### PR TITLE
samples: Fix warning for minimal pinout FEM in DTM and radio_test

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -3108,6 +3108,11 @@ NCSDK-19858: :ref:`at_monitor_readme` library and :ref:`nrf_cloud_mqtt_multi_ser
   Occasionally, the :ref:`at_monitor_readme` library heap becomes overrun, presumably due to one of the registered AT event listeners becoming stalled.
   This has only been observed with the :ref:`nrf_cloud_mqtt_multi_service` sample.
 
+.. rst-class:: v2-3-0 v2-2-0
+
+NCSDK-20095: Build warning in the RF test samples when the minimal pinout generic/Skyworks FEM is used
+  The :ref:`radio_test` and :ref:`direct_test_mode` samples build with a warning about generic/Skyworks FEM in minimal pinout configuration.
+
 Zephyr
 ******
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -207,6 +207,10 @@ Bluetooth samples
 
   * The :kconfig:option:`CONFIG_BT_SMP` Kconfig option is included when ``CONFIG_BT_HIDS_SECURITY_ENABLED`` is selected.
 
+* :ref:`direct_test_mode` sample:
+
+  * Removed a compilation warning when used with minimal pinout Skyworks FEM.
+
 Bluetooth mesh samples
 ----------------------
 

--- a/samples/bluetooth/direct_test_mode/src/fem/generic_fem.c
+++ b/samples/bluetooth/direct_test_mode/src/fem/generic_fem.c
@@ -34,7 +34,7 @@ static struct generic_fem {
 	const struct gpio_dt_spec chl;
 #endif
 
-} generic_fem_cfg = {
+} generic_fem_cfg __used = {
 #if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), ant_sel_gpios)
 	.ant_sel = GPIO_DT_SPEC_GET(GENERIC_FEM_NODE, ant_sel_gpios),
 #endif


### PR DESCRIPTION
Fix warning when DTM or radio_test is compiled with FEM in minimal pinout configuration.