### PR TITLE
doc: add files required for Zoomin tagging

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -59,6 +59,7 @@ Kconfig*                                  @tejlmand
 /doc/nrfxlib/                             @gmarull
 /doc/versions.json                        @carlescufi
 /doc/custom.properties                    @gmarull
+/doc/tags.yml                             @gmarull
 # All subfolders
 /drivers/                                 @anangl
 /drivers/serial/                          @nordic-krch @anangl

--- a/doc/custom.properties
+++ b/doc/custom.properties
@@ -1,2 +1,2 @@
-manual.name=ncs
-booktitle=nRF Connect SDK
+manual.name=ncs-__VERSION__
+booktitle=nRF Connect SDK - __VERSION__

--- a/doc/tags.yml
+++ b/doc/tags.yml
@@ -1,0 +1,29 @@
+# Document tags for Zoomin.
+
+# Tags for all topics:
+mapping_global:
+  - ncs
+  - ncs-__VERSION__
+  - cluster-ncs-__VERSION__
+
+# Tags for individual topics:
+mapping_topics:
+  - nrf/applications/*/README.html: ["applications"]
+  - nrf/applications/*/doc/*.html: ["applications"]
+  - nrf/samples/nrf9160/modem_shell/README.html: ["at-commands"]
+  - nrf/drivers/*.html: ["drivers"]
+  - nrf/libraries/*/*.html: ["libraries"]
+  - nrf/libraries/*/*/*.html: ["libraries"]
+  - nrf/external_comp/nrf_cloud.html: ["nrf-cloud"]
+  - nrf/protocols/*/*.html: ["protocols"]
+  - nrf/protocols/*/*/*.html: ["protocols"]
+  - nrf/protocols/*/*/*/*.html: ["protocols"]
+  - nrf/release_notes.html: ["release-notes"]
+  - nrf/releases/*.html: ["release-notes"]
+  - nrf/samples/*/README.html: ["samples"]
+  - nrf/samples/*/*/README.html: ["samples"]
+  - nrf/samples/*/*/*/README.html: ["samples"]
+  - nrf/samples/*/*/*/*/README.html: ["samples"]
+  - nrf/scripts/*/*.html: ["scripts"]
+  - nrf/scripts/*/*/*.html: ["scripts"]
+  - kconfig/index.html: ["kconfig"]


### PR DESCRIPTION
Update custom.properties and add tags.yml to the
2.4 release branch.