### PR TITLE
manifest: sdk-zephyr: Pull improvement for AP mode

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -55,7 +55,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: f8f113382356934cb6d1ef4cdad95a843f922085
+      revision: pull/1103/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
In case AP mode is unsupported clearly convey to the user.