### PR TITLE
lib: lte_link_control: add support for limited service sleep type

### DIFF
--- a/doc/nrf/app_dev/optimizing/power.rst
+++ b/doc/nrf/app_dev/optimizing/power.rst
@@ -141,6 +141,9 @@ To check whether the modem is able to activate PSM after RRC connection release,
    The active time is used in Step 3.
 #. Wait for ``%XMODEMSLEEP: 1`` notification or :c:enum:`LTE_LC_EVT_MODEM_SLEEP_ENTER` event with type :c:enum:`LTE_LC_MODEM_SLEEP_PSM` indicating that modem has entered PSM.
    If this notification is not received within PSM active time (allow for some margin), the modem was not able to enter PSM.
+
+   If ``%XMODEMSLEEP: 3`` notification or :c:enum:`LTE_LC_EVT_MODEM_SLEEP_ENTER` event with type :c:enum:`LTE_LC_MODEM_SLEEP_LIMITED_SERVICE` is received while waiting for PSM, the cell has been lost and the modem cannot enter PSM.
+   You can use this as a trigger to set the modem to offline mode quicker in this case, but it is not mandatory.
 #. If RRC connection is activated again (``+CSCON: 1`` or :c:enum:`LTE_LC_EVT_RRC_UPDATE` event with RRC mode set to :c:enum:`LTE_LC_RRC_MODE_CONNECTED`) while waiting for PSM, go back to Step 1.
 
 Power profiling example use case

--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -402,15 +402,20 @@ struct lte_lc_cells_info {
 };
 
 enum lte_lc_modem_sleep_type {
+	/** Power saving mode (PSM). */
 	LTE_LC_MODEM_SLEEP_PSM			= 1,
-	LTE_LC_MODEM_SLEEP_RF_INACTIVITY	= 2,	/* For example eDRX */
+	/** RF inactivity, for example eDRX. */
+	LTE_LC_MODEM_SLEEP_RF_INACTIVITY	= 2,
+	/** Limited service or out of coverage. */
+	LTE_LC_MODEM_SLEEP_LIMITED_SERVICE	= 3,
+	/** Flight mode. */
 	LTE_LC_MODEM_SLEEP_FLIGHT_MODE		= 4,
 };
 
 struct lte_lc_modem_sleep {
 	enum lte_lc_modem_sleep_type type;
 
-	/* If this value is set to -1. Sleep is considered infinite. */
+	/* If this value is set to -1, the sleep is considered infinite. */
 	int64_t time;
 };
 

--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -462,11 +462,12 @@ static void at_handler_xmodemsleep(const char *response)
 		return;
 	}
 
-	/* Link controller only supports PSM, RF inactivity and flight mode
+	/* Link controller only supports PSM, RF inactivity, limited service and flight mode
 	 * modem sleep types.
 	 */
 	if ((evt.modem_sleep.type != LTE_LC_MODEM_SLEEP_PSM) &&
 		(evt.modem_sleep.type != LTE_LC_MODEM_SLEEP_RF_INACTIVITY) &&
+		(evt.modem_sleep.type != LTE_LC_MODEM_SLEEP_LIMITED_SERVICE) &&
 		(evt.modem_sleep.type != LTE_LC_MODEM_SLEEP_FLIGHT_MODE)) {
 		return;
 	}

--- a/samples/nrf9160/modem_shell/src/link/link_shell_print.c
+++ b/samples/nrf9160/modem_shell/src/link/link_shell_print.c
@@ -20,7 +20,8 @@ link_shell_print_sleep_type_to_string(enum lte_lc_modem_sleep_type sleep_type, c
 	struct mapping_tbl_item const mapping_table[] = {
 		{ LTE_LC_MODEM_SLEEP_PSM, "PSM" },
 		{ LTE_LC_MODEM_SLEEP_RF_INACTIVITY, "RF inactivity" },
-		{ LTE_LC_MODEM_SLEEP_FLIGHT_MODE, "flightmode" },
+		{ LTE_LC_MODEM_SLEEP_LIMITED_SERVICE, "limited service"},
+		{ LTE_LC_MODEM_SLEEP_FLIGHT_MODE, "flight mode" },
 		{ -1, NULL }
 	};
 


### PR DESCRIPTION
Added support for modem sleep events because of limited service.