### PR TITLE
manifest: nrf_modem: v2.3.0

### DIFF
--- a/applications/asset_tracker_v2/src/main.c
+++ b/applications/asset_tracker_v2/src/main.c
@@ -201,18 +201,18 @@ static void handle_nrf_modem_lib_init_ret(void)
 	case 0:
 		/* Initialization successful, no action required. */
 		return;
-	case MODEM_DFU_RESULT_OK:
+	case NRF_MODEM_DFU_RESULT_OK:
 		LOG_DBG("MODEM UPDATE OK. Will run new modem firmware after reboot");
 		break;
-	case MODEM_DFU_RESULT_UUID_ERROR:
-	case MODEM_DFU_RESULT_AUTH_ERROR:
+	case NRF_MODEM_DFU_RESULT_UUID_ERROR:
+	case NRF_MODEM_DFU_RESULT_AUTH_ERROR:
 		LOG_ERR("MODEM UPDATE ERROR %d. Will run old firmware", ret);
 		break;
-	case MODEM_DFU_RESULT_HARDWARE_ERROR:
-	case MODEM_DFU_RESULT_INTERNAL_ERROR:
+	case NRF_MODEM_DFU_RESULT_HARDWARE_ERROR:
+	case NRF_MODEM_DFU_RESULT_INTERNAL_ERROR:
 		LOG_ERR("MODEM UPDATE FATAL ERROR %d. Modem failure", ret);
 		break;
-	case MODEM_DFU_RESULT_VOLTAGE_LOW:
+	case NRF_MODEM_DFU_RESULT_VOLTAGE_LOW:
 		LOG_ERR("MODEM UPDATE CANCELLED %d.", ret);
 		LOG_ERR("Please reboot once you have sufficient power for the DFU");
 		break;

--- a/applications/asset_tracker_v2/src/main.c
+++ b/applications/asset_tracker_v2/src/main.c
@@ -212,6 +212,10 @@ static void handle_nrf_modem_lib_init_ret(void)
 	case MODEM_DFU_RESULT_INTERNAL_ERROR:
 		LOG_ERR("MODEM UPDATE FATAL ERROR %d. Modem failure", ret);
 		break;
+	case MODEM_DFU_RESULT_VOLTAGE_LOW:
+		LOG_ERR("MODEM UPDATE CANCELLED %d.", ret);
+		LOG_ERR("Please reboot once you have sufficient power for the DFU");
+		break;
 	default:
 		/* All non-zero return codes other than DFU result codes are
 		 * considered irrecoverable and a reboot is needed.

--- a/applications/serial_lte_modem/src/main.c
+++ b/applications/serial_lte_modem/src/main.c
@@ -269,25 +269,25 @@ static void handle_nrf_modem_lib_init_ret(void)
 	switch (ret) {
 	case 0:
 		return; /* Initialization successful, no action required. */
-	case MODEM_DFU_RESULT_OK:
+	case NRF_MODEM_DFU_RESULT_OK:
 		LOG_INF("MODEM UPDATE OK. Will run new firmware");
 		fota_stage = FOTA_STAGE_COMPLETE;
 		fota_status = FOTA_STATUS_OK;
 		fota_info = 0;
 		break;
-	case MODEM_DFU_RESULT_UUID_ERROR:
-	case MODEM_DFU_RESULT_AUTH_ERROR:
+	case NRF_MODEM_DFU_RESULT_UUID_ERROR:
+	case NRF_MODEM_DFU_RESULT_AUTH_ERROR:
 		LOG_ERR("MODEM UPDATE ERROR %d. Will run old firmware", ret);
 		fota_status = FOTA_STATUS_ERROR;
 		fota_info = ret;
 		break;
-	case MODEM_DFU_RESULT_HARDWARE_ERROR:
-	case MODEM_DFU_RESULT_INTERNAL_ERROR:
+	case NRF_MODEM_DFU_RESULT_HARDWARE_ERROR:
+	case NRF_MODEM_DFU_RESULT_INTERNAL_ERROR:
 		LOG_ERR("MODEM UPDATE FATAL ERROR %d. Modem failure", ret);
 		fota_status = FOTA_STATUS_ERROR;
 		fota_info = ret;
 		break;
-	case MODEM_DFU_RESULT_VOLTAGE_LOW:
+	case NRF_MODEM_DFU_RESULT_VOLTAGE_LOW:
 		LOG_ERR("MODEM UPDATE CANCELLED %d.", ret);
 		LOG_ERR("Please reboot once you have sufficient power for the DFU");
 		fota_status = FOTA_STATUS_ERROR;

--- a/applications/serial_lte_modem/src/main.c
+++ b/applications/serial_lte_modem/src/main.c
@@ -287,6 +287,12 @@ static void handle_nrf_modem_lib_init_ret(void)
 		fota_status = FOTA_STATUS_ERROR;
 		fota_info = ret;
 		break;
+	case MODEM_DFU_RESULT_VOLTAGE_LOW:
+		LOG_ERR("MODEM UPDATE CANCELLED %d.", ret);
+		LOG_ERR("Please reboot once you have sufficient power for the DFU");
+		fota_status = FOTA_STATUS_ERROR;
+		fota_info = ret;
+		break;
 	default:
 		/* All non-zero return codes other than DFU result codes are
 		 * considered irrecoverable and a reboot is needed.

--- a/applications/serial_lte_modem/src/slm_defines.h
+++ b/applications/serial_lte_modem/src/slm_defines.h
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/net/net_ip.h>
+#include <nrf_socket.h>
 
 #ifndef SLM_AT_DEFINES_
 #define SLM_AT_DEFINES_
@@ -19,7 +20,7 @@
 
 /** The maximum allowed length of data send/receive through the SLM */
 #define SLM_MAX_PAYLOAD_SIZE 1024 /** max size of payload sent in command mode */
