### PR TITLE
Bluetooth: Mesh: config options to use tfm and oberon

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -89,7 +89,7 @@ Bluetooth® LE
 Bluetooth mesh
 --------------
 
-|no_changes_yet_note|
+* Added support for Trusted Firmware-M (TF-M) PSA as the crypto backend for mesh security toolbox for the platforms with :ref:`CMSE enabled <app_boards_spe_nspe_cpuapp_ns>`.
 
 See `Bluetooth mesh samples`_ for the list of changes in the Bluetooth mesh samples.
 
@@ -225,6 +225,26 @@ Bluetooth mesh samples
 * :ref:`bluetooth_mesh_sensor_client` sample:
 
   * Fixed an issue with the sample not fitting into RAM size on the nrf52dk_nrf52832 board.
+
+* :ref:`bluetooth_mesh_light` sample:
+
+  * Removed support for the configuration with :ref:`CMSE enabled <app_boards_spe_nspe_cpuapp_ns>` for :ref:`zephyr:thingy53_nrf5340`.
+
+* :ref:`bluetooth_mesh_light_lc` sample:
+
+  * Removed support for the configuration with :ref:`CMSE enabled <app_boards_spe_nspe_cpuapp_ns>` for :ref:`zephyr:thingy53_nrf5340`.
+
+* :ref:`bluetooth_mesh_light_dim` sample:
+
+  * Removed support for the configuration with :ref:`CMSE enabled <app_boards_spe_nspe_cpuapp_ns>` for :ref:`zephyr:thingy53_nrf5340`.
+
+* :ref:`bluetooth_mesh_light_switch` sample:
+
+  * Removed support for the configuration with :ref:`CMSE enabled <app_boards_spe_nspe_cpuapp_ns>` for :ref:`zephyr:thingy53_nrf5340`.
+
+* :ref:`bluetooth_mesh_sensor_server` sample:
+
+  * Removed support for the configuration with :ref:`CMSE enabled <app_boards_spe_nspe_cpuapp_ns>` for :ref:`zephyr:thingy53_nrf5340`.
 
 Cryptography samples
 --------------------

--- a/samples/bluetooth/mesh/light/sample.yaml
+++ b/samples/bluetooth/mesh/light/sample.yaml
@@ -11,10 +11,9 @@ tests:
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
       - thingy53_nrf5340_cpuapp
-      - thingy53_nrf5340_cpuapp_ns
       - nrf21540dk_nrf52840
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
-      nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp thingy53_nrf5340_cpuapp_ns
+      nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp
       nrf21540dk_nrf52840 nrf52833dk_nrf52833
     tags: bluetooth ci_build
   sample.bluetooth.mesh.light.dfu:

--- a/samples/bluetooth/mesh/light_ctrl/sample.yaml
+++ b/samples/bluetooth/mesh/light_ctrl/sample.yaml
@@ -11,10 +11,9 @@ tests:
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
       - thingy53_nrf5340_cpuapp
-      - thingy53_nrf5340_cpuapp_ns
       - nrf21540dk_nrf52840
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
-      nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp thingy53_nrf5340_cpuapp_ns
+      nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp
       nrf21540dk_nrf52840 nrf52833dk_nrf52833
     tags: bluetooth ci_build
   sample.bluetooth.mesh.light_ctrl.emds:
@@ -27,9 +26,8 @@ tests:
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
       - thingy53_nrf5340_cpuapp
-      - thingy53_nrf5340_cpuapp_ns
       - nrf21540dk_nrf52840
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
-      nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp thingy53_nrf5340_cpuapp_ns
+      nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp
       nrf21540dk_nrf52840 nrf52833dk_nrf52833
     tags: bluetooth ci_build

--- a/samples/bluetooth/mesh/light_dimmer/sample.yaml
+++ b/samples/bluetooth/mesh/light_dimmer/sample.yaml
@@ -11,9 +11,8 @@ tests:
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
       - thingy53_nrf5340_cpuapp
-      - thingy53_nrf5340_cpuapp_ns
       - nrf21540dk_nrf52840
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
-      nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp thingy53_nrf5340_cpuapp_ns
+      nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp
       nrf21540dk_nrf52840 nrf52833dk_nrf52833
     tags: bluetooth ci_build

--- a/samples/bluetooth/mesh/light_switch/sample.yaml
+++ b/samples/bluetooth/mesh/light_switch/sample.yaml
@@ -11,10 +11,9 @@ tests:
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
       - thingy53_nrf5340_cpuapp
-      - thingy53_nrf5340_cpuapp_ns
       - nrf21540dk_nrf52840
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
-      nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp thingy53_nrf5340_cpuapp_ns
+      nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp
       nrf21540dk_nrf52840 nrf52833dk_nrf52833
     tags: bluetooth ci_build
   sample.bluetooth.mesh.light_switch.lpn:

--- a/samples/bluetooth/mesh/sensor_server/sample.yaml
+++ b/samples/bluetooth/mesh/sensor_server/sample.yaml
@@ -8,9 +8,8 @@ tests:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
       - thingy53_nrf5340_cpuapp
-      - thingy53_nrf5340_cpuapp_ns
       - nrf21540dk_nrf52840
     platform_allow: >
-      nrf52dk_nrf52832 nrf52840dk_nrf52840 thingy53_nrf5340_cpuapp thingy53_nrf5340_cpuapp_ns
+      nrf52dk_nrf52832 nrf52840dk_nrf52840 thingy53_nrf5340_cpuapp
       nrf21540dk_nrf52840
     tags: bluetooth ci_build

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -109,6 +109,21 @@ config BT_MESH_PROXY_FILTER_SIZE
 
 endif
 
+config BT_MESH_USES_TFM_PSA
+	bool
+	select PSA_WANT_GENERATE_RANDOM
+	select PSA_WANT_ALG_CCM
+	select PSA_WANT_ALG_ECB_NO_PADDING
+	select PSA_WANT_ALG_CMAC
+	select PSA_WANT_ALG_HMAC
+	select PSA_WANT_ALG_ECDH
+	select PSA_WANT_ECC_SECP_R1_256
+
+choice TFM_PROFILE_TYPE
+	depends on BT_MESH_USES_TFM_PSA
+	default TFM_PROFILE_TYPE_NOT_SET
+endchoice
+
 rsource "Kconfig.models"
 rsource "Kconfig.dk_prov"
 rsource "shell/Kconfig"


### PR DESCRIPTION
PR adds configurtion options to use tf-m and Oberon as a default crypto engine for non-secure platforms
in mesh samples.