### PR TITLE
doc: nrf_provisioning: Add documentation for CoAP

### DIFF
--- a/doc/nrf/libraries/networking/nrf_provisioning.rst
+++ b/doc/nrf/libraries/networking/nrf_provisioning.rst
@@ -14,6 +14,7 @@ The current implementation supports the following technologies:
 * AT-command based provisioning commands
 * Writing key-value pair based settings to the :ref:`settings_api` storage
 * TLS-secured HTTP as the communication protocol
+* DTLS-secured CoAP as the communication protocol
 * Client authentication with attestation token
 * Client authentication with JWT token
 * CBOR as the data format
@@ -23,20 +24,30 @@ Configuration
 
 To enable the library, set the :kconfig:option:`CONFIG_NRF_PROVISIONING` Kconfig option to ``y``.
 
-Configuration options for transport protocol
-============================================
-
-Currently, HTTP is the only supported transport protocol.
-
-* :kconfig:option:`CONFIG_NRF_PROVISIONING_SYS_INIT` - Initializes the client in the system initialization phase
+* :kconfig:option:`CONFIG_NRF_PROVISIONING_AUTO_INIT` - Initializes the client in the system initialization phase
 * :kconfig:option:`CONFIG_NRF_PROVISIONING_ROOT_CA_SEC_TAG` - Root CA security tag for the Provisioning Service
-* :kconfig:option:`CONFIG_NRF_PROVISIONING_HTTP_HOSTNAME` - HTTP API hostname for the Provisioning Service
+* :kconfig:option:`CONFIG_NRF_PROVISIONING_INTERVAL_S` - Maximum provisioning interval, in seconds
+* :kconfig:option:`CONFIG_NRF_PROVISIONING_WITH_CERT` - Provisions the root CA certificate to the security tag if the tag is empty
+* :kconfig:option:`CONFIG_NRF_PROVISIONING_JWT` - Chooses JWT for client authentication
+* :kconfig:option:`CONFIG_NRF_PROVISIONING_ATTESTTOKEN` - Chooses identity attestation token for client authentication
+* :kconfig:option:`CONFIG_NRF_PROVISIONING_RX_BUF_SZ` - Response buffer size
+* :kconfig:option:`CONFIG_NRF_PROVISIONING_TX_BUF_SZ` - Request buffer size
+* :kconfig:option:`CONFIG_NRF_PROVISIONING_SHELL` - Enables shell module, which allows you to control the client over UART
+* :kconfig:option:`CONFIG_NRF_PROVISIONING_SETTINGS_STORAGE_PATH` - Sets the path for provisioning settings storage
+
+Configuration options for HTTP
+==============================
+
+* :kconfig:option:`CONFIG_NRF_PROVISIONING_HTTP_HOSTNAME` - HTTP API hostname for the Provisioning Service, default ``provisioning-http.nrfcloud.com``
 * :kconfig:option:`CONFIG_NRF_PROVISIONING_HTTP_PORT` - Port number for the Provisioning Service
 * :kconfig:option:`CONFIG_NRF_PROVISIONING_HTTP_TIMEOUT_MS` - Timeout in milliseconds for HTTP connection of the Provisioning Service
-* :kconfig:option:`CONFIG_NRF_PROVISIONING_HTTP_RX_BUF_SZ` - HTTP response payload buffer size
-* :kconfig:option:`CONFIG_NRF_PROVISIONING_HTTP_TX_BUF_SZ` - HTTP request body size
-* :kconfig:option:`CONFIG_NRF_PROVISIONING_HTTP_JWT` - Chooses JWT token for client authentication
-* :kconfig:option:`CONFIG_NRF_PROVISIONING_HTTP_ATTESTTOKEN` - Chooses attestation token for client authentication
+
+Configuration options for CoAP
+==============================
+
+* :kconfig:option:`CONFIG_NRF_PROVISIONING_COAP_HOSTNAME` - CoAP API hostname for the Provisioning Service, default ``coap.nrfcloud.com``
+* :kconfig:option:`CONFIG_NRF_PROVISIONING_COAP_PORT` - Port number for the Provisioning Service
+* :kconfig:option:`CONFIG_NRF_PROVISIONING_COAP_DTLS_SESSION_CACHE` - Chooses DTLS session cache
 
 .. _lib_nrf_provisioning_start:
 
