### PR TITLE
lib: bin: lwm2m_carrier: workaround for known issue NRF91-1702

### DIFF
--- a/applications/asset_tracker_v2/src/modules/modem_module.c
+++ b/applications/asset_tracker_v2/src/modules/modem_module.c
@@ -425,6 +425,9 @@ int lwm2m_carrier_event_handler(const lwm2m_carrier_event_t *evt)
 	}
 	case LWM2M_CARRIER_EVENT_FOTA_SUCCESS:
 		LOG_INF("LWM2M_CARRIER_EVENT_FOTA_SUCCESS");
+		/* Workaround for a known issue NRF91-1702. */
+		nrf_modem_lib_shutdown();
+		err = nrf_modem_lib_init();
 		break;
 	case LWM2M_CARRIER_EVENT_REBOOT: {
 		LOG_INF("LWM2M_CARRIER_EVENT_REBOOT");

--- a/applications/serial_lte_modem/src/lwm2m_carrier/slm_at_carrier.c
+++ b/applications/serial_lte_modem/src/lwm2m_carrier/slm_at_carrier.c
@@ -212,6 +212,9 @@ int lwm2m_carrier_event_handler(const lwm2m_carrier_event_t *event)
 		break;
 	case LWM2M_CARRIER_EVENT_FOTA_SUCCESS:
 		LOG_DBG("LWM2M_CARRIER_EVENT_FOTA_SUCCESS");
+		/* Workaround for a known issue NRF91-1702. */
+		nrf_modem_lib_shutdown();
+		err = nrf_modem_lib_init();
 		break;
 	case LWM2M_CARRIER_EVENT_REBOOT:
 		LOG_DBG("LWM2M_CARRIER_EVENT_REBOOT");

--- a/applications/serial_lte_modem/src/slm_at_fota.c
+++ b/applications/serial_lte_modem/src/slm_at_fota.c
@@ -376,10 +376,7 @@ void slm_fota_post_process(void)
 void slm_finish_modem_fota(int modem_lib_init_ret)
 {
 	if (handle_nrf_modem_lib_init_ret(modem_lib_init_ret)) {
-		char buf[40];
-
-		LOG_INF("Re-initializing the modem due to"
-				" ongoing modem firmware update.");
+		LOG_INF("Re-initializing the modem due to ongoing modem firmware update.");
 
 		/* The second init needs to be done regardless of the return value.
 		 * Refer to the below link for more information on the procedure.
@@ -388,14 +385,9 @@ void slm_finish_modem_fota(int modem_lib_init_ret)
 		modem_lib_init_ret = nrf_modem_lib_init();
 		handle_nrf_modem_lib_init_ret(modem_lib_init_ret);
 
-		nrf_modem_at_cmd(buf, sizeof(buf), "%s", "AT%SHORTSWVER");
-		if (strstr(buf, "1.3.4") || strstr(buf, "1.3.5")) {
-			/* Those versions suffer from a bug that provokes UICC failure (+CEREG: 90)
-			 * after the update, preventing the modem from registering to the network.
-			 */
-			LOG_INF("Applying the workaround to a modem firmware update issue...");
-			nrf_modem_lib_shutdown();
-			nrf_modem_lib_init();
-		}
+		/* Workaround for a known issue NRF91-1702. */
+		LOG_INF("Applying the workaround to a modem firmware update issue...");
+		nrf_modem_lib_shutdown();
+		nrf_modem_lib_init();
 	}
 }

--- a/doc/nrf/releases_and_maturity/known_issues.rst
+++ b/doc/nrf/releases_and_maturity/known_issues.rst
@@ -74,7 +74,7 @@ A known issue can list one or both of the following entries:
    When adding a new version, add it to the dropdown list above and move the "selected" option next to it.
    Once "selected" is moved, only issues that are valid for the new version will be displayed when entering the page.
 
-   Known issues process is described at https://projecttools.nordicsemi.no/confluence/pages/viewpage.action?pageId=82556815
+   Known issues process is described at https://nordicsemi.atlassian.net/wiki/spaces/NCS/pages/108237688/Known+Issues+process
 
    When updating this file, add entries in the following format:
 
@@ -2778,6 +2778,18 @@ NCSDK-6073: ``nrf_send`` is blocking
   **Affected platforms:** nRF9160
 
   **Workaround:** For |NCS| v1.4.0, set the non-blocking mode for a partial workaround for non-blocking operation.
