### PR TITLE
application: serial_lte_modem: Re-enable TFTP client

### DIFF
--- a/applications/serial_lte_modem/doc/FTP_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/FTP_AT_commands.rst
@@ -116,10 +116,6 @@ TFTP client #XTFTP
 
 The ``#XTFTP`` command allows you to send TFTP commands.
 
-   .. note::
-      The maximum supported file size is 2048 bytes.
-      TFTP write request is not supported yet.
-
 Set command
 -----------
 
@@ -130,22 +126,21 @@ Syntax
 
 ::
 
-   AT#XTFTP=<op>,<url>,<port>,<file_path>[,<mode>]
+   AT#XTFTP=<op>,<url>,<port>,<file_path>[,<mode>,<data>]
 
 * The ``<op>`` parameter can accept one of the following values:
 
   * ``1`` - TFTP read request using IP protocol family version 4.
-  * *Currently not supported* ``2`` - TFTP write request using IP protocol family version 4.
+  * ``2`` - TFTP write request using IP protocol family version 4.
   * ``3`` - TFTP read request using IP protocol family version 6.
-  * *Currently not supported* ``4`` - TFTP write request using IP protocol family version 6.
+  * ``4`` - TFTP write request using IP protocol family version 6.
 
 * The ``<url>`` parameter is a string.
   It indicates the hostname or the IP address of the TFTP server.
   Its maximum size is 128 bytes.
   When the parameter is an IP address, it supports both IPv4 and IPv6.
 * The ``<port>`` parameter is an unsigned 16-bit integer (0 - 65535).
-  It represents the TFTP service port on the remote server.
-  Default port 69 is applied if this parameter is omitted or set to ``0``.
+  It represents the TFTP service port on the remote server, which is usually port 69.
 * The ``<file_path>`` parameter is a string.
   It indicates the file path on the TFTP server to read from or write to.
   Its maximum size is 128 bytes.
@@ -153,6 +148,12 @@ Syntax
   It indicates the three modes defined in TFTP protocol.
   Valid values are ``netascii``, ``octet`` and ``mail``.
   The default value ``octet`` is applied if this parameter is omitted.
+* The ``<data>`` parameter is a string.
+  When ``<op>`` has a value of ``2`` or ``4``, this is the data to be put to the remote server.
+
+   .. note::
+      The maximum data size supported in WRITE request is 1024 bytes.
+      The TFTP connection is terminated by writing less than 512 bytes, as defined in the protocol specification (RFC 1350).
 
 Response syntax
 ~~~~~~~~~~~~~~~
@@ -177,18 +178,27 @@ Examples
 
 ::
 
-   AT#XTFTP=1,"tftp.server",,"test_tftp_fake.txt"
-   #XTFTP: -4, "remote error"
-   ERROR
+  AT#XTFTP=2,"tftp-server.com",69,"test_put_01.txt","octet","test send TFTP PUT"
+  #XTFTP: 18,"success"
+  OK
 
-   AT#XTFTP=1,"tftp.server",,"test_tftp.txt"
-   #XTFTP: 45,"success"
-   Test file for SLM TFTP client.
-   Does it work?
-   OK
+  AT#XTFTP=1,"tftp-server.com",69,"test_put_01.txt"
+  test send TFTP PUT
+  #XTFTP: 18,"success"
+  OK
 
-   AT#XTFTP=2,"tftp.server",,"test_upload.txt"
-   ERROR
+  AT#XTFTP=2,"tftp-server.com",69,"test_put_02.txt""octet","012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"
+  #XTFTP: 540,"success"
+  OK
+
+  AT#XTFTP=1,"tftp-server.com",69,"test_put_02.txt"
+  012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
+  #XTFTP: 540,"success"
+  OK
+
+  AT#XTFTP=1,"tftp-server.com",69,"test_put_not_exist.txt"
+  #XTFTP: -4, "remote error"
+  ERROR
 
 Read command
 ------------

--- a/applications/serial_lte_modem/prj.conf
+++ b/applications/serial_lte_modem/prj.conf
@@ -98,8 +98,6 @@ CONFIG_SLM_LOG_LEVEL_INF=y
 CONFIG_SLM_EXTERNAL_XTAL=n
 CONFIG_SLM_START_SLEEP=n
 CONFIG_SLM_DATAMODE_URC=n
-# Disable SLM_TFTPC until the client code is updated
-CONFIG_SLM_TFTPC=n
 
 # nRF Cloud based location services
 CONFIG_SLM_AGPS=n

