### PR TITLE
samples: matter: Fixed build failure for DFU over BT SMP.

### DIFF
--- a/samples/matter/common/src/ota_util.cpp
+++ b/samples/matter/common/src/ota_util.cpp
@@ -5,7 +5,6 @@
  */
 
 #include "ota_util.h"
-#include "ota_image_processor_base_impl.h"
 
 #if CONFIG_CHIP_OTA_REQUESTOR
 #include <app/clusters/ota-requestor/BDXDownloader.h>

--- a/samples/matter/common/src/ota_util.h
+++ b/samples/matter/common/src/ota_util.h
@@ -9,6 +9,7 @@
 #include <platform/nrfconnect/ExternalFlashManager.h>
 
 #if CONFIG_CHIP_OTA_REQUESTOR
+#include "ota_image_processor_base_impl.h"
 #include <platform/nrfconnect/OTAImageProcessorImpl.h>
 
 /**

--- a/samples/matter/lock/Kconfig
+++ b/samples/matter/lock/Kconfig
@@ -30,6 +30,7 @@ config THREAD_WIFI_SWITCHING
 	bool "Switching between Thread and Wi-Fi network support"
 	depends on SOC_SERIES_NRF53X
 	depends on NET_L2_OPENTHREAD || CHIP_WIFI
+	depends on CHIP_OTA_REQUESTOR
 	select EXPERIMENTAL
 	help
 	  Enable the functionality that allows a user to switch between Matter over Thread and Matter

--- a/west.yml
+++ b/west.yml
@@ -139,7 +139,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 2a8f797f1f4dc2439d6c4def25db7a4698d1f339
+      revision: 0bc1c70a941ea1a1ca9ca1c365af2c974ec90088
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
The DFU over BT SMP cannot be built without enablign Matter OTA Requestor, which is incorrect dependency.

* Moved ota_image_processor_base_impl.h include under Matter OTA Requestor ifdef
* Updated Matter revision to pull Kconfig dependencies fix