### PR TITLE
manifest: sdk-zephyr: Pull added OpenThread.io vendor prefix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 5385c25be98b6812b765d9ce90e3b2f8a03c5bf1
+      revision: pull/1213/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Added OpenThread.io vendor prefix to enable
`openthread,config` dts binding for additional OpenThread configurations.

Signed-off-by: Maciej Baczmanski <maciej.baczmanski@nordicsemi.no>