### PR TITLE
drivers: wifi: Use signal field from RX events

### DIFF
--- a/drivers/wifi/nrf700x/Kconfig.nrf700x
+++ b/drivers/wifi/nrf700x/Kconfig.nrf700x
@@ -261,4 +261,21 @@ config WIFI_FIXED_MAC_ADDRESS
 	string "WiFi Fixed MAC address in format XX:XX:XX:XX:XX:XX"
 	help
 		This overrides the MAC address read from OTP. Strictly for testing purposes only.
+
+config NRF700X_RSSI_STALE_TIMEOUT_MS
+	int "RSSI stale timeout in milliseconds"
+	default 1000
+	help
+	  RSSI stale timeout is the period after which driver querries
+	  RPU to get the RSSI the value.
+	  If data is active (e.g. ping), driver stores the RSSI value from
+	  the received frames and provides this stored information
+	  to wpa_supplicant. In this case a higher value will be suitable
+	  as stored RSSI value at driver will be updated regularly.
+	  If data is not active or after the stale timeout duration,
+	  driver queries the RPU to get the RSSI value
+	  and provides it to wpa_suuplicant. The value should be set to lower
+	  value as driver does not store it and requires RPU to provide the
+	  info.
+
 endif

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/default/fmac_structs.h
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/default/fmac_structs.h
@@ -245,6 +245,10 @@ struct wifi_nrf_fmac_callbk_fns {
 					  unsigned short frequency,
 					  signed short signal);
 #endif /* CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS */
