### PR TITLE
applications: serial_lte_modem: Rename AT#XUDPCLI's <cid> to <use_dtls_cid>

### DIFF
--- a/applications/serial_lte_modem/doc/TCPUDP_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/TCPUDP_AT_commands.rst
@@ -505,7 +505,7 @@ Syntax
 
 ::
 
-   #XUDPCLI=<op>[,<url>,<port>[,<sec_tag>[,<cid>]]]
+   #XUDPCLI=<op>[,<url>,<port>[,<sec_tag>[,<use_dtls_cid>]]]
 
 * The ``<op>`` parameter can accept one of the following values:
 
@@ -522,7 +522,7 @@ Syntax
 * The ``<sec_tag>`` parameter is an integer.
   If it is given, a DTLS client will be started.
   It indicates to the modem the credential of the security tag used for establishing a secure connection.
-* The ``<cid>`` parameter is an integer.
+* The ``<use_dtls_cid>`` parameter is an integer.
   It indicates whether to use DTLS's connection identifier.
   This parameter is only supported with modem firmware 1.3.5 and newer.
   See :ref:`SLM_AT_SSOCKETOPT` for more details regarding the allowed values.
@@ -589,7 +589,7 @@ Syntax
 
 ::
 
-   #XUDPCLI: <list of ops>,<url>,<port>,<sec_tag>,<cid>
+   #XUDPCLI: <list of ops>,<url>,<port>,<sec_tag>,<use_dtls_cid>
 
 Examples
 ~~~~~~~~
@@ -597,7 +597,7 @@ Examples
 ::
 
    AT#XUDPCLI=?
-   #XUDPCLI: (0,1,2),<url>,<port>,<sec_tag>,<cid>
+   #XUDPCLI: (0,1,2),<url>,<port>,<sec_tag>,<use_dtls_cid>
    OK
 
 UDP send data #XUDPSEND

--- a/applications/serial_lte_modem/src/slm_at_udp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_udp_proxy.c
@@ -487,11 +487,7 @@ static bool socket_is_in_use(void)
 	return true;
 }
 
-/**@brief handle AT#XUDPSVR commands
- *  AT#XUDPSVR=<op>[,<port>]
- *  AT#XUDPSVR? READ command not supported
- *  AT#XUDPSVR=?
- */
+/* Handles AT#XUDPSVR commands. */
 int handle_at_udp_server(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
@@ -536,11 +532,7 @@ int handle_at_udp_server(enum at_cmd_type cmd_type)
 	return err;
 }
 
-/**@brief handle AT#XUDPCLI commands
- *  AT#XUDPCLI=<op>[,<url>,<port>[,<sec_tag>[,<cid>]]]
- *  AT#XUDPCLI? READ command not supported
- *  AT#XUDPCLI=?
- */
+/* Handles AT#XUDPCLI commands. */
 int handle_at_udp_client(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
@@ -598,7 +590,7 @@ int handle_at_udp_client(enum at_cmd_type cmd_type)
 		break;
 
 	case AT_CMD_TYPE_TEST_COMMAND:
-		rsp_send("\r\n#XUDPCLI: (%d,%d,%d),<url>,<port>,<sec_tag>,<cid>\r\n",
+		rsp_send("\r\n#XUDPCLI: (%d,%d,%d),<url>,<port>,<sec_tag>,<use_dtls_cid>\r\n",
 			CLIENT_DISCONNECT, CLIENT_CONNECT, CLIENT_CONNECT6);
 		err = 0;
 		break;
@@ -610,11 +602,7 @@ int handle_at_udp_client(enum at_cmd_type cmd_type)
 	return err;
 }
 
-/**@brief handle AT#XUDPSEND commands
- *  AT#XUDPSEND[=<data>]
- *  AT#XUDPSEND? READ command not supported
- *  AT#XUDPSEND=? TEST command not supported
- */
+/* Handles AT#XUDPSEND command. */
 int handle_at_udp_send(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;


### PR DESCRIPTION
Avoid name clash with the PDP context ID in the socket AT commands.