### PR TITLE
doc: Update External flash memory

### DIFF
--- a/doc/nrf/working_with_nrf/nrf91/nrf9160.rst
+++ b/doc/nrf/working_with_nrf/nrf91/nrf9160.rst
@@ -328,6 +328,11 @@ Then add the following relevant devicetree blocks to the application`s devicetre
 
 .. code-block:: devicetree
 
+   /* Enable the external flash device (required) */
+   &mx25r64 {
+	    status = "okay";
+   };
+
    /* Configure partition manager to use mx25r64 as the external flash device */
    / {
        chosen {


### PR DESCRIPTION
The mx25r64 device tree node is disabled by default upstream. This requires explicit enabling of the mx25r64 device in an overlay for applications and samples using external flash.