### PR TITLE
samples: cellular: modem_shell: Improve "link edrx" command

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -422,6 +422,9 @@ Cellular samples (renamed from nRF9160 samples)
     * The sample to use the :ref:`lib_nrf_cloud` library function :c:func:`nrf_cloud_obj_pgps_request_create` to create a P-GPS request.
     * The modem system mode is now used when the sample starts, if the mode has not been set using the ``link sysmode`` command.
     * The sample to remove redundant shadow updates for nRF Cloud.
+    * The ``link edrx`` command syntax.
+      Parameters ``--ltem``, ``--nbiot``, ``--edrx_value,`` and ``--ptw`` are removed.
+      Instead, use ``--ltem_edrx``, ``--ltem_ptw``, ``--nbiot_edrx``, and ``--nbiot_ptw`` to give eDRX and PTW values for LTE-M and NB-IoT.
 
 * :ref:`lwm2m_client` sample:
 


### PR DESCRIPTION
Previously, the "link edrx" command required the system (LTE-M/NB-IoT) to be selected, although eDRX was always enabled for both systems.

The command syntax has now been changed so, that the system parameters are no longer used. Instead, it's possible to give eDRX and PTW values for both LTE-M and NB-IoT at the same time.

test-sdk-nrf: sdk-nrf-pr-12411