### PR TITLE
manifest: nrfxlib with import key from PSA core

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -129,11 +129,11 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 898fb739408df9f51f446cb2f3d307d342311de4
+      revision: ce794f1c6e605d45390b5a0a7747166a90a11d81
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: ffa268f5a71471c291fdaaac1eface16955b1616
+      revision: 7c5172c698aa2e988e9a3cb01d013e37242f169b
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter


### PR DESCRIPTION
This makes sure that we always call the function
psa_import_key_into_slot when no crypto accelerator import_key functionality is available. This is needed because our Oberon library does not support import_key for symmetric keys but it supports doing operations with symmetric keys. The psa_import_key_into_slot
function always includes the logic for symmetric keys, which has minor effects in increasing the code size. The support for asymmetric keys on the other hand is configurable which is a good for us since Oberon does support import_key with asymmetric keys.

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>