### PR TITLE
drivers: wifi: Rejig flow handling

### DIFF
--- a/drivers/wifi/nrf700x/zephyr/inc/zephyr_fmac_main.h
+++ b/drivers/wifi/nrf700x/zephyr/inc/zephyr_fmac_main.h
@@ -60,10 +60,8 @@ struct wifi_nrf_vif_ctx_zep {
 #ifdef CONFIG_WPA_SUPP
 	struct zep_wpa_supp_dev_callbk_fns supp_callbk_fns;
 #endif /* CONFIG_WPA_SUPP */
-	/* Used to store the negotiated twt flow id
-	 * for "twt_teardown_all" command.
-	 */
-	unsigned char neg_twt_flow_id;
+	unsigned char twt_flows_map;
+	unsigned char twt_flow_in_progress_map;
 #ifdef CONFIG_NET_STATISTICS_ETHERNET
 	struct net_stats_eth eth_stats;
 #endif /* CONFIG_NET_STATISTICS_ETHERNET */
@@ -78,7 +76,6 @@ struct wifi_nrf_vif_ctx_zep {
 		unsigned int ext_capa_len;
 	} iface_ext_capa;
 	bool cookie_resp_received;
-	bool twt_in_progress;
 	struct k_work wifi_nrf_net_iface_work;
 };
 

--- a/drivers/wifi/nrf700x/zephyr/inc/zephyr_wifi_mgmt.h
+++ b/drivers/wifi/nrf700x/zephyr/inc/zephyr_wifi_mgmt.h
@@ -50,6 +50,9 @@ void wifi_nrf_event_proc_twt_sleep_zep(void *vif_ctx,
 		struct nrf_wifi_umac_event_twt_sleep *twt_sleep_info,
 		unsigned int event_len);
 
+int wifi_nrf_twt_teardown_flows(struct wifi_nrf_vif_ctx_zep *vif_ctx_zep,
+		unsigned char start_flow_id, unsigned char end_flow_id);
+
 int wifi_nrf_get_power_save_config(const struct device *dev,
 		struct wifi_ps_config *ps_config);
 

--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_wpa_supp_if.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_wpa_supp_if.c
@@ -14,6 +14,7 @@
 #include <zephyr/logging/log.h>
 
 #include "zephyr_fmac_main.h"
+#include "zephyr_wifi_mgmt.h"
 #include "zephyr_wpa_supp_if.h"
 
 LOG_MODULE_DECLARE(wifi_nrf, CONFIG_WIFI_LOG_LEVEL);
@@ -427,6 +428,8 @@ void wifi_nrf_wpa_supp_event_proc_disassoc(void *if_priv,
 	if (vif_ctx_zep->supp_drv_if_ctx && vif_ctx_zep->supp_callbk_fns.disassoc)	{
 		vif_ctx_zep->supp_callbk_fns.disassoc(vif_ctx_zep->supp_drv_if_ctx, &event);
 	}
+
+	(void) wifi_nrf_twt_teardown_flows(vif_ctx_zep, 0, NRF_WIFI_MAX_TWT_FLOWS);
 }
 
 void *wifi_nrf_wpa_supp_dev_init(void *supp_drv_if_ctx, const char *iface_name,
@@ -634,7 +637,7 @@ int wifi_nrf_wpa_supp_deauthenticate(void *if_priv, const char *addr, unsigned s
 		goto out;
 	}
 
-	ret = 0;
+	ret = wifi_nrf_twt_teardown_flows(vif_ctx_zep, 0, NRF_WIFI_MAX_TWT_FLOWS);
 out:
 	return ret;
 }

--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 890edab701c076b8f8ded3cf2197179a75679ad2
+      revision: e405279d21343b0845242416cc306ad580bb3ba5
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
TWT flows ID should be used for easier flow management, so, use a bit map based flow ID and in progress detection. This enabled us to work with multiple flows (when supported in the feature).

Fixes SHEL-1719.