### PR TITLE
backport: tools: Update toolchain script

### DIFF
--- a/scripts/print_toolchain_checksum.sh
+++ b/scripts/print_toolchain_checksum.sh
@@ -2,7 +2,7 @@
 
 BASEDIR=$(dirname "$0")
 REQUIREMENTS=$BASEDIR/requirements-fixed.txt
-TOOLS_VERSIONS=$BASEDIR/tools-versions-linux.txt
+TOOLS_VERSIONS=$BASEDIR/tools-versions-linux.yml
 TOOLCHAIN_VERSION=$(cat $REQUIREMENTS $TOOLS_VERSIONS | sha256sum | head -c 10)
 
 echo "${TOOLCHAIN_VERSION}"


### PR DESCRIPTION
tools*.txt file was replaced by tools*.yaml. 

With this print_toolchain_checksum.sh and print_docker_image.sh give the correct information used in the CI and in VSCode.