### PR TITLE
manifest: sdk-hostap: Pull missing commits

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -109,7 +109,7 @@ manifest:
     - name: hostap
       repo-path: sdk-hostap
       path: modules/lib/hostap
-      revision: 4b93835253587b3b4193db23689b585a118b75a9
+      revision: 44c4504d1549ab0f6dda503050ad5ca2654d0f91
       userdata:
         ncs:
           upstream-url: https://w1.fi/cgit/hostap/


### PR DESCRIPTION
Few commits were missed during the upmerge preparation:

* Adding CODEOWNERS
* Fix for interface de-init