### PR TITLE
net: lib: download_client: Report ERANGE when range not supported

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -574,6 +574,7 @@ Libraries for networking
   * Refactored the :c:func:`download_client_connect` function to :c:func:`download_client_set_host` and made it non-blocking.
   * Added the :c:func:`download_client_get` function that combines the functionality of functions :c:func:`download_client_set_host`, :c:func:`download_client_start`, and :c:func:`download_client_disconnect`.
   * Changed configuration from one security tag to a list of security tags.
+  * Updated to report error ``ERANGE`` when HTTP range is requested but not supported by server.
   * Removed functions :c:func:`download_client_pause` and :c:func:`download_client_resume`.
 
 * :ref:`lib_lwm2m_location_assistance` library:

--- a/include/net/download_client.h
+++ b/include/net/download_client.h
@@ -46,6 +46,7 @@ enum download_client_evt_id {
 	 * - ETIMEDOUT: socket error, connection timed out
 	 * - EHOSTDOWN: host went down during download
 	 * - EBADMSG: HTTP response header not as expected
+	 * - ERANGE: HTTP response does not support range requests
 	 * - E2BIG: HTTP response header could not fit in buffer
 	 * - EPROTONOSUPPORT: Protocol is not supported
 	 * - EINVAL: Invalid configuration

--- a/subsys/net/lib/download_client/src/coap.c
+++ b/subsys/net/lib/download_client/src/coap.c
@@ -150,37 +150,37 @@ int coap_parse(struct download_client *client, size_t len)
 	err = coap_packet_parse(&response, client->buf, len, NULL, 0);
 	if (err) {
 		LOG_ERR("Failed to parse CoAP packet, err %d", err);
-		return -1;
+		return -EBADMSG;
 	}
 
 	err = coap_block_update(client, &response, &blk_off, &more);
 	if (err) {
-		return err;
+		return -EBADMSG;
 	}
 
 	if (coap_header_get_id(&response) != client->coap.pending.id) {
 		LOG_ERR("Response is not pending");
-		return -1;
+		return -EBADMSG;
 	}
 
 	coap_pending_clear(&client->coap.pending);
 
 	if (coap_header_get_type(&response) != COAP_TYPE_ACK) {
 		LOG_ERR("Response must be of coap type ACK");
-		return -1;
+		return -EBADMSG;
 	}
 
 	response_code = coap_header_get_code(&response);
 	if (response_code != COAP_RESPONSE_CODE_OK &&
 	    response_code != COAP_RESPONSE_CODE_CONTENT) {
 		LOG_ERR("Server responded with code 0x%x", response_code);
-		return -1;
+		return -EBADMSG;
 	}
 
 	payload = coap_packet_get_payload(&response, &payload_len);
 	if (!payload) {
 		LOG_WRN("No CoAP payload!");
-		return -1;
+		return -EBADMSG;
 	}
 
 	/* TODO: because our buffer is large enough for the whole datagram,

--- a/subsys/net/lib/download_client/src/download_client.c
+++ b/subsys/net/lib/download_client/src/download_client.c
@@ -656,14 +656,14 @@ static int handle_received(struct download_client *dl, ssize_t len)
 		}
 	} else {
 		/* Unknown protocol */
-		rc = -1;
+		rc = -EBADMSG;
 	}
 
 	if (rc < 0) {
 		/* Something was wrong with the packet
 		 * Restart and suspend
 		 */
-		error_evt_send(dl, EBADMSG);
+		error_evt_send(dl, -rc);
 		return -1;
 	}
 


### PR DESCRIPTION
Report error ERANGE from download_client when using range request and server respond with 200 (range not supported).