### PR TITLE
manifest: update nrfxlib

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -114,7 +114,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: v2.3.0-rc1
+      revision: 2ccb73113e54b9d56c07cfde838482c762584f19
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Update nrfxlib manifest to update the number of semaphores required by the Modem library.