### PR TITLE
lib: nrf_modem: release fd lock in `sendto`

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -381,6 +381,7 @@ Modem libraries
 
 * :ref:`nrf_modem_lib_readme`:
 
+  * Fixed a rare bug that caused a deadlock between two threads when one thread sent data while the other received a lot of data quickly.
   * Updated the :c:func:`nrf_modem_lib_shutdown` function to allow the modem to be in flight mode (``CFUN=4``) when shutting down the modem.
 
 * :ref:`lib_location` library:

--- a/lib/nrf_modem_lib/nrf91_sockets.c
+++ b/lib/nrf_modem_lib/nrf91_sockets.c
@@ -39,12 +39,6 @@
 
 #if defined(CONFIG_NET_SOCKETS_OFFLOAD)
 
-#if defined(CONFIG_NRF91_SOCKET_ENABLE_DEBUG_LOGS)
-/* TODO: Add debug */
-#endif
-
-#define PROTO_WILDCARD 0
-
 #define OBJ_TO_SD(obj) (((struct nrf_sock_ctx *)obj)->nrf_fd)
 #define OBJ_TO_CTX(obj) ((struct nrf_sock_ctx *)obj)
 

--- a/lib/nrf_modem_lib/nrf91_sockets.c
+++ b/lib/nrf_modem_lib/nrf91_sockets.c
@@ -551,16 +551,14 @@ static ssize_t nrf91_socket_offload_recvfrom(void *obj, void *buf, size_t len,
 	}
 
 	if (from == NULL || fromlen == NULL) {
-		retval = nrf_recvfrom(ctx->nrf_fd, buf, len, flags,
-				      NULL, NULL);
+		retval = nrf_recvfrom(ctx->nrf_fd, buf, len, flags, NULL, NULL);
 	} else {
 		/* Allocate space for maximum of IPv4 and IPv6 family type. */
-		struct nrf_sockaddr_in6 cliaddr_storage = { 0 };
+		struct nrf_sockaddr_in6 cliaddr_storage = {0};
 		nrf_socklen_t sock_len = sizeof(struct nrf_sockaddr_in6);
 		struct nrf_sockaddr *cliaddr = (struct nrf_sockaddr *)&cliaddr_storage;
 
-		retval = nrf_recvfrom(ctx->nrf_fd, buf, len, flags,
-				      cliaddr, &sock_len);
+		retval = nrf_recvfrom(ctx->nrf_fd, buf, len, flags, cliaddr, &sock_len);
 		if (retval < 0) {
 			goto exit;
 		}
@@ -571,8 +569,7 @@ static ssize_t nrf91_socket_offload_recvfrom(void *obj, void *buf, size_t len,
 			*fromlen = sizeof(struct sockaddr_in);
 		} else if (cliaddr->sa_family == NRF_AF_INET6 &&
 			   sock_len == sizeof(struct nrf_sockaddr_in6)) {
-			nrf_to_z_ipv6(from, (struct nrf_sockaddr_in6 *)
-					  cliaddr);
+			nrf_to_z_ipv6(from, (struct nrf_sockaddr_in6 *)cliaddr);
 			*fromlen = sizeof(struct sockaddr_in6);
 		}
 	}
@@ -598,26 +595,23 @@ static ssize_t nrf91_socket_offload_sendto(void *obj, const void *buf,
 	ssize_t retval;
 
 	if (ctx->lock) {
-		(void) k_mutex_unlock(ctx->lock);
+		(void)k_mutex_unlock(ctx->lock);
 	}
 
 	if (to == NULL) {
-		retval = nrf_sendto(sd, buf, len, flags, NULL,
-				    0);
+		retval = nrf_sendto(sd, buf, len, flags, NULL, 0);
 	} else if (to->sa_family == AF_INET) {
 		struct nrf_sockaddr_in ipv4;
 		nrf_socklen_t sock_len = sizeof(struct nrf_sockaddr_in);
 
 		z_to_nrf_ipv4(to, &ipv4);
-		retval = nrf_sendto(sd, buf, len, flags,
-				    (struct nrf_sockaddr*)&ipv4, sock_len);
+		retval = nrf_sendto(sd, buf, len, flags, (struct nrf_sockaddr *)&ipv4, sock_len);
 	} else if (to->sa_family == AF_INET6) {
 		struct nrf_sockaddr_in6 ipv6;
 		nrf_socklen_t sock_len = sizeof(struct nrf_sockaddr_in6);
 
 		z_to_nrf_ipv6(to, &ipv6);
-		retval = nrf_sendto(sd, buf, len, flags,
-				    (struct nrf_sockaddr*)&ipv6, sock_len);
+		retval = nrf_sendto(sd, buf, len, flags, (struct nrf_sockaddr *)&ipv6, sock_len);
 	} else {
 		errno = EAFNOSUPPORT;
 		retval = -1;


### PR DESCRIPTION
Let `sendto()` release the fd lock to be able to execute other
operations in the meantime, for example, `recv()`.

If `sendto()` doesn't release its lock, it can't be preempted by other
threads, including threads that `recv()`. This can create a deadlock
situation in case a lot of network data is received during a `sendto()`
call, filling up the shared memory and preventing the modem from
sending a response to the `sendto()` request, which then never returns,
preventing the `recv()` thread from being scheduled.