### PR TITLE
west command related fixes and updates

### DIFF
--- a/scripts/west_commands/ncs_commands.py
+++ b/scripts/west_commands/ncs_commands.py
@@ -30,7 +30,8 @@ except ImportError:
              "with pip3.")
 
 import ncs_west_helpers as nwh
-from pygit2_helpers import commit_affects_files, commit_title
+from pygit2_helpers import commit_affects_files, commit_title, \
+    title_has_sauce, title_is_revert
 
 WEST_V0_13_0_OR_LATER = version.parse(west_version) >= version.parse('0.13.0')
 
@@ -382,7 +383,17 @@ class NcsLoot(NcsWestCommand):
             if self.args.sha_only:
                 log.inf(sha)
             else:
-                log.inf(f'{index+1}. {sha} {title}')
+                # Emit a warning if we have a non-revert patch with an
+                # incorrect sauce tag. (Again, downstream might carry
+                # reverts of upstream patches, which we shouldn't warn
+                # about.)
+                if not title_has_sauce(title) and not title_is_revert(title):
+                    space = ' ' * len(f'{index+1}. ')
+                    sauce_note = \
+                        f'\n{space}[NOTE: commit title is missing a sauce tag]'
+                else:
+                    sauce_note = ''
+                log.inf(f'{index+1}. {sha} {title}{sauce_note}')
 
             if self.args.json:
                 json_sha_list.append(sha)

--- a/scripts/west_commands/ncs_west_helpers.py
+++ b/scripts/west_commands/ncs_west_helpers.py
@@ -28,8 +28,8 @@ except ImportError:
              "with pip3.")
 from west import log
 
-from pygit2_helpers import title_is_revert, title_has_sauce, \
-    title_no_sauce, commit_reverts_what, commit_title
+from pygit2_helpers import title_is_revert, title_no_sauce, \
+        commit_reverts_what, commit_title
 
 __all__ = ['InvalidRepositoryError', 'UnknownCommitsError', 'RepoAnalyzer']
 
@@ -256,15 +256,6 @@ class RepoAnalyzer:
                         log.wrn(('commit {} ("{}") reverts {}, '
                                  "which isn't in downstream history").
                                 format(sha, sl, rsha))
-
-            # Emit a warning if we have a non-revert patch with an
-            # incorrect sauce tag. (Again, downstream might carry reverts
-            # of upstream patches as hotfixes, which we shouldn't
-            # warn about.)
-            if (not title_has_sauce(sl, self._downstream_sauce) and
-                    not is_revert):
-                log.wrn(f'{self.downstream_repo.name}: bad or missing sauce tag: '
-                        f'{sha} ("{sl}")')
 
             downstream_out[sha] = c
             log.dbg('** added oot patch: {} ("{}")'.format(sha, sl),

--- a/west.yml
+++ b/west.yml
@@ -152,7 +152,7 @@ manifest:
       userdata:
         ncs:
           upstream-url: https://github.com/project-chip/connectedhomeip
-          upstream-sha: 4088a77f557e8571a39338fad51a1d8eb0131d79
+          upstream-sha: 8f66f4215bc0708efc8cc73bda80620e67d8955f
           compare-by-default: false
     - name: nrf-802154
       repo-path: sdk-nrf-802154
@@ -212,7 +212,7 @@ manifest:
       userdata:
         ncs:
           upstream-url: https://github.com/openthread/openthread
-          upstream-sha: 55074652907295709f9f3361244a6e76f732bcba
+          upstream-sha: d9abe3071c0131a4adb5d7e7451319b735e6d855
           compare-by-default: false
 
     # Other third-party repositories.


### PR DESCRIPTION
This pull fixes `west ncs-loot` to allow running the command with our current west manifest file without specifying the list of projects explicitly in most cases. Currently, that errors out when there are uncloned projects, which is likely since we now have projects like `ant` that not everybody as access to. Fix this by relaxing the error conditions to only error out if there are uncloned projects that have upstreams we need to compare NCS against.

It also improves the output of this command and fixes some stale values in west.yml so the output makes sense again.