### PR TITLE
net: lib: download_client: Add support for sec_tag list

### DIFF
--- a/applications/serial_lte_modem/src/dfu/slm_at_dfu.c
+++ b/applications/serial_lte_modem/src/dfu/slm_at_dfu.c
@@ -64,6 +64,7 @@ static uint32_t crc_32;
 static char hostname[URI_HOST_MAX];
 static char filepath[SLM_MAX_URL];
 static struct download_client dlc;
+static int sec_tag_list[1];
 static int socket_retries_left;
 static bool first_fragment;
 static uint16_t mtu;
@@ -308,13 +309,18 @@ static  int dfu_download_start(const char *host, const char *file, int sec_tag,
 	int err = -1;
 
 	struct download_client_cfg config = {
-		.sec_tag = sec_tag,
 		.frag_size_override = fragment_size,
 		.set_tls_hostname = (sec_tag != -1),
 	};
 
 	if (host == NULL || file == NULL) {
 		return -EINVAL;
+	}
+
+	if (sec_tag != -1) {
+		sec_tag_list[0] = sec_tag;
+		config.sec_tag_list = sec_tag_list;
+		config.sec_tag_count = 1;
 	}
 
 	socket_retries_left = CONFIG_SLM_DFU_SOCKET_RETRIES;

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -544,7 +544,8 @@ Libraries for networking
 
   * Refactored the :c:func:`download_client_connect` function to :c:func:`download_client_set_host` and made it non-blocking.
   * Added the :c:func:`download_client_get` function that combines the functionality of functions :c:func:`download_client_set_host`, :c:func:`download_client_start`, and :c:func:`download_client_disconnect`.
-  * Removed functions :c:func:`donwload_client_pause` and :c:func:`donwload_client_resume`.
+  * Changed configuration from one security tag to a list of security tags.
+  * Removed functions :c:func:`download_client_pause` and :c:func:`download_client_resume`.
 
 * :ref:`lib_lwm2m_location_assistance` library:
 

--- a/include/net/download_client.h
+++ b/include/net/download_client.h
@@ -92,10 +92,14 @@ struct download_client_evt {
  * @brief Download client configuration options.
  */
 struct download_client_cfg {
-	/** TLS security tag.
-	 *  Pass -1 to disable TLS.
+	/** TLS security tag list.
+	 *  Pass NULL to disable TLS.
 	 */
-	int sec_tag;
+	const int *sec_tag_list;
+	/** Number of TLS security tags in list.
+	 *  Set to 0 to disable TLS.
+	 */
+	uint8_t sec_tag_count;
 	/**
 	 * PDN ID to be used for the download.
 	 * Zero is the default PDN.

--- a/lib/bin/lwm2m_carrier/os/lwm2m_os.c
+++ b/lib/bin/lwm2m_carrier/os/lwm2m_os.c
@@ -504,13 +504,19 @@ void lwm2m_os_sms_client_deregister(int handle)
 
 static struct download_client http_downloader;
 static lwm2m_os_download_callback_t lwm2m_os_lib_callback;
+static int sec_tag_list[1];
 
 int lwm2m_os_download_connect(const char *host, const struct lwm2m_os_download_cfg *cfg)
 {
 	struct download_client_cfg config = {
-		.sec_tag = cfg->sec_tag,
 		.pdn_id = cfg->pdn_id,
 	};
+
+	if (cfg->sec_tag != -1) {
+		sec_tag_list[0] = cfg->sec_tag;
+		config.sec_tag_list = sec_tag_list;
+		config.sec_tag_count = 1;
+	}
 
 	return download_client_set_host(&http_downloader, host, &config);
 }

--- a/samples/nrf9160/download/src/main.c
+++ b/samples/nrf9160/download/src/main.c
@@ -22,15 +22,15 @@
 static const char cert[] = {
 	#include CONFIG_SAMPLE_CERT_FILE
 };
+static int sec_tag_list[] = { SEC_TAG };
 BUILD_ASSERT(sizeof(cert) < KB(4), "Certificate too large");
 #endif
 
 static struct download_client downloader;
 static struct download_client_cfg config = {
 #if CONFIG_SAMPLE_SECURE_SOCKET
-	.sec_tag = SEC_TAG,
-#else
-	.sec_tag = -1,
+	.sec_tag_list = sec_tag_list,
+	.sec_tag_count = ARRAY_SIZE(sec_tag_list),
 #endif
 };
 

--- a/subsys/net/lib/download_client/src/shell.c
+++ b/subsys/net/lib/download_client/src/shell.c
@@ -16,9 +16,10 @@ LOG_MODULE_DECLARE(download_client);
 static char host[CONFIG_DOWNLOAD_CLIENT_MAX_HOSTNAME_SIZE];
 static char file[CONFIG_DOWNLOAD_CLIENT_MAX_FILENAME_SIZE];
 
+static int sec_tag_list[1];
 static struct download_client downloader;
 static struct download_client_cfg config = {
-	.sec_tag = -1,
+	.sec_tag_list = sec_tag_list,
 };
 
 static const struct shell *shell_instance;
@@ -93,9 +94,10 @@ static int cmd_dc_config_sec_tag(const struct shell *shell, size_t argc,
 		return -EINVAL;
 	}
 
-	config.sec_tag = atoi(argv[1]);
+	sec_tag_list[0] = atoi(argv[1]);
+	config.sec_tag_count = 1;
 
-	shell_print(shell, "Security tag set: %d\n", config.sec_tag);
+	shell_print(shell, "Security tag set: %d\n", config.sec_tag_list[0]);
 	return 0;
 }
 

--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -414,10 +414,10 @@ int fota_download_start_with_image_type(const char *host, const char *file,
 	int sec_tag, uint8_t pdn_id, size_t fragment_size,
 	const enum dfu_target_image_type expected_type)
 {
+	static int sec_tag_list[1];
 	int err = -1;
 
 	struct download_client_cfg config = {
-		.sec_tag = sec_tag,
 		.pdn_id = pdn_id,
 		.frag_size_override = fragment_size,
 	};
@@ -445,6 +445,12 @@ int fota_download_start_with_image_type(const char *host, const char *file,
 
 	if (sec_tag != -1 && !is_ip_address(host)) {
 		config.set_tls_hostname = true;
+	}
+
+	if (sec_tag != -1) {
+		sec_tag_list[0] = sec_tag;
+		config.sec_tag_list = sec_tag_list;
+		config.sec_tag_count = 1;
 	}
 
 	socket_retries_left = CONFIG_FOTA_SOCKET_RETRIES;

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps_utils.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps_utils.c
@@ -47,6 +47,7 @@ static struct nrf_cloud_pgps_header saved_header;
 static K_SEM_DEFINE(dl_active, 1, 1);
 
 static struct download_client dlc;
+static int sec_tag_list[1];
 static int socket_retries_left;
 static npgps_buffer_handler_t buffer_handler;
 static npgps_eot_handler_t eot_handler;
@@ -470,11 +471,16 @@ int npgps_download_start(const char *host, const char *file, int sec_tag,
 	socket_retries_left = SOCKET_RETRIES;
 
 	struct download_client_cfg config = {
-		.sec_tag = sec_tag,
 		.pdn_id = pdn_id,
 		.frag_size_override = fragment_size,
 		.set_tls_hostname = (sec_tag != -1),
 	};
+
+	if (sec_tag != -1) {
+		sec_tag_list[0] = sec_tag;
+		config.sec_tag_list = sec_tag_list;
+		config.sec_tag_count = 1;
+	}
 
 	err = download_client_get(&dlc, host, &config, file, 0);
 	if (err != 0) {

--- a/tests/subsys/net/lib/download_client/src/main.c
+++ b/tests/subsys/net/lib/download_client/src/main.c
@@ -64,7 +64,6 @@ static bool wait_for_event(enum download_client_evt_id event, uint8_t seconds)
 }
 
 static struct download_client_cfg config = {
-	.sec_tag = -1,
 	.pdn_id = 0,
 	.frag_size_override = 0,
 };


### PR DESCRIPTION
Add support for giving a list of sec tags to the download client. This will improve the download logic when having multiple sec tags, and will reduce the number of download attempts on CA mismatch.