### PR TITLE
applications: matter: Improve BLE reconnection mechanism for Bridge

### DIFF
--- a/applications/matter_bridge/Kconfig
+++ b/applications/matter_bridge/Kconfig
@@ -55,6 +55,9 @@ config BT_SCAN_FILTER_ENABLE
 config BT_SCAN_UUID_CNT
 	default 2
 
+config BT_SCAN_ADDRESS_CNT
+	default 1
+
 config BT_GATT_CLIENT
 	default y
 

--- a/applications/matter_bridge/src/bridged_devices_creator.cpp
+++ b/applications/matter_bridge/src/bridged_devices_creator.cpp
@@ -242,6 +242,8 @@ CHIP_ERROR BridgedDeviceCreator::CreateDevice(int deviceType, const char *nodeLa
 	 * storage, the device has to be re-connected without confirming its existence by callback.
 	 */
 	if (index.HasValue() && endpointId.HasValue()) {
+		/* Confirm that the first connection was done and this will be only the device recovery. */
+		provider->ConfirmInitialConnection();
 		provider->InitializeBridgedDevice(btAddress, nullptr, nullptr);
 		BLEConnectivityManager::Instance().Recover(provider);
 		err = AddMatterDevice(deviceType, nodeLabel, provider, index, endpointId);

--- a/samples/matter/common/src/bridge/ble_bridged_device.h
+++ b/samples/matter/common/src/bridge/ble_bridged_device.h
@@ -20,6 +20,8 @@ struct BLEBridgedDevice {
 	bt_addr_le_t mAddr;
 	BLEConnectivityManager::DeviceConnectedCallback mFirstConnectionCallback;
 	void *mFirstConnectionCallbackContext;
+	bool mInitiallyConnected = false; /* Indicates whether the first connection has been established and the device
+					     has been successfully added to the Bridge. */
 	bt_conn *mConn;
 	BLEBridgedDeviceProvider *mProvider;
 };
@@ -27,10 +29,7 @@ struct BLEBridgedDevice {
 class BLEBridgedDeviceProvider : public BridgedDeviceDataProvider {
 public:
 	explicit BLEBridgedDeviceProvider(UpdateAttributeCallback callback) : BridgedDeviceDataProvider(callback) {}
-	~BLEBridgedDeviceProvider()
-	{
-		BLEConnectivityManager::Instance().RemoveBLEProvider(GetBtAddress());
-	}
+	~BLEBridgedDeviceProvider() { BLEConnectivityManager::Instance().RemoveBLEProvider(GetBtAddress()); }
 
 	virtual bt_uuid *GetServiceUuid() = 0;
 	virtual int ParseDiscoveredData(bt_gatt_dm *discoveredData) = 0;
@@ -46,6 +45,28 @@ public:
 
 	BLEBridgedDevice &GetBLEBridgedDevice() { return mDevice; }
 	void SetConnectionObject(bt_conn *conn) { mDevice.mConn = conn; }
+	void RemoveConnectionObject() { mDevice.mConn = nullptr; }
+
+	/**
+	 * @brief Check if the bridged device has been initially connected.
+	 *
+	 * The bridged device should call the @ref mFirstConnectionCallback only when it is the first connection.
+	 * This method returns indicates whether the callback has been called and the device is already initially
+	 * connected.
+	 *
+	 * @return true if the bridged device has been initially connected.
+	 * @return false if this is the first connection to the bridged device.
+	 */
+	bool IsInitiallyConnected() { return mDevice.mInitiallyConnected; }
+
+	/**
+	 * @brief Confirm that the @ref mFirstConnectionCallback has been already called .
+	 *
+	 * This method informs the bridged device that the @ref mFirstConnectionCallback has been called
+	 * and connection has been established successfully.
+	 *
+	 */
+	void ConfirmInitialConnection() { mDevice.mInitiallyConnected = true; }
 
 	bt_addr_le_t GetBtAddress() { return mDevice.mAddr; }
 


### PR DESCRIPTION
Now the reconnection mechanism works independently of the normal scan procedure.
When the connection to the BLE device is lost, the reconnection mechanism starts working, but when a user wants to perform scanning for the new devices, the mechanism stops working while the new scan is in progress, and after that goes back to searching for the lost device.
The scanned devices list is now independent of the reconnection mechanism, so it is not lost during the reconnection scan in progress.
Also, connection to a new BLE device is possible while the reconnection mechanism is working.
