### PR TITLE
wifi: Fix versions

### DIFF
--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fmac_api.h
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fmac_api.h
@@ -1233,18 +1233,16 @@ enum wifi_nrf_status wifi_nrf_fmac_fw_load(struct wifi_nrf_fmac_dev_ctx *fmac_de
 /**
  * wifi_nrf_fmac_ver_get() - Get FW versions from the RPU.
  * @fmac_dev_ctx: Pointer to the UMAC IF context for a RPU WLAN device.
- * @umac_ver: Pointer to the address where the UMAC version needs to be copied.
- * @lmac_ver: Pointer to the address where the LMAC version needs to be copied.
+ * @fw_ver: Pointer to the address where the FW version needs to be copied.
  *
- * This function is used to get Firmware versions from the RPU.
+ * This function is used to get Firmware version from the RPU.
  *
  * Returns: Status
  *		Pass: %WIFI_NRF_STATUS_SUCCESS
  *		Fail: %WIFI_NRF_STATUS_FAIL
  */
 enum wifi_nrf_status wifi_nrf_fmac_ver_get(struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx,
-					  unsigned int *umac_ver,
-					  unsigned int *lmac_ver);
+					  unsigned int *fw_ver);
 
 
 /**

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/fmac_api.c
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/fmac_api.c
@@ -862,31 +862,18 @@ out:
 
 
 enum wifi_nrf_status wifi_nrf_fmac_ver_get(struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx,
-					  unsigned int *umac_ver,
-					  unsigned int *lmac_ver)
+					  unsigned int *fw_ver)
 {
 	enum wifi_nrf_status status = WIFI_NRF_STATUS_FAIL;
 
 	status = hal_rpu_mem_read(fmac_dev_ctx->hal_dev_ctx,
-				  umac_ver,
+				  fw_ver,
 				  RPU_MEM_UMAC_VER,
-				  sizeof(*umac_ver));
+				  sizeof(*fw_ver));
 
 	if (status != WIFI_NRF_STATUS_SUCCESS) {
 		wifi_nrf_osal_log_err(fmac_dev_ctx->fpriv->opriv,
 				      "%s: Unable to read UMAC ver\n",
-				      __func__);
-		goto out;
-	}
-
-	status = hal_rpu_mem_read(fmac_dev_ctx->hal_dev_ctx,
-				  lmac_ver,
-				  RPU_MEM_LMAC_VER,
-				  sizeof(*lmac_ver));
-
-	if (status != WIFI_NRF_STATUS_SUCCESS) {
-		wifi_nrf_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to read LMAC ver\n",
 				      __func__);
 		goto out;
 	}

--- a/drivers/wifi/nrf700x/zephyr/inc/zephyr_fmac_main.h
+++ b/drivers/wifi/nrf700x/zephyr/inc/zephyr_fmac_main.h
@@ -29,6 +29,8 @@
 #include <fmac_api.h>
 #include <host_rpu_umac_if.h>
 
+#define NRF700X_DRIVER_VERSION "1.2.4.0"
+
 #ifndef CONFIG_NRF700X_RADIO_TEST
 /* Use same timeout as WPA supplicant, this is high mainly to handle
  * connected scan.
@@ -108,4 +110,5 @@ struct wifi_nrf_drv_priv_zep {
 };
 
 void wifi_nrf_scan_timeout_work(struct k_work *work);
+const char *wifi_nrf_get_drv_version(void);
 #endif /* __ZEPHYR_FMAC_MAIN_H__ */

--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_fmac_main.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_fmac_main.c
@@ -278,9 +278,8 @@ enum wifi_nrf_status wifi_nrf_fmac_dev_add_zep(struct wifi_nrf_drv_priv_zep *drv
 	sleep_type = SLEEP_DISABLE;
 #endif /* CONFIG_NRF700X_RADIO_TEST */
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
-	unsigned int umac_ver = 0;
-	unsigned int lmac_ver = 0;
 	struct nrf_wifi_tx_pwr_ctrl_params tx_pwr_ctrl_params;
+	unsigned int fw_ver = 0;
 
 	rpu_ctx_zep = &drv_priv_zep->rpu_ctx_zep;
 
@@ -319,8 +318,7 @@ enum wifi_nrf_status wifi_nrf_fmac_dev_add_zep(struct wifi_nrf_drv_priv_zep *drv
 	}
 
 	status = wifi_nrf_fmac_ver_get(rpu_ctx,
-				       &umac_ver,
-				       &lmac_ver);
+				       &fw_ver);
 
 	if (status != WIFI_NRF_STATUS_SUCCESS) {
 		LOG_ERR("%s: FW version read failed\n", __func__);
@@ -328,10 +326,10 @@ enum wifi_nrf_status wifi_nrf_fmac_dev_add_zep(struct wifi_nrf_drv_priv_zep *drv
 	}
 
 	LOG_INF("Firmware (v%d.%d.%d.%d) booted successfully\n",
-		NRF_WIFI_UMAC_VER(umac_ver),
-		NRF_WIFI_UMAC_VER_MAJ(umac_ver),
-		NRF_WIFI_UMAC_VER_MIN(umac_ver),
-		NRF_WIFI_UMAC_VER_EXTRA(umac_ver));
+		NRF_WIFI_UMAC_VER(fw_ver),
+		NRF_WIFI_UMAC_VER_MAJ(fw_ver),
+		NRF_WIFI_UMAC_VER_MIN(fw_ver),
+		NRF_WIFI_UMAC_VER_EXTRA(fw_ver));
 
 	tx_pwr_ctrl_params.ant_gain_2g = CONFIG_NRF700X_ANT_GAIN_2G;
 	tx_pwr_ctrl_params.ant_gain_5g_band1 = CONFIG_NRF700X_ANT_GAIN_5G_BAND1;

