### PR TITLE
[backport-v1.9] Add workaround for nRF53 anomaly 160

### DIFF
--- a/samples/nfc/writable_ndef_msg/src/main.c
+++ b/samples/nfc/writable_ndef_msg/src/main.c
@@ -181,7 +181,7 @@ int main(void)
 			atomic_set(&op_flags, FLASH_WRITE_FINISHED);
 		}
 
-		__WFE();
+		k_cpu_atomic_idle(irq_lock());
 	}
 
 fail:

--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v2.7.99-ncs1-1
+      revision: pull/1074/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
- pull in changes in Zephyr related to the workaround
- eliminate direct use of WFE in the sdk-nrf tree