### PR TITLE
drivers: wifi: Improve UDP Rx throughput

### DIFF
--- a/drivers/wifi/nrf700x/Kconfig.nrf700x
+++ b/drivers/wifi/nrf700x/Kconfig.nrf700x
@@ -151,7 +151,7 @@ config NRF700X_IRQ_WQ_PRIORITY
 
 config NRF700X_BH_WQ_PRIORITY
 	int "Priority of the workqueue for handling bottom half"
-	default 0
+	default -1
 
 config NRF700X_IRQ_WQ_STACK_SIZE
 	int "Stack size of the workqueue for handling IRQs"


### PR DESCRIPTION
Using co-operative threads improves UDP RX throughput by 10%, this is needed to pass a certification case.