### PR TITLE
doc: nrf: Replace instances of nRF700X with nRF70 series

### DIFF
--- a/doc/nrf/device_guides/wifi_coex.rst
+++ b/doc/nrf/device_guides/wifi_coex.rst
@@ -91,20 +91,20 @@ The following are the implementations supported by the MPSL-provided Bluetooth-o
 
 .. _ug_radio_mpsl_cx_nrf700x:
 
-nRF700x Wi-Fi coexistence
-=========================
+nRF70 Series Wi-Fi coexistence
+==============================
 
 Refer to :ref:`ug_radio_coex_mpsl_cx_based` for the general requirements of this implementation.
 
 Hardware description
 --------------------
 
-The nRF700x interface consists of the signals listed in the table below.
-The *Pin* is the pin name of the nRF700x device.
+The nRF70 Series device interface consists of the signals listed in the table below.
+The *Pin* is the pin name of the nRF70 Series device.
 The *Direction* is from the point of view of the SoC running the SR protocol.
-The *DT property* is the name of the devicetree node property that configures the connection between the SoC running the SR protocol and the nRF700x.
+The *DT property* is the name of the devicetree node property that configures the connection between the SoC running the SR protocol and the nRF70 Series device.
 
-.. table:: nRF700x coexistence protocol pins
+.. table:: nRF70 Series device coexistence protocol pins
 
    ============  =========  =================================  ==============
    Pin           Direction  Description                        DT property
@@ -115,10 +115,10 @@ The *DT property* is the name of the devicetree node property that configures th
    ============  =========  =================================  ==============
 
 
-Enabling nRF700x Wi-Fi coexistence
-----------------------------------
+Enabling nRF70 Series Wi-Fi coexistence
+---------------------------------------
 
-To enable Wi-Fi coexistence on the nRF700x, complete the following steps:
+To enable Wi-Fi coexistence on the nRF70 Series device, complete the following steps:
 
 1. Add the following node to the devicetree source file:
 
@@ -137,9 +137,9 @@ To enable Wi-Fi coexistence on the nRF700x, complete the following steps:
 #. Optionally, replace the node name ``nrf7002-coex`` with a custom one.
 #. Replace the pin numbers provided for each of the required properties:
 
-   * ``req-gpios`` - GPIO characteristic of the device that controls the ``COEX_REQ`` signal of the nRF700x.
-   * ``status0-gpios`` - GPIO characteristic of the device that controls the ``COEX_STATUS0`` signal of the nRF700x.
-   * ``grant-gpios`` - GPIO characteristic of the device that controls the ``COEX_GRANT`` signal of the nRF700x.
+   * ``req-gpios`` - GPIO characteristic of the device that controls the ``COEX_REQ`` signal of the nRF70 Series device.
+   * ``status0-gpios`` - GPIO characteristic of the device that controls the ``COEX_STATUS0`` signal of the nRF70 Series device.
+   * ``grant-gpios`` - GPIO characteristic of the device that controls the ``COEX_GRANT`` signal of the nRF70 Series device.
 
    .. note::
       ``GPIO_PULL_UP`` is added to avoid a floating input pin and is required on some boards only.
@@ -180,7 +180,7 @@ Hardware description
 The generic three wire interface consists of the signals listed in the table below.
 The *Pin* is a generic pin name of a PTA, identified rather by its function.
 The *Direction* is from the point of view of the SoC running the SR protocol.
-The *DT property* is the name of the devicetree node property that configures the connection between the SoC running SR protocol and the nRF700x.
+The *DT property* is the name of the devicetree node property that configures the connection between the SoC running SR protocol and the nRF70 Series device.
 
 .. table:: Generic three wire coexistence protocol pins
 

--- a/doc/nrf/device_guides/working_with_nrf/nrf70/developing/constrained.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf70/developing/constrained.rst
@@ -46,10 +46,10 @@ The following table explains the configuration options:
 |                                          | (based on available memory) | so this has to be equal to the number of packets.                                                                        |
 +------------------------------------------+-----------------------------+--------------------------------------------------------------------------------------------------------------------------+
 
-nRF700X driver performance and memory fine-tuning controls
-**********************************************************
+nRF70 Series driver performance and memory fine-tuning controls
+***************************************************************
 
-The nRF700x driver provides the following software configurations to fine-tune memory and performance based on the use case:
+The nRF70 Series driver provides the following software configurations to fine-tune memory and performance based on the use case:
 
 .. list-table::
    :header-rows: 1
@@ -64,19 +64,19 @@ The nRF700x driver provides the following software configurations to fine-tune m
      - Enable or disable Wi-Fi Protected Access (WPA) supplicant
      - Memory savings
      - This specifies the inclusion of the WPA supplicant module.
-       Disabling this flag restricts the nRF700x driver's functionality to STA scan only.
+       Disabling this flag restricts the nRF70 Series driver's functionality to STA scan only.
    * - :kconfig:option:`CONFIG_NRF700X_AP_MODE`
      - ``y`` or ``n``
      - Enable or disable Access Point (AP) mode
      - Memory savings
      - This specifies the inclusion of the AP mode module.
