### PR TITLE
doc: Adding note about added PAKE algorithms

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -294,7 +294,7 @@ Libraries for Zigbee
 sdk-nrfxlib
 -----------
 
-* Added experimental support for EC J-PAKE, SPAKE2+ and SRP.
+* Added experimental support for password-authenticated key exchange (PAKE) algorithms EC J-PAKE, SPAKE2+ and SRP.
 
 See the changelog for each library in the :doc:`nrfxlib documentation <nrfxlib:README>` for additional information.
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -294,7 +294,7 @@ Libraries for Zigbee
 sdk-nrfxlib
 -----------
 
-|no_changes_yet_note|
+* Added experimental support for EC J-PAKE, SPAKE2+ and SRP.
 
 See the changelog for each library in the :doc:`nrfxlib documentation <nrfxlib:README>` for additional information.
 


### PR DESCRIPTION
Added note about experimental support for EC J-PAKE, SPAKE2+ and SRP in nrf_security.