### PR TITLE
tests: aws_jobs: Make test use unity and cmock

### DIFF
--- a/tests/subsys/net/lib/aws_jobs/CMakeLists.txt
+++ b/tests/subsys/net/lib/aws_jobs/CMakeLists.txt
@@ -6,7 +6,10 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(json)
+project(aws_jobs_test)
+
+test_runner_generate(src/main.c)
+cmock_handle(${ZEPHYR_BASE}/include/zephyr/net/mqtt.h)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/subsys/net/lib/aws_jobs/prj.conf
+++ b/tests/subsys/net/lib/aws_jobs/prj.conf
@@ -3,6 +3,5 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
-CONFIG_ZTEST=y
-CONFIG_ZTEST_STACK_SIZE=4096
+CONFIG_UNITY=y
 CONFIG_AWS_JOBS=y

--- a/tests/subsys/net/lib/aws_jobs/src/main.c
+++ b/tests/subsys/net/lib/aws_jobs/src/main.c
@@ -6,117 +6,112 @@
 #include <string.h>
 #include <zephyr/types.h>
 #include <stdbool.h>
-#include <zephyr/ztest.h>
+#include <unity.h>
 #include <aws_jobs.h>
 #include <zephyr/net/mqtt.h>
 
-int mqtt_subscribe(struct mqtt_client *client,
-		   const struct mqtt_subscription_list *param)
-{
-	return 0;
-}
+#include "cmock_mqtt.h"
 
-int mqtt_unsubscribe(struct mqtt_client *client,
-		     const struct mqtt_subscription_list *param)
-{
-	return 0;
-}
+/* The unity_main is not declared in any header file. It is only defined in the generated test
+ * runner because of ncs' unity configuration. It is therefore declared here to avoid a compiler
+ * warning.
+ */
+extern int unity_main(void);
 
-static void test_aws_jobs_cmp__null(void)
+void test_aws_jobs_cmp__null(void)
 {
 	const char *published = "$aws/things/nrf-id/jobs/notify-next";
 	const char *subscribed = "$aws/things/nrf-id/jobs/notify-next";
 	int ret;
 
 	ret = aws_jobs_cmp(NULL, published, strlen(published), "");
-	zassert_false(ret, "");
+	TEST_ASSERT_FALSE(ret);
 
 	ret = aws_jobs_cmp(subscribed, NULL, strlen(published), "");
-	zassert_false(ret, "");
+	TEST_ASSERT_FALSE(ret);
 
 	ret = aws_jobs_cmp(subscribed, published, strlen(published), NULL);
-	zassert_false(ret, "");
+	TEST_ASSERT_FALSE(ret);
 }
 
-static void test_aws_jobs_cmp__empty(void)
+void test_aws_jobs_cmp__empty(void)
 {
 	const char *published = "$aws/things/nrf-id/jobs/notify-next";
 	const char *subscribed = "$aws/things/nrf-id/jobs/notify-next";
-	int ret;
+	bool ret;
 
 	ret = aws_jobs_cmp("", published, strlen(published), "");
-	zassert_false(ret, "Should not be equal, blank subscribed matched");
+	TEST_ASSERT_FALSE_MESSAGE(ret, "Should not be equal, blank subscribed matched");
 
 	ret = aws_jobs_cmp(subscribed, "", strlen(published), "");
-	zassert_false(ret, "Should not be equal, blank published matched");
+	TEST_ASSERT_FALSE_MESSAGE(ret, "Should not be equal, blank published matched");
 }
 
-static void test_aws_jobs_cmp__no_suffix(void)
+void test_aws_jobs_cmp__no_suffix(void)
 {
 	const char *published = "$aws/things/nrf-id/jobs/notify-next";
 	const char *subscribed = "$aws/things/nrf-id/jobs/notify-next";
-	int ret = aws_jobs_cmp(subscribed, published, strlen(published), "");
+	bool ret = aws_jobs_cmp(subscribed, published, strlen(published), "");
 
-	zassert_true(ret, "");
+	TEST_ASSERT(ret);
 }
 
