### PR TITLE
ci: docbuild: use actions/cache v3

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -34,7 +34,7 @@ jobs:
           path: ncs/nrf
           fetch-depth: 0
       - name: cache-pip
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-doc-pip


### PR DESCRIPTION
Because v1 uses deprecated features, so use latest version.

Ref https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default