### PR TITLE
samples: matter: Introduce to Matter NUS service

### DIFF
--- a/doc/nrf/libraries/bluetooth_services/services/nus.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/nus.rst
@@ -10,7 +10,7 @@ Nordic UART Service (NUS)
 The Bluetooth® LE GATT Nordic UART Service is a custom service that receives and writes data and serves as a bridge to the UART interface.
 
 The NUS Service is used in the :ref:`peripheral_uart` sample.
-It is also included with the Thingy:91 :ref:`connectivity_bridge`, but is disabled by default.
+It is also included with the Thingy:91 :ref:`connectivity_bridge`, but is disabled by default, and with the :ref:`Matter door lock sample <matter_lock_sample>`, as an optional feature that extends the Bluetooth LE connectivity.
 
 Service UUID
 ************

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -93,6 +93,13 @@ Matter fork
 
 The Matter fork in the |NCS| (``sdk-connectedhomeip``) contains all commits from the upstream Matter repository up to, and including, the ``1.0.0.2`` tag.
 
+  * Added:
+
+    * The Matter Nordic UART Service (NUS) feature to the :ref:`matter_lock_sample`.
+      This feature allows using Nordic UART Service to control the device remotely through Bluetooth LE and adding custom text commands to a Matter sample.
+      The Matter NUS implementation allows controlling the device regardless of whether the device is connected to a Matter network or not.
+      The feature is dedicated for the nRF5340 and the nRF52840 DKs.
+
 The following list summarizes the most important changes inherited from the upstream Matter:
 
 |no_changes_yet_note|
@@ -210,7 +217,10 @@ Thread samples
 Matter samples
 --------------
 
-|no_changes_yet_note|
+* :ref:`matter_lock_sample`:
+
+    * Added the Matter Nordic UART Service (NUS) feature, which allows controlling the door lock device remotely through Bluetooth LE using two simple commands: ``Lock`` and ``Unlock``.
+      This feature is dedicated for the nRF52840 and the nRF5340 DKs.
 
 NFC samples
 -----------

