### PR TITLE
manifest: sdk-hostap: Pull debug logs improvement

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -110,7 +110,7 @@ manifest:
     - name: hostap
       repo-path: sdk-hostap
       path: modules/lib/hostap
-      revision: ec4a32a3a7037603aa87dd5b31622141ceddf32b
+      revision: pull/92/head
       userdata:
         ncs:
           upstream-url: https://w1.fi/cgit/hostap/


### PR DESCRIPTION
This solves the problem of missing logs when WPA supplicant debug is enabled.