### PR TITLE
lib: rest_client: fix an undefined reference when using the library in c++…

### DIFF
--- a/include/net/rest_client.h
+++ b/include/net/rest_client.h
@@ -21,6 +21,10 @@
 #include <zephyr/net/http/client.h>
 #include <zephyr/net/http/parser.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** @brief TLS is not used. */
 #define REST_CLIENT_SEC_TAG_NO_SEC -1
 
@@ -159,6 +163,10 @@ int rest_client_request(struct rest_client_req_context *req_ctx,
  * @param[in,out] req_ctx Request context for communicating with REST client API.
  */
 void rest_client_request_defaults_set(struct rest_client_req_context *req_ctx);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 


### PR DESCRIPTION
Using the library in a c++ project undefined reference errors: 
`undefined reference to rest_client_request_defaults_set(rest_client_req_context*)'`

It is solved by using ifdefines and extern C instructions