### PR TITLE
bluetooth: mesh: fix sensor value to str conversion

### DIFF
--- a/include/bluetooth/mesh/sensor.h
+++ b/include/bluetooth/mesh/sensor.h
@@ -481,7 +481,7 @@ bt_mesh_sensor_column_format_get(const struct bt_mesh_sensor_type *type);
 static inline int bt_mesh_sensor_ch_to_str(const struct sensor_value *ch,
 					   char *str, size_t len)
 {
-	return snprintk(str, len, "%s%u.%06u",
+	return snprintk(str, len, "%s%u.%u",
 			((ch->val1 < 0 || ch->val2 < 0) ? "-" : ""),
 			abs(ch->val1), abs(ch->val2));
 }


### PR DESCRIPTION
val2 represents the decimal part of the sensor value and it's limited to six decimal points by design.