### PR TITLE
samples: net: MQTT: Add delay to prevent error

### DIFF
--- a/samples/net/mqtt/src/modules/network/network_wifi.c
+++ b/samples/net/mqtt/src/modules/network/network_wifi.c
@@ -93,6 +93,9 @@ static void network_task(void)
 	net_mgmt_init_event_callback(&net_mgmt_callback, wifi_mgmt_event_handler, MGMT_EVENTS);
 	net_mgmt_add_event_callback(&net_mgmt_callback);
 
+	/* Add temporary fix to prevent using Wi-Fi before WPA supplicant is ready. */
+	k_sleep(K_SECONDS(1));
+
 	connect();
 }
 


### PR DESCRIPTION
Add delay in `network_wifi.c` to prevent the sample from enabling
Wi-Fi before the WPA supplication is ready.