### PR TITLE
tests: nrf_profiler: Migrate to new ztest API

### DIFF
--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -22,12 +22,6 @@
   comment: "Excluded due to the old Ztest API  - issue: NCSDK-21698"
 
 - scenarios:
-    - nrf_profiler.core
-  platforms:
-    - all
-  comment: "Excluded due to the old Ztest API  - issue: NCSDK-21696"
-
-- scenarios:
     - zigbee.osif.*
     - zigbee.zboss_api.*
   platforms:

--- a/tests/subsys/nrf_profiler/README.txt
+++ b/tests/subsys/nrf_profiler/README.txt
@@ -1,13 +1,12 @@
 Profiler Test
 -------------
 
-Four tests are performed.
-One test is initialization test and the other three are performance tests.
-
-Performance tests do not check whether a data is transmitted.
+The test suite consists of three performance tests.
+The tests do not check whether data is transmitted.
 To examine it, one has to collect data transmitted to host using a Profiler backend's host tool and check manually whether the data is correct.
 
-Expected data is as follows:
+The expected output looks as follows:
+
 1. 100 events named "no data event" with no data.
 2. 100 events named "data event" with one value named "value1" of type "u32".
    The value starts from 0 and is incremented by one with every event.

--- a/tests/subsys/nrf_profiler/prj.conf
+++ b/tests/subsys/nrf_profiler/prj.conf
@@ -5,6 +5,10 @@
 #
 
 CONFIG_ZTEST=y
+CONFIG_ZTEST_NEW_API=y
+# Do not allow to randomize test order. Profiler events are expected to appear in a given order,
+# so that unit tests must run only once in a predefined order.
+CONFIG_ZTEST_SHUFFLE=n
 
 # Configuration required by Profiler
 CONFIG_USE_SEGGER_RTT=y

--- a/tests/subsys/nrf_profiler/src/main.c
+++ b/tests/subsys/nrf_profiler/src/main.c
@@ -86,13 +86,16 @@ static uint32_t test_performance_core(void (*profiler_func)(struct log_event_buf
 	return elapsed_time_us;
 }
 
-static void test_init(void)
+static void *test_init(void)
 {
 	zassert_ok(nrf_profiler_init(), "Error when initializing");
 	register_profiler_events();
+
+	return NULL;
 }
 
-static void test_performance1(void)
+/* Test in the suite are expected to run in alphanumerical order. */
+ZTEST(suite_nrf_profiler, test_performance_01)
 {
 	/* Profiling events with no data */
 	uint32_t elapsed_time_us = test_performance_core(NULL, no_data_event_id);
@@ -101,7 +104,7 @@ static void test_performance1(void)
 	       PROFILED_EVENTS_NB, elapsed_time_us);
 }
 
-static void test_performance2(void)
+ZTEST(suite_nrf_profiler, test_performance_02)
 {
 	uint32_t elapsed_time_us = test_performance_core(profile_data_event, data_event_id);
 
@@ -109,22 +112,12 @@ static void test_performance2(void)
 	       PROFILED_EVENTS_NB, elapsed_time_us);
 }
 
-static void test_performance3(void)
+ZTEST(suite_nrf_profiler, test_performance_03)
 {
 	uint32_t elapsed_time_us = test_performance_core(profile_big_event, big_event_id);
 
-	printk("Logged %d events with 14-byte data and 14-character string.\nElapsed time [us]: %d\n",
-	       PROFILED_EVENTS_NB, elapsed_time_us);
+	printk("Logged %d events with 14-byte data and 14-character string.\n"
+	       "Elapsed time [us]: %d\n", PROFILED_EVENTS_NB, elapsed_time_us);
 }
 
-void test_main(void)
-{
-	ztest_test_suite(nrf_profiler_tests,
-			 ztest_unit_test(test_init),
-			 ztest_unit_test(test_performance1),
-			 ztest_unit_test(test_performance2),
-			 ztest_unit_test(test_performance3)
-			 );
-
-	ztest_run_test_suite(nrf_profiler_tests);
-}
+ZTEST_SUITE(suite_nrf_profiler, NULL, test_init, NULL, NULL, NULL);


### PR DESCRIPTION
Change migrates test to new ztest API. The old API is deprecated.

Jira: NCSDK-21696