### PR TITLE
west.yml: Update Zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 1cdcadb94cee4f1e6a3dd7b34cc9cf276b245519
+      revision: 434be7b575ce338645801140fbd2e64738f8994e
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update Zephyr revision to bring in
`zephyr/tests/bsim/bluetooth/host/l2cap/split/scripts/l2cap_split.sh` test fix from this commit:
https://github.com/nrfconnect/sdk-zephyr/commit/434be7b575ce338645801140fbd2e64738f8994e