### PR TITLE
doc: BT service library docs clean up

### DIFF
--- a/doc/nrf/libraries/bluetooth_services/services/ancs_client.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/ancs_client.rst
@@ -82,9 +82,7 @@ Use the following functions to perform activities related to notifications:
 
 Samples using the library
 *************************
-The following |NCS| sample uses this library:
-
-* :ref:`peripheral_ancs_client`
+The :ref:`peripheral_ancs_client` sample uses this library.
 
 Dependencies
 ************

--- a/doc/nrf/libraries/bluetooth_services/services/bas_client.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/bas_client.rst
@@ -26,24 +26,24 @@ Usage
 There are different ways to retrieve the battery level:
 
 Notifications
-  Use :c:func:`bt_bas_subscribe_battery_level` to receive notifications from the connected Battery Service.
+  Use the :c:func:`bt_bas_subscribe_battery_level` function to receive notifications from the connected Battery Service.
   The notifications are passed to the provided callback function.
 
-  Note that it is not mandatory for the Battery Level Characteristic to support notifications.
+  The Battery Level Characteristic does not need to support notifications.
   If the server does not support notifications, read the current value as described below instead.
 
 Reading the current value
-  Use :c:func:`bt_bas_read_battery_level` to read the battery level.
+  Use the :c:func:`bt_bas_read_battery_level` function to read the battery level.
   When subscribing to notifications, you can call this function to retrieve the current value even when there is no change.
 
 Periodically reading the current value with time interval
-  Use :c:func:`bt_bas_start_per_read_battery_level` to periodically read the battery level with a given time interval.
+  Use the :c:func:`bt_bas_start_per_read_battery_level` function to periodically read the battery level with a given time interval.
   You can call this function only when notification support is not enabled in BAS.
   See :ref:`bas_client_readme_periodic` for more details.
 
 Getting the last known value
   The BAS Client stores the last known battery level information internally.
-  Use :c:func:`bt_bas_get_last_battery_level` to access it.
+  Use the :c:func:`bt_bas_get_last_battery_level` function to access it.
 
   .. note::
      The internally stored value is updated every time a notification or read response is received.
@@ -62,7 +62,7 @@ For many devices, the battery level value does not change frequently.
 Depending on the type of connected device, you can decide how often to read the battery level value.
 For example, if the expected battery life is in the order of years, reading the battery level value more frequently than once a week is not recommended.
 
-Periodic read interval can be changed while the periodic read is active.
+You can change the periodic read interval while the periodic read is active.
 In such case, the next read period is started with the new interval.
 
 .. note::

--- a/doc/nrf/libraries/bluetooth_services/services/bms.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/bms.rst
@@ -12,9 +12,9 @@ This module implements the Bond Management Service with the corresponding set of
 You can configure the service to support your desired feature set of bond management operations.
 All the BMS features in the "LE transport only" mode are supported:
 
- * delete the bond of the requesting device,
- * delete all bonds on the Server,
- * delete all bonds on the Server except the one of the requesting device.
+ * Delete the bond of the requesting device.
+ * Delete all bonds on the Server.
+ * Delete all bonds on the Server except the one of the requesting device.
 
 You can enable each feature when initializing the module.
 
@@ -23,7 +23,7 @@ Authorization
 
 You can require authorization to access each BMS feature.
 
-When required, the Client's request to execute a bond management operation should contain the authorization code.
+When required, the Client's request to execute a bond management operation must contain the authorization code.
 The Server compares the code with its local version and accepts the request only if the codes match.
 
 If you use at least one BMS feature that requires authorization, you need to provide a callback with comparison logic for the authorization codes.
@@ -32,7 +32,7 @@ You can set this callback when initializing the module.
 Deleting the bonds
 ******************
 
-The Server deletes bonding information on Client's request right away when there is no active Bluetooth® LE connection associated with a bond.
+The Server deletes bonding information on Client's request right away when there is no active Bluetooth® Low Energy connection associated with a bond.
 Otherwise, the Server removes the bond for a given peer when it disconnects.
 
 API documentation

--- a/doc/nrf/libraries/bluetooth_services/services/cgms.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/cgms.rst
@@ -23,7 +23,7 @@ Configuration
 Set the maximum number of glucose measurement records stored in the device using the :kconfig:option:`CONFIG_BT_CGMS_MAX_MEASUREMENT_RECORD` Kconfig option.
 The value of should be large enough to hold all records generated in a session.
 
-Set the logging level of the CGMS module using the :kconfig:option:`CONFIG_BT_CGMS_LOG_LEVEL` Kconfig option.
+Set the logging level of the CGMS module using the :kconfig:option:`CONFIG_BT_CGMS_LOG_LEVEL_CHOICE` Kconfig option.
 
 Usage
 *****

