### PR TITLE
manifest: Update Matter SDK to pull fix for Cmake script

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -147,7 +147,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 834a21bf2b0f22b9e9af7adb6167041b3dbdebf8
+      revision: 97b73256e666f867cb840f0beeeaa5091f47e544
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
This version of Matter SDK contains a fix for finding python executable within the Cmake factory data generation script.