### PR TITLE
doc: fast_pair: Improve provisioning data doc

### DIFF
--- a/applications/nrf_desktop/README.rst
+++ b/applications/nrf_desktop/README.rst
@@ -868,19 +868,23 @@ Selecting a build type from command line
 
    * NCS keyboard - The Fast Pair Provider meant to be used with keyboards:
 
-      * Device name: NCS keyboard
-      * Model ID: ``0x52FF02``
-      * Anti-spoofing key (base64, uncompressed): ``8E8ulwhSIp/skZeg27xmWv2SxRxTOagypHrf2OdrhGY=``
-      * Type: Input device
-      * Additional features: Data only connection, Support personalized name, Ringing device unsupported
+      .. |name| replace:: NCS keyboard
+      .. |model ID| replace:: ``0x52FF02``
+      .. |anti-spoofing key| replace:: ``8E8ulwhSIp/skZeg27xmWv2SxRxTOagypHrf2OdrhGY=``
+      .. |type| replace:: Input device
+      .. |additional features| replace:: Data only connection, Support personalized name, Ringing device unsupported
+
+      .. include:: /includes/fast_pair_device.txt
 
    * NCS gaming mouse - Fast Pair Provider meant to be used with gaming mice:
 
-      * Device name: NCS gaming mouse
-      * Model ID: ``0x8E717D``
-      * Anti-spoofing key (base64, uncompressed): ``dZxFzP7X9CcfLPC0apyRkmgsh3n2EbWo9NFNXfVuxAM=``
-      * Type: Input device
-      * Additional features: Data only connection, Support personalized name, Ringing device unsupported
+      .. |name| replace:: NCS gaming mouse
+      .. |model ID| replace:: ``0x8E717D``
+      .. |anti-spoofing key| replace:: ``dZxFzP7X9CcfLPC0apyRkmgsh3n2EbWo9NFNXfVuxAM=``
+      .. |type| replace:: Input device
+      .. |additional features| replace:: Data only connection, Support personalized name, Ringing device unsupported
+
+      .. include:: /includes/fast_pair_device.txt
 
    See :ref:`ug_bt_fast_pair_provisioning` documentation for the following information:
 

--- a/applications/nrf_desktop/README.rst
+++ b/applications/nrf_desktop/README.rst
@@ -866,25 +866,9 @@ Selecting a build type from command line
    You can use either your own provisioning data or the provisioning data obtained by Nordic Semiconductor for development purposes.
    The following debug devices are meant to be used with the nRF Desktop and have been registered:
 
-   * NCS keyboard - The Fast Pair Provider meant to be used with keyboards:
+   .. include:: /includes/fast_pair_keyboard.txt
 
-      .. |name| replace:: NCS keyboard
-      .. |model ID| replace:: ``0x52FF02``
-      .. |anti-spoofing key| replace:: ``8E8ulwhSIp/skZeg27xmWv2SxRxTOagypHrf2OdrhGY=``
-      .. |type| replace:: Input device
-      .. |additional features| replace:: Data only connection, Support personalized name, Ringing device unsupported
-
-      .. include:: /includes/fast_pair_device.txt
-
-   * NCS gaming mouse - Fast Pair Provider meant to be used with gaming mice:
-
-      .. |name| replace:: NCS gaming mouse
-      .. |model ID| replace:: ``0x8E717D``
-      .. |anti-spoofing key| replace:: ``dZxFzP7X9CcfLPC0apyRkmgsh3n2EbWo9NFNXfVuxAM=``
-      .. |type| replace:: Input device
-      .. |additional features| replace:: Data only connection, Support personalized name, Ringing device unsupported
-
-      .. include:: /includes/fast_pair_device.txt
+   .. include:: /includes/fast_pair_gaming_mouse.txt
 
    See :ref:`ug_bt_fast_pair_provisioning` documentation for the following information:
 

--- a/doc/nrf/includes/fast_pair_device.txt
+++ b/doc/nrf/includes/fast_pair_device.txt
@@ -1,0 +1,5 @@
+* Device name: |name|
+* Model ID: |model ID|
+* Anti-spoofing key (base64, uncompressed): |anti-spoofing key|
+* Type: |type|
+* Additional features: |additional features|

--- a/doc/nrf/includes/fast_pair_gaming_mouse.txt
+++ b/doc/nrf/includes/fast_pair_gaming_mouse.txt
@@ -1,0 +1,9 @@
+* NCS gaming mouse - Fast Pair Provider meant to be used with gaming mice:
+
+   .. |name| replace:: NCS gaming mouse
+   .. |model ID| replace:: ``0x8E717D``
+   .. |anti-spoofing key| replace:: ``dZxFzP7X9CcfLPC0apyRkmgsh3n2EbWo9NFNXfVuxAM=``
+   .. |type| replace:: Input device
+   .. |additional features| replace:: Data only connection, Support personalized name, Ringing device unsupported
+
+   .. include:: /includes/fast_pair_device.txt

--- a/doc/nrf/includes/fast_pair_keyboard.txt
+++ b/doc/nrf/includes/fast_pair_keyboard.txt
@@ -1,0 +1,9 @@
+* NCS keyboard - The Fast Pair Provider meant to be used with keyboards:
+
+   .. |name| replace:: NCS keyboard
+   .. |model ID| replace:: ``0x52FF02``
+   .. |anti-spoofing key| replace:: ``8E8ulwhSIp/skZeg27xmWv2SxRxTOagypHrf2OdrhGY=``
+   .. |type| replace:: Input device
+   .. |additional features| replace:: Data only connection, Support personalized name, Ringing device unsupported
+
+   .. include:: /includes/fast_pair_device.txt

--- a/samples/bluetooth/peripheral_fast_pair/README.rst
+++ b/samples/bluetooth/peripheral_fast_pair/README.rst
@@ -64,11 +64,13 @@ By default, if Model ID and Anti-Spoofing Private Key are not specified, the fol
 
 * NCS Fast Pair demo - The input device Fast Pair provider:
 
-   * Device name: NCS Fast Pair demo
-   * Model ID: ``0x2A410B``
-   * Anti-spoofing key (base64, uncompressed): ``Unoh+nycK/ZJ7k3dHsdcNpiP1SfOy0P/Lx5XixyYois=``
-   * Type: Input device
-   * Additional features: Data only connection, Support personalized name, Ringing device unsupported
+   .. |name| replace:: NCS Fast Pair demo
+   .. |model ID| replace:: ``0x2A410B``
+   .. |anti-spoofing key| replace:: ``Unoh+nycK/ZJ7k3dHsdcNpiP1SfOy0P/Lx5XixyYois=``
+   .. |type| replace:: Input device
+   .. |additional features| replace:: Data only connection, Support personalized name, Ringing device unsupported
+
+   .. include:: /includes/fast_pair_device.txt
 
 See :ref:`ug_bt_fast_pair_provisioning` in the Fast Pair user guide for details.
 


### PR DESCRIPTION
Adds fast_pair_device.txt to standardize the way of presenting Fast Pair devices in documentation.
This is a follow-up to [#11114 (comment)](https://github.com/nrfconnect/sdk-nrf/pull/11114#discussion_r1192461168) from https://github.com/nrfconnect/sdk-nrf/pull/11114.

Jira: NCSDK-21647