-       Disabling this flag restricts the nRF700x driver's functionality to :term:`Station mode (STA)` only.
+       Disabling this flag restricts the nRF70 Series driver's functionality to :term:`Station mode (STA)` only.
    * - :kconfig:option:`CONFIG_NRF700X_P2P_MODE`
      - ``y`` or ``n``
      - Enable or disable Wi-Fi direct mode
      - Memory Savings
      - This specifies the inclusion of the P2P mode module.
-       Disabling this flag restricts the nRF700x driver's functionality to STA or AP mode only.
+       Disabling this flag restricts the nRF70 Series driver's functionality to STA or AP mode only.
    * - :kconfig:option:`CONFIG_NRF700X_MAX_TX_TOKENS`
      - ``5``, ``10``, ``11``, ``12``
      - Maximum number of TX tokens.
@@ -87,17 +87,17 @@ The nRF700x driver provides the following software configurations to fine-tune m
        if the pipeline is not saturated. But to saturate the pipeline, a greater number of networking stack buffers,
        or queue depth, is required.
    * - :kconfig:option:`CONFIG_NRF700X_MAX_TX_AGGREGATION`
-     - ``1`` to ``Unlimited`` (based on available memory in nRF700x)
+     - ``1`` to ``Unlimited`` (based on available memory in nRF70 Series device)
      - Maximum number of frames that are coalesced into a single Wi-Fi frame (e.g., MPDU's in an A-MPDU, or MSDU's in an A-MSDU).
        The coalescing greatly improves the throughput for small frames or under high traffic load.
      - Performance tuning and Memory savings
      - This specifies the maximum number of frames that can be coalesced into a single Wi-Fi frame.
        More frames imply more coalescing opportunities but can add latency to the TX path as we wait for more frames to arrive.
    * - :kconfig:option:`CONFIG_NRF700X_RX_NUM_BUFS`
-     - ``1`` to ``Unlimited`` (based on available memory in nRF700x)
+     - ``1`` to ``Unlimited`` (based on available memory in nRF70 Series device)
      - Number of RX buffers
      - Memory savings
-     - This specifies the number of RX buffers that can be used by the nRF700x driver.
+     - This specifies the number of RX buffers that can be used by the nRF70 Series driver.
        The number of buffers must be enough to keep up with the RX traffic, otherwise packets might be dropped.
    * - :kconfig:option:`CONFIG_NRF700X_TX_MAX_DATA_SIZE`
      - ``64`` to ``1600``
@@ -118,9 +118,9 @@ The configuration options must be used in conjunction with the Zephyr networking
 These options form a staged pipeline all the way to the nRF7002 chip, any change in one stage of the pipeline will impact the performance and memory usage of the next stage.
 For example, solving bottleneck in one stage of the pipeline might lead to a bottleneck in the next stage.
 
-nRF700X packet memory
-*********************
-The nRF700x chipset has a special memory called the packet memory to store the Wi-Fi protocol frames for both TX and RX.
+nRF70 Series packet memory
+**************************
+The nRF70 Series device chipset has a special memory called the packet memory to store the Wi-Fi protocol frames for both TX and RX.
 The various configuration options that control the size of the packet memory are listed below:
 
 * :kconfig:option:`CONFIG_NRF700X_TX_MAX_DATA_SIZE`
@@ -156,7 +156,7 @@ There is a build time check to ensure that the total packet memory size does not
 Usage profiles
 **************
 
-The nRF700x driver can be used in the following profiles (not an exhaustive list):
+The nRF70 Series driver can be used in the following profiles (not an exhaustive list):
 
 .. list-table::
    :header-rows: 1

--- a/doc/nrf/drivers/wifi/nrf700x/nrf700x.rst
+++ b/doc/nrf/drivers/wifi/nrf700x/nrf700x.rst
@@ -1,36 +1,36 @@
 .. _nrf700x_wifi:
 
-nRF700X Wi-Fi driver
-####################
+nRF70 Series Wi-Fi driver
+#########################
 
 .. contents::
    :local:
    :depth: 2
 
-This driver implements the Wi-Fi® protocol for the nRF700X FullMAC series of devices.
+This driver implements the Wi-Fi® protocol for the nRF70 FullMAC Series of devices.
 FullMAC devices implement the Wi-Fi protocol in the chipset.
 The driver configures the chipset and transfers the frames to and from the device to the networking stack.
 
-nRF700X is a companion IC and can be used with any Nordic Semiconductor System-on-Chips (SoCs) such as the nRF53 and nRF91 Series SoCs.
+nRF70 Series device is a companion IC and can be used with any Nordic Semiconductor System-on-Chips (SoCs) such as the nRF53 and nRF91 Series SoCs.
 
 You can enable the driver by using the :kconfig:option:`CONFIG_WIFI_NRF700X` Kconfig option.
 
 Architecture
 *************
 
