### PR TITLE
Bluetooth: controller: Allow CONFIG_BT_MAX_CONN=1

### DIFF
--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -8,15 +8,6 @@ menu "Bluetooth Low Energy"
 
 if BT
 
-# BT_MAX_CONN is declared in Zephyr, here we add the range and default for
-# BT_LL_SOFTDEVICE which is tested with 20 connections.
-# When both connection roles are enabled there has to be one for each role.
-config BT_MAX_CONN
-	int
-	range 2 20 if BT_LL_SOFTDEVICE && BT_CENTRAL && BT_PERIPHERAL
-	range 1 20 if BT_LL_SOFTDEVICE
-	default 2 if BT_LL_SOFTDEVICE && BT_CENTRAL && BT_PERIPHERAL
-
 if BT_CTLR
 rsource "controller/Kconfig"
 endif

--- a/subsys/bluetooth/controller/CMakeLists.txt
+++ b/subsys/bluetooth/controller/CMakeLists.txt
@@ -29,3 +29,14 @@ zephyr_library_link_libraries_ifdef(
 zephyr_library_link_libraries(subsys__bluetooth)
 
 zephyr_include_directories(.)
+
+math(EXPR req_conns "${CONFIG_BT_CTLR_SDC_CENTRAL_COUNT} + ${CONFIG_BT_CTLR_SDC_PERIPHERAL_COUNT}")
+
+if (CONFIG_BT_MAX_CONN LESS req_conns)
+
+  message(WARNING "There are not enough host connection contexts to be able to \
+establish ${CONFIG_BT_CTLR_SDC_CENTRAL_COUNT} central and \
+${CONFIG_BT_CTLR_SDC_PERIPHERAL_COUNT} peripheral connections simultaneously. \
+For this to be possible, CONFIG_BT_MAX_CONN must be set to ${req_conns}.")
+
+endif()

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -48,6 +48,17 @@ config BT_LL_SOFTDEVICE_BUILD_TYPE_LIB
 
 endchoice
 
+# BT_MAX_CONN is declared in Zephyr, here we add the range and default for
+# BT_LL_SOFTDEVICE which is tested with 20 connections.
+#
+# If both connection roles are to be used simultaneously, then BT_MAX_CONN
+# should be equal to CONFIG_BT_CTLR_SDC_PERIPHERAL_COUNT +
+# CONFIG_BT_CTLR_SDC_CENTRAL_COUNT.
+config BT_MAX_CONN
+	int
+	range 1 20
+	default 2 if BT_CENTRAL && BT_PERIPHERAL
+
 config BT_CTLR_SDC_BSIM_BUILD
 	bool
 	default y if SOC_SERIES_BSIM_NRFXX
@@ -101,6 +112,16 @@ config BT_CTLR_SDC_LLPM
 	  Low Latency Packet Mode (LLPM) is a Nordic proprietary addition
 	  which lets the application use connection intervals down to 1 ms.
 
+config BT_CTLR_SDC_CENTRAL_COUNT
+	int "Number of concurrent central roles"
+	default BT_MAX_CONN if (BT_CENTRAL && !BT_PERIPHERAL)
+	default 1 if BT_CENTRAL
+	default 0
+	range 0 BT_MAX_CONN
+	help
+	  Number of concurrent central roles defines how many simultaneous
+	  connections can be created with the device working as a central.
+
 config BT_CTLR_SDC_PERIPHERAL_COUNT
 	int "Number of concurrent peripheral roles"
 	default BT_MAX_CONN if (BT_PERIPHERAL && !BT_CENTRAL)
@@ -110,8 +131,6 @@ config BT_CTLR_SDC_PERIPHERAL_COUNT
 	help
 	  Number of concurrent peripheral roles defines how many simultaneous
 	  connections can be created with the device working as a peripheral.
-	  NOTE: the number of central roles is defined as
-	  BT_MAX_CONN - BT_CTLR_SDC_PERIPHERAL_COUNT
 
 config BT_CTLR_SDC_MAX_CONN_EVENT_LEN_DEFAULT
 	int "Default max connection event length [us]"

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -35,23 +35,8 @@
 #include "zephyr/logging/log.h"
 LOG_MODULE_REGISTER(bt_sdc_hci_driver);
 
-#if defined(CONFIG_BT_CONN)
-/* It should not be possible to set CONFIG_BT_CTLR_SDC_PERIPHERAL_COUNT larger than
- * CONFIG_BT_MAX_CONN. Kconfig should make sure of that, this assert is to
- * verify that assumption.
- */
-BUILD_ASSERT(CONFIG_BT_CTLR_SDC_PERIPHERAL_COUNT <= CONFIG_BT_MAX_CONN);
-
-#define SDC_CENTRAL_COUNT (CONFIG_BT_MAX_CONN - CONFIG_BT_CTLR_SDC_PERIPHERAL_COUNT)
-
-#else
-
-#define SDC_CENTRAL_COUNT 0
-
-#endif /* CONFIG_BT_CONN */
-
 BUILD_ASSERT(!IS_ENABLED(CONFIG_BT_CENTRAL) ||
-			 (SDC_CENTRAL_COUNT > 0));
+			 (CONFIG_BT_CTLR_SDC_CENTRAL_COUNT > 0));
 
 BUILD_ASSERT(!IS_ENABLED(CONFIG_BT_PERIPHERAL) ||
 			 (CONFIG_BT_CTLR_SDC_PERIPHERAL_COUNT > 0));
@@ -156,7 +141,7 @@ BUILD_ASSERT(!IS_ENABLED(CONFIG_BT_PERIPHERAL) ||
 #define SDC_EXTRA_MEMORY CONFIG_BT_SDC_ADDITIONAL_MEMORY
 
 #define MEMPOOL_SIZE ((PERIPHERAL_COUNT * PERIPHERAL_MEM_SIZE) + \
-		      (SDC_CENTRAL_COUNT * CENTRAL_MEM_SIZE) + \
+		      (CONFIG_BT_CTLR_SDC_CENTRAL_COUNT * CENTRAL_MEM_SIZE) + \
 		      (SDC_ADV_SET_MEM_SIZE) + \
 		      (SDC_PERIODIC_ADV_MEM_SIZE) + \
 		      (SDC_PERIODIC_ADV_RSP_MEM_SIZE) + \
@@ -691,7 +676,7 @@ static int configure_memory_usage(void)
 	sdc_cfg_t cfg;
 
 #if !defined(CONFIG_BT_LL_SOFTDEVICE_PERIPHERAL)
-	cfg.central_count.count = SDC_CENTRAL_COUNT;
+	cfg.central_count.count = CONFIG_BT_CTLR_SDC_CENTRAL_COUNT;
 
 	/* NOTE: sdc_cfg_set() returns a negative errno on error. */
 	required_memory =


### PR DESCRIPTION
BT_MAX_CONN defines the number of host contexts. It seemed like a good idea at the time to piggyback on it for setting the number controller central/peripheral contexts, but that is not correct:

There is a valid use-case for an application that wants to be central or peripheral, but not simultaneously. In that case, enforcing this 1-1 relationship would waste memory in the host.

The upstream controller has no such restriction, so that also clears up build system headaches.