### PR TITLE
Ncsdk 20640 event manager proxy subscribe

### DIFF
--- a/doc/nrf/libraries/others/event_manager_proxy.rst
+++ b/doc/nrf/libraries/others/event_manager_proxy.rst
@@ -119,10 +119,11 @@ Subscribing to remote events
 ============================
 
 A core that wishes to listen to events from the remote core sends ``SUBSCRIBE`` command to that core during the initialization process.
-The ``SUBSCRIBE`` command uses :c:func:`event_manager_proxy_subscribe` function, which passes following arguments:
+The ``SUBSCRIBE`` command is sent using the :c:func:`event_manager_proxy_subscribe` function, which passes the following arguments:
 
-* ``local_event_id`` - This argument represents the local core ID that wishes to receive when the event is post-processed on the remote core.
-* ``remote_event_name`` - This argument represents the name of the event to be searched for.
+* ``ipc`` - This argument is an IPC instance that identifies the communication channel between the cores.
+* ``local_event_id`` - This argument represents the local core ID that is received when the event is post-processed on the remote core.
+  It is also used to get the event name to match the same event on the remote core.
 
 The remote core during the command processing searches for an event with the given name and registers the given event ID in an array of events.
 The created array of events directly reflects the array of event types.

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -535,6 +535,10 @@ Other libraries
 
   * The library now supports using the GPIO expander for the buttons, switches, and LEDs on the nRF9160 DK.
 
+* :ref:`app_event_manager` library:
+
+  * Added :c:macro:`APP_EVENT_ID` macro.
+
 Common Application Framework (CAF)
 ----------------------------------
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -539,6 +539,10 @@ Other libraries
 
   * Added :c:macro:`APP_EVENT_ID` macro.
 
+* :ref:`event_manager_proxy` library:
+
+  * Removed the ``remote_event_name`` argument from the :c:func:`event_manager_proxy_subscribe` function.
+
 Common Application Framework (CAF)
 ----------------------------------
 

--- a/include/app_event_manager.h
+++ b/include/app_event_manager.h
@@ -73,6 +73,16 @@ static inline bool app_event_get_type_flag(const struct event_type *et,
 	return (et->flags & BIT(flag)) != 0;
 }
 
+/**
+ * @brief Get the event ID
+ *
+ * Macro that creates event id pointer from the event name.
+ *
+ * @param ename The name of the event
+ * @return Event id pointer to struct event_type type
+ */
+#define APP_EVENT_ID(ename) _EVENT_ID(ename)
+
 /** @brief Create an event listener object.
  *
  * @param lname   Module name.

--- a/include/event_manager_proxy.h
+++ b/include/event_manager_proxy.h
@@ -32,7 +32,7 @@
  * @return See @ref event_manager_proxy_subscribe.
  */
 #define EVENT_MANAGER_PROXY_SUBSCRIBE(instance, ename) \
-	event_manager_proxy_subscribe((instance), _EVENT_ID(ename), STRINGIFY(ename))
+	event_manager_proxy_subscribe((instance), APP_EVENT_ID(ename))
 
 /**
  * @brief Add remote core communication channel.
@@ -69,7 +69,6 @@ int event_manager_proxy_add_remote(const struct device *instance);
  *
  * @param instance Remote IPC instance.
  * @param local_event_id The id of the event we wish to receive for the event on the remote core.
- * @param remote_event_name The name of the event to register.
  *
  * @retval 0 On success.
  * @retval -EACCES Function called after @ref event_manager_proxy_start.
@@ -79,8 +78,7 @@ int event_manager_proxy_add_remote(const struct device *instance);
  */
 int event_manager_proxy_subscribe(
 	const struct device *instance,
-	const struct event_type *local_event_id,
-	const char *remote_event_name);
+	const struct event_type *local_event_id);
 
 /**
  * @brief Start events transfer.

--- a/subsys/event_manager_proxy/event_manager_proxy.c
+++ b/subsys/event_manager_proxy/event_manager_proxy.c
@@ -417,13 +417,13 @@ static int send_subscribe_command_to_remote(struct emp_ipc_data *ipc,
 }
 
 int event_manager_proxy_subscribe(const struct device *instance,
-		const struct event_type *local_event_id, const char *remote_event_name)
+				  const struct event_type *local_event_id)
 {
 	__ASSERT_NO_MSG(!emp_started);
 
 	struct emp_ipc_data *ipc = find_ipc_by_instance(instance);
 
-	return send_subscribe_command_to_remote(ipc, local_event_id, remote_event_name);
+	return send_subscribe_command_to_remote(ipc, local_event_id, local_event_id->name);
 }
 
 static int send_start_command_to_remote(struct emp_ipc_data *ipc)


### PR DESCRIPTION
Remove the need of providing event name - the name is inside the event type structure.