### PR TITLE
scripts: sbom: Update Jinja2 requirement for west sbom

### DIFF
--- a/scripts/requirements-west-ncs-sbom.txt
+++ b/scripts/requirements-west-ncs-sbom.txt
@@ -1,2 +1,2 @@
-jinja2
+jinja2>=3.0.0
 scancode-toolkit[full]==31.2.6


### PR DESCRIPTION
The scancode-toolkit requires MarkupSafe>=2.0 which is incompatible with Jinja<3.0.

To fix package compatibility, Jinja must be upgraded together with scancode-toolkit.

NCSDK-22481