### PR TITLE
applications: nrf5340_audio: Make adv interval configurable

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/Kconfig
+++ b/applications/nrf5340_audio/src/bluetooth/Kconfig
@@ -20,11 +20,43 @@ config BLE_ACL_SUP_TIMEOUT
 	int "Bluetooth LE Supervision Timeout (x*10ms)"
 	default 400
 
+config BLE_ACL_PER_ADV_INT_MIN
+	hex "Minimum periodic advertising interval"
+	range 0x0018 0x03C0
+	default 0x0078
+	help
+	  Minimum hexadecimal value for the interval of periodic advertisements.
+	  For ms, multiply the provided value by 1.25.
+
+config BLE_ACL_PER_ADV_INT_MAX
+	hex "Maximum periodic advertising interval"
+	range 0x0018 0x03C0
+	default 0x00A0
+	help
+	  Maximum hexadecimal value for the interval of periodic advertisements.
+	  For ms, multiply the provided value by 1.25.
+
+config BLE_ACL_EXT_ADV_INT_MIN
+	hex "Minimum extended advertising interval"
+	range 0x0030 0x0780
+	default 0x00A0
+	help
+	  Minimum hexadecimal value for the interval of extended advertisements.
+	  For ms, multiply the provided value by 0.625.
+
+config BLE_ACL_EXT_ADV_INT_MAX
+	hex "Maximum extended advertising interval"
+	range 0x0030 0x0780
+	default 0x00F0
+	help
+	  Maximum hexadecimal value for the interval of extended advertisements.
+	  For ms, multiply the provided value by 0.625.
+
 config BLE_LE_POWER_CONTROL_ENABLED
-	bool "Enable LE power control feature"
+	bool "Enable Bluetooth LE power control feature"
 	default n
 	help
-	  The LE power control feature makes devices be able to change TX power
+	  The Bluetooth LE power control feature makes devices be able to change TX power
 	  dynamically and automatically during connection, which provides effective
 	  communication.
 

--- a/applications/nrf5340_audio/src/bluetooth/le_audio.h
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio.h
@@ -16,6 +16,19 @@
 
 #define LE_AUDIO_SDU_SIZE_OCTETS(bitrate) (bitrate / (1000000 / CONFIG_AUDIO_FRAME_DURATION_US) / 8)
 
+#define LE_AUDIO_EXTENDED_ADV_NAME                                                                 \
+	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV | BT_LE_ADV_OPT_USE_NAME,                            \
+			CONFIG_BLE_ACL_EXT_ADV_INT_MIN, CONFIG_BLE_ACL_EXT_ADV_INT_MAX, NULL)
+
+#define LE_AUDIO_EXTENDED_ADV_CONN_NAME                                                            \
+	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV | BT_LE_ADV_OPT_CONNECTABLE |                        \
+				BT_LE_ADV_OPT_USE_NAME,                                            \
+			CONFIG_BLE_ACL_EXT_ADV_INT_MIN, CONFIG_BLE_ACL_EXT_ADV_INT_MAX, NULL)
+
+#define LE_AUDIO_PERIODIC_ADV                                                                      \
+	BT_LE_PER_ADV_PARAM(CONFIG_BLE_ACL_PER_ADV_INT_MIN, CONFIG_BLE_ACL_PER_ADV_INT_MAX,        \
+			    BT_LE_PER_ADV_OPT_NONE)
+
 #if (CONFIG_AUDIO_SAMPLE_RATE_48000_HZ)
 #define BT_AUDIO_CODEC_CONFIG_FREQ BT_CODEC_CONFIG_LC3_FREQ_48KHZ
 #define BT_AUDIO_CODEC_CAPABILIY_FREQ BT_CODEC_LC3_FREQ_48KHZ

--- a/applications/nrf5340_audio/src/bluetooth/le_audio_bis_gateway.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_bis_gateway.c
@@ -193,14 +193,14 @@ static int adv_create(void)
 	uint32_t broadcast_id = 0;
 
 	/* Create a non-connectable non-scannable advertising set */
-	ret = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN_NAME, NULL, &adv);
+	ret = bt_le_ext_adv_create(LE_AUDIO_EXTENDED_ADV_NAME, NULL, &adv);
 	if (ret) {
 		LOG_ERR("Unable to create extended advertising set: %d", ret);
 		return ret;
 	}
 
 	/* Set periodic advertising parameters */
-	ret = bt_le_per_adv_set_param(adv, BT_LE_PER_ADV_DEFAULT);
+	ret = bt_le_per_adv_set_param(adv, LE_AUDIO_PERIODIC_ADV);
 	if (ret) {
 		LOG_ERR("Failed to set periodic advertising parameters (ret %d)", ret);
 		return ret;

--- a/applications/nrf5340_audio/src/bluetooth/le_audio_cis_headset.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_cis_headset.c
@@ -694,7 +694,7 @@ static int initialize(le_audio_receive_cb recv_cb, le_audio_timestamp_cb timestm
 		return ret;
 	}
 
-	ret = bt_le_ext_adv_create(BT_LE_EXT_ADV_CONN_NAME, NULL, &adv_ext);
+	ret = bt_le_ext_adv_create(LE_AUDIO_EXTENDED_ADV_CONN_NAME, NULL, &adv_ext);
 	if (ret) {
 		LOG_ERR("Failed to create advertising set");
 		return ret;

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -175,6 +175,9 @@ nRF5340 Audio
 
 * Moved the LE Audio controller for the network core to the standalone :ref:`lib_bt_ll_acs_nrf53_readme` library.
 
+* Added  Kconfig options for setting periodic and extended advertising intervals..
+  Search :ref:`Kconfig Reference <kconfig-search>` for ``BLE_ACL_PER_ADV_INT_`` and ``BLE_ACL_EXT_ADV_INT_`` to list all of them.
+
 nRF Machine Learning (Edge Impulse)
 -----------------------------------
 


### PR DESCRIPTION
- Add Kconfig for periodic advertising interval
- Add Kconfig for extended advertising interval
- Set default periodic adv to 150-200 ms
- OCT-2497