### PR TITLE
ci: Fix docbuild script for v1.9-branch

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout the code
@@ -39,14 +39,14 @@ jobs:
         run: |
           sudo apt update
           sudo apt-get install -y ninja-build mscgen plantuml libclang1-9 libclang-cpp9
-          wget -q https://www.doxygen.nl/files/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz
+          wget -q https://github.com/doxygen/doxygen/releases/download/Release_${DOXYGEN_VERSION//./_}/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz
           tar xf doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz
           echo "${PWD}/doxygen-${DOXYGEN_VERSION}/bin" >> $GITHUB_PATH
 
       - name: Install base dependencies
         working-directory: ncs
         run: |
-          sudo pip3 install -U setuptools wheel pip
+          sudo pip3 install -U "setuptools<=58.0.0" wheel
           pip3 install -r nrf/scripts/requirements-base.txt
 
       - name: West init and update
@@ -65,7 +65,7 @@ jobs:
       - name: Build documentation
         working-directory: ncs/nrf
         run: |
-          cmake -GNinja -Bdoc/_build -Sdoc -DSPHINXOPTS_EXTRA="-W"
+          cmake -GNinja -Bdoc/_build -Sdoc
           ninja -C doc/_build
 
       - name: Build cache

--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -4,10 +4,9 @@ sphinxcontrib-mscgen>=0.6
 sphinx-ncs-theme>=0.7.0
 m2r2
 sphinxcontrib-plantuml
-pygit2
+pygit2<=1.10
 pyyaml
 azure-storage-blob
 sphinx_markdown_tables
-markdown<3.3.5 # Workaround for ryanfox/sphinx-markdown-tables#34
-mistune<2.0 # Workaround for https://github.com/CrossNox/m2r2/issues/40
-breathe<4.33 # Workaround for #803 and #805 breathe issues
+breathe>=4.34
+docutils<0.18


### PR DESCRIPTION
Use Ubuntu 20.04 for the documentation build.
Update doxygen URL.
Update breathe version.
Limit setuptools version used.
Limit pytgi2 version used.