### PR TITLE
include: modem: lte_lc: fix typo

### DIFF
--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -995,7 +995,7 @@ int lte_lc_connect_async(lte_lc_evt_handler_t handler);
  */
 int lte_lc_init_and_connect_async(lte_lc_evt_handler_t handler);
 
-/** @brief Deinitialize the LTE module, powers of the modem.
+/** @brief Deinitialize the LTE module, powers off the modem.
  *
  * @retval 0 if successful.
  * @retval -EFAULT if an AT command failed.


### PR DESCRIPTION
This commit fixes a typo in the doxygen
of `lte_lc_deinit`.