### PR TITLE
application: serial_lte_modem: BUG-FIX for large MQTT PUB msg

### DIFF
--- a/applications/serial_lte_modem/src/mqtt_c/slm_at_mqtt.c
+++ b/applications/serial_lte_modem/src/mqtt_c/slm_at_mqtt.c
@@ -86,7 +86,7 @@ static int handle_mqtt_publish_evt(struct mqtt_client *const c, const struct mqt
 		evt->param.publish.message.topic.topic.size);
 	data_send("\r\n", 2);
 	do {
-		ret = mqtt_read_publish_payload(c, data_buf, sizeof(data_buf));
+		ret = mqtt_read_publish_payload_blocking(c, data_buf, sizeof(data_buf));
 		if (ret > 0) {
 			data_send(data_buf, ret);
 			size_read += ret;

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -154,6 +154,10 @@ nRF9160: Serial LTE modem
 
   * Use defines from the :ref:`lib_nrf_cloud` library for nRF Cloud related string values.
 
+* Fixed:
+
+  * A bug in receiving large MQTT Publish message.
+
 nRF5340 Audio
 -------------
 


### PR DESCRIPTION
If the PUB msg is larger than TCP MSS on modem side, there will
be multiple TCP packets received by modem, and multiple POLLIN
events in the MQTT polling thread to call mqtt_input(), which
in turn get -EBUSY and abort MQTT connection.

Need to force reading the whole payload by recv() in blocking
mode instead, in one mqtt_input() callback.

JIRA ticket: NRF91-1675