### PR TITLE
applications: Matter Bridge: architectural refactoring

### DIFF
--- a/applications/matter_bridge/CMakeLists.txt
+++ b/applications/matter_bridge/CMakeLists.txt
@@ -34,6 +34,7 @@ target_include_directories(app PRIVATE
     src/bridged_device_types
     ${COMMON_ROOT}/src
     ${COMMON_ROOT}/src/bridge/
+    ${COMMON_ROOT}/src/bridge/util
     ${NLIO_ROOT}/include
     ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/zzz_generated/app-common
 )
@@ -41,8 +42,8 @@ target_include_directories(app PRIVATE
 target_sources(app PRIVATE
     src/app_task.cpp
     src/main.cpp
+    src/bridge_shell.cpp
     ${COMMON_ROOT}/src/bridge/bridge_manager.cpp
-    ${COMMON_ROOT}/src/bridge/bridge_shell.cpp
     ${COMMON_ROOT}/src/bridge/bridged_device.cpp
     src/zap-generated/IMClusterCommandHandler.cpp
     src/zap-generated/callback-stub.cpp

--- a/applications/matter_bridge/Kconfig
+++ b/applications/matter_bridge/Kconfig
@@ -41,6 +41,9 @@ config BRIDGE_HUMIDITY_SENSOR_MAX_MEASURED_VALUE
 
 endif
 
+config EXPERIMENTAL
+	default y
+
 source "${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/chip-module/Kconfig.features"
 source "${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/chip-module/Kconfig.defaults"
 source "${ZEPHYR_BASE}/../nrf/samples/matter/common/src/bridge/Kconfig"

--- a/applications/matter_bridge/src/bridged_device_factory.h
+++ b/applications/matter_bridge/src/bridged_device_factory.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#pragma once
+
+#include "bridge_util.h"
+#include "bridged_device.h"
+#include "bridged_device_data_provider.h"
+#include <lib/support/CHIPMem.h>
+
+#ifdef CONFIG_BRIDGE_HUMIDITY_SENSOR_BRIDGED_DEVICE
+#include "humidity_sensor.h"
+#include "humidity_sensor_data_provider.h"
+#endif
+
+#ifdef CONFIG_BRIDGE_ONOFF_LIGHT_BRIDGED_DEVICE
+#include "onoff_light.h"
+#include "onoff_light_data_provider.h"
+#endif
+
+#ifdef CONFIG_BRIDGE_TEMPERATURE_SENSOR_BRIDGED_DEVICE
+#include "temperature_sensor.h"
+#include "temperature_sensor_data_provider.h"
+#endif
+
+namespace BridgeFactory
+{
+
+using UpdateAttributeCallback = BridgedDeviceDataProvider::UpdateAttributeCallback;
+using DeviceType = BridgedDevice::DeviceType;
+using BridgedDeviceFactory = DeviceFactory<BridgedDevice, const char *>;
+using DataProviderFactory = DeviceFactory<BridgedDeviceDataProvider, UpdateAttributeCallback>;
+
+auto checkLabel = [](const char *nodeLabel) {
+	/* If node label is provided it must fit the maximum defined length */
+	if (!nodeLabel || (nodeLabel && (strlen(nodeLabel) < BridgedDevice::kNodeLabelSize))) {
+		return true;
+	}
+	return false;
+};
+
+inline BridgedDeviceFactory &GetBridgedDeviceFactory()
+{
+	static BridgedDeviceFactory sBridgedDeviceFactory{
+#ifdef CONFIG_BRIDGE_HUMIDITY_SENSOR_BRIDGED_DEVICE
+		{ DeviceType::HumiditySensor,
+		  [](const char *nodeLabel) -> BridgedDevice * {
+			  if (!checkLabel(nodeLabel)) {
+				  return nullptr;
+			  }
+			  return chip::Platform::New<HumiditySensorDevice>(nodeLabel);
+		  } },
+#endif
+#ifdef CONFIG_BRIDGE_ONOFF_LIGHT_BRIDGED_DEVICE
+		{ DeviceType::OnOffLight,
+		  [](const char *nodeLabel) -> BridgedDevice * {
+			  if (!checkLabel(nodeLabel)) {
+				  return nullptr;
+			  }
+			  return chip::Platform::New<OnOffLightDevice>(nodeLabel);
+		  } },
+#endif
+#ifdef CONFIG_BRIDGE_TEMPERATURE_SENSOR_BRIDGED_DEVICE
+		{ BridgedDevice::DeviceType::TemperatureSensor,
+		  [](const char *nodeLabel) -> BridgedDevice * {
+			  if (!checkLabel(nodeLabel)) {
+				  return nullptr;
+			  }
+			  return chip::Platform::New<TemperatureSensorDevice>(nodeLabel);
+		  } },
+#endif
+	};
+	return sBridgedDeviceFactory;
+}
+
+inline DataProviderFactory &GetDataProviderFactory()
+{
+	static DataProviderFactory sDeviceDataProvider{
+#ifdef CONFIG_BRIDGE_HUMIDITY_SENSOR_BRIDGED_DEVICE
+		{ DeviceType::HumiditySensor,
+		  [](UpdateAttributeCallback clb) { return chip::Platform::New<HumiditySensorDataProvider>(clb); } },
+#endif
+#ifdef CONFIG_BRIDGE_ONOFF_LIGHT_BRIDGED_DEVICE
+		{ DeviceType::OnOffLight,
+		  [](UpdateAttributeCallback clb) { return chip::Platform::New<OnOffLightDataProvider>(clb); } },
+#endif
+#ifdef CONFIG_BRIDGE_TEMPERATURE_SENSOR_BRIDGED_DEVICE
+		{ DeviceType::TemperatureSensor,
+		  [](UpdateAttributeCallback clb) { return chip::Platform::New<TemperatureSensorDataProvider>(clb); } },
+#endif
+	};
+	return sDeviceDataProvider;
+}
+
+} // namespace BridgeFactory

--- a/applications/matter_bridge/src/bridged_device_types/humidity_sensor_data_provider.cpp
+++ b/applications/matter_bridge/src/bridged_device_types/humidity_sensor_data_provider.cpp
@@ -33,6 +33,8 @@ void HumiditySensorDataProvider::NotifyUpdateState(chip::ClusterId clusterId, ch
 CHIP_ERROR HumiditySensorDataProvider::UpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId,
 						   uint8_t *buffer)
 {
+	LOG_INF("Updating state of the HumiditySensorDataProvider, cluster ID: %u, attribute ID: %u. Dropping, currently not supported.",
+		clusterId, attributeId);
 	return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 

--- a/applications/matter_bridge/src/bridged_device_types/humidity_sensor_data_provider.h
+++ b/applications/matter_bridge/src/bridged_device_types/humidity_sensor_data_provider.h
@@ -15,6 +15,7 @@ public:
 	static constexpr uint16_t kMaxRandomTemperature = 50;
 
 	HumiditySensorDataProvider(UpdateAttributeCallback callback) : BridgedDeviceDataProvider(callback) {}
+	~HumiditySensorDataProvider() { k_timer_stop(&mTimer); }
 
 	void Init() override;
 	void NotifyUpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId, void *data,

--- a/applications/matter_bridge/src/bridged_device_types/onoff_light_data_provider.cpp
+++ b/applications/matter_bridge/src/bridged_device_types/onoff_light_data_provider.cpp
@@ -36,6 +36,9 @@ CHIP_ERROR OnOffLightDataProvider::UpdateState(chip::ClusterId clusterId, chip::
 		return CHIP_ERROR_INVALID_ARGUMENT;
 	}
 
+	LOG_INF("Updating state of the OnOffLightDataProvider, cluster ID: %u, attribute ID: %u.", clusterId,
+		attributeId);
+
 	switch (attributeId) {
 	case Clusters::OnOff::Attributes::OnOff::Id: {
 		mOnOff = *buffer;

--- a/applications/matter_bridge/src/bridged_device_types/onoff_light_data_provider.h
+++ b/applications/matter_bridge/src/bridged_device_types/onoff_light_data_provider.h
@@ -13,6 +13,7 @@ public:
 	static constexpr uint16_t kOnOffIntervalMs = 30000;
 
 	OnOffLightDataProvider(UpdateAttributeCallback callback) : BridgedDeviceDataProvider(callback) {}
+	~OnOffLightDataProvider() { k_timer_stop(&mTimer); }
 
 	void Init() override;
 	void NotifyUpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId, void *data,

--- a/applications/matter_bridge/src/bridged_device_types/temperature_sensor_data_provider.cpp
+++ b/applications/matter_bridge/src/bridged_device_types/temperature_sensor_data_provider.cpp
@@ -33,6 +33,8 @@ void TemperatureSensorDataProvider::NotifyUpdateState(chip::ClusterId clusterId,
 CHIP_ERROR TemperatureSensorDataProvider::UpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId,
 						      uint8_t *buffer)
 {
+	LOG_INF("Updating state of the TemperatureSensorDataProvider, cluster ID: %u, attribute ID: %u. Dropping, currently not supported.",
+		clusterId, attributeId);
 	return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 

--- a/applications/matter_bridge/src/bridged_device_types/temperature_sensor_data_provider.h
+++ b/applications/matter_bridge/src/bridged_device_types/temperature_sensor_data_provider.h
@@ -17,6 +17,7 @@ public:
 	static constexpr int16_t kMaxRandomTemperature = 10;
 
 	TemperatureSensorDataProvider(UpdateAttributeCallback callback) : BridgedDeviceDataProvider(callback) {}
+	~TemperatureSensorDataProvider() { k_timer_stop(&mTimer); }
 
 	void Init() override;
 	void NotifyUpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId, void *data,

--- a/samples/matter/common/src/bridge/bridge_manager.h
+++ b/samples/matter/common/src/bridge/bridge_manager.h
@@ -6,35 +6,52 @@
 
 #pragma once
 
+#include "bridge_util.h"
 #include "bridged_device.h"
 #include "bridged_device_data_provider.h"
-#include <map>
 
 class BridgeManager {
 public:
 	void Init();
-	CHIP_ERROR AddBridgedDevice(BridgedDevice::DeviceType bridgedDeviceType, const char *nodeLabel);
+	CHIP_ERROR AddBridgedDevices(BridgedDevice *aDevice, BridgedDeviceDataProvider *aDataProvider);
 	CHIP_ERROR RemoveBridgedDevice(uint16_t endpoint);
-	static BridgedDevice *GetBridgedDevice(uint16_t endpoint, const EmberAfAttributeMetadata *attributeMetadata,
-					       uint8_t *buffer);
-	static CHIP_ERROR HandleRead(uint16_t endpoint, chip::ClusterId clusterId,
+	static CHIP_ERROR HandleRead(uint16_t index, chip::ClusterId clusterId,
 				     const EmberAfAttributeMetadata *attributeMetadata, uint8_t *buffer,
 				     uint16_t maxReadLength);
-	static CHIP_ERROR HandleWrite(uint16_t endpoint, chip::ClusterId clusterId,
+	static CHIP_ERROR HandleWrite(uint16_t index, chip::ClusterId clusterId,
 				      const EmberAfAttributeMetadata *attributeMetadata, uint8_t *buffer);
 	static void HandleUpdate(BridgedDeviceDataProvider &dataProvider, chip::ClusterId clusterId,
 				 chip::AttributeId attributeId, void *data, size_t dataSize);
 
 private:
-	CHIP_ERROR AddDevice(BridgedDevice *device);
-
 	static constexpr uint8_t kMaxBridgedDevices = CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;
 	static constexpr uint8_t kMaxDataProviders = CONFIG_BRIDGE_MAX_BRIDGED_DEVICES_NUMBER;
 
-	/* TODO: Implement lightweight map to decrease flash usage. */
-	std::map<BridgedDevice *, BridgedDeviceDataProvider *> mDevicesMap;
-	BridgedDevice *mBridgedDevices[kMaxBridgedDevices];
-	BridgedDeviceDataProvider *mDataProviders[kMaxDataProviders];
+	using DevicePtr = chip::Platform::UniquePtr<BridgedDevice>;
+	using ProviderPtr = chip::Platform::UniquePtr<BridgedDeviceDataProvider>;
+	struct DevicePair {
+		DevicePair() : mDevice(nullptr), mProvider(nullptr) {}
+		DevicePair(DevicePtr device, ProviderPtr provider)
+			: mDevice(std::move(device)), mProvider(std::move(provider))
+		{
+		}
+		DevicePair &operator=(DevicePair &&other)
+		{
+			mDevice = std::move(other.mDevice);
+			mProvider = std::move(other.mProvider);
+			return *this;
+		}
+		operator bool() const { return mDevice && mProvider; }
+		DevicePair &operator=(const DevicePair &other) = delete;
+		DevicePtr mDevice;
+		ProviderPtr mProvider;
+	};
+	using DeviceMap = FiniteMap<DevicePair, kMaxBridgedDevices>;
+
+	CHIP_ERROR AddDevices(BridgedDevice *aDevice, BridgedDeviceDataProvider *aDataProvider);
+
+	DeviceMap mDevicesMap;
+	uint16_t mNumberOfProviders{ 0 };
 
 	chip::EndpointId mFirstDynamicEndpointId;
 	chip::EndpointId mCurrentDynamicEndpointId;

--- a/samples/matter/common/src/bridge/bridged_device.h
+++ b/samples/matter/common/src/bridge/bridged_device.h
@@ -38,7 +38,7 @@
 
 class BridgedDevice {
 public:
-	enum class DeviceType : uint16_t {
+	enum DeviceType : uint16_t {
 		BridgedNode = 0x0013,
 		OnOffLight = 0x0100,
 		TemperatureSensor = 0x0302,

--- a/samples/matter/common/src/bridge/bridged_device_data_provider.h
+++ b/samples/matter/common/src/bridge/bridged_device_data_provider.h
@@ -14,6 +14,7 @@ public:
 						 chip::AttributeId attributeId, void *data, size_t dataSize);
 
 	explicit BridgedDeviceDataProvider(UpdateAttributeCallback callback) { mUpdateAttributeCallback = callback; }
+	virtual ~BridgedDeviceDataProvider() = default;
 
 	virtual void Init() = 0;
 	virtual void NotifyUpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId, void *data,

--- a/samples/matter/common/src/bridge/util/bridge_util.h
+++ b/samples/matter/common/src/bridge/util/bridge_util.h
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#pragma once
+
+#include "bridged_device.h"
+
+#include <cstdint>
+#include <functional>
+#include <map>
+
+/*
+   DeviceFactory template container allows to instantiate a map which
+   binds supported BridgedDevice::DeviceType types with corresponding
+   creation method (e.g. constructor invocation). DeviceFactory can
+   only be constructed by passing a user-defined initialized list with
+   <BridgedDevice::DeviceType, ConcreteDeviceCreator> pairs.
+   Then, Create() method can be used to obtain an instance of demanded
+   device type with all passed arguments forwarded to the underlying
+   ConcreteDeviceCreator.
+*/
+template <typename T, typename... Args> class DeviceFactory {
+public:
+	using ConcreteDeviceCreator = std::function<T *(Args...)>;
+	using CreationMap = std::map<BridgedDevice::DeviceType, ConcreteDeviceCreator>;
+
+	DeviceFactory(std::initializer_list<std::pair<BridgedDevice::DeviceType, ConcreteDeviceCreator>> init)
+	{
+		for (auto &pair : init) {
+			mCreationMap.insert(pair);
+		}
+	}
+
+	DeviceFactory() = delete;
+	DeviceFactory(const DeviceFactory &) = delete;
+	DeviceFactory(DeviceFactory &&) = delete;
+	DeviceFactory &operator=(const DeviceFactory &) = delete;
+	DeviceFactory &operator=(DeviceFactory &&) = delete;
+	~DeviceFactory() = default;
+
+	T *Create(BridgedDevice::DeviceType deviceType, Args... params)
+	{
+		if (mCreationMap.find(deviceType) == mCreationMap.end()) {
+			return nullptr;
+		}
+		return mCreationMap[deviceType](std::forward<Args>(params)...);
+	}
+
+private:
+	CreationMap mCreationMap;
+};
+
+/*
+   FiniteMap template container allows to wrap mappings between uint16_t type key and T type value.
+   The size or the container is predefined at compilation time, therefore
+   the maximum number of stored elements must be well known. FiniteMap owns
+   inserted values, meaning that once the user inserts a value it will not longer
+   be valid outside of the container, i.e. FiniteMap cannot return stored object by copy.
+   FiniteMap's API offers basic operations like:
+     * inserting a new value under provided key (Insert)
+     * erasing existing item under given key (Erase)
+     * retrieving value stored under provided key ([] operator)
+     * checking if the map contains a non-null value under given key (Contains)
+     * iterating though stored item via publicly available mMap member
+   Prerequisites:
+     * T must have =operator(&&) and bool()operator implemented
+*/
+template <typename T, std::size_t N> struct FiniteMap {
+	struct Pair {
+		uint16_t key;
+		T value;
+	};
+
+	void Insert(uint16_t key, T &&value)
+	{
+		if (Contains(key)) {
+			/* The key with sane value already exists in the map, return prematurely. */
+			return;
+		} else if (mElementsCount < N) {
+			mMap[key].key = key;
+			mMap[key].value = std::move(value);
+			mElementsCount++;
+		}
+	}
+
+	bool Erase(uint16_t key)
+	{
+		const auto &it = std::find_if(std::begin(mMap), std::end(mMap),
+					      [key](const Pair &pair) { return pair.key == key; });
+		if (it != std::end(mMap) && it->value) {
+			/* Invalidate the value but leave the key unchanged */
+			it->value = T{};
+			mElementsCount--;
+			return true;
+		}
+		return false;
+	}
+
+	/* TODO: refactor to return a reference (Constains() check will be always needed) */
+	const T *operator[](uint16_t key) const
+	{
+		for (auto &it : mMap) {
+			if (key == it.key)
+				return &(it.value);
+		}
+		return nullptr;
+	}
+
+	bool Contains(uint16_t key)
+	{
+		const T *stored = (*this)[key];
+		if (stored && *stored) {
+			/* The key with sane value found in the map */
+			return true;
+		}
+		return false;
+	}
+
+	bool IsFull() { return mElementsCount >= N; }
+
+	Pair mMap[N];
+	uint16_t mElementsCount{ 0 };
+};


### PR DESCRIPTION
 Major scope:

  - allow to inject Matter and non-Matter devices to be bridged
    into the BridgeManager object
  - added devices factory to support bridged devices creation
  - implemented a dedicated map facilitating device object life
    time management
  - added necessary BridgeManager modifications
  
Also:

  - Added missing virtual constructor in abstract
    BridedDeviceDataProvider class.
  - stop the timer in data provider when object is being destructed
  - added more logs

