### PR TITLE
matter: samples: alignment in configurations tags

### DIFF
--- a/samples/matter/light_bulb/sample.yaml
+++ b/samples/matter/light_bulb/sample.yaml
@@ -3,13 +3,6 @@ sample:
   name: Matter Light Bulb
 tests:
   # Excluded in quarantine.yaml to limit resources usage in integration builds
-  sample.matter.light_bulb.debug:
-    build_only: true
-    integration_platforms:
-      - nrf52840dk_nrf52840
-      - nrf5340dk_nrf5340_cpuapp
-      - nrf7002dk_nrf5340_cpuapp
-    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
   sample.matter.light_bulb.release:
     build_only: true
     extra_args: CONF_FILE=prj_release.conf
@@ -27,7 +20,8 @@ tests:
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
   sample.matter.light_bulb.ffs:
     build_only: true
-    extra_args: CONFIG_CHIP_COMMISSIONABLE_DEVICE_TYPE=y CONFIG_CHIP_ROTATING_DEVICE_ID=y CONFIG_CHIP_DEVICE_TYPE=257
+    extra_args: CONFIG_CHIP_COMMISSIONABLE_DEVICE_TYPE=y CONFIG_CHIP_ROTATING_DEVICE_ID=y
+      CONFIG_CHIP_DEVICE_TYPE=257
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
@@ -37,14 +31,15 @@ tests:
     extra_args: CONF_FILE=prj_no_dfu.conf
     integration_platforms:
       - nrf21540dk_nrf52840
-    platform_allow: nrf52840dk_nrf52840 nrf21540dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf21540dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+      nrf7002dk_nrf5340_cpuapp
   # ---------------
-  sample.matter.light_bulb.debug.nrf5340dk:
+  sample.matter.light_bulb.debug:
     build_only: true
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
-  sample.matter.light_bulb.debug.nrf7002_ek:
+  sample.matter.light_bulb.nrf7002_ek:
     build_only: true
     extra_args: SHIELD=nrf7002_ek hci_rpmsg_SHIELD=nrf7002_ek_coex
     integration_platforms:

--- a/samples/matter/light_switch/sample.yaml
+++ b/samples/matter/light_switch/sample.yaml
@@ -3,19 +3,13 @@ sample:
   name: Matter Light Switch
 tests:
   # Excluded in quarantine.yaml to limit resources usage in integration builds
-  sample.matter.light_switch.debug:
-    build_only: true
-    integration_platforms:
-      - nrf52840dk_nrf52840
-      - nrf5340dk_nrf5340_cpuapp
-    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
   sample.matter.light_switch.release:
     build_only: true
     extra_args: CONF_FILE=prj_release.conf
     integration_platforms:
-    - nrf52840dk_nrf52840
-    - nrf5340dk_nrf5340_cpuapp
-    - nrf7002dk_nrf5340_cpuapp
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf7002dk_nrf5340_cpuapp
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
   sample.matter.light_switch.smp_dfu:
     build_only: true
@@ -29,15 +23,12 @@ tests:
     extra_args: CONF_FILE=prj_no_dfu.conf
     integration_platforms:
       - nrf21540dk_nrf52840
-    platform_allow: nrf52840dk_nrf52840 nrf21540dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf21540dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+      nrf7002dk_nrf5340_cpuapp
   # ---------------
-  sample.matter.light_switch.debug.nrf5340dk:
+  sample.matter.light_switch.debug:
     build_only: true
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
-    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
-  sample.matter.light_switch.debug.nrf7002dk:
-    build_only: true
-    integration_platforms:
       - nrf7002dk_nrf5340_cpuapp
-    platform_allow: nrf7002dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp

--- a/samples/matter/lock/sample.yaml
+++ b/samples/matter/lock/sample.yaml
@@ -31,7 +31,8 @@ tests:
     extra_args: CONF_FILE=prj_no_dfu.conf
     integration_platforms:
       - nrf21540dk_nrf52840
-    platform_allow: nrf52840dk_nrf52840 nrf21540dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf21540dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+      nrf7002dk_nrf5340_cpuapp
   sample.matter.lock.release.ffs:
     build_only: true
     extra_args: CONF_FILE=prj_release.conf CONFIG_CHIP_COMMISSIONABLE_DEVICE_TYPE=y
@@ -39,7 +40,7 @@ tests:
     integration_platforms:
       - nrf52840dk_nrf52840
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
-  sample.matter.lock.debug.ffs:
+  sample.matter.lock.ffs:
     build_only: true
     extra_args: CONFIG_CHIP_COMMISSIONABLE_DEVICE_TYPE=y
       CONFIG_CHIP_ROTATING_DEVICE_ID=y CONFIG_CHIP_DEVICE_TYPE=10
@@ -47,10 +48,11 @@ tests:
       - nrf5340dk_nrf5340_cpuapp
       - nrf7002dk_nrf5340_cpuapp
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
-  sample.matter.lock.release.smp_dfu_ffs:
+  sample.matter.lock.release.smp_dfu.ffs:
     build_only: true
-    extra_args: CONF_FILE=prj_release.conf CONFIG_CHIP_DFU_OVER_BT_SMP=y CONFIG_CHIP_COMMISSIONABLE_DEVICE_TYPE=y
-      CONFIG_CHIP_ROTATING_DEVICE_ID=y CONFIG_CHIP_DEVICE_TYPE=10
+    extra_args: CONF_FILE=prj_release.conf CONFIG_CHIP_DFU_OVER_BT_SMP=y
+      CONFIG_CHIP_COMMISSIONABLE_DEVICE_TYPE=y CONFIG_CHIP_ROTATING_DEVICE_ID=y
+      CONFIG_CHIP_DEVICE_TYPE=10
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
@@ -61,7 +63,7 @@ tests:
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
-  sample.matter.lock.smp_dfu_ffs:
+  sample.matter.lock.smp_dfu.ffs:
     build_only: true
     extra_args: CONFIG_CHIP_DFU_OVER_BT_SMP=y CONFIG_CHIP_COMMISSIONABLE_DEVICE_TYPE=y
       CONFIG_CHIP_ROTATING_DEVICE_ID=y CONFIG_CHIP_DEVICE_TYPE=10
