### PR TITLE
drivers: wifi: Fix the debug level for unhandled events

### DIFF
--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/event.c
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/event.c
@@ -510,7 +510,7 @@ static enum wifi_nrf_status umac_event_ctrl_process(struct wifi_nrf_fmac_dev_ctx
 		break;
 #endif /* CONFIG_WPA_SUPP */
 	default:
-		wifi_nrf_osal_log_err(fmac_dev_ctx->fpriv->opriv,
+		wifi_nrf_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
 				      "%s: No callback registered for event %d\n",
 				      __func__,
 				      umac_hdr->cmd_evnt);


### PR DESCRIPTION
This unncessarily causing error prints on the console and queries, as this is only for internal use i.e., to act as a trigger to implement those events, making it debug.