### PR TITLE
matter: pull change to update default number of RTC channels

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -105,6 +105,7 @@ Matter
   * The :ref:`ug_matter_tools` page with installation instructions for the ZAP tool, moved from the :ref:`ug_matter_creating_accessory` page.
   * The :ref:`ug_matter_tools` page with information about CHIP Tool, CHIP Certificate Tool, and the Spake2+ Python tool.
   * The :ref:`ug_matter_device_low_power_configuration` page with information about sleepy active threshold parameter configuration.
+  * The default number of user RTC channels on the nRF5340 SoC's network core from 2 to 3 (the platform default) to fix the CSL transmitter feature on Matter over Thread devices acting as Thread routers.
 
 See `Matter samples`_ for the list of changes for the Matter samples.
 

--- a/west.yml
+++ b/west.yml
@@ -139,7 +139,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 082cdb90668c658e227777fc38054dd7775a618c
+      revision: 5d9f36f7dd414406bbef0b754c3a52ecbb2fed17
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
Update the default number of RTC channels on nRF5340 to fix the CSL transmitter feature.