### PR TITLE
Lwm2m updates from upstream Zephyr

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -347,6 +347,18 @@ Cellular samples (renamed from nRF9160 samples)
 
     * The sample to use the :ref:`lib_nrf_cloud` library function :c:func:`nrf_cloud_obj_pgps_request_create` to create a P-GPS request.
 
+* :ref:`lwm2m_client` sample:
+
+  * Added:
+
+    * An overlay for using DTLS Connection Identifier.
+      This significantly reduces the DTLS handshake overhead when doing the LwM2M Update operation.
+
+  * Updated:
+
+    * The sample now uses tickless operating mode from Zephyr's LwM2M engine which does not cause device wake-up in 500 ms interval anymore.
+      This allows the device to achieve 2 uA of current usage while in PSM sleep mode.
+
 Trusted Firmware-M (TF-M) samples
 ---------------------------------
 
@@ -554,6 +566,10 @@ Libraries for networking
 
     * Support for using pre-provisioned X.509 certificates.
     * Support for using DTLS Connection Identifier
+
+  * Updated:
+
+    * Zephyr's LwM2M Connectivity Monitor object now uses a 16-bit value for radio signal strength so it does not roll over on values smaller than -126 dBm.
 
 * :ref:`lib_aws_fota` library:
 

--- a/samples/cellular/lwm2m_client/prj.conf
+++ b/samples/cellular/lwm2m_client/prj.conf
@@ -148,3 +148,7 @@ CONFIG_LTE_PTW_VALUE_NBIOT="0000"
 # Get notification before Tracking Area Update (TAU). Notification triggers registration
 # update and TAU will be sent with the update which decreases power consumption.
 CONFIG_LTE_LC_TAU_PRE_WARNING_NOTIFICATIONS=y
+
+# Optimize powersaving by using tickless mode in LwM2M engine
+CONFIG_NET_SOCKETPAIR=y
+CONFIG_LWM2M_TICKLESS=y

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_connmon.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_connmon.c
@@ -134,7 +134,7 @@ static void modem_signal_update(struct k_work *work)
 		return;
 	}
 
-	lwm2m_set_s8(&LWM2M_OBJ(4, 0, 2), modem_rsrp);
+	lwm2m_set_s16(&LWM2M_OBJ(4, 0, 2), modem_rsrp);
 	timestamp_prev = k_uptime_get_32();
 }
 

--- a/tests/subsys/net/lib/lwm2m_client_utils/src/connmon.c
+++ b/tests/subsys/net/lib/lwm2m_client_utils/src/connmon.c
@@ -23,7 +23,7 @@ static rsrp_cb_t modem_info_rsrp_cb;
 
 static uint8_t connmon_mode;
 
-static int8_t modem_rsrp_resource;
+static int16_t modem_rsrp_resource;
 
 static enum lte_lc_lte_mode lte_mode;
 
@@ -61,10 +61,10 @@ static int set_string_custom_fake(const struct lwm2m_obj_path *path, const char 
 	return 0;
 }
 
