### PR TITLE
modules: mcuboot: Disable Zephyr's MCUboot handling for child images

### DIFF
--- a/modules/mcuboot/CMakeLists.txt
+++ b/modules/mcuboot/CMakeLists.txt
@@ -28,6 +28,10 @@ endif()
 
 if(CONFIG_BOOTLOADER_MCUBOOT)
   if (CONFIG_NCS_IS_VARIANT_IMAGE)
+    # NCS Handles everything regarding mcuboot, ensure Zephyr doesn't interfere.
+    # This is a temporary solution until Zephyr signing has been made more modular.
+    set(CONFIG_BOOTLOADER_MCUBOOT False PARENT_SCOPE)
+
     # When building the variant of an image, the configuration of the variant image
     # is identical to the base image, except 'CONFIG_NCS_IS_VARIANT_IMAGE'. The
     # logic below should only be performed once, for the base image, not for the variant variant.


### PR DESCRIPTION
Change disables Zephyr's MCUboot handling in child images. The NCS handles needed operations on its own. Change is needed to ensure consistency for main application image and child images.

Jira: NCSDK-22347