### PR TITLE
modem: pdn: Allow PDP_TYPE-only config

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -304,7 +304,9 @@ Debug libraries
 Modem libraries
 ---------------
 
-|no_changes_yet_note|
+* :ref:`pdn_readme` library:
+
+  * Updated the library to allow a ``PDP_type``-only configuration in the :c:func:`pdn_ctx_configure` function.
 
 Libraries for networking
 ------------------------

--- a/lib/pdn/pdn.c
+++ b/lib/pdn/pdn.c
@@ -325,11 +325,7 @@ int pdn_ctx_configure(uint8_t cid, const char *apn, enum pdn_fam fam,
 	int err;
 	char family[] = "IPV4V6"; /* longest family */
 
-	if (!apn) {
-		return -EFAULT;
-	}
-
-	if (strlen(apn) >= APN_STR_MAX_LEN) {
+	if (apn != NULL && strlen(apn) >= APN_STR_MAX_LEN) {
 		return -EINVAL;
 	}
 
@@ -346,6 +342,9 @@ int pdn_ctx_configure(uint8_t cid, const char *apn, enum pdn_fam fam,
 	case PDN_FAM_NONIP:
 		strncpy(family, "Non-IP", sizeof(family));
 		break;
+	default:
+		LOG_ERR("Wrong family %d", fam);
+		return -EINVAL;
 	}
 
 	if (opt) {
@@ -359,7 +358,11 @@ int pdn_ctx_configure(uint8_t cid, const char *apn, enum pdn_fam fam,
 			opt->nslpi,
 			opt->secure_pco);
 	} else {
-		err = nrf_modem_at_printf("AT+CGDCONT=%u,%s,%s", cid, family, apn);
+		if (apn != NULL) {
+			err = nrf_modem_at_printf("AT+CGDCONT=%u,%s,%s", cid, family, apn);
+		} else {
+			err = nrf_modem_at_printf("AT+CGDCONT=%u,%s", cid, family);
+		}
 	}
 
 	if (err) {


### PR DESCRIPTION
Allow PDN configuration without APN but PDP_Type only.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>