### PR TITLE
Bluetooth: Mesh: Hue wrap around behavior

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -554,19 +554,29 @@ Bluetooth libraries and services
 
 * :ref:`bt_mesh` library:
 
-  * Added the :kconfig:option:`BT_MESH_LIGHT_CTRL_AMB_LIGHT_LEVEL_TIMEOUT` Kconfig option that configures a timeout before resetting the ambient light level to zero.
+  * Added:
+
+    * The :kconfig:option:`BT_MESH_LIGHT_CTRL_AMB_LIGHT_LEVEL_TIMEOUT` Kconfig option that configures a timeout before resetting the ambient light level to zero.
+    * The :c:member:`bt_mesh_light_hue.direction` field that specifies direction of the Hue state transition.
 
   * Updated:
 
     * The :kconfig:option:`CONFIG_BT_MESH_MODEL_SRV_STORE_TIMEOUT` Kconfig option, that is controlling timeout for storing of model states, is replaced by the :kconfig:option:`CONFIG_BT_MESH_STORE_TIMEOUT` Kconfig option.
     * The Light Lightness Actual and Generic Power Level states of the :ref:`bt_mesh_lightness_srv_readme` and :ref:`bt_mesh_plvl_srv_readme` models cannot dim to off.
       This is due to binding with Generic Level state when receiving Generic Delta Set and Generic Move Set messages.
+    * The :c:member:`bt_mesh_light_hue_srv_handlers.move_set` callback of the :ref:`bt_mesh_light_hue_srv_readme` model is only called for a continuous transition.
+      All other transitions are now handled by the :c:member:`bt_mesh_light_hue_srv_handlers.set` callback.
+    * The Hue Range state of the :ref:`bt_mesh_light_hue_srv_readme` model now allows :c:member:`bt_mesh_light_hsl_range.max` to be lower than :c:member:`bt_mesh_light_hsl_range.min`.
 
   * Fixed:
 
     * An issue where the :ref:`bt_mesh_dtt_srv_readme` model could not be found for models spanning multiple elements.
     * An issue where the :ref:`bt_mesh_sensor_srv_readme` model would add a corrupted marshalled sensor data into the Sensor Status message, because the fetched sensor value was outside the range.
       If the fetched sensor value is out of range, the marshalled sensor data for that sensor is not added to the Sensor Status message.
+
+  * Removed:
+
+    * The `bt_mesh_light_hue_srv_handlers.delta_set` callback of the :ref:`bt_mesh_light_hue_srv_readme` model is removed and replaced with the :c:member:`bt_mesh_light_hue_srv_handlers.set` callback.
 
 Bootloader libraries
 --------------------

--- a/include/bluetooth/mesh/light_hsl.h
+++ b/include/bluetooth/mesh/light_hsl.h
@@ -59,26 +59,6 @@ struct bt_mesh_light_hsl_params {
 	const struct bt_mesh_model_transition *transition;
 };
 
