### PR TITLE
manifest: Update zephyr with fromtree CoAP client

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: c6f38ecdee5e42f4812c2f33053638a1f8cb2cb8
+      revision: 2f5e820792d145c7a460f6c192c83e81d5348ddc
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
NOT FOR 2.4.0 RELEASE

Update to zephyr with fromtree CoAP client.