### PR TITLE
tests: zigbee: osif: Enable uart1 for nrf52833dk_nrf52833

### DIFF
--- a/tests/subsys/zigbee/osif/serial/serial_async_api/boards/nrf52833dk_nrf52833.overlay
+++ b/tests/subsys/zigbee/osif/serial/serial_async_api/boards/nrf52833dk_nrf52833.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Nordic Semiconductor ASA
+ * Copyright (c) 2022-2023 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
@@ -8,4 +8,8 @@
 	chosen {
 		ncs,zigbee-uart = &uart1;
 	};
+};
+
+&uart1 {
+	status = "okay";
 };

--- a/tests/subsys/zigbee/osif/serial/serial_basic_api/boards/nrf52833dk_nrf52833.overlay
+++ b/tests/subsys/zigbee/osif/serial/serial_basic_api/boards/nrf52833dk_nrf52833.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Nordic Semiconductor ASA
+ * Copyright (c) 2022-2023 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
@@ -8,4 +8,8 @@
 	chosen {
 		ncs,zigbee-uart = &uart1;
 	};
+};
+
+&uart1 {
+	status = "okay";
 };


### PR DESCRIPTION
Enable uart1 in overlay for nrf52833dk_nrf52833 platform.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

This does not shows yet, but can be seen affecting testing of auto-upmerge (https://jenkins-ncs.nordicsemi.no/blue/organizations/jenkins/latest%2Fsdk-nrf/detail/PR-10241/1/pipeline/398) by failing build with errors:
```
[2023-02-10T17:09:28.241Z] ../../../../../../../../zephyr/include/zephyr/device.h:83:41: error: '__device_dts_ord_104' undeclared here (not in a function); did you mean '__device_dts_ord_14'?

[2023-02-10T17:09:28.241Z]    83 | #define DEVICE_NAME_GET(dev_id) _CONCAT(__device_, dev_id)

[2023-02-10T17:09:28.241Z]       |                                         ^~~~~~~~~

[2023-02-10T17:09:28.241Z] ../../../../../../../../zephyr/include/zephyr/toolchain/common.h:132:26: note: in definition of macro '_DO_CONCAT'

[2023-02-10T17:09:28.241Z]   132 | #define _DO_CONCAT(x, y) x ## y

[2023-02-10T17:09:28.241Z]       |                          ^

[2023-02-10T17:09:28.241Z] ../../../../../../../../zephyr/include/zephyr/device.h:83:33: note: in expansion of macro '_CONCAT'

[2023-02-10T17:09:28.241Z]    83 | #define DEVICE_NAME_GET(dev_id) _CONCAT(__device_, dev_id)

[2023-02-10T17:09:28.241Z]       |                                 ^~~~~~~

[2023-02-10T17:09:28.241Z] ../../../../../../../../zephyr/include/zephyr/device.h:209:37: note: in expansion of macro 'DEVICE_NAME_GET'

[2023-02-10T17:09:28.241Z]   209 | #define DEVICE_DT_NAME_GET(node_id) DEVICE_NAME_GET(Z_DEVICE_DT_DEV_ID(node_id))

[2023-02-10T17:09:28.241Z]       |                                     ^~~~~~~~~~~~~~~

[2023-02-10T17:09:28.241Z] ../../../../../../../../zephyr/include/zephyr/device.h:226:34: note: in expansion of macro 'DEVICE_DT_NAME_GET'

[2023-02-10T17:09:28.241Z]   226 | #define DEVICE_DT_GET(node_id) (&DEVICE_DT_NAME_GET(node_id))

[2023-02-10T17:09:28.241Z]       |                                  ^~~~~~~~~~~~~~~~~~

[2023-02-10T17:09:28.241Z] ../../../../../../../../nrf/subsys/zigbee/osif/zb_nrf_async_serial.c:17:40: note: in expansion of macro 'DEVICE_DT_GET'

[2023-02-10T17:09:28.241Z]    17 | static const struct device *uart_dev = DEVICE_DT_GET(DT_CHOSEN(ncs_zigbee_uart));

[2023-02-10T17:09:28.241Z]       |                                        ^
```