### PR TITLE
cmake: partition_manager: Replace import_kconfig

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -392,3 +392,31 @@ function(get_shared var)
     set(${var} ${${var}} PARENT_SCOPE)
   endif()
 endfunction()
+
+#
+# Usage
+#   import_pm_config(<dotconf_file> <keys>)
+#
+# Import variables from a partition manager output .config file
+# (usually pm.config or pm_<DOMAIN>.config) into the CMake namespace.
+#
+# <dotconf_file>: Absolute path to the file.
+# <keys_out>:     Output variable, which will be populated with a list
+#                 of variable names loaded from <dotconf_file>.
+#
+function(import_pm_config dotconf_file keys_out)
+  file(STRINGS ${dotconf_file} DOTCONF_LIST ENCODING "UTF-8")
+  foreach(LINE ${DOTCONF_LIST})
+    # Parse `key=value` assignments, where every key is prefixed with `PM_`.
+    if("${LINE}" MATCHES "(^PM_[^=]+)=(.*$)")
+      set(key "${CMAKE_MATCH_1}")
+
+      # If the value is surrounded by quotation marks, strip them out.
+      string(REGEX REPLACE "\"(.*)\"" "\\1" value "${CMAKE_MATCH_2}")
+
+      list(APPEND keys "${key}")
+      set("${key}" "${value}" PARENT_SCOPE)
+    endif()
+  endforeach()
+  set("${keys_out}" "${keys}" PARENT_SCOPE)
+endfunction()

--- a/cmake/partition_manager.cmake
+++ b/cmake/partition_manager.cmake
@@ -339,7 +339,7 @@ endif()
 add_custom_target(partition_manager)
 
 # Make Partition Manager configuration available in CMake
-import_kconfig(PM_ ${pm_out_dotconf_file} pm_var_names)
+import_pm_config(${pm_out_dotconf_file} pm_var_names)
 
 foreach(name ${pm_var_names})
   set_property(
@@ -510,13 +510,13 @@ else()
       list(APPEND global_hex_depends    ${${d}_PM_DOMAIN_DYNAMIC_PARTITION}_subimage)
 
       # Add domain prefix cmake variables for all partitions
-      # Here, we actually overwrite the already imported kconfig values
+      # Here, we actually overwrite the already imported pm.config values
       # for our own domain. This is not an issue since all of these variables
       # are accessed through the 'partition_manager' target, and most likely
       # through generator expression, as this file is one of the last
       # cmake files executed in the configure stage.
       get_shared(conf_file IMAGE ${d} PROPERTY PM_DOTCONF_FILES)
-      import_kconfig(PM_ ${conf_file} ${d}_pm_var_names)
+      import_pm_config(${conf_file} ${d}_pm_var_names)
 
       foreach(name ${${d}_pm_var_names})
         set_property(

--- a/cmake/sysbuild/partition_manager.cmake
+++ b/cmake/sysbuild/partition_manager.cmake
@@ -148,7 +148,7 @@ function(partition_manager)
 
   add_custom_target(partition_manager${underscore}${PM_DOMAIN})
   set(pm_var_names)
-  import_kconfig(PM_ ${pm_out_dotconf_file} pm_var_names)
+  import_pm_config(${pm_out_dotconf_file} pm_var_names)
 
   if(DEFINED PM_MCUBOOT_PAD_SIZE AND
      (NOT "${PM_MCUBOOT_PAD_SIZE}" STREQUAL "${SB_CONFIG_PM_MCUBOOT_PAD}")
@@ -642,12 +642,12 @@ else()
       list(APPEND pm_out_region_file    ${APPLICATION_BINARY_DIR}/regions_${d}.yml)
 
       # Add domain prefix cmake variables for all partitions
-      # Here, we actually overwrite the already imported kconfig values
+      # Here, we actually overwrite the already imported pm.config values
       # for our own domain. This is not an issue since all of these variables
       # are accessed through the 'partition_manager' target, and most likely
       # through generator expression, as this file is one of the last
       # cmake files executed in the configure stage.
-      import_kconfig(PM_ ${APPLICATION_BINARY_DIR}/pm_${d}.config ${d}_pm_var_names)
+      import_pm_config(${APPLICATION_BINARY_DIR}/pm_${d}.config ${d}_pm_var_names)
 
       foreach(name ${${d}_pm_var_names})
         set_property(


### PR DESCRIPTION
Following the changes proposed in:

https://github.com/zephyrproject-rtos/zephyr/pull/59915

the `import_kconfig()` function in upstream Zephyr has been updated to become more aligned with Kconfiglib, which makes it less of a generic "key=value" parser. This could provoke subtle bugs in the CMake bits of partition manager, where the function is being used to parse `pm.config` files, which are not actual Kconfig fragments.

Add a replacement parser for `pm.config` files.