### PR TITLE
Doc: Bluetooth: Mesh: Add info about NLC

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -644,6 +644,7 @@
 
 .. _`Bluetooth mesh model specification`:
 .. _`Bluetooth mesh profile specification`: https://www.bluetooth.com/specifications/specs/
+.. _`Bluetooth NLC profile specifications`: https://www.bluetooth.com/specifications/specs/
 
 .. _`Bluetooth mesh model overview`: https://www.bluetooth.com/bluetooth-resources/bluetooth-mesh-models/
 .. _`Bluetooth mesh glossary`: https://www.bluetooth.com/learn-about-bluetooth/recent-enhancements/mesh/mesh-glossary/

--- a/doc/nrf/protocols/bt_mesh/index.rst
+++ b/doc/nrf/protocols/bt_mesh/index.rst
@@ -30,6 +30,7 @@ Make also sure to check the official `Bluetooth mesh glossary`_.
    architecture
    configuring
    model_config_app
+   nlc
    ble_mesh_dfu_samples
    fota
    node_removal

--- a/doc/nrf/protocols/bt_mesh/nlc.rst
+++ b/doc/nrf/protocols/bt_mesh/nlc.rst
@@ -1,0 +1,30 @@
+.. _ug_bt_mesh_nlc:
+
+Networked Lighting Control profiles
+###################################
+
+Bluetooth® Networked Lighting Control (NLC) profiles are a set of device profiles built on top of the Bluetooth mesh protocol, specified by the Bluetooth Special Interest Group (SIG) in the `Bluetooth NLC profile specifications`_.
+The NLC profiles can be used to implement interoperable network controlled lighting setups, including sensors, light fixtures, energy monitoring, scene selectors and dimmer controls.
+Each of the profiles specifies a set of models and a set of performance parameters.
+
+The |NCS| provides a demonstration of how to implement each of these profiles as part of the Bluetooth samples.
+An overview of the NLC profiles and the samples supporting them is provided in a table below.
+
+.. table::
+   :align: center
+
+   +-----------------------------------------+--------------------------------------+
+   | NLC profile                             | Sample                               |
+   +=========================================+======================================+
+   | Ambient Light Sensor NLC Profile        | :ref:`bluetooth_mesh_sensor_server`  |
+   +-----------------------------------------+--------------------------------------+
+   | Basic Lightness Controller NLC Profile  | :ref:`bluetooth_mesh_light_lc`       |
+   +-----------------------------------------+--------------------------------------+
+   | Basic Scene Selector NLC Profile        | :ref:`bluetooth_mesh_light_dim`      |
+   +-----------------------------------------+--------------------------------------+
+   | Dimming Control NLC Profile             | :ref:`bluetooth_mesh_light_dim`      |
+   +-----------------------------------------+--------------------------------------+
+   | Energy Monitor NLC Profile              | :ref:`bluetooth_mesh_light_lc`       |
+   +-----------------------------------------+--------------------------------------+
+   | Occupancy Sensor NLC Profile            | :ref:`bluetooth_mesh_sensor_server`  |
+   +-----------------------------------------+--------------------------------------+

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -82,6 +82,7 @@ Bluetooth mesh
 * Updated the protocol user guide with the information about :ref:`ble_mesh_dfu_samples`.
 * Updated the default configuration of advertising sets used by the Bluetooth mesh subsystem to improve performance of the Relay, GATT and Friend features.
   This configuration is specified in the :file:`ncs/nrf/subsys/bluetooth/mesh/Kconfig` file.
+* Updated samples :ref:`bluetooth_mesh_sensor_server`, :ref:`bluetooth_mesh_light_lc` and :ref:`bluetooth_mesh_light_dim` to demonstrate the Bluetooth :ref:`ug_bt_mesh_nlc`.
 
 See `Bluetooth mesh samples`_ for the list of changes in the Bluetooth mesh samples.
 

--- a/samples/bluetooth/mesh/light_ctrl/README.rst
+++ b/samples/bluetooth/mesh/light_ctrl/README.rst
@@ -9,6 +9,11 @@ Bluetooth: Mesh light fixture
 
 The Bluetooth® mesh light fixture sample demonstrates how to set up a light control mesh server model application, and control a dimmable LED with Bluetooth mesh using the :ref:`bt_mesh_onoff_readme`.
 
+This sample demonstrates how to implement the following :ref:`ug_bt_mesh_nlc`:
+
+  * Basic Lightness Controller NLC Profile
+  * Energy Monitor NLC Profile
+
 Requirements
 ************
 

--- a/samples/bluetooth/mesh/light_dimmer/README.rst
+++ b/samples/bluetooth/mesh/light_dimmer/README.rst
@@ -13,6 +13,11 @@ The sample provides the following functionality:
   * On/off and dim up/down using one button
   * Scene recall/store of light levels with a second button
 
+This sample demonstrates how to implement the following :ref:`ug_bt_mesh_nlc`:
+
+  * Dimming Control NLC Profile
+  * Basic Scene Selector NLC Profile
+
 Requirements
 ************
 

--- a/samples/bluetooth/mesh/sensor_server/README.rst
+++ b/samples/bluetooth/mesh/sensor_server/README.rst
@@ -15,6 +15,11 @@ In addition, the samples demonstrate usage of both :ref:`single-channel sensor t
    This sample must be paired with the :ref:`bluetooth_mesh_sensor_client` sample to show any functionality.
    The mesh sensor provides the sensor data used by the observer.
 
+This sample demonstrates how to implement the following :ref:`ug_bt_mesh_nlc`:
+
+  * Ambient Light Sensor NLC Profile
+  * Occupancy Sensor NLC Profile
+
 Requirements
 ************
 


### PR DESCRIPTION
This adds information about NLC profiles, and which samples demonstrate which NLC profiles, to the documentation.