### PR TITLE
tools: Update ccache version to 4.8.2

### DIFF
--- a/scripts/tools-versions-linux.yml
+++ b/scripts/tools-versions-linux.yml
@@ -23,7 +23,7 @@ zephyr-sdk:
     - x86_64-zephyr-elf
     - arm-zephyr-eabi
 ccache:
-  version: 3.7.7
+  version: 4.8.2
 dfu_util:
   version: 0.9-1
 doxygen:


### PR DESCRIPTION
Ccache 4.4+ has support for using the Redis protocol. It allows to configure shared ccache database.