### PR TITLE
samples: wifi: Fix board checks for build assert

### DIFF
--- a/samples/wifi/sr_coex/src/main.c
+++ b/samples/wifi/sr_coex/src/main.c
@@ -365,7 +365,7 @@ int main(void)
 #endif /* CONFIG_NRF700X_BT_COEX */
 
 #if !defined(CONFIG_COEX_SEP_ANTENNAS) && \
-	(!defined(CONFIG_BOARD_NRF7002DK_NRF7001_NRF5340_CPUAPP) || \
+	!(defined(CONFIG_BOARD_NRF7002DK_NRF7001_NRF5340_CPUAPP) || \
 	   defined(CONFIG_BOARD_NRF7002DK_NRF5340_CPUAPP))
 	BUILD_ASSERT("Shared antenna support is not available with nRF7002 shields");
 #endif


### PR DESCRIPTION
EK boards are not expected to have shared antenna. Hence a build assert is required to ensure that shared antenna config is not enabled for EK boards.
The current checks make this restriction applicable for DK boards as well. Skip the build assert for DK boards.