### PR TITLE
matter: rebase sdk-connectedhomeip

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -148,7 +148,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 2b5d2df45c8a4e83df7179f04fbd0c8cd084b5a3
+      revision: f5c24f9ffb795542fca7e923377ae28de3828670
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
Regular rebase of sdk-connectedhomeip history. We didn't have time to do it before the last release and the history needs some cleanup.