### PR TITLE
cmake: Enable link time optimization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,11 @@ set(NRF_DIR ${CMAKE_CURRENT_LIST_DIR} CACHE PATH "NCS root directory")
 # is cached.
 set(CONF_FILE_BUILD_TYPE ${CONF_FILE_BUILD_TYPE} CACHE INTERNAL "The build type")
 
+# Enable Link Time Optimization
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CONFIG_SIZE_OPTIMIZATIONS)
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -flto")
+endif()
+
 include(cmake/extensions.cmake)
 include(cmake/version.cmake)
 include(cmake/multi_image.cmake)

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_agps.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_agps.c
@@ -24,7 +24,7 @@ LOG_MODULE_REGISTER(nrf_cloud_agps, CONFIG_NRF_CLOUD_GPS_LOG_LEVEL);
 #include "nrf_cloud_transport.h"
 #include "nrf_cloud_agps_schema_v1.h"
 
-extern void agps_print(enum nrf_cloud_agps_type type, void *data);
+extern void agps_print(uint16_t type, void *data);
 
 static K_SEM_DEFINE(agps_injection_active, 1, 1);
 

--- a/tests/mocks/nrf_modem_at/mock_nrf_modem_at.c
+++ b/tests/mocks/nrf_modem_at/mock_nrf_modem_at.c
@@ -171,7 +171,7 @@ void __mock_nrf_modem_at_scanf_ReturnVarg_string(char *value)
 	strcpy(varg->value.str, value);
 }
 
-int __cmock_nrf_modem_at_scanf(const char *cmd, const char *fmt, ...)
+int  __attribute__((used)) __cmock_nrf_modem_at_scanf(const char *cmd, const char *fmt, ...)
 {
 	int i = 0;
 	va_list args;


### PR DESCRIPTION
Link time optimization is now enabled when the compiler is GNU and the
KConfig option CONFIG_SIZE_OPTIMIZATIONS is enabled.


Application | Compiled for | FLASH usage with LTO | FLASH usage Before LTO | Improvement
-- | -- | -- | -- | --
nrf5340_audio | nrf5340_audio_dk_nrf5340_cpuapp | 578988 | 578988 | 0
atv2 | nrf9160dk_nrf9160_ns | 254012 | 263072 | 9060
atv2 | nrf9160dk_nrf9160_ns -- -DSHIELD=nrf7002ek_nrf7002 -DOVERLAY_CONFIG=overlay-nrf7002ek-wifi-scan-only.conf -D DTC_OVERLAY_FILE="nrf9160dk_with_nrf7002ek.overlay" | 365180 | 376864 | 11684
atv2 | nrf9160dk_nrf9160_ns -- -DSHIELD=nrf7002ek_nrf7002 -DOVERLAY_CONFIG=overlay-nrf7002ek-wifi-scan-only.conf;overlay-debug.conf -D DTC_OVERLAY_FILE="nrf9160dk_with_nrf7002ek.overlay" | OVERFLOW by 5584 bytes | OVERFLOW by 17 Kbytes |  
nrf_desktop | nrf52833dk_nrf52820 | 227680 | 227620 | -60
zigbee_weather_station | thingy53_nrf5340_cpuapp | 275260 | 275324 | 64
machine_learning | thingy53_nrf5340_cpuapp | 491996 | 491996 | 0
serial_lte_modem | nrf9160dk_nrf9160_ns | 245072 | 244524 | -548


Signed-off-by: Balaji Srinivasan <balaji.srinivasan@nordicsemi.no>
