### PR TITLE
drivers: wifi: Changing default reorder_buf_size

### DIFF
--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_fmac_main.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_fmac_main.c
@@ -61,7 +61,7 @@ static const unsigned char aggregation = 1;
 static const unsigned char wmm = 1;
 static const unsigned char max_num_tx_agg_sessions = 4;
 static const unsigned char max_num_rx_agg_sessions = 8;
-static const unsigned char reorder_buf_size = 64;
+static const unsigned char reorder_buf_size = 16;
 static const unsigned char max_rxampdu_size = MAX_RX_AMPDU_SIZE_64KB;
 
 static const unsigned char max_tx_aggregation = CONFIG_NRF700X_MAX_TX_AGGREGATION;


### PR DESCRIPTION
[SHEL-1590] Setting default reorder_buf_size to 16 from 64. This will reduce the maximum number of buffers queued in the reorder buffer.