### PR TITLE
manifest: Bumped Matter revision to pull stack overflow fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -139,7 +139,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 0bc1c70a941ea1a1ca9ca1c365af2c974ec90088
+      revision: 1088cc84d24254277398317d31ef87200f80db38
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
There are some cases that Matter over Wi-Fi device may fall into stack overflow. The newer Matter revision contains bug fix solving the problem.