### PR TITLE
lib: edge_impulse: Make CMake aware of arch

### DIFF
--- a/lib/edge_impulse/CMakeLists.ei.template
+++ b/lib/edge_impulse/CMakeLists.ei.template
@@ -8,6 +8,9 @@ cmake_minimum_required(VERSION 3.13.1)
 set(CMAKE_C_COMPILER_FORCED   1)
 set(CMAKE_CXX_COMPILER_FORCED 1)
 
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_PROCESSOR "arm")
+
 project(edge_impulse)
 enable_language(ASM C CXX)
 


### PR DESCRIPTION
Edge impulse library is built as external project. To avoid CMake adding additional compiler flags
make sure it is aware that library is built
in cross-compilation for arm architecture.