### PR TITLE
samples: tfm: Enable secp256r1 for tfm_psa_template

### DIFF
--- a/samples/tfm/tfm_psa_template/README.rst
+++ b/samples/tfm/tfm_psa_template/README.rst
@@ -117,10 +117,11 @@ Firmware update
 
 This sample supports firmware update of both the application and TF-M, and the second stage bootloader.
 
-The firmware update process requires signature verification keys in order to sign the images used in the firmware update process.
+The firmware update process requires signature verification keys in order to sign the images used in the process.
 The nRF Secure Immutable bootloader and MCUboot will use signing keys that should not be used in production.
+For signing and verifying images, use ECDSA with secp256r1-sha256, which is supported by the |NCS| cryptographic libraries :ref:`nrf_oberon_readme` and :ref:`crypto_api_nrf_cc310_bl`.
 
-Example on how to generate and use keys:
+Below is an example of how to generate and use the keys.
 
 Generate security keys if needed:
 

--- a/samples/tfm/tfm_psa_template/child_image/mcuboot/prj.conf
+++ b/samples/tfm/tfm_psa_template/child_image/mcuboot/prj.conf
@@ -22,5 +22,8 @@ CONFIG_LOG_DEFAULT_LEVEL=0
 ### Decrease footprint by ~4 KB in comparison to CBPRINTF_COMPLETE=y
 CONFIG_CBPRINTF_NANO=y
 CONFIG_NRF_RTC_TIMER_USER_CHAN_COUNT=0
-# Enable fault injection hardening
+### Enable fault injection hardening
 CONFIG_BOOT_FIH_PROFILE_MEDIUM=y
+### Enable ECDSA P256 signing/verification
+CONFIG_BOOT_SIGNATURE_TYPE_ECDSA_P256=y
+CONFIG_BOOT_SIGNATURE_TYPE_RSA=n

--- a/west.yml
+++ b/west.yml
@@ -118,7 +118,7 @@ manifest:
           compare-by-default: false
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 3b7c7fb9ac786bf4d06aac5a19b5e6153a802584
+      revision: 60b2d401add1887830000325b60bb02c47bd6b3b
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR.git


### PR DESCRIPTION
This enables the secp256r1 as default signing method for the tfm_psa_sample. 
It also fixes a bug in MCUBOOT that breaks the fault injection protection when used with EC256.

Ref: NCSDK-20530