+
+.. rst-class:: v2-4-1 v2-4-0 v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0
+
+NRF91-1702: The modem may fail to attach to the network after a modem firmware update if the application core was not rebooted
+  Performing a modem delta update without rebooting the application core (to reinitialize the modem and run the new firmware) may lead to a UICC initialization failure.
+  The UICC failure can be confirmed by issuing the ``AT+CEREG?`` AT command to read the current network registration status after attempting a UICC activation.
+  In case of the failure, the returned network registration status is ``90``.
+
+  **Affected platforms:** nRF9160
+
+  **Workaround:** Reinitialize the :ref:`nrfxlib:nrf_modem` by calling :c:func:`nrf_modem_lib_shutdown` followed by :c:func:`nrf_modem_lib_init`,
+  or reboot the application core as done in the existing |NCS| samples and applications.
 
 Multiprotocol Service Layer (MPSL)
 ==================================

--- a/lib/bin/lwm2m_carrier/os/lwm2m_carrier.c
+++ b/lib/bin/lwm2m_carrier/os/lwm2m_carrier.c
@@ -43,6 +43,11 @@ __weak int lwm2m_carrier_event_handler(const lwm2m_carrier_event_t *event)
 	case LWM2M_CARRIER_EVENT_MODEM_SHUTDOWN:
 		err = nrf_modem_lib_shutdown();
 		break;
+	case LWM2M_CARRIER_EVENT_FOTA_SUCCESS:
+		/* Workaround for a known issue NRF91-1702. */
+		nrf_modem_lib_shutdown();
+		err = nrf_modem_lib_init();
+		break;
 	default:
 		break;
 	}
@@ -83,6 +88,11 @@ __weak int lwm2m_carrier_event_handler(const lwm2m_carrier_event_t *event)
 		break;
 	case LWM2M_CARRIER_EVENT_MODEM_SHUTDOWN:
 		err = nrf_modem_lib_shutdown();
+		break;
+	case LWM2M_CARRIER_EVENT_FOTA_SUCCESS:
+		/* Workaround for a known issue NRF91-1702. */
+		nrf_modem_lib_shutdown();
+		err = nrf_modem_lib_init();
 		break;
 	default:
 		break;

--- a/samples/cellular/http_update/application_update/src/main.c
+++ b/samples/cellular/http_update/application_update/src/main.c
@@ -159,6 +159,9 @@ int lwm2m_carrier_event_handler(const lwm2m_carrier_event_t *event)
 		break;
 	case LWM2M_CARRIER_EVENT_FOTA_SUCCESS:
 		printk("LWM2M_CARRIER_EVENT_FOTA_SUCCESS\n");
+		/* Workaround for a known issue NRF91-1702. */
+		nrf_modem_lib_shutdown();
+		err = nrf_modem_lib_init();
 		break;
 	case LWM2M_CARRIER_EVENT_REBOOT:
 		printk("LWM2M_CARRIER_EVENT_REBOOT\n");

--- a/samples/cellular/lwm2m_carrier/src/main.c
+++ b/samples/cellular/lwm2m_carrier/src/main.c
@@ -156,6 +156,9 @@ int lwm2m_carrier_event_handler(const lwm2m_carrier_event_t *event)
 		break;
 	case LWM2M_CARRIER_EVENT_FOTA_SUCCESS:
 		printk("LWM2M_CARRIER_EVENT_FOTA_SUCCESS\n");
+		/* Workaround for a known issue NRF91-1702. */
+		nrf_modem_lib_shutdown();
+		err = nrf_modem_lib_init();
 		break;
 	case LWM2M_CARRIER_EVENT_REBOOT:
 		printk("LWM2M_CARRIER_EVENT_REBOOT\n");

--- a/samples/cellular/modem_shell/src/shell.c
+++ b/samples/cellular/modem_shell/src/shell.c
@@ -158,6 +158,9 @@ int lwm2m_carrier_event_handler(const lwm2m_carrier_event_t *event)
 		break;
 	case LWM2M_CARRIER_EVENT_FOTA_SUCCESS:
 		mosh_print("LwM2M carrier event: fota success");
+		/* Workaround for a known issue NRF91-1702. */
+		nrf_modem_lib_shutdown();
+		err = nrf_modem_lib_init();
 		break;
 	case LWM2M_CARRIER_EVENT_REBOOT:
 		mosh_print("LwM2M carrier event: reboot");


### PR DESCRIPTION
Workaround for an issue where the UICC can fail to initialize after
a modem upgrade without resetting the application core, which is the
default behavior of the LwM2M Carrier library.