### PR TITLE
lib: location: Add support for GCI cell

### DIFF
--- a/doc/nrf/libraries/modem/location.rst
+++ b/doc/nrf/libraries/modem/location.rst
@@ -47,6 +47,9 @@ The supported location methods are as follows:
 * Cellular positioning
 
   * Uses :ref:`lte_lc_readme` for getting a list of nearby cellular base stations.
+  * Neighbor cell measurement is performed with :c:enum:`LTE_LC_NEIGHBOR_SEARCH_TYPE_EXTENDED_COMPLETE` search type.
+    A GCI search with :c:enum:`LTE_LC_NEIGHBOR_SEARCH_TYPE_GCI_EXTENDED_LIGHT` search type is performed if the previous search did not find enough cells.
+    For more details on GCI search, see :c:member:`location_cellular_config.cell_count`.
   * The ``cloud location`` method handles sending cell information to the selected location service and getting the calculated location back to the device.
 
 * Wi-Fi positioning
@@ -182,6 +185,7 @@ when :c:func:`location_config_defaults_set` function is called:
 * :kconfig:option:`CONFIG_LOCATION_REQUEST_DEFAULT_GNSS_VISIBILITY_DETECTION`
 * :kconfig:option:`CONFIG_LOCATION_REQUEST_DEFAULT_GNSS_PRIORITY_MODE`
 * :kconfig:option:`CONFIG_LOCATION_REQUEST_DEFAULT_CELLULAR_TIMEOUT`
+* :kconfig:option:`CONFIG_LOCATION_REQUEST_DEFAULT_CELLULAR_CELL_COUNT`
 * :kconfig:option:`CONFIG_LOCATION_REQUEST_DEFAULT_WIFI_TIMEOUT`
 
 Usage

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -360,6 +360,10 @@ Modem libraries
 
   * Updated the :c:func:`nrf_modem_lib_shutdown` function to allow the modem to be in flight mode (``CFUN=4``) when shutting down the modem.
 
+* :ref:`lib_location` library:
+
+  * Neighbor cell search is modified to use GCI search depending on :c:member:`location_cellular_config.cell_count` value.
+
 * :ref:`pdn_readme` library:
 
   * Updated the library to allow a ``PDP_type``-only configuration in the :c:func:`pdn_ctx_configure` function.

