### PR TITLE
ci: clang-format: enforce code formatting

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,22 @@
+name: Check code formatting
+
+on: pull_request
+
+env:
+  CLANG_FORMAT_VERSION: "16.0"
+
+jobs:
+  check-code-formatting:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install clang-format
+        run: pip install clang-format~=${CLANG_FORMAT_VERSION}
+
+      - name: Run clang-format
+        run: git clang-format origin/${{ github.base_ref }} --verbose


### PR DESCRIPTION
Add a new workflow that enforces code to be formatted using the rules specified in the `.clang-format` file. Because `git-clang-format` is used, only the changed lines are checked. This allows for a gradual codebase formatting.