### PR TITLE
manifest: west: Enable reset on fatal error for MCUBoot minimal

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -114,7 +114,7 @@ manifest:
           compare-by-default: false
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: v1.9.99-ncs4
+      revision: pull/241/head
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR.git


### PR DESCRIPTION
Minimal config in MCUboot was used as a reference for release mode and lead to bootloaders being stuck in the fatal error state.

Ref: NCSDK-19789