### PR TITLE
editorconfig: Add text editor configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*.{c,conf,cpp,dts,overlay,h,ld,py,rst,txt,yaml,yml}, Kconfig*, defconfig*, README]
+insert_final_newline = true


### PR DESCRIPTION
Add EditorConfig for cross-editor (some native, some plugin) settings to support coding rules. Initial setting is for a final newline, as checked by check_compliance.py line 715.

For details on EditorConfig, see https://editorconfig.org/

There are a lot of other settings that could be added, such as those checked by clang-format and checkpatch.pl and other scripts, e.g. line length, but I don't know enough about the project to set that up; so just starting with this small, specific rule (which I ran into submitting another change).

The benefit of EditorConfig is that it is cross-editor, allowing different contributors to use different editors but with the same project settings applied. Many editors have built in support, and there are many more that have plugins.