### PR TITLE
applications: machine_learning: Switch to file hosted by Nordic

### DIFF
--- a/applications/machine_learning/configuration/nrf52840dk_nrf52840/prj.conf
+++ b/applications/machine_learning/configuration/nrf52840dk_nrf52840/prj.conf
@@ -51,7 +51,7 @@ CONFIG_FP16=n
 
 # Use the NCS machine learning model for simulated acceleration signal
 CONFIG_EDGE_IMPULSE=y
-CONFIG_EDGE_IMPULSE_URI="http://studio.edgeimpulse.com/v1/api/201289/deployment/download?type=zip&modelType=int8"
+CONFIG_EDGE_IMPULSE_URI="https://developer.nordicsemi.com/nRF_Connect_SDK/EdgeImpulse/nrf_accel_sim-v35.zip"
 CONFIG_EI_WRAPPER=y
 
 ################################################################################

--- a/applications/machine_learning/configuration/nrf52840dk_nrf52840/prj_nus.conf
+++ b/applications/machine_learning/configuration/nrf52840dk_nrf52840/prj_nus.conf
@@ -70,7 +70,7 @@ CONFIG_FP16=n
 
 # Use the NCS machine learning model for simulated acceleration signal
 CONFIG_EDGE_IMPULSE=y
-CONFIG_EDGE_IMPULSE_URI="http://studio.edgeimpulse.com/v1/api/201289/deployment/download?type=zip&modelType=int8"
+CONFIG_EDGE_IMPULSE_URI="https://developer.nordicsemi.com/nRF_Connect_SDK/EdgeImpulse/nrf_accel_sim-v35.zip"
 CONFIG_EI_WRAPPER=y
 
 ################################################################################

--- a/applications/machine_learning/configuration/nrf52840dk_nrf52840/prj_release.conf
+++ b/applications/machine_learning/configuration/nrf52840dk_nrf52840/prj_release.conf
@@ -49,7 +49,7 @@ CONFIG_FP16=n
 
 # Use the NCS machine learning model for simulated acceleration signal
 CONFIG_EDGE_IMPULSE=y
-CONFIG_EDGE_IMPULSE_URI="http://studio.edgeimpulse.com/v1/api/201289/deployment/download?type=zip&modelType=int8"
+CONFIG_EDGE_IMPULSE_URI="https://developer.nordicsemi.com/nRF_Connect_SDK/EdgeImpulse/nrf_accel_sim-v35.zip"
 CONFIG_EI_WRAPPER=y
 
 ################################################################################

--- a/applications/machine_learning/configuration/nrf5340dk_nrf5340_cpuapp/prj.conf
+++ b/applications/machine_learning/configuration/nrf5340dk_nrf5340_cpuapp/prj.conf
@@ -69,7 +69,7 @@ CONFIG_FP16=n
 
 # Use the NCS machine learning model for simulated acceleration signal
 CONFIG_EDGE_IMPULSE=y
-CONFIG_EDGE_IMPULSE_URI="http://studio.edgeimpulse.com/v1/api/201289/deployment/download?type=zip&modelType=int8"
+CONFIG_EDGE_IMPULSE_URI="https://developer.nordicsemi.com/nRF_Connect_SDK/EdgeImpulse/nrf_accel_sim-v35.zip"
 CONFIG_EI_WRAPPER=y
 
 ################################################################################

--- a/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/prj.conf
+++ b/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/prj.conf
@@ -71,7 +71,7 @@ CONFIG_FP16=n
 
 # Use the NCS machine learning model for acceleration readouts coming from HW accelerometer
 CONFIG_EDGE_IMPULSE=y
-CONFIG_EDGE_IMPULSE_URI="http://studio.edgeimpulse.com/v1/api/200718/deployment/download?type=zip&modelType=int8"
+CONFIG_EDGE_IMPULSE_URI="https://developer.nordicsemi.com/nRF_Connect_SDK/EdgeImpulse/nrf_accel_hw-v36.zip"
 CONFIG_EI_WRAPPER=y
 CONFIG_EI_WRAPPER_DATA_BUF_SIZE=1000
 

--- a/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/prj_release.conf
+++ b/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/prj_release.conf
@@ -66,7 +66,7 @@ CONFIG_FP16=n
 
 # Use the NCS machine learning model for acceleration readouts coming from HW accelerometer
 CONFIG_EDGE_IMPULSE=y
