### PR TITLE
samples: nrf9160: modem_shell: Increase workqueue stack size

### DIFF
--- a/samples/nrf9160/modem_shell/Kconfig
+++ b/samples/nrf9160/modem_shell/Kconfig
@@ -117,6 +117,7 @@ config MOSH_PRINT_BUFFER_SIZE
 
 config MOSH_COMMON_WORKQUEUE_STACK_SIZE
 	int "Common workqueue stack size"
+	default 7168 if MOSH_CLOUD_REST || MOSH_CLOUD_MQTT
 	default 6144 if MOSH_STARTUP_CMDS && MOSH_CURL
 	default 4096
 


### PR DESCRIPTION
Increase MOSH_COMMON_WORKQUEUE_STACK_SIZE to 9126 to accommodate commands sent from cloud.
Normal commands are run in shell thread but commands sent from cloud are run in modem shell's own common thread.
This means we need to increase the stack for the common thread a lot just because of the commands sent from the cloud as we cannot run them in the same thread as normal shell commands.

Jira: MOSH-444