### PR TITLE
modules: mcuboot: Inform application about the MCUboot XIP mode

### DIFF
--- a/modules/mcuboot/Kconfig
+++ b/modules/mcuboot/Kconfig
@@ -28,6 +28,13 @@ config BOOT_BUILD_DIRECT_XIP_VARIANT
 	help
 	  Build a variant of the 'app' image which can be used for DIRECT_XIP.
 
+choice MCUBOOT_BOOTLOADER_MODE
+	default MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP if BOOT_BUILD_DIRECT_XIP_VARIANT
+	help
+	  Automatically inform application that MCUboot has been configured for
+	  DirectXIP operation if a direct XIP variant of the app image is built.
+endchoice
+
 # The name of this configuration needs to match the requirements set by the
 # script `partition_manager.py`. See `pm.yml` in the application directory
 # of MCUBoot.


### PR DESCRIPTION
Change modifies the default value of the CONFIG_MCUBOOT_BOOTLOADER_MODE Kconfig choice to CONFIG_MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP if CONFIG_BOOT_BUILD_DIRECT_XIP_VARIANT Kconfig option is enabled.

Jira: NCSDK-21381