### PR TITLE
caf: ble_state: Remove TX power update using HCI command on connected

### DIFF
--- a/doc/nrf/libraries/caf/ble_state.rst
+++ b/doc/nrf/libraries/caf/ble_state.rst
@@ -85,11 +85,7 @@ The |ble_state| keeps references to :c:struct:`bt_conn` objects to ensure that t
 When a new connection is established, the module calls :c:func:`bt_conn_ref` to increase the object reference counter.
 After :c:struct:`ble_peer_event` about disconnection or connection failure is received by all other application modules, the |ble_state| decrements the :c:struct:`bt_conn` object by using :c:func:`bt_conn_unref`.
 
-Behavior with SoftDevice Link Layer
-===================================
+Low Latency Packet Mode
+=======================
 
 If Nordic Semiconductor's SoftDevice Bluetooth LE Link Layer is selected (:kconfig:option:`CONFIG_BT_LL_SOFTDEVICE`) and the :kconfig:option:`CONFIG_CAF_BLE_USE_LLPM` option is enabled, the |ble_state| sends a Bluetooth HCI command to enable the LLPM when Bluetooth is ready.
-
-If the SoftDevice Link Layer is selected, the |ble_state| also sets the TX power for connections.
-The TX power is set according to Zephyr's Kconfig options related to selecting the default TX power.
-This is necessary because the mentioned Kconfig options are not automatically applied by the Bluetooth stack if the SoftDevice Link Layer is selected.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -793,6 +793,11 @@ Common Application Framework (CAF)
     * The library by improving broadcast of :c:struct:`module_state_event`.
       The event informing about entering either :c:enum:`MODULE_STATE_READY` or :c:enum:`MODULE_STATE_OFF` is not submitted until the CAF Bluetooth LE advertising module is initialized and ready.
 
+* :ref:`caf_ble_state`:
+
+   * Removed TX power update using a Bluetooth HCI command for SoftDevice Bluetooth LE Link Layer (:kconfig:option:`CONFIG_BT_LL_SOFTDEVICE`) right after a connection has been established.
+     The :kconfig:option:`CONFIG_BT_CTLR_TX_PWR` Kconfig option can be used to set the TX power for advertising and connections also for the SoftDevice Link Layer.
+
 * :ref:`caf_power_manager`:
 
   * Reduced verbosity of logs denoting allowed power states from ``info`` to ``debug``.

--- a/subsys/caf/modules/Kconfig.ble_state
+++ b/subsys/caf/modules/Kconfig.ble_state
@@ -8,12 +8,12 @@ menuconfig CAF_BLE_STATE
 	bool "Bluetooth LE state module"
 	depends on BT
 	depends on BT_SMP
-	select BT_CTLR_TX_PWR_DYNAMIC_CONTROL if BT_LL_SOFTDEVICE
 	select CAF_BLE_COMMON_EVENTS
 	help
-	  Module that enables Bluetooth, handles Zephyr's connection callbacks, propagates
-	  information about the connection state and parameters by using Application Event Manager events
-	  and exchanges GATT MTU on GATT Client.
+	  Module that enables Bluetooth, handles Zephyr's connection callbacks,
+	  propagates information about the connection state and parameters by
+	  using Application Event Manager events and exchanges GATT MTU on GATT
+	  Client.
 
 if CAF_BLE_STATE
 
@@ -66,27 +66,6 @@ config CAF_BLE_USE_LLPM
 	  applications in which the interface response time is critical for the user. It introduces
 	  the possibility to reduce the connection interval to 1 ms for one link. LLPM parameters
 	  can be used for a given connection only if it's supported by both peripheral and central.
-
-config CAF_BLE_STATE_TX_PWR
-	int
-	default 8 if BT_CTLR_TX_PWR_PLUS_8
-	default 7 if BT_CTLR_TX_PWR_PLUS_7
-	default 6 if BT_CTLR_TX_PWR_PLUS_6
-	default 5 if BT_CTLR_TX_PWR_PLUS_5
-	default 4 if BT_CTLR_TX_PWR_PLUS_4
-	default 3 if BT_CTLR_TX_PWR_PLUS_3
-	default 2 if BT_CTLR_TX_PWR_PLUS_2
-	default 0 if BT_CTLR_TX_PWR_0
-	default -4 if BT_CTLR_TX_PWR_MINUS_4
-	default -8 if BT_CTLR_TX_PWR_MINUS_8
-	default -12 if BT_CTLR_TX_PWR_MINUS_12
-	default -16 if BT_CTLR_TX_PWR_MINUS_16
-	default -20 if BT_CTLR_TX_PWR_MINUS_20
-	default -30 if BT_CTLR_TX_PWR_MINUS_30
-	default -40 if BT_CTLR_TX_PWR_MINUS_40
-	help
-	  For nrfxlib LL TX power has to be set using HCI commands.
-	  Zephyr Kconfig options are ignored.
 
 module = CAF_BLE_STATE
 module-str = caf module BLE state


### PR DESCRIPTION
Change removes the TX power update using a Bluetooth HCI command performed for SoftDevice Bluetooth LE Link Layer right after connection establishment. The Bluetooth controller's Kconfig option can be used to set the TX power used for both advertising and connections also for the SoftDevice Link Layer.

Jira: NCSDK-20804