### PR TITLE
applications: serial_lte_modem: Static code analysis fixes

### DIFF
--- a/applications/serial_lte_modem/src/lwm2m_carrier/slm_at_carrier.c
+++ b/applications/serial_lte_modem/src/lwm2m_carrier/slm_at_carrier.c
@@ -708,7 +708,7 @@ static int do_carrier_portfolio(void)
 		}
 	}
 
-	if (slm_util_cmd_casecmp(operation, "READ")) {
+	if (slm_util_cmd_casecmp(operation, "READ") && (param_count > 4)) {
 		ret = lwm2m_carrier_identity_read(instance_id, identity_type, buffer, &buf_len);
 		if (ret) {
 			return ret;
@@ -717,7 +717,7 @@ static int do_carrier_portfolio(void)
 		rsp_send("\r\n#XCARRIER: %s\r\n", buffer);
 
 		return 0;
-	} else if (slm_util_cmd_casecmp(operation, "WRITE")) {
+	} else if (slm_util_cmd_casecmp(operation, "WRITE") && (param_count > 4)) {
 		size = sizeof(buffer);
 
 		ret = util_string_get(&at_param_list, 5, buffer, &size);

--- a/applications/serial_lte_modem/src/main.c
+++ b/applications/serial_lte_modem/src/main.c
@@ -187,7 +187,8 @@ static void indicate_stop(void)
 #endif
 }
 
-static void gpio_cb_func(const struct device *dev, struct gpio_callback *gpio_cb, uint32_t pins)
+static void gpio_cb_func(const struct device *dev, struct gpio_callback *gpio_callback,
+			 uint32_t pins)
 {
 	int err;
 
@@ -211,7 +212,7 @@ static void gpio_cb_func(const struct device *dev, struct gpio_callback *gpio_cb
 	}
 
 	gpio_pin_interrupt_configure(gpio_dev, CONFIG_SLM_WAKEUP_PIN, GPIO_INT_DISABLE);
-	gpio_remove_callback(gpio_dev, gpio_cb);
+	gpio_remove_callback(gpio_dev, gpio_callback);
 }
 
 void enter_idle(void)
@@ -356,7 +357,7 @@ void handle_mcuboot_swap_ret(void)
 		} else {
 			fota_status = FOTA_STATUS_OK;
 			fota_info = 0;
-		} break;
+		}
 		break;
 	/** Swap failed because image to be run is not valid */
 	case BOOT_SWAP_TYPE_FAIL:


### PR DESCRIPTION
When the param_count value is less than or equal to 4, the identity_type parameter remained uninitialized. This was later passed on to lwm2m_carrier_identity_write which may lead to unknown behaviour. This is now fixed. The function do_carrier_portfolio now returns failure if the param_count value was less than or equal to 4 for READ and WRITE operations.

Found by sonarcloud as a violation of MISRA C:2004, 9.1

Link to bug report: https://sonarcloud.io/project/issues?open=AYZV4S0qbbRTHR5zJstU&id=balaji-nordic_sdk-nrf

The gpio_cb variable that had a file global scope was shadowed by the
local variable with the same name in gpio_cb_func() function. This is
now fixed. Also removed a spurious break statement.

Link to bug report: https://sonarcloud.io/project/issues?open=AYYxTe3SlImboaSTQvH3&id=balaji-nordic_sdk-nrf