### PR TITLE
doc: nrf_security: Improve PSA configuration documentation

### DIFF
--- a/doc/nrf/libraries/nrf_security/doc/driver_config.rst
+++ b/doc/nrf/libraries/nrf_security/doc/driver_config.rst
@@ -36,25 +36,25 @@ Cipher configurations
 
 To enable cipher modes, set one or more of the following Kconfig options:
 
-+----------------+------------------------------------------------------+
-| Cipher mode    | Configuration option                                 |
-+================+======================================================+
-| ECB_NO_PADDING | :kconfig:option:`CONFIG_PSA_WANT_ALG_ECB_NO_PADDING` |
-+----------------+------------------------------------------------------+
-| CBC_NO_PADDING | :kconfig:option:`CONFIG_PSA_WANT_ALG_CBC_NO_PADDING` |
-+----------------+------------------------------------------------------+
-| CBC_PKCS7      | :kconfig:option:`CONFIG_PSA_WANT_ALG_CBC_PKCS7`      |
-+----------------+------------------------------------------------------+
-| CFB            | :kconfig:option:`CONFIG_PSA_WANT_ALG_CFB`            |
-+----------------+------------------------------------------------------+
-| CTR            | :kconfig:option:`CONFIG_PSA_WANT_ALG_CTR`            |
-+----------------+------------------------------------------------------+
-| OFB            | :kconfig:option:`CONFIG_PSA_WANT_ALG_OFB`            |
-+----------------+------------------------------------------------------+
-| XTS            | :kconfig:option:`CONFIG_PSA_WANT_ALG_XTS`            |
-+----------------+------------------------------------------------------+
-| Stream cipher  | :kconfig:option:`CONFIG_PSA_WANT_ALG_STREAM_CIPHER`  |
-+----------------+------------------------------------------------------+
++-----------------------+------------------------------------------------------+
+| Cipher mode           | Configuration option                                 |
++=======================+======================================================+
+| ECB no padding        | :kconfig:option:`CONFIG_PSA_WANT_ALG_ECB_NO_PADDING` |
++-----------------------+------------------------------------------------------+
+| CBC no padding        | :kconfig:option:`CONFIG_PSA_WANT_ALG_CBC_NO_PADDING` |
++-----------------------+------------------------------------------------------+
+| CBC PKCS#7 padding    | :kconfig:option:`CONFIG_PSA_WANT_ALG_CBC_PKCS7`      |
++-----------------------+------------------------------------------------------+
+| CFB                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_CFB`            |
++-----------------------+------------------------------------------------------+
+| CTR                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_CTR`            |
++-----------------------+------------------------------------------------------+
+| OFB                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_OFB`            |
++-----------------------+------------------------------------------------------+
+| XTS                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_XTS`            |
++-----------------------+------------------------------------------------------+
+| Stream cipher         | :kconfig:option:`CONFIG_PSA_WANT_ALG_STREAM_CIPHER`  |
++-----------------------+------------------------------------------------------+
 
 
 Cipher driver configurations
@@ -62,25 +62,25 @@ Cipher driver configurations
 
 You can use the following Kconfig options for fine-grained control over which drivers provide cipher support:
 
