### PR TITLE
manifest: mesh upstream fixes for experimental mesh 1.1 features.

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: c2859f736bfc959b91cca472ba32563afccea0bc
+      revision: d80d5a5866cf09fd534ad2bc18979c0656c88597
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Updating sdk-zephyr revision for mesh 1.1 fixes from upstream.