### PR TITLE
manifest: Update Matter SDK revision to pull recent fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -139,7 +139,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: a6d38418aedb7209f5fa4e53c22c5619bf90cf26
+      revision: 0164b943c9fc3454af773ed2804514171b7b2c6c
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
All providing fixes are needed for NCS 2.4.0 release.