### PR TITLE
doc: Bluetooth peripheral samples: cleaning up

### DIFF
--- a/samples/bluetooth/nrf_dm/README.rst
+++ b/samples/bluetooth/nrf_dm/README.rst
@@ -248,7 +248,7 @@ In addition, it uses the following Zephyr libraries:
 
 * :ref:`zephyr:pwm_api`:
 
-  * ``drivers/pwm.h``
+  * :file:`drivers/pwm.h`
 
 * :file:`include/sys/printk.h`
 * :file:`include/sys/byteorder.h`
@@ -257,4 +257,4 @@ In addition, it uses the following Zephyr libraries:
 
   * :file:`include/bluetooth/bluetooth.h`
   * :file:`include/bluetooth/scan.h`
-* ``ext/hal/nordic/nrfx/hal/nrf_radio.h``
+* :file:`ext/hal/nordic/nrfx/hal/nrf_radio.h`

--- a/samples/bluetooth/peripheral_ams_client/README.rst
+++ b/samples/bluetooth/peripheral_ams_client/README.rst
@@ -18,7 +18,7 @@ The sample supports the following development kits:
 
 .. include:: /includes/tfm.txt
 
-The sample also requires a device running an AMS Server to connect with (for example, an iPhone which runs iOS, or a Bluetooth® Low Energy dongle and nRF Connect for Desktop).
+The sample also requires a device running an AMS Server to connect with (for example, an iPhone, or a computer with a Bluetooth® Low Energy dongle and nRF Connect for Desktop).
 
 Overview
 ********
@@ -33,10 +33,10 @@ User interface
 **************
 
 LED 1:
-   Blinks every two seconds, duty cycle 50%, when the main loop is running.
+   Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
 
 LED 2:
-   On when connected.
+   Lit when connected.
 
 Button 1:
    Enable and disable MS track attributes notification.
@@ -87,9 +87,9 @@ Testing with nRF Connect for Desktop
 #. Reset the kit.
 #. Start the Bluetooth Low Energy app of `nRF Connect for Desktop`_ and select the connected dongle that is used for communication.
 #. Set up the server:
-    a. Select the :guilabel:`Server setup` tab.
-    #. Select :guilabel:`Dongle configuration` > :guilabel:`Load setup`.
-    #. Load the :file:`AMS_central.ncs` file located under :file:`samples/bluetooth/peripheral_ams_client` in the |NCS| folder structure.
+   a. Select the **Server setup** tab.
+   #. Select :guilabel:`Dongle configuration` > :guilabel:`Load setup`.
+   #. Load the :file:`AMS_central.ncs` file located under :file:`samples/bluetooth/peripheral_ams_client` in the |NCS| folder structure.
 #. Click :guilabel:`Apply to device`.
 #. Select the :guilabel:`Connection Map` tab.
 #. Select :guilabel:`Dongle configuration` > :guilabel:`Security parameters`.
@@ -245,14 +245,14 @@ To test the next track feature, complete the following steps:
 
       AMS EU: 02,03,00 180.000
 
-   The notification informs about the updated song duration.
+   The notification shows the updated song duration.
 
 #. Set the **Apple Entity Update** value to ``02 02 00 6E 52 46 35 33 20 53 65 72 69 65 73 20 73 6F 6E 67``.
 #. Verify that the UART output is as follows::
 
       AMS EU: 02,02,00 nRF53 Series song
 
-   The notification informs about the updated song title.
+   The notification shows the updated song title.
 
 Disconnect
 ^^^^^^^^^^
@@ -271,15 +271,15 @@ This sample uses the following |NCS| libraries:
 
 In addition, it uses the following Zephyr libraries:
 
-* ``include/zephyr/types.h``
-* ``lib/libc/minimal/include/errno.h``
-* ``include/sys/printk.h``
+* :file:`include/zephyr/types.h`
+* :file:`lib/libc/minimal/include/errno.h`
+* :file:`include/sys/printk.h`
 * :ref:`zephyr:bluetooth_api`:
 
-  * ``include/bluetooth/bluetooth.h``
-  * ``include/bluetooth/conn.h``
-  * ``include/bluetooth/uuid.h``
-  * ``include/bluetooth/gatt.h``
+  * :file:`include/bluetooth/bluetooth.h`
+  * :file:`include/bluetooth/conn.h`
+  * :file:`include/bluetooth/uuid.h`
+  * :file:`include/bluetooth/gatt.h`
 
 The sample also uses the following secure firmware component:
 

--- a/samples/bluetooth/peripheral_ancs_client/README.rst
+++ b/samples/bluetooth/peripheral_ancs_client/README.rst
@@ -24,22 +24,22 @@ User interface
 **************
 
 LED 1:
-   * Blinks every two seconds, duty cycle 50%, when the main loop is running.
+   Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
 
 LED 2:
-   * On when connected.
+   Lit when connected.
 
 Button 1:
-   * Request iOS notification attributes (content) on UART.
+   Request iOS notification attributes (content) on UART.
 
 Button 2:
-   * Request iOS app attributes on UART.
+   Request iOS app attributes on UART.
 
 Button 3:
-   * Perform a positive action as a response to the last received notification.
+   Perform a positive action as a response to the last received notification.
 
 Button 4:
-   * Perform a negative action as a response to the last received notification.
+   Perform a negative action as a response to the last received notification.
 
 Building and running
 ********************
@@ -144,8 +144,8 @@ The following table shows the format of the message that the application must se
    |                  | 01            | Negative                    |
    +------------------+---------------+-----------------------------+
 
-#. Press **Button 3** to perform a positive action and verify that the **Apple Control Point** value is updated to ``02 01 02 03 04 00``.
-#. You can also press **Button 4** and observe that the server receives a negative action ``02 01 02 03 04 01``.
+* Press **Button 3** to perform a positive action and verify that the **Apple Control Point** value is updated to ``02 01 02 03 04 00``.
+* You can also press **Button 4** and observe that the server receives a negative action ``02 01 02 03 04 01``.
 
 Retrieve notification attributes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -274,15 +274,15 @@ This sample uses the following |NCS| libraries:
 
 In addition, it uses the following Zephyr libraries:
 
-* ``include/zephyr/types.h``
-* ``lib/libc/minimal/include/errno.h``
-* ``include/sys/printk.h``
+* :file:`include/zephyr/types.h`
+* :file:`lib/libc/minimal/include/errno.h`
+* :file:`include/sys/printk.h`
 * :ref:`zephyr:bluetooth_api`:
 
-  * ``include/bluetooth/bluetooth.h``
-  * ``include/bluetooth/conn.h``
-  * ``include/bluetooth/uuid.h``
-  * ``include/bluetooth/gatt.h``
+  * :file:`include/bluetooth/bluetooth.h`
+  * :file:`include/bluetooth/conn.h`
+  * :file:`include/bluetooth/uuid.h`
+  * :file:`include/bluetooth/gatt.h`
 
 The sample also uses the following secure firmware component:
 

--- a/samples/bluetooth/peripheral_bms/README.rst
+++ b/samples/bluetooth/peripheral_bms/README.rst
@@ -21,18 +21,18 @@ The sample also requires a Bluetooth® Low Energy dongle and nRF Connect for Des
 Overview
 ********
 
-When connected, the sample waits for Client's requests to perform any bond deleting operation.
+When connected, the sample waits for the client's requests to perform any bond-deleting operation.
 
-It supports up to two simultaneous Client connections.
+It supports up to two simultaneous client connections.
 
 User interface
 **************
 
 LED 1:
-   Blinks with a period of 2 seconds with the duty cycle set to 50% when the main loop is running and the device is advertising.
+   Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
 
 LED 2:
