### PR TITLE
applications: serial_lte_modem: Prefix all globals by slm_

### DIFF
--- a/applications/serial_lte_modem/src/ftp_c/slm_at_tftp.c
+++ b/applications/serial_lte_modem/src/ftp_c/slm_at_tftp.c
@@ -24,17 +24,13 @@ enum slm_ftp_operation {
 	TFTP_OP_MAX
 };
 
-/* global variable defined in different files */
-extern struct at_param_list at_param_list;
-extern uint8_t data_buf[SLM_MAX_MESSAGE_SIZE];
-
 void tftp_callback(const struct tftp_evt *evt)
 {
 	switch (evt->type) {
 	case TFTP_EVT_DATA:
 		if (evt->param.data.len > 0) {
-			memcpy(data_buf, evt->param.data.data_ptr, evt->param.data.len);
-			data_send(data_buf, evt->param.data.len);
+			memcpy(slm_data_buf, evt->param.data.data_ptr, evt->param.data.len);
+			data_send(slm_data_buf, evt->param.data.len);
 		}
 		break;
 
@@ -148,32 +144,32 @@ int handle_at_tftp(enum at_cmd_type cmd_type)
 	char filepath[SLM_MAX_FILEPATH];
 	char mode[16];   /** "netascii", "octet", "mail" */
 	int size;
-	int param_count = at_params_valid_count_get(&at_param_list);
+	int param_count = at_params_valid_count_get(&slm_at_param_list);
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		err = at_params_unsigned_short_get(&at_param_list, 1, &op);
+		err = at_params_unsigned_short_get(&slm_at_param_list, 1, &op);
 		if (err) {
 			return err;
 		}
 
 		size = sizeof(url);
-		err = util_string_get(&at_param_list, 2, url, &size);
+		err = util_string_get(&slm_at_param_list, 2, url, &size);
 		if (err) {
 			return err;
 		}
-		err = at_params_unsigned_short_get(&at_param_list, 3, &port);
+		err = at_params_unsigned_short_get(&slm_at_param_list, 3, &port);
 		if (err) {
 			return err;
 		}
 		size = sizeof(filepath);
-		err = util_string_get(&at_param_list, 4, filepath, &size);
+		err = util_string_get(&slm_at_param_list, 4, filepath, &size);
 		if (err) {
 			return err;
 		}
 		if (param_count > 5) {
 			size = sizeof(mode);
-			err = util_string_get(&at_param_list, 5, mode, &size);
+			err = util_string_get(&slm_at_param_list, 5, mode, &size);
 			if (err) {
 				return err;
 			}
@@ -194,7 +190,7 @@ int handle_at_tftp(enum at_cmd_type cmd_type)
 			uint8_t data[SLM_MAX_PAYLOAD_SIZE + 1] = {0};
 
 			size = sizeof(data);
-			err = util_string_get(&at_param_list, 6, data, &size);
+			err = util_string_get(&slm_at_param_list, 6, data, &size);
 			if (err) {
 				return err;
 			}

--- a/applications/serial_lte_modem/src/gnss/slm_at_gnss.c
+++ b/applications/serial_lte_modem/src/gnss/slm_at_gnss.c
@@ -69,10 +69,6 @@ static enum {
 	RUN_STATUS_MAX
 } run_status;
 
-extern struct k_work_q slm_work_q;
-extern struct at_param_list at_param_list;
-extern uint8_t at_buf[SLM_AT_MAX_CMD_LEN];
-
 static bool is_gnss_activated(void)
 {
 	int gnss_support = 0;
@@ -384,7 +380,7 @@ static void fix_rep_wk(struct k_work *work)
 	}
 
 #if defined(CONFIG_SLM_NRF_CLOUD)
-	if (nrf_cloud_send_location && nrf_cloud_ready) {
+	if (slm_nrf_cloud_send_location && slm_nrf_cloud_ready) {
 		/* Report to nRF Cloud by best-effort */
 		send_location(&pvt);
 	}
@@ -499,12 +495,12 @@ int handle_at_gps(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		err = at_params_unsigned_short_get(&at_param_list, 1, &op);
+		err = at_params_unsigned_short_get(&slm_at_param_list, 1, &op);
 		if (err < 0) {
 			return err;
 		}
 		if (op == GPS_START && run_type == RUN_TYPE_NONE) {
-			err = at_params_unsigned_short_get(&at_param_list, 2, &interval);
+			err = at_params_unsigned_short_get(&slm_at_param_list, 2, &interval);
 			if (err < 0) {
 				return err;
 			}
@@ -518,7 +514,7 @@ int handle_at_gps(enum at_cmd_type cmd_type)
 				LOG_ERR("Failed to set fix interval, error: %d", err);
 				return err;
 			}
-			if (at_params_unsigned_short_get(&at_param_list, 3, &timeout) == 0) {
+			if (at_params_unsigned_short_get(&slm_at_param_list, 3, &timeout) == 0) {
 				err = nrf_modem_gnss_fix_retry_set(timeout);
 				if (err) {
 					LOG_ERR("Failed to set fix retry, error: %d", err);
@@ -578,12 +574,12 @@ int handle_at_agps(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		err = at_params_unsigned_short_get(&at_param_list, 1, &op);
+		err = at_params_unsigned_short_get(&slm_at_param_list, 1, &op);
 		if (err < 0) {
 			return err;
 		}
-		if (op == AGPS_START && nrf_cloud_ready && run_type == RUN_TYPE_NONE) {
-			err = at_params_unsigned_short_get(&at_param_list, 2, &interval);
+		if (op == AGPS_START && slm_nrf_cloud_ready && run_type == RUN_TYPE_NONE) {
+			err = at_params_unsigned_short_get(&slm_at_param_list, 2, &interval);
 			if (err < 0) {
 				return err;
 			}
@@ -615,7 +611,7 @@ int handle_at_agps(enum at_cmd_type cmd_type)
 				LOG_ERR("Failed to set fix interval, error: %d", err);
 				return err;
 			}
-			if (at_params_unsigned_short_get(&at_param_list, 3, &timeout) == 0) {
+			if (at_params_unsigned_short_get(&slm_at_param_list, 3, &timeout) == 0) {
 				err = nrf_modem_gnss_fix_retry_set(timeout);
 				if (err) {
 					LOG_ERR("Failed to set fix retry, error: %d", err);
@@ -688,7 +684,7 @@ int handle_at_pgps(enum at_cmd_type cmd_type)
 		if (err < 0) {
 			return err;
 		}
-		if (op == PGPS_START && nrf_cloud_ready && run_type == RUN_TYPE_NONE) {
+		if (op == PGPS_START && slm_nrf_cloud_ready && run_type == RUN_TYPE_NONE) {
 			err = at_params_unsigned_short_get(&at_param_list, 2, &interval);
 			if (err < 0) {
 				return err;
@@ -768,7 +764,7 @@ int handle_at_gps_delete(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		err = at_params_unsigned_int_get(&at_param_list, 1, &mask);
+		err = at_params_unsigned_int_get(&slm_at_param_list, 1, &mask);
 		if (err < 0) {
 			return err;
 		}

--- a/applications/serial_lte_modem/src/gpio/slm_at_gpio.c
+++ b/applications/serial_lte_modem/src/gpio/slm_at_gpio.c
@@ -14,14 +14,8 @@
 
 LOG_MODULE_REGISTER(slm_gpio, CONFIG_SLM_LOG_LEVEL);
 
-/* global variable defined in different resources */
-extern struct at_param_list at_param_list;
-
 static const struct device *gpio_dev = DEVICE_DT_GET(DT_NODELABEL(gpio0));
 static sys_slist_t slm_gpios = SYS_SLIST_STATIC_INIT(&slm_gpios);
-
-/* global variable defined in different files */
-extern struct k_work_q slm_work_q;
 
 struct slm_gpio_pin_node {
 	sys_snode_t node;
@@ -210,12 +204,12 @@ int handle_at_gpio_configure(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		err = at_params_unsigned_short_get(&at_param_list, 1, &op);
+		err = at_params_unsigned_short_get(&slm_at_param_list, 1, &op);
 		if (err < 0) {
 			LOG_ERR("Fail to get op: %d", err);
 			return err;
 		}
-		err = at_params_unsigned_short_get(&at_param_list, 2, &pin);
+		err = at_params_unsigned_short_get(&slm_at_param_list, 2, &pin);
 		if (err < 0) {
 			LOG_ERR("Fail to get pin: %d", err);
 			return err;
@@ -245,7 +239,7 @@ int handle_at_gpio_operate(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		err = at_params_unsigned_short_get(&at_param_list, 1, &op);
+		err = at_params_unsigned_short_get(&slm_at_param_list, 1, &op);
 		if (err < 0) {
 			LOG_ERR("Fail to get OP code: %d", err);
 			return err;
@@ -254,7 +248,7 @@ int handle_at_gpio_operate(enum at_cmd_type cmd_type)
 			LOG_ERR("GPIO OP code is out of range: %d", op);
 			return -EINVAL;
 		}
-		err = at_params_unsigned_short_get(&at_param_list, 2, &pin);
+		err = at_params_unsigned_short_get(&slm_at_param_list, 2, &pin);
 		if (err < 0) {
 			LOG_ERR("Fail to get pin: %d", err);
 			return err;
@@ -264,7 +258,7 @@ int handle_at_gpio_operate(enum at_cmd_type cmd_type)
 			return -EINVAL;
 		}
 		if (op == SLM_GPIO_OP_WRITE) {
-			err = at_params_unsigned_short_get(&at_param_list, 3, &value);
+			err = at_params_unsigned_short_get(&slm_at_param_list, 3, &value);
 			if (err < 0) {
 				LOG_ERR("Fail to get value: %d", err);
 				return err;

--- a/applications/serial_lte_modem/src/lwm2m_carrier/slm_at_carrier.h
+++ b/applications/serial_lte_modem/src/lwm2m_carrier/slm_at_carrier.h
@@ -7,11 +7,16 @@
 #ifndef SLM_AT_CARRIER_
 #define SLM_AT_CARRIER_
 
+#include <stdint.h>
+
 /**@file slm_at_carrier.h
  *
  * @brief Vendor-specific AT command for LwM2M Carrier service.
  * @{
  */
+
+/* Whether to auto-connect to the network at startup or after a FOTA update. */
+extern int32_t slm_carrier_auto_connect;
 
 /**
  * @brief Initialize Carrier AT command parser.

--- a/applications/serial_lte_modem/src/nrfcloud/slm_at_nrfcloud.h
+++ b/applications/serial_lte_modem/src/nrfcloud/slm_at_nrfcloud.h
@@ -18,10 +18,10 @@
 #include <modem/at_cmd_parser.h>
 
 /* Whether the connection to nRF Cloud is ready. */
-extern bool nrf_cloud_ready;
+extern bool slm_nrf_cloud_ready;
 
 /* Whether to send the device's location to nRF Cloud. */
-extern bool nrf_cloud_send_location;
+extern bool slm_nrf_cloud_send_location;
 
 /* Handles the AT#XNRFCLOUD commands. */
 int handle_at_nrf_cloud(enum at_cmd_type cmd_type);

--- a/applications/serial_lte_modem/src/slm_at_cmng.c
+++ b/applications/serial_lte_modem/src/slm_at_cmng.c
@@ -33,9 +33,6 @@ enum slm_cmng_type {
 	AT_CMNG_TYPE_PSK_ID,
 };
 
-/* global variable defined in different files */
-extern struct at_param_list at_param_list;
-
 /**@brief handle AT#XCMNG commands
  *  AT#XCMNG=<opcode>[,<sec_tag>[,<type>[,<content>]]]
  *  AT#XCMNG? READ command not supported
@@ -51,11 +48,11 @@ int handle_at_xcmng(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		if (at_params_valid_count_get(&at_param_list) < 2) {
+		if (at_params_valid_count_get(&slm_at_param_list) < 2) {
 			LOG_ERR("Parameter missed");
 			return -EINVAL;
 		}
-		err = at_params_unsigned_short_get(&at_param_list, 1, &op);
+		err = at_params_unsigned_short_get(&slm_at_param_list, 1, &op);
 		if (err < 0) {
 			LOG_ERR("Fail to get op parameter: %d", err);
 			return err;
@@ -69,12 +66,12 @@ int handle_at_xcmng(enum at_cmd_type cmd_type)
 			LOG_ERR("XCMNG List is not supported");
 			return -EPERM;
 		}
-		if (at_params_valid_count_get(&at_param_list) < 4) {
+		if (at_params_valid_count_get(&slm_at_param_list) < 4) {
 			/* READ, WRITE, DELETE requires sec_tag and type */
 			LOG_ERR("Parameter missed");
 			return -EINVAL;
 		}
-		err = at_params_unsigned_int_get(&at_param_list, 2, &sec_tag);
+		err = at_params_unsigned_int_get(&slm_at_param_list, 2, &sec_tag);
 		if (err < 0) {
 			LOG_ERR("Fail to get sec_tag parameter: %d", err);
 			return err;
@@ -83,19 +80,19 @@ int handle_at_xcmng(enum at_cmd_type cmd_type)
 			LOG_ERR("Invalid security tag: %d", sec_tag);
 			return -EINVAL;
 		}
-		err = at_params_unsigned_short_get(&at_param_list, 3, &type);
+		err = at_params_unsigned_short_get(&slm_at_param_list, 3, &type);
 		if (err < 0) {
 			LOG_ERR("Fail to get type parameter: %d", err);
 			return err;
 		};
 		if (op == AT_CMNG_OP_WRITE) {
-			if (at_params_valid_count_get(&at_param_list) < 5) {
+			if (at_params_valid_count_get(&slm_at_param_list) < 5) {
 				/* WRITE requires sec_tag, type and content */
 				LOG_ERR("Parameter missed");
 				return -EINVAL;
 			}
 			content = k_malloc(SLM_AT_MAX_RSP_LEN);
-			err = util_string_get(&at_param_list, 4, content,
+			err = util_string_get(&slm_at_param_list, 4, content,
 						   &len);
 			if (err != 0) {
 				LOG_ERR("Failed to get content");

--- a/applications/serial_lte_modem/src/slm_at_fota.h
+++ b/applications/serial_lte_modem/src/slm_at_fota.h
@@ -31,10 +31,10 @@ enum fota_status {
 	FOTA_STATUS_CANCELLED
 };
 
-extern uint8_t fota_type;
-extern enum fota_stage fota_stage;
-extern enum fota_status fota_status;
-extern int32_t fota_info;
+extern uint8_t slm_fota_type; /* FOTA image type. */
+extern enum fota_stage slm_fota_stage; /* Current stage of FOTA process. */
+extern enum fota_status slm_fota_status; /* FOTA process status. */
+extern int32_t slm_fota_info; /* FOTA download percentage or failure cause in case of error. */
 
 /**
  * @brief Initialize FOTA AT command parser.

--- a/applications/serial_lte_modem/src/slm_at_host.h
+++ b/applications/serial_lte_modem/src/slm_at_host.h
@@ -23,6 +23,12 @@
 #define SLM_DATAMODE_FLAGS_NONE		0
 #define SLM_DATAMODE_FLAGS_MORE_DATA	1 << 0
 
+extern struct at_param_list slm_at_param_list; /* For AT parser. */
+extern uint8_t slm_data_buf[SLM_MAX_MESSAGE_SIZE];  /* For socket data. */
+extern uint8_t slm_at_buf[SLM_AT_MAX_CMD_LEN]; /* AT command buffer. */
+
+extern uint16_t slm_datamode_time_limit; /* Send trigger by time in data mode. */
+
 /**@brief Operations in datamode. */
 enum slm_datamode_operation {
 	DATAMODE_SEND,  /* Send data in datamode */

--- a/applications/serial_lte_modem/src/slm_at_icmp.c
+++ b/applications/serial_lte_modem/src/slm_at_icmp.c
@@ -38,13 +38,7 @@ static struct ping_argv_t {
 	uint16_t pdn;
 } ping_argv;
 
-/* global variable defined in different files */
-extern struct k_work_q slm_work_q;
-
 static struct k_work ping_work;
-
-/* global variable defined in different files */
-extern struct at_param_list at_param_list;
 
 static inline void setip(uint8_t *buffer, uint32_t ipaddr)
 {
@@ -539,35 +533,36 @@ int handle_at_icmp_ping(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		err = util_string_get(&at_param_list, 1, target, &size);
+		err = util_string_get(&slm_at_param_list, 1, target, &size);
 		if (err < 0) {
 			return err;
 		}
-		err = at_params_unsigned_short_get(&at_param_list, 2, &ping_argv.len);
+		err = at_params_unsigned_short_get(&slm_at_param_list, 2, &ping_argv.len);
 		if (err < 0) {
 			return err;
 		}
-		err = at_params_unsigned_short_get(&at_param_list, 3, &ping_argv.waitms);
+		err = at_params_unsigned_short_get(&slm_at_param_list, 3, &ping_argv.waitms);
 		if (err < 0) {
 			return err;
 		}
 		ping_argv.count = 1; /* default 1 */
-		if (at_params_valid_count_get(&at_param_list) > 4) {
-			err = at_params_unsigned_short_get(&at_param_list, 4, &ping_argv.count);
+		if (at_params_valid_count_get(&slm_at_param_list) > 4) {
+			err = at_params_unsigned_short_get(&slm_at_param_list, 4, &ping_argv.count);
 			if (err < 0) {
 				return err;
 			};
 		}
 		ping_argv.interval = 1000; /* default 1s */
-		if (at_params_valid_count_get(&at_param_list) > 5) {
-			err = at_params_unsigned_short_get(&at_param_list, 5, &ping_argv.interval);
+		if (at_params_valid_count_get(&slm_at_param_list) > 5) {
+			err = at_params_unsigned_short_get(
+				&slm_at_param_list, 5, &ping_argv.interval);
 			if (err < 0) {
 				return err;
 			};
 		}
 		ping_argv.pdn = 0; /* default 0 primary PDN */
-		if (at_params_valid_count_get(&at_param_list) > 6) {
-			err = at_params_unsigned_short_get(&at_param_list, 6, &ping_argv.pdn);
+		if (at_params_valid_count_get(&slm_at_param_list) > 6) {
+			err = at_params_unsigned_short_get(&slm_at_param_list, 6, &ping_argv.pdn);
 			if (err < 0) {
 				return err;
 			};

--- a/applications/serial_lte_modem/src/slm_at_sms.c
+++ b/applications/serial_lte_modem/src/slm_at_sms.c
@@ -24,9 +24,6 @@ enum slm_sms_operation {
 
 static int sms_handle;
 
-/* global variable defined in different files */
-extern struct at_param_list at_param_list;
-
 static void sms_callback(struct sms_data *const data, void *context)
 {
 	static uint16_t ref_number;
@@ -187,7 +184,7 @@ int handle_at_sms(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		err = at_params_unsigned_short_get(&at_param_list, 1, &op);
+		err = at_params_unsigned_short_get(&slm_at_param_list, 1, &op);
 		if (err) {
 			return err;
 		}
@@ -201,12 +198,12 @@ int handle_at_sms(enum at_cmd_type cmd_type)
 			int size;
 
 			size = SMS_MAX_ADDRESS_LEN_CHARS + 1;
-			err = util_string_get(&at_param_list, 2, number, &size);
+			err = util_string_get(&slm_at_param_list, 2, number, &size);
 			if (err) {
 				return err;
 			}
 			size = MAX_CONCATENATED_MESSAGE * SMS_MAX_PAYLOAD_LEN_CHARS;
-			err = util_string_get(&at_param_list, 3, message, &size);
+			err = util_string_get(&slm_at_param_list, 3, message, &size);
 			if (err) {
 				return err;
 			}

--- a/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
@@ -49,10 +49,6 @@ static struct tcp_proxy {
 	enum slm_tcp_role role;	/* Client or Server proxy */
 } proxy;
 
-/* global variable defined in different files */
-extern struct at_param_list at_param_list;
-extern uint8_t data_buf[SLM_MAX_MESSAGE_SIZE];
-
 /** forward declaration of thread function **/
 static void tcpcli_thread_func(void *p1, void *p2, void *p3);
 static void tcpsvr_thread_func(void *p1, void *p2, void *p3);
@@ -543,7 +539,7 @@ client_events:
 			if ((fds[1].revents & POLLIN) != POLLIN) {
 				continue;
 			}
-			ret = recv(fds[1].fd, (void *)data_buf, sizeof(data_buf), 0);
+			ret = recv(fds[1].fd, (void *)slm_data_buf, sizeof(slm_data_buf), 0);
 			if (ret < 0) {
 				LOG_WRN("recv() error: %d", -errno);
 				continue;
@@ -552,10 +548,10 @@ client_events:
 				continue;
 			}
 			if (in_datamode()) {
-				data_send(data_buf, ret);
+				data_send(slm_data_buf, ret);
 			} else {
 				rsp_send("\r\n#XTCPDATA: %d\r\n", ret);
-				data_send(data_buf, ret);
+				data_send(slm_data_buf, ret);
 			}
 		}
 	}
@@ -619,7 +615,7 @@ static void tcpcli_thread_func(void *p1, void *p2, void *p3)
 		if ((fds.revents & POLLIN) != POLLIN) {
 			continue;
 		}
-		ret = recv(fds.fd, (void *)data_buf, sizeof(data_buf), 0);
+		ret = recv(fds.fd, (void *)slm_data_buf, sizeof(slm_data_buf), 0);
 		if (ret < 0) {
 			LOG_WRN("recv() error: %d", -errno);
 			continue;
@@ -628,10 +624,10 @@ static void tcpcli_thread_func(void *p1, void *p2, void *p3)
 			continue;
 		}
 		if (in_datamode()) {
-			data_send(data_buf, ret);
+			data_send(slm_data_buf, ret);
 		} else {
 			rsp_send("\r\n#XTCPDATA: %d\r\n", ret);
-			data_send(data_buf, ret);
+			data_send(slm_data_buf, ret);
 		}
 	}
 
@@ -657,11 +653,11 @@ int handle_at_tcp_server(enum at_cmd_type cmd_type)
 	int err = -EINVAL;
 	uint16_t op;
 	uint16_t port;
-	int param_count = at_params_valid_count_get(&at_param_list);
+	int param_count = at_params_valid_count_get(&slm_at_param_list);
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		err = at_params_unsigned_short_get(&at_param_list, 1, &op);
+		err = at_params_unsigned_short_get(&slm_at_param_list, 1, &op);
 		if (err) {
 			return err;
 		}
@@ -670,13 +666,13 @@ int handle_at_tcp_server(enum at_cmd_type cmd_type)
 				LOG_ERR("Server is running.");
 				return -EINVAL;
 			}
-			err = at_params_unsigned_short_get(&at_param_list, 2, &port);
+			err = at_params_unsigned_short_get(&slm_at_param_list, 2, &port);
 			if (err) {
 				return err;
 			}
 			proxy.sec_tag = INVALID_SEC_TAG;
 			if (param_count > 3) {
-				err = at_params_int_get(&at_param_list, 3, &proxy.sec_tag);
+				err = at_params_int_get(&slm_at_param_list, 3, &proxy.sec_tag);
 				if (err) {
 					return err;
 				}
@@ -715,11 +711,11 @@ int handle_at_tcp_client(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
 	uint16_t op;
-	int param_count = at_params_valid_count_get(&at_param_list);
+	int param_count = at_params_valid_count_get(&slm_at_param_list);
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		err = at_params_unsigned_short_get(&at_param_list, 1, &op);
+		err = at_params_unsigned_short_get(&slm_at_param_list, 1, &op);
 		if (err) {
 			return err;
 		}
@@ -732,17 +728,17 @@ int handle_at_tcp_client(enum at_cmd_type cmd_type)
 				LOG_ERR("Client is connected.");
 				return -EINVAL;
 			}
-			err = util_string_get(&at_param_list, 2, url, &size);
+			err = util_string_get(&slm_at_param_list, 2, url, &size);
 			if (err) {
 				return err;
 			}
-			err = at_params_unsigned_short_get(&at_param_list, 3, &port);
+			err = at_params_unsigned_short_get(&slm_at_param_list, 3, &port);
 			if (err) {
 				return err;
 			}
 			proxy.sec_tag = INVALID_SEC_TAG;
 			if (param_count > 4) {
-				err = at_params_int_get(&at_param_list, 4, &proxy.sec_tag);
+				err = at_params_int_get(&slm_at_param_list, 4, &proxy.sec_tag);
 				if (err) {
 					return err;
 				}
@@ -784,9 +780,9 @@ int handle_at_tcp_send(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		if (at_params_valid_count_get(&at_param_list) > 1) {
+		if (at_params_valid_count_get(&slm_at_param_list) > 1) {
 			size = sizeof(data);
-			err = util_string_get(&at_param_list, 1, data, &size);
+			err = util_string_get(&slm_at_param_list, 1, data, &size);
 			if (err) {
 				return err;
 			}
@@ -818,7 +814,7 @@ int handle_at_tcp_hangup(enum at_cmd_type cmd_type)
 		if (proxy.role != TCP_ROLE_SERVER || proxy.sock_peer == INVALID_SOCKET) {
 			return -EINVAL;
 		}
-		err = at_params_int_get(&at_param_list, 1, &handle);
+		err = at_params_int_get(&slm_at_param_list, 1, &handle);
 		if (err) {
 			return err;
 		}

--- a/applications/serial_lte_modem/src/slm_at_udp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_udp_proxy.c
@@ -55,10 +55,6 @@ static struct udp_proxy {
 	};
 } proxy;
 
-/* global variable defined in different files */
-extern struct at_param_list at_param_list;
-extern uint8_t data_buf[SLM_MAX_MESSAGE_SIZE];
-
 /** forward declaration of thread function **/
 static void udp_thread_func(void *p1, void *p2, void *p3);
 
@@ -415,17 +411,19 @@ static void udp_thread_func(void *p1, void *p2, void *p3)
 				int size = sizeof(struct sockaddr_in);
 
 				memset(&proxy.remote, 0, sizeof(struct sockaddr_in));
-				ret = recvfrom(proxy.sock, (void *)data_buf, sizeof(data_buf), 0,
-					(struct sockaddr *)&(proxy.remote), &size);
+				ret = recvfrom(
+					proxy.sock, (void *)slm_data_buf, sizeof(slm_data_buf),
+					0, (struct sockaddr *)&(proxy.remote), &size);
 			} else {
 				int size = sizeof(struct sockaddr_in6);
 
 				memset(&proxy.remote6, 0, sizeof(struct sockaddr_in6));
-				ret = recvfrom(proxy.sock, (void *)data_buf, sizeof(data_buf), 0,
-					(struct sockaddr *)&(proxy.remote6), &size);
+				ret = recvfrom(
+					proxy.sock, (void *)slm_data_buf, sizeof(slm_data_buf),
+					0, (struct sockaddr *)&(proxy.remote6), &size);
 			}
 		} else {
-			ret = recv(proxy.sock, (void *)data_buf, sizeof(data_buf), 0);
+			ret = recv(proxy.sock, (void *)slm_data_buf, sizeof(slm_data_buf), 0);
 		}
 		if (ret < 0) {
 			LOG_WRN("recv() error: %d", -errno);
@@ -435,10 +433,10 @@ static void udp_thread_func(void *p1, void *p2, void *p3)
 			continue;
 		}
 		if (in_datamode()) {
-			data_send(data_buf, ret);
+			data_send(slm_data_buf, ret);
 		} else {
 			rsp_send("\r\n#XUDPDATA: %d\r\n", ret);
-			data_send(data_buf, ret);
+			data_send(slm_data_buf, ret);
 		}
 	} while (true);
 
@@ -496,7 +494,7 @@ int handle_at_udp_server(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		err = at_params_unsigned_short_get(&at_param_list, 1, &op);
+		err = at_params_unsigned_short_get(&slm_at_param_list, 1, &op);
 		if (err) {
 			return err;
 		}
@@ -504,7 +502,7 @@ int handle_at_udp_server(enum at_cmd_type cmd_type)
 			if (socket_is_in_use()) {
 				return -EINVAL;
 			}
-			err = at_params_unsigned_short_get(&at_param_list, 2, &port);
+			err = at_params_unsigned_short_get(&slm_at_param_list, 2, &port);
 			if (err) {
 				return err;
 			}
@@ -540,7 +538,7 @@ int handle_at_udp_client(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		err = at_params_unsigned_short_get(&at_param_list, 1, &op);
+		err = at_params_unsigned_short_get(&slm_at_param_list, 1, &op);
 		if (err) {
 			return err;
 		}
@@ -552,25 +550,26 @@ int handle_at_udp_client(enum at_cmd_type cmd_type)
 			if (socket_is_in_use()) {
 				return -EINVAL;
 			}
-			err = util_string_get(&at_param_list, 2, url, &size);
+			err = util_string_get(&slm_at_param_list, 2, url, &size);
 			if (err) {
 				return err;
 			}
-			err = at_params_unsigned_short_get(&at_param_list, 3, &port);
+			err = at_params_unsigned_short_get(&slm_at_param_list, 3, &port);
 			if (err) {
 				return err;
 			}
 			proxy.sec_tag = INVALID_SEC_TAG;
 			proxy.dtls_cid = INVALID_DTLS_CID;
-			const uint32_t param_count = at_params_valid_count_get(&at_param_list);
+			const uint32_t param_count = at_params_valid_count_get(&slm_at_param_list);
 
 			if (param_count > 4) {
-				if (at_params_int_get(&at_param_list, 4, &proxy.sec_tag)
+				if (at_params_int_get(&slm_at_param_list, 4, &proxy.sec_tag)
 				|| proxy.sec_tag == INVALID_SEC_TAG || proxy.sec_tag < 0) {
 					return -EINVAL;
 				}
 				if (param_count > 5) {
-					if (at_params_int_get(&at_param_list, 5, &proxy.dtls_cid)
+					if (at_params_int_get(
+						&slm_at_param_list, 5, &proxy.dtls_cid)
 					|| !(proxy.dtls_cid == TLS_DTLS_CID_DISABLED
 						|| proxy.dtls_cid == TLS_DTLS_CID_SUPPORTED
 						|| proxy.dtls_cid == TLS_DTLS_CID_ENABLED)) {
@@ -615,9 +614,9 @@ int handle_at_udp_send(enum at_cmd_type cmd_type)
 			LOG_ERR("Not connected yet");
 			return -ENOTCONN;
 		}
-		if (at_params_valid_count_get(&at_param_list) > 1) {
+		if (at_params_valid_count_get(&slm_at_param_list) > 1) {
 			size = sizeof(data);
-			err = util_string_get(&at_param_list, 1, data, &size);
+			err = util_string_get(&slm_at_param_list, 1, data, &size);
 			if (err) {
 				return err;
 			}

--- a/applications/serial_lte_modem/src/slm_uart_handler.c
+++ b/applications/serial_lte_modem/src/slm_uart_handler.c
@@ -399,9 +399,9 @@ int slm_uart_handler_init(slm_uart_rx_callback_t callback_t)
 		LOG_ERR("UART device not ready");
 		return -ENODEV;
 	}
-	if (!uart_configured) {
+	if (!slm_uart_configured) {
 		/* Save UART configuration to settings page */
-		uart_configured = true;
+		slm_uart_configured = true;
 		err = uart_config_get(uart_dev, &slm_uart);
 		if (err != 0) {
 			LOG_ERR("uart_config_get: %d", err);

--- a/applications/serial_lte_modem/src/slm_uart_handler.h
+++ b/applications/serial_lte_modem/src/slm_uart_handler.h
@@ -16,8 +16,8 @@
 
 #define HEXDUMP_LIMIT		16
 
-extern bool uart_configured;
-extern struct uart_config slm_uart;
+extern bool slm_uart_configured; /* UART: first-time configured */
+extern struct uart_config slm_uart; /* UART: config */
 
 /**@brief UART RX data callback type.
  *

--- a/applications/serial_lte_modem/src/slm_util.c
+++ b/applications/serial_lte_modem/src/slm_util.c
@@ -12,9 +12,6 @@
 
 LOG_LEVEL_SET(CONFIG_SLM_LOG_LEVEL);
 
-/* global variable defined in different files */
-extern struct at_param_list at_param_list;
-
 /**
  * @brief Compare string ignoring case
  */

--- a/applications/serial_lte_modem/src/slm_util.h
+++ b/applications/serial_lte_modem/src/slm_util.h
@@ -19,6 +19,8 @@
 #include <zephyr/net/socket.h>
 #include <modem/at_cmd_parser.h>
 
+extern struct k_work_q slm_work_q; /* SLM's work queue. */
+
 /**
  * @brief Compare string ignoring case
  *

--- a/applications/serial_lte_modem/src/twi/slm_at_twi.c
+++ b/applications/serial_lte_modem/src/twi/slm_at_twi.c
@@ -30,9 +30,6 @@ static const struct device *slm_twi_dev[] = {
 static uint8_t twi_data[TWI_DATA_LEN * 2 + 1];
 static char rsp_buf[256];
 
-/* global variable defined in different files */
-extern struct at_param_list at_param_list;
-
 static void do_twi_list(void)
 {
 	memset(rsp_buf, 0, sizeof(rsp_buf));
@@ -185,17 +182,17 @@ int handle_at_twi_write(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		if (at_params_valid_count_get(&at_param_list) != 4) {
+		if (at_params_valid_count_get(&slm_at_param_list) != 4) {
 			LOG_ERR("Wrong input parameters");
 			return -EINVAL;
 		}
-		err = at_params_unsigned_short_get(&at_param_list, 1, &index);
+		err = at_params_unsigned_short_get(&slm_at_param_list, 1, &index);
 		if (err < 0) {
 			LOG_ERR("Fail to get twi index: %d", err);
 			return err;
 		}
 		ascii_len = TWI_ADDR_LEN + 1;
-		err = util_string_get(&at_param_list, 2, twi_addr_ascii, &ascii_len);
+		err = util_string_get(&slm_at_param_list, 2, twi_addr_ascii, &ascii_len);
 		if (err < 0) {
 			LOG_ERR("Fail to get device address");
 			return err;
@@ -203,7 +200,7 @@ int handle_at_twi_write(enum at_cmd_type cmd_type)
 		sscanf(twi_addr_ascii, "%hx", &dev_addr);
 		LOG_DBG("dev_addr: %hx", dev_addr);
 		ascii_len = sizeof(twi_data);
-		err = util_string_get(&at_param_list, 3, twi_data, &ascii_len);
+		err = util_string_get(&slm_at_param_list, 3, twi_data, &ascii_len);
 		if (err) {
 			return err;
 		}
@@ -235,20 +232,20 @@ int handle_at_twi_read(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		err = at_params_unsigned_short_get(&at_param_list, 1, &index);
+		err = at_params_unsigned_short_get(&slm_at_param_list, 1, &index);
 		if (err < 0) {
 			LOG_ERR("Fail to get twi index: %d", err);
 			return err;
 		}
 		ascii_len = TWI_ADDR_LEN + 1;
-		err = util_string_get(&at_param_list, 2, twi_addr_ascii, &ascii_len);
+		err = util_string_get(&slm_at_param_list, 2, twi_addr_ascii, &ascii_len);
 		if (err < 0) {
 			LOG_ERR("Fail to get device address: %d", err);
 			return err;
 		}
 		sscanf(twi_addr_ascii, "%hx", &dev_addr);
 		LOG_DBG("dev_addr: %hx", dev_addr);
-		err = at_params_unsigned_short_get(&at_param_list, 3, &num_read);
+		err = at_params_unsigned_short_get(&slm_at_param_list, 3, &num_read);
 		if (err < 0) {
 			LOG_ERR("Fail to get bytes to read: %d", err);
 			return err;
@@ -287,13 +284,13 @@ int handle_at_twi_write_read(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		err = at_params_unsigned_short_get(&at_param_list, 1, &index);
+		err = at_params_unsigned_short_get(&slm_at_param_list, 1, &index);
 		if (err < 0) {
 			LOG_ERR("Fail to get twi index: %d", err);
 			return err;
 		}
 		ascii_len = TWI_ADDR_LEN + 1;
-		err = util_string_get(&at_param_list, 2, twi_addr_ascii, &ascii_len);
+		err = util_string_get(&slm_at_param_list, 2, twi_addr_ascii, &ascii_len);
 		if (err < 0) {
 			LOG_ERR("Fail to get device address");
 			return err;
@@ -301,12 +298,12 @@ int handle_at_twi_write_read(enum at_cmd_type cmd_type)
 		sscanf(twi_addr_ascii, "%hx", &dev_addr);
 		LOG_DBG("dev_addr: %hx", dev_addr);
 		ascii_len = sizeof(twi_data);
-		err = util_string_get(&at_param_list, 3, twi_data, &ascii_len);
+		err = util_string_get(&slm_at_param_list, 3, twi_data, &ascii_len);
 		if (err) {
 			return err;
 		}
 		LOG_DBG("Data to write: %s", (char *)twi_data);
-		err = at_params_unsigned_short_get(&at_param_list, 4, &num_read);
+		err = at_params_unsigned_short_get(&slm_at_param_list, 4, &num_read);
 		if (err < 0) {
 			LOG_ERR("Fail to get twi index: %d", err);
 			return err;


### PR DESCRIPTION
Also, declare them only once, in header files.
No more of this "global variable defined in different files".