### PR TITLE
samples: wifi: provisioning: Fix for BLE disconnection

### DIFF
--- a/samples/wifi/provisioning/prj.conf
+++ b/samples/wifi/provisioning/prj.conf
@@ -105,3 +105,5 @@ CONFIG_BT_WIFI_PROV=y
 CONFIG_BT_WIFI_PROV_LOG_LEVEL_INF=y
 
 CONFIG_WIFI_MGMT_EXT=y
+# Setting BT supervision timeout to 75units (750ms) to avoid timeout of BT connection when radio is granted to Wi-Fi during scan.
+CONFIG_BT_PERIPHERAL_PREF_TIMEOUT=75


### PR DESCRIPTION
[SHEL-1489] WLAN priority window is allocated for only 2.4GHz and idle scan, BLE supervision timeout is set to 750ms.