### PR TITLE
boards: nrf52833dongle_nrf52833: Update pin assignment

### DIFF
--- a/applications/nrf_desktop/configuration/nrf52833dongle_nrf52833/app.overlay
+++ b/applications/nrf_desktop/configuration/nrf52833dongle_nrf52833/app.overlay
@@ -57,32 +57,32 @@
 &pinctrl {
 	pwm0_default_alt: pwm0_default_alt {
 		group1 {
-			psels = <NRF_PSEL(PWM_OUT0, 1, 9)>;
+			psels = <NRF_PSEL(PWM_OUT0, 0, 15)>;
 			nordic,invert;
 		};
 	};
 
 	pwm0_sleep_alt: pwm0_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(PWM_OUT0, 1, 9)>;
+			psels = <NRF_PSEL(PWM_OUT0, 0, 15)>;
 			low-power-enable;
 		};
 	};
 
 	pwm1_default_alt: pwm1_default_alt {
 		group1 {
-			psels = <NRF_PSEL(PWM_OUT0, 0, 11)>,
-				<NRF_PSEL(PWM_OUT1, 0, 15)>,
-				<NRF_PSEL(PWM_OUT2, 0, 17)>;
+			psels = <NRF_PSEL(PWM_OUT0, 0, 20)>,
+				<NRF_PSEL(PWM_OUT1, 0, 28)>,
+				<NRF_PSEL(PWM_OUT2, 0, 29)>;
 			nordic,invert;
 		};
 	};
 
 	pwm1_sleep_alt: pwm1_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(PWM_OUT0, 0, 11)>,
-				<NRF_PSEL(PWM_OUT1, 0, 15)>,
-				<NRF_PSEL(PWM_OUT2, 0, 17)>;
+			psels = <NRF_PSEL(PWM_OUT0, 0, 20)>,
+				<NRF_PSEL(PWM_OUT1, 0, 28)>,
+				<NRF_PSEL(PWM_OUT2, 0, 29)>;
 			low-power-enable;
 		};
 	};

--- a/applications/nrf_desktop/configuration/nrf52833dongle_nrf52833/port_state_def.h
+++ b/applications/nrf_desktop/configuration/nrf52833dongle_nrf52833/port_state_def.h
@@ -19,8 +19,6 @@ const struct {} port_state_def_include_once;
 
 
 static const struct pin_state port0_on[] = {
-	{DT_GPIO_PIN(DT_ALIAS(led1), gpios), 1},
-	{DT_GPIO_PIN(DT_ALIAS(led2), gpios), 1}
 };
 
 static const struct pin_state port1_on[] = {

--- a/applications/nrf_desktop/configuration/nrf52840dongle_nrf52840/port_state_def.h
+++ b/applications/nrf_desktop/configuration/nrf52840dongle_nrf52840/port_state_def.h
@@ -19,11 +19,9 @@ const struct {} port_state_def_include_once;
 
 
 static const struct pin_state port0_on[] = {
-	{DT_GPIO_PIN(DT_ALIAS(led1), gpios), 1}
 };
 
 static const struct pin_state port1_on[] = {
-	{DT_GPIO_PIN(DT_ALIAS(led2), gpios), 1}
 };
 
 static const struct pin_state port0_off[] = {

--- a/boards/arm/nrf52833dongle_nrf52833/nrf52833dongle_nrf52833.dts
+++ b/boards/arm/nrf52833dongle_nrf52833/nrf52833dongle_nrf52833.dts
@@ -21,19 +21,19 @@
 	leds {
 		compatible = "gpio-leds";
 		led0_green: led_0 {
-			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
 			label = "Green LED 0";
 		};
 		led1_red: led_1 {
-			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio0 20 GPIO_ACTIVE_LOW>;
 			label = "Red LED 1";
 		};
 		led1_green: led_2 {
-			gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio0 28 GPIO_ACTIVE_LOW>;
 			label = "Green LED 1";
 		};
 		led1_blue: led_3 {
-			gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio0 29 GPIO_ACTIVE_LOW>;
 			label = "Blue LED 1";
 		};
 	};
@@ -41,7 +41,7 @@
 	buttons {
 		compatible = "gpio-keys";
 		button0: button_0 {
-			gpios = <&gpio0 10 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			gpios = <&gpio0 17 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "Push button switch 0";
 		};
 	};
@@ -87,18 +87,18 @@
 	uart0_default: uart0_default {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 0, 31)>,
-				<NRF_PSEL(UART_RTS, 0, 29)>,
+				<NRF_PSEL(UART_RTS, 0, 2)>,
 				<NRF_PSEL(UART_RX, 0, 30)>,
-				<NRF_PSEL(UART_CTS, 0, 28)>;
+				<NRF_PSEL(UART_CTS, 0, 3)>;
 		};
 	};
 
 	uart0_sleep: uart0_sleep {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 0, 31)>,
-				<NRF_PSEL(UART_RTS, 0, 29)>,
+				<NRF_PSEL(UART_RTS, 0, 2)>,
 				<NRF_PSEL(UART_RX, 0, 30)>,
-				<NRF_PSEL(UART_CTS, 0, 28)>;
+				<NRF_PSEL(UART_CTS, 0, 3)>;
 			low-power-enable;
 		};
 	};

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -264,6 +264,7 @@ nRF Desktop
   * Set the max compiled-in log level to ``warning`` for the Bluetooth HCI core (:kconfig:option:`CONFIG_BT_HCI_CORE_LOG_LEVEL`).
     This is done to avoid flooding logs during application boot.
   * The documentation with debug Fast Pair provisioning data obtained for development purposes.
+  * Aligned the nRF52833 dongle's board DTS configuration files and nRF Desktop's application-specific DTS overlays to hardware revision 0.2.1.
 
 Samples
 =======


### PR DESCRIPTION
Update pin assignment to match new hardware revision. Change also updates the nRF Desktop application.

Remove LED pins from `port_state_def.h` files in nRF Desktop dongle's configurations. Brightness of these LEDs is controlled by CAF LEDs module.

Jira: NCSDK-19933