### PR TITLE
subsys: samples: Align timers configuration to new NRFX

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -240,6 +240,10 @@ Bluetooth samples
 
     * Support for the nRF52840 DK.
 
+  * Updated:
+
+    * Aligned timers' configurations to the new nrfx API.
+
 Bluetooth mesh samples
 ----------------------
 
@@ -382,6 +386,10 @@ Other samples
 * Removed the random hardware unique key sample.
   The sample is redundant since its functionality is presented as part of the :ref:`hw_unique_key_usage` sample.
 
+* :ref:`radio_test` sample:
+
+  * Aligned the timer's configuration to the new nrfx API.
+
 Drivers
 =======
 
@@ -402,6 +410,10 @@ This section provides detailed lists of changes by :ref:`library <libraries>`.
 * Added:
 
   * :ref:`nrf_security` library, relocated from the sdk-nrfxlib repository to the :file:`subsys/nrf_security` directory.
+
+* Updated:
+
+  * :ref:`cpu_load` library by aligning the timer's configuration to the new nrfx API.
 
 Binary libraries
 ----------------

--- a/samples/bluetooth/direct_test_mode/src/dtm.c
+++ b/samples/bluetooth/direct_test_mode/src/dtm.c
@@ -601,7 +601,7 @@ static int timer_init(void)
 {
 	nrfx_err_t err;
 	nrfx_timer_config_t timer_cfg = {
-		.frequency = NRF_TIMER_FREQ_1MHz,
+		.frequency = NRFX_MHZ_TO_HZ(1),
 		.mode = NRF_TIMER_MODE_TIMER,
 		.bit_width = NRF_TIMER_BIT_WIDTH_16,
 	};
@@ -622,7 +622,7 @@ static int wait_timer_init(void)
 {
 	nrfx_err_t err;
 	nrfx_timer_config_t timer_cfg = {
-		.frequency = NRF_TIMER_FREQ_1MHz,
+		.frequency = NRFX_MHZ_TO_HZ(1),
 		.mode = NRF_TIMER_MODE_TIMER,
 		.bit_width = NRF_TIMER_BIT_WIDTH_16,
 	};
@@ -649,7 +649,7 @@ static int anomaly_timer_init(void)
 {
 	nrfx_err_t err;
 	nrfx_timer_config_t timer_cfg = {
-		.frequency = NRF_TIMER_FREQ_125kHz,
+		.frequency = NRFX_KHZ_TO_HZ(125),
 		.mode = NRF_TIMER_MODE_TIMER,
 		.bit_width = NRF_TIMER_BIT_WIDTH_16,
 	};

--- a/samples/peripheral/radio_test/src/radio_test.c
+++ b/samples/peripheral/radio_test/src/radio_test.c
@@ -775,7 +775,7 @@ static void timer_init(const struct radio_test_config *config)
 {
 	nrfx_err_t          err;
 	nrfx_timer_config_t timer_cfg = {
-		.frequency = NRF_TIMER_FREQ_1MHz,
+		.frequency = NRFX_MHZ_TO_HZ(1),
 		.mode      = NRF_TIMER_MODE_TIMER,
 		.bit_width = NRF_TIMER_BIT_WIDTH_24,
 		.p_context = (void *) config,

--- a/subsys/debug/cpu_load/cpu_load.c
+++ b/subsys/debug/cpu_load/cpu_load.c
@@ -140,7 +140,7 @@ int cpu_load_init(void)
 		return 0;
 	}
 
-	config.frequency = NRF_TIMER_FREQ_1MHz;
+	config.frequency = NRFX_MHZ_TO_HZ(1);
 	config.bit_width = NRF_TIMER_BIT_WIDTH_32;
 
 	if (IS_ENABLED(CONFIG_CPU_LOAD_ALIGNED_CLOCKS)) {

--- a/tests/subsys/debug/cpu_load/src/test_cpu_load.c
+++ b/tests/subsys/debug/cpu_load/src/test_cpu_load.c
@@ -43,7 +43,7 @@ ZTEST(cpu_load, test_cpu_load)
 						NRF_POWER_EVENT_SLEEPENTER);
 	uint32_t tsk = nrfx_timer_task_address_get(&timer, NRF_TIMER_TASK_COUNT);
 
-	config.frequency = NRF_TIMER_FREQ_1MHz;
+	config.frequency = NRFX_MHZ_TO_HZ(1);
 	config.bit_width = NRF_TIMER_BIT_WIDTH_32;
 
 	err = nrfx_timer_init(&timer, &config, timer_handler);


### PR DESCRIPTION
Align the frequency configuration of the
timers in DTM and radio_test to new NRFX API.

Align the frequency configuration of the
timers in cpu_load subsys module.

Jira: NCSDK-22784