### PR TITLE
doc: add create an application page

### DIFF
--- a/doc/nrf/create_application.rst
+++ b/doc/nrf/create_application.rst
@@ -1,0 +1,236 @@
+.. _create_application:
+
+Create an application
+#####################
+
+.. contents::
+   :local:
+   :depth: 2
+
+The process for creating an application in the |NCS| follows Zephyr's :ref:`Application Development principles <zephyr:application>` and the |NCS|'s :ref:`dev-model`.
+The following sections provide basic information based on these two sources.
+
+.. _create_application_structure:
+
+Application structure
+*********************
+
+Here are the files that most of the Zephyr and |NCS| applications include in its :file:`<app>` directory:
+
+.. ncs-include:: develop/application/index.rst
+   :docset: zephyr
+   :start-after: Here are the files in a simple Zephyr application:
+   :end-before: These contents are:
+
+You can read more about each of these files in Zephyr's :ref:`Application Development overview <zephyr:application>`.
+
+.. _create_application_types:
+
+Application types
+*****************
+
+Based on where the :file:`<app>` directory is located, you will usually work with one of two types of applications in the |NCS|: workspace or freestanding.
+These types are adopted from :ref:`Zephyr application types <zephyr:zephyr-app-types>`.
+
+.. _create_application_types_workspace:
+
+Workspace application
+=====================
+
+This kind of application is located inside a west workspace, but outside of the repositories of the SDK.
+The application placed in a workspace uses its own copy of the |NCS|.
+It specifies the |NCS| version through the :file:`west.yml` `west manifest file`_, which is located in the application :file:`<app>` directory.
+
+With this kind of application, the workspace has the following structure:
+
+.. code-block:: none
+
+   <home>/
+   └─── <west-workspace>/
+      ├─── .west/
+      ├─── nrf/
+      ├─── zephyr/
+      ├─── ...
+      └─── <app>/
+         ├── src/
+         ├── ...
+         └── west.yml
+
+This application type is suitable for the following development cases:
+
+* You want to take advantage of west to manage your own set of repositories.
+* You want to make changes to one or more of the repositories of the |NCS| when working on the application.
+* You want to develop a project that involves more than one build target, for example using a mesh networking protocol like :ref:`ug_matter` or :ref:`ug_bt_mesh`.
+* You want to run a big project that lets you develop most features without having to patch the |NCS| tree, for example with out-of-tree boards, drivers, SoCs, and so on.
+
+For more information about applications placed in workspace in the |NCS|, see the :ref:`workflow 4 on the development model page <dm_workflow_4>`.
+
+.. _create_application_types_freestanding:
+
+Freestanding application
+========================
+
+This kind of application is handled separately from the |NCS|.
+It is located out-of-tree, that is outside of a west workspace, and is not using the `west manifest file`_ to specify the SDK version.
+Instead, the |NCS| version is taken from the :makevar:`ZEPHYR_BASE` environment variable.
+This means that all freestanding applications will use the same |NCS| version and the same copy of the SDK.
+
+With this kind of application, the workspace has the following structure:
+
+.. code-block:: none
+
+   <home>/
+   ├─── <west-workspace>/
+   │  ├─── .west/
+   │  ├─── nrf/
+   │  ├─── zephyr/
+   │  └─── ...
+   └─── <app>/
+      ├─── src/
+      └─── ...
+
+This application type is suitable for the following development cases:
+
+* You prefer to use one copy of the |NCS| when working on one or more applications because of limited bandwidth.
+* You want to do quick prototyping and the results might be later deleted or migrated to an :ref:`application in a workspace <create_application_types_workspace>`.
+
+For more information about freestanding applications in the |NCS|, see the :ref:`workflow 2 on the development model page <dm_workflow_2>`.
+
+Creating an |NCS| application
+*****************************
+
+The process for creating an |NCS| application depends on the development environment.
+Using the |nRFVSC| is the recommended method.
+
+.. _creating_vsc:
+
+Creating application in the |nRFVSC|
+====================================
+
+Use the following steps depending on the application placement:
+
+.. tabs::
+
+   .. group-tab:: Workspace application (recommended)
+
+      To create a workspace application in the |nRFVSC|:
+
+      1. Open |VSC|.
+      #. Open the |nRFVSC|.
+      #. In the :guilabel:`Welcome View`, click the :guilabel:`Create a new application` action.
+         A quick pick menu appears.
+      #. Click **Create a blank application**.
+      #. Enter a location for the application.
+         This will be the *<west-workspace>/* directory mentioned in the :ref:`workspace application structure <create_application_types_workspace>`.
+      #. Enter the name of the application.
+         The application creation process starts after you enter the name.
+         When the application is created, a VS Code prompt appears.
+      #. Click **Open**.
+         This opens the new application and adds it to the :guilabel:`Applications View` in the extension.
+      #. Add the :file:`west.yml` to create a west workspace around the application:
+
+         a. In the :guilabel:`Welcome View`, click the :guilabel:`Manage SDKs` action.
+            A quick pick menu appears.
+         #. Click :guilabel:`Create west workspace`.
+         #. Enter a location for the :file:`west.yml` file that matches the location provided in step 4.
+         #. Select the SDK version for the west workspace.
+            The west workspace is initialized and the :guilabel:`Manage SDKs` action changes to :guilabel:`Open west manifest`.
+         #. In the :guilabel:`Applications View`, click the :guilabel:`Run West Update` button to update the workspace modules.
+
+      See the `extension documentation <west module management_>`_ for more information about west workspace and workspace applications in the extension.
+
+   .. group-tab:: Freestanding application
+
+      To create a freestanding application in the |nRFVSC|:
+
+      1. Open |VSC|.
+      #. Open the |nRFVSC|.
+      #. In the :guilabel:`Welcome View`, click the :guilabel:`Create a new application` action.
+         A quick pick menu appears.
+      #. Click **Create a blank application**.
+      #. Enter a location for the application.
+      #. Enter the name of the application.
+         The application creation process starts after you enter the name.
+         When the application is created, a VS Code prompt appears.
+      #. Click **Open**.
+         This opens the new application and adds it to the :guilabel:`Applications View` in the extension.
+
+      See the `extension documentation <Create a new application_>`_ for more information about creating freestanding applications in the extension.
+
+You can now start :ref:`configuring and building <configuration_and_build>` the application.
+
+.. _creating_cmd:
+
+Creating application for use with command line
+==============================================
+
+Nordic Semiconductor recommends using the example application repository to create a workspace application, but you can also create freestanding applications.
+
+Use the following steps depending on the application type:
+
+.. tabs::
+
+   .. group-tab:: Workspace application (recommended)
+
+      This recommended process for command line takes advantage of Nordic Semiconductor's example application template repository, similar to the example application used for :ref:`creating an application in Zephyr <zephyr:application>`.
+
+      .. include:: /releases_and_maturity/developing/adding_code.rst
+         :start-after: example_app_start
+         :end-before: example_app_end
+
+      To create a workspace application:
+
+      1. Open the `ncs-example-application`_ repository in your browser.
+      #. Click the :guilabel:`Use this template` button on the GitHub web user interface.
+         This creates your own copy of the template repository.
+         In the copy of the repository, the :file:`app` directory contains the template application that you can start modifying.
+      #. Open a command line terminal.
+      #. Initialize the repository with the repository name and path you have chosen for your manifest repository (*your-name/your-application* and *your-app-workspace*, respectively).
+         *your-app-workspace* corresponds to :file:`ncs/` in the :ref:`workspace application structure <create_application_types_workspace>`.
+         Use the following command pattern:
+
+         .. parsed-literal::
+            :class: highlight
+
+            west init -m https:\ //github.com/*your-name/your-application* *your-app-worskpace*
+
+      #. Go to the *your-app-workspace* directory using the following command pattern:
+
+         .. parsed-literal::
+            :class: highlight
+
+            cd *your-app-workspace*
+
+      #. Run the following west command to download the contents of the |NCS|:
+
+         .. code-block::
+            :class: highlight
+
+            west update
+
+         west will clone the |NCS| contents next to the example application directory.
+
+      For more information, see the detailed description of the :ref:`workspace application workflow <dm_workflow_4>`.
+
+   .. group-tab:: Freestanding application
+
+      This procedure follows Zephyr's steps for :ref:`zephyr:zephyr-creating-app-by-hand` and the :ref:`workflow 2 on the development model page <dm_workflow_2>`.
+      You can copy any of the :ref:`applications` or :ref:`samples` in the |NCS| as your source code files.
+
+      To create a freestanding application:
+
+      .. ncs-include:: develop/application/index.rst
+         :docset: zephyr
+         :start-after: as a starting point is likely to be easier.
+         :end-before: .. _important-build-vars:
+
+      #. Export a :ref:`Zephyr CMake package <zephyr:cmake_pkg>` by running the following command from the main directory of your |NCS| repository copied during :ref:`installation`:
+
+         .. code-block::
+            :class: highlight
+
+             west zephyr-export
+
+         This allows CMake to automatically load the boilerplate code required for building |NCS| applications.
+
+You can now start :ref:`configuring and building <configuration_and_build>` the application using the command line.

--- a/doc/nrf/index.rst
+++ b/doc/nrf/index.rst
@@ -18,6 +18,7 @@ A "99" at the end of the version number of this documentation indicates continuo
 
    introduction
    installation
+   create_application
    config_and_build
    test_and_optimize
    device_guides

--- a/doc/nrf/installation.rst
+++ b/doc/nrf/installation.rst
@@ -23,7 +23,7 @@ This repository is the manifest repository, because it contains the SDK's `west 
 To set up the |NCS|, use one of the following installation methods:
 
 * :ref:`Install the nRF Connect SDK automatically using nRF Connect for Desktop <auto_installation>`.
-  This will install all the :ref:`requirements <requirements>`, including the |VSC| and the `nRF Connect for Visual Studio Code`_ extension, which is recommended for building applications.
+  This will install all the :ref:`requirements <requirements>`, including the |VSC| and the `nRF Connect for Visual Studio Code`_ extension, which is recommended for creating and building applications.
 * :ref:`Install the nRF Connect SDK toolchain manually <manual_installation>`.
   This is an option if you have any issues when installing the |NCS| automatically.
 

--- a/doc/nrf/installation/assistant.rst
+++ b/doc/nrf/installation/assistant.rst
@@ -90,7 +90,7 @@ To build on the |nRFVSC|, complete the following steps:
 #. Click **Install missing extensions**.
 #. Once the extensions are installed, click **Open VS Code** button again.
 
-You can then follow the instructions in :ref:`programming_vsc`.
+You can then follow the instructions in :ref:`creating_vsc`.
 
 .. _auto_installation_choose_building_method_cl:
 
@@ -110,4 +110,4 @@ To build on the command line, complete the following steps:
 
 #. Select :guilabel:`Open command prompt`.
 
-You can then follow the instructions in :ref:`programming_cmd`.
+You can then follow the instructions in :ref:`creating_cmd`.

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -206,6 +206,7 @@
 .. _`How to work with build configurations`: https://nrfconnect.github.io/vscode-nrf-connect/guides/build_config.html
 .. _`Memory report`: https://nrfconnect.github.io/vscode-nrf-connect/guides/memory_overview.html
 .. _`Kconfig action in the Actions View`: https://nrfconnect.github.io/vscode-nrf-connect/reference/ui_sidebar_actions.html
+.. _`Create a new application`: https://nrfconnect.github.io/vscode-nrf-connect/reference/ui_sidebar_welcome.html#create-a-new-application
 
 .. _`SPAKE2+ Python Tool page`: https://project-chip.github.io/connectedhomeip-doc/scripts/tools/spake2p/README.html
 

--- a/doc/nrf/releases_and_maturity/developing/adding_code.rst
+++ b/doc/nrf/releases_and_maturity/developing/adding_code.rst
@@ -28,7 +28,9 @@ All workflows are described under the following basic assumptions:
 * Additional board definitions might be required by the user.
 * Additional libraries might be required by the user.
 * The term *application* refers to the application code and any board definitions and libraries it requires.
-* The application(s) will require updates of the |NCS| revision.
+* The application will require updates of the |NCS| revision.
+
+.. _dm_workflow_1:
 
 Workflow 1: Avoid Git and west
 ==============================
@@ -36,25 +38,36 @@ Workflow 1: Avoid Git and west
 If you have your own version control tools, you might want to simply not use Git or west at all, and instead rely on your own toolset.
 In such case, you must obtain a copy of the |NCS| on your file system and then manage the source code of both the SDK and your application yourself.
 
-Since no downloadable packages of the |NCS| are currently available, the simplest path to obtain the source code is to follow the instructions in the :ref:`corresponding section <dm-wf-get-ncs>` of the documentation.
-This requires you to install Git and west, but you can then ignore them from that point onwards.
-If you need to update the copy of the |NCS| you are working with, you can :ref:`obtain the source code <dm-wf-get-ncs>` again, or, if you have kept the original set of repositories, :ref:`update it instead <dm-wf-update-ncs>`.
+To obtain a copy of the |NCS|, you can use one of the following methods:
+
+* :ref:`auto_installation_tcm_setup` from nRF Connect for Desktop and download the desired |NCS| version.
+  This corresponds to steps 2 and 3 on the linked page.
+* Follow the instructions in the :ref:`dm-wf-get-ncs` section of the documentation.
+  This requires you to install Git and west, but you can then ignore them from that point onwards.
+
+If you need to update the copy of the |NCS| you are working with, you can obtain the source code again, or, if you have kept the original set of repositories, update it in the Toolchain Manager or by following steps in :ref:`dm-wf-update-ncs`.
+
 Once you have obtained a copy of the |NCS| source code, which is self-contained in a single folder, you can then proceed to manage that code in any way you see fit.
 
 Unless you take some :ref:`additional steps <zephyr:no-west>`, west itself must still be installed in order to build applications.
 
-Workflow 2: Out-of-tree application repository
-==============================================
+.. _dm_workflow_2:
+
+Workflow 2: Freestanding application repository
+===============================================
 
 Another approach to maintaining your application is to completely decouple it from the |NCS| repositories and instead host it wherever you prefer - in Git, another version control system, or simply on your hard drive.
-This is typically also known as "out-of-tree" application, meaning that the application, board definitions, and any other libraries are actually outside any of the repositories provided by the |NCS| and can be placed anywhere at all.
-As long as you do not need to make any changes to any of the repositories of the |NCS|, you can use the procedures to :ref:`get the source code <dm-wf-get-ncs>` and later :ref:`update it <dm-wf-update-ncs>`, and manage your application separately, inside or outside the top folder of the |NCS|.
+This is typically also known as a :ref:`freestanding <zephyr:zephyr-app-types>` or "out-of-tree" application, meaning that the application, board definitions, and any other libraries are actually outside any of the repositories provided by the |NCS| and can be placed anywhere at all.
 
+As long as you do not need to make changes to any of the repositories of the |NCS|, you can use either the :ref:`Toolchain Manager <auto_installation_tcm_setup>` or :ref:`command line <dm-wf-get-ncs>` to get the source code and update it later.
+This allows you to manage your application separately, whether it is inside or outside the top folder of the |NCS|.
 If you choose to have your application outside of the folder hierarchy of the |NCS|, the build system will find the location of the SDK through the :makevar:`ZEPHYR_BASE` environment variable, which is set either through a script or manually in an IDE.
 More information about application development and the |NCS| build and configuration system can be found in the :ref:`app_build_system` documentation section.
 
 The drawback with this approach is that any changes you make to the set of |NCS| repositories are not directly trackable using Git, since you do not have any of the |NCS| repositories forked.
 If you are tracking the main branch of the |NCS|, you can instead send the changes you require to the official repositories as Pull Requests, so that they are incorporated into the codebase.
+
+.. _dm_workflow_3:
 
 Workflow 3: Application in a fork of sdk-nrf
 ============================================
@@ -63,7 +76,7 @@ Forking the `sdk-nrf`_ repository and adding the application to it is another va
 This approach also allows you to fork additional |NCS| repositories and point to those.
 This can be useful if you have to make changes to those repositories beyond adding your own application to the manifest repository.
 
-In order to use this approach, you first need to :ref:`get the source code <dm-wf-get-ncs>`, and then :ref:`fork the sdk-nrf repository <dm-wf-fork>`.
+In order to use this approach, you first need to get the source code (either through the :ref:`Toolchain Manager <auto_installation_tcm_setup>` or :ref:`command line <dm-wf-get-ncs>`), and then :ref:`fork the sdk-nrf repository <dm-wf-fork>`.
 Once you have your own fork, you can start adding your application to your fork's tree and push it to your own Git server.
 Every time you want to update the revision of the |NCS| that you want to use as a basis for your application, you must follow the :ref:`instructions to update <dm-wf-update-ncs>` on your own fork of ``sdk-nrf``.
 
@@ -71,8 +84,8 @@ If you have changes in additional repositories beyond `sdk-nrf`_ itself, you can
 
 .. _dm_workflow_4:
 
-Workflow 4: Application as the manifest repository
-==================================================
+Workflow 4: Workspace application repository (recommended)
+==========================================================
 
 An additional possibility is to take advantage of west to manage your own set of repositories.
 This workflow is particularly beneficial if your application is split among multiple repositories or, just like in the previous workflow, if you want to make changes to one or more |NCS| repositories, since it allows you to define the full set of repositories yourself.
@@ -80,9 +93,12 @@ This workflow is particularly beneficial if your application is split among mult
 In order to implement this approach, you first need to create a manifest repository of your own, which just means a repository that contains a :file:`west.yml` manifest file in its root.
 Next you must populate the manifest file with the list of repositories and their revisions.
 
-You have a couple of different options to create your own repository.
+You have two different options to create your own repository, as discussed in the following subsections:
 
-Once you have your new manifest repository hosted online, you can use it with west just like you use the `sdk-nrf`_  repository when :ref:`getting <dm-wf-get-ncs>` and later :ref:`updating <dm-wf-update-ncs>` the source code.
+* `Recommended: Using the example application repository`_
+* `Creating your own manifest repository from scratch`_
+
+Once you have your new manifest repository hosted online, you can use it with west just like you use the `sdk-nrf`_  repository when getting the source code (either through the :ref:`Toolchain Manager <auto_installation_tcm_setup>` or :ref:`command line <dm-wf-get-ncs>`) and later :ref:`updating it from command line <dm-wf-update-ncs>`.
 You just need to replace ``sdk-nrf`` and ``nrf`` with the repository name and path you have chosen for your manifest repository (*your-name/your-application* and *your-app-workspace*, respectively), as shown in the following code:
 
 .. parsed-literal::
@@ -95,8 +111,12 @@ You just need to replace ``sdk-nrf`` and ``nrf`` with the repository name and pa
 After that, to modify the |NCS| version associated with your app, change the ``revision`` value in the manifest file to the `sdk-nrf`_ Git tag, SHA, or the branch you want to use, save the file, and run ``west update``.
 See :ref:`zephyr:west-basics` for more details.
 
+.. _dm_workflow_4_example_repo:
+
 Recommended: Using the example application repository
 -----------------------------------------------------
+
+.. example_app_start
 
 Nordic Semiconductor maintains a templated example repository as a reference for users that choose this workflow, `ncs-example-application`_.
 This repository showcases the following features of both the |NCS| and Zephyr:
@@ -111,6 +131,8 @@ This repository showcases the following features of both the |NCS| and Zephyr:
 * Example CI configuration (using Github Actions)
 * Custom :ref:`west extension <zephyr:west-extensions>`
 
+.. example_app_end
+
 It is highly recommended to use this templated repository as a starting point for your own application manifest repository.
 Click the :guilabel:`Use this template` button on the GitHub web user interface.
 Once you have your own copy of the repository, you can then modify it.
@@ -118,6 +140,8 @@ You can add your own projects to the manifest file, as well as your own boards, 
 
 The `ncs-example-application`_ repository is tagged every time a new release of the |NCS| is launched (starting with v2.3.0), using the same version number.
 This allows you to select the tag that matches the version of the |NCS| you intend to use.
+
+.. _dm_workflow_4_own_repo:
 
 Creating your own manifest repository from scratch
 --------------------------------------------------

--- a/doc/nrf/releases_and_maturity/developing/code_base.rst
+++ b/doc/nrf/releases_and_maturity/developing/code_base.rst
@@ -86,29 +86,37 @@ Repository types
 
 There are two main types of Git repositories in the |NCS| repository set:
 
-* nRF repositories
+nRF repositories
+  These repositories have the following characteristics:
 
   * Created, developed, and maintained by Nordic.
   * Usually licensed for use on Nordic products only.
 
-* OSS repositories
+  nRF repositories are stand-alone and have no upstreams, since they are unique to the |NCS|.
+  Some examples of repositories of this type are:
+
+  * `sdk-nrf`_: The main repository for Nordic-developed software.
+  * `sdk-nrfxlib`_: A repository containing linkable libraries developed by Nordic.
+
+OSS repositories
+  These repositories have the following characteristics:
 
   * Created and maintained by Nordic.
   * Soft forks of open-source projects.
   * Typically contain a small set of changes that are specific to |NCS|.
   * Updated ("upmerged") regularly with the latest changes from the open source project.
 
-nRF repositories are stand-alone and have no upstreams, since they are unique to the |NCS|.
-Some examples of repositories of this type are:
+  OSS repositories are typically soft forks of an upstream open source project, which Nordic maintains in order to keep a small set of changes that do not belong, or have not been merged, to the upstream official open-source repository.
+  For example:
 
-* `sdk-nrf`_: The main repository for Nordic-developed software.
-* `sdk-nrfxlib`_: A repository containing linkable libraries developed by Nordic.
+  * `sdk-zephyr`_ is a soft fork (and therefore a downstream) of the upstream official `Zephyr repository`_.
+  * `sdk-mcuboot`_ is a soft fork (and therefore a downstream) of the upstream official `MCUboot repository`_.
 
-OSS repositories, on the other hand, are typically soft forks of an upstream open source project, which Nordic maintains in order to keep a small set of changes that do not belong, or have not been merged, to the upstream official open-source repository.
-For example:
+  See also :ref:`dm-oss-downstreams` and :ref:`dm-oss-userdata` for more information about how these repositories are maintained.
 
-* `sdk-zephyr`_ is a soft fork (and therefore a downstream) of the upstream official `Zephyr repository`_.
-* `sdk-mcuboot`_ is a soft fork (and therefore a downstream) of the upstream official `MCUboot repository`_.
+From Zephyr perspective, all these repositories are considered :ref:`external modules <zephyr:modules>`.
+
+.. _dm_repo_structure:
 
 Repository structure
 ********************
@@ -128,6 +136,7 @@ The figure above depicts the |NCS| repository structure.
 A central concept with this repository structure is that each revision (in Git terms) of the `sdk-nrf`_ repository completely determines the revisions of all other
 repositories (that is, the west projects).
 This means that the linear Git history of this manifest repository also determines the history of the repository set in its entirety, thanks to the :file:`west.yml` `west manifest file`_ being part of the manifest repository.
+
 West reads the contents of the manifest file to find out which revisions of the project repositories are to be checked out every time ``west update`` is run.
 In this way, you can decide to work with a specific |NCS| release either by initializing a new west installation at a particular tag or by checking out the corresponding tag for a release in an existing installation and then updating your project repositories to the corresponding state with ``west update``.
 Alternatively, you can work with the latest state of development by using the main branch of the `sdk-nrf`_ repository, updating it with Git regularly and using ``west update`` to update the project repositories every time the manifest repository changes.

--- a/doc/nrf/releases_and_maturity/developing/managing_code.rst
+++ b/doc/nrf/releases_and_maturity/developing/managing_code.rst
@@ -37,6 +37,7 @@ This can be ``main`` if you want the latest state, or any released version (for 
 If you omit the ``--mr`` parameter, west defaults to ``main``.
 
 This is the procedure used for :ref:`getting the nRF Connect SDK code <cloning_the_repositories>` when :ref:`manual_installation`.
+When :ref:`installing the nRF Connect SDK <auto_installation_ncs_tcm>` using the automatic installation method, this is handled by the Toolchain Manager in nRF Connect for Desktop.
 
 .. _dm-wf-update-ncs:
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -976,6 +976,7 @@ Documentation
 
 * Added:
 
+  * :ref:`create_application` page that provides information about the applications available in the |NCS| and how to create them.
   * A page on :ref:`ug_wireless_coexistence` in :ref:`protocols`.
   * Pages on :ref:`thread_device_types` and :ref:`thread_sed_ssed` to the :ref:`ug_thread` documentation.
   * A new section :ref:`ug_pmic`, containing :ref:`ug_npm1300_features` and :ref:`ug_npm1300_gs`.


### PR DESCRIPTION
Added a new top page about creating an application. The page expands on information previously included on Introduction. At the same time, it reuses information from Development model, but without the same level of details.
Intended to work as a bridge with the VSC extention options. NCSDK-22780.