### PR TITLE
tfm: huk: Using full buffer to derive key

### DIFF
--- a/modules/tfm/tfm/boards/common/crypto_keys.c
+++ b/modules/tfm/tfm/boards/common/crypto_keys.c
@@ -30,7 +30,7 @@ static enum tfm_plat_err_t tfm_plat_get_huk(uint8_t *buf, size_t buf_len, size_t
 	uint8_t label[] = "TFM_HW_UNIQ_KEY";
 
 	int err = hw_unique_key_derive_key(HUK_KEYSLOT_MEXT, NULL, 0, label, sizeof(label), buf,
-					   HUK_SIZE_BYTES);
+					   buf_len);
 
 	if (err != HW_UNIQUE_KEY_SUCCESS) {
 		SPMLOG_DBGMSGVAL("hw_unique_key_derive_key err: ", err);


### PR DESCRIPTION
Also the first bytes nrf_cc3xx_platform_kmu_shadow_key_derive are different if output_size changes.
Therefore even on CC310 devices we have to use the previously used 32 bytes and just use the beginning of the buffer.

This ensures that still the same key gets derived after switching to the new buildin key framework.