### PR TITLE
manifest: Update Matter revision to pull DNSSD fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -122,7 +122,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: v2.3.0-rc1
+      revision: ce811122f2156f974577ddf9ee739b3ce476e0c2
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
Updated the Matter version to pull a fix that triggers the next checking of node lookup status, when the Timer has been set to the wrong time.

Fixes: KRKNWK-16148