### PR TITLE
doc: add mention of nRF Cloud Multi-service sample to CoAP library

### DIFF
--- a/doc/nrf/libraries/networking/nrf_cloud_coap.rst
+++ b/doc/nrf/libraries/networking/nrf_cloud_coap.rst
@@ -97,6 +97,7 @@ Samples using the library
 The following |NCS| samples use this library:
 
 * :ref:`modem_shell_application`
+* :ref:`nrf_cloud_multi_service`
 
 Limitations
 ***********


### PR DESCRIPTION
Adds the nRF Cloud multi-service library to the Samples using the library section of the nRF Cloud CoAP library.