### PR TITLE
drivers: wifi: Fix build issue for raw scan

### DIFF
--- a/drivers/wifi/nrf700x/zephyr/inc/zephyr_wifi_mgmt.h
+++ b/drivers/wifi/nrf700x/zephyr/inc/zephyr_wifi_mgmt.h
@@ -50,11 +50,4 @@ int wifi_nrf_get_power_save_config(const struct device *dev,
 void wifi_nrf_event_proc_get_power_save_info(void *vif_ctx,
 		struct nrf_wifi_umac_event_power_save_info *ps_info,
 		unsigned int event_len);
-
-#ifdef CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS
-void wifi_nrf_rx_bcn_prb_resp_frm(void *vif_ctx,
-				  void *frm,
-				  unsigned short frequency,
-				  signed short signal);
-#endif /* CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS */
 #endif /*  __ZEPHYR_WIFI_MGMT_H__ */

--- a/drivers/wifi/nrf700x/zephyr/inc/zephyr_wifi_mgmt_scan.h
+++ b/drivers/wifi/nrf700x/zephyr/inc/zephyr_wifi_mgmt_scan.h
@@ -25,4 +25,10 @@ void wifi_nrf_event_proc_disp_scan_res_zep(void *vif_ctx,
 				unsigned int event_len,
 				bool is_last);
 
+#ifdef CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS
+void wifi_nrf_rx_bcn_prb_resp_frm(void *vif_ctx,
+				  void *frm,
+				  unsigned short frequency,
+				  signed short signal);
+#endif /* CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS */
 #endif /* __ZEPHYR_DISP_SCAN_H__ */

--- a/samples/wifi/scan/sample.yaml
+++ b/samples/wifi/scan/sample.yaml
@@ -18,6 +18,13 @@ tests:
       - nrf9160dk_nrf9160_ns
     platform_allow: nrf5340dk_nrf5340_cpuapp nrf52840dk_nrf52840 nrf9160dk_nrf9160_ns
     tags: ci_build
+  sample.nrf7002_eks.raw_scan:
+    build_only: true
+    extra_args: SHIELD=nrf7002ek CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS=y
+    integration_platforms:
+      - nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns
+    tags: ci_build
   sample.nrf7000_eks.scan:
     build_only: true
     extra_args: SHIELD=nrf7002ek_nrf7000 CONFIG_WPA_SUPP=n


### PR DESCRIPTION
Fix build issue for raw scan mode. This seems to have been introduced during reorganization of scan code from zephyr_wifi_mgmt.c to zephyr_wifi_mgmt_scan.c.

Issue fixed: [SHEL-1944]

[SHEL-1944]: https://nordicsemi.atlassian.net/browse/SHEL-1944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