### PR TITLE
samples: fix conformance issues in nrf sample.yaml files

### DIFF
--- a/applications/asset_tracker_v2/sample.yaml
+++ b/applications/asset_tracker_v2/sample.yaml
@@ -61,7 +61,8 @@ tests:
     extra_configs:
       - CONFIG_AWS_IOT_BROKER_HOST_NAME="example-hostname.aws.com"
       - CONFIG_MEMFAULT_NCS_PROJECT_KEY="PROJECTKEY"
-    extra_args: OVERLAY_CONFIG="overlay-aws.conf;overlay-pgps.conf;overlay-debug.conf;overlay-memfault.conf"
+    extra_args: >
+      OVERLAY_CONFIG="overlay-aws.conf;overlay-pgps.conf;overlay-debug.conf;overlay-memfault.conf"
     tags: ci_build
   applications.asset_tracker_v2.azure:
     build_only: true
@@ -181,12 +182,16 @@ tests:
     integration_platforms:
       - nrf9160dk_nrf9160_ns
     platform_allow: nrf9160dk_nrf9160_ns
-    extra_args: SHIELD=nrf7002_ek OVERLAY_CONFIG=overlay-nrf7002ek-wifi-scan-only.conf DTC_OVERLAY_FILE="nrf9160dk_with_nrf7002ek.overlay"
+    extra_args: >
+      SHIELD=nrf7002_ek OVERLAY_CONFIG=overlay-nrf7002ek-wifi-scan-only.conf
+      DTC_OVERLAY_FILE="nrf9160dk_with_nrf7002ek.overlay"
     tags: ci_build
   applications.asset_tracker_v2.nrf7002ek_wifi-debug:
     build_only: true
     integration_platforms:
       - nrf9160dk_nrf9160_ns
     platform_allow: nrf9160dk_nrf9160_ns
-    extra_args: SHIELD=nrf7002_ek OVERLAY_CONFIG="overlay-nrf7002ek-wifi-scan-only.conf;overlay-debug.conf" DTC_OVERLAY_FILE="nrf9160dk_with_nrf7002ek.overlay"
+    extra_args: >
+      SHIELD=nrf7002_ek OVERLAY_CONFIG="overlay-nrf7002ek-wifi-scan-only.conf;overlay-debug.conf"
+      DTC_OVERLAY_FILE="nrf9160dk_with_nrf7002ek.overlay"
     tags: ci_build

--- a/applications/machine_learning/sample.yaml
+++ b/applications/machine_learning/sample.yaml
@@ -4,7 +4,9 @@ sample:
 tests:
   applications.machine_learning.zdebug:
     build_only: true
-    platform_allow: nrf52840dk_nrf52840 thingy53_nrf5340_cpuapp thingy53_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp
+    platform_allow: >
+      nrf52840dk_nrf52840 thingy53_nrf5340_cpuapp thingy53_nrf5340_cpuapp_ns
+      nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf52840dk_nrf52840
       - thingy53_nrf5340_cpuapp

--- a/applications/nrf_desktop/sample.yaml
+++ b/applications/nrf_desktop/sample.yaml
@@ -4,7 +4,10 @@ sample:
 tests:
   applications.nrf_desktop.zdebug:
     build_only: true
-    platform_allow: nrf52dmouse_nrf52832 nrf52kbd_nrf52832 nrf52810dmouse_nrf52810 nrf52820dongle_nrf52820 nrf52833dk_nrf52820 nrf52833dk_nrf52833 nrf52833dongle_nrf52833 nrf52840dk_nrf52840 nrf52840dongle_nrf52840 nrf52840gmouse_nrf52840 nrf5340dk_nrf5340_cpuapp
+    platform_allow: >
+      nrf52dmouse_nrf52832 nrf52kbd_nrf52832 nrf52810dmouse_nrf52810 nrf52820dongle_nrf52820
+      nrf52833dk_nrf52820 nrf52833dk_nrf52833 nrf52833dongle_nrf52833 nrf52840dk_nrf52840
+      nrf52840dongle_nrf52840 nrf52840gmouse_nrf52840 nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf52dmouse_nrf52832
       - nrf52kbd_nrf52832
@@ -52,7 +55,9 @@ tests:
     extra_args: CONF_FILE=prj_mcuboot_smp.conf
   applications.nrf_desktop.zdebugwithshell:
     build_only: true
-    platform_allow: nrf52kbd_nrf52832 nrf52833dk_nrf52833 nrf52833dongle_nrf52833 nrf52840dk_nrf52840 nrf52840dongle_nrf52840 nrf52840gmouse_nrf52840
+    platform_allow: >
+      nrf52kbd_nrf52832 nrf52833dk_nrf52833 nrf52833dongle_nrf52833 nrf52840dk_nrf52840
+      nrf52840dongle_nrf52840 nrf52840gmouse_nrf52840
     integration_platforms:
       - nrf52kbd_nrf52832
       - nrf52833dk_nrf52833
@@ -93,7 +98,10 @@ tests:
     extra_args: CONF_FILE=prj_keyboard.conf
   applications.nrf_desktop.zrelease:
     build_only: true
-    platform_allow: nrf52dmouse_nrf52832 nrf52kbd_nrf52832 nrf52810dmouse_nrf52810 nrf52820dongle_nrf52820 nrf52833dk_nrf52820 nrf52833dk_nrf52833 nrf52833dongle_nrf52833 nrf52840dk_nrf52840 nrf52840dongle_nrf52840 nrf52840gmouse_nrf52840 nrf5340dk_nrf5340_cpuapp
+    platform_allow: >
+      nrf52dmouse_nrf52832 nrf52kbd_nrf52832 nrf52810dmouse_nrf52810 nrf52820dongle_nrf52820
+      nrf52833dk_nrf52820 nrf52833dk_nrf52833 nrf52833dongle_nrf52833 nrf52840dk_nrf52840
+      nrf52840dongle_nrf52840 nrf52840gmouse_nrf52840 nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf52dmouse_nrf52832
       - nrf52kbd_nrf52832

