### PR TITLE
bluetooth: add additional config for PAwR failure reports

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -344,6 +344,11 @@ config BT_CTLR_SDC_PERIODIC_ADV_RSP_RX_BUFFER_COUNT
 	  until the host is able to pull the periodic advertising response reports.
 
 	  A value of 0 will disable reception of subevent responses.
+
+config BT_CTLR_SDC_PERIODIC_ADV_RSP_RX_FAILURE_REPORTING
+	bool "Response reports for when the PAwR advertiser fails to receive responses"
+	help
+	  Enables generating reports for failing to receive responses.
 endif
 
 

--- a/west.yml
+++ b/west.yml
@@ -127,7 +127,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 2567613ce0995f7c61ad1e47b26993d05142570a
+      revision: be07d83dbd3edd509b05e495e9df75665b3e16eb
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Can be used to enable reporting every response slot for which a response has not been received.