### PR TITLE
samples: lwm2m_client: Server initiated bootstrap fix

### DIFF
--- a/doc/nrf/releases/release-notes-2.4.2.rst
+++ b/doc/nrf/releases/release-notes-2.4.2.rst
@@ -82,6 +82,16 @@ This patch release adds a workaround in the :ref:`nrfxlib:nrf_modem` for modem f
 
 For more information, see item NRF91-1702 in the `Known issues page <known issues page on the main branch_>`_.
 
+Samples
+=======
+
+Cellular samples
+----------------
+
+:ref:`lwm2m_client` sample:
+
+* Added missing ``lwm2m_rd_client_start()`` call error handling.
+
 Zephyr
 ======
 

--- a/samples/nrf9160/lwm2m_client/src/main.c
+++ b/samples/nrf9160/lwm2m_client/src/main.c
@@ -447,7 +447,7 @@ static void rd_client_event(struct lwm2m_ctx *client, enum lwm2m_rd_client_event
 	case LWM2M_RD_CLIENT_EVENT_DISCONNECT:
 		LOG_DBG("Disconnected");
 		if (client_state != UPDATE_FIRMWARE) {
-			state_trigger_and_unlock(START);
+			state_set_and_unlock(START);
 		} else {
 			k_mutex_unlock(&lte_mutex);
 		}


### PR DESCRIPTION
Disconnect event can't trig state changes because at bootsrap generate that disconnect event.