### PR TITLE
EMDS: Fixed Coveriy issues

### DIFF
--- a/tests/subsys/emds/emds_api/src/main.c
+++ b/tests/subsys/emds/emds_api/src/main.c
@@ -77,7 +77,7 @@ static char *print_state(enum test_states s)
 static void app_store_cb(void)
 {
 #if defined(CONFIG_BT) && !defined(CONFIG_BT_LL_SW_SPLIT)
-	bt_enable(NULL);
+	(void)bt_enable(NULL);
 #endif
 }
 
@@ -329,12 +329,12 @@ ZTEST_SUITE(several_store, pragma_several_store, NULL, NULL, NULL, NULL);
 void test_main(void)
 {
 #if defined(CONFIG_BT) && !defined(CONFIG_BT_LL_SW_SPLIT)
-	bt_enable(NULL);
+	(void)bt_enable(NULL);
 #endif
 #if CONFIG_SETTINGS
-	settings_subsys_init();
-	settings_register(&emds_test_conf);
-	settings_load();
+	(void)settings_subsys_init();
+	(void)settings_register(&emds_test_conf);
+	(void)settings_load();
 #endif
 	enum test_states run_state = state[iteration];
 
@@ -350,12 +350,12 @@ void test_main(void)
 #if CONFIG_SETTINGS
 	iteration++;
 	if (iteration < ARRAY_SIZE(state)) {
-		settings_save_one("emds_test/iteration", &iteration, sizeof(iteration));
+		(void)settings_save_one("emds_test/iteration", &iteration, sizeof(iteration));
 		sys_reboot(SYS_REBOOT_COLD);
 	} else {
-		settings_save_one("emds_test/iteration", 0, sizeof(iteration));
+		(void)settings_save_one("emds_test/iteration", 0, sizeof(iteration));
 	}
 #else
-	emds_clear();
+	(void)emds_clear();
 #endif
 }

--- a/tests/subsys/emds/emds_flash/src/main.c
+++ b/tests/subsys/emds/emds_flash/src/main.c
@@ -535,8 +535,7 @@ ZTEST(emds_flash_tests, test_overflow)
 
 	data_in[0] = 'D';
 	for (size_t i = 0; i < test_cnt; i++) {
-		emds_flash_read(&ctx, i, data_out,
-				  sizeof(data_out));
+		(void)emds_flash_read(&ctx, i, data_out, sizeof(data_out));
 		zassert_false(memcmp(data_out, data_in, sizeof(data_out)), "Retrived wrong value");
 		memset(data_out, 0, sizeof(data_out));
 		data_in[0]++;
@@ -629,9 +628,9 @@ ZTEST(emds_flash_tests, test_write_speed)
 
 	memset(data_in_big, 69, sizeof(data_in_big));
 
-	dk_leds_init();
-	dk_set_led(0, false);
-	flash_clear();
+	(void)dk_leds_init();
+	(void)dk_set_led(0, false);
+	(void)flash_clear();
 	device_reset();
 
 #if defined(CONFIG_BT)
@@ -639,8 +638,8 @@ ZTEST(emds_flash_tests, test_write_speed)
 	(void)sdc_disable();
 	mpsl_uninit();
 #endif
-	emds_flash_init(&ctx);
-	emds_flash_prepare(&ctx, sizeof(data_in) + ctx.ate_size);
+	(void)emds_flash_init(&ctx);
+	(void)emds_flash_prepare(&ctx, sizeof(data_in) + ctx.ate_size);
 
 	tic = k_uptime_ticks();
 	dk_set_led(0, true);


### PR DESCRIPTION
Fixed issues reported by Coverity.

Solves several of this Coverity issues.
CID 199967 (#1 of 2): Unchecked return value (CHECKED_RETURN)
11. check_return: Calling ...... without checking return value