### PR TITLE
tests: bluetooth: Converted test to build_only

### DIFF
--- a/tests/bluetooth/iso/testcase.yaml
+++ b/tests/bluetooth/iso/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   bluetooth.bis_and_acl:
+    build_only: true
     platform_allow: nrf5340dk_nrf5340_cpuapp nrf5340_audio_dk_nrf5340_cpuapp
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp


### PR DESCRIPTION
This is not a unit test, hence the build_only tag has been added