### PR TITLE
applications: asset_tracker_v2: remove board target for mocked test

### DIFF
--- a/applications/asset_tracker_v2/tests/nrf_cloud_codec_mocked_cjson/testcase.yaml
+++ b/applications/asset_tracker_v2/tests/nrf_cloud_codec_mocked_cjson/testcase.yaml
@@ -1,8 +1,7 @@
 tests:
   asset_tracker_v2.nrf_cloud_codec_mocked_cjson_test:
-    platform_allow: native_posix qemu_cortex_m3 nrf9160dk_nrf9160_ns
+    platform_allow: native_posix qemu_cortex_m3
     integration_platforms:
       - native_posix
       - qemu_cortex_m3
-      - nrf9160dk_nrf9160_ns
     tags: nrf_cloud_codec_mocked_cJSON


### PR DESCRIPTION
This patch removes the physical board target for
nrf_cloud_codec_mocked_cjson since it's unnecessary and also doesn't work.