### PR TITLE
samples: radio_test: Add worakround for erratas 255, 256, 257

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -547,6 +547,12 @@
 
 .. _`Errata 254`: https://infocenter.nordicsemi.com/index.jsp?topic=%2Ferrata_nRF52840_Rev3%2FERR%2FnRF52840%2FRev3%2Flatest%2Fconfig_840_254.html
 
+.. _`Errata 255`: https://infocenter.nordicsemi.com/index.jsp?topic=%2Ferrata_nRF52833_Rev2%2FERR%2FnRF52833%2FRev2%2Flatest%2Fconfig_833_255.html
+
+.. _`Errata 256`: https://infocenter.nordicsemi.com/index.jsp?topic=%2Ferrata_nRF52820_Rev3%2FERR%2FnRF52820%2FRev3%2Flatest%2Fconfig_820_256.html
+
+.. _`Errata 257`: https://infocenter.nordicsemi.com/index.jsp?topic=%2Ferrata_nRF52811_Rev2%2FERR%2FnRF52811%2FRev2%2Flatest%2Fconfig_811_257.html
+
 .. _`Errata 117`: https://infocenter.nordicsemi.com/index.jsp?topic=%2Ferrata_nRF5340_Rev1%2FERR%2FnRF5340%2FRev1%2Flatest%2Fanomaly_340_117.html
 
 .. ### Source: academy.nordicsemi.com

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -269,7 +269,10 @@ Peripheral samples
 
 * :ref:`radio_test` sample:
 
-  * Added a workaround for the hardware `Errata 254`_ of the nRF52840 and nRF52833 chips.
+  * Added a workaround for the hardware `Errata 254`_ of the nRF52840 chip.
+  * Added a workaround for the hardware `Errata 255`_ of the nRF52833 chip.
+  * Added a workaround for the hardware `Errata 256`_ of the nRF52820 chip.
+  * Added a workaround for the hardware `Errata 257`_ of the nRF52811 chip.
   * Added a workaround for the hardware `Errata 117`_ of the nRF5340 chip.
 
 Trusted Firmware-M (TF-M) samples

--- a/samples/bluetooth/direct_test_mode/src/fem/fem.c
+++ b/samples/bluetooth/direct_test_mode/src/fem/fem.c
@@ -10,6 +10,7 @@
 #include <hal/nrf_radio.h>
 #include <hal/nrf_timer.h>
 #include <helpers/nrfx_gppi.h>
+#include <nrf_erratas.h>
 
 #include <zephyr/sys/printk.h>
 
@@ -328,8 +329,9 @@ int fem_init(NRF_TIMER_Type *timer_instance, uint8_t compare_channel_mask)
 	return 0;
 }
 
-#if defined(NRF52840_XXAA) || defined(NRF52833_XXAA)
-void fem_errata_254(nrf_radio_mode_t mode)
+#if (NRF52_CONFIGURATION_254_PRESENT || NRF52_CONFIGURATION_255_PRESENT || \
+	NRF52_CONFIGURATION_256_PRESENT || NRF52_CONFIGURATION_257_PRESENT)
+static void apply_fem_errata_25X(nrf_radio_mode_t mode)
 {
 	static uint8_t old_mode = NRF_RADIO_MODE_NRF_1MBIT;
 
@@ -360,8 +362,18 @@ void fem_errata_254(nrf_radio_mode_t mode)
 	old_mode = mode;
 }
 #else
-void fem_errata_254(nrf_radio_mode_t mode)
+static void apply_fem_errata_25X(nrf_radio_mode_t mode)
 {
-
+	ARG_UNUSED(mode);
 }
-#endif /* defined(NRF52840_XXAA) || defined(NRF52833_XXAA) */
+#endif /* (NRF52_CONFIGURATION_254_PRESENT || NRF52_CONFIGURATION_255_PRESENT || \
+	*  NRF52_CONFIGURATION_256_PRESENT || NRF52_CONFIGURATION_257_PRESENT)
+	*/
+
+void fem_errata_25X(nrf_radio_mode_t mode)
+{
+	if (nrf52_configuration_254() || nrf52_configuration_255() ||
+	    nrf52_configuration_256() || nrf52_configuration_257()) {
+		apply_fem_errata_25X(mode);
+	}
+}

--- a/samples/bluetooth/direct_test_mode/src/fem/fem.h
+++ b/samples/bluetooth/direct_test_mode/src/fem/fem.h
@@ -208,13 +208,13 @@ static inline int8_t fem_tx_output_power_max_get(uint16_t freq_mhz)
  */
 uint32_t fem_default_tx_gain_get(void);
 
-/** @brief Apply the workaround for the Errata 254 when appropriate.
+/** @brief Apply the workaround for the Errata 254, 255, 256, 257 when appropriate.
  *
  * This workaround is applied only if used with the correct hardware configuration.
  *
  * @param[in] mode Radio mode.
  */
-void fem_errata_254(nrf_radio_mode_t mode);
+void fem_errata_25X(nrf_radio_mode_t mode);
 
 #ifdef __cplusplus
 }

--- a/samples/peripheral/radio_test/src/radio_test.c
+++ b/samples/peripheral/radio_test/src/radio_test.c
@@ -203,7 +203,7 @@ static int fem_configure(bool rx, nrf_radio_mode_t mode,
 		printk("Failed to configure PA.\n");
 	}
 
-	fem_errata_254(mode);
+	fem_errata_25X(mode);
 
 	return err;
 }


### PR DESCRIPTION
Add workarounds for erratas 255, 256, 257 when used with FEM.
The workaround is the same for 254, 255, 256, 257 erratas.

Jira: NCSDK-20765