### PR TITLE
application: serial_lte_modem: Read device local time

### DIFF
--- a/applications/serial_lte_modem/doc/Generic_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/Generic_AT_commands.rst
@@ -505,6 +505,61 @@ Test command
 
 The test command is not supported.
 
+Device local time #XCCLK
+========================
+
+The ``#XCCLK`` command gets the real-time clock of the device.
+
+Set command
+-----------
+
+The set command returns the local time, the time zone and daylight-saving time info.
+
+Syntax
+~~~~~~
+
+::
+
+   #XCCLK
+
+Response syntax
+~~~~~~~~~~~~~~~
+
+::
+
+   #XCCLK: <time>,<time_zone>,<daylight_saving_time>
+
+The ``<time>`` value returns a string indicating local time in the format "yy/MM/dd,hh:mm:ss+zz", where the characters, from left to right, indicate year, month, day, hour, minutes, seconds.
+
+The ``<time_zone>`` value returns an integer indicating the difference, expressed in quarters of an hour, between the local time and GMT (value range from -48 to +48 and 99 for "not set").
+
+The ``<daylight_saving_time>`` value returns an integer indicating below:
+
+* ``0`` - No adjustment of daylight-saving time.
+* ``1`` - +1 hour adjustment of daylight-saving time.
+* ``2`` - +2 hours adjustment of daylight-saving time.
+
+Example
+~~~~~~~
+
+::
+
+  AT#XCCLK
+
+  #XCCLK: "23/07/24,12:27:43",+36,0
+
+  OK
+
+Read command
+------------
+
+The read command is not supported.
+
+Test command
+------------
+
+The test command is not supported.
+
 Native TLS CMNG #XCMNG
 ======================
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -173,6 +173,7 @@ nRF9160: Serial LTE modem
   * ``#XMODEMRESET`` AT command to reset the modem while keeping the application running.
     It is expected to be used during modem firmware update, which now only requires a reset of the modem.
   * DTLS connection identifier support to the ``#XSSOCKETOPT`` and ``#XUDPCLI`` AT commands.
+  * ``#XCCLK`` AT command to read device local time.
 
 * Updated:
 


### PR DESCRIPTION
Add `#XCCLK` command to get device local time. As Zephyr does not support local time conversion, get UTC by `AT%CCLK?` then use time zone and daylight_saving info to calculate local time.