### PR TITLE
manifest: Update Memfault SDK revision to pull latest fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -223,7 +223,7 @@ manifest:
       remote: throwtheswitch
     - name: memfault-firmware-sdk
       path: modules/lib/memfault-firmware-sdk
-      revision: 0.43.1
+      revision: 0.43.3
       remote: memfault
     - name: ant
       repo-path: sdk-ant


### PR DESCRIPTION
Memfault SDK 0.43.3 contains fixes that are needed in NCS.