### PR TITLE
lib: date_time: use millisecond precision in ntp api

### DIFF
--- a/lib/date_time/date_time_ntp.c
+++ b/lib/date_time/date_time_ntp.c
@@ -89,6 +89,7 @@ static bool is_connected_to_lte(void)
 int date_time_ntp_get(int64_t *date_time_ms)
 {
 	int err;
+	uint32_t milliseconds;
 
 #if defined(CONFIG_LTE_LINK_CONTROL)
 	if (!is_connected_to_lte()) {
@@ -108,7 +109,9 @@ int date_time_ntp_get(int64_t *date_time_ms)
 			continue;
 		}
 		LOG_DBG("Time obtained from NTP server %s", servers[i]);
-		*date_time_ms = (int64_t)sntp_time.seconds * 1000;
+
+		milliseconds = (uint32_t)(((double) sntp_time.fraction / UINT32_MAX) * 1000);
+		*date_time_ms = (int64_t)sntp_time.seconds * 1000 + milliseconds;
 		return 0;
 	}
 


### PR DESCRIPTION
Hi, 
the ntp part of the date_time lib ignores the fraction field returned by the ntp protocol, which leads to an accuracy within one second. I am aware that the date_time api docs mention that the fetched time is a UTC date time stamp so I guess this is expected behavior. But it is a little bit confusing that the api `date_time_now` method expects an `int64_t` pointer to a var called `unix_time_ms` which then has an accuracy of a second. 

Is it possible to update the ntp part to provide a millisecond accuracy as in my pr?

Regards