### PR TITLE
applications: nrf5340_audio: Remove duplicate sensor config

### DIFF
--- a/applications/nrf5340_audio/prj.conf
+++ b/applications/nrf5340_audio/prj.conf
@@ -58,5 +58,3 @@ CONFIG_DEVICE_SHELL=n
 # Suppress err msg from sd_check_card_type. Because SPI_SDHC has no card presence method,
 # assume card is in slot. Thus error message is always shown if card is not inserted
 CONFIG_SD_LOG_LEVEL_OFF=y
-
-CONFIG_SENSOR=y


### PR DESCRIPTION
SENSOR is set to 'y' in
nrf5340_audio Kconfig.defaults