### PR TITLE
manifest: Updated Matter revision to pull Wi-Fi fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -139,7 +139,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 40158ec52c59eefc611133db9304da39683ca270
+      revision: 082cdb90668c658e227777fc38054dd7775a618c
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
Pulled Wi-Fi related bug fixes:
* Fixed Wi-Fi reconnect mechanism
* Fixed compilation with nRF7002 EK support (replaced old kconfig name with the new one).

Fixes: KRKNWK-16908