### PR TITLE
doc: matter: add memory optimization page

### DIFF
--- a/doc/nrf/app_dev/optimizing/memory.rst
+++ b/doc/nrf/app_dev/optimizing/memory.rst
@@ -183,6 +183,8 @@ Besides applying `General recommendations`_, you can also complete the following
 * Reduce the verbosity of assert messages by setting :kconfig:option:`CONFIG_ASSERT_VERBOSE` to ``n``.
 * Check `Thread`_ memory footprint optimization actions, as the Matter application layer uses OpenThread.
 
+Additionally, you can turn off logging for single Matter modules on the Matter SDK side, as described in :ref:`ug_matter_device_optimizing_memory_logs`.
+
 .. _app_memory_nfc:
 
 NFC

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -121,6 +121,8 @@
 .. _`other controller setups`: https://github.com/nrfconnect/sdk-connectedhomeip/tree/9e6386c/src/controller
 .. _`CHIP Certificate Tool source files`: https://github.com/nrfconnect/sdk-connectedhomeip/tree/9e6386c/src/tools
 .. _`Bluetooth LE Arbiter's header file`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/9e6386c/src/platform/Zephyr/BLEAdvertisingArbiter.h
+.. _`LogModule enumeration`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/9e6386c/src/lib/support/logging/Constants.h
+.. _`Matter SDK's Logging header`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/9e6386c/src/lib/support/logging/CHIPLogging.h
 
 .. _`bt_nus_service.cpp`: https://github.com/nrfconnect/sdk-nrf/blob/main/samples/matter/common/src/bt_nus_service.cpp
 .. _`bt_nus_service.h`: https://github.com/nrfconnect/sdk-nrf/blob/main/samples/matter/common/src/bt_nus_service.h

--- a/doc/nrf/protocols/matter/getting_started/index.rst
+++ b/doc/nrf/protocols/matter/getting_started/index.rst
@@ -29,7 +29,8 @@ The pages will guide you through the following getting started process:
 #. In :ref:`ug_matter_device_advanced_kconfigs`, you will learn about more advanced Kconfig options related to Matter.
 #. :ref:`ug_matter_gs_transmission_power` provides information about the default transmission values for different protocols related to Matter and the list of Kconfig options that you can used to modify the transmission power.
 #. Once you have a grasp of the Matter configuration, :ref:`ug_matter_gs_adding_cluster` will teach you step by step how to add clusters to a Matter application created from the template sample.
-#. :ref:`ug_matter_device_adding_bt_services` explains how to add support for additional Bluetooth® LE services in your Matter application.
+#. :ref:`ug_matter_device_adding_bt_services` explains how to add support for additional Bluetooth® Low Energy services in your Matter application.
+#. In :ref:`ug_matter_device_low_power_configuration` and :ref:`ug_matter_device_optimizing_memory`, you can find information about how to optimize your application's resource usage.
 #. Finally, in :ref:`ug_matter_gs_ecosystem_compatibility_testing`, you will set up and test multiple Matter fabrics, each belonging to a different commercial ecosystem, and test their interoperability.
 
 Some of the pages will make reference to external documentation pages available in the |NCS| documentation under the :ref:`matter_index` tab.
@@ -44,8 +45,9 @@ These are built from the files available in the official `Matter GitHub reposito
    tools
    kconfig
    advanced_kconfigs
-   low_power_configuration
    transmission_power
    adding_clusters
    adding_bt_services
+   low_power_configuration
+   memory_optimization
    ecosystem_compatibility_testing

--- a/doc/nrf/protocols/matter/getting_started/memory_optimization.rst
+++ b/doc/nrf/protocols/matter/getting_started/memory_optimization.rst
@@ -1,0 +1,40 @@
+.. _ug_matter_device_optimizing_memory:
+
+Optimizing memory usage in Matter applications
+##############################################
+
+.. contents::
+   :local:
+   :depth: 2
+
+You can use different approaches to optimizing the memory usage of your Matter application, both on the |NCS| side and in the Matter SDK.
+
+Reducing memory usage on the |NCS| side
+***************************************
+
+See the :ref:`app_memory` guide for information about how to reduce memory usage for the |NCS| generally and for specific subsystems in particular, including Bluetooth® LE, Matter, and Thread.
+
+.. _ug_matter_device_optimizing_memory_logs:
+
+Cutting off log regions for Matter SDK modules
+**********************************************
+
+The Matter SDK, included in the |NCS| as one of the submodule repositories using a `dedicated Matter fork`_, provides a custom mechanism for optimizing memory usage in a Matter application.
+This solution defines a series of logging modules, each of which is a logical section of code that is a source of log messages and can include one or more files.
+For the complete list of modules, see the Matter SDK's `LogModule enumeration`_.
+
+You can reduce the memory usage of each of these modules in the following ways:
+
+* Define a custom logging level for each module by setting one of the `Matter SDK logging levels <Matter SDK's Logging header_>`_ (Error, Progress, Detail, or Automation) in :file:`src/chip_project_config.h`,  located in your application's directory.
+  For example, the following snippet shows the Bluetooth LE module set to logging at the `Detail` level:
+
+  .. code-block:: c
+
+     CHIP_CONFIG_LOG_MODULE_Ble_DETAIL 1
+
+* Turn off logging for any of the modules by setting its respective enabler to ``0`` in the Matter SDK's `LogModule enumeration`_.
+  For example, the following snippet shows the Bluetooth LE module cut off from logging its entries:
+
+  .. code-block:: c
+
+     CHIP_CONFIG_LOG_MODULE_Ble 0

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -86,7 +86,7 @@ See `Bluetooth mesh samples`_ for the list of changes in the Bluetooth mesh samp
 Matter
 ------
 
-|no_changes_yet_note|
+* Added a page about :ref:`ug_matter_device_optimizing_memory`.
 
 See `Matter samples`_ for the list of changes for the Matter samples.
 


### PR DESCRIPTION
Added a page about memory optimization for Matter. Added a section about disabling log regions.
KRKNWK-16450.