### PR TITLE
lib: lte_lc: Add parsing +CEDRXP: 0

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -433,6 +433,12 @@ Modem libraries
 
   * Updated the library to use ePCO mode if the Kconfig option :kconfig:option:`CONFIG_PDN_LEGACY_PCO` is not enabled.
 
+* :ref:`lte_lc_readme` library:
+
+  * Updated the library to handle notifications from the modem when eDRX is not used by the current cell.
+    The application now receives an :c:enum:`LTE_LC_EVT_EDRX_UPDATE` event with the network mode set to :c:enum:`LTE_LC_LTE_MODE_NONE` in these cases.
+    Modem firmware version v1.3.4 or newer is required to receive these events.
+
 Libraries for networking
 ------------------------
 

--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -50,7 +50,7 @@ enum lte_lc_system_mode {
 };
 
 /** LTE mode. The values for LTE-M and NB-IoT correspond to the values for the
- *  AcT field in an AT+CEREG response.
+ *  access technology field in AT responses.
  */
 enum lte_lc_lte_mode {
 	LTE_LC_LTE_MODE_NONE	= 0,
@@ -245,7 +245,9 @@ struct lte_lc_psm_cfg {
 };
 
 struct lte_lc_edrx_cfg {
-	/* LTE mode for which the configuration is valid. */
+	/* LTE mode for which the configuration is valid.
+	 * If the mode is LTE_LC_LTE_MODE_NONE, eDRX is not used by the current cell.
+	 */
 	enum lte_lc_lte_mode mode;
 	/* eDRX interval value [s] */
 	float edrx;

--- a/tests/lib/lte_lc/src/main.c
+++ b/tests/lib/lte_lc/src/main.c
@@ -16,13 +16,20 @@ static void test_parse_edrx(void)
 {
 	int err;
 	struct lte_lc_edrx_cfg cfg;
-	char *at_response_none = "+CEDRXP: 1,\"1000\",\"0101\",\"1011\"";
+	char *at_response_none = "+CEDRXP: 0";
+	char *at_response_fail = "+CEDRXP: 1,\"1000\",\"0101\",\"1011\"";
 	char *at_response_ltem = "+CEDRXP: 4,\"1000\",\"0101\",\"1011\"";
 	char *at_response_ltem_2 = "+CEDRXP: 4,\"1000\",\"0010\",\"1110\"";
 	char *at_response_nbiot = "+CEDRXP: 5,\"1000\",\"1101\",\"0111\"";
 	char *at_response_nbiot_2 = "+CEDRXP: 5,\"1000\",\"1101\",\"0101\"";
 
 	err = parse_edrx(at_response_none, &cfg);
+	zassert_equal(0, err, "parse_edrx failed, error: %d", err);
+	zassert_equal(cfg.edrx, 0, "Wrong eDRX value");
+	zassert_equal(cfg.ptw, 0, "Wrong PTW value");
+	zassert_equal(cfg.mode, LTE_LC_LTE_MODE_NONE, "Wrong LTE mode");
+
+	err = parse_edrx(at_response_fail, &cfg);
 	zassert_not_equal(0, err, "parse_edrx should have failed");
 
 	err = parse_edrx(at_response_ltem, &cfg);


### PR DESCRIPTION
Starting from mfw v1.3.4, the modem can notify the application if the current cell does not provide eDRX.
This patch adds parsing and forwarding of such events to the application in the form of LTE_LC_EVT_EDRX_UPDATE events with network mode set to LTE_LC_LTE_MODE_NONE.

Fixes CIA-893