### PR TITLE
manifest: Update sdk-mcuboot to Zephyr fork latest version

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -127,7 +127,7 @@ manifest:
           compare-by-default: false
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 823fd369c1430b50d263ccd6fbcf98bdd44001ba
+      revision: pull/264/head
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR.git


### PR DESCRIPTION
Merge in latest changes from Zephyr fork of MCUboot.

The auto-upmerge keeps lagging on the sdk-zephyr issues, so update MCUboot at least. 