### PR TITLE
samples: cellular: modem_shell: Fix Coverity warning

### DIFF
--- a/samples/cellular/modem_shell/src/gnss/gnss.c
+++ b/samples/cellular/modem_shell/src/gnss/gnss.c
@@ -275,7 +275,7 @@ static void gnss_carrier_location(struct nrf_modem_gnss_pvt_data_frame *pvt)
 		lwm2m_carrier_location_set(pvt->latitude,
 					   pvt->longitude,
 					   pvt->altitude,
-					   gnss_mktime(&pvt->datetime),
+					   (uint32_t)gnss_mktime(&pvt->datetime),
 					   pvt->accuracy);
 		lwm2m_carrier_velocity_set(pvt->heading,
 					   pvt->speed,


### PR DESCRIPTION
Carrier library API takes a 32-bit timestamp, added casting from 64-bit time_t.

In the long run the Carrier library API should probably be updated, but because the library is released as binary this will take some time.