### PR TITLE
doc: Bluetooth: Mesh: Move SW maturity up to protocol

### DIFF
--- a/doc/_scripts/software_maturity/software_maturity_features.yaml
+++ b/doc/_scripts/software_maturity/software_maturity_features.yaml
@@ -1,5 +1,6 @@
 top_table:
   Bluetooth: BT_CTLR
+  Bluetooth mesh: BT_MESH
   Zigbee: ZIGBEE
   Thread: NET_L2_OPENTHREAD
   LTE: LTE_LINK_CONTROL
@@ -19,7 +20,6 @@ features:
     Bluetooth LE Peripheral/Central: BT_CTLR && (BT_CENTRAL || BT_PERIPHERAL)
     LLPM: BT_CTLR_SDC_LLPM
     LE Coded PHY: BT_CTLR_PHY_CODED_SUPPORT
-    Bluetooth Mesh: BT_MESH
     Connectionless/Connected CTE Transmitter: BT_CTLR_DF_CTE_TX_SUPPORT
   zigbee:
     Zigbee (Sleepy) End Device: ZIGBEE_ROLE_END_DEVICE


### PR DESCRIPTION
The Bluetooth mesh is now put as a feature under Bluetooth, but should be a seperate section under protocol to be more visible. Move the Bluetooth mesh software maturity to the protocol table.