### PR TITLE
samples: direct_test_mode: Add support for the nRF52840 DK

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -162,7 +162,11 @@ Samples
 Bluetooth samples
 -----------------
 
-|no_changes_yet_note|
+* :ref:`direct_test_mode` sample:
+
+  * Added:
+
+    * Support for the nRF52840 DK.
 
 Bluetooth mesh samples
 ----------------------

--- a/samples/bluetooth/direct_test_mode/sample.yaml
+++ b/samples/bluetooth/direct_test_mode/sample.yaml
@@ -7,7 +7,8 @@ tests:
     integration_platforms:
       - nrf5340dk_nrf5340_cpunet
       - nrf21540dk_nrf52840
-    platform_allow: nrf5340dk_nrf5340_cpunet nrf21540dk_nrf52840
+      - nrf52840dk_nrf52840
+    platform_allow: nrf5340dk_nrf5340_cpunet nrf21540dk_nrf52840 nrf52840dk_nrf52840
     tags: bluetooth ci_build
   sample.bluetooth.direct_test_mode.nrf5340_nrf21540:
     build_only: true


### PR DESCRIPTION
This adds support for the nRF52840 DK in the
Direct Test Mode sample.