### PR TITLE
applications: nrf_desktop: Allow MCUboot to access external FLASH

### DIFF
--- a/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/child_image/mcuboot.overlay
+++ b/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/child_image/mcuboot.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};


### PR DESCRIPTION
Change introduces a missing "nordic,pm-ext-flash" chosen node to MCUboot child image configuration. This is needed to allow MCUboot to access external FLASH during image swap.

Jira: NCSDK-19970