### PR TITLE
tests: tf-m: Adding more build targets for TF-M architecture tests

### DIFF
--- a/tests/tfm/tfm_psa_test/testcase.yaml
+++ b/tests/tfm/tfm_psa_test/testcase.yaml
@@ -14,37 +14,54 @@ common:
 tests:
   tfm.psa_test_protected_storage_lvl1:
     tags: tfm_lvl1
-    extra_args: "CONFIG_TFM_PSA_TEST_PROTECTED_STORAGE=y CONFIG_TFM_ISOLATION_LEVEL=1"
+    extra_configs:
+      - CONFIG_TFM_PSA_TEST_PROTECTED_STORAGE=y
+      - CONFIG_TFM_ISOLATION_LEVEL=1
     timeout: 120
   tfm.psa_test_protected_storage_lvl2:
     tags: tfm_lvl2
-    extra_args: "CONFIG_TFM_PSA_TEST_PROTECTED_STORAGE=y"
+    extra_configs:
+      - CONFIG_TFM_PSA_TEST_PROTECTED_STORAGE=y
     timeout: 120
   tfm.psa_test_internal_trusted_storage_lvl1:
     tags: tfm_lvl1
-    extra_args: "CONFIG_TFM_PSA_TEST_INTERNAL_TRUSTED_STORAGE=y CONFIG_TFM_ISOLATION_LEVEL=1"
+    extra_configs:
+      - CONFIG_TFM_PSA_TEST_INTERNAL_TRUSTED_STORAGE=y
+      - CONFIG_TFM_ISOLATION_LEVEL=1
   tfm.psa_test_internal_trusted_storage_lvl2:
     tags: tfm_lvl2
-    extra_args: "CONFIG_TFM_PSA_TEST_INTERNAL_TRUSTED_STORAGE=y"
+    extra_configs:
+      - CONFIG_TFM_PSA_TEST_INTERNAL_TRUSTED_STORAGE=y
   tfm.psa_test_storage_lvl1:
     tags: tfm_lvl1
-    extra_args: "CONFIG_TFM_PSA_TEST_STORAGE=y CONFIG_TFM_ISOLATION_LEVEL=1"
+    extra_configs:
+      - CONFIG_TFM_PSA_TEST_STORAGE=y
+      - CONFIG_TFM_ISOLATION_LEVEL=1
     timeout: 130
   tfm.psa_test_storage_lvl2:
     tags: tfm_lvl2
-    extra_args: "CONFIG_TFM_PSA_TEST_STORAGE=y"
+    extra_configs:
+      - CONFIG_TFM_PSA_TEST_STORAGE=y
     timeout: 130
   tfm.psa_test_crypto_lvl1:
     tags: tfm_lvl1
-    extra_args: "CONFIG_TFM_PSA_TEST_CRYPTO=y CONFIG_TFM_ISOLATION_LEVEL=1"
+    extra_configs:
+      - CONFIG_TFM_PSA_TEST_CRYPTO=y
+      - CONFIG_TFM_ISOLATION_LEVEL=1
+    timeout: 120
     timeout: 120
   tfm.psa_test_crypto_lvl2:
     tags: tfm_lvl2
-    extra_args: "CONFIG_TFM_PSA_TEST_CRYPTO=y"
+    extra_configs:
+      - CONFIG_TFM_PSA_TEST_CRYPTO=y
+    timeout: 120
     timeout: 120
   tfm.psa_test_initial_attestation_lvl1:
     tags: tfm_lvl1
-    extra_args: "CONFIG_TFM_PSA_TEST_INITIAL_ATTESTATION=y CONFIG_TFM_ISOLATION_LEVEL=1"
+    extra_configs:
+      - CONFIG_TFM_PSA_TEST_INITIAL_ATTESTATION=y
+      - CONFIG_TFM_ISOLATION_LEVEL=1
   tfm.psa_test_initial_attestation_lvl2:
     tags: tfm_lvl2
-    extra_args: "CONFIG_TFM_PSA_TEST_INITIAL_ATTESTATION=y"
+    extra_configs:
+      - CONFIG_TFM_PSA_TEST_INITIAL_ATTESTATION=y

--- a/tests/tfm/tfm_psa_test/testcase.yaml
+++ b/tests/tfm/tfm_psa_test/testcase.yaml
@@ -49,12 +49,40 @@ tests:
       - CONFIG_TFM_PSA_TEST_CRYPTO=y
       - CONFIG_TFM_ISOLATION_LEVEL=1
     timeout: 120
