### PR TITLE
applications: nrf_desktop: Reduce log verbosity

### DIFF
--- a/applications/nrf_desktop/doc/usb_state_pm.rst
+++ b/applications/nrf_desktop/doc/usb_state_pm.rst
@@ -34,7 +34,8 @@ Implementation details
 For the change of the restricted power level, the module reacts to :c:struct:`usb_state_event`.
 Upon reception of the event and depending on the current USB state, the module requests different power restrictions:
 
-* If the USB state is set to :c:enum:`USB_STATE_POWERED` or :c:enum:`USB_STATE_ACTIVE`, the :c:enum:`POWER_MANAGER_LEVEL_ALIVE` is required.
+* If the USB state is set to :c:enum:`USB_STATE_POWERED`, the module restricts the power down level to the :c:enum:`POWER_MANAGER_LEVEL_SUSPENDED`.
+* If the USB state is set to :c:enum:`USB_STATE_ACTIVE`, the :c:enum:`POWER_MANAGER_LEVEL_ALIVE` is required.
 * If the USB state is set to :c:enum:`USB_STATE_DISCONNECTED`, any power level is allowed.
 * If the USB state is set to :c:enum:`USB_STATE_SUSPENDED`, the :c:enum:`POWER_MANAGER_LEVEL_SUSPENDED` is imposed.
   The module restricts the power down level to the :c:enum:`POWER_MANAGER_LEVEL_SUSPENDED` and generates :c:struct:`force_power_down_event`.

--- a/applications/nrf_desktop/src/modules/Kconfig.usb_state
+++ b/applications/nrf_desktop/src/modules/Kconfig.usb_state
@@ -102,6 +102,12 @@ choice USB_DRIVER_LOG_LEVEL_CHOICE
 	  Disable USB driver logs to avoid flooding logs.
 endchoice
 
+choice USB_HID_LOG_LEVEL_CHOICE
+	default USB_HID_LOG_LEVEL_WRN
+	help
+	  Reduce USB HID log level to avoid flooding logs on USB state changes.
+endchoice
+
 module = DESKTOP_USB_STATE
 module-str = USB state
 source "subsys/logging/Kconfig.template.log_config"

--- a/applications/nrf_desktop/src/modules/usb_state_pm.c
+++ b/applications/nrf_desktop/src/modules/usb_state_pm.c
@@ -27,6 +27,8 @@ static bool app_event_handler(const struct app_event_header *aeh)
 
 		switch (event->state) {
 		case USB_STATE_POWERED:
+			power_manager_restrict(MODULE_IDX(MODULE), POWER_MANAGER_LEVEL_SUSPENDED);
+			break;
 		case USB_STATE_ACTIVE:
 			power_manager_restrict(MODULE_IDX(MODULE), POWER_MANAGER_LEVEL_ALIVE);
 			break;

--- a/applications/nrf_desktop/src/modules/usb_state_pm.c
+++ b/applications/nrf_desktop/src/modules/usb_state_pm.c
@@ -23,7 +23,7 @@ static bool app_event_handler(const struct app_event_header *aeh)
 	if (is_usb_state_event(aeh)) {
 		const struct usb_state_event *event = cast_usb_state_event(aeh);
 
-		LOG_INF("USB state change detected");
+		LOG_DBG("USB state change detected");
 
 		switch (event->state) {
 		case USB_STATE_POWERED:
@@ -34,7 +34,7 @@ static bool app_event_handler(const struct app_event_header *aeh)
 			power_manager_restrict(MODULE_IDX(MODULE), POWER_MANAGER_LEVEL_MAX);
 			break;
 		case USB_STATE_SUSPENDED:
-			LOG_INF("USB suspended");
+			LOG_DBG("USB suspended");
 			power_manager_restrict(MODULE_IDX(MODULE), POWER_MANAGER_LEVEL_SUSPENDED);
 			force_power_down();
 			break;

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -166,6 +166,8 @@ nRF Desktop
 
   * Set the max compiled-in log level to ``warning`` for the USB HID class (:kconfig:option:`CONFIG_USB_HID_LOG_LEVEL_CHOICE`) and reduce the log message levels used in the :ref:`nrf_desktop_usb_state_pm` source code.
     This is done to avoid flooding logs during USB state changes.
+  * If the USB state is set to :c:enum:`USB_STATE_POWERED`, the :ref:`nrf_desktop_usb_state_pm` restricts the power down level to the :c:enum:`POWER_MANAGER_LEVEL_SUSPENDED` instead of requiring :c:enum:`POWER_MANAGER_LEVEL_ALIVE`.
+    This is done to prevent the device from powering down and waking up multiple times when an USB cable is connected.
 
 Samples
 =======

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -162,6 +162,11 @@ nRF Desktop
 
   All listed Kconfig options are enabled by default and depend on the :kconfig:option:`CONFIG_CAF_PM_EVENTS` Kconfig option.
 
+* Updated:
+
+  * Set the max compiled-in log level to ``warning`` for the USB HID class (:kconfig:option:`CONFIG_USB_HID_LOG_LEVEL_CHOICE`) and reduce the log message levels used in the :ref:`nrf_desktop_usb_state_pm` source code.
+    This is done to avoid flooding logs during USB state changes.
+
 Samples
 =======
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -307,6 +307,10 @@ Common Application Framework (CAF)
 
   * Updated the dependencies of the :kconfig:option:`CONFIG_CAF_BLE_ADV_FILTER_ACCEPT_LIST` Kconfig option so that it can be used when the Bluetooth controller is running on the network core.
 
+* :ref:`caf_power_manager`:
+
+  * Reduced verbosity of logs denoting allowed power states from ``info`` to ``debug``.
+
 Shell libraries
 ---------------
 

--- a/subsys/caf/modules/power_manager.c
+++ b/subsys/caf/modules/power_manager.c
@@ -118,10 +118,10 @@ static void restrict_power_state(size_t module, enum power_manager_level lvl)
 		}
 		module_flags_clear_bit(&power_mode_restrict_flags[current], module);
 	}
-	LOG_INF("Power state SUSPENDED: %s",
+	LOG_DBG("Power state SUSPENDED: %s",
 		check_if_power_state_allowed(POWER_MANAGER_LEVEL_SUSPENDED) ?
 			"ALLOWED" : "BLOCKED");
-	LOG_INF("Power state OFF: %s",
+	LOG_DBG("Power state OFF: %s",
 		check_if_power_state_allowed(POWER_MANAGER_LEVEL_OFF) ?
 			"ALLOWED" : "BLOCKED");
 }


### PR DESCRIPTION
PR:

- reduces log verbosity to avoid flooding logs in CI tests when an USB cable is attached
- allows to suspend device when in USB powered state to prevent triggering a sequence of multiple power downs and wake ups when an USB cable is attached.

Jira: NCSDK-21875