### PR TITLE
dtm: Enable optional fast ramp-up mode in DTM.

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -306,6 +306,8 @@ Bluetooth samples
 
     * Aligned timers' configurations to the new nrfx API.
     * Extracted the DTM radio API from the transport layer.
+    * Added support for the radio fast ramp-up feature.
+      This feature is enabled by default.
 
 * :ref:`peripheral_hids_keyboard` sample:
 

--- a/samples/bluetooth/direct_test_mode/Kconfig
+++ b/samples/bluetooth/direct_test_mode/Kconfig
@@ -66,6 +66,13 @@ config DTM_POWER_CONTROL_AUTOMATIC
 	  possible value. If this option is disabled, user can set the SoC output power and the
 	  front-end module gain with the separate vendor specific commands.
 
+config DTM_FAST_RAMP_UP
+	bool "Enable radio fast ramp up mode"
+	default y
+	help
+	  Do fast ramp up when starting the radio peripheral. This mode will significancy reduce
+	  the ramp up time and makes it almost the same on all supported chips.
+
 module = DTM_TRANSPORT
 module-str = "DTM_transport"
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"

--- a/samples/bluetooth/direct_test_mode/src/dtm.c
+++ b/samples/bluetooth/direct_test_mode/src/dtm.c
@@ -790,6 +790,7 @@ static int radio_init(void)
 
 	radio_tx_power_set(dtm_inst.phys_ch, dtm_inst.txpower);
 	nrf_radio_mode_set(NRF_RADIO, dtm_inst.radio_mode);
+	nrf_radio_fast_ramp_up_enable_set(NRF_RADIO, IS_ENABLED(CONFIG_DTM_FAST_RAMP_UP));
 
 	/* Set the access address, address0/prefix0 used for both Rx and Tx
 	 * address.
@@ -1324,7 +1325,7 @@ static int dtm_vendor_specific_pkt(uint32_t vendor_cmd, uint32_t vendor_option)
 		 */
 		radio_prepare(TX_MODE);
 
-		nrf_radio_modecnf0_set(NRF_RADIO, false,
+		nrf_radio_modecnf0_set(NRF_RADIO, IS_ENABLED(CONFIG_DTM_FAST_RAMP_UP),
 				       RADIO_MODECNF0_DTX_Center);
 
 		/* Shortcut between READY event and START task */


### PR DESCRIPTION
The DTM test will be able now to test radio with fast ramp-up mode enabled.
