### PR TITLE
net: lib: download_client: Non blocking connect 

### DIFF
--- a/applications/serial_lte_modem/src/dfu/slm_at_dfu.c
+++ b/applications/serial_lte_modem/src/dfu/slm_at_dfu.c
@@ -319,7 +319,7 @@ static  int dfu_download_start(const char *host, const char *file, int sec_tag,
 
 	socket_retries_left = CONFIG_SLM_DFU_SOCKET_RETRIES;
 	strncpy(file_buf, file, sizeof(file_buf));
-	err = download_client_connect(&dlc, host, &config);
+	err = download_client_set_host(&dlc, host, &config);
 	if (err != 0) {
 		return err;
 	}

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -542,6 +542,7 @@ Libraries for networking
 
   * Refactored the :c:func:`download_client_connect` function to :c:func:`download_client_set_host` and made it non-blocking.
   * Added the :c:func:`download_client_get` function that combines the functionality of functions :c:func:`download_client_set_host`, :c:func:`download_client_start`, and :c:func:`download_client_disconnect`.
+  * Removed functions :c:func:`donwload_client_pause` and :c:func:`donwload_client_resume`.
 
 * :ref:`lib_lwm2m_location_assistance` library:
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -538,6 +538,11 @@ Libraries for networking
 
   * Removed the old API ``lwm2m_firmware_get_update_state_cb()``.
 
+* :ref:`lib_download_client` library:
+
+  * Refactored the :c:func:`download_client_connect` function to :c:func:`download_client_set_host` and made it non-blocking.
+  * Added the :c:func:`download_client_get` function that combines the functionality of functions :c:func:`download_client_set_host`, :c:func:`download_client_start`, and :c:func:`download_client_disconnect`.
+
 * :ref:`lib_lwm2m_location_assistance` library:
 
   * Updated:

--- a/include/net/download_client.h
+++ b/include/net/download_client.h
@@ -251,21 +251,6 @@ __deprecated int download_client_connect(struct download_client *client, const c
  */
 int download_client_start(struct download_client *client, const char *file,
 			  size_t from);
-
-/**
- * @brief Pause the download.
- *
- * @param[in] client	Client instance.
- */
-void download_client_pause(struct download_client *client);
-
-/**
- * @brief Resume the download.
- *
- * @param[in] client	Client instance.
- */
-void download_client_resume(struct download_client *client);
-
 /**
  * @brief Retrieve the size of the file being downloaded, in bytes.
  *
@@ -291,7 +276,7 @@ int download_client_disconnect(struct download_client *client);
  * @brief Download a file asynchronously.
  *
  * This initiates an asynchronous connect-download-disconnect sequence to the target
- * host. When only one file is required form a target server, it can be used instead of
+ * host. When only one file is required from a target server, it can be used instead of
  * separate calls to download_client_set_host(), download_client_start()
  * and download_client_disconnect().
  *

--- a/include/net/download_client.h
+++ b/include/net/download_client.h
@@ -47,6 +47,9 @@ enum download_client_evt_id {
 	 * - EHOSTDOWN: host went down during download
 	 * - EBADMSG: HTTP response header not as expected
 	 * - E2BIG: HTTP response header could not fit in buffer
+	 * - EPROTONOSUPPORT: Protocol is not supported
+	 * - EINVAL: Invalid configuration
+	 * - EAFNOSUPPORT: Unsupported address family (IPv4/IPv6)
 	 *
 	 * In case of errors on the socket during send() or recv() (ECONNRESET),
 	 * returning zero from the callback will let the library attempt
@@ -182,10 +185,16 @@ struct download_client {
 
 	/** Set socket to native TLS */
 	bool set_native_tls;
+
+	/** Close the socket when finished. */
+	bool close_when_done;
 };
 
 /**
  * @brief Initialize the download client.
+ *
+ * This function can only be called once in each client instance as
+ * it starts the background thread.
  *
  * @param[in] client	Client instance.
  * @param[in] callback	Callback function.
@@ -196,7 +205,7 @@ int download_client_init(struct download_client *client,
 			 download_client_callback_t callback);
 
 /**
- * @brief Establish a connection to the server.
+ * @brief Set a target hostname.
  *
  * @param[in] client	Client instance.
  * @param[in] host	Name of the host to connect to, null-terminated.
@@ -206,9 +215,24 @@ int download_client_init(struct download_client *client,
  *
  * @retval int Zero on success, a negative error code otherwise.
  */
-int download_client_connect(struct download_client *client, const char *host,
+int download_client_set_host(struct download_client *client, const char *host,
 			    const struct download_client_cfg *config);
 
+/**
+ * @brief Set a target hostname.
+ *
+ * @deprecated Use download_client_set_host() instead.
+ *
+ * @param[in] client	Client instance.
+ * @param[in] host	Name of the host to connect to, null-terminated.
+ *			Can include scheme and port number, defaults to
+ *			HTTP or HTTPS if no scheme is provided.
+ * @param[in] config	Configuration options.
+ *
+ * @retval int Zero on success, a negative error code otherwise.
+ */
+__deprecated int download_client_connect(struct download_client *client, const char *host,
+			    const struct download_client_cfg *config);
 /**
  * @brief Download a file.
  *
@@ -262,6 +286,34 @@ int download_client_file_size_get(struct download_client *client, size_t *size);
  * @return Zero on success, a negative error code otherwise.
  */
 int download_client_disconnect(struct download_client *client);
+
+/**
+ * @brief Download a file asynchronously.
+ *
+ * This initiates an asynchronous connect-download-disconnect sequence to the target
+ * host. When only one file is required form a target server, it can be used instead of
+ * separate calls to download_client_set_host(), download_client_start()
+ * and download_client_disconnect().
+ *
+ * The download is carried out in fragments of up to
+ * @kconfig{CONFIG_DOWNLOAD_CLIENT_HTTP_FRAG_SIZE} bytes for HTTP, or
+ * @kconfig{CONFIG_DOWNLOAD_CLIENT_COAP_BLOCK_SIZE} bytes for CoAP,
+ * which are delivered to the application
+ * through @ref DOWNLOAD_CLIENT_EVT_FRAGMENT events.
+ *
+ * @param[in] client	Client instance.
+ * @param[in] host	Name of the host to connect to, null-terminated.
+ *			Can include scheme and port number, defaults to
+ *			HTTP or HTTPS if no scheme is provided.
+ * @param[in] config	Configuration options.
+ * @param[in] file	File to download, null-terminated.
+ * @param[in] from	Offset from where to resume the download,
+ *			or zero to download from the beginning.
+ *
+ * @retval int Zero on success, a negative error code otherwise.
+ */
+int download_client_get(struct download_client *client, const char *host,
+			const struct download_client_cfg *config, const char *file, size_t from);
 
 #ifdef __cplusplus
 }

--- a/include/net/download_client.h
+++ b/include/net/download_client.h
@@ -296,11 +296,11 @@ int download_client_disconnect(struct download_client *client);
  * through @ref DOWNLOAD_CLIENT_EVT_FRAGMENT events.
  *
  * @param[in] client	Client instance.
- * @param[in] host	Name of the host to connect to, null-terminated.
- *			Can include scheme and port number, defaults to
+ * @param[in] host	URI of the host to connect to.
+ *			Can include scheme, port number and full file path, defaults to
  *			HTTP or HTTPS if no scheme is provided.
  * @param[in] config	Configuration options.
- * @param[in] file	File to download, null-terminated.
+ * @param[in] file	File to download or NULL if path is already provided in host parameter.
  * @param[in] from	Offset from where to resume the download,
  *			or zero to download from the beginning.
  *

--- a/include/net/fota_download.h
+++ b/include/net/fota_download.h
@@ -29,6 +29,9 @@ extern "C" {
 
 /**
  * @brief FOTA download event IDs.
+ *
+ * After FINISHED, ERROR or CANCELLED event, the FOTA client is ready to
+ * accept new request.
  */
 enum fota_download_evt_id {
 	/** FOTA download progress report. */
@@ -127,6 +130,9 @@ int fota_download_start(const char *host, const char *file, int sec_tag,
  *
  * When the download is complete, the secondary slot of MCUboot is tagged as having
  * valid firmware inside it. The completion is reported through an event.
+ *
+ * URI parameters (host and file) are not copied, so pointers must stay valid
+ * until download is finished.
  *
  * @param host Name of host to start downloading from. Can include scheme
  *             and port number, for example https://google.com:443

--- a/lib/bin/lwm2m_carrier/os/lwm2m_os.c
+++ b/lib/bin/lwm2m_carrier/os/lwm2m_os.c
@@ -512,7 +512,7 @@ int lwm2m_os_download_connect(const char *host, const struct lwm2m_os_download_c
 		.pdn_id = cfg->pdn_id,
 	};
 
-	return download_client_connect(&http_downloader, host, &config);
+	return download_client_set_host(&http_downloader, host, &config);
 }
 
 int lwm2m_os_download_disconnect(void)

--- a/samples/nrf9160/download/src/main.c
+++ b/samples/nrf9160/download/src/main.c
@@ -164,6 +164,10 @@ static int callback(const struct download_client_evt *event)
 			/* Stop download */
 			return -1;
 		}
+		break;
+	case DOWNLOAD_CLIENT_EVT_CLOSED:
+		printk("Socket closed\n");
+		break;
 	}
 
 	return 0;

--- a/samples/nrf9160/download/src/main.c
+++ b/samples/nrf9160/download/src/main.c
@@ -197,7 +197,6 @@ int main(void)
 	}
 
 	printk("OK\n");
