### PR TITLE
manifest: Update Zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 3e48d5f080122db8a149bfb2c022b5825f86c984
+      revision: fa52a5de18c8de4d0ebc51d8ab60232f8c5594c2
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull in changes in Zephyr that fix a problem in the system timer driver (nrf_rtc_timer) that in specific conditions the COMPARE event for a scheduled timeout was not handled properly and in consequence the timeout expired with an additional delay of 512 seconds, i.e. after the RTC overflowed.