### PR TITLE
net: lib: nrf_cloud: prevent simultaneous downloads

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -521,6 +521,8 @@ Libraries for networking
     * Standardized encode and decode function names in the codec.
     * Moved the :c:func:`nrf_cloud_location_request_json_get` function from the :file:`nrf_cloud_location.h` file to :file:`nrf_cloud_codec.h`.
       The function is now renamed to :c:func:`nrf_cloud_location_request_msg_json_encode`.
+    * Allow only one file download at a time within the library.
+      MQTT-based FOTA, :kconfig:option:`CONFIG_NRF_CLOUD_FOTA`, has priority.
 
 * :ref:`lib_nrf_cloud_rest` library:
 

--- a/subsys/net/lib/nrf_cloud/CMakeLists.txt
+++ b/subsys/net/lib/nrf_cloud/CMakeLists.txt
@@ -33,13 +33,15 @@ zephyr_library_sources_ifdef(
 	src/nrf_cloud_agps.c
 	src/nrf_cloud_agps_utils.c
 	src/nrf_cloud_pgps.c
-	src/nrf_cloud_pgps_utils.c)
+	src/nrf_cloud_pgps_utils.c
+	src/nrf_cloud_download.c)
 zephyr_library_sources_ifdef(
 	CONFIG_NRF_CLOUD_LOCATION
 	src/nrf_cloud_location.c)
 zephyr_library_sources_ifdef(
 	CONFIG_NRF_CLOUD_FOTA
-	src/nrf_cloud_fota.c)
+	src/nrf_cloud_fota.c
+	src/nrf_cloud_download.c)
 zephyr_library_sources_ifdef(
 	CONFIG_NRF_CLOUD_REST
 	src/nrf_cloud_rest.c)

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_download.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_download.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef NRF_CLOUD_DOWNLOAD_H__
+#define NRF_CLOUD_DOWNLOAD_H__
+
+#include <dfu/dfu_target.h>
+#include <net/download_client.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum nrf_cloud_download_type {
+	NRF_CLOUD_DL_TYPE_NONE,
+
+	/* Download a FOTA update using the fota_download library */
+	NRF_CLOUD_DL_TYPE_FOTA,
+	/* Download data using the download_client library */
+	NRF_CLOUD_DL_TYPE_DL_CLIENT,
+
+	NRF_CLOUD_DL_TYPE_DL__LAST
+};
+
+struct nrf_cloud_download_fota {
+	/* FOTA update type */
+	enum dfu_target_image_type expected_type;
+};
+
+struct nrf_cloud_download_data {
+	/* Type of download to perform */
+	enum nrf_cloud_download_type type;
+
+	/* File download host */
+	const char *host;
+	/* File download path */
+	const char *path;
+
+	/* Download client configuration */
+	struct download_client_cfg dl_cfg;
+
+	union {
+		/* FOTA type data */
+		struct nrf_cloud_download_fota fota;
+		/* Download client type data */
+		struct download_client *dlc;
+	};
+};
+
+/** @brief Start download. Only one download at a time is allowed. FOTA downloads have priority.
+ *         If a FOTA download is started while a non-FOTA download is active, the non-FOTA
+ *         download is stopped.
+ */
+int nrf_cloud_download_start(struct nrf_cloud_download_data *const dl);
+
+/** @brief Reset the active download state. Call when download has ended. */
+void nrf_cloud_download_end(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NRF_CLOUD_DOWNLOAD_H__ */

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_download.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_download.c
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#if defined(CONFIG_FOTA_DOWNLOAD)
+#include <net/fota_download.h>
+#endif
+#include "nrf_cloud_download.h"
+LOG_MODULE_REGISTER(nrf_cloud_download, CONFIG_NRF_CLOUD_LOG_LEVEL);
+
+static K_MUTEX_DEFINE(active_dl_mutex);
+static struct nrf_cloud_download_data active_dl = { .type = NRF_CLOUD_DL_TYPE_NONE };
+
+void nrf_cloud_download_end(void)
+{
+	k_mutex_lock(&active_dl_mutex, K_FOREVER);
+	memset(&active_dl, 0, sizeof(active_dl));
+	active_dl.type = NRF_CLOUD_DL_TYPE_NONE;
+	k_mutex_unlock(&active_dl_mutex);
+}
+
+int nrf_cloud_download_start(struct nrf_cloud_download_data *const dl)
+{
+	if (!dl || !dl->path || (dl->type <= NRF_CLOUD_DL_TYPE_NONE) ||
+	    (dl->type >= NRF_CLOUD_DL_TYPE_DL__LAST)) {
+		return -EINVAL;
+	}
+
+	if (!IS_ENABLED(CONFIG_FOTA_DOWNLOAD) && (dl->type == NRF_CLOUD_DL_TYPE_FOTA)) {
+		return -ENOTSUP;
+	}
+
+	int ret = 0;
+
+	k_mutex_lock(&active_dl_mutex, K_FOREVER);
+
+	/* FOTA has priority */
+	if ((active_dl.type == NRF_CLOUD_DL_TYPE_FOTA) ||
+	    ((active_dl.type != NRF_CLOUD_DL_TYPE_NONE) &&
+	     (dl->type != NRF_CLOUD_DL_TYPE_FOTA))) {
+		k_mutex_unlock(&active_dl_mutex);
+		/* A download of equal or higher priority is already active. */
+		return -EBUSY;
+	}
+
+	/* If a download is active, that means the incoming download request is a FOTA
+	 * type, which has priority. Cancel the active download.
+	 */
+	if (active_dl.type == NRF_CLOUD_DL_TYPE_DL_CLIENT) {
+		LOG_INF("Stopping active download, incoming FOTA update download has priority");
+		ret = download_client_disconnect(active_dl.dlc);
+
+		if (ret) {
+			LOG_ERR("download_client_disconnect() failed, error %d", ret);
+		}
+	}
+
+	if (dl->type == NRF_CLOUD_DL_TYPE_FOTA) {
+#if defined(CONFIG_FOTA_DOWNLOAD)
+		ret = fota_download_start_with_image_type(dl->host, dl->path,
+			dl->dl_cfg.sec_tag_count ? dl->dl_cfg.sec_tag_list[0] : -1,
+			dl->dl_cfg.pdn_id, dl->dl_cfg.frag_size_override, dl->fota.expected_type);
+#endif
+	} else if (dl->type == NRF_CLOUD_DL_TYPE_DL_CLIENT) {
+		ret = download_client_get(dl->dlc, dl->host, &dl->dl_cfg,
+					  dl->path, 0);
+		if (ret) {
+			(void)download_client_disconnect(dl->dlc);
+		}
+	} else {
+		LOG_WRN("Unhandled download type: %d", dl->type);
+		ret = -EFTYPE;
+	}
+
+	if (ret == 0) {
+		active_dl = *dl;
+	}
+	k_mutex_unlock(&active_dl_mutex);
+
+	return ret;
+}

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -284,7 +284,7 @@ static int nct_client_id_set(const char * const client_id)
 		}
 	} else {
 		if (client_id) {
-			LOG_WRN("Not configured to for runtime client ID, ignoring");
+			LOG_WRN("Not configured for runtime client ID, ignoring");
 		}
 		len = nrf_cloud_configured_client_id_length_get();
 	}


### PR DESCRIPTION
Allow only one file download at a time within the nrf_cloud library. 
MQTT-based FOTA (CONFIG_NRF_CLOUD_FOTA) has priority. 
IRIS-5612