### PR TITLE
manifest: update sdk-connectedhomeip to enable minimal shell

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -147,7 +147,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 1e209c93fd43fd4eb313eec4285a36cb577800c4
+      revision: 8397def72f8a95f95612cab659eb226419311e49
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
Enable minimal shell configuration to save some ROM and RAM.