### PR TITLE
drivers: wifi: Scan only compilation changes

### DIFF
--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_fmac_main.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_fmac_main.c
@@ -12,7 +12,9 @@
 #include <stdlib.h>
 
 #include <zephyr/kernel.h>
+#ifdef CONFIG_NET_L2_ETHERNET
 #include <zephyr/net/ethernet.h>
+#endif
 #include <zephyr/logging/log.h>
 #include <zephyr/net/wifi_mgmt.h>
 
@@ -437,7 +439,7 @@ static const struct zep_wpa_supp_dev_ops wpa_supp_ops = {
 #endif /* !CONFIG_NRF700X_RADIO_TEST */
 
 
-#ifdef CONFIG_NETWORKING
+#ifdef CONFIG_NET_L2_ETHERNET
 ETH_NET_DEVICE_INIT(wlan0, /* name - token */
 		    "wlan0", /* driver name - dev->name */
 		    wifi_nrf_drv_main_zep, /* init_fn */


### PR DESCRIPTION
[SHEL-1251] With CONFIG_NET_NATIVE=y/n with scan only config compilation should work.

Signed-off-by: Ajay Parida <ajay.parida@nordicsemi.no>