### PR TITLE
cmake: partition_manager: Generate images for S0/S1 to external flash 

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -126,7 +126,7 @@ manifest:
           compare-by-default: false
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 823fd369c1430b50d263ccd6fbcf98bdd44001ba
+      revision: 8fe7070ee192f8e72a9a67560cee9e3518155579
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR.git


### PR DESCRIPTION
Implemented a fix in MCUBoot for NSIB + Multi-image for nRF53.

This enables partition manager and the build system to generate images
for S1 and S0 with the address of external QSPI flash. If the QSPI node
with XiP is defined in the DTS.

This is the same code used to move the application update into the
secondary slot in external flash.

Ref. NCSDK-19223