### PR TITLE
lib: nrf_modem: removal of deprecated functions

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -268,6 +268,11 @@ Modem libraries
 
 * :ref:`nrf_modem_lib_readme` library:
 
+  * Added:
+
+    * The function :c:func:`nrf_modem_lib_fault_strerror` to retrieve a statically allocated textual description of a given modem fault.
+      The function can be enabled using the new Kconfig option :kconfig:option:`CONFIG_NRF_MODEM_LIB_FAULT_STRERROR`.
+
   * Removed:
 
     * The deprecated function ``nrf_modem_lib_get_init_ret``.

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -271,6 +271,7 @@ Modem libraries
   * Removed:
 
     * The deprecated function ``nrf_modem_lib_get_init_ret``.
+    * The deprecated function ``nrf_modem_lib_shutdown_wait``.
 
 Libraries for networking
 ------------------------

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -273,6 +273,10 @@ Modem libraries
     * The function :c:func:`nrf_modem_lib_fault_strerror` to retrieve a statically allocated textual description of a given modem fault.
       The function can be enabled using the new Kconfig option :kconfig:option:`CONFIG_NRF_MODEM_LIB_FAULT_STRERROR`.
 
+  * Updated:
+
+    * The Kconfig option :kconfig:option:`CONFIG_NRF_MODEM_LIB_IPC_PRIO_OVERRIDE` is now deprecated.
+
   * Removed:
 
     * The deprecated function ``nrf_modem_lib_get_init_ret``.

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -272,6 +272,7 @@ Modem libraries
 
     * The deprecated function ``nrf_modem_lib_get_init_ret``.
     * The deprecated function ``nrf_modem_lib_shutdown_wait``.
+    * The deprecated Kconfig option ``CONFIG_NRF_MODEM_LIB_TRACE_ENABLED``.
 
 Libraries for networking
 ------------------------

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -266,7 +266,11 @@ Bootloader libraries
 Modem libraries
 ---------------
 
-|no_changes_yet_note|
+* :ref:`nrf_modem_lib_readme` library:
+
+  * Removed:
+
+    * The deprecated function ``nrf_modem_lib_get_init_ret``.
 
 Libraries for networking
 ------------------------

