### PR TITLE
doc: Add known issue for Advertising Providers

### DIFF
--- a/doc/nrf/releases_and_maturity/known_issues.rst
+++ b/doc/nrf/releases_and_maturity/known_issues.rst
@@ -2272,6 +2272,19 @@ CIA-351: Connectivity issues with :ref:`lib_azure_iot_hub`
   **Workaround:** Avoid using LTE Power Saving Mode (PSM) and extended DRX intervals longer than approximately 30 seconds. This will reduce the risk of the issue occurring, at the cost of increased power consumption.
 
 
+Bluetooth libraries and services
+================================
+
+.. rst-class:: v2-4-2 v2-4-1 v2-4-0
+
+NCSDK-23315: The :ref:`bt_le_adv_prov_readme` has an incorrect range and default value for the :kconfig:option:`CONFIG_BT_ADV_PROV_FAST_PAIR_ADV_BUF_SIZE` Kconfig option.
+  The buffer size has not been aligned to the new Fast Pair not discoverable advertising data size after size of the salt included in the data was increased from 1 byte to 2 bytes.
+  Too small default buffer size results in an assertion failure when generating an advertising data for the Fast Pair not discoverable advertising with five Account Keys and the Battery Notification enabled.
+  The assertion failure replicates in the :ref:`peripheral_fast_pair` sample.
+
+  **Workaround:** Manually cherry-pick and apply the commit with the fix from the ``main`` branch (commit hash: ``a8b668e82837295962348e9e681125c2ae11bb4e``).
+
+
 Other libraries
 ===============
 


### PR DESCRIPTION
Adds known issue related to improper configuration of CONFIG_BT_ADV_PROV_FAST_PAIR_ADV_BUF_SIZE.
Links to commit with fix for the issue.

Jira: NCSDK-23315