### PR TITLE
manifest: sdk-hostapd: Fix base64 redefinition error

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -106,7 +106,7 @@ manifest:
     - name: hostap
       repo-path: sdk-hostap
       path: modules/lib/hostap
-      revision: 73de50a279b35adf345eae35231813d0945991fd
+      revision: 6d949b2b1f95d53bc91f798ace564587e0408bd1
       userdata:
         ncs:
           upstream-url: https://w1.fi/cgit/hostap/


### PR DESCRIPTION
Pull fix for base64 redefinition error, fixes NRF7X-38.