### PR TITLE
nfc: Fix NFC IRQ context switching

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -598,7 +598,8 @@ Libraries for networking
 Libraries for NFC
 -----------------
 
-|no_changes_yet_note|
+  * Fixed the potential issue where the NFC interrupt context switching could loose interrupts data.
+    This could happen if interrupts would be executed much faster than the NFC workqueue or thread.
 
 Nordic Security Module
 ----------------------


### PR DESCRIPTION
Fixed issue where NFC events data could be missed in case when NFC interrupts would be executed faster than the NFC workqueue or the NFC thread.