### PR TITLE
tfm: Fix TF-M with Initial Attestation compilation error

### DIFF
--- a/modules/tfm/tfm/boards/CMakeLists.txt
+++ b/modules/tfm/tfm/boards/CMakeLists.txt
@@ -92,7 +92,7 @@ if (${TFM_PARTITION_CRYPTO})
   if (${TFM_PARTITION_INITIAL_ATTESTATION})
     target_sources(platform_s
       PRIVATE
-        ${NRF_DIR}/lib/identity_key/identity_key.c
+        ${ZEPHYR_NRF_MODULE_DIR}/lib/identity_key/identity_key.c
     )
   endif()
 


### PR DESCRIPTION
Fix TF-M with Initial Attestation enabled resulting in a compilation error for a missing path.
This is a regression from: c6154d55903cd70dba4bf794e816dcd077fdc10b