-+----------------+---------------------------------------------------------------------+----------------------------------------------------------------------+
-| Cipher mode    | nrf_cc3xx driver support                                            | nrf_oberon driver support                                            |
-+================+=====================================================================+======================================================================+
-| ECB_NO_PADDING | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_ECB_NO_PADDING_CC3XX` | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_ECB_NO_PADDING_OBERON` |
-+----------------+---------------------------------------------------------------------+----------------------------------------------------------------------+
-| CBC_NO_PADDING | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CBC_NO_PADDING_CC3XX` | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CBC_NO_PADDING_OBERON` |
-+----------------+---------------------------------------------------------------------+----------------------------------------------------------------------+
-| CBC_PKCS7      | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CBC_PKCS7_CC3XX`      | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CBC_PKCS7_OBERON`      |
-+----------------+---------------------------------------------------------------------+----------------------------------------------------------------------+
-| CFB            | Not supported                                                       | Not supported                                                        |
-+----------------+---------------------------------------------------------------------+----------------------------------------------------------------------+
-| CTR            | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CTR_CC3XX`            | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CTR_OBERON`            |
-+----------------+---------------------------------------------------------------------+----------------------------------------------------------------------+
-| OFB            | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_OFB_CC3XX`            | Not supported                                                        |
-+----------------+---------------------------------------------------------------------+----------------------------------------------------------------------+
-| XTS            | Not supported                                                       | Not supported                                                        |
-+----------------+---------------------------------------------------------------------+----------------------------------------------------------------------+
-| Stream cipher  | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_STREAM_CIPHER_CC3XX`  | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_STREAM_CIPHER_OBERON`  |
-+----------------+---------------------------------------------------------------------+----------------------------------------------------------------------+
++-----------------------+---------------------------------------------------------------------+----------------------------------------------------------------------+
+| Cipher mode           | nrf_cc3xx driver support                                            | nrf_oberon driver support                                            |
++=======================+=====================================================================+======================================================================+
+| ECB no padding        | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_ECB_NO_PADDING_CC3XX` | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_ECB_NO_PADDING_OBERON` |
++-----------------------+---------------------------------------------------------------------+----------------------------------------------------------------------+
+| CBC no padding        | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CBC_NO_PADDING_CC3XX` | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CBC_NO_PADDING_OBERON` |
++-----------------------+---------------------------------------------------------------------+----------------------------------------------------------------------+
+| CBC PKCS#7 padding    | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CBC_PKCS7_CC3XX`      | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CBC_PKCS7_OBERON`      |
++-----------------------+---------------------------------------------------------------------+----------------------------------------------------------------------+
+| CFB                   | Not supported                                                       | Not supported                                                        |
++-----------------------+---------------------------------------------------------------------+----------------------------------------------------------------------+
+| CTR                   | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CTR_CC3XX`            | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CTR_OBERON`            |
++-----------------------+---------------------------------------------------------------------+----------------------------------------------------------------------+
+| OFB                   | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_OFB_CC3XX`            | Not supported                                                        |
++-----------------------+---------------------------------------------------------------------+----------------------------------------------------------------------+
+| XTS                   | Not supported                                                       | Not supported                                                        |
++-----------------------+---------------------------------------------------------------------+----------------------------------------------------------------------+
+| Stream cipher         | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_STREAM_CIPHER_CC3XX`  | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_STREAM_CIPHER_OBERON`  |
++-----------------------+---------------------------------------------------------------------+----------------------------------------------------------------------+
 
 .. note::
    * The :ref:`nrf_security_drivers_cc3xx` is limited to AES key sizes of 128 bits on devices with Arm CryptoCell cc310.

--- a/doc/nrf/libraries/nrf_security/doc/driver_config.rst
+++ b/doc/nrf/libraries/nrf_security/doc/driver_config.rst
@@ -171,15 +171,15 @@ AEAD configurations
 
 To enable Authenticated Encryption with Associated Data (AEAD), set one or more of the following Kconfig options:
 
-+----------------+---------------------------------------------------------+
-| AEAD cipher    | Configuration option                                    |
-+================+=========================================================+
-| AES CCM        | :kconfig:option:`CONFIG_PSA_WANT_ALG_CCM`               |
-+----------------+---------------------------------------------------------+
-| AES GCM        | :kconfig:option:`CONFIG_PSA_WANT_ALG_GCM`               |
-+----------------+---------------------------------------------------------+
-| ChaCha/Poly    | :kconfig:option:`CONFIG_PSA_WANT_ALG_CHACHA20_POLY1305` |
-+----------------+---------------------------------------------------------+
++-----------------------+---------------------------------------------------------+
+| AEAD cipher           | Configuration option                                    |
++=======================+=========================================================+
+| AES CCM               | :kconfig:option:`CONFIG_PSA_WANT_ALG_CCM`               |
++-----------------------+---------------------------------------------------------+
+| AES GCM               | :kconfig:option:`CONFIG_PSA_WANT_ALG_GCM`               |
++-----------------------+---------------------------------------------------------+
+| ChaCha20-Poly1305     | :kconfig:option:`CONFIG_PSA_WANT_ALG_CHACHA20_POLY1305` |
++-----------------------+---------------------------------------------------------+
 
 
 AEAD driver configurations
