### PR TITLE
net: lib: download_client: Always close in handle_disconnect

### DIFF
--- a/include/net/download_client.h
+++ b/include/net/download_client.h
@@ -43,6 +43,8 @@ enum download_client_evt_id {
 	 *
 	 * Error reason may be one of the following:
 	 * - ECONNRESET: socket error, peer closed connection
+	 * - ECONNREFUSED: socket error, connection refused by server
+	 * - ENETDOWN: socket error, network down
 	 * - ETIMEDOUT: socket error, connection timed out
 	 * - EHOSTDOWN: host went down during download
 	 * - EBADMSG: HTTP response header not as expected

--- a/subsys/net/lib/download_client/src/download_client.c
+++ b/subsys/net/lib/download_client/src/download_client.c
@@ -713,21 +713,16 @@ static int handle_received(struct download_client *dl, ssize_t len)
 
 static int handle_disconnect(struct download_client *client)
 {
-	int err;
+	int err = 0;
 
 	k_mutex_lock(&client->mutex, K_FOREVER);
 
-	if (client->fd < 0) {
-		k_mutex_unlock(&client->mutex);
-		return -EINVAL;
-	}
-
-	err = close(client->fd);
-	if (err) {
-		err = errno;
-		k_mutex_unlock(&client->mutex);
-		LOG_ERR("Failed to close socket, errno %d", err);
-		return -err;
+	if (client->fd != -1) {
+		err = close(client->fd);
+		if (err) {
+			err = errno;
+			LOG_ERR("Failed to close socket, errno %d", err);
+		}
 	}
 
 	client->fd = -1;
@@ -742,7 +737,7 @@ static int handle_disconnect(struct download_client *client)
 
 	k_mutex_unlock(&client->mutex);
 
-	return 0;
+	return err;
 }
 
 void download_thread(void *client, void *a, void *b)

--- a/subsys/net/lib/download_client/src/download_client.c
+++ b/subsys/net/lib/download_client/src/download_client.c
@@ -488,7 +488,7 @@ static int reconnect(struct download_client *dl)
 {
 	int err;
 
-	LOG_INF("Reconnecting..");
+	LOG_INF("Reconnecting...");
 	if (dl->fd >= 0) {
 		err = close(dl->fd);
 		if (err) {
@@ -559,7 +559,7 @@ static int request_resend(struct download_client *dl)
  * @brief Handle socket errors.
  *
  * @param dl
- * @return negative value to stop the handler loop, zero to rettry the query.
+ * @return negative value to stop the handler loop, zero to retry the query.
  */
 static int handle_socket_error(struct download_client *dl, ssize_t len)
 {
@@ -642,7 +642,7 @@ static int handle_received(struct download_client *dl, ssize_t len)
 		if (rc > 0 &&
 		    (IS_ENABLED(CONFIG_DOWNLOAD_CLIENT_RANGE_REQUESTS) || !dl->http.has_header)) {
 			/* Wait for more data (fragment/header).
-			 * Unranged reguest (normal GET) should start forwarding the data
+			 * Unranged request (normal GET) should start forwarding the data
 			 * once HTTP headers are received. Ranged-GET should receive full
 			 * buffer(fragment) before sending an event.
 			 */


### PR DESCRIPTION
Always set state idle and cleanup client context in handle_disconnect.
An error may have happened before setting client->fd, and the client must be ready after a disconnect.

Document ECONNREFUSED and ENETDOWN for DOWNLOAD_CLIENT_EVT_ERROR.
Fix some typos.