### PR TITLE
NCSDK-22783: scripts: requirements: Update protobuf requirements

### DIFF
--- a/scripts/requirements-build.txt
+++ b/scripts/requirements-build.txt
@@ -4,6 +4,5 @@ ecdsa
 cryptography
 imagesize>=1.2.0
 intelhex
-protobuf
 pylint
 zcbor>=0.7.0

--- a/scripts/requirements-fixed.txt
+++ b/scripts/requirements-fixed.txt
@@ -38,6 +38,7 @@ future==0.18.3
 gcovr==4.2
 gitlint==0.15.0
 grpcio-tools==1.51.1
+protobuf==4.21.9
 idna==2.10
 imagesize==1.2.0
 imgtool==1.7.0


### PR DESCRIPTION
Minimal requirements for nanopb were not accurate to allow its usage.