### PR TITLE
applications: nrf_desktop: Improve DFU over SMP documentation

### DIFF
--- a/applications/nrf_desktop/README.rst
+++ b/applications/nrf_desktop/README.rst
@@ -1679,7 +1679,7 @@ The GATT Service is implemented by the :ref:`nrf_desktop_dev_descr`.
 Apart from the GATT Services, an nRF Desktop peripheral device must enable and configure the following application modules:
 
 * :ref:`nrf_desktop_ble_adv` - Controls the Bluetooth advertising.
-* :ref:`nrf_desktop_ble_latency` - Keeps the connection latency low when the :ref:`nrf_desktop_config_channel` is being used or when an update image is being received by the :ref:`nrf_desktop_ble_smp`.
+* :ref:`nrf_desktop_ble_latency` - Keeps the connection latency low when the :ref:`nrf_desktop_config_channel` is used or when either the :ref:`nrf_desktop_ble_smp` or :ref:`nrf_desktop_dfu_mcumgr` receive an update image.
   This is done to ensure quick data transfer.
 
 Optionally, you can also enable the following module:
@@ -1775,7 +1775,9 @@ The nRF Desktop application can use one of the following bootloaders:
     You can use the MCUboot for the background DFU through the :ref:`nrf_desktop_config_channel` and :ref:`nrf_desktop_dfu`.
     The MCUboot can also be used for the background DFU over Simple Management Protocol (SMP).
     The SMP can be used to transfer the new firmware image in the background, for example, from an Android device.
-    In that case, the :ref:`nrf_desktop_ble_smp` is used to handle the image transfer.
+    In that case, either the :ref:`nrf_desktop_ble_smp` or :ref:`nrf_desktop_dfu_mcumgr` is used to handle the image transfer.
+    The :ref:`nrf_desktop_ble_smp` relies on a generic module implemented in the Common Application Framework (CAF).
+    The :ref:`nrf_desktop_dfu_mcumgr` uses an application-specific implementation that allows to synchronize a secondary image slot access with the :ref:`nrf_desktop_dfu` using the :ref:`nrf_desktop_dfu_lock`.
 
   * :ref:`USB serial recovery <nrf_desktop_bootloader_serial_dfu>`.
     In this scenario, the MCUboot bootloader supports the USB serial recovery.
