### PR TITLE
application: serial_lte_modem: BUG-fix httpc multi thread

### DIFF
--- a/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
+++ b/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
@@ -504,6 +504,7 @@ static void httpc_thread_fn(void *arg1, void *arg2, void *arg3)
 	}
 
 	LOG_INF("HTTP thread terminated");
+	httpc.state = HTTPC_INIT;
 }
 
 #define HTTP_CRLF_STR "\\r\\n"
@@ -572,6 +573,11 @@ int handle_at_httpc_request(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
+		if (httpc.state > HTTPC_INIT) {
+			LOG_ERR("Previous HTTP request is not finished");
+			return -EEXIST;
+		}
+
 		memset(data_buf, 0, sizeof(data_buf));
 		/* Get method string */
 		size = HTTPC_METHOD_LEN;

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -266,6 +266,10 @@ nRF9160: Serial LTE modem
   * The response for the ``#XDFUGET`` command, using unsolicited notification to report download progress.
   * The ``#XSLMVER`` command to report the versions of both the |NCS| and the modem library.
 
+* Fixed:
+
+  * Fixed multiple http_request causing UsageFault when closing socket.
+
 nRF5340 Audio
 -------------
 


### PR DESCRIPTION
The socket of http client is only one which is not protected from multiple http_request, could result in socket being open and close at the same time by different httpc_thread instance.

Proposed fix:
Add new httpc_state HTTPC_END indicates HTTPC thread exists.
Sometime server disconnects will keep httpc_state as HTTPC_REQ_DONE.
Check if httpc_state is INIT or END before create httpc_thread.