### PR TITLE
manifest: nrfxlib with psa_import_key from core

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -127,7 +127,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 0c6641162fb3ef0aeb66c7626268c1239b30db93
+      revision: pull/933/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Nrfxlib now uses the psa_import_key from the
PSA core which allows us to remove the
implementation of the same functionality
in the different drivers. This only affects
symmetric keys.

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>