### PR TITLE
bluetooth: hids: Change HID report map size from uint8_t to uint16_t

### DIFF
--- a/include/bluetooth/services/hids.h
+++ b/include/bluetooth/services/hids.h
@@ -340,7 +340,7 @@ struct bt_hids_rep_map {
 	uint8_t const *data;
 
 	/** Size of the map. */
-	uint8_t size;
+	uint16_t size;
 };
 
 /** @brief HID Protocol Mode event handler.


### PR DESCRIPTION
In the bluetooth HID service, the size of a report descriptor is held by a `uint8_t`, which means that any report descriptors can only have 255 bytes at most. Most practical applications of report descriptors demand a more complex structure that far exceed that length. This change increases that limit to an `uint16_t`.

I don't see any reason why this field has to be an uint8_t. In my testing using a nrf52833_dk I have not seen any issues with the change.