### PR TITLE
doc: Added External flash memory and Modem trace flash backend

### DIFF
--- a/doc/nrf/includes/external_flash_nrf91.txt
+++ b/doc/nrf/includes/external_flash_nrf91.txt
@@ -1,7 +1,9 @@
 External flash
 ==============
 
-To use the external flash memory on the nRF9160 DK v0.14.0 or later versions, you must program the board controller by completing the following steps:
+To use the external flash memory on the nRF9160 DK v0.14.0 or later versions, the board controller firmware must be of version v2.0.1.
+This is the factory firmware version.
+If you need to program the board controller firmware again, complete the following steps:
 
 #. Download the nRF9160 DK board controller firmware from the `nRF9160 DK downloads`_ page.
 #. Make sure the **PROG/DEBUG SW10** switch on the nRF9160 DK is set to **nRF52**.

--- a/doc/nrf/libraries/modem/nrf_modem_lib.rst
+++ b/doc/nrf/libraries/modem/nrf_modem_lib.rst
@@ -76,6 +76,7 @@ In this case, the characteristics of the allocations made by these functions dep
 
 Modem trace module
 ******************
+
 To enable the tracing functionality, enable the :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE` Kconfig in your project configuration.
 The module is implemented in :file:`nrf/lib/nrf_modem_lib/nrf_modem_lib_trace.c` and consists of a thread that initializes, deinitializes, and forwards modem traces to a backend that can be selected by enabling any one of the following Kconfig options:
 
@@ -120,6 +121,41 @@ The logging happens at an interval set by the :kconfig:option:`CONFIG_NRF_MODEM_
 If the difference in the values of the :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_BITRATE_PERIOD_MS` Kconfig option and the :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_BITRATE_LOG_PERIOD_MS` Kconfig option is very high, you can sometimes observe high variation in measurements due to the short period over which the rolling average is calculated.
 
 To enable logging of the modem trace bitrate, enable the :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_BITRATE_LOG` Kconfig.
+
+.. _modem_trace_flash_backend:
+
+Modem trace flash backend
+=========================
+
+The flash backend stores :ref:`modem traces <modem_trace_module>` to the external flash storage on the nRF9160 DK.
+
+First, set up the :ref:`external flash <nrf9160_external_flash>` for your application.
+You can then set the following configuration options for the application to decide how to handle when the flash is full:
+
+   * :kconfig:option:`CONFIG_NRF_MODEM_TRACE_FLASH_NOSPACE_SIGNAL` - To get notified with a callback when the flash is full, and the application erases or sends the data to the cloud.
+   * :kconfig:option:`CONFIG_NRF_MODEM_TRACE_FLASH_NOSPACE_ERASE_OLDEST` - To automatically erase the oldest sector in the flash circular buffer.
+     The erase operation takes some time.
+     If the operation takes too long, traces are dropped by the modem.
+
+You can also increase heap and stack sizes when using the modem trace flash backend by setting values for the following configuration options:
+
+* :kconfig:option:`CONFIG_HEAP_MEM_POOL_SIZE` = ``2048``
+* :kconfig:option:`CONFIG_MAIN_STACK_SIZE` = ``4096``
+* :kconfig:option:`CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE` = ``4096``
+* :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_STACK_SIZE` = ``4096``
+
+The modem trace flash backend has some additional configuration options:
+
+* :kconfig:option:`CONFIG_FCB` - required for the flash circular buffer used in the backend.
+* :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_FLASH_PARTITION_SIZE` -  defines the space to be used for the modem trace partition.
+  The external flash size on the nRF9160 DK is 8 MB (equal to ``0x800000`` in HEX).
+
+It is also recommended to enable high drive mode and high-performance mode in devicetree.
+High drive is to ensure that the communication with the flash device is reliable at high speed.
+High-performance mode is a feature in the flash device that allows it to write and erase faster than in low-power mode.
+See the :ref:`external flash <nrf9160_external_flash>` documentation for more details.
+The trace backend needs to handle trace data at ~1 Mbps to avoid filling up the buffer in the modem.
+If the modem buffer is full, the modem drops modem traces until the buffer has space available again.
 
 .. _adding_custom_modem_trace_backends:
 

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -445,6 +445,7 @@
 
 .. _`nRF9160 DK Hardware`: https://infocenter.nordicsemi.com/topic/ug_nrf91_dk/UG/nrf91_DK/intro.html
 .. _`nRF9160 DK board control section in the nRF9160 DK User Guide`: https://infocenter.nordicsemi.com/topic/ug_nrf91_dk/UG/nrf91_DK/board_controller.html
+.. _`External memory section in the nRF9160 DK User Guide`: https://infocenter.nordicsemi.com/topic/ug_nrf91_dk/UG/nrf91_DK/external_memory.html
 .. _`Device programming section in the nRF9160 DK User Guide`: https://infocenter.nordicsemi.com/topic/ug_nrf91_dk/UG/nrf91_DK/mcu_device_programming.html
 .. _`VDD supply rail section in the nRF9160 DK User Guide`: https://infocenter.nordicsemi.com/topic/ug_nrf91_dk/UG/nrf91_DK/power_sources_vdd.html
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -764,6 +764,8 @@ Documentation
   * The :ref:`software_maturity` page with details about Bluetooth feature support.
   * The :ref:`ug_nrf5340_gs`, :ref:`ug_thingy53_gs`, :ref:`ug_nrf52_gs`, and :ref:`ug_ble_controller` pages with a link to the `Bluetooth LE Fundamentals course`_ in the `Nordic Developer Academy`_.
   * The :ref:`zigbee_weather_station_app` documentation to match the application template.
+  * The :ref:`ug_nrf9160` page with a section about :ref:`external flash <nrf9160_external_flash>`.
+  * The :ref:`nrf_modem_lib_readme` page with a section about :ref:`modem trace flash backend <modem_trace_flash_backend>`.
 
 Moved:
 

--- a/doc/nrf/working_with_nrf/nrf91/nrf9160.rst
+++ b/doc/nrf/working_with_nrf/nrf91/nrf9160.rst
@@ -30,9 +30,6 @@ Build the sample (located under ``ncs/zephyr/samples/hello_world``) for the nrf9
 To change the routing options, enable or disable the corresponding devicetree nodes for that board as needed.
 See :ref:`zephyr:nrf9160dk_board_controller_firmware` for detailed information.
 
-To use the external flash on the nRF9160 DK v0.14.0 or later versions, program the board controller firmware (:file:`nrf9160_dk_board_controller_fw_2.0.1.hex`) v2.0.1 or higher using the `Programmer app <Programming a Development Kit_>`_ in nRF Connect for Desktop.
-Make sure the **PROG/DEBUG SW10** switch on the nRF9160 DK is set to **nRF52**.
-
 .. _nrf9160_ug_updating_cloud_certificate:
 
 Updating the nRF Cloud certificate
@@ -285,6 +282,92 @@ To specify the board revision, append it to the build target when building.
 For example, when building a non-secure application for nRF9160 DK v1.0.0, use ``nrf9160dk_nrf9106_ns@1.0.0`` as build target.
 
 See :ref:`zephyr:application_board_version` and :ref:`zephyr:nrf9160dk_additional_hardware` for more information.
+
+.. _nrf9160_external_flash:
+
+External flash memory
+*********************
+
+The nRF9160 DK version 0.14.0 and later versions contain an 8 MB external flash (MX25R6435F).
+The external flash can be used to store data that does not fit on the internal flash.
+To free up GPIO when the external flash is not needed, the nRF9160 DK board controller (nRF52840 SoC) controls a switch to enable or disable routing between the external flash and the nRF9160 SIP.
+
+
+See `nRF9160 DK board controller <nRF9160 DK board control section in the nRF9160 DK User Guide_>`_ and `External memory <External memory section in the nRF9160 DK User Guide_>`_ sections in the nRF9160 DK user guides for more details.
+
+Programming the board controller firmware
+=========================================
+
+To use the external flash memory on the nRF9160 DK v0.14.0 or later versions, the board controller firmware must be of version v2.0.1.
+This is the factory firmware version.
+If you need to program the board controller firmware again, complete the following steps:
+
+#. Download the nRF9160 DK board controller firmware from the `nRF9160 DK downloads`_ page.
+#. Make sure the **PROG/DEBUG SW10** switch on the nRF9160 DK is set to **nRF52**.
+#. Program the board controller firmware (:file:`nrf9160_dk_board_controller_fw_2.0.1.hex`) using the `Programmer app <Programming a Development Kit_>`_ in nRF Connect for Desktop.
+   By default, this enables pin routing to external flash.
+
+Adding the configuration and devicetree option
+===============================================
+
+To use external flash, the application also needs to enable configuration and devicetree options.
+
+Enable the following Kconfig options by setting it to ``y`` in your project configuration:
+
+* :kconfig:option:`CONFIG_FLASH`
+* :kconfig:option:`CONFIG_FLASH_MAP`
+* :kconfig:option:`CONFIG_SPI`
+* :kconfig:option:`CONFIG_SPI_NOR`
+* :kconfig:option:`CONFIG_SPI_NOR_SFDP_DEVICETREE`
+* :kconfig:option:`CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK`
+
+To automatically include the devicetree overlay with the external flash, specify the board revision parameter when :ref:`gs_programming`.
+The board revision is printed on the label of your DK, just below the PCA number.
+
+Then add the following relevant devicetree blocks to the application`s devicetree overlay file, depending on your application`s needs:
+
+.. code-block:: devicetree
+
+   /* Configure partition manager to use mx25r64 as the external flash device */
+   / {
+       chosen {
+           nordic,pm-ext-flash = &mx25r64;
+       };
+   };
+
+   /* Enable high drive mode for the SPI3 pins to get a square signal at 8 MHz */
+   &spi3_default {
+       group1 {
+           nordic,drive-mode = <NRF_DRIVE_H0H1>;
+       };
+   };
+
+   /* Enable high performance mode to increase write/erase performance */
+   &mx25r64 {
+       mxicy,mx25r-power-mode = "high-performance";
+   };
+
+For more information about devicetree overlays, see :ref:`zephyr:use-dt-overlays`.
+
+Using Partition Manager
+=======================
+
+If your application was built using the |NCS|, you must define partitions using :ref:`partition_manager`.
+The built-in partition definitions can be found in the :file:`nrf/subsys/partition_manager` folder, and the file names start with ``pm.yml``.
+The files which have ``external_flash`` as their region will have support for storing partitions in the external flash.
+You can also find the configuration option required to place the partition in the external flash region in those files.
+For example, the :file:`pm.yml.pgps` file has an option (:kconfig:option:`CONFIG_PM_PARTITION_REGION_PGPS_EXTERNAL`) to place the PGPS partition in external flash:
+
+.. code-block:: c
+
+   #ifdef CONFIG_PM_PARTITION_REGION_PGPS_EXTERNAL
+     region: external_flash
+   #else
+     inside: [nonsecure_storage]
+   #endif
+     size: CONFIG_NRF_CLOUD_PGPS_PARTITION_SIZE
+
+It is also possible to change the size of the partition with :kconfig:option:`CONFIG_NRF_CLOUD_PGPS_PARTITION_SIZE`.
 
 .. _nrf9160_ug_drivs_libs_samples:
 


### PR DESCRIPTION
Added following documentation:
External flash memory
Modem trace flash backend

CIA-929 and CIA-928