### PR TITLE
lib: lte_link_control: improve API documentation

### DIFF
--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -3,8 +3,8 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
-#ifndef ZEPHYR_INCLUDE_LTE_LINK_CONTROL_H_
-#define ZEPHYR_INCLUDE_LTE_LINK_CONTROL_H_
+#ifndef LTE_LC_H__
+#define LTE_LC_H__
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -17,278 +17,389 @@ extern "C" {
 /**
  * @file lte_lc.h
  *
- * @defgroup lte_lc LTE Link Controller
+ * @defgroup lte_lc LTE link control library
  *
  * @{
  *
- * @brief Public APIs for the LTE Link Controller.
+ * Public APIs for the LTE link control library.
  */
 
-/* NOTE: enum lte_lc_nw_reg_status maps directly to the registration status
- *	 as returned by the AT command "AT+CEREG?".
+/**
+ * Network registration status.
+ *
+ * @note Maps directly to the registration status as returned by the AT command `AT+CEREG?`.
  */
 enum lte_lc_nw_reg_status {
+	/** Not registered. UE is not currently searching for an operator to register to. */
 	LTE_LC_NW_REG_NOT_REGISTERED		= 0,
+
+	/** Registered, home network. */
 	LTE_LC_NW_REG_REGISTERED_HOME		= 1,
+
+	/**
+	 * Not registered, but UE is currently trying to attach or searching for an operator to
+	 * register to.
+	 */
 	LTE_LC_NW_REG_SEARCHING			= 2,
+
+	/** Registration denied. */
 	LTE_LC_NW_REG_REGISTRATION_DENIED	= 3,
+
+	/** Unknown, for example out of LTE coverage. */
 	LTE_LC_NW_REG_UNKNOWN			= 4,
+
+	/** Registered, roaming. */
 	LTE_LC_NW_REG_REGISTERED_ROAMING	= 5,
+
 	LTE_LC_NW_REG_REGISTERED_EMERGENCY	= 8,
+
+	/** Not registered due to UICC failure. */
 	LTE_LC_NW_REG_UICC_FAIL			= 90
 };
 
+/** System mode. */
 enum lte_lc_system_mode {
 	LTE_LC_SYSTEM_MODE_NONE,
+
+	/** LTE-M only. */
 	LTE_LC_SYSTEM_MODE_LTEM,
+
+	/** NB-IoT only. */
 	LTE_LC_SYSTEM_MODE_NBIOT,
+
+	/** GNSS only. */
 	LTE_LC_SYSTEM_MODE_GPS,
+
+	/** LTE-M + GNSS. */
 	LTE_LC_SYSTEM_MODE_LTEM_GPS,
+
+	/** NB-IoT + GNSS. */
 	LTE_LC_SYSTEM_MODE_NBIOT_GPS,
+
+	/** LTE-M + NB-IoT. */
 	LTE_LC_SYSTEM_MODE_LTEM_NBIOT,
+
+	/** LTE-M + NB-IoT + GNSS. */
 	LTE_LC_SYSTEM_MODE_LTEM_NBIOT_GPS,
 };
 
-/** LTE mode. The values for LTE-M and NB-IoT correspond to the values for the
- *  access technology field in AT responses.
+/**
+ * LTE mode.
+ *
+ * The values for LTE-M and NB-IoT correspond to the values for the access technology field in AT
+ * responses.
  */
 enum lte_lc_lte_mode {
+	/** None. */
 	LTE_LC_LTE_MODE_NONE	= 0,
+
+	/** LTE-M. */
 	LTE_LC_LTE_MODE_LTEM	= 7,
+
+	/** NB-IoT. */
 	LTE_LC_LTE_MODE_NBIOT	= 9,
 };
 
-/** LTE mode preference. If more than one LTE system mode is enabled, the modem
- *  can select the mode that best meets the criteria set by this configuration.
- *  The LTE mode preference does not affect the way GPS operates.
+/**
+ * LTE mode preference.
  *
- *  Note that there's a distinction between preferred and prioritized mode.
+ * If multiple LTE system modes are enabled, the modem can select the mode that best meets the
+ * criteria set by this configuration. The LTE mode preference does not affect the way GNSS
+ * operates.
+ *
+ * Note that there's a distinction between preferred and prioritized mode.
  */
 enum lte_lc_system_mode_preference {
 	/** No LTE preference, automatically selected by the modem. */
 	LTE_LC_SYSTEM_MODE_PREFER_AUTO = 0,
 
-	/** LTE-M is preferred over PLMN selection. The modem will prioritize to
-	 *  use LTE-M and switch over to a PLMN where LTE-M is available whenever
-	 *  possible.
+	/**
+	 * LTE-M is preferred over PLMN selection.
+	 *
+	 * The modem will prioritize to use LTE-M and switch over to a PLMN where LTE-M is available
+	 * whenever possible.
 	 */
 	LTE_LC_SYSTEM_MODE_PREFER_LTEM,
 
-	/** NB-IoT is preferred over PLMN selection. The modem will prioritize to
-	 *  use NB-IoT and switch over to a PLMN where NB-IoT is available
-	 *  whenever possible.
+	/**
+	 * NB-IoT is preferred over PLMN selection.
+	 *
+	 * The modem will prioritize to use NB-IoT and switch over to a PLMN where NB-IoT is
+	 * available whenever possible.
 	 */
 	LTE_LC_SYSTEM_MODE_PREFER_NBIOT,
 
-	/** LTE-M is preferred, but PLMN selection is more important. The modem
-	 *  will prioritize to stay on home network and switch over to NB-IoT
-	 *  if LTE-M is not available.
+	/**
+	 * LTE-M is preferred, but PLMN selection is more important.
+	 *
+	 * The modem will prioritize to stay on home network and switch over to NB-IoT if LTE-M is
+	 * not available.
 	 */
 	LTE_LC_SYSTEM_MODE_PREFER_LTEM_PLMN_PRIO,
 
-	/** NB-IoT is preferred, but PLMN selection is more important. The modem
-	 *  will prioritize to stay on home network and switch over to LTE-M
-	 *  if NB-IoT is not available.
+	/**
+	 * NB-IoT is preferred, but PLMN selection is more important.
+	 *
+	 * The modem will prioritize to stay on home network and switch over to LTE-M if NB-IoT is
+	 * not available.
 	 */
 	LTE_LC_SYSTEM_MODE_PREFER_NBIOT_PLMN_PRIO
 };
 
-/** @brief Functional modes, used to control RF functionality in the modem.
+/**
+ * Functional mode, used to control RF functionality in the modem.
  *
- *  @note The functional modes map directly to the functional modes as described
- *	  in "nRF91 AT Commands - Command Reference Guide". Please refer to the
- *	  AT command guide to verify if a functional mode is supported by a
- *	  given modem firmware version.
+ * @note The values are mapped to modem functional modes as described in
+ *       "nRF91 AT Commands - Command Reference Guide". Refer to the AT command guide to
+ *       verify whether a functional mode is supported by a given modem firmware version.
  */
 enum lte_lc_func_mode {
-	/* Sets the device to minimum functionality. Disables both transmit and
-	 * receive RF circuits and deactivates LTE and GNSS.
+	/**
+	 * Sets the device to minimum functionality.
+	 *
+	 * Disables both transmit and receive RF circuits and deactivates LTE and GNSS.
 	 */
 	LTE_LC_FUNC_MODE_POWER_OFF		= 0,
 
-	/* Sets the device to full functionality. Both LTE and GNSS will become
-	 * active if the respective system modes are enabled.
+	/**
+	 * Sets the device to full functionality.
+	 *
+	 * Both LTE and GNSS will become active if the respective system modes are enabled.
 	 */
 	LTE_LC_FUNC_MODE_NORMAL			= 1,
 
-	/* Sets the device to receive only functionality. Can be used, for example,
-	 * to preevaluate connections with @ref lte_lc_conn_eval_params_get.
-	 * Available for modem firmware versions >= 1.3.0.
+	/**
+	 * Sets the device to receive only functionality.
+	 *
+	 * Can be used, for example, to evaluate connections with
+	 * lte_lc_conn_eval_params_get().
+	 *
+	 * @note This mode is only supported by modem firmware versions >= 1.3.0.
 	 */
 	LTE_LC_FUNC_MODE_RX_ONLY		= 2,
 
-	/* Sets the device to flight mode. Disables both transmit and receive RF
-	 * circuits and deactivates LTE and GNSS services.
+	/**
+	 * Sets the device to flight mode.
+	 *
+	 * Disables both transmit and receive RF circuits and deactivates LTE and GNSS services.
 	 */
 	LTE_LC_FUNC_MODE_OFFLINE		= 4,
 
-	/* Deactivates LTE without shutting down GNSS services. */
+	/** Deactivates LTE without shutting down GNSS services. */
 	LTE_LC_FUNC_MODE_DEACTIVATE_LTE		= 20,
 
-	/* Activates LTE without changing GNSS. */
+	/** Activates LTE without changing GNSS. */
 	LTE_LC_FUNC_MODE_ACTIVATE_LTE		= 21,
 
-	/* Deactivates GNSS without shutting down LTE services. */
+	/** Deactivates GNSS without shutting down LTE services. */
 	LTE_LC_FUNC_MODE_DEACTIVATE_GNSS	= 30,
 
-	/* Activates GNSS without changing LTE. */
+	/** Activates GNSS without changing LTE. */
 	LTE_LC_FUNC_MODE_ACTIVATE_GNSS		= 31,
 
-	/* Deactivates UICC. */
+	/** Deactivates UICC. */
 	LTE_LC_FUNC_MODE_DEACTIVATE_UICC	= 40,
 
-	/* Activates UICC. */
+	/** Activates UICC. */
 	LTE_LC_FUNC_MODE_ACTIVATE_UICC		= 41,
 
-	/* Sets the device to flight mode without shutting down UICC. */
+	/** Sets the device to flight mode without shutting down UICC. */
 	LTE_LC_FUNC_MODE_OFFLINE_UICC_ON	= 44,
 };
 
+/** Event type. */
 enum lte_lc_evt_type {
-	/** @brief Event received carrying information about the modems network registration
-	 *         status.
-	 *         The associated payload is the nw_reg_status member of
-	 *	   type @ref lte_lc_nw_reg_status in the event.
+	/**
+	 * Network registration status.
+	 *
+	 * The associated payload is the @c nw_reg_status member of type @ref lte_lc_nw_reg_status
+	 * in the event.
 	 */
 	LTE_LC_EVT_NW_REG_STATUS,
 
-	/** @brief Event received carrying information about PSM updates. Contains PSM parameters
-	 *	   given by the network.
-	 *         The associated payload is the psm_cfg member of type @ref lte_lc_psm_cfg
-	 *	   in the event.
+	/**
+	 * PSM parameters provided by the network.
+	 *
+	 * The associated payload is the @c psm_cfg member of type @ref lte_lc_psm_cfg in the event.
 	 */
 	LTE_LC_EVT_PSM_UPDATE,
 
-	/** @brief Event received carrying information about eDRX updates. Contains eDRX parameters
-	 *	   given by the network.
-	 *         The associated payload is the edrx_cfg member of type @ref lte_lc_edrx_cfg
-	 *	   in the event.
+	/**
+	 * eDRX parameters provided by the network.
+	 *
+	 * The associated payload is the @c edrx_cfg member of type @ref lte_lc_edrx_cfg in the
+	 * event.
 	 */
 	LTE_LC_EVT_EDRX_UPDATE,
 
-	/** @brief Event received carrying information about the modems RRC state.
-	 *         The associated payload is the rrc_mode member of type @ref lte_lc_rrc_mode
-	 *	   in the event.
+	/**
+	 * RRC connection state.
+	 *
+	 * The associated payload is the @c rrc_mode member of type @ref lte_lc_rrc_mode in the
+	 * event.
 	 */
 	LTE_LC_EVT_RRC_UPDATE,
 
-	/** @brief Event received carrying information about the currently connected cell.
-	 *         The associated payload is the cell member of type @ref lte_lc_cell
-	 *	   in the event. Note that only the cell.tac and cell.id members are populated
-	 *	   in the event payload. The rest are expected to be zero.
+	/**
+	 * Current cell.
+	 *
+	 * The associated payload is the @c cell member of type @ref lte_lc_cell in the event.
+	 * Only the @c cell.tac and @c cell.id members are populated in the event payload. The rest
+	 * are expected to be zero.
 	 */
 	LTE_LC_EVT_CELL_UPDATE,
 
-	/** @brief The currently active LTE mode is updated. If a system mode that
-	 *	   enables both LTE-M and NB-IoT is configured, the modem may change
-	 *	   the currently active LTE mode based on the system mode preference
-	 *	   and network availability. This event will then indicate which
-	 *	   LTE mode is currently used by the modem.
-	 *         The associated payload is the lte_mode member of type @ref lte_lc_lte_mode
-	 *	   in the event.
+	/**
+	 * Current LTE mode.
+	 *
+	 * If a system mode that enables both LTE-M and NB-IoT is configured, the modem may change
+	 * the currently active LTE mode based on the system mode preference and network
+	 * availability. This event will then indicate which LTE mode is currently used by the
+	 * modem.
+	 *
+	 * The associated payload is the @c lte_mode member of type @ref lte_lc_lte_mode in the
+	 * event.
 	 */
 	LTE_LC_EVT_LTE_MODE_UPDATE,
 
-	/** @brief Tracking Area Update pre-warning.
-	 *	   This event will be received a configurable amount of time before TAU is
-	 *	   scheduled to occur. This gives the application the opportunity to send
-	 *	   data over the network before the TAU happens, thus saving power by
-	 *	   avoiding sending data and the TAU separately.
-	 *         The associated payload is the time member of type uint64_t in the event.
+	/**
+	 * Tracking Area Update pre-warning.
+	 *
+	 * This event will be received some time before TAU is scheduled to occur. The time is
+	 * configurable. This gives the application the opportunity to send data over the network
+	 * before the TAU happens, thus saving power by avoiding sending data and the TAU
+	 * separately.
+	 *
+	 * The associated payload is the @c time member of type @c uint64_t in the event.
 	 */
 	LTE_LC_EVT_TAU_PRE_WARNING,
 
-	/** @brief Event containing results from neighbor cell measurements.
-	 *         The associated payload is the cells_info member of type @ref lte_lc_cells_info
-	 *	   in the event.
+	/**
+	 * Neighbor cell measurement results.
+	 *
+	 * The associated payload is the @c cells_info member of type @ref lte_lc_cells_info in the
+	 * event.
 	 */
 	LTE_LC_EVT_NEIGHBOR_CELL_MEAS,
 
-	/** @brief Modem sleep pre-warning
-	 *	   This event will be received a configurable amount of time before
-	 *	   the modem exits sleep. The time parameter associated with this
-	 *	   event signifies the time until modem exits sleep.
-	 *         The associated payload is the modem_sleep member of type @ref lte_lc_modem_sleep
-	 *	   in the event.
+	/**
+	 * Modem sleep pre-warning.
+	 *
+	 * This event will be received some time before the modem exits sleep. The time is
+	 * configurable.
+	 *
+	 * The associated payload is the @c modem_sleep member of type @ref lte_lc_modem_sleep in
+	 * the event. The @c time parameter indicates the time until modem exits sleep.
 	 */
 	LTE_LC_EVT_MODEM_SLEEP_EXIT_PRE_WARNING,
 
-	/** @brief This event will be received when the modem exits sleep.
-	 *         The associated payload is the modem_sleep member of type @ref lte_lc_modem_sleep
-	 *	   in the event.
+	/**
+	 * Modem exited from sleep.
+	 *
+	 * The associated payload is the @c modem_sleep member of type @ref lte_lc_modem_sleep in
+	 * the event.
 	 */
 	LTE_LC_EVT_MODEM_SLEEP_EXIT,
 
-	/** @brief This event will be received when the modem enters sleep.
-	 *         The time parameter associated with this event signifies
-	 *         the duration of the sleep.
-	 *         The associated payload is the modem_sleep member of type @ref lte_lc_modem_sleep
-	 *	   in the event.
+	/**
+	 * Modem entered sleep.
+	 *
+	 * The associated payload is the @c modem_sleep member of type @ref lte_lc_modem_sleep in
+	 * the event. The @c time parameter indicates the duration of the sleep.
 	 */
 	LTE_LC_EVT_MODEM_SLEEP_ENTER,
 
-	/** @brief Modem domain event carrying information about modem operation.
-	 *         The associated payload is the modem_evt member of type @ref lte_lc_modem_evt
-	 *	   in the event.
+	/**
+	 * Information about modem operation.
+	 *
+	 * The associated payload is the @c modem_evt member of type @ref lte_lc_modem_evt in the
+	 * event.
 	 */
 	LTE_LC_EVT_MODEM_EVENT,
 };
 
+/** RRC connection state. */
 enum lte_lc_rrc_mode {
+	/** Idle. */
 	LTE_LC_RRC_MODE_IDLE		= 0,
+
+	/** Connected. */
 	LTE_LC_RRC_MODE_CONNECTED	= 1,
 };
 
+/** Power Saving Mode (PSM) configuration. */
 struct lte_lc_psm_cfg {
-	int tau;		/* Periodic Tracking Area Update interval */
-	int active_time;	/* Active-time (time from RRC idle to PSM) */
+	/** Periodic Tracking Area Update interval in seconds. */
+	int tau;
+
+	/** Active-time (time from RRC idle to PSM) in seconds. */
+	int active_time;
 };
 
+/** eDRX configuration. */
 struct lte_lc_edrx_cfg {
-	/* LTE mode for which the configuration is valid.
-	 * If the mode is LTE_LC_LTE_MODE_NONE, eDRX is not used by the current cell.
+	/**
+	 * LTE mode for which the configuration is valid.
+	 *
+	 * If the mode is @ref LTE_LC_LTE_MODE_NONE, eDRX is not used by the current cell.
 	 */
 	enum lte_lc_lte_mode mode;
-	/* eDRX interval value [s] */
+
+	/** eDRX interval in seconds. */
 	float edrx;
-	/* Paging time window [s] */
+
+	/** Paging time window in seconds. */
 	float ptw;
 };
 
+/** Maximum timing advance value. */
 #define LTE_LC_CELL_TIMING_ADVANCE_MAX		20512
+/** Invalid timing advance value. */
 #define LTE_LC_CELL_TIMING_ADVANCE_INVALID	65535
+/** Maximum EARFCN value. */
 #define LTE_LC_CELL_EARFCN_MAX			262143
+/** Unknown or undetectable RSRP value. */
 #define LTE_LC_CELL_RSRP_INVALID		255
+/** Unknown or undetectable RSRQ value. */
 #define LTE_LC_CELL_RSRQ_INVALID		255
+/** Cell ID value not valid. */
 #define LTE_LC_CELL_EUTRAN_ID_INVALID		UINT32_MAX
+/** Maximum cell ID value. */
 #define LTE_LC_CELL_EUTRAN_ID_MAX		268435455
+/** Time difference not valid. */
 #define LTE_LC_CELL_TIME_DIFF_INVALID		0
 
-/** @brief Structure containing neighbor cell information. */
+/** Neighbor cell information. */
 struct lte_lc_ncell {
-	/** EARFCN of the neighbor cell, per 3GPP TS 36.101. */
+	/** EARFCN per 3GPP TS 36.101. */
 	uint32_t earfcn;
 
-	/** Difference in milliseconds of current cell and neighbor cell
-	 *  measurement, in the range -99999 ms < time_diff < 99999 ms.
+	/**
+	 * Difference of current cell and neighbor cell measurement, in the range
+	 * -99999 ms < time_diff < 99999 ms. @ref LTE_LC_CELL_TIME_DIFF_INVALID if the value is not
+	 * valid.
 	 */
 	int time_diff;
 
 	/** Physical cell ID. */
 	uint16_t phys_cell_id;
 
-	/** RSRP of the neighbor cell. Format is the same as for RSRP member
-	 *  of struct @ref lte_lc_cell.
+	/**
+	 * RSRP.
+	 *
+	 * Format is the same as for @c rsrp member of struct @ref lte_lc_cell.
 	 */
 	int16_t rsrp;
 
-	/** RSRQ of the neighbor cell. Format is the same as for RSRQ member
-	 *  of struct @ref lte_lc_cell.
+	/**
+	 * RSRQ.
+	 *
+	 * Format is the same as for @c rsrq member of struct @ref lte_lc_cell.
 	 */
 	int16_t rsrq;
 };
 
-/** @brief Structure containing cell information. */
+/** Cell information. */
 struct lte_lc_cell {
 	/** Mobile Country Code. */
 	int mcc;
@@ -296,106 +407,117 @@ struct lte_lc_cell {
 	/** Mobile Network Code. */
 	int mnc;
 
-	/** E-UTRAN cell ID, range 0 - LTE_LC_CELL_EUTRAN_ID_MAX */
+	/** E-UTRAN cell ID, range 0 - @ref LTE_LC_CELL_EUTRAN_ID_MAX. */
 	uint32_t id;
 
 	/** Tracking area code. */
 	uint32_t tac;
 
-	/** EARFCN of the cell, per 3GPP TS 36.101. */
+	/** EARFCN per 3GPP TS 36.101. */
 	uint32_t earfcn;
 
-	/** Timing advance decimal value.
-	 *  Range [0..20512, TIMING_ADVANCE_NOT_VALID = 65535].
+	/**
+	 * Timing advance decimal value.
 	 *
-	 * Note: Timing advance may be reported from past measurements.
-	 *	 The parameters @c timing_advance_meas_time and @c measurement_time
-	 *	 can be used to evaluate if the parameter is usable.
+	 * Range 0 - @ref LTE_LC_CELL_TIMING_ADVANCE_MAX. @ref LTE_LC_CELL_TIMING_ADVANCE_INVALID if
+	 * timing advance is not valid.
+	 *
+	 * @note Timing advance may be reported from past measurements. The parameters
+	 *       @c timing_advance_meas_time and @c measurement_time can be used to evaluate if
+	 *       the parameter is usable.
 	 */
 	uint16_t timing_advance;
 
-	/** Timing advance measurement time in milliseconds, calculated from modem
-	 *  boot time.
-	 *  Range 0 - 18 446 744 073 709 551 614 ms.
+	/**
+	 * Timing advance measurement time, calculated from modem boot time.
 	 *
-	 *  For modem firmware versions >= 1.3.1, timing advance measurement time may
-	 *  be reported from the modem. This means that timing advance data
-	 *  may now also be available in neighbor cell measurements done in
-	 *  RRC idle, even though the timing advance data was captured in RRC connected.
-	 *  If the value is not reported by the modem, it is set to 0.
+	 * Range 0 - 18 446 744 073 709 551 614 ms.
+	 *
+	 * @note For modem firmware versions >= 1.3.1, timing advance measurement time may be
+	 *       reported from the modem. This means that timing advance data may now also be
+	 *       available in neighbor cell measurements done in RRC idle, even though the timing
+	 *       advance data was captured in RRC connected. If the value is not reported by the
+	 *       modem, it is set to 0.
 	 */
 	uint64_t timing_advance_meas_time;
 
-	/** Measurement time of current cell in milliseconds.
-	 *  Range 0 - 18 446 744 073 709 551 614 ms.
+	/**
+	 * Measurement time.
+	 *
+	 * Range 0 - 18 446 744 073 709 551 614 ms.
 	 */
 	uint64_t measurement_time;
 
 	/** Physical cell ID. */
 	uint16_t phys_cell_id;
 
-	/** RSRP of the neighbor cell.
-	 *  -17: RSRP < -156 dBm
-	 *  -16: -156 ≤ RSRP < -155 dBm
-	 *  ...
-	 *  -3: -143 ≤ RSRP < -142 dBm
-	 *  -2: -142 ≤ RSRP < -141 dBm
-	 *  -1: -141 ≤ RSRP < -140 dBm
-	 *  0: RSRP < -140 dBm
-	 *  1: -140 ≤ RSRP < -139 dBm
-	 *  2: -139 ≤ RSRP < -138 dBm
-	 *  ...
-	 *  95: -46 ≤ RSRP < -45 dBm
-	 *  96: -45 ≤ RSRP < -44 dBm
-	 *  97: -44 ≤ RSRP dBm
-	 *  255: not known or not detectable
+	/**
+	 * RSRP.
+	 *
+	 * * -17: RSRP < -156 dBm
+	 * * -16: -156 ≤ RSRP < -155 dBm
+	 * * ...
+	 * * -3: -143 ≤ RSRP < -142 dBm
+	 * * -2: -142 ≤ RSRP < -141 dBm
+	 * * -1: -141 ≤ RSRP < -140 dBm
+	 * * 0: RSRP < -140 dBm
+	 * * 1: -140 ≤ RSRP < -139 dBm
+	 * * 2: -139 ≤ RSRP < -138 dBm
+	 * * ...
+	 * * 95: -46 ≤ RSRP < -45 dBm
+	 * * 96: -45 ≤ RSRP < -44 dBm
+	 * * 97: -44 ≤ RSRP dBm
+	 * * @ref LTE_LC_CELL_RSRP_INVALID : not known or not detectable
 	 */
 	int16_t rsrp;
 
-	/** RSRQ of the neighbor cell.
-	 *  -30: RSRQ < -34 dB
-	 *  -29:	-34 ≤ RSRQ < -33.5 dB
-	 *  ...
-	 *  -2: -20.5 ≤ RSRQ < -20 dB
-	 *  -1:	-20 ≤ RSRQ < -19.5 dB
-	 *  0: RSRQ < -19.5 dB
-	 *  1: -19.5 ≤ RSRQ < -19 dB
-	 *  2: -19 ≤ RSRQ < -18.5 dB
-	 *  ...
-	 *  32: -4 ≤ RSRQ < -3.5 dB
-	 *  33: -3.5 ≤ RSRQ < -3 dB
-	 *  34: -3 ≤ RSRQ dB
-	 *  35: -3 ≤ RSRQ < -2.5 dB
-	 *  36: -2.5 ≤ RSRQ < -2 dB
-	 *  ...
-	 *  45: 2 ≤ RSRQ < 2.5 dB
-	 *  46: 2.5 ≤ RSRQ dB
-	 *  255: not known or not detectable.
+	/**
+	 * RSRQ.
+	 *
+	 * * -30: RSRQ < -34 dB
+	 * * -29: -34 ≤ RSRQ < -33.5 dB
+	 * * ...
+	 * * -2: -20.5 ≤ RSRQ < -20 dB
+	 * * -1: -20 ≤ RSRQ < -19.5 dB
+	 * * 0: RSRQ < -19.5 dB
+	 * * 1: -19.5 ≤ RSRQ < -19 dB
+	 * * 2: -19 ≤ RSRQ < -18.5 dB
+	 * * ...
+	 * * 32: -4 ≤ RSRQ < -3.5 dB
+	 * * 33: -3.5 ≤ RSRQ < -3 dB
+	 * * 34: -3 ≤ RSRQ dB
+	 * * 35: -3 ≤ RSRQ < -2.5 dB
+	 * * 36: -2.5 ≤ RSRQ < -2 dB
+	 * * ...
+	 * * 45: 2 ≤ RSRQ < 2.5 dB
+	 * * 46: 2.5 ≤ RSRQ dB
+	 * * @ref LTE_LC_CELL_RSRQ_INVALID : not known or not detectable.
 	 */
 	int16_t rsrq;
 };
 
 
-/** @brief Structure containing results of neighbor cell measurements. */
+/** Results of neighbor cell measurements. */
 struct lte_lc_cells_info {
-	/** The current cell information is valid if the current cell ID is not
-	 *  set to LTE_LC_CELL_EUTRAN_ID_INVALID.
+	/**
+	 * The current cell information is valid if the current cell ID is not set to
+	 * @ref LTE_LC_CELL_EUTRAN_ID_INVALID.
 	 */
 	struct lte_lc_cell current_cell;
 
-	/** The ncells_count member indicates whether or not the neighbor_cells structure
-	 *  contains valid neighbor cell information. If it is zero, no neighbor cells were found
-	 *  for the current cell.
+	/**
+	 * Indicates whether or not the @c neighbor_cells contains valid neighbor cell information.
+	 * If it is zero, no neighbor cells were found for the current cell.
 	 */
 	uint8_t ncells_count;
 
 	/** Neighbor cells for the current cell. */
 	struct lte_lc_ncell *neighbor_cells;
 
-	/** The gci_cells_count member indicates whether or not the gci_cells structure contains
-	 *  valid surrounding cell information from
-	 *  GCI search types (@ref lte_lc_neighbor_search_type). If it is zero, no cells were
-	 *  found, and the information in the rest of structure members do not contain valid data.
+	/**
+	 * Indicates whether or not the @c gci_cells contains valid surrounding cell information
+	 * from GCI search types (@ref lte_lc_neighbor_search_type). If it is zero, no cells were
+	 * found.
 	 */
 	uint8_t gci_cells_count;
 
@@ -403,99 +525,166 @@ struct lte_lc_cells_info {
 	struct lte_lc_cell *gci_cells;
 };
 
+/** Modem sleep type. */
 enum lte_lc_modem_sleep_type {
-	/** Power saving mode (PSM). */
+	/** Power Saving Mode (PSM). */
 	LTE_LC_MODEM_SLEEP_PSM			= 1,
+
 	/** RF inactivity, for example eDRX. */
 	LTE_LC_MODEM_SLEEP_RF_INACTIVITY	= 2,
+
 	/** Limited service or out of coverage. */
 	LTE_LC_MODEM_SLEEP_LIMITED_SERVICE	= 3,
+
 	/** Flight mode. */
 	LTE_LC_MODEM_SLEEP_FLIGHT_MODE		= 4,
-	/** Proprietary PSM. This is valid only for modem firmware versions >= 2.0.0. */
+
+	/**
+	 * Proprietary PSM.
+	 *
+	 * @note This type is only supported by modem firmware versions >= 2.0.0.
+	 */
 	LTE_LC_MODEM_SLEEP_PROPRIETARY_PSM	= 7,
 };
 
+/** Modem sleep information. */
 struct lte_lc_modem_sleep {
 	/** Sleep type. */
 	enum lte_lc_modem_sleep_type type;
 
-	/** Sleep time in milliseconds. If this value is set to -1,
-	 *  the sleep is considered infinite.
+	/**
+	 * Sleep time in milliseconds. If this value is set to -1, the sleep is considered infinite.
 	 */
 	int64_t time;
 };
 
+/** Energy consumption estimate. */
 enum lte_lc_energy_estimate {
+	/**
+	 * Bad conditions.
+	 *
+	 * Difficulties in setting up connections. Maximum number of repetitions might be needed for
+	 * data.
+	 */
 	LTE_LC_ENERGY_CONSUMPTION_EXCESSIVE	= 5,
+
+	/**
+	 * Poor conditions.
+	 *
+	 * Setting up a connection might require retries and a higher number of repetitions for
+	 * data.
+	 */
 	LTE_LC_ENERGY_CONSUMPTION_INCREASED	= 6,
+
+	/**
+	 * Normal conditions.
+	 *
+	 * No repetitions for data or only a few repetitions in the worst case.
+	 */
 	LTE_LC_ENERGY_CONSUMPTION_NORMAL	= 7,
+
+	/**
+	 * Good conditions.
+	 *
+	 * Possibly very good conditions for small amounts of data.
+	 */
 	LTE_LC_ENERGY_CONSUMPTION_REDUCED	= 8,
+
+	/**
+	 * Excellent conditions.
+	 *
+	 * Efficient data transfer estimated also for larger amounts of data.
+	 */
 	LTE_LC_ENERGY_CONSUMPTION_EFFICIENT	= 9,
 };
 
+/** Cell in Tracking Area Identifier list. */
 enum lte_lc_tau_triggered {
-	/** The evaluated cell is in the Tracking Area Identifier list. When switching to this
-	 *  cell, a TAU will not be triggered.
+	/**
+	 * The evaluated cell is in the Tracking Area Identifier list.
+	 *
+	 * When switching to this cell, a TAU will not be triggered.
 	 */
 	LTE_LC_CELL_IN_TAI_LIST		= 0,
 
-	/** The evaluated cell is not in the Tracking Area Identifier list. When switching to this
-	 *  cell, a TAU will be triggered.
+	/**
+	 * The evaluated cell is not in the Tracking Area Identifier list.
+	 *
+	 * When switching to this cell, a TAU will be triggered.
 	 */
 	LTE_LC_CELL_NOT_IN_TAI_LIST	= 1,
+
+	/** Not known. */
 	LTE_LC_CELL_UNKNOWN		= UINT8_MAX
 };
 
+/** CE level. */
 enum lte_lc_ce_level {
+	/** No repetitions or a small number of repetitions. */
 	LTE_LC_CE_LEVEL_0_NO_REPETITION		= 0,
+
+	/** Medium number of repetitions. */
 	LTE_LC_CE_LEVEL_1_LOW_REPETITION	= 1,
+
+	/** Large number of repetitions. */
 	LTE_LC_CE_LEVEL_2_MEDIUM_REPETITION	= 2,
+
+	/** Very large number of repetitions. */
 	LTE_LC_CE_LEVEL_3_LARGE_REPETITION	= 3,
+
+	/** Not known. */
 	LTE_LC_CE_LEVEL_UNKNOWN			= UINT8_MAX,
 };
 
-/** @brief Reduced mobility mode */
+/** Reduced mobility mode. */
 enum lte_lc_reduced_mobility_mode {
 	/** Functionality according to the 3GPP relaxed monitoring feature. */
 	LTE_LC_REDUCED_MOBILITY_DEFAULT = 0,
+
 	/** Enable Nordic-proprietary reduced mobility feature. */
 	LTE_LC_REDUCED_MOBILITY_NORDIC = 1,
-	/** Full measurements for best possible mobility. Disable the 3GPP relaxed
-	 *  monitoring and Nordic-proprietary reduced mobility features.
+
+	/**
+	 * Full measurements for best possible mobility.
+	 *
+	 * Disable the 3GPP relaxed monitoring and Nordic-proprietary reduced mobility features.
 	 */
 	LTE_LC_REDUCED_MOBILITY_DISABLED = 2,
 };
 
-/** @brief Modem domain events. */
+/** Modem domain events. */
 enum lte_lc_modem_evt {
-	/** Indicates that a light search has been performed. This event gives the
-	 *  application the chance to stop using more power when searching networks
-	 *  in possibly weaker radio conditions.
-	 *  Before sending this event, the modem searches for cells based on previous
-	 *  cell history, measures the radio conditions, and makes assumptions on
-	 *  where networks might be deployed. This event means that the modem has
-	 *  not found a network that it could select based on the 3GPP network
-	 *  selection rules from those locations. It does not mean that there are
-	 *  no networks to be found in the area. The modem continues more thorough
-	 *  searches automatically after sending this status.
+	/**
+	 * Indicates that a light search has been performed.
+	 *
+	 * This event gives the application the chance to stop using more power when searching
+	 * networks in possibly weaker radio conditions. Before sending this event, the modem
+	 * searches for cells based on previous cell history, measures the radio conditions, and
+	 * makes assumptions on where networks might be deployed. This event means that the modem
+	 * has not found a network that it could select based on the 3GPP network selection rules
+	 * from those locations. It does not mean that there are no networks to be found in the
+	 * area. The modem continues more thorough searches automatically after sending this status.
 	 */
 	LTE_LC_MODEM_EVT_LIGHT_SEARCH_DONE,
 
-	/** Indicates that a network search has been performed. The modem has found
-	 *  a network that it can select according to the 3GPP network selection rules
-	 *  or all frequencies have been scanned and a suitable cell was not found.
-	 *  In the latter case, the modem enters normal limited service state
-	 *  functionality and performs scan for service periodically.
+	/**
+	 * Indicates that a network search has been performed.
+	 *
+	 * The modem has found a network that it can select according to the 3GPP network selection
+	 * rules or all frequencies have been scanned and a suitable cell was not found. In the
+	 * latter case, the modem enters normal limited service state functionality and performs
+	 * scan for service periodically.
 	 */
 	LTE_LC_MODEM_EVT_SEARCH_DONE,
-	/** The modem has detected a reset loop. A reset loop indicates that
-	 *  the modem restricts network attach attempts for the next 30 minutes.
-	 *  The timer does not run when the modem has no power or while it stays
-	 *  in the reset loop. The modem counts all the resets where the modem
-	 *  is not gracefully deinitialized with +CFUN=0 or using an API
-	 *  performing the equivalent operation, such as setting the functional
-	 *  mode to LTE_LC_FUNC_MODE_POWER_OFF.
+
+	/**
+	 * The modem has detected a reset loop.
+	 *
+	 * A reset loop indicates that the modem restricts network attach attempts for the next 30
+	 * minutes. The timer does not run when the modem has no power or while it stays in the
+	 * reset loop. The modem counts all the resets where the modem is not gracefully
+	 * deinitialized with `AT+CFUN=0` or using an API performing the equivalent operation, such
+	 * as setting the functional mode to @ref LTE_LC_FUNC_MODE_POWER_OFF.
 	 */
 	LTE_LC_MODEM_EVT_RESET_LOOP,
 
@@ -505,69 +694,81 @@ enum lte_lc_modem_evt {
 	/** The device is overheated and the modem is therefore deactivated. */
 	LTE_LC_MODEM_EVT_OVERHEATED,
 
-	/** The modem does not have an IMEI */
+	/** The modem does not have an IMEI. */
 	LTE_LC_MODEM_EVT_NO_IMEI,
 
-	/** Selected CE level in RACH procedure is 0, see 3GPP TS 36.331 for details.
+	/**
+	 * Selected CE level in RACH procedure is 0, see 3GPP TS 36.331 for details.
 	 *
-	 *  @note This event is supported for modem firmware versions >= 2.0.0.
+	 * @note This event is only supported by modem firmware versions >= 2.0.0.
 	 */
 	LTE_LC_MODEM_EVT_CE_LEVEL_0,
 
-	/** Selected CE level in RACH procedure is 1, see 3GPP TS 36.331 for details.
+	/**
+	 * Selected CE level in RACH procedure is 1, see 3GPP TS 36.331 for details.
 	 *
-	 *  @note This event is supported for modem firmware versions >= 2.0.0.
+	 * @note This event is only supported by modem firmware versions >= 2.0.0.
 	 */
 	LTE_LC_MODEM_EVT_CE_LEVEL_1,
 
-	/** Selected CE level in RACH procedure is 2, see 3GPP TS 36.331 for details.
+	/**
+	 * Selected CE level in RACH procedure is 2, see 3GPP TS 36.331 for details.
 	 *
-	 *  @note This event is supported for modem firmware versions >= 2.0.0.
+	 * @note This event is only supported by modem firmware versions >= 2.0.0.
 	 */
 	LTE_LC_MODEM_EVT_CE_LEVEL_2,
 
-	/** Selected CE level in RACH procedure is 3, see 3GPP TS 36.331 for details.
+	/**
+	 * Selected CE level in RACH procedure is 3, see 3GPP TS 36.331 for details.
 	 *
-	 *  @note This event is supported for modem firmware versions >= 2.0.0.
+	 * @note This event is only supported by modem firmware versions >= 2.0.0.
 	 */
 	LTE_LC_MODEM_EVT_CE_LEVEL_3,
 };
 
-/** @brief Type of factory reset to perform. */
+/** Type of factory reset to perform. */
 enum lte_lc_factory_reset_type {
 	/** Reset all modem data to factory settings. */
 	LTE_LC_FACTORY_RESET_ALL = 0,
+
 	/** Reset user-configurable data to factory settings. */
 	LTE_LC_FACTORY_RESET_USER = 1,
 };
 
-/** @brief Connection evaluation parameters.
+/**
+ * Connection evaluation parameters.
  *
- *  @note For more information on the various connection evaluation parameters, refer to the
- *	  "nRF91 AT Commands - Command Reference Guide".
+ * @note For more information on the various connection evaluation parameters, refer to the
+ *       "nRF91 AT Commands - Command Reference Guide".
  */
 struct lte_lc_conn_eval_params {
 	/** RRC connection state during measurements. */
 	enum lte_lc_rrc_mode rrc_state;
 
-	/** Relative estimated energy consumption for data transmission compared to nominal
-	 *  consumption.
+	/**
+	 * Relative estimated energy consumption for data transmission compared to nominal
+	 * consumption.
 	 */
 	enum lte_lc_energy_estimate energy_estimate;
 
-	/** Value that signifies if the evaluated cell is a part of the Tracking Area Identifier
-	 *  list received from the network.
+	/**
+	 * Value that indicates if the evaluated cell is a part of the Tracking Area Identifier
+	 * list received from the network.
 	 */
 	enum lte_lc_tau_triggered tau_trig;
 
-	/** Coverage Enhancement level for PRACH depending on RRC state measured in.
+	/**
+	 * Coverage Enhancement level for PRACH.
 	 *
-	 *  RRC IDLE: CE level is estimated based on RSRP and network configuration.
+	 * If @c rrc_state is @ref LTE_LC_RRC_MODE_IDLE, the CE level is estimated based on RSRP and
+	 * network configuration.
 	 *
-	 *  RRC CONNECTED: Currently configured CE level.
+	 * If @c rrc_state is @ref LTE_LC_RRC_MODE_CONNECTED, the currently used CE level is
+	 * reported.
 	 *
-	 *  CE levels 0-2 are supported in NB-IoT.
-	 *  CE levels 0-1 are supported in LTE-M.
+	 * CE levels 0-2 are supported in NB-IoT.
+	 *
+	 * CE levels 0-1 are supported in LTE-M.
 	 */
 	enum lte_lc_ce_level ce_level;
 
@@ -577,88 +778,112 @@ struct lte_lc_conn_eval_params {
 	/** Reduction in power density in dB. */
 	int16_t dl_pathloss;
 
-	/** Current RSRP level at time of report.
-	 * -17:  RSRP < -156 dBm
-	 * -16: -156 ≤ RSRP < -155 dBm
-	 *  ...
-	 * -3:  -143 ≤ RSRP < -142 dBm
-	 * -2:  -142 ≤ RSRP < -141 dBm
-	 * -1:  -141 ≤ RSRP < -140 dBm
-	 *  0:   RSRP < -140 dBm
-	 *  1:  -140 ≤ RSRP < -139 dBm
-	 *  2:  -139 ≤ RSRP < -138 dBm
-	 *  ...
-	 *  95: -46 ≤ RSRP < -45 dBm
-	 *  96: -45 ≤ RSRP < -44 dBm
-	 *  97: -44 ≤ RSRP dBm
-	 *  255: not known or not detectable
+	/**
+	 * Current RSRP level at time of report.
+	 *
+	 * * -17: RSRP < -156 dBm
+	 * * -16: -156 ≤ RSRP < -155 dBm
+	 * * ...
+	 * * -3: -143 ≤ RSRP < -142 dBm
+	 * * -2: -142 ≤ RSRP < -141 dBm
+	 * * -1: -141 ≤ RSRP < -140 dBm
+	 * * 0: RSRP < -140 dBm
+	 * * 1: -140 ≤ RSRP < -139 dBm
+	 * * 2: -139 ≤ RSRP < -138 dBm
+	 * * ...
+	 * * 95: -46 ≤ RSRP < -45 dBm
+	 * * 96: -45 ≤ RSRP < -44 dBm
+	 * * 97: -44 ≤ RSRP dBm
+	 * * @ref LTE_LC_CELL_RSRP_INVALID : not known or not detectable
 	 */
 	int16_t rsrp;
 
-	/** Current RSRQ level at time of report.
-	 * -30:  RSRQ < -34 dB
-	 * -29: -34 ≤ RSRQ < -33.5 dB
-	 * ...
-	 * -2:  -20.5 ≤ RSRQ < -20 dB
-	 * -1:  -20 ≤ RSRQ < -19.5 dB
-	 *  0:   RSRQ < -19.5 dB
-	 *  1:  -19.5 ≤ RSRQ < -19 dB
-	 *  2:  -19 ≤ RSRQ < -18.5 dB
-	 *  ...
-	 *  32: -4 ≤ RSRQ < -3.5 dB
-	 *  33: -3.5 ≤ RSRQ < -3 dB
-	 *  34: -3 ≤ RSRQ dB
-	 *  35: -3 ≤ RSRQ < -2.5 dB
-	 *  36: -2.5 ≤ RSRQ < -2 dB
-	 *  ...
-	 *  45:  2 ≤ RSRQ < 2.5 dB
-	 *  46:  2.5 ≤ RSRQ dB
-	 *  255: not known or not detectable.
+	/**
+	 * Current RSRQ level at time of report.
+	 *
+	 * * -30: RSRQ < -34 dB
+	 * * -29: -34 ≤ RSRQ < -33.5 dB
+	 * * ...
+	 * * -2: -20.5 ≤ RSRQ < -20 dB
+	 * * -1: -20 ≤ RSRQ < -19.5 dB
+	 * * 0: RSRQ < -19.5 dB
+	 * * 1: -19.5 ≤ RSRQ < -19 dB
+	 * * 2: -19 ≤ RSRQ < -18.5 dB
+	 * * ...
+	 * * 32: -4 ≤ RSRQ < -3.5 dB
+	 * * 33: -3.5 ≤ RSRQ < -3 dB
+	 * * 34: -3 ≤ RSRQ dB
+	 * * 35: -3 ≤ RSRQ < -2.5 dB
+	 * * 36: -2.5 ≤ RSRQ < -2 dB
+	 * * ...
+	 * * 45: 2 ≤ RSRQ < 2.5 dB
+	 * * 46: 2.5 ≤ RSRQ dB
+	 * * @ref LTE_LC_CELL_RSRQ_INVALID : not known or not detectable.
 	 */
 	int16_t rsrq;
 
-	/** Estimate of TX repetitions depending on RRC state measured in. 3GPP TS 36.331 and 36.213
+	/**
+	 * Estimated TX repetitions.
 	 *
-	 *  RRC IDLE: Initial preamble repetition level in (N)PRACH based on CE level and
-	 *	      network configuration.
+	 * If @c rrc_state is @ref LTE_LC_RRC_MODE_IDLE, this value is the initial preamble
+	 * repetition level in (N)PRACH based on CE level and network configuration.
 	 *
-	 *  RRC CONNECTED: Latest physical data channel (N)PUSCH transmission repetition level.
+	 * If @c rrc_state is @ref LTE_LC_RRC_MODE_CONNECTED, this value is the latest physical data
+	 * channel (N)PUSCH transmission repetition level.
+	 *
+	 * See 3GPP TS 36.331 and 36.213 for details.
 	 */
 	int16_t tx_rep;
 
-	/** Estimate of RX repetitions depending on RRC state measured in. 3GPP TS 36.331 and 36.213
+	/**
+	 * Estimated RX repetitions.
 	 *
-	 *  RRC IDLE: Initial Random Access control channel (M/NPDCCH) repetition level based on
-	 *	      CE level and network configuration.
+	 * If @c rrc_state is @ref LTE_LC_RRC_MODE_IDLE, this value is the initial random access
+	 * control channel (M/NPDCCH) repetition level based on CE level and network configuration.
 	 *
-	 *  RRC CONNECTED: Latest physical data channel (N)PDSCH reception repetition level.
+	 * If @c rrc_state is @ref LTE_LC_RRC_MODE_CONNECTED, this value is the latest physical data
+	 * channel (N)PDSCH reception repetition level.
+	 *
+	 * See 3GPP TS 36.331 and 36.213 for details.
 	 */
 	int16_t rx_rep;
 
 	/** Physical cell ID of evaluated cell. */
 	int16_t phy_cid;
 
-	/** Current band information. 0 when band information is not available. 3GPP TS 36.101. */
+	/**
+	 * Current band information.
+	 *
+	 * 0 when band information is not available.
+	 *
+	 * See 3GPP TS 36.101 for details.
+	 */
 	int16_t band;
 
-	/** Current signal-to-noise ratio at time of report.
-	 *  0:   SNR < -24 dB
-	 *  1:  -24 dB <= SNR < -23 dB
-	 *  2:  -23 dB <= SNR < -22 dB
-	 *  ...
-	 *  47:  22 dB <= SNR < 23 dB
-	 *  48:  23 dB <= SNR < 24 dB
-	 *  49:  24 dB <= SNR
-	 *  127: Not known or not detectable.
+	/**
+	 * Current signal-to-noise ratio at time of report.
+	 *
+	 * * 0:   SNR < -24 dB
+	 * * 1:  -24 dB <= SNR < -23 dB
+	 * * 2:  -23 dB <= SNR < -22 dB
+	 * * ...
+	 * * 47:  22 dB <= SNR < 23 dB
+	 * * 48:  23 dB <= SNR < 24 dB
+	 * * 49:  24 dB <= SNR
+	 * * 127: Not known or not detectable.
 	 */
 	int16_t snr;
 
-	/** Estimate of TX power in dBm depending on RRC state measured in.
-	 *  3GPP TS 36.101 and 36.213.
+	/**
+	 * Estimated TX power in dBm.
 	 *
-	 *  RRC IDLE: Estimated TX power level is for first preamble transmission in (N)PRACH).
+	 * If @c rrc_state is @ref LTE_LC_RRC_MODE_IDLE, the value is for first preamble
+	 * transmission in (N)PRACH.
 	 *
-	 *  RRC CONNECTED: Latest physical data channel (N)PUSCH transmission power level.
+	 * If @c rrc_state is @ref LTE_LC_RRC_MODE_CONNECTED, the value is the latest physical data
+	 * channel (N)PUSCH transmission power level.
+	 *
+	 * See 3GPP TS 36.101 and 36.213 for details.
 	 */
 	int16_t tx_power;
 
@@ -672,186 +897,239 @@ struct lte_lc_conn_eval_params {
 	uint32_t cell_id;
 };
 
-/** @brief Specifies which type of search the modem should perform when a neighbor
- *	   cell measurement is started.
+/**
+ * Specifies which type of search the modem should perform when a neighbor cell measurement is
+ * started.
  *
- *         When using search types up to LTE_LC_NEIGHBOR_SEARCH_TYPE_EXTENDED_COMPLETE,
- *         result contains parameters from current/serving cell
- *         and optionally up to CONFIG_LTE_NEIGHBOR_CELLS_MAX neighbor cells.
+ * When using search types up to @ref LTE_LC_NEIGHBOR_SEARCH_TYPE_EXTENDED_COMPLETE, the result
+ * contains parameters from current/serving cell and optionally up to
+ * @kconfig{CONFIG_LTE_NEIGHBOR_CELLS_MAX} neighbor cells.
  *
- *         GCI (Global Cell ID) search types are supported with modem firmware versions >= 1.3.4.
- *         Result notification for GCI search types include Cell ID, PLMN and
- *         TAC for up to gci_count (@ref lte_lc_ncellmeas_params) surrounding cells and
- *         optionally, similarly to search types up to
- *         LTE_LC_NEIGHBOR_SEARCH_TYPE_EXTENDED_COMPLETE, a list of neighbor cell measurement
- *         results related to the current_cell (@ref lte_lc_cells_info).
+ * Result notification for Global Cell ID (GCI) search types include Cell ID, PLMN and TAC for up to
+ * @c gci_count (@ref lte_lc_ncellmeas_params) surrounding cells.
  */
 enum lte_lc_neighbor_search_type {
-	/** The modem searches the network it is registered to (RPLMN) based on
-	 *  previous cell history.
-	 *  For modem firmware versions < 1.3.1, this is the only valid option.
+	/**
+	 * The modem searches the network it is registered to (RPLMN) based on previous cell
+	 * history.
 	 */
 	LTE_LC_NEIGHBOR_SEARCH_TYPE_DEFAULT = 1,
 
-	/** The modem starts with the same search method as the default type.
-	 *  If needed, it continues to search by measuring the radio conditions
-	 *  and makes assumptions on where networks might be deployed, i.e. a light search.
-	 *  The search is limited to bands that are valid for the area of the current
-	 *  ITU-T region. If RPLMN is not found based on previous cell history, the
-	 *  modem accepts any found PLMN.
+	/**
+	 * The modem starts with the same search method as the default type. If needed, it
+	 * continues to search by measuring the radio conditions and makes assumptions on where
+	 * networks might be deployed, in other words, a light search. The search is limited to
+	 * bands that are valid for the area of the current ITU-T region. If RPLMN is not found
+	 * based on previous cell history, the modem accepts any found PLMN.
+	 *
+	 * @note This search type is only supported by modem firmware versions >= v1.3.1.
 	 */
 	LTE_LC_NEIGHBOR_SEARCH_TYPE_EXTENDED_LIGHT = 2,
 
-	/** The modem follows the same procedure as for LTE_LC_NEIGHBOR_SEARCH_TYPE_EXTENDED_LIGHT,
-	 *  but will continue to perform a complete search instead of a light search,
-	 *  and the search is performed for all supported bands.
+	/**
+	 * The modem follows the same procedure as for
+	 * @ref LTE_LC_NEIGHBOR_SEARCH_TYPE_EXTENDED_LIGHT, but will continue to perform a complete
+	 * search instead of a light search, and the search is performed for all supported bands.
+	 *
+	 * @note This search type is only supported by modem firmware versions >= v1.3.1.
 	 */
 	LTE_LC_NEIGHBOR_SEARCH_TYPE_EXTENDED_COMPLETE = 3,
 
-	/** GCI search, option 1. Modem searches EARFCNs based on previous cell history. */
+	/**
+	 * GCI search, option 1. Modem searches EARFCNs based on previous cell history.
+	 *
+	 * @note This search type is only supported by modem firmware versions >= v1.3.4.
+	 */
 	LTE_LC_NEIGHBOR_SEARCH_TYPE_GCI_DEFAULT = 4,
 
-	/** GCI search, option 2. Modem starts with the same search method as in
-	 *  LTE_LC_NEIGHBOR_SEARCH_TYPE_GCI_DEFAULT. If less than gci_count cells were found,
-	 *  the modem performs a light search on bands that are valid for the area of
-	 *  the current ITU-T region.
+	/**
+	 * GCI search, option 2. Modem starts with the same search method as in
+	 * @ref LTE_LC_NEIGHBOR_SEARCH_TYPE_GCI_DEFAULT. If less than gci_count cells were found,
+	 * the modem performs a light search on bands that are valid for the area of the current
+	 * ITU-T region.
+	 *
+	 * @note This search type is only supported by modem firmware versions >= v1.3.4.
 	 */
 	LTE_LC_NEIGHBOR_SEARCH_TYPE_GCI_EXTENDED_LIGHT = 5,
 
-	/** GCI search, option 3. Modem starts with the same search method as in
-	 *  LTE_LC_NEIGHBOR_SEARCH_TYPE_GCI_DEFAULT. If less than gci_count cells were found,
-	 *  the modem performs a complete search on all supported bands.
+	/**
+	 * GCI search, option 3. Modem starts with the same search method as in
+	 * @ref LTE_LC_NEIGHBOR_SEARCH_TYPE_GCI_DEFAULT. If less than gci_count cells were found,
+	 * the modem performs a complete search on all supported bands.
+	 *
+	 * @note This search type is only supported by modem firmware versions >= v1.3.4.
 	 */
 	LTE_LC_NEIGHBOR_SEARCH_TYPE_GCI_EXTENDED_COMPLETE = 6,
 };
 
-/** @brief Neighbor cell measurement initiation parameters.
- *
- *  @note For modem firmware versions < v1.3.1, LTE_LC_NEIGHBOR_SEARCH_TYPE_DEFAULT
- *	  is the only accepted search_type. Other types result in an error.
- *	  For modem firmware versions >= v1.3.4, also GCI search types and gci_count
- *        are accepted.
- */
+/** Neighbor cell measurement initiation parameters. */
 struct lte_lc_ncellmeas_params {
 	/** Search type, @ref lte_lc_neighbor_search_type. */
 	enum lte_lc_neighbor_search_type search_type;
 
-	/** Maximum number of cells to be searched. Integer, range: 2-15.
-	 *  Mandatory with the GCI search types, ignored with other search types.
+	/**
+	 * Maximum number of GCI cells to be searched. Integer, range: 2-15.
+	 *
+	 * Current cell is counted as one cell. Mandatory with the GCI search types, ignored with
+	 * other search types.
+	 *
+	 * @note GCI search types are only supported by modem firmware versions >= v1.3.4.
 	 */
 	uint8_t gci_count;
 };
 
-/** Configuration for periodic search of type LTE_LC_PERIODIC_SEARCH_PATTERN_RANGE. */
+
+/** Search pattern type. */
+enum lte_lc_periodic_search_pattern_type {
+	/** Range search pattern. */
+	LTE_LC_PERIODIC_SEARCH_PATTERN_RANGE = 0,
+
+	/** Table search pattern. */
+	LTE_LC_PERIODIC_SEARCH_PATTERN_TABLE = 1,
+};
+
+/** Configuration for periodic search of type @ref LTE_LC_PERIODIC_SEARCH_PATTERN_RANGE. */
 struct lte_lc_periodic_search_range_cfg {
-	/** Sleep time in seconds between searches in the beginning of the range.
-	 *  Allowed values: 0 - 65535 seconds.
+	/**
+	 * Sleep time between searches in the beginning of the range.
+	 *
+	 * Allowed values: 0 - 65535 seconds.
 	 */
 	uint16_t initial_sleep;
 
-	/** Sleep time in seconds between searches in the end of the range.
-	 *  Allowed values: 0 - 65535 seconds.
+	/**
+	 * Sleep time between searches in the end of the range.
+	 *
+	 * Allowed values: 0 - 65535 seconds.
 	 */
 	uint16_t final_sleep;
 
-	/** Optional target time in minutes for achieving the @c final_sleep value.
-	 *  This can be used to determine angle factor between the initial and final sleep times.
-	 *  The timeline for the @c time_to_final_sleep starts from the beginning of the search
-	 *  pattern.
-	 *  If given, the value cannot be greater than the value of the @c pattern_end_point value
-	 *  in the same search pattern.
-	 *  If not given, the angle factor is calculated by using the @c pattern_end_point value so
-	 *  that the @c final_sleep value is reached at the point of @c pattern_end_point.
+	/**
+	 * Optional target time in minutes for achieving the @c final_sleep value.
 	 *
-	 *  Allowed values:
-	 *  -1: Not used
-	 *   0 - 1080 minutes
+	 * This can be used to determine angle factor between the initial and final sleep times.
+	 * The timeline for the @c time_to_final_sleep starts from the beginning of the search
+	 * pattern. If given, the value cannot be greater than the value of the
+	 * @c pattern_end_point  value in the same search pattern. If not given, the angle factor
+	 * is calculated by using the @c pattern_end_point value so, that the @c final_sleep
+	 * value is reached at the point of @c pattern_end_point.
+	 *
+	 * Allowed values:
+	 * * -1: Not used
+	 * * 0 - 1080 minutes
 	 */
 	int16_t time_to_final_sleep;
 
-	/** Time in minutes that must elapse before entering the next search pattern. The timeline
-	 *  for @c pattern_end_point starts from the beginning of the limited service starting
-	 *  point, which is the moment when the first sleep period started.
+	/**
+	 * Time that must elapse before entering the next search pattern.
 	 *
-	 *  Allowed values: 0 - 1080 minutes.
+	 * The timeline for @c pattern_end_point starts from the beginning of the limited service
+	 * starting point, which is the moment when the first sleep period started.
+	 *
+	 * Allowed values:
+	 * * 0 - 1080 minutes.
 	 */
 	int16_t pattern_end_point;
 };
 
-/** Configuration for periodic search of type LTE_LC_PERIODIC_SEARCH_PATTERN_TABLE.
- *  1 to 5 sleep time values for sleep between searches can be configured.
- *  It's mandatory to provide @c val_1, while the rest are optional.
- *  Unused values must be set to -1.
- *  After going through all values, the last value of the last search pattern is repeated, if
- *  not configured differently by the @c loop or @c return_to_pattern parameters.
+/**
+ * Configuration for periodic search of type @ref LTE_LC_PERIODIC_SEARCH_PATTERN_TABLE.
  *
- *  Allowed values:
- *  -1: Value unused.
- *   0 - 65535 seconds.
+ * 1 to 5 sleep time values for sleep between searches can be configured. It is mandatory to provide
+ * @c val_1, while the rest are optional. Unused values must be set to -1. After going through all
+ * values, the last value of the last search pattern is repeated, if not configured differently by
+ * the @c loop or @c return_to_pattern parameters.
+ *
+ * Allowed values:
+ * * -1: Value unused.
+ * * 0 - 65535 seconds.
  */
 struct lte_lc_periodic_search_table_cfg {
-	/** Mandatory when LTE_LC_PERIODIC_SEARCH_PATTERN_TABLE is used. */
+	/** Mandatory sleep time. */
 	int val_1;
 
-	/** Optional sleep time.
-	 *  Must be set to -1 if not used.
+	/**
+	 * Optional sleep time.
+	 *
+	 * Must be set to -1 if not used.
 	 */
 	int val_2;
 
-	/** Optional sleep time. @c val_2 must be configured for this parameter to have effect.
+	/**
+	 * Optional sleep time.
+	 *
+	 * @c val_2 must be configured for this parameter to take effect.
+	 *
 	 *  Must be set to -1 if not used.
 	 */
 	int val_3;
 
-	/** Optional sleep time. @c val_3 must be configured for this parameter to have effect.
-	 *  Must be set to -1 if not used.
+	/**
+	 * Optional sleep time.
+	 *
+	 * @c val_3 must be configured for this parameter to take effect.
+	 *
+	 * Must be set to -1 if not used.
 	 */
 	int val_4;
 
-	/** Optional sleep time. @c val_4 must be configured for this parameter to have effect.
-	 *  Must be set to -1 if not used.
+	/**
+	 * Optional sleep time.
+	 *
+	 * @c val_4 must be configured for this parameter to take effect.
+	 *
+	 * Must be set to -1 if not used.
 	 */
 	int val_5;
 };
 
-/** @brief Periodic search pattern.
- *	   A search pattern may be of either 'range' or 'table' type.
+/**
+ * Periodic search pattern.
+ *
+ * A search pattern may be of either 'range' or 'table' type.
  */
 struct lte_lc_periodic_search_pattern {
-	enum lte_lc_periodic_search_pattern_type {
-		LTE_LC_PERIODIC_SEARCH_PATTERN_RANGE = 0,
-		LTE_LC_PERIODIC_SEARCH_PATTERN_TABLE = 1,
-	} type;
+	/** Search pattern type. */
+	enum lte_lc_periodic_search_pattern_type type;
 
 	union {
+		/** Configuration for periodic search of type 'range'. */
 		struct lte_lc_periodic_search_range_cfg range;
+
+		/** Configuration for periodic search of type 'table'. */
 		struct lte_lc_periodic_search_table_cfg table;
 	};
 };
 
-/** @brief Periodic search configuration. */
+/** Periodic search configuration. */
 struct lte_lc_periodic_search_cfg {
-	/** Indicates if the last given pattern is looped from the beginning
-	 *  when the pattern has ended.
-	 *  If several patterns are configured, this impacts only the last pattern.
+	/**
+	 * Indicates if the last given pattern is looped from the beginning when the pattern has
+	 * ended.
+	 *
+	 * If several patterns are configured, this impacts only the last pattern.
 	 */
 	bool loop;
 
-	/** Indicates if the modem can return to a given search pattern with shorter sleeps, for
-	 *  example, when radio conditions change and the given pattern index has already
-	 *  been exceeded.
+	/**
+	 * Indicates if the modem can return to a given search pattern with shorter sleeps, for
+	 * example, when radio conditions change and the given pattern index has already been
+	 * exceeded.
 	 *
-	 *  Allowed values:
-	 *  0: No return pattern.
-	 *  1 - 4: Return to search pattern index 1..4.
+	 * Allowed values:
+	 * * 0: No return pattern.
+	 * * 1 - 4: Return to search pattern index 1..4.
 	 */
 	uint16_t return_to_pattern;
 
-	/** 0: No optimization. Every periodic search shall be all band search.
-	 *  1: Use default optimizations predefined by modem. Predefinition depends on
-	 *     the active data profile.
-	 *     See "nRF91 AT Commands - Command Reference Guide" for more information.
-	 *  2 - 20: Every n periodic search must be an all band search.
+	/**
+	 * Indicates if band optimization shall be used.
+	 *
+	 * * 0: No optimization. Every periodic search shall be all band search.
+	 * * 1: Use default optimizations predefined by modem. Predefinition depends on
+	 *      the active data profile.
+	 *      See "nRF91 AT Commands - Command Reference Guide" for more information.
+	 * * 2 - 20: Every n periodic search must be an all band search.
 	 */
 	uint16_t band_optimization;
 
@@ -862,20 +1140,18 @@ struct lte_lc_periodic_search_cfg {
 	struct lte_lc_periodic_search_pattern patterns[4];
 };
 
-/**
- * @brief Link controller callback for modem functional mode changes.
- */
+/** Callback for modem functional mode changes. */
 struct lte_lc_cfun_cb {
 	void (*callback)(enum lte_lc_func_mode, void *ctx);
 	void *context;
 };
 
 /**
- * @brief Define a callback for functional mode changes through @ref lte_lc_func_mode_set.
+ * Define a callback for functional mode changes through lte_lc_func_mode_set().
  *
- * @param name Callback name
- * @param _callback Callback function
- * @param _context User-defined context
+ * @param name Callback name.
+ * @param _callback Callback function.
+ * @param _context User-defined context.
  */
 #define LTE_LC_ON_CFUN(name, _callback, _context)                                                  \
 	static void _callback(enum lte_lc_func_mode, void *ctx);                                   \
@@ -884,66 +1160,99 @@ struct lte_lc_cfun_cb {
 		.context = _context,                                                               \
 	};
 
+/** LTE event. */
 struct lte_lc_evt {
+	/** Event type. */
 	enum lte_lc_evt_type type;
+
 	union {
+		/** Payload for event @ref LTE_LC_EVT_NW_REG_STATUS. */
 		enum lte_lc_nw_reg_status nw_reg_status;
+
+		/** Payload for event @ref LTE_LC_EVT_RRC_UPDATE. */
 		enum lte_lc_rrc_mode rrc_mode;
+
+		/** Payload for event @ref LTE_LC_EVT_PSM_UPDATE. */
 		struct lte_lc_psm_cfg psm_cfg;
+
+		/** Payload for event @ref LTE_LC_EVT_EDRX_UPDATE. */
 		struct lte_lc_edrx_cfg edrx_cfg;
+
+		/** Payload for event @ref LTE_LC_EVT_CELL_UPDATE. */
 		struct lte_lc_cell cell;
+
+		/** Payload for event @ref LTE_LC_EVT_LTE_MODE_UPDATE. */
 		enum lte_lc_lte_mode lte_mode;
+
+		/**
+		 * Payload for events @ref LTE_LC_EVT_MODEM_SLEEP_EXIT_PRE_WARNING,
+		 * @ref LTE_LC_EVT_MODEM_SLEEP_EXIT and @ref LTE_LC_EVT_MODEM_SLEEP_ENTER.
+		 */
 		struct lte_lc_modem_sleep modem_sleep;
+
+		/** Payload for event @ref LTE_LC_EVT_MODEM_EVENT. */
 		enum lte_lc_modem_evt modem_evt;
 
-		/* Time until next Tracking Area Update in milliseconds. */
+		/**
+		 * Payload for event @ref LTE_LC_EVT_TAU_PRE_WARNING.
+		 *
+		 * Time until next Tracking Area Update in milliseconds.
+		 */
 		uint64_t time;
 
+		/** Payload for event @ref LTE_LC_EVT_NEIGHBOR_CELL_MEAS. */
 		struct lte_lc_cells_info cells_info;
 	};
 };
 
+/**
+ * Handler for LTE events.
+ *
+ * @param[in] evt Event.
+ */
 typedef void(*lte_lc_evt_handler_t)(const struct lte_lc_evt *const evt);
 
-/** @brief Register event handler for LTE events.
+/**
+ * Register handler for LTE events.
  *
- *  @param handler Event handler.
+ * @param[in] handler Event handler.
  */
-
 void lte_lc_register_handler(lte_lc_evt_handler_t handler);
 
 /**
- * @brief Function to de-register event handler for LTE events.
+ * De-register handler for LTE events.
  *
- *  @param handler Event handler.
+ * @param[in] handler Event handler.
  *
- * @retval 0            If command execution was successful.
- * @retval -ENXIO       If handler cannot be found.
- * @retval -EINVAL      If handler is a NULL pointer.
+ * @retval 0 if successful.
+ * @retval -ENXIO if the handler was not found.
+ * @retval -EINVAL if the handler was a @c NULL pointer.
  */
 int lte_lc_deregister_handler(lte_lc_evt_handler_t handler);
 
-/** @brief Initializes the module and configures the modem.
+/**
+ * Initialize the library and configure the modem.
  *
- * @note a follow-up call to lte_lc_connect() or lte_lc_connect_async() must be
- *	 made to establish an LTE connection. The module can be initialized
- *	 only once, and subsequent calls will return 0.
+ * @note A follow-up call to lte_lc_connect() or lte_lc_connect_async() must be made to establish
+ *       an LTE connection. The library can be initialized only once, and subsequent calls will
+ *       return @c 0.
  *
  * @retval 0 if successful.
  * @retval -EFAULT if an AT command failed.
  */
 int lte_lc_init(void);
 
-/** @brief Function to make a connection with the modem.
+/**
+ * Connect to LTE network.
  *
- * @note Prior to calling this function a call to @ref lte_lc_init
- *	 must be made, otherwise -EPERM is returned.
+ * @note Before calling this function, a call to lte_lc_init() must be made, otherwise @c -EPERM is
+ *       returned.
  *
- * @note After initialization, the system mode will be set to the default mode
- *	 selected with Kconfig and LTE preference set to automatic selection.
+ * @note After initialization, the system mode will be set to the default mode selected with Kconfig
+ *       and LTE preference set to automatic selection.
  *
  * @retval 0 if successful.
- * @retval -EPERM if the link controller was not initialized.
+ * @retval -EPERM if the library was not initialized.
  * @retval -EFAULT if an AT command failed.
  * @retval -ETIMEDOUT if a connection attempt timed out before the device was
  *	   registered to a network.
@@ -951,13 +1260,13 @@ int lte_lc_init(void);
  */
 int lte_lc_connect(void);
 
-/** @brief Initializes the LTE module, configures the modem and connects to LTE
- *	   network. The function blocks until connection is established, or
- *	   the connection attempt times out.
+/**
+ * Initialize the library, configure the modem and connect to LTE network.
  *
- * @note The module can be initialized only once, and repeated calls will
- *	 return 0. lte_lc_connect_async() should be used on subsequent
- *	 calls.
+ * The function blocks until connection is established, or the connection attempt times out.
+ *
+ * @note The library can be initialized only once, and repeated calls will return @c 0.
+ *       lte_lc_connect_async() should be used on subsequent calls.
  *
  * @retval 0 if successful.
  * @retval -EFAULT if an AT command failed.
@@ -967,12 +1276,15 @@ int lte_lc_connect(void);
  */
 int lte_lc_init_and_connect(void);
 
-/** @brief Connect to LTE network. Non-blocking.
+/**
+ * Connect to LTE network.
  *
- * @note The module must be initialized before this function is called.
+ * The function returns immediately.
  *
- * @param handler Event handler for receiving LTE events. The parameter can be
- *	          NULL if an event handler is already registered.
+ * @note The library must be initialized before this function is called.
+ *
+ * @param[in] handler Event handler for receiving LTE events. The parameter can be @c NULL if an
+ *                    event handler is already registered.
  *
  * @retval 0 if successful.
  * @retval -EINVAL if no event handler was registered.
@@ -980,14 +1292,16 @@ int lte_lc_init_and_connect(void);
  */
 int lte_lc_connect_async(lte_lc_evt_handler_t handler);
 
-/** @brief Initializes the LTE module, configures the modem and connects to LTE
- *	   network. Non-blocking.
+/**
+ * Initialize the library, configure the modem and connect to LTE network.
  *
- * @note The module can be initialized only once, and repeated calls will
- *	 return 0. lte_lc_connect() should be used on subsequent calls.
+ * The function returns immediately.
  *
- * @param handler Event handler for receiving LTE events. The parameter can be
- *		  NULL if an event handler is already registered.
+ * @note The library can be initialized only once, and repeated calls will return @c 0.
+ *       lte_lc_connect() should be used on subsequent calls.
+ *
+ * @param[in] handler Event handler for receiving LTE events. The parameter can be @c NULL if an
+ *                    event handler is already registered.
  *
  * @retval 0 if successful.
  * @retval -EFAULT if an AT command failed.
@@ -995,73 +1309,82 @@ int lte_lc_connect_async(lte_lc_evt_handler_t handler);
  */
 int lte_lc_init_and_connect_async(lte_lc_evt_handler_t handler);
 
-/** @brief Deinitialize the LTE module, powers of the modem.
+/**
+ * Deinitialize the library and power off the modem.
  *
  * @retval 0 if successful.
  * @retval -EFAULT if an AT command failed.
  */
 int lte_lc_deinit(void);
 
-/** @brief Function for sending the modem to offline mode
+/**
+ * Set the modem to offline mode.
  *
  * @retval 0 if successful.
  * @retval -EFAULT if the functional mode could not be configured.
  */
 int lte_lc_offline(void);
 
-/** @brief Function for sending the modem to power off mode
+/**
+ * Set the modem to power off mode.
  *
  * @retval 0 if successful.
  * @retval -EFAULT if the functional mode could not be configured.
  */
 int lte_lc_power_off(void);
 
-/** @brief Function for sending the modem to normal mode
+/**
+ * Set the modem to normal mode.
  *
  * @retval 0 if successful.
  * @retval -EFAULT if the functional mode could not be configured.
  */
 int lte_lc_normal(void);
 
-/** @brief Function for setting modem PSM parameters:
- *         requested periodic TAU (RPTAU) and requested active time (RAT)
- *         to be used when PSM mode is subsequently enabled using `lte_lc_psm_req`.
- *         For reference see 3GPP 27.007 Ch. 7.38.
+/**
+ * Set modem PSM parameters.
  *
- * @param rptau Requested periodic TAU as null-terminated string.
- *              Set NULL to use manufacturer-specific default value.
- * @param rat Requested active time as null-terminated string.
- *            Set NULL to use manufacturer-specific default value.
+ * Requested periodic TAU (RPTAU) and requested active time (RAT) are used when PSM mode is
+ * subsequently enabled using lte_lc_psm_req().
+ *
+ * For reference see 3GPP 27.007 Ch. 7.38.
+ *
+ * @param[in] rptau Requested periodic TAU as a null-terminated string.
+ *                  Set to @c NULL to use manufacturer-specific default value.
+ * @param[in] rat Requested active time as a null-terminated string.
+ *                Set to @c NULL to use manufacturer-specific default value.
  *
  * @retval 0 if successful.
  * @retval -EINVAL if an input parameter was invalid.
  */
 int lte_lc_psm_param_set(const char *rptau, const char *rat);
 
-/** @brief Function for requesting modem to enable or disable
- *         power saving mode (PSM) using default Kconfig value or as set using
- *         `lte_lc_psm_param_set`.
+/**
+ * Request modem to enable or disable power saving mode (PSM).
  *
- *  @note CONFIG_LTE_PSM_REQ can be set to enable PSM, which is generally sufficient.
- *	  This option allows explicit disabling/enabling of PSM requesting
- *	  after modem initialization.
- *	  Calling this function for run-time control is possible, but it should be noted that
- *	  conflicts may arise with the value set by CONFIG_LTE_PSM_REQ if it is called
- *	  during modem initialization.
+ * PSM parameters can be set using @kconfig{CONFIG_LTE_PSM_REQ_RPTAU} and
+ * @kconfig{CONFIG_LTE_PSM_REQ_RAT}, or by calling lte_lc_psm_param_set().
+ *
+ * @note @kconfig{CONFIG_LTE_PSM_REQ} can be set to enable PSM, which is generally sufficient. This
+ *       option allows explicit disabling/enabling of PSM requesting after modem initialization.
+ *       Calling this function for run-time control is possible, but it should be noted that
+ *       conflicts may arise with the value set by @kconfig{CONFIG_LTE_PSM_REQ} if it is called
+ *       during modem initialization.
+ *
+ * @param[in] enable @c true to enable PSM, @c false to disable PSM.
  *
  * @retval 0 if successful.
  * @retval -EFAULT if AT command failed.
  */
 int lte_lc_psm_req(bool enable);
 
-/** @brief Function for getting the current PSM (Power Saving Mode)
- *	   configurations for periodic TAU (Tracking Area Update) and
- *	   active time, both in units of seconds.
+/**
+ * Get the current PSM (Power Saving Mode) configuration.
  *
- * @param tau Pointer to the variable for parsed periodic TAU interval in
- *	      seconds. Positive integer, or -1 if timer is deactivated.
- * @param active_time Pointer to the variable for parsed active time in seconds.
- *	              Positive integer, or -1 if timer is deactivated.
+ * @param[out] tau Periodic TAU interval in seconds. Positive integer,
+ *                 or @c -1 if timer is deactivated.
+ * @param[out] active_time Active time in seconds. Positive integer,
+ *                         or @c -1 if timer is deactivated.
  *
  * @retval 0 if successful.
  * @retval -EINVAL if input argument was invalid.
@@ -1071,72 +1394,87 @@ int lte_lc_psm_req(bool enable);
  */
 int lte_lc_psm_get(int *tau, int *active_time);
 
-/** @brief Function for setting Paging Time Window (PTW) value to be used when
- *	   eDRX is requested using `lte_lc_edrx_req`. PTW is set individually
- *	   for LTE-M and NB-IoT.
- *	   Requesting a specific PTW configuration should be done with caution.
- *	   The requested value must be compliant with the eDRX value that is
- *	   configured, and it's usually best to let the modem use default PTW
- *	   values.
- *	   For reference to which values can be set, see subclause 10.5.5.32 of 3GPP TS 24.008.
+/**
+ * Set the Paging Time Window (PTW) value to be used with eDRX.
  *
- * @param mode LTE mode to which the PTW value applies.
- * @param ptw Paging Time Window value as null-terminated string.
- *            Set NULL to use manufacturer-specific default value.
+ * eDRX can be requested using lte_lc_edrx_req(). PTW is set individually for LTE-M and NB-IoT.
+ *
+ * Requesting a specific PTW configuration should be done with caution. The requested value must be
+ * compliant with the eDRX value that is configured, and it is usually best to let the modem
+ * use default PTW values.
+ *
+ * For reference to which values can be set, see subclause 10.5.5.32 of 3GPP TS 24.008.
+ *
+ * @param[in] mode LTE mode to which the PTW value applies.
+ * @param[in] ptw Paging Time Window value as a null-terminated string.
+ *                Set to @c NULL to use manufacturer-specific default value.
  *
  * @retval 0 if successful.
  * @retval -EINVAL if an input parameter was invalid.
  */
 int lte_lc_ptw_set(enum lte_lc_lte_mode mode, const char *ptw);
 
-/** @brief Function for setting modem eDRX value to be used when
- *         eDRX is subsequently enabled using `lte_lc_edrx_req`.
- *         For reference see 3GPP 27.007 Ch. 7.40.
+/**
+ * Set the requested eDRX value.
  *
- * @param mode LTE mode to which the eDRX value applies.
- * @param edrx eDRX value as null-terminated string.
- *             Set NULL to use manufacturer-specific default.
+ * eDRX can be requested using lte_lc_edrx_req(). eDRX value is set individually for LTE-M and
+ * NB-IoT.
+ *
+ * For reference see 3GPP 27.007 Ch. 7.40.
+ *
+ * @param[in] mode LTE mode to which the eDRX value applies.
+ * @param[in] edrx eDRX value as a null-terminated string.
+ *                 Set to @c NULL to use manufacturer-specific default.
  *
  * @retval 0 if successful.
  * @retval -EINVAL if an input parameter was invalid.
  */
 int lte_lc_edrx_param_set(enum lte_lc_lte_mode mode, const char *edrx);
 
-/** @brief Function for requesting modem to enable or disable
- *         use of eDRX using values set by `lte_lc_edrx_param_set`. The
- *         default values are defined in Kconfig.
- *         For reference see 3GPP 27.007 Ch. 7.40.
+/**
+ * Request modem to enable or disable use of eDRX.
  *
- *  @note CONFIG_LTE_EDRX_REQ can be set to enable eDRX, which is generally sufficient.
- *	  This option allows explicit disabling/enabling of eDRX requesting after
- *	  modem initialization.
- *	  Calling this function for run-time control is possible, but it should be noted that
- *	  conflicts may arise with the value set by CONFIG_LTE_EDRX_REQ if it is called
- *	  during modem initialization.
+ * eDRX parameters can be set using @kconfig{CONFIG_LTE_EDRX_REQ_VALUE_LTE_M},
+ * @kconfig{CONFIG_LTE_EDRX_REQ_VALUE_NBIOT}, @kconfig{CONFIG_LTE_PTW_VALUE_LTE_M} and
+ * @kconfig{CONFIG_LTE_PTW_VALUE_NBIOT}, or by calling lte_lc_edrx_param_set() and
+ * lte_lc_ptw_set().
  *
- * @param enable Boolean value enabling or disabling the use of eDRX.
+ * For reference see 3GPP 27.007 Ch. 7.40.
+ *
+ * @note @kconfig{CONFIG_LTE_EDRX_REQ} can be set to enable eDRX, which is generally sufficient.
+ *       This option allows explicit disabling/enabling of eDRX requesting after modem
+ *       initialization. Calling this function for run-time control is possible, but it should be
+ *       noted that conflicts may arise with the value set by @kconfig{CONFIG_LTE_EDRX_REQ} if it is
+ *       called during modem initialization.
+ *
+ * @param[in] enable @c true to enable eDRX, @c false to disable eDRX.
  *
  * @retval 0 if successful.
  * @retval -EFAULT if AT command failed.
  */
 int lte_lc_edrx_req(bool enable);
 
-/** @brief Function for setting modem RAI value to be used when
- *         RAI is subsequently enabled using `lte_lc_rai_req`.
- *         For reference see 3GPP 24.301 Ch. 9.9.4.25.
+/**
+ * Set the RAI value to be used.
  *
- * @param value RAI value.
+ * RAI can be subsequently enabled using lte_lc_rai_req().
+ *
+ * For reference see 3GPP 24.301 Ch. 9.9.4.25.
+ *
+ * @param[in] value RAI value as a null-terminated string.
  *
  * @retval 0 if successful.
  * @retval -EINVAL if an input parameter was invalid.
  */
 int lte_lc_rai_param_set(const char *value);
 
-/** @brief Function for requesting modem to enable or disable
- *         use of RAI using values set by `lte_lc_rai_param_set`. The
- *         default values are defined in Kconfig.
+/**
+ * Request modem to enable or disable use of RAI.
  *
- * @param enable Boolean value enabling or disabling the use of RAI.
+ * Used RAI value can be set using @kconfig{CONFIG_LTE_RAI_REQ_VALUE} or by calling
+ * lte_lc_rai_param_set().
+ *
+ * @param[in] enable @c true to enable RAI, @c false to disable RAI.
  *
  * @retval 0 if successful.
  * @retval -EFAULT if AT command failed.
@@ -1144,9 +1482,10 @@ int lte_lc_rai_param_set(const char *value);
  */
 int lte_lc_rai_req(bool enable);
 
-/** @brief Get the current network registration status.
+/**
+ * Get the current network registration status.
  *
- * @param status Pointer for network registration status.
+ * @param[out] status Network registration status.
  *
  * @retval 0 if successful.
  * @retval -EINVAL if input argument was invalid.
@@ -1154,10 +1493,11 @@ int lte_lc_rai_req(bool enable);
  */
 int lte_lc_nw_reg_status_get(enum lte_lc_nw_reg_status *status);
 
-/** @brief Set the modem's system mode and LTE preference.
+/**
+ * Set the modem's system mode and LTE preference.
  *
- * @param mode System mode to set.
- * @param preference System mode preference.
+ * @param[in] mode System mode.
+ * @param[in] preference System mode preference.
  *
  * @retval 0 if successful.
  * @retval -EINVAL if input argument was invalid.
@@ -1166,10 +1506,11 @@ int lte_lc_nw_reg_status_get(enum lte_lc_nw_reg_status *status);
 int lte_lc_system_mode_set(enum lte_lc_system_mode mode,
 			   enum lte_lc_system_mode_preference preference);
 
-/** @brief Get the modem's system mode and LTE preference.
+/**
+ * Get the modem's system mode and LTE preference.
  *
- * @param mode Pointer to system mode variable.
- * @param preference Pointer to system mode preference variable. Can be NULL.
+ * @param[out] mode System mode.
+ * @param[out] preference System mode preference. Can be @c NULL.
  *
  * @retval 0 if successful.
  * @retval -EINVAL if input argument was invalid.
@@ -1178,9 +1519,10 @@ int lte_lc_system_mode_set(enum lte_lc_system_mode mode,
 int lte_lc_system_mode_get(enum lte_lc_system_mode *mode,
 			   enum lte_lc_system_mode_preference *preference);
 
-/** @brief Set the modem's functional mode.
+/**
+ * Set the modem's functional mode.
  *
- * @param mode Functional mode to set.
+ * @param[in] mode Functional mode.
  *
  * @retval 0 if successful.
  * @retval -EINVAL if input argument was invalid.
@@ -1188,9 +1530,10 @@ int lte_lc_system_mode_get(enum lte_lc_system_mode *mode,
  */
 int lte_lc_func_mode_set(enum lte_lc_func_mode mode);
 
-/** @brief Get the modem's functional mode.
+/**
+ * Get the modem's functional mode.
  *
- * @param mode Pointer to functional mode variable.
+ * @param[out] mode Functional mode.
  *
  * @retval 0 if successful.
  * @retval -EINVAL if input argument was invalid.
@@ -1198,9 +1541,10 @@ int lte_lc_func_mode_set(enum lte_lc_func_mode mode);
  */
 int lte_lc_func_mode_get(enum lte_lc_func_mode *mode);
 
-/** @brief Get the currently active LTE mode.
+/**
+ * Get the currently active LTE mode.
  *
- * @param mode Pointer to LTE mode variable.
+ * @param[out] mode LTE mode.
  *
  * @retval 0 if successful.
  * @retval -EINVAL if input argument was invalid.
@@ -1209,23 +1553,19 @@ int lte_lc_func_mode_get(enum lte_lc_func_mode *mode);
  */
 int lte_lc_lte_mode_get(enum lte_lc_lte_mode *mode);
 
-/** @brief Initiate a neighbor cell measurement.
- *         The result of the measurement is reported back as an event of the type
- *         LTE_LC_EVT_NEIGHBOR_CELL_MEAS, meaning that an event handler must be
- *         registered to receive the information.
- *	   Depending on the network conditions, LTE connection state and requested
- *         search type, it may take a while before the measurement result is
- *         ready and reported back.
- *         After the event is received, the neighbor cell measurements are automatically stopped.
+/**
+ * Initiate a neighbor cell measurement.
  *
- * @note For modem firmware versions < v1.3.1, LTE_LC_NEIGHBOR_SEARCH_TYPE_DEFAULT
- *       is the only accepted type. Other types will result in an error being returned.
- *       For modem firmware versions >= v1.3.4, also GCI search types and gci_count
- *       are accepted.
+ * The result of the measurement is reported back as an event of the type
+ * @ref LTE_LC_EVT_NEIGHBOR_CELL_MEAS, meaning that an event handler must be registered to receive
+ * the information. Depending on the network conditions, LTE connection state and requested search
+ * type, it may take a while before the measurement result is ready and reported back. After the
+ * event is received, the neighbor cell measurements are automatically stopped.
  *
- * @param params Pointer to search type parameters or NULL to initiate a measurement
- *               with the default parameters.
- *               See @c struct lte_lc_ncellmeas_params for more information.
+ * @note This feature is only supported by modem firmware versions >= v1.3.0.
+ *
+ * @param[in] params Search type parameters or @c NULL to initiate a measurement with the default
+ *                   parameters. See @ref lte_lc_ncellmeas_params for more information.
  *
  * @retval 0 if neighbor cell measurement was successfully initiated.
  * @retval -EFAULT if AT command failed.
@@ -1233,32 +1573,34 @@ int lte_lc_lte_mode_get(enum lte_lc_lte_mode *mode);
  */
 int lte_lc_neighbor_cell_measurement(struct lte_lc_ncellmeas_params *params);
 
-/** @brief Cancel an ongoing neighbor cell measurement.
- *
+/**
+ * Cancel an ongoing neighbor cell measurement.
  *
  * @retval 0 if neighbor cell measurement was cancelled.
  * @retval -EFAULT if AT command failed.
  */
 int lte_lc_neighbor_cell_measurement_cancel(void);
 
-/** @brief Get connection evaluation parameters. Connection evaluation parameters can be used to
- *	   determine the energy efficiency of data transmission prior to the actual
- *	   data transmission.
+/**
+ * Get connection evaluation parameters.
  *
- * @param params Pointer to structure to hold connection evaluation parameters.
+ * Connection evaluation parameters can be used to determine the energy efficiency of data
+ * transmission before the actual data transmission.
+ *
+ * @param[out] params Connection evaluation parameters.
  *
  * @return Zero on success, negative errno code if the API call fails, and a positive error
  *         code if the API call succeeds but connection evaluation fails due to modem/network
  *         related reasons.
  *
- * @retval 0 Evaluation succeeded.
- * @retval 1 Evaluation failed, no cell available.
- * @retval 2 Evaluation failed, UICC not available.
- * @retval 3 Evaluation failed, only barred cells available.
- * @retval 4 Evaluation failed, radio busy (e.g GNSS activity)
- * @retval 5 Evaluation failed, aborted due to higher priority operation.
- * @retval 6 Evaluation failed, UE not registered to network.
- * @retval 7 Evaluation failed, Unspecified.
+ * @retval 0 if evaluation succeeded.
+ * @retval 1 if evaluation failed, no cell available.
+ * @retval 2 if evaluation failed, UICC not available.
+ * @retval 3 if evaluation failed, only barred cells available.
+ * @retval 4 if evaluation failed, radio busy (e.g GNSS activity).
+ * @retval 5 if evaluation failed, aborted due to higher priority operation.
+ * @retval 6 if evaluation failed, UE not registered to network.
+ * @retval 7 if evaluation failed, unspecified.
  * @retval -EINVAL if input argument was invalid.
  * @retval -EFAULT if AT command failed.
  * @retval -EOPNOTSUPP if connection evaluation is not available in the current functional mode.
@@ -1266,53 +1608,60 @@ int lte_lc_neighbor_cell_measurement_cancel(void);
  */
 int lte_lc_conn_eval_params_get(struct lte_lc_conn_eval_params *params);
 
-/** @brief Enable modem domain events. See @ref lte_lc_modem_evt for
- *	   more information on what events may be received.
+/**
+ * Enable modem domain events.
  *
- *  @note This feature is supported for nRF9160 modem firmware v1.3.0 and later
- *	  versions. Attempting to use this API with older modem versions will
- *	  result in an error being returned.
+ * See @ref lte_lc_modem_evt for more information on which events may be received.
+ * An event handler must be registered to receive events.
  *
- *  @note An event handler must be registered in order to receive events.
- *
+ * @note This feature is only supported by modem firmware versions >= v1.3.0.
  *
  * @retval 0 if successful.
  * @retval -EFAULT if AT command failed.
  */
 int lte_lc_modem_events_enable(void);
 
-/** @brief Disable modem domain events.
+/**
+ * Disable modem domain events.
  *
  * @retval 0 if successful.
  * @retval -EFAULT if AT command failed.
  */
 int lte_lc_modem_events_disable(void);
 
-/** @brief Configure periodic searches. This configuration affects the periodic searches
- *	   that the modem performs in limited service state to obtain normal service.
- *	   See @c struct lte_lc_periodic_search_cfg and
- *	   "nRF91 AT Commands - Command Reference Guide" for more information and
- *	   in-depth explanations of periodic search configuration.
+/**
+ * Configure periodic searches.
+ *
+ * This configuration affects the periodic searches that the modem performs in limited service state
+ * to obtain normal service. See @ref lte_lc_periodic_search_cfg and
+ * "nRF91 AT Commands - Command Reference Guide" for more information and in-depth explanations of
+ * periodic search configuration.
+ *
+ * @param[in] cfg Periodic search configuration.
  *
  * @retval 0 if the configuration was successfully sent to the modem.
- * @retval -EINVAL if an input parameter was NULL or contained an invalid pattern count.
+ * @retval -EINVAL if an input parameter was @c NULL or contained an invalid pattern count.
  * @retval -EFAULT if an AT command could not be sent to the modem.
  * @retval -EBADMSG if the modem responded with an error to an AT command.
  */
 int lte_lc_periodic_search_set(const struct lte_lc_periodic_search_cfg *const cfg);
 
-/** @brief Get the configured periodic search parameters.
+/**
+ * Get the configured periodic search parameters.
+ *
+ * @param[out] cfg Periodic search configuration.
  *
  * @retval 0 if a configuration was found and populated to the provided pointer.
- * @retval -EINVAL if input parameter was NULL.
+ * @retval -EINVAL if input parameter was @c NULL.
  * @retval -ENOENT if no periodic search was not configured.
  * @retval -EFAULT if an AT command failed.
  * @retval -EBADMSG if the modem responded with an error to an AT command or the
- *		    response could not be parsed.
+ *         response could not be parsed.
  */
 int lte_lc_periodic_search_get(struct lte_lc_periodic_search_cfg *const cfg);
 
-/** @brief Clear the configured periodic search parameters.
+/**
+ * Clear the configured periodic search parameters.
  *
  * @retval 0 if the configuration was cleared.
  * @retval -EFAULT if an AT command could not be sent to the modem.
@@ -1320,50 +1669,50 @@ int lte_lc_periodic_search_get(struct lte_lc_periodic_search_cfg *const cfg);
  */
 int lte_lc_periodic_search_clear(void);
 
-/** @brief Request an extra search. This can be used for example when modem is in
- *	   sleep state between periodic searches. The search is performed only when
- *	   the modem is in sleep state between periodic searches.
+/**
+ * Request an extra search.
+ *
+ * This can be used for example when modem is in sleep state between periodic searches. The search
+ * is performed only when the modem is in sleep state between periodic searches.
  *
  * @retval 0 if the search request was successfully delivered to the modem.
  * @retval -EFAULT if an AT command could not be sent to the modem.
  */
 int lte_lc_periodic_search_request(void);
 
-/** @brief Read the current reduced mobility mode.
+/**
+ * Read the current reduced mobility mode.
  *
- *  @note This feature is supported for nRF9160 modem firmware v1.3.2 and later
- *	  versions. Attempting to use this API with older modem versions will
- *	  result in an error being returned.
+ * @note This feature is only supported by modem firmware versions >= v1.3.2.
  *
- * @param[out] mode pointer to where the current reduced mobility mode should be written to
+ * @param[out] mode Reduced mobility mode.
  *
  * @retval 0 if a mode was found and written to the provided pointer.
- * @retval -EINVAL if input parameter was NULL.
+ * @retval -EINVAL if input parameter was @c NULL.
  * @retval -EFAULT if an AT command failed.
  */
 int lte_lc_reduced_mobility_get(enum lte_lc_reduced_mobility_mode *mode);
 
-/** @brief Set reduced mobility mode.
+/**
+ * Set reduced mobility mode.
  *
- *  @note This feature is supported for nRF9160 modem firmware v1.3.2 and later
- *	  versions. Attempting to use this API with older modem versions will
- *	  result in an error being returned.
+ * @note This feature is only supported by modem firmware versions >= v1.3.2.
  *
- * @param[in] mode new reduced mobility mode
+ * @param[in] mode Reduced mobility mode.
  *
  * @retval 0 if the new reduced mobility mode was accepted by the modem.
  * @retval -EFAULT if an AT command failed.
  */
 int lte_lc_reduced_mobility_set(enum lte_lc_reduced_mobility_mode mode);
 
-/** @brief Reset modem to factory settings.
- *	   This operation is only allowed when the modem is not activated.
+/**
+ * Reset modem to factory settings.
  *
- *  @note This feature is supported for nRF9160 modem firmware v1.3.0 and later
- *	  versions. Attempting to use this API with older modem versions will
- *	  result in an error being returned.
+ * This operation is allowed only when the modem is not activated.
  *
- * @param type Variable that determines what type of modem data will be reset.
+ * @note This feature is only supported by modem firmware versions >= v1.3.0.
+ *
+ * @param[in] type Factory reset type.
  *
  * @retval 0 if factory reset was performed successfully.
  * @retval -EFAULT if an AT command failed.
@@ -1376,4 +1725,4 @@ int lte_lc_factory_reset(enum lte_lc_factory_reset_type type);
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_LTE_LINK_CONTROL_H_ */
+#endif /* LTE_LC_H__ */

--- a/include/modem/lte_lc_trace.h
+++ b/include/modem/lte_lc_trace.h
@@ -3,8 +3,8 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
-#ifndef ZEPHYR_INCLUDE_LTE_LINK_CONTROL_TRACE_H_
-#define ZEPHYR_INCLUDE_LTE_LINK_CONTROL_TRACE_H_
+#ifndef LTE_LC_TRACE_H__
+#define LTE_LC_TRACE_H__
 
 #include <zephyr/sys/util.h>
 
@@ -54,4 +54,4 @@ void lte_lc_trace_capture(enum lte_lc_trace_type type);
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_LTE_LINK_CONTROL_TRACE_H_ */
+#endif /* LTE_LC_TRACE_H__ */


### PR DESCRIPTION
Added missing descriptions. Improved the Doxygen generated documentation layout and made the documentation more consistent.