### PR TITLE
doc: security: Don't document how to flash a TF-M

### DIFF
--- a/doc/nrf/security/tfm.rst
+++ b/doc/nrf/security/tfm.rst
@@ -83,15 +83,6 @@ When :kconfig:option:`CONFIG_TFM_PROFILE_TYPE_MINIMAL` is set, the configurabili
 Hence, it is not possible to modify the TF-M minimal configuration to create your own variant of the minimal configuration.
 Instead, the default configuration must be used as a starting point.
 
-Programming
-***********
-
-The procedure for programming an application with TF-M is the same as for other multi-image applications in |NCS|.
-
-After building the application, a :file:`merged.hex` file is created that contains MCUboot, TF-M, and the application.
-The :file:`merged.hex` file can be then :ref:`programmed using nRF Connect for Visual Studio Code <programming_vsc>`.
-When using the command line, the file is programmed automatically when you call ``ninja flash`` or ``west flash``.
-
 Logging
 *******
 


### PR DESCRIPTION
Don't document how to flash TF-M as it is the same as for any NCS build.

This documentation is expensive to maintain as it is referencing development environment specifics that are unrelated to TF-M and subject to change.