### PR TITLE
lib: nrf_cloud_coap: add nrf_cloud_coap_bytes_send

### DIFF
--- a/include/net/nrf_cloud_coap.h
+++ b/include/net/nrf_cloud_coap.h
@@ -136,6 +136,18 @@ int nrf_cloud_coap_pgps_url_get(struct nrf_cloud_rest_pgps_request const *const 
 int nrf_cloud_coap_sensor_send(const char *app_id, double value, int64_t ts_ms);
 
 /**
+ * @brief Send raw bytes to nRF Cloud.
+ * @param[in]     app_id The app_id identifying the type of data.
+ * @param[in]     buf buffer with binary string.
+ * @param[in]     buf_len  length of buf in bytes.
+ * @param[in]     ts_ms  Timestamp the data was measured, or NRF_CLOUD_NO_TIMESTAMP.
+ *
+ * @retval 0 If successful.
+ *          Otherwise, a (negative) error code is returned.
+ */
+int nrf_cloud_coap_bytes_send(const char *app_id, uint8_t *buf, size_t buf_len, int64_t ts_ms);
+
+/**
  * @brief Send the device location in the @ref nrf_cloud_gnss_data PVT field to nRF Cloud.
  *
  *  The CoAP message is sent as a non-confirmable CoAP message. Only

--- a/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_coap
+++ b/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_coap
@@ -36,6 +36,10 @@ config NON_RESP_RETRIES
 	  result in up to this number of retransmissions of the request followed
 	  by waits for a response.
 
+config NRF_CLOUD_COAP_BYTES_MESSAGE_MAX_LEN
+	int "Maximum length of message encoded in nrf_cloud_coap_bytes_send"
+	default 64
+
 if WIFI
 
 config NRF_CLOUD_COAP_SEND_SSIDS

--- a/subsys/net/lib/nrf_cloud/coap/cddl/nrf_cloud_coap_device_msg.cddl
+++ b/subsys/net/lib/nrf_cloud/coap/cddl/nrf_cloud_coap_device_msg.cddl
@@ -22,7 +22,7 @@ pvt = {
 
 message_out = {
 	appId => tstr,
-	data => tstr/float/int/pvt,
+	data => bstr/tstr/float/int/pvt,
 	? ts => uint .size 8
 }
 

--- a/subsys/net/lib/nrf_cloud/coap/include/msg_encode_types.h
+++ b/subsys/net/lib/nrf_cloud/coap/include/msg_encode_types.h
@@ -59,12 +59,14 @@ struct message_out_ts {
 struct message_out {
 	struct zcbor_string _message_out_appId;
 	union {
+		struct zcbor_string _message_out_data_bstr;
 		struct zcbor_string _message_out_data_tstr;
 		double _message_out_data_float;
 		int32_t _message_out_data_int;
 		struct pvt _message_out_data__pvt;
 	};
 	enum {
+		_message_out_data_bstr,
 		_message_out_data_tstr,
 		_message_out_data_float,
 		_message_out_data_int,

--- a/subsys/net/lib/nrf_cloud/coap/src/msg_encode.c
+++ b/subsys/net/lib/nrf_cloud/coap/src/msg_encode.c
@@ -123,22 +123,27 @@ static bool encode_message_out(zcbor_state_t *state, const struct message_out *i
 		(((((zcbor_uint32_put(state, (1)))) &&
 		   (zcbor_tstr_encode(state, (&(*input)._message_out_appId)))) &&
 		  (((zcbor_uint32_put(state, (2)))) &&
-		   (((*input)._message_out_data_choice == _message_out_data_tstr)
-			    ? ((zcbor_tstr_encode(state, (&(*input)._message_out_data_tstr))))
-			    : (((*input)._message_out_data_choice == _message_out_data_float)
-				       ? ((zcbor_float64_encode(
-						 state, (&(*input)._message_out_data_float))))
+		   (((*input)._message_out_data_choice == _message_out_data_bstr)
+			    ? ((zcbor_bstr_encode(state, (&(*input)._message_out_data_bstr))))
+			    : (((*input)._message_out_data_choice == _message_out_data_tstr)
+				       ? ((zcbor_tstr_encode(state,
+							     (&(*input)._message_out_data_tstr))))
 				       : (((*input)._message_out_data_choice ==
-					   _message_out_data_int)
-						  ? ((zcbor_int32_encode(
+					   _message_out_data_float)
+						  ? ((zcbor_float64_encode(
 							    state,
-							    (&(*input)._message_out_data_int))))
+							    (&(*input)._message_out_data_float))))
 						  : (((*input)._message_out_data_choice ==
-						      _message_out_data__pvt)
-							     ? ((encode_pvt(
+						      _message_out_data_int)
+							     ? ((zcbor_int32_encode(
 								       state,
-							       (&(*input)._message_out_data__pvt))))
-							     : false))))) &&
+								       (&(*input)._message_out_data_int))))
+							     : (((*input)._message_out_data_choice ==
+								 _message_out_data__pvt)
+									? ((encode_pvt(
+										  state,
+										  (&(*input)._message_out_data__pvt))))
+									: false)))))) &&
 		  zcbor_present_encode(&((*input)._message_out_ts_present),
 				       (zcbor_encoder_t *)encode_repeated_message_out_ts, state,
 				       (&(*input)._message_out_ts))) ||


### PR DESCRIPTION
This patch adds a function to nrf cloud coap that allows sending of app-specific raw bytes data.