### PR TITLE
applications: nrf_desktop: Add devinfo config channel option to dfu

### DIFF
--- a/applications/nrf_desktop/Kconfig.hid
+++ b/applications/nrf_desktop/Kconfig.hid
@@ -204,18 +204,27 @@ config DESKTOP_DEVICE_VID
 	range 0 0XFFFF
 	default 0x1915
 	help
-	  Device Vendor ID used for both GATT Device Information Service and
-	  USB device. By default, Vendor ID of Nordic Semiconductor ASA is used.
+	  Device Vendor ID used for GATT Device Information Service, USB device
+	  and configuration channel. By default, Vendor ID of Nordic
+	  Semiconductor ASA is used.
 
 config DESKTOP_DEVICE_PID
 	hex "Product ID"
 	range 0 0XFFFF
 	default 0
 	help
-	  Device Product ID used for both GATT Device Information Service and
-	  USB device. Product ID is used to distinguish products made by the
-	  given vendor. Value must be configured in the application
+	  Device Product ID used for GATT Device Information Service, USB device
+	  and configuration channel. Product ID is used to distinguish products
+	  made by the given vendor. Value must be configured in the application
 	  configuration.
+
+config DESKTOP_DEVICE_GENERATION
+	string "Device generation"
+	default "default"
+	help
+	  The Kconfig option is used to specify device generation. The option
+	  allows to distinguish configurations that use the same board and
+	  bootloader, but are not interoperable.
 
 endmenu
 

--- a/applications/nrf_desktop/README.rst
+++ b/applications/nrf_desktop/README.rst
@@ -1001,6 +1001,11 @@ These Kconfig options determine the default values of device identifiers used fo
 * :ref:`nrf_desktop_usb_state_identifiers`
 * BLE GATT Device Information Service (:kconfig:option:`CONFIG_BT_DIS`) that is required for :ref:`nrf_desktop_bluetooth_guide_peripheral`
 
+.. note::
+   Apart from the mentioned common device identifiers, the nRF Desktop application defines an application-specific string representing device generation (:ref:`CONFIG_DESKTOP_DEVICE_GENERATION <config_desktop_app_options>`).
+   The generation allows to distinguish configurations that use the same board and bootloader, but are not interoperable.
+   The value can be read through the :ref:`nrf_desktop_config_channel`.
+
 Debug configuration
 -------------------
 

--- a/applications/nrf_desktop/doc/dfu.rst
+++ b/applications/nrf_desktop/doc/dfu.rst
@@ -48,6 +48,21 @@ If the buffer is small, the host must perform the DFU progress synchronization m
    For this reason, make sure that you use configuration with two image partitions.
    For more information on configuring the memory layout in the application, see the :ref:`nrf_desktop_flash_memory_layout` documentation.
 
+Device identification information
+=================================
+
+The DFU module provides the following information about the device through the :ref:`nrf_desktop_config_channel`:
+
+* Vendor ID (:ref:`CONFIG_DESKTOP_CONFIG_CHANNEL_DFU_VID <config_desktop_app_options>`)
+* Product ID (:ref:`CONFIG_DESKTOP_CONFIG_CHANNEL_DFU_PID <config_desktop_app_options>`)
+* Generation (:ref:`CONFIG_DESKTOP_CONFIG_CHANNEL_DFU_GENERATION <config_desktop_app_options>`)
+
+These values are fetched using the :ref:`devinfo <dfu_devinfo>` configuration channel option.
+
+.. note::
+   By default, the reported Vendor ID, Product ID, and generation are aligned with the values defined globally for the nRF Desktop application.
+   The default values of Kconfig options used by the DFU module are based on respectively :ref:`CONFIG_DESKTOP_DEVICE_VID <config_desktop_app_options>`, :ref:`CONFIG_DESKTOP_DEVICE_PID <config_desktop_app_options>` and :ref:`CONFIG_DESKTOP_DEVICE_GENERATION <config_desktop_app_options>`.
+
 Implementation details
 **********************
 
@@ -73,6 +88,7 @@ The module provides a simple protocol that allows the update tool on the host to
 The following :ref:`nrf_desktop_config_channel` options are available to perform the firmware update:
 
 * :ref:`fwinfo <dfu_fwinfo>` - Passes the information about the currently executed image from the device to the host.
+* :ref:`devinfo <dfu_devinfo>` - Passes the identification information about the device from the device to the host.
 * :ref:`reboot <dfu_reboot>` - Reboots the device.
 * :ref:`start <dfu_start>` - Starts the new update image transmission.
 * :ref:`data <dfu_data>` - Passes a chunk of the update image data from the host to the device.
@@ -86,6 +102,16 @@ fwinfo
 
    * Version and length of the image.
    * Partition ID of the image, used to specify the image placement on the flash.
+
+.. _dfu_devinfo:
+
+devinfo
+   Perform the fetch operation on this option to get the following information about the device:
+
+   * Vendor ID and Product ID
+   * Generation
+
+The device generation allows to distinguish configurations that use the same board and bootloader, but are not interoperable.
 
 .. _dfu_reboot:
 

