### PR TITLE
net: lib: aws_fota: Improve error handling for FOTA jobs

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -590,6 +590,7 @@ Libraries for networking
 
     * The :kconfig:option:`CONFIG_AWS_FOTA_HOSTNAME_MAX_LEN` Kconfig option has been replaced by the :kconfig:option:`CONFIG_DOWNLOAD_CLIENT_MAX_HOSTNAME_SIZE` Kconfig option.
     * The :kconfig:option:`CONFIG_AWS_FOTA_FILE_PATH_MAX_LEN` Kconfig option has been replaced by the :kconfig:option:`CONFIG_DOWNLOAD_CLIENT_MAX_FILENAME_SIZE` Kconfig option.
+    * AWS FOTA jobs are now marked as failed if the job document for the update is invalid.
 
 * :ref:`lib_azure_fota` library:
 

--- a/subsys/net/lib/aws_fota/include/aws_fota_json.h
+++ b/subsys/net/lib/aws_fota/include/aws_fota_json.h
@@ -37,6 +37,16 @@ extern "C" {
  */
 #define EXECUTION_OBJ_DECODED_BIT 2
 
+/** @brief AWS FOTA JSON parse result. */
+enum aws_fota_json_result {
+	AWS_FOTA_JSON_RES_SKIPPED = 1,		/*!< Not a FOTA job document, skipped */
+	AWS_FOTA_JSON_RES_SUCCESS = 0,		/*!< Job document parsed successfully */
+	AWS_FOTA_JSON_RES_INVALID_PARAMS = -1,	/*!< Input parameters invalid */
+	AWS_FOTA_JSON_RES_INVALID_JOB = -2,	/*!< Job document invalid, could not get job id */
+	AWS_FOTA_JSON_RES_INVALID_DOCUMENT = -3,/*!< FOTA update data invalid */
+	AWS_FOTA_JSON_RES_URL_TOO_LONG = -4,	/*!< Parts of URL too large for buffer */
+};
+
 /**
  * @brief Parse a given AWS IoT DescribeJobExecution response JSON object.
  *	  More information on this object can be found at https://docs.aws.amazon.com/iot/latest/developerguide/jobs-api.html#mqtt-describejobexecution
@@ -54,9 +64,7 @@ extern "C" {
  * @param[in] file_path_buf_size  Size of the output buffer for the "file" field
  * @param[out] version_number  Version number from the Job Execution data type.
  *
- * @return 0 if the Job Execution object is empty, 1 if Job Execution object was
- *	     correctly decoded, otherwise a negative error code is returned
- *	     identicating reason of failure.
+ * @return aws_fota_json_result specifying the result of the parse operation.
  **/
 int aws_fota_parse_DescribeJobExecution_rsp(const char *job_document,
 					    uint32_t payload_len,

--- a/tests/subsys/net/lib/aws_fota/aws_fota_json/src/main.c
+++ b/tests/subsys/net/lib/aws_fota/aws_fota_json/src/main.c
@@ -34,7 +34,7 @@ void test_parse_job_execution(void)
 						      hostname, sizeof(hostname),
 						      file_path, sizeof(file_path),
 						      &version_number);
-	TEST_ASSERT_EQUAL(1, ret);
+	TEST_ASSERT_EQUAL(AWS_FOTA_JSON_RES_SUCCESS, ret);
 	TEST_ASSERT_EQUAL_STRING(expected_job_id, job_id);
 	TEST_ASSERT_EQUAL(expected_version_number, version_number);
 	TEST_ASSERT_EQUAL_STRING(expected_hostname, hostname);
@@ -76,7 +76,7 @@ void test_parse_job_execution_single_url(void)
 						      hostname, sizeof(hostname),
 						      file_path, sizeof(file_path),
 						      &version_number);
-	TEST_ASSERT_EQUAL(1, ret);
+	TEST_ASSERT_EQUAL(AWS_FOTA_JSON_RES_SUCCESS, ret);
 	TEST_ASSERT_EQUAL_STRING(expected_job_id, job_id);
 	TEST_ASSERT_EQUAL(expected_version_number, version_number);
 	TEST_ASSERT_EQUAL_STRING(expected_hostname, hostname);
@@ -98,7 +98,7 @@ void test_parse_malformed_job_execution(void)
 						      hostname, sizeof(hostname),
 						      file_path, sizeof(file_path),
 						      &version_number);
-	TEST_ASSERT_EQUAL(-ENODATA, ret);
+	TEST_ASSERT_EQUAL(AWS_FOTA_JSON_RES_INVALID_JOB, ret);
 }
 
 void test_parse_job_execution_missing_host_field(void)
@@ -117,7 +117,7 @@ void test_parse_job_execution_missing_host_field(void)
 						      hostname, sizeof(hostname),
 						      file_path, sizeof(file_path),
 						      &version_number);
-	TEST_ASSERT_EQUAL(-ENODATA, ret);
+	TEST_ASSERT_EQUAL(AWS_FOTA_JSON_RES_INVALID_DOCUMENT, ret);
 }
 
 void test_parse_job_execution_missing_path_field(void)
@@ -135,7 +135,7 @@ void test_parse_job_execution_missing_path_field(void)
 						      hostname, sizeof(hostname),
 						      file_path, sizeof(file_path),
 						      &version_number);
-	TEST_ASSERT_EQUAL(-ENODATA, ret);
+	TEST_ASSERT_EQUAL(AWS_FOTA_JSON_RES_INVALID_DOCUMENT, ret);
 }
 
 void test_parse_job_execution_missing_job_id_field(void)
@@ -153,7 +153,7 @@ void test_parse_job_execution_missing_job_id_field(void)
 						      hostname, sizeof(hostname),
 						      file_path, sizeof(file_path),
 						      &version_number);
-	TEST_ASSERT_EQUAL(-ENODATA, ret);
+	TEST_ASSERT_EQUAL(AWS_FOTA_JSON_RES_INVALID_JOB, ret);
 }
 
 void test_parse_job_execution_missing_location_obj(void)
@@ -171,7 +171,7 @@ void test_parse_job_execution_missing_location_obj(void)
 						      hostname, sizeof(hostname),
 						      file_path, sizeof(file_path),
 						      &version_number);
-	TEST_ASSERT_EQUAL(-ENODATA, ret);
+	TEST_ASSERT_EQUAL(AWS_FOTA_JSON_RES_INVALID_DOCUMENT, ret);
 }
 
 void test_update_job_longer_than_max(void)
@@ -206,7 +206,7 @@ void test_timestamp_only(void)
 						      hostname, sizeof(hostname),
 						      file_path, sizeof(file_path),
 						      &version_number);
-	TEST_ASSERT_EQUAL(0, ret);
+	TEST_ASSERT_EQUAL(AWS_FOTA_JSON_RES_SKIPPED, ret);
 }
 
 void test_update_job_exec_rsp_minimal(void)


### PR DESCRIPTION
- Improves error handling by providing more fine grained errors on job parsing.

- Jobs are now marked as failed if document is invalid but the job id could be parsed. 

- A new error state is introduced to enableretries for marking jobs as failed.

- Additionally, the job update accepted/rejected topics are no longer subscribed to, as this is not necessary to receive the respective messages and thus adds unnecessary overhead.