### PR TITLE
net: lib: nrf_cloud: fix A-GPS data error handling

### DIFF
--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_agps.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_agps.c
@@ -551,6 +551,7 @@ static size_t get_next_agps_element(struct nrf_cloud_apgs_element *element,
 		break;
 	default:
 		LOG_DBG("Unhandled A-GPS data type: %d", element->type);
+		elements_left_to_process = 0;
 		return 0;
 	}
 


### PR DESCRIPTION
If parsing A-GPS data failed once, further attempts to parse A-GPS data also failed even if the data was correct.