### PR TITLE
samples: nrf9160: Fix full modem update CBOR format confusion

### DIFF
--- a/samples/nrf9160/http_update/full_modem_update/prj.conf
+++ b/samples/nrf9160/http_update/full_modem_update/prj.conf
@@ -82,10 +82,10 @@ CONFIG_MBEDTLS_GCM_C=n
 CONFIG_MBEDTLS_SHA256_C=y
 
 CONFIG_DOWNLOAD_HOST="nrfconnectsdk.s3.eu-central-1.amazonaws.com"
-CONFIG_DOWNLOAD_MODEM_0_FILE="fmfu_1.3.0.bin"
+CONFIG_DOWNLOAD_MODEM_0_FILE="fmfu_1.3.0.cbor"
 CONFIG_DOWNLOAD_MODEM_0_VERSION="mfw_nrf9160_1.3.0"
 
-CONFIG_DOWNLOAD_MODEM_1_FILE="fmfu_1.3.1.bin"
+CONFIG_DOWNLOAD_MODEM_1_FILE="fmfu_1.3.1.cbor"
 
 # Prevalidation is not yet supported by the modem firmware, so skip it for now.
 CONFIG_FMFU_FDEV_SKIP_PREVALIDATION=y


### PR DESCRIPTION
Downloading binary files which are serialized with CBOR but has the file ending `.bin` is confusing. This changes the format to `.cbor` instead of `.bin` to clarify that the files are CBOR serialized.

Ref. NCSDK-13172