### PR TITLE
net: lib: lwm2m_client_utils: Fix P-GPS start time check

### DIFF
--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/gnss_assistance_obj.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/gnss_assistance_obj.c
@@ -47,7 +47,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define PREDICTION_INTERVAL_MIN				120
 #define PREDICTION_INTERVAL_MAX				480
 
-#define START_TIME_MAX					83699
+#define START_TIME_MAX					86399
 
 static int32_t assist_type;
 static uint32_t agps_mask;


### PR DESCRIPTION
`location_assist_pgps_set_start_time()` used invalid maximum value when checking if the given start time was within the correct range. Because of this P-GPS did not work at a specific time of day.