### PR TITLE
doc: matter: add webinar embeds

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -991,7 +991,7 @@
 
 .. _`Memfault Diagnostic GATT Service`: https://memfault.notion.site/Memfault-Diagnostic-GATT-Service-MDS-ffd5a430062649cd9bf6edbf64e2563b
 
-.. _`Developing Matter products with nRF Connect SDK`: https://www.youtube.com/watch?v=kdMJQFDRoss
+.. _`Developing Matter 1.0 products with nRF Connect SDK`: https://www.youtube.com/watch?v=9Ar13rMxGIk
 
 .. _`iBasis IoT network coverage`: https://ibasis.com/solutions/iot-connectivity/network-coverage/
 

--- a/doc/nrf/protocols/matter/end_product/index.rst
+++ b/doc/nrf/protocols/matter/end_product/index.rst
@@ -10,6 +10,14 @@ How to create Matter end product
 This section provides information about Matter end product development.
 It is intended for users who are familiar enough with both the Matter technology and the |NCS|.
 
+Watch the following video for an overview of the Matter end product development process.
+
+.. raw:: html
+
+   <h1 align="center">
+   <iframe width="560" height="315" src="https://www.youtube.com/embed/ZV6fjTLAqdA" title="How to go to market with Matter" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+   </h1>
+
 The pages that follow deal with the preparation of the device for market launch, starting with :ref:`ug_matter_device_prerequisites` and the reference to the :ref:`ug_matter_device_factory_provisioning` guide.
 Finally, we discuss topics related to Matter certification (:ref:`ug_matter_device_attestation`, :ref:`ug_matter_device_dcl`, and :ref:`ug_matter_device_certification`) and :ref:`ug_matter_device_bootloader`.
 

--- a/doc/nrf/protocols/matter/getting_started/index.rst
+++ b/doc/nrf/protocols/matter/getting_started/index.rst
@@ -7,7 +7,15 @@ Getting started with Matter
    :local:
    :depth: 2
 
-Read pages in this section to start working with Matter using Nordic Semiconductor's SoCs and tools in both the |NCS| and Zephyr.
+Read pages in this section and watch the video to start working with Matter using Nordic Semiconductor's SoCs and tools in both the |NCS| and Zephyr.
+
+The following video showcases several aspects of the Matter setup, discussed in detail on the following pages.
+
+.. raw:: html
+
+   <h1 align="center">
+   <iframe width="560" height="315" src="https://www.youtube.com/embed/9Ar13rMxGIk" title="Getting started with Matter" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+   </h1>
 
 The pages will guide you through the following getting started process:
 

--- a/doc/nrf/protocols/matter/index.rst
+++ b/doc/nrf/protocols/matter/index.rst
@@ -19,7 +19,7 @@ Matter over Thread support is in the :ref:`production state <software_maturity>`
 
 The |NCS| allows you to develop applications that are compatible with Matter.
 See :ref:`matter_samples` for the list of available samples or :ref:`Matter Weather Station <matter_weather_station_app>` for specific Matter application.
-If you are new to Matter, you can follow along with the video tutorials on Nordic Semiconductor's YouTube channel, for example `Developing Matter products with nRF Connect SDK`_.
+If you are new to Matter, you can follow along with the video tutorials on Nordic Semiconductor's YouTube channel, for example `Developing Matter 1.0 products with nRF Connect SDK`_.
 
 .. note::
     |matter_gn_required_note|

--- a/doc/nrf/protocols/matter/overview/index.rst
+++ b/doc/nrf/protocols/matter/overview/index.rst
@@ -9,17 +9,12 @@ Matter overview
 
 |matter_intro|
 
-Watch the following webinar for a brief introduction to Matter.
+Watch the following video for a brief introduction to Matter.
 
 .. raw:: html
 
    <h1 align="center">
-   <iframe id="Matter_Introduction_TechWebinar"
-           title="NordicTech Webinar: Introduction to Matter"
-           width="700"
-           height="393"
-           src="https://webinars.nordicsemi.com/v.ihtml/player.html?source=embed&photo%5fid=70782494">
-   </iframe>
+   <iframe width="560" height="315" src="https://www.youtube.com/embed/v_285vCHifw" title="Introduction to Matter" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
    </h1>
 
 The following are some of the key features of Matter:


### PR DESCRIPTION
Added new embeds for Matter webinars.
Replaced one embed with a YouTube iFrame.
KRKNWK-16086.