### PR TITLE
Fix an issue when ESB_NEVER_DISABLE_TX is enabled.

### DIFF
--- a/subsys/esb/esb.c
+++ b/subsys/esb/esb.c
@@ -1603,7 +1603,9 @@ int esb_write_payload(const struct esb_payload *payload)
 
 	if (esb_cfg.mode == ESB_MODE_PTX &&
 	    esb_cfg.tx_mode == ESB_TXMODE_AUTO &&
-	    esb_state == ESB_STATE_IDLE) {
+	    (esb_state == ESB_STATE_IDLE ||
+	     (IS_ENABLED(CONFIG_ESB_NEVER_DISABLE_TX) ?
+	      esb_state == ESB_STATE_PTX_TXIDLE : 0))) {
 		start_tx_transaction();
 	}
 


### PR DESCRIPTION
The experimental feature `ESB_NEVER_DISABLE_TX` can achieve delay below 100µs in-between data transmission and reception. When input data flow in not fast enough, and ESB fifo gets empty, static variable `esb_state` remains to `ESB_STATE_PTX_TXIDLE` instead of `ESB_STATE_IDLE`. 
The esb_write_payload checks this flag before initiating a new transmission, and the new case where `esb_write_payload = ESB_STATE_PTX_TXIDLE` was forgotten.

This bugfix follows the experimental feature PR (now merged) : https://github.com/nrfconnect/sdk-nrf/pull/9835