### PR TITLE
manifest: pull Matter fix for IPv4 builds

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -148,7 +148,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: ab1abc1ed9c8a4342b55782aae7416b860f5d89d
+      revision: 8fe5bee7b651f4a375fd5afd306f1576b42a4db6
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
This change allows to build nrfconnect SDK samples with Matter over IPv6 but IPv4 still available for third party development within the same application.