### PR TITLE
Move A-GPS and P-GPS request encoding into codec file

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -417,6 +417,12 @@ Libraries for networking
     * Moved the :c:func:`nrf_cloud_location_request_json_get` function from the :file:`nrf_cloud_location.h` file to :file:`nrf_cloud_codec.h`.
       The function is now renamed to :c:func:`nrf_cloud_location_request_msg_json_encode`.
 
+* :ref:`lib_nrf_cloud_rest` library:
+
+  * Updated:
+
+    * The mask angle parameter can now be omitted from an A-GPS REST request by using the value ``NRF_CLOUD_AGPS_MASK_ANGLE_NONE``.
+
 * :ref:`lib_lwm2m_client_utils` library:
 
   * Updated:

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -423,6 +423,8 @@ Libraries for networking
   * Updated:
 
     * The mask angle parameter can now be omitted from an A-GPS REST request by using the value ``NRF_CLOUD_AGPS_MASK_ANGLE_NONE``.
+    * Use defines from the :file:`nrf_cloud_pgps.h` file for omitting parameters from a P-GPS request.
+      Removed the following values: ``NRF_CLOUD_REST_PGPS_REQ_NO_COUNT``, ``NRF_CLOUD_REST_PGPS_REQ_NO_INTERVAL``, ``NRF_CLOUD_REST_PGPS_REQ_NO_GPS_DAY``, and ``NRF_CLOUD_REST_PGPS_REQ_NO_GPS_TOD``.
 
 * :ref:`lib_lwm2m_client_utils` library:
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -404,6 +404,7 @@ Libraries for networking
     * A new event :c:enum:`NRF_CLOUD_EVT_TRANSPORT_CONNECT_ERROR` to indicate an error while the transport connection is being established when the :kconfig:option:`CONFIG_NRF_CLOUD_CONNECTION_POLL_THREAD` Kconfig option is enabled.
       Earlier this was indicated with a second :c:enum:`NRF_CLOUD_EVT_TRANSPORT_CONNECTING` event with an error status.
     * A public header file :file:`nrf_cloud_codec.h` that contains encoding and decoding functions for nRF Cloud data.
+    * Defines to enable parameters to be omitted from a P-GPS request.
 
   * Removed:
 

