### PR TITLE
doc: add mention of nRF7002 EB to Thingy:53 documentation

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -823,6 +823,7 @@ Documentation
 * Added:
 
   * A page on :ref:`ug_nrf70_developing_regulatory_support` in the :ref:`ug_nrf70_developing` user guide.
+  * A section on :ref:`building Wi-Fi applications<thingy53_build_pgm_targets_wifi>` to the :ref:`ug_thingy53` page.
 
 * Updated:
 

--- a/doc/nrf/working_with_nrf/nrf53/thingy53.rst
+++ b/doc/nrf/working_with_nrf/nrf53/thingy53.rst
@@ -70,6 +70,23 @@ For more information about files generated as output of the build process, see :
 See the following sections for details regarding building and programming the firmware for Thingy:53 in various environments.
 See :ref:`thingy53_app_update` for more detailed information about updating firmware on Thingy:53.
 
+.. _thingy53_build_pgm_targets_wifi:
+
+Building Wi-Fi applications on Thingy:53
+----------------------------------------
+
+You can use the Nordic Thingy:53 with the nRF7002 Expansion Board (EB) for Wi-Fi development.
+Connect the nRF7002 EB to the **P9** connector on Thingy:53.
+
+To build for the nRF7002 EB with Thingy:53, use the ``thingy53_nrf5340_cpuapp`` build target with the CMake ``SHIELD`` variable set to ``nrf7002eb_nrf7002``.
+For example, you can use the following command when building on the command line:
+
+.. code-block::
+
+   west build -b thingy53_nrf5340_cpuapp -- -DSHIELD=nrf7002eb_nrf7002
+
+For the compatible Wi-Fi samples in the |NCS|, see the :ref:`wifi_samples` section.
+
 .. _thingy53_build_pgm_vscode:
 
 Building and programming using |VSC|


### PR DESCRIPTION
Wi-Fi development with Thingy:53 will be supported using the nRF7002 Expansion Board. This adds necessary information to the Developing with Thingy:53 page.