--- a/samples/bluetooth/mesh/sensor_server/sample.yaml
+++ b/samples/bluetooth/mesh/sensor_server/sample.yaml
@@ -10,6 +10,7 @@ tests:
       - thingy53_nrf5340_cpuapp
       - thingy53_nrf5340_cpuapp_ns
       - nrf21540dk_nrf52840
-    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 thingy53_nrf5340_cpuapp thingy53_nrf5340_cpuapp_ns
+    platform_allow: >
+      nrf52dk_nrf52832 nrf52840dk_nrf52840 thingy53_nrf5340_cpuapp thingy53_nrf5340_cpuapp_ns
       nrf21540dk_nrf52840
     tags: bluetooth ci_build

--- a/samples/bluetooth/nrf_dm/sample.yaml
+++ b/samples/bluetooth/nrf_dm/sample.yaml
@@ -11,7 +11,8 @@ tests:
       - nrf52833dk_nrf52833
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
-    platform_allow: nrf52dk_nrf52832 nrf52833dk_nrf52833 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+    platform_allow: >
+      nrf52dk_nrf52832 nrf52833dk_nrf52833 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
     tags: bluetooth ci_build
   sample.bluetooth.nrf_dm.timeslot.high_precision:
     build_only: true

--- a/samples/bluetooth/peripheral_rscs/sample.yaml
+++ b/samples/bluetooth/peripheral_rscs/sample.yaml
@@ -10,6 +10,7 @@ tests:
       - nrf52833dk_nrf52833
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
-    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf5340dk_nrf5340_cpuapp
+    platform_allow: >
+      nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf5340dk_nrf5340_cpuapp
       nrf5340dk_nrf5340_cpuapp_ns
     tags: bluetooth ci_build

--- a/samples/caf_sensor_manager/sample.yaml
+++ b/samples/caf_sensor_manager/sample.yaml
@@ -29,14 +29,18 @@ tests:
     platform_allow: nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
-    extra_args: CONFIG_SERIAL=n CONFIG_CONSOLE=n CONFIG_UART_CONSOLE=n CONFIG_LOG=n remote_CONFIG_SERIAL=n remote_CONFIG_CONSOLE=n remote_CONFIG_UART_CONSOLE=n remote_CONFIG_LOG=n
+    extra_args: >
+      CONFIG_SERIAL=n CONFIG_CONSOLE=n CONFIG_UART_CONSOLE=n CONFIG_LOG=n remote_CONFIG_SERIAL=n
+      remote_CONFIG_CONSOLE=n remote_CONFIG_UART_CONSOLE=n remote_CONFIG_LOG=n
   sample.caf_sensor_manager.nrf5340dk_singlecore.power_consumption_test:
     build_only: true
     platform_allow: nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
-    extra_args: OVERLAY_CONFIG=boards/nrf5340dk_nrf5340_cpuapp_singlecore.conf CONFIG_SERIAL=n CONFIG_CONSOLE=n CONFIG_UART_CONSOLE=n CONFIG_LOG=n
-                DTC_OVERLAY_FILE=boards/nrf5340dk_nrf5340_cpuapp_singlecore.overlay
+    extra_args: >
+      OVERLAY_CONFIG=boards/nrf5340dk_nrf5340_cpuapp_singlecore.conf CONFIG_SERIAL=n
+      CONFIG_CONSOLE=n CONFIG_UART_CONSOLE=n CONFIG_LOG=n
+      DTC_OVERLAY_FILE=boards/nrf5340dk_nrf5340_cpuapp_singlecore.overlay
   sample.caf_sensor_manager.nrf5340dk_singlecore.correctness_test:
     build_only: false
     platform_allow: nrf5340dk_nrf5340_cpuapp

--- a/samples/crypto/aes_cbc/sample.yaml
+++ b/samples/crypto/aes_cbc/sample.yaml
@@ -1,19 +1,22 @@
 sample:
-    description: This app provides an example of performing AES encryption and
-        decryption using AES CBC mode
-    name: AES CBC example
+  description: |
+    This app provides an example of performing AES encryption and decryption
+    using AES CBC mode
+  name: AES CBC example
 tests:
-    sample.aes_cbc:
-        tags: introduction psa cc3xx
-        platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
-        harness: console
-        harness_config:
-          type: multi_line
-          regex:
-            - ".*Example finished successfully!.*"
-        integration_platforms:
-            - nrf5340dk_nrf5340_cpuapp_ns
-            - nrf5340dk_nrf5340_cpuapp
-            - nrf9160dk_nrf9160_ns
-            - nrf9160dk_nrf9160
-            - nrf52840dk_nrf52840
+  sample.aes_cbc:
+    tags: introduction psa cc3xx
+    platform_allow: >
+      nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns
+      nrf9160dk_nrf9160 nrf52840dk_nrf52840
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - ".*Example finished successfully!.*"
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp_ns
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf9160dk_nrf9160_ns
+      - nrf9160dk_nrf9160
+      - nrf52840dk_nrf52840

--- a/samples/crypto/aes_ccm/sample.yaml
+++ b/samples/crypto/aes_ccm/sample.yaml
@@ -1,19 +1,22 @@
 sample:
-    description: This app provides an example of performing AES encryption and
-        decryption using AES CCM mode
-    name: AES CCM example
+  description: |
+    This app provides an example of performing AES encryption and decryption
+    using AES CCM mode
+  name: AES CCM example
 tests:
-    sample.aes_ccm:
-        tags: introduction psa cc3xx
-        platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
-        harness: console
-        harness_config:
-          type: multi_line
-          regex:
-            - ".*Example finished successfully!.*"
-        integration_platforms:
-            - nrf5340dk_nrf5340_cpuapp_ns
-            - nrf5340dk_nrf5340_cpuapp
-            - nrf9160dk_nrf9160_ns
-            - nrf9160dk_nrf9160
-            - nrf52840dk_nrf52840
+  sample.aes_ccm:
+    tags: introduction psa cc3xx
+    platform_allow: >
+      nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp
+      nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - ".*Example finished successfully!.*"
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp_ns
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf9160dk_nrf9160_ns
+      - nrf9160dk_nrf9160
+      - nrf52840dk_nrf52840

--- a/samples/crypto/aes_ctr/sample.yaml
+++ b/samples/crypto/aes_ctr/sample.yaml
@@ -1,19 +1,22 @@
 sample:
-    description: This app provides an example of performing AES encryption and
-        decryption using AES CTR mode
-    name: AES CTR example
+  description: |
+    This app provides an example of performing AES encryption and decryption
+    using AES CTR mode
+  name: AES CTR example
 tests:
-    sample.aes_ctr:
-        tags: introduction psa cc3xx
-        platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
-        harness: console
-        harness_config:
-          type: multi_line
-          regex:
-            - ".*Example finished successfully!.*"
-        integration_platforms:
-            - nrf5340dk_nrf5340_cpuapp_ns
-            - nrf5340dk_nrf5340_cpuapp
-            - nrf9160dk_nrf9160_ns
-            - nrf9160dk_nrf9160
-            - nrf52840dk_nrf52840
+  sample.aes_ctr:
+    tags: introduction psa cc3xx
+    platform_allow: >
+      nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns
+      nrf9160dk_nrf9160 nrf52840dk_nrf52840
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - ".*Example finished successfully!.*"
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp_ns
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf9160dk_nrf9160_ns
+      - nrf9160dk_nrf9160
+      - nrf52840dk_nrf52840

--- a/samples/crypto/chachapoly/sample.yaml
+++ b/samples/crypto/chachapoly/sample.yaml
@@ -1,19 +1,22 @@
 sample:
-    description: This app provides an example of performing encryption and
-        decryption using Chacha20-Poly1305
-    name: Chacha20-Poly1305 example
+  description: |
+    This app provides an example of performing encryption and decryption using
+    Chacha20-Poly1305
+  name: Chacha20-Poly1305 example
 tests:
-    sample.chacha_poly:
-        tags: introduction psa cc3xx
-        platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
-        harness: console
-        harness_config:
-          type: multi_line
-          regex:
-            - ".*Example finished successfully!.*"
-        integration_platforms:
-            - nrf5340dk_nrf5340_cpuapp_ns
-            - nrf5340dk_nrf5340_cpuapp
-            - nrf9160dk_nrf9160_ns
-            - nrf9160dk_nrf9160
-            - nrf52840dk_nrf52840
+  sample.chacha_poly:
+    tags: introduction psa cc3xx
+    platform_allow: >
+        nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns
+        nrf9160dk_nrf9160 nrf52840dk_nrf52840
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - ".*Example finished successfully!.*"
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp_ns
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf9160dk_nrf9160_ns
+      - nrf9160dk_nrf9160
+      - nrf52840dk_nrf52840

--- a/samples/crypto/ecdh/sample.yaml
+++ b/samples/crypto/ecdh/sample.yaml
@@ -1,20 +1,22 @@
 sample:
-    description: This app provides an example of performing Elliptic-curve
-        Diffie–Hellman key echange which allows two parties to obtain a common
-        secret
-    name: ECDH example
+  description: |
+    This app provides an example of performing Elliptic-curve Diffie–Hellman
+    key echange which allows two parties to obtain a common secret
+  name: ECDH example
 tests:
-    sample.ecdh:
-        tags: introduction psa cc3xx
-        platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
-        harness: console
-        harness_config:
-          type: multi_line
-          regex:
-            - ".*Example finished successfully!.*"
-        integration_platforms:
-            - nrf5340dk_nrf5340_cpuapp_ns
-            - nrf5340dk_nrf5340_cpuapp
-            - nrf9160dk_nrf9160_ns
-            - nrf9160dk_nrf9160
-            - nrf52840dk_nrf52840
+  sample.ecdh:
+    tags: introduction psa cc3xx
+    platform_allow: >
+      nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp
+      nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - ".*Example finished successfully!.*"
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp_ns
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf9160dk_nrf9160_ns
+      - nrf9160dk_nrf9160
+      - nrf52840dk_nrf52840

--- a/samples/crypto/ecdsa/sample.yaml
+++ b/samples/crypto/ecdsa/sample.yaml
@@ -1,19 +1,21 @@
 sample:
-    description: This app provides an example of signing/verifying using ECDSA
-        signatures
-    name: ECDSA example
+  description: |
+    This app provides an example of signing/verifying using ECDSA signatures
+  name: ECDSA example
 tests:
