### PR TITLE
Llpm sample connect directly to 1ms

### DIFF
--- a/samples/bluetooth/llpm/README.rst
+++ b/samples/bluetooth/llpm/README.rst
@@ -106,33 +106,32 @@ After programming the sample to both development kits, test it by performing the
 
    - The central outputs the following information::
 
-       Press any key to set LLPM short connection connection interval (1 ms)
+       Press any key to start measuring transmission latency
 
    - The peripheral outputs the following information::
 
        Press any key to start measuring transmission latency
 
 #. Press a key in the terminal that is connected to the peripheral.
-#. Observe the terminal connected to the peripheral. The latency measurements are printed in the terminal.
-   The latency is expected to be shorter than the default connection interval::
+#. Observe the terminal connected to the peripheral.
+   The latency measurements are printed in the terminal.
+   The latency is expected to be around 1 ms.
 
-       Transmission Latency: 80917 (us), CRC mismatches: 0
+       Transmission Latency: 1083 (us), CRC mismatches: 0
 
 #. Press a key in the terminal that is connected to the central.
-#. Observe the connection gets updated to LLPM connection interval (1 ms) on both sides::
-
-       Connection interval updated: LLPM (1 ms)
-
 #. Observe the terminal connected to the peripheral.
    The measured latency on the peripheral becomes approximate 1 ms::
 
        Transmission Latency: 1098 (us), CRC mismatches: 0
 
-#. Press a key in the terminal that is connected to the central.
-#. Observe the terminal connected to the central.
-   The measured latency on the central remains approximate 1 ms::
+#. Observe the central switches to standard 7.5 ms interval right after performing latency measurements.
 
-       Transmission Latency: 1235 (us), CRC mismatches: 0
+#. Observe the terminal connected to the central.
+   The latency is higher now.
+
+   Connection interval updated: 7.5 ms
+   Transmission Latency: 4592 (us), CRC mismatches: 0
 
 .. msc::
    hscale = "1.3";
@@ -162,99 +161,132 @@ The result should look similar to the following output.
 
 - For the central::
 
-   ***** Booting Zephyr OS build v1.14.99-ncs3-snapshot2-2647-gd6e67554cfeb *****
+   *** Booting Zephyr OS build v3.3.99-ncs1-2858-gc9d01d05ce83 ***
+   Starting Bluetooth LLPM example
+   I: SoftDevice Controller build revision:
+   I: 01 2d a8 d4 0d e5 25 cf |.-....%.
+   I: a3 48 8d 2f 56 e0 59 c8 |.H./V.Y.
+   I: 24 df 3d 58             |$.=X
+   I: HW Platform: Nordic Semiconductor (0x0002)
+   I: HW Variant: nRF52x (0x0002)
+   I: Firmware: Standard Bluetooth controller (0x00) Version 1.43053 Build 635768276
+   I: Identity: FF:FA:56:08:E1:DD (random)
+   I: HCI: version 5.4 (0x0d) revision 0x10b7, manufacturer 0x0059
+   I: LMP: version 5.4 (0x0d) subver 0x10b7
    Bluetooth initialized
    LLPM mode enabled
-   Choose device role - type c (central) or p (peripheral): c
+   Choose device role - type c (central) or p (peripheral):
    Central. Starting scanning
    Scanning successfully started
-   Connection event reports enabled
-   Filter not match. Address: 08:c6:a4:e0:72:e9 (random) connectable: 0
-   Filter not match. Address: 13:04:eb:f1:0b:46 (random) connectable: 0
-   Filter not match. Address: 2b:74:72:c3:8f:a8 (random) connectable: 0
-   Filter not match. Address: 02:ec:f9:bb:ec:27 (random) connectable: 0
-   Filter not match. Address: 01:54:cf:d4:31:cd (random) connectable: 0
-   Filter not match. Address: 3e:21:91:91:52:82 (random) connectable: 0
-   Filter not match. Address: 08:c6:a4:e0:72:e9 (random) connectable: 0
-   Filter not match. Address: 37:63:6a:ed:38:e2 (random) connectable: 0
-   Filter not match. Address: 56:c6:75:17:80:d8 (random) connectable: 1
-   Filters matched. Address: f9:3c:9c:d1:f6:07 (random) connectable: 1
+   Filter does not match. Address: 1F:25:BE:AC:D4:47 (random) connectable: 0
+   Filter does not match. Address: 5E:29:3A:8C:5A:8D (random) connectable: 0
+   Filter does not match. Address: 2C:E8:67:EA:C9:27 (random) connectable: 1
+   Filters matched. Address: C3:06:3D:25:7F:73 (random) connectable: 1
+   Filter does not match. Address: EA:0E:68:82:9D:0C (random) connectable: 1
+   Filter does not match. Address: 1B:CC:D4:7C:9E:31 (random) connectable: 0
    Connected as central
