### PR TITLE
lib: lte_link_control: Change default system mode

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -609,7 +609,10 @@ Modem libraries
 
 * :ref:`lte_lc_readme` library:
 
-  * Updated the CE level enum names for :c:enum:`lte_lc_ce_level` to not include the number of repetitions.
+  * Updated:
+
+    * The CE level enum names for :c:enum:`lte_lc_ce_level` to not include the number of repetitions.
+    * The default network mode from :kconfig:option:`CONFIG_LTE_NETWORK_MODE_LTE_M` to :kconfig:option:`CONFIG_LTE_NETWORK_MODE_LTE_M_GPS`.
 
   * Removed:
 

--- a/lib/lte_link_control/Kconfig
+++ b/lib/lte_link_control/Kconfig
@@ -142,9 +142,9 @@ config LTE_PTW_VALUE_NBIOT
 
 choice LTE_NETWORK_MODE
 	prompt "Select network mode"
-	default LTE_NETWORK_MODE_LTE_M
+	default LTE_NETWORK_MODE_LTE_M_GPS
 	help
-		Select either LTE-M or Narrowband-IOT (NB-IoT) network mode
+		Select the modem system mode.
 
 config LTE_NETWORK_DEFAULT
 	bool "Use default"


### PR DESCRIPTION
Changed default system mode to LTE-M + GNSS. GNSS can be enabled in the system mode mask even if it's not used by the application. GNSS needs to be anyway started separately.