### PR TITLE
manifest: mcuboot pull in swap area change

### DIFF
--- a/subsys/partition_manager/Kconfig
+++ b/subsys/partition_manager/Kconfig
@@ -45,6 +45,13 @@ config RPMSG_NRF53_SRAM_SIZE
 	  This option specifies size of the memory region to be used
 	  for the RPMsg shared memory
 
+# Workaround for not being able to have commas in macro arguments
+DT_ZEPHYR_FLASH := zephyr,flash
+DT_CHOSEN_ZEPHYR_FLASH := $(dt_chosen_path,$(DT_ZEPHYR_FLASH))
+config PM_ERASE_BLOCK_SIZE
+	hex
+	default $(dt_node_int_prop_hex,$(DT_CHOSEN_ZEPHYR_FLASH),erase-block-size)
+
 if FILE_SYSTEM_LITTLEFS
 partition=LITTLEFS
 partition-size=0x6000

--- a/west.yml
+++ b/west.yml
@@ -116,7 +116,7 @@ manifest:
           compare-by-default: false
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: c78d59dbe8ec48cfbdff9a0bfc12f25b90c73d2f
+      revision: pull/185/head
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR.git


### PR DESCRIPTION
Also add option exposing erase block size

This is needed since the preprocessing of pm.yml files is done differently from other zephyr files and its not trivial to add the required include paths to use devicetree macros im pm.yml files.

Ref: NCSDK-7203