### PR TITLE
cmake: Prevent cleanup of RAM when coredump RAM backend is used

### DIFF
--- a/modules/mcuboot/CMakeLists.txt
+++ b/modules/mcuboot/CMakeLists.txt
@@ -241,6 +241,14 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
     set(imgtool_security_counter --security-counter ${CONFIG_MCUBOOT_HW_DOWNGRADE_PREVENTION_COUNTER_VALUE})
   endif()
 
+  # Don't delete RAM-backed coredumps
+  if (CONFIG_MEMFAULT_RAM_BACKED_COREDUMP)
+    add_overlay_config(
+      mcuboot
+      ${ZEPHYR_NRF_MODULE_DIR}/modules/mcuboot/memfault_ram_backend.conf
+    )
+  endif()
+
   add_child_image(
     NAME mcuboot
     SOURCE_DIR ${ZEPHYR_MCUBOOT_MODULE_DIR}/boot/zephyr

--- a/modules/mcuboot/memfault_ram_backend.conf
+++ b/modules/mcuboot/memfault_ram_backend.conf
@@ -1,0 +1,3 @@
+# This Kconfig fragment is applied to the MCUBoot configuration when
+# MCUBoot's RAM backend is enabled. Otherwise, coredumps would just be lost.
+CONFIG_MCUBOOT_NRF_CLEANUP_NONSECURE_RAM=n


### PR DESCRIPTION
This patch prevents deletion of coredumps by MCUBoot. It should fix the broken asset_tracker+memfault configuration on the Thingy:91.