### PR TITLE
samples: matter: Change image checking condition for OTA.

### DIFF
--- a/applications/matter_bridge/src/app_task.cpp
+++ b/applications/matter_bridge/src/app_task.cpp
@@ -133,10 +133,7 @@ CHIP_ERROR AppTask::Init()
 
 #ifdef CONFIG_CHIP_OTA_REQUESTOR
 	/* OTA image confirmation must be done before the factory data init. */
-	err = OtaConfirmNewImage();
-	if (err != CHIP_NO_ERROR) {
-		return err;
-	}
+	OtaConfirmNewImage();
 #endif
 
 	/* Initialize CHIP server */

--- a/applications/matter_weather_station/src/app_task.cpp
+++ b/applications/matter_weather_station/src/app_task.cpp
@@ -219,10 +219,7 @@ CHIP_ERROR AppTask::Init()
 
 #ifdef CONFIG_CHIP_OTA_REQUESTOR
 	/* OTA image confirmation must be done before the factory data init. */
-	err = OtaConfirmNewImage();
-	if (err != CHIP_NO_ERROR) {
-		return err;
-	}
+	OtaConfirmNewImage();
 #endif
 
 #ifdef CONFIG_MCUMGR_TRANSPORT_BT

--- a/doc/nrf/releases_and_maturity/known_issues.rst
+++ b/doc/nrf/releases_and_maturity/known_issues.rst
@@ -297,25 +297,26 @@ KRKNWK-17535: The application core can crash on nRF5340 after the OTA firmware u
         #include <platform/CHIPDeviceLayer.h>
         #include <zephyr/dfu/mcuboot.h>
 
