### PR TITLE
applications: connectivity_bridge: Redirect logs to RTT

### DIFF
--- a/applications/connectivity_bridge/app.overlay
+++ b/applications/connectivity_bridge/app.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Nordic Semiconductor ASA
+ * Copyright (c) 2023 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
@@ -11,5 +11,20 @@
 
 	cdc_acm_uart1: cdc_acm_uart1 {
 		compatible = "zephyr,cdc-acm-uart";
+	};
+
+	rtt0: rtt_chan0 {
+		compatible = "segger,rtt-uart";
+		status = "okay";
+	};
+};
+
+/ {
+	chosen {
+		zephyr,console = &rtt0;
+		zephyr,shell-uart = &rtt0;
+		zephyr,uart-mcumgr = &rtt0;
+		zephyr,bt-mon-uart = &rtt0;
+		zephyr,bt-c2h-uart = &rtt0;
 	};
 };


### PR DESCRIPTION
This patch makes sure that logs are definitely routed to RTT. Previously, BLE logs would be routed towards the nRF91, causing parsing errors.