### PR TITLE
samples: nrf9160: modem_shell: Fix nRF7002 EK build command in readme

### DIFF
--- a/samples/nrf9160/modem_shell/README.rst
+++ b/samples/nrf9160/modem_shell/README.rst
@@ -1069,7 +1069,7 @@ For example:
 
 .. code-block:: console
 
-   west build -p -b nrf9160dk_nrf9160ns -- -DSHIELD=nrf7002_ek -DDTC_OVERLAY_FILE=nrf9160dk_with_nrf7002ek.overlay -DOVERLAY_CONFIG=overlay-nrf7002ek-wifi-scan-only.conf
+   west build -p -b nrf9160dk_nrf9160_ns -- -DSHIELD=nrf7002_ek -DDTC_OVERLAY_FILE=nrf9160dk_with_nrf7002ek.overlay -DOVERLAY_CONFIG=overlay-nrf7002ek-wifi-scan-only.conf
 
 See :ref:`cmake_options` for more instructions on how to add these options.
 


### PR DESCRIPTION
Fixed board name in build command with nRF7002 EK.