### PR TITLE
tfm: Revert abort crypto operation on failure

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -131,7 +131,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: fb18cfa42495acab64c7a50738100a4c308cd350
+      revision: 0b3e5ce3bda40da4fc8f167536bfcc1f7fc9c1f9
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter


### PR DESCRIPTION
Revert downstream patch to release TF-M crypto operation when crypto operation has failed and entered an error state. The application has to abort the crypto operation.

NCSDK-16491