### PR TITLE
Partition Manager: Support for Disk Access

### DIFF
--- a/scripts/partition_manager.py
+++ b/scripts/partition_manager.py
@@ -249,6 +249,8 @@ def clean_sub_partitions(reqs, sub_partitions):
 
 def convert_str_to_list(with_str):
     for k, v in with_str.items():
+        if k == 'extra_params':
+            continue
         if isinstance(v, dict):
             convert_str_to_list(v)
         elif isinstance(v, str) and k not in PERMITTED_STR_KEYS:

--- a/scripts/partition_manager/partition_manager.rst
+++ b/scripts/partition_manager/partition_manager.rst
@@ -311,6 +311,37 @@ region: string
    Specify the region where a partition should be placed.
    See :ref:`pm_regions`.
 
+affiliation: string or list
+   This property groups the partition with other partitions with the specified affiliation.
+   Affiliations are used to generate ``PM_FOREACH_AFFILIATED_TO_<affliation>(fn)`` macros, which let you invoke the macro ``fn`` on all definitions of the partitions with the specified affiliation.
+   The macro passes the partition name from the YAML file to the ``fn`` macro, using the upper-case formatting.
+   Currently, the ``disk`` affiliation is reserved by the flash disk driver in Zephyr to generate disk objects from partitions defined by the Partition Manager.
+
+extra_params: dict
+   This is a dictionary of extra ``<param_name>`` parameters for the partition.
+   The Partition Manager only uses them for generating ``PM_<uppercase_partition_name>_EXTRA_PARAM_<param_name>`` definitions, with the value taken from the YAML file, as assigned to the extra parameter.
+   The Partition Manager does not use or process these parameters in any other way.
+   Extra parameters can be used by other subsystems to add additional information to partitions.
+   Currently, this feature is only used by the flash disk driver in Zephyr to generate disk objects for use with the Disk Access API, with the following extra parameters: ``disk_sector_size``, ``disk_cache_size``, ``disk_name``, and ``disk_read_only``.
+   The following code snippet shows an example of the disk partition configuration using the ``extra_params`` dictionary:
+
+   .. code-block:: yaml
+      :caption: Example of disk partition
+
+      fatfs_storage:
+          affiliation: disk
+          extra_params: {
+              disk_name: "SD",
+              disk_cache_size: 4096,
+              disk_sector_size: 512,
+              disk_read_only: 0
+          }
+          placement:
+              before: [end]
+              align: {start: 4096}
+          inside: [nonsecure_storage]
+          size: 65536
+
 .. _partition_manager_ram_configuration:
 
 RAM partition configuration


### PR DESCRIPTION
Series of commits that allow Disk Access from Zephyr to work with Partition Manager.

To make partition Flash Disk partition, it needs to be affiliated with "disk" and given extra parameters for configuring disk, for example:

```
some_storage:
  affiliation: disk
  extra_params: {
    disk_name: "SD",
    disk_cache_size: 4096,
    disk_sector_size: 512,
    disk_read_only: 0
  }
  placement:
    before: [end]
  inside: [nonsecure_storage]
  size: 65536
```
Defines partition that can be used by disk access - actually will be, when disk access is enabled - for creating disk.
Note that without `affiliation` and `extra_params`  this is just an ordinary flash partition. When disk access is not enabled, affiliation has no effect unless directly used by user for something else.

**Update 2023-07-14 10:45 UTC**
Fixed doc issues.
**Update 2023-07-20 11:12 UTC**
Removed no longer needed commits: Zephyr sha change in manifest and dynamic partition configuration.
**Update 2023-07-26 9:43 UTC**
Force push with doc fix
**Update 2023-07-28 10:50 UTC**
Force push with update from main