### PR TITLE
applications: asset_tracker_v2: Enable `FW_INFO` in MCUboot image

### DIFF
--- a/applications/asset_tracker_v2/child_image/mcuboot.conf
+++ b/applications/asset_tracker_v2/child_image/mcuboot.conf
@@ -5,4 +5,5 @@
 #
 
 # Increase the monotonic firmware version before building a firmware update
+CONFIG_FW_INFO=y
 CONFIG_FW_INFO_FIRMWARE_VERSION=1


### PR DESCRIPTION
Enable `FW_INFO` in MCUboot image to prevent build warning stating that FW info is not enabled. And to ensure that updating of the bootloader actually works due to it depending on the monotonic fw version being increased.