### PR TITLE
shields: nrf7002eb: Update pins as per latest board revision

### DIFF
--- a/boards/shields/nrf7002eb/nrf7002eb_coex.overlay
+++ b/boards/shields/nrf7002eb/nrf7002eb_coex.overlay
@@ -7,8 +7,8 @@
 	nrf_radio_coex: nrf7002-coex {
 		status = "okay";
 		compatible = "nordic,nrf700x-coex";
-		status0-gpios = <&edge_connector 15 GPIO_ACTIVE_HIGH>;
+		status0-gpios = <&gpio1 1 GPIO_ACTIVE_HIGH>;
 		req-gpios = <&gpio1 0 GPIO_ACTIVE_HIGH>;
-		grant-gpios = <&gpio1 1 (GPIO_PULL_DOWN | GPIO_ACTIVE_LOW)>;
+		grant-gpios = <&edge_connector 15 (GPIO_PULL_DOWN | GPIO_ACTIVE_LOW)>;
 	};
 };


### PR DESCRIPTION
Latest board revision (0.9.0) has status and grant pins swapped.