### PR TITLE
applications: Improved handling states in Matter Bridge

### DIFF
--- a/applications/matter_bridge/src/bridged_device_types/humidity_sensor.cpp
+++ b/applications/matter_bridge/src/bridged_device_types/humidity_sensor.cpp
@@ -100,50 +100,58 @@ CHIP_ERROR HumiditySensorDevice::HandleReadRelativeHumidityMeasurement(Attribute
 CHIP_ERROR HumiditySensorDevice::HandleAttributeChange(chip::ClusterId clusterId, chip::AttributeId attributeId,
 						       void *data, size_t dataSize)
 {
-	if (clusterId != Clusters::RelativeHumidityMeasurement::Id || !data) {
+	CHIP_ERROR err = CHIP_NO_ERROR;
+	if (!data) {
 		return CHIP_ERROR_INVALID_ARGUMENT;
 	}
 
-	CHIP_ERROR err;
+	switch (clusterId) {
+	case Clusters::BridgedDeviceBasicInformation::Id:
+		return HandleWriteDeviceBasicInformation(clusterId, attributeId, data, dataSize);
+	case Clusters::RelativeHumidityMeasurement::Id: {
+		switch (attributeId) {
+		case Clusters::RelativeHumidityMeasurement::Attributes::MeasuredValue::Id: {
+			int16_t value;
 
-	switch (attributeId) {
-	case Clusters::RelativeHumidityMeasurement::Attributes::MeasuredValue::Id: {
-		int16_t value;
+			err = CopyAttribute(data, dataSize, &value, sizeof(value));
 
-		err = CopyAttribute(data, dataSize, &value, sizeof(value));
+			if (err != CHIP_NO_ERROR) {
+				return err;
+			}
 
-		if (err != CHIP_NO_ERROR) {
-			return err;
+			SetMeasuredValue(value);
+
+			break;
 		}
+		case Clusters::RelativeHumidityMeasurement::Attributes::MinMeasuredValue::Id: {
+			int16_t value;
 
-		SetMeasuredValue(value);
+			err = CopyAttribute(data, dataSize, &value, sizeof(value));
 
-		break;
-	}
-	case Clusters::RelativeHumidityMeasurement::Attributes::MinMeasuredValue::Id: {
-		int16_t value;
+			if (err != CHIP_NO_ERROR) {
+				return err;
+			}
 
-		err = CopyAttribute(data, dataSize, &value, sizeof(value));
+			SetMinMeasuredValue(value);
 
-		if (err != CHIP_NO_ERROR) {
-			return err;
+			break;
 		}
+		case Clusters::RelativeHumidityMeasurement::Attributes::MaxMeasuredValue::Id: {
+			int16_t value;
 
-		SetMinMeasuredValue(value);
+			err = CopyAttribute(data, dataSize, &value, sizeof(value));
 
-		break;
-	}
-	case Clusters::RelativeHumidityMeasurement::Attributes::MaxMeasuredValue::Id: {
-		int16_t value;
+			if (err != CHIP_NO_ERROR) {
+				return err;
+			}
 
-		err = CopyAttribute(data, dataSize, &value, sizeof(value));
+			SetMaxMeasuredValue(value);
 
-		if (err != CHIP_NO_ERROR) {
-			return err;
+			break;
 		}
-
-		SetMaxMeasuredValue(value);
-
+		default:
+			return CHIP_ERROR_INVALID_ARGUMENT;
+		}
 		break;
 	}
 	default:

--- a/applications/matter_bridge/src/bridged_device_types/onoff_light.cpp
+++ b/applications/matter_bridge/src/bridged_device_types/onoff_light.cpp
@@ -112,19 +112,17 @@ CHIP_ERROR OnOffLightDevice::HandleWrite(ClusterId clusterId, AttributeId attrib
 CHIP_ERROR OnOffLightDevice::HandleAttributeChange(chip::ClusterId clusterId, chip::AttributeId attributeId, void *data,
 						   size_t dataSize)
 {
+	CHIP_ERROR err = CHIP_NO_ERROR;
 	if (!data) {
 		return CHIP_ERROR_INVALID_ARGUMENT;
 	}
 
 	switch (clusterId) {
 	case Clusters::BridgedDeviceBasicInformation::Id:
-		HandleWriteDeviceBasicInformation(clusterId, attributeId, data, dataSize);
-		return CHIP_NO_ERROR;
+		return HandleWriteDeviceBasicInformation(clusterId, attributeId, data, dataSize);
 	case Clusters::OnOff::Id: {
 		switch (attributeId) {
 		case Clusters::OnOff::Attributes::OnOff::Id: {
-			CHIP_ERROR err;
-
 			bool value;
 
 			err = CopyAttribute(data, dataSize, &value, sizeof(value));
@@ -139,10 +137,11 @@ CHIP_ERROR OnOffLightDevice::HandleAttributeChange(chip::ClusterId clusterId, ch
 		default:
 			return CHIP_ERROR_INVALID_ARGUMENT;
 		}
+		break;
 	}
 	default:
 		return CHIP_ERROR_INVALID_ARGUMENT;
 	}
 
-	return CHIP_ERROR_INVALID_ARGUMENT;
+	return err;
 }

--- a/applications/matter_bridge/src/bridged_device_types/temperature_sensor.cpp
+++ b/applications/matter_bridge/src/bridged_device_types/temperature_sensor.cpp
@@ -98,50 +98,58 @@ CHIP_ERROR TemperatureSensorDevice::HandleReadTemperatureMeasurement(AttributeId
 CHIP_ERROR TemperatureSensorDevice::HandleAttributeChange(chip::ClusterId clusterId, chip::AttributeId attributeId,
 							  void *data, size_t dataSize)
 {
-	if (clusterId != Clusters::TemperatureMeasurement::Id || !data) {
+	CHIP_ERROR err = CHIP_NO_ERROR;
+	if (!data) {
 		return CHIP_ERROR_INVALID_ARGUMENT;
 	}
 
-	CHIP_ERROR err;
+	switch (clusterId) {
+	case Clusters::BridgedDeviceBasicInformation::Id:
+		return HandleWriteDeviceBasicInformation(clusterId, attributeId, data, dataSize);
+	case Clusters::TemperatureMeasurement::Id: {
+		switch (attributeId) {
+		case Clusters::TemperatureMeasurement::Attributes::MeasuredValue::Id: {
+			int16_t value;
 
-	switch (attributeId) {
-	case Clusters::TemperatureMeasurement::Attributes::MeasuredValue::Id: {
-		int16_t value;
+			err = CopyAttribute(data, dataSize, &value, sizeof(value));
 
-		err = CopyAttribute(data, dataSize, &value, sizeof(value));
+			if (err != CHIP_NO_ERROR) {
+				return err;
+			}
 
-		if (err != CHIP_NO_ERROR) {
-			return err;
+			SetMeasuredValue(value);
+
+			break;
 		}
+		case Clusters::TemperatureMeasurement::Attributes::MinMeasuredValue::Id: {
+			int16_t value;
 
-		SetMeasuredValue(value);
+			err = CopyAttribute(data, dataSize, &value, sizeof(value));
 
-		break;
-	}
-	case Clusters::TemperatureMeasurement::Attributes::MinMeasuredValue::Id: {
-		int16_t value;
+			if (err != CHIP_NO_ERROR) {
+				return err;
+			}
 
-		err = CopyAttribute(data, dataSize, &value, sizeof(value));
+			SetMinMeasuredValue(value);
 
-		if (err != CHIP_NO_ERROR) {
-			return err;
+			break;
 		}
+		case Clusters::TemperatureMeasurement::Attributes::MaxMeasuredValue::Id: {
+			int16_t value;
 
-		SetMinMeasuredValue(value);
+			err = CopyAttribute(data, dataSize, &value, sizeof(value));
 
-		break;
-	}
-	case Clusters::TemperatureMeasurement::Attributes::MaxMeasuredValue::Id: {
-		int16_t value;
+			if (err != CHIP_NO_ERROR) {
+				return err;
+			}
 
-		err = CopyAttribute(data, dataSize, &value, sizeof(value));
+			SetMaxMeasuredValue(value);
 
-		if (err != CHIP_NO_ERROR) {
-			return err;
+			break;
 		}
-
-		SetMaxMeasuredValue(value);
-
+		default:
+			return CHIP_ERROR_INVALID_ARGUMENT;
+		}
 		break;
 	}
 	default:

--- a/applications/matter_bridge/src/chip_project_config.h
+++ b/applications/matter_bridge/src/chip_project_config.h
@@ -16,3 +16,8 @@
 #pragma once
 
 #define CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT CONFIG_BRIDGE_MAX_DYNAMIC_ENDPOINTS_NUMBER
+
+/* Disable handling only single connection to avoid stopping Matter service BLE advertising
+ * while other BLE bridge-related connections are open.
+ */
+#define CHIP_DEVICE_CONFIG_CHIPOBLE_SINGLE_CONNECTION 0

--- a/samples/matter/common/src/bridge/bridge_manager.cpp
+++ b/samples/matter/common/src/bridge/bridge_manager.cpp
@@ -321,6 +321,10 @@ CHIP_ERROR BridgeManager::HandleRead(uint16_t index, ClusterId clusterId,
 	VerifyOrReturnValue(Instance().mDevicesMap.Contains(index), CHIP_ERROR_INTERNAL);
 
 	auto *device = Instance().mDevicesMap[index].mDevice;
+
+	/* Verify if the device is reachable or we should return prematurely. */
+	VerifyOrReturnError(device->GetIsReachable(), CHIP_ERROR_INCORRECT_STATE);
+
 	return device->HandleRead(clusterId, attributeMetadata->attributeId, buffer, maxReadLength);
 }
 
@@ -331,6 +335,10 @@ CHIP_ERROR BridgeManager::HandleWrite(uint16_t index, ClusterId clusterId,
 	VerifyOrReturnValue(Instance().mDevicesMap.Contains(index), CHIP_ERROR_INTERNAL);
 
 	auto *device = Instance().mDevicesMap[index].mDevice;
+
+	/* Verify if the device is reachable or we should return prematurely. */
+	VerifyOrReturnError(device->GetIsReachable(), CHIP_ERROR_INCORRECT_STATE);
+
 	CHIP_ERROR err = device->HandleWrite(clusterId, attributeMetadata->attributeId, buffer);
 
 	/* After updating MatterBridgedDevice state, forward request to the non-Matter device. */

--- a/samples/matter/common/src/bridge/matter_bridged_device.h
+++ b/samples/matter/common/src/bridge/matter_bridged_device.h
@@ -76,7 +76,6 @@ public:
 
 	bool GetIsReachable() const { return mIsReachable; }
 	const char *GetNodeLabel() const { return mNodeLabel; }
-	void SetIsReachable(bool isReachable) { mIsReachable = isReachable; }
 	uint16_t GetBridgedDeviceBasicInformationClusterRevision()
 	{
 		return kBridgedDeviceBasicInformationClusterRevision;
@@ -94,6 +93,8 @@ public:
 	size_t mDataVersionSize;
 
 protected:
+	void SetIsReachable(bool isReachable) { mIsReachable = isReachable; }
+
 	chip::EndpointId mEndpointId;
 
 private:


### PR DESCRIPTION
Introduced several improvements for handling different application states:
* Added using IsReachable attribute to decide about propagating read/write requests and return failure response in case device is offline.
* Fixed fault caused by calling connection unref in BLEConnectivityManager on connection coming from a Matter core service.
* Disabled single connection mode, as it resulted in stopping Matter BLE service advertising after any BLE bridged device was connected.