### PR TITLE
ci: use forked branches of CI/Verification repositories

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library("CI_LIB") _
+@Library("CI_LIB@v2.3-branch") _
 
 def pipeline = new ncs.sdk_nrf.Main()
 

--- a/test-manifests/99-default-test-nrf.yml
+++ b/test-manifests/99-default-test-nrf.yml
@@ -11,7 +11,7 @@ manifest:
     - name: test_nrf
       remote: ncs-test
       repo-path: test-fw-nrfconnect-nrf
-      revision: master
+      revision: v2.3-branch
       import:
         name-blocklist: [sdk-nrf]
       userdata:


### PR DESCRIPTION
* Jenkinsfile loads CI_LIB@v2.3-branch
* 99-default-test-nrf.yml loads v2.3-branch of test-fw-nrfconnect-nrf

Signed-off-by: Sebastian Wezel <sebastian.wezel@nordicsemi.no>
