### PR TITLE
west.yml: Update Zephyr to bring MCUmgr fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 4c765eaad4953cf08c7bf2b1fc3cbff7383d05ff
+      revision: pull/1156/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Change updates Zephyr to fix check for chosen code partition in direct-xip mode and improve image version comparison.

Jira: NCSDK-21381
Jira: NCSDK-21420