### PR TITLE
tests: mcuboot: don't use debug optimization

### DIFF
--- a/tests/modules/mcuboot/external_flash/child_image/mcuboot/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/modules/mcuboot/external_flash/child_image/mcuboot/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,5 @@
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/tests/modules/mcuboot/external_flash/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/tests/modules/mcuboot/external_flash/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,5 @@
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/tests/modules/mcuboot/external_flash/child_image/mcuboot/prj.conf
+++ b/tests/modules/mcuboot/external_flash/child_image/mcuboot/prj.conf
@@ -11,8 +11,6 @@
 # MCUboot requires a large stack size, otherwise an MPU fault will occur
 CONFIG_MAIN_STACK_SIZE=10240
 
-CONFIG_DEBUG_OPTIMIZATIONS=y
-
 # Enable flash operations
 CONFIG_FLASH=y
 


### PR DESCRIPTION
This is needed to fit within flash limits.