### PR TITLE
samples: peripheral: lpuart: Decrease current draw on nRF52840 DK 3.0.0

### DIFF
--- a/samples/peripheral/lpuart/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/peripheral/lpuart/boards/nrf52840dk_nrf52840.overlay
@@ -17,6 +17,21 @@
 	disable-rx;
 };
 
+&uart0_default {
+	/* Disconnect CTS and RTS lines from pins.
+	 * This is a temporary workaround for increased current consumption
+	 * observed on nRF52840 v3.0.0 only (~450 uA more then on v2.1.0).
+	 */
+	group1 {
+		psels = <NRF_PSEL(UART_TX, 0, 20)>,
+			<NRF_PSEL_DISCONNECTED(UART_RTS)>;
+	};
+	group2 {
+		psels = <NRF_PSEL(UART_RX, 0, 22)>,
+			<NRF_PSEL_DISCONNECTED(UART_CTS)>;
+	};
+};
+
 &gpiote {
 	interrupts = <6 NRF_DEFAULT_IRQ_PRIORITY>;
 };


### PR DESCRIPTION
Disconnect CTS and RTS lines from pins it is assigned to by default. This supresses extra power consumption of ~440 uA observed on nRF52840 DK v3.0.0.

Ref. NCSDK-21683