### PR TITLE
doc: lib: lwm2m_carrier: fix CESQ events documentation

### DIFF
--- a/doc/nrf/libraries/bin/lwm2m_carrier/requirements.rst
+++ b/doc/nrf/libraries/bin/lwm2m_carrier/requirements.rst
@@ -18,7 +18,7 @@ Following are some of the requirements and limitations of the application while 
 
    * SMS events (``AT+CNMI``).
    * Packet Domain events (``AT+CGEREP``).
-   * Extended signal quality events (``AT+CESQ``).
+   * Signal quality events (``AT%CESQ``).
    * ODIS events (``AT+ODISNTF``).
    * Universal Integrated Circuit Card events (``AT%XSIM``).
    * Network Time events (``AT%XTIME``).


### PR DESCRIPTION
The AT command that subscribes to notifications of changes in signal quality is AT%CESQ, and not AT+CESQ, which returns the received signal quality parameters upon issuing it.