### PR TITLE
Bl storage fixes

### DIFF
--- a/include/bl_storage.h
+++ b/include/bl_storage.h
@@ -201,14 +201,15 @@ enum lcs {
  * time. Writes to @p dst are done a byte at a time.
  *
  * @param[out] dst destination buffer.
- * @param[in] src source buffer. Must be 4-byte-aligned.
+ * @param[in] src source buffer in OTP. Must be 4-byte-aligned.
  * @param[in] size number of *bytes* in src to copy into dst. Must be divisible by 4.
  */
 NRFX_STATIC_INLINE void otp_copy32(uint8_t *restrict dst, uint32_t volatile * restrict src,
 				   size_t size)
 {
 	for (int i = 0; i < size / 4; i++) {
-		uint32_t val = src[i];
+		/* OTP is in UICR */
+		uint32_t val = nrfx_nvmc_uicr_word_read(src + i);
 
 		for (int j = 0; j < 4; j++) {
 			dst[i * 4 + j] = (val >> 8 * j) & 0xFF;


### PR DESCRIPTION
2 commits:

[bl_storage: Refactor to use nrfx_nvmc_uicr_word_read](https://github.com/nrfconnect/sdk-nrf/commit/b46618d8cda651022c933350c4cd70e014108309) 

Use nrfx_nvmc_uicr_word_read to read from UICR/OTP instead of applying
the DSB errata 7 workaround manually.

This improves readability and code re-use.

nrfx_nvmc_uicr_word_read also has a slightly more optimal
implementation as it omits the DSB instruction for unaffected
platforms.


[bl_storage: Use nrfx_nvmc_uicr_word_read when accessing OTP](https://github.com/nrfconnect/sdk-nrf/commit/369116691aa21eed8f5d525ed30168eebcbd5aca) 

Errata 7 for nrf91 requires a DSB instruction after accessing
UICR/OTP.

It's unclear if we can be affected by the errata here but we apply the
workaround anyway just to be safe.