### PR TITLE
manifest: sdk-hostap: Pull in flash optimization option

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -110,7 +110,7 @@ manifest:
     - name: hostap
       repo-path: sdk-hostap
       path: modules/lib/hostap
-      revision: 08100fa3da76b4b164bbdd37d1d150df3c9bffb3
+      revision: 649e1bbc75fe651b0be325b21d28dcaa9478d692
       userdata:
         ncs:
           upstream-url: https://w1.fi/cgit/hostap/


### PR DESCRIPTION
This Kconfig option saves about ~23kB of flash at the cost of debug information.