### PR TITLE
boards: arm: thingy91: Secure boot

### DIFF
--- a/boards/arm/thingy91_nrf9160/CMakeLists.txt
+++ b/boards/arm/thingy91_nrf9160/CMakeLists.txt
@@ -4,19 +4,10 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 
-if(CONFIG_BOARD_THINGY91_NRF9160 AND NOT DEFINED CONFIG_MCUBOOT)
-	zephyr_library()
-	zephyr_library_sources(adp5360_init.c)
-endif()
+zephyr_library()
+zephyr_library_sources_ifdef(CONFIG_ADP536X adp5360_init.c)
 
 if(CONFIG_BOARD_THINGY91_NRF9160_NS)
-	# If TF-M is used, the ADP5360 configuration must be done in non-secure
-	# as we can't instruct TF-M to run it.
-	if(CONFIG_BUILD_WITH_TFM)
-		zephyr_library()
-		zephyr_library_sources(adp5360_init.c)
-	endif()
-
 	# Use static partition layout to ensure the partition layout remains
 	# unchanged after DFU. This needs to be made globally available
 	# because it is used in other CMake files.

--- a/boards/arm/thingy91_nrf9160/CMakeLists.txt
+++ b/boards/arm/thingy91_nrf9160/CMakeLists.txt
@@ -7,15 +7,16 @@
 zephyr_library()
 zephyr_library_sources_ifdef(CONFIG_ADP536X adp5360_init.c)
 
-if(CONFIG_BOARD_THINGY91_NRF9160_NS)
-	# Use static partition layout to ensure the partition layout remains
-	# unchanged after DFU. This needs to be made globally available
-	# because it is used in other CMake files.
-	if(CONFIG_LWM2M_CARRIER)
-		set(PM_STATIC_YML_FILE ${CMAKE_CURRENT_LIST_DIR}/thingy91_pm_static_lwm2m_carrier.yml CACHE INTERNAL "")
-	else()
-		set(PM_STATIC_YML_FILE ${CMAKE_CURRENT_LIST_DIR}/thingy91_pm_static.yml CACHE INTERNAL "")
-	endif()
+if(CONFIG_THINGY91_STATIC_PARTITIONS_FACTORY)
+  set(PM_STATIC_YML_FILE ${CMAKE_CURRENT_LIST_DIR}/thingy91_pm_static.yml CACHE INTERNAL "")
+endif()
+
+if(CONFIG_THINGY91_STATIC_PARTITIONS_SECURE_BOOT)
+  set(PM_STATIC_YML_FILE ${CMAKE_CURRENT_LIST_DIR}/thingy91_pm_static_secure_boot.yml CACHE INTERNAL "")
+endif()
+
+if(CONFIG_THINGY91_STATIC_PARTITIONS_LWM2M_CARRIER)
+  set(PM_STATIC_YML_FILE ${CMAKE_CURRENT_LIST_DIR}/thingy91_pm_static_lwm2m_carrier.yml CACHE INTERNAL "")
 endif()
 
 zephyr_library_sources(nrf52840_reset.c)

--- a/boards/arm/thingy91_nrf9160/Kconfig.board
+++ b/boards/arm/thingy91_nrf9160/Kconfig.board
@@ -12,4 +12,38 @@ config BOARD_THINGY91_NRF9160
 config BOARD_THINGY91_NRF9160_NS
 	bool "nRF9160 THINGY91 non-secure"
 
