### PR TITLE
application: serial_lte_modem: FIX UART RX disable timing issue

### DIFF
--- a/applications/serial_lte_modem/src/slm_at_host.c
+++ b/applications/serial_lte_modem/src/slm_at_host.c
@@ -852,6 +852,8 @@ static void cmd_send(struct k_work *work)
 
 	ARG_UNUSED(work);
 
+	uart_receive_disable(false);
+
 	if (at_buf_overflow) {
 		rsp_send_error();
 		goto done;
@@ -955,8 +957,6 @@ static int cmd_rx_handler(uint8_t character)
 	return 0;
 
 send:
-	uart_receive_disable(false);
-
 	at_buf[at_cmd_len] = '\0';
 	at_buf_len = at_cmd_len;
 	k_work_submit(&cmd_send_work);


### PR DESCRIPTION
 Move UART disablement out from interrupt context so that we can
 wait to take semaphores.

Related to 0a4fc57d2ebd0d3d1ca2bf4d6b1bf16453aaea53.