### PR TITLE
manifest: update zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -55,7 +55,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: e414f084261667ff274f6e617064a8b2823edd3d
+      revision: f8f113382356934cb6d1ef4cdad95a843f922085
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This commit adds sdk-zephyr update fixing issue in mesh advertiser:

"Fixes issue where randomness can be removed for advertising sets that have to handle other adv types than the BT_MESH_FRIEND_ADV tag type."