### PR TITLE
scripts: Moved wget installation from requirements buld to fixed.

### DIFF
--- a/scripts/requirements-build.txt
+++ b/scripts/requirements-build.txt
@@ -5,5 +5,4 @@ imagesize>=1.2.0
 intelhex
 protobuf
 pylint
-wget==3.2
 zcbor==0.5.1

--- a/scripts/requirements-fixed.txt
+++ b/scripts/requirements-fixed.txt
@@ -112,3 +112,4 @@ yamllint==1.30.0
 zcbor==0.5.1
 zipp==3.4.0
 grpcio-tools==1.51.1
+wget==3.2


### PR DESCRIPTION
The wget package was incorrectly added to the requirements-build instead of the requirements-fixed, so in the end the package is not properly installed and customers are struggling with its lack.