-   Conn. interval is 80 units (1.25 ms/unit)
+   Conn. interval is 3329 units (1.25 ms/unit)
+   Security changed: level 2, err: 0
    Service discovery completed
-   Press any key to set LLPM short connection interval (1 ms)
    Press any key to start measuring transmission latency
-   Connection interval updated: LLPM (1 ms)
-   Transmission Latency: 1235 (us), CRC mismatches: 0
-   Transmission Latency: 1007 (us), CRC mismatches: 0
-   Transmission Latency: 1434 (us), CRC mismatches: 0
-   Transmission Latency: 1312 (us), CRC mismatches: 0
-   Transmission Latency: 1220 (us), CRC mismatches: 0
-   Transmission Latency: 991 (us), CRC mismatches: 0
-   Transmission Latency: 1419 (us), CRC mismatches: 0
-   Transmission Latency: 1281 (us), CRC mismatches: 0
-   Transmission Latency: 1052 (us), CRC mismatches: 0
-   Transmission Latency: 991 (us), CRC mismatches: 0
-   Transmission Latency: 1403 (us), CRC mismatches: 0
+   Transmission Latency: 1037 (us), CRC mismatches: 0
    Transmission Latency: 1296 (us), CRC mismatches: 0
+   Transmission Latency: 1342 (us), CRC mismatches: 0
+   Transmission Latency: 1419 (us), CRC mismatches: 0
+   Transmission Latency: 961 (us), CRC mismatches: 0
    Transmission Latency: 1052 (us), CRC mismatches: 0
-   Transmission Latency: 976 (us), CRC mismatches: 0
-   Transmission Latency: 1358 (us), CRC mismatches: 0
-   Transmission Latency: 1281 (us), CRC mismatches: 0
+   Transmission Latency: 1296 (us), CRC mismatches: 0
+   Transmission Latency: 1342 (us), CRC mismatches: 0
+   Transmission Latency: 1419 (us), CRC mismatches: 0
+   Transmission Latency: 961 (us), CRC mismatches: 0
    Transmission Latency: 1052 (us), CRC mismatches: 0
-   Transmission Latency: 976 (us), CRC mismatches: 0
-   Transmission Latency: 1358 (us), CRC mismatches: 0
-   Transmission Latency: 1281 (us), CRC mismatches: 0
+   Transmission Latency: 1296 (us), CRC mismatches: 0
+   Transmission Latency: 1342 (us), CRC mismatches: 0
+   Transmission Latency: 1419 (us), CRC mismatches: 0
+   Transmission Latency: 961 (us), CRC mismatches: 0
    Transmission Latency: 1052 (us), CRC mismatches: 0
