### PR TITLE
lib: lte_link_control: Add support for reading eDRX parameters

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -414,6 +414,7 @@ Cellular samples (renamed from nRF9160 samples)
 
     * Support for accessing nRF Cloud services using CoAP through the :ref:`lib_nrf_cloud_coap` library.
     * Support for GSM 7bit encoded hexadecimal string in SMS messages.
+    * Support for reading the currently configured eDRX parameters using the ``link edrx`` command.
 
   * Updated:
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -664,12 +664,16 @@ Modem libraries
 
 * :ref:`lte_lc_readme` library:
 
+  * Added the function :c:func:`lte_lc_edrx_get` for reading eDRX parameters currently provided by the network.
+
   * Updated:
 
     * The functions :c:func:`lte_lc_rai_req` and :c:func:`lte_lc_rai_param_set` and the Kconfig option :kconfig:option:`CONFIG_LTE_RAI_REQ_VALUE` are now deprecated.
       The application uses the Kconfig option :kconfig:option:`CONFIG_LTE_RAI_REQ` and ``SO_RAI_*`` socket options instead.
     * The CE level enum names for :c:enum:`lte_lc_ce_level` to not include the number of repetitions.
     * The default network mode from :kconfig:option:`CONFIG_LTE_NETWORK_MODE_LTE_M` to :kconfig:option:`CONFIG_LTE_NETWORK_MODE_LTE_M_GPS`.
+
+  * Fixed a memory leak in +CEDRXS AT notification parser.
 
   * Removed:
 

--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -337,7 +337,7 @@ struct lte_lc_edrx_cfg {
 	/**
 	 * LTE mode for which the configuration is valid.
 	 *
-	 * If the mode is @ref LTE_LC_LTE_MODE_NONE, eDRX is not used by the current cell.
+	 * If the mode is @ref LTE_LC_LTE_MODE_NONE, access technology is not using eDRX.
 	 */
 	enum lte_lc_lte_mode mode;
 
@@ -1449,6 +1449,18 @@ int lte_lc_edrx_param_set(enum lte_lc_lte_mode mode, const char *edrx);
  * @retval -EFAULT if AT command failed.
  */
 int lte_lc_edrx_req(bool enable);
+
+/**
+ * Get the eDRX parameters currently provided by the network.
+ *
+ * @param[out] edrx_cfg eDRX configuration.
+ *
+ * @retval 0 if successful.
+ * @retval -EINVAL if input argument was invalid.
+ * @retval -EFAULT if AT command failed.
+ * @retval -EBADMSG if parsing of the AT command response failed.
+ */
+int lte_lc_edrx_get(struct lte_lc_edrx_cfg *edrx_cfg);
 
 /**
  * Set the RAI value to be used.

--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -1078,6 +1078,30 @@ int lte_lc_edrx_req(bool enable)
 	return 0;
 }
 
+int lte_lc_edrx_get(struct lte_lc_edrx_cfg *edrx_cfg)
+{
+	int err;
+	char response[48];
+
+	if (edrx_cfg == NULL) {
+		return -EINVAL;
+	}
+
+	err = nrf_modem_at_cmd(response, sizeof(response), "AT+CEDRXRDP");
+	if (err) {
+		LOG_ERR("Failed to request eDRX parameters, error: %d", err);
+		return -EFAULT;
+	}
+
+	err = parse_edrx(response, edrx_cfg);
+	if (err) {
+		LOG_ERR("Failed to parse eDRX parameters, error: %d", err);
+		return -EBADMSG;
+	}
+
+	return 0;
+}
+
 int lte_lc_rai_req(bool enable)
 {
 	int err;

--- a/samples/cellular/modem_shell/src/link/link_shell.c
+++ b/samples/cellular/modem_shell/src/link/link_shell.c
@@ -168,8 +168,9 @@ static const char link_normal_mode_auto_usage_str[] =
 	"  -d, --disable,         Disable autoconnect\n";
 
 static const char link_edrx_usage_str[] =
-	"Usage: link edrx --enable --ltem|--nbiot [options] | --disable\n"
+	"Usage: link edrx --enable --ltem|--nbiot [options] | --disable | --read\n"
 	"Options:\n"
+	"  -r, --read,             Read eDRX parameters currently provided by the network\n"
 	"  -d, --disable,          Disable eDRX\n"
 	"  -e, --enable,           Enable eDRX\n"
 	"  -m, --ltem,             Set for LTE-M (LTE Cat-M1) system mode\n"
@@ -1080,6 +1081,22 @@ static int link_shell_edrx(const struct shell *shell, size_t argc, char **argv)
 			mosh_error("Cannot disable eDRX: %d", ret);
 		} else {
 			mosh_print("eDRX disabled");
+		}
+	} else if (common_option == LINK_COMMON_READ) {
+		struct lte_lc_edrx_cfg edrx_cfg;
+
+		ret = lte_lc_edrx_get(&edrx_cfg);
+		if (ret < 0) {
+			mosh_error("Cannot read eDRX parameters: %d", ret);
+		} else {
+			if (edrx_cfg.mode == LTE_LC_LTE_MODE_NONE) {
+				mosh_print("eDRX not in use");
+			} else {
+				mosh_print("eDRX LTE mode: %s, eDRX interval: %.2f s, PTW: %.2f s",
+					   edrx_cfg.mode == LTE_LC_LTE_MODE_LTEM ?
+						"LTE-M" : "NB-IoT",
+					   edrx_cfg.edrx, edrx_cfg.ptw);
+			}
 		}
 	} else {
 		link_shell_print_usage(LINK_CMD_EDRX);


### PR DESCRIPTION
Implemented support to LTE LC for reading eDRX parameters currently configured by the network. Fixed memory leak in +CEDRXS notification parser.

Implemented support to modem_shell for reading the currently configured eDRX parameters using the "link edrx" command.