### PR TITLE
TF-M: Fix and document TF-M build issue with printf and heap

### DIFF
--- a/doc/nrf/releases_and_maturity/known_issues.rst
+++ b/doc/nrf/releases_and_maturity/known_issues.rst
@@ -3579,6 +3579,11 @@ Trusted Firmware-M (TF-M)
 
 The issues in this section are related to the TF-M implementation in the |NCS|.
 
+.. rst-class:: v2-4-0
+
+NCSDK-22818: TF-M does not build with :kconfig:option:`CONFIG_TFM_PROFILE_TYPE_MINIMAL` disabled and :kconfig:option:`CONFIG_TFM_LOG_LEVEL_SILENCE` enabled
+  This fails with the error: message "undefined reference to 'end'" caused by printf being included in the build.
+
 .. rst-class:: v2-4-1 v2-4-0 v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0
 
 NCSDK-22629: TF-M might fail to reset when using nrfjprog version 10.22.x on nRF9160 platforms

--- a/modules/tfm/tfm/boards/CMakeLists.txt
+++ b/modules/tfm/tfm/boards/CMakeLists.txt
@@ -65,6 +65,11 @@ if (NOT ${PLATFORM_DEFAULT_PROVISIONING})
     )
 endif()
 
+target_sources(tfm_sprt
+    PRIVATE
+        $<$<NOT:$<BOOL:${TFM_SP_LOG_RAW_ENABLED}>>:${CMAKE_CURRENT_SOURCE_DIR}/common/dummy_tfm_sp_log_raw.c>
+)
+
 # Disabling UART stdout not supported in NS Image, which is always built even when not needed.
 target_sources(platform_ns
   PRIVATE

--- a/modules/tfm/tfm/boards/common/dummy_tfm_sp_log_raw.c
+++ b/modules/tfm/tfm/boards/common/dummy_tfm_sp_log_raw.c
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+
+/* This function is here in case any references to printf has been accidentally
+ * left in the code. This will then mute this printfs from pulling in the real
+ * printf instead of the function defined in tfm_sp_log_raw.c when this file
+ * is not part of the build.
+ */
+int printf(const char *fmt, ...)
+{
+        return 0;
+}


### PR DESCRIPTION
Fix undefined reference to 'end' when disabling secure output from the
TF-M image.

When secure output is disabled the printf function is not overriden
in TF-M and the libc variant has references to heap functions.
Make sure that the printf function is overriden for this case also and
drop the output message.

NCSDK-22818