### PR TITLE
manifest: update zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 75f67930b8d5616b5c0745de03b14a45fec897ac
+      revision: bb6a7db2c510c743374e9a8340ac065e6ae996c8
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This commit brings in zephyr containing the fix against crashes of nrf5340 net core when wfi instruction was followed by access to the memory.