### PR TITLE
manifest: sdk-hostap: Pull fix for unncessary prints

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -102,7 +102,7 @@ manifest:
     # changes.
     - name: sdk-hostap
       path: modules/lib/hostap
-      revision: 4240dc1f37c2af7f83aedf77ab909df2476c5b37
+      revision: 8d3f26d7da1b49815fbd0fe8335189cfac4ded85
     - name: mcuboot
       repo-path: sdk-mcuboot
       revision: 6242c860864bc6a1ed45f4f1af0e57b53cf3b858


### PR DESCRIPTION
OK/FAIL are not needed when wpa_cli is not used as we don't use them in interactive mode.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>