### PR TITLE
doc: matter: persistent subscriptions and Matter docset version

### DIFF
--- a/doc/matter/conf.py
+++ b/doc/matter/conf.py
@@ -21,6 +21,9 @@ ZEPHYR_BASE = utils.get_projdir("zephyr")
 # General configuration --------------------------------------------------------
 
 project = "Matter"
+copyright = "2020-2023, Matter Contributors"
+author = "Matter Contributors"
+version = "1.0.0"
 
 sys.path.insert(0, str(ZEPHYR_BASE / "doc" / "_extensions"))
 sys.path.insert(0, str(NRF_BASE / "doc" / "_extensions"))

--- a/doc/nrf/protocols/matter/getting_started/advanced_kconfigs.rst
+++ b/doc/nrf/protocols/matter/getting_started/advanced_kconfigs.rst
@@ -24,6 +24,17 @@ You can configure the Matter protocol to use NFC tag for commissioning, instead 
 
 To enable NFC for commissioning and share the onboarding payload in an NFC tag, set the :kconfig:option:`CONFIG_CHIP_NFC_COMMISSIONING` Kconfig option.
 
+.. _ug_matter_configuring_optional_persistent_subscriptions:
+
+Persistent subscriptions
+========================
+
+You can configure the Matter protocol to keep Matter subscriptions on the publisher node.
+This allows the device to save information about subscriptions and use it to re-establish the subscriptions immediately when coming back online after being offline for a longer time, for example due to a power outage.
+This is a much faster way than waiting for the subscriber node to notice that the publisher node is again available in the network.
+
+To enable persistent subscriptions, set the :kconfig:option:`CONFIG_CHIP_PERSISTENT_SUBSCRIPTIONS` Kconfig option.
+
 .. _ug_matter_configuring_optional_log:
 
 Logging configuration

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -84,10 +84,14 @@ Bluetooth mesh
 Matter
 ------
 
-* Added the Matter Nordic UART Service (NUS) feature to the :ref:`matter_lock_sample`.
-  This feature allows using Nordic UART Service to control the device remotely through Bluetooth LE and adding custom text commands to a Matter sample.
-  The Matter NUS implementation allows controlling the device regardless of whether the device is connected to a Matter network or not.
-  The feature is dedicated for the nRF5340 and the nRF52840 DKs.
+* Added:
+
+  * Support for the :ref:`ug_matter_configuring_optional_persistent_subscriptions` feature.
+  * The Matter Nordic UART Service (NUS) feature to the :ref:`matter_lock_sample`.
+    This feature allows using Nordic UART Service to control the device remotely through Bluetooth LE and adding custom text commands to a Matter sample.
+    The Matter NUS implementation allows controlling the device regardless of whether the device is connected to a Matter network or not.
+    The feature is dedicated for the nRF5340 and the nRF52840 DKs.
+
 * Updated:
 
   * The :ref:`ug_matter` protocol page with a table that lists compatibility versions for the |NCS|, the Matter SDK, and the Matter specification.


### PR DESCRIPTION
Extended advanced kconfigs docs to include information about
Matter persistent subscriptions configuration.
Added Matter version to the docset.

----

This PR has been reworked in scope due to the delay of the Matter dev tag. It only includes updates not related to the dev tag.