-
 	err = download_client_init(&downloader, callback);
 	if (err) {
 		printk("Failed to initialize the client, err %d", err);
@@ -209,15 +208,9 @@ int main(void)
 	mbedtls_sha256_starts(&sha256_ctx, false);
 #endif
 
-	err = download_client_connect(&downloader, URL, &config);
-	if (err) {
-		printk("Failed to connect, err %d", err);
-		return 0;
-	}
-
 	ref_time = k_uptime_get();
 
-	err = download_client_start(&downloader, URL, STARTING_OFFSET);
+	err = download_client_get(&downloader, URL, &config, URL, STARTING_OFFSET);
 	if (err) {
 		printk("Failed to start the downloader, err %d", err);
 		return 0;

--- a/subsys/net/lib/download_client/Kconfig
+++ b/subsys/net/lib/download_client/Kconfig
@@ -127,6 +127,7 @@ config DOWNLOAD_CLIENT_COAP_MAX_RETRANSMIT_REQUEST_COUNT
 
 config DOWNLOAD_CLIENT_RANGE_REQUESTS
 	bool "Always use HTTP Range requests"
+	default y
 	help
 	  Always use HTTP Range requests when downloading (RFC 7233).
 	  This option can be useful to limit the amount of incoming data from the server

--- a/subsys/net/lib/download_client/src/coap.c
+++ b/subsys/net/lib/download_client/src/coap.c
@@ -87,10 +87,10 @@ int coap_initiate_retransmission(struct download_client *dl)
 	return 0;
 }
 
-int coap_block_update(struct download_client *client, struct coap_packet *pkt, size_t *blk_off)
+static int coap_block_update(struct download_client *client, struct coap_packet *pkt,
+			     size_t *blk_off, bool *more)
 {
 	int err, new_current;
-	bool more;
 
 	*blk_off = client->coap.block_ctx.current %
 		   coap_block_size_to_bytes(client->coap.block_ctx.block_size);
@@ -108,7 +108,7 @@ int coap_block_update(struct download_client *client, struct coap_packet *pkt, s
 	if (new_current < client->coap.block_ctx.current) {
 		LOG_WRN("Block out of order %d, expected %d", new_current,
 			client->coap.block_ctx.current);
-		return 1;
+		return -1;
 	} else if (new_current > client->coap.block_ctx.current) {
 		LOG_WRN("Block out of order %d, expected %d", new_current,
 			client->coap.block_ctx.current);
@@ -120,13 +120,13 @@ int coap_block_update(struct download_client *client, struct coap_packet *pkt, s
 		return err;
 	}
 
-	if (client->file_size == 0) {
+	if (client->file_size == 0 && client->coap.block_ctx.total_size > 0) {
 		LOG_DBG("Total size: %d", client->coap.block_ctx.total_size);
 		client->file_size = client->coap.block_ctx.total_size;
 	}
 
-	more = coap_next_block(pkt, &client->coap.block_ctx);
-	if (!more) {
+	*more = coap_next_block(pkt, &client->coap.block_ctx);
+	if (!*more) {
 		LOG_DBG("Last block received");
 	}
 
@@ -141,6 +141,7 @@ int coap_parse(struct download_client *client, size_t len)
 	uint16_t payload_len;
 	const uint8_t *payload;
 	struct coap_packet response;
+	bool more;
 
 	/* TODO: currently we stop download on every error, but this is mostly not necessary
 	 * and we can just request the same block again using retry mechanism
@@ -152,7 +153,7 @@ int coap_parse(struct download_client *client, size_t len)
 		return -1;
 	}
 
-	err = coap_block_update(client, &response, &blk_off);
+	err = coap_block_update(client, &response, &blk_off, &more);
 	if (err) {
 		return err;
 	}
@@ -194,6 +195,11 @@ int coap_parse(struct download_client *client, size_t len)
 
 	client->offset += payload_len - blk_off;
 	client->progress += payload_len - blk_off;
+
+	if (!more) {
+		/* Mark the end, in case we did not know the total size */
+		client->file_size = client->progress;
+	}
 
 	return 0;
 }

--- a/subsys/net/lib/download_client/src/download_client.c
+++ b/subsys/net/lib/download_client/src/download_client.c
@@ -966,6 +966,10 @@ int download_client_get(struct download_client *client, const char *host,
 		return -EINVAL;
 	}
 
+	if (file == NULL) {
+		file = host;
+	}
+
 	k_mutex_lock(&client->mutex, K_FOREVER);
 
 	rc = download_client_set_host(client, host, config);

--- a/subsys/net/lib/download_client/src/download_client.c
+++ b/subsys/net/lib/download_client/src/download_client.c
@@ -658,6 +658,7 @@ int download_client_init(struct download_client *const client,
 		return -EINVAL;
 	}
 
+	memset(client, 0, sizeof(*client));
 	client->fd = -1;
 	client->callback = callback;
 	k_sem_init(&client->wait_for_download, 0, 1);
@@ -685,9 +686,9 @@ int download_client_connect(struct download_client *client, const char *host,
 		return -EINVAL;
 	}
 
-	if (client->fd != -1) {
+	if (client->fd != -1 || client->host) {
 		/* Already connected */
-		return 0;
+		return -EALREADY;
 	}
 
 	if (config->frag_size_override > CONFIG_DOWNLOAD_CLIENT_BUF_SIZE) {

--- a/subsys/net/lib/download_client/src/download_client.c
+++ b/subsys/net/lib/download_client/src/download_client.c
@@ -801,16 +801,7 @@ int download_client_get(struct download_client *client, const char *host,
 	}
 
 	return rc;
-}
 
-void download_client_pause(struct download_client *client)
-{
-	k_thread_suspend(client->tid);
-}
-
-void download_client_resume(struct download_client *client)
-{
-	k_thread_resume(client->tid);
 }
 
 int download_client_file_size_get(struct download_client *client, size_t *size)

--- a/subsys/net/lib/download_client/src/shell.c
+++ b/subsys/net/lib/download_client/src/shell.c
@@ -118,32 +118,6 @@ static int cmd_dc_set_host(const struct shell *shell, size_t argc, char **argv)
 	return 0;
 }
 
-static int cmd_dc_pause(const struct shell *shell, size_t argc, char **argv)
-{
-	if (argc != 1) {
-		shell_warn(shell, "usage: dc pause");
-		return 0;
-	}
-
-	download_client_pause(&downloader);
-	shell_print(shell, "Paused");
-
-	return 0;
-}
-
-static int cmd_dc_resume(const struct shell *shell, size_t argc, char **argv)
-{
-	if (argc != 1) {
-		shell_warn(shell, "usage: dc resume");
-		return 0;
-	}
-
-	download_client_resume(&downloader);
-	shell_print(shell, "Resuming");
-
-	return 0;
-}
-
 static int cmd_dc_download(const struct shell *shell, size_t argc, char **argv)
 {
 	int err;
@@ -208,8 +182,6 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_dc,
 	SHELL_CMD(disconnect, NULL, "Disconnect from a host",
 		  cmd_dc_disconnect),
 	SHELL_CMD(download, NULL, "Download a file", cmd_dc_download),
-	SHELL_CMD(pause, NULL, "Pause download", cmd_dc_pause),
-	SHELL_CMD(resume, NULL, "Resume download", cmd_dc_resume),
 	SHELL_CMD(get, NULL, "Download", cmd_dc_get),
 	SHELL_SUBCMD_SET_END
 );

--- a/subsys/net/lib/download_client/src/shell.c
+++ b/subsys/net/lib/download_client/src/shell.c
@@ -53,6 +53,9 @@ static int callback(const struct download_client_evt *event)
 			    event->error);
 		downloaded = 0;
 		break;
+	case DOWNLOAD_CLIENT_EVT_CLOSED:
+		shell_print(shell_instance, "socket closed");
+		break;
 	}
 	return 0;
 }

--- a/subsys/net/lib/download_client/src/shell.c
+++ b/subsys/net/lib/download_client/src/shell.c
@@ -144,16 +144,24 @@ static int cmd_dc_get(const struct shell *shell, size_t argc, char **argv)
 {
 	int err;
 	size_t from = 0;
+	char *f = file;
 
-	if (argc < 3) {
-		shell_warn(shell, "usage: dc get <url> <file> [offset]");
+	if (argc < 2) {
+		shell_warn(shell, "usage: dc get <url> [<file>|NULL] [offset]");
 		return -EINVAL;
 	}
 
 	shell_instance = shell;
 
 	memcpy(host, argv[1], MIN(strlen(argv[1]) + 1, sizeof(host)));
-	memcpy(file, argv[2], MIN(strlen(argv[2]) + 1, sizeof(file)));
+	if (argc > 2) {
+		memcpy(file, argv[2], MIN(strlen(argv[2]) + 1, sizeof(file)));
+		if (strstr(file, "NULL")) {
+			f = NULL;
+		}
+	} else {
+		f = NULL;
+	}
 
 	if (argc > 3) {
 		errno = 0;
@@ -164,7 +172,8 @@ static int cmd_dc_get(const struct shell *shell, size_t argc, char **argv)
 		}
 	}
 
-	err = download_client_get(&downloader, host, &config, file, from);
+
+	err = download_client_get(&downloader, host, &config, f, from);
 
 	if (err) {
 		shell_warn(shell, "download_client_get() failed, err %d",

--- a/subsys/net/lib/download_client/src/shell.c
+++ b/subsys/net/lib/download_client/src/shell.c
@@ -96,7 +96,7 @@ static int cmd_dc_config_sec_tag(const struct shell *shell, size_t argc,
 	return 0;
 }
 
-static int cmd_dc_connect(const struct shell *shell, size_t argc, char **argv)
+static int cmd_dc_set_host(const struct shell *shell, size_t argc, char **argv)
 {
 	int err;
 
@@ -109,12 +109,10 @@ static int cmd_dc_connect(const struct shell *shell, size_t argc, char **argv)
 
 	memcpy(host, argv[1], MIN(strlen(argv[1]) + 1, sizeof(host)));
 
-	err = download_client_connect(&downloader, host, &config);
+	err = download_client_set_host(&downloader, host, &config);
 	if (err) {
-		shell_warn(shell, "download_client_connect() failed, err %d",
+		shell_warn(shell, "download_client_set_host() failed, err %d",
 			   err);
-	} else {
-		shell_print(shell, "Connected");
 	}
 
 	return 0;
@@ -167,6 +165,31 @@ static int cmd_dc_download(const struct shell *shell, size_t argc, char **argv)
 	return 0;
 }
 
+static int cmd_dc_get(const struct shell *shell, size_t argc, char **argv)
+{
+	int err;
+
+	if (argc != 3) {
+		shell_warn(shell, "usage: dc get <url> <file>");
+		return 0;
+	}
+
+	shell_instance = shell;
+
+	memcpy(host, argv[1], MIN(strlen(argv[1]) + 1, sizeof(host)));
+	memcpy(file, argv[2], MIN(strlen(argv[1]) + 1, sizeof(file)));
+
+	err = download_client_get(&downloader, host, &config, file, 0);
+
+	if (err) {
+		shell_warn(shell, "download_client_get() failed, err %d",
+			   err);
+	} else {
+		shell_print(shell, "Downloading");
+	}
+	return 0;
+}
+
 static int cmd_dc_disconnect(const struct shell *shell, size_t argc,
 			     char **argv)
 {
@@ -181,12 +204,13 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_config,
 
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_dc,
 	SHELL_CMD(config, &sub_config, "Configure", cmd_dc_config),
-	SHELL_CMD(connect, NULL, "Connect to a host", cmd_dc_connect),
+	SHELL_CMD(set_host, NULL, "Set a target host", cmd_dc_set_host),
 	SHELL_CMD(disconnect, NULL, "Disconnect from a host",
 		  cmd_dc_disconnect),
 	SHELL_CMD(download, NULL, "Download a file", cmd_dc_download),
 	SHELL_CMD(pause, NULL, "Pause download", cmd_dc_pause),
 	SHELL_CMD(resume, NULL, "Resume download", cmd_dc_resume),
+	SHELL_CMD(get, NULL, "Download", cmd_dc_get),
 	SHELL_SUBCMD_SET_END
 );
 

--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -277,14 +277,7 @@ static void download_with_offset(struct k_work *unused)
 		return;
 	}
 
-	err = download_client_connect(&dlc, dlc.host, &dlc.config);
-	if (err != 0) {
-		LOG_ERR("%s failed to connect with error %d", __func__, err);
-		send_error_evt(FOTA_DOWNLOAD_ERROR_CAUSE_DOWNLOAD_FAILED);
-		return;
-	}
-
-	err = download_client_start(&dlc, dlc.file, offset);
+	err = download_client_get(&dlc, dlc.host, &dlc.config, dlc.file, offset);
 	if (err != 0) {
 		LOG_ERR("%s failed to start download  with error %d", __func__,
 			err);
@@ -427,14 +420,9 @@ int fota_download_start_with_image_type(const char *host, const char *file,
 	}
 #endif /* PM_S1_ADDRESS */
 
-	err = download_client_connect(&dlc, host, &config);
-	if (err != 0) {
-		return err;
-	}
-
 	img_type_expected = expected_type;
 
-	err = download_client_start(&dlc, file_buf_ptr, 0);
+	err = download_client_get(&dlc, host, &config, file_buf_ptr, 0);
 	if (err != 0) {
 		download_client_disconnect(&dlc);
 		return err;

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps_utils.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps_utils.c
@@ -476,12 +476,7 @@ int npgps_download_start(const char *host, const char *file, int sec_tag,
 		.set_tls_hostname = (sec_tag != -1),
 	};
 
-	err = download_client_connect(&dlc, host, &config);
-	if (err != 0) {
-		return err;
-	}
-
-	err = download_client_start(&dlc, file, 0);
+	err = download_client_get(&dlc, host, &config, file, 0);
 	if (err != 0) {
 		download_client_disconnect(&dlc);
 		return err;

--- a/tests/subsys/net/lib/download_client/src/main.c
+++ b/tests/subsys/net/lib/download_client/src/main.c
@@ -14,6 +14,7 @@
 #include "mock/dl_coap.h"
 
 static enum download_client_evt_id last_event = -1;
+static struct download_client client;
 
 static int download_client_callback(const struct download_client_evt *event)
 {
@@ -21,17 +22,7 @@ static int download_client_callback(const struct download_client_evt *event)
 		return -EINVAL;
 	}
 
-	switch (event->id) {
-	case DOWNLOAD_CLIENT_EVT_FRAGMENT:
-		last_event = DOWNLOAD_CLIENT_EVT_FRAGMENT;
-		break;
-	case DOWNLOAD_CLIENT_EVT_DONE:
-		last_event = DOWNLOAD_CLIENT_EVT_DONE;
-		break;
-	case DOWNLOAD_CLIENT_EVT_ERROR:
-		last_event = DOWNLOAD_CLIENT_EVT_ERROR;
-		break;
-	}
+	last_event = event->id;
 
 	return 0;
 }
@@ -78,20 +69,23 @@ static struct download_client_cfg config = {
 	.frag_size_override = 0,
 };
 
-static void dl_coap_start(struct download_client *client)
+static void dl_coap_start(void)
 {
 	static const char host[] = "coap://10.1.0.10";
+	static bool initialized;
 	int err;
 
-	memset(client, 0, sizeof(struct download_client));
+	if (!initialized) {
+		memset(&client, 0, sizeof(struct download_client));
+		err = download_client_init(&client, download_client_callback);
+		zassert_ok(err, NULL);
+		initialized = true;
+	}
 
-	err = download_client_init(client, download_client_callback);
+	err = download_client_set_host(&client, host, &config);
 	zassert_ok(err, NULL);
 
-	err = download_client_set_host(client, host, &config);
-	zassert_ok(err, NULL);
-
-	err = download_client_start(client, "no.file", 0);
+	err = download_client_start(&client, "no.file", 0);
 	zassert_ok(err, NULL);
 }
 
@@ -101,11 +95,12 @@ static void de_init(struct download_client *client)
 
 	err = download_client_disconnect(client);
 	zassert_ok(err, NULL);
+
+	wait_for_event(DOWNLOAD_CLIENT_EVT_CLOSED, 10);
 }
 
 static void test_download_simple(void)
 {
-	struct download_client client;
 	int32_t recvfrom_params[] = { 25, 25, 25 };
 	int32_t sendto_params[] = { 20, 20, 20 };
 
@@ -115,7 +110,7 @@ static void test_download_simple(void)
 			   ARRAY_SIZE(recvfrom_params));
 	mock_return_values("mock_socket_offload_sendto", sendto_params, ARRAY_SIZE(sendto_params));
 
-	dl_coap_start(&client);
+	dl_coap_start();
 
 	zassert_ok(wait_for_event(DOWNLOAD_CLIENT_EVT_DONE, 10), "Download must have finished");
 
@@ -124,7 +119,6 @@ static void test_download_simple(void)
 
 static void test_download_reconnect_on_socket_error(void)
 {
-	struct download_client client;
 	int32_t recvfrom_params[] = { 25, -1, 25, 25 };
 	int32_t sendto_params[] = { 20, 20, 20, 20 };
 
@@ -134,7 +128,7 @@ static void test_download_reconnect_on_socket_error(void)
 			   ARRAY_SIZE(recvfrom_params));
 	mock_return_values("mock_socket_offload_sendto", sendto_params, ARRAY_SIZE(sendto_params));
 
-	dl_coap_start(&client);
+	dl_coap_start();
 
 	zassert_ok(wait_for_event(DOWNLOAD_CLIENT_EVT_DONE, 10), "Download must have finished");
 
@@ -143,7 +137,6 @@ static void test_download_reconnect_on_socket_error(void)
 
 static void test_download_reconnect_on_peer_close(void)
 {
-	struct download_client client;
 	int32_t recvfrom_params[] = { 25, 0, 25, 25 };
 	int32_t sendto_params[] = { 20, 20, 20, 20 };
 
@@ -153,7 +146,7 @@ static void test_download_reconnect_on_peer_close(void)
 			   ARRAY_SIZE(recvfrom_params));
 	mock_return_values("mock_socket_offload_sendto", sendto_params, ARRAY_SIZE(sendto_params));
 
-	dl_coap_start(&client);
+	dl_coap_start();
 
 	zassert_ok(wait_for_event(DOWNLOAD_CLIENT_EVT_DONE, 10), "Download must have finished");
 
@@ -162,7 +155,6 @@ static void test_download_reconnect_on_peer_close(void)
 
 static void test_download_ignore_duplicate_block(void)
 {
-	struct download_client client;
 	int32_t recvfrom_params[] = { 25, 25, 25, 25 };
 	int32_t sendto_params[] = { 20, 20, 20 };
 	int32_t coap_parse_retv[] = { 0, 0, 1, 0 };
@@ -175,7 +167,7 @@ static void test_download_ignore_duplicate_block(void)
 	mock_return_values("coap_parse", coap_parse_retv, ARRAY_SIZE(coap_parse_retv));
 	override_return_values.func_coap_parse = true;
 
-	dl_coap_start(&client);
+	dl_coap_start();
 
 	zassert_ok(wait_for_event(DOWNLOAD_CLIENT_EVT_DONE, 10), "Download must have finished");
 
@@ -184,7 +176,6 @@ static void test_download_ignore_duplicate_block(void)
 
 static void test_download_abort_on_invalid_block(void)
 {
-	struct download_client client;
 	int32_t recvfrom_params[] = { 25, 25, 25 };
 	int32_t sendto_params[] = { 20, 20, 20 };
 	int32_t coap_parse_retv[] = { 0, 0, -1 };
@@ -197,11 +188,29 @@ static void test_download_abort_on_invalid_block(void)
 	mock_return_values("coap_parse", coap_parse_retv, ARRAY_SIZE(coap_parse_retv));
 	override_return_values.func_coap_parse = true;
 
-	dl_coap_start(&client);
+	dl_coap_start();
 
 	zassert_ok(wait_for_event(DOWNLOAD_CLIENT_EVT_ERROR, 10), "Download must be on error");
 
 	de_init(&client);
+}
+
+static void test_get(void)
+{
+	int err;
+	int32_t recvfrom_params[] = { 25, 25, 25 };
+	int32_t sendto_params[] = { 20, 20, 20 };
+
+	dl_coap_init(75, 20);
+
+	mock_return_values("mock_socket_offload_recvfrom", recvfrom_params,
+			   ARRAY_SIZE(recvfrom_params));
+	mock_return_values("mock_socket_offload_sendto", sendto_params, ARRAY_SIZE(sendto_params));
+
+	err = download_client_get(&client, "coap://192.168.1.2/large", &config, NULL, 0);
+	zassert_ok(err, NULL);
+	zassert_ok(wait_for_event(DOWNLOAD_CLIENT_EVT_DONE, 10), "Download must have finished");
+	zassert_ok(wait_for_event(DOWNLOAD_CLIENT_EVT_CLOSED, 10), "Socket must have closed");
 }
 
 void test_main(void)
@@ -210,7 +219,8 @@ void test_main(void)
 			 ztest_unit_test(test_download_reconnect_on_socket_error),
 			 ztest_unit_test(test_download_reconnect_on_peer_close),
 			 ztest_unit_test(test_download_ignore_duplicate_block),
-			 ztest_unit_test(test_download_abort_on_invalid_block));
+			 ztest_unit_test(test_download_abort_on_invalid_block),
+			 ztest_unit_test(test_get));
 
 	ztest_run_test_suite(lib_fota_download_test);
 }

--- a/tests/subsys/net/lib/download_client/src/main.c
+++ b/tests/subsys/net/lib/download_client/src/main.c
@@ -88,7 +88,7 @@ static void dl_coap_start(struct download_client *client)
 	err = download_client_init(client, download_client_callback);
 	zassert_ok(err, NULL);
 
-	err = download_client_connect(client, host, &config);
+	err = download_client_set_host(client, host, &config);
 	zassert_ok(err, NULL);
 
 	err = download_client_start(client, "no.file", 0);

--- a/tests/subsys/net/lib/fota_download/src/test_fota_download.c
+++ b/tests/subsys/net/lib/fota_download/src/test_fota_download.c
@@ -115,7 +115,7 @@ int download_client_init(struct download_client *client,
 	return 0;
 }
 
-int download_client_connect(struct download_client *client, const char *host,
+int download_client_set_host(struct download_client *client, const char *host,
 			    const struct download_client_cfg *config)
 {
 	if (fail_on_connect == true) {
@@ -123,6 +123,29 @@ int download_client_connect(struct download_client *client, const char *host,
 	}
 	/* Mark connection */
 	client->fd = 1;
+
+	return 0;
+}
+
+int download_client_get(struct download_client *client, const char *host,
+			const struct download_client_cfg *config, const char *file, size_t from)
+{
+	if (fail_on_connect == true) {
+		return -1;
+	}
+	/* Mark connection */
+	client->fd = 1;
+
+	download_client_start_file = file;
+
+	if (fail_on_start == true) {
+		return -1;
+	}
+
+	if (from == ARBITRARY_IMAGE_OFFSET) {
+		download_with_offset_success = true;
+		k_sem_give(&download_with_offset_sem);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
### Refactor API for non-blocking support
    
* Don't block on download_client_connect() or download_client_disconnect()
* Refactor download_client_connect() to download_client_set_host()
  so the name indicates that it does not yet initiate anything.
* Add function download_client_get() that combines set_host,
  start and disconnect.
* Do all name queries and socket connections in the background
  thread.
* Add new event `DOWNLOAD_CLIENT_EVT_CLOSED` to indicate that background thread has closed the connection and new download can be started.
    
Now there are two options to use this API:
1. set_host() and call start() for multiple files,
   and finally call disconnect().
2. Call get().
    
On both cases, init() should only be called once.
* Both cycles can be repeated.
* Both use cases can be stopped/aborted by disconnect().

### Refactor the handler loop 

* Add mutexes to protect internal state
* Refactor the handling loop so there is no "goto". This should lead to more maintainable code. I had hard time understanding the request-loop and its many corner cases. It should be clearer now.
* Various minor fixes

### Remove pause and resume
    
Pause and resume are non thread safe operations and
there are no use for them as we can just disconnect
and resume with offset.

### Various fixes

* Return -EALREADY if connect called twice
* download_client_disconnect() should be called before connecting again.
* Fix unranged HTTP GET
* Fix CoAP download ending
   For GET requests where we don't know the full size, we must
   use the last_block marker and end the transfer at that point.

