### PR TITLE
wifi: Pull Wi-Fi security fixes

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -1,16 +1,16 @@
 # This is the Jenkins ci variant of the .github/labler.yaml
 
 "CI-run-twister":
- - any:
-    - "!.github/**/*"
-    - "!.vscode/**/*"
-    - "!doc/**/*"
-    - "!test-manifests/**/*"
-    - "!CODEOWNERS"
-    - "!LICENSE"
-    - "!**/*.rst"
-    - "!VERSION"
-    - "!ncs_version.h.in"
+  - any:
+      - "!.github/**/*"
+      - "!.vscode/**/*"
+      - "!doc/**/*"
+      - "!test-manifests/**/*"
+      - "!CODEOWNERS"
+      - "!LICENSE"
+      - "!**/*.rst"
+      - "!VERSION"
+      - "!ncs_version.h.in"
 
 "CI-tool-test-linux":
   - "scripts/requirements*.txt"
@@ -159,14 +159,14 @@
 
 "CI-ble-test":
   - any:
-    - "subsys/bluetooth/**/*"
-    - "!subsys/bluetooth/mesh/**/*"
+      - "subsys/bluetooth/**/*"
+      - "!subsys/bluetooth/mesh/**/*"
   - any:
-    - "include/bluetooth/**/*"
-    - "!include/bluetooth/mesh/**/*"
+      - "include/bluetooth/**/*"
+      - "!include/bluetooth/mesh/**/*"
   - any:
-    - "samples/bluetooth/**/*"
-    - "!samples/bluetooth/mesh/**/*"
+      - "samples/bluetooth/**/*"
+      - "!samples/bluetooth/mesh/**/*"
   - "subsys/nrf_rpc/**/*"
   - "subsys/mpsl/**/*"
   - "drivers/mpsl/**/*"
@@ -191,11 +191,11 @@
   - "modules/nrfxlib/nrf_802154/**/*"
   - "applications/zigbee_weather_station/**/*"
   - any:
-    - "subsys/bluetooth/**/*"
-    - "!subsys/bluetooth/mesh/**/*"
+      - "subsys/bluetooth/**/*"
+      - "!subsys/bluetooth/mesh/**/*"
   - any:
-    - "include/bluetooth/**/*"
-    - "!include/bluetooth/mesh/**/*"
+      - "include/bluetooth/**/*"
+      - "!include/bluetooth/mesh/**/*"
 
 "CI-thingy91-test":
   - "ext/cjson/**/*"
@@ -297,11 +297,11 @@
   - "subsys/nrf_rpc/**/*"
   - "subsys/partition_manager/**/*"
   - any:
-    - "subsys/bluetooth/**/*"
-    - "!subsys/bluetooth/mesh/**/*"
+      - "subsys/bluetooth/**/*"
+      - "!subsys/bluetooth/mesh/**/*"
   - any:
-    - "include/bluetooth/**/*"
-    - "!include/bluetooth/mesh/**/*"
+      - "include/bluetooth/**/*"
+      - "!include/bluetooth/mesh/**/*"
 
 "CI-thread-test":
   - "samples/openthread/**/*"
@@ -358,11 +358,11 @@
   - "subsys/partition_manager/**/*"
   - "modules/mcuboot/**/*"
   - any:
-    - "include/bluetooth/**/*"
-    - "!include/bluetooth/mesh/**/*"
+      - "include/bluetooth/**/*"
+      - "!include/bluetooth/mesh/**/*"
   - any:
-    - "subsys/bluetooth/**/*"
-    - "!subsys/bluetooth/mesh/**/*"
+      - "subsys/bluetooth/**/*"
+      - "!subsys/bluetooth/mesh/**/*"
 
 "CI-esb-test":
   - "include/esb.h"

--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -462,6 +462,7 @@
 "CI-wifi":
   - "drivers/wifi/**/*"
   - "samples/wifi/**/*"
+  - "modules/lib/hostap/**/*"
 
 "CI-cloud-test":
   - "include/net/nrf_cloud*"

--- a/west.yml
+++ b/west.yml
@@ -110,7 +110,7 @@ manifest:
     - name: hostap
       repo-path: sdk-hostap
       path: modules/lib/hostap
-      revision: 91e968deb55f4f638a780afd776fc45002078d02
+      revision: 38912c797f6f460beb4888fca133dffc294d3da3
       userdata:
         ncs:
           upstream-url: https://w1.fi/cgit/hostap/


### PR DESCRIPTION
Fixes Wi-Fi security regression due to a change in nrf-security that modifies MbedTLS HEAP usage.