### PR TITLE
tools: added more filters to downstream tests for lwm2m carrier lib

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -104,10 +104,21 @@
 "CI-lwm2m-test":
   - "include/modem/lte_lc*.h"
   - "include/modem/nrf_modem_lib.h"
-  - "lib/bin/**/*"
+  - "lib/bin/lwm2m_carrier/**/*"
   - "lib/lte_link_control/**/*"
+  - "lib/modem_key_mgmt/**/*"
   - "lib/nrf_modem_lib/**/*"
   - "samples/cellular/lwm2m_carrier/**/*"
+  - "include/modem/at_monitor.h"
+  - "lib/at_monitor/**/*"
+  - "include/net/download_client.h"
+  - "subsys/net/lib/download_client/**/*"
+  - "lib/sms/**/*"
+  - "include/modem/sms.h"
+  - "lib/pdn/**/*"
+  - "include/modem/pdn.h"
+  - "include/modem/at_params.h"
+  - "include/modem/modem_key_mgmt.h"
 
 "CI-boot-dfu-test":
   - "include/bl*"


### PR DESCRIPTION
Some dependencies for lwm2m carrier lib was missing and a new project had been added to the bin folder so had to change that filter option.