### PR TITLE
manifest: Update sdk-mcuboot to MCUboot version in Zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -118,7 +118,7 @@ manifest:
           compare-by-default: false
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 60b2d401add1887830000325b60bb02c47bd6b3b
+      revision: pull/255/head
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR.git


### PR DESCRIPTION
Update sdk-mcuboot to latest, at this point, in Zephyr:
  1558e7ab0aadb4eac11f03befb5ccd3fa3f0aafe
as brought in by upstream Zephyr PR
  af2576a127c27e3a715605be53339c3cadca5243