### PR TITLE
applications: serial_lte_modem: Coverity fixes

### DIFF
--- a/applications/serial_lte_modem/src/gnss/slm_at_gnss.c
+++ b/applications/serial_lte_modem/src/gnss/slm_at_gnss.c
@@ -249,6 +249,11 @@ static void ncell_meas_mon(const char *notify)
 {
 	int err;
 	uint32_t param_count;
+	char cid[9] = {0};
+	char plmn[6] = {0};
+	char mcc[4]  = {0};
+	char tac[9] = {0};
+	size_t size;
 
 	ncell_meas_status = -1;
 	at_params_list_clear(&at_param_list);
@@ -275,9 +280,6 @@ static void ncell_meas_mon(const char *notify)
 	}
 
 	/* parse Cell ID */
-	char cid[9] = {0};
-	size_t size;
-
 	size = sizeof(cid);
 	err = util_string_get(&at_param_list, 2, cid, &size);
 	if (err) {
@@ -289,9 +291,6 @@ static void ncell_meas_mon(const char *notify)
 	}
 
 	/* parse PLMN */
-	char plmn[6] = {0};
-	char mcc[4]  = {0};
-
 	size = sizeof(plmn);
 	err = util_string_get(&at_param_list, 3, plmn, &size);
 	if (err) {
@@ -308,8 +307,6 @@ static void ncell_meas_mon(const char *notify)
 	}
 
 	/* parse TAC */
-	char tac[9] = {0};
-
 	size = sizeof(tac);
 	err = util_string_get(&at_param_list, 4, tac, &size);
 	if (err) {

--- a/applications/serial_lte_modem/src/slm_at_icmp.c
+++ b/applications/serial_lte_modem/src/slm_at_icmp.c
@@ -126,6 +126,7 @@ static uint32_t send_ping_wait_reply(void)
 	int plseqnr;
 	int ret;
 	const uint16_t icmp_hdr_len = ICMP_HDR_LEN;
+	struct timeval tv;
 
 	if (si->ai_family == AF_INET) {
 		/* Generate IPv4 ICMP EchoReq */
@@ -269,10 +270,8 @@ static uint32_t send_ping_wait_reply(void)
 	/* We have a blocking socket and we do not want to block for
 	 * a long for sending. Thus, let's set the timeout:
 	 */
-	struct timeval tv = {
-		.tv_sec = (ping_argv.waitms / 1000),
-		.tv_usec = (ping_argv.waitms % 1000) * 1000,
-	};
+	tv.tv_sec = (ping_argv.waitms / 1000);
+	tv.tv_usec = (ping_argv.waitms % 1000) * 1000;
 
 	if (setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, (struct timeval *)&tv,
 		       sizeof(struct timeval)) < 0) {

--- a/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
@@ -254,6 +254,7 @@ static int do_tcp_server_stop(void)
 static int do_tcp_client_connect(const char *url, uint16_t port)
 {
 	int ret;
+	struct sockaddr sa;
 
 	/* Open socket */
 	if (proxy.sec_tag == INVALID_SEC_TAG) {
@@ -288,10 +289,6 @@ static int do_tcp_client_connect(const char *url, uint16_t port)
 	}
 
 	/* Connect to remote host */
-	struct sockaddr sa = {
-		.sa_family = AF_UNSPEC
-	};
-
 	ret = util_resolve_host(0, url, port, proxy.family, &sa);
 	if (ret) {
 		LOG_ERR("getaddrinfo() error: %s", gai_strerror(ret));

--- a/applications/serial_lte_modem/src/slm_at_udp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_udp_proxy.c
@@ -166,6 +166,7 @@ static int do_udp_server_stop(void)
 static int do_udp_client_connect(const char *url, uint16_t port)
 {
 	int ret;
+	struct sockaddr sa;
 
 	/* Open socket */
 	if (proxy.sec_tag == INVALID_SEC_TAG) {
@@ -193,10 +194,6 @@ static int do_udp_client_connect(const char *url, uint16_t port)
 	}
 
 	/* Connect to remote host */
-	struct sockaddr sa = {
-		.sa_family = AF_UNSPEC
-	};
-
 	ret = util_resolve_host(0, url, port, proxy.family, &sa);
 	if (ret) {
 		LOG_ERR("getaddrinfo() error: %s", gai_strerror(ret));


### PR DESCRIPTION
Some minor coverity fixes:
Skipping initialization while still in scope when using goto.
Always true compare.