### PR TITLE
applications: fix the usage fault in Matter Bridge

### DIFF
--- a/samples/matter/common/src/bridge/util/bridge_util.h
+++ b/samples/matter/common/src/bridge/util/bridge_util.h
@@ -98,7 +98,7 @@ template <typename T, std::size_t N> struct FiniteMap {
 		const auto &it = std::find_if(std::begin(mMap), std::end(mMap),
 					      [key](const Item &item) { return item.key == key; });
 		if (it != std::end(mMap) && it->value) {
-			it->value.~T();
+			it->value = T{};
 			it->key = kInvalidKey;
 			mElementsCount--;
 			return true;


### PR DESCRIPTION
This patch fixes a crash when adding a new bridged device to the previously used slot.
The move assignment operator already calls the ~T but also clears the current object,
which is what we actually need here.