### PR TITLE
net: lib: nrf_cloud: include service info in device status encoding

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -356,6 +356,10 @@ Libraries for networking
 
     * The old API ``lwm2m_firmware_get_update_state_cb()``.
 
+  * Updated:
+
+    * The :c:func:`nrf_cloud_device_status_msg_encode` function now includes the service info when encoding the device status.
+
 Libraries for NFC
 -----------------
 

--- a/include/net/nrf_cloud_rest.h
+++ b/include/net/nrf_cloud_rest.h
@@ -387,8 +387,7 @@ int nrf_cloud_rest_send_location(struct nrf_cloud_rest_context *const rest_ctx,
 
 /**
  * @brief Send the device status to nRF Cloud as a device message. In addition to standard
- * message storage, the data (excluding nrf_cloud_svc_info) will also be stored in the
- * device's shadow.
+ * message storage, the data will also be stored in the device's shadow.
  *
  * @param[in,out] rest_ctx Context for communicating with nRF Cloud's REST API.
  * @param[in]     device_id Null-terminated, unique device ID registered with nRF Cloud.

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec.c
@@ -1639,11 +1639,7 @@ int nrf_cloud_device_status_msg_encode(const struct nrf_cloud_device_status *con
 		}
 	}
 
-	/* For now, exclude dev_status->svc since the info is not useful in a device message.
-	 * This can be included when support for writing serviceInfo to the shadow from DEVICE
-	 * messages is added: IRIS-5448
-	 */
-	err = info_encode(data_obj, dev_status->modem, NULL);
+	err = info_encode(data_obj, dev_status->modem, dev_status->svc);
 
 	return err;
 }

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fsm.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fsm.c
@@ -476,7 +476,7 @@ static int cc_rx_data_handler(const struct nct_evt *nct_evt)
 	bool control_found = false;
 	const enum nfsm_state current_state = nfsm_get_current_state();
 
-	LOG_INF("CC RX on topic %s: %s",
+	LOG_DBG("CC RX on topic %s: %s",
 		(const char *)nct_evt->param.cc->topic.ptr,
 		(const char *)nct_evt->param.cc->data.ptr);
 	handle_device_config_update(nct_evt, &config_found);


### PR DESCRIPTION
Add the service info when encoding a device status message. 
nRF Cloud now supports writing the service info to the device's shadow.
IRIS-5481