### PR TITLE
doc improvement: matter: add page about configuring tx power

### DIFF
--- a/doc/nrf/app_dev/working_with_fem/index.rst
+++ b/doc/nrf/app_dev/working_with_fem/index.rst
@@ -17,6 +17,8 @@ For testing purposes, a FEM is usually integrated in either a development kit or
 
 This guide describes how to add support for 2 different front-end module (FEM) implementations to your application in |NCS|.
 
+.. _ug_radio_fem_sw_support:
+
 Software support
 ****************
 
@@ -28,6 +30,8 @@ The following test samples support FEM control:
 * :ref:`direct_test_mode`
 
 You can also use your own FEM driver when required.
+
+.. _ug_radio_fem_sw_support_mpsl:
 
 Using MPSL
 ==========
@@ -80,6 +84,8 @@ You can do that by setting the :kconfig:option:`CONFIG_MPSL_FEM_ONLY` Kconfig op
 
 Some applications can perform calls to the :ref:`nrfxlib:mpsl_fem` API even though no RF Front-End module is physically connected to the device and the :kconfig:option:`CONFIG_MPSL_FEM` Kconfig option is set to ``n``.
 In that case, ensure that the :kconfig:option:`CONFIG_MPSL_FEM_API_AVAILABLE` Kconfig option is set to ``y``.
+
+.. _ug_radio_fem_sw_support_mpsl_fem_output:
 
 Setting the FEM output power
 ----------------------------

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -309,6 +309,9 @@
 
 .. _`Matter weather station application from the v2.1.1`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/2.1.1/nrf/applications/matter_weather_station/README.html
 
+.. _`CONFIG_BT_CTLR_TX_PWR_MINUS`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/kconfig/index.html#!CONFIG_BT_CTLR_TX_PWR_MINUS
+.. _`CONFIG_BT_CTLR_TX_PWR_PLUS`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/kconfig/index.html#!CONFIG_BT_CTLR_TX_PWR_PLUS
+
 .. ### Source: www.nordicsemi.com
 
 .. _`Nordic Semiconductor website`: https://www.nordicsemi.com/
@@ -521,6 +524,8 @@
 .. _`SWD Select`: https://infocenter.nordicsemi.com/topic/ug_thingy91/UG/thingy91/hw_description/programming_debugging_interface.html
 
 .. _`access port protection mechanism`: https://infocenter.nordicsemi.com/index.jsp?topic=%2Fps_nrf52840%2Fdif.html&anchor=concept_udr_mns_1s
+
+.. _`Electrical specification for nRF7002`: https://infocenter.nordicsemi.com/index.jsp?topic=%2Fps_nrf7002%2Fchapters%2Felspec%2Fdoc%2Felectrical_specification.html
 
 .. ### Source: academy.nordicsemi.com
 

--- a/doc/nrf/protocols/matter/getting_started/index.rst
+++ b/doc/nrf/protocols/matter/getting_started/index.rst
@@ -19,6 +19,7 @@ The pages will guide you through the following getting started process:
    You will also use some of the :ref:`ug_matter_tools` for this process.
 #. :ref:`ug_matter_gs_kconfig` describes the basic Kconfig configuration if you want to start developing your own Matter application.
 #. In :ref:`ug_matter_device_advanced_kconfigs`, you will learn about more advanced Kconfig options related to Matter.
+#. :ref:`ug_matter_gs_transmission_power` provides information about the default transmission values for different protocols related to Matter and the list of Kconfig options that you can used to modify the transmission power.
 #. Once you have a grasp of the Matter configuration, :ref:`ug_matter_gs_adding_cluster` will teach you step by step how to add clusters to a Matter application created from the template sample.
 #. Finally, in :ref:`ug_matter_gs_ecosystem_compatibility_testing`, you will set up and test multiple Matter fabrics, each belonging to a different commercial ecosystem, and test their interoperability.
 
