### PR TITLE
doc: nRF5340: Network core bootloader sample: add Kconfig setting

### DIFF
--- a/samples/nrf5340/netboot/README.rst
+++ b/samples/nrf5340/netboot/README.rst
@@ -55,6 +55,16 @@ During the boot process, the network core bootloader sample and MCUboot interact
 
 .. _net_bootloader_build_and_run:
 
+Configuration
+*************
+
+|config|
+
+Configuration options
+=====================
+
+To set the minimum partitioning size, use the Kconfig option :kconfig:option:`CONFIG_NETBOOT_MIN_PARTITION_SIZE`.
+
 Building and running
 ********************
 


### PR DESCRIPTION
Added a mention about setting the CONFIG_NETBOOT_MIN_PARTITION_SIZE Kconfig option.

Ref: NCSDK-17553