--- a/include/net/nrf_cloud_agps.h
+++ b/include/net/nrf_cloud_agps.h
@@ -19,6 +19,9 @@
 extern "C" {
 #endif
 
+/** Exclude the mask angle from the A-GPS request */
+#define NRF_CLOUD_AGPS_MASK_ANGLE_NONE	0xFF
+
 /** @defgroup nrf_cloud_agps nRF Cloud A-GPS
  * @{
  */

--- a/include/net/nrf_cloud_pgps.h
+++ b/include/net/nrf_cloud_pgps.h
@@ -66,6 +66,15 @@ struct nrf_cloud_pgps_prediction {
 	uint32_t sentinel;
 } __packed;
 
+/** Omit the prediction count from P-GPS request */
+#define NRF_CLOUD_PGPS_REQ_NO_COUNT	0
+/** Omit the prediction validity period from P-GPS request */
+#define NRF_CLOUD_PGPS_REQ_NO_INTERVAL	0
+/** Omit the GPS day from P-GPS request */
+#define NRF_CLOUD_PGPS_REQ_NO_GPS_DAY	0
+/** Omit the GPS time of day from P-GPS request */
+#define NRF_CLOUD_PGPS_REQ_NO_GPS_TOD	(-1)
+
 /** @brief P-GPS request type */
 struct gps_pgps_request {
 	/** Number of predictions desired. */

--- a/include/net/nrf_cloud_rest.h
+++ b/include/net/nrf_cloud_rest.h
@@ -138,7 +138,8 @@ struct nrf_cloud_rest_agps_request {
 	bool filtered;
 	/** Constrain the set of ephemerides to only those currently
 	 *  visible at or above the specified elevation threshold
-	 *  angle in degrees. Range is 0 to 90.
+	 *  angle in degrees. Range is 0 to 90.  Set to
+	 *  NRF_CLOUD_AGPS_MASK_ANGLE_NONE to exclude from request.
 	 */
 	uint8_t mask_angle;
 };

--- a/include/net/nrf_cloud_rest.h
+++ b/include/net/nrf_cloud_rest.h
@@ -154,19 +154,10 @@ struct nrf_cloud_rest_agps_result {
 	size_t agps_sz;
 };
 
-/** Omit the prediction count from P-GPS request */
-#define NRF_CLOUD_REST_PGPS_REQ_NO_COUNT	0
-/** Omit the prediction validity period from P-GPS request */
-#define NRF_CLOUD_REST_PGPS_REQ_NO_INTERVAL	0
-/** Omit the GPS day from P-GPS request */
-#define NRF_CLOUD_REST_PGPS_REQ_NO_GPS_DAY	0
-/** Omit the GPS time of day from P-GPS request */
-#define NRF_CLOUD_REST_PGPS_REQ_NO_GPS_TOD	(-1)
-
 /** @brief Data required for nRF Cloud Predicted GPS (P-GPS) request */
 struct nrf_cloud_rest_pgps_request {
 	/** Data to be included in the P-GPS request. To omit an item
-	 * use the appropriate `NRF_CLOUD_REST_PGPS_REQ_NO_` define.
+	 * use the appropriate `NRF_CLOUD_PGPS_REQ_NO_` define.
 	 */
 	const struct gps_pgps_request *pgps_req;
 };
@@ -216,6 +207,7 @@ int nrf_cloud_rest_agps_data_get(struct nrf_cloud_rest_context *const rest_ctx,
 	struct nrf_cloud_rest_agps_request const *const request,
 	struct nrf_cloud_rest_agps_result *const result);
 
+#if defined(CONFIG_NRF_CLOUD_PGPS)
 /**
  * @brief nRF Cloud Predicted GPS (P-GPS) data request.
  *
@@ -231,6 +223,7 @@ int nrf_cloud_rest_agps_data_get(struct nrf_cloud_rest_context *const rest_ctx,
  */
 int nrf_cloud_rest_pgps_data_get(struct nrf_cloud_rest_context *const rest_ctx,
 	struct nrf_cloud_rest_pgps_request const *const request);
+#endif
 
 /**
  * @brief Requests nRF Cloud FOTA job info for the specified device.

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_agps_schema_v1.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_agps_schema_v1.h
@@ -27,6 +27,7 @@ extern "C" {
 #define NRF_CLOUD_AGPS_MAX_SV_TOW			(32U)
 
 enum nrf_cloud_agps_type {
+	NRF_CLOUD_AGPS__TYPE_INVALID			= 0,
 	NRF_CLOUD_AGPS_UTC_PARAMETERS			= 1,
 	NRF_CLOUD_AGPS_EPHEMERIDES			= 2,
 	NRF_CLOUD_AGPS_ALMANAC				= 3,

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec_internal.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec_internal.h
@@ -232,6 +232,13 @@ int nrf_cloud_pgps_req_json_encode(const struct gps_pgps_request * const request
 				   cJSON * const pgps_req_obj_out);
 #endif
 
+/** @brief Convert a JSON payload to a parameterized URL for REST. Converts only objects at
+ * the root level. Converts only integers and integer arrays, strings, and boolean values.
+ * String values are assumed to be URL-compatible.
+ */
+int nrf_cloud_json_to_url_params_convert(char * const buf, const size_t buf_size,
+					 const cJSON * const obj);
+
 #ifdef CONFIG_NRF_CLOUD_GATEWAY
 typedef int (*gateway_state_handler_t)(void *root_obj);
 

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec_internal.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec_internal.h
@@ -222,6 +222,16 @@ int nrf_cloud_agps_req_json_encode(const struct nrf_modem_gnss_agps_data_frame *
 				   cJSON * const agps_req_obj_out);
 #endif
 
+#if defined(CONFIG_NRF_CLOUD_PGPS)
+/** @brief Encode the data payload of an nRF Cloud P-GPS request into the provided object */
+int nrf_cloud_pgps_req_data_json_encode(const struct gps_pgps_request * const request,
+					cJSON * const data_obj_out);
+
+/** @brief Encode an P-GPS request device message to be sent to nRF Cloud */
+int nrf_cloud_pgps_req_json_encode(const struct gps_pgps_request * const request,
+				   cJSON * const pgps_req_obj_out);
+#endif
+
 #ifdef CONFIG_NRF_CLOUD_GATEWAY
 typedef int (*gateway_state_handler_t)(void *root_obj);
 

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec_internal.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec_internal.h
@@ -16,12 +16,16 @@
 #if defined(CONFIG_NRF_CLOUD_PGPS)
 #include <net/nrf_cloud_pgps.h>
 #endif
-#if defined(CONFIG_NRF_CLOUD_AGPS) || defined(CONFIG_NRF_CLOUD_PGPS)
+#if defined(CONFIG_NRF_CLOUD_AGPS)
 #include <net/nrf_cloud_agps.h>
+#endif
+#if defined(CONFIG_NRF_MODEM)
+#include <nrf_modem_gnss.h>
 #endif
 #include <net/nrf_cloud_location.h>
 #include "cJSON.h"
 #include "nrf_cloud_fsm.h"
+#include "nrf_cloud_agps_schema_v1.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -121,8 +125,12 @@ int nrf_cloud_pgps_response_decode(const char *const response,
 				   struct nrf_cloud_pgps_result *const result);
 #endif
 
-/** @brief Add common [network] modem info to the provided cJSON object */
-int nrf_cloud_network_info_json_encode(cJSON * const data_obj);
+/** @brief Add cellular network info to the provided cJSON object.
+ * If the cell_inf parameter is NULL, the codec will obtain the current network
+ * info from the modem.
+ */
+int nrf_cloud_cell_info_json_encode(cJSON * const data_obj,
+				    const struct lte_lc_cell *const cell_inf);
 
 /** @brief Build a cellular positioning request in the provided cJSON object
  * using the provided cell info
@@ -200,6 +208,19 @@ enum nrf_cloud_rcv_topic nrf_cloud_dc_rx_topic_decode(const char * const topic);
  * CONFIG_NRF_CLOUD_SEND_DEVICE_STATUS is enabled.
  */
 void nrf_cloud_set_app_version(const char * const app_ver);
+
+/** @brief Encode the data payload of an nRF Cloud A-GPS request into the provided object */
+int nrf_cloud_agps_req_data_json_encode(const enum nrf_cloud_agps_type * const types,
+					const size_t type_count,
+					const struct lte_lc_cell * const cell_inf,
+					const bool filtered_ephem, const uint8_t mask_angle,
+					cJSON * const data_obj_out);
+
+/** @brief Encode an A-GPS request device message to be sent to nRF Cloud */
+#if defined(CONFIG_NRF_CLOUD_AGPS)
+int nrf_cloud_agps_req_json_encode(const struct nrf_modem_gnss_agps_data_frame * const request,
+				   cJSON * const agps_req_obj_out);
+#endif
 
 #ifdef CONFIG_NRF_CLOUD_GATEWAY
 typedef int (*gateway_state_handler_t)(void *root_obj);

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_agps.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_agps.c
@@ -54,50 +54,20 @@ bool nrf_cloud_agps_request_in_progress(void)
 	return atomic_get(&request_in_progress) != 0;
 }
 
