### PR TITLE
scripts: Update ble_console scripts for Python3 and Bluez>=5

### DIFF
--- a/scripts/shell/ble_console/BluetoothConsole.py
+++ b/scripts/shell/ble_console/BluetoothConsole.py
@@ -9,7 +9,7 @@ import os
 
 import gi
 gi.require_version('Gtk', '3.0')
-from gi.repository import Gtk, GLib
+from gi.repository import Gtk, GLib  # pylint: disable=no-name-in-module
 
 from dbus import DBusException
 from TerminalNotebook import TerminalNotebook
@@ -81,8 +81,8 @@ class BluetoothConsole( TerminalNotebook, BluetoothConnection):
         self.window.show_all()
         self.display_message("Welcome to Bluetooth Console by Nordic Semiconductor\r\nSelect device from context menu to connect", 8000)
 
-    """Signal from BlueZ"""
     def bt_read_event(self, *args, **kwargs):
+    """Signal from BlueZ"""
         if len(args) >= 2:
             if (args[0] == READ_CHARACTERISTIC) and ('Value' in args[1]):
                 array = args[1]["Value"]

--- a/scripts/shell/ble_console/BluetoothConsole.py
+++ b/scripts/shell/ble_console/BluetoothConsole.py
@@ -9,10 +9,7 @@ import os
 
 import gi
 gi.require_version('Gtk', '3.0')
-from gi.repository import Gtk, GObject, Gdk, GLib
-
-gi.require_version('Vte', '2.91')
-from gi.repository import Vte
+from gi.repository import Gtk, GLib
 
 from dbus import DBusException
 from TerminalNotebook import TerminalNotebook
@@ -32,7 +29,6 @@ class BluetoothConsole( TerminalNotebook, BluetoothConnection):
         self.window.set_title('Bluetooth Console')
         self.window.set_default_size(730,410)
         self.window.set_resizable(True)
-        #self.window.set_position(Gtk.WIN_POS_CENTER)
 
         if getattr(sys, 'frozen', False):
             # frozen (released)
@@ -65,15 +61,15 @@ class BluetoothConsole( TerminalNotebook, BluetoothConnection):
         menubar = Gtk.MenuBar()
 
         filemenu = Gtk.Menu()
-        filem = Gtk.MenuItem("File")
+        filem = Gtk.MenuItem(label="File")
         filem.set_submenu(filemenu)
 
-        exit = Gtk.MenuItem("Exit")
+        exit = Gtk.MenuItem(label="Exit")
         exit.connect("activate", Gtk.main_quit)
         filemenu.append(exit)
 
         self.connect_menu = Gtk.Menu()
-        connect_item = Gtk.MenuItem("Select device")
+        connect_item = Gtk.MenuItem(label="Select device")
         connect_item.set_submenu(self.connect_menu)
 
         menubar.append(filem)
@@ -137,7 +133,7 @@ class BluetoothConsole( TerminalNotebook, BluetoothConnection):
                 self.connect_menu.remove(dev)
 
             for dev in connected_devs:
-                dev_menu_item = Gtk.CheckMenuItem(self.get_device_name(dev) + ' (' + dev + ')')
+                dev_menu_item = Gtk.CheckMenuItem(label=self.get_device_name(dev) + ' (' + dev + ')')
                 if dev in opened_devices:
                     dev_menu_item.set_active(True)
                     self.connect_to_device(dev)
@@ -150,7 +146,7 @@ class BluetoothConsole( TerminalNotebook, BluetoothConnection):
         # When there are no connected NUS devices, show info in menu
         items = [item for item in self.connect_menu]
         if not items:
-            no_bonded_menu_item = Gtk.CheckMenuItem('No compatible devices connected')
+            no_bonded_menu_item = Gtk.CheckMenuItem(label='No compatible devices connected')
             self.connect_menu.append(no_bonded_menu_item)
             self.connect_menu.show_all()
 

--- a/scripts/shell/ble_console/TerminalNotebook.py
+++ b/scripts/shell/ble_console/TerminalNotebook.py
@@ -5,10 +5,10 @@ import re
 
 import gi
 gi.require_version('Gtk', '3.0')
-from gi.repository import Gtk, Gdk
+from gi.repository import Gtk, Gdk  # pylint: disable=no-name-in-module
 
 gi.require_version('Vte', '2.91')
-from gi.repository import Vte
+from gi.repository import Vte  # pylint: disable=no-name-in-module
 
 COLOR_TERMINAL_ACTIVE = Gdk.RGBA(0.0/256, 0.0/256, 0.0/256, 0.8)
 COLOR_TERMINAL_INACTIVE = Gdk.RGBA(200.0/256, 200.0/256, 200.0/256, 0.8)
@@ -79,7 +79,7 @@ class TerminalNotebook(object):
             if self.device_terminal_dict[device] == terminal:
                 label_text = self.labels[device].get_text()
 
-                if state == False :
+                if not state:
                     terminal.set_color_background(COLOR_TERMINAL_INACTIVE)
                     self.display_message_method("Lost connection with " + device)
                     # Strikethrough name of inactive device

--- a/scripts/shell/ble_console/setup_with_cx_freeze.py
+++ b/scripts/shell/ble_console/setup_with_cx_freeze.py
@@ -5,7 +5,7 @@ from cx_Freeze import setup, Executable
 
 setup(name="Bluetooth NUS Shell for nRF Connect SDK",
       description="BLE Console is a host-side application providing access to Shell over Bluetooth Low Energy in Nordic devices.",
-      version="1.2",
+      version="1.3",
       options={"build_exe": {"build_exe": "build",
                              "packages": ["gi"],
                              "include_files":


### PR DESCRIPTION
This is a dupe of #9098, submitted under my own account so we can get CI results

Update the BLE UART console python scripts to make them work with Python 3 and newer versions of BlueZ. Also includes fixes to avoid deprecation warnings when calling Gtk-MenuItem functions.