### PR TITLE
applications: nrf_desktop: Change ts resolution to us in motion sim

### DIFF
--- a/applications/nrf_desktop/src/hw_interface/Kconfig.motion
+++ b/applications/nrf_desktop/src/hw_interface/Kconfig.motion
@@ -80,13 +80,14 @@ config DESKTOP_MOTION_RIGHT_KEY_ID
 	  ID of key use for generating right motion.
 
 config DESKTOP_MOTION_SIMULATED_EDGE_TIME
-	int "Time for transition between two points in a trajectory [ms]"
+	int "Time for transition between two points in a trajectory [us]"
 	depends on DESKTOP_MOTION_SIMULATED_ENABLE
-	range 8 1000000
-	default 16
+	range 8 1000000000
+	default 16384
 	help
 	  The simulated movement data will be tracing predefined path, an eight-sided polygon.
 	  Must be power of two (calculations speedup).
+	  The resolution may be limited by the precision of the system's hardware clock.
 
 config DESKTOP_MOTION_SIMULATED_SCALE_FACTOR
 	int "Scale factor for given shape"

--- a/applications/nrf_desktop/src/hw_interface/motion_simulated.c
+++ b/applications/nrf_desktop/src/hw_interface/motion_simulated.c
@@ -72,12 +72,22 @@ static void motion_event_send(int16_t dx, int16_t dy)
 	APP_EVENT_SUBMIT(event);
 }
 
+static uint64_t get_timestamp(void)
+{
+	/* Use higher resolution if available. */
+	if (IS_ENABLED(CONFIG_TIMER_HAS_64BIT_CYCLE_COUNTER)) {
+		return k_cyc_to_us_near64(k_cycle_get_64());
+	} else {
+		return k_cyc_to_us_near64(k_cycle_get_32());
+	}
+}
+
 static void generate_motion_event(void)
 {
 	BUILD_ASSERT((edge_time & (edge_time - 1)) == 0,
 			 "Edge time must be power of 2");
 
-	uint32_t t = k_uptime_get_32();
+	uint64_t t = get_timestamp();
 	size_t v1_id = (t / edge_time) % ARRAY_SIZE(coords);
 	size_t v2_id = (v1_id + 1) % ARRAY_SIZE(coords);
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -222,6 +222,7 @@ nRF Desktop
     This is done to prevent the device from powering down and waking up multiple times when an USB cable is connected.
   * Disabled ``CONFIG_BOOT_SERIAL_IMG_GRP_HASH`` in MCUboot bootloader release configurations of boards that use nRF52820 SoC.
     This is done to reduce the memory consumption.
+  * To improve the accuracy, the generation of simulated movement data in the :ref:`nrf_desktop_motion` now uses a timestamp in microseconds based on the cycle count (either :c:func:`k_cycle_get_32` or :c:func:`k_cycle_get_64` function depending on the :kconfig:option:`CONFIG_TIMER_HAS_64BIT_CYCLE_COUNTER` Kconfig option).
 
 Thingy:53: Matter weather station
 ---------------------------------


### PR DESCRIPTION
Make the module rely on the cycle count and change timestamp resolution used in the Motion Simulated module from milliseconds to microseconds to increase accuracy.

Jira: NCSDK-22778