### PR TITLE
lib: bin: lwm2m_carrier: Wait for SIM ready at startup

### DIFF
--- a/lib/bin/lwm2m_carrier/include/lwm2m_carrier.h
+++ b/lib/bin/lwm2m_carrier/include/lwm2m_carrier.h
@@ -290,6 +290,11 @@ typedef struct {
 } lwm2m_carrier_config_t;
 
 /**
+ * @brief Wait until SIM is ready.
+ */
+void lwm2m_carrier_sim_ready_wait(void);
+
+/**
  * @brief Initialize the LwM2M carrier library.
  *
  * @param[in] config Configuration parameters for the library. Optional.


### PR DESCRIPTION
Some UICC will fail the OTA procedure if the AT command AT+CRSM is used. A previously unused UICC may need the OTA to receive MSISDN.

The carrier library will use the AT+CRSM command during startup, and need the MSISDN for some operators. To avoid a failing OTA, delay carrier library startup until a successful AT+CNUM.