### PR TITLE
lib: edge_impulse: Add backup download source

### DIFF
--- a/applications/machine_learning/configuration/nrf52840dk_nrf52840/prj.conf
+++ b/applications/machine_learning/configuration/nrf52840dk_nrf52840/prj.conf
@@ -51,7 +51,7 @@ CONFIG_FP16=n
 
 # Use the NCS machine learning model for simulated acceleration signal
 CONFIG_EDGE_IMPULSE=y
-CONFIG_EDGE_IMPULSE_URI="https://developer.nordicsemi.com/nRF_Connect_SDK/EdgeImpulse/nrf_accel_sim-v35.zip"
+CONFIG_EDGE_IMPULSE_URI="https://developer.nordicsemi.com/nRF_Connect_SDK/EdgeImpulse/nrf_accel_sim-v35.zip; https://buranrgstorageacc.blob.core.windows.net/nrf-connect-sdk-edgeimpulse/nrf_accel_sim-v35.zip"
 CONFIG_EI_WRAPPER=y
 
 ################################################################################

--- a/applications/machine_learning/configuration/nrf52840dk_nrf52840/prj_nus.conf
+++ b/applications/machine_learning/configuration/nrf52840dk_nrf52840/prj_nus.conf
@@ -70,7 +70,7 @@ CONFIG_FP16=n
 
 # Use the NCS machine learning model for simulated acceleration signal
 CONFIG_EDGE_IMPULSE=y
-CONFIG_EDGE_IMPULSE_URI="https://developer.nordicsemi.com/nRF_Connect_SDK/EdgeImpulse/nrf_accel_sim-v35.zip"
+CONFIG_EDGE_IMPULSE_URI="https://developer.nordicsemi.com/nRF_Connect_SDK/EdgeImpulse/nrf_accel_sim-v35.zip; https://buranrgstorageacc.blob.core.windows.net/nrf-connect-sdk-edgeimpulse/nrf_accel_sim-v35.zip"
 CONFIG_EI_WRAPPER=y
 
 ################################################################################

--- a/applications/machine_learning/configuration/nrf52840dk_nrf52840/prj_release.conf
+++ b/applications/machine_learning/configuration/nrf52840dk_nrf52840/prj_release.conf
@@ -49,7 +49,7 @@ CONFIG_FP16=n
 
 # Use the NCS machine learning model for simulated acceleration signal
 CONFIG_EDGE_IMPULSE=y
-CONFIG_EDGE_IMPULSE_URI="https://developer.nordicsemi.com/nRF_Connect_SDK/EdgeImpulse/nrf_accel_sim-v35.zip"
+CONFIG_EDGE_IMPULSE_URI="https://developer.nordicsemi.com/nRF_Connect_SDK/EdgeImpulse/nrf_accel_sim-v35.zip; https://buranrgstorageacc.blob.core.windows.net/nrf-connect-sdk-edgeimpulse/nrf_accel_sim-v35.zip"
 CONFIG_EI_WRAPPER=y
 
 ################################################################################

--- a/applications/machine_learning/configuration/nrf5340dk_nrf5340_cpuapp/prj.conf
+++ b/applications/machine_learning/configuration/nrf5340dk_nrf5340_cpuapp/prj.conf
@@ -69,7 +69,7 @@ CONFIG_FP16=n
 
 # Use the NCS machine learning model for simulated acceleration signal
 CONFIG_EDGE_IMPULSE=y
-CONFIG_EDGE_IMPULSE_URI="https://developer.nordicsemi.com/nRF_Connect_SDK/EdgeImpulse/nrf_accel_sim-v35.zip"
+CONFIG_EDGE_IMPULSE_URI="https://developer.nordicsemi.com/nRF_Connect_SDK/EdgeImpulse/nrf_accel_sim-v35.zip; https://buranrgstorageacc.blob.core.windows.net/nrf-connect-sdk-edgeimpulse/nrf_accel_sim-v35.zip"
 CONFIG_EI_WRAPPER=y
 
 ################################################################################

--- a/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/prj.conf
+++ b/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/prj.conf
@@ -71,7 +71,7 @@ CONFIG_FP16=n
 
 # Use the NCS machine learning model for acceleration readouts coming from HW accelerometer
 CONFIG_EDGE_IMPULSE=y
-CONFIG_EDGE_IMPULSE_URI="https://developer.nordicsemi.com/nRF_Connect_SDK/EdgeImpulse/nrf_accel_hw-v36.zip"
+CONFIG_EDGE_IMPULSE_URI="https://developer.nordicsemi.com/nRF_Connect_SDK/EdgeImpulse/nrf_accel_hw-v36.zip; https://buranrgstorageacc.blob.core.windows.net/nrf-connect-sdk-edgeimpulse/nrf_accel_hw-v36.zip"
 CONFIG_EI_WRAPPER=y
 CONFIG_EI_WRAPPER_DATA_BUF_SIZE=1000
 

--- a/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/prj_release.conf
+++ b/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/prj_release.conf
@@ -66,7 +66,7 @@ CONFIG_FP16=n
 
 # Use the NCS machine learning model for acceleration readouts coming from HW accelerometer
 CONFIG_EDGE_IMPULSE=y
-CONFIG_EDGE_IMPULSE_URI="https://developer.nordicsemi.com/nRF_Connect_SDK/EdgeImpulse/nrf_accel_hw-v36.zip"
+CONFIG_EDGE_IMPULSE_URI="https://developer.nordicsemi.com/nRF_Connect_SDK/EdgeImpulse/nrf_accel_hw-v36.zip; https://buranrgstorageacc.blob.core.windows.net/nrf-connect-sdk-edgeimpulse/nrf_accel_hw-v36.zip"
 CONFIG_EI_WRAPPER=y
 CONFIG_EI_WRAPPER_DATA_BUF_SIZE=1000
 

