### PR TITLE
Bluetooth: add le power control HCI vs cmd APR handling

### DIFF
--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -465,6 +465,7 @@ static void vs_supported_commands(sdc_hci_vs_supported_vs_commands_t *cmds)
 #if defined(CONFIG_BT_CTLR_LE_POWER_CONTROL)
 	cmds->write_remote_tx_power = 1;
 	cmds->set_auto_power_control_request_param = 1;
+	cmds->set_power_control_apr_handling = 1;
 #endif
 }
 #endif	/* CONFIG_BT_HCI_VS */
@@ -1219,6 +1220,8 @@ static uint8_t vs_cmd_put(uint8_t const * const cmd,
 		return sdc_hci_cmd_vs_write_remote_tx_power((void *)cmd_params);
 	case SDC_HCI_OPCODE_CMD_VS_SET_AUTO_POWER_CONTROL_REQUEST_PARAM:
 		return sdc_hci_cmd_vs_set_auto_power_control_request_param((void *)cmd_params);
+	case SDC_HCI_OPCODE_CMD_VS_SET_POWER_CONTROL_APR_HANDLING:
+		return sdc_hci_cmd_vs_set_power_control_apr_handling((void *)cmd_params);
 #endif
 	default:
 		return BT_HCI_ERR_UNKNOWN_CMD;

--- a/west.yml
+++ b/west.yml
@@ -140,7 +140,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 16721d9c09b2e37fc805fa992a7537211bd0836b
+      revision: 83892a4e56b9dfc4cfcc954e62cfb65cec13509c
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
The vs command set_power_control_apr_handling can be used to enable utilization of remote APR (acceptible power reduction), received with the power control response from peer, to adjust the local tx power.

For this the sdk-nrfxlib revision is updated as well.