### PR TITLE
applications: nrf_desktop: Handle update images with unaligned size

### DIFF
--- a/applications/nrf_desktop/src/modules/Kconfig.config_channel
+++ b/applications/nrf_desktop/src/modules/Kconfig.config_channel
@@ -57,8 +57,13 @@ comment "DFU"
 config DESKTOP_CONFIG_CHANNEL_DFU_ENABLE
 	bool "DFU over the config channel"
 	depends on DESKTOP_CONFIG_CHANNEL_ENABLE
+	select SOC_FLASH_NRF_EMULATE_ONE_BYTE_WRITE_ACCESS if \
+	       !PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY
 	help
 	  This option enables DFU over the config channel.
+	  The option automatically enables 8-bit write block size emulation to
+	  ensure that update images with size unaligned to word size can be
+	  handled while writing to SoC FLASH.
 
 if DESKTOP_CONFIG_CHANNEL_DFU_ENABLE
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -154,7 +154,8 @@ nRF Machine Learning (Edge Impulse)
 nRF Desktop
 -----------
 
-|no_changes_yet_note|
+* The :ref:`nrf_desktop_dfu` automatically enables 8-bit write block size emulation (:kconfig:option:`CONFIG_SOC_FLASH_NRF_EMULATE_ONE_BYTE_WRITE_ACCESS`) to ensure that update images with sizes unaligned to word size can be successfully stored in the internal FLASH.
+  The feature is not enabled if the MCUboot bootloader is used and the secondary slot is placed in an external FLASH (when :kconfig:option:`CONFIG_PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY` is enabled).
 
 Samples
 =======


### PR DESCRIPTION
Change enables 8-bit write block size emulation to ensure that update images with size unaligned to word size can be handled while writing to SoC FLASH.

Jira: NCSDK-20085