### PR TITLE
wifi: shields: Adding nRF7002 evaluation board files

### DIFF
--- a/boards/shields/nrf7002_eb/Kconfig.shield
+++ b/boards/shields/nrf7002_eb/Kconfig.shield
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config SHIELD_NRF7002_EB
+	def_bool $(shields_list_contains,nrf7002_eb)

--- a/boards/shields/nrf7002_eb/nrf7002_eb.overlay
+++ b/boards/shields/nrf7002_eb/nrf7002_eb.overlay
@@ -1,0 +1,22 @@
+/* Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+#include <freq.h>
+#include "nrf7002_eb_coex.overlay"
+
+&edge_connector_spi {
+	status = "okay";
+	cs-gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+
+	nrf7002: nrf7002@0 {
+		compatible = "nordic,nrf7002-spi";
+		status = "okay";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(8)>;
+
+		bucken-gpios = <&gpio0 4 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
+		iovdd-ctrl-gpios = <&gpio0 4 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>; /* pin duplicated intentionally */
+		host-irq-gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
+	};
+};

--- a/boards/shields/nrf7002_eb/nrf7002_eb_coex.overlay
+++ b/boards/shields/nrf7002_eb/nrf7002_eb_coex.overlay
@@ -1,0 +1,14 @@
+/* Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	nrf_radio_coex: nrf7002-coex {
+		status = "okay";
+		compatible = "nordic,nrf700x-coex";
+		status0-gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
+		req-gpios = <&gpio1 0 GPIO_ACTIVE_HIGH>;
+		grant-gpios = <&gpio1 1 GPIO_ACTIVE_HIGH>;
+	};
+};

--- a/dts/bindings/wifi/nordic,nrf7002.yaml
+++ b/dts/bindings/wifi/nordic,nrf7002.yaml
@@ -8,7 +8,7 @@ include: base.yaml
 properties:
     iovdd-ctrl-gpios:
         type: phandle-array
-        required: true
+        required: false
         description: |
             GPIO of the SOC controlling IO VDD Control pin of the nRF7002
     bucken-gpios:

--- a/samples/wifi/shell/boards/thingy53_nrf5340.overlay
+++ b/samples/wifi/shell/boards/thingy53_nrf5340.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Disabled because of conflicts on P0.9, P0.10, P0.11 and P0.12 
+ * which conflict with SPI MOSI, MISO, CLK pins and HOST IRQ on 7002*/
+&uart0 {
+	status = "disabled";
+};


### PR DESCRIPTION
Adding nRF7002 shield files and the required dts, bindings and overlay files This is targeted to work with Thingy53 boards.