### PR TITLE
Bluetooth: Controller: Mark LE Power Control Feature as supported

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -314,8 +314,7 @@ config BT_CTLR_ECDH_IN_MPSL_WORK
 endif # BT_CTLR_ECDH
 
 config BT_CTLR_LE_POWER_CONTROL
-	bool "LE Power Control [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "LE Power Control"
 	help
 	  Enable support for LE Power Control feature that defined in the Bluetooth
 	  Core specification, Version 5.3 | Vol 6, Part B, Section 4.6.31.

--- a/west.yml
+++ b/west.yml
@@ -139,7 +139,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 62d5e535fc24962c209cc48d10d697c16bd6c7ae
+      revision: 8579c4193d47385115e8d465672b099f9b423518
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
This commit removes the "experimental" tag from LE Power Control, as well as update the sdk-nrfxlib revision.
- https://github.com/nrfconnect/sdk-nrfxlib/pull/1074