### PR TITLE
drivers: wifi: Maximum TX packets aggregattion 12

### DIFF
--- a/drivers/wifi/nrf700x/Kconfig.nrf700x
+++ b/drivers/wifi/nrf700x/Kconfig.nrf700x
@@ -123,7 +123,7 @@ config NRF700X_RX_NUM_BUFS
 
 config NRF700X_MAX_TX_AGGREGATION
 	int "Maximum number of TX packets to aggregate"
-	default 15
+	default 12
 
 config NRF700X_MAX_TX_TOKENS
 	int "Maximum number of TX tokens"


### PR DESCRIPTION
[CAL-2905] Maximum number of aggregation frames set to 12 for hardware limitation.

@udaynordic