### PR TITLE
samples: bluetooth: nrf_dm: Align configurations for nrf5340

### DIFF
--- a/samples/bluetooth/nrf_dm/child_image/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay
+++ b/samples/bluetooth/nrf_dm/child_image/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay
@@ -7,6 +7,11 @@
 #include <zephyr/dt-bindings/ipc_service/static_vrings.h>
 
 / {
+	/* The timer instance to use. */
+	chosen {
+		ncs,dm-timer = &timer2;
+	};
+
 	chosen {
 		/delete-property/ zephyr,ipc_shm;
 	};


### PR DESCRIPTION
Sets `ncs,dm-timer` to select timer instances for nrf5340.