### PR TITLE
applications: nrf5340_audio: Remove loop dependency in dfu-entry

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/le_audio_cis_gateway.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_cis_gateway.c
@@ -209,7 +209,7 @@ static void available_contexts_cb(struct bt_conn *conn, enum bt_audio_context sn
 	LOG_DBG("conn: %s, snk ctx %d src ctx %d\n", addr, snk_ctx, src_ctx);
 }
 
-const struct bt_audio_unicast_client_cb unicast_client_cbs = {
+static const struct bt_audio_unicast_client_cb unicast_client_cbs = {
 	.location = unicast_client_location_cb,
 	.available_contexts = available_contexts_cb,
 };

--- a/applications/nrf5340_audio/src/main.c
+++ b/applications/nrf5340_audio/src/main.c
@@ -194,8 +194,8 @@ void main(void)
 	}
 
 #if defined(CONFIG_AUDIO_DFU_ENABLE)
-	/* Check DFU BTN before Initialize BLE */
-	dfu_entry_check();
+	/* Check DFU BTN before initialize BLE */
+	dfu_entry_check((void *)ble_core_init);
 #endif
 
 	/* Initialize BLE, with callback for when BLE is ready */

--- a/applications/nrf5340_audio/src/modules/dfu_entry.c
+++ b/applications/nrf5340_audio/src/modules/dfu_entry.c
@@ -6,14 +6,15 @@
 
 /* Override compiler definition to use size-bounded string copying and concatenation function */
 #define _BSD_SOURCE
-#include "string.h"
+#include "dfu_entry.h"
+
 #include <zephyr/kernel.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/settings/settings.h>
 
+#include "string.h"
 #include "button_assignments.h"
-#include "ble_core.h"
 #include "button_handler.h"
 #include "macros_common.h"
 #include "channel_assignment.h"
@@ -98,7 +99,7 @@ static void on_ble_core_ready_dfu_entry(void)
 	smp_adv();
 }
 
-void dfu_entry_check(void)
+void dfu_entry_check(ble_init_func ble_init)
 {
 	int ret;
 	bool pressed;
@@ -110,7 +111,7 @@ void dfu_entry_check(void)
 
 	if (pressed) {
 		LOG_INF("Enter SMP_SVR service only status");
-		ret = ble_core_init(on_ble_core_ready_dfu_entry);
+		ret = ble_init(on_ble_core_ready_dfu_entry);
 		ERR_CHK(ret);
 
 		while (1) {

--- a/applications/nrf5340_audio/src/modules/dfu_entry.h
+++ b/applications/nrf5340_audio/src/modules/dfu_entry.h
@@ -8,9 +8,15 @@
 #define _DFU_ENTRY_H_
 
 /**
- * @brief Check Btn pressed status to advertise SMP_SVR service only
+ * @brief	Pointer to function that initializes the BLE subsystem
  */
+typedef int (*ble_init_func)(void *ready_callback);
 
-void dfu_entry_check(void);
+/**
+ * @brief Check button pressed status to advertise SMP_SVR service only
+ *
+ * @param[in]	ble_init Pointer to function that initializes the BLE subsystem
+ */
+void dfu_entry_check(ble_init_func ble_init);
 
 #endif /* _DFU_ENTRY_H_ */


### PR DESCRIPTION
Remove loop dependency between dfu-entry.c and ble_core.c. OCT-2466
Signed-off-by: Jui-Chou Chung <jui-chou.chung@nordicsemi.no>