### PR TITLE
Bluetooth: Mesh: Free up space in network core

### DIFF
--- a/subsys/bluetooth/mesh/hci_rpmsg_child_image_overlay.conf
+++ b/subsys/bluetooth/mesh/hci_rpmsg_child_image_overlay.conf
@@ -10,3 +10,16 @@
 # configuration.
 CONFIG_BT_EXT_ADV=y
 CONFIG_BT_EXT_ADV_MAX_ADV_SET=5
+
+# Reduce buffers to free up some space in RAM
+# This replicates configuration for single-core devices
+CONFIG_BT_BUF_ACL_RX_SIZE=37
+CONFIG_BT_BUF_ACL_TX_SIZE=37
+CONFIG_BT_CTLR_DATA_LENGTH_MAX=37
+
+# Disable unused Bluetooth features
+CONFIG_BT_CTLR_DUP_FILTER_LEN=0
+CONFIG_BT_CTLR_LE_ENC=n
+CONFIG_BT_CTLR_CHAN_SEL_2=n
+CONFIG_BT_CTLR_MIN_USED_CHAN=n
+CONFIG_BT_CTLR_PRIVACY=n


### PR DESCRIPTION
Free up space in network core by copying controller configuration from single-core devices.