### PR TITLE
drivers: wifi: Bug fix of memory leak in interface up-down

### DIFF
--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/default/fmac_api.c
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/default/fmac_api.c
@@ -2162,6 +2162,11 @@ out:
 				       del_vif_cmd);
 	}
 
+	if (vif_ctx) {
+		wifi_nrf_osal_mem_free(fmac_dev_ctx->fpriv->opriv,
+				       vif_ctx);
+	}
+
 	return status;
 }
 


### PR DESCRIPTION
Memory allocated for a virtual interface in wifi_nrf_fmac_add_vif, is never freed in the corresponding wifi_nrf_fmac_del_vif. It results in the driver leaking 40 bytes of memory every time the networking interface is cycled.
Free the memory of vif_ctx in out: tag of wifi_nrf_fmac_del_vif.