### PR TITLE
manifest: Update Matter revision to pull CHIPtool workflow fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -122,7 +122,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 0a72fe40ed90d5162bd2419e203ca8036c7345b2
+      revision: 2806b0bbc4b45d34ec4d5d6797ce1708989add43
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
Currently CHIPtool (Matter controller for Linux) has dependency to openSSL.
The issue is that Ubuntu 20.04 and Ubuntu 22.04 use different versions of OpenSSL and the version built under 20.04 does not work under 22.04 (without some hacks to install the old openssl version) and vice verse.

Removed the dependency to the dynamic library to build CHIPtool with the mbedTLS sources.