### PR TITLE
doc: Issue with update_ad and ChaChaPoly on CryptoCell

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -2267,6 +2267,11 @@ nrfxlib
 
 Crypto
 ======
+.. rst-class:: v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0
+
+NCSDK-20688: For ChaCha-Poly, incorrect tag will be produced if plaintext is empty
+  For encryption, empty plaintext will result in incorrect tag.
+  For decryption, correct tags will not be accepted.
 
 .. rst-class:: v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0
 

--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -2270,6 +2270,11 @@ Crypto
 
 .. rst-class:: v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0
 
+NCSDK-20688: For AES GCM, calling :c:func:`psa_aead_update_ad` multiple times will result in an incorrect tag on CryptoCell
+  It is only supported to feed the additional data for AES GCM once using the CryptoCell backend.
+
+.. rst-class:: v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0
+
 NCSDK-20287: Using AES GCM with other nonce sizes than 12 bytes will produce an incorrect tag on CryptoCell
   Both PSA Crypto and legacy Mbed TLS APIs are affected.
 


### PR DESCRIPTION
Calling psa_aead_update_ad multiple times on AES GCM does result in invalid tags.