### PR TITLE
doc: AES GCM issue with CryptoCell

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -2256,6 +2256,11 @@ nrfxlib
 Crypto
 ======
 
+.. rst-class:: v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0
+
+NCSDK-20287: Using AES GCM with other nonce sizes than 12 bytes will produce an incorrect tag on CryptoCell
+  Both PSA Crypto and legacy Mbed TLS APIs are affected.
+
 .. rst-class:: v2-0-2 v2-0-1 v2-0-0
 
 NCSDK-15697: ECDH key generation for Curve25519 is failing with the legacy Mbed TLS APIs for CryptoCell


### PR DESCRIPTION
Add known issue NCSDK-20287: For AES-GCM, nonce sizes other than 12 bytes not supported.