### PR TITLE
net: lib: nrf_cloud: allow a-gps codec functions for p-gps builds

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -394,6 +394,7 @@ Libraries for networking
   * Updated:
 
     * Moved JSON manipulation from :file:`nrf_cloud_fota.c` to :file:`nrf_cloud_codec_internal.c`.
+    * Fixed a build issue that occurred when MQTT and P-GPS are enabled and A-GPS is disabled.
 
   * Removed:
 

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec_internal.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec_internal.h
@@ -17,7 +17,7 @@
 #if defined(CONFIG_NRF_CLOUD_PGPS)
 #include <net/nrf_cloud_pgps.h>
 #endif
-#if defined(CONFIG_NRF_CLOUD_AGPS)
+#if defined(CONFIG_NRF_CLOUD_AGPS) || defined(CONFIG_NRF_CLOUD_PGPS)
 #include <net/nrf_cloud_agps.h>
 #endif
 #if defined(CONFIG_NRF_MODEM)
@@ -287,7 +287,7 @@ int nrf_cloud_modem_pvt_data_encode(const struct nrf_modem_gnss_pvt_data_frame	*
 				    cJSON * const pvt_data_obj);
 #endif
 
-#if defined(CONFIG_NRF_CLOUD_AGPS)
+#if defined(CONFIG_NRF_CLOUD_AGPS) || defined(CONFIG_NRF_CLOUD_PGPS)
 /** @brief Build A-GPS type array based on request.
  */
 int nrf_cloud_agps_type_array_get(const struct nrf_modem_gnss_agps_data_frame *const request,

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec_internal.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec_internal.c
@@ -3022,7 +3022,7 @@ int nrf_cloud_modem_pvt_data_encode(const struct nrf_modem_gnss_pvt_data_frame	*
 }
 #endif /* CONFIG_NRF_MODEM */
 
-#if defined(CONFIG_NRF_CLOUD_AGPS)
+#if defined(CONFIG_NRF_CLOUD_AGPS) || defined(CONFIG_NRF_CLOUD_PGPS)
 int nrf_cloud_agps_req_json_encode(const struct nrf_modem_gnss_agps_data_frame * const request,
 				   cJSON * const agps_req_obj_out)
 {


### PR DESCRIPTION
Fix build issue when performing an MQTT build with P-GPS enabled and A-GPS disabled.
IRIS-6520