### PR TITLE
lib: location: Fix warning log for wrong GNSS system/func mode

### DIFF
--- a/lib/location/method_gnss.c
+++ b/lib/location/method_gnss.c
@@ -906,9 +906,8 @@ static void method_gnss_positioning_work_fn(struct k_work *work)
 
 	/* Configure GNSS to continuous tracking mode */
 	err = nrf_modem_gnss_fix_interval_set(1);
-	if (err == -EINVAL) {
-		LOG_WRN("First nrf_modem_gnss API function failed. It could be that "
-			"modem's system or functional mode doesn't allow GNSS usage.");
+	if (err == -NRF_EACCES) {
+		LOG_WRN("Modem's system or functional mode doesn't allow GNSS usage");
 	}
 
 #if defined(CONFIG_NRF_CLOUD_AGPS_ELEVATION_MASK)


### PR DESCRIPTION
Location library is expected to print a verbose error when GNSS is not enabled in the system or functional mode. The error returned by the GNSS API was changed in libmodem v2.3.0, but the implementation in the library still expects the old error.