-   On when connected.
+   Lit when connected.
 
 Building and running
 ********************
@@ -91,13 +91,13 @@ This sample uses the following |NCS| libraries:
 
 In addition, it uses the following Zephyr libraries:
 
-* ``include/zephyr/types.h``
-* ``lib/libc/minimal/include/errno.h``
-* ``include/sys/printk.h``
+* :file:`include/zephyr/types.h`
+* :file:`lib/libc/minimal/include/errno.h`
+* :file:`include/sys/printk.h`
 * :ref:`GPIO Interface <zephyr:api_peripherals>`
 * :ref:`zephyr:bluetooth_api`:
 
-  * ``include/bluetooth/bluetooth.h``
-  * ``include/bluetooth/conn.h``
-  * ``include/bluetooth/uuid.h``
-  * ``include/bluetooth/gatt.h``
+  * :file:`include/bluetooth/bluetooth.h`
+  * :file:`include/bluetooth/conn.h`
+  * :file:`include/bluetooth/uuid.h`
+  * :file:`include/bluetooth/gatt.h`

--- a/samples/bluetooth/peripheral_cgms/README.rst
+++ b/samples/bluetooth/peripheral_cgms/README.rst
@@ -24,7 +24,7 @@ Overview
 The sample demonstrates a basic Bluetooth® Low Energy Peripheral role functionality that exposes the Continuous Glucose Monitoring GATT Service.
 Once it connects to a Central device, it generates dummy glucose measurement values.
 You can use it together with the Continuous Glucose module in the nRF Toolbox app.
-You may also use nRF Connect app to interact with the CGMS module.
+You can also use the `nRF Connect for Mobile`_ to interact with the CGMS module.
 
 Building and running
 ********************
@@ -61,16 +61,16 @@ Dependencies
 
 This sample uses the following Zephyr libraries:
 
-* ``include/zephyr/types.h``
-* ``include/errno.h``
-* ``include/zephyr.h``
-* ``include/sys/printk.h``
-* ``include/sys/byteorder.h``
+* :file:`include/zephyr/types.h`
+* :file:`include/errno.h`
+* :file:`include/zephyr.h`
+* :file:`include/sys/printk.h`
+* :file:`include/sys/byteorder.h`
 
 * :ref:`zephyr:bluetooth_api`:
 
-* ``include/bluetooth/bluetooth.h``
-* ``include/bluetooth/conn.h``
-* ``include/bluetooth/uuid.h``
-* ``include/bluetooth/gatt.h``
-* ``include/bluetooth/services/cgms.h``
+* :file:`include/bluetooth/bluetooth.h`
+* :file:`include/bluetooth/conn.h`
+* :file:`include/bluetooth/uuid.h`
+* :file:`include/bluetooth/gatt.h`
+* :file:`include/bluetooth/services/cgms.h`

--- a/samples/bluetooth/peripheral_cts_client/README.rst
+++ b/samples/bluetooth/peripheral_cts_client/README.rst
@@ -32,13 +32,13 @@ User interface
 **************
 
 LED 1:
-   * Blinks with a period of 2 seconds, duty cycle 50%, when the main loop is running.
+   Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
 
 LED 2:
-   * On when connected.
+   Lit when connected.
 
 Button 1:
-   * Read the current time.
+   Read the current time.
 
 Building and running
 ********************
@@ -118,8 +118,8 @@ After programming the sample to your development kit, you can test it with `nRF 
           External update  0
           Manual update    0
 
-#. Disconnect the device in nRF Connect.
-#. As bond information is preserved by nRF Connect, you can immediately reconnect to the device by clicking the Connect button again.
+#. Disconnect the device in the Bluetooth Low Energy app.
+#. As bond information is preserved by the Bluetooth Low Energy app, you can immediately reconnect to the device by clicking the :guilabel:`Connect` button again.
 
 Dependencies
 ************
@@ -132,15 +132,15 @@ This sample uses the following |NCS| libraries:
 
 In addition, it uses the following Zephyr libraries:
 
-* ``include/zephyr/types.h``
-* ``lib/libc/minimal/include/errno.h``
-* ``include/sys/printk.h``
+* :file:`include/zephyr/types.h`
+* :file:`lib/libc/minimal/include/errno.h`
+* :file:`include/sys/printk.h`
 * :ref:`zephyr:bluetooth_api`:
 
-  * ``include/bluetooth/bluetooth.h``
-  * ``include/bluetooth/conn.h``
-  * ``include/bluetooth/uuid.h``
-  * ``include/bluetooth/gatt.h``
+  * :file:`include/bluetooth/bluetooth.h`
+  * :file:`include/bluetooth/conn.h`
+  * :file:`include/bluetooth/uuid.h`
+  * :file:`include/bluetooth/gatt.h`
 
 The sample also uses the following secure firmware component:
 

--- a/samples/bluetooth/peripheral_fast_pair/README.rst
+++ b/samples/bluetooth/peripheral_fast_pair/README.rst
@@ -57,14 +57,14 @@ See `Fast Pair Advertising`_ for detailed information about discoverable and not
 Fast Pair device registration
 =============================
 
-Before a device can be used as a Fast Pair Provider, you must register the device model with Google.
+Before you can use a device as a Fast Pair Provider, you must register the device model with Google.
 This is required to obtain Model ID and Anti-Spoofing Private Key.
 See :ref:`ug_bt_fast_pair_provisioning` in the Fast Pair user guide for details.
 
 .. tip::
    The sample provides TX power in the Bluetooth advertising data.
    There is no need to provide the TX power value during device model registration.
-   The device is using only Bluetooth LE, so you must select **Skip connecting audio profiles (e.g. A2DP, HFP)** option when registering the device.
+   The device is using only Bluetooth LE, so you must select **Skip connecting audio profiles (e.g. A2DP or HFP)** option when registering the device.
 
 Seeker device
 =============
@@ -73,7 +73,7 @@ A Fast Pair Seeker device is required to test the Fast Pair procedure.
 This is one of the two `Fast Pair roles`_.
 
 For example, you can use an Android device as the Seeker device.
-To test with a debug mode Model ID, the Android device must be configured to include debug results while displaying the nearby Fast Pair Providers.
+To test with a debug mode Model ID, you must configure the Android device to include debug results while displaying the nearby Fast Pair Providers.
 For details, see `Verifying Fast Pair`_ in the GFPS documentation.
 
 Not discoverable advertising requirements
@@ -168,7 +168,7 @@ Testing
 1. |connect_terminal_specific|
    The sample provides Fast Pair debug logs to inform about state of the Fast Pair procedure.
 #. Reset the kit.
-#. Observe that **LED 1** is blinking (firmware is running) and **LED 3** is turned on (device is Fast Pair discoverable).
+#. Observe that **LED 1** is blinking (firmware is running) and **LED 3** is lit (device is Fast Pair discoverable).
    This means that the device is now working as Fast Pair Provider and is advertising.
 #. On the Android device, go to :guilabel:`Settings` > :guilabel:`Google` > :guilabel:`Devices & sharing` (or :guilabel:`Device connections`, depending on your Android device configuration) > :guilabel:`Devices`.
 #. Move the Android device close to the Fast Pair Provider that is advertising.
@@ -181,14 +181,14 @@ Testing
 
    The device model name and displayed logo depend on the data provided during the device model registration.
 #. Tap the :guilabel:`Connect` button to initiate the connection and trigger the Fast Pair procedure.
-   After the procedure is finished, the pop-up is updated to inform about successfully completed Fast Pair procedure.
-   **LED 2** turns on to indicate that the device is connected with the Bluetooth Central.
+   After the procedure has completed, the pop-up is updated to inform about successfully completed Fast Pair procedure.
+   **LED 2** is lit to indicate that the device is connected with the Bluetooth Central.
 
    .. note::
       Some Android devices might disconnect right after the Fast Pair procedure has completed.
       Go to :guilabel:`Settings` > :guilabel:`Bluetooth` and tap on the bonded Fast Pair Provider to reconnect.
 
-   The connected Fast Pair Provider can now be used to control audio volume of the Bluetooth Central.
+   You can now use the connected Fast Pair Provider to control audio volume of the Bluetooth Central.
 #. Press **Button 2** to increase the audio volume.
 #. Press **Button 4** to decrease the audio volume.
 
@@ -237,13 +237,13 @@ Test not discoverable advertising by completing `Testing`_ and the following add
 
 #. In the show UI indication mode, when the notification appears, tap on it to trigger the Fast Pair procedure.
 #. Wait for the notification about successful Fast Pair procedure.
-   **LED 2** is turned on to inform that the device is connected with the Bluetooth Central.
+   **LED 2** is lit to inform that the device is connected with the Bluetooth Central.
 
    .. note::
       Some Android devices might disconnect right after Fast Pair procedure is finished.
       Go to :guilabel:`Settings` > :guilabel:`Bluetooth` and tap on the bonded Fast Pair Provider to reconnect.
 
-   The connected Fast Pair Provider can now be used to control the audio volume of the Bluetooth Central.
+   You can now use the connected Fast Pair Provider to control the audio volume of the Bluetooth Central.
 #. Press **Button 2** to increase the audio volume.
 #. Press **Button 4** to decrease the audio volume.
 
@@ -263,10 +263,10 @@ Testing Personalized Name extension is described in `Fast Pair Certification Gui
 Battery Notification extension
 ------------------------------
 
