### PR TITLE
samples: wifi: shell: Add a superset build combination for 7001/7002 EK

### DIFF
--- a/samples/wifi/shell/sample.yaml
+++ b/samples/wifi/shell/sample.yaml
@@ -144,6 +144,32 @@ tests:
     platform_allow: thingy53_nrf5340_cpuapp
     tags: ci_build
   # Used by QA and also acts as a memory stress test (keep it last)
+  sample.nrf7001.superset:
+    build_only: true
+    extra_args:
+      OVERLAY_CONFIG=overlay-zperf.conf
+      CONFIG_NRF700X_UTIL=y
+      CONFIG_WPA_CLI=y
+      CONFIG_NET_IPV4_FRAGMENT=y
+      CONFIG_NET_IPV4_FRAGMENT_MAX_PKT=24
+    integration_platforms:
+      - nrf7002dk_nrf5340_cpuapp
+    platform_allow: nrf7002dk_nrf5340_cpuapp
+    tags: ci_build
+  # Used by QA and also acts as a memory stress test
+  sample.nrf7001_ek.superset:
+    build_only: true
+    extra_args:
+      OVERLAY_CONFIG=overlay-zperf.conf
+      CONFIG_NRF700X_UTIL=y
+      CONFIG_WPA_CLI=y
+      CONFIG_NET_IPV4_FRAGMENT=y
+      CONFIG_NET_IPV4_FRAGMENT_MAX_PKT=24
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf7002dk_nrf5340_cpuapp
+    tags: ci_build
+  # Used by QA and also acts as a memory stress test
   sample.nrf7002.superset:
     build_only: true
     extra_args:
@@ -154,5 +180,18 @@ tests:
       CONFIG_NET_IPV4_FRAGMENT_MAX_PKT=24
     integration_platforms:
       - nrf7002dk_nrf5340_cpuapp
+    platform_allow: nrf7002dk_nrf5340_cpuapp
+    tags: ci_build
+  # Used by QA and also acts as a memory stress test
+  sample.nrf7002_ek.superset:
+    build_only: true
+    extra_args:
+      OVERLAY_CONFIG=overlay-zperf.conf
+      CONFIG_NRF700X_UTIL=y
+      CONFIG_WPA_CLI=y
+      CONFIG_NET_IPV4_FRAGMENT=y
+      CONFIG_NET_IPV4_FRAGMENT_MAX_PKT=24
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp
     platform_allow: nrf7002dk_nrf5340_cpuapp
     tags: ci_build


### PR DESCRIPTION
Combination used for all Nightly tests.