### PR TITLE
samples: bluetooth: peripheral_mds: fix heap memory size configuration

### DIFF
--- a/samples/bluetooth/peripheral_mds/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/samples/bluetooth/peripheral_mds/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Heap memory is required for the memfault_demo_cli.c and bt_rpmsg.
+CONFIG_HEAP_MEM_POOL_SIZE=4096


### PR DESCRIPTION
This commit configures the heap size.
The heap size is 4096B when BT_RPMSG is enabled.

Ref: NCSDK-21623