-#define SLM_MAX_MESSAGE_SIZE 2048 /** align with NRF_MODEM_TLS_MAX_MESSAGE_SIZE */
+#define SLM_MAX_MESSAGE_SIZE NRF_SOCKET_TLS_MAX_MESSAGE_SIZE
 
 #define SLM_MAX_SOCKET_COUNT 8    /** re-define NRF_MODEM_MAX_SOCKET_COUNT */
 

--- a/doc/nrf/libraries/dfu/fmfu_fdev.rst
+++ b/doc/nrf/libraries/dfu/fmfu_fdev.rst
@@ -17,7 +17,7 @@ For more information, see :ref:`lib_dfu_target_full_modem_update`.
 
 The serialized modem firmware contains the hash of the firmware and a signature.
 These fields are used to pre-validate the modem firmware before it is programmed to the modem, ensuring that the data about to be written corresponds to the data that have been signed.
-Once the modem firmware is pre-validated, it is written to the modem using the :file:`nrf_modem_full_dfu.h` API.
+Once the modem firmware is pre-validated, it is written to the modem using the :file:`nrf_modem_bootloader.h` API.
 
 .. _lib_fmfu_fdev_serialization:
 

--- a/doc/nrf/libraries/modem/nrf_modem_lib.rst
+++ b/doc/nrf/libraries/modem/nrf_modem_lib.rst
@@ -348,21 +348,22 @@ This value is automatically passed by the integration layer to the library durin
 
 When the application is built using CMake, the :ref:`partition_manager` automatically reads the Kconfig options of the integration layer.
 Partition manager decides about the placement of the regions in RAM and reserves memory according to the given size.
-As a result, the Partition manager generates the following parameters:
+As a result, the Partition manager generates the following definitions:
 
 * ``PM_NRF_MODEM_LIB_CTRL_ADDRESS`` - Address of the Control region
 * ``PM_NRF_MODEM_LIB_TX_ADDRESS`` - Address of the TX region
 * ``PM_NRF_MODEM_LIB_RX_ADDRESS`` - Address of the RX region
 * ``PM_NRF_MODEM_LIB_TRACE_ADDRESS`` - Address of the Trace region
-
-Partition manager also generates the following additional parameters:
-
 * ``PM_NRF_MODEM_LIB_CTRL_SIZE`` - Size of the Control region
 * ``PM_NRF_MODEM_LIB_TX_SIZE`` - Size of the TX region
 * ``PM_NRF_MODEM_LIB_RX_SIZE`` - Size of the RX region
 * ``PM_NRF_MODEM_LIB_TRACE_SIZE`` - Size of the Trace region
 
-These parameters will have identical values as the ``CONFIG_NRF_MODEM_LIB_SHMEM_*_SIZE`` configuration options.
+These definitions will have identical values as the ``CONFIG_NRF_MODEM_LIB_SHMEM_*_SIZE`` configuration options.
+
+.. important::
+   The heap implementation used for allocations on the TX region has an overhead of up to 128 bytes.
+   Adjust the size of the TX region accordingly, so that its size is 128 bytes larger than the largest allocation you expect to happen (longest AT command, largest payload passed to :c:func:`nrf_send`) in your application.
 
 When the Modem library is initialized by the integration layer in |NCS|, the integration layer automatically passes the boundaries of each shared memory region to the Modem library during the :c:func:`nrf_modem_lib_init` call.
 

--- a/doc/nrf/libraries/networking/nrf_cloud.rst
+++ b/doc/nrf/libraries/networking/nrf_cloud.rst
@@ -139,7 +139,7 @@ Following are the supported FOTA types:
 
 * ``"APP"`` - Updates the application.
 * ``"BOOT"`` - Updates the :ref:`upgradable_bootloader`.
-* ``"MDM_FULL"`` - :ref:`Full modem FOTA <full_dfu>` updates the entire modem firmware image. Full modem updates require |external_flash_size| of available space. For the nRF9160, a full modem firmware image is approximately 2 MB. Consider the power and network costs before deploying full modem FOTA updates.
+* ``"MDM_FULL"`` - :ref:`Full modem FOTA <nrf_modem_bootloader>` updates the entire modem firmware image. Full modem updates require |external_flash_size| of available space. For the nRF9160, a full modem firmware image is approximately 2 MB. Consider the power and network costs before deploying full modem FOTA updates.
 * ``"MODEM"`` - :ref:`Delta modem FOTA <nrf_modem_delta_dfu>` applies incremental changes between specific versions of the modem firmware. Delta modem updates are much smaller in size and do not require external memory.
 
 For example, a device that supports all the FOTA types writes the following data into the device shadow:

--- a/doc/nrf/releases/release-notes-1.7.0.rst
+++ b/doc/nrf/releases/release-notes-1.7.0.rst
@@ -599,7 +599,7 @@ nrfxlib
 * :ref:`nrf_modem` section pages:
 
   * :ref:`nrfxlib:nrf_modem_api` - Updated with new API sections.
-  * :ref:`full_dfu` - Updated with major changes.
+  * :ref:`nrfxlib:nrf_modem_bootloader` - Updated with major changes.
   * Renamed the "AT commands" page to ``AT socket``.
   * :ref:`nrfxlib:nrf_modem_at` - Page added.
   * :ref:`nrfxlib:nrf_modem_delta_dfu` - Page added.

