### PR TITLE
doc: Movement of MQTT sample

### DIFF
--- a/doc/nrf/samples/nrf9160.rst
+++ b/doc/nrf/samples/nrf9160.rst
@@ -9,4 +9,5 @@ nRF9160 samples
    :glob:
 
    ../../../samples/nrf9160/*/README
+   ../../../samples/net/*/README
    ../../../samples/nrf9160/http_update/*/README

--- a/doc/nrf/samples/other.rst
+++ b/doc/nrf/samples/other.rst
@@ -13,6 +13,5 @@ Other samples
    ../../../samples/ipc/*/README
    ../../../samples/keys/*/README
    ../../../samples/mpsl/*/README
-   ../../../samples/net/*/README
    ../../../samples/peripheral/*/README
    ../../../samples/sensor/*/README

--- a/doc/nrf/samples/wifi.rst
+++ b/doc/nrf/samples/wifi.rst
@@ -9,3 +9,4 @@ Wi-Fi samples
    :glob:
 
    ../../../samples/wifi/*/README
+    ../../../samples/net/*/README


### PR DESCRIPTION
MQTT sample documentation is moved from
other samples.The sample documentation is
now placed under following pages:
1. nRF9160 samples
2. Wi-Fi Samples

Signed-off-by: divya pillai <divya.pillai@nordicsemi.no>