### PR TITLE
samples: mmss: Increase at monitor heap size

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -437,6 +437,7 @@ nRF9160 samples
   * Updated:
 
     * The sample now uses a partition in external flash for full modem FOTA updates.
+    * Increased AT monitor heap to prevent occasional overruns
 
   * Added:
 

--- a/samples/nrf9160/nrf_cloud_mqtt_multi_service/prj.conf
+++ b/samples/nrf9160/nrf_cloud_mqtt_multi_service/prj.conf
@@ -38,6 +38,10 @@ CONFIG_LOG_BUFFER_SIZE=4096
 CONFIG_HEAP_MEM_POOL_SIZE=24576
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 
+# AT monitor heap size should be tuned for each application.
+# This is the smallest power of 2 that works reliably with MMSS.
+CONFIG_AT_MONITOR_HEAP_SIZE=2048
+
 # Network
 CONFIG_NETWORKING=y
 CONFIG_NET_NATIVE=n


### PR DESCRIPTION
Before this commit, MMSS randomly becomes inoperable due to the at monitor heap being overrun. This commit increases the heap size to the minimum power of two that prevents the issue from happening