### PR TITLE
manifest: Update nrfxlib

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -139,7 +139,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: ae69502a63b91172517c1755a82de553cd40ea68
+      revision: c2dc802ded9eae0ad576a908ca14669d146ca83b
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Update nrfxlib with latest changes to mpsl and sdc.

mpsl does no longer do clock calibration.