### PR TITLE
treewide: Remove confirmable parameter from location assistance

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/lwm2m_integration/lwm2m_integration.c
+++ b/applications/asset_tracker_v2/src/cloud/lwm2m_integration/lwm2m_integration.c
@@ -507,8 +507,9 @@ int cloud_wrap_cloud_location_send(char *buf, size_t len, bool ack, uint32_t id)
 	ARG_UNUSED(buf);
 	ARG_UNUSED(len);
 	ARG_UNUSED(id);
+	ARG_UNUSED(ack);
 
-	return location_assistance_ground_fix_request_send(&client, ack);
+	return location_assistance_ground_fix_request_send(&client);
 }
 
 int cloud_wrap_agps_request_send(char *buf, size_t len, bool ack, uint32_t id)
@@ -516,8 +517,9 @@ int cloud_wrap_agps_request_send(char *buf, size_t len, bool ack, uint32_t id)
 	ARG_UNUSED(buf);
 	ARG_UNUSED(len);
 	ARG_UNUSED(id);
+	ARG_UNUSED(ack);
 
-	return location_assistance_agps_request_send(&client, ack);
+	return location_assistance_agps_request_send(&client);
 }
 
 int cloud_wrap_pgps_request_send(char *buf, size_t len, bool ack, uint32_t id)
@@ -525,8 +527,9 @@ int cloud_wrap_pgps_request_send(char *buf, size_t len, bool ack, uint32_t id)
 	ARG_UNUSED(buf);
 	ARG_UNUSED(len);
 	ARG_UNUSED(id);
+	ARG_UNUSED(ack);
 
-	return location_assistance_pgps_request_send(&client, ack);
+	return location_assistance_pgps_request_send(&client);
 }
 
 int cloud_wrap_memfault_data_send(char *buf, size_t len, bool ack, uint32_t id)

--- a/applications/asset_tracker_v2/tests/lwm2m_integration/src/lwm2m_integration_test.c
+++ b/applications/asset_tracker_v2/tests/lwm2m_integration/src/lwm2m_integration_test.c
@@ -205,14 +205,14 @@ void test_lwm2m_integration_ui_send(void)
 
 void test_lwm2m_integration_neighbor_cells_send(void)
 {
-	__cmock_location_assistance_ground_fix_request_send_ExpectAndReturn(&client, true, 0);
+	__cmock_location_assistance_ground_fix_request_send_ExpectAndReturn(&client, 0);
 
 	TEST_ASSERT_EQUAL(0, cloud_wrap_cloud_location_send(NULL, 0, true, 0));
 }
 
 void test_lwm2m_integration_agps_request_send(void)
 {
-	__cmock_location_assistance_agps_request_send_ExpectAndReturn(&client, true, 0);
+	__cmock_location_assistance_agps_request_send_ExpectAndReturn(&client, 0);
 
 	TEST_ASSERT_EQUAL(0, cloud_wrap_agps_request_send(NULL, 0, true, 0));
 }
@@ -238,7 +238,7 @@ void test_lwm2m_integration_batch_send(void)
 
 void test_lwm2m_integration_pgps_request_send(void)
 {
-	__cmock_location_assistance_pgps_request_send_ExpectAndReturn(&client, true, 0);
+	__cmock_location_assistance_pgps_request_send_ExpectAndReturn(&client, 0);
 
 	TEST_ASSERT_EQUAL(0, cloud_wrap_pgps_request_send(NULL, 0, true, 0));
 }

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -542,6 +542,7 @@ Libraries for networking
   * Updated:
 
     * :file:`lwm2m_client_utils_location.h` includes new API for location assistance to register application callback to receive result codes from location assistance.
+    * :file:`lwm2m_client_utils_location.h` by removing deprecated confirmable parameters from location assistance APIs.
 
 * :ref:`pdn_readme` library:
 

