### PR TITLE
Add support for proprietary Power Saving Mode (PSM)

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -666,7 +666,10 @@ Modem libraries
 
 * :ref:`lte_lc_readme` library:
 
-  * Added the function :c:func:`lte_lc_edrx_get` for reading eDRX parameters currently provided by the network.
+  * Added:
+
+    * The function :c:func:`lte_lc_edrx_get` for reading eDRX parameters currently provided by the network.
+    * Support for proprietary Power Saving Mode (PSM).
 
   * Updated:
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -412,6 +412,7 @@ Cellular samples (renamed from nRF9160 samples)
 
   * Added:
 
+    * Support for controlling proprietary Power Saving Mode (PSM).
     * Support for accessing nRF Cloud services using CoAP through the :ref:`lib_nrf_cloud_coap` library.
     * Support for GSM 7bit encoded hexadecimal string in SMS messages.
     * Support for reading the currently configured eDRX parameters using the ``link edrx`` command.

--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -1356,7 +1356,7 @@ int lte_lc_normal(void);
 int lte_lc_psm_param_set(const char *rptau, const char *rat);
 
 /**
- * Request modem to enable or disable power saving mode (PSM).
+ * Request modem to enable or disable Power Saving Mode (PSM).
  *
  * PSM parameters can be set using @kconfig{CONFIG_LTE_PSM_REQ_RPTAU} and
  * @kconfig{CONFIG_LTE_PSM_REQ_RAT}, or by calling lte_lc_psm_param_set().
@@ -1389,6 +1389,32 @@ int lte_lc_psm_req(bool enable);
  *         modem is not registered to network.
  */
 int lte_lc_psm_get(int *tau, int *active_time);
+
+/**
+ * Request modem to enable or disable proprietary Power Saving Mode (PSM).
+ *
+ * The purpose of the proprietary PSM feature is to perform a PSM-like sleep when network does not
+ * allow normal PSM usage. During proprietary PSM, modem will fall to sleep in the same way than it
+ * would do if network allowed to use PSM. Sending of MO data or MO SMS will automatically wake up
+ * the modem just like if modem was in normal PSM sleep.
+ *
+ * To use the feature, also PSM request must be enabled using @kconfig{CONFIG_LTE_PSM_REQ} or
+ * lte_lc_psm_req().
+ *
+ * Refer to the AT command guide for guidance and limitations of this feature.
+ *
+ * @note @kconfig{CONFIG_LTE_PROPRIETARY_PSM_REQ} can be set to enable proprietary PSM, which is
+ *       generally sufficient. This option allows to enable or disable proprietary PSM after modem
+ *       initialization. Calling this function for run-time control is possible, but it should be
+ *       noted that conflicts may arise with the value set by
+ *       @kconfig{CONFIG_LTE_PROPRIETARY_PSM_REQ} if it is called during modem initialization.
+ *
+ * @note This feature is only supported by modem firmware versions >= v2.0.0.
+ *
+ * @retval 0 if successful.
+ * @retval -EFAULT if AT command failed.
+ */
+int lte_lc_proprietary_psm_req(bool enable);
 
 /**
  * Set the Paging Time Window (PTW) value to be used with eDRX.

--- a/lib/lte_link_control/Kconfig
+++ b/lib/lte_link_control/Kconfig
@@ -85,6 +85,13 @@ config LTE_PSM_REQ_RAT
 	  See 3GPP 27.007 Ch. 7.38.
 	  And 3GPP 24.008 Ch. 10.5.7.3 for data format.
 
+config LTE_PROPRIETARY_PSM_REQ
+	bool "Enable use of proprietary PSM"
+	help
+	  Enable use of proprietary PSM using AT%FEACONF. To use this feature, also PSM request
+	  must be enabled using CONFIG_LTE_PSM_REQ or lte_lc_psm_req().
+	  Refer to the AT command guide for guidance and limitations of this feature.
+
 config LTE_EDRX_REQ
 	bool "Enable eDRX request"
 	help

--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -43,6 +43,18 @@ LOG_MODULE_REGISTER(lte_lc, CONFIG_LTE_LINK_CONTROL_LOG_LEVEL);
 		LTE_LC_SYSTEM_MODE_LTEM_NBIOT_GPS		: \
 	LTE_LC_SYSTEM_MODE_DEFAULT)
 
+/* Internal enums */
+
+enum feaconf_oper {
+	FEACONF_OPER_WRITE = 0,
+	FEACONF_OPER_READ  = 1,
+	FEACONF_OPER_LIST  = 2
+};
+
+enum feaconf_feat {
+	FEACONF_FEAT_PROPRIETARY_PSM = 0
+};
+
 /* Static variables */
 
 static bool is_initialized;
