### PR TITLE
tests: nrfx_integration_test: Update and migrate to new Ztest API

### DIFF
--- a/tests/drivers/nrfx_integration_test/prj.conf
+++ b/tests/drivers/nrfx_integration_test/prj.conf
@@ -5,6 +5,7 @@
 #
 
 CONFIG_ZTEST=y
+CONFIG_ZTEST_NEW_API=y
 CONFIG_ASSERT=y
 # Prevent compilation of Zephyr I2C and SPI driver shims (enabling of the nrfx
 # Kconfig options would cause them to be compiled, even though the corresponding

--- a/tests/drivers/nrfx_integration_test/src/main.c
+++ b/tests/drivers/nrfx_integration_test/src/main.c
@@ -15,7 +15,7 @@
 
 NRFX_STATIC_ASSERT(true);
 
-static void test_build(void)
+ZTEST(test_nrfx_integration, test_build)
 {
 	IRQn_Type dummy_irq_number = (IRQn_Type)0;
 	nrfx_atomic_t dummy_atomic_object;
@@ -50,11 +50,4 @@ static void test_build(void)
 			 NRFX_EGUS_USED | NRFX_TIMERS_USED;
 }
 
-void test_main(void)
-{
-	ztest_test_suite(test_nrfx_integration,
-		ztest_unit_test(test_build)
-	);
-
-	ztest_run_test_suite(test_nrfx_integration);
-}
+ZTEST_SUITE(test_nrfx_integration, NULL, NULL, NULL, NULL, NULL);

--- a/tests/drivers/nrfx_integration_test/src/main.c
+++ b/tests/drivers/nrfx_integration_test/src/main.c
@@ -20,6 +20,7 @@ ZTEST(test_nrfx_integration, test_build)
 	IRQn_Type dummy_irq_number = (IRQn_Type)0;
 	nrfx_atomic_t dummy_atomic_object;
 	volatile uint32_t used_resources;
+	volatile uint32_t test_val;
 
 	NRFX_ASSERT(true);
 
@@ -44,9 +45,14 @@ ZTEST(test_nrfx_integration, test_build)
 	NRFX_ATOMIC_FETCH_XOR(&dummy_atomic_object, 0);
 	NRFX_ATOMIC_FETCH_ADD(&dummy_atomic_object, 0);
 	NRFX_ATOMIC_FETCH_SUB(&dummy_atomic_object, 0);
+	NRFX_ATOMIC_CAS(&dummy_atomic_object, 0, 1);
+
+	test_val = NRFX_CLZ(1);
+	test_val = NRFX_CTZ(1);
 
 	used_resources = NRFX_DPPI_CHANNELS_USED | NRFX_DPPI_GROUPS_USED |
 			 NRFX_PPI_CHANNELS_USED | NRFX_PPI_GROUPS_USED |
+			 NRFX_GPIOTE_CHANNELS_USED |
 			 NRFX_EGUS_USED | NRFX_TIMERS_USED;
 }
 


### PR DESCRIPTION
- Migrate the test to the new Ztest API
- Add checks for new definitions that were introduced in nrfx_glue.h