### PR TITLE
manifest: Update Zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v3.2.99-ncs2-rc2
+      revision: pull/1085/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull in a change in Zephyr that warns the user if the workaround for nRF5340 anomaly 160 is unavailable due to the kernel configuration (lack of the system clock).