### PR TITLE
manifest: update Find My revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -172,7 +172,7 @@ manifest:
         - homekit
     - name: find-my
       repo-path: sdk-find-my
-      revision: 064197448d356b5ed206ec8f4c89dc18b3052b80
+      revision: 66c20c4ab87023d205444162a62971bb3f3ff786
       groups:
         - find-my
     - name: azure-sdk-for-c


### PR DESCRIPTION
Updated Find My revision to include an improvement that prevents a Find My connection to be associated as a Bluetooth LE bond.

Ref: NCSDK-20487