### PR TITLE
doc: ncs: add definition of NCS toolchain

### DIFF
--- a/doc/nrf/getting_started/installing.rst
+++ b/doc/nrf/getting_started/installing.rst
@@ -16,11 +16,12 @@ For instructions on automatic installation, see the :ref:`gs_assistant` page.
 
 To manually install the |NCS|, you must first install all the required tools and clone the |NCS| repositories.
 
+The |NCS| :term:`toolchain` includes the Zephyr SDK and then adds on top of it tools and modules required to build |NCS| samples and applications.
 If you already have your system set up to work with Zephyr OS, based on Zephyr's :ref:`zephyr:getting_started`, it means you have most of the requirements for the |NCS| installed.
-The only requirement that is not covered by the installation steps in Zephyr is the :ref:`GN tool <gs_installing_gn>`.
-This tool is needed only for :ref:`ug_matter` applications.
+However, you still need to install a set of additional tools, including Python dependencies and the |nRFVSC|.
+You might also need the :ref:`GN tool <gs_installing_gn>` if you are insterested in creating :ref:`ug_matter` applications.
 
-Before you start setting up the toolchain, install available updates for your operating system.
+Before you start setting up the |NCS| toolchain, install available updates for your operating system.
 See :ref:`gs_recommended_versions` for information on the supported operating systems and Zephyr features.
 
 .. _gs_installing_tools:
@@ -389,16 +390,16 @@ Use the following commands to install the requirements for each repository.
 
 .. rst-class:: numbered-step
 
-Install a Toolchain
-*******************
-
-A toolchain provides a compiler, assembler, linker, and other programs required to build Zephyr applications.
+Install the Zephyr SDK
+**********************
 
 The Zephyr Software Development Kit (SDK) contains toolchains for each of Zephyr's supported architectures.
-It also includes additional host tools, such as custom QEMU and OpenOCD builds.
+Each toolchain provides a compiler, assembler, linker, and some, but not all, of the rest of the programs required to build Zephyr applications.
+The Zephyr SDK also includes additional host tools, such as custom QEMU and OpenOCD builds.
+It is at the base of the |NCS| :term:`toolchain`, which adds on top of it several tools and modules of its own.
 
 .. note::
-   When updating Zephyr SDK, :ref:`verify the Zephyr SDK variables <zephyr:toolchain_zephyr_sdk_update>`.
+   When updating the Zephyr SDK, :ref:`verify the Zephyr SDK variables <zephyr:toolchain_zephyr_sdk_update>`.
    Make sure that the ``zephyr`` toolchain is selected, not ``gnuarmemb``.
 
 .. tabs::

--- a/doc/nrf/getting_started/recommended_versions.rst
+++ b/doc/nrf/getting_started/recommended_versions.rst
@@ -20,7 +20,7 @@ However, there are some Zephyr features that are currently only available on Lin
 
    .. _gs_update_os:
 
-   Before you start setting up the toolchain, install available updates for your operating system.
+   Before you start setting up the |NCS| toolchain, install available updates for your operating system.
 
 .. _gs_supported_OS:
 
@@ -93,8 +93,13 @@ Not applicable
 .. note::
    The |NCS| tools are not supported by the older versions of the operating system.
 
+|NCS| toolchain
+***************
+
+The |NCS| :term:`toolchain` includes the Zephyr SDK and then adds on top of it tools and modules required to build |NCS| samples and applications.
+
 Required tools
-**************
+==============
 
 The following table shows the tools that are required for working with |NCS| v\ |version|.
 It lists the versions that are used for testing and installed when using the :ref:`Toolchain Manager <gs_app_tcm>`, as described in :ref:`gs_assistant`.
@@ -176,9 +181,8 @@ Other versions might also work, but are not verified.
          * - West
            - |west_recommended_ver_darwin|
 
-
 Required Python dependencies
-****************************
+============================
 
 The following table shows the Python packages that are required for working with |NCS| v\ |version|.
 If no version is specified, the default version provided with pip is recommended.
@@ -188,7 +192,7 @@ The :ref:`Toolchain Manager <gs_app_tcm>` will install all Python dependencies i
 If you install manually, see :ref:`additional_deps` for instructions on how to install the Python dependencies and :ref:`gs_updating` for information about how to keep them updated.
 
 Building and running applications, samples, and tests
-=====================================================
+-----------------------------------------------------
 
 .. list-table::
    :header-rows: 1
@@ -229,7 +233,7 @@ Building and running applications, samples, and tests
 .. _python_req_documentation:
 
 Building documentation
-======================
+----------------------
 
 .. list-table::
    :header-rows: 1

--- a/doc/nrf/glossary.rst
+++ b/doc/nrf/glossary.rst
@@ -696,7 +696,9 @@ Glossary
       This reliability comes at the cost of control packets overhead of the protocol itself, making it unsuitable for bandwidth-constrained applications.
 
    Toolchain
-      A set of development tools.
+      A set of development tools: compiler, assembler, and linker.
+      The Zephyr SDK includes this set plus a couple more Zephyr-specific tools.
+      The |NCS| toolchain is based on the Zephyr SDK and then adds on top of it a :ref:`set of tools and modules specific to the |NCS| <gs_recommended_versions>` that are required to build |NCS| samples and applications.
 
    Transmit Data (TXD)
       A signal line in a serial interface that transmits data to another device.


### PR DESCRIPTION
Clarified what the NCS toolchain is, as opposed to Zephyr toolchain. NCSDK-19663.

----

Please check the JIRA task and the link to the Teams conversation for details where this change is coming from:
https://projecttools.nordicsemi.no/jira/browse/NCSDK-19663