-CONFIG_EDGE_IMPULSE_URI="http://studio.edgeimpulse.com/v1/api/200718/deployment/download?type=zip&modelType=int8"
+CONFIG_EDGE_IMPULSE_URI="https://developer.nordicsemi.com/nRF_Connect_SDK/EdgeImpulse/nrf_accel_hw-v36.zip"
 CONFIG_EI_WRAPPER=y
 CONFIG_EI_WRAPPER_DATA_BUF_SIZE=1000
 

--- a/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/prj_rtt.conf
+++ b/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/prj_rtt.conf
@@ -73,7 +73,7 @@ CONFIG_FP16=n
 
 # Use the NCS machine learning model for acceleration readouts coming from HW accelerometer
 CONFIG_EDGE_IMPULSE=y
-CONFIG_EDGE_IMPULSE_URI="http://studio.edgeimpulse.com/v1/api/200718/deployment/download?type=zip&modelType=int8"
+CONFIG_EDGE_IMPULSE_URI="https://developer.nordicsemi.com/nRF_Connect_SDK/EdgeImpulse/nrf_accel_hw-v36.zip"
 CONFIG_EI_WRAPPER=y
 CONFIG_EI_WRAPPER_DATA_BUF_SIZE=1000
 

--- a/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp_ns/prj.conf
+++ b/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp_ns/prj.conf
@@ -71,7 +71,7 @@ CONFIG_FP16=n
 
 # Use the NCS machine learning model for acceleration readouts coming from HW accelerometer
 CONFIG_EDGE_IMPULSE=y
-CONFIG_EDGE_IMPULSE_URI="http://studio.edgeimpulse.com/v1/api/200718/deployment/download?type=zip&modelType=int8"
+CONFIG_EDGE_IMPULSE_URI="https://developer.nordicsemi.com/nRF_Connect_SDK/EdgeImpulse/nrf_accel_hw-v36.zip"
 CONFIG_EI_WRAPPER=y
 CONFIG_EI_WRAPPER_DATA_BUF_SIZE=1000
 

--- a/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp_ns/prj_release.conf
+++ b/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp_ns/prj_release.conf
@@ -66,7 +66,7 @@ CONFIG_FP16=n
 
 # Use the NCS machine learning model for acceleration readouts coming from HW accelerometer
 CONFIG_EDGE_IMPULSE=y
-CONFIG_EDGE_IMPULSE_URI="http://studio.edgeimpulse.com/v1/api/200718/deployment/download?type=zip&modelType=int8"
+CONFIG_EDGE_IMPULSE_URI="https://developer.nordicsemi.com/nRF_Connect_SDK/EdgeImpulse/nrf_accel_hw-v36.zip"
 CONFIG_EI_WRAPPER=y
 CONFIG_EI_WRAPPER_DATA_BUF_SIZE=1000
 

--- a/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp_ns/prj_rtt.conf
+++ b/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp_ns/prj_rtt.conf
@@ -73,7 +73,7 @@ CONFIG_FP16=n
 
 # Use the NCS machine learning model for acceleration readouts coming from HW accelerometer
 CONFIG_EDGE_IMPULSE=y
-CONFIG_EDGE_IMPULSE_URI="http://studio.edgeimpulse.com/v1/api/200718/deployment/download?type=zip&modelType=int8"
+CONFIG_EDGE_IMPULSE_URI="https://developer.nordicsemi.com/nRF_Connect_SDK/EdgeImpulse/nrf_accel_hw-v36.zip"
 CONFIG_EI_WRAPPER=y
 CONFIG_EI_WRAPPER_DATA_BUF_SIZE=1000
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -149,7 +149,7 @@ nRF5340 Audio
 nRF Machine Learning (Edge Impulse)
 -----------------------------------
 
-|no_changes_yet_note|
+* Updated the machine learning models (:kconfig:option:`CONFIG_EDGE_IMPULSE_URI`) used by the application so that they are now hosted by Nordic Semiconductor.
 
 nRF Desktop
 -----------

--- a/samples/edge_impulse/wrapper/prj.conf
+++ b/samples/edge_impulse/wrapper/prj.conf
@@ -19,5 +19,5 @@ CONFIG_FP16=n
 
 # Enable Edge Impulse
 CONFIG_EDGE_IMPULSE=y
-CONFIG_EDGE_IMPULSE_URI="http://studio.edgeimpulse.com/v1/api/201289/deployment/download?type=zip&modelType=int8"
+CONFIG_EDGE_IMPULSE_URI="https://developer.nordicsemi.com/nRF_Connect_SDK/EdgeImpulse/nrf_accel_sim-v35.zip"
 CONFIG_EI_WRAPPER=y


### PR DESCRIPTION
Switch to downloading Neural Netowrk model package from Nordic Semiconductor servers instead of Edge Impulse's one.

NCSDK-19397