### PR TITLE
modules: tfm:Improve TF-M alignment assert message

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -3013,6 +3013,14 @@ tx_buffer_length set incorrectly
 Trusted Firmware-M (TF-M)
 *************************
 
+.. rst-class:: v2-3-0
+
+NCSDK-20864: TF-M unaligned partitions when MCUboot padding and debug optimizations are enabled
+  When building TF-M using the :ref:`partition_manager` with the MCUboot bootloader enabled (:kconfig:option:`CONFIG_BOOTLOADER_MCUBOOT`), with either :kconfig:option:`CONFIG_DEBUG_OPTIMIZATIONS` or :kconfig:option:`CONFIG_TFM_CMAKE_BUILD_TYPE_DEBUG` also enabled, the resulting partitions are not aligned with :kconfig:option:`CONFIG_NRF_SPU_FLASH_REGION_SIZE` as required by the :ref:`ug_tfm_partition_alignment_requirements`.
+  This will cause the build to fail.
+
+  **Workaround:** Disable the :kconfig:option:`CONFIG_DEBUG_OPTIMIZATIONS` and :kconfig:option:`CONFIG_TFM_CMAKE_BUILD_TYPE_DEBUG` options, or subtract 0x200 from the current value of the :kconfig:option:`CONFIG_PM_PARTITION_SIZE_TFM` option, to comply with the :ref:`ug_tfm_partition_alignment_requirements`.
+
 .. rst-class:: v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0
 
 NCSDK-17501: Partition Manager: Ignored alignment for partitions

--- a/modules/tfm/tfm/boards/common/assert.c
+++ b/modules/tfm/tfm/boards/common/assert.c
@@ -7,14 +7,19 @@
 #include <pm_config.h>
 #include "autoconf.h"
 #include "region_defs.h"
-
+#include <zephyr/toolchain/common.h>
 
 #define IS_ALIGNED_POW2(value, align) (((value) & ((align) - 1)) == 0)
 
 /* Making sure the borders between secure and non-secure regions are aligned with the SPU regions */
-
 #if !(IS_ALIGNED_POW2(PM_TFM_NONSECURE_ADDRESS, CONFIG_NRF_SPU_FLASH_REGION_SIZE))
-#error "TF-M non-secure address start is not aligned on SPU region size"
+#pragma message "\n\n!!!Partition alignment error!!!"\
+                "\nThe non-secure start address in pm_static.yml"\
+                " or generated partition.yml is: " STRINGIFY(PM_TFM_NONSECURE_ADDRESS)\
+                "\nwhich is not aligned with the SPU region size."\
+                "\nRefer to the documentation section 'TF-M partition alignment requirements'"\
+                "\nfor more information.\n\n"
+#error "TF-M non-secure start address is not aligned on SPU region size"
 #endif
 
 #if !(IS_ALIGNED_POW2(PM_SRAM_NONSECURE_ADDRESS, SPU_SRAM_REGION_SIZE))


### PR DESCRIPTION
Adds more information to the TF-M assert mesage
which enforces the requirement of
the non secure partition of TF-M to be aligned
with the SPU partition size.
Also adds a limitation to the TF-M documentation
to inform users about this.

Ref: NCSDK-20693

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>