### PR TITLE
doc: nrf_security name change

### DIFF
--- a/doc/nrf/libraries/nrf_security/doc/configuration.rst
+++ b/doc/nrf/libraries/nrf_security/doc/configuration.rst
@@ -7,15 +7,15 @@ Configuration
    :local:
    :depth: 2
 
-You can enable the Nordic Security Module using `PSA crypto support`_ or `Legacy crypto support`_.
+You can enable the nRF Security subsystem using `PSA crypto support`_ or `Legacy crypto support`_.
 
-To enable the Nordic Security Module, set the :kconfig:option:`CONFIG_NRF_SECURITY` Kconfig option along with additional configuration options, as described in :ref:`nrf_security_driver_config`.
+To enable nRF Security, set the :kconfig:option:`CONFIG_NRF_SECURITY` Kconfig option along with additional configuration options, as described in :ref:`nrf_security_driver_config`.
 This includes PSA crypto support by default.
 
 PSA crypto support
 ******************
 
-PSA crypto support is included by default when you enable Nordic Security Module through the :kconfig:option:`CONFIG_NRF_SECURITY` Kconfig option.
+PSA crypto support is included by default when you enable nRF Security through the :kconfig:option:`CONFIG_NRF_SECURITY` Kconfig option.
 PSA crypto support is provided through PSA Crypto APIs and is implemented by PSA core.
 PSA core uses PSA drivers to implement the cryptographic features either in software, or using hardware accelerators.
 
@@ -24,13 +24,13 @@ PSA core uses PSA drivers to implement the cryptographic features either in soft
 Legacy crypto support
 *********************
 
-To enable the legacy crypto support mode of Nordic Security Module, set both the :kconfig:option:`CONFIG_NORDIC_SECURITY_BACKEND` and :kconfig:option:`CONFIG_NRF_SECURITY` Kconfig options along with additional configuration options, as described in :ref:`nrf_security_legacy_config`.
+To enable the legacy crypto support mode of nRF Security, set both the :kconfig:option:`CONFIG_NORDIC_SECURITY_BACKEND` and :kconfig:option:`CONFIG_NRF_SECURITY` Kconfig options along with additional configuration options, as described in :ref:`nrf_security_legacy_config`.
 The legacy crypto support allows backwards compatibility for software that requires usage of Mbed TLS crypto toolbox functions prefixed with ``mbedtls_``.
 
 Custom Mbed TLS configuration files
 ***********************************
 
-The Nordic Security Module (nrf_security) Kconfig options are used to generate an Mbed TLS configuration file.
+The nRF Security Kconfig options are used to generate an Mbed TLS configuration file.
 
 Although not recommended, it is possible to provide a custom Mbed TLS configuration file by disabling :kconfig:option:`CONFIG_GENERATE_MBEDTLS_CFG_FILE`.
 See :ref:`nrf_security_tls_header`.
@@ -39,4 +39,4 @@ Building with TF-M
 ******************
 
 If :kconfig:option:`CONFIG_BUILD_WITH_TFM` is enabled together with :kconfig:option:`CONFIG_NRF_SECURITY`, the TF-M secure image will enable the use of the hardware acceleration of Arm CryptoCell.
-In this case, the Kconfig configurations in the Nordic Security Module control the features enabled in TF-M.
+In this case, the Kconfig configurations in the nRF Security subsystem control the features enabled in TF-M.

--- a/doc/nrf/libraries/nrf_security/doc/drivers.rst
+++ b/doc/nrf/libraries/nrf_security/doc/drivers.rst
@@ -1,13 +1,13 @@
 .. _nrf_security_drivers:
 
-nrf_security drivers
+nRF Security drivers
 ####################
 
 .. contents::
    :local:
    :depth: 2
 
