### PR TITLE
manifest: Update zephyr for app dependency on offsets header fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: b54c8baeeafb3d6e9eef6092c5d88a6771548460
+      revision: pull/1149/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update zephyr version:
Fix app dependency on offsets header file generated by the build system.