### PR TITLE
samples: aws_iot: Option to use UUID as device id

### DIFF
--- a/samples/nrf9160/aws_iot/Kconfig
+++ b/samples/nrf9160/aws_iot/Kconfig
@@ -6,15 +6,15 @@
 
 menu "AWS IoT Sample Settings"
 
-config APP_VERSION
+config AWS_IOT_SAMPLE_APP_VERSION
 	string "Application version"
 	default "v1.0.0"
 
-config PUBLICATION_INTERVAL_SECONDS
+config AWS_IOT_SAMPLE_PUBLICATION_INTERVAL_SECONDS
 	int "Interval in seconds that the sample will publish data"
 	default 60
 
-config CONNECTION_RETRY_TIMEOUT_SECONDS
+config AWS_IOT_SAMPLE_CONNECTION_RETRY_TIMEOUT_SECONDS
 	int "Number of seconds between each AWS IoT connection retry"
 	default 30
 

--- a/samples/nrf9160/aws_iot/Kconfig
+++ b/samples/nrf9160/aws_iot/Kconfig
@@ -18,6 +18,12 @@ config CONNECTION_RETRY_TIMEOUT_SECONDS
 	int "Number of seconds between each AWS IoT connection retry"
 	default 30
 
+config AWS_IOT_SAMPLE_DEVICE_ID_USE_HW_ID
+	bool "Use HW ID as device ID"
+	select HW_ID_LIBRARY
+	help
+	  Use the devices's hardware ID as device ID when connecting to AWS IOT
+
 module = AWS_IOT_SAMPLE
 module-str = AWS IoT sample
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"

--- a/samples/nrf9160/aws_iot/README.rst
+++ b/samples/nrf9160/aws_iot/README.rst
@@ -82,6 +82,11 @@ CONFIG_PUBLICATION_INTERVAL_SECONDS
 CONFIG_CONNECTION_RETRY_TIMEOUT_SECONDS
    Configures the number of seconds between each AWS IoT connection retry.
 
+.. _CONFIG_AWS_IOT_SAMPLE_DEVICE_ID_USE_HW_ID:
+
+CONFIG_AWS_IOT_SAMPLE_DEVICE_ID_USE_HW_ID
+   Configures the sample to use HWID as Device ID.
+
 .. note::
 
    The sample sets the option :kconfig:option:`CONFIG_MQTT_KEEPALIVE` to the maximum allowed value, 1200 seconds (20 minutes) as specified by AWS IoT Core.

--- a/samples/nrf9160/aws_iot/README.rst
+++ b/samples/nrf9160/aws_iot/README.rst
@@ -67,19 +67,19 @@ Configuration options
 The application-specific configurations used in the sample are listed below.
 They are located in :file:`samples/nrf9160/aws_iot/Kconfig`.
 
-.. _CONFIG_APP_VERSION:
+.. _CONFIG_AWS_IOT_SAMPLE_APP_VERSION:
 
-CONFIG_APP_VERSION
+CONFIG_AWS_IOT_SAMPLE_APP_VERSION
    Publishes the application version number to the AWS IoT message broker.
 
-.. _CONFIG_PUBLICATION_INTERVAL_SECONDS:
+.. _CONFIG_AWS_IOT_SAMPLE_PUBLICATION_INTERVAL_SECONDS:
 
-CONFIG_PUBLICATION_INTERVAL_SECONDS
+CONFIG_AWS_IOT_SAMPLE_PUBLICATION_INTERVAL_SECONDS
    Configures the time interval between each publishing of the message.
 
-.. _CONFIG_CONNECTION_RETRY_TIMEOUT_SECONDS:
+.. _CONFIG_AWS_IOT_SAMPLE_CONNECTION_RETRY_TIMEOUT_SECONDS:
 
-CONFIG_CONNECTION_RETRY_TIMEOUT_SECONDS
+CONFIG_AWS_IOT_SAMPLE_CONNECTION_RETRY_TIMEOUT_SECONDS
    Configures the number of seconds between each AWS IoT connection retry.
 
 .. _CONFIG_AWS_IOT_SAMPLE_DEVICE_ID_USE_HW_ID:

--- a/samples/nrf9160/aws_iot/src/main.c
+++ b/samples/nrf9160/aws_iot/src/main.c
@@ -119,7 +119,7 @@ static int shadow_update(bool version_number_include)
 	}
 
 	if (version_number_include) {
-		err = json_add_str(reported_obj, "app_version", CONFIG_APP_VERSION);
+		err = json_add_str(reported_obj, "app_version", CONFIG_AWS_IOT_SAMPLE_APP_VERSION);
 	} else {
 		err = 0;
 	}
@@ -177,9 +177,11 @@ static void connect_work_fn(struct k_work *work)
 		LOG_ERR("aws_iot_connect, error: %d", err);
 	}
 
-	LOG_INF("Next connection retry in %d seconds", CONFIG_CONNECTION_RETRY_TIMEOUT_SECONDS);
+	LOG_INF("Next connection retry in %d seconds",
+		CONFIG_AWS_IOT_SAMPLE_CONNECTION_RETRY_TIMEOUT_SECONDS);
 
-	k_work_schedule(&connect_work, K_SECONDS(CONFIG_CONNECTION_RETRY_TIMEOUT_SECONDS));
+	k_work_schedule(&connect_work,
+			K_SECONDS(CONFIG_AWS_IOT_SAMPLE_CONNECTION_RETRY_TIMEOUT_SECONDS));
 }
 
 static void shadow_update_work_fn(struct k_work *work)
@@ -195,9 +197,11 @@ static void shadow_update_work_fn(struct k_work *work)
 		LOG_ERR("shadow_update, error: %d", err);
 	}
 
-	LOG_INF("Next data publication in %d seconds", CONFIG_PUBLICATION_INTERVAL_SECONDS);
+	LOG_INF("Next data publication in %d seconds",
+		CONFIG_AWS_IOT_SAMPLE_PUBLICATION_INTERVAL_SECONDS);
 
-	k_work_schedule(&shadow_update_work, K_SECONDS(CONFIG_PUBLICATION_INTERVAL_SECONDS));
+	k_work_schedule(&shadow_update_work,
+			K_SECONDS(CONFIG_AWS_IOT_SAMPLE_PUBLICATION_INTERVAL_SECONDS));
 }
 
 static void shadow_update_version_work_fn(struct k_work *work)
@@ -273,7 +277,7 @@ void aws_iot_event_handler(const struct aws_iot_evt *const evt)
 		/** Start sequential shadow data updates.
 		 */
 		k_work_schedule(&shadow_update_work,
-				K_SECONDS(CONFIG_PUBLICATION_INTERVAL_SECONDS));
+				K_SECONDS(CONFIG_AWS_IOT_SAMPLE_PUBLICATION_INTERVAL_SECONDS));
 
 #if defined(CONFIG_NRF_MODEM_LIB)
 		int err = lte_lc_psm_req(true);
@@ -497,7 +501,7 @@ void main(void)
 {
 	int err;
 
-	LOG_INF("The AWS IoT sample started, version: %s", CONFIG_APP_VERSION);
+	LOG_INF("The AWS IoT sample started, version: %s", CONFIG_AWS_IOT_SAMPLE_APP_VERSION);
 
 	cJSON_Init();
 


### PR DESCRIPTION
Add Kconfig option to use hardware id as device id.