-   Transmission Latency: 976 (us), CRC mismatches: 0
-   Transmission Latency: 1358 (us), CRC mismatches: 0
-   Transmission Latency: 1281 (us), CRC mismatches: 0
+   Transmission Latency: 1296 (us), CRC mismatches: 0
+   Transmission Latency: 1342 (us), CRC mismatches: 0
+   Transmission Latency: 1419 (us), CRC mismatches: 0
+   Transmission Latency: 961 (us), CRC mismatches: 0
+   Transmission Latency: 1052 (us), CRC mismatches: 0
+   Transmission Latency: 1296 (us), CRC mismatches: 0
+   Transmission Latency: 1342 (us), CRC mismatches: 0
+   Transmission Latency: 1419 (us), CRC mismatches: 0
+   Transmission Latency: 961 (us), CRC mismatches: 0
+   Connection interval updated: 7.5 ms
+   Transmission Latency: 1922 (us), CRC mismatches: 0
+   Transmission Latency: 7064 (us), CRC mismatches: 0
+   Transmission Latency: 13244 (us), CRC mismatches: 0
+   Transmission Latency: 4592 (us), CRC mismatches: 0
+   Transmission Latency: 7019 (us), CRC mismatches: 0
+   Transmission Latency: 5691 (us), CRC mismatches: 0
+   Transmission Latency: 4592 (us), CRC mismatches: 0
+   Transmission Latency: 7019 (us), CRC mismatches: 0
+   Transmission Latency: 5706 (us), CRC mismatches: 0
+   Transmission Latency: 4577 (us), CRC mismatches: 0
+   Transmission Latency: 7019 (us), CRC mismatches: 0
+   Transmission Latency: 5706 (us), CRC mismatches: 0
+   Transmission Latency: 4592 (us), CRC mismatches: 0
+   Transmission Latency: 7019 (us), CRC mismatches: 0
+   Transmission Latency: 5691 (us), CRC mismatches: 0
+   Transmission Latency: 4592 (us), CRC mismatches: 0
+   Transmission Latency: 7019 (us), CRC mismatches: 0
+   Transmission Latency: 5706 (us), CRC mismatches: 0
 
 - For the peripheral::
 
-   ***** Booting Zephyr OS build v1.14.99-ncs3-snapshot2-2647-gd6e67554cfeb *****
+   *** Booting Zephyr OS build v3.3.99-ncs1-2858-gc9d01d05ce83 ***
+   Starting Bluetooth LLPM example
+   I: SoftDevice Controller build revision:
+   I: 01 2d a8 d4 0d e5 25 cf |.-....%.
+   I: a3 48 8d 2f 56 e0 59 c8 |.H./V.Y.
+   I: 24 df 3d 58             |$.=X
+   I: HW Platform: Nordic Semiconductor (0x0002)
+   I: HW Variant: nRF52x (0x0002)
+   I: Firmware: Standard Bluetooth controller (0x00) Version 1.43053 Build 635768276
+   I: Identity: C3:06:3D:25:7F:73 (random)
+   I: HCI: version 5.4 (0x0d) revision 0x10b7, manufacturer 0x0059
+   I: LMP: version 5.4 (0x0d) subver 0x10b7
    Bluetooth initialized
    LLPM mode enabled
-   Choose device role - type c (central) or p (peripheral): p
-   Slave role. Starting advertising
+   Choose device role - type c (central) or p (peripheral):
+   Peripheral. Starting advertising
    Advertising successfully started
    Connection event reports enabled
-   Filter not match. Address: 1d:18:b1:84:fd:05 (random) connectable: 0
-   Filter not match. Address: 00:92:3f:a6:3f:48 (random) connectable: 0
-   Filter not match. Address: 02:ec:f9:bb:ec:27 (random) connectable: 0
-   Filter not match. Address: 3e:21:91:91:52:82 (random) connectable: 0
-   Filter not match. Address: 08:c6:a4:e0:72:e9 (random) connectable: 0
-   Filter not match. Address: 13:04:eb:f1:0b:46 (random) connectable: 0
-   Filter not match. Address: cb:01:1a:2d:6e:ae (random) connectable: 1
-   Filter not match. Address: 5c:f2:70:c2:3f:9f (random) connectable: 1
+   W: opcode 0x200a status 0x0d
    Connected as peripheral
-   Conn. interval is 80 units (1.25 ms/unit)
+   Conn. interval is 3329 units (1.25 ms/unit)
+   W: opcode 0x2032 status 0x3a
+   E: Failed LE Set PHY (-5)
+   Security changed: level 2, err: 0
    Service discovery completed
    Press any key to start measuring transmission latency
