### PR TITLE
lib: pdn: fix PDN context initialization

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -491,6 +491,11 @@ Modem libraries
 
   * Updated the library to use ePCO mode if the Kconfig option :kconfig:option:`CONFIG_PDN_LEGACY_PCO` is not enabled.
 
+  * Fixed:
+
+    * A bug in the initialization of a new PDN context without a PDN event handler.
+    * A memory leak in the :c:func:`pdn_ctx_create` function.
+
 * :ref:`lte_lc_readme` library:
 
   * Updated:


### PR DESCRIPTION
When creating a new PDN context, assign the event handler regardless of
whether the input callback is NULL or not. The callback pointer is
uninitialized having been allocated from the heap, which could lead to
illegal access upon receiving events. Additionally, free the PDN context,
should the initialization fail.