-    sample.ecdsa:
-        tags: introduction psa cc3xx
-        platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
-        harness: console
-        harness_config:
-          type: multi_line
-          regex:
-            - ".*Example finished successfully!.*"
-        integration_platforms:
-            - nrf5340dk_nrf5340_cpuapp_ns
-            - nrf5340dk_nrf5340_cpuapp
-            - nrf9160dk_nrf9160_ns
-            - nrf9160dk_nrf9160
-            - nrf52840dk_nrf52840
+  sample.ecdsa:
+    tags: introduction psa cc3xx
+    platform_allow: >
+      nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns
+      nrf9160dk_nrf9160 nrf52840dk_nrf52840
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - ".*Example finished successfully!.*"
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp_ns
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf9160dk_nrf9160_ns
+      - nrf9160dk_nrf9160
+      - nrf52840dk_nrf52840

--- a/samples/crypto/hkdf/sample.yaml
+++ b/samples/crypto/hkdf/sample.yaml
@@ -1,18 +1,20 @@
 sample:
-    description: HMAC key derivation function example
-    name: HKDF example
+  description: HMAC key derivation function example
+  name: HKDF example
 tests:
-    sample.hkdf:
-        tags: introduction psa cc3xx
-        platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
-        harness: console
-        harness_config:
-          type: multi_line
-          regex:
-            - ".*Example finished successfully!.*"
-        integration_platforms:
-            - nrf5340dk_nrf5340_cpuapp_ns
-            - nrf5340dk_nrf5340_cpuapp
-            - nrf9160dk_nrf9160_ns
-            - nrf9160dk_nrf9160
-            - nrf52840dk_nrf52840
+  sample.hkdf:
+    tags: introduction psa cc3xx
+    platform_allow: >
+      nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns
+      nrf9160dk_nrf9160 nrf52840dk_nrf52840
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - ".*Example finished successfully!.*"
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp_ns
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf9160dk_nrf9160_ns
+      - nrf9160dk_nrf9160
+      - nrf52840dk_nrf52840

--- a/samples/crypto/hmac/sample.yaml
+++ b/samples/crypto/hmac/sample.yaml
@@ -1,20 +1,22 @@
 sample:
-    description: This app provides an example of performing HMAC signing and
-        verification using the SHA256 hashing algorithm
-        decryption using AES CBC mode
-    name: HMAC example
+  description: |
+    This app provides an example of performing HMAC signing and verification
+    using the SHA256 hashing algorithm decryption using AES CBC mode
+  name: HMAC example
 tests:
-    sample.hmac:
-        tags: introduction psa cc3xx
-        platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
-        harness: console
-        harness_config:
-          type: multi_line
-          regex:
-            - ".*Example finished successfully!.*"
-        integration_platforms:
-            - nrf5340dk_nrf5340_cpuapp_ns
-            - nrf5340dk_nrf5340_cpuapp
-            - nrf9160dk_nrf9160_ns
-            - nrf9160dk_nrf9160
-            - nrf52840dk_nrf52840
+  sample.hmac:
+    tags: introduction psa cc3xx
+    platform_allow: >
+        nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp
+        nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - ".*Example finished successfully!.*"
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp_ns
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf9160dk_nrf9160_ns
+      - nrf9160dk_nrf9160
+      - nrf52840dk_nrf52840

--- a/samples/crypto/persistent_key_usage/sample.yaml
+++ b/samples/crypto/persistent_key_usage/sample.yaml
@@ -1,20 +1,23 @@
 sample:
-    description: This app provides an example of using peristent keys with the
-        PSA APIs. A random AES persistent key is generated and imported
-        to the PSA keystore.
-    name: Persistent key example
+  description: |
+    This app provides an example of using peristent keys with the
+    PSA APIs. A random AES persistent key is generated and imported
+    to the PSA keystore.
+  name: Persistent key example
 tests:
-    sample.persistent_key_usage:
-        tags: introduction psa cc3xx
-        platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
-        harness: console
-        harness_config:
-          type: multi_line
-          regex:
-            - ".*Example finished successfully!.*"
-        integration_platforms:
-            - nrf5340dk_nrf5340_cpuapp_ns
-            - nrf5340dk_nrf5340_cpuapp
-            - nrf9160dk_nrf9160_ns
-            - nrf9160dk_nrf9160
-            - nrf52840dk_nrf52840
+  sample.persistent_key_usage:
+    tags: introduction psa cc3xx
+    platform_allow: >
+      nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns
+      nrf9160dk_nrf9160 nrf52840dk_nrf52840
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - ".*Example finished successfully!.*"
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp_ns
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf9160dk_nrf9160_ns
+      - nrf9160dk_nrf9160
+      - nrf52840dk_nrf52840

--- a/samples/crypto/psa_tls/sample.yaml
+++ b/samples/crypto/psa_tls/sample.yaml
@@ -1,6 +1,6 @@
 sample:
-  description: This app provides an example of performing TLS handshake as either
-    server or client
+  description: |
+    This app provides an example of performing TLS handshake as either server or client
   name: TLS Sample
 tests:
   ################################################################################

--- a/samples/crypto/rng/sample.yaml
+++ b/samples/crypto/rng/sample.yaml
@@ -1,18 +1,20 @@
 sample:
-    description: This app provides an example of how to produce random numbers
-    name: RNG example
+  description: This app provides an example of how to produce random numbers
+  name: RNG example
 tests:
-    sample.rng:
-        tags: introduction psa cc3xx
-        platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
-        harness: console
-        harness_config:
-          type: multi_line
-          regex:
-            - ".*Example finished successfully!.*"
-        integration_platforms:
-            - nrf5340dk_nrf5340_cpuapp_ns
-            - nrf5340dk_nrf5340_cpuapp
-            - nrf9160dk_nrf9160_ns
-            - nrf9160dk_nrf9160
-            - nrf52840dk_nrf52840
+  sample.rng:
+    tags: introduction psa cc3xx
+    platform_allow: >
+      nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp
+      nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - ".*Example finished successfully!.*"
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp_ns
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf9160dk_nrf9160_ns
+      - nrf9160dk_nrf9160
+      - nrf52840dk_nrf52840

