### PR TITLE
doc: Correct the link to PSA Crypto API version

### DIFF
--- a/doc/nrf/app_dev/tfm/index.rst
+++ b/doc/nrf/app_dev/tfm/index.rst
@@ -66,7 +66,7 @@ In such case, the Kconfig configurations in the Nordic Security Backend control 
 You can configure what crypto modules to include in TF-M by using the ``TFM_CRYPTO_`` Kconfig options found in file :file:`zephyr/modules/trusted-firmware-m/Kconfig.tfm.crypto_modules`.
 
 TF-M utilizes :ref:`hardware unique keys <lib_hw_unique_key>` when the PSA Crypto key derivation APIs are used, and ``psa_key_derivation_setup`` is called with the algorithm ``TFM_CRYPTO_ALG_HUK_DERIVATION``.
-For more information about the PSA cryptography and the API, see `PSA Cryptography API 1.1`_.
+For more information about the PSA cryptography and the API, see `PSA Cryptography API 1.0.1`_.
 
 .. _tfm_minimal_build:
 

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -183,7 +183,7 @@
 
 .. _`Memfault WebBluetooth Client`: https://memfault.github.io/web-ble-example/
 
-.. _`PSA Cryptography API 1.1`: https://armmbed.github.io/mbed-crypto/html/
+.. _`PSA Cryptography API 1.0.1`: https://armmbed.github.io/mbed-crypto/1.0.1/html/index.html
 
 .. ### Source: developer.nordicsemi.com
 

--- a/doc/nrf/security.rst
+++ b/doc/nrf/security.rst
@@ -59,7 +59,7 @@ Cryptographic operations in |NCS|
 *********************************
 
 Cryptographic operations in |NCS| are handled by the :ref:`nrfxlib:nrf_security`, which is configurable through Kconfig options.
-The module can be enabled through the :kconfig:option:`CONFIG_NRF_SECURITY` Kconfig option, and it allows the usage of `Mbed TLS`_ and `PSA Cryptography API 1.1`_ for cryptographic operations and random number generation in the application.
+The module can be enabled through the :kconfig:option:`CONFIG_NRF_SECURITY` Kconfig option, and it allows the usage of `Mbed TLS`_ and `PSA Cryptography API 1.0.1`_ for cryptographic operations and random number generation in the application.
 
 The :ref:`nrfxlib:nrf_security` acts as an orchestrator for the different cryptographic libraries available in the system.
 These libraries include the binary versions of accelerated cryptographic libraries listed in :ref:`nrfxlib:crypto`, and the open source Mbed TLS implementation in |NCS| located in `sdk-mbedtls`_.


### PR DESCRIPTION
The previous link provided pointed to the PSA Cryptography API 1.1 but only 1.0.1 is supported there the link in the doc's got corrected.

Signed-off-by: Markus Swarowsky <markus.swarowsky@nordicsemi.no>