+if BOARD_THINGY91_NRF9160_NS
+
+choice
+	prompt "Thingy:91 partition layout"
+	default THINGY91_STATIC_PARTITIONS_SECURE_BOOT if SECURE_BOOT
+	default THINGY91_STATIC_PARTITIONS_LWM2M_CARRIER if LWM2M_CARRIER
+	default THINGY91_STATIC_PARTITIONS_FACTORY
+
+config THINGY91_STATIC_PARTITIONS_FACTORY
+	bool "Factory Thingy:91 partition layout"
+	help
+	   The default Thingy:91 partition layout used in the factory firmware. This ensures
+	   firmware updates are compatible with Thingy:91 when flashing firmware over USB or over
+	   the air.
+
+config THINGY91_STATIC_PARTITIONS_SECURE_BOOT
+	bool "Secure boot Thingy:91 partition layout [EXPERIMENTAL]"
+	depends on SECURE_BOOT
+	select EXPERIMENTAL
+	help
+	   Similar to the factory partition layout, but also has space for the Immutable Bootloader
+	   and two MCUboot slots. A debugger is needed to flash Thingy:91 the first time.
+	   This layout is still under development and should not be used in production.
+
+config THINGY91_STATIC_PARTITIONS_LWM2M_CARRIER
+	bool "LWM2M Carrier  partition layout"
+	depends on LWM2M_CARRIER
+	help
+	  Use a partition layout including a storage partition needed for the lwm2m carrier library.
+
+endchoice
+
+endif # BOARD_THINGY91_NRF9160_NS
+
 endif # SOC_NRF9160_SICA

--- a/boards/arm/thingy91_nrf9160/Kconfig.board
+++ b/boards/arm/thingy91_nrf9160/Kconfig.board
@@ -15,7 +15,7 @@ config BOARD_THINGY91_NRF9160_NS
 if BOARD_THINGY91_NRF9160_NS
 
 choice
-	prompt "Thingy:91 partition layout"
+	prompt "Pre-defined Thingy:91 partition layout"
 	default THINGY91_STATIC_PARTITIONS_SECURE_BOOT if SECURE_BOOT
 	default THINGY91_STATIC_PARTITIONS_LWM2M_CARRIER if LWM2M_CARRIER
 	default THINGY91_STATIC_PARTITIONS_FACTORY
@@ -41,6 +41,14 @@ config THINGY91_STATIC_PARTITIONS_LWM2M_CARRIER
 	depends on LWM2M_CARRIER
 	help
 	  Use a partition layout including a storage partition needed for the lwm2m carrier library.
+
+config THINGY91_NO_PREDEFINED_LAYOUT
+	bool "None [EXPERIMENTAL]"
+	select EXPERIMENTAL
+	help
+	   Disable pre-defined static partition layout. This allows the application to use a dynamic
+	   layout or define a custom static partition layout for the application. A debugger is
+	   needed to flash Thingy:91 with a different partition layout.
 
 endchoice
 

--- a/boards/arm/thingy91_nrf9160/Kconfig.defconfig
+++ b/boards/arm/thingy91_nrf9160/Kconfig.defconfig
@@ -9,8 +9,10 @@ if BOARD_THINGY91_NRF9160 || BOARD_THINGY91_NRF9160_NS
 config BOARD
 	default "thingy91_nrf9160"
 
+# Enable Zephyr power regulator ADP536x
 config REGULATOR
-	default y if !MCUBOOT
+	default y
+	depends on !IS_BOOTLOADER_IMG
 
 # By default, if we build for a Non-Secure version of the board,
 # enable building with TF-M as the Secure Execution Environment.

--- a/boards/arm/thingy91_nrf9160/thingy91_nrf9160_defconfig
+++ b/boards/arm/thingy91_nrf9160/thingy91_nrf9160_defconfig
@@ -21,11 +21,5 @@ CONFIG_SERIAL=y
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y
 
-# Enable I2C
-CONFIG_I2C=y
-
-# Enable power management IC ADP536x
-CONFIG_ADP536X=y
-
 # Disable entropy driver, as it's not yet implemented for nRF9160
 CONFIG_ENTROPY_NRF5_RNG=n

--- a/boards/arm/thingy91_nrf9160/thingy91_nrf9160_ns_defconfig
+++ b/boards/arm/thingy91_nrf9160/thingy91_nrf9160_ns_defconfig
@@ -24,14 +24,8 @@ CONFIG_SERIAL=y
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y
 
-# Enable I2C
-CONFIG_I2C=y
-
 # Enable SPI
 CONFIG_SPI=y
