### PR TITLE
modules: hal_nordic: lp_timer hw_task use timer_exact_set

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 5385c25be98b6812b765d9ce90e3b2f8a03c5bf1
+      revision: b92f3123358eea8774715b42b4f3741e2eb96d46
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
nRF 802.15.4 Radio Driver delayed tx/rx could be triggered at imprecise moment of time (with additional delay) despite hardware triggering of delayed operations is used due to the way `z_nrf_rtc_timer_set` function of nrf_rtc_timer works. This PR uses the function `z_nrf_rtc_timer_exact_set` to ensure the delayed operation is either triggered exactly at requested time or doesn't happen at all.

KRKNWK-16481