--- a/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/prj_rtt.conf
+++ b/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/prj_rtt.conf
@@ -73,7 +73,7 @@ CONFIG_FP16=n
 
 # Use the NCS machine learning model for acceleration readouts coming from HW accelerometer
 CONFIG_EDGE_IMPULSE=y
-CONFIG_EDGE_IMPULSE_URI="https://developer.nordicsemi.com/nRF_Connect_SDK/EdgeImpulse/nrf_accel_hw-v36.zip"
+CONFIG_EDGE_IMPULSE_URI="https://developer.nordicsemi.com/nRF_Connect_SDK/EdgeImpulse/nrf_accel_hw-v36.zip; https://buranrgstorageacc.blob.core.windows.net/nrf-connect-sdk-edgeimpulse/nrf_accel_hw-v36.zip"
 CONFIG_EI_WRAPPER=y
 CONFIG_EI_WRAPPER_DATA_BUF_SIZE=1000
 

--- a/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp_ns/prj.conf
+++ b/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp_ns/prj.conf
@@ -71,7 +71,7 @@ CONFIG_FP16=n
 
 # Use the NCS machine learning model for acceleration readouts coming from HW accelerometer
 CONFIG_EDGE_IMPULSE=y
-CONFIG_EDGE_IMPULSE_URI="https://developer.nordicsemi.com/nRF_Connect_SDK/EdgeImpulse/nrf_accel_hw-v36.zip"
+CONFIG_EDGE_IMPULSE_URI="https://developer.nordicsemi.com/nRF_Connect_SDK/EdgeImpulse/nrf_accel_hw-v36.zip; https://buranrgstorageacc.blob.core.windows.net/nrf-connect-sdk-edgeimpulse/nrf_accel_hw-v36.zip"
 CONFIG_EI_WRAPPER=y
 CONFIG_EI_WRAPPER_DATA_BUF_SIZE=1000
 

--- a/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp_ns/prj_release.conf
+++ b/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp_ns/prj_release.conf
@@ -66,7 +66,7 @@ CONFIG_FP16=n
 
 # Use the NCS machine learning model for acceleration readouts coming from HW accelerometer
 CONFIG_EDGE_IMPULSE=y
-CONFIG_EDGE_IMPULSE_URI="https://developer.nordicsemi.com/nRF_Connect_SDK/EdgeImpulse/nrf_accel_hw-v36.zip"
+CONFIG_EDGE_IMPULSE_URI="https://developer.nordicsemi.com/nRF_Connect_SDK/EdgeImpulse/nrf_accel_hw-v36.zip; https://buranrgstorageacc.blob.core.windows.net/nrf-connect-sdk-edgeimpulse/nrf_accel_hw-v36.zip"
 CONFIG_EI_WRAPPER=y
 CONFIG_EI_WRAPPER_DATA_BUF_SIZE=1000
 

--- a/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp_ns/prj_rtt.conf
+++ b/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp_ns/prj_rtt.conf
@@ -73,7 +73,7 @@ CONFIG_FP16=n
 
 # Use the NCS machine learning model for acceleration readouts coming from HW accelerometer
 CONFIG_EDGE_IMPULSE=y
-CONFIG_EDGE_IMPULSE_URI="https://developer.nordicsemi.com/nRF_Connect_SDK/EdgeImpulse/nrf_accel_hw-v36.zip"
+CONFIG_EDGE_IMPULSE_URI="https://developer.nordicsemi.com/nRF_Connect_SDK/EdgeImpulse/nrf_accel_hw-v36.zip; https://buranrgstorageacc.blob.core.windows.net/nrf-connect-sdk-edgeimpulse/nrf_accel_hw-v36.zip"
 CONFIG_EI_WRAPPER=y
 CONFIG_EI_WRAPPER_DATA_BUF_SIZE=1000
 

--- a/lib/edge_impulse/Kconfig
+++ b/lib/edge_impulse/Kconfig
@@ -43,10 +43,12 @@ config EDGE_IMPULSE_URI
 	default ''
 	help
 	  Specify URI used to access archive with Edge Impulse library.
-	  The library will be downloaded into build directory. Make sure
-	  to specify the HTTP API key header as EI_API_KEY_HEADER variable
-	  during build if the HTTP server uses it.
-	  You can also specify absolute file path of a local file.
+	  The library will be downloaded into the build directory. You can specify
+	  more than one URI separated by a semicolon.
+	  Make sure to specify the HTTP API key header as EI_API_KEY_HEADER
+	  variable during build if the HTTP server uses it.
+	  You can also specify the absolute file path of a local file. In that
+	  case, only one URI has to be defined.
 
 endif # EDGE_IMPULSE
 

--- a/samples/edge_impulse/wrapper/prj.conf
+++ b/samples/edge_impulse/wrapper/prj.conf
@@ -19,5 +19,5 @@ CONFIG_FP16=n
 
 # Enable Edge Impulse
 CONFIG_EDGE_IMPULSE=y
-CONFIG_EDGE_IMPULSE_URI="https://developer.nordicsemi.com/nRF_Connect_SDK/EdgeImpulse/nrf_accel_sim-v35.zip"
+CONFIG_EDGE_IMPULSE_URI="https://developer.nordicsemi.com/nRF_Connect_SDK/EdgeImpulse/nrf_accel_sim-v35.zip; https://buranrgstorageacc.blob.core.windows.net/nrf-connect-sdk-edgeimpulse/nrf_accel_sim-v35.zip"
 CONFIG_EI_WRAPPER=y


### PR DESCRIPTION
Add backup download source for Edge Impulse model. If download from the first source fails, an attempt to download from the next source is performed.
This improves stability when building the applications, samples and tests.

Jira: NCSDK-19397.