### PR TITLE
manifest: sdk-zephyr: Pull drop incomplete data in periodic scanner

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 951ca965d423a8103b5c18328cbc1ac503990701
+      revision: 0cd59b0c43aa0c9d6682066aca74ac05be094169
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Fixes host sending incomplete periodic adv data to application