### PR TITLE
net: lwm2m_client_utils: Fix race condition on Firmware object

### DIFF
--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_adv_firmware.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_adv_firmware.c
@@ -114,6 +114,7 @@ void lwm2m_adv_firmware_set_update_state(uint16_t obj_inst_id, uint8_t state)
 		LOG_DBG("Already at state %d", state);
 		return;
 	}
+	lwm2m_registry_lock();
 
 	path = LWM2M_OBJ(LWM2M_OBJECT_ADV_FIRMWARE_ID, obj_inst_id, FIRMWARE_UPDATE_RESULT_ID);
 
@@ -147,6 +148,7 @@ void lwm2m_adv_firmware_set_update_state(uint16_t obj_inst_id, uint8_t state)
 		break;
 	default:
 		LOG_ERR("Unhandled state: %u", state);
+		lwm2m_registry_unlock();
 		return;
 	}
 
@@ -161,6 +163,7 @@ void lwm2m_adv_firmware_set_update_state(uint16_t obj_inst_id, uint8_t state)
 	now = time(NULL);
 	path.res_id = FIRMWARE_LAST_STATE_CHANGE_TIME_ID;
 	lwm2m_set_time(&path, now);
+	lwm2m_registry_unlock();
 }
 
 uint8_t lwm2m_adv_firmware_get_update_result(uint16_t obj_inst_id)
@@ -173,6 +176,7 @@ void lwm2m_adv_firmware_set_update_result(uint16_t obj_inst_id, uint8_t result)
 	uint8_t state;
 	bool error = false;
 	struct lwm2m_obj_path path;
+	lwm2m_registry_lock();
 
 	switch (result) {
 	case RESULT_DEFAULT:
@@ -228,6 +232,7 @@ void lwm2m_adv_firmware_set_update_result(uint16_t obj_inst_id, uint8_t result)
 		break;
 	default:
 		LOG_ERR("Unhandled result: %u", result);
+		lwm2m_registry_unlock();
 		return;
 	}
 
@@ -237,6 +242,7 @@ void lwm2m_adv_firmware_set_update_result(uint16_t obj_inst_id, uint8_t result)
 
 	path = LWM2M_OBJ(LWM2M_OBJECT_ADV_FIRMWARE_ID, obj_inst_id, FIRMWARE_UPDATE_RESULT_ID);
 	lwm2m_set_u8(&path, result);
+	lwm2m_registry_unlock();
 
 	LOG_DBG("Update result = %d", result);
 }

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
@@ -373,7 +373,7 @@ static void set_state(uint16_t id, uint8_t state)
 		LOG_WRN("Set state blocked by id, state %d", state);
 		return;
 	}
-
+	lwm2m_registry_lock();
 	if (IS_ENABLED(CONFIG_LWM2M_CLIENT_UTILS_ADV_FIRMWARE_UPDATE_OBJ_SUPPORT)) {
 		lwm2m_adv_firmware_set_update_state(id, state);
 	} else {
@@ -381,6 +381,7 @@ static void set_state(uint16_t id, uint8_t state)
 		lwm2m_firmware_set_update_state_inst(id, state);
 #endif
 	}
+	lwm2m_registry_unlock();
 }
 
 static void set_result(uint16_t id, uint8_t result)
@@ -389,7 +390,7 @@ static void set_result(uint16_t id, uint8_t result)
 		LOG_WRN("Set result blocked by id,  result %d", result);
 		return;
 	}
-
+	lwm2m_registry_lock();
 	if (IS_ENABLED(CONFIG_LWM2M_CLIENT_UTILS_ADV_FIRMWARE_UPDATE_OBJ_SUPPORT)) {
 		lwm2m_adv_firmware_set_update_result(id, result);
 	} else {
@@ -397,6 +398,7 @@ static void set_result(uint16_t id, uint8_t result)
 		lwm2m_firmware_set_update_result_inst(id, result);
 #endif
 	}
+	lwm2m_registry_unlock();
 }
 
 static int firmware_target_prepare(int dfu_image_type)
@@ -605,6 +607,7 @@ static void update_work_handler(struct k_work *work)
 		}
 	}
 
+	lwm2m_registry_lock();
 	if (update_data.type == MODEM_DELTA) {
 		result = apply_firmware_delta_modem_update();
 		if (result == RESULT_SUCCESS) {
@@ -623,6 +626,7 @@ static void update_work_handler(struct k_work *work)
 	}
 
 	firmware_update_check_linked_instances(instance_id);
+	lwm2m_registry_unlock();
 	reboot_work_handler();
 }
 


### PR DESCRIPTION
net: lwm2m: Fix race condition on Firmware object

Fix possible race conditions when state and results are written
by locking the registry, so a first write does not cause Notify message
to be send too early.