### PR TITLE
mpsl: cx: allow to use nRF700x with nRF53 without nRF RPC

### DIFF
--- a/subsys/mpsl/cx/CMakeLists.txt
+++ b/subsys/mpsl/cx/CMakeLists.txt
@@ -12,6 +12,6 @@ if (CONFIG_MPSL_CX_THREAD OR CONFIG_MPSL_CX_BT_1WIRE OR CONFIG_MPSL_CX_NRF700X)
     zephyr_library_sources_ifdef(CONFIG_MPSL_CX_NRF700X nrf700x/mpsl_cx_nrf700x.c)
 endif()
 
-if (CONFIG_MPSL_CX_NRF700X AND CONFIG_SOC_SERIES_NRF53X)
+if (CONFIG_MPSL_CX_NRF700X AND CONFIG_SOC_SERIES_NRF53X AND CONFIG_NRF_RPC)
     zephyr_library_sources(nrf700x/mpsl_cx_nrf700x_rpc.c)
 endif()

--- a/subsys/mpsl/cx/Kconfig
+++ b/subsys/mpsl/cx/Kconfig
@@ -50,8 +50,8 @@ config MPSL_CX_NRF700X
 	depends on MPSL_CX_NRF700X_SUPPORT
 	select NRFX_GPIOTE if !MPSL_CX_PIN_FORWARDER
 	select GPIO if !MPSL_CX_PIN_FORWARDER
-	select NRF_RPC if SOC_SERIES_NRF53X
-	select NRF_RPC_CBOR if SOC_SERIES_NRF53X
+	imply NRF_RPC if SOC_SERIES_NRF53X
+	imply NRF_RPC_CBOR if SOC_SERIES_NRF53X
 	bool "nRF700x Radio Coexistence"
 	help
 	  Radio Coexistence supporting nRF700x interface.


### PR DESCRIPTION
Some applications might not want to have the possibility to enable or disable coexistence in run-time. Currently, serialization of these APIs is enforced and cannot be turned off when nRF700x coexistence interface is selected. This commit changes that by allowing the user to disable this serialization. It is still enabled by default though.