### PR TITLE
doc: Added information about Amazon Alexa support in Matter

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -733,6 +733,7 @@
 .. _`Understanding Frustration-Free Setup`: https://developer.amazon.com/docs/frustration-free-setup/understanding-ffs.html
 .. _`Matter Simple Setup for Wi-Fi Overview`: https://developer.amazon.com/docs/frustration-free-setup/matter-simple-setup-for-wifi-overview.html
 .. _`Matter Simple Setup for Thread Overview`: https://developer.amazon.com/docs/frustration-free-setup/matter-simple-setup-for-thread-overview.html
+.. _`Amazon Alexa integration with Matter`: https://developer.amazon.com/en-US/docs/alexa/smarthome/matter-support.html
 
 .. ### Source: openthread.io
 

--- a/doc/nrf/protocols/matter/getting_started/ecosystem_compatibility_testing.rst
+++ b/doc/nrf/protocols/matter/getting_started/ecosystem_compatibility_testing.rst
@@ -26,6 +26,7 @@ At the very least, you need the following pieces of hardware to set up and test 
   * `Apple Home <Apple Home integration with Matter_>`_
   * `Google Home <Google Home integration with Matter_>`_
   * `Samsung SmartThings <Samsung SmartThings integration with Matter_>`_
+  * `Amazon Alexa <Amazon Alexa integration with Matter_>`_
 
 * 1x Wi-Fi Access Point supporting IPv6 connected to the Internet (for example, Asus RT-AC1300G, as used in the tutorial)
 * 1x PC with nRF Connect SDK v2.2.0 (or later) installed

--- a/doc/nrf/protocols/matter/overview/dev_model.rst
+++ b/doc/nrf/protocols/matter/overview/dev_model.rst
@@ -37,6 +37,6 @@ Compatibility with commercial ecosystems
 One of the key features of the Matter protocol is the interoperability of different ecosystems it provides.
 Implementing support for Matter enables the :ref:`ug_matter_overview_multi_fabrics` and allows different vendor products to co-exist within the same Matter network.
 
-The Matter stack in the |NCS| will work with any commercial Matter ecosystem as long as these ecosystems are compatible with the official Matter implementation (for example `Apple Home <Apple Home integration with Matter_>`_, `Google Home <Google Home integration with Matter_>`_, or `Samsung SmartThings <Samsung SmartThings integration with Matter_>`_).
+The Matter stack in the |NCS| will work with any commercial Matter ecosystem as long as these ecosystems are compatible with the official Matter implementation (for example `Apple Home <Apple Home integration with Matter_>`_, `Google Home <Google Home integration with Matter_>`_, `Samsung SmartThings <Samsung SmartThings integration with Matter_>`_, or `Amazon Alexa <Amazon Alexa integration with Matter_>`_).
 
 For an example of interoperability of some commercial ecosystems, see :ref:`ug_matter_gs_ecosystem_compatibility_testing`.


### PR DESCRIPTION
Updated documentation to add Amazon Alexa to the list of commercial ecosystems supporting Matter