--- a/applications/nrf_desktop/src/modules/Kconfig.config_channel
+++ b/applications/nrf_desktop/src/modules/Kconfig.config_channel
@@ -78,6 +78,37 @@ config DESKTOP_CONFIG_CHANNEL_DFU_SYNC_BUFFER_SIZE
 	  The host must perform progress synchronization at least
 	  every synchronization buffer bytes count.
 
+config DESKTOP_CONFIG_CHANNEL_DFU_VID
+	hex "Configuration channel Vendor ID"
+	range 0 0XFFFF
+	default DESKTOP_DEVICE_VID
+	help
+	  Configuration channel allows devices to report their Vendor ID. The
+	  Vendor ID is reported together with Product ID and device generation.
+
+	  The information is useful if nRF Desktop peripheral is connected
+	  through nRF Desktop dongle and host computer has no direct access to
+	  the VID and PID.
+
+config DESKTOP_CONFIG_CHANNEL_DFU_PID
+	hex "Configuration channel Product ID"
+	range 0 0XFFFF
+	default DESKTOP_DEVICE_PID
+	help
+	  Configuration channel allows devices to report their Product ID. The
+	  Product ID is reported together with Vendor ID and device generation.
+
+	  The information is useful if nRF Desktop peripheral is connected
+	  through nRF Desktop dongle and host computer has no direct access to
+	  the VID and PID.
+
+config DESKTOP_CONFIG_CHANNEL_DFU_GENERATION
+	string "Device generation"
+	default DESKTOP_DEVICE_GENERATION
+	help
+	  Configuration channel allows devices to report their generation. The
+	  generation is reported together with Vendor ID and Product ID.
+
 module = DESKTOP_CONFIG_CHANNEL_DFU
 module-str = Config channel DFU
 source "subsys/logging/Kconfig.template.log_config"

--- a/applications/nrf_desktop/src/modules/dfu.c
+++ b/applications/nrf_desktop/src/modules/dfu.c
@@ -91,6 +91,7 @@ enum dfu_opt {
 	DFU_OPT_REBOOT,
 	DFU_OPT_FWINFO,
 	DFU_OPT_VARIANT,
+	DFU_OPT_DEVINFO,
 
 	DFU_OPT_COUNT
 };
@@ -101,7 +102,8 @@ const static char * const opt_descr[] = {
 	[DFU_OPT_SYNC] = "sync",
 	[DFU_OPT_REBOOT] = "reboot",
 	[DFU_OPT_FWINFO] = "fwinfo",
-	[DFU_OPT_VARIANT] = OPT_DESCR_MODULE_VARIANT
+	[DFU_OPT_VARIANT] = OPT_DESCR_MODULE_VARIANT,
+	[DFU_OPT_DEVINFO] = "devinfo"
 };
 
 static uint8_t dfu_slot_id(void)
@@ -504,6 +506,33 @@ static void handle_dfu_bootloader_variant(uint8_t *data, size_t *size)
 	strcpy((char *)data, BOOTLOADER_NAME);
 }
 
