### PR TITLE
applications: asset_tracker_v2: Disable logger for printk()

### DIFF
--- a/applications/asset_tracker_v2/overlay-debug.conf
+++ b/applications/asset_tracker_v2/overlay-debug.conf
@@ -19,6 +19,10 @@ CONFIG_LOG_MAX_LEVEL=4
 # Increase log buffer size to prevent logs being dropped.
 CONFIG_LOG_BUFFER_SIZE=2048
 
+# Disable routing of printk() through the logging subsystem.
+# This is a workaround to ensure that long strings are printed properly.
+CONFIG_LOG_PRINTK=n
+
 # Module debug configurations.
 CONFIG_APPLICATION_MODULE_LOG_LEVEL_DBG=y
 CONFIG_CLOUD_MODULE_LOG_LEVEL_DBG=y


### PR DESCRIPTION
Disable the use of the logging sybsystem for printk(). This is done as a workaround for an issue where long strings may not be printed properly.
The downside of this solution, is that prints done using printk() may be out of sync with those printed with the logger in deferred mode.

Fixes CIA-892