### PR TITLE
drivers: wifi: Clean boot logs

### DIFF
--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/cmd.c
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/cmd.c
@@ -140,7 +140,8 @@ enum wifi_nrf_status umac_cmd_init(struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx,
 #ifdef CONFIG_NRF700X_TCP_IP_CHECKSUM_OFFLOAD
 	umac_cmd_data->sys_params.tcp_ip_checksum_offload = 1;
 #endif /* CONFIG_NRF700X_TCP_IP_CHECKSUM_OFFLOAD */
-	wifi_nrf_osal_log_info(fmac_dev_ctx->fpriv->opriv, "RPU LPM type: %s\n",
+
+	wifi_nrf_osal_log_dbg(fmac_dev_ctx->fpriv->opriv, "RPU LPM type: %s\n",
 		umac_cmd_data->sys_params.sleep_enable == 2 ? "HW" :
 		umac_cmd_data->sys_params.sleep_enable == 1 ? "SW" : "DISABLED");
 #ifndef CONFIG_NRF700X_RADIO_TEST

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/fmac_api.c
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/fmac_api.c
@@ -619,9 +619,9 @@ enum wifi_nrf_status wifi_nrf_fmac_fw_load(struct wifi_nrf_fmac_dev_ctx *fmac_de
 					      __func__);
 			goto out;
 		} else {
-			wifi_nrf_osal_log_info(fmac_dev_ctx->fpriv->opriv,
-					       "%s: LMAC patches loaded\n",
-					       __func__);
+			wifi_nrf_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
+					      "%s: LMAC patches loaded\n",
+					      __func__);
 		}
 
 		status = wifi_nrf_hal_fw_patch_boot(fmac_dev_ctx->hal_dev_ctx,
@@ -644,9 +644,9 @@ enum wifi_nrf_status wifi_nrf_fmac_fw_load(struct wifi_nrf_fmac_dev_ctx *fmac_de
 					      __func__);
 			goto out;
 		} else {
-			wifi_nrf_osal_log_info(fmac_dev_ctx->fpriv->opriv,
-					       "%s: LMAC boot check passed\n",
-					       __func__);
+			wifi_nrf_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
+					      "%s: LMAC boot check passed\n",
+					      __func__);
 		}
 	} else {
 		status = wifi_nrf_hal_fw_patch_boot(fmac_dev_ctx->hal_dev_ctx,
@@ -669,9 +669,9 @@ enum wifi_nrf_status wifi_nrf_fmac_fw_load(struct wifi_nrf_fmac_dev_ctx *fmac_de
 					      __func__);
 			goto out;
 		} else {
-			wifi_nrf_osal_log_info(fmac_dev_ctx->fpriv->opriv,
-					       "%s: LMAC boot check passed\n",
-					       __func__);
+			wifi_nrf_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
+					      "%s: LMAC boot check passed\n",
+					      __func__);
 		}
 	}
 
@@ -702,9 +702,9 @@ enum wifi_nrf_status wifi_nrf_fmac_fw_load(struct wifi_nrf_fmac_dev_ctx *fmac_de
 					      __func__);
 			goto out;
 		} else {
-			wifi_nrf_osal_log_info(fmac_dev_ctx->fpriv->opriv,
-					       "%s: UMAC patches loaded\n",
-					       __func__);
+			wifi_nrf_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
+					      "%s: UMAC patches loaded\n",
+					      __func__);
 		}
 
 		status = wifi_nrf_hal_fw_patch_boot(fmac_dev_ctx->hal_dev_ctx,
@@ -727,9 +727,9 @@ enum wifi_nrf_status wifi_nrf_fmac_fw_load(struct wifi_nrf_fmac_dev_ctx *fmac_de
 					      __func__);
 			goto out;
 		} else {
-			wifi_nrf_osal_log_info(fmac_dev_ctx->fpriv->opriv,
-					       "%s: UMAC boot check passed\n",
-					       __func__);
+			wifi_nrf_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
+					      "%s: UMAC boot check passed\n",
+					      __func__);
 		}
 	} else {
 		status = wifi_nrf_hal_fw_patch_boot(fmac_dev_ctx->hal_dev_ctx,
@@ -752,9 +752,9 @@ enum wifi_nrf_status wifi_nrf_fmac_fw_load(struct wifi_nrf_fmac_dev_ctx *fmac_de
 					      __func__);
 			goto out;
 		} else {
-			wifi_nrf_osal_log_info(fmac_dev_ctx->fpriv->opriv,
-					       "%s: UMAC boot check passed\n",
-					       __func__);
+			wifi_nrf_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
+					      "%s: UMAC boot check passed\n",
+					      __func__);
 		}
 	}
 

--- a/drivers/wifi/nrf700x/zephyr/src/qspi/src/qspi_if.c
+++ b/drivers/wifi/nrf700x/zephyr/src/qspi/src/qspi_if.c
@@ -1096,8 +1096,6 @@ int qspi_init(struct qspi_config *config)
 
 	k_sem_init(&qspi_config->lock, 1, 1);
 
-	LOG_INF("QSPI freq = %d MHz\n", INST_0_SCK_FREQUENCY/MHZ(1));
-	LOG_INF("QSPI latency = %d\n", qspi_config->qspi_slave_latency);
 	return rc;
 }
 

--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_fmac_main.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_fmac_main.c
@@ -273,6 +273,8 @@ enum wifi_nrf_status wifi_nrf_fmac_dev_add_zep(struct wifi_nrf_drv_priv_zep *drv
 	sleep_type = SLEEP_DISABLE;
 #endif /* CONFIG_NRF700X_RADIO_TEST */
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
+	unsigned int umac_ver = 0;
+	unsigned int lmac_ver = 0;
 
 	rpu_ctx_zep = &drv_priv_zep->rpu_ctx_zep;
 
@@ -309,6 +311,21 @@ enum wifi_nrf_status wifi_nrf_fmac_dev_add_zep(struct wifi_nrf_drv_priv_zep *drv
 		LOG_ERR("%s: wifi_nrf_fmac_fw_load failed\n", __func__);
 		goto out;
 	}
+
+	status = wifi_nrf_fmac_ver_get(rpu_ctx,
+				       &umac_ver,
+				       &lmac_ver);
+
+	if (status != WIFI_NRF_STATUS_SUCCESS) {
+		LOG_ERR("%s: FW version read failed\n", __func__);
+		goto out;
+	}
+
+	LOG_INF("Firmware (v%d:%d:%d:%d) booted successfully\n",
+		NRF_WIFI_UMAC_VER(umac_ver),
+		NRF_WIFI_UMAC_VER_MAJ(umac_ver),
+		NRF_WIFI_UMAC_VER_MIN(umac_ver),
+		NRF_WIFI_UMAC_VER_EXTRA(umac_ver));
 
 	status = wifi_nrf_fmac_dev_init(rpu_ctx_zep->rpu_ctx,
 #ifndef CONFIG_NRF700X_RADIO_TEST


### PR DESCRIPTION
1. Clean up Wi-Fi driver boot log messages by removing non-essential informational messages 
2. Display firmware version on successful boot of Sheliak

This addresses the following jira issues:
[SHEL-1347]