### PR TITLE
NFC platform hardfault fix

### DIFF
--- a/doc/nrf/releases_and_maturity/known_issues.rst
+++ b/doc/nrf/releases_and_maturity/known_issues.rst
@@ -2596,6 +2596,17 @@ Problems with RTT Viewer/Logger
   **Workaround:** Set the RTT Control Block address to 0 and it will try to search from address 0 and upwards.
   If this does not work, look in the :file:`builddir/zephyr/zephyr.map` file to find the address of the ``_SEGGER_RTT`` symbol in the map file and use that as input to the viewer/logger.
 
+NFC
+===
+
+.. rst-class:: v2-4-1 v2-4-0 v2-3-0
+
+NCSDK-22799: Assert when requesting clock from the NFC interrupt context.
+  The NFC interrupt is a low latency interrupt.
+  It calls the Zephyr subsystem API that can rarely cause undefined behavior.
+
+  **Workaround** To fix the issue, disable the :kconfig:option:`CONFIG_NFC_ZERO_LATENCY_IRQ` Kconfig option.
+
 MCUboot
 *******
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -713,6 +713,9 @@ Libraries for NFC
   * Fixed the potential issue where the NFC interrupt context switching could loose interrupts data.
     This could happen if interrupts would be executed much faster than the NFC workqueue or thread.
 
+  * Fixed an issue where an assertion could be triggered when requesting clock from the NFC platform interrupt context.
+    The NFC interrupt is no longer a zero latency interrupt.
+
 * :ref:`nfc_t4t_isodep_readme` library:
 
   * Fixed the ISO-DEP error recovery process in case where the R(ACK) frame is received in response to the R(NAK) frame from the poller device.

--- a/subsys/nfc/lib/Kconfig
+++ b/subsys/nfc/lib/Kconfig
@@ -80,15 +80,14 @@ config NFC_THREAD_PRIORITY
 
 endif# NFC_OWN_THREAD
 
-config NFC_ZERO_LATENCY_IRQ
-	bool "Use Zero Latency IRQ for NFC"
+config NFC_LOW_LATENCY_IRQ
+	bool "Use low latency IRQ for NFC"
 	default y
-	select ZERO_LATENCY_IRQS
 	help
 	  Using this option ensures fast NFC interrupt
 	  execution on the cost of using additional interrupt (SWI).
 
-if NFC_ZERO_LATENCY_IRQ
+if NFC_LOW_LATENCY_IRQ
 
 config NFC_SWI_NUMBER
 	int

--- a/subsys/nfc/lib/platform.c
+++ b/subsys/nfc/lib/platform.c
@@ -28,12 +28,6 @@ LOG_MODULE_REGISTER(nfc_platform, CONFIG_NFC_PLATFORM_LOG_LEVEL);
 
 #define DT_DRV_COMPAT nordic_nrf_clock
 
-#ifdef CONFIG_NFC_ZERO_LATENCY_IRQ
-#define NFCT_IRQ_FLAGS	IRQ_ZERO_LATENCY
-#else
-#define NFCT_IRQ_FLAGS	0
-#endif /* CONFIG_NFC_ZERO_LATENCY_IRQ */
-
 static struct onoff_manager *hf_mgr;
 static struct onoff_client cli;
 
@@ -63,7 +57,7 @@ nrfx_err_t nfc_platform_setup(nfc_lib_cb_resolve_t nfc_lib_cb_resolve)
 	__ASSERT_NO_MSG(hf_mgr);
 
 	IRQ_DIRECT_CONNECT(NFCT_IRQn, CONFIG_NFCT_IRQ_PRIORITY,
-			   nfc_isr_wrapper, NFCT_IRQ_FLAGS);
+			   nfc_isr_wrapper, 0);
 	IRQ_CONNECT(NFC_TIMER_IRQn, CONFIG_NFCT_IRQ_PRIORITY,
 		    nfc_timer_irq_handler, NULL,  0);
 

--- a/subsys/nfc/lib/platform_internal_thread.c
+++ b/subsys/nfc/lib/platform_internal_thread.c
@@ -11,7 +11,7 @@
 
 LOG_MODULE_DECLARE(nfc_platform, CONFIG_NFC_PLATFORM_LOG_LEVEL);
 
-#ifdef CONFIG_NFC_ZERO_LATENCY_IRQ
+#ifdef CONFIG_NFC_LOW_LATENCY_IRQ
 #define SWI_NAME(number)	SWI_NAME2(number)
 #ifdef CONFIG_SOC_SERIES_NRF53X
 #define SWI_NAME2(number)	EGU ## number ## _IRQn
@@ -20,7 +20,7 @@ LOG_MODULE_DECLARE(nfc_platform, CONFIG_NFC_PLATFORM_LOG_LEVEL);
 #endif
 
 #define NFC_SWI_IRQN		SWI_NAME(CONFIG_NFC_SWI_NUMBER)
-#endif /* CONFIG_NFC_ZERO_LATENCY_IRQ */
+#endif /* CONFIG_NFC_LOW_LATENCY_IRQ */
 
 #define NFC_LIB_CTX_SIZE CONFIG_NFC_LIB_CTX_MAX_SIZE
 
@@ -185,7 +185,7 @@ static void schedule_callback(void)
 #endif /* CONFIG_NFC_OWN_THREAD */
 }
 
-#ifdef CONFIG_NFC_ZERO_LATENCY_IRQ
+#ifdef CONFIG_NFC_LOW_LATENCY_IRQ
 ISR_DIRECT_DECLARE(nfc_swi_handler)
 {
 	schedule_callback();
@@ -194,7 +194,7 @@ ISR_DIRECT_DECLARE(nfc_swi_handler)
 
 	return 1;
 }
-#endif /* CONFIG_NFC_ZERO_LATENCY_IRQ */
+#endif /* CONFIG_NFC_LOW_LATENCY_IRQ */
 
 int nfc_platform_internal_init(nfc_lib_cb_resolve_t cb_rslv)
 {
@@ -202,11 +202,11 @@ int nfc_platform_internal_init(nfc_lib_cb_resolve_t cb_rslv)
 		return -EINVAL;
 	}
 
-#ifdef CONFIG_NFC_ZERO_LATENCY_IRQ
+#ifdef CONFIG_NFC_LOW_LATENCY_IRQ
 	IRQ_DIRECT_CONNECT(NFC_SWI_IRQN, CONFIG_NFCT_IRQ_PRIORITY,
 			   nfc_swi_handler, 0);
 	irq_enable(NFC_SWI_IRQN);
-#endif /* CONFIG_NFC_ZERO_LATENCY_IRQ */
+#endif /* CONFIG_NFC_LOW_LATENCY_IRQ */
 
 	nfc_cb_resolve = cb_rslv;
 	buf_full = false;
@@ -253,9 +253,9 @@ void nfc_platform_cb_request(const void *ctx,
 	}
 
 end:
-#ifdef CONFIG_NFC_ZERO_LATENCY_IRQ
+#ifdef CONFIG_NFC_LOW_LATENCY_IRQ
 	NVIC_SetPendingIRQ(NFC_SWI_IRQN);
 #else
 	schedule_callback();
-#endif /* CONFIG_NFC_ZERO_LATENCY_IRQ */
+#endif /* CONFIG_NFC_LOW_LATENCY_IRQ */
 }


### PR DESCRIPTION
Fixed the issue where an assertion could be triggered when requesting clock from the NFC platform interrupt context.