### PR TITLE
samples: peripheral: Enable uart in lpuart overlays

### DIFF
--- a/samples/peripheral/lpuart/boards/nrf21540dk_nrf52840.overlay
+++ b/samples/peripheral/lpuart/boards/nrf21540dk_nrf52840.overlay
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: LicenseRef-Nordic-5-Clause */
 
 &uart1 {
+	status = "okay";
 	pinctrl-0 = <&uart1_default_alt>;
 	pinctrl-1 = <&uart1_sleep_alt>;
 	pinctrl-names = "default", "sleep";

--- a/samples/peripheral/lpuart/boards/nrf52833dk_nrf52833.overlay
+++ b/samples/peripheral/lpuart/boards/nrf52833dk_nrf52833.overlay
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: LicenseRef-Nordic-5-Clause */
 
 &uart1 {
+	status = "okay";
 	pinctrl-0 = <&uart1_default_alt>;
 	pinctrl-1 = <&uart1_sleep_alt>;
 	pinctrl-names = "default", "sleep";

--- a/samples/peripheral/lpuart/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/peripheral/lpuart/boards/nrf52840dk_nrf52840.overlay
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: LicenseRef-Nordic-5-Clause */
 
 &uart1 {
+	status = "okay";
 	pinctrl-0 = <&uart1_default_alt>;
 	pinctrl-1 = <&uart1_sleep_alt>;
 	pinctrl-names = "default", "sleep";


### PR DESCRIPTION
Add missing status = "okay" to lpuart sample board overlays.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

Found while testing auto-upmerge (https://jenkins-ncs.nordicsemi.no/blue/organizations/jenkins/latest%2Fsdk-nrf/detail/PR-10241/1/pipeline/), this is not yet triggering on sdk-nrf/main, but can already be fixed.