### PR TITLE
applications: nrf5340_audio: Remove dependencies from error_handler

### DIFF
--- a/applications/nrf5340_audio/src/utils/error_handler.c
+++ b/applications/nrf5340_audio/src/utils/error_handler.c
@@ -8,40 +8,38 @@
 #include <zephyr/sys/reboot.h>
 #include <zephyr/fatal.h>
 #include <zephyr/logging/log_ctrl.h>
-
-#include "board.h"
-#include "led.h"
+#include <zephyr/drivers/gpio.h>
 
 /* Print everything from the error handler */
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(error_handler, CONFIG_ERROR_HANDLER_LOG_LEVEL);
 
-static void led_error_indication(void)
-{
-#if defined(CONFIG_BOARD_NRF5340_AUDIO_DK_NRF5340_CPUAPP)
-	(void)led_on(LED_APP_RGB, LED_COLOR_RED);
-#elif defined(CONFIG_BOARD_NRF5340_AUDIO_DK_NRF5340_CPUNET)
-	(void)led_on(LED_NET_RGB, LED_COLOR_RED);
-#endif /* defined(CONFIG_BOARD_NRF5340_AUDIO_DK_NRF5340_CPUAPP) */
-}
+#if (defined(CONFIG_BOARD_NRF5340_AUDIO_DK_NRF5340_CPUAPP) && (CONFIG_DEBUG))
+/* nRF5340 Audio DK center RGB LED */
+static const struct gpio_dt_spec center_led_r = GPIO_DT_SPEC_GET(DT_NODELABEL(rgb1_red), gpios);
+static const struct gpio_dt_spec center_led_g = GPIO_DT_SPEC_GET(DT_NODELABEL(rgb1_green), gpios);
+static const struct gpio_dt_spec center_led_b = GPIO_DT_SPEC_GET(DT_NODELABEL(rgb1_blue), gpios);
+#endif /* (defined(CONFIG_BOARD_NRF5340_AUDIO_DK_NRF5340_CPUAPP) && (CONFIG_DEBUG)) */
 
 void error_handler(unsigned int reason, const z_arch_esf_t *esf)
 {
 #if (CONFIG_DEBUG)
 	LOG_ERR("Caught system error -- reason %d. Entering infinite loop", reason);
 	LOG_PANIC();
-	led_error_indication();
+#if defined(CONFIG_BOARD_NRF5340_AUDIO_DK_NRF5340_CPUAPP)
+	(void)gpio_pin_configure_dt(&center_led_r, GPIO_OUTPUT_ACTIVE);
+	(void)gpio_pin_configure_dt(&center_led_g, GPIO_OUTPUT_INACTIVE);
+	(void)gpio_pin_configure_dt(&center_led_b, GPIO_OUTPUT_INACTIVE);
+#endif /* defined(CONFIG_BOARD_NRF5340_AUDIO_DK_NRF5340_CPUAPP) */
 	irq_lock();
 	while (true) {
 		__asm__ volatile("nop");
 	}
-
 #else
 	LOG_ERR("Caught system error -- reason %d. Cold rebooting.", reason);
 #if (CONFIG_LOG)
 	LOG_PANIC();
 #endif /* (CONFIG_LOG) */
-	led_error_indication();
 	sys_reboot(SYS_REBOOT_COLD);
 #endif /* (CONFIG_DEBUG) */
 	CODE_UNREACHABLE;
@@ -49,7 +47,7 @@ void error_handler(unsigned int reason, const z_arch_esf_t *esf)
 
 void bt_ctlr_assert_handle(char *c, int code)
 {
-	LOG_ERR("BT Controller assert: %s, code: 0x%x", c, code);
+	LOG_ERR("BT controller assert: %s, code: 0x%x", c, code);
 	error_handler(code, NULL);
 }
 


### PR DESCRIPTION
The center LED is now controlled
by the GPIO driver directly

OCT-2463