### PR TITLE
caf: buttons: Add selective wakeup functionality

### DIFF
--- a/doc/nrf/libraries/caf/buttons.rst
+++ b/doc/nrf/libraries/caf/buttons.rst
@@ -119,7 +119,7 @@ For example, if the configuration file looks as described in the `Configuration`
 Power management states
 =======================
 
-If the :kconfig:option:`CONFIG_CAF_BUTTONS_PM_EVENTS` Kconfig option is enabled, the module can react to power management events and submit ``wake_up_event``.
+If the :kconfig:option:`CONFIG_CAF_BUTTONS_PM_EVENTS` Kconfig option is enabled, the module can react to power management events and submit :c:struct:`wake_up_event`.
 In that case, the following additional states are available:
 
 * ``STATE_SUSPENDING``
@@ -127,12 +127,12 @@ In that case, the following additional states are available:
 
 The power management events that module can react to are the following:
 
-* ``power_down_event``
-* ``wake_up_event``
+* :c:struct:`power_down_event`
+* :c:struct:`wake_up_event`
 
-If a ``power_down_event`` comes while the module is in the ``STATE_SCANNING`` state, the module switches to ``STATE_SUSPENDING`` and remains in this state until no button is pressed.
+If a :c:struct:`power_down_event` comes while the module is in the ``STATE_SCANNING`` state, the module switches to ``STATE_SUSPENDING`` and remains in this state until no button is pressed.
 Then, it switches to ``STATE_IDLE``.
 
-If a ``power_down_event`` comes while the module is in the ``STATE_ACTIVE`` state, the module switches to ``STATE_IDLE`` immediately.
+If a :c:struct:`power_down_event` comes while the module is in the ``STATE_ACTIVE`` state, the module switches to ``STATE_IDLE`` immediately.
 Similarly, as in ``STATE_ACTIVE``, in ``STATE_IDLE`` the module enables the GPIO interrupts and waits for the pin state to change.
-However, in ``STATE_IDLE`` the module can also invoke ``wake_up_event`` and send it to all subscribing modules.
+However, in ``STATE_IDLE`` the module can also invoke :c:struct:`wake_up_event` and send it to all subscribing modules.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -522,6 +522,12 @@ Other libraries
 Common Application Framework (CAF)
 ----------------------------------
 
+* :ref:`caf_buttons`:
+
+  * Added selective wakeup functionality.
+    The module's configuration file can specify a subset of buttons that is not used to trigger an application wakeup.
+    Each row and column specifies an additional flag (:c:member:`gpio_pin.wakeup_blocked`) that can be set to prevent an entire row or column of buttons from acting as a wakeup source.
+
 * :ref:`caf_ble_adv`:
 
   * Updated the dependencies of the :kconfig:option:`CONFIG_CAF_BLE_ADV_FILTER_ACCEPT_LIST` Kconfig option so that it can be used when the Bluetooth controller is running on the network core.

--- a/include/caf/gpio_pins.h
+++ b/include/caf/gpio_pins.h
@@ -7,9 +7,13 @@
 #ifndef _GPIO_PINS_H_
 #define _GPIO_PINS_H_
 
+#include <stdbool.h>
+#include <stdint.h>
+
 struct gpio_pin {
 	uint8_t port;
 	uint8_t pin;
+	bool wakeup_blocked;
 };
 
 #endif /* _GPIO_PINS_H_ */

--- a/subsys/caf/modules/buttons.c
+++ b/subsys/caf/modules/buttons.c
@@ -197,6 +197,11 @@ static int suspend(void)
 
 static void resume(void)
 {
+	if (state == STATE_SUSPENDING) {
+		state = STATE_SCANNING;
+		return;
+	}
+
 	if (state != STATE_IDLE) {
 		/* Already activated. */
 		return;

--- a/subsys/caf/modules/buttons.c
+++ b/subsys/caf/modules/buttons.c
@@ -56,6 +56,16 @@ static enum state state;
 
 static void scan_fn(struct k_work *work);
 
+static uint32_t get_wakeup_mask(const struct gpio_pin *pins, size_t cnt)
+{
+	uint32_t mask = BIT64_MASK(32);
+
+	for (size_t i = 0; i < cnt; i++) {
+		WRITE_BIT(mask, i, !pins[i].wakeup_blocked);
+	}
+
+	return mask;
+}
 
 static int set_cols(uint32_t mask)
 {
@@ -75,8 +85,16 @@ static int set_cols(uint32_t mask)
 						       col[i].pin, val);
 			}
 		} else {
-			err = gpio_pin_configure(gpio_devs[col[i].port],
-						 col[i].pin, GPIO_INPUT);
+			gpio_flags_t flags = GPIO_INPUT;
+			gpio_flags_t pull = (IS_ENABLED(CONFIG_CAF_BUTTONS_POLARITY_INVERSED) ?
+					    (GPIO_PULL_UP) : (GPIO_PULL_DOWN));
+
+			/* The pull is necessary to ensure pin state and prevent unexpected
+			 * behaviour that could be triggered by accumulating charge.
+			 */
+			flags |= pull;
+
+			err = gpio_pin_configure(gpio_devs[col[i].port], col[i].pin, flags);
 		}
 
 		if (err) {
@@ -127,7 +145,7 @@ static int set_trig_mode(void)
 	return err;
 }
 
