### PR TITLE
Bluetooth: Mesh: Remove storage timers from models

### DIFF
--- a/doc/nrf/libraries/bluetooth_services/mesh/gen_plvl_srv.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/gen_plvl_srv.rst
@@ -89,7 +89,7 @@ The Generic Power Level Server stores any changes to the Default Power and Power
 This information is used to reestablish the correct Generic Power Level when the device powers up.
 
 If option :kconfig:option:`CONFIG_BT_SETTINGS` is enabled, the Generic Power Level Server stores all its states persistently using a configurable storage delay to stagger storing.
-See :kconfig:option:`CONFIG_BT_MESH_MODEL_SRV_STORE_TIMEOUT`.
+See :kconfig:option:`CONFIG_BT_MESH_STORE_TIMEOUT`.
 
 The Generic Power Level Server can use the :ref:`emergency data storage (EMDS) <emds_readme>` together with persistent storage to:
 

--- a/doc/nrf/libraries/bluetooth_services/mesh/gen_ponoff_srv.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/gen_ponoff_srv.rst
@@ -62,7 +62,7 @@ Persistent storage
 The Generic On Power Up state is stored persistently, along with the current Generic OnOff state of the extended :ref:`bt_mesh_onoff_srv_readme`.
 
 If :kconfig:option:`CONFIG_BT_SETTINGS` is enabled, the Generic Power OnOff Server stores all its states persistently using a configurable storage delay to stagger storing.
-See :kconfig:option:`CONFIG_BT_MESH_MODEL_SRV_STORE_TIMEOUT`.
+See :kconfig:option:`CONFIG_BT_MESH_STORE_TIMEOUT`.
 
 API documentation
 =================

--- a/doc/nrf/libraries/bluetooth_services/mesh/gen_prop_srv.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/gen_prop_srv.rst
@@ -61,7 +61,7 @@ The Generic Manufacturer Property Server and Generic Admin Property Server model
 Any permanent changes to the property values themselves should be stored manually by the application.
 
 If :kconfig:option:`CONFIG_BT_SETTINGS` is enabled, the Generic Admin Property Server stores all its states persistently using a configurable storage delay to stagger storing.
-See :kconfig:option:`CONFIG_BT_MESH_MODEL_SRV_STORE_TIMEOUT`.
+See :kconfig:option:`CONFIG_BT_MESH_STORE_TIMEOUT`.
 
 API documentation
 =================

--- a/doc/nrf/libraries/bluetooth_services/mesh/light_ctrl_srv.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/light_ctrl_srv.rst
@@ -370,7 +370,7 @@ Persistent Storage
 ******************
 
 If :kconfig:option:`CONFIG_BT_SETTINGS` is enabled, the Light LC Server stores all its states persistently using a configurable storage delay to stagger storing.
-See :kconfig:option:`CONFIG_BT_MESH_MODEL_SRV_STORE_TIMEOUT`.
+See :kconfig:option:`CONFIG_BT_MESH_STORE_TIMEOUT`.
 
 Changes to the configuration properties are stored and restored on power-up, so the compile time configuration is only valid the first time the device powers up, until the configuration is changed.
 

--- a/doc/nrf/libraries/bluetooth_services/mesh/light_hue_srv.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/light_hue_srv.rst
@@ -72,7 +72,7 @@ The Light Hue Server stores the following information:
 This information is used to reestablish the correct Hue level when the device powers up.
 
 If :kconfig:option:`CONFIG_BT_SETTINGS` is enabled, the Light Hue Server stores all its states persistently using a configurable storage delay to stagger storing.
-See :kconfig:option:`CONFIG_BT_MESH_MODEL_SRV_STORE_TIMEOUT`.
+See :kconfig:option:`CONFIG_BT_MESH_STORE_TIMEOUT`.
 
 The Light Hue Server can use the :ref:`emergency data storage (EMDS) <emds_readme>` together with persistent storage to:
 

--- a/doc/nrf/libraries/bluetooth_services/mesh/light_sat_srv.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/light_sat_srv.rst
@@ -65,7 +65,7 @@ The Light Saturation Server stores the following information:
 This information is used to reestablish the correct Saturation level when the device powers up.
 
 If :kconfig:option:`CONFIG_BT_SETTINGS` is enabled, the Light Saturation Server stores all its states persistently using a configurable storage delay to stagger storing.
