### PR TITLE
Manifest: Update sdk-zephyr rev with a bugfix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 80493dd34fc629cd50462f84ea6bd090a3d17325
+      revision: 042fc99b1ecdc0acc14acd03ebddb8c133d87d3a
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Fixes a bug in the Bluetooth host related to handling ISO data packets.

See https://github.com/nrfconnect/sdk-zephyr/pull/1273