### PR TITLE
wifi: scan: Fix scan results display

### DIFF
--- a/samples/wifi/scan/prj.conf
+++ b/samples/wifi/scan/prj.conf
@@ -31,6 +31,9 @@ CONFIG_DEBUG_COREDUMP_MEMORY_DUMP_MIN=y
 # Logging
 CONFIG_LOG=y
 CONFIG_PRINTK=y
+# If below config is enabled, printk logs are
+# buffered. For unbuffered messages, disable this.
+CONFIG_LOG_PRINTK=n
 
 # printing of scan results puts pressure on queues in new locking
 # design in net_mgmt. So, use a typical number of networks in a crowded


### PR DESCRIPTION
As LOG_PRINTK is enabled, printk is buffering the
scan results. So, disabled the config

Fixes SHEL-1450