### PR TITLE
net: lib: aws_fota: Determine protocol from job document

### DIFF
--- a/doc/nrf/libraries/networking/aws_fota.rst
+++ b/doc/nrf/libraries/networking/aws_fota.rst
@@ -7,14 +7,14 @@ AWS FOTA
    :local:
    :depth: 2
 
-The Amazon Web Services firmware over-the-air (AWS FOTA) library combines the :ref:`lib_aws_jobs` and :ref:`lib_fota_download` libraries into a library that can perform an over-the-air firmware update using HTTP and MQTT TLS.
+The Amazon Web Services firmware over-the-air (AWS FOTA) library combines the :ref:`lib_aws_jobs` and :ref:`lib_fota_download` libraries into a library that can perform an over-the-air firmware update using HTTP and HTTPS.
 
 It connects to the specified broker using the existing or given certificates and uses `TLS`_ for the MQTT connection.
 This means that the data sent in each MQTT message is encrypted.
 
 When an update is available, the library receives a notification that contains metadata about the update.
 This metadata contains the location of the uploaded firmware image.
-The library then uses HTTP to download the firmware image, replacing the current firmware with the downloaded firmware.
+The library then uses HTTP or HTTPS to download the firmware image, replacing the current firmware with the downloaded firmware.
 After the new firmware image is downloaded, the application must perform a reboot to run the new image and complete the FOTA process.
 The library supports the updating of delta images for both the application and modem firmware.
 
@@ -65,6 +65,7 @@ Creating a FOTA job
 #. Click the uploaded image file :file:`app_update.bin` and copy the *Object URL* without the *https://* prefix and folder path.
 #. Create a text file (job document) with content as in the snippet, replacing the following data:
 
+     * *protocol* with either `http` or `https`.
      * *host_url* with the *Object URL* copied in the previous step (for example, ``examplebucket.s3.eu-central-1.amazonaws.com``).
      * *file_path* with the path and file name (for example, ``app_update.bin``).
 
@@ -76,7 +77,7 @@ Creating a FOTA job
         "fwversion": "v1.0.2",
         "size": 181124,
         "location": {
-          "protocol": "http:",
+          "protocol": "*protocol*",
           "host": "*host_url*",
           "path": "*file_path*"
          }
@@ -148,7 +149,7 @@ The following sequence diagram shows how a firmware over-the-air update is imple
 AWS IoT jobs
 ============
 
-The implementation uses a job document like the following (where *bucket_name* is the name of your bucket and *file_name* is the name of your file) for passing information from `AWS IoT jobs`_ to the device:
+The implementation uses a job document like the following (where *protocol* is either `http` or `https`, *bucket_name* is the name of your bucket and *file_name* is the name of your file) for passing information from `AWS IoT jobs`_ to the device:
 
 .. parsed-literal::
    :class: highlight
