### PR TITLE
Mfp display

### DIFF
--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw/host_rpu_umac_if.h
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw/host_rpu_umac_if.h
@@ -2878,6 +2878,9 @@ struct nrf_wifi_umac_event_new_scan_results {
 #define NRF_WIFI_802_11AC (1 << 4)
 #define NRF_WIFI_802_11AX (1 << 5)
 
+#define NRF_WIFI_MFP_REQUIRED (1 << 0)
+#define NRF_WIFI_MFP_CAPABLE  (1 << 1)
+
 struct umac_display_results {
 	struct nrf_wifi_ssid ssid;
 	unsigned char mac_addr[NRF_WIFI_ETH_ADDR_LEN];
@@ -2889,7 +2892,7 @@ struct umac_display_results {
 	unsigned short capability;
 	struct nrf_wifi_signal signal;
 	unsigned char twt_support;
-	unsigned char reserved2;
+	unsigned char mfp_flag;
 	unsigned char reserved3;
 	unsigned char reserved4;
 } __NRF_WIFI_PKD;

--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_wifi_mgmt.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_wifi_mgmt.c
@@ -161,6 +161,17 @@ out:
 	return status;
 }
 
+static inline enum wifi_mfp_options drv_to_wifi_mgmt_mfp(unsigned char mfp_flag)
+{
+	if (!mfp_flag)
+		return WIFI_MFP_DISABLE;
+	if (mfp_flag & NRF_WIFI_MFP_REQUIRED)
+		return WIFI_MFP_REQUIRED;
+	if (mfp_flag & NRF_WIFI_MFP_CAPABLE)
+		return WIFI_MFP_OPTIONAL;
+
+	return WIFI_MFP_UNKNOWN;
+}
 static inline enum wifi_security_type drv_to_wifi_mgmt(int drv_security_type)
 {
 	switch (drv_security_type) {
@@ -218,6 +229,8 @@ void wifi_nrf_event_proc_disp_scan_res_zep(void *vif_ctx,
 		res.channel = r->nwk_channel;
 
 		res.security = drv_to_wifi_mgmt(r->security_type);
+
+		res.mfp = drv_to_wifi_mgmt_mfp(r->mfp_flag);
 
 		memcpy(res.ssid,
 		       r->ssid.nrf_wifi_ssid,

--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 5acaefeafa7a96bd8199a94f520dbdacc7d14160
+      revision: 1b36aa5754cfb699e3599b66ba21c4192fc35227
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Incorrect information of MFP capabilities was getting displayed. This fixes the information that driver passes up to the application.