### PR TITLE
lib: nrf_modem: NRF_MODEM_LIB_ON_INIT only allow pre-link operations

### DIFF
--- a/doc/nrf/libraries/modem/nrf_modem_lib.rst
+++ b/doc/nrf/libraries/modem/nrf_modem_lib.rst
@@ -38,6 +38,13 @@ These compile-time callbacks allow any part of the application to perform any se
 Furthermore, the callbacks ensure that the setup steps are repeated whenever another part of the application turns the modem on or off.
 The callbacks registered using :c:macro:`NRF_MODEM_LIB_ON_INIT` are executed after the library is initialized.
 The result of the initialization and the callback context are provided to these callbacks.
+
+.. note::
+  The callback can be used to perform modem and library configurations that require the modem to be turned on in offline mode.
+  The callback cannot be used to change the modem's functional mode.
+  Calls to :c:func:`lte_lc_connect` and ``CFUN`` AT calls are not allowed, and must be done after :c:func:`nrf_modem_lib_init` has returned.
+  If a library needs to perform operations after the link is up, it can use the :ref:`lte_lc_readme` and subscribe to a :c:macro:`LTE_LC_ON_CFUN` callback.
+
 Callbacks for the macro :c:macro:`NRF_MODEM_LIB_ON_INIT` must have the signature ``void callback_name(int ret, void *ctx)``, where ``ret`` is the result of the initialization and ``ctx`` is the context passed to the macro.
 The callbacks registered using :c:macro:`NRF_MODEM_LIB_ON_SHUTDOWN` are executed before the library is shut down.
 The callback context is provided to these callbacks.

--- a/include/modem/nrf_modem_lib.h
+++ b/include/modem/nrf_modem_lib.h
@@ -99,6 +99,13 @@ struct nrf_modem_lib_shutdown_cb {
  *
  * The callback function @p _callback is invoked after the library has been initialized.
  *
+ * @note The @c NRF_MODEM_LIB_ON_INIT callback can be used to perform modem and library
+ * configurations that require the modem to be turned on in offline mode. It cannot be used to
+ * change the modem functional mode. Calls to @c lte_lc_connect and CFUN AT calls are not
+ * allowed, and must be done after @c nrf_modem_lib_init has returned. If a library needs to
+ * perform operations after the link is up, it can use the link controller and subscribe to a
+ * @c LTE_LC_ON_CFUN callback.
+ *
  * @param name Callback name
  * @param _callback Callback function name
  * @param _context User-defined context for the callback


### PR DESCRIPTION
Turning on the modem and attaching to the network are two different operations. CFUN can take an unpredictable amount of time, which we cannot allow in modem lib init hooks. Also, the hooks may require the modem to be in offline modem when performing its operations.