### PR TITLE
west.yml: Update manifest to bring MCUboot direct XIP revert

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: c9d01d05ce83a8cec0fd60bf8e2ba27c1534d08f
+      revision: pull/1260/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -126,7 +126,7 @@ manifest:
           compare-by-default: false
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 823fd369c1430b50d263ccd6fbcf98bdd44001ba
+      revision: pull/266/head
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR.git


### PR DESCRIPTION
Change updates manifest to bring MCUboot direct XIP revert.

Jira: NCSDK-22836