### PR TITLE
Move nrf_cloud JSON encoding into codec file

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/nrf_cloud/nrf_cloud_codec.c
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/nrf_cloud/nrf_cloud_codec.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <date_time.h>
+#include <net/nrf_cloud_codec.h>
 #include <net/nrf_cloud_location.h>
 #include <cloud_codec.h>
 

--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/nrf_cloud/nrf_cloud_codec.c
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/nrf_cloud/nrf_cloud_codec.c
@@ -728,7 +728,8 @@ int cloud_codec_encode_cloud_location(
 		return -ENODATA;
 	}
 
-	err = nrf_cloud_location_request_json_get(
+	root_obj = cJSON_CreateObject();
+	err = nrf_cloud_location_request_msg_json_encode(
 		cloud_location->neighbor_cells_valid ? &cell_info : NULL,
 #if defined(CONFIG_LOCATION_METHOD_WIFI)
 		cloud_location->wifi_access_points_valid ? &wifi_info : NULL,
@@ -736,9 +737,10 @@ int cloud_codec_encode_cloud_location(
 		NULL,
 #endif
 		true,
-		&root_obj);
+		root_obj);
 	if (err) {
-		LOG_ERR("nrf_cloud_location_request_json_get, error: %d", err);
+		LOG_ERR("nrf_cloud_location_request_msg_json_encode, error: %d", err);
+		cJSON_Delete(root_obj);
 		return -ENOMEM;
 	}
 

--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/nrf_cloud/nrf_cloud_codec.c
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/nrf_cloud/nrf_cloud_codec.c
@@ -740,8 +740,7 @@ int cloud_codec_encode_cloud_location(
 		root_obj);
 	if (err) {
 		LOG_ERR("nrf_cloud_location_request_msg_json_encode, error: %d", err);
-		cJSON_Delete(root_obj);
-		return -ENOMEM;
+		goto exit;
 	}
 
 	buffer = cJSON_PrintUnformatted(root_obj);
@@ -760,7 +759,9 @@ int cloud_codec_encode_cloud_location(
 	output->len = strlen(buffer);
 
 exit:
-	cloud_location->queued = false;
+	if (!err) {
+		cloud_location->queued = false;
+	}
 	cJSON_Delete(root_obj);
 	return err;
 #endif /* CONFIG_NRF_CLOUD_LOCATION */

--- a/applications/asset_tracker_v2/tests/nrf_cloud_codec_mocked_cjson/CMakeLists.txt
+++ b/applications/asset_tracker_v2/tests/nrf_cloud_codec_mocked_cjson/CMakeLists.txt
@@ -18,6 +18,7 @@ test_runner_generate(src/nrf_cloud_codec_mocked_test.c)
 cmock_handle(${ASSET_TRACKER_V2_DIR}/src/cloud/cloud_codec/json_helpers.h)
 cmock_handle(${NRF_DIR}/include/date_time.h)
 cmock_handle(${NRF_DIR}/include/net/nrf_cloud.h)
+cmock_handle(${NRF_DIR}/include/net/nrf_cloud_codec.h)
 cmock_handle(src/cJSON_to_mock.h)
 
 # add test file

--- a/applications/serial_lte_modem/src/gnss/slm_at_gnss.c
+++ b/applications/serial_lte_modem/src/gnss/slm_at_gnss.c
@@ -10,6 +10,7 @@
 #include <date_time.h>
 #include <nrf_modem_gnss.h>
 #include <net/nrf_cloud.h>
+#include <net/nrf_cloud_codec.h>
 #include <net/nrf_cloud_agps.h>
 #include <net/nrf_cloud_pgps.h>
 #include <net/nrf_cloud_location.h>

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -384,6 +384,7 @@ Libraries for networking
     * A public header file :file:`nrf_cloud_defs.h` that contains common defines for interacting with nRF Cloud and the :ref:`lib_nrf_cloud` library.
     * A new event :c:enum:`NRF_CLOUD_EVT_TRANSPORT_CONNECT_ERROR` to indicate an error while the transport connection is being established when the :kconfig:option:`CONFIG_NRF_CLOUD_CONNECTION_POLL_THREAD` Kconfig option is enabled.
       Earlier this was indicated with a second :c:enum:`NRF_CLOUD_EVT_TRANSPORT_CONNECTING` event with an error status.
+    * A public header file :file:`nrf_cloud_codec.h` that contains encoding and decoding functions for nRF Cloud data.
 
   * Removed:
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -157,6 +157,7 @@ nRF9160: Asset Tracker v2
 
   * Use defines from the :ref:`lib_nrf_cloud` library for nRF Cloud related string values.
   * The application now integrates the :ref:`lib_lwm2m_client_utils` FOTA callback functionality.
+  * The application now uses the function :c:func:`nrf_cloud_location_request_msg_json_encode` to create an nRF Cloud location request message.
 
 nRF9160: Serial LTE modem
 -------------------------
@@ -395,6 +396,8 @@ Libraries for networking
     * The :c:func:`nrf_cloud_device_status_msg_encode` function now includes the service info when encoding the device status.
     * Renamed files :file:`nrf_cloud_codec.h` and :file:`nrf_cloud_codec.c` to :file:`nrf_cloud_codec_internal.h` and :file:`nrf_cloud_codec_internal.c` respectively.
     * Standarized encode and decode function names in the codec.
+    * Moved the :c:func:`nrf_cloud_location_request_json_get` function from the :file:`nrf_cloud_location.h` file to :file:`nrf_cloud_codec.h`.
+      The function is now renamed to :c:func:`nrf_cloud_location_request_msg_json_encode`.
 
 * :ref:`lib_lwm2m_client_utils` library:
 

--- a/include/net/nrf_cloud.h
+++ b/include/net/nrf_cloud.h
@@ -13,7 +13,6 @@
 #if defined(CONFIG_MODEM_INFO)
 #include <modem/modem_info.h>
 #endif
-#include <cJSON.h>
 #include <net/nrf_cloud_defs.h>
 #include <dfu/dfu_target_full_modem.h>
 #if defined(CONFIG_NRF_MODEM)
@@ -770,32 +769,6 @@ int nrf_cloud_process(void);
 int nrf_cloud_modem_fota_completed(const bool fota_success);
 
 /**
- * @brief Add service info into the provided cJSON object.
- *
- * @param[in]     svc_inf     Service info to add.
- * @param[in,out] svc_inf_obj cJSON object to which service info will be added.
- *
- * @retval 0 If successful.
- * @return A negative value indicates an error.
- */
-int nrf_cloud_service_info_json_encode(const struct nrf_cloud_svc_info * const svc_inf,
-				       cJSON * const svc_inf_obj);
-
-/**
- * @brief Add modem info into the provided cJSON object.
- *
- * @note To add modem info, CONFIG_MODEM_INFO must be enabled.
- *
- * @param[in]     mod_inf     Modem info to add.
- * @param[in,out] mod_inf_obj cJSON object to which modem info will be added.
- *
- * @retval 0 If successful.
- * @return A negative value indicates an error.
- */
-int nrf_cloud_modem_info_json_encode(const struct nrf_cloud_modem_info * const mod_inf,
-				     cJSON * const mod_inf_obj);
-
-/**
  * @brief Function to retrieve the current device ID.
  *
  * @param[in,out] id_buf Buffer to receive the device ID.
@@ -865,28 +838,6 @@ int nrf_cloud_pending_fota_job_process(struct nrf_cloud_settings_fota_job * cons
  * @return A negative value indicates an error.
  */
 int nrf_cloud_bootloader_fota_slot_set(struct nrf_cloud_settings_fota_job * const job);
-
-/**
- * @brief Function to check for a JSON error message in data received from nRF Cloud via MQTT.
- *
- * @param[in] buf Data received from nRF Cloud.
- * @param[in] app_id appId value to check for.
- *                   Set to NULL to skip appID check.
- * @param[in] msg_type messageType value to check for.
- *                     Set to NULL to skip messageType check.
- * @param[out] err Error code found in message.
- *
- * @retval 0 Error code found (and matched app_id and msg_type if provided).
- * @retval -ENOENT Error code found, but did not match specified app_id and msg_type.
- * @retval -ENOMSG No error code found.
- * @retval -EBADMSG Invalid error code data format.
- * @retval -ENODATA JSON data was not found.
- * @return A negative value indicates an error.
- */
-int nrf_cloud_error_msg_decode(const char *const buf,
-			       const char *const app_id,
-			       const char *const msg_type,
-			       enum nrf_cloud_error *const err);
 
 /**
  * @brief Function to retrieve the FOTA type of a pending FOTA job. A value of
@@ -975,19 +926,6 @@ bool nrf_cloud_fota_is_type_modem(const enum nrf_cloud_fota_type type);
  * @retval false Specified FOTA type is not enabled by the configuration.
  */
 bool nrf_cloud_fota_is_type_enabled(const enum nrf_cloud_fota_type type);
-
-/**
- * @brief Add GNSS location data, formatted as an nRF Cloud device message,
- *        to the provided cJSON object.
- *
- * @param[in]     gnss     Service info to add.
- * @param[in,out] gnss_msg_obj cJSON object to which GNSS data will be added.
- *
- * @retval 0 If successful.
- * @return A negative value indicates an error.
- */
-int nrf_cloud_gnss_msg_json_encode(const struct nrf_cloud_gnss_data * const gnss,
-				   cJSON * const gnss_msg_obj);
 /** @} */
 
 #ifdef __cplusplus

--- a/include/net/nrf_cloud_codec.h
+++ b/include/net/nrf_cloud_codec.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef NRF_CLOUD_CODEC_H__
+#define NRF_CLOUD_CODEC_H__
+
+#include <net/nrf_cloud.h>
+#include <cJSON.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @defgroup nrf_cloud_codec nRF Cloud Codec
+ * @{
+ */
+
+/**
+ * @brief Add GNSS location data, formatted as an nRF Cloud device message,
+ *        to the provided cJSON object.
+ *
+ * @param[in]     gnss     Service info to add.
+ * @param[in,out] gnss_msg_obj cJSON object to which GNSS data will be added.
+ *
+ * @retval 0 If successful.
+ * @return A negative value indicates an error.
+ */
+int nrf_cloud_gnss_msg_json_encode(const struct nrf_cloud_gnss_data * const gnss,
+				   cJSON * const gnss_msg_obj);
+
+/**
+ * @brief Check for a JSON error message in data received from nRF Cloud via MQTT.
+ *
+ * @param[in] buf Data received from nRF Cloud.
+ * @param[in] app_id appId value to check for.
+ *                   Set to NULL to skip appID check.
+ * @param[in] msg_type messageType value to check for.
+ *                     Set to NULL to skip messageType check.
+ * @param[out] err Error code found in message.
+ *
+ * @retval 0 Error code found (and matched app_id and msg_type if provided).
+ * @retval -ENOENT Error code found, but did not match specified app_id and msg_type.
+ * @retval -ENOMSG No error code found.
+ * @retval -EBADMSG Invalid error code data format.
+ * @retval -ENODATA JSON data was not found.
+ * @return A negative value indicates an error.
+ */
+int nrf_cloud_error_msg_decode(const char * const buf,
+			       const char * const app_id,
+			       const char * const msg_type,
+			       enum nrf_cloud_error * const err);
+
+/**
+ * @brief Add service info into the provided cJSON object.
+ *
+ * @param[in]     svc_inf     Service info to add.
+ * @param[in,out] svc_inf_obj cJSON object to which service info will be added.
+ *
+ * @retval 0 If successful.
+ * @return A negative value indicates an error.
+ */
+int nrf_cloud_service_info_json_encode(const struct nrf_cloud_svc_info * const svc_inf,
+				       cJSON * const svc_inf_obj);
+
+/**
+ * @brief Add modem info into the provided cJSON object.
+ *
+ * @note To add modem info, CONFIG_MODEM_INFO must be enabled.
+ *
+ * @param[in]     mod_inf     Modem info to add.
+ * @param[in,out] mod_inf_obj cJSON object to which modem info will be added.
+ *
+ * @retval 0 If successful.
+ * @return A negative value indicates an error.
+ */
+int nrf_cloud_modem_info_json_encode(const struct nrf_cloud_modem_info * const mod_inf,
+				     cJSON * const mod_inf_obj);
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NRF_CLOUD_CODEC_H__ */

--- a/include/net/nrf_cloud_codec.h
+++ b/include/net/nrf_cloud_codec.h
@@ -9,6 +9,8 @@
 
 #include <net/nrf_cloud.h>
 #include <cJSON.h>
+#include <modem/lte_lc.h>
+#include <net/wifi_location_common.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -19,11 +21,10 @@ extern "C" {
  */
 
 /**
- * @brief Add GNSS location data, formatted as an nRF Cloud device message,
- *        to the provided cJSON object.
+ * @brief Create an nRF Cloud GNSS device message using the provided GNSS data.
  *
  * @param[in]     gnss     Service info to add.
- * @param[in,out] gnss_msg_obj cJSON object to which GNSS data will be added.
+ * @param[in,out] gnss_msg_obj cJSON object to which the GNSS message will be added.
  *
  * @retval 0 If successful.
  * @return A negative value indicates an error.
@@ -32,7 +33,53 @@ int nrf_cloud_gnss_msg_json_encode(const struct nrf_cloud_gnss_data * const gnss
 				   cJSON * const gnss_msg_obj);
 
 /**
- * @brief Check for a JSON error message in data received from nRF Cloud via MQTT.
+ * @brief Create an nRF Cloud location request device message using the provided
+ *        cellular and/or Wi-Fi data.
+ *
+ * @param cells_inf Cell info; can be NULL if Wi-Fi info is provided.
+ * @param wifi_inf Wi-Fi info; can be NULL if cell info is provided.
+ * @param request_loc If true, cloud will send location to the device.
+ *                    If false, cloud will not send location to the device.
+ * @param loc_req_obj cJSON object to which the location request message will be added.
+ *
+ * @retval 0 If successful.
+ * @retval -EDOM The number of access points in the Wi-Fi-only request was smaller than
+ *               the minimum required value NRF_CLOUD_LOCATION_WIFI_AP_CNT_MIN.
+ * @return A negative value indicates an error.
+ */
+int nrf_cloud_location_request_msg_json_encode(const struct lte_lc_cells_info * const cells_inf,
+					       const struct wifi_scan_info * const wifi_inf,
+					       const bool request_loc,
+					       cJSON * const loc_req_obj);
+
+/**
+ * @brief Add service info into the provided cJSON object.
+ *
+ * @param[in]     svc_inf     Service info to add.
+ * @param[in,out] svc_inf_obj cJSON object to which the service info will be added.
+ *
+ * @retval 0 If successful.
+ * @return A negative value indicates an error.
+ */
+int nrf_cloud_service_info_json_encode(const struct nrf_cloud_svc_info *const svc_inf,
+				       cJSON * const svc_inf_obj);
+
+/**
+ * @brief Add modem info into the provided cJSON object.
+ *
+ * @note To add modem info, CONFIG_MODEM_INFO must be enabled.
+ *
+ * @param[in]     mod_inf     Modem info to add.
+ * @param[in,out] mod_inf_obj cJSON object to which the modem info will be added.
+ *
+ * @retval 0 If successful.
+ * @return A negative value indicates an error.
+ */
+int nrf_cloud_modem_info_json_encode(const struct nrf_cloud_modem_info *const mod_inf,
+				     cJSON * const mod_inf_obj);
+
+/**
+ * @brief Check for a JSON error message in the data received from nRF Cloud over MQTT.
  *
  * @param[in] buf Data received from nRF Cloud.
  * @param[in] app_id appId value to check for.
@@ -42,7 +89,7 @@ int nrf_cloud_gnss_msg_json_encode(const struct nrf_cloud_gnss_data * const gnss
  * @param[out] err Error code found in message.
  *
  * @retval 0 Error code found (and matched app_id and msg_type if provided).
- * @retval -ENOENT Error code found, but did not match specified app_id and msg_type.
+ * @retval -ENOENT Error code found, but did not match specified the app_id and msg_type.
  * @retval -ENOMSG No error code found.
  * @retval -EBADMSG Invalid error code data format.
  * @retval -ENODATA JSON data was not found.
@@ -52,32 +99,6 @@ int nrf_cloud_error_msg_decode(const char * const buf,
 			       const char * const app_id,
 			       const char * const msg_type,
 			       enum nrf_cloud_error * const err);
-
-/**
- * @brief Add service info into the provided cJSON object.
- *
- * @param[in]     svc_inf     Service info to add.
- * @param[in,out] svc_inf_obj cJSON object to which service info will be added.
- *
- * @retval 0 If successful.
- * @return A negative value indicates an error.
- */
-int nrf_cloud_service_info_json_encode(const struct nrf_cloud_svc_info * const svc_inf,
-				       cJSON * const svc_inf_obj);
-
-/**
- * @brief Add modem info into the provided cJSON object.
- *
- * @note To add modem info, CONFIG_MODEM_INFO must be enabled.
- *
- * @param[in]     mod_inf     Modem info to add.
- * @param[in,out] mod_inf_obj cJSON object to which modem info will be added.
- *
- * @retval 0 If successful.
- * @return A negative value indicates an error.
- */
-int nrf_cloud_modem_info_json_encode(const struct nrf_cloud_modem_info * const mod_inf,
-				     cJSON * const mod_inf_obj);
 /** @} */
 
 #ifdef __cplusplus

--- a/include/net/nrf_cloud_location.h
+++ b/include/net/nrf_cloud_location.h
@@ -15,7 +15,6 @@
 #include <modem/lte_lc.h>
 #include <net/nrf_cloud.h>
 #include <net/wifi_location_common.h>
-#include <cJSON.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -108,23 +107,6 @@ int nrf_cloud_location_request(const struct lte_lc_cells_info *const cells_inf,
 			       const struct wifi_scan_info *const wifi_inf,
 			       const bool request_loc, nrf_cloud_location_response_t cb);
 #endif /* CONFIG_NRF_CLOUD_MQTT */
-
-/** @brief Get the reference to a cJSON object containing a location request.
- *
- * @param cells_inf Cell info; can be NULL if Wi-Fi info is provided.
- * @param wifi_inf Wi-Fi info; can be NULL if cell info is provided.
- * @param request_loc If true, cloud will send location to the device.
- *                    If false, cloud will not send location to the device.
- * @param req_obj_out The reference to the generated cJSON object.
- *
- * @retval 0 If successful.
- * @retval -EDOM The number of access points in the Wi-Fi-only request was smaller than
- *               the minimum required value NRF_CLOUD_LOCATION_WIFI_AP_CNT_MIN.
- * @return A negative value indicates an error.
- */
-int nrf_cloud_location_request_json_get(const struct lte_lc_cells_info *const cells_inf,
-					const struct wifi_scan_info *const wifi_inf,
-					const bool request_loc, cJSON **req_obj_out);
 
 /** @brief Process location data received from nRF Cloud over MQTT or REST.
  *

--- a/samples/nrf9160/modem_shell/src/location/location_cmd_utils.c
+++ b/samples/nrf9160/modem_shell/src/location/location_cmd_utils.c
@@ -14,6 +14,7 @@
 #include <math.h>
 #include <getopt.h>
 #include <net/nrf_cloud.h>
+#include <net/nrf_cloud_codec.h>
 #include <modem/location.h>
 
 #include "mosh_print.h"

--- a/samples/nrf9160/nrf_cloud_mqtt_multi_service/src/application.c
+++ b/samples/nrf9160/nrf_cloud_mqtt_multi_service/src/application.c
@@ -9,6 +9,7 @@
 #include <nrf_modem_at.h>
 #include <nrf_errno.h>
 #include <net/nrf_cloud.h>
+#include <net/nrf_cloud_codec.h>
 #include <net/nrf_cloud_alerts.h>
 #include <date_time.h>
 #include <cJSON.h>

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_agps.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_agps.c
@@ -9,6 +9,7 @@
 #include <nrf_modem_gnss.h>
 #include <cJSON.h>
 #include <modem/modem_info.h>
+#include <net/nrf_cloud_codec.h>
 #include <net/nrf_cloud_defs.h>
 #include <net/nrf_cloud_agps.h>
 #if defined(CONFIG_NRF_CLOUD_PGPS)

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec_internal.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec_internal.c
@@ -7,6 +7,7 @@
 #include "nrf_cloud_codec_internal.h"
 #include "nrf_cloud_mem.h"
 #include "nrf_cloud_fsm.h"
+#include <net/nrf_cloud_codec.h>
 #include <net/nrf_cloud_location.h>
 #include <net/nrf_cloud_alerts.h>
 #include <stdbool.h>

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_rest.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_rest.c
@@ -16,6 +16,7 @@
 #endif
 #include <modem/nrf_modem_lib.h>
 #include <modem/modem_key_mgmt.h>
+#include <net/nrf_cloud_codec.h>
 #include <net/nrf_cloud_rest.h>
 #include <net/rest_client.h>
 #include <zephyr/logging/log.h>


### PR DESCRIPTION
Move encode and decode functions from nrf_cloud.h into a new public header, net/nrf_cloud_codec.h.
Move the location request message encoding function into the new public nrf_cloud_codec.h file.
Also, rename the function and update signature to conform with other encode function.
Update asset_tracker_v2 to use new function.

NCSDK-19171 NCSDK-19174