### PR TITLE
manifest: Update sdk-zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 35510c3d8e95826803ffaee1bb678163e1846320
+      revision: 9a0b8a317a91089f048c38233635240f21ab298d
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Change updates manifest to pull Bluetooth host new bt_conn_set_bondable() function which allows to set bondable flag per connection.

Jira: NCSDK-21190