### PR TITLE
manifest: sdk-zephyr: Pull TWT crash fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: b37ce40878ec52295afe6350d17712d60eb6639a
+      revision: 1cdcadb94cee4f1e6a3dd7b34cc9cf276b245519
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull fix for TWT crash while printing when shell is NULL.