### PR TITLE
Fix for the nRF RPC entropy sample

### DIFF
--- a/samples/nrf_rpc/entropy_nrf53/cpuapp/src/entropy_ser.c
+++ b/samples/nrf_rpc/entropy_nrf53/cpuapp/src/entropy_ser.c
@@ -236,6 +236,7 @@ static void entropy_get_result_handler(const struct nrf_rpc_group *group,
 	}
 
 	memcpy(buf, zst.value, zst.len);
+	length = zst.len;
 
 	nrf_rpc_cbor_decoding_done(group, ctx);
 

--- a/samples/nrf_rpc/entropy_nrf53/cpuapp/src/main.c
+++ b/samples/nrf_rpc/entropy_nrf53/cpuapp/src/main.c
@@ -14,20 +14,23 @@
 
 static uint8_t buffer[BUFFER_LENGTH];
 
+static void entropy_print(const uint8_t *buffer, size_t length)
+{
+	for (size_t i = 0; i < length; i++) {
+		printk("  0x%02x", buffer[i]);
+	}
+
+	printk("\n");
+}
+
 static void result_callback(int result, uint8_t *buffer, size_t length)
 {
-	size_t i;
-
 	if (result) {
 		printk("Entropy remote get failed: %d\n", result);
 		return;
 	}
 
-	for (i = 0; i < length; i++) {
-		printk("  0x%02x", buffer[i]);
-	}
-
-	printk("\n");
+	entropy_print(buffer, length);
 }
 
 int main(void)
@@ -53,11 +56,7 @@ int main(void)
 			continue;
 		}
 
-		for (int i = 0; i < BUFFER_LENGTH; i++) {
-			printk("  0x%02x", buffer[i]);
-		}
-
-		printk("\n");
+		entropy_print(buffer, ARRAY_SIZE(buffer));
 
 		k_sleep(K_MSEC(2000));
 
@@ -67,11 +66,7 @@ int main(void)
 			continue;
 		}
 
-		for (int i = 0; i < BUFFER_LENGTH; i++) {
-			printk("  0x%02x", buffer[i]);
-		}
-
-		printk("\n");
+		entropy_print(buffer, ARRAY_SIZE(buffer));
 
 		k_sleep(K_MSEC(2000));
 

--- a/samples/nrf_rpc/entropy_nrf53/cpunet/src/entropy_ser.c
+++ b/samples/nrf_rpc/entropy_nrf53/cpunet/src/entropy_ser.c
@@ -28,6 +28,15 @@ NRF_RPC_GROUP_DEFINE(entropy_group, "nrf_sample_entropy", &entropy_group_tr, NUL
 
 static const struct device *entropy = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
 
+static void entropy_print(const uint8_t *buffer, size_t length)
+{
+	for (size_t i = 0; i < length; i++) {
+		printk("  0x%02x", buffer[i]);
+	}
+
+	printk("\n");
+}
+
 static void rsp_error_code_send(const struct nrf_rpc_group *group, int err_code)
 {
 	struct nrf_rpc_cbor_ctx ctx;
@@ -117,6 +126,9 @@ static void entropy_get_handler(const struct nrf_rpc_group *group, struct nrf_rp
 	}
 
 	err = entropy_get_entropy(entropy, buf, length);
+	if (!err) {
+		entropy_print(buf, length);
+	}
 
 	switch (type) {
 	case CALL_TYPE_STANDARD:


### PR DESCRIPTION
This fixes nRF RPC entropy sample on nRF53.