### PR TITLE
doc: known_issues: CMake 3.25 fail TF-M arch tests

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -3033,6 +3033,14 @@ tx_buffer_length set incorrectly
 Trusted Firmware-M (TF-M)
 *************************
 
+.. rst-class:: v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0
+
+NCSDK-18321: TF-M PSA architecture tests do not build with CMake v3.25.x
+  The :ref:`tfm_psa_test` fails to build with CMake version 3.25.x with missing header files.
+  This happens because the CMake install command is executed before the build command with the affected CMake versions.
+
+  **Workaround:** Don't use the CMake version 3.25.x.
+
 .. rst-class:: v2-3-0
 
 NCSDK-20864: TF-M unaligned partitions when MCUboot padding and debug optimizations are enabled

--- a/tests/tfm/tfm_psa_test/CMakeLists.txt
+++ b/tests/tfm/tfm_psa_test/CMakeLists.txt
@@ -6,6 +6,11 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
+if(${CMAKE_MAJOR_VERSION} EQUAL "3" AND ${CMAKE_MINOR_VERSION} EQUAL "25")
+message(FATAL_ERROR "CMake versions 3.25.x are not compatible wth the PSA architecture tests.\n"
+                    "Use an earlier (<= 3.24.x) or later (>= 3.26.x) version of CMake.")
+endif()
+
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(tfm_psa_test)


### PR DESCRIPTION
CMake versions 3.25.x broke the build of the TF-M
architecture test. This adds a knwn issue to inform customers how to bypass this issue.

Ref: NCSDK-21320