### PR TITLE
tests: edge_impulse increase timeout

### DIFF
--- a/tests/lib/edge_impulse/testcase.yaml
+++ b/tests/lib/edge_impulse/testcase.yaml
@@ -7,3 +7,4 @@ tests:
       - nrf9160dk_nrf9160_ns
       - qemu_cortex_m3
     tags: edge_impulse
+    timeout: 420


### PR DESCRIPTION
shuffling tests are running much longer than before