### PR TITLE
samples: Bluetooth: Mesh: fix id collision between ble and ble mesh gatt services

### DIFF
--- a/samples/bluetooth/mesh/ble_peripheral_lbs_coex/prj.conf
+++ b/samples/bluetooth/mesh/ble_peripheral_lbs_coex/prj.conf
@@ -37,6 +37,7 @@ CONFIG_BT_EXT_ADV=y
 # 5 sets are used by Bluetooth mesh, 1 is needed for the sample advs.
 CONFIG_BT_EXT_ADV_MAX_ADV_SET=6
 CONFIG_BT_MAX_CONN=3
+CONFIG_BT_ID_MAX=2
 
 # Disable unused Bluetooth features
 CONFIG_BT_CTLR_DUP_FILTER_LEN=0

--- a/samples/bluetooth/mesh/ble_peripheral_lbs_coex/src/lb_service_handler.c
+++ b/samples/bluetooth/mesh/ble_peripheral_lbs_coex/src/lb_service_handler.c
@@ -40,6 +40,8 @@ static const struct bt_data sd[] = {
 	BT_DATA_BYTES(BT_DATA_UUID128_ALL, BT_UUID_LBS_VAL),
 };
 
+static struct bt_le_ext_adv *adv;
+static struct bt_le_ext_adv_start_param ext_adv_param;
 static bool ble_button_state;
 
 static void connected(struct bt_conn *conn, uint8_t err)
@@ -89,14 +91,47 @@ static void button_changed(uint32_t button_state, uint32_t has_changed)
 
 static void lbs_adv_start(void)
 {
-	int err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
+	struct bt_le_adv_param *adv_params = BT_LE_ADV_CONN;
+	int err;
+	size_t id_count = 0xFF;
 
+	/* Use different identity from Bluetooth mesh to avoid conflicts with Mesh Provisioning
+	 * Service and Mesh Proxy Service advertisements.
+	 */
+	bt_id_get(NULL, &id_count);
+
+	if (id_count < CONFIG_BT_ID_MAX) {
+		adv_params->id = bt_id_create(NULL, NULL);
+		if (adv_params->id < 0) {
+			printk("Unable to create a new identity for LBS (err %d)."
+			       " Using the default one.\n", adv_params->id);
+			adv_params->id = BT_ID_DEFAULT;
+		}
+
+		printk("Created a new identity for LBS: %d\n", adv_params->id);
+	} else {
+		adv_params->id = BT_ID_DEFAULT + 1;
+		printk("Recovered identity for LBS: %d\n", adv_params->id);
+	}
+
+	err = bt_le_ext_adv_create(adv_params, NULL, &adv);
 	if (err) {
-		printk("Advertising failed to start (err %d)\n", err);
+		printk("Creating LBS service adv instance failed (err %d)\n", err);
 		return;
 	}
 
-	printk("Advertising successfully started\n");
+	err = bt_le_ext_adv_set_data(adv, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
+	if (err) {
+		printk("Setting LBS service adv data failed (err %d)\n", err);
+		return;
+	}
+
+	err = bt_le_ext_adv_start(adv, &ext_adv_param);
+	if (err) {
+		printk("Starting advertising of LBS service failed (err %d)\n", err);
+	} else {
+		printk("Advertising successfully started\n");
+	}
 }
 
 static void lbs_init(void)


### PR DESCRIPTION
BLE and BLE MESH GATT services used the same id. That caused the situation when mobile app wasn't able to connect to mesh proxy if ble gatt is active.