### PR TITLE
applications: asset_tracker_v2: Use new Zephyr overlay arguments

### DIFF
--- a/applications/asset_tracker_v2/doc/app_behavior.rst
+++ b/applications/asset_tracker_v2/doc/app_behavior.rst
@@ -129,7 +129,7 @@ A-GPS and P-GPS
 The application supports processing of incoming A-GPS and P-GPS data to reduce the GNSS Time-To-First-Fix (`TTFF`_).
 Requesting and processing of A-GPS data is a default feature of the application.
 See :ref:`nRF Cloud A-GPS and P-GPS <nrfcloud_agps_pgps>` for further details.
-To enable support for P-GPS, add the parameter ``-DOVERLAY_CONFIG=overlay-pgps.conf`` to your build command.
+To enable support for P-GPS, add the parameter ``-DEXTRA_CONF_FILE=overlay-pgps.conf`` to your build command.
 
 .. note::
    Enabling support for P-GPS creates a new flash partition in the image for storing P-GPS data.

--- a/applications/asset_tracker_v2/doc/asset_tracker_v2_description.rst
+++ b/applications/asset_tracker_v2/doc/asset_tracker_v2_description.rst
@@ -137,7 +137,7 @@ Multiple overlay files can be included to enable multiple features at the same t
    DTS overlay files are named the same as the build target and use the file extension :file:`.overlay`.
    When they are placed in the :file:`boards` folder and the DTS overlay filename matches the build target,
    the build system automatically selects and applies the overlay.
-   You can give the custom DTS overlay files as a compiler option ``-DDTC_OVERLAY_FILE=<dtc_filename>.overlay``.
+   You can give the custom DTS overlay files as a compiler option ``-DEXTRA_DTC_OVERLAY_FILE=<dtc_filename>.overlay``.
 
 Optional library configurations
 ===============================

--- a/applications/asset_tracker_v2/doc/cloud_module.rst
+++ b/applications/asset_tracker_v2/doc/cloud_module.rst
@@ -96,7 +96,7 @@ For additional documentation on the various FOTA implementations, refer to the r
 
 Full modem FOTA updates are only supported by nRF Cloud.
 This application implements full modem FOTA only for the nRF9160 development kit version 0.14.0 and higher.
-To enable full modem FOTA, add the ``-DOVERLAY_CONFIG=overlay-full_modem_fota.conf`` parameter to your build command.
+To enable full modem FOTA, add the ``-DEXTRA_CONF_FILE=overlay-full_modem_fota.conf`` parameter to your build command.
 
 Also, specify your development kit version by appending it to the board name.
 For example, if your development kit version is 1.0.1, use the board name ``nrf9160dk_nrf9160_ns@1_0_1`` in your build command.

--- a/applications/asset_tracker_v2/doc/location_module.rst
+++ b/applications/asset_tracker_v2/doc/location_module.rst
@@ -68,15 +68,15 @@ Wi-Fi positioning
 
 Wi-Fi positioning is supported with an nRF7002 EK on the nRF9160 DK.
 To enable Wi-Fi positioning and especially nRF7002 functionality, use a
-special DTC overlay with the compiler option ``-DDTC_OVERLAY_FILE=nrf9160dk_with_nrf7002ek.overlay`` and a
-configuration overlay ``-DOVERLAY_CONFIG=overlay-nrf7002ek-wifi-scan-only.conf``.
+special DTC overlay with the compiler option ``-DEXTRA_DTC_OVERLAY_FILE=nrf9160dk_with_nrf7002ek.overlay`` and a
+configuration overlay ``-DEXTRA_CONF_FILE=overlay-nrf7002ek-wifi-scan-only.conf``.
 
 To build for the nRF9160 DK with nRF7002 EK, use the ``nrf9160dk_nrf9160_ns`` build target with the ``SHIELD`` CMake option set to ``nrf7002ek`` and a scan-only overlay configuration.
 The following is an example of the CLI command:
 
 .. code-block:: console
 
