### PR TITLE
caf: ble_smp: Update binary file name

### DIFF
--- a/applications/nrf_desktop/README.rst
+++ b/applications/nrf_desktop/README.rst
@@ -1930,12 +1930,21 @@ Depending on the side on which the process is handled:
 * On the host side, the process is handled by the :ref:`nrf_desktop_config_channel_script`.
   See the tool documentation for more information about how to execute the background DFU process on the host.
 
+.. _nrf_desktop_image_transfer_over_smp:
+
 Image transfer over SMP
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 If the MCUboot bootloader is selected, the update image can also be transferred in the background through the :ref:`nrf_desktop_ble_smp`.
 The `nRF Connect for Mobile`_ application uses binary files for the image transfer over the Simple Management Protocol (SMP).
-Depending on the selected image slot either the :file:`zephyr/app_update.bin` or :file:`zephyr/mcuboot_secondary_app_update.bin` file must be used for the background DFU procedure.
+The :guilabel:`DFU` button appears in the tab of the connected Bluetooth device that supports the image transfer over the SMP.
+After pressing the button, you can select the :file:`*.bin` file used for the firmware update.
+
+After building your application for configuration with the :ref:`nrf_desktop_ble_smp` enabled, the following firmware update files are generated in the build directory:
+
+ * :file:`zephyr/app_update.bin` - The application image that is bootable from the primary slot.
+ * :file:`zephyr/mcuboot_secondary_app_update.bin` - The application image that is bootable from the secondary slot.
+   The file is generated only if the MCUboot bootloader is built in the direct-xip mode.
 
 If the MCUboot bootloader uses the built-in direct-xip mode, you must upload the image for the slot that is currently unused.
 If the MCUboot bootloader built-in swap mode is used, the :file:`zephyr/app_update.bin` file must always be used.

--- a/applications/nrf_desktop/doc/smp.rst
+++ b/applications/nrf_desktop/doc/smp.rst
@@ -13,6 +13,7 @@ The |smp| is responsible for performing a Device Firmware Upgrade (DFU) over Blu
 You can perform the DFU using for example the `nRF Connect for Mobile`_ application.
 The :guilabel:`DFU` button appears in the tab with the connected Bluetooth® devices.
 After pressing the button, you can select the :file:`*.bin` file that is to be used for the firmware update.
+See the :ref:`nrf_desktop_image_transfer_over_smp` section for information about which binary file should be used for the DFU image transfer.
 
 Module events
 *************

--- a/doc/nrf/libraries/caf/ble_smp.rst
+++ b/doc/nrf/libraries/caf/ble_smp.rst
@@ -38,19 +38,31 @@ The |smp| supports registering OS management handlers automatically, which you c
 Implementation details
 **********************
 
-The module registers the :c:func:`upload_confirm_cb` callback that is used to submit ``ble_smp_transfer_event``.
+The module periodically submits :c:struct:`ble_smp_transfer_event` during the image upload.
+The module registers the :c:func:`upload_confirm_cb` callback that is used to submit :c:struct:`ble_smp_transfer_event`.
 The module registers itself as the final subscriber of the event to track the number of submitted events.
-If a ``ble_smp_transfer_event`` was already submitted, but was not yet processed, the module desists from submitting subsequent event.
-After the previously submitted event is processed, the module submits a subsequent event when :c:func:`upload_confirm_cb` callback is called.
+If a :c:struct:`ble_smp_transfer_event` was already submitted but not processed, the module desists from submitting a subsequent event.
+After the previously submitted event is processed, the module submits a subsequent event when the :c:func:`upload_confirm_cb` callback is called.
 
 The application user must not perform more than one firmware upgrade at a time.
 The modification of the data by multiple application modules can result in a broken image that is going to be rejected by the bootloader.
 
-The module periodically submits ``ble_smp_transfer_event`` while the image is being uploaded.
+You can perform the DFU using, for example, the `nRF Connect for Mobile`_ application.
+The :guilabel:`DFU` button appears in the tab of the connected Bluetooth device that supports the image transfer over the Simple Management Protocol (SMP).
+After pressing the button, you can select the :file:`*.bin` file used for the firmware update.
 
-You can perform the DFU using for example the `nRF Connect for Mobile`_ application.
-The :guilabel:`DFU` button appears in the tab with the connected Bluetooth devices.
-After pressing the button, you can select the :file:`*.bin` file that is to be used for the firmware update.
+After building your application for configuration with the |smp| enabled, the following firmware update files are generated in the build directory:
+
+ * :file:`zephyr/app_update.bin` - The application image that is bootable from the primary slot.
+ * :file:`zephyr/mcuboot_secondary_app_update.bin` - The application image that is bootable from the secondary slot.
+   The file is generated only if the MCUboot bootloader is built in the direct-xip mode.
+
+If the MCUboot bootloader is built in the direct-xip mode, you must upload the image to the slot that is currently unused.
+If the MCUboot bootloader is built in the swap mode instead, you must use the :file:`zephyr/app_update.bin` file.
+In the swap mode, the MCUboot bootloader always moves the new application image to the primary slot before booting it.
+For more information about the MCUboot configuration, see the :ref:`MCUboot <mcuboot:mcuboot_wrapper>` documentation.
 
 .. note::
-  The SMP firmware update file is generated as :file:`zephyr/app_update.bin` in the build directory when building your application for configuration with the |smp| enabled.
+  If the :kconfig:option:`CONFIG_MCUMGR_GRP_IMG_REJECT_DIRECT_XIP_MISMATCHED_SLOT` Kconfig option is enabled in the application configuration, the device rejects an update image upload for the invalid slot.
+  It is recommended to enable the option if the application uses MCUboot in the direct-xip mode.
+  The upload rejection can be used as a simple mechanism of verifying which image update should be used.


### PR DESCRIPTION
Change updates information about the binary file that should be used for the DFU procedure. This is needed to align documentation with use case where MCUboot bootloader in direct-xip mode is used.

Change also updates references to ble_smp_transfer_event.

Jira: NCSDK-21651