### PR TITLE
manifest: Update nrfxlib with possibility to split mpsl and fem

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -140,7 +140,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: ef2b4998af6278f10305a7e0eea9890fd244c3a0
+      revision: bb42c9c169177ff96b5f5b055b6c087679bfdcd3
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Update nrfxlib revision to allow using mpsl and fem as separate libraries.