### PR TITLE
manifest: Update ble-controller/MPSL revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -131,7 +131,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: v2.4.0-rc2
+      revision: 3e7571fcfaf948b7e2e8850d3707df504d75af28
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Includes updates:
- Critical bugfix for nRF53 qualification

This adds https://github.com/nrfconnect/sdk-nrfxlib/pull/1005