@@ -72,13 +74,15 @@ tests:
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
   sample.matter.lock.switchable_thread.nrf7002_ek:
     build_only: true
-    extra_args: SHIELD=nrf7002_ek hci_rpmsg_SHIELD=nrf7002_ek_coex CONF_FILE=prj_thread_wifi_switched.conf CONFIG_CHIP_WIFI=n
+    extra_args: SHIELD=nrf7002_ek hci_rpmsg_SHIELD=nrf7002_ek_coex
+      CONF_FILE=prj_thread_wifi_switched.conf CONFIG_CHIP_WIFI=n
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
     platform_allow: nrf5340dk_nrf5340_cpuapp
   sample.matter.lock.switchable_wifi.nrf7002_ek:
     build_only: true
-    extra_args: SHIELD=nrf7002_ek hci_rpmsg_SHIELD=nrf7002_ek_coex CONF_FILE=prj_thread_wifi_switched.conf
+    extra_args: SHIELD=nrf7002_ek hci_rpmsg_SHIELD=nrf7002_ek_coex
+      CONF_FILE=prj_thread_wifi_switched.conf
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
     platform_allow: nrf5340dk_nrf5340_cpuapp

--- a/samples/matter/template/sample.yaml
+++ b/samples/matter/template/sample.yaml
@@ -3,34 +3,25 @@ sample:
   name: Matter Template
 tests:
   # Excluded in quarantine.yaml to limit resources usage in integration builds
-  sample.matter.template.debug:
-    build_only: true
-    integration_platforms:
-      - nrf52840dk_nrf52840
-      - nrf5340dk_nrf5340_cpuapp
-    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
   sample.matter.template.release:
     build_only: true
     extra_args: CONF_FILE=prj_release.conf
     integration_platforms:
-    - nrf52840dk_nrf52840
-    - nrf5340dk_nrf5340_cpuapp
-    - nrf7002dk_nrf5340_cpuapp
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf7002dk_nrf5340_cpuapp
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
   sample.matter.template.no_dfu:
     build_only: true
     extra_args: CONF_FILE=prj_no_dfu.conf
     integration_platforms:
       - nrf21540dk_nrf52840
-    platform_allow: nrf52840dk_nrf52840 nrf21540dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf21540dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+      nrf7002dk_nrf5340_cpuapp
   # ---------------
-  sample.matter.template.debug.nrf5340dk:
+  sample.matter.template.debug:
     build_only: true
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
-    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
-  sample.matter.template.debug.nrf7002dk:
-    build_only: true
-    integration_platforms:
       - nrf7002dk_nrf5340_cpuapp
-    platform_allow: nrf7002dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp

--- a/samples/matter/window_covering/sample.yaml
+++ b/samples/matter/window_covering/sample.yaml
@@ -3,12 +3,6 @@ sample:
   name: Matter Window Covering
 tests:
   # Excluded in quarantine.yaml to limit resources usage in integration builds
-  sample.matter.window_cover.debug:
-    build_only: true
-    integration_platforms:
-      - nrf52840dk_nrf52840
-      - nrf5340dk_nrf5340_cpuapp
-    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
   sample.matter.window_cover.release:
     build_only: true
     extra_args: CONF_FILE=prj_release.conf
@@ -24,7 +18,7 @@ tests:
       - nrf5340dk_nrf5340_cpuapp
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
   # ---------------
-  sample.matter.window_cover.debug.nrf5340dk:
+  sample.matter.window_cover.debug:
     build_only: true
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp

--- a/scripts/quarantine_integration.yaml
+++ b/scripts/quarantine_integration.yaml
@@ -1,33 +1,3 @@
-# The configurations resulting as a product of scenarios and platforms
-# will be skipped if quarantine is used. More details here:
-# https://docs.zephyrproject.org/latest/guides/test/twister.html#quarantine
-# To have an empty list use:
-# - scenarios:
-#    - None
-#  platforms:
-#    - all
-
-- scenarios:
-    - sample.tfm.psa_test_crypto
-    - sample.tfm.psa_test_initial_attestation
-    - sample.tfm.psa_test_internal_trusted_storage
-    - sample.tfm.psa_test_protected_storage
-    - sample.tfm.psa_test_storage
-    - sample.tfm.regression_ipc_lvl1
-    - sample.tfm.regression_ipc_lvl2
-    - sample.tfm.regression_lib_mode
-  platforms:
-    - all
-  comment: "Disable zephyr Regression and PSA Arch tests, we maintain copies of these in sdk-nrf"
-
-- scenarios:
-    - applications.asset_tracker_v2.nrf7002ek_wifi-debug
-    - applications.asset_tracker_v2.nrf7002ek_wifi-release
-  platforms:
-    - all
-  comment: "Temporary disable till the issue is fixed"
-
-
 # Configurations excluded to limit resources usage in CI integration builds.
 # To use with "quarantine-list" twister argument.
 


### PR DESCRIPTION
- no duplicates for plain debug configuration
- required more complex quarantine file to limit builds in CI
- new quarantine file prepared to be enabled in CI

test-sdk-nrf: PR-515