### PR TITLE
samples: wifi: Add build support for nrf7001 DK board

### DIFF
--- a/samples/wifi/radio_test/sample.yaml
+++ b/samples/wifi/radio_test/sample.yaml
@@ -9,6 +9,12 @@ tests:
       - nrf7002dk_nrf5340_cpuapp
     platform_allow: nrf7002dk_nrf5340_cpuapp
     tags: ci_build
+  sample.nrf7001.radio_test:
+    build_only: true
+    integration_platforms:
+      - nrf7002dk_nrf7001_nrf5340_cpuapp
+    platform_allow: nrf7002dk_nrf7001_nrf5340_cpuapp
+    tags: ci_build
   sample.nrf7002.radio_test_combo:
     build_only: true
     extra_args: CONFIG_NRF700X_RADIO_TEST_COMBO=y

--- a/samples/wifi/scan/sample.yaml
+++ b/samples/wifi/scan/sample.yaml
@@ -9,6 +9,12 @@ tests:
       - nrf7002dk_nrf5340_cpuapp
     platform_allow: nrf7002dk_nrf5340_cpuapp
     tags: ci_build
+  sample.nrf7001.scan:
+    build_only: true
+    integration_platforms:
+      - nrf7002dk_nrf7001_nrf5340_cpuapp
+    platform_allow: nrf7002dk_nrf7001_nrf5340_cpuapp
+    tags: ci_build
   sample.nrf7002_eks.scan:
     build_only: true
     extra_args: SHIELD=nrf7002ek

--- a/samples/wifi/sta/Kconfig
+++ b/samples/wifi/sta/Kconfig
@@ -49,7 +49,7 @@ config STA_SAMPLE_PASSWORD
 
 config NRF700X_QSPI_ENCRYPTION_KEY
 	string "16 bytes QSPI encryption key, only for testing purposes"
-	depends on BOARD_NRF7002DK_NRF5340_CPUAPP
+	depends on (BOARD_NRF7002DK_NRF5340_CPUAPP || BOARD_NRF7002DK_NRF7001_NRF5340_CPUAPP)
 	help
 	  Specify the QSPI encryption key
 endmenu

--- a/samples/wifi/sta/sample.yaml
+++ b/samples/wifi/sta/sample.yaml
@@ -9,6 +9,12 @@ tests:
       - nrf7002dk_nrf5340_cpuapp
     platform_allow: nrf7002dk_nrf5340_cpuapp
     tags: ci_build
+  sample.nrf7001.sta:
+    build_only: true
+    integration_platforms:
+      - nrf7002dk_nrf7001_nrf5340_cpuapp
+    platform_allow: nrf7002dk_nrf7001_nrf5340_cpuapp
+    tags: ci_build
   sample.nrf7002_eks.sta:
     build_only: true
     extra_args: SHIELD=nrf7002ek


### PR DESCRIPTION
Add change to build scan, sta and radio_test samples for nrf7001 dk board.

Fixes SHEL-1627.