### PR TITLE
manifest: sdk-hostap: Pull fix for scan busy after disconnect

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -110,7 +110,7 @@ manifest:
     - name: hostap
       repo-path: sdk-hostap
       path: modules/lib/hostap
-      revision: 42a92ba947785b35ad4e85cbf6e121e4d9a3bd50
+      revision: pull/113/head
       userdata:
         ncs:
           upstream-url: https://w1.fi/cgit/hostap/


### PR DESCRIPTION
Pull in the fix to abort ongoing scan (if any) during disconnect.