### PR TITLE
manifest: update zephyr with nrf_802154 ed_dbm public API change

### DIFF
--- a/samples/peripheral/802154_phy_test/src/rf_proc.c
+++ b/samples/peripheral/802154_phy_test/src/rf_proc.c
@@ -283,8 +283,10 @@ void nrf_802154_cca_failed(nrf_802154_cca_error_t error)
 	k_work_submit(&rf_cca_failed_wq);
 }
 
-void nrf_802154_energy_detected(uint8_t result)
+void nrf_802154_energy_detected(const nrf_802154_energy_detected_t *p_result)
 {
+	uint8_t result = nrf_802154_energy_level_from_dbm_calculate(p_result->ed_dbm);
+
 	LOG_INF("ED finished with result %d", result);
 
 	rf_ed_detected_info.result = result;

--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 036274a34fee62c6404e7a428f6c1d48d69a8966
+      revision: 9e7d6bbdf82f8d1fa17c1dc82c6a868554000025
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This commit brings in Zephyr with updates needed to adjust to changes in public API of nRF 802.15.4 Radio Driver.