### PR TITLE
doc: Add documentation on Git authentication

### DIFF
--- a/doc/nrf/getting_started/installing.rst
+++ b/doc/nrf/getting_started/installing.rst
@@ -317,6 +317,7 @@ To clone the repositories, complete the following steps:
       west update
 
    Depending on your connection, this might take some time.
+   See :ref:`gs_git_auth` if you are asked for your GitHub username and password.
 #. Export a :ref:`Zephyr CMake package <zephyr:cmake_pkg>`.
    This allows CMake to automatically load the boilerplate code required for building |NCS| applications::
 
@@ -464,7 +465,7 @@ Define the required environment variables as follows, depending on your operatin
 
       Navigate to the :file:`ncs` folder and enter the following command: ``zephyr\zephyr-env.cmd``
 
-      If you need to define additional environment variables, create the file :file:`%userprofile%\zephyrrc.cmd` and add the variables there.
+      If you need to define additional environment variables, create the file :file:`%userprofile%\\zephyrrc.cmd` and add the variables there.
       This file is loaded automatically when you run the above command.
       See :ref:`zephyr:env_vars_zephyrrc` for more information.
 

--- a/doc/nrf/getting_started/recommended_versions.rst
+++ b/doc/nrf/getting_started/recommended_versions.rst
@@ -176,6 +176,42 @@ Other versions might also work, but are not verified.
          * - West
            - |west_recommended_ver_darwin|
 
+.. _gs_git_auth:
+
+Git authentication
+******************
+
+During the process of :ref:`getting the |NCS| code <cloning_the_repositories>`,
+in some cases running ``west update`` might require :ref:`west <zephyr:west>` to
+fetch from private repositories on GitHub. Because the `west manifest file`_
+uses ``https://`` URLs instead of ``ssh://``, you may be prompted to type your
+GitHub username and Personal Access Token multiple times; GitHub has a
+comprehensive `documentation page
+<https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-authentication-to-github>`_
+on the subject.
+In many cases (including Windows) the Git installation includes `Git Credential Manager
+<https://github.com/git-ecosystem/git-credential-manager>`_, which will handle
+GitHub authentication.
+
+However, if you would are already using `SSH-based authentication
+<https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent>`_,
+you can reuse your SSH setup by adding the following to your
+:file:`~/.gitconfig` (or :file:`%userprofile%\\.gitconfig` on Windows):
+
+.. code-block:: console
+
+   [url "ssh://git@github.com"]
+           insteadOf = https://github.com
+
+This will rewrite the URLs on-the-fly so that Git uses ``ssh://`` for all
+network operations with GitHub.
+
+Another option instead is to create a :file:`~/.git-credentials`
+(or :file:`%userprofile%\\.git-credentials` on Windows) and add this line to it:
+
+.. code-block:: console
+
+   https://<GitHub username>:<Personal Access Token>@github.com
 
 Required Python dependencies
 ****************************


### PR DESCRIPTION
Some west projects are hosted in GitHub private repositories. In order for users to be able to fetch them, Git needs to authenticate with GitHub. Setting this up can be tricky, so provide help for users.