@@ -731,6 +743,11 @@ static int init_and_connect(void)
 	return connect_lte(true);
 }
 
+static int feaconf_write(enum feaconf_feat feat, bool state)
+{
+	return nrf_modem_at_printf("AT%%FEACONF=%d,%d,%u", FEACONF_OPER_WRITE, feat, state);
+}
+
 /* Public API */
 
 int lte_lc_init(void)
@@ -968,6 +985,15 @@ int lte_lc_psm_get(int *tau, int *active_time)
 	*active_time = psm_cfg.active_time;
 
 	LOG_DBG("TAU: %d sec, active time: %d sec", *tau, *active_time);
+
+	return 0;
+}
+
+int lte_lc_proprietary_psm_req(bool enable)
+{
+	if (feaconf_write(FEACONF_FEAT_PROPRIETARY_PSM, enable) != 0) {
+		return -EFAULT;
+	}
 
 	return 0;
 }

--- a/lib/lte_link_control/lte_lc_modem_hooks.c
+++ b/lib/lte_link_control/lte_lc_modem_hooks.c
@@ -32,6 +32,19 @@ static void on_modem_init(int err, void *ctx)
 		return;
 	}
 
+	if (IS_ENABLED(CONFIG_LTE_PROPRIETARY_PSM_REQ)) {
+		err = lte_lc_proprietary_psm_req(true);
+		if (err) {
+			LOG_ERR("Failed to configure proprietary PSM, err %d", err);
+			return;
+		}
+	} else {
+		/* Return value is ignored because this feature is not supported by all MFW
+		 * versions.
+		 */
+		(void)lte_lc_proprietary_psm_req(false);
+	}
+
 	err = lte_lc_edrx_req(IS_ENABLED(CONFIG_LTE_EDRX_REQ));
 	if (err) {
 		LOG_ERR("Failed to configure eDRX, err %d", err);

--- a/samples/cellular/modem_shell/src/link/link.c
+++ b/samples/cellular/modem_shell/src/link/link.c
@@ -700,7 +700,8 @@ void link_rai_read(void)
 
 	err = link_api_rai_status(&rai_status);
 	if (err == 0) {
-		mosh_print("Release Assistance Indication status is enabled=%d", rai_status);
+		mosh_print("Release Assistance Indication is %s",
+			   rai_status ? "enabled" : "disabled");
 	} else {
 		mosh_error("Reading RAI failed with error code %d", err);
 	}
@@ -713,9 +714,9 @@ int link_rai_enable(bool enable)
 	err = nrf_modem_at_printf("AT%%RAI=%d", enable);
 	if (!err) {
 		mosh_print(
-			"Release Assistance Indication functionality set to enabled=%d.\n"
+			"Release Assistance Indication functionality %s.\n"
 			"The change will be applied when going to normal mode for the next time.",
-			enable);
+			enable ? "enabled" : "disabled");
 	} else {
 		mosh_error("RAI AT command failed, error: %d", err);
 		return -EFAULT;
@@ -761,4 +762,18 @@ int link_setdnsaddr(const char *ip_address)
 	}
 
 	return 0;
+}
+
+void link_propripsm_read(void)
+{
+	int ret;
+	uint16_t state;
+
+	ret = nrf_modem_at_scanf("AT%FEACONF=1,0", "%%FEACONF: %*u,%hu", &state);
+	if (ret == 1) {
+		mosh_print("Proprietary PSM is %s",
+			   state == 1 ? "enabled" : "disabled");
+	} else {
+		mosh_error("Reading proprietary PSM failed with error code %d", ret);
+	}
 }

