### PR TITLE
net: lib: download_client: Allow use of DTLS CID

### DIFF
--- a/doc/nrf/libraries/networking/download_client.rst
+++ b/doc/nrf/libraries/networking/download_client.rst
@@ -58,6 +58,8 @@ Make sure to configure the :kconfig:option:`CONFIG_DOWNLOAD_CLIENT_BUF_SIZE` and
 
 The application must provision the TLS credentials and pass the security tag to the library when using CoAPS and calling :c:func:`download_client_connect`.
 
+When you have modem firmware v1.3.5 or newer, you can use the :kconfig:option:`CONFIG_DOWNLOAD_CLIENT_CID` Kconfig option to enable the DTLS Connection Identifier feature in this library.
+
 Limitations
 ***********
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -799,6 +799,10 @@ Libraries for networking
 
 * :ref:`lib_download_client` library:
 
+  * Added:
+
+    * Kconfig option :kconfig:option:`CONFIG_DOWNLOAD_CLIENT_CID` that allows use of Connection Identifier on DTLS connection.
+
   * Updated:
 
     * The :kconfig:option:`CONFIG_DOWNLOAD_CLIENT_MAX_HOSTNAME_SIZE` Kconfig option's default value to ``255``.

--- a/subsys/net/lib/download_client/Kconfig
+++ b/subsys/net/lib/download_client/Kconfig
@@ -141,6 +141,12 @@ config DOWNLOAD_CLIENT_IPV6
 	  Prefer IPv6 protocol but fallback to
 	  IPv4 when the hostname can't be resolved.
 
+config DOWNLOAD_CLIENT_CID
+	bool "Use DTLS Connection-ID"
+	help
+	  Use DTLS Connection-ID option when downloading from CoAPS resources.
+	  This requires modem firmware 1.3.5 or newer.
+
 config DOWNLOAD_CLIENT_SHELL
 	bool "Enable shell"
 	depends on SHELL

--- a/subsys/net/lib/download_client/src/coap.c
+++ b/subsys/net/lib/download_client/src/coap.c
@@ -154,10 +154,6 @@ int coap_parse(struct download_client *client, size_t len)
 		return -EBADMSG;
 	}
 
-	err = coap_block_update(client, &response, &blk_off, &more);
-	if (err) {
-		return -EBADMSG;
-	}
 
 	if (coap_header_get_id(&response) != client->coap.pending.id) {
 		LOG_ERR("Response is not pending");
@@ -175,6 +171,11 @@ int coap_parse(struct download_client *client, size_t len)
 	if (response_code != COAP_RESPONSE_CODE_OK &&
 	    response_code != COAP_RESPONSE_CODE_CONTENT) {
 		LOG_ERR("Server responded with code 0x%x", response_code);
+		return -EBADMSG;
+	}
+
+	err = coap_block_update(client, &response, &blk_off, &more);
+	if (err) {
 		return -EBADMSG;
 	}
 

--- a/subsys/net/lib/download_client/src/coap.c
+++ b/subsys/net/lib/download_client/src/coap.c
@@ -47,6 +47,7 @@ int coap_block_init(struct download_client *client, size_t from)
 	coap_block_transfer_init(&client->coap.block_ctx,
 				 CONFIG_DOWNLOAD_CLIENT_COAP_BLOCK_SIZE, 0);
 	client->coap.block_ctx.current = from;
+	coap_pending_clear(&client->coap.pending);
 	return 0;
 }
 


### PR DESCRIPTION
* When connecting to DTLS service, enable Connection-ID.
    This helps the X509 certificate modes, where timeouts might happen during the certificate transfer.
