### PR TITLE
samples: matter: switchable door lock cli support

### DIFF
--- a/samples/matter/lock/Kconfig
+++ b/samples/matter/lock/Kconfig
@@ -58,6 +58,11 @@ config APPLICATION_OTHER_LABEL
 	default "Wi-Fi" if NET_L2_OPENTHREAD
 	default "Thread" if CHIP_WIFI
 
+config THREAD_WIFI_SWITCHING_CLI_SUPPORT
+	bool "Add CLI command for triggering of the switch between Thread and Wi-Fi"
+	default n
+	select CHIP_LIB_SHELL
+
 endif
 
 # Sample configuration used for Thread networking

--- a/samples/matter/lock/src/app_task.h
+++ b/samples/matter/lock/src/app_task.h
@@ -70,6 +70,10 @@ private:
 	bool mSwitchImagesTimerActive = false;
 #endif
 
+#ifdef CONFIG_THREAD_WIFI_SWITCHING_CLI_SUPPORT
+	static void RegisterSwitchCliCommand();
+#endif
+
 	FunctionEvent mFunction = FunctionEvent::NoneSelected;
 	bool mFunctionTimerActive = false;
 


### PR DESCRIPTION
Add support for switching door lock Thread/Wi-Fi
images from command line. This feature primarily
aims to support tests automation.

Signed-off-by: Marcin Kajor <marcin.kajor@nordicsemi.no>