### PR TITLE
net: lib: nrf_cloud: filter local APs from Wi-Fi location req

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -569,16 +569,25 @@ Libraries for networking
 
     * :c:struct:`nrf_cloud_obj` structure and functions for encoding and decoding nRF Cloud data.
     * :c:func:`nrf_cloud_obj_pgps_request_create` function that creates a P-GPS request for nRF Cloud.
+    * A new internal codec function :c:func:`nrf_cloud_obj_location_request_payload_add`, which excludes local Wi-Fi access point MAC addresses from the location request.
 
   * Updated:
 
     * Moved JSON manipulation from :file:`nrf_cloud_fota.c` to :file:`nrf_cloud_codec_internal.c`.
     * Fixed a build issue that occurred when MQTT and P-GPS are enabled and A-GPS is disabled.
+    * :c:func:`nrf_cloud_obj_location_request_create` to use the new function :c:func:`nrf_cloud_obj_location_request_payload_add`.
 
   * Removed:
 
     * Unused internal codec function ``nrf_cloud_format_single_cell_pos_req_json()``.
     * ``nrf_cloud_location_request_msg_json_encode()`` function and replaced with :c:func:`nrf_cloud_obj_location_request_create`.
+    * ``nrf_cloud_location_req_json_encode()`` internal codec function.
+
+* :ref:`lib_nrf_cloud_rest` library:
+
+  * Updated:
+
+    * :c:func:`nrf_cloud_rest_location_get` to use the new function :c:func:`nrf_cloud_obj_location_request_payload_add`.
 
 * Added the :ref:`lib_nrf_cloud_coap` library for accessing nRF Cloud services using CoAP.
 

--- a/include/net/nrf_cloud_codec.h
+++ b/include/net/nrf_cloud_codec.h
@@ -105,7 +105,8 @@ struct nrf_cloud_obj {
  * @retval false Type is invalid.
  */
 #define NRF_CLOUD_OBJ_TYPE_VALID(_obj_ptr) \
-	(bool)((_obj_ptr->type > NRF_CLOUD_OBJ_TYPE__UNDEFINED) && \
+	(bool)((_obj_ptr != NULL) && \
+	       (_obj_ptr->type > NRF_CLOUD_OBJ_TYPE__UNDEFINED) && \
 	       (_obj_ptr->type < NRF_CLOUD_OBJ_TYPE__LAST))
 
 /**

--- a/include/net/nrf_cloud_rest.h
+++ b/include/net/nrf_cloud_rest.h
@@ -119,7 +119,11 @@ struct nrf_cloud_rest_context {
 struct nrf_cloud_rest_location_request {
 	/** Cellular network information used in request */
 	struct lte_lc_cells_info *cell_info;
-	/** Wi-Fi network information used in request */
+	/** Wi-Fi network information used in request.
+	 * The minimum number of access points required by nRF Cloud is
+	 * defined by NRF_CLOUD_LOCATION_WIFI_AP_CNT_MIN. Access points with
+	 * a local MAC address will not be included in the request.
+	 */
 	struct wifi_scan_info *wifi_info;
 	/** If true, nRF Cloud will not send the location data to the device
 	 * in the REST response body. The location will still be recorded in the cloud.

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec_internal.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec_internal.h
@@ -226,16 +226,17 @@ int nrf_cloud_cell_info_json_encode(cJSON * const data_obj,
 int nrf_cloud_cell_pos_req_json_encode(struct lte_lc_cells_info const *const inf,
 				       cJSON * const req_obj_out);
 
-/** @brief Build a location request string using the provided info.
- * If successful, memory will be allocated for the output string and the user is
- * responsible for freeing it using @ref cJSON_free.
- */
-int nrf_cloud_location_req_json_encode(struct lte_lc_cells_info const *const cell_info,
-				       struct wifi_scan_info const *const wifi_info,
-				       char **string_out);
+/** @brief Add the location request data payload to the provided initialized object */
+int nrf_cloud_obj_location_request_payload_add(struct nrf_cloud_obj *const obj,
+					       struct lte_lc_cells_info const *const cells_inf,
+					       struct wifi_scan_info const *const wifi_inf);
 
-/** @brief Build a WiFi positioning request in the provided cJSON object
- * using the provided WiFi info
+/** @brief Build a Wi-Fi positioning request in the provided cJSON object using the provided
+ * Wi-Fi info. Local MAC addresses are not included in the request.
+ *
+ * @retval 0 Success.
+ * @retval -ENODATA Access point (non-local) count less than NRF_CLOUD_LOCATION_WIFI_AP_CNT_MIN.
+ * @return -ENOMEM Out of memory.
  */
 int nrf_cloud_wifi_req_json_encode(struct wifi_scan_info const *const wifi,
 				   cJSON *const req_obj_out);

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec.c
@@ -749,24 +749,10 @@ int nrf_cloud_obj_location_request_create(struct nrf_cloud_obj *const obj,
 	switch (obj->type) {
 	case NRF_CLOUD_OBJ_TYPE_JSON:
 	{
-		if (cells_inf) {
-			err = nrf_cloud_cell_pos_req_json_encode(cells_inf, data_obj.json);
-			if ((err == -ENODATA) && (wifi_inf != NULL)) {
-				LOG_WRN("No GCI cells, excluding cellular data from request");
-			} else if (err) {
-				LOG_ERR("Failed to add cell info to location request, error: %d",
-					err);
-				goto cleanup;
-			}
-		}
-
-		if (wifi_inf) {
-			err = nrf_cloud_wifi_req_json_encode(wifi_inf, data_obj.json);
-			if (err) {
-				LOG_ERR("Failed to add Wi-Fi info to location request, error: %d",
-					err);
-				goto cleanup;
-			}
+		/* Add cell/wifi info */
+		err = nrf_cloud_obj_location_request_payload_add(&data_obj, cells_inf, wifi_inf);
+		if (err) {
+			goto cleanup;
 		}
 
 		/* Add data object to the location request object */


### PR DESCRIPTION
Do not include access points with local MAC addresses in nRF Cloud location requests. The cloud will discard them.

Consolidate location request message generation into one function, nrf_cloud_obj_location_request_payload_add(), and remove nrf_cloud_location_req_json_encode().

IRIS-6733