### PR TITLE
manifest: sdk-zephyr: Pull wrong include fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 0cd59b0c43aa0c9d6682066aca74ac05be094169
+      revision: 3e48d5f080122db8a149bfb2c022b5825f86c984
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Remove `#include "utils/code_utils.h"` and macros connected with it. File was incorrectly included in `diag.c` as it is OpenThread's header used for examples only, resulting in build errors while building with prebuilt OpenThread samples.