### PR TITLE
doc: small fixes to Thingy:53 documentation

### DIFF
--- a/doc/nrf/working_with_nrf/nrf53/thingy53.rst
+++ b/doc/nrf/working_with_nrf/nrf53/thingy53.rst
@@ -176,14 +176,17 @@ Samples and applications built for Thingy:53 include the MCUboot bootloader that
 This method uses signed binary files :file:`app_update.bin` and :file:`net_core_app_update.bin` (or :file:`dfu_application.zip`).
 You can program the precompiled firmware image using one of the following ways:
 
-* Use the :doc:`mcuboot:index-ncs` feature and the built-in serial recovery mode of Thingy:53.
-  In this scenario Thingy is connected directly to your PC through USB.
+* Use the :doc:`MCUboot<mcuboot:index-ncs>` feature and the built-in serial recovery mode of Thingy:53.
+  In this scenario, the Thingy is connected directly to your PC through USB.
+  For details, refer to the :ref:`thingy53_app_mcuboot_bootloader` section.
+
+  See the :ref:`thingy53_gs_updating_usb` section in the :ref:`ug_thingy53_gs` guide for the detailed procedures on how to program the Thingy:53 using `nRF Connect Programmer`_.
 * Update the firmware over-the-air (OTA) using Bluetooth LE and the nRF Programmer mobile application for Android or iOS.
   To use this method, the application that is currently programmed on Thingy:53 must support it.
   For details, refer to :ref:`thingy53_app_fota_smp` section.
   All precompiled images support OTA using Bluetooth.
 
-See :ref:`thingy53_gs_updating_firmware` for the detailed procedures on how to program a Thingy:53 using `nRF Connect Programmer`_ or the `nRF Programmer`_ for Android or iOS.
+  See the :ref:`thingy53_gs_updating_ble` section in the :ref:`ug_thingy53_gs` guide for the detailed procedures on how to program a Thingy:53 using `nRF Programmer`_ for Android or iOS.
 
 .. _thingy53_app_guide:
 
@@ -218,7 +221,7 @@ MCUboot bootloader
 
 MCUboot bootloader is enabled by default for Thingy:53 in the :file:`Kconfig.defconfig` file of the board.
 This ensures that the sample includes the MCUboot bootloader and that an MCUboot-compatible image is generated when the sample is built.
-When using |NCS| to build the MCUboot bootloader for the Thingy:53, the configuration is applied automatically from the MCUboot repository.
+When using the |NCS| to build the MCUboot bootloader for the Thingy:53, the configuration is applied automatically from the MCUboot repository.
 
 The MCUboot bootloader supports serial recovery and a custom command to erase the settings storage partition.
 Erasing the settings partition is needed to ensure that an application is not booted with incompatible content loaded from the settings partition.

--- a/doc/nrf/working_with_nrf/nrf53/thingy53_gs.rst
+++ b/doc/nrf/working_with_nrf/nrf53/thingy53_gs.rst
@@ -139,18 +139,16 @@ Complete the following steps to update the firmware:
 
    The :file:`CONTENTS.txt` file in the extracted folder contains the location and names of the different firmware images.
 
-#. Open the connector cover on the side of the Nordic Thingy:53 and plug the Nordic Thingy:53 into the computer using a USB-C cable.
+#. Take off the top cover of the Nordic Thingy:53 so you can access the **SW2** button in Step 7.
+#. Plug the Nordic Thingy:53 into the computer using a USB-C cable.
 
    .. figure:: images/thingy53_sw1_usb.svg
       :alt: The Nordic Thingy:53 schematic - **SW1** and USB connector cover
 
       The Nordic Thingy:53 schematic - **SW1** and USB connector cover
 
-#. Move the power switch **SW1** to the **ON** position.
 #. Open nRF Connect for Desktop and launch the Programmer app.
-#. Move the power switch **SW1** to the **OFF** position.
-#. Take off the top cover to access the **SW2** button.
-#. Press **SW2** while switching **SW1** to the **ON** position.
+#. Press **SW2** while moving the power switch **SW1** to the **ON** position.
 
    .. figure:: images/thingy53_sw1_sw2.svg
       :alt: The Nordic Thingy:53 schematic - **SW1** and **SW2**
@@ -187,7 +185,7 @@ Complete the following steps to update the firmware:
 
    When the update is complete, a **Completed successfully** message appears.
 
-You can now disconnect the Nordic Thingy:53 from the computer.
+You can now disconnect the Nordic Thingy:53 from the computer and put the top cover back on.
 
 .. _thingy53_gs_updating_external_probe:
 


### PR DESCRIPTION
Fixes small inconsistencies in the Getting started and Developing pages for the Thingy:53.