### PR TITLE
applications: asset_tracker_v2: fix movement timeout handling

### DIFF
--- a/applications/asset_tracker_v2/src/main.c
+++ b/applications/asset_tracker_v2/src/main.c
@@ -286,10 +286,15 @@ static void data_sample_timer_handler(struct k_timer *timer)
 {
 	ARG_UNUSED(timer);
 
-	/* Cancel if a previous sample request has not completed or the device is not under
-	 * activity in passive mode.
+	/* Cancel if a previous sample request has not completed. */
+	if (sample_request_ongoing) {
+		return;
+	}
+
+	/* Cancel if the data sample timer expired and device is not under activity in passive mode.
+	 * Movement timeout timer triggers sampling also when there is no movement.
 	 */
-	if (sample_request_ongoing || ((sub_state == SUB_STATE_PASSIVE_MODE) && !activity)) {
+	if (timer == &data_sample_timer && sub_state == SUB_STATE_PASSIVE_MODE && !activity) {
 		return;
 	}
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -140,6 +140,8 @@ nRF9160: Asset Tracker v2
   * Enabled link time optimization to reduce the flash size of the application.
     You can disable this using the Kconfig option :kconfig:option:`CONFIG_ASSET_TRACKER_V2_LTO`.
 
+* Fixed an issue with movement timeout handling in passive mode.
+
 nRF9160: Serial LTE modem
 -------------------------
 


### PR DESCRIPTION
Fixed movement timeout handling in passive mode. The movement timeout timer should trigger data sampling regardless of movement.