### PR TITLE
doc: reorganize known issues

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -5,7 +5,7 @@ Known issues
 
 .. contents::
    :local:
-   :depth: 2
+   :depth: 3
 
 Known issues listed on this page *and* tagged with the :ref:`latest official release version <release_notes>` are valid for the current state of development.
 Use the drop-down filter to see known issues for previous releases and check if they are still valid.
@@ -54,6 +54,11 @@ Use the drop-down filter to see known issues for previous releases and check if 
      <option value="v0-3-0">v0.3.0</option>
    </select>
 
+Affected platforms
+  If a known issue does not list specific platforms in the **Affected platforms** list, it is valid for all hardware platforms.
+
+Workarounds
+  Some known issues list available workarounds, which can be discovered and added over time.
 
 .. HOWTO
 
@@ -72,489 +77,365 @@ Use the drop-down filter to see known issues for previous releases and check if 
 
      There can be several paragraphs, but they must be indented correctly.
 
+     **Affected platforms:** Write what hardware platform is affected by this issue.
+     If an issue touches all hardware platforms, this line is not needed.
+
      **Workaround:** The last paragraph contains the workaround.
      The workaround is optional.
 
-nRF9160
-*******
+Protocols
+*********
 
-Asset tracker
+The issues in this section are related to :ref:`protocols`.
+
+Bluetooth® LE
 =============
 
-.. rst-class:: v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0
+The issues in this section are related to :ref:`ug_ble_controller`.
 
-NCSDK-6898: Setting :kconfig:option:`CONFIG_SECURE_BOOT` does not work
-  The immutable bootloader is not able to find the required metadata in the MCUboot image.
-  See the related NCSDK-6898 known issue in `Build system`_ for more details.
+.. _ncsdk_19865:
 
-  **Workaround:** Set :kconfig:option:`CONFIG_FW_INFO` in MCUboot.
+.. rst-class:: v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0 v0-4-0 v0-3-0
 
-.. rst-class:: v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0
+NCSDK-19865: GATT Robust Caching issues for bonded peers
+  The Client Supported Features value written by a bonded peer may not be stored in the non-volatile memory.
+  Change awareness of the bonded peer is lost on reboot.
+  After reboot, each bonded peer is initially marked as change-unaware.
 
-External antenna performance setting
-  The preprogrammed Asset Tracker does not come with the best external antenna performance.
+  **Workaround:** Disable the GATT Caching feature (:kconfig:option:`CONFIG_BT_GATT_CACHING`).
+  Make sure that Bluetooth bonds are removed together with disabling GATT Caching if the functionality is disabled during a firmware upgrade.
 
-  **Workaround:** If you are using nRF9160 DK v0.15.0 or higher and Thingy:91 v1.4.0 or higher, set :kconfig:option:`CONFIG_NRF9160_GPS_ANTENNA_EXTERNAL` to ``y``.
-  Alternatively, for nRF9160 DK v0.15.0, you can set the :kconfig:option:`CONFIG_NRF9160_GPS_COEX0_STRING` option to ``AT%XCOEX0`` when building the preprogrammed Asset Tracker to achieve the best external antenna performance.
+.. rst-class:: v2-0-2
 
-.. rst-class:: v1-3-2 v1-3-1 v1-3-0
+DRGN-17695: The BT RX thread stack might overflow if the :kconfig:option:`CONFIG_BT_SMP` is enabled
+  When performing SMP pairing MPU FAULTs might be triggered because the stack is not large enough.
 
-NCSDK-5574: Warnings during FOTA
-   The nRF9160: Asset Tracker application prints warnings and error messages during successful FOTA.
+  **Workaround:** Increase the stack size manually in the project configuration file (:file:`prj.conf`) using :kconfig:option:`CONFIG_BT_RX_STACK_SIZE`.
 
-.. rst-class:: v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0 v0-4-0 v0-3-0
+.. rst-class:: v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0
 
-NCSDK-6689: High current consumption in Asset Tracker
-  The nRF9160: Asset Tracker might show up to 2.5 mA current consumption in idle mode with :kconfig:option:`CONFIG_POWER_OPTIMIZATION_ENABLE` set to ``y``.
+NCSDK-13459: Uninitialized size in hids_boot_kb_outp_report_read
+  When reading from the boot keyboard output report characteristic, the :ref:`hids_readme` calls the registered callback with uninitialized report size.
 
-.. rst-class:: v1-0-0 v0-4-0 v0-3-0
+  **Workaround:** Manually cherry-pick and apply commit with fix from main (commit hash: ``f18250dad6cbd9778de7af4b8a774b58e55fe720``).
 
-Sending data before connecting to nRF Cloud
-  The nRF9160: Asset Tracker application does not wait for connection to nRF Cloud before trying to send data.
-  This causes the application to crash if the user toggles one of the switches before the kit is connected to the cloud.
+.. rst-class:: v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0
 
-.. rst-class:: v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0 v0-4-0 v0-3-0
+NCSDK-9106: Bluetooth® ECC thread stack size too small
+  The Bluetooth ECC thread used during the pairing procedure with LE Secure Connections might overflow when an interrupt is triggered when the stack usage is at its maximum.
 
-IRIS-2676: Missing support for FOTA on nRF Cloud
-  The nRF9160: Asset Tracker application does not support the nRF Cloud FOTA_v2 protocol.
+  **Workaround:** Increase the ECC stack size by setting ``CONFIG_BT_HCI_ECC_STACK_SIZE`` to ``1140``.
 
-  **Workaround:** The implementation for supporting the nRF Cloud FOTA_v2 can be found in the following commits:
+.. rst-class:: v1-5-0 v1-4-2 v1-4-1 v1-4-0
 
-					* cef289b559b92186cc54f0257b8c9adc0997f334
-					* 156d4cf3a568869adca445d43a786d819ae10250
-					* f520159f0415f011ae66efb816384a8f7bade83d
+DRGN-15435: GATT notifications and Writes Without Response might be sent out of order
+  GATT notifications and Writes Without Response might be sent out of order when not using a complete callback.
 
-Asset Tracker v2
-================
+  **Workaround:** Always set a callback for notifications and Writes Without Response.
 
-.. rst-class:: v2-2-0
+.. rst-class:: v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0
 
-CIA-845: The application cannot be built with :file:`overlay-carrier.conf` (carrier library) enabled for Nordic Thingy:91
-  Building with :ref:`liblwm2m_carrier_readme` library enabled for Nordic Thingy:91 will result in a ``FLASH`` overflow and a build error.
+DRGN-15448: Incomplete bond overwrite during pairing procedure when peer is not using the IRK stored in the bond
+  When pairing with a peer that has deleted its bond information and is using a new IRK to establish the connection, the existing bond is not overwritten during the pairing procedure.
+  This can lead to MIC errors during reconnection if the old LTK is used instead.
 
-.. rst-class:: v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0
+.. rst-class:: v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0
 
-CIA-463: Wrong network mode parameter reported to cloud
-  The network mode string present in ``deviceInfo`` (nRF Cloud) and ``dev`` (Azure IoT Hub and AWS IoT) JSON objects that is reported to cloud might contain wrong network modes.
-  The network mode string contains the network modes that the modem is configured to use, not what the modem actually connects to the LTE network with.
+NCSDK-8224: Callbacks for "security changed" and "pairing failed" are not always called
+  The pairing failed and security changed callbacks are not called when the connection is disconnected during the pairing procedure or the required security is not met.
 
-.. rst-class:: v1-9-2 v1-9-1 v1-9-0
+  **Workaround:** Application should use the disconnected callback to handle pairing failed.
 
-NCSDK-14235: Timestamps that are sent in cloud messages drift over time
-  Due to a bug in the :ref:`lib_date_time` library, timestamps that are sent to cloud drift because they are calculated incorrectly.
+.. rst-class:: v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0
 
-.. rst-class:: v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-0
+NCSDK-8223: GATT requests might deadlock RX thread
+  GATT requests might deadlock the RX thread when all TX buffers are taken by GATT requests and the RX thread tries to allocate a TX buffer for a response.
+  This causes a deadlock because only the RX thread releases the TX buffers for the GATT requests.
+  The deadlock is resolved by a 30 second timeout, but the ATT bearer cannot transmit without reconnecting.
 
-CIA-604: ATv2 cannot be built for the ``thingy91_nrf9160_ns`` build target with ``SECURE_BOOT`` enabled
-  Due to the use of static partitions with the Thingy:91, there is insufficient room in the flash memory to enable both the primary and secondary bootloaders.
+  **Workaround:** Set :kconfig:option:`CONFIG_BT_L2CAP_TX_BUF_COUNT` >= ``CONFIG_BT_ATT_TX_MAX`` + 2.
 
-.. rst-class:: v2-0-2 v2-0-1 v2-0-0
+.. rst-class:: v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0
 
-CIA-661: Asset Tracker v2 application configured for LwM2M cannot be built for the ``nrf9160dk_nrf9160_ns`` build target with modem traces or Memfault enabled
-  The :ref:`asset_tracker_v2` application configured for LwM2M cannot be built for the ``nrf9160dk_nrf9160_ns`` build target with :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE` for modem traces or :file:`overlay-memfault.conf` for Memfault due to memory constraints.
+NCSDK-6845: Pairing failure with simultaneous pairing on multiple connections
+  When using LE Secure Connections pairing, the pairing fails with simultaneous pairing on multiple connections.
+  The failure reason is unspecified.
 
-  **Workaround:** Use one of the following workarounds for modem traces:
+  **Workaround:** Retry the pairing on the connections that failed one by one after the pairing procedure has finished.
 
-  * Use Secure Partition Manager instead of TF-M by setting ``CONFIG_SPM`` to ``y`` and :kconfig:option:`CONFIG_BUILD_WITH_TFM` to ``n``.
-  * Reduce the value of :kconfig:option:`CONFIG_NRF_MODEM_LIB_SHMEM_TRACE_SIZE` to 8 Kb, however, this might lead to loss of modem traces.
+.. rst-class:: v1-4-0 v1-3-2 v1-3-1 v1-3-0
 
-  For Memfault, use Secure Partition Manager instead of TF-M by setting ``CONFIG_SPM`` to ``y`` and :kconfig:option:`CONFIG_BUILD_WITH_TFM` to ``n``.
+NCSDK-6844: Security procedure failure can terminate GATT client request
+  A security procedure terminates the GATT client request that is currently in progress, unless the request was the reason to initiate the security procedure.
+  If a new GATT client request is queued at this time, this might potentially cause a GATT transaction violation and fail as well.
 
-.. rst-class:: v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0
+  **Workaround:** Do not initiate a security procedure in parallel with GATT client requests.
 
-CIA-890: The application cannot be built with :file:`overlay-debug.conf` and :kconfig:option:`CONFIG_DEBUG_OPTIMIZATIONS` set to ``y``
-  Due to insufficient flash space for the application when it is not optimized, the :ref:`asset_tracker_v2` application cannot be built with :file:`overlay-debug.conf` and :kconfig:option:`CONFIG_DEBUG_OPTIMIZATIONS` set to ``y``.
+.. rst-class:: v1-3-0
 
-  **Workaround:** To free up flash space when debugging locally, comment out the following Kconfig options in the :file:`prj.conf` file:
+NCSDK-5711: High-throughput transmission can deadlock the receive thread
+  High-throughput transmission can deadlock the receive thread if the connection is suddenly disconnected.
 
-  * :kconfig:option:`CONFIG_BOOTLOADER_MCUBOOT`
-  * :kconfig:option:`CONFIG_IMG_MANAGER`
-  * :kconfig:option:`CONFIG_MCUBOOT_IMG_MANAGER`
-  * :kconfig:option:`CONFIG_IMG_ERASE_PROGRESSIVELY`
-  * :kconfig:option:`CONFIG_BUILD_S1_VARIANT`
+.. rst-class:: v1-2-1 v1-2-0
 
-  This removes the partitions for the MCUboot bootloader, the secondary bootloader, and the secondary application image slot.
-  Any functionality depending on those will not work with this configuration.
+Only secure applications can use Bluetooth® LE
+  Bluetooth LE cannot be used in a non-secure application, for example, an application built for the ``nrf5340_dk_nrf5340_cpuappns`` build target.
 
-  Alternatively, disable logging for non-relevant modules or libraries in the :file:`overlay-debug.conf` file until the image fits in flash.
+  **Affected platforms:** nRF5340
 
-Serial LTE Modem
-================
+  **Workaround:** Use the ``nrf5340_dk_nrf5340_cpuapp`` build target instead.
 
-.. rst-class:: v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0
+.. rst-class:: v1-2-1 v1-2-0 v1-1-0
 
-NCSDK-13895: Build failure for target Thingy:91 with secure_bootloader overlay
-  Building the application for Thingy:91 fails if secure_bootloader overlay is included.
+:kconfig:option:`CONFIG_BT_SMP` alignment requirement
+  When running the :ref:`bluetooth_central_dfu_smp` sample, the :kconfig:option:`CONFIG_BT_SMP` configuration must be aligned between this sample and the Zephyr counterpart (:ref:`zephyr:smp_svr_sample`).
+  However, security is not enabled by default in the Zephyr sample.
 
-.. rst-class:: v2-3-0
 
-NCSDK-20047: SLM logging over RTT is not available
-  There is a conflict with MCUboot RTT logging.
-  In order to save power, SLM configures MCUboot to use RTT instead of UART for logging.
-  SLM itself uses RTT for logging as well.
-  With a recent change, MCUboot exclusively takes control of the RTT logging, which causes the conflict.
+Bluetooth mesh
+==============
 
-  **Workaround:** Remove ``CONFIG_USE_SEGGER_RTT=y`` and ``CONFIG_RTT_CONSOLE=y`` from :file:`child_image\mcuboot.conf`.
+The issues in this section are related to the :ref:`ug_bt_mesh` protocol.
 
-.. _known_issues_other:
+.. rst-class:: v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1
 
-Other issues
-============
+NCSDK-16800: RPL is not cleared on IV index recovery
+  After recovering the IV index, a node doesn't clear the replay protection list, which leads to incorrect triggering of the replay attack protection mechanism.
 
-.. rst-class:: v2-3-0
+  **Workaround:** Call ``bt_mesh_rpl_reset`` twice after the IV index recovery is done.
 
-CIA-892: Assert or crash when printing long strings with the ``%s`` qualifier
-  When logging a string with the ``%s`` qualifier, the maximum length of any inserted string is 1022 bytes.
-  If the string is longer, an assert or a crash can occur.
-  Given that the default value of the :kconfig:option:`CONFIG_LOG_PRINTK` Kconfig option has been changed from ``n`` to ``y`` in the |NCS| v2.3.0 release, the :c:func:`printk` function may also cause this issue, unless the application disables this option.
+.. rst-class:: v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1
 
-  **Workaround:** To fix the issue, cherry-pick commits from the upstream `Zephyr PR #54901 <https://github.com/zephyrproject-rtos/zephyr/pull/54901>`_.
+NCSDK-16798: Friend Subscription List might have duplicate entries
+  If a Low Power node loses a Friend Subscription List Add Confirm message, it repeats the request.
+  The Friend does not check both the transaction number and the presence of the addresses in the subscription list.
+  This causes a situation where the Friend fills the subscription list with duplicate addresses.
+
+.. rst-class:: v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0
+
+NCSDK-16782: The extended advertiser might not work with Bluetooth mesh
+  Using the extended advertiser instead of the legacy advertiser can lead to getting composition data while provisioning to fail.
+  This problem might manifest in the sample :ref:`bluetooth_ble_peripheral_lbs_coex`, as it is using the extended advertiser.
+
+.. rst-class:: v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0
+
+NCSDK-16579: Advertising Node Identity and Network ID might not work with the extended advertiser
+  Advertising Node Identity and Network ID do not work with the extended advertising API when the :kconfig:option:`CONFIG_BT_MESH_ADV_EXT_GATT_SEPARATE` option is enabled.
+
+  **Workaround:** Don't enable the :kconfig:option:`CONFIG_BT_MESH_ADV_EXT_GATT_SEPARATE` option.
+
+.. rst-class:: v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1
+
+NCSDK-14399: Legacy advertiser can occasionally do more message retransmissions than requested
+  When using the legacy advertiser, the stack sleeps for at least 50 ms after starting advertising a message, which might result in more messages to be advertised than requested.
+
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1
+
+NCSDK-16061: IV update procedure fails on the device
+  Bluetooth® mesh device does not undergo IV update and fails to participate in the procedure initiated by any other node unless it is rebooted after the provisioning.
+
+  **Workaround:** Reboot the device after provisioning.
+
+.. rst-class:: v1-6-1 v1-6-0
+
+NCSDK-10200: The device stops sending Secure Network Beacons after re-provisioning
+  Bluetooth® mesh stops sending Secure Network Beacons if the device is re-provisioned after reset through Config Node Reset message or ``bt_mesh_reset()`` call.
+
+  **Workaround:** Reboot the device after re-provisioning.
+
+.. rst-class:: v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0
+
+NCSDK-5580: nRF5340 only supports SoftDevice Controller
+  On nRF5340, only the :ref:`nrfxlib:softdevice_controller` is supported for Bluetooth® mesh.
+
+  **Affected platforms:** nRF5340
+
+Enhanced ShockBurst (ESB)
+=========================
+
+The issues in this section are related to the :ref:`ug_esb` protocol.
 
 .. rst-class:: v2-3-0 v2-2-0
 
-CIA-857: LTE Link Controller spurious events
-  When using the :ref:`lte_lc_readme` library, a memory comparison is done between padded structs that may result in comparing bytes that have undefined initialization values.
-  This may cause spurious ``LTE_LC_EVT_CELL_UPDATE`` and ``LTE_LC_EVT_PSM_UPDATE`` events even though the information contained in the event has not changed since last update event.
+NCSDK-20092: ESB does not send packet longer than 63 bytes
+  ESB does not support sending packets longer than 63 bytes, but has no such hardware limitation.
 
-.. rst-class:: v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0
 
-NCSDK-15512: Modem traces retrieval incompatible with TF-M
-  Enabling modem traces with :kconfig:option:`CONFIG_UART NRF_MODEM_LIB_TRACE_BACKEND_UART` set to ``y`` will disable TF-M logging from secure processing environment (using :kconfig:option:`CONFIG_TFM_LOG_LEVEL_SILENCE` set to ``y``) including output from hardware fault handlers.
-  You can either use **UART1** for TF-M output or for modem traces, but not for both.
+Matter
+======
 
-.. rst-class:: v2-0-2 v2-0-1 v2-0-0
+The issues in this section are related to the :ref:`ug_matter` protocol.
 
-NCSDK-15471: Compilation with SUPL client library fails when TF-M is enabled
-  Building an application that uses the SUPL client library fails if TF-M is used.
+.. rst-class:: v2-3-0
 
-  **Workaround:** Use one of the following workarounds:
+KRKNWK-16728: Sleepy device may consume much power when commissioned to a commercial ecosystem
+  The controllers in the commercial ecosystem fabric establish a subscription to a Matter device's attributes.
+  The controller requests using some subscription intervals, and the Matter device may negotiate other values, but by default it just accepts the requested ones.
+  In some cases, the selected intervals can be small, and the Matter device will have to report status very often, which results in high power consumption.
 
-  * Use Secure Partition Manager instead of TF-M.
-  * Disable the FPU by setting :kconfig:option:`CONFIG_FPU` to ``n``.
+  **Workaround:** Implement ``OnSubscriptionRequested`` method in your application to set values of subscription report intervals that are appropriate for your use case.
+  This is an example of how your implementation could look:
 
-.. rst-class:: v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0
+  .. code-block::
 
-CIA-351: Connectivity issues with Azure IoT Hub
-  If a ``device-bound`` message is sent to the device while it is in the LTE Power Saving Mode (PSM), the TCP connection will most likely be terminated by the server.
-  Known symptoms of this are frequent reconnections to cloud, messages sent to Azure IoT Hub never arriving, and FOTA images being downloaded twice.
+     #include <app/ReadHandler.h>
 
-  **Workaround:** Avoid using LTE Power Saving Mode (PSM) and extended DRX intervals longer than approximately 30 seconds. This will reduce the risk of the issue occurring, at the cost of increased power consumption.
+     class SubscriptionApplicationCallback : public chip::app::ReadHandler::ApplicationCallback
+     {
+        CHIP_ERROR OnSubscriptionRequested(chip::app::ReadHandler & aReadHandler,
+                                           chip::Transport::SecureSession & aSecureSession) override;
+     };
 