--- a/doc/nrf/releases/release-notes-1.8.0.rst
+++ b/doc/nrf/releases/release-notes-1.8.0.rst
@@ -719,7 +719,7 @@ Modem library
     See the :ref:`nrfxlib:nrf_modem_changelog` for detailed information.
   * nrf_errno values have been aligned with the errno values of newlibc C library.
   * The :ref:`Modem API <nrf_modem_api>` (:file:`nrf_modem.h`) has been updated to return negative errno values on error.
-  * The :ref:`Full Modem DFU API <nrf_modem_full_dfu_api>` (:file:`nrf_modem_full_dfu.h`) has been updated to return negative errno values on error.
+  * The :ref:`Full Modem DFU API <nrf_modem_bootloader_api>` (:file:`nrf_modem_full_dfu.h`) has been updated to return negative errno values on error.
   * The :ref:`GNSS API <nrf_modem_gnss_api>` (:file:`nrf_modem_gnss.h`) has been updated to return negative errno values on error.
 
 * Removed:

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -622,6 +622,8 @@ Modem libraries
 
   * Updated:
 
+    * It is now possible to poll Modem library and Zephyr sockets at the same time using the :c:func:`poll` function.
+      This includes special sockets such as event sockets created using the :c:func:`eventfd` function.
     * The minimal value of :kconfig:option:`CONFIG_NRF_MODEM_LIB_SHMEM_RX_SIZE` to meet the requirements of modem firmware 1.3.4.
     * The :c:func:`nrf_modem_lib_diag_stats_get` function now returns an error if called when the :ref:`nrf_modem_lib_readme` library has not been initialized.
     * The trace backend interface to be exposed to the :ref:`modem_trace_module` using the :c:struct:`nrf_modem_lib_trace_backend` struct.

--- a/doc/nrf/working_with_nrf/nrf91/nrf91_features.rst
+++ b/doc/nrf/working_with_nrf/nrf91/nrf91_features.rst
@@ -130,7 +130,7 @@ Full upgrade
   * When using a wireless connection, the upgrade is applied over-the-air (OTA).
     See :ref:`nrf9160_fota` for more information.
 
- See :ref:`nrfxlib:full_dfu` for more information on the full firmware updates of modem using :ref:`nrfxlib:nrf_modem`.
+ See :ref:`nrfxlib:nrf_modem_bootloader` for more information on the full firmware updates of modem using :ref:`nrfxlib:nrf_modem`.
 
 Delta patches
   Delta patches are upgrades that contain only the difference from the last version.

--- a/doc/nrfxlib/known-warnings.txt
+++ b/doc/nrfxlib/known-warnings.txt
@@ -1,6 +1,6 @@
 # Each line should contain the regular expression of a known Sphinx warning
 # that should be filtered out
-.*Duplicate C declaration.*\n.*'\.\. c:.*:: nrf_modem_full_dfu_digest'.*
-.*Duplicate C declaration.*\n.*'\.\. c:.*:: nrf_modem_full_dfu_uuid'.*
+.*Duplicate C declaration.*\n.*'\.\. c:.*:: nrf_modem_bootloader_digest'.*
+.*Duplicate C declaration.*\n.*'\.\. c:.*:: nrf_modem_bootloader_uuid'.*
 .*Duplicate C declaration.*\n.*'\.\. c:.*:: nrf_modem_delta_dfu_uuid'.*
 .*Duplicate C declaration.*\n.*'\.\. c:.*:: union mpsl_fem_event_t.@[0-9]+ event'.*

