### PR TITLE
download_client: Allow use of DTLS CID 

### DIFF
--- a/doc/nrf/libraries/networking/download_client.rst
+++ b/doc/nrf/libraries/networking/download_client.rst
@@ -58,6 +58,8 @@ Make sure to configure the :kconfig:option:`CONFIG_DOWNLOAD_CLIENT_BUF_SIZE` and
 
 The application must provision the TLS credentials and pass the security tag to the library when using CoAPS and calling :c:func:`download_client_connect`.
 
+When modem firmware v1.3.5 or newer is used, you can enable the support for DTLS Connection Identifier feature in the download client library by enabling :kconfig:option:`CONFIG_DOWNLOAD_CLIENT_CID` Kconfig option.
+
 Limitations
 ***********
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -379,6 +379,10 @@ Libraries for networking
 
   * Added explanation of text versus dictionary logs.
 
+* :ref:`lib_download_client` library:
+
+  * Added support for DTLS Connection Identifier feature.
+
 * :ref:`lib_nrf_cloud` library:
 
   * Added:

--- a/subsys/net/lib/download_client/Kconfig
+++ b/subsys/net/lib/download_client/Kconfig
@@ -141,6 +141,12 @@ config DOWNLOAD_CLIENT_IPV6
 	  Prefer IPv6 protocol but fallback to
 	  IPv4 when the hostname can't be resolved.
 
+config DOWNLOAD_CLIENT_CID
+	bool "Use DTLS Connection-ID"
+	help
+	  Use DTLS Connection-ID option when downloading from CoAPS resources.
+	  This requires modem firmware 1.3.5 or newer.
+
 config DOWNLOAD_CLIENT_SHELL
 	bool "Enable shell"
 	depends on SHELL

--- a/subsys/net/lib/download_client/src/coap.c
+++ b/subsys/net/lib/download_client/src/coap.c
@@ -47,6 +47,7 @@ int coap_block_init(struct download_client *client, size_t from)
 	coap_block_transfer_init(&client->coap.block_ctx,
 				 CONFIG_DOWNLOAD_CLIENT_COAP_BLOCK_SIZE, 0);
 	client->coap.block_ctx.current = from;
+	coap_pending_clear(&client->coap.pending);
 	return 0;
 }
 

--- a/subsys/net/lib/download_client/src/download_client.c
+++ b/subsys/net/lib/download_client/src/download_client.c
@@ -17,6 +17,7 @@
 #else
 #include <zephyr/net/socket.h>
 #endif
+#include <zephyr/net/socket_ncs.h>
 #include <zephyr/net/tls_credentials.h>
 #include <net/download_client.h>
 #include <zephyr/logging/log.h>
@@ -387,6 +388,19 @@ static int client_connect(struct download_client *dl)
 			err = socket_tls_hostname_set(dl->fd, dl->host);
 			if (err) {
 				goto cleanup;
+			}
+		}
+
+		if (dl->proto == IPPROTO_DTLS_1_2 && IS_ENABLED(CONFIG_DOWNLOAD_CLIENT_CID)) {
+			/* Enable connection ID */
+			uint32_t dtls_cid = TLS_DTLS_CID_ENABLED;
+
+			err = zsock_setsockopt(dl->fd, SOL_TLS, TLS_DTLS_CID, &dtls_cid,
+					       sizeof(dtls_cid));
+			if (err) {
+				err = -errno;
+				LOG_ERR("Failed to enable TLS_DTLS_CID: %d", err);
+				/* Not fatal, so continue */
 			}
 		}
 	}


### PR DESCRIPTION
Few changes to the download client:

* When connecting to DTLS service, enable Connection-ID. Controlled by Kconfig.
* Refactor to use Zephyr socket API instead of POSIX socket API. This is easier regarding headers.
* Clear CoAP timeout values on start of transmission.

