### PR TITLE
applications: Added DFU over SMP support to the Matter Bridge

### DIFF
--- a/applications/matter_bridge/CMakeLists.txt
+++ b/applications/matter_bridge/CMakeLists.txt
@@ -115,8 +115,12 @@ endif() # CONFIG_BRIDGE_HUMIDITY_SENSOR_BRIDGED_DEVICE
 
 endif() # CONFIG_BRIDGED_DEVICE_BT
 
-if(CONFIG_CHIP_OTA_REQUESTOR)
+if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_TRANSPORT_BT)
     target_sources(app PRIVATE ${COMMON_ROOT}/src/ota_util.cpp)
+endif()
+
+if(CONFIG_MCUMGR_TRANSPORT_BT)
+    target_sources(app PRIVATE ${COMMON_ROOT}/src/dfu_over_smp.cpp)
 endif()
 
 chip_configure_data_model(app

--- a/applications/matter_bridge/README.rst
+++ b/applications/matter_bridge/README.rst
@@ -47,6 +47,38 @@ The application supports bridging the following Matter device types:
 * Temperature Sensor
 * Humidity Sensor
 
+The application supports over-the-air (OTA) device firmware upgrade (DFU) using either of the two following protocols:
+
+* Matter OTA update protocol.
+  Querying and downloading a new firmware image is done using the Matter operational network.
+* Simple Management Protocol (SMP) over Bluetooth LE.
+  The DFU is done using either a smartphone application or a PC command line tool.
+  Note that this protocol is not part of the Matter specification.
+
+In both cases, MCUboot secure bootloader is used to apply the new firmware image.
+
+Matter OTA update protocol is enabled by default.
+To configure the application to support the DFU over both Matter and SMP, use the ``-DCONFIG_CHIP_DFU_OVER_BT_SMP=y`` build flag.
+
+See :ref:`cmake_options` for instructions on how to add these options to your build.
+
+
+When building on the command line, run the following command:
+
+.. parsed-literal::
+   :class: highlight
+
+   west build -b *build_target* -- *dfu_build_flag*
+
+Replace *build_target* with the build target name of the hardware platform you are using (see `Requirements`_), and *dfu_build_flag* with the desired DFU build flag.
+For example:
+
+.. code-block:: console
+
+   west build -b nrf7002dk_nrf5340_cpuapp -- -DCONFIG_CHIP_DFU_OVER_BT_SMP=y
+
+For information about how to upgrade the device firmware using a PC or a smartphone, see the :ref:`matter_bridge_app_dfu` section.
+
 .. _matter_bridge_app_bridged_support:
 
 Bridged device support
@@ -112,8 +144,13 @@ User interface
     :end-before: matter_door_lock_sample_led1_end
 
 Button 1:
-     If pressed for six seconds, it initiates the factory reset of the device.
-     Releasing the button within the six-second window cancels the factory reset procedure.
+    Depending on how long you press the button:
+
+    * If pressed for less than three seconds, it initiates the SMP server (Simple Management Protocol).
+      After that, the Direct Firmware Update (DFU) over Bluetooth Low Energy can be started.
+      (See `Updating the device firmware`_.)
+    * If pressed for more than three seconds, it initiates the factory reset of the device.
+      Releasing the button within a 3-second window of the initiation cancels the factory reset procedure.
 
 Button 2:
      Enables Bluetooth LE advertising for the predefined period of time (15 minutes by default), and makes the device discoverable over Bluetooth LE.
@@ -448,6 +485,8 @@ For this application, you can use one of the following :ref:`onboarding informat
 
        - MT:06PS042C00KA0648G00
        - 34970112332
+
+.. _matter_bridge_app_dfu:
 
 Updating the device firmware
 ============================

--- a/applications/matter_bridge/src/app_event.h
+++ b/applications/matter_bridge/src/app_event.h
@@ -14,7 +14,7 @@ class LEDWidget;
 
 enum class AppEventType : uint8_t { None = 0, Button, ButtonPushed, ButtonReleased, Timer, UpdateLedState };
 
-enum class FunctionEvent : uint8_t { NoneSelected = 0, FactoryReset };
+enum class FunctionEvent : uint8_t { NoneSelected = 0, SoftwareUpdate = 0, FactoryReset };
 
 struct AppEvent {
 	union {

--- a/applications/matter_bridge/src/app_task.cpp
+++ b/applications/matter_bridge/src/app_task.cpp
@@ -50,7 +50,8 @@ using namespace ::chip::DeviceLayer;
 namespace
 {
 constexpr size_t kAppEventQueueSize = 10;
-constexpr uint32_t kFactoryResetTriggerTimeout = 6000;
+constexpr uint32_t kFactoryResetTriggerTimeout = 3000;
+constexpr uint32_t kFactoryResetCancelWindowTimeout = 3000;
 
 K_MSGQ_DEFINE(sAppEventQueue, sizeof(AppEvent), kAppEventQueueSize, alignof(AppEvent));
 k_timer sFunctionTimer;
@@ -73,6 +74,7 @@ static constexpr uint8_t kUuidServicesNumber = ARRAY_SIZE(sUuidServices);
 
 namespace LedConsts
 {
+constexpr uint32_t kBlinkRate_ms{ 500 };
 namespace StatusLed
 {
 	namespace Unprovisioned
@@ -137,6 +139,12 @@ CHIP_ERROR AppTask::Init()
 #ifdef CONFIG_CHIP_OTA_REQUESTOR
 	/* OTA image confirmation must be done before the factory data init. */
 	OtaConfirmNewImage();
+#endif
+
+#ifdef CONFIG_MCUMGR_TRANSPORT_BT
+	/* Initialize DFU over SMP */
+	GetDFUOverSMP().Init();
+	GetDFUOverSMP().ConfirmNewImage();
 #endif
 
 	/* Initialize CHIP server */
@@ -239,15 +247,26 @@ void AppTask::FunctionTimerTimeoutCallback(k_timer *timer)
 	PostEvent(event);
 }
 
-void AppTask::FunctionTimerEventHandler(const AppEvent &)
+void AppTask::FunctionTimerEventHandler(const AppEvent &event)
 {
-	if (Instance().mFunction == FunctionEvent::FactoryReset) {
+	if (event.Type != AppEventType::Timer) {
+		return;
+	}
+
+	/* If we reached here, the button was held past kFactoryResetTriggerTimeout, initiate factory reset */
+	if (Instance().mFunction == FunctionEvent::SoftwareUpdate) {
+		LOG_INF("Factory Reset Triggered. Release button within %ums to cancel.", kFactoryResetTriggerTimeout);
+
+		/* Start timer for kFactoryResetCancelWindowTimeout to allow user to cancel, if required. */
+		Instance().StartTimer(kFactoryResetCancelWindowTimeout);
+		Instance().mFunction = FunctionEvent::FactoryReset;
+
+		/* Turn off all LEDs before starting blink to make sure blink is coordinated. */
+		sStatusLED.Set(false);
+		sStatusLED.Blink(LedConsts::kBlinkRate_ms);
+	} else if (Instance().mFunction == FunctionEvent::FactoryReset) {
+		/* Actually trigger Factory Reset */
 		Instance().mFunction = FunctionEvent::NoneSelected;
-		LOG_INF("Factory Reset triggered");
-
-		sStatusLED.Set(true);
-		sFactoryResetLEDs.Set(true);
-
 		chip::Server::GetInstance().ScheduleFactoryReset();
 	}
 }
@@ -257,12 +276,30 @@ void AppTask::FunctionHandler(const AppEvent &event)
 	if (event.ButtonEvent.PinNo != FUNCTION_BUTTON)
 		return;
 
+	/* To trigger software update: press the FUNCTION_BUTTON button briefly (< kFactoryResetTriggerTimeout)
+	 * To initiate factory reset: press the FUNCTION_BUTTON for kFactoryResetTriggerTimeout +
+	 * kFactoryResetCancelWindowTimeout All LEDs start blinking after kFactoryResetTriggerTimeout to signal factory
+	 * reset has been initiated. To cancel factory reset: release the FUNCTION_BUTTON once all LEDs start blinking
+	 * within the kFactoryResetCancelWindowTimeout.
+	 */
 	if (event.ButtonEvent.Action == static_cast<uint8_t>(AppEventType::ButtonPushed)) {
-		Instance().StartTimer(kFactoryResetTriggerTimeout);
-		Instance().mFunction = FunctionEvent::FactoryReset;
-	} else if (event.ButtonEvent.Action == static_cast<uint8_t>(AppEventType::ButtonReleased)) {
-		if (Instance().mFunction == FunctionEvent::FactoryReset) {
-			sFactoryResetLEDs.Set(false);
+		if (!Instance().mFunctionTimerActive && Instance().mFunction == FunctionEvent::NoneSelected) {
+			Instance().StartTimer(kFactoryResetTriggerTimeout);
+
+			Instance().mFunction = FunctionEvent::SoftwareUpdate;
+		}
+	} else {
+		/* If the button was released before factory reset got initiated, trigger a software update. */
+		if (Instance().mFunctionTimerActive && Instance().mFunction == FunctionEvent::SoftwareUpdate) {
+			Instance().CancelTimer();
+			Instance().mFunction = FunctionEvent::NoneSelected;
+
+#ifdef CONFIG_MCUMGR_TRANSPORT_BT
+			GetDFUOverSMP().StartServer();
+#else
+			LOG_INF("Software update is disabled");
+#endif
+		} else if (Instance().mFunctionTimerActive && Instance().mFunction == FunctionEvent::FactoryReset) {
 			UpdateStatusLED();
 			Instance().CancelTimer();
 			Instance().mFunction = FunctionEvent::NoneSelected;
@@ -351,11 +388,13 @@ void AppTask::ChipEventHandler(const ChipDeviceEvent *event, intptr_t /* arg */)
 void AppTask::CancelTimer()
 {
 	k_timer_stop(&sFunctionTimer);
+	mFunctionTimerActive = false;
 }
 
 void AppTask::StartTimer(uint32_t timeoutInMs)
 {
 	k_timer_start(&sFunctionTimer, K_MSEC(timeoutInMs), K_NO_WAIT);
+	mFunctionTimerActive = true;
 }
 
 void AppTask::PostEvent(const AppEvent &event)

--- a/applications/matter_bridge/src/app_task.h
+++ b/applications/matter_bridge/src/app_task.h
@@ -17,6 +17,10 @@
 #include <platform/nrfconnect/DeviceInstanceInfoProviderImpl.h>
 #endif
 
+#ifdef CONFIG_MCUMGR_TRANSPORT_BT
+#include "dfu_over_smp.h"
+#endif
+
 struct k_timer;
 
 class AppTask {

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -283,6 +283,7 @@ Matter Bridge
   * The :ref:`Matter bridge <matter_bridge_app>` application.
   * Support for the Bluetooth LE bridged devices.
   * Support for bridging of the Bluetooth LE Environmental Sensor (ESP).
+  * Support for performing Device Firmware Upgrade (DFU) over Bluetooth LE using Simple Management Protocol (SMP).
 
 Samples
 =======

--- a/samples/matter/lock/README.rst
+++ b/samples/matter/lock/README.rst
@@ -286,7 +286,7 @@ LED 2:
 Button 1:
     Depending on how long you press the button:
 
-    * If pressed for less than three seconds, it initiates the SMP server (Security Manager Protocol).
+    * If pressed for less than three seconds, it initiates the SMP server (Simple Management Protocol).
       After that, the Direct Firmware Update (DFU) over Bluetooth Low Energy can be started.
       (See `Upgrading the device firmware`_.)
     * If pressed for more than three seconds, it initiates the factory reset of the device.

--- a/samples/matter/thermostat/README.rst
+++ b/samples/matter/thermostat/README.rst
@@ -156,7 +156,7 @@ User interface
 Button 1:
     Depending on how long you press the button:
 
-    * If pressed for less than three seconds, it initiates the SMP server (Security Manager Protocol).
+    * If pressed for less than three seconds, it initiates the SMP server (Simple Management Protocol).
       After that, the Direct Firmware Update (DFU) over Bluetooth Low Energy can be started.
       (See `Upgrading the device firmware`_.)
     * If pressed for more than three seconds, it initiates the factory reset of the device.


### PR DESCRIPTION
Implemented code allowing to enable DFU over SMP in the Matter bridge application and updated readme to describe how to use it.