--- a/include/mgmt/fmfu_mgmt.h
+++ b/include/mgmt/fmfu_mgmt.h
@@ -28,7 +28,7 @@ extern "C" {
  *  update command handler group.
  *
  * The modem library must be initialized in DFU mode before calling this
- * function - nrf_modem_lib_init(FULL_DFU_MODE).
+ * function - nrf_modem_lib_init(BOOTLOADER_MODE).
  *
  * @retval 0 on success, negative integer on failure.
  */

--- a/include/modem/nrf_modem_lib.h
+++ b/include/modem/nrf_modem_lib.h
@@ -28,6 +28,15 @@ extern "C" {
  * @brief API of the SMS nRF Modem library wrapper module.
  */
 
+
+/** @brief Modem library mode */
+enum nrf_modem_mode {
+	/** Normal operation mode */
+	NORMAL_MODE,
+	/** Bootloader (full DFU) mode */
+	BOOTLOADER_MODE,
+};
+
 /**
  * @brief Initialize the Modem library.
  *

--- a/lib/bin/lwm2m_carrier/os/lwm2m_os.c
+++ b/lib/bin/lwm2m_carrier/os/lwm2m_os.c
@@ -389,6 +389,10 @@ int lwm2m_os_nrf_modem_init(void)
 		LOG_ERR("Modem firmware update failed.");
 		LOG_ERR("Fatal error.");
 		break;
+	case MODEM_DFU_RESULT_VOLTAGE_LOW:
+		LOG_ERR("Modem firmware update cancelled.");
+		LOG_ERR("Please reboot once you have sufficient power for the DFU.");
+		break;
 	default:
 		LOG_ERR("Could not initialize modem library.");
 		LOG_ERR("Fatal error.");

--- a/lib/bin/lwm2m_carrier/os/lwm2m_os.c
+++ b/lib/bin/lwm2m_carrier/os/lwm2m_os.c
@@ -375,21 +375,21 @@ int lwm2m_os_nrf_modem_init(void)
 	switch (nrf_err) {
 	case 0:
 		break;
-	case MODEM_DFU_RESULT_OK:
+	case NRF_MODEM_DFU_RESULT_OK:
 		LOG_INF("Modem firmware update successful.");
 		LOG_INF("Modem will run the new firmware after reboot.");
 		break;
-	case MODEM_DFU_RESULT_UUID_ERROR:
-	case MODEM_DFU_RESULT_AUTH_ERROR:
+	case NRF_MODEM_DFU_RESULT_UUID_ERROR:
+	case NRF_MODEM_DFU_RESULT_AUTH_ERROR:
 		LOG_ERR("Modem firmware update failed.");
 		LOG_ERR("Modem will run non-updated firmware on reboot.");
 		break;
-	case MODEM_DFU_RESULT_HARDWARE_ERROR:
-	case MODEM_DFU_RESULT_INTERNAL_ERROR:
+	case NRF_MODEM_DFU_RESULT_HARDWARE_ERROR:
+	case NRF_MODEM_DFU_RESULT_INTERNAL_ERROR:
 		LOG_ERR("Modem firmware update failed.");
 		LOG_ERR("Fatal error.");
 		break;
-	case MODEM_DFU_RESULT_VOLTAGE_LOW:
+	case NRF_MODEM_DFU_RESULT_VOLTAGE_LOW:
 		LOG_ERR("Modem firmware update cancelled.");
 		LOG_ERR("Please reboot once you have sufficient power for the DFU.");
 		break;

--- a/lib/modem_key_mgmt/modem_key_mgmt.c
+++ b/lib/modem_key_mgmt/modem_key_mgmt.c
@@ -9,7 +9,6 @@
 #include <string.h>
 #include <zephyr/kernel.h>
 #include <nrf_modem_at.h>
-#include <nrf_modem_limits.h>
 #include <modem/modem_key_mgmt.h>
 #include <zephyr/logging/log.h>
 

--- a/lib/nrf_modem_lib/Kconfig.modemlib
+++ b/lib/nrf_modem_lib/Kconfig.modemlib
@@ -169,11 +169,12 @@ config NRF_MODEM_LIB_SHMEM_CTRL_SIZE
 config NRF_MODEM_LIB_SHMEM_TX_SIZE
 	int "TX region size"
 	range 1024 32768
-	default 8192
+	# Set default to 8k plus Zephyr heap overhead (128 bytes)
+	default 8320
 	help
-	  Size of the shared memory region owned by the application. This area holds all outgoing data
-	  from the application to the modem, e.g. buffers passed to `send()`. Its size affects directly
-	  the largest payload that can be sent at once, and the largest AT command that can be sent.
+	  Size of the shared memory region owned by the application. This area holds all outgoing
+	  data from the application to the modem, e.g. buffers passed to `send()`, AT commands.
+	  The size must be a multiple of four to keep the memory partitions word-aligned.
 
 config NRF_MODEM_LIB_SHMEM_RX_SIZE
 	int "RX region size"
@@ -182,6 +183,7 @@ config NRF_MODEM_LIB_SHMEM_RX_SIZE
 	help
 	  Size of the shared memory region owned by the modem.
 	  This area holds all incoming data from the modem, plus the modem's own control structures.
+	  The size must be a multiple of four to keep the memory partitions word-aligned.
 
 config NRF_MODEM_LIB_SHMEM_TRACE_SIZE_OVERRIDE
 	bool "Custom trace region size"

--- a/lib/nrf_modem_lib/nrf_modem_lib.c
+++ b/lib/nrf_modem_lib/nrf_modem_lib.c
@@ -27,6 +27,11 @@ LOG_MODULE_DECLARE(nrf_modem, CONFIG_NRF_MODEM_LIB_LOG_LEVEL);
 #define NRF_MODEM_IPC_IRQ DT_IRQ_BY_IDX(DT_NODELABEL(ipc), 0, irq)
 BUILD_ASSERT(IPC_IRQn == NRF_MODEM_IPC_IRQ, "NRF_MODEM_IPC_IRQ mismatch");
 
+/* The heap implementation in `nrf_modem_os.c` require some overhead
+ * to allow allocating up to `NRF_MODEM_LIB_SHMEM_TX_SIZE` bytes.
+ */
+#define NRF_MODEM_LIB_SHMEM_TX_HEAP_OVERHEAD_SIZE 128
+
 struct shutdown_thread {
 	sys_snode_t node;
 	struct k_sem sem;
@@ -47,7 +52,8 @@ static const struct nrf_modem_init_params init_params = {
 	},
 	.shmem.tx = {
 		.base = PM_NRF_MODEM_LIB_TX_ADDRESS,
-		.size = CONFIG_NRF_MODEM_LIB_SHMEM_TX_SIZE,
+		.size = CONFIG_NRF_MODEM_LIB_SHMEM_TX_SIZE -
+			NRF_MODEM_LIB_SHMEM_TX_HEAP_OVERHEAD_SIZE,
 	},
 	.shmem.rx = {
 		.base = PM_NRF_MODEM_LIB_RX_ADDRESS,
@@ -59,6 +65,13 @@ static const struct nrf_modem_init_params init_params = {
 		.size = CONFIG_NRF_MODEM_LIB_SHMEM_TRACE_SIZE,
 	},
 #endif
+	.fault_handler = nrf_modem_fault_handler
+};
+
+static const struct nrf_modem_bootloader_init_params bootloader_init_params = {
+	.ipc_irq_prio = CONFIG_NRF_MODEM_LIB_IPC_IRQ_PRIO,
+	.shmem.base = PM_NRF_MODEM_LIB_SRAM_ADDRESS,
+	.shmem.size = PM_NRF_MODEM_LIB_SRAM_SIZE,
 	.fault_handler = nrf_modem_fault_handler
 };
 
@@ -121,7 +134,7 @@ static int _nrf_modem_lib_init(const struct device *unused)
 	IRQ_CONNECT(NRF_MODEM_IPC_IRQ, CONFIG_NRF_MODEM_LIB_IPC_IRQ_PRIO,
 		    nrfx_isr, nrfx_ipc_irq_handler, 0);
 
-	init_ret = nrf_modem_init(&init_params, NORMAL_MODE);
+	init_ret = nrf_modem_init(&init_params);
 
 	if (IS_ENABLED(CONFIG_NRF_MODEM_LIB_LOG_FW_VERSION_UUID)) {
 		log_fw_version_uuid();
@@ -180,7 +193,7 @@ int nrf_modem_lib_init(enum nrf_modem_mode mode)
 	if (mode == NORMAL_MODE) {
 		return _nrf_modem_lib_init(NULL);
 	} else {
-		return nrf_modem_init(&init_params, FULL_DFU_MODE);
+		return nrf_modem_bootloader_init(&bootloader_init_params);
 	}
 }
 

--- a/lib/nrf_modem_lib/sanity.c
+++ b/lib/nrf_modem_lib/sanity.c
@@ -118,6 +118,17 @@ BUILD_ASSERT(SHMEM_IN_USE < SHMEM_END,
 	     "The libmodem shmem configuration exceeds the range of "
 	     "memory readable by the Modem core");
 
+BUILD_ASSERT(PM_NRF_MODEM_LIB_CTRL_ADDRESS % 4 == 0,
+	"libmodem CTRL region base address must be word aligned");
+BUILD_ASSERT(PM_NRF_MODEM_LIB_TX_ADDRESS % 4 == 0,
+	"libmodem TX region base address must be word aligned");
+BUILD_ASSERT(PM_NRF_MODEM_LIB_RX_ADDRESS % 4 == 0,
+	"libmodem RX region base address must be word aligned");
+#if CONFIG_NRF_MODEM_LIB_TRACE
+BUILD_ASSERT(PM_NRF_MODEM_LIB_TRACE_ADDRESS % 4 == 0,
+	"libmodem Trace region base address must be word aligned");
+#endif
+
 /* Socket values sanity check */
 
 #if defined(CONFIG_NET_SOCKETS_OFFLOAD)

--- a/samples/nrf9160/aws_iot/src/main.c
+++ b/samples/nrf9160/aws_iot/src/main.c
@@ -418,22 +418,22 @@ static void nrf_modem_lib_dfu_handler(void)
 	err = modem_lib_init_result;
 
 	switch (err) {
-	case MODEM_DFU_RESULT_OK:
+	case NRF_MODEM_DFU_RESULT_OK:
 		LOG_INF("Modem update suceeded, reboot");
 		sys_reboot(SYS_REBOOT_COLD);
 		break;
-	case MODEM_DFU_RESULT_UUID_ERROR:
-	case MODEM_DFU_RESULT_AUTH_ERROR:
+	case NRF_MODEM_DFU_RESULT_UUID_ERROR:
+	case NRF_MODEM_DFU_RESULT_AUTH_ERROR:
 		LOG_INF("Modem update failed, error: %d", err);
 		LOG_INF("Modem will use old firmware");
 		sys_reboot(SYS_REBOOT_COLD);
 		break;
-	case MODEM_DFU_RESULT_HARDWARE_ERROR:
-	case MODEM_DFU_RESULT_INTERNAL_ERROR:
+	case NRF_MODEM_DFU_RESULT_HARDWARE_ERROR:
+	case NRF_MODEM_DFU_RESULT_INTERNAL_ERROR:
 		LOG_INF("Modem update malfunction, error: %d, reboot", err);
 		sys_reboot(SYS_REBOOT_COLD);
 		break;
-	case MODEM_DFU_RESULT_VOLTAGE_LOW:
+	case NRF_MODEM_DFU_RESULT_VOLTAGE_LOW:
 		LOG_INF("Modem update cancelled due to low power, error: %d", err);
 		LOG_INF("Please reboot once you have sufficient power for the DFU");
 		break;

--- a/samples/nrf9160/aws_iot/src/main.c
+++ b/samples/nrf9160/aws_iot/src/main.c
@@ -433,6 +433,10 @@ static void nrf_modem_lib_dfu_handler(void)
 		LOG_INF("Modem update malfunction, error: %d, reboot", err);
 		sys_reboot(SYS_REBOOT_COLD);
 		break;
+	case MODEM_DFU_RESULT_VOLTAGE_LOW:
+		LOG_INF("Modem update cancelled due to low power, error: %d", err);
+		LOG_INF("Please reboot once you have sufficient power for the DFU");
+		break;
 	default:
 		break;
 	}

--- a/samples/nrf9160/azure_fota/src/main.c
+++ b/samples/nrf9160/azure_fota/src/main.c
@@ -204,22 +204,22 @@ void main(void)
 	LOG_INF("This may take a while if a modem firmware update is pending");
 
 	switch (modem_lib_init_result) {
-	case MODEM_DFU_RESULT_OK:
-		LOG_INF("Modem firmware update successful");
+	case NRF_MODEM_DFU_RESULT_OK:
+		LOG_INF("Modem firmware update successful!");
 		LOG_INF("Modem will run the new firmware after reboot");
 		k_thread_suspend(k_current_get());
 		break;
-	case MODEM_DFU_RESULT_UUID_ERROR:
-	case MODEM_DFU_RESULT_AUTH_ERROR:
+	case NRF_MODEM_DFU_RESULT_UUID_ERROR:
+	case NRF_MODEM_DFU_RESULT_AUTH_ERROR:
 		LOG_INF("Modem firmware update failed");
 		LOG_INF("Modem will run non-updated firmware on reboot.");
 		break;
-	case MODEM_DFU_RESULT_HARDWARE_ERROR:
-	case MODEM_DFU_RESULT_INTERNAL_ERROR:
+	case NRF_MODEM_DFU_RESULT_HARDWARE_ERROR:
+	case NRF_MODEM_DFU_RESULT_INTERNAL_ERROR:
 		LOG_INF("Modem firmware update failed");
 		LOG_INF("Fatal error.");
 		break;
-	case MODEM_DFU_RESULT_VOLTAGE_LOW:
+	case NRF_MODEM_DFU_RESULT_VOLTAGE_LOW:
 		LOG_INF("Modem firmware update failed");
 		LOG_INF("Please reboot once you have sufficient power for the DFU.");
 		break;

--- a/samples/nrf9160/azure_fota/src/main.c
+++ b/samples/nrf9160/azure_fota/src/main.c
@@ -219,6 +219,10 @@ void main(void)
 		LOG_INF("Modem firmware update failed");
 		LOG_INF("Fatal error.");
 		break;
+	case MODEM_DFU_RESULT_VOLTAGE_LOW:
+		LOG_INF("Modem firmware update failed");
+		LOG_INF("Please reboot once you have sufficient power for the DFU.");
+		break;
 	case -1:
 		LOG_INF("Could not initialize modem library");
 		LOG_INF("Fatal error.");

--- a/samples/nrf9160/fmfu_smp_svr/src/main.c
+++ b/samples/nrf9160/fmfu_smp_svr/src/main.c
@@ -32,7 +32,7 @@ void main(void)
 	/* Shutdown modem to prepare for DFU */
 	nrf_modem_lib_shutdown();
 
-	nrf_modem_lib_init(FULL_DFU_MODE);
+	nrf_modem_lib_init(BOOTLOADER_MODE);
 	/* Register SMP Communication stats */
 	fmfu_mgmt_stat_init();
 	/* Initialize MCUMgr handlers for full modem update */

--- a/samples/nrf9160/http_update/full_modem_update/src/main.c
+++ b/samples/nrf9160/http_update/full_modem_update/src/main.c
@@ -9,7 +9,7 @@
 #include <dfu/dfu_target_full_modem.h>
 #include <net/fota_download.h>
 #include <zephyr/shell/shell.h>
-#include <nrf_modem_full_dfu.h>
+#include <nrf_modem_bootloader.h>
 #include <modem/modem_info.h>
 #include <dfu/fmfu_fdev.h>
 #include <zephyr/drivers/gpio.h>
@@ -65,9 +65,9 @@ static void apply_fmfu_from_ext_flash(bool valid_init)
 		}
 	}
 
-	err = nrf_modem_lib_init(FULL_DFU_MODE);
+	err = nrf_modem_lib_init(BOOTLOADER_MODE);
 	if (err != 0) {
-		printk("nrf_modem_lib_init(FULL_DFU_MODE) failed: %d\n", err);
+		printk("nrf_modem_lib_init(BOOTLOADER_MODE) failed: %d\n", err);
 		return;
 	}
 

--- a/samples/nrf9160/http_update/modem_delta_update/src/main.c
+++ b/samples/nrf9160/http_update/modem_delta_update/src/main.c
@@ -104,24 +104,24 @@ void main(void)
 	err = modem_lib_init_result;
 #endif
 	switch (err) {
-	case MODEM_DFU_RESULT_OK:
+	case NRF_MODEM_DFU_RESULT_OK:
 		printk("Modem firmware update successful!\n");
 		printk("Modem will run the new firmware after reboot\n");
 		printk("Press 'Reset' button or enter 'reset' to apply new firmware\n");
 		k_thread_suspend(k_current_get());
 		break;
-	case MODEM_DFU_RESULT_UUID_ERROR:
-	case MODEM_DFU_RESULT_AUTH_ERROR:
+	case NRF_MODEM_DFU_RESULT_UUID_ERROR:
+	case NRF_MODEM_DFU_RESULT_AUTH_ERROR:
 		printk("Modem firmware update failed\n");
 		printk("Modem will run non-updated firmware on reboot.\n");
 		printk("Press 'Reset' button or enter 'reset'\n");
 		break;
-	case MODEM_DFU_RESULT_HARDWARE_ERROR:
-	case MODEM_DFU_RESULT_INTERNAL_ERROR:
+	case NRF_MODEM_DFU_RESULT_HARDWARE_ERROR:
+	case NRF_MODEM_DFU_RESULT_INTERNAL_ERROR:
 		printk("Modem firmware update failed\n");
 		printk("Fatal error.\n");
 		break;
-	case MODEM_DFU_RESULT_VOLTAGE_LOW:
+	case NRF_MODEM_DFU_RESULT_VOLTAGE_LOW:
 		printk("Modem firmware update failed\n");
 		printk("Please reboot once you have sufficient power for the DFU.\n");
 		break;

--- a/samples/nrf9160/http_update/modem_delta_update/src/main.c
+++ b/samples/nrf9160/http_update/modem_delta_update/src/main.c
@@ -121,6 +121,10 @@ void main(void)
 		printk("Modem firmware update failed\n");
 		printk("Fatal error.\n");
 		break;
+	case MODEM_DFU_RESULT_VOLTAGE_LOW:
+		printk("Modem firmware update failed\n");
+		printk("Please reboot once you have sufficient power for the DFU.\n");
+		break;
 	case -1:
 		printk("Could not initialize momdem library.\n");
 		printk("Fatal error.\n");

--- a/samples/nrf9160/modem_shell/src/main.c
+++ b/samples/nrf9160/modem_shell/src/main.c
@@ -262,24 +262,24 @@ void main(void)
 	case 0:
 		/* Modem library was initialized successfully. */
 		break;
-	case MODEM_DFU_RESULT_OK:
+	case NRF_MODEM_DFU_RESULT_OK:
 		printk("Modem firmware update successful!\n");
 		printk("Modem will run the new firmware after reboot\n");
 		sys_reboot(SYS_REBOOT_WARM);
 		return;
-	case MODEM_DFU_RESULT_UUID_ERROR:
-	case MODEM_DFU_RESULT_AUTH_ERROR:
+	case NRF_MODEM_DFU_RESULT_UUID_ERROR:
+	case NRF_MODEM_DFU_RESULT_AUTH_ERROR:
 		printk("Modem firmware update failed!\n");
 		printk("Modem will run non-updated firmware on reboot.\n");
 		sys_reboot(SYS_REBOOT_WARM);
 		return;
-	case MODEM_DFU_RESULT_HARDWARE_ERROR:
-	case MODEM_DFU_RESULT_INTERNAL_ERROR:
+	case NRF_MODEM_DFU_RESULT_HARDWARE_ERROR:
+	case NRF_MODEM_DFU_RESULT_INTERNAL_ERROR:
 		printk("Modem firmware update failed!\n");
 		printk("Fatal error.\n");
 		sys_reboot(SYS_REBOOT_WARM);
 		return;
-	case MODEM_DFU_RESULT_VOLTAGE_LOW:
+	case NRF_MODEM_DFU_RESULT_VOLTAGE_LOW:
 		printk("Modem firmware update cancelled due to low power.\n");
 		printk("Please reboot once you have sufficient power for the DFU\n");
 		break;

--- a/samples/nrf9160/modem_shell/src/main.c
+++ b/samples/nrf9160/modem_shell/src/main.c
@@ -279,6 +279,10 @@ void main(void)
 		printk("Fatal error.\n");
 		sys_reboot(SYS_REBOOT_WARM);
 		return;
+	case MODEM_DFU_RESULT_VOLTAGE_LOW:
+		printk("Modem firmware update cancelled due to low power.\n");
+		printk("Please reboot once you have sufficient power for the DFU\n");
+		break;
 	default:
 		/* Modem library initialization failed. */
 		printk("Could not initialize modemlib.\n");

--- a/samples/nrf9160/nrf_cloud_mqtt_multi_service/src/connection.c
+++ b/samples/nrf9160/nrf_cloud_mqtt_multi_service/src/connection.c
@@ -680,7 +680,7 @@ static int setup_modem(void)
 		if (ret < 0) {
 			LOG_ERR("Modem library initialization failed, error: %d", ret);
 			return ret;
-		} else if (ret == MODEM_DFU_RESULT_OK) {
+		} else if (ret == NRF_MODEM_DFU_RESULT_OK) {
 			LOG_DBG("Modem library initialized after "
 				"successful modem firmware update.");
 		} else if (ret > 0) {

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
@@ -25,7 +25,7 @@
 
 #if defined(CONFIG_DFU_TARGET_FULL_MODEM)
 #include <dfu/dfu_target_full_modem.h>
-#include <nrf_modem_full_dfu.h>
+#include <nrf_modem_bootloader.h>
 #include <dfu/fmfu_fdev.h>
 #include <string.h>
 #endif
@@ -403,9 +403,9 @@ static uint8_t apply_fmfu_from_ext_flash(void)
 		return RESULT_UPDATE_FAILED;
 	}
 
-	ret = nrf_modem_lib_init(FULL_DFU_MODE);
+	ret = nrf_modem_lib_init(BOOTLOADER_MODE);
 	if (ret != 0) {
-		LOG_ERR("nrf_modem_lib_init(FULL_DFU_MODE) failed: %d\n", ret);
+		LOG_ERR("nrf_modem_lib_init(BOOTLOADER_MODE) failed: %d\n", ret);
 		return RESULT_UPDATE_FAILED;
 	}
 
@@ -459,7 +459,7 @@ static uint8_t apply_firmware_delta_modem_update(void)
 
 	ret = modem_lib_init_result;
 	switch (ret) {
-	case MODEM_DFU_RESULT_OK:
+	case NRF_MODEM_DFU_RESULT_OK:
 		LOG_INF("MODEM UPDATE OK. Will run new firmware");
 		result = RESULT_SUCCESS;
 		break;

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota_common.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota_common.c
@@ -108,9 +108,9 @@ int nrf_cloud_fota_fmfu_apply(void)
 		return err;
 	}
 
-	err = nrf_modem_lib_init(FULL_DFU_MODE);
+	err = nrf_modem_lib_init(BOOTLOADER_MODE);
 	if (err != 0) {
-		LOG_ERR("nrf_modem_lib_init(FULL_DFU_MODE) failed: %d", err);
+		LOG_ERR("nrf_modem_lib_init(BOOTLOADER_MODE) failed: %d", err);
 		(void)nrf_modem_lib_init(NORMAL_MODE);
 		return err;
 	}
@@ -192,16 +192,16 @@ static enum nrf_cloud_fota_validate_status modem_delta_fota_validate_get(void)
 {
 #if defined(CONFIG_NRF_MODEM_LIB)
 	switch (modem_lib_init_result) {
-	case MODEM_DFU_RESULT_OK:
+	case NRF_MODEM_DFU_RESULT_OK:
 		LOG_INF("Modem FOTA update confirmed");
 		return NRF_CLOUD_FOTA_VALIDATE_PASS;
-	case MODEM_DFU_RESULT_INTERNAL_ERROR:
-	case MODEM_DFU_RESULT_UUID_ERROR:
-	case MODEM_DFU_RESULT_AUTH_ERROR:
-	case MODEM_DFU_RESULT_HARDWARE_ERROR:
+	case NRF_MODEM_DFU_RESULT_INTERNAL_ERROR:
+	case NRF_MODEM_DFU_RESULT_UUID_ERROR:
+	case NRF_MODEM_DFU_RESULT_AUTH_ERROR:
+	case NRF_MODEM_DFU_RESULT_HARDWARE_ERROR:
 		LOG_ERR("Modem FOTA error: %d", modem_lib_init_result);
 		return NRF_CLOUD_FOTA_VALIDATE_FAIL;
-	case MODEM_DFU_RESULT_VOLTAGE_LOW:
+	case NRF_MODEM_DFU_RESULT_VOLTAGE_LOW:
 		LOG_ERR("Modem FOTA cancelled: %d", modem_lib_init_result);
 		LOG_ERR("Please reboot once you have sufficient power for the DFU");
 		return NRF_CLOUD_FOTA_VALIDATE_FAIL;

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota_common.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota_common.c
@@ -201,6 +201,10 @@ static enum nrf_cloud_fota_validate_status modem_delta_fota_validate_get(void)
 	case MODEM_DFU_RESULT_HARDWARE_ERROR:
 		LOG_ERR("Modem FOTA error: %d", modem_lib_init_result);
 		return NRF_CLOUD_FOTA_VALIDATE_FAIL;
+	case MODEM_DFU_RESULT_VOLTAGE_LOW:
+		LOG_ERR("Modem FOTA cancelled: %d", modem_lib_init_result);
+		LOG_ERR("Please reboot once you have sufficient power for the DFU");
+		return NRF_CLOUD_FOTA_VALIDATE_FAIL;
 	default:
 		LOG_INF("Modem FOTA result unknown: %d", modem_lib_init_result);
 		break;

--- a/tests/subsys/net/lib/lwm2m_fota_utils/src/firmware.c
+++ b/tests/subsys/net/lib/lwm2m_fota_utils/src/firmware.c
@@ -612,7 +612,7 @@ ZTEST(lwm2m_client_utils_firmware, test_firmware_update)
 	printf("State %d\r\n", state);
 	zassert_equal(state, STATE_DOWNLOADED, "wrong result value");
 
-	lwm2m_firmware_emulate_modem_lib_init(MODEM_DFU_RESULT_AUTH_ERROR);
+	lwm2m_firmware_emulate_modem_lib_init(NRF_MODEM_DFU_RESULT_AUTH_ERROR);
 	do_firmware_update(modem_instance);
 	result = get_modem_result();
 	state = get_app_state();
@@ -633,7 +633,7 @@ ZTEST(lwm2m_client_utils_firmware, test_firmware_update)
 	printf("State %d\r\n", state);
 	zassert_equal(state, STATE_DOWNLOADED, "wrong result value");
 
-	lwm2m_firmware_emulate_modem_lib_init(MODEM_DFU_RESULT_OK);
+	lwm2m_firmware_emulate_modem_lib_init(NRF_MODEM_DFU_RESULT_OK);
 	do_firmware_update(modem_instance);
 	result = get_modem_result();
 	zassert_equal(boot_img_num, 0, "wrong img num");
@@ -758,7 +758,7 @@ ZTEST(lwm2m_client_utils_firmware, test_firmware_multinstace_download)
 	printf("Update %d\r\n", rc);
 	zassert_equal(rc, 0, "wrong result value");
 	/* Stub Linked write for update */
-	lwm2m_firmware_emulate_modem_lib_init(MODEM_DFU_RESULT_OK);
+	lwm2m_firmware_emulate_modem_lib_init(NRF_MODEM_DFU_RESULT_OK);
 	k_sleep(K_SECONDS(6));
 	state = get_modem_state();
 	zassert_equal(state, STATE_IDLE, "wrong result value");

--- a/tests/subsys/net/lib/lwm2m_fota_utils/src/stubs.c
+++ b/tests/subsys/net/lib/lwm2m_fota_utils/src/stubs.c
@@ -8,6 +8,7 @@
 #include <zephyr/fff.h>
 
 #include <net/lwm2m_client_utils.h>
+#include <modem/nrf_modem_lib.h>
 #include <modem/modem_key_mgmt.h>
 #include <modem/lte_lc.h>
 #include <modem/modem_info.h>

--- a/tests/subsys/net/lib/lwm2m_fota_utils/src/stubs.h
+++ b/tests/subsys/net/lib/lwm2m_fota_utils/src/stubs.h
@@ -10,6 +10,7 @@
 #include <zephyr/ztest.h>
 #include <zephyr/fff.h>
 #include <nrf_modem.h>
+#include <modem/nrf_modem_lib.h>
 #include <net/lwm2m_client_utils.h>
 #include <modem/modem_key_mgmt.h>
 #include <modem/modem_info.h>

--- a/west.yml
+++ b/west.yml
@@ -114,7 +114,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: fe3f47a2dd4ff806304a74ae91fd721348dc787d
+      revision: 161b58f53846891351812d621116e7d6b0eb0e50
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Add nrf_modem v2.3.0 library.

This release adds capability to offload both nrf91 sockets and Zephyr sockets using poll(). It also improves the efficiency of
`nrf_modem_os_timedwait()`.

See the `CHANGELOG` file in nrfxlib/nrf_modem for a complete list of changes in the library.

test-sdk-nrf: sdk-nrf-pr-10242