### PR TITLE
manifest: pull Matter Wi-Fi connection log extension

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -122,7 +122,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 2806b0bbc4b45d34ec4d5d6797ce1708989add43
+      revision: 618aca3145ddf364f8da16077961038de586d759
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
This adds RSSI info into the connection request log,
which comes in handy when analyzing DUT's TX/RX power.