### PR TITLE
Add missing cell RSRP value for GNSS assistance

### DIFF
--- a/lib/location/CMakeLists.txt
+++ b/lib/location/CMakeLists.txt
@@ -9,8 +9,11 @@ zephyr_library_sources(location.c)
 zephyr_library_sources(location_core.c)
 zephyr_library_sources(location_utils.c)
 zephyr_library_sources_ifdef(CONFIG_LOCATION_METHOD_GNSS method_gnss.c)
-zephyr_library_sources_ifdef(CONFIG_LOCATION_METHOD_CELLULAR scan_cellular.c)
 zephyr_library_sources_ifdef(CONFIG_LOCATION_METHOD_WIFI scan_wifi.c)
+
+if(CONFIG_LOCATION_METHOD_CELLULAR OR CONFIG_LOCATION_METHOD_GNSS)
+zephyr_library_sources(scan_cellular.c)
+endif()
 
 if(CONFIG_LOCATION_METHOD_CELLULAR OR CONFIG_LOCATION_METHOD_WIFI)
 zephyr_library_sources(method_cloud_location.c)

--- a/lib/location/location_utils.h
+++ b/lib/location/location_utils.h
@@ -9,24 +9,6 @@
 
 #include <modem/location.h>
 
-/** Modem parameters. */
-struct location_utils_modem_params_info {
-	/** Mobile Country Code. */
-	int mcc;
-
-	/** Mobile Network Code. */
-	int mnc;
-
-	/** E-UTRAN cell ID */
-	uint32_t cell_id;
-
-	/** Tracking area code. */
-	uint32_t tac;
-
-	/** Physical cell ID. */
-	uint16_t phys_cell_id;
-};
-
 /**
  * @brief Check if LTE networking is available.
  *
@@ -37,16 +19,6 @@ struct location_utils_modem_params_info {
  * @retval false     LTE networking is not available.
  */
 bool location_utils_is_lte_available(void);
-
-/**
- * @brief Read modem parameters.
- *
- * @param[out] modem_params Context where parameters are filled.
- *
- * @retval true      If modem parameters were received successfully.
- * @retval false     If modem parameters were not received successfully.
- */
-int location_utils_modem_params_read(struct location_utils_modem_params_info *modem_params);
 
 /**
  * @brief Generate JWT buffer to be used for nRF Cloud REST API use.

--- a/lib/location/method_cloud_location.c
+++ b/lib/location/method_cloud_location.c
@@ -65,13 +65,13 @@ static void method_cloud_location_positioning_work_fn(struct k_work *work)
 
 #if defined(CONFIG_LOCATION_METHOD_WIFI)
 	if (wifi_config != NULL) {
-		err = scan_wifi_start(&wifi_scan_ready);
+		scan_wifi_start(&wifi_scan_ready);
 	}
 #endif
 
 #if defined(CONFIG_LOCATION_METHOD_CELLULAR)
 	if (cell_config != NULL) {
-		err = scan_cellular_start(cell_config->cell_count);
+		scan_cellular_start(cell_config->cell_count, false);
 		scan_cellular_info = scan_cellular_results_get();
 	}
 #endif

--- a/lib/location/scan_cellular.h
+++ b/lib/location/scan_cellular.h
@@ -10,7 +10,7 @@
 #include <modem/lte_lc.h>
 
 int scan_cellular_init(void);
-int scan_cellular_start(uint8_t cell_count);
+void scan_cellular_start(uint8_t cell_count, bool light_search);
 struct lte_lc_cells_info *scan_cellular_results_get(void);
 int scan_cellular_cancel(void);
 

--- a/lib/location/scan_wifi.c
+++ b/lib/location/scan_wifi.c
@@ -46,7 +46,7 @@ struct wifi_scan_info *scan_wifi_results_get(void)
 	return &scan_wifi_info;
 }
 
-int scan_wifi_start(struct k_sem *wifi_scan_ready)
+void scan_wifi_start(struct k_sem *wifi_scan_ready)
 {
 	int ret;
 
@@ -64,7 +64,6 @@ int scan_wifi_start(struct k_sem *wifi_scan_ready)
 		k_sem_give(wifi_scan_ready);
 		wifi_scan_ready = NULL;
 	}
-	return ret;
 }
 
 static void scan_wifi_result_handle(struct net_mgmt_event_callback *cb)

--- a/lib/location/scan_wifi.h
+++ b/lib/location/scan_wifi.h
@@ -10,7 +10,7 @@
 #include <net/wifi_location_common.h>
 
 int scan_wifi_init(void);
-int scan_wifi_start(struct k_sem *wifi_scan_ready);
+void scan_wifi_start(struct k_sem *wifi_scan_ready);
 struct wifi_scan_info *scan_wifi_results_get(void);
 int scan_wifi_cancel(void);
 

--- a/samples/cellular/modem_shell/src/gnss/gnss.c
+++ b/samples/cellular/modem_shell/src/gnss/gnss.c
@@ -568,6 +568,19 @@ static int serving_cell_info_get(struct lte_lc_cell *serving_cell)
 
 	serving_cell->tac = strtol(resp_buf, NULL, 16);
 
+	err = modem_info_short_get(MODEM_INFO_RSRP, &serving_cell->rsrp);
+	if (err < 0) {
+		return err;
+	}
+
+	if (serving_cell->rsrp == 255) {
+		/* No valid RSRP, modem is probably in PSM and the cell information might not be
+		 * valid anymore. %NCELLMEAS could be used to wake up the modem and perform a cell
+		 * search instead, but this is good enough for modem_shell.
+		 */
+		serving_cell->rsrp = 0; /* -140 dBm */
+	}
+
 	/* Request for MODEM_INFO_MNC returns both MNC and MCC in the same string. */
 	err = modem_info_string_get(MODEM_INFO_OPERATOR,
 				    resp_buf,


### PR DESCRIPTION
Added missing cell RSRP value for GNSS assistance to Location library and modem_shell sample.

Changed Location library to use `%NCELLMEAS` instead of `%XMONITOR` to get the cell information, because `%XMONITOR` may return stale cell information when modem is in PSM. `%XMONITOR` was also used as a fallback for MFWs which do not support `%NCELLMEAS`, but that is no longer needed with the MFWs supported by the next SDK release.