### PR TITLE
[v2.4-branch] manifest: nrf_modem v2.4.1

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -131,7 +131,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: v2.4.1
+      revision: 30841c2ad6d3b022406b167ab0ebaf46e8901c56
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
nrf_modem v2.4.1 release.

See CHANGELOG file in nrfxlib for details.