### PR TITLE
applications: nrf5340_audio: Remove call to audio_datapath in le_audio

### DIFF
--- a/applications/nrf5340_audio/src/audio/Kconfig
+++ b/applications/nrf5340_audio/src/audio/Kconfig
@@ -103,6 +103,21 @@ config AUDIO_BIT_DEPTH_OCTETS
 	help
 	  Bit depth of one sample in storage given in octets.
 
+config AUDIO_MIN_PRES_DLY_US
+	int "The minimum presentation delay"
+	default 4000
+	help
+	  The minimum allowable presentation delay in microseconds.
+	  This needs to allow time for decoding and internal routing.
+	  For 48kHz sampling rate and 96kbps bitrate this is about 4000 us.
+
+config AUDIO_MAX_PRES_DLY_US
+	int "The maximum presentation delay"
+	default 60000
+	help
+	  The maximum allowable presentation delay in microseconds.
+	  Increasing this will also increase the FIFO buffers to allow buffering.
+
 choice AUDIO_SOURCE_GATEWAY
 	prompt "Audio source for gateway"
 	default AUDIO_SOURCE_I2S if WALKIE_TALKIE_DEMO

--- a/applications/nrf5340_audio/src/audio/audio_datapath.h
+++ b/applications/nrf5340_audio/src/audio/audio_datapath.h
@@ -47,26 +47,15 @@ int audio_datapath_pres_delay_us_set(uint32_t delay_us);
 void audio_datapath_pres_delay_us_get(uint32_t *delay_us);
 
 /**
- * @brief Adjust timing to make sure audio data is sent just in time for BLE event
- *
- * @note  The time from last anchor point is checked and then blocks of 1ms
- *        can be dropped to allow the sending of encoded data to be sent just
- *        before the connection interval opens up. This is done to reduce overall
- *        latency.
- *
- * @param[in]  sdu_ref_us  The sdu reference to the previous sent packet in µs
- */
-void audio_datapath_just_in_time_check_and_adjust(uint32_t sdu_ref_us);
-
-/**
  * @brief Update sdu_ref_us so that drift compensation can work correctly
  *
  * @note This function is only valid for gateway using I2S as audio source
  *       and unidirectional audio stream (gateway to headset(s))
  *
- * @param sdu_ref_us ISO timestamp reference from BLE controller
+ * @param sdu_ref_us    ISO timestamp reference from BLE controller
+ * @param adjust        Indicate if the sdu_ref should be used to adjust timing
  */
