### PR TITLE
samples: matter: Fixed handling bridged device reachable attribute

### DIFF
--- a/applications/matter_bridge/src/bridged_device_types/humidity_sensor.cpp
+++ b/applications/matter_bridge/src/bridged_device_types/humidity_sensor.cpp
@@ -54,12 +54,6 @@ CHIP_ERROR HumiditySensorDevice::HandleRead(ClusterId clusterId, AttributeId att
 					    uint16_t maxReadLength)
 {
 	switch (clusterId) {
-	case Clusters::BridgedDeviceBasicInformation::Id:
-		return HandleReadBridgedDeviceBasicInformation(attributeId, buffer, maxReadLength);
-		break;
-	case Clusters::Descriptor::Id:
-		return HandleReadDescriptor(attributeId, buffer, maxReadLength);
-		break;
 	case Clusters::RelativeHumidityMeasurement::Id:
 		return HandleReadRelativeHumidityMeasurement(attributeId, buffer, maxReadLength);
 		break;

--- a/applications/matter_bridge/src/bridged_device_types/onoff_light.cpp
+++ b/applications/matter_bridge/src/bridged_device_types/onoff_light.cpp
@@ -59,12 +59,6 @@ CHIP_ERROR OnOffLightDevice::HandleRead(ClusterId clusterId, AttributeId attribu
 					uint16_t maxReadLength)
 {
 	switch (clusterId) {
-	case Clusters::BridgedDeviceBasicInformation::Id:
-		return HandleReadBridgedDeviceBasicInformation(attributeId, buffer, maxReadLength);
-		break;
-	case Clusters::Descriptor::Id:
-		return HandleReadDescriptor(attributeId, buffer, maxReadLength);
-		break;
 	case Clusters::OnOff::Id:
 		return HandleReadOnOff(attributeId, buffer, maxReadLength);
 		break;

--- a/applications/matter_bridge/src/bridged_device_types/temperature_sensor.cpp
+++ b/applications/matter_bridge/src/bridged_device_types/temperature_sensor.cpp
@@ -52,12 +52,6 @@ CHIP_ERROR TemperatureSensorDevice::HandleRead(ClusterId clusterId, AttributeId 
 					       uint16_t maxReadLength)
 {
 	switch (clusterId) {
-	case Clusters::BridgedDeviceBasicInformation::Id:
-		return HandleReadBridgedDeviceBasicInformation(attributeId, buffer, maxReadLength);
-		break;
-	case Clusters::Descriptor::Id:
-		return HandleReadDescriptor(attributeId, buffer, maxReadLength);
-		break;
 	case Clusters::TemperatureMeasurement::Id:
 		return HandleReadTemperatureMeasurement(attributeId, buffer, maxReadLength);
 		break;

--- a/samples/matter/common/src/bridge/bridge_manager.cpp
+++ b/samples/matter/common/src/bridge/bridge_manager.cpp
@@ -322,6 +322,18 @@ CHIP_ERROR BridgeManager::HandleRead(uint16_t index, ClusterId clusterId,
 
 	auto *device = Instance().mDevicesMap[index].mDevice;
 
+	/* Handle reads for the generic information for all bridged devices. Provide a valid answer even if device state
+	 * is unreachable. */
+	switch (clusterId) {
+	case Clusters::BridgedDeviceBasicInformation::Id:
+		return device->HandleReadBridgedDeviceBasicInformation(attributeMetadata->attributeId, buffer,
+								       maxReadLength);
+	case Clusters::Descriptor::Id:
+		return device->HandleReadDescriptor(attributeMetadata->attributeId, buffer, maxReadLength);
+	default:
+		break;
+	}
+
 	/* Verify if the device is reachable or we should return prematurely. */
 	VerifyOrReturnError(device->GetIsReachable(), CHIP_ERROR_INCORRECT_STATE);
 


### PR DESCRIPTION
The current implementation returns failure if the device is not reachable and read request is received. It applied also to the reachable attribute itself.

Moved handling attributes common to all bridged devices to the bridge_manager, before validating the reachable state.