### PR TITLE
Fast Pair: Separate show/hide UI indications from advertising mode

### DIFF
--- a/doc/nrf/external_comp/bt_fast_pair.rst
+++ b/doc/nrf/external_comp/bt_fast_pair.rst
@@ -93,7 +93,7 @@ The Fast Pair service implementation provides API to generate the advertising da
   To use this extension, ensure the following:
 
   #. Call :c:func:`bt_fast_pair_battery_set` to provide battery information.
-  #. Set :c:member:`bt_fast_pair_adv_config.adv_battery_mode` to either :c:enum:`BT_FAST_PAIR_ADV_BATTERY_MODE_SHOW_UI_IND` or :c:enum:`BT_FAST_PAIR_ADV_BATTERY_MODE_HIDE_UI_IND` to include the battery notification in the generated advertising payload.
+  #. Set :c:member:`bt_fast_pair_not_disc_adv_info.battery_mode` in :c:struct:`bt_fast_pair_adv_config` to either :c:enum:`BT_FAST_PAIR_ADV_BATTERY_MODE_SHOW_UI_IND` or :c:enum:`BT_FAST_PAIR_ADV_BATTERY_MODE_HIDE_UI_IND` to include the battery notification in the generated advertising payload.
 
   See the `Fast Pair Battery Notification extension`_ documentation for more details about this extension.
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -287,6 +287,7 @@ Bluetooth samples
 
 * :ref:`peripheral_fast_pair` sample:
 
+  * Added automatic switching to the Fast Pair not discoverable advertising mode with the hide UI indication instead of removing the Fast Pair advertising payload when all bond slots are taken.
   * Updated by disabling the :kconfig:option:`CONFIG_BT_SETTINGS_CCC_LAZY_LOADING` Kconfig option as a workaround fix for the `Zephyr issue #61033`_.
   * Fixed an issue where the sample was unable to advertise in Fast Pair not discoverable advertising mode when it had five Account Keys written.
 
@@ -561,6 +562,7 @@ Bluetooth libraries and services
 
   * Updated by deleting reset in progress flag from settings storage instead of storing it as ``false`` on factory reset operation.
     This is done to ensure that no Fast Pair data is left in the settings storage after the factory reset.
+  * Changed the :c:struct:`bt_fast_pair_adv_config` structure and the :c:enum:`bt_fast_pair_adv_mode` enumerator to separate advertising mode from show or hide UI indication advertising information.
 
 * :ref:`bt_le_adv_prov_readme` library:
 

