### PR TITLE
manifest: Update SDC revision to not include headers when build from src

### DIFF
--- a/subsys/bluetooth/CMakeLists.txt
+++ b/subsys/bluetooth/CMakeLists.txt
@@ -17,7 +17,3 @@ add_subdirectory_ifdef(CONFIG_BT_MESH mesh)
 add_subdirectory_ifdef(CONFIG_BT_NRF_SERVICES services)
 
 add_subdirectory_ifdef(CONFIG_BT_RPC rpc)
-
-if(CONFIG_BT)
-  zephyr_link_libraries(INTERFACE SOFTDEVICE_CONTROLLER_LIB_HEADERS)
-endif()

--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -16,6 +16,12 @@ config BT_MAX_CONN
 	range 1 20 if BT_LL_SOFTDEVICE
 	default 2 if BT_LL_SOFTDEVICE && BT_CENTRAL && BT_PERIPHERAL
 
+config BT_LL_SOFTDEVICE_HEADERS_INCLUDE
+	bool
+	default y if !BT_CTLR
+	help
+	  Include SoftDevice header files provided with the library.
+
 if BT_CTLR
 rsource "controller/Kconfig"
 endif

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -47,6 +47,7 @@ choice BT_LL_SOFTDEVICE_BUILD_TYPE
 
 config BT_LL_SOFTDEVICE_BUILD_TYPE_LIB
 	bool "Use library"
+	select BT_LL_SOFTDEVICE_HEADERS_INCLUDE
 
 endchoice
 

--- a/west.yml
+++ b/west.yml
@@ -131,7 +131,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 7a073076f8df142918e053f7143589d00009e955
+      revision: e9735b27c7b341f6517c1d0c24a1467562f6042f
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Update SDC revision to avoid include nrfxlib/softdevice_controller header files when SDC is build from sources as submodule.

Signed-off-by: Piotr Pryga [piotr.pryga@nordicsemi.no](mailto:piotr.pryga@nordicsemi.no)