### PR TITLE
Enable external flash in nrf cloud samples

### DIFF
--- a/samples/nrf9160/nrf_cloud_mqtt_multi_service/boards/nrf9160dk_nrf9160_ns_0_14_0.overlay
+++ b/samples/nrf9160/nrf_cloud_mqtt_multi_service/boards/nrf9160dk_nrf9160_ns_0_14_0.overlay
@@ -10,6 +10,11 @@
 	};
 };
 
+/* External flash device is disabled by default */
+&mx25r64 {
+	status = "okay";
+};
+
 /* Enable high drive mode for the SPI3 pins to get a square signal at 8 MHz */
 &spi3_default {
 	group1 {

--- a/samples/nrf9160/nrf_cloud_mqtt_multi_service/child_image/mcuboot/boards/nrf9160dk_nrf9160_0_14_0.overlay
+++ b/samples/nrf9160/nrf_cloud_mqtt_multi_service/child_image/mcuboot/boards/nrf9160dk_nrf9160_0_14_0.overlay
@@ -10,6 +10,11 @@
 	};
 };
 
+/* External flash device is disabled by default */
+&mx25r64 {
+	status = "okay";
+};
+
 /* Enable high drive mode for the SPI3 pins to get a square signal at 8 MHz */
 &spi3_default {
 	group1 {

--- a/samples/nrf9160/nrf_cloud_rest_fota/boards/nrf9160dk_nrf9160_ns_0_14_0.overlay
+++ b/samples/nrf9160/nrf_cloud_rest_fota/boards/nrf9160dk_nrf9160_ns_0_14_0.overlay
@@ -10,6 +10,11 @@
 	};
 };
 
+/* External flash device is disabled by default */
+&mx25r64 {
+	status = "okay";
+};
+
 /* Enable high drive mode for the SPI3 pins to get a square signal at 8 MHz */
 &spi3_default {
 	group1 {


### PR DESCRIPTION
External flash has been disabled by default: https://github.com/nrfconnect/sdk-zephyr/commit/a190997328d0f388e74c5d38071ed8e7d88c36fa#diff-a1bd366df81d234adb8293fd38dac1c3ad0c20283ff1722bb44f6d23140ca11e
Enable it for the nrf_cloud samples that require it.