### PR TITLE
samples: nrf9160: mosh: add nRF9161 tests with external flash

### DIFF
--- a/samples/nrf9160/modem_shell/sample.yaml
+++ b/samples/nrf9160/modem_shell/sample.yaml
@@ -201,6 +201,16 @@ tests:
     extra_configs:
       - CONFIG_MEMFAULT_NCS_PROJECT_KEY="0123456789abcdef0123456789abcdef"
     tags: ci_build
+  sample.nrf9161.modem_shell.memfault_modem_trace:
+    build_only: true
+    integration_platforms:
+      - nrf9161dk_nrf9161_ns
+    platform_allow: nrf9161dk_nrf9161_ns
+    extra_args: OVERLAY_CONFIG="overlay-modem-trace.conf;overlay-memfault.conf"
+                DTC_OVERLAY_FILE="nrf9161dk_ext_flash.overlay"
+    extra_configs:
+      - CONFIG_MEMFAULT_NCS_PROJECT_KEY="0123456789abcdef0123456789abcdef"
+    tags: ci_build
   sample.nrf9160.modem_shell.memfault_modem_trace_ram:
     build_only: true
     integration_platforms:


### PR DESCRIPTION
Add nRF9161 tests with external flash to CI (build).