### PR TITLE
applications: nrf5340_audio: Suppress false error message of image state

### DIFF
--- a/applications/nrf5340_audio/dfu/conf/Kconfig.dfu
+++ b/applications/nrf5340_audio/dfu/conf/Kconfig.dfu
@@ -70,6 +70,10 @@ config MCUMGR_GRP_IMG
 	bool
 	default y
 
+config MCUMGR_GRP_IMG_LOG_LEVEL
+	int
+	default 0
+
 config MCUMGR_TRANSPORT_NETBUF_SIZE
 	int
 	default 1024


### PR DESCRIPTION
image state command will try to read image state before upload app. This commit introduces false error message while opening ram_disk partition which does not exist in application.

https://github.com/nrfconnect/sdk-zephyr/commit/df0fa6d9651ff935eafedaff383f6d098bac18e5