### PR TITLE
samples: lwm2m_client: Unlox the mutex on update event as well

### DIFF
--- a/samples/nrf9160/lwm2m_client/src/main.c
+++ b/samples/nrf9160/lwm2m_client/src/main.c
@@ -426,6 +426,7 @@ static void rd_client_event(struct lwm2m_ctx *client, enum lwm2m_rd_client_event
 
 	case LWM2M_RD_CLIENT_EVENT_REG_UPDATE:
 		LOG_DBG("Registration update started");
+		k_mutex_unlock(&lte_mutex);
 		break;
 
 	case LWM2M_RD_CLIENT_EVENT_REG_UPDATE_COMPLETE:


### PR DESCRIPTION
One RD client event seemed to bypass unlocking of LTE mutex. This causes problems when some events might be generated by shell.