### PR TITLE
openthread: Remove duplicated incorrect setting of openthread security.

### DIFF
--- a/subsys/net/openthread/Kconfig.defconfig
+++ b/subsys/net/openthread/Kconfig.defconfig
@@ -169,10 +169,6 @@ config NET_PKT_TIMESTAMP
 	bool
 	default y
 
-config OPENTHREAD_MAC_SOFTWARE_TX_SECURITY_ENABLE
-	bool
-	default n
-
 # CSL Transmitter configuration
 config OPENTHREAD_PLATFORM_CSL_UNCERT
 	int


### PR DESCRIPTION
This commit removes `OPENTHREAD_MAC_SOFTWARE_TX_SECURITY_ENABLE` from openthread kconfig defaults and lests it to be handled from `zephyr/modules/openthread/Kconfig.thread`.