### PR TITLE
net: lib: nrf_provisioning: Fix null pointer dereferencing

### DIFF
--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_codec.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_codec.c
@@ -297,9 +297,11 @@ static int exec_at_cmd(struct command *cmd_req, struct cdc_out_fmt_data *out)
 			resp = NULL;
 			if (sscanf(out->at_buff, "AT%%KEYGEN=%d,%d,%*s", &tag, &type) == 2) {
 				LOG_DBG("Clear sec_tag %d, type %d", tag, type);
-				ret = nrf_provisioning_at_del_credential(tag, type);
-				if (ret < 0) {
-					LOG_ERR("AT cmd failed, error: %d", ret);
+				int err;
+
+				err = nrf_provisioning_at_del_credential(tag, type);
+				if (err < 0) {
+					LOG_ERR("AT cmd failed, error: %d", err);
 				}
 			}
 			resp_sz *= 2; /* Previous size wasn't sufficient */


### PR DESCRIPTION
Since the nrf_provisioning_at_del_credential was overwriting the value
of ret, there was a case when resp_sz becomes greater than
AT_RESP_MAX_SIZE, put_at_resp() was called with resp pointing to NULL.
This further lead to strlen() with NULL Pointer as input. This is now
fixed by creating a separate variable for storing the return value of
nrf_provisioning_at_del_credential.

Found as violation of MITRE, CWE-476 by sonarcloud.

[Bug report]( https://sonarcloud.io/project/issues?resolved=false&sinceLeakPeriod=true&types=BUG&pullRequest=160&id=balaji-nordic_sdk-nrf&open=AYouFTykAz_JJukRU8mW )

