### PR TITLE
wifi: UMAC Interface file clean up

### DIFF
--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw/host_rpu_common_if.h
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw/host_rpu_common_if.h
@@ -6,8 +6,9 @@
  */
 
 /**
+ * @file
+ * @brief Common interface between host and RPU
  *
- *@brief <Common interface between host and RPU>
  */
 #ifndef __NRF_WIFI_HOST_RPU_COMMON_IFACE_H__
 #define __NRF_WIFI_HOST_RPU_COMMON_IFACE_H__
@@ -36,36 +37,33 @@
 #define NRF_WIFI_UMAC_BOOT_EXCP_VECT_3 0x00000000
 
 /**
- * enum nrf_wifi_host_rpu_msg_type - RPU message type
- * @NRF_WIFI_HOST_RPU_MSG_TYPE_SYSTEM: Unused
- * @NRF_WIFI_HOST_RPU_MSG_TYPE_SUPPLICANT: Unused
- * @NRF_WIFI_HOST_RPU_MSG_TYPE_DATA: Data path and System messages
- * @NRF_WIFI_HOST_RPU_MSG_TYPE_UMAC: Control path messages
+ * @brief This enum defines the different categories of messages that can be exchanged between
+ *  the Host and the RPU.
  *
- * Different categories of messages that can passed between the Host and
- * the RPU.
  */
 enum nrf_wifi_host_rpu_msg_type {
-/* INIT command may send using system type */
+	/** System interface messages */
 	NRF_WIFI_HOST_RPU_MSG_TYPE_SYSTEM,
+	/** Unused */
 	NRF_WIFI_HOST_RPU_MSG_TYPE_SUPPLICANT,
+	/** Data path messages */
 	NRF_WIFI_HOST_RPU_MSG_TYPE_DATA,
+	/** Control path messages */
 	NRF_WIFI_HOST_RPU_MSG_TYPE_UMAC
 };
 /**
- * struct host_rpu_msg - Message header for HOST-RPU interaction
- * @hdr: Message header
- * @type: Type of the RPU message
- * @msg: Actual message
+ * @brief This structure defines the common message header used to encapsulate each message
+ *  exchanged between the Host and UMAC.
  *
- * The common message header that encapsulates each message passed between the
- * Host and UMAC.
  */
 
 struct host_rpu_msg {
+	/** Header */
 	struct host_rpu_msg_hdr hdr;
+	/** Type of the RPU message see &enum nrf_wifi_host_rpu_msg_type */
 	signed int type;
-	signed char msg[0]; /* actual message */
+	/** Actual message */
+	signed char msg[0];
 } __NRF_WIFI_PKD;
 
 #define NRF_WIFI_PENDING_FRAMES_BITMAP_AC_VO (1 << 0)
@@ -74,30 +72,50 @@ struct host_rpu_msg {
 #define NRF_WIFI_PENDING_FRAMES_BITMAP_AC_BK (1 << 3)
 
 /**
- * struct sta_pend_frames_bitmap - STA pending frames bitmap in SoftAP power save mode.
- * @mac_addr: STA MAC address
- * @pend_frames_bitmap: Pending frames bitmap for each access category
+ * @brief This structure represents the bitmap of STA (Station) pending frames in
+ *  SoftAP power save mode.
+ *
  */
 
 struct sap_pend_frames_bitmap {
+	/** STA MAC address */
 	unsigned char mac_addr[6];
+	/** Pending frames bitmap for each access category */
 	unsigned char pend_frames_bitmap;
 } __NRF_WIFI_PKD;
 
+/**
+ * @brief This structure represents the information related to UMAC.
+ *
+ */
 struct host_rpu_umac_info {
+	/** Boot status signature */
 	unsigned int boot_status;
+	/** UMAC version */
 	unsigned int version;
+	/** @ref sap_pend_frames_bitmap */
 	struct sap_pend_frames_bitmap sap_bitmap[4];
+	/** Hardware queues info &enum host_rpu_hpqm_info */
 	struct host_rpu_hpqm_info hpqm_info;
+	/** OTP params */
 	unsigned int info_part;
+	/** OTP params */
 	unsigned int info_variant;
+	/** OTP params */
 	unsigned int info_lromversion;
+	/** OTP params */
 	unsigned int info_uromversion;
+	/** OTP params */
 	unsigned int info_uuid[4];
+	/** OTP params */
 	unsigned int info_spare0;
+	/** OTP params */
 	unsigned int info_spare1;
+	/** OTP params */
 	unsigned int mac_address0[2];
+	/** OTP params */
 	unsigned int mac_address1[2];
+	/** OTP params */
 	unsigned int calib[9];
 } __NRF_WIFI_PKD;
 #endif /* __NRF_WIFI_HOST_RPU_IFACE_H__ */

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw/host_rpu_data_if.h
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw/host_rpu_data_if.h
@@ -77,57 +77,7 @@ struct nrf_wifi_umac_head {
 
 } __NRF_WIFI_PKD;
 
-/**
- * struct nrf_wifi_packet_info - Data packet frame pointers.
- * @head: Pointer to the start of headroom.
- * @data: Potiner to the start of data/actual frame data.
- * @tail: End of frame data.
- * @end: End of tailroom.
- *
- */
 
-struct nrf_wifi_packet_info {
-	unsigned int head;
-	unsigned int data;
-	unsigned int tail;
-	unsigned int end;
-} __NRF_WIFI_PKD;
-
-/**
- * struct nrf_wifi_mgmt_buff_config - Configure management buffers.
- * @umac_head: UMAC cmd header, See &struct nrf_wifi_umac_hdr.
- * @num_mgmt_bufs: Number of Mgmt buffers to be configured.
- * @ddr_ptrs: Management DDR buffer pointers.
- *
- * Management buffers once programmed will be used internally by UMAC.
- */
-
-struct nrf_wifi_mgmt_buff_config {
-	struct nrf_wifi_umac_head umac_head;
-	unsigned int num_mgmt_bufs;
-	unsigned int ddr_ptrs[MAX_MGMT_BUFS];
-} __NRF_WIFI_PKD;
-
-/**
- * HEADER_FILL_FLAGS - mac80211 header filled information.
- * @FC_POPULATED: Frame Control field is populated by Host Driver.
- * @DUR_POPULATED: Duration field is populated by Host Driver.
- * @ADDR1_POPULATED: Address 1 field is populated by Host Driver.
- * @ADDR2_POPULATED: Address 2 field is populated by Host Driver.
- * @ADDR3_POPULATED: Address 3 field is populated by Host Driver.
- * @SEQ_CTRL_POPULATED: Sequence Control field is populated by Host Driver.
- * @QOS_CTRL_POPULATED: Qos field is populated by Host Driver.
- *
- */
-enum HEADER_FILL_FLAGS {
-	FC_POPULATED	=	0x00000001 << 1,
-	DUR_POPULATED	=	0x00000001 << 2,
-	ADDR1_POPULATED =	0x00000001 << 3,
-	ADDR2_POPULATED =	0x00000001 << 4,
-	ADDR3_POPULATED =	0x00000001 << 5,
-	SEQ_CTRL_POPULATED =	0x00000001 << 6,
-	QOS_CTRL_POPULATED =	0x00000001 << 7,
-};
 
 /**
  * struct tx_mac_hdr_info - Tx mac80211 header information.

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw/host_rpu_data_if.h
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw/host_rpu_data_if.h
@@ -6,9 +6,10 @@
  */
 
 /**
- *
- *@brief <Data interface between host and RPU>
+ * @file
+ * @brief Data interface between host and RPU
  */
+
 #ifndef __HOST_RPU_DATA_IF_H__
 #define __HOST_RPU_DATA_IF_H__
 
@@ -20,258 +21,239 @@
 #define NRF_WIFI_ETH_ADDR_LEN 6
 #define TX_BUF_HEADROOM 52
 
-/*
- * -------------------------------------------------------------
- * | host_rpu_msg | cmd1 | cmd2 | cmd2 |...................... |
- * -------------------------------------------------------------
- * host_rpu_msg.msg_len should contains total length of all commands
- */
-
 /**
- * enum nrf_wifi_umac_data_commands - UMAC init and data buffer command/events
- *
- * @NRF_WIFI_CMD_MGMT_BUFF_CONFIG: Configure MGMT frame buffer.
- *	See &struct nrf_wifi_rx_buff_config
- * @NRF_WIFI_CMD_TX_BUFF: Transmit data packet.
- *	See &struct nrf_wifi_tx_buff
- * @NRF_WIFI_CMD_TX_BUFF_DONE: TX done event.
- *	See &struct nrf_wifi_tx_buff_done
- * @NRF_WIFI_CMD_RX_BUFF: RX data event.
- *	See &struct nrf_wifi_rx_buff
- * @NRF_WIFI_CMD_CARRIER_ON: STA connection complete event.
- *	See &struct nrf_wifi_data_carrier_state
- * @NRF_WIFI_CMD_CARRIER_OFF: STA disconnected event.
- *	See &struct nrf_wifi_data_carrier_state
- * @NRF_WIFI_CMD_PM_MODE: SoftAP client power save event.
- *	See &struct nrf_wifi_sap_client_pwrsave
- * @NRF_WIFI_CMD_PS_GET_FRAMES: SoftAP client PS get frames event.
- *	See &struct nrf_wifi_sap_ps_get_frames
+ * @brief UMAC data interface commands and events.
  *
  */
 enum nrf_wifi_umac_data_commands {
+	/** Unused. */
 	NRF_WIFI_CMD_MGMT_BUFF_CONFIG,
-	/* host uses NRF_WIFI_CMD_TX_BUFF to give tx packet to RPU */
+	/** Transmit data packet @ref nrf_wifi_tx_buff */
 	NRF_WIFI_CMD_TX_BUFF,
-	/* RPU sends tx status to the host using NRF_WIFI_CMD_TX_BUFF_DONE */
+	/** TX done event @ref nrf_wifi_tx_buff_done */
 	NRF_WIFI_CMD_TX_BUFF_DONE,
-	/* RPU send received buffer using NRF_WIFI_CMD_RX_BUFF to host */
+	/** RX packet event @ref nrf_wifi_rx_buff*/
 	NRF_WIFI_CMD_RX_BUFF,
+	/** Event to indicate interface is operational
+	 *  @ref nrf_wifi_data_carrier_state
+	 */
 	NRF_WIFI_CMD_CARRIER_ON,
+	/** Event to indicate interface is non-operational
+	 *  @ref nrf_wifi_data_carrier_state
+	 */
 	NRF_WIFI_CMD_CARRIER_OFF,
+	/** Event to indicate softap client's power save mode
+	 *  If client is in power save mode, host should start buffering
+	 *  packets until it receives NRF_WIFI_CMD_PS_GET_FRAMES event.
+	 */
 	NRF_WIFI_CMD_PM_MODE,
+	/** Event to indicate to start sending buffered packets for
+	 *  softap client @ref nrf_wifi_sap_ps_get_frames.
+	 */
 	NRF_WIFI_CMD_PS_GET_FRAMES,
 };
 
 /**
- * struct nrf_wifi_umac_head - Command/Event header.
- * @cmd: Command/Event id.
- * @len: Payload length.
+ * @brief Data interface Command and Event header.
  *
- * This header needs to be initialized in every command and has the event
- * id info in case of events.
  */
-
 struct nrf_wifi_umac_head {
+	/** Command or Event id see &enum nrf_wifi_umac_data_commands */
 	unsigned int cmd;
+	/** length */
 	unsigned int len;
 
 } __NRF_WIFI_PKD;
 
 
-
 /**
- * struct tx_mac_hdr_info - Tx mac80211 header information.
- * @umac_head: UMAC cmd header, See &struct nrf_wifi_umac_hdr.
- * @umac_fill_flags: Flags indicates which of the following fields present.
- * @fc: Frame Control.
- * @more_data: 0-> No more Data, 1-> More Data
- * @dest: Destination Address.
- * @src: Source Address.
- * @etype: Ethernet type.
- * @dscp_or_tos: Type of Service.
- * @more_data:more frames queued
- * @eosp: End Of Service Period flag(applicable in U-APSD)
+ * @brief Tx mac80211 header information.
  *
- * Host fills the mac80211 header fields and indicates to UMAC.
  */
-
 struct tx_mac_hdr_info {
+	/** Unused */
 	signed int umac_fill_flags;
+	/** frame control */
 	unsigned short fc;
+	/** source Mac header */
 	unsigned char dest[6];
+	/** destination Mac address */
 	unsigned char src[6];
-	/* needed only if UMAC is preparing LLC header */
+	/** Ethernet type */
 	unsigned short etype;
-	/* needed for TID */
+	/** Type of Service */
 	unsigned int dscp_or_tos;
+	/** more frames queued */
 	unsigned char more_data;
+	/** End Of Service Period flag(applicable in U-APSD) */
 	unsigned char eosp;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_tx_buff_info - TX data command info.
- * @pkt_length: Tx packet length.
- * @ddr_ptr: Tx packet data pointer.
+ * @brief This structure provides the information of each packet in the tx command.
+ *
  */
 
 struct nrf_wifi_tx_buff_info {
+	/** Tx packet length */
 	unsigned short pkt_length;
+	/** Tx packet address */
 	unsigned int ddr_ptr;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_tx_buff - Send TX packet.
- * @umac_head: UMAC cmd header. See &struct nrf_wifi_umac_hdr.
- * @wdev_id: wdev interface id.
- * @tx_desc_num: Descriptor id.
- * @mac_hdr_info: Common mac header for all packets to be Txed.
- * @pending_buf_size: Pending buffer at host
- * @num_tx_pkts: Number of packets.
- * @tx_buff_info: See nrf_wifi_tx_buff_info_t for details, the array size can be maximum
- *	of MAX_TX_AGG_SIZE
+ * @brief This structure provides the parameters for the tx command.
  *
- * Host sends the packet information which needs to transmit by
- * using %NRF_WIFI_CMD_TX_BUFF.
  */
-
 struct nrf_wifi_tx_buff {
+	/** Command header @ref nrf_wifi_umac_head */
 	struct nrf_wifi_umac_head umac_head;
+	/** Interface id */
 	unsigned char wdev_id;
+	/** Descriptor id */
 	unsigned char tx_desc_num;
-	/* Common Fields */
-	/* common for all coalesced packets: Pre-Aggregation */
+	/** Common mac header for all packets in this command
+	 *  @ref tx_mac_hdr_info
+	 */
 	struct tx_mac_hdr_info mac_hdr_info;
+	/** Pending buffer size at host to encode queue size
+	 *  in qos control field of mac header in TWT enable case
+	 */
 	unsigned int pending_buf_size;
+	/** Number of packets sending in this command */
 	unsigned char num_tx_pkts;
+	/** Each packets information @ref nrf_wifi_tx_buff_info */
 	struct nrf_wifi_tx_buff_info tx_buff_info[0];
 } __NRF_WIFI_PKD;
 
-/**
- * @NRF_WIFI_TX_STATUS_SUCCESS: TX was successful.
- * @NRF_WIFI_TX_STATUS_FAILED: TX failed.
- *
- */
 #define NRF_WIFI_TX_STATUS_SUCCESS 0
 #define NRF_WIFI_TX_STATUS_FAILED 1
 
 /**
- * struct nrf_wifi_tx_buff_done - TX done event.
- * @umac_head: UMAC event header. See &struct nrf_wifi_umac_hdr.
- * @tx_desc_num: Descriptor id.
- * @num_tx_status_code: Total number of received tx status code, the array size can be maximum
- *	of MAX_TX_AGG_SIZE
- * @timestamp_t1: Frame sent time at Phy
- * @timestamp_t4: Frame ack received time at Phy
- * @tx_status_code: Status of TX packet.
+ * @brief This structure represents the Tx done event(NRF_WIFI_CMD_TX_BUFF_DONE).
  *
- * RPU acknowledges the packet transmition by using %NRF_WIFI_CMD_TX_BUFF_DONE.
  */
-
 struct nrf_wifi_tx_buff_done {
+	/** Header @ref nrf_wifi_umac_head */
 	struct nrf_wifi_umac_head umac_head;
+	/** Descriptor id */
 	unsigned char tx_desc_num;
+	/** Number of packets in this Tx done event */
 	unsigned char num_tx_status_code;
+	/** Frame sent time at Phy */
 	unsigned char timestamp_t1[6];
+	/** Frame ack received time at Phy */
 	unsigned char timestamp_t4[6];
+	/** Status of Tx packet. Maximum of MAX_TX_AGG_SIZE */
 	unsigned char tx_status_code[0];
 } __NRF_WIFI_PKD;
 
 /**
- * enum nrf_wifi_rx_pkt_type: The Received packet type
- * @NRF_WIFI_RX_PKT_DATA: The Rx packet is of type data.
- * @NRF_WIFI_RX_PKT_BCN_PRB_RSP: The RX packet is of type beacon or probe response
+ * @brief This structure defines the type of received packet.
  *
  */
-
 enum nrf_wifi_rx_pkt_type {
+	/** The Rx packet is of type data */
 	NRF_WIFI_RX_PKT_DATA,
+	/** RX packet is beacon or probe response */
 	NRF_WIFI_RX_PKT_BCN_PRB_RSP
-
 };
-/*!
- * struct nrf_wifi_rx_buff_info - RX data event info.
- * @descriptor_id: Descriptor id.
- * @rx_pkt_len: Rx packet length.
- * @timestamp_t2: Frame received time at Phy
- * @timestamp_t3: Ack sent time at Phy
- */
 
+/**
+ * @brief This structure provides information about the parameters in the RX data event.
+ *
+ */
 struct nrf_wifi_rx_buff_info {
+	/** Descriptor id */
 	unsigned short descriptor_id;
+	/** Rx packet length */
 	unsigned short rx_pkt_len;
+	/** type PKT_TYPE_MPDU/PKT_TYPE_MSDU_WITH_MAC/PKT_TYPE_MSDU */
 	unsigned char pkt_type;
+	/** Frame received time at Phy */
 	unsigned char timestamp_t2[6];
+	/** Ack sent time at Phy */
 	unsigned char timestamp_t3[6];
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_rx_buf - RX data event.
- * @umac_head: UMAC event header. See &struct nrf_wifi_umac_hdr.
- * @wdev_id: wdev interface id.
- * @rx_pkt_cnt: Number of packets received.
- * @rx_pkt_type: Rx packet type.
- * After receiving the RX packet RPU informs the host using NRF_WIFI_CMD_RX_BUFF.
- * Host refills the buffer using NRF_WIFI_CMD_2K_RX_BUFF_CONFIG.
+ * @brief This structure represents RX data event(NRF_WIFI_CMD_RX_BUFF).
+ *
  */
-
 struct nrf_wifi_rx_buff {
+	/** Header @ref nrf_wifi_umac_head */
 	struct nrf_wifi_umac_head umac_head;
+	/** Rx packet type. see &enum nrf_wifi_rx_pkt_type */
 	signed int rx_pkt_type;
+	/** Interface id */
 	unsigned char wdev_id;
+	/** Number of packets in this event */
 	unsigned char rx_pkt_cnt;
-	unsigned char rpu_align_offset;
+	/** Depricated */
+	unsigned char reserved;
+	/** MAC header length. Same for all packets in this event */
 	unsigned char mac_header_len;
+	/** Frequency on which this packet received */
 	unsigned short frequency;
+	/** signal strength */
 	signed short signal;
+	/** Information of each packet. @ref nrf_wifi_rx_buff_info */
 	struct nrf_wifi_rx_buff_info rx_buff_info[0];
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_data_carrier_state - Carrier state info.
- * @umac_head: UMAC event header. See &struct nrf_wifi_umac_hdr.
+ * @brief This structure provides information about the carrier (interface) state.
+ *
  */
-
 struct nrf_wifi_data_carrier_state {
+	/** Header @ref nrf_wifi_umac_head */
 	struct nrf_wifi_umac_head umac_head;
+	/** Interface id */
 	unsigned int wdev_id;
 
 } __NRF_WIFI_PKD;
 
-/**
- * @NRF_WIFI_CLIENT_ACTIVE: SoftAP client is in active mode.
- * @NRF_WIFI_CLIENT_PS_MODE: SoftAP client is in power save mode.
- */
+/** SoftAP client is in active mode */
 #define NRF_WIFI_CLIENT_ACTIVE 0
+/** SoftAP client is in power save mode */
 #define NRF_WIFI_CLIENT_PS_MODE 1
 
 /**
- * struct nrf_wifi_sap_client_pwrsave - SofAP client power save info.
- * @umac_head: UMAC event header. See &struct nrf_wifi_umac_hdr.
- * @wdev_id: wdev interface id.
- * @sta_ps_state: NRF_WIFI_CLIENT_ACTIVE or NRF_WIFI_CLIENT_PS_MODE
- * @mac_addr: STA MAC Address
+ * @brief This structure describes an event related to the power save state of the softap's client.
+ *  When the client is in PS mode (NRF_WIFI_CLIENT_PS_MODE), the host should queue Tx packets.
+ *  When the client is in wakeup mode (NRF_WIFI_CLIENT_ACTIVE), the host should send all
+ *  buffered and upcoming Tx packets.
+ *
  */
-
 struct nrf_wifi_sap_client_pwrsave {
+	/** Header @ref nrf_wifi_umac_head */
 	struct nrf_wifi_umac_head umac_head;
+	/** Interface id */
 	unsigned int wdev_id;
+	/** state NRF_WIFI_CLIENT_ACTIVE or NRF_WIFI_CLIENT_PS_MODE */
 	unsigned char sta_ps_state;
+	/** STA MAC Address */
 	unsigned char mac_addr[NRF_WIFI_ETH_ADDR_LEN];
 
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_sap_ps_get_frames - SofAP client PS get frames info.
- * @umac_head: UMAC event header. See &struct nrf_wifi_umac_hdr.
- * @wdev_id: wdev interface id.
- * @mac_addr: STA MAC Address
- * @num_frames: Num frames to transmit in service period
+ * @brief This structure represents an event that instructs the host to transmit a specific
+ *  number of frames that host queued when softap's client is in power save mode.
+ *  This event is primarily used when Softap's client operates in legacy power save mode.
+ *  In this scenario, the access point (AP) is required to send a single packet for every PS POLL
+ *  frame it receives from the client. Additionally, this mechanism will also be utilized in
+ *  UAPSD power save.
+ *
  */
-
 struct nrf_wifi_sap_ps_get_frames {
+	/** Header @ref nrf_wifi_umac_head */
 	struct nrf_wifi_umac_head umac_head;
+	/** Interface id */
 	unsigned int wdev_id;
+	/** STA MAC Address */
 	unsigned char mac_addr[NRF_WIFI_ETH_ADDR_LEN];
+	/** Number of frames to be transmitted in this service period */
 	signed char num_frames;
 
 } __NRF_WIFI_PKD;

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw/host_rpu_sys_if.h
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw/host_rpu_sys_if.h
@@ -56,58 +56,6 @@
 
 #define NRF_WIFI_COUNTRY_CODE_LEN 2
 
-/*#define NRF_WIFI_PHY_CALIB_FLAG_RXDC 1*/
-/*#define NRF_WIFI_PHY_CALIB_FLAG_TXDC 2*/
-/*#define NRF_WIFI_PHY_CALIB_FLAG_TXPOW 4*/
-/*#define NRF_WIFI_PHY_CALIB_FLAG_TXIQ 8*/
-/*#define NRF_WIFI_PHY_CALIB_FLAG_RXIQ 16*/
-/*#define NRF_WIFI_PHY_CALIB_FLAG_DPD 32*/
-
-/**
- * enum nrf_wifi_sys_iftype - Interface types based on functionality.
- *
- * @NRF_WIFI_UMAC_IFTYPE_UNSPECIFIED: Unspecified type, driver decides.
- * @NRF_WIFI_UMAC_IFTYPE_ADHOC: Independent BSS member.
- * @NRF_WIFI_UMAC_IFTYPE_STATION: Managed BSS member.
- * @NRF_WIFI_UMAC_IFTYPE_AP: Access point.
- * @NRF_WIFI_UMAC_IFTYPE_AP_VLAN: VLAN interface for access points; VLAN interfaces
- *	are a bit special in that they must always be tied to a pre-existing
- *	AP type interface.
- * @NRF_WIFI_UMAC_IFTYPE_WDS: Wireless Distribution System.
- * @NRF_WIFI_UMAC_IFTYPE_MONITOR: Monitor interface receiving all frames.
- * @NRF_WIFI_UMAC_IFTYPE_MESH_POINT: Mesh point.
- * @NRF_WIFI_UMAC_IFTYPE_P2P_CLIENT: P2P client.
- * @NRF_WIFI_UMAC_IFTYPE_P2P_GO: P2P group owner.
- * @NRF_WIFI_UMAC_IFTYPE_P2P_DEVICE: P2P device interface type, this is not a netdev
- *	and therefore can't be created in the normal ways, use the
- *	%NRF_WIFI_UMAC_CMD_START_P2P_DEVICE and %NRF_WIFI_UMAC_CMD_STOP_P2P_DEVICE
- *	commands (Refer &enum nrf_wifi_umac_commands) to create and destroy one.
- * @NRF_WIFI_UMAC_IFTYPE_OCB: Outside Context of a BSS.
- *	This mode corresponds to the MIB variable dot11OCBActivated=true.
- * @NRF_WIFI_UMAC_IFTYPE_MAX: Highest interface type number currently defined.
- * @NRF_WIFI_UMAC_IFTYPES: Number of defined interface types.
- *
- * Lists the different interface types based on how they are configured
- * functionally.
- */
-enum nrf_wifi_sys_iftype {
-	NRF_WIFI_UMAC_IFTYPE_UNSPECIFIED,
-	NRF_WIFI_UMAC_IFTYPE_ADHOC,
-	NRF_WIFI_UMAC_IFTYPE_STATION,
-	NRF_WIFI_UMAC_IFTYPE_AP,
-	NRF_WIFI_UMAC_IFTYPE_AP_VLAN,
-	NRF_WIFI_UMAC_IFTYPE_WDS,
-	NRF_WIFI_UMAC_IFTYPE_MONITOR,
-	NRF_WIFI_UMAC_IFTYPE_MESH_POINT,
-	NRF_WIFI_UMAC_IFTYPE_P2P_CLIENT,
-	NRF_WIFI_UMAC_IFTYPE_P2P_GO,
-	NRF_WIFI_UMAC_IFTYPE_P2P_DEVICE,
-	NRF_WIFI_UMAC_IFTYPE_OCB,
-
-	/* keep last */
-	NRF_WIFI_UMAC_IFTYPES,
-	NRF_WIFI_UMAC_IFTYPE_MAX = NRF_WIFI_UMAC_IFTYPES - 1
-};
 
 /**
  * enum rpu_op_mode - operating modes.
@@ -464,34 +412,6 @@ struct nrf_wifi_sys_head {
 
 } __NRF_WIFI_PKD;
 
-/**
- * struct bgscan_params - Background Scan parameters.
- * @enabled: Enable/Disable background scan.
- * @channel_list: List of channels to scan.
- * @channel_flags: Channel flags for each of the channels which are to be
- *	scanned.
- * @scan_intval: Back ground scan is done at regular intervals. This
- *	value is set to the interval value (in ms).
- * @channel_dur: Time to be spent on each channel (in ms).
- * @serv_channel_dur: In "Connected State" scanning, we need to share the time
- *	between operating channel and non-operating channels.
- *	After scanning each channel, the firmware spends
- *	"serv_channel_dur" (in ms) on the operating channel.
- * @num_channels: Number of channels to be scanned.
- *
- * This structure specifies the parameters which will be used during a
- * Background Scan.
- */
-
-struct nrf_wifi_bgscan_params {
-	unsigned int enabled;
-	unsigned char channel_list[50];
-	unsigned char channel_flags[50];
-	unsigned int scan_intval;
-	unsigned int channel_dur;
-	unsigned int serv_channel_dur;
-	unsigned int num_channels;
-} __NRF_WIFI_PKD;
 
 /**
  * @NRF_WIFI_FEATURE_DISABLE: Feature Disable.
@@ -685,16 +605,6 @@ struct nrf_wifi_cmd_he_gi_ltf_config {
 	unsigned char enable;
 } __NRF_WIFI_PKD;
 
-/* host has to use nrf_wifi_data_buff_config_complete structure to inform rpu about
- * completin of buffers configuration. fill NRF_WIFI_CMD_BUFF_CONFIG_COMPLETE in cmd
- * field.
- */
-
-struct nrf_wifi_cmd_buff_config_complete {
-	struct nrf_wifi_sys_head sys_head;
-} __NRF_WIFI_PKD;
-
-
 #define		NRF_WIFI_DISABLE		0
 #define		NRF_WIFI_ENABLE		1
 
@@ -705,11 +615,6 @@ enum rpu_pkt_preamble {
 	RPU_PKT_PREAMBLE_MAX,
 };
 
-struct nrf_wifi_cmd_mode {
-	struct nrf_wifi_sys_head sys_head;
-	signed int mode;
-
-} __NRF_WIFI_PKD;
 
 
 struct rpu_conf_params {
@@ -966,47 +871,6 @@ struct nrf_wifi_umac_event_err_status {
 		unsigned int status;
 } __NRF_WIFI_PKD;
 
-#ifndef CONFIG_NRF700X_RADIO_TEST
-/**
- * struct nrf_wifi_event_buff_config_done - Buffers configuration done
- * @sys_head: UMAC header, See &struct nrf_wifi_sys_head.
- * @mac_addr: Mac address of the RPU
- *
- * RPU sends this event in response to NRF_WIFI_CMD_BUFF_CONFIG_COMPLETE informing
- * RPU is initialized
- */
-
-struct nrf_wifi_event_buff_config_done {
-	struct nrf_wifi_sys_head sys_head;
-	unsigned char mac_addr[NRF_WIFI_ETH_ADDR_LEN];
-
-} __NRF_WIFI_PKD;
-
-/**
- * struct nrf_wifi_txrx_buffs_config - TX/RX buffers config event.
- * @sys_head: UMAC header, See &struct nrf_wifi_sys_head.
- * @max_tx_descs: Max number of tx descriptors.
- * @max_2k_rx_descs: Max number of 2k rx descriptors.
- * @num_8k_rx_descs: Max number of 2k rx descriptors.
- * @num_mgmt_descs: Max number of mgmt buffers.
- *
- * After initialization RPU sends NRF_WIFI_EVENT_BUFF_CONFIG
- * to inform host regarding descriptors.
- * 8K buffer are for internal purpose. At initialization time host
- * submits the 8K buffer and UMAC uses buffers to configure LMAC
- * for receiving AMSDU packets.
- */
-
-struct nrf_wifi_event_buffs_config {
-	struct nrf_wifi_sys_head sys_head;
-	unsigned int max_tx_descs;
-	unsigned int max_2k_rx_descs;
-	unsigned int num_8k_rx_descs;
-	unsigned int num_mgmt_descs;
-
-} __NRF_WIFI_PKD;
-
-#endif /* !CONFIG_NRF700X_RADIO_TEST */
 
 /**
  * struct nrf_wifi_event_init_done - UMAC initialization done

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw/host_rpu_sys_if.h
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw/host_rpu_sys_if.h
@@ -6,8 +6,8 @@
  */
 
 /**
- *
- *@brief <System interface between host and RPU>
+ * @file
+ * @brief System interface between host and RPU
  */
 
 #ifndef __HOST_RPU_SYS_IF_H__
@@ -56,522 +56,772 @@
 
 #define NRF_WIFI_COUNTRY_CODE_LEN 2
 
-
 /**
- * enum rpu_op_mode - operating modes.
+ * @brief This enum provides a list of different operating modes.
  *
- * @RPU_OP_MODE_NORMAL: Normal mode is the regular mode of operation
- * @RPU_OP_MODE_DBG: Debug mode can be used to control certain parameters
- *	like TX rate etc in order to debug functional issues
- * @RPU_OP_MODE_PROD: Production mode is used for performing production
- *	tests using continuous Tx/Rx on a configured channel at a particular
- *	rate, power etc
- * @RPU_OP_MODE_FCM: In the FCM mode different type of calibration like RF
- *	calibration can be performed
- *
- * Lists the different types of operating modes.
  */
 enum rpu_op_mode {
+	/** Radio test mode is used for performing radio tests using
+	 *  continuous Tx/Rx on a configured channel at a particular rate or power.
+	 */
 	RPU_OP_MODE_RADIO_TEST,
+	/** In this mode different types of calibration like RF calibration can be performed */
 	RPU_OP_MODE_FCM,
+	/** Regular mode of operation */
 	RPU_OP_MODE_REG,
+	/** Debug mode can be used to control certain parameters like TX rate
+	 *  in order to debug functional issues.
+	 */
 	RPU_OP_MODE_DBG,
+	/** Highest mode number currently defined */
 	RPU_OP_MODE_MAX
 };
 
 /**
- * enum rpu_stats_type - statistics type.
- *
- * To obtain statistics relevant to the operation mode set via op_mode
- * parameter.
+ *  @brief This enum defines various types of statistics.
  */
-
 enum rpu_stats_type {
+	/** All statistics includes PHY, LMAC & UMAC */
 	RPU_STATS_TYPE_ALL,
+	/** Host statistics */
 	RPU_STATS_TYPE_HOST,
+	/** UMAC statistics */
 	RPU_STATS_TYPE_UMAC,
+	/** LMAC statistics*/
 	RPU_STATS_TYPE_LMAC,
+	/** PHY statistics */
 	RPU_STATS_TYPE_PHY,
+	/** Highest statistics type number currently defined */
 	RPU_STATS_TYPE_MAX
 };
 
 /**
- * enum rpu_tput_mode - Throughput mode
- *
+ * @brief- Throughput mode
  * Throughput mode to be used for transmitting the packet.
  */
 enum rpu_tput_mode {
+	/** Legacy mode */
 	RPU_TPUT_MODE_LEGACY,
+	/** High Throuput mode(11n) */
 	RPU_TPUT_MODE_HT,
+	/** Very hight throughput(11ac) */
 	RPU_TPUT_MODE_VHT,
+	/** HE SU mode */
 	RPU_TPUT_MODE_HE_SU,
+	/** HE ER SU mode */
 	RPU_TPUT_MODE_HE_ER_SU,
+	/** HE TB mode */
 	RPU_TPUT_MODE_HE_TB,
+	/** Highest throughput mode currently defined */
 	RPU_TPUT_MODE_MAX
 };
 
 /**
- * enum nrf_wifi_sys_commands - system commands
- * @NRF_WIFI_CMD_INIT: After host driver bringup host sends the NRF_WIFI_CMD_INIT
- *	to the RPU. then RPU initializes and responds with
- *	NRF_WIFI_EVENT_BUFF_CONFIG.
- * @NRF_WIFI_CMD_BUFF_CONFIG_COMPLETE: Host sends this command to RPU after
- *	completion of all buffers configuration
- * @NRF_WIFI_CMD_TX: command to send a Tx packet
- * @NRF_WIFI_CMD_MODE: command to specify mode of operation
- * @NRF_WIFI_CMD_GET_STATS: command to get statistics
- * @NRF_WIFI_CMD_CLEAR_STATS: command to clear statistics
- * @NRF_WIFI_CMD_RX: command to ENABLE/DISABLE receiving packets in radio test mode
- * @NRF_WIFI_CMD_DEINIT: RPU De-initialization
- * @NRF_WIFI_CMD_HE_GI_LTF_CONFIG: Configure HE_GI & HE_LTF.
+ * @brief - System commands.
  *
  */
 enum nrf_wifi_sys_commands {
+	/** Command to initialize RPU and RPU responds with NRF_WIFI_EVENT_INIT_DONE */
 	NRF_WIFI_CMD_INIT,
+	/** command to send a Tx packet in radiotest mode */
 	NRF_WIFI_CMD_TX,
+	/** Unused */
 	NRF_WIFI_CMD_IF_TYPE,
+	/** command to specify mode of operation */
 	NRF_WIFI_CMD_MODE,
+	/** command to get statistics */
 	NRF_WIFI_CMD_GET_STATS,
+	/** command to clear statistics */
 	NRF_WIFI_CMD_CLEAR_STATS,
+	/** command to ENABLE/DISABLE receiving packets in radiotest mode */
 	NRF_WIFI_CMD_RX,
+	/** Command to measure battery voltage and RPU responds	with NRF_WIFI_EVENT_PWR_DATA */
 	NRF_WIFI_CMD_PWR,
+	/** RPU De-initialization */
 	NRF_WIFI_CMD_DEINIT,
+	/** Command for WIFI & Bluetooth coexistence */
 	NRF_WIFI_CMD_BTCOEX,
+	/** Command to start RF test */
 	NRF_WIFI_CMD_RF_TEST,
+	/** Configure HE_GI & HE_LTF */
 	NRF_WIFI_CMD_HE_GI_LTF_CONFIG,
+	/** Command for getting UMAC memory statistics */
 	NRF_WIFI_CMD_UMAC_INT_STATS,
+	/** Command for Setting the channel & Rf params in radiotest mode */
 	NRF_WIFI_CMD_RADIO_TEST_INIT,
+	/** Command for setting country in radiotest mode */
 	NRF_WIFI_CMD_RT_REQ_SET_REG,
+	/** Command to enable/disable fixed data rate in regular mode */
 	NRF_WIFI_CMD_TX_FIX_DATA_RATE,
 };
 
 /**
- * enum nrf_wifi_sys_events -
- * @NRF_WIFI_EVENT_BUFF_CONFIG: Response to NRF_WIFI_CMD_INIT
- *	see &struct nrf_wifi_event_buffs_config
- * @NRF_WIFI_EVENT_BUFF_CONFIG_DONE: Response to NRF_WIFI_CMD_BUFF_CONFIG_COMPLETE
- * @NRF_WIFI_EVENT_STATS: Response to NRF_WIFI_CMD_GET_STATS
- * @NRF_WIFI_EVENT_DEINIT_DONE: Response to NRF_WIFI_CMD_DEINIT
+ * @brief - Events from the RPU.
  *
- * Events from the RPU for different commands.
  */
 enum nrf_wifi_sys_events {
+	/** Response to NRF_WIFI_CMD_PWR */
 	NRF_WIFI_EVENT_PWR_DATA,
-
+	/** Response to NRF_WIFI_CMD_INIT */
 	NRF_WIFI_EVENT_INIT_DONE,
+	/** Response to NRF_WIFI_CMD_GET_STATS */
 	NRF_WIFI_EVENT_STATS,
+	/** Response to NRF_WIFI_CMD_DEINIT */
 	NRF_WIFI_EVENT_DEINIT_DONE,
+	/** Response to NRF_WIFI_CMD_RF_TEST */
 	NRF_WIFI_EVENT_RF_TEST,
+	/** Response to NRF_WIFI_CMD_BTCOEX. */
 	NRF_WIFI_EVENT_COEX_CONFIG,
+	/** Response to NRF_WIFI_CMD_UMAC_INT_STATS */
 	NRF_WIFI_EVENT_INT_UMAC_STATS,
+	/** Command status events for radio test commands*/
 	NRF_WIFI_EVENT_RADIOCMD_STATUS
 };
 
+/**
+ * @brief - Channel Bandwidth types.
+ *
+ **/
 enum rpu_ch_bw {
+	/** 20MHz bandwidth */
 	RPU_CH_BW_20,
+	/** 40MHz bandwidth */
 	RPU_CH_BW_40,
+	/** 80MHz bandwidth */
 	RPU_CH_BW_MAX
 };
 
+/**
+ * @brief - This structure specifies the parameters required to configure a specific channel.
+ *
+ */
 struct chan_params {
+	/** Primary channel number */
 	unsigned int primary_num;
+	/** Channel bandwidth */
 	unsigned char bw;
+	/** 20Mhz offset value */
 	signed int sec_20_offset;
+	/** 40Mhz offset value */
 	signed int sec_40_offset;
 } __NRF_WIFI_PKD;
 
+/**
+ * @brief This structure specifies the parameters required to start or stop the RX (receive)
+ *  operation in radiotest mode.
+ *
+ */
 struct rpu_conf_rx_radio_test_params {
+	/** Number of spatial streams supported. Currently unused. */
 	unsigned char nss;
 	/* Input to the RF for operation */
 	unsigned char rf_params[NRF_WIFI_RF_PARAMS_SIZE];
+	/** An array containing RF and baseband control params */
 	struct chan_params chan;
+	/** Copy OTP params to this memory */
 	signed char phy_threshold;
+	/** Calibration bit map value. More information can be found in the phy_rf_params.h file.
+	 */
 	unsigned int phy_calib;
+	/** Start Rx : 1, Stop Rx :0 */
 	unsigned char rx;
 } __NRF_WIFI_PKD;
 
-
+/**
+ * @brief This structure specifies the UMAC (Upper MAC) RX (receive) debug parameters
+ *  specifically designed for debugging purpose.
+ *
+ */
 
 struct umac_rx_dbg_params {
+	/** Total lmac events received to UMAC */
 	unsigned int lmac_events;
+	/** Total Rx events(LMAC_EVENT_RX) received in ISR */
 	unsigned int rx_events;
+	/** Received coalised events from LMAC */
 	unsigned int rx_coalesce_events;
+	/** Total Rx packets received from LMAC */
 	unsigned int total_rx_pkts_from_lmac;
-
+	/** Maximum RX packets buffered at any point of time in UMAC.*/
 	unsigned int max_refill_gap;
+	/** Difference between rx packets received from lmac and packets sent to host */
 	unsigned int current_refill_gap;
-
+	/** Number of Packets queued to reorder buffer due to out of order */
 	unsigned int out_of_order_mpdus;
+	/** Number of packets removed from reorder buffer */
 	unsigned int reorder_free_mpdus;
-
+	/** Number of Rx packets resubmitted to LMAC by UMAC */
 	unsigned int umac_consumed_pkts;
+	/** Number of Rx packets sent to Host for resubmiting */
 	unsigned int host_consumed_pkts;
-
+	/** Total events posted to UMAC RX thread from LMAC */
 	unsigned int rx_mbox_post;
+	/** Total events received to UMAC RX thread from LMAC */
 	unsigned int rx_mbox_receive;
-
+	/** Number of packets received in out of order */
 	unsigned int reordering_ampdu;
+	/** Messages posted  to TX mbox from timer ISR */
 	unsigned int timer_mbox_post;
+	/** Messages received from timer ISR */
 	unsigned int timer_mbox_rcv;
+	/** Messages posted to TX mbox from work scheduler */
 	unsigned int work_mbox_post;
+	/** Messages received from work scheduler */
 	unsigned int work_mbox_rcv;
+	/** Messages posted to TX mbox from tasklet function */
 	unsigned int tasklet_mbox_post;
+	/** Messages received from tasklet function */
 	unsigned int tasklet_mbox_rcv;
+	/** Management frames sent to userspace */
 	unsigned int userspace_offload_frames;
+	/** Number of times where requested buffer size is not available
+	 *  and allocated from next available memory buffer
+	 */
 	unsigned int alloc_buf_fail;
-
+	/** Total packets count in RX thread */
 	unsigned int rx_packet_total_count;
+	/** Number of data packets received */
 	unsigned int rx_packet_data_count;
+	/** Number of Qos data packets received */
 	unsigned int rx_packet_qos_data_count;
+	/** Number of protected data packets received */
 	unsigned int rx_packet_protected_data_count;
+	/** Number of management packets received */
 	unsigned int rx_packet_mgmt_count;
+	/** Number of beacon packets received */
 	unsigned int rx_packet_beacon_count;
+	/** Number of probe response packets received */
 	unsigned int rx_packet_probe_resp_count;
+	/** Number of authentication packets received */
 	unsigned int rx_packet_auth_count;
+	/** Number of deauthentication packets received */
 	unsigned int rx_packet_deauth_count;
+	/** Number of assoc response packets received */
 	unsigned int rx_packet_assoc_resp_count;
+	/** Number of disassociation packets received */
 	unsigned int rx_packet_disassoc_count;
+	/** Number of action frames received */
 	unsigned int rx_packet_action_count;
+	/** Number of probe request packets received */
 	unsigned int rx_packet_probe_req_count;
+	/** Other management packets received */
 	unsigned int rx_packet_other_mgmt_count;
+	/** Maximum coalised packets received from LMAC in any RX event */
 	signed char max_coalesce_pkts;
+	/** Packets received with null skb pointer from LMAC */
 	unsigned int null_skb_pointer_from_lmac;
+	/** Number of unexpected management packets received in coalesce event */
 	unsigned int unexpected_mgmt_pkt;
 
 } __NRF_WIFI_PKD;
 
+/**
+ * @brief This structure specifies the UMAC TX (transmit) debug parameters used for
+ *  debugging purposes.
+ *
+ */
 struct umac_tx_dbg_params {
+	/** Total number of tx commands received from host */
 	unsigned int tx_cmd;
+	/** Non coalesce packets received */
 	unsigned int tx_non_coalesce_pkts_rcvd_from_host;
+	/** coalesce packets received */
 	unsigned int tx_coalesce_pkts_rcvd_from_host;
+	/** Maximum number of coalesce packets received in any
+	 *  TX command coalesce packets received
+	 */
 	unsigned int tx_max_coalesce_pkts_rcvd_from_host;
+	/** Maximum Tx commands currently in process at any point of time in UMAC */
 	unsigned int tx_cmds_max_used;
+	/** Number of Tx commands that are currently in process in UMAC */
 	unsigned int tx_cmds_currently_in_use;
+	/** Number of tx done events sent to host */
 	unsigned int tx_done_events_send_to_host;
+	/** Number of tx done success packets sent to host */
 	unsigned int tx_done_success_pkts_to_host;
+	/** Number of tx done failure packets sent to host */
 	unsigned int tx_done_failure_pkts_to_host;
+	/** Number of packets received from host that needs to be encrypted */
 	unsigned int tx_cmds_with_crypto_pkts_rcvd_from_host;
+	/** Number of packets received from host that need not to be encrypted */
 	unsigned int tx_cmds_with_non_crypto_pkts_rcvd_from_host;
+	/** Number of broadcast	packets received from host */
 	unsigned int tx_cmds_with_broadcast_pkts_rcvd_from_host;
+	/** Number of multicast	packets received from host */
 	unsigned int tx_cmds_with_multicast_pkts_rcvd_from_host;
+	/** Number of unicast packets received from host */
 	unsigned int tx_cmds_with_unicast_pkts_rcvd_from_host;
-
+	/** UMAC internal count */
 	unsigned int xmit;
+	/** Number of addba requests sent */
 	unsigned int send_addba_req;
+	/** Total ADD BA responses received from host */
 	unsigned int addba_resp;
+	/** Total packets received in softmac tx function */
 	unsigned int softmac_tx;
+	/** Number of packets generated internally in UMAC */
 	unsigned int internal_pkts;
+	/** Number of packets Received from host */
 	unsigned int external_pkts;
+	/** Total tx commmands sent to lmac */
 	unsigned int tx_cmds_to_lmac;
+	/** Tx dones received from LMAC */
 	unsigned int tx_dones_from_lmac;
+	/** Total commands sent to lmac in UMAC hal */
 	unsigned int total_cmds_to_lmac;
-
+	/** Number of data packets sent */
 	unsigned int tx_packet_data_count;
+	/** Number of management packets sent */
 	unsigned int tx_packet_mgmt_count;
+	/** Number of beacon packets sent */
 	unsigned int tx_packet_beacon_count;
+	/** Number of probe request packets sent */
 	unsigned int tx_packet_probe_req_count;
+	/** Number of authentication packets sent */
 	unsigned int tx_packet_auth_count;
+	/** Number of deauthentication packets sent */
 	unsigned int tx_packet_deauth_count;
+	/** Number of association request packets sent */
 	unsigned int tx_packet_assoc_req_count;
+	/** Number of disassociation packets sent */
 	unsigned int tx_packet_disassoc_count;
+	/** Number of action packets sent */
 	unsigned int tx_packet_action_count;
+	/** Other management packets sent */
 	unsigned int tx_packet_other_mgmt_count;
+	/** Number of Non management packets sent */
 	unsigned int tx_packet_non_mgmt_data_count;
 
 } __NRF_WIFI_PKD;
+
+/**
+ * @brief This structure specifies the UMAC command and event debug parameters used for
+ *  debugging purpose.
+ *
+ */
 struct umac_cmd_evnt_dbg_params {
+	/** Number of command init received from host */
 	unsigned char cmd_init;
+	/** Number of init_done events sent to host */
 	unsigned char event_init_done;
+	/** Number of rf test command received from host */
 	unsigned char cmd_rf_test;
+	/** Number of connect command received from host */
 	unsigned char cmd_connect;
+	/** Number of get_stats command received from host */
 	unsigned int cmd_get_stats;
+	/** Number of power save state events sent to host */
 	unsigned int event_ps_state;
+	/** Unused*/
 	unsigned int cmd_set_reg;
+	/** Number of get regulatory commands received from host */
 	unsigned int cmd_get_reg;
+	/** Number of request set regulatory commands received from host */
 	unsigned int cmd_req_set_reg;
+	/** Number of trigger scan commands received from host */
 	unsigned int cmd_trigger_scan;
+	/** Number of scan done events sent to host */
 	unsigned int event_scan_done;
+	/** Number of get scan commands received from the host to get scan results */
 	unsigned int cmd_get_scan;
+	/** Number of scan commands sent to LMAC */
 	unsigned int umac_scan_req;
+	/** Number of scan complete events received from LMAC */
 	unsigned int umac_scan_complete;
+	/** Number of scan requests received from host when previous scan is in progress */
 	unsigned int umac_scan_busy;
+	/** Number of authentication requests received from host */
 	unsigned int cmd_auth;
+	/** Number of association requests received from host */
 	unsigned int cmd_assoc;
+	/** Number of deauthentication requests received from host */
 	unsigned int cmd_deauth;
+	/** Number of register frame commands received from host to register
+	 *  a management frame type which should be passed to host
+	 */
 	unsigned int cmd_register_frame;
+	/** Number of command frames from host which will be used for
+	 *  transmitting management frames
+	 */
 	unsigned int cmd_frame;
+	/** Number of delete key commands from host */
 	unsigned int cmd_del_key;
+	/** Number of new key commands received from host */
 	unsigned int cmd_new_key;
+	/** Number of set key commands received from host */
 	unsigned int cmd_set_key;
+	/** Number of get key commands received from host */
 	unsigned int cmd_get_key;
+	/** Number of beacon hint events sent to host */
 	unsigned int event_beacon_hint;
+	/** Number of regulatory change events sent to host when regulatory change command
+	 *  received from host such as in response to command NL80211_CMD_REG_CHANGE
+	 */
 	unsigned int event_reg_change;
+	/** Number of regulatory change events sent to host other than
+	 *  host request for regulatory change
+	 */
 	unsigned int event_wiphy_reg_change;
+	/** Number of set station commands received from host */
 	unsigned int cmd_set_station;
+	/** Number of new station commands received from host */
 	unsigned int cmd_new_station;
+	/** Number of del station commands received from host */
 	unsigned int cmd_del_station;
+	/** Number of new interface commands received from host */
 	unsigned int cmd_new_interface;
+	/** Number of set interface commands received from host */
 	unsigned int cmd_set_interface;
+	/** Number of get interface commands received from host */
 	unsigned int cmd_get_interface;
+	/** Number of set_ifflags commands received from host */
 	unsigned int cmd_set_ifflags;
+	/** Number of set_ifflags events sent to host */
 	unsigned int cmd_set_ifflags_done;
+	/** Number of set bss command received from host */
 	unsigned int cmd_set_bss;
+	/** Number of set wiphy command received from host */
 	unsigned int cmd_set_wiphy;
+	/** Number of start access point command received from host */
 	unsigned int cmd_start_ap;
+	/** Number of power save configuration commands sent to LMAC */
 	unsigned int LMAC_CMD_PS;
+	/** Current power save state configured to LMAC through LMAC_CMD_PS command */
 	unsigned int CURR_STATE;
 } __NRF_WIFI_PKD;
 
 #ifndef CONFIG_NRF700X_RADIO_TEST
 
+/**
+ * @brief This structure specifies the UMAC interface debug parameters used for debugging purpose.
+ *
+ */
 struct nrf_wifi_interface_stats {
+	/** Number of unicast packets sent */
 	unsigned int tx_unicast_pkt_count;
+	/** Number of multicast packets sent */
 	unsigned int tx_multicast_pkt_count;
+	/** Number of broadcast packets sent */
 	unsigned int tx_broadcast_pkt_count;
+	/** Number of tx data bytes sent */
 	unsigned int tx_bytes;
+	/** Number of unicast packets received */
 	unsigned int rx_unicast_pkt_count;
+	/** Number of multicast packets received */
 	unsigned int rx_multicast_pkt_count;
+	/** Number of broadcast packets received */
 	unsigned int rx_broadcast_pkt_count;
+	/** Number of beacon packets received */
 	unsigned int rx_beacon_success_count;
+	/** Number of beacon packets missed */
 	unsigned int rx_beacon_miss_count;
+	/** Number of rx data bytes received */
 	unsigned int rx_bytes;
+	/** Number of packets with checksum mismatch received */
 	unsigned int rx_checksum_error_count;
+	/** Number of duplicate packets received */
 	unsigned int replay_attack_drop_cnt;
 } __NRF_WIFI_PKD;
 
+/**
+ * @brief This structure defines the UMAC debug statistics. It contains the necessary parameters
+ *  and fields used to gather and present debugging statistics within the UMAC layer.
+ *
+ */
 struct rpu_umac_stats {
+	/** Transmit debug statistics @ref umac_tx_dbg_params */
 	struct umac_tx_dbg_params tx_dbg_params;
+	/** Receive debug statistics @ref umac_rx_dbg_params */
 	struct umac_rx_dbg_params rx_dbg_params;
+	/** Command Event debug statistics @ref umac_cmd_evnt_dbg_params */
 	struct umac_cmd_evnt_dbg_params cmd_evnt_dbg_params;
+	/** Interface debug parameters @ref nrf_wifi_interface_stats */
 	struct nrf_wifi_interface_stats interface_data_stats;
 } __NRF_WIFI_PKD;
 
+/**
+ * @brief This structure defines the LMAC debug parameters.
+ *
+ */
 struct rpu_lmac_stats {
-	/*LMAC DEBUG Stats*/
+	/** Number of reset command counts from UMAC */
 	unsigned int reset_cmd_cnt;
+	/** Number of reset complete events sent to UMAC */
 	unsigned int reset_complete_event_cnt;
+	/** Number of events unable to generate */
 	unsigned int unable_gen_event;
+	/** Number of channel program commands from UMAC */
 	unsigned int ch_prog_cmd_cnt;
+	/** Number of channel program done events to UMAC */
 	unsigned int channel_prog_done;
+	/** Number of Tx commands from UMAC */
 	unsigned int tx_pkt_cnt;
+	/** Number of Tx done events to UMAC */
 	unsigned int tx_pkt_done_cnt;
+	/** Unused */
 	unsigned int scan_pkt_cnt;
+	/** Number of internal Tx packets */
 	unsigned int internal_pkt_cnt;
+	/** Number of Tx dones for internal packets */
 	unsigned int internal_pkt_done_cnt;
+	/** Number of acknowledgment responses */
 	unsigned int ack_resp_cnt;
+	/** Number of transmit timeouts */
 	unsigned int tx_timeout;
+	/** Number of deaggregation ISRs */
 	unsigned int deagg_isr;
+	/** Number of deaggregation input descriptor empties */
 	unsigned int deagg_inptr_desc_empty;
+	/** Number of deaggregation circular buffer full events */
 	unsigned int deagg_circular_buffer_full;
+	/** Number of LMAC received ISRs */
 	unsigned int lmac_rxisr_cnt;
+	/** Number of received packets decrypted */
 	unsigned int rx_decryptcnt;
+	/** Number of packet decryption failures during processing */
 	unsigned int process_decrypt_fail;
+	/** Number of RX event preparation failures */
 	unsigned int prepa_rx_event_fail;
+	/** Number of RX core pool full counts */
 	unsigned int rx_core_pool_full_cnt;
+	/** Number of RX MPDU CRC successes */
 	unsigned int rx_mpdu_crc_success_cnt;
+	/** Number of RX MPDU CRC failures */
 	unsigned int rx_mpdu_crc_fail_cnt;
+	/** Number of RX OFDM CRC successes */
 	unsigned int rx_ofdm_crc_success_cnt;
+	/** Number of RX OFDM CRC failures */
 	unsigned int rx_ofdm_crc_fail_cnt;
+	/** Number of RX DSSS CRC successes */
 	unsigned int rxDSSSCrcSuccessCnt;
+	/** Number of RX DSSS CRC failures */
 	unsigned int rxDSSSCrcFailCnt;
+	/** Number of RX crypto start counts */
 	unsigned int rx_crypto_start_cnt;
+	/** Number of RX crypto done counts */
 	unsigned int rx_crypto_done_cnt;
+	/** Number of RX event buffer full counts */
 	unsigned int rx_event_buf_full;
+	/** Number of RX external RAM buffer full counts */
 	unsigned int rx_extram_buf_full;
+	/** Number of scan requests receive from UMAC */
 	unsigned int scan_req;
+	/** Number of scan complete events sent to UMAC */
 	unsigned int scan_complete;
+	/** Number of scan abort requests */
 	unsigned int scan_abort_req;
+	/** Number of scan abort complete events */
 	unsigned int scan_abort_complete;
+	/** Number of internal buffer pool null counts */
 	unsigned int internal_buf_pool_null;
-	/*END:LMAC DEBUG Stats*/
 } __NRF_WIFI_PKD;
 
 #endif /* !CONFIG_NRF700X_RADIO_TEST */
 
+/**
+ * @brief This structure defines the PHY (Physical Layer) debug statistics.
+ *
+ */
 struct rpu_phy_stats {
+	/** Rssi average value received from LMAC */
 	signed char rssi_avg;
+	/** Unused */
 	unsigned char pdout_val;
+	/** Number of OFDM CRC Pass packets */
 	unsigned int ofdm_crc32_pass_cnt;
+	/** Number of OFDM CRC Fail packets */
 	unsigned int ofdm_crc32_fail_cnt;
+	/** Number of DSSS CRC Pass packets */
 	unsigned int dsss_crc32_pass_cnt;
+	/** Number of DSSS CRC Fail packets */
 	unsigned int dsss_crc32_fail_cnt;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_sys_head - Command/Event header.
- * @cmd: Command/Event id.
- * @len: Payload length.
+ * @brief The UMAC header structure for system commands and events defines the format
+ *  used to transmit and receive system-level commands and events.
  *
- * This header needs to be initialized in every command and has the event
- * id info in case of events.
  */
-
 struct nrf_wifi_sys_head {
+	/** Command/Event id */
 	unsigned int cmd_event;
+	/** message length */
 	unsigned int len;
-
 } __NRF_WIFI_PKD;
 
-
-/**
- * @NRF_WIFI_FEATURE_DISABLE: Feature Disable.
- * @NRF_WIFI_FEATURE_ENABLE: Feature Enable.
- *
- */
+/** Feature Disable */
 #define NRF_WIFI_FEATURE_DISABLE 0
+/** Feature Enable */
 #define NRF_WIFI_FEATURE_ENABLE 1
 
 /**
- * enum max_rx_ampdu_size - Max Rx AMPDU size in KB
+ * @brief The maximum Rx (receive) A-MPDU size in KB.
  *
- * Max Rx AMPDU Size
  */
 enum max_rx_ampdu_size {
+	/** 8KB AMPDU Size */
 	MAX_RX_AMPDU_SIZE_8KB,
+	/** 16KB AMPDU Size */
 	MAX_RX_AMPDU_SIZE_16KB,
+	/** 32KB AMPDU Size */
 	MAX_RX_AMPDU_SIZE_32KB,
+	/** 64KB AMPDU Size */
 	MAX_RX_AMPDU_SIZE_64KB
 };
 
 /**
- * struct nrf_wifi_data_config_params - Data config parameters
- * @rate_protection_type:0->NONE, 1->RTS/CTS, 2->CTS2SELF
- * @aggregation: Agreegation is enabled(NRF_WIFI_FEATURE_ENABLE) or disabled
- *		(NRF_WIFI_FEATURE_DISABLE)
- * @wmm: WMM is enabled(NRF_WIFI_FEATURE_ENABLE) or disabled
- *		(NRF_WIFI_FEATURE_DISABLE)
- * @max_num_tx_agg_sessions: Max number of aggregated TX sessions
- * @max_num_rx_agg_sessions: Max number of aggregated RX sessions
- * @reorder_buf_size: Reorder buffer size (1 to 64)
- * @max_rxampdu_size: Max RX AMPDU size (8/16/32/64 KB), see
- *					enum max_rx_ampdu_size
+ * @brief This structure specifies the configuration parameters used for configuring
+ *  data-related settings.
  *
- * Data configuration parameters provided in command NRF_WIFI_CMD_INIT
  */
 
 struct nrf_wifi_data_config_params {
+	/** rate_protection_type:0->NONE, 1->RTS/CTS, 2->CTS2SELF */
 	unsigned char rate_protection_type;
+	/** Aggregation is enabled(NRF_WIFI_FEATURE_ENABLE) or
+	 *  disabled(NRF_WIFI_FEATURE_DISABLE)
+	 */
 	unsigned char aggregation;
+	/** WMM is enabled(NRF_WIFI_FEATURE_ENABLE) or
+	 *  disabled(NRF_WIFI_FEATURE_DISABLE)
+	 */
 	unsigned char wmm;
+	/** Max number of aggregated TX sessions */
 	unsigned char max_num_tx_agg_sessions;
+	/** Max number of aggregated RX sessions */
 	unsigned char max_num_rx_agg_sessions;
+	/** maximum aggregation size */
 	unsigned char max_tx_aggregation;
+	/** Reorder buffer size (1 to 64) */
 	unsigned char reorder_buf_size;
+	/** Max RX AMPDU size (8/16/32/64 KB), see &enum max_rx_ampdu_size */
 	signed int max_rxampdu_size;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_sys_params - Init parameters during NRF_WIFI_CMD_INIT
- * @mac_addr: MAC address of the interface
- * @sleep_enable: enable rpu sleep
- * @hw_bringup_time:
- * @sw_bringup_time:
- * @bcn_time_out:
- * @calib_sleep_clk:
- * @rf_params: RF parameters
- * @rf_params_valid: Indicates whether the @rf_params has a valid value.
- * @phy_calib: PHY calibration parameters
+ * @brief This structure specifies the parameters that need to be provided for the command
+ *  NRF_WIFI_CMD_INIT. The NRF_WIFI_CMD_INIT command is typically used to initialize the
+ *  Wi-Fi module and prepare it for further communication.
  *
- * System parameters provided for command NRF_WIFI_CMD_INIT
  */
 
 struct nrf_wifi_sys_params {
+	/** enable rpu sleep */
 	unsigned int sleep_enable;
+	/** Normal/FTM mode */
 	unsigned int hw_bringup_time;
+	/** Antenna Configuration, applicable only for 1x1 */
 	unsigned int sw_bringup_time;
+	/** Internal tuning parameter */
 	unsigned int bcn_time_out;
+	/** Set to 1 if rpu is expected to perform sleep clock calibration */
 	unsigned int calib_sleep_clk;
+	/** calib bit map value. More info can be found in phy_rf_params.h NRF_WIFI_DEF_PHY_CALIB */
 	unsigned int phy_calib;
 #ifndef CONFIG_NRF700X_RADIO_TEST
+	/** MAC address of the interface */
 	unsigned char mac_addr[NRF_WIFI_ETH_ADDR_LEN];
+	/** An array containing RF & baseband control params */
 	unsigned char rf_params[NRF_WIFI_RF_PARAMS_SIZE];
+	/** Indicates whether the rf_params has a valid value */
 	unsigned char rf_params_valid;
 #endif /* !CONFIG_NRF700X_RADIO_TEST */
 } __NRF_WIFI_PKD;
 
 
 /**
- * struct nrf_wifi_tx_pow_ctrl_params - Parameters which control TX power.
- * @ant_gain_2g: Antenna gain for 2.4 GHz band.
- * @ant_gain_5g_band1 : Antenna gain for 5 GHz band (5150 MHz - 5350 MHz).
- * ant_gain_5g_band2 : Antenna gain for 5 GHz band (5470 MHz - 5730 MHz).
- * ant_gain_5g_band3 : Antenna gain for 5 GHz band (5730 MHz - 5895 MHz).
- * @band_edge_2g_lo: Transmit power backoff (in dB) for lower edge of 2.4 GHz frequency band.
- * @band_edge_2g_hi: Transmit power backoff (in dB) for upper edge of 2.4 GHz frequency band.
- * @band_edge_5g_unii_1_lo: Transmit power backoff (in dB) for lower edge of UNII-1 frequency band.
- * @band_edge_5g_unii_1_hi: Transmit power backoff (in dB) for upper edge of UNII-1 frequency band.
- * @band_edge_5g_unii_2a_lo: Transmit power backoff (in dB) for lower edge of UNII-2A frequency band
- * @band_edge_5g_unii_2a_hi: Transmit power backoff (in dB) for upper edge of UNII-2A frequency band
- * @band_edge_5g_unii_2c_lo: Transmit power backoff (in dB) for lower edge of UNII-2C frequency band
- * @band_edge_5g_unii_2c_hi: Transmit power backoff (in dB) for upper edge of UNII-2C frequency band
- * @band_edge_5g_unii_3_lo: Transmit power backoff (in dB) for lower edge of UNII-3 frequency band.
- * @band_edge_5g_unii_3_hi: Transmit power backoff (in dB) for upper edge of UNII-3 frequency band.
- * @band_edge_5g_unii_4_lo: Transmit power backoff (in dB) for lower edge of UNII-4 frequency band.
- * @band_edge_5g_unii_4_hi: Transmit power backoff (in dB) for upper edge of UNII-4 frequency band.
+ * @brief This structure defines the parameters used to control the transmit (TX) power.
  *
- * System parameters provided for controlling TX power.
  */
 
 struct nrf_wifi_tx_pwr_ctrl_params {
+	/** Antenna gain for 2.4 GHz band */
 	unsigned char ant_gain_2g;
+	/** Antenna gain for 5 GHz band (5150 MHz - 5350 MHz) */
 	unsigned char ant_gain_5g_band1;
+	/** Antenna gain for 5 GHz band (5470 MHz - 5730 MHz) */
 	unsigned char ant_gain_5g_band2;
+	/** Antenna gain for 5 GHz band (5730 MHz - 5895 MHz) */
 	unsigned char ant_gain_5g_band3;
+	/** Transmit power backoff (in dB) for lower edge of 2.4 GHz frequency band */
 	unsigned char band_edge_2g_lo;
+	/** Transmit power backoff (in dB) for upper edge of 2.4 GHz frequency band */
 	unsigned char band_edge_2g_hi;
+	/** Transmit power backoff (in dB) for lower edge of UNII-1 frequency band */
 	unsigned char band_edge_5g_unii_1_lo;
+	/** Transmit power backoff (in dB) for upper edge of UNII-1 frequency band */
 	unsigned char band_edge_5g_unii_1_hi;
+	/** Transmit power backoff (in dB) for lower edge of UNII-2A frequency band */
 	unsigned char band_edge_5g_unii_2a_lo;
+	/** Transmit power backoff (in dB) for upper edge of UNII-2A frequency band */
 	unsigned char band_edge_5g_unii_2a_hi;
+	/** Transmit power backoff (in dB) for lower edge of UNII-2C frequency band */
 	unsigned char band_edge_5g_unii_2c_lo;
+	/** Transmit power backoff (in dB) for upper edge of UNII-2C frequency band */
 	unsigned char band_edge_5g_unii_2c_hi;
+	/** Transmit power backoff (in dB) for lower edge of UNII-3 frequency band */
 	unsigned char band_edge_5g_unii_3_lo;
+	/** Transmit power backoff (in dB) for upper edge of UNII-3 frequency band */
 	unsigned char band_edge_5g_unii_3_hi;
+	/** Transmit power backoff (in dB) for lower edge of UNII-4 frequency band */
 	unsigned char band_edge_5g_unii_4_lo;
+	/** Transmit power backoff (in dB) for upper edge of UNII-4 frequency band */
 	unsigned char band_edge_5g_unii_4_hi;
 } __NRF_WIFI_PKD;
 
+/**
+ * @brief This enum defines different types of operating bands.
+ *
+ */
 enum op_band {
+	/** All bands */
 	BAND_ALL,
+	/** 2.4Ghz band */
 	BAND_24G
 };
 
 /**
- * struct nrf_wifi_cmd_sys_init - Initialize UMAC
- * @sys_head: umac header, see &nrf_wifi_sys_head
- * @wdev_id : id of the interface.
- * @sys_params: iftype, mac address, see nrf_wifi_sys_params
- * @rx_buf_pools: LMAC Rx buffs pool params, see struct rx_buf_pool_params
- * @data_config_params: Data configuration params, see struct nrf_wifi_data_config_params
- * @tcp_ip_checksum_offload: 0:umac checksum disable 1: umac checksum enable
- * @op_band: operating band see enum op_band
- * @mgmt_buff_offload: Target selection for management buffers deallocation 0:HOST 1:UMAC.
- * After host driver bringup host sends the NRF_WIFI_CMD_INIT to the RPU.
- * then RPU initializes and responds with NRF_WIFI_EVENT_BUFF_CONFIG.
+ * @brief This structure defines the command responsible for initializing the UMAC.
+ *  After the host driver brings up, the host sends NRF_WIFI_CMD_INIT to the RPU.
+ *  The RPU then performs the initialization and responds with NRF_WIFI_EVENT_INIT_DONE
+ *  once the initialization is completed.
+ *
  */
 
 struct nrf_wifi_cmd_sys_init {
+	/** umac header, @ref nrf_wifi_sys_head */
 	struct nrf_wifi_sys_head sys_head;
+	/** id of the interface */
 	unsigned int wdev_id;
+	/** @ref nrf_wifi_sys_params */
 	struct nrf_wifi_sys_params sys_params;
+	/** LMAC Rx buffs pool params, @ref rx_buf_pool_params */
 	struct rx_buf_pool_params rx_buf_pools[MAX_NUM_OF_RX_QUEUES];
+	/** Data configuration params, @ref nrf_wifi_data_config_params */
 	struct nrf_wifi_data_config_params data_config_params;
+	/** Calibration trigger control info based on battery voltage and temperature changes.
+	 *  @ref temp_vbat_config from lmac_if_common.h
+	 */
 	struct temp_vbat_config temp_vbat_config_params;
+	/** 0:umac checksum disable 1: umac checksum enable */
 	unsigned char tcp_ip_checksum_offload;
+	/** Country code to set */
 	unsigned char country_code[NRF_WIFI_COUNTRY_CODE_LEN];
+	/** Operating band see enum op_band */
 	unsigned int op_band;
+	/** System parameters provided for controlling the TX power */
 	struct nrf_wifi_tx_pwr_ctrl_params tx_pwr_ctrl_params;
+	/** Offload mgmt buffer refill to UMAC when enabled */
 	unsigned char mgmt_buff_offload;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_cmd_sys_deinit - De-initialize UMAC
- * @sys_head: umac header, see &nrf_wifi_sys_head
+ * @brief This structure defines the command used to de-initialize the RPU.
  *
- * De-initializes the RPU.
  */
 
 struct nrf_wifi_cmd_sys_deinit {
+	/** umac header, @ref nrf_wifi_sys_head */
 	struct nrf_wifi_sys_head sys_head;
 } __NRF_WIFI_PKD;
 
@@ -584,329 +834,498 @@ struct nrf_wifi_cmd_sys_deinit {
 #define NRF_WIFI_HE_LTF_12800NS 2
 
 /**
- * struct nrf_wifi_cmd_he_gi_ltf_config - Confure HE-GI and HE-LTF.
- * @sys_head: umac header, see &nrf_wifi_sys_head
- * @wdev_id: wdev interface id.
- * @he_gi_type: HE GI type(NRF_WIFI_HE_GI_800NS/NRF_WIFI_HE_GI_1600NS/NRF_WIFI_HE_GI_3200NS).
- * @he_ltf: HE LTF(NRF_WIFI_HE_LTF_3200NS/NRF_WIFI_HE_LTF_6400NS/NRF_WIFI_HE_LTF_12800NS).
- * @enable: Fixed HE GI & LTF values can be enabled and disabled
- * Host configures the HE-GI & HE-LTF for testing purpose
- * need to use this values in Tx command sending to LMAC.
+ * @brief This structure defines the command used to configure
+ *  High-Efficiency Guard Interval(HE-GI) and High-Efficiency Long Training Field (HE-LTF).
+ *
+ *  HE-GI duration determines the guard interval length used in the HE transmission.
+ *  HE-LTF is used for channel estimation and signal detection in HE transmissions.
+ *
  */
 
 struct nrf_wifi_cmd_he_gi_ltf_config {
+	/** umac header, see &nrf_wifi_sys_head */
 	struct nrf_wifi_sys_head sys_head;
+	/** wdev interface id */
 	unsigned char wdev_id;
-#define NRF_WIFI_HE_GI_800NS 0
-#define NRF_WIFI_HE_GI_1600NS 1
-#define NRF_WIFI_HE_GI_3200NS 2
+	/** HE GI type (NRF_WIFI_HE_GI_800NS/NRF_WIFI_HE_GI_1600NS/NRF_WIFI_HE_GI_3200NS) */
 	unsigned char he_gi_type;
+	/** HE LTF (NRF_WIFI_HE_LTF_3200NS/NRF_WIFI_HE_LTF_6400NS/NRF_WIFI_HE_LTF_12800NS) */
 	unsigned char he_ltf;
+	/** Fixed HE GI & LTF values can be enabled and disabled */
 	unsigned char enable;
 } __NRF_WIFI_PKD;
 
-#define		NRF_WIFI_DISABLE		0
+#define		NRF_WIFI_DISABLE	0
 #define		NRF_WIFI_ENABLE		1
-
+/**
+ * @brief This enum represents the different types of preambles used.
+ *  Preambles are sequences of known symbols transmitted before the actual
+ *  data transmission to enable synchronization, channel estimation, and
+ *  frame detection at the receiver.
+ *
+ */
 enum rpu_pkt_preamble {
+	/** Short preamble packet */
 	RPU_PKT_PREAMBLE_SHORT,
+	/** Long preamble packet */
 	RPU_PKT_PREAMBLE_LONG,
+	/** mixed preamble packet */
 	RPU_PKT_PREAMBLE_MIXED,
+	/** Highest preamble type currently defined */
 	RPU_PKT_PREAMBLE_MAX,
 };
 
 
-
+/**
+ * @brief This structure describes different Physical Layer (PHY) configuration parameters used
+ *  in RF test and Radio test scenarios. These parameters are specific to testing and evaluating
+ *  the performance of the radio hardware.
+ *
+ */
 struct rpu_conf_params {
+	/** Unused. Number of spatial streams supported. Support is there for 1x1 only. */
 	unsigned char nss;
+	/** Unused */
 	unsigned char antenna_sel;
+	/** An array containing RF & baseband control params */
 	unsigned char rf_params[NRF_WIFI_RF_PARAMS_SIZE];
+	/** Not required */
 	unsigned char tx_pkt_chnl_bw;
+	/** WLAN packet formats. 0->Legacy 1->HT 2->VHT 3->HE(SU) 4->HE(ERSU) and 5->HE(TB) */
 	unsigned char tx_pkt_tput_mode;
+	/** Short Guard enable/disable */
 	unsigned char tx_pkt_sgi;
-
+	/** Not required */
 	unsigned char tx_pkt_nss;
+	/** Preamble type. 0->short, 1->Long and 2->Mixed */
 	unsigned char tx_pkt_preamble;
+	/** Not used */
 	unsigned char tx_pkt_stbc;
+	/** 0->BCC 1->LDPC. Supporting only BCC in nRF7002 */
 	unsigned char tx_pkt_fec_coding;
+	/** Valid MCS number between 0 to 7 */
 	signed char tx_pkt_mcs;
+	/** Legacy rate to be used in Mbps (1, 2, 5.5, 11, 6, 9, 12, 18, 24, 36, 48, 54) */
 	signed char tx_pkt_rate;
+	/** Copy OTP params to this memory */
 	signed char phy_threshold;
+	/** Calibration bit map value. refer NRF_WIFI_DEF_PHY_CALIB */
 	unsigned int phy_calib;
+	/** Radio test mode or System mode selection */
 	signed int op_mode;
+	/** Channel related info viz, channel, bandwidth, primary 20 offset */
 	struct chan_params chan;
+	/** Value of 0 means continuous transmission.Greater than 1 is invalid */
 	unsigned char tx_mode;
+	/** Number of packets to be transmitted. Any number above 0.
+	 *  Set -1 for continuous transmission
+	 */
 	signed int tx_pkt_num;
+	/** Length of the packet (in bytes) to be transmitted */
 	unsigned short tx_pkt_len;
+	/** Desired TX power in dBm in the range 0 dBm to 21 dBm in steps of 1 dBm */
 	unsigned int tx_power;
+	/** Transmit WLAN packet */
 	unsigned char tx;
+	/** Receive WLAN packet */
 	unsigned char rx;
+	/**  Not required */
 	unsigned char aux_adc_input_chain_id;
+	/**  Unused */
 	unsigned char agg;
+	/** Select HE LTF type viz, 0->1x, 1->2x and 2->4x */
 	unsigned char he_ltf;
+	/** Select HE LTF type viz, 0->0.8us, 1->1.6us and 2->3.2us */
 	unsigned char he_gi;
+	/** Not required */
 	unsigned char set_he_ltf_gi;
+	/** Not required */
 	unsigned char power_save;
+	/** Not required */
 	unsigned int rts_threshold;
+	/** Not required */
 	unsigned int uapsd_queue;
+	/** Interval between TX packets in us (Min: 200, Max: 200000, Default: 200) */
 	unsigned int tx_pkt_gap_us;
+	/** Configure WLAN antenna switch(0-separate/1-shared) */
 	unsigned char wlan_ant_switch_ctrl;
+	/** Switch to control the BLE antenna or shared WiFi antenna */
 	unsigned char ble_ant_switch_ctrl;
+	/** Resource unit (RU) size (26,52,106 or 242) */
 	unsigned char ru_tone;
+	/** Location of resource unit (RU) in 20 MHz spectrum */
 	unsigned char ru_index;
+	/** Desired tone frequency to be transmitted */
 	signed char tx_tone_freq;
+	/** RX LNA gain */
 	unsigned char lna_gain;
+	/** RX BB gain */
 	unsigned char bb_gain;
+	/** Number of RX samples to be captured */
 	unsigned short int capture_length;
+	/** Configure WLAN to bypass regulatory */
 	unsigned char bypass_regulatory;
+	/** Two letter country code (00: Default for WORLD) */
 	unsigned char country_code[NRF_WIFI_COUNTRY_CODE_LEN];
+	/** Contention window value to be configured */
 	unsigned int tx_pkt_cw;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_cmd_mode_params
- * @sys_head: UMAC header, See &struct nrf_wifi_sys_head
- * @conf: configuration parameters of different modes see &union rpu_conf_params
+ * @brief This structure defines the command used to configure the RPU with different
+ *  PHY configuration parameters specifically designed for RF test and Radio test scenarios.
+ *  The command is intended to set up the RPU for testing and evaluating the performance
+ *  of the radio hardware.
  *
- * configures the RPU with config parameters provided in this command
  */
 
 struct nrf_wifi_cmd_mode_params {
+	/** UMAC header, See &struct nrf_wifi_sys_head */
 	struct nrf_wifi_sys_head sys_head;
+	/** configuration parameters of different modes see &union rpu_conf_params */
 	struct rpu_conf_params conf;
+	/** Packet length */
 	unsigned short pkt_length[MAX_TX_AGG_SIZE];
+	/** Packet ddr pointer */
 	unsigned int ddr_ptrs[MAX_TX_AGG_SIZE];
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_cmd_radio_test_init - command radio_test_init
- * @sys_head: UMAC header, See &struct nrf_wifi_sys_head
- * @conf: radiotest init configuration parameters
- * see &struct nrf_wifi_radio_test_init_info
+ * @brief This structure represents the parameters required to initialize a radio test.
  *
  */
 struct nrf_wifi_radio_test_init_info {
+	/** An array containing RF & baseband control params */
 	unsigned char rf_params[NRF_WIFI_RF_PARAMS_SIZE];
+	/** Channel related info viz, channel, bandwidth, primary 20 offset */
 	struct chan_params chan;
+	/** Phy threshold value to be sent to LMAC in channel programming */
 	signed char phy_threshold;
+	/** Calibration bit map value. refer phy_rf_params.h NRF_WIFI_DEF_PHY_CALIB */
 	unsigned int phy_calib;
 } __NRF_WIFI_PKD;
 
+/**
+ * @brief This structure defines the command used to initialize a radio test.
+ *
+ */
 struct nrf_wifi_cmd_radio_test_init {
+	/** UMAC header, @ref nrf_wifi_sys_head*/
 	struct nrf_wifi_sys_head sys_head;
+	/** radiotest init configuration parameters @ref nrf_wifi_radio_test_init_info */
 	struct nrf_wifi_radio_test_init_info conf;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_cmd_rx - command rx
- * @sys_head: UMAC header, See &struct nrf_wifi_sys_head
- * @conf: rx configuration parameters see &struct rpu_conf_rx_radio_test_params
- * @:rx_enable: 1-Enable Rx to receive packets contineously on specified channel
- *	0-Disable Rx stop receiving packets and clear statistics
- *
- * Command RPU to Enable/Disable Rx
+ * @brief This structure defines the command used to enable or disable the reception (Rx).
+ *  It allows controlling the radio hardware's receive functionality to start or stop listening
+ *  for incoming data frames.
  */
 
 struct nrf_wifi_cmd_rx {
+	/** UMAC header, @ref nrf_wifi_sys_head */
 	struct nrf_wifi_sys_head sys_head;
+	/** rx configuration parameters @ref rpu_conf_rx_radio_test_params */
 	struct rpu_conf_rx_radio_test_params conf;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_cmd_get_stats - Get statistics
- * @sys_head: UMAC header, See &struct nrf_wifi_sys_head
- * @stats_type: Statistics type see &enum rpu_stats_type
- * @op_mode: Production mode or FCM mode
- *
- * This command is to Request the statistics corresponding to stats_type
- * selected
+ * @brief This structure defines the command used to retrieve statistics from the RPU.
  *
  */
-
 struct nrf_wifi_cmd_get_stats {
+	/** UMAC header, @ref nrf_wifi_sys_head*/
 	struct nrf_wifi_sys_head sys_head;
+	/** Statistics type &enum rpu_stats_type */
 	signed int stats_type;
+	/** Production mode or FCM mode */
 	signed int op_mode;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_cmd_clear_stats - clear statistics
- * @sys_head: UMAC header, See &struct nrf_wifi_sys_head.
- * @stats_type: Type of statistics to clear see &enum rpu_stats_type
+ * @brief This structure defines the command used to clear or reset statistics.
  *
- * This command is to clear the statistics corresponding to stats_type selected
+ *
  */
-
 struct nrf_wifi_cmd_clear_stats {
+	/** UMAC header, @ref nrf_wifi_sys_head */
 	struct nrf_wifi_sys_head sys_head;
+	/** Type of statistics to clear &enum rpu_stats_type */
 	signed int stats_type;
 } __NRF_WIFI_PKD;
 
+/**
+ * @brief This structure represents the command used to obtain power monitor information
+ *  specific to different data types.
+ *
+ */
 struct nrf_wifi_cmd_pwr {
+	/** UMAC header, @ref nrf_wifi_sys_head */
 	struct nrf_wifi_sys_head sys_head;
+	/** Type of Control info that host need */
 	signed int data_type;
 } __NRF_WIFI_PKD;
 
+/**
+ * @brief Structure for coexistence (coex) switch configuration.
+ *
+ */
 struct coex_wlan_switch_ctrl {
+	/** Host to coexistence manager message id */
 	signed int rpu_msg_id;
+	/** Switch configuration value */
 	signed int switch_A;
 } __NRF_WIFI_PKD;
 
+/**
+ * @brief The structure represents the command used to configure the Wi-Fi side shared switch
+ *  for Bluetooth coexistence (btcoex).
+ *
+ */
 struct nrf_wifi_cmd_btcoex {
+	/** UMAC header, @ref nrf_wifi_sys_head */
 	struct nrf_wifi_sys_head sys_head;
+	/** Switch configuration data */
 	struct coex_wlan_switch_ctrl conf;
 } __NRF_WIFI_PKD;
 
+/**
+ * @brief The structure defines the parameters used to configure the coexistence hardware.
+ *
+ */
+
 struct rpu_cmd_coex_config_info {
+	/** Length of coexistence configuration data */
 	unsigned int len;
+	/** Coexistence configuration data */
 	unsigned char coex_cmd[0];
 } __NRF_WIFI_PKD;
 
+/**
+ * @brief This structure defines the command used to configure the coexistence hardware.
+ *
+ */
 struct nrf_wifi_cmd_coex_config {
+	/** UMAC header, @ref nrf_wifi_sys_head */
 	struct nrf_wifi_sys_head sys_head;
+	/** Coexistence configuration data. @ref rpu_cmd_coex_config_info */
 	struct rpu_cmd_coex_config_info coex_config_info;
 } __NRF_WIFI_PKD;
 
+/**
+ * @brief This structure describes the coexistence configuration data received
+ *  in the NRF_WIFI_EVENT_COEX_CONFIG event.
+ *
+ */
 struct rpu_evnt_coex_config_info {
+	/** Length of coexistence configuration data */
 	unsigned int len;
+	/** Coexistence configuration data */
 	unsigned char coex_event[0];
 } __NRF_WIFI_PKD;
 
+/**
+ * @brief This structure defines the event used to represent coexistence configuration.
+ *
+ */
 struct nrf_wifi_event_coex_config {
+	/** UMAC header, @ref nrf_wifi_sys_head */
 	struct nrf_wifi_sys_head sys_head;
+	/** Coexistence configuration data in the event. @ref rpu_evnt_coex_config_info */
 	struct rpu_evnt_coex_config_info coex_config_info;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_cmd_fix_tx_rate - UMAC deinitialization done
- * @sys_head: UMAC header, See &struct nrf_wifi_sys_head.
- * rate_flags: refer &enum rpu_tput_mode.
- * fixed_rate: -1 Disable fixed rate and use ratecontrol selected rate.
- *             >0 legacy rates: 1,2,55,11,6,9,12,18,24,36,48,54.
- *                11N VHT HE  : MCS index 0 to 7.
+ * @brief This structure defines the command used to fix the transmission (Tx) data rate.
+ *  The command allows setting a specific data rate for data transmission, ensuring that the
+ *  system uses the designated rate instead of dynamically adapting to changing channel conditions.
+ *
  */
 
 struct nrf_wifi_cmd_fix_tx_rate {
+	/** UMAC header, @ref nrf_wifi_sys_head */
 	struct nrf_wifi_sys_head sys_head;
+	/** refer see &enum rpu_tput_mode */
 	unsigned char rate_flags;
+	/** fixed_rate: -1 Disable fixed rate and use ratecontrol selected rate
+	 *  fixed rate: >0 legacy rates: 1,2,55,11,6,9,12,18,24,36,48,54
+	 *		  11N VHT HE  : MCS index 0 to 7.
+	 */
 	int fixed_rate;
 } __NRF_WIFI_PKD;
 
+/**
+ * @brief This structure describes rf test command information.
+ *
+ */
 struct rpu_cmd_rftest_info {
+	/** length of the rf test command */
 	unsigned int len;
+	/** Rf test command data */
 	unsigned char rfcmd[0];
 } __NRF_WIFI_PKD;
 
+/**
+ * @brief This structure defines the command used for RF (Radio Frequency) testing.
+ *  RF test commands are specifically designed to configure and control the radio hardware
+ *  for conducting tests and evaluating its performance in various scenarios.
+ *
+ */
 struct nrf_wifi_cmd_rftest {
+	/** UMAC header, @ref nrf_wifi_sys_head */
 	struct nrf_wifi_sys_head sys_head;
+	/** @ref rpu_cmd_rftest_info */
 	struct rpu_cmd_rftest_info rf_test_info;
 } __NRF_WIFI_PKD;
 
+/**
+ * @brief This structure describes rf test event information.
+ *
+ */
 struct rpu_evnt_rftest_info {
+	/** length of the rf test event */
 	unsigned int len;
+	/** Rf test event data */
 	unsigned char rfevent[0];
 } __NRF_WIFI_PKD;
 
+/**
+ * @brief This structure describes the event generated during RF (Radio Frequency) testing.
+ *
+ */
 struct nrf_wifi_event_rftest {
+	/** UMAC header, @ref nrf_wifi_sys_head */
 	struct nrf_wifi_sys_head sys_head;
+	/** @ref rpu_evnt_rftest_info */
 	struct rpu_evnt_rftest_info rf_test_info;
 } __NRF_WIFI_PKD;
 
+/**
+ * @brief This structure represents the power data event generated in response to
+ *  the NRF_WIFI_CMD_PWR command.
+ *
+ *  The NRF_WIFI_CMD_PWR command is used to retrieve power-related data or measurements
+ *  from the radio hardware.
+ *
+ */
 struct nrf_wifi_event_pwr_data {
+	/** UMAC header, @ref nrf_wifi_sys_head */
 	struct nrf_wifi_sys_head sys_head;
+	/** Power monitor command status info */
 	signed int mon_status;
+	/** Data */
 	signed int data_type;
+	/** Data that host may want to read from Power IP */
 	struct nrf_wifi_rpu_pwr_data data;
 } __NRF_WIFI_PKD;
 
-
 /**
- * struct rpu_fw_stats - FW statistics
- * @phy:  PHY statistics  see &struct rpu_phy_stats
- * @lmac: LMAC statistics see &struct rpu_lmac_stats
- * @umac: UMAC statistics see &struct rpu_umac_stats
- *
- * This structure is a combination of all the statistics that the RPU firmware
- * can provide
+ * @brief This structure is a comprehensive combination of all the firmware statistics
+ *  that the RPU (Radio Processing Unit) can provide.
  *
  */
-
 struct rpu_fw_stats {
+	/** PHY statistics  @ref rpu_phy_stats */
 	struct rpu_phy_stats phy;
 #ifndef CONFIG_NRF700X_RADIO_TEST
+	/** LMAC statistics @ref rpu_lmac_stats */
 	struct rpu_lmac_stats lmac;
+	/** UMAC statistics @ref rpu_umac_stats */
 	struct rpu_umac_stats umac;
 #endif /* !CONFIG_NRF700X_RADIO_TEST */
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_event_stats - statistics event
- * @sys_head: UMAC header, See &struct nrf_wifi_sys_head.
- * @fw: All the statistics that the firmware can provide.
+ * @brief This structure represents the event that provides RPU statistics in response
+ *  to the command NRF_WIFI_CMD_GET_STATS in a wireless communication system.
  *
- * This event is the response to command NRF_WIFI_CMD_GET_STATS.
+ *  The NRF_WIFI_CMD_GET_STATS command is used to request various statistics from the RPU.
  *
  */
 
 struct nrf_wifi_umac_event_stats {
+	/** UMAC header, @ref nrf_wifi_sys_head */
 	struct nrf_wifi_sys_head sys_head;
+	/** All the statistics that the firmware can provide @ref rpu_fw_stats*/
 	struct rpu_fw_stats fw;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_event_cmd_err_status - cmd error indication
- * @sys_head: UMAC header, See &struct nrf_wifi_sys_head.
- * @status: status of the command ie Fail(Type of err) or success.
- *
- * This event is the response to command chanl_prog.
+ * @brief This enum defines various error status values that may occur during a radio test.
  *
  */
 enum nrf_wifi_radio_test_err_status {
-		NRF_WIFI_UMAC_CMD_SUCCESS = 1,
-		NRF_WIFI_UMAC_INVALID_CHNL
+	/** Command success  */
+	NRF_WIFI_UMAC_CMD_SUCCESS = 1,
+	/** Invalid channel error */
+	NRF_WIFI_UMAC_INVALID_CHNL
 };
 
+/**
+ * @brief This structure defines an event that indicates the error status values that may occur
+ *  during a radio test. It serves as a response to the radio test commands.
+ *
+ */
 struct nrf_wifi_umac_event_err_status {
-		struct nrf_wifi_sys_head sys_head;
-		unsigned int status;
+	/** UMAC header, @ref nrf_wifi_sys_head */
+	struct nrf_wifi_sys_head sys_head;
+	/** status of the command, Fail/success &enum nrf_wifi_radio_test_err_status */
+	unsigned int status;
 } __NRF_WIFI_PKD;
 
-
 /**
- * struct nrf_wifi_event_init_done - UMAC initialization done
- * @sys_head: UMAC header, See &struct nrf_wifi_sys_head.
- *
- * RPU sends this event in response to NRF_WIFI_CMD_INIT indicating that the RPU is
- * initialized
+ * @brief This structure represents the UMAC initialization done event.
+ *  The event is sent by the RPU (Radio Processing Unit) in response to
+ *  the NRF_WIFI_CMD_INIT command, indicating that the RPU initialization
+ *  process has been completed successfully.
  */
 
 struct nrf_wifi_event_init_done {
+	/** UMAC header, @ref nrf_wifi_sys_head */
 	struct nrf_wifi_sys_head sys_head;
 } __NRF_WIFI_PKD;
 
+/**
+ * @brief structure for UMAC memory pool information.
+ *
+ */
 struct pool_data_to_host {
+	/** Size of the memory buffer */
 	unsigned int buffer_size;
+	/** Number of pool items available for the above memory buffer */
 	unsigned char num_pool_items;
+	/** Maximum pools allocated at any point of time */
 	unsigned char items_num_max_allocated;
+	/** Currently allocated pools */
 	unsigned char items_num_cur_allocated;
+	/** Total number of pool allocated */
 	unsigned int items_num_total_allocated;
+	/** Number of times this memory pool is full */
 	unsigned int items_num_not_allocated;
 } __NRF_WIFI_PKD;
 
+/**
+ * @brief This structure represents the event that provides UMAC (Upper MAC) internal
+ *  memory statistics in response to the NRF_WIFI_CMD_UMAC_INT_STATS command.
+ *
+ */
 struct umac_int_stats {
+	/** UMAC header, @ref nrf_wifi_sys_head */
 	struct nrf_wifi_sys_head sys_head;
+	/** See @ref pool_data_to_host */
 	struct pool_data_to_host scratch_dynamic_memory_info[56];
+	/** See @ref pool_data_to_host */
 	struct pool_data_to_host retention_dynamic_memory_info[56];
 } __NRF_WIFI_PKD;
+
 /**
- * struct nrf_wifi_event_deinit_done - UMAC deinitialization done
- * @sys_head: UMAC header, See &struct nrf_wifi_sys_head.
- *
- * RPU sends this event in response to NRF_WIFI_CMD_DEINIT indicating that the RPU is
- * deinitialized
+ * @brief This structure represents the event that indicates the completion of UMAC
+ *  deinitialization. The RPU sends this event as a response to the NRF_WIFI_CMD_DEINIT
+ *  command, signaling that the UMAC has been successfully deinitialized.
  */
 
 struct nrf_wifi_event_deinit_done {
+	/** UMAC header, @ref nrf_wifi_sys_head */
 	struct nrf_wifi_sys_head sys_head;
 } __NRF_WIFI_PKD;
 

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw/host_rpu_umac_if.h
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw/host_rpu_umac_if.h
@@ -343,41 +343,7 @@ enum nrf_wifi_auth_type {
 	NRF_WIFI_AUTHTYPE_AUTOMATIC
 };
 
-/**
- * enum nrf_wifi_hidden_ssid - Hidden SSID usage.
- * @NRF_WIFI_HIDDEN_SSID_NOT_IN_USE: Do not hide SSID (i.e., broadcast it in
- *	Beacon frames).
- * @NRF_WIFI_HIDDEN_SSID_ZERO_LEN: Hide SSID by using zero-length SSID element
- *	in Beacon frames.
- * @NRF_WIFI_HIDDEN_SSID_ZERO_CONTENTS: Hide SSID by using correct length of SSID
- *	element in Beacon frames but zero out each byte in the SSID.
- *
- * Enable/Disable Hidden SSID feature and also lists the different mechanisms of
- * hiding the SSIDs.
- */
-enum nrf_wifi_hidden_ssid {
-	NRF_WIFI_HIDDEN_SSID_NOT_IN_USE,
-	NRF_WIFI_HIDDEN_SSID_ZERO_LEN,
-	NRF_WIFI_HIDDEN_SSID_ZERO_CONTENTS
-};
 
-/**
- * enum nrf_wifi_smps_mode - SMPS mode.
- * @NRF_WIFI_SMPS_OFF: SMPS off (use all antennas).
- * @NRF_WIFI_SMPS_STATIC: Static SMPS (use a single antenna).
- * @NRF_WIFI_SMPS_DYNAMIC: Dynamic smps (start with a single antenna and
- *	turn on other antennas after CTS/RTS).
- *
- * Requested SMPS mode (for AP mode).
- */
-enum nrf_wifi_smps_mode {
-	NRF_WIFI_SMPS_OFF,
-	NRF_WIFI_SMPS_STATIC,
-	NRF_WIFI_SMPS_DYNAMIC,
-
-	__NRF_WIFI_SMPS_AFTER_LAST,
-	NRF_WIFI_SMPS_MAX = __NRF_WIFI_SMPS_AFTER_LAST - 1
-};
 
 /**
  * enum nrf_wifi_bss_status - BSS status.
@@ -1269,24 +1235,7 @@ struct nrf_wifi_umac_key_info {
 	unsigned char key_idx;
 } __NRF_WIFI_PKD;
 
-#define NRF_WIFI_CMD_GET_KEY_MAC_ADDR_VALID (1 << 0)
-#define NRF_WIFI_CMD_GET_KEY_KEY_IDX_VALID (1 << 1)
 
-struct nrf_wifi_umac_cmd_get_key {
-	struct nrf_wifi_umac_hdr umac_hdr;
-	unsigned int valid_fields;
-	unsigned char mac_addr[NRF_WIFI_ETH_ADDR_LEN];
-	unsigned char key_idx;
-} __NRF_WIFI_PKD;
-
-#define NRF_WIFI_EVENT_GET_KEY_MAC_ADDR_VALID (1 << 0)
-
-struct nrf_wifi_umac_event_get_key {
-	struct nrf_wifi_umac_hdr umac_hdr;
-	unsigned int valid_fields;
-	struct nrf_wifi_umac_key_info key_info;
-	unsigned char mac_addr[NRF_WIFI_ETH_ADDR_LEN];
-} __NRF_WIFI_PKD;
 
 /**
  * enum scan_mode - scan operation mode
@@ -1825,21 +1774,7 @@ struct freq_params {
 
 } __NRF_WIFI_PKD;
 
-/**
- * struct nrf_wifi_umac_cmd_set_channel - Set channel configuration.
- * @umac_hdr: UMAC command header. Refer &struct nrf_wifi_umac_hdr.
- * @valid_fields: Indicate which of the following structure parameters are valid.
- * @freq_params: Information related to channel parameters
- *
- * This structure represents the command to set the wireless channel configuration.
- */
 
-struct nrf_wifi_umac_cmd_set_channel {
-	struct nrf_wifi_umac_hdr umac_hdr;
-#define NRF_WIFI_CMD_SET_CHANNEL_FREQ_PARAMS_VALID (1 << 0)
-	unsigned int valid_fields;
-	struct freq_params freq_params;
-} __NRF_WIFI_PKD;
 /**
  * struct nrf_wifi_txq_params - TX queue parameter attributes.
  * @txop: Transmit oppurtunity.
@@ -2524,62 +2459,6 @@ struct nrf_wifi_umac_cmd_set_qos_map {
 	struct nrf_wifi_umac_qos_map_info info;
 } __NRF_WIFI_PKD;
 
-#define NRF_WIFI_SET_WOWLAN_FLAG_TRIG_ANY (1 << 0)
-#define NRF_WIFI_SET_WOWLAN_FLAG_TRIG_DISCONNECT (1 << 1)
-#define NRF_WIFI_SET_WOWLAN_FLAG_TRIG_MAGIC_PKT (1 << 2)
-#define NRF_WIFI_SET_WOWLAN_FLAG_TRIG_GTK_REKEY_FAILURE (1 << 3)
-#define NRF_WIFI_SET_WOWLAN_FLAG_TRIG_EAP_IDENT_REQUEST (1 << 4)
-#define NRF_WIFI_SET_WOWLAN_FLAG_TRIG_4WAY_HANDSHAKE (1 << 5)
-
-/**
- * struct nrf_wifi_umac_set_wowlan_info - Information about wowlan
- *	trigger settings.
- * @nrf_wifi_flags: Wakeup trigger conditions. NRF_WIFI_SET_WOWLAN_FLAG_TRIG_ANY,
- * NRF_WIFI_SET_WOWLAN_FLAG_TRIG_DISCONNECT and etc.
- *
- * This structure represents the information about wowlan settings.
- */
-
-struct nrf_wifi_umac_set_wowlan_info {
-	unsigned short nrf_wifi_flags;
-} __NRF_WIFI_PKD;
-
-/**
- * struct nrf_wifi_umac_cmd_set_wowlan - Setting Wake on WLAN configurations.
- * @umac_hdr: UMAC command header. Refer &struct nrf_wifi_umac_hdr.
- * @info: WoWLAN wakeup trigger information.
- *
- * This structure represents the command to set the WoWLAN triger
- * configs before going to sleep(Host).
- */
-
-struct nrf_wifi_umac_cmd_set_wowlan {
-	struct nrf_wifi_umac_hdr umac_hdr;
-	struct nrf_wifi_umac_set_wowlan_info info;
-} __NRF_WIFI_PKD;
-
-/**
- * struct nrf_wifi_umac_cmd_suspend - suspend the bus transactions.
- * @umac_hdr: UMAC command header. Refer &struct nrf_wifi_umac_hdr.
- *
- * This structure represents the command to suspend the bus transactions.
- */
-
-struct nrf_wifi_umac_cmd_suspend {
-	struct nrf_wifi_umac_hdr umac_hdr;
-} __NRF_WIFI_PKD;
-
-/**
- * struct nrf_wifi_umac_cmd_resume - resume the bus transactions.
- * @umac_hdr: UMAC command header. Refer &struct nrf_wifi_umac_hdr.
- *
- * This structure represents the command to resumes the bus transactions.
- */
-
-struct nrf_wifi_umac_cmd_resume {
-	struct nrf_wifi_umac_hdr umac_hdr;
-} __NRF_WIFI_PKD;
-
 /**
  * struct nrf_wifi_umac_cmd_get_tx_power - get tx power.
  * @umac_hdr: UMAC command header. Refer &struct nrf_wifi_umac_hdr.
@@ -2956,39 +2835,6 @@ struct nrf_wifi_umac_event_mlme {
 	unsigned char req_ie[0];
 } __NRF_WIFI_PKD;
 
-#define NRF_WIFI_EVENT_CONNECT_STATUS_CODE_VALID (1 << 0)
-#define NRF_WIFI_EVENT_CONNECT_MAC_ADDR_VALID (1 << 1)
-#define NRF_WIFI_EVENT_CONNECT_REQ_IE_VALID (1 << 2)
-#define NRF_WIFI_EVENT_CONNECT_RESP_IE_VALID (1 << 3)
-#define NRF_WIFI_EVENT_CONNECT_AUTHORIZED_VALID (1 << 4)
-#define NRF_WIFI_EVENT_CONNECT_KEY_REPLAY_CTR_VALID (1 << 5)
-#define NRF_WIFI_EVENT_CONNECT_PTK_KCK_VALID (1 << 6)
-#define NRF_WIFI_EVENT_CONNECT_PTK_KEK_VALID (1 << 7)
-
-/*
- * struct nrf_wifi_umac_event_connect - Connection complete event.
- * @umac_hdr: UMAC event header. Refer &struct nrf_wifi_umac_hdr.
- * @valid_fields: Indicate which of the following parameters are valid.
- * @status_code: StatusCode for the %NRF_WIFI_CMD_CONNECT event.
- * @mac_addr: BSSID of the BSS (6 octets).
- * @req_ie: if TRUE connect_ie will be correspnding to req_ie
- * @resp_ie: if TRUE connect_ie will be correspnding to resp_ie
- * @connect_ie: (Re)association request/response information elements as sent by peer,
- *	for ROAM and successful CONNECT events.
- *
- */
-
-struct nrf_wifi_umac_event_connect {
-	struct nrf_wifi_umac_hdr umac_hdr;
-	unsigned int valid_fields;
-	unsigned short status_code;
-	unsigned char mac_addr[NRF_WIFI_ETH_ADDR_LEN];
-	unsigned char req_ie;
-	unsigned char resp_ie;
-	struct nrf_wifi_ie connect_ie;
-
-} __NRF_WIFI_PKD;
-
 #define NRF_WIFI_CMD_SEND_STATION_ASSOC_REQ_IES_VALID (1 << 0)
 
 /**
@@ -3146,26 +2992,7 @@ struct nrf_wifi_umac_event_get_channel {
 	struct nrf_wifi_chan_definition chan_def;
 } __NRF_WIFI_PKD;
 
-struct umac_cmd_ibss_join {
-	struct nrf_wifi_umac_hdr umac_hdr;
-	struct nrf_wifi_ssid ssid;
-	struct freq_params freq_params;
-	unsigned char nrf_wifi_bssid[NRF_WIFI_ETH_ADDR_LEN];
-} __NRF_WIFI_PKD;
 
-struct nrf_wifi_cmd_leave_ibss {
-	struct nrf_wifi_umac_hdr umac_hdr;
-
-} __NRF_WIFI_PKD;
-
-struct nrf_wifi_umac_cmd_win_sta_connect {
-	struct nrf_wifi_umac_hdr umac_hdr;
-	unsigned int center_frequency;
-	signed int auth_type;
-	struct nrf_wifi_ie wpa_ie;
-	struct nrf_wifi_ssid ssid;
-	unsigned char nrf_wifi_bssid[NRF_WIFI_ETH_ADDR_LEN];
-} __NRF_WIFI_PKD;
 
 /* CMD_START_P2P_DEVICE */
 
@@ -3173,10 +3000,6 @@ struct nrf_wifi_cmd_start_p2p {
 	struct nrf_wifi_umac_hdr umac_hdr;
 } __NRF_WIFI_PKD;
 
-struct nrf_wifi_cmd_get_ifindex {
-	struct nrf_wifi_umac_hdr umac_hdr;
-	signed char ifacename[IFACENAMSIZ];
-} __NRF_WIFI_PKD;
 
 struct nrf_wifi_umac_cmd_conn_info {
 	struct nrf_wifi_umac_hdr umac_hdr;
@@ -3234,31 +3057,6 @@ struct nrf_wifi_umac_event_power_save_info {
 	unsigned short listen_interval;
 	unsigned char num_twt_flows;
 	struct nrf_wifi_umac_config_twt_info twt_flow_info[0];
-} __NRF_WIFI_PKD;
-
-#define NRF_WIFI_TX_BITRATE_MASK_LEGACY_MAX_LEN 8
-#define NRF_WIFI_IEEE80211_HT_MCS_MASK_LEN 10
-#define NRF_WIFI_VHT_NSS_MAX 8
-
-struct tx_rates {
-	unsigned int legacy_len;
-	unsigned int ht_mcs_len;
-	unsigned int vht_mcs_len;
-	unsigned char legacy[NRF_WIFI_TX_BITRATE_MASK_LEGACY_MAX_LEN];
-	unsigned char ht_mcs[NRF_WIFI_IEEE80211_HT_MCS_MASK_LEN];
-	unsigned short vht_mcs[NRF_WIFI_VHT_NSS_MAX];
-
-} __NRF_WIFI_PKD;
-
-#define NRF_WIFI_SET_TX_BITRATE_MASK_BAND_2GHZ_VALID (1 << 0)
-#define NRF_WIFI_SET_TX_BITRATE_MASK_BAND_5GHZ_VALID (1 << 1)
-#define NRF_WIFI_SET_TX_BITRATE_MASK_BAND_60GHZ_VALID (1 << 2)
-
-struct nrf_wifi_set_tx_bitrate_mask {
-	struct nrf_wifi_umac_hdr umac_hdr;
-	unsigned int valid_fields;
-	struct tx_rates control[3];
-
 } __NRF_WIFI_PKD;
 
 #define NRF_WIFI_EVENT_TRIGGER_SCAN_IE_VALID (1 << 0)
@@ -3550,34 +3348,10 @@ struct nrf_wifi_cmd_req_set_reg {
 	unsigned char nrf_wifi_alpha2[NRF_WIFI_COUNTRY_CODE_LEN];
 } __NRF_WIFI_PKD;
 
-struct nrf_wifi_event_send_beacon_hint {
-	struct nrf_wifi_umac_hdr umac_hdr;
-	struct nrf_wifi_event_channel channel_before;
-	struct nrf_wifi_event_channel channel_after;
-
-} __NRF_WIFI_PKD;
-
-#define NRF_WIFI_EVNT_WIPHY_SELF_MANAGED (1 << 0)
-
-struct nrf_wifi_event_regulatory_change {
-	struct nrf_wifi_umac_hdr umac_hdr;
-	unsigned short nrf_wifi_flags;
-	signed int intr;
-	signed char regulatory_type;
-	unsigned char nrf_wifi_alpha2[NRF_WIFI_COUNTRY_CODE_LEN];
-
-} __NRF_WIFI_PKD;
-
 struct nrf_wifi_umac_event_cmd_status {
 	struct nrf_wifi_umac_hdr umac_hdr;
 	unsigned int cmd_id;
 	unsigned int cmd_status;
 } __NRF_WIFI_PKD;
 
-struct nrf_wifi_umac_event_coalesce {
-	struct nrf_wifi_umac_hdr umac_hdr;
-	unsigned char sta_addr[NRF_WIFI_ETH_ADDR_LEN];
-	unsigned short tid;
-	unsigned char coalesce; /*1 = enable coalesce 0 = disable coalesce*/
-} __NRF_WIFI_PKD;
 #endif /* __HOST_RPU_UMAC_IF_H */

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw/host_rpu_umac_if.h
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw/host_rpu_umac_if.h
@@ -6,9 +6,10 @@
  */
 
 /**
- *
- *@brief <Control interface between host and RPU>
+ * @file
+ * @brief Control interface between host and RPU
  */
+
 #ifndef __HOST_RPU_UMAC_IF_H
 #define __HOST_RPU_UMAC_IF_H
 
@@ -20,613 +21,554 @@
 #define MAX_NRF_WIFI_UMAC_CMD_SIZE 400
 
 /**
- * enum nrf_wifi_umac_commands - Commands that the host can send to the RPU.
+ * @brief The host can send the following commands to the RPU.
  *
- * @NRF_WIFI_UMAC_CMD_TRIGGER_SCAN: Trigger a new scan with the given parameters.
- *	See &struct nrf_wifi_umac_cmd_scan
- * @NRF_WIFI_UMAC_CMD_GET_SCAN_RESULTS: Request for scan results.
- *	See &struct nrf_wifi_umac_cmd_get_scan_results
- * @NRF_WIFI_UMAC_CMD_AUTHENTICATE: Send authentication request to AP.
- *	See &struct nrf_wifi_umac_cmd_auth
- * @NRF_WIFI_UMAC_CMD_ASSOCIATE: Send associate request to AP.
- *	See &struct nrf_wifi_umac_cmd_assoc
- * @NRF_WIFI_UMAC_CMD_DEAUTHENTICATE: Send deauthentication request to AP.
- *	See &struct nrf_wifi_umac_cmd_disconn
- * @NRF_WIFI_UMAC_CMD_SET_WIPHY: Set wiphy parameters.
- *	See &struct nrf_wifi_umac_cmd_set_wiphy
- * @NRF_WIFI_UMAC_CMD_NEW_KEY: Add new key.
- *	See &struct nrf_wifi_umac_cmd_key
- * @NRF_WIFI_UMAC_CMD_DEL_KEY: Delete crypto key.
- *	See &struct nrf_wifi_umac_cmd_key
- * @NRF_WIFI_UMAC_CMD_SET_KEY: Set default key to use.
- *	See &struct nrf_wifi_umac_cmd_set_key
- * @NRF_WIFI_UMAC_CMD_GET_KEY: Unused.
- * @NRF_WIFI_UMAC_CMD_NEW_BEACON: Set the beacon fields in AP mode.
- *	See &struct nrf_wifi_umac_cmd_start_ap
- * @NRF_WIFI_UMAC_CMD_SET_BEACON: Set the beacon fields in AP mode.
- *	See &struct nrf_wifi_umac_cmd_set_beacon
- * @NRF_WIFI_UMAC_CMD_SET_BSS: Set the BSS.
- *	See &struct nrf_wifi_umac_cmd_set_bss
- * @NRF_WIFI_UMAC_CMD_START_AP: Start the device as Soft AP.
- *	See &struct nrf_wifi_umac_cmd_start_ap
- * @NRF_WIFI_UMAC_CMD_STOP_AP: Stop the AP mode.
- *	See &struct nrf_wifi_umac_cmd_stop_ap
- * @NRF_WIFI_UMAC_CMD_NEW_INTERFACE: Adding interface.
- *	See &struct nrf_wifi_umac_cmd_add_vif
- * @NRF_WIFI_UMAC_CMD_SET_INTERFACE: Change interface configuration.
- *	See &struct nrf_wifi_umac_cmd_chg_vif_attr
- * @NRF_WIFI_UMAC_CMD_DEL_INTERFACE: Delete interface.
- *	See &struct nrf_wifi_umac_cmd_del_vif
- * @NRF_WIFI_UMAC_CMD_SET_IFFLAGS: Change interface flags.
- *	See &struct nrf_wifi_umac_cmd_chg_vif_state
- * @NRF_WIFI_UMAC_CMD_NEW_STATION: Add a new station.
- *	See &struct nrf_wifi_umac_cmd_add_sta
- * @NRF_WIFI_UMAC_CMD_DEL_STATION: Delete station.
- *	See &struct nrf_wifi_umac_cmd_del_sta
- * @NRF_WIFI_UMAC_CMD_SET_STATION: Change station info.
- *	See &struct nrf_wifi_umac_cmd_chg_sta
- * @NRF_WIFI_UMAC_CMD_GET_STATION: Get station info.
- *	See &struct nrf_wifi_umac_cmd_get_sta
- * @NRF_WIFI_UMAC_CMD_START_P2P_DEVICE: Start the P2P device.
- *	See &struct nrf_wifi_umac_cmd_start_p2p_dev
- * @NRF_WIFI_UMAC_CMD_STOP_P2P_DEVICE: Stop the P2P device.
- *	See &struct nrf_wifi_umac_cmd_stop_p2p_dev
- * @NRF_WIFI_UMAC_CMD_REMAIN_ON_CHANNEL: Unused.
- * @NRF_WIFI_UMAC_CMD_CANCEL_REMAIN_ON_CHANNEL: Unused.
- * @NRF_WIFI_UMAC_CMD_SET_CHANNEL: Unused.
- * @NRF_WIFI_UMAC_CMD_RADAR_DETECT: Unused.
- * @NRF_WIFI_UMAC_CMD_REGISTER_FRAME: Whitelist filter based on frame types.
- *	See &struct nrf_wifi_umac_cmd_mgmt_frame_reg
- * @NRF_WIFI_UMAC_CMD_FRAME: Send a management frame.
- *	See &struct nrf_wifi_umac_cmd_mgmt_tx
- * @NRF_WIFI_UMAC_CMD_JOIN_IBSS: Unused.
- * @NRF_WIFI_UMAC_CMD_WIN_STA_CONNECT: Connect to AP.
- *	See &struct nrf_wifi_umac_cmd_win_sta_connect
- * @NRF_WIFI_UMAC_CMD_SET_POWER_SAVE: Power save Enable/Disable
- *	See &struct nrf_wifi_umac_cmd_set_power_save
- * @NRF_WIFI_UMAC_CMD_SET_WOWLAN: Set the WoWLAN trigger configs
- *	See &struct nrf_wifi_umac_cmd_set_wowlan
- * @NRF_WIFI_UMAC_CMD_SUSPEND: Suspend the bus after WoWLAN configurations
- *	See &struct nrf_wifi_umac_cmd_suspend
- * @NRF_WIFI_UMAC_CMD_RESUME: Resume the bus activity before wakeup
- *	See &struct nrf_wifi_umac_cmd_resume
- * @NRF_WIFI_UMAC_CMD_GET_CHANNEL: Get Channel info
- *		See &struct nrf_wifi_umac_cmd_get_channel
- * @NRF_WIFI_UMAC_CMD_GET_TX_POWER: Get Tx power level
- *		See &struct nrf_wifi_umac_cmd_get_tx_power
- * @NRF_WIFI_UMAC_CMD_GET_REG : Get Regulatory info
- *		See &struct nrf_wifi_reg_t
- * @NRF_WIFI_UMAC_CMD_SET_REG : Set Regulatory info
- *		See &struct nrf_wifi_reg_t
- *
- * Lists the different ID's to be used to when sending a command to the RPU.
- * All the commands are to be encapsulated using struct host_rpu_msg.
  */
 enum nrf_wifi_umac_commands {
-
+	/** Trigger a new scan @ref nrf_wifi_umac_cmd_scan */
 	NRF_WIFI_UMAC_CMD_TRIGGER_SCAN,
+	/** Request for scan results @ref nrf_wifi_umac_cmd_get_scan_results */
 	NRF_WIFI_UMAC_CMD_GET_SCAN_RESULTS,
+	/** Send authentication request to AP @ref nrf_wifi_umac_cmd_auth */
 	NRF_WIFI_UMAC_CMD_AUTHENTICATE,
+	/** Send associate request to AP @ref nrf_wifi_umac_cmd_assoc */
 	NRF_WIFI_UMAC_CMD_ASSOCIATE,
+	/** Send deauthentication request to AP @ref nrf_wifi_umac_cmd_disconn */
 	NRF_WIFI_UMAC_CMD_DEAUTHENTICATE,
+	/** Set wiphy parameters @ref nrf_wifi_umac_cmd_set_wiphy */
 	NRF_WIFI_UMAC_CMD_SET_WIPHY,
+	/** Add new key @ref nrf_wifi_umac_cmd_key */
 	NRF_WIFI_UMAC_CMD_NEW_KEY,
+	/** Delete key @ref nrf_wifi_umac_cmd_key */
 	NRF_WIFI_UMAC_CMD_DEL_KEY,
+	/** Set default key to use @ref nrf_wifi_umac_cmd_set_key */
 	NRF_WIFI_UMAC_CMD_SET_KEY,
+	/** Unused */
 	NRF_WIFI_UMAC_CMD_GET_KEY,
+	/** Unused */
 	NRF_WIFI_UMAC_CMD_NEW_BEACON,
+	/** Change the beacon on an AP interface @ref nrf_wifi_umac_cmd_set_beacon */
 	NRF_WIFI_UMAC_CMD_SET_BEACON,
+	/** Set the BSS @ref nrf_wifi_umac_cmd_set_bss */
 	NRF_WIFI_UMAC_CMD_SET_BSS,
+	/** Start soft AP operation on an AP interface @ref nrf_wifi_umac_cmd_start_ap */
 	NRF_WIFI_UMAC_CMD_START_AP,
+	/** Stop soft AP operation @ref nrf_wifi_umac_cmd_stop_ap */
 	NRF_WIFI_UMAC_CMD_STOP_AP,
+	/** Create new interface @ref nrf_wifi_umac_cmd_add_vif */
 	NRF_WIFI_UMAC_CMD_NEW_INTERFACE,
+	/** Change interface configuration @ref nrf_wifi_umac_cmd_chg_vif_attr*/
 	NRF_WIFI_UMAC_CMD_SET_INTERFACE,
+	/** Delete interface @ref nrf_wifi_umac_cmd_del_vif */
 	NRF_WIFI_UMAC_CMD_DEL_INTERFACE,
+	/** Change interface flags @ref nrf_wifi_umac_cmd_chg_vif_state */
 	NRF_WIFI_UMAC_CMD_SET_IFFLAGS,
-	NRF_WIFI_UMAC_CMD_NEW_STATION, /*Add a STA in SoftAP mode*/
+	/** Add a new station @ref nrf_wifi_umac_cmd_add_sta */
+	NRF_WIFI_UMAC_CMD_NEW_STATION,
+	/** Delete station @ref nrf_wifi_umac_cmd_del_sta */
 	NRF_WIFI_UMAC_CMD_DEL_STATION,
+	/** Change station info @ref nrf_wifi_umac_cmd_chg_sta */
 	NRF_WIFI_UMAC_CMD_SET_STATION,
+	/** Get station info @ref nrf_wifi_umac_cmd_get_sta */
 	NRF_WIFI_UMAC_CMD_GET_STATION,
+	/** Start the P2P device @ref nrf_wifi_cmd_start_p2p */
 	NRF_WIFI_UMAC_CMD_START_P2P_DEVICE,
+	/** Stop the P2P device @ref nrf_wifi_umac_cmd_stop_p2p_dev */
 	NRF_WIFI_UMAC_CMD_STOP_P2P_DEVICE,
+	/** Remain awake on the specified channel @ref nrf_wifi_umac_cmd_remain_on_channel */
 	NRF_WIFI_UMAC_CMD_REMAIN_ON_CHANNEL,
+	/** Cancel a pending ROC duration @ref nrf_wifi_umac_cmd_cancel_remain_on_channel */
 	NRF_WIFI_UMAC_CMD_CANCEL_REMAIN_ON_CHANNEL,
+	/** Unused */
 	NRF_WIFI_UMAC_CMD_SET_CHANNEL,
+	/** Unused */
 	NRF_WIFI_UMAC_CMD_RADAR_DETECT,
+	/** Whitelist filter based on frame types @ref nrf_wifi_umac_cmd_mgmt_frame_reg */
 	NRF_WIFI_UMAC_CMD_REGISTER_FRAME,
+	/** Send a management frame @ref nrf_wifi_umac_cmd_mgmt_tx */
 	NRF_WIFI_UMAC_CMD_FRAME,
+	/** Unused */
 	NRF_WIFI_UMAC_CMD_JOIN_IBSS,
+	/** Unused */
 	NRF_WIFI_UMAC_CMD_WIN_STA_CONNECT,
+	/** Power save Enable/Disable @ref nrf_wifi_umac_cmd_set_power_save */
 	NRF_WIFI_UMAC_CMD_SET_POWER_SAVE,
+	/** Unused */
 	NRF_WIFI_UMAC_CMD_SET_WOWLAN,
+	/** Unused */
 	NRF_WIFI_UMAC_CMD_SUSPEND,
+	/** Unused */
 	NRF_WIFI_UMAC_CMD_RESUME,
+	/** QOS map @ref nrf_wifi_umac_cmd_set_qos_map */
 	NRF_WIFI_UMAC_CMD_SET_QOS_MAP,
+	/** Get Channel info @ref nrf_wifi_umac_cmd_get_channel */
 	NRF_WIFI_UMAC_CMD_GET_CHANNEL,
+	/** Get Tx power level @ref nrf_wifi_umac_cmd_get_tx_power */
 	NRF_WIFI_UMAC_CMD_GET_TX_POWER,
+	/** Get interface @ref nrf_wifi_cmd_get_interface */
 	NRF_WIFI_UMAC_CMD_GET_INTERFACE,
+	/** Get Wiphy info @ref nrf_wifi_cmd_get_wiphy */
 	NRF_WIFI_UMAC_CMD_GET_WIPHY,
+	/** Get hardware address @ref nrf_wifi_cmd_get_ifhwaddr */
 	NRF_WIFI_UMAC_CMD_GET_IFHWADDR,
+	/** Set hardware address @ref nrf_wifi_cmd_set_ifhwaddr */
 	NRF_WIFI_UMAC_CMD_SET_IFHWADDR,
+	/** Get regulatory domain @ref nrf_wifi_umac_cmd_get_reg */
 	NRF_WIFI_UMAC_CMD_GET_REG,
+	/** Unused */
 	NRF_WIFI_UMAC_CMD_SET_REG,
+	/** Set regulatory domain @ref  nrf_wifi_cmd_req_set_reg */
 	NRF_WIFI_UMAC_CMD_REQ_SET_REG,
+	/** Config UAPSD @ref nrf_wifi_umac_cmd_config_uapsd */
 	NRF_WIFI_UMAC_CMD_CONFIG_UAPSD,
+	/** Config TWT @ref nrf_wifi_umac_cmd_config_twt */
 	NRF_WIFI_UMAC_CMD_CONFIG_TWT,
+	/** Teardown TWT @ref nrf_wifi_umac_cmd_teardown_twt */
 	NRF_WIFI_UMAC_CMD_TEARDOWN_TWT,
+	/** Abort scan @ref nrf_wifi_umac_cmd_abort_scan */
 	NRF_WIFI_UMAC_CMD_ABORT_SCAN,
+	/** Multicast filter @ref nrf_wifi_umac_cmd_mcast_filter */
 	NRF_WIFI_UMAC_CMD_MCAST_FILTER,
+	/** Change macaddress @ref nrf_wifi_umac_cmd_change_macaddr */
 	NRF_WIFI_UMAC_CMD_CHANGE_MACADDR,
+	/** Set powersave timeout @ref nrf_wifi_umac_cmd_set_power_save_timeout */
 	NRF_WIFI_UMAC_CMD_SET_POWER_SAVE_TIMEOUT,
+	/** Get connection information @ref nrf_wifi_umac_cmd_conn_info */
 	NRF_WIFI_UMAC_CMD_GET_CONNECTION_INFO,
+	/** Get power save information @ref nrf_wifi_umac_cmd_get_power_save_info */
 	NRF_WIFI_UMAC_CMD_GET_POWER_SAVE_INFO,
+	/** Set listen interval @ref nrf_wifi_umac_cmd_set_listen_interval */
 	NRF_WIFI_UMAC_CMD_SET_LISTEN_INTERVAL,
+	/** Configure extended power save @ref nrf_wifi_umac_cmd_config_extended_ps */
 	NRF_WIFI_UMAC_CMD_CONFIG_EXTENDED_PS
 };
 
-
-/**
- * enum nrf_wifi_umac_events - Events that the RPU can send to the host.
- *
- * @NRF_WIFI_UMAC_EVENT_TRIGGER_SCAN_START: Unused.
- * @NRF_WIFI_UMAC_EVENT_SCAN_ABORTED: Indicate scan has been cancelled.
- *	See &struct nrf_wifi_umac_event_trigger_scan
- * @NRF_WIFI_UMAC_EVENT_SCAN_DONE: Indicate scan results are available.
- *	See &struct nrf_wifi_umac_event_trigger_scan
- * @NRF_WIFI_UMAC_EVENT_SCAN_RESULT: Scan result. We will receive one event for all
- *	the scan results until umac_hdr->seq == 0.
- *	See &struct nrf_wifi_umac_event_new_scan_results
- * @NRF_WIFI_UMAC_EVENT_AUTHENTICATE: Authentication status.
- *	See &struct nrf_wifi_umac_event_mlme
- * @NRF_WIFI_UMAC_EVENT_ASSOCIATE: Association status.
- *	See &struct nrf_wifi_umac_event_mlme
- * @NRF_WIFI_UMAC_EVENT_CONNECT: Connection complete event.
- *	See &struct nrf_wifi_umac_event_connect
- * @NRF_WIFI_UMAC_EVENT_DEAUTHENTICATE: Station deauth event.
- *	See &struct nrf_wifi_umac_event_mlme
- * @NRF_WIFI_UMAC_EVENT_NEW_STATION: Station added indication.
- *	See &struct nrf_wifi_umac_event_new_station
- * @NRF_WIFI_UMAC_EVENT_DEL_STATION: Station deleted indication.
- *	See &struct nrf_wifi_umac_event_new_station
- * @NRF_WIFI_UMAC_EVENT_GET_STATION: Station info indication.
- *	See &nrf_wifi_umac_event_station_t
- * @NRF_WIFI_UMAC_EVENT_REMAIN_ON_CHANNEL: Unused.
- * @NRF_WIFI_UMAC_EVENT_CANCEL_REMAIN_ON_CHANNEL: Unused.
- * @NRF_WIFI_UMAC_EVENT_DISCONNECT: Unused.
- * @NRF_WIFI_UMAC_EVENT_FRAME: RX management frame.
- *	See &struct nrf_wifi_umac_event_mlme
- * @NRF_WIFI_UMAC_EVENT_COOKIE_RESP: Cookie mapping for NRF_WIFI_UMAC_CMD_FRAME.
- *	See &struct nrf_wifi_umac_event_cookie_rsp
- * @NRF_WIFI_UMAC_EVENT_FRAME_TX_STATUS: TX management frame transmitted.
- *	See &struct nrf_wifi_umac_event_mlme
- * @NRF_WIFI_UMAC_EVENT_GET_CHANNEL: Send Channel info.
- *	See &struct nrf_wifi_umac_event_get_channel
- * @NRF_WIFI_UMAC_EVENT_GET_TX_POWER: Send Tx power.
- *	See &struct nrf_wifi_umac_event_get_tx_power
- * @NRF_WIFI_UMAC_EVENT_SET_INTERFACE: NRF_WIFI_UMAC_CMD_SET_INTERFACE status.
- *	See &struct nrf_wifi_umac_event_set_interface
- * @NRF_WIFI_UMAC_EVENT_GET_REG: NRF_WIFI_UMAC_CMD_GET_REG status
- *	See &struct nrf_wifi_reg_t
- * @NRF_WIFI_UMAC_EVENT_SET_REG: NRF_WIFI_UMAC_CMD_SET_REG status
- *	See &struct nrf_wifi_reg_t
- * @NRF_WIFI_UMAC_EVENT_REQ_SET_REG: NRF_WIFI_UMAC_CMD_REQ_SET_REG status
- *	See &struct nrf_wifi_reg_t
- * @NRF_WIFI_UMAC_EVENT_SCAN_DISPLAY_RESULT: Scan display result. We will receive one event for all
- *	the scan results until umac_hdr->seq == 0
- * Lists the ID's to used by the RPU when sending a Event to the Host. All the
- * events are encapsulated using struct host_rpu_msg.
- */
+ /**
+  * @brief The host can receive the following events from the RPU.
+  *
+  */
 
 enum nrf_wifi_umac_events {
 	NRF_WIFI_UMAC_EVENT_UNSPECIFIED = 256,
+	/** Indicate scan started @ref nrf_wifi_umac_event_trigger_scan */
 	NRF_WIFI_UMAC_EVENT_TRIGGER_SCAN_START,
+	/** Unused */
 	NRF_WIFI_UMAC_EVENT_SCAN_ABORTED,
+	/** Indicate scan done @ref nrf_wifi_umac_event_scan_done */
 	NRF_WIFI_UMAC_EVENT_SCAN_DONE,
+	/** Scan result event @ref nrf_wifi_umac_event_new_scan_results */
 	NRF_WIFI_UMAC_EVENT_SCAN_RESULT,
+	/** Authentication status @ref nrf_wifi_umac_event_mlme */
 	NRF_WIFI_UMAC_EVENT_AUTHENTICATE,
+	/** Association status @ref nrf_wifi_umac_event_mlme*/
 	NRF_WIFI_UMAC_EVENT_ASSOCIATE,
+	/** Unused */
 	NRF_WIFI_UMAC_EVENT_CONNECT,
+	/** Station deauth event @ref nrf_wifi_umac_event_mlme */
 	NRF_WIFI_UMAC_EVENT_DEAUTHENTICATE,
+	/** Station disassoc event @ref nrf_wifi_umac_event_mlme */
 	NRF_WIFI_UMAC_EVENT_DISASSOCIATE,
+	/** Station added indication @ref nrf_wifi_umac_event_new_station */
 	NRF_WIFI_UMAC_EVENT_NEW_STATION,
+	/** Station added indication @ref nrf_wifi_umac_event_new_station */
 	NRF_WIFI_UMAC_EVENT_DEL_STATION,
+	/** Station info indication @ref nrf_wifi_umac_event_new_station */
 	NRF_WIFI_UMAC_EVENT_GET_STATION,
+	/** remain on channel event @ref nrf_wifi_event_remain_on_channel */
 	NRF_WIFI_UMAC_EVENT_REMAIN_ON_CHANNEL,
+	/** Unused */
 	NRF_WIFI_UMAC_EVENT_CANCEL_REMAIN_ON_CHANNEL,
+	/** Unused */
 	NRF_WIFI_UMAC_EVENT_DISCONNECT,
+	/** RX management frame @ref nrf_wifi_umac_event_mlme */
 	NRF_WIFI_UMAC_EVENT_FRAME,
+	/** Cookie mapping for NRF_WIFI_UMAC_CMD_FRAME @ref nrf_wifi_umac_event_cookie_rsp */
 	NRF_WIFI_UMAC_EVENT_COOKIE_RESP,
+	/** TX management frame transmitted @ref nrf_wifi_umac_event_mlme */
 	NRF_WIFI_UMAC_EVENT_FRAME_TX_STATUS,
+	/** @ref nrf_wifi_umac_event_vif_state */
 	NRF_WIFI_UMAC_EVENT_IFFLAGS_STATUS,
+	/** Send Tx power @ref nrf_wifi_umac_event_get_tx_power */
 	NRF_WIFI_UMAC_EVENT_GET_TX_POWER,
+	/** Send Channel info @ref nrf_wifi_umac_event_get_channel */
 	NRF_WIFI_UMAC_EVENT_GET_CHANNEL,
+	/** @ref nrf_wifi_umac_event_set_interface */
 	NRF_WIFI_UMAC_EVENT_SET_INTERFACE,
+	/** @ref nrf_wifi_umac_event_mlme */
 	NRF_WIFI_UMAC_EVENT_UNPROT_DEAUTHENTICATE,
+	/** @ref nrf_wifi_umac_event_mlme */
 	NRF_WIFI_UMAC_EVENT_UNPROT_DISASSOCIATE,
+	/** @ref nrf_wifi_interface_info */
 	NRF_WIFI_UMAC_EVENT_NEW_INTERFACE,
+	/** @ref nrf_wifi_event_get_wiphy */
 	NRF_WIFI_UMAC_EVENT_NEW_WIPHY,
+	/** Unused */
 	NRF_WIFI_UMAC_EVENT_GET_IFHWADDR,
+	/** Get regulatory @ref nrf_wifi_reg */
 	NRF_WIFI_UMAC_EVENT_GET_REG,
+	/** Unused */
 	NRF_WIFI_UMAC_EVENT_SET_REG,
+	/** Unused */
 	NRF_WIFI_UMAC_EVENT_REQ_SET_REG,
+	/** Unused */
 	NRF_WIFI_UMAC_EVENT_GET_KEY,
+	/** Unused */
 	NRF_WIFI_UMAC_EVENT_BEACON_HINT,
+	/** Unused */
 	NRF_WIFI_UMAC_EVENT_REG_CHANGE,
+	/** Unused */
 	NRF_WIFI_UMAC_EVENT_WIPHY_REG_CHANGE,
+	/** Display scan result @ref nrf_wifi_umac_event_new_scan_display_results */
 	NRF_WIFI_UMAC_EVENT_SCAN_DISPLAY_RESULT,
+	/** @ref nrf_wifi_umac_event_cmd_status */
 	NRF_WIFI_UMAC_EVENT_CMD_STATUS,
+	/** @ref nrf_wifi_umac_event_new_scan_results */
 	NRF_WIFI_UMAC_EVENT_BSS_INFO,
+	/** Send TWT response information @ref nrf_wifi_umac_cmd_config_twt */
 	NRF_WIFI_UMAC_EVENT_CONFIG_TWT,
+	/** Send TWT teardown information @ref nrf_wifi_umac_cmd_teardown_twt */
 	NRF_WIFI_UMAC_EVENT_TEARDOWN_TWT,
+	/** Send block or unblock state @ref nrf_wifi_umac_event_twt_sleep */
 	NRF_WIFI_UMAC_EVENT_TWT_SLEEP,
+	/** Unused */
 	NRF_WIFI_UMAC_EVENT_COALESCING,
+	/** Unused */
 	NRF_WIFI_UMAC_EVENT_MCAST_FILTER,
+	/** send connection information @ref nrf_wifi_umac_event_conn_info. */
 	NRF_WIFI_UMAC_EVENT_GET_CONNECTION_INFO,
+	/** @ref nrf_wifi_umac_event_power_save_info */
 	NRF_WIFI_UMAC_EVENT_GET_POWER_SAVE_INFO
 };
-#define	IMG_UMAC_EVENT_MCAST_FILTER 298
+
 /**
- * enum nrf_wifi_band - Frequency band.
+ * @brief Represents the values that can be used to specify the frequency band.
  *
- * @NRF_WIFI_BAND_2GHZ: 2.4 GHz ISM band.
- * @NRF_WIFI_BAND_5GHZ: Around 5 GHz band (4.9 - 5.7 GHz).
- * @NRF_WIFI_BAND_60GHZ: Unused.
- *
- * This enum represents the values that can be used to specify which frequency
- * band is used.
  */
+
 enum nrf_wifi_band {
+	/** 2.4 GHz ISM band */
 	NRF_WIFI_BAND_2GHZ,
+	/** Around 5 GHz band (4.9 - 5.7 GHz) */
 	NRF_WIFI_BAND_5GHZ,
+	/** Unused */
 	NRF_WIFI_BAND_60GHZ,
 };
 
 /**
- * enum nrf_wifi_mfp - Management frame protection state.
+ * @brief Enable or Disable Management Frame Protection.
  *
- * @NRF_WIFI_MFP_NO: Management frame protection not used.
- * @NRF_WIFI_MFP_REQUIRED: Management frame protection required.
- *
- * Enabling/Disabling of Management Frame Protection.
  */
 enum nrf_wifi_mfp {
+	/** Management frame protection not used */
 	NRF_WIFI_MFP_NO,
+	/** Management frame protection required */
 	NRF_WIFI_MFP_REQUIRED,
 };
 
 /**
- * enum nrf_wifi_key_type - Key Type
+ * @brief Enumerates the various categories of security keys.
  *
- * @NRF_WIFI_KEYTYPE_GROUP: Group (broadcast/multicast) key
- * @NRF_WIFI_KEYTYPE_PAIRWISE: Pairwise (unicast/individual) key
- * @NRF_WIFI_KEYTYPE_PEERKEY: Peer key (DLS)
- * @NUM_NRF_WIFI_KEYTYPES: Number of defined key types
- *
- * Lists the different categories of security keys.
  */
 enum nrf_wifi_key_type {
-
+	/** Group (broadcast/multicast) key */
 	NRF_WIFI_KEYTYPE_GROUP,
+	/** Pairwise (unicast/individual) key */
 	NRF_WIFI_KEYTYPE_PAIRWISE,
+	/** Peer key (DLS) */
 	NRF_WIFI_KEYTYPE_PEERKEY,
-
+	/** Number of defined key types */
 	NUM_NRF_WIFI_KEYTYPES
 };
 
 /**
- * enum nrf_wifi_auth_type - Authentication Type.
+ * @brief Enumerates the various types of authentication mechanisms.
  *
- * @NRF_WIFI_AUTHTYPE_OPEN_SYSTEM: Open System authentication.
- * @NRF_WIFI_AUTHTYPE_SHARED_KEY: Shared Key authentication (WEP only).
- * @NRF_WIFI_AUTHTYPE_FT: Fast BSS Transition (IEEE 802.11r).
- * @NRF_WIFI_AUTHTYPE_NETWORK_EAP: Network EAP (some Cisco APs and mainly LEAP).
- * @NRF_WIFI_AUTHTYPE_SAE: Simultaneous authentication of equals.
- * @__NRF_WIFI_AUTHTYPE_NUM: Internal.
- * @NRF_WIFI_AUTHTYPE_MAX: Maximum valid auth algorithm.
- * @NRF_WIFI_AUTHTYPE_AUTOMATIC: Determine automatically (if necessary by
- *	trying multiple times); this is invalid in netlink -- leave out
- *	the attribute for this on CONNECT commands.
- *
- * Lists the different types of authentication mechanisms.
  */
 enum nrf_wifi_auth_type {
-
+	/** Open System authentication */
 	NRF_WIFI_AUTHTYPE_OPEN_SYSTEM,
+	/** Shared Key authentication (WEP only) */
 	NRF_WIFI_AUTHTYPE_SHARED_KEY,
+	/** Fast BSS Transition (IEEE 802.11r) */
 	NRF_WIFI_AUTHTYPE_FT,
+	/** Network EAP (some Cisco APs and mainly LEAP) */
 	NRF_WIFI_AUTHTYPE_NETWORK_EAP,
+	/** Simultaneous authentication of equals */
 	NRF_WIFI_AUTHTYPE_SAE,
-
-	/* keep last */
+	/** Internal */
 	__NRF_WIFI_AUTHTYPE_NUM,
+	/** Maximum valid auth algorithm */
 	NRF_WIFI_AUTHTYPE_MAX = __NRF_WIFI_AUTHTYPE_NUM,
+	/** Determine automatically (if necessary by trying multiple times) */
 	NRF_WIFI_AUTHTYPE_AUTOMATIC
 };
 
-
-
 /**
- * enum nrf_wifi_bss_status - BSS status.
- * @NRF_WIFI_BSS_STATUS_AUTHENTICATED: Authenticated with this BSS.
- *	Note that this is no longer used since cfg80211 no longer
- *	keeps track of whether or not authentication was done with
- *	a given BSS.
- * @NRF_WIFI_BSS_STATUS_ASSOCIATED: Associated with this BSS.
- * @NRF_WIFI_BSS_STATUS_IBSS_JOINED: Joined to this IBSS.
+ * @brief Represents the interface's status concerning this BSS (Basic Service Set).
  *
- * The BSS status is a BSS attribute in scan dumps, which
- * indicates the status the interface has with respect to this BSS.
  */
 enum nrf_wifi_bss_status {
-
+	/**
+	 * Authenticated with this BSS
+	 * Note that this is no longer used since cfg80211 no longer
+	 * keeps track of whether or not authentication was done with
+	 * a given BSS.
+	 */
 	NRF_WIFI_BSS_STATUS_AUTHENTICATED,
+	/** Associated with this BSS */
 	NRF_WIFI_BSS_STATUS_ASSOCIATED,
+	/** Joined to this IBSS */
 	NRF_WIFI_BSS_STATUS_IBSS_JOINED,
 };
 
 /**
- * enum nrf_wifi_channel_type - Channel type.
- * @NRF_WIFI_CHAN_NO_HT: 20 MHz, non-HT channel.
- * @NRF_WIFI_CHAN_HT20: 20 MHz HT channel.
- * @NRF_WIFI_CHAN_HT40MINUS: HT40 channel, secondary channel
- *      below the control channel.
- * @NRF_WIFI_CHAN_HT40PLUS: HT40 channel, secondary channel
- *      above the control channel.
+ * @brief Enumerates the various categories of channels.
  *
- * Lists the different categories of channels.
  */
 enum nrf_wifi_channel_type {
+	/** 20 MHz, non-HT channel */
 	NRF_WIFI_CHAN_NO_HT,
+	/** 20 MHz HT channel */
 	NRF_WIFI_CHAN_HT20,
+	/** HT40 channel, secondary channel below the control channel */
 	NRF_WIFI_CHAN_HT40MINUS,
+	/** HT40 channel, secondary channel above the control channel */
 	NRF_WIFI_CHAN_HT40PLUS
 };
 
 /**
- * enum nrf_wifi_chan_width - Channel width definitions.
+ * @brief Enumerates the various channel widths available.
  *
- *
- * @NRF_WIFI_CHAN_WIDTH_20_NOHT: 20 MHz, non-HT channel.
- * @NRF_WIFI_CHAN_WIDTH_20: 20 MHz HT channel.
- * @NRF_WIFI_CHAN_WIDTH_40: 40 MHz channel, the %NRF_WIFI_ATTR_CENTER_FREQ1
- *	attribute must be provided as well.
- * @NRF_WIFI_CHAN_WIDTH_80: 80 MHz channel, the %NRF_WIFI_ATTR_CENTER_FREQ1
- *	attribute must be provided as well.
- * @NRF_WIFI_CHAN_WIDTH_80P80: 80+80 MHz channel, the %NRF_WIFI_ATTR_CENTER_FREQ1
- *	and %NRF_WIFI_ATTR_CENTER_FREQ2 attributes must be provided as well.
- * @NRF_WIFI_CHAN_WIDTH_160: 160 MHz channel, the %NRF_WIFI_ATTR_CENTER_FREQ1
- *	attribute must be provided as well.
- * @NRF_WIFI_CHAN_WIDTH_5: 5 MHz OFDM channel.
- * @NRF_WIFI_CHAN_WIDTH_10: 10 MHz OFDM channel.
- *
- * Lists the different channel widths.
  */
 enum nrf_wifi_chan_width {
+	/** 20 MHz, non-HT channel */
 	NRF_WIFI_CHAN_WIDTH_20_NOHT,
+	/** 20 MHz HT channel */
 	NRF_WIFI_CHAN_WIDTH_20,
+	/** 40 MHz channel, the @ref %NRF_WIFI_ATTR_CENTER_FREQ1 must be provided as well */
 	NRF_WIFI_CHAN_WIDTH_40,
+	/** 80 MHz channel, the @ref %NRF_WIFI_ATTR_CENTER_FREQ1 must be provided as well */
 	NRF_WIFI_CHAN_WIDTH_80,
+	/** 80+80 MHz channel, the @ref %NRF_WIFI_ATTR_CENTER_FREQ1 and
+	 *  @ref %NRF_WIFI_ATTR_CENTER_FREQ2 must be provided as well
+	 */
 	NRF_WIFI_CHAN_WIDTH_80P80,
+	/** 160 MHz channel, the %NRF_WIFI_ATTR_CENTER_FREQ1 must be provided as well */
 	NRF_WIFI_CHAN_WIDTH_160,
+	/**  5 MHz OFDM channel */
 	NRF_WIFI_CHAN_WIDTH_5,
+	/** 10 MHz OFDM channel */
 	NRF_WIFI_CHAN_WIDTH_10,
 };
 
 /**
- * enum nrf_wifi_iftype - Interface types based on functionality.
+ * @brief Interface types based on functionality.
  *
- * @NRF_WIFI_IFTYPE_UNSPECIFIED: Unspecified type, driver decides.
- * @NRF_WIFI_IFTYPE_ADHOC: Independent BSS member.
- * @NRF_WIFI_IFTYPE_STATION: Managed BSS member.
- * @NRF_WIFI_IFTYPE_AP: Access point.
- * @NRF_WIFI_IFTYPE_AP_VLAN: VLAN interface for access points; VLAN interfaces
- *      are a bit special in that they must always be tied to a pre-existing
- *      AP type interface.
- * @NRF_WIFI_IFTYPE_WDS: Wireless Distribution System.
- * @NRF_WIFI_IFTYPE_MONITOR: Monitor interface receiving all frames.
- * @NRF_WIFI_IFTYPE_MESH_POINT: Mesh point.
- * @NRF_WIFI_IFTYPE_P2P_CLIENT: P2P client.
- * @NRF_WIFI_IFTYPE_P2P_GO: P2P group owner.
- * @NRF_WIFI_IFTYPE_P2P_DEVICE: P2P device interface type, this is not a netdev
- *	and therefore can't be created in the normal ways, use the
- *	%NRF_WIFI_UMAC_CMD_START_P2P_DEVICE and %NRF_WIFI_UMAC_CMD_STOP_P2P_DEVICE
- *	commands (Refer &enum nrf_wifi_umac_commands) to create and destroy one.
- * @NRF_WIFI_IFTYPE_OCB: Outside Context of a BSS.
- *	This mode corresponds to the MIB variable dot11OCBActivated=true.
- * @NRF_WIFI_IFTYPE_MAX: Highest interface type number currently defined.
- * @NUM_NRF_WIFI_IFTYPES: Number of defined interface types.
- *
- * Lists the different interface types based on how they are configured
- * functionally.
  */
 enum nrf_wifi_iftype {
+	/** Unspecified type, driver decides */
 	NRF_WIFI_IFTYPE_UNSPECIFIED,
+	/** Not Supported */
 	NRF_WIFI_IFTYPE_ADHOC,
+	/** Managed BSS member */
 	NRF_WIFI_IFTYPE_STATION,
+	/** Access point */
 	NRF_WIFI_IFTYPE_AP,
+	/** Not Supported */
 	NRF_WIFI_IFTYPE_AP_VLAN,
+	/** Not Supported */
 	NRF_WIFI_IFTYPE_WDS,
+	/** Not Supported */
 	NRF_WIFI_IFTYPE_MONITOR,
+	/** Not Supported */
 	NRF_WIFI_IFTYPE_MESH_POINT,
+	/** P2P client */
 	NRF_WIFI_IFTYPE_P2P_CLIENT,
+	/** P2P group owner */
 	NRF_WIFI_IFTYPE_P2P_GO,
+	/** P2P device use the @ref %NRF_WIFI_UMAC_CMD_START_P2P_DEVICE &
+	 *  @ref %NRF_WIFI_UMAC_CMD_STOP_P2P_DEVICE commands to create and destroy one
+	 */
 	NRF_WIFI_IFTYPE_P2P_DEVICE,
+	/** Not Supported */
 	NRF_WIFI_IFTYPE_OCB,
-
-	/* keep last */
+	/** Highest interface type number currently defined */
 	NUM_NRF_WIFI_IFTYPES,
+	/** Number of defined interface types */
 	NRF_WIFI_IFTYPE_MAX = NUM_NRF_WIFI_IFTYPES - 1
 };
 
 /**
- * enum nrf_wifi_ps_state - powersave state
- * @NRF_WIFI_PS_DISABLED: powersave is disabled
- * @NRF_WIFI_PS_ENABLED: powersave is enabled
+ * @brief Powersave state.
+ *
  */
 enum nrf_wifi_ps_state {
+	/** powersave is disabled */
 	NRF_WIFI_PS_DISABLED,
+	/** powersave is enabled */
 	NRF_WIFI_PS_ENABLED,
 };
 
-/*Will add additional info if required*/
 /**
- * enum nrf_wifi_security_type - WLAN security type
- * @NRF_WIFI_WEP: WEP
- * @NRF_WIFI_WPA: WPA
- * @NRF_WIFI_WPA2: WPA2
- * @NRF_WIFI_WPA3: WPA3
- * @NRF_WIFI_WAPI: WAPI
+ * @brief WLAN security types.
+ *
  */
 enum nrf_wifi_security_type {
+	/** OPEN */
 	NRF_WIFI_OPEN,
+	/** WEP */
 	NRF_WIFI_WEP,
+	/** WPA */
 	NRF_WIFI_WPA,
+	/** WPA2 */
 	NRF_WIFI_WPA2,
+	/** WPA3 */
 	NRF_WIFI_WPA3,
+	/** WAPI */
 	NRF_WIFI_WAPI,
+	/** Enterprise mode */
 	NRF_WIFI_EAP,
+	/** WPA2 sha 256 */
 	NRF_WIFI_WPA2_256
 };
 
 /**
- * enum nrf_wifi_reg_initiator - Indicates the initiator of a reg domain request
- * @NL80211_REGDOM_SET_BY_CORE: Core queried CRDA for a dynamic world
- * regulatory domain.
- * @NL80211_REGDOM_SET_BY_USER: User asked the wireless core to set the
- * regulatory domain.
- * @NL80211_REGDOM_SET_BY_DRIVER: a wireless drivers has hinted to the
- * wireless core it thinks its knows the regulatory domain we should be in.
- * @NL80211_REGDOM_SET_BY_COUNTRY_IE: the wireless core has received an
- * 802.11 country information element with regulatory information it
- * thinks we should consider. cfg80211 only processes the country
- *	code from the IE, and relies on the regulatory domain information
- *	structure passed by userspace (CRDA) from our wireless-regdb.
- *	If a channel is enabled but the country code indicates it should
- *	be disabled we disable the channel and re-enable it upon disassociation.
+ * @brief Denotes the originator of a regulatory domain request.
+ *
  */
 enum nrf_wifi_reg_initiator {
+	/** Core queried CRDA for a dynamic world regulatory domain */
 	NRF_WIFI_REGDOM_SET_BY_CORE,
+	/** User asked the wireless core to set the regulatory domain */
 	NRF_WIFI_REGDOM_SET_BY_USER,
+	/**
+	 * A wireless drivers has hinted to the wireless core it thinks
+	 * its knows the regulatory domain we should be in
+	 */
 	NRF_WIFI_REGDOM_SET_BY_DRIVER,
+	/**
+	 * the wireless core has received an
+	 * 802.11 country information element with regulatory information it
+	 * thinks we should consider. cfg80211 only processes the country
+	 * code from the IE, and relies on the regulatory domain information
+	 * structure passed by userspace (CRDA) from our wireless-regdb
+	 * If a channel is enabled but the country code indicates it should
+	 * be disabled we disable the channel and re-enable it upon disassociation
+	 */
 	NRF_WIFI_REGDOM_SET_BY_COUNTRY_IE,
 };
 
 /**
- * enum nrf_wifi_reg_type - specifies the type of regulatory domain
- * @NL80211_REGDOM_TYPE_COUNTRY: the regulatory domain set is one that pertains
- *	to a specific country. When this is set you can count on the
- *	ISO / IEC 3166 alpha2 country code being valid.
- * @NL80211_REGDOM_TYPE_WORLD: the regulatory set domain is the world regulatory
- * domain.
- * @NL80211_REGDOM_TYPE_CUSTOM_WORLD: the regulatory domain set is a custom
- * driver specific world regulatory domain. These do not apply system-wide
- * and are only applicable to the individual devices which have requested
- * them to be applied.
- * @NL80211_REGDOM_TYPE_INTERSECTION: the regulatory domain set is the product
- *	of an intersection between two regulatory domains -- the previously
- *	set regulatory domain on the system and the last accepted regulatory
- *	domain request to be processed.
+ * @brief Specifies the type of regulatory domain.
+ *
  */
 enum nrf_wifi_reg_type {
+	/**
+	 * the regulatory domain set is one that pertains
+	 * to a specific country. When this is set you can count on the
+	 * ISO / IEC 3166 alpha2 country code being valid.
+	 *
+	 */
 	NRF_WIFI_REGDOM_TYPE_COUNTRY,
+	/** the regulatory set domain is the world regulatory domain */
 	NRF_WIFI_REGDOM_TYPE_WORLD,
+	/**
+	 * the regulatory domain set is a custom
+	 * driver specific world regulatory domain. These do not apply system-wide
+	 * and are only applicable to the individual devices which have requested
+	 * them to be applied.
+	 */
 	NRF_WIFI_REGDOM_TYPE_CUSTOM_WORLD,
+	/**
+	 * the regulatory domain set is the product
+	 * of an intersection between two regulatory domains -- the previously
+	 * set regulatory domain on the system and the last accepted regulatory
+	 * domain request to be processed.
+	 */
 	NRF_WIFI_REGDOM_TYPE_INTERSECTION,
 };
 
 #define NRF_WIFI_MAX_SSID_LEN 32
 
 /**
- * struct nrf_wifi_ssid - SSID list.
- * @nrf_wifi_ssid_len: Indicates the number of values in ssid parameter.
- * @nrf_wifi_ssid: SSID (binary attribute, 0..32 octets).
+ * @brief This structure provides details about the SSID.
  *
- * This structure describes the parameters to describe list of SSIDs
- * used by the @scan_common parameter in &struct nrf_wifi_umac_cmd_scan.
  */
 
 struct nrf_wifi_ssid {
+	/** length of SSID */
 	unsigned char nrf_wifi_ssid_len;
+	/** SSID string */
 	unsigned char nrf_wifi_ssid[NRF_WIFI_MAX_SSID_LEN];
 } __NRF_WIFI_PKD;
 
 #define NRF_WIFI_MAX_IE_LEN 400
 
 /**
- * struct nrf_wifi_ie - Information element(s) data.
- * @ie_len: Indicates the number of values in ie parameter.
- * @ie: Information element data.
+ * @brief This structure contains data related to the Information Elements (IEs).
  *
- * This structure describes the Information element(s) data being passed.
  */
 
 struct nrf_wifi_ie {
+	/** length of IE */
 	unsigned short ie_len;
+	/** Information element data */
 	signed char ie[NRF_WIFI_MAX_IE_LEN];
 } __NRF_WIFI_PKD;
 
 #define NRF_WIFI_MAX_SEQ_LENGTH 256
 
 /**
- * struct nrf_wifi_seq - Transmit key sequence number.
- * @nrf_wifi_seq_len: Length of the seq parameter.
- * @nrf_wifi_seq: Key sequence number data.
+ * @brief Transmit key sequence number.
  *
- * Transmit key sequence number (IV/PN) for TKIP and CCMP keys, each six bytes
- * in little endian.
  */
 
 struct nrf_wifi_seq {
+	/** Length of the seq parameter */
 	signed int nrf_wifi_seq_len;
+	/** Key sequence number data */
 	unsigned char nrf_wifi_seq[NRF_WIFI_MAX_SEQ_LENGTH];
 } __NRF_WIFI_PKD;
 
 #define NRF_WIFI_MAX_KEY_LENGTH 256
 
 /**
- * struct nrf_wifi_key - Key data.
+ * @brief This structure holds information related to a security key.
  *
- * @nrf_wifi_key_len: Length of the key data.
- * @nrf_wifi_key: Key data.
- *
- * This structure represents a security key data.
  */
 
 struct nrf_wifi_key {
+	/** Length of the key data */
 	unsigned int nrf_wifi_key_len;
+	/** Key data */
 	unsigned char nrf_wifi_key[NRF_WIFI_MAX_KEY_LENGTH];
 } __NRF_WIFI_PKD;
 
 #define NRF_WIFI_MAX_SAE_DATA_LENGTH 256
 
 /**
- * struct nrf_wifi_umac_sae - SAE element in auth frame.
- *
- * @sae_data_len: Length of SAE element data.
- * @sae_data: SAE element data.
- *
- * This structure represents SAE elements in Authentication frames.
+ * @brief This structure represents SAE elements in Authentication frame.
  *
  */
 
 struct nrf_wifi_sae {
+	/** Length of SAE element data */
 	signed int sae_data_len;
+	/** SAE element data */
 	unsigned char sae_data[NRF_WIFI_MAX_SAE_DATA_LENGTH];
 } __NRF_WIFI_PKD;
 
 #define NRF_WIFI_MAX_FRAME_LEN 400
 
 /**
- * struct nrf_wifi_umac_frame - Frame data.
+ * @brief This structure defines the frame that is intended for transmission.
  *
- * @frame_len: Length of the frame.
- * @frame: Frame data.
- *
- * This structure describes a frame being passed.
  */
 
 struct nrf_wifi_frame {
+	/** Length of the frame  */
 	signed int frame_len;
+	/** frame data */
 	signed char frame[NRF_WIFI_MAX_FRAME_LEN];
 } __NRF_WIFI_PKD;
 
@@ -635,21 +577,18 @@ struct nrf_wifi_frame {
 #define NRF_WIFI_INDEX_IDS_WIPHY_IDX_VALID (1 << 2)
 
 /**
- * struct nrf_wifi_index_ids - UMAC interface index.
+ * @brief This structure contains details about the interface information.
  *
- * @valid_fields: Indicate which properties below are set.
- * @wdev_id: wdev id.
- * @ifindex: Unused.
- * @wiphy_idx: Unused.
- *
- * Command header expected by UMAC. Legacy header in place to handle requests
- * from supplicant in RPU.
  */
 
 struct nrf_wifi_index_ids {
+	/** Indicate which properties below are set */
 	unsigned int valid_fields;
+	/** wdev id */
 	signed int ifaceindex;
+	/** Unused */
 	signed int nrf_wifi_wiphy_idx;
+	/** Unused */
 	unsigned long long wdev_id;
 } __NRF_WIFI_PKD;
 
@@ -657,60 +596,52 @@ struct nrf_wifi_index_ids {
 #define NRF_WIFI_MAX_SUPP_RATES 60
 
 /**
- * struct nrf_wifi_supp_rates - Scan request parameters.
- *
- * @valid_fields: Indicate which of the following parameters are valid.
- * @band: Frequency band, see enum nrf_wifi_umac_band.
- * @nrf_wifi_num_rates: Number of values in rates parameter.
- * @rates: Rates per to be advertised as supported in scan,
- *	 nested array attribute containing an entry for each band, with the
- *	 entry being a list of supported rates as defined by IEEE 802.11
- *	 7.3.2.2 but without the length restriction (at most
- *	 %NRF_WIFI_MAX_SUPP_RATES).
- *
- * This structure specifies the parameters to be used when sending
- * %NRF_WIFI_UMAC_CMD_TRIGGER_SCAN command (Refer &enum nrf_wifi_umac_commands).
+ * @brief This structure provides information about the rate parameters.
  *
  */
 
 struct nrf_wifi_supp_rates {
+	/** Indicate which of the following parameters are valid */
 	unsigned int valid_fields;
+	/** Frequency band, see &enum nrf_wifi_band */
 	signed int band;
+	/** Number of values in rates parameter */
 	signed int nrf_wifi_num_rates;
+	/** List of supported rates as defined by IEEE 802.11 7.3.2.2 */
 	unsigned char rates[NRF_WIFI_MAX_SUPP_RATES];
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_channel - channel definition
+ * @brief This structure contains details about a channel's information.
  *
- * This structure describes a single channel for use.
- *
- * @center_frequency: center frequency in MHz
- * @hw_value: hardware-specific value for the channel
- * @nrf_wifi_flags: channel flags from &enum nrf_wifi_channel_flags.
- * @nrf_wifi_orig_flags: channel flags at registration time, used by regulatory
- * code to support devices with additional restrictions
- * @band: band this channel belongs to.
- * @nrf_wifi_max_antenna_gain: maximum antenna gain in dBi
- * @nrf_wifi_max_power: maximum transmission power (in dBm)
- * @nrf_wifi_max_reg_power: maximum regulatory transmission power (in dBm)
- * @nrf_wifi_beacon_found: helper to regulatory code to indicate when a beacon
- * has been found on this channel. Use regulatory_hint_found_beacon()
- * to enable this, this is useful only on 5 GHz band.
- * @nrf_wifi_orig_mag: internal use
- * @nrf_wifi_orig_mpwr: internal use
  */
 struct nrf_wifi_channel {
+	/** band this channel belongs to */
 	signed int band;
+	/** center frequency in MHz */
 	unsigned int center_frequency;
+	/** channel flags from see &enum nrf_wifi_channel_flags */
 	unsigned int nrf_wifi_flags;
+	/** maximum antenna gain in dBi */
 	signed int nrf_wifi_max_antenna_gain;
+	/** maximum transmission power (in dBm) */
 	signed int nrf_wifi_max_power;
+	/** maximum regulatory transmission power (in dBm) */
 	signed int nrf_wifi_max_reg_power;
+	/** channel flags at registration time, used by regulatory
+	 *  code to support devices with additional restrictions
+	 */
 	unsigned int nrf_wifi_orig_flags;
+	/** internal use */
 	signed int nrf_wifi_orig_mag;
+	/** internal use */
 	signed int nrf_wifi_orig_mpwr;
+	/** hardware-specific value for the channel */
 	unsigned short hw_value;
+	/** helper to regulatory code to indicate when a beacon
+	 *  has been found on this channel. Use regulatory_hint_found_beacon()
+	 *  to enable this, this is useful only on 5 GHz band.
+	 */
 	signed char nrf_wifi_beacon_found;
 } __NRF_WIFI_PKD;
 
@@ -726,41 +657,6 @@ struct nrf_wifi_channel {
 #define NRF_WIFI_SCAN_MAX_NUM_FREQUENCIES 64
 #define MAX_NUM_CHANNELS 42
 
-/**
- * scan_flags -	scan request control flags
- *
- * Scan request control flags are used to control the handling
- * of CMD_TRIGGER_SCAN request.
- *
- * @#define NRF_WIFI_SCAN_FLAG_LOW_PRIORITY: scan request has low priority
- * @#define NRF_WIFI_SCAN_FLAG_FLUSH: flush cache before scanning
- * @#define NRF_WIFI_SCAN_FLAG_AP: force a scan even if the interface is configured
- *	as AP and the beaconing has already been configured. This attribute is
- *	dangerous because will destroy stations performance as a lot of frames
- *	will be lost while scanning off-channel, therefore it must be used only
- *	when really needed
- * @#define NRF_WIFI_SCAN_FLAG_RANDOM_ADDR: use a random MAC address for this scan (or
- *	for scheduled scan: a different one for every scan iteration). When the
- *	flag is set, depending on device capabilities the @MAC and
- *	@MAC_MASK attributes may also be given in which case only
- *	the masked bits will be preserved from the MAC address and the remainder
- *	randomised. If the attributes are not given full randomisation (46 bits,
- *	locally administered 1, multicast 0) is assumed.
- *	This flag must not be requested when the feature isn't supported, check
- *	the nl80211 feature flags for the device.
- * @#define NRF_WIFI_SCAN_FLAG_FILS_MAX_CHANNEL_TIME: fill the dwell time in the FILS
- *	request parameters IE in the probe request
- * @#define NRF_WIFI_SCAN_FLAG_ACCEPT_BCAST_PROBE_RESP: accept broadcast probe responses
- * @#define NRF_WIFI_SCAN_FLAG_OCE_PROBE_REQ_HIGH_TX_RATE: send probe request frames at
- *	rate of at least 5.5M. In case non OCE AP is dicovered in the channel,
- *	only the first probe req in the channel will be sent in high rate.
- * @#define NRF_WIFI_SCAN_FLAG_OCE_PROBE_REQ_DEFERRAL_SUPPRESSION: allow probe request
- *	tx deferral (dot11FILSProbeDelay shall be set to 15ms)
- *	and suppression (if it has received a broadcast Probe Response frame,
- *	Beacon frame or FILS Discovery frame from an AP that the STA considers
- *	a suitable candidate for (re-)association - suitable in terms of
- *	SSID and/or RSSI
- */
 #define NRF_WIFI_SCAN_FLAG_LOW_PRIORITY (1 << 0)
 #define NRF_WIFI_SCAN_FLAG_FLUSH (1 << 1)
 #define NRF_WIFI_SCAN_FLAG_AP (1 << 2)
@@ -776,43 +672,40 @@ struct nrf_wifi_channel {
 #define NRF_WIFI_SCAN_FLAG_MIN_PREQ_CONTENT (1 << 12)
 
 /**
- * struct nrf_wifi_scan_params - Scan request parameters.
+ * @brief This structure provides details about the parameters required for a scan request.
  *
- * @valid_fields: Indicate which of the following parameters are valid.
- * @num_scan_ssids: Number of elements in scan_ssids parameter.
- * @scan_ssids: Nested attribute with SSIDs, leave out for passive
- *	 scanning and include a zero-length SSID (wildcard) for wildcard scan.
- * @ie: Information element(s) data.
- * @num_scan_channels: Num of scan channels.
- * @scan_frequencies: Channel information.
- * @mac_addr: MAC address (various uses).
- * @mac_addr_mask: MAC address mask.
- * @scan_flags: Scan request control flags (u32). Bit values
- *	(NRF_WIFI_SCAN_FLAG_LOW_PRIORITY/NRF_WIFI_SCAN_FLAG_RANDOM_ADDR...)
- * @supp_rates: Supported rates.
- * @no_cck: used to send probe requests at non CCK rate in 2GHz band
- * @oper_ch__duration: Operating channel duration when STA is connected to AP
- * @scan_duration: Max scan duration in TU
- * @channels: See struct nrf_wifi_channel
- *
- * This structure specifies the parameters to be used when sending
- * %NRF_WIFI_UMAC_CMD_TRIGGER_SCAN command (Refer &enum nrf_wifi_umac_commands).
  */
 
 struct nrf_wifi_scan_params {
+	/** Indicate which of the following parameters are valid */
 	unsigned int valid_fields;
+	/** Number of ssids valid in scan_ssids parameter */
 	unsigned char num_scan_ssids;
+	/** Number of channels to be scanned */
 	unsigned char num_scan_channels;
+	/** Scan request control flags (u32). Bit values
+	 *  (NRF_WIFI_SCAN_FLAG_LOW_PRIORITY/NRF_WIFI_SCAN_FLAG_RANDOM_ADDR...)
+	 */
 	unsigned int scan_flags;
+	/** ssid info @ref nrf_wifi_ssid */
 	struct nrf_wifi_ssid scan_ssids[NRF_WIFI_SCAN_MAX_NUM_SSIDS];
+	/** Information element(s) data @ref nrf_wifi_ie*/
 	struct nrf_wifi_ie ie;
+	/** Supported rates @ref nrf_wifi_supp_rates */
 	struct nrf_wifi_supp_rates supp_rates;
+	/** MAC address */
 	unsigned char mac_addr[NRF_WIFI_ETH_ADDR_LEN];
+	/** MAC address mask */
 	unsigned char mac_addr_mask[NRF_WIFI_ETH_ADDR_LEN];
+	/** used to send probe requests at non CCK rate in 2GHz band */
 	unsigned char no_cck;
+	/** Operating channel duration when STA is connected to AP */
 	unsigned short oper_ch_duration;
+	/** Max scan duration in TU */
 	unsigned short scan_duration[MAX_NUM_CHANNELS];
+	/** Max probe count in channels */
 	unsigned char probe_cnt[MAX_NUM_CHANNELS];
+	/** channels to be scanned @ref nrf_wifi_channel */
 	struct nrf_wifi_channel channels[0];
 } __NRF_WIFI_PKD;
 
@@ -820,38 +713,30 @@ struct nrf_wifi_scan_params {
 #define NRF_WIFI_HT_CAPABILITY_MASK_VALID (1 << 1)
 #define NRF_WIFI_VHT_CAPABILITY_VALID (1 << 2)
 #define NRF_WIFI_VHT_CAPABILITY_MASK_VALID (1 << 3)
+
 #define NRF_WIFI_CMD_HT_VHT_CAPABILITY_DISABLE_HT (1 << 0)
 #define NRF_WIFI_HT_VHT_CAPABILITY_MAX_SIZE 256
 
 /**
- * struct nrf_wifi_ht_vht_capabilities - VHT capability information.
- * @valid_fields: Indicate which of the following parameters are valid.
- * @ht_capability: HT Capability information element (from
- *	association request when used with %NRF_WIFI_UMAC_CMD_NEW_STATION in
- *	&enum nrf_wifi_umac_commands).
- * @ht_capability_mask: Specify which bits of the
- *	ATTR_HT_CAPABILITY to which attention should be paid.
- *	The values that may be configured are:
- *	MCS rates, MAX-AMSDU, HT-20-40 and HT_CAP_SGI_40
- *	AMPDU density and AMPDU factor.
- *	All values are treated as suggestions and may be ignored
- *	by the driver as required.
- * @vht_capability: VHT Capability information element (from
- *	association request when used with %NRF_WIFI_UMAC_CMD_NEW_STATION in
- *	&enum nrf_wifi_umac_commands).
- * @vht_capability_mask: Specify which bits in vht_capability to which attention
- *	should be paid.
- * @nrf_wifi_flags: Indicate which capabilities have been specified.
+ * @brief This structure contains specific information about the VHT (Very High Throughput)
+ *  and HT ((High Throughput)) capabilities.
  *
- * This structure encapsulates the VHT capability information.
  */
 
 struct nrf_wifi_ht_vht_capabilities {
+	/** Indicate which of the following parameters are valid */
 	unsigned int valid_fields;
+	/** Indicate which capabilities have been specified */
 	unsigned short nrf_wifi_flags;
+	/** HT Capability information element (from association request when
+	 *  used with NRF_WIFI_UMAC_CMD_NEW_STATION).
+	 */
 	unsigned char ht_capability[NRF_WIFI_HT_VHT_CAPABILITY_MAX_SIZE];
+	/** Specify which bits of the ht_capability are masked */
 	unsigned char ht_capability_mask[NRF_WIFI_HT_VHT_CAPABILITY_MAX_SIZE];
+	/** VHT Capability information element */
 	unsigned char vht_capability[NRF_WIFI_HT_VHT_CAPABILITY_MAX_SIZE];
+	/** Specify which bits in vht_capability to which attention should be paid */
 	unsigned char vht_capability_mask[NRF_WIFI_HT_VHT_CAPABILITY_MAX_SIZE];
 } __NRF_WIFI_PKD;
 
@@ -860,25 +745,27 @@ struct nrf_wifi_ht_vht_capabilities {
 #define NRF_WIFI_SIGNAL_TYPE_UNSPEC 3
 
 /**
- * struct nrf_wifi_signal - Signal information.
+ * @brief This structure represents information related to the signal strength.
  *
- * @signal_type: MBM or unspecified.
- * @signal: If MBM signal strength of probe response/beacon
- *	in mBm (100 * dBm) (s32)
- *	If unspecified signal strength of the probe response/beacon
- *	in unspecified units, scaled to 0..100 (u8).
- *
- * This structure represents signal information.
  */
 
 struct nrf_wifi_signal {
+	/** MBM or unspecified */
 	unsigned int signal_type;
 
+	/** signal */
 	union {
+		/** If MBM signal strength of probe response/beacon
+		 *  in mBm (100 * dBm) (s32)
+		 */
 		unsigned int mbm_signal;
+		/** If unspecified signal strength of the probe response/beacon
+		 *  in unspecified units, scaled to 0..100 (u8).
+		 */
 		unsigned char unspec_signal;
 	} __NRF_WIFI_PKD signal;
 } __NRF_WIFI_PKD;
+
 #define NRF_WIFI_WPA_VERSION_1 (1 << 0)
 #define NRF_WIFI_WPA_VERSION_2 (1 << 1)
 
@@ -903,83 +790,69 @@ struct nrf_wifi_signal {
 #define NRF_WIFI_CONNECT_COMMON_INFO_PREV_BSSID (1 << 15)
 
 /**
- * struct nrf_wifi_connect_common_info - Connection properties.
+ * @brief This structure contains parameters related to the connection.
  *
- * @valid_fields: Indicate which of the following parameters are valid.
- * @mac_addr: MAC address (various uses).
- * @mac_addr_hint: MAC address recommendation as initial BSS.
- * @frequency: Frequency of the selected channel in MHz, defines the channel
- *	together with the (deprecated) %NRF_WIFI_UMAC_ATTR_WIPHY_CHANNEL_TYPE
- *	attribute or the attributes %NRF_WIFI_UMAC_ATTR_CHANNEL_WIDTH and if needed
- *	%NRF_WIFI_UMAC_ATTR_CENTER_FREQ1 and %NRF_WIFI_UMAC_ATTR_CENTER_FREQ2.
- * @freq_hint: Frequency of the recommended initial BS.
- * @bg_scan_period: Background scan period in seconds or 0 to disable
- *	background scan.
- * @ssid: SSID (binary attribute, 0..32 octets).
- * @wpa_ie: Information element(s) data.
- * @wpa_versions: Used with CONNECT, ASSOCIATE, and NEW_BEACON to
- *	indicate which WPA version(s) the AP we want to associate with is using
- * @num_cipher_suites_pairwise: Number of pairwise cipher suites.
- * @cipher_suites_pairwise: For crypto settings for connect or
- *	other commands, indicates which pairwise cipher suites are used.
- * @cipher_suite_group: For crypto settings for connect or
- *	other commands, indicates which group cipher suite is used.
- * @num_akm_suites: Number of groupwise cipher suites.
- * @akm_suites: Used with CONNECT, ASSOCIATE, and NEW_BEACON to
- *	indicate which key management algorithm(s) to use (an array of u32).
- * @use_mfp: Whether management frame protection (IEEE 802.11w) is
- *	used for the association; this attribute can be used
- *	with %NRF_WIFI_UMAC_CMD_ASSOCIATE and %NRF_WIFI_UMAC_CMD_CONNECT requests (Refer
- *	&enum nrf_wifi_umac_commands).
- * @ht_vht_capabilitys: VHT Capability information element (from
- *	association request when used with %NRF_WIFI_UMAC_CMD_NEW_STATION in
- *	&enum nrf_wifi_umac_commands).
- * @nrf_wifi_flags: Flag for indicating whether the current connection
- *	shall support Radio Resource Measurements (11k). This attribute can be
- *	used with %NRF_WIFI_UMAC_CMD_ASSOCIATE and %NRF_WIFI_UMAC_CMD_CONNECT requests
- *	(Refer &enum nrf_wifi_umac_commands).
- *	User space applications are expected to use this flag only if the
- *	underlying device supports these minimal RRM features:
- *	%NRF_WIFI_UMAC_FEATURE_DS_PARAM_SET_IE_IN_PROBES,
- *	%NRF_WIFI_UMAC_FEATURE_QUIET,
- *	If this flag is used, driver must add the Power Capabilities IE to the
- *	association request. In addition, it must also set the RRM capability
- *	flag in the association request's Capability Info field.
- *	flag indicating whether user space controls
- *	IEEE 802.1X port, i.e., sets/clears %NRF_WIFI_UMAC_STA_FLAG_AUTHORIZED, in
- *	station mode. If the flag is included in %NRF_WIFI_UMAC_CMD_ASSOCIATE
- *	request, the driver will assume that the port is unauthorized until
- *	authorized by user space. Otherwise, port is marked authorized by
- *	default in station mode.
- *
- * This structure specifies the parameters to be used when building
- * connect_common_info when sending %NRF_WIFI_UMAC_CMD_ASSOCIATE command (Refer
- * &enum nrf_wifi_umac_commands).
  */
 
 struct nrf_wifi_connect_common_info {
+	/** Indicate which of the following parameters are valid */
 	unsigned int valid_fields;
+	/** Frequency of the selected channel in MHz */
 	unsigned int frequency;
+	/** Frequency of the recommended initial BSS */
 	unsigned int freq_hint;
+	/** Indicates which WPA version(s) */
 	unsigned int wpa_versions;
+	/** Number of pairwise cipher suites */
 	signed int num_cipher_suites_pairwise;
+	/** For crypto settings, indicates which pairwise cipher suites are used */
 	unsigned int cipher_suites_pairwise[7];
+	/** For crypto settings, indicates which group cipher suite is used */
 	unsigned int cipher_suite_group;
+	/** Number of groupwise cipher suites */
 	unsigned int num_akm_suites;
+	/** Indicate which key management algorithm(s) to use */
 	unsigned int akm_suites[NRF_WIFI_MAX_NR_AKM_SUITES];
+	/** Whether management frame protection (IEEE 802.11w) is used for the association */
 	signed int use_mfp;
-
+	/** Flag for indicating whether the current connection
+	 *  shall support Radio Resource Measurements (11k)
+	 */
 	unsigned int nrf_wifi_flags;
+	/** Background scan period in seconds or 0 to disable background scan */
 	unsigned short bg_scan_period;
+	/** MAC address */
 	unsigned char mac_addr[NRF_WIFI_ETH_ADDR_LEN];
+	/** MAC address recommendation as initial BSS */
 	unsigned char mac_addr_hint[NRF_WIFI_ETH_ADDR_LEN];
+	/** SSID (binary attribute, 0..32 octets) */
 	struct nrf_wifi_ssid ssid;
+	/** IE's @ref nrf_wifi_ie */
 	struct nrf_wifi_ie wpa_ie;
+	/** VHT Capability information element @ref nrf_wifi_ht_vht_capabilities */
 	struct nrf_wifi_ht_vht_capabilities ht_vht_capabilities;
+	/** A 16-bit value indicating the ethertype that will be used for key negotiation.
+	 *  If it is not specified, the value defaults to 0x888E.
+	 */
 	unsigned short control_port_ether_type;
+	/** When included along with control_port_ether_type, indicates that the custom
+	 *  ethertype frames used for key negotiation must not be encrypted.
+	 */
 	unsigned char control_port_no_encrypt;
+	/** Indicating whether user space controls IEEE 802.1X port, If set, the RPU will
+	 *  assume that the port is unauthorized until authorized by user space.
+	 *  Otherwise, port is marked authorized by default in station mode.
+	 */
 	signed char control_port;
+	/** previous BSSID, used to specify a request to reassociate
+	 *  within an ESS that is, to use Reassociate Request frame (with the value of
+	 *  this attribute in the Current AP address field) instead of Association
+	 *  Request frame which is used for the initial association to an ESS.
+	 */
 	unsigned char prev_bssid[NRF_WIFI_ETH_ADDR_LEN];
+	/** Bss max idle timeout value in sec which will be encapsulated into
+	 *  BSS MAX IDLE IE in assoc request frame.
+	 */
 	unsigned short maxidle_insec;
 
 } __NRF_WIFI_PKD;
@@ -989,34 +862,43 @@ struct nrf_wifi_connect_common_info {
 #define NRF_WIFI_BEACON_DATA_MAX_PROBE_RESP_LEN 400
 
 /**
- * struct nrf_wifi_beacon_data - beacon & probe data
- * @head_len: length of @head
- * @tail_len: length of @tail
- * @probe_resp_len: length of probe response template (@probe_resp)
- * @head: head portion of beacon (before TIM IE) or %NULL if not changed
- * @tail: tail portion of beacon (after TIM IE) or %NULL if not changed
- * @probe_resp: probe response template
+ * @brief This structure provides information about beacon and probe data.
+ *
  */
 
 struct nrf_wifi_beacon_data {
+	/** length of head */
 	unsigned int head_len;
+	/** length of tail */
 	unsigned int tail_len;
+	/** length of probe response template (probe_resp) */
 	unsigned int probe_resp_len;
+	/**  head portion of beacon (before TIM IE) or %NULL if not changed  */
 	unsigned char head[NRF_WIFI_BEACON_DATA_MAX_HEAD_LEN];
+	/** tail portion of beacon (after TIM IE) or %NULL if not changed */
 	unsigned char tail[NRF_WIFI_BEACON_DATA_MAX_TAIL_LEN];
+	/** probe response template */
 	unsigned char probe_resp[NRF_WIFI_BEACON_DATA_MAX_PROBE_RESP_LEN];
 } __NRF_WIFI_PKD;
 
-/*
- * struct nrf_wifi_sta_flag_update - Station flags mask/set.
- * @mask: Mask of station flags to set.
- * @set: Values to set them to.
+#define NRF_WIFI_STA_FLAG_INVALID (1 << 0)
+#define NRF_WIFI_STA_FLAG_AUTHORIZED (1 << 1)
+#define NRF_WIFI_STA_FLAG_SHORT_PREAMBLE (1 << 2)
+#define NRF_WIFI_STA_FLAG_WME (1 << 3)
+#define NRF_WIFI_STA_FLAG_MFP (1 << 4)
+#define NRF_WIFI_STA_FLAG_AUTHENTICATED (1 << 5)
+#define NRF_WIFI_STA_FLAG_TDLS_PEER (1 << 6)
+#define NRF_WIFI_STA_FLAG_ASSOCIATED (1 << 7)
+
+/**
+ * @brief This structure provides information regarding station flags.
  *
- * Both mask and set contain bits as per &enum nrf_wifi_sta_flags.
  */
 
 struct nrf_wifi_sta_flag_update {
+	/** Mask of station flags to set */
 	unsigned int nrf_wifi_mask;
+	/** Values to set them to. NRF_WIFI_STA_FLAG_AUTHORIZED */
 	unsigned int nrf_wifi_set;
 } __NRF_WIFI_PKD;
 
@@ -1025,6 +907,7 @@ struct nrf_wifi_sta_flag_update {
 #define NRF_WIFI_RATE_INFO_BITRATE_MCS_VALID (1 << 2)
 #define NRF_WIFI_RATE_INFO_BITRATE_VHT_MCS_VALID (1 << 3)
 #define NRF_WIFI_RATE_INFO_BITRATE_VHT_NSS_VALID (1 << 4)
+
 #define NRF_WIFI_RATE_INFO_0_MHZ_WIDTH (1 << 0)
 #define NRF_WIFI_RATE_INFO_5_MHZ_WIDTH (1 << 1)
 #define NRF_WIFI_RATE_INFO_10_MHZ_WIDTH (1 << 2)
@@ -1034,41 +917,44 @@ struct nrf_wifi_sta_flag_update {
 #define NRF_WIFI_RATE_INFO_SHORT_GI (1 << 6)
 #define NRF_WIFI_RATE_INFO_80P80_MHZ_WIDTH (1 << 7)
 
-/*
- * struct nrf_wifi_rate_info - Rate information.
- * @valid_fields: Valid fields with in this structure.
- * @bitrate: bitrate.
- * @bitrate_compat: Bitrate copmpatible.
- * @nrf_wifi_mcs: Modulation and Coding Scheme(MCS).
- * @vht_mcs: MCS related to VHT.
- * @vht_nss: NSS related to VHT .
- * @nrf_wifi_flags: Rate flags .
+/**
+ * @brief This structure contains information about rate parameters.
  *
- * Both mask and set contain bits as per &enum nrf_wifi_sta_flags.
  */
 
 struct nrf_wifi_rate_info {
+	/** Valid fields with in this structure */
 	unsigned int valid_fields;
+	/** bitrate */
 	unsigned int bitrate;
+	/** Bitrate compatible */
 	unsigned short bitrate_compat;
+	/** Modulation and Coding Scheme(MCS) */
 	unsigned char nrf_wifi_mcs;
+	/** MCS related to VHT */
 	unsigned char vht_mcs;
+	/** NSS related to VHT */
 	unsigned char vht_nss;
+	/** Rate flags NRF_WIFI_RATE_INFO_0_MHZ_WIDTH */
 	unsigned int nrf_wifi_flags;
 
 } __NRF_WIFI_PKD;
 
-/*
- * struct nrf_wifi_sta_bss_parameters - BSS parameters for the attached station
- * Information about the currently associated BSS
- * @flags: bitflag of flags (CTS_PROT, SHORT_PREAMBLE, SHORT_SLOT_TIME)
- * @dtim_period: DTIM period for the BSS
- * @beacon_interval: beacon interval
- */
+#define NRF_WIFI_BSS_PARAM_FLAGS_CTS_PROT (1<<0)
+#define NRF_WIFI_BSS_PARAM_FLAGS_SHORT_PREAMBLE (1<<1)
+#define NRF_WIFI_BSS_PARAM_FLAGS_SHORT_SLOT_TIME (1<<2)
 
+/**
+ * @brief This structure provides information about the Basic Service Set (BSS)
+ *  parameters for the attached station.
+ *
+ */
 struct nrf_wifi_sta_bss_parameters {
+	/** bitfields of flags NRF_WIFI_BSS_PARAM_FLAGS_CTS_PROT */
 	unsigned char nrf_wifi_flags;
+	/** DTIM period for the BSS */
 	unsigned char dtim_period;
+	/** beacon interval */
 	unsigned short beacon_interval;
 } __NRF_WIFI_PKD;
 
@@ -1103,96 +989,93 @@ struct nrf_wifi_sta_bss_parameters {
 #define NRF_WIFI_STA_INFO_STA_BSS_PARAMS_VALID (1 << 27)
 #define NRF_WIFI_IEEE80211_MAX_CHAINS 4
 
-/*
- * struct nrf_wifi_sta_info - STA information.
- * @valid_fields: Valid fields with in this structure.
- * @connected_time: time since the station is last connected.
- * @inactive_time: time since last activity, in msec.
- * @rx_bytes: total received bytes from this station.
- * @tx_bytes: total transmitted bytes to this station.
- * @chain_signal_mask: per-chain signal mask value.
- * @chain_signal: per-chain signal strength of last PPDU.
- * @chain_signal_avg_mask: per-chain signal strength average mask value.
- * @chain_signal_avg: per-chain signal strength average.
- * @tx_bitrate: see the struct nrf_wifi_rate_info.
- * @tx_bitrate: see the struct nrf_wifi_rate_info.
- * @llid: Not used.
- * @plid: Not used.
- * @plink_state: Not used.
- * @signal: signal strength of last received PPDU, in dbm.
- * @signal_avg: signal strength average, in dbm.
- * @rx_packets: total received packet from this station.
- * @tx_packets: total transmitted packets to this station.
- * @tx_retries: total retries to this station.
- * @tx_failed: total failed packets to this station.
- * @expected_throughput: expected throughput considering also the mac80211
- *	header, in kbps.
- * @beacon_loss_count: count of times beacon loss was detected.
- * @local_pm: Not used.
- * @peer_pm: Not used.
- * @nonpeer_pm: Not used.
- * @sta_flags: see struct nrf_wifi_sta_flag_update.
- * @t_offset: timing offset with respect to this STA.
- * @rx_dropped_misc: count of times other(non beacon) loss was detected.
- * @rx_beacon: count of times beacon.
- * @rx_beacon_signal_avg: average of beacon signal.
- * @bss_param: Station connected BSS params
+/**
+ * @brief This structure contains information about a Station (STA).
+ *
  */
 
 struct nrf_wifi_sta_info {
+	/** Valid fields with in this structure */
 	unsigned int valid_fields;
+	/** time since the station is last connected */
 	unsigned int connected_time;
+	/** time since last activity, in msec */
 	unsigned int inactive_time;
+	/** total received bytes from this station */
 	unsigned int rx_bytes;
+	/** total transmitted bytes to this station */
 	unsigned int tx_bytes;
+	/** per-chain signal mask value */
 	unsigned int chain_signal_mask;
+	/** per-chain signal strength of last PPDU */
 	unsigned char chain_signal[NRF_WIFI_IEEE80211_MAX_CHAINS];
+	/** per-chain signal strength average mask value */
 	unsigned int chain_signal_avg_mask;
+	/** per-chain signal strength average */
 	unsigned char chain_signal_avg[NRF_WIFI_IEEE80211_MAX_CHAINS];
+	/**@ref nrf_wifi_rate_info */
 	struct nrf_wifi_rate_info tx_bitrate;
+	/**@ref nrf_wifi_rate_info */
 	struct nrf_wifi_rate_info rx_bitrate;
+	/** Not used */
 	unsigned short llid;
+	/** Not used */
 	unsigned short plid;
+	/** Not used */
 	unsigned char plink_state;
+	/** signal strength of last received PPDU, in dbm */
 	signed int signal;
+	/** signal strength average, in dbm */
 	signed int signal_avg;
+	/** total received packet from this station */
 	unsigned int rx_packets;
+	/** total transmitted packets to this station */
 	unsigned int tx_packets;
+	/** total retries to this station */
 	unsigned int tx_retries;
+	/** total failed packets to this station */
 	unsigned int tx_failed;
+	/** expected throughput in kbps */
 	unsigned int expected_throughput;
+	/** count of times beacon loss was detected */
 	unsigned int beacon_loss_count;
+	/** Not used */
 	unsigned int local_pm;
+	/** Not used */
 	unsigned int peer_pm;
+	/** Not used */
 	unsigned int nonpeer_pm;
+	/** station flags @ref nrf_wifi_sta_flag_update */
 	struct nrf_wifi_sta_flag_update sta_flags;
+	/** timing offset with respect to this STA */
 	unsigned long long t_offset;
+	/** count of times other(non beacon) loss was detected */
 	unsigned long long rx_dropped_misc;
+	/** count of times beacon */
 	unsigned long long rx_beacon;
+	/** average of beacon signal */
 	long long rx_beacon_signal_avg;
+	/** Station connected BSS params. @ref nrf_wifi_sta_bss_parameters */
 	struct nrf_wifi_sta_bss_parameters bss_param;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_hdr - Common command/event header.
+ * @brief The command header expected by UMAC to handle requests from the control interface.
  *
- * @cmd_evnt: UMAC command/event value. (Refer	&enum nrf_wifi_umac_commands).
- * @ids: Interface properties.
- *
- * Command header expected by UMAC. Legacy header in place to handle requests
- * from supplicant in RPU.
  */
 
 struct nrf_wifi_umac_hdr {
-	/* private: presently unused */
+	/** unused */
 	unsigned int portid;
-	/* private: presently unused */
+	/** unused */
 	unsigned int seq;
-	/* public: */
+	/** UMAC command/event value see &enum nrf_wifi_umac_commands
+	 *  see &enum nrf_wifi_umac_events
+	 */
 	unsigned int cmd_evnt;
-	/* private: presently unused */
+	/** unused */
 	signed int rpu_ret_val;
-	/* public: */
+	/** Interface information @ref nrf_wifi_index_ids */
 	struct nrf_wifi_index_ids ids;
 } __NRF_WIFI_PKD;
 
@@ -1202,6 +1085,7 @@ struct nrf_wifi_umac_hdr {
 #define NRF_WIFI_SEQ_VALID (1 << 3)
 #define NRF_WIFI_CIPHER_SUITE_VALID (1 << 4)
 #define NRF_WIFI_KEY_INFO_VALID (1 << 5)
+
 #define NRF_WIFI_KEY_DEFAULT (1 << 0)
 #define NRF_WIFI_KEY_DEFAULT_TYPES (1 << 1)
 #define NRF_WIFI_KEY_DEFAULT_MGMT (1 << 2)
@@ -1209,128 +1093,111 @@ struct nrf_wifi_umac_hdr {
 #define NRF_WIFI_KEY_DEFAULT_TYPE_MULTICAST (1 << 4)
 
 /**
- * struct nrf_wifi_umac_key_info - Key information.
+ * @brief This structure contains information about a security key.
  *
- * @valid_fields: Indicate which of the following parameters are valid.
- * @key: Key data, see &struct nrf_wifi_key.
- * @key_type: Key Type,	see &enum nrf_wifi_key_type
- * @key_idx: Key ID (0-3).
- * @seq: Transmit key sequence number (IV/PN) for TKIP and
- *	CCMP keys, each six bytes in little endian.
- * @cipher_suite: Key cipher suite (as defined by IEEE 802.11
- *	section 7.3.2.25.1).
- * @nrf_wifi_flags: A nested attribute containing flags
- *	attributes, specifying what a key should be set as default as.
- *
- * This structure represents a security key.
  */
 
 struct nrf_wifi_umac_key_info {
+	/** Indicate which of the following parameters are valid */
 	unsigned int valid_fields;
+	/** Key cipher suite (as defined by IEEE 802.11 section 7.3.2.25.1) */
 	unsigned int cipher_suite;
+	/** Specify what a key should be set as default as example NRF_WIFI_KEY_DEFAULT_MGMT */
 	unsigned short nrf_wifi_flags;
+	/** Key Type, see &enum nrf_wifi_key_type */
 	signed int key_type;
+	/** Key data @ref nrf_wifi_key */
 	struct nrf_wifi_key key;
+	/** Transmit key sequence number (IV/PN) for TKIP and CCMP keys,
+	 *  each six bytes in little endian @ref nrf_wifi_seq
+	 */
 	struct nrf_wifi_seq seq;
+	/** Key ID (0-3) */
 	unsigned char key_idx;
 } __NRF_WIFI_PKD;
 
-
-
 /**
- * enum scan_mode - scan operation mode
- * @AUTO: auto or legacy scan operation
- * @CHANNEL_MAPPING_SCAN: channel mapping mode. most of parameters will come from host.
+ * @brief This enum represents the various types of scanning operations.
  *
- * This enum represents the different types of scanning operations.
  */
 enum scan_mode {
+	/** auto or legacy scan operation */
 	AUTO_SCAN = 0,
+	/** Mapped scan. Host will control channels */
 	CHANNEL_MAPPING_SCAN
 };
 
 /**
- * enum scan_reason - scan reason
- * @SCAN_DISPLAY: scan for display purpose in user space
- * @SCAN_CONNECT: scan for connection purpose.
+ * @brief This enum describes the different types of scan.
  *
- * This enum represents the different types of scan reasons.
  */
 enum scan_reason {
+	/** scan for display purpose in user space */
 	SCAN_DISPLAY = 0,
+	/** scan for connection purpose */
 	SCAN_CONNECT
 };
 
 /**
- * struct nrf_wifi_umac_scan_info - Scan related information.
+ * @brief This structure contains details about scan request information.
  *
- * @scan_mode:see enum scan_mode .
- * @scan_reason:see enum scan_reason .
- * @scan_params: Refer to &struct nrf_wifi_umac_scan_params.
- *
- * Properties to be used when triggering a new scan request
  */
 
 struct nrf_wifi_umac_scan_info {
+	/** scan mode @ref scan_mode */
 	signed int scan_mode;
+	/** scan type see &enum scan_reason */
 	signed int scan_reason;
+	/** scan parameters @ref nrf_wifi_scan_params */
 	struct nrf_wifi_scan_params scan_params;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_cmd_scan - Scan request properties.
+ * @brief This structure defines a command scan request.
  *
- * @umac_hdr: Refer to &struct nrf_wifi_umac_hdr.
- * @info: Refer to &struct nrf_wifi_umac_scan_info.
- *
- * Properties to be used when triggering a new scan request
  */
 
 struct nrf_wifi_umac_cmd_scan {
-	/* public: */
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** @ref nrf_wifi_umac_scan_info */
 	struct nrf_wifi_umac_scan_info info;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_cmd_abort_scan - Abort Scan request.
- *
- * @umac_hdr: Refer to &struct nrf_wifi_umac_hdr.
+ * @brief This structure defines a command to abort a scan request.
  *
  */
 
 struct nrf_wifi_umac_cmd_abort_scan {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_cmd_get_scan_results - Get scan results.
+ * @brief TThis structure defines a command to request scan results.
+ * This command should be executed only if we have received a
+ * NRF_WIFI_UMAC_EVENT_SCAN_DONE event for a previous scan.
  *
- * @umac_hdr: Refer to &struct nrf_wifi_umac_hdr.
- * @scan_reason: Refer to &enum scan_reason.
- *
- * Properties to be used when requesting for scan results. This should be
- * allowed only if we received a %NRF_WIFI_UMAC_EVENT_SCAN_DONE for a
- * %NRF_WIFI_UMAC_CMD_TRIGGER_SCAN earlier.
  */
 
 struct nrf_wifi_umac_cmd_get_scan_results {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** scan type see &enum scan_reason */
 	signed int scan_reason;
 } __NRF_WIFI_PKD;
+
 /**
- * struct nrf_wifi_umac_event_scan_done - Scan Done event.
- *
- * @umac_hdr: Refer to &struct img_umac_hdr.
- * @status :	0->Scan successful
- *				1->Scan aborted
- * @scan_type:	0->display_scan
- *				1->connect_scan
+ * @brief This structure provides details about the "Scan Done" event.
  *
  */
 struct nrf_wifi_umac_event_scan_done {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** status, 0=Scan successful & 1=Scan aborted */
 	signed int status;
+	/** scan type see &enum scan_reason */
 	unsigned int scan_type;
 } __NRF_WIFI_PKD;
 
@@ -1339,44 +1206,46 @@ struct nrf_wifi_umac_event_scan_done {
 #define MCAST_ADDR_DEL 1
 
 /**
- * struct nrf_wifi_umac_mcast_cfg - mcast related information.
+ * @brief This structure represents the parameters used to configure the multicast address filter.
  *
- * @type: Add (0) or Delete (1)
- * @mac-addr: multicast address to be added/deleted.
  */
 struct nrf_wifi_umac_mcast_cfg {
+	/** Add (0) or Delete (1) */
 	unsigned int type;
+	/** multicast address to be added/deleted */
 	unsigned char mac_addr[NRF_WIFI_ETH_ADDR_LEN];
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_cmd_mcast_filter - set mcast address
- *
- * @umac_hdr: Refer to &struct nrf_wifi_umac_hdr.
- * @info: Refer to &struct nrf_wifi_umac_mcast_cfg.
+ * @brief This structure defines a command used to set multicast (mcast) addresses.
  *
  */
 struct nrf_wifi_umac_cmd_mcast_filter {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** @ref nrf_wifi_umac_mcast_cfg */
 	struct nrf_wifi_umac_mcast_cfg info;
 } __NRF_WIFI_PKD;
 
 
 /**
- * struct nrf_wifi_umac_cmd_change_macaddr - Change MAC Address
- *
- *    - This has to be used only when the interface is down.
- *
- * @umac_hdr: Refer to &struct img_umac_hdr.
- * @mac_addr : MAC address to be set
+ * @brief This structure represents the parameters used to change the MAC address.
  *
  */
+
 struct nrf_wifi_umac_change_macaddr_info {
+	/** MAC address to be set */
 	unsigned char mac_addr[NRF_WIFI_ETH_ADDR_LEN];
 } __NRF_WIFI_PKD;
-
+/**
+ * @brief This structure describes command to change MAC address.
+ *  This has to be used only when the interface is down.
+ *
+ */
 struct nrf_wifi_umac_cmd_change_macaddr {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** @ref nrf_wifi_umac_change_macaddr_info */
 	struct nrf_wifi_umac_change_macaddr_info macaddr_info;
 } __NRF_WIFI_PKD;
 
@@ -1388,116 +1257,119 @@ struct nrf_wifi_umac_cmd_change_macaddr {
 #define NRF_WIFI_CMD_AUTHENTICATE_SSID_VALID (1 << 3)
 #define NRF_WIFI_CMD_AUTHENTICATE_IE_VALID (1 << 4)
 #define NRF_WIFI_CMD_AUTHENTICATE_SAE_VALID (1 << 5)
+
 #define NRF_WIFI_CMD_AUTHENTICATE_LOCAL_STATE_CHANGE (1 << 0)
 
-
 /**
- * struct nrf_wifi_umac_auth_info - Authentication command parameters.
+ * @brief This structure specifies the parameters to be used when sending an authentication request.
  *
- * @frequency: Frequency of the selected channel in MHz,
- *	 defines the channel together with the (deprecated)
- *	 %NRF_WIFI_UMAC_ATTR_WIPHY_CHANNEL_TYPE attribute or the attributes
- *	 %NRF_WIFI_UMAC_ATTR_CHANNEL_WIDTH and if needed %NRF_WIFI_UMAC_ATTR_CENTER_FREQ1
- *	 and %NRF_WIFI_UMAC_ATTR_CENTER_FREQ2.
- * @nrf_wifi_flags: Flag attribute to indicate that a command
- *	 is requesting a local authentication/association state change without
- *	 invoking actual management frame exchange. This can be used with
- *	 %NRF_WIFI_UMAC_CMD_AUTHENTICATE, %NRF_WIFI_UMAC_CMD_DEAUTHENTICATE
- *	 (Refer &enum nrf_wifi_umac_commands).
- * @auth_type: Authentication type.
- * @key_info: Key information in a nested attribute with
- *	 %NRF_WIFI_UMAC_KEY_* sub-attributes.
- * @ssid: SSID (binary attribute, 0..32 octets).
- * @ie: Information element(s) data.
- * @sae: SAE elements in Authentication frames. This starts
- *	 with the Authentication transaction sequence number field.
- * @nrf_wifi_bssid: MAC address (various uses).
- *
- * This structure specifies the parameters to be used when sending auth request.
  */
 
 struct nrf_wifi_umac_auth_info {
+	/** Frequency of the selected channel in MHz */
 	unsigned int frequency;
+	/** Flag attribute to indicate that a command is requesting a local
+	 *  authentication/association state change without invoking actual management
+	 *  frame exchange. This can be used with NRF_WIFI_UMAC_CMD_AUTHENTICATE
+	 *  NRF_WIFI_UMAC_CMD_DEAUTHENTICATE.
+	 */
 	unsigned short nrf_wifi_flags;
+	/** Authentication type. see &enum nrf_wifi_auth_type */
 	signed int auth_type;
+	/** Key information */
 	struct nrf_wifi_umac_key_info key_info;
+	/** SSID (binary attribute, 0..32 octets) */
 	struct nrf_wifi_ssid ssid;
+	/** Information element(s) data */
 	struct nrf_wifi_ie ie;
+	/** SAE elements in Authentication frames. This starts
+	 *  with the Authentication transaction sequence number field.
+	 */
 	struct nrf_wifi_sae sae;
+	/** MAC address (various uses) */
 	unsigned char nrf_wifi_bssid[NRF_WIFI_ETH_ADDR_LEN];
+	/** The following parameters will be used to construct bss database in case of
+	 * cfg80211 offload to host case.
+	 */
+	/** scanning width */
 	signed int scan_width;
+	/** Signal strength */
 	signed int nrf_wifi_signal;
+	/** Received elements from beacon or probe response */
 	signed int from_beacon;
+	/** BSS information element data */
 	struct nrf_wifi_ie bss_ie;
+	/** BSS capability */
 	unsigned short capability;
+	/** Beacon interval(ms) */
 	unsigned short beacon_interval;
+	/** Beacon tsf */
 	unsigned long long tsf;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_cmd_auth - Authentication command structure.
+ * @brief This structure defines a command used to send an authentication request.
  *
- * @umac_hdr: UMAC command header. See &struct nrf_wifi_umac_hdr.
- * @valid_fields: Indicate which of the following parameters are valid.
- * @info: Information to be passed along with the authentication command.
- *	See &struct nrf_wifi_umac_auth_info.
- *
- * This structure specifies the format to be used when sending an auth request.
  */
 
 struct nrf_wifi_umac_cmd_auth {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Indicate which of the following parameters are valid */
 	unsigned int valid_fields;
+	/** Information to be passed in the authentication command @ref nrf_wifi_umac_auth_info */
 	struct nrf_wifi_umac_auth_info info;
 } __NRF_WIFI_PKD;
 
 #define NRF_WIFI_CMD_ASSOCIATE_MAC_ADDR_VALID (1 << 0)
 
 /**
- * struct nrf_wifi_umac_assoc_info - Association command parameters.
+ * @brief This structure specifies the parameters to be used when sending an association request.
  *
- * @center_frequency: Frequency of the selected channel in MHz, defines the channel
- *	together with the (deprecated)
- *	%NRF_WIFI_UMAC_ATTR_WIPHY_CHANNEL_TYPE attribute or the attributes
- *	%NRF_WIFI_UMAC_ATTR_CHANNEL_WIDTH and if needed
- *	%NRF_WIFI_UMAC_ATTR_CENTER_FREQ1 and %NRF_WIFI_UMAC_ATTR_CENTER_FREQ2.
- * @ssid: SSID (binary attribute, 0..32 octets).
- * @wpa_ie: WPA information element data.
- * @nrf_wifi_bssid: MAC address (various uses).
- *
- * This structure specifies the parameters to be used when sending an assoc
- * request.
  */
 
 struct nrf_wifi_umac_assoc_info {
+	/** Frequency of the selected channel in MHz */
 	unsigned int center_frequency;
+	/** ssid @ref nrf_wifi_ssid */
 	struct nrf_wifi_ssid ssid;
+	/** MAC address (various uses) */
 	unsigned char nrf_wifi_bssid[NRF_WIFI_ETH_ADDR_LEN];
+	/**  WPA information element data. @ref nrf_wifi_ie */
 	struct nrf_wifi_ie wpa_ie;
+	/** Whether management frame protection (IEEE 802.11w) is used for the association */
 	unsigned char use_mfp;
+	/** Indicating whether user space controls IEEE 802.1X port. If set, the RPU will
+	 *  assume that the port is unauthorized until authorized by user space.
+	 *  Otherwise, port is marked authorized by default in station mode.
+	 */
 	signed char control_port;
+	/** Previous BSSID used in flag */
 	unsigned int prev_bssid_flag;
+	/** Previous BSSID used in Re-assoc. */
 	unsigned char prev_bssid[NRF_WIFI_ETH_ADDR_LEN];
+	/** Bss max idle timeout value in sec wich will be encapsulated into
+	 *  BSS MAX IDLE IE in assoc request frame.
+	 */
 	unsigned short bss_max_idle_time;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_cmd_assoc - Association command parameters
+ * @brief This structure specifies the parameters to be used when sending an association request.
  *
- * @umac_hdr: UMAC command header. Refer &struct nrf_wifi_umac_hdr.
- * @valid_fields: Indicate which of the following parameters are valid.
- * @connect_common_info: Connection attributes.
- * @mac_addr: Previous BSSID, to be used by in ASSOCIATE commands to specify
- *	using a reassociate frame.
- *
- * This structure specifies the parameters to be used when sending
- * %NRF_WIFI_UMAC_CMD_ASSOCIATE command.
  */
 
 struct nrf_wifi_umac_cmd_assoc {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Indicate which of the following parameters are valid */
 	unsigned int valid_fields;
+	/** @ref nrf_wifi_connect_common_info */
 	struct nrf_wifi_connect_common_info connect_common_info;
+	/**
+	 * Previous BSSID, to be used by in ASSOCIATE commands to specify
+	 * using a reassociate frame.
+	 */
 	unsigned char mac_addr[NRF_WIFI_ETH_ADDR_LEN];
 } __NRF_WIFI_PKD;
 
@@ -1505,42 +1377,33 @@ struct nrf_wifi_umac_cmd_assoc {
 #define NRF_WIFI_CMD_MLME_LOCAL_STATE_CHANGE (1 << 0)
 
 /**
- * struct nrf_wifi_umac_disconn_info - Parameters to be used along with any of the
- *	disconnection commands.
+ * @brief This structure specifies the parameters to be passed while sending a
+ *  deauthentication request (NRF_WIFI_UMAC_CMD_DEAUTHENTICATE).
  *
- * @nrf_wifi_flags: Flag attribute to indicate that a command is requesting a local
- *	deauthentication/disassociation state change without invoking
- *	actual management frame exchange. This can be used with
- *	%NRF_WIFI_UMAC_CMD_DISASSOCIATE, %NRF_WIFI_UMAC_CMD_DEAUTHENTICATE
- *	(Refer &enum nrf_wifi_umac_commands).
- * @reason_code: ReasonCode for disassociation or deauthentication.
- * @mac_addr: MAC address (various uses).
- *
- * This structure specifies the parameters to be used when sending any of the
- * disconnection commands i.e. %NRF_WIFI_UMAC_CMD_DISCONNECT (or)
- * %NRF_WIFI_UMAC_CMD_DISASSOCIATE (or) %NRF_WIFI_UMAC_CMD_DEAUTHENTICATE.
  */
 
 struct nrf_wifi_umac_disconn_info {
+	/** Indicates that a command is requesting a local deauthentication/disassociation
+	 *  state change without invoking actual management frame exchange.
+	 */
 	unsigned short nrf_wifi_flags;
+	/** Reason code for disassociation or deauthentication */
 	unsigned short reason_code;
+	/** MAC address (various uses) */
 	unsigned char mac_addr[NRF_WIFI_ETH_ADDR_LEN];
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_cmd_disconn - Disconnection command parameters
+ * @brief This structure specifies the parameters to be used when sending a disconnect request.
  *
- * @umac_hdr: UMAC command header. Refer &struct nrf_wifi_umac_hdr.
- * @valid_fields: Indicate which of the following parameters are valid.
- *
- * This structure specifies the parameters to be used when sending
- * %NRF_WIFI_UMAC_CMD_DISCONNECT (or) %NRF_WIFI_UMAC_CMD_DISASSOCIATE (or)
- * %NRF_WIFI_UMAC_CMD_DEAUTHENTICATE.
  */
 
 struct nrf_wifi_umac_cmd_disconn {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Indicate which of the following parameters are valid */
 	unsigned int valid_fields;
+	/** @ref nrf_wifi_umac_disconn_info */
 	struct nrf_wifi_umac_disconn_info info;
 } __NRF_WIFI_PKD;
 
@@ -1550,139 +1413,121 @@ struct nrf_wifi_umac_cmd_disconn {
 #define NRF_WIFI_CMD_NEW_INTERFACE_IFNAME_VALID (1 << 3)
 
 /**
- * struct nrf_wifi_umac_add_vif_info - Information for creating a new virtual
- *	interface.
+ * @brief This structure contains the information to be passed to the RPU
+ *  to create a new virtual interface using the NRF_WIFI_UMAC_CMD_NEW_INTERFACE command.
  *
- * @iftype: Interface type, see enum nrf_wifi_sys_iftype.
- * @nrf_wifi_use_4addr: Use 4-address frames on a virtual interface.
- * @mon_flags: Monitor configuration flags.
- * @mac_addr: MAC Address.
- * @ifacename: Interface name.
- *
- * This structure represents the information to be passed to the RPU to
- * create a new virtual interface using the %NRF_WIFI_UMAC_CMD_NEW_INTERFACE
- * command.
  */
-
 struct nrf_wifi_umac_add_vif_info {
+	/** Interface type, see enum nrf_wifi_sys_iftype */
 	signed int iftype;
+	/** Use 4-address frames on a virtual interface */
 	signed int nrf_wifi_use_4addr;
-	unsigned int mon_flags; /*	|| (1 << enum nrf_wifi_mntr_flags) */
+	/** Unused */
+	unsigned int mon_flags;
+	/** MAC Address */
 	unsigned char mac_addr[NRF_WIFI_ETH_ADDR_LEN];
+	/** Interface name */
 	signed char ifacename[16];
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_cmd_add_vif - Create a new virtual interface
+ * @brief This structure defines a command used to create a new virtual interface
+ *  using the NRF_WIFI_UMAC_CMD_NEW_INTERFACE command.
  *
- * @umac_hdr: UMAC command header. Refer &struct nrf_wifi_umac_hdr.
- * @valid_fields: Indicate which of the following parameters are valid.
- * @info: VIF specific information to be passed to the RPU.
- *
- * This structure represents a command to be passed to inform the RPU to
- * create a new virtual interface.
  */
 
 struct nrf_wifi_umac_cmd_add_vif {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Indicate which of the following parameters are valid */
 	unsigned int valid_fields;
+	/** VIF specific information to be passed to the RPU @ref nrf_wifi_umac_add_vif_info */
 	struct nrf_wifi_umac_add_vif_info info;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_cmd_del_vif - Delete a virtual interface
+ * @brief This structure defines a command used to delete a virtual interface.
+ *  However, this command is not allowed on the default interface.
  *
- * @umac_hdr: UMAC command header. Refer &struct nrf_wifi_umac_hdr.
- *
- * This structure represents a command to be passed to inform the RPU to
- * delete a virtual interface. This cmd is not allowed on default interface.
  */
 
 struct nrf_wifi_umac_cmd_del_vif {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
 } __NRF_WIFI_PKD;
 
 #define NRF_WIFI_FRAME_MATCH_MAX_LEN 8
 
 /**
- * struct nrf_wifi_umac_frame_match - Frame data to match for RX filter.
- * @frame_match_len: Length of data.
- * @frame_match: Data to match.
+ * @brief This structure represents the data of management frame that must be matched for
+ *  processing in userspace.
  *
- * This structure represents the frame data to match so that the RPU RX filter
- * can pass up the matching frames.
  */
 
 struct nrf_wifi_umac_frame_match {
+	/** Length of data */
 	unsigned int frame_match_len;
+	/** Data to match */
 	unsigned char frame_match[NRF_WIFI_FRAME_MATCH_MAX_LEN];
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_mgmt_frame_info - Information regarding management frame to
- *	be registered to be received.
- * @frame_type: Frame type/subtype.
- * @frame_match: A binary attribute which typically must contain at least one
- *	byte.
+ * @brief This structure contains information about the type of management frame
+ *  that should be passed to the driver for processing in userspace.
  *
- * This structure represents information regarding a management frame which
- * should not be filtered by the RPU and passed up.
  */
 
 struct nrf_wifi_umac_mgmt_frame_info {
+	/** Frame type/subtype */
 	unsigned short frame_type;
+	/** Match information Refer &struct nrf_wifi_umac_frame_match */
 	struct nrf_wifi_umac_frame_match frame_match;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_cmd_mgmt_frame_reg - Register management frame type to be
- *	received.
- * @umac_hdr: UMAC event header. Refer &struct nrf_wifi_umac_hdr
- * @info: Management frame specific information to be passed to the RPU.
+ * @brief This structure defines a command to inform the RPU to register a management frame,
+ *  which must not be filtered by the RPU and should instead be passed to the host for
+ *  userspace processing.
  *
- * This structure represents a command to be passed to inform the RPU to
- * register a management frame which should not be filtered by the RPU and
- * passed up.
  */
 
 struct nrf_wifi_umac_cmd_mgmt_frame_reg {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/**
+	 * Management frame specific information to be passed to the RPU.
+	 * @ref nrf_wifi_umac_mgmt_frame_info
+	 */
 	struct nrf_wifi_umac_mgmt_frame_info info;
 } __NRF_WIFI_PKD;
 
 #define NRF_WIFI_CMD_KEY_MAC_ADDR_VALID (1 << 0)
 
 /**
- * struct nrf_wifi_umac_cmd_key - Parameters when adding new key
+ * @brief This structure represents command to add a new key.
  *
- * @umac_hdr: UMAC event header. Refer &struct nrf_wifi_umac_hdr.
- * @valid_fields: Indicate which of the following parameters are valid.
- * @key_info: Key information in a nested attribute with
- *	%NRF_WIFI_UMAC_KEY_* sub-attributes.
- * @mac_addr: MAC address associated with the key.
- *
- * This structure represents a command to add a new key.
  */
 
 struct nrf_wifi_umac_cmd_key {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Indicate which of the following parameters are valid */
 	unsigned int valid_fields;
+	/** Key information. @ref nrf_wifi_umac_key_info */
 	struct nrf_wifi_umac_key_info key_info;
+	/** MAC address associated with the key */
 	unsigned char mac_addr[NRF_WIFI_ETH_ADDR_LEN];
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_set_key - Parameters when setting default key.
+ * @brief This structure defines a command that is used to add a new key.
  *
- * @umac_hdr: UMAC event header. Refer &struct nrf_wifi_umac_hdr.
- * @key_info: Key information in a nested attribute with
- *	%NRF_WIFI_UMAC_KEY_* sub-attributes.
- *
- * This structure represents a command to set a default key.
  */
 
 struct nrf_wifi_umac_cmd_set_key {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Key information , @ref nrf_wifi_umac_key_info */
 	struct nrf_wifi_umac_key_info key_info;
 } __NRF_WIFI_PKD;
 
@@ -1697,51 +1542,48 @@ struct nrf_wifi_umac_cmd_set_key {
 #define NRF_WIFI_BASIC_MAX_SUPP_RATES 32
 
 /**
- * struct nrf_wifi_umac_bss_info - BSS attributes.
- * @p2p_go_ctwindow: P2P GO Client Traffic Window, used with
- *	the START_AP and SET_BSS commands.
- * @p2p_opp_ps: P2P GO opportunistic PS, used with the
- *	START_AP and SET_BSS commands. This can have the values 0 or 1;
- *	if not given in START_AP 0 is assumed, if not given in SET_BSS
- *	no change is made.
- * @num_basic_rates: Number of basic rate elements.
- * @ht_opmode: HT operation mode.
- * @cts: Whether CTS protection is enabled (0 or 1).
- * @preamble: Whether short preamble is enabled (0 or 1).
- * @slot: Whether short slot time enabled (0 or 1).
- * @ap_isolate: (AP mode) Do not forward traffic between stations connected to
- *	this BSS.
- * @basic_rates: Basic rates, array of basic rates in format defined by
- *	IEEE 802.11 7.3.2.2 but without the length restriction
- *	(at most %NRF_WIFI_MAX_SUPP_RATES).
+ * @brief This structure contains parameters that describe the BSS (Basic Service Set) information.
  *
- * This structure represents the BSS attributes.
  */
 
 struct nrf_wifi_umac_bss_info {
+	/** P2P GO Client Traffic Window, used with
+	 *  the START_AP and SET_BSS commands.
+	 */
 	unsigned int p2p_go_ctwindow;
+	/** P2P GO opportunistic PS, used with the
+	 *  START_AP and SET_BSS commands. This can have the values 0 or 1;
+	 *  if not given in START_AP 0 is assumed, if not given in SET_BSS
+	 *  no change is made.
+	 */
 	unsigned int p2p_opp_ps;
+	/** Number of basic rate elements */
 	unsigned int num_basic_rates;
+	/** HT operation mode */
 	unsigned short ht_opmode;
+	/** Whether CTS protection is enabled (0 or 1) */
 	unsigned char nrf_wifi_cts;
+	/** Whether short preamble is enabled (0 or 1) */
 	unsigned char preamble;
+	/** Whether short slot time enabled (0 or 1) */
 	unsigned char nrf_wifi_slot;
+	/** (AP mode) Do not forward traffic between stations connected to this BSS */
 	unsigned char ap_isolate;
+	/** Basic rates, array of basic rates in format defined by IEEE 802.11 7.3.2.2 */
 	unsigned char basic_rates[NRF_WIFI_BASIC_MAX_SUPP_RATES];
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_cmd_set_bss - Set BSS attributes.
- * @umac_hdr: UMAC event header. Refer &struct nrf_wifi_umac_hdr.
- * @valid_fields: Indicate which of the following parameters are valid
- * @bss_info: BSS specific information to be passed to the RPU.
+ * @brief This structure represents a command used to set BSS (Basic Service Set) parameters.
  *
- * This structure represents a command to set BSS attributes.
  */
 
 struct nrf_wifi_umac_cmd_set_bss {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Indicate which of the following parameters are valid */
 	unsigned int valid_fields;
+	/** BSS specific information to be passed to the RPU @ref nrf_wifi_umac_bss_info */
 	struct nrf_wifi_umac_bss_info bss_info;
 } __NRF_WIFI_PKD;
 
@@ -1752,61 +1594,55 @@ struct nrf_wifi_umac_cmd_set_bss {
 #define NRF_WIFI_SET_FREQ_PARAMS_CHANNEL_TYPE_VALID (1 << 4)
 
 /**
- * struct freq_params - Frequency configuration.
- * @valid_fields: Indicate which of the following parameters are valid.
- * @frequency: Value in MHz.
- * @channel_width: Width of the channel (refer &enum nrf_wifi_chan_width).
- * @channel_type: Type of channel (refer &enum nrf_wifi_channel_type).
+ * @brief This structure contains information about frequency parameters.
  *
- * This structure represents a frequency parameters to be set.
  */
 
 struct freq_params {
+	/** Indicate which of the following parameters are valid */
 	unsigned int valid_fields;
+	/** Value in MHz */
 	signed int frequency;
+	/** Width of the channel @see &enu nrf_wifi_chan_width */
 	signed int channel_width;
-	/* private : presently unused */
+	/** Unused */
 	signed int center_frequency1;
-	/* private : presently unused */
+	/** Unused */
 	signed int center_frequency2;
-	/* public: */
+	/** Type of channel see &enum nrf_wifi_channel_type */
 	signed int channel_type;
-
 } __NRF_WIFI_PKD;
 
-
 /**
- * struct nrf_wifi_txq_params - TX queue parameter attributes.
- * @txop: Transmit oppurtunity.
- * @cwmin: Minimum contention window.
- * @cwmax: Maximum contention window.
- * @aifs: Arbitration interframe spacing.
- * @ac: Access category.
+ * @brief This structure contains information about transmit queue parameters.
  *
- * This structure represents transmit queue parameters.
  */
 
 struct nrf_wifi_txq_params {
+	/** Transmit oppurtunity */
 	unsigned short txop;
+	/** Minimum contention window */
 	unsigned short cwmin;
+	/** Maximum contention window */
 	unsigned short cwmax;
+	/** Arbitration interframe spacing */
 	unsigned char aifs;
+	/** Access category */
 	unsigned char ac;
 
 } __NRF_WIFI_PKD;
 
 /**
- * enum nrf_wifi_tx_power_type - TX power adjustment.
- * @NRF_WIFI_TX_POWER_AUTOMATIC: Automatically determine transmit power.
- * @NRF_WIFI_TX_POWER_LIMITED: Limit TX power by the mBm parameter.
- * @NRF_WIFI_TX_POWER_FIXED: Fix TX power to the mBm parameter.
+ * @brief Types of transmit power settings.
  *
- * Types of transmit power settings.
  */
-enum nrf_wifi_tx_power_type {
 
+enum nrf_wifi_tx_power_type {
+	/** Automatically determine transmit power */
 	NRF_WIFI_TX_POWER_AUTOMATIC,
+	/** Limit TX power by the mBm parameter */
 	NRF_WIFI_TX_POWER_LIMITED,
+	/** Fix TX power to the mBm parameter */
 	NRF_WIFI_TX_POWER_FIXED,
 };
 
@@ -1814,17 +1650,16 @@ enum nrf_wifi_tx_power_type {
 #define NRF_WIFI_TX_POWER_SETTING_TX_POWER_LEVEL_VALID (1 << 1)
 
 /**
- * struct nrf_wifi_tx_power_setting - TX power configuration.
- * @valid_fields: Indicate which of the following parameters are valid.
- * @type: Power value type, see nrf_wifi_tx_power_type.
- * @tx_power_level: Transmit power level in signed mBm units.
+ * @brief This structure contains the parameters related to the transmit power setting.
  *
- * This structure represents the transmit power setting parameters.
  */
 
 struct nrf_wifi_tx_power_setting {
+	/** Indicate which of the following parameters are valid */
 	unsigned int valid_fields;
+	/** Power value type, see nrf_wifi_tx_power_type */
 	signed int type;
+	/** Transmit power level in signed mBm units */
 	signed int tx_power_level;
 
 } __NRF_WIFI_PKD;
@@ -1842,66 +1677,63 @@ struct nrf_wifi_tx_power_setting {
 #define NRF_WIFI_CMD_SET_WIPHY_WIPHY_NAME_VALID (1 << 10)
 
 /**
- * struct nrf_wifi_umac_set_wiphy_info - wiphy configuration.
- * @rts_threshold: RTS threshold (TX frames with length
- *	larger than or equal to this use RTS/CTS handshake); allowed range:
- *	0..65536, disable with (u32)-1.
- * @frag_threshold: Fragmentation threshold, i.e., maximum
- *	length in octets for frames; allowed range: 256..8000, disable
- *	fragmentation with (u32)-1.
- * @antenna_tx: Bitmap of allowed antennas for transmitting.
- *	This can be used to mask out antennas which are not attached or should
- *	not be used for transmitting. If an antenna is not selected in this
- *	bitmap the hardware is not allowed to transmit on this antenna.
- * @antenna_rx: Bitmap of allowed antennas for receiving.
- *	This can be used to mask out antennas which are not attached or should
- *	not be used for receiving. If an antenna is not selected in this bitmap
- *	the hardware should not be configured to receive on this antenna.
- * @freq_params: Frequency of the selected channel in MHz,
- *	defines the channel together with the (deprecated)
- *	%NRF_WIFI_ATTR_WIPHY_CHANNEL_TYPE attribute or the attributes
- *	%NRF_WIFI_ATTR_CHANNEL_WIDTH and if needed %NRF_WIFI_ATTR_CENTER_FREQ1
- *	and %NRF_WIFI_ATTR_CENTER_FREQ2.
- * @txq_params: A nested array of TX queue parameters.
- * @tx_power_setting: Transmit power setting type. See
- *	&enum nrf_wifi_tx_power_setting for possible values.
- * @retry_short: TX retry limit for frames whose length is
- *	less than or equal to the RTS threshold; allowed range: 1..255.
- * @retry_long: TX retry limit for frames whose length is
- *	greater than the RTS threshold; allowed range: 1..255.
- * @coverage_class:Coverage Class as defined by IEEE 802.11
- *	section 7.3.2.9.
- * @wiphy_name: WIPHY name (used for renaming).
+ * @brief This structure contains information about the configuration parameters
+ *  needed to set up and configure the wireless Physical Layer.
  *
- * This structure represents the wireless PHY configuration.
  */
 
 struct nrf_wifi_umac_set_wiphy_info {
+	/** RTS threshold, TX frames with length larger than or equal to this use RTS/CTS handshake
+	 *  allowed range: 0..65536, disable with -1.
+	 */
 	unsigned int rts_threshold;
+	/** Fragmentation threshold, maximum length in octets for frames.
+	 *  allowed range: 256..8000, disable fragmentation with (u32)-1.
+	 */
 	unsigned int frag_threshold;
+	/** Bitmap of allowed antennas for transmitting. This can be used to mask out
+	 *  antennas which are not attached or should not be used for transmitting.
+	 *  If an antenna is not selected in this bitmap the hardware is not allowed
+	 *  to transmit on this antenna.
+	 */
 	unsigned int antenna_tx;
+	/** Bitmap of allowed antennas for receiving. This can be used to mask out antennas
+	 *  which are not attached or should not be used for receiving. If an antenna is
+	 *  not selected in this bitmap the hardware should not be configured to receive
+	 *  on this antenna.
+	 */
 	unsigned int antenna_rx;
+	/** Frequency information of the a channel see &struct freq_params */
 	struct freq_params freq_params;
+	/** TX queue parameters @ref nrf_wifi_txq_params */
 	struct nrf_wifi_txq_params txq_params;
+	/** Tx power settings @ref nrf_wifi_tx_power_setting @ref nrf_wifi_tx_power_setting */
 	struct nrf_wifi_tx_power_setting tx_power_setting;
+	/** TX retry limit for frames whose length is less than or equal to the RTS threshold
+	 *  allowed range: 1..255.
+	 */
 	unsigned char retry_short;
+	/** TX retry limit for frames whose length is greater than the RTS threshold
+	 *  allowed range: 1..255.
+	 */
 	unsigned char retry_long;
+	/** Unused */
 	unsigned char coverage_class;
+	/** WIPHY name (used for renaming) */
 	signed char wiphy_name[32];
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_cmd_set_wiphy - Set wiphy configuration.
- * @umac_hdr: UMAC command header. Refer &struct nrf_wifi_umac_hdr.
- * @valid_fields: Indicate which of the following structure parameters are valid.
- * @info: Information related to wiphy parameters
+ * @brief This structure defines the command to set the wireless PHY configuration.
  *
- * This structure represents the command to set the wireless PHY configuration.
  */
 
 struct nrf_wifi_umac_cmd_set_wiphy {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Indicates which of the following parameters are valid */
 	unsigned int valid_fields;
+	/** @ref nrf_wifi_umac_set_wiphy_info */
 	struct nrf_wifi_umac_set_wiphy_info info;
 } __NRF_WIFI_PKD;
 
@@ -1910,88 +1742,106 @@ struct nrf_wifi_umac_cmd_set_wiphy {
 #define NRF_WIFI_CMD_DEL_STATION_REASON_CODE_VALID (1 << 2)
 
 /**
- * struct nrf_wifi_umac_del_sta_info - Information regarding a station to be
- *	deleted.
- * @mac_addr: MAC address of the station.
- * @mgmt_subtype: Management frame subtype.
- * @reason_code: Reason code for DEAUTHENTICATION and DISASSOCIATION.
+ * @brief This structure contains the parameters to delete a station.
  *
- * This structure represents the information regarding a station to be deleted
- * from the RPU.
  */
 
 struct nrf_wifi_umac_del_sta_info {
+	/** MAC address of the station */
 	unsigned char mac_addr[NRF_WIFI_ETH_ADDR_LEN];
+	/** Management frame subtype */
 	unsigned char mgmt_subtype;
+	/** Reason code for DEAUTHENTICATION and DISASSOCIATION */
 	unsigned short reason_code;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_cmd_del_sta - Delete a station entry.
- * @umac_hdr: UMAC command header. Refer &struct nrf_wifi_umac_hdr.
- * @valid_fields: Indicate which of the following parameters are valid.
- * @info: Information regarding the station to be deleted.
+ * @brief This structure defines the command to delete a station.
  *
- * This structure represents the command to delete a station.
  */
 
 struct nrf_wifi_umac_cmd_del_sta {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Indicate which of the following parameters are valid */
 	unsigned int valid_fields;
+	/** Information regarding the station to be deleted @ref nrf_wifi_umac_del_sta_info */
 	struct nrf_wifi_umac_del_sta_info info;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_get_sta_info - Station information get.
- * @mac_addr: MAC address of the station.
- * This structure represents the information regarding a station info to be get.
+ * @brief This structure contains the information required for obtaining station details.
+ *
  */
 
 struct nrf_wifi_umac_get_sta_info {
+	/** MAC address of the station */
 	unsigned char mac_addr[NRF_WIFI_ETH_ADDR_LEN];
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_cmd_get_sta - Get a station info.
- * @umac_hdr: UMAC command header. Refer &struct nrf_wifi_umac_hdr.
- * @info: Information regarding the station to get.
+ * @brief This structure defines the command to get station information.
  *
- * This structure represents the command to get station info.
  */
 
 struct nrf_wifi_umac_cmd_get_sta {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Information regarding the station to get @ref nrf_wifi_umac_get_sta_info */
 	struct nrf_wifi_umac_get_sta_info info;
 } __NRF_WIFI_PKD;
 
 #define NRF_WIFI_EXT_CAPABILITY_MAX_LEN 32
 
+/**
+ * @brief Extended capability information.
+ */
+
 struct nrf_wifi_ext_capability {
+	/** length */
 	unsigned int ext_capability_len;
+	/** Extended capability info*/
 	unsigned char ext_capability[NRF_WIFI_EXT_CAPABILITY_MAX_LEN];
 
 } __NRF_WIFI_PKD;
 
 #define NRF_WIFI_SUPPORTED_CHANNELS_MAX_LEN 64
 
+/**
+ * @brief Supported channels.
+ */
+
 struct nrf_wifi_supported_channels {
+	/** number of channels */
 	unsigned int supported_channels_len;
+	/** channels info */
 	unsigned char supported_channels[NRF_WIFI_SUPPORTED_CHANNELS_MAX_LEN];
 
 } __NRF_WIFI_PKD;
 
-#define NRF_WIFI_SUPPORTED_OPER_CLASSES_MAX_LEN 64
+#define NRF_WIFI_OPER_CLASSES_MAX_LEN 64
 
+/**
+ * @brief Operating classes information.
+ */
 struct nrf_wifi_supported_oper_classes {
+	/** length */
 	unsigned int supported_oper_classes_len;
-	unsigned char supported_oper_classes[NRF_WIFI_SUPPORTED_OPER_CLASSES_MAX_LEN];
+	/** oper_class info*/
+	unsigned char supported_oper_classes[NRF_WIFI_OPER_CLASSES_MAX_LEN];
 
 } __NRF_WIFI_PKD;
 
 #define NRF_WIFI_STA_FLAGS2_MAX_LEN 64
 
+/**
+ * @brief Station flags.
+ */
+
 struct nrf_wifi_sta_flags2 {
+	/** length */
 	unsigned int sta_flags2_len;
+	/** flags */
 	unsigned char sta_flags2[NRF_WIFI_STA_FLAGS2_MAX_LEN];
 
 } __NRF_WIFI_PKD;
@@ -2013,65 +1863,63 @@ struct nrf_wifi_sta_flags2 {
 #define NRF_WIFI_CMD_SET_STATION_LISTEN_INTERVAL_VALID (1 << 15)
 
 /**
- * struct nrf_wifi_umac_chg_sta_info - Information about station entry to be updated.
- * @nrf_wifi_listen_interval: Listen interval as defined by IEEE 802.11 7.3.1.6.
- * @sta_vlan: Vlan interface station should belong to.
- * @aid: AID or zero for no change.
- * @nrf_wifi_peer_aid: Unused.
- * @sta_capability: Station capability.
- * @spare: Unused.
- * @supp_rates: Supported rates in IEEE 802.11 format.
- * @ext_capability: Extended capabilities of the station.
- * @supported_channels: Supported channels in IEEE 802.11 format.
- * @supported_oper_classes: Supported oper classes in IEEE 802.11 format.
- * @sta_flags2: Unused.
- * @ht_capability: HT capabilities of station.
- * @vht_capability: VHT capabilities of station.
- * @mac_addr: Station mac address.
- * @opmode_notif: Information if operating mode field is used.
- * @wme_uapsd_queues: Bitmap of queues configured for uapsd. Same format
- *	as the AC bitmap in the QoS info field.
- * @wme_max_sp: Max Service Period. same format as the MAX_SP in the
- *	QoS info field (but already shifted down).
- *
- * This structure represents the information needed to update a station entry
+ * @brief This structure represents the information needed to update a station entry
  * in the RPU.
+ *
  */
 
 struct nrf_wifi_umac_chg_sta_info {
+	/** Listen interval as defined by IEEE 802.11 7.3.1.6 */
 	signed int nrf_wifi_listen_interval;
+	/** Unused */
 	unsigned int sta_vlan;
+	/** AID or zero for no change */
 	unsigned short aid;
+	/** Unused */
 	unsigned short nrf_wifi_peer_aid;
+	/** Station capability */
 	unsigned short sta_capability;
+	/** Unused */
 	unsigned short spare;
+	/** Supported rates in IEEE 802.11 format @ref nrf_wifi_supp_rates */
 	struct nrf_wifi_supp_rates supp_rates;
+	/** Extended capabilities of the station @ref nrf_wifi_ext_capability */
 	struct nrf_wifi_ext_capability ext_capability;
+	/** Supported channels in IEEE 802.11 format @ref nrf_wifi_supported_channels */
 	struct nrf_wifi_supported_channels supported_channels;
+	/** Supported oper classes in IEEE 802.11 format @ref nrf_wifi_supported_oper_classes */
 	struct nrf_wifi_supported_oper_classes supported_oper_classes;
-	/*struct nrf_wifi_sta_flags2 sta_flags2;*/
+	/** station flags mask/set @ref nrf_wifi_sta_flag_update @ref nrf_wifi_sta_flag_update */
 	struct nrf_wifi_sta_flag_update sta_flags2;
+	/** HT capabilities of station */
 	unsigned char ht_capability[NRF_WIFI_HT_VHT_CAPABILITY_MAX_SIZE];
+	/** VHT capabilities of station */
 	unsigned char vht_capability[NRF_WIFI_HT_VHT_CAPABILITY_MAX_SIZE];
+	/** Station mac address */
 	unsigned char mac_addr[NRF_WIFI_ETH_ADDR_LEN];
+	/** Information if operating mode field is used */
 	unsigned char opmode_notif;
+	/** Bitmap of queues configured for uapsd. Same format
+	 *  as the AC bitmap in the QoS info field.
+	 */
 	unsigned char wme_uapsd_queues;
+	/** Max Service Period. same format as the MAX_SP in the
+	 *  QoS info field (but already shifted down).
+	 */
 	unsigned char wme_max_sp;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_cmd_chg_sta - Update station entry.
- * @umac_hdr: UMAC command header. Refer &struct nrf_wifi_umac_hdr.
- * @valid_fields: Indicate which of the following parameters are valid.
- * @info: Information about station entry to be updated.
+ * @brief This structure defines the command for updating the parameters of a station entry.
  *
- * This structure represents the command to update the parameters of a
- * station entry.
  */
 
 struct nrf_wifi_umac_cmd_chg_sta {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Indicate which of the following parameters are valid */
 	unsigned int valid_fields;
+	/** @ref nrf_wifi_umac_chg_sta_info */
 	struct nrf_wifi_umac_chg_sta_info info;
 } __NRF_WIFI_PKD;
 
@@ -2092,63 +1940,62 @@ struct nrf_wifi_umac_cmd_chg_sta {
 #define NRF_WIFI_CMD_NEW_STATION_LISTEN_INTERVAL_VALID (1 << 15)
 
 /**
- * struct nrf_wifi_umac_add_sta_info - Information about a station entry to be added.
- * @nrf_wifi_listen_interval: Listen interval as defined by IEEE 802.11 7.3.1.6.
- * @sta_vlan: VLAN interface station should belong to.
- * @aid: AID or zero for no change.
- * @nrf_wifi_peer_aid: Unused.
- * @sta_capability: Station capability.
- * @spare: Unused.
- * @supp_rates: Supported rates in IEEE 802.11 format.
- * @ext_capability: Extended capabilities of the station.
- * @supported_channels: Supported channels in IEEE 802.11 format.
- * @supported_oper_classes: Supported oper classes in IEEE 802.11 format.
- * @sta_flags2: Unused.
- * @ht_capability: HT capabilities of station.
- * @vht_capability: VHT capabilities of station.
- * @mac_addr: Station mac address.
- * @opmode_notif: Information if operating mode field is used
- * @wme_uapsd_queues: Bitmap of queues configured for uapsd. same format
- *	as the AC bitmap in the QoS info field.
- * @wme_max_sp: Max Service Period. same format as the MAX_SP in the
- *	QoS info field (but already shifted down).
+ * @brief This structure describes the parameters for adding a new station entry to the RPU.
  *
- * This structure represents the information about a new station entry to be
- * added to the RPU.
  */
 
 struct nrf_wifi_umac_add_sta_info {
+	/** Listen interval as defined by IEEE 802.11 7.3.1.6 */
 	signed int nrf_wifi_listen_interval;
+	/** Unused */
 	unsigned int sta_vlan;
+	/** AID or zero for no change */
 	unsigned short aid;
+	/** Unused */
 	unsigned short nrf_wifi_peer_aid;
+	/** Station capability */
 	unsigned short sta_capability;
+	/** Unused */
 	unsigned short spare;
+	/** Supported rates in IEEE 802.11 format @ref nrf_wifi_supp_rates */
 	struct nrf_wifi_supp_rates supp_rates;
+	/** Extended capabilities of the station @ref nrf_wifi_ext_capability */
 	struct nrf_wifi_ext_capability ext_capability;
+	/** Supported channels in IEEE 802.11 format @ref nrf_wifi_supported_channels */
 	struct nrf_wifi_supported_channels supported_channels;
+	/** Supported oper classes in IEEE 802.11 format @ref nrf_wifi_supported_oper_classes */
 	struct nrf_wifi_supported_oper_classes supported_oper_classes;
-	/*struct nrf_wifi_sta_flags2 sta_flags2;*/
+	/** station flags mask/set @ref nrf_wifi_sta_flag_update */
 	struct nrf_wifi_sta_flag_update sta_flags2;
+	/** HT capabilities of station */
 	unsigned char ht_capability[NRF_WIFI_HT_VHT_CAPABILITY_MAX_SIZE];
+	/** VHT capabilities of station */
 	unsigned char vht_capability[NRF_WIFI_HT_VHT_CAPABILITY_MAX_SIZE];
+	/** Station mac address */
 	unsigned char mac_addr[NRF_WIFI_ETH_ADDR_LEN];
+	/** Information if operating mode field is used */
 	unsigned char opmode_notif;
+	/** Bitmap of queues configured for uapsd. same format
+	 *  as the AC bitmap in the QoS info field.
+	 */
 	unsigned char wme_uapsd_queues;
+	/** Max Service Period. same format as the MAX_SP in the
+	 *  QoS info field (but already shifted down).
+	 */
 	unsigned char wme_max_sp;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_cmd_add_sta - Add station entry
- * @umac_hdr: UMAC command header. Refer &struct nrf_wifi_umac_hdr.
- * @valid_fields: Indicate which of the following parameters are valid.
+ * @brief This structure defines the command for adding a new station entry.
  *
- * This structure represents the commands to add a new station entry.
  */
 
 struct nrf_wifi_umac_cmd_add_sta {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Indicate which of the following parameters are valid */
 	unsigned int valid_fields;
+	/** @ref nrf_wifi_umac_add_sta_info */
 	struct nrf_wifi_umac_add_sta_info info;
 } __NRF_WIFI_PKD;
 
@@ -2158,103 +2005,97 @@ struct nrf_wifi_umac_cmd_add_sta {
 #define NRF_WIFI_CMD_BEACON_INFO_CIPHER_SUITE_GROUP_VALID (1 << 3)
 #define NRF_WIFI_CMD_BEACON_INFO_INACTIVITY_TIMEOUT_VALID (1 << 4)
 #define NRF_WIFI_CMD_BEACON_INFO_FREQ_PARAMS_VALID (1 << 5)
+
 #define NRF_WIFI_CMD_BEACON_INFO_PRIVACY (1 << 0)
 #define NRF_WIFI_CMD_BEACON_INFO_CONTROL_PORT_NO_ENCRYPT (1 << 1)
 #define NRF_WIFI_CMD_BEACON_INFO_P2P_CTWINDOW_VALID (1 << 6)
 #define NRF_WIFI_CMD_BEACON_INFO_P2P_OPPPS_VALID (1 << 7)
 
 /**
- * struct nrf_wifi_umac_start_ap_info - Attributes needed to start SoftAP operation.
- * @beacon_interval: Beacon frame interval.
- * @dtim_period: DTIM count.
- * @hidden_ssid: Send beacons with wildcard sssid.
- * @auth_type: Authentication type, see nrf_wifi_auth_type.
- * @smps_mode: Unused.
- * @nrf_wifi_flags: Beacon info flags.
- * @beacon_data: Beacon frame, See &struct nrf_wifi_beacon_data.
- * @ssid: SSID string, See &struct nrf_wifi_ssid.
- * @connect_common_info: Connect params, See &struct nrf_wifi_connect_common_info.
- * @freq_params: Channel info, See &struct freq_params.
- * @inactivity_timeout: Time to stop ap after inactivity period.
- * @p2p_go_ctwindow: P2P GO Client Traffic Window.
- * @p2p_opp_ps: Opportunistic power save allows P2P Group Owner to save power
- *	when all its associated clients are sleeping.
+ * @brief This structure describes the parameters required to be passed to the RPU when
+ *  initiating a SoftAP (Soft Access Point).
  *
- * This structure represents the attributes that need to be passed to the RPU
- * when starting a SoftAP.
  */
 
 struct nrf_wifi_umac_start_ap_info {
+	/** Beacon frame interval */
 	unsigned short beacon_interval;
+	/** DTIM count */
 	unsigned char dtim_period;
+	/** Send beacons with wildcard sssid */
 	signed int hidden_ssid;
+	/** Authentication type, see &enum nrf_wifi_auth_type */
 	signed int auth_type;
+	/** Unused */
 	signed int smps_mode;
+	/** Beacon info flags */
 	unsigned int nrf_wifi_flags;
+	/** Beacon frame, @ref nrf_wifi_beacon_data */
 	struct nrf_wifi_beacon_data beacon_data;
+	/** SSID string, @ref nrf_wifi_ssid */
 	struct nrf_wifi_ssid ssid;
+	/** Connect params, @ref nrf_wifi_connect_common_info */
 	struct nrf_wifi_connect_common_info connect_common_info;
+	/** Channel info, see &struct freq_params */
 	struct freq_params freq_params;
+	/** Time to stop ap after inactivity period */
 	unsigned short inactivity_timeout;
+	/** P2P GO Client Traffic Window */
 	unsigned char p2p_go_ctwindow;
+	/** Opportunistic power save allows P2P Group Owner to save power
+	 *  when all its associated clients are sleeping.
+	 */
 	unsigned char p2p_opp_ps;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_cmd_start_ap - Start SoftAP
- * @umac_hdr: UMAC command header. Refer &struct nrf_wifi_umac_hdr.
- * @valid_fields: Indicate which of the following parameters are valid.
- * @info: Attributes that need to be passed to the RPU when starting a SoftAP.
- *	*See &struct nrf_wifi_umac_start_ap_info)
+ * @brief This structure defines the command for starting the SoftAP using
+ *  NRF_WIFI_UMAC_CMD_NEW_BEACON and NRF_WIFI_UMAC_CMD_START_AP.
  *
- * The struct nrf_wifi_umac_cmd_start_ap is same for the following message types
- * %NRF_WIFI_UMAC_CMD_NEW_BEACON
- * %NRF_WIFI_UMAC_CMD_START_AP
- * (Refer &enum nrf_wifi_umac_commands).
  */
 
 struct nrf_wifi_umac_cmd_start_ap {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Indicate which of the following parameters are valid */
 	unsigned int valid_fields;
+	/** Parameters that need to be passed to the RPU when starting a SoftAP.
+	 *  @ref nrf_wifi_umac_start_ap_info
+	 */
 	struct nrf_wifi_umac_start_ap_info info;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_cmd_stop_ap - Stop SoftAP
- * @umac_hdr: UMAC command header. Refer &struct nrf_wifi_umac_hdr.
+ * @brief This structure defines the command used to stop Soft AP operation.
  *
- * This structure represents the command to stop the operation of a Soft AP.
  */
 
 struct nrf_wifi_umac_cmd_stop_ap {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_set_beacon_info - Attributes needed to set Beacon & Probe Rsp.
- * @beacon_data: Beacon frame, See &struct nrf_wifi_beacon_data.
+ * @brief This structure represents the parameters that must be passed to the RPU when
+ *  configuring Beacon and Probe response data.
  *
- * This structure represents the attributes that need to be passed to the RPU
- * when Beacon & Probe Rsp data settings.
  */
 
 struct nrf_wifi_umac_set_beacon_info {
+	/** Beacon frame, @ref nrf_wifi_beacon_data */
 	struct nrf_wifi_beacon_data beacon_data;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_cmd_set_beacon - Set beacon data
- * @umac_hdr: UMAC command header. Refer &struct nrf_wifi_umac_hdr.
- * @info: Attributes that need to be passed to the RPU when Beacon &
- *	Probe response data to set.
- *	See &struct nrf_wifi_umac_set_beacon_info)
+ * @brief This structure defines the command for setting the beacon data using
+ *  NRF_WIFI_UMAC_CMD_SET_BEACON.
  *
- * %NRF_WIFI_UMAC_CMD_SET_BEACON
- * (Refer &enum nrf_wifi_umac_commands).
  */
 
 struct nrf_wifi_umac_cmd_set_beacon {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** @ref nrf_wifi_umac_set_beacon_info */
 	struct nrf_wifi_umac_set_beacon_info info;
 } __NRF_WIFI_PKD;
 
@@ -2262,87 +2103,86 @@ struct nrf_wifi_umac_cmd_set_beacon {
 #define NRF_WIFI_SET_INTERFACE_USE_4ADDR_VALID (1 << 1)
 
 /**
- * struct nrf_wifi_umac_chg_vif_attr_info - Interface attributes to be changed.
- * @iftype: Interface type, see &enum nrf_wifi_iftype.
- * @nrf_wifi_user_4addr: Unused.
+ * @brief This structure contains the information that needs to be provided to the RPU
+ *  when modifying the attributes of a virtual interface.
  *
- * This structure represents the information to be passed to the RPU when
- * changing the attributes of a virtual interface.
  */
 
 struct nrf_wifi_umac_chg_vif_attr_info {
+	/** Interface type, see &enum nrf_wifi_iftype */
 	signed int iftype;
+	/** Unused */
 	signed int nrf_wifi_use_4addr;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_cmd_chg_vif_attr - Change virtual interface attributes.
- * @umac_hdr: UMAC command header. Refer &struct nrf_wifi_umac_hdr.
- * @valid_fields: Indicate which of the following parameters are valid.
- * @info: Interface attributes to be changed.
+ * @brief This structure defines the command used to change the interface.
  *
- * This structure represents the command to change interface attributes.
  */
 
 struct nrf_wifi_umac_cmd_chg_vif_attr {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Indicate which of the following parameters are valid */
 	unsigned int valid_fields;
+	/** Interface attributes to be changed @ref nrf_wifi_umac_chg_vif_attr_info */
 	struct nrf_wifi_umac_chg_vif_attr_info info;
 } __NRF_WIFI_PKD;
 
 #define IFACENAMSIZ 16
 
 /**
- * struct nrf_wifi_umac_chg_vif_state_info- Interface state information.
- * @state: Interface state (1 = UP / 0 = DOWN).
- * @ifacename: Interface name.
+ * @brief This structure contains the information that needs to be passed to the RPU
+ *  when changing the interface state, specifically when bringing it up or down
  *
- * This structure represents the information to be passed the RPU when changing
- * the state (up/down) of a virtual interface.
  */
 
 struct nrf_wifi_umac_chg_vif_state_info {
+	/** Interface state (1 = UP / 0 = DOWN) */
 	signed int state;
+	/** Interface name */
 	signed char ifacename[IFACENAMSIZ];
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_cmd_chg_vif_state- Change the interface state
- * @umac_hdr: UMAC command header. Refer &struct nrf_wifi_umac_hdr.
- * @info: Interface state information.
+ * @brief This structure defines the command used to change the interface state.
  *
- * This structure represents the command to change interface state.
  */
 
 struct nrf_wifi_umac_cmd_chg_vif_state {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** @ref nrf_wifi_umac_chg_vif_state_info */
 	struct nrf_wifi_umac_chg_vif_state_info info;
 } __NRF_WIFI_PKD;
+/**
+ * @brief This structure defines an event-to-command mapping for NRF_WIFI_UMAC_CMD_SET_IFFLAGS.
+ *
+ */
 
 struct nrf_wifi_umac_event_vif_state {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Status to command NRF_WIFI_UMAC_CMD_SET_IFFLAGS */
 	signed int status;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_cmd_start_p2p_dev - Start P2P mode on an interface
- * @umac_hdr: UMAC command header. Refer &struct nrf_wifi_umac_hdr.
- *
- * This structure represents the command to start P2P mode on an interface.
+ * @brief This structure defines the command used to start P2P (Peer-to-Peer) mode on an interface.
  */
 
 struct nrf_wifi_cmd_start_p2p {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_cmd_stop_p2p_dev - stop p2p mode
- * @umac_hdr: UMAC command header. Refer &struct nrf_wifi_umac_hdr.
+ * @brief This structure represents the command for stopping P2P mode on an interface.
  *
- * This structure represents the command to stop P2P mode on an interface.
  */
 
 struct nrf_wifi_umac_cmd_stop_p2p_dev {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
 } __NRF_WIFI_PKD;
 
@@ -2355,122 +2195,119 @@ struct nrf_wifi_umac_cmd_stop_p2p_dev {
 #define NRF_WIFI_CMD_FRAME_DONT_WAIT_FOR_ACK (1 << 2)
 
 /**
- * struct nrf_wifi_umac_mgmt_tx_info - Information about a management frame to be
- *	transmitted.
- * @flags: OFFCHANNEL_TX_OK, NO_CCK_RATE, DONT_WAIT_FOR_ACK.
- * @dur: Duration field value.
- * @frame: Management frame to transmit.
- * @frequency: Channel.
- * @freq_params: Frequency configuration, See &struct freq_params.
- * @host_cookie: Identifier to be used for processing done event,
- *	see %NRF_WIFI_UMAC_EVENT_FRAME_TX_STATUS.
+ * @brief This structure describes the parameters required to transmit a
+ *  management frame from the host.
  *
- * This structure represents the information about a management frame to be
- * transmitted.
  */
 
 struct nrf_wifi_umac_mgmt_tx_info {
+	/** OFFCHANNEL_TX_OK, NO_CCK_RATE, DONT_WAIT_FOR_ACK */
 	unsigned int nrf_wifi_flags;
+	/** Channel frequency */
 	unsigned int frequency;
+	/** Duration field value */
 	unsigned int dur;
+	/** Management frame to transmit, @ref nrf_wifi_frame */
 	struct nrf_wifi_frame frame;
+	/** Frequency configuration, see &struct freq_params */
 	struct freq_params freq_params;
+	/** Identifier to be used for processing event,
+	 *  NRF_WIFI_UMAC_EVENT_FRAME_TX_STATUS.
+	 */
 	unsigned long long host_cookie;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_cmd_mgmt_tx - Tranmit a management frame.
- * @umac_hdr: UMAC event header. Refer &struct nrf_wifi_umac_hdr.
- * @valid_fields: Indicate which of the following parameters are valid.
- * @info: Information about the management frame to be transmitted.
+ * @brief This structure defines the command used to transmit a management frame.
  *
- * This structure represents the command to transmit a management frame.
  */
 
 struct nrf_wifi_umac_cmd_mgmt_tx {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Indicate which of the following parameters are valid */
 	unsigned int valid_fields;
+	/** Information about the management frame to be transmitted.
+	 *  @ref nrf_wifi_umac_mgmt_tx_info
+	 */
 	struct nrf_wifi_umac_mgmt_tx_info info;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_set_power_save_info - Information about power save
- *	settings.
- * @ps_state: power save is disabled or enabled, see enum nrf_wifi_ps_state.
+ * @brief This structure represents the information regarding the power save state.
  *
- * This structure represents the information about power save state
  */
 
 struct nrf_wifi_umac_set_power_save_info {
+	/** power save is disabled or enabled, see enum nrf_wifi_ps_state */
 	signed int ps_state;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_cmd_set_power_save - Set power save enable or disbale.
- * @umac_hdr: UMAC command header. Refer &struct nrf_wifi_umac_hdr.
- * @info: Power save parameters settings.
+ * @brief This structure represents the command used to enable or disable the power save
+ *  functionality.
  *
- * This structure represents the command to enable or disable the power
- * save functionality.
  */
 
 struct nrf_wifi_umac_cmd_set_power_save {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Power save setting parameters.
+	 * @ref nrf_wifi_umac_set_power_save_info
+	 */
 	struct nrf_wifi_umac_set_power_save_info info;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_cmd_set_power_save_timeout - Set power save timeout.
- * @umac_hdr: UMAC command header. Refer &struct nrf_wifi_umac_hdr.
- * @timeout: Timeout value in milli seconds.
- *     if timeout < 0 RPU will set timeout to 100ms.
+ * @brief This structure represents the command to configure power save timeout value.
  *
- * This structure represents the command to configure power save timeout value.
  */
 
 struct nrf_wifi_umac_cmd_set_power_save_timeout {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Timeout value in milli seconds
+	 * if timeout < 0 RPU will set timeout to 100ms
+	 */
 	signed int timeout;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_qos_map_info - qos map info.
- * @qos_map_info_len: length of qos_map info field.
- * @qos_map_info: contains qos_map info as received from stack.
+ * @brief This structure represents the information of qos_map.
  *
- * This structure represents the information of qos_map.
  */
 
 struct nrf_wifi_umac_qos_map_info {
+	/** length of qos_map info field */
 	unsigned int qos_map_info_len;
+	/** contains qos_map info as received from stack */
 	unsigned char qos_map_info[256];
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_cmd_set_qos_map - Set qos map info.
- * @umac_hdr: UMAC command header. Refer &struct nrf_wifi_umac_hdr.
- * @info: qos map info.
+ * @brief This structure represents the information related to the Quality of Service (QoS) map.
  *
- * This structure represents the command to pass qos_map info.
  */
 
 struct nrf_wifi_umac_cmd_set_qos_map {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** qos map info. @ref nrf_wifi_umac_qos_map_info */
 	struct nrf_wifi_umac_qos_map_info info;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_cmd_get_tx_power - get tx power.
- * @umac_hdr: UMAC command header. Refer &struct nrf_wifi_umac_hdr.
+ * @brief This structure defines the command used to retrieve the transmit power information.
  *
- * This structure represents the command to get tx power.
  */
 
 struct nrf_wifi_umac_cmd_get_tx_power {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
 } __NRF_WIFI_PKD;
+
 /**
- * @brief This structure represents the command to get regulatory domain.
+ * @brief This structure defines the command used to obtain the regulatory domain information.
  *
  */
 
@@ -2478,14 +2315,14 @@ struct nrf_wifi_umac_cmd_get_reg {
 	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
 } __NRF_WIFI_PKD;
+
 /**
- * struct nrf_wifi_umac_cmd_get_channel - get channel info.
- * @umac_hdr: UMAC command header. Refer &struct nrf_wifi_umac_hdr.
+ * @brief This structure defines the command used to retrieve channel information.
  *
- * This structure represents the command to get channel information.
  */
 
 struct nrf_wifi_umac_cmd_get_channel {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
 } __NRF_WIFI_PKD;
 
@@ -2493,30 +2330,30 @@ struct nrf_wifi_umac_cmd_get_channel {
 #define NRF_WIFI_TWT_NEGOTIATION_TYPE_BROADCAST 2
 
 /**
- * enum nrf_wifi_twt_setup_cmd_type - TWT Setup command/Response type.
- * @NRF_WIFI_REQUEST_TWT:STA requests to join a TWT without specifying a target wake time.
- * @NRF_WIFI_SUGGEST_TWT:STA requests to join a TWT with specifying a target wake time and other
- *		params, these values can change during negotiation.
- * @NRF_WIFI_DEMAND_TWT:requests to join a TWT with demanded a target wake time and other params.
- *		STA rejects if AP not scheduling those params.
- * @NRF_WIFI_GROUPING_TWT:Response to the STA request(suggest/demand), these are may be different
- *		params.
- * @NRF_WIFI_ACCEPT_TWT: AP accept the STA requested params.
- * @NRF_WIFI_ALTERNATE_TWT:AP may suggest the params, these may be different from STA requested.
- * @NRF_WIFI_DICTATE_TWT:AP may suggest the params, these may be different from STA requested.
- * @NRF_WIFI_REJECT_TWT: AP may reject the STA requested params.
+ * @brief TWT setup commands and events.
  *
- * Types of TWT setup command/events.
  */
 
 enum nrf_wifi_twt_setup_cmd_type {
+	/** STA requests to join a TWT without specifying a target wake time */
 	NRF_WIFI_REQUEST_TWT,
+	/** STA requests to join a TWT with specifying a target wake time and
+	 *  other params, these values can change during negotiation.
+	 */
 	NRF_WIFI_SUGGEST_TWT,
+	/** requests to join a TWT with demanded a target wake time
+	 * and other params. STA rejects if AP not scheduling those params.
+	 */
 	NRF_WIFI_DEMAND_TWT,
+	/** Response to the STA request(suggest/demand), these may be different params */
 	NRF_WIFI_GROUPING_TWT,
+	/** AP accept the STA requested params */
 	NRF_WIFI_ACCEPT_TWT,
+	/** AP may suggest the params, these may be different from STA requested */
 	NRF_WIFI_ALTERNATE_TWT,
+	/** AP may suggest the params, these may be different from STA requested */
 	NRF_WIFI_DICTATE_TWT,
+	/** AP may reject the STA requested params */
 	NRF_WIFI_REJECT_TWT,
 };
 
@@ -2525,50 +2362,55 @@ enum nrf_wifi_twt_setup_cmd_type {
 
 #define NRF_WIFI_TWT_RESP_RECEIVED 0
 #define NRF_WIFI_TWT_RESP_NOT_RECEIVED 1
+
 /**
- * struct nrf_wifi_umac_config_twt_info - TWT params info.
- * @twt_flow_id: TWT flow Id.
- * @neg_type:NRF_WIFI_TWT_NEGOTIATION_TYPE_INDIVIDUAL/NRF_WIFI_TWT_NEGOTIATION_TYPE_BROADAST
- * @setup_cmd: see enum nrf_wifi_twt_setup_cmd_type
- * @ap_trigger_frame: indicating AP to initiate a trigger frame(ps_poll/Null) before data transfer
- * @is_implicit:1->implicit(same negotiated values to be used), 0->AP sends new calculated TWT
- *	values for every service period.
- * @twt_flow_type: Whether STA has to send the PS-Poll/Null frame
- *		indicating that it's in wake period(NRF_WIFI_TWT_FLOW_TYPE_ANNOUNCED)
- * @twt_target_wake_interval_exponent: wake interval exponent value
- * @twt_target_wake_interval_mantissa: wake interval mantissa value
- * @target_wake_time: start of the waketime value after successful TWT negotiation
- * @nominal_min_twt_wake_duration: min TWT wake duration
- * @dialog_token: dialog_token of twt frame.
- * @twt_resp_status: 0->not received 1->received.
- * This structure represents the command provides TWT information.
+ * @brief This structure describes the TWT information.
+ *
  */
 
 struct nrf_wifi_umac_config_twt_info {
+	/** TWT flow Id */
 	unsigned char twt_flow_id;
+	/** Negotiation type
+	 *  NRF_WIFI_TWT_NEGOTIATION_TYPE_INDIVIDUAL or
+	 *  NRF_WIFI_TWT_NEGOTIATION_TYPE_BROADAST
+	 */
 	unsigned char neg_type;
+	/** see &enum nrf_wifi_twt_setup_cmd_type  */
 	signed int setup_cmd;
+	/** indicating AP to initiate a trigger frame (ps_poll/Null) before data transfer */
 	unsigned char ap_trigger_frame;
+	/** 1->implicit(same negotiated values to be used),
+	 *  0->AP sends new calculated TWT values for every service period.
+	 */
 	unsigned char is_implicit;
+	/** Whether STA has to send the PS-Poll/Null frame
+	 *  indicating that it's in wake period(NRF_WIFI_TWT_FLOW_TYPE_ANNOUNCED)
+	 */
 	unsigned char twt_flow_type;
+	/** wake interval exponent value  */
 	unsigned char twt_target_wake_interval_exponent;
+	/** wake interval mantissa value */
 	unsigned short twt_target_wake_interval_mantissa;
-	/*unsigned char target_wake_time[8];*/
+	/** start of the waketime value after successful TWT negotiation */
 	unsigned long long target_wake_time;
+	/** min TWT wake duration */
 	unsigned int nominal_min_twt_wake_duration;
+	/** dialog_token of twt frame */
 	unsigned char dialog_token;
+	/** 0->not received 1->received */
 	unsigned char twt_resp_status;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_cmd_config_twt - configuring TWT params.
- * @umac_hdr: UMAC command header. Refer &struct nrf_wifi_umac_hdr.
- * @info: refer to struct nrf_wifi_umac_config_twt_info.
- * This structure represents the command provides TWT information.
+ * @brief This structure defines the parameters required for setting up TWT session.
+ *
  */
 
 struct nrf_wifi_umac_cmd_config_twt {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** TWT configuration info @ref nrf_wifi_umac_config_twt_info */
 	struct nrf_wifi_umac_config_twt_info info;
 } __NRF_WIFI_PKD;
 
@@ -2576,92 +2418,102 @@ struct nrf_wifi_umac_cmd_config_twt {
 #define TRIGGER_NOT_RECEIVED 2
 
 /**
- * struct nrf_wifi_umac_teardown_twt_info - delete TWT params info.
- * @twt_flow_id: TWT flow Id.
- * @reason_code: reason for teardown.
- * This structure represents the command provides TWT delete information.
+ * @brief This structure represents the TWT delete information.
+ *
  */
 
 struct nrf_wifi_umac_teardown_twt_info {
+	/** TWT flow Id  */
 	unsigned char twt_flow_id;
+	/** reason for teardown */
 	unsigned char reason_code;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_cmd_del_twt - delete TWT establishment.
- * @umac_hdr: UMAC command header. Refer &struct nrf_wifi_umac_hdr.
- * @info: refer to struct nrf_wifi_umac_teardown_twt_info.
- * This structure represents the command provides TWT delete establishment.
+ * @brief This structure defines the command used to delete or remove a TWT session
+ *
  */
 
 struct nrf_wifi_umac_cmd_teardown_twt {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** @ref nrf_wifi_umac_teardown_twt_info */
 	struct nrf_wifi_umac_teardown_twt_info info;
 } __NRF_WIFI_PKD;
 
 #define TWT_BLOCK_TX 0
 #define TWT_UNBLOCK_TX 1
 /**
- * struct twt_sleep_info- TWT sleep information
- * @type: value for blocking/unblocking TX
- * @info: refer to struct twt_sleep_info
+ * @brief This structure represents the information related to Tx (transmit) block/unblock.
+ *
  */
 struct twt_sleep_info {
+	/** value for blocking/unblocking TX
+	 *  (TWT_BLOCK_TX or TWT_UNBLOCK_TX)
+	 */
 	unsigned int type;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_event_twt_sleep- TWT sleep information
- * @umac_hdr: UMAC command header. Refer &struct nrf_wifi_umac_hdr.
- * @info: refer to struct twt_sleep_info
+ * @brief This structure defines an event used to indicate to the host whether to block or
+ *  unblock Tx (transmit) packets in TWT communication.
+ *
  */
 
 struct nrf_wifi_umac_event_twt_sleep {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** @ref twt_sleep_info */
 	struct twt_sleep_info info;
 } __NRF_WIFI_PKD;
 
 #define UAPSD_Q_MIN 0
 #define UAPSD_Q_MAX 15
 /**
- * struct nrf_wifi_umac_uapsd_info - uaspd queues info
- * @uapsd_queue: UAPSD-Q value
- * This structure represents the information about UAPSD-Q.
+ * @brief This structure represents the information about UAPSD queues.
+ *
  */
 
 struct nrf_wifi_umac_uapsd_info {
+	/** UAPSD-Q value */
 	unsigned int uapsd_queue;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_cmd_config_uapsd - Config UAPSD-Q..
- * @umac_hdr: UMAC command header. Refer &struct nrf_wifi_umac_hdr.
- * @info: Refer &struct nrf_wifi_umac_uapsd_info
- * This structure represents the command to configure UAPSD-Q value.
+ * @brief This structure defines the command used to configure the UAPSD-Q value.
+ *
  */
 
 struct nrf_wifi_umac_cmd_config_uapsd {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** @ref nrf_wifi_umac_uapsd_info */
 	struct nrf_wifi_umac_uapsd_info info;
 } __NRF_WIFI_PKD;
 
 /**
- * struct nrf_wifi_umac_event_trigger_scan - Scan complete event
- * @umac_hdr: UMAC event header. Refer &struct nrf_wifi_umac_hdr.
- * @valid_fields: Indicate which of the following parameters are valid.
+ * @brief This structure represents the event used to indicate that a scan has started.
  *
- * This structure represents the event to indicate a scan complete and includes
- * the scan complete information.
  */
 
 struct nrf_wifi_umac_event_trigger_scan {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Indicate which of the following parameters are valid */
 	unsigned int valid_fields;
+	/** Scan request control flags (u32). Bit values
+	 * (NRF_WIFI_SCAN_FLAG_LOW_PRIORITY/NRF_WIFI_SCAN_FLAG_RANDOM_ADDR...)
+	 */
 	unsigned int nrf_wifi_scan_flags;
+	/** No.of ssids in scan request */
 	unsigned char num_scan_ssid;
+	/** No.of frequencies in scan request */
 	unsigned char num_scan_frequencies;
+	/** center frequencies */
 	unsigned short scan_frequencies[NRF_WIFI_SCAN_MAX_NUM_FREQUENCIES];
+	/** @ref nrf_wifi_ssid */
 	struct nrf_wifi_ssid scan_ssid[NRF_WIFI_SCAN_MAX_NUM_SSIDS];
+	/** @ref nrf_wifi_ie */
 	struct nrf_wifi_ie ie;
 } __NRF_WIFI_PKD;
 
@@ -2678,87 +2530,53 @@ struct nrf_wifi_umac_event_trigger_scan {
 #define NRF_WIFI_NEW_SCAN_RESULTS_BSS_PRESP_DATA (1 << 0)
 
 /**
- * struct nrf_wifi_umac_event_new_scan_results - Scan result
- * @umac_hdr: UMAC event header. Refer &struct nrf_wifi_umac_hdr.
- * @valid_fields: Indicate which of the following parameters are valid.
- * @generation: Used to indicate consistent snapshots for
- *	dumps. This number increases whenever the object list being
- *	dumped changes, and as such userspace can verify that it has
- *	obtained a complete and consistent snapshot by verifying that
- *	all dump messages contain the same generation number. If it
- *	changed then the list changed and the dump should be repeated
- *	completely from scratch.
- * @mac_addr: BSSID of the BSS (6 octets).
- * @ies_tsf: TSF of the received probe response/beacon (u64)
- *	(if @NRF_WIFI_BSS_PRESP_DATA is present then this is known to be
- *	from a probe response, otherwise it may be from the same beacon
- *	that the NRF_WIFI_BSS_BEACON_TSF will be from).
- * @ies: Binary attribute containing the
- *	raw information elements from the probe response/beacon (bin);
- *	if the %NRF_WIFI_BSS_BEACON_IES attribute is present and the data is
- *	different then the IEs here are from a Probe Response frame; otherwise
- *	they are from a Beacon frame.
- *	However, if the driver does not indicate the source of the IEs, these
- *	IEs may be from either frame subtype.
- *	If present, the @NRF_WIFI_BSS_PRESP_DATA attribute indicates that the
- *	data here is known to be from a probe response, without any heuristics.
- * @beacon_ies_tsf: TSF of the last received beacon
- *	(not present if no beacon frame has been received yet).
- * @beacon_ies: Binary attribute containing the raw information
- *	elements from a Beacon frame (bin); not present if no Beacon frame has
- *	yet been received.
- * @beacon_interval: Beacon interval of the (I)BSS.
- * @capability: Capability field (CPU order).
- * @frequency: Frequency in MHz.
- * @chan_width: Channel width of the control channel.
- * @seen_ms_ago: Age of this BSS entry in ms.
- * @signal: If MBMsignal strength of probe response/beacon
- *	in mBm (100 * dBm) (s32) or signal strength of the probe
- *	response/beacon in unspecified units, scaled to 0..100
- * @status: Status, if this BSS is "used".
+ * @brief This structure serves as a response to the command NRF_WIFI_UMAC_CMD_GET_SCAN_RESULTS.
+ *  It contains scan results for each entry. RPU sends multiple events of this type for every
+ *  scan entry, and when umac_hdr->seq == 0, it indicates the last scan entry.
  *
- * This structure is returned as a response for %NRF_WIFI_UMAC_CMD_GET_SCAN_RESULTS. It
- * contains a scan result entry.
  */
 
 struct nrf_wifi_umac_event_new_scan_results {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Indicate which of the following parameters are valid */
 	unsigned int valid_fields;
+	/** Unused */
 	unsigned int generation;
+	/** Frequency in MHz */
 	unsigned int frequency;
+	/** Channel width of the control channel */
 	unsigned int chan_width;
+	/** Age of this BSS entry in ms */
 	unsigned int seen_ms_ago;
+	/** Unused */
 	unsigned int nrf_wifi_flags;
+	/** Status, if this BSS is "used" */
 	signed int status;
+	/** TSF of the received probe response/beacon (u64) */
 	unsigned long long ies_tsf;
+	/** TSF of the last received beacon
+	 *  (not present if no beacon frame has been received yet).
+	 */
 	unsigned long long beacon_ies_tsf;
+	/** Beacon interval of BSS */
 	unsigned short beacon_interval;
+	/** Capability field */
 	unsigned short capability;
+	/** Signal strength, @ref nrf_wifi_signal */
 	struct nrf_wifi_signal signal;
+	/** BSSID of the BSS (6 octets) */
 	unsigned char mac_addr[NRF_WIFI_ETH_ADDR_LEN];
-	unsigned int    ies_len;
-	unsigned int    beacon_ies_len;
-	unsigned char   ies[0];
+	/** Indicates length of IE's present at the starting of ies[0] */
+	unsigned int ies_len;
+	/** Indicates length of beacon_ies present after ies+ies_len */
+	unsigned int beacon_ies_len;
+	/** contains raw information elements from the probe response/beacon.
+	 * If beacon_ies are not present then the IEs here are from a Probe Response
+	 * frame; otherwise they are from a Beacon frame.
+	 */
+	unsigned char ies[0];
 } __NRF_WIFI_PKD;
-
-/**
- * struct nrf_wifi_umac_event_new_scan_display_results - Scan result for dispaly purpose
- * @umac_hdr: UMAC event header. Refer &struct nrf_wifi_umac_hdr.
- * @ssid: Network SSID.
- * @mac_addr: BSSID of the BSS (6 octets).
- * @nwk_band: Network band of operation, refer &enum nrf_wifi_band.
- * @nwk_channel: Network channel number.
- * @protocol: Network protocol, refer #defines NRF_WIFI_802_11*.
- * @security_type: Network security mode, refer &enum nrf_wifi_security_type.
- * @beacon_interval: Beacon interval of the (I)BSS.
- * @capability: Capability field (CPU order).
- * @signal: If MBMsignal strength of probe response/beacon
- *	in mBm (100 * dBm) (s32) or signal strength of the probe
- *	response/beacon in unspecified units, scaled to 0..100
- *
- * This structure is returned as a response for %NRF_WIFI_UMAC_CMD_GET_SCAN_RESULTS. It
- * contains a scan result entry.
- */
 
 #define NRF_WIFI_802_11A (1 << 0)
 #define NRF_WIFI_802_11B (1 << 1)
@@ -2769,31 +2587,57 @@ struct nrf_wifi_umac_event_new_scan_results {
 
 #define NRF_WIFI_MFP_REQUIRED (1 << 0)
 #define NRF_WIFI_MFP_CAPABLE  (1 << 1)
+/**
+ * @brief This structure represents the response for NRF_WIFI_UMAC_CMD_GET_SCAN_RESULTS.
+ *  It contains the displayed scan result.
+ *
+ */
 
 struct umac_display_results {
+	/** Network SSID @ref nrf_wifi_ssid */
 	struct nrf_wifi_ssid ssid;
+	/** BSSID of the BSS (6 octets) */
 	unsigned char mac_addr[NRF_WIFI_ETH_ADDR_LEN];
+	/** Network band of operation, refer &enum nrf_wifi_band */
 	signed int nwk_band;
+	/** Network channel number */
 	unsigned int nwk_channel;
+	/**  Protocol type (NRF_WIFI_802_11A) */
 	unsigned char protocol_flags;
+	/** Network security mode, refer &enum nrf_wifi_security_type */
 	signed int security_type;
+	/** Beacon interval of the BSS */
 	unsigned short beacon_interval;
+	/** Capability field */
 	unsigned short capability;
+	/** Signal strength. Refer &struct nrf_wifi_signal */
 	struct nrf_wifi_signal signal;
+	/** TWT support */
 	unsigned char twt_support;
+	/** management frame protection NRF_WIFI_MFP_REQUIRED/NRF_WIFI_MFP_CAPABLE */
 	unsigned char mfp_flag;
+	/** reserved */
 	unsigned char reserved3;
+	/** reserved */
 	unsigned char reserved4;
 } __NRF_WIFI_PKD;
 
 #define DISPLAY_BSS_TOHOST_PEREVNT 8
 
+/**
+ * @brief This structure serves as a response to the command NRF_WIFI_UMAC_CMD_GET_SCAN_RESULTS
+ *  of display scan type. It contains a maximum of DISPLAY_BSS_TOHOST_PEREVENT scan results
+ *  in each event. When umac_hdr->seq == 0, it indicates the last scan event.
+ *
+ */
+
 struct nrf_wifi_umac_event_new_scan_display_results {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
-	/*Number of scan results in the current event*/
+	/** Number of scan results in the current event */
 	unsigned char event_bss_count;
+	/** Display scan results info @ref umac_display_results */
 	struct umac_display_results display_results[DISPLAY_BSS_TOHOST_PEREVNT];
-	/* struct umac_display_results display_results[10]; */
 } __NRF_WIFI_PKD;
 
 #define NRF_WIFI_EVENT_MLME_FRAME_VALID (1 << 0)
@@ -2804,70 +2648,64 @@ struct nrf_wifi_umac_event_new_scan_display_results {
 #define NRF_WIFI_EVENT_MLME_WME_UAPSD_QUEUES_VALID (1 << 5)
 #define NRF_WIFI_EVENT_MLME_RXMGMT_FLAGS_VALID (1 << 6)
 #define NRF_WIFI_EVENT_MLME_IE_VALID   (1 << 7)
+
 #define NRF_WIFI_EVENT_MLME_TIMED_OUT (1 << 0)
 #define NRF_WIFI_EVENT_MLME_ACK (1 << 1)
 
 /**
- * struct nrf_wifi_umac_event_mlme - MLME event
- *
- * @umac_hdr: UMAC event header. Refer &struct nrf_wifi_umac_hdr.
- * @valid_fields: Indicate which of the following parameters are valid
- * @frame: Frame data (binary attribute), including frame header
- *	and body, but not FCS; used, e.g., with NRF_WIFI_UMAC_CMD_AUTHENTICATE and
- *	%NRF_WIFI_UMAC_CMD_ASSOCIATE events.
- * @mac_addr: BSSID of the BSS (6 octets)
- * @frequency: Frequency of the selected channel in MHz
- * @cookie: Generic 64-bit cookie to identify objects.
- * @rx_signal_dbm: Signal strength in dBm (as a 32-bit int);
- *	this attribute is (depending on the driver capabilities) added to
- *	received frames indicated with %NRF_WIFI_CMD_FRAME.
- * @wme_uapsd_queues: Bitmap of uapsd queues.
- * @nrf_wifi_flags: Indicate whether the frame was acked or timed out.
- *
- * This structure represents different STA MLME events for e.g. Authentication
- * Response received, Association Response received etc.
+ * @brief This structure represent different responses received from the access point during
+ *  various stages of the connection process like Authentication Response and Association Response.
  *
  */
 
 struct nrf_wifi_umac_event_mlme {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Indicate which of the following parameters are valid */
 	unsigned int valid_fields;
+	/** Frequency of the channel in MHz */
 	unsigned int frequency;
+	/** Signal strength in dBm */
 	unsigned int rx_signal_dbm;
+	/** Indicate whether the frame was acked or timed out */
 	unsigned int nrf_wifi_flags;
+	/** cookie identifier */
 	unsigned long long cookie;
+	/** Frame data, including frame header and body @ref nrf_wifi_frame */
 	struct nrf_wifi_frame frame;
+	/** BSSID of the BSS */
 	unsigned char mac_addr[NRF_WIFI_ETH_ADDR_LEN];
+	/** Bitmap of uapsd queues */
 	unsigned char wme_uapsd_queues;
+	/** Request(AUTH/ASSOC) ie length */
 	unsigned int req_ie_len;
+	/** ie's */
 	unsigned char req_ie[0];
 } __NRF_WIFI_PKD;
 
 #define NRF_WIFI_CMD_SEND_STATION_ASSOC_REQ_IES_VALID (1 << 0)
 
 /**
- * struct nrf_wifi_umac_event_new_station - Station add event.
- * @umac_hdr: UMAC event header. Refer &struct nrf_wifi_umac_hdr.
- * @valid_fields: Indicate if assoc_req ies is valid.
- * @is_sta_legacy: Set to 1 if STA is Legacy(a/b/g)
- * @wme: set to 1: STA supports QoS/WME
- * @mac_addr: Station mac address.
- * @generation: generation number
- * @sta_info: Station information.
- * @assoc_req_ies: Ies passed by station doing assoc request.
+ * @brief This structure represents an event that is generated when a station is added or removed.
  *
- * This structure represents an event which is generated when a station is
- * added or deleted.
  */
 
 struct nrf_wifi_umac_event_new_station {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Indicate if assoc_req ies is valid */
 	unsigned int valid_fields;
+	/** set to 1: STA supports QoS/WME */
 	unsigned char wme;
+	/** Set to 1 if STA is Legacy(a/b/g) */
 	unsigned char is_sta_legacy;
+	/** Station mac address */
 	unsigned char mac_addr[NRF_WIFI_ETH_ADDR_LEN];
+	/** generation number */
 	unsigned int generation;
+	/** Station information @ref nrf_wifi_sta_info */
 	struct nrf_wifi_sta_info sta_info;
+	/** @ref nrf_wifi_ie */
 	struct nrf_wifi_ie assoc_req_ies;
 
 } __NRF_WIFI_PKD;
@@ -2876,131 +2714,132 @@ struct nrf_wifi_umac_event_new_station {
 #define NRF_WIFI_CMD_COOKIE_RSP_MAC_ADDR_VALID (1 << 1)
 
 /**
- * struct	nrf_wifi_umac_event_cookie_rsp - Cookie for management frame.
- * @umac_hdr: UMAC event header. Refer &struct nrf_wifi_umac_hdr.
- * @valid_fields: Indicate if assoc_req ies is valid.
- * @host_cookie: Identifier passed during %NRF_WIFI_UMAC_CMD_FRAME.
- * @cookie: Cookie used to indicate TX done in %NRF_WIFI_UMAC_EVENT_FRAME_TX_STATUS
+ * @brief This structure specifies the cookie response event, which is used to receive an
+ *  RPU cookie associated with the host cookie passed during NRF_WIFI_UMAC_CMD_FRAME.
  *
- * We receive an RPU cookie that is associated with the host cookie
- * passed during NRF_WIFI_UMAC_CMD_FRAME
  */
 
 struct nrf_wifi_umac_event_cookie_rsp {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Indicate if assoc_req ies is valid */
 	unsigned int valid_fields;
+	/** Identifier passed during NRF_WIFI_UMAC_CMD_FRAME */
 	unsigned long long host_cookie;
+	/** Cookie used to indicate TX done in NRF_WIFI_UMAC_EVENT_FRAME_TX_STATUS */
 	unsigned long long cookie;
+	/** Mac address */
 	unsigned char mac_addr[NRF_WIFI_ETH_ADDR_LEN];
 
 } __NRF_WIFI_PKD;
 
 /**
- * struct	nrf_wifi_umac_event_get_txpwr - Tx power.
- * @umac_hdr: UMAC event header. Refer &struct nrf_wifi_umac_hdr.
- * @txpwr_level: Tx power level
+ * @brief This structure represents the event that corresponds to the command
+ *  NRF_WIFI_UMAC_CMD_GET_TX_POWER. It is used to retrieve the transmit power
+ *  information from the device
  *
- * Tx power information in dbm
  */
 
 struct nrf_wifi_umac_event_get_tx_power {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Tx power in dbm */
 	signed int txpwr_level;
 
 } __NRF_WIFI_PKD;
 
 /**
- * struct	nrf_wifi_umac_event_set_interface - set interface status.
- * @umac_hdr: UMAC event header. Refer &struct nrf_wifi_umac_hdr.
- * @return_value: return value
+ * @brief This structure represents the response to the command NRF_WIFI_UMAC_CMD_SET_INTERFACE.
+ *  It contains the necessary information indicating the result or status of the interface
+ *  configuration operation after the command has been executed.
  *
- * NRF_WIFI_UMAC_CMD_SET_INTERFACE status
  */
 
 struct nrf_wifi_umac_event_set_interface {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** return value */
 	signed int return_value;
 } __NRF_WIFI_PKD;
 
 /**
- * enum nrf_wifi_channel_flags - channel flags
+ * @brief channel flags.
  *
  * Channel flags set by the regulatory control code.
- *
- * @CHAN_DISABLED: This channel is disabled.
- * @CHAN_NO_IR: do not initiate radiation, this includes
- * sending probe requests or beaconing.
- * @CHAN_RADAR: Radar detection is required on this channel.
- * @CHAN_NO_HT40PLUS: extension channel above this channel
- *	is not permitted.
- * @CHAN_NO_HT40MINUS: extension channel below this channel
- *	is not permitted.
- * @CHAN_NO_OFDM: OFDM is not allowed on this channel.
- * @CHAN_NO_80MHZ: If the driver supports 80 MHz on the band,
- *	this flag indicates that an 80 MHz channel cannot use this
- *	channel as the control or any of the secondary channels.
- *	This may be due to the driver or due to regulatory bandwidth
- *	restrictions.
- * @CHAN_NO_160MHZ: If the driver supports 160 MHz on the band,
- *	this flag indicates that an 160 MHz channel cannot use this
- *	channel as the control or any of the secondary channels.
- *	This may be due to the driver or due to regulatory bandwidth
- *	restrictions.
- * @CHAN_INDOOR_ONLY: see %NL80211_FREQUENCY_ATTR_INDOOR_ONLY
- * @CHAN_GO_CONCURRENT: see %NL80211_FREQUENCY_ATTR_GO_CONCURRENT
- * @CHAN_NO_20MHZ: 20 MHz bandwidth is not permitted
- *	on this channel.
- * @CHAN_NO_10MHZ: 10 MHz bandwidth is not permitted
- *	on this channel.
  *
  */
 
 enum nrf_wifi_channel_flags {
+	/** This channel is disabled */
 	CHAN_DISABLED     = 1<<0,
+	/** do not initiate radiation, this includes sending probe requests or beaconing */
 	CHAN_NO_IR        = 1<<1,
-	/* hole at 1<<2 */
+	/** Radar detection is required on this channel hole at 1<<2 */
 	CHAN_RADAR        = 1<<3,
+	/** extension channel above this channel is not permitted */
 	CHAN_NO_HT40PLUS  = 1<<4,
+	/** extension channel below this channel is not permitted */
 	CHAN_NO_HT40MINUS = 1<<5,
+	/** OFDM is not allowed on this channel */
 	CHAN_NO_OFDM      = 1<<6,
+	/** If the driver supports 80 MHz on the band,
+	 * this flag indicates that an 80 MHz channel cannot use this
+	 * channel as the control or any of the secondary channels.
+	 * This may be due to the driver or due to regulatory bandwidth
+	 * restrictions.
+	 */
 	CHAN_NO_80MHZ     = 1<<7,
+	/** If the driver supports 160 MHz on the band,
+	 * this flag indicates that an 160 MHz channel cannot use this
+	 * channel as the control or any of the secondary channels.
+	 * This may be due to the driver or due to regulatory bandwidth
+	 * restrictions.
+	 */
 	CHAN_NO_160MHZ    = 1<<8,
+	/** @ref NL80211_FREQUENCY_ATTR_INDOOR_ONLY */
 	CHAN_INDOOR_ONLY  = 1<<9,
+	/** @ref NL80211_FREQUENCY_ATTR_GO_CONCURRENT */
 	CHAN_GO_CONCURRENT    = 1<<10,
+	/** 20 MHz bandwidth is not permitted on this channel */
 	CHAN_NO_20MHZ     = 1<<11,
+	/** 10 MHz bandwidth is not permitted on this channel */
 	CHAN_NO_10MHZ     = 1<<12,
 };
 
 /**
- * struct nrf_wifi_chan_def - channel definition
- * @chan: the (control) channel
- * @width: channel width
- * @center_frequency1: center frequency of first segment
- * @center_frequency2: center frequency of second segment
- * (only with 80+80 MHz)
+ * @brief channel definition.
+ *
  */
 
 struct nrf_wifi_chan_definition {
+	/** Frequency of the selected channel in MHz */
 	struct nrf_wifi_channel chan;
+	/** channel width */
 	signed int width;
+	/** center frequency of first segment */
 	unsigned int center_frequency1;
+	/** center frequency of second segment (only with 80+80 MHz) */
 	unsigned int center_frequency2;
 } __NRF_WIFI_PKD;
 
 /**
- * struct	nrf_wifi_umac_event_get_channel - Get channel info.
- * @umac_hdr: UMAC event header. Refer &struct nrf_wifi_umac_hdr.
- * @chan_def: Channel definition.
+ * @brief This structure represents channel information and serves as the event for the
+ *  command NRF_WIFI_UMAC_CMD_GET_CHANNEL.
  *
- * The structure gives Channel information.
  */
-
 struct nrf_wifi_umac_event_get_channel {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Channel information.@ref nrf_wifi_chan_definition */
 	struct nrf_wifi_chan_definition chan_def;
 } __NRF_WIFI_PKD;
 
+/**
+ * @brief This structure represents the command used to retrieve connection information.
+ *
+ */
 struct nrf_wifi_umac_cmd_conn_info {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
 } __NRF_WIFI_PKD;
 
@@ -3013,27 +2852,63 @@ enum link_mode {
 	NRF_WIFI_MODE_11AX
 };
 
+/**
+ * @brief This structure represents the information related to the connection of a station.
+ *
+ */
+
 struct nrf_wifi_umac_event_conn_info {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Beacon interval */
 	unsigned short beacon_interval;
+	/** DTIM interval */
 	unsigned char dtim_interval;
+	/** Station association state */
 	unsigned char associated;
+	/** TWT supported or not */
 	unsigned char twt_capable;
+	/** Refer &enum link_mode */
 	unsigned char linkmode;
 } __NRF_WIFI_PKD;
 
+
+/**
+ * @brief This structure defines the command used to retrieve power save information.
+ *
+ */
 struct nrf_wifi_umac_cmd_get_power_save_info {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
 } __NRF_WIFI_PKD;
 
+/**
+ * @brief This structure defines the command used to set the listen interval period.
+ *  It determines how frequently a device wakes up to check for any pending data or traffic
+ *  from the access point. By setting the listen interval, devices can adjust their power-saving
+ *  behavior to balance power efficiency and responsiveness to incoming data.
+ *
+ */
 struct nrf_wifi_umac_cmd_set_listen_interval {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** listen interval */
 	unsigned short listen_interval;
 } __NRF_WIFI_PKD;
 
+/**
+ * @brief This structure represents the command used to enable or disable extended power save mode.
+ *  When enabled, the RPU wakes up based on the listen interval, allowing the device to spend more
+ *  time in a lower power state. When disabled, the RPU wakes up based on the DTIM period, which
+ *  may require more frequent wake-ups but can provide better responsiveness for receiving
+ *  multicast/broadcast traffic.
+ *
+ */
 struct nrf_wifi_umac_cmd_config_extended_ps {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
-	unsigned char enable_extended_ps; /*1= enable 0=disable*/
+	/** 1=enable 0=disable */
+	unsigned char enable_extended_ps;
 } __NRF_WIFI_PKD;
 
 #define NRF_WIFI_MAX_TWT_FLOWS 8
@@ -3041,103 +2916,185 @@ struct nrf_wifi_umac_cmd_config_extended_ps {
 #define NRF_WIFI_PS_MODE_WMM 1
 
 /**
- * Most APs have a DTIM value of 3, so we are expecting
- * a minimum listen interval of 3 beacon intervals.
+ * @brief Given that most APs typically use a DTIM value of 3,
+ *  we anticipate a minimum listen interval of 3 beacon intervals.
+ *
  */
 #define NRF_WIFI_LISTEN_INTERVAL_MIN 3
 
+/**
+ * @brief This structure represents an event that provides information about the RPU power save
+ *  mode. It contains details regarding the current power save mode and its settings.
+ *
+ */
 struct nrf_wifi_umac_event_power_save_info {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Power save mode. NRF_WIFI_PS_MODE_LEGACY/NRF_WIFI_PS_MODE_WMM */
 	unsigned char ps_mode;
+	/** Power save enable flag */
 	unsigned char enabled;
-	unsigned char extended_ps; /*1= ONN 0=OFF*/
+	/** Extended power save ON(1)/OFF(0) */
+	unsigned char extended_ps;
+	/** Is TWT responder */
 	unsigned char twt_responder;
+	/** Power save timed out value */
 	signed int ps_timeout;
+	/** Listen interval value */
 	unsigned short listen_interval;
+	/** Number TWT flows */
 	unsigned char num_twt_flows;
+	/** TWT info of each flow @ref nrf_wifi_umac_config_twt_info */
 	struct nrf_wifi_umac_config_twt_info twt_flow_info[0];
 } __NRF_WIFI_PKD;
 
 #define NRF_WIFI_EVENT_TRIGGER_SCAN_IE_VALID (1 << 0)
 #define NRF_WIFI_EVENT_TRIGGER_SCAN_SCAN_FLAGS_VALID (1 << 1)
+/**
+ * @brief This structure contains information relevant to the "Remain on Channel" operation.
+ *  It is used to specify the details related to the duration and channel on which a device
+ *  needs to stay without regular data transmission or reception.
+ *
+ */
 
 struct remain_on_channel_info {
+	/** Amount of time to remain on specified channel */
 	unsigned int dur;
+	/** Frequency configuration, see &struct freq_params */
 	struct freq_params nrf_wifi_freq_params;
+	/** Identifier to be used for processing NRF_WIFI_UMAC_EVENT_COOKIE_RESP event */
 	unsigned long long host_cookie;
+	/** Unused */
 	unsigned long long cookie;
 
 } __NRF_WIFI_PKD;
 
 #define NRF_WIFI_CMD_ROC_FREQ_PARAMS_VALID (1 << 0)
 #define NRF_WIFI_CMD_ROC_DURATION_VALID (1 << 1)
+/**
+ * @brief This structure represents the command used to keep the device awake on the specified
+ *  channel for a designated period. The command initiates the "Remain on Channel" operation.
+ *
+ */
 
 struct nrf_wifi_umac_cmd_remain_on_channel {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Indicate which of the following parameters are valid */
 	unsigned int valid_fields;
+	/** Information about channel parameters.@ref remain_on_channel_info */
 	struct remain_on_channel_info info;
 
 } __NRF_WIFI_PKD;
 
 #define NRF_WIFI_CMD_CANCEL_ROC_COOKIE_VALID (1 << 0)
-
+/**
+ * @brief This structure represents the command to cancel "Remain on Channel" operation.
+ *
+ */
 struct nrf_wifi_umac_cmd_cancel_remain_on_channel {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Indicate which of the following parameters are valid */
 	unsigned int valid_fields;
+	/** cookie to identify remain on channel */
 	unsigned long long cookie;
-
 } __NRF_WIFI_PKD;
 
 #define NRF_WIFI_EVENT_ROC_FREQ_VALID (1 << 0)
 #define NRF_WIFI_EVENT_ROC_COOKIE_VALID (1 << 1)
 #define NRF_WIFI_EVENT_ROC_DURATION_VALID (1 << 2)
 #define NRF_WIFI_EVENT_ROC_CH_TYPE_VALID (1 << 3)
+/**
+ * @brief This structure represents the response to command "Remain on Channel".
+ *
+ */
 
 struct nrf_wifi_event_remain_on_channel {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Indicate which of the following parameters are valid */
 	unsigned int valid_fields;
+	/** Frequency of the channel */
 	unsigned int frequency;
+	/** duration that can be requested with the remain-on-channel operation(ms) */
 	unsigned int dur;
+	/** see &enum nrf_wifi_channel_type */
 	unsigned int ch_type;
+	/** cookie to identify remain on channel */
 	unsigned long long cookie;
-
 } __NRF_WIFI_PKD;
 
+/**
+ * @brief This structure defines the command used to retrieve interface information.
+ *
+ */
 struct nrf_wifi_cmd_get_interface {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
 } __NRF_WIFI_PKD;
 
-struct nrf_wifi_interface_info {
-	struct nrf_wifi_umac_hdr umac_hdr;
 #define NRF_WIFI_INTERFACE_INFO_CHAN_DEF_VALID (1 << 0)
 #define NRF_WIFI_INTERFACE_INFO_SSID_VALID (1 << 1)
 #define NRF_WIFI_INTERFACE_INFO_IFNAME_VALID (1 << 2)
+
+/**
+ * @brief This structure represents an event that contains information about a network interface.
+ *
+ */
+
+struct nrf_wifi_interface_info {
+	/** Header @ref nrf_wifi_umac_hdr */
+	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Indicate which of the following parameters are valid */
 	unsigned int valid_fields;
+	/** Interface type, see &enum nrf_wifi_iftype */
 	signed int nrf_wifi_iftype;
+	/** Interface name */
 	signed char ifacename[IFACENAMSIZ];
+	/** Mac address */
 	unsigned char nrf_wifi_eth_addr[NRF_WIFI_ETH_ADDR_LEN];
+	/** @ref nrf_wifi_chan_definition */
 	struct nrf_wifi_chan_definition chan_def;
+	/** @ref nrf_wifi_ssid */
 	struct nrf_wifi_ssid ssid;
 } __NRF_WIFI_PKD;
 
-struct nrf_wifi_event_mcs_info {
 #define NRF_WIFI_HT_MCS_MASK_LEN 10
 #define NRF_WIFI_HT_MCS_RES_LEN 3
+
+/**
+ * @brief MCS information.
+ *
+ */
+struct nrf_wifi_event_mcs_info {
+	/** Highest supported RX rate */
 	unsigned short nrf_wifi_rx_highest;
+	/** RX mask */
 	unsigned char nrf_wifi_rx_mask[NRF_WIFI_HT_MCS_MASK_LEN];
+	/** TX parameters */
 	unsigned char nrf_wifi_tx_params;
+	/** reserved */
 	unsigned char nrf_wifi_reserved[NRF_WIFI_HT_MCS_RES_LEN];
 } __NRF_WIFI_PKD;
 
+/**
+ * @brief This structure represents HT capability parameters.
+ *
+ */
 struct nrf_wifi_event_sta_ht_cap {
+	/** 1 indicates HT Supported */
 	signed int nrf_wifi_ht_supported;
+	/** HT capabilities, as in the HT information IE */
 	unsigned short nrf_wifi_cap;
+	/** MCS information. @ref nrf_wifi_event_mcs_info */
 	struct nrf_wifi_event_mcs_info mcs;
+	/** A-MPDU factor, as in 11n */
 	unsigned char nrf_wifi_ampdu_factor;
+	/** A-MPDU density, as in 11n */
 	unsigned char nrf_wifi_ampdu_density;
 } __NRF_WIFI_PKD;
 
-struct nrf_wifi_event_channel {
 #define NRF_WIFI_CHAN_FLAG_FREQUENCY_ATTR_NO_IR (1 << 0)
 #define NRF_WIFI_CHAN_FLAG_FREQUENCY_ATTR_NO_IBSS (1 << 1)
 #define NRF_WIFI_CHAN_FLAG_FREQUENCY_ATTR_RADAR (1 << 2)
@@ -3153,82 +3110,132 @@ struct nrf_wifi_event_channel {
 
 #define NRF_WIFI_CHAN_DFS_VALID (1 << 12)
 #define NRF_WIFI_CHAN_DFS_CAC_TIME_VALID (1 << 13)
+
+/**
+ * @brief This structure represents channel parameters.
+ */
+struct nrf_wifi_event_channel {
+	/** channel flags NRF_WIFI_CHAN_FLAG_FREQUENCY_ATTR_NO_IBSS */
 	unsigned short nrf_wifi_flags;
+	/** maximum transmission power (in dBm) */
 	signed int nrf_wifi_max_power;
+	/** DFS state time */
 	unsigned int nrf_wifi_time;
+	/** DFS CAC time in ms */
 	unsigned int dfs_cac_msec;
+	/** Channel parameters are valid or not 1=valid */
 	signed char ch_valid;
+	/** Channel center frequency */
 	unsigned short center_frequency;
+	/** Current dfs state */
 	signed char dfs_state;
 } __NRF_WIFI_PKD;
 
-struct nrf_wifi_event_rate {
 #define NRF_WIFI_EVENT_GET_WIPHY_FLAG_RATE_SHORT_PREAMBLE (1 << 0)
+/**
+ * @brief This structure represents rate information.
+ */
+struct nrf_wifi_event_rate {
+	/** NRF_WIFI_EVENT_GET_WIPHY_FLAG_RATE_SHORT_PREAMBLE */
 	unsigned short nrf_wifi_flags;
+	/** Bitrate in units of 100 kbps */
 	unsigned short nrf_wifi_bitrate;
 } __NRF_WIFI_PKD;
+/**
+ * @brief VHT MCS information.
+ *
+ */
 
 struct nrf_wifi_event_vht_mcs_info {
+	/** RX MCS map 2 bits for each stream, total 8 streams */
 	unsigned short rx_mcs_map;
+	/** Indicates highest long GI VHT PPDU data rate
+	 *  STA can receive. Rate expressed in units of 1 Mbps.
+	 *  If this field is 0 this value should not be used to
+	 *  consider the highest RX data rate supported.
+	 */
 	unsigned short rx_highest;
+	/** TX MCS map 2 bits for each stream, total 8 streams */
 	unsigned short tx_mcs_map;
+	/** Indicates highest long GI VHT PPDU data rate
+	 *  STA can transmit. Rate expressed in units of 1 Mbps.
+	 *  If this field is 0 this value should not be used to
+	 *  consider the highest TX data rate supported.
+	 */
 	unsigned short tx_highest;
 } __NRF_WIFI_PKD;
 
+/**
+ * @brief This structure represents VHT capability parameters.
+ *
+ */
 struct nrf_wifi_event_sta_vht_cap {
+	/** 1 indicates VHT Supported */
 	signed char nrf_wifi_vht_supported;
+	/** VHT capability info */
 	unsigned int nrf_wifi_cap;
+	/** Refer @ref nrf_wifi_event_vht_mcs_info */
 	struct nrf_wifi_event_vht_mcs_info vht_mcs;
 } __NRF_WIFI_PKD;
 
+/**
+ * @brief Frequency band information.
+ *
+ */
 struct nrf_wifi_event_supported_band {
+	/** No.of channels */
 	unsigned short nrf_wifi_n_channels;
+	/** No.of bitrates */
 	unsigned short nrf_wifi_n_bitrates;
+	/** Array of channels the hardware can operate in this band */
 	struct nrf_wifi_event_channel channels[29];
+	/** Array of bitrates the hardware can operate with in this band */
 	struct nrf_wifi_event_rate bitrates[13];
+	/** HT capabilities in this band */
 	struct nrf_wifi_event_sta_ht_cap ht_cap;
+	/** VHT capabilities in this band */
 	struct nrf_wifi_event_sta_vht_cap vht_cap;
+	/** the band this structure represents */
 	signed char band;
 } __NRF_WIFI_PKD;
 
+/**
+ * @brief Interface limits.
+ *
+ */
 struct nrf_wifi_event_iface_limit {
+	/** max interface limits */
 	unsigned short nrf_wifi_max;
+	/** types */
 	unsigned short nrf_wifi_types;
 } __NRF_WIFI_PKD;
 
-struct nrf_wifi_event_iface_combination {
-	unsigned int nrf_wifi_num_different_channels;
-	signed int beacon_int_infra_match;
-	struct nrf_wifi_event_iface_limit limits[2];
-	unsigned short nrf_wifi_max_interfaces;
-	unsigned char nrf_wifi_radar_detect_widths;
-	unsigned char nrf_wifi_n_limits;
-	unsigned char nrf_wifi_radar_detect_regions;
 
 #define NRF_WIFI_EVENT_GET_WIPHY_VALID_RADAR_DETECT_WIDTHS (1 << 0)
 #define NRF_WIFI_EVENT_GET_WIPHY_VALID_RADAR_DETECT_REGIONS (1 << 1)
 #define NRF_WIFI_EVENT_GET_WIPHY_VALID_ (1 << 2)
+/**
+ * @brief This structure defines an event that represents interface combinations.
+ *
+ */
+struct nrf_wifi_event_iface_combination {
+	/** channels count */
+	unsigned int nrf_wifi_num_different_channels;
+	/** Unused */
+	signed int beacon_int_infra_match;
+	/** @ref nrf_wifi_event_iface_limit */
+	struct nrf_wifi_event_iface_limit limits[2];
+	/** Max interfaces */
+	unsigned short nrf_wifi_max_interfaces;
+	/** Not used */
+	unsigned char nrf_wifi_radar_detect_widths;
+	/** Not used */
+	unsigned char nrf_wifi_n_limits;
+	/** Not used */
+	unsigned char nrf_wifi_radar_detect_regions;
+	/** Not used */
 	unsigned char comb_valid;
 } __NRF_WIFI_PKD;
-
-struct nrf_wifi_event_get_wiphy {
-	struct nrf_wifi_umac_hdr umac_hdr;
-
-	unsigned int nrf_wifi_frag_threshold;
-	unsigned int nrf_wifi_rts_threshold;
-	unsigned int nrf_wifi_available_antennas_tx;
-	unsigned int nrf_wifi_available_antennas_rx;
-	unsigned int nrf_wifi_probe_resp_offload;
-	unsigned int tx_ant;
-	unsigned int rx_ant;
-	unsigned int split_start2_flags;
-	unsigned int max_remain_on_channel_duration;
-	unsigned int ap_sme_capa;
-	unsigned int features;
-	unsigned int max_acl_mac_addresses;
-	unsigned int max_ap_assoc_sta;
-#define NRF_WIFI_EVENT_GET_WIPHY_MAX_CIPHER_COUNT 30
-	unsigned int cipher_suites[NRF_WIFI_EVENT_GET_WIPHY_MAX_CIPHER_COUNT];
 
 #define NRF_WIFI_EVENT_GET_WIPHY_IBSS_RSN (1 << 0)
 #define NRF_WIFI_EVENT_GET_WIPHY_MESH_AUTH (1 << 1)
@@ -3238,7 +3245,6 @@ struct nrf_wifi_event_get_wiphy {
 #define NRF_WIFI_EVENT_GET_WIPHY_TDLS_EXTERNAL_SETUP (1 << 5)
 #define NRF_WIFI_EVENT_GET_WIPHY_CONTROL_PORT_ETHERTYPE (1 << 6)
 #define NRF_WIFI_EVENT_GET_WIPHY_OFFCHANNEL_TX_OK (1 << 7)
-	unsigned int get_wiphy_flags;
 
 #define NRF_WIFI_GET_WIPHY_VALID_PROBE_RESP_OFFLOAD (1 << 0)
 #define NRF_WIFI_GET_WIPHY_VALID_TX_ANT (1 << 1)
@@ -3252,104 +3258,235 @@ struct nrf_wifi_event_get_wiphy {
 #define NRF_WIFI_GET_WIPHY_VALID_MAX_AP_ASSOC_STA (1 << 9)
 #define NRF_WIFI_GET_WIPHY_VALID_WIPHY_NAME (1 << 10)
 #define NRF_WIFI_GET_WIPHY_VALID_EXTENDED_FEATURES (1 << 11)
-	unsigned int params_valid;
 
-	unsigned short int max_scan_ie_len;
-	unsigned short int max_sched_scan_ie_len;
-	unsigned short int interface_modes;
-	struct nrf_wifi_event_iface_combination iface_com[6];
+#define NRF_WIFI_EVENT_GET_WIPHY_MAX_CIPHER_COUNT 30
 
-	signed char supp_commands[40];
-	unsigned char retry_short;
-	unsigned char retry_long;
-	unsigned char coverage_class;
-	unsigned char max_scan_ssids;
-	unsigned char max_sched_scan_ssids;
-	unsigned char max_match_sets;
-	unsigned char n_cipher_suites;
-	unsigned char max_num_pmkids;
-	unsigned char extended_capabilities_len;
-	unsigned char extended_capabilities[10];
-	unsigned char extended_capabilities_mask[10];
+#define NRF_WIFI_INDEX_IDS_WIPHY_NAME 32
+#define NRF_WIFI_EVENT_GET_WIPHY_NUM_BANDS 2
+
 #define EXTENDED_FEATURE_LEN 60
 #define DIV_ROUND_UP_NL(n, d) (((n) + (d)-1) / (d))
 
+/**
+ * @brief This structure represents wiphy parameters.
+ *
+ */
+struct nrf_wifi_event_get_wiphy {
+	/** Header @ref nrf_wifi_umac_hdr */
+	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Unused */
+	unsigned int nrf_wifi_frag_threshold;
+	/** RTS threshold value */
+	unsigned int nrf_wifi_rts_threshold;
+	/** Unused */
+	unsigned int nrf_wifi_available_antennas_tx;
+	/** Unused */
+	unsigned int nrf_wifi_available_antennas_rx;
+	/** Unused */
+	unsigned int nrf_wifi_probe_resp_offload;
+	/** Unused */
+	unsigned int tx_ant;
+	/** Unused */
+	unsigned int rx_ant;
+	/** Unused */
+	unsigned int split_start2_flags;
+	/** Maximum ROC duration */
+	unsigned int max_remain_on_channel_duration;
+	/** Unused */
+	unsigned int ap_sme_capa;
+	/** Unused */
+	unsigned int features;
+	/** Unused */
+	unsigned int max_acl_mac_addresses;
+	/** maximum number of associated stations supported in AP mode */
+	unsigned int max_ap_assoc_sta;
+	/** supported cipher suites */
+	unsigned int cipher_suites[NRF_WIFI_EVENT_GET_WIPHY_MAX_CIPHER_COUNT];
+	/** wiphy flags NRF_WIFI_EVENT_GET_WIPHY_AP_UAPSD */
+	unsigned int get_wiphy_flags;
+	/** valid parameters NRF_WIFI_GET_WIPHY_VALID_WIPHY_NAME */
+	unsigned int params_valid;
+	/** Maximum scan IE length */
+	unsigned short int max_scan_ie_len;
+	/** Unused */
+	unsigned short int max_sched_scan_ie_len;
+	/** bit mask of interface value of see &enum nrf_wifi_iftype */
+	unsigned short int interface_modes;
+	/** Unused */
+	struct nrf_wifi_event_iface_combination iface_com[6];
+	/** Unused */
+	signed char supp_commands[40];
+	/** Retry limit for short frames */
+	unsigned char retry_short;
+	/** Retry limit for long frames */
+	unsigned char retry_long;
+	/** Unused */
+	unsigned char coverage_class;
+	/** Maximum ssids supported in scan */
+	unsigned char max_scan_ssids;
+	/** Unused */
+	unsigned char max_sched_scan_ssids;
+	/** Unused */
+	unsigned char max_match_sets;
+	/** Unused */
+	unsigned char n_cipher_suites;
+	/** Unused */
+	unsigned char max_num_pmkids;
+	/** length of the extended capabilities */
+	unsigned char extended_capabilities_len;
+	/** Extended capabilities */
+	unsigned char extended_capabilities[10];
+	/** Extended capabilities mask */
+	unsigned char extended_capabilities_mask[10];
+	/** Unused */
 	unsigned char ext_features[DIV_ROUND_UP_NL(EXTENDED_FEATURE_LEN, 8)];
+	/** Unused */
 	unsigned char ext_features_len;
+	/** Unused */
 	signed char num_iface_com;
-#define NRF_WIFI_INDEX_IDS_WIPHY_NAME 32
+	/** Wiphy name */
 	signed char wiphy_name[NRF_WIFI_INDEX_IDS_WIPHY_NAME];
-
-#define NRF_WIFI_EVENT_GET_WIPHY_NUM_BANDS 2
+	/** Supported bands info. @ref nrf_wifi_event_supported_band */
 	struct nrf_wifi_event_supported_band sband[NRF_WIFI_EVENT_GET_WIPHY_NUM_BANDS];
 } __NRF_WIFI_PKD;
-
-/* NL80211_CMD_GET_WIPHY */
-
+/**
+ * @brief This structure represents the command used to retrieve Wireless PHY (wiphy) information.
+ *
+ */
 struct nrf_wifi_cmd_get_wiphy {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
 } __NRF_WIFI_PKD;
 
+/**
+ * @brief This structure represents the command to get hardware address.
+ *
+ */
 struct nrf_wifi_cmd_get_ifhwaddr {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Interface name */
 	signed char ifacename[IFACENAMSIZ];
 } __NRF_WIFI_PKD;
 
+/**
+ * @brief This structure represents the command used to retrieve the hardware address or
+ *  MAC address of the device.
+ *
+ */
 struct nrf_wifi_cmd_set_ifhwaddr {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Interface name */
 	signed char ifacename[IFACENAMSIZ];
+	/** Hardware address to be set */
 	unsigned char nrf_wifi_hwaddr[NRF_WIFI_ETH_ADDR_LEN];
 } __NRF_WIFI_PKD;
 
-struct nrf_wifi_reg_rules {
 #define REG_RULE_FLAGS_VALID (1 << 0)
 #define FREQ_RANGE_START_VALID (1 << 1)
 #define FREQ_RANGE_END_VALID (1 << 2)
 #define FREQ_RANGE_MAX_BW_VALID (1 << 3)
 #define POWER_RULE_MAX_EIRP_VALID (1 << 4)
-	unsigned int valid_fields;
 
+#define NRF_WIFI_RULE_FLAGS_NO_OFDM (1<<0)
+#define NRF_WIFI_RULE_FLAGS_NO_CCK (1<<1)
+#define NRF_WIFI_RULE_FLAGS_NO_INDOOR (1<<2)
+#define NRF_WIFI_RULE_FLAGS_NO_OUTDOOR (1<<3)
+#define NRF_WIFI_RULE_FLAGS_DFS (1<<4)
+#define NRF_WIFI_RULE_FLAGS_PTP_ONLY  (1<<5)
+#define NRF_WIFI_RULE_FLAGS_PTMP_ONLY (1<<6)
+#define NRF_WIFI_RULE_FLAGS_NO_IR (1<<7)
+#define NRF_WIFI_RULE_FLAGS_IBSS (1<<8)
+#define NRF_WIFI_RULE_FLAGS_AUTO_BW (1<<11)
+#define NRF_WIFI_RULE_FLAGS_IR_CONCURRENT (1<<12)
+#define NRF_WIFI_RULE_FLAGS_NO_HT40MINUS (1<<13)
+#define NRF_WIFI_RULE_FLAGS_NO_HT40PLUS (1<<14)
+#define NRF_WIFI_RULE_FLAGS_NO_80MHZ (1<<15)
+#define NRF_WIFI_RULE_FLAGS_NO_160MHZ (1<<16)
+
+/**
+ * @brief This structure represents the information related to the regulatory domain
+ *  of a wireless device. The regulatory domain defines the specific rules and regulations
+ *  that govern the usage of radio frequencies in a particular geographical region.
+ *
+ */
+
+struct nrf_wifi_reg_rules {
+	/** Indicate which of the following parameters are valid */
+	unsigned int valid_fields;
+	/** NRF_WIFI_RULE_FLAGS_NO_CCK and NRF_WIFI_RULE_FLAGS_NO_INDOOR */
 	unsigned int rule_flags;
+	/** starting frequencry for the regulatory rule in KHz */
 	unsigned int freq_range_start;
+	/** ending frequency for the regulatory rule in KHz */
 	unsigned int freq_range_end;
+	/** maximum allowed bandwidth for this frequency range */
 	unsigned int freq_range_max_bw;
+	/** maximum allowed EIRP mBm (100 * dBm) */
 	unsigned int pwr_max_eirp;
 
 } __NRF_WIFI_PKD;
 
-/* NL80211_CMD_SET_REG , NL80211_CMD_GET_REG*/
-
-struct nrf_wifi_reg {
-	struct nrf_wifi_umac_hdr umac_hdr;
-
 #define NRF_WIFI_CMD_SET_REG_ALPHA2_VALID (1 << 0)
 #define NRF_WIFI_CMD_SET_REG_RULES_VALID (1 << 1)
 #define NRF_WIFI_CMD_SET_REG_DFS_REGION_VALID (1 << 2)
-	unsigned int valid_fields;
-	unsigned int dfs_region;
+
 #define MAX_NUM_REG_RULES 32
+
+/**
+ * @brief This structure represents an event that contains regulatory domain information.
+ *
+ */
+
+struct nrf_wifi_reg {
+	/** Header @ref nrf_wifi_umac_hdr */
+	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Indicate which of the following parameters are valid */
+	unsigned int valid_fields;
+	/** region for regulatory */
+	unsigned int dfs_region;
+	/** No.of regulatory rules */
 	unsigned int num_reg_rules;
+	/** rules info. @ref nrf_wifi_reg_rules */
 	struct nrf_wifi_reg_rules nrf_wifi_reg_rules[MAX_NUM_REG_RULES];
+	/** Country code */
 	unsigned char nrf_wifi_alpha2[NRF_WIFI_COUNTRY_CODE_LEN];
 } __NRF_WIFI_PKD;
-
-/* NL80211_CMD_REQ_SET_REG */
-
-struct nrf_wifi_cmd_req_set_reg {
-	struct nrf_wifi_umac_hdr umac_hdr;
 
 #define NRF_WIFI_CMD_REQ_SET_REG_ALPHA2_VALID (1 << 0)
 #define NRF_WIFI_CMD_REQ_SET_REG_USER_REG_HINT_TYPE_VALID (1 << 1)
-/* This bit in valid_fields indicates user settings are forced (1) or not (0) */
 #define NRF_WIFI_CMD_REQ_SET_REG_USER_REG_FORCE (1 << 2)
+/**
+ * @brief This structure represents the command used to set the regulatory domain
+ *  for a wireless device. It allows configuring the device to adhere to the rules
+ *  and regulations specific to the geographical region in which it is operating.
+ *
+ */
+struct nrf_wifi_cmd_req_set_reg {
+	/** Header @ref nrf_wifi_umac_hdr */
+	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Indicate which of the following parameters are valid */
 	unsigned int valid_fields;
+	/** Type of regulatory hint passed from userspace */
 	unsigned int nrf_wifi_user_reg_hint_type;
+	/** Country code */
 	unsigned char nrf_wifi_alpha2[NRF_WIFI_COUNTRY_CODE_LEN];
 } __NRF_WIFI_PKD;
 
+/**
+ * @brief This structure represents the status code for a command. It is used to indicate
+ *  the outcome or result of executing a specific command. The status code provides valuable
+ *  information about the success, failure, or any errors encountered during the execution
+ *  of the command, helping to understand the current state of the device.
+ *
+ */
 struct nrf_wifi_umac_event_cmd_status {
+	/** Header @ref nrf_wifi_umac_hdr */
 	struct nrf_wifi_umac_hdr umac_hdr;
+	/** Command id. see &enum nrf_wifi_umac_commands */
 	unsigned int cmd_id;
+	/** Status codes */
 	unsigned int cmd_status;
 } __NRF_WIFI_PKD;
 

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw/host_rpu_umac_if.h
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw/host_rpu_umac_if.h
@@ -2331,7 +2331,7 @@ struct nrf_wifi_umac_event_vif_state {
  * This structure represents the command to start P2P mode on an interface.
  */
 
-struct nrf_wifi_umac_cmd_start_p2p_dev {
+struct nrf_wifi_cmd_start_p2p {
 	struct nrf_wifi_umac_hdr umac_hdr;
 } __NRF_WIFI_PKD;
 
@@ -2469,7 +2469,15 @@ struct nrf_wifi_umac_cmd_set_qos_map {
 struct nrf_wifi_umac_cmd_get_tx_power {
 	struct nrf_wifi_umac_hdr umac_hdr;
 } __NRF_WIFI_PKD;
+/**
+ * @brief This structure represents the command to get regulatory domain.
+ *
+ */
 
+struct nrf_wifi_umac_cmd_get_reg {
+	/** Header @ref nrf_wifi_umac_hdr */
+	struct nrf_wifi_umac_hdr umac_hdr;
+} __NRF_WIFI_PKD;
 /**
  * struct nrf_wifi_umac_cmd_get_channel - get channel info.
  * @umac_hdr: UMAC command header. Refer &struct nrf_wifi_umac_hdr.
@@ -2991,15 +2999,6 @@ struct nrf_wifi_umac_event_get_channel {
 	struct nrf_wifi_umac_hdr umac_hdr;
 	struct nrf_wifi_chan_definition chan_def;
 } __NRF_WIFI_PKD;
-
-
-
-/* CMD_START_P2P_DEVICE */
-
-struct nrf_wifi_cmd_start_p2p {
-	struct nrf_wifi_umac_hdr umac_hdr;
-} __NRF_WIFI_PKD;
-
 
 struct nrf_wifi_umac_cmd_conn_info {
 	struct nrf_wifi_umac_hdr umac_hdr;

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw/lmac_if_common.h
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw/lmac_if_common.h
@@ -135,52 +135,61 @@ struct INT_HPQ {
 } __NRF_WIFI_PKD;
 
 /**
- * struct lmac_fw_config_params:lmac firmware config params
- * @boot_status:		lmac firmware boot status. LMAC will set to
- *				0x5a5a5a5a after completing boot process.
- * @rpu_config_name:		rpu config name. this is a string and
- *				expected sting is explorer or whisper
- * @rpu_config_number:		rpu config number
- * @HP_lmac_to_host_isr_en:	lmac register address to enable ISR to Host
- * @HP_lmac_to_host_isr_clear:	Address to Clear host ISR
- * @HP_set_lmac_isr:		Address to set ISR to lmac Clear host ISR
- * @FreeCmdPtrQ:		queue which contains Free GRAM pointers for
- *				commands.
- * @cmdPtrQ:			Command pointer queue. Host should pick gram
- *				pointer from FreeCmdPtrQ. Populate command in
- *				GRAM and submit back to this queue for RPU.
- * @eventPtrQ:			Event pointer queue. Host should pick gram
- *				event pointer in isr
- * @version:			lmac firmware version
- *
+ * @brief LMAC firmware config params
  *
  */
 struct lmac_fw_config_params {
+	/** lmac firmware boot status. LMAC will set to 0x5a5a5a5a after completing boot process */
 	unsigned int boot_status;
+	/** LMAC version */
 	unsigned int version;
+	/** Address to resubmit Rx buffers */
 	unsigned int lmac_rx_buffer_addr;
+	/** Maximum Rx descriptors */
 	unsigned int lmac_rx_max_desc_cnt;
+	/** size of each descriptor size */
 	unsigned int lmac_rx_desc_size;
+	/** rpu config name. this is a string */
 	unsigned char rpu_config_name[16];
+	/** rpu config number */
 	unsigned char rpu_config_number[8];
+	/** numRX */
 	unsigned int numRX;
+	/** numTX */
 	unsigned int numTX;
 #define FREQ_2_4_GHZ 1
 #define FREQ_5_GHZ 2
+	/** supported bands */
 	unsigned int bands;
+	/** system frequency */
 	unsigned int sys_frequency_in_mhz;
+	/** queue which contains Free GRAM pointers for commands */
 	struct hpqm_queue FreeCmdPtrQ;
+	/** Command pointer queue. Host should pick pointer from FreeCmdPtrQ, populate
+	 *  command into that address and submit back to this queue for RPU
+	 */
 	struct hpqm_queue cmdPtrQ;
+	/** queue which contains Free GRAM pointers for events */
 	struct hpqm_queue eventPtrQ;
+	/** Event pointer queue. Host should pick pointer from FreeCmdPtrQ, populate
+	 *  command into that address and submit back to this queue for RPU
+	 */
 	struct hpqm_queue freeEventPtrQ;
+	/** Rx buffer queue */
 	struct hpqm_queue SKBGramPtrQ_1;
+	/** Rx buffer queue */
 	struct hpqm_queue SKBGramPtrQ_2;
+	/** Rx buffer queue */
 	struct hpqm_queue SKBGramPtrQ_3;
+	/** lmac register address to enable ISR to Host */
 	unsigned int HP_lmac_to_host_isr_en;
+	/** Address to Clear host ISR */
 	unsigned int HP_lmac_to_host_isr_clear;
+	/** Address to set ISR to lmac Clear host ISR */
 	unsigned int HP_set_lmac_isr;
 
 #define NUM_32_QUEUES 4
+	/** Hardware queues */
 	struct INT_HPQ hpq32[NUM_32_QUEUES];
 
 } __NRF_WIFI_PKD;
@@ -188,9 +197,12 @@ struct lmac_fw_config_params {
 #define MAX_NUM_OF_RX_QUEUES 3
 
 struct rx_buf_pool_params {
+	/** buffer size */
 	unsigned short buf_sz;
+	/** number of buffers */
 	unsigned short num_bufs;
 } __NRF_WIFI_PKD;
+
 struct temp_vbat_config {
 	unsigned int temp_based_calib_en;
 	unsigned int temp_calib_bitmap;

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/default/fmac_api.c
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/default/fmac_api.c
@@ -2425,39 +2425,6 @@ out:
 }
 
 #ifdef CONFIG_NRF700X_STA_MODE
-enum wifi_nrf_status wifi_nrf_fmac_suspend(void *dev_ctx)
-{
-	enum wifi_nrf_status status = WIFI_NRF_STATUS_FAIL;
-	struct nrf_wifi_umac_cmd_suspend *suspend_cmd = NULL;
-	struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx = NULL;
-
-	fmac_dev_ctx = dev_ctx;
-
-	suspend_cmd = wifi_nrf_osal_mem_zalloc(fmac_dev_ctx->fpriv->opriv,
-					       sizeof(*suspend_cmd));
-
-	if (!suspend_cmd) {
-		wifi_nrf_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n", __func__);
-		goto out;
-	}
-
-	suspend_cmd->umac_hdr.cmd_evnt = NRF_WIFI_UMAC_CMD_SUSPEND;
-
-	status = umac_cmd_cfg(fmac_dev_ctx,
-			      suspend_cmd,
-			      sizeof(*suspend_cmd));
-out:
-	if (suspend_cmd) {
-		wifi_nrf_osal_mem_free(fmac_dev_ctx->fpriv->opriv,
-				       suspend_cmd);
-	}
-
-	return status;
-
-}
-
-
 enum wifi_nrf_status wifi_nrf_fmac_get_tx_power(void *dev_ctx,
 						unsigned int if_idx)
 {
@@ -2604,39 +2571,6 @@ out:
 	if (cmd) {
 		wifi_nrf_osal_mem_free(fmac_dev_ctx->fpriv->opriv,
 				       cmd);
-	}
-
-	return status;
-}
-
-
-enum wifi_nrf_status wifi_nrf_fmac_resume(void *dev_ctx)
-{
-	enum wifi_nrf_status status = WIFI_NRF_STATUS_FAIL;
-	struct nrf_wifi_umac_cmd_resume *resume_cmd = NULL;
-	struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx = NULL;
-
-	fmac_dev_ctx = dev_ctx;
-
-	resume_cmd = wifi_nrf_osal_mem_zalloc(fmac_dev_ctx->fpriv->opriv,
-					      sizeof(*resume_cmd));
-
-	if (!resume_cmd) {
-		wifi_nrf_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
-				      __func__);
-		goto out;
-	}
-
-	resume_cmd->umac_hdr.cmd_evnt = NRF_WIFI_UMAC_CMD_RESUME;
-
-	status = umac_cmd_cfg(fmac_dev_ctx,
-			      resume_cmd,
-			      sizeof(*resume_cmd));
-out:
-	if (resume_cmd) {
-		wifi_nrf_osal_mem_free(fmac_dev_ctx->fpriv->opriv,
-				       resume_cmd);
 	}
 
 	return status;
@@ -2807,40 +2741,6 @@ out:
 	return status;
 }
 
-
-enum wifi_nrf_status wifi_nrf_fmac_set_wowlan(void *dev_ctx,
-					      unsigned int var)
-{
-	enum wifi_nrf_status status = WIFI_NRF_STATUS_FAIL;
-	struct nrf_wifi_umac_cmd_set_wowlan *set_wowlan = NULL;
-	struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx = NULL;
-
-	fmac_dev_ctx = dev_ctx;
-
-	set_wowlan = wifi_nrf_osal_mem_zalloc(fmac_dev_ctx->fpriv->opriv,
-					      sizeof(*set_wowlan));
-
-	if (!set_wowlan) {
-		wifi_nrf_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
-				      __func__);
-		goto out;
-	}
-
-	set_wowlan->umac_hdr.cmd_evnt = NRF_WIFI_UMAC_CMD_SET_WOWLAN;
-	set_wowlan->info.nrf_wifi_flags = var;
-
-	status = umac_cmd_cfg(fmac_dev_ctx,
-			      set_wowlan,
-			      sizeof(*set_wowlan));
-out:
-	if (set_wowlan) {
-		wifi_nrf_osal_mem_free(fmac_dev_ctx->fpriv->opriv,
-				       set_wowlan);
-	}
-
-	return status;
-}
 
 enum wifi_nrf_status wifi_nrf_fmac_get_wiphy(void *dev_ctx, unsigned char if_idx)
 {

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/default/fmac_api.c
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/default/fmac_api.c
@@ -1687,7 +1687,7 @@ enum wifi_nrf_status wifi_nrf_fmac_p2p_dev_start(void *dev_ctx,
 						 unsigned char if_idx)
 {
 	enum wifi_nrf_status status = WIFI_NRF_STATUS_FAIL;
-	struct nrf_wifi_umac_cmd_start_p2p_dev *start_p2p_dev_cmd = NULL;
+	struct nrf_wifi_cmd_start_p2p *start_p2p_dev_cmd = NULL;
 	const struct wifi_nrf_osal_ops *osal_ops = NULL;
 	struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx = NULL;
 

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/fmac_api_common.c
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/fmac_api_common.c
@@ -621,7 +621,7 @@ enum wifi_nrf_status wifi_nrf_fmac_get_reg(struct wifi_nrf_fmac_dev_ctx *fmac_de
 					   struct wifi_nrf_fmac_reg_info *reg_info)
 {
 	enum wifi_nrf_status status = WIFI_NRF_STATUS_FAIL;
-	struct nrf_wifi_reg *get_reg_cmd = NULL;
+	struct nrf_wifi_umac_cmd_get_reg *get_reg_cmd = NULL;
 	unsigned int count = 0;
 
 	if (!fmac_dev_ctx || !reg_info) {

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/tx.c
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/tx.c
@@ -584,9 +584,6 @@ enum wifi_nrf_status tx_cmd_prepare(struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx,
 
 	config->tx_desc_num = desc;
 
-	config->mac_hdr_info.umac_fill_flags =
-		ADDR2_POPULATED | ADDR3_POPULATED;
-
 	wifi_nrf_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
 			      config->mac_hdr_info.dest,
 			      wifi_nrf_util_get_dest(fmac_dev_ctx, nwb),


### PR DESCRIPTION
1. Added doxygen style comments to missing commands and events in UMAC interface files
2. Removed unused commands and its corresponding structures in interface files
3. Updated command structures for NRF_WIFI_UMAC_CMD_GET_REG and NRF_WIFI_UMAC_CMD_START_P2P_DEVICE