### PR TITLE
manifest: Update to Zephyr with latest HW models

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 4618cfe53df3154a6ee4101c2e68e98531fdda98
+      revision: 9b2ecc048c1a4194ff6bb1e5ae883f979496383e
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pick the latest Zephyr, which includes the latest
nRF HW models.

----

Tests https://github.com/nrfconnect/sdk-zephyr/pull/1198