### PR TITLE
bluetooth: fast_pair: add support for info callbacks

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -256,7 +256,10 @@ Binary libraries
 Bluetooth libraries and services
 --------------------------------
 
-|no_changes_yet_note|
+* :ref:`bt_fast_pair_readme`:
+
+  * Added the :c:func:`bt_fast_pair_info_cb_register` function and the :c:struct:`bt_fast_pair_info_cb` structure to register Fast Pair information callbacks.
+    The :c:member:`bt_fast_pair_info_cb.account_key_written` callback can be used to notify the application about the Account Key writes.
 
 Bootloader libraries
 --------------------

--- a/include/bluetooth/services/fast_pair.h
+++ b/include/bluetooth/services/fast_pair.h
@@ -99,6 +99,20 @@ struct bt_fast_pair_battery {
 	uint8_t level;
 };
 
+/** Fast Pair information callback descriptor. */
+struct bt_fast_pair_info_cb {
+	/** Notify that the Account Key has been written.
+	 *
+	 * This information can be used for example to update the Fast Pair advertising
+	 * data in the not discoverable mode. Due to execution context constraints
+	 * (Bluetooth RX thread), it is not recommended to block for long periods
+	 * of time in this callback.
+	 *
+	 *  @param conn Connection object that wrote the Account Key.
+	 */
+	void (*account_key_written)(struct bt_conn *conn);
+};
+
 /** Get Fast Pair advertising data buffer size.
  *
  * @param[in] fp_adv_config	Fast Pair advertising config.
@@ -166,6 +180,18 @@ bool bt_fast_pair_has_account_key(void);
  */
 int bt_fast_pair_battery_set(enum bt_fast_pair_battery_comp battery_comp,
 			     struct bt_fast_pair_battery battery);
+
+/** Register Fast Pair information callbacks.
+ *
+ *  This function registers an instance of information callbacks. The registered instance needs to
+ *  persist in the memory after this function exits, as it is used directly without the copy
+ *  operation. It is possible to register only one instance of callbacks with this API.
+ *
+ *  @param cb Callback struct.
+ *
+ *  @return Zero on success or negative error code otherwise
+ */
+int bt_fast_pair_info_cb_register(const struct bt_fast_pair_info_cb *cb);
 
 /** Perform a reset to the default factory settings for Google Fast Pair Service.
  *

--- a/samples/bluetooth/peripheral_fast_pair/src/main.c
+++ b/samples/bluetooth/peripheral_fast_pair/src/main.c
@@ -352,6 +352,11 @@ static void button_changed(uint32_t button_state, uint32_t has_changed)
 	bond_remove_btn_handle(button_state, has_changed);
 }
 
+static void fp_account_key_written(struct bt_conn *conn)
+{
+	LOG_INF("Fast Pair Account Key has been written");
+}
+
 void main(void)
 {
 	bool run_led_on = true;
@@ -361,6 +366,9 @@ void main(void)
 	};
 	static struct bt_conn_auth_info_cb auth_info_cb = {
 		.pairing_complete = pairing_complete
+	};
+	static const struct bt_fast_pair_info_cb fp_info_callbacks = {
+		.account_key_written = fp_account_key_written,
 	};
 
 	LOG_INF("Starting Bluetooth Fast Pair example");
@@ -374,6 +382,12 @@ void main(void)
 	err = bt_conn_auth_info_cb_register(&auth_info_cb);
 	if (err) {
 		LOG_ERR("Registering authentication info callbacks failed (err %d)", err);
+		return;
+	}
+
+	err = bt_fast_pair_info_cb_register(&fp_info_callbacks);
+	if (err) {
+		LOG_ERR("Registering Fast Pair info callbacks failed (err %d)", err);
 		return;
 	}
 


### PR DESCRIPTION
Added support for Fast Pair information callbacks. Currently, the callback structure supports one callback type that is used to notify the application about the Account Key list changes.

Ref: NCSDK-15899