### PR TITLE
samples: Bluetooth: df: Add postfix in sample.yaml to remove duplicates

### DIFF
--- a/samples/bluetooth/direction_finding_central/sample.yaml
+++ b/samples/bluetooth/direction_finding_central/sample.yaml
@@ -2,20 +2,20 @@ sample:
   name: Direction Finding Central
   description: Sample application showing central role of Direction Finding in connected mode
 tests:
-  sample.bluetooth.direction_finding_central:
+  sample.bluetooth.direction_finding_central_nrf:
     build_only: true
     platform_allow: nrf52833dk_nrf52833 nrf52833dk_nrf52820 nrf5340dk_nrf5340_cpuapp
     tags: bluetooth
     integration_platforms:
-        - nrf52833dk_nrf52833
-        - nrf52833dk_nrf52820
-        - nrf5340dk_nrf5340_cpuapp
-  sample.bluetooth.direction_finding_central.aod:
+      - nrf52833dk_nrf52833
+      - nrf52833dk_nrf52820
+      - nrf5340dk_nrf5340_cpuapp
+  sample.bluetooth.direction_finding_central_nrf.aod:
     extra_args: OVERLAY_CONFIG="overlay-aod.conf"
     build_only: true
     platform_allow: nrf52833dk_nrf52833 nrf52833dk_nrf52820 nrf5340dk_nrf5340_cpuapp
     tags: bluetooth
     integration_platforms:
-        - nrf52833dk_nrf52833
-        - nrf52833dk_nrf52820
-        - nrf5340dk_nrf5340_cpuapp
+      - nrf52833dk_nrf52833
+      - nrf52833dk_nrf52820
+      - nrf5340dk_nrf5340_cpuapp

--- a/samples/bluetooth/direction_finding_connectionless_rx/sample.yaml
+++ b/samples/bluetooth/direction_finding_connectionless_rx/sample.yaml
@@ -2,20 +2,20 @@ sample:
   name: Direction Finding Connectionless Locator
   description: Sample application showing connectionless Direction Finding reception
 tests:
-  sample.bluetooth.direction_finding_connectionless_rx:
+  sample.bluetooth.direction_finding_connectionless_rx_nrf:
     build_only: true
     platform_allow: nrf52833dk_nrf52833 nrf52833dk_nrf52820 nrf5340dk_nrf5340_cpuapp
     tags: bluetooth
     integration_platforms:
-        - nrf52833dk_nrf52833
-        - nrf52833dk_nrf52820
-        - nrf5340dk_nrf5340_cpuapp
-  sample.bluetooth.direction_finding_connectionless_rx.aod:
+      - nrf52833dk_nrf52833
+      - nrf52833dk_nrf52820
+      - nrf5340dk_nrf5340_cpuapp
+  sample.bluetooth.direction_finding_connectionless_rx_nrf.aod:
     extra_args: OVERLAY_CONFIG="overlay-aod.conf"
     build_only: true
     platform_allow: nrf52833dk_nrf52833 nrf52833dk_nrf52820 nrf5340dk_nrf5340_cpuapp
     tags: bluetooth
     integration_platforms:
-        - nrf52833dk_nrf52833
-        - nrf52833dk_nrf52820
-        - nrf5340dk_nrf5340_cpuapp
+      - nrf52833dk_nrf52833
+      - nrf52833dk_nrf52820
+      - nrf5340dk_nrf5340_cpuapp

--- a/samples/bluetooth/direction_finding_connectionless_tx/sample.yaml
+++ b/samples/bluetooth/direction_finding_connectionless_tx/sample.yaml
@@ -2,20 +2,20 @@ sample:
   name: Direction Finding Connectionless Beacon
   description: Sample application showing connectionless Direction Finding transmission
 tests:
-  sample.bluetooth.direction_finding_connectionless:
+  sample.bluetooth.direction_finding_connectionless_nrf:
     build_only: true
     platform_allow: nrf52833dk_nrf52833 nrf52833dk_nrf52820 nrf5340dk_nrf5340_cpuapp
     tags: bluetooth
     integration_platforms:
-        - nrf52833dk_nrf52833
-        - nrf52833dk_nrf52820
-        - nrf5340dk_nrf5340_cpuapp
-  sample.bluetooth.direction_finding_connectionless.aoa:
+      - nrf52833dk_nrf52833
+      - nrf52833dk_nrf52820
+      - nrf5340dk_nrf5340_cpuapp
+  sample.bluetooth.direction_finding_connectionless_nrf.aoa:
     extra_args: OVERLAY_CONFIG="overlay-aoa.conf"
     build_only: true
     platform_allow: nrf52833dk_nrf52833 nrf52833dk_nrf52820 nrf5340dk_nrf5340_cpuapp
     tags: bluetooth
     integration_platforms:
-        - nrf52833dk_nrf52833
-        - nrf52833dk_nrf52820
-        - nrf5340dk_nrf5340_cpuapp
+      - nrf52833dk_nrf52833
+      - nrf52833dk_nrf52820
+      - nrf5340dk_nrf5340_cpuapp

--- a/samples/bluetooth/direction_finding_peripheral/sample.yaml
+++ b/samples/bluetooth/direction_finding_peripheral/sample.yaml
@@ -2,20 +2,20 @@ sample:
   name: Direction Finding Peripheral
   description: Sample application showing peripheral role of Direction Finding in connected mode
 tests:
-  sample.bluetooth.direction_finding_peripheral:
+  sample.bluetooth.direction_finding_peripheral_nrf:
     build_only: true
     platform_allow: nrf52833dk_nrf52833 nrf52833dk_nrf52820 nrf5340dk_nrf5340_cpuapp
     tags: bluetooth
     integration_platforms:
-        - nrf52833dk_nrf52833
-        - nrf52833dk_nrf52820
-        - nrf5340dk_nrf5340_cpuapp
-  sample.bluetooth.direction_finding_peripheral.aod:
+      - nrf52833dk_nrf52833
+      - nrf52833dk_nrf52820
+      - nrf5340dk_nrf5340_cpuapp
+  sample.bluetooth.direction_finding_peripheral_nrf.aod:
     extra_args: OVERLAY_CONFIG="overlay-aoa.conf"
     build_only: true
     platform_allow: nrf52833dk_nrf52833 nrf52833dk_nrf52820 nrf5340dk_nrf5340_cpuapp
     tags: bluetooth
     integration_platforms:
-        - nrf52833dk_nrf52833
-        - nrf52833dk_nrf52820
-        - nrf5340dk_nrf5340_cpuapp
+      - nrf52833dk_nrf52833
+      - nrf52833dk_nrf52820
+      - nrf5340dk_nrf5340_cpuapp


### PR DESCRIPTION
There is a twister run issue caused by duplication of direction finding sample names in sdk-nrf and Zephyr repositories. To remove the problem names used in sample.yaml in sdk-nrf are extended with postfix `_nrf`. That makes them unique in scope of these repositories.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>