### PR TITLE
doc: Move MQTT sample to net folder

### DIFF
--- a/doc/nrf/samples.rst
+++ b/doc/nrf/samples.rst
@@ -27,6 +27,7 @@ Those samples are a good starting point for understanding how to put together yo
    samples/edge
    samples/gazell
    samples/matter
+   samples/multicore
    samples/net
    samples/nfc
    samples/nrf5340
@@ -36,4 +37,3 @@ Those samples are a good starting point for understanding how to put together yo
    samples/zigbee
    samples/wifi
    samples/other
-   samples/multicore

--- a/doc/nrf/samples.rst
+++ b/doc/nrf/samples.rst
@@ -27,6 +27,7 @@ Those samples are a good starting point for understanding how to put together yo
    samples/edge
    samples/gazell
    samples/matter
+   samples/net
    samples/nfc
    samples/nrf5340
    samples/nrf9160

--- a/doc/nrf/samples/net.rst
+++ b/doc/nrf/samples/net.rst
@@ -1,0 +1,11 @@
+.. _networking_samples:
+
+Networking samples
+##################
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Subpages
+   :glob:
+
+    ../../../samples/net/*/README

--- a/doc/nrf/samples/nrf9160.rst
+++ b/doc/nrf/samples/nrf9160.rst
@@ -9,5 +9,4 @@ nRF9160 samples
    :glob:
 
    ../../../samples/nrf9160/*/README
-   ../../../samples/net/*/README
    ../../../samples/nrf9160/http_update/*/README

--- a/doc/nrf/samples/wifi.rst
+++ b/doc/nrf/samples/wifi.rst
@@ -9,4 +9,3 @@ Wi-Fi samples
    :glob:
 
    ../../../samples/wifi/*/README
-    ../../../samples/net/*/README


### PR DESCRIPTION
The MQTT sample is moved to networking folder
NCSDK-21055