### PR TITLE
applications: bump MCUboot image version to 2.4.0 for ML

### DIFF
--- a/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/prj.conf
+++ b/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/prj.conf
@@ -158,7 +158,7 @@ CONFIG_USB_NRFX_WORK_QUEUE_STACK_SIZE=1200
 ################################################################################
 # Bootloader and MCUmgr (OTA DFU) Configuration
 
-CONFIG_MCUBOOT_IMAGE_VERSION="2.3.0+0"
+CONFIG_MCUBOOT_IMAGE_VERSION="2.4.0+0"
 
 CONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU=y
 

--- a/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/prj_release.conf
+++ b/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/prj_release.conf
@@ -148,7 +148,7 @@ CONFIG_BOARD_SERIAL_BACKEND_CDC_ACM=n
 ################################################################################
 # Bootloader and MCUmgr (OTA DFU) Configuration
 
-CONFIG_MCUBOOT_IMAGE_VERSION="2.3.0+0"
+CONFIG_MCUBOOT_IMAGE_VERSION="2.4.0+0"
 
 CONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU=y
 

--- a/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/prj_rtt.conf
+++ b/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/prj_rtt.conf
@@ -168,7 +168,7 @@ CONFIG_BOARD_SERIAL_BACKEND_CDC_ACM=n
 ################################################################################
 # Bootloader and MCUmgr (OTA DFU) Configuration
 
-CONFIG_MCUBOOT_IMAGE_VERSION="2.3.0+0"
+CONFIG_MCUBOOT_IMAGE_VERSION="2.4.0+0"
 
 CONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU=y
 

--- a/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp_ns/prj.conf
+++ b/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp_ns/prj.conf
@@ -158,7 +158,7 @@ CONFIG_USB_NRFX_WORK_QUEUE_STACK_SIZE=1200
 ################################################################################
 # Bootloader and MCUmgr (OTA DFU) Configuration
 
-CONFIG_MCUBOOT_IMAGE_VERSION="2.3.0+0"
+CONFIG_MCUBOOT_IMAGE_VERSION="2.4.0+0"
 
 CONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU=y
 

--- a/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp_ns/prj_release.conf
+++ b/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp_ns/prj_release.conf
@@ -148,7 +148,7 @@ CONFIG_BOARD_SERIAL_BACKEND_CDC_ACM=n
 ################################################################################
 # Bootloader and MCUmgr (OTA DFU) Configuration
 
-CONFIG_MCUBOOT_IMAGE_VERSION="2.3.0+0"
+CONFIG_MCUBOOT_IMAGE_VERSION="2.4.0+0"
 
 CONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU=y
 

--- a/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp_ns/prj_rtt.conf
+++ b/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp_ns/prj_rtt.conf
@@ -168,7 +168,7 @@ CONFIG_BOARD_SERIAL_BACKEND_CDC_ACM=n
 ################################################################################
 # Bootloader and MCUmgr (OTA DFU) Configuration
 
-CONFIG_MCUBOOT_IMAGE_VERSION="2.3.0+0"
+CONFIG_MCUBOOT_IMAGE_VERSION="2.4.0+0"
 
 CONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU=y
 


### PR DESCRIPTION
CONFIG_MCUBOOT_IMAGE_VERSION values were updated for NCS 2.4.0