--- a/doc/nrf/libraries/bluetooth_services/services/ddfs.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/ddfs.rst
@@ -7,7 +7,7 @@ Direction and Distance Finding Service (DDFS)
    :local:
    :depth: 2
 
-The Bluetooth® LE GATT Direction and Distance Finding Service is a custom service that allows publication of distance, azimuth and elevation measurement data.
+The Bluetooth® Low Energy GATT Direction and Distance Finding Service is a custom service that allows publication of distance, azimuth and elevation measurement data.
 It also allows adjusting the measurement configuration parameters.
 
 .. note::
@@ -16,7 +16,7 @@ It also allows adjusting the measurement configuration parameters.
 Service UUID
 ************
 
-The 128-bit vendor-specific service UUID is 21490000-494a-4573-98af-f126af76f490.
+The 128-bit vendor-specific service UUID is ``21490000-494a-4573-98af-f126af76f490``.
 
 .. list-table:: Characteristic UUIDs
     :widths: auto
@@ -25,15 +25,15 @@ The 128-bit vendor-specific service UUID is 21490000-494a-4573-98af-f126af76f490
     * - Characteristic
       - UUID
     * - Distance Measurement
-      - 21490001-494a-4573-98af-f126af76f490
+      - ``21490001-494a-4573-98af-f126af76f490``
     * - Azimuth Measurement
-      - 21490002-494a-4573-98af-f126af76f490
+      - ``21490002-494a-4573-98af-f126af76f490``
     * - Elevation Measurement
-      - 21490003-494a-4573-98af-f126af76f490
+      - ``21490003-494a-4573-98af-f126af76f490``
     * - DDF Feature
-      - 21490004-494a-4573-98af-f126af76f490
+      - ``21490004-494a-4573-98af-f126af76f490``
     * - Control Point
-      - 21490005-494a-4573-98af-f126af76f490
+      - ``21490005-494a-4573-98af-f126af76f490``
 
 Characteristics
 ***************

--- a/doc/nrf/libraries/bluetooth_services/services/dfu_smp.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/dfu_smp.rst
@@ -21,15 +21,15 @@ The SMP Service Client is used in the :ref:`bluetooth_central_dfu_smp` sample.
 Service UUID
 ************
 
-The 128-bit service UUID is 8D53DC1D-1DB7-4CD3-868B-8A527460AA84 (16-bit offset: 0x0001).
+The 128-bit service UUID is ``8D53DC1D-1DB7-4CD3-868B-8A527460AA84`` (16-bit offset: ``0x0001``).
 
 Characteristics
 ***************
 
 This service has one characteristic that is used for both requests and responses.
 
-SMP Characteristic (DA2E7828-FBCE-4E01-AE9E-261174997C48)
-=========================================================
+SMP Characteristic (``DA2E7828-FBCE-4E01-AE9E-261174997C48``)
+=============================================================
 
 Write Without Response
    * Write an SMP command with data.
@@ -54,23 +54,22 @@ For most operations, this requires a bigger MTU size than the default one.
 This requires MTU negotiation in the MTU exchange process (see :c:func:`bt_gatt_exchange_mtu`).
 Writing long characteristic values is not supported.
 
-Note that this is a limitation of the :ref:`zephyr:smp_svr_sample`, not of the SMP Client.
+This is a limitation of the :ref:`zephyr:smp_svr_sample`, not of the SMP Client.
 
 Sending a command
 =================
 
-To send a command, use :c:func:`bt_dfu_smp_command`.
-The command is provided as a raw binary buffer consisting of a :c:struct:`dfu_smp_header` and the payload.
-
+To send a command, use the :c:func:`bt_dfu_smp_command` function.
+The command is provided as a raw binary buffer consisting of a :c:struct:`bt_dfu_smp_header` and the payload.
 
 Processing the response
 =======================
 
-The response to a command is sent as notification.
-It is passed to the callback function that was provided when issuing the command with :c:func:`bt_dfu_smp_command`.
+The response to a command is sent as a notification.
+It is passed to the callback function that was provided when issuing the command with the :c:func:`bt_dfu_smp_command` function.
 
-Use :c:func:`bt_dfu_smp_rsp_state` to access the data of the current part of the response.
-As the response might be received in multiple notifications, use :c:func:`bt_dfu_smp_rsp_total_check` to verify if this is the last part of the response.
+Use the :c:func:`bt_dfu_smp_rsp_state` function to access the data of the current part of the response.
+As the response might be received in multiple notifications, use the :c:func:`bt_dfu_smp_rsp_total_check` function to verify if this is the last part of the response.
 The offset size of the current part and the total size are available in fields of the :c:struct:`bt_dfu_smp_rsp_state` structure.
 
 