@@ -158,7 +159,7 @@ The implementation uses a job document like the following (where *bucket_name* i
      "fwversion": "v1.0.2",
      "size": 181124,
      "location": {
-       "protocol": "http:",
+       "protocol": "*protocol*",
        "host": "*bucket_name*.amazonaws.com",
        "path": "*file_name*.bin"
       }
@@ -183,8 +184,8 @@ For information on how to use presigned AWS S3 URLs, refer to `AWS IoT Developer
 Limitations
 ***********
 
-* The current implementation ignores the value specified in the ``protocol`` field and uses HTTP by default.
-  To use HTTPS instead, apply the changes described in :ref:`the HTTPS section of the download client documentation <download_client_https>` to the :ref:`lib_fota_download` library.
+* If the :kconfig:option:`CONFIG_AWS_FOTA_DOWNLOAD_SECURITY_TAG` Kconfig option is not configured but HTTPS is selected as the protocol, the update job fails.
+  For further information about HTTPS support, refer to :ref:`the HTTPS section of the download client documentation <download_client_https>`.
 * The library requires a Content-Range header to be present in the HTTP response from the server.
   This limitation is inherited from the :ref:`lib_download_client` library.
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -656,6 +656,7 @@ Libraries for networking
     * The :kconfig:option:`CONFIG_AWS_FOTA_HOSTNAME_MAX_LEN` Kconfig option has been replaced by the :kconfig:option:`CONFIG_DOWNLOAD_CLIENT_MAX_HOSTNAME_SIZE` Kconfig option.
     * The :kconfig:option:`CONFIG_AWS_FOTA_FILE_PATH_MAX_LEN` Kconfig option has been replaced by the :kconfig:option:`CONFIG_DOWNLOAD_CLIENT_MAX_FILENAME_SIZE` Kconfig option.
     * AWS FOTA jobs are now marked as failed if the job document for the update is invalid.
+    * The protocol (HTTP or HTTPS) is now automatically chosen based on the `protocol` or `url` fields in the job document for the update.
 
 * :ref:`lib_azure_fota` library:
 

--- a/subsys/net/lib/aws_fota/include/aws_fota_json.h
+++ b/subsys/net/lib/aws_fota/include/aws_fota_json.h
@@ -62,6 +62,8 @@ enum aws_fota_json_result {
  * @param[out] file_path_buf  Output buffer for the "file" field from the Job
  *			      Document
  * @param[in] file_path_buf_size  Size of the output buffer for the "file" field
+ * @param[out] protocol_buf  Output buffer for the "protocol" field from the Job Document
+ * @param[in] protocol_buf_size  Size of the output buffer for the "protocol" field
  * @param[out] version_number  Version number from the Job Execution data type.
  *
  * @return aws_fota_json_result specifying the result of the parse operation.
@@ -73,6 +75,8 @@ int aws_fota_parse_DescribeJobExecution_rsp(const char *job_document,
 					    size_t hostname_buf_size,
 					    char *file_path_buf,
 					    size_t file_path_buf_size,
+					    char *protocol_buf,
+					    size_t protocol_buf_size,
 					    int *version_number);
 
 /**

--- a/tests/subsys/net/lib/aws_fota/aws_fota_json/src/main.c
+++ b/tests/subsys/net/lib/aws_fota/aws_fota_json/src/main.c
@@ -21,10 +21,12 @@ void test_parse_job_execution(void)
 	int version_number;
 	int expected_version_number = 1;
 	char expected_job_id[] = "9b5caac6-3e8a-45dd-9273-c1b995762f4a";
+	char expected_protocol[] = "https:";
 	char expected_hostname[] = "fota-update-bucket.s3.eu-central-1.amazonaws.com";
 	char expected_file_path[] = "/update.bin?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAWXEL53DXIU7W72AE%2F20190606%2Feu-central-1%2Fs3%2Faws4_request&X-Amz-Date=20190606T081505Z&X-Amz-Expires=604800&X-Amz-Signature=913e00b97efe5565a901df4ff0b87e4878a406941d711f59d45915035989adcc&X-Amz-SignedHeaders=host";
 	char encoded[] = "{\"timestamp\":1559808907,\"execution\":{\"jobId\":\"9b5caac6-3e8a-45dd-9273-c1b995762f4a\",\"status\":\"QUEUED\",\"queuedAt\":1559808906,\"lastUpdatedAt\":1559808906,\"versionNumber\":1,\"executionNumber\":1,\"jobDocument\":{\"operation\":\"app_fw_update\",\"fwversion\":\"2\",\"size\":181124,\"location\":{\"protocol\":\"https:\",\"host\":\"fota-update-bucket.s3.eu-central-1.amazonaws.com\",\"path\":\"/update.bin?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAWXEL53DXIU7W72AE%2F20190606%2Feu-central-1%2Fs3%2Faws4_request&X-Amz-Date=20190606T081505Z&X-Amz-Expires=604800&X-Amz-Signature=913e00b97efe5565a901df4ff0b87e4878a406941d711f59d45915035989adcc&X-Amz-SignedHeaders=host\"}}}}";
 	char job_id[100];
+	char protocol[10];
 	char hostname[100];
 	char file_path[1000];
 
@@ -33,10 +35,12 @@ void test_parse_job_execution(void)
 						      job_id,
 						      hostname, sizeof(hostname),
 						      file_path, sizeof(file_path),
+						      protocol, sizeof(protocol),
 						      &version_number);
 	TEST_ASSERT_EQUAL(AWS_FOTA_JSON_RES_SUCCESS, ret);
 	TEST_ASSERT_EQUAL_STRING(expected_job_id, job_id);
 	TEST_ASSERT_EQUAL(expected_version_number, version_number);
+	TEST_ASSERT_EQUAL_STRING(expected_protocol, protocol);
 	TEST_ASSERT_EQUAL_STRING(expected_hostname, hostname);
 	TEST_ASSERT_EQUAL_STRING(expected_file_path, file_path);
 }
@@ -47,6 +51,7 @@ void test_parse_job_execution_single_url(void)
 	int version_number;
 	int expected_version_number = 1;
 	char expected_job_id[] = "9b5caac6-3e8a-45dd-9273-c1b995762f4a";
+	char expected_protocol[] = "https";
 	char expected_hostname[] = "fota-update-bucket.s3.eu-central-1.amazonaws.com";
 	char expected_file_path[] = "update.bin?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential="
 								"AKIAWXEL53DXIU7W72AE%2F20190606%2Feu-central-1%2Fs3%2Faws4_request"
@@ -67,6 +72,7 @@ void test_parse_job_execution_single_url(void)
 					 "913e00b97efe5565a901df4ff0b87e4878a406941d711f59d45915035989adcc"
 					 "&X-Amz-SignedHeaders=host\"}}}}";
 	char job_id[100];
+	char protocol[10];
 	char hostname[100];
 	char file_path[1000];
 
@@ -75,10 +81,12 @@ void test_parse_job_execution_single_url(void)
 						      job_id,
 						      hostname, sizeof(hostname),
 						      file_path, sizeof(file_path),
+						      protocol, sizeof(protocol),
 						      &version_number);
 	TEST_ASSERT_EQUAL(AWS_FOTA_JSON_RES_SUCCESS, ret);
 	TEST_ASSERT_EQUAL_STRING(expected_job_id, job_id);
 	TEST_ASSERT_EQUAL(expected_version_number, version_number);
+	TEST_ASSERT_EQUAL_STRING(expected_protocol, protocol);
 	TEST_ASSERT_EQUAL_STRING(expected_hostname, hostname);
 	TEST_ASSERT_EQUAL_STRING(expected_file_path, file_path);
 }
@@ -87,6 +95,7 @@ void test_parse_malformed_job_execution(void)
 {
 	int ret;
 	char job_id[100];
+	char protocol[5];
 	char hostname[100];
 	char file_path[1000];
 	int version_number;
@@ -97,6 +106,7 @@ void test_parse_malformed_job_execution(void)
 						      job_id,
 						      hostname, sizeof(hostname),
 						      file_path, sizeof(file_path),
+						      protocol, sizeof(protocol),
 						      &version_number);
 	TEST_ASSERT_EQUAL(AWS_FOTA_JSON_RES_INVALID_JOB, ret);
 }
@@ -106,6 +116,7 @@ void test_parse_job_execution_missing_host_field(void)
 	int ret;
 	int version_number;
 	char job_id[100];
+	char protocol[5];
 	char hostname[100];
 	char file_path[1000];
 
@@ -116,6 +127,7 @@ void test_parse_job_execution_missing_host_field(void)
 						      job_id,
 						      hostname, sizeof(hostname),
 						      file_path, sizeof(file_path),
+						      protocol, sizeof(protocol),
 						      &version_number);
 	TEST_ASSERT_EQUAL(AWS_FOTA_JSON_RES_INVALID_DOCUMENT, ret);
 }
@@ -125,6 +137,7 @@ void test_parse_job_execution_missing_path_field(void)
 	int ret;
 	int version_number;
 	char job_id[100];
+	char protocol[5];
 	char hostname[100];
 	char file_path[1000];
 	char encoded[] = "{\"timestamp\":1559808907,\"execution\":{\"jobId\":\"9b5caac6-3e8a-45dd-9273-c1b995762f4a\",\"status\":\"QUEUED\",\"queuedAt\":1559808906,\"lastUpdatedAt\":1559808906,\"versionNumber\":1,\"executionNumber\":1,\"jobDocument\":{\"operation\":\"app_fw_update\",\"fwversion\":\"2\",\"size\":181124,\"location\":{\"protocol\":\"https:\",\"host\":\"fota-update-bucket.s3.eu-central-1.amazonaws.com\"}}}}";
@@ -134,6 +147,7 @@ void test_parse_job_execution_missing_path_field(void)
 						      job_id,
 						      hostname, sizeof(hostname),
 						      file_path, sizeof(file_path),
+						      protocol, sizeof(protocol),
 						      &version_number);
 	TEST_ASSERT_EQUAL(AWS_FOTA_JSON_RES_INVALID_DOCUMENT, ret);
 }
@@ -143,6 +157,7 @@ void test_parse_job_execution_missing_job_id_field(void)
 	int ret;
 	int version_number;
 	char job_id[100];
+	char protocol[5];
 	char hostname[100];
 	char file_path[1000];
 	char encoded[] = "{\"timestamp\":1559808907,\"execution\":{\"status\":\"QUEUED\",\"queuedAt\":1559808906,\"lastUpdatedAt\":1559808906,\"versionNumber\":1,\"executionNumber\":1,\"jobDocument\":{\"operation\":\"app_fw_update\",\"fwversion\":\"2\",\"size\":181124,\"location\":{\"protocol\":\"https:\",\"host\":\"fota-update-bucket.s3.eu-central-1.amazonaws.com\",\"path\":\"/update.bin?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAWXEL53DXIU7W72AE%2F20190606%2Feu-central-1%2Fs3%2Faws4_request&X-Amz-Date=20190606T081505Z&X-Amz-Expires=604800&X-Amz-Signature=913e00b97efe5565a901df4ff0b87e4878a406941d711f59d45915035989adcc&X-Amz-SignedHeaders=host\"}}}}";
@@ -152,6 +167,7 @@ void test_parse_job_execution_missing_job_id_field(void)
 						      job_id,
 						      hostname, sizeof(hostname),
 						      file_path, sizeof(file_path),
+						      protocol, sizeof(protocol),
 						      &version_number);
 	TEST_ASSERT_EQUAL(AWS_FOTA_JSON_RES_INVALID_JOB, ret);
 }
@@ -161,6 +177,7 @@ void test_parse_job_execution_missing_location_obj(void)
 	int ret;
 	int version_number;
 	char job_id[100];
+	char protocol[5];
 	char hostname[100];
 	char file_path[1000];
 	char encoded[] = "{\"timestamp\":1559808907,\"execution\":{\"jobId\":\"9b5caac6-3e8a-45dd-9273-c1b995762f4a\",\"status\":\"QUEUED\",\"queuedAt\":1559808906,\"lastUpdatedAt\":1559808906,\"versionNumber\":1,\"executionNumber\":1,\"jobDocument\":{\"operation\":\"app_fw_update\",\"fwversion\":\"2\",\"size\":181124}}}}";
@@ -170,6 +187,7 @@ void test_parse_job_execution_missing_location_obj(void)
 						      job_id,
 						      hostname, sizeof(hostname),
 						      file_path, sizeof(file_path),
+						      protocol, sizeof(protocol),
 						      &version_number);
 	TEST_ASSERT_EQUAL(AWS_FOTA_JSON_RES_INVALID_DOCUMENT, ret);
 }
@@ -195,6 +213,7 @@ void test_timestamp_only(void)
 {
 	int ret;
 	char job_id[100];
+	char protocol[5];
 	char hostname[100];
 	char file_path[100];
 	char encoded[] = "{\"timestamp\":1559808907}";
@@ -205,6 +224,7 @@ void test_timestamp_only(void)
 						      job_id,
 						      hostname, sizeof(hostname),
 						      file_path, sizeof(file_path),
+						      protocol, sizeof(protocol),
 						      &version_number);
 	TEST_ASSERT_EQUAL(AWS_FOTA_JSON_RES_SKIPPED, ret);
 }


### PR DESCRIPTION
For FOTA downloads using the aws_fota library, the protocol is now determined from the job document (protocol field or url). If no security tag is configured and the protocol is set to https, the job is marked as failed.