--- a/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.c
+++ b/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.c
@@ -18,7 +18,6 @@
 LOG_MODULE_REGISTER(slm_ftp, CONFIG_SLM_LOG_LEVEL);
 
 #define FTP_MAX_OPTION		32
-#define FTP_MAX_FILEPATH	128
 
 #define FTP_USER_ANONYMOUS      "anonymous"
 #define FTP_PASSWORD_ANONYMOUS  "anonymous@example.com"
@@ -59,7 +58,7 @@ typedef struct ftp_op_list {
 } ftp_op_list_t;
 
 static bool ftp_verbose_on;
-static char filepath[FTP_MAX_FILEPATH];
+static char filepath[SLM_MAX_FILEPATH];
 static int sz_filepath;
 static int (*ftp_data_mode_handler)(const uint8_t *data, int len);
 
@@ -326,8 +325,8 @@ static int do_ftp_ls(void)
 			return ret;
 		}
 	}
-	memset(filepath, 0x00, FTP_MAX_FILEPATH);
-	sz_filepath = FTP_MAX_FILEPATH;
+	memset(filepath, 0x00, SLM_MAX_FILEPATH);
+	sz_filepath = SLM_MAX_FILEPATH;
 	if (param_count > 3) {
 		ret = util_string_get(&at_param_list, 3, filepath, &sz_filepath);
 		if (ret) {
@@ -350,7 +349,7 @@ static int do_ftp_cd(void)
 {
 	int ret;
 
-	sz_filepath = FTP_MAX_FILEPATH;
+	sz_filepath = SLM_MAX_FILEPATH;
 	ret = util_string_get(&at_param_list, 2, filepath, &sz_filepath);
 	if (ret) {
 		return ret;
@@ -365,7 +364,7 @@ static int do_ftp_mkdir(void)
 {
 	int ret;
 
-	sz_filepath = FTP_MAX_FILEPATH;
+	sz_filepath = SLM_MAX_FILEPATH;
 	ret = util_string_get(&at_param_list, 2, filepath, &sz_filepath);
 	if (ret) {
 		return ret;
@@ -380,7 +379,7 @@ static int do_ftp_rmdir(void)
 {
 	int ret;
 
-	sz_filepath = FTP_MAX_FILEPATH;
+	sz_filepath = SLM_MAX_FILEPATH;
 	ret = util_string_get(&at_param_list, 2, filepath, &sz_filepath);
 	if (ret) {
 		return ret;
@@ -394,10 +393,10 @@ static int do_ftp_rmdir(void)
 static int do_ftp_rename(void)
 {
 	int ret;
-	char file_new[FTP_MAX_FILEPATH];
-	int sz_file_new = FTP_MAX_FILEPATH;
+	char file_new[SLM_MAX_FILEPATH];
+	int sz_file_new = SLM_MAX_FILEPATH;
 
-	sz_filepath = FTP_MAX_FILEPATH;
+	sz_filepath = SLM_MAX_FILEPATH;
 	ret = util_string_get(&at_param_list, 2, filepath, &sz_filepath);
 	if (ret) {
 		return ret;
@@ -416,7 +415,7 @@ static int do_ftp_delete(void)
 {
 	int ret;
 
-	sz_filepath = FTP_MAX_FILEPATH;
+	sz_filepath = SLM_MAX_FILEPATH;
 	ret = util_string_get(&at_param_list, 2, filepath, &sz_filepath);
 	if (ret) {
 		return ret;
@@ -431,7 +430,7 @@ static int do_ftp_get(void)
 {
 	int ret;
 
-	sz_filepath = FTP_MAX_FILEPATH;
+	sz_filepath = SLM_MAX_FILEPATH;
 	ret = util_string_get(&at_param_list, 2, filepath, &sz_filepath);
 	if (ret) {
 		return ret;
@@ -485,7 +484,7 @@ static int do_ftp_put(void)
 {
 	int ret;
 
-	sz_filepath = FTP_MAX_FILEPATH;
+	sz_filepath = SLM_MAX_FILEPATH;
 	ret = util_string_get(&at_param_list, 2, filepath, &sz_filepath);
 	if (ret) {
 		return ret;
@@ -574,7 +573,7 @@ static int do_ftp_mput(void)
 {
 	int ret;
 
-	sz_filepath = FTP_MAX_FILEPATH;
+	sz_filepath = SLM_MAX_FILEPATH;
 	ret = util_string_get(&at_param_list, 2, filepath, &sz_filepath);
 	if (ret) {
 		return ret;

--- a/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.h
+++ b/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.h
@@ -9,7 +9,7 @@
 
 /**@file
  *
- * @brief Vendor-specific AT command for FTP service.
+ * @brief Vendor-specific AT command for FTP and TFTP services.
  * @{
  */
 /**
@@ -19,6 +19,14 @@
  *           Otherwise, a (negative) error code is returned.
  */
 int slm_at_ftp_init(void);
+
+/**
+ * @brief Initialize TFTP AT command parser.
+ *
+ * @retval 0 If the operation was successful.
+ *           Otherwise, a (negative) error code is returned.
+ */
+int slm_at_tftp_init(void);
 
 /**
  * @brief Uninitialize FTP AT command parser.

--- a/applications/serial_lte_modem/src/ftp_c/slm_at_tftp.c
+++ b/applications/serial_lte_modem/src/ftp_c/slm_at_tftp.c
@@ -11,11 +11,9 @@
 #include <zephyr/net/tftp.h>
 #include "slm_util.h"
 #include "slm_at_host.h"
+#include "slm_at_ftp.h"
 
 LOG_MODULE_REGISTER(slm_tftp, CONFIG_SLM_LOG_LEVEL);
-
-#define TFTP_MAX_FILEPATH	128
-#define TFTP_DEFAULT_PORT       69
 
 /**@brief Socketopt operations. */
 enum slm_ftp_operation {
@@ -24,7 +22,6 @@ enum slm_ftp_operation {
 	TFTP_PUT,	/** IPv4 TFTP Write */
 	TFTP_GET6,	/** IPv6 TFTP Read */
 	TFTP_PUT6,	/** IPv6 TFTP Write */
-	/* count */
 	TFTP_OP_MAX
 };
 
@@ -32,60 +29,115 @@ enum slm_ftp_operation {
 extern struct at_param_list at_param_list;
 extern uint8_t data_buf[SLM_MAX_MESSAGE_SIZE];
 
+void tftp_callback(const struct tftp_evt *evt)
+{
+	switch (evt->type) {
+	case TFTP_EVT_DATA:
+		if (evt->param.data.len > 0) {
+			memcpy(data_buf, evt->param.data.data_ptr, evt->param.data.len);
+			data_send(data_buf, evt->param.data.len);
+		}
+		break;
+
+	case TFTP_EVT_ERROR:
+		LOG_ERR("ERROR: %d, %s", evt->param.error.code, evt->param.error.msg);
+		break;
+
+	default:
+		break;
+	}
+}
+
 static int do_tftp_get(int family, const char *server, uint16_t port, const char *filepath,
 			const char *mode)
 {
 	int ret;
-	struct sockaddr sa = {
-		.sa_family = AF_UNSPEC
+	struct tftpc client = {
+		.callback = tftp_callback
 	};
 
-	ret = util_resolve_host(0, server, port, family, &sa);
+	ret = util_resolve_host(0, server, port, family, &client.server);
 	if (ret) {
 		LOG_ERR("getaddrinfo() error: %s", gai_strerror(ret));
 		return -EAGAIN;
 	}
 
-	struct tftpc client = {
-		.user_buf = data_buf,
-		.user_buf_size = sizeof(data_buf)
-	};
-
-	ret = tftp_get(&sa, &client, filepath, mode);
-	if (ret != 0) {
+	ret = tftp_get(&client, filepath, mode);
+	if (ret < 0) {
 		switch (ret) {
 		case TFTPC_DUPLICATE_DATA:
-			rsp_send("\r\n#XTFTP: -1, \"duplicate data\"\r\n");
+			rsp_send("\r\n#XTFTP: %d, \"duplicate data\"\r\n", ret);
 			break;
 		case TFTPC_BUFFER_OVERFLOW:
-			rsp_send("\r\n#XTFTP: -2, \"buffer overflow\"\r\n");
-			break;
-		case TFTPC_REMOTE_ERROR:
-			rsp_send("\r\n#XTFTP: -4, \"remote error\"\r\n");
-			break;
-		case TFTPC_RETRIES_EXHAUSTED:
-			rsp_send("\r\n#XTFTP: -5, \"retries exhausted\"\r\n");
+			rsp_send("\r\n#XTFTP: %d, \"buffer overflow\"\r\n", ret);
 			break;
 		case TFTPC_UNKNOWN_FAILURE:
+			rsp_send("\r\n#XTFTP: %d, \"unknown failure\"\r\n", ret);
+			break;
+		case TFTPC_REMOTE_ERROR:
+			rsp_send("\r\n#XTFTP: %d, \"remote error\"\r\n", ret);
+			break;
+		case TFTPC_RETRIES_EXHAUSTED:
+			rsp_send("\r\n#XTFTP: %d, \"retries exhausted\"\r\n", ret);
+			break;
 		default:
-			rsp_send("\r\n#XTFTP: -3, \"unknown failure\"\r\n");
+			rsp_send("\r\n#XTFTP: %d, \"other failure\"\r\n", ret);
 			break;
 		}
 	} else {
-		rsp_send("\r\n#XTFTP: %d,\"success\"\r\n", client.user_buf_size);
+		rsp_send("\r\n#XTFTP: %d,\"success\"\r\n", ret);
+		ret = 0;
 	}
-	/* API does not add null-terminator */
-	if (client.user_buf_size < sizeof(data_buf)) {
-		data_buf[client.user_buf_size] = 0x00;
-	}
-	data_send(data_buf, strlen(data_buf));
+
 	return ret;
 }
 
+static int do_tftp_put(int family, const char *server, uint16_t port, const char *filepath,
+			const char *mode, const uint8_t *data, size_t datalen)
+{
+	int ret;
+	struct tftpc client = {
+		.callback = tftp_callback
+	};
 
+	ret = util_resolve_host(0, server, port, family, &client.server);
+	if (ret) {
+		LOG_ERR("getaddrinfo() error: %s", gai_strerror(ret));
+		return -EAGAIN;
+	}
+
+	ret = tftp_put(&client, filepath, mode, data, datalen);
+	if (ret < 0) {
+		switch (ret) {
+		case TFTPC_DUPLICATE_DATA:
+			rsp_send("\r\n#XTFTP: %d, \"duplicate data\"\r\n", ret);
+			break;
+		case TFTPC_BUFFER_OVERFLOW:
+			rsp_send("\r\n#XTFTP: %d, \"unknown overflow\"\r\n", ret);
+			break;
+		case TFTPC_UNKNOWN_FAILURE:
+			rsp_send("\r\n#XTFTP: %d, \"unknown failure\"\r\n", ret);
+			break;
+		case TFTPC_REMOTE_ERROR:
+			rsp_send("\r\n#XTFTP: %d, \"remote error\"\r\n", ret);
+			break;
+		case TFTPC_RETRIES_EXHAUSTED:
+			rsp_send("\r\n#XTFTP: %d, \"retries exhausted\"\r\n", ret);
+			break;
+		default:
+			rsp_send("\r\n#XTFTP: %d, \"other failure\"\r\n", ret);
+			break;
+		}
+	} else {
+		rsp_send("\r\n#XTFTP: %d,\"success\"\r\n", ret);
+		ret = 0;
+	}
+
+	return ret;
+}
 
 /**@brief handle AT#XTFTP commands
- *  AT#XTFTP=<op>,<url>,<port>,<file_path>[,<mode>]
+ *  AT#XTFTP=<op>,<url>,<port>,<file_path>[,<mode>,<data>]
  *  AT#XTFTP? READ is not supported
  *  AT#XTFTP=?
  */
@@ -93,6 +145,11 @@ int handle_at_tftp(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
 	uint16_t op;
+	uint16_t port;
+	char url[SLM_MAX_URL];
+	char filepath[SLM_MAX_FILEPATH];
+	char mode[16];   /** "netascii", "octet", "mail" */
+	int size;
 	int param_count = at_params_valid_count_get(&at_param_list);
 
 	switch (cmd_type) {
@@ -101,56 +158,59 @@ int handle_at_tftp(enum at_cmd_type cmd_type)
 		if (err) {
 			return err;
 		}
-		if (op == TFTP_GET || op == TFTP_GET6) {
-			uint16_t port;
-			char url[SLM_MAX_URL];
-			char filepath[TFTP_MAX_FILEPATH];
-			char mode[16];   /** "netascii", "octet", "mail" */
-			int size;
 
-			size = sizeof(url);
-			err = util_string_get(&at_param_list, 2, url, &size);
+		size = sizeof(url);
+		err = util_string_get(&at_param_list, 2, url, &size);
+		if (err) {
+			return err;
+		}
+		err = at_params_unsigned_short_get(&at_param_list, 3, &port);
+		if (err) {
+			return err;
+		}
+		size = sizeof(filepath);
+		err = util_string_get(&at_param_list, 4, filepath, &size);
+		if (err) {
+			return err;
+		}
+		if (param_count > 5) {
+			size = sizeof(mode);
+			err = util_string_get(&at_param_list, 5, mode, &size);
 			if (err) {
 				return err;
 			}
-			(void)at_params_unsigned_short_get(&at_param_list, 3, &port);
-			if (port == 0) {
-				port = TFTP_DEFAULT_PORT;
+			if (!slm_util_cmd_casecmp(mode, "netascii") &&
+			    !slm_util_cmd_casecmp(mode, "octet") &&
+			    !slm_util_cmd_casecmp(mode, "mail")) {
+				return -EINVAL;
 			}
-			size = sizeof(filepath);
-			err = util_string_get(&at_param_list, 4, filepath, &size);
-			if (err) {
-				return err;
-			}
-			if (param_count > 5) {
-				size = sizeof(mode);
-				err = util_string_get(&at_param_list, 5, mode, &size);
-				if (err) {
-					return err;
-				}
-				if (!slm_util_cmd_casecmp(mode, "netascii") &&
-				    !slm_util_cmd_casecmp(mode, "octet") &&
-				    !slm_util_cmd_casecmp(mode, "mail")) {
-					return -EINVAL;
-				}
-			} else {
-				strcpy(mode, "octet");
-			}
+		} else {
+			strcpy(mode, "octet");
+		}
 
-			if (op == TFTP_GET) {
-				err = do_tftp_get(AF_INET, url, port, filepath, mode);
-			} else {
-				err = do_tftp_get(AF_INET6, url, port, filepath, mode);
-			}
+		if (op == TFTP_GET) {
+			err = do_tftp_get(AF_INET, url, port, filepath, mode);
+		} else if (op == TFTP_GET6) {
+			err = do_tftp_get(AF_INET6, url, port, filepath, mode);
 		} else if (op == TFTP_PUT || op == TFTP_PUT6) {
-			LOG_WRN("TFTP Put not supported");
-			err = -ENOSYS;
+			uint8_t data[SLM_MAX_PAYLOAD_SIZE + 1] = {0};
+
+			size = sizeof(data);
+			err = util_string_get(&at_param_list, 6, data, &size);
+			if (err) {
+				return err;
+			}
+			if (op == TFTP_PUT) {
+				err = do_tftp_put(AF_INET, url, port, filepath, mode, data, size);
+			} else {
+				err = do_tftp_put(AF_INET6, url, port, filepath, mode, data, size);
+			}
 		} else {
 			err = -EINVAL;
 		} break;
 
 	case AT_CMD_TYPE_TEST_COMMAND:
-		rsp_send("\r\n#XTFTP: (%d,%d,%d,%d),<url>,<port>,<file_path>,<mode>\r\n",
+		rsp_send("\r\n#XTFTP: (%d,%d,%d,%d),<url>,<port>,<file_path>,<mode>,<data>\r\n",
 			TFTP_GET, TFTP_PUT, TFTP_GET6, TFTP_PUT6);
 		err = 0;
 		break;

--- a/applications/serial_lte_modem/src/slm_defines.h
+++ b/applications/serial_lte_modem/src/slm_defines.h
@@ -25,6 +25,7 @@
 #define SLM_MAX_SOCKET_COUNT 8    /** re-define NRF_MODEM_MAX_SOCKET_COUNT */
 
 #define SLM_MAX_URL          128  /** max size of URL string */
+#define SLM_MAX_FILEPATH     128  /** max size of filepath string */
 #define SLM_MAX_USERNAME     32   /** max size of username in login */
 #define SLM_MAX_PASSWORD     32   /** max size of password in login */
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -171,9 +171,18 @@ nRF9160: Asset Tracker v2
 nRF9160: Serial LTE modem
 -------------------------
 
-* Added AT command ``#XWIFIPOS`` to get Wi-Fi location from nRF Cloud.
-* Updated the application to use defines from the :ref:`lib_nrf_cloud` library for string values related to nRF Cloud.
-* Fixed a bug in receiving a large MQTT Publish message.
+* Added:
+
+  * AT command ``#XWIFIPOS`` to get Wi-Fi location from nRF Cloud.
+  * Support for *WRITE REQUEST* in TFTP client.
+
+* Updated:
+
+  * Use defines from the :ref:`lib_nrf_cloud` library for nRF Cloud related string values.
+
+* Fixed:
+
+  * A bug in receiving large MQTT Publish message.
 
 nRF5340 Audio
 -------------


### PR DESCRIPTION
Re-enable TFTP client by default.
Adapt to Zephyr upstream TFTP library updates:
.Write support
.Client context