### PR TITLE
manifest: sdk-zephyr: Pull TC priority changes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 8182ebc2d257c309b9c50fc0d895a4b88a672a1b
+      revision: pull/1106/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Mark priority automatically based on DSCP.