### PR TITLE
doc: nrf70: Add traffic information

### DIFF
--- a/doc/nrf/device_guides/working_with_nrf/nrf70/developing/constrained.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf70/developing/constrained.rst
@@ -251,7 +251,7 @@ The nRF70 Series driver can be used in the following profiles (not an exhaustive
        ``CONFIG_NET_PKT_RX_COUNT=10``
        ``CONFIG_NET_BUF_TX_COUNT=64``
        ``CONFIG_NET_BUF_RX_COUNT=10``
-       ``CONFIG_NET_BUF_TX_COUNT=64``
+       ``CONFIG_NRF700X_RX_NUM_BUFS=10``
        ``CONFIG_NET_BUF_DATA_SIZE=1100``
        ``CONFIG_HEAP_MEM_POOL_SIZE=230000``
        ``CONFIG_SPEED_OPTIMIZATIONS=y``
@@ -265,17 +265,22 @@ The nRF70 Series driver can be used in the following profiles (not an exhaustive
        ``UDP-RX: 12.8 Mbps``
    * - :abbr:`STA (Station)` mode
      - RX prioritized :abbr:`STA (Station)` mode
-     - ``CONFIG_NRF700X_MAX_TX_TOKENS=5``
-       ``CONFIG_NRF700X_RX_NUM_BUFS=63``
-       ``CONFIG_NRF700X_TX_MAX_DATA_SIZE=512``
-       ``CONFIG_NRF700X_RX_MAX_DATA_SIZE=1600``
-       ``CONFIG_NET_PKT_TX_COUNT=8``
+     - ``CONFIG_WPA_SUPP=y``
+       ``CONFIG_NRF700X_AP_MODE=n``
+       ``CONFIG_NRF700X_P2P_MODE=n``
+       ``CONFIG_NET_PKT_TX_COUNT=5``
        ``CONFIG_NET_PKT_RX_COUNT=64``
-       ``CONFIG_NET_BUF_TX_COUNT=16``
+       ``CONFIG_NET_BUF_TX_COUNT=10``
        ``CONFIG_NET_BUF_RX_COUNT=64``
-       ``CONFIG_NET_BUF_DATA_SIZE=1500``
+       ``CONFIG_NRF700X_RX_NUM_BUFS=64``
+       ``CONFIG_NET_BUF_DATA_SIZE=1100``
+       ``CONFIG_HEAP_MEM_POOL_SIZE=230000``
+       ``CONFIG_SPEED_OPTIMIZATIONS=y``
+       ``CONFIG_NRF700X_UTIL=n``
+       ``CONFIG_NRF700X_MAX_TX_AGGREGATION=2``
+       ``CONFIG_NRF700X_MAX_TX_TOKENS=5``
      - Display devices streaming data
-     - ``TCP-TX: 4 Mbps``
-       ``TCP-RX: 7 Mbps``
-       ``UDP-TX: 1 Mbps``
-       ``UDP-RX: 10 Mbps``
+     - ``TCP-TX: 5.3  Mbps``
+       ``TCP-RX: 7.9  Mbps``
+       ``UDP-TX: 8.6  Mbps``
+       ``UDP-RX: 12.7 Mbps``

--- a/doc/nrf/device_guides/working_with_nrf/nrf70/developing/constrained.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf70/developing/constrained.rst
@@ -176,10 +176,7 @@ The nRF70 Series driver can be used in the following profiles (not an exhaustive
        ``CONFIG_NET_BUF_TX_COUNT=1``
        ``CONFIG_NET_BUF_RX_COUNT=1``
      - Location services
-     - ``TCP-TX: 1.5 Mbps``
-       ``TCP-RX: 1.5 Mbps``
-       ``UDP-TX: 1.5 Mbps``
-       ``UDP-RX: 1.5 Mbps``
+     - ``N/A``
    * - :abbr:`STA (Station)` mode
      - IoT devices
      - ``CONFIG_WPA_SUPP=y``
@@ -284,3 +281,7 @@ The nRF70 Series driver can be used in the following profiles (not an exhaustive
        ``TCP-RX: 7.9  Mbps``
        ``UDP-TX: 8.6  Mbps``
        ``UDP-RX: 12.7 Mbps``
+
+.. note::
+   The measured throughputs, as shown in the table above, are based on tests conducted using the nRF7002 DK (updating the configuration parameters corresponding to the selected profile in the :file:`overlay-zperf.conf` file).
+   The results represent the best throughput, averaged over three iterations, and were obtained with a good RSSI signal in a clean environment.

--- a/doc/nrf/device_guides/working_with_nrf/nrf70/developing/constrained.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf70/developing/constrained.rst
@@ -224,21 +224,24 @@ The nRF70 Series driver can be used in the following profiles (not an exhaustive
        ``UDP-RX: 0.5 Mbps``
    * - :abbr:`STA (Station)` mode
      - High performance :abbr:`STA (Station)` mode
-     - ``CONFIG_NRF700X_MAX_TX_TOKENS=12``
-       ``CONFIG_NRF700X_MAX_TX_AGGREGATION=1``
-       ``CONFIG_NRF700X_RX_NUM_BUFS=63``
-       ``CONFIG_NRF700X_TX_MAX_DATA_SIZE=1600``
-       ``CONFIG_NRF700X_RX_MAX_DATA_SIZE=1600``
-       ``CONFIG_NET_PKT_TX_COUNT=16``
-       ``CONFIG_NET_PKT_RX_COUNT=16``
-       ``CONFIG_NET_BUF_TX_COUNT=32``
-       ``CONFIG_NET_BUF_RX_COUNT=16``
-       ``CONFIG_NET_BUF_DATA_SIZE=1500``
+     - ``CONFIG_WPA_SUPP=y``
+       ``CONFIG_NRF700X_AP_MODE=n``
+       ``CONFIG_NRF700X_P2P_MODE=n``
+       ``CONFIG_NET_PKT_TX_COUNT=30``
+       ``CONFIG_NET_PKT_RX_COUNT=30``
+       ``CONFIG_NET_BUF_TX_COUNT=30``
+       ``CONFIG_NET_BUF_RX_COUNT=60``
+       ``CONFIG_NET_BUF_DATA_SIZE=1100``
+       ``CONFIG_HEAP_MEM_POOL_SIZE=230000``
+       ``CONFIG_SPEED_OPTIMIZATIONS=y``
+       ``CONFIG_NRF700X_UTIL=n``
+       ``CONFIG_NRF700X_MAX_TX_AGGREGATION=9``
+       ``CONFIG_NRF700X_MAX_TX_TOKENS=12``
      - High data rate IoT devices
-     - ``TCP-TX: 10 Mbps``
-       ``TCP-RX: 10 Mbps``
-       ``UDP-TX: 10 Mbps``
-       ``UDP-RX: 10 Mbps``
+     - ``TCP-TX: 14.2 Mbps``
+       ``TCP-RX: 7.4  Mbps``
+       ``UDP-TX: 12.4 Mbps``
+       ``UDP-RX: 26.2 Mbps``
    * - :abbr:`STA (Station)` mode
      - TX prioritized :abbr:`STA (Station)` mode
      - ``CONFIG_NRF700X_MAX_TX_TOKENS=12``

--- a/doc/nrf/device_guides/working_with_nrf/nrf70/developing/constrained.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf70/developing/constrained.rst
@@ -182,19 +182,25 @@ The nRF70 Series driver can be used in the following profiles (not an exhaustive
        ``UDP-RX: 1.5 Mbps``
    * - :abbr:`STA (Station)` mode
      - IoT devices
-     - ``CONFIG_WPA_SUPP=y``
+    - ``CONFIG_WPA_SUPP=y``
        ``CONFIG_NRF700X_AP_MODE=n``
        ``CONFIG_NRF700X_P2P_MODE=n``
-       ``CONFIG_NET_PKT_TX_COUNT=8``
-       ``CONFIG_NET_PKT_RX_COUNT=8``
-       ``CONFIG_NET_BUF_TX_COUNT=16``
-       ``CONFIG_NET_BUF_RX_COUNT=8``
-       ``CONFIG_NET_BUF_DATA_SIZE=128``
+       ``CONFIG_NET_PKT_TX_COUNT=6``
+       ``CONFIG_NET_PKT_RX_COUNT=6``
+       ``CONFIG_NET_BUF_TX_COUNT=12``
+       ``CONFIG_NET_BUF_RX_COUNT=6``
+       ``CONFIG_NRF700X_RX_NUM_BUFS=6``
+       ``CONFIG_NET_BUF_DATA_SIZE=800``
+       ``CONFIG_HEAP_MEM_POOL_SIZE=230000``
+       ``CONFIG_SPEED_OPTIMIZATIONS=y``
+       ``CONFIG_NRF700X_UTIL=n``
+       ``CONFIG_NRF700X_MAX_TX_AGGREGATION=1``
+       ``CONFIG_NRF700X_MAX_TX_TOKENS=5``
      - IoT devices
-     - ``TCP-TX: 1.5 Mbps``
-       ``TCP-RX: 1.5 Mbps``
-       ``UDP-TX: 1.5 Mbps``
-       ``UDP-RX: 1.5 Mbps``
+     - ``TCP-TX: 5.2 Mbps``
+       ``TCP-RX: 3.4 Mbps``
+       ``UDP-TX: 5.5 Mbps``
+       ``UDP-RX: 4.1 Mbps``
    * - :abbr:`STA (Station)` mode
      - Memory optimized :abbr:`STA (Station)` mode
      - ``CONFIG_NRF700X_MAX_TX_TOKENS=5``

--- a/doc/nrf/device_guides/working_with_nrf/nrf70/developing/constrained.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf70/developing/constrained.rst
@@ -165,26 +165,53 @@ The nRF70 Series driver can be used in the following profiles (not an exhaustive
      - Profile
      - Configuration Options
      - Use cases
+     - Throughputs
    * - STA scan only
      - Scan only
      - ``CONFIG_WPA_SUPP=n``
        ``CONFIG_NRF700X_AP_MODE=n``
        ``CONFIG_NRF700X_P2P_MODE=n``
+       ``CONFIG_NET_PKT_TX_COUNT=1``
+       ``CONFIG_NET_PKT_RX_COUNT=1``
+       ``CONFIG_NET_BUF_TX_COUNT=1``
+       ``CONFIG_NET_BUF_RX_COUNT=1``
      - Location services
+     - ``TCP-TX: 1.5 Mbps``
+       ``TCP-RX: 1.5 Mbps``
+       ``UDP-TX: 1.5 Mbps``
+       ``UDP-RX: 1.5 Mbps``
    * - :abbr:`STA (Station)` mode
      - IoT devices
      - ``CONFIG_WPA_SUPP=y``
        ``CONFIG_NRF700X_AP_MODE=n``
        ``CONFIG_NRF700X_P2P_MODE=n``
+       ``CONFIG_NET_PKT_TX_COUNT=8``
+       ``CONFIG_NET_PKT_RX_COUNT=8``
+       ``CONFIG_NET_BUF_TX_COUNT=16``
+       ``CONFIG_NET_BUF_RX_COUNT=8``
+       ``CONFIG_NET_BUF_DATA_SIZE=128``
      - IoT devices
+     - ``TCP-TX: 1.5 Mbps``
+       ``TCP-RX: 1.5 Mbps``
+       ``UDP-TX: 1.5 Mbps``
+       ``UDP-RX: 1.5 Mbps``
    * - :abbr:`STA (Station)` mode
      - Memory optimized :abbr:`STA (Station)` mode
      - ``CONFIG_NRF700X_MAX_TX_TOKENS=5``
        ``CONFIG_NRF700X_MAX_TX_AGGREGATION=1``
        ``CONFIG_NRF700X_RX_NUM_BUFS=4``
-       ``CONFIG_NRF700X_TX_MAX_DATA_SIZE=512``
-       ``CONFIG_NRF700X_RX_MAX_DATA_SIZE=512``
+       ``CONFIG_NRF700X_TX_MAX_DATA_SIZE=256``
+       ``CONFIG_NRF700X_RX_MAX_DATA_SIZE=256``
+       ``CONFIG_NET_PKT_TX_COUNT=4``
+       ``CONFIG_NET_PKT_RX_COUNT=4``
+       ``CONFIG_NET_BUF_TX_COUNT=8``
+       ``CONFIG_NET_BUF_RX_COUNT=4``
+       ``CONFIG_NET_BUF_DATA_SIZE=256``
      - Sensors with low data requirements
+     - ``TCP-TX: 1.5 Mbps``
+       ``TCP-RX: 1.5 Mbps``
+       ``UDP-TX: 1.5 Mbps``
+       ``UDP-RX: 1.5 Mbps``
    * - :abbr:`STA (Station)` mode
      - High performance :abbr:`STA (Station)` mode
      - ``CONFIG_NRF700X_MAX_TX_TOKENS=12``
@@ -192,7 +219,16 @@ The nRF70 Series driver can be used in the following profiles (not an exhaustive
        ``CONFIG_NRF700X_RX_NUM_BUFS=63``
        ``CONFIG_NRF700X_TX_MAX_DATA_SIZE=1600``
        ``CONFIG_NRF700X_RX_MAX_DATA_SIZE=1600``
+       ``CONFIG_NET_PKT_TX_COUNT=16``
+       ``CONFIG_NET_PKT_RX_COUNT=16``
+       ``CONFIG_NET_BUF_TX_COUNT=32``
+       ``CONFIG_NET_BUF_RX_COUNT=16``
+       ``CONFIG_NET_BUF_DATA_SIZE=1500``
      - High data rate IoT devices
+     - ``TCP-TX: 10 Mbps``
+       ``TCP-RX: 10 Mbps``
+       ``UDP-TX: 10 Mbps``
+       ``UDP-RX: 10 Mbps``
    * - :abbr:`STA (Station)` mode
      - TX prioritized :abbr:`STA (Station)` mode
      - ``CONFIG_NRF700X_MAX_TX_TOKENS=12``
@@ -200,11 +236,29 @@ The nRF70 Series driver can be used in the following profiles (not an exhaustive
        ``CONFIG_NRF700X_RX_NUM_BUFS=4``
        ``CONFIG_NRF700X_TX_MAX_DATA_SIZE=1600``
        ``CONFIG_NRF700X_RX_MAX_DATA_SIZE=512``
+       ``CONFIG_NET_PKT_TX_COUNT=32``
+       ``CONFIG_NET_PKT_RX_COUNT=4``
+       ``CONFIG_NET_BUF_TX_COUNT=64``
+       ``CONFIG_NET_BUF_RX_COUNT=4``
+       ``CONFIG_NET_BUF_DATA_SIZE=1500``
      - Sensors with high data rate
+     - ``TCP-TX: 8 Mbps``
+       ``TCP-RX: 1 Mbps``
+       ``UDP-TX: 10 Mbps``
+       ``UDP-RX: 2 Mbps``
    * - :abbr:`STA (Station)` mode
      - RX prioritized :abbr:`STA (Station)` mode
      - ``CONFIG_NRF700X_MAX_TX_TOKENS=5``
        ``CONFIG_NRF700X_RX_NUM_BUFS=63``
        ``CONFIG_NRF700X_TX_MAX_DATA_SIZE=512``
        ``CONFIG_NRF700X_RX_MAX_DATA_SIZE=1600``
+       ``CONFIG_NET_PKT_TX_COUNT=8``
+       ``CONFIG_NET_PKT_RX_COUNT=64``
+       ``CONFIG_NET_BUF_TX_COUNT=16``
+       ``CONFIG_NET_BUF_RX_COUNT=64``
+       ``CONFIG_NET_BUF_DATA_SIZE=1500``
      - Display devices streaming data
+     - ``TCP-TX: 4 Mbps``
+       ``TCP-RX: 7 Mbps``
+       ``UDP-TX: 1 Mbps``
+       ``UDP-RX: 10 Mbps``

--- a/doc/nrf/device_guides/working_with_nrf/nrf70/developing/constrained.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf70/developing/constrained.rst
@@ -244,21 +244,25 @@ The nRF70 Series driver can be used in the following profiles (not an exhaustive
        ``UDP-RX: 26.2 Mbps``
    * - :abbr:`STA (Station)` mode
      - TX prioritized :abbr:`STA (Station)` mode
-     - ``CONFIG_NRF700X_MAX_TX_TOKENS=12``
-       ``CONFIG_NRF700X_MAX_TX_AGGREGATION=9``
-       ``CONFIG_NRF700X_RX_NUM_BUFS=4``
-       ``CONFIG_NRF700X_TX_MAX_DATA_SIZE=1600``
-       ``CONFIG_NRF700X_RX_MAX_DATA_SIZE=512``
+     - ``CONFIG_WPA_SUPP=y``
+       ``CONFIG_NRF700X_AP_MODE=n``
+       ``CONFIG_NRF700X_P2P_MODE=n``
        ``CONFIG_NET_PKT_TX_COUNT=32``
-       ``CONFIG_NET_PKT_RX_COUNT=4``
+       ``CONFIG_NET_PKT_RX_COUNT=10``
        ``CONFIG_NET_BUF_TX_COUNT=64``
-       ``CONFIG_NET_BUF_RX_COUNT=4``
-       ``CONFIG_NET_BUF_DATA_SIZE=1500``
+       ``CONFIG_NET_BUF_RX_COUNT=10``
+       ``CONFIG_NET_BUF_TX_COUNT=64``
+       ``CONFIG_NET_BUF_DATA_SIZE=1100``
+       ``CONFIG_HEAP_MEM_POOL_SIZE=230000``
+       ``CONFIG_SPEED_OPTIMIZATIONS=y``
+       ``CONFIG_NRF700X_UTIL=n``
+       ``CONFIG_NRF700X_MAX_TX_AGGREGATION=9``
+       ``CONFIG_NRF700X_MAX_TX_TOKENS=12``
      - Sensors with high data rate
-     - ``TCP-TX: 8 Mbps``
-       ``TCP-RX: 1 Mbps``
-       ``UDP-TX: 10 Mbps``
-       ``UDP-RX: 2 Mbps``
+     - ``TCP-TX: 9.2  Mbps``
+       ``TCP-RX: 3.6  Mbps``
+       ``UDP-TX: 26.6 Mbps``
+       ``UDP-RX: 12.8 Mbps``
    * - :abbr:`STA (Station)` mode
      - RX prioritized :abbr:`STA (Station)` mode
      - ``CONFIG_NRF700X_MAX_TX_TOKENS=5``

--- a/doc/nrf/device_guides/working_with_nrf/nrf70/developing/constrained.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf70/developing/constrained.rst
@@ -182,7 +182,7 @@ The nRF70 Series driver can be used in the following profiles (not an exhaustive
        ``UDP-RX: 1.5 Mbps``
    * - :abbr:`STA (Station)` mode
      - IoT devices
-    - ``CONFIG_WPA_SUPP=y``
+     - ``CONFIG_WPA_SUPP=y``
        ``CONFIG_NRF700X_AP_MODE=n``
        ``CONFIG_NRF700X_P2P_MODE=n``
        ``CONFIG_NET_PKT_TX_COUNT=6``
@@ -203,21 +203,25 @@ The nRF70 Series driver can be used in the following profiles (not an exhaustive
        ``UDP-RX: 4.1 Mbps``
    * - :abbr:`STA (Station)` mode
      - Memory optimized :abbr:`STA (Station)` mode
-     - ``CONFIG_NRF700X_MAX_TX_TOKENS=5``
+     - ``CONFIG_WPA_SUPP=y``
+       ``CONFIG_NRF700X_AP_MODE=n``
+       ``CONFIG_NRF700X_P2P_MODE=n``
+       ``CONFIG_NET_PKT_TX_COUNT=6``
+       ``CONFIG_NET_PKT_RX_COUNT=6``
+       ``CONFIG_NET_BUF_TX_COUNT=12``
+       ``CONFIG_NET_BUF_RX_COUNT=6``
+       ``CONFIG_NRF700X_RX_NUM_BUFS=6``
+       ``CONFIG_NET_BUF_DATA_SIZE=500``
+       ``CONFIG_HEAP_MEM_POOL_SIZE=230000``
+       ``CONFIG_SPEED_OPTIMIZATIONS=y``
+       ``CONFIG_NRF700X_UTIL=n``
        ``CONFIG_NRF700X_MAX_TX_AGGREGATION=1``
-       ``CONFIG_NRF700X_RX_NUM_BUFS=4``
-       ``CONFIG_NRF700X_TX_MAX_DATA_SIZE=256``
-       ``CONFIG_NRF700X_RX_MAX_DATA_SIZE=256``
-       ``CONFIG_NET_PKT_TX_COUNT=4``
-       ``CONFIG_NET_PKT_RX_COUNT=4``
-       ``CONFIG_NET_BUF_TX_COUNT=8``
-       ``CONFIG_NET_BUF_RX_COUNT=4``
-       ``CONFIG_NET_BUF_DATA_SIZE=256``
+       ``CONFIG_NRF700X_MAX_TX_TOKENS=5``
      - Sensors with low data requirements
-     - ``TCP-TX: 1.5 Mbps``
+     - ``TCP-TX: 0.3 Mbps``
        ``TCP-RX: 1.5 Mbps``
-       ``UDP-TX: 1.5 Mbps``
-       ``UDP-RX: 1.5 Mbps``
+       ``UDP-TX: 5.1 Mbps``
+       ``UDP-RX: 0.5 Mbps``
    * - :abbr:`STA (Station)` mode
      - High performance :abbr:`STA (Station)` mode
      - ``CONFIG_NRF700X_MAX_TX_TOKENS=12``


### PR DESCRIPTION
Extend the usage profiles to include recommended network buffer configuration and expected throughput. The throughputs are dummy, need to be updated once we run tests with the configuration.