### PR TITLE
applications: nrf5340_audio: Get SDU size properly

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/le_audio_bis_headset.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_bis_headset.c
@@ -185,7 +185,7 @@ static void stream_recv_cb(struct bt_bap_stream *stream, const struct bt_iso_rec
 		bad_frame = true;
 	}
 
-	uint32_t octets_per_sdu = bt_codec_cfg_get_octets_per_frame(stream->codec);
+	uint32_t octets_per_sdu = active_stream.codec->octets_per_sdu;
 
 	if (buf->len != octets_per_sdu && bad_frame != true) {
 		data_size_mismatch_cnt++;

--- a/applications/nrf5340_audio/src/bluetooth/le_audio_cis_gateway.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_cis_gateway.c
@@ -586,7 +586,7 @@ static void stream_recv_cb(struct bt_bap_stream *stream, const struct bt_iso_rec
 		return;
 	}
 
-	uint32_t octets_per_frame = bt_codec_cfg_get_octets_per_frame(stream->codec);
+	uint32_t octets_per_frame = stream->qos->sdu;
 
 	if (buf->len != octets_per_frame && bad_frame != true) {
 		data_size_mismatch_cnt++;

--- a/applications/nrf5340_audio/src/bluetooth/le_audio_cis_headset.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_cis_headset.c
@@ -445,7 +445,7 @@ static void stream_recv_cb(struct bt_bap_stream *stream, const struct bt_iso_rec
 		bad_frame = true;
 	}
 
-	uint32_t octets_per_frame = bt_codec_cfg_get_octets_per_frame(stream->codec);
+	uint32_t octets_per_frame = stream->qos->sdu;
 
 	if (buf->len != octets_per_frame && bad_frame != true) {
 		data_size_mismatch_cnt++;


### PR DESCRIPTION
Use API to get SDU size in stream_recv_cb() would
consume too much time and cause stream receving
not work properly. SDU size should get from the
existed structure after stream is configured.