--- a/samples/matter/common/src/bt_nus_service.cpp
+++ b/samples/matter/common/src/bt_nus_service.cpp
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "bt_nus_service.h"
+
+#include <zephyr/logging/log.h>
+#include <zephyr/settings/settings.h>
+
+#include <platform/CHIPDeviceLayer.h>
+
+using namespace ::chip;
+using namespace ::chip::DeviceLayer;
+
+LOG_MODULE_DECLARE(app, CONFIG_MATTER_LOG_LEVEL);
+
+#define NUS_BT_NAME (CONFIG_BT_DEVICE_NAME "_NUS")
+
+namespace
+{
+constexpr uint32_t kAdvertisingOptions = BT_LE_ADV_OPT_CONNECTABLE;
+constexpr uint8_t kAdvertisingFlags = BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR;
+constexpr uint8_t kBTUuid[] = { BT_UUID_NUS_VAL };
+} /* namespace */
+
+BT_CONN_CB_DEFINE(conn_callbacks) = {
+	.connected = NUSService::Connected,
+	.disconnected = NUSService::Disconnected,
+	.security_changed = NUSService::SecurityChanged,
+};
+bt_conn_auth_cb NUSService::sConnAuthCallbacks = {
+	.passkey_display = AuthPasskeyDisplay,
+	.cancel = AuthCancel,
+};
+bt_conn_auth_info_cb NUSService::sConnAuthInfoCallbacks = {
+	.pairing_complete = PairingComplete,
+	.pairing_failed = PairingFailed,
+};
+bt_nus_cb NUSService::sNusCallbacks = {
+	.received = RxCallback,
+};
+
+NUSService NUSService::sInstance;
+
+bool NUSService::Init(uint8_t priority, uint16_t minInterval, uint16_t maxInterval)
+{
+	mAdvertisingItems[0] = BT_DATA(BT_DATA_FLAGS, &kAdvertisingFlags, sizeof(kAdvertisingFlags));
+	mAdvertisingItems[1] = BT_DATA(BT_DATA_NAME_COMPLETE, NUS_BT_NAME, strlen(NUS_BT_NAME));
+
+	mServiceItems[0] = BT_DATA(BT_DATA_UUID128_ALL, kBTUuid, sizeof(kBTUuid));
+
+	mAdvertisingRequest.priority = priority;
+	mAdvertisingRequest.options = kAdvertisingOptions;
+	mAdvertisingRequest.minInterval = minInterval;
+	mAdvertisingRequest.maxInterval = maxInterval;
+	mAdvertisingRequest.advertisingData = Span<bt_data>(mAdvertisingItems);
+	mAdvertisingRequest.scanResponseData = Span<bt_data>(mServiceItems);
+
+	mAdvertisingRequest.onStarted = [](int rc) {
+		if (rc == 0) {
+			LOG_INF("NUS BLE advertising started");
+		} else {
+			LOG_ERR("Failed to start NUS BLE advertising: %d", rc);
+		}
+	};
+	mAdvertisingRequest.onStopped = []() { LOG_DBG("NUS BLE advertising stopped"); };
+
+	settings_load();
+#if defined(CONFIG_BT_FIXED_PASSKEY)
+	VerifyOrReturnError(bt_passkey_set(CONFIG_CHIP_NUS_FIXED_PASSKEY) == 0, false);
+#endif
+	VerifyOrReturnError(bt_conn_auth_cb_register(&sConnAuthCallbacks) == 0, false);
+	VerifyOrReturnError(bt_conn_auth_info_cb_register(&sConnAuthInfoCallbacks) == 0, false);
+	VerifyOrReturnError(bt_nus_init(&sNusCallbacks) == 0, false);
+
+	return true;
+}
+
+void NUSService::StartServer()
+{
+	if (mIsStarted) {
+		LOG_WRN("NUS service was already started");
+		return;
+	}
+
+	PlatformMgr().LockChipStack();
+	CHIP_ERROR ret = BLEAdvertisingArbiter::InsertRequest(mAdvertisingRequest);
+	PlatformMgr().UnlockChipStack();
+
+	if (CHIP_NO_ERROR != ret) {
+		LOG_ERR("Could not start NUS service");
+		return;
+	}
+	mIsStarted = true;
+	LOG_INF("NUS service started");
+}
+
+void NUSService::StopServer()
+{
+	VerifyOrReturn(mIsStarted);
+
+	PlatformMgr().LockChipStack();
+	BLEAdvertisingArbiter::CancelRequest(mAdvertisingRequest);
+	PlatformMgr().UnlockChipStack();
+
+	mIsStarted = false;
+	LOG_INF("NUS service stopped");
+}
+
+void NUSService::RxCallback(bt_conn *conn, const uint8_t *const data, uint16_t len)
+{
+	VerifyOrReturn(bt_conn_get_security(GetNUSService().mBTConnection) >= BT_SECURITY_L2);
+	LOG_DBG("NUS received: %d bytes", len);
+	GetNUSService().DispatchCommand(reinterpret_cast<const char *>(data), len);
+}
+
+bool NUSService::RegisterCommand(const char *const name, size_t length, CommandCallback callback, void *context)
+{
+	VerifyOrReturnError(name, false);
+	VerifyOrReturnError(mCommandsCounter < CONFIG_CHIP_NUS_MAX_COMMANDS, false);
+	VerifyOrReturnError(length < CONFIG_CHIP_NUS_MAX_COMMAND_LEN, false);
+
+	Command newCommand{};
+	memcpy(newCommand.command, name, length);
+	newCommand.callback = callback;
+	newCommand.context = context;
+	mCommandsList[mCommandsCounter++] = newCommand;
+
+	return true;
+}
+
+void NUSService::DispatchCommand(const char *const data, uint16_t len)
+{
+	for (const auto &c : mCommandsList) {
+		if (strncmp(data, c.command, len) == 0 && len == strlen(c.command)) {
+			if (c.callback) {
+				PlatformMgr().LockChipStack();
+				c.callback(c.context);
+				PlatformMgr().UnlockChipStack();
+			}
+			return;
+		}
+	}
+	LOG_ERR("NUS command unknown!");
+}
+
+bool NUSService::SendData(const char *const data, size_t length)
+{
+	VerifyOrReturnError(mIsStarted && mBTConnection, false);
+	VerifyOrReturnError(mBTConnection, false);
+	VerifyOrReturnError(bt_conn_get_security(mBTConnection) >= BT_SECURITY_L2, false);
+	VerifyOrReturnError(bt_nus_send(mBTConnection, reinterpret_cast<const uint8_t *const>(data), length) == 0,
+			    false);
+	return true;
+}
+
+void NUSService::Connected(bt_conn *conn, uint8_t err)
+{
+	if (err || !conn) {
+		LOG_ERR("NUS Connection failed (err %u)", err);
+		return;
+	}
+
+	GetNUSService().mBTConnection = conn;
+	bt_conn_set_security(conn, BT_SECURITY_L3);
+
+	LOG_INF("NUS BT Connected to %s", LogAddress(conn));
+}
+
+void NUSService::Disconnected(bt_conn *conn, uint8_t reason)
+{
+	LOG_INF("NUS BT Disconnected from %s (reason %u)", LogAddress(conn), reason);
+	GetNUSService().mBTConnection = nullptr;
+}
+
+void NUSService::SecurityChanged(bt_conn *conn, bt_security_t level, enum bt_security_err err)
+{
+	if (!err) {
+		LOG_DBG("NUS BT Security changed: %s level %u", LogAddress(conn), level);
+	} else {
+		LOG_ERR("NUS BT Security failed: level %u err %d", level, err);
+	}
+}
+
+void NUSService::AuthPasskeyDisplay(bt_conn *conn, unsigned int passkey)
+{
+	LOG_INF("PROVIDE THE FOLLOWING CODE IN YOUR MOBILE APP: %d", passkey);
+}
+
+void NUSService::AuthCancel(bt_conn *conn)
+{
+	LOG_INF("NUS BT Pairing cancelled: %s", LogAddress(conn));
+
+	bt_conn_disconnect(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+}
+
+void NUSService::PairingComplete(bt_conn *conn, bool bonded)
+{
+	LOG_DBG("NUS BT Pairing completed: %s, bonded: %d", LogAddress(conn), bonded);
+}
+
+void NUSService::PairingFailed(bt_conn *conn, enum bt_security_err reason)
+{
+	LOG_ERR("NUS BT Pairing failed to %s : reason %d", LogAddress(conn), static_cast<uint8_t>(reason));
+}
+
+char *NUSService::LogAddress(bt_conn *conn)
+{
+#if CONFIG_LOG
+	static char addr[BT_ADDR_LE_STR_LEN];
+	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	return addr;
+#endif
+	return NULL;
+}

--- a/samples/matter/common/src/bt_nus_service.h
+++ b/samples/matter/common/src/bt_nus_service.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#pragma once
+
+#include "app_event.h"
+
+#include <platform/Zephyr/BLEAdvertisingArbiter.h>
+
+#include <bluetooth/services/nus.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+
+class NUSService {
+public:
+	using CommandCallback = void (*)(void *context);
+	struct Command {
+		char command[CONFIG_CHIP_NUS_MAX_COMMAND_LEN];
+		CommandCallback callback;
+		void *context;
+	};
+
+	/**
+	 * @brief Initialize Nordic UART Service (NUS)
+	 *
+	 * Initialize internal structures and set Bluetooth LE advertisement parameters.
+	 */
+	bool Init(uint8_t priority, uint16_t minInterval, uint16_t maxInterval);
+
+	/**
+	 * @brief Start the Nordic UART Service server
+	 *
+	 * Register Nordic UART Service that supports controlling lock and unlock operations
+	 * using Bluetooth LE commands. The Nordic UART Service may begin immediately.
+	 */
+	void StartServer();
+
+	/**
+	 * @brief Stop the Nordic UART Service server
+	 *
+	 * Unregister Nordic UART Service  that supports controlling lock and unlock operations
+	 * using Bluetooth LE commands. The Nordic UART Service will be disabled and the next service with the highest priority will begin immediately.
+	 */
+	void StopServer();
+
+	/**
+	 * @brief Send data to the connected device
+	 * 
+	 * Send data to the connected and paired device.
+	 * 
+	 * @return false if the device cannot send data, true otherwise.
+	 */
+	bool SendData(const char *const data, size_t length);
+
+	/**
+	 * @brief Register a new command for NUS service
+	 * 
+	 * The new command consist of a callback that will be called when the device receives the provided command name.
+	 * The name of the command must be null-terminated.
+	 * 
+	 * @return false if there is no space for the next command (See CONFIG_CHIP_NUS_MAX_COMMANDS kConfig), or the name is empty.
+	 */
+	bool RegisterCommand(const char *const name, size_t length, CommandCallback callback, void *context);
+
+	friend NUSService &GetLockNUSService();
+	static NUSService sInstance;
+
+	/**
+	 * Static callbacks for the Bluetooth LE connection
+	*/
+	static void Connected(struct bt_conn *conn, uint8_t err);
+	static void Disconnected(struct bt_conn *conn, uint8_t reason);
+	static void SecurityChanged(struct bt_conn *conn, bt_security_t level, enum bt_security_err err);
+
+private:
+
+	void DispatchCommand(const char *const data, uint16_t len);
+
+	static void RxCallback(struct bt_conn *conn, const uint8_t *const data, uint16_t len);
+	static void AuthPasskeyDisplay(struct bt_conn *conn, unsigned int passkey);
+	static void AuthCancel(struct bt_conn *conn);
+	static void PairingComplete(struct bt_conn *conn, bool bonded);
+	static void PairingFailed(struct bt_conn *conn, enum bt_security_err reason);
+	static char* LogAddress(struct bt_conn *conn);
+
+	static struct bt_conn_auth_cb sConnAuthCallbacks;
+	static struct bt_conn_auth_info_cb sConnAuthInfoCallbacks;
+	static struct bt_nus_cb sNusCallbacks;
+
+	bool mIsStarted = false;
+	chip::DeviceLayer::BLEAdvertisingArbiter::Request mAdvertisingRequest = {};
+	std::array<bt_data, 2> mAdvertisingItems;
+	std::array<bt_data, 1> mServiceItems;
+	std::array<Command, CONFIG_CHIP_NUS_MAX_COMMANDS> mCommandsList;
+	uint8_t mCommandsCounter = 0;
+	struct bt_conn *mBTConnection;
+
+
+};
+
+inline NUSService &GetNUSService()
+{
+	return NUSService::sInstance;
+}

--- a/samples/matter/lock/CMakeLists.txt
+++ b/samples/matter/lock/CMakeLists.txt
@@ -55,6 +55,10 @@ if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_SMP_BT)
     target_sources(app PRIVATE ${COMMON_ROOT}/src/ota_util.cpp)
 endif()
 
