### PR TITLE
samples: matter: Added custom handling of subscription requests

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -1008,6 +1008,34 @@ KRKNWK-6073: Potential delay during FOTA
 Matter
 ======
 
+.. rst-class:: v2-3-0
+
+KRKNWK-16728: Sleepy device may consume much power when commissioned to a commercial ecosystem
+  The controllers in the commercial ecosystem fabric establish a subscription to a Matter device's attributes.
+  The controller requests using some subscription intervals, and the Matter device may negotiate other values, but by default it just accepts the requested ones.
+  In some cases, the selected intervals can be small, and the Matter device will have to report status very often, which results in high power consumption.
+
+  **Workaround:** Implement ``OnSubscriptionRequested`` method in your application to set values of subscription report intervals that are appropriate for your use case.
+  This is an example of how your implementation could look:
+
+  .. code-block::
+
+     #include <app/ReadHandler.h>
+
+     class SubscriptionApplicationCallback : public chip::app::ReadHandler::ApplicationCallback
+     {
+        CHIP_ERROR OnSubscriptionRequested(chip::app::ReadHandler & aReadHandler,
+                                           chip::Transport::SecureSession & aSecureSession) override;
+     };
+
+     CHIP_ERROR SubscriptionApplicationCallback::OnSubscriptionRequested(chip::app::ReadHandler & aReadHandler,
+                                                          chip::Transport::SecureSession & aSecureSession)
+     {
+        /* Set the interval in seconds appropriate for your application use case, e.g. 15 seconds. */
+        uint32_t exampleMaxInterval = 15;
+        return aReadHandler.SetReportingIntervals(exampleMaxInterval);
+     }
+
 .. rst-class:: v2-3-0 v2-2-0
 
 KRKNWK-16575: Applications with factory data support do not boot up properly on nRF5340

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -111,6 +111,7 @@ The following list summarizes the most important changes inherited from the upst
   You can now use the factory data script to generate a manual pairing code and a QR Code that are required to commission a Matter-enabled device over Bluetooth LE.
   Generated onboarding codes should be put on the device's package or on the device itself.
   For details, see the Generating onboarding codes section on the :doc:`matter:nrfconnect_factory_data_configuration` page in the Matter documentation.
+* Introduced ``SLEEPY_ACTIVE_THRESHOLD`` parameter that makes the Matter sleepy device stay awake for a specified amount of time after network activity.
 
 Thread
 ------

--- a/samples/matter/common/src/icd_util.cpp
+++ b/samples/matter/common/src/icd_util.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "icd_util.h"
+
+ICDUtil ICDUtil::sICDUtil;
+
+CHIP_ERROR ICDUtil::OnSubscriptionRequested(chip::app::ReadHandler &aReadHandler,
+					    chip::Transport::SecureSession &aSecureSession)
+{
+	uint16_t agreedMaxInterval = CONFIG_CHIP_MAX_PREFERRED_SUBSCRIPTION_REPORT_INTERVAL;
+	uint16_t requestedMinInterval = 0;
+	uint16_t requestedMaxInterval = 0;
+	aReadHandler.GetReportingIntervals(requestedMinInterval, requestedMaxInterval);
+
+	if (requestedMaxInterval > agreedMaxInterval) {
+		agreedMaxInterval = requestedMaxInterval;
+	} else if (agreedMaxInterval > kSubscriptionMaxIntervalPublisherLimit) {
+		agreedMaxInterval = kSubscriptionMaxIntervalPublisherLimit;
+	}
+
+	return aReadHandler.SetReportingIntervals(agreedMaxInterval);
+}

--- a/samples/matter/common/src/icd_util.h
+++ b/samples/matter/common/src/icd_util.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#pragma once
+
+#include <app/ReadHandler.h>
+
+class ICDUtil : public chip::app::ReadHandler::ApplicationCallback {
+	CHIP_ERROR OnSubscriptionRequested(chip::app::ReadHandler &aReadHandler,
+					   chip::Transport::SecureSession &aSecureSession) override;
+
+	friend ICDUtil &GetICDUtil();
+	static ICDUtil sICDUtil;
+};
+
+inline ICDUtil &GetICDUtil()
+{
+	return ICDUtil::sICDUtil;
+}

