### PR TITLE
modules/mcuboot: Add support for mcuboot image encryption.

### DIFF
--- a/cmake/multi_image.cmake
+++ b/cmake/multi_image.cmake
@@ -19,6 +19,11 @@ if(IMAGE_NAME)
   if(CONFIG_BOOT_SIGNATURE_KEY_FILE)
     set_shared(IMAGE ${IMAGE_NAME} PROPERTY SIGNATURE_KEY_FILE ${CONFIG_BOOT_SIGNATURE_KEY_FILE})
   endif()
+  # Share the encryption key file so that the parent image can use it to
+  # generate encrypted update candidates.
+  if(CONFIG_BOOT_ENCRYPTION_KEY_FILE)
+    set_shared(IMAGE ${IMAGE_NAME} PROPERTY ENCRYPTION_KEY_FILE ${CONFIG_BOOT_ENCRYPTION_KEY_FILE})
+  endif()
 
   generate_shared(IMAGE ${IMAGE_NAME} FILE ${CMAKE_BINARY_DIR}/shared_vars.cmake)
 else()

--- a/modules/mcuboot/CMakeLists.txt
+++ b/modules/mcuboot/CMakeLists.txt
@@ -159,6 +159,7 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
       COMMAND
       # Sign the binary version of the input hex file.
       ${sign_cmd}
+      ${encrypt_cmd}
       ${sign_dependencies}
       ${SIGN_ARG_ROM_FIXED}
       --slot-size ${SIGN_ARG_SLOT_SIZE}
@@ -304,6 +305,34 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
     endif()
   endif()
 
+   if (NOT DEFINED CONFIG_BOOT_ENCRYPTION_KEY_FILE)
+     get_shared(mcuboot_enc_key IMAGE mcuboot PROPERTY ENCRYPTION_KEY_FILE)
+     set(CONFIG_BOOT_ENCRYPTION_KEY_FILE ${mcuboot_enc_key})
+   endif ()
+
+   foreach (filepath ${mcuboot_CONF_FILE})
+     file(STRINGS ${filepath} mcuboot_CONFIG_BOOT_ENCRYPTION_KEY_FILE
+          REGEX "^CONFIG_BOOT_ENCRYPTION_KEY_FILE=")
+     if (mcuboot_CONFIG_BOOT_ENCRYPTION_KEY_FILE)
+       get_filename_component(mcuboot_CONF_DIR ${filepath} DIRECTORY)
+     endif()
+   endforeach()
+
+   if(IS_ABSOLUTE ${CONFIG_BOOT_ENCRYPTION_KEY_FILE})
+     set(mcuboot_enc_key_file ${CONFIG_BOOT_ENCRYPTION_KEY_FILE})
+   elseif (DEFINED mcuboot_CONF_DIR)
+     if (EXISTS ${mcuboot_CONF_DIR}/${CONFIG_BOOT_ENCRYPTION_KEY_FILE})
+       set(mcuboot_enc_key_file ${mcuboot_CONF_DIR}/${CONFIG_BOOT_ENCRYPTION_KEY_FILE})
+     endif()
+   endif()
+
+  if(CONFIG_MCUBOOT_ENCRYPT_IMAGES)
+    # Set key from MCUBoot source directory
+    if (NOT DEFINED mcuboot_enc_key_file)
+	set(mcuboot_enc_key_file ${ZEPHYR_MCUBOOT_MODULE_DIR}/${CONFIG_BOOT_ENCRYPTION_KEY_FILE})
+    endif()
+  endif()
+
   if(CONFIG_SIGN_IMAGES)
     # Set default key
     if (NOT DEFINED mcuboot_key_file)
@@ -346,6 +375,12 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
     else()
       set(imgtool_extra)
     endif()
+
+     if(CONFIG_MCUBOOT_ENCRYPT_IMAGES)
+       set(encrypt_cmd --encrypt ${mcuboot_enc_key_file})
+     else()
+       set(encrypt_cmd)
+     endif()
 
     set(sign_cmd
       ${PYTHON_EXECUTABLE}

--- a/modules/mcuboot/Kconfig
+++ b/modules/mcuboot/Kconfig
@@ -21,6 +21,23 @@ config SIGN_IMAGES
 	  Sign images for MCUBoot as integrated part of the build stages using
 	  the private key.
 
+config BOOT_ENCRYPTION_KEY_FILE
+	string "MCUBoot encryption private PEM key file"
+	depends on !MCUBOOT_BUILD_STRATEGY_FROM_SOURCE
+	help
+	  Absolute path to PEM key file containing the private key.
+	  The file contains the public key that is used to encrypt the
+          ephemeral key that encrypts the image. The corresponding
+          private key is hard coded in the MCUboot source code and is
+          used to decrypt the ephemeral key that is embedded in the
+          image.
+
+config MCUBOOT_ENCRYPT_IMAGES
+	bool "Encrypt images for MCUBoot"
+	depends on SIGN_IMAGES
+	help
+	  Encrypt update image for MCUBoot as integrated part of the build stage.
+
 if BOOTLOADER_MCUBOOT
 
 config BOOT_BUILD_DIRECT_XIP_VARIANT


### PR DESCRIPTION
1. add BOOT_ENCRYPTION_KEY_FILE and MCUBOOT_ENCRYPT_IMAGES config.
1. add config for encryption key to get the file name of private key which is going to used in the imgtool --encrypt option.
2. add encryption option for app_update.bin