### PR TITLE
nrf_security:  User-supplied entropy for test

### DIFF
--- a/subsys/nrf_security/Kconfig.psa
+++ b/subsys/nrf_security/Kconfig.psa
@@ -94,6 +94,12 @@ config PSA_CRYPTO_DRIVER_ALG_PRNG_TEST
 	  Internal option used for testing. User provided function will be called
 	  to get random bytes.
 
+config PSA_CRYPTO_DRIVER_ENTROPY_TEST
+	bool
+	help
+	  Internal option used for testing. User provided function will be called
+	  to get entropy bytes.
+
 menuconfig PSA_NATIVE_ITS
 	bool "PSA native Internal Trusted Storage"
 	depends on MBEDTLS_PSA_CRYPTO_STORAGE_C

--- a/subsys/nrf_security/cmake/psa_crypto_config.cmake
+++ b/subsys/nrf_security/cmake/psa_crypto_config.cmake
@@ -191,6 +191,7 @@ kconfig_check_and_set_base_to_one(PSA_NATIVE_ITS)
 kconfig_check_and_set_base_to_one(PSA_EITS_BACKEND_ZEPHYR)
 kconfig_check_and_set_base_to_one(PSA_CRYPTO_SECURE)
 kconfig_check_and_set_base_to_one(PSA_CRYPTO_DRIVER_ALG_PRNG_TEST)
+kconfig_check_and_set_base_to_one(PSA_CRYPTO_DRIVER_ENTROPY_TEST)
 
 # PSA and Drivers
 kconfig_check_and_set_base_to_one(MBEDTLS_PSA_CRYPTO_C)

--- a/subsys/nrf_security/configs/psa_crypto_config.h.template
+++ b/subsys/nrf_security/configs/psa_crypto_config.h.template
@@ -228,6 +228,7 @@
 #cmakedefine PSA_EITS_BACKEND_ZEPHYR                            @PSA_EITS_BACKEND_ZEPHYR@
 #cmakedefine PSA_CRYPTO_SECURE                                  @PSA_CRYPTO_SECURE@
 #cmakedefine PSA_CRYPTO_DRIVER_ALG_PRNG_TEST                    @PSA_CRYPTO_DRIVER_ALG_PRNG_TEST@
+#cmakedefine PSA_CRYPTO_DRIVER_ENTROPY_TEST                     @PSA_CRYPTO_DRIVER_ENTROPY_TEST@
 
 /* PSA and drivers */
 #cmakedefine MBEDTLS_PSA_CRYPTO_C

--- a/subsys/nrf_security/src/drivers/nrf_cc3xx_platform/Kconfig
+++ b/subsys/nrf_security/src/drivers/nrf_cc3xx_platform/Kconfig
@@ -5,7 +5,7 @@
 #
 
 config PSA_CRYPTO_DRIVER_ALG_PRNG_CC3XX_PLATFORM
-	bool
+	bool ""
 	default y
 	depends on CRYPTOCELL_USABLE
 	depends on PSA_WANT_GENERATE_RANDOM

--- a/subsys/nrf_security/src/psa_crypto_driver_wrappers.c
+++ b/subsys/nrf_security/src/psa_crypto_driver_wrappers.c
@@ -140,6 +140,11 @@
 psa_status_t prng_test_generate_random(uint8_t *output, size_t output_size);
 #endif
 
+#if defined(PSA_CRYPTO_DRIVER_ENTROPY_TEST)
+psa_status_t test_get_entropy(uint32_t flags, size_t *estimate_bits, uint8_t *output,
+					    size_t output_size);
+#endif
+
 psa_status_t psa_driver_wrapper_init(void)
 {
 	return PSA_SUCCESS;
@@ -2508,15 +2513,22 @@ psa_status_t psa_driver_wrapper_free_random(psa_driver_random_context_t *context
 psa_status_t psa_driver_wrapper_get_entropy(uint32_t flags, size_t *estimate_bits, uint8_t *output,
 					    size_t output_size)
 {
+	psa_status_t status;
+#if defined(PSA_CRYPTO_DRIVER_ENTROPY_TEST)
+	status = test_get_entropy(flags, estimate_bits, output, output_size);
+	if (status != PSA_ERROR_NOT_SUPPORTED) {
+		return status;
+	}
+#endif
 #if defined(PSA_CRYPTO_DRIVER_ENTROPY_ZEPHYR)
-	return zephyr_get_entropy(flags, estimate_bits, output, output_size);
+	status = zephyr_get_entropy(flags, estimate_bits, output, output_size);
 #endif
 
 	(void)flags;
 	(void)output;
 	(void)output_size;
 	*estimate_bits = 0;
-	return PSA_ERROR_INSUFFICIENT_ENTROPY;
+	return status;
 }
 
 #endif /* MBEDTLS_PSA_CRYPTO_C */


### PR DESCRIPTION
Allow test application to provide entropy.

Signed-off--by: Stephen Kingston <stephen.kingston@nordicsemi.no>