### PR TITLE
manifest: updated Matter SDK revision to pull recent changes

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -107,7 +107,10 @@ The Matter fork in the |NCS| (``sdk-connectedhomeip``) contains all commits from
 
 The following list summarizes the most important changes inherited from the upstream Matter:
 
-|no_changes_yet_note|
+* Updated the factory data generation script with the feature for generating the onboarding code.
+  You can now use the factory data script to generate a manual pairing code and a QR Code that are required to commission a Matter-enabled device over Bluetooth LE.
+  Generated onboarding codes should be put on the device's package or on the device itself.
+  For details, see the Generating onboarding codes section on the :doc:`matter:nrfconnect_factory_data_configuration` page in the Matter documentation.
 
 Thread
 ------

--- a/west.yml
+++ b/west.yml
@@ -137,7 +137,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: f21435a1117a23f1e844255a765c191a5db01d20
+      revision: cd4fa25906f83805a105155844db5d27e8e3fe62
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
In the newest Matter SDK revision we added the possibility to generate Matter onboarding codes using a factory data generation script.