### PR TITLE
drivers: wifi: Fix the interface check

### DIFF
--- a/drivers/wifi/nrf700x/zephyr/inc/zephyr_fmac_main.h
+++ b/drivers/wifi/nrf700x/zephyr/inc/zephyr_fmac_main.h
@@ -15,6 +15,7 @@
 #include <stdio.h>
 
 #include <zephyr/kernel.h>
+#include <zephyr/net/net_if.h>
 #ifndef CONFIG_NRF700X_RADIO_TEST
 #include <zephyr/net/wifi_mgmt.h>
 #include <zephyr/net/ethernet.h>
@@ -116,5 +117,6 @@ const char *wifi_nrf_get_drv_version(void);
 enum wifi_nrf_status wifi_nrf_fmac_dev_add_zep(struct wifi_nrf_drv_priv_zep *drv_priv_zep);
 enum wifi_nrf_status wifi_nrf_fmac_dev_rem_zep(struct wifi_nrf_drv_priv_zep *drv_priv_zep);
 enum wifi_nrf_status wifi_nrf_fw_load(void *rpu_ctx);
+struct wifi_nrf_vif_ctx_zep *wifi_nrf_get_vif_ctx(struct net_if *iface);
 
 #endif /* __ZEPHYR_FMAC_MAIN_H__ */

--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_fmac_main.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_fmac_main.c
@@ -95,6 +95,26 @@ const char *wifi_nrf_get_drv_version(void)
 	return NRF700X_DRIVER_VERSION;
 }
 
+/* If the interface is not Wi-Fi then errors are expected, so, fail silently */
+struct wifi_nrf_vif_ctx_zep *wifi_nrf_get_vif_ctx(struct net_if *iface)
+{
+	struct wifi_nrf_vif_ctx_zep *vif_ctx_zep = NULL;
+	struct wifi_nrf_ctx_zep *rpu_ctx = &rpu_drv_priv_zep.rpu_ctx_zep;
+
+	if (!iface || !rpu_ctx) {
+		return NULL;
+	}
+
+	for (int i = 0; i < ARRAY_SIZE(rpu_ctx->vif_ctx_zep); i++) {
+		if (rpu_ctx->vif_ctx_zep[i].zep_net_if_ctx == iface) {
+			vif_ctx_zep = &rpu_ctx->vif_ctx_zep[i];
+			break;
+		}
+	}
+
+	return vif_ctx_zep;
+}
+
 void wifi_nrf_event_proc_scan_start_zep(void *if_priv,
 					struct nrf_wifi_umac_event_trigger_scan *scan_start_event,
 					unsigned int event_len)

--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_net_if.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_net_if.c
@@ -178,18 +178,10 @@ static void ip_maddr_event_handler(struct net_mgmt_event_callback *cb,
 				   struct net_if *iface)
 {
 	struct wifi_nrf_vif_ctx_zep *vif_ctx_zep = NULL;
-	const struct device *dev = NULL;
 	struct net_eth_addr mac_addr;
 	struct nrf_wifi_umac_mcast_cfg *mcast_info = NULL;
 	enum wifi_nrf_status status;
 	uint8_t mac_string_buf[sizeof("xx:xx:xx:xx:xx:xx")];
-
-	dev = net_if_get_device(iface);
-
-	if (!dev) {
-		LOG_ERR("%s: dev is NULL\n", __func__);
-		return;
-	}
 
 	for (int i = 0; i < ARRAY_SIZE(rpu_ctx->vif_ctx_zep); i++) {
 		if (rpu_ctx->vif_ctx_zep[i].zep_net_if_ctx == iface) {

--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_net_if.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_net_if.c
@@ -207,7 +207,7 @@ static void ip_maddr_event_handler(struct net_mgmt_event_callback *cb,
 	    (mgmt_event == NET_EVENT_IPV4_MADDR_DEL)) {
 		if ((cb->info == NULL) ||
 		    (cb->info_length != sizeof(struct in_addr))) {
-			return;
+			goto out;
 		}
 
 		net_eth_ipv4_mcast_to_mac_addr((const struct in_addr *)cb->info,
@@ -223,7 +223,7 @@ static void ip_maddr_event_handler(struct net_mgmt_event_callback *cb,
 		   (mgmt_event == NET_EVENT_IPV6_MADDR_DEL)) {
 		if ((cb->info == NULL) ||
 		    (cb->info_length != sizeof(struct in6_addr))) {
-			return;
+			goto out;
 		}
 
 		net_eth_ipv6_mcast_to_mac_addr(
@@ -253,7 +253,7 @@ static void ip_maddr_event_handler(struct net_mgmt_event_callback *cb,
 					       WIFI_MAC_ADDR_LEN, mac_string_buf,
 					       sizeof(mac_string_buf)));
 	}
-
+out:
 	k_free(mcast_info);
 }
 

--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_net_if.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_net_if.c
@@ -183,6 +183,13 @@ static void ip_maddr_event_handler(struct net_mgmt_event_callback *cb,
 	enum wifi_nrf_status status;
 	uint8_t mac_string_buf[sizeof("xx:xx:xx:xx:xx:xx")];
 
+	if (mgmt_event != NET_EVENT_IPV4_MADDR_ADD &&
+	    mgmt_event != NET_EVENT_IPV4_MADDR_DEL &&
+	    mgmt_event != NET_EVENT_IPV6_MADDR_ADD &&
+	    mgmt_event != NET_EVENT_IPV6_MADDR_DEL) {
+		return;
+	}
+
 	vif_ctx_zep = wifi_nrf_get_vif_ctx(iface);
 	if (!vif_ctx_zep) {
 		return;

--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_net_if.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_net_if.c
@@ -183,11 +183,9 @@ static void ip_maddr_event_handler(struct net_mgmt_event_callback *cb,
 	enum wifi_nrf_status status;
 	uint8_t mac_string_buf[sizeof("xx:xx:xx:xx:xx:xx")];
 
-	for (int i = 0; i < ARRAY_SIZE(rpu_ctx->vif_ctx_zep); i++) {
-		if (rpu_ctx->vif_ctx_zep[i].zep_net_if_ctx == iface) {
-			vif_ctx_zep = &rpu_ctx->vif_ctx_zep[i];
-			break;
-		}
+	vif_ctx_zep = wifi_nrf_get_vif_ctx(iface);
+	if (!vif_ctx_zep) {
+		return;
 	}
 
 	mcast_info = k_calloc(sizeof(*mcast_info), sizeof(char));


### PR DESCRIPTION
commit 34f31d55bd("drivers: wifi: Fix IP event handling") missed checking for validity of VIF context, so, it still assumes the interface is Wi-Fi and goes ahead, causing a crash.

Also, convert the check to a helper function to be used in multiple places.