### PR TITLE
samples: nrf9160: modem_shell: Twister config for integration job

### DIFF
--- a/samples/nrf9160/modem_shell/sample.yaml
+++ b/samples/nrf9160/modem_shell/sample.yaml
@@ -243,14 +243,8 @@ tests:
         CONFIG_LOCATION_METHOD_WIFI=n
     tags: ci_build
 
-  # Configurations with modem UART traces to make sure they fit into image
-  sample.nrf9160.modem_shell_modem_uart_trace:
-    build_only: true
-    extra_args: CONFIG_NRF_MODEM_LIB_TRACE=y
-    integration_platforms:
-      - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
-    tags: ci_build
+  # Configurations with modem UART traces to make sure they fit into image.
+  # Basic UART trace configuration is tested in sample.nrf9160.modem_shell.integration_config.
   sample.nrf9160.modem_shell.non_offloading_ip_modem_uart_trace:
     build_only: true
     extra_args: OVERLAY_CONFIG=overlay-non-offloading.conf CONFIG_NRF_MODEM_LIB_TRACE=y
@@ -264,4 +258,16 @@ tests:
     integration_platforms:
       - thingy91_nrf9160_ns
     platform_allow: thingy91_nrf9160_ns
+    tags: ci_build
+
+  # Configuration which will be used by the CI integration job to verify PRs
+  sample.nrf9160.modem_shell.integration_config:
+    build_only: true
+    extra_configs:
+      - CONFIG_LTE_NETWORK_MODE_LTE_M=y
+        CONFIG_MODEM_ANTENNA_GNSS_EXTERNAL=y
+        CONFIG_NRF_MODEM_LIB_TRACE=y
+    integration_platforms:
+      - nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     tags: ci_build


### PR DESCRIPTION
Adding a configuration, which CI will use in integration jobs to verify the PRs. This reduces the need to rebuild the same stuff and speeds up the CI.