### PR TITLE
lib: nrf_modem: do not reset poll signals

### DIFF
--- a/lib/nrf_modem_lib/nrf91_sockets.c
+++ b/lib/nrf_modem_lib/nrf91_sockets.c
@@ -803,7 +803,6 @@ static struct nrf_sock_ctx *find_ctx(int fd)
 
 static void pollcb(struct nrf_pollfd *pollfd)
 {
-	int flags;
 	struct nrf_sock_ctx *ctx;
 
 	ctx = find_ctx(pollfd->fd);
@@ -811,27 +810,7 @@ static void pollcb(struct nrf_pollfd *pollfd)
 		return;
 	}
 
-	if (pollfd->revents & NRF_POLLNVAL) {
-		flags = ZSOCK_POLLNVAL;
-		goto signal;
-	}
-
-	flags = 0;
-	if ((pollfd->revents & NRF_POLLIN) && (pollfd->events & NRF_POLLIN)) {
-		flags |= ZSOCK_POLLIN;
-	}
-	if ((pollfd->revents & NRF_POLLOUT) && (pollfd->events & NRF_POLLOUT)) {
-		flags |= ZSOCK_POLLOUT;
-	}
-	if (pollfd->revents & NRF_POLLHUP) {
-		flags |= ZSOCK_POLLHUP;
-	}
-	if (pollfd->revents & NRF_POLLERR) {
-		flags |= ZSOCK_POLLERR;
-	}
-
-signal:
-	k_poll_signal_raise(&ctx->poll, flags);
+	k_poll_signal_raise(&ctx->poll, pollfd->revents);
 }
 
 static int nrf91_poll_prepare(struct nrf_sock_ctx *ctx, struct zsock_pollfd *pfd,
@@ -892,7 +871,6 @@ static int nrf91_poll_update(struct nrf_sock_ctx *ctx, struct zsock_pollfd *pfd,
 	}
 
 	pfd->revents = flags;
-	k_poll_signal_reset(&ctx->poll);
 
 	return 0;
 }


### PR DESCRIPTION
Don't reset poll signals on `ZFD_IOCTL_POLL_UPDATE`, it is not what we are supposed to do there. Just report the flags instead.

Simplify the poll callback logic, and simply raise the flags as reported by `revents`. Those are set only if they were set in `events` to begin with, or they are `POLLHUP`/`POLLERR`/`POLLNVAL` in which case we must report them unconditionally.

The ZSOCK_POLL values are build-asserted against NRF_POLL values.