### PR TITLE
manifest: west.yml: MCUBoot support for NSIB + Multi-image 

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -126,7 +126,7 @@ manifest:
           compare-by-default: false
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 823fd369c1430b50d263ccd6fbcf98bdd44001ba
+      revision: pull/260/head
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR.git


### PR DESCRIPTION
Add support in MCUBoot for using multi-image and NSIB for nRF53.

Ref. NCSDK-19223