### PR TITLE
manifest: sdk-hostap: Enable OSS history comparison

### DIFF
--- a/.github/workflows/oss-history.yml
+++ b/.github/workflows/oss-history.yml
@@ -33,4 +33,4 @@ jobs:
         uses: nrfconnect/action-oss-history@main
         with:
           workspace: 'ncs'
-          args: -p zephyr -p mcuboot
+          args: -p zephyr -p mcuboot -p hostap

--- a/west.yml
+++ b/west.yml
@@ -114,7 +114,7 @@ manifest:
         ncs:
           upstream-url: https://w1.fi/cgit/hostap/
           upstream-sha: e792f38db8471f35ee94f109a4093dece8f78c6a
-          compare-by-default: false
+          compare-by-default: true
     - name: wfa-qt-control-app
       repo-path: sdk-wi-fiquicktrack-controlappc
       path: modules/lib/wfa-qt-control-app


### PR DESCRIPTION
This runs the oss-history CI on sdk-hostap OOT patches.