### PR TITLE
lib: dk_buttons_and_leds: fix for nRF9160DK IO expander

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -464,7 +464,9 @@ Libraries for NFC
 Other libraries
 ---------------
 
-|no_changes_yet_note|
+* :ref:`dk_buttons_and_leds_readme` library:
+
+  * The library now supports using the GPIO expander for the buttons, switches, and LEDs on the nRF9160 DK.
 
 Common Application Framework (CAF)
 ----------------------------------


### PR DESCRIPTION
The driver for the PCAL6408A IO expander on the nRF9160DK does not support disabling the interrupts while they are being processed. Move disabling of the interrupts to the buttons_scan_fn function. Also, the IO expander driver only supports edge driven interrupts, so this is added to the configuration.