### PR TITLE
manifest: Update Matter revision to pull WiFi security type fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -122,7 +122,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: ce811122f2156f974577ddf9ee739b3ce476e0c2
+      revision: 0a72fe40ed90d5162bd2419e203ca8036c7345b2
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
Update the Matter version to pull a fix for the WiFi security type.
Previously the security type was wrongly cast from Zephyr to Matter enum types.
Used switch-case-based mapping between two enum types (Zephyr-Matter) to make sure that we properly cast between two different types.

Fixes: KRKNWK-16325