### PR TITLE
doc: thingy53: nrf52: Update docs after config simplification (USB CDC ACM, FOTA)

### DIFF
--- a/doc/nrf/libraries/caf/ble_smp.rst
+++ b/doc/nrf/libraries/caf/ble_smp.rst
@@ -38,8 +38,6 @@ The |smp| supports registering OS management handlers automatically, which you c
 Implementation details
 **********************
 
-During the initialization, the module registers the SMP Bluetooth service, which allows to perform DFU over Bluetooth LE.
-
 The module registers the :c:func:`upload_confirm_cb` callback that is used to submit ``ble_smp_transfer_event``.
 The module registers itself as the final subscriber of the event to track the number of submitted events.
 If an ``ble_smp_transfer_event`` was already submitted, but was not yet processed, the module desists from submitting subsequent event.

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -461,7 +461,7 @@
 .. _`Programming SoCs with nrfjprog`: https://infocenter.nordicsemi.com/topic/ug_nrf_cltools/UG/cltools/nrf_nrfjprogexe.html
 
 .. _`Nordic Thingy:53 Hardware`: https://infocenter.nordicsemi.com/topic/ug_thingy53/UG/thingy53/intro/frontpage.html
-.. _`Nordic Thingy:53 Regulatory notices`: https://infocenter.nordicsemi.com/topic/ug_thingy53/UG/thingy53/regulatory/regulatory_notices.
+.. _`Nordic Thingy:53 Regulatory notices`: https://infocenter.nordicsemi.com/topic/ug_thingy53/UG/thingy53/regulatory/regulatory_notices.html
 
 .. _`Nordic Thingy:91 User Guide`: https://infocenter.nordicsemi.com/topic/ug_thingy91/UG/thingy91/intro/frontpage.html
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -52,6 +52,34 @@ Build system
 
   * Manifest file entry ``mbedtls`` (:makevar:`ZEPHYR_MBEDTLS_MODULE_DIR`) checked out at path :file:`modules/crypto/mbedtls` now points to |NCS|'s fork of MbedTLS instead of Zephyr's fork.
 
+Working with nRF52 Series
+=========================
+
+* Developing with nRF52 Series:
+
+  * Added Kconfig options :kconfig:option:`CONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU` and :kconfig:option:`CONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU_SPEEDUP` to configure FOTA updates over Bluetooth Low Energy in the default setup.
+    The default setup uses MCUmgr libraries with the Bluetooth transport layer and requires the user to enable MCUboot bootloader.
+    See details in the FOTA updates section of :ref:`ug_nrf52_developing` guide.
+
+Working with nRF53 Series
+=========================
+
+* Developing with nRF5340 DK:
+
+  * Added Kconfig options :kconfig:option:`CONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU` and :kconfig:option:`CONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU_SPEEDUP` to configure FOTA updates over Bluetooth Low Energy in the default setup.
+    The default setup uses MCUmgr libraries with the Bluetooth transport layer and requires the user to enable MCUboot bootloader.
+    See details in the FOTA updates section of :ref:`ug_nrf5340` guide.
+
+* Developing with Thingy:53:
+
+  * Added the :kconfig:option:`CONFIG_BOARD_SERIAL_BACKEND_CDC_ACM` Kconfig option to configure USB CDC ACM to be used as logger's backend by default.
+    See details in :ref:`thingy53_app_usb` section of Thingy:53 application guide.
+  * Provided support for Thingy:53 FOTA updates within the :kconfig:option:`CONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU` option.
+    See details in :ref:`thingy53_app_fota_smp` section of Thingy:53 application guide.
+  * Enabled MCUboot bootloader in Thingy:53 board configuration by default.
+    See details in :ref:`thingy53_app_mcuboot_bootloader` section of Thingy:53 application guide.
+  * Cleaned up Thingy:53 specific configuration files of samples and applications as a result of introducing simplifications.
+
 Protocols
 =========
 
@@ -843,5 +871,7 @@ Documentation
 
   * The :ref:`software_maturity` page with details about Wi-Fi feature support.
   * The :ref:`app_power_opt` user guide by adding a section about power saving features.