--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_fmac_main.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_fmac_main.c
@@ -88,6 +88,11 @@ static const unsigned int rx3_buf_sz = 1000;
 
 struct wifi_nrf_drv_priv_zep rpu_drv_priv_zep;
 
+const char *wifi_nrf_get_drv_version(void)
+{
+	return NRF700X_DRIVER_VERSION;
+}
+
 void wifi_nrf_event_proc_scan_start_zep(void *if_priv,
 					struct nrf_wifi_umac_event_trigger_scan *scan_start_event,
 					unsigned int event_len)

--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_wifi_util.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_wifi_util.c
@@ -529,7 +529,7 @@ static int nrf_wifi_util_show_host_rpu_ps_ctrl_state(const struct shell *shell,
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
 
 
-static int nrf_wifi_util_show_fw_ver(const struct shell *shell,
+static int nrf_wifi_util_show_vers(const struct shell *shell,
 				  size_t argc,
 				  const char *argv[])
 {
@@ -538,6 +538,9 @@ static int nrf_wifi_util_show_fw_ver(const struct shell *shell,
 	unsigned int fw_ver;
 
 	fmac_dev_ctx = ctx->rpu_ctx;
+
+	shell_fprintf(shell, SHELL_INFO, "Driver version: %s\n",
+				  NRF700X_DRIVER_VERSION);
 
 	status = wifi_nrf_fmac_ver_get(fmac_dev_ctx, &fw_ver);
 
@@ -1051,10 +1054,10 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      1,
 		      0),
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
-	SHELL_CMD_ARG(show_fw_ver,
+	SHELL_CMD_ARG(show_vers,
 		      NULL,
-		      "Display the firmware version",
-		      nrf_wifi_util_show_fw_ver,
+		      "Display the driver and the firmware versions",
+		      nrf_wifi_util_show_vers,
 		      1,
 		      0),
 #ifndef CONFIG_NRF700X_RADIO_TEST

--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_wifi_util.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_wifi_util.c
@@ -535,11 +535,11 @@ static int nrf_wifi_util_show_fw_ver(const struct shell *shell,
 {
 	enum wifi_nrf_status status = WIFI_NRF_STATUS_FAIL;
 	struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx = NULL;
-	unsigned int umac_ver, lmac_ver;
+	unsigned int fw_ver;
 
 	fmac_dev_ctx = ctx->rpu_ctx;
 
-	status = wifi_nrf_fmac_ver_get(fmac_dev_ctx, &umac_ver, &lmac_ver);
+	status = wifi_nrf_fmac_ver_get(fmac_dev_ctx, &fw_ver);
 
 	if (status != WIFI_NRF_STATUS_SUCCESS) {
 		shell_fprintf(shell,
@@ -549,15 +549,11 @@ static int nrf_wifi_util_show_fw_ver(const struct shell *shell,
 	}
 
 	shell_fprintf(shell, SHELL_INFO,
-		 "UMAC version: %d.%d.%d.%d\nLMAC version: %d.%d.%d.%d\n",
-		  NRF_WIFI_UMAC_VER(umac_ver),
-		  NRF_WIFI_UMAC_VER_MAJ(umac_ver),
-		  NRF_WIFI_UMAC_VER_MIN(umac_ver),
-		  NRF_WIFI_UMAC_VER_EXTRA(umac_ver),
-		  NRF_WIFI_LMAC_VER(lmac_ver),
-		  NRF_WIFI_LMAC_VER_MAJ(lmac_ver),
-		  NRF_WIFI_LMAC_VER_MIN(lmac_ver),
-		  NRF_WIFI_LMAC_VER_EXTRA(lmac_ver));
+		 "Firmware version: %d.%d.%d.%d\n",
+		  NRF_WIFI_UMAC_VER(fw_ver),
+		  NRF_WIFI_UMAC_VER_MAJ(fw_ver),
+		  NRF_WIFI_UMAC_VER_MIN(fw_ver),
+		  NRF_WIFI_UMAC_VER_EXTRA(fw_ver));
 
 	return status;
 }


### PR DESCRIPTION
This needs more work, but its a start. We could automate based on NCS version ( `VERSION` file) and also add a net_mgmt command to fetch the version by applications rather than a global C function as API.