### PR TITLE
debug: Add ETB tracing library

### DIFF
--- a/include/debug/etb_trace.h
+++ b/include/debug/etb_trace.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef __ETB_TRACE_H
+#define __ETB_TRACE_H
+
+#include <stdint.h>
+#include <zephyr/kernel.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define ETB_BUFFER_SIZE			KB(2)
+
+/**
+ * @brief Set up debug unit and start ETB tracing.
+ *
+ */
+void etb_trace_start(void);
+
+/**
+ * @brief Stop ETB tracing.
+ *
+ */
+void etb_trace_stop(void);
+
+/**
+ * @brief Retrieve ETB trace data to buffer
+ *
+ * @param[out] buf output buffer
+ * @param[in] buf_size size of output buffer
+ * @return size_t number of bytes written
+ */
+size_t etb_data_get(volatile uint32_t *buf, size_t buf_size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __ETB_TRACE_H */

--- a/modules/memfault-firmware-sdk/CMakeLists.txt
+++ b/modules/memfault-firmware-sdk/CMakeLists.txt
@@ -26,4 +26,8 @@ zephyr_library_sources_ifdef(
         CONFIG_MEMFAULT_NCS_BT_METRICS
         memfault_bt_metrics.c)
 
+zephyr_library_sources_ifdef(
+        CONFIG_MEMFAULT_NCS_ETB_CAPTURE
+        memfault_etb_trace_capture.c)
+
 zephyr_include_directories(config)

--- a/modules/memfault-firmware-sdk/Kconfig
+++ b/modules/memfault-firmware-sdk/Kconfig
@@ -159,6 +159,14 @@ config MEMFAULT_NCS_USE_DEFAULT_METRICS
 	select MEMFAULT_METRICS_EXTRA_DEFS_FILE
 	default y if (MEMFAULT_NCS_STACK_METRICS || MEMFAULT_NCS_LTE_METRICS || MEMFAULT_NCS_BT_METRICS)
 
+config MEMFAULT_NCS_ETB_CAPTURE
+	bool "Enable ETB trace capture"
+	depends on ETB_TRACE
+	help
+	  Enable storing of the content in the Embedded Trace Buffer (ETB) on crash.
+	  This will include the content of the ETB buffer into the coredump as the global variable
+	  `etb_buf`.
+
 config MEMFAULT_NCS_INTERNAL_FLASH_BACKED_COREDUMP
 	bool "Save coredump to internal flash instead of RAM"
 	select MEMFAULT_COREDUMP_STORAGE_CUSTOM

--- a/modules/memfault-firmware-sdk/config/memfault_platform_config.h
+++ b/modules/memfault-firmware-sdk/config/memfault_platform_config.h
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifdef CONFIG_MEMFAULT_NCS_ETB_CAPTURE
+#define MEMFAULT_PLATFORM_FAULT_HANDLER_CUSTOM 1
+#endif

--- a/modules/memfault-firmware-sdk/memfault_etb_trace_capture.c
+++ b/modules/memfault-firmware-sdk/memfault_etb_trace_capture.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/types.h>
+#include <debug/etb_trace.h>
+#include <memfault/panics/platform/coredump.h>
+
+#define ETB_BUFFER_VALID_MAGIC 0xDEADBEEF
+
+static volatile uint32_t etb_buf[ETB_BUFFER_SIZE / 4];
+static volatile uint32_t etb_buf_valid;
+
+/**
+ * @brief When a fault occurs, save ETB trace data to RAM
+ *
+ * @param regs unused
+ * @param reason unused
+ */
+void memfault_platform_fault_handler(const sMfltRegState *regs, eMemfaultRebootReason reason)
+{
+	ARG_UNUSED(regs);
+	ARG_UNUSED(reason);
+
+	etb_trace_stop();
+	etb_data_get(etb_buf, ARRAY_SIZE(etb_buf));
+
+	etb_buf_valid = ETB_BUFFER_VALID_MAGIC;
+}

--- a/samples/nrf9160/memfault/overlay-etb.conf
+++ b/samples/nrf9160/memfault/overlay-etb.conf
@@ -1,0 +1,7 @@
+# ETB tracing
+CONFIG_ETB_TRACE=y
+CONFIG_ETB_TRACE_PM=y
+CONFIG_MEMFAULT_NCS_ETB_CAPTURE=y
+# Reduce logging to avoid filling up ETB with data not related to the crash
+CONFIG_FAULT_DUMP=0
+CONFIG_KERNEL_LOG_LEVEL_OFF=y

--- a/samples/nrf9160/memfault/sample.yaml
+++ b/samples/nrf9160/memfault/sample.yaml
@@ -10,3 +10,13 @@ tests:
       - thingy91_nrf9160_ns
     platform_allow: nrf9160dk_nrf9160_ns thingy91_nrf9160_ns
     tags: ci_build
+  sample.nrf9160.memfault.etb:
+    build_only: true
+    extra_configs:
+      - CONFIG_MEMFAULT_NCS_PROJECT_KEY="dummy-key"
+    extra_args: OVERLAY_CONFIG=overlay-etb.conf
+    integration_platforms:
+      - nrf9160dk_nrf9160_ns
+      - thingy91_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns thingy91_nrf9160_ns
+    tags: ci_build

--- a/subsys/debug/CMakeLists.txt
+++ b/subsys/debug/CMakeLists.txt
@@ -4,6 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-
-add_subdirectory_ifdef(CONFIG_PPI_TRACE		ppi_trace)
 add_subdirectory_ifdef(CONFIG_CPU_LOAD		cpu_load)
+add_subdirectory_ifdef(CONFIG_ETB_TRACE		etb_trace)
+add_subdirectory_ifdef(CONFIG_PPI_TRACE		ppi_trace)

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -6,7 +6,8 @@
 
 menu "Debug"
 
-rsource "ppi_trace/Kconfig"
 rsource "cpu_load/Kconfig"
+rsource "etb_trace/Kconfig"
+rsource "ppi_trace/Kconfig"
 
 endmenu

--- a/subsys/debug/etb_trace/CMakeLists.txt
+++ b/subsys/debug/etb_trace/CMakeLists.txt
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+zephyr_sources(etb_trace.c)
+zephyr_sources_ifdef(CONFIG_ETB_TRACE_PM etb_trace_pm.c)

--- a/subsys/debug/etb_trace/Kconfig
+++ b/subsys/debug/etb_trace/Kconfig
@@ -1,0 +1,35 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config ETB_TRACE
+	bool "Enable ETB trace"
+	help
+	  Enable tracing using Coresight modules such as ETM, ITM and store them to ETB.
+
+if ETB_TRACE
+
+config ETB_TRACE_SYS_INIT
+	bool "Initialize automatically"
+	default y
+
+config ETB_TRACE_PM
+	bool "Power management"
+	select ARM_ON_ENTER_CPU_IDLE_HOOK
+	help
+	  Tracing requires the debug system in the SoC to be enabled, which increases overall
+	  power consumption by several mA.
+	  Enabling this option will reduce the power consumption by disabling tracing when the
+	  CPU is about to go to idle for an expected period longer than
+	  CONFIG_ETB_TRACE_PM_MIN_IDLE_TIME_MS.
+	  Enabling this option will introduce latency to the system, as it will run code both
+	  when entering and exiting idle, including when entering ISRs.
+
+config ETB_TRACE_PM_MIN_IDLE_TIME_MS
+	int "Minimum idle time"
+	default 1000
+	depends on ETB_TRACE_PM
+
+endif # ETB_TRACE

--- a/subsys/debug/etb_trace/etb_trace.c
+++ b/subsys/debug/etb_trace/etb_trace.c
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
+#include <debug/etb_trace.h>
+
+#define LAR_OFFSET			0xFB0
+#define LSR_OFFSET			0xFB4
+#define CS_UNLOCK_KEY			0xC5ACCE55
+#define CS_LOCK_KEY			0x00000000
+
+#define ETB_BASE_ADDR			0xE0051000
+#define ETB_RDP				(ETB_BASE_ADDR + 0x004)
+#define ETB_STS				(ETB_BASE_ADDR + 0x00C)
+#define ETB_RRD				(ETB_BASE_ADDR + 0x010)
+#define ETB_RRP				(ETB_BASE_ADDR + 0x014)
+#define ETB_RWP				(ETB_BASE_ADDR + 0x018)
+#define ETB_TRG				(ETB_BASE_ADDR + 0x01C)
+#define ETB_CTL				(ETB_BASE_ADDR + 0x020)
+#define ETB_RWD				(ETB_BASE_ADDR + 0x024)
+#define ETB_FFSR			(ETB_BASE_ADDR + 0x300)
+#define ETB_FFCR			(ETB_BASE_ADDR + 0x304)
+#define ETB_LAR				(ETB_BASE_ADDR + ETB_OFFSET)
+
+#define ATB_1_BASE_ADDR			0xE005A000
+#define ATB_1_CTL			(ATB_1_BASE_ADDR + 0x000)
+#define ATB_1_PRIO			(ATB_1_BASE_ADDR + 0x004)
+
+#define ATB_2_BASE_ADDR			0xE005B000
+#define ATB_2_CTL			(ATB_2_BASE_ADDR + 0x000)
+#define ATB_2_PRIO			(ATB_2_BASE_ADDR + 0x004)
+
+#define ATB_REPLICATOR_BASE_ADDR	0xE0058000
+#define ATB_REPLICATOR_IDFILTER0	(ATB_REPLICATOR_BASE_ADDR + 0x000)
+#define ATB_REPLICATOR_IDFILTER1	(ATB_REPLICATOR_BASE_ADDR + 0x004)
+
+#define ETM_BASE_ADDR			0xE0041000
+#define ETM_TRCPRGCTLR			(ETM_BASE_ADDR + 0x004) /* Programming Control Register */
+#define ETM_TRCSTATR			(ETM_BASE_ADDR + 0x00C) /* Status Register */
+#define ETM_TRCCONFIGR			(ETM_BASE_ADDR + 0x010) /* Trace Configuration Register */
+#define ETM_TRCCCCTLR			(ETM_BASE_ADDR + 0x038) /* Cycle Count Control Register */
+#define ETM_TRCSTALLCTLR		(ETM_BASE_ADDR + 0x02C) /* Stall Control Register */
+#define ETM_TRCTSCTLR			(ETM_BASE_ADDR + 0x030) /* Timestamp Control Register */
+#define ETM_TRCTRACEIDR			(ETM_BASE_ADDR + 0x040) /* Trace ID Register */
+#define ETM_TRCVICTLR			(ETM_BASE_ADDR + 0x080) /* ViewInst Main Control Register */
+#define ETM_TRCEVENTCTL0R		(ETM_BASE_ADDR + 0x020) /* Event Control 0 Register */
+#define ETM_TRCEVENTCTL1R		(ETM_BASE_ADDR + 0x024) /* Event Control 1 Register */
+#define ETM_TRCPDSR			(ETM_BASE_ADDR + 0x314) /* Power down status register */
+
+#define ITM_BASE_ADDR			0xE0000000
+#define ITM_TER				(ITM_BASE_ADDR + 0xE00) /* Trace Enable Register */
+#define ITM_TCR				(ITM_BASE_ADDR + 0xE80) /* Trace Control Register */
+
+#define DWT_BASE_ADDR			0xE0001000
+#define DWT_CCYCCNT			(DWT_BASE_ADDR + 0x004) /* Cycle Count Register */
+
+#define TIMESTAMP_GENERATOR_BASE_ADDR	0xE0053000
+#define TIMESTAMP_GENERATOR_CNCTR	(TIMESTAMP_GENERATOR_BASE_ADDR + 0x000)
+
+#define SET_REG(reg, value)	*((volatile uint32_t *)(reg)) = value
+#define GET_REG(reg)		*((volatile uint32_t *)(reg))
+#define CS_UNLOCK(reg_base)	*((volatile uint32_t *)(reg_base + LAR_OFFSET)) = CS_UNLOCK_KEY
+#define CS_LOCK(reg_base)	*((volatile uint32_t *)(reg_base + LAR_OFFSET)) = CS_LOCK_KEY
+
+/* Declaring as static variables to make them appear with the correct value in ELF file
+ * for simplified trace processing.
+ */
+
+/* Bit 3: Branch broadcast mode enabled. */
+static volatile uint32_t etm_trcconfigr = BIT(3);
+/* Set trace ID to 0x10  */
+static volatile uint32_t etm_trctraceidr = 0x10;
+
+static void etm_init(void)
+{
+	/* Disable ETM to allow configuration */
+	SET_REG(ETM_TRCPRGCTLR, 0);
+
+	/* Wait until ETM is idle and PM is stable */
+	while ((GET_REG(ETM_TRCSTATR) & (BIT(1) | BIT(0))) != (BIT(1) | BIT(0))) {
+	}
+
+	/* Configure the ETM */
+	SET_REG(ETM_TRCCONFIGR, etm_trcconfigr);
+
+	/* The trace unit can not stall the processor for instruction traces, at the risk of
+	 * losing traces.
+	 */
+	SET_REG(ETM_TRCSTALLCTLR, 0);
+
+	/* Global Timestamp Control Register to zero, no stamps included in the trace.  */
+	SET_REG(ETM_TRCTSCTLR, 0);
+
+	/* Set the trace stream ID */
+	SET_REG(ETM_TRCTRACEIDR, etm_trctraceidr);
+
+	/* Bit 0: Enable event 0.
+	 * Bit 9: Indicates the current status of the start/stop logic.
+	 * Bit 10: Always trace reset exceptions.
+	 * Bit 11: Always trace system error exceptions.
+	 */
+	SET_REG(ETM_TRCVICTLR, BIT(11) | BIT(10) | BIT(9) | BIT(0));
+
+	/* No events are configured */
+	SET_REG(ETM_TRCEVENTCTL0R, 0);
+	SET_REG(ETM_TRCEVENTCTL1R, 0);
+
+	/* Enable ETM */
+	SET_REG(ETM_TRCPRGCTLR, BIT(0));
+}
+
+static void etm_stop(void)
+{
+	/* Disable ETM */
+	SET_REG(ETM_TRCPRGCTLR, 0);
+}
+
+static void atb_init(void)
+{
+	/* ATB replicator */
+	CS_UNLOCK(ATB_REPLICATOR_BASE_ADDR);
+
+	/* ID filter for master port 0 */
+	SET_REG(ATB_REPLICATOR_IDFILTER0, 0xFFFFFFFFUL);
+	/* ID filter for master port 1, allowing ETM traces from CM33 to ETB */
+	SET_REG(ATB_REPLICATOR_IDFILTER1, 0xFFFFFFFDUL);
+
+	CS_LOCK(ATB_REPLICATOR_BASE_ADDR);
+
+	/* ATB funnel 1 */
+	CS_UNLOCK(ATB_1_BASE_ADDR);
+
+	/* Set pririty 1 for ports 0 and 1 */
+	SET_REG(ATB_1_PRIO, 0x00000009UL);
+
+	/* Enable port 0 and 1, and set hold time to 4 transactions */
+	SET_REG(ATB_1_CTL, 0x00000303UL);
+
+	CS_LOCK(ATB_1_BASE_ADDR);
+
+	/* ATB funnel 2 */
+	CS_UNLOCK(ATB_2_BASE_ADDR);
+
+	/* Set priority 3 for port 3 */
+	SET_REG(ATB_2_PRIO, 0x00003000UL);
+
+	/* Enable ETM traces on port 3, and set hold time to 4 transactions */
+	SET_REG(ATB_2_CTL,  0x00000308UL);
+
+	CS_LOCK(ATB_2_BASE_ADDR);
+}
+
+static void etb_init(void)
+{
+	CS_UNLOCK(ETB_BASE_ADDR);
+
+	/* Disable ETB */
+	SET_REG(ETB_CTL, 0);
+
+	/* Wait for formatter to stop */
+	while ((GET_REG(ETB_FFSR) & BIT(1)) == 0) {
+	}
+
+	/* Enable formatter in continuous mode */
+	SET_REG(ETB_FFCR, BIT(1) | BIT(0));
+
+	/* Enable ETB */
+	SET_REG(ETB_CTL, 0x1);
+
+	while ((GET_REG(ETB_FFSR) & BIT(1)) != 0) {
+	}
+
+	CS_LOCK(ETB_BASE_ADDR);
+}
+
+static void etb_stop(void)
+{
+	CS_UNLOCK(ETB_BASE_ADDR);
+
+	/* Disable ETB */
+	SET_REG(ETB_CTL, 0);
+
+	/* Wait for formatter to stop */
+	while (GET_REG(ETB_FFSR) & BIT(0)) {
+	}
+
+	CS_LOCK(ETB_BASE_ADDR);
+}
+
+static void debug_init(void)
+{
+	NRF_TAD_S->TASKS_CLOCKSTART = TAD_TASKS_CLOCKSTART_TASKS_CLOCKSTART_Msk;
+}
+
+void etb_trace_start(void)
+{
+	debug_init();
+	atb_init();
+	etb_init();
+	etm_init();
+}
+
+void etb_trace_stop(void)
+{
+	etm_stop();
+	etb_stop();
+}
+
+size_t etb_data_get(volatile uint32_t *buf, size_t buf_size)
+{
+	size_t i = 0;
+
+	if (buf_size == 0) {
+		return 0;
+	}
+
+	CS_UNLOCK(ETB_BASE_ADDR);
+
+	/* Set read pointer to the last write pointer */
+	SET_REG(ETB_RRP, GET_REG(ETB_RWP));
+
+	for (; i < buf_size; i++) {
+		buf[i] = GET_REG(ETB_RRD);
+	}
+
+	CS_LOCK(ETB_BASE_ADDR);
+
+	return i + 1;
+}
+
+#if defined(CONFIG_ETB_TRACE_SYS_INIT)
+static int init(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	etb_trace_start();
+
+	return 0;
+}
+
+SYS_INIT(init, EARLY, 0);
+#endif /* defined (CONFIG_ETB_TRACE_SYS_INIT) */

--- a/subsys/debug/etb_trace/etb_trace_pm.c
+++ b/subsys/debug/etb_trace/etb_trace_pm.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/wait_q.h>
+#include <debug/etb_trace.h>
+
+/* Flag to signal that we suspect a long enough sleep duration to justify turning off tracing. */
+static bool trace_stopped;
+
+/**
+ * @brief Resume tracing on wakeup if it was stopped previously.
+ *
+ */
+void sys_clock_idle_exit(void)
+{
+	if (trace_stopped) {
+		etb_trace_start();
+
+		trace_stopped = false;
+	}
+}
+
+/**
+ * @brief Turn off debug unit and tracing if going to sleep for a long period of time.
+ *
+ * @return always true to allow going to idle
+ */
+bool z_arm_on_enter_cpu_idle(void)
+{
+	if (_kernel.idle > k_ms_to_ticks_ceil32(CONFIG_ETB_TRACE_PM_MIN_IDLE_TIME_MS)) {
+		etb_trace_stop();
+		NRF_TAD_S->TASKS_CLOCKSTOP = TAD_TASKS_CLOCKSTOP_TASKS_CLOCKSTOP_Msk;
+		trace_stopped = true;
+	}
+
+	return true;
+}


### PR DESCRIPTION
Add library to capture instruction traces and store them to the Embedded Trace Buffer. This also enables adding the buffer's contents to Memfault coredumps. Since ETB tracing is using lots of power, there is also a feature to turn off tracing while sleeping.

This is mostly @jtguggedal 's work.