### PR TITLE
samples: thread: Rename cdc_acm_uart node

### DIFF
--- a/samples/openthread/coprocessor/usb.overlay
+++ b/samples/openthread/coprocessor/usb.overlay
@@ -6,12 +6,12 @@
 
 / {
 	chosen {
-		zephyr,ot-uart = &cdc_acm_uart0;
+		zephyr,ot-uart = &cdc_acm_uart;
 	};
 };
 
 &zephyr_udc0 {
-	cdc_acm_uart0: cdc_acm_uart0 {
+	cdc_acm_uart: cdc_acm_uart {
 		compatible = "zephyr,cdc-acm-uart";
 	};
 };


### PR DESCRIPTION
This commit renames cdc_acm_uart0 node to cdc_acm_uart to accommodate to changes in nrf52840 dongle board - cdc_acm_uart node is added by default.
Align with commit: https://github.com/nrfconnect/sdk-zephyr/commit/897d2b82042f63273d443389351244280bd45e84