### PR TITLE
samples: bootloader: Add missing conf file for nrf5340_audio_dk

### DIFF
--- a/samples/bootloader/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
+++ b/samples/bootloader/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# CC3xx is currently not used for nrf53
+CONFIG_HW_CC3XX=n
+CONFIG_NRF_CC3XX_PLATFORM=n
+# nPM1100 is not used by the bootloader
+CONFIG_REGULATOR_NPM1100=n


### PR DESCRIPTION
The nsib lacks a conf file for nrf5340_audio_dk_nrf5340_cpuapp that turns off CC3XX and nPM1100. These are enabled by default for this board but must be turned off in nsib to avoid compilation errors.

Ref: NCSIDB-960

Signed-off-by: Ole Sæther <ole.saether@nordicsemi.no>