### PR TITLE
samples: direct_test_mode: Add support for the MPSL Tx power splitter

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -213,6 +213,10 @@ Bluetooth samples
 * :ref:`direct_test_mode` sample:
 
   * Removed a compilation warning when used with minimal pinout Skyworks FEM.
+  * Added support for the :ref:`nrfxlib:mpsl_fem` Tx power split feature.
+    The DTM command ``0x09`` for setting the transmitter power level takes into account the front-end module gain when this sample is built with support for front-end modules.
+    The vendor-specific commands for setting the SoC output power and the front-end module gain are not available when the :kconfig:option:`CONFIG_DTM_POWER_CONTROL_AUTOMATIC` Kconfig option is enabled.
+  * Added support for +1 dBm, +2 dBm, and +3 dBm output power on the nRF5340 DK.
 
 Bluetooth mesh samples
 ----------------------

--- a/samples/bluetooth/direct_test_mode/Kconfig
+++ b/samples/bluetooth/direct_test_mode/Kconfig
@@ -42,5 +42,15 @@ config DTM_USB
 	  Use USB instead of UART as the DTM interface. For nRF5340 the USB from application core
 	  is used as communication interface.
 
+config DTM_POWER_CONTROL_AUTOMATIC
+	bool "Automatic power control"
+	depends on FEM
+	default y
+	help
+	  Set the SoC output power and the front-end module gain to achieve the Tx output power
+	  requested by user. If the exact value cannot be achieved, power is set to the closest
+	  possible value. If this option is disabled, user can set the SoC output power and the
+	  front-end module gain with the separate vendor specific commands.
+
 rsource "src/fem/Kconfig"
 source "Kconfig.zephyr"

--- a/samples/bluetooth/direct_test_mode/README.rst
+++ b/samples/bluetooth/direct_test_mode/README.rst
@@ -106,6 +106,37 @@ The DTM sample supports all four PHYs specified in DTM, but not all devices supp
    * - LE Coded S=2
      - Yes
 
+Tx output power
+===============
+
+This sample has several ways to set the device output power.
+The behavior of the commands vary depending on the hardware configuration and Kconfig options as follows:
+
+* DTM without front-end module support:
+
+   * The official ``0x09`` DTM command sets the SoC Tx output power closest to the requested one when the exact power level is not supported.
+   * The ``SET_TX_POWER`` vendor-specific command sets the SoC Tx output power.
+     You must use only the Tx power values supported by your SoC.
+     See the actual values in the SoC Product Specification.
+
+* DTM with front-end module support:
+
+   * The official ``0x09`` DTM command when the :kconfig:option:`CONFIG_DTM_POWER_CONTROL_AUTOMATIC` Kconfig option is enabled, which is a default state.
+     This command takes into account the SoC output power and the front-end module gain to set total output power.
+
+     .. note::
+        The returned output power using this command is valid only for channel 0.
+        If you perform the test on a different channel than the real output power measured by your tester device, it can be equal or less than the returned one.
+        This is because the DTM specification has a limitation when it assumes that output power is the same for all channels.
+        That is why the chosen output power might not be available for the given channel.
+
+   * When the :kconfig:option:`CONFIG_DTM_POWER_CONTROL_AUTOMATIC` Kconfig option is disabled, the official ``0x09`` DTM command sets only the SoC output power.
+     These commands behave in the same way for the DTM without front-end module support.
+     Additionally, you can use following vendor-specific commands:
+
+      * The ``SET_TX_POWER`` command sets the SoC Tx output power.
+      * The ``FEM_GAIN_SET`` command sets the front-end module gain.
+
 Bluetooth Direction Finding support
 ===================================
 
@@ -256,6 +287,15 @@ Vendor specific commands can be divided into different categories as follows:
 
   If you have changed the default parameters of the front-end module, you can restore them.
   You can either send the ``FEM_DEFAULT_PARAMS_SET`` command or power cycle the front-end module.
+
+.. note::
+  When you build the DTM sample with support for front-end modules and the :kconfig:option:`CONFIG_DTM_POWER_CONTROL_AUTOMATIC` Kconfig option is enabled, the following vendor-specific command are not available:
+
+      * ``SET_TX_POWER``
+      * ``FEM_GAIN_SET``
+
+   You can disable the :kconfig:option:`CONFIG_DTM_POWER_CONTROL_AUTOMATIC` Kconfig option if you want to set the SoC output power and the front-end module gain by separate commands.
+   The official DTM command ``0x09`` for setting power level takes into account the SoC output power and the front-end module gain to set the total requested output power.
 
 The DTM-to-Serial adaptation layer
 ==================================

--- a/samples/bluetooth/direct_test_mode/sample.yaml
+++ b/samples/bluetooth/direct_test_mode/sample.yaml
@@ -33,3 +33,12 @@ tests:
       - nrf5340dk_nrf5340_cpunet
     platform_allow: nrf5340dk_nrf5340_cpunet
     tags: bluetooth ci_build
+  sample.bluetooth.direct_test_mode.nrf5340_nrf21540.no_automatic_power:
+    build_only: true
+    extra_args: SHIELD=nrf21540_ek
+    extra_configs:
+      - CONFIG_DTM_POWER_CONTROL_AUTOMATIC=n
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpunet
+    platform_allow: nrf5340dk_nrf5340_cpunet
+    tags: bluetooth ci_build

