### PR TITLE
Bluetooth: Controller: add add_hci_le_transmitter_test_v4

### DIFF
--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -413,6 +413,10 @@ void hci_internal_supported_commands(sdc_hci_ip_supported_commands_t *cmds)
 	cmds->hci_le_enhanced_read_transmit_power_level = 1;
 	cmds->hci_le_read_remote_transmit_power_level = 1;
 	cmds->hci_le_set_transmit_power_reporting_enable = 1;
+	/* NOTE: The DTM commands are *not* supported by the SoftDevice
+	 * controller. See doc/nrf/known_issues.rst.
+	 */
+	cmds->hci_le_transmitter_test_v4 = 1;
 #endif
 
 #if defined(CONFIG_BT_CTLR_LE_POWER_CONTROL) || defined(CONFIG_BT_CTLR_ADV_EXT)


### PR DESCRIPTION
Add add_hci_le_transmitter_test_v4 to local supported cmds

When selecting ICS to qualify Le Power Control the LE Transmitter Test command [v4] is mandatory.
