### PR TITLE
net: lib: nrf_cloud_pgps: fix P-GPS GPS system time injection

### DIFF
--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps.c
@@ -1062,7 +1062,7 @@ int nrf_cloud_pgps_inject(struct nrf_cloud_pgps_prediction *p,
 			/* send time */
 			err = nrf_cloud_agps_process((const char *)&sys_time,
 						     sizeof(sys_time) -
-						     sizeof(sys_time.time.sv_tow));
+						     sizeof(sys_time.time.sv_tow) + 4);
 			if (err) {
 				LOG_ERR("Error injecting P-GPS sys_time (%u, %u): %d",
 					sys_time.time.date_day, sys_time.time.time_full_s,


### PR DESCRIPTION
GPS system time was rejected by the A-GPS library because the length of data was shorter than expected. Time injection started failing after PR #10647 because the length of data is now checked.

For a reason unknown to me the length of GPS system time is 4 bytes longer than `struct nrf_cloud_agps_system_time` without the TOW elements. This is the length the A-GPS library expects the data to be and the length of the data received from the cloud, so the implementation was updated accordingly.