### PR TITLE
lib: pdn: only execute init hook if initialization is successful

### DIFF
--- a/lib/pdn/pdn.c
+++ b/lib/pdn/pdn.c
@@ -176,6 +176,11 @@ static void on_modem_init(int ret, void *ctx)
 	int err;
 	(void) err;
 
+	if (ret != 0) {
+		/* Return if modem initialization failed */
+		return;
+	}
+
 #if defined(CONFIG_PDN_LEGACY_PCO)
 	err = nrf_modem_at_printf("AT%%XEPCO=0");
 	if (err) {

--- a/modules/memfault-firmware-sdk/memfault_integration.c
+++ b/modules/memfault-firmware-sdk/memfault_integration.c
@@ -191,6 +191,11 @@ NRF_MODEM_LIB_ON_INIT(memfault_ncs_init_hook, on_modem_lib_init, NULL);
 
 static void on_modem_lib_init(int ret, void *ctx)
 {
+	if (ret != 0) {
+		/* Return if modem initialization failed */
+		return;
+	}
+
 	init(NULL);
 }
 


### PR DESCRIPTION
Only perfom the setup steps in libmodem init hook if libmodem's initialization was successful. The setup steps consist of AT commands that would otherwise fail and print errors.

@jtguggedal `memfault` init hook doesn't seem to check the initialization result either.
Shall I add a commit to fix that, or is there a reason why it is not checking it?