### PR TITLE
mpsl: coex: disable granted interrupt on callback deregister

### DIFF
--- a/subsys/mpsl/cx/nrf700x/mpsl_cx_nrf700x.c
+++ b/subsys/mpsl/cx/nrf700x/mpsl_cx_nrf700x.c
@@ -26,6 +26,7 @@
 #include <zephyr/devicetree.h>
 
 #include "hal/nrf_gpio.h"
+#include <nrfx_gpiote.h>
 
 /*
  * Typical part of device tree describing coex (sample port and pin numbers).
@@ -53,12 +54,16 @@
 
 #define REQUEST_LEAD_TIME 0U
 
+#define GRANT_PIN_PORT_NO  DT_PROP(DT_GPIO_CTLR(CX_NODE, grant_gpios), port)
+#define GRANT_PIN_PIN_NO   DT_GPIO_PIN(CX_NODE, grant_gpios)
+
 static const struct gpio_dt_spec req_spec     = GPIO_DT_SPEC_GET(CX_NODE, req_gpios);
 static const struct gpio_dt_spec status0_spec = GPIO_DT_SPEC_GET(CX_NODE, status0_gpios);
 static const struct gpio_dt_spec grant_spec   = GPIO_DT_SPEC_GET(CX_NODE, grant_gpios);
 
 static mpsl_cx_cb_t callback;
 static struct gpio_callback grant_cb;
+static uint32_t grant_abs_pin;
 
 static bool enabled = true;
 
@@ -221,6 +226,12 @@ static int32_t register_callback(mpsl_cx_cb_t cb)
 {
 	callback = cb;
 
+	if (cb != NULL) {
+		nrfx_gpiote_trigger_enable(grant_abs_pin, true);
+	} else {
+		nrfx_gpiote_trigger_disable(grant_abs_pin);
+	}
+
 	return 0;
 }
 
@@ -263,6 +274,8 @@ static int mpsl_cx_init(void)
 	if (ret < 0) {
 		return ret;
 	}
+	grant_abs_pin = NRF_GPIO_PIN_MAP(GRANT_PIN_PORT_NO, GRANT_PIN_PIN_NO);
+	nrfx_gpiote_trigger_disable(grant_abs_pin);
 
 	gpio_init_callback(&grant_cb, gpiote_irq_handler, BIT(grant_spec.pin));
 	gpio_add_callback(grant_spec.port, &grant_cb);


### PR DESCRIPTION
This commit makes calling the .p_register_callback (called by MPSL) disable the "granted" interrupt if NULL pointer is passed as an argument (deregistering callback). The interrupt is enabled if a non-NULL pointer is passed.

If all the protocols deregister their callback when they no longer use the radio (after ending their timeslot), then this will disable the interrupt during sleep periods. The processor will no longer be waken up on (possibly spurious) changes of the GRANT pin.