### PR TITLE
Location assistance, provide a result callback for application

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -522,6 +522,12 @@ Libraries for networking
 
   * Removed the old API ``lwm2m_firmware_get_update_state_cb()``.
 
+* :ref:`lib_lwm2m_location_assistance` library:
+
+  * Updated:
+
+    * :file:`lwm2m_client_utils_location.h` includes new API for location assistance to register application callback to receive result codes from location assistance.
+
 * :ref:`pdn_readme` library:
 
   * Added:

--- a/include/net/lwm2m_client_utils_location.h
+++ b/include/net/lwm2m_client_utils_location.h
@@ -34,6 +34,32 @@
 #define LOCATION_ASSIST_RESULT_CODE_TEMP_ERR		1
 
 /**
+ * @typedef location_assistance_result_code_cb_t
+ * @brief Callback for location assistance result.
+ *
+ * This callback is called whenever there is a new result in the location assistance and the
+ * location assistance resend handler has been initialized.
+ *
+ * @param result_code Contains following possible result codes:
+ *                    LOCATION_ASSIST_RESULT_CODE_OK when there are no problems
+ *                    LOCATION_ASSIST_RESULT_CODE_PERMANENT_ERR when there is a permanent error
+ *                    between LwM2M-server and the nrfCloud. Location assistance library will no
+ *                    longer send any requests. Device needs reboot for assistance library to
+ *                    resume operation.
+ *                    LOCATION_ASSIST_RESULT_CODE_TEMP_ERR when there is a temporary error between
+ *                    LwM2M-server and the nrfCloud. The library automatically uses exponential
+ *                    backoff for the retries.
+ */
+typedef void (*location_assistance_result_code_cb_t)(int32_t result_code);
+
+/**
+ * @brief Set the location assistance result code calback
+ *
+ * @param cb callback function to call when there is a new result from location assistance.
+ */
+void location_assistance_set_result_code_cb(location_assistance_result_code_cb_t cb);
+
+/**
  * @brief Set the A-GPS request mask
  *
  * @param agps_req The A-GPS request coming from the GNSS module.

--- a/subsys/net/lib/lwm2m_client_utils/location/location_assistance.c
+++ b/subsys/net/lib/lwm2m_client_utils/location/location_assistance.c
@@ -61,6 +61,8 @@ static bool permanent_error;
 static bool temp_error;
 static int retry_seconds;
 
+static location_assistance_result_code_cb_t result_code_cb;
+
 static int do_agps_request_send(struct lwm2m_ctx *ctx, bool confirmable);
 static int do_pgps_request_send(struct lwm2m_ctx *ctx, bool confirmable);
 static int do_ground_fix_request_send(struct lwm2m_ctx *ctx, bool confirmable);
@@ -104,6 +106,11 @@ static void location_assist_gnss_result_cb(int32_t data)
 	default:
 		LOG_ERR("Unknown error %d", data);
 	}
+
+	/* Notify the application about the result if it has requested a callback */
+	if (result_code_cb) {
+		result_code_cb(data);
+	}
 }
 
 static struct k_work_delayable location_assist_ground_fix_work;
@@ -134,6 +141,11 @@ static void location_assist_ground_fix_result_cb(int32_t data)
 		break;
 	default:
 		LOG_ERR("Unknown error %d", data);
+	}
+
+	/* Notify the application about the result if it has requested a callback */
+	if (result_code_cb) {
+		result_code_cb(data);
 	}
 }
 
@@ -351,4 +363,9 @@ int location_assistance_init_resend_handler(void)
 	}
 
 	return 0;
+}
+
+void location_assistance_set_result_code_cb(location_assistance_result_code_cb_t cb)
+{
+	result_code_cb = cb;
 }


### PR DESCRIPTION
The result callback will be called whenever there is a new result in the location assistance objects and the `location_assistance_init_resend_handler` has been initialized. If the `location_assistance_init_resend_handler` hasn't been initialized, the application is responsible for resend handling and reading the result codes from the location assistance objects.