### PR TITLE
script: Auto-upmerging sdk-mcuboot from upstream

### DIFF
--- a/.github/workflows/create-upmerge-PRs.yml
+++ b/.github/workflows/create-upmerge-PRs.yml
@@ -8,6 +8,7 @@ on: workflow_dispatch
 env:
   GH_TOKEN: ${{ secrets.NCS_GITHUB_UPMERGE_TOKEN }}
   ZEPHYR_UPSTREAM: https://github.com/zephyrproject-rtos/zephyr
+  MCUBOOT_UPSTREAM: https://github.com/zephyrproject-rtos/mcuboot
   PR_TARGET_BRANCH: upmerge-tmp
 
 jobs:
@@ -31,15 +32,18 @@ jobs:
         working-directory: ncs
         run: |
           west init -l nrf
-          west update zephyr bsim
+          west update zephyr bsim mcuboot
           git config --global user.email "noreply@nordicsemi.no"
           git config --global user.name "Nordic Builder"
           echo "SDK_ZEPHYR=$(west list zephyr -f {url} | awk -F// '{print $NF}')" >> $GITHUB_ENV
+          echo "SDK_MCUBOOT=$(west list mcuboot -f {url} | awk -F// '{print $NF}')" >> $GITHUB_ENV
 
       - name: Try closing existing auto-upmerge PRs
         run: |
            SDK_ZEPHYR_PR=$(gh pr list --repo $SDK_ZEPHYR --label "auto-upmerge" --json number --jq .[0].number)
            gh pr close $SDK_ZEPHYR_PR --repo $SDK_ZEPHYR | true
+           SDK_MCUBOOT_PR=$(gh pr list --repo $SDK_MCUBOOT --label "auto-upmerge" --json number --jq .[0].number)
+           gh pr close $SDK_MCUBOOT_PR --repo $SDK_MCUBOOT | true
            SDK_NRF_PR=$(gh pr list --repo $GITHUB_SERVER_URL/$GITHUB_REPOSITORY --label "auto-upmerge" --json number --jq .[0].number)
            gh pr close $SDK_NRF_PR --repo $GITHUB_SERVER_URL/$GITHUB_REPOSITORY | true
 
@@ -50,22 +54,42 @@ jobs:
           git checkout -b upmerge_local
           west ncs-upmerger zephyr
           git push origin upmerge_local:auto-upmerge/$GITHUB_RUN_ID -u
+          MCUBOOT_UPSTREAM_REV=$(cat west.yml | awk -e '/- name: mcuboot/,/path: bootloader\/mcuboot/ { if ($0 ~ "revision:.*") { print $2; }; }')
 
           UPSTREAMHASH=$(git rev-parse --short upstream/main)
           ZEPHYR_PR_URL=$(gh pr create --base $PR_TARGET_BRANCH --title "[nrf mergeup] Merge upstream automatically up to commit $UPSTREAMHASH" --body "Automatic upmerge action" --repo $SDK_ZEPHYR --label "auto-upmerge")
           echo "ZEPHYR_PR_URL=$ZEPHYR_PR_URL" >> $GITHUB_ENV
           echo "Created PR: $ZEPHYR_PR_URL"
+          echo "MCUboot revision used by upstream: ${MCUBOOT_UPSTREAM_REV}"
+          echo "MCUBOOT_UPSTREAM_REV=${MCUBOOT_UPSTREAM_REV}" >> $GITHUB_ENV
+
+      - name: Run ncs-upmerge and create sdk-mcuboot upmerge PR
+        working-directory: ncs/bootloader/mcuboot
+        run: |
+          git remote add -f upstream $MCUBOOT_UPSTREAM && git remote add -f origin https://nordicbuilder:${{secrets.NCS_GITHUB_UPMERGE_TOKEN}}@$SDK_MCUBOOT
+          git checkout -b upmerge_local
+          west ncs-upmerger mcuboot
+          git push origin upmerge_local:auto-upmerge/$GITHUB_RUN_ID -u
+
+          UPSTREAMHASH=${MCUBOOT_UPSTREAM_REV}
+          MCUBOOT_PR_URL=$(gh pr create --base $PR_TARGET_BRANCH --title "[nrf mergeup] Merge upstream automatically up to commit $UPSTREAMHASH" --body "Automatic upmerge action" --repo $SDK_MCUBOOT --label "auto-upmerge")
+          echo "MCUBOOT_PR_URL=$MCUBOOT_PR_URL" >> $GITHUB_ENV
+          echo "Created PR: $MCUBOOT_PR_URL"
+
 
       - name: create sdk-nrf PR with updated west.yml
         working-directory: ncs/nrf
         run: |
           NEW_REV=$(echo "pull/$(basename $ZEPHYR_PR_URL)/head" | sed 's/\//\\\//g')
+          NEW_MCUBOOT_REV=$(echo "pull/$(basename $MCUBOOT_PR_URL)/head" | sed 's/\//\\\//g')
           OLD_REV=$(west list zephyr -f {revision})
+          OLD_MCUBOOT_REV=$(west list mcuboot -f {revision})
           git checkout -b upmerge_local
           sed -i "s/revision: $OLD_REV/revision: $NEW_REV/" west.yml
+          sed -i "s/revision: $OLD_MCUBOOT_REV/revision: $NEW_MCUBOOT_REV/" west.yml
           git commit -a -m "manifest: Update sdk-zephyr revision (automatic Zephyr upmerge)" -m "Automatically created by Github Action" --signoff
           git push origin upmerge_local:auto-upmerge/$GITHUB_RUN_ID -u
-          gh pr create --base $PR_TARGET_BRANCH --title "manifest: Update sdk-zephyr revision (automatic upmerge)" --body "Automatic upmerge action" --label "CI-all-test" --label "auto-upmerge"
+          gh pr create --base $PR_TARGET_BRANCH --title "manifest: Update revisions of upmerged projects (automatic upmerge)" --body "Automatic upmerge action" --label "CI-all-test" --label "auto-upmerge"
 
   failure-notifier:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The commit adds auto-upmerging workflow for sdk-mcuboot.

Currently it works on upmerge-tmp branch.