### PR TITLE
doc improvement: Add nRF7001 in the supported boards list

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -498,6 +498,7 @@
 
 .. _`Product specification for nRF70 Series devices`: https://infocenter.nordicsemi.com/topic/ps_nrf7002/keyfeatures_html5.html
 .. _`nRF7002 DK Hardware`: https://infocenter.nordicsemi.com/topic/ug_nrf7002_dk/UG/nrf7002_DK/intro.html
+.. _`nRF70 Series`: https://infocenter.nordicsemi.com/topic/struct_nrf70/struct/nrf70.html
 
 .. _`Guidelines and application notes for nRF70 Series devices`: https://infocenter.nordicsemi.com/topic/struct_nrf70/struct/nrf70_guidelines.html
 

--- a/doc/nrf/working_with_nrf/nrf70/features.rst
+++ b/doc/nrf/working_with_nrf/nrf70/features.rst
@@ -44,6 +44,11 @@ Devices in the nRF70 Series are supported by the following boards in the `Zephyr
      - ``nrf7002dk_nrf5340_cpuapp``
      - | `Product Specification <Product specification for nRF70 Series devices_>`_
        | `User Guide <nRF7002 DK Hardware_>`_
+   * - nRF7001 emulation on nRF7002 DK
+     - Not applicable
+     - PCA10143
+     - ``nrf7002dk_nrf7001_nrf5340_cpuapp``
+     - | `nRF70 Series Specification <nRF70 Series_>`_
    * - nRF5340 DK
      - nRF7002 EK
      - PCA10095


### PR DESCRIPTION
Added nRF7001 in the supported boards list in the
Features of nRF70 Series guide.