--- a/include/net/lwm2m_client_utils_location.h
+++ b/include/net/lwm2m_client_utils_location.h
@@ -72,31 +72,28 @@ int location_assistance_agps_set_mask(const struct nrf_modem_gnss_agps_data_fram
  * @brief Send the A-GPS assistance request to LwM2M server
  *
  * @param ctx LwM2M client context for sending the data.
- * @param confirmable Boolean value to indicate should the server return confirmation.
  * @return Returns a negative error code (errno.h) indicating
  *         reason of failure or 0 for success.
  */
-int location_assistance_agps_request_send(struct lwm2m_ctx *ctx, bool confirmable);
+int location_assistance_agps_request_send(struct lwm2m_ctx *ctx);
 
 /**
  * @brief Send the Ground Fix request to LwM2M server
  *
  * @param ctx LwM2M client context for sending the data.
- * @param confirmable Boolean value to indicate should the server return confirmation.
  * @return Returns a negative error code (errno.h) indicating
  *         reason of failure or 0 for success.
  */
-int location_assistance_ground_fix_request_send(struct lwm2m_ctx *ctx, bool confirmable);
+int location_assistance_ground_fix_request_send(struct lwm2m_ctx *ctx);
 
 /**
  * @brief Send the P-GPS assistance request to LwM2M server
  *
  * @param ctx LwM2M client context for sending the data.
- * @param confirmable Boolean value to indicate should the server return confirmation.
  * @return Returns a negative error code (errno.h) indicating
  *         reason of failure or 0 for success.
  */
-int location_assistance_pgps_request_send(struct lwm2m_ctx *ctx, bool confirmable);
+int location_assistance_pgps_request_send(struct lwm2m_ctx *ctx);
 
 /**
  * @brief Initialize the location assistance library resend handler.

--- a/samples/nrf9160/lwm2m_client/src/events/location_event_handler.c
+++ b/samples/nrf9160/lwm2m_client/src/events/location_event_handler.c
@@ -30,7 +30,7 @@ static bool handle_agps_request(const struct gnss_agps_request_event *event)
 	while (location_assistance_agps_set_mask(&event->agps_req) == -EAGAIN) {
 		k_sleep(REQUEST_WAIT_INTERVAL);
 	}
-	while (location_assistance_agps_request_send(client_ctx, true) == -EAGAIN) {
+	while (location_assistance_agps_request_send(client_ctx) == -EAGAIN) {
 		k_sleep(REQUEST_WAIT_INTERVAL);
 	}
 
@@ -42,7 +42,7 @@ static bool handle_agps_request(const struct gnss_agps_request_event *event)
 static bool handle_ground_fix_location_event(bool send_back)
 {
 	ground_fix_set_report_back(send_back);
-	location_assistance_ground_fix_request_send(client_ctx, true);
+	location_assistance_ground_fix_request_send(client_ctx);
 
 	return true;
 }
@@ -51,7 +51,7 @@ static bool handle_ground_fix_location_event(bool send_back)
 #if defined(CONFIG_LWM2M_CLIENT_UTILS_LOCATION_ASSIST_PGPS)
 static bool handle_pgps_data_request_event(void)
 {
-	while (location_assistance_pgps_request_send(client_ctx, true) == -EAGAIN) {
+	while (location_assistance_pgps_request_send(client_ctx) == -EAGAIN) {
 		k_sleep(REQUEST_WAIT_INTERVAL);
 	}
 	return true;

--- a/samples/nrf9160/modem_shell/src/gnss/gnss.c
+++ b/samples/nrf9160/modem_shell/src/gnss/gnss.c
@@ -640,7 +640,7 @@ static void get_agps_data(struct k_work *item)
 		return;
 	}
 	location_assistance_agps_set_mask(&agps_request);
-	err = location_assistance_agps_request_send(cloud_lwm2m_client_ctx_get(), true);
+	err = location_assistance_agps_request_send(cloud_lwm2m_client_ctx_get());
 	if (err) {
 		mosh_error("GNSS: Failed to request A-GPS data, error: %d", err);
 	}
@@ -855,7 +855,7 @@ static void get_pgps_data_work_fn(struct k_work *work)
 		return;
 	}
 
-	err = location_assistance_pgps_request_send(cloud_lwm2m_client_ctx_get(), true);
+	err = location_assistance_pgps_request_send(cloud_lwm2m_client_ctx_get());
 	if (err) {
 		mosh_error("GNSS: Failed to request P-GPS data, err: %d", err);
 	} else {

--- a/samples/nrf9160/modem_shell/src/location/location_srv_ext_lwm2m.c
+++ b/samples/nrf9160/modem_shell/src/location/location_srv_ext_lwm2m.c
@@ -31,7 +31,7 @@ void location_srv_ext_agps_handle(const struct nrf_modem_gnss_agps_data_frame *a
 
 	location_assistance_agps_set_mask(agps_req);
 
-	while ((err = location_assistance_agps_request_send(cloud_lwm2m_client_ctx_get(), true)) ==
+	while ((err = location_assistance_agps_request_send(cloud_lwm2m_client_ctx_get())) ==
 	       -EAGAIN) {
 		/* LwM2M client utils library is currently handling a P-GPS data request, need to
 		 * wait until it has been completed.
@@ -63,7 +63,7 @@ void location_srv_ext_pgps_handle(const struct gps_pgps_request *pgps_req)
 		return;
 	}
 
-	while ((err = location_assistance_pgps_request_send(cloud_lwm2m_client_ctx_get(), true)) ==
+	while ((err = location_assistance_pgps_request_send(cloud_lwm2m_client_ctx_get())) ==
 	       -EAGAIN) {
 		/* LwM2M client utils library is currently handling an A-GPS data request, need to
 		 * wait until it has been completed.
@@ -164,7 +164,7 @@ void location_srv_ext_cellular_handle(
 		goto exit;
 	}
 
-	err = location_assistance_ground_fix_request_send(cloud_lwm2m_client_ctx_get(), true);
+	err = location_assistance_ground_fix_request_send(cloud_lwm2m_client_ctx_get());
 	if (err) {
 		mosh_error("Failed to send cellular location request, err: %d", err);
 		goto exit;

--- a/tests/subsys/net/lib/lwm2m_client_utils/src/location_assistance.c
+++ b/tests/subsys/net/lib/lwm2m_client_utils/src/location_assistance.c
@@ -75,7 +75,7 @@ ZTEST(lwm2m_client_utils_location_assistance, test_agps_send)
 	rc = location_assistance_agps_set_mask(&agps_req);
 	zassert_equal(rc, 0, "Error %d", rc);
 
-	rc = location_assistance_agps_request_send(&client_ctx, true);
+	rc = location_assistance_agps_request_send(&client_ctx);
 	zassert_equal(rc, 0, "Error %d", rc);
 	zassert_equal(lwm2m_send_cb_fake.call_count, 1, "Request not sent");
 
@@ -95,7 +95,7 @@ ZTEST(lwm2m_client_utils_location_assistance, test_pgps_send)
 	zassert_not_null(create_obj_cb, "Callback was null");
 	struct lwm2m_engine_obj_inst *gnss_obj = create_obj_cb(0);
 
-	rc = location_assistance_pgps_request_send(&client_ctx, true);
+	rc = location_assistance_pgps_request_send(&client_ctx);
 	zassert_equal(rc, 0, "Error %d", rc);
 	zassert_equal(lwm2m_send_cb_fake.call_count, 1, "Request not sent");
 
@@ -118,11 +118,11 @@ ZTEST(lwm2m_client_utils_location_assistance, test_simultaneous_send)
 	rc = location_assistance_agps_set_mask(&agps_req);
 	zassert_equal(rc, 0, "Error %d", rc);
 
-	rc = location_assistance_agps_request_send(&client_ctx, true);
+	rc = location_assistance_agps_request_send(&client_ctx);
 	zassert_equal(rc, 0, "Error %d", rc);
 	zassert_equal(lwm2m_send_cb_fake.call_count, 1, "Request not sent");
 
-	rc = location_assistance_pgps_request_send(&client_ctx, true);
+	rc = location_assistance_pgps_request_send(&client_ctx);
 	zassert_equal(rc, -EAGAIN, "Error %d", rc);
 
 	gnss_obj->resources[GNSS_ASSIST_ASSIST_DATA].post_write_cb(0, GNSS_ASSIST_ASSIST_DATA, 0,
@@ -130,7 +130,7 @@ ZTEST(lwm2m_client_utils_location_assistance, test_simultaneous_send)
 
 	zassert_equal(nrf_cloud_agps_process_fake.call_count, 1, "Data not processed");
 
-	rc = location_assistance_pgps_request_send(&client_ctx, true);
+	rc = location_assistance_pgps_request_send(&client_ctx);
 	zassert_equal(rc, 0, "Error %d", rc);
 	zassert_equal(lwm2m_send_cb_fake.call_count, 2, "Request not sent");
 
@@ -146,7 +146,7 @@ ZTEST(lwm2m_client_utils_location_assistance, test_ground_fix_send)
 
 	setup();
 
-	rc = location_assistance_ground_fix_request_send(&client_ctx, true);
+	rc = location_assistance_ground_fix_request_send(&client_ctx);
 
 	zassert_equal(rc, 0, "Error %d", rc);
 	zassert_equal(lwm2m_send_cb_fake.call_count, 1, "Request not sent");
@@ -169,7 +169,7 @@ ZTEST(lwm2m_client_utils_location_assistance, test_temporary_failure)
 	rc = location_assistance_agps_set_mask(&agps_req);
 	zassert_equal(rc, 0, "Error %d", rc);
 
-	rc = location_assistance_agps_request_send(&client_ctx, true);
+	rc = location_assistance_agps_request_send(&client_ctx);
 	zassert_equal(rc, 0, "Error %d", rc);
 	zassert_equal(lwm2m_send_cb_fake.call_count, 1, "Request not sent");
 
@@ -177,7 +177,7 @@ ZTEST(lwm2m_client_utils_location_assistance, test_temporary_failure)
 								   resbuf, 4, true, 4);
 	k_sleep(K_MSEC(100));
 
-	rc = location_assistance_agps_request_send(&client_ctx, true);
+	rc = location_assistance_agps_request_send(&client_ctx);
 	zassert_equal(rc, -EALREADY, "Error %d", rc);
 	zassert_equal(last_result_code, LOCATION_ASSIST_RESULT_CODE_TEMP_ERR, "Wrong result");
 
@@ -204,7 +204,7 @@ ZTEST(lwm2m_client_utils_location_assistance, test_zzzpermanent_failure)
 	rc = location_assistance_agps_set_mask(&agps_req);
 	zassert_equal(rc, 0, "Error %d", rc);
 
-	rc = location_assistance_agps_request_send(&client_ctx, true);
+	rc = location_assistance_agps_request_send(&client_ctx);
 	zassert_equal(rc, 0, "Error %d", rc);
 	zassert_equal(lwm2m_send_cb_fake.call_count, 1, "Request not sent");
 


### PR DESCRIPTION
The confirmable is not used anymore in the `lwm2m_send`, remove the parameter from the location assistance APIs as it is deprecated.