@@ -187,15 +187,15 @@ AEAD driver configurations
 
 You can use the following Kconfig options for fine-grained control over which drivers provide AEAD support:
 
-+----------------+------------------------------------------------------------------------+-------------------------------------------------------------------------+
-| AEAD cipher    | nrf_cc3xx driver support                                               | nrf_oberon driver support                                               |
-+================+========================================================================+=========================================================================+
-| AES CCM        | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CCM_CC3XX`               | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CCM_OBERON`               |
-+----------------+------------------------------------------------------------------------+-------------------------------------------------------------------------+
-| AES GCM        | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_GCM_CC3XX`               | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_GCM_OBERON`               |
-+----------------+------------------------------------------------------------------------+-------------------------------------------------------------------------+
-| ChaCha/Poly    | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CHACHA20_POLY1305_CC3XX` | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CHACHA20_POLY1305_OBERON` |
-+----------------+------------------------------------------------------------------------+-------------------------------------------------------------------------+
++-----------------------+------------------------------------------------------------------------+-------------------------------------------------------------------------+
+| AEAD cipher           | nrf_cc3xx driver support                                               | nrf_oberon driver support                                               |
++=======================+========================================================================+=========================================================================+
+| AES CCM               | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CCM_CC3XX`               | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CCM_OBERON`               |
++-----------------------+------------------------------------------------------------------------+-------------------------------------------------------------------------+
+| AES GCM               | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_GCM_CC3XX`               | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_GCM_OBERON`               |
++-----------------------+------------------------------------------------------------------------+-------------------------------------------------------------------------+
+| ChaCha20-Poly1305     | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CHACHA20_POLY1305_CC3XX` | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CHACHA20_POLY1305_OBERON` |
++-----------------------+------------------------------------------------------------------------+-------------------------------------------------------------------------+
 
 .. note::
    * The :ref:`nrf_security_drivers_cc3xx` is limited to AES key sizes of 128 bits on devices with Arm CryptoCell cc310.

--- a/doc/nrf/libraries/nrf_security/doc/driver_config.rst
+++ b/doc/nrf/libraries/nrf_security/doc/driver_config.rst
@@ -31,10 +31,10 @@ If multiple drivers are enabled, the first ordered item in this table takes prec
 Enabling or disabling PSA driver specific configurations controls the support for a given algorithm, per driver.
 
 
-AES cipher configurations
-*************************
+Cipher configurations
+*********************
 
-To enable AES cipher modes, set one or more of the following Kconfig options:
+To enable cipher modes, set one or more of the following Kconfig options:
 
 +----------------+------------------------------------------------------+
 | Cipher mode    | Configuration option                                 |
@@ -57,10 +57,10 @@ To enable AES cipher modes, set one or more of the following Kconfig options:
 +----------------+------------------------------------------------------+
 
 
-AES cipher driver configurations
-================================
+Cipher driver configurations
+============================
 
-You can use the following Kconfig options for fine-grained control over which drivers provide AES cipher support:
+You can use the following Kconfig options for fine-grained control over which drivers provide cipher support:
 
 +----------------+---------------------------------------------------------------------+----------------------------------------------------------------------+
 | Cipher mode    | nrf_cc3xx driver support                                            | nrf_oberon driver support                                            |
@@ -162,8 +162,8 @@ You can use the following Kconfig options for fine-grained control over which dr
 +----------------+-----------------------------------------------------------+------------------------------------------------------------+
 
 .. note::
-   * The :ref:`nrf_security_drivers_cc3xx` is limited to AES CMAC key sizes of 128 bits on devices with Arm CryptoCell cc310.
-   * The :ref:`nrf_security_drivers_cc3xx` is limited to HMAC using SHA-1, SHA-224, and SHA-256 on devices with Arm CryptoCell.
+   * The :ref:`nrf_security_drivers_cc3xx` is limited to CMAC using AES key sizes of 128 bits on devices with Arm CryptoCell cc310.
+   * The :ref:`nrf_security_drivers_cc3xx` is limited to HMAC using SHA-1, SHA-224, and SHA-256.
 
 
 AEAD configurations
