### PR TITLE
manifest: sdk-zephyr: Pull DHCP unicast offer feature

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: a2a683b95343e47116caf936e695e754076e3c53
+      revision: f8818ca669fada5bcbe97f51c4dcde5ebfe69afc
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This fixes DHCP issues with misbehaving APs that do not conform to "bootp flag".

Fixes SHEL-1171.