### PR TITLE
tests: add the possibility to mock device.h

### DIFF
--- a/scripts/unity/header_prepare.py
+++ b/scripts/unity/header_prepare.py
@@ -50,6 +50,11 @@ def header_prepare(in_file, out_file, out_wrap_file):
         r'__syscall\s+',
         re.M | re.S)
     content = syscall_decl_pattern.sub("", content)
+    
+    # remove DT_FOREACH_STATUS_OKAY_NODE
+    # specific to device.h mocking but necessary for now
+    dt_foreach_pattern = re.compile(r"DT_FOREACH_STATUS_OKAY_NODE.*", re.M)
+    content = dt_foreach_pattern.sub(r"", content)
 
     # For now it handles extern function declaration but maybe extended later
     # if other cases are found.


### PR DESCRIPTION
With the default header python script, every `__device_dts_ord_` variable was defined two time while mocking device.h

Removing the `DT_FOREACH_STATUS_OKAY_NODE` macro before generating the mock and test runner remove this multiple definition error.

As of now I didn't find a better way to do it. The FUNC_EXCLUDE and WORD_EXCLUDE don't work with this.

This can help people wanting to do integration testing with posix arch for their app with `device_is_ready` function in it without the need of creating an emulator or fake driver for each device used.