### PR TITLE
doc: fix release notes

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-2.3.0.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-2.3.0.rst
@@ -636,7 +636,7 @@ Wi-Fi samples
 Other samples
 -------------
 
-* :ref:`esb_ptx` and :ref:`esb_prx` samples:
+* Enhanced ShockBurst: Transmitter/Receiver sample:
 
   * Added support for front-end modules and :ref:`zephyr:nrf21540dk_nrf52840`.
 


### PR DESCRIPTION
Revert change in 2.3 RN

--------------------------------
Only name should have been updated in old RN that was causing doc build fails.
Fixing what was edited in PR #12343 