### PR TITLE
applications: nrf_desktop: Add peers cache to HID forward module

### DIFF
--- a/applications/nrf_desktop/src/events/config_event.c
+++ b/applications/nrf_desktop/src/events/config_event.c
@@ -17,11 +17,14 @@ static const char * const status_name[] = {
 static void log_config_event(const struct app_event_header *aeh)
 {
 	const struct config_event *event = cast_config_event(aeh);
+	const char *status_str = "UNKNOWN";
 
-	__ASSERT_NO_MSG(event->status < ARRAY_SIZE(status_name));
+	if (event->status < ARRAY_SIZE(status_name)) {
+		status_str = status_name[event->status];
+	}
 
 	APP_EVENT_MANAGER_LOG(aeh, "%s %s rcpt: %02x id: %02x",
-			status_name[event->status],
+			status_str,
 			event->is_request ? "req" : "rsp",
 			event->recipient,
 			event->event_id);

--- a/applications/nrf_desktop/src/events/config_event.h
+++ b/applications/nrf_desktop/src/events/config_event.h
@@ -36,7 +36,8 @@ extern "C" {
 	X(TIMEOUT)			\
 	X(REJECT)			\
 	X(WRITE_FAIL)			\
-	X(DISCONNECTED)
+	X(DISCONNECTED)			\
+	X(GET_PEERS_CACHE)
 
 enum config_status {
 #define X(name) _CONCAT(CONFIG_STATUS_, name),

--- a/applications/nrf_desktop/src/modules/hid_forward.c
+++ b/applications/nrf_desktop/src/modules/hid_forward.c
@@ -824,17 +824,21 @@ static bool handle_config_event(struct config_event *event)
 		return false;
 	}
 
-	if ((event->recipient == CFG_CHAN_RECIPIENT_LOCAL) &&
-	    ((event->status == CONFIG_STATUS_INDEX_PEERS) ||
-	     (event->status == CONFIG_STATUS_GET_PEER))) {
-		handle_config_channel_peers_req(event);
-		return true;
+	if (event->recipient == CFG_CHAN_RECIPIENT_LOCAL) {
+		if ((event->status == CONFIG_STATUS_INDEX_PEERS) ||
+		    (event->status == CONFIG_STATUS_GET_PEER)) {
+			handle_config_channel_peers_req(event);
+			return true;
+		}
+
+		/* Do not try to forward requests for local recipient. */
+		return false;
 	}
 
 	struct hids_peripheral *per = find_peripheral(event->recipient);
 
 	if (!per) {
-		LOG_INF("Recipent %02" PRIx8 "not found", event->recipient);
+		LOG_INF("Recipient %02" PRIx8 " not found", event->recipient);
 		return false;
 	}
 


### PR DESCRIPTION
PR introduces:

- Configuration channel peers cache functionality to the HID forward module. The option allows host tools to retrieve information about change of the connected peripherals without need of complete rediscovery.
- Support for the peers cache in the HID configurator script.
- Configuration channel implementation cleanups.
- Fix for invalid assertion in config event logging implementation.

Jira: NCSDK-17179