### PR TITLE
samples: cellular: nrf_provisioning: Increase RX buffer size

### DIFF
--- a/samples/cellular/nrf_provisioning/overlay-at_shell.conf
+++ b/samples/cellular/nrf_provisioning/overlay-at_shell.conf
@@ -1,0 +1,7 @@
+# Enable AT shell
+CONFIG_AT_SHELL=y
+
+# Increase RX ring buffer and command line buffer
+# to enable writing of certificates from AT shell
+CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=512
+CONFIG_SHELL_CMD_BUFF_SIZE=2048

--- a/samples/cellular/nrf_provisioning/prj.conf
+++ b/samples/cellular/nrf_provisioning/prj.conf
@@ -34,8 +34,13 @@ CONFIG_NRF_PROVISIONING_CBOR_RECORDS=20
 
 # Maximum length between provisioning requests
 CONFIG_NRF_PROVISIONING_INTERVAL_S=86400
+
 # Request spread factor
 CONFIG_NRF_PROVISIONING_SPREAD_S=5
+
+# Device's RX buffer size.
+# May need to be increased when provisioning large certificates
+CONFIG_NRF_PROVISIONING_RX_BUF_SZ=2048
 
 # Networking
 CONFIG_NETWORKING=y


### PR DESCRIPTION
Increase RX buffer size to support provisioning of larger certificates.
Add overlay file for AT shell