### PR TITLE
lib: identity_key: Fix missing enable of PSA dependencies

### DIFF
--- a/lib/identity_key/Kconfig
+++ b/lib/identity_key/Kconfig
@@ -11,10 +11,13 @@ menuconfig IDENTITY_KEY
 	depends on !TRUSTED_EXECUTION_NONSECURE
 	depends on MAIN_STACK_SIZE >= 2048
 	depends on ASSERT
+	select PSA_WANT_ALG_ECDSA # Needed to set implicit config PSA_WANT_KEY_TYPE_ECC_KEY_PAIR
+	select PSA_WANT_ECC_SECP_R1_256
 	help
 	  This option adds support for an identity key stored in the KMU.
 	  The key is stored in an encrypted form and is decrypted
 	  by the identity key APIs.
+	  The identity key is an ECC secp256r1 key pair.
 
 if IDENTITY_KEY
 

--- a/lib/identity_key/identity_key.c
+++ b/lib/identity_key/identity_key.c
@@ -40,7 +40,6 @@ static int generate_random_secp256r1_private_key(uint8_t *key_buff)
 	 */
 	psa_set_key_usage_flags(&key_attributes, PSA_KEY_USAGE_SIGN_HASH | PSA_KEY_USAGE_EXPORT);
 	psa_set_key_lifetime(&key_attributes, PSA_KEY_LIFETIME_VOLATILE);
-	psa_set_key_algorithm(&key_attributes, PSA_ALG_ECDSA(PSA_ALG_SHA_256));
 	psa_set_key_type(&key_attributes, PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1));
 	psa_set_key_bits(&key_attributes, IDENTITY_KEY_SIZE_BYTES * 8);
 

--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -201,9 +201,15 @@ config TFM_EXPERIMENTAL
 config TFM_PARTITION_INITIAL_ATTESTATION
 	bool
 	default y if !TFM_PROFILE_TYPE_MINIMAL
+	select PSA_WANT_ALG_SHA_256
+	select PSA_WANT_ALG_ECDSA
+	select PSA_WANT_ECC_SECP_R1_256
 	help
 	   We select "implementation ID" because it is a mandatory claim
 	   in the IAT.
+	   The initial attestation partition requires ECDSA algorithm with
+	   SHA-256 and and uses the Identity Key stored in the KMU.
+	   The identity key is a secp256r1 key pair.
 
 config TFM_QCBOR_PATH
 	string


### PR DESCRIPTION
Fix identity key sample regression after PSA WANT symbols was set to default disabled.
Enable the required PSA dependencies for the Identity Key library.