-.. rst-class:: v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0
-
-NCSDK-10106: Elevated current consumption when using applications without :ref:`nrfxlib:nrf_modem` on nRF9160
-  When running applications that do not enable :ref:`nrfxlib:nrf_modem` on nRF9160 with build code B1A, current consumption will stay at 3 mA when in sleep.
-
-  **Workaround:** Enable :ref:`nrfxlib:nrf_modem`.
-
-.. rst-class:: v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0
-
-NCSDK-8075: Invalid initialization of ``mbedtls_entropy_context`` mutex type
-  The calls to :cpp:func:`mbedtls_entropy_init` do not zero-initialize the member variable ``mutex`` when ``nrf_cc3xx`` is enabled.
-
-  **Workaround:** Zero-initialize the structure type before using it or make it a static variable to ensure that it is zero-initialized.
-
-.. rst-class:: v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0
-
-Receive error with large packets
-  nRF91 fails to receive large packets (over 4000 bytes).
-
-.. rst-class:: v1-9-2 v1-9-1 v1-9-0
-
-The time returned by :ref:`lib_date_time` library becomes incorrect after one week of uptime
-  The time returned by :ref:`lib_date_time` library becomes incorrect after one week elapses.
-  This is due to an issue with clock_gettime() API.
-
-.. _tnsw_46156:
-
-.. rst-class:: v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0
-
-TNSW-46156: The LwM2M carrier library can in some cases trigger a modem bug related to PDN deactivation (AT+CGACT) in NB-IoT mode.
-  This causes excessive network signaling which can make interactions with the modem (AT commands or :ref:`nrfxlib:nrf_modem` functions) hang for several minutes.
-
-  **Workaround:** Add a small delay before PDN deactivation as shown in `Pull Request #10379 <https://github.com/nrfconnect/sdk-nrf/pull/10379>`_.
+     CHIP_ERROR SubscriptionApplicationCallback::OnSubscriptionRequested(chip::app::ReadHandler & aReadHandler,
+                                                          chip::Transport::SecureSession & aSecureSession)
+     {
+        /* Set the interval in seconds appropriate for your application use case, e.g. 60 seconds. */
+        uint32_t exampleMaxInterval = 60;
+        return aReadHandler.SetReportingIntervals(exampleMaxInterval);
+     }
 
 .. rst-class:: v2-3-0 v2-2-0
 
-NCSDK-18746: LwM2M carrier library fails to complete non-secure bootstrap when using a custom URI and the default security tag
-  If the LwM2M carrier library is operating in generic mode (not connecting to any of the predefined supported carriers), and the :kconfig:option:`CONFIG_LWM2M_CARRIER_CUSTOM_URI` is set to connect to a non-secure server, the library attempts to retrieve a PSK from :kconfig:option:`CONFIG_LWM2M_CARRIER_SERVER_SEC_TAG` even though a PSK is not needed for the non-secure bootstrap.
-  The PSK in this ``sec_tag`` is not used, but reading the ``sec_tag`` causes the bootstrap to fail if the :kconfig:option:`CONFIG_LWM2M_CARRIER_SERVER_SEC_TAG` is set to the default value (``0``).
+KRKNWK-16575: Applications with factory data support do not boot up properly on nRF5340
+  When the Matter sample is built for ``nrf5340dk_nrf5340_cpuapp`` build target with the :kconfig:option:`CONFIG_CHIP_FACTORY_DATA` Kconfig option set to ``y`` the application returns prematurely the error code 200016 because the factory data partition is not aligned with the :kconfig:option:`CONFIG_FPROTECT_BLOCK_SIZE` Kconfig option.
 
-  **Workaround:** Assign any non-zero value to :kconfig:option:`CONFIG_LWM2M_CARRIER_SERVER_SEC_TAG`.
+  **Affected platforms:** nRF5340
 
-.. rst-class:: v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-3-1 v1-2-1 v1-2-0
+  **Workaround:** Manually cherry-pick and apply commit from the main branch (commit hash: ``ec9ad82637b0383ebf91eb1155813450ad9fcffb``).
 
-NCSDK-12912: LwM2M carrier library does not recover if initial network connection fails
-  When the device is switched on, if :cpp:func:`lte_lc_connect()` returns an error at timeout, it will cause :cpp:func:`lwm2m_carrier_init()` to fail.
-  Thus, the device will fail to connect to carrier device management servers.
+.. rst-class:: v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1
 
-  **Workaround:** Increase :kconfig:option:`CONFIG_LTE_NETWORK_TIMEOUT` to allow :ref:`lte_lc_readme` more time to successfully connect.
+KRKNWK-16783: Accessory may become unresponsive after several hours
+  A Matter accessory may stop sending Report Data messages due to an internal bug in the Matter stack v1.0.0.0 and thus become unresponsive for Matter controllers.
 
-.. rst-class:: v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-1 v1-5-0 v1-4-2 v1-3-1 v1-2-1 v1-2-0
+  **Workaround:** Manually cherry-pick and apply commit from the `dedicated Matter fork`_ (commit hash: ``23f08242f92973a7a3308b4d62a82c59cf6cf6b3``).
 
-NCSDK-12913: LwM2M carrier library will fail to initialize if phone number is not present in SIM
-  The SIM phone number is needed during the :ref:`liblwm2m_carrier_readme` library start-up.
-  For new SIM cards, it might take some time before the phone number is received by the network.
-  The LwM2M carrier library does not wait for this to happen.
-  Thus, the device can fail to connect to the carrier's device management servers.
+.. rst-class:: v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1
 
-  **Workaround:** Use one of the following workarounds:
+KRKNWK-15846: Android CHIP Tool crashes when subscribing in the :guilabel:`LIGHT ON/OFF & LEVEL CLUSTER`
+  The Android CHIP Tool crashes when attempting to start the subscription after typing minimum and maximum subscription interval values.
+  Also, the Subscription window in the :guilabel:`LIGHT ON/OFF & LEVEL CLUSTER` contains faulty GUI layout (overlapping captions) used when passing minimum and maximum subscription interval values.
+  This affects the Android CHIP Tool revision used for the |NCS| v2.2.0, v2.1.1, and v2.1.2 releases.
 
-  * Reboot or power-cycle the device after the SIM has received a phone number from the network.
-  * Apply the following commits, depending on your |NCS| version:
+  .. note::
+      The support for the Android CHIP Tool is removed as of the |NCS| v2.3.0 for Matter in the |NCS|. Use CHIP Tool for Linux or macOS instead, as described in :ref:`ug_matter_gs_testing`.
 
-    * `v1.7-branch <https://github.com/nrfconnect/sdk-nrf/pull/6287>`_
-    * `v1.6-branch <https://github.com/nrfconnect/sdk-nrf/pull/6286>`_
-    * `v1.4-branch <https://github.com/nrfconnect/sdk-nrf/pull/6270>`_
+.. rst-class:: v2-2-0 v2-1-2 v2-1-1
 
-.. rst-class:: v1-8-0
+KRKNWK-15913: Factory data set parsing issues
+  The ``user`` field in the factory data set is not properly parsed. The field should be of the ``MAP`` type instead of the ``BSTR`` type.
 
-NCSDK-13106: When replacing a Verizon SIM card, the LwM2M carrier library does not reconnect to the device management servers
-  When a Verizon SIM card is replaced with a new Verizon SIM card, the library fails to fetch the correct PSK for the bootstrap server.
-  Thus, the device fails to connect to the carrier's device management servers.
+  **Workaround:** Manually cherry-pick and apply commit with fix to ``sdk-connectedhomeip`` (commit hash: ``3875c6f78c77212a3f62a5c825ff9b4e5054bbb4``).
 
-  **Workaround:** Use one of the following workarounds:
+.. rst-class:: v2-1-2 v2-1-1
 
-  * Use the :kconfig:option:`CONFIG_LWM2M_CARRIER_USE_CUSTOM_PSK` and :kconfig:option:`CONFIG_LWM2M_CARRIER_CUSTOM_PSK` configuration options to set the appropriate PSK needed for Verizon test or live servers.
-    This PSK can be obtain from the carrier.
-  * After inserting a new SIM card, reboot the device again.
+KRKNWK-15749: Invalid ZAP Tool revision used
+  The ZAP Tool revision used for the |NCS| v2.1.1 and v2.1.2 releases is not compatible with the :file:`zap` files that define the Data Model in |NCS| Matter samples.
+  This results in the ZAP Tool not being able to parse :file:`zap` files from Matter samples.
 
-.. rst-class:: v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0
+  **Workaround:** Check out the proper ZAP Tool revision with the following commands, where *<NCS_root_directory>* is the path to your |NCS| installation:
 
-NCSDK-11684: Failure loading KMU registers on nRF9160 devices
-  Certain builds will experience problems loading HUK to KMU due to a bug in nrf_cc3xx_platform library prior to version 0.9.12.
-  The problem arises in certain builds depending on alignment of code.
-  The reason for the issue is improper handling of PAN 7 on nRF9160 devices.
+    .. code-block::
 
-  **Workaround:** Update to nrf_cc3xx_platform/nrf_cc3xx_mbedcrypto v0.9.12 or newer versions if KMU is needed.
+       cd <NCS_root_directory>/modules/lib/matter/
+       git -C third_party/zap/repo/ checkout -f 2ae226
+       git add third_party/zap/repo/
 
-.. rst-class:: v1-7-1 v1-7-0
+.. rst-class:: v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0
 
-NCSDK-11033: Dial-up usage not working
-  Dial-up usage with MoSh PPP does not work and causes the nRF9160 DK to crash when it is connected to a PC.
+KRKNWK-14473: Unreliable communication with the window covering sample
+  The :ref:`window covering sample <matter_window_covering_sample>` might rarely become unresponsive for a couple of seconds after commissioning to the Matter network.
 
-  **Workaround:** Manually pick the fix available in Zephyr to the `Zephyr issue #38516`_.
-
-.. rst-class:: v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0
-
-NCSDK-7856: Faulty indirection on ``nrf_cc3xx`` memory slab when freeing the platform mutex
-  The :cpp:func:`mutex_free_platform` function has a bug where a call to :cpp:func:`k_mem_slab_free` provides wrong indirection on a parameter to free the platform mutex.
-
-  **Workaround:** Write the call to free the mutex in the following way: ``k_mem_slab_free(&mutex_slab, &mutex->mutex)``.
-  The change adds ``&`` before the parameter ``mutex->mutex``.
-
-.. rst-class:: v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0
-
-NCSDK-7914: The ``nrf_cc3xx`` RSA implementation does not deduce missing parameters
-  The calls to :cpp:func:`mbedtls_rsa_complete` will not deduce all types of missing RSA parameters when using ``nrf_cc3xx`` v0.9.6 or earlier.
-
-  **Workaround:** Calculate the missing parameters outside of this function or update to ``nrf_cc3xx`` v0.9.7 or later.
-
-.. rst-class:: v1-4-2 v1-4-1 v1-4-0
-
-NRF91-989: Unable to bootstrap after changing SIMs
-  In some cases, swapping the SIM card might trigger the bootstrap Pre-Shared Key to be deleted from the device. This can prevent future bootstraps from succeeding.
-
-.. rst-class:: v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0
-
-NCSDK-5666: LTE Sensor Gateway
-  The :ref:`lte_sensor_gateway` sample crashes when Thingy:52 is flipped.
-
-.. rst-class:: v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0
-
-NCSDK-6073: ``nrf_send`` is blocking
-  The :cpp:func:`nrf_send` function in the :ref:`nrfxlib:nrf_modem` might be blocking for several minutes, even if the socket is configured for non-blocking operation.
-  The behavior depends on the cellular network connection.
-
-  **Workaround:** For |NCS| v1.4.0, set the non-blocking mode for a partial workaround for non-blocking operation.
-
-.. rst-class:: v1-2-0
-
-GPS sockets and SUPL client library stops working
-  The `nRF9160: GPS with SUPL client library <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.2.0/nrf/samples/nrf9160/gps/README.html>`_ sample stops working if :ref:`supl_client` support is enabled, but the SUPL host name cannot be resolved.
-
-  **Workaround:** Insert a delay (``k_sleep()``) of a few seconds after the ``printf`` on line 294 in :file:`main.c`.
-
-.. rst-class:: v1-2-0 v1-1-0 v1-0-0
-
-Calling ``nrf_connect()`` immediately causes fail
-  ``nrf_connect()`` fails if called immediately after initialization of the device.
-  A delay of 1000 ms is required for this to work as intended.
-
-.. rst-class:: v1-2-0 v1-1-0 v1-0-0 v0-4-0 v0-3-0
-
-Problems with RTT Viewer/Logger
-  The SEGGER Control Block cannot be found by automatic search by the RTT Viewer/Logger.
-
-  **Workaround:** Set the RTT Control Block address to 0 and it will try to search from address 0 and upwards.
-  If this does not work, look in the :file:`builddir/zephyr/zephyr.map` file to find the address of the ``_SEGGER_RTT`` symbol in the map file and use that as input to the viewer/logger.
-
-.. rst-class:: v1-0-0 v0-4-0 v0-3-0
-
-Modem FW reset on debugger connection through SWD
-  If a debugger (for example, J-Link) is connected through SWD to the nRF9160, the modem firmware will reset.
-  Therefore, the LTE modem cannot be operational during debug sessions.
-
-.. rst-class:: v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0
-
-NCSDK-9441: Fmfu SMP server sample is unstable with the newest J-Link version
-  Full modem serial update does not work on development kit with debugger chip version delivered with J-Link software > 6.88a
-
-  **Workaround:** Downgrade the debugger chip to the firmware released with J-Link 6.88a or use another way of transferring serial data to the chip.
-
-.. rst-class:: v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0
-
-NCSDK-20026: LTE Sensor Gateway fails to run
-  The :ref:`lte_sensor_gateway` sample system faults when the board version is not included with the build target while building the sample.
-  This is due to an issue with the low-power UART and HCI drivers.
-
-  **Workaround:** Include the board version when building the :ref:`bluetooth-hci-lpuart-sample` sample and the :ref:`lte_sensor_gateway` sample.
-  For example, for board version 1.1.0, the samples must be built in the following way:
-
-  The :ref:`bluetooth-hci-lpuart-sample` sample:
-
-  .. parsed-literal::
-     :class: highlight
-
-     west build --board nrf9160dk_nrf52840@1.1.0
-
-  The :ref:`lte_sensor_gateway` sample:
-
-  .. parsed-literal::
-     :class: highlight
-
-     west build --board nrf9160dk_nrf9160_ns@1.1.0
+  **Workaround:** Switch from SSED to SED role.
 
 .. rst-class:: v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0
 
-CIA-738: FMFU does not use external flash partitions
-  Full modem FOTA support assumes full control of the external flash; it does not use an external flash partition.
-  It cannot be combined with other usages, such as storing settings or P-GPS data.
+KRKNWK-15088: Android CHIP Tool shuts down on changing the sensor type
+  When you change the current sensor type after activating the monitoring of another sensor type, the application shuts down.
 
-.. rst-class:: v2-2-0
+  **Workaround:** Restart the application and select the desired sensor type again.
 
-NCSDK-18376: P-GPS in external flash fails to inject first prediction during load sequence
-  When using external flash with P-GPS, stored predictions cannot be reliably read to satisfy the modem's need for ephemeris data when actively downloading and storing predictions to the same external flash.
-  Once the download is complete, the predictions can be reliably read.
+  .. note::
+      The support for the Android CHIP Tool is removed as of the |NCS| v2.3.0 for Matter in the |NCS|. Use CHIP Tool for Linux or macOS instead, as described in :ref:`ug_matter_gs_testing`.
 
-nRF7002
-*******
+.. rst-class:: v2-0-2
 
-.. rst-class:: v2-3-0
+KRKNWK-14748: Matter command times out when a Matter device becomes a Thread router
+  When a Full Thread Device becomes a router, it will ignore incoming packets for a short period of time, typically between 1-2 seconds.
+  This might disrupt the communication over Matter and lead to transaction timeouts.
 
-SHEL-1352: Incorrect base address used in the OTP TX trim coefficients
-  Incorrect base address used for TX trim coefficients in the One-Time Programmable (OTP) memory results in transmit power deviating by +/- 2 dB from the target value.
-
-nRF5
-****
-
-nRF5340
-=======
-
-.. rst-class:: v2-3-0
-
-NCSDK-20967: The :ref:`nrf_rpc_entropy_nrf53` sample does not work on the network core.
-  The network core will not work due a hard fault.
-
-.. rst-class:: v2-2-0
-
-NCSDK-20070: The :ref:`direct_test_mode` antenna switching does not work on the nRF5340 DK with the nRF21540 EK shield.
-  The antenna select DTM command does not have any effect because the GPIO pin which controls antenna is not forwarded to nRF5340DK network core.
-
-  **Workaround** Add a ``<&gpio1 6 0>`` entry in :file:`samples/bluetooth/direct_test_mode/conf/remote_shell/pin_fwd.dts`.
-
-.. rst-class:: v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0
-
-NCSDK-16856: Increased power consumption observed for the Low Power UART sample on nRF5340 DK
-  The power consumption of the :ref:`lpuart_sample` sample measured using the nRF5340 DK v2.0.0 is about 200 uA higher than expected.
-
-  **Workaround:** Disconnect flow control lines for VCOM2 with the SW7 DIP switch on the board.
+  In more recent versions of Matter, this problem has been eliminated by enhancing Matter's Message Reliability Protocol.
+  This fix will be included in the future versions of the |NCS|.
 
 .. rst-class:: v2-0-2 v2-0-1 v2-0-0
 
-NCSDK-16338: Setting gain for nRF21540 Front-end module does not work in the :ref:`radio_test` sample
-  Setting FEM gain for nRF21540 Front-end module does not work in the :ref:`radio_test` sample with the nRF5340 SoC.
+KRKNWK-14206: CHIP Tool for Android might crash when using Cluster Interactive Tool screen
+  Cluster Interaction Tool screen crashes when trying to send a command that takes an optional argument.
 
-  **Workaround:** Enable the SPI 0 instance in the nRF5340 network core DTS overlay file.
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0
 
-.. rst-class:: v1-9-0
+KRKNWK-14180: The QSPI sleep mode is not handled efficiently in Matter samples on the nRF53 SoC
+  QSPI is active during every Bluetooth LE connection in the Matter samples that are programmed on the nRF53 SoC.
+  This results in higher power consumption, for example during commissioning into the Matter network.
 
-NCSDK-13925: Build warning in the RF test samples when the nRF21540 EK support is enabled
-  :ref:`radio_test` and :ref:`direct_test_mode` build with warnings for nRF5340 with the :ref:`ug_radio_fem_nrf21540_ek` support.
+  **Affected platforms:** nRF5340
 
-  **Workaround:** Change the parameter type in the :c:func:`nrf21540_tx_gain_set()` function in :file:`ncs/nrf/samples/bluetooth/direct_test_mode/src/fem/nrf21540.c` from :c:type:`uint8_t` to :c:type:`uint32_t`.
+.. rst-class:: v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0
 
-.. rst-class:: v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0
+KRKNWK-11225: CHIP Tool for Android cannot communicate with a Matter device after the device reboots
+  CHIP Tool for Android does not implement any mechanism to recover a secure session to a Matter device after the device has rebooted and lost the session.
+  As a result, the device can no longer decrypt and process messages sent by CHIP Tool for Android as the controller keeps using stale cryptographic keys.
 
-NCSDK-11432: DFU: Erasing secondary slot returns error response
-  Trying to erase secondary slot results in an error response.
-  Slot is still erased.
-  This issue is only occurring when the application is compiled for multi-image.
+  **Workaround:** Do not reboot the device after commissioning it with CHIP Tool for Android.
 
-.. rst-class:: v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0
+  .. note::
+      The support for the Android CHIP Tool is removed as of the |NCS| v2.3.0 for Matter in the |NCS|. Use CHIP Tool for Linux or macOS instead, as described in :ref:`ug_matter_gs_testing`.
 
-NCSDK-9786: Wrong FLASH_PAGE_ERASE_MAX_TIME_US for the nRF53 network core
-  ``FLASH_PAGE_ERASE_MAX_TIME_US`` defines the execution window duration when doing the flash operation synchronously along the radio operations (:kconfig:option:`CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE` not enabled).
+.. rst-class:: v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0
 
