### PR TITLE
samples: openthread: add GPIO diag configuration for nRF52840 dongle

### DIFF
--- a/samples/openthread/cli/README.rst
+++ b/samples/openthread/cli/README.rst
@@ -64,6 +64,21 @@ See `Testing diagnostic module`_ section for an example.
 .. note::
     If you disable the :kconfig:option:`CONFIG_OPENTHREAD_NORDIC_LIBRARY_MASTER` feature set, you can enable the diagnostic module with the :kconfig:option:`CONFIG_OPENTHREAD_DIAG` Kconfig option.
 
+For the ``nrf52840dongle_nrf52840`` build target, diagnostic GPIO commands can also be used.
+They are enabled in the ``openthread_config`` node in the :file:`boards/nrf52840dongle_nrf52840.overlay` file, with the node configured for the **P0.19** pin, which is connected to the **RESET** pin on the nRF52840 Dongle.
+The pin is set in output mode with a low state so that the **RESET** pin is pulled to **GND**, which results in the device rebooting without skipping the bootloader.
+This functionality is not enabled by other commands, such as ``factoryreset``, as they can only trigger a software reset, skipping the bootloader.
+
+To reboot to the bootloader, run the following commands on the device:
+
+.. code-block:: console
+
+   uart:~$ ot diag start
+   start diagnostics mode
+   status 0x00
+   Done
+   uart:~$ ot diag gpio mode 0 out
+
 Configuration
 *************
 

--- a/samples/openthread/coprocessor/README.rst
+++ b/samples/openthread/coprocessor/README.rst
@@ -72,6 +72,12 @@ You can also use your own application, provided that it supports the Spinel comm
     |thread_hwfc_enabled|
     In addition, the Co-processor sample reconfigures the baud rate to 1000000 bit/s by default.
 
+Diagnostic module
+=================
+
+The Co-processor sample enables a diagnostic module in a similar way as described in the :ref:`ot_cli_sample_diag_module` section of the :ref:`ot_cli_sample` sample documentation.
+However, the Co-processor and CLI samples use different commands for the module, as described in the :ref:`ot_coprocessor_testing` section.
+
 Configuration
 *************
 
@@ -112,6 +118,8 @@ Building and running
 |enable_thread_before_testing|
 
 .. include:: /includes/build_and_run.txt
+
+.. _ot_coprocessor_testing:
 
 Testing
 =======

--- a/samples/openthread/coprocessor/boards/nrf52840dongle_nrf52840.overlay
+++ b/samples/openthread/coprocessor/boards/nrf52840dongle_nrf52840.overlay
@@ -1,24 +1,9 @@
-/* Copyright (c) 2021 Nordic Semiconductor ASA
+/* Copyright (c) 2023 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-&uart0 {
-	status = "okay";
-	hw-flow-control;
-};
-
 / {
-	/*
-	* In some default configurations within the nRF Connect SDK,
-	* e.g. on nRF52840, the chosen zephyr,entropy node is &cryptocell.
-	* This devicetree overlay ensures that default is overridden wherever it
-	* is set, as this application uses the RNG node for entropy exclusively.
-	*/
-	chosen {
-		zephyr,entropy = &rng;
-	};
-
 	/*
 	 * nRF52840 dongle has pin P0.19 connected to reset. By setting it
 	 * in output mode with low state reset is pulled to GND, which results in


### PR DESCRIPTION
Created nodes in `nrf52840dongle_nrf52840.overlay` for coprocessor and cli openthread samples.
Configuration aims to enable rebooting the dongle from OT level without skipping the bootloader.

Updated `Diagnostic module` sections for cli and coprocessor samples with information about diagnostic GPIO commands for nRF52840 dongle and instructions on how to use them to reboot the dongle without
skipping bootloader.