### PR TITLE
caf: ble_adv: Improve module_state_event broadcast

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -738,6 +738,8 @@ Common Application Framework (CAF)
 * :ref:`caf_ble_adv`:
 
   * Updated the dependencies of the :kconfig:option:`CONFIG_CAF_BLE_ADV_FILTER_ACCEPT_LIST` Kconfig option so that it can be used when the Bluetooth controller is running on the network core.
+  * Improved broadcast of :c:struct:`module_state_event`.
+    The event informing about entering either :c:enum:`MODULE_STATE_READY` or :c:enum:`MODULE_STATE_OFF` is not submitted until the CAF Bluetooth LE advertising module is initialized and ready.
 
 * :ref:`caf_power_manager`:
 

--- a/subsys/caf/modules/ble_adv.c
+++ b/subsys/caf/modules/ble_adv.c
@@ -483,19 +483,26 @@ static void broadcast_module_state(enum state prev_state, enum state new_state)
 	bool submit_ready = false;
 	bool submit_off = false;
 
-	if (is_module_state_off(prev_state) && !is_module_state_off(new_state)) {
-		submit_ready = true;
-	}
+	__ASSERT_NO_MSG(is_module_state_disabled(prev_state) ||
+			!is_module_state_disabled(new_state));
 
-	if (!is_module_state_off(prev_state) && is_module_state_off(new_state)) {
-		submit_off = true;
-	}
+	if (is_module_state_disabled(prev_state)) {
+		if (!is_module_state_disabled(new_state)) {
+			submit_ready = true;
 
-	if (is_module_state_disabled(prev_state) && !is_module_state_disabled(new_state)) {
-		submit_ready = true;
-	}
+			if (is_module_state_off(new_state)) {
+				submit_off = true;
+			}
+		}
+	} else {
+		if (is_module_state_off(prev_state) && !is_module_state_off(new_state)) {
+			submit_ready = true;
+		}
 
-	__ASSERT_NO_MSG(!submit_ready || !submit_off);
+		if (!is_module_state_off(prev_state) && is_module_state_off(new_state)) {
+			submit_off = true;
+		}
+	}
 
 	if (submit_ready) {
 		module_set_state(MODULE_STATE_READY);


### PR DESCRIPTION
Change improves broadcast of module_state_event. This is done to prevent reporting MODULE_STATE_READY before Bluetooth LE advertising module is initialized and ready.

Jira: NCSDK-23082