### PR TITLE
applications: nrf5340_audio: Reduce reconnect time in CIS

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/Kconfig
+++ b/applications/nrf5340_audio/src/bluetooth/Kconfig
@@ -10,7 +10,11 @@ menu "Bluetooth"
 
 config BLE_ACL_CONN_INTERVAL
 	int "Bluetooth LE ACL Connection Interval (x*1.25ms)"
-	default 80
+	default 32
+	help
+	  When the LE Audio Controller Subsystem for nRF53 is used, this
+	  interval should be a multiple of the ISO interval and maximum 4x
+	  larger than the lowest interval.
 
 config BLE_ACL_SLAVE_LATENCY
 	int "Bluetooth LE Slave Latency"
@@ -18,7 +22,7 @@ config BLE_ACL_SLAVE_LATENCY
 
 config BLE_ACL_SUP_TIMEOUT
 	int "Bluetooth LE Supervision Timeout (x*10ms)"
-	default 400
+	default 100
 
 config BLE_ACL_PER_ADV_INT_MIN
 	hex "Minimum periodic advertising interval"
@@ -39,17 +43,25 @@ config BLE_ACL_PER_ADV_INT_MAX
 config BLE_ACL_EXT_ADV_INT_MIN
 	hex "Minimum extended advertising interval"
 	range 0x0030 0x0780
+	default 0x30 if TRANSPORT_BIS
 	default 0x00A0
 	help
 	  Minimum hexadecimal value for the interval of extended advertisements.
+	  When the LE Audio Controller Subsystem for nRF53 is used, this interval
+	  should be a multiple of the ISO interval and maximum 4x larger than the
+	  lowest interval if using BIS.
 	  For ms, multiply the provided value by 0.625.
 
 config BLE_ACL_EXT_ADV_INT_MAX
 	hex "Maximum extended advertising interval"
 	range 0x0030 0x0780
+	default 0x40 if TRANSPORT_BIS
 	default 0x00F0
 	help
 	  Maximum hexadecimal value for the interval of extended advertisements.
+	  When the LE Audio Controller Subsystem for nRF53 is used, this interval
+	  should be a multiple of the ISO interval and maximum 4x larger than the
+	  lowest interval if using BIS.
 	  For ms, multiply the provided value by 0.625.
 
 choice NRF5340_AUDIO_GATEWAY_SCAN_MODE

--- a/applications/nrf5340_audio/src/bluetooth/le_audio_cis_gateway.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_cis_gateway.c
@@ -547,9 +547,19 @@ static void stream_stopped_cb(struct bt_bap_stream *stream, uint8_t reason)
 		headsets[channel_index].hci_wrn_printed = false;
 	}
 
-	if (!ep_state_check(headsets[AUDIO_CH_L].sink_stream.ep, BT_BAP_EP_STATE_STREAMING) &&
-	    !ep_state_check(headsets[AUDIO_CH_R].sink_stream.ep, BT_BAP_EP_STATE_STREAMING)) {
-		le_audio_event_publish(LE_AUDIO_EVT_NOT_STREAMING);
+	/* Check if the other stream is streaming, send event if not */
+	if (stream == &headsets[AUDIO_CH_L].sink_stream) {
+		if (!ep_state_check(headsets[AUDIO_CH_R].sink_stream.ep,
+				    BT_BAP_EP_STATE_STREAMING)) {
+			le_audio_event_publish(LE_AUDIO_EVT_NOT_STREAMING);
+		}
+	} else if (stream == &headsets[AUDIO_CH_R].sink_stream) {
+		if (!ep_state_check(headsets[AUDIO_CH_L].sink_stream.ep,
+				    BT_BAP_EP_STATE_STREAMING)) {
+			le_audio_event_publish(LE_AUDIO_EVT_NOT_STREAMING);
+		}
+	} else {
+		LOG_WRN("Unknown stream");
 	}
 }
 