+
+	/** Callback function to be called when to process rssi of the received frame. */
+	void (*process_rssi_from_rx)(void *os_vif_ctx,
+				     signed short signal);
 };
 
 /**

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/rx.c
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/rx.c
@@ -215,6 +215,8 @@ enum wifi_nrf_status wifi_nrf_fmac_rx_event_process(struct wifi_nrf_fmac_dev_ctx
 
 	vif_ctx = fmac_dev_ctx->vif_ctx[config->wdev_id];
 
+	fmac_dev_ctx->fpriv->callbk_fns.process_rssi_from_rx(vif_ctx->os_vif_ctx,
+							     config->signal);
 	num_pkts = config->rx_pkt_cnt;
 
 	for (i = 0; i < num_pkts; i++) {

--- a/drivers/wifi/nrf700x/osal/utils/inc/util.h
+++ b/drivers/wifi/nrf700x/osal/utils/inc/util.h
@@ -16,6 +16,9 @@
 #include <stdbool.h>
 #include "osal_api.h"
 
+/* Convert power from mBm to dBm */
+#define MBM_TO_DBM(gain) ((gain) / 100)
+
 int nrf_wifi_utils_hex_str_to_val(struct wifi_nrf_osal_priv *opriv,
 				  unsigned char *hex_arr,
 				  unsigned int hex_arr_sz,

--- a/drivers/wifi/nrf700x/zephyr/inc/zephyr_fmac_main.h
+++ b/drivers/wifi/nrf700x/zephyr/inc/zephyr_fmac_main.h
@@ -80,6 +80,8 @@ struct wifi_nrf_vif_ctx_zep {
 	bool cookie_resp_received;
 	bool twt_in_progress;
 	struct k_work wifi_nrf_net_iface_work;
+	unsigned long rssi_record_timestamp_us;
+	signed short rssi;
 };
 
 struct wifi_nrf_vif_ctx_map {

--- a/drivers/wifi/nrf700x/zephyr/inc/zephyr_wifi_mgmt.h
+++ b/drivers/wifi/nrf700x/zephyr/inc/zephyr_wifi_mgmt.h
@@ -63,4 +63,6 @@ void wifi_nrf_rx_bcn_prb_resp_frm(void *vif_ctx,
 				  unsigned short frequency,
 				  signed short signal);
 #endif /* CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS */
+void wifi_nrf_process_rssi_from_rx(void *vif_ctx,
+				   signed short signal);
 #endif /*  __ZEPHYR_DISP_SCAN_H__ */

--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_fmac_main.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_fmac_main.c
@@ -443,6 +443,7 @@ static int wifi_nrf_drv_main_zep(const struct device *dev)
 #ifdef CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS
 	callbk_fns.rx_bcn_prb_resp_callbk_fn = wifi_nrf_rx_bcn_prb_resp_frm;
 #endif /* CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS */
+	callbk_fns.process_rssi_from_rx = wifi_nrf_process_rssi_from_rx;
 #ifdef CONFIG_WPA_SUPP
 	callbk_fns.scan_res_callbk_fn = wifi_nrf_wpa_supp_event_proc_scan_res;
 	callbk_fns.auth_resp_callbk_fn = wifi_nrf_wpa_supp_event_proc_auth_resp;

--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_wifi_mgmt.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_wifi_mgmt.c
@@ -14,6 +14,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 
+#include "util.h"
 #include "fmac_api.h"
 #include "fmac_tx.h"
 #include "zephyr_fmac_main.h"
@@ -900,8 +901,7 @@ void wifi_nrf_rx_bcn_prb_resp_frm(void *vif_ctx,
 				      frame_length);
 	}
 
-#define MBM_TO_DBM 100
-	bcn_prb_resp_info.rssi = (val / MBM_TO_DBM); /* mBm to dBm */
+	bcn_prb_resp_info.rssi = MBM_TO_DBM(val);
 	bcn_prb_resp_info.frequency = frequency;
 	bcn_prb_resp_info.frame_length = frame_length;
 
@@ -910,3 +910,31 @@ void wifi_nrf_rx_bcn_prb_resp_frm(void *vif_ctx,
 
 }
 #endif /* CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS */
+
+void wifi_nrf_process_rssi_from_rx(void *vif_ctx,
+				   signed short signal)
+{
+	struct wifi_nrf_vif_ctx_zep *vif_ctx_zep = vif_ctx;
+	struct wifi_nrf_ctx_zep *rpu_ctx_zep = NULL;
+	struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx = NULL;
+
+	vif_ctx_zep = vif_ctx;
+
+	if (!vif_ctx_zep) {
+		LOG_ERR("%s: vif_ctx_zep is NULL\n", __func__);
+		return;
+	}
+
+	rpu_ctx_zep = vif_ctx_zep->rpu_ctx_zep;
+
+	if (!rpu_ctx_zep) {
+		LOG_ERR("%s: rpu_ctx_zep is NULL\n", __func__);
+		return;
+	}
+
+	fmac_dev_ctx = rpu_ctx_zep->rpu_ctx;
+
+	vif_ctx_zep->rssi = MBM_TO_DBM(signal);
+	vif_ctx_zep->rssi_record_timestamp_us =
+		wifi_nrf_osal_time_get_curr_us(fmac_dev_ctx->fpriv->opriv);
+}

--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_wpa_supp_if.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_wpa_supp_if.c
@@ -998,6 +998,7 @@ int wifi_nrf_wpa_supp_signal_poll(void *if_priv, struct wpa_signal_info *si, uns
 	struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx = NULL;
 	enum wifi_nrf_status ret = WIFI_NRF_STATUS_FAIL;
 	int sem_ret;
+	int rssi_record_elapsed_time_ms = 0;
 
 	if (!if_priv || !si || !bssid) {
 		LOG_ERR("%s: Invalid params\n", __func__);
@@ -1009,17 +1010,25 @@ int wifi_nrf_wpa_supp_signal_poll(void *if_priv, struct wpa_signal_info *si, uns
 	fmac_dev_ctx = rpu_ctx_zep->rpu_ctx;
 
 	vif_ctx_zep->signal_info = si;
-	ret = wifi_nrf_fmac_get_station(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx, bssid);
-	if (ret != WIFI_NRF_STATUS_SUCCESS) {
-		LOG_ERR("%s: Failed to get station info\n", __func__);
-		goto out;
-	}
 
-	sem_ret = k_sem_take(&wait_for_event_sem, K_MSEC(RPU_RESP_EVENT_TIMEOUT));
-	if (sem_ret) {
-		LOG_ERR("%s: Failed to get station info, ret = %d\n", __func__, sem_ret);
-		ret = WIFI_NRF_STATUS_FAIL;
-		goto out;
+	rssi_record_elapsed_time_ms = wifi_nrf_osal_time_elapsed_us(fmac_dev_ctx->fpriv->opriv,
+						    vif_ctx_zep->rssi_record_timestamp_us) / 1000;
+
+	if (rssi_record_elapsed_time_ms > CONFIG_NRF700X_RSSI_STALE_TIMEOUT_MS) {
+		ret = wifi_nrf_fmac_get_station(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx, bssid);
+		if (ret != WIFI_NRF_STATUS_SUCCESS) {
+			LOG_ERR("%s: Failed to send get station info command\n", __func__);
+			goto out;
+		}
+
+		sem_ret = k_sem_take(&wait_for_event_sem, K_MSEC(RPU_RESP_EVENT_TIMEOUT));
+		if (sem_ret) {
+			LOG_ERR("%s: Failed to get station info, ret = %d\n", __func__, sem_ret);
+			ret = WIFI_NRF_STATUS_FAIL;
+			goto out;
+		}
+	} else {
+		si->current_signal = (int)vif_ctx_zep->rssi;
 	}
 
 	ret = wifi_nrf_fmac_get_interface(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx);

--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_wpa_supp_if.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_wpa_supp_if.c
@@ -1033,7 +1033,7 @@ int wifi_nrf_wpa_supp_signal_poll(void *if_priv, struct wpa_signal_info *si, uns
 
 	ret = wifi_nrf_fmac_get_interface(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx);
 	if (ret != WIFI_NRF_STATUS_SUCCESS) {
-		LOG_ERR("%s: Failed to get interface info\n", __func__);
+		LOG_ERR("%s: Failed to send get interface info command\n", __func__);
 		goto out;
 	}
 


### PR DESCRIPTION
For RSSI queries RPU only if no data is active.
If data is active maintains average signal strength and then provides it to WPA supplicant.