### PR TITLE
tests/modules/lib/zcbor: Fix missing zcbode_decode.h

### DIFF
--- a/tests/modules/lib/zcbor/decode/src/main.c
+++ b/tests/modules/lib/zcbor/decode/src/main.c
@@ -6,6 +6,7 @@
 #include <zephyr/ztest.h>
 #include "test_decode.h"
 #include "zcbor_encode.h"
+#include "zcbor_decode.h"
 
 ZTEST(lib_zcbor_test1, test_decode)
 {


### PR DESCRIPTION
Decode test has been missing zcbor_decode.h.