### PR TITLE
bluetooth: hids: Increase max HID report map size from 255 to 512 bytes

### DIFF
--- a/include/bluetooth/services/hids.h
+++ b/include/bluetooth/services/hids.h
@@ -340,7 +340,7 @@ struct bt_hids_rep_map {
 	uint8_t const *data;
 
 	/** Size of the map. */
-	uint8_t size;
+	uint16_t size;
 };
 
 /** @brief HID Protocol Mode event handler.

--- a/subsys/bluetooth/services/hids.c
+++ b/subsys/bluetooth/services/hids.c
@@ -14,6 +14,7 @@
 
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/att.h>
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/uuid.h>
@@ -878,6 +879,11 @@ int bt_hids_init(struct bt_hids *hids_obj,
 		 const struct bt_hids_init_param *init_param)
 {
 	LOG_DBG("Initializing HIDS.");
+
+	if (init_param->rep_map.size > BT_ATT_MAX_ATTRIBUTE_LEN) {
+		LOG_WRN("Report map size exceeds max ATT attribute length");
+		return -EMSGSIZE;
+	}
 
 	hids_obj->pm.evt_handler = init_param->pm_evt_handler;
 	hids_obj->cp.evt_handler = init_param->cp_evt_handler;


### PR DESCRIPTION
In the bluetooth HID service, the size of a report descriptor is held by a uint8_t, which means that any report descriptors can only have 255 bytes at most. However, the maximum report descriptor size is actually given by the maximum GATT attribute length, which is 512 bytes. This commit replaces the uint8_t for a uint16_t and adds an assertion that enforces the limit set by the Bluetooth specification.