### PR TITLE
caf: ble_adv: Adapt CAF_BLE_ADV_FILTER_ACCEPT_LIST for multi-core

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -283,7 +283,9 @@ Other libraries
 Common Application Framework (CAF)
 ----------------------------------
 
-|no_changes_yet_note|
+* :ref:`caf_ble_adv`:
+
+  * Updated the dependencies of the :kconfig:option:`CONFIG_CAF_BLE_ADV_FILTER_ACCEPT_LIST` Kconfig option so that it can be used when the Bluetooth controller is running on the network core.
 
 Shell libraries
 ---------------

--- a/subsys/caf/modules/Kconfig.ble_adv
+++ b/subsys/caf/modules/Kconfig.ble_adv
@@ -101,8 +101,8 @@ endif
 config CAF_BLE_ADV_FILTER_ACCEPT_LIST
 	bool "Enable filter accept list"
 	select BT_FILTER_ACCEPT_LIST
-	select BT_CTLR_FILTER_ACCEPT_LIST
-	select BT_CTLR_PRIVACY
+	select BT_CTLR_FILTER_ACCEPT_LIST if BT_CTLR
+	select BT_CTLR_PRIVACY if BT_CTLR
 	help
 	  If the used local identity already has bond, the device will filter
 	  incoming scan response data requests and connection requests. In


### PR DESCRIPTION
This change adapts dependencies of the CAF_BLE_ADV_FILTER_ACCEPT_LIST Kconfig option so this feature would work in multi-core config, for example when running Bluetooth controller in form of hci_rpmsg on network core.

Jira: NCSDK-21679