### PR TITLE
manifest: sdk-zephyr: MCUmgr img client upload fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 582837b2010d033344cb524f0e95f8de86c62d03
+      revision: 00c27fe11656f31fbed5873bb4bd2ce6f0cc477a
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Fix Image upload without MCUBoot recovery mode.