### PR TITLE
scripts: requirements-build.txt: Update zcbor version

### DIFF
--- a/scripts/requirements-build.txt
+++ b/scripts/requirements-build.txt
@@ -5,4 +5,4 @@ imagesize>=1.2.0
 intelhex
 protobuf
 pylint
-zcbor==0.5.1
+zcbor>=0.7.0


### PR DESCRIPTION
The zcbor script needs to be newer to work with the given zcbor library.

NCSDK-22604