### PR TITLE
tools: Update Ccache to version 4.8.2

### DIFF
--- a/scripts/tools-versions-linux.yml
+++ b/scripts/tools-versions-linux.yml
@@ -23,7 +23,7 @@ zephyr-sdk:
     - x86_64-zephyr-elf
     - arm-zephyr-eabi
 ccache:
-  version: 4.8.1
+  version: 4.8.2
 dfu_util:
   version: 0.9-1
 doxygen:


### PR DESCRIPTION
Main purpose of this commit is to rebuild Linux toolchain bundle with bundler v0.14.3.
Currently used bundle was built using bundler v0.14.1 which ignores ccache entry.