### PR TITLE
quarantine_windows: Add EBC tests

### DIFF
--- a/scripts/quarantine_windows_mac.yaml
+++ b/scripts/quarantine_windows_mac.yaml
@@ -7,20 +7,7 @@
 #  platforms:
 #    - None
 
-- scenarios:
-    - applications.asset_tracker_v2.aws
-    - applications.asset_tracker_v2.azure
-    - applications.asset_tracker_v2.cloud.cloud_codec.json_common.azure
-    - applications.asset_tracker_v2.cloud.cloud_codec.json_common.aws
-    - applications.asset_tracker_v2.debug
-    - applications.asset_tracker_v2.nrf_cloud
-    - sample.app_event_manager
-    - sample.app_event_manager_shell
-    - sample.app_event_manager_shell.native_posix
-    - sample.caf_sensor_manager.correctness_test
-    - sample.edge_impulse.wrapper
-    - sample.net.mqtt.native_posix.tls
-  platforms:
+- platforms:
     - native_posix
     - qemu_cortex_m3
     - qemu_x86
@@ -34,6 +21,9 @@
     - asset_tracker_v2.nrf_cloud_codec_test
     - asset_tracker_v2.nrf_cloud_codec_mocked_cjson_test
     - asset_tracker_v2.ui_module_test.tester
-  platforms:
-    - all
   comment: "ruby package not available in Windows toolchain"
+
+- scenarios:
+    - sample.esb.prx
+    - sample.esb.ptx
+  comment: "Cmake error for EBC tests - NCSDK-21089"


### PR DESCRIPTION
Add EBC tests to quarantine.
Rename file from quarantine_windows to quarantine_windows_mac as it is common for both platforms.

Signed-off-by: Rafal Wozniakowski <rafal.wozniakowski@nordicsemi.no>