### PR TITLE
manifest: bootloader: mcuboot: Fix wrong use of if defined

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -127,7 +127,7 @@ manifest:
           compare-by-default: false
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 4e84f31172c5120bb9d300603d28ff2759d7b640
+      revision: 823fd369c1430b50d263ccd6fbcf98bdd44001ba
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR.git


### PR DESCRIPTION
The file nrf_cleanup.c has
#if defined(USE_PARTITION_MANAGER)
Which is true even if USE_PARTITION_MANAGER=n.
This must be changed to "#if USE_PARTITION_MANAGER" for correct behaviour.

Ref: NCSIDB-987