### PR TITLE
lib: azure_iot_hub: Increase default username buffer size

### DIFF
--- a/doc/nrf/libraries/networking/azure_iot_hub.rst
+++ b/doc/nrf/libraries/networking/azure_iot_hub.rst
@@ -99,8 +99,7 @@ To connect to Azure IoT Hub without using DPS, complete the following minimum re
    If the ``device_id.size`` buffer size is zero, the compile-time option :kconfig:option:`CONFIG_AZURE_IOT_HUB_DEVICE_ID`` is used.
 #. Make sure that the device is already registered with your Azure IoT Hub, or follow the instructions in `Registering the device with Azure IoT Hub`_.
 #. Set the :kconfig:option:`CONFIG_MQTT_HELPER_SEC_TAG` option to the security tag used in :ref:`azure_iot_hub_flash_certs`.
-
-   Optionally, set the :kconfig:option:`CONFIG_MQTT_HELPER_SEC_TAG` option if multiple server certificates are provisioned.
+   Optionally, set the :kconfig:option:`CONFIG_MQTT_HELPER_SECONDARY_SEC_TAG` option if multiple server certificates are provisioned.
 
 
 .. _dps_config:
@@ -122,7 +121,7 @@ To connect to Azure IoT Hub using DPS, complete the following steps:
 
    You can also set the registration ID at run time.
 #. Set :kconfig:option:`CONFIG_MQTT_HELPER_SEC_TAG` to the security tag used while :ref:`azure_iot_hub_flash_certs`.
-   Optionally, set the :kconfig:option:`CONFIG_MQTT_HELPER_SEC_TAG` option if multiple server certificates are provisioned.
+   Optionally, set the :kconfig:option:`CONFIG_MQTT_HELPER_SECONDARY_SEC_TAG` option if multiple server certificates are provisioned.
 
 
 Application integration

--- a/subsys/net/lib/azure_iot_hub/Kconfig
+++ b/subsys/net/lib/azure_iot_hub/Kconfig
@@ -47,7 +47,7 @@ config AZURE_IOT_HUB_DPS
 
 config AZURE_IOT_HUB_USER_NAME_BUF_SIZE
 	int "User name max length"
-	default 128
+	default 160
 	help
 	  Maximum length of the user name.
 


### PR DESCRIPTION
Increase the default username buffer size from 128 to 160, which is value based on experiment.

Also correct minor issue in doc.