### PR TITLE
[DNM] zephyr: pull improvement to NVS lookup cache

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 4579f028e1e6139786491e352c50bc9528b09c7d
+      revision: pull/1263/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull an improvement to the NVS lookup cache when the NVS is used as a settings backend.