### PR TITLE
tools: toolchain_checksum to be identical on unix and windows

### DIFF
--- a/scripts/print_toolchain_checksum.sh
+++ b/scripts/print_toolchain_checksum.sh
@@ -3,6 +3,6 @@
 BASEDIR=$(dirname "$0")
 REQUIREMENTS=$BASEDIR/requirements-fixed.txt
 TOOLS_VERSIONS=$BASEDIR/tools-versions-linux.yml
-TOOLCHAIN_VERSION=$(cat $REQUIREMENTS $TOOLS_VERSIONS | sha256sum | head -c 10)
+TOOLCHAIN_VERSION=$(cat $REQUIREMENTS $TOOLS_VERSIONS | tr -d '\r' | sha256sum | head -c 10)
 
 echo "${TOOLCHAIN_VERSION}"


### PR DESCRIPTION
Fixes an issue where the toolchain_checksum script returned different values depending on if the files were stored with unix or windows line endings.

Solved by always removing carriage return characters before computing the sha256sum.