-
-# Enable power management IC ADP536x
-CONFIG_ADP536X=y
 
 # Disable entropy driver, as it's not yet implemented for nRF9160
 CONFIG_ENTROPY_NRF5_RNG=n

--- a/boards/arm/thingy91_nrf9160/thingy91_pm_static_secure_boot.yml
+++ b/boards/arm/thingy91_nrf9160/thingy91_pm_static_secure_boot.yml
@@ -1,0 +1,76 @@
+b0_container:
+  address: 0x0
+  size: 0x8000
+  span: [b0]
+b0:
+  address: 0x0
+  size: 0x8000
+
+s0:
+  address: 0x8000
+  size: 0x10000
+  span: [s0_pad, mcuboot]
+s0_pad:
+  address: 0x8000
+  size: 0x200
+s0_image:
+  address: 0x8200
+  size: 0xfe00
+  span: [mcuboot]
+mcuboot:
+  address: 0x8200
+  size: 0xfe00
+
+s1:
+  address: 0x18000
+  size: 0x10000
+  span: [s1_pad, s1_image]
+s1_pad:
+  address: 0x18000
+  size: 0x200
+s1_image:
+  address: 0x18200
+  size: 0xfe00
+
+mcuboot_primary:
+  address: 0x28000
+  size: 0x68000
+  span: [mcuboot_pad, tfm, app]
+tfm_secure:
+  address: 0x28000
+  size: 0x8000
+  span: [mcuboot_pad, tfm]
+mcuboot_pad:
+  address: 0x28000
+  size: 0x200
+tfm:
+  address: 0x28200
+  size: 0x7e00
+app_image:
+  address: 0x28200
+  size: 0x67e00
+  span: [tfm, app]
+mcuboot_primary_app:
+  address: 0x28200
+  size: 0x67e00
+  span: [app, tfm]
+
+tfm_nonsecure:
+  address: 0x30000
+  size: 0x60000
+  span: [app]
+
+mcuboot_secondary:
+  address: 0x90000
+  size: 0x68000
+
+nonsecure_storage:
+  address: 0xf8000
+  size: 0x2000
+  span: [settings_storage]
+settings_storage:
+  address: 0xf8000
+  size: 0x2000
+EMPTY_0:
+  address: 0xfa000
+  size: 0x6000

--- a/doc/nrf/device_guides/working_with_nrf/nrf91/thingy91.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf91/thingy91.rst
@@ -634,3 +634,24 @@ Building and programming on the command line
           west flash
 
       The device resets and runs the programmed sample or application.
+
+.. _thingy91_partition_layout:
+
+Partition layout
+================
+
+When building firmware on the Thingy:91 board, a static partition layout matching the factory layout is used.
+This ensures that programming firmware through USB works.
+In this case, the MCUboot bootloader will not be updated.
+So, to maintain compatibility, it is important that the image partitions do not get moved.
+When programming the Thingy:91 through an external debug probe, all partitions, including MCUboot, are programmed.
+This enables the possibility of using an updated bootloader or defining an application-specific partition layout.
+
+Configure the partition layout using one of the following configuration options:
+
+* :kconfig:option:`CONFIG_THINGY91_STATIC_PARTITIONS_FACTORY` - This option is the default Thingy:91 partition layout used in the factory firmware.
+  This ensures firmware updates are compatible with Thingy:91 when programming firmware through USB.
+* :kconfig:option:`CONFIG_THINGY91_STATIC_PARTITIONS_SECURE_BOOT` - This option is similar to the factory partition layout, but also has space for the immutable bootloader and two MCUboot slots.
+  A debugger is needed to program Thingy:91 for the first time.
+  This is an :ref:`experimental <software_maturity>` feature.
+* :kconfig:option:`CONFIG_THINGY91_STATIC_PARTITIONS_LWM2M_CARRIER` - This option uses a partition layout, including a storage partition needed for the :ref:`liblwm2m_carrier_readme` library.

