### PR TITLE
application: serial_lte_modem: Fixing fota timeout and save issues

### DIFF
--- a/applications/serial_lte_modem/src/main.c
+++ b/applications/serial_lte_modem/src/main.c
@@ -367,6 +367,9 @@ void handle_mcuboot_swap_ret(void)
 	default:
 		break;
 	}
+
+	/* Save fota status */
+	slm_setting_fota_save();
 }
 
 int start_execute(void)


### PR DESCRIPTION
- Modem's erase timeout extended from 10 to 20 seconds: In some cases the old timeout was not long enough and timeout error was occured even if the erasing was succesfully.
- Fota status is saved in boot: Previously the fota status was not saved during boot when the flash swap was done. Due to this  unsolicited notification "#XFOTA: 5,0" was missing. 