### PR TITLE
manifest: Fix usage of HEAP and printf in TF-M

### DIFF
--- a/modules/tfm/tfm/boards/CMakeLists.txt
+++ b/modules/tfm/tfm/boards/CMakeLists.txt
@@ -97,12 +97,6 @@ endif()
 if (${TFM_PARTITION_CRYPTO})
   target_link_libraries(platform_s PRIVATE platform_cc3xx)
 
-  # NCSDK-19561 cc3xx libraries requires heap.
-  target_compile_definitions(platform_region_defs
-    INTERFACE
-        ENABLE_HEAP
-  )
-
   # Needed in order to get crypto partition modules flags
   target_link_libraries(platform_s PRIVATE tfm_psa_rot_partition_crypto)
 endif()

--- a/west.yml
+++ b/west.yml
@@ -131,11 +131,11 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 482754ec38e976f927c36044188690d782907162
+      revision: 508e546ee92bf37100425bfef48418f66fe4215e
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: ab8140dd25da98356619ae7ed02b735404c5b962
+      revision: 13a4b367e9223cc59f080b4887ccfa4339986af0
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter


### PR DESCRIPTION
The nrf_cc3xx 0.9.17 now depends on external built platform.c instead of having it internally built.
We can then remove TF-M usage of heap and provide the function mbedtls_platform_set_printf to TF-M.

NCSDK-19561
NCSDK-19569