### PR TITLE
manifest: sdk-zephyr: Pull fix for twt flow id range

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 6ae8ab054126778fcc0054d5243580e72197359c
+      revision: pull/1136/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Fixes SHEL-1571, TWT Flow ID value range should be between 0 to 7