### PR TITLE
bluetooth: add vs command set_auto_power_control_request_param to nrf

### DIFF
--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -454,6 +454,7 @@ static void vs_supported_commands(sdc_hci_vs_supported_vs_commands_t *cmds)
 	cmds->event_length_set = 1;
 #if defined(CONFIG_BT_CTLR_LE_POWER_CONTROL)
 	cmds->write_remote_tx_power = 1;
+	cmds->set_auto_power_control_request_param = 1;
 #endif
 }
 #endif	/* CONFIG_BT_HCI_VS */
@@ -1201,6 +1202,8 @@ static uint8_t vs_cmd_put(uint8_t const * const cmd,
 #if defined(CONFIG_BT_CTLR_LE_POWER_CONTROL)
 	case SDC_HCI_OPCODE_CMD_VS_WRITE_REMOTE_TX_POWER:
 		return sdc_hci_cmd_vs_write_remote_tx_power((void *)cmd_params);
+	case SDC_HCI_OPCODE_CMD_VS_SET_AUTO_POWER_CONTROL_REQUEST_PARAM:
+		return sdc_hci_cmd_vs_set_auto_power_control_request_param((void *)cmd_params);
 #endif
 	default:
 		return BT_HCI_ERR_UNKNOWN_CMD;


### PR DESCRIPTION
The HCI command is used to set the configurable parameters for autonomous LE Power Control Request.