### PR TITLE
net: lib: nrf_cloud: add kconfig opts for Wi-Fi location req encoding

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -643,12 +643,14 @@ Libraries for networking
     * Support for CoAP CBOR type handling to nrf_cloud_obj.
     * Warning message discouraging use of :kconfig:option:`CONFIG_NRF_CLOUD_PROVISION_CERTIFICATES` for purposes other than testing.
     * Reporting of protocol (MQTT, REST, or CoAP) as well as method (LTE or Wi-Fi) to the device shadow.
+    * Kconfig choice :kconfig:option:`NRF_CLOUD_WIFI_LOCATION_ENCODE_OPT` for selecting the data that is encoded in Wi-Fi location requests.
 
   * Updated:
 
     * Moved JSON manipulation from :file:`nrf_cloud_fota.c` to :file:`nrf_cloud_codec_internal.c`.
     * :c:func:`nrf_cloud_obj_location_request_create` to use the new function :c:func:`nrf_cloud_obj_location_request_payload_add`.
     * Retry handling for P-GPS data download errors to retry ``ECONNREFUSED`` errors.
+    * By default, Wi-Fi location requests include only the MAC address and RSSI value.
 
   * Fixed:
 

--- a/subsys/net/lib/nrf_cloud/Kconfig
+++ b/subsys/net/lib/nrf_cloud/Kconfig
@@ -74,6 +74,27 @@ config NRF_CLOUD_DEVICE_STATUS_ENCODE_VOLTAGE
 	depends on MODEM_INFO_ADD_DEVICE
 	default y
 
+choice NRF_CLOUD_WIFI_LOCATION_ENCODE_OPT
+	prompt "Encoding options for Wi-Fi location requests"
+	default NRF_CLOUD_WIFI_LOCATION_ENCODE_OPT_MAC_RSSI
+
+config NRF_CLOUD_WIFI_LOCATION_ENCODE_OPT_MAC_ONLY
+	bool "Encode only the MAC address"
+	help
+		The MAC address is the only required parameter.
+
+config NRF_CLOUD_WIFI_LOCATION_ENCODE_OPT_MAC_RSSI
+	bool "Encode the MAC address and the RSSI value"
+	help
+		The RSSI value may improve location accuracy.
+
+config NRF_CLOUD_WIFI_LOCATION_ENCODE_OPT_ALL
+	bool "Encode all available parameters"
+	help
+		This option increases the memory required for creating requests.
+		It also increases the amount of data sent to nRF Cloud.
+endchoice
+
 endif
 
 if NRF_CLOUD_AGPS || NRF_CLOUD_PGPS


### PR DESCRIPTION
Add Kconfig choice `NRF_CLOUD_WIFI_LOCATION_ENCODE_OPT` to control the data included in Wi-Fi location requests.
By default, requests now include only the MAC and RSSI. IRIS-6815