### PR TITLE
net: l2_wifi_if_conn: Fix cmake warning

### DIFF
--- a/subsys/net/CMakeLists.txt
+++ b/subsys/net/CMakeLists.txt
@@ -5,4 +5,4 @@
 #
 
 add_subdirectory(lib)
-add_subdirectory(l2_wifi_if_conn)
+add_subdirectory_ifdef(CONFIG_L2_WIFI_CONNECTIVITY l2_wifi_if_conn)

--- a/subsys/net/l2_wifi_if_conn/CMakeLists.txt
+++ b/subsys/net/l2_wifi_if_conn/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 
 zephyr_library()
-zephyr_library_sources_ifdef(CONFIG_L2_WIFI_CONNECTIVITY l2_wifi_conn.c)
+zephyr_library_sources(l2_wifi_conn.c)
 
 zephyr_library_include_directories(
     ${ZEPHYR_BASE}/include


### PR DESCRIPTION
Fixes a cmake warning being emitted when the Kconfig is not enabled by moving the check up a directory.