### PR TITLE
ci: Fix oss-history script for v1.9-branch

### DIFF
--- a/.github/workflows/oss-history.yml
+++ b/.github/workflows/oss-history.yml
@@ -3,7 +3,7 @@ on: pull_request
 
 jobs:
   contribs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Check OSS history
     steps:
       - name: Checkout the code
@@ -25,6 +25,6 @@ jobs:
           git -C zephyr remote add upstream https://github.com/zephyrproject-rtos/zephyr
 
       - name: Check OSS history
-        uses: nrfconnect/action-oss-history@main
+        uses: nrfconnect/action-oss-history@58f389dcef17b24bac57c668bb3c1c7a7a496be0
         with:
           workspace: 'ncs'

--- a/scripts/requirements-extra.txt
+++ b/scripts/requirements-extra.txt
@@ -1,3 +1,4 @@
+cffi==1.15.0
 pygit2==1.6.1
 editdistance>=0.5.0
 PyGithub


### PR DESCRIPTION
cffi is installed as a pygit2 dependency. There was a mismatch though between system-provided cssi package version, and the one installed by pip.

Resolve this by fixing the cffi and ubuntu versions used by the script.

Use fixed action-oss-history revision.