### PR TITLE
drivers: wifi: Disable TCP/IP checksum offload with IP fragmentation

### DIFF
--- a/drivers/wifi/nrf700x/Kconfig.nrf700x
+++ b/drivers/wifi/nrf700x/Kconfig.nrf700x
@@ -53,7 +53,7 @@ config NRF_WIFI_LOW_POWER
 
 config NRF700X_TCP_IP_CHECKSUM_OFFLOAD
 	bool "Enable TCP/IP checksum offload"
-	default y
+	default y if !(NET_IPV4_FRAGMENT || NET_IPV6_FRAGMENT)
 
 config NRF700X_REG_DOMAIN
 	string "The ISO/IEC alpha2 country code for the country in which this device is currently operating. Default 00 (World regulatory)"


### PR DESCRIPTION
When IP fragementation is enabled, the checksum needs to computed before fragmentation and verified only after re-assembly, but as fragmentation/re-assembly are done in Zephy, offloaded checksum won't work.

Till we figure out a permanent solution for this, disable checksum offload when IP fragmentation is enabled.

Fixes SHEL-1800.