### PR TITLE
kconfig: openthread: Increase mbedtls heap size.

### DIFF
--- a/subsys/net/openthread/Kconfig.defconfig
+++ b/subsys/net/openthread/Kconfig.defconfig
@@ -140,7 +140,7 @@ config MBEDTLS_CIPHER_MODE_XTS
 
 config MBEDTLS_HEAP_SIZE
 	int
-	default 10240
+	default 12440
 
 config OPENTHREAD_PING_SENDER
 	bool


### PR DESCRIPTION
Correct handling of x.509 certificates and/or logging from mbedtls requires heap increase.
change value from 10240KiB to 12440 KiB.