### PR TITLE
applications: asset_tracker_v2: fix garbage return

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/aws_iot/aws_iot_codec.c
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/aws_iot/aws_iot_codec.c
@@ -62,7 +62,7 @@ int cloud_codec_encode_cloud_location(
 	struct cloud_codec_data *output,
 	struct cloud_data_cloud_location *cloud_location)
 {
-	int err;
+	int err = -ENODATA;
 	char *buffer;
 
 	__ASSERT_NO_MSG(output != NULL);

--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/azure_iot_hub/azure_iot_hub_codec.c
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/azure_iot_hub/azure_iot_hub_codec.c
@@ -33,7 +33,7 @@ int cloud_codec_encode_cloud_location(
 	struct cloud_codec_data *output,
 	struct cloud_data_cloud_location *cloud_location)
 {
-	int err;
+	int err = -ENODATA;
 	char *buffer;
 
 	__ASSERT_NO_MSG(output != NULL);


### PR DESCRIPTION
cloud_codec_encode_cloud_location was returning garbage value in some cases. This is now fixed by setting the init value of err to -ENODATA.

Found as violation of MISRA C:2004, 9.1 by sonarcloud.

[Link to bug](https://sonarcloud.io/project/issues?resolved=false&types=BUG&sinceLeakPeriod=true&pullRequest=163&id=balaji-nordic_sdk-nrf )