### PR TITLE
samples: cellular: Updated samples with modem lib shutdown()

### DIFF
--- a/samples/cellular/battery/src/main.c
+++ b/samples/cellular/battery/src/main.c
@@ -424,6 +424,10 @@ int main(void)
 
 		k_sleep(K_SECONDS(refresh_interval));
 	}
+	err = nrf_modem_lib_shutdown();
+	if (err) {
+		printk("Failed to shutdown modem lib, err %d\n", err);
+	}
 
 	return 0;
 }

--- a/samples/cellular/ciphersuites/src/main.c
+++ b/samples/cellular/ciphersuites/src/main.c
@@ -234,5 +234,10 @@ clean_up:
 
 	lte_lc_power_off();
 
+	err = nrf_modem_lib_shutdown();
+	if (err) {
+		printk("Failed to shutdown modem lib, err %d\n", err);
+	}
+
 	return 0;
 }

--- a/samples/cellular/download/src/main.c
+++ b/samples/cellular/download/src/main.c
@@ -152,6 +152,11 @@ static int callback(const struct download_client_evt *event)
 #endif /* CONFIG_SAMPLE_COMPUTE_HASH */
 
 		lte_lc_power_off();
+		int err = nrf_modem_lib_shutdown();
+
+		if (err) {
+			printk("Failed to shutdown modem lib, err %d\n", err);
+		}
 		printk("Bye\n");
 		return 0;
 
@@ -162,6 +167,11 @@ static int callback(const struct download_client_evt *event)
 		} else {
 			lte_lc_power_off();
 			/* Stop download */
+			int err = nrf_modem_lib_shutdown();
+
+			if (err) {
+				printk("Failed to shutdown modem lib, err %d\n", err);
+			}
 			return -1;
 		}
 		break;

--- a/samples/cellular/pdn/src/main.c
+++ b/samples/cellular/pdn/src/main.c
@@ -163,6 +163,10 @@ int main(void)
 	ifaddrs_print();
 
 	lte_lc_power_off();
+	err = nrf_modem_lib_shutdown();
+	if (err) {
+		printk("Failed to shutdown modem lib, err %d\n", err);
+	}
 	printk("Bye\n");
 
 	return 0;


### PR DESCRIPTION
This PR adds nrf_modem_lib_shutdown() to gracefully shutdown modem on completion of the samples