### PR TITLE
drivers: wifi: Re-organize code to separate radiotest and default mode

### DIFF
--- a/drivers/wifi/nrf700x/CMakeLists.txt
+++ b/drivers/wifi/nrf700x/CMakeLists.txt
@@ -72,6 +72,7 @@ zephyr_library_sources_ifndef(CONFIG_NRF700X_RADIO_TEST
 
 zephyr_library_sources_ifdef(CONFIG_NRF700X_RADIO_TEST
 	osal/fw_if/umac_if/src/radio_test/fmac_api.c
+	osal/fw_if/umac_if/src/fmac_util.c
 )
 
 zephyr_library_sources_ifdef(CONFIG_NRF700X_DATA_TX

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/default/fmac_structs.h
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/default/fmac_structs.h
@@ -330,11 +330,7 @@ struct tx_config {
  * This structure maintains the context information necessary for the
  * operation of the UMAC IF layer.
  */
-struct wifi_nrf_fmac_priv {
-	/** Handle to the OS abstraction layer. */
-	struct wifi_nrf_osal_priv *opriv;
-	/** Handle to the HAL layer. */
-	struct wifi_nrf_hal_priv *hpriv;
+struct wifi_nrf_fmac_priv_def {
 	/** Callback functions to be called on various events. */
 	struct wifi_nrf_fmac_callbk_fns callbk_fns;
 	/** Data path configuration parameters. */
@@ -345,7 +341,7 @@ struct wifi_nrf_fmac_priv {
 	unsigned int rx_desc[MAX_NUM_OF_RX_QUEUES];
 	/** Maximum number of host buffers needed for RX frames. */
 	unsigned int num_rx_bufs;
-#if defined(CONFIG_NRF700X_STA_MODE) || defined(__DOXYGEN__)
+#if defined(CONFIG_NRF700X_STA_MODE)
 	/** Maximum number of tokens available for TX. */
 	unsigned char num_tx_tokens;
 	/** Maximum number of TX tokens available reserved per AC. */
@@ -365,16 +361,10 @@ struct wifi_nrf_fmac_priv {
  * This structure maintains the context information necessary for the
  * a single instance of an FullMAC based RPU.
  */
-struct wifi_nrf_fmac_dev_ctx {
-	/** Handle to the FMAC IF abstraction layer. */
-	struct wifi_nrf_fmac_priv *fpriv;
-	/** Handle to the OS abstraction layer. */
-	void *os_dev_ctx;
-	/** Handle to the HAL layer. */
-	void *hal_dev_ctx;
+struct wifi_nrf_fmac_dev_ctx_def {
 	/** Array of pointers to virtual interfaces created on this device. */
 	struct wifi_nrf_fmac_vif_ctx *vif_ctx[MAX_NUM_VIFS];
-#if defined(CONFIG_NRF700X_RX_WQ_ENABLED) || defined(__DOXYGEN__)
+#if defined(CONFIG_NRF700X_RX_WQ_ENABLED)
 	/** Tasklet for RX. */
 	void *rx_tasklet;
 	/** Queue for RX tasklet. */
@@ -386,36 +376,21 @@ struct wifi_nrf_fmac_dev_ctx {
 	unsigned char num_sta;
 	/** Number of interfaces in AP mode. */
 	unsigned char num_ap;
-	/** Firmware statistics. */
-	struct rpu_fw_stats *fw_stats;
-	/** Firmware statistics requested. */
-	bool stats_req;
-	/** Firmware boot done. */
-	bool fw_boot_done;
-	/** Firmware init done. */
-	bool fw_init_done;
-	/** Firmware deinit done. */
-	bool fw_deinit_done;
-	/** Alpha2 valid. */
-	bool alpha2_valid;
-	/** Alpha2 country code, last byte is reserved for null character. */
-	unsigned char alpha2[3];
 	/** Queue for storing mapping info of RX buffers. */
 	struct wifi_nrf_fmac_buf_map_info *rx_buf_info;
-#if defined(CONFIG_NRF700X_STA_MODE) || defined(__DOXYGEN__)
+#if defined(CONFIG_NRF700X_STA_MODE)
 	/** Queue for storing mapping info of TX buffers. */
 	struct wifi_nrf_fmac_buf_map_info *tx_buf_info;
 	/** Context information related to TX path. */
 	struct tx_config tx_config;
 	/** TWT state of the RPU. */
 	enum wifi_nrf_fmac_twt_state twt_sleep_status;
-#if defined(CONFIG_NRF700X_TX_DONE_WQ_ENABLED) || defined(__DOXYGEN__)
+#if defined(CONFIG_NRF700X_TX_DONE_WQ_ENABLED)
 	/** Tasklet for TX done. */
 	void *tx_done_tasklet;
 #endif /* CONFIG_NRF700X_TX_DONE_WQ_ENABLED */
 #endif /* CONFIG_NRF700X_STA_MODE */
 };
-
 
 /**
  * @brief Structure to hold per VIF context information for the UMAC IF layer.

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fmac_structs_common.h
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fmac_structs_common.h
@@ -98,6 +98,48 @@ struct wifi_nrf_fmac_reg_info {
 	 /** Forcefully set regulatory. */
 	bool force;
 };
+
+/**
+ * @brief Structure to hold common fmac priv parameter data.
+ *
+ */
+struct wifi_nrf_fmac_priv {
+	/** Handle to the OS abstraction layer. */
+	struct wifi_nrf_osal_priv *opriv;
+	/** Handle to the HAL layer. */
+	struct wifi_nrf_hal_priv *hpriv;
+	/** Data pointer to mode specific parameters */
+	char priv[];
+};
+
+/**
+ * @brief Structure to hold common fmac dev context parameter data.
+ *
+ */
+struct wifi_nrf_fmac_dev_ctx {
+	/** Handle to the FMAC IF abstraction layer. */
+	struct wifi_nrf_fmac_priv *fpriv;
+	/** Handle to the OS abstraction layer. */
+	void *os_dev_ctx;
+	/** Handle to the HAL layer. */
+	void *hal_dev_ctx;
+	/** Firmware statistics. */
+	struct rpu_fw_stats *fw_stats;
+	/** Firmware statistics requested. */
+	bool stats_req;
+	/** Firmware boot done. */
+	bool fw_boot_done;
+	/** Firmware init done. */
+	bool fw_init_done;
+	/** Firmware deinit done. */
+	bool fw_deinit_done;
+	/** Alpha2 valid. */
+	bool alpha2_valid;
+	/** Alpha2 country code, last byte is reserved for null character. */
+	unsigned char alpha2[3];
+	/** Data pointer to mode specific parameters */
+	char priv[];
+};
 /**
  * @}
  */

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fmac_util.h
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fmac_util.h
@@ -131,5 +131,10 @@ void wifi_nrf_util_rx_convert_amsdu_to_eth(struct wifi_nrf_fmac_dev_ctx *fmac_de
 
 bool wifi_nrf_util_is_arr_zero(unsigned char *arr,
 			       unsigned int arr_sz);
+
 #endif /* !CONFIG_NRF700X_RADIO_TEST */
+
+void *wifi_fmac_priv(struct wifi_nrf_fmac_priv *def);
+void *wifi_dev_priv(struct wifi_nrf_fmac_dev_ctx *def);
+
 #endif /* __FMAC_UTIL_H__ */

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/radio_test/fmac_structs.h
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/radio_test/fmac_structs.h
@@ -27,52 +27,12 @@
 #endif
 
 /**
- * @brief  Structure to hold context information for the UMAC IF layer.
- *
- * This structure maintains the context information necessary for the
- * operation of the UMAC IF layer.
- */
-struct wifi_nrf_fmac_priv {
-	/* To fix duplicate warning */
-#if !defined(__DOXYGEN__)
-	/** Handle to the OSAL layer. */
-	struct wifi_nrf_osal_priv *opriv;
-	/** Handle to the HAL layer. */
-	struct wifi_nrf_hal_priv *hpriv;
-#endif /* !defined(__DOXYGEN__) */
-};
-
-
-/**
  * @brief  Structure to hold per device context information for the UMAC IF layer.
  *
  * This structure maintains the context information necessary for the
  * a single instance of an FullMAC based RPU.
  */
-struct wifi_nrf_fmac_dev_ctx {
-	/* To fix duplicate warning */
-#if !defined(__DOXYGEN__)
-	/** Handle to the FMAC IF layer. */
-	struct wifi_nrf_fmac_priv *fpriv;
-	/** Handle to the OSAL layer. */
-	void *os_dev_ctx;
-	/** Handle to the HAL layer. */
-	void *hal_dev_ctx;
-	/** Firmware statistics. */
-	struct rpu_fw_stats *fw_stats;
-	/** Firmware statistics requested. */
-	bool stats_req;
-	/** Firmware boot done. */
-	bool fw_boot_done;
-	/** Firmware init done. */
-	bool fw_init_done;
-	/** Firmware deinit done. */
-	bool fw_deinit_done;
-	/** Alpha2 valid. */
-	bool alpha2_valid;
-	/** Alpha2 country code, last byte is reserved for null character. */
-	unsigned char alpha2[3];
-#endif /* !defined(__DOXYGEN__) */
+struct wifi_nrf_fmac_dev_ctx_rt {
 	/** Firmware RF test command type. */
 	enum nrf_wifi_rf_test rf_test_type;
 	/** Firmware RF test capability data. */

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/cmd.c
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/cmd.c
@@ -12,6 +12,7 @@
 #include "host_rpu_umac_if.h"
 #include "hal_api.h"
 #include "fmac_structs.h"
+#include "fmac_util.h"
 
 struct host_rpu_msg *umac_cmd_alloc(struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx,
 				    int type,
@@ -102,6 +103,9 @@ enum wifi_nrf_status umac_cmd_init(struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx,
 	struct host_rpu_msg *umac_cmd = NULL;
 	struct nrf_wifi_cmd_sys_init *umac_cmd_data = NULL;
 	unsigned int len = 0;
+	struct wifi_nrf_fmac_priv_def *def_priv = NULL;
+
+	def_priv = wifi_fmac_priv(fmac_dev_ctx->fpriv);
 
 	len = sizeof(*umac_cmd_data);
 
@@ -150,7 +154,7 @@ enum wifi_nrf_status umac_cmd_init(struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx,
 #ifndef CONFIG_NRF700X_RADIO_TEST
 	wifi_nrf_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
 			      umac_cmd_data->rx_buf_pools,
-			      fmac_dev_ctx->fpriv->rx_buf_pools,
+			      def_priv->rx_buf_pools,
 			      sizeof(umac_cmd_data->rx_buf_pools));
 
 	wifi_nrf_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/fmac_api_common.c
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/fmac_api_common.c
@@ -206,13 +206,18 @@ struct wifi_nrf_fmac_dev_ctx *wifi_nrf_fmac_dev_add(struct wifi_nrf_fmac_priv *f
 						    void *os_dev_ctx)
 {
 	struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx = NULL;
+#ifndef CONFIG_NRF700X_RADIO_TEST
+	struct wifi_nrf_fmac_dev_ctx_def *fmac_dev_priv = NULL;
+#else
+	struct wifi_nrf_fmac_dev_ctx_rt *fmac_dev_priv = NULL;
+#endif
 
 	if (!fpriv || !os_dev_ctx) {
 		return NULL;
 	}
 
 	fmac_dev_ctx = wifi_nrf_osal_mem_zalloc(fpriv->opriv,
-						sizeof(*fmac_dev_ctx));
+						sizeof(*fmac_dev_ctx) + sizeof(*fmac_dev_priv));
 
 	if (!fmac_dev_ctx) {
 		wifi_nrf_osal_log_err(fpriv->opriv,
@@ -238,7 +243,10 @@ struct wifi_nrf_fmac_dev_ctx *wifi_nrf_fmac_dev_add(struct wifi_nrf_fmac_priv *f
 		goto out;
 	}
 #ifdef CONFIG_NRF700X_DATA_TX
-	fpriv->hpriv->cfg_params.max_ampdu_len_per_token = fpriv->max_ampdu_len_per_token;
+	struct wifi_nrf_fmac_priv_def *def_priv = NULL;
+
+	def_priv = wifi_fmac_priv(fpriv);
+	fpriv->hpriv->cfg_params.max_ampdu_len_per_token = def_priv->max_ampdu_len_per_token;
 #endif /* CONFIG_NRF700X_DATA_TX */
 out:
 	return fmac_dev_ctx;
@@ -298,13 +306,17 @@ enum wifi_nrf_status wifi_nrf_fmac_stats_get(struct wifi_nrf_fmac_dev_ctx *fmac_
 		}
 	}
 
+
 #ifndef CONFIG_NRF700X_RADIO_TEST
+	struct wifi_nrf_fmac_dev_ctx_def *def_dev_ctx = NULL;
+
+	def_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 	if ((stats_type == RPU_STATS_TYPE_ALL) ||
 	    (stats_type == RPU_STATS_TYPE_HOST)) {
 		wifi_nrf_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
 				      &stats->host,
-				      &fmac_dev_ctx->host_stats,
-				      sizeof(fmac_dev_ctx->host_stats));
+				      &def_dev_ctx->host_stats,
+				      sizeof(def_dev_ctx->host_stats));
 	}
 #endif
 

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/fmac_peer.c
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/fmac_peer.c
@@ -19,13 +19,16 @@ int wifi_nrf_fmac_peer_get_id(struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx,
 {
 	int i;
 	struct peers_info *peer;
+	struct wifi_nrf_fmac_dev_ctx_def *def_dev_ctx = NULL;
+
+	def_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
 	if (wifi_nrf_util_is_multicast_addr(mac_addr)) {
 		return MAX_PEERS;
 	}
 
 	for (i = 0; i < MAX_PEERS; i++) {
-		peer = &fmac_dev_ctx->tx_config.peers[i];
+		peer = &def_dev_ctx->tx_config.peers[i];
 		if (peer->peer_id == -1) {
 			continue;
 		}
@@ -47,23 +50,25 @@ int wifi_nrf_fmac_peer_add(struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx,
 	int i;
 	struct peers_info *peer;
 	struct wifi_nrf_fmac_vif_ctx *vif_ctx = NULL;
+	struct wifi_nrf_fmac_dev_ctx_def *def_dev_ctx = NULL;
 
-	vif_ctx = fmac_dev_ctx->vif_ctx[if_idx];
+	def_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
+	vif_ctx = def_dev_ctx->vif_ctx[if_idx];
 
 	if (wifi_nrf_util_is_multicast_addr(mac_addr)
 	    && (vif_ctx->if_type == NRF_WIFI_IFTYPE_AP)) {
 
-		fmac_dev_ctx->tx_config.peers[MAX_PEERS].if_idx = if_idx;
-		fmac_dev_ctx->tx_config.peers[MAX_PEERS].peer_id = MAX_PEERS;
-		fmac_dev_ctx->tx_config.peers[MAX_PEERS].is_legacy = 1;
+		def_dev_ctx->tx_config.peers[MAX_PEERS].if_idx = if_idx;
+		def_dev_ctx->tx_config.peers[MAX_PEERS].peer_id = MAX_PEERS;
+		def_dev_ctx->tx_config.peers[MAX_PEERS].is_legacy = 1;
 
 
 		return MAX_PEERS;
 	}
 
 	for (i = 0; i < MAX_PEERS; i++) {
-		peer = &fmac_dev_ctx->tx_config.peers[i];
+		peer = &def_dev_ctx->tx_config.peers[i];
 
 		if (peer->peer_id == -1) {
 			wifi_nrf_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
@@ -99,9 +104,12 @@ void wifi_nrf_fmac_peer_remove(struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx,
 {
 	struct peers_info *peer;
 	struct wifi_nrf_fmac_vif_ctx *vif_ctx = NULL;
+	struct wifi_nrf_fmac_dev_ctx_def *def_dev_ctx = NULL;
 
-	vif_ctx = fmac_dev_ctx->vif_ctx[if_idx];
-	peer = &fmac_dev_ctx->tx_config.peers[peer_id];
+	def_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
+
+	vif_ctx = def_dev_ctx->vif_ctx[if_idx];
+	peer = &def_dev_ctx->tx_config.peers[peer_id];
 
 	wifi_nrf_osal_mem_set(fmac_dev_ctx->fpriv->opriv,
 			      peer,
@@ -125,12 +133,15 @@ void wifi_nrf_fmac_peers_flush(struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx,
 	struct wifi_nrf_fmac_vif_ctx *vif_ctx = NULL;
 	unsigned int i = 0;
 	struct peers_info *peer = NULL;
+	struct wifi_nrf_fmac_dev_ctx_def *def_dev_ctx = NULL;
 
-	vif_ctx = fmac_dev_ctx->vif_ctx[if_idx];
-	fmac_dev_ctx->tx_config.peers[MAX_PEERS].peer_id = -1;
+	def_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
+
+	vif_ctx = def_dev_ctx->vif_ctx[if_idx];
+	def_dev_ctx->tx_config.peers[MAX_PEERS].peer_id = -1;
 
 	for (i = 0; i < MAX_PEERS; i++) {
-		peer = &fmac_dev_ctx->tx_config.peers[i];
+		peer = &def_dev_ctx->tx_config.peers[i];
 		if (peer->if_idx == if_idx) {
 
 			wifi_nrf_osal_mem_set(fmac_dev_ctx->fpriv->opriv,

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/fmac_util.c
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/fmac_util.c
@@ -10,6 +10,7 @@
  */
 
 #include "osal_api.h"
+#include "fmac_api_common.h"
 #include "fmac_util.h"
 #include "host_rpu_umac_if.h"
 
@@ -288,11 +289,14 @@ int wifi_nrf_util_get_vif_indx(struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx,
 {
 	int i = 0;
 	int vif_index = -1;
+	struct wifi_nrf_fmac_dev_ctx_def *def_dev_ctx = NULL;
+
+	def_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
 	for (i = 0; i < MAX_PEERS; i++) {
-		if (!wifi_nrf_util_ether_addr_equal(fmac_dev_ctx->tx_config.peers[i].ra_addr,
+		if (!wifi_nrf_util_ether_addr_equal(def_dev_ctx->tx_config.peers[i].ra_addr,
 						    mac_addr)) {
-			vif_index = fmac_dev_ctx->tx_config.peers[i].if_idx;
+			vif_index = def_dev_ctx->tx_config.peers[i].if_idx;
 			break;
 		}
 	}
@@ -350,4 +354,14 @@ bool wifi_nrf_util_is_arr_zero(unsigned char *arr,
 	}
 
 	return true;
+}
+
+void *wifi_fmac_priv(struct wifi_nrf_fmac_priv *def)
+{
+	return &def->priv;
+}
+
+void *wifi_dev_priv(struct wifi_nrf_fmac_dev_ctx *def)
+{
+	return &def->priv;
 }

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/fmac_vif.c
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/fmac_vif.c
@@ -11,15 +11,20 @@
 
 #include "fmac_vif.h"
 #include "host_rpu_umac_if.h"
+#include "fmac_util.h"
 
 
 int wifi_nrf_fmac_vif_check_if_limit(struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx,
 				     int if_type)
 {
+	struct wifi_nrf_fmac_dev_ctx_def *def_dev_ctx;
+
+	def_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
+
 	switch (if_type) {
 	case NRF_WIFI_IFTYPE_STATION:
 	case NRF_WIFI_IFTYPE_P2P_CLIENT:
-		if (fmac_dev_ctx->num_sta >= MAX_NUM_STAS) {
+		if (def_dev_ctx->num_sta >= MAX_NUM_STAS) {
 			wifi_nrf_osal_log_err(fmac_dev_ctx->fpriv->opriv,
 					      "%s: Maximum STA Interface type exceeded\n",
 					      __func__);
@@ -28,7 +33,7 @@ int wifi_nrf_fmac_vif_check_if_limit(struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx,
 		break;
 	case NRF_WIFI_IFTYPE_AP:
 	case NRF_WIFI_IFTYPE_P2P_GO:
-		if (fmac_dev_ctx->num_ap >= MAX_NUM_APS) {
+		if (def_dev_ctx->num_ap >= MAX_NUM_APS) {
 			wifi_nrf_osal_log_err(fmac_dev_ctx->fpriv->opriv,
 					      "%s: Maximum AP Interface type exceeded\n",
 					      __func__);
@@ -49,14 +54,18 @@ int wifi_nrf_fmac_vif_check_if_limit(struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx,
 void wifi_nrf_fmac_vif_incr_if_type(struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx,
 				    int if_type)
 {
+	struct wifi_nrf_fmac_dev_ctx_def *def_dev_ctx;
+
+	def_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
+
 	switch (if_type) {
 	case NRF_WIFI_IFTYPE_STATION:
 	case NRF_WIFI_IFTYPE_P2P_CLIENT:
-		fmac_dev_ctx->num_sta++;
+		def_dev_ctx->num_sta++;
 		break;
 	case NRF_WIFI_IFTYPE_AP:
 	case NRF_WIFI_IFTYPE_P2P_GO:
-		fmac_dev_ctx->num_ap++;
+		def_dev_ctx->num_ap++;
 		break;
 	default:
 		wifi_nrf_osal_log_err(fmac_dev_ctx->fpriv->opriv,
@@ -69,14 +78,18 @@ void wifi_nrf_fmac_vif_incr_if_type(struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx,
 void wifi_nrf_fmac_vif_decr_if_type(struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx,
 				    int if_type)
 {
+	struct wifi_nrf_fmac_dev_ctx_def *def_dev_ctx;
+
+	def_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
+
 	switch (if_type) {
 	case NRF_WIFI_IFTYPE_STATION:
 	case NRF_WIFI_IFTYPE_P2P_CLIENT:
-		fmac_dev_ctx->num_sta--;
+		def_dev_ctx->num_sta--;
 		break;
 	case NRF_WIFI_IFTYPE_AP:
 	case NRF_WIFI_IFTYPE_P2P_GO:
-		fmac_dev_ctx->num_ap--;
+		def_dev_ctx->num_ap--;
 		break;
 	default:
 		wifi_nrf_osal_log_err(fmac_dev_ctx->fpriv->opriv,
@@ -91,14 +104,16 @@ void wifi_nrf_fmac_vif_clear_ctx(void *dev_ctx,
 {
 	struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx = NULL;
 	struct wifi_nrf_fmac_vif_ctx *vif_ctx = NULL;
+	struct wifi_nrf_fmac_dev_ctx_def *def_dev_ctx;
 
 	fmac_dev_ctx = dev_ctx;
+	def_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
-	vif_ctx = fmac_dev_ctx->vif_ctx[if_idx];
+	vif_ctx = def_dev_ctx->vif_ctx[if_idx];
 
 	wifi_nrf_osal_mem_free(fmac_dev_ctx->fpriv->opriv,
 			       vif_ctx);
-	fmac_dev_ctx->vif_ctx[if_idx] = NULL;
+	def_dev_ctx->vif_ctx[if_idx] = NULL;
 }
 
 
@@ -108,10 +123,12 @@ void wifi_nrf_fmac_vif_update_if_type(void *dev_ctx,
 {
 	struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx = NULL;
 	struct wifi_nrf_fmac_vif_ctx *vif_ctx = NULL;
+	struct wifi_nrf_fmac_dev_ctx_def *def_dev_ctx = NULL;
 
 	fmac_dev_ctx = dev_ctx;
+	def_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
-	vif_ctx = fmac_dev_ctx->vif_ctx[if_idx];
+	vif_ctx = def_dev_ctx->vif_ctx[if_idx];
 
 	wifi_nrf_fmac_vif_decr_if_type(fmac_dev_ctx,
 				       vif_ctx->if_type);
@@ -125,6 +142,9 @@ void wifi_nrf_fmac_vif_update_if_type(void *dev_ctx,
 unsigned int wifi_nrf_fmac_get_num_vifs(void *dev_ctx)
 {
 	struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx = dev_ctx;
+	struct wifi_nrf_fmac_dev_ctx_def *def_dev_ctx = NULL;
+
+	def_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
 	if (!fmac_dev_ctx) {
 		/* Don't return error here, as FMAC might be initialized based
@@ -133,5 +153,5 @@ unsigned int wifi_nrf_fmac_get_num_vifs(void *dev_ctx)
 		return 0;
 	}
 
-	return fmac_dev_ctx->num_sta + fmac_dev_ctx->num_ap;
+	return def_dev_ctx->num_sta + def_dev_ctx->num_ap;
 }

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/radio_test/fmac_api.c
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/radio_test/fmac_api.c
@@ -39,7 +39,6 @@ static enum wifi_nrf_status wifi_nrf_fmac_fw_init_rt(struct wifi_nrf_fmac_dev_ct
 	unsigned long start_time_us = 0;
 	enum wifi_nrf_status status = WIFI_NRF_STATUS_FAIL;
 
-
 	status = umac_cmd_init(fmac_dev_ctx,
 #ifdef CONFIG_NRF_WIFI_LOW_POWER
 			       sleep_type,
@@ -136,12 +135,10 @@ out:
 	return status;
 }
 
-
 void wifi_nrf_fmac_dev_deinit_rt(struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx)
 {
 	wifi_nrf_fmac_fw_deinit_rt(fmac_dev_ctx);
 }
-
 
 struct wifi_nrf_fmac_priv *wifi_nrf_fmac_init_rt(void)
 {
@@ -215,12 +212,14 @@ enum wifi_nrf_status wait_for_radio_cmd_status(struct wifi_nrf_fmac_dev_ctx *fma
 {
 	unsigned int count = 0;
 	enum nrf_wifi_radio_test_err_status radio_cmd_status;
+	struct wifi_nrf_fmac_dev_ctx_rt *rt_dev_ctx = NULL;
 
+	rt_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 	do {
 		wifi_nrf_osal_sleep_ms(fmac_dev_ctx->fpriv->opriv,
 				       1);
 		count++;
-	} while ((!fmac_dev_ctx->radio_cmd_done) &&
+	} while ((!rt_dev_ctx->radio_cmd_done) &&
 		 (count < timeout));
 
 	if (count == timeout) {
@@ -231,7 +230,7 @@ enum wifi_nrf_status wait_for_radio_cmd_status(struct wifi_nrf_fmac_dev_ctx *fma
 		goto out;
 	}
 
-	radio_cmd_status = fmac_dev_ctx->radio_cmd_status;
+	radio_cmd_status = rt_dev_ctx->radio_cmd_status;
 
 	if (radio_cmd_status != NRF_WIFI_UMAC_CMD_SUCCESS) {
 		wifi_nrf_osal_log_err(fmac_dev_ctx->fpriv->opriv,
@@ -251,6 +250,9 @@ enum wifi_nrf_status wifi_nrf_fmac_radio_test_init(struct wifi_nrf_fmac_dev_ctx 
 {
 	enum wifi_nrf_status status = WIFI_NRF_STATUS_FAIL;
 	struct nrf_wifi_radio_test_init_info init_params;
+	struct wifi_nrf_fmac_dev_ctx_rt *rt_dev_ctx = NULL;
+
+	rt_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
 	wifi_nrf_osal_mem_set(fmac_dev_ctx->fpriv->opriv,
 			      &init_params,
@@ -270,7 +272,7 @@ enum wifi_nrf_status wifi_nrf_fmac_radio_test_init(struct wifi_nrf_fmac_dev_ctx 
 	init_params.phy_threshold = params->phy_threshold;
 	init_params.phy_calib = params->phy_calib;
 
-	fmac_dev_ctx->radio_cmd_done = false;
+	rt_dev_ctx->radio_cmd_done = false;
 	status = umac_cmd_prog_init(fmac_dev_ctx,
 				    &init_params);
 
@@ -296,8 +298,11 @@ enum wifi_nrf_status wifi_nrf_fmac_radio_test_prog_tx(struct wifi_nrf_fmac_dev_c
 						      struct rpu_conf_params *params)
 {
 	enum wifi_nrf_status status = WIFI_NRF_STATUS_FAIL;
+	struct wifi_nrf_fmac_dev_ctx_rt *rt_dev_ctx = NULL;
 
-	fmac_dev_ctx->radio_cmd_done = false;
+	rt_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
+
+	rt_dev_ctx->radio_cmd_done = false;
 	status = umac_cmd_prog_tx(fmac_dev_ctx,
 				  params);
 
@@ -323,6 +328,9 @@ enum wifi_nrf_status wifi_nrf_fmac_radio_test_prog_rx(struct wifi_nrf_fmac_dev_c
 {
 	enum wifi_nrf_status status = WIFI_NRF_STATUS_FAIL;
 	struct rpu_conf_rx_radio_test_params rx_params;
+	struct wifi_nrf_fmac_dev_ctx_rt *rt_dev_ctx = NULL;
+
+	rt_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
 	wifi_nrf_osal_mem_set(fmac_dev_ctx->fpriv->opriv,
 			      &rx_params,
@@ -345,7 +353,7 @@ enum wifi_nrf_status wifi_nrf_fmac_radio_test_prog_rx(struct wifi_nrf_fmac_dev_c
 	rx_params.phy_calib = params->phy_calib;
 	rx_params.rx = params->rx;
 
-	fmac_dev_ctx->radio_cmd_done = false;
+	rt_dev_ctx->radio_cmd_done = false;
 	status = umac_cmd_prog_rx(fmac_dev_ctx,
 				  &rx_params);
 
@@ -375,7 +383,10 @@ enum wifi_nrf_status nrf_wifi_fmac_rf_test_rx_cap(struct wifi_nrf_fmac_dev_ctx *
 {
 	enum wifi_nrf_status status = WIFI_NRF_STATUS_FAIL;
 	struct nrf_wifi_rf_test_capture_params rf_test_cap_params;
+	struct wifi_nrf_fmac_dev_ctx_rt *rt_dev_ctx = NULL;
 	unsigned int count = 0;
+
+	rt_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
 	wifi_nrf_osal_mem_set(fmac_dev_ctx->fpriv->opriv,
 			      &rf_test_cap_params,
@@ -387,9 +398,9 @@ enum wifi_nrf_status nrf_wifi_fmac_rf_test_rx_cap(struct wifi_nrf_fmac_dev_ctx *
 	rf_test_cap_params.lna_gain = lna_gain;
 	rf_test_cap_params.bb_gain = bb_gain;
 
-	fmac_dev_ctx->rf_test_type = rf_test_type;
-	fmac_dev_ctx->rf_test_cap_data = cap_data;
-	fmac_dev_ctx->rf_test_cap_sz = (num_samples * 3);
+	rt_dev_ctx->rf_test_type = rf_test_type;
+	rt_dev_ctx->rf_test_cap_data = cap_data;
+	rt_dev_ctx->rf_test_cap_sz = (num_samples * 3);
 
 	status = umac_cmd_prog_rf_test(fmac_dev_ctx,
 				       &rf_test_cap_params,
@@ -407,15 +418,15 @@ enum wifi_nrf_status nrf_wifi_fmac_rf_test_rx_cap(struct wifi_nrf_fmac_dev_ctx *
 		wifi_nrf_osal_sleep_ms(fmac_dev_ctx->fpriv->opriv,
 				       100);
 		count++;
-	} while ((fmac_dev_ctx->rf_test_type != NRF_WIFI_RF_TEST_MAX) &&
+	} while ((rt_dev_ctx->rf_test_type != NRF_WIFI_RF_TEST_MAX) &&
 		 (count < WIFI_NRF_FMAC_RF_TEST_EVNT_TIMEOUT));
 
 	if (count == WIFI_NRF_FMAC_RF_TEST_EVNT_TIMEOUT) {
 		wifi_nrf_osal_log_err(fmac_dev_ctx->fpriv->opriv,
 				      "%s: Timed out\n",
 				      __func__);
-		fmac_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_MAX;
-		fmac_dev_ctx->rf_test_cap_data = NULL;
+		rt_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_MAX;
+		rt_dev_ctx->rf_test_cap_data = NULL;
 		status = WIFI_NRF_STATUS_FAIL;
 		goto out;
 	}
@@ -432,7 +443,10 @@ enum wifi_nrf_status nrf_wifi_fmac_rf_test_tx_tone(struct wifi_nrf_fmac_dev_ctx 
 {
 	enum wifi_nrf_status status = WIFI_NRF_STATUS_FAIL;
 	struct nrf_wifi_rf_test_tx_params rf_test_tx_params;
+	struct wifi_nrf_fmac_dev_ctx_rt *rt_dev_ctx = NULL;
 	unsigned int count = 0;
+
+	rt_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
 	wifi_nrf_osal_mem_set(fmac_dev_ctx->fpriv->opriv,
 			      &rf_test_tx_params,
@@ -444,9 +458,9 @@ enum wifi_nrf_status nrf_wifi_fmac_rf_test_tx_tone(struct wifi_nrf_fmac_dev_ctx 
 	rf_test_tx_params.tx_pow = tx_power;
 	rf_test_tx_params.enabled = enable;
 
-	fmac_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_TX_TONE;
-	fmac_dev_ctx->rf_test_cap_data = NULL;
-	fmac_dev_ctx->rf_test_cap_sz = 0;
+	rt_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_TX_TONE;
+	rt_dev_ctx->rf_test_cap_data = NULL;
+	rt_dev_ctx->rf_test_cap_sz = 0;
 
 	status = umac_cmd_prog_rf_test(fmac_dev_ctx,
 				       &rf_test_tx_params,
@@ -464,15 +478,15 @@ enum wifi_nrf_status nrf_wifi_fmac_rf_test_tx_tone(struct wifi_nrf_fmac_dev_ctx 
 		wifi_nrf_osal_sleep_ms(fmac_dev_ctx->fpriv->opriv,
 				       100);
 		count++;
-	} while ((fmac_dev_ctx->rf_test_type != NRF_WIFI_RF_TEST_MAX) &&
+	} while ((rt_dev_ctx->rf_test_type != NRF_WIFI_RF_TEST_MAX) &&
 		 (count < WIFI_NRF_FMAC_RF_TEST_EVNT_TIMEOUT));
 
 	if (count == WIFI_NRF_FMAC_RF_TEST_EVNT_TIMEOUT) {
 		wifi_nrf_osal_log_err(fmac_dev_ctx->fpriv->opriv,
 				      "%s: Timed out\n",
 				      __func__);
-		fmac_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_MAX;
-		fmac_dev_ctx->rf_test_cap_data = NULL;
+		rt_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_MAX;
+		rt_dev_ctx->rf_test_cap_data = NULL;
 		status = WIFI_NRF_STATUS_FAIL;
 		goto out;
 	}
@@ -487,7 +501,10 @@ enum wifi_nrf_status nrf_wifi_fmac_rf_test_dpd(struct wifi_nrf_fmac_dev_ctx *fma
 {
 	enum wifi_nrf_status status = WIFI_NRF_STATUS_FAIL;
 	struct nrf_wifi_rf_test_dpd_params rf_test_dpd_params;
+	struct wifi_nrf_fmac_dev_ctx_rt *rt_dev_ctx = NULL;
 	unsigned int count = 0;
+
+	rt_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
 	wifi_nrf_osal_mem_set(fmac_dev_ctx->fpriv->opriv,
 			      &rf_test_dpd_params,
@@ -497,9 +514,9 @@ enum wifi_nrf_status nrf_wifi_fmac_rf_test_dpd(struct wifi_nrf_fmac_dev_ctx *fma
 	rf_test_dpd_params.test = NRF_WIFI_RF_TEST_DPD;
 	rf_test_dpd_params.enabled = enable;
 
-	fmac_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_DPD;
-	fmac_dev_ctx->rf_test_cap_data = NULL;
-	fmac_dev_ctx->rf_test_cap_sz = 0;
+	rt_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_DPD;
+	rt_dev_ctx->rf_test_cap_data = NULL;
+	rt_dev_ctx->rf_test_cap_sz = 0;
 
 	status = umac_cmd_prog_rf_test(fmac_dev_ctx,
 					   &rf_test_dpd_params,
@@ -517,15 +534,15 @@ enum wifi_nrf_status nrf_wifi_fmac_rf_test_dpd(struct wifi_nrf_fmac_dev_ctx *fma
 		wifi_nrf_osal_sleep_ms(fmac_dev_ctx->fpriv->opriv,
 				       100);
 		count++;
-	} while ((fmac_dev_ctx->rf_test_type != NRF_WIFI_RF_TEST_MAX) &&
+	} while ((rt_dev_ctx->rf_test_type != NRF_WIFI_RF_TEST_MAX) &&
 		 (count < WIFI_NRF_FMAC_RF_TEST_EVNT_TIMEOUT));
 
 	if (count == WIFI_NRF_FMAC_RF_TEST_EVNT_TIMEOUT) {
 		wifi_nrf_osal_log_err(fmac_dev_ctx->fpriv->opriv,
 				      "%s: Timed out\n",
 				      __func__);
-		fmac_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_MAX;
-		fmac_dev_ctx->rf_test_cap_data = NULL;
+		rt_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_MAX;
+		rt_dev_ctx->rf_test_cap_data = NULL;
 		status = WIFI_NRF_STATUS_FAIL;
 		goto out;
 	}
@@ -539,7 +556,10 @@ enum wifi_nrf_status nrf_wifi_fmac_rf_get_temp(struct wifi_nrf_fmac_dev_ctx *fma
 {
 	enum wifi_nrf_status status = WIFI_NRF_STATUS_FAIL;
 	struct nrf_wifi_temperature_params rf_test_get_temperature;
+	struct wifi_nrf_fmac_dev_ctx_rt *rt_dev_ctx = NULL;
 	unsigned int count = 0;
+
+	rt_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
 	wifi_nrf_osal_mem_set(fmac_dev_ctx->fpriv->opriv,
 			      &rf_test_get_temperature,
@@ -548,9 +568,9 @@ enum wifi_nrf_status nrf_wifi_fmac_rf_get_temp(struct wifi_nrf_fmac_dev_ctx *fma
 
 	rf_test_get_temperature.test = NRF_WIFI_RF_TEST_GET_TEMPERATURE;
 
-	fmac_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_GET_TEMPERATURE;
-	fmac_dev_ctx->rf_test_cap_data = NULL;
-	fmac_dev_ctx->rf_test_cap_sz = 0;
+	rt_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_GET_TEMPERATURE;
+	rt_dev_ctx->rf_test_cap_data = NULL;
+	rt_dev_ctx->rf_test_cap_sz = 0;
 
 	status = umac_cmd_prog_rf_test(fmac_dev_ctx,
 					   &rf_test_get_temperature,
@@ -568,15 +588,15 @@ enum wifi_nrf_status nrf_wifi_fmac_rf_get_temp(struct wifi_nrf_fmac_dev_ctx *fma
 		wifi_nrf_osal_sleep_ms(fmac_dev_ctx->fpriv->opriv,
 				       100);
 		count++;
-	} while ((fmac_dev_ctx->rf_test_type != NRF_WIFI_RF_TEST_MAX) &&
+	} while ((rt_dev_ctx->rf_test_type != NRF_WIFI_RF_TEST_MAX) &&
 		 (count < WIFI_NRF_FMAC_RF_TEST_EVNT_TIMEOUT));
 
 	if (count == WIFI_NRF_FMAC_RF_TEST_EVNT_TIMEOUT) {
 		wifi_nrf_osal_log_err(fmac_dev_ctx->fpriv->opriv,
 				      "%s: Timed out\n",
 				      __func__);
-		fmac_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_MAX;
-		fmac_dev_ctx->rf_test_cap_data = NULL;
+		rt_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_MAX;
+		rt_dev_ctx->rf_test_cap_data = NULL;
 		status = WIFI_NRF_STATUS_FAIL;
 		goto out;
 	}
@@ -589,7 +609,10 @@ enum wifi_nrf_status nrf_wifi_fmac_rf_get_rf_rssi(struct wifi_nrf_fmac_dev_ctx *
 {
 	enum wifi_nrf_status status = WIFI_NRF_STATUS_FAIL;
 	struct nrf_wifi_rf_get_rf_rssi rf_get_rf_rssi_params;
+	struct wifi_nrf_fmac_dev_ctx_rt *rt_dev_ctx = NULL;
 	unsigned int count = 0;
+
+	rt_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
 	wifi_nrf_osal_mem_set(fmac_dev_ctx->fpriv->opriv,
 			      &rf_get_rf_rssi_params,
@@ -600,9 +623,9 @@ enum wifi_nrf_status nrf_wifi_fmac_rf_get_rf_rssi(struct wifi_nrf_fmac_dev_ctx *
 	rf_get_rf_rssi_params.lna_gain = 3;
 	rf_get_rf_rssi_params.bb_gain = 10;
 
-	fmac_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_RF_RSSI;
-	fmac_dev_ctx->rf_test_cap_data = NULL;
-	fmac_dev_ctx->rf_test_cap_sz = 0;
+	rt_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_RF_RSSI;
+	rt_dev_ctx->rf_test_cap_data = NULL;
+	rt_dev_ctx->rf_test_cap_sz = 0;
 
 	status = umac_cmd_prog_rf_test(fmac_dev_ctx,
 					   &rf_get_rf_rssi_params,
@@ -620,15 +643,15 @@ enum wifi_nrf_status nrf_wifi_fmac_rf_get_rf_rssi(struct wifi_nrf_fmac_dev_ctx *
 		wifi_nrf_osal_sleep_ms(fmac_dev_ctx->fpriv->opriv,
 				       100);
 		count++;
-	} while ((fmac_dev_ctx->rf_test_type != NRF_WIFI_RF_TEST_MAX) &&
+	} while ((rt_dev_ctx->rf_test_type != NRF_WIFI_RF_TEST_MAX) &&
 		 (count < WIFI_NRF_FMAC_RF_TEST_EVNT_TIMEOUT));
 
 	if (count == WIFI_NRF_FMAC_RF_TEST_EVNT_TIMEOUT) {
 		wifi_nrf_osal_log_err(fmac_dev_ctx->fpriv->opriv,
 				      "%s: Timed out\n",
 				      __func__);
-		fmac_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_MAX;
-		fmac_dev_ctx->rf_test_cap_data = NULL;
+		rt_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_MAX;
+		rt_dev_ctx->rf_test_cap_data = NULL;
 		status = WIFI_NRF_STATUS_FAIL;
 		goto out;
 	}
@@ -643,7 +666,10 @@ enum wifi_nrf_status nrf_wifi_fmac_set_xo_val(struct wifi_nrf_fmac_dev_ctx *fmac
 {
 	enum wifi_nrf_status status = WIFI_NRF_STATUS_FAIL;
 	struct nrf_wifi_rf_test_xo_calib nrf_wifi_rf_test_xo_calib_params;
+	struct wifi_nrf_fmac_dev_ctx_rt *rt_dev_ctx = NULL;
 	unsigned int count = 0;
+
+	rt_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
 	wifi_nrf_osal_mem_set(fmac_dev_ctx->fpriv->opriv,
 			      &nrf_wifi_rf_test_xo_calib_params,
@@ -654,9 +680,9 @@ enum wifi_nrf_status nrf_wifi_fmac_set_xo_val(struct wifi_nrf_fmac_dev_ctx *fmac
 	nrf_wifi_rf_test_xo_calib_params.xo_val = value;
 
 
-	fmac_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_XO_CALIB;
-	fmac_dev_ctx->rf_test_cap_data = NULL;
-	fmac_dev_ctx->rf_test_cap_sz = 0;
+	rt_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_XO_CALIB;
+	rt_dev_ctx->rf_test_cap_data = NULL;
+	rt_dev_ctx->rf_test_cap_sz = 0;
 
 	status = umac_cmd_prog_rf_test(fmac_dev_ctx,
 					   &nrf_wifi_rf_test_xo_calib_params,
@@ -674,15 +700,15 @@ enum wifi_nrf_status nrf_wifi_fmac_set_xo_val(struct wifi_nrf_fmac_dev_ctx *fmac
 		wifi_nrf_osal_sleep_ms(fmac_dev_ctx->fpriv->opriv,
 				       100);
 		count++;
-	} while ((fmac_dev_ctx->rf_test_type != NRF_WIFI_RF_TEST_MAX) &&
+	} while ((rt_dev_ctx->rf_test_type != NRF_WIFI_RF_TEST_MAX) &&
 		 (count < WIFI_NRF_FMAC_RF_TEST_EVNT_TIMEOUT));
 
 	if (count == WIFI_NRF_FMAC_RF_TEST_EVNT_TIMEOUT) {
 		wifi_nrf_osal_log_err(fmac_dev_ctx->fpriv->opriv,
 				      "%s: Timed out\n",
 				      __func__);
-		fmac_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_MAX;
-		fmac_dev_ctx->rf_test_cap_data = NULL;
+		rt_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_MAX;
+		rt_dev_ctx->rf_test_cap_data = NULL;
 		status = WIFI_NRF_STATUS_FAIL;
 		goto out;
 	}
@@ -696,7 +722,10 @@ enum wifi_nrf_status nrf_wifi_fmac_rf_test_compute_xo(struct wifi_nrf_fmac_dev_c
 {
 	enum wifi_nrf_status status = WIFI_NRF_STATUS_FAIL;
 	struct nrf_wifi_rf_get_xo_value rf_get_xo_value_params;
+	struct wifi_nrf_fmac_dev_ctx_rt *rt_dev_ctx = NULL;
 	unsigned int count = 0;
+
+	rt_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
 	wifi_nrf_osal_mem_set(fmac_dev_ctx->fpriv->opriv,
 			      &rf_get_xo_value_params,
@@ -705,9 +734,9 @@ enum wifi_nrf_status nrf_wifi_fmac_rf_test_compute_xo(struct wifi_nrf_fmac_dev_c
 
 	rf_get_xo_value_params.test = NRF_WIFI_RF_TEST_XO_TUNE;
 
-	fmac_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_XO_TUNE;
-	fmac_dev_ctx->rf_test_cap_data = NULL;
-	fmac_dev_ctx->rf_test_cap_sz = 0;
+	rt_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_XO_TUNE;
+	rt_dev_ctx->rf_test_cap_data = NULL;
+	rt_dev_ctx->rf_test_cap_sz = 0;
 
 	status = umac_cmd_prog_rf_test(fmac_dev_ctx,
 					   &rf_get_xo_value_params,
@@ -725,15 +754,15 @@ enum wifi_nrf_status nrf_wifi_fmac_rf_test_compute_xo(struct wifi_nrf_fmac_dev_c
 		wifi_nrf_osal_sleep_ms(fmac_dev_ctx->fpriv->opriv,
 				       100);
 		count++;
-	} while ((fmac_dev_ctx->rf_test_type != NRF_WIFI_RF_TEST_MAX) &&
+	} while ((rt_dev_ctx->rf_test_type != NRF_WIFI_RF_TEST_MAX) &&
 		 (count < WIFI_NRF_FMAC_RF_TEST_EVNT_TIMEOUT));
 
 	if (count == WIFI_NRF_FMAC_RF_TEST_EVNT_TIMEOUT) {
 		wifi_nrf_osal_log_err(fmac_dev_ctx->fpriv->opriv,
 				      "%s: Timed out\n",
 				      __func__);
-		fmac_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_MAX;
-		fmac_dev_ctx->rf_test_cap_data = NULL;
+		rt_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_MAX;
+		rt_dev_ctx->rf_test_cap_data = NULL;
 		status = WIFI_NRF_STATUS_FAIL;
 		goto out;
 	}

--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_fmac_main.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_fmac_main.c
@@ -22,6 +22,7 @@
 
 #include <util.h>
 #include <fmac_api.h>
+#include "fmac_util.h"
 #include <zephyr_fmac_main.h>
 
 #ifndef CONFIG_NRF700X_RADIO_TEST
@@ -563,15 +564,18 @@ static int wifi_nrf_drv_main_zep(const struct device *dev)
 	}
 
 #ifdef CONFIG_NRF700X_DATA_TX
-	rpu_drv_priv_zep.fmac_priv->max_ampdu_len_per_token =
+	struct wifi_nrf_fmac_priv_def *def_priv = NULL;
+
+	def_priv = wifi_fmac_priv(rpu_drv_priv_zep.fmac_priv);
+	def_priv->max_ampdu_len_per_token =
 		(RPU_PKTRAM_SIZE - (CONFIG_NRF700X_RX_NUM_BUFS * CONFIG_NRF700X_RX_MAX_DATA_SIZE)) /
 		CONFIG_NRF700X_MAX_TX_TOKENS;
 	/* Align to 4-byte */
-	rpu_drv_priv_zep.fmac_priv->max_ampdu_len_per_token &= ~0x3;
+	def_priv->max_ampdu_len_per_token &= ~0x3;
 
 	/* Alignment overhead for size based coalesce */
-	rpu_drv_priv_zep.fmac_priv->avail_ampdu_len_per_token =
-	rpu_drv_priv_zep.fmac_priv->max_ampdu_len_per_token -
+	def_priv->avail_ampdu_len_per_token =
+	def_priv->max_ampdu_len_per_token -
 		(MAX_PKT_RAM_TX_ALIGN_OVERHEAD * max_tx_aggregation);
 #endif /* CONFIG_NRF700X_DATA_TX */
 

--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_net_if.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_net_if.c
@@ -18,6 +18,7 @@ LOG_MODULE_DECLARE(wifi_nrf, CONFIG_WIFI_LOG_LEVEL);
 
 #include "util.h"
 #include "fmac_api.h"
+#include "fmac_util.h"
 #include "shim.h"
 #include "zephyr_fmac_main.h"
 #include "zephyr_wpa_supp_if.h"
@@ -69,8 +70,11 @@ void wifi_nrf_if_rx_frm(void *os_vif_ctx, void *frm)
 	int status;
 	struct wifi_nrf_ctx_zep *rpu_ctx_zep = vif_ctx_zep->rpu_ctx_zep;
 	struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx = rpu_ctx_zep->rpu_ctx;
-	struct rpu_host_stats *host_stats = &fmac_dev_ctx->host_stats;
+	struct wifi_nrf_fmac_dev_ctx_def *def_dev_ctx = NULL;
+	struct rpu_host_stats *host_stats = NULL;
 
+	def_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
+	host_stats = &def_dev_ctx->host_stats;
 	host_stats->total_rx_pkts++;
 
 	pkt = net_pkt_from_nbuf(iface, frm);

--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_wifi_util.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_wifi_util.c
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include "host_rpu_umac_if.h"
 #include "fmac_api.h"
+#include "fmac_util.h"
 #include "zephyr_fmac_main.h"
 #include "zephyr_wifi_util.h"
 
@@ -311,6 +312,7 @@ static int nrf_wifi_util_tx_stats(const struct shell *shell,
 	struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx = NULL;
 	void *queue = NULL;
 	unsigned int tx_pending_pkts = 0;
+	struct wifi_nrf_fmac_dev_ctx_def *def_dev_ctx = NULL;
 
 	vif_index = atoi(argv[1]);
 	if ((vif_index < 0) || (vif_index >= max_vif_index)) {
@@ -323,6 +325,7 @@ static int nrf_wifi_util_tx_stats(const struct shell *shell,
 	}
 
 	fmac_dev_ctx = ctx->rpu_ctx;
+	def_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
 	/* TODO: Get peer_index from shell once AP mode is supported */
 	shell_fprintf(shell,
@@ -331,7 +334,7 @@ static int nrf_wifi_util_tx_stats(const struct shell *shell,
 		vif_index);
 
 	for (int i = 0; i < WIFI_NRF_FMAC_AC_MAX ; i++) {
-		queue = fmac_dev_ctx->tx_config.data_pending_txq[peer_index][i];
+		queue = def_dev_ctx->tx_config.data_pending_txq[peer_index][i];
 		tx_pending_pkts = wifi_nrf_utils_q_len(fmac_dev_ctx->fpriv->opriv, queue);
 
 		shell_fprintf(
@@ -339,7 +342,7 @@ static int nrf_wifi_util_tx_stats(const struct shell *shell,
 			SHELL_INFO,
 			"Outstanding tokens: ac: %d -> %d (pending_q_len: %d)\n",
 			i,
-			fmac_dev_ctx->tx_config.outstanding_descs[i],
+			def_dev_ctx->tx_config.outstanding_descs[i],
 			tx_pending_pkts);
 	}
 


### PR DESCRIPTION
This set of changes separates radio test and default mode dependencies on device context and fmac private structures so that radio test and default mode can be treated as independent modes. This will also allow doxygen documentation to be properly generated for radio test and default modes