-   west build -p -b nrf9160dk_nrf9160_ns -- -DSHIELD=nrf7002ek -DDTC_OVERLAY_FILE=nrf9160dk_with_nrf7002ek.overlay -DOVERLAY_CONFIG=overlay-nrf7002ek-wifi-scan-only.conf
+   west build -p -b nrf9160dk_nrf9160_ns -- -DSHIELD=nrf7002ek -DEXTRA_DTC_OVERLAY_FILE=nrf9160dk_with_nrf7002ek.overlay -DEXTRA_CONF_FILE=overlay-nrf7002ek-wifi-scan-only.conf
 
 Wi-Fi positioning has the following limitations:
 

--- a/applications/asset_tracker_v2/sample.yaml
+++ b/applications/asset_tracker_v2/sample.yaml
@@ -17,7 +17,7 @@ tests:
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - thingy91_nrf9160_ns
-    extra_args: OVERLAY_CONFIG=overlay-pgps.conf
+    extra_args: EXTRA_CONF_FILE=overlay-pgps.conf
     tags: ci_build
   applications.asset_tracker_v2.nrf_cloud-no-agps:
     build_only: true
@@ -38,7 +38,7 @@ tests:
       - native_posix
     extra_configs:
       - CONFIG_AWS_IOT_BROKER_HOST_NAME="example-hostname.aws.com"
-    extra_args: OVERLAY_CONFIG="overlay-aws.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-aws.conf"
     tags: ci_build
   applications.asset_tracker_v2.aws-pgps:
     build_only: true
@@ -49,7 +49,7 @@ tests:
       - thingy91_nrf9160_ns
     extra_configs:
       - CONFIG_AWS_IOT_BROKER_HOST_NAME="example-hostname.aws.com"
-    extra_args: OVERLAY_CONFIG="overlay-aws.conf;overlay-pgps.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-aws.conf;overlay-pgps.conf"
     tags: ci_build
   applications.asset_tracker_v2.aws-all:
     build_only: true
@@ -62,7 +62,7 @@ tests:
       - CONFIG_AWS_IOT_BROKER_HOST_NAME="example-hostname.aws.com"
       - CONFIG_MEMFAULT_NCS_PROJECT_KEY="PROJECTKEY"
     extra_args: >
-      OVERLAY_CONFIG="overlay-aws.conf;overlay-pgps.conf;overlay-debug.conf;overlay-memfault.conf"
+      EXTRA_CONF_FILE="overlay-aws.conf;overlay-pgps.conf;overlay-debug.conf;overlay-memfault.conf"
     tags: ci_build
   applications.asset_tracker_v2.azure:
     build_only: true
@@ -75,7 +75,7 @@ tests:
     extra_configs:
       - CONFIG_AZURE_IOT_HUB_DPS_HOSTNAME="global.azure-devices-provisioning.net"
       - CONFIG_AZURE_IOT_HUB_DPS_ID_SCOPE="IDSCOPE"
-    extra_args: OVERLAY_CONFIG="overlay-azure.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-azure.conf"
     tags: ci_build
   applications.asset_tracker_v2.debug:
     build_only: true
@@ -85,7 +85,7 @@ tests:
       - nrf9160dk_nrf9160_ns
       - thingy91_nrf9160_ns
       - native_posix
-    extra_args: OVERLAY_CONFIG=overlay-debug.conf
+    extra_args: EXTRA_CONF_FILE=overlay-debug.conf
     tags: ci_build
   applications.asset_tracker_v2.debug-memfault:
     build_only: true
@@ -96,7 +96,7 @@ tests:
       - thingy91_nrf9160_ns
     extra_configs:
       - CONFIG_MEMFAULT_NCS_PROJECT_KEY="PROJECTKEY"
-    extra_args: OVERLAY_CONFIG="overlay-debug.conf;overlay-memfault.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-debug.conf;overlay-memfault.conf"
     tags: ci_build
   applications.asset_tracker_v2.memfault:
     build_only: true
