### PR TITLE
west.yml: Update Zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: eb28632680089351c7bd4365cf3742bf7eff70d3
+      revision: b37ce40878ec52295afe6350d17712d60eb6639a
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Change updates Zephyr revision to bring in QDEC driver fix.

Jira: NCSDK-22626