### PR TITLE
driver: wifi: Enforce minimum value for NRF700X_MAX_TX_TOKENS

### DIFF
--- a/drivers/wifi/nrf700x/Kconfig.nrf700x
+++ b/drivers/wifi/nrf700x/Kconfig.nrf700x
@@ -126,6 +126,7 @@ config NRF700X_MAX_TX_AGGREGATION
 
 config NRF700X_MAX_TX_TOKENS
 	int "Maximum number of TX tokens"
+	range 5 12 if !NRF700X_RADIO_TEST
 	default 10
 
 config NRF700X_TX_MAX_DATA_SIZE

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/tx.c
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/tx.c
@@ -9,6 +9,7 @@
  * FMAC IF Layer of the Wi-Fi driver.
  */
 
+#include <zephyr/sys/__assert.h>
 #include "list.h"
 #include "queue.h"
 #include "hal_api.h"
@@ -28,6 +29,8 @@ static void set_spare_desc_q_map(struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx,
 {
 	unsigned short spare_desc_indx = 0;
 
+	__ASSERT(fmac_dev_ctx->fpriv->num_tx_tokens_per_ac != 0, "num_tx_tokens_per_ac is zero");
+
 	spare_desc_indx = (desc % (fmac_dev_ctx->fpriv->num_tx_tokens_per_ac *
 				   WIFI_NRF_FMAC_AC_MAX));
 
@@ -45,6 +48,8 @@ static void clear_spare_desc_q_map(struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx,
 				   int tx_done_q)
 {
 	unsigned short spare_desc_indx = 0;
+
+	__ASSERT(fmac_dev_ctx->fpriv->num_tx_tokens_per_ac != 0, "num_tx_tokens_per_ac is zero");
 
 	spare_desc_indx = (desc % (fmac_dev_ctx->fpriv->num_tx_tokens_per_ac *
 				   WIFI_NRF_FMAC_AC_MAX));


### PR DESCRIPTION
The minimum value of `NRF700X_MAX_TX_TOKENS` has to be atleast `WIFI_NRF_FMAC_AC_MAX` (5). If not, this will lead to the setting of `num_tx_tokens_per_ac` to 0 by `wifi_nrf_fmac_init()` which in-turn will lead to divide by zero errors in `clear_spare_desc_q_map()` and `set_spare_desc_q_map()`. This is now fixed by enforcing a minimal value for the KConfig symbol `NRF700X_MAX_TX_TOKENS`.
Also added ASSERT statements to catch this condition if it ever arises.

Found as violation of CERT, INT33-C and MITRE, CWE-369 by sonarcloud.