--- a/doc/nrf/libraries/bluetooth_services/services/fast_pair.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/fast_pair.rst
@@ -7,7 +7,7 @@ Google Fast Pair Service (GFPS)
    :local:
    :depth: 2
 
-The Google Fast Pair Service (Fast Pair for short) implements a Bluetooth® LE GATT Service required when :ref:`ug_bt_fast_pair`.
+The Google Fast Pair Service (Fast Pair for short) implements a Bluetooth® Low Energy (LE) GATT Service required when :ref:`ug_bt_fast_pair`.
 
 Service UUID
 ************
@@ -23,7 +23,7 @@ The implementation in the |NCS| follows these requirements.
 Configuration
 *************
 
-Set the :kconfig:option:`CONFIG_BT_FAST_PAIR` to enable the module.
+Set the :kconfig:option:`CONFIG_BT_FAST_PAIR` Kconfig option to enable the module.
 
 The following Kconfig options are also available for this module:
 
@@ -54,19 +54,19 @@ During discoverable advertising session, the Resolvable Private Address (RPA) ro
 Therefore, consider the following points:
 
 * Make sure that your advertising session is shorter than the value in the :kconfig:option:`CONFIG_BT_RPA_TIMEOUT` option.
-* Call :c:func:`bt_le_oob_get_local` to trigger RPA rotation and reset the RPA timeout right before the start of advertising.
+* Call the :c:func:`bt_le_oob_get_local` function to trigger RPA rotation and reset the RPA timeout right before advertising starts.
 
 Bluetooth Security Manager Protocol (SMP)
 -----------------------------------------
 
-The service selects :kconfig:option:`CONFIG_BT_SMP`, :kconfig:option:`CONFIG_BT_SMP_APP_PAIRING_ACCEPT`, and :kconfig:option:`CONFIG_BT_SMP_ENFORCE_MITM`.
-The Fast Pair specification requires support for Bluetooth LE pairing and enforcing :term:`Man-in-the-Middle (MITM)` protection during the Fast Pair procedure.
+The service selects the Kconfig options :kconfig:option:`CONFIG_BT_SMP`, :kconfig:option:`CONFIG_BT_SMP_APP_PAIRING_ACCEPT`, and :kconfig:option:`CONFIG_BT_SMP_ENFORCE_MITM`.
+The Fast Pair specification requires support for Bluetooth® Low Energy pairing and enforcing :term:`Man-in-the-Middle (MITM)` protection during the Fast Pair procedure.
 
 Firmware Revision characteristic
 --------------------------------
 
 The Fast Pair specification requires enabling GATT Device Information Service and the Firmware Revision characteristic.
-For this reason, the default values of :kconfig:option:`CONFIG_BT_DIS` and :kconfig:option:`CONFIG_BT_DIS_FW_REV`, respectively, are set to enabled.
+For this reason, the default values of the Kconfig options :kconfig:option:`CONFIG_BT_DIS` and :kconfig:option:`CONFIG_BT_DIS_FW_REV`, respectively, are set to enabled.
 The default value of :kconfig:option:`CONFIG_BT_DIS_FW_REV_STR` is set to :kconfig:option:`CONFIG_MCUBOOT_IMAGE_VERSION` if :kconfig:option:`CONFIG_BOOTLOADER_MCUBOOT` is enabled.
 Otherwise, it is set to ``0.0.0+0``.
 
@@ -82,26 +82,26 @@ Because of this requirement, the default values of the following Kconfig options
 * :kconfig:option:`CONFIG_BT_CTLR_DATA_LENGTH_MAX`
 
 .. tip::
-   In case of :ref:`nRF53 Series <ug_nrf53>`, this part of the configuration cannot be automatically updated for the network core and you must manually align it.
-   The listed options must be set on the network core to default values specified by the GFPS Kconfig options.
+   When using :ref:`nRF53 Series <ug_nrf53>` devices, this part of the configuration cannot be automatically updated for the network core and you must manually align it.
+   The listed options must be set on the network core to the default values specified by the GFPS Kconfig options.
 
 Security re-establishment
 -------------------------
 
 By default, the Fast Pair service disables the automatic security re-establishment request as a peripheral (:kconfig:option:`CONFIG_BT_GATT_AUTO_SEC_REQ`).
-This is done to allow Fast Pair Seeker to control the security re-establishment.
+This allows a Fast Pair Seeker to control the security re-establishment.
 
 Partition Manager
 -----------------
 
 The Fast Pair provisioning data is preprogrammed to a dedicated flash memory partition.
