### PR TITLE
samples: lwm2m_client: Client state machine fix

### DIFF
--- a/samples/nrf9160/lwm2m_client/src/main.c
+++ b/samples/nrf9160/lwm2m_client/src/main.c
@@ -447,7 +447,9 @@ static void rd_client_event(struct lwm2m_ctx *client, enum lwm2m_rd_client_event
 	case LWM2M_RD_CLIENT_EVENT_DISCONNECT:
 		LOG_DBG("Disconnected");
 		if (client_state != UPDATE_FIRMWARE) {
-			state_set_and_unlock(START);
+			state_trigger_and_unlock(START);
+		} else {
+			k_mutex_unlock(&lte_mutex);
 		}
 		break;
 
@@ -681,9 +683,13 @@ int main(void)
 		switch (client_state) {
 		case START:
 			LOG_INF("Client connect to server");
-			state_set_and_unlock(CONNECTING);
-			lwm2m_rd_client_start(&client, endpoint_name, bootstrap_flags,
-					      rd_client_event, NULL);
+			ret = lwm2m_rd_client_start(&client, endpoint_name, bootstrap_flags,
+						    rd_client_event, NULL);
+			if (ret) {
+				state_trigger_and_unlock(NETWORK_ERROR);
+			} else {
+				state_trigger_and_unlock(CONNECTING);
+			}
 			break;
 
 		case BOOTSTRAP:


### PR DESCRIPTION
Fix firmware Update state for handling Disconnect state.

Fix lw2m_rd_client_start() call if it return error client jump to network error which recover state.