--- a/samples/crypto/rsa/sample.yaml
+++ b/samples/crypto/rsa/sample.yaml
@@ -1,19 +1,21 @@
 sample:
-    description: This app provides an example of performing RSA signing and
-        verification
-    name: RSA example
+  description: |
+    This app provides an example of performing RSA signing and verification
+  name: RSA example
 tests:
-    sample.rsa:
-        tags: introduction psa cc3xx
-        platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
-        harness: console
-        harness_config:
-          type: multi_line
-          regex:
-            - ".*Example finished successfully!.*"
-        integration_platforms:
-            - nrf5340dk_nrf5340_cpuapp_ns
-            - nrf5340dk_nrf5340_cpuapp
-            - nrf9160dk_nrf9160_ns
-            - nrf9160dk_nrf9160
-            - nrf52840dk_nrf52840
+  sample.rsa:
+    tags: introduction psa cc3xx
+    platform_allow: >
+      nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160
+      nrf52840dk_nrf52840
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - ".*Example finished successfully!.*"
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp_ns
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf9160dk_nrf9160_ns
+      - nrf9160dk_nrf9160
+      - nrf52840dk_nrf52840

--- a/samples/crypto/sha256/sample.yaml
+++ b/samples/crypto/sha256/sample.yaml
@@ -1,34 +1,36 @@
 sample:
-    description: This app provides an example of hashing using SHA256
-    name: SHA256 example
+  description: This app provides an example of hashing using SHA256
+  name: SHA256 example
 tests:
-    sample.sha256:
-        tags: introduction psa cc3xx
-        platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
-        harness: console
-        harness_config:
-          type: multi_line
-          regex:
-            - ".*Example finished successfully!.*"
-        integration_platforms:
-            - nrf5340dk_nrf5340_cpuapp_ns
-            - nrf5340dk_nrf5340_cpuapp
-            - nrf9160dk_nrf9160_ns
-            - nrf9160dk_nrf9160
-            - nrf52840dk_nrf52840
-    # Build integration regression protection.
-    sample.nrf_security.sha256.integration:
-        build_only: True
-        extra_args: CONFIG_BOOTLOADER_MCUBOOT=y
-        platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840 nrf52833dk_nrf52833
-        integration_platforms:
-            - nrf5340dk_nrf5340_cpuapp_ns
-            - nrf52840dk_nrf52840
-            - nrf52833dk_nrf52833
-    sample.newlib_libc.sha256:
-        build_only: True
-        extra_args: CONFIG_NEWLIB_LIBC=y
-        platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840
-        integration_platforms:
-            - nrf5340dk_nrf5340_cpuapp_ns
-            - nrf52840dk_nrf52840
+  sample.sha256:
+    tags: introduction psa cc3xx
+    platform_allow: >
+      nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns
+      nrf9160dk_nrf9160 nrf52840dk_nrf52840
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - ".*Example finished successfully!.*"
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp_ns
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf9160dk_nrf9160_ns
+      - nrf9160dk_nrf9160
+      - nrf52840dk_nrf52840
+  # Build integration regression protection.
+  sample.nrf_security.sha256.integration:
+    build_only: true
+    extra_args: CONFIG_BOOTLOADER_MCUBOOT=y
+    platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840 nrf52833dk_nrf52833
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp_ns
+      - nrf52840dk_nrf52840
+      - nrf52833dk_nrf52833
+  sample.newlib_libc.sha256:
+    build_only: true
+    extra_args: CONFIG_NEWLIB_LIBC=y
+    platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp_ns
+      - nrf52840dk_nrf52840

--- a/samples/hw_id/sample.yaml
+++ b/samples/hw_id/sample.yaml
@@ -9,7 +9,8 @@ tests:
       - nrf5340dk_nrf5340_cpuapp_ns
       - nrf9160dk_nrf9160
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf9160dk_nrf9160 nrf9160dk_nrf9160_ns
+    platform_allow: >
+      nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf9160dk_nrf9160 nrf9160dk_nrf9160_ns
     tags: ci_build
   sample.hw_id.uuid:
     build_only: true
@@ -32,6 +33,7 @@ tests:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
-    platform_allow: nrf51dk_nrf51422 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns
+    platform_allow: >
+      nrf51dk_nrf51422 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns
     tags: ci_build
     extra_args: OVERLAY_CONFIG=overlay-ble-mac.conf

--- a/samples/keys/hw_unique_key/sample.yaml
+++ b/samples/keys/hw_unique_key/sample.yaml
@@ -2,20 +2,22 @@ sample:
   description: Generate and write random keys to the KMU.
   name: Random HW Unique Key
 common:
