### PR TITLE
[backport-v1.9] manifest: Update zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 25f6e1655c33e662688968e08cd52bbce12b9835
+      revision: pull/1108/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull in a patch in Zephyr that changes the "Anomaly 160 trigger conditions detected" message logging level to DEBUG.