### PR TITLE
drivers: wifi: Fix stack overflow

### DIFF
--- a/drivers/wifi/nrf700x/Kconfig.nrf700x
+++ b/drivers/wifi/nrf700x/Kconfig.nrf700x
@@ -155,9 +155,9 @@ config NRF700X_BH_WQ_PRIORITY
 
 config NRF700X_IRQ_WQ_STACK_SIZE
 	int "Stack size of the workqueue for handling IRQs"
-	default 1024
+	default 2048
 
 config NRF700X_BH_WQ_STACK_SIZE
 	int "Stack size of the workqueue for handling bottom half"
-	default 1024
+	default 2048
 endif


### PR DESCRIPTION
Under high memory load, some allocations in nRF700x driver fail resulting in a error print that uses vsnprintf and as the stack size is less it results in a stack overflow.

Increase the stack sizes to handle the error scenarios.