### PR TITLE
applications: nrf_desktop: Allow build with PM events disabled

### DIFF
--- a/applications/nrf_desktop/doc/ble_latency.rst
+++ b/applications/nrf_desktop/doc/ble_latency.rst
@@ -39,6 +39,9 @@ You can set the option :ref:`CONFIG_DESKTOP_BLE_LOW_LATENCY_LOCK <config_desktop
 This speeds up sending the first HID report after not sending a report for some connection intervals.
 Enabling this option increases the power consumption - the connection latency is kept low unless the device is in the low power mode.
 
+You can use the :ref:`CONFIG_DESKTOP_BLE_LATENCY_PM_EVENTS <config_desktop_app_options>` Kconfig option to enable or disable handling of the power management events, such as :c:struct:`power_down_event` and :c:struct:`wake_up_event`.
+The option is enabled by default and depends on the :kconfig:option:`CONFIG_CAF_PM_EVENTS` Kconfig option.
+
 Implementation details
 **********************
 

--- a/applications/nrf_desktop/doc/board.rst
+++ b/applications/nrf_desktop/doc/board.rst
@@ -43,3 +43,6 @@ Every :c:struct:`pin_state` defines the state of a single GPIO pin:
 
 * :c:member:`pin_state.pin` - Pin number.
 * :c:member:`pin_state.val` - Value set for the pin.
+
+You can use the :ref:`CONFIG_DESKTOP_BOARD_PM_EVENTS <config_desktop_app_options>` Kconfig option to enable or disable handling of the power management events, such as :c:struct:`power_down_event` and :c:struct:`wake_up_event`.
+The option is enabled by default and depends on the :kconfig:option:`CONFIG_CAF_PM_EVENTS` Kconfig option.

--- a/applications/nrf_desktop/doc/motion.rst
+++ b/applications/nrf_desktop/doc/motion.rst
@@ -37,6 +37,9 @@ See the following sections for more information.
 
 Depending on the selected configuration option, a different implementation file is used during the build process.
 
+You can use the :ref:`CONFIG_DESKTOP_MOTION_PM_EVENTS <config_desktop_app_options>` Kconfig option to enable or disable handling of the power management events, such as :c:struct:`power_down_event` and :c:struct:`wake_up_event`.
+The option is enabled by default and depends on the :kconfig:option:`CONFIG_CAF_PM_EVENTS` Kconfig option.
+
 Movement data from motion sensors
 =================================
 

--- a/applications/nrf_desktop/src/hw_interface/Kconfig
+++ b/applications/nrf_desktop/src/hw_interface/Kconfig
@@ -6,6 +6,7 @@
 
 menu "Hardware interface modules"
 
+rsource "Kconfig.board"
 rsource "Kconfig.motion"
 rsource "Kconfig.buttons_sim"
 rsource "Kconfig.selector"
@@ -13,9 +14,5 @@ rsource "Kconfig.wheel"
 rsource "Kconfig.battery_charger"
 rsource "Kconfig.battery_meas"
 rsource "Kconfig.passkey"
-
-module = DESKTOP_BOARD
-module-str = board module
-source "subsys/logging/Kconfig.template.log_config"
 
 endmenu

--- a/applications/nrf_desktop/src/hw_interface/Kconfig.board
+++ b/applications/nrf_desktop/src/hw_interface/Kconfig.board
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+menu "Board configuration"
+
+config DESKTOP_BOARD_PM_EVENTS
+	bool "Power management events support"
+	depends on CAF_PM_EVENTS
+	default y
+	help
+	  React on power management events in board module.
+
+module = DESKTOP_BOARD
+module-str = board module
+source "subsys/logging/Kconfig.template.log_config"
+
+endmenu

--- a/applications/nrf_desktop/src/hw_interface/Kconfig.motion
+++ b/applications/nrf_desktop/src/hw_interface/Kconfig.motion
@@ -175,6 +175,14 @@ config DESKTOP_MOTION_SENSOR_SLEEP_DISABLE_ON_USB
 	  Low power modes reduce device power consumption, but increase
 	  response time.
 
+config DESKTOP_MOTION_PM_EVENTS
+	bool "Power management events support"
+	depends on DESKTOP_MOTION_SIMULATED_ENABLE || DESKTOP_MOTION_SENSOR_ENABLE
+	depends on CAF_PM_EVENTS
+	default y
+	help
+	  React on power management events in motion module.
+
 if !DESKTOP_MOTION_NONE
 module = DESKTOP_MOTION
 module-str = motion module

--- a/applications/nrf_desktop/src/hw_interface/board.c
+++ b/applications/nrf_desktop/src/hw_interface/board.c
@@ -115,7 +115,8 @@ static bool app_event_handler(const struct app_event_header *aeh)
 		return false;
 	}
 
-	if (is_wake_up_event(aeh)) {
+	if (IS_ENABLED(CONFIG_DESKTOP_BOARD_PM_EVENTS) &&
+	    is_wake_up_event(aeh)) {
 		if (!initialized) {
 			initialized = true;
 
@@ -124,7 +125,8 @@ static bool app_event_handler(const struct app_event_header *aeh)
 		return false;
 	}
 
-	if (is_power_down_event(aeh)) {
+	if (IS_ENABLED(CONFIG_DESKTOP_BOARD_PM_EVENTS) &&
+	    is_power_down_event(aeh)) {
 		const struct power_down_event *event = cast_power_down_event(aeh);
 
 		/* Do not cut off leds power on error */
@@ -147,6 +149,8 @@ static bool app_event_handler(const struct app_event_header *aeh)
 	return false;
 }
 APP_EVENT_LISTENER(MODULE, app_event_handler);
-APP_EVENT_SUBSCRIBE(MODULE, power_down_event);
 APP_EVENT_SUBSCRIBE_EARLY(MODULE, module_state_event);
+#if CONFIG_DESKTOP_BOARD_PM_EVENTS
+APP_EVENT_SUBSCRIBE(MODULE, power_down_event);
 APP_EVENT_SUBSCRIBE(MODULE, wake_up_event);
+#endif

--- a/applications/nrf_desktop/src/hw_interface/motion_sensor.c
+++ b/applications/nrf_desktop/src/hw_interface/motion_sensor.c
@@ -201,9 +201,12 @@ static void data_ready_handler(const struct device *dev, const struct sensor_tri
 
 	case STATE_SUSPENDED:
 	case STATE_SUSPENDED_DISCONNECTED:
-		/* Wake up system - this will wake up thread */
-		APP_EVENT_SUBMIT(new_wake_up_event());
-		break;
+		if (IS_ENABLED(CONFIG_DESKTOP_MOTION_PM_EVENTS)) {
+			/* Wake up system - this will wake up thread */
+			APP_EVENT_SUBMIT(new_wake_up_event());
+			break;
+		}
+		/* Fall-through */
 
 	case STATE_FETCHING:
 	case STATE_DISABLED:
@@ -629,7 +632,8 @@ static bool app_event_handler(const struct app_event_header *aeh)
 		return false;
 	}
 
-	if (is_wake_up_event(aeh)) {
+	if (IS_ENABLED(CONFIG_DESKTOP_MOTION_PM_EVENTS) &&
+	    is_wake_up_event(aeh)) {
 		k_spinlock_key_t key = k_spin_lock(&state.lock);
 		if ((state.state == STATE_SUSPENDED) ||
 		    (state.state == STATE_SUSPENDED_DISCONNECTED)) {
@@ -651,7 +655,8 @@ static bool app_event_handler(const struct app_event_header *aeh)
 		return false;
 	}
 
-	if (is_power_down_event(aeh)) {
+	if (IS_ENABLED(CONFIG_DESKTOP_MOTION_PM_EVENTS) &&
+	    is_power_down_event(aeh)) {
 		k_spinlock_key_t key = k_spin_lock(&state.lock);
 
 		switch (state.state) {
@@ -710,7 +715,6 @@ static bool app_event_handler(const struct app_event_header *aeh)
 }
 APP_EVENT_LISTENER(MODULE, app_event_handler);
 APP_EVENT_SUBSCRIBE(MODULE, module_state_event);
-APP_EVENT_SUBSCRIBE(MODULE, wake_up_event);
 APP_EVENT_SUBSCRIBE(MODULE, hid_report_sent_event);
 APP_EVENT_SUBSCRIBE(MODULE, hid_report_subscription_event);
 #if CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE
@@ -719,4 +723,7 @@ APP_EVENT_SUBSCRIBE_EARLY(MODULE, config_event);
 #if CONFIG_DESKTOP_MOTION_SENSOR_SLEEP_DISABLE_ON_USB
 APP_EVENT_SUBSCRIBE(MODULE, usb_state_event);
 #endif
+#if CONFIG_DESKTOP_MOTION_PM_EVENTS
+APP_EVENT_SUBSCRIBE(MODULE, wake_up_event);
 APP_EVENT_SUBSCRIBE_EARLY(MODULE, power_down_event);
+#endif

--- a/applications/nrf_desktop/src/hw_interface/motion_simulated.c
+++ b/applications/nrf_desktop/src/hw_interface/motion_simulated.c
@@ -149,13 +149,15 @@ static bool app_event_handler(const struct app_event_header *aeh)
 		return false;
 	}
 
-	if (is_power_down_event(aeh)) {
+	if (IS_ENABLED(CONFIG_DESKTOP_MOTION_PM_EVENTS) &&
+	    is_power_down_event(aeh)) {
 		atomic_set(&state, STATE_SUSPENDED);
 
 		return false;
 	}
 
-	if (is_wake_up_event(aeh)) {
+	if (IS_ENABLED(CONFIG_DESKTOP_MOTION_PM_EVENTS) &&
+	    is_wake_up_event(aeh)) {
 		set_default_state();
 
 		return false;
@@ -168,9 +170,11 @@ static bool app_event_handler(const struct app_event_header *aeh)
 }
 
 APP_EVENT_LISTENER(MODULE, app_event_handler);
-APP_EVENT_SUBSCRIBE(MODULE, power_down_event);
 APP_EVENT_SUBSCRIBE(MODULE, module_state_event);
+#if CONFIG_DESKTOP_MOTION_PM_EVENTS
+APP_EVENT_SUBSCRIBE(MODULE, power_down_event);
 APP_EVENT_SUBSCRIBE(MODULE, wake_up_event);
+#endif
 APP_EVENT_SUBSCRIBE(MODULE, hid_report_sent_event);
 APP_EVENT_SUBSCRIBE(MODULE, hid_report_subscription_event);
 

--- a/applications/nrf_desktop/src/modules/Kconfig.ble_latency
+++ b/applications/nrf_desktop/src/modules/Kconfig.ble_latency
@@ -37,6 +37,13 @@ config DESKTOP_BLE_LOW_LATENCY_LOCK
 	  some connection intervals. Enabling this option increases the power
 	  consumption of the device.
 
+config DESKTOP_BLE_LATENCY_PM_EVENTS
+	bool "Power management events support"
+	depends on CAF_PM_EVENTS
+	default y
+	help
+	  React on power management events in BLE latency module.
+
 module = DESKTOP_BLE_LATENCY
 module-str = BLE latency
 source "subsys/logging/Kconfig.template.log_config"

--- a/applications/nrf_desktop/src/modules/ble_latency.c
+++ b/applications/nrf_desktop/src/modules/ble_latency.c
@@ -290,6 +290,7 @@ static bool app_event_handler(const struct app_event_header *aeh)
 	}
 
 	if (IS_ENABLED(CONFIG_DESKTOP_BLE_LOW_LATENCY_LOCK) &&
+	    IS_ENABLED(CONFIG_DESKTOP_BLE_LATENCY_PM_EVENTS) &&
 	    is_power_down_event(aeh)) {
 		const struct power_down_event *event =
 			cast_power_down_event(aeh);
@@ -303,6 +304,7 @@ static bool app_event_handler(const struct app_event_header *aeh)
 	}
 
 	if (IS_ENABLED(CONFIG_DESKTOP_BLE_LOW_LATENCY_LOCK) &&
+	    IS_ENABLED(CONFIG_DESKTOP_BLE_LATENCY_PM_EVENTS) &&
 	    is_wake_up_event(aeh)) {
 		latency_state |= CONN_LOW_LATENCY_LOCKED;
 		update_llpm_conn_latency_lock();
@@ -326,7 +328,7 @@ APP_EVENT_SUBSCRIBE(MODULE, ble_smp_transfer_event);
 #if CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE
 APP_EVENT_SUBSCRIBE_EARLY(MODULE, config_event);
 #endif
-#if CONFIG_DESKTOP_BLE_LOW_LATENCY_LOCK
+#if CONFIG_DESKTOP_BLE_LOW_LATENCY_LOCK && CONFIG_DESKTOP_BLE_LATENCY_PM_EVENTS
 APP_EVENT_SUBSCRIBE(MODULE, power_down_event);
 APP_EVENT_SUBSCRIBE(MODULE, wake_up_event);
 #endif

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -154,7 +154,13 @@ nRF Machine Learning (Edge Impulse)
 nRF Desktop
 -----------
 
-|no_changes_yet_note|
+* Added Kconfig options to enable handling of the power management events for the following nRF Desktop modules:
+
+  * :ref:`nrf_desktop_board` - The :ref:`CONFIG_DESKTOP_BOARD_PM_EVENTS <config_desktop_app_options>` Kconfig option.
+  * :ref:`nrf_desktop_motion` - The :ref:`CONFIG_DESKTOP_MOTION_PM_EVENTS <config_desktop_app_options>` Kconfig option.
+  * :ref:`nrf_desktop_ble_latency` - The :ref:`CONFIG_DESKTOP_BLE_LATENCY_PM_EVENTS <config_desktop_app_options>` Kconfig option.
+
+  All listed Kconfig options are enabled by default and depend on the :kconfig:option:`CONFIG_CAF_PM_EVENTS` Kconfig option.
 
 Samples
 =======


### PR DESCRIPTION
Added ifdefs and Kconfig options to allow building motion, board and ble_latency modules when PM events are disabled.

Jira: NCSDK-21679