### PR TITLE
samples: openthread: increase the default RX stack size for logging

### DIFF
--- a/samples/openthread/cli/overlay-logging.conf
+++ b/samples/openthread/cli/overlay-logging.conf
@@ -5,6 +5,9 @@
 # Enable Zephyr logging
 CONFIG_LOG=y
 
+# Increase the default RX stack size
+CONFIG_IEEE802154_NRF5_RX_STACK_SIZE=832
+
 # Use separate thread for logging
 CONFIG_LOG_MODE_DEFERRED=y
 


### PR DESCRIPTION
For nrf5340 in cli samples with logging enabled, `nrf5_rx` usage can go up to 808 bytes, resulting with overflow.
This commit increases the default RX stack size if `overlay-logging.conf` is enabled.