### PR TITLE
doc: add cookie consent form

### DIFF
--- a/doc/_utils/utils.py
+++ b/doc/_utils/utils.py
@@ -1,3 +1,9 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
 from os import PathLike
 from pathlib import Path
 from typing import Tuple, Optional
@@ -83,7 +89,7 @@ def get_srcdir(docset: str) -> PathLike:
     return get_builddir() / docset / "src"
 
 
-def get_intersphinx_mapping(docset: str) -> Optional[Tuple[str, str]]:
+def get_intersphinx_mapping(docset: str) -> Optional[Tuple[str, str]]: # pylint: disable=unsubscriptable-object
     """Obtain intersphinx configuration for a given docset.
 
     Args:

--- a/doc/_utils/utils.py
+++ b/doc/_utils/utils.py
@@ -119,3 +119,9 @@ def add_google_analytics(app: Sphinx) -> None:
 
     app.add_js_file("https://www.googletagmanager.com/gtag/js?id=G-ZPVZRKFQJR")
     app.add_js_file("js/ga-tracker.js")
+    app.add_js_file(
+        "https://policy.app.cookieinformation.com/uc.js",
+        id="CookieConsent",
+        type="text/javascript",
+        **{"data-culture": "EN"},
+    )


### PR DESCRIPTION
Add a script from cookieinformation.com to provide a cookie consent service. Needs implementation using GTM.