### PR TITLE
manifest: update Zephyr to pull in EXTRA_CONF_FILE and snippets update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 1b36aa5754cfb699e3599b66ba21c4192fc35227
+      revision: pull/1191/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This manifest updates Zephyr for support of the upstream changes on configuration file handling:
- OVERLAY_CONFIG --> EXTRA_CONF_FILE
- EXTRA_DTC_OVERLAY_FILE

in addition, the snippets variable scope is pulled in, which includes snippet support for the same variables.
This fixes upstream issues:
https://github.com/zephyrproject-rtos/zephyr/issues/57139
https://github.com/zephyrproject-rtos/zephyr/issues/57775