### PR TITLE
applications: Matter Bridge: fixed the device type list

### DIFF
--- a/applications/matter_bridge/src/bridged_device_types/humidity_sensor.cpp
+++ b/applications/matter_bridge/src/bridged_device_types/humidity_sensor.cpp
@@ -46,7 +46,7 @@ HumiditySensorDevice::HumiditySensorDevice(const char *nodeLabel) : MatterBridge
 	mDataVersionSize = kHumidityDataVersionSize;
 	mEp = &bridgedHumidityEndpoint;
 	mDeviceTypeList = kBridgedHumidityDeviceTypes;
-	mDeviceTypeListSize = sizeof(kBridgedHumidityDeviceTypes);
+	mDeviceTypeListSize = ARRAY_SIZE(kBridgedHumidityDeviceTypes);
 	mDataVersion = static_cast<DataVersion *>(chip::Platform::MemoryAlloc(sizeof(DataVersion) * mDataVersionSize));
 }
 

--- a/applications/matter_bridge/src/bridged_device_types/onoff_light.cpp
+++ b/applications/matter_bridge/src/bridged_device_types/onoff_light.cpp
@@ -51,7 +51,7 @@ OnOffLightDevice::OnOffLightDevice(const char *nodeLabel) : MatterBridgedDevice(
 	mDataVersionSize = kLightDataVersionSize;
 	mEp = &bridgedLightEndpoint;
 	mDeviceTypeList = kBridgedOnOffDeviceTypes;
-	mDeviceTypeListSize = sizeof(kBridgedOnOffDeviceTypes);
+	mDeviceTypeListSize = ARRAY_SIZE(kBridgedOnOffDeviceTypes);
 	mDataVersion = static_cast<DataVersion *>(chip::Platform::MemoryAlloc(sizeof(DataVersion) * mDataVersionSize));
 }
 

--- a/applications/matter_bridge/src/bridged_device_types/temperature_sensor.cpp
+++ b/applications/matter_bridge/src/bridged_device_types/temperature_sensor.cpp
@@ -44,7 +44,7 @@ TemperatureSensorDevice::TemperatureSensorDevice(const char *nodeLabel) : Matter
 	mDataVersionSize = kTemperatureDataVersionSize;
 	mEp = &bridgedTemperatureEndpoint;
 	mDeviceTypeList = kBridgedTemperatureDeviceTypes;
-	mDeviceTypeListSize = sizeof(kBridgedTemperatureDeviceTypes);
+	mDeviceTypeListSize = ARRAY_SIZE(kBridgedTemperatureDeviceTypes);
 	mDataVersion = static_cast<DataVersion *>(chip::Platform::MemoryAlloc(sizeof(DataVersion) * mDataVersionSize));
 }
 


### PR DESCRIPTION
We need to provide the number of device types incorporated in the created endpoint. It was calculated incorrectly (as the overall array size in bytes) and therefore we observed trash in the chip-tool output when querying the device-type-list on the descriptor cluster.