### PR TITLE
tfm: Add override headers for zephyr log and error handling

### DIFF
--- a/lib/hw_unique_key/hw_unique_key_internal.h
+++ b/lib/hw_unique_key/hw_unique_key_internal.h
@@ -11,29 +11,10 @@
 
 /* Define print and panic macros. This library can be compiled for different OSes. */
 #ifdef __ZEPHYR__
-#include <zephyr/sys/printk.h>
 #include <zephyr/kernel.h>
-#define HUK_PRINT(msg) printk(msg)
-#define HUK_PRINT_VAL(msg, val) printk(msg " %d", val)
-#define HUK_PANIC k_panic
-
 #elif defined(__NRF_TFM__)
-#include "tfm_spm_log.h"
 #include "utilities.h"
-#define HUK_PRINT(msg) SPMLOG_DBGMSG(msg)
-#define HUK_PRINT_VAL(msg, val) SPMLOG_DBGMSGVAL(msg, val)
-#define HUK_PANIC tfm_core_panic
-
-#else
-static void panic(void)
-{
-	while (1)
-		;
-}
-#define HUK_PRINT(...)
-#define HUK_PANIC panic
-
-#endif /* __ZEPHYR__ */
+#endif
 
 /* The available slots as an array that can be iterated over. */
 static const enum hw_unique_key_slot huk_slots[] = {

--- a/lib/hw_unique_key/hw_unique_key_kmu.c
+++ b/lib/hw_unique_key/hw_unique_key_kmu.c
@@ -9,6 +9,7 @@
 #include "hw_unique_key_internal.h"
 #include <nrfx.h>
 #include <mdk/nrf_erratas.h>
+#include <zephyr/kernel.h>
 
 #define KMU_KEYSLOT_SIZE_WORDS 4
 
@@ -71,9 +72,8 @@ void hw_unique_key_write(enum hw_unique_key_slot kmu_slot, const uint8_t *key)
 #endif
 
 	if (err != 0) {
-		HUK_PRINT_VAL("The HUK writing to: ", kmu_slot);
-		HUK_PRINT_VAL("  failed with error code: ", err);
-		HUK_PANIC();
+		printk("The HUK writing to: %d failed with error code: %d\r\n", kmu_slot, err);
+		k_panic();
 	}
 }
 

