### PR TITLE
manifest: MCUboot revision update to test ECDSA changes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -118,7 +118,7 @@ manifest:
           compare-by-default: false
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 60b2d401add1887830000325b60bb02c47bd6b3b
+      revision: pull/254/head
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR.git


### PR DESCRIPTION
This manifest update is used for testing how ECDSA changes, in MCUtools/MCUboot, affect sdk-mcuboot.