### PR TITLE
Bluetooth: Controller: Internal APIs for supported cmds and features

### DIFF
--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -194,7 +194,7 @@ static void encode_command_complete_header(uint8_t * const event,
 	event[BT_HCI_EVT_HDR_SIZE + sizeof(struct bt_hci_evt_cmd_complete)] = status;
 }
 
-static void supported_commands(sdc_hci_ip_supported_commands_t *cmds)
+void hci_internal_supported_commands(sdc_hci_ip_supported_commands_t *cmds)
 {
 	memset(cmds, 0, sizeof(*cmds));
 
@@ -478,7 +478,8 @@ static void supported_features(sdc_hci_ip_lmp_features_t *features)
 	features->le_supported = 1;
 }
 
-static void le_supported_features(sdc_hci_cmd_le_read_local_supported_features_return_t *features)
+void hci_internal_le_supported_features(
+	sdc_hci_cmd_le_read_local_supported_features_return_t *features)
 {
 	memset(features, 0, sizeof(*features));
 
@@ -706,7 +707,7 @@ static uint8_t info_param_cmd_put(uint8_t const * const cmd,
 		return sdc_hci_cmd_ip_read_local_version_information((void *)event_out_params);
 	case SDC_HCI_OPCODE_CMD_IP_READ_LOCAL_SUPPORTED_COMMANDS:
 		*param_length_out += sizeof(sdc_hci_cmd_ip_read_local_supported_commands_return_t);
-		supported_commands((void *)event_out_params);
+		hci_internal_supported_commands((void *)event_out_params);
 		return 0;
 	case SDC_HCI_OPCODE_CMD_IP_READ_LOCAL_SUPPORTED_FEATURES:
 		*param_length_out += sizeof(sdc_hci_cmd_ip_read_local_supported_features_return_t);
@@ -760,7 +761,7 @@ static uint8_t le_controller_cmd_put(uint8_t const * const cmd,
 
 	case SDC_HCI_OPCODE_CMD_LE_READ_LOCAL_SUPPORTED_FEATURES:
 		*param_length_out += sizeof(sdc_hci_cmd_le_read_local_supported_features_return_t);
-		le_supported_features((void *)event_out_params);
+		hci_internal_le_supported_features((void *)event_out_params);
 		return 0;
 
 	case SDC_HCI_OPCODE_CMD_LE_SET_RANDOM_ADDRESS:

--- a/subsys/bluetooth/controller/hci_internal.h
+++ b/subsys/bluetooth/controller/hci_internal.h
@@ -10,6 +10,8 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <sdc_hci_cmd_le.h>
+#include <sdc_hci_cmd_info_params.h>
 
 #ifndef HCI_INTERNAL_H__
 #define HCI_INTERNAL_H__
@@ -81,5 +83,19 @@ int hci_internal_user_cmd_handler_register(const hci_internal_user_cmd_handler_t
  * @return Zero on success or (negative) error code otherwise.
  */
 int hci_internal_msg_get(uint8_t *msg_out, sdc_hci_msg_type_t *msg_type_out);
+
+/** @brief Retrieve the list of supported commands configured for this build
+ *
+ * @param[out] cmds The list of supported commands
+ */
+void hci_internal_supported_commands(
+	sdc_hci_ip_supported_commands_t *cmds);
+
+/** @brief Retrieve the list of supported LE features configured for this build
+ *
+ * @param[out] features The list of supported features
+ */
+void hci_internal_le_supported_features(
+	sdc_hci_cmd_le_read_local_supported_features_return_t *features);
 
 #endif


### PR DESCRIPTION
This will make it easier to override what features and commands that are supported using the API hci_internal_user_cmd_handler_register().