### PR TITLE
Serial_lte_modem fix for delta DFU and LTE LC log cleanup

### DIFF
--- a/applications/serial_lte_modem/src/main.c
+++ b/applications/serial_lte_modem/src/main.c
@@ -430,8 +430,7 @@ int main(void)
 #else
 			handle_nrf_modem_lib_init_ret(err);
 #endif /* CONFIG_SLM_CARRIER */
-		}
-		if (fota_type == DFU_TARGET_IMAGE_TYPE_MCUBOOT ||
+		} else if (fota_type == DFU_TARGET_IMAGE_TYPE_MCUBOOT ||
 			   fota_type == SLM_DFU_TARGET_IMAGE_TYPE_BL1) {
 			handle_mcuboot_swap_ret();
 		} else {

--- a/applications/serial_lte_modem/src/main.c
+++ b/applications/serial_lte_modem/src/main.c
@@ -58,12 +58,15 @@ BUILD_ASSERT(CONFIG_SLM_WAKEUP_PIN >= 0, "Wake up pin not configured");
 #if defined(CONFIG_SLM_CARRIER)
 NRF_MODEM_LIB_ON_INIT(serial_lte_modem_init_hook, on_modem_lib_init, NULL);
 
+K_SEM_DEFINE(modem_sem, 0, 1);
+
 /* Initialized to value different than success (0) */
 static int modem_lib_init_result = -1;
 
 static void on_modem_lib_init(int ret, void *ctx)
 {
 	modem_lib_init_result = ret;
+	k_sem_give(&modem_sem);
 }
 #endif /* CONFIG_SLM_CARRIER */
 
@@ -414,13 +417,19 @@ int main(void)
 		LOG_WRN("Failed to init slm settings");
 	}
 
-	if (!IS_ENABLED(CONFIG_SLM_CARRIER)) {
-		err = nrf_modem_lib_init();
-		if (err < 0) {
-			LOG_ERR("Modem library init failed, err: %d", err);
-			return err;
-		}
+#if defined(CONFIG_SLM_CARRIER)
+	err = k_sem_take(&modem_sem, K_SECONDS(5));
+	if (err) {
+		LOG_ERR("Modem library initialization timed out");
+		return err;
 	}
+#else
+	err = nrf_modem_lib_init();
+	if (err < 0) {
+		LOG_ERR("Modem library init failed, err: %d", err);
+		return err;
+	}
+#endif
 
 	/* Post-FOTA handling */
 	if (fota_stage != FOTA_STAGE_INIT) {

--- a/lib/lte_link_control/lte_lc_modem_hooks.c
+++ b/lib/lte_link_control/lte_lc_modem_hooks.c
@@ -17,6 +17,10 @@ NRF_MODEM_LIB_ON_SHUTDOWN(lte_lc_shutdown_hook, on_modem_shutdown, NULL);
 static void on_modem_init(int err, void *ctx)
 {
 	if (err) {
+		if (err == NRF_MODEM_DFU_RESULT_OK) {
+			LOG_DBG("Modem DFU, lte_lc not initialized");
+			return;
+		}
 		LOG_ERR("Modem library init error: %d, lte_lc not initialized", err);
 		return;
 	}


### PR DESCRIPTION
* Do not call handle_mcuboot_swap_ret when performing delta DFU.
* Do not log error in LTE LC modem init hook when DFU update is
successful.

Addresses https://github.com/nrfconnect/sdk-nrf/commit/0a919f1d9aa6b0fca2764864445b2e8b6441c0ca#r110880756