-  The ``FLASH_PAGE_ERASE_MAX_TIME_US`` value of the nRF53 network core is lower than required.
-  For this reason, if :kconfig:option:`CONFIG_SOC_FLASH_NRF_RADIO_SYNC_MPSL` is set to ``y`` and :kconfig:option:`CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE` is set to ``n``, a flash erase operation on the nRF5340 network core will result in an MPSL timeslot OVERSTAYED assert.
+KRKNWK-10589: CHIP Tool for Android crashes when commissioning a Matter device
+  In random circumstances, CHIP Tool for Android crashes when trying to connect to a Matter device over Bluetooth® LE.
 
-  **Workaround:** Increase ``FLASH_PAGE_ERASE_MAX_TIME_US`` (defined in :file:`ncs/zephyr/soc/arm/nordic_nrf/nrf53/soc.h`) from 44850UL to 89700UL (the same value as for the application core).
+  **Workaround:** Restart the application and try to commission the Matter device again.
+  If the problem persists, clear the application data and try again.
 
-.. rst-class:: v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0
+.. rst-class:: v1-9-2 v1-9-1 v1-9-0
 
-NCSDK-7234: UART output is not received from the network core
-  The UART output is not received from the network core if the application core is programmed and running with a non-secure image (using the ``nrf5340dk_nrf5340_cpuapp_ns`` build target).
+KRKNWK-12950: CHIP Tool for Android opens the commissioning window using an incorrect PIN code
+  CHIP Tool for Android uses a random code instead of a user-provided PIN code to open the commissioning window on a Matter device.
 
-.. rst-class:: v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0
+.. rst-class:: v1-6-1 v1-6-0
 
-KRKNWK-6756: 802.15.4 Service Layer (SL) library support for the nRF53
-  The binary variant of the 802.15.4 Service Layer (SL) library for the nRF53 does not support such features as synchronization of **TIMER** with **RTC** or timestamping of received frames.
-  For this reason, 802.15.4 features like delayed transmission or delayed reception are not available for the nRF53.
+KRKNWK-10387: Matter service is needlessly advertised over Bluetooth® LE during DFU
+  The Matter samples can be configured to include the support for Device Firmware Upgrade (DFU) over Bluetooth LE.
+  When the DFU procedure is started, the Matter Bluetooth LE service is needlessly advertised, revealing the device identifiers such as Vendor and Product IDs.
+  The service is meant to be advertised only during the device commissioning.
 
-.. rst-class:: v1-3-2 v1-3-1 v1-3-0
+.. rst-class:: v1-5-2 v1-5-1 v1-5-0
 
-FOTA does not work
-  FOTA with the :ref:`zephyr:smp_svr_sample` does not work.
+KRKNWK-9214: Pigweed submodule might not be accessible from some regions
+  The ``west update`` command might generate log notifications about the failure to access the pigweed submodule.
+  As a result, the Matter samples will not build.
 
-Nordic Thingy:53
-================
+  **Workaround:** Execute the following commands in the root folder:
 
-.. rst-class:: v2-2-0
+    .. code-block::
 
-NCSDK-18263: |NCS| samples may fail to boot on Thingy:53
-  |NCS| samples and applications that are not listed under :ref:`thingy53_compatible_applications` fail to boot on Nordic Thingy:53.
-  The MCUboot bootloader is not built together with these samples, but the Thingy:53's :ref:`static Partition Manager memory map <ug_pm_static>` requires it (the application image does not start at the beginning of the internal ``FLASH``.)
-
-  **Workaround:** Revert the ``9a8680372fdb6e09f3d6537c8c6751dd5c50bf86`` commit in the sdk-zephyr repository and revert the ``1f9765df5acbb36afff0ce40c94ba65d44d19d70`` commit in sdk-nrf.
-  During conflict resolution, make sure to update the :file:`west.yml` file in the sdk-nrf to point to the reverting commit in sdk-zephyr.
-
-nRF52820
-========
-
-.. rst-class:: v1-3-2 v1-3-1 v1-3-0
-
-Missing :file:`CMakeLists.txt`
-  The :file:`CMakeLists.txt` file for developing applications that emulate nRF52820 on the nRF52833 DK is missing.
-
-  **Workaround:** Create a :file:`CMakeLists.txt` file in the :file:`ncs/zephyr/boards/arm/nrf52833dk_nrf52820` folder with the following content:
-
-  .. parsed-literal::
-    :class: highlight
-
-    zephyr_compile_definitions(DEVELOP_IN_NRF52833)
-    zephyr_compile_definitions(NRFX_COREDEP_DELAY_US_LOOP_CYCLES=3)
-
-  You can `download this file <nRF52820 CMakeLists.txt_>`_ from the upstream Zephyr repository.
-  After you add it, the file is automatically included by the build system.
+       git -C modules/lib/matter submodule set-url third_party/pigweed/repo https://github.com/google/pigweed.git
+       git -C modules/lib/matter submodule sync third_party/pigweed/repo
+       west update
 
 Thread
 ======
+
+The issues in this section are related to the :ref:`ug_thread` protocol.
 
 .. rst-class:: v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1
 
 KRKNWK-14756: Increased average latency during communication with nRF5340-based SED
   The measured average latency (RTT) of the Echo Request/Response transaction sometimes shows a slight increase over the baseline when the receiver is a Sleepy End Device based on the nRF5340 SoC platform.
+
+  **Affected platforms:** nRF5340
 
 .. rst-class:: v2-0-0
 
@@ -631,12 +512,16 @@ KRKNWK-11037:  ``Udp::GetEphemeralPort`` can cause infinite loop
 KRKNWK-9461 / KRKNWK-9596 : Multiprotocol sample crashes with some smartphones
   With some smartphones, the multiprotocol sample crashes on the nRF5340 due to timer timeout inside the 802.15.4 radio driver logic.
 
+  **Affected platforms:** nRF5340
+
 .. rst-class:: v1-4-2 v1-4-1 v1-4-0
 
 KRKNWK-7885: Throughput is lower when using CC310 nrf_security backend
   A decrease of throughput of around 5-10% has been observed for the :ref:`CC310 nrf_security backend <nrfxlib:nrf_security_backends_cc3xx>` when compared with :ref:`nrf_oberon <nrf_security_backends_oberon>` or :ref:`the standard mbedtls backend <nrf_security_backends_orig_mbedtls>`.
   CC310 nrf_security backend is used by default for nRF52840 boards.
   The source of throughput decrease is coupled to the cost of RTOS mutex locking when using the :ref:`CC310 nrf_security backend <nrfxlib:nrf_security_backends_cc3xx>` when the APIs are called with shorter inputs.
+
+  **Affected platforms:** nRF52840
 
   **Workaround:** Use AES-CCM ciphers from the nrf_oberon backend by setting the following options:
 
@@ -686,8 +571,11 @@ KRKNWK-6358: CoAP client sample provisioning issues
 KRKNWK-6408: ``diag`` command not supported
   The ``diag`` command is not yet supported by Thread in the |NCS|.
 
+
 Zigbee
 ======
+
+The issues in this section are related to the :ref:`ug_zigbee` protocol.
 
 .. rst-class:: v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0
 
@@ -947,6 +835,8 @@ KRKNWK-8200: Successful signal on commissioning fail
 KRKNWK-9461 / KRKNWK-9596: Multiprotocol sample crashes with some smartphones
   With some smartphones, the multiprotocol sample crashes on the nRF5340 due to timer timeout inside the 802.15.4 radio driver logic.
 
+  **Affected platforms:** nRF5340
+
 .. rst-class:: v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1
 
 KRKNWK-6348: ZCL Occupancy Sensing cluster is not complete
@@ -1010,172 +900,18 @@ KRKNWK-7836: Coordinator asserting when flooded with ZDO commands
 KRKNWK-6073: Potential delay during FOTA
   There might be a noticeable delay (~220 ms) between calling the ZBOSS API and on-the-air activity.
 
-Matter
-======
-
-.. rst-class:: v2-3-0
-
-KRKNWK-16728: Sleepy device may consume much power when commissioned to a commercial ecosystem
-  The controllers in the commercial ecosystem fabric establish a subscription to a Matter device's attributes.
-  The controller requests using some subscription intervals, and the Matter device may negotiate other values, but by default it just accepts the requested ones.
-  In some cases, the selected intervals can be small, and the Matter device will have to report status very often, which results in high power consumption.
-
-  **Workaround:** Implement ``OnSubscriptionRequested`` method in your application to set values of subscription report intervals that are appropriate for your use case.
-  This is an example of how your implementation could look:
-
-  .. code-block::
-
-     #include <app/ReadHandler.h>
-
-     class SubscriptionApplicationCallback : public chip::app::ReadHandler::ApplicationCallback
-     {
-        CHIP_ERROR OnSubscriptionRequested(chip::app::ReadHandler & aReadHandler,
-                                           chip::Transport::SecureSession & aSecureSession) override;
-     };
-
-     CHIP_ERROR SubscriptionApplicationCallback::OnSubscriptionRequested(chip::app::ReadHandler & aReadHandler,
-                                                          chip::Transport::SecureSession & aSecureSession)
-     {
-        /* Set the interval in seconds appropriate for your application use case, e.g. 60 seconds. */
-        uint32_t exampleMaxInterval = 60;
-        return aReadHandler.SetReportingIntervals(exampleMaxInterval);
-     }
-
-.. rst-class:: v2-3-0 v2-2-0
-
-KRKNWK-16575: Applications with factory data support do not boot up properly on nRF5340
-  When the Matter sample is built for ``nrf5340dk_nrf5340_cpuapp`` build target with the :kconfig:option:`CONFIG_CHIP_FACTORY_DATA` Kconfig option set to ``y`` the application returns prematurely the error code 200016 because the factory data partition is not aligned with the :kconfig:option:`CONFIG_FPROTECT_BLOCK_SIZE` Kconfig option.
-
-  **Workaround:** Manually cherry-pick and apply commit from the main branch (commit hash: ``ec9ad82637b0383ebf91eb1155813450ad9fcffb``).
-
-.. rst-class:: v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1
-
-KRKNWK-16783: Accessory may become unresponsive after several hours
-  A Matter accessory may stop sending Report Data messages due to an internal bug in the Matter stack v1.0.0.0 and thus become unresponsive for Matter controllers.
-
-  **Workaround:** Manually cherry-pick and apply commit from the `dedicated Matter fork`_ (commit hash: ``23f08242f92973a7a3308b4d62a82c59cf6cf6b3``).
-
-.. rst-class:: v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1
-
-KRKNWK-15846: Android CHIP Tool crashes when subscribing in the :guilabel:`LIGHT ON/OFF & LEVEL CLUSTER`
-  The Android CHIP Tool crashes when attempting to start the subscription after typing minimum and maximum subscription interval values.
-  Also, the Subscription window in the :guilabel:`LIGHT ON/OFF & LEVEL CLUSTER` contains faulty GUI layout (overlapping captions) used when passing minimum and maximum subscription interval values.
-  This affects the Android CHIP Tool revision used for the |NCS| v2.2.0, v2.1.1, and v2.1.2 releases.
-
-  .. note::
-      The support for the Android CHIP Tool is removed as of the |NCS| v2.3.0 for Matter in the |NCS|. Use CHIP Tool for Linux or macOS instead, as described in :ref:`ug_matter_gs_testing`.
-
-.. rst-class:: v2-2-0 v2-1-2 v2-1-1
-
-KRKNWK-15913: Factory data set parsing issues
-  The ``user`` field in the factory data set is not properly parsed. The field should be of the ``MAP`` type instead of the ``BSTR`` type.
-
-  **Workaround:** Manually cherry-pick and apply commit with fix to ``sdk-connectedhomeip`` (commit hash: ``3875c6f78c77212a3f62a5c825ff9b4e5054bbb4``).
-
-.. rst-class:: v2-1-2 v2-1-1
-
-KRKNWK-15749: Invalid ZAP Tool revision used
-  The ZAP Tool revision used for the |NCS| v2.1.1 and v2.1.2 releases is not compatible with the :file:`zap` files that define the Data Model in |NCS| Matter samples.
-  This results in the ZAP Tool not being able to parse :file:`zap` files from Matter samples.
-
-  **Workaround:** Check out the proper ZAP Tool revision with the following commands, where *<NCS_root_directory>* is the path to your |NCS| installation:
-
-    .. code-block::
-
-       cd <NCS_root_directory>/modules/lib/matter/
-       git -C third_party/zap/repo/ checkout -f 2ae226
-       git add third_party/zap/repo/
-
-.. rst-class:: v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0
-
-KRKNWK-14473: Unreliable communication with the window covering sample
-  The :ref:`window covering sample <matter_window_covering_sample>` might rarely become unresponsive for a couple of seconds after commissioning to the Matter network.
-
-  **Workaround:** Switch from SSED to SED role.
-
-.. rst-class:: v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0
-
-KRKNWK-15088: Android CHIP Tool shuts down on changing the sensor type
-  When you change the current sensor type after activating the monitoring of another sensor type, the application shuts down.
-
-  **Workaround:** Restart the application and select the desired sensor type again.
-
-  .. note::
-      The support for the Android CHIP Tool is removed as of the |NCS| v2.3.0 for Matter in the |NCS|. Use CHIP Tool for Linux or macOS instead, as described in :ref:`ug_matter_gs_testing`.
-
-.. rst-class:: v2-0-2
-
-KRKNWK-14748: Matter command times out when a Matter device becomes a Thread router
-  When a Full Thread Device becomes a router, it will ignore incoming packets for a short period of time, typically between 1-2 seconds.
-  This might disrupt the communication over Matter and lead to transaction timeouts.
-
-  In more recent versions of Matter, this problem has been eliminated by enhancing Matter's Message Reliability Protocol.
-  This fix will be included in the future versions of the |NCS|.
-
-.. rst-class:: v2-0-2 v2-0-1 v2-0-0
-
-KRKNWK-14206: CHIP Tool for Android might crash when using Cluster Interactive Tool screen
-  Cluster Interaction Tool screen crashes when trying to send a command that takes an optional argument.
-
-.. rst-class:: v2-0-2 v2-0-1 v2-0-0
-
-KRKNWK-14180: The QSPI sleep mode is not handled efficiently in Matter samples on the nRF53 SoC
-  QSPI is active during every Bluetooth LE connection in the Matter samples that are programmed on the nRF53 SoC.
-  This results in higher power consumption, for example during commissioning into the Matter network.
-
-.. rst-class:: v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0
-
-KRKNWK-11225: CHIP Tool for Android cannot communicate with a Matter device after the device reboots
-  CHIP Tool for Android does not implement any mechanism to recover a secure session to a Matter device after the device has rebooted and lost the session.
-  As a result, the device can no longer decrypt and process messages sent by CHIP Tool for Android as the controller keeps using stale cryptographic keys.
-
-  **Workaround:** Do not reboot the device after commissioning it with CHIP Tool for Android.
-
-  .. note::
-      The support for the Android CHIP Tool is removed as of the |NCS| v2.3.0 for Matter in the |NCS|. Use CHIP Tool for Linux or macOS instead, as described in :ref:`ug_matter_gs_testing`.
-
-.. rst-class:: v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0
-
-KRKNWK-10589: CHIP Tool for Android crashes when commissioning a Matter device
-  In random circumstances, CHIP Tool for Android crashes when trying to connect to a Matter device over Bluetooth® LE.
-
-  **Workaround:** Restart the application and try to commission the Matter device again.
-  If the problem persists, clear the application data and try again.
-
-.. rst-class:: v1-9-2 v1-9-1 v1-9-0
-
-KRKNWK-12950: CHIP Tool for Android opens the commissioning window using an incorrect PIN code
-  CHIP Tool for Android uses a random code instead of a user-provided PIN code to open the commissioning window on a Matter device.
-
-.. rst-class:: v1-6-1 v1-6-0
-
-KRKNWK-10387: Matter service is needlessly advertised over Bluetooth® LE during DFU
-  The Matter samples can be configured to include the support for Device Firmware Upgrade (DFU) over Bluetooth LE.
-  When the DFU procedure is started, the Matter Bluetooth LE service is needlessly advertised, revealing the device identifiers such as Vendor and Product IDs.
-  The service is meant to be advertised only during the device commissioning.
-
-.. rst-class:: v1-5-2 v1-5-1 v1-5-0
-
-KRKNWK-9214: Pigweed submodule might not be accessible from some regions
-  The ``west update`` command might generate log notifications about the failure to access the pigweed submodule.
-  As a result, the Matter samples will not build.
-
-  **Workaround:** Execute the following commands in the root folder:
-
-    .. code-block::
-
-       git -C modules/lib/matter submodule set-url third_party/pigweed/repo https://github.com/google/pigweed.git
-       git -C modules/lib/matter submodule sync third_party/pigweed/repo
-       west update
-
 HomeKit
 =======
+
+The issues in this section are related to the HomeKit protocol.
 
 .. rst-class:: v2-3-0 v2-2-0
 
 KRKNWK-16503: OTA DFU using the iOS Home app (over UARP) does not work on the nRF5340 SoC
   Application core cannot be upgraded due to a problem with uploading images for two cores.
   Uploading the network core image overrides an already uploaded application core image.
+
+  **Affected platforms:** nRF5340
 
   **Workaround:** Manually cherry-pick and apply commit from the main branch (commit hash: ``09874a36edf21ced7d3c9356de07df6f0ff3d457``).
 
@@ -1207,6 +943,8 @@ KRKNWK-14081: HomeKit SDK light bulb example does not work with MTD
 NCSDK-13947: Net core downgrade prevention does not work on nRF5340
   HAP certification requirements are not met because of this issue.
 
+  **Affected platforms:** nRF5340
+
 .. rst-class:: v2-0-2 v2-0-1 v2-0-0
 
 KRKNWK-13607: Stateless switch application crashes upon factory reset
@@ -1233,6 +971,8 @@ KRKNWK-11729: Stateless switch event characteristic value not handled according 
 KRKNWK-13063: RTT logs do not work with the Light Bulb multiprotocol sample with DFU on nRF52840
   The Light Bulb multiprotocol sample with Nordic DFU activated in debug version for nRF52840 platform does not display RTT logs properly.
 
+  **Affected platforms:** nRF52840
+
   **Workaround:** Disable RTT logs for the bootloader.
 
 .. rst-class:: v1-9-2 v1-9-1 v1-9-0
@@ -1247,6 +987,8 @@ KRKNWK-13064: Nordic DFU is not compliant with HAP certification requirements
 KRKNWK-12474: Multiprotocol samples on nRF52840 might not switch to Thread
   Samples might not switch to Thread mode as expected and remain in Bluetooth mode instead.
   The issue is related to older iOS versions.
+
+  **Affected platforms:** nRF52840
 
   **Workaround:** Update your iPhone to iOS 15.4.
 
@@ -1301,8 +1043,176 @@ KRKNWK-11666: CLI command ``hap services`` returns incorrect results
 KRKNWK-11365: HAP tool's ``provision`` command freezes
   This issue happens on macOS when an EUI argument is not passed in attempt to read EUI from a connected board.
 
