### PR TITLE
Bluetooth: Mesh: alternate location publishing

### DIFF
--- a/include/bluetooth/mesh/gen_loc_srv.h
+++ b/include/bluetooth/mesh/gen_loc_srv.h
@@ -131,8 +131,15 @@ struct bt_mesh_loc_srv {
 		BT_MESH_MODEL_BUF_LEN(BT_MESH_LOC_OP_GLOBAL_STATUS,
 				      BT_MESH_LOC_MSG_LEN_GLOBAL_STATUS))];
 
-	/** Current opcode being published. */
-	uint16_t pub_op;
+	/** Location publishing state. */
+	struct {
+		/** Global location is available for publishing. */
+		uint8_t is_global_available: 1;
+		/** Local location is available for publishing. */
+		uint8_t is_local_available: 1;
+		/** The last published location over periodic publication. */
+		uint8_t was_last_local: 1;
+	} pub_state;
 	/** Pointer to a handler structure. */
 	const struct bt_mesh_loc_srv_handlers *const handlers;
 };


### PR DESCRIPTION
The Location model shall support model publication. When configured for publication, the Generic Location Server shall publish Generic Location Global Status messages if the server knows its global location or shall publish Generic Location Local Status messages if the server knows its local location. If configured for periodic publications, and both global and local locations are known, the Generic Location Server shall alternate between publishing its local and global locations in consecutive publish periods.