### PR TITLE
samples: cellular: modem_shell: Use snippet for enabling UART traces

### DIFF
--- a/samples/cellular/modem_shell/sample.yaml
+++ b/samples/cellular/modem_shell/sample.yaml
@@ -26,7 +26,9 @@ tests:
     tags: ci_build
   sample.cellular.modem_shell.cloud_mqtt_rest:
     build_only: true
-    extra_args: CONFIG_MOSH_CLOUD_MQTT=y CONFIG_MOSH_CLOUD_REST=y
+    extra_configs:
+      - CONFIG_MOSH_CLOUD_MQTT=y
+      - CONFIG_MOSH_CLOUD_REST=y
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - nrf9161dk_nrf9161_ns
@@ -297,7 +299,7 @@ tests:
   # Basic UART trace configuration is tested in sample.nrf9160.modem_shell.integration_config.
   sample.cellular.modem_shell_modem_uart_trace:
     build_only: true
-    extra_args: CONFIG_NRF_MODEM_LIB_TRACE=y
+    extra_args: SNIPPET="nrf91-modem-trace-uart"
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - nrf9161dk_nrf9161_ns
@@ -305,7 +307,7 @@ tests:
     tags: ci_build
   sample.cellular.modem_shell.non_offloading_ip_modem_uart_trace:
     build_only: true
-    extra_args: OVERLAY_CONFIG=overlay-non-offloading.conf CONFIG_NRF_MODEM_LIB_TRACE=y
+    extra_args: OVERLAY_CONFIG=overlay-non-offloading.conf SNIPPET="nrf91-modem-trace-uart"
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - nrf9161dk_nrf9161_ns
@@ -313,7 +315,7 @@ tests:
     tags: ci_build
   sample.cellular.modem_shell.thingy91_modem_uart_trace:
     build_only: true
-    extra_args: CONFIG_NRF_MODEM_LIB_TRACE=y
+    extra_args: SNIPPET="nrf91-modem-trace-uart"
     integration_platforms:
       - thingy91_nrf9160_ns
     platform_allow: thingy91_nrf9160_ns
@@ -325,7 +327,7 @@ tests:
     extra_configs:
       - CONFIG_LTE_NETWORK_MODE_LTE_M=y
       - CONFIG_MODEM_ANTENNA_GNSS_EXTERNAL=y
-      - CONFIG_NRF_MODEM_LIB_TRACE=y
+    extra_args: SNIPPET="nrf91-modem-trace-uart"
     integration_platforms:
       - nrf9160dk_nrf9160_ns
     platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns


### PR DESCRIPTION
Updated sample.yaml to use nrf91-modem-trace-uart snippet for enabling modem UART traces.

Updated disabling of UART1 to use Zephyr PM API when the Zephyr UART trace backend is used.

Fixed possible deadlock when disabling UART1 using direct register access.