### PR TITLE
manifest: zephyr: update zephyr wth 802154 multiple cca support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 451c1c4b439597b6f4fa6466cb070a0b15aea641
+      revision: 036274a34fee62c6404e7a428f6c1d48d69a8966
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This PR brings in sdk-zephyr with commits cherry-picked from upstream zephyr containing support for 802.15.4 Multiple CCA feature.

KRKNWK-17306