### PR TITLE
quarantine_windows: add mqqt native_posix sample

### DIFF
--- a/scripts/quarantine_windows.yaml
+++ b/scripts/quarantine_windows.yaml
@@ -15,6 +15,7 @@
     - sample.app_event_manager_shell.native_posix
     - sample.caf_sensor_manager.correctness_test
     - sample.edge_impulse.wrapper
+    - sample.net.mqtt.native_posix.tls
   platforms:
     - native_posix
     - qemu_cortex_m3


### PR DESCRIPTION
New MQTT native_posix sample shall not be built on Windows OS.