### PR TITLE
tests: fast_pair: storage: Migrate to new ztest API

### DIFF
--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -13,9 +13,3 @@
   platforms:
     - all
   comment: "Temporary disable till the issue is fixed"
-
-- scenarios:
-    - fast_pair.storage.factory_reset.*
-  platforms:
-    - all
-  comment: "Excluded due to the old Ztest API  - issue: NCSDK-21698"

--- a/tests/subsys/bluetooth/fast_pair/storage/factory_reset/prj.conf
+++ b/tests/subsys/bluetooth/fast_pair/storage/factory_reset/prj.conf
@@ -5,6 +5,9 @@
 #
 
 CONFIG_ZTEST=y
+CONFIG_ZTEST_NEW_API=y
+# Do not randomize test order, tests depend on predefined execution order.
+CONFIG_ZTEST_SHUFFLE=n
 
 # Enable settings to store data in non-volatile memory
 CONFIG_FLASH=y


### PR DESCRIPTION
Change migrates test to new ztest API. The old API is deprecated. Change also removes test from quarantine.

Jira: NCSDK-21698