### PR TITLE
doc : Add link to Zephyr release notes

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -425,6 +425,9 @@ For the list of |NCS| specific commits, including commits cherry-picked from ups
 
 The current |NCS| main branch is based on revision ``4bbd91a908`` of Zephyr.
 
+.. note::
+   For possible breaking changes and changes between the latest Zephyr release and the current Zephyr version, refer to the :ref:`Zephyr release notes <zephyr_release_notes>`.
+
 Additions specific to |NCS|
 ---------------------------
 


### PR DESCRIPTION
Add note to point to Zephyr release notes
for informing about any breaking changes.