### PR TITLE
doc: nRF5340_audio: add note about VSC extension

### DIFF
--- a/applications/nrf5340_audio/README.rst
+++ b/applications/nrf5340_audio/README.rst
@@ -640,6 +640,9 @@ You can build and program the application in one of the following ways:
 * :ref:`nrf53_audio_app_building_standard`.
   Using this method requires building and programming each development kit separately.
 
+.. important::
+   Building and programming using the |nRFVSC| is currently not supported.
+
 .. note::
    You might want to check the :ref:`nRF5340 Audio application known issues <known_issues_nrf5340audio>` before building and programming the application.
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -198,6 +198,7 @@ nRF5340 Audio
   Search :ref:`Kconfig Reference <kconfig-search>` for ``BLE_ACL_PER_ADV_INT_`` and ``BLE_ACL_EXT_ADV_INT_`` to list all of them.
 * Implemented :ref:`zephyr:zbus` for handling events from buttons and LE Audio.
 * Reduced supervision timeout to reduce reconnection times for CIS.
+* Updated the :ref:`nrf53_audio_app` application documentation with a note about missing support for the |nRFVSC|.
 
 nRF Machine Learning (Edge Impulse)
 -----------------------------------


### PR DESCRIPTION
Added an important note about missing support for the VSC extension.