### PR TITLE
samples: bluetooth: Set report ID in HIDs keyboard to 0.

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -244,6 +244,12 @@ Bluetooth samples
 
     * Aligned timers' configurations to the new nrfx API.
 
+* :ref:`peripheral_hids_keyboard` sample:
+
+  * Changed:
+
+    * Fixed an interoperability issue with iOS devices by setting the report IDs of HID input and output reports to zero.
+
 Bluetooth mesh samples
 ----------------------
 

--- a/samples/bluetooth/peripheral_hids_keyboard/src/main.c
+++ b/samples/bluetooth/peripheral_hids_keyboard/src/main.c
@@ -38,8 +38,8 @@
 
 #define OUTPUT_REPORT_MAX_LEN            1
 #define OUTPUT_REPORT_BIT_MASK_CAPS_LOCK 0x02
-#define INPUT_REP_KEYS_REF_ID            1
-#define OUTPUT_REP_KEYS_REF_ID           1
+#define INPUT_REP_KEYS_REF_ID            0
+#define OUTPUT_REP_KEYS_REF_ID           0
 #define MODIFIER_KEY_POS                 0
 #define SHIFT_KEY_CODE                   0x02
 #define SCAN_CODE_POS                    2


### PR DESCRIPTION
As confirmed with iOS 16, setting the report ID for input and output reports to 0 in peripheral_hids_keyboard sample fixes an issue where the device would not be detected as a native keyboard input.
The new setting seems to be aligned also with the HID Service Specification V10r00, section 2.5.3.2 which says the ID shall be non-zero, when there are multiple reports defined within a specific report type. In this case there is just 1 input and 1 output report, so there is no need to distinguish reports within each type by their IDs.

This PR reintroduces https://github.com/nrfconnect/sdk-nrf/pull/8772