### PR TITLE
samples: matter: modify default configuration of Matter samples

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -103,6 +103,9 @@ Matter
 
 * Added a page about :ref:`ug_matter_device_optimizing_memory`.
 * Fixed an IPC crash on nRF5340 when Zephyr's main thread takes a long time.
+* Disabled OpenThread shell by default in Matter over Thread samples.
+* Enabled :kconfig:option:`CHIP_FACTORY_RESET_ERASE_NVS` Kconfig option by default, including for builds without factory data support.
+  The firmware now erases all flash pages in the non-volatile storage during a factory reset, instead of just clearing Matter-related settings.
 
 See `Matter samples`_ for the list of changes for the Matter samples.
 
@@ -380,6 +383,8 @@ Thread samples
 
 Matter samples
 --------------
+
+* Disabled OpenThread shell by default in Matter over Thread samples.
 
 * :ref:`matter_lock_sample` sample:
 


### PR DESCRIPTION
This PR brings changes related to the default configuration of Matter:
 - disables BLE Gatt cache
 - enables NVS erase natively
 - disables OT shell