### PR TITLE
doc: wi-fi: Add links to documentation

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -467,6 +467,7 @@
 .. _`nRF21540 Product Specification`: https://infocenter.nordicsemi.com/topic/struct_fem/struct/nrf21540_ps.html
 
 .. _`Product specification for nRF70 Series devices`: https://infocenter.nordicsemi.com/topic/ps_nrf7002/keyfeatures_html5.html
+.. _`nRF7002 DK Hardware`: https://infocenter.nordicsemi.com/topic/ug_nrf7002_dk/UG/nrf7002_DK/intro.html
 
 .. _`Guidelines and application notes for nRF70 Series devices`: https://infocenter.nordicsemi.com/topic/struct_nrf70/struct/nrf70_guidelines.html
 

--- a/doc/nrf/working_with_nrf/nrf70/features.rst
+++ b/doc/nrf/working_with_nrf/nrf70/features.rst
@@ -43,7 +43,8 @@ Devices in the nRF70 Series are supported by the following boards in the `Zephyr
    * - nRF7002 DK
      - PCA10143
      - ``nrf7002dk_nrf5340_cpuapp``
-     -
+     - | `Product Specification <Product specification for nRF70 Series devices_>`_
+       | `User Guide <nRF7002 DK Hardware_>`_
 
 Supported Wi-Fi standards and modes
 ===================================


### PR DESCRIPTION
Added links to Product Specification, Getting started guide, and User Guide for nRF7002 in the Features page.