### PR TITLE
doc: update references to add_partition_manager_config

### DIFF
--- a/scripts/partition_manager/partition_manager.rst
+++ b/scripts/partition_manager/partition_manager.rst
@@ -93,11 +93,11 @@ The following code shows how the ``settings`` subsystem configuration is added.
 .. code-block:: cmake
 
    if (CONFIG_SETTINGS_FCB OR CONFIG_SETTINGS_NVS)
-     add_partition_manager_config(pm.yml.settings)
+     ncs_add_partition_manager_config(pm.yml.settings)
    endif()
 
 When multiple application images, within the same domain, build the same subsystem code, there are some limitations if the code adds a Partition Manager configuration file using this methodology.
-In particular, partition definitions are global per domain, and must be identical across all the calls to ``add_partition_manager_config()``.
+In particular, partition definitions are global per domain, and must be identical across all the calls to ``ncs_add_partition_manager_config()``.
 If the same partition is defined twice with different configurations within a domain, the Partition Manager will fail.
 
 .. note::


### PR DESCRIPTION
The function add_partition_manager_config was prefixed with nvs_ to get exposed to OOT users to let them add partition manager configuration files since the commit bb1da8c7e25e368341634114a2746f733bb763e3.

The references in the documentation were not updated since then, and it still uses the former name.

This updates all the references for the function in the repository.

Jira: NCSDK-5493