### PR TITLE
Bluetooth: Mesh: Fix Sensor Server sample

### DIFF
--- a/include/bluetooth/mesh/sensor_srv.h
+++ b/include/bluetooth/mesh/sensor_srv.h
@@ -51,11 +51,12 @@ struct bt_mesh_sensor_srv;
 			 BT_MESH_MODEL_USER_DATA(struct bt_mesh_sensor_srv,    \
 						 _srv),                        \
 			 &_bt_mesh_sensor_srv_cb),                             \
-	BT_MESH_MODEL(BT_MESH_MODEL_ID_SENSOR_SETUP_SRV,                       \
-		      _bt_mesh_sensor_setup_srv_op,                            \
-		      &(_srv)->setup_pub,                                      \
-		      BT_MESH_MODEL_USER_DATA(struct bt_mesh_sensor_srv,       \
-					      _srv))
+	BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_SENSOR_SETUP_SRV,                    \
+			 _bt_mesh_sensor_setup_srv_op,                         \
+			 &(_srv)->setup_pub,                                   \
+			 BT_MESH_MODEL_USER_DATA(struct bt_mesh_sensor_srv,    \
+					      _srv),                           \
+			 &_bt_mesh_sensor_setup_srv_cb)
 
 /** Sensor server instance. */
 struct bt_mesh_sensor_srv {
@@ -146,6 +147,7 @@ int bt_mesh_sensor_srv_sample(struct bt_mesh_sensor_srv *srv,
 /** @cond INTERNAL_HIDDEN */
 extern const struct bt_mesh_model_cb _bt_mesh_sensor_srv_cb;
 extern const struct bt_mesh_model_op _bt_mesh_sensor_srv_op[];
+extern const struct bt_mesh_model_cb _bt_mesh_sensor_setup_srv_cb;
 extern const struct bt_mesh_model_op _bt_mesh_sensor_setup_srv_op[];
 /** @endcond */
 

--- a/samples/bluetooth/mesh/sensor_server/README.rst
+++ b/samples/bluetooth/mesh/sensor_server/README.rst
@@ -40,20 +40,27 @@ Overview
 
 The following Bluetooth mesh sensor types, and their settings, are used in this sample:
 
-* :c:var:`bt_mesh_sensor_present_dev_op_temp` - Published by the server according to its publishing period (see :ref:`bluetooth_mesh_sensor_server_conf_models`), or periodically requested by the client.
+* On Sensor Server instance on Element 1:
 
-  * :c:var:`bt_mesh_sensor_dev_op_temp_range_spec` - Used as a setting for the :c:var:`bt_mesh_sensor_present_dev_op_temp` sensor type to set the range of reported temperatures.
+  * :c:var:`bt_mesh_sensor_present_amb_light_level` - Periodically requested by the client.
 
-* :c:var:`bt_mesh_sensor_rel_runtime_in_a_dev_op_temp_range` - Periodically requested by the client.
-* :c:var:`bt_mesh_sensor_presence_detected` - Published when a button is pressed on the server.
-* :c:var:`bt_mesh_sensor_time_since_presence_detected` - Periodically requested by the client and published by the server according to its publishing period (see :ref:`bluetooth_mesh_sensor_server_conf_models`).
+    * :c:var:`bt_mesh_sensor_gain` - Used as a setting for the :c:var:`bt_mesh_sensor_present_amb_light_level` sensor type to set the gain the ambient light sensor value is multiplied with.
+    * :c:var:`bt_mesh_sensor_present_amb_light_level` - Used as a setting for the :c:var:`bt_mesh_sensor_present_amb_light_level` sensor type to calculate sensor gain based on measured reference ambient light level. This value does only have a set command.
 
-  * :c:var:`bt_mesh_sensor_motion_threshold` - Used as a setting for the :c:var:`bt_mesh_sensor_presence_detected` sensor type to set the time (0-10 seconds) before the presence is detected.
+* On Sensor Server instance on Element 2:
 
-* :c:var:`bt_mesh_sensor_present_amb_light_level` - Periodically requested by the client.
+  * :c:var:`bt_mesh_sensor_presence_detected` - Published when a button is pressed on the server.
+  * :c:var:`bt_mesh_sensor_time_since_presence_detected` - Periodically requested by the client and published by the server according to its publishing period (see :ref:`bluetooth_mesh_sensor_server_conf_models`).
 
-  * :c:var:`bt_mesh_sensor_gain` - Used as a setting for the :c:var:`bt_mesh_sensor_present_amb_light_level` sensor type to set the gain the ambient light sensor value is multiplied with.
-  * :c:var:`bt_mesh_sensor_present_amb_light_level` - Used as a setting for the :c:var:`bt_mesh_sensor_present_amb_light_level` sensor type to calculate sensor gain based on measured reference ambient light level. This value does only have a set command.
+    * :c:var:`bt_mesh_sensor_motion_threshold` - Used as a setting for the :c:var:`bt_mesh_sensor_presence_detected` sensor type to set the time (0-10 seconds) before the presence is detected.
+
+* On Sensor Server instance on Element 3:
+
+  * :c:var:`bt_mesh_sensor_present_dev_op_temp` - Published by the server according to its publishing period (see :ref:`bluetooth_mesh_sensor_server_conf_models`), or periodically requested by the client.
+
+    * :c:var:`bt_mesh_sensor_dev_op_temp_range_spec` - Used as a setting for the :c:var:`bt_mesh_sensor_present_dev_op_temp` sensor type to set the range of reported temperatures.
+
+  * :c:var:`bt_mesh_sensor_rel_runtime_in_a_dev_op_temp_range` - Periodically requested by the client.
 
 .. note::
    These values can be requested through shell commands by the :ref:`bluetooth_mesh_sensor_client`.
@@ -73,25 +80,25 @@ Models
 
 The following table shows the Bluetooth mesh sensor composition data for this sample:
 
-   +---------------------+
-   | Element 1           |
-   +=====================+
-   | Config Server       |
-   +---------------------+
-   | Health Server       |
-   +---------------------+
-   | Sensor Server       |
-   +---------------------+
-   | Sensor Setup Server |
-   +---------------------+
+.. table::
+   :align: center
+
+   ===================  ===================  ===================
+   Element 1            Element 2            Element 3
+   ===================  ===================  ===================
+   Config Server        Sensor Server        Sensor Server
+   Health Server        Sensor Setup Server  Sensor Setup Server
+   Sensor Server
+   Sensor Setup Server
+   ===================  ===================  ===================
 
 The models are used for the following purposes:
 
 * Config Server allows configurator devices to configure the node remotely.
 * Health Server provides ``attention`` callbacks that are used during provisioning to call your attention to the device.
   These callbacks trigger blinking of the LEDs.
-* Sensor Server provides sensor data to one or more :ref:`mesh sensor observers <bt_mesh_sensor_cli_readme>`.
-* Sensor Setup Server is used for configuration of the Sensor Server.
+* Sensor Server instances provide sensor data to one or more :ref:`mesh sensor observers <bt_mesh_sensor_cli_readme>`.
+* Sensor Setup Server instances are used for configuration of the corresponding Sensor Server instances.
 
 The model handling is implemented in :file:`src/model_handler.c`.
 It uses the TEMP_NRF5 or BME680 temperature sensor depending on the platform.
@@ -174,7 +181,7 @@ Configuring models
 
 See :ref:`ug_bt_mesh_model_config_app` for details on how to configure the mesh models with the nRF Mesh mobile app.
 
-Configure the Sensor Server model on the **Mesh Sensor** node:
+Configure Sensor Server model on each element on the **Mesh Sensor** node:
 
 * Bind the model to **Application Key 1**.
 * Set the publication parameters:
@@ -184,15 +191,15 @@ Configure the Sensor Server model on the **Mesh Sensor** node:
 
 * Set the subscription parameters: Select an existing group or create a new one, but make sure that the Sensor Client publishes to the same group.
 
-The Sensor Server model is now configured and able to send data to the Sensor Client.
+The Sensor Server models are now configured and able to send data to the Sensor Client.
 
-Configure the Sensor Setup Server model on the **Mesh Sensor** node:
+Configure the corresponding Sensor Setup Server model on each element on the **Mesh Sensor** node:
 
 * Bind the model to **Application Key 1**.
 
 * Set the subscription parameters: Select an existing group or create a new one, but make sure that the Sensor Client publishes to the same group.
 
-The Sensor Setup Server model is now configured and able to receive sensor setting messages from the Sensor Client.
+The Sensor Setup Server models are now configured and able to receive sensor setting messages from the Sensor Client.
 
 .. note::
    To enable Sensor Server configuration by a Sensor Client, an application key must be bound to the Sensor Setup Server.

--- a/samples/bluetooth/mesh/sensor_server/src/model_handler.c
+++ b/samples/bluetooth/mesh/sensor_server/src/model_handler.c
@@ -48,6 +48,7 @@ static const struct device *dev = DEVICE_DT_GET(SENSOR_NODE);
 static uint32_t tot_temp_samps;
 static uint32_t col_samps[ARRAY_SIZE(columns)];
 static struct sensor_value pres_mot_thres;
+static double amb_light_level_ref;
 static double amb_light_level_gain = 1.0;
 /* Using a dummy ambient light value because we do not have a real ambient light sensor. */
 static double dummy_ambient_light_value;
@@ -371,8 +372,9 @@ static int amb_light_level_ref_set(struct bt_mesh_sensor_srv *srv,
 				   struct bt_mesh_msg_ctx *ctx,
 				   const struct sensor_value *value)
 {
-	double amb_light_level_ref = sensor_value_to_double(value);
 	struct sensor_value gain_value_tmp;
+
+	amb_light_level_ref = sensor_value_to_double(value);
 
 	/* When using the a real ambient light sensor the sensor value should be
 	 * read and used instead of the dummy value.
@@ -391,6 +393,16 @@ static int amb_light_level_ref_set(struct bt_mesh_sensor_srv *srv,
 	return 0;
 }
 
+static void amb_light_level_ref_get(struct bt_mesh_sensor_srv *srv,
+				     struct bt_mesh_sensor *sensor,
+				     const struct bt_mesh_sensor_setting *setting,
+				     struct bt_mesh_msg_ctx *ctx,
+				     struct sensor_value *rsp)
+{
+	(void)sensor_value_from_double(rsp, amb_light_level_ref);
+	printk("Ambient light level ref: %s\n", bt_mesh_sensor_ch_str(rsp));
+};
+
 static struct bt_mesh_sensor_setting amb_light_level_setting[] = {
 	{
 		.type = &bt_mesh_sensor_gain,
@@ -399,6 +411,7 @@ static struct bt_mesh_sensor_setting amb_light_level_setting[] = {
 	},
 	{
 		.type = &bt_mesh_sensor_present_amb_light_level,
+		.get = amb_light_level_ref_get,
 		.set = amb_light_level_ref_set,
 	},
 };

--- a/samples/bluetooth/mesh/sensor_server/src/model_handler.c
+++ b/samples/bluetooth/mesh/sensor_server/src/model_handler.c
@@ -333,7 +333,7 @@ static void amb_light_level_gain_get(struct bt_mesh_sensor_srv *srv,
 				     struct sensor_value *rsp)
 {
 	(void)sensor_value_from_double(rsp, amb_light_level_gain);
-	printk("Ambient light level gain: %f\n", amb_light_level_gain);
+	printk("Ambient light level gain: %s\n", bt_mesh_sensor_ch_str(rsp));
 };
 
 static void amb_light_level_gain_store(double gain)
@@ -360,7 +360,7 @@ static int amb_light_level_gain_set(struct bt_mesh_sensor_srv *srv,
 				    const struct sensor_value *value)
 {
 	amb_light_level_gain_store(sensor_value_to_double(value));
-	printk("Ambient light level gain: %f\n", amb_light_level_gain);
+	printk("Ambient light level gain: %s\n", bt_mesh_sensor_ch_str(value));
 
 	return 0;
 }
@@ -372,6 +372,7 @@ static int amb_light_level_ref_set(struct bt_mesh_sensor_srv *srv,
 				   const struct sensor_value *value)
 {
 	double amb_light_level_ref = sensor_value_to_double(value);
+	struct sensor_value gain_value_tmp;
 
 	/* When using the a real ambient light sensor the sensor value should be
 	 * read and used instead of the dummy value.
@@ -382,8 +383,10 @@ static int amb_light_level_ref_set(struct bt_mesh_sensor_srv *srv,
 		amb_light_level_gain_store(FLT_MAX);
 	}
 
-	printk("Ambient light level ref(%f), gain(%f)\n",
-		amb_light_level_ref, amb_light_level_gain);
+	sensor_value_from_double(&gain_value_tmp, amb_light_level_gain);
+
+	printk("Ambient light level ref(%s) ", bt_mesh_sensor_ch_str(value));
+	printk("gain(%s)\n", bt_mesh_sensor_ch_str(&gain_value_tmp));
 
 	return 0;
 }

--- a/subsys/bluetooth/mesh/Kconfig.models
+++ b/subsys/bluetooth/mesh/Kconfig.models
@@ -610,6 +610,7 @@ menuconfig BT_MESH_SENSOR_SRV
 	bool "Sensor Server"
 	select BT_MESH_NRF_MODELS
 	select BT_MESH_SENSOR
+	select BT_MESH_MODEL_EXTENSIONS
 	help
 	  Enable mesh Sensor Server model.
 

--- a/subsys/bluetooth/mesh/sensor_srv.c
+++ b/subsys/bluetooth/mesh/sensor_srv.c
@@ -202,7 +202,7 @@ static int handle_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		if (sensor) {
 			buf_status_add(srv, sensor, ctx, &rsp);
 		} else {
-			LOG_WRN("Unknown sensor ID 0x%04x", id);
+			LOG_DBG("Unknown sensor ID 0x%04x", id);
 			sensor_status_id_encode(&rsp, 0, id);
 		}
 
@@ -253,7 +253,7 @@ static int handle_column_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx
 	net_buf_simple_add_le16(&rsp, id);
 
 	if (!sensor || !sensor->series.get) {
-		LOG_WRN("No series support in 0x%04x", sensor->type->id);
+		LOG_DBG("No series support in 0x%04x", sensor->type->id);
 		goto respond;
 	}
 
@@ -279,7 +279,7 @@ static int handle_column_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx
 	}
 
 	if (!sensor->series.columns) {
-		LOG_WRN("No series support in 0x%04x", sensor->type->id);
+		LOG_DBG("No series support in 0x%04x", sensor->type->id);
 		goto respond;
 	}
 
@@ -348,7 +348,7 @@ static int handle_series_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx
 	net_buf_simple_add_le16(&rsp, id);
 
 	if (!sensor || !sensor->series.get) {
-		LOG_WRN("No series support in 0x%04x", sensor->type->id);
+		LOG_DBG("No series support in 0x%04x", sensor->type->id);
 		goto respond;
 	}
 
@@ -390,7 +390,7 @@ static int handle_series_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx
 
 	col_format = bt_mesh_sensor_column_format_get(sensor->type);
 	if (!col_format || !sensor->series.columns) {
-		LOG_WRN("No series support in 0x%04x", sensor->type->id);
+		LOG_DBG("No series support in 0x%04x", sensor->type->id);
 		goto respond;
 	}
 

--- a/subsys/bluetooth/mesh/sensor_srv.c
+++ b/subsys/bluetooth/mesh/sensor_srv.c
@@ -1110,6 +1110,17 @@ const struct bt_mesh_model_cb _bt_mesh_sensor_srv_cb = {
 	.settings_set = sensor_srv_settings_set,
 };
 
+static int sensor_setup_srv_init(struct bt_mesh_model *model)
+{
+	struct bt_mesh_sensor_srv *srv = model->user_data;
+
+	return bt_mesh_model_extend(model, srv->model);
+}
+
+const struct bt_mesh_model_cb _bt_mesh_sensor_setup_srv_cb = {
+	.init = sensor_setup_srv_init,
+};
+
 int bt_mesh_sensor_srv_pub(struct bt_mesh_sensor_srv *srv,
 			   struct bt_mesh_msg_ctx *ctx,
 			   struct bt_mesh_sensor *sensor,

--- a/subsys/bluetooth/mesh/sensor_types.c
+++ b/subsys/bluetooth/mesh/sensor_types.c
@@ -443,7 +443,7 @@ static int float32_encode(const struct bt_mesh_sensor_format *format,
 			  const struct sensor_value *val,
 			  struct net_buf_simple *buf)
 {
-	if (net_buf_simple_tailroom(buf) < 1) {
+	if (net_buf_simple_tailroom(buf) < sizeof(float)) {
 		return -ENOMEM;
 	}
 
@@ -458,7 +458,7 @@ static int float32_encode(const struct bt_mesh_sensor_format *format,
 static int float32_decode(const struct bt_mesh_sensor_format *format,
 			  struct net_buf_simple *buf, struct sensor_value *val)
 {
-	if (buf->len < 1) {
+	if (buf->len < sizeof(float)) {
 		return -ENOMEM;
 	}
 


### PR DESCRIPTION
This PR changes the following:
- Fixes extension of Sensor Server and Sensor Setup Server models
- Fixes length check for coefficient sensor type
- Reduces number of warning logs print by Sensor Server
- Fixes %f formatting issue
- Groups sensors by server instances
- Adds getter for gain setting