### PR TITLE
drivers: wifi: Implement radio status event

### DIFF
--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fmac_structs.h
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fmac_structs.h
@@ -75,6 +75,10 @@ struct wifi_nrf_fmac_dev_ctx {
 	enum nrf_wifi_rf_test rf_test_type;
 	void *rf_test_cap_data;
 	unsigned int rf_test_cap_sz;
+#ifdef CONFIG_NRF700X_RADIO_TEST
+	bool radio_cmd_done;
+	enum nrf_wifi_radio_test_err_status radio_cmd_status;
+#endif /* CONFIG_NRF700X_RADIO_TEST */
 };
 
 #else /* CONFIG_NRF700X_RADIO_TEST */

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/event.c
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/event.c
@@ -758,9 +758,19 @@ static enum wifi_nrf_status umac_process_sys_events(struct wifi_nrf_fmac_dev_ctx
 		status = umac_event_rf_test_process(fmac_dev_ctx,
 						    sys_head);
 		break;
+	case NRF_WIFI_EVENT_RADIOCMD_STATUS:
+		struct nrf_wifi_umac_event_err_status *umac_status =
+			((struct nrf_wifi_umac_event_err_status *)sys_head);
+		fmac_dev_ctx->radio_cmd_status = umac_status->status;
+		fmac_dev_ctx->radio_cmd_done = true;
+		status = WIFI_NRF_STATUS_SUCCESS;
+		break;
 #endif /* CONFIG_NRF700X_RADIO_TEST */
 	default:
-		status = WIFI_NRF_STATUS_FAIL;
+		wifi_nrf_osal_log_err(fmac_dev_ctx->fpriv->opriv,
+				      "%s: Unknown event recd: %d\n",
+				      __func__,
+				      ((struct nrf_wifi_sys_head *)sys_head)->cmd_event);
 		break;
 	}
 


### PR DESCRIPTION
For all radio test commands (init, TX and RX) UMAC now sends a status command primarily to handle OTP disable of 5GHz.

Fixes NRF7X-43.


@vivinordic @krga2022  Please test, I have only done basic testing as I don't have the setup.