### PR TITLE
applications: serial_lte_modem: replace OVERLAY_CONFIG by EXTRA_CONF_FILE

### DIFF
--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -231,7 +231,7 @@ The following configuration files are provided:
 * :file:`prj.conf` - This configuration file contains the standard configuration for the serial LTE modem application.
 
 * :file:`overlay-native_tls.conf` - This configuration file contains additional configuration options that are required to use :ref:`slm_native_tls`.
-  You can include it by adding ``-DOVERLAY_CONFIG=overlay-native_tls.conf`` to your build command.
+  You can include it by adding ``-DEXTRA_CONF_FILE=overlay-native_tls.conf`` to your build command.
   See :ref:`cmake_options`.
 
 * :file:`overlay-carrier.conf` - Configuration file that adds |NCS| :ref:`liblwm2m_carrier_readme` support.

--- a/applications/serial_lte_modem/overlay-native_tls.conf
+++ b/applications/serial_lte_modem/overlay-native_tls.conf
@@ -1,6 +1,6 @@
 # To build serial LTE modem native TLS socket support
 # add the following to your west build command:
-#       -DOVERLAY_CONFIG=overlay-native_tls.conf
+#       -- -DEXTRA_CONF_FILE=overlay-native_tls.conf
 #
 
 # TLS configuration

--- a/applications/serial_lte_modem/sample.yaml
+++ b/applications/serial_lte_modem/sample.yaml
@@ -11,7 +11,7 @@ tests:
     tags: ci_build
   applications.serial_lte_modem.native_tls:
     build_only: true
-    extra_args: OVERLAY_CONFIG=overlay-native_tls.conf
+    extra_args: EXTRA_CONF_FILE=overlay-native_tls.conf
     platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns thingy91_nrf9160_ns
     integration_platforms:
       - nrf9160dk_nrf9160_ns
@@ -20,7 +20,7 @@ tests:
     tags: ci_build
   applications.serial_lte_modem.lwm2m_carrier:
     build_only: true
-    extra_args: OVERLAY_CONFIG=overlay-carrier.conf
+    extra_args: EXTRA_CONF_FILE=overlay-carrier.conf
     platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns thingy91_nrf9160_ns
     integration_platforms:
       - nrf9160dk_nrf9160_ns


### PR DESCRIPTION
Reflect the changes in upstream Zephyr.