+Applications
+************
+
+The issues in this section are related to :ref:`applications`.
+
+nRF9160: Asset Tracker v2
+=========================
+
+The issues in this section are related to the :ref:`asset_tracker_v2` application.
+
+.. rst-class:: v2-2-0
+
+CIA-845: The application cannot be built with :file:`overlay-carrier.conf` (carrier library) enabled for Nordic Thingy:91
+  Building with :ref:`liblwm2m_carrier_readme` library enabled for Nordic Thingy:91 will result in a ``FLASH`` overflow and a build error.
+
+  **Affected platforms:** nRF9160
+
+.. rst-class:: v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0
+
+CIA-463: Wrong network mode parameter reported to cloud
+  The network mode string present in ``deviceInfo`` (nRF Cloud) and ``dev`` (Azure IoT Hub and AWS IoT) JSON objects that is reported to cloud might contain wrong network modes.
+  The network mode string contains the network modes that the modem is configured to use, not what the modem actually connects to the LTE network with.
+
+  **Affected platforms:** nRF9160
+
+.. rst-class:: v1-9-2 v1-9-1 v1-9-0
+
+NCSDK-14235: Timestamps that are sent in cloud messages drift over time
+  Due to a bug in the :ref:`lib_date_time` library, timestamps that are sent to cloud drift because they are calculated incorrectly.
+
+  **Affected platforms:** nRF9160
+
+.. rst-class:: v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-0
+
+CIA-604: ATv2 cannot be built for the ``thingy91_nrf9160_ns`` build target with ``SECURE_BOOT`` enabled
+  Due to the use of static partitions with the Thingy:91, there is insufficient room in the flash memory to enable both the primary and secondary bootloaders.
+
+  **Affected platforms:** nRF9160
+
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0
+
+CIA-661: Asset Tracker v2 application configured for LwM2M cannot be built for the ``nrf9160dk_nrf9160_ns`` build target with modem traces or Memfault enabled
+  The :ref:`asset_tracker_v2` application configured for LwM2M cannot be built for the ``nrf9160dk_nrf9160_ns`` build target with :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE` for modem traces or :file:`overlay-memfault.conf` for Memfault due to memory constraints.
+
+  **Affected platforms:** nRF9160
+
+  **Workaround:** Use one of the following workarounds for modem traces:
+
+  * Use Secure Partition Manager instead of TF-M by setting ``CONFIG_SPM`` to ``y`` and :kconfig:option:`CONFIG_BUILD_WITH_TFM` to ``n``.
+  * Reduce the value of :kconfig:option:`CONFIG_NRF_MODEM_LIB_SHMEM_TRACE_SIZE` to 8 Kb, however, this might lead to loss of modem traces.
+
+  For Memfault, use Secure Partition Manager instead of TF-M by setting ``CONFIG_SPM`` to ``y`` and :kconfig:option:`CONFIG_BUILD_WITH_TFM` to ``n``.
+
+.. rst-class:: v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0
+
+CIA-890: The application cannot be built with :file:`overlay-debug.conf` and :kconfig:option:`CONFIG_DEBUG_OPTIMIZATIONS` set to ``y``
+  Due to insufficient flash space for the application when it is not optimized, the :ref:`asset_tracker_v2` application cannot be built with :file:`overlay-debug.conf` and :kconfig:option:`CONFIG_DEBUG_OPTIMIZATIONS` set to ``y``.
+
+  **Affected platforms:** nRF9160
+
+  **Workaround:** To free up flash space when debugging locally, comment out the following Kconfig options in the :file:`prj.conf` file:
+
+  * :kconfig:option:`CONFIG_BOOTLOADER_MCUBOOT`
+  * :kconfig:option:`CONFIG_IMG_MANAGER`
+  * :kconfig:option:`CONFIG_MCUBOOT_IMG_MANAGER`
+  * :kconfig:option:`CONFIG_IMG_ERASE_PROGRESSIVELY`
+  * :kconfig:option:`CONFIG_BUILD_S1_VARIANT`
+
+  This removes the partitions for the MCUboot bootloader, the secondary bootloader, and the secondary application image slot.
+  Any functionality depending on those will not work with this configuration.
+
+  Alternatively, disable logging for non-relevant modules or libraries in the :file:`overlay-debug.conf` file until the image fits in flash.
+
+nRF9160: Asset tracker
+======================
+
+The issues in this section are related to the nRF9160: Asset tracker application.
+This application was removed in :ref:`nRF Connect SDK v1.9.0 <ncs_release_notes_190>` and replaced by :ref:`asset_tracker_v2`.
+
+.. rst-class:: v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0
+
+NCSDK-6898: Setting :kconfig:option:`CONFIG_SECURE_BOOT` does not work
+  The immutable bootloader is not able to find the required metadata in the MCUboot image.
+  See the related NCSDK-6898 known issue in `Build system`_ for more details.
+
+  **Affected platforms:** nRF9160
+
+  **Workaround:** Set :kconfig:option:`CONFIG_FW_INFO` in MCUboot.
+
+.. rst-class:: v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0
+
+External antenna performance setting
+  The preprogrammed Asset Tracker does not come with the best external antenna performance.
+
+  **Affected platforms:** nRF9160
+
+  **Workaround:** If you are using nRF9160 DK v0.15.0 or higher and Thingy:91 v1.4.0 or higher, set :kconfig:option:`CONFIG_NRF9160_GPS_ANTENNA_EXTERNAL` to ``y``.
+  Alternatively, for nRF9160 DK v0.15.0, you can set the :kconfig:option:`CONFIG_NRF9160_GPS_COEX0_STRING` option to ``AT%XCOEX0`` when building the preprogrammed Asset Tracker to achieve the best external antenna performance.
+
+.. rst-class:: v1-3-2 v1-3-1 v1-3-0
+
+NCSDK-5574: Warnings during FOTA
+  The nRF9160: Asset Tracker application prints warnings and error messages during successful FOTA.
+
+  **Affected platforms:** nRF9160
+
+.. rst-class:: v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0 v0-4-0 v0-3-0
+
+NCSDK-6689: High current consumption in Asset Tracker
+  The nRF9160: Asset Tracker might show up to 2.5 mA current consumption in idle mode with :kconfig:option:`CONFIG_POWER_OPTIMIZATION_ENABLE` set to ``y``.
+
+  **Affected platforms:** nRF9160
+
+.. rst-class:: v1-0-0 v0-4-0 v0-3-0
+
+Sending data before connecting to nRF Cloud
+  The nRF9160: Asset Tracker application does not wait for connection to nRF Cloud before trying to send data.
+  This causes the application to crash if the user toggles one of the switches before the kit is connected to the cloud.
+
+  **Affected platforms:** nRF9160
+
+.. rst-class:: v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0 v0-4-0 v0-3-0
+
+IRIS-2676: Missing support for FOTA on nRF Cloud
+  The nRF9160: Asset Tracker application does not support the nRF Cloud FOTA_v2 protocol.
+
+  **Affected platforms:** nRF9160
+
+  **Workaround:** The implementation for supporting the nRF Cloud FOTA_v2 can be found in the following commits:
+
+					* cef289b559b92186cc54f0257b8c9adc0997f334
+					* 156d4cf3a568869adca445d43a786d819ae10250
+					* f520159f0415f011ae66efb816384a8f7bade83d
+
+nRF9160: Serial LTE Modem
+=========================
+
+The issues in this section are related to the :ref:`serial_lte_modem` application.
+
+.. rst-class:: v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0
+
+NCSDK-13895: Build failure for target Thingy:91 with secure_bootloader overlay
+  Building the application for Thingy:91 fails if secure_bootloader overlay is included.
+
+  **Affected platforms:** Thingy:91
+
+.. rst-class:: v2-3-0
+
+NCSDK-20047: SLM logging over RTT is not available
+  There is a conflict with MCUboot RTT logging.
+  In order to save power, SLM configures MCUboot to use RTT instead of UART for logging.
+  SLM itself uses RTT for logging as well.
+  With a recent change, MCUboot exclusively takes control of the RTT logging, which causes the conflict.
+
+  **Affected platforms:** nRF9160
+
+  **Workaround:** Remove ``CONFIG_USE_SEGGER_RTT=y`` and ``CONFIG_RTT_CONSOLE=y`` from :file:`child_image\mcuboot.conf`.
+
+.. rst-class:: v1-0-0 v0-4-0 v0-3-0
+
+Modem FW reset on debugger connection through SWD
+  If a debugger (for example, J-Link) is connected through SWD to the nRF9160, the modem firmware will reset.
+  Therefore, the LTE modem cannot be operational during debug sessions.
+
+  **Affected platforms:** nRF9160
+
 nRF Desktop
 ===========
+
+The issues in this section are related to the :ref:`nrf_desktop` application.
 
 .. note::
     nRF Desktop is also affected by the Bluetooth LE issue :ref:`NCSDK-19865 <ncsdk_19865>`.
@@ -1328,6 +1238,8 @@ NCSDK-20366: Possible bus fault in :ref:`nrf_desktop_selector` while toggling a 
 NCSDK-19970: MCUboot bootloader fails to swap images on nRF52840 DK that uses external flash
    The MCUboot bootloader cannot access external flash because the chosen ``nordic,pm-ext-flash`` is not defined in the MCUboot child image's devicetree.
    As a result ``nrf52840dk_nrf52840`` using ``prj_mcuboot_qspi.conf`` configuration fails to swap images after a complete image transfer.
+
+   **Affected platforms:** nRF52840
 
    **Workaround**: Manually cherry-pick and apply the commit with the fix from the ``main`` branch (commit hash: ``7cea1b7e681a39ce2e2143b6b03132d95b7606ab``).
    Make sure to also cherry-pick and apply the commit that fixes a build system issue (commit `ec23df1fa305e99194ceac87a028f6da206a3ff1` from ``main`` branch).
@@ -1418,12 +1330,21 @@ NCSDK-14117: Build fails for nRF52840DK in the ``prj_b0_wwcb`` configuration
   The build failure is caused by outdated Kconfig options in the nRF52840 DK's ``prj_b0_wwcb`` configuration.
   The nRF52840 DK's ``prj_b0_wwcb`` configuration does not explicitly define static partition map either.
 
+  **Affected platforms:** nRF52840
+
   **Workaround:** Manually cherry-pick and apply commit with fix from ``main`` (commit hash: ``cf4c465aceeb00d83a4f50edf67ce8c26427ac52``).
+
+.. rst-class:: v1-2-1 v1-2-0 v1-1-0 v1-0-0
+
+Reconnection issues on some operating systems
+  On some operating systems, the :ref:`nrf_desktop` application is unable to reconnect to a Bluetooth host.
 
 .. _known_issues_nrf5340audio:
 
 nRF5340 Audio
 =============
+
+The issues in this section are related to the :ref:`nrf53_audio_app` application.
 
 .. rst-class:: v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0
 
@@ -1431,6 +1352,8 @@ OCT-2501: Charging over seven hours results in error
   Since the nRF5340 Audio DK uses a large battery, the nPM1100 can go into error when charging time surpasses 7 hours.
   This is because of a protection timeout on the PMIC.
   The charging is stopped when this error occurs.
+
+  **Affected platforms:** nRF5340 Audio DK
 
   **Workaround:** To start the charging again, turn the nRF5340 Audio DK off and then on again.
 
@@ -1440,15 +1363,21 @@ OCT-2472: Headset fault upon gateway reset in the bidirectional stream mode
   The headset may react with a usage fault when the :kconfig:option:`CONFIG_STREAM_BIDIRECTIONAL` application Kconfig option is set to ``y`` and the gateway is reset during a stream.
   This issue is under investigation.
 
+  **Affected platforms:** nRF5340 Audio DK
+
 .. rst-class:: v2-3-0
 
 OCT-2470: Discovery of Media Control Service fails
   When restarting or resetting the gateway, one or more headsets may run into a condition where the discovery of the Media Control Service fails.
 
+  **Affected platforms:** nRF5340 Audio DK
+
 .. rst-class:: v2-3-0 v2-2-0
 
 OCT-2070: Detection issues with USB-C to USB-C connection
   Using USB-C to USB-C when connecting an nRF5340 Audio DK to PC is not correctly detected on some Windows systems.
+
+  **Affected platforms:** nRF5340 Audio DK
 
 .. rst-class:: v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0
 
@@ -1456,10 +1385,14 @@ OCT-2154: USB audio interface does not work correctly on macOS
   The audio stream is intermittent on the headset side after connecting the gateway to a Mac computer and starting audio stream.
   This issue occurs sporadically after building the nRF5340 Audio application with the default USB port as the audio source.
 
+  **Affected platforms:** nRF5340 Audio DK
+
 .. rst-class:: v2-2-0
 
 OCT-2347: Stream reestablishment issues in CIS
   In the CIS mode, if a stream is running and the headset is reset, the gateway cannot reestablish the stream properly.
+
+  **Affected platforms:** nRF5340 Audio DK
 
 Controller subsystem for nRF5340 Audio
 --------------------------------------
@@ -1509,15 +1442,18 @@ OCX-168: Issues with reestablishing streams
 
    **Workaround:** Set retransmits (RTN) to a lower value to reduce the resynchronization time.
 
-
 nRF Machine Learning
 ====================
+
+The issues in this section are related to the :ref:`nrf_machine_learning_app` application.
 
 .. rst-class:: v2-2-0
 
 NCSDK-18532: MCUboot bootloader does not swap images after OTA DFU on nRF5340 DK and Thingy:53
    The MCUboot bootloader cannot access external flash because the chosen ``nordic,pm-ext-flash`` is not defined in the MCUboot child image's devicetree.
    As a result, MCUboot cannot swap images that are received during the OTA update.
+
+   **Affected platforms:** nRF5340, Thingy:53
 
    **Workaround**: Manually cherry-pick and apply the commit with the fix from the ``main`` branch (commit hash: ``f54f6bbd423b12a595e76425e688f034926b8018``) to fix the issue for ``nrf5340dk_nrf5340_cpuapp``.
    Similar fix needs to be applied for the Thingy:53 board.
@@ -1536,21 +1472,463 @@ NCSDK-13923: Device might crash during Bluetooth bonding
 NCSDK-16644: :ref:`nrf_machine_learning_app` does not go to sleep and does not wake up on Thingy:53
   nRF Machine learning application on Thingy:53 does not sleep after a period of inactivity and does not wake up after an activity occurs.
 
+  **Affected platforms:** Thingy:53
+
   **Workaround:** Manually cherry-pick and apply two commits with the fix from the ``main`` branch (commit hashes: ``7381bfcb9c23cd6f78e6ef7fd3ff82b700f81b0f``, ``7e8c23a6632632f0cee885abe955e37a6942911d``).
 
-Pelion
-======
+Samples
+*******
 
-.. rst-class:: v1-6-1 v1-6-0
+The issues in this section are related to :ref:`samples`.
 
-NCSDK-10196: DFU fails for some configurations with the quick session resume feature enabled
-  Enabling :kconfig:option:`CONFIG_PELION_QUICK_SESSION_RESUME` together with the OpenThread network backend leads to the quick session resume failure during the DFU packet exchange.
-  This is valid for the :ref:`nRF52840 DK <ug_nrf52>` and the :ref:`nRF5340 DK <ug_nrf5340>`.
+.. rst-class:: v2-2-0
 
-  **Workaround:** Use the quick session resume feature only for configurations with the cellular network backend.
+NCSDK-18263: |NCS| samples may fail to boot on Thingy:53
+  |NCS| samples and applications that are not listed under :ref:`thingy53_compatible_applications` fail to boot on Nordic Thingy:53.
+  The MCUboot bootloader is not built together with these samples, but the Thingy:53's :ref:`static Partition Manager memory map <ug_pm_static>` requires it (the application image does not start at the beginning of the internal ``FLASH``.)
+
+  **Affected platforms:** Thingy:53
+
+  **Workaround:** Revert the ``9a8680372fdb6e09f3d6537c8c6751dd5c50bf86`` commit in the sdk-zephyr repository and revert the ``1f9765df5acbb36afff0ce40c94ba65d44d19d70`` commit in sdk-nrf.
+  During conflict resolution, make sure to update the :file:`west.yml` file in the sdk-nrf to point to the reverting commit in sdk-zephyr.
+
+
+Bluetooth samples
+=================
+
+.. rst-class:: v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0 v0-4-0 v0-3-0
+
+NCSDK-19942: HID samples do not work with Android 13
+  The :ref:`peripheral_hids_keyboard` and :ref:`peripheral_hids_mouse` samples enter a connection-disconnection loop when you try to connect to them from a device that is running Android 13.
+
+.. rst-class:: v2-3-0 v2-2-0
+
+NCSDK-18518: Cannot build peripheral UART and peripheral LBS samples for the nRF52810 and nRF52811 devices with the Zephyr Bluetooth LE Controller
+  The :ref:`peripheral_uart` and :ref:`peripheral_lbs` samples fail to build for the nRF52810 and nRF52811 devices when the :kconfig:option:`CONFIG_BT_LL_CHOICE` Kconfig option is set to :kconfig:option:`CONFIG_BT_LL_SW_SPLIT`.
+
+  **Affected platforms:** nRF52811, nRF52810
+
+  **Workaround:** Use the SoftDevice Controller: set the :kconfig:option:`CONFIG_BT_LL_CHOICE` Kconfig option to :kconfig:option:`CONFIG_BT_LL_SOFTDEVICE`.
+
+.. rst-class:: v2-2-0
+
+NCSDK-20070: The :ref:`direct_test_mode` antenna switching does not work on the nRF5340 DK with the nRF21540 EK shield.
+  The antenna select DTM command does not have any effect because the GPIO pin which controls antenna is not forwarded to the nRF5340 DK network core.
+
+  **Affected platforms:** nRF5340, nRF21540
+
+  **Workaround** Add a ``<&gpio1 6 0>`` entry in :file:`samples/bluetooth/direct_test_mode/conf/remote_shell/pin_fwd.dts`.
+
+.. rst-class:: v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0
+
+NCSDK-19727: Cannot build the :ref:`peripheral_hids_mouse` sample with security disabled
+  Build fails when the :kconfig:option:`CONFIG_BT_HIDS_SECURITY_ENABLED` Kconfig option is disabled.
+
+  **Workaround:** Build the sample with its default configuration, that is, enable the :kconfig:option:`CONFIG_BT_HIDS_SECURITY_ENABLED` Kconfig option.
+
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0
+
+NCSDK-15527: Advertising in the :ref:`peripheral_hr_coded` sample and scanning in the :ref:`bluetooth_central_hr_coded` sample cannot be started when using the SW Split Link Layer
+  The :kconfig:option:`CONFIG_BT_CTLR_ADV_EXT` option required by these samples is disabled by default in the SW Split Link Layer.
+
+  **Workaround:** Enable the :kconfig:option:`CONFIG_BT_CTLR_ADV_EXT` option in the project configuration file (:file:`prj.conf`).
+
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0
+
+NCSDK-15229: Incorrect peer's throughput calculation in the :ref:`ble_throughput` sample
+  The peer's measured throughput is understated because it includes a delay, during which there is no data transfer.
+
+  **Workaround:** Manually cherry-pick and apply commit with fix from main (commit hash: ``05871f9b9c2aebf0a3c188a61b3788baea783180``).
+
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0
+
+NCSDK-16060: :ref:`peripheral_lbs` sample build fails when the :kconfig:option:`CONFIG_BT_LBS_SECURITY_ENABLED` option is disabled
+  Build failure is caused by the undefined ``conn_auth_info_callbacks`` structure.
+
+  **Workaround:** Manually cherry-pick and apply commit with fix from ``main`` (commit hash: ``32c827b20f3c5ab85a359e572d366da310fe2767``).
+
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0
+
+NCSDK-15724: Bluetooth's Peripheral UART sample fails to start on Thingy:53
+  Enabling USB by the :ref:`Peripheral UART's <peripheral_uart>` main function ends with error because the USB was already enabled by the Thingy:53-specific code.
+
+  **Affected platforms:** Thingy:53
+
+  **Workaround:** Manually cherry-pick and apply commit with fix from ``main`` (commit hash: ``b834ff8860f3a30fe19c99dbf4c0c99b0b017245``).
+
+.. rst-class:: v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0
+
+NCSDK-9820: Notification mismatch in :ref:`peripheral_lbs`
+  When testing the :ref:`peripheral_lbs` sample, if you press and release **Button 1** while holding one of the other buttons, the notification for button release is the same as for the button press.
+
+.. rst-class:: v1-8-0
+
+NCSDK-12886: Peripheral UART sample building issue with nRF52811
+  The :ref:`peripheral_uart` sample built for nRF52811 asserts on the nRF52840 DK in rev. 2.1.0 (build target: ``nrf52840dk_nrf52811``).
+
+  **Affected platforms:** nRF52840, nRF52811
+
+.. rst-class:: v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0
+
+NCSDK-8321: NUS shell transport sample does not display the initial shell prompt
+  NUS shell transport sample does not display the initial shell prompt ``uart:~$`` on the remote terminal.
+  Also, few logs with sending errors are displayed on the terminal connected directly to the DK.
+  This issue is caused by the shell being enabled before turning on the notifications for the NUS service by the remote peer.
+
+  **Workaround:** Enable the shell after turning on the NUS notifications or block it until turning on the notifications.
+
+.. rst-class:: v1-2-1 v1-2-0
+
+Peripheral HIDS keyboard sample cannot be used with nRF Bluetooth® LE Controller
+  The :ref:`peripheral_hids_keyboard` sample cannot be used with the :ref:`nrfxlib:softdevice_controller` because the NFC subsystem does not work with the controller library.
+  The library uses the MPSL Clock driver, which does not provide an API for asynchronous clock operation.
+  NFC requires this API to work correctly.
+
+.. rst-class:: v1-2-1 v1-2-0
+
+Peripheral HIDS mouse sample advertising issues
+  When the :ref:`peripheral_hids_mouse` sample is used with the Zephyr Bluetooth® LE Controller, directed advertising does not time out and the regular advertising cannot be started.
+
+.. rst-class:: v1-2-1 v1-2-0
+
+Central HIDS sample issues with directed advertising
+  The :ref:`bluetooth_central_hids` sample cannot connect to a peripheral that uses directed advertising.
+
+.. rst-class:: v1-1-0
+
+Unstable samples
+  Bluetooth® Low Energy peripheral samples are unstable in some conditions (when pairing and bonding are performed and then disconnections/re-connections happen).
+
+.. rst-class:: v1-1-0 v1-0-0
+
+:ref:`central_uart` cannot handle long strings
+  A too long 212-byte string cannot be handled when entered to the console to send to :ref:`peripheral_uart`.
+
+.. rst-class:: v1-0-0
+
+:ref:`bluetooth_central_hids` loses UART connectivity
+  After programming a HEX file to the nrf52_pca10040 board, UART connectivity is lost when using the Bluetooth® LE Controller.
+  The board must be reset to get UART output.
+
+  **Affected platforms:** nRF52832
+
+.. rst-class:: v1-1-0 v1-0-0
+
+Samples crashing on nRF51 when using GPIO
+  On nRF51 devices, Bluetooth® LE samples that use GPIO might crash when buttons are pressed frequently.
+  In such case, the GPIO ISR introduces latency that violates real-time requirements of the Radio ISR.
+  nRF51 is more sensitive to this issue than nRF52 (faster core).
+
+  **Affected platforms:** nRF51 Series, nRF52832
+
+.. rst-class:: v0-4-0
+
+GATT Discovery Manager missing support
+  The :ref:`gatt_dm_readme` is not supported on nRF51 devices.
+
+  **Affected platforms:** nRF51 Series
+
+.. rst-class:: v0-4-0
+
+Samples do not work with SD Controller v0.1.0
+  Bluetooth® LE samples cannot be built with the :ref:`nrfxlib:softdevice_controller` v0.1.0.
+
+.. rst-class:: v0-3-0
+
+Peripheral UART string size issue
+  :ref:`peripheral_uart` cannot handle the corner case that a user attempts to send a string of more than 211 bytes.
+
+.. rst-class:: v1-0-0 v0-4-0 v0-3-0
+
+LED Button Service reporting issue
+  :ref:`peripheral_lbs` does not report the Button 1 state correctly.
+
+.. rst-class:: v1-2-1 v1-2-0 v1-1-0 v1-0-0 v0-4-0 v0-3-0
+
+MITM protection missing for central samples
+  The central samples (:ref:`central_uart`, :ref:`bluetooth_central_hids`) do not support any pairing methods with MITM protection.
+
+.. rst-class:: v0-3-0
+
+Reconnection issues after bonding
+  The peripheral samples (:ref:`peripheral_uart`, :ref:`peripheral_lbs`, :ref:`peripheral_hids_mouse`) have reconnection issues after performing bonding (LE Secure Connection pairing enable) with nRF Connect for Desktop.
+  These issues result in disconnection.
+
+.. rst-class:: v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0
+
+NCSDK-17883: Cannot build peripheral UART sample with security (:kconfig:option:`CONFIG_BT_NUS_SECURITY_ENABLED`) disabled
+  The :ref:`peripheral_uart` sample fails to build when the :kconfig:option:`BT_NUS_SECURITY_ENABLED` Kconfig option is disabled.
+
+  **Workaround:** In :file:`main.c` file, search for the ``#else`` entry of the ``#if defined(CONFIG_BT_NUS_SECURITY_ENABLED)`` item and add an empty declaration of the ``conn_auth_info_callbacks`` structure, just after the similar empty definition of ``conn_auth_callbacks``.
+
+.. rst-class:: v1-9-0
+
+Antenna switching does not work on targets ``nrf5340dk_nrf5340_cpuapp`` and ``nrf5340dk_nrf5340__cpuapp_ns``
+  Antenna switching does not work when :ref:`direction finding sample <ble_samples>` applications are built for ``nrf5340dk_nrf5340_cpuapp`` and ``nrf5340dk_nrf5340_cpuapp_ns`` targets.
+  That is caused by GPIO pins that are responsible for access to antenna switches, not being assigned to network core.
+
+  **Affected platforms:** nRF5340
+
+NFC samples
+===========
+
+The issues in this section are related to :ref:`nfc_samples`.
+
+.. rst-class:: v2-2-0
+
+NCSDK-19168: The :ref:`peripheral_nfc_pairing` and :ref:`central_nfc_pairing` samples cannot pair using OOB data.
+  The :ref:`nfc_ndef_ch_rec_parser_readme` library parses AC records in an invalid way.
+  As a result, the samples cannot parse OOB data for pairing.
+
+  **Workaround:** Revert the :file:`subsys/nfc/ndef/ch_record_parser.c` file to the state from the :ref:`ncs_release_notes_210`.
+
+  .. code-block::
+
+     cd <NCS_root_directory>
+     git checkout v2.1.0 -- subsys/nfc/ndef/ch_record_parser.c
+
+.. rst-class:: v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0
+
+NCSDK-19347: NFC Reader samples return false errors with value ``1``.
+  The :c:func:`nfc_t4t_isodep_transmit` function of the :ref:`nfc_t4t_isodep_readme` library can return ``1`` as error code even if a delayed operation has been scheduled correctly and should return ``0``.
+  This happens when the ISO-DEP frame is sent for the first time.
+  In samples, this error is propagated from the higher level :c:func:`nfc_t4t_hl_procedure_ndef_tag_app_select` function.
+  The :ref:`tnep_poller_readme` library operations can call the application error callback with error code ``1``, meaning that a delayed operation has been scheduled successfully.
+
+  **Workaround:** Ignore the :ref:`tnep_poller_readme` error callback with error value ``1``.
+  Treat the return value ``1`` of the functions :c:func:`nfc_t4t_isodep_transmit` and :c:func:`nfc_t4t_hl_procedure_ndef_tag_app_select` as success.
+
+.. rst-class:: v1-2-1 v1-2-0
+
+Sample incompatibility with the nRF5340 PDK
+  The :ref:`nfc_tnep_poller` and :ref:`nfc_tag_reader` samples cannot be run on the nRF5340 PDK.
+  There is an incorrect number of pins defined in the MDK files, and the pins required for :ref:`st25r3911b_nfc_readme` cannot be configured properly.
+
+  **Affected platforms:** nRF5340
+
+.. rst-class:: v1-2-1 v1-2-0 v1-1-0
+
+Unstable NFC tag samples
+  NFC tag samples are unstable when exhaustively tested (performing many repeated read and/or write operations).
+  NFC tag data might be corrupted.
+
+nRF9160 samples
+===============
+
+.. rst-class:: v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0
+
+NCSDK-5666: LTE Sensor Gateway
+  The :ref:`lte_sensor_gateway` sample crashes when Thingy:52 is flipped.
+
+  **Affected platforms:** nRF9160, Thingy:52
+
+.. rst-class:: v1-2-0
+
+GPS sockets and SUPL client library stops working
+  The `nRF9160: GPS with SUPL client library <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.2.0/nrf/samples/nrf9160/gps/README.html>`_ sample stops working if :ref:`supl_client` support is enabled, but the SUPL host name cannot be resolved.
+
+  **Affected platforms:** nRF9160
+
+  **Workaround:** Insert a delay (``k_sleep()``) of a few seconds after the ``printf`` on line 294 in :file:`main.c`.
+
+.. rst-class:: v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0
+
+NCSDK-9441: The :ref:`fmfu_smp_svr_sample` sample is unstable with the newest J-Link version
+  Full modem serial update does not work on development kit with debugger chip version delivered with J-Link software > 6.88a
+
+  **Affected platforms:** nRF9160
+
+  **Workaround:** Downgrade the debugger chip to the firmware released with J-Link 6.88a or use another way of transferring serial data to the chip.
+
+.. rst-class:: v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0
+
+NCSDK-20026: LTE Sensor Gateway fails to run
+  The :ref:`lte_sensor_gateway` sample system faults when the board version is not included with the build target while building the sample.
+  This is due to an issue with the low-power UART and HCI drivers.
+
+  **Affected platforms:** nRF9160
+
+  **Workaround:** Include the board version when building the :ref:`bluetooth-hci-lpuart-sample` sample and the :ref:`lte_sensor_gateway` sample.
+  For example, for board version 1.1.0, the samples must be built in the following way:
+
+  The :ref:`bluetooth-hci-lpuart-sample` sample:
+
+  .. parsed-literal::
+     :class: highlight
+
+     west build --board nrf9160dk_nrf52840@1.1.0
+
+  The :ref:`lte_sensor_gateway` sample:
+
+  .. parsed-literal::
+     :class: highlight
+
+     west build --board nrf9160dk_nrf9160_ns@1.1.0
+
+.. rst-class:: v1-7-1 v1-7-0
+
+NCSDK-11033: Dial-up usage not working
+  Dial-up usage with :ref:`MoSh PPP <modem_shell_application>` does not work and causes the nRF9160 DK to crash when it is connected to a PC.
+
+  **Affected platforms:** nRF9160
+
+  **Workaround:** Manually pick the fix available in Zephyr to the `Zephyr issue #38516`_.
+
+nRF5340 samples
+===============
+
+.. rst-class:: v2-3-0
+
+NCSDK-20967: The :ref:`nrf_rpc_entropy_nrf53` sample does not work on the network core.
+  The network core will not work due a hard fault.
+
+  **Affected platforms:** nRF5340
+
+Other samples
+=============
+
+.. rst-class:: v2-3-0
+
+NCSDK-20046: IPC service sample does not work with ``nrf5340dk_nrf5340_cpuapp``
+  The :ref:`ipc_service_sample` sample does not work with the ``nrf5340dk_nrf5340_cpuapp`` :ref:`build target <app_boards_names_zephyr>` due to a misconfiguration.
+  The application core does not log anything, while the network core seems to work and bond, but cannot transfer data.
+  When using UART, there is no output visible.
+
+  **Affected platforms:** nRF5340
+
+.. rst-class:: v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0
+
+NCSDK-16856: Increased power consumption observed for the Low Power UART sample on nRF5340 DK
+  The power consumption of the :ref:`lpuart_sample` sample measured using the nRF5340 DK v2.0.0 is about 200 uA higher than expected.
+
+  **Affected platforms:** nRF5340
+
+  **Workaround:** Disconnect flow control lines for VCOM2 with the SW7 DIP switch on the board.
+
+.. rst-class:: v2-2-0
+
+NCSDK-18847: :ref:`radio_test` sample does not build with support for Skyworks front-end module
+  When building a sample with support for a front-end module different from nRF21540, the sample uses a non-existing configuration to initialize TX power data.
+  This causes a compilation error because the source file containing code for a generic front-end module is not included in the build.
+
+  **Workaround:** Do not use the :kconfig:option:`CONFIG_RADIO_TEST_POWER_CONTROL_AUTOMATIC` Kconfig option and replace ``CONFIG_GENERIC_FEM`` with ``CONFIG_MPSL_FEM_SIMPLE_GPIO`` in the :file:`CMakeLists.txt` file of the sample.
+
+.. rst-class:: v2-3-0
+
+NCSDK-19858: :ref:`at_monitor_readme` library and :ref:`nrf_cloud_mqtt_multi_service` sample heap overrun
+  Occasionally, the :ref:`at_monitor_readme` library heap becomes overrun, presumably due to one of the registered AT event listeners becoming stalled.
+  This has only been observed with the :ref:`nrf_cloud_mqtt_multi_service` sample.
+
+.. rst-class:: v2-3-0 v2-2-0
+
+NCSDK-20095: Build warning in the RF test samples when the minimal pinout generic/Skyworks FEM is used
+  The :ref:`radio_test` and :ref:`direct_test_mode` samples build with a warning about generic/Skyworks FEM in minimal pinout configuration.
+
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0
+
+NCSDK-16338: Setting gain for nRF21540 Front-end module does not work in the :ref:`radio_test` sample
+  Setting FEM gain for nRF21540 Front-end module does not work in the :ref:`radio_test` sample with the nRF5340 SoC.
+
+  **Affected platforms:** nRF5340, nRF21540
+
+  **Workaround:** Enable the SPI 0 instance in the nRF5340 network core DTS overlay file.
+
+.. rst-class:: v1-9-0
+
+NCSDK-13925: Build warning in the RF test samples when the nRF21540 EK support is enabled
+  :ref:`radio_test` and :ref:`direct_test_mode` build with warnings for nRF5340 with the :ref:`ug_radio_fem_nrf21540_ek` support.
+
+  **Affected platforms:** nRF5340, nRF21540
+
+  **Workaround:** Change the parameter type in the :c:func:`nrf21540_tx_gain_set()` function in :file:`ncs/nrf/samples/bluetooth/direct_test_mode/src/fem/nrf21540.c` from :c:type:`uint8_t` to :c:type:`uint32_t`.
+
+.. rst-class:: v1-5-2 v1-5-1 v1-5-0
+
+NCSDK-7173: nRF5340 network core bootloader cannot be built stand-alone
+  The :ref:`nc_bootloader` sample does not compile when built stand-alone.
+  It compiles without problems when included as a child image.
+
+  **Affected platforms:** nRF5340
+
+  **Workaround:** Include the :ref:`nc_bootloader` sample as child image instead of compiling it stand-alone.
+
+Libraries
+*********
+
+The issues in this section are related to :ref:`libraries`.
+
+Binary libraries
+================
+
+.. _tnsw_46156:
+
+.. rst-class:: v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0
+
+TNSW-46156: The :ref:`liblwm2m_carrier_readme` library can in some cases trigger a modem bug related to PDN deactivation (AT+CGACT) in NB-IoT mode.
+  This causes excessive network signaling which can make interactions with the modem (AT commands or :ref:`nrfxlib:nrf_modem` functions) hang for several minutes.
+
+  **Affected platforms:** nRF9160
+
+  **Workaround:** Add a small delay before PDN deactivation as shown in `Pull Request #10379 <https://github.com/nrfconnect/sdk-nrf/pull/10379>`_.
+
+.. rst-class:: v2-3-0 v2-2-0
+
+NCSDK-18746: The :ref:`liblwm2m_carrier_readme` library fails to complete non-secure bootstrap when using a custom URI and the default security tag
+  If the LwM2M carrier library is operating in generic mode (not connecting to any of the predefined supported carriers), and the :kconfig:option:`CONFIG_LWM2M_CARRIER_CUSTOM_URI` is set to connect to a non-secure server, the library attempts to retrieve a PSK from :kconfig:option:`CONFIG_LWM2M_CARRIER_SERVER_SEC_TAG` even though a PSK is not needed for the non-secure bootstrap.
+  The PSK in this ``sec_tag`` is not used, but reading the ``sec_tag`` causes the bootstrap to fail if the :kconfig:option:`CONFIG_LWM2M_CARRIER_SERVER_SEC_TAG` is set to the default value (``0``).
+
+  **Affected platforms:** nRF9160
+
+  **Workaround:** Assign any non-zero value to :kconfig:option:`CONFIG_LWM2M_CARRIER_SERVER_SEC_TAG`.
+
+.. rst-class:: v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-3-1 v1-2-1 v1-2-0
+
+NCSDK-12912: The :ref:`liblwm2m_carrier_readme` library does not recover if initial network connection fails
+  When the device is switched on, if :cpp:func:`lte_lc_connect()` returns an error at timeout, it will cause :cpp:func:`lwm2m_carrier_init()` to fail.
+  Thus, the device will fail to connect to carrier device management servers.
+
+  **Affected platforms:** nRF9160
+
+  **Workaround:** Increase :kconfig:option:`CONFIG_LTE_NETWORK_TIMEOUT` to allow :ref:`lte_lc_readme` more time to successfully connect.
+
+.. rst-class:: v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-1 v1-5-0 v1-4-2 v1-3-1 v1-2-1 v1-2-0
+
+NCSDK-12913: The :ref:`liblwm2m_carrier_readme` library will fail to initialize if phone number is not present in SIM
+  The SIM phone number is needed during the :ref:`liblwm2m_carrier_readme` library start-up.
+  For new SIM cards, it might take some time before the phone number is received by the network.
+  The LwM2M carrier library does not wait for this to happen.
+  Thus, the device can fail to connect to the carrier's device management servers.
+
+  **Affected platforms:** nRF9160
+
+  **Workaround:** Use one of the following workarounds:
+
+  * Reboot or power-cycle the device after the SIM has received a phone number from the network.
+  * Apply the following commits, depending on your |NCS| version:
+
+    * `v1.7-branch <https://github.com/nrfconnect/sdk-nrf/pull/6287>`_
+    * `v1.6-branch <https://github.com/nrfconnect/sdk-nrf/pull/6286>`_
+    * `v1.4-branch <https://github.com/nrfconnect/sdk-nrf/pull/6270>`_
+
+.. rst-class:: v1-8-0
+
+NCSDK-13106: When replacing a Verizon SIM card, the :ref:`liblwm2m_carrier_readme` library does not reconnect to the device management servers
+  When a Verizon SIM card is replaced with a new Verizon SIM card, the library fails to fetch the correct PSK for the bootstrap server.
+  Thus, the device fails to connect to the carrier's device management servers.
+
+  **Affected platforms:** nRF9160
+
+  **Workaround:** Use one of the following workarounds:
+
+  * Use the :kconfig:option:`CONFIG_LWM2M_CARRIER_USE_CUSTOM_PSK` and :kconfig:option:`CONFIG_LWM2M_CARRIER_CUSTOM_PSK` configuration options to set the appropriate PSK needed for Verizon test or live servers.
+    This PSK can be obtain from the carrier.
+  * After inserting a new SIM card, reboot the device again.
+
 
 Common Application Framework (CAF)
 ==================================
