### PR TITLE
ci: docpublish: add missing docs/ prefix

### DIFF
--- a/.github/workflows/docpublish.yml
+++ b/.github/workflows/docpublish.yml
@@ -30,7 +30,7 @@ jobs:
           mkdir -p ~/.ssh && \
             ssh-keyscan -p 2222 transfer.nordicsemi.no >> ~/.ssh/known_hosts
           # upload files
-          for file in *.zip; do
+          for file in docs/*.zip; do
             echo "put ${file}" | \
               sshpass -e sftp -P 2222 -o BatchMode=no -b - $SSHUSER@transfer.nordicsemi.no
           done
@@ -41,4 +41,4 @@ jobs:
           github-token: ${{ secrets.NCS_GITHUB_TOKEN }}
           urlroot: ${{ secrets.NCS_DOC_URL_ROOT }}
           pr-prefix: "PR-"
-          pr-file: pr.txt
+          pr-file: docs/pr.txt


### PR DESCRIPTION
Artifact is extracted in docs/, add missing prefix.