### PR TITLE
mcuboot: Support non-volatile counters

### DIFF
--- a/doc/nrf/app_dev/bootloaders_and_dfu/fw_update.rst
+++ b/doc/nrf/app_dev/bootloaders_and_dfu/fw_update.rst
@@ -282,13 +282,20 @@ See :ref:`ug_bootloader_adding_presigned_variants` for details.
 Using MCUboot
 =============
 
-Currently, the |NCS| supports only *semantic versioning* for all the applications verified by MCUboot.
+MCUboot supports two different implementations of downgrade protection:
 
-.. note::
-   Within the |NCS| framework, specifying this semantic version for an application serves no purpose and does not prevent downgrades from normal firmware updates.
+* Software-based prevention, where the current version can be encoded into the currently active image.
+* Hardware-based prevention, where the current version can be encoded into a non-volatile storage partition outside of any image.
 
-   To prevent downgrades from firmware upgrades in the field, see :ref:`ug_fw_update_image_versions_mcuboot_downgrade`.
-   See also the Kconfig documentation for the ``CONFIG_MCUBOOT_IMAGE_VERSION`` option for more details about its use within the |NCS|.
+.. _ug_fw_update_image_versions_mcuboot_downgrade:
+
+Software-based downgrade prevention
+-----------------------------------
+
+The |NCS| supports MCUboot's software-based downgrade prevention for application images, using semantic versioning.
+This feature offers protection against any outdated firmware that is uploaded to a device.
+
+You can enable this feature by setting the configuration options ``CONFIG_MCUBOOT_DOWNGRADE_PREVENTION`` and ``CONFIG_BOOT_UPGRADE_ONLY`` for the MCUboot image.
 
 To assign a semantic version number to your application, pass the version string into the ``CONFIG_MCUBOOT_IMAGE_VERSION`` option for the application:
 
@@ -297,16 +304,6 @@ To assign a semantic version number to your application, pass the version string
    CONFIG_MCUBOOT_IMAGE_VERSION="0.1.2+3"
 
 See the `Semantic versioning`_ webpage or :doc:`mcuboot:imgtool` for details on version syntax.
-
-.. _ug_fw_update_image_versions_mcuboot_downgrade:
-
-Preventing downgrades using MCUboot
------------------------------------
-
-The |NCS| supports MCUboot's software-based downgrade prevention for application images, using semantic versioning.
-This feature offers protection against any outdated firmware that is uploaded to a device.
-
-You can enable this feature by setting the ``CONFIG_MCUBOOT_DOWNGRADE_PREVENTION`` and ``CONFIG_BOOT_UPGRADE_ONLY`` options for the MCUboot image.
 
 .. warning::
 
@@ -333,6 +330,13 @@ If this image has, in order of precedence, a *major*, *minor*, or *revision* val
 
    The optional label or build number specified after the ``+`` character is ignored when evaluating the version.
    An existing application image with version ``0.1.2+3`` can be overwritten by an uploaded image with ``0.1.2+2``, but not by one with ``0.1.1+2``.
+
+Hardware-based downgrade prevention
+-----------------------------------
+
+Hardware-based downgrade prevention is implemented with a counter value stored in the *provision* partition of the non-volatile storage.
+
+See the :ref:`bootloader_monotonic_counter` section for how to enable and configure this feature.
 
 .. _ug_fw_mcuboot_output:
 

--- a/doc/nrf/app_dev/bootloaders_and_dfu/index.rst
+++ b/doc/nrf/app_dev/bootloaders_and_dfu/index.rst
@@ -57,7 +57,7 @@ You can find an overview of currently supported bootloaders in the table below:
      - No
      - Yes
      - Yes
