### PR TITLE
boards: nrf5340: use nrf_reset_network_force_off

### DIFF
--- a/boards/arm/nrf7002dk_nrf5340/nrf5340_cpunet_reset.c
+++ b/boards/arm/nrf7002dk_nrf5340/nrf5340_cpunet_reset.c
@@ -9,6 +9,7 @@
 #include <zephyr/logging/log.h>
 
 #include <soc.h>
+#include <hal/nrf_reset.h>
 
 LOG_MODULE_REGISTER(nrf7002dk_nrf5340_cpuapp, CONFIG_LOG_DEFAULT_LEVEL);
 
@@ -47,7 +48,7 @@ static int remoteproc_mgr_boot(void)
 	 */
 
 	/* Release the Network MCU, 'Release force off signal' */
-	NRF_RESET->NETWORK.FORCEOFF = RESET_NETWORK_FORCEOFF_FORCEOFF_Release;
+	nrf_reset_network_force_off(NRF_RESET, false);
 
 	LOG_DBG("Network MCU released.");
 #endif /* !CONFIG_TRUSTED_EXECUTION_SECURE */

--- a/boards/arm/nrf7002dk_nrf7001_nrf5340/nrf5340_cpunet_reset.c
+++ b/boards/arm/nrf7002dk_nrf7001_nrf5340/nrf5340_cpunet_reset.c
@@ -9,6 +9,7 @@
 #include <zephyr/logging/log.h>
 
 #include <soc.h>
+#include <hal/nrf_reset.h>
 
 LOG_MODULE_REGISTER(nrf7002dk_nrf7001_nrf5340_cpuapp, CONFIG_LOG_DEFAULT_LEVEL);
 
@@ -47,7 +48,7 @@ static int remoteproc_mgr_boot(void)
 	 */
 
 	/* Release the Network MCU, 'Release force off signal' */
-	NRF_RESET->NETWORK.FORCEOFF = RESET_NETWORK_FORCEOFF_FORCEOFF_Release;
+	nrf_reset_network_force_off(NRF_RESET, false);
 
 	LOG_DBG("Network MCU released.");
 #endif /* !CONFIG_TRUSTED_EXECUTION_SECURE */

--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 6fb229ca3c88b3c7c1ec9b0a2995703032eae4a8
+      revision: c6f38ecdee5e42f4812c2f33053638a1f8cb2cb8
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
The function nrf_reset_network_force_off contains workaround for errata 161 for nRF5340 SoC. This function should be used instead of manual writing to NRF_RESET->NETWORK.FORCEOFF register.