### PR TITLE
treewide: rename nrf7002ek_nrf7002 to nrf7002ek

### DIFF
--- a/applications/asset_tracker_v2/doc/location_module.rst
+++ b/applications/asset_tracker_v2/doc/location_module.rst
@@ -71,12 +71,12 @@ To enable Wi-Fi positioning and especially nRF7002 functionality, use a
 special DTC overlay with the compiler option ``-DDTC_OVERLAY_FILE=nrf9160dk_with_nrf7002ek.overlay`` and a
 configuration overlay ``-DOVERLAY_CONFIG=overlay-nrf7002ek-wifi-scan-only.conf``.
 
-To build for the nRF9160 DK with nRF7002 EK, use the ``nrf9160dk_nrf9160_ns`` build target with the ``SHIELD`` CMake option set to ``nrf7002ek_nrf7002`` and a scan-only overlay configuration.
+To build for the nRF9160 DK with nRF7002 EK, use the ``nrf9160dk_nrf9160_ns`` build target with the ``SHIELD`` CMake option set to ``nrf7002ek`` and a scan-only overlay configuration.
 The following is an example of the CLI command:
 
 .. code-block:: console
 
-   west build -p -b nrf9160dk_nrf9160ns -- -DSHIELD=nrf7002ek_nrf7002 -DDTC_OVERLAY_FILE=nrf9160dk_with_nrf7002ek.overlay -DOVERLAY_CONFIG=overlay-nrf7002ek-wifi-scan-only.conf
+   west build -p -b nrf9160dk_nrf9160_ns -- -DSHIELD=nrf7002ek -DDTC_OVERLAY_FILE=nrf9160dk_with_nrf7002ek.overlay -DOVERLAY_CONFIG=overlay-nrf7002ek-wifi-scan-only.conf
 
 Wi-Fi positioning has the following limitations:
 

--- a/applications/asset_tracker_v2/nrf91xxdk_with_nrf7002ek.overlay
+++ b/applications/asset_tracker_v2/nrf91xxdk_with_nrf7002ek.overlay
@@ -13,7 +13,7 @@
 };
 
 /* Disabled because of conflicts on P0.00 and P0.01 - Arduino pins D0 and D1
- * (iovdd-ctrl-gpios and bucken-gpios in nrf7002ek_nrf7002, respectively). */
+ * (iovdd-ctrl-gpios and bucken-gpios in nrf7002ek, respectively). */
 &uart1 {
 	status = "disabled";
 };

--- a/doc/nrf/protocols/matter/getting_started/hw_requirements.rst
+++ b/doc/nrf/protocols/matter/getting_started/hw_requirements.rst
@@ -16,7 +16,7 @@ Supported SoCs
 
 Currently the following SoCs from Nordic Semiconductor are supported for use with the Matter protocol:
 
-* :ref:`nRF5340 <gs_programming_board_names>` (Matter over Thread and Matter over Wi-Fi through the ``nrf7002ek_nrf7002`` shield)
+* :ref:`nRF5340 <gs_programming_board_names>` (Matter over Thread and Matter over Wi-Fi through the ``nrf7002ek`` shield)
 * :ref:`nRF5340 + nRF7002 <gs_programming_board_names>` (Matter over Thread and Matter over Wi-Fi)
 * :ref:`nRF52840 <gs_programming_board_names>` (Matter over Thread)
 

--- a/doc/nrf/protocols/matter/overview/integration.rst
+++ b/doc/nrf/protocols/matter/overview/integration.rst
@@ -88,7 +88,7 @@ This platform design is suitable for the following development kits:
 
 For this design, the Wi-Fi driver on the application core communicates with the external nRF7002 Wi-Fi 6 Companion IC over QSPI or SPI:
 
-* For the ``nrf5340dk_nrf5340_cpuapp``, nRF7002 support is added using ``nrf7002ek_nrf7002`` shield connected through SPI.
+* For the ``nrf5340dk_nrf5340_cpuapp``, nRF7002 support is added using ``nrf7002ek`` shield connected through SPI.
 * For the ``nrf7002dk_nrf5340_cpuapp``, nRF7002 is connected with the nRF5340 SoC through QSPI.
 
 .. figure:: images/matter_platform_design_nRF53_wifi.svg
@@ -115,7 +115,7 @@ This platform design is suitable for the following development kits:
    :header: heading
    :rows: nrf5340dk_nrf5340_cpuapp
 
-This design is only available for the ``nrf5340dk_nrf5340_cpuapp`` with the ``nrf7002ek_nrf7002`` shield.
+This design is only available for the ``nrf5340dk_nrf5340_cpuapp`` with the ``nrf7002ek`` shield.
 The Wi-Fi driver on the application core communicates through SPI with the external nRF7002 EK shield, which works as the Wi-Fi 6 Companion IC.
 
 .. figure:: images/matter_platform_design_nRF53_wifi_switching.svg