-See :kconfig:option:`CONFIG_BT_MESH_MODEL_SRV_STORE_TIMEOUT`.
+See :kconfig:option:`CONFIG_BT_MESH_STORE_TIMEOUT`.
 
 The Light Saturation Server can use the :ref:`emergency data storage (EMDS) <emds_readme>` together with persistent storage for the following purposes:
 

--- a/doc/nrf/libraries/bluetooth_services/mesh/light_temp_srv.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/light_temp_srv.rst
@@ -78,7 +78,7 @@ The Light CTL Temperature Server stores the following information:
 This information is used to reestablish the correct Temperature level when the device powers up.
 
 If :kconfig:option:`CONFIG_BT_SETTINGS` is enabled, the Light CTL Temperature Server stores all its states persistently using a configurable storage delay to stagger storing.
-See :kconfig:option:`CONFIG_BT_MESH_MODEL_SRV_STORE_TIMEOUT`.
+See :kconfig:option:`CONFIG_BT_MESH_STORE_TIMEOUT`.
 
 The Light CTL Temperature Server can use the :ref:`emergency data storage (EMDS) <emds_readme>` together with persistent storage to:
 

--- a/doc/nrf/libraries/bluetooth_services/mesh/light_xyl_srv.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/light_xyl_srv.rst
@@ -205,7 +205,7 @@ In addition, the model takes over the persistent storage responsibility of the :
 This information is used to reestablish the correct light configuration when the device powers up.
 
 If :kconfig:option:`CONFIG_BT_SETTINGS` is enabled, the Light xyL Server stores all its states persistently using a configurable storage delay to stagger storing.
-See :kconfig:option:`CONFIG_BT_MESH_MODEL_SRV_STORE_TIMEOUT`.
+See :kconfig:option:`CONFIG_BT_MESH_STORE_TIMEOUT`.
 
 The Light xyL Server can use the :ref:`emergency data storage (EMDS) <emds_readme>` together with persistent storage to:
 

--- a/doc/nrf/libraries/bluetooth_services/mesh/lightness_srv.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/lightness_srv.rst
@@ -101,7 +101,7 @@ The Light Lightness Server stores the following information:
 This information is used to reestablish the correct Light level when the device powers up.
 
 If :kconfig:option:`CONFIG_BT_SETTINGS` is enabled, the Light Lightness Server stores all its states persistently using a configurable storage delay to stagger storing.
-See :kconfig:option:`CONFIG_BT_MESH_MODEL_SRV_STORE_TIMEOUT`.
+See :kconfig:option:`CONFIG_BT_MESH_STORE_TIMEOUT`.
 
 The Light Lightness Server can use the :ref:`emergency data storage (EMDS) <emds_readme>` together with persistent storage for the following purposes:
 

--- a/doc/nrf/libraries/bluetooth_services/mesh/sensor_srv.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/sensor_srv.rst
@@ -78,7 +78,7 @@ Any other data is managed by the application and must be stored separately.
 This applies for example to sensor settings or sample data.
 
 If :kconfig:option:`CONFIG_BT_SETTINGS` is enabled, the Sensor Server stores all its states persistently using a configurable storage delay to stagger storing.
-See :kconfig:option:`CONFIG_BT_MESH_MODEL_SRV_STORE_TIMEOUT`.
+See :kconfig:option:`CONFIG_BT_MESH_STORE_TIMEOUT`.
 
 API documentation
 =================

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -289,7 +289,11 @@ Binary libraries
 Bluetooth libraries and services
 --------------------------------
 
-|no_changes_yet_note|
+* :ref:`bt_mesh` library:
+
+  * Updated:
+
+    * The :kconfig:option:`BT_MESH_MODEL_SRV_STORE_TIMEOUT` Kconfig option, that is controlling timeout for storing of model states, is replaced by the :kconfig:option:`BT_MESH_STORE_TIMEOUT` Kconfig option.
 
 Bootloader libraries
 --------------------

