### PR TITLE
tests: edge_impulse: Fix missing dependency on zephyr generated headers

### DIFF
--- a/lib/edge_impulse/CMakeLists.txt
+++ b/lib/edge_impulse/CMakeLists.txt
@@ -60,6 +60,7 @@ ExternalProject_Add(edge_impulse_project
     BUILD_ALWAYS True
     USES_TERMINAL_BUILD True
 )
+add_dependencies(edge_impulse_project zephyr_generated_headers)
 
 # This targets remove the `edge_impulse_project-download` stamp file, which
 # causes the Edge impulse library to be fetched on each build invocation.


### PR DESCRIPTION
Fix missing dependency on zephyr generated headers for the edge_impulse_project.
This target is built as an external project, and cannot depend on zephyr_generated_headers where it is declared, because zephyr_generated_headers is a custom command instead of an interface library.