--- a/samples/nrf9160/location/README.rst
+++ b/samples/nrf9160/location/README.rst
@@ -75,7 +75,7 @@ For example:
 
 .. code-block:: console
 
-   west build -p -b nrf9160dk_nrf9160ns -- -DSHIELD=nrf7002ek -DDTC_OVERLAY_FILE=nrf9160dk_with_nrf7002ek.overlay -DOVERLAY_CONFIG=overlay-nrf7002ek-wifi-scan-only.conf
+   west build -p -b nrf9160dk_nrf9160_ns -- -DSHIELD=nrf7002ek -DDTC_OVERLAY_FILE=nrf9160dk_with_nrf7002ek.overlay -DOVERLAY_CONFIG=overlay-nrf7002ek-wifi-scan-only.conf
 
 See :ref:`cmake_options` for more instructions on how to add these options.
 

--- a/samples/nrf9160/location/nrf9160dk_with_nrf7002ek.overlay
+++ b/samples/nrf9160/location/nrf9160dk_with_nrf7002ek.overlay
@@ -13,7 +13,7 @@
 };
 
 /* Disabled because of conflicts on P0.00 and P0.01 - Arduino pins D0 and D1
- * (iovdd-ctrl-gpios and bucken-gpios in nrf7002ek_nrf7002, respectively). */
+ * (iovdd-ctrl-gpios and bucken-gpios in nrf7002ek, respectively). */
 &uart1 {
 	status = "disabled";
 };

--- a/samples/nrf9160/lwm2m_client/boards/nrf9160dk_with_nrf7002ek.overlay
+++ b/samples/nrf9160/lwm2m_client/boards/nrf9160dk_with_nrf7002ek.overlay
@@ -13,7 +13,7 @@
 };
 
 /* Disabled because of conflicts on P0.00 and P0.01 - Arduino pins D0 and D1
- * (iovdd-ctrl-gpios and bucken-gpios in nrf7002ek_nrf7002, respectively). */
+ * (iovdd-ctrl-gpios and bucken-gpios in nrf7002ek, respectively). */
 &uart1 {
 	status = "disabled";
 };

--- a/samples/nrf9160/modem_shell/nrf9160dk_with_nrf7002ek.overlay
+++ b/samples/nrf9160/modem_shell/nrf9160dk_with_nrf7002ek.overlay
@@ -13,7 +13,7 @@
 };
 
 /* Disabled because of conflicts on P0.00 and P0.01 - Arduino pins D0 and D1
- * (iovdd-ctrl-gpios and bucken-gpios in nrf7002ek_nrf7002, respectively). */
+ * (iovdd-ctrl-gpios and bucken-gpios in nrf7002ek, respectively). */
 &uart1 {
 	status = "disabled";
 };

--- a/samples/nrf9160/nrf_cloud_mqtt_multi_service/nrf9160dk_with_nrf7002ek.overlay
+++ b/samples/nrf9160/nrf_cloud_mqtt_multi_service/nrf9160dk_with_nrf7002ek.overlay
@@ -13,7 +13,7 @@
 };
 
 /* Disabled because of conflicts on P0.00 and P0.01 - Arduino pins D0 and D1
- * (iovdd-ctrl-gpios and bucken-gpios in nrf7002ek_nrf7002, respectively). */
+ * (iovdd-ctrl-gpios and bucken-gpios in nrf7002ek, respectively). */
 &uart1 {
 	status = "disabled";
 };

--- a/samples/wifi/shell/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/wifi/shell/boards/nrf52840dk_nrf52840.overlay
@@ -5,13 +5,13 @@
  */
 
 /* Disabled because of a conflict on P1.08 - Arduino pin D7 (host-irq-gpios
- * in nrf7002ek_nrf7002). */
+ * in nrf7002ek). */
 &spi1 {
 	status = "disabled";
 };
 
 /* Disabled because of conflicts on P1.01 and P1.02 - Arduino pins D0 and D1
- * (iovdd-ctrl-gpios and bucken-gpios in nrf7002ek_nrf7002, respectively). */
+ * (iovdd-ctrl-gpios and bucken-gpios in nrf7002ek, respectively). */
 &uart1 {
 	status = "disabled";
 };

--- a/samples/wifi/shell/boards/nrf9160dk_nrf9160_ns.overlay
+++ b/samples/wifi/shell/boards/nrf9160dk_nrf9160_ns.overlay
@@ -13,7 +13,7 @@
 };
 
 /* Disabled because of conflicts on P0.00 and P0.01 - Arduino pins D0 and D1
- * (iovdd-ctrl-gpios and bucken-gpios in nrf7002ek_nrf7002, respectively). */
+ * (iovdd-ctrl-gpios and bucken-gpios in nrf7002ek, respectively). */
 &uart1 {
 	status = "disabled";
 };


### PR DESCRIPTION
This patch fixes build commands in the docs that referred to a non-existent shield name.
