### PR TITLE
doc improvement: change warnings to cautions

### DIFF
--- a/doc/nrf/app_dev/bootloaders_and_dfu/fw_update.rst
+++ b/doc/nrf/app_dev/bootloaders_and_dfu/fw_update.rst
@@ -305,7 +305,7 @@ To assign a semantic version number to your application, pass the version string
 
 See the `Semantic versioning`_ webpage or :doc:`mcuboot:imgtool` for details on version syntax.
 
-.. warning::
+.. caution::
 
    Enabling ``CONFIG_BOOT_UPGRADE_ONLY`` prevents the fallback recovery of application images.
    Consult its Kconfig description and the :doc:`MCUboot Design documentation <mcuboot:design>` for more information on how to use it.

--- a/doc/nrf/libraries/bluetooth_services/mesh/light_ctrl_srv.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/light_ctrl_srv.rst
@@ -384,7 +384,7 @@ When powering up, the Light LC Server behavior depends on the controlled Light L
 * On Power Up is :c:enumerator:`BT_MESH_ON_POWER_UP_RESTORE` - The Light LC Server is enabled and takes control of the Lightness Server.
   If the last known value of the Light OnOff state was On, the Light LC Server triggers a transition to the On state.
 
-.. warning::
+.. caution::
     The Light LC Server is only re-enabled on startup if the Light Lightness Server's extended Generic Power OnOff Server is in the restore mode.
 
 API documentation


### PR DESCRIPTION
A couple of docs had a warning. They are only used if there is a risk of personal injury or death.