--- a/doc/nrf/device_guides/working_with_nrf/nrf91/thingy91.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf91/thingy91.rst
@@ -655,3 +655,7 @@ Configure the partition layout using one of the following configuration options:
   A debugger is needed to program Thingy:91 for the first time.
   This is an :ref:`experimental <software_maturity>` feature.
 * :kconfig:option:`CONFIG_THINGY91_STATIC_PARTITIONS_LWM2M_CARRIER` - This option uses a partition layout, including a storage partition needed for the :ref:`liblwm2m_carrier_readme` library.
+* :kconfig:option:`CONFIG_THINGY91_NO_PREDEFINED_LAYOUT` - Enabling this option disables Thingy:91 pre-defined static partitions.
+  This allows the application to use a dynamic layout or define a custom static partition layout for the application.
+  A debugger is needed to program Thingy:91 for the first time.
+  This is an :ref:`experimental <software_maturity>` feature.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -53,7 +53,8 @@ nRF Front-End Modules
 Working with nRF91 Series
 =========================
 
-|no_changes_yet_note|
+* Added new partition layout configuration options for Thingy:91.
+  See :ref:`thingy91_partition_layout` for more details.
 
 Working with nRF52 Series
 =========================

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -555,7 +555,9 @@ nRF Security
 Other libraries
 ---------------
 
-|no_changes_yet_note|
+* :ref:`lib_adp536x` library:
+
+  * Fixed issue where the adp536x driver was included in the immutable bootloader on Thingy:91 when :kconfig:option:`CONFIG_SECURE_BOOT` was enabled.
 
 Common Application Framework (CAF)
 ----------------------------------

--- a/lib/adp536x/Kconfig
+++ b/lib/adp536x/Kconfig
@@ -7,5 +7,9 @@
 
 config ADP536X
 	bool "ADP536x"
+	default y
+	depends on !IS_BOOTLOADER_IMG
+	depends on DT_HAS_ADI_ADP5360_ENABLED
+	select I2C
 	help
 	  Enable ADP536x

--- a/subsys/bootloader/Kconfig
+++ b/subsys/bootloader/Kconfig
@@ -238,6 +238,13 @@ config SB_BPROT_IN_DEBUG
 endif # SECURE_BOOT_DEBUG
 endif # IS_SECURE_BOOTLOADER
 
+config IS_BOOTLOADER_IMG
+	bool
+	default y if IS_SECURE_BOOTLOADER || MCUBOOT
+	help
+	  Helper symbol which is set when the current image is a bootloader. This includes mcuboot
+	  and the secure bootloader.
+
 config NRF53_UPGRADE_NETWORK_CORE
 	bool "Support updating nRF53 Network Core application"
 	default y


### PR DESCRIPTION
This PR fixes some problems that appears when trying to build for thingy:91 with `CONFIG_SECURE_BOOT` enabled:
- ADP536X needed to be excluded from the secure bootloader. Created a new kconfig symbol `IS_BOOTLOADER` to make it easier to check for both mcuboot and the secure bootloader at the same time.
- The thingy:91 board CMakeLists.txt enforced a static partition layout that did not include partitions for the secure bootloader and an extra slot for updating mcuboot. Added new kconfig options to allow the user to select what partition layout to use.
- Not directly related, but also added a kconfig option (`CONFIG_THINGY91_PARTITION_MANAGER`) to not inject a thingy:91 board static configuration for those that want to use dynamic or an application specific static partition layout.

This does not solve every problem for using secure boot on thingy:91, but is a couple of steps in the right direction. Further steps are needed to get it working properly, but I want to reduce the scope of this PR and delegate some of the remaining work to other teams. Marked the new partitions layouts as experimental to make it clear that this is not production ready and under development, as described in [software maturity levels](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/releases_and_maturity/software_maturity.html#software-maturity-levels).

Known issues:
- After updating mcuboot using nRF Programmer, the boot process halts after the immutable bootloader.
- Compiling with `CONFIG_THINGY91_PARTITION_MANAGER=y` and `CONFIG_SECURE_BOOT=n` will fail because the dynamic `app` partition is not aligned according to SPU flash region size.

CIA-604