### PR TITLE
manifest: Update bsim to v2.1.1

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -243,7 +243,7 @@ manifest:
     - name: bsim
       repo-path: bsim_west
       remote: babblesim
-      revision: 908ffde6298a937c6549dbfa843a62caab26bfc5
+      revision: 384a091445c57b44ac8cbd18ebd245b47c71db94
       import:
         path-prefix: tools
 


### PR DESCRIPTION
```
Update bsim to 2.1.1 (from a pre 2.1 version)

base: 02838ca -> 19d62424
  libUtil: Bugfix on bs_results error case
  libPhyCom: Added minor extra debug print
  device handbrake: Fix poke_period parameter
  libUtilv1: bs_symbols: Fix bug for very long symbol names
ext_2G4_phy_v1: cf2d86e -> d47c6dd90
  dump_postprocess: BLE ellisys: Fix time saturation at 2seconds
  cmd line parsing: Fix typo in error message
ext_2G4_channel_multiatt: e09bc2d -> bde72a5
  doc: Improved README
ext_2G4_modem_BLE_simple: ce975a3 -> 809ab07
  doc: Added README file
```