### PR TITLE
samples: nrf9160: fmfu_smp_svr: Increase main stack size

### DIFF
--- a/samples/nrf9160/fmfu_smp_svr/prj.conf
+++ b/samples/nrf9160/fmfu_smp_svr/prj.conf
@@ -26,6 +26,9 @@ CONFIG_MCUBOOT_BOOTUTIL_LIB=y
 # Some command handlers require a large stack.
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
 
+# nrf_modem requires a larger main stack than is default
+CONFIG_MAIN_STACK_SIZE=2048
+
 # Enable the UART mcumgr transports.
 CONFIG_MCUMGR_TRANSPORT_UART=y
 CONFIG_BASE64=y


### PR DESCRIPTION
nrf_modem_lib_shutdown requires a larger stack to avoid a stack overflow.