-The nrf_security module supports multiple enabled PSA drivers at the same time.
+The nRF Security subsystem supports multiple enabled PSA drivers at the same time.
 This mechanism is intended to extend the available feature set of hardware-accelerated cryptography or to provide alternative implementations of the PSA Crypto APIs.
 
 You can enable a cryptographic feature or algorithm using PSA Crypto API configurations that follow the format ``PSA_WANT_ALG_XXXX``.
@@ -16,7 +16,7 @@ Enabling more than one PSA driver might add support for additional key sizes or 
 
 It is possible to disable specific features on the PSA driver level to optimize the code size.
 
-The nrf_security module supports the following PSA drivers:
+The nRF Security supports the following PSA drivers:
 
 * Arm CryptoCell cc3xx binary
 * nrf_oberon binary

--- a/doc/nrf/libraries/nrf_security/doc/mbed_tls_header.rst
+++ b/doc/nrf/libraries/nrf_security/doc/mbed_tls_header.rst
@@ -3,7 +3,7 @@
 User-provided Mbed TLS config header
 ####################################
 
-The Nordic Security Module provides a Kconfig interface to control compilation and linking of Mbed TLS and the :ref:`nrf_cc3xx_mbedcrypto_readme` or :ref:`nrf_oberon_readme` libraries.
+The nRF Security subsystem provides a Kconfig interface to control compilation and linking of Mbed TLS and the :ref:`nrf_cc3xx_mbedcrypto_readme` or :ref:`nrf_oberon_readme` libraries.
 
 The Kconfig interface and build system ensures that the configuration of nrf_security is valid and working.
 It also ensures that dependencies between different cryptographic APIs are met.

--- a/doc/nrf/libraries/nrf_security/index.rst
+++ b/doc/nrf/libraries/nrf_security/index.rst
@@ -1,14 +1,14 @@
 .. _nrf_security_readme:
 .. _nrf_security:
 
-Nordic Security Module
-######################
+nRF Security
+############
 
-The Nordic Security Module (nrf_security) provides an integration between Mbed TLS and software libraries that provide hardware-accelerated cryptographic functionality on selected Nordic Semiconductor SoCs as well as alternate software-based implementations of the Mbed TLS APIs.
-This module includes a PSA driver abstraction layer to enable both hardware-accelerated and software-based implementation at the same time.
+The nRF Security subsystem (nrf_security) provides an integration between Mbed TLS and software libraries that provide hardware-accelerated cryptographic functionality on selected Nordic Semiconductor SoCs as well as alternate software-based implementations of the Mbed TLS APIs.
+The subsystem includes a PSA driver abstraction layer to enable both hardware-accelerated and software-based implementation at the same time.
 
-The nrf_security module can interface with the :ref:`nrf_cc3xx_mbedcrypto_readme`.
-This library conforms to the specific revision of Mbed TLS that is supplied through the nRF Connect SDK.
+The nRF Security subsystem can interface with the :ref:`nrf_cc3xx_mbedcrypto_readme`.
+This library conforms to the specific revision of Mbed TLS that is supplied through the |NCS|.
 
 .. toctree::
    :maxdepth: 2

--- a/doc/nrf/releases_and_maturity/known_issues.rst
+++ b/doc/nrf/releases_and_maturity/known_issues.rst
@@ -2809,7 +2809,7 @@ NCSDK-5546: Oberon missing symbols for HKDF
 
 .. rst-class:: v1-3-1 v1-3-0
 
-Limited support for Nordic Security Module
+Limited support for nRF Security subsystem (previously called Nordic Security Module)
   The :ref:`nrf_security` is currently only fully supported on nRF52840 and nRF9160 devices.
   It gives compile errors on nRF52832, nRF52833, nRF52820, nRF52811, and nRF52810.
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -768,15 +768,19 @@ Libraries for NFC
   * Fixed the ISO-DEP error recovery process in case where the R(ACK) frame is received in response to the R(NAK) frame from the poller device.
     The poller device raised a false semantic error instead of resending the last I-block.
 
-Nordic Security Module
-----------------------
+nRF Security
+------------
 
-* :ref:`nrf_security` library:
+The following changes are applied to :ref:`nrf_security` library:
 