+
+The issues in this section are related to :ref:`lib_caf`.
 
 .. rst-class:: v1-8-0
 
@@ -1618,368 +1996,79 @@ NCSIDB-925: Event subscribers in the :ref:`app_event_manager` may overlap when u
   Make sure that the event name does not start the same way as another event.
   For example, creating the following events: ``rx_event`` and ``rx_event_error_event`` would still cause the issue.
 
-Subsystems
-**********
-
-Bluetooth® LE
-=============
-
-.. rst-class:: v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0 v0-4-0 v0-3-0
-
-NCSDK-19942: HID samples do not work with Android 13
-  The :ref:`peripheral_hids_keyboard` and :ref:`peripheral_hids_mouse` samples enter a connection-disconnection loop when you try to connect to them from a device that is running Android 13.
-
-.. _ncsdk_19865:
-
-.. rst-class:: v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0 v0-4-0 v0-3-0
-
-NCSDK-19865: GATT Robust Caching issues for bonded peers
-  The Client Supported Features value written by a bonded peer may not be stored in the non-volatile memory.
-  Change awareness of the bonded peer is lost on reboot.
-  After reboot, each bonded peer is initially marked as change-unaware.
-
-  **Workaround:** Disable the GATT Caching feature (:kconfig:option:`CONFIG_BT_GATT_CACHING`).
-  Make sure that Bluetooth bonds are removed together with disabling GATT Caching if the functionality is disabled during a firmware upgrade.
+Modem libraries
+===============
 
 .. rst-class:: v2-3-0 v2-2-0
 
-NCSDK-18518: Cannot build peripheral UART and peripheral LBS samples for the nRF52810 and nRF52811 devices with the Zephyr Bluetooth LE Controller
-  The :ref:`peripheral_uart` and :ref:`peripheral_lbs` samples fail to build for the nRF52810 and nRF52811 devices when the :kconfig:option:`CONFIG_BT_LL_CHOICE` Kconfig option is set to :kconfig:option:`CONFIG_BT_LL_SW_SPLIT`.
+CIA-857: LTE Link Controller spurious events
+  When using the :ref:`lte_lc_readme` library, a memory comparison is done between padded structs that may result in comparing bytes that have undefined initialization values.
+  This may cause spurious ``LTE_LC_EVT_CELL_UPDATE`` and ``LTE_LC_EVT_PSM_UPDATE`` events even though the information contained in the event has not changed since last update event.
 
