### PR TITLE
ext: iperf3: fix for the mosh background threading usage

### DIFF
--- a/ext/iperf3/iperf_tcp.c
+++ b/ext/iperf3/iperf_tcp.c
@@ -142,7 +142,8 @@ iperf_tcp_send(struct iperf_stream *sp)
 
 #else
 	    /* 64bit variable printing is not working */
-        printf("sent %d bytes of %d, total %d\n", r, sp->settings->blksize, (uint32_t)sp->result->bytes_sent);
+        iperf_printf(sp->test, "sent %d bytes of %d, total %d\n",
+                        r, sp->settings->blksize, (uint32_t)sp->result->bytes_sent);
 #endif        
     }
     return r;


### PR DESCRIPTION
One of the tcp uplink debug prints were printed to foreground because iperf_print() wasn't used.

Jira: MOSH-417