@@ -152,6 +163,25 @@ The feature is enabled by selecting :kconfig:option:`CONFIG_NRF_PROVISIONING_SHE
      now    :Do provisioning now
      token  :Get the attestation token
      uuid   :Get device UUID
+
+Dependencies
+************
+
+This library uses the following |NCS| libraries:
+
+* :ref:`lte_lc_readme`
+* :ref:`modem_info_readme`
+* :ref:`modem_key_mgmt`
+* :ref:`lib_rest_client`
+
+It uses the following `sdk-nrfxlib`_ library:
+
+* :ref:`nrfxlib:nrf_modem`
+
+It uses the following Zephyr libraries:
+
+* :ref:`CoAP <zephyr:networking_api>`
+* :ref:`CoAP Client <zephyr:coap_client_interface>`
 
 .. _nrf_provisioning_api:
 

--- a/samples/cellular/nrf_provisioning/README.rst
+++ b/samples/cellular/nrf_provisioning/README.rst
@@ -61,30 +61,72 @@ CONFIG_NRF_PROVISIONING_ROOT_CA_SEC_TAG
    Root CA security tag for the nRF Cloud Provisioning Service.
    Needs to be set explicitly and if not, the compilation fails.
 
+.. _CONFIG_RF_PROVISIONING_RX_BUF_S:
+
+CONFIG_RF_PROVISIONING_RX_BUF_S
+   Configures the response payload buffer size.
+
+.. _CONFIG_NRF_PROVISIONING_TX_BUF_SZ:
+
+CONFIG_NRF_PROVISIONING_TX_BUF_SZ
+   Configures the command request buffer size.
+
+.. _CONFIG_NRF_PROVISIONING_ATTESTTOKEN:
+
+CONFIG_NRF_PROVISIONING_ATTESTTOKEN
+   Configures attestation token for client authentication.
+
+.. _CONFIG_NRF_PROVISIONING_JWT:
+
+CONFIG_NRF_PROVISIONING_JWT
+   Configures JWT for client authentication.
+
+HTTP options
+------------
+
 .. _CONFIG_NRF_PROVISIONING_HTTP_HOSTNAME:
 
 CONFIG_NRF_PROVISIONING_HTTP_HOSTNAME
-   Configures the hostname of the nRF Device provisioning service.
+   Configures the hostname of the nRF Cloud Provisioning Service.
 
 .. _CONFIG_NRF_PROVISIONING_HTTP_PORT:
 
 CONFIG_NRF_PROVISIONING_HTTP_PORT
-   Configures the HTTP port of the nRF Device provisioning service.
+   Configures the HTTP port of the nRF Cloud Provisioning Service.
 
 .. _CONFIG_NRF_PROVISIONING_HTTP_TIMEOUT_MS:
 
 CONFIG_NRF_PROVISIONING_HTTP_TIMEOUT_MS
    Configures the HTTP timeout.
 
-.. _CONFIG_RF_PROVISIONING_HTTP_RX_BUF_S:
+CoAP options
+------------
 
-CONFIG_RF_PROVISIONING_HTTP_RX_BUF_S
-   Configures the response payload buffer size.
+.. _CONFIG_NRF_PROVISIONING_COAP_HOSTNAME:
 
-.. _CONFIG_NRF_PROVISIONING_HTTP_TX_BUF_SZ:
+CONFIG_NRF_PROVISIONING_COAP_HOSTNAME
+   Configures the hostname of the nRF Cloud Provisioning Service.
 
-CONFIG_NRF_PROVISIONING_HTTP_TX_BUF_SZ
-   Configures the command request body size.
+.. _CONFIG_NRF_PROVISIONING_COAP_PORT:
+
+CONFIG_NRF_PROVISIONING_COAP_PORT
+   Configures the CoAP port of the nRF Cloud Provisioning Service.
+
+.. _CONFIG_NRF_PROVISIONING_COAP_DTLS_SESSION_CACHE:
+
+CONFIG_NRF_PROVISIONING_COAP_DTLS_SESSION_CACHE
+   Enables DTLS session cache.
+
+Configuration files
+===================
+
+The sample provides predefined configuration files for typical use cases.
+
+The following files are available:
+
+* :file:`prj.conf` - Standard default configuration file.
+* :file:`overlay-coap.conf` - Enables CoAP transfer protocol support.
+* :file:`overlay-jwt.conf` - Enables authentication with JWT.
 
 Building and running
 ********************
@@ -114,6 +156,7 @@ The following is an example output of the sample when there is no provisioning c
 .. code-block:: console
 
 	<inf> nrf_provisioning_sample: Establishing LTE link ...
+	<inf> nrf_provisioning_http: Requesting commands
 	<inf> nrf_provisioning_http: Connected
 	<inf> nrf_provisioning_http: No more commands to process on server side
 
@@ -122,12 +165,16 @@ The following is an example output when the sample is processing commands from t
 .. code-block:: console
 
 	<inf> nrf_provisioning_sample: Establishing LTE link ...
+	<inf> nrf_provisioning_http: Requesting commands
 	<inf> nrf_provisioning_http: Connected
+	<inf> nrf_provisioning_http: Processing commands
 	<inf> nrf_provisioning: Disconnected from network - provisioning paused
 	<inf> nrf_provisioning: Connected; home network - provisioning resumed
 	<inf> nrf_provisioning_sample: Modem connection restored
 	<inf> nrf_provisioning_sample: Waiting for modem to acquire network time...
 	<inf> nrf_provisioning_sample: Network time obtained
+	<inf> nrf_provisioning_http: Sending response to server
+	<inf> nrf_provisioning_http: Requesting commands
 	<inf> nrf_provisioning_http: Connected
 	<inf> nrf_provisioning_http: No more commands to process on server side
 
@@ -137,5 +184,8 @@ Dependencies
 This sample uses the following |NCS| libraries:
 
 * :ref:`lte_lc_readme`
-* :ref:`modem_info_readme`
 * :ref:`lib_nrf_provisioning`
+
+It uses the following `sdk-nrfxlib`_ library:
+
+* :ref:`nrfxlib:nrf_modem`


### PR DESCRIPTION
Add documentation about CoAP configuration.
Add information about Kconfig options and configuration files.