### PR TITLE
net: lib: nrf_cloud_rest: use A-GPS request encoding in codec

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -556,6 +556,7 @@ Libraries for networking
     * The mask angle parameter can now be omitted from an A-GPS REST request by using the value ``NRF_CLOUD_AGPS_MASK_ANGLE_NONE``.
     * Use defines from the :file:`nrf_cloud_pgps.h` file for omitting parameters from a P-GPS request.
       Removed the following values: ``NRF_CLOUD_REST_PGPS_REQ_NO_COUNT``, ``NRF_CLOUD_REST_PGPS_REQ_NO_INTERVAL``, ``NRF_CLOUD_REST_PGPS_REQ_NO_GPS_DAY``, and ``NRF_CLOUD_REST_PGPS_REQ_NO_GPS_TOD``.
+    * A-GPS request encoding now uses the common codec function and new nRF Cloud API format.
 
 * :ref:`lib_lwm2m_client_utils` library:
 

--- a/include/net/nrf_cloud_rest.h
+++ b/include/net/nrf_cloud_rest.h
@@ -44,10 +44,12 @@ enum nrf_cloud_http_status {
 
 /** @brief nRF Cloud AGPS REST request types */
 enum nrf_cloud_rest_agps_req_type {
+	/** Request all assistance data */
 	NRF_CLOUD_REST_AGPS_REQ_ASSISTANCE,
+	/** Request only location (NRF_CLOUD_AGPS_LOCATION) */
 	NRF_CLOUD_REST_AGPS_REQ_LOCATION,
-	NRF_CLOUD_REST_AGPS_REQ_CUSTOM,
-	NRF_CLOUD_REST_AGPS_REQ_UNSPECIFIED,
+	/** Request the data specified by nrf_modem_gnss_agps_data_frame */
+	NRF_CLOUD_REST_AGPS_REQ_CUSTOM
 };
 
 #define NRF_CLOUD_REST_TIMEOUT_NONE		(SYS_FOREVER_MS)
@@ -124,7 +126,7 @@ struct nrf_cloud_rest_location_request {
 /** @brief Data required for nRF Cloud Assisted GPS (A-GPS) request */
 struct nrf_cloud_rest_agps_request {
 	enum nrf_cloud_rest_agps_req_type type;
-	/** Required for custom request type */
+	/** Required for custom request type (NRF_CLOUD_REST_AGPS_REQ_CUSTOM) */
 	struct nrf_modem_gnss_agps_data_frame *agps_req;
 	/** Optional; provide network info or set to NULL. The cloud cannot
 	 * provide location assistance data if network info is NULL.
@@ -179,6 +181,7 @@ int nrf_cloud_rest_location_get(struct nrf_cloud_rest_context *const rest_ctx,
 	struct nrf_cloud_rest_location_request const *const request,
 	struct nrf_cloud_location_result *const result);
 
+#if defined(CONFIG_NRF_CLOUD_AGPS)
 /**
  * @brief nRF Cloud Assisted GPS (A-GPS) data request.
  *
@@ -197,6 +200,8 @@ int nrf_cloud_rest_location_get(struct nrf_cloud_rest_context *const rest_ctx,
  *           Otherwise, a (negative) error code is returned:
  *           - -EINVAL will be returned, and an error message printed, if invalid parameters
  *		are given.
+ *           - -ENOENT will be returned if there was no A-GPS data requested for the specified
+ *		request type.
  *           - -ENOBUFS will be returned, and an error message printed, if there is not enough
  *             buffer space to store retrieved AGPS data.
  *           - See @verbatim embed:rst:inline :ref:`nrf_cloud_rest_failure` @endverbatim for all
@@ -206,6 +211,7 @@ int nrf_cloud_rest_location_get(struct nrf_cloud_rest_context *const rest_ctx,
 int nrf_cloud_rest_agps_data_get(struct nrf_cloud_rest_context *const rest_ctx,
 	struct nrf_cloud_rest_agps_request const *const request,
 	struct nrf_cloud_rest_agps_result *const result);
+#endif /* CONFIG_NRF_CLOUD_AGPS */
 
 #if defined(CONFIG_NRF_CLOUD_PGPS)
 /**

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec_internal.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec_internal.h
@@ -234,10 +234,16 @@ enum nrf_cloud_rcv_topic nrf_cloud_dc_rx_topic_decode(const char * const topic);
  */
 void nrf_cloud_set_app_version(const char * const app_ver);
 
+/** @brief Build A-GPS type array based on request.
+ */
+int nrf_cloud_agps_type_array_get(const struct nrf_modem_gnss_agps_data_frame * const request,
+				  enum nrf_cloud_agps_type *array, const size_t array_size);
+
 /** @brief Encode the data payload of an nRF Cloud A-GPS request into the provided object */
 int nrf_cloud_agps_req_data_json_encode(const enum nrf_cloud_agps_type * const types,
 					const size_t type_count,
 					const struct lte_lc_cell * const cell_inf,
+					const bool fetch_cell_inf,
 					const bool filtered_ephem, const uint8_t mask_angle,
 					cJSON * const data_obj_out);
 

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec_internal.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec_internal.h
@@ -144,12 +144,6 @@ void nrf_cloud_fota_job_free(struct nrf_cloud_fota_job_info *const job);
 int nrf_cloud_rest_fota_execution_decode(const char *const response,
 					struct nrf_cloud_fota_job_info *const job);
 
-#if defined(CONFIG_NRF_CLOUD_PGPS)
-/** @brief Parse the PGPS response (REST and MQTT) from nRF Cloud */
-int nrf_cloud_pgps_response_decode(const char *const response,
-				   struct nrf_cloud_pgps_result *const result);
-#endif
-
 /** @brief Add cellular network info to the provided cJSON object.
  * If the cell_inf parameter is NULL, the codec will obtain the current network
  * info from the modem.
@@ -215,12 +209,6 @@ int nrf_cloud_rest_error_decode(const char *const buf, enum nrf_cloud_error *con
 int nrf_cloud_pvt_data_encode(const struct nrf_cloud_gnss_pvt * const pvt,
 			      cJSON * const pvt_data_obj);
 
-#if defined(CONFIG_NRF_MODEM)
-/** @brief Encode a modem PVT data frame to be sent to nRF Cloud */
-int nrf_cloud_modem_pvt_data_encode(const struct nrf_modem_gnss_pvt_data_frame	* const mdm_pvt,
-				    cJSON * const pvt_data_obj);
-#endif
-
 /** @brief Replace legacy c2d topic with wilcard topic string.
  * Return true, if the topic was modified; otherwise false.
  */
@@ -234,11 +222,6 @@ enum nrf_cloud_rcv_topic nrf_cloud_dc_rx_topic_decode(const char * const topic);
  */
 void nrf_cloud_set_app_version(const char * const app_ver);
 
-/** @brief Build A-GPS type array based on request.
- */
-int nrf_cloud_agps_type_array_get(const struct nrf_modem_gnss_agps_data_frame * const request,
-				  enum nrf_cloud_agps_type *array, const size_t array_size);
-
 /** @brief Encode the data payload of an nRF Cloud A-GPS request into the provided object */
 int nrf_cloud_agps_req_data_json_encode(const enum nrf_cloud_agps_type * const types,
 					const size_t type_count,
@@ -247,13 +230,28 @@ int nrf_cloud_agps_req_data_json_encode(const enum nrf_cloud_agps_type * const t
 					const bool filtered_ephem, const uint8_t mask_angle,
 					cJSON * const data_obj_out);
 
-/** @brief Encode an A-GPS request device message to be sent to nRF Cloud */
-#if defined(CONFIG_NRF_CLOUD_AGPS)
-int nrf_cloud_agps_req_json_encode(const struct nrf_modem_gnss_agps_data_frame * const request,
-				   cJSON * const agps_req_obj_out);
+#if defined(CONFIG_NRF_MODEM)
+/** @brief Encode a modem PVT data frame to be sent to nRF Cloud */
+int nrf_cloud_modem_pvt_data_encode(const struct nrf_modem_gnss_pvt_data_frame	* const mdm_pvt,
+				    cJSON * const pvt_data_obj);
 #endif
 
+#if defined(CONFIG_NRF_CLOUD_AGPS)
+/** @brief Build A-GPS type array based on request.
+ */
+int nrf_cloud_agps_type_array_get(const struct nrf_modem_gnss_agps_data_frame * const request,
+				  enum nrf_cloud_agps_type *array, const size_t array_size);
+
+/** @brief Encode an A-GPS request device message to be sent to nRF Cloud */
+int nrf_cloud_agps_req_json_encode(const struct nrf_modem_gnss_agps_data_frame * const request,
+				   cJSON * const agps_req_obj_out);
+#endif /* CONFIG_NRF_CLOUD_AGPS */
+
 #if defined(CONFIG_NRF_CLOUD_PGPS)
+/** @brief Parse the PGPS response (REST and MQTT) from nRF Cloud */
+int nrf_cloud_pgps_response_decode(const char *const response,
+				   struct nrf_cloud_pgps_result *const result);
+
 /** @brief Encode the data payload of an nRF Cloud P-GPS request into the provided object */
 int nrf_cloud_pgps_req_data_json_encode(const struct gps_pgps_request * const request,
 					cJSON * const data_obj_out);

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec_internal.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec_internal.c
@@ -2815,6 +2815,7 @@ int nrf_cloud_agps_type_array_get(const struct nrf_modem_gnss_agps_data_frame * 
 int nrf_cloud_agps_req_data_json_encode(const enum nrf_cloud_agps_type * const types,
 					const size_t type_count,
 					const struct lte_lc_cell * const cell_inf,
+					const bool fetch_cell_inf,
 					const bool filtered_ephem, const uint8_t mask_angle,
 					cJSON * const data_obj_out)
 {
@@ -2835,11 +2836,13 @@ int nrf_cloud_agps_req_data_json_encode(const enum nrf_cloud_agps_type * const t
 			mask_angle);
 	}
 
-	/* Add the cell info */
-	err = nrf_cloud_cell_info_json_encode(data_obj_out, cell_inf);
-	if (err) {
-		LOG_ERR("Failed to add cellular network info to A-GPS request: %d", err);
-		goto cleanup;
+	/* Add the cell info if provided or fetch flag set */
+	if (cell_inf || fetch_cell_inf) {
+		err = nrf_cloud_cell_info_json_encode(data_obj_out, cell_inf);
+		if (err) {
+			LOG_ERR("Failed to add cellular network info to A-GPS request: %d", err);
+			goto cleanup;
+		}
 	}
 
 	/* Add the requested types */
@@ -2901,7 +2904,7 @@ int nrf_cloud_agps_req_json_encode(const struct nrf_modem_gnss_agps_data_frame *
 #endif
 
 	/* Populate the request payload */
-	err = nrf_cloud_agps_req_data_json_encode(types, type_count, NULL,
+	err = nrf_cloud_agps_req_data_json_encode(types, type_count, NULL, true,
 						  IS_ENABLED(CONFIG_NRF_CLOUD_AGPS_FILTERED),
 						  mask_angle, data_obj);
 	if (!err) {


### PR DESCRIPTION
The REST API has been updated to accept the same payload as
MQTT, allowing for the REST library to use the codec functions
to encode the A-GPS request.

Group codec functions that share `#ifdef` blocks.

IRIS-5896