### PR TITLE
bluetooth: fast_pair: Delete "reset" flag instead of storing false

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -345,6 +345,11 @@ Binary libraries
 Bluetooth libraries and services
 --------------------------------
 
+* :ref:`bt_fast_pair_readme` library:
+
+  * Deleted reset in progress flag from settings storage instead of storing it as ``false`` on factory reset operation.
+    This is done to ensure that no Fast Pair data is left in the settings storage after the factory reset.
+
 * :ref:`bt_mesh` library:
 
   * Added:

--- a/subsys/bluetooth/services/fast_pair/fp_storage/fp_storage_manager.c
+++ b/subsys/bluetooth/services/fast_pair/fp_storage/fp_storage_manager.c
@@ -76,8 +76,13 @@ static int reset_in_progress_set(bool in_progress)
 {
 	int err;
 
-	err = settings_save_one(SETTINGS_RESET_IN_PROGRESS_FULL_NAME, &in_progress,
-				sizeof(in_progress));
+	if (in_progress) {
+		err = settings_save_one(SETTINGS_RESET_IN_PROGRESS_FULL_NAME, &in_progress,
+					sizeof(in_progress));
+	} else {
+		err = settings_delete(SETTINGS_RESET_IN_PROGRESS_FULL_NAME);
+	}
+
 	if (err) {
 		return err;
 	}

--- a/tests/subsys/bluetooth/fast_pair/storage/factory_reset/src/main.c
+++ b/tests/subsys/bluetooth/fast_pair/storage/factory_reset/src/main.c
@@ -182,35 +182,6 @@ static int fp_settings_data_validate_empty_cb(const char *key, size_t len, setti
 		return 0;
 	}
 
-	if (!strncmp(key, SETTINGS_RESET_IN_PROGRESS_FULL_NAME,
-		     sizeof(SETTINGS_RESET_IN_PROGRESS_FULL_NAME))) {
-		int rc;
-		bool reset_in_progress;
-
-		if (len != sizeof(reset_in_progress)) {
-			*err = -EINVAL;
-			return *err;
-		}
-
-		rc = read_cb(cb_arg, &reset_in_progress, len);
-		if (rc < 0) {
-			*err = rc;
-			return *err;
-		}
-
-		if (rc != len) {
-			*err = -EINVAL;
-			return *err;
-		}
-
-		if (reset_in_progress) {
-			*err = -EFAULT;
-			return *err;
-		}
-
-		return 0;
-	}
-
 	*err = -EFAULT;
 	return *err;
 }


### PR DESCRIPTION
Change deletes Fast Pair storage manager's "reset" flag instead of storing it as false to ensure no data is left in settings after a successful factory reset operation.

PR also aligns the Fast Pair factory reset unit test.

Jira: NCSDK-20219