### PR TITLE
drivers: wifi: Optimize the memory consumed by logs

### DIFF
--- a/drivers/wifi/nrf700x/Kconfig
+++ b/drivers/wifi/nrf700x/Kconfig
@@ -70,6 +70,22 @@ config NRF700X_REG_DOMAIN
 config NET_MGMT_EVENT_STACK_SIZE
 	default 2048 if !WPA_SUPP
 
+config NRF700X_LOG_VERBOSE
+	bool "Maintains the verbosity of information in logs"
+
+module = WIFI_NRF700X
+module-dep = LOG
+module-str = Log level for Wi-Fi nRF700x driver
+module-help = Sets log level for Wi-Fi nRF700x driver
+source "subsys/logging/Kconfig.template.log_config"
+
+config NRF700X_LOG_LEVEL
+	int "Sets the log level of Wi-Fi driver"
+	default 0 if WIFI_NRF700X_LOG_LEVEL_DBG # MSG_EXCESSIVE
+	default 3 if WIFI_NRF700X_LOG_LEVEL_INF # MSG_INFO
+	default 5 if WIFI_NRF700X_LOG_LEVEL_ERR # MSG_ERROR
+	default 6
+
 config NRF700X_ON_QSPI
 	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF700X_QSPI))
 	select NRFX_QSPI

--- a/drivers/wifi/nrf700x/osal/os_if/inc/osal_api.h
+++ b/drivers/wifi/nrf700x/osal/os_if/inc/osal_api.h
@@ -15,6 +15,9 @@
 #include <stdarg.h>
 #include "osal_structs.h"
 
+#ifndef CONFIG_NRF700X_LOG_VERBOSE
+#define __func__ ""
+#endif /* CONFIG_NRF700X_LOG_VERBOSE */
 /**
  * wifi_nrf_osal_init() - Initialize the OSAL layer.
  *
@@ -314,6 +317,9 @@ void wifi_nrf_osal_spinlock_irq_rel(struct wifi_nrf_osal_priv *opriv,
 				     unsigned long *flags);
 
 
+#if CONFIG_NRF700X_LOG_LEVEL  > 0
+#define wifi_nrf_osal_log_dbg(level, fmt, ...)
+#else
 /**
  * wifi_nrf_osal_log_dbg() - Log a debug message.
  * @opriv: Pointer to the OSAL context returned by the @wifi_nrf_osal_init API.
@@ -326,8 +332,12 @@ void wifi_nrf_osal_spinlock_irq_rel(struct wifi_nrf_osal_priv *opriv,
  */
 int wifi_nrf_osal_log_dbg(struct wifi_nrf_osal_priv *opriv,
 			   const char *fmt, ...);
+#endif
 
 
+#if CONFIG_NRF700X_LOG_LEVEL > 3
+#define wifi_nrf_osal_log_info(level, fmt, ...)
+#else
 /**
  * wifi_nrf_osal_log_info() - Log a informational message.
  * @opriv: Pointer to the OSAL context returned by the @wifi_nrf_osal_init API.
@@ -340,8 +350,12 @@ int wifi_nrf_osal_log_dbg(struct wifi_nrf_osal_priv *opriv,
  */
 int wifi_nrf_osal_log_info(struct wifi_nrf_osal_priv *opriv,
 			    const char *fmt, ...);
+#endif
 
 
+#if CONFIG_NRF700X_LOG_LEVEL > 5
+#define wifi_nrf_osal_log_err(level, fmt, ...)
+#else  /* > 5 */
 /**
  * wifi_nrf_osal_log_err() - Logs an error message.
  * @opriv: Pointer to the OSAL context returned by the @wifi_nrf_osal_init API.
@@ -354,6 +368,7 @@ int wifi_nrf_osal_log_info(struct wifi_nrf_osal_priv *opriv,
  */
 int wifi_nrf_osal_log_err(struct wifi_nrf_osal_priv *opriv,
 			   const char *fmt, ...);
+#endif
 
 
 /**

--- a/drivers/wifi/nrf700x/osal/os_if/src/osal.c
+++ b/drivers/wifi/nrf700x/osal/os_if/src/osal.c
@@ -189,6 +189,7 @@ void wifi_nrf_osal_spinlock_irq_rel(struct wifi_nrf_osal_priv *opriv,
 }
 
 
+#if CONFIG_NRF700X_LOG_LEVEL < 1
 int wifi_nrf_osal_log_dbg(struct wifi_nrf_osal_priv *opriv,
 			  const char *fmt,
 			  ...)
@@ -204,8 +205,10 @@ int wifi_nrf_osal_log_dbg(struct wifi_nrf_osal_priv *opriv,
 
 	return ret;
 }
+#endif /* CONFIG_NRF700X_LOG_LEVEL < 1 */
 
 
+#if CONFIG_NRF700X_LOG_LEVEL <= 3
 int wifi_nrf_osal_log_info(struct wifi_nrf_osal_priv *opriv,
 			   const char *fmt,
 			   ...)
@@ -221,8 +224,10 @@ int wifi_nrf_osal_log_info(struct wifi_nrf_osal_priv *opriv,
 
 	return ret;
 }
+#endif /* CONFIG_NRF700X_LOG_LEVEL <=3 */
 
 
+#if CONFIG_NRF700X_LOG_LEVEL <= 5
 int wifi_nrf_osal_log_err(struct wifi_nrf_osal_priv *opriv,
 			  const char *fmt,
 			  ...)
@@ -238,6 +243,7 @@ int wifi_nrf_osal_log_err(struct wifi_nrf_osal_priv *opriv,
 
 	return ret;
 }
+#endif /* CONFIG_NRF700X_LOG_LEVEL <=5 */
 
 
 void *wifi_nrf_osal_llist_node_alloc(struct wifi_nrf_osal_priv *opriv)

--- a/west.yml
+++ b/west.yml
@@ -109,7 +109,7 @@ manifest:
     - name: hostap
       repo-path: sdk-hostap
       path: modules/lib/hostap
-      revision: 44c4504d1549ab0f6dda503050ad5ca2654d0f91
+      revision: 8b0abe8f10ef14b25a97972da46aee8ee5aef63a
       userdata:
         ncs:
           upstream-url: https://w1.fi/cgit/hostap/


### PR DESCRIPTION
Limit the information displayed in logging (function, line etc.). Disable printing of debug message by default.