### PR TITLE
applications: nrf5340_audio: Remove NULL char from broadcast name

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/le_audio_bis_gateway.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_bis_gateway.c
@@ -234,8 +234,8 @@ static int adv_create(void)
 		broadcast_id = CONFIG_BT_AUDIO_BROADCAST_ID_FIXED;
 	}
 
-	ext_ad[0] = (struct bt_data)BT_DATA_BYTES(BT_DATA_BROADCAST_NAME,
-						  CONFIG_BT_AUDIO_BROADCAST_NAME);
+	ext_ad[0] = (struct bt_data)BT_DATA(BT_DATA_BROADCAST_NAME, CONFIG_BT_AUDIO_BROADCAST_NAME,
+					    sizeof(CONFIG_BT_AUDIO_BROADCAST_NAME) - 1);
 
 	/* Setup extended advertising data */
 	net_buf_simple_add_le16(&ad_buf, BT_UUID_BROADCAST_AUDIO_VAL);


### PR DESCRIPTION
Removes the NULL character from the end of the broadcast name string before including it in the advertising data. As the string is defined from a macro it will always be null terminated so no checks are needed.