### PR TITLE
tests: fast_pair: storage: factory_reset: Exclude native_posix

### DIFF
--- a/tests/subsys/bluetooth/fast_pair/storage/factory_reset/testcase.yaml
+++ b/tests/subsys/bluetooth/fast_pair/storage/factory_reset/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   fast_pair.storage.factory_reset.default:
+    platform_exclude: native_posix
     integration_platforms:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
@@ -11,22 +12,27 @@ tests:
       - nrf52840dk_nrf52840
     extra_args: CONFIG_REBOOT=n
   fast_pair.storage.factory_reset.6keys:
+    platform_exclude: native_posix
     integration_platforms:
       - nrf52840dk_nrf52840
     extra_args: CONFIG_BT_FAST_PAIR_STORAGE_ACCOUNT_KEY_MAX=6
   fast_pair.storage.factory_reset.7keys:
+    platform_exclude: native_posix
     integration_platforms:
       - nrf52840dk_nrf52840
     extra_args: CONFIG_BT_FAST_PAIR_STORAGE_ACCOUNT_KEY_MAX=7
   fast_pair.storage.factory_reset.8keys:
+    platform_exclude: native_posix
     integration_platforms:
       - nrf52840dk_nrf52840
     extra_args: CONFIG_BT_FAST_PAIR_STORAGE_ACCOUNT_KEY_MAX=8
   fast_pair.storage.factory_reset.9keys:
+    platform_exclude: native_posix
     integration_platforms:
       - nrf52840dk_nrf52840
     extra_args: CONFIG_BT_FAST_PAIR_STORAGE_ACCOUNT_KEY_MAX=9
   fast_pair.storage.factory_reset.10keys:
+    platform_exclude: native_posix
     integration_platforms:
       - nrf52840dk_nrf52840
     extra_args: CONFIG_BT_FAST_PAIR_STORAGE_ACCOUNT_KEY_MAX=10


### PR DESCRIPTION
Only test without reboot can be run on the native_posix. Calling system reboot on native_posix leads to test failure.

Jira: NCSDK-21047