### PR TITLE
lib: bin: lwm2m_carrier: add missing dependency

### DIFF
--- a/lib/bin/lwm2m_carrier/Kconfig
+++ b/lib/bin/lwm2m_carrier/Kconfig
@@ -65,6 +65,7 @@ config LWM2M_CARRIER_ATT
 config LWM2M_CARRIER_LG_UPLUS
 	bool "LG U+"
 	depends on DFU_TARGET_MCUBOOT
+	depends on FLASH_MAP
 	default y
 	help
 	  Enable Carrier Library when the SIM Subscriber ID is LG U+.


### PR DESCRIPTION
Added a missing dependency to enable LG U+ support.

Signed-off-by: Kacper Radoszewski <kacper.radoszewski@nordicsemi.no>