--- a/modules/tfm/tfm/boards/CMakeLists.txt
+++ b/modules/tfm/tfm/boards/CMakeLists.txt
@@ -32,6 +32,7 @@ target_compile_definitions(platform_s
 
 target_include_directories(platform_s
   PUBLIC
+  include
   ${partition_includes}
   ${board_includes}
   services/include

--- a/modules/tfm/tfm/boards/include/zephyr/kernel.h
+++ b/modules/tfm/tfm/boards/include/zephyr/kernel.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef __ZEPHYR_KERNEL_H
+#define __ZEPHYR_KERNEL_H
+
+/* Compatebility header for using Zephyr API in TF-M.
+ *
+ * The macros and functions here can be used by code that is common for both
+ * Zephyr and TF-M RTOS.
+ *
+ * The functionality will be forwarded to TF-M equivalent of the Zephyr API.
+ */
+
+#define k_panic() tfm_core_panic()
+
+#endif /* __ZEPHYR_KERNEL_H */

--- a/modules/tfm/tfm/boards/include/zephyr/logging/log.h
+++ b/modules/tfm/tfm/boards/include/zephyr/logging/log.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef __ZEPHYR_LOGGING_LOG_H__
+#define __ZEPHYR_LOGGING_LOG_H__
+
+/* Compatebility header for using Zephyr API in TF-M.
+ *
+ * The macros and functions here can be used by code that is common for both
+ * Zephyr and TF-M RTOS.
+ *
+ * The functionality will be forwarded to TF-M equivalent of the Zephyr API.
+ */
+
+#include "tfm_sp_log.h"
+
+#define LOG_MODULE_DECLARE(...)
+#define LOG_MODULE_REGISTER(...)
+
+#define LOG_ERR(...) LOG_ERRFMT(__VA_ARGS__)
+#define LOG_WRN(...) LOG_WRNFMT(__VA_ARGS__)
+#define LOG_INF(...) LOG_INFFMT(__VA_ARGS__)
+#define LOG_DBG(...) LOG_DBGFMT(__VA_ARGS__)
+
+#endif /* __ZEPHYR_LOGGING_LOG_H__ */

--- a/modules/tfm/tfm/boards/include/zephyr/sys/__assert.h
+++ b/modules/tfm/tfm/boards/include/zephyr/sys/__assert.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef __ZEPHYR_SYS__ASSERT_H
+#define __ZEPHYR_SYS__ASSERT_H
+
+/* Compatebility header for using Zephyr API in TF-M.
+ *
+ * The macros and functions here can be used by code that is common for both
+ * Zephyr and TF-M RTOS.
+ *
+ * The functionality will be forwarded to TF-M equivalent of the Zephyr API.
+ */
+
+#include <autoconf.h>
+#include "tfm_sp_log.h"
+
+#ifdef CONFIG_ASSERT
+/* Use same print mode as non-secure. */
+#define __ASSERT_VERBOSE CONFIG_ASSERT_VERBOSE
+#define __ASSERT_NO_MSG_INFO CONFIG_ASSERT_NO_MSG_INFO
+#define __ASSERT_NO_COND_INFO CONFIG_ASSERT_NO_COND_INFO
+#define __ASSERT_NO_FILE_INFO CONFIG_ASSERT_NO_FILE_INFO
+#else
+/* Set default ASSERT print mode if asserts are disabled in non-secure.
+ * Calling psa_core_panic will not log any information.
+ */
+#define __ASSERT_VERBOSE 1
+#define __ASSERT_NO_MSG_INFO 1
+#define __ASSERT_NO_COND_INFO 1
+#endif
+
+#define _STRINGIFY(s) #s
+
+#if defined(__ASSERT_VERBOSE)
+#define __ASSERT_PRINT(fmt, ...)                                               \
+	printf(fmt, ##__VA_ARGS__)
+#else
+#define __ASSERT_PRINT(fmt, ...)
+#endif
+
+#ifdef __ASSERT_NO_MSG_INFO
+#define __ASSERT_MSG_INFO(fmt, ...)
+#else
+#define __ASSERT_MSG_INFO(fmt, ...)                                            \
+	__ASSERT_PRINT("\t" fmt "\r\n", ##__VA_ARGS__)
+#endif
+
+#define __ASSERT_POST_ACTION() tfm_core_panic()
+#define __ASSERT_UNREACHABLE __builtin_unreachable()
+
+#if !defined(__ASSERT_NO_COND_INFO) && !defined(__ASSERT_NO_FILE_INFO)
+#define __ASSERT_LOC(test)                                                     \
+	__ASSERT_PRINT("ASSERTION FAIL [%s] @ %s:%d\r\n",                      \
+		_STRINGIFY(test),                                              \
+		__FILE__, __LINE__)
+#endif
+
+#if defined(__ASSERT_NO_COND_INFO) && !defined(__ASSERT_NO_FILE_INFO)
+#define __ASSERT_LOC(test)                                                     \
+	__ASSERT_PRINT("ASSERTION FAIL @ %s:%d\r\n",                           \
+		__FILE__, __LINE__)
+#endif
+
+#if !defined(__ASSERT_NO_COND_INFO) && defined(__ASSERT_NO_FILE_INFO)
+#define __ASSERT_LOC(test)                                                     \
+	__ASSERT_PRINT("ASSERTION FAIL [%s]\r\n",                              \
+		_STRINGIFY(test))
+#endif
+
+#if defined(__ASSERT_NO_COND_INFO) && defined(__ASSERT_NO_FILE_INFO)
+#define __ASSERT_LOC(test)                                                     \
+	__ASSERT_PRINT("ASSERTION FAIL\r\n")
+#endif
+
+#define __ASSERT_NO_MSG(test)                                                  \
+	do {                                                                   \
+		if (!(test)) {                                                 \
+			__ASSERT_LOC(test);                                    \
+			__ASSERT_POST_ACTION();                                \
+			__ASSERT_UNREACHABLE;                                  \
+		}                                                              \
+	} while (false)
+
+#define __ASSERT(test, fmt, ...)                                               \
+	do {                                                                   \
+		if (!(test)) {                                                 \
+			__ASSERT_LOC(test);                                    \
+			__ASSERT_MSG_INFO(fmt, ##__VA_ARGS__);                 \
+			__ASSERT_POST_ACTION();                                \
+			__ASSERT_UNREACHABLE;                                  \
+		}                                                              \
+	} while (false)
+
+#endif /* __ZEPHYR_SYS__ASSERT_H */

--- a/modules/tfm/tfm/boards/include/zephyr/sys/check.h
+++ b/modules/tfm/tfm/boards/include/zephyr/sys/check.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef __ZEPHYR_SYS_CHECK_H
+#define __ZEPHYR_SYS_CHECK_H
+
+/* Compatebility header for using Zephyr API in TF-M.
+ *
+ * The macros and functions here can be used by code that is common for both
+ * Zephyr and TF-M RTOS.
+ *
+ * The functionality will be forwarded to TF-M equivalent of the Zephyr API.
+ */
+
+#include <autoconf.h>
+#include <zephyr/sys/__assert.h>
+
+/* Note:
+ * CONFIG_NO_RUNTIME_CHECKS is not implemented for TF-M.
+ * We don't allow exclusion of these checks.
+ */
+#if defined(CONFIG_ASSERT_ON_ERRORS)
+#define CHECKIF(expr)               \
+	__ASSERT_NO_MSG(!(expr));   \
+	if (0)
+#else
+#define CHECKIF(expr)               \
+	if (expr)
+#endif
+
+
+#endif /* ZEPHYR_INCLUDE_SYS_CHECK_H_ */
+
+#endif /* __ZEPHYR_SYS_CHECK_H */

--- a/modules/tfm/tfm/boards/include/zephyr/sys/printk.h
+++ b/modules/tfm/tfm/boards/include/zephyr/sys/printk.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#ifndef __ZEPHYR_KERNEL_H
-#define __ZEPHYR_KERNEL_H
+#ifndef __ZEPHYR_SYS_PRINTK_H
+#define __ZEPHYR_SYS_PRINTK_H
 
 /* Compatebility header for using Zephyr API in TF-M.
  *
@@ -15,8 +15,8 @@
  * The functionality will be forwarded to TF-M equivalent of the Zephyr API.
  */
 
-#include <zephyr/sys/printk.h>
+#include "tfm_sp_log.h"
 
-#define k_panic() tfm_core_panic()
+#define printk(fmt, ...) printf(fmt, ##__VA_ARGS__)
 
-#endif /* __ZEPHYR_KERNEL_H */
+#endif /* __ZEPHYR_SYS_PRINTK_H */


### PR DESCRIPTION
Implement a minimal set of the zephyr include headers for logging and error handling so that code needed in both Zepyhr and TF-M can use the same interface, with error and logging being redirected in the TF-M case to equivalent implementations.

Port the HW unique key library code to use the zephyr interface instead of handling this through internal macros.