-static int callback_ctrl(bool enable)
+static int callback_ctrl(uint32_t enable_mask)
 {
 	int err = 0;
 
@@ -143,7 +161,7 @@ static int callback_ctrl(bool enable)
 	 */
 
 	for (size_t i = 0; (i < ARRAY_SIZE(row)) && !err; i++) {
-		if (enable) {
+		if (enable_mask & BIT(i)) {
 			/* Level interrupt is needed to leave deep sleep mode.
 			 * Edge interrupt gives only 7 channels. It is not
 			 * suitable for larger matrix/number of GPIO buttons.
@@ -160,11 +178,32 @@ static int callback_ctrl(bool enable)
 							   GPIO_INT_DISABLE);
 		}
 	}
-	if (!enable) {
+	if (!enable_mask) {
 		/* Callbacks are disabled but they could fire in the meantime.
 		 * Make sure pending work is canceled.
 		 */
 		k_work_cancel_delayable(&button_pressed);
+	}
+
+	return err;
+}
+
+static int setup_pin_wakeup(void)
+{
+	uint32_t wakeup_cols = get_wakeup_mask(col, ARRAY_SIZE(col));
+	uint32_t wakeup_rows = get_wakeup_mask(row, ARRAY_SIZE(row));
+
+	/* Disable callbacks (and cancel the work) to ensure it will not be scheduled by an
+	 * invalid button in the idle state.
+	 */
+	int err = callback_ctrl(0);
+
+	if (!err) {
+		/* Setup callbacks and columns for the idle state. */
+		err = set_cols(wakeup_cols);
+		if (!err) {
+			err = callback_ctrl(wakeup_rows);
+		}
 	}
 
 	return err;
@@ -184,8 +223,11 @@ static int suspend(void)
 		break;
 
 	case STATE_ACTIVE:
-		state = STATE_IDLE;
-		err = callback_ctrl(true);
+		err = setup_pin_wakeup();
+		if (!err) {
+			state = STATE_IDLE;
+		}
+
 		break;
 
 	case STATE_IDLE:
@@ -212,16 +254,13 @@ static void resume(void)
 		return;
 	}
 
-	int err = callback_ctrl(false);
-	if (err) {
-		LOG_ERR("Cannot disable callbacks");
-	} else {
-		state = STATE_SCANNING;
-	}
+	int err = callback_ctrl(0);
 
 	if (err) {
+		LOG_ERR("Cannot disable callbacks");
 		module_set_state(MODULE_STATE_ERROR);
 	} else {
+		state = STATE_SCANNING;
 		scan_fn(NULL);
 
 		module_set_state(MODULE_STATE_READY);
@@ -252,7 +291,7 @@ static void scan_fn(struct k_work *work)
 	}
 
 	/* Avoid draining current between scans */
-	if (set_cols(0x00000000)) {
+	if (set_cols(0)) {
 		LOG_ERR("Cannot set neutral state");
 		goto error;
 	}
@@ -329,7 +368,11 @@ static void scan_fn(struct k_work *work)
 		switch (state) {
 		case STATE_SCANNING:
 			state = STATE_ACTIVE;
-			err = callback_ctrl(true);
+			err = callback_ctrl(BIT64_MASK(32));
+
+			if (!err) {
+				err = set_cols(BIT64_MASK(32));
+			}
 			break;
 
 		case STATE_SUSPENDING:
@@ -347,15 +390,10 @@ static void scan_fn(struct k_work *work)
 		}
 
 		if (err) {
-			LOG_ERR("Cannot enable callbacks");
+			LOG_ERR("Cannot enable callbacks or set neutral state");
 			goto error;
 		}
 
-		/* Prepare to wait for a callback */
-		if (set_cols(0xFFFFFFFF)) {
-			LOG_ERR("Cannot set neutral state");
-			goto error;
-		}
 	}
 
 	return;
@@ -371,7 +409,7 @@ static void button_pressed_isr(const struct device *gpio_dev,
 	int err = 0;
 
 	/* Scanning will be scheduled, switch off pins */
-	if (set_cols(0x00000000)) {
+	if (set_cols(0)) {
 		LOG_ERR("Cannot control pins");
 		err = -EFAULT;
 	}
@@ -407,7 +445,7 @@ static void button_pressed_isr(const struct device *gpio_dev,
 
 static void button_pressed_fn(struct k_work *work)
 {
-	int err = callback_ctrl(false);
+	int err = callback_ctrl(0);
 
 	if (err) {
 		LOG_ERR("Cannot disable callbacks");

--- a/subsys/caf/modules/buttons.c
+++ b/subsys/caf/modules/buttons.c
@@ -32,6 +32,11 @@ LOG_MODULE_REGISTER(MODULE, CONFIG_CAF_BUTTONS_LOG_LEVEL);
 /* For directly connected GPIO, scan rows once. */
 #define COLUMNS MAX(ARRAY_SIZE(col), 1)
 
+BUILD_ASSERT(ARRAY_SIZE(col) <= 32,
+	     "Implementation uses uint32_t for bitmasks and supports up to 32 columns");
+BUILD_ASSERT(ARRAY_SIZE(row) <= 32,
+	     "Implementation uses uint32_t for bitmasks and supports up to 32 rows");
+
 enum state {
 	STATE_IDLE,
 	STATE_ACTIVE,


### PR DESCRIPTION
Allow to specify a subset of buttons used to wake up application. The newly added configuration is disabled by default in *.def file
to ensure backwards compatibility.

Jira: NCSDK-22505