@@ -107,7 +107,7 @@ tests:
       - thingy91_nrf9160_ns
     extra_configs:
       - CONFIG_MEMFAULT_NCS_PROJECT_KEY="PROJECTKEY"
-    extra_args: OVERLAY_CONFIG=overlay-memfault.conf
+    extra_args: EXTRA_CONF_FILE=overlay-memfault.conf
     tags: ci_build
   applications.asset_tracker_v2.low-power:
     build_only: true
@@ -116,7 +116,7 @@ tests:
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - thingy91_nrf9160_ns
-    extra_args: OVERLAY_CONFIG=overlay-low-power.conf
+    extra_args: EXTRA_CONF_FILE=overlay-low-power.conf
     tags: ci_build
   applications.asset_tracker_v2.carrier.nrf9160dk:
     build_only: true
@@ -125,7 +125,7 @@ tests:
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - thingy91_nrf9160_ns
-    extra_args: OVERLAY_CONFIG=overlay-carrier.conf
+    extra_args: EXTRA_CONF_FILE=overlay-carrier.conf
     tags: ci_build
   applications.asset_tracker_v2.carrier.nrf9161dk:
     build_only: true
@@ -133,8 +133,8 @@ tests:
     platform_allow: nrf9161dk_nrf9161_ns
     integration_platforms:
       - nrf9161dk_nrf9161_ns
-    extra_args: OVERLAY_CONFIG=overlay-carrier.conf
-                DTC_OVERLAY_FILE=nrf9161dk_with_ext_flash.overlay
+    extra_args: EXTRA_CONF_FILE=overlay-carrier.conf
+                EXTRA_DTC_OVERLAY_FILE=nrf9161dk_with_ext_flash.overlay
     tags: ci_build
   applications.asset_tracker_v2.lwm2m.low-power:
     build_only: true
@@ -143,7 +143,7 @@ tests:
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - thingy91_nrf9160_ns
-    extra_args: OVERLAY_CONFIG="overlay-lwm2m.conf;overlay-low-power.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-lwm2m.conf;overlay-low-power.conf"
     tags: ci_build
   applications.asset_tracker_v2.lwm2m.debug:
     build_only: true
@@ -152,7 +152,7 @@ tests:
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - thingy91_nrf9160_ns
-    extra_args: OVERLAY_CONFIG="overlay-lwm2m.conf;overlay-debug.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-lwm2m.conf;overlay-debug.conf"
     tags: ci_build
   applications.asset_tracker_v2.lwm2m.debug-modem_trace:
     build_only: true
@@ -165,7 +165,7 @@ tests:
       - CONFIG_NRF_MODEM_LIB_TRACE=y
       - CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_UART_ZEPHYR=y
     extra_args: >
-      OVERLAY_CONFIG="overlay-lwm2m.conf;overlay-debug.conf"
+      EXTRA_CONF_FILE="overlay-lwm2m.conf;overlay-debug.conf"
       SNIPPET="nrf91-modem-trace-uart"
     tags: ci_build
   applications.asset_tracker_v2.lwm2m.memfault:
@@ -178,7 +178,7 @@ tests:
       - thingy91_nrf9160_ns
     extra_configs:
       - CONFIG_MEMFAULT_NCS_PROJECT_KEY="PROJECTKEY"
-    extra_args: OVERLAY_CONFIG="overlay-lwm2m.conf;overlay-memfault.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-lwm2m.conf;overlay-memfault.conf"
     tags: ci_build
   applications.asset_tracker_v2.memfault-low-power:
     build_only: true
@@ -190,23 +190,23 @@ tests:
       - thingy91_nrf9160_ns
     extra_configs:
       - CONFIG_MEMFAULT_NCS_PROJECT_KEY="PROJECTKEY"
-    extra_args: OVERLAY_CONFIG="overlay-low-power.conf;overlay-memfault.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-low-power.conf;overlay-memfault.conf"
     tags: ci_build
   applications.asset_tracker_v2.nrf7002ek_wifi.nrf9160dk:
     build_only: true
     integration_platforms:
       - nrf9160dk_nrf9160_ns
     platform_allow: nrf9160dk_nrf9160_ns
