### PR TITLE
samples: matter: Moved confirmation of the OTA image to the Init.

### DIFF
--- a/applications/matter_bridge/src/app_task.cpp
+++ b/applications/matter_bridge/src/app_task.cpp
@@ -131,6 +131,14 @@ CHIP_ERROR AppTask::Init()
 	k_timer_init(&sFunctionTimer, &AppTask::FunctionTimerTimeoutCallback, nullptr);
 	k_timer_user_data_set(&sFunctionTimer, this);
 
+#ifdef CONFIG_CHIP_OTA_REQUESTOR
+	/* OTA image confirmation must be done before the factory data init. */
+	err = OtaConfirmNewImage();
+	if (err != CHIP_NO_ERROR) {
+		return err;
+	}
+#endif
+
 	/* Initialize CHIP server */
 #if CONFIG_CHIP_FACTORY_DATA
 	ReturnErrorOnFailure(mFactoryDataProvider.Init());

--- a/applications/matter_weather_station/src/app_task.cpp
+++ b/applications/matter_weather_station/src/app_task.cpp
@@ -217,6 +217,21 @@ CHIP_ERROR AppTask::Init()
 		return chip::System::MapErrorZephyr(ret);
 	}
 
+#ifdef CONFIG_CHIP_OTA_REQUESTOR
+	/* OTA image confirmation must be done before the factory data init. */
+	err = OtaConfirmNewImage();
+	if (err != CHIP_NO_ERROR) {
+		return err;
+	}
+#endif
+
+#ifdef CONFIG_MCUMGR_TRANSPORT_BT
+	/* Initialize DFU over SMP */
+	GetDFUOverSMP().Init();
+	GetDFUOverSMP().ConfirmNewImage();
+	GetDFUOverSMP().StartServer();
+#endif
+
 /* Get factory data */
 #ifdef CONFIG_CHIP_FACTORY_DATA
 	ReturnErrorOnFailure(mFactoryDataProvider.Init());
@@ -233,13 +248,6 @@ CHIP_ERROR AppTask::Init()
 #else
 	SetDeviceInstanceInfoProvider(&DeviceInstanceInfoProviderMgrImpl());
 	SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
-#endif
-
-#ifdef CONFIG_MCUMGR_TRANSPORT_BT
-	/* Initialize DFU over SMP */
-	GetDFUOverSMP().Init();
-	GetDFUOverSMP().ConfirmNewImage();
-	GetDFUOverSMP().StartServer();
 #endif
 
 	/* Initialize timers */

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -101,10 +101,15 @@ See `Bluetooth mesh samples`_ for the list of changes in the Bluetooth mesh samp
 Matter
 ------
 
-* Fixed an IPC crash on nRF5340 when Zephyr's main thread takes a long time.
 * Disabled OpenThread shell by default in Matter over Thread samples.
 * Enabled :kconfig:option:`CHIP_FACTORY_RESET_ERASE_NVS` Kconfig option by default, including for builds without factory data support.
   The firmware now erases all flash pages in the non-volatile storage during a factory reset, instead of just clearing Matter-related settings.
+
+* Fixed:
+
+  * An IPC crash on nRF5340 when Zephyr's main thread takes a long time.
+  * An application core crash on nRF5340 targets with the factory data module enabled.
+    The crash would happen after the OTA firmware update finishes and the image is confirmed.
 
 * Added:
 

--- a/samples/matter/common/src/ota_util.h
+++ b/samples/matter/common/src/ota_util.h
@@ -30,6 +30,16 @@ chip::DeviceLayer::OTAImageProcessorImpl &GetOTAImageProcessor();
  */
 void InitBasicOTARequestor();
 
+/**
+ * Check if the current image is the first boot the after OTA update and if so
+ * confirm it in MCUBoot.
+ *
+ * @return CHIP_NO_ERROR if the image has been confirmed, or it is not the first
+ * boot after the OTA update.
+ * Other CHIP_ERROR codes if the image could not be confirmed.
+ */
+CHIP_ERROR OtaConfirmNewImage();
+
 #endif /* CONFIG_CHIP_OTA_REQUESTOR */
 
 /**

--- a/samples/matter/light_bulb/src/app_task.cpp
+++ b/samples/matter/light_bulb/src/app_task.cpp
@@ -177,12 +177,6 @@ CHIP_ERROR AppTask::Init()
 	/* Initialize trigger effect timer */
 	k_timer_init(&sTriggerEffectTimer, &AppTask::TriggerEffectTimerTimeoutCallback, nullptr);
 
-#ifdef CONFIG_MCUMGR_TRANSPORT_BT
-	/* Initialize DFU over SMP */
-	GetDFUOverSMP().Init();
-	GetDFUOverSMP().ConfirmNewImage();
-#endif
-
 	/* Initialize lighting device (PWM) */
 	uint8_t minLightLevel = kDefaultMinLevel;
 	Clusters::LevelControl::Attributes::MinLevel::Get(kLightEndpointId, &minLightLevel);
@@ -195,6 +189,20 @@ CHIP_ERROR AppTask::Init()
 		return chip::System::MapErrorZephyr(ret);
 	}
 	mPWMDevice.SetCallbacks(ActionInitiated, ActionCompleted);
+
+#ifdef CONFIG_CHIP_OTA_REQUESTOR
+	/* OTA image confirmation must be done before the factory data init. */
+	err = OtaConfirmNewImage();
+	if (err != CHIP_NO_ERROR) {
+		return err;
+	}
+#endif
+
+#ifdef CONFIG_MCUMGR_TRANSPORT_BT
+	/* Initialize DFU over SMP */
+	GetDFUOverSMP().Init();
+	GetDFUOverSMP().ConfirmNewImage();
+#endif
 
 	/* Initialize CHIP server */
 #if CONFIG_CHIP_FACTORY_DATA

