### PR TITLE
samples: nrf9160: modem_shell: Remove warning if AT%REL14FEAT fails

### DIFF
--- a/samples/nrf9160/modem_shell/src/link/link.c
+++ b/samples/nrf9160/modem_shell/src/link/link.c
@@ -510,10 +510,6 @@ static int link_enable_disable_rel14_features(bool enable)
 		mosh_warn("Release 14 features %s AT-command failed, err %d",
 			((enable) ? "enable" : "disable"),
 			ret);
-	} else if (ret > 0) {
-		mosh_warn("Release 14 features %s AT-command error, type %d err %d",
-			((enable) ? "enable" : "disable"),
-			nrf_modem_at_err_type(ret), nrf_modem_at_err(ret));
 	}
 	return 0;
 }


### PR DESCRIPTION
In mfw2.0 release AT%REL14FEAT will be removed so the warning would be annoying. And we want the functionality for mfw 1.3.x.

Jira: MOSH-457