### PR TITLE
samples: cellular: modem_shell: sock: Add packet number prefix

### DIFF
--- a/samples/cellular/modem_shell/src/sock/sock.h
+++ b/samples/cellular/modem_shell/src/sock/sock.h
@@ -20,20 +20,24 @@ enum sock_recv_print_format {
 	SOCK_RECV_PRINT_FORMAT_HEX,
 };
 
-int sock_open_and_connect(int family, int type, char *address, int port,
-			  int bind_port, int pdn_cid, bool secure, int sec_tag,
-			  bool session_cache, int peer_verify,
-			  char *peer_hostname);
+int sock_open_and_connect(
+	int family, int type, char *address, int port,
+	int bind_port, int pdn_cid, bool secure, int sec_tag,
+	bool session_cache, int peer_verify,
+	char *peer_hostname);
 
-int sock_send_data(int socket_id, char *data, int data_length, int interval,
-		   bool blocking, int buffer_size, bool data_format_hex);
+int sock_send_data(
+	int socket_id, char *data, int data_length, int interval, bool packet_number_prefix,
+	bool blocking, int buffer_size, bool data_format_hex);
 
-int sock_recv(int socket_id, bool receive_start, int data_length, bool blocking,
-	      enum sock_recv_print_format print_format);
+int sock_recv(
+	int socket_id, bool receive_start, int data_length, bool blocking,
+	enum sock_recv_print_format print_format);
 
 int sock_close(int socket_id);
-int sock_rai(int socket_id, bool rai_last, bool rai_no_data, bool rai_one_resp,
-	     bool rai_ongoing, bool rai_wait_more);
+int sock_rai(
+	int socket_id, bool rai_last, bool rai_no_data, bool rai_one_resp,
+	bool rai_ongoing, bool rai_wait_more);
 int sock_list(void);
 
 #endif /* MOSH_SOCK_H */

--- a/samples/cellular/modem_shell/src/sock/sock_shell.c
+++ b/samples/cellular/modem_shell/src/sock/sock_shell.c
@@ -80,6 +80,12 @@ static const char sock_usage_str[] =
 	"                            used with -d or -e option.\n"
 	"  -e, --period, [int]       Data sending interval in seconds. You must also\n"
 	"                            specify -d.\n"
+	"      --packet_number_prefix\n"
+	"                            Add a 4 digit packet number into the beginning of each\n"
+	"                            packet.\n"
+	"                            The number is between 0001..9999 and it can roll over.\n"
+	"                            Must be used with -d and -e options and without\n"
+	"                            -l and -x options.\n"
 	"  -B, --blocking, [int]     Blocking (1) or non-blocking (0) mode. This is only\n"
 	"                            valid when -l is given. Default value is 1.\n"
 	"  -s, --buffer_size, [int]  Send buffer size. This is only valid when -l is\n"
@@ -91,7 +97,7 @@ static const char sock_usage_str[] =
 	"                            of hexadecimal characters and each pair of two\n"
 	"                            characters form a single byte. Any spaces will be\n"
 	"                            removed before processing.\n"
-	"                            Examples of hexadecimal data strings:\n"
+	"                            Examples of equivalent hexadecimal data strings:\n"
 	"                                010203040506070809101112\n"
 	"                                01 02 03 04 05 06 07 08 09 10 11 12\n"
 	"                                01020304 05060708 09101112\n"
@@ -138,6 +144,7 @@ static const char sock_usage_str[] =
 #define SOCK_SHELL_OPT_RAI_ONE_RESP 202
 #define SOCK_SHELL_OPT_RAI_ONGOING 203
 #define SOCK_SHELL_OPT_RAI_WAIT_MORE 204
+#define SOCK_SHELL_OPT_PACKET_NUMBER_PREFIX 205
 
 /* Specifying the expected options (both long and short): */
 static struct option long_options[] = {
@@ -161,6 +168,7 @@ static struct option long_options[] = {
 	{ "start",          no_argument,       0, 'r' },
 	{ "blocking",       required_argument, 0, 'B' },
 	{ "print_format",   required_argument, 0, 'P' },
+	{ "packet_number_prefix", no_argument, 0, SOCK_SHELL_OPT_PACKET_NUMBER_PREFIX },
 	{ "rai_last",       no_argument,       0, SOCK_SHELL_OPT_RAI_LAST },
 	{ "rai_no_data",    no_argument,       0, SOCK_SHELL_OPT_RAI_NO_DATA },
 	{ "rai_one_resp",   no_argument,       0, SOCK_SHELL_OPT_RAI_ONE_RESP },
@@ -224,6 +232,7 @@ int sock_shell(const struct shell *shell, size_t argc, char **argv)
 	char arg_send_data[SOCK_MAX_SEND_DATA_LEN + 1];
 	int arg_data_length = 0;
 	int arg_data_interval = SOCK_SEND_DATA_INTERVAL_NONE;
+	bool arg_packet_number_prefix = false;
 	int arg_buffer_size = SOCK_BUFFER_SIZE_NONE;
 	bool arg_data_format_hex = false;
 	bool arg_receive_start = false;
@@ -415,6 +424,10 @@ int sock_shell(const struct shell *shell, size_t argc, char **argv)
 			break;
 
 		/* Options without short option: */
+		case SOCK_SHELL_OPT_PACKET_NUMBER_PREFIX:
+			arg_packet_number_prefix = true;
+			break;
+
 		case SOCK_SHELL_OPT_RAI_LAST:
 			arg_rai_last = true;
 			break;
@@ -457,6 +470,7 @@ int sock_shell(const struct shell *shell, size_t argc, char **argv)
 			arg_send_data,
 			arg_data_length,
 			arg_data_interval,
+			arg_packet_number_prefix,
 			arg_blocking_send,
 			arg_buffer_size,
 			arg_data_format_hex);


### PR DESCRIPTION
Sock tool: Add `--packet_number_prefix` option to include an index of the packet that is sent in periodic sending. This enables tracking of which send operations have been sent properly.