### PR TITLE
manifest: Bugfix for external flash with single slot MCUBoot

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -128,7 +128,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: c28768eb2aa7b68e1420b7e260f6139b5b019ebd
+      revision: pull/257/head
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR.git


### PR DESCRIPTION
This is a bugfix where you can't update the network core using only a single secondary slot in external flash. This is due to the fact that the network core update data is inaccessible to the network core in external flash and needs to be copied into the ram of the application core.

Ref: NCSDK-21379