--- a/include/modem/nrf_modem_lib.h
+++ b/include/modem/nrf_modem_lib.h
@@ -132,17 +132,6 @@ struct nrf_modem_lib_shutdown_cb {
 __deprecated void nrf_modem_lib_shutdown_wait(void);
 
 /**
- * @brief Get the last return value of nrf_modem_lib_init.
- *
- * This function can be used to access the last return value of
- * nrf_modem_lib_init. This can be used to check the state of a modem
- * firmware exchange when the Modem library was initialized at boot-time.
- *
- * @return int The last return value of nrf_modem_lib_init.
- */
-__deprecated int nrf_modem_lib_get_init_ret(void);
-
-/**
  * @brief Shutdown the Modem library, releasing its resources.
  *
  * @return int Zero on success, non-zero otherwise.

--- a/include/modem/nrf_modem_lib.h
+++ b/include/modem/nrf_modem_lib.h
@@ -134,8 +134,17 @@ struct nrf_modem_lib_shutdown_cb {
  */
 void nrf_modem_fault_handler(struct nrf_modem_fault_info *fault_info);
 
-#if defined(CONFIG_NRF_MODEM_LIB_MEM_DIAG) || defined(__DOXYGEN__)
+#if defined(CONFIG_NRF_MODEM_LIB_FAULT_STRERROR) || defined(__DOXYGEN__)
+/**
+ * @brief Retrieve a statically allocated textual description of a given fault.
+ *
+ * @param fault The fault.
+ * @return const char* Textual description of the given fault.
+ */
+const char *nrf_modem_lib_fault_strerror(int fault);
+#endif
 
+#if defined(CONFIG_NRF_MODEM_LIB_MEM_DIAG) || defined(__DOXYGEN__)
 struct nrf_modem_lib_diag_stats {
 	struct {
 		struct sys_memory_stats heap;
@@ -146,7 +155,6 @@ struct nrf_modem_lib_diag_stats {
 		uint32_t failed_allocs;
 	} shmem;
 };
-
 /**
  * @brief Retrieve heap runtime statistics.
  *
@@ -155,8 +163,7 @@ struct nrf_modem_lib_diag_stats {
  * @return int Zero on success, non-zero otherwise.
  */
 int nrf_modem_lib_diag_stats_get(struct nrf_modem_lib_diag_stats *stats);
-
-#endif /* defined(CONFIG_NRF_MODEM_LIB_MEM_DIAG) || defined(__DOXYGEN__) */
+#endif
 
 /** @} */
 

--- a/include/modem/nrf_modem_lib.h
+++ b/include/modem/nrf_modem_lib.h
@@ -124,14 +124,6 @@ struct nrf_modem_lib_shutdown_cb {
 	};
 
 /**
- * @brief Makes a thread sleep until next time nrf_modem_lib_init() is called.
- *
- * When nrf_modem_lib_shutdown() is called a thread can call this function to be
- * woken up next time nrf_modem_lib_init() is called.
- */
-__deprecated void nrf_modem_lib_shutdown_wait(void);
-
-/**
  * @brief Shutdown the Modem library, releasing its resources.
  *
  * @return int Zero on success, non-zero otherwise.

--- a/lib/nrf_modem_lib/Kconfig.modemlib
+++ b/lib/nrf_modem_lib/Kconfig.modemlib
@@ -18,16 +18,6 @@ config NRF_MODEM_LIB_SYS_INIT
 	  Please note that initialization is synchronous and can take up to one
 	  minute in case the modem firmware is updated.
 
-DT_IPC := $(dt_nodelabel_path,ipc)
-config NRF_MODEM_LIB_IPC_IRQ_PRIO_OVERRIDE
-	bool "Override IPC IRQ priority"
-	help
-	  Override the IPC IRQ priority set in device tree
-
-config NRF_MODEM_LIB_IPC_IRQ_PRIO
-	int "IPC IRQ priority" if NRF_MODEM_LIB_IPC_IRQ_PRIO_OVERRIDE
-	default $(dt_node_array_prop_int,$(DT_IPC),interrupts,1) if !NRF_MODEM_LIB_IPC_IRQ_PRIO_OVERRIDE
-
 menu "Memory configuration"
 
 config NRF_MODEM_LIB_HEAP_SIZE
@@ -236,6 +226,11 @@ config NRF_MODEM_LIB_FAULT_STRERROR
 	  Compile a table with a textual description of fault reasons.
 	  The description can be retrieved with nrf_modem_lib_fault_strerror().
 
+DT_IPC := $(dt_nodelabel_path,ipc)
+config NRF_MODEM_LIB_IPC_IRQ_PRIO
+	int "IPC IRQ priority" if NRF_MODEM_LIB_IPC_IRQ_PRIO_OVERRIDE
+	default $(dt_node_array_prop_int,$(DT_IPC),interrupts,1) if !NRF_MODEM_LIB_IPC_IRQ_PRIO_OVERRIDE
+
 module = NRF_MODEM_LIB
 module-str = Modem library
 source "subsys/logging/Kconfig.template.log_config"
@@ -243,3 +238,11 @@ source "subsys/logging/Kconfig.template.log_config"
 config NRF_MODEM_LIB_LOG_FW_VERSION_UUID
 	depends on LOG
 	bool "Log FW version and UUID during initialization"
+
+comment "Deprecated"
+
+config NRF_MODEM_LIB_IPC_IRQ_PRIO_OVERRIDE
+	bool "Override IPC IRQ priority"
+	select DEPRECATED
+	help
+	  Override the IPC IRQ priority set in device tree

--- a/lib/nrf_modem_lib/Kconfig.modemlib
+++ b/lib/nrf_modem_lib/Kconfig.modemlib
@@ -230,6 +230,12 @@ config NRF_MODEM_LIB_ON_FAULT_APPLICATION_SPECIFIC
 
 endchoice # NRF_MODEM_LIB_ON_FAULT
 
+config NRF_MODEM_LIB_FAULT_STRERROR
+	bool "Compile fault reason table"
+	help
+	  Compile a table with a textual description of fault reasons.
+	  The description can be retrieved with nrf_modem_lib_fault_strerror().
+
 module = NRF_MODEM_LIB
 module-str = Modem library
 source "subsys/logging/Kconfig.template.log_config"

--- a/lib/nrf_modem_lib/Kconfig.modemlib
+++ b/lib/nrf_modem_lib/Kconfig.modemlib
@@ -18,104 +18,7 @@ config NRF_MODEM_LIB_SYS_INIT
 	  Please note that initialization is synchronous and can take up to one
 	  minute in case the modem firmware is updated.
 
-menuconfig NRF_MODEM_LIB_TRACE
-	bool "Tracing"
-	help
-	  When enabled, a portion of RAM (called Trace region) will be shared with the modem to receive modem's trace data.
-	  The size of the Trace region is defined by the NRF_MODEM_LIB_SHMEM_TRACE_SIZE option.
-	  Trace data is output on the chosen trace backend.
-
-if NRF_MODEM_LIB_TRACE
-
-# Add trace backends
-rsource "trace_backends/Kconfig"
-
-config NRF_MODEM_LIB_TRACE_STACK_SIZE
-	int "Modem trace thread stack size"
-	default 768 if SIZE_OPTIMIZATIONS
-	default 1024
-
-config NRF_MODEM_LIB_TRACE_LEVEL_OVERRIDE
-	bool "Override trace level"
-	default y
-
-if NRF_MODEM_LIB_TRACE_LEVEL_OVERRIDE
-
-choice NRF_MODEM_LIB_TRACE_LEVEL_CHOICE
-	prompt "Trace level"
-
-config NRF_MODEM_LIB_TRACE_LEVEL_FULL
-	bool "Full"
-config NRF_MODEM_LIB_TRACE_LEVEL_LTE_AND_IP
-	bool "IP and LTE"
-config NRF_MODEM_LIB_TRACE_LEVEL_IP_ONLY
-	bool "IP only"
-config NRF_MODEM_LIB_TRACE_LEVEL_COREDUMP_ONLY
-	bool "Coredump only"
-config NRF_MODEM_LIB_TRACE_LEVEL_OFF
-	bool "Off"
-
-endchoice
-
-config NRF_MODEM_LIB_TRACE_LEVEL
-	int
-	default 0 if NRF_MODEM_LIB_TRACE_LEVEL_OFF
-	default 1 if NRF_MODEM_LIB_TRACE_LEVEL_COREDUMP_ONLY
-	default 2 if NRF_MODEM_LIB_TRACE_LEVEL_FULL
-	default 4 if NRF_MODEM_LIB_TRACE_LEVEL_IP_ONLY
-	default 5 if NRF_MODEM_LIB_TRACE_LEVEL_LTE_AND_IP
-
-endif # NRF_MODEM_LIB_TRACE_LEVEL_OVERRIDE
-
-config NRF_MODEM_LIB_TRACE_THREAD_PRIO_OVERRIDE
-	bool "Override trace thread priority"
-
-config NRF_MODEM_LIB_TRACE_THREAD_PRIO
-	int "Priority of the trace processing thread"
-	depends on NRF_MODEM_LIB_TRACE_THREAD_PRIO_OVERRIDE
-	default 0
-
-config NRF_MODEM_LIB_TRACE_BACKEND_BITRATE
-	bool "Measure trace backend bitrate"
-
-if NRF_MODEM_LIB_TRACE_BACKEND_BITRATE
-
-config NRF_MODEM_LIB_TRACE_BACKEND_BITRATE_PERIOD_MS
-	int "Rolling interval where the bitrate is measured (millisec)"
-	default 1000
-
-config NRF_MODEM_LIB_TRACE_BACKEND_BITRATE_LOG
-	depends on LOG
-	bool "Log trace backend bitrate"
-
-if NRF_MODEM_LIB_TRACE_BACKEND_BITRATE_LOG
-
-config NRF_MODEM_LIB_TRACE_BACKEND_BITRATE_LOG_PERIOD_MS
-	int "Bitrate log interval (millisec)"
-	default 5000
-
-endif # NRF_MODEM_LIB_TRACE_BACKEND_BITRATE_LOG
-
-endif # NRF_MODEM_LIB_TRACE_BACKEND_BITRATE
-
-config NRF_MODEM_LIB_TRACE_BITRATE_LOG
-	depends on NRF_MODEM_LIB_LOG_LEVEL_INF || NRF_MODEM_LIB_LOG_LEVEL_DBG
-	bool "Log trace bitrate"
-
-if NRF_MODEM_LIB_TRACE_BITRATE_LOG
-
-config NRF_MODEM_LIB_TRACE_BITRATE_LOG_PERIOD_MS
-	int "Bitrate log interval (millisec)"
-	default 1000
-
-endif # NRF_MODEM_LIB_TRACE_BITRATE_LOG
-
-endif # NRF_MODEM_LIB_TRACE
-
-menu "Interrupt priorities"
-
 DT_IPC := $(dt_nodelabel_path,ipc)
-
 config NRF_MODEM_LIB_IPC_IRQ_PRIO_OVERRIDE
 	bool "Override IPC IRQ priority"
 	help
@@ -124,30 +27,8 @@ config NRF_MODEM_LIB_IPC_IRQ_PRIO_OVERRIDE
 config NRF_MODEM_LIB_IPC_IRQ_PRIO
 	int "IPC IRQ priority" if NRF_MODEM_LIB_IPC_IRQ_PRIO_OVERRIDE
 	default $(dt_node_array_prop_int,$(DT_IPC),interrupts,1) if !NRF_MODEM_LIB_IPC_IRQ_PRIO_OVERRIDE
-endmenu
 
-choice NRF_MODEM_LIB_ON_FAULT
-	prompt "Action on modem fault"
-	default NRF_MODEM_LIB_ON_FAULT_DO_NOTHING
-
-config NRF_MODEM_LIB_ON_FAULT_DO_NOTHING
-	bool "Do nothing"
-	help
-	  Let the fault handler log the fault and return.
-
-config NRF_MODEM_LIB_ON_FAULT_RESET_MODEM
-	bool "Reset modem"
-	help
-	  Let the fault handler reset the modem.
-
-config NRF_MODEM_LIB_ON_FAULT_APPLICATION_SPECIFIC
-	bool "Application defined"
-	help
-	  Let the application define the fault handler function.
-
-endchoice # NRF_MODEM_LIB_ON_FAULT
-
-comment "Heap and buffers"
+menu "Memory configuration"
 
 config NRF_MODEM_LIB_HEAP_SIZE
 	int "Library heap size"
@@ -233,14 +114,126 @@ config NRF_MODEM_LIB_MEM_DIAG_DUMP_PERIOD_MS
 	int "Period (millisec)"
 	default 20000
 
-endif
+endif # NRF_MODEM_LIB_MEM_DIAG && LOG
+endmenu # Memory config
 
-comment "Logging"
+menuconfig NRF_MODEM_LIB_TRACE
+	bool "Tracing"
+	help
+	  When enabled, a portion of RAM (called Trace region) will be shared with the modem to receive modem's trace data.
+	  The size of the Trace region is defined by the NRF_MODEM_LIB_SHMEM_TRACE_SIZE option.
+	  Trace data is output on the chosen trace backend.
 
-config NRF_MODEM_LIB_LOG_FW_VERSION_UUID
-	depends on LOG
-	bool "Log FW version and UUID during initialization"
+if NRF_MODEM_LIB_TRACE
+
+# Add trace backends
+rsource "trace_backends/Kconfig"
+
+config NRF_MODEM_LIB_TRACE_STACK_SIZE
+	int "Modem trace thread stack size"
+	default 768 if SIZE_OPTIMIZATIONS
+	default 1024
+
+config NRF_MODEM_LIB_TRACE_LEVEL_OVERRIDE
+	bool "Override trace level"
+	default y
+
+if NRF_MODEM_LIB_TRACE_LEVEL_OVERRIDE
+
+choice NRF_MODEM_LIB_TRACE_LEVEL_CHOICE
+	prompt "Trace level"
+
+config NRF_MODEM_LIB_TRACE_LEVEL_FULL
+	bool "Full"
+config NRF_MODEM_LIB_TRACE_LEVEL_LTE_AND_IP
+	bool "IP and LTE"
+config NRF_MODEM_LIB_TRACE_LEVEL_IP_ONLY
+	bool "IP only"
+config NRF_MODEM_LIB_TRACE_LEVEL_COREDUMP_ONLY
+	bool "Coredump only"
+config NRF_MODEM_LIB_TRACE_LEVEL_OFF
+	bool "Off"
+
+endchoice
+
+config NRF_MODEM_LIB_TRACE_LEVEL
+	int
+	default 0 if NRF_MODEM_LIB_TRACE_LEVEL_OFF
+	default 1 if NRF_MODEM_LIB_TRACE_LEVEL_COREDUMP_ONLY
+	default 2 if NRF_MODEM_LIB_TRACE_LEVEL_FULL
+	default 4 if NRF_MODEM_LIB_TRACE_LEVEL_IP_ONLY
+	default 5 if NRF_MODEM_LIB_TRACE_LEVEL_LTE_AND_IP
+
+endif # NRF_MODEM_LIB_TRACE_LEVEL_OVERRIDE
+
+config NRF_MODEM_LIB_TRACE_THREAD_PRIO_OVERRIDE
+	bool "Override trace thread priority"
+
+config NRF_MODEM_LIB_TRACE_THREAD_PRIO
+	int "Priority of the trace processing thread"
+	depends on NRF_MODEM_LIB_TRACE_THREAD_PRIO_OVERRIDE
+	default 0
+
+config NRF_MODEM_LIB_TRACE_BITRATE_LOG
+	depends on NRF_MODEM_LIB_LOG_LEVEL_INF || NRF_MODEM_LIB_LOG_LEVEL_DBG
+	bool "Log trace bitrate"
+	help
+	  Log the speed at which the modem emits traces, in bps.
+
+config NRF_MODEM_LIB_TRACE_BITRATE_LOG_PERIOD_MS
+	int "Bitrate log interval (millisec)"
+	depends on NRF_MODEM_LIB_TRACE_BITRATE_LOG
+	default 1000
+
+config NRF_MODEM_LIB_TRACE_BACKEND_BITRATE
+	bool "Measure trace backend bitrate"
+	help
+	  Measure the speed at which the backend processes traces, in bps.
+	  Enables compilation of nrf_modem_lib_trace_backend_bitrate_get().
+
+config NRF_MODEM_LIB_TRACE_BACKEND_BITRATE_PERIOD_MS
+	int "Rolling interval where the bitrate is measured (millisec)"
+	depends on NRF_MODEM_LIB_TRACE_BACKEND_BITRATE
+	default 1000
+
+config NRF_MODEM_LIB_TRACE_BACKEND_BITRATE_LOG
+	bool "Log trace backend bitrate"
+	depends on NRF_MODEM_LIB_TRACE_BACKEND_BITRATE
+	help
+	  Log the speed at which the selected backend is processing traces, in bps.
+
+config NRF_MODEM_LIB_TRACE_BACKEND_BITRATE_LOG_PERIOD_MS
+	int "Bitrate log interval (millisec)"
+	depends on NRF_MODEM_LIB_TRACE_BACKEND_BITRATE_LOG
+	default 5000
+
+endif # NRF_MODEM_LIB_TRACE
+
+choice NRF_MODEM_LIB_ON_FAULT
+	prompt "Action on modem fault"
+	default NRF_MODEM_LIB_ON_FAULT_DO_NOTHING
+
+config NRF_MODEM_LIB_ON_FAULT_DO_NOTHING
+	bool "Do nothing"
+	help
+	  Let the fault handler log the fault and return.
+
+config NRF_MODEM_LIB_ON_FAULT_RESET_MODEM
+	bool "Reset modem"
+	help
+	  Let the fault handler reset the modem.
+
+config NRF_MODEM_LIB_ON_FAULT_APPLICATION_SPECIFIC
+	bool "Application defined"
+	help
+	  Let the application define the fault handler function.
+
+endchoice # NRF_MODEM_LIB_ON_FAULT
 
 module = NRF_MODEM_LIB
 module-str = Modem library
 source "subsys/logging/Kconfig.template.log_config"
+
+config NRF_MODEM_LIB_LOG_FW_VERSION_UUID
+	depends on LOG
+	bool "Log FW version and UUID during initialization"

--- a/lib/nrf_modem_lib/Kconfig.modemlib
+++ b/lib/nrf_modem_lib/Kconfig.modemlib
@@ -19,8 +19,7 @@ config NRF_MODEM_LIB_SYS_INIT
 	  minute in case the modem firmware is updated.
 
 menuconfig NRF_MODEM_LIB_TRACE
-	bool "Tracing" if !NRF_MODEM_LIB_TRACE_ENABLED
-	default y if NRF_MODEM_LIB_TRACE_ENABLED
+	bool "Tracing"
 	help
 	  When enabled, a portion of RAM (called Trace region) will be shared with the modem to receive modem's trace data.
 	  The size of the Trace region is defined by the NRF_MODEM_LIB_SHMEM_TRACE_SIZE option.
@@ -245,13 +244,3 @@ config NRF_MODEM_LIB_LOG_FW_VERSION_UUID
 module = NRF_MODEM_LIB
 module-str = Modem library
 source "subsys/logging/Kconfig.template.log_config"
-
-comment "Deprecated"
-
-config NRF_MODEM_LIB_TRACE_ENABLED
-	bool "Enable proprietary traces (DEPRECATED)"
-	help
-	  Deprecated, use NRF_MODEM_LIB_TRACE instead.
-	  When enabled, a portion of RAM (called Trace region) will be shared with the modem to receive modem's trace data.
-	  The size of the Trace region is defined by the NRF_MODEM_LIB_SHMEM_TRACE_SIZE option.
-	  Trace data is output on the chosen trace backend.

--- a/lib/nrf_modem_lib/nrf_modem_lib.c
+++ b/lib/nrf_modem_lib/nrf_modem_lib.c
@@ -197,11 +197,6 @@ int nrf_modem_lib_init(enum nrf_modem_mode mode)
 	}
 }
 
-int nrf_modem_lib_get_init_ret(void)
-{
-	return init_ret;
-}
-
 int nrf_modem_lib_shutdown(void)
 {
 	LOG_DBG("Shutting down modem library");


### PR DESCRIPTION
Removed two deprecated functions, reorganized the Kconfig menu and introduced a new function to retrieve a textual description of fault reasons.