### PR TITLE
compliance: Add ZEPHYR_NRF_MODULE_DIR env var for running compliance

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -71,6 +71,7 @@ jobs:
       if: contains(github.event.pull_request.user.login, 'dependabot[bot]') != true
       run: |
         export ZEPHYR_BASE="$(dirname "$(pwd)")/zephyr"
+        export ZEPHYR_NRF_MODULE_DIR="$(dirname "$(pwd)")/nrf"
         # debug
         ls -la
         git log --pretty=oneline | head -n 10


### PR DESCRIPTION
Add ZEPHYR_NRF_MODULE_DIR env var for running compliance.

ZEPHYR_NRF_MODULE_DIR will be used by nrfxlib/Kconfig.nrfxlib, but in
general, any Kconfig source file could refer to any module dir.

kconfig.cmake exports each ZEPHYR_*_MODULE_DIR to Kconfig, but
checkcompliance does not so we add this env var to align with how the
build system invokes Kconfig.

I don't know how to add all MODULES in a clean way so we just add the
one we (will soon) need.
