### PR TITLE
[DNM] manifest: Update sdk-nrfxlib revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -141,7 +141,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 66ee4d770aeeab6c520f4f50db0eb37e1dd97526
+      revision: pull/1076/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
The update here is for revert PR to sdk-nrfxlib, my mistake. It will be marked as [DNM] for now as there is a slim chance that no sdk-nrfxlib main update is needed before upmerge gets merged, in which case we could avoid ugly revert on main.

Update sdk-nrfxlib.