-    tags: huk
-    platform_allow: nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf9160dk_nrf9160 nrf9160dk_nrf9160_ns nrf52840dk_nrf52840 nrf21540dk_nrf52840
-    integration_platforms:
-      - nrf5340dk_nrf5340_cpuapp
-      - nrf5340dk_nrf5340_cpuapp_ns
-      - nrf9160dk_nrf9160
-      - nrf9160dk_nrf9160_ns
-      - nrf52840dk_nrf52840
-      - nrf21540dk_nrf52840
-    harness: console
-    harness_config:
-      type: multi_line
-      regex:
-        - "Ciphertext \\(with authentication tag\\):"
+  tags: huk
+  platform_allow: >
+    nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf9160dk_nrf9160
+    nrf9160dk_nrf9160_ns nrf52840dk_nrf52840 nrf21540dk_nrf52840
+  integration_platforms:
+    - nrf5340dk_nrf5340_cpuapp
+    - nrf5340dk_nrf5340_cpuapp_ns
+    - nrf9160dk_nrf9160
+    - nrf9160dk_nrf9160_ns
+    - nrf52840dk_nrf52840
+    - nrf21540dk_nrf52840
+  harness: console
+  harness_config:
+    type: multi_line
+    regex:
+      - "Ciphertext \\(with authentication tag\\):"
 tests:
   sample.keys.hw_unique_key:
     tags: huk ci_build

--- a/samples/keys/random_hw_unique_key/sample.yaml
+++ b/samples/keys/random_hw_unique_key/sample.yaml
@@ -2,26 +2,27 @@ sample:
   description: Generate and write random keys to the KMU.
   name: Random HW Unique Key
 common:
-    tags: huk
-    platform_allow: nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf21540dk_nrf52840
-    integration_platforms:
-      - nrf5340dk_nrf5340_cpuapp
-      - nrf9160dk_nrf9160
-      - nrf52840dk_nrf52840
-      - nrf21540dk_nrf52840
-    harness: console
-    harness_config:
-      type: multi_line
-      regex:
-        - "Writing random keys to KMU."
-        - "Success!"
+  tags: huk
+  platform_allow: >
+    nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf21540dk_nrf52840
+  integration_platforms:
+    - nrf5340dk_nrf5340_cpuapp
+    - nrf9160dk_nrf9160
+    - nrf52840dk_nrf52840
+    - nrf21540dk_nrf52840
+  harness: console
+  harness_config:
+    type: multi_line
+    regex:
+      - "Writing random keys to KMU."
+      - "Success!"
 tests:
   sample.keys.random_hw_unique_key:
     tags: huk ci_build
   sample.newlib_libc.random_hw_unique_key:
-        build_only: True
-        extra_args: CONFIG_NEWLIB_LIBC=y
-        platform_allow: nrf5340dk_nrf5340_cpuapp nrf52840dk_nrf52840
-        integration_platforms:
-            - nrf5340dk_nrf5340_cpuapp
-            - nrf52840dk_nrf52840
+    build_only: true
+    extra_args: CONFIG_NEWLIB_LIBC=y
+    platform_allow: nrf5340dk_nrf5340_cpuapp nrf52840dk_nrf52840
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf52840dk_nrf52840

--- a/samples/matter/light_bulb/sample.yaml
+++ b/samples/matter/light_bulb/sample.yaml
@@ -20,7 +20,8 @@ tests:
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
   sample.matter.light_bulb.ffs:
     build_only: true
-    extra_args: CONFIG_CHIP_COMMISSIONABLE_DEVICE_TYPE=y CONFIG_CHIP_ROTATING_DEVICE_ID=y
+    extra_args: >
+      CONFIG_CHIP_COMMISSIONABLE_DEVICE_TYPE=y CONFIG_CHIP_ROTATING_DEVICE_ID=y
       CONFIG_CHIP_DEVICE_TYPE=257
     integration_platforms:
       - nrf52840dk_nrf52840
@@ -31,7 +32,8 @@ tests:
     extra_args: CONF_FILE=prj_no_dfu.conf
     integration_platforms:
       - nrf21540dk_nrf52840
-    platform_allow: nrf52840dk_nrf52840 nrf21540dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+    platform_allow: >
+      nrf52840dk_nrf52840 nrf21540dk_nrf52840 nrf5340dk_nrf5340_cpuapp
       nrf7002dk_nrf5340_cpuapp
   # ---------------
   sample.matter.light_bulb.debug:

--- a/samples/matter/light_switch/sample.yaml
+++ b/samples/matter/light_switch/sample.yaml
@@ -23,9 +23,8 @@ tests:
     extra_args: CONF_FILE=prj_no_dfu.conf
     integration_platforms:
       - nrf21540dk_nrf52840
-    platform_allow: nrf52840dk_nrf52840 nrf21540dk_nrf52840 nrf5340dk_nrf5340_cpuapp
-      nrf7002dk_nrf5340_cpuapp
-  # ---------------
+    platform_allow: >
+      nrf52840dk_nrf52840 nrf21540dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
   sample.matter.light_switch.debug:
     build_only: true
     integration_platforms:

--- a/samples/matter/lock/sample.yaml
+++ b/samples/matter/lock/sample.yaml
@@ -31,8 +31,8 @@ tests:
     extra_args: CONF_FILE=prj_no_dfu.conf
     integration_platforms:
       - nrf21540dk_nrf52840
-    platform_allow: nrf52840dk_nrf52840 nrf21540dk_nrf52840 nrf5340dk_nrf5340_cpuapp
-      nrf7002dk_nrf5340_cpuapp
+    platform_allow: >
+      nrf52840dk_nrf52840 nrf21540dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
   sample.matter.lock.release.ffs:
     build_only: true
     extra_args: CONF_FILE=prj_release.conf CONFIG_CHIP_COMMISSIONABLE_DEVICE_TYPE=y
@@ -50,13 +50,13 @@ tests:
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
   sample.matter.lock.release.smp_dfu.ffs:
     build_only: true
