### PR TITLE
applications: serial_lte_modem: Update 9161 pins

### DIFF
--- a/applications/serial_lte_modem/boards/nrf9161dk_nrf9161_ns.conf
+++ b/applications/serial_lte_modem/boards/nrf9161dk_nrf9161_ns.conf
@@ -12,8 +12,8 @@
 # unmask the following config
 CONFIG_UART_0_NRF_HW_ASYNC_TIMER=2
 CONFIG_UART_0_NRF_HW_ASYNC=y
-CONFIG_SLM_WAKEUP_PIN=6
-CONFIG_SLM_INDICATE_PIN=2
+CONFIG_SLM_WAKEUP_PIN=8
+CONFIG_SLM_INDICATE_PIN=0
 
 # Use UART_2 (when working with external MCU)
 # unmask the following config


### PR DESCRIPTION
Update CONFIG_SLM_WAKEUP_PIN and CONFIG_SLM_INDICATE_PIN default values for nrf9161dk.