### PR TITLE
manifest: Update sdk-ant revision

### DIFF
--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -55,20 +55,3 @@
   platforms:
     - all
   comment: "Temporary disable till the issue is fixed"
-
-- scenarios:
-    - sample.ant_advanced_burst
-    - sample.ant_background_scanning
-    - sample.ant_broadcast_rx
-    - sample.ant_broadcast_tx
-    - sample.bpwr_rx
-    - sample.bpwr_tx
-    - sample.bsc_rx
-    - sample.bsc_tx
-    - sample.hrm_rx
-    - sample.hrm_tx
-    - sample.ble_ant_app_hrm
-    - sample.ant_rpc
-  platforms:
-    - all
-  comment: "ANT samples fail to build because the ANT repository redefines IS_POWER_OF_TWO macro"

--- a/west.yml
+++ b/west.yml
@@ -225,7 +225,7 @@ manifest:
       remote: memfault
     - name: ant
       repo-path: sdk-ant
-      revision: 7df46a12ace258473c1f2b3b98de690b5799ac64
+      revision: 373e6987cb18bacec6baab11d119333d92338589
       remote: ant-nrfconnect
       groups:
         - ant


### PR DESCRIPTION
Update revision to ANT for nRF Connect SDK v0.5.1. This contains a header change to unblock Zephyr upmerge (https://github.com/nrfconnect/sdk-nrf/pull/10535).

Remove ANT samples from quarantine. (https://github.com/nrfconnect/sdk-nrf/commit/c3b8271554ed016b2fa2edae1aea37a94bd56764)