### PR TITLE
scripts: Fix cryptography python package minimum version requirement

### DIFF
--- a/scripts/requirements-build.txt
+++ b/scripts/requirements-build.txt
@@ -1,7 +1,7 @@
 cbor2>=5.4.2.post1
 clang-format
 ecdsa
-cryptography
+cryptography>=35.0.0
 imagesize>=1.2.0
 intelhex
 pylint


### PR DESCRIPTION
Fix cryptography python package minimum version requirement. scripts/bootloader/keygen.py uses a function in a way that does not work with older versions, e.g. 2.8.0, where the generate_private_key has a required 'backend' argument.

Fails with the following message:
key = ec.generate_private_key(ec.SECP256R1())
TypeError: generate_private_key() missing 1 required positional argument: 'backend'.