### PR TITLE
doc: add link to Bluetooth LE DevAcademy course

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -554,6 +554,7 @@
 
 .. _`nRF Connect SDK Fundamentals course`: https://academy.nordicsemi.com/courses/nrf-connect-sdk-fundamentals/
 .. _`Cellular IoT Fundamentals course`: https://academy.nordicsemi.com/courses/cellular-iot-fundamentals/
+.. _`Bluetooth LE Fundamentals course`: https://academy.nordicsemi.com/courses/bluetooth-low-energy-fundamentals/
 
 .. ### Source: devzone.nordicsemi.com
 

--- a/doc/nrf/protocols/ble/index.rst
+++ b/doc/nrf/protocols/ble/index.rst
@@ -23,6 +23,7 @@ Both Link Layers integrate with the Zephyr Bluetooth Host, which completes the f
 It is possible to select either Bluetooth LE Controller for application development.
 See `Usage in samples`_ for more information.
 
+If you want to go through an online training course to familiarize yourself with Bluetooth Low Energy and the development of Bluetooth LE applications, enroll in the `Bluetooth LE Fundamentals course`_ in the `Nordic Developer Academy`_.
 
 SoftDevice Controller
 *********************

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -501,4 +501,6 @@ cJSON
 Documentation
 =============
 
-* Updated the :ref:`software_maturity` page with details about Bluetooth feature support.
+Updated:
+  * The :ref:`software_maturity` page with details about Bluetooth feature support.
+  * The :ref:`ug_nrf5340_gs`, :ref:`ug_thingy53_gs`, :ref:`ug_nrf52_gs`, and :ref:`ug_ble_controller` pages with a link to the `Bluetooth LE Fundamentals course`_ in the `Nordic Developer Academy`_.

--- a/doc/nrf/working_with_nrf/nrf52/gs.rst
+++ b/doc/nrf/working_with_nrf/nrf52/gs.rst
@@ -15,6 +15,8 @@ If you have already set up your nRF52 Series DK and want to learn more, see the 
 * :ref:`ug_nrf52` for more advanced topics related to the nRF52 Series if you are already familiar with the |NCS|.
 * The :ref:`introductory documentation <getting_started>` for more information on the |NCS| and the development environment.
 
+If you want to go through an online training course to familiarize yourself with Bluetooth Low Energy and the development of Bluetooth LE applications, enroll in the `Bluetooth LE Fundamentals course`_ in the `Nordic Developer Academy`_.
+
 .. _nrf52_gs_requirements:
 
 Minimum requirements

--- a/doc/nrf/working_with_nrf/nrf53/nrf5340_gs.rst
+++ b/doc/nrf/working_with_nrf/nrf53/nrf5340_gs.rst
@@ -15,6 +15,8 @@ If you have already set up your nRF5340 DK and want to learn more, see the follo
 * :ref:`ug_nrf5340` for more advanced topics related to the nRF5340 DK if you are already familiar with the |NCS|.
 * The :ref:`introductory documentation <getting_started>` for more information on the |NCS| and the development environment.
 
+If you want to go through an online training course to familiarize yourself with Bluetooth Low Energy and the development of Bluetooth LE applications, enroll in the `Bluetooth LE Fundamentals course`_ in the `Nordic Developer Academy`_.
+
 .. _nrf5340_gs_requirements:
 
 Minimum requirements

--- a/doc/nrf/working_with_nrf/nrf53/thingy53_gs.rst
+++ b/doc/nrf/working_with_nrf/nrf53/thingy53_gs.rst
@@ -15,6 +15,8 @@ If you have already set up your Nordic Thingy:53 and want to learn more, see the
 * :ref:`ug_thingy53` for more advanced topics related to the Nordic Thingy:53.
 * The :ref:`introductory documentation <getting_started>` for more information on the |NCS| and the development environment.
 
+If you want to go through an online training course to familiarize yourself with Bluetooth Low Energy and the development of Bluetooth LE applications, enroll in the `Bluetooth LE Fundamentals course`_ in the `Nordic Developer Academy`_.
+
 .. _thingy53_gs_requirements:
 
 Minimum requirements


### PR DESCRIPTION
The Nordic Developer Academy recently added a course for Bluetooth LE Fundamentals. This adds a link to the course to documentation where users might be interested in enrolling.