### PR TITLE
tools: update nrf-connect-sdk-toolchain=2.3.0

### DIFF
--- a/scripts/ncs-toolchain-version-minimum.txt
+++ b/scripts/ncs-toolchain-version-minimum.txt
@@ -1,3 +1,3 @@
 # This file specifies the minimum nRF Connect SDK Toolchain that will be
 # working with this release.
-nrf-connect-sdk-toolchain=2.2.0
+nrf-connect-sdk-toolchain=2.3.0


### PR DESCRIPTION
In CI we are using toolchain-manager=0.11.0 which has index v3, but this isn't released publicly yet. 
nRF Connect for Desktop is what customers are using and still requires old bundles/index.
This is a key in the toolchain-manager index v2. 

We need new bundles named 2.3.0 to be created and stored in : 
https://developer.nordicsemi.com/.pc-tools/toolchain-v2/
before this PR can be merged. 