### PR TITLE
samples: matter: Fixed window covering setting value issue.

### DIFF
--- a/samples/matter/window_covering/src/window_covering.cpp
+++ b/samples/matter/window_covering/src/window_covering.cpp
@@ -54,12 +54,14 @@ void WindowCovering::DriveCurrentLiftPosition(intptr_t)
 	OperationalState state = ComputeOperationalState(target, current);
 	UpdateOperationalStatus(MoveType::LIFT, state);
 
-	chip::Percent100ths step = CalculateSingleStep(MoveType::LIFT);
+	chip::Percent100ths position = CalculateNextPosition(MoveType::LIFT);
 
 	if (state == OperationalState::MovingUpOrOpen) {
-		positionToSet.SetNonNull(step > target.Value() ? step : target.Value());
+		positionToSet.SetNonNull(position > target.Value() ? position : target.Value());
 	} else if (state == OperationalState::MovingDownOrClose) {
-		positionToSet.SetNonNull(step < target.Value() ? step : target.Value());
+		positionToSet.SetNonNull(position < target.Value() ? position : target.Value());
+	} else {
+		positionToSet.SetNonNull(current.Value());
 	}
 
 	LiftPositionSet(Endpoint(), positionToSet);
@@ -79,7 +81,7 @@ void WindowCovering::DriveCurrentLiftPosition(intptr_t)
 	}
 }
 
-chip::Percent100ths WindowCovering::CalculateSingleStep(MoveType aMoveType)
+chip::Percent100ths WindowCovering::CalculateNextPosition(MoveType aMoveType)
 {
 	EmberAfStatus status{};
 	chip::Percent100ths percent100ths{};
@@ -147,12 +149,14 @@ void WindowCovering::DriveCurrentTiltPosition(intptr_t)
 	OperationalState state = ComputeOperationalState(target, current);
 	UpdateOperationalStatus(MoveType::TILT, state);
 
-	chip::Percent100ths step = CalculateSingleStep(MoveType::TILT);
+	chip::Percent100ths position = CalculateNextPosition(MoveType::TILT);
 
 	if (state == OperationalState::MovingUpOrOpen) {
-		positionToSet.SetNonNull(step > target.Value() ? step : target.Value());
+		positionToSet.SetNonNull(position > target.Value() ? position : target.Value());
 	} else if (state == OperationalState::MovingDownOrClose) {
-		positionToSet.SetNonNull(step < target.Value() ? step : target.Value());
+		positionToSet.SetNonNull(position < target.Value() ? position : target.Value());
+	} else {
+		positionToSet.SetNonNull(current.Value());
 	}
 
 	TiltPositionSet(Endpoint(), positionToSet);
@@ -195,7 +199,7 @@ void WindowCovering::StartMove(MoveType aMoveType)
 void WindowCovering::SetSingleStepTarget(OperationalState aDirection)
 {
 	UpdateOperationalStatus(mCurrentUIMoveType, aDirection);
-	SetTargetPosition(aDirection, CalculateSingleStep(mCurrentUIMoveType));
+	SetTargetPosition(aDirection, CalculateNextPosition(mCurrentUIMoveType));
 }
 
 void WindowCovering::UpdateOperationalStatus(MoveType aMoveType, OperationalState aDirection)

--- a/samples/matter/window_covering/src/window_covering.h
+++ b/samples/matter/window_covering/src/window_covering.h
@@ -51,7 +51,7 @@ private:
 	static void UpdateOperationalStatus(MoveType aMoveType, OperationalState aDirection);
 	static bool TargetCompleted(MoveType aMoveType, NPercent100ths aCurrent, NPercent100ths aTarget);
 	static void StartTimer(MoveType aMoveType, uint32_t aTimeoutMs);
-	static chip::Percent100ths CalculateSingleStep(MoveType aMoveType);
+	static chip::Percent100ths CalculateNextPosition(MoveType aMoveType);
 	static void DriveCurrentLiftPosition(intptr_t);
 	static void DriveCurrentTiltPosition(intptr_t);
 	static void MoveTimerTimeoutCallback(chip::System::Layer *systemLayer, void *appState);


### PR DESCRIPTION
While setting a value that was out of scope, the algorithm had been bricked and there wasn't a possibility to change the value anymore.