### PR TITLE
applications: nrf_desktop: Align application name in sample.yaml

### DIFF
--- a/applications/nrf_desktop/sample.yaml
+++ b/applications/nrf_desktop/sample.yaml
@@ -1,6 +1,6 @@
 sample:
-  name: nRF52 Desktop
-  description: BLE HID device reference design
+  name: nRF Desktop
+  description: HID device reference design
 tests:
   applications.nrf_desktop.zdebug:
     build_only: true


### PR DESCRIPTION
Change aligns application name and description in `sample.yaml` with the application documentation.

Jira: NCSDK-23317