-    extra_args: CONF_FILE=prj_release.conf CONFIG_CHIP_DFU_OVER_BT_SMP=y
-      CONFIG_CHIP_COMMISSIONABLE_DEVICE_TYPE=y CONFIG_CHIP_ROTATING_DEVICE_ID=y
-      CONFIG_CHIP_DEVICE_TYPE=10
+    extra_args: >
+      CONF_FILE=prj_release.conf CONFIG_CHIP_DFU_OVER_BT_SMP=y
+      CONFIG_CHIP_COMMISSIONABLE_DEVICE_TYPE=y
+      CONFIG_CHIP_ROTATING_DEVICE_ID=y CONFIG_CHIP_DEVICE_TYPE=10
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
-  # ---------------
   sample.matter.lock.release.nrf21540_ek:
     build_only: true
     extra_args: CONF_FILE=prj_release.conf SHIELD=nrf21540_ek
@@ -74,15 +74,16 @@ tests:
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
   sample.matter.lock.switchable_thread.nrf7002_ek:
     build_only: true
-    extra_args: SHIELD=nrf7002_ek hci_rpmsg_SHIELD=nrf7002_ek_coex
+    extra_args: >
+      SHIELD=nrf7002_ek hci_rpmsg_SHIELD=nrf7002_ek_coex
       CONF_FILE=prj_thread_wifi_switched.conf CONFIG_CHIP_WIFI=n
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
     platform_allow: nrf5340dk_nrf5340_cpuapp
   sample.matter.lock.switchable_wifi.nrf7002_ek:
     build_only: true
-    extra_args: SHIELD=nrf7002_ek hci_rpmsg_SHIELD=nrf7002_ek_coex
-      CONF_FILE=prj_thread_wifi_switched.conf
+    extra_args: >
+      SHIELD=nrf7002_ek hci_rpmsg_SHIELD=nrf7002_ek_coex CONF_FILE=prj_thread_wifi_switched.conf
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
     platform_allow: nrf5340dk_nrf5340_cpuapp

--- a/samples/matter/template/sample.yaml
+++ b/samples/matter/template/sample.yaml
@@ -16,9 +16,8 @@ tests:
     extra_args: CONF_FILE=prj_no_dfu.conf
     integration_platforms:
       - nrf21540dk_nrf52840
-    platform_allow: nrf52840dk_nrf52840 nrf21540dk_nrf52840 nrf5340dk_nrf5340_cpuapp
-      nrf7002dk_nrf5340_cpuapp
-  # ---------------
+    platform_allow: >
+      nrf52840dk_nrf52840 nrf21540dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
   sample.matter.template.debug:
     build_only: true
     integration_platforms:

--- a/samples/nrf5340/remote_shell/sample.yaml
+++ b/samples/nrf5340/remote_shell/sample.yaml
@@ -10,7 +10,8 @@ tests:
     tags: ci_build
   sample.nrf5340.remote_ipc_shell.uart.build:
     build_only: true
-    extra_args: CONF_FILE=prj_uart.conf DTC_OVERLAY_FILE=boards/nrf5340dk_nrf5340_cpuapp_uart.overlay
+    extra_args: >
+      CONF_FILE=prj_uart.conf DTC_OVERLAY_FILE=boards/nrf5340dk_nrf5340_cpuapp_uart.overlay
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
     platform_allow: nrf5340dk_nrf5340_cpuapp

--- a/samples/nrf9160/location/sample.yaml
+++ b/samples/nrf9160/location/sample.yaml
@@ -9,7 +9,8 @@ tests:
     tags: ci_build
   sample.nrf9160.location.esp_wifi:
     build_only: true
-    extra_args: OVERLAY_CONFIG=overlay-esp-wifi.conf DTC_OVERLAY_FILE="esp_8266_nrf9160ns.overlay"
+    extra_args: >
+      OVERLAY_CONFIG=overlay-esp-wifi.conf DTC_OVERLAY_FILE="esp_8266_nrf9160ns.overlay"
     integration_platforms:
       - nrf9160dk_nrf9160_ns
     platform_allow: nrf9160dk_nrf9160_ns
@@ -26,5 +27,7 @@ tests:
     integration_platforms:
       - nrf9160dk_nrf9160_ns
     platform_allow: nrf9160dk_nrf9160_ns
-    extra_args: SHIELD=nrf7002_ek OVERLAY_CONFIG=overlay-nrf7002ek-wifi-scan-only.conf DTC_OVERLAY_FILE="nrf9160dk_with_nrf7002ek.overlay"
+    extra_args: >
+      SHIELD=nrf7002_ek OVERLAY_CONFIG=overlay-nrf7002ek-wifi-scan-only.conf
+      DTC_OVERLAY_FILE="nrf9160dk_with_nrf7002ek.overlay"
     tags: ci_build

--- a/samples/openthread/cli/sample.yaml
+++ b/samples/openthread/cli/sample.yaml
@@ -4,7 +4,8 @@ sample:
 tests:
   sample.openthread.cli:
     build_only: true
-    platform_allow: nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840 nrf21540dk_nrf52840
+    platform_allow: >
+      nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840 nrf21540dk_nrf52840
     tags: ci_build
     extra_args: OVERLAY_CONFIG=overlay-ci.conf;overlay-multiprotocol.conf;overlay-tcp.conf
     integration_platforms:
@@ -21,10 +22,12 @@ tests:
       - nrf52833dk_nrf52833
   sample.openthread.cli.thread_1_1:
     build_only: true
-    platform_allow: nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840 nrf21540dk_nrf52840
+    platform_allow: >
+      nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840 nrf21540dk_nrf52840
     tags: ci_build
