### PR TITLE
workflow: backport: Update nodes' requirements

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   backport:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     name: Backport
     steps:
       - name: Backport


### PR DESCRIPTION
Ubuntu 18.04 was depricated in github and the action was pending waiting for unexisting nodes. Aligned with the version used in the zephyr upstream.