### PR TITLE
samples: nrf9160: enable external flash in DK overlays using it

### DIFF
--- a/samples/nrf9160/http_update/full_modem_update/boards/nrf9160dk_nrf9160_ns.overlay
+++ b/samples/nrf9160/http_update/full_modem_update/boards/nrf9160dk_nrf9160_ns.overlay
@@ -9,7 +9,7 @@
 		   <&gpio0 25 GPIO_ACTIVE_LOW>;
 	mx25r64: mx25r6435f@1 {
 		compatible = "jedec,spi-nor";
-		reg = <0>;
+		reg = <1>;
 		status = "okay";
 		spi-max-frequency = <80000000>;
 		jedec-id = [c2 28 17];

--- a/samples/nrf9160/lwm2m_client/boards/nrf9160dk_nrf9160_ns.overlay
+++ b/samples/nrf9160/lwm2m_client/boards/nrf9160dk_nrf9160_ns.overlay
@@ -21,7 +21,7 @@
 		   <&gpio0 25 GPIO_ACTIVE_LOW>;
 	mx25r64: mx25r6435f@1 {
 		compatible = "jedec,spi-nor";
-		reg = <0>;
+		reg = <1>;
 		status = "okay";
 		spi-max-frequency = <80000000>;
 		jedec-id = [c2 28 17];


### PR DESCRIPTION
Fixup for external flash chip select. Fixes 879c6254ffe8e5b6e9ed0582fe1cb5863a298c6a