### PR TITLE
manifest: Update zephyr revision to pull bt_conn_auth_cb_overlay fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 72190c87d49c1039fe2159ab355504ea3e7261a5
+      revision: 10d1197916f81fd8017c2962a88476aba671c773
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This change pulls NULL pointer dereference fix in
bt_conn_auth_cb_overlay in BT host.

Jira: NCSDK-20049