### PR TITLE
lib: nrf_modem: split normal and bootloader initialization functions.

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/nrf_cloud_integration.c
+++ b/applications/asset_tracker_v2/src/cloud/nrf_cloud_integration.c
@@ -83,7 +83,7 @@ static int fmfu_and_modem_init(const struct device *dev)
 	}
 
 	/* Ignore the result, it will be checked later */
-	(void)nrf_modem_lib_init(NORMAL_MODE);
+	(void)nrf_modem_lib_init();
 
 	return 0;
 }

--- a/applications/serial_lte_modem/src/main.c
+++ b/applications/serial_lte_modem/src/main.c
@@ -91,7 +91,7 @@ static void on_modem_failure_shutdown(struct k_work *work)
 
 static void on_modem_failure_reinit(struct k_work *work)
 {
-	int ret = nrf_modem_lib_init(NORMAL_MODE);
+	int ret = nrf_modem_lib_init();
 
 	ARG_UNUSED(work);
 	rsp_send("\r\n#XMODEM: INIT,%d\r\n", ret);

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -390,12 +390,17 @@ Modem libraries
 
 * :ref:`nrf_modem_lib_readme` library:
 
-  * Added the function :c:func:`nrf_modem_lib_fault_strerror` to retrieve a statically allocated textual description of a given modem fault.
-    The function can be enabled using the new Kconfig option :kconfig:option:`CONFIG_NRF_MODEM_LIB_FAULT_STRERROR`.
+  * Added:
+
+    * The function :c:func:`nrf_modem_lib_fault_strerror` to retrieve a statically allocated textual description of a given modem fault.
+      The function can be enabled using the new Kconfig option :kconfig:option:`CONFIG_NRF_MODEM_LIB_FAULT_STRERROR`.
+    * The :c:func:`nrf_modem_lib_bootloader_init` function to initialize the Modem library in bootloader mode.
 
   * Updated:
 
     * The Kconfig option :kconfig:option:`CONFIG_NRF_MODEM_LIB_IPC_PRIO_OVERRIDE` is now deprecated.
+    * The :c:func:`nrf_modem_lib_init` function is now initializing the Modem library in normal operating mode only and the ``mode`` parameter is removed from the input parameters.
+      Use the :c:func:`nrf_modem_lib_bootloader_init` function to initialize the Modem library in bootloader mode.
 
   * Removed:
 

--- a/include/mgmt/fmfu_mgmt.h
+++ b/include/mgmt/fmfu_mgmt.h
@@ -27,8 +27,8 @@ extern "C" {
 /** @brief Setup and register the command handler for full modem
  *  update command handler group.
  *
- * The modem library must be initialized in DFU mode before calling this
- * function - nrf_modem_lib_init(BOOTLOADER_MODE).
+ * The modem library must be initialized in bootloader mode before calling this
+ * function - nrf_modem_lib_bootloader_init().
  *
  * @retval 0 on success, negative integer on failure.
  */

--- a/include/modem/nrf_modem_lib.h
+++ b/include/modem/nrf_modem_lib.h
@@ -40,25 +40,32 @@ enum nrf_modem_mode {
 /**
  * @brief Initialize the Modem library and turn on the modem.
  *
- * This function initializes all integration components of the nrf_modem library
- * and turns on the modem. The operation can take a few minutes when a firmware update
- * is scheduled. If your application supports modem firmware updates, consider initializing
- * the library manually to have control of what the application should do in the meantime.
+ * The operation can take a few minutes when a firmware update is scheduled.
  *
- * The library can initialize the modem in normal mode or bootloader mode.
- *
- * The bootloader mode is used to update the whole modem firmware.
- * When modem is initialized in bootloader mode, no other functionality is available.
- * In particular, networking sockets and AT commands won't be available.
- *
- * To switch between the bootloader mode and normal mode, shutdown the modem
+ * To switch between the bootloader mode and normal operating mode, shutdown the modem
  * with @ref nrf_modem_lib_shutdown() and re-initialize it in the desired mode.
+ * Use @ref nrf_modem_lib_init() to initialize in normal mode and
+ * @ref nrf_modem_lib_bootloader_init() to initialize the Modem library in bootloader mode.
  *
- * @param[in] mode Initialization mode.
+ * @return int Zero on success, a positive value @em nrf_modem_dfu when executing
+ *         Modem firmware updates, and negative errno on other failures.
+ */
+int nrf_modem_lib_init(void);
+
+/**
+ * @brief Initialize the Modem library in bootloader mode and turn on the modem.
+ *
+ * When the modem is initialized in bootloader mode, no other functionality is available. In
+ * particular, networking sockets and AT commands won't be available.
+ *
+ * To switch between the bootloader mode and normal operating mode, shutdown the modem
+ * with @ref nrf_modem_lib_shutdown() and re-initialize it in the desired mode.
+ * Use @ref nrf_modem_lib_init() to initialize in normal mode and
+ * @ref nrf_modem_lib_bootloader_init() to initialize the Modem library in bootloader mode.
  *
  * @return int Zero on success, non-zero otherwise.
  */
-int nrf_modem_lib_init(enum nrf_modem_mode mode);
+int nrf_modem_lib_bootloader_init(void);
 
 /**
  * @brief Shutdown the Modem library and turn off the modem.

--- a/lib/bin/lwm2m_carrier/os/lwm2m_os.c
+++ b/lib/bin/lwm2m_carrier/os/lwm2m_os.c
@@ -369,7 +369,7 @@ int lwm2m_os_nrf_modem_init(void)
 #if defined CONFIG_NRF_MODEM_LIB_SYS_INIT
 	int nrf_err = modem_lib_init_result;
 #else
-	int nrf_err = nrf_modem_lib_init(NORMAL_MODE);
+	int nrf_err = nrf_modem_lib_init();
 #endif /* CONFIG_NRF_MODEM_LIB_SYS_INIT */
 
 	switch (nrf_err) {

--- a/lib/nrf_modem_lib/fault.c
+++ b/lib/nrf_modem_lib/fault.c
@@ -81,7 +81,7 @@ static void restart_on_fault(void *p1, void *p2, void *p3)
 		 */
 		k_yield();
 
-		(void)nrf_modem_lib_init(NORMAL_MODE);
+		(void)nrf_modem_lib_init();
 	}
 }
 

--- a/lib/nrf_modem_lib/nrf_modem_lib.c
+++ b/lib/nrf_modem_lib/nrf_modem_lib.c
@@ -32,8 +32,6 @@ BUILD_ASSERT(IPC_IRQn == NRF_MODEM_IPC_IRQ, "NRF_MODEM_IPC_IRQ mismatch");
  */
 #define NRF_MODEM_LIB_SHMEM_TX_HEAP_OVERHEAD_SIZE 128
 
-static enum nrf_modem_mode init_mode;
-
 static const struct nrf_modem_init_params init_params = {
 	.ipc_irq_prio = CONFIG_NRF_MODEM_LIB_IPC_IRQ_PRIO,
 	.shmem.ctrl = {
@@ -141,14 +139,14 @@ static int _nrf_modem_lib_init(const struct device *unused)
 	return rc;
 }
 
-int nrf_modem_lib_init(enum nrf_modem_mode mode)
+int nrf_modem_lib_init(void)
 {
-	init_mode = mode;
-	if (mode == NORMAL_MODE) {
-		return _nrf_modem_lib_init(NULL);
-	} else {
-		return nrf_modem_bootloader_init(&bootloader_init_params);
-	}
+	return _nrf_modem_lib_init(NULL);
+}
+
+int nrf_modem_lib_bootloader_init(void)
+{
+	return nrf_modem_bootloader_init(&bootloader_init_params);
 }
 
 int nrf_modem_lib_shutdown(void)

--- a/samples/nrf9160/fmfu_smp_svr/src/main.c
+++ b/samples/nrf9160/fmfu_smp_svr/src/main.c
@@ -13,7 +13,7 @@
 
 void main(void)
 {
-	int err = nrf_modem_lib_init(NORMAL_MODE);
+	int err = nrf_modem_lib_init();
 
 	if (err == 0) {
 		char modem_version[MODEM_INFO_MAX_RESPONSE_SIZE];
@@ -32,7 +32,7 @@ void main(void)
 	/* Shutdown modem to prepare for DFU */
 	nrf_modem_lib_shutdown();
 
-	nrf_modem_lib_init(BOOTLOADER_MODE);
+	nrf_modem_lib_bootloader_init();
 	/* Register SMP Communication stats */
 	fmfu_mgmt_stat_init();
 	/* Initialize MCUMgr handlers for full modem update */

--- a/samples/nrf9160/http_update/application_update/src/main.c
+++ b/samples/nrf9160/http_update/application_update/src/main.c
@@ -179,7 +179,7 @@ void main(void)
 	printk("Using version %d\n", CONFIG_APPLICATION_VERSION);
 
 #if !defined(CONFIG_LWM2M_CARRIER)
-	err = nrf_modem_lib_init(NORMAL_MODE);
+	err = nrf_modem_lib_init();
 	if (err) {
 		printk("Failed to initialize modem library!");
 		return;

--- a/samples/nrf9160/http_update/full_modem_update/src/main.c
+++ b/samples/nrf9160/http_update/full_modem_update/src/main.c
@@ -65,9 +65,9 @@ static void apply_fmfu_from_ext_flash(bool valid_init)
 		}
 	}
 
-	err = nrf_modem_lib_init(BOOTLOADER_MODE);
+	err = nrf_modem_lib_bootloader_init();
 	if (err != 0) {
-		printk("nrf_modem_lib_init(BOOTLOADER_MODE) failed: %d\n", err);
+		printk("nrf_modem_lib_bootloader_init() failed: %d\n", err);
 		return;
 	}
 
@@ -83,7 +83,7 @@ static void apply_fmfu_from_ext_flash(bool valid_init)
 		return;
 	}
 
-	err = nrf_modem_lib_init(NORMAL_MODE);
+	err = nrf_modem_lib_init();
 	if (err != 0) {
 		printk("nrf_modem_lib_init() failed: %d\n", err);
 		return;
@@ -204,7 +204,7 @@ void main(void)
 		return;
 	}
 
-	err = nrf_modem_lib_init(NORMAL_MODE);
+	err = nrf_modem_lib_init();
 	if (err) {
 		printk("Failed to initialize modem lib, err: %d\n", err);
 		printk("This could indicate that an earlier update failed\n");

--- a/samples/nrf9160/http_update/modem_delta_update/src/main.c
+++ b/samples/nrf9160/http_update/modem_delta_update/src/main.c
@@ -96,7 +96,7 @@ void main(void)
 
 	printk("Initializing modem library\n");
 #if !defined(CONFIG_NRF_MODEM_LIB_SYS_INIT)
-	err = nrf_modem_lib_init(NORMAL_MODE);
+	err = nrf_modem_lib_init();
 #else
 	/* If nrf_modem_lib is initialized on post-kernel we should
 	 * fetch the returned error code instead of nrf_modem_lib_init

--- a/samples/nrf9160/lwm2m_client/src/main.c
+++ b/samples/nrf9160/lwm2m_client/src/main.c
@@ -575,7 +575,7 @@ void main(void)
 	LOG_INF(APP_BANNER);
 
 #if !defined(CONFIG_NRF_MODEM_LIB_SYS_INIT)
-	ret = nrf_modem_lib_init(NORMAL_MODE);
+	ret = nrf_modem_lib_init();
 	if (ret < 0) {
 		LOG_ERR("Unable to init modem library (%d)", ret);
 		return;

--- a/samples/nrf9160/modem_callbacks/src/main.c
+++ b/samples/nrf9160/modem_callbacks/src/main.c
@@ -37,7 +37,7 @@ void main(void)
 	printk("Modem callbacks sample started\n");
 
 	printk("Initializing modem library\n");
-	err = nrf_modem_lib_init(NORMAL_MODE);
+	err = nrf_modem_lib_init();
 	if (err) {
 		printk("Modem initialization failed, err %d\n", err);
 		return;

--- a/samples/nrf9160/modem_shell/src/main.c
+++ b/samples/nrf9160/modem_shell/src/main.c
@@ -230,7 +230,7 @@ void main(void)
 	 * This is necessary for the modem trace flash backend. Which depend on the flash device
 	 * to be initialized before initializing the nRF modem library.
 	 */
-	nrf_modem_lib_init(NORMAL_MODE);
+	nrf_modem_lib_init();
 #endif
 
 #if defined(CONFIG_NRF_CLOUD_REST) || defined(CONFIG_NRF_CLOUD_MQTT)

--- a/samples/nrf9160/modem_trace_flash/src/main.c
+++ b/samples/nrf9160/modem_trace_flash/src/main.c
@@ -114,7 +114,7 @@ void main(void)
 		LOG_ERR("uart1 device not found/ready!");
 	}
 
-	nrf_modem_lib_init(NORMAL_MODE);
+	nrf_modem_lib_init();
 
 	err = nrf_modem_lib_trace_level_set(NRF_MODEM_LIB_TRACE_LEVEL_FULL);
 	if (err) {

--- a/samples/nrf9160/nrf_cloud_mqtt_multi_service/src/connection.c
+++ b/samples/nrf9160/nrf_cloud_mqtt_multi_service/src/connection.c
@@ -678,7 +678,7 @@ static int setup_modem(void)
 		 * positive value to indicate that this occurred. This code can be used to
 		 * determine whether the update was successful.
 		 */
-		int ret = nrf_modem_lib_init(NORMAL_MODE);
+		int ret = nrf_modem_lib_init();
 
 		if (ret < 0) {
 			LOG_ERR("Modem library initialization failed, error: %d", ret);

--- a/samples/nrf9160/nrf_cloud_rest_device_message/src/main.c
+++ b/samples/nrf9160/nrf_cloud_rest_device_message/src/main.c
@@ -309,7 +309,7 @@ static int init(void)
 
 	/* Init modem */
 	if (!IS_ENABLED(CONFIG_NRF_MODEM_LIB_SYS_INIT)) {
-		modem_lib_init_result = nrf_modem_lib_init(NORMAL_MODE);
+		modem_lib_init_result = nrf_modem_lib_init();
 	}
 	if (modem_lib_init_result) {
 		LOG_ERR("Failed to initialize modem library: 0x%X", modem_lib_init_result);

--- a/samples/nrf9160/nrf_cloud_rest_fota/src/main.c
+++ b/samples/nrf9160/nrf_cloud_rest_fota/src/main.c
@@ -453,7 +453,7 @@ int init(void)
 #endif
 
 	if (!IS_ENABLED(CONFIG_NRF_MODEM_LIB_SYS_INIT)) {
-		modem_lib_init_result = nrf_modem_lib_init(NORMAL_MODE);
+		modem_lib_init_result = nrf_modem_lib_init();
 	}
 
 	/* This function may perform a reboot if a FOTA update is in progress */

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
@@ -500,9 +500,9 @@ static uint8_t apply_fmfu_from_ext_flash(void)
 		return RESULT_UPDATE_FAILED;
 	}
 
-	ret = nrf_modem_lib_init(BOOTLOADER_MODE);
+	ret = nrf_modem_lib_bootloader_init();
 	if (ret != 0) {
-		LOG_ERR("nrf_modem_lib_init(BOOTLOADER_MODE) failed: %d\n", ret);
+		LOG_ERR("nrf_modem_lib_bootloader_init() failed: %d\n", ret);
 		return RESULT_UPDATE_FAILED;
 	}
 
@@ -552,7 +552,7 @@ static uint8_t apply_firmware_delta_modem_update(void)
 
 	lte_lc_deinit();
 	nrf_modem_lib_shutdown();
-	ret = nrf_modem_lib_init(NORMAL_MODE);
+	ret = nrf_modem_lib_init();
 
 	ret = modem_lib_init_result;
 	switch (ret) {

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota_common.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota_common.c
@@ -108,17 +108,17 @@ int nrf_cloud_fota_fmfu_apply(void)
 		return err;
 	}
 
-	err = nrf_modem_lib_init(BOOTLOADER_MODE);
+	err = nrf_modem_lib_bootloader_init();
 	if (err != 0) {
-		LOG_ERR("nrf_modem_lib_init(BOOTLOADER_MODE) failed: %d", err);
-		(void)nrf_modem_lib_init(NORMAL_MODE);
+		LOG_ERR("nrf_modem_lib_bootloader_init() failed: %d", err);
+		(void)nrf_modem_lib_init();
 		return err;
 	}
 
 	err = fmfu_fdev_load(fmfu_buf, sizeof(fmfu_buf), fmfu_dev.dev, fmfu_dev.offset);
 	if (err != 0) {
 		LOG_ERR("Failed to apply full modem update, error: %d", err);
-		(void)nrf_modem_lib_init(NORMAL_MODE);
+		(void)nrf_modem_lib_init();
 		return err;
 	}
 

--- a/tests/lib/at_custom_cmd/src/main.c
+++ b/tests/lib/at_custom_cmd/src/main.c
@@ -19,7 +19,7 @@ static void *suite_setup(void)
 {
 	int err;
 
-	err = nrf_modem_lib_init(NORMAL_MODE);
+	err = nrf_modem_lib_init();
 	zassert_ok(err, "Failed to initialize");
 
 	return NULL;

--- a/tests/lib/gcf_sms/src/main.c
+++ b/tests/lib/gcf_sms/src/main.c
@@ -68,7 +68,7 @@ static void *suite_setup(void)
 {
 	int err;
 
-	err = nrf_modem_lib_init(NORMAL_MODE);
+	err = nrf_modem_lib_init();
 	zassert_ok(err, "Failed to initialize");
 
 	return NULL;

--- a/tests/subsys/net/lib/lwm2m_fota_utils/src/stubs.c
+++ b/tests/subsys/net/lib/lwm2m_fota_utils/src/stubs.c
@@ -61,7 +61,7 @@ DEFINE_FAKE_VALUE_FUNC(int, modem_info_rsrp_register, rsrp_cb_t);
 DEFINE_FAKE_VOID_FUNC(engine_trigger_update, bool);
 DEFINE_FAKE_VALUE_FUNC(int, dfu_target_mcuboot_set_buf, uint8_t *, size_t);
 DEFINE_FAKE_VALUE_FUNC(int, nrf_modem_lib_shutdown);
-DEFINE_FAKE_VALUE_FUNC(int, nrf_modem_lib_init, enum nrf_modem_mode);
+DEFINE_FAKE_VALUE_FUNC(int, nrf_modem_lib_init);
 DEFINE_FAKE_VALUE_FUNC(int, fota_download_init, fota_download_callback_t);
 DEFINE_FAKE_VALUE_FUNC(int, fota_download_start_with_image_type, const char *, const char *, int,
 		       uint8_t, size_t, const enum dfu_target_image_type);

--- a/tests/subsys/net/lib/lwm2m_fota_utils/src/stubs.h
+++ b/tests/subsys/net/lib/lwm2m_fota_utils/src/stubs.h
@@ -58,7 +58,7 @@ DECLARE_FAKE_VALUE_FUNC(int, lte_lc_lte_mode_get, enum lte_lc_lte_mode *);
 DECLARE_FAKE_VALUE_FUNC(int, modem_info_rsrp_register, rsrp_cb_t);
 DECLARE_FAKE_VALUE_FUNC(int, dfu_target_mcuboot_set_buf, uint8_t *, size_t);
 DECLARE_FAKE_VALUE_FUNC(int, nrf_modem_lib_shutdown);
-DECLARE_FAKE_VALUE_FUNC(int, nrf_modem_lib_init, enum nrf_modem_mode);
+DECLARE_FAKE_VALUE_FUNC(int, nrf_modem_lib_init);
 DECLARE_FAKE_VALUE_FUNC(int, fota_download_init, fota_download_callback_t);
 DECLARE_FAKE_VALUE_FUNC(int, fota_download_start_with_image_type, const char *, const char *, int,
 			uint8_t, size_t, const enum dfu_target_image_type);


### PR DESCRIPTION
Split the normal mode and bootloader initialization functions. This saves flash when only one of the modes are used.
Use a macro for nrf_modem_lib_init() for now to allow it to be called both with and without the mode parameter.

test-sdk-nrf: sdk-nrf-pr-10671