### PR TITLE
manifest: sdk-hostap: Pull fix for SAE PMKSA caching

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -106,7 +106,7 @@ manifest:
     - name: hostap
       repo-path: sdk-hostap
       path: modules/lib/hostap
-      revision: a7c991e1c10b0d42bdb73bea95d1b45b87b7adbd
+      revision: pull/78/head
       userdata:
         ncs:
           upstream-url: https://w1.fi/cgit/hostap/


### PR DESCRIPTION
Fixes SHEL-1002, PMKSA caching is now supported for SAE.