### PR TITLE
lib: nrf_modem: move modem trace initialization as early as possible

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -639,6 +639,7 @@ Modem libraries
     * The trace backends can now return ``-EAGAIN`` if the write operation can be retried.
     * Fixed a rare bug that caused a deadlock between two threads when one thread sent data while the other received a lot of data quickly.
     * The ``SO_IP_ECHO_REPLY``, ``SO_IPV6_ECHO_REPLY``, ``SO_TCP_SRV_SESSTIMEO`` and ``SO_SILENCE_ALL`` socket option levels to align with the modem option levels.
+    * The :ref:`modem_trace_module` is now initialized before the callbacks registered using the :c:macro:`NRF_MODEM_LIB_ON_INIT` macro are called.
 
 * :ref:`lte_lc_readme` library:
 

--- a/lib/nrf_modem_lib/nrf_modem_lib.c
+++ b/lib/nrf_modem_lib/nrf_modem_lib.c
@@ -67,6 +67,10 @@ static const struct nrf_modem_bootloader_init_params bootloader_init_params = {
 	.fault_handler = nrf_modem_fault_handler
 };
 
+#if CONFIG_NRF_MODEM_LIB_TRACE
+extern void nrf_modem_lib_trace_init(void);
+#endif /* CONFIG_NRF_MODEM_LIB_TRACE */
+
 static void log_fw_version_uuid(void)
 {
 	int err;
@@ -121,11 +125,19 @@ static int _nrf_modem_lib_init(void)
 
 	rc = nrf_modem_init(&init_params);
 
+#if CONFIG_NRF_MODEM_LIB_TRACE
+	/* We enable tracing as early as possible because the modem can only store a given
+	 * amount of traces internally before they are dropped.
+	 */
+	nrf_modem_lib_trace_init();
+#endif /* CONFIG_NRF_MODEM_LIB_TRACE */
+
 	if (IS_ENABLED(CONFIG_NRF_MODEM_LIB_LOG_FW_VERSION_UUID)) {
 		log_fw_version_uuid();
 	}
 
 	LOG_DBG("Modem library has initialized, ret %d", rc);
+
 	STRUCT_SECTION_FOREACH(nrf_modem_lib_init_cb, e) {
 		LOG_DBG("Modem init callback: %p", e->callback);
 		e->callback(rc, e->context);

--- a/lib/nrf_modem_lib/nrf_modem_lib_trace.c
+++ b/lib/nrf_modem_lib/nrf_modem_lib_trace.c
@@ -18,8 +18,6 @@
 
 LOG_MODULE_REGISTER(nrf_modem_lib_trace, CONFIG_NRF_MODEM_LIB_LOG_LEVEL);
 
-NRF_MODEM_LIB_ON_INIT(trace_init, trace_init_callback, NULL);
-
 K_SEM_DEFINE(trace_sem, 0, 1);
 K_SEM_DEFINE(trace_clear_sem, 0, 1);
 K_SEM_DEFINE(trace_done_sem, 1, 1);
@@ -329,11 +327,9 @@ static int trace_init(void)
 	return 0;
 }
 
-static void trace_init_callback(int err, void *ctx)
+void nrf_modem_lib_trace_init(void)
 {
-	if (err) {
-		return;
-	}
+	int err;
 
 	err = trace_init();
 	if (err) {

--- a/tests/lib/nrf_modem_lib/nrf_modem_lib_trace/src/main.c
+++ b/tests/lib/nrf_modem_lib/nrf_modem_lib_trace/src/main.c
@@ -57,6 +57,8 @@ static int trace_backend_write_cmock_num_calls;
 
 static int callback_evt;
 
+extern void nrf_modem_lib_trace_init(void);
+
 /* This is the override for the _weak callback. */
 void nrf_modem_lib_trace_callback(enum nrf_modem_lib_trace_event evt)
 {
@@ -95,13 +97,6 @@ void setUp(void)
 	RESET_FAKE(nrf_modem_at_printf);
 
 	clear_rw_frags();
-}
-
-static void NRF_MODEM_LIB_ON_INIT_callback(void)
-{
-	STRUCT_SECTION_FOREACH(nrf_modem_lib_init_cb, e) {
-		e->callback(0, e->context);
-	}
 }
 
 static void generate_trace_frag(struct nrf_modem_trace_data *frag)
@@ -217,7 +212,7 @@ void test_trace_thread_handler_get_single(void)
 	__cmock_trace_backend_write_Stub(trace_backend_write_stub);
 	__cmock_trace_backend_deinit_Stub(trace_backend_deinit_stub);
 
-	NRF_MODEM_LIB_ON_INIT_callback();
+	nrf_modem_lib_trace_init();
 
 	generate_trace_frag(&header);
 	generate_trace_frag(&data);
@@ -248,7 +243,7 @@ void test_trace_thread_handler_get_multi(void)
 	__cmock_trace_backend_write_Stub(trace_backend_write_stub);
 	__cmock_trace_backend_deinit_Stub(trace_backend_deinit_stub);
 
-	NRF_MODEM_LIB_ON_INIT_callback();
+	nrf_modem_lib_trace_init();
 
 	for (int i = 0; i < TRACE_THREAD_HANDLER_MULTI_RUNS; i++) {
 		struct nrf_modem_trace_data header = { 0 };
@@ -291,7 +286,7 @@ void test_trace_thread_handler_write_efault(void)
 	__cmock_trace_backend_write_Stub(trace_backend_write_stub);
 	__cmock_trace_backend_deinit_Stub(trace_backend_deinit_stub);
 
-	NRF_MODEM_LIB_ON_INIT_callback();
+	nrf_modem_lib_trace_init();
 
 	generate_trace_frag(&header);
 	generate_trace_frag(&data);
@@ -315,7 +310,7 @@ void test_trace_thread_handler_get_einprogress(void)
 	__cmock_trace_backend_write_Stub(trace_backend_write_stub);
 	__cmock_trace_backend_deinit_Stub(trace_backend_deinit_stub);
 
-	NRF_MODEM_LIB_ON_INIT_callback();
+	nrf_modem_lib_trace_init();
 
 	nrf_modem_trace_get_error = -EINPROGRESS;
 
@@ -331,7 +326,7 @@ void test_trace_thread_handler_get_enodata(void)
 	__cmock_trace_backend_write_Stub(trace_backend_write_stub);
 	__cmock_trace_backend_deinit_Stub(trace_backend_deinit_stub);
 
-	NRF_MODEM_LIB_ON_INIT_callback();
+	nrf_modem_lib_trace_init();
 
 	nrf_modem_trace_get_error = -ENODATA;
 
@@ -347,7 +342,7 @@ void test_trace_thread_handler_get_eshutdown(void)
 	__cmock_trace_backend_write_Stub(trace_backend_write_stub);
 	__cmock_trace_backend_deinit_Stub(trace_backend_deinit_stub);
 
-	NRF_MODEM_LIB_ON_INIT_callback();
+	nrf_modem_lib_trace_init();
 
 	nrf_modem_trace_get_error = -ESHUTDOWN;
 
@@ -387,7 +382,7 @@ void test_nrf_modem_lib_trace_enospc(void)
 	__cmock_trace_backend_write_Stub(trace_backend_write_stub);
 	__cmock_trace_backend_deinit_Stub(trace_backend_deinit_stub);
 
-	NRF_MODEM_LIB_ON_INIT_callback();
+	nrf_modem_lib_trace_init();
 
 	trace_backend_write_error = -ENOSPC;
 


### PR DESCRIPTION
The modem will drop traces if they are not handled before the shared trace memory is full. Initialize the trace module as early as possible to start processing traces earlier.