### PR TITLE
workflows: Allow trusted authors to publish docs

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -74,13 +74,13 @@ jobs:
           ninja -C doc/_build
 
       - name: Build cache
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'external') }}
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'external') || contains(github.event.pull_request.labels.*.name, 'CI-trusted-author') }}
         working-directory: ncs/nrf
         run: |
             python3 doc/_scripts/cache_create.py -b doc/_build -o cache
 
       - name: Prepare extra cache files
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'external') }}
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'external') || contains(github.event.pull_request.labels.*.name, 'CI-trusted-author') }}
         working-directory: ncs/nrf/cache
         run: |
           mkdir extra && cd extra
@@ -107,7 +107,7 @@ jobs:
           fi
 
       - name: Archive cache
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'external') }}
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'external') || contains(github.event.pull_request.labels.*.name, 'CI-trusted-author') }}
         uses: actions/upload-artifact@v2
         with:
           name: cache


### PR DESCRIPTION
Modified the conditionals to allow publication if they do not have the `external` tag, OR have the `CI-trusted-author` tag.