### PR TITLE
doc: sml: uppercase column titles

### DIFF
--- a/doc/_extensions/software_maturity_table.py
+++ b/doc/_extensions/software_maturity_table.py
@@ -196,7 +196,7 @@ class SoftwareMaturityTable(SphinxDirective):
         row += nodes.entry()
 
         for soc in all_socs:
-            soc = soc.replace("nrf", "nRF")
+            soc = soc.upper().replace("NRF", "nRF")
             entry = nodes.entry()
             entry += nodes.paragraph(text=soc)
             row += entry


### PR DESCRIPTION
Changed column titles from lowercase to uppercase. "NRF" is still turned into "nRF".