@@ -174,9 +174,9 @@ To enable Authenticated Encryption with Associated Data (AEAD), set one or more 
 +-----------------------+---------------------------------------------------------+
 | AEAD cipher           | Configuration option                                    |
 +=======================+=========================================================+
-| AES CCM               | :kconfig:option:`CONFIG_PSA_WANT_ALG_CCM`               |
+| CCM                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_CCM`               |
 +-----------------------+---------------------------------------------------------+
-| AES GCM               | :kconfig:option:`CONFIG_PSA_WANT_ALG_GCM`               |
+| GCM                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_GCM`               |
 +-----------------------+---------------------------------------------------------+
 | ChaCha20-Poly1305     | :kconfig:option:`CONFIG_PSA_WANT_ALG_CHACHA20_POLY1305` |
 +-----------------------+---------------------------------------------------------+
@@ -190,16 +190,16 @@ You can use the following Kconfig options for fine-grained control over which dr
 +-----------------------+------------------------------------------------------------------------+-------------------------------------------------------------------------+
 | AEAD cipher           | nrf_cc3xx driver support                                               | nrf_oberon driver support                                               |
 +=======================+========================================================================+=========================================================================+
-| AES CCM               | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CCM_CC3XX`               | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CCM_OBERON`               |
+| CCM                   | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CCM_CC3XX`               | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CCM_OBERON`               |
 +-----------------------+------------------------------------------------------------------------+-------------------------------------------------------------------------+
-| AES GCM               | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_GCM_CC3XX`               | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_GCM_OBERON`               |
+| GCM                   | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_GCM_CC3XX`               | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_GCM_OBERON`               |
 +-----------------------+------------------------------------------------------------------------+-------------------------------------------------------------------------+
 | ChaCha20-Poly1305     | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CHACHA20_POLY1305_CC3XX` | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CHACHA20_POLY1305_OBERON` |
 +-----------------------+------------------------------------------------------------------------+-------------------------------------------------------------------------+
 
 .. note::
    * The :ref:`nrf_security_drivers_cc3xx` is limited to AES key sizes of 128 bits on devices with Arm CryptoCell cc310.
-   * The :ref:`nrf_security_drivers_cc3xx` does not provide hardware support for AES GCM on devices with Arm CryptoCell cc310.
+   * The :ref:`nrf_security_drivers_cc3xx` does not provide hardware support for GCM on devices with Arm CryptoCell cc310.
 
 
 ECC configurations

--- a/doc/nrf/libraries/nrf_security/doc/driver_config.rst
+++ b/doc/nrf/libraries/nrf_security/doc/driver_config.rst
@@ -320,15 +320,15 @@ To enable PRNG seeded by entropy (also known as TRNG), set one or more of the fo
 +---------------------------+-------------------------------------------------+
 | PRNG algorithms           | Configuration option                            |
 +===========================+=================================================+
-| CTR_DRBG                  | :kconfig:option:`CONFIG_PSA_WANT_ALG_CTR_DRBG`  |
+| CTR-DRBG                  | :kconfig:option:`CONFIG_PSA_WANT_ALG_CTR_DRBG`  |
 +---------------------------+-------------------------------------------------+
-| HMAC_DRBG                 | :kconfig:option:`CONFIG_PSA_WANT_ALG_HMAC_DRBG` |
+| HMAC-DRBG                 | :kconfig:option:`CONFIG_PSA_WANT_ALG_HMAC_DRBG` |
 +---------------------------+-------------------------------------------------+
 
 .. note::
    * Both PRNG algorithms are NIST qualified Cryptographically Secure Pseudo Random Number Generators (CSPRNG).
    * :kconfig:option:`CONFIG_PSA_WANT_ALG_CTR_DRBG` and :kconfig:option:`CONFIG_PSA_WANT_ALG_HMAC_DRBG` are custom configurations not described by the PSA Crypto specification.
-   * If multiple PRNG algorithms are enabled at the same time, CTR_DRBG will be prioritized for random number generation through the front-end APIs for PSA Crypto.
+   * If multiple PRNG algorithms are enabled at the same time, CTR-DRBG will be prioritized for random number generation through the front-end APIs for PSA Crypto.
 
 
 RNG driver configurations

