### PR TITLE
scripts: sbom: Increase scancode license score threshold

### DIFF
--- a/scripts/west_commands/sbom/scancode_toolkit_detector.py
+++ b/scripts/west_commands/sbom/scancode_toolkit_detector.py
@@ -37,6 +37,7 @@ def run_scancode(file: FileInfo) -> 'set(str)':
         command_execute(args.scancode, '-cl',
                         '--json', output_file.name,
                         '--license-text',
+                        '--license-score', '100',
                         '--license-text-diagnostics',
                         '--quiet',
                         file.file_path, allow_stderr=True)


### PR DESCRIPTION
Scancode toolkit tries to guess the license type
in the source files. By default, any match (even
not precise) is reported. This behavior is not
good for us. We need to ensure fully matching
license.