### PR TITLE
Find My: fixes for the next v2.4 minor releases

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: b57a7488aa3a49fe71b9a042a3d54f2d463b352b
+      revision: 75f67930b8d5616b5c0745de03b14a45fec897ac
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -184,7 +184,7 @@ manifest:
         - homekit
     - name: find-my
       repo-path: sdk-find-my
-      revision: v2.4.0
+      revision: efb1ff413902e6c80f7713f00095868d70013194
       groups:
         - find-my
     - name: azure-sdk-for-c


### PR DESCRIPTION
Updated Find My and Zephyr revision to include fixes for the v2.4.0 release of the Find My add-on for nRF Connect SDK that will be part of the next minor release.

Ref: NCSDK-22417