### PR TITLE
samples: matter: remove nrf7001ek and nrf7000ek platform

### DIFF
--- a/samples/matter/light_bulb/sample.yaml
+++ b/samples/matter/light_bulb/sample.yaml
@@ -47,15 +47,3 @@ tests:
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
     platform_allow: nrf5340dk_nrf5340_cpuapp
-  sample.matter.light_bulb.nrf7000_ek:
-    build_only: true
-    extra_args: SHIELD=nrf7002ek_nrf7000 hci_rpmsg_SHIELD=nrf7002ek_nrf7000_coex CONFIG_WPA_SUPP=n
-    integration_platforms:
-      - nrf5340dk_nrf5340_cpuapp
-    platform_allow: nrf5340dk_nrf5340_cpuapp
-  sample.matter.light_bulb.nrf7001_ek:
-    build_only: true
-    extra_args: SHIELD=nrf7002ek_nrf7001 hci_rpmsg_SHIELD=nrf7002ek_nrf7001_coex
-    integration_platforms:
-      - nrf5340dk_nrf5340_cpuapp
-    platform_allow: nrf5340dk_nrf5340_cpuapp

--- a/samples/matter/lock/sample.yaml
+++ b/samples/matter/lock/sample.yaml
@@ -79,37 +79,9 @@ tests:
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
     platform_allow: nrf5340dk_nrf5340_cpuapp
-  sample.matter.lock.switchable_thread.nrf7000_ek:
-    build_only: true
-    extra_args: SHIELD=nrf7002ek_nrf7000 hci_rpmsg_SHIELD=nrf7002ek_nrf7000_coex CONFIG_WPA_SUPP=n
-      CONF_FILE=prj_thread_wifi_switched.conf CONFIG_CHIP_WIFI=n
-    integration_platforms:
-      - nrf5340dk_nrf5340_cpuapp
-    platform_allow: nrf5340dk_nrf5340_cpuapp
-  sample.matter.lock.switchable_thread.nrf7001_ek:
-    build_only: true
-    extra_args: SHIELD=nrf7002ek_nrf7001 hci_rpmsg_SHIELD=nrf7002ek_nrf7001_coex
-      CONF_FILE=prj_thread_wifi_switched.conf CONFIG_CHIP_WIFI=n
-    integration_platforms:
-      - nrf5340dk_nrf5340_cpuapp
-    platform_allow: nrf5340dk_nrf5340_cpuapp
   sample.matter.lock.switchable_wifi.nrf7002_ek:
     build_only: true
     extra_args: SHIELD=nrf7002ek_nrf7002 hci_rpmsg_SHIELD=nrf7002ek_nrf7002_coex
-      CONF_FILE=prj_thread_wifi_switched.conf
-    integration_platforms:
-      - nrf5340dk_nrf5340_cpuapp
-    platform_allow: nrf5340dk_nrf5340_cpuapp
-  sample.matter.lock.switchable_wifi.nrf7000_ek:
-    build_only: true
-    extra_args: SHIELD=nrf7002ek_nrf7000 hci_rpmsg_SHIELD=nrf7002ek_nrf7000_coex CONFIG_WPA_SUPP=n
-      CONF_FILE=prj_thread_wifi_switched.conf
-    integration_platforms:
-      - nrf5340dk_nrf5340_cpuapp
-    platform_allow: nrf5340dk_nrf5340_cpuapp
-  sample.matter.lock.switchable_wifi.nrf7001_ek:
-    build_only: true
-    extra_args: SHIELD=nrf7002ek_nrf7001 hci_rpmsg_SHIELD=nrf7002ek_nrf7001_coex
       CONF_FILE=prj_thread_wifi_switched.conf
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp


### PR DESCRIPTION
Matter samples don't supports nrf7002ek_nrf7001 and nrf7002ek_nrf7000, hence not supported platforms should be removed from matter's sample.yaml.