### PR TITLE
Bluetooth: Mesh: Develop/fixing light lc sm conditions

### DIFF
--- a/include/bluetooth/mesh/light_ctrl_srv.h
+++ b/include/bluetooth/mesh/light_ctrl_srv.h
@@ -99,11 +99,18 @@ struct bt_mesh_light_ctrl_srv;
 
 /** Light Lightness Control Server state */
 enum bt_mesh_light_ctrl_srv_state {
-	/** Standby state */
+	/** Standby state, merges the Light LC State Machine states of OFF,
+	 * STANDBY, FADE_STANDBY_AUTO and FADE_STANDBY_MANUAL in the Mesh Model
+	 * Specification section 6.2.5.
+	 */
 	LIGHT_CTRL_STATE_STANDBY,
-	/** On state */
+	/** On state, merges the Light LC State Machine states of FADE_ON and
+	 * RUN in the Mesh Model Specification section 6.2.5.
+	 */
 	LIGHT_CTRL_STATE_ON,
-	/** Prolong state */
+	/** Prolong state, merges the Light LC State Machine states of FADE and
+	 * PROLONG in the Mesh Model Specification section 6.2.5.
+	 */
 	LIGHT_CTRL_STATE_PROLONG,
 
 	/** The number of states. */

--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -999,13 +999,29 @@ static int handle_sensor_status(struct bt_mesh_model *model, struct bt_mesh_msg_
 
 		/* Occupancy sensor */
 
-		/* OCC_MODE must be enabled for the occupancy sensors to be
-		 * able to turn on the light:
-		 */
-		if (srv->state == LIGHT_CTRL_STATE_STANDBY &&
-		    !atomic_test_bit(&srv->flags, FLAG_OCC_MODE) &&
-		    !(atomic_test_bit(&srv->flags, FLAG_TRANSITION) &&
-		      !atomic_test_bit(&srv->flags, FLAG_MANUAL))) {
+		if ((srv->state == LIGHT_CTRL_STATE_STANDBY &&
+			/* According to the Mesh Model Specification section
+			 * 6.2.5.6: When in the specifications STANDBY state,
+			 * and the Auto Occupancy condition is false, the
+			 * Occupancy On event should not be processed.
+			 */
+			((!atomic_test_bit(&srv->flags, FLAG_OCC_MODE) &&
+			  !atomic_test_bit(&srv->flags, FLAG_TRANSITION) &&
+			  !atomic_test_bit(&srv->flags, FLAG_MANUAL))
+			  ||
+			/* According to the Mesh Model Specification section
+			 * 6.2.5.12: When in the specifications FADE STANDBY
+			 * MANUAL state, the Occupancy On event should not be
+			 * processed.
+			 */
+			  (atomic_test_bit(&srv->flags, FLAG_TRANSITION) &&
+			   atomic_test_bit(&srv->flags, FLAG_MANUAL)))) ||
+		    /* According to the Mesh Model Specification section
+		     * 6.2.5.7: When in the specifications FADE ON state, the
+		     * Occupancy On event should not be processed.
+		     */
+		    (srv->state == LIGHT_CTRL_STATE_ON &&
+		     atomic_test_bit(&srv->flags, FLAG_TRANSITION))) {
 			continue;
 		}
 

--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -1622,6 +1622,7 @@ static int light_ctrl_srv_start(struct bt_mesh_model *model)
 
 	switch (srv->lightness->ponoff.on_power_up) {
 	case BT_MESH_ON_POWER_UP_OFF:
+	case BT_MESH_ON_POWER_UP_ON:
 		if (atomic_test_bit(&srv->flags,
 				    FLAG_CTRL_SRV_MANUALLY_ENABLED)) {
 			ctrl_enable(srv);
@@ -1637,17 +1638,6 @@ static int light_ctrl_srv_start(struct bt_mesh_model *model)
 		 * restarts, we'll restore to On even though we were off in the
 		 * previous power cycle, unless we store the Off state here.
 		 */
-		store(srv, FLAG_STORE_STATE);
-		break;
-	case BT_MESH_ON_POWER_UP_ON:
-		if (atomic_test_bit(&srv->flags,
-				    FLAG_CTRL_SRV_MANUALLY_ENABLED)) {
-			ctrl_enable(srv);
-		} else {
-			lightness_on_power_up(srv->lightness);
-			ctrl_disable(srv);
-			schedule_resume_timer(srv);
-		}
 		store(srv, FLAG_STORE_STATE);
 		break;
 	case BT_MESH_ON_POWER_UP_RESTORE:


### PR DESCRIPTION
According to sections 6.2.3.5 of MshMDLd1.1r12, the value of the
Light LC Ambient LuxLevel state is set to 0 at power-up and when
the node is provisioned on the network.
According to sections 6.2.5.12 and 6.2.5.7 the Occupancy On should
not trigger any transition.

Signed-off-by: Ingar Kulbrandstad <ingar.kulbrandstad@nordicsemi.no>