### PR TITLE
applications: Fixed rdid generation for Matter weather station

### DIFF
--- a/applications/matter_weather_station/src/app_task.cpp
+++ b/applications/matter_weather_station/src/app_task.cpp
@@ -231,6 +231,7 @@ CHIP_ERROR AppTask::Init()
 		memset(sTestEventTriggerEnableKey, 0, sizeof(sTestEventTriggerEnableKey));
 	}
 #else
+	SetDeviceInstanceInfoProvider(&DeviceInstanceInfoProviderMgrImpl());
 	SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
 #endif
 

--- a/applications/matter_weather_station/src/app_task.h
+++ b/applications/matter_weather_station/src/app_task.h
@@ -18,6 +18,8 @@
 
 #if CONFIG_CHIP_FACTORY_DATA
 #include <platform/nrfconnect/FactoryDataProvider.h>
+#else
+#include <platform/nrfconnect/DeviceInstanceInfoProviderImpl.h>
 #endif
 
 #ifdef CONFIG_CHIP_ICD_SUBSCRIPTION_HANDLING


### PR DESCRIPTION
RDID was not correctly generated for the Matter weather station, because application hasn't set DeviceInstanceInfoProvider. After adding registration to app task, the problem was solved.