### PR TITLE
lib: pdn: Set ePCO mode

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -332,6 +332,10 @@ Modem libraries
     * The deprecated function ``nrf_modem_lib_shutdown_wait``.
     * The deprecated Kconfig option ``CONFIG_NRF_MODEM_LIB_TRACE_ENABLED``.
 
+* :ref:`pdn_readme` library:
+
+  * Updated the library to use ePCO mode if the Kconfig option :kconfig:option:`CONFIG_PDN_LEGACY_PCO` is not enabled.
+
 Libraries for networking
 ------------------------
 

--- a/lib/pdn/pdn.c
+++ b/lib/pdn/pdn.c
@@ -174,7 +174,13 @@ static void on_modem_init(int ret, void *ctx)
 		LOG_ERR("Failed to set legacy PCO mode, err %d", err);
 		return;
 	}
-#endif
+#else
+	err = nrf_modem_at_printf("AT%%XEPCO=1");
+	if (err) {
+		LOG_ERR("Failed to set ePCO mode, err %d", err);
+		return;
+	}
+#endif /* CONFIG_PDN_LEGACY_PCO */
 
 #if defined(CONFIG_PDN_DEFAULTS_OVERRIDE)
 	err = pdn_ctx_configure(0, CONFIG_PDN_DEFAULT_APN,


### PR DESCRIPTION
If CONFIG_PDN_LEGACY_PCO is not set and AT%XEPCO=0 has been set to the modem, it will use the legacy PCO mode also after rebooting the device.

Signed-off-by: Tero Nikula <tero.nikula@anicare.fi>