### PR TITLE
Enable QZSS satellites in NMEA

### DIFF
--- a/samples/cellular/gnss/src/main.c
+++ b/samples/cellular/gnss/src/main.c
@@ -484,6 +484,11 @@ static int gnss_init_and_start(void)
 		return -1;
 	}
 
+	/* Make QZSS satellites visible in the NMEA output. */
+	if (nrf_modem_gnss_qzss_nmea_mode_set(NRF_MODEM_GNSS_QZSS_NMEA_MODE_CUSTOM) != 0) {
+		LOG_WRN("Failed to enable custom QZSS NMEA mode");
+	}
+
 	/* This use case flag should always be set. */
 	uint8_t use_case = NRF_MODEM_GNSS_USE_CASE_MULTIPLE_HOT_START;
 

--- a/samples/cellular/modem_shell/src/gnss/gnss.c
+++ b/samples/cellular/modem_shell/src/gnss/gnss.c
@@ -1015,6 +1015,7 @@ static void pgps_event_handler(struct nrf_cloud_pgps_event *event)
 
 static void gnss_api_init(void)
 {
+	int err;
 	static bool gnss_api_initialized;
 
 	/* Reset event handler in case some other handler was set in the meantime. */
@@ -1022,6 +1023,13 @@ static void gnss_api_init(void)
 
 	if (gnss_api_initialized) {
 		return;
+	}
+
+	/* Make QZSS satellites visible in the NMEA output. */
+	err = nrf_modem_gnss_qzss_nmea_mode_set(NRF_MODEM_GNSS_QZSS_NMEA_MODE_CUSTOM);
+	if (err) {
+		mosh_warn("GNSS: Failed to enable custom QZSS NMEA mode, error: %d (%s)",
+			  err, gnss_err_to_str(err));
 	}
 
 	gnss_api_initialized = true;

--- a/samples/cellular/modem_shell/src/gnss/gnss_shell.c
+++ b/samples/cellular/modem_shell/src/gnss/gnss_shell.c
@@ -812,7 +812,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_gnss_config_qzss_nmea,
 	SHELL_CMD_ARG(standard, NULL, "Standard NMEA reporting.",
 		      cmd_gnss_config_qzss_nmea_standard, 1, 0),
-	SHELL_CMD_ARG(custom, NULL, "Custom NMEA reporting.",
+	SHELL_CMD_ARG(custom, NULL, "Custom NMEA reporting (default).",
 		      cmd_gnss_config_qzss_nmea_custom, 1, 0),
 	SHELL_SUBCMD_SET_END
 );


### PR DESCRIPTION
Enabled custom QZSS NMEA mode for gnss and modem_shell samples. QZSS satellites are reported in $GPGSA and $GPGSV sentences using PRNs 193...202.