### PR TITLE
lib: nrf_modem: add sanity if CONFIG_NRF_MODEM_LINK_BINARY is enabled

### DIFF
--- a/lib/nrf_modem_lib/CMakeLists.txt
+++ b/lib/nrf_modem_lib/CMakeLists.txt
@@ -18,6 +18,6 @@ if(CONFIG_NRF_MODEM_LIB_TRACE)
 endif()
 
 zephyr_library_sources(fault.c)
-zephyr_library_sources(sanity.c)
+zephyr_library_sources_ifdef(CONFIG_NRF_MODEM_LINK_BINARY sanity.c)
 
 zephyr_linker_sources(RODATA nrf_modem_lib.ld)


### PR DESCRIPTION
Add sanity checks if CONFIG_NRF_MODEM_LINK_BINARY is enabled.