### PR TITLE
manifest: pull Matter fix for unused variable

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -122,7 +122,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: ed6a5ba3bb560642e06d5c1f0c4d81fce152360a
+      revision: 13ee50e217b1f9c3bac13f6e68b2d5e9188c3c3c
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
This fixes a build error in Matter over WiFi
samples (generated from a warning).