### PR TITLE
tests: bluetooth: Make memcpy operation more clear

### DIFF
--- a/tests/bluetooth/tester/src/model_handler.c
+++ b/tests/bluetooth/tester/src/model_handler.c
@@ -264,7 +264,7 @@ static void prop_get(struct bt_mesh_prop_srv *srv, struct bt_mesh_msg_ctx *ctx,
 	}
 
 	val->size = sizeof(property);
-	memcpy(val->value, &property.current, sizeof(property));
+	memcpy(val->value, &property, sizeof(property));
 }
 
 static void prop_mfr_get(struct bt_mesh_prop_srv *srv,
@@ -277,7 +277,7 @@ static void prop_mfr_get(struct bt_mesh_prop_srv *srv,
 	}
 
 	val->size = sizeof(property);
-	memcpy(val->value, &property.current, sizeof(property));
+	memcpy(val->value, &property, sizeof(property));
 }
 
 static int sensor_data_get(struct bt_mesh_sensor_srv *srv,


### PR DESCRIPTION
Previously the memcpy was copying the contents of the address of property.current assuming that 'current' will always be the first element in the structure. This is now fixed by changing to source of the memcpy to address of the property struct itself. Technically they are both the same, but this makes the intention more clear and makes the code less prone to bugs.

Found as a voilation of MITRE, CWE-131 by sonarcloud.

Link to bug report: https://sonarcloud.io/project/issues?fileUuids=AYTON30XKjB6nK53VR_C&resolved=false&severities=BLOCKER&id=balaji-nordic_sdk-nrf&open=AYXPYVrO7N55hgsd3p6v&tab=code