### PR TITLE
manifest: sdk-hostap: Pull hostap fix to display correct security

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -110,7 +110,7 @@ manifest:
     - name: hostap
       repo-path: sdk-hostap
       path: modules/lib/hostap
-      revision: ad60a475e4e71a1f6228e7c0c00602906991db2d
+      revision: 8093a8d4809e030fc63451cc378e65cdd424148a
       userdata:
         ncs:
           upstream-url: https://w1.fi/cgit/hostap/


### PR DESCRIPTION
Pull hostap fix for displaying correct security mode in status.