--- a/include/modem/location.h
+++ b/include/modem/location.h
@@ -339,6 +339,9 @@ struct location_cellular_config {
 	 * @ref location_config_defaults_set function is called and can be changed
 	 * at build time with CONFIG_LOCATION_REQUEST_DEFAULT_CELLULAR_TIMEOUT configuration.
 	 *
+	 * Timeout only applies to neighbor cell search, not the cloud communication.
+	 * Timeout for the entire location request specified in @ref location_config structure
+	 * is still valid.
 	 * When CONFIG_LOCATION_SERVICE_EXTERNAL is enabled, this timeout stops when
 	 * event LOCATION_EVT_CLOUD_LOCATION_EXT_REQUEST is sent. However, timeout specified in
 	 * @ref location_config structure is still valid.
@@ -354,6 +357,28 @@ struct location_cellular_config {
 	 * This parameter is ignored when CONFIG_LOCATION_SERVICE_EXTERNAL is enabled.
 	 */
 	enum location_service service;
+
+	/**
+	 * @brief Number of cells to be requested for cellular positioning.
+	 *
+	 * @details Default value is 4. It is applied when
+	 * @ref location_config_defaults_set function is called and can be changed
+	 * at build time with CONFIG_LOCATION_REQUEST_DEFAULT_CELLULAR_CELL_COUNT configuration.
+	 *
+	 * Maximum value is 15.
+	 *
+	 * Zero indicates that only normal neighbor cell search is performed but no GCI search.
+	 *
+	 * If there are less than requested number of neighbor cells (including current cell),
+	 * GCI (surrounding) cells are requested also.
+	 *
+	 * Note that even if there are a lot of cells available, the number of cells
+	 * used for positioning may be lower than the requested number of cells due to
+	 * the behavior of the search algorithm. Also, the number of cells used for
+	 * positioning may be higher than the requested number of cells if there are
+	 * more neighbor cells (including current cell).
+	 */
+	uint8_t cell_count;
 };
 
 /** Wi-Fi positioning configuration. */
@@ -365,6 +390,10 @@ struct location_wifi_config {
 	 * @details Default value is 30000 (30 seconds). It is applied when
 	 * @ref location_config_defaults_set function is called and can be changed
 	 * at build time with CONFIG_LOCATION_REQUEST_DEFAULT_WIFI_TIMEOUT configuration.
+	 *
+	 * Timeout only applies to Wi-Fi scan, not the cloud communication.
+	 * Timeout for the entire location request specified in @ref location_config structure
+	 * is still valid.
 	 *
 	 * When CONFIG_LOCATION_SERVICE_EXTERNAL is enabled, this timeout stops when
 	 * event LOCATION_EVT_CLOUD_LOCATION_EXT_REQUEST is sent. However, timeout specified in

--- a/lib/location/Kconfig
+++ b/lib/location/Kconfig
@@ -279,6 +279,14 @@ config LOCATION_REQUEST_DEFAULT_CELLULAR_TIMEOUT
 	  Default value used in location_config_defaults_set() function for timeout
 	  member within location_cellular_config structure.
 
+config LOCATION_REQUEST_DEFAULT_CELLULAR_CELL_COUNT
+	int "Number of requested cellular neighbors"
+	default 4
+	range 0 15
+	help
+	  Default value used in location_config_defaults_set() function for cell_count
+	  member within location_cellular_config structure.
+
 endif # LOCATION_METHOD_CELLULAR
 
 if LOCATION_METHOD_WIFI

--- a/lib/location/location.c
+++ b/lib/location/location.c
@@ -194,6 +194,7 @@ static void location_config_method_defaults_set(
 #if defined(CONFIG_LOCATION_METHOD_CELLULAR)
 		method->cellular.timeout = CONFIG_LOCATION_REQUEST_DEFAULT_CELLULAR_TIMEOUT;
 		method->cellular.service = LOCATION_SERVICE_ANY;
+		method->cellular.cell_count = CONFIG_LOCATION_REQUEST_DEFAULT_CELLULAR_CELL_COUNT;
 #endif
 	} else if (method_type == LOCATION_METHOD_WIFI) {
 #if defined(CONFIG_LOCATION_METHOD_WIFI)

--- a/lib/location/location_core.c
+++ b/lib/location/location_core.c
@@ -335,6 +335,7 @@ void location_core_config_log(const struct location_config *config)
 			LOG_DBG("      Service: %s (%d)",
 				location_core_service_str(config->methods[i].cellular.service),
 				config->methods[i].cellular.service);
+			LOG_DBG("      Cell count: %d", config->methods[i].cellular.cell_count);
 #if defined(CONFIG_LOCATION_METHOD_WIFI)
 		} else if (type == LOCATION_METHOD_WIFI) {
 			LOG_DBG("      Timeout: %dms", config->methods[i].wifi.timeout);
@@ -365,6 +366,8 @@ static int location_core_location_get_pos(void)
 
 	location_core_current_config_set(&loc_req_info.config);
 	/* Location request starts from the first method */
+	loc_req_info.timeout_uptime = (loc_req_info.config.timeout != SYS_FOREVER_MS) ?
+		k_uptime_get() + loc_req_info.config.timeout : SYS_FOREVER_MS;
 	loc_req_info.execute_fallback = true;
 	loc_req_info.current_method_index = 0;
 	requested_method = loc_req_info.methods[loc_req_info.current_method_index];

--- a/lib/location/location_core.h
+++ b/lib/location/location_core.h
@@ -36,6 +36,12 @@ struct location_request_info {
 
 	/** Whether to perform fallback for current location request processing. */
 	bool execute_fallback;
+
+	/**
+	 * Device uptime when location request timer expires.
+	 * This is used in cloud location method to calculate timeout for the cloud operation.
+	 */
+	int64_t timeout_uptime;
 };
 
 struct location_method_api {

--- a/lib/location/scan_cellular.c
+++ b/lib/location/scan_cellular.c
@@ -139,15 +139,12 @@ int scan_cellular_start(uint8_t cell_count)
 	 */
 	scan_cellular_cell_count = scan_cellular_cell_count - scan_cellular_info.ncells_count;
 
-	if (scan_cellular_cell_count > 0) {
+	LOG_DBG("scan_cellular_start: scan_cellular_cell_count=%d", scan_cellular_cell_count);
+
+	if (scan_cellular_cell_count > 1) {
 
 		ncellmeas_params.search_type = LTE_LC_NEIGHBOR_SEARCH_TYPE_GCI_EXTENDED_LIGHT;
 		ncellmeas_params.gci_count = scan_cellular_cell_count;
-
-		/* GCI count given to modem cannot be one */
-		if (ncellmeas_params.gci_count == 1) {
-			ncellmeas_params.gci_count++;
-		}
 
 		err = lte_lc_neighbor_cell_measurement(&ncellmeas_params);
 		if (err) {

--- a/lib/location/scan_cellular.h
+++ b/lib/location/scan_cellular.h
@@ -10,7 +10,7 @@
 #include <modem/lte_lc.h>
 
 int scan_cellular_init(void);
-int scan_cellular_start(struct k_sem *ncellmeas_ready);
+int scan_cellular_start(uint8_t cell_count);
 struct lte_lc_cells_info *scan_cellular_results_get(void);
 int scan_cellular_cancel(void);
 

--- a/samples/nrf9160/modem_shell/src/location/location_shell.c
+++ b/samples/nrf9160/modem_shell/src/location/location_shell.c
@@ -65,6 +65,7 @@ static const char location_get_usage_str[] =
 	"[--gnss_timeout <timeout in secs>] [--gnss_visibility]\n"
 	"[--gnss_priority] [--gnss_cloud_nmea] [--gnss_cloud_pvt]\n"
 	"[--cellular_timeout <timeout in secs>] [--cellular_service <service_string>]\n"
+	"[--cellular_cell_count <cell count>]\n"
 	"[--wifi_timeout <timeout in secs>] [--wifi_service <service_string>]\n"
 	"[--cloud_resp_disabled]\n"
 	"\n"
@@ -89,6 +90,8 @@ static const char location_get_usage_str[] =
 	"                              Zero means timeout is disabled.\n"
 	"  --cellular_service, [str]   Used cellular positioning service:\n"
 	"                              'any' (default), 'nrf' or 'here'\n"
+	"  --cellular_cell_count, [int]\n"
+	"                              Requested number of cells\n"
 	"  --wifi_timeout, [float]     Wi-Fi timeout in seconds. Zero means timeout is disabled.\n"
 	"  --wifi_service, [str]       Used Wi-Fi positioning service:\n"
 	"                              'any' (default), 'nrf' or 'here'\n"
@@ -110,6 +113,7 @@ enum {
 	LOCATION_SHELL_OPT_GNSS_LOC_CLOUD_PVT,
 	LOCATION_SHELL_OPT_CELLULAR_TIMEOUT,
 	LOCATION_SHELL_OPT_CELLULAR_SERVICE,
+	LOCATION_SHELL_OPT_CELLULAR_CELL_COUNT,
 	LOCATION_SHELL_OPT_CLOUD_RESP_DISABLED,
 	LOCATION_SHELL_OPT_WIFI_TIMEOUT,
 	LOCATION_SHELL_OPT_WIFI_SERVICE,
@@ -130,6 +134,7 @@ static struct option long_options[] = {
 	{ "gnss_cloud_pvt", no_argument, 0, LOCATION_SHELL_OPT_GNSS_LOC_CLOUD_PVT },
 	{ "cellular_timeout", required_argument, 0, LOCATION_SHELL_OPT_CELLULAR_TIMEOUT },
 	{ "cellular_service", required_argument, 0, LOCATION_SHELL_OPT_CELLULAR_SERVICE },
+	{ "cellular_cell_count", required_argument, 0, LOCATION_SHELL_OPT_CELLULAR_CELL_COUNT },
 	{ "cloud_resp_disabled", no_argument, 0, LOCATION_SHELL_OPT_CLOUD_RESP_DISABLED },
 	{ "wifi_timeout", required_argument, 0, LOCATION_SHELL_OPT_WIFI_TIMEOUT },
 	{ "wifi_service", required_argument, 0, LOCATION_SHELL_OPT_WIFI_SERVICE },
@@ -392,6 +397,8 @@ int location_shell(const struct shell *shell, size_t argc, char **argv)
 	float cellular_timeout = 0;
 	bool cellular_timeout_set = false;
 	enum location_service cellular_service = LOCATION_SERVICE_ANY;
+	int cellular_cell_count = 0;
+	bool cellular_cell_count_set = false;
 
 	float wifi_timeout = 0;
 	bool wifi_timeout_set = false;
@@ -462,6 +469,10 @@ int location_shell(const struct shell *shell, size_t argc, char **argv)
 				mosh_error("Unknown cellular positioning service. See usage:");
 				goto show_usage;
 			}
+			break;
+		case LOCATION_SHELL_OPT_CELLULAR_CELL_COUNT:
+			cellular_cell_count = atoi(optarg);
+			cellular_cell_count_set = true;
 			break;
 		case LOCATION_SHELL_OPT_CLOUD_RESP_DISABLED:
 #if defined(CONFIG_LOCATION_SERVICE_EXTERNAL)
@@ -607,6 +618,9 @@ int location_shell(const struct shell *shell, size_t argc, char **argv)
 					config.methods[i].cellular.timeout =
 						(cellular_timeout == 0) ?
 						SYS_FOREVER_MS : cellular_timeout * MSEC_PER_SEC;
+				}
+				if (cellular_cell_count_set) {
+					config.methods[i].cellular.cell_count = cellular_cell_count;
 				}
 			} else if (config.methods[i].method == LOCATION_METHOD_WIFI) {
 				config.methods[i].wifi.service = wifi_service;

--- a/tests/lib/location/src/location_test.c
+++ b/tests/lib/location/src/location_test.c
@@ -48,6 +48,10 @@ static const char ncellmeas_resp[] =
 	"%NCELLMEAS:0,\"00011B07\",\"26295\",\"00B7\",2300,7,63,31,"
 	"150344527,2300,8,60,29,0,2400,11,55,26,184\r\n";
 
+static const char ncellmeas_gci_resp[] =
+	"%NCELLMEAS:0,\"00023906\",\"24405\",\"5A00\",64,1830518,6400,116,53,16,1840265,1,0,"
+	"\"001E3904\",\"24405\",\"5A00\",65535,0,6400,42,48,7,1840265,0,0\r\n";
+
 char http_resp[512];
 
 static const char http_resp_header_ok[] =
@@ -358,6 +362,8 @@ void test_location_cellular(void)
 
 	location_config_defaults_set(&config, 1, methods);
 
+	config.methods[0].cellular.cell_count = 2;
+
 	test_location_event_data.id = LOCATION_EVT_LOCATION;
 	test_location_event_data.location.latitude = 61.50375;
 	test_location_event_data.location.longitude = 23.896979;
@@ -366,7 +372,7 @@ void test_location_cellular(void)
 
 	location_callback_called_expected = true;
 
-	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS=2", 0);
 	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT+CGACT?", 0);
 	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
 	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
@@ -401,9 +407,10 @@ void test_location_cellular_cancel_during_ncellmeas(void)
 	enum location_method methods[] = {LOCATION_METHOD_CELLULAR};
 
 	location_config_defaults_set(&config, 1, methods);
+	config.methods[0].cellular.cell_count = 2;
 	location_callback_called_expected = false;
 
-	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS=2", 0);
 
 	err = location_request(&config);
 	TEST_ASSERT_EQUAL(0, err);
@@ -519,14 +526,14 @@ void test_location_request_default(void)
 
 	/***** Fallback to cellular *****/
 
-	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS=2", 0);
 	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT+CGACT?", 0);
 	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
 	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
 	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
 		(char *)cgact_resp_active, sizeof(cgact_resp_active));
 
-	cellular_rest_req_resp_handle();
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS=4,%d", 0);
 
 	/* Select cellular service to be used */
 	rest_req_ctx.url = "here.api"; /* Needs a fix once rest_req_ctx is verified */
@@ -538,10 +545,15 @@ void test_location_request_default(void)
 	 * Otherwise, lte_lc would ignore NCELLMEAS notification because no NCELLMEAS on going
 	 * from lte_lc point of view.
 	 */
-	k_sleep(K_MSEC(10000));
+	k_sleep(K_MSEC(1000));
 
 	/* Trigger NCELLMEAS response which further triggers the rest of the location calculation */
 	at_monitor_dispatch(ncellmeas_resp);
+
+	cellular_rest_req_resp_handle();
+
+	k_sleep(K_MSEC(1000));
+	at_monitor_dispatch(ncellmeas_gci_resp);
 }
 
 /* Test location request with:
@@ -559,6 +571,7 @@ void test_location_request_mode_all_cellular_gnss(void)
 	location_config_defaults_set(&config, 2, methods);
 	config.mode = LOCATION_REQ_MODE_ALL;
 	config.methods[0].cellular.timeout = SYS_FOREVER_MS;
+	config.methods[0].cellular.cell_count = 2;
 	config.methods[1].gnss.timeout = -10;
 
 	test_location_event_data.id = LOCATION_EVT_LOCATION;
@@ -570,7 +583,7 @@ void test_location_request_mode_all_cellular_gnss(void)
 
 	/***** First cellular positioning *****/
 
-	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS=2", 0);
 	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT+CGACT?", 0);
 	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
 	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
@@ -675,6 +688,7 @@ void test_location_request_timeout_cellular_gnss_mode_all(void)
 	location_config_defaults_set(&config, 2, methods);
 	config.mode = LOCATION_REQ_MODE_ALL;
 	config.methods[0].cellular.timeout = 100;
+	config.methods[0].cellular.cell_count = 2;
 	config.methods[1].gnss.timeout = 100;
 
 	test_location_event_data.id = LOCATION_EVT_TIMEOUT;
@@ -682,7 +696,7 @@ void test_location_request_timeout_cellular_gnss_mode_all(void)
 	location_callback_called_expected = true;
 
 	/***** First cellular positioning *****/
-	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS=2", 0);
 
 	err = location_request(&config);
 	TEST_ASSERT_EQUAL(0, err);
@@ -859,6 +873,7 @@ void test_location_cellular_periodic(void)
 
 	location_config_defaults_set(&config, 1, methods);
 	config.interval = 1;
+	config.methods[0].cellular.cell_count = 2;
 
 	test_location_event_data.id = LOCATION_EVT_LOCATION;
 	test_location_event_data.location.latitude = 61.50375;
@@ -868,7 +883,7 @@ void test_location_cellular_periodic(void)
 
 	location_callback_called_expected = true;
 
-	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS=2", 0);
 	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT+CGACT?", 0);
 	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
 	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
@@ -913,7 +928,7 @@ void test_location_cellular_periodic(void)
 	rest_req_ctx.port = HTTPS_PORT;
 	rest_req_ctx.host = CONFIG_LOCATION_SERVICE_HERE_HOSTNAME;
 
-	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS=2", 0);
 	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT+CGACT?", 0);
 	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
 	__cmock_nrf_modem_at_cmd_IgnoreArg_len();

--- a/tests/lib/location/src/location_test.c
+++ b/tests/lib/location/src/location_test.c
@@ -49,8 +49,8 @@ static const char ncellmeas_resp[] =
 	"150344527,2300,8,60,29,0,2400,11,55,26,184\r\n";
 
 static const char ncellmeas_gci_resp[] =
-	"%NCELLMEAS:0,\"00023906\",\"24405\",\"5A00\",64,1830518,6400,116,53,16,1840265,1,0,"
-	"\"001E3904\",\"24405\",\"5A00\",65535,0,6400,42,48,7,1840265,0,0\r\n";
+	"%NCELLMEAS:0,\"00011B07\",\"26295\",\"00B7\",10512,9034,2300,7,63,31,150344527,1,0,"
+	"\"00011B08\",\"26295\",\"00B7\",65535,0,2300,9,62,30,150345527,0,0\r\n";
 
 char http_resp[512];
 
@@ -545,14 +545,14 @@ void test_location_request_default(void)
 	 * Otherwise, lte_lc would ignore NCELLMEAS notification because no NCELLMEAS on going
 	 * from lte_lc point of view.
 	 */
-	k_sleep(K_MSEC(1000));
+	k_sleep(K_MSEC(100));
 
 	/* Trigger NCELLMEAS response which further triggers the rest of the location calculation */
 	at_monitor_dispatch(ncellmeas_resp);
 
 	cellular_rest_req_resp_handle();
 
-	k_sleep(K_MSEC(1000));
+	k_sleep(K_MSEC(100));
 	at_monitor_dispatch(ncellmeas_gci_resp);
 }
 

--- a/tests/lib/lte_lc_api/src/lte_lc_api_test.c
+++ b/tests/lib/lte_lc_api/src/lte_lc_api_test.c
@@ -975,6 +975,22 @@ void test_lte_lc_cereg(void)
 	at_monitor_dispatch(at_notif);
 }
 
+/* Test failing neighbor cell measurement first to see that the semaphore is given properly */
+void test_lte_lc_neighbor_cell_measurement_fail(void)
+{
+	int ret;
+
+	struct lte_lc_ncellmeas_params params = {
+		.search_type = LTE_LC_NEIGHBOR_SEARCH_TYPE_EXTENDED_COMPLETE,
+		.gci_count = 0,
+	};
+
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS=2", -NRF_ENOMEM);
+
+	ret = lte_lc_neighbor_cell_measurement(&params);
+	TEST_ASSERT_EQUAL(-EFAULT, ret);
+}
+
 void test_lte_lc_neighbor_cell_measurement_neighbors(void)
 {
 	int ret;


### PR DESCRIPTION
Support added for GCI (surrounding) cells in cellular positioning. `NCELLMEAS=2` is used by default. If we don’t find X cells, do `NCELLMEAS=4,Y`, where `Y=5-X`.

X is requested cell count and run-time configurable through `cell_count` member of `struct location_cellular_config` and build time configurable through `CONFIG_LOCATION_REQUEST_DEFAULT_CELLULAR_CELL_COUNT`.

Cellular timeout will change to apply only for NCELLMEAS operation ignoring the cloud communication. Same change for Wi-Fi timeout.

GCI search can be disabled completely by setting `CONFIG_LOCATION_REQUEST_DEFAULT_CELLULAR_CELL_COUNT=0`

Jira: NCSDK-21877