### PR TITLE
net: nrf_provisioning: Add kconfig to save the command id

### DIFF
--- a/subsys/net/lib/nrf_provisioning/Kconfig
+++ b/subsys/net/lib/nrf_provisioning/Kconfig
@@ -38,6 +38,11 @@ config NRF_PROVISIONING_WITH_CERT
 	help
 	  Includes the root certificate used by the server side and provisions it if needed.
 
+config NRF_PROVISIONING_SAVE_CMD_ID
+	bool "Save the latest command id to storage"
+	help
+	  Saves the latest command id to storage after successful Finished command.
+
 rsource "Kconfig.nrf_provisioning_http"
 
 rsource "Kconfig.nrf_provisioning_at"

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning.c
@@ -544,7 +544,10 @@ int nrf_provisioning_req(void)
 			LOG_ERR("Provisioning failed, error: %d", ret);
 		} else if (ret > 0) {
 			/* Provisioning finished */
-			commit_latest_cmd_id();
+			if (IS_ENABLED(CONFIG_NRF_PROVISIONING_SAVE_CMD_ID)) {
+				LOG_DBG("Saving the latest command id");
+				commit_latest_cmd_id();
+			}
 			dm.cb(dm.user_data);
 		}
 


### PR DESCRIPTION
Add new kconfig NRF_PROVISIONING_SAVE_CMD_ID. When enabled the latest command id is saved to storage after successful Finished command.