### PR TITLE
applications: serial_lte_modem: Remove modem delta firmware update workaround

### DIFF
--- a/applications/serial_lte_modem/src/slm_at_fota.c
+++ b/applications/serial_lte_modem/src/slm_at_fota.c
@@ -376,7 +376,6 @@ void slm_fota_post_process(void)
 void slm_finish_modem_fota(int modem_lib_init_ret)
 {
 	if (handle_nrf_modem_lib_init_ret(modem_lib_init_ret)) {
-		char buf[40];
 
 		LOG_INF("Re-initializing the modem due to"
 				" ongoing modem firmware update.");
@@ -387,15 +386,5 @@ void slm_finish_modem_fota(int modem_lib_init_ret)
 		 */
 		modem_lib_init_ret = nrf_modem_lib_init();
 		handle_nrf_modem_lib_init_ret(modem_lib_init_ret);
-
-		nrf_modem_at_cmd(buf, sizeof(buf), "%s", "AT%SHORTSWVER");
-		if (strstr(buf, "1.3.4") || strstr(buf, "1.3.5")) {
-			/* Those versions suffer from a bug that provokes UICC failure (+CEREG: 90)
-			 * after the update, preventing the modem from registering to the network.
-			 */
-			LOG_INF("Applying the workaround to a modem firmware update issue...");
-			nrf_modem_lib_shutdown();
-			nrf_modem_lib_init();
-		}
 	}
 }


### PR DESCRIPTION
Working around the modem firmware bug is now taken care of by the modem library.