### PR TITLE
applications: asset_tracker_v2: Fix adxl372 configuration on Thingy:91

### DIFF
--- a/applications/asset_tracker_v2/boards/thingy91_nrf9160_ns.overlay
+++ b/applications/asset_tracker_v2/boards/thingy91_nrf9160_ns.overlay
@@ -22,4 +22,10 @@
 	adxl362: adxl362@0 {
 		autosleep;
 	};
+
+	adxl372: adxl372@1 {
+		odr = <4>;
+		bw = <4>;
+		hpf = <0>;
+	};
 };


### PR DESCRIPTION
In a change to the adxl372 driver in Zephyr, the configuration of the sample rate, high-pass and low-pass corner frequencies was moved from Kconfig to the devicetree.

This PR updates the devicetree overlay to configure these parameters as required for the impact detection, using the previous default Kconfig values.