### PR TITLE
nrf_security: Add support for mbedTLS memory debug

### DIFF
--- a/subsys/nrf_security/Kconfig.tls
+++ b/subsys/nrf_security/Kconfig.tls
@@ -164,6 +164,13 @@ config MBEDTLS_DEBUG_LEVEL
 	  3 Information
 	  4 Verbose
 
+config MBEDTLS_MEMORY_DEBUG
+	bool "mbed TLS memory debug activation"
+	help
+	  Enable debugging of buffer allocator memory issues. Automatically
+	  prints (to stderr) all (fatal) messages on memory allocation
+	  issues. Enables function for 'debug output' of allocated memory.
+
 config MBEDTLS_SSL_PROTO_DTLS
 	bool "Enable support for DTLS"
 	depends on MBEDTLS_SSL_PROTO_TLS1_2

--- a/subsys/nrf_security/cmake/legacy_crypto_config.cmake
+++ b/subsys/nrf_security/cmake/legacy_crypto_config.cmake
@@ -96,6 +96,7 @@ kconfig_check_and_set_base(MBEDTLS_PKCS5_C)
 kconfig_check_and_set_base(MBEDTLS_PK_PARSE_C)
 kconfig_check_and_set_base(MBEDTLS_PK_WRITE_C)
 kconfig_check_and_set_base(MBEDTLS_DEBUG_C)
+kconfig_check_and_set_base(MBEDTLS_MEMORY_DEBUG)
 
 kconfig_check_and_set_base(MBEDTLS_PSA_CRYPTO_SPM)
 

--- a/subsys/nrf_security/configs/legacy_crypto_config.h.template
+++ b/subsys/nrf_security/configs/legacy_crypto_config.h.template
@@ -1066,7 +1066,7 @@
  *
  * Uncomment this macro to let the buffer allocator print out error messages.
  */
-//#define MBEDTLS_MEMORY_DEBUG
+ #cmakedefine MBEDTLS_MEMORY_DEBUG
 
 /**
  * \def MBEDTLS_MEMORY_BACKTRACE


### PR DESCRIPTION
This commit enables application to set the `CONFIG_MBEDTLS_MEMORY_DEBUG` KConfig and pass it to mbedTLS configuration.

The description of the MBEDTLS_MEMORY_DEBUG has been copied from sdk-zephyr.