+static void handle_dfu_devinfo(uint8_t *data, size_t *size)
+{
+	LOG_INF("Device information requested");
+	const uint16_t vid = CONFIG_DESKTOP_CONFIG_CHANNEL_DFU_VID;
+	const uint16_t pid = CONFIG_DESKTOP_CONFIG_CHANNEL_DFU_PID;
+	const char *generation = CONFIG_DESKTOP_CONFIG_CHANNEL_DFU_GENERATION;
+	size_t pos = 0;
+
+	BUILD_ASSERT(sizeof(CONFIG_DESKTOP_CONFIG_CHANNEL_DFU_GENERATION) > 1,
+		     "CONFIG_DESKTOP_CONFIG_CHANNEL_DFU_GENERATION cannot be an empty string");
+	BUILD_ASSERT((sizeof(vid) + sizeof(pid) +
+		      sizeof(CONFIG_DESKTOP_CONFIG_CHANNEL_DFU_GENERATION)) <=
+		     CONFIG_CHANNEL_FETCHED_DATA_MAX_SIZE,
+		     "CONFIG_DESKTOP_CONFIG_CHANNEL_DFU_GENERATION is too long");
+
+	sys_put_le16(vid, &data[pos]);
+	pos += sizeof(vid);
+
+	sys_put_le16(pid, &data[pos]);
+	pos += sizeof(pid);
+
+	strcpy(&data[pos], generation);
+	pos += strlen(generation);
+
+	*size = pos;
+}
+
 static void handle_reboot_request(uint8_t *data, size_t *size)
 {
 	LOG_INF("System reboot requested");
@@ -669,6 +698,10 @@ static void fetch_config(const uint8_t opt_id, uint8_t *data, size_t *size)
 
 	case DFU_OPT_VARIANT:
 		handle_dfu_bootloader_variant(data, size);
+		break;
+
+	case DFU_OPT_DEVINFO:
+		handle_dfu_devinfo(data, size);
 		break;
 
 	default:

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -195,7 +195,13 @@ nRF Machine Learning (Edge Impulse)
 nRF Desktop
 -----------
 
-* Added the :ref:`nrf_desktop_swift_pair_app`. The module is used to enable or disable the Swift Pair Bluetooth advertising payload depending on the selected Bluetooth peer (used local identity).
+Added:
+
+* The :ref:`nrf_desktop_swift_pair_app`. The module is used to enable or disable the Swift Pair Bluetooth advertising payload depending on the selected Bluetooth peer (used local identity).
+* An application-specific string representing device generation (:ref:`CONFIG_DESKTOP_DEVICE_GENERATION <config_desktop_app_options>`).
+  The generation allows to distinguish configurations that use the same board and bootloader, but are not interoperable.
+  The value can be read through the :ref:`nrf_desktop_config_channel`.
+  On the firmware side, fetching the values is handled by the :ref:`nrf_desktop_dfu`.
 
 * Updated:
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -470,6 +470,11 @@ This section provides detailed lists of changes by :ref:`script <scripts>`.
 
   * Fixed an issue that prevented an empty gap after static partitions for a region with START_TO_END strategy.
 
+* :ref:`nrf_desktop_config_channel_script`:
+
+  * Added support for the device information (``devinfo``) option fetching.
+    The option provides device's Vendor ID, Product ID and generation.
+
 MCUboot
 =======
 

--- a/scripts/hid_configurator/README.rst
+++ b/scripts/hid_configurator/README.rst
@@ -17,6 +17,7 @@ It can be used for the following purposes:
 * `Performing DFU`_
 * `Rebooting the device`_
 * `Getting information about the firmware version`_
+* `Getting identification information about the device`_
 * `Playing LED stream`_
 
 Overview
@@ -267,6 +268,23 @@ To obtain information about the firmware running on the device, run the followin
 
 .. note::
   Only devices with :ref:`nrf_desktop_dfu` support the ``fwinfo`` command.
+
+Getting identification information about the device
+===================================================
+
+To obtain information about the device's Vendor ID, Product ID, and generation, run the following command:
+
+.. parsed-literal::
+    :class: highlight
+
+    python3 configurator_cli.py DEVICE devinfo
+
+.. note::
+  Only devices with the :ref:`nrf_desktop_dfu` support the ``devinfo`` command.
+
+The command can be used to obtain Vendor ID and Product ID of devices connected through an nRF Desktop dongle.
+The generation is a string that allows to distinguish configurations that use the same board and bootloader, but are not interoperable.
+For more information about implementation in firmware, see nRF Desktop's :ref:`nrf_desktop_dfu`.
 
 Playing LED stream
 ==================

--- a/scripts/hid_configurator/configurator_cli.py
+++ b/scripts/hid_configurator/configurator_cli.py
@@ -13,7 +13,7 @@ from NrfHidManager import NrfHidManager
 from modules.module_config import MODULE_CONFIG
 from modules.config import change_config, fetch_config
 from modules.dfu import DfuImage
-from modules.dfu import fwinfo, fwreboot, dfu_transfer
+from modules.dfu import fwinfo, devinfo, fwreboot, dfu_transfer
 from modules.led_stream import send_continuous_led_stream
 try:
     from modules.music_led_stream import send_music_led_stream
@@ -157,6 +157,15 @@ def perform_fwinfo(dev, args):
         print('FW info request failed')
 
 
+def perform_devinfo(dev, args):
+    info = devinfo(dev)
+
+    if info is not None:
+        print(info)
+    else:
+        print('Device information request failed')
+
+
 def perform_fwreboot(dev, args):
     success, rebooted = fwreboot(dev)
 
@@ -201,6 +210,7 @@ def parse_arguments():
                             action='store_true')
 
     sp_commands.add_parser('fwinfo', help='Obtain information about FW image')
+    sp_commands.add_parser('devinfo', help='Obtain identification information about device')
     sp_commands.add_parser('fwreboot', help='Request FW reboot')
 
     parser_stream = sp_commands.add_parser('led_stream',
@@ -277,6 +287,7 @@ configurator.ALLOWED_COMMANDS = {
     'show' : perform_show,
     'dfu' : perform_dfu,
     'fwinfo' : perform_fwinfo,
+    'devinfo' : perform_devinfo,
     'fwreboot' : perform_fwreboot,
     'config' : perform_config,
     'led_stream' : perform_led_stream

--- a/scripts/hid_configurator/modules/dfu.py
+++ b/scripts/hid_configurator/modules/dfu.py
@@ -56,7 +56,7 @@ class DFUInfo:
         return self.sync_buffer_size
 
     def is_started(self):
-        return (self.dfu_state == self._DFU_STATE_ACTIVE) or (self.dfu_state == self._DFU_STATE_STORING)
+        return self.dfu_state in (self._DFU_STATE_ACTIVE, self._DFU_STATE_STORING)
 
     def is_storing(self):
         return self.dfu_state == self._DFU_STATE_STORING


### PR DESCRIPTION
PR introduces device information configuration channel option to the dfu module. The option allows to fetch information about device's Vendor ID, Product ID and generation. The generation string allows to distinguish configurations that use the same board and bootloader, but are not interoperable.

PR also introduces needed follow-up changes to the HID configurator Python script.

Jira: NCSDK-19213