### PR TITLE
workflows: trigger docbuild on sample.yaml changes

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -10,6 +10,7 @@ on:
       - '.github/workflows/docbuild.yml'
       - '**.rst'
       - '**/Kconfig'
+      - '**/sample.yaml'
       - 'doc/**'
       - 'include/**'
       - 'scripts/requirements-doc.txt'


### PR DESCRIPTION
The `sample.yaml` files are read by the `table-from-sample-yaml` directive when building the docs. Any changes to these files will affect the documentation build, and should be checked.