### PR TITLE
applications: nrf5340_audio: Remove dependency for setting interleaved

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/Kconfig
+++ b/applications/nrf5340_audio/src/bluetooth/Kconfig
@@ -414,7 +414,6 @@ config BT_AUDIO_BROADCAST_IMMEDIATE_FLAG
 
 config BT_AUDIO_PACKING_INTERLEAVED
 	bool "Interleaved packing"
-	depends on TRANSPORT_BIS
 	default n
 	help
 	  ISO channels can either be interleaved or sequentially packed; sequential is the default one.


### PR DESCRIPTION
- Interleaved can be set for both CIS and BIS