### PR TITLE
samples: crypto: psa_tls: Don't test secure-only nrf91

### DIFF
--- a/samples/crypto/psa_tls/sample.yaml
+++ b/samples/crypto/psa_tls/sample.yaml
@@ -11,12 +11,11 @@ tests:
     extra_args: >
       OVERLAY_CONFIG="overlays/server.conf;overlays/ecdsa.conf;overlays/cc3xx-oberon-psa.conf"
     platform_allow: >
-      nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160 nrf5340dk_nrf5340_cpuapp_ns
+      nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns
       nrf9160dk_nrf9160_ns
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
-      - nrf9160dk_nrf9160
       - nrf9160dk_nrf9160_ns
     tags: ci_build cc3xx_oberon
   sample.psa_tls.client.ecdsa.cc3xx_oberon:
@@ -24,11 +23,10 @@ tests:
     extra_args: >
       OVERLAY_CONFIG="overlays/client.conf;overlays/ecdsa.conf;overlays/cc3xx-oberon-psa.conf"
     platform_allow: >
-      nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160 nrf5340dk_nrf5340_cpuapp_ns nrf9160dk_nrf9160_ns
+      nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf9160dk_nrf9160_ns
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
-      - nrf9160dk_nrf9160
       - nrf9160dk_nrf9160_ns
     tags: ci_build cc3xx_oberon
   ################################################################################
@@ -38,41 +36,37 @@ tests:
     build_only: true
     extra_args: >
       OVERLAY_CONFIG="overlays/server.conf;overlays/rsa.conf;overlays/cc3xx-legacy.conf"
-    platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160 nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
-      - nrf9160dk_nrf9160
     tags: ci_build legacy cc3xx_legacy
   sample.psa_tls.client.rsa.cc3xx_legacy:
     build_only: true
     extra_args: >
       OVERLAY_CONFIG="overlays/client.conf;overlays/rsa.conf;overlays/cc3xx-legacy.conf"
-    platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160 nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
-      - nrf9160dk_nrf9160
     tags: ci_build legacy cc3xx_legacy
   sample.psa_tls.server.ecdsa.cc3xx_legacy:
     build_only: true
     extra_args: >
       OVERLAY_CONFIG="overlays/server.conf;overlays/ecdsa.conf;overlays/cc3xx-legacy.conf"
-    platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160 nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
-      - nrf9160dk_nrf9160
     tags: ci_build legacy cc3xx_legacy
   sample.psa_tls.client.ecdsa.cc3xx_legacy:
     build_only: true
     extra_args: >
       OVERLAY_CONFIG="overlays/client.conf;overlays/ecdsa.conf;overlays/cc3xx-legacy.conf"
-    platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160 nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
-      - nrf9160dk_nrf9160
     tags: ci_build legacy cc3xx_legacy
   ################################################################################
   ## Legacy APIs with Oberon (secure-only)
@@ -81,39 +75,35 @@ tests:
     build_only: true
     extra_args: >
       OVERLAY_CONFIG="overlays/server.conf;overlays/rsa.conf;overlays/oberon-legacy.conf"
-    platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160 nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
-      - nrf9160dk_nrf9160
     tags: ci_build legacy oberon_legacy
   sample.psa_tls.client.rsa.oberon_legacy:
     build_only: true
     extra_args: >
       OVERLAY_CONFIG="overlays/client.conf;overlays/rsa.conf;overlays/oberon-legacy.conf"
-    platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160 nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
-      - nrf9160dk_nrf9160
     tags: ci_build legacy oberon_legacy
   sample.psa_tls.server.ecdsa.oberon_legacy:
     build_only: true
     extra_args: >
       OVERLAY_CONFIG="overlays/server.conf;overlays/ecdsa.conf;overlays/oberon-legacy.conf"
-    platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160 nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
-      - nrf9160dk_nrf9160
     tags: ci_build legacy oberon_legacy
   sample.psa_tls.client.ecdsa.oberon_legacy:
     build_only: true
     extra_args: >
       OVERLAY_CONFIG="overlays/client.conf;overlays/ecdsa.conf;overlays/oberon-legacy.conf"
-    platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160 nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
-      - nrf9160dk_nrf9160
     tags: ci_build legacy oberon_legacy


### PR DESCRIPTION
Don't test secure-only nrf91 with psa_tls. NCS applications must use non-secure nrf91 due to a HW limitation in nrf91.

For this reason all nrf9160 samples test only against nrf91_ns and not nrf91 secure-only.

The only reason to test secure-only would be to test a library that would be used by a bootloader, but I can't imagine a bootloader would be doing psa_tls so skip this testing.

Omitting this testing will reduce CI load and decrease maintenance cost.