### PR TITLE
applications: asset_tracker_v2: Remove experimental from lwm2m

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/Kconfig.lwm2m_integration
+++ b/applications/asset_tracker_v2/src/cloud/Kconfig.lwm2m_integration
@@ -5,12 +5,11 @@
 #
 
 module = LWM2M_INTEGRATION
-module-prompt = "LwM2M integration [Experimental]"
+module-prompt = "LwM2M integration"
 orsource "../../../../subsys/net/lib/Kconfig.cloud_$(CLOUD_SERVICE_SELECTOR)"
 
 config $(module)
 	bool
-	select EXPERIMENTAL
 	prompt "LwM2M integration layer" if !CLOUD_SERVICE_MUTUAL_EXCLUSIVE
 
 if LWM2M_INTEGRATION


### PR DESCRIPTION
lwm2m is considered stable. Remove experimental tag from the asset tracker v2 lwm2m integration.