@@ -557,9 +567,19 @@ static void stream_released_cb(struct bt_bap_stream *stream)
 {
 	LOG_DBG("Audio Stream %p released", (void *)stream);
 
-	if (!ep_state_check(headsets[AUDIO_CH_L].sink_stream.ep, BT_BAP_EP_STATE_STREAMING) &&
-	    !ep_state_check(headsets[AUDIO_CH_R].sink_stream.ep, BT_BAP_EP_STATE_STREAMING)) {
-		le_audio_event_publish(LE_AUDIO_EVT_NOT_STREAMING);
+	/* Check if the other stream is streaming, send event if not */
+	if (stream == &headsets[AUDIO_CH_L].sink_stream) {
+		if (!ep_state_check(headsets[AUDIO_CH_R].sink_stream.ep,
+				    BT_BAP_EP_STATE_STREAMING)) {
+			le_audio_event_publish(LE_AUDIO_EVT_NOT_STREAMING);
+		}
+	} else if (stream == &headsets[AUDIO_CH_R].sink_stream) {
+		if (!ep_state_check(headsets[AUDIO_CH_L].sink_stream.ep,
+				    BT_BAP_EP_STATE_STREAMING)) {
+			le_audio_event_publish(LE_AUDIO_EVT_NOT_STREAMING);
+		}
+	} else {
+		LOG_WRN("Unknown stream");
 	}
 }
 
@@ -756,7 +776,7 @@ static void discover_sink_cb(struct bt_conn *conn, struct bt_codec *codec, struc
 	uint8_t temp_cap_index = 0;
 
 	if (params->err == BT_ATT_ERR_ATTRIBUTE_NOT_FOUND) {
-		LOG_INF("No sinks found");
+		LOG_WRN("No sinks found");
 		return;
 	} else if (params->err) {
 		LOG_ERR("Discovery failed: %d", params->err);
@@ -879,7 +899,7 @@ static void discover_source_cb(struct bt_conn *conn, struct bt_codec *codec, str
 	uint8_t temp_cap_index = 0;
 
 	if (params->err == BT_ATT_ERR_ATTRIBUTE_NOT_FOUND) {
-		LOG_INF("No sources found");
+		LOG_WRN("No sources found");
 		return;
 	} else if (params->err) {
 		LOG_ERR("Discovery failed: %d", params->err);
@@ -1350,11 +1370,6 @@ static int iso_stream_send(uint8_t const *const data, size_t size, struct le_aud
 	int ret;
 	struct net_buf *buf;
 
-	if (!ep_state_check(headset.sink_stream.ep, BT_BAP_EP_STATE_STREAMING)) {
-		LOG_DBG("%s channel not connected", headset.ch_name);
-		return 0;
-	}
-
 	/* net_buf_alloc allocates buffers for APP->NET transfer over HCI RPMsg,
 	 * but when these buffers are released it is not guaranteed that the
 	 * data has actually been sent. The data might be queued on the NET core,
@@ -1622,19 +1637,24 @@ int le_audio_send(struct encoded_audio enc_audio)
 		}
 	}
 
-	ret = iso_stream_send(enc_audio.data, data_size_pr_stream, headsets[AUDIO_CH_L]);
-	if (ret) {
-		LOG_DBG("Failed to send data to left channel");
+	if (ep_state_check(headsets[AUDIO_CH_L].sink_stream.ep, BT_BAP_EP_STATE_STREAMING)) {
+		ret = iso_stream_send(enc_audio.data, data_size_pr_stream, headsets[AUDIO_CH_L]);
+		if (ret) {
+			LOG_DBG("Failed to send data to left channel");
+		}
 	}
 
-	if (enc_audio.num_ch == 1) {
-		ret = iso_stream_send(enc_audio.data, data_size_pr_stream, headsets[AUDIO_CH_R]);
-	} else {
-		ret = iso_stream_send(&enc_audio.data[data_size_pr_stream], data_size_pr_stream,
-				      headsets[AUDIO_CH_R]);
-	}
-	if (ret) {
-		LOG_DBG("Failed to send data to right channel");
+	if (ep_state_check(headsets[AUDIO_CH_R].sink_stream.ep, BT_BAP_EP_STATE_STREAMING)) {
+		if (enc_audio.num_ch == 1) {
+			ret = iso_stream_send(enc_audio.data, data_size_pr_stream,
+					      headsets[AUDIO_CH_R]);
+		} else {
+			ret = iso_stream_send(&enc_audio.data[data_size_pr_stream],
+					      data_size_pr_stream, headsets[AUDIO_CH_R]);
+		}
+		if (ret) {
+			LOG_DBG("Failed to send data to right channel");
+		}
 	}
 
 	return 0;

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -194,11 +194,10 @@ nRF5340 Audio
 -------------
 
 * Moved the LE Audio controller for the network core to the standalone :ref:`lib_bt_ll_acs_nrf53_readme` library.
-
 * Added Kconfig options for setting periodic and extended advertising intervals.
   Search :ref:`Kconfig Reference <kconfig-search>` for ``BLE_ACL_PER_ADV_INT_`` and ``BLE_ACL_EXT_ADV_INT_`` to list all of them.
-
 * Implemented :ref:`zephyr:zbus` for handling events from buttons and LE Audio.
+* Reduced supervision timeout to reduce reconnection times for CIS.
 
 nRF Machine Learning (Edge Impulse)
 -----------------------------------


### PR DESCRIPTION
- Reduce supervision timeout to 1 second
- Set periodic and ext adv ranges to 30-40ms for BIS
- Set ACL conn interval to 40ms
- Fix bug when getting out of range for CIS
- OCT-2243