### PR TITLE
samples: nrf9160: https_client: remove SOCK_NATIVE_TLS

### DIFF
--- a/samples/nrf9160/https_client/src/main.c
+++ b/samples/nrf9160/https_client/src/main.c
@@ -227,11 +227,7 @@ void main(void)
 		  INET6_ADDRSTRLEN);
 	printk("Resolved %s (%s)\n", peer_addr, net_family2str(res->ai_family));
 
-	if (IS_ENABLED(CONFIG_SAMPLE_TFM_MBEDTLS)) {
-		fd = socket(res->ai_family, SOCK_STREAM | SOCK_NATIVE_TLS, IPPROTO_TLS_1_2);
-	} else {
-		fd = socket(res->ai_family, SOCK_STREAM, IPPROTO_TLS_1_2);
-	}
+	fd = socket(res->ai_family, SOCK_STREAM, IPPROTO_TLS_1_2);
 	if (fd == -1) {
 		printk("Failed to open socket!\n");
 		goto clean_up;


### PR DESCRIPTION
Remove logical ORing of SOCK_NATIVE_TLS from socket() call when CONFIG_SAMPLE_TFM_MBEDTLS=y

This caused the connect() call to fail with 22 (EINVAL) since the merging of sdk-nrf/commit/6e303d8c