### PR TITLE
samples: net: azure_iot_hub: add nRF9161DK support

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -470,6 +470,7 @@ Networking samples
 * :ref:`azure_iot_hub` sample:
 
   * Added support for Wi-Fi and LTE connectivity through the connection manager API.
+  * Added support for the nRF9161 development kit.
   * Moved the sample from :file:`nrf9160/azure_iot_hub` folder to :file:`net/azure_iot_hub`.
     The documentation is now found in the :ref:`networking_samples` section.
 

--- a/samples/net/azure_iot_hub/boards/nrf9161dk_nrf9161_ns.conf
+++ b/samples/net/azure_iot_hub/boards/nrf9161dk_nrf9161_ns.conf
@@ -1,0 +1,36 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# LibC
+CONFIG_NEWLIB_LIBC=n
+CONFIG_NEWLIB_LIBC_FLOAT_PRINTF=n
+CONFIG_PICOLIBC=y
+
+# Heap and stacks
+CONFIG_HEAP_MEM_POOL_SIZE=4096
+CONFIG_MAIN_STACK_SIZE=4096
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
+
+# LED control
+CONFIG_DK_LIBRARY=y
+
+# Disable Duplicate Address Detection (DAD)
+# due to not being properly implemented for offloaded interfaces.
+CONFIG_NET_IPV6_NBR_CACHE=n
+CONFIG_NET_IPV6_MLD=n
+
+# Connection Manager and Connectivity layer
+CONFIG_LTE_CONNECTIVITY=y
+CONFIG_NET_CONNECTION_MANAGER_STACK_SIZE=2048
+CONFIG_NRF_MODEM_LIB_ON_FAULT_APPLICATION_SPECIFIC=y
+
+# Turn off automatic behavior to give more control to the application
+CONFIG_NRF_MODEM_LIB_NET_IF_AUTO_START=n
+CONFIG_LTE_CONNECTIVITY_AUTO_DOWN=n
+
+# AT Host
+CONFIG_UART_INTERRUPT_DRIVEN=y
+CONFIG_AT_HOST_LIBRARY=y

--- a/samples/net/azure_iot_hub/sample.yaml
+++ b/samples/net/azure_iot_hub/sample.yaml
@@ -5,7 +5,8 @@ tests:
     build_only: true
     integration_platforms:
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
+      - nrf9161dk_nrf9161_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     tags: ci_build
   sample.net.azure_iot_hub.wifi:
     build_only: true
@@ -20,7 +21,8 @@ tests:
     build_only: true
     integration_platforms:
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
+      - nrf9161dk_nrf9161_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     extra_args: OVERLAY_CONFIG=overlay-dps.conf
     extra_configs:
       - CONFIG_AZURE_IOT_HUB_DPS_ID_SCOPE="test-scope"


### PR DESCRIPTION
Add nRF9161DK support to azure_iot_hub sample.