### PR TITLE
manifest: Update sdk-ant revision

### DIFF
--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -110,23 +110,6 @@
   comment: "Configurations excluded to limit resources usage in integration builds"
 
 - scenarios:
-    - sample.ant_advanced_burst
-    - sample.ant_background_scanning
-    - sample.ant_broadcast_rx
-    - sample.ant_broadcast_tx
-    - sample.bpwr_rx
-    - sample.bpwr_tx
-    - sample.bsc_rx
-    - sample.bsc_tx
-    - sample.hrm_rx
-    - sample.hrm_tx
-    - sample.ble_ant_app_hrm
-    - sample.ant_rpc
-  platforms:
-    - all
-  comment: "ANT samples fail to build; need to change main()'s signature to int main(void)"
-
-- scenarios:
     - sample.bluetooth.mesh.sensor_client
   platforms:
     - nrf52dk_nrf52832

--- a/west.yml
+++ b/west.yml
@@ -227,7 +227,7 @@ manifest:
       remote: memfault
     - name: ant
       repo-path: sdk-ant
-      revision: 373e6987cb18bacec6baab11d119333d92338589
+      revision: fd3bb49b535093b5ccfc16ad37f965c32aae2e7e
       remote: ant-nrfconnect
       groups:
         - ant


### PR DESCRIPTION
Update revision to ANT for nRF Connect SDK v1.0.0. 
Remove ANT samples from quarantine.