### PR TITLE
fast_pair: Align salt size in the not discoverable advertising

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -338,6 +338,7 @@ Bluetooth libraries and services
 
   * Added the :c:func:`bt_fast_pair_info_cb_register` function and the :c:struct:`bt_fast_pair_info_cb` structure to register Fast Pair information callbacks.
     The :c:member:`bt_fast_pair_info_cb.account_key_written` callback can be used to notify the application about the Account Key writes.
+  * Updated the salt size in the Fast Pair not discoverable advertising from 1 byte to 2 bytes to align with the Fast Pair specification update.
 
 Bootloader libraries
 --------------------

--- a/subsys/bluetooth/services/fast_pair/fp_advertising.c
+++ b/subsys/bluetooth/services/fast_pair/fp_advertising.c
@@ -66,7 +66,7 @@ static size_t bt_fast_pair_adv_data_size_non_discoverable(size_t account_key_cnt
 	if (account_key_cnt == 0) {
 		res += sizeof(empty_account_key_list);
 	} else {
-		uint8_t salt;
+		uint16_t salt;
 
 		res += FIELD_LEN_TYPE_SIZE;
 		res += fp_crypto_account_key_filter_size(account_key_cnt);
@@ -168,7 +168,7 @@ static int fp_adv_data_fill_non_discoverable(struct net_buf_simple *buf, size_t 
 		struct fp_account_key ak[CONFIG_BT_FAST_PAIR_STORAGE_ACCOUNT_KEY_MAX];
 		size_t ak_filter_size = fp_crypto_account_key_filter_size(account_key_cnt);
 		size_t account_key_get_cnt = account_key_cnt;
-		uint8_t salt;
+		uint16_t salt;
 		int err;
 
 		err = sys_csrand_get(&salt, sizeof(salt));
@@ -198,7 +198,7 @@ static int fp_adv_data_fill_non_discoverable(struct net_buf_simple *buf, size_t 
 		}
 
 		net_buf_simple_add_u8(buf, ENCODE_FIELD_LEN_TYPE(sizeof(salt), FP_FIELD_TYPE_SALT));
-		net_buf_simple_add_u8(buf, salt);
+		net_buf_simple_add_be16(buf, salt);
 	}
 
 	if (add_battery_info) {

--- a/subsys/bluetooth/services/fast_pair/fp_crypto/fp_crypto_common.c
+++ b/subsys/bluetooth/services/fast_pair/fp_crypto/fp_crypto_common.c
@@ -94,7 +94,7 @@ size_t fp_crypto_account_key_filter_size(size_t n)
 }
 
 int fp_crypto_account_key_filter(uint8_t *out, const struct fp_account_key *account_key_list,
-				 size_t n, uint8_t salt, const uint8_t *battery_info)
+				 size_t n, uint16_t salt, const uint8_t *battery_info)
 {
 	size_t s = fp_crypto_account_key_filter_size(n);
 	uint8_t v[FP_ACCOUNT_KEY_LEN + sizeof(salt) + FP_CRYPTO_BATTERY_INFO_LEN];
@@ -110,8 +110,8 @@ int fp_crypto_account_key_filter(uint8_t *out, const struct fp_account_key *acco
 		memcpy(v, account_key_list[i].key, FP_ACCOUNT_KEY_LEN);
 		pos += FP_ACCOUNT_KEY_LEN;
 
-		v[pos] = salt;
-		pos++;
+		sys_put_be16(salt, &v[pos]);
+		pos += sizeof(salt);
 
 		if (battery_info) {
 			memcpy(&v[pos], battery_info, FP_CRYPTO_BATTERY_INFO_LEN);

--- a/subsys/bluetooth/services/fast_pair/fp_crypto/include/fp_crypto.h
+++ b/subsys/bluetooth/services/fast_pair/fp_crypto/include/fp_crypto.h
@@ -148,14 +148,15 @@ size_t fp_crypto_account_key_filter_size(size_t n);
  * @param[in] account_key_list Pointer to array of Account Keys. Array length has to be at least
  *			       equal to number of Account Keys.
  * @param[in] n Number of account keys (n >= 1).
- * @param[in] salt Random byte - Salt.
+ * @param[in] salt Random 2-byte value - Salt. The Salt is concatenated with Account Keys in
+ *		   big-endian format.
  * @param[in] battery_info Battery info or NULL if there is no battery info. Length of battery info
  *			   must be equal to @ref FP_CRYPTO_BATTERY_INFO_LEN.
  *
  * @return 0 If the operation was successful. Otherwise, a (negative) error code is returned.
  */
 int fp_crypto_account_key_filter(uint8_t *out, const struct fp_account_key *account_key_list,
-				 size_t n, uint8_t salt, const uint8_t *battery_info);
+				 size_t n, uint16_t salt, const uint8_t *battery_info);
 
 /** Encode data to Additional Data packet.
  *

--- a/tests/subsys/bluetooth/fast_pair/crypto/src/main.c
+++ b/tests/subsys/bluetooth/fast_pair/crypto/src/main.c
@@ -184,14 +184,14 @@ static void test_aes_key_from_ecdh_shared_secret(void)
 
 static void test_bloom_filter(void)
 {
-	static const uint8_t salt = 0xC7;
+	static const uint16_t salt = 0xC7C8;
 
 	static const struct fp_account_key first_account_key_list[] = {
 		{ .key = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0x00, 0xAA, 0xBB,
 			  0xCC, 0xDD, 0xEE, 0xFF} }
 		};
 
-	static const uint8_t first_bloom_filter[] = {0x0A, 0x42, 0x88, 0x10};
+	static const uint8_t first_bloom_filter[] = {0x02, 0x0C, 0x80, 0x2A};
 
 	uint8_t first_result_buf[sizeof(first_bloom_filter)];
 
@@ -207,7 +207,7 @@ static void test_bloom_filter(void)
 
 	static const uint8_t battery_info[] = {0b00110011, 0b01000000, 0b01000000, 0b01000000};
 
-	static const uint8_t first_bloom_filter_with_battery_info[] = {0x4A, 0x00, 0xF0, 0x00};
+	static const uint8_t first_bloom_filter_with_battery_info[] = {0x01, 0x01, 0x46, 0x0A};
 
 	zassert_equal(sizeof(first_result_buf), sizeof(first_bloom_filter_with_battery_info),
 		      "Invalid size of expected result.");
@@ -226,7 +226,7 @@ static void test_bloom_filter(void)
 			  0x77, 0x77, 0x88, 0x88} }
 		};
 
-	static const uint8_t second_bloom_filter[] = {0x2F, 0xBA, 0x06, 0x42, 0x00};
+	static const uint8_t second_bloom_filter[] = {0x84, 0x4A, 0x62, 0x20, 0x8B};
 
 	uint8_t second_result_buf[sizeof(second_bloom_filter)];
 
@@ -239,8 +239,8 @@ static void test_bloom_filter(void)
 	zassert_mem_equal(second_result_buf, second_bloom_filter, sizeof(second_bloom_filter),
 			  "Invalid resulting filter.");
 
-	static const uint8_t second_bloom_filter_with_battery_info[] = {0x10, 0x22, 0x56, 0xC0,
-									0x4D};
+	static const uint8_t second_bloom_filter_with_battery_info[] = {0x46, 0x15, 0x24, 0xD0,
+									0x08};
 
 	zassert_equal(sizeof(second_result_buf), sizeof(second_bloom_filter_with_battery_info),
 		      "Invalid size of expected result.");


### PR DESCRIPTION
Changes the salt size in the not discoverable advertising from 1 byte to 2 bytes, because the Fast Pair specification has changed. Aligns crypto test to new salt size and new test cases from Fast Pair specification.

Jira: NCSDK-19427