### PR TITLE
net: lib: lwm2m_client_utils: Add delay after credential changed

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -597,6 +597,7 @@ Libraries for networking
 
     * Support for using pre-provisioned X.509 certificates.
     * Support for using DTLS Connection Identifier
+    * Configurable delay after bootstrap. See :kconfig:option:`CONFIG_LWM2M_CLIENT_UTILS_SLEEP_AFTER_CREDENTIAL_WRITE`.
 
   * Updated:
 

--- a/subsys/net/lib/lwm2m_client_utils/Kconfig
+++ b/subsys/net/lib/lwm2m_client_utils/Kconfig
@@ -45,6 +45,14 @@ config LWM2M_CLIENT_UTILS_BOOTSTRAP_TLS_TAG
 	  may write credentials into first LwM2M security instance "0/0/5".
 	  Client utilities only write to this security tag if it is empty.
 
+config LWM2M_CLIENT_UTILS_SLEEP_AFTER_CREDENTIAL_WRITE
+	int "Time to sleep after security credential have been written. (seconds)"
+	default 15
+	help
+	  This is a workaround for some Bootstrap servers that might not be fast enough
+	  to send generated credentials into the target servers.
+	  To disable this, set to zero.
+
 endif # LWM2M_CLIENT_UTILS_SECURITY_OBJ_SUPPORT
 
 config LWM2M_CLIENT_UTILS_CONN_MON_OBJ_SUPPORT

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_security.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_security.c
@@ -351,6 +351,11 @@ out:
 		k_sleep(K_SECONDS(ret));
 	}
 
+	if (CONFIG_LWM2M_CLIENT_UTILS_SLEEP_AFTER_CREDENTIAL_WRITE > 0) {
+		LOG_INF("Delay after credentials have been changed.");
+		k_sleep(K_SECONDS(CONFIG_LWM2M_CLIENT_UTILS_SLEEP_AFTER_CREDENTIAL_WRITE));
+	}
+
 	return ret;
 }
 


### PR DESCRIPTION
This is a workaround for some Bootstrap servers that might not be fast enough to send generated credentials into the target servers.