### PR TITLE
drivers: wifi: Fix the return value

### DIFF
--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_net_if.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_net_if.c
@@ -125,7 +125,6 @@ int wifi_nrf_if_send(const struct device *dev,
 
 	if ((vif_ctx_zep->if_carr_state != WIFI_NRF_FMAC_IF_CARR_STATE_ON) ||
 	    (!vif_ctx_zep->authorized && !is_eapol(pkt))) {
-		ret = 0;
 		goto out;
 	}
 


### PR DESCRIPTION
This crept in due to a bad rebase. This causes wrong feedback to be sent up the stack.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>