### PR TITLE
clang-format: add parameter.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -101,6 +101,7 @@ IncludeCategories:
     Priority: 1
 IncludeIsMainRegex: '(Test)?$'
 IndentCaseLabels: false
+IndentGotoLabels: false
 #IndentPPDirectives: None # Unknown to clang-format-5.0
 IndentWidth: 8
 IndentWrappedFunctionNames: false


### PR DESCRIPTION
GotoLabels added to conform to code standard