### PR TITLE
tests: crypto: remove redundant harness config

### DIFF
--- a/tests/crypto/testcase.yaml
+++ b/tests/crypto/testcase.yaml
@@ -7,10 +7,6 @@ tests:
       - nrf9160dk_nrf9160
       - nrf5340dk_nrf5340_cpuapp
     tags: crypto ci_build legacy builtin_legacy
-    harness_config:
-      type: multi_line
-      regex:
-        - ".*PROJECT EXECUTION SUCCESSFUL.*"
     timeout: 600
   crypto.cc3xx:
     extra_args: OVERLAY_CONFIG=overlay-cc3xx.conf
@@ -20,10 +16,6 @@ tests:
       - nrf9160dk_nrf9160
       - nrf5340dk_nrf5340_cpuapp
     tags: crypto ci_build legacy cc3xx_legacy
-    harness_config:
-      type: multi_line
-      regex:
-        - ".*PROJECT EXECUTION SUCCESSFUL.*"
     timeout: 200
   crypto.oberon:
     extra_args: OVERLAY_CONFIG=overlay-oberon.conf
@@ -33,8 +25,4 @@ tests:
       - nrf9160dk_nrf9160
       - nrf5340dk_nrf5340_cpuapp
     tags: crypto ci_build legacy oberon_legacy
-    harness_config:
-      type: multi_line
-      regex:
-        - ".*PROJECT EXECUTION SUCCESSFUL.*"
     timeout: 200


### PR DESCRIPTION
For tests written with Ztest framework there it is unnecessary to provide in `testcase.yaml` file information about expected regex. If `harness` option is not specified in `testcase.yaml`, then Twister by default use `ztest` harness, and information passed in `harness_config` will be ignored. Default `ztest` harness has defined appropriate expected regexes in its source code.