### PR TITLE
applications: Enabled using persistent storage in Matter bridge

### DIFF
--- a/applications/matter_bridge/CMakeLists.txt
+++ b/applications/matter_bridge/CMakeLists.txt
@@ -43,6 +43,7 @@ target_sources(app PRIVATE
     src/app_task.cpp
     src/main.cpp
     src/bridge_shell.cpp
+    src/bridged_devices_creator.cpp
     ${COMMON_ROOT}/src/bridge/bridge_manager.cpp
     ${COMMON_ROOT}/src/bridge/matter_bridged_device.cpp
     ${COMMON_ROOT}/src/bridge/bridge_storage_manager.cpp

--- a/applications/matter_bridge/Kconfig
+++ b/applications/matter_bridge/Kconfig
@@ -46,7 +46,7 @@ config BT_SCAN
 
 # Configure how many Bluetooth LE devices the Matter bridge can support (the final number is given value - 1, as 1 connection is used for the Matter Bluetooth LE service).
 config BT_MAX_CONN
-	default 2
+	default 3
 
 config BT_SCAN_FILTER_ENABLE
 	default y

--- a/applications/matter_bridge/src/app_task.h
+++ b/applications/matter_bridge/src/app_task.h
@@ -48,6 +48,7 @@ private:
 	static void LEDStateUpdateHandler(LEDWidget &ledWidget);
 	static void FunctionTimerTimeoutCallback(k_timer *timer);
 	static void UpdateStatusLED();
+	static CHIP_ERROR RestoreBridgedDevices();
 
 	FunctionEvent mFunction = FunctionEvent::NoneSelected;
 	bool mFunctionTimerActive = false;

--- a/applications/matter_bridge/src/bridged_device_types/ble_environmental_data_provider.h
+++ b/applications/matter_bridge/src/bridged_device_types/ble_environmental_data_provider.h
@@ -22,17 +22,6 @@ public:
 			       size_t dataSize) override;
 	CHIP_ERROR UpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer) override;
 	bt_uuid *GetServiceUuid() override;
-	int MatchBleDevice(BLEBridgedDevice *device) override
-	{
-		if (!device) {
-			return -EINVAL;
-		}
-
-		mDevice = device;
-		mDevice->mProvider = this;
-
-		return 0;
-	}
 	int ParseDiscoveredData(bt_gatt_dm *discoveredData) override;
 
 private:

--- a/applications/matter_bridge/src/bridged_device_types/ble_onoff_light_data_provider.h
+++ b/applications/matter_bridge/src/bridged_device_types/ble_onoff_light_data_provider.h
@@ -15,7 +15,6 @@
 class BleOnOffLightDataProvider : public BLEBridgedDeviceProvider {
 public:
 	explicit BleOnOffLightDataProvider(UpdateAttributeCallback callback) : BLEBridgedDeviceProvider(callback) {}
-	~BleOnOffLightDataProvider() = default;
 
 	void Init() override;
 	void NotifyUpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId, void *data,
@@ -28,17 +27,6 @@ public:
 					  uint16_t length);
 
 	bt_uuid *GetServiceUuid() override;
-	int MatchBleDevice(BLEBridgedDevice *device) override
-	{
-		if (!device) {
-			return -EINVAL;
-		}
-
-		mDevice = device;
-		mDevice->mProvider = this;
-
-		return 0;
-	}
 	int ParseDiscoveredData(bt_gatt_dm *discoveredData) override;
 
 private:

