### PR TITLE
samples: nrf5340: Remove empty net core from multi-core sample

### DIFF
--- a/samples/caf_sensor_manager/Kconfig
+++ b/samples/caf_sensor_manager/Kconfig
@@ -18,6 +18,10 @@ config APP_REMOTE_BOARD
 	string "The name of the board to be used by remote image"
 	depends on APP_INCLUDE_REMOTE_IMAGE
 
+# Disabling adding an empty net core image as we provide our own in this sample.
+config NCS_SAMPLE_EMPTY_NET_CORE_CHILD_IMAGE
+	bool "Add empty netcore child image"
+	default n
 endmenu
 
 menu "Zephyr Kernel"

--- a/samples/multicore/hello_world/sample.yaml
+++ b/samples/multicore/hello_world/sample.yaml
@@ -10,3 +10,10 @@ tests:
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
     tags: ci_build
+  sample.nrf5340.multicore:
+    build_only: true
+    platform_allow: nrf5340dk_nrf5340_cpuapp
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp
+    tags: ci_build
+    extra_args: -DCONFIG_BOOTLOADER_MCUBOOT=y


### PR DESCRIPTION
Due to a change for all nRF5340 samples from 82a3b99 an empty net core image was added to the multi-core sample. In this sample we provide our own net core image and don't need the empty net core image for the build.

Added override to the KConfig and a configuration to the sample so that similar issues may be caught by CI.

Ref. NCSDK-20186