### PR TITLE
application: serial_lte_modem: Allow auto-connect for NIDD

### DIFF
--- a/applications/serial_lte_modem/doc/CARRIER_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/CARRIER_AT_commands.rst
@@ -76,6 +76,7 @@ Syntax
 
 The ``<cmd>`` command is a string, and can be used as follows:
 
+* ``AT#XCARRIER="auto_connect","read|write"[,<auto-connect-flag>]``
 * ``AT#XCARRIER="app_data"[,<data>]``
 * ``AT#XCARRIER="battery_level",<battery_level>``
 * ``AT#XCARRIER="battery_status",<battery_status>``
@@ -106,6 +107,19 @@ The response syntax depends on the commands used.
 
 Examples
 ~~~~~~~~
+
+::
+
+   AT#XCARRIER="auto_connect","read"
+   #XCARRIER: auto_connect 1
+   OK
+
+   AT#XCARRIER="auto_connect","write",0
+   OK
+
+   AT#XCARRIER="auto_connect","read"
+   #XCARRIER: auto_connect 0
+   OK
 
 ::
 

--- a/applications/serial_lte_modem/src/slm_settings.h
+++ b/applications/serial_lte_modem/src/slm_settings.h
@@ -30,6 +30,13 @@ void slm_settings_fota_init(void);
 int slm_settings_fota_save(void);
 
 /**
+ * @brief Saves the auto-connect settings to NVM.
+ *
+ * @retval 0 on success, nonzero otherwise.
+ */
+int slm_settings_auto_connect_save(void);
+
+/**
  * @brief Saves the UART settings to NVM.
  *
  * @retval 0 on success, nonzero otherwise.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -177,6 +177,8 @@ nRF9160: Serial LTE modem
   * ``#XMODEMRESET`` AT command to reset the modem while keeping the application running.
     It is expected to be used during modem firmware update, which now only requires a reset of the modem.
   * DTLS connection identifier support to the ``#XSSOCKETOPT`` and ``#XUDPCLI`` AT commands.
+  * An ``auto_connect`` operation in the ``#XCARRIER`` carrier command.
+    The operation controls automatic registration of UE to LTE network.
 
 * Updated:
 


### PR DESCRIPTION
For the use case of FOTA over NIDD with lwm2m_carrier, 
.Enable auto-connect NIDD after FOTA image is applied.
.Enable auto-connect NIDD on all kinds of reset.
.Add `AT#XCARRIER="auto-connect","read|write"[,<auto-connect-flag>]` to control YES/NO of auto-connect.

Dependence: libmodem v2.4.2

UPDATE: the solution has been expanded to support both U-bind and N-bind for LwM2M_Carrier.