### PR TITLE
doc: nrf: enable copybutton extension

### DIFF
--- a/doc/nrf/conf.py
+++ b/doc/nrf/conf.py
@@ -44,6 +44,7 @@ extensions = [
     "sphinx_tabs.tabs",
     "software_maturity_table",
     "sphinx_togglebutton",
+    "sphinx_copybutton",
     "notfound.extension",
 ]
 


### PR DESCRIPTION
This allows copying source snippets by just clicking on a button. This extension is already enabled in the Zephyr docset (inherited from upstream).