### PR TITLE
manifest: sdk-hostap: Pull assert check for HEAP

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -102,7 +102,7 @@ manifest:
     # changes.
     - name: sdk-hostap
       path: modules/lib/hostap
-      revision: 8d3f26d7da1b49815fbd0fe8335189cfac4ded85
+      revision: pull/67/head
     - name: mcuboot
       repo-path: sdk-mcuboot
       revision: v1.9.99-ncs4-rc1


### PR DESCRIPTION
This enables the assert for minimum libc HEAP and fails boot, saves us time from hard to debug issues due to low HEAP.