### PR TITLE
nrf_security: Check for existence of RNG driver at build time

### DIFF
--- a/subsys/nrf_security/src/psa_crypto_driver_wrappers.c
+++ b/subsys/nrf_security/src/psa_crypto_driver_wrappers.c
@@ -2432,6 +2432,9 @@ psa_status_t psa_driver_wrapper_init_random(psa_driver_random_context_t *context
 	return PSA_SUCCESS;
 }
 
+#if defined(PSA_CRYPTO_DRIVER_ALG_PRNG_TEST) ||	\
+	defined(PSA_CRYPTO_DRIVER_ALG_PRNG_CC3XX_PLATFORM) || \
+	defined(PSA_CRYPTO_DRIVER_ALG_PRNG_OBERON)
 psa_status_t psa_driver_wrapper_get_random(psa_driver_random_context_t *context, uint8_t *output,
 					   size_t output_size)
 {
@@ -2483,6 +2486,7 @@ psa_status_t psa_driver_wrapper_get_random(psa_driver_random_context_t *context,
 	(void)output_size;
 	return PSA_ERROR_NOT_SUPPORTED;
 }
+#endif
 
 psa_status_t psa_driver_wrapper_free_random(psa_driver_random_context_t *context)
 {


### PR DESCRIPTION
Check for existence of an RNG driver at build time.

This moves input validation from runtime to build time.

We take psa_driver_wrapper_get_random functions that just return "not supported" out of the build as this should be detected at build time, not runtime.