### PR TITLE
samples: memfault: Add missing board file

### DIFF
--- a/samples/debug/memfault/boards/nrf9161dk_nrf9161_ns.conf
+++ b/samples/debug/memfault/boards/nrf9161dk_nrf9161_ns.conf
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Modem library
+CONFIG_NRF_MODEM_LIB=y
+
+# LTE link control
+CONFIG_LTE_LINK_CONTROL=y
+CONFIG_LTE_NETWORK_MODE_LTE_M_NBIOT=y
+CONFIG_PDN=y
+CONFIG_PDN_ESM_STRERROR=y
+
+# Network
+CONFIG_NET_NATIVE=n
+CONFIG_NET_SOCKETS=y
+CONFIG_NET_SOCKETS_OFFLOAD=y
+
+# Memfault
+CONFIG_MEMFAULT_NCS_LTE_METRICS=y
+
+# Certificate management
+CONFIG_MEMFAULT_ROOT_CERT_STORAGE_NRF9160_MODEM=y
+CONFIG_MODEM_KEY_MGMT=y
+
+# AT command capability in shell
+CONFIG_AT_SHELL=y
+CONFIG_SHELL_WILDCARD=n


### PR DESCRIPTION
Board file for nrf9161 dk was missing.