### PR TITLE
tests: crypto: Skip GCM tests on CC310

### DIFF
--- a/tests/crypto/test_cases/test_aead.c
+++ b/tests/crypto/test_cases/test_aead.c
@@ -626,6 +626,7 @@ ZTEST(test_suite_aead, test_case_aead_ccm_simple)
 	exec_test_case_aead_simple();
 }
 
+#if defined(CONFIG_OBERON_BACKEND) || defined(CONFIG_CC312_BACKEND)
 ZTEST(test_suite_aead, test_case_aead_gcm)
 {
 	aead_gcm_setup();
@@ -637,6 +638,7 @@ ZTEST(test_suite_aead, test_case_aead_gcm_setup_simple)
 	aead_gcm_setup_simple();
 	exec_test_case_aead_simple();
 }
+#endif
 
 ZTEST(test_suite_aead, test_case_chachapoly)
 {

--- a/tests/crypto/test_cases/test_hkdf.c
+++ b/tests/crypto/test_cases/test_hkdf.c
@@ -152,6 +152,7 @@ ITEM_REGISTER(test_case_hkdf_data, test_case_t test_hkdf) = {
 	.vectors_stop = __stop_test_vector_hkdf_data,
 };
 
+#if defined(CONFIG_CRYPTO_TEST_HASH)
 ZTEST_SUITE(test_suite_hkdf, NULL, NULL, NULL, NULL, NULL);
 
 ZTEST(test_suite_hkdf, test_case_hkdf)
@@ -159,3 +160,4 @@ ZTEST(test_suite_hkdf, test_case_hkdf)
 	hkdf_setup();
 	exec_test_case_hkdf();
 }
+#endif

--- a/tests/crypto/test_cases/test_hmac.c
+++ b/tests/crypto/test_cases/test_hmac.c
@@ -168,6 +168,7 @@ ITEM_REGISTER(test_case_hmac_data, test_case_t test_hmac_combined) = {
 	.vectors_stop = __stop_test_vector_hmac_data,
 };
 
+#if defined(CONFIG_CRYPTO_TEST_HASH)
 ZTEST_SUITE(test_suite_hmac, NULL, NULL, NULL, NULL, NULL);
 
 ZTEST(test_suite_hmac, test_case_hmac)
@@ -183,3 +184,4 @@ ZTEST(test_suite_hmac, test_case_hmac_combined)
 	exec_test_case_hmac_combined();
 	hmac_combined_teardown();
 }
+#endif

--- a/tests/crypto/test_cases/test_sha_256.c
+++ b/tests/crypto/test_cases/test_sha_256.c
@@ -220,6 +220,7 @@ ITEM_REGISTER(test_case_sha_256_data, test_case_t test_sha_256_long) = {
 	.vectors_stop = __stop_test_vector_hash_256_long_data,
 };
 
+#if defined(CONFIG_CRYPTO_TEST_HASH)
 ZTEST_SUITE(test_suite_sha_256, NULL, NULL, NULL, NULL, NULL);
 
 ZTEST(test_suite_sha_256, test_case_sha_256)
@@ -235,3 +236,4 @@ ZTEST(test_suite_sha_256, test_case_sha_256_long)
 	exec_test_case_sha_256_long();
 	sha_256_long_teardown();
 }
+#endif

--- a/tests/crypto/test_cases/test_sha_512.c
+++ b/tests/crypto/test_cases/test_sha_512.c
@@ -220,6 +220,7 @@ ITEM_REGISTER(test_case_sha_512_data, test_case_t test_sha_512_long) = {
 	.vectors_stop = __stop_test_vector_hash_512_long_data,
 };
 
+#if defined(CONFIG_CRYPTO_TEST_HASH)
 ZTEST_SUITE(test_suite_sha_512, NULL, NULL, NULL, NULL, NULL);
 
 ZTEST(test_suite_sha_512, test_case_sha_256)
@@ -235,3 +236,4 @@ ZTEST(test_suite_sha_512, test_case_sha_256_long)
 	exec_test_case_sha_512_long();
 	sha_512_long_teardown();
 }
+#endif


### PR DESCRIPTION
These checks were there previously in main.c (which doesn't exist anymore), and was missed during ztest API migration.
- Check for Oberon/CC312 is needed because CC310 on 9160/52840 doesn't support GCM
- CONFIG_CRYPTO_TEST_HASH is not used and is always 'y', but keeping in case it's needed later.

Tested locally with all backends.
![image](https://user-images.githubusercontent.com/124266045/234885116-3335f064-559d-4fc6-a947-93037ee05e78.png)
