### PR TITLE
drivers: wifi: Enable TCP/IP checksum offload by default

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -337,7 +337,12 @@ Drivers
 
 This section provides detailed lists of changes by :ref:`driver <drivers>`.
 
-|no_changes_yet_note|
+Wi-Fi drivers
+-------------
+
+* Added:
+
+  * TCP/IP checksum offload is now enabled by default for the nRF70 Series.
 
 Libraries
 =========

--- a/drivers/wifi/nrf700x/Kconfig.nrf700x
+++ b/drivers/wifi/nrf700x/Kconfig.nrf700x
@@ -49,6 +49,7 @@ config NRF_WIFI_LOW_POWER
 
 config NRF700X_TCP_IP_CHECKSUM_OFFLOAD
 	bool "Enable TCP/IP checksum offload"
+	default y
 
 config NRF700X_REG_DOMAIN
 	string "The ISO/IEC alpha2 country code for the country in which this device is currently operating. Default 00 (World regulatory)"

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/cmd.c
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/cmd.c
@@ -141,7 +141,7 @@ enum wifi_nrf_status umac_cmd_init(struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx,
 	umac_cmd_data->sys_params.sleep_enable = sleep_type;
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
 #ifdef CONFIG_NRF700X_TCP_IP_CHECKSUM_OFFLOAD
-	umac_cmd_data->sys_params.tcp_ip_checksum_offload = 1;
+	umac_cmd_data->tcp_ip_checksum_offload = 1;
 #endif /* CONFIG_NRF700X_TCP_IP_CHECKSUM_OFFLOAD */
 
 	wifi_nrf_osal_log_dbg(fmac_dev_ctx->fpriv->opriv, "RPU LPM type: %s\n",


### PR DESCRIPTION
This is now fully supported and working, so, making this default to reduce load on host processor.

Fixes SHEL-1683.