### PR TITLE
samples: Fix incorrect names in yaml

### DIFF
--- a/applications/asset_tracker_v2/sample.yaml
+++ b/applications/asset_tracker_v2/sample.yaml
@@ -204,7 +204,7 @@ tests:
     build_only: true
     integration_platforms:
       - nrf9161dk_nrf9161_ns
-    platform_allow: ns nrf9161dk_nrf9161_ns
+    platform_allow: nrf9161dk_nrf9161_ns
     extra_args: SHIELD=nrf7002ek OVERLAY_CONFIG=overlay-nrf7002ek-wifi-scan-only.conf
                 DTC_OVERLAY_FILE="nrf91xxdk_with_nrf7002ek.overlay;nrf9161dk_with_ext_flash.overlay"
     tags: ci_build

--- a/samples/debug/ppi_trace/sample.yaml
+++ b/samples/debug/ppi_trace/sample.yaml
@@ -7,5 +7,5 @@ tests:
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf9160dk_nrf9160
-    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf9160dk_nrf9160 nrf21540_nrf52840
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf9160dk_nrf9160 nrf21540dk_nrf52840
     tags: ci_build


### PR DESCRIPTION
Fixes typos in platform names in sample.yamls
Those incorrect names causes twister failures.