--- a/samples/cellular/modem_shell/src/link/link.h
+++ b/samples/cellular/modem_shell/src/link/link.h
@@ -37,5 +37,6 @@ int link_func_mode_get(void);
 void link_rai_read(void);
 int link_rai_enable(bool enable);
 int link_setdnsaddr(const char *ip_address);
+void link_propripsm_read(void);
 
 #endif /* MOSH_LINK_H */

--- a/samples/cellular/modem_shell/src/link/link_shell.c
+++ b/samples/cellular/modem_shell/src/link/link_shell.c
@@ -48,6 +48,7 @@ enum link_shell_command {
 	LINK_CMD_RAI,
 	LINK_CMD_DNSADDR,
 	LINK_CMD_REDMOB,
+	LINK_CMD_PROPRIPSM
 };
 
 enum link_shell_common_options {
@@ -324,6 +325,13 @@ static const char link_redmob_usage_str[] =
 	"      --default,      Enable default reduced mobility mode\n"
 	"      --nordic,       Enable Nordic proprietary reduced mobility mode\n";
 
+static const char link_propripsm_usage_str[] =
+	"Usage: link propripsm --read | --disable | --enable\n"
+	"Options:\n"
+	"  -r, --read,         Read proprietary PSM status\n"
+	"  -d, --disable,      Disable proprietary PSM\n"
+	"  -e, --enable,       Enable proprietary PSM\n";
+
 /******************************************************************************/
 
 /* Following are not having short options: */
@@ -497,6 +505,9 @@ static void link_shell_print_usage(enum link_shell_command command)
 		break;
 	case LINK_CMD_REDMOB:
 		mosh_print_no_format(link_redmob_usage_str);
+		break;
+	case LINK_CMD_PROPRIPSM:
+		mosh_print_no_format(link_propripsm_usage_str);
 		break;
 	default:
 		break;
@@ -1394,6 +1405,36 @@ static int link_shell_nmodeauto(const struct shell *shell, size_t argc, char **a
 	return 0;
 }
 
+static int link_shell_propripsm(const struct shell *shell, size_t argc, char **argv)
+{
+	int err;
+	enum link_shell_common_options common_option = LINK_COMMON_NONE;
+
+	common_option = link_shell_getopt_common(argc, argv);
+
+	if (common_option == LINK_COMMON_READ) {
+		link_propripsm_read();
+	} else if (common_option == LINK_COMMON_ENABLE) {
+		err = lte_lc_proprietary_psm_req(true);
+		if (!err) {
+			mosh_print("Proprietary PSM enabled");
+		} else {
+			mosh_error("Cannot enable proprietary PSM: %d", err);
+		}
+	} else if (common_option == LINK_COMMON_DISABLE) {
+		err = lte_lc_proprietary_psm_req(false);
+		if (!err) {
+			mosh_print("Proprietary PSM disabled");
+		} else {
+			mosh_error("Cannot disable proprietary PSM: %d", err);
+		}
+	} else {
+		link_shell_print_usage(LINK_CMD_PROPRIPSM);
+	}
+
+	return 0;
+}
+
 static int link_shell_psm(const struct shell *shell, size_t argc, char **argv)
 {
 	int ret = 0;
@@ -2085,6 +2126,10 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		"Enabling/disabling of automatic connecting and going to normal mode after "
 		"the bootup. Persistent between the sessions. Has impact after the bootup.",
 		link_shell_nmodeauto, 0, 10),
+	SHELL_CMD_ARG(
+		propripsm, NULL,
+		"Enable/disable proprietary Power Saving Mode (PSM).",
+		link_shell_propripsm, 0, 10),
 	SHELL_CMD_ARG(
 		psm, NULL,
 		"Enable/disable Power Saving Mode (PSM) with default or with custom parameters.",


### PR DESCRIPTION
Implemented support for proprietary Power Saving Mode (PSM).

LTE link control only has a toggle for enabling/disabling proprietary PSM. After the feature has been enabled, the modem does the final decision when to use it.