### PR TITLE
bluetooth: remove SDC_USE_NEW_MEM_API

### DIFF
--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -19,7 +19,6 @@
 #include <stdbool.h>
 #include <zephyr/sys/__assert.h>
 
-#define SDC_USE_NEW_MEM_API
 #include <sdc.h>
 #include <sdc_soc.h>
 #include <sdc_hci.h>


### PR DESCRIPTION
changes fully propagated, can remove this now.