### PR TITLE
doc: changelog: add Bluetooth `hci_err.h` note

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -83,8 +83,12 @@ See `Samples`_ for lists of changes for the protocol-related samples.
 
 Bluetooth® LE
 -------------
+* Updated the Bluetooth HCI headers.
+  The ``hci.h`` header now contains only the function prototypes, and the new
+  ``hci_types.h`` header defines all HCI-related macros and structs.
 
-|no_changes_yet_note|
+  The previous ``hci_err.h`` header has been merged into the new ``hci_types.h`` header.
+  This can break builds that were directly including ``hci_err.h``.
 
 Bluetooth mesh
 --------------


### PR DESCRIPTION
This might break customers' builds if they include `hci_err.h` directly.

Builds that include `hci.h` will be fine, as it includes the new `hci_types.h`.

Changed in upstream PR:
https://github.com/zephyrproject-rtos/zephyr/pull/59072