### PR TITLE
partition_manager.py: Fix a bug where 'align' spec was deleted.

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -1061,6 +1061,9 @@ This section provides detailed lists of changes by :ref:`script <scripts>`.
 
   * The size of the span partitions was changed to include the alignment partitions (``EMPTY_x``) appearing between other partitions, but not alignment partitions at the beginning or end of the span partition.
     The size of the span partitions now reflects the memory space taken from the start of the first of its elements to the end of the last, not just the sum of the sizes of the included partitions.
+  * Fixed a bug where the ``align`` spec was deleted.
+    This would happen in cases where two ``placement`` specs were identical.
+    When disambiguating one of them, the ``align`` spec was not preserved.
 
 * :ref:`west_sbom`:
 


### PR DESCRIPTION
This happened in a case where two placement specs were identical. When disambiguating one of them, the alignment spec was not preserved.

Jira: NCSIDB-1032