### PR TITLE
script: keygen.py: Change from `ecdsa` to `cryptography`

### DIFF
--- a/scripts/requirements-build.txt
+++ b/scripts/requirements-build.txt
@@ -1,6 +1,7 @@
 cbor2>=5.4.2.post1
 clang-format
 ecdsa
+cryptography
 imagesize>=1.2.0
 intelhex
 protobuf


### PR DESCRIPTION
Changes the library used by `kegen.py` from `ecdsa` to `cryptography. The reason for this change is `ecdsa` statement about itself:

"This library was not designed with security in mind. If you are processing data that needs to be protected we suggest you use a quality wrapper around OpenSSL. pyca/cryptography is one example of such a wrapper. The primary use-case of this library is as a portable library for interoperability testing and as a teaching tool."

Keygen is now changed to `cryptography` which uses OpenSSL as a back-end.

Ref. NCSDK-18419