-The following figure illustrates the architecture of the nRF700X Wi-Fi driver.
+The following figure illustrates the architecture of the nRF70 Series Wi-Fi driver.
 
 .. figure:: /images/nrf700x_wifi_driver.svg
-   :alt: nRF700X Wi-Fi driver block diagram
+   :alt: nRF70 Series Wi-Fi driver block diagram
    :align: center
    :figclass: align-center
 
-   nRF700X Wi-Fi driver architecture overview
+   nRF70 Series Wi-Fi driver architecture overview
 
 Design overview
 ***************
 
-The nRF700X Wi-Fi driver follows an OS agnostic design, and the driver implementation is split into OS agnostic and OS (Zephyr) specific code.
+The nRF70 Series Wi-Fi driver follows an OS agnostic design, and the driver implementation is split into OS agnostic and OS (Zephyr) specific code.
 The OS agnostic code is located in the :file:`drivers/wifi/nrf700x/osal/` folder and the OS specific code is located in the :file:`drivers/wifi/nrf700x/zephyr/` folder.
 
 The driver supports two modes of operations:
@@ -57,16 +57,16 @@ Except for scan only mode, the driver uses host access point daemon (hostapd) to
 
 Radio Test mode
 ^^^^^^^^^^^^^^^
-The nRF700X Wi-Fi driver supports Radio Test mode, which you can use to test the RF performance of the nRF700X device.
+The nRF70 Series Wi-Fi driver supports Radio Test mode, which you can use to test the RF performance of the nRF70 Series device.
 This is a build time option that you can enable using the :kconfig:option:`CONFIG_NRF700X_RADIO_TEST` Kconfig option.
 
 For more details about using this driver in Radio Test mode, see :ref:`wifi_radio_test`.
 
-Driver to nRF700X communication
-*******************************
+Driver to nRF70 Series device communication
+*******************************************
 
-The driver communicates with the nRF700X device using the QSPI/SPI interface.
-The driver uses the QSPI/SPI interface to send commands to the nRF700X device, and to transfer the data to and from the device.
+The driver communicates with the nRF70 Series device using the QSPI/SPI interface.
+The driver uses the QSPI/SPI interface to send commands to the nRF70 Series device, and to transfer the data to and from the device.
 The nRF7002 DK uses QSPI whereas the nRF7002 EK uses SPI.
 
 To connect the nRF7002 EK to the SoC, the ``nrf7002ek`` shield is required.
@@ -74,7 +74,7 @@ To connect the nRF7002 EK to the SoC, the ``nrf7002ek`` shield is required.
 Configuration
 *************
 
-The nRF700X Wi-Fi driver has the following configuration options:
+The nRF70 Series Wi-Fi driver has the following configuration options:
 
 .. options-from-kconfig::
    :show-type:
@@ -83,14 +83,14 @@ The nRF700X Wi-Fi driver has the following configuration options:
 API documentation
 *****************
 
-After the nrf700x driver has been initialized, the application will see it as an Ethernet interface.
+After the nRF70 Series driver has been initialized, the application will see it as an Ethernet interface.
 To use the Ethernet interface, the application can use `Zephyr Network APIs`_.
 
 Low-level API documentation
 ***************************
 
-The nRF700X Wi-Fi driver provides a low-level API for use cases where the application needs to access the nRF700X device directly.
-This is typically intended for customers who want to use the nRF700X device in a different platform than Zephyr.
+The nRF70 Series Wi-Fi driver provides a low-level API for use cases where the application needs to access the nRF70 Series device directly.
+This is typically intended for customers who want to use the nRF70 Series device in a different platform than Zephyr.
 
 .. toctree::
    :maxdepth: 1

--- a/doc/nrf/drivers/wifi/nrf700x/subpages/low_api_radio_test.rst
+++ b/doc/nrf/drivers/wifi/nrf700x/subpages/low_api_radio_test.rst
@@ -1,7 +1,7 @@
 Radio Test mode
 ---------------
 
-This mode is used for testing the RF performance of the nRF700X device, mainly to characterize the RF.
+This mode is used for testing the RF performance of the nRF70 Series device, mainly to characterize the RF.
 
 .. note::
 

--- a/doc/nrf/drivers/wifi/nrf700x/subpages/low_api_wifi.rst
+++ b/doc/nrf/drivers/wifi/nrf700x/subpages/low_api_wifi.rst
@@ -1,7 +1,7 @@
 Wi-Fi mode
 ----------
 
-This mode is used for normal operation of the nRF700X device in, for example, STA mode or other modes that are supported in the future.
+This mode is used for normal operation of the nRF70 Series device in, for example, STA mode or other modes that are supported in the future.
 
 | Header file: :file:`drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/default/fmac_api.h`
 | Source file: :file:`drivers/wifi/nrf700x/osal/fw_if/umac_if/src/default/fmac_api.c`


### PR DESCRIPTION
Replace instances of nRF700X with nRF70 series in NCS documentation.