### PR TITLE
drivers: wifi: QSPI HFCLK192M tuning

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -140,6 +140,7 @@ Wi-Fi
   * The :kconfig:option:`CONFIG_NRF_WIFI_IF_AUTO_START` Kconfig option to enable an application to set/unset AUTO_START on an interface.
     This can be done by using the ``NET_IF_NO_AUTO_START`` flag.
   * Support for sending TWT sleep/wake events to applications.
+  * The nRF5340 HFCLK192M clock divider is set to the default value ``Div4`` for lower power consumption when the QSPI peripheral is idle.
 
 Applications
 ============


### PR DESCRIPTION
On nRF53 Series SoCs, set the HFCLK192M clock divider to /2 when doing QSPI transactions. When the QSPI peripheral is idle, set the HFCLK192M clock divider to the default /4 setting for lower power consumption.