-void audio_datapath_sdu_ref_update(uint32_t sdu_ref_us);
+void audio_datapath_sdu_ref_update(uint32_t sdu_ref_us, bool adjust);
 
 /**
  * @brief Input an audio data frame which is processed and outputted over I2S

--- a/applications/nrf5340_audio/src/bluetooth/Kconfig
+++ b/applications/nrf5340_audio/src/bluetooth/Kconfig
@@ -369,22 +369,6 @@ config BT_AUDIO_PACKING_INTERLEAVED
 	help
 	  ISO channels can either be interleaved or sequentially packed; sequential is the default one.
 
-config BT_AUDIO_PREFERRED_MIN_PRES_DLY_US
-	int "The preferred minimum presentation delay"
-	range AUDIO_MIN_PRES_DLY_US AUDIO_MAX_PRES_DLY_US
-	default 10000
-	help
-	  The preferred minimum presentation delay in micro seconds. This can not
-	  be less than the absolute minimum presentation delay.
-
-config BT_AUDIO_PREFERRED_MAX_PRES_DLY_US
-	int "The preferred maximum presentation delay"
-	range BT_AUDIO_PREFERRED_MIN_PRES_DLY_US AUDIO_MAX_PRES_DLY_US
-	default 40000
-	help
-	  The preferred maximum presentation delay in micro seconds. This can not
-	  be larger than the absolute maximum presentation delay.
-
 choice	BT_AUDIO_PRES_DLY_SRCH
 	prompt "Default search mode for the presentation delay"
 	default BT_AUDIO_PRES_DELAY_SRCH_PREF_MIN
@@ -442,6 +426,22 @@ config BT_AUDIO_PRESENTATION_DELAY_US
 	  is in range of the max and min supported by the audio receivers.
 	  If it is outside this range, then it will revert to the closest
 	  supported value.
+
+config BT_AUDIO_PREFERRED_MIN_PRES_DLY_US
+	int "The preferred minimum presentation delay"
+	range AUDIO_MIN_PRES_DLY_US AUDIO_MAX_PRES_DLY_US
+	default 10000
+	help
+	  The preferred minimum presentation delay in microseconds. This can not
+	  be less than the absolute minimum presentation delay.
+
+config BT_AUDIO_PREFERRED_MAX_PRES_DLY_US
+	int "The preferred maximum presentation delay"
+	range BT_AUDIO_PREFERRED_MIN_PRES_DLY_US AUDIO_MAX_PRES_DLY_US
+	default 40000
+	help
+	  The preferred maximum presentation delay in microseconds. This can not
+	  be less than the absolute maximum presentation delay.
 
 config BT_AUDIO_MAX_TRANSPORT_LATENCY_MS
 	int "Max transport latency"

--- a/applications/nrf5340_audio/src/bluetooth/le_audio.h
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio.h
@@ -105,6 +105,7 @@
 
 enum le_audio_evt_type {
 	LE_AUDIO_EVT_CONFIG_RECEIVED,
+	LE_AUDIO_EVT_PRES_DELAY_SET,
 	LE_AUDIO_EVT_STREAMING,
 	LE_AUDIO_EVT_NOT_STREAMING,
 	LE_AUDIO_EVT_NUM_EVTS
@@ -125,6 +126,16 @@ struct le_audio_evt {
  */
 typedef void (*le_audio_receive_cb)(const uint8_t *const data, size_t size, bool bad_frame,
 				    uint32_t sdu_ref, enum audio_channel channel_index);
+
+/**
+ * @brief Callback for using the timestamp of the previously sent audio packet
+ *
+ * @note  Can be used for drift calculation/compensation
+ *
+ * @param timestamp     The timestamp
+ * @param adjust        Indicate if the sdu_ref should be used to adjust timing
+ */
+typedef void (*le_audio_timestamp_cb)(uint32_t timestamp, bool adjust);
 
 enum le_audio_user_defined_action {
 	LE_AUDIO_USER_DEFINED_ACTION_1,
@@ -155,14 +166,16 @@ int le_audio_user_defined_button_press(enum le_audio_user_defined_action action)
 /**
  * @brief Get configuration for audio stream
  *
- * @param bitrate	Pointer to bitrate used
- * @param sampling_rate	Pointer to sampling rate used
+ * @param bitrate	Pointer to bitrate used, can be NULL
+ * @param sampling_rate	Pointer to sampling rate used, can be NULL
+ * @param pres_delay	Pointer to presentation delay used, can be NULL
  *
  * @return	0 for success,
  *		-ENXIO if the feature is disabled,
+ *		-ENOTSUP if the feature is not supported,
  *		error otherwise
  */
-int le_audio_config_get(uint32_t *bitrate, uint32_t *sampling_rate);
+int le_audio_config_get(uint32_t *bitrate, uint32_t *sampling_rate, uint32_t *pres_delay);
 
 /**
  * @brief	Increase volume by one step
@@ -214,10 +227,11 @@ int le_audio_send(struct encoded_audio enc_audio);
  * @brief Enable Bluetooth LE Audio
  *
  * @param recv_cb	Callback for receiving Bluetooth LE Audio data
+ * @param timestamp_cb	Callback for using timestamp
  *
  * @return		0 for success, error otherwise
  */
-int le_audio_enable(le_audio_receive_cb recv_cb);
+int le_audio_enable(le_audio_receive_cb recv_cb, le_audio_timestamp_cb timestamp_cb);
 
 /**
  * @brief Disable Bluetooth LE Audio


### PR DESCRIPTION
- cis_headset no longer calls audio_datapath_pres_delay_us_set
- Add a callback to le_audio_send
- Remove direct call from le_audio files to audio_datapath