### PR TITLE
Bluetooth: add le power control HCI vs cmd APR handling

### DIFF
--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -1219,6 +1219,8 @@ static uint8_t vs_cmd_put(uint8_t const * const cmd,
 		return sdc_hci_cmd_vs_write_remote_tx_power((void *)cmd_params);
 	case SDC_HCI_OPCODE_CMD_VS_SET_AUTO_POWER_CONTROL_REQUEST_PARAM:
 		return sdc_hci_cmd_vs_set_auto_power_control_request_param((void *)cmd_params);
+	case SDC_HCI_OPCODE_CMD_VS_SET_POWER_CONTROL_APR_HANDLING:
+		return sdc_hci_cmd_vs_set_power_control_apr_handling((void *)cmd_params);
 #endif
 	default:
 		return BT_HCI_ERR_UNKNOWN_CMD;


### PR DESCRIPTION
The vs command set_power_control_apr_handling can be used to enable utilization of remote APR (acceptible power reduction), received with the power control response from peer, to adjust the local tx power.