### PR TITLE
Bluetooth: Controller: Mark LE Power Control Feature as supported

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -314,8 +314,7 @@ config BT_CTLR_ECDH_IN_MPSL_WORK
 endif # BT_CTLR_ECDH
 
 config BT_CTLR_LE_POWER_CONTROL
-	bool "LE Power Control [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "LE Power Control"
 	help
 	  Enable support for LE Power Control feature that defined in the Bluetooth
 	  Core specification, Version 5.3 | Vol 6, Part B, Section 4.6.31.


### PR DESCRIPTION
This comment removes the "experimental" tag from LE Power Control.