### PR TITLE
bluetooth: controller: kconfig: Add periodic adv event length kconfig

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -138,6 +138,19 @@ config BT_CTLR_SDC_MAX_CONN_EVENT_LEN_DEFAULT
 	  microseconds. The event length and the connection interval are the
 	  primary parameters for setting the throughput of a connection.
 
+config BT_CTLR_SDC_PERIODIC_ADV_EVENT_LEN_DEFAULT_OVERRIDE
+	bool "Override periodic adv event length default"
+
+config BT_CTLR_SDC_PERIODIC_ADV_EVENT_LEN_DEFAULT
+	int "Default periodic advertising event length [us]"
+	default 7500 if !BT_CTLR_SDC_PERIODIC_ADV_EVENT_LEN_DEFAULT_OVERRIDE
+	range 0 4000000
+	help
+	  The time set aside for periodic advertising each periodic advertising
+	  interval in microseconds. The event length is the primary parameter for
+	  how much data can be transmitted by the periodic advertiser without
+	  scheduling conflicts occurring.
+
 config BT_CTLR_SDC_TX_PACKET_COUNT
 	int "Number of Link Layer ACL TX buffers"
 	default 3

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -965,6 +965,17 @@ static int hci_driver_open(void)
 		return err;
 	}
 
+	if (IS_ENABLED(CONFIG_BT_PER_ADV)) {
+		sdc_hci_cmd_vs_periodic_adv_event_length_set_t params = {
+			.event_length_us = CONFIG_BT_CTLR_SDC_PERIODIC_ADV_EVENT_LEN_DEFAULT
+		};
+		err = sdc_hci_cmd_vs_periodic_adv_event_length_set(&params);
+		if (err) {
+			MULTITHREADING_LOCK_RELEASE();
+			return -ENOTSUP;
+		}
+	}
+
 	MULTITHREADING_LOCK_RELEASE();
 
 	return 0;

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -755,16 +755,6 @@ static int configure_memory_usage(void)
 		return required_memory;
 	}
 
-	cfg.event_length.event_length_us =
-		CONFIG_BT_CTLR_SDC_MAX_CONN_EVENT_LEN_DEFAULT;
-	required_memory =
-		sdc_cfg_set(SDC_DEFAULT_RESOURCE_CFG_TAG,
-				       SDC_CFG_TYPE_EVENT_LENGTH,
-				       &cfg);
-	if (required_memory < 0) {
-		return required_memory;
-	}
-
 #if defined(CONFIG_BT_BROADCASTER) || defined(CONFIG_BT_LL_SOFTDEVICE_MULTIROLE)
 	cfg.adv_count.count = SDC_ADV_SET_COUNT;
 
@@ -970,6 +960,17 @@ static int hci_driver_open(void)
 			.event_length_us = CONFIG_BT_CTLR_SDC_PERIODIC_ADV_EVENT_LEN_DEFAULT
 		};
 		err = sdc_hci_cmd_vs_periodic_adv_event_length_set(&params);
+		if (err) {
+			MULTITHREADING_LOCK_RELEASE();
+			return -ENOTSUP;
+		}
+	}
+
+	if (IS_ENABLED(CONFIG_BT_CONN)) {
+		sdc_hci_cmd_vs_event_length_set_t params = {
+			.event_length_us = CONFIG_BT_CTLR_SDC_MAX_CONN_EVENT_LEN_DEFAULT
+		};
+		err = sdc_hci_cmd_vs_event_length_set(&params);
 		if (err) {
 			MULTITHREADING_LOCK_RELEASE();
 			return -ENOTSUP;


### PR DESCRIPTION
This can be used to set the periodic advertising event length via sdc_hci_cmd_vs_periodic_adv_event_length_set