### PR TITLE
ci: update checkout/upload-artifact actions

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: ncs/nrf
           fetch-depth: 0
@@ -102,7 +102,7 @@ jobs:
 
       - name: Store
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'external') || contains(github.event.pull_request.labels.*.name, 'CI-trusted-author') }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: docs
           path: |

--- a/.github/workflows/license-reusable.yml
+++ b/.github/workflows/license-reusable.yml
@@ -49,7 +49,7 @@ jobs:
     name: Run license checks on patch series (PR)
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: ncs/${{ inputs.path }}
         ref: ${{ github.event.pull_request.head.sha }}
@@ -123,7 +123,7 @@ jobs:
             -c origin/${BASE_REF}..
 
     - name: Upload results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       continue-on-error: true
       if: always() && contains(github.event.pull_request.user.login, 'dependabot[bot]') != true
       with:

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -13,7 +13,7 @@ jobs:
     name: Manifest
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: ncs/nrf
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/oss-history.yml
+++ b/.github/workflows/oss-history.yml
@@ -7,7 +7,7 @@ jobs:
     name: Check OSS history
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: ncs/nrf
           fetch-depth: 0


### PR DESCRIPTION
Switch to v3, as v2 is using soon to be deprecated options.