--- a/applications/matter_bridge/src/bridged_devices_creator.cpp
+++ b/applications/matter_bridge/src/bridged_devices_creator.cpp
@@ -1,0 +1,348 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "bridged_devices_creator.h"
+#include "bridge_manager.h"
+#include "bridge_storage_manager.h"
+#include "bridged_device_factory.h"
+
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_DECLARE(app, CONFIG_CHIP_APP_LOG_LEVEL);
+
+namespace
+{
+CHIP_ERROR StoreDevice(MatterBridgedDevice *device, BridgedDeviceDataProvider *provider, uint8_t index)
+{
+	uint16_t endpointId;
+	uint8_t count = 0;
+	uint8_t indexes[BridgeManager::kMaxBridgedDevices] = { 0 };
+	bool deviceRefresh = false;
+
+	/* Check if a device is already present in the storage. */
+	if (BridgeStorageManager::Instance().LoadBridgedDeviceEndpointId(endpointId, index)) {
+		deviceRefresh = true;
+	}
+
+	if (!BridgeStorageManager::Instance().StoreBridgedDevice(device, index)) {
+		LOG_ERR("Failed to store bridged device");
+		return CHIP_ERROR_INTERNAL;
+	}
+
+/* Store additional information that are not present for every generic MatterBridgedDevice. */
+#ifdef CONFIG_BRIDGED_DEVICE_BT
+	BLEBridgedDeviceProvider *bleProvider = static_cast<BLEBridgedDeviceProvider *>(provider);
+
+	bt_addr_le_t addr = bleProvider->GetBtAddress();
+
+	if (!BridgeStorageManager::Instance().StoreBtAddress(addr, index)) {
+		LOG_ERR("Failed to store bridged device's Bluetooth address");
+		return CHIP_ERROR_INTERNAL;
+	}
+#endif
+
+	/* If a device was not present in the storage before, put new index on the end of list and increment the count
+	 * number of stored devices. */
+	if (!deviceRefresh) {
+		CHIP_ERROR err = BridgeManager::Instance().GetDevicesIndexes(indexes, sizeof(indexes), count);
+		if (CHIP_NO_ERROR != err) {
+			LOG_ERR("Failed to get bridged devices indexes");
+			return err;
+		}
+
+		if (!BridgeStorageManager::Instance().StoreBridgedDevicesIndexes(indexes, count)) {
+			LOG_ERR("Failed to store bridged devices indexes.");
+			return CHIP_ERROR_INTERNAL;
+		}
+
+		if (!BridgeStorageManager::Instance().StoreBridgedDevicesCount(count)) {
+			LOG_ERR("Failed to store bridged devices count.");
+			return CHIP_ERROR_INTERNAL;
+		}
+	}
+
+	return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR AddMatterDevice(int deviceType, const char *nodeLabel, BridgedDeviceDataProvider *provider,
+			   chip::Optional<uint8_t> index, chip::Optional<uint16_t> endpointId)
+{
+	VerifyOrReturnError(provider != nullptr, CHIP_ERROR_INVALID_ARGUMENT, LOG_ERR("No valid data provider!"));
+
+	CHIP_ERROR err;
+
+	if (deviceType == MatterBridgedDevice::DeviceType::EnvironmentalSensor) {
+		/* Handle special case for environmental sensor */
+		auto *temperatureBridgedDevice = BridgeFactory::GetBridgedDeviceFactory().Create(
+			MatterBridgedDevice::DeviceType::TemperatureSensor, nodeLabel);
+
+		if (!temperatureBridgedDevice) {
+			LOG_ERR("Cannot allocate Matter device of given type");
+			return CHIP_ERROR_NO_MEMORY;
+		}
+
+		auto *humidityBridgedDevice = BridgeFactory::GetBridgedDeviceFactory().Create(
+			MatterBridgedDevice::DeviceType::HumiditySensor, nodeLabel);
+
+		if (!humidityBridgedDevice) {
+			chip::Platform::Delete(temperatureBridgedDevice);
+			LOG_ERR("Cannot allocate Matter device of given type");
+			return CHIP_ERROR_NO_MEMORY;
+		}
+
+		MatterBridgedDevice *newBridgedDevices[] = { temperatureBridgedDevice, humidityBridgedDevice };
+		uint8_t deviceIndexes[] = { 0, 0 };
+		err = BridgeManager::Instance().AddBridgedDevices(newBridgedDevices, provider,
+								  ARRAY_SIZE(newBridgedDevices), deviceIndexes);
+
+		if (err == CHIP_NO_ERROR) {
+			for (uint8_t i = 0; i < ARRAY_SIZE(newBridgedDevices); i++) {
+				err = StoreDevice(newBridgedDevices[i], provider, deviceIndexes[i]);
+				if (err != CHIP_NO_ERROR) {
+					break;
+				}
+			}
+		}
+	} else {
+		auto *newBridgedDevice = BridgeFactory::GetBridgedDeviceFactory().Create(
+			static_cast<MatterBridgedDevice::DeviceType>(deviceType), nodeLabel);
+
+		MatterBridgedDevice *newBridgedDevices[] = { newBridgedDevice };
+
+		if (!newBridgedDevice) {
+			LOG_ERR("Cannot allocate Matter device of given type");
+			return CHIP_ERROR_NO_MEMORY;
+		}
+
+		uint8_t deviceIndex[] = { 0 };
+		uint16_t endpointIds[] = { 0 };
+
+		/* The current implementation assumes that index and endpoint id values are given only in case of
+		 * recovering a device. In such scenario the devices (endpoints) are recovered one by one, so it's not
+		 * an option for environmental sensor. */
+		if (index.HasValue() && endpointId.HasValue()) {
+			endpointIds[0] = endpointId.Value();
+			deviceIndex[0] = index.Value();
+			err = BridgeManager::Instance().AddBridgedDevices(
+				newBridgedDevices, provider, ARRAY_SIZE(newBridgedDevices), deviceIndex, endpointIds);
+		} else {
+			err = BridgeManager::Instance().AddBridgedDevices(newBridgedDevices, provider,
+									  ARRAY_SIZE(newBridgedDevices), deviceIndex);
+		}
+
+		if (err == CHIP_NO_ERROR) {
+			err = StoreDevice(newBridgedDevice, provider, deviceIndex[0]);
+		}
+	}
+
+	if (err != CHIP_NO_ERROR) {
+		LOG_ERR("Adding Matter bridged device failed: %s", ErrorStr(err));
+	}
+	return err;
+}
+
+#ifdef CONFIG_BRIDGED_DEVICE_SIMULATED
+BridgedDeviceDataProvider *CreateSimulatedProvider(int deviceType)
+{
+	return BridgeFactory::GetSimulatedDataProviderFactory().Create(
+		static_cast<MatterBridgedDevice::DeviceType>(deviceType), BridgeManager::HandleUpdate);
+}
+#endif /* CONFIG_BRIDGED_DEVICE_SIMULATED */
+
+#ifdef CONFIG_BRIDGED_DEVICE_BT
+
+struct BluetoothConnectionContext {
+	int deviceType;
+	char nodeLabel[MatterBridgedDevice::kNodeLabelSize] = { 0 };
+	BLEBridgedDeviceProvider *provider;
+	bt_addr_le_t address;
+	chip::Optional<uint8_t> index;
+	chip::Optional<uint16_t> endpointId;
+};
+
+void BluetoothDeviceConnected(bt_gatt_dm *discoveredData, bool discoverySucceeded, void *context)
+{
+	if (!context) {
+		return;
+	}
+
+	BluetoothConnectionContext *ctx = reinterpret_cast<BluetoothConnectionContext *>(context);
+
+	VerifyOrExit(discoveredData && discoverySucceeded, );
+	VerifyOrExit(ctx->provider->ParseDiscoveredData(discoveredData) == 0, );
+
+	/* Schedule adding device to main thread to avoid overflowing the BT stack. */
+	VerifyOrExit(chip::DeviceLayer::PlatformMgr().ScheduleWork(
+			     [](intptr_t context) {
+				     BluetoothConnectionContext *ctx =
+					     reinterpret_cast<BluetoothConnectionContext *>(context);
+				     if (CHIP_NO_ERROR != AddMatterDevice(ctx->deviceType, ctx->nodeLabel,
+									  ctx->provider, ctx->index, ctx->endpointId)) {
+					     BLEConnectivityManager::Instance().RemoveBLEProvider(ctx->address);
+					     chip::Platform::Delete(ctx->provider);
+				     }
+				     chip::Platform::Delete(ctx);
+			     },
+			     reinterpret_cast<intptr_t>(ctx)) == CHIP_NO_ERROR, );
+	return;
+
+exit:
+	BLEConnectivityManager::Instance().RemoveBLEProvider(ctx->address);
+	chip::Platform::Delete(ctx);
+}
+
+BridgedDeviceDataProvider *CreateBleProvider(int deviceType)
+{
+	return BridgeFactory::GetBleDataProviderFactory().Create(
+		static_cast<MatterBridgedDevice::DeviceType>(deviceType), BridgeManager::HandleUpdate);
+}
+#endif /* CONFIG_BRIDGED_DEVICE_BT */
+} /* namespace */
+
+#ifdef CONFIG_BRIDGED_DEVICE_BT
+CHIP_ERROR BridgedDeviceCreator::CreateDevice(int deviceType, const char *nodeLabel, bt_addr_le_t btAddress,
+					      chip::Optional<uint8_t> index, chip::Optional<uint16_t> endpointId)
+{
+	CHIP_ERROR err;
+
+	/* Check if there is already existing provider for given address.
+	 * In case it is, the provider was either connected or recovered before. All what needs to be done is creating
+	 * new Matter endpoint. In case there isn't, the provider has to be created.
+	 */
+	BLEBridgedDeviceProvider *provider = BLEConnectivityManager::Instance().FindBLEProvider(btAddress);
+	if (provider) {
+		return AddMatterDevice(deviceType, nodeLabel, provider, index, endpointId);
+	}
+
+	/* The EnvironmentalSensor is a dummy device type, so it is not saved in the persistent storage. For now the
+	 * only BLE service handling temperature and humidity device types is environmental sensor, so it's necessary to
+	 * perform mapping. */
+	if (deviceType == MatterBridgedDevice::DeviceType::TemperatureSensor ||
+	    deviceType == MatterBridgedDevice::DeviceType::HumiditySensor) {
+		provider = static_cast<BLEBridgedDeviceProvider *>(
+			CreateBleProvider(MatterBridgedDevice::DeviceType::EnvironmentalSensor));
+	} else {
+		provider = static_cast<BLEBridgedDeviceProvider *>(CreateBleProvider(deviceType));
+	}
+
+	if (!provider) {
+		return CHIP_ERROR_NO_MEMORY;
+	}
+
+	err = BLEConnectivityManager::Instance().AddBLEProvider(provider);
+	VerifyOrExit(err == CHIP_NO_ERROR, );
+
+	/* There are two cases for creating a new device:
+	 * - connecting new device for the first time - the index and endpoint id are not relevant, the new Bluetooth LE
+	 * connection has to be created and the operation confirmed by connected callback.
+	 * - recovering a device that was connected in the past after reboot - the index and endpoint id are read from
+	 * storage, the device has to be re-connected without confirming its existence by callback.
+	 */
+	if (index.HasValue() && endpointId.HasValue()) {
+		provider->InitializeBridgedDevice(btAddress, nullptr, nullptr);
+		BLEConnectivityManager::Instance().Recover(provider);
+		err = AddMatterDevice(deviceType, nodeLabel, provider, index, endpointId);
+	} else {
+		/* The device object can be created once the Bluetooth LE connection will be established. */
+		BluetoothConnectionContext *context = chip::Platform::New<BluetoothConnectionContext>();
+
+		VerifyOrExit(context, err = CHIP_ERROR_NO_MEMORY);
+
+		chip::Platform::UniquePtr<BluetoothConnectionContext> contextPtr(context);
+		contextPtr->deviceType = deviceType;
+
+		if (nodeLabel) {
+			strcpy(contextPtr->nodeLabel, nodeLabel);
+		}
+
+		contextPtr->provider = provider;
+		contextPtr->index = index;
+		contextPtr->endpointId = endpointId;
+		contextPtr->address = btAddress;
+
+		provider->InitializeBridgedDevice(btAddress, BluetoothDeviceConnected, contextPtr.get());
+		err = BLEConnectivityManager::Instance().Connect(provider);
+
+		if (err == CHIP_NO_ERROR) {
+			contextPtr.release();
+		}
+	}
+
+exit:
+
+	if (err != CHIP_NO_ERROR) {
+		BLEConnectivityManager::Instance().RemoveBLEProvider(btAddress);
+		chip::Platform::Delete(provider);
+	}
+
+	return err;
+}
+#else
+CHIP_ERROR BridgedDeviceCreator::CreateDevice(int deviceType, const char *nodeLabel, chip::Optional<uint8_t> index,
+					      chip::Optional<uint16_t> endpointId)
+{
+#if defined(CONFIG_BRIDGED_DEVICE_SIMULATED)
+	BridgedDeviceDataProvider *provider = CreateSimulatedProvider(deviceType);
+	/* The device is simulated, so it can be added immediately. */
+	return AddMatterDevice(deviceType, nodeLabel, provider, index, endpointId);
+#else
+	return CHIP_ERROR_NOT_IMPLEMENTED;
+#endif /* CONFIG_BRIDGED_DEVICE_SIMULATED */
+}
+#endif /* CONFIG_BRIDGED_DEVICE_BT */
+
+CHIP_ERROR BridgedDeviceCreator::RemoveDevice(int endpointId)
+{
+	uint8_t index;
+	uint8_t count = 0;
+	uint8_t indexes[BridgeManager::kMaxBridgedDevices] = { 0 };
+
+	CHIP_ERROR err = BridgeManager::Instance().RemoveBridgedDevice(endpointId, index);
+
+	if (CHIP_NO_ERROR != err) {
+		LOG_ERR("Failed to remove bridged device");
+		return err;
+	}
+
+	err = BridgeManager::Instance().GetDevicesIndexes(indexes, sizeof(indexes), count);
+	if (CHIP_NO_ERROR != err) {
+		LOG_ERR("Failed to get bridged devices indexes");
+		return err;
+	}
+
+	/* Update the current indexes list. */
+	if (!BridgeStorageManager::Instance().StoreBridgedDevicesIndexes(indexes, count)) {
+		LOG_ERR("Failed to store bridged devices indexes.");
+		return CHIP_ERROR_INTERNAL;
+	}
+
+	if (!BridgeStorageManager::Instance().StoreBridgedDevicesCount(count)) {
+		LOG_ERR("Failed to store bridged devices count.");
+		return CHIP_ERROR_INTERNAL;
+	}
+
+	if (!BridgeStorageManager::Instance().RemoveBridgedDeviceEndpointId(index)) {
+		LOG_ERR("Failed to remove bridged device endpoint id.");
+		return CHIP_ERROR_INTERNAL;
+	}
+
+	/* Ignore error, as node label may not be present in the storage. */
+	BridgeStorageManager::Instance().RemoveBridgedDeviceNodeLabel(index);
+
+	if (!BridgeStorageManager::Instance().RemoveBridgedDeviceType(index)) {
+		LOG_ERR("Failed to remove bridged device type.");
+		return CHIP_ERROR_INTERNAL;
+	}
+
+#ifdef CONFIG_BRIDGED_DEVICE_BT
+	if (!BridgeStorageManager::Instance().RemoveBtAddress(index)) {
+		LOG_ERR("Failed to remove bridged device Bluetooth address.");
+		return CHIP_ERROR_INTERNAL;
+	}
+#endif
+
+	return CHIP_NO_ERROR;
+}

--- a/applications/matter_bridge/src/bridged_devices_creator.h
+++ b/applications/matter_bridge/src/bridged_devices_creator.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#pragma once
+
+#include <lib/core/CHIPError.h>
+#include <lib/core/Optional.h>
+
+#include <zephyr/bluetooth/addr.h>
+
+namespace BridgedDeviceCreator
+{
+#ifdef CONFIG_BRIDGED_DEVICE_BT
+/**
+ * @brief Create a bridged device.
+ *
+ * @param deviceType the Matter device type of a bridged device to be created
+ * @param nodeLabel node label of a Matter device to be created
+ * @param btAddress the Bluetooth LE address of a device to be bridged with created Matter device
+ * @param index optional index object that shall have a valid value set if the value is meant
+ * to be used to index assignment, or shall not have a value set if the default index assignment should be used.
+ * @param endpointId optional endpoint id object that shall have a valid value set if the value is meant
+ * to be used to endpoint id assignment, or shall not have a value set if the default endpoint id assignment should be
+ * used.
+ * @return CHIP_NO_ERROR on success
+ * @return other error code on failure
+ */
+CHIP_ERROR CreateDevice(int deviceType, const char *nodeLabel, bt_addr_le_t btAddress,
+			chip::Optional<uint8_t> index = chip::Optional<uint8_t>(),
+			chip::Optional<uint16_t> endpointId = chip::Optional<uint16_t>());
+#else
+/**
+ * @brief Create a bridged device.
+ *
+ * @param deviceType the Matter device type of a bridged device to be created
+ * @param nodeLabel node label of a Matter device to be created
+ * @param index optional index object that shall have a valid value set if the value is meant
+ * to be used to index assignment, or shall not have a value set if the default index assignment should be used.
+ * @param endpointId optional endpoint id object that shall have a valid value set if the value is meant
+ * to be used to endpoint id assignment, or shall not have a value set if the default endpoint id assignment should be
+ * used.
+ * @return CHIP_NO_ERROR on success
+ * @return other error code on failure
+ */
+CHIP_ERROR CreateDevice(int deviceType, const char *nodeLabel,
+			chip::Optional<uint8_t> index = chip::Optional<uint8_t>(),
+			chip::Optional<uint16_t> endpointId = chip::Optional<uint16_t>());
+#endif
+
+/**
+ * @brief Remove bridged device.
+ *
+ * @param endpointId value of endpoint id specifying the bridged device to be removed
+ * @return CHIP_NO_ERROR on success
+ * @return other error code on failure
+ */
+CHIP_ERROR RemoveDevice(int endpointId);
+} /* namespace BridgedDeviceCreator */

--- a/samples/matter/common/src/bridge/ble_connectivity_manager.cpp
+++ b/samples/matter/common/src/bridge/ble_connectivity_manager.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "ble_connectivity_manager.h"
+#include "ble_bridged_device.h"
 
 #include <bluetooth/gatt_dm.h>
 #include <bluetooth/scan.h>
@@ -59,37 +60,42 @@ void BLEConnectivityManager::FilterMatch(bt_scan_device_info *device_info, bt_sc
 
 void BLEConnectivityManager::ConnectionHandler(bt_conn *conn, uint8_t conn_err)
 {
-	const bt_addr_le_t *addr = bt_conn_get_dst(conn);
+	const bt_addr_le_t *dstAddr = bt_conn_get_dst(conn);
 	char str_addr[BT_ADDR_LE_STR_LEN];
 	int err;
-	BLEBridgedDevice *device = nullptr;
+	BLEBridgedDeviceProvider *provider = nullptr;
 
-	bt_addr_le_to_str(addr, str_addr, sizeof(str_addr));
+	bt_addr_le_to_str(dstAddr, str_addr, sizeof(str_addr));
 
 	/* Find the created device instance based on address. */
-	for (int i = 0; i < Instance().mCreatedDevicesCounter; i++) {
-		if (memcmp(&Instance().mCreatedDevices[i].mAddr, addr, sizeof(Instance().mCreatedDevices[i].mAddr)) ==
-		    0) {
-			device = &Instance().mCreatedDevices[i];
+	for (int i = 0; i < kMaxConnectedDevices; i++) {
+		if (Instance().mConnectedProviders[i] == nullptr) {
+			continue;
+		}
+
+		bt_addr_le_t addr = Instance().mConnectedProviders[i]->GetBtAddress();
+		if (memcmp(&addr, dstAddr, sizeof(addr)) == 0) {
+			provider = Instance().mConnectedProviders[i];
 			break;
 		}
 	}
 
-	if (!device) {
+	/* The device with given address was not found.  */
+	if (!provider) {
 		return;
 	}
 
 	/* TODO: Add security validation. */
 
 	if (conn_err && Instance().mRecovery.mRecoveryInProgress) {
-		Instance().mRecovery.PutDevice(device);
+		Instance().mRecovery.PutProvider(provider);
 		return;
 	}
 
 	LOG_INF("Connected: %s", str_addr);
 
 	/* Start GATT discovery for the device's service UUID. */
-	err = bt_gatt_dm_start(conn, device->mServiceUuid, &discovery_cb, device);
+	err = bt_gatt_dm_start(conn, provider->GetServiceUuid(), &discovery_cb, provider);
 	if (err) {
 		LOG_ERR("Could not start the discovery procedure, error "
 			"code: %d",
@@ -99,54 +105,48 @@ void BLEConnectivityManager::ConnectionHandler(bt_conn *conn, uint8_t conn_err)
 
 void BLEConnectivityManager::DisconnectionHandler(bt_conn *conn, uint8_t reason)
 {
-	/* Verify whether the device should be recovered */
-	BLEBridgedDevice *device = Instance().FindBLEBridgedDevice(conn);
+	char addr[BT_ADDR_LE_STR_LEN];
+	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
-	if (device) {
-		char addr[BT_ADDR_LE_STR_LEN];
-		bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	LOG_INF("Disconnected: %s (reason %u)", addr, reason);
 
-		LOG_INF("Disconnected: %s (reason %u)", addr, reason);
+	/* Try to find provider matching the connection */
+	BLEBridgedDeviceProvider *provider = Instance().FindBLEProvider(*bt_conn_get_dst(conn));
 
-		if (device->mConn) {
-			bt_conn_unref(device->mConn);
-			device->mConn = nullptr;
-		}
+	bt_conn_unref(conn);
 
+	if (provider) {
+		/* Verify whether the device should be recovered. */
 		if (reason == BT_HCI_ERR_CONN_TIMEOUT) {
-			Instance().mRecovery.NotifyLostDevice(device);
-			if (device->mProvider) {
-				VerifyOrReturn(CHIP_NO_ERROR == device->mProvider->NotifyReachableStatusChange(false),
-					       LOG_WRN("The device has not been notified about the status change."));
-			}
+			Instance().mRecovery.NotifyProviderToRecover(provider);
+			VerifyOrReturn(CHIP_NO_ERROR == provider->NotifyReachableStatusChange(false),
+				       LOG_WRN("The device has not been notified about the status change."));
 		}
-
-		/* TODO Add removing a device when disconnection has been invoked by the user */
 	}
 }
 
 void BLEConnectivityManager::DiscoveryCompletedHandler(bt_gatt_dm *dm, void *context)
 {
 	LOG_INF("The GATT discovery completed");
-	BLEBridgedDevice *device = reinterpret_cast<BLEBridgedDevice *>(context);
+	BLEBridgedDeviceProvider *provider = reinterpret_cast<BLEBridgedDeviceProvider *>(context);
 	bool discoveryResult = false;
 	const bt_gatt_dm_attr *gatt_service_attr = bt_gatt_dm_service_get(dm);
 	const bt_gatt_service_val *gatt_service = bt_gatt_dm_attr_service_val(gatt_service_attr);
 
-	VerifyOrExit(device, );
+	VerifyOrExit(provider, );
 	bt_gatt_dm_data_print(dm);
-	VerifyOrExit(bt_uuid_cmp(gatt_service->uuid, device->mServiceUuid) == 0, );
-	device->mConn = bt_gatt_dm_conn_get(dm);
+	VerifyOrExit(bt_uuid_cmp(gatt_service->uuid, provider->GetServiceUuid()) == 0, );
 
 	discoveryResult = true;
 exit:
 
 	if (!Instance().mRecovery.mRecoveryInProgress) {
-		device->mFirstConnectionCallback(device, dm, discoveryResult, device->mFirstConnectionCallbackContext);
+		provider->GetBLEBridgedDevice().mFirstConnectionCallback(
+			dm, discoveryResult, provider->GetBLEBridgedDevice().mFirstConnectionCallbackContext);
 	}
 
-	if (device->mProvider) {
-		VerifyOrReturn(CHIP_NO_ERROR == device->mProvider->NotifyReachableStatusChange(true),
+	if (provider) {
+		VerifyOrReturn(CHIP_NO_ERROR == provider->NotifyReachableStatusChange(true),
 			       LOG_WRN("The device has not been notified about the status change."));
 	}
 
@@ -163,18 +163,20 @@ void BLEConnectivityManager::DiscoveryNotFound(bt_conn *conn, void *context)
 {
 	LOG_ERR("GATT service could not be found during the discovery");
 
-	BLEBridgedDevice *device = reinterpret_cast<BLEBridgedDevice *>(context);
+	BLEBridgedDeviceProvider *provider = reinterpret_cast<BLEBridgedDeviceProvider *>(context);
 
-	device->mFirstConnectionCallback(device, nullptr, false, device->mFirstConnectionCallbackContext);
+	provider->GetBLEBridgedDevice().mFirstConnectionCallback(
+		nullptr, false, provider->GetBLEBridgedDevice().mFirstConnectionCallbackContext);
 }
 
 void BLEConnectivityManager::DiscoveryError(bt_conn *conn, int err, void *context)
 {
 	LOG_ERR("The GATT discovery procedure failed with %d", err);
 
-	BLEBridgedDevice *device = reinterpret_cast<BLEBridgedDevice *>(context);
+	BLEBridgedDeviceProvider *provider = reinterpret_cast<BLEBridgedDeviceProvider *>(context);
 
-	device->mFirstConnectionCallback(device, nullptr, false, device->mFirstConnectionCallbackContext);
+	provider->GetBLEBridgedDevice().mFirstConnectionCallback(
+		nullptr, false, provider->GetBLEBridgedDevice().mFirstConnectionCallbackContext);
 }
 
 CHIP_ERROR BLEConnectivityManager::Init(bt_uuid **serviceUuids, uint8_t serviceUuidsCount)
@@ -249,24 +251,30 @@ void BLEConnectivityManager::ReScanCallback(ScannedDevice *devices, uint8_t coun
 	LOG_DBG("Found devices no. %d", Instance().mScannedDevicesCounter);
 
 	if (Instance().mScannedDevicesCounter != 0 && !Instance().mRecovery.mRecoveryInProgress) {
-		BLEBridgedDevice *deviceLost = Instance().mRecovery.GetDevice();
+		BLEBridgedDeviceProvider *deviceLost = Instance().mRecovery.GetProvider();
 		if (deviceLost) {
 			for (uint8_t idx = 0; idx < Instance().mScannedDevicesCounter; idx++) {
 				auto &deviceScanned = Instance().mScannedDevices[idx];
-				if (memcmp(&deviceScanned.mAddr, &deviceLost->mAddr, sizeof(deviceLost->mAddr)) == 0) {
+				bt_addr_le_t address = deviceLost->GetBtAddress();
+
+				if (memcmp(&deviceScanned.mAddr, &address, sizeof(address)) == 0) {
 					LOG_DBG("Found the lost device");
 
 					Instance().mRecovery.mIndexToRecover = idx;
-					Instance().mRecovery.mCurrentDevice = deviceLost;
+					Instance().mRecovery.mCurrentProvider = deviceLost;
 					Instance().mRecovery.mRecoveryInProgress = true;
 
 					DeviceLayer::PlatformMgr().ScheduleWork(
-						[](intptr_t context) { Instance().Reconnect(); }, 0);
+						[](intptr_t context) {
+							Instance().Reconnect(
+								reinterpret_cast<BLEBridgedDeviceProvider *>(context));
+						},
+						reinterpret_cast<intptr_t>(deviceLost));
 					break;
 				}
 			}
 			if (!Instance().mRecovery.mRecoveryInProgress) {
-				Instance().mRecovery.NotifyLostDevice(deviceLost);
+				Instance().mRecovery.NotifyProviderToRecover(deviceLost);
 			}
 		}
 	} else if (Instance().mRecovery.IsNeeded()) {
@@ -303,8 +311,12 @@ void BLEConnectivityManager::ScanTimeoutHandle(intptr_t context)
 				     Instance().mScanDoneCallbackContext);
 }
 
-CHIP_ERROR BLEConnectivityManager::Reconnect()
+CHIP_ERROR BLEConnectivityManager::Reconnect(BLEBridgedDeviceProvider *provider)
 {
+	if (!provider) {
+		return CHIP_ERROR_INVALID_ARGUMENT;
+	}
+
 	StopScan();
 
 	bt_conn *conn;
@@ -315,81 +327,149 @@ CHIP_ERROR BLEConnectivityManager::Reconnect()
 	if (err) {
 		LOG_ERR("Creating reconnection failed (err %d)", err);
 		return System::MapErrorZephyr(err);
+	} else {
+		provider->SetConnectionObject(conn);
 	}
 
 	return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR BLEConnectivityManager::Connect(uint8_t index, BLEBridgedDevice::DeviceConnectedCallback callback,
-					   void *context, bt_uuid *serviceUuid)
+CHIP_ERROR BLEConnectivityManager::Connect(BLEBridgedDeviceProvider *provider)
 {
-	/* Check if device selected to connect is present on the scanned devices list. */
-	if (mScannedDevicesCounter <= index) {
-		return CHIP_ERROR_INVALID_ARGUMENT;
-	}
-
-	/* Verify whether there is a free space for a new device. */
-	if (mCreatedDevicesCounter >= kMaxCreatedDevices) {
-		return CHIP_ERROR_NO_MEMORY;
-	}
-
-	if (!callback || !serviceUuid) {
+	if (!provider) {
 		return CHIP_ERROR_INVALID_ARGUMENT;
 	}
 
 	StopScan();
 
 	bt_conn *conn;
+	bt_le_conn_param *connParams = GetScannedDeviceConnParams(provider->GetBLEBridgedDevice().mAddr);
 
-	int err = bt_conn_le_create(&mScannedDevices[index].mAddr, create_param, &mScannedDevices[index].mConnParam,
-				    &conn);
+	if (!connParams) {
+		LOG_ERR("Failed to get conn params");
+		return CHIP_ERROR_INTERNAL;
+	}
+
+	int err = bt_conn_le_create(&provider->GetBLEBridgedDevice().mAddr, create_param, connParams, &conn);
 
 	if (err) {
 		LOG_ERR("Creating connection failed (err %d)", err);
 		return System::MapErrorZephyr(err);
+	} else {
+		provider->SetConnectionObject(conn);
 	}
-
-	mCreatedDevices[mCreatedDevicesCounter].mAddr = mScannedDevices[index].mAddr;
-	mCreatedDevices[mCreatedDevicesCounter].mFirstConnectionCallback = callback;
-	mCreatedDevices[mCreatedDevicesCounter].mFirstConnectionCallbackContext = context;
-	mCreatedDevices[mCreatedDevicesCounter].mServiceUuid = serviceUuid;
-	mCreatedDevicesCounter++;
 
 	return CHIP_NO_ERROR;
 }
 
-BLEBridgedDevice *BLEConnectivityManager::FindBLEBridgedDevice(bt_conn *conn)
+CHIP_ERROR BLEConnectivityManager::AddBLEProvider(BLEBridgedDeviceProvider *provider)
 {
-	bt_conn_info info_in, info_local;
+	if (!provider) {
+		return CHIP_ERROR_INVALID_ARGUMENT;
+	}
 
-	VerifyOrExit(conn, );
-	VerifyOrExit(bt_conn_get_info(conn, &info_in) == 0, );
+	if (mConnectedProvidersCounter >= kMaxConnectedDevices) {
+		return CHIP_ERROR_NO_MEMORY;
+	}
 
-	/* Find BLE device that matches given connection id. */
-	for (int i = 0; i < mCreatedDevicesCounter; i++) {
-		if (bt_conn_get_info(mCreatedDevices[i].mConn, &info_local) == 0) {
-			if (info_local.id == info_in.id) {
-				return &mCreatedDevices[i];
-			}
+	/* Find first free slot to store new providers' address. */
+	for (auto i = 0; i < kMaxConnectedDevices; i++) {
+		if (mConnectedProviders[i] == nullptr) {
+			mConnectedProviders[i] = provider;
+			mConnectedProvidersCounter++;
+			return CHIP_NO_ERROR;
 		}
 	}
 
-exit:
+	return CHIP_ERROR_NOT_FOUND;
+}
+
+CHIP_ERROR BLEConnectivityManager::RemoveBLEProvider(bt_addr_le_t address)
+{
+	BLEBridgedDeviceProvider *provider = nullptr;
+
+	/* Find provider's address on the list and remove it. */
+	for (auto i = 0; i < kMaxConnectedDevices; i++) {
+		if (mConnectedProviders[i] == nullptr) {
+			continue;
+		}
+
+		bt_addr_le_t addr = mConnectedProviders[i]->GetBtAddress();
+		if (memcmp(&addr, &address, sizeof(address)) == 0) {
+			provider = mConnectedProviders[i];
+			mConnectedProviders[i] = nullptr;
+			mConnectedProvidersCounter--;
+			break;
+		}
+	}
+
+	if (!provider) {
+		return CHIP_ERROR_NOT_FOUND;
+	}
+
+	if (!provider->GetBLEBridgedDevice().mConn) {
+		return CHIP_ERROR_INTERNAL;
+	}
+
+	/* Release the connection immediately in case of disconnection failed, as callback will not be called. */
+	if (bt_conn_disconnect(provider->GetBLEBridgedDevice().mConn, BT_HCI_ERR_REMOTE_USER_TERM_CONN) != 0) {
+		bt_conn_unref(provider->GetBLEBridgedDevice().mConn);
+	}
+
+	return CHIP_NO_ERROR;
+}
+
+BLEBridgedDeviceProvider *BLEConnectivityManager::FindBLEProvider(bt_addr_le_t address)
+{
+	/* Find BLE provider that matches given address. */
+	for (int i = 0; i < kMaxConnectedDevices; i++) {
+		if (!mConnectedProviders[i]) {
+			continue;
+		}
+
+		bt_addr_le_t addr = mConnectedProviders[i]->GetBtAddress();
+
+		if (memcmp(&addr, &address, sizeof(addr)) == 0) {
+			return mConnectedProviders[i];
+		}
+	}
+
+	return nullptr;
+}
+
+CHIP_ERROR BLEConnectivityManager::GetScannedDeviceAddress(bt_addr_le_t *address, uint8_t index)
+{
+	if (address == nullptr || index >= mScannedDevicesCounter) {
+		return CHIP_ERROR_INVALID_ARGUMENT;
+	}
+
+	memcpy(address, &mScannedDevices[index].mAddr, sizeof(mScannedDevices[index].mAddr));
+
+	return CHIP_NO_ERROR;
+}
+
+bt_le_conn_param *BLEConnectivityManager::GetScannedDeviceConnParams(bt_addr_le_t address)
+{
+	for (auto i = 0; i < mScannedDevicesCounter; i++) {
+		if (memcmp(&mScannedDevices[i].mAddr, &address, sizeof(address)) == 0) {
+			return &mScannedDevices[i].mConnParam;
+		}
+	}
 
 	return nullptr;
 }
 
 BLEConnectivityManager::Recovery::Recovery()
 {
-	ring_buf_init(&mRingBuf, sizeof(mDevicesToRecover), reinterpret_cast<uint8_t *>(mDevicesToRecover));
+	ring_buf_init(&mRingBuf, sizeof(mProvidersToRecover), reinterpret_cast<uint8_t *>(mProvidersToRecover));
 	k_timer_init(&mRecoveryTimer, TimerTimeoutCallback, nullptr);
 	k_timer_user_data_set(&mRecoveryTimer, this);
 }
 
-void BLEConnectivityManager::Recovery::NotifyLostDevice(BLEBridgedDevice *device)
+void BLEConnectivityManager::Recovery::NotifyProviderToRecover(BLEBridgedDeviceProvider *provider)
 {
-	if (device) {
-		PutDevice(device);
+	if (provider) {
+		PutProvider(provider);
 		StartTimer();
 	}
 }
@@ -401,19 +481,19 @@ void BLEConnectivityManager::Recovery::TimerTimeoutCallback(k_timer *timer)
 		[](intptr_t) { Instance().Scan(ReScanCallback, nullptr, kRecoveryScanTimeoutMs); }, 0);
 }
 
-BLEBridgedDevice *BLEConnectivityManager::Recovery::GetDevice()
+BLEBridgedDeviceProvider *BLEConnectivityManager::Recovery::GetProvider()
 {
 	uint32_t deviceAddr;
 	int ret = ring_buf_get(&mRingBuf, reinterpret_cast<uint8_t *>(&deviceAddr), sizeof(deviceAddr));
 	if (ret == sizeof(deviceAddr)) {
-		return reinterpret_cast<BLEBridgedDevice *>(deviceAddr);
+		return reinterpret_cast<BLEBridgedDeviceProvider *>(deviceAddr);
 	}
 
 	return nullptr;
 }
 
-bool BLEConnectivityManager::Recovery::PutDevice(BLEBridgedDevice *device)
+bool BLEConnectivityManager::Recovery::PutProvider(BLEBridgedDeviceProvider *provider)
 {
-	int ret = ring_buf_put(&mRingBuf, reinterpret_cast<uint8_t *>(&device), sizeof(device));
-	return ret == sizeof(device);
+	int ret = ring_buf_put(&mRingBuf, reinterpret_cast<uint8_t *>(&provider), sizeof(provider));
+	return ret == sizeof(provider);
 }


### PR DESCRIPTION
Added storing bridged devices in the persistent storage after creation, removing them from the storage after removal and
loading them from the storage after boot.

Additionally reworked the bridge manager API for adding devices and created a separate bridged devices creator module.
