### PR TITLE
samples: bluetooth: encrypt throughput sample

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -288,6 +288,11 @@ Bluetooth samples
 
   * Updated by disabling the :kconfig:option:`CONFIG_BT_SETTINGS_CCC_LAZY_LOADING` Kconfig option as a workaround fix for the `Zephyr issue #61033`_.
 
+* :ref:`ble_throughput` sample:
+
+  * Enabled encryption in the sample.
+    The measured throughput is calculated over the encrypted data, which is how most of the Bluetooth products use this protocol.
+
 Bluetooth mesh samples
 ----------------------
 


### PR DESCRIPTION
By the same logic we used when we decided to encrypt the llpm sample in https://github.com/nrfconnect/sdk-nrf/pull/11720
we should also encrypt throughput sample. We should demonstrate the throughput we can get, with encryption on.

And conenct with 7.5ms interval to speed up encryption. The sample will switch to the interval selected by console (or 400ms if nothing is selected) before doing the throgputmeasurment.

Currently failing sample nightly test run, so that needs to be looked into before mergeing. https://jenkins-ncs.nordicsemi.no/blue/organizations/jenkins/latest%2Fsub%2Ftest-fw-nrfconnect-ble_samples/detail/master/9307/pipeline/

Disconnect with BT_HCI_ERR_INSTANT_PASSED