### PR TITLE
.github: labeler.yaml: Change path to changelog after it moved

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -15,7 +15,7 @@
   - "**/*.rst"
 
 "changelog-entry-required":
-  - all: ["!doc/nrf/releases/release-notes-changelog.rst"]
+  - all: ["!doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst"]
 
 "ble mesh":
   - "subsys/bluetooth/mesh/*"


### PR DESCRIPTION
The changelog moved to a new subdirectory, update this so the PR labeler works properly (doesn't add the changelog-required label when the changelog has been updated).

NCSDK-22320