-static int set_s8_custom_fake(const struct lwm2m_obj_path *path, int8_t value)
+static int set_s16_custom_fake(const struct lwm2m_obj_path *path, int16_t value)
 {
 	if (path->obj_id == 4 && path->obj_inst_id == 0 && path->res_id == 2) {
-		zassert_equal((int8_t)RSRP_IDX_TO_DBM(modem_rsrp_resource), value);
+		zassert_equal((int16_t)RSRP_IDX_TO_DBM(modem_rsrp_resource), value);
 	} else {
 		zassert(0, "Invalid path");
 		return -EINVAL;
@@ -162,7 +162,7 @@ ZTEST(lwm2m_client_utils_connmon, test_connected)
 	modem_rsrp_resource = 50;
 	lte_lc_register_handler_fake.custom_fake = copy_event_handler;
 	lwm2m_set_string_fake.custom_fake = set_string_custom_fake;
-	lwm2m_set_s8_fake.custom_fake = set_s8_custom_fake;
+	lwm2m_set_s16_fake.custom_fake = set_s16_custom_fake;
 	modem_info_params_get_fake.custom_fake = copy_modem_info;
 	modem_info_rsrp_register_fake.custom_fake = copy_rsrp_handler;
 	lwm2m_init_connmon();
@@ -174,7 +174,7 @@ ZTEST(lwm2m_client_utils_connmon, test_connected)
 	zassert_equal(lwm2m_set_string_fake.call_count, 3, "Strings not set");
 	modem_info_rsrp_cb(modem_rsrp_resource);
 	k_sleep(K_MSEC(100));
-	zassert_equal(lwm2m_set_s8_fake.call_count, 1, "RSRP not set");
+	zassert_equal(lwm2m_set_s16_fake.call_count, 1, "RSRP not set");
 	evt.nw_reg_status = LTE_LC_NW_REG_NOT_REGISTERED;
 	handler(&evt);
 	k_sleep(K_MSEC(100));

--- a/tests/subsys/net/lib/lwm2m_client_utils/src/stubs.c
+++ b/tests/subsys/net/lib/lwm2m_client_utils/src/stubs.c
@@ -86,7 +86,7 @@ DEFINE_FAKE_VALUE_FUNC(int, lwm2m_create_res_inst, const struct lwm2m_obj_path *
 DEFINE_FAKE_VALUE_FUNC(int, lwm2m_set_res_buf, const struct lwm2m_obj_path *, void *, uint16_t,
 			     uint16_t, uint8_t);
 DEFINE_FAKE_VALUE_FUNC(int, lwm2m_set_u32, const struct lwm2m_obj_path *, uint32_t);
-DEFINE_FAKE_VALUE_FUNC(int, lwm2m_set_s8, const struct lwm2m_obj_path *, int8_t);
+DEFINE_FAKE_VALUE_FUNC(int, lwm2m_set_s16, const struct lwm2m_obj_path *, int16_t);
 DEFINE_FAKE_VALUE_FUNC(int, lwm2m_set_s32, const struct lwm2m_obj_path *, int32_t);
 DEFINE_FAKE_VALUE_FUNC(int, lwm2m_register_exec_callback, const struct lwm2m_obj_path *,
 		       lwm2m_engine_execute_cb_t);

--- a/tests/subsys/net/lib/lwm2m_client_utils/src/stubs.h
+++ b/tests/subsys/net/lib/lwm2m_client_utils/src/stubs.h
@@ -81,7 +81,7 @@ DECLARE_FAKE_VALUE_FUNC(int, lwm2m_create_res_inst, const struct lwm2m_obj_path 
 DECLARE_FAKE_VALUE_FUNC(int, lwm2m_set_res_buf, const struct lwm2m_obj_path *, void *, uint16_t,
 			uint16_t, uint8_t);
 DECLARE_FAKE_VALUE_FUNC(int, lwm2m_set_u32, const struct lwm2m_obj_path *, uint32_t);
-DECLARE_FAKE_VALUE_FUNC(int, lwm2m_set_s8, const struct lwm2m_obj_path *, int8_t);
+DECLARE_FAKE_VALUE_FUNC(int, lwm2m_set_s16, const struct lwm2m_obj_path *, int16_t);
 DECLARE_FAKE_VALUE_FUNC(int, lwm2m_set_s32, const struct lwm2m_obj_path *, int32_t);
 DECLARE_FAKE_VALUE_FUNC(int, modem_info_rsrp_register, rsrp_cb_t);
 DECLARE_FAKE_VALUE_FUNC(int, lwm2m_register_exec_callback, const struct lwm2m_obj_path *,
@@ -113,7 +113,7 @@ DECLARE_FAKE_VALUE_FUNC(int, at_params_list_init, struct at_param_list *, size_t
 	FUNC(lwm2m_get_res_buf)                         \
 	FUNC(lwm2m_get_u8)                              \
 	FUNC(lwm2m_get_bool)                            \
-	FUNC(lwm2m_set_s8)                              \
+	FUNC(lwm2m_set_s16)                             \
 	FUNC(lwm2m_set_s32)                             \
 	FUNC(lwm2m_set_opaque)                          \
 	FUNC(lwm2m_set_string)                          \

--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 4579f028e1e6139786491e352c50bc9528b09c7d
+      revision: c9d01d05ce83a8cec0fd60bf8e2ba27c1534d08f
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Fetch LwM2M related updates from upstream Zephyr:
* CoAP timeout rollover fix
* 16bit RSRP resource
* Tickless operating mode for LwM2M engine

Implement required changes on `nrf` side.

Related `sdk-zephyr` PR: https://github.com/nrfconnect/sdk-zephyr/pull/1264

