### PR TITLE
drivers: wifi: Fix network interface state handling

### DIFF
--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/default/fmac_api.c
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/default/fmac_api.c
@@ -2224,6 +2224,7 @@ enum wifi_nrf_status wifi_nrf_fmac_chg_vif_state(void *dev_ctx,
 		wifi_nrf_osal_sleep_ms(fmac_dev_ctx->fpriv->opriv, 1);
 
 	if (count == 0) {
+		status = WIFI_NRF_STATUS_FAIL;
 		wifi_nrf_osal_log_err(fmac_dev_ctx->fpriv->opriv,
 				      "%s: RPU is unresponsive for %d sec\n",
 				      __func__, RPU_CMD_TIMEOUT_MS / 1000);

--- a/drivers/wifi/nrf700x/zephyr/inc/zephyr_fmac_main.h
+++ b/drivers/wifi/nrf700x/zephyr/inc/zephyr_fmac_main.h
@@ -79,6 +79,7 @@ struct wifi_nrf_vif_ctx_zep {
 	} iface_ext_capa;
 	bool cookie_resp_received;
 	bool twt_in_progress;
+	struct k_work wifi_nrf_net_iface_work;
 };
 
 struct wifi_nrf_vif_ctx_map {


### PR DESCRIPTION
As per [1] the carrier state should be on once the Wi-Fi driver is ready and then dormant state can be used to intimate network stack about Wi-Fi association status.

Fix to use the proper APIs. Fixes NRF7X-50.

[1] - https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/connectivity/networking/api/net_if.html#network-interface-state-management