-  **Workaround:** Use the SoftDevice Controller: set the :kconfig:option:`CONFIG_BT_LL_CHOICE` Kconfig option to :kconfig:option:`CONFIG_BT_LL_SOFTDEVICE`.
+  **Affected platforms:** nRF9160
 
-.. rst-class:: v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0
+.. rst-class:: v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0
 
-NCSDK-19727: Cannot build the :ref:`peripheral_hids_mouse` sample with security disabled.
-  Build fails when the :kconfig:option:`CONFIG_BT_HIDS_SECURITY_ENABLED` Kconfig option is disabled.
+NCSDK-15512: Modem traces retrieval incompatible with TF-M
+  Enabling modem traces with :kconfig:option:`CONFIG_UART_NRF_MODEM_LIB_TRACE_BACKEND_UART` set to ``y`` will disable TF-M logging from secure processing environment (using :kconfig:option:`CONFIG_TFM_LOG_LEVEL_SILENCE` set to ``y``) including output from hardware fault handlers.
+  You can either use **UART1** for TF-M output or for modem traces, but not for both.
 
-  **Workaround:** Build the sample with its default configuration, that is, enable the :kconfig:option:`CONFIG_BT_HIDS_SECURITY_ENABLED` Kconfig option.
+  **Affected platforms:** nRF9160
 
-.. rst-class:: v2-0-2
 
-DRGN-17695: The BT RX thread stack might overflow if the :kconfig:option:`CONFIG_BT_SMP` is enabled
-  When performing SMP pairing MPU FAULTs might be triggered because the stack is not large enough.
+Libraries for networking
+========================
 
-  **Workaround:** Increase the stack size manually in the project configuration file (:file:`prj.conf`) using :kconfig:option:`CONFIG_BT_RX_STACK_SIZE`.
+.. rst-class:: v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0
+
+CIA-351: Connectivity issues with :ref:`lib_azure_iot_hub`
+  If a ``device-bound`` message is sent to the device while it is in the LTE Power Saving Mode (PSM), the TCP connection will most likely be terminated by the server.
+  Known symptoms of this are frequent reconnections to cloud, messages sent to Azure IoT Hub never arriving, and FOTA images being downloaded twice.
+
+  **Affected platforms:** nRF9160
+
+  **Workaround:** Avoid using LTE Power Saving Mode (PSM) and extended DRX intervals longer than approximately 30 seconds. This will reduce the risk of the issue occurring, at the cost of increased power consumption.
+
+
+Other libraries
+===============
+
+.. rst-class:: v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0
+
+NCSDK-18398: Build fails if shell is enabled
+   Enabling the Zephyr's :ref:`zephyr:shell_api` module together with :ref:`nrf_profiler` results in a build failure because of the bug in the :file:`CMakeLists.txt` file.
+
+   **Workaround:** Manually cherry-pick and apply the commit with the fix from the ``main`` branch (commit hash: ``fdac428e902ebd96885160dd3ae5d08d21642926``).
 
 .. rst-class:: v2-0-2 v2-0-1 v2-0-0
 
-NCSDK-15527: Advertising in the :ref:`peripheral_hr_coded` sample and scanning in the :ref:`bluetooth_central_hr_coded` sample cannot be started when using the SW Split Link Layer
-  The :kconfig:option:`CONFIG_BT_CTLR_ADV_EXT` option required by these samples is disabled by default in the SW Split Link Layer.
+NCSDK-15471: Compilation with :ref:`SUPL client <supl_client>` library fails when TF-M is enabled
+  Building an application that uses the SUPL client library fails if TF-M is used.
 
-  **Workaround:** Enable the :kconfig:option:`CONFIG_BT_CTLR_ADV_EXT` option in the project configuration file (:file:`prj.conf`).
+  **Affected platforms:** nRF9160
 
-.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0
+  **Workaround:** Use one of the following workarounds:
 
-NCSDK-15229: Incorrect peer's throughput calculation in the :ref:`ble_throughput` sample
-  The peer's measured throughput is understated because it includes a delay, during which there is no data transfer.
+  * Use Secure Partition Manager instead of TF-M.
+  * Disable the FPU by setting :kconfig:option:`CONFIG_FPU` to ``n``.
 
-  **Workaround:** Manually cherry-pick and apply commit with fix from main (commit hash: ``05871f9b9c2aebf0a3c188a61b3788baea783180``).
+.. rst-class:: v1-9-2 v1-9-1 v1-9-0
 
-.. rst-class:: v2-0-2 v2-0-1 v2-0-0
+The time returned by :ref:`lib_date_time` library becomes incorrect after one week of uptime
+  The time returned by :ref:`lib_date_time` library becomes incorrect after one week elapses.
+  This is due to an issue with clock_gettime() API.
 
-NCSDK-16060: :ref:`peripheral_lbs` sample build fails when the :kconfig:option:`CONFIG_BT_LBS_SECURITY_ENABLED` option is disabled
-  Build failure is caused by the undefined ``conn_auth_info_callbacks`` structure.
+  **Affected platforms:** nRF9160
 
-  **Workaround:** Manually cherry-pick and apply commit with fix from ``main`` (commit hash: ``32c827b20f3c5ab85a359e572d366da310fe2767``).
+Subsystems
+**********
 
-.. rst-class:: v2-0-2 v2-0-1 v2-0-0
-
-NCSDK-15724: Bluetooth's Peripheral UART sample fails to start on Thingy:53
-  Enabling USB by the :ref:`Peripheral UART's <peripheral_uart>` main function ends with error because the USB was already enabled by the Thingy:53-specific code.
-
-  **Workaround:** Manually cherry-pick and apply commit with fix from ``main`` (commit hash: ``b834ff8860f3a30fe19c99dbf4c0c99b0b017245``).
-
-.. rst-class:: v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0
-
-NCSDK-13459: Uninitialized size in hids_boot_kb_outp_report_read
-  When reading from the boot keyboard output report characteristic, the :ref:`hids_readme` calls the registered callback with uninitialized report size.
-
-  **Workaround:** Manually cherry-pick and apply commit with fix from main (commit hash: ``f18250dad6cbd9778de7af4b8a774b58e55fe720``).
-
-.. rst-class:: v1-8-0
-
-NCSDK-12886: Peripheral UART sample building issue with nRF52811
-  The :ref:`peripheral_uart` sample built for nRF52811 asserts on the nRF52840 DK in rev. 2.1.0 (build target: ``nrf52840dk_nrf52811``).
-
-.. rst-class:: v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0
-
-NCSDK-9820: Notification mismatch in :ref:`peripheral_lbs`
-  When testing the :ref:`peripheral_lbs` sample, if you press and release **Button 1** while holding one of the other buttons, the notification for button release is the same as for the button press.
-
-.. rst-class:: v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0
-
-NCSDK-9106: Bluetooth® ECC thread stack size too small
-  The Bluetooth ECC thread used during the pairing procedure with LE Secure Connections might overflow when an interrupt is triggered when the stack usage is at its maximum.
-
-  **Workaround:** Increase the ECC stack size by setting ``CONFIG_BT_HCI_ECC_STACK_SIZE`` to ``1140``.
-
-.. rst-class:: v1-5-0 v1-4-2 v1-4-1 v1-4-0
-
-DRGN-15435: GATT notifications and Writes Without Response might be sent out of order
-  GATT notifications and Writes Without Response might be sent out of order when not using a complete callback.
-
-  **Workaround:** Always set a callback for notifications and Writes Without Response.
-
-.. rst-class:: v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0
-
-DRGN-15448: Incomplete bond overwrite during pairing procedure when peer is not using the IRK stored in the bond
-  When pairing with a peer that has deleted its bond information and is using a new IRK to establish the connection, the existing bond is not overwritten during the pairing procedure.
-  This can lead to MIC errors during reconnection if the old LTK is used instead.
-
-.. rst-class:: v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0
-
-NCSDK-8321: NUS shell transport sample does not display the initial shell prompt
-  NUS shell transport sample does not display the initial shell prompt ``uart:~$`` on the remote terminal.
-  Also, few logs with sending errors are displayed on the terminal connected directly to the DK.
-  This issue is caused by the shell being enabled before turning on the notifications for the NUS service by the remote peer.
-
-  **Workaround:** Enable the shell after turning on the NUS notifications or block it until turning on the notifications.
-
-.. rst-class:: v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0
-
-NCSDK-8224: Callbacks for "security changed" and "pairing failed" are not always called
-  The pairing failed and security changed callbacks are not called when the connection is disconnected during the pairing procedure or the required security is not met.
-
-  **Workaround:** Application should use the disconnected callback to handle pairing failed.
-
-.. rst-class:: v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0
-
-NCSDK-8223: GATT requests might deadlock RX thread
-  GATT requests might deadlock the RX thread when all TX buffers are taken by GATT requests and the RX thread tries to allocate a TX buffer for a response.
-  This causes a deadlock because only the RX thread releases the TX buffers for the GATT requests.
-  The deadlock is resolved by a 30 second timeout, but the ATT bearer cannot transmit without reconnecting.
-
-  **Workaround:** Set :kconfig:option:`CONFIG_BT_L2CAP_TX_BUF_COUNT` >= ``CONFIG_BT_ATT_TX_MAX`` + 2.
-
-.. rst-class:: v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0
-
-NCSDK-6845: Pairing failure with simultaneous pairing on multiple connections
-  When using LE Secure Connections pairing, the pairing fails with simultaneous pairing on multiple connections.
-  The failure reason is unspecified.
-
-  **Workaround:** Retry the pairing on the connections that failed one by one after the pairing procedure has finished.
-
-.. rst-class:: v1-4-0 v1-3-2 v1-3-1 v1-3-0
-
-NCSDK-6844: Security procedure failure can terminate GATT client request
-  A security procedure terminates the GATT client request that is currently in progress, unless the request was the reason to initiate the security procedure.
-  If a new GATT client request is queued at this time, this might potentially cause a GATT transaction violation and fail as well.
-
-  **Workaround:** Do not initiate a security procedure in parallel with GATT client requests.
-
-.. rst-class:: v1-3-0
-
-NCSDK-5711: High-throughput transmission can deadlock the receive thread
-  High-throughput transmission can deadlock the receive thread if the connection is suddenly disconnected.
-
-.. rst-class:: v1-2-1 v1-2-0
-
-Only secure applications can use Bluetooth® LE
-  Bluetooth LE cannot be used in a non-secure application, for example, an application built for the ``nrf5340_dk_nrf5340_cpuappns`` build target.
-
-  **Workaround:** Use the ``nrf5340_dk_nrf5340_cpuapp`` build target instead.
-
-.. rst-class:: v1-2-1 v1-2-0
-
-Peripheral HIDS keyboard sample cannot be used with nRF Bluetooth® LE Controller
-  The :ref:`peripheral_hids_keyboard` sample cannot be used with the :ref:`nrfxlib:softdevice_controller` because the NFC subsystem does not work with the controller library.
-  The library uses the MPSL Clock driver, which does not provide an API for asynchronous clock operation.
-  NFC requires this API to work correctly.
-
-.. rst-class:: v1-2-1 v1-2-0
-
-Peripheral HIDS mouse sample advertising issues
-  When the :ref:`peripheral_hids_mouse` sample is used with the Zephyr Bluetooth® LE Controller, directed advertising does not time out and the regular advertising cannot be started.
-
-.. rst-class:: v1-2-1 v1-2-0
-
-Central HIDS sample issues with directed advertising
-  The :ref:`bluetooth_central_hids` sample cannot connect to a peripheral that uses directed advertising.
-
-.. rst-class:: v1-1-0
-
-Unstable samples
-  Bluetooth® Low Energy peripheral samples are unstable in some conditions (when pairing and bonding are performed and then disconnections/re-connections happen).
-
-.. rst-class:: v1-2-1 v1-2-0 v1-1-0
-
-:kconfig:option:`CONFIG_BT_SMP` alignment requirement
-  When running the :ref:`bluetooth_central_dfu_smp` sample, the :kconfig:option:`CONFIG_BT_SMP` configuration must be aligned between this sample and the Zephyr counterpart (:ref:`zephyr:smp_svr_sample`).
-  However, security is not enabled by default in the Zephyr sample.
-
-.. rst-class:: v1-2-1 v1-2-0 v1-1-0 v1-0-0
-
-Reconnection issues on some operating systems
-  On some operating systems, the :ref:`nrf_desktop` application is unable to reconnect to a host.
-
-.. rst-class:: v1-1-0 v1-0-0
-
-:ref:`central_uart` cannot handle long strings
-  A too long 212-byte string cannot be handled when entered to the console to send to :ref:`peripheral_uart`.
-
-.. rst-class:: v1-0-0
-
-:ref:`bluetooth_central_hids` loses UART connectivity
-  After programming a HEX file to the nrf52_pca10040 board, UART connectivity is lost when using the Bluetooth® LE Controller.
-  The board must be reset to get UART output.
-
-.. rst-class:: v1-1-0 v1-0-0
-
-Samples crashing on nRF51 when using GPIO
-  On nRF51 devices, Bluetooth® LE samples that use GPIO might crash when buttons are pressed frequently.
-  In such case, the GPIO ISR introduces latency that violates real-time requirements of the Radio ISR.
-  nRF51 is more sensitive to this issue than nRF52 (faster core).
-
-.. rst-class:: v0-4-0
-
-GATT Discovery Manager missing support
-  The :ref:`gatt_dm_readme` is not supported on nRF51 devices.
-
-.. rst-class:: v0-4-0
-
-Samples do not work with SD Controller v0.1.0
-  Bluetooth® LE samples cannot be built with the :ref:`nrfxlib:softdevice_controller` v0.1.0.
-
-.. rst-class:: v1-0-0 v0-4-0 v0-3-0
-
-LED Button Service reporting issue
-  :ref:`peripheral_lbs` does not report the Button 1 state correctly.
-
-.. rst-class:: v1-2-1 v1-2-0 v1-1-0 v1-0-0 v0-4-0 v0-3-0
-
-MITM protection missing for central samples
-  The central samples (:ref:`central_uart`, :ref:`bluetooth_central_hids`) do not support any pairing methods with MITM protection.
-
-.. rst-class:: v0-3-0
-
-Peripheral UART string size issue
-  :ref:`peripheral_uart` cannot handle the corner case that a user attempts to send a string of more than 211 bytes.
-
-.. rst-class:: v0-3-0
-
-Reconnection issues after bonding
-  The peripheral samples (:ref:`peripheral_uart`, :ref:`peripheral_lbs`, :ref:`peripheral_hids_mouse`) have reconnection issues after performing bonding (LE Secure Connection pairing enable) with nRF Connect for Desktop.
-  These issues result in disconnection.
-
-.. rst-class:: v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0
-
-NCSDK-17883: Cannot build peripheral UART sample with security (:kconfig:option:`CONFIG_BT_NUS_SECURITY_ENABLED`) disabled
-  The :ref:`peripheral_uart` sample fails to build when the :kconfig:option:`BT_NUS_SECURITY_ENABLED` Kconfig option is disabled.
-
-  **Workaround:** In :file:`main.c` file, search for the ``#else`` entry of the ``#if defined(CONFIG_BT_NUS_SECURITY_ENABLED)`` item and add an empty declaration of the ``conn_auth_info_callbacks`` structure, just after the similar empty definition of ``conn_auth_callbacks``.
-
-Bluetooth mesh
-==============
-
-.. rst-class:: v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1
-
-NCSDK-16800: RPL is not cleared on IV index recovery
-  After recovering the IV index, a node doesn't clear the replay protection list, which leads to incorrect triggering of the replay attack protection mechanism.
-
-  **Workaround:** Call ``bt_mesh_rpl_reset`` twice after the IV index recovery is done.
-
-.. rst-class:: v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1
-
-NCSDK-16798: Friend Subscription List might have duplicate entries
-  If a Low Power node loses a Friend Subscription List Add Confirm message, it repeats the request.
-  The Friend does not check both the transaction number and the presence of the addresses in the subscription list.
-  This causes a situation where the Friend fills the subscription list with duplicate addresses.
-
-.. rst-class:: v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0
-
-NCSDK-16782: The extended advertiser might not work with Bluetooth mesh
-  Using the extended advertiser instead of the legacy advertiser can lead to getting composition data while provisioning to fail.
-  This problem might manifest in the sample :ref:`bluetooth_ble_peripheral_lbs_coex`, as it is using the extended advertiser.
-
-.. rst-class:: v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0
-
-NCSDK-16579: Advertising Node Identity and Network ID might not work with the extended advertiser
-  Advertising Node Identity and Network ID do not work with the extended advertising API when the :kconfig:option:`CONFIG_BT_MESH_ADV_EXT_GATT_SEPARATE` option is enabled.
-
-  **Workaround:** Don't enable the :kconfig:option:`CONFIG_BT_MESH_ADV_EXT_GATT_SEPARATE` option.
-
-.. rst-class:: v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1
-
-NCSDK-14399: Legacy advertiser can occasionally do more message retransmissions than requested
-  When using the legacy advertiser, the stack sleeps for at least 50 ms after starting advertising a message, which might result in more messages to be advertised than requested.
-
-.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1
-
-NCSDK-16061: IV update procedure fails on the device
-  Bluetooth® mesh device does not undergo IV update and fails to participate in the procedure initiated by any other node unless it is rebooted after the provisioning.
-
-  **Workaround:** Reboot the device after provisioning.
-
-.. rst-class:: v1-6-1 v1-6-0
-
-NCSDK-10200: The device stops sending Secure Network Beacons after re-provisioning
-  Bluetooth® mesh stops sending Secure Network Beacons if the device is re-provisioned after reset through Config Node Reset message or ``bt_mesh_reset()`` call.
-
-  **Workaround:** Reboot the device after re-provisioning.
-
-.. rst-class:: v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0
-
-NCSDK-5580: nRF5340 only supports SoftDevice Controller
-  On nRF5340, only the :ref:`nrfxlib:softdevice_controller` is supported for Bluetooth® mesh.
-
-Bluetooth direction finding
-===========================
-
-.. rst-class:: v1-9.0
-
-Antenna switching does not work on targets ``nrf5340dk_nrf5340_cpuapp`` and ``nrf5340dk_nrf5340__cpuapp_ns``
-  Antenna switching does not work when direction finding sample applications are built for ``nrf5340dk_nrf5340_cpuapp`` and ``nrf5340dk_nrf5340_cpuapp_ns`` targets. That is caused by GPIO pins that are responsible for access to antenna switches, not being assigned to network core.
-
-
-Bootloader
-==========
-
-.. rst-class:: v1-5-2 v1-5-1 v1-5-0
-
-NCSDK-7173: nRF5340 network core bootloader cannot be built stand-alone
-  The :ref:`nc_bootloader` sample does not compile when built stand-alone.
-  It compiles without problems when included as a child image.
-
-  **Workaround:** Include the :ref:`nc_bootloader` sample as child image instead of compiling it stand-alone.
-
-.. rst-class:: v1-1-0
-
-Public keys revocation
-  Public keys are not revoked when subsequent keys are used.
-
-.. rst-class:: v1-1-0
-
-Incompatibility with nRF51
-  The bootloader does not work properly on nRF51.
-
-.. rst-class:: v1-2-1 v1-2-0 v1-1-0 v1-0-0 v0-4-0 v0-3-0
-
-Immutable bootloader not supported in SES
-  Building and programming the immutable bootloader (see :ref:`ug_bootloader`) is not supported in SEGGER Embedded Studio.
-
-.. rst-class:: v1-2-1 v1-2-0 v1-1-0 v1-0-0 v0-4-0 v0-3-0
-
-Immutable bootloader board restrictions
-  The immutable bootloader can only be used with the following boards:
-
-  * ``nrf52840_pca10056``
-  * ``nrf9160_pca10090``
-
-.. rst-class:: v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0
-
-nRF Secure Immutable Bootloader and netboot can overwrite non-OTP provisioning data
-  In architectures that do not have OTP regions, b0 and b0n images incorrectly linked to the size of their container can overwrite provisioning partition data from their image sizes.
-  Issue related to NCSDK-7982.
-
-.. rst-class:: v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0
-
-The combination of nRF Secure Immutable Bootloader and MCUboot fails to upgrade both the application and MCUboot
-  Due to a change in dependency handling in MCUboot, MCUboot does not read any update as a valid update.
-  Issue related to NCSDK-8681.
+The issues in this section are related to different subsystems.
 
 Build system
 ============