--- a/samples/matter/light_switch/CMakeLists.txt
+++ b/samples/matter/light_switch/CMakeLists.txt
@@ -60,6 +60,10 @@ if(CONFIG_MCUMGR_TRANSPORT_BT)
     target_sources(app PRIVATE ${COMMON_ROOT}/src/dfu_over_smp.cpp)
 endif()
 
+if(CONFIG_CHIP_ICD_SUBSCRIPTION_HANDLING)
+    target_sources(app PRIVATE ${COMMON_ROOT}/src/icd_util.cpp)
+endif()
+
 chip_configure_data_model(app
     INCLUDE_SERVER
     BYPASS_IDL

--- a/samples/matter/light_switch/Kconfig
+++ b/samples/matter/light_switch/Kconfig
@@ -41,6 +41,8 @@ config NRF_WIFI_LOW_POWER
 
 endif # CHIP_WIFI
 
+config CHIP_ICD_SUBSCRIPTION_HANDLING
+	default y
 
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.features"
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.defaults"

--- a/samples/matter/light_switch/src/app_task.cpp
+++ b/samples/matter/light_switch/src/app_task.cpp
@@ -33,6 +33,10 @@
 #include "ota_util.h"
 #endif
 
+#ifdef CONFIG_CHIP_ICD_SUBSCRIPTION_HANDLING
+#include <app/InteractionModelEngine.h>
+#endif
+
 #include <dk_buttons_and_leds.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
@@ -188,6 +192,10 @@ CHIP_ERROR AppTask::Init()
 	ReturnErrorOnFailure(chip::Server::GetInstance().Init(initParams));
 	ConfigurationMgr().LogDeviceConfig();
 	PrintOnboardingCodes(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
+
+#ifdef CONFIG_CHIP_ICD_SUBSCRIPTION_HANDLING
+	chip::app::InteractionModelEngine::GetInstance()->RegisterReadHandlerAppCallback(&GetICDUtil());
+#endif
 
 	/*
 	 * Add CHIP event handler and start CHIP thread.

--- a/samples/matter/light_switch/src/app_task.h
+++ b/samples/matter/light_switch/src/app_task.h
@@ -19,6 +19,10 @@
 #include "dfu_over_smp.h"
 #endif
 
+#ifdef CONFIG_CHIP_ICD_SUBSCRIPTION_HANDLING
+#include "icd_util.h"
+#endif
+
 struct k_timer;
 struct Identify;
 

--- a/samples/matter/lock/CMakeLists.txt
+++ b/samples/matter/lock/CMakeLists.txt
@@ -71,6 +71,10 @@ if(CONFIG_THREAD_WIFI_SWITCHING)
     )
 endif()
 
+if(CONFIG_CHIP_ICD_SUBSCRIPTION_HANDLING)
+    target_sources(app PRIVATE ${COMMON_ROOT}/src/icd_util.cpp)
+endif()
+
 chip_configure_data_model(app
     INCLUDE_SERVER
     BYPASS_IDL

--- a/samples/matter/lock/Kconfig
+++ b/samples/matter/lock/Kconfig
@@ -93,6 +93,9 @@ config NRF_WIFI_LOW_POWER
 
 endif # CHIP_WIFI
 
+config CHIP_ICD_SUBSCRIPTION_HANDLING
+	default y
+
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.features"
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.defaults"
 source "Kconfig.zephyr"

--- a/samples/matter/lock/src/app_task.cpp
+++ b/samples/matter/lock/src/app_task.cpp
@@ -47,6 +47,10 @@ using chip::Shell::shell_command_t;
 #include "ota_util.h"
 #endif
 
+#ifdef CONFIG_CHIP_ICD_SUBSCRIPTION_HANDLING
+#include <app/InteractionModelEngine.h>
+#endif
+
 #include <dk_buttons_and_leds.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
@@ -54,6 +58,8 @@ using chip::Shell::shell_command_t;
 #ifdef CONFIG_THREAD_WIFI_SWITCHING
 #include <pm_config.h>
 #endif
+
+#include <app/InteractionModelEngine.h>
 
 LOG_MODULE_DECLARE(app, CONFIG_CHIP_APP_LOG_LEVEL);
 
@@ -225,6 +231,10 @@ CHIP_ERROR AppTask::Init()
 	ReturnErrorOnFailure(chip::Server::GetInstance().Init(initParams));
 	ConfigurationMgr().LogDeviceConfig();
 	PrintOnboardingCodes(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
+
+#ifdef CONFIG_CHIP_ICD_SUBSCRIPTION_HANDLING
+	chip::app::InteractionModelEngine::GetInstance()->RegisterReadHandlerAppCallback(&GetICDUtil());
+#endif
 
 	/*
 	 * Add CHIP event handler and start CHIP thread.

--- a/samples/matter/lock/src/app_task.h
+++ b/samples/matter/lock/src/app_task.h
@@ -20,6 +20,10 @@
 #include "dfu_over_smp.h"
 #endif
 
+#ifdef CONFIG_CHIP_ICD_SUBSCRIPTION_HANDLING
+#include "icd_util.h"
+#endif
+
 struct k_timer;
 struct Identify;
 
@@ -71,8 +75,8 @@ private:
 #endif
 
 #ifdef CONFIG_CHIP_NUS
-	static void NUSLockCallback(void* context);
-	static void NUSUnlockCallback(void* context);
+	static void NUSLockCallback(void *context);
+	static void NUSUnlockCallback(void *context);
 #endif
 
 #ifdef CONFIG_THREAD_WIFI_SWITCHING_CLI_SUPPORT

--- a/samples/matter/window_covering/CMakeLists.txt
+++ b/samples/matter/window_covering/CMakeLists.txt
@@ -57,6 +57,10 @@ if(CONFIG_MCUMGR_TRANSPORT_BT)
     target_sources(app PRIVATE ${COMMON_ROOT}/src/dfu_over_smp.cpp)
 endif()
 
+if(CONFIG_CHIP_ICD_SUBSCRIPTION_HANDLING)
+    target_sources(app PRIVATE ${COMMON_ROOT}/src/icd_util.cpp)
+endif()
+
 chip_configure_data_model(app
     INCLUDE_SERVER
     BYPASS_IDL

--- a/samples/matter/window_covering/Kconfig
+++ b/samples/matter/window_covering/Kconfig
@@ -19,6 +19,9 @@ config OPENTHREAD_DEFAULT_TX_POWER
 	int
 	default 0
 
+config CHIP_ICD_SUBSCRIPTION_HANDLING
+	default y
+
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.features"
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.defaults"
 source "Kconfig.zephyr"

--- a/samples/matter/window_covering/src/app_task.cpp
+++ b/samples/matter/window_covering/src/app_task.cpp
@@ -21,6 +21,10 @@
 #include "ota_util.h"
 #endif
 
+#ifdef CONFIG_CHIP_ICD_SUBSCRIPTION_HANDLING
+#include <app/InteractionModelEngine.h>
+#endif
+
 #include <dk_buttons_and_leds.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
@@ -152,6 +156,10 @@ CHIP_ERROR AppTask::Init()
 	ReturnErrorOnFailure(chip::Server::GetInstance().Init(initParams));
 	ConfigurationMgr().LogDeviceConfig();
 	PrintOnboardingCodes(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
+
+#ifdef CONFIG_CHIP_ICD_SUBSCRIPTION_HANDLING
+	chip::app::InteractionModelEngine::GetInstance()->RegisterReadHandlerAppCallback(&GetICDUtil());
+#endif
 
 	/*
 	 * Add CHIP event handler and start CHIP thread.

--- a/samples/matter/window_covering/src/app_task.h
+++ b/samples/matter/window_covering/src/app_task.h
@@ -20,6 +20,10 @@
 #include "dfu_over_smp.h"
 #endif
 
+#ifdef CONFIG_CHIP_ICD_SUBSCRIPTION_HANDLING
+#include "icd_util.h"
+#endif
+
 struct k_timer;
 struct Identify;
 

--- a/west.yml
+++ b/west.yml
@@ -139,7 +139,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: cd4fa25906f83805a105155844db5d27e8e3fe62
+      revision: 2a8f797f1f4dc2439d6c4def25db7a4698d1f339
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
* Added OnSubscriptionRequested callback example implementation to make the Matter accessory device negotiate subscription report interval instead of always accepting the requested value.
* Extend low power configuration documentation to inform how to modify subscription reports interval.