### PR TITLE
applications: serial_lte_modem: Remove bootloader fota update

### DIFF
--- a/applications/serial_lte_modem/doc/FOTA_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/FOTA_AT_commands.rst
@@ -31,7 +31,6 @@ Syntax
   * ``0`` - Cancel FOTA (during download only).
   * ``1`` - Start FOTA for application update.
   * ``2`` - Start FOTA for modem delta update.
-  * ``3`` - Start FOTA for bootloader update (optional if :ref:`nRF Secure Immutable Bootloader (NSIB) <bootloader>` enabled).
   * ``6`` - Read application image size and version (optional for application FOTA).
   * ``7`` - Read modem scratch space size and offset (optional for modem FOTA).
   * ``8`` - Erase MCUboot secondary slot (optional for application FOTA).
@@ -114,17 +113,6 @@ Example
 
    Application download and activate if NSIB is enabled
    AT#XFOTA=1,"http://remote.host/fota/slm_app_update.bin+slm_app_update.bin"
-   OK
-   #XFOTA: 1,0,0
-   ...
-   #XFOTA:4,0
-   AT#XRESET
-   OK
-   READY
-   #XFOTA: 5,0
-
-   Bootloader download and activate if NSIB is enabled
-   AT#XFOTA=3,"http://remote.host/fota/signed_by_mcuboot_and_b0_s0_image_update.bin+signed_by_mcuboot_and_b0_s1_image_update.bin"
    OK
    #XFOTA: 1,0,0
    ...
@@ -218,16 +206,5 @@ Examples
    AT#XFOTA=?
 
    #XFOTA: (0,1,2,6,7,8,9),<file_url>,<sec_tag>,<apn>
-
-   OK
-
-Examples(if NSIB is enabled)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-::
-
-   AT#XFOTA=?
-
-   #XFOTA: (0,1,2,3,6,7,8,9),<file_url>,<sec_tag>,<apn>
 
    OK

--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -224,10 +224,6 @@ The following configuration files are provided:
   You can include it by adding ``-DOVERLAY_CONFIG=overlay-native_tls.conf`` to your build command.
   See :ref:`cmake_options`.
 
-* :file:`overlay-secure_bootloader.conf` - This configuration file contains additional configuration options that are required to use :ref:`ug_bootloader`.
-  You can include it by adding ``-DOVERLAY_CONFIG=overlay-secure_bootloader`` to your build command.
-  See :ref:`cmake_options`.
-
 * :file:`overlay-carrier.conf` - Configuration file that adds |NCS| :ref:`liblwm2m_carrier_readme` support.
   See :ref:`slm_carrier_library_support` for more information on how to connect to an operator's device management platform.
 

--- a/applications/serial_lte_modem/overlay-secure_bootloader.conf
+++ b/applications/serial_lte_modem/overlay-secure_bootloader.conf
@@ -1,8 +1,0 @@
-#
-# Copyright (c) 2021 Nordic Semiconductor ASA
-#
-# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
-#
-CONFIG_SECURE_BOOT=y
-#CONFIG_SB_SIGNING_KEY_FILE="my_key_file.pem"
-CONFIG_BUILD_S1_VARIANT=y

--- a/applications/serial_lte_modem/src/main.c
+++ b/applications/serial_lte_modem/src/main.c
@@ -312,23 +312,6 @@ void handle_mcuboot_swap_ret(void)
 
 	fota_stage = FOTA_STAGE_COMPLETE;
 	switch (type) {
-	/** Attempt to boot the contents of slot 0. */
-	case BOOT_SWAP_TYPE_NONE:
-	/** MCUBOOT set BOOT_SWAP_TYPE_NONE after swapping B1 image, even TEST flag is set
-	 * by dfu_target_mcuboot library. There is no need to confirm image for B1 update.
-	 * But prompt which slot is activated.
-	 */
-#if defined(CONFIG_SECURE_BOOT)
-		bool s0_active;
-
-		fota_download_s0_active_get(&s0_active);
-		if (fota_type == SLM_DFU_TARGET_IMAGE_TYPE_BL1) {
-			LOG_INF("s0_active %d", s0_active);
-			fota_status = FOTA_STATUS_OK;
-			fota_info = 0;
-			break;
-		}
-#endif
 	/** Swap to slot 1. Absent a confirm command, revert back on next boot. */
 	case BOOT_SWAP_TYPE_TEST:
 	/** Swap to slot 1, and permanently switch to booting its contents. */
@@ -415,8 +398,7 @@ int main(void)
 	if (fota_stage != FOTA_STAGE_INIT) {
 		if (fota_type == DFU_TARGET_IMAGE_TYPE_MODEM_DELTA) {
 			handle_nrf_modem_lib_init_ret(err);
-		} else if (fota_type == DFU_TARGET_IMAGE_TYPE_MCUBOOT ||
-			   fota_type == SLM_DFU_TARGET_IMAGE_TYPE_BL1) {
+		} else if (fota_type == DFU_TARGET_IMAGE_TYPE_MCUBOOT) {
 			handle_mcuboot_swap_ret();
 		} else {
 			LOG_ERR("Unknown DFU type: %d", fota_type);

--- a/applications/serial_lte_modem/src/slm_at_fota.h
+++ b/applications/serial_lte_modem/src/slm_at_fota.h
@@ -28,11 +28,6 @@ enum fota_status {
 };
 
 /**
- * @brief Define SLM specified FOTA type for Bootloader
- */
-#define SLM_DFU_TARGET_IMAGE_TYPE_BL1	(DFU_TARGET_IMAGE_TYPE_MODEM_DELTA + 1)
-
-/**
  * @brief Initialize FOTA AT command parser.
  *
  * @retval 0 If the operation was successful.

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -148,6 +148,7 @@ nRF9160: Serial LTE modem
 * Removed:
 
   * DFU AT commands ``#XDFUGET``, ``#XDFUSIZE`` and ``#XDFURUN`` because they were not usable without a custom application in the target (nRF52 series) device.
+  * Support for bootloader FOTA update because it is not needed for Serial LTE modem.
 
 nRF5340 Audio
 -------------


### PR DESCRIPTION
Bootloader FOTA update is removed because it is not needed for Serial LTE modem.