-Test `Fast Pair Battery Notification extension`_ by completing the following steps:
+Complete the following steps to test `Fast Pair Battery Notification extension`_:
 
 #. Pair the Fast Pair Provider with at least one Fast Pair Seeker.
-#. Put the Fast Pair Provider in not discoverable advertising mode.
+#. Set the Fast Pair Provider in not discoverable advertising mode.
 #. Verify that the Provider is advertising sample battery data using the `nRF Connect for Mobile`_ application.
 
 .. note::

--- a/samples/bluetooth/peripheral_gatt_dm/README.rst
+++ b/samples/bluetooth/peripheral_gatt_dm/README.rst
@@ -64,17 +64,17 @@ This sample uses the following |NCS| libraries:
 
 In addition, it uses the following Zephyr libraries:
 
-* ``include/zephyr/types.h``
-* ``lib/libc/minimal/include/errno.h``
-* ``include/sys/printk.h``
-* ``include/sys/byteorder.h``
+* :file:`include/zephyr/types.h`
+* :file:`lib/libc/minimal/include/errno.h`
+* :file:`include/sys/printk.h`
+* :file:`include/sys/byteorder.h`
 * :ref:`zephyr:bluetooth_api`:
 
-  * ``include/bluetooth/bluetooth.h``
-  * ``include/bluetooth/hci.h``
-  * ``include/bluetooth/conn.h``
-  * ``include/bluetooth/uuid.h``
-  * ``include/bluetooth/gatt.h``
+  * :file:`include/bluetooth/bluetooth.h`
+  * :file:`include/bluetooth/hci.h`
+  * :file:`include/bluetooth/conn.h`
+  * :file:`include/bluetooth/uuid.h`
+  * :file:`include/bluetooth/gatt.h`
 
 The sample also uses the following secure firmware component:
 

--- a/samples/bluetooth/peripheral_hids_keyboard/README.rst
+++ b/samples/bluetooth/peripheral_hids_keyboard/README.rst
@@ -39,9 +39,9 @@ LE Secure Out-of-Band pairing with NFC is enabled by default in this sample.
 You can disable this feature by clearing the `NFC_OOB_PAIRING` flag in the application configuration.
 The following paragraphs describe the application behavior when NFC pairing is enabled.
 
-When the application starts, it initializes and starts the NFCT peripheral, which is used for pairing.
+When the application starts, it initializes and starts the NFCT peripheral that is used for pairing.
 The application does not start advertising immediately, but only when the NFC tag is read by an NFC polling device, for example a smartphone or a tablet with NFC support.
-To trigger advertising without NFC, you can press **Button 4**.
+To trigger advertising without NFC, press **Button 4**.
 The NDEF message that the tag sends to the NFC device contains data required to initiate pairing.
 To start the NFC data transfer, the NFC device must touch the NFC antenna that is connected to the nRF52 device.
 
@@ -64,10 +64,10 @@ Button 2:
    When pairing, press this button to reject the passkey value which is printed on the COM listener to prevent pairing with the other device.
 
 LED 1:
-   Blinks with a period of 2 seconds (duty cycle 50%) when the device is advertising.
+   Blinks with a period of two seconds with the duty cycle set to 50% when the main loop is running and the device is advertising.
 
 LED 2:
-   On when at least one device is connected.
+   Lit when at least one device is connected.
 
 LED 3:
    Indicates if Caps Lock is enabled.
@@ -108,7 +108,7 @@ To test with a Microsoft Windows computer that has a Bluetooth® radio, complete
 
 1. Power on your development kit.
 #. Press **Button 4** on the kit if the device is not advertising.
-   Advertising is indicated by blinking **LED 1**.
+   A blinking **LED 1** indicates that the device is advertising.
 #. |connect_terminal|
 #. On your Windows computer, search for Bluetooth devices and connect to the device named "NCS HIDS keyboard".
 #. Observe that the connection state is indicated by **LED 2**.
@@ -133,14 +133,14 @@ To test with `nRF Connect for Desktop`_, complete the following steps:
 
 1. Power on your development kit.
 #. Press **Button 4** on the kit if the device is not advertising.
-   Advertising is indicated by blinking **LED 1**.
+   A blinking **LED 1** indicates that the device is advertising.
 #. |connect_terminal|
 #. Start `nRF Connect for Desktop`_.
 #. Open the Bluetooth Low Energy app.
 #. Connect to the device from the app. The device is advertising as "NCS HIDS keyboard".
 #. Pair the devices:
 
-   a. Click the settings button for the device in the app.
+   a. Click the :guilabel:`Settings` button for the device in the app.
    #. Select :guilabel:`Pair`.
    #. Optionally, select :guilabel:`Perform Bonding`.
 
@@ -166,20 +166,20 @@ To test with `nRF Connect for Desktop`_, complete the following steps:
    Observe that two notifications are received on one of the HID Report characteristics, denoting press and release for one character of the test message.
    The first one has the value ``02000F0000000000``, the second has the value ``0200000000000000``.
    These values correspond to press and release of character "l" with the Shift key pressed.
-#. In nRF Connect, select the HID Report (which has UUID 0x2A4D and the properties Read, WriteWithoutResponse, and Write).
+#. In the Bluetooth Low Energy app, select the HID Report (which has UUID ``0x2A4D`` and the properties ``Read``, ``WriteWithoutResponse``, and ``Write``).
    Enter ``02`` in the text box and click the :guilabel:`tick mark` button.
    This sets the modifier bit of the Output Report to 02, which simulates turning Caps Lock ON.
 
-   Observe that **LED 3** turns on.
+   Observe that **LED 3** is lit.
 #. Select the same HID Report again.
    Enter ``00`` in the text box and click :guilabel:`Write`.
    This sets the modifier bit to 00, which simulates turning Caps Lock OFF.
 
    Observe that **LED 3** turns off.