-/** Hue delta set parameters */
-struct bt_mesh_light_hue_delta {
-	/** Translation from original value. */
-	int32_t delta;
-	/**
-	 * Whether this is a new transaction. If true, the delta should be
-	 * relative to the current value. If false, the delta should be
-	 * relative to the original value in the previous delta_set command.
-	 */
-	bool new_transaction;
-	/**
-	 * Transition time parameters for the state change, or NULL.
-	 *
-	 * When sending, setting the transition to NULL makes the receiver use
-	 * its default transition time parameters, or 0 if no default transition
-	 * time is set.
-	 */
-	const struct bt_mesh_model_transition *transition;
-};
-
 /** Hue move set parameters */
 struct bt_mesh_light_hue_move {
 	/** Translation to make for every transition step. */
@@ -115,6 +95,17 @@ struct bt_mesh_light_hue {
 	 * time is set.
 	 */
 	const struct bt_mesh_model_transition *transition;
+	/**
+	 * Direction of the Hue state change, if @c transition is present.
+	 *
+	 * If positive, the current value should be incremented even if the target value is less
+	 * than the current value. If negative, the current value should be decremented even if the
+	 * target value is greater than the current value. The application is responsible for
+	 * wrapping the Hue state around when the value reaches the end of the type range.
+	 *
+	 * @note Set by the Light Hue Server model.
+	 */
+	int direction;
 };
 
 /** Common Light Saturation set message parameters. */

--- a/include/bluetooth/mesh/light_hue_srv.h
+++ b/include/bluetooth/mesh/light_hue_srv.h
@@ -66,6 +66,13 @@ struct bt_mesh_light_hue_srv_handlers {
 	 * @ref bt_mesh_model_transition_time returns a nonzero value, the application is
 	 * responsible for publishing a value of the Hue state at the end of the transition.
 	 *
+	 * When a state change is not-instantaneous, the @ref bt_mesh_light_hue::direction field
+	 * represents a direction in which the value of the Hue state should change. When the target
+	 * value of the Hue state is less than the current value and the direction field is
+	 * positive, or when the target value is greater than the current value and the direction
+	 * field is negative, the application is responsible for wrapping the value of the Hue
+	 * state around when the value reaches the end of the type range.
+	 *
 	 *  @note This handler is mandatory.
 	 *
 	 *  @param[in] srv Server to set the Hue state of.
@@ -77,36 +84,6 @@ struct bt_mesh_light_hue_srv_handlers {
 			  struct bt_mesh_msg_ctx *ctx,
 			  const struct bt_mesh_light_hue *set,
 			  struct bt_mesh_light_hue_status *rsp);
-
-	/**
-	 * @brief Change the hue relative to its current value.
-	 *
-	 * If @c delta_set::new_transaction is false, the state transition
-	 * should use the same start point as the previous delta_set message,
-	 * effectively overriding the previous message. If it's true, the level
-	 * transition should start from the current level, stopping any
-	 * ongoing transitions.
-	 *
-	 *  When reaching the border values for the state, the value should wrap
-	 *  around. While the server is executing a move command, it should
-	 *  report its @c target value as @ref BT_MESH_LIGHT_HSL_MIN or
-	 *  @ref BT_MESH_LIGHT_HSL_MAX, depending on whether it's moving up or
-	 *  down.
-	 *
-	 * @note This handler is mandatory.
-	 *
-	 * @param[in] srv       Light Hue server.
-	 * @param[in] ctx       Message context, or NULL if the callback was not
-	 *                      triggered by a mesh message.
-	 * @param[in] delta_set Parameters of the state change. Note that the
-	 *                      transition will always be non-NULL.
-	 * @param[out] rsp      Response structure to be filled.
-	 */
-	void (*const delta_set)(
-		struct bt_mesh_light_hue_srv *srv,
-		struct bt_mesh_msg_ctx *ctx,
-		const struct bt_mesh_light_hue_delta *delta_set,
-		struct bt_mesh_light_hue_status *rsp);
 
 	/** @brief Move the hue continuously at a certain rate.
 	 *

--- a/subsys/bluetooth/mesh/light_hsl_internal.h
+++ b/subsys/bluetooth/mesh/light_hsl_internal.h
@@ -53,7 +53,7 @@ light_hue_sat_range_buf_pull(struct net_buf_simple *buf,
 
 void bt_mesh_light_hue_srv_set(struct bt_mesh_light_hue_srv *srv,
 				   struct bt_mesh_msg_ctx *ctx,
-				   const struct bt_mesh_light_hue *set,
+				   struct bt_mesh_light_hue *set,
 				   struct bt_mesh_light_hue_status *status);
 
 void bt_mesh_light_hue_srv_default_set(struct bt_mesh_light_hue_srv *srv,

--- a/subsys/bluetooth/mesh/light_hsl_internal.h
+++ b/subsys/bluetooth/mesh/light_hsl_internal.h
@@ -65,9 +65,9 @@ void bt_mesh_light_hue_srv_range_set(
 	const struct bt_mesh_light_hsl_range *range);
 
 void bt_mesh_light_sat_srv_set(struct bt_mesh_light_sat_srv *srv,
-				   struct bt_mesh_msg_ctx *ctx,
-				   const struct bt_mesh_light_sat *set,
-				   struct bt_mesh_light_sat_status *status);
+			       struct bt_mesh_msg_ctx *ctx,
+			       struct bt_mesh_light_sat *set,
+			       struct bt_mesh_light_sat_status *status);
 
 void bt_mesh_light_sat_srv_default_set(struct bt_mesh_light_sat_srv *srv,
 					   struct bt_mesh_msg_ctx *ctx,

--- a/subsys/bluetooth/mesh/light_hsl_srv.c
+++ b/subsys/bluetooth/mesh/light_hsl_srv.c
@@ -288,10 +288,6 @@ static int range_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 
 	hue.min = net_buf_simple_pull_le16(buf);
 	hue.max = net_buf_simple_pull_le16(buf);
-	if (hue.max < hue.min) {
-		return -EINVAL;
-	}
-
 
 	sat.min = net_buf_simple_pull_le16(buf);
 	sat.max = net_buf_simple_pull_le16(buf);

--- a/subsys/bluetooth/mesh/light_sat_srv.c
+++ b/subsys/bluetooth/mesh/light_sat_srv.c
@@ -85,7 +85,6 @@ static int sat_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	 * in macro:
 	 */
 	set.lvl = net_buf_simple_pull_le16(buf);
-	set.lvl = CLAMP(set.lvl, srv->range.min, srv->range.max);
 	tid = net_buf_simple_pull_u8(buf);
 
 	if (tid_check_and_update(&srv->prev_transaction, tid, ctx) != 0) {
@@ -208,7 +207,7 @@ static void lvl_set(struct bt_mesh_lvl_srv *lvl_srv,
 
 	uint16_t sat = LVL_TO_SAT(lvl_set->lvl);
 
-	set.lvl = MIN(MAX(sat, srv->range.min), srv->range.max);
+	set.lvl = sat;
 	set.transition = lvl_set->transition;
 	bt_mesh_light_sat_srv_set(srv, ctx, &set, &status);
 
@@ -450,9 +449,11 @@ const struct bt_mesh_model_cb _bt_mesh_light_sat_srv_cb = {
 
 void bt_mesh_light_sat_srv_set(struct bt_mesh_light_sat_srv *srv,
 			       struct bt_mesh_msg_ctx *ctx,
-			       const struct bt_mesh_light_sat *set,
+			       struct bt_mesh_light_sat *set,
 			       struct bt_mesh_light_sat_status *status)
 {
+	set->lvl = CLAMP(set->lvl, srv->range.min, srv->range.max);
+
 	srv->transient.last = set->lvl;
 	srv->handlers->set(srv, ctx, set, status);
 

--- a/tests/subsys/bluetooth/mesh/light_hue/CMakeLists.txt
+++ b/tests/subsys/bluetooth/mesh/light_hue/CMakeLists.txt
@@ -1,0 +1,36 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(bt_mesh_ligth_hue_subsystem_test)
+
+FILE(GLOB app_sources src/*.c)
+
+target_sources(app
+  PRIVATE
+  ${app_sources}
+  ${ZEPHYR_NRF_MODULE_DIR}/subsys/bluetooth/mesh/light_hue_srv.c
+  ${ZEPHYR_NRF_MODULE_DIR}/subsys/bluetooth/mesh/model_utils.c
+  )
+
+target_include_directories(app
+  PRIVATE
+  ${ZEPHYR_NRF_MODULE_DIR}/subsys/bluetooth/mesh
+  ${ZEPHYR_BASE}/subsys/bluetooth
+  )
+
+target_compile_options(app
+  PRIVATE
+  -DCONFIG_BT_MESH_MOD_ACKD_TIMEOUT_BASE=3000
+  -DCONFIG_BT_MESH_MOD_ACKD_TIMEOUT_PER_HOP=50
+  -DCONFIG_BT_LOG_LEVEL=0
+  -DCONFIG_BT_MESH_USES_TINYCRYPT
+)
+
+zephyr_ld_options(
+    ${LINKERFLAGPREFIX},--allow-multiple-definition
+    )

--- a/tests/subsys/bluetooth/mesh/light_hue/prj.conf
+++ b/tests/subsys/bluetooth/mesh/light_hue/prj.conf
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Ztest configuration
+CONFIG_ZTEST=y
+CONFIG_ZTEST_NEW_API=y
+CONFIG_ZTEST_MOCKING=y
+CONFIG_ZTEST_PARAMETER_COUNT=30
+
+CONFIG_NET_BUF=y

--- a/tests/subsys/bluetooth/mesh/light_hue/src/main.c
+++ b/tests/subsys/bluetooth/mesh/light_hue/src/main.c
@@ -1,0 +1,673 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <stdint.h>
+#include <zephyr/ztest.h>
+#include <zephyr/bluetooth/mesh.h>
+#include <bluetooth/mesh/models.h>
+#include <bluetooth/mesh/light_hue_srv.h>
+#include "model_utils.h"
+
+#define HUE_TO_LVL(_hue) ((_hue) - 32768)
+
+static uint16_t light_hue_val;
+
+static void hue_set(struct bt_mesh_light_hue_srv *srv,
+			  struct bt_mesh_msg_ctx *ctx,
+			  const struct bt_mesh_light_hue *set,
+			  struct bt_mesh_light_hue_status *rsp)
+{
+	ztest_check_expected_value(set->lvl);
+
+	if (set->transition) {
+		ztest_check_expected_value(set->transition->time);
+		ztest_check_expected_value(set->direction);
+	}
+
+	if (!set->transition) {
+		rsp->current = set->lvl;
+		rsp->remaining_time = 0;
+	} else {
+		rsp->current = light_hue_val;
+		rsp->target = set->lvl;
+		rsp->remaining_time = set->transition->time;
+	}
+}
+
+static void hue_move_set(struct bt_mesh_light_hue_srv *srv,
+			       struct bt_mesh_msg_ctx *ctx,
+			       const struct bt_mesh_light_hue_move *move,
+			       struct bt_mesh_light_hue_status *rsp)
+{
+	ztest_check_expected_value(move->delta);
+
+	if (move->transition) {
+		ztest_check_expected_value(move->transition->time);
+	}
+
+	if (!move->transition) {
+		rsp->current = light_hue_val;
+		rsp->remaining_time = 0;
+	} else {
+		rsp->current = light_hue_val;
+		rsp->target = light_hue_val + move->delta;
+		rsp->remaining_time = move->transition->time;
+	}
+}
+
+static void hue_get(struct bt_mesh_light_hue_srv *srv,
+			  struct bt_mesh_msg_ctx *ctx,
+			  struct bt_mesh_light_hue_status *rsp)
+{
+	rsp->current = light_hue_val;
+	rsp->target = light_hue_val;
+	rsp->remaining_time = 0;
+}
+
+static void hue_default_update(struct bt_mesh_light_hue_srv *srv,
+				     struct bt_mesh_msg_ctx *ctx,
+				     uint16_t old_default,
+				     uint16_t new_default)
+{
+	zassert_true(false);
+}
+
+static void hue_range_update(
+		struct bt_mesh_light_hue_srv *srv,
+		struct bt_mesh_msg_ctx *ctx,
+		const struct bt_mesh_light_hsl_range *old_range,
+		const struct bt_mesh_light_hsl_range *new_range)
+{
+	zassert_true(false);
+}
+
+static struct bt_mesh_light_hue_srv_handlers light_hue_srv_handlers = {
+	.set = hue_set,
+	.move_set = hue_move_set,
+	.get = hue_get,
+	.default_update = hue_default_update,
+	.range_update = hue_range_update,
+};
+
+static struct bt_mesh_light_hue_srv light_hue_srv =
+	BT_MESH_LIGHT_HUE_SRV_INIT(&light_hue_srv_handlers);
+
+static struct bt_mesh_model mock_light_hue_srv_model = {
+	.user_data = &light_hue_srv,
+	.elem_idx = 1,
+};
+
+/** Mocks ******************************************/
+
+static int hue_status_pub(struct net_buf_simple *buf)
+{
+	uint16_t current, target;
+	int32_t remaining_time;
+
+	current = net_buf_simple_pull_le16(buf);
+	ztest_check_expected_value(current);
+
+	if (buf->len > 0) {
+		target = net_buf_simple_pull_le16(buf);
+		remaining_time = model_transition_decode(net_buf_simple_pull_u8(buf));
+
+		ztest_check_expected_value(target);
+		ztest_check_expected_value(remaining_time);
+
+		zassert_equal(buf->len, 0);
+	}
+
+	return 0;
+}
+
+int bt_mesh_msg_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+	       struct net_buf_simple *buf)
+{
+	uint16_t opcode;
+
+	ztest_check_expected_value(model);
+	ztest_check_expected_value(ctx);
+	ztest_check_expected_value(buf->len);
+
+	/* Only 2 octets opcodes are supported by this test. */
+	zassert_equal(buf->data[0] >> 6, 2);
+
+	opcode = net_buf_simple_pull_be16(buf);
+	zassert_equal(BT_MESH_LIGHT_HUE_OP_STATUS, opcode);
+	hue_status_pub(buf);
+
+	return 0;
+}
+
+void bt_mesh_model_msg_init(struct net_buf_simple *msg, uint32_t opcode)
+{
+	zassert_equal(BT_MESH_MODEL_OP_LEN(opcode), 2);
+
+	net_buf_simple_init(msg, 0);
+	net_buf_simple_add_be16(msg, opcode);
+}
+
+int bt_mesh_model_extend(struct bt_mesh_model *mod,
+			 struct bt_mesh_model *base_mod)
+{
+	return 0;
+}
+
+int bt_mesh_lvl_srv_pub(struct bt_mesh_lvl_srv *srv,
+			struct bt_mesh_msg_ctx *ctx,
+			const struct bt_mesh_lvl_status *status)
+{
+	return 0;
+}
+
+/** End Mocks **************************************/
+
+static int hue_set_unack_send(struct bt_mesh_light_hue *set)
+{
+	static uint8_t tid;
+	struct bt_mesh_msg_ctx ctx = {
+		.addr = 1,
+	};
+
+	NET_BUF_SIMPLE_DEFINE(buf, 5);
+	net_buf_simple_init(&buf, 0);
+
+	net_buf_simple_add_le16(&buf, set->lvl);
+	net_buf_simple_add_u8(&buf, tid++);
+
+	if (set->transition) {
+		model_transition_buf_add(&buf, set->transition);
+	}
+
+	return _bt_mesh_light_hue_srv_op[2].func(&mock_light_hue_srv_model, &ctx, &buf);
+}
+
+static int lvl_set_unack_send(struct bt_mesh_lvl_set *set)
+{
+	struct bt_mesh_msg_ctx ctx = {
+		.addr = 1,
+	};
+	struct bt_mesh_lvl_status rsp_stub;
+
+	light_hue_srv.lvl.handlers->set(&light_hue_srv.lvl, &ctx, set, &rsp_stub);
+
+	return 0;
+}
+
+static int lvl_delta_set_unack_send(struct bt_mesh_lvl_delta_set *set)
+{
+	struct bt_mesh_msg_ctx ctx = {
+		.addr = 1,
+	};
+	struct bt_mesh_lvl_status rsp_stub;
+
+	light_hue_srv.lvl.handlers->delta_set(&light_hue_srv.lvl, &ctx, set, &rsp_stub);
+
+	return 0;
+}
+
+static int lvl_move_set_unack_send(struct bt_mesh_lvl_move_set *set)
+{
+	struct bt_mesh_msg_ctx ctx = {
+		.addr = 1,
+	};
+	struct bt_mesh_lvl_status rsp_stub;
+
+	light_hue_srv.lvl.handlers->move_set(&light_hue_srv.lvl, &ctx, set, &rsp_stub);
+
+	return 0;
+}
+
+static void expect_hue_status_pub(struct bt_mesh_light_hue_status *status)
+{
+	ztest_expect_value(bt_mesh_msg_send, model, &mock_light_hue_srv_model);
+	ztest_expect_value(bt_mesh_msg_send, ctx, NULL);
+	ztest_expect_value(bt_mesh_msg_send, buf->len, status->remaining_time ? 7 : 4);
+
+	ztest_expect_value(hue_status_pub, current, status->current);
+
+	if (status->remaining_time != 0) {
+		ztest_expect_value(hue_status_pub, target, status->target);
+		ztest_expect_value(hue_status_pub, remaining_time, status->remaining_time);
+	}
+}
+
+static void expect_hue_set_cb(struct bt_mesh_light_hue *set)
+{
+	ztest_expect_value(hue_set, set->lvl, set->lvl);
+
+	if (set->transition) {
+		ztest_expect_value(hue_set, set->transition->time, set->transition->time);
+		ztest_expect_value(hue_set, set->direction, set->direction);
+	}
+}
+
+static void expect_hue_move_set_cb(struct bt_mesh_light_hue_move *move)
+{
+	ztest_expect_value(hue_move_set, move->delta, move->delta);
+
+	if (move->transition) {
+		ztest_expect_value(hue_move_set, move->transition->time, move->transition->time);
+	}
+}
+
+static void setup(void *f)
+{
+	zassert_not_null(_bt_mesh_light_hue_srv_cb.init, "Init cb is null");
+	zassert_ok(_bt_mesh_light_hue_srv_cb.init(&mock_light_hue_srv_model), "Init failed");
+}
+
+static void teardown(void *f)
+{
+	zassert_not_null(_bt_mesh_light_hue_srv_cb.reset, "Reset cb is null");
+	_bt_mesh_light_hue_srv_cb.reset(&mock_light_hue_srv_model);
+}
+
+/* Test Hue value clamping without transition. */
+ZTEST(light_hue_srv_test, test_hue_set)
+{
+	struct {
+		uint16_t min;
+		uint16_t max;
+		uint16_t current_hue;
+		uint16_t target_hue;
+		uint16_t expected_hue;
+	} test_vector[] = {
+		/* Range Min, Range Max, Current, Target, Expected */
+		{  0,         0xFFFF,    0,       0,      0       },
+		{  0,         0xFFFF,    0,       0xFFFF, 0xFFFF  },
+		/* [100, 0xFF00] */
+		{  100,       0xFF00,    0xFFFF,  99,     100     },
+		{  100,       0xFF00,    100,     0xFF01, 0xFF00  },
+		{  100,       0xFF00,    0xFF00,  101,    101     },
+		{  100,       0xFF00,    101,     0xFEFF, 0xFEFF  },
+		/* [0 - 100, 0xFF00 - 0xFFFF] */
+		{  0xFF00,    100,       0xFEFF,  101,    100     },
+		{  0xFF00,    100,       100,     0xFEFF, 0xFF00  },
+		{  0xFF00,    100,       0xFF00,  99,     99      },
+		{  0xFF00,    100,       99,      0xFF01, 0xFF01  },
+	};
+
+	for (size_t i = 0; i < ARRAY_SIZE(test_vector); i++) {
+		struct bt_mesh_light_hue_status status = {};
+
+		printk("Checking test_vector[%d]\n", i);
+
+		light_hue_srv.range.min = test_vector[i].min;
+		light_hue_srv.range.max = test_vector[i].max;
+		light_hue_val = test_vector[i].current_hue;
+
+		status.current = test_vector[i].expected_hue;
+		expect_hue_status_pub(&status);
+
+		struct bt_mesh_light_hue hue_set = {
+			.lvl = test_vector[i].target_hue,
+		};
+		struct bt_mesh_light_hue exp_hue_set = {
+			.lvl = test_vector[i].expected_hue,
+		};
+
+		expect_hue_set_cb(&exp_hue_set);
+		zassert_ok(hue_set_unack_send(&hue_set));
+	}
+}
+
+/* Test Hue value clamping with transition. */
+ZTEST(light_hue_srv_test, test_hue_set_transition)
+{
+	struct {
+		uint16_t min;
+		uint16_t max;
+		uint16_t current_hue;
+		uint16_t target_hue;
+		uint16_t expected_hue;
+		int direction;
+	} test_vector[] = {
+		/* Range Min, Range Max, Current, Target, Expected, Diretion */
+		{  0,         0xFFFF,    0,       0x7FFF, 0x7FFF,    1  },
+		{  0,         0xFFFF,    0xFFFF,  0x8000, 0x8000,   -1  },
+		/* Direction points to the shortest path which causes the value to wrap around. */
+		{  0,         0xFFFF,    0xFFFF,  0,      0,         1  },
+		{  0,         0xFFFF,    0,       0xFFFF, 0xFFFF,   -1  },
+		/* [100, 0xFF00] */
+		{  100,       0xFF00,    0xFFFF,  99,     100,      -1  },
+		{  100,       0xFF00,    100,     0xFF01, 0xFF00,    1  },
+		{  100,       0xFF00,    0xFF00,  101,    101,      -1  },
+		{  100,       0xFF00,    101,     0xFEFF, 0xFEFF,    1  },
+		/* [0 - 100, 0xFF00 - 0xFFFF] */
+		{  0xFF00,    100,       0xFEFF,  101,    100,       1  },
+		{  0xFF00,    100,       100,     0xFEFF, 0xFF00,   -1  },
+		{  0xFF00,    100,       0xFF00,  99,     99,        1  },
+		{  0xFF00,    100,       99,      0xFF01, 0xFF01,   -1  },
+	};
+
+	for (size_t i = 0; i < ARRAY_SIZE(test_vector); i++) {
+		struct bt_mesh_light_hue_status status = {
+			.current = test_vector[i].current_hue,
+			.target = test_vector[i].expected_hue,
+			.remaining_time = 100, /* Same as Transition Time set below. */
+		};
+
+		printk("Checking test_vector[%d]\n", i);
+
+		light_hue_srv.range.min = test_vector[i].min;
+		light_hue_srv.range.max = test_vector[i].max;
+		light_hue_val = test_vector[i].current_hue;
+
+		expect_hue_status_pub(&status);
+
+		/* Use arbitrary Transition Time value to see different current and target values
+		 * in the status message.
+		 */
+		struct bt_mesh_model_transition transition = {
+			.time = 100,
+		};
+		struct bt_mesh_light_hue hue_set = {
+			.lvl = test_vector[i].target_hue,
+			.transition = &transition,
+		};
+		struct bt_mesh_light_hue exp_hue_set = {
+			.lvl = test_vector[i].expected_hue,
+			.transition = &transition,
+			.direction = test_vector[i].direction,
+		};
+
+		expect_hue_set_cb(&exp_hue_set);
+		zassert_ok(hue_set_unack_send(&hue_set));
+	}
+}
+
+/* Test Hue value clamping and binding with Generic Level state when sending Generic Level Set
+ * message.
+ */
+ZTEST(light_hue_srv_test, test_lvl_set)
+{
+	struct {
+		uint16_t min;
+		uint16_t max;
+		uint16_t current_hue;
+		int16_t target_lvl;
+		uint16_t expected_hue;
+		int direction;
+	} test_vector[] = {
+		/* See binding between Hue state and Generic Level state in MshMDLd1.1 spec,
+		 * section 6.1.4.1.1:
+		 *
+		 *     Generic Level state
+		 * -0x8000      0      0x7FFF
+		 *    |---------|--------|
+		 *    0      0x8000    0xFFFF
+		 *     Light Hue state
+		 */
+		/* Range Min, Range Max, Current, Level,    Expected, Diretion */
+		{  0,         0xFFFF,    0,        0,       0x8000,   -1  },
+		{  0,         0xFFFF,    0,       -1,       0x7FFF,    1  },
+		{  0,         0xFFFF,    0,        0x7FFF,  0xFFFF,   -1  },
+		{  0,         0xFFFF,    0xFF00,  -0x7FFF,  1,         1  },
+		{  0,         0xFFFF,    0x64,     0x7FFF,  0xFFFF,   -1  },
+		{  0,         0xFFFF,    0xFF00,  -0x7FFF,  1,         1  },
+		/* [100, 0xFF00] */
+		{  100,       0xFF00,    0x7F00,  -0x7F9B,  101,      -1  },
+		{  100,       0xFF00,    0x7F00,   0x7EFF,  0xFEFF,    1  },
+		{  100,       0xFF00,    0x7F00,  -0x7F9D,  100,      -1  },
+		{  100,       0xFF00,    0x7F00,   0x7F01,  0xFF00,    1  },
+		/* [0 - 100, 0xFF00 - 0xFFFF] */
+		{  0xFF00,    0x100,     0,        0x7FFF,  0xFFFF,   -1   },
+		{  0xFF00,    0x100,     0,       -0x7FFF,  1,         1   },
+		{  0xFF00,    0x100,     0,        0x7EFF,  0xFF00,   -1   },
+		{  0xFF00,    0x100,     0,       -0x7EFF,  0x100,     1   },
+	};
+
+	for (size_t i = 0; i < ARRAY_SIZE(test_vector); i++) {
+		struct bt_mesh_light_hue_status status = {
+			.current = test_vector[i].current_hue,
+			.target = test_vector[i].expected_hue,
+			.remaining_time = 100, /* Same as Transition Time set below. */
+		};
+
+		printk("Checking test_vector[%d]\n", i);
+
+		light_hue_srv.range.min = test_vector[i].min;
+		light_hue_srv.range.max = test_vector[i].max;
+		light_hue_val = test_vector[i].current_hue;
+
+		expect_hue_status_pub(&status);
+
+		/* Use arbitrary Transition Time value to see different current and target values
+		 * in the status message.
+		 */
+		struct bt_mesh_model_transition transition = {
+			.time = 100,
+		};
+		struct bt_mesh_lvl_set lvl_set = {
+			.lvl = test_vector[i].target_lvl,
+			.transition = &transition,
+			.new_transaction = true,
+		};
+		struct bt_mesh_light_hue exp_hue_set = {
+			.lvl = test_vector[i].expected_hue,
+			.transition = &transition,
+			.direction = test_vector[i].direction,
+		};
+
+		expect_hue_set_cb(&exp_hue_set);
+		zassert_ok(lvl_set_unack_send(&lvl_set));
+	}
+}
+
+/* Test Hue value clamping and binding with Generic Level state when sending Generic Delta Set
+ * message.
+ */
+ZTEST(light_hue_srv_test, test_lvl_delta_set)
+{
+	struct {
+		uint16_t min;
+		uint16_t max;
+		uint16_t current_hue;
+		int32_t lvl_delta;
+		uint16_t expected_hue;
+		int direction;
+	} test_vector[] = {
+		/* See binding between Hue state and Generic Level state in MshMDLd1.1 spec,
+		 * section 6.1.4.1.1:
+		 *
+		 *     Generic Level state
+		 * -0x8000      0      0x7FFF
+		 *    |---------|--------|
+		 *    0      0x8000    0xFFFF
+		 *     Light Hue state
+		 */
+		/* Range Min, Range Max, Current, Delta,    Expected, Diretion */
+		{  0,         0xFFFF,    0,        0x7FFF,  0x7FFF,    1  },
+		{  0,         0xFFFF,    0xFFFF,  -0x7FFF,  0x8000,   -1  },
+		{  0,         0xFFFF,    0x8001,   0x7FFF,  0,         1  },
+		{  0,         0xFFFF,    0x8000,   0x7FFF,  0xFFFF,    1  },
+		{  0,         0xFFFF,    0xFF00,   0x101,   1,         1  },
+		{  0,         0xFFFF,    0x100,   -0x101,   0xFFFF,   -1  },
+		{  0,         0xFFFF,    0,       -0x8000,  0x8000,   -1  },
+		{  0,         0xFFFF,    0xFFFF,   0x7FFF,  0x7FFE,    1  },
+		/* [100, 0xFF00] */
+		{  0x100,     0xFF00,    0x7F00,  -0x7F01,  0x100,    -1  },
+		{  0x100,     0xFF00,    0x8000,   0x7F01,  0xFF00,    1  },
+		{  0x100,     0xFF00,    0x100,   -0x8000,  0x100,     1  },
+		{  0x100,     0xFF00,    0xFF00,   0x7FFF,  0xFF00,    1  },
+		/* [0 - 100, 0xFF00 - 0xFFFF] */
+		{  0xFF00,    0x100,     0,        0x101,   0x100,     1   },
+		{  0xFF00,    0x100,     0,       -0x101,   0xFF00,   -1   },
+	};
+
+	for (size_t i = 0; i < ARRAY_SIZE(test_vector); i++) {
+		struct bt_mesh_light_hue_status status = {
+			.current = test_vector[i].current_hue,
+			.target = test_vector[i].expected_hue,
+			.remaining_time = 100, /* Same as Transition Time set below. */
+		};
+
+		printk("Checking test_vector[%d]\n", i);
+
+		light_hue_srv.range.min = test_vector[i].min;
+		light_hue_srv.range.max = test_vector[i].max;
+		light_hue_val = test_vector[i].current_hue;
+
+		expect_hue_status_pub(&status);
+
+		/* Use arbitrary Transition Time value to see different current and target values
+		 * in the status message.
+		 */
+		struct bt_mesh_model_transition transition = {
+			.time = 100,
+		};
+		struct bt_mesh_lvl_delta_set lvl_delta_set = {
+			.delta = test_vector[i].lvl_delta,
+			.transition = &transition,
+			.new_transaction = true,
+		};
+		struct bt_mesh_light_hue exp_hue_set = {
+			.lvl = test_vector[i].expected_hue,
+			.transition = &transition,
+			.direction = test_vector[i].direction,
+		};
+
+		expect_hue_set_cb(&exp_hue_set);
+		zassert_ok(lvl_delta_set_unack_send(&lvl_delta_set));
+	}
+}
+
+/* Test Hue value clamping and binding with Generic Level state when sending Generic Move Set
+ * message when Hue value range is limited.
+ */
+ZTEST(light_hue_srv_test, test_lvl_move_set_finite)
+{
+	struct {
+		uint16_t min;
+		uint16_t max;
+		uint16_t current_hue;
+		int32_t lvl_move;
+		uint16_t expected_hue;
+		int direction;
+		int32_t remaining_time;
+	} test_vector[] = {
+		/* See binding between Hue state and Generic Level state in MshMDLd1.1 spec,
+		 * section 6.1.4.1.1:
+		 *
+		 *     Generic Level state
+		 * -0x8000      0      0x7FFF
+		 *    |---------|--------|
+		 *    0      0x8000    0xFFFF
+		 *     Light Hue state
+		 */
+		/* Range Min, Range Max, Current, Move,     Expected, Diretion, Rem Time */
+		/* [100, 0xFF00] */
+		{  0x100,     0xFF00,    0x7F00,   0x100,   0xFF00,    1,       128 * 100    },
+		{  0x100,     0xFF00,    0x7F00,  -0x100,   0x100,    -1,       126 * 100    },
+		/* [0 - 100, 0xFF00 - 0xFFFF] */
+		{  0xFF00,    0x100,     0,        0x1,     0x100,     1,       0x100 * 100  },
+		{  0xFF00,    0x100,     0,       -0x1,     0xFF00,   -1,       0x100 * 100  },
+	};
+
+	for (size_t i = 0; i < ARRAY_SIZE(test_vector); i++) {
+		struct bt_mesh_light_hue_status status = {
+			.current = test_vector[i].current_hue,
+			.target = test_vector[i].expected_hue,
+			.remaining_time = model_transition_decode(
+					model_transition_encode(test_vector[i].remaining_time)),
+		};
+
+		printk("Checking test_vector[%d]\n", i);
+
+		light_hue_srv.range.min = test_vector[i].min;
+		light_hue_srv.range.max = test_vector[i].max;
+		light_hue_val = test_vector[i].current_hue;
+
+		expect_hue_status_pub(&status);
+
+		/* Use arbitrary Transition Time value to see different current and target values
+		 * in the status message.
+		 */
+		struct bt_mesh_model_transition transition = {
+			.time = 100,
+		};
+		struct bt_mesh_lvl_move_set lvl_move_set = {
+			.delta = test_vector[i].lvl_move,
+			.transition = &transition,
+			.new_transaction = true,
+		};
+		struct bt_mesh_model_transition exp_transition = {
+			.time = test_vector[i].remaining_time,
+		};
+		struct bt_mesh_light_hue exp_hue_set = {
+			.lvl = test_vector[i].expected_hue,
+			.transition = &exp_transition,
+			.direction = test_vector[i].direction,
+		};
+
+		expect_hue_set_cb(&exp_hue_set);
+		zassert_ok(lvl_move_set_unack_send(&lvl_move_set));
+	}
+}
+
+/* Test Hue value clamping and binding with Generic Level state when sending Generic Move Set
+ * message when Hue value range is not limited.
+ */
+ZTEST(light_hue_srv_test, test_lvl_move_set_infinite)
+{
+	struct {
+		uint16_t current_hue;
+		int32_t lvl_move;
+		uint16_t expected_hue;
+	} test_vector[] = {
+		/* See binding between Hue state and Generic Level state in MshMDLd1.1 spec,
+		 * section 6.1.4.1.1:
+		 *
+		 *     Generic Level state
+		 * -0x8000      0      0x7FFF
+		 *    |---------|--------|
+		 *    0      0x8000    0xFFFF
+		 *     Light Hue state
+		 */
+		/* Current, Move,    Expected */
+		{  0x7F00,   0x100,  0x8000   },
+		{  0x7F00,  -0x100,  0x7E00   },
+	};
+
+	light_hue_srv.range.min = 0;
+	light_hue_srv.range.max = 0xFFFF;
+
+	for (size_t i = 0; i < ARRAY_SIZE(test_vector); i++) {
+		struct bt_mesh_light_hue_status status = {
+			.current = test_vector[i].current_hue,
+			.target = test_vector[i].expected_hue,
+			.remaining_time = 100, /* Same as Transition Time set below. */
+		};
+
+		printk("Checking test_vector[%d]\n", i);
+
+		light_hue_val = test_vector[i].current_hue;
+
+		expect_hue_status_pub(&status);
+
+		/* Use arbitrary Transition Time value to see different current and target values
+		 * in the status message.
+		 */
+		struct bt_mesh_model_transition transition = {
+			.time = 100,
+		};
+		struct bt_mesh_lvl_move_set lvl_move_set = {
+			.delta = test_vector[i].lvl_move,
+			.transition = &transition,
+			.new_transaction = true,
+		};
+		struct bt_mesh_light_hue_move exp_hue_move = {
+			.delta = test_vector[i].lvl_move,
+			.transition = &transition,
+		};
+
+		expect_hue_move_set_cb(&exp_hue_move);
+		zassert_ok(lvl_move_set_unack_send(&lvl_move_set));
+	}
+}
+
+ZTEST_SUITE(light_hue_srv_test, NULL, NULL, setup, teardown, NULL);

--- a/tests/subsys/bluetooth/mesh/light_hue/testcase.yaml
+++ b/tests/subsys/bluetooth/mesh/light_hue/testcase.yaml
@@ -1,0 +1,6 @@
+tests:
+  bluetooth.mesh.light_hue:
+    platform_allow: native_posix qemu_cortex_m3
+    tags: bluetooth ci_build
+    integration_platforms:
+      - qemu_cortex_m3


### PR DESCRIPTION
This PR implements wrap around behavior for Hue state according to
MshMDLd1.1 (section 6.1.4.1).

In short:
- when range is [0, 0xFFFF]:
  - the Hue state can wrap around;
  - when transition is not instantaneous, the transition should take the
    shortest path to the target value;
  - when GL Move transition is not instantaneous, it can only be stopped
    by Generic Move Set (Unack) message with Delta Level value set to 0;
- Range Max can be less than Range Min:
  - the Hue state wraps around when crosses 0/0xFFFF values by
    transition from the current to the target value;
- when range doesn't include the entire value range:
  - GL Move transition stops at Range Max/Min.