### PR TITLE
treewide: Remove unnecessary modem dependencies related to MMSS

### DIFF
--- a/lib/location/Kconfig
+++ b/lib/location/Kconfig
@@ -6,17 +6,19 @@
 
 menuconfig LOCATION
 	bool "Location"
-	depends on NRF_MODEM_LIB
-	depends on LTE_LINK_CONTROL
 
 if LOCATION
 
 config LOCATION_METHOD_GNSS
 	bool "Allow GNSS to be used for obtaining the location"
+	depends on NRF_MODEM_LIB
+	depends on LTE_LINK_CONTROL
 	default y
 
 config LOCATION_METHOD_CELLULAR
 	bool "Allow cellular positioning to be used for obtaining the location"
+	depends on NRF_MODEM_LIB
+	depends on LTE_LINK_CONTROL
 	select CJSON_LIB if !LOCATION_SERVICE_EXTERNAL
 	default y
 

--- a/lib/location/cloud_service/cloud_service.c
+++ b/lib/location/cloud_service/cloud_service.c
@@ -10,8 +10,6 @@
 
 #include <zephyr/logging/log.h>
 #include <zephyr/net/tls_credentials.h>
-#include <modem/lte_lc.h>
-#include <modem/modem_key_mgmt.h>
 
 #include "cloud_service.h"
 #include "cloud_service_nrf.h"

--- a/lib/location/location_utils.h
+++ b/lib/location/location_utils.h
@@ -28,12 +28,15 @@ struct location_utils_modem_params_info {
 };
 
 /**
- * @brief Check if default PDN context is active.
+ * @brief Check if LTE networking is available.
  *
- * @retval true      If default PDN context is active.
- * @retval false     If default PDN context is not active.
+ * Checks for an active default PDN bearer, but does not check cell registration status,
+ * so may give false positive, but not false negative.
+ *
+ * @retval true      LTE networking is available.
+ * @retval false     LTE networking is not available.
  */
-bool location_utils_is_default_pdn_active(void);
+bool location_utils_is_lte_available(void);
 
 /**
  * @brief Read modem parameters.

--- a/lib/location/method_cloud_location.c
+++ b/lib/location/method_cloud_location.c
@@ -126,7 +126,7 @@ static void method_cloud_location_positioning_work_fn(struct k_work *work)
 		.timeout_ms = used_timeout_ms
 	};
 
-	if (!location_utils_is_default_pdn_active()) {
+	if (IS_ENABLED(CONFIG_NRF_MODEM_LIB) && !location_utils_is_lte_available()) {
 		/* Not worth to start trying to fetch the location over LTE.
 		 * Thus, fail faster in this case and save the trying "costs".
 		 */

--- a/samples/nrf9160/nrf_cloud_mqtt_multi_service/CMakeLists.txt
+++ b/samples/nrf9160/nrf_cloud_mqtt_multi_service/CMakeLists.txt
@@ -18,6 +18,12 @@ target_sources(app PRIVATE src/temperature.c)
 target_sources(app PRIVATE src/fota_support.c)
 target_sources(app PRIVATE src/led_control.c)
 target_sources(app PRIVATE src/location_tracking.c)
+
+# Include modem-specific features if supported
+if(CONFIG_NRF_MODEM_LIB)
+	target_sources(app PRIVATE src/at_commands.c)
+endif()
+
 # NORDIC SDK APP END
 
 zephyr_include_directories(src)

