### PR TITLE
samples: wifi: FICR changes to read INFO data.

### DIFF
--- a/drivers/wifi/nrf700x/osal/hw_if/hal/inc/fw/rpu_if.h
+++ b/drivers/wifi/nrf700x/osal/hw_if/hal/inc/fw/rpu_if.h
@@ -232,6 +232,9 @@ static const struct rpu_addr_map RPU_ADDR_MAP_MCU[] = {
 #define PRODTEST_TRIM13 45
 #define PRODTEST_TRIM14 46
 #define PRODCTRL_DISABLE5GHZ 47
+#define INFO_PART 48
+#define INFO_VARIANT 49
+#define INFO_UUID 52
 #define QSPI_KEY 68
 #define MAC0_ADDR 72
 #define MAC1_ADDR 74

--- a/samples/wifi/radio_test/src/nrf_wifi_radio_ficr_shell.c
+++ b/samples/wifi/radio_test/src/nrf_wifi_radio_ficr_shell.c
@@ -144,6 +144,16 @@ static int nrf_wifi_radio_test_otp_read_params(const struct shell *shell,
 		val[PRODCTRL_DISABLE5GHZ]);
 	shell_fprintf(shell, SHELL_INFO, "\n");
 
+	shell_fprintf(shell, SHELL_INFO, "INFO_PART = 0x%08x\n", val[INFO_PART]);
+	shell_fprintf(shell, SHELL_INFO, "INFO_VARIANT = 0x%08x\n", val[INFO_VARIANT]);
+	shell_fprintf(shell, SHELL_INFO, "\n");
+
+	shell_fprintf(shell, SHELL_INFO, "INFO_UUID0 = 0x%08x\n", val[INFO_UUID + 0]);
+	shell_fprintf(shell, SHELL_INFO, "INFO_UUID1 = 0x%08x\n", val[INFO_UUID + 1]);
+	shell_fprintf(shell, SHELL_INFO, "INFO_UUID2 = 0x%08x\n", val[INFO_UUID + 2]);
+	shell_fprintf(shell, SHELL_INFO, "INFO_UUID3 = 0x%08x\n", val[INFO_UUID + 3]);
+	shell_fprintf(shell, SHELL_INFO, "\n");
+
 	shell_fprintf(shell, SHELL_INFO, "MAC0: Reg0 = 0x%08x\n", val[MAC0_ADDR]);
 	shell_fprintf(shell, SHELL_INFO, "MAC0: Reg1 = 0x%08x\n", val[MAC0_ADDR + 1]);
 	shell_fprintf(shell, SHELL_INFO, "MAC0 Addr  = %02x:%02x:%02x:%02x:%02x:%02x\n",


### PR DESCRIPTION
[SHEL-1856] Extend otp_read_command to read INFO_PART, INFO_VARIANT and INFO_UUID from OTP.

[SHEL-1856]: https://nordicsemi.atlassian.net/browse/SHEL-1856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