### PR TITLE
samples: zigbee: ncp: Enable uart1

### DIFF
--- a/samples/zigbee/ncp/boards/nrf52833dk_nrf52833.overlay
+++ b/samples/zigbee/ncp/boards/nrf52833dk_nrf52833.overlay
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2021-2022 Nordic Semiconductor ASA
+ * Copyright (c) 2021-2023 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 &uart1 {
+	status = "okay";
 	pinctrl-0 = <&uart1_default_alt>;
 	pinctrl-1 = <&uart1_sleep_alt>;
 	pinctrl-names = "default", "sleep";


### PR DESCRIPTION
Adding missing status = "okay" to uart1 configuration in nrf52833dk_nrf52833.overlay.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

Not yet triggered, but already happens with auto-upmerge branch testing (https://jenkins-ncs.nordicsemi.no/blue/organizations/jenkins/latest%2Fsdk-nrf/detail/PR-10241/1/pipeline/398), in form of build error:
```
[2023-02-10T17:08:14.732Z]                  from ../../../../../nrf/subsys/zigbee/osif/zb_nrf_async_serial.c:7:

[2023-02-10T17:08:14.732Z] ../../../../../zephyr/include/zephyr/device.h:83:41: error: '__device_dts_ord_112' undeclared here (not in a function); did you mean '__device_dts_ord_12'?

[2023-02-10T17:08:14.732Z]    83 | #define DEVICE_NAME_GET(dev_id) _CONCAT(__device_, dev_id)

[2023-02-10T17:08:14.732Z]       |                                         ^~~~~~~~~

[2023-02-10T17:08:14.732Z] ../../../../../zephyr/include/zephyr/toolchain/common.h:132:26: note: in definition of macro '_DO_CONCAT'

[2023-02-10T17:08:14.732Z]   132 | #define _DO_CONCAT(x, y) x ## y

[2023-02-10T17:08:14.732Z]       |                          ^

[2023-02-10T17:08:14.732Z] ../../../../../zephyr/include/zephyr/device.h:83:33: note: in expansion of macro '_CONCAT'

[2023-02-10T17:08:14.732Z]    83 | #define DEVICE_NAME_GET(dev_id) _CONCAT(__device_, dev_id)

[2023-02-10T17:08:14.732Z]       |                                 ^~~~~~~

[2023-02-10T17:08:14.732Z] ../../../../../zephyr/include/zephyr/device.h:209:37: note: in expansion of macro 'DEVICE_NAME_GET'

[2023-02-10T17:08:14.732Z]   209 | #define DEVICE_DT_NAME_GET(node_id) DEVICE_NAME_GET(Z_DEVICE_DT_DEV_ID(node_id))

[2023-02-10T17:08:14.732Z]       |                                     ^~~~~~~~~~~~~~~

[2023-02-10T17:08:14.732Z] ../../../../../zephyr/include/zephyr/device.h:226:34: note: in expansion of macro 'DEVICE_DT_NAME_GET'

[2023-02-10T17:08:14.732Z]   226 | #define DEVICE_DT_GET(node_id) (&DEVICE_DT_NAME_GET(node_id))

[2023-02-10T17:08:14.732Z]       |                                  ^~~~~~~~~~~~~~~~~~

[2023-02-10T17:08:14.732Z] ../../../../../nrf/subsys/zigbee/osif/zb_nrf_async_serial.c:17:40: note: in expansion of macro 'DEVICE_DT_GET'

[2023-02-10T17:08:14.732Z]    17 | static const struct device *uart_dev = DEVICE_DT_GET(DT_CHOSEN(ncs_zigbee_uart));

```

**2023-02-13** Updated commit according to comment from here https://github.com/nrfconnect/sdk-nrf/pull/10250#discussion_r1105547257 by moving `status` to the top of definition.
**2023-02-15** Force pushed because CLA stuck.