### PR TITLE
lib: pdn: add APN rate control events

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -776,6 +776,7 @@ Modem libraries
 
 * :ref:`pdn_readme` library:
 
+  * Added the :c:enumerator:`PDN_EVENT_APN_RATE_CONTROL_ON` and :c:enumerator:`PDN_EVENT_APN_RATE_CONTROL_OFF` events to report on the status of APN rate control.
   * Updated the library to allow a ``PDP_type``-only configuration in the :c:func:`pdn_ctx_configure` function.
 
 * :ref:`modem_key_mgmt` library:

--- a/include/modem/pdn.h
+++ b/include/modem/pdn.h
@@ -61,6 +61,8 @@ enum pdn_event {
 	PDN_EVENT_IPV6_UP,		/**< PDN has IPv6 connectivity */
 	PDN_EVENT_IPV6_DOWN,		/**< PDN has lost IPv6 connectivity */
 	PDN_EVENT_NETWORK_DETACH,	/**< Network detached */
+	PDN_EVENT_APN_RATE_CONTROL_ON,	/**< APN rate control is ON for given PDN */
+	PDN_EVENT_APN_RATE_CONTROL_OFF, /**< APN rate control is OFF for given PDN */
 };
 
 /** @brief PDN authentication method */


### PR DESCRIPTION
Add events for APN rate control.
Have not been able to tests the new functionality yet..

The modem won't send `CGEV APNRATECTRL STAT` notifications upon CFUN mode changes (NW detach) or PDN deactivation.
Should this library send the APN rate control events "spontaneously" in those cases?