### PR TITLE
application: matter: Repair Matter Weather Station release build

### DIFF
--- a/applications/matter_weather_station/sample.yaml
+++ b/applications/matter_weather_station/sample.yaml
@@ -21,7 +21,7 @@ tests:
       - thingy53_nrf5340_cpuapp
   applications.matter_weather_station.release:
     build_only: true
-    extra_args: OVERLAY_CONFIG=overlay-factory_data.conf CONF_FILE=release.conf
+    extra_args: OVERLAY_CONFIG=overlay-factory_data.conf CONF_FILE=prj_release.conf
     platform_allow: thingy53_nrf5340_cpuapp
     platform_exclude: thingy53_nrf5340_cpuapp_ns
     integration_platforms:


### PR DESCRIPTION
There is a mistake regarding the Matter Weather Station Twister build due to a spelling mistake.