### PR TITLE
application: nrf5340_audio: Fix num_conn not initialized

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/bt_management/bt_mgmt.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/bt_mgmt.c
@@ -75,7 +75,7 @@ static void connected_cb(struct bt_conn *conn, uint8_t err)
 {
 	int ret;
 	char addr[BT_ADDR_LE_STR_LEN];
-	uint8_t num_conn;
+	uint8_t num_conn = 0;
 	uint16_t conn_handle;
 	enum ble_hci_vs_tx_power conn_tx_pwr;
 	struct bt_mgmt_msg msg;

--- a/applications/nrf5340_audio/src/bluetooth/le_audio.h
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio.h
@@ -11,6 +11,7 @@
 #include <zephyr/bluetooth/audio/audio.h>
 #include <audio_defines.h>
 
+#define LE_AUDIO_ZBUS_EVENT_WAIT_TIME	  K_MSEC(5)
 #define LE_AUDIO_SDU_SIZE_OCTETS(bitrate) (bitrate / (1000000 / CONFIG_AUDIO_FRAME_DURATION_US) / 8)
 
 #if (CONFIG_AUDIO_SAMPLE_RATE_48000_HZ)

--- a/applications/nrf5340_audio/src/bluetooth/le_audio_bis_gateway.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_bis_gateway.c
@@ -75,7 +75,7 @@ static void le_audio_event_publish(enum le_audio_evt_type event)
 
 	msg.event = event;
 
-	ret = zbus_chan_pub(&le_audio_chan, &msg, K_NO_WAIT);
+	ret = zbus_chan_pub(&le_audio_chan, &msg, LE_AUDIO_ZBUS_EVENT_WAIT_TIME);
 	ERR_CHK(ret);
 }
 

--- a/applications/nrf5340_audio/src/bluetooth/le_audio_bis_headset.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_bis_headset.c
@@ -77,7 +77,7 @@ static void le_audio_event_publish(enum le_audio_evt_type event)
 
 	msg.event = event;
 
-	ret = zbus_chan_pub(&le_audio_chan, &msg, K_NO_WAIT);
+	ret = zbus_chan_pub(&le_audio_chan, &msg, LE_AUDIO_ZBUS_EVENT_WAIT_TIME);
 	ERR_CHK(ret);
 }
 

--- a/applications/nrf5340_audio/src/bluetooth/le_audio_cis_gateway.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_cis_gateway.c
@@ -112,7 +112,7 @@ static void le_audio_event_publish(enum le_audio_evt_type event, struct bt_conn 
 	msg.event = event;
 	msg.conn = conn;
 
-	ret = zbus_chan_pub(&le_audio_chan, &msg, K_NO_WAIT);
+	ret = zbus_chan_pub(&le_audio_chan, &msg, LE_AUDIO_ZBUS_EVENT_WAIT_TIME);
 	ERR_CHK(ret);
 }
 

--- a/applications/nrf5340_audio/src/bluetooth/le_audio_cis_headset.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_cis_headset.c
@@ -77,7 +77,7 @@ static void le_audio_event_publish(enum le_audio_evt_type event, struct bt_conn 
 	msg.event = event;
 	msg.conn = conn;
 
-	ret = zbus_chan_pub(&le_audio_chan, &msg, K_NO_WAIT);
+	ret = zbus_chan_pub(&le_audio_chan, &msg, LE_AUDIO_ZBUS_EVENT_WAIT_TIME);
 	ERR_CHK(ret);
 }
 


### PR DESCRIPTION
Fixed num_conn not initialized properly which could cause the CIS gateway cannot establish connection properly.