### PR TITLE
tests: Bluetooth: Mesh: enable deferred mode log

### DIFF
--- a/tests/subsys/bluetooth/mesh/models/prj.conf
+++ b/tests/subsys/bluetooth/mesh/models/prj.conf
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 CONFIG_NCS_SAMPLES_DEFAULTS=y
+CONFIG_LOG_MODE_DEFERRED=y
 
 # General configuration
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048


### PR DESCRIPTION
Deferred mode should be use when friendship is enable.