### PR TITLE
doc: emds: document formula for time estimation

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -543,3 +543,7 @@ Added:
 * A page on :ref:`ug_wireless_coexistence` in :ref:`protocols`.
 * Pages on :ref:`thread_device_types` and :ref:`thread_sed_ssed` to the :ref:`ug_thread` documentation.
 * A new section :ref:`ug_pmic`, containing :ref:`ug_npm1300_features` and :ref:`ug_npm1300_gs`.
+
+Updated:
+
+* The :ref:`emds_readme` library documentation with :ref:`emds_readme_application_integration` section about the formula used to compute the required storage time at shutdown in a worst case scenario.

--- a/samples/bluetooth/mesh/light_ctrl/README.rst
+++ b/samples/bluetooth/mesh/light_ctrl/README.rst
@@ -171,8 +171,10 @@ FEM support
 Emergency data storage
 ======================
 
-To build this sample with support for emergency data storage, set ``OVERLAY_CONFIG`` to :file:`overlay-emds.conf`.
+To build this sample with support for emergency data storage (EMDS), set ``OVERLAY_CONFIG`` to :file:`overlay-emds.conf`.
 This will save replay protection list (RPL) data and some of the :ref:`bt_mesh_lightness_srv_readme` data to the emergency data storage instead of to the :ref:`settings_api`.
+When using EMDS, certain considerations need to be taken regarding hardware choices in your application design.
+See :ref:`emds_readme_application_integration` in the EMDS documentation for more information.
 
 See :ref:`cmake_options` for instructions on how to add this option.
 For more information about using configuration overlay files, see :ref:`zephyr:important-build-vars` in the Zephyr documentation.

--- a/subsys/emds/emds_flash.c
+++ b/subsys/emds/emds_flash.c
@@ -426,6 +426,7 @@ int emds_flash_init(struct emds_fs *fs)
 
 	k_mutex_lock(&fs->emds_lock, K_FOREVER);
 	fs->ate_size = align_size(fs, sizeof(struct emds_ate));
+	__ASSERT(fs->ate_size == 8, "ATE size not aligned with documented value");
 	rc = ate_last_recover(fs);
 	k_mutex_unlock(&fs->emds_lock);
 	if (rc) {


### PR DESCRIPTION
This adds documentation of the formula used to compute the required storage time at shutdown in the worst-case.