### PR TITLE
manifest: Remove cryptocell usable configs and use HAS_HW instead

### DIFF
--- a/drivers/entropy/Kconfig
+++ b/drivers/entropy/Kconfig
@@ -6,7 +6,7 @@
 
 config ENTROPY_CC3XX
 	bool "Arm CC3XX RNG driver for Nordic devices"
-	depends on (CRYPTOCELL_USABLE && !BUILD_WITH_TFM)
+	depends on HAS_HW_NRF_CC3XX && !BUILD_WITH_TFM
 	depends on ENTROPY_GENERATOR
 	select ENTROPY_HAS_DRIVER
 	default y

--- a/subsys/nrf_security/Kconfig.legacy
+++ b/subsys/nrf_security/Kconfig.legacy
@@ -92,7 +92,7 @@ config MBEDTLS_CCM_ALT
 config MBEDTLS_GCM_ALT
 	bool
 	depends on CC312_BACKEND || \
-		   (PSA_CRYPTO_DRIVER_CC3XX && CRYPTOCELL_CC312_USABLE)
+		   (PSA_CRYPTO_DRIVER_CC3XX && HAS_HW_NRF_CC312)
 	default y
 
 config MBEDTLS_CHACHA20_ALT
@@ -220,12 +220,12 @@ config NRF_SECURITY_ADVANCED
 config CC310_ONLY_PSA_ENABLED
 	bool
 	default y
-	depends on CRYPTOCELL_CC310_USABLE && !PSA_CRYPTO_DRIVER_OBERON
+	depends on HAS_HW_NRF_CC310 && !PSA_CRYPTO_DRIVER_OBERON
 
 config CC312_ONLY_PSA_ENABLED
 	bool
 	default y
-	depends on CRYPTOCELL_CC312_USABLE && !PSA_CRYPTO_DRIVER_OBERON
+	depends on HAS_HW_NRF_CC312 && !PSA_CRYPTO_DRIVER_OBERON
 
 config CC310_ONLY_ENABLED
 	bool
@@ -284,7 +284,7 @@ if MBEDTLS_LEGACY_CRYPTO_C
 
 config CC310_BACKEND
 	bool
-	depends on CRYPTOCELL_CC310_USABLE && !BUILD_WITH_TFM && \
+	depends on HAS_HW_NRF_CC310 && !BUILD_WITH_TFM && \
 		   (PSA_CRYPTO_DRIVER_CC3XX || CC3XX_BACKEND)
 	default y
 	help
@@ -292,7 +292,7 @@ config CC310_BACKEND
 
 config CC312_BACKEND
 	bool
-	depends on CRYPTOCELL_CC312_USABLE && !BUILD_WITH_TFM && \
+	depends on HAS_HW_NRF_CC312 && !BUILD_WITH_TFM && \
 		   (PSA_CRYPTO_DRIVER_CC3XX || CC3XX_BACKEND)
 	default y
 	help
@@ -306,7 +306,7 @@ config OBERON_BACKEND_FORCED
 
 config CC3XX_BACKEND
 	bool
-	depends on CRYPTOCELL_USABLE && !OBERON_BACKEND_FORCED
+	depends on HAS_HW_NRF_CC3XX && !OBERON_BACKEND_FORCED
 	prompt "Configuration to enable CryptoCell CC3XX for legacy mbed TLS APIs"
 	help
 	  This configuration enables legacy mbed TLS APIs using cc3xx.
@@ -327,14 +327,14 @@ config MBEDTLS_CTR_DRBG_C
 	bool
 	prompt "PRNG using CTR_DRBG"
 	select MBEDTLS_AES_C
-	default y if !CRYPTOCELL_USABLE
+	default y if !HAS_HW_NRF_CC3XX
 	help
 	  This setting will enable CTR_DRBG APIs in mbed TLS.
 	  Corresponds to MBEDTLS_CTR_DRBG_C setting in mbed TLS config file.
 
 config MBEDTLS_CTR_DRBG_USE_128_BIT_KEY
 	bool
-	default y if CRYPTOCELL_CC310_USABLE
+	default y if HAS_HW_NRF_CC310
 	help
 	  Use 128 bit AES instead of 256 bit for CTR_DRBG.
 
@@ -355,7 +355,7 @@ config MBEDTLS_ENTROPY_C
 	bool
 	prompt "Entropy gathering"
 	depends on !MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG
-	default y if !CRYPTOCELL_USABLE
+	default y if !HAS_HW_NRF_CC3XX
 	help
 	  Enable this setting to build entropy APIs usable to gather entropy
 	  form external sources. Only in use for devices that doesn't have

--- a/subsys/nrf_security/src/drivers/Kconfig
+++ b/subsys/nrf_security/src/drivers/Kconfig
@@ -17,6 +17,7 @@ config PSA_CRYPTO_DRIVER_OBERON
 config PSA_CRYPTO_DRIVER_CC3XX
 	prompt "CryptoCell PSA driver"
 	bool
+	depends on HAS_HW_NRF_CC3XX
 	help
 	  This configuration enables the usage of CryptoCell for the supported operations.
 	  Disabling this option will result in all crypto operations being handled by
@@ -128,14 +129,12 @@ config PSA_USE_CC3XX_CTR_DRBG_DRIVER
 	bool
 	default y
 	depends on PSA_USE_CTR_DRBG_DRIVER
-	depends on CRYPTOCELL_USABLE
 	depends on BUILD_WITH_TFM || NRF_CC3XX_PLATFORM
 
 config PSA_USE_CC3XX_HMAC_DRBG_DRIVER
 	bool
 	default y
 	depends on PSA_USE_HMAC_DRBG_DRIVER
-	depends on CRYPTOCELL_USABLE
 	depends on BUILD_WITH_TFM || NRF_CC3XX_PLATFORM
 
 endmenu

--- a/subsys/nrf_security/src/legacy/CMakeLists.txt
+++ b/subsys/nrf_security/src/legacy/CMakeLists.txt
@@ -46,7 +46,7 @@ if(CONFIG_MBEDTLS_LEGACY_CRYPTO_C OR
   )
 endif()
 
-if(CONFIG_CRYPTOCELL_CC310_USABLE)
+if(CONFIG_HAS_HW_NRF_CC310)
 append_with_prefix(src_crypto_legacy ${ARM_MBEDTLS_PATH}/library
   gcm.c
 )

--- a/west.yml
+++ b/west.yml
@@ -141,7 +141,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 89d19c9b364ddd6cb54c1926649769246d1138a4
+      revision: ccf385bbdf7d8be61c3a96134f014f05fbd801d6
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Remove the configurations for cryptocell usable and use the standard HAS_HW configurations instead.