### PR TITLE
manifest: Add basic support for DirectXIP

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: c2859f736bfc959b91cca472ba32563afccea0bc
+      revision: pull/1166/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Brings in sdk-zephyr commits that provide basic support for DirectXIP operation to MCUmgr.