### PR TITLE
net: lib: nrf_cloud: add parameter to disable location response

### DIFF
--- a/doc/nrf/libraries/networking/nrf_cloud.rst
+++ b/doc/nrf/libraries/networking/nrf_cloud.rst
@@ -238,3 +238,21 @@ API documentation
 .. doxygengroup:: nrf_cloud
    :project: nrf
    :members:
+
+nRF Cloud codec documentation
+*****************************
+
+| Header file: :file:`include/net/nrf_cloud_codec.h`
+
+.. doxygengroup:: nrf_cloud_codec
+   :project: nrf
+   :members:
+
+nRF Cloud common definitions
+****************************
+
+| Header file: :file:`include/net/nrf_cloud_defs.h`
+
+.. doxygengroup:: nrf_cloud_defs
+   :project: nrf
+   :members:

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -216,6 +216,11 @@ nRF9160 samples
 
    * Updated credentials for the HTTPS connection.
 
+* :ref:`nrf_cloud_rest_cell_pos_sample` sample:
+
+  * Added the ``disable_response`` parameter to the :c:struct:`nrf_cloud_rest_location_request` structure.
+    If set to true, no location data is returned to the device when the :c:func:`nrf_cloud_rest_location_get` function is called.
+
 Trusted Firmware-M (TF-M) samples
 ---------------------------------
 

--- a/include/net/nrf_cloud_defs.h
+++ b/include/net/nrf_cloud_defs.h
@@ -9,6 +9,10 @@
 
 #include <zephyr/toolchain/common.h>
 
+/** @defgroup nrf_cloud_defs nRF Cloud common defines
+ * @{
+ */
+
 /* Message schemas defined by nRF Cloud:
  * https://github.com/nRFCloud/application-protocols/tree/v1/schemas
  */
@@ -180,9 +184,9 @@
 #define NRF_CLOUD_JSON_KEY_APP_VER		"appVersion"
 #define NRF_CLOUD_JSON_VAL_NOT_ASSOC		"not_associated"
 #define NRF_CLOUD_JSON_VAL_PAIRED		"paired"
-/** Current FOTA version string used in device shadow */
+/* Current FOTA version string used in device shadow */
 #define NRF_CLOUD_FOTA_VER_STR			"fota_v" STRINGIFY(NRF_CLOUD_FOTA_VER)
-/** Max length of nRF Cloud's stage/environment name */
+/* Max length of nRF Cloud's stage/environment name */
 #define NRF_CLOUD_STAGE_ID_MAX_LEN		8
 /** Max length of a tenant ID on nRF Cloud */
 #define NRF_CLOUD_TENANT_ID_MAX_LEN		64
@@ -206,4 +210,5 @@
 #define NRF_CLOUD_JSON_VAL_TOPIC_WILDCARD	"/+"
 #define NRF_CLOUD_JSON_VAL_TOPIC_BIN		"/bin"
 
+/** @} */
 #endif /* NRF_CLOUD_DEFS_H__ */

--- a/include/net/nrf_cloud_rest.h
+++ b/include/net/nrf_cloud_rest.h
@@ -121,6 +121,10 @@ struct nrf_cloud_rest_location_request {
 	struct lte_lc_cells_info *cell_info;
 	/** Wi-Fi network information used in request */
 	struct wifi_scan_info *wifi_info;
+	/** If true, nRF Cloud will not send the location data to the device
+	 * in the REST response body. The location will still be recorded in the cloud.
+	 */
+	bool disable_response;
 };
 
 /** @brief Data required for nRF Cloud Assisted GPS (A-GPS) request */


### PR DESCRIPTION
Add `disable_response` parameter to the
`nrf_cloud_rest_location_request` struct.
This gives `nrf_cloud_rest_location_get` the ability to disable the location data response data from nRF Cloud. IRIS-6130