### PR TITLE
scripts: quarantine: add tests with old Ztest API

### DIFF
--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -108,3 +108,29 @@
   platforms:
     - thingy53_nrf5340_cpuapp
   comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - fast_pair.crypto.*
+  platforms:
+    - all
+  comment: "Excluded due to the old Ztest API - issue: NCSDK-20431"
+
+- scenarios:
+    - fast_pair.storage.account_key_storage.*
+    - fast_pair.storage.factory_reset.*
+  platforms:
+    - all
+  comment: "Excluded due to the old Ztest API  - issue: NCSDK-21698"
+
+- scenarios:
+    - nrf_profiler.core
+  platforms:
+    - all
+  comment: "Excluded due to the old Ztest API  - issue: NCSDK-21696"
+
+- scenarios:
+    - zigbee.osif.*
+    - zigbee.zboss_api.*
+  platforms:
+    - all
+  comment: "Excluded due to the old Ztest API  - issue: KRKNWK-16665"


### PR DESCRIPTION
Since Zephyr 3.4 old Ztest API is deprecated and all tests with old API fail during building by Twister. They should be moved to quarantine until they will be rewritten to new Ztest API.

Tracking issues:
 - `tests/subsys/bluetooth/fast_pair/crypto` - NCSDK-20431
 - `tests/subsys/bluetooth/fast_pair/storage` - NCSDK-21698
 - `tests/subsys/nrf_profiler` - NCSDK-21696
 - `tests/subsys/zigbee` - KRKNWK-16665