### PR TITLE
net: lib: nrf_cloud: Set job type to invalid after job info is freed.

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -576,6 +576,7 @@ Libraries for networking
     * Moved JSON manipulation from :file:`nrf_cloud_fota.c` to :file:`nrf_cloud_codec_internal.c`.
     * Fixed a build issue that occurred when MQTT and P-GPS are enabled and A-GPS is disabled.
     * :c:func:`nrf_cloud_obj_location_request_create` to use the new function :c:func:`nrf_cloud_obj_location_request_payload_add`.
+    * Fixed a bug that prevented an MQTT FOTA job from being started.
 
   * Removed:
 

--- a/include/net/nrf_cloud_coap.h
+++ b/include/net/nrf_cloud_coap.h
@@ -168,7 +168,7 @@ int nrf_cloud_coap_location_get(struct nrf_cloud_rest_location_request const *co
  *
  * @param[out]    job Parsed job info. If no job exists, type will
  *                    be set to invalid. If a job exists, user must call
- *                    @ref nrf_cloud_rest_fota_job_free to free the memory
+ *                    @ref nrf_cloud_coap_fota_job_free to free the memory
  *                    allocated by this function.
  *
  * @return 0 if the request succeeded, a positive value indicating a CoAP result code,

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec_internal.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec_internal.c
@@ -1794,13 +1794,12 @@ void nrf_cloud_fota_job_free(struct nrf_cloud_fota_job_info *const job)
 	}
 
 	nrf_cloud_free(job->id);
-	job->id = NULL;
-
 	nrf_cloud_free(job->host);
-	job->host = NULL;
-
 	nrf_cloud_free(job->path);
-	job->path = NULL;
+
+	/* Reset entire struct since info is no longer valid */
+	memset(job, 0, sizeof(*job));
+	job->type = NRF_CLOUD_FOTA_TYPE__INVALID;
 }
 
 /* FOTA job format via MQTT:
@@ -2254,8 +2253,6 @@ err_cleanup:
 	}
 
 	nrf_cloud_fota_job_free(job);
-	memset(job, 0, sizeof(*job));
-	job->type = NRF_CLOUD_FOTA_TYPE__INVALID;
 
 	return ret;
 }


### PR DESCRIPTION
Fixes a bug that prevents a new MQTT FOTA job from being started after a FOTA job has just completed.
IRIS-6799