-#if IS_ENABLED(CONFIG_NRF_CLOUD_MQTT)
-static int json_add_types_array(cJSON * const obj, enum nrf_cloud_agps_type *types,
-				const size_t type_count)
-{
-	__ASSERT_NO_MSG(obj != NULL);
-	__ASSERT_NO_MSG(types != NULL);
-
-	cJSON *array;
-
-	if (!type_count) {
-		return -EINVAL;
-	}
-
-	array = cJSON_AddArrayToObject(obj, NRF_CLOUD_JSON_KEY_AGPS_TYPES);
-	if (!array) {
-		return -ENOMEM;
-	}
-
-	for (size_t i = 0; i < type_count; i++) {
-		cJSON_AddItemToArray(array, cJSON_CreateNumber(types[i]));
-	}
-
-	if (cJSON_GetArraySize(array) != type_count) {
-		cJSON_DeleteItemFromObject(obj, NRF_CLOUD_JSON_KEY_AGPS_TYPES);
-		return -ENOMEM;
-	}
-
-	return 0;
-}
-#endif /* IS_ENABLED(CONFIG_NRF_CLOUD_MQTT) */
-
 int nrf_cloud_agps_request(const struct nrf_modem_gnss_agps_data_frame *request)
 {
 #if IS_ENABLED(CONFIG_NRF_CLOUD_MQTT)
 	if (nfsm_get_current_state() != STATE_DC_CONNECTED) {
 		return -EACCES;
 	}
+	if (!request) {
+		return -EINVAL;
+	}
 
 	int err;
-	enum nrf_cloud_agps_type types[9];
-	size_t type_count = 0;
-	cJSON *data_obj;
 	cJSON *agps_req_obj;
-	uint32_t ephem;
+	/* Copy the request so that the ephemeris mask can be modified if necessary */
+	struct nrf_modem_gnss_agps_data_frame req = *request;
 
 	atomic_set(&request_in_progress, 0);
 
@@ -105,115 +75,34 @@ int nrf_cloud_agps_request(const struct nrf_modem_gnss_agps_data_frame *request)
 	memset(&processed, 0, sizeof(processed));
 	k_mutex_unlock(&processed_lock);
 
-	if (request->data_flags & NRF_MODEM_GNSS_AGPS_GPS_UTC_REQUEST) {
-		types[type_count++] = NRF_CLOUD_AGPS_UTC_PARAMETERS;
-	}
-
-	ephem = request->sv_mask_ephe;
 #if defined(CONFIG_NRF_CLOUD_AGPS_FILTERED)
 	/**
 	 * Determine if we processed ephemerides assistance less than 2 hours ago; if so,
 	 * we can skip this.
 	 */
-	if (ephem &&
+	if (req.sv_mask_ephe &&
 	    (last_request_timestamp != 0) &&
 	    ((k_uptime_get() - last_request_timestamp) < AGPS_UPDATE_PERIOD)) {
 		LOG_WRN("A-GPS request was sent less than 2 hours ago");
-		ephem = 0;
+		req.sv_mask_ephe = 0;
 	}
 #endif
 
-	if (ephem) {
-		types[type_count++] = NRF_CLOUD_AGPS_EPHEMERIDES;
-	}
-
-	if (request->sv_mask_alm) {
-		types[type_count++] = NRF_CLOUD_AGPS_ALMANAC;
-	}
-
-	if (request->data_flags & NRF_MODEM_GNSS_AGPS_KLOBUCHAR_REQUEST) {
-		types[type_count++] = NRF_CLOUD_AGPS_KLOBUCHAR_CORRECTION;
-	}
-
-	if (request->data_flags & NRF_MODEM_GNSS_AGPS_NEQUICK_REQUEST) {
-		types[type_count++] = NRF_CLOUD_AGPS_NEQUICK_CORRECTION;
-	}
-
-	if (request->data_flags & NRF_MODEM_GNSS_AGPS_SYS_TIME_AND_SV_TOW_REQUEST) {
-		types[type_count++] = NRF_CLOUD_AGPS_GPS_TOWS;
-		types[type_count++] = NRF_CLOUD_AGPS_GPS_SYSTEM_CLOCK;
-	}
-
-	if (request->data_flags & NRF_MODEM_GNSS_AGPS_POSITION_REQUEST) {
-		types[type_count++] = NRF_CLOUD_AGPS_LOCATION;
-	}
-
-	if (request->data_flags & NRF_MODEM_GNSS_AGPS_INTEGRITY_REQUEST) {
-		types[type_count++] = NRF_CLOUD_AGPS_INTEGRITY;
-	}
-
-	if (type_count == 0) {
-		LOG_INF("No A-GPS data types requested");
-		return 0;
-	}
-
-	/* Create request JSON containing a data object */
-	agps_req_obj = json_create_req_obj(NRF_CLOUD_JSON_APPID_VAL_AGPS,
-					   NRF_CLOUD_JSON_MSG_TYPE_VAL_DATA);
-	data_obj = cJSON_AddObjectToObject(agps_req_obj, NRF_CLOUD_JSON_DATA_KEY);
-
-	if (!agps_req_obj || !data_obj) {
-		err = -ENOMEM;
-		goto cleanup;
-	}
-
-#if defined(CONFIG_NRF_CLOUD_AGPS_FILTERED)
-	cJSON *filtered;
-
-	filtered = cJSON_AddTrueToObjectCS(data_obj, NRF_CLOUD_JSON_FILTERED_KEY);
-	if (!filtered) {
-		err = -ENOMEM;
-		goto cleanup;
-	}
-
-	cJSON *mask;
-
-	mask = cJSON_AddNumberToObjectCS(data_obj,
-					 NRF_CLOUD_JSON_KEY_ELEVATION_MASK,
-					 CONFIG_NRF_CLOUD_AGPS_ELEVATION_MASK);
-	if (!mask) {
-		err = -ENOMEM;
-		goto cleanup;
-	}
-	LOG_DBG("Requesting filtered ephemerides with elevation mask angle = %u degrees",
-		CONFIG_NRF_CLOUD_AGPS_ELEVATION_MASK);
-#endif
-
-	/* Add modem info and A-GPS types to the data object */
-	err = nrf_cloud_network_info_json_encode(data_obj);
-	if (err) {
-		LOG_ERR("Failed to add modem info to A-GPS request: %d", err);
-		goto cleanup;
-	}
-	err = json_add_types_array(data_obj, types, type_count);
-	if (err) {
-		LOG_ERR("Failed to add types array to A-GPS request %d", err);
-		goto cleanup;
-	}
-
-	err = json_send_to_cloud(agps_req_obj);
+	agps_req_obj = cJSON_CreateObject();
+	err = nrf_cloud_agps_req_json_encode(&req, agps_req_obj);
 	if (!err) {
-		atomic_set(&request_in_progress, 1);
+		err = json_send_to_cloud(agps_req_obj);
+		if (!err) {
+			atomic_set(&request_in_progress, 1);
+		}
+	} else {
+		err = -ENOMEM;
 	}
 
-cleanup:
 	cJSON_Delete(agps_req_obj);
-
 	return err;
 #else /* IS_ENABLED(CONFIG_NRF_CLOUD_MQTT) */
-
 	LOG_ERR("CONFIG_NRF_CLOUD_MQTT must be enabled in order to use this API");
-
 	return -ENOTSUP;
 #endif
 }

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_rest.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_rest.c
@@ -90,11 +90,7 @@ LOG_MODULE_REGISTER(nrf_cloud_rest, CONFIG_NRF_CLOUD_REST_LOG_LEVEL);
  */
 #define AGPS_CUSTOM_TYPE_STR_SZ		(AGPS_CUSTOM_TYPE_CNT * 2)
 
-#define API_GET_PGPS_BASE		API_VER "/location/pgps?"
-#define PGPS_REQ_PREDICT_CNT		"&" NRF_CLOUD_JSON_PGPS_PRED_COUNT "=%u"
-#define PGPS_REQ_PREDICT_INT_MIN	"&" NRF_CLOUD_JSON_PGPS_INT_MIN "=%u"
-#define PGPS_REQ_START_GPS_DAY		"&" NRF_CLOUD_JSON_PGPS_GPS_DAY "=%u"
-#define PGPS_REQ_START_GPS_TOD_S	"&" NRF_CLOUD_JSON_PGPS_GPS_TIME "=%u"
+#define API_GET_PGPS_BASE		API_VER "/location/pgps"
 
 #define API_DEVICES_BASE		"/devices"
 #define API_DEVICES_STATE_TEMPLATE	API_VER API_DEVICES_BASE "/%s/state"
@@ -1066,6 +1062,7 @@ clean_up:
 	return ret;
 }
 
