### PR TITLE
manifest: Update MCUboot revision to bring in fromtree fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -118,7 +118,7 @@ manifest:
           compare-by-default: false
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: v1.10.0-ncs1-rc1
+      revision: pull/256/head
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR.git


### PR DESCRIPTION
Fix for possible memset not being called in error path.