### PR TITLE
drivers: wifi: Implement scan timeout

### DIFF
--- a/drivers/wifi/nrf700x/zephyr/inc/zephyr_fmac_main.h
+++ b/drivers/wifi/nrf700x/zephyr/inc/zephyr_fmac_main.h
@@ -30,6 +30,11 @@
 #include <host_rpu_umac_if.h>
 
 #ifndef CONFIG_NRF700X_RADIO_TEST
+/* Use same timeout as WPA supplicant, this is high mainly to handle
+ * connected scan.
+ */
+#define WIFI_NRF_SCAN_TIMEOUT (K_SECONDS(30))
+
 struct wifi_nrf_vif_ctx_zep {
 	const struct device *zep_dev_ctx;
 	struct net_if *zep_net_if_ctx;
@@ -41,6 +46,7 @@ struct wifi_nrf_vif_ctx_zep {
 	bool scan_in_progress;
 	int scan_type;
 	unsigned int scan_res_cnt;
+	struct k_work_delayable scan_timeout_work;
 
 	struct net_eth_addr mac_addr;
 
@@ -100,4 +106,6 @@ struct wifi_nrf_drv_priv_zep {
 	/* TODO: Replace with a linked list to handle unlimited RPUs */
 	struct wifi_nrf_ctx_zep rpu_ctx_zep;
 };
+
+void wifi_nrf_scan_timeout_work(struct k_work *work);
 #endif /* __ZEPHYR_FMAC_MAIN_H__ */

--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_fmac_main.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_fmac_main.c
@@ -436,6 +436,10 @@ static int wifi_nrf_drv_main_zep(const struct device *dev)
 			__func__);
 		goto fmac_deinit;
 	}
+#ifndef CONFIG_NRF700X_RADIO_TEST
+	k_work_init_delayable(&vif_ctx_zep->scan_timeout_work,
+			      wifi_nrf_scan_timeout_work);
+#endif /* !CONFIG_NRF700X_RADIO_TEST */
 
 	return 0;
 fmac_deinit:

--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_wpa_supp_if.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_wpa_supp_if.c
@@ -136,6 +136,7 @@ void wifi_nrf_wpa_supp_event_proc_scan_done(void *if_priv,
 		vif_ctx_zep->supp_callbk_fns.scan_done(vif_ctx_zep->supp_drv_if_ctx,
 			&event);
 	}
+	k_work_cancel_delayable(&vif_ctx_zep->scan_timeout_work);
 }
 
 void wifi_nrf_wpa_supp_event_proc_scan_res(void *if_priv,
@@ -539,6 +540,8 @@ int wifi_nrf_wpa_supp_scan2(void *if_priv, struct wpa_driver_scan_params *params
 
 	vif_ctx_zep->scan_type = SCAN_CONNECT;
 	vif_ctx_zep->scan_in_progress = true;
+
+	k_work_schedule(&vif_ctx_zep->scan_timeout_work, WIFI_NRF_SCAN_TIMEOUT);
 
 	ret = 0;
 out:


### PR DESCRIPTION
In case scan times out (either display or WPA supplicant) for any reason we end up reject all further scan requests, depending on the reason for scan timeout subsequent scan might work e.g., scan done dropped due to momentary memory pressure.

Add a delayed work to handle scan timeout (30secs), I don't think this should be user configurable, so, leaving it in the code.

Fixes SHEL-1500.