--- a/include/bluetooth/services/fast_pair.h
+++ b/include/bluetooth/services/fast_pair.h
@@ -23,30 +23,36 @@ extern "C" {
 /** Value that denotes unknown battery level (see @ref bt_fast_pair_battery). */
 #define BT_FAST_PAIR_BATTERY_LEVEL_UNKNOWN	0x7f
 
-/** @brief Fast Pair advertising mode. Used to generate advertising packet.
- *
- * According to Fast Pair specification, when no Account Key has been saved on the device both Fast
- * Pair not discoverable advertising modes result in the same advertising data.
- */
+/** @brief Fast Pair advertising mode. Used to generate advertising packet. */
 enum bt_fast_pair_adv_mode {
 	/** Fast Pair discoverable advertising. */
-	BT_FAST_PAIR_ADV_MODE_DISCOVERABLE,
+	BT_FAST_PAIR_ADV_MODE_DISC,
 
-	/** Fast Pair not discoverable advertising, show UI indication. */
-	BT_FAST_PAIR_ADV_MODE_NOT_DISCOVERABLE_SHOW_UI_IND,
-
-	/** Fast Pair not discoverable advertising, hide UI indication. */
-	BT_FAST_PAIR_ADV_MODE_NOT_DISCOVERABLE_HIDE_UI_IND,
+	/** Fast Pair not discoverable advertising. */
+	BT_FAST_PAIR_ADV_MODE_NOT_DISC,
 
 	/** Number of Fast Pair advertising modes. */
 	BT_FAST_PAIR_ADV_MODE_COUNT
 };
 
+/** @brief Fast Pair not discoverable advertising type. Used to generate advertising packet. */
+enum bt_fast_pair_not_disc_adv_type {
+	/** Show UI indication. */
+	BT_FAST_PAIR_NOT_DISC_ADV_TYPE_SHOW_UI_IND,
+
+	/** Hide UI indication. */
+	BT_FAST_PAIR_NOT_DISC_ADV_TYPE_HIDE_UI_IND,
+
+	/** Number of Fast Pair not discoverable advertising types. */
+	BT_FAST_PAIR_NOT_DISC_ADV_TYPE_COUNT
+};
+
 /** @brief Fast Pair advertising battery mode. Used to generate advertising packet.
  *
  * Battery data can be included in advertising packet only if the Fast Pair Provider is in Fast Pair
- * not discoverable advertising mode. To prevent tracking, the Fast Pair Provider should not include
- * battery data in the advertising packet all the time.
+ * not discoverable advertising mode and is in possesion of at least one Account Key. To prevent
+ * tracking, the Fast Pair Provider should not include battery data in the advertising packet
+ * all the time.
  */
 enum bt_fast_pair_adv_battery_mode {
 	/** Do not advertise battery data. */
@@ -77,13 +83,41 @@ enum bt_fast_pair_battery_comp {
 	BT_FAST_PAIR_BATTERY_COMP_COUNT
 };
 
+/** @brief Fast Pair discoverable advertising info. Currently empty. */
+struct bt_fast_pair_disc_adv_info {};
+
+/** @brief Fast Pair not discoverable advertising info. */
+struct bt_fast_pair_not_disc_adv_info {
+	/** Advertising type. According to Fast Pair specification, when no Account Key has been
+	 *  saved on the device, this field has no effect on the advertising data.
+	 */
+	enum bt_fast_pair_not_disc_adv_type type;
+
+	/** Fast Pair advertising battery mode. Battery values can be set using
+	 *  @ref bt_fast_pair_battery_set.
+	 */
+	enum bt_fast_pair_adv_battery_mode battery_mode;
+};
+
 /** @brief Fast Pair advertising config. Used to generate advertising packet. */
 struct bt_fast_pair_adv_config {
 	/** Fast Pair advertising mode. */
-	enum bt_fast_pair_adv_mode adv_mode;
+	enum bt_fast_pair_adv_mode mode;
 
-	/** Fast Pair advertising battery mode. */
-	enum bt_fast_pair_adv_battery_mode adv_battery_mode;
+	/** Fast Pair advertising info. Content depends on Fast Pair advertising mode
+	 *  (see @ref mode field).
+	 */
+	union {
+		/** Fast Pair discoverable advertising info. Relevant if @ref mode field set to
+		 *  @ref BT_FAST_PAIR_ADV_MODE_DISC.
+		 */
+		struct bt_fast_pair_disc_adv_info disc;
+
+		/** Fast Pair not discoverable advertising info. Relevant if @ref mode field set to
+		 *  @ref BT_FAST_PAIR_ADV_MODE_NOT_DISC.
+		 */
+		struct bt_fast_pair_not_disc_adv_info not_disc;
+	};
 };
 
 /** @brief Fast Pair battery component descriptor. */

--- a/samples/bluetooth/peripheral_fast_pair/README.rst
+++ b/samples/bluetooth/peripheral_fast_pair/README.rst
@@ -124,7 +124,7 @@ Button 1:
        * After a Bluetooth Central successfully pairs.
 
        After the device reaches the maximum number of paired devices (:kconfig:option:`CONFIG_BT_MAX_PAIRED`), the device stops looking for new peers.
-       Therefore, the device no longer advertises in the pairing mode (:c:member:`bt_le_adv_prov_adv_state.pairing_mode`), and only the Fast Pair not discoverable advertising with hide UI indication mode includes the Fast Pair payload.
+       Therefore, the device no longer advertises in the pairing mode (:c:member:`bt_le_adv_prov_adv_state.pairing_mode`), and the Fast Pair advertising mode is automatically set to the Fast Pair not discoverable advertising with the hide UI indication on every advertising start.
 
 Button 2:
    Increases audio volume of the connected Bluetooth Central.

--- a/samples/bluetooth/peripheral_fast_pair/include/bt_adv_helper.h
+++ b/samples/bluetooth/peripheral_fast_pair/include/bt_adv_helper.h
@@ -28,12 +28,12 @@ extern "C" {
  *
  * The function handles also periodic RPA rotation and Fast Pair advertising data update.
  *
- * @param[in] fp_adv_mode	Fast Pair advertising mode.
+ * @param[in] pairing_mode	Device is in pairing mode.
  * @param[in] new_adv_session	A new advertising session was started.
  *
  * @return 0 if the operation was successful. Otherwise, a (negative) error code is returned.
  */
-int bt_adv_helper_adv_start(enum bt_fast_pair_adv_mode fp_adv_mode, bool new_adv_session);
+int bt_adv_helper_adv_start(bool pairing_mode, bool new_adv_session);
 
 /** Stop Fast Pair sample advertising
  *

--- a/samples/bluetooth/peripheral_fast_pair/src/bt_adv_helper.c
+++ b/samples/bluetooth/peripheral_fast_pair/src/bt_adv_helper.c
@@ -10,8 +10,6 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
 #include <bluetooth/adv_prov.h>
-#include <bluetooth/adv_prov/fast_pair.h>
-#include <bluetooth/services/fast_pair.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(fp_sample, LOG_LEVEL_INF);
@@ -26,13 +24,13 @@ LOG_MODULE_DECLARE(fp_sample, LOG_LEVEL_INF);
  * timeout must be lower than CONFIG_BT_RPA_TIMEOUT to ensure that RPA rotation will always trigger
  * update of Account Key Filter advertising data.
  */
-#define RPA_TIMEOUT_NON_DISCOVERABLE	(13 * SEC_PER_MIN)
+#define RPA_TIMEOUT_NOT_DISC		(13 * SEC_PER_MIN)
 #define RPA_TIMEOUT_OFFSET_MAX		(2 * SEC_PER_MIN)
 #define RPA_TIMEOUT_FAST_PAIR_MAX	(15 * SEC_PER_MIN)
 
 BUILD_ASSERT(RPA_TIMEOUT_FAST_PAIR_MAX < CONFIG_BT_RPA_TIMEOUT);
 
-static enum bt_fast_pair_adv_mode adv_helper_fp_adv_mode;
+static bool adv_helper_pairing_mode;
 static bool adv_helper_new_adv_session;
 
 static void rpa_rotate_fn(struct k_work *w);
@@ -53,57 +51,7 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.connected        = connected,
 };
 
-static void bond_cnt_cb(const struct bt_bond_info *info, void *user_data)
-{
-	size_t *cnt = user_data;
-
-	(*cnt)++;
-}
-
-static size_t bond_cnt(void)
-{
-	size_t cnt = 0;
-
-	bt_foreach_bond(BT_ID_DEFAULT, bond_cnt_cb, &cnt);
-
-	return cnt;
-}
-
-static bool can_pair(void)
-{
-	return (bond_cnt() < CONFIG_BT_MAX_PAIRED);
-}
-
-static bool pairing_mode(enum bt_fast_pair_adv_mode fp_adv_mode)
-{
-	return ((fp_adv_mode == BT_FAST_PAIR_ADV_MODE_DISCOVERABLE) && can_pair());
-}
-
-static void configure_fp_adv_prov(enum bt_fast_pair_adv_mode fp_adv_mode)
-{
-	bt_le_adv_prov_fast_pair_enable(can_pair());
-
-	switch (fp_adv_mode) {
-	case BT_FAST_PAIR_ADV_MODE_DISCOVERABLE:
-		break;
-
-	case BT_FAST_PAIR_ADV_MODE_NOT_DISCOVERABLE_SHOW_UI_IND:
-		bt_le_adv_prov_fast_pair_show_ui_pairing(true);
-		break;
-
-	case BT_FAST_PAIR_ADV_MODE_NOT_DISCOVERABLE_HIDE_UI_IND:
-		bt_le_adv_prov_fast_pair_enable(true);
-		bt_le_adv_prov_fast_pair_show_ui_pairing(false);
-		break;
-
-	default:
-		/* Should not happen. */
-		__ASSERT_NO_MSG(false);
-		break;
-	};
-}
-
-static int adv_start_internal(enum bt_fast_pair_adv_mode fp_adv_mode)
+static int adv_start_internal(void)
 {
 	struct bt_le_oob oob;
 	int err = bt_le_adv_stop();
@@ -120,8 +68,6 @@ static int adv_start_internal(enum bt_fast_pair_adv_mode fp_adv_mode)
 		return err;
 	}
 
-	configure_fp_adv_prov(fp_adv_mode);
-
 	size_t ad_len = bt_le_adv_prov_get_ad_prov_cnt();
 	size_t sd_len = bt_le_adv_prov_get_sd_prov_cnt();
 	struct bt_data ad[ad_len];
@@ -130,7 +76,7 @@ static int adv_start_internal(enum bt_fast_pair_adv_mode fp_adv_mode)
 	struct bt_le_adv_prov_adv_state state;
 	struct bt_le_adv_prov_feedback fb;
 
-	state.pairing_mode = pairing_mode(fp_adv_mode);
+	state.pairing_mode = adv_helper_pairing_mode;
 	state.in_grace_period = false;
 	state.rpa_rotated = true;
 	state.new_adv_session = adv_helper_new_adv_session;
@@ -162,8 +108,8 @@ static int adv_start_internal(enum bt_fast_pair_adv_mode fp_adv_mode)
 
 	err = bt_le_adv_start(&adv_param, ad, ad_len, sd, sd_len);
 
-	if ((!err) && (fp_adv_mode != BT_FAST_PAIR_ADV_MODE_DISCOVERABLE)) {
-		unsigned int rpa_timeout_ms = RPA_TIMEOUT_NON_DISCOVERABLE * MSEC_PER_SEC;
+	if ((!err) && (!adv_helper_pairing_mode)) {
+		unsigned int rpa_timeout_ms = RPA_TIMEOUT_NOT_DISC * MSEC_PER_SEC;
 		int8_t rand;
 
 		err = sys_csrand_get(&rand, sizeof(rand));
@@ -187,22 +133,22 @@ static int adv_start_internal(enum bt_fast_pair_adv_mode fp_adv_mode)
 
 static void rpa_rotate_fn(struct k_work *w)
 {
-	(void)adv_start_internal(adv_helper_fp_adv_mode);
+	(void)adv_start_internal();
 }
 
-int bt_adv_helper_adv_start(enum bt_fast_pair_adv_mode fp_adv_mode, bool new_adv_session)
+int bt_adv_helper_adv_start(bool pairing_mode, bool new_adv_session)
 {
 	int ret = k_work_cancel_delayable(&rpa_rotate);
 
 	__ASSERT_NO_MSG(ret == 0);
 	ARG_UNUSED(ret);
 
-	adv_helper_fp_adv_mode = fp_adv_mode;
+	adv_helper_pairing_mode = pairing_mode;
 	adv_helper_new_adv_session = new_adv_session;
 
-	LOG_INF("Looking for a new peer: %s", pairing_mode(adv_helper_fp_adv_mode) ? "yes" : "no");
+	LOG_INF("Looking for a new peer: %s", pairing_mode ? "yes" : "no");
 
-	return adv_start_internal(fp_adv_mode);
+	return adv_start_internal();
 }
 
 int bt_adv_helper_adv_stop(void)

--- a/subsys/bluetooth/services/fast_pair/fp_advertising.c
+++ b/subsys/bluetooth/services/fast_pair/fp_advertising.c
@@ -43,14 +43,20 @@ static const uint8_t empty_account_key_list;
 
 static int check_adv_config_range(struct bt_fast_pair_adv_config fp_adv_config)
 {
-	if ((fp_adv_config.adv_mode >= BT_FAST_PAIR_ADV_MODE_COUNT) ||
-	    (fp_adv_config.adv_mode < 0)) {
+	if ((fp_adv_config.mode >= BT_FAST_PAIR_ADV_MODE_COUNT) || (fp_adv_config.mode < 0)) {
 		return -EINVAL;
 	}
 
-	if ((fp_adv_config.adv_battery_mode >= BT_FAST_PAIR_ADV_BATTERY_MODE_COUNT) ||
-	    (fp_adv_config.adv_battery_mode < 0)) {
-		return -EINVAL;
+	if (fp_adv_config.mode == BT_FAST_PAIR_ADV_MODE_NOT_DISC) {
+		if ((fp_adv_config.not_disc.type >= BT_FAST_PAIR_NOT_DISC_ADV_TYPE_COUNT) ||
+		    (fp_adv_config.not_disc.type < 0)) {
+			return -EINVAL;
+		}
+
+		if ((fp_adv_config.not_disc.battery_mode >= BT_FAST_PAIR_ADV_BATTERY_MODE_COUNT) ||
+		    (fp_adv_config.not_disc.battery_mode < 0)) {
+			return -EINVAL;
+		}
 	}
 
 	return 0;
@@ -104,11 +110,11 @@ size_t bt_fast_pair_adv_data_size(struct bt_fast_pair_adv_config fp_adv_config)
 
 	res += sizeof(fast_pair_uuid);
 
-	if (fp_adv_config.adv_mode == BT_FAST_PAIR_ADV_MODE_DISCOVERABLE) {
+	if (fp_adv_config.mode == BT_FAST_PAIR_ADV_MODE_DISC) {
 		res += bt_fast_pair_adv_data_size_discoverable();
 	} else {
 		res += bt_fast_pair_adv_data_size_non_discoverable(account_key_cnt,
-								   fp_adv_config.adv_battery_mode);
+							fp_adv_config.not_disc.battery_mode);
 	}
 
 	return res;
@@ -236,12 +242,10 @@ int bt_fast_pair_adv_data_fill(struct bt_data *bt_adv_data, uint8_t *buf, size_t
 		return -EINVAL;
 	}
 
-	if (fp_adv_config.adv_battery_mode != BT_FAST_PAIR_ADV_BATTERY_MODE_NONE) {
-		if (fp_adv_config.adv_mode == BT_FAST_PAIR_ADV_MODE_DISCOVERABLE) {
-			LOG_INF("Battery data can't be included in Discoverable Advertising");
-		} else if (account_key_cnt == 0) {
-			LOG_INF("Battery data can't be included when Account Key List is empty");
-		}
+	if ((fp_adv_config.mode == BT_FAST_PAIR_ADV_MODE_NOT_DISC) &&
+	    (fp_adv_config.not_disc.battery_mode != BT_FAST_PAIR_ADV_BATTERY_MODE_NONE) &&
+	    (account_key_cnt == 0)) {
+		LOG_INF("Battery data can't be included when Account Key List is empty");
 	}
 
 	net_buf_simple_init_with_data(&nb, buf, buf_size);
@@ -249,16 +253,16 @@ int bt_fast_pair_adv_data_fill(struct bt_data *bt_adv_data, uint8_t *buf, size_t
 
 	net_buf_simple_add_le16(&nb, fast_pair_uuid);
 
-	if (fp_adv_config.adv_mode == BT_FAST_PAIR_ADV_MODE_DISCOVERABLE) {
+	if (fp_adv_config.mode == BT_FAST_PAIR_ADV_MODE_DISC) {
 		err = fp_adv_data_fill_discoverable(&nb);
 	} else {
-		if (fp_adv_config.adv_mode == BT_FAST_PAIR_ADV_MODE_NOT_DISCOVERABLE_SHOW_UI_IND) {
+		if (fp_adv_config.not_disc.type == BT_FAST_PAIR_NOT_DISC_ADV_TYPE_SHOW_UI_IND) {
 			ak_filter_type = FP_FIELD_TYPE_SHOW_PAIRING_UI_INDICATION;
 		} else {
 			ak_filter_type = FP_FIELD_TYPE_HIDE_PAIRING_UI_INDICATION;
 		}
 		err = fp_adv_data_fill_non_discoverable(&nb, account_key_cnt, ak_filter_type,
-							fp_adv_config.adv_battery_mode);
+							fp_adv_config.not_disc.battery_mode);
 	}
 
 	if (!err) {


### PR DESCRIPTION
Changed bt_fast_pair_adv_config struture.
Aligned Fast Pair Advertising Provider with new API.
Aligned Fast Pair sample with new API.
Slightly changed Fast Pair sample behavior:
Added automatic switching to the Fast Pair not discoverable advertising
mode with the hide UI indication instead of removing Fast Pair
advertising payload when all bond slots are taken.

Jira: NCSDK-18122