-#. Disconnect the device in nRF Connect.
+#. Disconnect the device in the Bluetooth Low Energy app.
    Observe that no new notifications are received.
 #. If the advertising did not start automatically, press **Button 4** to continue advertising.
-#. As bond information is preserved by nRF Connect, you can immediately reconnect to the device by clicking the Connect button again.
+#. As bond information is preserved by the Bluetooth Low Energy app, you can immediately reconnect to the device by clicking the :guilabel:`Connect` button again.
 
 
 Testing with Android using NFC for pairing
@@ -215,19 +215,19 @@ When the `NFC_OOB_PAIRING` feature is enabled, it also uses the Type 2 Tag libra
 
 The sample uses the following Zephyr libraries:
 
-* ``include/zephyr/types.h``
-* ``include/sys/printk.h``
-* ``include/sys/byteorder.h``
+* :file:`include/zephyr/types.h`
+* :file:`include/sys/printk.h`
+* :file:`include/sys/byteorder.h`
 * :ref:`GPIO Interface <zephyr:api_peripherals>`
 * :ref:`zephyr:settings_api`
 * :ref:`zephyr:bluetooth_api`:
 
-  * ``include/bluetooth/bluetooth.h``
-  * ``include/bluetooth/hci.h``
-  * ``include/bluetooth/conn.h``
-  * ``include/bluetooth/uuid.h``
-  * ``include/bluetooth/gatt.h``
-  * ``samples/bluetooth/gatt/bas.h``
+  * :file:`include/bluetooth/bluetooth.h`
+  * :file:`include/bluetooth/hci.h`
+  * :file:`include/bluetooth/conn.h`
+  * :file:`include/bluetooth/uuid.h`
+  * :file:`include/bluetooth/gatt.h`
+  * :file:`samples/bluetooth/gatt/bas.h`
 
 References
 **********

--- a/samples/bluetooth/peripheral_hids_mouse/README.rst
+++ b/samples/bluetooth/peripheral_hids_mouse/README.rst
@@ -25,36 +25,36 @@ Overview
 ********
 
 The sample uses the buttons on a development kit to simulate the movement of a mouse.
-The four buttons simulate movement to the left, upward, to the right, and downward, respectively.
+The four buttons simulate movement to the left, up, right, and down, respectively.
 Mouse clicks are not simulated.
 
 This sample exposes the HID GATT Service.
 It uses a report map for a generic mouse.
 
-You can also disable directed advertising feature by clearing the BT_DIRECTED_ADVERTISING flag in the application configuration.
-This feature is enabled by default and it changes the way in which advertising works in comparison to the other Bluetooth® Low Energy samples.
+You can also disable the directed advertising feature by clearing the ``BT_DIRECTED_ADVERTISING`` flag in the application configuration.
+This feature is enabled by default and it changes the way how advertising works in comparison to the other Bluetooth® Low Energy samples.
 When the device wants to advertise, it starts with high duty cycle directed advertising provided that it has bonding information.
-If the timeout occurs, then the device starts directed advertising to the next bonded peer.
-If all bonding information is used and there is still no connection, then the regular advertising starts.
+If the timeout occurs, the device starts directed advertising to the next bonded peer.
+If all bonding information is used and there is still no connection, the regular advertising starts.
 
 User interface
 **************
 
 Button 1:
-   Simulate moving the mouse pointer 5 pixels to the left.
+   Simulate moving the mouse pointer five pixels to the left.
 
    When pairing, press this button to confirm the passkey value that is printed on the COM listener to pair with the other device.
 
 Button 2:
-   Simulate moving the mouse pointer 5 pixels upward.
+   Simulate moving the mouse pointer five pixels up.
 
    When pairing, press this button to reject the passkey value that is printed on the COM listener to prevent pairing with the other device.
 
 Button 3:
-   Simulate moving the mouse pointer 5 pixels to the right.
+   Simulate moving the mouse pointer five pixels to the right.
 
 Button 4:
-   Simulate moving the mouse pointer 5 pixels downward.
+   Simulate moving the mouse pointer five pixels down.
 
 Configuration
 *************
