### PR TITLE
applications: serial_lte_modem: unify AT command handler comments

### DIFF
--- a/applications/serial_lte_modem/src/ftp_c/slm_at_tftp.c
+++ b/applications/serial_lte_modem/src/ftp_c/slm_at_tftp.c
@@ -130,11 +130,7 @@ static int do_tftp_put(int family, const char *server, uint16_t port, const char
 	return ret;
 }
 
-/**@brief handle AT#XTFTP commands
- *  AT#XTFTP=<op>,<url>,<port>,<file_path>[,<mode>,<data>]
- *  AT#XTFTP? READ is not supported
- *  AT#XTFTP=?
- */
+/* Handles AT#XTFTP commands. */
 int handle_at_tftp(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;

--- a/applications/serial_lte_modem/src/gnss/slm_at_gnss.c
+++ b/applications/serial_lte_modem/src/gnss/slm_at_gnss.c
@@ -481,11 +481,7 @@ static void gnss_event_handler(int event)
 	}
 }
 
-/**@brief handle AT#XGPS commands
- *  AT#XGPS=<op>[,<interval>[,<timeout>]]
- *  AT#XGPS?
- *  AT#XGPS=?
- */
+/* Handles AT#XGPS commands. */
 int handle_at_gps(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
@@ -559,11 +555,7 @@ static void gps_sec_to_day_time(int64_t gps_sec, uint16_t *gps_day, uint32_t *gp
 	*gps_time_of_day = (uint32_t)(gps_sec % SEC_PER_DAY);
 }
 
-/**@brief handle AT#XAGPS commands
- *  AT#XAGPS=<op>[,<interval>[,<timeout>]]
- *  AT#XAGPS?
- *  AT#XAGPS=?
- */
+/* Handles AT#XAGPS commands. */
 int handle_at_agps(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
@@ -666,11 +658,7 @@ int handle_at_agps(enum at_cmd_type cmd_type)
 #endif /* CONFIG_NRF_CLOUD_AGPS */
 
 #if defined(CONFIG_SLM_NRF_CLOUD) && defined(CONFIG_NRF_CLOUD_PGPS)
-/**@brief handle AT#XPGPS commands
- *  AT#XPGPS=<op>[,<interval>[,<timeout>]]
- *  AT#XPGPS?
- *  AT#XPGPS=?
- */
+/* Handles AT#XPGPS commands. */
 int handle_at_pgps(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
@@ -752,11 +740,7 @@ int handle_at_pgps(enum at_cmd_type cmd_type)
 }
 #endif /* CONFIG_NRF_CLOUD_PGPS */
 
-/**@brief handle AT#XGPSDEL commands
- *  AT#XGPSDEL=<mask>
- *  AT#XGPSDEL? READ command not supported
- *  AT#XGPSDEL=?
- */
+/* Handles AT#XGPSDEL commands. */
 int handle_at_gps_delete(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;

--- a/applications/serial_lte_modem/src/gpio/slm_at_gpio.c
+++ b/applications/serial_lte_modem/src/gpio/slm_at_gpio.c
@@ -192,11 +192,7 @@ static int do_gpio_pin_operate(uint16_t op, gpio_pin_t pin, uint16_t value)
 	return 0;
 }
 
-/**@brief handle AT#XGPIOCFG commands
- *  AT#XGPIOCFG=<op>,<pin>
- *  AT#XGPIOCFG?
- *  AT#XGPIOCFG=? Test command not supported
- */
+/* Handles AT#XGPIOCFG commands. */
 int handle_at_gpio_configure(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
@@ -227,11 +223,7 @@ int handle_at_gpio_configure(enum at_cmd_type cmd_type)
 	return err;
 }
 
-/**@brief handle AT#XGPIO commands
- *  AT#XGPIO=<pin>,<op>[,<value>]
- *  AT#XGPIO? READ command not supported
- *  AT#XGPIO=? TEST command not supported
- */
+/* Handles AT#XGPIO command. */
 int handle_at_gpio_operate(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;

--- a/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
+++ b/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
@@ -412,11 +412,7 @@ static int do_http_request(void)
 	return err;
 }
 
-/**@brief handle AT#XHTTPCCON commands
- *  AT#XHTTPCCON=<op>[,<host>,<port>[,<sec_tag>]]
- *  AT#XHTTPCCON? READ command not supported
- *  AT#XHTTPCCON=?
- */
+/* Handles AT#XHTTPCCON commands. */
 int handle_at_httpc_connect(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
@@ -545,12 +541,7 @@ static int http_headers_preprocess(size_t size)
 	return 0;
 }
 
-/**@brief handle AT#XHTTPCREQ commands
- *  AT#XHTTPCREQ=<method>,<resource>[,<headers>[,<content_type>,<content_length>
- *    [,<chunked_transfer>]]]
- *  AT#XHTTPCREQ? READ command not supported
- *  AT#XHTTPCREQ=?
- */
+/* Handles AT#XHTTPCREQ commands. */
 int handle_at_httpc_request(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;

--- a/applications/serial_lte_modem/src/mqtt_c/slm_at_mqtt.c
+++ b/applications/serial_lte_modem/src/mqtt_c/slm_at_mqtt.c
@@ -433,11 +433,7 @@ static int do_mqtt_subscribe(uint16_t op,
 	return err;
 }
 
-/**@brief handle AT#XMQTTCON commands
- *  AT#XMQTTCON=<op>[,<cid>,<username>,<password>,<url>,<port>[,<sec_tag>]]
- *  AT#XMQTTCON?
- *  AT#XMQTTCON=?
- */
+/* Handles AT#XMQTTCON commands. */
 int handle_at_mqtt_connect(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
@@ -543,11 +539,7 @@ static int mqtt_datamode_callback(uint8_t op, const uint8_t *data, int len, uint
 	return ret;
 }
 
-/**@brief handle AT#XMQTTPUB commands
- *  AT#XMQTTPUB=<topic>[,<msg>[,<qos>[,<retain>]]]
- *  AT#XMQTTPUB? READ command not supported
- *  AT#XMQTTPUB=?
- */
+/* Handles AT#XMQTTPUB commands. */
 int handle_at_mqtt_publish(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
@@ -623,11 +615,7 @@ int handle_at_mqtt_publish(enum at_cmd_type cmd_type)
 	return err;
 }
 
-/**@brief handle AT#XMQTTSUB commands
- *  AT#XMQTTSUB=<topic>,<qos>
- *  AT#XMQTTSUB? READ command not supported
- *  AT#XMQTTSUB=?
- */
+/* Handles AT#XMQTTSUB commands. */
 int handle_at_mqtt_subscribe(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
@@ -664,11 +652,7 @@ int handle_at_mqtt_subscribe(enum at_cmd_type cmd_type)
 	return err;
 }
 
-/**@brief handle AT#XMQTTUNSUB commands
- *  AT#XMQTTUNSUB=<topic>
- *  AT#XMQTTUNSUB? READ command not supported
- *  AT#XMQTTUNSUB=?
- */
+/* Handles AT#XMQTTUNSUB commands. */
 int handle_at_mqtt_unsubscribe(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;

--- a/applications/serial_lte_modem/src/slm_at_cmng.c
+++ b/applications/serial_lte_modem/src/slm_at_cmng.c
@@ -33,11 +33,7 @@ enum slm_cmng_type {
 	AT_CMNG_TYPE_PSK_ID,
 };
 
-/**@brief handle AT#XCMNG commands
- *  AT#XCMNG=<opcode>[,<sec_tag>[,<type>[,<content>]]]
- *  AT#XCMNG? READ command not supported
- *  AT#XCMNG=? READ command not supported
- */
+/* Handles AT#XCMNG command. */
 int handle_at_xcmng(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;

--- a/applications/serial_lte_modem/src/slm_at_commands.c
+++ b/applications/serial_lte_modem/src/slm_at_commands.c
@@ -109,11 +109,7 @@ static void modem_power_off(void)
 	}
 }
 
-/** @brief Handles AT#XSLMVER command.
- *  AT#XSLMVER
- *  AT#XSLMVER? not supported
- *  AT#XSLMVER=? not supported
- */
+/* Handles AT#XSLMVER command. */
 static int handle_at_slmver(enum at_cmd_type type)
 {
 	int ret = -EINVAL;
@@ -151,11 +147,7 @@ static void go_sleep_wk(struct k_work *work)
 	}
 }
 
-/** @brief Handles AT#XSLEEP commands.
- *  AT#XSLEEP=<sleep_mode>
- *  AT#XSLEEP? not supported
- *  AT#XSLEEP=?
- */
+/* Handles AT#XSLEEP commands. */
 static int handle_at_sleep(enum at_cmd_type type)
 {
 	int ret = -EINVAL;
@@ -178,11 +170,7 @@ static int handle_at_sleep(enum at_cmd_type type)
 	return ret;
 }
 
-/** @brief Handles AT#XSHUTDOWN command.
- *  AT#XSHUTDOWN
- *  AT#XSHUTDOWN? not supported
- *  AT#XSHUTDOWN=? not supported
- */
+/* Handles AT#XSHUTDOWN command. */
 static int handle_at_shutdown(enum at_cmd_type type)
 {
 	int ret = -EINVAL;
@@ -198,11 +186,7 @@ static int handle_at_shutdown(enum at_cmd_type type)
 	return ret;
 }
 
-/** @brief Handles AT#XRESET command.
- *  AT#XRESET
- *  AT#XRESET? not supported
- *  AT#XRESET=? not supported
- */
+/* Handles AT#XRESET command. */
 static int handle_at_reset(enum at_cmd_type type)
 {
 	int ret = -EINVAL;
@@ -219,11 +203,7 @@ static int handle_at_reset(enum at_cmd_type type)
 	return ret;
 }
 
-/** @brief Handles AT#XMODEMRESET command.
- *  AT#XMODEMRESET
- *  AT#XMODEMRESET? not supported
- *  AT#XMODEMRESET=? not supported
- */
+/* Handles AT#XMODEMRESET command. */
 static int handle_at_modemreset(enum at_cmd_type type)
 {
 	if (type != AT_CMD_TYPE_SET_COMMAND) {
@@ -265,11 +245,7 @@ static int handle_at_modemreset(enum at_cmd_type type)
 	return 0;
 }
 
-/** @brief Handles AT#XUUID command.
- *  AT#XUUID
- *  AT#XUUID? not supported
- *  AT#XUUID=? not supported
- */
+/* Handles AT#XUUID command. */
 static int handle_at_uuid(enum at_cmd_type type)
 {
 	int ret;
@@ -305,11 +281,7 @@ static void set_uart_wk(struct k_work *work)
 	}
 }
 
-/** @brief Handles AT#XSLMUART commands.
- *  AT#XSLMUART[=<baud_rate>]
- *  AT#XSLMUART?
- *  AT#XSLMUART=?
- */
+/* Handles AT#XSLMUART commands. */
 static int handle_at_slmuart(enum at_cmd_type type)
 {
 	int ret = -EINVAL;
@@ -359,11 +331,7 @@ static int handle_at_slmuart(enum at_cmd_type type)
 	return ret;
 }
 
-/** @brief Handles AT#XDATACTRL commands.
- *  AT#XDATACTRL=<time_limit>
- *  AT#XDATACTRL?
- *  AT#XDATACTRL=?
- */
+/* Handles AT#XDATACTRL commands. */
 static int handle_at_datactrl(enum at_cmd_type cmd_type)
 {
 	int ret = 0;
@@ -398,11 +366,6 @@ static int handle_at_datactrl(enum at_cmd_type cmd_type)
 	return ret;
 }
 
-/** @brief Handles AT#XCLAC command.
- *  AT#XCLAC
- *  AT#XCLAC? not supported
- *  AT#XCLAC=? not supported
- */
 int handle_at_clac(enum at_cmd_type cmd_type);
 
 /* TCP proxy commands */
@@ -609,6 +572,7 @@ static struct slm_at_cmd {
 
 };
 
+/* Handles AT#XCLAC command. */
 int handle_at_clac(enum at_cmd_type cmd_type)
 {
 	int ret = -EINVAL;

--- a/applications/serial_lte_modem/src/slm_at_fota.c
+++ b/applications/serial_lte_modem/src/slm_at_fota.c
@@ -259,11 +259,7 @@ static void fota_dl_handler(const struct fota_download_evt *evt)
 	}
 }
 
-/** @brief Handles AT#XFOTA commands.
- *  AT#XFOTA=<op>[,<file_url>[,<sec_tag>[,<pdn_id>]]]
- *  AT#XFOTA? TEST command not supported
- *  AT#XFOTA=?
- */
+/* Handles AT#XFOTA commands. */
 int handle_at_fota(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;

--- a/applications/serial_lte_modem/src/slm_at_icmp.c
+++ b/applications/serial_lte_modem/src/slm_at_icmp.c
@@ -520,11 +520,7 @@ static int ping_test_handler(const char *target)
 	return 0;
 }
 
-/**@brief handle AT#XPING commands
- *  AT#XPING=<url>,<length>,<timeout>[,<count>[,<interval>[,<pdn>]]]
- *  AT#XPING? READ command not supported
- *  AT#XPING=? TEST command not supported
- */
+/* Handles AT#XPING command. */
 int handle_at_icmp_ping(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;

--- a/applications/serial_lte_modem/src/slm_at_sms.c
+++ b/applications/serial_lte_modem/src/slm_at_sms.c
@@ -172,11 +172,7 @@ static int do_sms_send(const char *number, const char *message)
 }
 
 
-/**@brief handle AT#XSMS commands
- *  AT#XSMS=<op>,[<number>,<message>]
- *  AT#XSMS? READ command not supported
- *  AT#XSMS=?
- */
+/* Handles AT#XSMS commands. */
 int handle_at_sms(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;

--- a/applications/serial_lte_modem/src/slm_at_socket.c
+++ b/applications/serial_lte_modem/src/slm_at_socket.c
@@ -963,11 +963,7 @@ static int socket_datamode_callback(uint8_t op, const uint8_t *data, int len, ui
 	return ret;
 }
 
-/**@brief handle AT#XSOCKET commands
- *  AT#XSOCKET=<op>[,<type>,<role>[,<cid>]]
- *  AT#XSOCKET?
- *  AT#XSOCKET=?
- */
+/* Handles AT#XSOCKET commands. */
 int handle_at_socket(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
@@ -1034,11 +1030,7 @@ int handle_at_socket(enum at_cmd_type cmd_type)
 	return err;
 }
 
-/**@brief handle AT#XSOCKET commands
- *  AT#XSSOCKET=<op>[,<type>,<role>,<sec_tag>[,<peer_verify>[,<cid>]]]
- *  AT#XSSOCKET?
- *  AT#XSSOCKET=?
- */
+/* Handles AT#XSOCKET commands. */
 int handle_at_secure_socket(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
@@ -1133,11 +1125,7 @@ int handle_at_secure_socket(enum at_cmd_type cmd_type)
 	return err;
 }
 
-/**@brief handle AT#XSOCKETSELECT commands
- *  AT#XSOCKETSELECT=<fd>
- *  AT#XSOCKETSELECT?
- *  AT#XSOCKETSELECT=?
- */
+/* Handles AT#XSOCKETSELECT commands. */
 int handle_at_socket_select(enum at_cmd_type cmd_type)
 {
 	int err = 0;
@@ -1184,11 +1172,7 @@ int handle_at_socket_select(enum at_cmd_type cmd_type)
 
 }
 
-/**@brief handle AT#XSOCKETOPT commands
- *  AT#XSOCKETOPT=<op>,<name>[,<value>]
- *  AT#XSOCKETOPT? READ command not supported
- *  AT#XSOCKETOPT=?
- */
+/* Handles AT#XSOCKETOPT commands. */
 int handle_at_socketopt(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
@@ -1232,11 +1216,7 @@ int handle_at_socketopt(enum at_cmd_type cmd_type)
 	return err;
 }
 
-/**@brief handle AT#XSSOCKETOPT commands
- *  AT#XSSOCKETOPT=<op>,<name>[,<value>]
- *  AT#XSSOCKETOPT? READ command not supported
- *  AT#XSSOCKETOPT=?
- */
+/* Handles AT#XSSOCKETOPT commands. */
 int handle_at_secure_socketopt(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
@@ -1296,11 +1276,7 @@ int handle_at_secure_socketopt(enum at_cmd_type cmd_type)
 	return err;
 }
 
-/**@brief handle AT#XBIND commands
- *  AT#XBIND=<port>
- *  AT#XBIND?
- *  AT#XBIND=? TEST command not supported
- */
+/* Handles AT#XBIND commands. */
 int handle_at_bind(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
@@ -1322,11 +1298,7 @@ int handle_at_bind(enum at_cmd_type cmd_type)
 	return err;
 }
 
-/**@brief handle AT#XCONNECT commands
- *  AT#XCONNECT=<url>,<port>
- *  AT#XCONNECT?
- *  AT#XCONNECT=? TEST command not supported
- */
+/* Handles AT#XCONNECT commands. */
 int handle_at_connect(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
@@ -1359,11 +1331,7 @@ int handle_at_connect(enum at_cmd_type cmd_type)
 	return err;
 }
 
-/**@brief handle AT#XLISTEN commands
- *  AT#XLISTEN
- *  AT#XLISTEN? READ command not supported
- *  AT#XLISTEN=? TEST command not supported
- */
+/* Handles AT#XLISTEN commands. */
 int handle_at_listen(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
@@ -1385,11 +1353,7 @@ int handle_at_listen(enum at_cmd_type cmd_type)
 	return err;
 }
 
-/**@brief handle AT#XACCEPT commands
- *  AT#XACCEPT=<timeout>
- *  AT#XACCEPT? READ command not supported
- *  AT#XACCEPT=? TEST command not supported
- */
+/* Handles AT#XACCEPT command. */
 int handle_at_accept(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
@@ -1425,11 +1389,7 @@ int handle_at_accept(enum at_cmd_type cmd_type)
 	return err;
 }
 
-/**@brief handle AT#XSEND commands
- *  AT#XSEND[=<data>]
- *  AT#XSEND? READ command not supported
- *  AT#XSEND=? TEST command not supported
- */
+/* Handles AT#XSEND command. */
 int handle_at_send(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
@@ -1457,11 +1417,7 @@ int handle_at_send(enum at_cmd_type cmd_type)
 	return err;
 }
 
-/**@brief handle AT#XRECV commands
- *  AT#XRECV=<timeout>
- *  AT#XRECV? READ command not supported
- *  AT#XRECV=? TEST command not supported
- */
+/* Handles AT#XRECV command. */
 int handle_at_recv(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
@@ -1490,11 +1446,7 @@ int handle_at_recv(enum at_cmd_type cmd_type)
 	return err;
 }
 
-/**@brief handle AT#XSENDTO commands
- *  AT#XSENDTO=<url>,<port>[<data>]
- *  AT#XSENDTO? READ command not supported
- *  AT#XSENDTO=? TEST command not supported
- */
+/* Handles AT#XSENDTO command. */
 int handle_at_sendto(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
@@ -1532,11 +1484,7 @@ int handle_at_sendto(enum at_cmd_type cmd_type)
 	return err;
 }
 
-/**@brief handle AT#XRECVFROM commands
- *  AT#XRECVFROM=<timeout>[,<flags>]
- *  AT#XRECVFROM? READ command not supported
- *  AT#XRECVFROM=? TEST command not supported
- */
+/* Handles AT#XRECVFROM command. */
 int handle_at_recvfrom(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
@@ -1565,11 +1513,7 @@ int handle_at_recvfrom(enum at_cmd_type cmd_type)
 	return err;
 }
 
-/**@brief handle AT#XGETADDRINFO commands
- *  AT#XGETADDRINFO=<url>
- *  AT#XGETADDRINFO? READ command not supported
- *  AT#XGETADDRINFO=? TEST command not supported
- */
+/* Handles AT#XGETADDRINFO command. */
 int handle_at_getaddrinfo(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
@@ -1627,11 +1571,7 @@ int handle_at_getaddrinfo(enum at_cmd_type cmd_type)
 	return err;
 }
 
-/**@brief handle AT#XPOLL commands
- *  AT#XPOLL=<timeout>[,<handle1>[,<handle2> ...<handle8>]
- *  AT#XPOLL? READ command not support
- *  AT#XPOLL=? TEST command not support
- */
+/* Handles AT#XPOLL command. */
 int handle_at_poll(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;

--- a/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
@@ -643,11 +643,7 @@ static void tcpcli_thread_func(void *p1, void *p2, void *p3)
 	LOG_INF("TCP client thread terminated");
 }
 
-/**@brief handle AT#XTCPSVR commands
- *  AT#XTCPSVR=<op>[,<port>[,[sec_tag]]
- *  AT#XTCPSVR?
- *  AT#XTCPSVR=?
- */
+/* Handles AT#XTCPSVR commands. */
 int handle_at_tcp_server(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
@@ -702,11 +698,7 @@ int handle_at_tcp_server(enum at_cmd_type cmd_type)
 	return err;
 }
 
-/**@brief handle AT#XTCPCLI commands
- *  AT#XTCPCLI=<op>[,<url>,<port>[,[sec_tag]]
- *  AT#XTCPCLI?
- *  AT#XTCPCLI=?
- */
+/* Handles AT#XTCPCLI commands. */
 int handle_at_tcp_client(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
@@ -767,11 +759,7 @@ int handle_at_tcp_client(enum at_cmd_type cmd_type)
 	return err;
 }
 
-/**@brief handle AT#XTCPSEND commands
- *  AT#XTCPSEND[=<data>]
- *  AT#XTCPSEND? READ command not supported
- *  AT#XTCPSEND=? TEST command not supported
- */
+/* Handles AT#XTCPSEND command. */
 int handle_at_tcp_send(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
@@ -799,11 +787,7 @@ int handle_at_tcp_send(enum at_cmd_type cmd_type)
 	return err;
 }
 
-/**@brief handle AT#XTCPHANGUP commands
- *  AT#XTCPHANGUP=<handle>
- *  AT#XTCPHANGUP? READ command not supported
- *  AT#XTCPHANGUP=?
- */
+/* Handles AT#XTCPHANGUP commands. */
 int handle_at_tcp_hangup(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;

--- a/applications/serial_lte_modem/src/twi/slm_at_twi.c
+++ b/applications/serial_lte_modem/src/twi/slm_at_twi.c
@@ -146,11 +146,7 @@ static int do_twi_write_read(uint16_t index, uint16_t dev_addr, const uint8_t *t
 	return ret;
 }
 
-/**@brief handle AT#XTWILS commands
- *  AT#XTWILS
- *  AT#XTWILS? READ command not supported
- *  AT#XTWILS=? TEST command not supported
- */
+/* Handles AT#XTWILS command. */
 int handle_at_twi_list(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
@@ -168,11 +164,7 @@ int handle_at_twi_list(enum at_cmd_type cmd_type)
 	return err;
 }
 
-/**@brief handle AT#XTWIW commands
- *  AT#XTWIW=<index>,<dev_addr>,<data>
- *  AT#XTWIW? READ command not supported
- *  AT#XTWIW=?
- */
+/* Handles AT#XTWIW commands. */
 int handle_at_twi_write(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
@@ -218,11 +210,7 @@ int handle_at_twi_write(enum at_cmd_type cmd_type)
 	return err;
 }
 
-/**@brief handle AT#XTWIR commands
- *  AT#XTWIR=<index>,<dev_addr>,<num_read>
- *  AT#XTWIR? READ command not supported
- *  AT#XTWIR=?
- */
+/* Handles AT#XTWIR commands. */
 int handle_at_twi_read(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
@@ -270,11 +258,7 @@ int handle_at_twi_read(enum at_cmd_type cmd_type)
 	return err;
 }
 
-/**@brief handle AT#XTWIWR commands
- *  AT#XTWIWR=<index>,<dev_addr>,<data>,<num_read>
- *  AT#XTWIWR? READ command not supported
- *  AT#XTWIWR=?
- */
+/* Handles AT#XTWIWR commands. */
 int handle_at_twi_write_read(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;


### PR DESCRIPTION
They now contain only the command name and whether one or more (set/read/test) commands are supported (using plural).