--- a/include/bluetooth/mesh/gen_plvl_srv.h
+++ b/include/bluetooth/mesh/gen_plvl_srv.h
@@ -163,10 +163,6 @@ struct bt_mesh_plvl_srv {
 	/** User handler functions. */
 	const struct bt_mesh_plvl_srv_handlers *const handlers;
 
-#if CONFIG_BT_SETTINGS
-	/** Storage timer */
-	struct k_work_delayable store_timer;
-#endif
 	/** Current Power Range. */
 	struct bt_mesh_plvl_range range;
 	/** Current Default Power. */

--- a/include/bluetooth/mesh/gen_ponoff_srv.h
+++ b/include/bluetooth/mesh/gen_ponoff_srv.h
@@ -104,10 +104,6 @@ struct bt_mesh_ponoff_srv {
 			     enum bt_mesh_on_power_up old_on_power_up,
 			     enum bt_mesh_on_power_up new_on_power_up);
 
-#if CONFIG_BT_SETTINGS
-	/** Storage timer */
-	struct k_work_delayable store_timer;
-#endif
 	/** Current OnPowerUp state. */
 	enum bt_mesh_on_power_up on_power_up;
 };

--- a/include/bluetooth/mesh/gen_prop_srv.h
+++ b/include/bluetooth/mesh/gen_prop_srv.h
@@ -163,10 +163,6 @@ struct bt_mesh_prop_srv {
 	/** Which state is currently being published. */
 	enum bt_mesh_prop_srv_state pub_state;
 
-#if CONFIG_BT_SETTINGS
-	/** Storage timer */
-	struct k_work_delayable store_timer;
-#endif
 	/** List of properties supported by the server. */
 	struct bt_mesh_prop *const properties;
 	/** Number of properties supported by the server. */

--- a/include/bluetooth/mesh/light_ctrl_srv.h
+++ b/include/bluetooth/mesh/light_ctrl_srv.h
@@ -155,10 +155,6 @@ struct bt_mesh_light_ctrl_srv {
 	/** State timer */
 	struct k_work_delayable timer;
 
-#if CONFIG_BT_SETTINGS
-	/** Storage timer */
-	struct k_work_delayable store_timer;
-#endif
 	/** Timer for delayed action */
 	struct k_work_delayable action_delay;
 	/** Configuration parameters */

--- a/include/bluetooth/mesh/light_hue_srv.h
+++ b/include/bluetooth/mesh/light_hue_srv.h
@@ -200,10 +200,6 @@ struct bt_mesh_light_hue_srv {
 	/** Transaction ID tracker for the set messages. */
 	struct bt_mesh_tid_ctx prev_transaction;
 
-#if CONFIG_BT_SETTINGS
-	/** Storage timer */
-	struct k_work_delayable store_timer;
-#endif
 	/** Hue range */
 	struct bt_mesh_light_hsl_range range;
 	/** Default Hue level */

--- a/include/bluetooth/mesh/light_sat_srv.h
+++ b/include/bluetooth/mesh/light_sat_srv.h
@@ -147,10 +147,6 @@ struct bt_mesh_light_sat_srv {
 	/** Transaction ID tracker for the set messages. */
 	struct bt_mesh_tid_ctx prev_transaction;
 
-#if CONFIG_BT_SETTINGS
-	/** Storage timer */
-	struct k_work_delayable store_timer;
-#endif
 	/** Saturation range */
 	struct bt_mesh_light_hsl_range range;
 	/** Default Saturation level */

--- a/include/bluetooth/mesh/light_temp_srv.h
+++ b/include/bluetooth/mesh/light_temp_srv.h
@@ -135,10 +135,6 @@ struct bt_mesh_light_temp_srv {
 	/** Handler function structure. */
 	const struct bt_mesh_light_temp_srv_handlers *handlers;
 
-#if CONFIG_BT_SETTINGS
-	/** Storage timer */
-	struct k_work_delayable store_timer;
-#endif
 	/** Default light temperature and delta UV */
 	struct bt_mesh_light_temp dflt;
 	/** Current Temperature range. */

--- a/include/bluetooth/mesh/light_xyl_srv.h
+++ b/include/bluetooth/mesh/light_xyl_srv.h
@@ -165,10 +165,6 @@ struct bt_mesh_light_xyl_srv {
 	/** Transaction ID tracker for the set messages. */
 	struct bt_mesh_tid_ctx prev_transaction;
 
-#if CONFIG_BT_SETTINGS
-	/** Storage timer */
-	struct k_work_delayable store_timer;
-#endif
 	/** Current range parameters */
 	struct bt_mesh_light_xy_range range;
 	/** Handler function structure. */

--- a/include/bluetooth/mesh/lightness_srv.h
+++ b/include/bluetooth/mesh/lightness_srv.h
@@ -166,10 +166,6 @@ struct bt_mesh_lightness_srv {
 	/** User handler functions. */
 	const struct bt_mesh_lightness_srv_handlers *const handlers;
 
-#if CONFIG_BT_SETTINGS
-	/** Storage timer */
-	struct k_work_delayable store_timer;
-#endif
 	/** Current Light Level Range. */
 	struct bt_mesh_lightness_range range;
 	/** Current Default Light Level. */

--- a/include/bluetooth/mesh/sensor_srv.h
+++ b/include/bluetooth/mesh/sensor_srv.h
@@ -69,10 +69,6 @@ struct bt_mesh_sensor_srv {
 	/** Number of sensors. */
 	uint8_t sensor_count;
 
-#if CONFIG_BT_SETTINGS
-	/** Storage timer */
-	struct k_work_delayable store_timer;
-#endif
 	/** Publish parameters. */
 	struct bt_mesh_model_pub pub;
 	/* Publication buffer */

--- a/include/bluetooth/mesh/vnd/dm_srv.h
+++ b/include/bluetooth/mesh/vnd/dm_srv.h
@@ -30,10 +30,6 @@ struct bt_mesh_dm_srv {
 	struct bt_mesh_tid_ctx prev_transaction;
 	/** Access model pointer. */
 	struct bt_mesh_model *model;
-#if CONFIG_BT_SETTINGS
-	/** Storage timer */
-	struct k_work_delayable store_timer;
-#endif
 	/** Flag indicating measurement in progress */
 	bool is_busy;
 	/** Default configuration */

--- a/subsys/bluetooth/mesh/Kconfig.models
+++ b/subsys/bluetooth/mesh/Kconfig.models
@@ -31,18 +31,6 @@ config BT_MESH_MOD_ACKD_TIMEOUT_PER_HOP
 
 endmenu
 
-if BT_SETTINGS
-
-config BT_MESH_MODEL_SRV_STORE_TIMEOUT
-	int "Delay (in seconds) before storing changes to mesh model servers"
-	range 0 1000000
-	default 0
-	help
-	  Time to wait before storing changes to the mesh model servers.
-	  Effectively the minimum interval of changes.
-
-endif
-
 rsource "vnd/Kconfig"
 
 config BT_MESH_ONOFF_SRV

--- a/subsys/bluetooth/mesh/light_hue_srv.c
+++ b/subsys/bluetooth/mesh/light_hue_srv.c
@@ -28,11 +28,9 @@ struct settings_data {
 } __packed;
 
 #if CONFIG_BT_SETTINGS
-static void store_timeout(struct k_work *work)
+static void hue_srv_pending_store(struct bt_mesh_model *model)
 {
-	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
-	struct bt_mesh_light_hue_srv *srv = CONTAINER_OF(
-		dwork, struct bt_mesh_light_hue_srv, store_timer);
+	struct bt_mesh_light_hue_srv *srv = model->user_data;
 
 	struct settings_data data = {
 		.range = srv->range,
@@ -50,9 +48,7 @@ static void store_timeout(struct k_work *work)
 static void store(struct bt_mesh_light_hue_srv *srv)
 {
 #if CONFIG_BT_SETTINGS
-	k_work_schedule(
-		&srv->store_timer,
-		K_SECONDS(CONFIG_BT_MESH_MODEL_SRV_STORE_TIMEOUT));
+	bt_mesh_model_data_store_schedule(srv->model);
 #endif
 }
 
@@ -360,10 +356,7 @@ static int hue_srv_init(struct bt_mesh_model *model)
 	net_buf_simple_init_with_data(&srv->buf, srv->pub_data,
 				      ARRAY_SIZE(srv->pub_data));
 
-#if CONFIG_BT_SETTINGS
-	k_work_init_delayable(&srv->store_timer, store_timeout);
-
-#if IS_ENABLED(CONFIG_EMDS)
+#if IS_ENABLED(CONFIG_BT_SETTINGS) && IS_ENABLED(CONFIG_EMDS)
 	srv->emds_entry.entry.id = EMDS_MODEL_ID(model);
 	srv->emds_entry.entry.data = (uint8_t *)&srv->transient;
 	srv->emds_entry.entry.len = sizeof(srv->transient);
@@ -372,7 +365,6 @@ static int hue_srv_init(struct bt_mesh_model *model)
 	if (err) {
 		return err;
 	}
-#endif
 #endif
 
 	return bt_mesh_model_extend(model, srv->lvl.model);
@@ -420,6 +412,9 @@ const struct bt_mesh_model_cb _bt_mesh_light_hue_srv_cb = {
 	.init = hue_srv_init,
 	.settings_set = hue_srv_settings_set,
 	.reset = hue_srv_reset,
+#if CONFIG_BT_SETTINGS
+	.pending_store = hue_srv_pending_store,
+#endif
 };
 
 void bt_mesh_light_hue_srv_set(struct bt_mesh_light_hue_srv *srv,

--- a/subsys/bluetooth/mesh/light_xyl_srv.c
+++ b/subsys/bluetooth/mesh/light_xyl_srv.c
@@ -23,11 +23,9 @@ struct bt_mesh_light_xyl_srv_settings_data {
 } __packed;
 
 #if CONFIG_BT_SETTINGS
-static void store_timeout(struct k_work *work)
+static void bt_mesh_light_xyl_srv_pending_store(struct bt_mesh_model *model)
 {
-	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
-	struct bt_mesh_light_xyl_srv *srv = CONTAINER_OF(
-		dwork, struct bt_mesh_light_xyl_srv, store_timer);
+	struct bt_mesh_light_xyl_srv *srv = model->user_data;
 
 	struct bt_mesh_light_xyl_srv_settings_data data = {
 		.default_params = srv->xy_default,
@@ -45,9 +43,7 @@ static void store_timeout(struct k_work *work)
 static void store_state(struct bt_mesh_light_xyl_srv *srv)
 {
 #if CONFIG_BT_SETTINGS
-	k_work_schedule(
-		&srv->store_timer,
-		K_SECONDS(CONFIG_BT_MESH_MODEL_SRV_STORE_TIMEOUT));
+	bt_mesh_model_data_store_schedule(srv->model);
 #endif
 }
 
@@ -536,10 +532,7 @@ static int bt_mesh_light_xyl_srv_init(struct bt_mesh_model *model)
 	net_buf_simple_init_with_data(&srv->pub_buf, srv->pub_data,
 				      sizeof(srv->pub_data));
 
-#if CONFIG_BT_SETTINGS
-	k_work_init_delayable(&srv->store_timer, store_timeout);
-
-#if IS_ENABLED(CONFIG_EMDS)
+#if IS_ENABLED(CONFIG_BT_SETTINGS) && IS_ENABLED(CONFIG_EMDS)
 	srv->emds_entry.entry.id = EMDS_MODEL_ID(model);
 	srv->emds_entry.entry.data = (uint8_t *)&srv->transient;
 	srv->emds_entry.entry.len = sizeof(srv->transient);
@@ -548,7 +541,6 @@ static int bt_mesh_light_xyl_srv_init(struct bt_mesh_model *model)
 	if (err) {
 		return err;
 	}
-#endif
 #endif
 
 	lightness_srv =
@@ -636,6 +628,9 @@ const struct bt_mesh_model_cb _bt_mesh_light_xyl_srv_cb = {
 	.init = bt_mesh_light_xyl_srv_init,
 	.start = bt_mesh_light_xyl_srv_start,
 	.settings_set = bt_mesh_light_xyl_srv_settings_set,
+#if CONFIG_BT_SETTINGS
+	.pending_store = bt_mesh_light_xyl_srv_pending_store,
+#endif
 	.reset = bt_mesh_light_xyl_srv_reset,
 };
 

--- a/subsys/bluetooth/mesh/lightness_srv.c
+++ b/subsys/bluetooth/mesh/lightness_srv.c
@@ -30,11 +30,9 @@ struct bt_mesh_lightness_srv_settings_data {
 static const char *const repr_str[] = { "Actual", "Linear" };
 
 #if CONFIG_BT_SETTINGS
-static void store_timeout(struct k_work *work)
+static void bt_mesh_lightness_srv_pending_store(struct bt_mesh_model *model)
 {
-	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
-	struct bt_mesh_lightness_srv *srv = CONTAINER_OF(
-		dwork, struct bt_mesh_lightness_srv, store_timer);
+	struct bt_mesh_lightness_srv *srv = model->user_data;
 
 	struct bt_mesh_lightness_srv_settings_data data = {
 		.default_light = srv->default_light,
@@ -62,9 +60,7 @@ static void store_timeout(struct k_work *work)
 static void store_state(struct bt_mesh_lightness_srv *srv)
 {
 #if CONFIG_BT_SETTINGS
-	k_work_schedule(
-		&srv->store_timer,
-		K_SECONDS(CONFIG_BT_MESH_MODEL_SRV_STORE_TIMEOUT));
+	bt_mesh_model_data_store_schedule(srv->lightness_model);
 #endif
 }
 
@@ -856,10 +852,7 @@ static int bt_mesh_lightness_srv_init(struct bt_mesh_model *model)
 	net_buf_simple_init_with_data(&srv->pub_buf, srv->pub_data,
 				      sizeof(srv->pub_data));
 
-#if CONFIG_BT_SETTINGS
-	k_work_init_delayable(&srv->store_timer, store_timeout);
-
-#if IS_ENABLED(CONFIG_EMDS)
+#if IS_ENABLED(CONFIG_BT_SETTINGS) && IS_ENABLED(CONFIG_EMDS)
 	srv->emds_entry.entry.id = EMDS_MODEL_ID(model);
 	srv->emds_entry.entry.data = (uint8_t *)&srv->transient;
 	srv->emds_entry.entry.len = sizeof(srv->transient);
@@ -867,7 +860,6 @@ static int bt_mesh_lightness_srv_init(struct bt_mesh_model *model)
 	if (err) {
 		return err;
 	}
-#endif
 #endif
 
 	err = bt_mesh_model_extend(model, srv->ponoff.ponoff_model);
@@ -972,6 +964,7 @@ const struct bt_mesh_model_cb _bt_mesh_lightness_srv_cb = {
 #ifdef CONFIG_BT_SETTINGS
 	.settings_set = bt_mesh_lightness_srv_settings_set,
 	.start = bt_mesh_lightness_srv_start,
+	.pending_store = bt_mesh_lightness_srv_pending_store,
 #endif
 };
 

--- a/subsys/bluetooth/mesh/sensor_srv.c
+++ b/subsys/bluetooth/mesh/sensor_srv.c
@@ -37,11 +37,9 @@ static struct bt_mesh_sensor *sensor_get(struct bt_mesh_sensor_srv *srv,
 }
 
 #if CONFIG_BT_SETTINGS
-static void store_timeout(struct k_work *work)
+static void sensor_srv_pending_store(struct bt_mesh_model *model)
 {
-	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
-	struct bt_mesh_sensor_srv *srv = CONTAINER_OF(
-		dwork, struct bt_mesh_sensor_srv, store_timer);
+	struct bt_mesh_sensor_srv *srv = model->user_data;
 
 	/* Cadence is stored as a sequence of cadence status messages */
 	NET_BUF_SIMPLE_DEFINE(buf, (CONFIG_BT_MESH_SENSOR_SRV_SENSORS_MAX *
@@ -74,9 +72,7 @@ static void store_timeout(struct k_work *work)
 static void cadence_store(struct bt_mesh_sensor_srv *srv)
 {
 #if CONFIG_BT_SETTINGS
-	k_work_schedule(
-		&srv->store_timer,
-		K_SECONDS(CONFIG_BT_MESH_MODEL_SRV_STORE_TIMEOUT));
+	bt_mesh_model_data_store_schedule(srv->model);
 #endif
 }
 
@@ -971,10 +967,6 @@ static int sensor_srv_init(struct bt_mesh_model *model)
 
 	sys_slist_init(&srv->sensors);
 
-#if CONFIG_BT_SETTINGS
-	k_work_init_delayable(&srv->store_timer, store_timeout);
-#endif
-
 	/* Establish a sorted list of sensors, as this is a requirement when
 	 * sending multiple sensor values in one message.
 	 */
@@ -1108,6 +1100,9 @@ const struct bt_mesh_model_cb _bt_mesh_sensor_srv_cb = {
 	.init = sensor_srv_init,
 	.reset = sensor_srv_reset,
 	.settings_set = sensor_srv_settings_set,
+#if CONFIG_BT_SETTINGS
+	.pending_store = sensor_srv_pending_store,
+#endif
 };
 
 static int sensor_setup_srv_init(struct bt_mesh_model *model)


### PR DESCRIPTION
Each model instance allocates k_work structure that is used to postpone state storing. Mesh now provides new API that can be used to schedule storing model's data and a callback that is called upon timeout and where a model store its data.

This commit removes such dedicated timers from models and uses new mesh API with mesh settings thread to save some RAM for applications.

To control timeout use CONFIG_BT_MESH_STORE_TIMEOUT instead of CONFIG_BT_MESH_MODEL_SRV_STORE_TIMEOUT.