### PR TITLE
doc: Bluetooth: Mesh: Remove "not-adopted" for Mesh DFU spec 1.0

### DIFF
--- a/doc/nrf/protocols/bt_mesh/dfu_over_bt_mesh.rst
+++ b/doc/nrf/protocols/bt_mesh/dfu_over_bt_mesh.rst
@@ -13,7 +13,7 @@ The DFU specification is implemented in the Zephyr Bluetooth mesh DFU subsystem 
 * :ref:`zephyr:bluetooth_mesh_dfu_cli`
 * :ref:`zephyr:bluetooth_mesh_dfd_srv`
 
-The specification that the Bluetooth mesh DFU subsystem is based on is not adopted yet, and therefore this feature should be used for experimental purposes only.
+The Bluetooth mesh DFU subsystem is in experimental state.
 For more information about the Zephyr Bluetooth mesh DFU subsystem, see :ref:`zephyr:bluetooth_mesh_dfu`.
 
 The Bluetooth mesh subsystem in |NCS| provides a set of samples that can be used for evaluation of the Bluetooth mesh DFU specification and subsystem:


### PR DESCRIPTION
Mesh DFU specification is now adopted. But the DFU subsystem is still in experimental state.