### PR TITLE
applications: nrf_desktop: Fix returning error in MCUmgr callbacks

### DIFF
--- a/applications/nrf_desktop/src/modules/dfu_mcumgr.c
+++ b/applications/nrf_desktop/src/modules/dfu_mcumgr.c
@@ -69,7 +69,8 @@ static enum mgmt_cb_return mcumgr_img_mgmt_cb(uint32_t event,
 	k_work_reschedule(&dfu_timeout, DFU_TIMEOUT);
 	if (IS_ENABLED(CONFIG_DESKTOP_DFU_LOCK) && dfu_lock_claim(&mcumgr_owner)) {
 		(void)k_work_cancel_delayable(&dfu_timeout);
-		return MGMT_ERR_EACCESSDENIED;
+		*rc = MGMT_ERR_EACCESSDENIED;
+		return MGMT_CB_ERROR_RC;
 	}
 
 	if (IS_ENABLED(CONFIG_MCUMGR_TRANSPORT_BT) &&
@@ -96,7 +97,8 @@ static enum mgmt_cb_return mcumgr_os_mgmt_reset_cb(uint32_t event,
 	k_work_reschedule(&dfu_timeout, DFU_TIMEOUT);
 	if (IS_ENABLED(CONFIG_DESKTOP_DFU_LOCK) && dfu_lock_claim(&mcumgr_owner)) {
 		(void)k_work_cancel_delayable(&dfu_timeout);
-		return MGMT_ERR_EACCESSDENIED;
+		*rc = MGMT_ERR_EACCESSDENIED;
+		return MGMT_CB_ERROR_RC;
 	}
 
 	return MGMT_CB_OK;


### PR DESCRIPTION
Change fixes returning error in MCUmgr callbacks. This prevents assertion failures when the error is returned by the application module.

Jira: NCSDK-22964