### PR TITLE
doc: Cellular: Azure FOTA sample formatting fix

### DIFF
--- a/samples/cellular/azure_fota/README.rst
+++ b/samples/cellular/azure_fota/README.rst
@@ -68,7 +68,7 @@ Check and configure the following library Kconfig options:
 
 .. note::
    To provide the device ID used in the connection towards Azure IoT Hub at run time, set the ``device_id`` member of the :c:struct:`azure_iot_hub_config` structure when calling the :c:func:`azure_iot_hub_connect` function.
-   If the ``device_id.size`` buffer size is zero, the compile-time option :kconfig:option:`CONFIG_AZURE_IOT_HUB_DEVICE_ID`` is used.
+   If the ``device_id.size`` buffer size is zero, the compile-time option :kconfig:option:`CONFIG_AZURE_IOT_HUB_DEVICE_ID` is used.
 
 .. include:: /libraries/modem/nrf_modem_lib/nrf_modem_lib_trace.rst
    :start-after: modem_lib_sending_traces_UART_start


### PR DESCRIPTION
One of the Kconfig options had wrong formatting.
This PR fixes it.