### PR TITLE
Bluetooth: remove direct include of `hci_err.h`

### DIFF
--- a/subsys/bluetooth/controller/ecdh.c
+++ b/subsys/bluetooth/controller/ecdh.c
@@ -11,7 +11,6 @@
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/buf.h>
-#include <zephyr/bluetooth/hci_err.h>
 #include <zephyr/drivers/bluetooth/hci_driver.h>
 
 #include <mpsl/mpsl_work.h>

--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/bluetooth/hci.h>
-#include <zephyr/bluetooth/hci_err.h>
 #include <zephyr/bluetooth/buf.h>
 #include <zephyr/sys/byteorder.h>
 #include <sdc_hci.h>


### PR DESCRIPTION
It is already included by `hci.h` and has been removed in upstream: https://github.com/zephyrproject-rtos/zephyr/pull/59072