### PR TITLE
drivers: wifi: TX coalesce logic tuning

### DIFF
--- a/drivers/wifi/nrf700x/Kconfig.nrf700x
+++ b/drivers/wifi/nrf700x/Kconfig.nrf700x
@@ -98,7 +98,7 @@ config NRF700X_RX_NUM_BUFS
 
 config NRF700X_MAX_TX_AGGREGATION
 	int "Maximum number of TX packets to aggregate"
-	default 6
+	default 15
 
 config NRF700X_MAX_TX_TOKENS
 	int "Maximum number of TX tokens"

--- a/drivers/wifi/nrf700x/osal/hw_if/hal/inc/hal_api.h
+++ b/drivers/wifi/nrf700x/osal/hw_if/hal/inc/hal_api.h
@@ -151,7 +151,8 @@ unsigned long wifi_nrf_hal_buf_unmap_rx(struct wifi_nrf_hal_dev_ctx *hal_ctx,
 unsigned long wifi_nrf_hal_buf_map_tx(struct wifi_nrf_hal_dev_ctx *hal_ctx,
 				      unsigned long buf,
 				      unsigned int buf_len,
-				      unsigned int desc_id);
+				      unsigned int desc_id,
+				      unsigned int buf_indx);
 
 unsigned long wifi_nrf_hal_buf_unmap_tx(struct wifi_nrf_hal_dev_ctx *hal_ctx,
 					unsigned int desc_id);

--- a/drivers/wifi/nrf700x/osal/hw_if/hal/inc/hal_structs.h
+++ b/drivers/wifi/nrf700x/osal/hw_if/hal/inc/hal_structs.h
@@ -216,7 +216,7 @@ struct wifi_nrf_hal_dev_ctx {
 	unsigned long addr_rpu_pktram_base_tx;
 	unsigned long addr_rpu_pktram_base_rx;
 	unsigned long addr_rpu_pktram_base_rx_pool[MAX_NUM_OF_RX_QUEUES];
-
+	unsigned long addr_last_buf;
 #ifdef CONFIG_NRF_WIFI_LOW_POWER
 	enum RPU_PS_STATE rpu_ps_state;
 	void *rpu_ps_timer;

--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_fmac_main.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_fmac_main.c
@@ -39,24 +39,21 @@ struct wifi_nrf_drv_priv_zep rpu_drv_priv_zep;
 
 #define MAX_RX_QUEUES 3
 
-#define TOTAL_TX_FRAMES \
-	(CONFIG_NRF700X_MAX_TX_TOKENS * CONFIG_NRF700X_MAX_TX_AGGREGATION)
 #define MAX_TX_FRAME_SIZE \
 	(CONFIG_NRF700X_TX_MAX_DATA_SIZE + TX_BUF_HEADROOM)
 #define TOTAL_TX_SIZE \
-	(TOTAL_TX_FRAMES * MAX_TX_FRAME_SIZE)
+	(CONFIG_NRF700X_MAX_TX_TOKENS * CONFIG_NRF700X_TX_MAX_DATA_SIZE)
 #define TOTAL_RX_SIZE \
 	(CONFIG_NRF700X_RX_NUM_BUFS * CONFIG_NRF700X_RX_MAX_DATA_SIZE)
 
 BUILD_ASSERT(CONFIG_NRF700X_MAX_TX_TOKENS >= 1,
 	"At least one TX token is required");
-BUILD_ASSERT(CONFIG_NRF700X_MAX_TX_AGGREGATION <= 16,
-	"Max TX aggregation is 16");
+BUILD_ASSERT(CONFIG_NRF700X_MAX_TX_AGGREGATION <= 15,
+	"Max TX aggregation is 15");
 BUILD_ASSERT(CONFIG_NRF700X_RX_NUM_BUFS >= 1,
 	"At least one RX buffer is required");
-
-BUILD_ASSERT(RPU_PKTRAM_SIZE >= (TOTAL_TX_SIZE + TOTAL_RX_SIZE),
-		"Packet RAM overflow in Sheliak");
+BUILD_ASSERT(RPU_PKTRAM_SIZE - TOTAL_RX_SIZE >= TOTAL_TX_SIZE,
+	"Packet RAM overflow: not enough memory for TX");
 
 static const unsigned char aggregation = 1;
 static const unsigned char wmm = 1;


### PR DESCRIPTION
[SHEL-1217] TX coalesce logic to accommodate more number of frames based on current subframe lengths. Existing Current logic uses fixed number of frames without taking frame lengths into consideration. More number of frames will get aggregated for lower lengths of pkts.