+if(CONFIG_CHIP_NUS)
+    target_sources(app PRIVATE ${COMMON_ROOT}/src/bt_nus_service.cpp)
+endif()
+
 if(CONFIG_MCUMGR_SMP_BT)
     target_sources(app PRIVATE ${COMMON_ROOT}/src/dfu_over_smp.cpp)
 endif()

--- a/samples/matter/lock/prj_release.conf
+++ b/samples/matter/lock/prj_release.conf
@@ -20,6 +20,7 @@ CONFIG_DK_LIBRARY=y
 
 # Bluetooth Low Energy configuration
 CONFIG_BT_DEVICE_NAME="MatterLock"
+CONFIG_BT_FIXED_PASSKEY=y
 
 # Enable system reset on fatal error
 CONFIG_RESET_ON_FATAL_ERROR=y

--- a/samples/matter/lock/sample.yaml
+++ b/samples/matter/lock/sample.yaml
@@ -54,3 +54,9 @@ tests:
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
     platform_allow: nrf5340dk_nrf5340_cpuapp
+  sample.matter.lock.nus:
+    build_only: true
+    extra_args: CONFIG_CHIP_NUS=y
+    integration_platforms:
+      - nrf52840dk_nrf52840
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp

--- a/samples/matter/lock/src/app_event.h
+++ b/samples/matter/lock/src/app_event.h
@@ -21,6 +21,7 @@ enum class AppEventType : uint8_t {
 	UpdateLedState,
 	IdentifyStart,
 	IdentifyStop,
+	NUSCommand,
 };
 
 enum class FunctionEvent : uint8_t { NoneSelected = 0, SoftwareUpdate = 0, FactoryReset, AdvertisingStart };

