### PR TITLE
samples: nrf_cloud_multi_service: Wi-Fi scan config

### DIFF
--- a/samples/cellular/nrf_cloud_multi_service/overlay_nrf7002ek_wifi_no_lte.conf
+++ b/samples/cellular/nrf_cloud_multi_service/overlay_nrf7002ek_wifi_no_lte.conf
@@ -98,7 +98,7 @@ CONFIG_LOCATION_METHOD_WIFI=y
 # We set this to 30 in this overlay (as opposed to 60 in the wifi-scan-only overlay) so that
 # CONFIG_HEAP_MEM_POOL_SIZE can be small enough to leave at least 24kB of unused RAM in the final
 # build, which is required by WPA_supp
-CONFIG_NRF700X_SCAN_LIMIT=30
+CONFIG_WIFI_MGMT_SCAN_MAX_BSS_CNT=30
 CONFIG_LOCATION_METHOD_WIFI_SCANNING_RESULTS_MAX_CNT=30
 
 ## Enable shell and WIFI_CREDENTIALS shell
@@ -120,7 +120,7 @@ CONFIG_NET_RX_STACK_SIZE=2048
 CONFIG_POSIX_MAX_FDS=16
 CONFIG_NET_SOCKETS_POLL_MAX=8
 # Heap allocation should be changed when CONFIG_LOCATION_METHOD_WIFI_SCANNING_RESULTS_MAX_CNT
-# and CONFIG_NRF700X_SCAN_LIMIT (which should be the same value) are changed. With the limit at 30,
+# and CONFIG_WIFI_MGMT_SCAN_MAX_BSS_CNT (which should be the same value) are changed. With the limit at 30,
 # this could be set as low as 130000. Add 256 bytes for each additional scanning result, assuming
 # sane SSID lengths. We set the heap much higher in case of long SSIDs.
 CONFIG_HEAP_MEM_POOL_SIZE=130000


### PR DESCRIPTION
CONFIG_NRF700X_SCAN_LIMIT has been removed in PR #12008. 
Replace with CONFIG_WIFI_MGMT_SCAN_MAX_BSS_CNT.