### PR TITLE
sample: slm_shell: Support nRF7002 DK

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -186,6 +186,12 @@ nRF9160 samples
     * Use defines from the :ref:`lib_nrf_cloud` library for nRF Cloud related string values.
       Remove the inclusion of the file :file:`nrf_cloud_codec.h`.
 
+* :ref:`slm_shell_sample` sample:
+
+  * Added:
+
+    * Support for the nRF7002 DK PCA10143.
+
 Peripheral samples
 ------------------
 

--- a/samples/nrf9160/slm_shell/README.rst
+++ b/samples/nrf9160/slm_shell/README.rst
@@ -13,7 +13,7 @@ This sample enables an external MCU to send modem or SLM proprietary AT commands
 Requirements
 ************
 
-SLM application should be configured to use UART_2 on nRF9160 side.
+The SLM application should be configured to use UART_2 on the nRF9160 side with no hardware flow control.
 
 The sample supports the following development kits:
 
@@ -40,6 +40,10 @@ The following table shows how to connect PCA10056 UART_1 to nRF9160 UART_2 for c
    * - GPIO GND
      - GPIO GND
 
+.. note::
+   The GPIO output level on the nRF9160 side must be 3 V to work with the nRF52 series DK.
+   You can set the VDD voltage with the **VDD IO** switch (**SW9**).
+
 The following table shows how to connect PCA10095 UART_2 to nRF9160 UART_2 for communication through UART:
 
 .. list-table::
@@ -60,7 +64,31 @@ The following table shows how to connect PCA10095 UART_2 to nRF9160 UART_2 for c
      - GPIO GND
 
 .. note::
-   SW9 on nRF9160 DK (VDD IO) should be set to 3V to work with the nRF52 and nRF53 series DK.
+   The GPIO output level on the nRF9160 side must be 3 V to work with the nRF53 series DK.
+   You can set the VDD voltage with the **VDD IO** switch (**SW9**).
+
+The following table shows how to connect PCA10143 UART_2 to nRF9160 UART_2 for communication through UART:
+
+.. list-table::
+   :align: center
+   :header-rows: 1
+
+   * - nRF7002 DK
+     - nRF9160 DK
+   * - UART TX P1.04
+     - UART RX P0.11
+   * - UART RX P1.05
+     - UART TX P0.10
+   * - GPIO OUT P0.31
+     - GPIO IN P0.31
+   * - GPIO IN P0.30 (optional)
+     - GPIO OUT P0.30 (optional)
+   * - GPIO GND
+     - GPIO GND
+
+.. note::
+   The GPIO output level on the nRF9160 side must be 1.8 V to work with the nRF70 series DK.
+   You can set the VDD voltage with the **VDD IO** switch (**SW9**).
 
 References
 **********

--- a/samples/nrf9160/slm_shell/boards/nrf7002dk_nrf5340_cpuapp.conf
+++ b/samples/nrf9160/slm_shell/boards/nrf7002dk_nrf5340_cpuapp.conf
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Configuration file for nRF7002DK.
+# This file is merged with prj.conf in the application folder, and options
+# set here will take precedence if they are present in both files.
+
+CONFIG_NRFX_UARTE2=y
+CONFIG_UART_2_INTERRUPT_DRIVEN=n
+CONFIG_UART_2_ASYNC=y
+CONFIG_UART_2_NRF_HW_ASYNC=y
+CONFIG_UART_2_NRF_HW_ASYNC_TIMER=2
+CONFIG_MODEM_SLM_WAKEUP_PIN=30
+CONFIG_MODEM_SLM_INDICATE_PIN=31

--- a/samples/nrf9160/slm_shell/boards/nrf7002dk_nrf5340_cpuapp.overlay
+++ b/samples/nrf9160/slm_shell/boards/nrf7002dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		ncs,slm-uart = &uart2;
+	};
+};
+
+&uart2 {
+	compatible = "nordic,nrf-uarte";
+	current-speed = <115200>;
+	status = "okay";
+
+	pinctrl-0 = <&uart2_default>;
+	pinctrl-1 = <&uart2_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&pinctrl {
+	uart2_default: uart2_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 4)>;
+		};
+		group2 {
+			psels = <NRF_PSEL(UART_RX, 1, 5)>;
+			bias-pull-up;
+		};
+	};
+
+	uart2_sleep: uart2_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 4)>,
+				<NRF_PSEL(UART_RX, 1, 5)>;
+			low-power-enable;
+		};
+	};
+};

--- a/samples/nrf9160/slm_shell/sample.yaml
+++ b/samples/nrf9160/slm_shell/sample.yaml
@@ -7,5 +7,6 @@ tests:
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
-    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+      - nrf7002dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
     tags: ci_build


### PR DESCRIPTION
Update overlay files and doc to support nRF7002 DK.