### PR TITLE
Bluetooth: Mesh: Fix dim to dark behavior

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -448,6 +448,7 @@ Bluetooth libraries and services
   * Updated:
 
     * The :kconfig:option:`BT_MESH_MODEL_SRV_STORE_TIMEOUT` Kconfig option, that is controlling timeout for storing of model states, is replaced by the :kconfig:option:`BT_MESH_STORE_TIMEOUT` Kconfig option.
+    * The Light Lightness Actual and Generic Power Level states of the :ref:`bt_mesh_lightness_srv_readme` and :ref:`bt_mesh_plvl_srv_readme` models cannot dim to off. This is due to binding with Generic Level state when receiving Generic Delta Set and Generic Move Set messages.
 
   * Fixed an issue where the :ref:'bt_mesh_dtt_srv_readme' model could not be found for models spanning multiple elements.
   * Fixed an issue where the :ref:'bt_mesh_sensor_srv_readme' model would add a corrupted marshalled sensor data into the Sensor Status message because the fetched sensor value was outside of range.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -258,6 +258,7 @@ Bluetooth mesh samples
 
 * :ref:`bluetooth_mesh_light_lc` sample:
 
+  * Fixed an issue where the sample could return an invalid Light Lightness Status message if the transition time was evaluated to zero.
   * Removed support for the configuration with :ref:`CMSE enabled <app_boards_spe_nspe_cpuapp_ns>` for :ref:`zephyr:thingy53_nrf5340`.
 
 * :ref:`bluetooth_mesh_light_dim` sample:

--- a/samples/bluetooth/mesh/light_ctrl/src/model_handler.c
+++ b/samples/bluetooth/mesh/light_ctrl/src/model_handler.c
@@ -132,7 +132,7 @@ static void light_set(struct bt_mesh_lightness_srv *srv,
 		CONTAINER_OF(srv, struct lightness_ctx, lightness_srv);
 
 	start_new_light_trans(set, l_ctx);
-	rsp->current = l_ctx->current_lvl;
+	rsp->current = l_ctx->rem_time ? l_ctx->current_lvl : l_ctx->target_lvl;
 	rsp->target = l_ctx->target_lvl;
 	rsp->remaining_time = set->transition ? set->transition->time : 0;
 }

--- a/subsys/bluetooth/mesh/gen_plvl_srv.c
+++ b/subsys/bluetooth/mesh/gen_plvl_srv.c
@@ -463,10 +463,10 @@ static void lvl_delta_set(struct bt_mesh_lvl_srv *lvl_srv,
 	}
 
 	struct bt_mesh_plvl_set set = {
-		/* Clamp the target value before storing it in a uint16_t to
-		 * avoid overflow:
+		/* Clamp the value to the power level range to prevent it be moved back to zero in
+		 * binding with Generic Level state.
 		 */
-		.power_lvl = CLAMP(start_lvl + delta_set->delta, 0, UINT16_MAX),
+		.power_lvl = CLAMP(start_lvl + delta_set->delta, srv->range.min, srv->range.max),
 		.transition = delta_set->transition,
 	};
 


### PR DESCRIPTION
According to E22980, section 6.1.2.2.2 of MshMDLd1.1, Delta Set and Move
Set can never dim the lightness value to zero.