### PR TITLE
net: lib: nrf_cloud: add missing AIR_QUAL handler to shadow encoder

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -574,8 +574,12 @@ Libraries for networking
   * Updated:
 
     * Moved JSON manipulation from :file:`nrf_cloud_fota.c` to :file:`nrf_cloud_codec_internal.c`.
-    * Fixed a build issue that occurred when MQTT and P-GPS are enabled and A-GPS is disabled.
     * :c:func:`nrf_cloud_obj_location_request_create` to use the new function :c:func:`nrf_cloud_obj_location_request_payload_add`.
+
+  * Fixed:
+
+    * A build issue that occurred when MQTT and P-GPS are enabled and A-GPS is disabled.
+    * A bug preventing ``AIR_QUAL`` from being enabled in shadow UI service info.
 
   * Removed:
 

--- a/include/net/nrf_cloud.h
+++ b/include/net/nrf_cloud.h
@@ -448,10 +448,10 @@ struct nrf_cloud_svc_info_ui {
 	uint8_t log:1;
 	/** Dictionary (binary) Logs */
 	uint8_t dictionary_log:1;
-
-	/* Items without UI support on nRF Cloud */
 	/** Air Quality */
 	uint8_t air_quality:1;
+
+	/* Items without UI support on nRF Cloud */
 	/** Light sensor */
 	uint8_t light_sensor:1;
 	/** Button */

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec_internal.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec_internal.c
@@ -1122,6 +1122,11 @@ static int nrf_cloud_encode_service_info_ui(const struct nrf_cloud_svc_info_ui *
 				cJSON_CreateString(sensor_type_str[NRF_CLOUD_SENSOR_AIR_PRESS]));
 			++item_cnt;
 		}
+		if (ui->air_quality) {
+			cJSON_AddItemToArray(array,
+				cJSON_CreateString(sensor_type_str[NRF_CLOUD_SENSOR_AIR_QUAL]));
+			++item_cnt;
+		}
 		if (ui->gnss) {
 			cJSON_AddItemToArray(array,
 				cJSON_CreateString(sensor_type_str[NRF_CLOUD_SENSOR_GNSS]));


### PR DESCRIPTION
Prior to this commit, nrf_cloud_encode_service_info_ui erroneously ignores the air_quality member of nrf_cloud_svc_info_ui. This commit adds the missing handler, so that AIR_QUALITY is correctly enabled when updating shadow.

IRIS-6724