### PR TITLE
samples: Bluetooth: Mesh: add configs with overlay in twister ci

### DIFF
--- a/samples/bluetooth/mesh/light/sample.yaml
+++ b/samples/bluetooth/mesh/light/sample.yaml
@@ -17,3 +17,11 @@ tests:
       nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp thingy53_nrf5340_cpuapp_ns
       nrf21540dk_nrf52840 nrf52833dk_nrf52833
     tags: bluetooth ci_build
+  sample.bluetooth.mesh.light.dfu:
+    build_only: true
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf21540dk_nrf52840
+    platform_allow: nrf52840dk_nrf52840 nrf21540dk_nrf52840
+    extra_args: OVERLAY_CONFIG=overlay-dfu.conf
+    tags: bluetooth ci_build

--- a/samples/bluetooth/mesh/light_switch/sample.yaml
+++ b/samples/bluetooth/mesh/light_switch/sample.yaml
@@ -17,3 +17,12 @@ tests:
       nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp thingy53_nrf5340_cpuapp_ns
       nrf21540dk_nrf52840 nrf52833dk_nrf52833
     tags: bluetooth ci_build
+  sample.bluetooth.mesh.light_switch.lpn:
+    build_only: true
+    integration_platforms:
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf52833dk_nrf52833
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52833dk_nrf52833
+    extra_args: OVERLAY_CONFIG=overlay-lpn.conf
+    tags: bluetooth ci_build


### PR DESCRIPTION
PR adds mesh sample configurations those use overlays to twister build ci plan.