### PR TITLE
doc: fix numbered steps

### DIFF
--- a/doc/nrf/device_guides/working_with_nrf/nrf91/nrf9160.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf91/nrf9160.rst
@@ -243,7 +243,7 @@ Building and programming on the command line
 
 .. include:: ../../../includes/cmd_build_and_run.txt
 
-#. Program the application:
+6. Program the application:
 
 .. include:: nrf9160.rst
    :start-after: prog_nrf9160_start

--- a/doc/nrf/device_guides/working_with_nrf/nrf91/thingy91.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf91/thingy91.rst
@@ -213,7 +213,7 @@ Building and programming on the command line
 
 .. include:: ../../../includes/cmd_build_and_run.txt
 
-#. Program the application:
+6. Program the application:
 
 .. include:: thingy91.rst
    :start-after: prog_extdebugprobe_start

--- a/doc/nrf/device_guides/working_with_nrf/nrf91/thingy91_gsg.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf91/thingy91_gsg.rst
@@ -484,9 +484,9 @@ Program the nRF9160 SiP application
 
       #. Select the appropriate Asset Tracker v2 firmware file.
 
-      .. note::
+         .. note::
 
-         If you are connecting over NB-IoT and your operator does not support extended Protocol Configuration Options (ePCO), select the file that has legacy Protocol Configuration Options (PCO) mode enabled.
+            If you are connecting over NB-IoT and your operator does not support extended Protocol Configuration Options (ePCO), select the file that has legacy Protocol Configuration Options (PCO) mode enabled.
 
       #. Click :guilabel:`Open`.
       #. Scroll down in the menu on the left to the **DEVICE** section and click :guilabel:`Erase & write`.

--- a/doc/nrf/external_comp/nrf_cloud.rst
+++ b/doc/nrf/external_comp/nrf_cloud.rst
@@ -133,13 +133,13 @@ The |NCS| provides the :ref:`lib_nrf_cloud` library, which if enabled, allows yo
 
 For more information on the various services, see the following documentation:
 
-1. :ref:`lib_nrf_cloud_agps`
-#. :ref:`lib_nrf_cloud_location`
-#. :ref:`lib_nrf_cloud_fota`
-#. :ref:`lib_nrf_cloud_pgps`
-#. :ref:`lib_nrf_cloud_alert`
-#. :ref:`lib_nrf_cloud_log`
-#. :ref:`lib_nrf_cloud_coap`
+* :ref:`lib_nrf_cloud_agps`
+* :ref:`lib_nrf_cloud_location`
+* :ref:`lib_nrf_cloud_fota`
+* :ref:`lib_nrf_cloud_pgps`
+* :ref:`lib_nrf_cloud_alert`
+* :ref:`lib_nrf_cloud_log`
+* :ref:`lib_nrf_cloud_coap`
 
 Applications and samples
 ************************


### PR DESCRIPTION
A couple of numbered steps on pages in the Working with nRF91 Series had incorrect numbering.

Using nRF Cloud with NCS page under Integrations had a list that shouldn't be numbered.