### PR TITLE
samples: matter: disable WiFi LMP for ICD samples

### DIFF
--- a/samples/matter/light_switch/Kconfig
+++ b/samples/matter/light_switch/Kconfig
@@ -37,7 +37,7 @@ endif # NET_L2_OPENTHREAD
 if CHIP_WIFI
 
 config NRF_WIFI_LOW_POWER
-	default y
+	default n
 
 endif # CHIP_WIFI
 

--- a/samples/matter/lock/Kconfig
+++ b/samples/matter/lock/Kconfig
@@ -89,7 +89,7 @@ endif # NET_L2_OPENTHREAD
 if CHIP_WIFI
 
 config NRF_WIFI_LOW_POWER
-	default y
+	default n
 
 endif # CHIP_WIFI
 


### PR DESCRIPTION
We observe some IPv6 connectivity issues in automated tests. 
This commit aims to exclude LPM from potential reasons.

DO NOT MERGE