### PR TITLE
samples: bluetooth: mesh: dfu: Add DFU srv shell cmds for cancelling dfu

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -206,6 +206,10 @@ Bluetooth mesh samples
 
   * Fixed an issue with the sample not fitting into RAM size on the nrf52dk_nrf52832 board.
 
+* :ref:`ble_mesh_dfu_target` sample:
+
+  * Enabled Firmware Update Server shell commands allowing users to cancel DFU on the Target node.
+
 Cryptography samples
 --------------------
 

--- a/samples/bluetooth/mesh/dfu/target/README.rst
+++ b/samples/bluetooth/mesh/dfu/target/README.rst
@@ -181,6 +181,13 @@ The firmware distribution process then succeeds on the Distributor side, if the 
 
 For more information about the firmware distribution process, see :ref:`zephyr:bluetooth_mesh_dfu`.
 
+Interacting with the sample through shell
+-----------------------------------------
+
+This sample enables the Firmware Update Server model shell commands using the :kconfig:option:`CONFIG_BT_MESH_SHELL_DFU_SRV` Kconfig option.
+This allows cancelling of an ongoing DFU transfer using the ``mesh models dfu srv rx-cancel`` shell command, if the ongoing DFU transfer gets stalled.
+See :ref:`bluetooth_mesh_shell` for information about Bluetooth mesh shell commands.
+
 Logging
 =======
 

--- a/samples/bluetooth/mesh/dfu/target/prj.conf
+++ b/samples/bluetooth/mesh/dfu/target/prj.conf
@@ -65,6 +65,19 @@ CONFIG_BT_MESH_DFU_SRV=y
 CONFIG_BT_MESH_DFU_METADATA=y
 CONFIG_BT_MESH_SAR_CFG_SRV=y
 
+# Enable DFU Server shell commands to let user cancel DFU from shell
+CONFIG_BT_MESH_SHELL=y
+CONFIG_BT_MESH_SHELL_DFU_SRV=y
+# Disable other shell commands that get enabled automatically
+CONFIG_BT_MESH_SHELL_BLOB_IO_FLASH=n
+CONFIG_BT_MESH_SHELL_BLOB_SRV=n
+CONFIG_BT_MESH_SHELL_DFU_METADATA=n
+CONFIG_BT_MESH_SHELL_GATT_PROXY=n
+CONFIG_BT_MESH_SHELL_TEST=n
+CONFIG_BT_MESH_SHELL_PROV=n
+# Flash shell module uses 8k of RAM for testing buffers, disable to save RAM
+CONFIG_FLASH_SHELL=n
+
 # Reconfigure transport SAR for DFU
 # Increase probability of delivering segmented messages
 CONFIG_BT_MESH_SAR_TX_UNICAST_RETRANS_COUNT=0x5


### PR DESCRIPTION
It is possible that DFU Client and DFU Server states get desynchronized and cancelling DFU procedure from DFU Client using mesh dfd-cancel message is not possible. When running dfu target sample, it may get stuck in phase 2 and won't let to start a new DFU procedure.

This commit enables DFU server shell commands in the target sample to let a user cancel the ongoing DFU procedure.