### PR TITLE
manifest: Add bsim as an optional group

### DIFF
--- a/.github/workflows/license-reusable.yml
+++ b/.github/workflows/license-reusable.yml
@@ -124,7 +124,7 @@ jobs:
 
     - name: Upload results
       uses: actions/upload-artifact@v2
-      continue-on-error: True
+      continue-on-error: true
       if: always() && contains(github.event.pull_request.user.login, 'dependabot[bot]') != true
       with:
         name: licenses.xml

--- a/.github/workflows/license-reusable.yml
+++ b/.github/workflows/license-reusable.yml
@@ -95,7 +95,7 @@ jobs:
         else
             west init -m ${{ inputs.nrf_repo }} --mr ${{ inputs.nrf_rev }}
         fi
-        west update zephyr
+        west update -n zephyr bsim
         west zephyr-export
         echo "ZEPHYR_BASE=$(pwd)/zephyr" >> $GITHUB_ENV
         # debug

--- a/west.yml
+++ b/west.yml
@@ -35,13 +35,15 @@ manifest:
       url-base: https://github.com/memfault
     - name: ant-nrfconnect
       url-base: https://github.com/ant-nrfconnect
+    - name: babblesim
+      url-base: https://github.com/BabbleSim
 
   # If not otherwise specified, the projects below should be obtained
   # from the ncs remote.
   defaults:
     remote: ncs
 
-  group-filter: [-homekit, -nrf-802154, -dragoon, -find-my, -ant]
+  group-filter: [-homekit, -nrf-802154, -dragoon, -find-my, -ant, -babblesim]
 
   # "projects" is a list of git repositories which make up the NCS
   # source code.
@@ -229,6 +231,13 @@ manifest:
       remote: ant-nrfconnect
       groups:
         - ant
+    - name: bsim
+      repo-path: bsim_west
+      remote: babblesim
+      revision: 908ffde6298a937c6549dbfa843a62caab26bfc5
+      import:
+        path-prefix: tools
+
 
   # West-related configuration for the nrf repository.
   self:


### PR DESCRIPTION
As agreed today, a PR to add bsim to the sdk-nrf manifest so it can be updated ahead/independently of the Zephyr one

To facilitate developers experience, fetch the required BabbleSim components using the west manifest.
Until now, users would need fetch bsim on their own. For many years there has been a request to automate this process. This is the first step.