### PR TITLE
partition_manager: Move misplaced size statement in pm.yml.settings

### DIFF
--- a/subsys/partition_manager/pm.yml.settings
+++ b/subsys/partition_manager/pm.yml.settings
@@ -8,5 +8,5 @@ settings_storage:
 #else
     align: {start: CONFIG_PM_PARTITION_ALIGN_SETTINGS_STORAGE}
   inside: [nonsecure_storage]
-  size: CONFIG_PM_PARTITION_SIZE_SETTINGS_STORAGE
 #endif
+  size: CONFIG_PM_PARTITION_SIZE_SETTINGS_STORAGE


### PR DESCRIPTION
Move the size statement outside the ifdef since it must be set in both cases.

Ref: NCSIDB-1012