### PR TITLE
applications: nrf_desktop: Avoid BLE scan stop on HID output report

### DIFF
--- a/applications/nrf_desktop/src/modules/ble_scan.c
+++ b/applications/nrf_desktop/src/modules/ble_scan.c
@@ -516,6 +516,13 @@ static bool app_event_handler(const struct app_event_header *aeh)
 	static bool ble_bond_ready;
 
 	if (is_hid_report_event(aeh)) {
+		const struct hid_report_event *event = cast_hid_report_event(aeh);
+
+		/* Ignore HID output reports. Subscriber is NULL for a HID output report. */
+		if (!event->subscriber) {
+			return false;
+		}
+
 		/* Do not scan when devices are in use. */
 		scan_counter = 0;
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -230,6 +230,9 @@ nRF Desktop
   * To improve the accuracy, the generation of simulated movement data in the :ref:`nrf_desktop_motion` now uses a timestamp in microseconds based on the cycle count (either :c:func:`k_cycle_get_32` or :c:func:`k_cycle_get_64` function depending on the :kconfig:option:`CONFIG_TIMER_HAS_64BIT_CYCLE_COUNTER` Kconfig option).
   * Aligned Kconfig option names in the :ref:`nrf_desktop_motion` implementation that generates motion from button presses.
     The Kconfig options defining used key IDs are prefixed with ``CONFIG_MOTION_BUTTONS_`` instead of ``CONFIG_MOTION_`` to ensure consistency with configuration of other implementations of the motion module.
+  * The :ref:`nrf_desktop_ble_scan` no longer stops Bluetooth LE scanning when it receives :c:struct:`hid_report_event` related to a HID output report.
+    Sending HID output report is triggered by a HID host.
+    Scanning stop may lead to an edge case where the scanning is stopped, but there are no peripherals connected to the dongle.
 
 Thingy:53: Matter weather station
 ---------------------------------


### PR DESCRIPTION
Change avoids stopping BLE scanning on HID output report. Sending HID output report is triggered by a HID host. Stopping scanning may lead to an edge case where scanning is stopped and there are no peripherals connected to the dongle.

Jira: NCSDK-22768