@@ -69,7 +69,7 @@ The HID service specification does not require encryption (:kconfig:option:`CONF
 Building and running
 ********************
 
-To build this sample with the :ref:`nrf_rpc_ipc_readme` library on the nRF5340 DK, set :makevar:`OVERLAY_CONFIG` option to the :file:`overlay-nrf_rpc.conf` file.
+To build this sample with the :ref:`nrf_rpc_ipc_readme` library on the nRF5340 DK, set the :makevar:`OVERLAY_CONFIG` option to the :file:`overlay-nrf_rpc.conf` file.
 
 .. code-block::
 
@@ -82,7 +82,7 @@ To build this sample with the :ref:`nrf_rpc_ipc_readme` library on the nRF5340 D
 Testing
 =======
 
-After programming the sample to your development kit, you can test it either by connecting the development kit as a mouse device to a Microsoft Windows computer or by connecting to it with `nRF Connect for Desktop`_.
+After programming the sample to your development kit, you can test it either by connecting the development kit as a mouse device to a Microsoft Windows computer or by connecting to it with the Bluetooth Low Energy app of the `nRF Connect for Desktop`_.
 
 Testing with a Microsoft Windows computer
 -----------------------------------------
@@ -112,7 +112,7 @@ To test with `nRF Connect for Desktop`_, complete the following steps:
 #. Open the Bluetooth Low Energy app.
 #. Connect to the device from the app. The device is advertising as "NCS HIDS mouse"
 #. Optionally, bond to the device.
-   Click the settings button for the device in the app, select **Pair**, check :guilabel:`Perform Bonding`, and click :guilabel:`Pair`.
+   Click the :guilabel:`Settings` button for the device in the app, select **Pair**, check :guilabel:`Perform Bonding`, and click :guilabel:`Pair`.
    Optionally check :guilabel:`Enable MITM protection` to pair with MITM protection and use a button on the device to confirm or reject passkey value.
 #. Click :guilabel:`Match` in the app.
    Wait until the bond is established before you continue.
@@ -125,16 +125,16 @@ To test with `nRF Connect for Desktop`_, complete the following steps:
    These are transmitted as 12-bit signed integers.
    The format used for mouse reports is the following byte array, where LSB/MSB is the least/most significant bit: ``[8 LSB (X), 4 LSB (Y) | 4 MSB(X), 8 MSB(Y)]``.
 
-   Therefore, ``FB0F00`` denotes an X-translation of FFB = -5 (two's complement format), which means a movement of 5 pixels to the left, and a Y-translation of 000 = 0.
+   Therefore, ``FB0F00`` denotes an X-translation of FFB = -5 (two's complement format), which means a movement of five pixels to the left, and a Y-translation of 000 = 0.
 #. Push **Button 2**.
    Observe that the value ``00B0FF`` is received on the same HID Report characteristic.
 #. Push **Button 3**.
    Observe that the value ``050000`` is received on the same HID Report characteristic.
 #. Push **Button 4**.
    Observe that the value ``005000`` is received on the same HID Report characteristic.
-#. Disconnect the device in nRF Connect.
+#. Disconnect the device in the Bluetooth Low Energy app of nRF Connect for Desktop.
    Observe that no new notifications are received and the device is advertising.
-#. As bond information is preserved by nRF Connect, you can immediately reconnect to the device by clicking the Connect button again.
+#. As bond information is preserved by the Bluetooth Low Energy app, you can immediately reconnect to the device by clicking the :guilabel:`Connect` button again.
 
 
 Dependencies
@@ -147,21 +147,21 @@ This sample uses the following |NCS| libraries:
 
 In addition, it uses the following Zephyr libraries:
 
-* ``include/zephyr/types.h``
-* ``lib/libc/minimal/include/assert.h``
-* ``lib/libc/minimal/include/errno.h``
-* ``include/sys/printk.h``
-* ``include/sys/byteorder.h``
+* :file:`include/zephyr/types.h`
+* :file:`lib/libc/minimal/include/assert.h`
+* :file:`lib/libc/minimal/include/errno.h`
+* :file:`include/sys/printk.h`
+* :file:`include/sys/byteorder.h`
 * :ref:`GPIO Interface <zephyr:api_peripherals>`
 * :ref:`zephyr:settings_api`
 * :ref:`zephyr:bluetooth_api`:
 
-  * ``include/bluetooth/bluetooth.h``
-  * ``include/bluetooth/hci.h``
-  * ``include/bluetooth/conn.h``
-  * ``include/bluetooth/uuid.h``
-  * ``include/bluetooth/gatt.h``
-  * ``samples/bluetooth/gatt/bas.h``
+  * :file:`include/bluetooth/bluetooth.h`
+  * :file:`include/bluetooth/hci.h`
+  * :file:`include/bluetooth/conn.h`
+  * :file:`include/bluetooth/uuid.h`
+  * :file:`include/bluetooth/gatt.h`
+  * :file:`samples/bluetooth/gatt/bas.h`
 
 The sample also uses the following secure firmware component:
 

--- a/samples/bluetooth/peripheral_hr_coded/README.rst
+++ b/samples/bluetooth/peripheral_hr_coded/README.rst
@@ -35,7 +35,7 @@ User interface
 The user interface of the sample depends on the hardware platform you are using.
 
 LED 1:
-   Blinks when the main loop is running (that is, the device is advertising) with a period of two seconds, duty cycle 50%.
+   Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
 
 LED 2:
    Lit when the development kit is connected.
@@ -73,20 +73,20 @@ This sample uses the following |NCS| library:
 
 This sample uses the following Zephyr libraries:
 
-* ``include/zephyr/types.h``
-* ``include/errno.h``
-* ``include/zephyr.h``
-* ``include/sys/printk.h``
-* ``include/sys/byteorder.h``
+* :file:`include/zephyr/types.h`
+* :file:`include/errno.h`
+* :file:`include/zephyr.h`
+* :file:`include/sys/printk.h`
+* :file:`include/sys/byteorder.h`
 * :ref:`zephyr:kernel_api`:
 
-  * ``include/kernel.h``
+  * :file:`include/kernel.h`
 
 * :ref:`zephyr:bluetooth_api`:
 
-* ``include/bluetooth/bluetooth.h``
-* ``include/bluetooth/conn.h``
-* ``include/bluetooth/uuid.h``
-* ``include/bluetooth/gatt.h``
-* ``include/bluetooth/services/bas.h``
-* ``include/bluetooth/services/hrs.h``
+* :file:`include/bluetooth/bluetooth.h`
+* :file:`include/bluetooth/conn.h`
+* :file:`include/bluetooth/uuid.h`
+* :file:`include/bluetooth/gatt.h`
+* :file:`include/bluetooth/services/bas.h`
+* :file:`include/bluetooth/services/hrs.h`

--- a/samples/bluetooth/peripheral_lbs/README.rst
+++ b/samples/bluetooth/peripheral_lbs/README.rst
@@ -41,7 +41,7 @@ nRF52840 Dongle
 ===============
 
 Green LED:
-   When the main loop is running (that is, the device is advertising), the LED blinks with a period of 2 seconds, duty cycle 50%.
+   Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
 
 RGB LED:
    The RGB LED channels are used independently to display the following information:
@@ -59,7 +59,7 @@ RGB LED:
    The RGB LED channels are used independently to display the following information:
 
    * Red - If the main loop is running (that is, the device is advertising).
-     The LED blinks with a period of 2 seconds, duty cycle 50%.
+     The LED blinks with a period of two seconds, duty cycle 50%.
    * Green - If the device is connected.
    * Blue - If user set the LED using Nordic LED Button Service.
 
@@ -73,13 +73,13 @@ Development kits
 ================
 
 LED 1:
-   Blinks when the main loop is running (that is, the device is advertising) with a period of 2 seconds, duty cycle 50%.
+   Blinks when the main loop is running (that is, the device is advertising) with a period of two seconds, duty cycle 50%.
 
 LED 2:
-   On when the development kit is connected.
+   Lit when the development kit is connected.
 
 LED 3:
-   On when the development kit is controlled remotely from the connected device.
+   Lit when the development kit is controlled remotely from the connected device.
 
 Button 1:
    Send a notification with the button state: "pressed" or "released".
@@ -96,7 +96,7 @@ Minimal build
 You can build the sample with a minimum configuration as a demonstration of how to reduce code size and RAM usage, using the ``-DCONF_FILE='prj_minimal.conf'`` flag in your build.
 
 See :ref:`cmake_options` for instructions on how to add this option to your build.
-For example, when building on the command line, you can do so as follows:
+For example, when building on the command line, you can add the option as follows:
 
 .. code-block:: console
 
@@ -150,18 +150,18 @@ This sample uses the following |NCS| libraries:
 
 In addition, it uses the following Zephyr libraries:
 
-* ``include/zephyr/types.h``
-* ``lib/libc/minimal/include/errno.h``
-* ``include/sys/printk.h``
-* ``include/sys/byteorder.h``
+* :file:`include/zephyr/types.h`
+* :file:`lib/libc/minimal/include/errno.h`
+* :file:`include/sys/printk.h`
+* :file:`include/sys/byteorder.h`
 * :ref:`GPIO Interface <zephyr:api_peripherals>`
 * :ref:`zephyr:bluetooth_api`:
 
-  * ``include/bluetooth/bluetooth.h``
-  * ``include/bluetooth/hci.h``
-  * ``include/bluetooth/conn.h``
-  * ``include/bluetooth/uuid.h``
-  * ``include/bluetooth/gatt.h``
+  * :file:`include/bluetooth/bluetooth.h`
+  * :file:`include/bluetooth/hci.h`
+  * :file:`include/bluetooth/conn.h`
+  * :file:`include/bluetooth/uuid.h`
+  * :file:`include/bluetooth/gatt.h`
 
 The sample also uses the following secure firmware component:
 

--- a/samples/bluetooth/peripheral_mds/README.rst
+++ b/samples/bluetooth/peripheral_mds/README.rst
@@ -58,8 +58,8 @@ The following metrics are enabled by default in this sample:
 * Stack usage metrics shows the free stack space in bytes.
   Configurable by the :kconfig:option:`CONFIG_MEMFAULT_NCS_STACK_METRICS` Kconfig option.
 
-  * ``NcsBtRxUnusedStack`` - HCI Rx thread stack.
-  * ``NcsBtTxUnusedStack`` - HCI Tx thread stack.
+  * ``NcsBtRxUnusedStack`` - HCI RX thread stack.
+  * ``NcsBtTxUnusedStack`` - HCI TX thread stack.
 
 Error tracking with trace events
 ================================
@@ -99,7 +99,7 @@ The sample supports a simple user interface.
 You can control the sample using predefined buttons, while LEDs are used to display information.
 
 LED 1:
-   Blinks when the main loop is running (that is, the device is advertising) with a period of two seconds, duty cycle 50%.
+   Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
 
 LED 2:
    Lit when the development kit is connected.
@@ -131,11 +131,9 @@ The Memfault SDK allows configuring some of its options using Kconfig.
 For the options not configurable using Kconfig, use the :file:`samples/bluetooth/peripheral_mds/memfault_config/memfault_platform_config.h` file.
 See `Memfault SDK`_ for more information.
 
-To send data to the Memfault cloud through a Bluetooth gateway, you must configure a project key using the :kconfig:option:`CONFIG_MEMFAULT_NCS_PROJECT_KEY` option.
+To send data to the Memfault cloud through a Bluetooth gateway, you must configure a project key using the :kconfig:option:`CONFIG_MEMFAULT_NCS_PROJECT_KEY` Kconfig option.
 You can find your project key in the project settings at `Memfault Dashboards`_.
-You also need to set the following static configuration option for this sample:
-
-* :kconfig:option:`CONFIG_MEMFAULT_NCS_DEVICE_ID` - Memfault device ID.
+You also need to set the :kconfig:option:`CONFIG_MEMFAULT_NCS_DEVICE_ID` static Kconfig option for this sample
 
 Building and running
 ********************

--- a/samples/bluetooth/peripheral_nfc_pairing/README.rst
+++ b/samples/bluetooth/peripheral_nfc_pairing/README.rst
@@ -140,8 +140,8 @@ In addition, it uses the Type 4 Tag library from nrfxlib:
 
 It uses the following Zephyr libraries:
 
-* ``include/zephyr.h``
-* ``include/device.h``
+* :file:`include/zephyr.h`
+* :file:`include/device.h`
 * :ref:`GPIO Interface <zephyr:api_peripherals>`
 
 The sample also uses the following secure firmware component:

--- a/samples/bluetooth/peripheral_power_profiling/README.rst
+++ b/samples/bluetooth/peripheral_power_profiling/README.rst
@@ -89,15 +89,15 @@ Service UUID
 
 This sample implements the vendor-specific service.
 
-The 128-bit service UUID is **00001630-1212-EFDE-1523-785FEABCD123**.
+The 128-bit service UUID is ``00001630-1212-EFDE-1523-785FEABCD123``.
 
 Characteristics
 ===============
 
-The 128-bit characteristic UUID is **00001630-1212-EFDE-1524-785FEABCD123**.
+The 128-bit characteristic UUID is ``00001630-1212-EFDE-1524-785FEABCD123``.
 This characteristic value can be read or sent by the notification mechanism.
 The value is an array filled with zeroes.
-You can configure the length of data using the :kconfig:option:`CONFIG_BT_POWER_PROFILING_DATA_LENGTH` Kconfig option.
+You can configure the length of data using the :ref:`CONFIG_BT_POWER_PROFILING_DATA_LENGTH <CONFIG_BT_POWER_PROFILING_DATA_LENGTH>` Kconfig option.
 
 This characteristic has a CCC descriptor associated with it.
 
@@ -107,8 +107,8 @@ User interface
 The sample uses buttons and LEDs to provide a simple user interface.
 
 LED 1:
-   Blinks when main loop is running with a period of two seconds, duty cycle 50%.
-    Off when the device is in system off state.
+   Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
+   Off when the device is in system off state.
 
 LED 2:
    Lit when an NFC field is detected.
@@ -131,30 +131,62 @@ Configuration
 
 The Peripheral Power Profiling sample allows configuring some of its settings using Kconfig.
 You can set different options to monitor the power consumption of your development kit.
-You can modify the following options:
+You can modify the following options (available in the Kconfig file at :file:`samples/bluetooth/peripheral_power_profiling`):
 
-   * :kconfig:option:`CONFIG_BT_POWER_PROFILING_DATA_LENGTH` - sets notification data length.
-   * :kconfig:option:`CONFIG_BT_POWER_PROFILING_NOTIFICATION_INTERVAL` - sets notification sending interval in milliseconds.
+.. _CONFIG_BT_POWER_PROFILING_DATA_LENGTH:
 
-      Notifications are started when the central device enables it by writing to the characteristic CCC descriptor.
-   * :kconfig:option:`CONFIG_BT_POWER_PROFILING_NOTIFICATION_TIMEOUT` - sets notification timeout.
+CONFIG_BT_POWER_PROFILING_DATA_LENGTH - Notification data length
+   Sets the length of the data sent through notification mechanism.
 
-      Notifications are sent until this timeout is fired.
-      After that, the sample disconnects and enters the system off mode.
-   * :kconfig:option:`CONFIG_BT_POWER_PROFILING_CONNECTABLE_ADV_DURATION` - sets connectable advertising duration in (N * 10) milliseconds.
+.. _CONFIG_BT_POWER_PROFILING_NOTIFICATION_INTERVAL:
 
-      If the connection is not established during advertising, the device enters the system off state.
+CONFIG_BT_POWER_PROFILING_NOTIFICATION_INTERVAL - Notification interval
+   Sets the notification send interval in milliseconds. Notification data is sent on every interval expiration.
+   Notifications are started when the central device enables it by writing to the characteristic CCC descriptor.
 
-   * :kconfig:option:`CONFIG_BT_POWER_PROFILING_NON_CONNECTABLE_ADV_DURATION` - sets non-connectable advertising duration in (N * 10) milliseconds.
+.. _CONFIG_BT_POWER_PROFILING_NOTIFICATION_TIMEOUT:
 
-      When the advertising ends, the device enters the system off state if there is no outgoing connection.
-   * :kconfig:option:`CONFIG_BT_POWER_PROFILING_NFC_ADV_DURATION` - sets advertising duration after the NFC field detection in (N * 10) milliseconds.
+CONFIG_BT_POWER_PROFILING_NOTIFICATION_TIMEOUT - Notification timeout
+   Sets the notification timeout in milliseconds. When this timeout fires the device will stop sending notifications.
+   After that, the sample disconnects and enters the system off mode.
 
-      If the connection was not established during advertising, the device enters the system off state.
-   * :kconfig:option:`CONFIG_BT_POWER_PROFILING_CONNECTABLE_ADV_INTERVAL_MIN` - sets connectable advertising minimum interval in (N * 0.625) milliseconds.
-   * :kconfig:option:`CONFIG_BT_POWER_PROFILING_CONNECTABLE_ADV_INTERVAL_MAX` - sets connectable advertising maximum interval in (N * 0.625) milliseconds.
-   * :kconfig:option:`CONFIG_BT_POWER_PROFILING_NON_CONNECTABLE_ADV_INTERVAL_MIN` - sets non-connectable advertising minimum interval in (N * 0.625) milliseconds.
-   * :kconfig:option:`CONFIG_BT_POWER_PROFILING_NON_CONNECTABLE_ADV_INTERVAL_MAX` - sets non-connectable advertising maximum interval in (N * 0.625) milliseconds.
+.. _CONFIG_BT_POWER_PROFILING_CONNECTABLE_ADV_DURATION:
+
+CONFIG_BT_POWER_PROFILING_CONNECTABLE_ADV_DURATION - Connectable advertising duration
+   Sets the connectable advertising duration in N*10 milliseconds unit.
+   If the connection is not established during advertising, the device enters the system off state.
+
+.. _CONFIG_BT_POWER_PROFILING_NON_CONNECTABLE_ADV_DURATION:
+
+CONFIG_BT_POWER_PROFILING_NON_CONNECTABLE_ADV_DURATION - Non-connectable advertising duration
+   Sets the non-connectable advertising duration in N*10 milliseconds unit.
+   When the advertising ends, the device enters the system off state if there is no outgoing connection.
+
+.. _CONFIG_BT_POWER_PROFILING_NFC_ADV_DURATION:
+
+CONFIG_BT_POWER_PROFILING_NFC_ADV_DURATION - Advertising duration when the NFC field is detected
+   Sets the advertising duration when the NFC field is detected in N*10 milliseconds unit.
+   If the connection was not established during advertising, the device enters the system off state.
+
+.. _CONFIG_BT_POWER_PROFILING_CONNECTABLE_ADV_INTERVAL_MIN:
+
+CONFIG_BT_POWER_PROFILING_CONNECTABLE_ADV_INTERVAL_MIN - Connectable advertising minimum interval
+   Sets the connectable advertising minimum interval in 0.625 milliseconds unit.
+
+.. _CONFIG_BT_POWER_PROFILING_CONNECTABLE_ADV_INTERVAL_MAX:
+
+CONFIG_BT_POWER_PROFILING_CONNECTABLE_ADV_INTERVAL_MAX - Connectable advertising maximum interval
+   Sets the connectable advertising maximum interval in 0.625 milliseconds unit.
+
+.. _CONFIG_BT_POWER_PROFILING_NON_CONNECTABLE_ADV_INTERVAL_MIN:
+
+CONFIG_BT_POWER_PROFILING_NON_CONNECTABLE_ADV_INTERVAL_MIN - Non-connectable advertising minimum interval
+   Sets the non-connectable advertising minimum interval in 0.625 milliseconds unit.
+
+.. _CONFIG_BT_POWER_PROFILING_NON_CONNECTABLE_ADV_INTERVAL_MAX:
+
+CONFIG_BT_POWER_PROFILING_NON_CONNECTABLE_ADV_INTERVAL_MAX - Non-connectable advertising maximum interval
+   Sets the non-connectable advertising maximum interval in 0.625 milliseconds unit.
 
 Building and running
 ********************
@@ -200,7 +232,7 @@ Testing with nRF Connect for Desktop and Power Profiler Kit II (PPK2)
 #. Observe that notifications are received.
 
    Monitor the power consumption during notification sending.
-#. After the timeout set by the :kconfig:option:`CONFIG_BT_POWER_PROFILING_NOTIFICATION_TIMEOUT` option, your development kit disconnects and enters the system off mode.
+#. After the timeout set by the :ref:`CONFIG_BT_POWER_PROFILING_NOTIFICATION_TIMEOUT <CONFIG_BT_POWER_PROFILING_NOTIFICATION_TIMEOUT>` option, your development kit disconnects and enters the system off mode.
 #. Repeat this test using different wake-up methods and different parameters, and monitor the power consumption for your new setup.
 
 Dependencies
@@ -220,17 +252,17 @@ It uses the Type 2 Tag library from `sdk-nrfxlib`_:
 
 In addition, it uses the following Zephyr libraries:
 
-* ``include/zephyr/sys/kernel.h``
-* ``include/zephyr/sys/atomic.h``
+* :file`include/zephyr/sys/kernel.h`
+* :file:`include/zephyr/sys/atomic.h`
 * :ref:`zephyr:settings_api`
 * :ref:`zephyr:bluetooth_api`:
 
-  * ``include/zephyr/bluetooth/bluetooth.h``
-  * ``include/zephyr/bluetooth/conn.h``
-  * ``include/zephyr/bluetooth/uuid.h``
-  * ``include/zephyr/bluetooth/gatt.h``
+  * :file:`include/zephyr/bluetooth/bluetooth.h`
+  * :file:`include/zephyr/bluetooth/conn.h`
+  * :file:`include/zephyr/bluetooth/uuid.h`
+  * :file:`include/zephyr/bluetooth/gatt.h`
 
 * :ref:`zephyr:pm-guide`:
 
-  * ``include/zephyr/pm/pm.h``
-  * ``include/zephyr/pm/policy.h``
+  * :file:`include/zephyr/pm/pm.h`
+  * :file:`include/zephyr/pm/policy.h`

--- a/samples/bluetooth/peripheral_rscs/README.rst
+++ b/samples/bluetooth/peripheral_rscs/README.rst
@@ -32,10 +32,10 @@ User interface
 **************
 
 LED 1:
-   Blinks every two seconds with the duty cycle set to 50% when the main loop is running and the device is advertising.
+   Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
 
 LED 2:
-   On when connected.
+   Lit when connected.
 
 Building and running
 ********************
@@ -82,16 +82,16 @@ This sample uses the following |NCS| libraries:
 
 In addition, it uses the following Zephyr libraries:
 
-* ``include/zephyr/types.h``
-* ``lib/libc/minimal/include/errno.h``
-* ``include/sys/printk.h``
-* ``include/random/rand32.h``
+* :file:`include/zephyr/types.h`
+* :file:`lib/libc/minimal/include/errno.h`
+* :file:`include/sys/printk.h`
+* :file:`include/random/rand32.h`
 * :ref:`zephyr:bluetooth_api`:
 
-  * ``include/bluetooth/bluetooth.h``
-  * ``include/bluetooth/conn.h``
-  * ``include/bluetooth/uuid.h``
-  * ``include/bluetooth/gatt.h``
+  * :file:`include/bluetooth/bluetooth.h`
+  * :file:`include/bluetooth/conn.h`
+  * :file:`include/bluetooth/uuid.h`
+  * :file:`include/bluetooth/gatt.h`
 
 The sample also uses the following secure firmware component:
 

--- a/samples/bluetooth/peripheral_status/README.rst
+++ b/samples/bluetooth/peripheral_status/README.rst
@@ -46,18 +46,18 @@ RGB LED:
    The RGB LED channels are used independently to display the following information:
 
    * Red - If the main loop is running (that is, the device is advertising).
-     The LED blinks with a period of 2 seconds, duty cycle of 50%.
+     Blinks with a period of two seconds with the duty cycle set to 50% when the main loop is running and the device is advertising.
    * Green - If the device is connected.
 
    For example, if Thingy:53 is connected over Bluetooth, the LED color toggles between green and yellow.
    The green LED channel is kept on, and the red LED channel is blinking.
 
 Button 1:
-   Set Button 1 NSMS Status Characteristic to: "Pressed" or "Released".
+   Set **Button 1** NSMS Status Characteristic to: "Pressed" or "Released".
    Notify the client if notification is enabled.
 
 Button 2 (the one hidden under the cover):
-   Set Button 2 NSMS Status Characteristic to: "Pressed" or "Released".
+   Set **Button 2** NSMS Status Characteristic to: "Pressed" or "Released".
    Notify the client if notification is enabled.
    By default, this service requires the connection to be secured to read or notify.
 
@@ -65,17 +65,17 @@ Development kits
 ================
 
 LED 1:
-   Blinks when the main loop is running (that is, the device is advertising) with a period of 2 seconds, duty cycle of 50%.
+   Blinks with a period of two seconds with the duty cycle set to 50% when the main loop is running and the device is advertising.
 
 LED 2:
-   On when the development kit is connected.
+   Lit when the development kit is connected.
 
 Button 1:
-   Set Button 1 NSMS Status Characteristic to: "Pressed" or "Released".
+   Set **Button 1** NSMS Status Characteristic to: "Pressed" or "Released".
    Notify the client if notification is enabled.
 
 Button 2 (the one hidden under the cover):
-   Set Button 2 NSMS Status Characteristic to: "Pressed" or "Released".
+   Set **Button 2** NSMS Status Characteristic to: "Pressed" or "Released".
    Notify the client if notification is enabled.
    By default, this service requires the connection to be secured to read or notify.
 
@@ -117,7 +117,9 @@ After programming the sample to your dongle or development kit, test it by perfo
 #. Read **Nordic Status Message Service** message characteristic to check the initial status - if no button was pressed, it should be "Unknown".
 #. Enable notification for the characteristic found.
 #. Press the related button and observe the message change between "Pressed" and "Released".
-#. Note that performing the same for Button 2 characteristic must require a secured connection.
+
+.. note::
+   Performing the same for **Button 2** characteristic requires a secured connection.
 
 Dependencies
 ************
@@ -129,18 +131,18 @@ This sample uses the following |NCS| libraries:
 
 In addition, it uses the following Zephyr libraries:
 
-* ``include/zephyr/types.h``
-* ``lib/libc/minimal/include/errno.h``
-* ``include/sys/printk.h``
-* ``include/sys/byteorder.h``
+* :file:`include/zephyr/types.h`
+* :file:`lib/libc/minimal/include/errno.h`
+* :file:`include/sys/printk.h`
+* :file:`include/sys/byteorder.h`
 * :ref:`GPIO Interface <zephyr:api_peripherals>`
 * :ref:`zephyr:bluetooth_api`:
 
-  * ``include/bluetooth/bluetooth.h``
-  * ``include/bluetooth/hci.h``
-  * ``include/bluetooth/conn.h``
-  * ``include/bluetooth/uuid.h``
-  * ``include/bluetooth/gatt.h``
+  * :file:`include/bluetooth/bluetooth.h`
+  * :file:`include/bluetooth/hci.h`
+  * :file:`include/bluetooth/conn.h`
+  * :file:`include/bluetooth/uuid.h`
+  * :file:`include/bluetooth/gatt.h`
 
 The sample also uses the following secure firmware component:
 

--- a/samples/bluetooth/peripheral_uart/README.rst
+++ b/samples/bluetooth/peripheral_uart/README.rst
@@ -96,7 +96,7 @@ The UART async adapter creates and initializes an instance of the async module.
 This is needed because the USB CDC ACM implementation provides only the interrupt interface.
 The adapter uses data provided in the :c:struct:`uart_async_adapter_data` to connect to the UART device that does not use the asynchronous interface.
 
-The module requires the :kconfig:option:`CONFIG_BT_NUS_UART_ASYNC_ADAPTER` to be set to ``y``.
+The module requires the :ref:`CONFIG_BT_NUS_UART_ASYNC_ADAPTER <CONFIG_BT_NUS_UART_ASYNC_ADAPTER>` to be set to ``y``.
 For more information about the adapter, see the :file:`uart_async_adapter` source files available in the :file:`peripheral_uart/src` directory.
 
 MCUboot with serial recovery of the networking core image
@@ -114,10 +114,10 @@ Development kits
 ================
 
 LED 1:
-   Blinks with a period of 2 seconds, duty cycle 50%, when the main loop is running (device is advertising).
+   Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
 
 LED 2:
-   On when connected.
+   Lit when connected.
 
 Button 1:
    Confirm the passkey value that is printed in the debug logs to pair/bond with the other device.
@@ -138,6 +138,21 @@ Button:
    Confirm the passkey value that is printed in the debug logs to pair/bond with the other device.
    Thingy:53 has only one button, therefore the passkey value cannot be rejected by pressing a button.
 
+Configuration
+*************
+
+|config|
+
+Configuration options
+=====================
+
+Check and configure the following configuration options for the sample:
+
+.. _CONFIG_BT_NUS_UART_ASYNC_ADAPTER:
+
+CONFIG_BT_NUS_UART_ASYNC_ADAPTER - Enable UART async adapter
+   Enables asynchronous adapter for UART drives that supports only IRQ interface.
+
 Building and running
 ********************
 
@@ -154,9 +169,9 @@ To activate the optional extensions supported by this sample, modify :makevar:`O
 
 * For the minimal build variant, set :file:`prj_minimal.conf`.
 * For the USB CDC ACM extension, set :file:`prj_cdc.conf`.
-  Additionally, you need to set :makevar:`DTC_OVERLAY_FILE` to :file:`usb.overlay`.
+  Additionally, you need to set :makevar:`DTC_OVERLAY_FILE` to the :file:`usb.overlay` file.
 * For the MCUboot with serial recovery of the networking core image feature, set the :file:`nrf5340dk_app_sr_net.conf` file.
-  You also need to set the :makevar:`mcuboot_OVERLAY_CONFIG` variant to :file:`nrf5340dk_mcuboot_sr_net.conf`.
+  You also need to set the :makevar:`mcuboot_OVERLAY_CONFIG` variant to the :file:`nrf5340dk_mcuboot_sr_net.conf` file.
 
 See :ref:`cmake_options` for instructions on how to add this option.
 For more information about using configuration overlay files, see :ref:`zephyr:important-build-vars` in the Zephyr documentation.
@@ -177,19 +192,19 @@ After programming the sample to your development kit, complete the following ste
 #. Observe that **LED 1** is blinking and that the device is advertising with the device name that is configured in :kconfig:option:`CONFIG_BT_DEVICE_NAME`.
 #. Observe that the text "Starting Nordic UART service example" is printed on the COM listener running on the computer.
 #. Connect to the device using nRF Connect for Mobile.
-   Observe that **LED 2** is on.
+   Observe that **LED 2** is lit.
 #. Optionally, pair or bond with the device with MITM protection.
    This requires using the passkey value displayed in debug messages.
    See :ref:`peripheral_uart_debug` for details on how to access debug messages.
    To confirm pairing or bonding, press **Button 1** on the device and accept the passkey value on the smartphone.
 #. In the application, observe that the services are shown in the connected device.
-#. Select the UART RX characteristic value in nRF Connect.
+#. Select the UART RX characteristic value in nRF Connect for Mobile.
    You can write to the UART RX and get the text displayed on the COM listener.
-#. Type '0123456789' and tap :guilabel:`SEND`.
+#. Type "0123456789" and tap :guilabel:`SEND`.
    Verify that the text "0123456789" is displayed on the COM listener.
 #. To send data from the device to your phone or tablet, enter any text, for example, "Hello", and press Enter to see it on the COM listener.
    Observe that a notification is sent to the peer.
-#. Disconnect the device in nRF Connect.
+#. Disconnect the device in nRF Connect for Mobile.
    Observe that **LED 2** turns off.
 
 Dependencies
@@ -206,23 +221,23 @@ This sample uses the following |NCS| libraries:
 
 In addition, it uses the following Zephyr libraries:
 
-* ``include/zephyr/types.h``
-* ``boards/arm/nrf*/board.h``
+* :file:`include/zephyr/types.h`
+* :file:`boards/arm/nrf*/board.h`
 * :ref:`zephyr:kernel_api`:
 
-  * ``include/kernel.h``
+  * :file:`include/kernel.h`
 
 * :ref:`zephyr:api_peripherals`:
 
-   * ``include/gpio.h``
-   * ``include/uart.h``
+   * :file:`include/gpio.h`
+   * :file:`include/uart.h`
 
 * :ref:`zephyr:bluetooth_api`:
 
-  * ``include/bluetooth/bluetooth.h``
-  * ``include/bluetooth/gatt.h``
-  * ``include/bluetooth/hci.h``
-  * ``include/bluetooth/uuid.h``
+  * :file:`include/bluetooth/bluetooth.h`
+  * :file:`include/bluetooth/gatt.h`
+  * :file:`include/bluetooth/hci.h`
+  * :file:`include/bluetooth/uuid.h`
 
 The sample also uses the following secure firmware component:
 


### PR DESCRIPTION
Some rewordings and formatting fixes to various
BT peripheral sample docs. Also listing sample-
specific Kconfig options so that they are linkable.