### PR TITLE
samples: nrf9160: modem_shell: workaround ICMP echo reply CRC error

### DIFF
--- a/samples/nrf9160/modem_shell/src/ping/icmp_ping.c
+++ b/samples/nrf9160/modem_shell/src/ping/icmp_ping.c
@@ -182,6 +182,9 @@ static uint32_t send_ping_wait_reply(struct icmp_ping_shell_cmd_argv *ping_args,
 		/* data[2..3] = checksum, calculated later */
 		/* data[4..5] = 0; */ /* Identifier */
 		/* data[6] = 0;  */ /* seqnr >> 8 */
+		if (seqnr == UINT8_MAX) {
+			seqnr = 0;
+		}
 		data[7] = ++seqnr;
 
 		/* Payload */


### PR DESCRIPTION
Using zero as ICMP echo message sequence number causes a CRC error in the echo reply. It's not clear why, because according to the ICMP RFC zero should be a valid value, but skipping zero makes the problem go away.

MOSH-436