### PR TITLE
doc: nrf: add native_posix entry for sample board rows extension

### DIFF
--- a/doc/nrf/includes/sample_board_rows.txt
+++ b/doc/nrf/includes/sample_board_rows.txt
@@ -149,3 +149,7 @@
 .. nrf7002dk_nrf5340_cpunet
 
 | :ref:`nRF7002 DK <nrf7002dk_nrf5340>` | PCA10143 | :ref:`nrf7002dk_nrf5340 <nrf7002dk_nrf5340>` | ``nrf7002dk_nrf5340_cpunet`` |
+
+.. native_posix
+
+| Native Posix | | native_posix | ``native_posix`` |


### PR DESCRIPTION
Some samples list native_posix as an option now, so it needs to be part of sample_board_rows.txt file.