### PR TITLE
manifest: Update to nrf_cc3xx 0.9.17 and nrf_oberon 3.0.13

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -127,7 +127,7 @@ manifest:
     - name: mbedtls
       path: modules/crypto/mbedtls
       repo-path: sdk-mbedtls
-      revision: 3c2bc903cb396af6033115c8186f0807ef81bdaf
+      revision: 9ca9f885bafb3a5d4896600f478147ad69757d82
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib

--- a/west.yml
+++ b/west.yml
@@ -131,7 +131,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 2fa09cf5566a3ec04de696b9e967aaa8bd370f86
+      revision: 74d47036a5ca4804ea895c111aabd5d095918a0a
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Update crypto runtime libraries:
nrf_cc3xx 0.9.17
nrf_oberon 3.0.13

test-sdk-nrf: testing-cryptocell-oberon-release-04-25