### PR TITLE
net: wifi_mgmt_ext: Fix open security

### DIFF
--- a/subsys/net/lib/wifi_mgmt_ext/wifi_mgmt_ext.c
+++ b/subsys/net/lib/wifi_mgmt_ext/wifi_mgmt_ext.c
@@ -28,7 +28,7 @@ static inline const char *wpa_supp_security_txt(enum wifi_security_type security
 {
 	switch (security) {
 	case WIFI_SECURITY_TYPE_NONE:
-		return "OPEN";
+		return "NONE";
 	case WIFI_SECURITY_TYPE_PSK:
 		return "WPA-PSK";
 	case WIFI_SECURITY_TYPE_PSK_SHA256:


### PR DESCRIPTION
The key management value for open security should be NONE not OPEN.