### PR TITLE
ci: Freeze action-oss-history revision

### DIFF
--- a/.github/workflows/oss-history.yml
+++ b/.github/workflows/oss-history.yml
@@ -25,7 +25,7 @@ jobs:
           git -C zephyr remote add upstream https://github.com/zephyrproject-rtos/zephyr
 
       - name: Check OSS history
-        uses: nrfconnect/action-oss-history@main
+        uses: nrfconnect/action-oss-history@d4259fb8e2e7b272a5d12fd43e6ab8be740bd512
         with:
           workspace: 'ncs'
           args: -p zephyr -p mcuboot


### PR DESCRIPTION
The action-oss-history repository has moved forward, adding extra checks which do not pass on v2.1-branch. Therefore, freeze the repository revision on a version that was used when NCS v2.1 was released.