--- a/doc/nrf/libraries/nrf_security/doc/driver_config.rst
+++ b/doc/nrf/libraries/nrf_security/doc/driver_config.rst
@@ -315,7 +315,10 @@ You can use the following Kconfig options for fine-grained control over which dr
 RNG configurations
 ******************
 
-To enable PRNG seeded by entropy (also known as TRNG), set one or more of the following configurations:
+Enable RNG using the :kconfig:option:`CONFIG_PSA_WANT_GENERATE_RANDOM` Kconfig option.
+
+RNG uses PRNG seeded by entropy (also known as TRNG).
+When RNG is enabled, set at least one of the following configurations:
 
 +---------------------------+-------------------------------------------------+
 | PRNG algorithms           | Configuration option                            |

--- a/subsys/nrf_security/src/drivers/nrf_cc3xx/Kconfig
+++ b/subsys/nrf_security/src/drivers/nrf_cc3xx/Kconfig
@@ -173,13 +173,13 @@ config PSA_CRYPTO_DRIVER_ALG_RSA_OAEP_CC3XX
 
 config PSA_CRYPTO_DRIVER_ALG_RSA_PKCS1V15_CRYPT_CC3XX
 	bool
-	prompt "PSA RSA crypt support (PKCS1V15 mode) - cc3xx" if !PSA_PROMPTLESS
+	prompt "PSA RSA crypt support (PKCS#1 v1.5 mode) - cc3xx" if !PSA_PROMPTLESS
 	default y if !PSA_DEFAULT_OFF
 	depends on PSA_WANT_ALG_RSA_PKCS1V15_CRYPT
 
 config PSA_CRYPTO_DRIVER_ALG_RSA_PKCS1V15_SIGN_CC3XX
 	bool
-	prompt "PSA RSA signature support (PKCS1V15 mode) - cc3xx" if !PSA_PROMPTLESS
+	prompt "PSA RSA signature support (PKCS#1 v1.5 mode) - cc3xx" if !PSA_PROMPTLESS
 	default y if !PSA_DEFAULT_OFF
 	depends on PSA_WANT_ALG_RSA_PKCS1V15_SIGN
 

--- a/subsys/nrf_security/src/drivers/nrf_oberon/Kconfig
+++ b/subsys/nrf_security/src/drivers/nrf_oberon/Kconfig
@@ -218,13 +218,13 @@ config PSA_CRYPTO_DRIVER_ALG_RSA_OAEP_OBERON
 
 config PSA_CRYPTO_DRIVER_ALG_RSA_PKCS1V15_CRYPT_OBERON
 	bool
-	prompt "PSA RSA crypt support (PKCS1V15 mode) - oberon" if !PSA_PROMPTLESS
+	prompt "PSA RSA crypt support (PKCS#1 v1.5 mode) - oberon" if !PSA_PROMPTLESS
 	default y if !PSA_DEFAULT_OFF
 	depends on PSA_WANT_ALG_RSA_PKCS1V15_CRYPT
 
 config PSA_CRYPTO_DRIVER_ALG_RSA_PKCS1V15_SIGN_OBERON
 	bool
-	prompt "PSA RSA signature support (PKCS1V15 mode) - oberon" if !PSA_PROMPTLESS
+	prompt "PSA RSA signature support (PKCS#1 v1.5 mode) - oberon" if !PSA_PROMPTLESS
 	default y if !PSA_DEFAULT_OFF
 	depends on PSA_WANT_ALG_RSA_PKCS1V15_SIGN
 

--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 52222dc79450304fe4a32e5e0e77b9a460a93a86
+      revision: 01e2e4c9ce8294d74032a2d33e0dcb1b74802568
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -140,7 +140,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: dc8c95a8f5e7b7fe102632172b923849b17f0a33
+      revision: 4eca399cc6e8a095f320aafdd272606ee1294a13
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Improve the PSA configuration.
See commits for details.

Pull zephyr for PSA dependency fixes, as well as updating PSA configuration to be aligned with NCS documentation.