--- a/samples/matter/lock/src/app_task.cpp
+++ b/samples/matter/lock/src/app_task.cpp
@@ -20,6 +20,10 @@ using chip::Shell::Engine;
 using chip::Shell::shell_command_t;
 #endif
 
+#ifdef CONFIG_CHIP_NUS
+#include "bt_nus_service.h"
+#endif
+
 #include <platform/CHIPDeviceLayer.h>
 
 #include "board_util.h"
@@ -69,6 +73,12 @@ constexpr size_t kAppEventQueueSize = 10;
 constexpr EndpointId kLockEndpointId = 1;
 #if NUMBER_OF_BUTTONS == 2
 constexpr uint32_t kAdvertisingTriggerTimeout = 3000;
+#endif
+
+#ifdef CONFIG_CHIP_NUS
+constexpr uint16_t kAdvertisingIntervalMin = 400;
+constexpr uint16_t kAdvertisingIntervalMax = 500;
+constexpr uint8_t kLockNUSPriority = 2;
 #endif
 
 K_MSGQ_DEFINE(sAppEventQueue, sizeof(AppEvent), kAppEventQueueSize, alignof(AppEvent));
@@ -187,6 +197,16 @@ CHIP_ERROR AppTask::Init()
 	/* Initialize DFU over SMP */
 	GetDFUOverSMP().Init();
 	GetDFUOverSMP().ConfirmNewImage();
