### PR TITLE
manifest: Updating nrfxlib

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -114,7 +114,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: be94cc3f090d3b5c9ed9aecb77edda98ba036120
+      revision: 021fba7bad493a023dc8cd8b5763939fcc9b07c1
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Moving mpsl under softdevice controller,
without this we get linker errors when linking with un-obfuscated softdevice-controller and mpsl libraries.

linker errors like:
"undefined reference to mpsl_cx_granted_ops_get