### PR TITLE
lib: edge_impulse: Fix issue with double recompilation

### DIFF
--- a/lib/edge_impulse/CMakeLists.txt
+++ b/lib/edge_impulse/CMakeLists.txt
@@ -30,9 +30,7 @@ if(NOT ${EI_URI} MATCHES "^[a-z]+://")
   endif()
 endif()
 
-
-file(GLOB_RECURSE  edge_impulse_all_headers CONFIGURE_DEPENDS "${EDGE_IMPULSE_SOURCE_DIR}/*.h")
-
+file(GLOB_RECURSE  edge_impulse_all_headers "${EDGE_IMPULSE_SOURCE_DIR}/*.h")
 
 include(ExternalProject)
 ExternalProject_Add(edge_impulse_project


### PR DESCRIPTION
Fixes an issue whereby after a build, the project would seem to be out of date and be rebuilt for no reason.

Fixes NCSDK-18470