### PR TITLE
lib: at_host: Use zephyr LOG for outgoing modem responses

### DIFF
--- a/lib/at_host/at_host.c
+++ b/lib/at_host/at_host.c
@@ -48,6 +48,11 @@ static struct k_work cmd_send_work;
 
 static inline void write_uart_string(const char *str)
 {
+	if (IS_ENABLED(CONFIG_LOG_BACKEND_UART)) {
+		LOG_RAW("%s", str);
+		return;
+	}
+
 	/* Send characters until, but not including, null */
 	for (size_t i = 0; str[i]; i++) {
 		uart_poll_out(uart_dev, str[i]);


### PR DESCRIPTION
Use zephyr LOG for outgoing modem responses.
This ensures that responses received the modem are scheduled in turn by the zephyr logging system.

Previously these logs could cut zephyr LOG output because its pushed directly on UART. This lead to tests failing because the expected output was corrupted by these modem responses.