### PR TITLE
bluetooth: adv_prov: fast_pair: Increase advertising buffer size

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -285,6 +285,7 @@ Bluetooth samples
 * :ref:`peripheral_fast_pair` sample:
 
   * Updated by disabling the :kconfig:option:`CONFIG_BT_SETTINGS_CCC_LAZY_LOADING` Kconfig option as a workaround fix for the `Zephyr issue #61033`_.
+  * Fixed an issue where the sample was unable to advertise in Fast Pair not discoverable advertising mode when it had five Account Keys written.
 
 Bluetooth mesh samples
 ----------------------
@@ -551,6 +552,12 @@ Bluetooth libraries and services
 
   * Updated by deleting reset in progress flag from settings storage instead of storing it as ``false`` on factory reset operation.
     This is done to ensure that no Fast Pair data is left in the settings storage after the factory reset.
+
+* :ref:`bt_le_adv_prov_readme` library:
+
+  * Changed the allowed range of the :kconfig:option:`CONFIG_CONFIG_BT_ADV_PROV_FAST_PAIR_ADV_BUF_SIZE` Kconfig option and set its default value to 26.
+    This is done to align the buffer size to the new Fast Pair not discoverable advertising data size after the size of the salt included in the data was increased from 1 byte to 2 bytes.
+    The default value has been set to maximum to mitigate buffer overflow issues in the future.
 
 * :ref:`bt_mesh` library:
 

--- a/subsys/bluetooth/adv_prov/providers/Kconfig.fast_pair
+++ b/subsys/bluetooth/adv_prov/providers/Kconfig.fast_pair
@@ -21,11 +21,23 @@ if BT_ADV_PROV_FAST_PAIR
 
 config BT_ADV_PROV_FAST_PAIR_ADV_BUF_SIZE
 	int "Size of buffer used for advertising data"
-	range 10 25
-	default 19
+	range 11 26
+	default 26
 	help
-	  Size of the buffer must be big enough to fit Fast Pair advertising
-	  packet.
+	  Size of the buffer must be big enough to fit Fast Pair advertising packet.
+
+	  (10 + 1.2 * maximum number of Account Keys encoded in the advertising packet) - truncated
+	  bytes are needed. Additional 4 bytes are needed when battery data is included in Fast Pair
+	  advertising.
+
+	  11 bytes are needed when battery data is not included in Fast Pair advertising
+	  and only 1 Account Key has been written.
+
+	  20 bytes are needed when battery data is included in Fast Pair advertising
+	  and 5 Account Keys have been written.
+
+	  26 bytes are needed when battery data is included in Fast Pair advertising
+	  and 10 Account Keys have been written.
 
 config BT_ADV_PROV_FAST_PAIR_SHOW_UI_PAIRING
 	bool "Show UI indication in Fast Pair not discoverable advertising"


### PR DESCRIPTION
Added known issue related to too small buffer size in Fast Pair advertising that manifested in Fast Pair sample.
Increased default advertising buffer size to fix the issue.

Jira: NCSDK-23315