### PR TITLE
applications: nrf5340_audio: fix bad frame not triggering PLC

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/le_audio_bis_headset.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_bis_headset.c
@@ -178,7 +178,7 @@ static void stream_recv_cb(struct bt_bap_stream *stream, const struct bt_iso_rec
 
 	uint32_t octets_per_sdu = bt_codec_cfg_get_octets_per_frame(stream->codec);
 
-	if (buf->len != octets_per_sdu) {
+	if (buf->len != octets_per_sdu && bad_frame != true) {
 		data_size_mismatch_cnt++;
 		if ((data_size_mismatch_cnt % 500) == 1) {
 			LOG_DBG("Data size mismatch, received: %d, codec: %d, total: %d", buf->len,

--- a/applications/nrf5340_audio/src/bluetooth/le_audio_cis_gateway.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_cis_gateway.c
@@ -577,7 +577,7 @@ static void stream_recv_cb(struct bt_bap_stream *stream, const struct bt_iso_rec
 
 	uint32_t octets_per_frame = bt_codec_cfg_get_octets_per_frame(stream->codec);
 
-	if (buf->len != octets_per_frame) {
+	if (buf->len != octets_per_frame && bad_frame != true) {
 		data_size_mismatch_cnt++;
 		if ((data_size_mismatch_cnt % 500) == 1) {
 			LOG_DBG("Data size mismatch, received: %d, codec: %d, total: %d", buf->len,

--- a/applications/nrf5340_audio/src/bluetooth/le_audio_cis_headset.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_cis_headset.c
@@ -448,7 +448,7 @@ static void stream_recv_cb(struct bt_bap_stream *stream, const struct bt_iso_rec
 
 	uint32_t octets_per_frame = bt_codec_cfg_get_octets_per_frame(stream->codec);
 
-	if (buf->len != octets_per_frame) {
+	if (buf->len != octets_per_frame && bad_frame != true) {
 		data_size_mismatch_cnt++;
 		if ((data_size_mismatch_cnt % 500) == 1) {
 			LOG_DBG("Data size mismatch, received: %d, codec: %d, total: %d", buf->len,


### PR DESCRIPTION
If the length of a frame is invalid but tagged with bad frame, this frame still needs to send to receive_cb(), since audio_datapath needs the bad_frame flag and also the timestamp.
OCT-2526