### PR TITLE
pm: Fix shared SRAM calculation

### DIFF
--- a/subsys/partition_manager/CMakeLists.txt
+++ b/subsys/partition_manager/CMakeLists.txt
@@ -80,7 +80,10 @@ if (CONFIG_NRF_MODEM_LIB)
   ncs_add_partition_manager_config(pm.yml.libmodem)
 endif()
 
-if (CONFIG_IPC_SERVICE AND CONFIG_SOC_NRF5340_CPUAPP)
+# The default DTS configuration for the nRF5340 CPUAPP includes the
+# the shared SRAM region, so, inform the partition manager about this
+# region.
+if (CONFIG_SOC_NRF5340_CPUAPP)
   ncs_add_partition_manager_config(pm.yml.rpmsg_nrf53)
 endif()
 

--- a/subsys/partition_manager/Kconfig
+++ b/subsys/partition_manager/Kconfig
@@ -39,7 +39,7 @@ DT_CHOSEN_Z_IPC_SHM := zephyr,ipc_shm
 config RPMSG_NRF53_SRAM_SIZE
 	hex "RPMsg shared memory size"
 	default "$(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_IPC_SHM))"
-	depends on IPC_SERVICE && SOC_NRF5340_CPUAPP
+	depends on SOC_NRF5340_CPUAPP
 	depends on PARTITION_MANAGER_ENABLED
 	help
 	  This option specifies size of the memory region to be used


### PR DESCRIPTION
Fixes the available RAM print in the memory footprint at end of the build.