### PR TITLE
Bluetooth: Mesh: Fixed build error with overlay-dfu.conf

### DIFF
--- a/samples/bluetooth/mesh/light/src/smp_dfu.c
+++ b/samples/bluetooth/mesh/light/src/smp_dfu.c
@@ -150,7 +150,6 @@ int smp_dfu_init(void)
 	 * communication, a secondary advertising set is necessary to broadcast
 	 * the SMP service.
 	 */
-	err = smp_service_adv_init();
+	return smp_service_adv_init();
 /* .. include_endpoint_light_smp_dfu_rst_2 */
-	return err;
 }


### PR DESCRIPTION
Fixed a missing err declaration when building with overlay-dfu.conf.