### PR TITLE
lib: nrf_modem_lib: Dynamic modem trace control

### DIFF
--- a/include/modem/nrf_modem_lib_trace.h
+++ b/include/modem/nrf_modem_lib_trace.h
@@ -105,6 +105,24 @@ int nrf_modem_lib_trace_read(uint8_t *buf, size_t len);
  */
 int nrf_modem_lib_trace_clear(void);
 
+#if defined(CONFIG_NRF_MODEM_LIB_TRACE_DEFERRED)
+/** @brief Start receiving modem trace
+ *
+ * This function activates modem trace with defined set of CONFIG_NRF_MODEM_LIB_TRACE_LEVEL_XXX.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+int nrf_modem_lib_trace_start(void);
+
+/** @brief Stop receiving modem trace
+ *
+ * This function de-activates modem trace.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+int nrf_modem_lib_trace_stop(void);
+#endif /* CONFIG_NRF_MODEM_LIB_TRACE_DEFERRED */
+
 #if defined(CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_BITRATE) || defined(__DOXYGEN__)
 /** @brief Get the last measured rolling average bitrate of the trace backend.
  *

--- a/lib/nrf_modem_lib/Kconfig.modemlib
+++ b/lib/nrf_modem_lib/Kconfig.modemlib
@@ -130,6 +130,12 @@ menuconfig NRF_MODEM_LIB_TRACE
 
 if NRF_MODEM_LIB_TRACE
 
+config NRF_MODEM_LIB_TRACE_DEFERRED
+	bool "Defer modem trace"
+	help
+	  Defer the modem trace function until the application explicitly start receiving the traces.
+	  By default modem trace is not deferred.
+
 # Add trace backends
 rsource "trace_backends/Kconfig"
 


### PR DESCRIPTION
Currently modem trace is controlled by static configuration. 
Add one configuration to enable deferred trace output: 
`NRF_MODEM_LIB_TRACE_DEFERRED`
Also add two new APIs to provide trace output control: 
`int nrf_modem_lib_trace_start(void)`
`int nrf_modem_lib_trace_stop(void)`

Main purpose is to enable applications to start/stop modem trace dynamically or only when necessary, so as to stay in low power when modem trace is not required.