### PR TITLE
nrf_security: MBEDTLS_MPI_MAX_SIZE to configurable

### DIFF
--- a/subsys/nrf_security/Kconfig.legacy
+++ b/subsys/nrf_security/Kconfig.legacy
@@ -264,8 +264,10 @@ config MBEDTLS_MPI_WINDOW_SIZE
 
 config MBEDTLS_MPI_MAX_SIZE
 	int
-	default 256 if CRYPTOCELL_CC310_USABLE || !CRYPTOCELL_USABLE
-	default 384 if CRYPTOCELL_CC312_USABLE
+	prompt "Maximum number of bytes for usable MPIs." if !(CC312_BACKEND || CC310_BACKEND)
+	default 256 if CC310_BACKEND
+	default 384 if CC312_BACKEND
+	range 256 2048
 
 config MBEDTLS_LEGACY_CRYPTO_C
 	bool


### PR DESCRIPTION
Add prompt to MBEDTLS_MPI_MAX_SIZE to make it configurable from applications.

--

We need to be able to set this to 512, to provide RSA 4096 support, which is needed due to Serial LTE Modem application test environment setup. See also, Jira ticket NCSDK-22624.