### PR TITLE
samples: nrf9160: mmss: Increase MCUBoot secondary partition size

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -209,6 +209,12 @@ nRF9160 samples
 
     * The sample now integrates the :ref:`lib_lwm2m_client_utils` FOTA callback functionality.
 
+* :ref:`nrf_cloud_mqtt_multi_service` sample:
+
+  * Updated:
+
+    * Increased the MCUboot partition size to the minimum necessary to allow bootloader FOTA.
+
 Peripheral samples
 ------------------
 

--- a/samples/nrf9160/nrf_cloud_mqtt_multi_service/child_image/mcuboot/boards/nrf9160dk_nrf9160.conf
+++ b/samples/nrf9160/nrf_cloud_mqtt_multi_service/child_image/mcuboot/boards/nrf9160dk_nrf9160.conf
@@ -12,3 +12,7 @@ CONFIG_SPI_NRFX_RAM_BUFFER_SIZE=32
 CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y
 
 CONFIG_FPROTECT=y
+
+# Enabling SPI increases the MCUBoot image size so that it does not fit in the default
+# partition size (0xC000). The minimum required size is 0xD000
+CONFIG_PM_PARTITION_SIZE_MCUBOOT=0xD000


### PR DESCRIPTION
Increase the size of the MCUBoot secondary partition to the minimum required for bootloader FOTA