### PR TITLE
wifi: shields: Add nrf7002 evaluation board to thingy53

### DIFF
--- a/boards/shields/nrf7002ek_nrf7002_eb/Kconfig.shield
+++ b/boards/shields/nrf7002ek_nrf7002_eb/Kconfig.shield
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+DT_COMPAT_NORDIC_NRF700X_QSPI := nordic,nrf700x-qspi
+DT_COMPAT_NORDIC_NRF700X_SPI := nordic,nrf700x-spi
+
+config SHIELD_NRF7002EK_NRF7002_EB
+	def_bool $(shields_list_contains,nrf7002ek_nrf7002_eb)
+
+config NRF7002_ON_QSPI
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF700X_QSPI))
+	depends on SHIELD_NRF7002EK_NRF7002_EB
+
+config NRF7002_ON_SPI
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF700X_SPI))
+	depends on SHIELD_NRF7002EK_NRF7002_EB
+
+config BOARD_NRF7002
+	bool
+	default y if SHIELD_NRF7002EK_NRF7002_EB

--- a/boards/shields/nrf7002ek_nrf7002_eb/boards/thingy53_nrf5340_cpuapp.overlay
+++ b/boards/shields/nrf7002ek_nrf7002_eb/boards/thingy53_nrf5340_cpuapp.overlay
@@ -1,0 +1,22 @@
+/* Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+ /* The below overlays might not be explicitly required but still
+  * kept here to warn of the conflicting pins that could hamper
+  * functionality later
+  */
+
+/*
+ * This uses gpio0 pin 8 that conflicts with STATUS pin of Wi-Fi SR coex
+ */
+&npm1100_force_pwm_mode {
+	status = "disabled";
+};
+
+/* Pins P0.9, P0.10, P0.11, P0.12 conflicting with SPI4,
+ * nrf7002 host irq */
+&uart0 {
+	status = "disabled";
+};

--- a/boards/shields/nrf7002ek_nrf7002_eb/nrf7002ek_nrf7002_eb.overlay
+++ b/boards/shields/nrf7002ek_nrf7002_eb/nrf7002ek_nrf7002_eb.overlay
@@ -1,0 +1,26 @@
+/* Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+#include <freq.h>
+#include "nrf7002ek_nrf7002_eb_coex.overlay"
+
+&edge_connector_spi {
+	status = "okay";
+
+	nrf700x: nrf7002@0 {
+		compatible = "nordic,nrf700x-spi";
+		status = "okay";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(8)>;
+
+		bucken-gpios = <&edge_connector 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
+
+		/* No separate pin for IOVDD, BUCKEN will handle IOVDD automatically,
+		 * but this entry is for compatibility purposes and to avoid adding a
+		 * special case in the nRF700x driver.
+		 */
+		iovdd-ctrl-gpios = <&edge_connector 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
+		host-irq-gpios = <&edge_connector 19 GPIO_ACTIVE_HIGH>;
+	};
+};

--- a/boards/shields/nrf7002ek_nrf7002_eb/nrf7002ek_nrf7002_eb_coex.overlay
+++ b/boards/shields/nrf7002ek_nrf7002_eb/nrf7002ek_nrf7002_eb_coex.overlay
@@ -1,0 +1,14 @@
+/* Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	nrf_radio_coex: nrf7002-coex {
+		status = "okay";
+		compatible = "nordic,nrf700x-coex";
+		status0-gpios = <&edge_connector 15 GPIO_ACTIVE_HIGH>;
+		req-gpios = <&gpio1 0 GPIO_ACTIVE_HIGH>;
+		grant-gpios = <&gpio1 1 GPIO_ACTIVE_HIGH>;
+	};
+};

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -163,12 +163,11 @@ Wi-Fi
 
   * Support for nRF7000 EK.
   * Support for nRF7001 EK and nRF7001 DK.
+  * Support for a new shield, nRF7002 Evaluation Board (EB) for Thingy53 (rev 1.1.0).
 
 * Updated:
 
   * The shield for nRF7002 EK (``nrf7002_ek`` -> ``nrf7002ek_nrf7002``).
-
-|no_changes_yet_note|
 
 Applications
 ============

--- a/drivers/wifi/nrf700x/zephyr/src/qspi/src/rpu_hw_if.c
+++ b/drivers/wifi/nrf700x/zephyr/src/qspi/src/rpu_hw_if.c
@@ -198,8 +198,12 @@ int rpu_pwron(void)
 		LOG_ERR("IOVDD GPIO set failed...\n");
 		return ret;
 	}
-	/* Settling time for iovdd switch (TCK106AG): ~600us */
-	k_msleep(1);
+	/* Settling time for iovdd nRF7002 DK/EK - switch (TCK106AG): ~600us
+	 * For nRF7002 Evaluation board, we add 1ms more to ensure
+	 * that the total time after bucken assertion is more than 2.5ms
+	 * so making this 3ms (1ms + 2ms)
+	 */
+	k_msleep(2);
 	LOG_DBG("Bucken = %d, IOVDD = %d\n", gpio_pin_get_dt(&bucken_spec),
 			gpio_pin_get_dt(&iovdd_ctrl_spec));
 

