### PR TITLE
samples: matter: disable Wi-Fi LMP in the case of OTA

### DIFF
--- a/samples/matter/common/src/ota_multi_image_processor_impl.cpp
+++ b/samples/matter/common/src/ota_multi_image_processor_impl.cpp
@@ -19,6 +19,10 @@ CHIP_ERROR OTAMultiImageProcessorImpl::PrepareDownload()
 
 	TriggerFlashAction(ExternalFlashManager::Action::WAKE_UP);
 
+#ifdef CONFIG_WIFI_NRF700X
+	ReturnErrorOnFailure(WiFiManager::Instance().SetLowPowerMode(false));
+#endif /* CONFIG_WIFI_NRF700X */
+
 	return DeviceLayer::SystemLayer().ScheduleLambda(
 		[this] { mDownloader->OnPreparedForDownload(PrepareMultiDownload()); });
 }


### PR DESCRIPTION
... for samples with switchable app variant feature.
This has been already done for all other Wi-Fi based Matter samples.