### PR TITLE
doc: Add Wireless coexistence page under Protocols

### DIFF
--- a/doc/nrf/protocols.rst
+++ b/doc/nrf/protocols.rst
@@ -20,5 +20,4 @@ They introduce you to concepts that are important to work with the protocol and 
    protocols/thread/index
    protocols/zigbee/index
    protocols/wifi/index
-
-For details on Wi-Fi coexistence with short range protocols (like Bluetooth LE or Thread), see the :ref:`ug_radio_coex` page.
+   protocols/coexistence/index

--- a/doc/nrf/protocols/coexistence/index.rst
+++ b/doc/nrf/protocols/coexistence/index.rst
@@ -1,0 +1,49 @@
+.. _ug_wireless_coexistence:
+
+Wireless coexistence
+####################
+
+The |NCS| allows you to develop applications with wireless coexistence.
+
+The following table lists wireless coexistence between protocols:
+
+.. list-table::
+    :widths: auto
+    :header-rows: 1
+
+    * - Wireless coexistence
+      - Bluetooth LE
+      - Thread
+      - Zigbee
+      - Wi-Fi
+      - LTE-M/NB-IoT
+    * - Bluetooth LE
+      - N/A
+      - :ref:`Supported<ug_multiprotocol_support>`
+      - :ref:`Supported<ug_multiprotocol_support>`
+      - :ref:`Supported<ug_radio_coex>`
+      - :ref:`Supported <ug_radio_coex_bluetooth_only_1wire>`
+    * - Thread
+      - :ref:`Supported<ug_multiprotocol_support>`
+      - N/A
+      -
+      - :ref:`Supported<ug_radio_coex>`
+      -
+    * - Zigbee
+      - :ref:`Supported<ug_multiprotocol_support>`
+      -
+      - N/A
+      - :ref:`Supported<ug_radio_coex>`
+      -
+    * - Wi-Fi
+      - :ref:`Supported<ug_radio_coex>`
+      - :ref:`Supported<ug_radio_coex>`
+      - :ref:`Supported<ug_radio_coex>`
+      - N/A
+      -
+    * - LTE-M/NB-IoT
+      - :ref:`Supported <ug_radio_coex_bluetooth_only_1wire>`
+      -
+      -
+      -
+      - N/A

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -365,4 +365,4 @@ cJSON
 Documentation
 =============
 
-|no_changes_yet_note|
+* Added a page on :ref:`ug_wireless_coexistence` in :ref:`protocols`.


### PR DESCRIPTION
Add Wireless coexistence page under Protocols
Move “BT radio coexistence” guide to "Wi-Fi Coexistence" page

NCSDK-20383 and NCSDK-20385