### PR TITLE
drivers: wifi: Make Kconfig symbols selectable

### DIFF
--- a/drivers/wifi/nrf700x/Kconfig
+++ b/drivers/wifi/nrf700x/Kconfig
@@ -26,11 +26,11 @@ module-help = Sets log level for Wi-Fi nRF700x bus layers
 source "subsys/net/Kconfig.template.log_config.net"
 
 config NRF700X_STA_MODE
-	bool
+	bool "Enable nRF700X STA mode"
 	default y if WPA_SUPP
 
 config NRF_WIFI_IF_AUTO_START
-	bool
+	bool "Enable Wi-Fi interface auto start on boot"
 	default y
 
 config NRF_WIFI_PATCHES_EXT_FLASH


### PR DESCRIPTION
Make symbols NRF700X_STA_MODE and NRF_WIFI_IF_AUTO_START user selectable.