-The GFPS selects :kconfig:option:`CONFIG_PM_SINGLE_IMAGE` to enable the :ref:`partition_manager`.
+The GFPS selects the :kconfig:option:`CONFIG_PM_SINGLE_IMAGE` Kconfig option to enable the :ref:`partition_manager`.
 
 Settings
 --------
 
 The GFPS uses Zephyr's :ref:`zephyr:settings_api` to store Account Keys and the Personalized Name.
-Because of this, the GFPS selects :kconfig:option:`CONFIG_SETTINGS`.
+Because of this, the GFPS selects the :kconfig:option:`CONFIG_SETTINGS` Kconfig option.
 
 Implementation details
 **********************
@@ -116,9 +116,9 @@ Bluetooth authentication
 The Bluetooth pairing is handled using a set of Bluetooth authentication callbacks (:c:struct:`bt_conn_auth_cb`).
 The pairing flow and the set of Bluetooth authentication callbacks in use depend on whether the connected peer follows the Fast Pair pairing flow:
 
-* If the peer follows the Fast Pair pairing flow, the Fast Pair service calls :c:func:`bt_conn_auth_cb_overlay` to automatically overlay the Bluetooth authentication callbacks.
+* If the peer follows the Fast Pair pairing flow, the Fast Pair service calls the :c:func:`bt_conn_auth_cb_overlay` function to automatically overlay the Bluetooth authentication callbacks.
   The function is called while handling the Key-based Pairing request.
-  Overlying callbacks allow the GFPS to take over Bluetooth authentication during `Fast Pair Procedure`_ and perform all of the required operations without interacting with the application.
+  Overlying callbacks allow the GFPS to take over Bluetooth authentication during the `Fast Pair Procedure`_ and perform all of the required operations without interacting with the application.
 * If the peer does not follow the Fast Pair pairing flow, normal Bluetooth LE pairing and global Bluetooth authentication callbacks are used.
 
 API documentation

--- a/doc/nrf/libraries/bluetooth_services/services/hids.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/hids.rst
@@ -7,25 +7,20 @@ GATT Human Interface Device (HID) Service
    :local:
    :depth: 2
 
-This module implements the Human Interface Device Service with the corresponding
-set of characteristics. When initialized, it adds the HID Service and a set of
-characteristics, according to the HID Service specification and to the user
-requirements, to the Zephyr Bluetooth® stack database.
+This module implements the Human Interface Device Service with the corresponding set of characteristics.
+When initialized, it adds the HID Service and a set of characteristics, according to the `HID Service Specification`_ and the user requirements, to the Zephyr Bluetooth® stack database.
 
-If enabled, notification of Input Report characteristics is performed when the
-application calls the corresponding :c:func:`bt_hids_inp_rep_send` function.
+If enabled, a notification of Input Report characteristics is sent when the application calls the corresponding :c:func:`bt_hids_inp_rep_send` function.
 
-You can register dedicated event handlers for most of the HIDS characteristics
-to be notified about changes in their values.
+You can register dedicated event handlers for most of the HIDS characteristics to be notified about changes in their values.
 
-The HIDS module must be notified about the incoming connect and
-disconnect events using the dedicated API. This is done to synchronize
-the connection state of HIDS with the top module that uses it.
+The HIDS module must be notified about the incoming connect and disconnect events using the dedicated API.
+This is done to synchronize the connection state of HIDS with the top module that uses it.
 
 .. note::
 
-   Some systems require security to use the HID service.
-   To ensure interoperability, enable the :kconfig:option:`CONFIG_BT_HIDS_DEFAULT_PERM_RW_ENCRYPT` option.
+   Some systems require security to use the HID Service.
+   To ensure interoperability, enable the :kconfig:option:`CONFIG_BT_HIDS_DEFAULT_PERM_RW_ENCRYPT` Kconfig option.
 
 The HID Service is used in the following samples:
 
@@ -35,35 +30,28 @@ The HID Service is used in the following samples:
 Service Changed support
 ***********************
 
-You can change the structure of the HID Service dynamically, even
-during an ongoing connection, by using the Service Changed feature that is
-supported by the Zephyr Bluetooth stack. To do it, you must
-uninitialize the currently used HIDS instance, prepare a new description of the
-service structure, and initialize a new instance. In such case, the Bluetooth
-stack automatically notifies connected peers about the changed service.
+You can change the structure of the HID Service dynamically, even during an ongoing connection, by using the Service Changed feature supported by the Zephyr Bluetooth stack.
+You must uninitialize the currently used HIDS instance, prepare a new description of the service structure, and initialize a new instance.
+In such case, the Bluetooth stack automatically notifies connected peers about the changed service.
 
 Multiclient support
 *******************
 
