### PR TITLE
doc: BT library docs clean up

### DIFF
--- a/doc/nrf/libraries/bluetooth_services/conn_ctx.rst
+++ b/doc/nrf/libraries/bluetooth_services/conn_ctx.rst
@@ -7,13 +7,12 @@ Bluetooth connection context
    :local:
    :depth: 2
 
-Data related to a Bluetooth® connection can be stored in a Bluetooth® connection context.
-The Bluetooth connection context library can be used with Bluetooth LE services that require the connection context to support multilink functionality for the GATT server role.
+Data related to a Bluetooth® connection can be stored in a Bluetooth connection context.
+You can use this library with Bluetooth Low Energy (LE) services that require the connection context to support multilink functionality for the GATT server role.
 
 Each instance of the library can store the contexts for a configurable number of Bluetooth connections (see :ref:`zephyr:bluetooth_connection_mgmt` in the Zephyr documentation).
 
-The following Bluetooth LE service shows how to use this library: :ref:`hids_readme`
-
+The :ref:`hids_readme` shows how to use this library.
 
 API documentation
 *****************

--- a/doc/nrf/libraries/bluetooth_services/enocean.rst
+++ b/doc/nrf/libraries/bluetooth_services/enocean.rst
@@ -19,7 +19,7 @@ The library supports different types of commissioning for both wall switches and
 The library supports replay protection based on sequence numbers.
 Only new, authenticated packets from commissioned devices will go through to the event callbacks.
 
-If the :kconfig:option:`CONFIG_BT_SETTINGS` subsystem is enabled, the device information of all commissioned devices are stored persistently using the :ref:`zephyr:settings_api` subsystem, including the sequence number information.
+If the :kconfig:option:`CONFIG_BT_SETTINGS` subsystem is enabled, the device information of all commissioned devices is stored persistently using the :ref:`zephyr:settings_api` subsystem, including the sequence number information.
 
 For a demonstration of the library features, see the :ref:`enocean_sample` sample.
 
@@ -40,7 +40,7 @@ However, when using the library with your application, you can configure the lim
 Usage
 =====
 
-The EnOcean library uses :c:func:`bt_le_scan_cb_register` to receive Bluetooth advertisement packets from nearby EnOcean devices.
+The EnOcean library uses the :c:func:`bt_le_scan_cb_register` function to receive Bluetooth advertisement packets from nearby EnOcean devices.
 The Bluetooth stack must be initialized separately, and Bluetooth scanning must be started by the application.
 The Bluetooth mesh stack does this automatically, so when combined, the application does not need to perform any additional initialization.
 
@@ -49,21 +49,21 @@ The Bluetooth mesh stack does this automatically, so when combined, the applicat
 Commissioning
 *************
 
-Before the library is able to process sensor or button messages from nearby EnOcean devices, the devices must be commissioned.
+The devices must be commissioned so that the library can process sensor or button messages from nearby EnOcean devices.
 By default, the commissioning behavior may be triggered by interacting with the devices, as explained in the following sections.
 
-To enable radio-based commissioning in your application, call :c:func:`bt_enocean_commissioning_enable`.
+To enable radio-based commissioning in your application, call the :c:func:`bt_enocean_commissioning_enable` function.
 
 Commissioning wall switches
 ---------------------------
 
-EnOcean Easyfit wall switches may be put into the commissioning mode by completing the following sequence:
+To set the EnOcean Easyfit wall switches into the commissioning mode, complete the following sequence:
 
-1. Press and hold one of the buttons for more than 7 seconds before releasing it.
-#. Quickly press and release the same button (hold for less than 2 seconds).
-#. Press and hold the same button again for more than 7 seconds before releasing it.
+1. Press and hold one of the buttons for more than seven seconds before releasing it.
+#. Quickly press and release the same button (hold for less than two seconds).
+#. Press and hold the same button again for more than seven seconds before releasing it.
 
-The switch will transmit its security key, which the library picks up and stores before calling the :c:member:`bt_enocean_callbacks.commissioned` callback.
+The switch transmits its security key, and the library picks up and stores the key before calling the :c:member:`bt_enocean_callbacks.commissioned` callback.
 
 To exit the commissioning mode on a wall switch device, press any of the other buttons on the switch.
 The library will now be reporting button presses through the :c:member:`bt_enocean_callbacks.button` callback.
@@ -78,21 +78,21 @@ The sensor unit never enters the commissioning mode.
 After publishing its security key, the sensor unit automatically goes back to reporting sensor readings at periodic intervals.
 
 .. note::
-   EnOcean devices may be configured to disable radio-based commissioning through NFC.
+   You can configure EnOcean devices to disable radio-based commissioning through NFC.
    In such case, the security key must be obtained through manual input.
 
 Observing output
 ****************
 
-After commissioning an EnOcean device, its activity may be monitored through the :c:type:`bt_enocean_handlers` callback functions passed to :c:func:`bt_enocean_init`.
+After commissioning an EnOcean device, you can monitor its activity through the :c:type:`bt_enocean_handlers` callback functions passed to the :c:func:`bt_enocean_init` function.
 See the :ref:`enocean_sample` for a demonstration of the handler callback functions.
 
 Dependencies
 ************
 
