### PR TITLE
lib: identity_key: Add missing stdbool.h include

### DIFF
--- a/include/identity_key.h
+++ b/include/identity_key.h
@@ -8,6 +8,7 @@
 #define IDENTITY_KEY_H_
 
 #include <stdint.h>
+#include <stdbool.h>
 
 /**
  * @file


### PR DESCRIPTION
bool type was use in the header file without including stdbool.h which caused build issues with NEWLIB_LIBC enabled.