--- a/samples/bluetooth/direct_test_mode/src/dtm_hw.c
+++ b/samples/bluetooth/direct_test_mode/src/dtm_hw.c
@@ -38,6 +38,9 @@ const uint32_t nrf_power_value[] = {
 	RADIO_TXPOWER_TXPOWER_Neg1dBm,
 #endif /* defined (RADIO_TXPOWER_TXPOWER_Neg1dBm) */
 	RADIO_TXPOWER_TXPOWER_0dBm,
+#if defined(RADIO_TXPOWER_TXPOWER_Pos1dBm)
+	RADIO_TXPOWER_TXPOWER_Pos1dBm,
+#endif /* RADIO_TXPOWER_TXPOWER_Pos1dBm */
 #if defined(RADIO_TXPOWER_TXPOWER_Pos2dBm)
 	RADIO_TXPOWER_TXPOWER_Pos2dBm,
 #endif /* defined(RADIO_TXPOWER_TXPOWER_Pos2dBm) */

--- a/samples/bluetooth/direct_test_mode/src/dtm_hw_config.h
+++ b/samples/bluetooth/direct_test_mode/src/dtm_hw_config.h
@@ -36,6 +36,20 @@ extern "C" {
 	* defined(NRF52811_XXAA) || defined(NRF52820_XXAA)
 	*/
 
+#ifdef NRF53_SERIES
+#ifndef RADIO_TXPOWER_TXPOWER_Pos3dBm
+	#define RADIO_TXPOWER_TXPOWER_Pos3dBm (0x03UL)
+#endif /* RADIO_TXPOWER_TXPOWER_Pos3dBm */
+
+#ifndef RADIO_TXPOWER_TXPOWER_Pos2dBm
+	#define RADIO_TXPOWER_TXPOWER_Pos2dBm (0x02UL)
+#endif /* RADIO_TXPOWER_TXPOWER_Pos2dBm */
+
+#ifndef RADIO_TXPOWER_TXPOWER_Pos1dBm
+	#define RADIO_TXPOWER_TXPOWER_Pos1dBm (0x01UL)
+#endif /* RADIO_TXPOWER_TXPOWER_Pos1dBm */
+#endif /* NRF53_SERIES */
+
 #ifdef __cplusplus
 }
 #endif

--- a/samples/bluetooth/direct_test_mode/src/fem/fem.c
+++ b/samples/bluetooth/direct_test_mode/src/fem/fem.c
@@ -276,6 +276,13 @@ int8_t fem_tx_output_power_prepare(int8_t power, int8_t *radio_tx_power, uint16_
 	return output_power;
 }
 
+int8_t fem_tx_output_power_check(int8_t power, uint16_t freq_mhz, bool tx_power_ceiling)
+{
+	mpsl_tx_power_split_t power_split = { 0 };
+
+	return mpsl_fem_tx_power_split(power, &power_split, freq_mhz, tx_power_ceiling);
+}
+
 uint32_t fem_default_tx_gain_get(void)
 {
 	if (fem_api->tx_default_gain_get) {

--- a/samples/bluetooth/direct_test_mode/src/fem/fem.h
+++ b/samples/bluetooth/direct_test_mode/src/fem/fem.h
@@ -161,6 +161,47 @@ uint32_t fem_radio_rx_ramp_up_delay_get(bool fast, nrf_radio_mode_t mode);
  */
 int8_t fem_tx_output_power_prepare(int8_t power, int8_t *radio_tx_power, uint16_t freq_mhz);
 
+/**@brief Check a real Tx output power, for the SoC with the front-end module for given parameters.
+ *
+ * Check if the requested output power can be achieved. This function returns the exact value or
+ * if this value is not available for given frequency, the closest greater or lower value to the
+ * requested output power.
+ *
+ * @param[in] power Tx power level to check.
+ * @param[in] freq_mhz Frequency in MHz. The output power check is valid only for this frequency.
+ * @param[in] tx_power_ceiling Flag to get the ceiling or floor of the requested transmit power
+ *                             level.
+ *
+ * @return The real Tx output power in dBm, which can be achieved for the given frequency. It might
+ *         be different than @p power and depending on @p tx_power_ceiling it can be greater or
+ *         lower than the requested one.
+ */
+int8_t fem_tx_output_power_check(int8_t power, uint16_t freq_mhz, bool tx_power_ceiling);
+
+/**@brief Get the minimum Tx output power for the SoC with the front-end module.
+ *
+ * @param[in] freq_mHz Frequency in MHz. The minimum output power is valid only for this frequency.
+ *
+ * @return The minimum output power in dBm.
+ */
+static inline int8_t fem_tx_output_power_min_get(uint16_t freq_mhz)
+{
+	/* Using INT8_MIN returns the minimum supported Tx output power value. */
+	return fem_tx_output_power_check(INT8_MIN, freq_mhz, false);
+}
+
+/**@brief Get the maximum Tx output power for the SoC with the front-end module.
+ *
+ * @param[in] freq_mHz Frequency in MHz. The maximum output power is valid only for this frequency.
+ *
+ * @return The maximum output power in dBm.
+ */
+static inline int8_t fem_tx_output_power_max_get(uint16_t freq_mhz)
+{
+	/* Using INT8_MAX returns the maximum supported Tx output power value. */
+	return fem_tx_output_power_check(INT8_MAX, freq_mhz, true);
+}
+
 /** @brief Get the front-end module default Tx gain.
  *
  * @return The front-end module default Tx gain value.


### PR DESCRIPTION
This adds support for automatic power control for the SoC with the front-end module. The requested output power is splitted automatically between SoC and front-end module gain.

