### PR TITLE
quarantine_windows_mac: Quarantine all asset tracker tests

### DIFF
--- a/scripts/quarantine_windows_mac.yaml
+++ b/scripts/quarantine_windows_mac.yaml
@@ -31,23 +31,7 @@
   comment: "Cmake error for EBC tests - NCSDK-21089"
 
 - scenarios:
-    - applications.asset_tracker_v2.nrf7002ek_wifi-debug
-  comment: "FLASH overflow issue under investigation"
-
-- scenarios:
     - sample.net.mqtt.nrf9160.tls
     - sample.net.mqtt
-    - applications.asset_tracker_v2.carrier.nrf9161dk
-    - applications.asset_tracker_v2.carrier.nrf9160dk
-    - applications.asset_tracker_v2.lwm2m.memfault
-    - applications.asset_tracker_v2.memfault-low-power
-    - applications.asset_tracker_v2.nrf7002ek_wifi.nrf9161dk
-    - applications.asset_tracker_v2.aws
-    - applications.asset_tracker_v2.aws-all
-    - applications.asset_tracker_v2.aws-pgps
-    - applications.asset_tracker_v2.debug
-    - applications.asset_tracker_v2.debug-memfault
-    - applications.asset_tracker_v2.low-power
-    - applications.asset_tracker_v2.lwm2m.debug
-    - applications.asset_tracker_v2.lwm2m.debug-modem_trace
+    - applications.asset_tracker_v2.*
   comment: "build failure on Windows after Zephyr upmerge - NCSIDB-1039"


### PR DESCRIPTION
Quarantine all asset_tracker_v2 tests untill issue NCSIDB-1039 is fixed.
Remove wifi-debug test as it is added to general quarantine file.