-The HIDS module is able to handle multiple connected peers at the same time. The
-server allocates context data for each connected client. The context data
-is then used to store the values of HIDS characteristics. These values are
-unique for each connected peer. While sending notifications, the user
-can also target a specific client by providing the connection instance
-that is associated with it.
+The HIDS module can handle multiple connected peers at the same time.
+The server allocates context data for each connected client.
+The context data is then used to store the values of HIDS characteristics.
+These values are unique for each connected peer.
+While sending notifications, you can also target a specific client by providing the connection instance that is associated with it.
 
 Report masking
 **************
 
-The HIDS module can consist of reports that are used to transmit differential
-data. One example of such a report type is a mouse report. In a mouse report,
-mouse movement data represents the position change along the X or Y axis and
-should only be interpreted once by the HID host. After receiving a notification from
-the HID device, the client should not be able to get any non-zero value from
-the differential data part of the report by using the GATT Read Request on its
-characteristic. This is achieved by report masking. You can
-configure a relevant mask for a report to specify which
-part of the report is not to be stored as a characteristic value.
+The HIDS module can consist of reports that are used to transmit differential data.
+One example of such a report type is a mouse report.
+In a mouse report, mouse movement data represents the position change along the X or Y axis and should only be interpreted once by the HID host.
+After receiving a notification from the HID device, the client should not be able to get any non-zero value from the differential data part of the report by using the GATT Read Request on its characteristic.
+This is achieved by report masking.
+You can configure a relevant mask for a report to specify which part of the report is not to be stored as a characteristic value.
 
 API documentation
 *****************

--- a/doc/nrf/libraries/bluetooth_services/services/hogp.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/hogp.rst
@@ -44,10 +44,10 @@ The following functions are available to retrieve the readiness state of the ser
 Reading the report map
 ======================
 
-To read the report map, call :c:func:`bt_hogp_map_read`.
+To read the report map, call the :c:func:`bt_hogp_map_read` function.
 If the report map does not fit into a single PDU, call the function repeatedly with different offsets.
 
-There is no specific support for HIDS report map interpretation implemented in the HIDS Client.
+The HIDS report map interpretation implemented in the HIDS Client is not specifically supported.
 
 Accessing the reports
 =====================
@@ -67,7 +67,7 @@ The report size is always updated before the callback function is called while r
 It can be obtained by calling :c:func:`bt_hogp_rep_size`.
 
 All report operations require a report info pointer as input.
-How to retrieve this pointer depends on if you are processing a normal report or a boot report.
+How to retrieve this pointer depends on whether you are processing a normal report or a boot report.
 
 .. tabs::
 
@@ -88,7 +88,7 @@ How to retrieve this pointer depends on if you are processing a normal report or
       * For the keyboard boot protocol, the two functions :c:func:`bt_hogp_rep_boot_kbd_in` and :c:func:`bt_hogp_rep_boot_kbd_out` return a non-NULL value.
 
       All these functions return report pointers that may be used in the access functions.
-      Note, however, that these pointers cannot be used as a previous record pointer in :c:func:`bt_hogp_rep_next`.
+      However, these pointers cannot be used as a previous record pointer in :c:func:`bt_hogp_rep_next`.
 
 Changing protocol mode
 ======================

--- a/doc/nrf/libraries/bluetooth_services/services/hrs_client.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/hrs_client.rst
@@ -18,18 +18,17 @@ It can also configure the Heart Rate Service on a remote device by writing speci
 Configuration
 *************
 
-Applications use the scanning module for detecting advertising devices that support the Heart Rate Service.
-If the advertising device is detected, the application will connect to it automatically and will start receiving HRS data.
+Applications use the :ref:`lib_nrf_bt_scan_readme` for detecting advertising devices that support the Heart Rate Service.
+If an advertising device is detected, the application connects to it automatically and starts receiving HRS data.
 
 Once a connection with a remote device providing a Heart Rate Service is established, the client needs service discovery to discover Heart Rate Service handles.
 If this succeeds, the handles of the Heart Rate Service must be assigned to a HRS client instance using the :c:func:`bt_hrs_client_handles_assign` function.
-
-The application is ready to operate with the remote Heart Rate Service.
+Now, the application is ready to operate with the remote Heart Rate Service.
 
 Usage
 *****
 
-Retrieve data from Heart Rate Service or configure its behavior using the following functions:
+Retrieve data from the Heart Rate Service or configure its behavior using the following functions:
 
 * :c:func:`bt_hrs_client_measurement_subscribe` - Enable notifications for the Heart Rate Measurement characteristic.
 

--- a/doc/nrf/libraries/bluetooth_services/services/latency.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/latency.rst
@@ -13,18 +13,18 @@ This characteristic can be used to calculate the round-trip time of a GATT Write
 Service UUID
 ************
 
