### PR TITLE
boards: shields: Fix conflcits with nRF9161

### DIFF
--- a/boards/shields/nrf7002ek/boards/nrf9161dk_nrf9161.overlay
+++ b/boards/shields/nrf7002ek/boards/nrf9161dk_nrf9161.overlay
@@ -1,0 +1,6 @@
+/* Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <nrf9161dk_leds_on_io_expander.dtsi>

--- a/boards/shields/nrf7002ek/boards/nrf9161dk_nrf9161_ns.overlay
+++ b/boards/shields/nrf7002ek/boards/nrf9161dk_nrf9161_ns.overlay
@@ -1,0 +1,6 @@
+/* Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <nrf9161dk_leds_on_io_expander.dtsi>


### PR DESCRIPTION
LEDs on nRF9161 conflict with Wi-Fi GPIOs, so, use the GPIO extender for LEDs to fix the conflict.