-     - :ref:`Semantic (SW) <ug_fw_update_image_versions_mcuboot>`
+     - :ref:`Monotonic (HW) <bootloader_monotonic_counter>`, :ref:`Semantic (SW) <ug_fw_update_image_versions_mcuboot>`
      - Image swap - single primary
        Dual-slot direct-xip
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -312,7 +312,7 @@ The code for integrating MCUboot into |NCS| is located in the :file:`ncs/nrf/mod
 
 The following list summarizes both the main changes inherited from upstream MCUboot and the main changes applied to the |NCS| specific additions:
 
-|no_changes_yet_note|
+* Added support for the downgrade prevention feature using hardware security counters (:kconfig:option:`MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION`).
 
 Zephyr
 ======

--- a/include/bl_storage.h
+++ b/include/bl_storage.h
@@ -36,6 +36,12 @@ extern "C" {
 /* Counter used by NSIB to check the firmware version */
 #define BL_MONOTONIC_COUNTERS_DESC_NSIB 0x1
 
+/* Counter used by MCUBOOT to check the firmware version. Suffixed
+ * with ID0 as we might support checking the version of multiple
+ * images in the future.
+ */
+#define BL_MONOTONIC_COUNTERS_DESC_MCUBOOT_ID0 0x2
+
 /** Storage for the PRoT Security Lifecycle state, that consists of 4 states:
  *  - Device assembly and test
  *  - PRoT Provisioning

--- a/modules/mcuboot/CMakeLists.txt
+++ b/modules/mcuboot/CMakeLists.txt
@@ -231,6 +231,16 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
       )
   endif()
 
+  # Enable the same option in the MCUBoot child image
+  if (CONFIG_MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION)
+    add_overlay_config(
+      mcuboot
+      ${ZEPHYR_NRF_MODULE_DIR}/modules/mcuboot/hw_counters.conf
+    )
+
+    set(imgtool_security_counter --security-counter ${CONFIG_MCUBOOT_HW_DOWNGRADE_PREVENTION_COUNTER_VALUE})
+  endif()
+
   add_child_image(
     NAME mcuboot
     SOURCE_DIR ${ZEPHYR_MCUBOOT_MODULE_DIR}/boot/zephyr
@@ -332,6 +342,7 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
       --align       ${CONFIG_MCUBOOT_FLASH_WRITE_BLOCK_SIZE}
       --version     ${CONFIG_MCUBOOT_IMAGE_VERSION}
       --pad-header
+      ${imgtool_security_counter}
       ${imgtool_extra}
       )
 

--- a/modules/mcuboot/Kconfig
+++ b/modules/mcuboot/Kconfig
@@ -49,6 +49,40 @@ config MCUBOOT_IMAGE_VERSION
 	  with version 0.1.2+3 can be overwritten by an uploaded image with
 	  0.1.2+2, but not by one with 0.1.1+2.
 
+menuconfig MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION
+	bool "Downgrade prevention using hardware security counters"
+	depends on SOC_NRF5340_CPUAPP || SOC_NRF9160
+	help
+	  This option can be enabled by the application and will ensure
+	  that the MCUBOOT_HW_DOWNGRADE_PREVENTION Kconfig option is
+	  enabled in the MCUboot image.
+
+if MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION
+
+config MCUBOOT_HW_DOWNGRADE_PREVENTION_COUNTER_SLOTS
+	int "Number of available hardware counter slots"
+	default 240
+	range 2 300
+	help
+	  When MCUBOOT_HW_DOWNGRADE_PREVENTION is enabled, MCUboot will use
+	  one hardware counter for each updatable image (UPDATEABLE_IMAGE_NUMBER).
+	  This configuration specifies how many counter slots will be allocated
+	  for each hardware counter. The hardware counters are stored in OTP storage.
+	  The rationale for the default number (240): Assume one update a month for
+	  10 years, then double that value just in case. This default fits
+	  comfortably within the OTP region of UICR.
+
+config MCUBOOT_HW_DOWNGRADE_PREVENTION_COUNTER_VALUE
+	int "Security counter value"
+	default 1
+	range 1 65535
+	help
+	  The security counter value for this image.
+	  This is the value that will be passed to the --security-counter
+	  parameter of imgtool.py
+
+endif # MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION
+
 # HACK: NCS temphack to keep our imgtool integration working now that
 # there is no CONFIG_DT_* CMake namespace anymore. Use Zephyr
 # kconfigfunctions to thread the flash write block size through

--- a/modules/mcuboot/hw_counters.conf
+++ b/modules/mcuboot/hw_counters.conf
@@ -1,0 +1,11 @@
+# This Kconfig fragment is applied to the MCUBoot configuration when
+# we want to enable the hardware security counters for downgrade
+# prevention.
+CONFIG_MCUBOOT_HW_DOWNGRADE_PREVENTION=y
+
+# These NSIB libraries are enabled here because they are used by the above
+# option. The above option is defined by MCUBoot's Kconfig sources and
+# there is currently no way to set these options aside from enabling
+# them through this KConfig fragment simultaneously as we do here.
+CONFIG_SECURE_BOOT_STORAGE=y
+CONFIG_SECURE_BOOT_CRYPTO=y

--- a/samples/bootloader/README.rst
+++ b/samples/bootloader/README.rst
@@ -207,14 +207,16 @@ A non-volatile *monotonic counter* can be stored in the *Provision* area and is 
 
 Counter updates are written to slots in the *Provision* area, with each new counter update occupying a new slot.
 For this reason, the number of counter updates, and therefore firmware version updates, is limited.
-Enable the counter with the :kconfig:option:`CONFIG_SB_MONOTONIC_COUNTER` option.
 
-The supported number of updates depends on the size of the *Provision* area and how much of that area is taken up by other features, like public key hashes.
-See option :kconfig:option:`CONFIG_SB_NUM_VER_COUNTER_SLOTS` for more details.
+Using a counter is optional and can be configured for the application using configuration options.
+You can also configure the supported number of updates, but the number is limited by the size of the *Provision* area and how much of that area is taken up by other features, like public key hashes.
+In addition, you can configure what firmware version of the image you want to boot.
 
-To set the firmware version for an image, build it using the :kconfig:option:`CONFIG_FW_INFO_FIRMWARE_VERSION` option set appropriately.
+For NSIB, the configuration options are :kconfig:option:`CONFIG_SB_MONOTONIC_COUNTER`, :kconfig:option:`CONFIG_SB_NUM_VER_COUNTER_SLOTS`, and :kconfig:option:`CONFIG_FW_INFO_FIRMWARE_VERSION`.
 
-To set options for child images, such as MCUBoot, see the :ref:`ug_multi_image_variables` section.
+For MCUboot, the configuration options are :kconfig:option:`CONFIG_MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION`, :kconfig:option:`CONFIG_MCUBOOT_HW_DOWNGRADE_PREVENTION_COUNTER_SLOTS`, and :kconfig:option:`MCUBOOT_HW_DOWNGRADE_PREVENTION_COUNTER_VALUE`.
+
+To set options for child images, such as NSIB and MCUboot, see the :ref:`ug_multi_image_variables` section.
 
 .. bootloader_monotonic_counter_end
 

--- a/scripts/bootloader/provision.py
+++ b/scripts/bootloader/provision.py
@@ -18,6 +18,11 @@ LCS_STATE_SIZE = 0x8
 IMPLEMENTATION_ID_SIZE = 0x20
 NUM_BYTES_PROVISIONED_ELSEWHERE = LCS_STATE_SIZE + IMPLEMENTATION_ID_SIZE
 
+# These variable names and values are copied from bl_storage.h and
+# should be kept in sync
+BL_MONOTONIC_COUNTERS_DESC_NSIB = 1
+BL_MONOTONIC_COUNTERS_DESC_MCUBOOT_ID0 = 2
+
 def generate_provision_intel_hex_file(provision_data, provision_address, output, max_size):
     assert len(provision_data) <= max_size, """Provisioning data doesn't fit.
 Reduce the number of public keys or counter slots and try again."""
@@ -26,26 +31,70 @@ Reduce the number of public keys or counter slots and try again."""
     ih.frombytes(provision_data, offset=provision_address)
     ih.write_hex_file(output)
 
-def add_hw_counters(provision_data, num_counter_slots_version):
-    num_counters = min(num_counter_slots_version, 1)
+
+def add_hw_counters(provision_data, num_counter_slots_version, mcuboot_counters_slots):
+    num_counters = min(mcuboot_counters_slots, 1) + min(num_counter_slots_version, 1)
 
     if num_counters == 0:
         return provision_data
 
     assert num_counter_slots_version % 2 == 0, "--num-counters-slots-version must be an even number"
+    assert mcuboot_counters_slots    % 2 == 0, "--mcuboot-counters-slots     must be an even number"
 
     provision_data += struct.pack('H', 1) # Type "counter collection"
-    provision_data += struct.pack('H', num_counters)
+    provision_data += struct.pack('H', num_counters) # Could be 0, 1, or 2
 
     if num_counter_slots_version > 0:
-        provision_data += struct.pack('H', 1) # counter description
+        provision_data += struct.pack('H', BL_MONOTONIC_COUNTERS_DESC_NSIB)
         provision_data += struct.pack('H', num_counter_slots_version)
         provision_data += bytes(2 * num_counter_slots_version * [0xFF])
 
+    if mcuboot_counters_slots > 0:
+        provision_data += struct.pack('H', BL_MONOTONIC_COUNTERS_DESC_MCUBOOT_ID0)
+        provision_data += struct.pack('H', mcuboot_counters_slots)
+        provision_data += bytes(2 * mcuboot_counters_slots * [0xFF])
+
     return provision_data
 
+
+def generate_mcuboot_only_provision_hex_file(provision_address, output, max_size, mcuboot_counters_slots):
+    # This function generates a .hex file with the provisioned data
+    # for the uncommon use-case where MCUBoot is present, but NSIB is
+    # not.
+    #
+    # To simplify the FW libraries we don't make them aware of the
+    # fact that NSIB is not present, so even though MCUBoot doesn't
+    # use the NSIB specific metadata in
+    # num_bytes_in_bl_storage_data_struct, we still provision dummy
+    # data to make sure the counters are offset correctly.
+    #
+    # NB: An exception to the rule is num_bytes_in_num_public_keys,
+    # which we set to 0 and which will be used by MCUBoot at runtime
+    # to calculate where the counter are located.
+
+    num_bytes_in_lcs = LCS_STATE_SIZE
+    num_bytes_in_implementation_id = IMPLEMENTATION_ID_SIZE
+    num_bytes_in_s0_address = 4
+    num_bytes_in_s1_address = 4
+    num_bytes_in_num_public_keys = 4
+
+    num_bytes_in_bl_storage_data_struct = \
+        num_bytes_in_lcs + \
+        num_bytes_in_implementation_id + \
+        num_bytes_in_s0_address + \
+        num_bytes_in_s1_address + \
+        num_bytes_in_num_public_keys
+
+    provision_data = bytes(num_bytes_in_bl_storage_data_struct * [0])
+
+    provision_data = add_hw_counters(provision_data, 0, mcuboot_counters_slots)
+
+    generate_provision_intel_hex_file(provision_data, provision_address, output, max_size)
+
+
 def generate_provision_hex_file(s0_address, s1_address, hashes, provision_address, output, max_size,
-                                num_counter_slots_version):
+                                num_counter_slots_version, mcuboot_counters_slots):
+
     provision_data = struct.pack('III', s0_address, s1_address,
                                  len(hashes))
 
@@ -53,7 +102,7 @@ def generate_provision_hex_file(s0_address, s1_address, hashes, provision_addres
         provision_data += struct.pack('I', 0xFFFFFFFF) # Invalidation token
         provision_data += mhash
 
-    provision_data = add_hw_counters(provision_data, num_counter_slots_version)
+    provision_data = add_hw_counters(provision_data, num_counter_slots_version, mcuboot_counters_slots)
 
     generate_provision_intel_hex_file(provision_data, provision_address, output, max_size)
 
@@ -77,6 +126,10 @@ def parse_args():
                         help='Number of monotonic counter slots for version number.')
     parser.add_argument('--no-verify-hashes', required=False, action="store_true",
                         help="Don't check hashes for applicability. Use this option only for testing.")
+    parser.add_argument('--mcuboot-only', required=False, action="store_true",
+                        help="The MCUBOOT bootloader is used without the NSIB bootloader. Only the provision address, the MCUBOOT counters and the MCUBOOT counters slots arguments will be used.")
+    parser.add_argument('--mcuboot-counters-slots', required=False, type=int, default=0,
+                        help='Number of monotonic counter slots for every MCUBOOT counter.')
     return parser.parse_args()
 
 
@@ -100,8 +153,22 @@ def get_hashes(public_key_files, verify_hashes):
 def main():
     args = parse_args()
 
+    if not args.mcuboot_only and args.s0_addr is None:
+        raise RuntimeError("Either --mcuboot-only or --s0-addr must be specified")
+
+    if args.mcuboot_only:
+        generate_mcuboot_only_provision_hex_file(
+            provision_address=args.provision_addr,
+            output=args.output,
+            max_size=args.max_size,
+            mcuboot_counters_slots=args.mcuboot_counters_slots
+        )
+        return
+
+
     s0_address = args.s0_addr
     s1_address = args.s1_addr if args.s1_addr is not None else s0_address
+
     # The LCS and implementation ID is stored in the OTP before the
     # rest of the provisioning data so add it to the given base
     # address
@@ -116,13 +183,16 @@ def main():
             not args.no_verify_hashes
         )
 
-    generate_provision_hex_file(s0_address=s0_address,
-                                s1_address=s1_address,
-                                hashes=hashes,
-                                provision_address=provision_address,
-                                output=args.output,
-                                max_size=max_size,
-                                num_counter_slots_version=args.num_counter_slots_version)
+    generate_provision_hex_file(
+        s0_address=s0_address,
+        s1_address=s1_address,
+        hashes=hashes,
+        provision_address=provision_address,
+        output=args.output,
+        max_size=max_size,
+        num_counter_slots_version=args.num_counter_slots_version,
+        mcuboot_counters_slots=args.mcuboot_counters_slots
+    )
 
 
 if __name__ == '__main__':

--- a/scripts/bootloader/provision.py
+++ b/scripts/bootloader/provision.py
@@ -51,7 +51,7 @@ def parse_args():
         description='Generate provisioning hex file.',
         formatter_class=argparse.RawDescriptionHelpFormatter,
         allow_abbrev=False)
-    parser.add_argument('--s0-addr', type=lambda x: int(x, 0), required=True, help='Address of image slot s0')
+    parser.add_argument('--s0-addr', type=lambda x: int(x, 0), required=False, help='Address of image slot s0')
     parser.add_argument('--s1-addr', type=lambda x: int(x, 0), required=False, help='Address of image slot s1')
     parser.add_argument('--provision-addr', type=lambda x: int(x, 0),
                         required=True, help='Address at which to place the provisioned data')

--- a/scripts/bootloader/provision.py
+++ b/scripts/bootloader/provision.py
@@ -37,8 +37,9 @@ def generate_provision_hex_file(s0_address, s1_address, hashes, provision_addres
     if num_counters == 1:
         provision_data += struct.pack('H', 1) # counter description
         provision_data += struct.pack('H', num_counter_slots_version)
+        provision_data += bytes(2 * mcuboot_counters_slots * [0xFF])
 
-    assert (len(provision_data) + (2 * num_counter_slots_version)) <= max_size, """Provisioning data doesn't fit.
+    assert len(provision_data) <= max_size, """Provisioning data doesn't fit.
 Reduce the number of public keys or counter slots and try again."""
 
     ih = IntelHex()

--- a/scripts/bootloader/provision.py
+++ b/scripts/bootloader/provision.py
@@ -13,7 +13,7 @@ from ecdsa import VerifyingKey
 from hashlib import sha256
 import os
 
-# Size of LCS storage in OTP in bytes
+# Size of LCS storage and implementation ID in OTP in bytes
 LCS_STATE_SIZE = 0x8
 IMPLEMENTATION_ID_SIZE = 0x20
 NUM_BYTES_PROVISIONED_ELSEWHERE = LCS_STATE_SIZE + IMPLEMENTATION_ID_SIZE

--- a/subsys/CMakeLists.txt
+++ b/subsys/CMakeLists.txt
@@ -13,6 +13,10 @@ add_subdirectory_ifdef(CONFIG_SECURE_BOOT_CRYPTO bootloader/bl_crypto)
 add_subdirectory_ifdef(CONFIG_SECURE_BOOT_VALIDATION bootloader/bl_validation)
 add_subdirectory_ifdef(CONFIG_SECURE_BOOT_STORAGE bootloader/bl_storage)
 
+if(CONFIG_BOOTLOADER_PROVISION_HEX)
+  include(bootloader/cmake/provision_hex.cmake)
+endif()
+
 add_subdirectory(net)
 add_subdirectory_ifdef(CONFIG_ESB		esb)
 add_subdirectory_ifdef(CONFIG_APP_EVENT_MANAGER	app_event_manager)

--- a/subsys/bootloader/Kconfig
+++ b/subsys/bootloader/Kconfig
@@ -31,6 +31,14 @@ config SECURE_BOOT
 	  Set this option to enable the first stage bootloader which
 	  verifies the signature of the app.
 
+config BOOTLOADER_PROVISION_HEX
+	bool
+	default y if SECURE_BOOT
+	default y if MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION
+	help
+	  Generate provision.hex if NSIB is enabled or if MCUboot hardware
+	  counters are enabled.
+
 if SECURE_BOOT
 
 module=B0
@@ -139,6 +147,7 @@ config SB_MONOTONIC_COUNTER
 
 config SB_NUM_VER_COUNTER_SLOTS
 	int "Number of monotonic counter slots used for the firmware version"
+	default 20 if BOOTLOADER_MCUBOOT
 	default 240
 	range 2 300 if SOC_NRF5340_CPUAPP || SOC_NRF9160
 	range 2 1800 if SOC_SERIES_NRF52X
@@ -151,7 +160,10 @@ config SB_NUM_VER_COUNTER_SLOTS
 	  number to ensure that the total size of header and slots is aligned on a 32-bit word.
 	  Rationale for the default number (240): Assume one update a month for
 	  10 years, then double that value just in case. This default fits
-	  comfortably within the "OTP" region of UICR.
+	  comfortably within the OTP region of UICR.
+	  When a second stage bootloader is enabled, such as MCUboot, this counter is used
+	  for the updates of the second stage bootloader and not of the application image. Thus
+	  the default when MCUboot is enabled is 20, to allow two updates a year for 10 years.
 	  Regarding ranges: The actual maximum depends on the number of
 	  provisioned public keys, since they share the space. The same is true if
 	  other data is stored in the "OTP" region (on for example nRF91 and nRF53).

--- a/subsys/bootloader/bl_storage/CMakeLists.txt
+++ b/subsys/bootloader/bl_storage/CMakeLists.txt
@@ -6,3 +6,8 @@
 
 zephyr_library()
 zephyr_library_sources(bl_storage.c)
+
+if(CONFIG_MCUBOOT_HW_DOWNGRADE_PREVENTION)
+  # NB: This option can only be enabled for the MCUBoot image
+  zephyr_library_sources(nrf_nv_counters.c)
+endif()

--- a/subsys/bootloader/bl_storage/bl_storage.c
+++ b/subsys/bootloader/bl_storage/bl_storage.c
@@ -20,6 +20,11 @@ BUILD_ASSERT(CONFIG_SB_NUM_VER_COUNTER_SLOTS % 2 == 0,
 			 "CONFIG_SB_NUM_VER_COUNTER_SLOTS must be an even number");
 #endif
 
+#ifdef CONFIG_MCUBOOT_HW_DOWNGRADE_PREVENTION_COUNTER_SLOTS
+BUILD_ASSERT(CONFIG_MCUBOOT_HW_DOWNGRADE_PREVENTION_COUNTER_SLOTS % 2 == 0,
+			 "CONFIG_MCUBOOT_HW_DOWNGRADE_PREVENTION_COUNTER_SLOTS was not an even number");
+#endif
+
 /** This library implements monotonic counters where each time the counter
  *  is increased, a new slot is written.
  *  This way, the counter can be updated without erase. This is, among other things,

--- a/subsys/bootloader/bl_storage/nrf_nv_counters.c
+++ b/subsys/bootloader/bl_storage/nrf_nv_counters.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/** @file
+ * @brief This source file is an adapter layer from MCUBoot's boot_nv_security_counter
+ *        API onto the NCS/NSIB library bl_storage.
+ */
+
+#include <stdint.h>
+#include <bl_storage.h>
+#include "bootutil/fault_injection_hardening.h"
+
+fih_int boot_nv_security_counter_init(void)
+{
+	return FIH_SUCCESS;
+}
+
+fih_int boot_nv_security_counter_get(uint32_t image_id, fih_int *security_cnt)
+{
+	int err;
+	uint16_t cur_sec_cnt;
+
+	if (security_cnt == NULL) {
+		return FIH_FAILURE;
+	}
+
+	/* We support only one counter in MCUBOOT */
+	if (image_id > 0) {
+		return FIH_FAILURE;
+	}
+
+	err = get_monotonic_counter(BL_MONOTONIC_COUNTERS_DESC_MCUBOOT_ID0, &cur_sec_cnt);
+	if (err != 0) {
+		return FIH_FAILURE;
+	}
+
+	*security_cnt = cur_sec_cnt;
+
+	return FIH_SUCCESS;
+}
+
+int32_t boot_nv_security_counter_update(uint32_t image_id, uint32_t img_security_cnt)
+{
+	/* We only support 16 bits image counters */
+	if ((img_security_cnt & 0xFFFF0000) > 0) {
+		return -1;
+	}
+
+	/* MCUBoot permits calling this function with img_security_cnt
+	 * equal to the currently stored value (security_cnt). But
+	 * set_monotonic_counter does not permit this, so we check the old
+	 * value before updating.
+	 */
+	fih_int security_cnt;
+
+	fih_int fih_err = boot_nv_security_counter_get(image_id, &security_cnt);
+
+	if (fih_err != FIH_SUCCESS) {
+		return fih_err;
+	}
+
+	if (security_cnt == (uint16_t)img_security_cnt) {
+		return FIH_SUCCESS;
+	}
+
+	return set_monotonic_counter(BL_MONOTONIC_COUNTERS_DESC_MCUBOOT_ID0,
+				     (uint16_t)img_security_cnt);
+}

--- a/subsys/bootloader/cmake/provision_hex.cmake
+++ b/subsys/bootloader/cmake/provision_hex.cmake
@@ -4,58 +4,78 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-if (DEFINED CONFIG_SB_MONOTONIC_COUNTER)
-  set(monotonic_counter_arg
-    --num-counter-slots-version ${CONFIG_SB_NUM_VER_COUNTER_SLOTS})
+# This CMakeLists.txt is executed only by the parent application
+# and generates the provision.hex file.
+
+if (CONFIG_NCS_IS_VARIANT_IMAGE)
+  # When building the variant of an image, the configuration of the variant image
+  # is identical to the base image, except 'CONFIG_NCS_IS_VARIANT_IMAGE'. This file is
+  # included when provisioning, which can be the case for the base
+  # image. However, the logic in this file should only be performed once, for
+  # the base image, not for the variant variant. Hence, we have this check to avoid
+  # execution of this file for the variant image.
+  return()
 endif()
 
 # Build and include hex file containing provisioned data for the bootloader.
 set(PROVISION_HEX_NAME     provision.hex)
 set(PROVISION_HEX          ${PROJECT_BINARY_DIR}/${PROVISION_HEX_NAME})
 
-# Skip signing if MCUBoot is to be booted and its not built from source
-if ((CONFIG_SB_VALIDATE_FW_SIGNATURE OR CONFIG_SB_VALIDATE_FW_HASH) AND
-    NOT (CONFIG_BOOTLOADER_MCUBOOT AND NOT CONFIG_MCUBOOT_BUILD_STRATEGY_FROM_SOURCE))
+if(CONFIG_SECURE_BOOT)
+    if (DEFINED CONFIG_SB_MONOTONIC_COUNTER)
+      set(monotonic_counter_arg
+        --num-counter-slots-version ${CONFIG_SB_NUM_VER_COUNTER_SLOTS})
+    endif()
 
-  # Input is comma separated string, convert to CMake list type
-  string(REPLACE "," ";" PUBLIC_KEY_FILES_LIST "${CONFIG_SB_PUBLIC_KEY_FILES}")
+    # Skip signing if MCUBoot is to be booted and its not built from source
+    if ((CONFIG_SB_VALIDATE_FW_SIGNATURE OR CONFIG_SB_VALIDATE_FW_HASH) AND
+        NOT (CONFIG_BOOTLOADER_MCUBOOT AND NOT CONFIG_MCUBOOT_BUILD_STRATEGY_FROM_SOURCE))
 
-  include(${CMAKE_CURRENT_LIST_DIR}/../cmake/debug_keys.cmake)
-  include(${CMAKE_CURRENT_LIST_DIR}/../cmake/sign.cmake)
+      # Input is comma separated string, convert to CMake list type
+      string(REPLACE "," ";" PUBLIC_KEY_FILES_LIST "${CONFIG_SB_PUBLIC_KEY_FILES}")
 
-  if (${CONFIG_SB_DEBUG_SIGNATURE_PUBLIC_KEY_LAST})
-    message(WARNING
-      "
+      include(${CMAKE_CURRENT_LIST_DIR}/debug_keys.cmake)
+      include(${CMAKE_CURRENT_LIST_DIR}/sign.cmake)
+
+      if (${CONFIG_SB_DEBUG_SIGNATURE_PUBLIC_KEY_LAST})
+        message(WARNING
+          "
       -----------------------------------------------------------------
       --- WARNING: SB_DEBUG_SIGNATURE_PUBLIC_KEY_LAST is enabled.   ---
       --- This config should only be enabled for testing/debugging. ---
       -----------------------------------------------------------------")
-    list(APPEND PUBLIC_KEY_FILES ${SIGNATURE_PUBLIC_KEY_FILE})
-  else()
-    list(INSERT PUBLIC_KEY_FILES 0 ${SIGNATURE_PUBLIC_KEY_FILE})
-  endif()
+        list(APPEND PUBLIC_KEY_FILES ${SIGNATURE_PUBLIC_KEY_FILE})
+      else()
+        list(INSERT PUBLIC_KEY_FILES 0 ${SIGNATURE_PUBLIC_KEY_FILE})
+      endif()
 
-  # Convert CMake list type back to comma separated string.
-  string(REPLACE ";" "," PUBLIC_KEY_FILES "${PUBLIC_KEY_FILES}")
+      # Convert CMake list type back to comma separated string.
+      string(REPLACE ";" "," PUBLIC_KEY_FILES "${PUBLIC_KEY_FILES}")
 
-  set(public_keys_file_arg
-    --public-key-files "${PUBLIC_KEY_FILES}"
-    )
+      set(public_keys_file_arg
+        --public-key-files "${PUBLIC_KEY_FILES}"
+      )
 
-  set(PROVISION_DEPENDS signature_public_key_file_target)
+      set(PROVISION_DEPENDS signature_public_key_file_target)
+    endif()
+
+    if (CONFIG_SOC_NRF5340_CPUNET)
+      set(s0_arg --s0-addr $<TARGET_PROPERTY:partition_manager,PM_APP_ADDRESS>)
+    else()
+      set(s0_arg --s0-addr $<TARGET_PROPERTY:partition_manager,PM_S0_ADDRESS>)
+      set(s1_arg --s1-addr $<TARGET_PROPERTY:partition_manager,PM_S1_ADDRESS>)
+    endif()
+
+    if (CONFIG_SB_DEBUG_NO_VERIFY_HASHES)
+      set(no_verify_hashes_arg --no-verify-hashes)
+    endif()
 endif()
 
-if (CONFIG_SOC_NRF5340_CPUNET)
-  set(s0_arg --s0-addr $<TARGET_PROPERTY:partition_manager,PM_APP_ADDRESS>)
-else()
-  set(s0_arg --s0-addr $<TARGET_PROPERTY:partition_manager,PM_S0_ADDRESS>)
-  set(s1_arg --s1-addr $<TARGET_PROPERTY:partition_manager,PM_S1_ADDRESS>)
+if(CONFIG_MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION)
+  set(mcuboot_counters_slots --mcuboot-counters-slots ${CONFIG_MCUBOOT_HW_DOWNGRADE_PREVENTION_COUNTER_SLOTS})
 endif()
 
-if (CONFIG_SB_DEBUG_NO_VERIFY_HASHES)
-  set(no_verify_hashes_arg --no-verify-hashes)
-endif()
-
+if(CONFIG_SECURE_BOOT)
 add_custom_command(
   OUTPUT
   ${PROVISION_HEX}
@@ -67,9 +87,10 @@ add_custom_command(
   --provision-addr $<TARGET_PROPERTY:partition_manager,PM_PROVISION_ADDRESS>
   ${public_keys_file_arg}
   --output ${PROVISION_HEX}
-  ${monotonic_counter_arg}
   --max-size ${CONFIG_PM_PARTITION_SIZE_PROVISION}
+  ${monotonic_counter_arg}
   ${no_verify_hashes_arg}
+  ${mcuboot_counters_slots}
   DEPENDS
   ${PROVISION_KEY_DEPENDS}
   WORKING_DIRECTORY
@@ -78,31 +99,57 @@ add_custom_command(
   "Creating data to be provisioned to the Bootloader, storing to ${PROVISION_HEX_NAME}"
   USES_TERMINAL
   )
-
-add_custom_target(
-  provision_target
-  DEPENDS
+elseif(CONFIG_MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION)
+add_custom_command(
+  OUTPUT
   ${PROVISION_HEX}
-  ${PROVISION_DEPENDS}
+  COMMAND
+  ${PYTHON_EXECUTABLE}
+  ${NRF_DIR}/scripts/bootloader/provision.py
+  --mcuboot-only
+  --provision-addr $<TARGET_PROPERTY:partition_manager,PM_PROVISION_ADDRESS>
+  --output ${PROVISION_HEX}
+  --max-size ${CONFIG_PM_PARTITION_SIZE_PROVISION}
+  ${mcuboot_counters_num}
+  ${mcuboot_counters_slots}
+  DEPENDS
+  ${PROVISION_KEY_DEPENDS}
+  WORKING_DIRECTORY
+  ${PROJECT_BINARY_DIR}
+  COMMENT
+  "Creating data to be provisioned to the Bootloader, storing to ${PROVISION_HEX_NAME}"
+  USES_TERMINAL
   )
+endif()
 
-get_property(
-  provision_set
-  GLOBAL PROPERTY provision_PM_HEX_FILE SET
-  )
 
-if(NOT provision_set)
-  # Set hex file and target for the 'provision' placeholder partition.
-  # This includes the hex file (and its corresponding target) to the build.
-  set_property(
-    GLOBAL PROPERTY
-    provision_PM_HEX_FILE
-    ${PROVISION_HEX}
-    )
-
-  set_property(
-    GLOBAL PROPERTY
-    provision_PM_TARGET
+if(CONFIG_SECURE_BOOT OR CONFIG_MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION)
+  add_custom_target(
     provision_target
+    DEPENDS
+    ${PROVISION_HEX}
+    ${PROVISION_DEPENDS}
     )
+
+  get_property(
+    provision_set
+    GLOBAL PROPERTY provision_PM_HEX_FILE SET
+    )
+
+  if(NOT provision_set)
+    # Set hex file and target for the 'provision' placeholder partition.
+    # This includes the hex file (and its corresponding target) to the build.
+    set_property(
+      GLOBAL PROPERTY
+      provision_PM_HEX_FILE
+      ${PROVISION_HEX}
+      )
+
+    set_property(
+      GLOBAL PROPERTY
+      provision_PM_TARGET
+      provision_target
+      )
+  endif()
+
 endif()

--- a/subsys/bootloader/image/CMakeLists.txt
+++ b/subsys/bootloader/image/CMakeLists.txt
@@ -38,5 +38,3 @@ if (image_to_boot)
 else()
   assert(CONFIG_FW_INFO "CONFIG_FW_INFO must be set")
 endif()
-
-include(../cmake/provision_hex.cmake)

--- a/tests/subsys/bootloader/boot_chains/testcase.yaml
+++ b/tests/subsys/bootloader/boot_chains/testcase.yaml
@@ -27,3 +27,7 @@ tests:
     platform_allow:
       nrf5340dk_nrf5340_cpuapp_ns
       nrf9160dk_nrf9160_ns
+  boot_chains.bootloader_mcuboot_and_nv_counters:
+    extra_args:
+      CONFIG_BOOTLOADER_MCUBOOT=y
+      CONFIG_MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION=y


### PR DESCRIPTION
Support enforcing roll-back protection with non-volatile counters in
MCUBoot.