+  * The :ref:`ug_thingy53` by aligning with current simplified configuration.
+  * The :ref:`ug_nrf52_developing` by aligning with current simplified FOTA configuration.
 
 .. |no_changes_yet_note| replace:: No changes since the latest |NCS| release.

--- a/doc/nrf/working_with_nrf/nrf52/developing.rst
+++ b/doc/nrf/working_with_nrf/nrf52/developing.rst
@@ -20,7 +20,7 @@ To get started with your nRF52 Series DK, follow the steps in the :ref:`ug_nrf52
 If you are not familiar with the |NCS| and the development environment, see the :ref:`introductory documentation <getting_started>`.
 
 .. _ug_nrf52_developing_ble_fota:
-.. fota_upgrades_start
+.. fota_upgrades_intro_start
 
 FOTA updates
 ************
@@ -31,20 +31,58 @@ You can also use FOTA updates to replace the application.
 .. note::
    For the possibility of introducing an upgradable bootloader, refer to :ref:`ug_bootloader_adding`.
 
+.. fota_upgrades_intro_end
+
+.. fota_upgrades_over_ble_intro_start
+
 FOTA over Bluetooth Low Energy
 ==============================
 
+FOTA updates are supported using MCUmgr's Simple Management Protocol (SMP) over Bluetooth.
+The application acts as a GATT server and allows the connected Bluetooth Central device to perform a firmware update.
+To use FOTA over Bluetooth LE, samples must support Bluetooth peripheral role (:kconfig:option:`CONFIG_BT_PERIPHERAL`).
+
+The application supports SMP handlers related to:
+
+* Image management.
+* Operating System (OS) management used to reboot the device after the firmware upload is complete.
+* Erasing settings partition used to ensure that a new application is not booted with incompatible content in the settings partition written by the previous application.
+
 To enable support for FOTA updates, do the following:
+
+* Enable the :kconfig:option:`CONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU` Kconfig option, which implies configuration of the following:
+
+   * All of the SMP command handlers mentioned in the previous paragraph.
+   * SMP BT reassembly feature.
+   * The :kconfig:option:`CONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU_SPEEDUP` Kconfig option automatically extends the Bluetooth buffers, which allows to speed up the FOTA transfer over Bluetooth, but also increases RAM usage.
+
+.. fota_upgrades_over_ble_intro_end
+
+.. fota_upgrades_over_ble_mandatory_mcuboot_start
 
 * Use MCUboot as the upgradable bootloader (:kconfig:option:`CONFIG_BOOTLOADER_MCUBOOT` must be enabled).
   For more information, go to the :doc:`mcuboot:index-ncs` page.
-* Enable the mcumgr module that handles the transport protocol over Bluetooth® Low Energy as follows:
 
-  a. Enable the Kconfig options :kconfig:option:`CONFIG_MCUMGR_CMD_OS_MGMT`, :kconfig:option:`CONFIG_MCUMGR_CMD_IMG_MGMT`, and :kconfig:option:`CONFIG_MCUMGR_SMP_BT`.
-  #. Call the functions :c:func:`os_mgmt_register_group()` and :c:func:`img_mgmt_register_group()` in your application.
-  #. Call the :c:func:`smp_bt_register()` function in your application to initialize the mcumgr Bluetooth Low Energy transport.
+.. fota_upgrades_over_ble_mandatory_mcuboot_end
 
-  After completing these steps, your application advertises the SMP Service with ``UUID 8D53DC1D-1DB7-4CD3-868B-8A527460AA84``.
+.. fota_upgrades_over_ble_additional_information_start
+
+If necessary, you can modify any of the implied options or defaulted values introduced by the :kconfig:option:`CONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU` Kconfig option.
+
+You can either add these Kconfig options to the configuration files of your application or have them inline in a project build command.
+Here is an example of how you can build for the :ref:`peripheral_lbs` sample:
+
+.. parsed-literal::
+   :class: highlight
+
+    west build -b *build_target* -- -DCONFIG_BOOTLOADER_MCUBOOT=y -DCONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU=y
+
+When you connect to the device after the build has completed and the firmware has been programmed to it, the SMP Service is enabled with the ``UUID 8D53DC1D-1DB7-4CD3-868B-8A527460AA84``.
+If you want to add SMP Service to advertising data, refer to the :ref:`zephyr:smp_svr_sample`.
+
+.. fota_upgrades_over_ble_additional_information_end
+
+.. fota_upgrades_outro_start
 
 To perform a FOTA update, complete the following steps:
 
@@ -87,7 +125,7 @@ This configuration was carefully selected to achieve the maximum possible throug
 
 Consider using these features in your project to speed up the FOTA update process.
 
-.. fota_upgrades_end
+.. fota_upgrades_outro_end
 
 .. _ug_nrf52_developing_fota_in_mesh:
 .. fota_upgrades_bt_mesh_start

--- a/doc/nrf/working_with_nrf/nrf53/nrf5340.rst
+++ b/doc/nrf/working_with_nrf/nrf53/nrf5340.rst
@@ -523,8 +523,26 @@ See the following instructions.
          Otherwise, if you recover the application core first and the network core last, the binary written to the application core is deleted and readback protection is enabled again after a reset.
 
 .. include:: ../nrf52/developing.rst
-   :start-after: fota_upgrades_start
-   :end-before: fota_upgrades_end
+   :start-after: fota_upgrades_intro_start
+   :end-before: fota_upgrades_intro_end
+
+.. include:: ../nrf52/developing.rst
+   :start-after: fota_upgrades_over_ble_intro_start
+   :end-before: fota_upgrades_over_ble_intro_end
+
+.. include:: ../nrf52/developing.rst
+   :start-after: fota_upgrades_over_ble_mandatory_mcuboot_start
+   :end-before: fota_upgrades_over_ble_mandatory_mcuboot_end
+
+Bluetooth buffers configuration introduced by the :kconfig:option:`CONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU_SPEEDUP` Kconfig option is also automatically applied to the network core child image by the dedicated overlay file.
+
+.. include:: ../nrf52/developing.rst
+   :start-after: fota_upgrades_over_ble_additional_information_start
+   :end-before: fota_upgrades_over_ble_additional_information_end
+
+.. include:: ../nrf52/developing.rst
+   :start-after: fota_upgrades_outro_start
+   :end-before: fota_upgrades_outro_end
 
 .. include:: ../nrf52/developing.rst
    :start-after: fota_upgrades_bt_mesh_start

--- a/doc/nrf/working_with_nrf/nrf53/thingy53.rst
+++ b/doc/nrf/working_with_nrf/nrf53/thingy53.rst
@@ -25,10 +25,6 @@ By default, the serial terminal is accessible through the USB CDC ACM class hand
 The serial port is visible right after the Thingy:53 is connected to the host using a USB cable.
 The CDC ACM baudrate is ignored, and transfer goes with USB speed.
 
-.. note::
-   Some of the samples and applications compatible with Thingy:53 may provide multiple instances of USB CDC ACM class.
-   In that case, the first instance is used to provide logs, and the others are used for application-specific usages.
-
 .. _thingy53_building_pgming:
 
 Building and programming from the source code
@@ -36,7 +32,7 @@ Building and programming from the source code
 
 You can program the Nordic Thingy:53 by using the images obtained by building the code in the |NCS| environment.
 
-To set up your system to be able to build a compatible firmware image, follow the :ref:`getting_started` guide for the |NCS|.
+To set up your system to be able to build a firmware image, follow the :ref:`getting_started` guide for the |NCS|.
 
 .. _thingy53_build_pgm_targets:
 
@@ -55,12 +51,8 @@ The build targets of interest for Thingy:53 in the |NCS| are listed in the follo
 | nRF5340 SoC - Network core     |``thingy53_nrf5340_cpunet``                                                                                                       |
 +--------------------------------+----------------------------------------------------------------------------------------------------------------------------------+
 
-.. note::
-   The |NCS| samples and applications that are compatible with the Nordic Thingy:53 follow the :ref:`thingy53_app_guide`.
-   The application guide defines a consistent partition map and bootloader configuration to allow serial and OTA firmware updates.
-
-The |NCS| by default uses :ref:`ug_multi_image` for Thingy:53.
-Because of this, when you choose ``thingy53_nrf5340_cpuapp`` or ``thingy53_nrf5340_cpuapp_ns`` as the build target when building a sample or application that is compatible with Thingy:53, you will generate firmware for both the application core and network core:
+The |NCS| uses :ref:`ug_multi_image` for Thingy:53 by default.
+When you choose ``thingy53_nrf5340_cpuapp`` or ``thingy53_nrf5340_cpuapp_ns`` as the build target when building a sample or application, you will generate firmware for both the application core and network core:
 
 * The application core firmware consists of MCUboot bootloader and an application image.
 * The network core firmware consists of network core bootloader (B0n) and application firmware of the network core.
@@ -76,7 +68,6 @@ The build process generates firmware in two formats:
 For more information about files generated as output of the build process, see :ref:`app_build_output_files`.
 
 See the following sections for details regarding building and programming the firmware for Thingy:53 in various environments.
-If your Thingy:53 is already programmed with a Thingy:53-compatible sample or application, you can also use the MCUboot bootloader to update the firmware after you finish building.
 See :ref:`thingy53_app_update` for more detailed information about updating firmware on Thingy:53.
 
 .. _thingy53_build_pgm_vscode:
@@ -127,7 +118,9 @@ To build and program the source code from the command line, complete the followi
 
       west build -b *build_target* -d *destination_directory_name*
 
-   The build target should be ``thingy53_nrf5340_cpuapp`` or ``thingy53_nrf5340_cpuapp_ns`` when building samples for the application core and ``thingy53_nrf5340_cpunet`` when building for the network core.
+   The build target should be ``thingy53_nrf5340_cpuapp`` or ``thingy53_nrf5340_cpuapp_ns`` when building samples for the application core.
+   The proper child image for ``thingy53_nrf5340_cpunet`` will be built automatically.
+   See :ref:`thingy53_build_pgm_targets` for details.
 
 #. Program the sample or application:
 
@@ -156,19 +149,15 @@ See :ref:`thingy53_gs_updating_firmware` for details about updating firmware ima
 Firmware update using external debug probe
 ------------------------------------------
 
-If you are using an external debug probe, such as the nRF5340 DK, or any J-Link device supporting ARM Cortex-M33, you do not have to use applications that follow the :ref:`thingy53_app_guide`.
-In that case, you can program the Thingy:53 in a similar way as nRF5340 DK.
+If you are using an external debug probe, such as the nRF5340 DK, or any J-Link device supporting ARM Cortex-M33, you can program the Thingy:53 the same way as nRF5340 DK.
 See :ref:`ug_nrf5340` for details.
-
-.. note::
-   You need to program a sample or application compatible with the Nordic :ref:`thingy53_app_guide` to bring back serial recovery and DFU OTA.
 
 .. _thingy53_app_update_mcuboot:
 
 Firmware update using MCUboot bootloader
 ----------------------------------------
 
-The Thingy:53-compatible samples and applications include the MCUboot bootloader that you can use to update firmware.
+Samples and applications built for Thingy:53 include the MCUboot bootloader that you can use to update the firmware out of the box.
 This method uses signed binary files :file:`app_update.bin` and :file:`net_core_app_update.bin` (or :file:`dfu_application.zip`).
 You can program the precompiled firmware image using one of the following ways:
 
@@ -176,9 +165,10 @@ You can program the precompiled firmware image using one of the following ways:
   In this scenario Thingy is connected directly to your PC through USB.
 * Update the firmware over-the-air (OTA) using Bluetooth LE and the nRF Programmer mobile application for Android or iOS.
   To use this method, the application that is currently programmed on Thingy:53 must support it.
+  For details, refer to :ref:`thingy53_app_fota_smp` section.
   All precompiled images support OTA using Bluetooth.
 
-See :ref:`thingy53_gs_updating_firmware` for the detailed procedures on how to program a Thingy:53 using `nRF Connect Programmer`_ or the nRF Programmer for Android or iOS.
+See :ref:`thingy53_gs_updating_firmware` for the detailed procedures on how to program a Thingy:53 using `nRF Connect Programmer`_ or the `nRF Programmer`_ for Android or iOS.
 
 .. _thingy53_app_guide:
 
@@ -186,27 +176,18 @@ Thingy:53 application guide
 ***************************
 
 The Nordic Thingy:53 does not have a built-in J-Link debug IC.
-Because of that, the samples and applications that are compatible with the Nordic Thingy:53 by default include the MCUboot bootloader with serial recovery support.
-You can update applications compatible with the Nordic Thingy:53 using the DFU functionality with either `nRF Connect Programmer`_ or the `nRF Programmer`_ mobile application.
-
-Enabling DFU and MCUboot requires consistency in configuration of the samples and applications.
-For a sample or application to be compatible with Thingy:53, the application must comply with the configurations described in the following sections.
-
-.. note::
-   To use your application with the Nordic Thingy:53 preprogrammed bootloader, you must only set the proper configuration for the Partition Manager and MCUboot.
-   Configurations that enable the other features are not mandatory, but you can enable them if needed.
-
-   All applications compatible with the Nordic Thingy:53 in the |NCS| also support the additional features.
-   Refer to the source code of the samples and applications for examples of implementation.
+Because of that, the Thingy:53 board enables MCUboot bootloader with serial recovery support and predefined static Partition Manager memory map by default.
+You can also enable FOTA updates manually.
+See the following sections for details of what is configured by default and what you can configure by yourself.
 
 .. _thingy53_app_partition_manager_config:
 
 Partition manager configuration
 ===============================
 
-The samples compatible with the Nordic Thingy:53 use :ref:`partition_manager` to define memory partitions.
+The samples and applications for Nordic Thingy:53 use the :ref:`partition_manager` by default to define memory partitions.
 The memory layout must stay consistent, so that MCUboot can perform proper image updates and clean up the settings storage partition.
-To ensure that partition layout does not change between builds, the sample must use a static partition layout that is consistent between all compatible samples in the |NCS|.
+To ensure that the partition layout does not change between builds, the sample must use a static partition layout that is consistent between all samples in the |NCS|.
 The memory partitions are defined in the :file:`pm_static_thingy53_nrf5340_cpuapp.yml` and :file:`pm_static_thingy53_nrf5340_cpuapp_ns.yml` files in the :file:`zephyr/boards/arm/thingy53_nrf5340` directory.
 
 The PCD SRAM partition is locked by the MCUboot bootloader to prevent the application from modifying the network core firmware.
@@ -220,48 +201,43 @@ The overlay is applied automatically.
 MCUboot bootloader
 ==================
 
-Each sample must enable the MCUboot bootloader and use the same configuration of the bootloader as all of the Nordic Thingy:53-compatible samples in the |NCS|.
+MCUboot bootloader is enabled by default for Thingy:53 in the :file:`Kconfig.defconfig` file of the board.
 This ensures that the sample includes the MCUboot bootloader and that an MCUboot-compatible image is generated when the sample is built.
 When using |NCS| to build the MCUboot bootloader for the Thingy:53, the configuration is applied automatically from the MCUboot repository.
 
 The MCUboot bootloader supports serial recovery and a custom command to erase the settings storage partition.
 Erasing the settings partition is needed to ensure that an application is not booted with incompatible content loaded from the settings partition.
 
-Use the following Kconfig options to enable the MCUboot bootloader:
-
-* :kconfig:option:`CONFIG_BOOTLOADER_MCUBOOT`
-* :kconfig:option:`CONFIG_IMG_MANAGER`
-* :kconfig:option:`CONFIG_MCUBOOT_IMG_MANAGER`
-* :kconfig:option:`CONFIG_IMG_ERASE_PROGRESSIVELY`
-
-In addition, set the :kconfig:option:`CONFIG_UPDATEABLE_IMAGE_NUMBER` option to ``2`` and set an image version, such as ``"1.0.0+0"``, using the :kconfig:option:`CONFIG_MCUBOOT_IMAGE_VERSION` Kconfig option.
-
-See :file:`thingy53_nrf5340_cpuapp.conf` in a compatible sample for how this is done.
+In addition, you can set an image version, such as ``"2.3.0+0"``, using the :kconfig:option:`CONFIG_MCUBOOT_IMAGE_VERSION` Kconfig option.
 
 .. _thingy53_app_usb:
 
 USB
 ===
 
-An application compatible with the Nordic Thingy:53 is expected to enable USB CDC ACM as backend for logging.
-The logs are provided using USB CDC ACM to allow accessing them without additional hardware.
+The logs on the Thingy:53 board are provided by default using USB CDC ACM to allow access to them without additional hardware.
 
-Most of the applications and samples compatible with the Nordic Thingy:53 use only a single instance of USB CDC ACM that works as the logger's backend.
+Most of the applications and samples for Thingy:53 use only a single instance of USB CDC ACM that works as the logger's backend.
 No other USB classes are used.
 These samples can share a common USB product name, vendor ID, and product ID.
 If a sample supports additional USB classes or more than one instance of USB CDC ACM, it must use a dedicated product name, vendor ID, and product ID.
 
-To enable the USB device stack and the CDC ACM class:
+The :kconfig:option:`CONFIG_BOARD_SERIAL_BACKEND_CDC_ACM` Kconfig option (defined in the :file:`zephyr/boards/arm/thingy53_nrf5340/Kconfig.defconfig` file) automatically sets the default values of USB product name, vendor ID and product ID of Thingy:53.
+It also enables the USB device stack and initializes the USB device at boot.
+The remote wakeup feature of a USB device is disabled by default as it requires extra action from the application side.
+A single USB CDC ACM instance is automatically included in the default board's DTS configuration file (:file:`zephyr/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts`).
+The USB CDC instance is used to forward application logs.
 
-* Use the options :kconfig:option:`CONFIG_USB_DEVICE_STACK` and :kconfig:option:`CONFIG_USB_CDC_ACM`.
-* Set the default log level with the :kconfig:option:`CONFIG_USB_CDC_ACM_LOG_LEVEL_ERR` and :kconfig:option:`CONFIG_USB_DEVICE_LOG_LEVEL_ERR` Kconfig options.
-* Enable the UART log backend with the :kconfig:option:`CONFIG_LOG_BACKEND_UART` Kconfig option and disable SEGGER RTT with both the :kconfig:option:`CONFIG_LOG_BACKEND_RTT` and :kconfig:option:`CONFIG_USE_SEGGER_RTT` Kconfig options.
+If you do not want to use the USB CDC ACM as a backend for logging out of the box, you can disable it as follows:
 
-See :file:`thingy53_nrf5340_cpuapp.conf` in a compatible sample for how this is done.
+* Disable the :kconfig:option:`CONFIG_BOARD_SERIAL_BACKEND_CDC_ACM` Kconfig option.
+* If USB CDC ACM is not used for anything else, you can disable it in the application's DTS overlay file:
 
-In addition, you have to call the :c:func:`usb_enable` function from your application to initialize the USB stack.
+  .. code-block:: none
 
-See the :file:`thingy53.c` source file in a compatible sample for how this is done.
+     &cdc_acm_uart {
+         status = "disabled";
+     };
 
 .. _thingy53_app_antenna:
 
@@ -278,7 +254,7 @@ The Nordic Thingy:53 has an RF front-end with two 2.4 GHz antennas:
 
    Nordic Thingy:53 - Antenna connections
 
-The samples in the |NCS| that are compatible with the Nordic Thingy:53 use **ANT1** by default, with the nRF21540 gain set to +10 dBm.
+The samples in the |NCS| use **ANT1** by default, with the nRF21540 gain set to +10 dBm.
 You can configure the TX gain with the :kconfig:option:`CONFIG_MPSL_FEM_NRF21540_TX_GAIN_DB` Kconfig option to select between +10 dBm or +20 dBm gain.
 To use the **ANT2** antenna, disable the :kconfig:option:`CONFIG_MPSL_FEM` Kconfig option in the network core's child image configuration.
 
@@ -288,34 +264,17 @@ To use the **ANT2** antenna, disable the :kconfig:option:`CONFIG_MPSL_FEM` Kconf
 
 .. _thingy53_app_fota_smp:
 
-FOTA and SMP
-============
+.. include:: ../nrf52/developing.rst
+   :start-after: fota_upgrades_over_ble_intro_start
+   :end-before: fota_upgrades_over_ble_intro_end
 
-FOTA updates on the Nordic Thingy:53 are supported using MCUmanager's Simple Management Protocol (SMP) over Bluetooth.
-The application acts as a GATT server and allows the connected Bluetooth Central to perform the firmware update for both the application and network core.
-The Bluetooth configuration is updated to allow quick DFU data transfer.
+Bluetooth buffers configuration introduced by the :kconfig:option:`CONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU_SPEEDUP` Kconfig option is also automatically applied to the network core child image by the dedicated overlay file.
+Thingy:53 supports network core upgrade out of the box.
 
-The application supports SMP handlers related to:
+.. include:: ../nrf52/developing.rst
+   :start-after: fota_upgrades_over_ble_additional_information_start
+   :end-before: fota_upgrades_over_ble_additional_information_end
 
-* Image management.
-* Operating System (OS) management -- used to reboot the device after the firmware upload is complete.
-* Erasing settings partition -- used to ensure that a new application is not booted with incompatible content in the settings partition written by the previous application.
-
-To enable the MCUmanager library and handling of SMP commands over Bluetooth, use the options :kconfig:option:`CONFIG_MCUMGR` and :kconfig:option:`CONFIG_MCUMGR_SMP_BT`.
-Also, disable encryption and authentication requirement for the Bluetooth SMP transport using :kconfig:option:`CONFIG_MCUMGR_SMP_BT_AUTHEN`.
-
-You need to enable the MCUmanager handlers for image and OS management.
-Use the options :kconfig:option:`CONFIG_MCUMGR_CMD_IMG_MGMT` and :kconfig:option:`CONFIG_MCUMGR_CMD_OS_MGMT`.
-
-You also have to enable the MCUmanager processing of basic Zephyr group commands and storage erase commands.
-Use the options :kconfig:option:`CONFIG_MCUMGR_GRP_ZEPHYR_BASIC` and :kconfig:option:`CONFIG_MCUMGR_GRP_BASIC_CMD_STORAGE_ERASE`.
-
-See :file:`thing53_nrf5340_cpuapp.conf` in a compatible sample for how this is done.
-
-In addition, the application must call the functions :c:func:`os_mgmt_register_group` and :c:func:`img_mgmt_register_group` to register the image and OS management command handlers.
-The application must also call :c:func:`smp_bt_register` to register the SMP Bluetooth Service.
-
-See the :file:`thingy53.c` source file in a compatible sample for how this is done.
 
 .. _thingy53_app_external_flash:
 
@@ -323,21 +282,18 @@ External flash
 ==============
 
 During a FOTA update, there might not be enough space available in internal flash storage to store the existing application and network core images as well as the incoming images, so the incoming images must be stored in external flash storage.
-This means that a sample compatible with the Nordic Thingy:53 must enable the external flash using the QSPI driver.
-Enable the option :kconfig:option:`CONFIG_NORDIC_QSPI_NOR`, and set :kconfig:option:`CONFIG_NORDIC_QSPI_NOR_FLASH_LAYOUT_PAGE_SIZE` to ``4096`` and :kconfig:option:`CONFIG_NORDIC_QSPI_NOR_STACK_WRITE_BUFFER_SIZE` to ``16``.
-See :file:`thingy53_nrf5340_cpuapp.conf` in a compatible sample for how this is done.
+The Thingy:53 board automatically configures external flash storage and QSPI driver when FOTA updates are implied with the :kconfig:option:`CONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU` Kconfig option.
 
 .. _thingy53_compatible_applications:
 
-Samples and applications compatible with Thingy:53
-==================================================
+Samples and applications for Thingy:53 with FOTA out of the box
+===============================================================
 
-The following samples and applications in the |NCS| are already compatible with Thingy:53:
+The following samples and applications in the |NCS| enable FOTA for Thingy:53 by default:
 
 * Applications:
 
   * :ref:`matter_weather_station_app`
-  * :ref:`zigbee_weather_station_app`
   * :ref:`nrf_machine_learning_app`
 
 * Samples:


### PR DESCRIPTION
Updated user guides for nRF52/53 series DKs & Thingy:53 and changelog.

PR has been separated for several commits:
* link fix
* related to USB CDC ACM and pm-ext-flash configuration: #10115 & #10024
* Thingy:53 + nRF52/53 series DKs related to FOTA configuration: #9999 PR

Jira: NCSDK-19197