### PR TITLE
manifest: sdk-zephyr: Pull CoAP library update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 8f601c9e1b4eecee1ae76b9b897e8d85a0fa0b18
+      revision: pull/1221/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Use Zephyr internal zsock_ calls to remove dependency to NET_SOCKETS_POSIX_NAMES.