### PR TITLE
bluetooth: fast_pair: fp_storage: Change overwriting Account Key scheme

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -601,6 +601,8 @@ Bluetooth libraries and services
     * The :kconfig:option:`CONFIG_BT_FAST_PAIR_STORAGE_EXT_PN` Kconfig option to the :kconfig:option:`CONFIG_BT_FAST_PAIR_STORAGE_PN` Kconfig option.
     * The :kconfig:option:`CONFIG_BT_FAST_PAIR_STORAGE_EXT_PN_LEN_MAX` Kconfig option to the :kconfig:option:`CONFIG_BT_FAST_PAIR_STORAGE_PN_LEN_MAX` Kconfig option.
 
+  * Updated the Fast Pair storage module to overwrite the least recently used Account Key instead of the oldest Account Key on Account Key write.
+
 * :ref:`bt_le_adv_prov_readme` library:
 
   * Changed the allowed range of the :kconfig:option:`CONFIG_BT_ADV_PROV_FAST_PAIR_ADV_BUF_SIZE` Kconfig option and set its default value to 26.

--- a/subsys/bluetooth/services/fast_pair/fp_storage/include/fp_storage_ak.h
+++ b/subsys/bluetooth/services/fast_pair/fp_storage/include/fp_storage_ak.h
@@ -52,6 +52,8 @@ int fp_storage_ak_save(const struct fp_account_key *account_key);
 int fp_storage_ak_count(void);
 
 /** Get stored Account Key List.
+ *  This function should not be used if only one key is about to be used, because it doesn't trigger
+ *  key usage order update. Use @ref fp_storage_ak_find instead.
  *
  * @param[out] buf Pointer to buffer used to store array of Account Keys. Array length has to be
  *		   greater than or equal to number of stored Account Keys.
@@ -66,6 +68,7 @@ int fp_storage_ak_get(struct fp_account_key *buf, size_t *key_count);
 
 /** Iterate over stored Account Keys to find a key that matches user-defined conditions.
  *  If such a key is found, the iteration process stops and this function returns.
+ *  Found key is marked as recently used by storage module.
  *
  * @param[out] account_key Found Account Key. It is possible to pass NULL pointer if the found
  *                         key value is irrelevant.

--- a/subsys/bluetooth/services/fast_pair/fp_storage/include_priv/fp_storage_ak_priv.h
+++ b/subsys/bluetooth/services/fast_pair/fp_storage/include_priv/fp_storage_ak_priv.h
@@ -46,6 +46,13 @@ extern "C" {
 #define SETTINGS_AK_NAME_MAX_SIZE \
 	(sizeof(SETTINGS_AK_FULL_PREFIX) + SETTINGS_AK_NAME_MAX_SUFFIX_LEN)
 
+/** Settings key name for Account Key order. */
+#define SETTINGS_AK_ORDER_KEY_NAME "order"
+
+/** Full settings key name for Account Key order (including subtree name). */
+#define SETTINGS_AK_ORDER_FULL_NAME \
+	(SETTINGS_AK_SUBTREE_NAME SETTINGS_NAME_SEPARATOR_STR SETTINGS_AK_ORDER_KEY_NAME)
+
 /** Max number of Account Keys. */
 #define ACCOUNT_KEY_CNT CONFIG_BT_FAST_PAIR_STORAGE_ACCOUNT_KEY_MAX
 
@@ -81,29 +88,6 @@ static inline uint8_t account_key_id_to_idx(uint8_t account_key_id)
 
 	return (account_key_id - ACCOUNT_KEY_MIN_ID) % ACCOUNT_KEY_CNT;
 }
-
-/** Generate next Account Key ID.
- *
- * @param[in] account_key_id Current Account Key ID.
- *
- * @return Next Account Key ID.
- */
-static inline uint8_t next_account_key_id(uint8_t account_key_id)
-{
-	if (account_key_id == ACCOUNT_KEY_MAX_ID) {
-		return ACCOUNT_KEY_MIN_ID;
-	}
-
-	return account_key_id + 1;
-}
-
-/** Delete an Account Key from settings.
- *
- * @param[in] index Account Key index.
- *
- * @return 0 If the operation was successful. Otherwise, a (negative) error code is returned.
- */
-int fp_storage_ak_delete(uint8_t index);
 
 /** Clear storage data loaded to RAM. */
 void fp_storage_ak_ram_clear(void);

--- a/tests/subsys/bluetooth/fast_pair/storage/account_key_storage/src/test_corrupted_data.c
+++ b/tests/subsys/bluetooth/fast_pair/storage/account_key_storage/src/test_corrupted_data.c
@@ -13,6 +13,19 @@
 #include "storage_mock.h"
 #include "common_utils.h"
 
+/* This function is made just for this corrupted data test.
+ * It assumes that the least recently used key is always the oldest key that has been written.
+ * It's not meant to be used anywhere else.
+ */
+static uint8_t next_account_key_id(uint8_t account_key_id)
+{
+	if (account_key_id == ACCOUNT_KEY_MAX_ID) {
+		return ACCOUNT_KEY_MIN_ID;
+	}
+
+	return account_key_id + 1;
+}
+
 static void store_key(uint8_t key_id)
 {
 	int err;
@@ -214,23 +227,6 @@ ZTEST(suite_fast_pair_storage_corrupted, test_drop_keys)
 
 	zassert_equal(account_key_id_to_idx(ACCOUNT_KEY_MIN_ID), account_key_id_to_idx(key_id),
 		      "Test should write key exactly after rollover");
-	store_key(key_id);
-
-	settings_load_error_validate();
-}
-
-ZTEST(suite_fast_pair_storage_corrupted, test_drop_rollover)
-{
-	uint8_t key_id = ACCOUNT_KEY_MIN_ID;
-
-	for (size_t i = 0; i < ACCOUNT_KEY_CNT; i++) {
-		store_key(key_id);
-		key_id = next_account_key_id(key_id);
-	}
-
-	zassert_equal(account_key_id_to_idx(ACCOUNT_KEY_MIN_ID), account_key_id_to_idx(key_id),
-		      "Test should drop key exactly after rollover");
-	key_id = next_account_key_id(key_id);
 	store_key(key_id);
 
 	settings_load_error_validate();


### PR DESCRIPTION
Earlier, the oldest Account Key was being overwrited by new one. Now, we overwrite the least recently used Account Key as according to the Fast Pair specification. New Settings entry has been introduced to keep track of which Key to overwrite.

TODO: Needs edge case testing and tests alignment.

Jira: NCSDK-21061