### PR TITLE
samples: nrf9160: nrf_cloud_rest_fota: Disable SPI for mcuboot

### DIFF
--- a/samples/nrf9160/nrf_cloud_rest_fota/child_image/mcuboot.conf
+++ b/samples/nrf9160/nrf_cloud_rest_fota/child_image/mcuboot.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable SPI and SPI NOR as the bootloader needs neither
+CONFIG_SPI=n
+CONFIG_SPI_NOR=n


### PR DESCRIPTION
Disables SPI and SPI NOR being included in the mcuboot build, which gives a build error due to the lack of multithreading. Neither are required for this, so explicitly disable them for the mcuboot build.