### PR TITLE
kconfig SDC: Remove redundant default to LIB

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -42,7 +42,6 @@ menu "SoftDevice Controller"
 
 choice BT_LL_SOFTDEVICE_BUILD_TYPE
 	prompt "SoftDevice Controller build type"
-	default BT_LL_SOFTDEVICE_BUILD_TYPE_LIB
 
 config BT_LL_SOFTDEVICE_BUILD_TYPE_LIB
 	bool "Use library"


### PR DESCRIPTION
There is only one choice for BT_LL_SOFTDEVICE_BUILD_TYPE when building without the source repositories,
so there is no need to default to it.

Not doing so allows setting a different default when the source repository is added.