--- a/samples/nrf9160/nrf_cloud_mqtt_multi_service/src/at_commands.c
+++ b/samples/nrf9160/nrf_cloud_mqtt_multi_service/src/at_commands.c
@@ -1,0 +1,68 @@
+/* Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <nrf_modem_at.h>
+#include <nrf_errno.h>
+#include <modem/location.h>
+#include <cJSON.h>
+#include <stdio.h>
+
+#include "nrf_cloud_codec_internal.h"
+#include "connection.h"
+#include "at_commands.h"
+
+LOG_MODULE_REGISTER(at_cmd_execution, CONFIG_MQTT_MULTI_SERVICE_LOG_LEVEL);
+
+/* AT command request error handling */
+#define AT_CMD_REQUEST_ERR_FORMAT "Error while processing AT command request: %d"
+#define AT_CMD_REQUEST_ERR_MAX_LEN (sizeof(AT_CMD_REQUEST_ERR_FORMAT) + 20)
+BUILD_ASSERT(CONFIG_AT_CMD_REQUEST_RESPONSE_BUFFER_LENGTH >= AT_CMD_REQUEST_ERR_MAX_LEN,
+	     "Not enough AT command response buffer for printing error events.");
+
+/* Buffer to contain modem responses when performing AT command requests */
+static char at_cmd_resp_buf[CONFIG_AT_CMD_REQUEST_RESPONSE_BUFFER_LENGTH];
+
+char *execute_at_cmd_request(const char *const cmd)
+{
+	LOG_DBG("Modem AT command requested: %s", cmd);
+
+	/* Clear the response buffer */
+	memset(at_cmd_resp_buf, 0, sizeof(at_cmd_resp_buf));
+
+	/* Pass the command off to the modem.
+	 *
+	 * We must pass the command in using a format specifier it might contain special characters
+	 * such as %.
+	 *
+	 * We subtract 1 from the passed-in response buffer length to ensure that the response is
+	 * always null-terminated, even when the response is longer than the response buffer size.
+	 */
+
+	int err = nrf_modem_at_cmd(at_cmd_resp_buf, sizeof(at_cmd_resp_buf) - 1, "%s", cmd);
+
+	/* Post-process the response */
+	LOG_DBG("Modem AT command response (%d, %d): %s",
+		nrf_modem_at_err_type(err), nrf_modem_at_err(err), at_cmd_resp_buf);
+
+	/* Trim \r\n from modem response for better readability in the portal. */
+	at_cmd_resp_buf[MAX(0, strlen(at_cmd_resp_buf) - 2)] = '\0';
+
+	/* If an error occurred with the request, report it */
+	if (err < 0) {
+		/* Negative error codes indicate an error with the modem lib itself, so the
+		 * response buffer will be empty (or filled with junk). Thus, we can print the
+		 * error message directly into it.
+		 */
+		snprintf(at_cmd_resp_buf, sizeof(at_cmd_resp_buf), AT_CMD_REQUEST_ERR_FORMAT, err);
+		LOG_ERR("%s", at_cmd_resp_buf);
+	}
+
+	/* Return a pointer to the start of the command response buffer (which is now populated with
+	 * the AT command response)
+	 */
+	return &at_cmd_resp_buf[0];
+}

--- a/samples/nrf9160/nrf_cloud_mqtt_multi_service/src/at_commands.h
+++ b/samples/nrf9160/nrf_cloud_mqtt_multi_service/src/at_commands.h
@@ -1,0 +1,31 @@
+/* Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef _AT_CMD_REQUESTS_H_
+#define _AT_CMD_REQUESTS_H_
+
+/**
+ * @brief Forwards an AT command string to the modem, and returns a pointer
+ * to a buffer containing the modem's response, or a human readable error.
+ *
+ * If CONFIG_NRF_MODEM_LIB is not enabled, the function is not compiled and always
+ * returns an error string.
+ *
+ * Please note that the returned response buffer becomes unsafe to use as soon as
+ * the next AT command request is made, so be sure to copy or handle the response before performing
+ * another request.
+ *
+ * Do not modify the string in the returned response buffer.
+ *
+ * @param cmd - The AT command to execute.
+ * @return char* a pointer into a NULL-terminated buffer containing the command response.
+ */
+#if defined(CONFIG_NRF_MODEM_LIB)
+char *execute_at_cmd_request(const char *const cmd);
+#else /* CONFIG_NRF_MODEM_LIB */
+#define execute_at_cmd_request(...) "AT command requests are not supported by this build!"
+#endif /* CONFIG_NRF_MODEM_LIB */
+
+#endif /* _AT_CMD_REQUESTS_H_ */

--- a/samples/nrf9160/nrf_cloud_mqtt_multi_service/src/connection.c
+++ b/samples/nrf9160/nrf_cloud_mqtt_multi_service/src/connection.c
@@ -5,13 +5,12 @@
 
 #include <zephyr/kernel.h>
 #include <stdio.h>
-#include <modem/nrf_modem_lib.h>
-#include <modem/lte_lc.h>
 #include <zephyr/net/socket.h>
 #include <net/nrf_cloud.h>
 #include <net/nrf_cloud_codec.h>
 #include <date_time.h>
 #include <zephyr/logging/log.h>