--- a/samples/wifi/provisioning/sample.yaml
+++ b/samples/wifi/provisioning/sample.yaml
@@ -25,3 +25,10 @@ tests:
       - nrf52840dk_nrf52840
     platform_allow: nrf5340dk_nrf5340_cpuapp nrf52840dk_nrf52840
     tags: ci_build
+  sample.nrf7002_eb.thingy53.provisioning:
+    build_only: true
+    extra_args: SHIELD=nrf7002ek_nrf7002_eb
+    integration_platforms:
+      - thingy53_nrf5340_cpuapp
+    platform_allow: thingy53_nrf5340_cpuapp
+    tags: ci_build

--- a/samples/wifi/radio_test/sample.yaml
+++ b/samples/wifi/radio_test/sample.yaml
@@ -40,3 +40,10 @@ tests:
       - nrf52840dk_nrf52840
     platform_allow: nrf5340dk_nrf5340_cpuapp nrf52840dk_nrf52840
     tags: ci_build
+  sample.nrf7002_eb.thingy53.radio_test:
+    build_only: true
+    extra_args: SHIELD=nrf7002ek_nrf7002_eb
+    integration_platforms:
+      - thingy53_nrf5340_cpuapp
+    platform_allow: thingy53_nrf5340_cpuapp
+    tags: ci_build

--- a/samples/wifi/scan/sample.yaml
+++ b/samples/wifi/scan/sample.yaml
@@ -33,3 +33,10 @@ tests:
       - nrf52840dk_nrf52840
     platform_allow: nrf5340dk_nrf5340_cpuapp nrf52840dk_nrf52840
     tags: ci_build
+  sample.nrf7002_eb.thingy53.scan:
+    build_only: true
+    extra_args: SHIELD=nrf7002ek_nrf7002_eb
+    integration_platforms:
+      - thingy53_nrf5340_cpuapp
+    platform_allow: thingy53_nrf5340_cpuapp
+    tags: ci_build

--- a/samples/wifi/shell/sample.yaml
+++ b/samples/wifi/shell/sample.yaml
@@ -136,4 +136,10 @@ tests:
     integration_platforms:
       - nrf7002dk_nrf5340_cpuapp_ns
     platform_allow: nrf7002dk_nrf5340_cpuapp_ns
+  sample.nrf7002_eb.thingy53.shell:
+    build_only: true
+    extra_args: SHIELD=nrf7002ek_nrf7002_eb CONFIG_BOARD_ENABLE_CPUNET=y
+    integration_platforms:
+      - thingy53_nrf5340_cpuapp
+    platform_allow: thingy53_nrf5340_cpuapp
     tags: ci_build

--- a/samples/wifi/sr_coex/sample.yaml
+++ b/samples/wifi/sr_coex/sample.yaml
@@ -28,4 +28,10 @@ tests:
       - nrf5340dk_nrf5340_cpuapp
     extra_args: SHIELD=nrf7002ek_nrf7001 hci_rpmsg_SHIELD=nrf7002ek_nrf7001_coex
     platform_allow: nrf5340dk_nrf5340_cpuapp
+  sample.nrf7002_eb.thingy53.sr_coex:
+    build_only: true
+    extra_args: SHIELD=nrf7002ek_nrf7002_eb
+    integration_platforms:
+      - thingy53_nrf5340_cpuapp
+    platform_allow: thingy53_nrf5340_cpuapp
     tags: ci_build

--- a/samples/wifi/sta/sample.yaml
+++ b/samples/wifi/sta/sample.yaml
@@ -33,3 +33,10 @@ tests:
       - nrf52840dk_nrf52840
     platform_allow: nrf5340dk_nrf5340_cpuapp nrf52840dk_nrf52840
     tags: ci_build
+  sample.nrf7002_eb.thingy53.sta:
+    build_only: true
+    extra_args: SHIELD=nrf7002ek_nrf7002_eb
+    integration_platforms:
+      - thingy53_nrf5340_cpuapp
+    platform_allow: thingy53_nrf5340_cpuapp
+    tags: ci_build

--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 8182ebc2d257c309b9c50fc0d895a4b88a672a1b
+      revision: ed5f87293cfa907650db2d69a865414cd9ec1e1e
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Adding nRF7002 shield files and the required dts, bindings and overlay files This is targeted to work with Thingy53 boards