### PR TITLE
doc improvement: matter: update docset info for zoomin

### DIFF
--- a/doc/matter/conf.py
+++ b/doc/matter/conf.py
@@ -20,7 +20,7 @@ ZEPHYR_BASE = utils.get_projdir("zephyr")
 
 # General configuration --------------------------------------------------------
 
-project = "Matter"
+project = "Matter SDK"
 copyright = "2020-2023, Matter Contributors"
 author = "Matter Contributors"
 version = "1.1.0"
@@ -42,7 +42,7 @@ html_static_path = [str(NRF_BASE / "doc" / "_static")]
 html_last_updated_fmt = "%b %d, %Y"
 html_show_sourcelink = True
 html_show_sphinx = False
-html_title = "Matter documentation (nRF Connect SDK)"
+html_title = "Matter SDK documentation (nRF Connect SDK)"
 
 html_theme_options = {
     "docset": "matter",


### PR DESCRIPTION
Edited the name, html heading, and the docset subtitle for Matter. Reason: clearly differentiate the Matter SDK docset from the NCS docs in Zoomin, regardless of placement.