### PR TITLE
Bluetooth: Mesh: apply scheduler publication errata

### DIFF
--- a/include/bluetooth/mesh/scheduler_srv.h
+++ b/include/bluetooth/mesh/scheduler_srv.h
@@ -72,6 +72,8 @@ struct bt_mesh_scheduler_srv {
 		sched_tai[BT_MESH_SCHEDULER_ACTION_ENTRY_COUNT];
 		/* Index of the ongoing action. */
 		uint8_t idx;
+		/* Index of the last executed action. */
+		uint8_t last_idx;
 		/* Bit field indicating active entries
 		 * in the Schedule Register.
 		 */


### PR DESCRIPTION
When scheduler server model is configured for publication: •  If no action has been executed, the Scheduler Server shall send a Scheduler Status message (see Section 5.3.5.2.2).
•  If an action has been executed, the Scheduler Server shall send Scheduler Action Status messages (see Section 5.3.5.2.4) with the Schedule Register field set to the value of the Schedule Register state (see Section 5.1.4.2) for the most recently executed action.