### PR TITLE
doc improvement: Bluetooth libraries: fixing path to header file

### DIFF
--- a/doc/nrf/libraries/bluetooth_services/services/bas_client.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/bas_client.rst
@@ -72,7 +72,7 @@ In such case, the next read period is started with the new interval.
 API documentation
 *****************
 
-| Header file: :file:`include/bas_client.h`
+| Header file: :file:`include/bluetooth/services/bas_client.h`
 | Source file: :file:`subsys/bluetooth/services/bas_client.c`
 
 .. doxygengroup:: bt_bas_client_api

--- a/doc/nrf/libraries/bluetooth_services/services/hids.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/hids.rst
@@ -56,7 +56,7 @@ You can configure a relevant mask for a report to specify which part of the repo
 API documentation
 *****************
 
-| Header file: :file:`include/hids.h`
+| Header file: :file:`include/bluetooth/services/hids.h`
 | Source file: :file:`subsys/bluetooth/services/hids.c`
 
 .. doxygengroup:: bt_hids

--- a/doc/nrf/libraries/bluetooth_services/services/lbs.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/lbs.rst
@@ -39,7 +39,7 @@ Write:
 API documentation
 *****************
 
-| Header file: :file:`include/lbs.h`
+| Header file: :file:`include/bluetooth/services/lbs.h`
 | Source file: :file:`subsys/bluetooth/services/lbs.c`
 
 .. doxygengroup:: bt_lbs

--- a/doc/nrf/libraries/bluetooth_services/services/mds.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/mds.rst
@@ -84,7 +84,7 @@ To enable privacy, set the :kconfig:option:`CONFIG_BT_PRIVACY` option.
 API documentation
 *****************
 
-| Header file: :file:`include/mds.h`
+| Header file: :file:`include/bluetooth/services/mds.h`
 | Source file: :file:`subsys/bluetooth/services/mds.c`
 
 .. doxygengroup:: bt_mds

--- a/doc/nrf/libraries/bluetooth_services/services/nsms.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/nsms.rst
@@ -43,7 +43,7 @@ To use this library, enable the :kconfig:option:`CONFIG_BT_NSMS` Kconfig option.
 API documentation
 *****************
 
-| Header file: :file:`include/nsms.h`
+| Header file: :file:`include/bluetooth/services/nsms.h`
 | Source file: :file:`subsys/bluetooth/services/nsms.c`
 
 .. doxygengroup:: bt_nsms

--- a/doc/nrf/libraries/bluetooth_services/services/nus_client.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/nus_client.rst
@@ -29,7 +29,7 @@ Another dedicated callback is triggered when your request has been completed, to
 API documentation
 *****************
 
-| Header file: :file:`include/nus_client.h`
+| Header file: :file:`include/bluetooth/services/nus_client.h`
 | Source file: :file:`subsys/bluetooth/services/nus_client.c`
 
 .. doxygengroup:: bt_nus_client

--- a/doc/nrf/libraries/bluetooth_services/services/throughput.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/throughput.rst
@@ -42,7 +42,7 @@ Read
 API documentation
 *****************
 
-| Header file: :file:`include/throughput.h`
+| Header file: :file:`include/bluetooth/services/throughput.h`
 | Source file: :file:`subsys/bluetooth/services/throughput.c`
 
 .. doxygengroup::  bt_throughput


### PR DESCRIPTION
Corrected the path to the header file in a few
Bluetooth library docs.