### PR TITLE
wifi: Add emergency transmission support in TWT flows

### DIFF
--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/default/fmac_structs.h
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/default/fmac_structs.h
@@ -24,6 +24,7 @@
 
 #define MAX_PEERS 5
 #define MAX_SW_PEERS (MAX_PEERS + 1)
+#define WIFI_NRF_AC_TWT_PRIORITY_EMERGENCY 0xFF
 
 
 /**

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw/host_rpu_data_if.h
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw/host_rpu_data_if.h
@@ -66,7 +66,7 @@ struct nrf_wifi_umac_head {
 } __NRF_WIFI_PKD;
 
 #define DSCP_TOS_MASK  0xFFFF
-#define EMERGENCY_TX BIT(31)
+#define DSCP_OR_TOS_TWT_EMERGENCY_TX  (1 << 31)
 
 /**
  * @brief Tx mac80211 header information.

--- a/drivers/wifi/nrf700x/osal/os_if/inc/osal_api.h
+++ b/drivers/wifi/nrf700x/osal/os_if/inc/osal_api.h
@@ -493,7 +493,7 @@ void wifi_nrf_osal_llist_add_node_tail(struct wifi_nrf_osal_priv *opriv,
  * to the head of a linked list(@llist) allocated by @wifi_nrf_osal_llist_alloc.
  *
  * Return: None.
-*/
+ */
 void wifi_nrf_osal_llist_add_node_head(struct wifi_nrf_osal_priv *opriv,
 					void *llist,
 					void *llist_node);