-static void test_aws_jobs_cmp__suffix(void)
+void test_aws_jobs_cmp__suffix(void)
 {
 	const char *accepted = "$aws/things/nrf-id/jobs/123/update/accepted";
 	const char *subscribe = "$aws/things/nrf-id/jobs/123/update/#";
 	const char *rejected = "$aws/things/nrf-id/jobs/123/update/rejected";
 	const char *no_match = "$aws/things/nrf-id/jobs/666/update/accepted";
-	int ret = aws_jobs_cmp(subscribe, accepted, strlen(accepted),
-			"accepted");
+	bool ret = aws_jobs_cmp(subscribe, accepted, strlen(accepted), "accepted");
 
-	zassert_true(ret > 0, "Should be equal");
+	TEST_ASSERT_MESSAGE(ret, "Should be equal");
 
 	ret = aws_jobs_cmp(subscribe, rejected, strlen(rejected), "rejected");
-	zassert_true(ret > 0, "Should be equal");
+	TEST_ASSERT_MESSAGE(ret, "Should be equal");
 
 	ret = aws_jobs_cmp(subscribe, accepted, strlen(accepted), "rejected");
-	zassert_false(ret > 0, "Should not be equal, looking for rejected");
+	TEST_ASSERT_FALSE_MESSAGE(ret, "Should not be equal, looking for rejected");
 
 	ret = aws_jobs_cmp(subscribe, no_match, strlen(no_match), "accepted");
-	zassert_false(ret > 0, "Should not be equal");
-
+	TEST_ASSERT_FALSE_MESSAGE(ret, "Should not be equal");
 }
 
-static void test_aws_jobs_subscribe_topic_update(void)
+void test_aws_jobs_subscribe_topic_update(void)
 {
 	const char *expected = "$aws/things/client_id_123/jobs/job_id/update/#";
 	char *client_id = "client_id_123";
 	struct mqtt_client client = {.client_id.utf8 = client_id};
 	char topic_buf[AWS_JOBS_TOPIC_MAX_LEN];
 
+	__cmock_mqtt_subscribe_ExpectAndReturn(&client, NULL, 0);
+	/* Skip checking param which is internally constructed by the unit under test. */
+	__cmock_mqtt_subscribe_IgnoreArg_param();
+
 	int ret = aws_jobs_subscribe_topic_update(&client, "job_id", topic_buf);
 
-	zassert_equal(ret, 0, "Should be 0");
-	zassert_true(strcmp(expected, topic_buf) == 0, "Should be equal");
+	TEST_ASSERT_EQUAL(0, ret);
+	TEST_ASSERT_EQUAL_STRING(expected, topic_buf);
 }
 
-static void test_aws_jobs_subscribe_topic_get(void)
+void test_aws_jobs_subscribe_topic_get(void)
 {
 	const char *expected = "$aws/things/client_id_123/jobs/job_id/get/#";
 	char *client_id = "client_id_123";
 	struct mqtt_client client = {.client_id.utf8 = client_id};
 	char topic_buf[AWS_JOBS_TOPIC_MAX_LEN];
 
+	__cmock_mqtt_subscribe_ExpectAndReturn(&client, NULL, 0);
+	/* Skip checking param which is internally constructed by the unit under test. */
+	__cmock_mqtt_subscribe_IgnoreArg_param();
+
 	int ret = aws_jobs_subscribe_topic_get(&client, "job_id", topic_buf);
 
-	zassert_equal(ret, 0, "Should be 0");
-	zassert_true(strcmp(expected, topic_buf) == 0, "Should be equal");
+	TEST_ASSERT_EQUAL(0, ret);
+	TEST_ASSERT_EQUAL_STRING(expected, topic_buf);
 }
 
-void test_main(void)
+int main(void)
 {
-	ztest_test_suite(aws_jobs_test,
-			 ztest_unit_test(test_aws_jobs_cmp__null),
-			 ztest_unit_test(test_aws_jobs_cmp__empty),
-			 ztest_unit_test(test_aws_jobs_cmp__no_suffix),
-			 ztest_unit_test(test_aws_jobs_cmp__suffix),
-			 ztest_unit_test(test_aws_jobs_subscribe_topic_update),
-			 ztest_unit_test(test_aws_jobs_subscribe_topic_get)
-			 );
-	ztest_run_test_suite(aws_jobs_test);
+	(void)unity_main();
+	return 0;
 }


### PR DESCRIPTION
The old ztest API is deprecated. So migrated this test to unity test
framework.
Also mocked the APIs from mqtt.h used by the unit under test using
cmock. Previously these APIs were stubbed within the test code.

Signed-off-by: Balaji Srinivasan <balaji.srinivasan@nordicsemi.no>
