### PR TITLE
doc: Add instructions about using the external flash memory

### DIFF
--- a/applications/asset_tracker_v2/doc/asset_tracker_v2_description.rst
+++ b/applications/asset_tracker_v2/doc/asset_tracker_v2_description.rst
@@ -22,6 +22,8 @@ Requirements
 
 .. include:: /includes/tfm.txt
 
+.. include:: /includes/external_flash_nrf91.txt
+
 Overview
 ********
 

--- a/doc/nrf/includes/external_flash_nrf91.txt
+++ b/doc/nrf/includes/external_flash_nrf91.txt
@@ -1,0 +1,13 @@
+External flash
+==============
+
+To use the external flash memory on the nRF9160 DK v0.14.0 or later versions, you must program the board controller by completing the following steps:
+
+#. Download the nRF9160 DK board controller firmware from the `nRF9160 DK downloads`_ page.
+#. Make sure the **PROG/DEBUG SW10** switch on the nRF9160 DK is set to **nRF52**.
+#. Program the board controller firmware (:file:`nrf9160_dk_board_controller_fw_2.0.1.hex`) using the `Programmer app <Programming a Development Kit_>`_ in nRF Connect for Desktop.
+
+.. note::
+   The board controller firmware version must be v2.0.1 or higher, which enables the pin routing to external flash.
+
+See :ref:`nrf9160_ug_intro` for more details.

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -422,6 +422,7 @@
 
 .. _`nRF Connect Programmer`: https://infocenter.nordicsemi.com/topic/ug_nc_programmer/UG/nrf_connect_programmer/ncp_introduction.html
 .. _`Programming the nRF52840 Dongle`: https://infocenter.nordicsemi.com/topic/ug_nc_programmer/UG/nrf_connect_programmer/ncp_programming_dongle.html
+.. _`Programming a Development Kit`: https://infocenter.nordicsemi.com/topic/ug_nc_programmer/UG/common/ncp_programming_dk.html
 
 .. _`nRF pynrfjprog`: https://infocenter.nordicsemi.com/topic/ug_pynrfjprog/UG/pynrfjprog/pynrfjprog_lpage.html
 

--- a/doc/nrf/working_with_nrf/nrf91/nrf9160.rst
+++ b/doc/nrf/working_with_nrf/nrf91/nrf9160.rst
@@ -30,6 +30,9 @@ Build the sample (located under ``ncs/zephyr/samples/hello_world``) for the nrf9
 To change the routing options, enable or disable the corresponding devicetree nodes for that board as needed.
 See :ref:`zephyr:nrf9160dk_board_controller_firmware` for detailed information.
 
+To use the external flash on the nRF9160 DK v0.14.0 or later versions, program the board controller firmware (:file:`nrf9160_dk_board_controller_fw_2.0.1.hex`) v2.0.1 or higher using the `Programmer app <Programming a Development Kit_>`_ in nRF Connect for Desktop.
+Make sure the **PROG/DEBUG SW10** switch on the nRF9160 DK is set to **nRF52**.
+
 .. _nrf9160_ug_updating_cloud_certificate:
 
 Updating the nRF Cloud certificate

--- a/samples/nrf9160/http_update/full_modem_update/README.rst
+++ b/samples/nrf9160/http_update/full_modem_update/README.rst
@@ -19,9 +19,7 @@ The sample supports the following development kit, version 0.14.0 or higher:
 
 .. include:: /includes/tfm.txt
 
-On the nRF9160 DK, set the control signal from the nRF52840 board controller MCU (**P0.19**) to *high* to let the nRF9160 communicate with the external flash memory.
-Enable the ``external_flash_pins_routing`` node in devicetree.
-See :ref:`zephyr:nrf9160dk_board_controller_firmware` for details on building the firmware for the nRF52840 board controller MCU.
+.. include:: /includes/external_flash_nrf91.txt
 
 Overview
 ********

--- a/samples/nrf9160/modem_shell/README.rst
+++ b/samples/nrf9160/modem_shell/README.rst
@@ -18,6 +18,8 @@ The sample supports the following development kits:
 
 .. include:: /includes/tfm.txt
 
+.. include:: /includes/external_flash_nrf91.txt
+
 Overview
 ********
 

--- a/samples/nrf9160/modem_trace_backend/README.rst
+++ b/samples/nrf9160/modem_trace_backend/README.rst
@@ -18,6 +18,8 @@ The sample supports the following development kit:
 
 .. include:: /includes/tfm.txt
 
+.. include:: /includes/external_flash_nrf91.txt
+
 Overview
 ********
 

--- a/samples/nrf9160/modem_trace_flash/README.rst
+++ b/samples/nrf9160/modem_trace_flash/README.rst
@@ -16,22 +16,9 @@ The sample supports the following development kit, version 0.14.0 or higher:
 
 .. table-from-sample-yaml::
 
-The control signal from the nRF52840 board controller MCU (**P0.19**) must be set to *high* to let the nRF9160 communicate with the external flash memory.
-To do this, enable the ``external_flash_pins_routing`` node in the devicetree and program the :ref:`zephyr:hello_world` sample for the ``nrf9160dk_nrf52840`` board.
-
-To enable the ``external_flash_pins_routing`` node in devicetree, add the following code in the devicetree overlay in the Hello World application:
-
-.. code-block:: none
-
-   &external_flash_pins_routing {
-           status = "okay";
-   };
-
-See :ref:`nrf9160_ug_intro` for more details.
-
-
 .. include:: /includes/tfm.txt
 
+.. include:: /includes/external_flash_nrf91.txt
 
 Overview
 ********

--- a/samples/nrf9160/nrf_cloud_mqtt_multi_service/README.rst
+++ b/samples/nrf9160/nrf_cloud_mqtt_multi_service/README.rst
@@ -22,6 +22,8 @@ The sample supports the following development kits:
 
 .. include:: /includes/tfm.txt
 
+.. include:: /includes/external_flash_nrf91.txt
+
 .. _nrf_cloud_mqtt_multi_service_features:
 
 Features

--- a/samples/nrf9160/nrf_cloud_rest_fota/README.rst
+++ b/samples/nrf9160/nrf_cloud_rest_fota/README.rst
@@ -18,13 +18,12 @@ The sample supports the following development kits:
 
 .. include:: /includes/tfm.txt
 
+The sample requires an `nRF Cloud`_ account and modem firmware v1.3.x or later.
+
 .. note::
    Full modem FOTA requires development kit version 0.14.0 or higher.
 
-The sample requires an `nRF Cloud`_ account.
-
-.. note::
-   This sample requires modem firmware v1.3.x or later.
+.. include:: /includes/external_flash_nrf91.txt
 
 Overview
 ********


### PR DESCRIPTION
The instruction to use the external flash memory is added to following applicaiton and samples:

Require external flash:
nrf/samples/nrf9160/modem_trace_flash_download
nrf/samples/nrf9160/modem_trace_flash
applications/asset_tracker_v2
 
Have optional features requiring external flash:
nrf/samples/nrf9160/modem_shell
nrf/samples/nrf9160/nrf_cloud_rest_fota
nrf/samples/nrf9160/nrf_cloud_mqtt_multi_service

CIA-855