### PR TITLE
lib: nrf_modem: do CFUN=0 in nrf_modem_lib_shutdown if not done already

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -505,6 +505,8 @@ Modem libraries
       Use the :c:func:`nrf_modem_lib_bootloader_init` function to initialize the Modem library in bootloader mode.
     * The Kconfig option :kconfig:option:`CONFIG_NRF_MODEM_LIB_SYS_INIT` is now deprecated.
       The application initializes the modem library using the :c:func:`nrf_modem_lib_init` function instead.
+    * The :c:func:`nrf_modem_lib_shutdown` function now checks that the modem is in minimal functional mode (``CFUN=0``) before shutting down the modem.
+      If not, a warning is given to the application, and minimal functional mode is set before calling the :c:func:`nrf_modem_shutdown` function.
 
   * Removed:
 

--- a/include/modem/nrf_modem_lib.h
+++ b/include/modem/nrf_modem_lib.h
@@ -61,6 +61,8 @@ int nrf_modem_lib_bootloader_init(void);
 /**
  * @brief Shutdown the Modem library and turn off the modem.
  *
+ * @note The modem must be put in minimal function mode before being shut down.
+ *
  * @return int Zero on success, non-zero otherwise.
  */
 int nrf_modem_lib_shutdown(void);


### PR DESCRIPTION
The modem is required to be in minimal functional mode (CFUN=0) before it is shut down. This commit checks if this is the case when calling nrf_modem_lib_shutdown. If not, throw a warning and set the functional mode.