+
+The issues in this section are related to :ref:`app_build_system`.
 
 .. rst-class:: v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0
 
@@ -2003,6 +2092,18 @@ NCSDK-10672: :file:`dfu_application.zip` is not updated during build
   In the configuration with MCUboot, the :file:`dfu_application.zip` might not be properly updated after code or configuration changes, because of missing dependencies.
 
   **Workaround:** Clear the build if :file:`dfu_application.zip` is going to be released to make sure that it is up to date.
+
+.. rst-class:: v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0
+
+NCSDK-9786: Wrong FLASH_PAGE_ERASE_MAX_TIME_US for the nRF53 network core
+  ``FLASH_PAGE_ERASE_MAX_TIME_US`` defines the execution window duration when doing the flash operation synchronously along the radio operations (:kconfig:option:`CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE` not enabled).
+
+  The ``FLASH_PAGE_ERASE_MAX_TIME_US`` value of the nRF53 network core is lower than required.
+  For this reason, if :kconfig:option:`CONFIG_SOC_FLASH_NRF_RADIO_SYNC_MPSL` is set to ``y`` and :kconfig:option:`CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE` is set to ``n``, a flash erase operation on the nRF5340 network core will result in an MPSL timeslot OVERSTAYED assert.
+
+  **Affected platforms:** nRF5340
+
+  **Workaround:** Increase ``FLASH_PAGE_ERASE_MAX_TIME_US`` (defined in :file:`ncs/zephyr/soc/arm/nordic_nrf/nrf53/soc.h`) from 44850UL to 89700UL (the same value as for the application core).
 
 .. rst-class:: v1-4-2 v1-4-1 v1-4-0
 
@@ -2056,6 +2157,13 @@ NCSDK-11234: Statically defined "pcd_sram" partition might cause ARM usage fault
 
   **Workaround:** Ensure that partitions defined by DTS and Partition Manager are consistent.
 
+.. rst-class:: v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0
+
+NCSDK-7234: UART output is not received from the network core
+  The UART output is not received from the network core if the application core is programmed and running with a non-secure image (using the ``nrf5340dk_nrf5340_cpuapp_ns`` build target).
+
+  **Affected platforms:** nRF5340
+
 .. rst-class:: v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0
 
 NCSDK-7982: Partition manager: Incorrect partition size linkage from name conflict
@@ -2064,13 +2172,109 @@ NCSDK-7982: Partition manager: Incorrect partition size linkage from name confli
 
   **Workaround:** Rename the container partitions in the :file:`pm.yml` and :file:`pm_static.yml` files to something that does not match the child images' names, and rename the child images' main image partition to its name in :file:`CMakeLists.txt`.
 
+.. rst-class:: v1-3-2 v1-3-1 v1-3-0
+
+Missing :file:`CMakeLists.txt`
+  The :file:`CMakeLists.txt` file for developing applications that emulate nRF52820 on the nRF52833 DK is missing.
+
+  **Affected platforms:** nRF52833, nRF52820
+
+  **Workaround:** Create a :file:`CMakeLists.txt` file in the :file:`ncs/zephyr/boards/arm/nrf52833dk_nrf52820` folder with the following content:
+
+  .. parsed-literal::
+    :class: highlight
+
+    zephyr_compile_definitions(DEVELOP_IN_NRF52833)
+    zephyr_compile_definitions(NRFX_COREDEP_DELAY_US_LOOP_CYCLES=3)
+
+  You can `download this file <nRF52820 CMakeLists.txt_>`_ from the upstream Zephyr repository.
+  After you add it, the file is automatically included by the build system.
+
+
+Bootloader
+==========
+
+The issues in this section are related to :ref:`Bootloaders <app_bootloaders>`.
+
+.. rst-class:: v2-3-0
+
+SHEL-1352: Incorrect base address used in the OTP TX trim coefficients
+  Incorrect base address used for TX trim coefficients in the One-Time Programmable (OTP) memory results in transmit power deviating by +/- 2 dB from the target value.
+
+  **Affected platforms:** nRF7002
+
+.. rst-class:: v2-2-0
+
+NCSDK-18376: P-GPS in external flash fails to inject first prediction during load sequence
+  When using external flash with P-GPS, stored predictions cannot be reliably read to satisfy the modem's need for ephemeris data when actively downloading and storing predictions to the same external flash.
+  Once the download is complete, the predictions can be reliably read.
+
+  **Affected platforms:** nRF9160
+
+.. rst-class:: v1-1-0
+
+Public keys revocation
+  Public keys are not revoked when subsequent keys are used.
+
+.. rst-class:: v1-1-0
+
+Incompatibility with nRF51
+  The bootloader does not work properly on nRF51.
+
+  **Affected platforms:** nRF51 Series
+
+.. rst-class:: v1-2-1 v1-2-0 v1-1-0 v1-0-0 v0-4-0 v0-3-0
+
+Immutable bootloader not supported in SES
+  Building and programming the immutable bootloader (see :ref:`ug_bootloader`) is not supported in SEGGER Embedded Studio.
+
+.. rst-class:: v1-2-1 v1-2-0 v1-1-0 v1-0-0 v0-4-0 v0-3-0
+
+Immutable bootloader board restrictions
+  The immutable bootloader can only be used with the following boards:
+
+  * ``nrf52840_pca10056``
+  * ``nrf9160_pca10090``
+
+.. rst-class:: v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0
+
+nRF Secure Immutable Bootloader and netboot can overwrite non-OTP provisioning data
+  In architectures that do not have OTP regions, b0 and b0n images incorrectly linked to the size of their container can overwrite provisioning partition data from their image sizes.
+  Issue related to NCSDK-7982.
+
+.. rst-class:: v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0
+
+The combination of nRF Secure Immutable Bootloader and MCUboot fails to upgrade both the application and MCUboot
+  Due to a change in dependency handling in MCUboot, MCUboot does not read any update as a valid update.
+  Issue related to NCSDK-8681.
+
+.. rst-class:: v1-4-2 v1-4-1 v1-4-0
+
+NRF91-989: Unable to bootstrap after changing SIMs
+  In some cases, swapping the SIM card might trigger the bootstrap Pre-Shared Key to be deleted from the device.
+  This can prevent future bootstraps from succeeding.
+
+  **Affected platforms:** nRF9160
+
 DFU and FOTA
 ============
+
+The issues in this section are related to :ref:`Device Firmware Updates <app_bootloaders>`.
+
+.. rst-class:: v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0
+
+CIA-738: FMFU does not use external flash partitions
+  Full modem FOTA support assumes full control of the external flash; it does not use an external flash partition.
+  It cannot be combined with other usages, such as storing settings or P-GPS data.
+
+  **Affected platforms:** nRF9160
 
 .. rst-class:: v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0
 
 NCSDK-18357: Serial recovery does not work on nRF5340 network core
   If a network core serial recovery is attempted using MCUboot serial recovery, the upload will complete, but the image will not be transferred to the network core and the upgrade will fail.
+
+  **Affected platforms:** nRF5340
 
 .. rst-class:: v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0
 
@@ -2088,10 +2292,20 @@ NCSDK-11308: Powering off device immediately after serial recovery of the nRF53 
   The network core will not be able to boot if the device is powered off too soon after completing a serial recovery update procedure of the network core firmware.
   This is because the firmware is being copied from shared RAM to network core flash **after** mcumgr indicates that the serial recovery procedure has completed.
 
+  **Affected platforms:** nRF5340
   **Workaround:** Use one of the following workarounds:
 
   * Wait for 30 seconds before powering off the device after performing serial recovery of the nRF53 network core firmware.
   * Re-upload the network core firmware with a new serial recovery procedure if the device was powered off too soon in a previous procedure.
+
+.. rst-class:: v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0
+
+NCSDK-11432: DFU: Erasing secondary slot returns error response
+  Trying to erase secondary slot results in an error response.
+  Slot is still erased.
+  This issue is only occurring when the application is compiled for multi-image.
+
+  **Affected platforms:** nRF5340
 
 .. rst-class:: v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0
 
@@ -2142,113 +2356,33 @@ FW upgrade is broken for multi-image builds
 
   **Workaround:** Build MCUboot and the application separately.
 
-Enhanced ShockBurst (ESB)
-=========================
+Logging
+=======
 
-.. rst-class:: v2-3-0 v2-2-0
+.. rst-class:: v2-3-0
 
-NCSDK-20092: ESB does not send packet longer than 63 bytes
-  ESB does not support sending packets longer than 63 bytes, but has no such hardware limitation.
+CIA-892: Assert or crash when printing long strings with the ``%s`` qualifier
+  When logging a string with the ``%s`` qualifier, the maximum length of any inserted string is 1022 bytes.
+  If the string is longer, an assert or a crash can occur.
+  Given that the default value of the :kconfig:option:`CONFIG_LOG_PRINTK` Kconfig option has been changed from ``n`` to ``y`` in the |NCS| v2.3.0 release, the :c:func:`printk` function may also cause this issue, unless the application disables this option.
 
-NFC
-===
+  **Workaround:** To fix the issue, cherry-pick commits from the upstream `Zephyr PR #54901 <https://github.com/zephyrproject-rtos/zephyr/pull/54901>`_.
 
-.. rst-class:: v2-2-0
+.. rst-class:: v1-2-0 v1-1-0 v1-0-0 v0-4-0 v0-3-0
 
-NCSDK-19168: The :ref:`peripheral_nfc_pairing` and :ref:`central_nfc_pairing` samples cannot pair using OOB data.
-  The :ref:`nfc_ndef_ch_rec_parser_readme` library parses AC records in an invalid way.
-  As a result, the samples cannot parse OOB data for pairing.
+Problems with RTT Viewer/Logger
+  The SEGGER Control Block cannot be found by automatic search by the RTT Viewer/Logger.
 
-  **Workaround:** Revert the :file:`subsys/nfc/ndef/ch_record_parser.c` file to the state from the :ref:`ncs_release_notes_210`.
+  **Affected platforms:** nRF9160
 
-  .. code-block::
+  **Workaround:** Set the RTT Control Block address to 0 and it will try to search from address 0 and upwards.
+  If this does not work, look in the :file:`builddir/zephyr/zephyr.map` file to find the address of the ``_SEGGER_RTT`` symbol in the map file and use that as input to the viewer/logger.
 
-     cd <NCS_root_directory>
-     git checkout v2.1.0 -- subsys/nfc/ndef/ch_record_parser.c
-
-.. rst-class:: v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0
-
-NCSDK-19347: NFC Reader samples return false errors with value ``1``.
-  The :c:func:`nfc_t4t_isodep_transmit` function of the :ref:`nfc_t4t_isodep_readme` library can return ``1`` as error code even if a delayed operation has been scheduled correctly and should return ``0``.
-  This happens when the ISO-DEP frame is sent for the first time.
-  In samples, this error is propagated from the higher level :c:func:`nfc_t4t_hl_procedure_ndef_tag_app_select` function.
-  The :ref:`tnep_poller_readme` library operations can call the application error callback with error code ``1``, meaning that a delayed operation has been scheduled successfully.
-
-  **Workaround:** Ignore the :ref:`tnep_poller_readme` error callback with error value ``1``.
-  Treat the return value ``1`` of the functions :c:func:`nfc_t4t_isodep_transmit` and :c:func:`nfc_t4t_hl_procedure_ndef_tag_app_select` as success.
-
-.. rst-class:: v1-2-1 v1-2-0
-
-Sample incompatibility with the nRF5340 PDK
-  The :ref:`nfc_tnep_poller` and :ref:`nfc_tag_reader` samples cannot be run on the nRF5340 PDK.
-  There is an incorrect number of pins defined in the MDK files, and the pins required for :ref:`st25r3911b_nfc_readme` cannot be configured properly.
-
-.. rst-class:: v1-2-1 v1-2-0 v1-1-0
-
-Unstable NFC tag samples
-  NFC tag samples are unstable when exhaustively tested (performing many repeated read and/or write operations).
-  NFC tag data might be corrupted.
-
-nRF Profiler
-============
-
-.. rst-class:: v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0
-
-NCSDK-18398: Build fails if shell is enabled
-   Enabling the Zephyr's :ref:`zephyr:shell_api` module together with :ref:`nrf_profiler` results in a build failure because of the bug in the :file:`CMakeLists.txt` file.
-
-   **Workaround:** Manually cherry-pick and apply the commit with the fix from the ``main`` branch (commit hash: ``fdac428e902ebd96885160dd3ae5d08d21642926``).
-
-Secure Partition Manager (SPM)
-==============================
-
-.. note::
-    The Secure Partition Manager (SPM) is deprecated as of |NCS| v2.1.0 and removed after |NCS| v2.2.0. It is replaced by :ref:`Trusted Firmware-M (TF-M) <ug_tfm>`.
-
-.. rst-class:: v2-2-0
-
-NCSDK-19156: Building SPM for other boards than ``nrf5340dk_nrf5340_cpuapp`` and ``nrf9160dk_nrf9160`` fails with compilation error in cortex_m_systick.c
-  This happens because the :kconfig:option:`CONFIG_CORTEX_M_SYSTICK` configuration option is enabled while the systick node is disabled in the devicetree.
-
-  **Workaround** Enable the systick node in a DTS overlay file for the SPM build by completing the following steps:
-
-  1. Create an overlay file :file:`systick_enabled.overlay` with the following content:
-
-     .. code-block::
-
-        &systick {
-          status = "okay";
-        };
-
-  #. Add the overlay file as a build argument to SPM:
-
-     .. parsed-literal::
-       :class: highlight
-
-       west build -- -Dspm_DTC_OVERLAY_FILE=systick_enabled.overlay
-
-.. rst-class:: v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0
-
-NCSIDB-114: Default logging causes crash
-  Enabling default logging in the Secure Partition Manager sample makes it crash if the sample logs any data after the application has booted (for example, during a SecureFault, or in a secure service).
-  At that point, RTC1 and UARTE0 are non-secure.
-
-  **Workaround:** Do not enable logging and add a breakpoint in the fault handling, or try a different logging backend.
-
-.. rst-class:: v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0
-
-NCSDK-8232: Secure Partition Manager and application building together
-  It is not possible to build and program Secure Partition Manager and the application individually.
-
-.. rst-class:: v1-5-2 v1-5-1 v1-5-0
-
-CIA-248: Samples with default SPM config fails to build for ``thingy91_nrf9160_ns``
-   All samples using the default SPM config fails to build for the ``thingy91_nrf9160_ns``  build target if the sample is not set up with MCUboot.
-
-   **Workaround:** Use the main branch.
 
 MCUboot
 *******
+
+The issues in this section are related to :ref:`MCUboot <mcuboot_wrapper>`.
 
 .. rst-class:: v2-0-2 v2-0-1 v2-0-0
 
@@ -2265,6 +2399,8 @@ Recovery with the USB does not work
 nrfxlib
 *******
 
+The issues in this section are related to components provided in :ref:`nrfxlib`.
+
 Crypto
 ======
 .. rst-class:: v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0
@@ -2278,10 +2414,21 @@ NCSDK-20688: For ChaCha-Poly, incorrect tag will be produced if plaintext is emp
 NCSDK-20688: For AES GCM, calling :c:func:`psa_aead_update_ad` multiple times will result in an incorrect tag on CryptoCell
   It is only supported to feed the additional data for AES GCM once using the CryptoCell backend.
 
+The issues in this section are related to :ref:`nrfxlib:crypto`.
+
 .. rst-class:: v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0
 
 NCSDK-20287: Using AES GCM with other nonce sizes than 12 bytes will produce an incorrect tag on CryptoCell
   Both PSA Crypto and legacy Mbed TLS APIs are affected.
+
+.. rst-class:: v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0
+
+NCSDK-8075: Invalid initialization of ``mbedtls_entropy_context`` mutex type
+  The calls to :cpp:func:`mbedtls_entropy_init` do not zero-initialize the member variable ``mutex`` when ``nrf_cc3xx`` is enabled.
+
+  **Affected platforms:** nRF9160
+
+  **Workaround:** Zero-initialize the structure type before using it or make it a static variable to ensure that it is zero-initialized.
 
 .. rst-class:: v2-0-2 v2-0-1 v2-0-0
 
@@ -2324,6 +2471,36 @@ NCSDK-13844: Limited support for GCM in PSA Crypto APIs in Oberon
 NCSDK-13900: Limited AES CBC PKCS7 support in PSA Crypto APIs
   The provided implementation in the CryptoCell accelerator for AES CBC with PKCS7 padding does not support multipart APIs.
 
+.. rst-class:: v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0
+
+NCSDK-11684: Failure loading KMU registers on nRF9160 devices
+  Certain builds will experience problems loading HUK to KMU due to a bug in nrf_cc3xx_platform library prior to version 0.9.12.
+  The problem arises in certain builds depending on alignment of code.
+  The reason for the issue is improper handling of PAN 7 on nRF9160 devices.
+
+  **Affected platforms:** nRF9160
+
+  **Workaround:** Update to nrf_cc3xx_platform/nrf_cc3xx_mbedcrypto v0.9.12 or newer versions if KMU is needed.
+
+.. rst-class:: v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0
+
+NCSDK-7856: Faulty indirection on ``nrf_cc3xx`` memory slab when freeing the platform mutex
+  The :cpp:func:`mutex_free_platform` function has a bug where a call to :cpp:func:`k_mem_slab_free` provides wrong indirection on a parameter to free the platform mutex.
+
+  **Affected platforms:** nRF9160
+
+  **Workaround:** Write the call to free the mutex in the following way: ``k_mem_slab_free(&mutex_slab, &mutex->mutex)``.
+  The change adds ``&`` before the parameter ``mutex->mutex``.
+
+.. rst-class:: v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0
+
+NCSDK-7914: The ``nrf_cc3xx`` RSA implementation does not deduce missing parameters
+  The calls to :cpp:func:`mbedtls_rsa_complete` will not deduce all types of missing RSA parameters when using ``nrf_cc3xx`` v0.9.6 or earlier.
+
+  **Affected platforms:** nRF9160
+
+  **Workaround:** Calculate the missing parameters outside of this function or update to ``nrf_cc3xx`` v0.9.7 or later.
+
 .. rst-class:: v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0
 
 NCSDK-5883: CMAC behavior issues
@@ -2343,6 +2520,8 @@ NCSDK-5546: Oberon missing symbols for HKDF
 Limited support for Nordic Security Module
   The :ref:`nrfxlib:nrf_security` is currently only fully supported on nRF52840 and nRF9160 devices.
   It gives compile errors on nRF52832, nRF52833, nRF52820, nRF52811, and nRF52810.
+
+  **Affected platforms:** nRF52832, nRF52833, nRF52820, nRF52811, nRF52810
 
   **Workaround:** To fix the errors, cherry-pick commits in `nrfxlib PR #205 <https://github.com/nrfconnect/sdk-nrfxlib/pull/205>`_.
 
@@ -2377,8 +2556,19 @@ Closing sockets
   Moreover, closing a socket does not properly clean up all memory resources.
   If a socket is opened and closed multiple times, this might starve the system.
 
-Modem Library
+Modem library
 =============
+
+The issues in this section are related to :ref:`nrfxlib:nrf_modem`.
+
+.. rst-class:: v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0
+
+NCSDK-10106: Elevated current consumption when using applications without :ref:`nrfxlib:nrf_modem` on nRF9160
+  When running applications that do not enable :ref:`nrfxlib:nrf_modem` on nRF9160 with build code B1A, current consumption will stay at 3 mA when in sleep.
+
+  **Affected platforms:** nRF9160
+
+  **Workaround:** Enable :ref:`nrfxlib:nrf_modem`.
 
 .. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0
 
@@ -2390,8 +2580,20 @@ NCSDK-14312: The :c:func:`nrf_recv` function crashes occasionally
 NCSDK-13360: The :c:func:`nrf_recv` function crashes if closed by another thread while receiving data
   When calling the :c:func:`nrf_recv` function, closing the socket from another thread while it is receiving data causes a crash.
 
+.. rst-class:: v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0
+
+NCSDK-6073: ``nrf_send`` is blocking
+  The :cpp:func:`nrf_send` function in the :ref:`nrfxlib:nrf_modem` might be blocking for several minutes, even if the socket is configured for non-blocking operation.
+  The behavior depends on the cellular network connection.
+
+  **Affected platforms:** nRF9160
+
+  **Workaround:** For |NCS| v1.4.0, set the non-blocking mode for a partial workaround for non-blocking operation.
+
 Multiprotocol Service Layer (MPSL)
 ==================================
