### PR TITLE
Fix undeclared struct when security is disabled

### DIFF
--- a/samples/bluetooth/peripheral_hids_mouse/src/main.c
+++ b/samples/bluetooth/peripheral_hids_mouse/src/main.c
@@ -639,6 +639,7 @@ static struct bt_conn_auth_info_cb conn_auth_info_callbacks = {
 };
 #else
 static struct bt_conn_auth_cb conn_auth_callbacks;
+static struct bt_conn_auth_info_cb conn_auth_info_callbacks;
 #endif
 
 


### PR DESCRIPTION
When compiling this example I needed to make this modification for it to work. Security option was disabled in Kconfig.