### PR TITLE
doc: requirements: do not requite pygit <= 1.10

### DIFF
--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -4,7 +4,7 @@ sphinxcontrib-mscgen>=0.6
 sphinx-ncs-theme>=1.0.3,<1.1
 m2r2>=0.3.2
 sphinxcontrib-plantuml
-pygit2<=1.10
+pygit2
 pyyaml
 azure-storage-blob
 sphinx_markdown_tables


### PR DESCRIPTION
There's no need to pin pygit2 for now.