+#include <modem/nrf_modem_lib.h>
 
 #include "connection.h"
 

--- a/samples/nrf9160/nrf_cloud_mqtt_multi_service/src/location_tracking.c
+++ b/samples/nrf9160/nrf_cloud_mqtt_multi_service/src/location_tracking.c
@@ -8,11 +8,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 #include <modem/location.h>
-#include <modem/nrf_modem_lib.h>
-#include <nrf_modem_at.h>
 #include <date_time.h>
-#include <net/nrf_cloud_agps.h>
-#include <net/nrf_cloud_pgps.h>
 
 #include "location_tracking.h"
 

--- a/samples/nrf9160/nrf_cloud_mqtt_multi_service/src/location_tracking.h
+++ b/samples/nrf9160/nrf_cloud_mqtt_multi_service/src/location_tracking.h
@@ -32,7 +32,8 @@ int start_location_tracking(location_update_cb_t handler_cb, int interval);
 static inline bool location_tracking_enabled(void)
 {
 	return IS_ENABLED(CONFIG_LOCATION_TRACKING_GNSS) ||
-	       IS_ENABLED(CONFIG_LOCATION_TRACKING_CELLULAR);
+	       IS_ENABLED(CONFIG_LOCATION_TRACKING_CELLULAR) ||
+	       IS_ENABLED(CONFIG_LOCATION_TRACKING_WIFI);
 }
 
 

--- a/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_location
+++ b/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_location
@@ -6,7 +6,5 @@
 config NRF_CLOUD_LOCATION
 	bool "Enable nRF Cloud Location (cellular and/or Wi-Fi) over MQTT"
 	imply FPU
-	depends on MODEM_INFO
-	depends on MODEM_INFO_ADD_NETWORK
 	depends on NRF_CLOUD_MQTT
 	select CJSON_LIB

--- a/tests/lib/location/CMakeLists.txt
+++ b/tests/lib/location/CMakeLists.txt
@@ -20,3 +20,9 @@ cmock_handle(${ZEPHYR_NRFXLIB_MODULE_DIR}/nrf_modem/include/nrf_modem_at.h FUNC_
 zephyr_include_directories(${ZEPHYR_NRFXLIB_MODULE_DIR}/nrf_modem/include)
 
 target_sources(app PRIVATE src/location_test.c)
+
+# Extend autoconf.h for nrf/lib/location
+# Allows KConfig options to be enabled for nrf/lib/location without affecting CMake
+# ..__nrf__lib__location is the name assigned to nrf/lib/location by the zephyr_library() macro in
+# zephyr/cmake/modules/extensions.cmake
+target_compile_options(..__nrf__lib__location PRIVATE "SHELL: -imacros ${PROJECT_SOURCE_DIR}/location_lib_autoconf_ext.h")

--- a/tests/lib/location/Kconfig
+++ b/tests/lib/location/Kconfig
@@ -4,10 +4,19 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-config LOCATION
+config LOCATION_METHOD_GNSS
 	bool "Internal"
 	#depends on NRF_MODEM_LIB
 	depends on LTE_LINK_CONTROL
+	default y
+	help
+	  Redefinition to disable modemlib requirement from the tests as we want to mock it.
+
+config LOCATION_METHOD_CELLULAR
+	bool "Internal"
+	#depends on NRF_MODEM_LIB
+	depends on LTE_LINK_CONTROL
+	select CJSON_LIB if !LOCATION_SERVICE_EXTERNAL
 	default y
 	help
 	  Redefinition to disable modemlib requirement from the tests as we want to mock it.

--- a/tests/lib/location/location_lib_autoconf_ext.h
+++ b/tests/lib/location/location_lib_autoconf_ext.h
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Cause nrf/lib/location to act as though CONFIG_NRF_MODEM_LIB is enabled, even though it isn't.
+ * (It isn't enabled because we are mocking it)
+ */
+#define CONFIG_NRF_MODEM_LIB 1


### PR DESCRIPTION
Remove various unnecessary modem dependencies that prevent building the MQTT Multi Service Sample for Wi-Fi-only targets.

IRIS-6344
IRIS-5812