### PR TITLE
boards: Remove obsolete nrf-family parameter

### DIFF
--- a/boards/arm/thingy91_nrf52840/board.cmake
+++ b/boards/arm/thingy91_nrf52840/board.cmake
@@ -1,7 +1,6 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA.
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 
-board_runner_args(nrfjprog "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/thingy91_nrf9160/board.cmake
+++ b/boards/arm/thingy91_nrf9160/board.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA.
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 
-board_runner_args(nrfjprog "--nrf-family=NRF91" "--softreset")
+board_runner_args(nrfjprog "--softreset")
 board_runner_args(jlink "--device=cortex-m33" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
This param is now obsolete and not required at all.