@@ -35,5 +36,6 @@ These are built from the files available in the official `Matter GitHub reposito
    kconfig
    advanced_kconfigs
    low_power_configuration
+   transmission_power
    adding_clusters
    ecosystem_compatibility_testing

--- a/doc/nrf/protocols/matter/getting_started/low_power_configuration.rst
+++ b/doc/nrf/protocols/matter/getting_started/low_power_configuration.rst
@@ -3,6 +3,10 @@
 Reducing power consumption in Matter applications
 #################################################
 
+.. contents::
+   :local:
+   :depth: 2
+
 The Matter protocol can be used in various device types that are designed to be battery supplied, where a low power consumption is of critical importance.
 
 There are many ways to reduce the power consumption in your application, including methods related to the adopted network technology, disabling specific modules, or configuring features meant for optimizing power consumption.
@@ -22,7 +26,7 @@ The Matter supports using Thread and Wi-Fi as the IPv6-based networking technolo
 Both of the technologies come with their own solutions for optimizing the protocol behavior in terms of power consumption.
 However, the general goal of the optimization for both is to reduce the time spent in the active state and put the device in the inactive (sleep) state whenever possible.
 Reducing the device activity time usually comes with a higher response time and a lower performance.
-When optimizing the power consumption, you must be aware of the trade-off between the power consumption and the device performance, and choose the optimal configuration for his use case.
+When optimizing the power consumption, you must be aware of the trade-off between the power consumption and the device performance, and choose the optimal configuration for your use case.
 
 Matter over Thread
 ==================
@@ -150,22 +154,4 @@ The radio transmitter power (radio TX power) has a significant impact on the dev
 The higher the transmitting power, the greater the wireless communication range, which leads to higher power consumption.
 Make sure to choose the optimal configuration for your specific use case.
 
-The radio transmitter power configuration must be modified separately for every wireless technology used in the Matter applications.
-
-Bluetooth LE
-============
-
-To change the radio TX power used by the Bluetooth LE protocol, set the :kconfig:option:`CONFIG_BT_CTLR_TX_PWR` Kconfig option to the desired value.
-However, you cannot set this config value directly, as it obtains the value from the selected ``CONFIG_BT_CTLR_TX_PWR_MINUS_<X>`` or ``CONFIG_BT_CTLR_TX_PWR_PLUS_<X>``, where *<X>* is replaced by the desired power value.
-For example, to set Bluetooth LE TX power to +5 dBM, set the :kconfig:option:`CONFIG_BT_CTLR_TX_PWR_PLUS_5` Kconfig option to ``y``.
-The configuration must be applied to both the application and the network core images in a consistent manner.
-
-Thread
-======
-
-To change the radio TX power used by the Thread protocol, set the :kconfig:option:`CONFIG_OPENTHREAD_DEFAULT_TX_POWER` to the desired value.
-
-Wi-Fi
-=====
-
-Changing TX power for the Wi-Fi protocol is currently not supported.
+See :ref:`ug_matter_gs_transmission_power` for more information.

--- a/doc/nrf/protocols/matter/getting_started/transmission_power.rst
+++ b/doc/nrf/protocols/matter/getting_started/transmission_power.rst
@@ -1,0 +1,197 @@
+.. _ug_matter_gs_transmission_power:
+
+Configuring transmission power
+##############################
+
+.. contents::
+   :local:
+   :depth: 2
+
+You can configure the radio transmitter power (TX power) of your device to increase or decrease the wireless communication range of your device.
+The radio transmitter power configuration must be modified separately for every wireless technology used in the Matter applications.
+
+TX power settings can have a significant impact on the device's power consumption when :ref:`ug_matter_device_low_power_configuration`.
+
+.. _ug_matter_gs_transmission_power_default:
+
+Default TX power
+****************
+
+The following table lists the default TX power values.
+
++--------------------------------------------------------------+--------------------------+------------------------------------------------------+-----------------------------------------------------------------+
+| Sample                                                       | Board name               | Output power for Thread (dBm; range from -40 to 20)  | Output power for Bluetooth® LE (dBm; range from -40 to 3 or 8)  |
++==============================================================+==========================+======================================================+=================================================================+
+| :ref:`Light Bulb (FTD) <matter_light_bulb_sample>`           | nrf52840dk_nrf52840      | 8                                                    | 0                                                               |
+|                                                              +--------------------------+------------------------------------------------------+-----------------------------------------------------------------+
+|                                                              | nrf5340dk_nrf5340        | 3                                                    | 0                                                               |
+|                                                              +--------------------------+------------------------------------------------------+-----------------------------------------------------------------+
+|                                                              | nrf7002dk_nrf5340        | 3                                                    | 0                                                               |
+|                                                              +--------------------------+------------------------------------------------------+-----------------------------------------------------------------+
+|                                                              | nrf21540dk_nrf52840      | 20                                                   | 0                                                               |
++--------------------------------------------------------------+--------------------------+------------------------------------------------------+-----------------------------------------------------------------+
+| :ref:`Light Switch (SED) <matter_light_switch_sample>`       | nrf52840dk_nrf52840      | 0                                                    | 0                                                               |
+|                                                              +--------------------------+------------------------------------------------------+-----------------------------------------------------------------+
+|                                                              | nrf5340dk_nrf5340        | 0                                                    | 0                                                               |
+|                                                              +--------------------------+------------------------------------------------------+-----------------------------------------------------------------+
+|                                                              | nrf7002dk_nrf5340        | 0                                                    | 0                                                               |
+|                                                              +--------------------------+------------------------------------------------------+-----------------------------------------------------------------+
+|                                                              | nrf21540dk_nrf52840      | 0                                                    | 0                                                               |
++--------------------------------------------------------------+--------------------------+------------------------------------------------------+-----------------------------------------------------------------+
+| :ref:`Lock (SED) <matter_lock_sample>`                       | nrf52840dk_nrf52840      | 0                                                    | 0                                                               |
+|                                                              +--------------------------+------------------------------------------------------+-----------------------------------------------------------------+
+|                                                              | nrf5340dk_nrf5340        | 0                                                    | 0                                                               |
+|                                                              +--------------------------+------------------------------------------------------+-----------------------------------------------------------------+
+|                                                              | nrf7002dk_nrf5340        | 0                                                    | 0                                                               |
+|                                                              +--------------------------+------------------------------------------------------+-----------------------------------------------------------------+
+|                                                              | nrf21540dk_nrf52840      | 0                                                    | 0                                                               |
++--------------------------------------------------------------+--------------------------+------------------------------------------------------+-----------------------------------------------------------------+
+| :ref:`Template (MTD) <matter_template_sample>`               | nrf52840dk_nrf52840      | 8                                                    | 0                                                               |
+|                                                              +--------------------------+------------------------------------------------------+-----------------------------------------------------------------+
+|                                                              | nrf5340dk_nrf5340        | 3                                                    | 0                                                               |
+|                                                              +--------------------------+------------------------------------------------------+-----------------------------------------------------------------+
+|                                                              | nrf7002dk_nrf5340        | 3                                                    | 0                                                               |
+|                                                              +--------------------------+------------------------------------------------------+-----------------------------------------------------------------+
+|                                                              | nrf21540dk_nrf52840      | 20                                                   | 0                                                               |
++--------------------------------------------------------------+--------------------------+------------------------------------------------------+-----------------------------------------------------------------+
+| :ref:`Widow Covering (SSED) <matter_window_covering_sample>` | nrf52840dk_nrf52840      | 0                                                    | 0                                                               |
+|                                                              +--------------------------+------------------------------------------------------+-----------------------------------------------------------------+
+|                                                              | nrf5340dk_nrf5340        | 0                                                    | 0                                                               |
+|                                                              +--------------------------+------------------------------------------------------+-----------------------------------------------------------------+
+|                                                              | nrf7002dk_nrf5340        | 0                                                    | 0                                                               |
+|                                                              +--------------------------+------------------------------------------------------+-----------------------------------------------------------------+
+|                                                              | nrf21540dk_nrf52840      | 0                                                    | 0                                                               |
++--------------------------------------------------------------+--------------------------+------------------------------------------------------+-----------------------------------------------------------------+
+
+.. _ug_matter_gs_transmission_power_thread:
+
+Changing TX power for Thread
+****************************
+
+To change the radio TX power used by the Thread protocol, set the :kconfig:option:`CONFIG_OPENTHREAD_DEFAULT_TX_POWER` Kconfig option to the desired dBm value in a range from ``-40`` to ``20`` dBm.
+
+The following table lists the maximum output power values in dBm for each board.
+The maximum value of 20 dBm is only recommended for devices that are using :ref:`radio Front-End Modules <ug_radio_fem>`.
+
++--------------------------+-----------------------------------------------------------------------------+
+| Board name               | Min - max TX power (dBm)                                                    |
++==========================+=============================================================================+
+| nrf52840dk_nrf52840      | -40 to +8                                                                   |
++--------------------------+-----------------------------------------------------------------------------+
+| nrf5340dk_nrf5340        | -40 to +3                                                                   |
++--------------------------+-----------------------------------------------------------------------------+
+| nrf7002dk_nrf5340        | -40 to +3                                                                   |
++--------------------------+-----------------------------------------------------------------------------+
+| nrf21540dk_nrf52840      | -40 to +20 (:ref:`more information <ug_matter_gs_transmission_power_fem>`)  |
++--------------------------+-----------------------------------------------------------------------------+
+
+You can provide the desired value also as a CMake argument when building the sample.
+
+.. tabs::
+
+   .. group-tab:: nRF Connect for VS Code
+
+      To build a Matter sample with a custom Thread TX power in the nRF Connect for VS Code IDE, add the :kconfig:option:`CONFIG_OPENTHREAD_DEFAULT_TX_POWER` Kconfig option variable and the dBm value to the build configuration's :guilabel:`Extra CMake arguments` and rebuild the build configuration.
+      For example, if you want to build for the ``nrf52840dk_nrf52840`` build target with the default Thread TX power equal to 2 dBm, add ``-DCONFIG_OPENTHREAD_DEFAULT_TX_POWER=2``.
+
+      See `nRF Connect for VS Code extension pack <How to work with build configurations_>`_ documentation for more information.
+
+   .. group-tab:: Command line
+
+      To build a Matter sample with a custom Thread TX power from the command line, add the :kconfig:option:`CONFIG_OPENTHREAD_DEFAULT_TX_POWER` Kconfig option variable and the dBm value to the build command.
+      For example, if you want to build for the ``nrf52840dk_nrf52840`` build target with the default Thread TX power equal to 2 dBm, run the following command:
+
+      .. code-block:: console
+
+         west build -b nrf52840dk_nrf52840 -- -DCONFIG_OPENTHREAD_DEFAULT_TX_POWER=2
+
+..
+
+.. _ug_matter_gs_transmission_power_bluetooth:
+
+Changing TX power for Bluetooth LE
+**********************************
+
+To change the radio TX power used by Zephyr's Bluetooth LE controller, set the :kconfig:option:`CONFIG_BT_CTLR_TX_PWR` Kconfig option to the desired value.
+However, you cannot set this config value directly, as it obtains the value from the selected ``CONFIG_BT_CTLR_TX_PWR_MINUS_<X>`` or ``CONFIG_BT_CTLR_TX_PWR_PLUS_<X>``, where *<X>* is replaced by the desired power value, in an irregular dBm range from ``-40`` to ``3`` or ``8`` dBm (depending on the SoC).
+For example, to set Bluetooth LE TX power to +5 dBM, set the :kconfig:option:`CONFIG_BT_CTLR_TX_PWR_PLUS_5` Kconfig option to ``y``.
+
+Check the :ref:`Kconfig Reference <kconfig-search>` for the full list of possible values for `CONFIG_BT_CTLR_TX_PWR_MINUS`_ and `CONFIG_BT_CTLR_TX_PWR_PLUS`_, as well as their dependencies.
+The only exception is the value of 0 dBm, which is set with the :kconfig:option:`CONFIG_BT_CTLR_TX_PWR_0` Kconfig option.
+
+The following table lists the minimum and maximum output power values in dBm for each board.
+
++--------------------------+-----------------------------------------------------------------------------------------------------------------+
+| Board name               | Min - max TX power (dBm)                                                                                        |
++==========================+=================================================================================================================+
+| nrf52840dk_nrf52840      | -40 to +8 (:kconfig:option:`CONFIG_BT_CTLR_TX_PWR_MINUS_40` to :kconfig:option:`CONFIG_BT_CTLR_TX_PWR_PLUS_8`)  |
++--------------------------+-----------------------------------------------------------------------------------------------------------------+
+| nrf5340dk_nrf5340        | -40 to +3 (:kconfig:option:`CONFIG_BT_CTLR_TX_PWR_MINUS_40` to :kconfig:option:`CONFIG_BT_CTLR_TX_PWR_PLUS_3`)  |
++--------------------------+-----------------------------------------------------------------------------------------------------------------+
+| nrf7002dk_nrf5340        | -40 to +3 (:kconfig:option:`CONFIG_BT_CTLR_TX_PWR_MINUS_40` to :kconfig:option:`CONFIG_BT_CTLR_TX_PWR_PLUS_3`)  |
++--------------------------+-----------------------------------------------------------------------------------------------------------------+
+| nrf21540dk_nrf52840      | :ref:`Handled automatically by the FEM driver <ug_matter_gs_transmission_power_fem>`                            |
++--------------------------+-----------------------------------------------------------------------------------------------------------------+
+
+For multicore boards, the configuration must be applied to the network core image.
+You can do this by either editing the :file:`prj.conf` file or building the sample with an additional argument, as described in the following tabs.
+
+.. tabs::
+
+   .. group-tab:: nRF Connect for VS Code
+
+      To build a Matter sample with a custom Bluetooth LE TX power in the nRF Connect for VS Code IDE, add the desired :kconfig:option:`CONFIG_BT_CTLR_TX_PWR` Kconfig option for the network core to the build configuration's :guilabel:`Extra CMake arguments` and rebuild the build configuration.
+      To build for the network core, make sure to add the ``childImageName_`` parameter between ``-D`` and the name of the Kconfig option.
+      The parameter name varies depending on the devices you are building for.
+      For example:
+
+      * If you want to build for Thread devices for the ``nrf5340dk_nrf5340_cpuapp`` build target with a Bluetooth LE TX power equal to 3 dBm, add ``-Dmultiprotocol_rpmsg_CONFIG_BT_CTLR_TX_PWR_PLUS_3=y`` as the CMake argument.
+      * If you want to build for Wi-Fi® devices for the ``nrf7002dk_nrf5340_cpuapp`` build target with a Bluetooth LE TX power equal to 3 dBm, add ``-Dhci_rpmsg_CONFIG_BT_CTLR_TX_PWR_PLUS_3=y`` as the CMake argument.
+
+      See `nRF Connect for VS Code extension pack <How to work with build configurations_>`_ documentation for more information.
+
+   .. group-tab:: Command line
+
+      To build a Matter sample with a custom Bluetooth LE TX power from the command line, add the desired :kconfig:option:`CONFIG_BT_CTLR_TX_PWR` Kconfig option for the network core to the build command.
+      To build for the network core, make sure to add the ``childImageName_`` parameter between ``-D`` and the name of the Kconfig option.
+      The parameter name varies depending on the devices you are building for.
+      For example:
+
+      * If you want to build for Thread devices for the ``nrf5340dk_nrf5340_cpuapp`` build target with a Bluetooth LE TX power equal to 3 dBm, run the following command:
+
+        .. code-block:: console
+
+           west build -b nrf5340dk_nrf5340_cpuapp -- -Dmultiprotocol_rpmsg_CONFIG_BT_CTLR_TX_PWR_PLUS_3=y
+
+      * If you want to build for Wi-Fi® devices for the ``nrf7002dk_nrf5340_cpuapp`` build target with a Bluetooth LE TX power equal to 3 dBm, run the following command:
+
+        .. code-block:: console
+
+           west build -b nrf7002dk_nrf5340_cpuapp -- -Dhci_rpmsg_CONFIG_BT_CTLR_TX_PWR_PLUS_3=y
+
+..
+
+.. _ug_matter_gs_transmission_power_wifi:
+
+Changing TX power for Wi-Fi
+***************************
+
+Changing TX power for the Wi-Fi protocol is currently not supported.
+
+The maximum TX power for Wi-Fi depends on the frequency band and the modulation used.
+See `Electrical specification for nRF7002`_ for reference values.
+
+.. _ug_matter_gs_transmission_power_fem:
+
+Changing TX power for FEM
+*************************
+
+The Matter application can support optional :ref:`radio Front-End Modules <ug_radio_fem>`.
+When you work with Matter over Thread, you can control the TX power of the device by configuring the FEM's TX gain.
+
+By default, the TX FEM gain is handled automatically by the FEM driver.
+After setting the desired TX output power, for example using the :kconfig:option:`CONFIG_OPENTHREAD_DEFAULT_TX_POWER` Kconfig option, the radio driver configures the FEM gain to reach the desired value.
+However, you can disable this feature and set the FEM gain TX power value manually.
+For information about how to do this, read the :ref:`ug_radio_fem` page, in particular :ref:`ug_radio_fem_sw_support_mpsl_fem_output`.
+
+The RX FEM gain is set to 13 dB by default, so the signal received at the antenna port will gain 13 dB and it will be provided to the SoC.

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -123,6 +123,7 @@ Matter
   * Documentation about :ref:`ug_matter_gs_ecosystem_compatibility_testing`.
   * Support for ZAP tool under Windows.
   * Documentation about :ref:`ug_matter_device_low_power_configuration`.
+  * Documentation about :ref:`ug_matter_gs_transmission_power`.
 
 * Updated:
 


### PR DESCRIPTION
Added a new page to Matter docs about TX power configuration. Includes sections for Wi-Fi, Thread, and BLE.
KRKNWK-16157.