### PR TITLE
samples: bluetooth: Fix building HIDS Mouse with security disabled.

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -1475,6 +1475,13 @@ Subsystems
 Bluetooth® LE
 =============
 
+.. rst-class:: v2-2-0 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0
+
+NCSDK-19727: Cannot build the :ref:`peripheral_hids_mouse` sample with security disabled.
+  Build fails when the :kconfig:option:`CONFIG_BT_HIDS_SECURITY_ENABLED` Kconfig option is disabled.
+
+  **Workaround:** Build the sample with its default configuration, that is, enable the :kconfig:option:`CONFIG_BT_HIDS_SECURITY_ENABLED` Kconfig option.
+
 .. rst-class:: v2-2-0
 
 NCSDK-18518: Cannot build peripheral UART and peripheral LBS samples for the nRF52810 and nRF52811 devices with the Zephyr Bluetooth LE Controller

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -398,6 +398,10 @@ Bluetooth samples
 
   * Fixed an issue where the antenna switching was not functional on the nRF5340 DK with the nRF21540 EK shield.
 
+* :ref:`peripheral_hids_mouse` sample:
+
+  * Fixed building the sample with the :kconfig:option:`CONFIG_BT_HIDS_SECURITY_ENABLED` Kconfig option disabled.
+
 Bluetooth mesh samples
 ----------------------
 

--- a/samples/bluetooth/peripheral_hids_mouse/sample.yaml
+++ b/samples/bluetooth/peripheral_hids_mouse/sample.yaml
@@ -27,6 +27,14 @@ tests:
       - nrf5340dk_nrf5340_cpuapp
     platform_allow: nrf5340dk_nrf5340_cpuapp
     tags: bluetooth ci_build
+  sample.bluetooth.peripheral_hids_mouse.no_sec:
+    build_only: true
+    extra_configs:
+      - CONFIG_BT_HIDS_SECURITY_ENABLED=n
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+    tags: bluetooth ci_build
   # Build integration regression protection.
   sample.nrf_security.bluetooth.integration:
       build_only: True

--- a/samples/bluetooth/peripheral_hids_mouse/src/main.c
+++ b/samples/bluetooth/peripheral_hids_mouse/src/main.c
@@ -639,7 +639,8 @@ static struct bt_conn_auth_info_cb conn_auth_info_callbacks = {
 };
 #else
 static struct bt_conn_auth_cb conn_auth_callbacks;
-#endif
+static struct bt_conn_auth_info_cb conn_auth_info_callbacks;
+#endif /* defined(CONFIG_BT_HIDS_SECURITY_ENABLED) */
 
 
 static void num_comp_reply(bool accept)


### PR DESCRIPTION
The example was not building when the Kconfig option: CONFIG_BT_HIDS_SECURITY_ENABLED is disabled.