### PR TITLE
Bluetooth: Controller: Kconfig: No default BT_SDC_ADDITIONAL_MEMORY

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -242,7 +242,6 @@ endchoice
 
 config BT_SDC_ADDITIONAL_MEMORY
 	int "Allocates additional memory to the SDC memory pool"
-	default 0
 	help
 	  This is for testing and internal use only.
 


### PR DESCRIPTION
This will implicitly set the default to 0 and allow others to redefine a default value.