### PR TITLE
manifest: sdk-zephyr: Pull double free Ethernet fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: bf10b681f176255544867f158e6ebf472d2c7d6b
+      revision: 6257acfada15ba7f43a1ed38c69a1ca61ffc757c
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This fixes double free bus fault  with wifi connect and disconnect.

Fixes SHEL-1293.