+#if defined(CONFIG_NRF_CLOUD_PGPS)
 int nrf_cloud_rest_pgps_data_get(struct nrf_cloud_rest_context *const rest_ctx,
 				 struct nrf_cloud_rest_pgps_request const *const request)
 {
@@ -1073,113 +1070,58 @@ int nrf_cloud_rest_pgps_data_get(struct nrf_cloud_rest_context *const rest_ctx,
 	__ASSERT_NO_MSG(request != NULL);
 
 	int ret;
+
 	size_t url_sz;
-	size_t remain;
-	size_t pos;
 	char *auth_hdr = NULL;
 	char *url = NULL;
+	cJSON *data_obj;
 	struct rest_client_req_context req;
 	struct rest_client_resp_context resp;
 
 	memset(&resp, 0, sizeof(resp));
 	init_rest_client_request(rest_ctx, &req, HTTP_GET);
 
-	/* Determine size of URL buffer and allocate */
-	url_sz = sizeof(API_GET_PGPS_BASE);
-
-	if (request->pgps_req) {
-		if (request->pgps_req->prediction_count !=
-		NRF_CLOUD_REST_PGPS_REQ_NO_COUNT) {
-			url_sz += sizeof(PGPS_REQ_PREDICT_CNT) +
-				  UINT32_MAX_STR_SZ;
-		}
-		if (request->pgps_req->prediction_period_min !=
-		    NRF_CLOUD_REST_PGPS_REQ_NO_INTERVAL) {
-			url_sz += sizeof(PGPS_REQ_PREDICT_INT_MIN) +
-				  UINT32_MAX_STR_SZ;
-		}
-		if (request->pgps_req->gps_day !=
-		    NRF_CLOUD_REST_PGPS_REQ_NO_GPS_DAY) {
-			url_sz += sizeof(PGPS_REQ_START_GPS_DAY) +
-				  UINT32_MAX_STR_SZ;
-		}
-		if (request->pgps_req->gps_time_of_day !=
-		    NRF_CLOUD_REST_PGPS_REQ_NO_GPS_TOD) {
-			url_sz += sizeof(PGPS_REQ_START_GPS_TOD_S) +
-				  UINT32_MAX_STR_SZ;
-		}
+	/* Encode the request data as JSON */
+	data_obj = cJSON_CreateObject();
+	ret = nrf_cloud_pgps_req_data_json_encode(request->pgps_req, data_obj);
+	if (ret) {
+		goto clean_up;
 	}
 
+	/* Create a parameterized URL from the JSON data to use for the GET request.
+	 * The HTTP request body is not used in GET requests.
+	 * Use the rx_buf temporarily.
+	 */
+	ret = nrf_cloud_json_to_url_params_convert(rest_ctx->rx_buf, rest_ctx->rx_buf_len,
+						   data_obj);
+
+	/* Cleanup JSON obj */
+	cJSON_Delete(data_obj);
+	data_obj = NULL;
+
+	if (ret) {
+		LOG_ERR("Could not create P-GPS request URL");
+		goto clean_up;
+	}
+
+	url_sz = sizeof(API_GET_PGPS_BASE) + strlen(rest_ctx->rx_buf);
 	url = nrf_cloud_malloc(url_sz);
 	if (!url) {
 		ret = -ENOMEM;
 		goto clean_up;
 	}
-	req.url = url;
 
-	/* Format API URL */
-	ret = snprintk(url, url_sz, API_GET_PGPS_BASE);
-	if ((ret < 0) || (ret >= url_sz)) {
+	ret = snprintk(url, url_sz, "%s%s", API_GET_PGPS_BASE, rest_ctx->rx_buf);
+	if (ret < 0 || ret >= url_sz) {
 		LOG_ERR("Could not format URL");
 		ret = -ETXTBSY;
 		goto clean_up;
 	}
-	pos = ret;
-	remain = url_sz - ret;
 
-	if (request->pgps_req) {
-		if (request->pgps_req->prediction_count !=
-		    NRF_CLOUD_REST_PGPS_REQ_NO_COUNT) {
-			ret = snprintk(&url[pos], remain, PGPS_REQ_PREDICT_CNT,
-				request->pgps_req->prediction_count);
-			if ((ret < 0) || (ret >= remain)) {
-				LOG_ERR("Could not format URL: prediction count");
-				ret = -ETXTBSY;
-				goto clean_up;
-			}
-			pos += ret;
-			remain -= ret;
-		}
+	/* Set the URL */
+	req.url = url;
 
-		if (request->pgps_req->prediction_period_min !=
-		    NRF_CLOUD_REST_PGPS_REQ_NO_INTERVAL) {
-			ret = snprintk(&url[pos], remain, PGPS_REQ_PREDICT_INT_MIN,
-				       request->pgps_req->prediction_period_min);
-			if ((ret < 0) || (ret >= remain)) {
-				LOG_ERR("Could not format URL: prediction interval");
-				ret = -ETXTBSY;
-				goto clean_up;
-			}
-			pos += ret;
-			remain -= ret;
-		}
-
-		if (request->pgps_req->gps_day !=
-		    NRF_CLOUD_REST_PGPS_REQ_NO_GPS_DAY) {
-			ret = snprintk(&url[pos], remain, PGPS_REQ_START_GPS_DAY,
-				       request->pgps_req->gps_day);
-			if ((ret < 0) || (ret >= remain)) {
-				LOG_ERR("Could not format URL: GPS day");
-				ret = -ETXTBSY;
-				goto clean_up;
-			}
-			pos += ret;
-			remain -= ret;
-		}
-
-		if (request->pgps_req->gps_time_of_day !=
-		    NRF_CLOUD_REST_PGPS_REQ_NO_GPS_TOD) {
-			ret = snprintk(&url[pos], remain, PGPS_REQ_START_GPS_TOD_S,
-				       request->pgps_req->gps_time_of_day);
-			if ((ret < 0) || (ret >= remain)) {
-				LOG_ERR("Could not format URL: GPS time");
-				ret = -ETXTBSY;
-				goto clean_up;
-			}
-			pos += ret;
-			remain -= ret;
-		}
-	}
+	LOG_DBG("URL: %s", url);
 
 	/* Format auth header */
 	ret = generate_auth_header(rest_ctx->auth, &auth_hdr);
@@ -1206,11 +1148,16 @@ clean_up:
 	if (auth_hdr) {
 		nrf_cloud_free(auth_hdr);
 	}
+	if (req.body) {
+		cJSON_free((void *)req.body);
+	}
+	cJSON_Delete(data_obj);
 
 	close_connection(rest_ctx);
 
 	return ret;
 }
+#endif /* CONFIG_NRF_CLOUD_PGPS */
 
 int nrf_cloud_rest_disconnect(struct nrf_cloud_rest_context *const rest_ctx)
 {
@@ -1465,8 +1412,14 @@ int nrf_cloud_rest_device_status_message_send(struct nrf_cloud_rest_context *con
 	}
 
 	json_msg = cJSON_PrintUnformatted(msg_obj);
+
 	cJSON_Delete(msg_obj);
 	msg_obj = NULL;
+
+	if (!json_msg) {
+		err = -ENOMEM;
+		goto clean_up;
+	}
 
 	err = nrf_cloud_rest_send_device_message(rest_ctx, device_id, json_msg, false, NULL);
 


### PR DESCRIPTION
Move JSON encoding out of A-GPS module and into the codec.
Allow the mask angle to be excluded from a REST A-GPS request.
Move JSON encoding out of P-GPS module and into the codec.
Use P-GPS request data encoding function in the codec.

NCSDK-19171