### PR TITLE
lib: lte_link_control: fix CE level enum naming

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -604,6 +604,7 @@ Modem libraries
 
 * :ref:`lte_lc_readme` library:
 
+  * Updated the CE level enum names for :c:enum:`lte_lc_ce_level` to not include the number of repetitions.
   * Removed obsolete registration status :c:enum:`LTE_LC_NW_REG_REGISTERED_EMERGENCY`.
 
 * :ref:`lib_location` library:

--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -619,19 +619,19 @@ enum lte_lc_tau_triggered {
 /** CE level. */
 enum lte_lc_ce_level {
 	/** No repetitions or a small number of repetitions. */
-	LTE_LC_CE_LEVEL_0_NO_REPETITION		= 0,
+	LTE_LC_CE_LEVEL_0	= 0,
 
 	/** Medium number of repetitions. */
-	LTE_LC_CE_LEVEL_1_LOW_REPETITION	= 1,
+	LTE_LC_CE_LEVEL_1	= 1,
 
 	/** Large number of repetitions. */
-	LTE_LC_CE_LEVEL_2_MEDIUM_REPETITION	= 2,
+	LTE_LC_CE_LEVEL_2	= 2,
 
 	/** Very large number of repetitions. */
-	LTE_LC_CE_LEVEL_3_LARGE_REPETITION	= 3,
+	LTE_LC_CE_LEVEL_3	= 3,
 
 	/** Not known. */
-	LTE_LC_CE_LEVEL_UNKNOWN			= UINT8_MAX,
+	LTE_LC_CE_LEVEL_UNKNOWN	= UINT8_MAX,
 };
 
 /** Reduced mobility mode. */

--- a/samples/cellular/modem_shell/src/link/link_api.c
+++ b/samples/cellular/modem_shell/src/link/link_api.c
@@ -161,13 +161,14 @@ void link_api_coneval_read_for_shell(void)
 	};
 
 	struct mapping_tbl_item const coneval_ce_level_strs[] = {
-		{ LTE_LC_CE_LEVEL_0_NO_REPETITION,
+		{ LTE_LC_CE_LEVEL_0,
 		  "0: CE level 0, No repetitions or small nbr of repetitions" },
-		{ LTE_LC_CE_LEVEL_1_LOW_REPETITION,
+		{ LTE_LC_CE_LEVEL_1,
 		  "1: CE level 1, Medium nbr of repetitions" },
-		{ LTE_LC_CE_LEVEL_2_MEDIUM_REPETITION,
+		{ LTE_LC_CE_LEVEL_2,
 		  "2: CE level 2, Large nbr of repetitions" },
-		{ 3, "3: CE level 3, Very large nbr of repetitions" },
+		{ LTE_LC_CE_LEVEL_3,
+		  "3: CE level 3, Very large nbr of repetitions" },
 		{ LTE_LC_CE_LEVEL_UNKNOWN, "Unknown" },
 		{ -1, NULL }
 	};


### PR DESCRIPTION
The number of repetitions in the CE level enum names were incorrect. Renamed the values to only have the CE level number, the number of repetitions is mentioned in the description.