### PR TITLE
doc: sml: Fix SoC discovery

### DIFF
--- a/doc/_scripts/software_maturity/software_maturity_scanner.py
+++ b/doc/_scripts/software_maturity/software_maturity_scanner.py
@@ -273,7 +273,7 @@ def find_all_socs(all_samples: List[str]) -> List[str]:
 
     # Only use nRF boards, but not nRF51 series
     all_boards = set(filter(BOARD_FILTER, all_boards))
-    all_socs = {re.search(r"_(nrf[0-9]+)", b).group(1) for b in all_boards}
+    all_socs = {re.findall(r"_(nrf[0-9]+)", b)[-1] for b in all_boards}
     return list(sorted(all_socs))
 
 


### PR DESCRIPTION
With the introduction of nRF7001/nRF7000 emulated targets (based on nRF7002), the regex to capture SoC from the build target needs to handle this.

Easiest way would be to find all 'nrf[0-9]+' patterns and pick last one as SoC, this is based on the below convention:

  `physicalBoard_emulatedBoard_physicalSoC` with emulatedBoard being
optional.