### PR TITLE
Nrf7 x 26

### DIFF
--- a/samples/wifi/radio_test/sample_description.rst
+++ b/samples/wifi/radio_test/sample_description.rst
@@ -128,7 +128,7 @@ Testing
          * To run a continuous Orthogonal frequency-division multiplexing (OFDM) TX traffic sequence with the following configuration:
 
            * Channel: 11
-           * Frame duration: 5484 us
+           * Frame duration: 2708 us
            * Inter-frame gap: 4200 us
 
            Execute the following sequence of commands:
@@ -136,8 +136,8 @@ Testing
            .. code-block:: console
 
               wifi_radio_test init 11
-              wifi_radio_test tx_pkt_len 4095
               wifi_radio_test tx_pkt_rate 12
+              wifi_radio_test tx_pkt_len 4000
               wifi_radio_test tx_power 4
               wifi_radio_test tx_pkt_gap 4200
               wifi_radio_test tx 1
@@ -155,8 +155,8 @@ Testing
 
               wifi_radio_test init 14
               wifi_radio_test tx_pkt_preamble 1
-              wifi_radio_test tx_pkt_len 1024
               wifi_radio_test tx_pkt_rate 1
+              wifi_radio_test tx_pkt_len 1024
               wifi_radio_test tx_power 10
               wifi_radio_test tx_pkt_gap 8600
               wifi_radio_test tx 1
@@ -177,7 +177,7 @@ Testing
               * D - Frame duration (us)
               * L - Frame length (bytes)
               * R - Data rate (Mbps)
-              * P - PHY overhead duration (us) (Values: 24 us - Legacy OFDM, 192 us - DSSS)
+              * P - PHY overhead duration (us) (Values: 20 us - Legacy OFDM, 192 us - DSSS)
 
          * To run a RX test with the following configuration:
 

--- a/samples/wifi/radio_test/src/nrf_wifi_radio_test_shell.c
+++ b/samples/wifi/radio_test/src/nrf_wifi_radio_test_shell.c
@@ -769,7 +769,26 @@ static int nrf_wifi_radio_test_set_tx_pkt_len(const struct shell *shell,
 		return -ENOEXEC;
 	}
 
-	if (ctx->conf_params.tx_pkt_tput_mode == RPU_TPUT_MODE_HE_TB) {
+	if (ctx->conf_params.tx_pkt_tput_mode == RPU_TPUT_MODE_LEGACY) {
+		if ((ctx->conf_params.tx_pkt_rate == 1) ||
+		    (ctx->conf_params.tx_pkt_rate == 2) ||
+			(ctx->conf_params.tx_pkt_rate == 5) ||
+			(ctx->conf_params.tx_pkt_rate == 11) ){	
+			if (val > 2300) {
+				shell_fprintf(shell,
+					      SHELL_ERROR,
+					      "max 'tx_pkt_len' size for DSSS is 2300 bytes\n");
+				return -ENOEXEC;
+			}	
+		} else {
+			if (val > 4000) {
+				shell_fprintf(shell,
+					      SHELL_ERROR,
+					      "max 'tx_pkt_len' size for legacy is 4000 bytes\n");
+				return -ENOEXEC;
+			}
+		}
+	} else if (ctx->conf_params.tx_pkt_tput_mode == RPU_TPUT_MODE_HE_TB) {
 		if (ctx->conf_params.ru_tone == 26) {
 			if (val >= 350) {
 				shell_fprintf(shell,

--- a/samples/wifi/radio_test/src/nrf_wifi_radio_test_shell.c
+++ b/samples/wifi/radio_test/src/nrf_wifi_radio_test_shell.c
@@ -773,13 +773,13 @@ static int nrf_wifi_radio_test_set_tx_pkt_len(const struct shell *shell,
 		if ((ctx->conf_params.tx_pkt_rate == 1) ||
 		    (ctx->conf_params.tx_pkt_rate == 2) ||
 			(ctx->conf_params.tx_pkt_rate == 5) ||
-			(ctx->conf_params.tx_pkt_rate == 11) ){	
+			(ctx->conf_params.tx_pkt_rate == 11)) {
 			if (val > 2300) {
 				shell_fprintf(shell,
 					      SHELL_ERROR,
 					      "max 'tx_pkt_len' size for DSSS is 2300 bytes\n");
 				return -ENOEXEC;
-			}	
+			}
 		} else {
 			if (val > 4000) {
 				shell_fprintf(shell,

--- a/samples/wifi/radio_test/src/nrf_wifi_radio_test_shell.c
+++ b/samples/wifi/radio_test/src/nrf_wifi_radio_test_shell.c
@@ -770,23 +770,11 @@ static int nrf_wifi_radio_test_set_tx_pkt_len(const struct shell *shell,
 	}
 
 	if (ctx->conf_params.tx_pkt_tput_mode == RPU_TPUT_MODE_LEGACY) {
-		if ((ctx->conf_params.tx_pkt_rate == 1) ||
-		    (ctx->conf_params.tx_pkt_rate == 2) ||
-			(ctx->conf_params.tx_pkt_rate == 5) ||
-			(ctx->conf_params.tx_pkt_rate == 11)) {
-			if (val > 2300) {
-				shell_fprintf(shell,
-					      SHELL_ERROR,
-					      "max 'tx_pkt_len' size for DSSS is 2300 bytes\n");
-				return -ENOEXEC;
-			}
-		} else {
-			if (val > 4000) {
-				shell_fprintf(shell,
-					      SHELL_ERROR,
-					      "max 'tx_pkt_len' size for legacy is 4000 bytes\n");
-				return -ENOEXEC;
-			}
+		if (val > 4000) {
+			shell_fprintf(shell,
+				      SHELL_ERROR,
+				      "max 'tx_pkt_len' size for legacy is 4000 bytes\n");
+			return -ENOEXEC;
 		}
 	} else if (ctx->conf_params.tx_pkt_tput_mode == RPU_TPUT_MODE_HE_TB) {
 		if (ctx->conf_params.ru_tone == 26) {


### PR DESCRIPTION
Set maximum payload length to 4000 bytes for legacy frames. 
Set maximum payload length to 2300 bytes for DSSS frames. 

Update sample_description.rst file to reflect this change in documentation.