### PR TITLE
Fix 5340 pin conflicts

### DIFF
--- a/boards/shields/nrf7002_ek/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/boards/shields/nrf7002_ek/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,15 @@
+/* Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* This node by default forwards the UART1 pins to CPUNET, but as UART1 uses
+ * same pins as bucken and iovdd-ctrl, we need these pins to be controlled by
+ * the CPUAPP. Since a child node of gpio_fwd cannot be disabled, hence
+ * the entire node is disabled. If the application needs to forward other pins
+ * to the CPUNET, it should create a separate instance of nrf-gpio-forwarder
+ * and use it instead.
+ */
+&gpio_fwd {
+	status = "disabled";
+};

--- a/boards/shields/nrf7002_ek/nrf7002_ek.overlay
+++ b/boards/shields/nrf7002_ek/nrf7002_ek.overlay
@@ -15,8 +15,8 @@
 		reg = <0>;
 		spi-max-frequency = <DT_FREQ_M(8)>;
 
-		iovdd-ctrl-gpios = <&arduino_header 6 GPIO_ACTIVE_HIGH>;    /* D0 */
-		bucken-gpios = <&arduino_header 7 GPIO_ACTIVE_HIGH>;        /* D1 */
+		iovdd-ctrl-gpios = <&arduino_header 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;    /* D0 */
+		bucken-gpios = <&arduino_header 7 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;        /* D1 */
 		host-irq-gpios = <&arduino_header 13 GPIO_ACTIVE_HIGH>;     /* D7 */
 	};
 };

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/fmac_api.c
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/fmac_api.c
@@ -3188,7 +3188,7 @@ enum wifi_nrf_status wifi_nrf_fmac_chg_vif_state(void *dev_ctx,
 	if (count == 0) {
 		wifi_nrf_osal_log_err(fmac_dev_ctx->fpriv->opriv,
 				      "%s: RPU is unresponsive for %d sec\n",
-				      __func__, RPU_CMD_TIMEOUT_MS);
+				      __func__, RPU_CMD_TIMEOUT_MS / 1000);
 		goto out;
 	}
 

--- a/drivers/wifi/nrf700x/zephyr/src/qspi/inc/rpu_hw_if.h
+++ b/drivers/wifi/nrf700x/zephyr/src/qspi/inc/rpu_hw_if.h
@@ -16,8 +16,6 @@
 #include <stdlib.h>
 #include <zephyr/drivers/gpio.h>
 
-#define SLEEP_TIME_MS 10
-
 enum {
 	SYSBUS = 0,
 	EXT_SYS_BUS,

--- a/drivers/wifi/nrf700x/zephyr/src/qspi/src/rpu_hw_if.c
+++ b/drivers/wifi/nrf700x/zephyr/src/qspi/src/rpu_hw_if.c
@@ -181,9 +181,11 @@ int rpu_gpio_config(void)
 int rpu_pwron(void)
 {
 	gpio_pin_set_dt(&bucken_spec, 1);
-	k_msleep(SLEEP_TIME_MS);
+	/* Settling time is 50us (H0) or 100us (L0) */
+	k_msleep(1);
 	gpio_pin_set_dt(&iovdd_ctrl_spec, 1);
-	k_msleep(SLEEP_TIME_MS);
+	/* Settling time for iovdd switch (TCK106AG): ~600us */
+	k_msleep(1);
 	LOG_DBG("BUCKEN=1, IOVDD=1...\n");
 
 	return 0;

--- a/drivers/wifi/nrf700x/zephyr/src/qspi/src/rpu_hw_if.c
+++ b/drivers/wifi/nrf700x/zephyr/src/qspi/src/rpu_hw_if.c
@@ -171,7 +171,17 @@ int rpu_gpio_config(void)
 
 	ret = gpio_pin_configure_dt(&bucken_spec, (GPIO_OUTPUT | NRF_GPIO_DRIVE_H0H1));
 
+	if (ret) {
+		LOG_ERR("BUCKEN GPIO configuration failed...\n");
+		return ret;
+	}
+
 	ret = gpio_pin_configure_dt(&iovdd_ctrl_spec, GPIO_OUTPUT);
+
+	if (ret) {
+		LOG_ERR("IOVDD GPIO configuration failed...\n");
+		return ret;
+	}
 
 	LOG_DBG("GPIO configuration done...\n\n");
 
@@ -180,13 +190,24 @@ int rpu_gpio_config(void)
 
 int rpu_pwron(void)
 {
-	gpio_pin_set_dt(&bucken_spec, 1);
+	int ret;
+
+	ret = gpio_pin_set_dt(&bucken_spec, 1);
+	if (ret) {
+		LOG_ERR("BUCKEN GPIO set failed...\n");
+		return ret;
+	}
 	/* Settling time is 50us (H0) or 100us (L0) */
 	k_msleep(1);
-	gpio_pin_set_dt(&iovdd_ctrl_spec, 1);
+	ret = gpio_pin_set_dt(&iovdd_ctrl_spec, 1);
+	if (ret) {
+		LOG_ERR("IOVDD GPIO set failed...\n");
+		return ret;
+	}
 	/* Settling time for iovdd switch (TCK106AG): ~600us */
 	k_msleep(1);
-	LOG_DBG("BUCKEN=1, IOVDD=1...\n");
+	LOG_DBG("Bucken = %d, IOVDD = %d\n", gpio_pin_get_dt(&bucken_spec),
+			gpio_pin_get_dt(&iovdd_ctrl_spec));
 
 	return 0;
 }

--- a/drivers/wifi/nrf700x/zephyr/src/qspi/src/rpu_hw_if.c
+++ b/drivers/wifi/nrf700x/zephyr/src/qspi/src/rpu_hw_if.c
@@ -316,7 +316,7 @@ int rpu_enable(void)
 
 int rpu_disable(void)
 {
-	gpio_pin_set_dt(&iovdd_ctrl_spec, 0); /* IOVDD CNTRL = 0 */
 	gpio_pin_set_dt(&bucken_spec, 0); /* BUCKEN = 0 */
+	gpio_pin_set_dt(&iovdd_ctrl_spec, 0); /* IOVDD CNTRL = 0 */
 	return 0;
 }

--- a/samples/wifi/shell/sample.yaml
+++ b/samples/wifi/shell/sample.yaml
@@ -17,6 +17,13 @@ tests:
       - nrf52840dk_nrf52840
     platform_allow: nrf5340dk_nrf5340_cpuapp nrf52840dk_nrf52840
     tags: ci_build
+  sample.nrf7002_eks_cpunet.shell:
+    build_only: true
+    extra_args: SHIELD=nrf7002_ek CONFIG_BOARD_ENABLE_CPUNET=y
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf5340dk_nrf5340_cpuapp
+    tags: ci_build
   sample.nrf7002.shell.zperf:
     build_only: true
     extra_args: OVERLAY_CONFIG=overlay-zperf.conf

--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -48,3 +48,10 @@
   platforms:
     - all
   comment: "Disable building selected Matter samples to limit resources usage"
+
+- scenarios:
+    - applications.asset_tracker_v2.nrf7002ek_wifi-debug
+    - applications.asset_tracker_v2.nrf7002ek_wifi-release
+  platforms:
+    - all
+  comment: "Temporary disable till the issue is fixed"


### PR DESCRIPTION
CPUNET UART conflicts with nRF7002 EK pins, this attempts to solve for all samples instead of doing it for every sample.