-    extra_args: CONFIG_OPENTHREAD_THREAD_VERSION_1_1=y
-                OVERLAY_CONFIG=overlay-ci.conf;overlay-multiprotocol.conf
+    extra_args: >
+      CONFIG_OPENTHREAD_THREAD_VERSION_1_1=y
+      OVERLAY_CONFIG=overlay-ci.conf;overlay-multiprotocol.conf
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
@@ -32,10 +35,13 @@ tests:
       - nrf21540dk_nrf52840
   sample.openthread.cli.usb:
     build_only: true
-    platform_allow: nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840 nrf52840dongle_nrf52840 nrf21540dk_nrf52840
+    platform_allow: >
+      nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840
+      nrf52840dongle_nrf52840 nrf21540dk_nrf52840
     tags: ci_build
-    extra_args: OVERLAY_CONFIG=overlay-usb.conf;overlay-ci.conf;overlay-multiprotocol.conf;overlay-tcp.conf
-                DTC_OVERLAY_FILE=usb.overlay
+    extra_args: >
+      OVERLAY_CONFIG=overlay-usb.conf;overlay-ci.conf;overlay-multiprotocol.conf;overlay-tcp.conf
+      DTC_OVERLAY_FILE=usb.overlay
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
@@ -44,7 +50,8 @@ tests:
       - nrf21540dk_nrf52840
   sample.openthread.cli.low_power:
     build_only: true
-    platform_allow: nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840 nrf21540dk_nrf52840
+    platform_allow: >
+      nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840 nrf21540dk_nrf52840
     tags: ci_build
     extra_args: OVERLAY_CONFIG=overlay-ci.conf;overlay-low_power.conf
                 DTC_OVERLAY_FILE=low_power.overlay
@@ -55,9 +62,9 @@ tests:
       - nrf21540dk_nrf52840
   # Build integration regression protection.
   sample.nrf_security.openthread.integration:
-      build_only: true
-      extra_args: CONFIG_NRF_SECURITY=y
-      platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840
-      integration_platforms:
-          - nrf5340dk_nrf5340_cpuapp_ns
-          - nrf52840dk_nrf52840
+    build_only: true
+    extra_args: CONFIG_NRF_SECURITY=y
+    platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp_ns
+      - nrf52840dk_nrf52840

--- a/samples/peripheral/radio_test/sample.yaml
+++ b/samples/peripheral/radio_test/sample.yaml
@@ -9,7 +9,8 @@ tests:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpunet
       - nrf7002dk_nrf5340_cpunet
-    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpunet nrf7002dk_nrf5340_cpunet
+    platform_allow: >
+      nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpunet nrf7002dk_nrf5340_cpunet
     tags: ci_build
   sample.peripheral.radio_test.nrf5340_nrf21540:
     build_only: true

--- a/samples/zigbee/light_bulb/sample.yaml
+++ b/samples/zigbee/light_bulb/sample.yaml
@@ -14,7 +14,9 @@ tests:
     tags: ci_build smoke
   sample.zigbee.light_bulb.with_shell:
     build_only: true
-    extra_args: CONFIG_ZIGBEE_SHELL=y CONFIG_ZIGBEE_SHELL_DEBUG_CMD=y CONFIG_ZIGBEE_LOGGER_EP=n CONFIG_ZIGBEE_SHELL_ENDPOINT=10 CONFIG_LOG_MODE_DEFERRED=y
+    extra_args: >
+      CONFIG_ZIGBEE_SHELL=y CONFIG_ZIGBEE_SHELL_DEBUG_CMD=y CONFIG_ZIGBEE_LOGGER_EP=n
+      CONFIG_ZIGBEE_SHELL_ENDPOINT=10 CONFIG_LOG_MODE_DEFERRED=y
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf52833dk_nrf52833

--- a/samples/zigbee/light_switch/sample.yaml
+++ b/samples/zigbee/light_switch/sample.yaml
@@ -49,7 +49,9 @@ tests:
     tags: ci_build
   sample.zigbee.light_switch.with_shell:
     build_only: true
-    extra_args: CONFIG_ZIGBEE_SHELL=y CONFIG_ZIGBEE_SHELL_DEBUG_CMD=y CONFIG_ZIGBEE_LOGGER_EP=n CONFIG_ZIGBEE_SHELL_ENDPOINT=1 CONFIG_LOG_MODE_DEFERRED=y
+    extra_args: >
+      CONFIG_ZIGBEE_SHELL=y CONFIG_ZIGBEE_SHELL_DEBUG_CMD=y CONFIG_ZIGBEE_LOGGER_EP=n
+      CONFIG_ZIGBEE_SHELL_ENDPOINT=1 CONFIG_LOG_MODE_DEFERRED=y
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf52833dk_nrf52833

--- a/samples/zigbee/ncp/sample.yaml
+++ b/samples/zigbee/ncp/sample.yaml
@@ -4,7 +4,8 @@ sample:
 tests:
   sample.zigbee.ncp:
     build_only: true
-    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf21540dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+    platform_allow: >
+      nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf21540dk_nrf52840 nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf52833dk_nrf52833


### PR DESCRIPTION
-Fixing compliance in sample.yamle for applications and samples for
 bluetooth, CAF, crypto, hw_id, matter, remote_shell location,
 openthread, peripheral, zigbee and nfc.
-Updated sample.yaml files to conform to the lint rules on line-length -Utilizing yaml "folding" with ">" for platform_allow and  extra_args split into multiple lines without spurious newlines added.
-Utilizing yaml "chomping" with "|" for descriptions that needed to be split up in multiple lines.
-Fix some indentation issues in psa_tls and crypto samples

Note: The only sample not touched is nrf/samples/nrf9160/modem_shell as this has more complex quoted inputs for overlays that are too long

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>