### PR TITLE
lib: nrf_modem: increase minimum NRF_MODEM_LIB_SHMEM_RX_SIZE

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -675,6 +675,7 @@ Modem libraries
     * Fixed a rare bug that caused a deadlock between two threads when one thread sent data while the other received a lot of data quickly.
     * The ``SO_IP_ECHO_REPLY``, ``SO_IPV6_ECHO_REPLY``, ``SO_TCP_SRV_SESSTIMEO`` and ``SO_SILENCE_ALL`` socket option levels to align with the modem option levels.
     * The :ref:`modem_trace_module` is now initialized before the callbacks registered using the :c:macro:`NRF_MODEM_LIB_ON_INIT` macro are called.
+    * The minimal value of the :kconfig:option:`CONFIG_NRF_MODEM_LIB_SHMEM_RX_SIZE` Kconfig option to meet the requirements of modem firmware v2.0.0.
 
 * :ref:`lte_lc_readme` library:
 

--- a/lib/nrf_modem_lib/Kconfig.modemlib
+++ b/lib/nrf_modem_lib/Kconfig.modemlib
@@ -62,7 +62,8 @@ config NRF_MODEM_LIB_SHMEM_TX_SIZE
 
 config NRF_MODEM_LIB_SHMEM_RX_SIZE
 	int "RX region size"
-	range 2488 32768
+	range 2488 32768 if SOC_NRF9160
+	range 2616 32768 if SOC_NRF9120
 	default 8192
 	help
 	  Size of the shared memory region owned by the modem.


### PR DESCRIPTION
With modem firmware 2.0.0 the minimum value of
NRF_MODEM_LIB_SHMEM_RX_SIZE is increased.