### PR TITLE
applications: asset_tracker_v2: Add case for missing event

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/lwm2m_integration/lwm2m_integration.c
+++ b/applications/asset_tracker_v2/src/cloud/lwm2m_integration/lwm2m_integration.c
@@ -158,6 +158,9 @@ static void rd_client_event(struct lwm2m_ctx *client, enum lwm2m_rd_client_event
 			state = CONNECTED;
 		}
 		break;
+	case LWM2M_RD_CLIENT_EVENT_REG_UPDATE:
+		LOG_DBG("LWM2M_RD_CLIENT_EVENT_REG_UPDATE");
+		break;
 	case LWM2M_RD_CLIENT_EVENT_DEREGISTER_FAILURE:
 		LOG_WRN("LWM2M_RD_CLIENT_EVENT_DEREGISTER_FAILURE");
 		cloud_wrap_evt.type = CLOUD_WRAP_EVT_ERROR;


### PR DESCRIPTION
Add case for missing event `LWM2M_RD_CLIENT_EVENT_REG_UPDATE` to prevent a warning stating that an unknown event is triggered.