### PR TITLE
nrf_security: Remove help text about only Oberon PSA core support

### DIFF
--- a/subsys/nrf_security/src/drivers/nrf_cc3xx_platform/Kconfig
+++ b/subsys/nrf_security/src/drivers/nrf_cc3xx_platform/Kconfig
@@ -9,8 +9,6 @@ config PSA_CRYPTO_DRIVER_ALG_PRNG_CC3XX_PLATFORM
 	default y
 	depends on CRYPTOCELL_USABLE
 	depends on PSA_WANT_GENERATE_RANDOM
-	help
-	  Only Oberon PSA core supports generate random through driver interface.
 
 config PSA_CRYPTO_DRIVER_ALG_CTR_DRBG_CC3XX_PLATFORM
 	bool

--- a/subsys/nrf_security/src/drivers/nrf_oberon/Kconfig
+++ b/subsys/nrf_security/src/drivers/nrf_oberon/Kconfig
@@ -52,8 +52,6 @@ config PSA_CRYPTO_DRIVER_HAS_KDF_SUPPORT_OBERON
 	depends on PSA_CRYPTO_DRIVER_ALG_HKDF_OBERON || \
 		   PSA_CRYPTO_DRIVER_ALG_TLS12_PRF_OBERON || \
 		   PSA_CRYPTO_DRIVER_ALG_TLS12_PSK_TO_MS_OBERON
-	help
-	  Only Oberon PSA core supports Key Derivation through driver interface.
 
 config PSA_CRYPTO_DRIVER_HAS_ASYM_ENCRYPT_SUPPORT_OBERON
 	bool
@@ -107,8 +105,6 @@ config PSA_CRYPTO_DRIVER_ALG_PRNG_OBERON
 	default y
 	depends on !PSA_CRYPTO_DRIVER_ALG_PRNG_CC3XX_PLATFORM
 	depends on PSA_WANT_GENERATE_RANDOM
-	help
-	  Only Oberon PSA core supports generate random through driver interface.
 
 config PSA_CRYPTO_DRIVER_ALG_CTR_DRBG_OBERON
 	bool

--- a/subsys/nrf_security/src/drivers/zephyr/Kconfig
+++ b/subsys/nrf_security/src/drivers/zephyr/Kconfig
@@ -9,5 +9,3 @@ config PSA_CRYPTO_DRIVER_ENTROPY_ZEPHYR
 	default y
 	depends on !PSA_CRYPTO_DRIVER_ALG_PRNG_CC3XX_PLATFORM
 	depends on PSA_WANT_GENERATE_RANDOM
-	help
-	  Only Oberon PSA core supports entropy through driver interface.


### PR DESCRIPTION
Remove help text about only Oberon PSA core support. With Mbed TLS builtin PSA core support removed there is no longer a need to document this support limitation.