### PR TITLE
doc: known_issues: Add NCSDK-22810

### DIFF
--- a/doc/nrf/releases_and_maturity/known_issues.rst
+++ b/doc/nrf/releases_and_maturity/known_issues.rst
@@ -1293,6 +1293,14 @@ NCSDK-8304: HID configurator issues for peripherals connected over Bluetooth® L
 
   **Workaround:** Use BlueZ in version 5.56 or higher.
 
+.. rst-class:: v2-4-1 v2-4-0 v2-3-0 v2-2-0 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0
+
+NCSDK-22810: Assertion fail when logging :c:struct:`config_event` with an unknown status
+  The :c:member:`config_event.status` field is set according to data received from the host computer over :ref:`nrf_desktop_config_channel`.
+  Setting it to a value unknown to an nRF Desktop device should not cause assertion failure.
+
+  **Workaround:** Manually cherry-pick and apply the commit with the fix from the ``main`` branch (commit hash: ``a49008a980dbddcb48c80736f76fedbfda9c03f6``).
+
 .. rst-class:: v2-3-0 v2-2-0 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0
 
 NCSDK-20366: Possible bus fault in :ref:`nrf_desktop_selector` while toggling a hardware selector


### PR DESCRIPTION
Change adds known issue related to assertion failure when logging config_event with an unknown status.

Jira: NCSDK-22810