### PR TITLE
boards: shields: nrf7002ek: Fix SPI CS GPIOs overwrite

### DIFF
--- a/boards/shields/nrf7002ek/nrf7002ek.overlay
+++ b/boards/shields/nrf7002ek/nrf7002ek.overlay
@@ -7,7 +7,6 @@
 
 &arduino_spi {
 	status = "okay";
-	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
 
 	nrf700x: nrf7002@0 {
 		compatible = "nordic,nrf700x-spi";

--- a/boards/shields/nrf7002ek_nrf7000/nrf7002ek_nrf7000.overlay
+++ b/boards/shields/nrf7002ek_nrf7000/nrf7002ek_nrf7000.overlay
@@ -7,7 +7,6 @@
 
 &arduino_spi {
 	status = "okay";
-	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
 
 	nrf700x: nrf7000@0 {
 		compatible = "nordic,nrf700x-spi";

--- a/boards/shields/nrf7002ek_nrf7001/nrf7002ek_nrf7001.overlay
+++ b/boards/shields/nrf7002ek_nrf7001/nrf7002ek_nrf7001.overlay
@@ -7,7 +7,6 @@
 
 &arduino_spi {
 	status = "okay";
-	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
 
 	nrf700x: nrf7001@0 {
 		compatible = "nordic,nrf700x-spi";


### PR DESCRIPTION
In case the original DTS has multi-element array for CS GPIOs, then the Wi-Fi shield will overwrite causing build failures. E.g., nRF8160DK 0.14.0 (default now).

As the default value needed for Wi-Fi is already set in original DTS remove the entry from the overlays.