-        CHIP_ERROR OtaConfirmNewImage()
-        {
-          CHIP_ERROR err = CHIP_NO_ERROR;
-          OTAImageProcessorImpl &imageProcessor = GetOTAImageProcessor();
-          if (imageProcessor.IsFirstImageRun()) {
-            CHIP_ERROR err = System::MapErrorZephyr(boot_write_img_confirmed());
-            if (CHIP_NO_ERROR == err) {
-              imageProcessor.SetImageConfirmed();
-            }
+        #ifndef CONFIG_SOC_SERIES_NRF53X
+          VerifyOrReturn(mcuboot_swap_type() == BOOT_SWAP_TYPE_REVERT);
+        #endif
+
+        OTAImageProcessorImpl &imageProcessor = GetOTAImageProcessor();
+        if(!boot_is_img_confirmed()){
+          CHIP_ERROR err = System::MapErrorZephyr(boot_write_img_confirmed());
+          if (CHIP_NO_ERROR == err) {
+            imageProcessor.SetImageConfirmed();
+            ChipLogProgress(SoftwareUpdate, "New firmware image confirmed");
+          } else {
+            ChipLogError(SoftwareUpdate, "Failed to confirm firmware image, it will be reverted on the next boot");
           }
-          ChipLogError(SoftwareUpdate, "Failed to confirm firmware image, it will be reverted on the next boot");
-          return err;
         }
 
   #. Add the following line to the :file:`samples/matter/common/src/ota_util.h`:
 
      .. code-block::
 
-        CHIP_ERROR OtaConfirmNewImage();
+        void OtaConfirmNewImage();
 
   #. Add the following lines to the ``AppTask::Init()`` method in the :file:`app_task.cpp` file located in a sample directory before initialization of the factory data module (``mFactoryDataProvider.Init()``):
 
@@ -323,10 +324,7 @@ KRKNWK-17535: The application core can crash on nRF5340 after the OTA firmware u
 
         #ifdef CONFIG_CHIP_OTA_REQUESTOR
           /* OTA image confirmation must be done before the factory data init. */
-          err = OtaConfirmNewImage();
-          if (err != CHIP_NO_ERROR) {
-            return err;
-          }
+          OtaConfirmNewImage();
         #endif
 
 .. rst-class:: v2-4-0 v2-3-0

--- a/samples/matter/common/src/ota_multi_image_processor_impl.cpp
+++ b/samples/matter/common/src/ota_multi_image_processor_impl.cpp
@@ -48,7 +48,7 @@ CHIP_ERROR OTAMultiImageProcessorImpl::PrepareMultiDownload()
 
 CHIP_ERROR OTAMultiImageProcessorImpl::ConfirmCurrentImage()
 {
-	CHIP_ERROR err = System::MapErrorZephyr(boot_write_img_confirmed());
+	CHIP_ERROR err = mImageConfirmed ? CHIP_NO_ERROR : CHIP_ERROR_INCORRECT_STATE;
 	if (err == CHIP_NO_ERROR) {
 		err = System::MapErrorZephyr(OTAMultiImageDownloaders::Apply());
 	}

--- a/samples/matter/common/src/ota_multi_image_processor_impl.h
+++ b/samples/matter/common/src/ota_multi_image_processor_impl.h
@@ -22,7 +22,11 @@ public:
 
 	CHIP_ERROR PrepareDownload() override;
 	CHIP_ERROR ConfirmCurrentImage() override;
+	void SetImageConfirmed() { mImageConfirmed = true; }
 
 protected:
 	CHIP_ERROR PrepareMultiDownload();
+
+private:
+    bool mImageConfirmed = false;
 };

--- a/samples/matter/common/src/ota_util.cpp
+++ b/samples/matter/common/src/ota_util.cpp
@@ -63,18 +63,27 @@ void InitBasicOTARequestor()
 	imageProcessor.TriggerFlashAction(ExternalFlashManager::Action::SLEEP);
 }
 
-CHIP_ERROR OtaConfirmNewImage()
+void OtaConfirmNewImage()
 {
-	CHIP_ERROR err = CHIP_NO_ERROR;
+
+#ifndef CONFIG_SOC_SERIES_NRF53X
+	/* Check if the image is run in the REVERT mode and eventually
+	confirm it to prevent reverting on the next boot.
+	On nRF53 target there is not way to verify current swap type
+	because we use permanent swap so we can skip it. */
+	VerifyOrReturn(mcuboot_swap_type() == BOOT_SWAP_TYPE_REVERT);
+#endif
+
 	OTAImageProcessorImpl &imageProcessor = GetOTAImageProcessor();
-	if (imageProcessor.IsFirstImageRun()) {
+	if(!boot_is_img_confirmed()){
 		CHIP_ERROR err = System::MapErrorZephyr(boot_write_img_confirmed());
 		if (CHIP_NO_ERROR == err) {
 			imageProcessor.SetImageConfirmed();
+			ChipLogProgress(SoftwareUpdate, "New firmware image confirmed");
+		} else {
+			ChipLogError(SoftwareUpdate, "Failed to confirm firmware image, it will be reverted on the next boot");
 		}
 	}
-	ChipLogError(SoftwareUpdate, "Failed to confirm firmware image, it will be reverted on the next boot");
-	return err;
 }
 
 #endif

--- a/samples/matter/common/src/ota_util.h
+++ b/samples/matter/common/src/ota_util.h
@@ -38,7 +38,7 @@ void InitBasicOTARequestor();
  * boot after the OTA update.
  * Other CHIP_ERROR codes if the image could not be confirmed.
  */
-CHIP_ERROR OtaConfirmNewImage();
+void OtaConfirmNewImage();
 
 #endif /* CONFIG_CHIP_OTA_REQUESTOR */
 

--- a/samples/matter/light_bulb/src/app_task.cpp
+++ b/samples/matter/light_bulb/src/app_task.cpp
@@ -192,10 +192,7 @@ CHIP_ERROR AppTask::Init()
 
 #ifdef CONFIG_CHIP_OTA_REQUESTOR
 	/* OTA image confirmation must be done before the factory data init. */
-	err = OtaConfirmNewImage();
-	if (err != CHIP_NO_ERROR) {
-		return err;
-	}
+	OtaConfirmNewImage();
 #endif
 
 #ifdef CONFIG_MCUMGR_TRANSPORT_BT

--- a/samples/matter/light_switch/src/app_task.cpp
+++ b/samples/matter/light_switch/src/app_task.cpp
@@ -172,10 +172,7 @@ CHIP_ERROR AppTask::Init()
 
 #ifdef CONFIG_CHIP_OTA_REQUESTOR
 	/* OTA image confirmation must be done before the factory data init. */
-	err = OtaConfirmNewImage();
-	if (err != CHIP_NO_ERROR) {
-		return err;
-	}
+	OtaConfirmNewImage();
 #endif
 
 #ifdef CONFIG_MCUMGR_TRANSPORT_BT

--- a/samples/matter/lock/src/app_task.cpp
+++ b/samples/matter/lock/src/app_task.cpp
@@ -213,10 +213,7 @@ CHIP_ERROR AppTask::Init()
 
 #ifdef CONFIG_CHIP_OTA_REQUESTOR
 	/* OTA image confirmation must be done before the factory data init. */
-	err = OtaConfirmNewImage();
-	if (err != CHIP_NO_ERROR) {
-		return err;
-	}
+	OtaConfirmNewImage();
 #endif
 
 #ifdef CONFIG_MCUMGR_TRANSPORT_BT

--- a/samples/matter/template/src/app_task.cpp
+++ b/samples/matter/template/src/app_task.cpp
@@ -146,10 +146,7 @@ CHIP_ERROR AppTask::Init()
 
 #ifdef CONFIG_CHIP_OTA_REQUESTOR
 	/* OTA image confirmation must be done before the factory data init. */
-	err = OtaConfirmNewImage();
-	if (err != CHIP_NO_ERROR) {
-		return err;
-	}
+	OtaConfirmNewImage();
 #endif
 
 	/* Initialize CHIP server */

--- a/samples/matter/thermostat/src/app_task.cpp
+++ b/samples/matter/thermostat/src/app_task.cpp
@@ -164,10 +164,7 @@ CHIP_ERROR AppTask::Init()
 
 #ifdef CONFIG_CHIP_OTA_REQUESTOR
 	/* OTA image confirmation must be done before the factory data init. */
-	err = OtaConfirmNewImage();
-	if (err != CHIP_NO_ERROR) {
-		return err;
-	}
+	OtaConfirmNewImage();
 #endif
 
 #ifdef CONFIG_MCUMGR_TRANSPORT_BT

--- a/samples/matter/window_covering/src/app_task.cpp
+++ b/samples/matter/window_covering/src/app_task.cpp
@@ -136,10 +136,7 @@ CHIP_ERROR AppTask::Init()
 
 #ifdef CONFIG_CHIP_OTA_REQUESTOR
 	/* OTA image confirmation must be done before the factory data init. */
-	err = OtaConfirmNewImage();
-	if (err != CHIP_NO_ERROR) {
-		return err;
-	}
+	OtaConfirmNewImage();
 #endif
 
 #ifdef CONFIG_MCUMGR_TRANSPORT_BT


### PR DESCRIPTION
If we want to confirm the new firmware update in the AppTask Init method we cannot rely on the imageProcessor and instead of that, we need to call the mcuboot_swap_type function to verify whether the swapping type is equal to REVERT.