--- a/drivers/wifi/nrf700x/osal/os_if/inc/osal_api.h
+++ b/drivers/wifi/nrf700x/osal/os_if/inc/osal_api.h
@@ -709,6 +709,18 @@ void *wifi_nrf_osal_nbuf_data_pull(struct wifi_nrf_osal_priv *opriv,
 
 
 /**
+ * wifi_nrf_osal_nbuf_get_priority() - Get the priority of a network buffer.
+ *
+ * @opriv: Pointer to the OSAL context returned by the @wifi_nrf_osal_init API.
+ * @nbuf: Pointer to a network buffer.
+ *
+ * Gets the priority of a network buffer(@nbuf).
+ *
+ * Return: Priority of the network buffer.
+ */
+unsigned char wifi_nrf_osal_nbuf_get_priority(struct wifi_nrf_osal_priv *opriv,
+					       void *nbuf);
+/**
  * wifi_nrf_osal_tasklet_alloc() - Allocate a tasklet.
  * @opriv: Pointer to the OSAL context returned by the @wifi_nrf_osal_init API.
  * @type: Type of tasklet.

--- a/drivers/wifi/nrf700x/osal/os_if/inc/osal_api.h
+++ b/drivers/wifi/nrf700x/osal/os_if/inc/osal_api.h
@@ -484,6 +484,20 @@ void wifi_nrf_osal_llist_add_node_tail(struct wifi_nrf_osal_priv *opriv,
 
 
 /**
+ * wifi_nrf_osal_llist_add_node_head() - Add a node to the head of a linked list.
+ * @opriv: Pointer to the OSAL context returned by the @wifi_nrf_osal_init API.
+ * @llist: Pointer to a linked list.
+ * @llist_node: Pointer to a linked list node.
+ *
+ * Adds a linked list node(@llist_node) allocated by @wifi_nrf_osal_llist_node_alloc
+ * to the head of a linked list(@llist) allocated by @wifi_nrf_osal_llist_alloc.
+ *
+ * Return: None.
+*/
+void wifi_nrf_osal_llist_add_node_head(struct wifi_nrf_osal_priv *opriv,
+					void *llist,
+					void *llist_node);
+/**
  * wifi_nrf_osal_llist_get_node_head() - Get the head of a linked list.
  * @opriv: Pointer to the OSAL context returned by the @wifi_nrf_osal_init API.
  * @llist: Pointer to a linked list.

--- a/drivers/wifi/nrf700x/osal/os_if/inc/osal_ops.h
+++ b/drivers/wifi/nrf700x/osal/os_if/inc/osal_ops.h
@@ -72,6 +72,8 @@
  * @llist_init: Initialize a linked list allocated by @llist_alloc.
  * @llist_add_node_tail: Add a linked list node allocated by @llist_node_alloc
  *                       to the tail of a linked list allocated by @llist_alloc.
+ * @llist_add_node_head: Add a linked list node allocated by @llist_node_alloc
+ * 					 to the head of a linked list allocated by @llist_alloc.
  * @llist_get_node_head: Return the head node from a linked list while still
  *                       leaving the node as part of the linked list. If the
  *                       linked list is empty return NULL.
@@ -209,6 +211,7 @@ struct wifi_nrf_osal_ops {
 	void (*llist_free)(void *llist);
 	void (*llist_init)(void *llist);
 	void (*llist_add_node_tail)(void *llist, void *llist_node);
+	void (*llist_add_node_head)(void *llist, void *llist_node);
 	void *(*llist_get_node_head)(void *llist);
 	void *(*llist_get_node_nxt)(void *llist, void *llist_node);
 	void (*llist_del_node)(void *llist, void *llist_node);

--- a/drivers/wifi/nrf700x/osal/os_if/inc/osal_ops.h
+++ b/drivers/wifi/nrf700x/osal/os_if/inc/osal_ops.h
@@ -73,7 +73,7 @@
  * @llist_add_node_tail: Add a linked list node allocated by @llist_node_alloc
  *                       to the tail of a linked list allocated by @llist_alloc.
  * @llist_add_node_head: Add a linked list node allocated by @llist_node_alloc
- * 					 to the head of a linked list allocated by @llist_alloc.
+ *					 to the head of a linked list allocated by @llist_alloc.
  * @llist_get_node_head: Return the head node from a linked list while still
  *                       leaving the node as part of the linked list. If the
  *                       linked list is empty return NULL.

--- a/drivers/wifi/nrf700x/osal/os_if/inc/osal_ops.h
+++ b/drivers/wifi/nrf700x/osal/os_if/inc/osal_ops.h
@@ -101,6 +101,7 @@
  * @nbuf_data_pull: Decrease the data area of a network buffer(@nbuf) by @size
  *                  bytes at the start of the area and return the pointer to the
  *                  beginning of the data area.
+ * @nbuf_get_priority: Get the priority of a network buffer(@nbuf).
  *
  * @tasklet_alloc: Allocate a tasklet structure and return a pointer to it.
  * @tasklet_free: Free a tasklet structure that had been allocated using
@@ -226,6 +227,7 @@ struct wifi_nrf_osal_ops {
 	void *(*nbuf_data_put)(void *nbuf, unsigned int size);
 	void *(*nbuf_data_push)(void *nbuf, unsigned int size);
 	void *(*nbuf_data_pull)(void *nbuf, unsigned int size);
+	unsigned char (*nbuf_get_priority)(void *nbuf);
 
 	void *(*tasklet_alloc)(int type);
 	void (*tasklet_free)(void *tasklet);

--- a/drivers/wifi/nrf700x/osal/os_if/src/osal.c
+++ b/drivers/wifi/nrf700x/osal/os_if/src/osal.c
@@ -303,6 +303,14 @@ void wifi_nrf_osal_llist_add_node_tail(struct wifi_nrf_osal_priv *opriv,
 					       llist_node);
 }
 
+void wifi_nrf_osal_llist_add_node_head(struct wifi_nrf_osal_priv *opriv,
+				       void *llist,
+				       void *llist_node)
+{
+	return opriv->ops->llist_add_node_head(llist,
+					       llist_node);
+}
+
 
 void *wifi_nrf_osal_llist_get_node_head(struct wifi_nrf_osal_priv *opriv,
 					void *llist)

--- a/drivers/wifi/nrf700x/osal/os_if/src/osal.c
+++ b/drivers/wifi/nrf700x/osal/os_if/src/osal.c
@@ -414,6 +414,12 @@ void *wifi_nrf_osal_nbuf_data_pull(struct wifi_nrf_osal_priv *opriv,
 					  size);
 }
 
+unsigned char wifi_nrf_osal_nbuf_get_priority(struct wifi_nrf_osal_priv *opriv,
+					      void *nbuf)
+{
+	return opriv->ops->nbuf_get_priority(nbuf);
+}
+
 
 void *wifi_nrf_osal_tasklet_alloc(struct wifi_nrf_osal_priv *opriv, int type)
 {

--- a/drivers/wifi/nrf700x/osal/utils/inc/list.h
+++ b/drivers/wifi/nrf700x/osal/utils/inc/list.h
@@ -24,6 +24,10 @@ enum wifi_nrf_status wifi_nrf_utils_list_add_tail(struct wifi_nrf_osal_priv *opr
 						  void *list,
 						  void *data);
 
+enum wifi_nrf_status wifi_nrf_utils_list_add_head(struct wifi_nrf_osal_priv *opriv,
+						  void *list,
+						  void *data);
+
 void wifi_nrf_utils_list_del_node(struct wifi_nrf_osal_priv *opriv,
 				  void *list,
 				  void *data);

--- a/drivers/wifi/nrf700x/osal/utils/inc/queue.h
+++ b/drivers/wifi/nrf700x/osal/utils/inc/queue.h
@@ -24,6 +24,10 @@ enum wifi_nrf_status wifi_nrf_utils_q_enqueue(struct wifi_nrf_osal_priv *opriv,
 					      void *q,
 					      void *q_node);
 
+enum wifi_nrf_status wifi_nrf_utils_q_enqueue_head(struct wifi_nrf_osal_priv *opriv,
+						   void *q,
+						   void *q_node);
+
 void *wifi_nrf_utils_q_dequeue(struct wifi_nrf_osal_priv *opriv,
 			       void *q);
 

--- a/drivers/wifi/nrf700x/osal/utils/src/list.c
+++ b/drivers/wifi/nrf700x/osal/utils/src/list.c
@@ -68,6 +68,32 @@ enum wifi_nrf_status wifi_nrf_utils_list_add_tail(struct wifi_nrf_osal_priv *opr
 	return WIFI_NRF_STATUS_SUCCESS;
 }
 
+enum wifi_nrf_status wifi_nrf_utils_list_add_head(struct wifi_nrf_osal_priv *opriv,
+						  void *list,
+						  void *data)
+{
+	void *list_node = NULL;
+
+	list_node = wifi_nrf_osal_llist_node_alloc(opriv);
+
+	if (!list_node) {
+		wifi_nrf_osal_log_err(opriv,
+				      "%s: Unable to allocate list node\n",
+				      __func__);
+		return WIFI_NRF_STATUS_FAIL;
+	}
+
+	wifi_nrf_osal_llist_node_data_set(opriv,
+					  list_node,
+					  data);
+
+	wifi_nrf_osal_llist_add_node_head(opriv,
+					  list,
+					  list_node);
+
+	return WIFI_NRF_STATUS_SUCCESS;
+}
+
 void wifi_nrf_utils_list_del_node(struct wifi_nrf_osal_priv *opriv,
 				  void *list,
 				  void *data)

--- a/drivers/wifi/nrf700x/osal/utils/src/queue.c
+++ b/drivers/wifi/nrf700x/osal/utils/src/queue.c
@@ -35,6 +35,15 @@ enum wifi_nrf_status wifi_nrf_utils_q_enqueue(struct wifi_nrf_osal_priv *opriv,
 					    data);
 }
 
+enum wifi_nrf_status wifi_nrf_utils_q_enqueue_head(struct wifi_nrf_osal_priv *opriv,
+						   void *q,
+						   void *data)
+{
+	return wifi_nrf_utils_list_add_head(opriv,
+					    q,
+					    data);
+}
+
 
 void *wifi_nrf_utils_q_dequeue(struct wifi_nrf_osal_priv *opriv,
 			       void *q)

--- a/drivers/wifi/nrf700x/zephyr/src/shim.c
+++ b/drivers/wifi/nrf700x/zephyr/src/shim.c
@@ -199,6 +199,7 @@ struct nwb {
 	int hostbuffer;
 	void *cleanup_ctx;
 	void (*cleanup_cb)();
+	unsigned char priority;
 };
 
 static void *zep_shim_nbuf_alloc(unsigned int size)
@@ -294,6 +295,13 @@ static void *zep_shim_nbuf_data_pull(void *nbuf, unsigned int size)
 	return nwb->data;
 }
 
+static unsigned char zep_shim_nbuf_get_priority(void *nbuf)
+{
+	struct nwb *nwb = (struct nwb *)nbuf;
+
+	return nwb->priority;
+}
+
 #include <zephyr/net/ethernet.h>
 #include <zephyr/net/net_core.h>
 
@@ -316,6 +324,8 @@ void *net_pkt_to_nbuf(struct net_pkt *pkt)
 	data = zep_shim_nbuf_data_put(nwb, len);
 
 	net_pkt_read(pkt, data, len);
+
+	nwb->priority = net_pkt_priority(pkt);
 
 	return nwb;
 }
@@ -795,6 +805,7 @@ static const struct wifi_nrf_osal_ops wifi_nrf_os_zep_ops = {
 	.nbuf_data_put = zep_shim_nbuf_data_put,
 	.nbuf_data_push = zep_shim_nbuf_data_push,
 	.nbuf_data_pull = zep_shim_nbuf_data_pull,
+	.nbuf_get_priority = zep_shim_nbuf_get_priority,
 
 	.tasklet_alloc = zep_shim_work_alloc,
 	.tasklet_free = zep_shim_work_free,

--- a/drivers/wifi/nrf700x/zephyr/src/shim.c
+++ b/drivers/wifi/nrf700x/zephyr/src/shim.c
@@ -431,6 +431,19 @@ static void zep_shim_llist_add_node_tail(void *llist, void *llist_node)
 	zep_llist->len += 1;
 }
 
+static void zep_shim_llist_add_node_head(void *llist, void *llist_node)
+{
+	struct zep_shim_llist *zep_llist = NULL;
+	struct zep_shim_llist_node *zep_node = NULL;
+
+	zep_llist = (struct zep_shim_llist *)llist;
+	zep_node = (struct zep_shim_llist_node *)llist_node;
+
+	sys_dlist_prepend(&zep_llist->head, &zep_node->head);
+
+	zep_llist->len += 1;
+}
+
 static void *zep_shim_llist_get_node_head(void *llist)
 {
 	struct zep_shim_llist_node *zep_head_node = NULL;
@@ -767,6 +780,7 @@ static const struct wifi_nrf_osal_ops wifi_nrf_os_zep_ops = {
 	.llist_free = zep_shim_llist_free,
 	.llist_init = zep_shim_llist_init,
 	.llist_add_node_tail = zep_shim_llist_add_node_tail,
+	.llist_add_node_head = zep_shim_llist_add_node_head,
 	.llist_get_node_head = zep_shim_llist_get_node_head,
 	.llist_get_node_nxt = zep_shim_llist_get_node_nxt,
 	.llist_del_node = zep_shim_llist_del_node,

--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 7c771b10d2628d1f4a9949dd4aa52bfe1bb6ac91
+      revision: ccce28fdaa47eef765ff9d7e2ae6f020a96accb8
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
When TWT flow is active and if the application has emergency data then don't wait for the next TWT SP and instead schedule this data ASAP using EDCA. We use `pkt->priority` with special value `0xFF` to indicate the emergency.