-    extra_args: SHIELD=nrf7002ek OVERLAY_CONFIG=overlay-nrf7002ek-wifi-scan-only.conf
-                DTC_OVERLAY_FILE="nrf91xxdk_with_nrf7002ek.overlay;nrf9160dk_with_ext_flash.overlay"
+    extra_args: SHIELD=nrf7002ek EXTRA_CONF_FILE=overlay-nrf7002ek-wifi-scan-only.conf
+                EXTRA_DTC_OVERLAY_FILE="nrf91xxdk_with_nrf7002ek.overlay;nrf9160dk_with_ext_flash.overlay"
     tags: ci_build
   applications.asset_tracker_v2.nrf7002ek_wifi.nrf9161dk:
     build_only: true
     integration_platforms:
       - nrf9161dk_nrf9161_ns
     platform_allow: nrf9161dk_nrf9161_ns
-    extra_args: SHIELD=nrf7002ek OVERLAY_CONFIG=overlay-nrf7002ek-wifi-scan-only.conf
-                DTC_OVERLAY_FILE="nrf91xxdk_with_nrf7002ek.overlay;nrf9161dk_with_ext_flash.overlay"
+    extra_args: SHIELD=nrf7002ek EXTRA_CONF_FILE=overlay-nrf7002ek-wifi-scan-only.conf
+                EXTRA_DTC_OVERLAY_FILE="nrf91xxdk_with_nrf7002ek.overlay;nrf9161dk_with_ext_flash.overlay"
     tags: ci_build
   applications.asset_tracker_v2.nrf7002ek_wifi-debug:
     build_only: true
@@ -215,6 +215,6 @@ tests:
       - nrf9161dk_nrf9161_ns
     platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     extra_args: SHIELD=nrf7002ek
-                OVERLAY_CONFIG="overlay-nrf7002ek-wifi-scan-only.conf;overlay-debug.conf"
-                DTC_OVERLAY_FILE="nrf91xxdk_with_nrf7002ek.overlay"
+                EXTRA_CONF_FILE="overlay-nrf7002ek-wifi-scan-only.conf;overlay-debug.conf"
+                EXTRA_DTC_OVERLAY_FILE="nrf91xxdk_with_nrf7002ek.overlay"
     tags: ci_build

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -173,6 +173,7 @@ nRF9160: Asset Tracker v2
   * Default value of the Kconfig option :kconfig:option:`CONFIG_DATA_ACTIVE_TIMEOUT_SECONDS` is changed to 300 seconds.
   * Enabled link time optimization to reduce the flash size of the application.
     You can disable this using the Kconfig option :kconfig:option:`CONFIG_ASSET_TRACKER_V2_LTO`.
+  * Replaced overlay arguments ``OVERLAY_CONFIG`` and ``DTC_OVERLAY_FILE`` with the new Zephyr overlay arguments ``EXTRA_CONF_FILE`` and ``EXTRA_DTC_OVERLAY_FILE`` so as to avoid overriding of board overlay for the nRF9160 DK v0.14.0.
 
 * Fixed an issue with movement timeout handling in passive mode.
 

--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -8,13 +8,6 @@
 #    - all
 
 - scenarios:
-    - applications.asset_tracker_v2.nrf7002ek_wifi-debug
-    - applications.asset_tracker_v2.nrf7002ek_wifi-release
-  platforms:
-    - all
-  comment: "Temporary disable till the issue is fixed"
-
-- scenarios:
     - applications.nrf_desktop.zrelease
   platforms:
     - nrf52833dk_nrf52820


### PR DESCRIPTION
Replace overlay arguments OVERLAY_CONFIG and DTC_OVERLAY_FILE with the new Zephyr overlay arguments EXTRA_CONF_FILE and EXTRA_DTC_OVERLAY_FILE in documentation and sample.yaml.

This fixes a problem with some overlays overriding the board overlay for the nRF9160 DK 0.14.0 board in the application folder.