### PR TITLE
boards: thingy91_nrf52840: enable bt controller based on BT

### DIFF
--- a/boards/arm/thingy91_nrf52840/Kconfig.defconfig
+++ b/boards/arm/thingy91_nrf52840/Kconfig.defconfig
@@ -9,6 +9,12 @@ if BOARD_THINGY91_NRF52840
 config BOARD
 	default "thingy91_nrf52840"
 
+config BT_CTLR
+	default BT
+
+config BT_WAIT_NOP
+	default BT
+
 if USB
 
 config USB_NRFX


### PR DESCRIPTION
Enable bluetooth controller and NOP event when BT is enabled by the user.

Signed-off-by: Bartosz Bilas <b.bilas@grinn-global.com>