-The 128-bit service UUID is 67136E01-58DB-F39B-3446-FDDE58C0813A.
+The 128-bit service UUID is ``67136E01-58DB-F39B-3446-FDDE58C0813A``.
 
 Characteristics
 ***************
 
 This service has one characteristic.
 
-Latency Characteristic (67136E02-58DB-F39B-3446-FDDE58C0813A)
-=============================================================
+Latency Characteristic (``67136E02-58DB-F39B-3446-FDDE58C0813A``)
+=================================================================
 
 Write
-   The server is waiting for a write request from the client, then it will automatically reply a write response back.
+   The server is waiting for a write request from the client, and replies with a write response.
 
 
 API documentation

--- a/doc/nrf/libraries/bluetooth_services/services/latency_client.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/latency_client.rst
@@ -8,13 +8,13 @@ GATT Latency Client
    :depth: 2
 
 The Latency Client can be used to interact with a connected peer that is running the Latency service with the :ref:`latency_readme`.
-It writes data to the Latency characteristic and wait for a response to count the time spend of a GATT Write operation.
+It writes data to the Latency characteristic and waits for a response to count the time spent of a GATT Write operation.
 
 Latency Characteristic
 **********************
 
-To send data to the Latency Characteristic, use the send API of this module.
-The sending procedure is asynchronous, so the data to be sent must remain valid until a dedicated callback notifies you that the Write Request has been completed.
+To request latency data from the Latency Characteristic, use the :c:func:`bt_latency_request` function.
+The request sending procedure is asynchronous, so the request data to be sent must remain valid until a dedicated callback notifies you that the Write Request has been completed.
 
 API documentation
 *****************

--- a/doc/nrf/libraries/bluetooth_services/services/lbs.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/lbs.rst
@@ -14,15 +14,15 @@ The LBS Service is used in the :ref:`peripheral_lbs` sample.
 Service UUID
 ************
 
-The 128-bit vendor-specific service UUID is 00001523-1212-EFDE-1523-785FEABCD123.
+The 128-bit vendor-specific service UUID is ``00001523-1212-EFDE-1523-785FEABCD123``.
 
 Characteristics
 ***************
 
 This service has two characteristics.
 
-Button Characteristic (00001524-1212-EFDE-1523-785FEABCD123)
-============================================================
+Button Characteristic (``00001524-1212-EFDE-1523-785FEABCD123``)
+================================================================
 
 Notify:
     Enable notifications for the Button Characteristic to receive button data from the application.
@@ -30,8 +30,8 @@ Notify:
 Read:
     Read button data from the application.
 
-LED Characteristic (00001525-1212-EFDE-1523-785FEABCD123)
-=========================================================
+LED Characteristic (``00001525-1212-EFDE-1523-785FEABCD123``)
+=============================================================
 
 Write:
     Write data to the LED Characteristic to change the LED state.

--- a/doc/nrf/libraries/bluetooth_services/services/mds.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/mds.rst
@@ -7,7 +7,7 @@ Memfault Diagnostic Service (MDS)
    :local:
    :depth: 2
 
-The Bluetooth® LE GATT Memfault Diagnostic Service is a custom service that forwards diagnostic data collected by firmware through a Bluetooth gateway.
+The Bluetooth® Low Energy (LE) GATT Memfault Diagnostic Service is a custom service that forwards diagnostic data collected by firmware through a Bluetooth gateway.
 The diagnostic data is collected by the `Memfault SDK`_ integrated with the |NCS|.
 
 To get started with Memfault integration in |NCS|, see :ref:`ug_memfault`.
@@ -17,7 +17,7 @@ The MDS is used in the :ref:`peripheral_mds` sample.
 Service UUID
 ************
 
-The 128-bit service UUID is **54220000-f6a5-4007-a371-722f4ebd8436**.
+The 128-bit service UUID is ``54220000-f6a5-4007-a371-722f4ebd8436``.
 
 Characteristics
 ***************
@@ -32,7 +32,7 @@ The service implementation available in the |NCS| follows these requirements.
 Configuration
 *************
 
-Set the :kconfig:option:`CONFIG_BT_MDS` to enable the service.
+Set the :kconfig:option:`CONFIG_BT_MDS` Kconfig option to enable the service.
 
 The following configuration options are available for this module:
 
@@ -71,8 +71,8 @@ Restricting access
 
 The Memfault service characteristics data might contain sensitive data.
 It is recommended to use the Bluetooth privacy and encrypted link to access the diagnostic data.
