### PR TITLE
manifest: sdk-zephyr: Pull fix for PS timeout data type

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: e405279d21343b0845242416cc306ad580bb3ba5
+      revision: 8f601c9e1b4eecee1ae76b9b897e8d85a0fa0b18
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Fixes the sign of the data type for PS timeout.