-  * Removed:
+* Updated:
 
-    * Option to build Mbed TLS builtin PSA core (:kconfig:option:`CONFIG_PSA_CORE_BUILTIN`).
-    * Option to build Mbed TLS builtin PSA crypto driver (:kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_BUILTIN`) and all its associated algorithms (``CONFIG_MBEDTLS_PSA_BUILTIN_ALG_xxx``).
+  * The subsystem and its library are renamed from Nordic Security Module to nRF Security.
+
+* Removed:
+
+  * Option to build Mbed TLS builtin PSA core (:kconfig:option:`CONFIG_PSA_CORE_BUILTIN`).
+  * Option to build Mbed TLS builtin PSA crypto driver (:kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_BUILTIN`) and all its associated algorithms (``CONFIG_MBEDTLS_PSA_BUILTIN_ALG_xxx``).
 
 Other libraries
 ---------------

--- a/subsys/nrf_security/Kconfig
+++ b/subsys/nrf_security/Kconfig
@@ -4,19 +4,19 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-menu "nrf_security module"
+menu "nRF Security"
 
 config NORDIC_SECURITY_PROMPTLESS
 	bool
 	help
-	  Internal setting to disable the Nordic security backend
+	  Internal setting to disable the Nordic security backend.
 	  This setting is Kconfig internal that must be used by subsystems that
-	  provides nRF Security selection groups.
+	  provide nRF Security selection groups.
 
 
 config NORDIC_SECURITY_BACKEND
 	bool
-	prompt "Use nrf_security with Mbed TLS legacy crypto APIs support" \
+	prompt "Use nRF Security with Mbed TLS legacy crypto APIs support" \
 		if !NORDIC_SECURITY_PROMPTLESS
 	default y if BUILD_WITH_TFM
 	depends on SOC_FAMILY_NRF
@@ -32,13 +32,13 @@ config NORDIC_SECURITY_BACKEND
 
 config NRF_SECURITY
 	bool
-	prompt "Use nrf_security module" if !PSA_PROMPTLESS
+	prompt "Enable nRF Security" if !PSA_PROMPTLESS
 	depends on SOC_FAMILY_NRF
 	default y if BUILD_WITH_TFM
 	select ENTROPY_GENERATOR
 	select DISABLE_MBEDTLS_BUILTIN if MBEDTLS
 	help
-	  Set this configuration to enable nrf_security module. This provides
+	  Set this configuration to enable nRF Security. This provides
 	  Arm PSA cryptography APIs with RNG support (optionally).
 
 config PSA_PROMPTLESS

--- a/subsys/nrf_security/cmake/nrf_security_debug.cmake
+++ b/subsys/nrf_security/cmake/nrf_security_debug.cmake
@@ -3,12 +3,12 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
-# The purpose of this file is to provice a set of debug commands to nrf security
-# module.
+# The purpose of this file is to provide a set of debug commands to nRF Security
+# subsystem.
 
 
 #
-# Internal macro that shows debug output in for nrf_security related
+# Internal macro that shows debug output in for nRF Security related
 # configurations when Cmake is run with -DDEBUG_NRF_SECURITY=1
 #
 macro(nrf_security_debug)

--- a/tests/crypto/README.rst
+++ b/tests/crypto/README.rst
@@ -143,7 +143,7 @@ Building and running
 .. include:: /includes/build_and_run_test.txt
 
 There are multiple ways to build the tests.
-See :ref:`nrf_security` for additional information about configuring the Nordic Security Module.
+See :ref:`nrf_security` for additional information about configuring the nRF Security subsystem.
 You can use the following configuration files to build the test in a specific setup:
 
 * :file:`overlay-cc3xx.conf` uses hardware acceleration using the Arm CryptoCell accelerator (for cryptography and entropy for random number generation).


### PR DESCRIPTION
Changing the name of Nordic Security Module
to remove the module reference
(as it is a subsystem and not actually a module)