### PR TITLE
quarantine: added sample.hw_id.ble@nrf51dk_nrf51422

### DIFF
--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -45,3 +45,9 @@
   platforms:
     - all
   comment: "Disable building selected Matter samples to limit resources usage"
+
+- scenarios:
+    - sample.hw_id.ble
+  platforms:
+    - nrf51dk_nrf51422
+  comment: "nRF51 SoC is not supported, see NCSDK-19772"


### PR DESCRIPTION
Added this sample to the quarantine as we are not supporting nRF51 since a while.