### PR TITLE
bluetooth: fast_pair: reorganise function for factory reset

### DIFF
--- a/subsys/bluetooth/services/fast_pair/CMakeLists.txt
+++ b/subsys/bluetooth/services/fast_pair/CMakeLists.txt
@@ -18,6 +18,7 @@ zephyr_library_sources_ifdef(CONFIG_BT_FAST_PAIR_GATT_SERVICE	   fp_gatt_service
 zephyr_library_sources_ifdef(CONFIG_BT_FAST_PAIR_KEYS		   fp_keys.c)
 zephyr_library_sources_ifdef(CONFIG_BT_FAST_PAIR_REGISTRATION_DATA fp_registration_data.c)
 zephyr_library_sources_ifdef(CONFIG_BT_FAST_PAIR_BATTERY	   fp_battery.c)
+zephyr_library_sources_ifdef(CONFIG_BT_FAST_PAIR_FACTORY_RESET	   fp_factory_reset.c)
 
 if(CONFIG_BT_FAST_PAIR_CRYPTO)
   add_subdirectory(fp_crypto)

--- a/subsys/bluetooth/services/fast_pair/Kconfig.fast_pair
+++ b/subsys/bluetooth/services/fast_pair/Kconfig.fast_pair
@@ -117,6 +117,12 @@ config BT_FAST_PAIR_BATTERY
 	help
 	  Add Fast Pair battery module source files.
 
+config BT_FAST_PAIR_FACTORY_RESET
+	bool
+	default y
+	help
+	  Add Fast Pair factory reset source files.
+
 module = BT_FAST_PAIR
 module-str = Fast Pair Service
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"

--- a/subsys/bluetooth/services/fast_pair/fp_factory_reset.c
+++ b/subsys/bluetooth/services/fast_pair/fp_factory_reset.c
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <bluetooth/services/fast_pair.h>
+
+#include "fp_storage.h"
+
+int bt_fast_pair_factory_reset(void)
+{
+	return fp_storage_factory_reset();
+}

--- a/subsys/bluetooth/services/fast_pair/fp_storage/fp_storage_manager.c
+++ b/subsys/bluetooth/services/fast_pair/fp_storage/fp_storage_manager.c
@@ -7,7 +7,8 @@
 #include <errno.h>
 #include <string.h>
 #include <zephyr/settings/settings.h>
-#include <bluetooth/services/fast_pair.h>
+
+#include "fp_storage.h"
 
 #include "fp_storage_manager.h"
 #include "fp_storage_manager_priv.h"
@@ -129,7 +130,7 @@ static int fp_settings_commit(void)
 SETTINGS_STATIC_HANDLER_DEFINE(fp_storage_manager, SETTINGS_SM_SUBTREE_NAME, NULL,
 			       fp_settings_set, fp_settings_commit, NULL);
 
-int bt_fast_pair_factory_reset(void)
+int fp_storage_factory_reset(void)
 {
 	int err;
 

--- a/subsys/bluetooth/services/fast_pair/fp_storage/include/fp_storage.h
+++ b/subsys/bluetooth/services/fast_pair/fp_storage/include/fp_storage.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef _FP_STORAGE_H_
+#define _FP_STORAGE_H_
+
+#include <sys/types.h>
+
+/**
+ * @defgroup fp_storage Fast Pair storage API for common operations
+ * @brief Internal API for common operations of Fast Pair storage
+ *
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Perform a reset to the default factory settings for all storage modules.
+ *
+ * Clears the Fast Pair storage. If the reset operation is interrupted by system reboot or power
+ * outage, the reset is automatically resumed at the stage of loading the Fast Pair storage.
+ * It prevents the Fast Pair storage from ending in unwanted state after the reset interruption.
+ *
+ * @return 0 if the operation was successful. Otherwise, a (negative) error code is returned.
+ */
+int fp_storage_factory_reset(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* _FP_STORAGE_H_ */

--- a/tests/subsys/bluetooth/fast_pair/storage/factory_reset/src/main.c
+++ b/tests/subsys/bluetooth/fast_pair/storage/factory_reset/src/main.c
@@ -11,8 +11,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(test_main);
 
-#include <bluetooth/services/fast_pair.h>
-
+#include "fp_storage.h"
 #include "fp_storage_ak.h"
 #include "fp_storage_ak_priv.h"
 #include "fp_storage_pn.h"
@@ -394,7 +393,7 @@ static void store_data_and_factory_reset(void)
 	cu_account_keys_validate_loaded(seed, key_count);
 	personalized_name_validate_loaded(name);
 
-	err = bt_fast_pair_factory_reset();
+	err = fp_storage_factory_reset();
 	zassert_ok(err, "Unexpected error in factory reset");
 }
 


### PR DESCRIPTION
Reorganised functions required for the bt_fast_pair_factory_reset API.