@@ -1833,7 +1835,7 @@ The swap mode is the image upgrade mode used by default for the :ref:`background
 
 If the swap mode is used, the application must request firmware upgrade and confirm the running image.
 For this purpose, make sure to enable :kconfig:option:`CONFIG_IMG_MANAGER` and :kconfig:option:`CONFIG_MCUBOOT_IMG_MANAGER` Kconfig options in the application configuration.
-These options allow the :ref:`nrf_desktop_dfu` and :ref:`nrf_desktop_ble_smp` to manage the DFU image.
+These options allow the :ref:`nrf_desktop_dfu`, :ref:`nrf_desktop_ble_smp`, and :ref:`nrf_desktop_dfu_mcumgr` to manage the DFU image.
 
 .. note::
   When the MCUboot bootloader is in the swap mode, it can use a secondary image slot located on the external flash.
@@ -1853,7 +1855,7 @@ In that scenario, the MCUboot bootloader simply boots the image with the higher 
 
 By default, the MCUboot bootloader ignores the build number while comparing image versions.
 Enable the ``CONFIG_BOOT_VERSION_CMP_USE_BUILD_NUMBER`` Kconfig option in the bootloader configuration to use the build number while comparing image versions.
-To apply the same option for the :ref:`nrf_desktop_ble_smp`, enable the :kconfig:option:`CONFIG_MCUMGR_GRP_IMG_VERSION_CMP_USE_BUILD_NUMBER` Kconfig option in the application configuration.
+To apply the same option for the :ref:`nrf_desktop_ble_smp` or :ref:`nrf_desktop_dfu_mcumgr`, enable the :kconfig:option:`CONFIG_MCUMGR_GRP_IMG_VERSION_CMP_USE_BUILD_NUMBER` Kconfig option in the application configuration.
 
 It is recommended to also enable the :kconfig:option:`CONFIG_MCUMGR_GRP_IMG_REJECT_DIRECT_XIP_MISMATCHED_SLOT` Kconfig option in the application configuration to make sure that MCUmgr rejects application image updates with invalid start address.
 This prevents uploading an update image build for improper slot through the MCUmgr's Simple Management Protocol (SMP).
@@ -1901,7 +1903,7 @@ At the end of these three stages, the nRF Desktop application will be rebooted w
 
 .. note::
   The background firmware upgrade can also be performed over the Simple Management Protocol (SMP).
-  For more detailed information about the DFU over SMP, read the :ref:`nrf_desktop_ble_smp` documentation.
+  For more details about the DFU over SMP, read the :ref:`nrf_desktop_ble_smp` or :ref:`nrf_desktop_dfu_mcumgr` documentation.
 
 Update image generation
 -----------------------
@@ -1935,12 +1937,12 @@ Depending on the side on which the process is handled:
 Image transfer over SMP
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-If the MCUboot bootloader is selected, the update image can also be transferred in the background through the :ref:`nrf_desktop_ble_smp`.
+If the MCUboot bootloader is selected, the update image can also be transferred in the background either through the :ref:`nrf_desktop_ble_smp` or :ref:`nrf_desktop_dfu_mcumgr`.
 The `nRF Connect for Mobile`_ application uses binary files for the image transfer over the Simple Management Protocol (SMP).
 The :guilabel:`DFU` button appears in the tab of the connected Bluetooth device that supports the image transfer over the SMP.
 After pressing the button, you can select the :file:`*.bin` file used for the firmware update.
 
-After building your application for configuration with the :ref:`nrf_desktop_ble_smp` enabled, the following firmware update files are generated in the build directory:
+After building your application for configuration with either the :ref:`nrf_desktop_ble_smp` or :ref:`nrf_desktop_dfu_mcumgr` enabled, the following firmware update files are generated in the build directory:
 
  * :file:`zephyr/app_update.bin` - The application image that is bootable from the primary slot.
  * :file:`zephyr/mcuboot_secondary_app_update.bin` - The application image that is bootable from the secondary slot.

--- a/applications/nrf_desktop/doc/ble_latency.rst
+++ b/applications/nrf_desktop/doc/ble_latency.rst
@@ -9,7 +9,7 @@ Bluetooth LE latency module
 
 Use the Bluetooth® LE latency module for the following purposes:
 
-* Lower the Bluetooth LE connection latency either when :ref:`nrf_desktop_config_channel` is in use or when a firmware update is received by the :ref:`nrf_desktop_ble_smp` (low latency ensures quick data exchange).
+* Lower the Bluetooth LE connection latency when the :ref:`nrf_desktop_config_channel` is in use or when a firmware update is received either by the :ref:`nrf_desktop_ble_smp` or :ref:`nrf_desktop_dfu_mcumgr` (low latency ensures quick data exchange).
 * Request setting the initial connection parameters for a new Bluetooth connection.
 * Keep the connection latency low for the LLPM (Low Latency Packet Mode) connections to improve performance.
 * Disconnect the Bluetooth Central if the connection has not been secured in the predefined amount of time after the connection occurred.
@@ -51,10 +51,10 @@ The |ble_latency| uses delayed works (:c:struct:`k_work_delayable`) to control t
 The module listens for the following events related to data transfer initiated by the connected Bluetooth central:
 
 * ``config_event`` - This event is received when the :ref:`nrf_desktop_config_channel` is in use.
-* ``ble_smp_transfer_event`` - This event is received when the firmware update is received by :ref:`nrf_desktop_ble_smp`.
+* ``ble_smp_transfer_event`` - This event is received when either the :ref:`nrf_desktop_ble_smp` or :ref:`nrf_desktop_dfu_mcumgr` receives a firmware update.
 
 When these events are received, the module sets the connection latency to low.
-When the :ref:`nrf_desktop_config_channel` is no longer in use and the firmware update is not received by :ref:`nrf_desktop_ble_smp` (no mentioned events for ``LOW_LATENCY_CHECK_PERIOD_MS``), the module sets the connection latency to :kconfig:option:`CONFIG_BT_PERIPHERAL_PREF_LATENCY`  to reduce the power consumption.
+When the :ref:`nrf_desktop_config_channel` is no longer in use, and neither :ref:`nrf_desktop_ble_smp` nor :ref:`nrf_desktop_dfu_mcumgr` receive firmware updates (no mentioned events for ``LOW_LATENCY_CHECK_PERIOD_MS``), the module sets the connection latency to :kconfig:option:`CONFIG_BT_PERIPHERAL_PREF_LATENCY` to reduce the power consumption.
 
   .. note::
      If the option :ref:`CONFIG_DESKTOP_BLE_LOW_LATENCY_LOCK <config_desktop_app_options>` is enabled, the LLPM connection latency is not increased unless the device is in the low power mode.

--- a/applications/nrf_desktop/doc/dfu.rst
+++ b/applications/nrf_desktop/doc/dfu.rst
@@ -84,7 +84,7 @@ The DFU module leverages the :ref:`nrf_desktop_dfu_lock` to synchronize flash ac
 If multiple DFU transports are enabled in your application configuration, make sure that the following conditions are met:
 
 * The :ref:`CONFIG_DESKTOP_DFU_LOCK <config_desktop_app_options>` option is enabled
-* All of the used DFU transports use the :ref:`nrf_desktop_dfu_lock` module.
+* All of the used DFU transports use the :ref:`nrf_desktop_dfu_lock`.
 
 On each DFU attempt, the module attempts to claim ownership over the DFU flash using the DFU Lock API.
 It holds the DFU owner status until the DFU process is completed or timed out.
@@ -102,7 +102,7 @@ The DFU module implementation is centered around the transmission and the storag
 * `Protocol operations`_ - How the module exchanges information with the host.
 * `Partition preparation`_ - How the module prepares for receiving an image.
 
-The firmware transfer operation can also be carried out by :ref:`nrf_desktop_ble_smp`.
+The firmware transfer operation can also be carried out either by the :ref:`nrf_desktop_ble_smp` or :ref:`nrf_desktop_dfu_mcumgr`.
 The application user must not perform more than one firmware upgrade at a time.
 The modification of the data by multiple application modules would result in a broken image that would be rejected by the bootloader.
 

--- a/applications/nrf_desktop/doc/dfu_lock.rst
+++ b/applications/nrf_desktop/doc/dfu_lock.rst
@@ -8,7 +8,7 @@ DFU lock utility
    :depth: 2
 
 The DFU lock utility provides a synchronization mechanism for accessing the DFU flash.
-It is needed for application configurations that support more than one DFU transports.
+It is needed for application configurations that support more than one DFU transport.
 
 The DFU lock utility provides a basic synchronization API for all declared DFU owners.
 Each DFU owner can be declared using the :c:struct:`dfu_lock_owner` structure.
@@ -26,7 +26,7 @@ The previous owner can use this callback for tracking the DFU flash status and t
 Configuration
 *************
 
-Use the :ref:`CONFIG_DESKTOP_DFU_LOCK <config_desktop_app_options>` option to enable the utility module.
+Use the :ref:`CONFIG_DESKTOP_DFU_LOCK <config_desktop_app_options>` option to enable the utility.
 
 Currently, the DFU lock utility is automatically used if you enable both supported DFU transports in your application:
 

--- a/applications/nrf_desktop/doc/dfu_mcumgr.rst
+++ b/applications/nrf_desktop/doc/dfu_mcumgr.rst
@@ -10,8 +10,9 @@ Device Firmware Upgrade MCUmgr module
 The Device Firmware Upgrade MCUmgr module is responsible for performing a Device Firmware Upgrade (DFU) over Simple Management Protocol (SMP).
 
 If you enable the Bluetooth LE as transport, you can perform the DFU using, for example, the `nRF Connect for Mobile`_ application.
-The :guilabel:`DFU` button appears in the tab with the connected Bluetooth® devices.
+The :guilabel:`DFU` button appears in the tab of the connected Bluetooth device that supports the image transfer over the Simple Management Protocol (SMP).
 After pressing the button, you can select the :file:`*.bin` file used for the firmware update.
+See the :ref:`nrf_desktop_image_transfer_over_smp` section for information about which binary file should be used for the DFU image transfer.
 
 .. note::
     The Device Firmware Upgrade MCUmgr module implementation is currently marked as experimental because it uses internal MCUmgr API.

--- a/applications/nrf_desktop/doc/smp.rst
+++ b/applications/nrf_desktop/doc/smp.rst
@@ -9,11 +9,7 @@ Simple Management Protocol module
    :depth: 2
 
 The |smp| is responsible for performing a Device Firmware Upgrade (DFU) over Bluetooth® LE.
-
-You can perform the DFU using for example the `nRF Connect for Mobile`_ application.
-The :guilabel:`DFU` button appears in the tab with the connected Bluetooth® devices.
-After pressing the button, you can select the :file:`*.bin` file that is to be used for the firmware update.
-See the :ref:`nrf_desktop_image_transfer_over_smp` section for information about which binary file should be used for the DFU image transfer.
+You can perform the DFU using, for example, the `nRF Connect for Mobile`_ application.
 
 Module events
 *************
@@ -29,4 +25,4 @@ Implementation details
 **********************
 
 nRF Desktop uses the |smp| from :ref:`lib_caf` (CAF).
-See the :ref:`CAF module <caf_ble_smp>` page for implementation details.
+See the :ref:`CAF module <caf_ble_smp>` page for the implementation details and guide on how to perform the firmware update in the `nRF Connect for Mobile`_ application.


### PR DESCRIPTION
Change updates documentation to inform about both modules used for the DFU over SMP. Change also contains other small improvements related to the SMP DFU documentation.

Jira: NCSDK-21667