### PR TITLE
manifest: update sdk-zephyr revision

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -206,6 +206,10 @@ Bluetooth samples
 
   * The Bluetooth 3-wire coex sample because of the removal of the 3-wire implementation.
 
+* :ref:`peripheral_hids_keyboard` sample:
+
+  * Fixed the NFC connection Kconfig DTS dependency.
+
 * :ref:`peripheral_hids_mouse` sample:
 
   * The :kconfig:option:`CONFIG_BT_SMP` Kconfig option is included when ``CONFIG_BT_HIDS_SECURITY_ENABLED`` is selected.

--- a/west.yml
+++ b/west.yml
@@ -55,7 +55,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: f8f113382356934cb6d1ef4cdad95a843f922085
+      revision: pull/1111/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Updated sdk-zephyr contains fix to
peripheral_hids_keyboard NFC functionality.