### PR TITLE
subsys: aws_iot: Kconfig variable for poll thread stack size

### DIFF
--- a/subsys/net/lib/aws_iot/Kconfig
+++ b/subsys/net/lib/aws_iot/Kconfig
@@ -157,6 +157,15 @@ config AWS_IOT_CONNECTION_POLL_THREAD
 	bool "Enable polling on MQTT socket in AWS IoT backend"
 	default y
 
+if AWS_IOT_CONNECTION_POLL_THREAD
+
+config AWS_IOT_POLL_THREAD_STACK_SIZE
+	int "stack size of the AWS IoT poll thread"
+	default 4096 if BOARD_QEMU_X86
+	default 3072
+
+endif
+
 module=AWS_IOT
 module-dep=LOG
 module-str=AWS IoT

--- a/subsys/net/lib/aws_iot/src/aws_iot.c
+++ b/subsys/net/lib/aws_iot/src/aws_iot.c
@@ -1264,12 +1264,7 @@ reset:
 	goto start;
 }
 
-#ifdef CONFIG_BOARD_QEMU_X86
-#define POLL_THREAD_STACK_SIZE 4096
-#else
-#define POLL_THREAD_STACK_SIZE 3072
-#endif
-K_THREAD_DEFINE(aws_connection_poll_thread, POLL_THREAD_STACK_SIZE,
+K_THREAD_DEFINE(aws_connection_poll_thread, CONFIG_AWS_IOT_POLL_THREAD_STACK_SIZE,
 		aws_iot_cloud_poll, NULL, NULL, NULL,
 		K_LOWEST_APPLICATION_THREAD_PRIO, 0, 0);
 #endif /* defined(CONFIG_AWS_IOT_CONNECTION_POLL_THREAD) */


### PR DESCRIPTION
The hard-coded values are sufficient for the SDK samples as is, however it is easy to make modifications that require additional stack space (enabling logging, modifying the network configuration, doing too much in the callback, ...) and not currently possible to increase it without direct SDK edits

There also doesn't seem to be any particular reason not to make this a configurable value