### PR TITLE
tests: lib: edge_impulse: Add missing dependencies

### DIFF
--- a/tests/lib/edge_impulse/CMakeLists.txt
+++ b/tests/lib/edge_impulse/CMakeLists.txt
@@ -35,3 +35,5 @@ target_sources(app PRIVATE src/main.cpp)
 # Test uses ei_test_params.h file from edge_impuse_zip directory to verify if
 # ei_wrapper properly forwards the data between application and EI library.
 target_include_directories(app PRIVATE src/edge_impulse_zip/)
+
+add_dependencies(app edge_impulse edge_impulse_project offsets)


### PR DESCRIPTION
This commit adds missing dependencies for edge impulse testing.

Temporary - DNM. Testing if this works. I cannot recreate the issue on local machine.