### PR TITLE
applications: matter: Fix the wrongly handled status on Matter Bridge

### DIFF
--- a/applications/matter_bridge/src/ble_providers/ble_bridged_device_factory.cpp
+++ b/applications/matter_bridge/src/ble_providers/ble_bridged_device_factory.cpp
@@ -174,7 +174,7 @@ struct BluetoothConnectionContext {
 	bt_addr_le_t address;
 };
 
-void BluetoothDeviceConnected(bt_gatt_dm *discoveredData, bool discoverySucceeded, void *context)
+void BluetoothDeviceConnected(bool discoverySucceeded, void *context)
 {
 	if (!context) {
 		return;
@@ -182,8 +182,7 @@ void BluetoothDeviceConnected(bt_gatt_dm *discoveredData, bool discoverySucceede
 
 	BluetoothConnectionContext *ctx = reinterpret_cast<BluetoothConnectionContext *>(context);
 
-	VerifyOrExit(discoveredData && discoverySucceeded, );
-	VerifyOrExit(ctx->provider->ParseDiscoveredData(discoveredData) == 0, );
+	VerifyOrExit(discoverySucceeded, );
 
 	/* Schedule adding device to main thread to avoid overflowing the BT stack. */
 	VerifyOrExit(chip::DeviceLayer::PlatformMgr().ScheduleWork(

--- a/applications/matter_bridge/src/ble_providers/ble_onoff_light_data_provider.h
+++ b/applications/matter_bridge/src/ble_providers/ble_onoff_light_data_provider.h
@@ -30,6 +30,8 @@ public:
 	int ParseDiscoveredData(bt_gatt_dm *discoveredData) override;
 
 private:
+	void Subscribe();
+
 	bool mOnOff = false;
 	uint16_t mLedCharacteristicHandle;
 	bt_gatt_write_params mGattWriteParams;

--- a/samples/matter/common/src/bridge/ble_connectivity_manager.cpp
+++ b/samples/matter/common/src/bridge/ble_connectivity_manager.cpp
@@ -158,12 +158,16 @@ void BLEConnectivityManager::DiscoveryCompletedHandler(bt_gatt_dm *dm, void *con
 	discoveryResult = true;
 exit:
 	if (provider) {
+		VerifyOrReturn(provider->ParseDiscoveredData(dm) == 0,
+			       LOG_ERR("Cannot parse the GATT discovered data."));
+
 		if (!provider->IsInitiallyConnected()) {
 			/* Provider is not initalized it so we need to call the first connection callback */
 			provider->GetBLEBridgedDevice().mFirstConnectionCallback(
-				dm, discoveryResult, provider->GetBLEBridgedDevice().mFirstConnectionCallbackContext);
+				discoveryResult, provider->GetBLEBridgedDevice().mFirstConnectionCallbackContext);
 			provider->ConfirmInitialConnection();
 		}
+
 		VerifyOrReturn(CHIP_NO_ERROR == provider->NotifyReachableStatusChange(true),
 			       LOG_WRN("The device has not been notified about the status change."));
 	}
@@ -179,7 +183,7 @@ void BLEConnectivityManager::DiscoveryNotFound(bt_conn *conn, void *context)
 	if (provider) {
 		if (!provider->IsInitiallyConnected()) {
 			provider->GetBLEBridgedDevice().mFirstConnectionCallback(
-				nullptr, false, provider->GetBLEBridgedDevice().mFirstConnectionCallbackContext);
+				false, provider->GetBLEBridgedDevice().mFirstConnectionCallbackContext);
 		} else {
 			Instance().mRecovery.NotifyProviderToRecover(provider);
 		}
@@ -194,7 +198,7 @@ void BLEConnectivityManager::DiscoveryError(bt_conn *conn, int err, void *contex
 
 	if (!provider->IsInitiallyConnected()) {
 		provider->GetBLEBridgedDevice().mFirstConnectionCallback(
-			nullptr, false, provider->GetBLEBridgedDevice().mFirstConnectionCallbackContext);
+			false, provider->GetBLEBridgedDevice().mFirstConnectionCallbackContext);
 	}
 }
 

--- a/samples/matter/common/src/bridge/ble_connectivity_manager.h
+++ b/samples/matter/common/src/bridge/ble_connectivity_manager.h
@@ -65,7 +65,7 @@ private:
 	};
 
 public:
-	using DeviceConnectedCallback = void (*)(bt_gatt_dm *discoveredData, bool discoverySucceeded, void *context);
+	using DeviceConnectedCallback = void (*)(bool discoverySucceeded, void *context);
 	using ScanDoneCallback = void (*)(ScannedDevice *devices, uint8_t count, void *context);
 
 	/**


### PR DESCRIPTION
Currently, the Matter Bridge cannot read the current LED state from the LBS characteristic. After losing the connection between the Bridge and the BLE LBS device we lost information about the current LED state.

To avoid losing the LED state synchronization, when the Matter bridge retrieves the connection to a Bluetooth LE LBS device we should set the current value of LED on the BLE device. We should focus on two scenarios:

1. If The Bridge has not been rebooted and the connection is retrieved, then the state of the LED that is kept in RAM should be set on the LBS device.
2. The Bridge has been rebooted and it restored all connections to BLE devices, and then we should force the initial LED state on the BLE device.

Another change is regarding ESP subscriptions. We cannot subscribe to the GATT in the Init method because we do not have
an active connection. We should subscribe after checking all GATT descriptors and unsubscribe when the lost connection is detected and stop the timer.