### PR TITLE
nrf_802154: nrf_802154_serialization_error never returns

### DIFF
--- a/samples/nrf5340/multiprotocol_rpmsg/src/main.c
+++ b/samples/nrf5340/multiprotocol_rpmsg/src/main.c
@@ -265,9 +265,11 @@ void nrf_802154_serialization_error(const nrf_802154_ser_err_data_t *err)
 {
 	(void)err;
 	__ASSERT(false, "802.15.4 serialization error");
+	k_oops();
 }
 
 void nrf_802154_sl_fault_handler(uint32_t id, int32_t line, const char *err)
 {
 	__ASSERT(false, "module_id: %u, line: %d, %s", id, line, err);
+	k_oops();
 }


### PR DESCRIPTION
Functions nrf_802154_serialization_error and
nrf_802154_sl_fault_handler shall never return.
However `__ASSERT()` might expand to an empty instruction CONFIG_ASSERT=n and is not enough to stop execution.

Similar changes to 802154_rpmsg app and the shim ieee802154_nrf5.c in upstream zephyr https://github.com/zephyrproject-rtos/zephyr/pull/58173 - they are expected to be available on regular upmerge.