-Enable the :kconfig:option:`CONFIG_BT_SMP` option to require encryption for access in the default configuration.
-It is also highly recommended to implement the :c:func:`access_enable` callback.
+Enable the :kconfig:option:`CONFIG_BT_SMP` Kconfig option to require encryption for access in the default configuration.
+It is also highly recommended to implement the :c:member:`access_enable` callback.
 See :ref:`peripheral_mds` for an implementation example.
 
 Bluetooth privacy

--- a/doc/nrf/libraries/bluetooth_services/services/nsms.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/nsms.rst
@@ -12,22 +12,22 @@ The status can be either notified or directly read (without waiting for notifica
 
 The NSMS service is used in the :ref:`peripheral_status` sample.
 
-Multiple instances of the service can be implemented to show the status of different parts of the system.
-The instances can be distinguished by the client by its name provided in the Characteristic User Description (CUD).
+You can implement multiple instances of the service to show the status of different parts of the system.
+The client can distinguish different instances by the name provided in the Characteristic User Description (CUD).
 
 Service UUID
 ************
 
-The 128-bit vendor-specific service UUID is 57a70000-9350-11ed-a1eb-x0242ac120002.
+The 128-bit vendor-specific service UUID is ``57a70000-9350-11ed-a1eb-x0242ac120002``.
 
 Characteristics
 ***************
 
-This service has one characteristic with the CCC and CUD descriptors.
+This service has one characteristic with the Client Characteristic Configuration (CCC) and CUD descriptors.
 CUD holds the name of the Status Message and helps to distinguish between different instances of the NSMS on the same device.
 
-Status Characteristic (57a70001-9350-11ed-a1eb-0242ac120002)
-============================================================
+Status Characteristic (``57a70001-9350-11ed-a1eb-0242ac120002``)
+================================================================
 
 Notify
   Enable notifications for the Status Characteristic to receive notifications when the status message changes.

--- a/doc/nrf/libraries/bluetooth_services/services/nus.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/nus.rst
@@ -7,7 +7,7 @@ Nordic UART Service (NUS)
    :local:
    :depth: 2
 
-The Bluetooth® LE GATT Nordic UART Service is a custom service that receives and writes data and serves as a bridge to the UART interface.
+The Bluetooth® Low Energy (LE) GATT Nordic UART Service is a custom service that receives and writes data and serves as a bridge to the UART interface.
 
 The NUS Service is used in the :ref:`peripheral_uart` sample.
 It is also included with the Thingy:91 :ref:`connectivity_bridge`, but is disabled by default, and with the :ref:`Matter door lock sample <matter_lock_sample>`, as an optional feature that extends the Bluetooth LE connectivity.
@@ -15,21 +15,21 @@ It is also included with the Thingy:91 :ref:`connectivity_bridge`, but is disabl
 Service UUID
 ************
 
-The 128-bit vendor-specific service UUID is 6E400001-B5A3-F393-E0A9-E50E24DCCA9E  (16-bit offset: 0x0001).
+The 128-bit vendor-specific service UUID is ``6E400001-B5A3-F393-E0A9-E50E24DCCA9E`` (16-bit offset: ``0x0001``).
 
 Characteristics
 ***************
 
 This service has two characteristics.
 
-RX Characteristic (6E400002-B5A3-F393-E0A9-E50E24DCCA9E)
-========================================================
+RX Characteristic (``6E400002-B5A3-F393-E0A9-E50E24DCCA9E``)
+============================================================
 
 Write or Write Without Response
-   Write data to the RX Characteristic to send it on to the UART interface.
+   Write data to the RX Characteristic to send it to the UART interface.
 
-TX Characteristic (6E400003-B5A3-F393-E0A9-E50E24DCCA9E)
-========================================================
+TX Characteristic (``6E400003-B5A3-F393-E0A9-E50E24DCCA9E``)
+============================================================
 
 Notify
    Enable notifications for the TX Characteristic to receive data from the application.

--- a/doc/nrf/libraries/bluetooth_services/services/nus_client.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/nus_client.rst
@@ -16,14 +16,14 @@ The NUS Service Client is used in the :ref:`central_uart` sample.
 RX Characteristic
 *****************
 
-To send data to the RX Characteristic, use the send API of this module.
+To send data to the RX Characteristic, use the :c:func:`bt_nus_client_send` function of this module.
 The sending procedure is asynchronous, so the data to be sent must remain valid until a dedicated callback notifies you that the Write Request has been completed.
 
 TX Characteristic
 *****************
 
 To receive data coming from the TX Characteristic, enable notifications after the service discovery.
-After that, you can request to disable notifications again by returning the STOP value in the callback that is used to handle incoming data.
+After that, you can request to disable notifications again by returning the ``STOP`` value in the callback that is used to handle incoming data.
 Another dedicated callback is triggered when your request has been completed, to inform you that you have unsubscribed successfully.
 
 API documentation

--- a/doc/nrf/libraries/bluetooth_services/services/throughput.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/throughput.rst
@@ -17,26 +17,26 @@ The GATT Throughput Service is used in the :ref:`ble_throughput` sample.
 Service UUID
 ************
 
-The 128-bit service UUID is 0483DADD-6C9D-6CA9-5D41-03AD4FFF4ABB.
+The 128-bit service UUID is ``0483DADD-6C9D-6CA9-5D41-03AD4FFF4ABB``.
 
 Characteristics
 ***************
 
 This service has one characteristic.
 
-Throughput (0x1524)
-===================
+Throughput (``0x1524``)
+=======================
 
 Write Without Response
    * Write any data to the characteristic to measure throughput.
-   * Write 0 bytes to the characteristic to reset the metrics.
+   * Write one byte to the characteristic to reset the metrics.
 
 Read
    The read operation returns 3*4 bytes (12 bytes) that contain the metrics:
 
-   * 4 bytes unsigned: Number of GATT writes received
-   * 4 bytes unsigned: Total bytes received
-   * 4 bytes unsigned: Throughput in bits per second
+   * Four bytes unsigned: Number of GATT writes received
+   * Four bytes unsigned: Total bytes received
+   * Four bytes unsigned: Throughput in bits per second
 
 
 API documentation

--- a/doc/nrf/libraries/bluetooth_services/services/wifi_prov.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/wifi_prov.rst
@@ -24,38 +24,38 @@ Service declaration
 The Wi-Fi Provisioning Service is instantiated as a primary service.
 Set the service UUID value as defined in the following table.
 
-========================== ====================================
+========================== ========================================
 Service name               UUID
-Wi-Fi Provisioning Service 14387800-130c-49e7-b877-2881c89cb258
-========================== ====================================
+Wi-Fi Provisioning Service ``14387800-130c-49e7-b877-2881c89cb258``
+========================== ========================================
 
 Service characteristics
 =======================
 
 The UUID value of characteristics are defined in the following table.
 
-========================== ====================================
+========================== ========================================
 Characteristic name        UUID
-Information                14387801-130c-49e7-b877-2881c89cb258
-Operation Control Point    14387802-130c-49e7-b877-2881c89cb258
-Data Out                   14387803-130c-49e7-b877-2881c89cb258
-========================== ====================================
+Information                ``14387801-130c-49e7-b877-2881c89cb258``
+Operation Control Point    ``14387802-130c-49e7-b877-2881c89cb258``
+Data Out                   ``14387803-130c-49e7-b877-2881c89cb258``
+========================== ========================================
 
 The characteristic requirements of the Wi-Fi Provisioning Service are shown in the following table.
 
 +-----------------+-------------+-------------+-------------+-------------+
 | Characteristic  | Requirement | Mandatory   | Optional    | Security    |
-| Name            |             | Properties  | Properties  | Permissions |
+| name            |             | properties  | properties  | permissions |
 +=================+=============+=============+=============+=============+
-| Information     | Mandatory   | Read        |             | No Security |
+| Information     | Mandatory   | Read        |             | No security |
 |                 |             |             |             | required    |
 +-----------------+-------------+-------------+-------------+-------------+
 | Operation       | Mandatory   | Indicate,   |             | Encryption  |
-| Control         |             | Write       |             | Required    |
+| Control         |             | Write       |             | required    |
 | Point           |             |             |             |             |
 +-----------------+-------------+-------------+-------------+-------------+
 | Operation       | Mandatory   | Read, Write |             | Encryption  |
-| Control         |             |             |             | Required    |
+| Control         |             |             |             | required    |
 | Point           |             |             |             |             |
 | - Client        |             |             |             |             |
 | Characteristic  |             |             |             |             |
@@ -63,10 +63,10 @@ The characteristic requirements of the Wi-Fi Provisioning Service are shown in t
 | descriptor      |             |             |             |             |
 +-----------------+-------------+-------------+-------------+-------------+
 | Data Out        | Mandatory   | Notify      |             | Encryption  |
-|                 |             |             |             | Required    |
+|                 |             |             |             | required    |
 +-----------------+-------------+-------------+-------------+-------------+
 | Data Out        | Mandatory   | Read, Write |             | Encryption  |
-| - Client        |             |             |             | Required    |
+| - Client        |             |             |             | required    |
 | Characteristic  |             |             |             |             |
 | Configuration   |             |             |             |             |
 | descriptor      |             |             |             |             |


### PR DESCRIPTION
Mostly rewording and formatting fixes
to the BT service library docs (excluding Mesh).
Also some link fixes.

Ref: NCSDK-21324