### PR TITLE
doc: vsc: fix links and mention memory report

### DIFF
--- a/doc/nrf/app_dev/optimizing/memory.rst
+++ b/doc/nrf/app_dev/optimizing/memory.rst
@@ -17,6 +17,7 @@ General recommendations
 To reduce the memory footprint, ensure that your application uses the minimum required resources and tune the |NCS| configuration parameters.
 Complete the following actions to optimize your application:
 
+* Use the `Memory report`_ feature in the |nRFVSC| to check the size and percentage of memory that each symbol uses on your device for RAM, ROM, and partitions (when applicable).
 * Follow the guides for :ref:`optimizing Zephyr <zephyr:optimizations>`.
   Also see the implementation of the :ref:`zephyr:minimal_sample` sample.
 * Analyze stack usage in each thread of your application by using the :ref:`zephyr:thread_analyzer`.

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -175,11 +175,12 @@
 .. _`Migrating IDE`: https://nrfconnect.github.io/vscode-nrf-connect/reference/ui_sidebar_welcome.html#open-an-existing-application
 .. _`How to debug an application`:
 .. _`How to connect to the terminal`: https://nrfconnect.github.io/vscode-nrf-connect/get_started/quick_debug.html
-.. _`Debugging applications for a multi-core System on Chip`: https://nrfconnect.github.io/vscode-nrf-connect/guides/debug_concepts.html
+.. _`Debugging applications for a multi-core System on Chip`: https://nrfconnect.github.io/vscode-nrf-connect/guides/debug_use.html#how-to-debug-applications-for-a-multi-core-system-on-chip
 .. _`west module management`: https://nrfconnect.github.io/vscode-nrf-connect/guides/west_module_management.html
 .. _`Custom launch and debug configurations`: https://nrfconnect.github.io/vscode-nrf-connect/guides/debug_advanced.html#custom-launch-and-debug-configurations
-.. _`Application-specific flash options`: https://nrfconnect.github.io/vscode-nrf-connect/guides/build_customize_config.html#application-specific-flash-options
+.. _`Application-specific flash options`: https://nrfconnect.github.io/vscode-nrf-connect/guides/bd_work_with_boards.html#how-to-flash-boards
 .. _`How to work with build configurations`: https://nrfconnect.github.io/vscode-nrf-connect/guides/build_config.html
+.. _`Memory report`: https://nrfconnect.github.io/vscode-nrf-connect/guides/memory_overview.html
 
 .. _`Azure SDK for Embedded C`: https://azure.github.io/azure-sdk-for-c/
 


### PR DESCRIPTION
Fixed links to the VSC extension docs.
Added mention of the memory report feature in optimizing memory. VSC-1450.