### PR TITLE
Remove mbedtls_hkdf usage

### DIFF
--- a/subsys/nrf_security/cmake/psa_crypto_config.cmake
+++ b/subsys/nrf_security/cmake/psa_crypto_config.cmake
@@ -310,7 +310,6 @@ kconfig_check_and_set_base_to_one(MBEDTLS_PK_WRITE_C)
 kconfig_check_and_set_base_to_one(MBEDTLS_MD_C)
 kconfig_check_and_set_base_to_one(MBEDTLS_THREADING_C)
 kconfig_check_and_set_base_to_one(MBEDTLS_THREADING_ALT)
-kconfig_check_and_set_base_to_one(MBEDTLS_HKDF_C)
 
 # Set the max curve bits for the PSA APIs without using MBEDTLS defines
 if (CONFIG_PSA_CRYPTO_DRIVER_ECC_SECP_R1_521_CC3XX)

--- a/subsys/nrf_security/configs/psa_crypto_config.h.template
+++ b/subsys/nrf_security/configs/psa_crypto_config.h.template
@@ -420,11 +420,6 @@
 #cmakedefine MBEDTLS_MPI_WINDOW_SIZE       @MBEDTLS_MPI_WINDOW_SIZE@ /**< Maximum window size used. */
 #cmakedefine MBEDTLS_MPI_MAX_SIZE          @MBEDTLS_MPI_MAX_SIZE@ /**< Maximum number of bytes for usable MPIs. */
 
-/* TF-M has dependency on mbedtls_hkdf function in order to avoid a recursion problem.
- * See tfm_builtin_key_loader.c for explanation.
- */
-#cmakedefine MBEDTLS_HKDF_C
-
 #include "psa/psa_crypto_config_oberon.h"
 
 #endif /* PSA_CRYPTO_CONFIG_H */

--- a/subsys/nrf_security/src/legacy/CMakeLists.txt
+++ b/subsys/nrf_security/src/legacy/CMakeLists.txt
@@ -47,13 +47,6 @@ if(CONFIG_MBEDTLS_LEGACY_CRYPTO_C OR
   )
 endif()
 
-if(CONFIG_MBEDTLS_PSA_CRYPTO_SPM AND CONFIG_MBEDTLS_HKDF_C)
-  # TF-M 1.7.0 requires legacy mbedtls_hkdf function in key loader.
-  append_with_prefix(src_crypto_legacy ${ARM_MBEDTLS_PATH}/library
-    hkdf.c
-  )
-endif()
-
 if(CONFIG_CRYPTOCELL_CC310_USABLE)
 append_with_prefix(src_crypto_legacy ${ARM_MBEDTLS_PATH}/library
   gcm.c

--- a/subsys/nrf_security/tfm/CMakeLists.txt
+++ b/subsys/nrf_security/tfm/CMakeLists.txt
@@ -73,13 +73,6 @@ set(CONFIG_MBEDTLS_USE_PSA_CRYPTO                   False)
 # complete build with all libraries and a full mbedcrypto library for linking.
 set(CONFIG_BUILD_WITH_TFM                           False)
 
-# In TF-M 1.7.0 we required mbedtls_hkdf function in HUK derivation.
-if (CONFIG_TFM_PROFILE_TYPE_MINIMAL)
-  set(CONFIG_MBEDTLS_HKDF_C                         False)
-else()
-  set(CONFIG_MBEDTLS_HKDF_C                         True)
-endif()
-
 if (NOT CONFIG_TFM_PROFILE_TYPE_MINIMAL AND CONFIG_PSA_CORE_OBERON)
   set(CONFIG_PSA_CRYPTO_DRIVER_OBERON                 True)
   set(CONFIG_PSA_CRYPTO_DRIVER_HAS_KDF_SUPPORT_OBERON True)

--- a/west.yml
+++ b/west.yml
@@ -144,7 +144,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: v1.7.0-ncs1
+      revision: 2ff3fddf645aff27fac90a71c315459e765b402d
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter


### PR DESCRIPTION
Updates nrfxlib and TF-M to include changes that removes the dependency on Mbed TLS HKDF.