### PR TITLE
manifest: Bring nrfxlib with CC3XX PSA fixes

### DIFF
--- a/samples/tfm/provisioning_image/README.rst
+++ b/samples/tfm/provisioning_image/README.rst
@@ -63,7 +63,7 @@ Configuration
 Building and running
 ********************
 
-.. |sample path| replace:: :file:`samples/keys/identity_key_generate`
+.. |sample path| replace:: :file:`samples/tfm/provisioning_image`
 
 .. include:: /includes/build_and_run.txt
 

--- a/west.yml
+++ b/west.yml
@@ -131,7 +131,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: ac671e8bcd994d2025aa3f4763c0742ca8dadc3e
+      revision: 37e3dd8997b3db49527c7cdcea92021ee3c0e97c
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Brings nrfxlib with a correction on the supported algorithms when CC3XX is used with PSA APIs. AES OFB is now reported as supported and the CFB is reported as not supported as it should.

Ref: NCSDK-21022
Ref: NCSDK-20664