### PR TITLE
CODEOWNERS: set ncs-ci for docker related files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -182,6 +182,9 @@ Kconfig*                                  @tejlmand
 /scripts/requirements-*.txt               @tejlmand @grho @shanthanordic @ihansse
 /scripts/west_commands/sbom/              @doki-nordic @maje-emb
 /scripts/bootloader/                      @hakonfam @sigvartmh
+/scripts/ncs-docker-version.txt           @nrfconnect/ncs-ci
+/scripts/print_docker_image.sh            @nrfconnect/ncs-ci
+/scripts/print_toolchain_checksum.sh      @nrfconnect/ncs-ci
 /share/zephyrbuild-package/               @tejlmand
 /share/ncs-package/                       @tejlmand
 /subsys/bluetooth/                        @alwa-nordic @carlescufi @KAGA164


### PR DESCRIPTION
Following scripts are managed by ncs-ci
* /scripts/ncs-docker-version.txt
* /scripts/print_docker_image.sh
* /scripts/print_toolchain_checksum.sh