--- a/samples/matter/light_switch/src/app_task.cpp
+++ b/samples/matter/light_switch/src/app_task.cpp
@@ -170,6 +170,14 @@ CHIP_ERROR AppTask::Init()
 	k_timer_user_data_set(&sDimmerPressKeyTimer, this);
 	k_timer_user_data_set(&sFunctionTimer, this);
 
+#ifdef CONFIG_CHIP_OTA_REQUESTOR
+	/* OTA image confirmation must be done before the factory data init. */
+	err = OtaConfirmNewImage();
+	if (err != CHIP_NO_ERROR) {
+		return err;
+	}
+#endif
+
 #ifdef CONFIG_MCUMGR_TRANSPORT_BT
 	/* Initialize DFU over SMP */
 	GetDFUOverSMP().Init();

--- a/samples/matter/lock/src/app_task.cpp
+++ b/samples/matter/lock/src/app_task.cpp
@@ -196,12 +196,6 @@ CHIP_ERROR AppTask::Init()
 	k_timer_init(&sSwitchImagesTimer, &AppTask::SwitchImagesTimerTimeoutCallback, nullptr);
 #endif
 
-#ifdef CONFIG_MCUMGR_TRANSPORT_BT
-	/* Initialize DFU over SMP */
-	GetDFUOverSMP().Init();
-	GetDFUOverSMP().ConfirmNewImage();
-#endif
-
 #ifdef CONFIG_CHIP_NUS
 	/* Initialize Nordic UART Service for Lock purposes */
 	if (!GetNUSService().Init(kLockNUSPriority, kAdvertisingIntervalMin, kAdvertisingIntervalMax)) {
@@ -216,6 +210,20 @@ CHIP_ERROR AppTask::Init()
 
 	/* Initialize lock manager */
 	BoltLockMgr().Init(LockStateChanged);
+
+#ifdef CONFIG_CHIP_OTA_REQUESTOR
+	/* OTA image confirmation must be done before the factory data init. */
+	err = OtaConfirmNewImage();
+	if (err != CHIP_NO_ERROR) {
+		return err;
+	}
+#endif
+
+#ifdef CONFIG_MCUMGR_TRANSPORT_BT
+	/* Initialize DFU over SMP */
+	GetDFUOverSMP().Init();
+	GetDFUOverSMP().ConfirmNewImage();
+#endif
 
 	/* Initialize CHIP server */
 #if CONFIG_CHIP_FACTORY_DATA

--- a/samples/matter/template/src/app_task.cpp
+++ b/samples/matter/template/src/app_task.cpp
@@ -144,6 +144,14 @@ CHIP_ERROR AppTask::Init()
 	k_timer_init(&sFunctionTimer, &AppTask::FunctionTimerTimeoutCallback, nullptr);
 	k_timer_user_data_set(&sFunctionTimer, this);
 
+#ifdef CONFIG_CHIP_OTA_REQUESTOR
+	/* OTA image confirmation must be done before the factory data init. */
+	err = OtaConfirmNewImage();
+	if (err != CHIP_NO_ERROR) {
+		return err;
+	}
+#endif
+
 	/* Initialize CHIP server */
 #if CONFIG_CHIP_FACTORY_DATA
 	ReturnErrorOnFailure(mFactoryDataProvider.Init());

--- a/samples/matter/thermostat/src/app_task.cpp
+++ b/samples/matter/thermostat/src/app_task.cpp
@@ -162,6 +162,14 @@ CHIP_ERROR AppTask::Init()
 	k_timer_init(&sFunctionTimer, &AppTask::FunctionTimerTimeoutCallback, nullptr);
 	k_timer_user_data_set(&sFunctionTimer, this);
 
+#ifdef CONFIG_CHIP_OTA_REQUESTOR
+	/* OTA image confirmation must be done before the factory data init. */
+	err = OtaConfirmNewImage();
+	if (err != CHIP_NO_ERROR) {
+		return err;
+	}
+#endif
+
 #ifdef CONFIG_MCUMGR_TRANSPORT_BT
 	/* Initialize DFU over SMP */
 	GetDFUOverSMP().Init();

--- a/samples/matter/window_covering/src/app_task.cpp
+++ b/samples/matter/window_covering/src/app_task.cpp
@@ -134,6 +134,14 @@ CHIP_ERROR AppTask::Init()
 	k_timer_init(&sFunctionTimer, &AppTask::FunctionTimerTimeoutCallback, nullptr);
 	k_timer_user_data_set(&sFunctionTimer, this);
 
+#ifdef CONFIG_CHIP_OTA_REQUESTOR
+	/* OTA image confirmation must be done before the factory data init. */
+	err = OtaConfirmNewImage();
+	if (err != CHIP_NO_ERROR) {
+		return err;
+	}
+#endif
+
 #ifdef CONFIG_MCUMGR_TRANSPORT_BT
 	/* Initialize DFU over SMP */
 	GetDFUOverSMP().Init();

--- a/west.yml
+++ b/west.yml
@@ -147,7 +147,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: ad33cfbc151e0845017e1a978caded45cd7651eb
+      revision: eeb7280620fff1e16a75cfa41338186fd952c432
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
Confirmation of the OTA update should not be delegated to be done in Matter Thread because Fprotect already has been set during the factory data initialization and blocked writing to the restricted areas. Confirming must be done in the Init method before initializing the Factory data module. Then, the result should be delivered to the image processor implementation.