-   Transmission Latency: 80917 (us), CRC mismatches: 0
-   Transmission Latency: 80841 (us), CRC mismatches: 0
-   Transmission Latency: 80749 (us), CRC mismatches: 0
-   Transmission Latency: 80673 (us), CRC mismatches: 0
-   Transmission Latency: 80596 (us), CRC mismatches: 0
-   Transmission Latency: 80505 (us), CRC mismatches: 0
-   Transmission Latency: 80429 (us), CRC mismatches: 0
-   Transmission Latency: 80337 (us), CRC mismatches: 0
-   Transmission Latency: 80261 (us), CRC mismatches: 0
-   Transmission Latency: 80184 (us), CRC mismatches: 0
-   Transmission Latency: 80093 (us), CRC mismatches: 0
-   Transmission Latency: 80017 (us), CRC mismatches: 0
-   Transmission Latency: 79940 (us), CRC mismatches: 0
-   Transmission Latency: 79849 (us), CRC mismatches: 0
-   Connection interval updated: LLPM (1 ms)
-   Transmission Latency: 81604 (us), CRC mismatches: 0
-   Transmission Latency: 30181 (us), CRC mismatches: 0
-   Transmission Latency: 1098 (us), CRC mismatches: 0
-   Transmission Latency: 1129 (us), CRC mismatches: 0
-   Transmission Latency: 1037 (us), CRC mismatches: 0
-   Transmission Latency: 930 (us), CRC mismatches: 0
-   Transmission Latency: 1312 (us), CRC mismatches: 0
    Transmission Latency: 1083 (us), CRC mismatches: 0
+   Transmission Latency: 1312 (us), CRC mismatches: 0
+   Transmission Latency: 900 (us), CRC mismatches: 0
    Transmission Latency: 1007 (us), CRC mismatches: 0
+   Transmission Latency: 1052 (us), CRC mismatches: 0
+   Transmission Latency: 1083 (us), CRC mismatches: 0
+   Transmission Latency: 1358 (us), CRC mismatches: 0
+   Transmission Latency: 915 (us), CRC mismatches: 0
+   Transmission Latency: 1007 (us), CRC mismatches: 0
+   Transmission Latency: 1052 (us), CRC mismatches: 0
+   Transmission Latency: 1098 (us), CRC mismatches: 0
+   Transmission Latency: 1296 (us), CRC mismatches: 0
+   Transmission Latency: 900 (us), CRC mismatches: 0
+   Transmission Latency: 1007 (us), CRC mismatches: 0
+   Connection interval updated: 7.5 ms
+   Transmission Latency: 1052 (us), CRC mismatches: 0
+   Transmission Latency: 7247 (us), CRC mismatches: 0
+   Transmission Latency: 5950 (us), CRC mismatches: 0
+   Transmission Latency: 4867 (us), CRC mismatches: 0
+   Transmission Latency: 7293 (us), CRC mismatches: 0
+   Transmission Latency: 5996 (us), CRC mismatches: 0
+   Transmission Latency: 4913 (us), CRC mismatches: 0
+   Transmission Latency: 7385 (us), CRC mismatches: 0
+   Transmission Latency: 6088 (us), CRC mismatches: 0
+   Transmission Latency: 5004 (us), CRC mismatches: 0
 
 
 Dependencies

--- a/samples/bluetooth/llpm/src/main.c
+++ b/samples/bluetooth/llpm/src/main.c
@@ -27,9 +27,9 @@
 
 #define DEVICE_NAME	CONFIG_BT_DEVICE_NAME
 #define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
-#define INTERVAL_MIN    0x6     /* 6 units,  7.5 ms */
-#define INTERVAL_MAX    0x6     /* 6 units,  7.5 ms */
-#define INTERVAL_LLPM   0x0D01   /* Proprietary  1 ms */
+#define INTERVAL_MIN      0x6    /* 6 units,  7.5 ms */
+#define INTERVAL_MIN_US  7500    /* 7.5 ms */
+#define INTERVAL_LLPM  0x0D01    /* Proprietary  1 ms */
 #define INTERVAL_LLPM_US 1000
 
 
@@ -39,7 +39,7 @@ static struct bt_conn *default_conn;
 static struct bt_latency latency;
 static struct bt_latency_client latency_client;
 static struct bt_le_conn_param *conn_param =
