### PR TITLE
manifest: Remove tinycbor

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -96,7 +96,6 @@ manifest:
           - picolibc
           - psa-arch-tests
           - segger
-          - tinycbor
           - tinycrypt
           - tf-m-tests
           - uoscore-uedhoc


### PR DESCRIPTION
tinycbor was removed from the upstream zephyr manifest a long time ago, therefore remove it from the ncs manifest import.