+  tfm.psa_test_crypto_lvl1.cc3xx:
+    tags: tfm_lvl1
+    extra_configs:
+      - CONFIG_TFM_PSA_TEST_CRYPTO=y
+      - CONFIG_TFM_ISOLATION_LEVEL=1
+      - CONFIG_PSA_CRYPTO_DRIVER_CC3XX=y
+      - CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
+    timeout: 120
+  tfm.psa_test_crypto_lvl1.cc3xx_oberon:
+    tags: tfm_lvl1
+    extra_configs:
+      - CONFIG_TFM_PSA_TEST_CRYPTO=y
+      - CONFIG_TFM_ISOLATION_LEVEL=1
+      - CONFIG_PSA_CRYPTO_DRIVER_CC3XX=y
+      - CONFIG_PSA_CRYPTO_DRIVER_OBERON=y
     timeout: 120
   tfm.psa_test_crypto_lvl2:
     tags: tfm_lvl2
     extra_configs:
       - CONFIG_TFM_PSA_TEST_CRYPTO=y
     timeout: 120
+  tfm.psa_test_crypto_lvl2.cc3xx:
+    tags: tfm_lvl2
+    extra_configs:
+      - CONFIG_TFM_PSA_TEST_CRYPTO=y
+      - CONFIG_PSA_CRYPTO_DRIVER_CC3XX=y
+      - CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
+    timeout: 120
+  tfm.psa_test_crypto_lvl2.cc3xx_oberon:
+    tags: tfm_lvl2
+    extra_configs:
+      - CONFIG_TFM_PSA_TEST_CRYPTO=y
+      - CONFIG_PSA_CRYPTO_DRIVER_CC3XX=y
+      - CONFIG_PSA_CRYPTO_DRIVER_OBERON=y
     timeout: 120
   tfm.psa_test_initial_attestation_lvl1:
     tags: tfm_lvl1

--- a/tests/tfm/tfm_regression_test/testcase.yaml
+++ b/tests/tfm/tfm_regression_test/testcase.yaml
@@ -16,30 +16,42 @@ common:
 tests:
   tfm.regression_ipc_lvl1:
     tags: tfm_lvl1
-    extra_args: CONFIG_TFM_IPC=y CONFIG_TFM_ISOLATION_LEVEL=1
+    extra_configs:
+      - CONFIG_TFM_IPC=y
+      - CONFIG_TFM_ISOLATION_LEVEL=1
     timeout: 200
 
   tfm.regression_ipc_lvl2.mbedtls_builtin:
     tags: tfm_lvl2
-    extra_args: CONFIG_PSA_CRYPTO_DRIVER_CC3XX=n CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
+    extra_configs:
+      - CONFIG_PSA_CRYPTO_DRIVER_CC3XX=n
+      - CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
     timeout: 200
 
   tfm.regression_ipc_lvl2.cc3xx:
     tags: tfm_lvl2
-    extra_args: CONFIG_PSA_CRYPTO_DRIVER_CC3XX=y CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
+    extra_configs:
+      - CONFIG_PSA_CRYPTO_DRIVER_CC3XX=y
+      - CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
     timeout: 200
 
   tfm.regression_ipc_lvl2.oberon:
     tags: tfm_lvl2
-    extra_args: CONFIG_PSA_CRYPTO_DRIVER_CC3XX=n CONFIG_PSA_CRYPTO_DRIVER_OBERON=y
+    extra_configs:
+      - CONFIG_PSA_CRYPTO_DRIVER_CC3XX=n
+      - CONFIG_PSA_CRYPTO_DRIVER_OBERON=y
     timeout: 200
 
   tfm.regression_ipc_lvl2.cc3xx_oberon:
     tags: tfm_lvl2
-    extra_args: CONFIG_PSA_CRYPTO_DRIVER_CC3XX=y CONFIG_PSA_CRYPTO_DRIVER_OBERON=y
+    extra_configs:
+      - CONFIG_PSA_CRYPTO_DRIVER_CC3XX=y
+      - CONFIG_PSA_CRYPTO_DRIVER_OBERON=y
     timeout: 200
 
   tfm.regression_sfn_lvl1:
     tags: tfm_lvl1
-    extra_args: CONFIG_TFM_SFN=y CONFIG_TFM_ISOLATION_LEVEL=1
+    extra_configs:
+      - CONFIG_TFM_SFN=y
+      - CONFIG_TFM_ISOLATION_LEVEL=1
     timeout: 200


### PR DESCRIPTION
-Converting testcase.yaml to use extra_configs instead of extra_args to prevent line length issues
-Adding more targets to PSA crypto tests in TF-M architecture test suite

ref: NCSDK-21404

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>