### PR TITLE
ci: Add tfm and mcuboot to thingy91 test

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -210,6 +210,8 @@
   - "samples/nrf9160/udp/**/*"
   - "samples/nrf9160/aws_iot/**/*"
   - "samples/nrf9160/azure_iot_hub/**/*"
+  - "modules/tfm/**/*"
+  - "modules/mcuboot/**/*"
 
 "CI-apps-test":
   - "applications/machine_learning/**/*"


### PR DESCRIPTION
Changes in modules/tfm and modules/mcuboot should trigger the thingy91 CI job.