### PR TITLE
manifest: pull Matter fprotect fix

### DIFF
--- a/applications/matter_weather_station/Kconfig
+++ b/applications/matter_weather_station/Kconfig
@@ -13,16 +13,6 @@ config AVERAGE_CURRENT_CONSUMPTION
 	  The predicted average current consumption of the Matter weather station
 	  device, used to estimate the remaining battery time.
 
-if CHIP_FACTORY_DATA
-
-# Overwrite the Fprotect block size to fit the size of the factory data partition.
-# See lib/fprotect/Kconfig to get full description of this config.
-config FPROTECT_BLOCK_SIZE
-	hex
-	default 0x1000
-
-endif
-
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.features"
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.defaults"
 source "Kconfig.zephyr"

--- a/applications/matter_weather_station/configuration/thingy53_nrf5340_cpuapp/pm_static_factory_data.yml
+++ b/applications/matter_weather_station/configuration/thingy53_nrf5340_cpuapp/pm_static_factory_data.yml
@@ -25,14 +25,14 @@ mcuboot_primary_app:
   region: flash_primary
   size: 0xdfe00
   span: *id002
-settings_storage:
+factory_data:
   address: 0xf0000
   region: flash_primary
-  size: 0xf000
-factory_data:
-  address: 0xff000
+  size: 0x4000
+settings_storage:
+  address: 0xf4000
   region: flash_primary
-  size: 0x1000
+  size: 0xc000
 mcuboot_primary_1:
   address: 0x0
   size: 0x40000

--- a/doc/nrf/protocols/matter/end_product/bootloader.rst
+++ b/doc/nrf/protocols/matter/end_product/bootloader.rst
@@ -51,14 +51,23 @@ The nRF Connect platform in Matter uses Zephyr's :ref:`zephyr:settings_api` API 
 This requires that you define the ``settings_storage`` partition in the flash.
 The recommended minimum size of the partition is 16 kB, but you can reserve even more space if your application uses the storage extensively.
 
-As you can see in the listing above, Matter samples in the |NCS| reserve exactly 16 kB for the ``settings_storage`` partition.
+As you can see in :ref:`ug_matter_hw_requirements_layouts`, Matter samples in the |NCS| reserve exactly 16 kB for the ``settings_storage`` partition.
 
 Factory data partition
 ======================
 
 If you make a real Matter product, you also need the ``factory_data`` partition to store the factory data.
 The factory data contains a set of immutable device identifiers, certificates and cryptographic keys, programmed onto a device at the time of the device fabrication.
-For that partition one flash page of 4kB should be enough in most use cases.
+For that partition one flash page of 4 kB should be enough in most use cases.
+
+By default, the ``factory_data`` partition is write-protected with the :ref:`fprotect_readme` driver (``fprotect``).
+The hardware limitations require that the write-protected areas are aligned to :kconfig:option:`CONFIG_FPROTECT_BLOCK_SIZE`.
+For this reason, to effectively implement ``fprotect``, make sure that the :ref:`partition layout of the application <ug_matter_hw_requirements_layouts>` meets the following requirements:
+
+* The ``factory_data`` partition is placed right after the ``app`` partition in the address space (that is, the ``factory_data`` partition offset must be equal to the last address of the ``app`` partition).
+* The ``settings_storage`` partition size must be a multiple of :kconfig:option:`CONFIG_FPROTECT_BLOCK_SIZE`, which may differ depending on the SoC in use.
+
+In case your memory map does not follow these requirements, you can still use the factory data implementation without the write protection by setting the :kconfig:option:`CHIP_FACTORY_DATA_WRITE_PROTECT` to ``n``, although this is not recommended.
 
 See the :ref:`ug_matter_device_attestation_device_data_generating` section on the Device Attestation page for more information about the factory data in Matter.
 

--- a/west.yml
+++ b/west.yml
@@ -135,7 +135,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 6eec6a3ec9b3e07ed76707afd5cd2ef1089e8d43
+      revision: 683ceeb5dc291a3dd61017ecc5f1c1fc367050c9
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
This patch aligns Matter factory data partition
with the SPU/ACL driver block sizes.