### PR TITLE
drivers: wifi: Get extended capabilities

### DIFF
--- a/drivers/wifi/nrf700x/zephyr/inc/zephyr_fmac_main.h
+++ b/drivers/wifi/nrf700x/zephyr/inc/zephyr_fmac_main.h
@@ -63,6 +63,11 @@ struct wifi_nrf_vif_ctx_zep {
 	bool ps_config_info_evnt;
 	bool passive_scan;
 	bool authorized;
+	struct wifi_nrf_ext_capa {
+		enum nrf_wifi_iftype iftype;
+		unsigned char *ext_capa, *ext_capa_mask;
+		unsigned int ext_capa_len;
+	} iface_ext_capa;
 };
 
 struct wifi_nrf_vif_ctx_map {
@@ -84,6 +89,8 @@ struct wifi_nrf_ctx_zep {
 	struct rpu_conf_params conf_params;
 #endif /* CONFIG_NRF700X_WIFI_UTIL */
 #endif /* CONFIG_NRF700X_RADIO_TEST */
+	unsigned char *extended_capa, *extended_capa_mask;
+	unsigned int extended_capa_len;
 };
 
 struct wifi_nrf_drv_priv_zep {

--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_fmac_main.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_fmac_main.c
@@ -53,7 +53,7 @@ BUILD_ASSERT(RPU_PKTRAM_SIZE >=
 static const unsigned char aggregation = 1;
 static const unsigned char wmm = 1;
 static const unsigned char max_num_tx_agg_sessions = 4;
-static const unsigned char max_num_rx_agg_sessions = 2;
+static const unsigned char max_num_rx_agg_sessions = 8;
 static const unsigned char reorder_buf_size = 64;
 static const unsigned char max_rxampdu_size = MAX_RX_AMPDU_SIZE_64KB;
 


### PR DESCRIPTION
[SHEL-1269]: Multiple BSSID bit is not set in Association request
- Implement get_ext_capab op to get MBSSID support cap. info
- Update max_num_rx_agg_sessions to 8

Signed-off-by: Sridhar Nuvusetty <sridhar.nuvusetty@nordicsemi.no>