### PR TITLE
samples: wifi: Fix twister failure

### DIFF
--- a/samples/wifi/shell/sample.yaml
+++ b/samples/wifi/shell/sample.yaml
@@ -200,7 +200,7 @@ tests:
   sample.nrf7002.superset.debug:
     build_only: true
     extra_args:
-      OVERLAY_CONFIG="overlay-zperf.conf overlay-debug.conf"
+      OVERLAY_CONFIG=overlay-debug.conf;overlay-zperf.conf
       CONFIG_NRF700X_UTIL=y
       CONFIG_WPA_CLI=y
       CONFIG_NET_IPV4_FRAGMENT=y


### PR DESCRIPTION
Separate the conf files in OVERLAY_CONFIG with ";" instead of space. This fixes the twister error.