-The EnOcean library depends on the :kconfig:option:`CONFIG_BT_OBSERVER` capability in the Bluetooth stack to function.
+The EnOcean library depends on the :kconfig:option:`CONFIG_BT_OBSERVER` capability in the Bluetooth stack.
 
-To enable persistent storage of device commissioning data, the :kconfig:option:`CONFIG_BT_SETTINGS` subsystem must also be enabled.
+To enable persistent storing of device commissioning data, you must also enable the :kconfig:option:`CONFIG_BT_SETTINGS` Kconfig option.
 
 API documentation
 =================

--- a/doc/nrf/libraries/bluetooth_services/gatt_dm.rst
+++ b/doc/nrf/libraries/bluetooth_services/gatt_dm.rst
@@ -20,7 +20,7 @@ The GATT Discovery Manager is used, for example, in the :ref:`bluetooth_central_
 Limitations
 ***********
 
-* Only one discovery procedure can be running at the same time.
+Only one discovery procedure at a time can be running.
 
 API documentation
 *****************

--- a/doc/nrf/libraries/bluetooth_services/gatt_pool.rst
+++ b/doc/nrf/libraries/bluetooth_services/gatt_pool.rst
@@ -7,7 +7,7 @@ Bluetooth GATT attribute pools
    :local:
    :depth: 2
 
-GATT attribute pools can be used to dynamically create a service description, which can later be registered in the Zephyr GATT database.
+You can use GATT attribute pools to dynamically create a service description that can later be registered in the Zephyr GATT database.
 
 Every GATT service is essentially a set of GATT attributes that are ordered in a particular way.
 There are different types of attributes that can be registered to create a service:
@@ -19,7 +19,7 @@ There are different types of attributes that can be registered to create a servi
 
 The API of the GATT attribute pools module allows to register different types of GATT attributes listed above.
 After each registration, a part of the memory is reserved for each attribute.
-You can also unregister attributes that are no longer needed by using the module's API.
+You can also unregister unnecessary attributes using the module's API.
 In this case, the previously reserved memory is released.
 This can be useful when you want to restructure your service by using the Service Changed feature that is supported by the Zephyr Bluetooth® stack (see, for example, the :ref:`hids_readme`).
 

--- a/doc/nrf/libraries/bluetooth_services/rpc.rst
+++ b/doc/nrf/libraries/bluetooth_services/rpc.rst
@@ -8,22 +8,22 @@ Bluetooth Low Energy Remote Procedure Call
    :depth: 2
 
 The |NCS| supports Bluetooth® Low Energy (LE) stack serialization.
-The full Bluetooth LE stack can run on another device or CPU, such as the nRF5340 DK network core using :ref:`nrfxlib:nrf_rpc`.
+The full Bluetooth LE stack can run on another device or CPU, such as the nRF5340 DK network core using the :ref:`nrfxlib:nrf_rpc`.
 
 Network core
 ************
 
 The :ref:`ble_rpc_host` sample is designed specifically to enable the Bluetooth LE stack functionality on a remote MCU (for example, the nRF5340 network core) using the :ref:`nrfxlib:nrf_rpc`.
-You can program this sample to the network core to run standard Bluetooth Low Energy samples on nRF5340.
+You can program this sample to the network core to run standard Bluetooth Low Energy samples on the nRF5340 DK.
 You can use either the SoftDevice Controller or the Zephyr Bluetooth LE Controller for this sample.
 
 Application core
 ****************
 
 To use the Bluetooth LE stack through nRF RPC, an additional configuration is needed.
-When building samples for the application core, enable the :kconfig:option:`CONFIG_BT_RPC_STACK` to run the Bluetooth LE stack on the network core.
+When building samples for the application core, enable the :kconfig:option:`CONFIG_BT_RPC_STACK` Kconfig option to run the Bluetooth LE stack on the network core.
 This option builds :ref:`ble_rpc_host` automatically as a child image.
-For more details, see: :ref:`ug_nrf5340_building`.
+For more details, see :ref:`ug_nrf5340_building`.
 
 Open a command prompt in the build folder of the application sample and enter the following command to build the application for the application core, with :ref:`ble_rpc_host` as child image:
 

--- a/doc/nrf/libraries/bluetooth_services/scan.rst
+++ b/doc/nrf/libraries/bluetooth_services/scan.rst
@@ -169,9 +169,7 @@ The :kconfig:option:`CONFIG_BT_SCAN_CONN_ATTEMPTS_COUNT` Kconfig option adjusts 
 Samples using the library
 *************************
 
-The following |NCS| application uses this library:
-
-* :ref:`nrf_desktop`
+The :ref:`nrf_desktop` application uses this library.
 
 Dependencies
 ************


### PR DESCRIPTION
Some rewording and formatting fixes
to the BT library docs (excluding Mesh).