### PR TITLE
asset_tracker_v2: Enable link time optimization

### DIFF
--- a/applications/asset_tracker_v2/CMakeLists.txt
+++ b/applications/asset_tracker_v2/CMakeLists.txt
@@ -39,3 +39,7 @@ if (CONFIG_BOARD_QEMU_X86 OR CONFIG_BOARD_NATIVE_POSIX)
         target_compile_options(app PRIVATE
 	        -DCONFIG_LTE_NEIGHBOR_CELLS_MAX=10)
 endif()
+
+if(CONFIG_ASSET_TRACKER_V2_LTO)
+        target_compile_options(app PRIVATE "-flto")
+endif()

--- a/applications/asset_tracker_v2/Kconfig
+++ b/applications/asset_tracker_v2/Kconfig
@@ -19,6 +19,14 @@ config ASSET_TRACKER_V2_APP_VERSION_MAX_LEN
 	int "Maximum length of the application firmware version"
 	default 150
 
+config ASSET_TRACKER_V2_LTO
+	bool "Enable link time optimization"
+	default y if SIZE_OPTIMIZATIONS
+	help
+	  Compile the Asset Tracker application code with link time optimization enabled. This
+	  option is only applied for the application code and not the libraries and external modules
+	  that are linked in.
+
 rsource "src/modules/Kconfig.modules_common"
 rsource "src/modules/Kconfig.cloud_module"
 rsource "src/cloud/Kconfig.lwm2m_integration"

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -134,7 +134,10 @@ This section provides detailed lists of changes by :ref:`application <applicatio
 nRF9160: Asset Tracker v2
 -------------------------
 
-|no_changes_yet_note|
+* Updated:
+
+  * Enabled link time optimization to reduce the flash size of the application.
+    You can disable this using the Kconfig option :kconfig:option:`CONFIG_ASSET_TRACKER_V2_LTO`.
 
 nRF9160: Serial LTE modem
 -------------------------


### PR DESCRIPTION
Enable link time optimization for the application code. This is intended
for reducing the flash usage.

The flash usage for the asset tracker application reduces by 1576 bytes
when built for nrf9160dk_nrf9160_ns platform (without any other
additional options). The RAM usages increases by 48 bytes.

I tried enabling this globally across NCS in this PR https://github.com/nrfconnect/sdk-nrf/pull/11276 . The improvement there was significant (9k) but only for asset tracker v2 (see the table in that PR).  The other applications had negligible or even negative improvement. So I decided to only enable this for the application code for asset tracker v2 application.
