### PR TITLE
applications: Fixed ICD subscriptions handling for weather station

### DIFF
--- a/applications/matter_weather_station/CMakeLists.txt
+++ b/applications/matter_weather_station/CMakeLists.txt
@@ -59,6 +59,10 @@ if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_TRANSPORT_BT)
     target_sources(app PRIVATE ${COMMON_ROOT}/src/ota_util.cpp)
 endif()
 
+if(CONFIG_CHIP_ICD_SUBSCRIPTION_HANDLING)
+    target_sources(app PRIVATE ${COMMON_ROOT}/src/icd_util.cpp)
+endif()
+
 chip_configure_data_model(app
     INCLUDE_SERVER
     BYPASS_IDL

--- a/applications/matter_weather_station/src/app_task.cpp
+++ b/applications/matter_weather_station/src/app_task.cpp
@@ -26,6 +26,10 @@
 #include "ota_util.h"
 #endif
 
+#ifdef CONFIG_CHIP_ICD_SUBSCRIPTION_HANDLING
+#include <app/InteractionModelEngine.h>
+#endif
+
 #include <dk_buttons_and_leds.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/kernel.h>
@@ -243,6 +247,10 @@ CHIP_ERROR AppTask::Init()
 
 	ConfigurationMgr().LogDeviceConfig();
 	PrintOnboardingCodes(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
+
+#ifdef CONFIG_CHIP_ICD_SUBSCRIPTION_HANDLING
+	chip::app::InteractionModelEngine::GetInstance()->RegisterReadHandlerAppCallback(&GetICDUtil());
+#endif
 
 	/*
 	 * Add CHIP event handler and start CHIP thread.

--- a/applications/matter_weather_station/src/app_task.h
+++ b/applications/matter_weather_station/src/app_task.h
@@ -20,6 +20,10 @@
 #include <platform/nrfconnect/FactoryDataProvider.h>
 #endif
 
+#ifdef CONFIG_CHIP_ICD_SUBSCRIPTION_HANDLING
+#include "icd_util.h"
+#endif
+
 struct k_timer;
 
 class AppTask {


### PR DESCRIPTION
Support for ICD subscriptions doesn't work for weather station, because it was only enabled in Kconfig and there is not necessary code implemented to handle it in application.