+#endif
+
+#ifdef CONFIG_CHIP_NUS
+	/* Initialize Nordic UART Service for Lock purposes */
+	if (!GetNUSService().Init(kLockNUSPriority, kAdvertisingIntervalMin, kAdvertisingIntervalMax)) {
+		ChipLogError(Zcl, "Cannot initialize NUS service");
+	}
+	GetNUSService().RegisterCommand("Lock", sizeof("Lock"), NUSLockCallback, nullptr);
+	GetNUSService().RegisterCommand("Unlock", sizeof("Unlock"), NUSUnlockCallback, nullptr);
+	GetNUSService().StartServer();
 #endif
 
 	/* Initialize lock manager */
@@ -613,6 +633,9 @@ void AppTask::LockStateChanged(BoltLockManager::State state, BoltLockManager::Op
 	case BoltLockManager::State::kLockingCompleted:
 		LOG_INF("Lock action completed");
 		sLockLED.Set(true);
+#ifdef CONFIG_CHIP_NUS
+		GetNUSService().SendData("Locked", sizeof("Locked"));
+#endif
 		break;
 	case BoltLockManager::State::kUnlockingInitiated:
 		LOG_INF("Unlock action initiated");
@@ -620,6 +643,9 @@ void AppTask::LockStateChanged(BoltLockManager::State state, BoltLockManager::Op
 		break;
 	case BoltLockManager::State::kUnlockingCompleted:
 		LOG_INF("Unlock action completed");
+#ifdef CONFIG_CHIP_NUS
+		GetNUSService().SendData("Unlocked", sizeof("Unlocked"));
+#endif
 		sLockLED.Set(false);
 		break;
 	}
@@ -687,5 +713,35 @@ void AppTask::RegisterSwitchCliCommand()
 							"switch_images",
 							"Switch between Thread and Wi-Fi application variants" };
 	Engine::Root().RegisterCommands(&sSwitchCommand, 1);
+}
+#endif
+
+#ifdef CONFIG_CHIP_NUS
+void AppTask::NUSLockCallback(void *context)
+{
+	LOG_INF("Received LOCK command from NUS");
+	if (BoltLockMgr().mState == BoltLockManager::State::kLockingCompleted ||
+	    BoltLockMgr().mState == BoltLockManager::State::kLockingInitiated) {
+		LOG_INF("Device is already locked");
+	} else {
+		AppEvent nus_event;
+		nus_event.Type = AppEventType::NUSCommand;
+		nus_event.Handler = LockActionEventHandler;
+		PostEvent(nus_event);
+	}
+}
+
+void AppTask::NUSUnlockCallback(void *context)
+{
+	LOG_INF("Received LOCK command from NUS");
+	if (BoltLockMgr().mState == BoltLockManager::State::kUnlockingCompleted ||
+	    BoltLockMgr().mState == BoltLockManager::State::kUnlockingInitiated) {
+		LOG_INF("Device is already unlocked");
+	} else {
+		AppEvent nus_event;
+		nus_event.Type = AppEventType::NUSCommand;
+		nus_event.Handler = LockActionEventHandler;
+		PostEvent(nus_event);
+	}
 }
 #endif

--- a/samples/matter/lock/src/app_task.h
+++ b/samples/matter/lock/src/app_task.h
@@ -70,6 +70,11 @@ private:
 	bool mSwitchImagesTimerActive = false;
 #endif
 
+#ifdef CONFIG_CHIP_NUS
+	static void NUSLockCallback(void* context);
+	static void NUSUnlockCallback(void* context);
+#endif
+
 #ifdef CONFIG_THREAD_WIFI_SWITCHING_CLI_SUPPORT
 	static void RegisterSwitchCliCommand();
 #endif

--- a/west.yml
+++ b/west.yml
@@ -135,7 +135,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 14b61315456ae5f103fe6cd3bcb4a94bed4a54d7
+      revision: 6eec6a3ec9b3e07ed76707afd5cd2ef1089e8d43
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
Matter over Thread lets you can integrate an additional Bluetooth LE service with any Matter application.
Thanks to this solution, you can declare commands specific to a Matter sample and use them to control the device remotely through Bluetooth LE.
Connection to the device is secure and requires providing a random-generated passcode (debug build) or predefined passcode (release build).