### PR TITLE
tests: gatt_dm: Migrate to the new Ztest API

### DIFF
--- a/tests/subsys/bluetooth/gatt_dm/prj.conf
+++ b/tests/subsys/bluetooth/gatt_dm/prj.conf
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 CONFIG_ZTEST=y
+CONFIG_ZTEST_NEW_API=y
 CONFIG_NETWORKING=y
 
 CONFIG_BT=y


### PR DESCRIPTION
Migrate the GATT Discovery Manager tests to the new Ztest API.