### PR TITLE
samples: matter: Fixed door lock feature map.

### DIFF
--- a/samples/matter/lock/src/zcl_callbacks.cpp
+++ b/samples/matter/lock/src/zcl_callbacks.cpp
@@ -111,12 +111,6 @@ void emberAfDoorLockClusterInitCallback(EndpointId endpoint)
 			     endpoint, CONFIG_LOCK_NUM_CREDENTIALS_PER_USER),
 		     "number of credentials per user");
 
-	/*
-	 * Set FeatureMap to (kUser|kPinCredential), default is:
-	 * (kUser|kAccessSchedules|kRfidCredential|kPinCredential) 0x113
-	 */
-	logOnFailure(DoorLock::Attributes::FeatureMap::Set(endpoint, 0x101), "feature map");
-
 	AppTask::Instance().UpdateClusterState(BoltLockMgr().GetState(),
 					       BoltLockManager::OperationSource::kUnspecified);
 }


### PR DESCRIPTION
Door lock sample has incorrect feature map value, because it is hardcoded in cpp file, instead of using the value generated from the .zap file.