### PR TITLE
lib: location: Change NCELLMEAS type from ext_comp to ext_light

### DIFF
--- a/lib/location/method_cloud_location.c
+++ b/lib/location/method_cloud_location.c
@@ -65,13 +65,13 @@ static void method_cloud_location_positioning_work_fn(struct k_work *work)
 
 #if defined(CONFIG_LOCATION_METHOD_WIFI)
 	if (wifi_config != NULL) {
-		scan_wifi_start(&wifi_scan_ready);
+		scan_wifi_execute(&wifi_scan_ready);
 	}
 #endif
 
 #if defined(CONFIG_LOCATION_METHOD_CELLULAR)
 	if (cell_config != NULL) {
-		scan_cellular_start(cell_config->cell_count, false);
+		scan_cellular_execute(cell_config->cell_count);
 		scan_cellular_info = scan_cellular_results_get();
 	}
 #endif

--- a/lib/location/method_gnss.c
+++ b/lib/location/method_gnss.c
@@ -293,7 +293,7 @@ static void method_gnss_nrf_cloud_agps_request(void)
 	struct lte_lc_cells_info *scan_results;
 
 	/* Get network info for the A-GPS location request. */
-	scan_cellular_start(0, true);
+	scan_cellular_execute(0);
 	scan_results = scan_cellular_results_get();
 	if (scan_results == NULL) {
 		LOG_WRN("Requesting A-GPS data without location assistance");

--- a/lib/location/scan_cellular.c
+++ b/lib/location/scan_cellular.c
@@ -84,11 +84,10 @@ void scan_cellular_lte_ind_handler(const struct lte_lc_evt *const evt)
 	}
 }
 
-void scan_cellular_start(uint8_t cell_count, bool light_search)
+void scan_cellular_execute(uint8_t cell_count)
 {
 	struct lte_lc_ncellmeas_params ncellmeas_params = {
-		.search_type = light_search ? LTE_LC_NEIGHBOR_SEARCH_TYPE_EXTENDED_LIGHT :
-					      LTE_LC_NEIGHBOR_SEARCH_TYPE_EXTENDED_COMPLETE,
+		.search_type = LTE_LC_NEIGHBOR_SEARCH_TYPE_EXTENDED_LIGHT,
 		.gci_count = 0
 	};
 	int err;
@@ -120,7 +119,7 @@ void scan_cellular_start(uint8_t cell_count, bool light_search)
 	 */
 	scan_cellular_cell_count = scan_cellular_cell_count - scan_cellular_info.ncells_count;
 
-	LOG_DBG("scan_cellular_start: scan_cellular_cell_count=%d", scan_cellular_cell_count);
+	LOG_DBG("scan_cellular_execute: scan_cellular_cell_count=%d", scan_cellular_cell_count);
 
 	if (scan_cellular_cell_count > 1) {
 

--- a/lib/location/scan_cellular.h
+++ b/lib/location/scan_cellular.h
@@ -10,7 +10,7 @@
 #include <modem/lte_lc.h>
 
 int scan_cellular_init(void);
-void scan_cellular_start(uint8_t cell_count, bool light_search);
+void scan_cellular_execute(uint8_t cell_count);
 struct lte_lc_cells_info *scan_cellular_results_get(void);
 int scan_cellular_cancel(void);
 

--- a/lib/location/scan_wifi.c
+++ b/lib/location/scan_wifi.c
@@ -46,7 +46,7 @@ struct wifi_scan_info *scan_wifi_results_get(void)
 	return &scan_wifi_info;
 }
 
-void scan_wifi_start(struct k_sem *wifi_scan_ready)
+void scan_wifi_execute(struct k_sem *wifi_scan_ready)
 {
 	int ret;
 

--- a/lib/location/scan_wifi.h
+++ b/lib/location/scan_wifi.h
@@ -10,7 +10,7 @@
 #include <net/wifi_location_common.h>
 
 int scan_wifi_init(void);
-void scan_wifi_start(struct k_sem *wifi_scan_ready);
+void scan_wifi_execute(struct k_sem *wifi_scan_ready);
 struct wifi_scan_info *scan_wifi_results_get(void);
 int scan_wifi_cancel(void);
 

--- a/tests/lib/location/src/location_test.c
+++ b/tests/lib/location/src/location_test.c
@@ -372,7 +372,7 @@ void test_location_cellular(void)
 
 	location_callback_called_expected = true;
 
-	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS=2", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS=1", 0);
 	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT+CGACT?", 0);
 	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
 	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
@@ -410,7 +410,7 @@ void test_location_cellular_cancel_during_ncellmeas(void)
 	config.methods[0].cellular.cell_count = 2;
 	location_callback_called_expected = false;
 
-	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS=2", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS=1", 0);
 
 	err = location_request(&config);
 	TEST_ASSERT_EQUAL(0, err);
@@ -526,7 +526,7 @@ void test_location_request_default(void)
 
 	/***** Fallback to cellular *****/
 
-	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS=2", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS=1", 0);
 	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT+CGACT?", 0);
 	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
 	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
@@ -583,7 +583,7 @@ void test_location_request_mode_all_cellular_gnss(void)
 
 	/***** First cellular positioning *****/
 
-	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS=2", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS=1", 0);
 	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT+CGACT?", 0);
 	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
 	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
@@ -696,7 +696,7 @@ void test_location_request_timeout_cellular_gnss_mode_all(void)
 	location_callback_called_expected = true;
 
 	/***** First cellular positioning *****/
-	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS=2", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS=1", 0);
 
 	err = location_request(&config);
 	TEST_ASSERT_EQUAL(0, err);
@@ -883,7 +883,7 @@ void test_location_cellular_periodic(void)
 
 	location_callback_called_expected = true;
 
-	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS=2", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS=1", 0);
 	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT+CGACT?", 0);
 	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
 	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
@@ -928,7 +928,7 @@ void test_location_cellular_periodic(void)
 	rest_req_ctx.port = HTTPS_PORT;
 	rest_req_ctx.host = CONFIG_LOCATION_SERVICE_HERE_HOSTNAME;
 
-	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS=2", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS=1", 0);
 	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT+CGACT?", 0);
 	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
 	__cmock_nrf_modem_at_cmd_IgnoreArg_len();


### PR DESCRIPTION
For some reason, we decided to use NCELLMEAS search_type 2 (extended complete) for normal neighbor cells.
At the same time we used search type 4 (extended light) for GCI search.
Because "extended complete" can take a lot of time for normal and GCI cells, we are changing normal neighbor search also to use "extended light" search type.

Jira: NCSDK-23454