### PR TITLE
bluetooth: services: nsms: Fix CCC permissions

### DIFF
--- a/doc/nrf/libraries/bluetooth_services/services/nsms.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/nsms.rst
@@ -26,8 +26,8 @@ Characteristics
 This service has one characteristic with the CCC and CUD descriptors.
 CUD holds the name of the Status Message and helps to distinguish between different instances of the NSMS on the same device.
 
-Status Characteristic (57a70001-9350-11ed-a1eb-x0242ac120002)
-=============================================================
+Status Characteristic (57a70001-9350-11ed-a1eb-0242ac120002)
+============================================================
 
 Notify
   Enable notifications for the Status Characteristic to receive notifications when the status message changes.

--- a/include/bluetooth/services/nsms.h
+++ b/include/bluetooth/services/nsms.h
@@ -72,6 +72,10 @@ ssize_t bt_nsms_status_read(struct bt_conn *conn,
 					 (BT_GATT_PERM_READ)          \
 				       )
 
+#define _BT_NSMS_CH_WRITE_PERM(_authen) ((_authen) ?                    \
+					  (BT_GATT_PERM_WRITE_AUTHEN) : \
+					  (BT_GATT_PERM_WRITE)          \
+					)
 /* @note:
  * The macro is required to provide proper arguments expansion as we are using name concatenation.
  * This allow proper double argument expansion.
@@ -107,7 +111,8 @@ ssize_t bt_nsms_status_read(struct bt_conn *conn,
 					       bt_nsms_status_read,                     \
 					       NULL,                                    \
 					       (void *)&CONCAT(_nsms, _status_str)),    \
-			BT_GATT_CCC(NULL, _BT_NSMS_CH_READ_PERM(_authen)),              \
+			BT_GATT_CCC(NULL, _BT_NSMS_CH_READ_PERM(_authen) |              \
+					  _BT_NSMS_CH_WRITE_PERM(_authen)),             \
 			BT_GATT_CUD(_name, _BT_NSMS_CH_READ_PERM(_authen)),             \
 	);                                                                              \
 	static const struct bt_nsms _nsms = {                                           \


### PR DESCRIPTION
This commit adds missing write permissions to CCC attribute. Typo fix in nsms documentation.