### PR TITLE
lte_connectivity: fix LTE_CONNECTIVITY build with CONFIG_POSIX_API=y

### DIFF
--- a/lib/nrf_modem_lib/lte_connectivity/lte_ip_addr_helper.c
+++ b/lib/nrf_modem_lib/lte_connectivity/lte_ip_addr_helper.c
@@ -12,6 +12,10 @@
 #include <nrf_modem_at.h>
 #include <string.h>
 
+#ifdef CONFIG_POSIX_API
+#include <arpa/inet.h>
+#endif
+
 #include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(ip_addr_helper, CONFIG_LTE_CONNECTIVITY_LOG_LEVEL);


### PR DESCRIPTION
`inet_pton()` function is only accessible when:
 * `CONFIG_POSIX_API=y` or
 * `CONFIG_NET_SOCKETS_POSIX_NAMES=y` are enabled.

Depending on the selected option (both are mutually exclusive), its definition is located in different header file.
`lte_ip_addr_helper.c` (part of `LTE_CONNECTIVITY`) is including just one of those, assuming `CONFIG_NET_SOCKETS_POSIX_NAMES=y`.

Add compatibility with `CONFIG_POSIX_API=y` by including `arpa/inet.h` whenever POSIX API is enabled.

Fixes:
```
/nrfconnnect-sdk/nrf/lib/nrf_modem_lib/lte_connectivity/lte_ip_addr_helper.c:60:33: warning: implicit declaration of function 'inet_pton' [-Wimplicit-function-declaration]
   60 |         if ((addr4 != NULL) && (inet_pton(AF_INET, addr1, tmp) == 1)) {
      |                                 ^~~~~~~~~
```