### PR TITLE
applications: asset_tracker_v2: make json_common test portable

### DIFF
--- a/applications/asset_tracker_v2/tests/json_common/CMakeLists.txt
+++ b/applications/asset_tracker_v2/tests/json_common/CMakeLists.txt
@@ -9,6 +9,8 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(json_common_test)
 
+set(ASSET_TRACKER_V2_DIR ../..)
+
 test_runner_generate(src/main.c)
 
 FILE(GLOB app_sources src/*.c)
@@ -16,13 +18,13 @@ target_sources(app PRIVATE ${app_sources})
 
 target_include_directories(app PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}/src
-	${CMAKE_CURRENT_SOURCE_DIR}/../../src/cloud/cloud_codec/
-	${CMAKE_CURRENT_SOURCE_DIR}/../../../../../nrfxlib/nrf_modem/include/)
+	${ASSET_TRACKER_V2_DIR}/src/cloud/cloud_codec/
+	${NRF_DIR}/../nrfxlib/nrf_modem/include/)
 
 target_sources(app PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}/mock/date_time_mock.c
-	${CMAKE_CURRENT_SOURCE_DIR}/../../src/cloud/cloud_codec/json_common.c
-	${CMAKE_CURRENT_SOURCE_DIR}/../../src/cloud/cloud_codec/json_helpers.c)
+	${ASSET_TRACKER_V2_DIR}/src/cloud/cloud_codec/json_common.c
+	${ASSET_TRACKER_V2_DIR}/src/cloud/cloud_codec/json_helpers.c)
 
 target_compile_options(app PRIVATE
 	-DCONFIG_ASSET_TRACKER_V2_APP_VERSION_MAX_LEN=20


### PR DESCRIPTION
This patch fixes the issue of the json_common tests failing when moving the asset_tracker_v2 to a different location.