### PR TITLE
sample: lwm2m_client: Rd client start and disconnect fix

### DIFF
--- a/samples/cellular/lwm2m_client/src/main.c
+++ b/samples/cellular/lwm2m_client/src/main.c
@@ -447,7 +447,7 @@ static void rd_client_event(struct lwm2m_ctx *client, enum lwm2m_rd_client_event
 	case LWM2M_RD_CLIENT_EVENT_DISCONNECT:
 		LOG_DBG("Disconnected");
 		if (client_state != UPDATE_FIRMWARE) {
-			state_set_and_unlock(START);
+			state_trigger_and_unlock(START);
 		} else {
 			k_mutex_unlock(&lte_mutex);
 		}
@@ -686,9 +686,9 @@ int main(void)
 			ret = lwm2m_rd_client_start(&client, endpoint_name, bootstrap_flags,
 						    rd_client_event, NULL);
 			if (ret) {
-				state_set_and_unlock(NETWORK_ERROR);
+				state_trigger_and_unlock(NETWORK_ERROR);
 			} else {
-				state_set_and_unlock(CONNECTING);
+				state_trigger_and_unlock(CONNECTING);
 			}
 			break;
 


### PR DESCRIPTION
Replased Client state machine to use a proper function which release proper lock and trig a new state.