### PR TITLE
Bluetooth: mesh: remove relative paths in samples

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -255,6 +255,8 @@ Bluetooth mesh samples
 
   * Removed support for the configuration with :ref:`CMSE enabled <app_boards_spe_nspe_cpuapp_ns>` for :ref:`zephyr:thingy53_nrf5340`.
 
+* Fixed an issue where some samples copied using the `nRF Connect for Visual Studio Code`_ extension would not compile due to relative paths in :file:`CMakeLists.txt`, which were referencing files outside of the applications folder.
+
 Cryptography samples
 --------------------
 

--- a/samples/bluetooth/mesh/dfu/distributor/CMakeLists.txt
+++ b/samples/bluetooth/mesh/dfu/distributor/CMakeLists.txt
@@ -4,15 +4,15 @@ cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mesh_dfu_distributor)
 
-set(common_dir ${CMAKE_CURRENT_SOURCE_DIR}/../common/src)
+set(dfu_common_dir ${ZEPHYR_NRF_MODULE_DIR}/samples/bluetooth/mesh/dfu/common/src)
 
 include_directories(
-	${common_dir}
+	${dfu_common_dir}
 	${ZEPHYR_NRF_MODULE_DIR}/samples/bluetooth/mesh/common
 )
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources}
 	${ZEPHYR_NRF_MODULE_DIR}/samples/bluetooth/mesh/common/smp_bt.c
-	${common_dir}/dfu_target.c
+	${dfu_common_dir}/dfu_target.c
 )

--- a/samples/bluetooth/mesh/dfu/target/CMakeLists.txt
+++ b/samples/bluetooth/mesh/dfu/target/CMakeLists.txt
@@ -4,10 +4,10 @@ cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mesh_dfu_target)
 
-set(common_dir ${CMAKE_CURRENT_SOURCE_DIR}/../common/src)
+set(dfu_common_dir ${ZEPHYR_NRF_MODULE_DIR}/samples/bluetooth/mesh/dfu/common/src)
 
-include_directories(${common_dir})
+include_directories(${dfu_common_dir})
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources}
-			${common_dir}/dfu_target.c)
+			${dfu_common_dir}/dfu_target.c)


### PR DESCRIPTION
Fixed an issue where samples copied via the VS Code extension did not compile due to relative paths in CMakeLists, referencing files outside the applications folder.