### PR TITLE
lib: date_time: Fix AUTO_UPDATE for non-LTE builds

### DIFF
--- a/lib/date_time/date_time_core.c
+++ b/lib/date_time/date_time_core.c
@@ -146,11 +146,13 @@ void date_time_lte_ind_handler(const struct lte_lc_evt *const evt)
 
 void date_time_core_init(void)
 {
-	if (IS_ENABLED(CONFIG_DATE_TIME_AUTO_UPDATE) && IS_ENABLED(CONFIG_LTE_LINK_CONTROL)) {
-		lte_lc_register_handler(date_time_lte_ind_handler);
+	if (!IS_ENABLED(CONFIG_DATE_TIME_AUTO_UPDATE)) {
+		return;
 	}
 
-	if (!IS_ENABLED(CONFIG_DATE_TIME_AUTO_UPDATE)) {
+	if (IS_ENABLED(CONFIG_LTE_LINK_CONTROL)) {
+		lte_lc_register_handler(date_time_lte_ind_handler);
+	} else {
 		date_time_core_schedule_update(false);
 	}
 }


### PR DESCRIPTION
Currently, if CONFIG_LTE_LINK_CONTROL is not enabled, the date_time auto_update loop will not self-start unless CONFIG_DATE_TIME_AUTO_UPDATE is disabled.

This means that CONFIG_DATE_TIME_AUTO_UPDATE has the opposite effect intended if CONFIG_LTE_LINK_CONTROL is not enabled.

After this commit, automatic date_time updates are always enabled if CONFIG_DATE_TIME_AUTO_UPDATE is enabled, regardless of whether CONFIG_LTE_LINK_CONTROL is.

If CONFIG_LTE_LINK_CONTROL is enabled, this will be done by registering a callback with lte_lc_register_handler.

In all other cases, the auto_update loop will be started by calling date_time_core_schedule_update, and from then on the date_time library will periodically query its configured time source.