### PR TITLE
modem_lib: add RAM trace backend

### DIFF
--- a/lib/nrf_modem_lib/trace_backends/CMakeLists.txt
+++ b/lib/nrf_modem_lib/trace_backends/CMakeLists.txt
@@ -7,3 +7,4 @@
 add_subdirectory_ifdef(CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_FLASH flash)
 add_subdirectory_ifdef(CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_RTT rtt)
 add_subdirectory_ifdef(CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_UART uart)
+add_subdirectory_ifdef(CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_RAM ram)

--- a/lib/nrf_modem_lib/trace_backends/Kconfig
+++ b/lib/nrf_modem_lib/trace_backends/Kconfig
@@ -10,6 +10,7 @@ endchoice
 rsource "uart/Kconfig"
 rsource "flash/Kconfig"
 rsource "rtt/Kconfig"
+rsource "ram/Kconfig"
 
 module = MODEM_TRACE_BACKEND
 module-str = Modem trace backend

--- a/lib/nrf_modem_lib/trace_backends/ram/CMakeLists.txt
+++ b/lib/nrf_modem_lib/trace_backends/ram/CMakeLists.txt
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+zephyr_library_sources(ram.c)

--- a/lib/nrf_modem_lib/trace_backends/ram/Kconfig
+++ b/lib/nrf_modem_lib/trace_backends/ram/Kconfig
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2022-2023 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Adds Ram to the trace backend choice.
+choice NRF_MODEM_LIB_TRACE_BACKEND
+
+config NRF_MODEM_LIB_TRACE_BACKEND_RAM
+	bool "Stream modem traces to RAM buffer"
+	depends on RING_BUFFER
+	help
+	  Use RAM trace backend.
+
+endchoice # NRF_MODEM_LIB_TRACE_BACKEND
+
+if NRF_MODEM_LIB_TRACE_BACKEND_RAM
+
+config NRF_MODEM_LIB_TRACE_BACKEND_RAM_LENGTH
+	int "RAM buffer size"
+	default 32768
+
+
+endif # NRF_MODEM_LIB_TRACE_BACKEND_RAM

--- a/lib/nrf_modem_lib/trace_backends/ram/ram.c
+++ b/lib/nrf_modem_lib/trace_backends/ram/ram.c
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <sys/errno.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/ring_buffer.h>
+#include <zephyr/logging/log.h>
+#include <modem/trace_backend.h>
+
+LOG_MODULE_REGISTER(modem_trace_backend, CONFIG_MODEM_TRACE_BACKEND_LOG_LEVEL);
+
+
+/* Let's put this in noinit, so it can be read out after a crash/reboot. */
+static __noinit uint8_t _ring_buffer_data_ram_trace_buf[
+	CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_RAM_LENGTH
+];
+
+__noinit struct ring_buf ram_trace_buf;
+__noinit uint32_t ram_trace_buf_magic;
+
+static trace_backend_processed_cb trace_processed_callback;
+
+static bool is_initialized(void)
+{
+	return ram_trace_buf_magic == 0xdeadbeed;
+}
+
+int trace_backend_init(trace_backend_processed_cb trace_processed_cb)
+{
+	if (!is_initialized()) {
+		ram_trace_buf.buffer = _ring_buffer_data_ram_trace_buf;
+		ram_trace_buf.size = ARRAY_SIZE(_ring_buffer_data_ram_trace_buf);
+		ring_buf_reset(&ram_trace_buf);
+		ram_trace_buf_magic = 0xdeadbeed;
+	}
+	trace_processed_callback = trace_processed_cb;
+	return 0;
+}
+
+int trace_backend_deinit(void)
+{
+	/* nothing happens */
+	return 0;
+}
+
+size_t trace_backend_data_size(void)
+{
+	if (!is_initialized()) {
+		return -EPERM;
+	}
+	return ring_buf_size_get(&ram_trace_buf);
+}
+
+int trace_backend_read(void *buf, size_t len)
+{
+	if (!is_initialized()) {
+		return -EPERM;
+	}
+	return ring_buf_get(&ram_trace_buf, buf, len);
+}
+
+int trace_backend_write(const void *data, size_t len)
+{
+	if (!is_initialized()) {
+		return -EPERM;
+	}
+	if (len > ring_buf_capacity_get(&ram_trace_buf)) {
+		LOG_ERR("trace_backend_write called with more data then buffer can store!");
+		len = ring_buf_capacity_get(&ram_trace_buf);
+		ring_buf_reset(&ram_trace_buf);
+	}
+
+	uint32_t free_space = ring_buf_space_get(&ram_trace_buf);
+
+	if (len > free_space) {
+		ring_buf_get(&ram_trace_buf, NULL, len - free_space);
+	}
+
+	int result = ring_buf_put(&ram_trace_buf, data, len);
+
+	trace_processed_callback(len);
+
+	return result;
+}
+
+int trace_backend_clear(void)
+{
+	if (!is_initialized()) {
+		return -EPERM;
+	}
+	ring_buf_reset(&ram_trace_buf);
+	return 0;
+}
+
+struct nrf_modem_lib_trace_backend trace_backend = {
+	.init = trace_backend_init,
+	.deinit = trace_backend_deinit,
+	.write = trace_backend_write,
+	.data_size = trace_backend_data_size,
+	.read = trace_backend_read,
+	.clear = trace_backend_clear,
+};

--- a/samples/nrf9160/modem_shell/overlay-modem-trace-ram.conf
+++ b/samples/nrf9160/modem_shell/overlay-modem-trace-ram.conf
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_NRF_MODEM_LIB_TRACE=y
+CONFIG_NRF_MODEM_LIB_SYS_INIT=n
+CONFIG_NRF_MODEM_LIB_TRACE_LEVEL_OFF=y
+
+# Modem trace flash backend
+CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_RAM=y
+CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_RAM_LENGTH=32768

--- a/samples/nrf9160/modem_shell/sample.yaml
+++ b/samples/nrf9160/modem_shell/sample.yaml
@@ -158,6 +158,15 @@ tests:
     extra_configs:
      - CONFIG_MEMFAULT_NCS_PROJECT_KEY="0123456789abcdef0123456789abcdef"
     tags: ci_build
+  sample.nrf9160.modem_shell.memfault_modem_trace_ram:
+    build_only: true
+    integration_platforms:
+      - nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns
+    extra_args: OVERLAY_CONFIG="overlay-modem-trace-ram.conf;overlay-memfault.conf"
+    extra_configs:
+     - CONFIG_MEMFAULT_NCS_PROJECT_KEY="0123456789abcdef0123456789abcdef"
+    tags: ci_build
 
   # Configurations for different location method combinations
   sample.nrf9160.modem_shell.location_gnss_wifi_no_cellular:


### PR DESCRIPTION
This patch adds a RAM based modem trace backend.
A script to extract the trace from a coredump like provided by memfault is also added.