### PR TITLE
Bluetooth: Mesh: Fix samples twister failures for upmerge

### DIFF
--- a/samples/bluetooth/mesh/light_dimmer/src/main.c
+++ b/samples/bluetooth/mesh/light_dimmer/src/main.c
@@ -41,7 +41,7 @@ static void bt_ready(int err)
 	printk("Mesh initialized\n");
 }
 
-void main(void)
+int main(void)
 {
 	int err;
 
@@ -51,4 +51,6 @@ void main(void)
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 	}
+
+	return 0;
 }

--- a/subsys/bluetooth/mesh/shell/shell_utils.c
+++ b/subsys/bluetooth/mesh/shell/shell_utils.c
@@ -14,8 +14,6 @@
 #include "mesh/access.h"
 #include "shell_utils.h"
 
-extern int errno;
-
 struct shell_model_instance {
 	uint16_t addr;
 	uint8_t elem_idx;


### PR DESCRIPTION
This PR fixes the following issues with mesh samples:
- Removes `extern int errno;` as the type may conflict with how it is defined in
`zephyr-sdk/arm-zephyr-eabi/picolibc/include/sys/errno.h`
- Return type of `main` function should be int when -Werror=main is enabled

The failures can be found here: https://jenkins-ncs.nordicsemi.no/job/latest/job/sdk-nrf/job/PR-12112/63/#showFailuresLink