### PR TITLE
drivers: wifi: Fix the default tokens

### DIFF
--- a/drivers/wifi/nrf700x/Kconfig.nrf700x
+++ b/drivers/wifi/nrf700x/Kconfig.nrf700x
@@ -90,11 +90,11 @@ config RX_NUM_BUFS
 
 config MAX_TX_AGGREGATION
 	int "Maximum number of TX packets to aggregate"
-	default 9
+	default 6
 
 config MAX_TX_TOKENS
 	int "Maximum number of TX tokens"
-	default 5
+	default 10
 
 config TX_MAX_DATA_SIZE
 	int "Maximum size of TX data"


### PR DESCRIPTION
For decent Zperf/ping results we need at least 2 tokens, so, make it default and reduce the MAX TX aggregation to accomodate for the increase in tokens.

With this we can get decent TX and RX throughputs.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>