### PR TITLE
net: nrf_provisioning: Improve logging

### DIFF
--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_coap.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_coap.c
@@ -92,7 +92,7 @@ static int dtls_setup(int fd)
 		TLS_SEC_TAG,
 	};
 
-	LOG_INF("TLS setup");
+	LOG_INF("DTLS setup");
 
 	/* Set up TLS peer verification */
 	verify = TLS_PEER_VERIFY_REQUIRED;
@@ -563,6 +563,7 @@ int nrf_provisioning_coap_req(struct nrf_provisioning_coap_context *const coap_c
 			break;
 		}
 
+		LOG_INF("Requesting commands");
 		ret = request_commands(&client, coap_ctx);
 		if (ret < 0) {
 			break;
@@ -585,6 +586,7 @@ int nrf_provisioning_coap_req(struct nrf_provisioning_coap_context *const coap_c
 			cdc_ctx.opkt = tx_buf.coap;
 			cdc_ctx.opkt_sz = sizeof(tx_buf);
 
+			LOG_INF("Processing commands");
 			ret = nrf_provisioning_codec_process_commands();
 			if (ret < 0) {
 				LOG_ERR("ret %d", ret);
@@ -606,6 +608,7 @@ int nrf_provisioning_coap_req(struct nrf_provisioning_coap_context *const coap_c
 				break;
 			}
 
+			LOG_INF("Sending response to server");
 			ret = send_response(&client, coap_ctx, &cdc_ctx);
 			if (ret < 0) {
 				break;

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_codec.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_codec.c
@@ -257,6 +257,7 @@ int filter_cme_error(struct command *cmd, int cme_error)
 
 	for (int i = 0;	i < at_cmd->_at_command_ignore_cme_errors_uint_count; i++) {
 		if (at_cmd->_at_command_ignore_cme_errors_uint[i] == cme_error) {
+			LOG_DBG("Filtered CME error %d", cme_error);
 			filtered = true;
 		}
 	}
@@ -302,10 +303,14 @@ static int exec_at_cmd(struct command *cmd_req, struct cdc_out_fmt_data *out)
 		} else if (ret < 0) {
 			LOG_ERR("AT cmd failed, error: %d", ret);
 		} else if (ret > 0) {
-			ret = filter_cme_error(cmd_req, nrf_modem_at_err(ret));
 			/* 'ERROR' or '+CME ERROR'. Doesn't matter which */
-			LOG_INF("AT cmd failed, type %d, err %d",
+			LOG_DBG("AT cmd failed, type %d, err %d",
 				nrf_modem_at_err_type(ret), nrf_modem_at_err(ret));
+			ret = filter_cme_error(cmd_req, nrf_modem_at_err(ret));
+			if (ret) {
+				/* ERROR was not filtered */
+				LOG_ERR("AT cmd failed, error: %d", ret);
+			}
 		}
 		break;
 	}

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_http.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_http.c
@@ -496,6 +496,7 @@ int nrf_provisioning_http_req(struct nrf_provisioning_http_context *const rest_c
 
 		print_req_info(&req, sizeof(headers) / sizeof(*headers) - 1);
 
+		LOG_INF("Requesting commands");
 		ret = rest_client_request(&req, &resp);
 		k_free(auth_hdr);
 		auth_hdr = NULL;
@@ -543,6 +544,7 @@ int nrf_provisioning_http_req(struct nrf_provisioning_http_context *const rest_c
 			cdc_ctx.opkt = tx_buf.http;
 			cdc_ctx.opkt_sz = sizeof(tx_buf);
 
+			LOG_INF("Processing commands");
 			ret = nrf_provisioning_codec_process_commands();
 			if (ret < 0) {
 				break;
@@ -551,6 +553,7 @@ int nrf_provisioning_http_req(struct nrf_provisioning_http_context *const rest_c
 				finished = true;
 			}
 
+			LOG_INF("Sending response to server");
 			ret = nrf_provisioning_responses_req(rest_ctx, &req, &resp, &cdc_ctx);
 			if (ret < 0) {
 				finished = false;


### PR DESCRIPTION
Add some prints to show provisioning steps.
Fix log from CME error filtering.