### PR TITLE
manifest: Update sdk-zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: c7094146b5b47fd4da05ed773e0128e2e6a634e1
+      revision: 96a0d4e857edbbb03a336cbb06c027355bfb75fc
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Revision updated to 96a0d4e857edbbb03a336cbb06c027355bfb75fc

Somebody tries to make me unhappy and left the sdk-zephyr behind.