### PR TITLE
drivers: wifi: Enable QSPI lower power only in LPM

### DIFF
--- a/drivers/wifi/nrf700x/Kconfig.nrf700x
+++ b/drivers/wifi/nrf700x/Kconfig.nrf700x
@@ -85,7 +85,7 @@ config NRF700X_BT_COEX
 
 config NRF700X_QSPI_LOW_POWER
 	bool "Enable low power mode in QSPI"
-	default y
+	default y if NRF_WIFI_LOW_POWER
 
 # Performance fine tuning options
 


### PR DESCRIPTION
This only makes sense if it matches the overall system power state, for Wi-Fi that is LPM.