### PR TITLE
samples: wifi: shell: Add a superset combo for memory stress test

### DIFF
--- a/samples/wifi/shell/sample.yaml
+++ b/samples/wifi/shell/sample.yaml
@@ -137,3 +137,16 @@ tests:
       - nrf7002dk_nrf5340_cpuapp_ns
     platform_allow: nrf7002dk_nrf5340_cpuapp_ns
     tags: ci_build
+  # Used by QA and also acts as a memory stress test (keep it last)
+  sample.nrf7002.superset:
+    build_only: true
+    extra_args:
+      OVERLAY_CONFIG=overlay-zperf.conf
+      CONFIG_NRF700X_UTIL=y
+      CONFIG_WPA_CLI=y
+      CONFIG_NET_IPV4_FRAGMENT=y
+      CONFIG_NET_IPV4_FRAGMENT_MAX_PKT=24
+    integration_platforms:
+      - nrf7002dk_nrf5340_cpuapp
+    platform_allow: nrf7002dk_nrf5340_cpuapp
+    tags: ci_build


### PR DESCRIPTION
This is the combination used by QA, its good to make sure this always builds and also the same will be used in the nightlies.