### PR TITLE
nrf_security: Fix psa_driver_wrapper_get_builtin_key

### DIFF
--- a/subsys/nrf_security/src/psa_crypto_driver_wrappers.c
+++ b/subsys/nrf_security/src/psa_crypto_driver_wrappers.c
@@ -636,13 +636,12 @@ psa_status_t psa_driver_wrapper_get_builtin_key(psa_drv_slot_number_t slot_numbe
 	psa_key_location_t location = PSA_KEY_LIFETIME_GET_LOCATION(attributes->core.lifetime);
 
 	switch (location) {
-	default:
 #if defined(PSA_CRYPTO_DRIVER_TFM_BUILTIN_KEY_LOADER)
 	case TFM_BUILTIN_KEY_LOADER_KEY_LOCATION:
 		return tfm_builtin_key_loader_get_key_buffer(slot_number, attributes, key_buffer,
 							     key_buffer_size, key_buffer_length);
 #endif /* PSA_CRYPTO_DRIVER_TFM_BUILTIN_KEY_LOADER */
-
+	default:
 		(void)slot_number;
 		(void)key_buffer;
 		(void)key_buffer_size;


### PR DESCRIPTION
Bugfix for psa_driver_wrapper_get_builtin_key. Presumably introduced in 32ff463bebffff02ccb3e9b7b7285c72a3612db4 through a bad conflict resolution.

The consequences of the bug are unknown.