### PR TITLE
net: fota_download: Release FOTA resources properly

### DIFF
--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -300,7 +300,7 @@ static int download_client_callback(const struct download_client_evt *event)
 error_and_close:
 	atomic_clear_bit(&flags, FLAG_RESUME);
 	(void)download_client_disconnect(&dlc);
-	dfu_target_reset();
+	dfu_target_done(false);
 	return -1;
 }
 


### PR DESCRIPTION
Instead of calling dfu_target_reset(), we should just call dfu_target_done(false) to mark the download as incomplete. DFU Target library internally handles erasing, at least on Delta modem updates.