+
+The issues in this section are related to :ref:`nrfxlib:mpsl`.
 
 .. rst-class:: v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0
 
@@ -2416,6 +2618,8 @@ DRGN-14153: Radio Notification power performance penalty
 KRKNWK-8842: MPSL does not support nRF21540 revision 1 or older
   The nRF21540 revision 1 or older is not supported by MPSL.
   This also applies to kits that contain this device.
+
+  **Affected platforms:** nRF21540
 
   **Workaround:** Check the `Nordic Semiconductor website`_ for the latest information on availability of the product version of nRF21540.
 
@@ -2462,6 +2666,8 @@ DRGN-16506: Higher current consumption between timeslot events made with :c:macr
 DRGN-15223: :kconfig:option:`CONFIG_SYSTEM_CLOCK_NO_WAIT` is not supported for nRF5340
   Using :kconfig:option:`CONFIG_SYSTEM_CLOCK_NO_WAIT` with nRF5340 devices might not work as expected.
 
+  **Affected platforms:** nRF5340
+
 .. rst-class:: v1-4-2 v1-4-1
 
 DRGN-15176: :kconfig:option:`CONFIG_SYSTEM_CLOCK_NO_WAIT` is ignored when Low Frequency Clock is started before initializing MPSL
@@ -2485,6 +2691,7 @@ DRGN-11059: Front-end module API not implemented for SoftDevice Controller
 802.15.4 Radio driver
 =====================
 
+The issues in this section are related to :ref:`nrfxlib:nrf_802154`.
 In addition to the known issues listed here, see also :ref:`802.15.4 Radio driver limitations <nrf_802154_limitations>` for permanent limitations.
 
 .. rst-class:: v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0
@@ -2492,6 +2699,8 @@ In addition to the known issues listed here, see also :ref:`802.15.4 Radio drive
 KRKNWK-14950: MPSL asserts during operation with heavy load
   An operation under heavy load can end with a crash, with the MPSL message ``ASSERT: 108, 659``.
   This issue was observed very rarely during stress tests on the devices from the nRF53 and nRF52 Series.
+
+  **Affected platforms:** nRF5340, Thingy:53, nRF52832, nRF52833, nRF52840
 
 .. rst-class:: v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0
 
@@ -2505,6 +2714,14 @@ KRKNWK-11384: Assertion with Bluetooth® LE and multiprotocol usage
 
 .. rst-class:: v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0
 
+KRKNWK-6756: 802.15.4 Service Layer (SL) library support for the nRF53
+  The binary variant of the 802.15.4 Service Layer (SL) library for the nRF53 does not support such features as synchronization of **TIMER** with **RTC** or timestamping of received frames.
+  For this reason, 802.15.4 features like delayed transmission or delayed reception are not available for the nRF53.
+
+  **Affected platforms:** nRF5340
+
+.. rst-class:: v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0
+
 KRKNWK-8133: CSMA-CA issues
   Using CSMA-CA with the open-source variant of the 802.15.4 Service Layer (SL) library causes an assertion fault.
   CSMA-CA support is currently not available in the open-source SL library.
@@ -2515,11 +2732,14 @@ KRKNWK-6255: RSSI parameter adjustment is not applied
   The RADIO: RSSI parameter adjustment errata (153 for nRF52840, 225 for nRF52833 and nRF52820, 87 for nRF5340) are not applied for RSSI, LQI, Energy Detection, and CCA values used by the 802.15.4 protocol.
   There is an expected offset up to +/- 6 dB in extreme temperatures of values based on RSSI measurement.
 
+  **Affected platforms:** nRF5340, nRF52840, nRF52833, nRF52820
+
   **Workaround:** To apply RSSI parameter adjustments, cherry-pick the commits in `hal_nordic PR #88 <https://github.com/zephyrproject-rtos/hal_nordic/pull/88>`_, `sdk-nrfxlib PR #381 <https://github.com/nrfconnect/sdk-nrfxlib/pull/381>`_, and `sdk-zephyr PR #430 <https://github.com/nrfconnect/sdk-zephyr/pull/430>`_.
 
 SoftDevice Controller
 =====================
 
+The issues in this section are related to :ref:`nrfxlib:softdevice_controller`.
 In addition to the known issues listed here, see also :ref:`softdevice_controller_limitations` for permanent limitations.
 
 .. rst-class:: v2-3-0
@@ -2665,6 +2885,8 @@ DRGN-16859: The vendor-specific HCI commands Zephyr Write TX Power Level and Zep
 DRGN-16808: Assertion on nRF53 Series devices when the RC oscillator is used as the Low Frequency clock source
   The SoftDevice Controller might assert when :kconfig:option:`CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC` is set on nRF53 Series devices and the device is connected as a peripheral.
 
+  **Affected platforms:** nRF5340, Thingy:53
+
   **Workaround:** Do not use the RC oscillator as the Low Frequency clock source.
 
 .. rst-class:: v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0
@@ -2702,6 +2924,8 @@ DRGN-16341: The SoftDevice Controller might discard LE Extended Advertising Repo
 DRGN-16113: Active scanner assert when performing extended scanning
   The active scanner might assert when performing extended scanning on Coded PHY with a full whitelist.
 
+  **Affected platforms:** nRF5340, Thingy:53, nRF52840, nRF52833, nRF52832
+
   **Workaround:** On nRF52 Series devices, do not use coex and fem. On nRF53 series devices, do not use CODED PHY.
 
 .. rst-class:: v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0
@@ -2726,6 +2950,8 @@ DRGN-15852: In rare cases on nRF53 Series devices, an assert can occur while sca
   This only occurs when the host started scanning using HCI LE Set Scan Enable.
   This is default configuration of the Bluetooth® host.
 
+  **Affected platforms:** nRF5340, Thingy:53
+
   **Workaround:** Use extended scanning commands.
   That is, set :kconfig:option:`CONFIG_BT_EXT_ADV` to use HCI LE Set Extended Scan Enable instead.
 
@@ -2739,6 +2965,8 @@ DRGN-15852: In rare cases on nRF53 Series, the scanner generates corrupted adver
   * Direct_Address_Type
   * TX_Power
   * Advertising_SID
+
+  **Affected platforms:** nRF5340, Thingy:53
 
 .. rst-class:: v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0
 
@@ -2850,6 +3078,8 @@ DRGN-15475: Samples might not initialize the SoftDevice Controller HCI driver co
 DRGN-15382: The SoftDevice Controller cannot be qualified on nRF52832
   The SoftDevice Controller cannot be qualified on nRF52832.
 
+  **Affected platforms:** nRF52832
+
   **Workaround:** Upgrade to v1.5.1 or use the main branch.
 
 .. rst-class:: v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0
@@ -2943,6 +3173,8 @@ Several issues for nRF5340
     This issue can only occur when sending a packet on either LE 1M or LE 2M PHY after receiving or transmitting a packet on LE Coded PHY.
     If this occurs while performing a Link Layer Control Procedure, the controller could end up retransmitting an acknowledged packet, resulting in a disconnect.
 
+  **Affected platforms:** nRF5340
+
 .. rst-class:: v1-1-0 v1-0-0
 
 Sending control packet twice
@@ -2995,6 +3227,8 @@ Timeout without sending packet
 nrfx
 ****
 
+The issues in this section are related to drivers provided in nrfx.
+
 MDK
 ===
 
@@ -3002,6 +3236,8 @@ MDK
 
 Incorrect pin definition for nRF5340
   For nRF5340, the pins **P1.12** to **P1.15** are unavailable due to an incorrect pin number definition in the MDK.
+
+  **Affected platforms:** nRF5340
 
 nrfx_saadc driver
 =================
@@ -3028,10 +3264,33 @@ nrfx_uart driver
 tx_buffer_length set incorrectly
   The nrfx_uart driver might incorrectly set the internal tx_buffer_length variable when high optimization level is set during compilation.
 
+Integrations
+************
+
+The issues in this section are related to :ref:`integrations`.
+
+Pelion
+======
+
+The issues in this section are related to Pelion Device Management integration.
+The support for Pelion Device Management and the related library and application were removed in :ref:`nRF Connect SDK v1.9.0 <ncs_release_notes_190>`.
+
+.. rst-class:: v1-6-1 v1-6-0
+
+NCSDK-10196: DFU fails for some configurations with the quick session resume feature enabled
+  Enabling :kconfig:option:`CONFIG_PELION_QUICK_SESSION_RESUME` together with the OpenThread network backend leads to the quick session resume failure during the DFU packet exchange.
+  This is valid for the :ref:`nRF52840 DK <ug_nrf52>` and the :ref:`nRF5340 DK <ug_nrf5340>`.
+
+  **Affected platforms:** nRF5340, nRF52840
+
+  **Workaround:** Use the quick session resume feature only for configurations with the cellular network backend.
+
 .. _known_issue_tfm:
 
 Trusted Firmware-M (TF-M)
 *************************
+
+The issues in this section are related to the TF-M implementation in the |NCS|.
 
 .. rst-class:: v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0
 
@@ -3105,6 +3364,8 @@ TF-M is not supported for Thingy:91 v1.5.0 and lower versions
   TF-M is compatible with all versions of the Thingy:91 if you first upgrade the bootloader using an external debug probe.
   Additionally, TF-M functions while using the bootloader to upgrade the firmware if you upgrade the bootloader to |NCS| v2.0.0.
 
+  **Affected platforms:** Thingy:91
+
 .. rst-class:: v2-0-2 v2-0-1 v2-0-0
 
 NCSDK-15382: TF-M uses more RAM compared to SPM in the minimal configuration
@@ -3151,6 +3412,8 @@ NCSDK-11195: Build errors when enabling :kconfig:option:`CONFIG_BUILD_WITH_TFM` 
 NCSDK-12306: Enabling debug configuration causes usage fault on nRF9160
   When the debug configuration :kconfig:option:`CONFIG_TFM_CMAKE_BUILD_TYPE_DEBUG` is enabled, a usage fault is triggered during boot on nRF9160.
 
+  **Affected platforms:** nRF9160
+
 .. rst-class:: v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0
 
 NCSDK-14590: Usage fault in interrupt handlers when using FPU extensions
@@ -3181,6 +3444,8 @@ NCSDK-14015: Execution halts during boot
   When the :kconfig:option:`CONFIG_RPMSG_SERVICE` is enabled on the nRF5340 SoC together with TF-M, the firmware does not boot.
   This option is used by OpenThread and Bluetooth modules.
 
+  **Affected platforms:** nRF5340
+
   **Workaround:** Place the ``rpmsg_nrf53_sram`` partition inside the ``sram_nonsecure`` partition using :ref:`partition_manager`.
 
 .. rst-class:: v1-9-0
@@ -3188,37 +3453,12 @@ NCSDK-14015: Execution halts during boot
 NCSDK-13949: TF-M Secure Image copies FICR to RAM on nRF9160
   TF-M Secure Image copies the FICR to RAM address between ``0x2003E000`` and ``0x2003F000`` during boot on nRF9160.
 
-Samples
-*******
-
-.. rst-class:: v2-3-0
-
-NCSDK-20046: IPC service sample does not work with ``nrf5340dk_nrf5340_cpuapp``
-  The :ref:`ipc_service_sample` sample does not work with the ``nrf5340dk_nrf5340_cpuapp`` :ref:`build target <app_boards_names_zephyr>` due to a misconfiguration.
-  The application core does not log anything, while the network core seems to work and bond, but cannot transfer data.
-  When using UART, there is no output visible.
-
-.. rst-class:: v2-2-0
-
-NCSDK-18847: :ref:`radio_test` sample does not build with support for Skyworks front-end module
-  When building a sample with support for a front-end module different from nRF21540, the sample uses a non-existing configuration to initialize TX power data.
-  This causes a compilation error because the source file containing code for a generic front-end module is not included in the build.
-
-  **Workaround:** Do not use the :kconfig:option:`CONFIG_RADIO_TEST_POWER_CONTROL_AUTOMATIC` Kconfig option and replace ``CONFIG_GENERIC_FEM`` with ``CONFIG_MPSL_FEM_SIMPLE_GPIO`` in the :file:`CMakeLists.txt` file of the sample.
-
-.. rst-class:: v2-3-0
-
-NCSDK-19858: :ref:`at_monitor_readme` library and :ref:`nrf_cloud_mqtt_multi_service` sample heap overrun
-  Occasionally, the :ref:`at_monitor_readme` library heap becomes overrun, presumably due to one of the registered AT event listeners becoming stalled.
-  This has only been observed with the :ref:`nrf_cloud_mqtt_multi_service` sample.
-
-.. rst-class:: v2-3-0 v2-2-0
-
-NCSDK-20095: Build warning in the RF test samples when the minimal pinout generic/Skyworks FEM is used
-  The :ref:`radio_test` and :ref:`direct_test_mode` samples build with a warning about generic/Skyworks FEM in minimal pinout configuration.
+  **Affected platforms:** nRF9160
 
 Zephyr
 ******
+
+The issues in this section are related to the Zephyr downstream in the |NCS|.
 
 .. rst-class:: v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0
 
@@ -3227,6 +3467,8 @@ NCSDK-20104: MCUboot configuration can prevent application from being able to ru
   The intention is that the application that gets booted clears this region.
   If the user application's startup variables reside in this memory location, the application will stop with a fault and be unable to start.
   This issue replaces the issue NCSDK-18426, which mentioned a fault in the firmware when using RTT on nRF52 Series devices.
+
+  **Affected platforms:** nRF52840, nRF52833, nRF52830, nRF52820
 
   **Workaround:** Enable :kconfig:option:`CONFIG_MCUBOOT_CLEANUP_ARM_CORE`` in MCUboot configuration.
 
@@ -3265,6 +3507,13 @@ NCSDK-6328: USB CDC ACM Composite Sample Application fails Chapter 9 Tests from 
 NCSDK-6331: WebUSB sample application fails Chapter 9 Tests from USB3CV test tool
   :ref:`zephyr:webusb-sample` fails the USB3CV compliance TD 9.21: LPM L1 Suspend Resume Test from the Chapter 9 Test suite.
 
+.. rst-class:: v1-3-2 v1-3-1 v1-3-0
+
+FOTA does not work
+  FOTA with the :ref:`zephyr:smp_svr_sample` does not work.
+
+  **Affected platforms:** nRF5340
+
 .. rst-class:: v1-3-1 v1-3-0
 
 NCSIDB-108: Thread context switch might lead to a kernel fault
@@ -3290,12 +3539,37 @@ NCSDK-6832: SMP Server sample fails upon initialization
 
   **Workaround:** Set :kconfig:option:`CONFIG_MAIN_STACK_SIZE` to ``2048``.
 
+.. _known_issues_other:
+
+Other issues
+************
+
+.. rst-class:: v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0
+
+Receive error with large packets
+  nRF9160 fails to receive large packets (over 4000 bytes).
+
+  **Affected platforms:** nRF9160
+
+.. rst-class:: v1-2-0 v1-1-0 v1-0-0
+
+Calling ``nrf_connect()`` immediately causes fail
+  ``nrf_connect()`` fails if called immediately after initialization of the device.
+  A delay of 1000 ms is required for this to work as intended.
+
+  **Affected platforms:** nRF9160
+
+Known issues for deprecated components
+**************************************
+
+This section lists known issues for components that have been deprecated during the |NCS| development.
+These issues are visible for older releases.
+
 SEGGER Embedded Studio Nordic Edition
-*************************************
+=====================================
 
 .. note::
-    SEGGER Embedded Studio Nordic Edition support has been deprecated with the |NCS| v2.0.0 release.
-    |VSC| is now the default IDE for the |NCS|.
+    SEGGER Embedded Studio Nordic Edition support has been deprecated with the |NCS| v2.0.0 release and |VSC| is now the default IDE for the |NCS|.
     Use the `Open an existing application <Migrating IDE_>`_ option in the |nRFVSC| to migrate your application.
 
 .. rst-class:: v1-4-2 v1-4-1 v1-4-0
@@ -3324,6 +3598,58 @@ NCSDK-9992: Multiple extra CMake options applied as single option
   For example: ``-DFOO=foo -DBAR=bar`` will define the CMake variable ``FOO`` having the value ``foo -DBAR=bar``.
 
   **Workaround:** Create a CMake preload script containing ``FOO`` and ``BAR`` settings, and then specify ``-C <pre-load-script>.cmake`` in :guilabel:`Extra CMake Build Options`.
+
+Secure Partition Manager (SPM)
+==============================
+
+.. note::
+    The Secure Partition Manager (SPM) is deprecated as of |NCS| v2.1.0 and removed after |NCS| v2.2.0. It is replaced by :ref:`Trusted Firmware-M (TF-M) <ug_tfm>`.
+
+.. rst-class:: v2-2-0
+
+NCSDK-19156: Building SPM for other boards than ``nrf5340dk_nrf5340_cpuapp`` and ``nrf9160dk_nrf9160`` fails with compilation error in :file:`cortex_m_systick.c`
+  This happens because the :kconfig:option:`CONFIG_CORTEX_M_SYSTICK` configuration option is enabled while the systick node is disabled in the devicetree.
+
+  **Affected platforms:** nRF9160, nRF5340
+
+  **Workaround:** Enable the systick node in a DTS overlay file for the SPM build by completing the following steps:
+
+  1. Create an overlay file :file:`systick_enabled.overlay` with the following content:
+
+     .. code-block::
+
+        &systick {
+          status = "okay";
+        };
+
+  #. Add the overlay file as a build argument to SPM:
+
+     .. parsed-literal::
+       :class: highlight
+
+       west build -- -Dspm_DTC_OVERLAY_FILE=systick_enabled.overlay
+
+.. rst-class:: v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0
+
+NCSIDB-114: Default logging causes crash
+  Enabling default logging in the Secure Partition Manager sample makes it crash if the sample logs any data after the application has booted (for example, during a SecureFault, or in a secure service).
+  At that point, RTC1 and UARTE0 are non-secure.
+
+  **Workaround:** Do not enable logging and add a breakpoint in the fault handling, or try a different logging backend.
+
+.. rst-class:: v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0
+
+NCSDK-8232: Secure Partition Manager and application building together
+  It is not possible to build and program Secure Partition Manager and the application individually.
+
+.. rst-class:: v1-5-2 v1-5-1 v1-5-0
+
+CIA-248: Samples with default SPM config fails to build for ``thingy91_nrf9160_ns``
+   All samples using the default SPM config fails to build for the ``thingy91_nrf9160_ns``  build target if the sample is not set up with MCUboot.
+
+   **Affected platforms:** Thingy:91
+
+   **Workaround:** Use the main branch.
 
 Zephyr repository issues
 ************************

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -716,6 +716,9 @@ Documentation
 
 Updated:
 
+  * The structure of sections on the :ref:`known_issues` page.
+    Known issues were moved around, but no changes were made to their description.
+    The hardware-only sections were removed and replaced by the "Affected platforms" list.
   * The :ref:`software_maturity` page with details about Bluetooth feature support.
   * The :ref:`ug_nrf5340_gs`, :ref:`ug_thingy53_gs`, :ref:`ug_nrf52_gs`, and :ref:`ug_ble_controller` pages with a link to the `Bluetooth LE Fundamentals course`_ in the `Nordic Developer Academy`_.
   * The :ref:`zigbee_weather_station_app` documentation to match the application template.


### PR DESCRIPTION
Edited structure of known issues to mirror code and doc structure. Removed hardware sections, including the "catch-them-all" nRF5 section. Added "Affected platforms" instead. This makes the page ready for the upcoming devices.
NCSDK-19202.

----

Quick summary:

- hardware sections are gone -- Issues that I couldn't pinpoint to a SW section are now placed in "Other issues"
- "Affected platforms" are in -- These are added to all known issues that mention one or more specific platform in the description (or are located in a platform-specific area, like nRF9160 samples). Adding this list to sections that are already specific to a platform is an overkill now, but once we start moving samples to new platforms, the issues might not carry over to the new devices, hence I think it makes sense to add them now.

If something is incorrectly placed, we can fix that _also_ during the usual pre-release review, so I would suggest getting this in after fixing major issues rather than working on every detail.

----

Rendered docs: https://developer.nordicsemi.com/nRF_Connect_SDK_dev/doc/PR-11104/nrf/known_issues.html