### PR TITLE
cmake: Set kernel version to NCS version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,9 @@ set(NRF_DIR ${CMAKE_CURRENT_LIST_DIR} CACHE PATH "NCS root directory")
 # is cached.
 set(CONF_FILE_BUILD_TYPE ${CONF_FILE_BUILD_TYPE} CACHE INTERNAL "The build type")
 
+# Customize the Zephyr kernel version.h using nRF Connect SDK ncs_version.h.
+set(KERNEL_VERSION_CUSTOMIZATION \#include;<ncs_version.h> PARENT_SCOPE)
+
 include(cmake/extensions.cmake)
 include(cmake/version.cmake)
 include(cmake/multi_image.cmake)

--- a/Kconfig.nrf
+++ b/Kconfig.nrf
@@ -28,6 +28,10 @@ endif # BUILD_WITH_TFM
 
 menu "Nordic nRF Connect"
 
+# Override boot banner
+config BOOT_BANNER_STRING
+	default "Booting nRF Connect SDK version"
+
 # Override configuration from zephyr which sets this to 0x200 if MCUboot is
 # enabled (CONFIG_BOOTLOADER_MCUBOOT), since NCS use partition_manager to
 # get this offset intsead.

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -3,4 +3,30 @@ math(EXPR NCS_VERSION_CODE "(${NCS_VERSION_MAJOR} << 16) + (${NCS_VERSION_MINOR}
 # to_hex is made available by ${ZEPHYR_BASE}/cmake/hex.cmake
 to_hex(${NCS_VERSION_CODE} NCS_VERSION_NUMBER)
 
-configure_file(${ZEPHYR_NRF_MODULE_DIR}/ncs_version.h.in ${ZEPHYR_BINARY_DIR}/include/generated/ncs_version.h)
+if(DEFINED BUILD_VERSION)
+  set(ncs_banner_version BUILD_VERSION)
+else()
+  set(ncs_banner_version NCS_BUILD_VERSION)
+endif()
+
+add_custom_command(
+  OUTPUT ${PROJECT_BINARY_DIR}/include/generated/ncs_version.h
+  COMMAND ${CMAKE_COMMAND} -DZEPHYR_BASE=${ZEPHYR_BASE}
+    -DOUT_FILE=${PROJECT_BINARY_DIR}/include/generated/ncs_version.h
+    -DVERSION_TYPE=NCS
+    # We don't want Zephyr to parse the NCS VERSION file as it is not conforming to Zephyr VERSION
+    # format. Pointing to a non-existing file allows us full control from CMake instead.
+    -DVERSION_FILE=${NRF_DIR}/VERSIONFILEDUMMY
+    -DNCS_VERSION_CODE=${NCS_VERSION_CODE}
+    -DNCS_VERSION_NUMBER=${NCS_VERSION_NUMBER}
+    -DNCS_VERSION_MAJOR=${NCS_VERSION_MAJOR}
+    -DNCS_VERSION_MINOR=${NCS_VERSION_MINOR}
+    -DNCS_PATCHLEVEL=${NCS_VERSION_PATCH}
+    -DNCS_VERSION_STRING=${NCS_VERSION}
+    -DNCS_VERSION_CUSTOMIZATION="\#define;BANNER_VERSION;STRINGIFY\(${ncs_banner_version}\)"
+    -P ${ZEPHYR_BASE}/cmake/gen_version_h.cmake
+    DEPENDS ${NRF_DIR}/VERSION ${git_dependency}
+)
+add_custom_target(ncs_version_h DEPENDS ${PROJECT_BINARY_DIR}/include/generated/ncs_version.h)
+
+add_dependencies(version_h ncs_version_h)

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -56,6 +56,9 @@ Build system
 * Removed the ``CONFIG_MCUBOOT_IMAGE_VERSION`` Kconfig option in favor of using a dedicated :ref:`application VERSION file <zephyr:app-version-details>` to set the version.
    You can alternatively set the version by using the :kconfig:option:`CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION` Kconfig option, but using a :file:`VERSION` file is the recommended approach.
 
+* The |NCS| name and version is now displayed instead of the Zephyr version as the default boot banner when applications boot.
+  This can be customized in user applications.
+
 Working with nRF91 Series
 =========================
 


### PR DESCRIPTION
    Sets the zephyr kernel version to the version of NCS so that the
    boot banner displays the correct NCS details instead of sdk-zephyr
    details

and

    manifest: Update sdk-zephyr revision
    
    Adds the boot banner override features which displays the NCS
    version