### PR TITLE
applications: nrf_desktop: Inform about MCUboot+XIP support in docs

### DIFF
--- a/applications/nrf_desktop/doc/dfu.rst
+++ b/applications/nrf_desktop/doc/dfu.rst
@@ -29,12 +29,6 @@ To perform the firmware upgrade, you must enable the bootloader.
 You can use the DFU module with either MCUboot or B0 bootloader.
 For more information on how to enable the bootloader, see the :ref:`nrf_desktop_bootloader` documentation.
 
-.. note::
-   If you selected the MCUboot bootloader, the DFU module:
-
-   * Requests the image upgrade after the whole image is transferred over the :ref:`nrf_desktop_config_channel`.
-   * Confirms the running image after device reboot.
-
 Enable the DFU module using the :ref:`CONFIG_DESKTOP_CONFIG_CHANNEL_DFU_ENABLE <config_desktop_app_options>` option.
 It requires the transport option :ref:`CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE <config_desktop_app_options>` to be selected, as it uses :ref:`nrf_desktop_config_channel` for the transmission of the update image.
 
@@ -47,6 +41,26 @@ If the buffer is small, the host must perform the DFU progress synchronization m
    The received update image chunks are stored on the dedicated flash memory partition when the current version of the device firmware is running.
    For this reason, make sure that you use configuration with two image partitions.
    For more information on configuring the memory layout in the application, see the :ref:`nrf_desktop_flash_memory_layout` documentation.
+
+MCUboot bootloader mode
+=======================
+
+The MCUboot bootloader can either move the image to the primary slot before booting it (``swap mode``) or boot the image directly from the secondary slot (``direct-xip mode``).
+
+If the MCUboot bootloader in the swap mode is selected, the DFU module does the following:
+
+ * Requests the image upgrade after the whole image is transferred over the :ref:`nrf_desktop_config_channel`.
+ * Confirms the running image after the device is rebooted.
+
+If the MCUboot bootloader's direct-xip mode is used, the module does not mark the newly uploaded image as pending and does not confirm it after a successful boot.
+In that case, the DFU module assumes that the MCUboot direct-xip bootloader simply boots an image with the higher version, so there is no need to mark the image as pending and confirm it.
+
+The :ref:`CONFIG_DESKTOP_CONFIG_CHANNEL_DFU_MCUBOOT_DIRECT_XIP <config_desktop_app_options>` option is used to inform the DFU module that the device uses the MCUboot bootloader in the direct-xip mode.
+If the option is enabled, the DFU module reports the ``MCUBOOT+XIP`` bootloader name instead of ``MCUBOOT`` to indicate that the bootloader working in the direct-xip mode is used.
+The option depends on enabling the MCUboot bootloader (:kconfig:option:`CONFIG_BOOTLOADER_MCUBOOT`) and is enabled by default if the direct-xip variant of the application image is built (:kconfig:option:`CONFIG_BOOT_BUILD_DIRECT_XIP_VARIANT`).
+
+.. note::
+   The configured MCUboot bootloader mode needs to be manually aligned for both bootloader and application image.
 
 Device identification information
 =================================

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -223,6 +223,8 @@ nRF Desktop
     On the firmware side, fetching the values is handled by the :ref:`nrf_desktop_dfu`.
   * Unpairing old peers right after a successful erase advertising procedure.
     This prevents blocking the bond slots until the subsequent erase advertising procedure is triggered.
+  * Support for the :ref:`nrf_desktop_dfu` for devices using the MCUboot bootloader built in the direct-xip mode (``MCUBOOT+XIP``).
+    In this mode, the image is booted directly from the secondary slot instead of moving it to the primary slot.
 
 * Updated:
 
@@ -649,8 +651,12 @@ This section provides detailed lists of changes by :ref:`script <scripts>`.
 
 * :ref:`nrf_desktop_config_channel_script`:
 
-  * Added support for the device information (``devinfo``) option fetching.
-    The option provides device's Vendor ID, Product ID and generation.
+  * Added:
+
+    * Support for the device information (``devinfo``) option fetching.
+      The option provides device's Vendor ID, Product ID and generation.
+    * Support for devices using MCUboot bootloader built in the direct-xip mode (``MCUBOOT+XIP``).
+      In this mode, the image is booted directly from the secondary slot without moving it to the primary slot.
 
 MCUboot
 =======


### PR DESCRIPTION
Change introduces documentation for using MCUboot bootloader working in the direct-xip mode.

Jira: NCSDK-20586