### PR TITLE
lib: bin: lwm2m_carrier: Remove direct link of C library

### DIFF
--- a/lib/bin/lwm2m_carrier/CMakeLists.txt
+++ b/lib/bin/lwm2m_carrier/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 
 set(                    LWM2M_CARRIER_TARGET liblwm2m_carrier)
 zephyr_library_import(${LWM2M_CARRIER_TARGET} ${LWM2M_CARRIER_LIB_PATH}/liblwm2m_carrier.a)
-target_link_libraries(${LWM2M_CARRIER_TARGET} INTERFACE modem -lc)
+target_link_libraries(${LWM2M_CARRIER_TARGET} INTERFACE modem)
 
 ncs_add_partition_manager_config(pm.yml.lwm2m_carrier)
 


### PR DESCRIPTION
Linking the C library in this manner will cause newlibc to be linked if picolibc is enabled. As the C library will be linked without this it can be safely removed.