### PR TITLE
drivers: wifi: Fix QSPI encryption regression

### DIFF
--- a/drivers/wifi/nrf700x/zephyr/src/qspi/src/qspi_if.c
+++ b/drivers/wifi/nrf700x/zephyr/src/qspi/src/qspi_if.c
@@ -1303,6 +1303,13 @@ int qspi_enable_encryption(uint8_t *key)
 	if (qspi_config->encryption)
 		return -EALREADY;
 
+	int ret = qspi_device_init(&qspi_perip);
+
+	if (ret != 0) {
+		LOG_ERR("qspi_device_init failed: %d\n", ret);
+		return -EIO;
+	}
+
 	memcpy(qspi_config->p_cfg.key, key, 16);
 
 	err = nrfx_qspi_dma_encrypt(&qspi_config->p_cfg);
@@ -1318,6 +1325,8 @@ int qspi_enable_encryption(uint8_t *key)
 	}
 
 	qspi_config->encryption = true;
+
+	qspi_device_uninit(&qspi_perip);
 
 	return 0;
 #else


### PR DESCRIPTION
When low-power mode support for QSPI was added, it broke QSPI encryption because the QSPI device will be uninitialized after the use, so, the encrypt fails, add init/deinit to the encryption.

Fixes SHEL-1765.