### PR TITLE
scripts: update NCS Toolchain to request Zephyr SDK 0.16.1

### DIFF
--- a/scripts/tools-versions-darwin.yml
+++ b/scripts/tools-versions-darwin.yml
@@ -15,7 +15,7 @@ west:
 nanopb:
   version: 0.4.6
 zephyr-sdk:
-  version: 0.16.0
+  version: 0.16.1
   architectures: # https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.16.0
     - aarch64-zephyr-elf
     - x86_64-zephyr-elf

--- a/scripts/tools-versions-linux.yml
+++ b/scripts/tools-versions-linux.yml
@@ -17,7 +17,7 @@ gn:
 nanopb:
   version: 0.4.6
 zephyr-sdk:
-  version: 0.16.0
+  version: 0.16.1
   architectures: # https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.16.0
     - aarch64-zephyr-elf
     - x86_64-zephyr-elf

--- a/scripts/tools-versions-win10.yml
+++ b/scripts/tools-versions-win10.yml
@@ -15,7 +15,7 @@ west:
 nanopb:
   version: 0.4.6
 zephyr-sdk:
-  version: 0.16.0
+  version: 0.16.1
   architectures: # https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.16.0
     - aarch64-zephyr-elf
     - x86_64-zephyr-elf


### PR DESCRIPTION
Zephyr SDK 0.16.1 has been updated to include picolibc 0.18.1.

Update NCS to use latest released Zephyr SDK to take full advantage of the switch to Picolibc being default libc implementation in Zephyr.