### PR TITLE
net: lib: nrf_cloud: fix upmerge-related log problem

### DIFF
--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_log.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_log.c
@@ -92,7 +92,7 @@ static void log_inject(int log_level, const char *fmt, va_list ap)
 
 	/* Cloud logging is enabled, so send it through the main logging system. */
 	z_log_msg_runtime_vcreate(Z_LOG_LOCAL_DOMAIN_ID, NULL, log_level,
-				  NULL, 0, Z_LOG_MSG2_CBPRINTF_FLAGS(0), fmt, ap);
+				  NULL, 0, Z_LOG_MSG_CBPRINTF_FLAGS(0), fmt, ap);
 }
 
 #else /* !CONFIG_NRF_CLOUD_LOG_BACKEND */


### PR DESCRIPTION
The name of Z_LOG_MSG2_CBPRINTF_FLAGS changed to
Z_LOG_MSG_CBPRINTF_FLAGS upstream, causing a compiler error.