-	BT_LE_CONN_PARAM(INTERVAL_MIN, INTERVAL_MAX, 0, 400);
+	BT_LE_CONN_PARAM(INTERVAL_LLPM, INTERVAL_LLPM, 0, 400);
 static struct bt_conn_info conn_info = {0};
 
 static const struct bt_data ad[] = {
@@ -230,6 +230,9 @@ static void le_param_updated(struct bt_conn *conn, uint16_t interval,
 {
 	if (interval == INTERVAL_LLPM) {
 		printk("Connection interval updated: LLPM (1 ms)\n");
+	} else {
+		__ASSERT_NO_MSG(interval == INTERVAL_MIN);
+		printk("Connection interval updated: 7.5 ms\n");
 	}
 }
 
@@ -259,7 +262,7 @@ static int enable_llpm_mode(void)
 	return 0;
 }
 
-static int enable_llpm_short_connection_interval(void)
+static int vs_change_connection_interval(uint16_t interval_us)
 {
 	int err;
 	struct net_buf *buf;
@@ -283,7 +286,7 @@ static int enable_llpm_short_connection_interval(void)
 
 	cmd_conn_update = net_buf_add(buf, sizeof(*cmd_conn_update));
 	cmd_conn_update->connection_handle   = conn_handle;
-	cmd_conn_update->conn_interval_us    = INTERVAL_LLPM_US;
+	cmd_conn_update->conn_interval_us    = interval_us;
 	cmd_conn_update->conn_latency        = 0;
 	cmd_conn_update->supervision_timeout = 300;
 
@@ -367,24 +370,12 @@ static const struct bt_latency_client_cb latency_client_cb = {
 static void test_run(void)
 {
 	int err;
-
 	if (!test_ready) {
 		/* disconnected while blocking inside _getchar() */
 		return;
 	}
 
 	test_ready = false;
-
-	/* Switch to LLPM short connection interval */
-	if (conn_info.role == BT_CONN_ROLE_CENTRAL) {
-		printk("Press any key to set LLPM short connection interval (1 ms)\n");
-		console_getchar();
-
-		if (enable_llpm_short_connection_interval()) {
-			printk("Enable LLPM short connection interval failed\n");
-			return;
-		}
-	}
 
 	printk("Press any key to start measuring transmission latency\n");
 	console_getchar();
@@ -409,6 +400,27 @@ static void test_run(void)
 		}
 
 		memset(&llpm_latency, 0, sizeof(llpm_latency));
+		if (conn_info.role == BT_CONN_ROLE_CENTRAL) {
+			static int counter;
+			static uint16_t interval_us = INTERVAL_LLPM_US;
+
+			counter++;
+			/* Arbitrarily chosen number of measurments
+			 * to do before switching interval
+			 */
+			if (counter == 20) {
+				counter = 0;
+				if (interval_us == INTERVAL_LLPM_US) {
+					interval_us = INTERVAL_MIN_US;
+				} else {
+					interval_us = INTERVAL_LLPM_US;
+				}
+				if (vs_change_connection_interval(interval_us)) {
+					printk("Enable LLPM short connection interval failed\n");
+					return;
+				}
+			}
+		}
 	}
 }
 

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -103,6 +103,7 @@ config SYSTEM_WORKQUEUE_STACK_SIZE
 config BT_CTLR_SDC_LLPM
 	bool "Enable Low Latency Packet Mode support"
 	depends on SOC_SERIES_NRF52X
+	select BT_CONN_PARAM_ANY
 	help
 	  Low Latency Packet Mode (LLPM) is a Nordic proprietary addition
 	  which lets the application use connection intervals down to 1 ms.


### PR DESCRIPTION
samples: bluetooth: Connect directly to 1ms in llpm sample
    
This improves speed of setting up encryption and doing service discovery by alot.

doing the minimum now in this PR, we can probably also get rid of the vs hci command  (SDC_HCI_OPCODE_CMD_VS_CONN_UPDATE) and use the zephyr funciton to change connection interval now. but that will be in a later PR 