### PR TITLE
doc: bluetooth: mesh: Split out mesh samples

### DIFF
--- a/doc/nrf/device_guides/working_with_nrf/nrf52/features.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf52/features.rst
@@ -84,7 +84,7 @@ See :ref:`ug_bootloader` for more information and instructions on how to enable 
 Supported protocols
 *******************
 
-The nRF52 Series multiprotocol radio supports Bluetooth Low Energy (LE), proprietary protocols (including Enhanced ShockBurst and Gazell), ANT, Thread, Zigbee, and 802.15.4.
+The nRF52 Series multiprotocol radio supports Bluetooth Low Energy (LE) including Bluetooth mesh, proprietary protocols (including Enhanced ShockBurst and Gazell), ANT, Thread, Zigbee, and 802.15.4.
 Standard interface protocols like NFC and USB are supported on a range of the devices in the series and with supporting software.
 
 .. note::
@@ -119,7 +119,7 @@ It is optimized for creating large-scale device networks, and implemented accord
 
 Bluetooth mesh networking allows one-to-one, one-to-many, and many-to-many communication, using the Bluetooth LE protocol to exchange messages between the mesh nodes in the network.
 
-The |NCS| contains a variety of :ref:`Bluetooth mesh samples <ble_samples>` that target nRF52 Series devices.
+The |NCS| contains a variety of :ref:`bt_mesh_samples` that target nRF52 Series devices.
 In addition, you can run the :ref:`Bluetooth mesh samples <zephyr:bluetooth-samples>` that are included from Zephyr.
 
 For available libraries, see :ref:`bt_mesh` (|NCS|) and :ref:`zephyr:bluetooth_mesh` (Zephyr).

--- a/doc/nrf/device_guides/working_with_nrf/nrf53/nrf5340.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf53/nrf5340.rst
@@ -205,7 +205,7 @@ Bluetooth mesh
 --------------
 
 Bluetooth mesh operates on Bluetooth Low Energy (LE), and is implemented according to Bluetooth Mesh Profile Specification v1.0.1 and Bluetooth Mesh Model Specification v1.0.1.
-For the application core, the |NCS| provides several Bluetooth mesh samples along with the :ref:`Bluetooth Low Energy samples <ble_samples>`.
+For the application core, the |NCS| provides several :ref:`bt_mesh_samples`.
 In addition, you can find Bluetooth mesh samples with :ref:`Bluetooth samples in Zephyr <zephyr:bluetooth-samples>`.
 
 IEEE 802.15.4 (Thread and Zigbee)

--- a/doc/nrf/libraries/bluetooth_services/mesh.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh.rst
@@ -13,7 +13,7 @@ See the :ref:`Bluetooth mesh user guide <ug_bt_mesh>` for an overview of the tec
 
 The end-user applications (such as Luminaire control) are defined with the help of client-server Bluetooth mesh models defined in the `Bluetooth mesh model specification`_.
 Bluetooth mesh libraries contain modules, including the Bluetooth mesh models, provided by Nordic Semiconductor to aid in the development of Bluetooth mesh-based applications.
-They implement default behavior of a Bluetooth mesh device, and are used in :ref:`Bluetooth mesh samples <ble_samples>`.
+They implement default behavior of a Bluetooth mesh device, and are used in :ref:`bt_mesh_samples`.
 
 For information on how to use the supplied libraries for Bluetooth mesh, see :ref:`ug_bt_mesh_configuring`.
 

--- a/doc/nrf/libraries/bluetooth_services/mesh/dk_prov.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/dk_prov.rst
@@ -11,7 +11,7 @@ This application-side module is a basic implementation of the provisioning proce
 It supports four types of out-of-band (OOB) authentication methods and uses the Hardware Information driver to generate a deterministic UUID to uniquely represent the device.
 For more information about provisioning in Bluetooth® mesh, see the :ref:`zephyr:bluetooth_mesh_provisioning` page in Zephyr.
 
-Used primarily in :ref:`Bluetooth mesh sample applications <ble_samples>`, this handler acts as a reference implementation for the application-specific part of provisioning.
+Used primarily in :ref:`bt_mesh_samples` applications, this handler acts as a reference implementation for the application-specific part of provisioning.
 It is enabled with the :kconfig:option:`CONFIG_BT_MESH_DK_PROV` option and by calling :c:func:`bt_mesh_dk_prov_init` in main.
 
 The handling of the OOB authentication methods is closely tied to the hardware parameters of the Development Kits from Nordic Semiconductor.

--- a/doc/nrf/protocols/bt/ble/index.rst
+++ b/doc/nrf/protocols/bt/ble/index.rst
@@ -58,7 +58,7 @@ See the :ref:`Zephyr documentation <zephyr:bluetooth-overview>` for a detailed l
 Usage in samples
 ****************
 
-Most :ref:`Bluetooth LE samples <ble_samples>` in the |NCS| can use either Bluetooth LE Controller.
+Most :ref:`Bluetooth LE samples <ble_samples>` in the |NCS|, including the :ref:`bt_mesh_samples`, can use either Bluetooth LE Controller.
 An exception is the :ref:`ble_llpm` sample, which requires the SoftDevice Controller that supports LLPM.
 There is also a separate controller for the :ref:`nrf53_audio_app` application, namely the :ref:`lib_bt_ll_acs_nrf53_readme`.
 

--- a/doc/nrf/protocols/bt/bt_mesh/index.rst
+++ b/doc/nrf/protocols/bt/bt_mesh/index.rst
@@ -14,7 +14,7 @@ The messages are encrypted with two layers of 128-bit AES-CCM encryption, allowi
 The end-user applications are implemented as a set of mesh models.
 The Bluetooth SIG defines some generic and reusable models in the `Bluetooth mesh model specification`_, but vendors are free to define their own models.
 
-See :ref:`samples` for the list of available Bluetooth mesh samples.
+The |NCS| provides a number of :ref:`bt_mesh_samples` that demonstrate the Bluetooth mesh features and behavior.
 
 The Bluetooth mesh samples use the `nRF Mesh mobile app`_ to perform provisioning and configuration.
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -1059,6 +1059,7 @@ Documentation
   * A page on :ref:`ug_nrf70_developing_scan_operation` in the :ref:`ug_nrf70_developing` user guide.
   * The :ref:`ug_bt_qualification` page in :ref:`protocols`.
   * A section on Wi-Fi in the :ref:`app_memory` page.
+  * Own page for :ref:`bt_mesh_samples`.
 
 * Updated:
 

--- a/doc/nrf/samples.rst
+++ b/doc/nrf/samples.rst
@@ -26,6 +26,7 @@ General information about samples in the |NCS|
 
    samples/amazon_sidewalk
    samples/bl
+   samples/mesh
    samples/cellular
    samples/crypto
    samples/debug

--- a/doc/nrf/samples/bl.rst
+++ b/doc/nrf/samples/bl.rst
@@ -9,6 +9,3 @@ Bluetooth samples
    :glob:
 
    ../../../samples/bluetooth/*/README
-   ../../../samples/bluetooth/mesh/*/README
-   ../../../samples/bluetooth/mesh/dfu/distributor/README
-   ../../../samples/bluetooth/mesh/dfu/target/README

--- a/doc/nrf/samples/mesh.rst
+++ b/doc/nrf/samples/mesh.rst
@@ -1,0 +1,13 @@
+.. _bt_mesh_samples:
+
+Bluetooth mesh samples
+######################
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Subpages
+   :glob:
+
+   ../../../samples/bluetooth/mesh/*/README
+   ../../../samples/bluetooth/mesh/dfu/distributor/README
+   ../../../samples/bluetooth/mesh/dfu/target/README

--- a/samples/bluetooth/mesh/ble_peripheral_lbs_coex/README.rst
+++ b/samples/bluetooth/mesh/ble_peripheral_lbs_coex/README.rst
@@ -1,18 +1,18 @@
 .. _bluetooth_ble_peripheral_lbs_coex:
 
-Bluetooth: Mesh and peripheral coexistence
-##########################################
+Bluetooth mesh: Coexistence with other LE services
+##################################################
 
 .. contents::
    :local:
    :depth: 2
 
-This sample demonstrates how to combine Bluetooth® mesh and Bluetooth Low Energy features in a single application.
+This sample demonstrates how to combine Bluetooth® mesh and another Bluetooth Low Energy (LE) service in a single application.
 
 Requirements
 ************
 
-The mesh and peripheral coexistence sample supports the following development kits:
+This sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
@@ -24,7 +24,7 @@ The sample also requires a smartphone with `nRF Connect for Mobile`_ and one of 
 Overview
 ********
 
-The purpose of this sample is to showcase an application where a peripheral can operate independently of Bluetooth mesh.
+The purpose of this sample is to showcase an application where another Bluetooth LE service can operate independently of Bluetooth mesh.
 It combines the features of the :ref:`peripheral_lbs` sample and the :ref:`bluetooth_mesh_light` sample into a single application.
 
 The :ref:`lbs_readme` controls the state of a LED and monitors the state of a button on the device.

--- a/samples/bluetooth/mesh/chat/README.rst
+++ b/samples/bluetooth/mesh/chat/README.rst
@@ -1,6 +1,6 @@
 .. _bt_mesh_chat:
 
-Bluetooth: Mesh chat
+Bluetooth mesh: Chat
 ####################
 
 .. contents::

--- a/samples/bluetooth/mesh/dfu/distributor/README.rst
+++ b/samples/bluetooth/mesh/dfu/distributor/README.rst
@@ -1,6 +1,6 @@
 .. _ble_mesh_dfu_distributor:
 
-Bluetooth: Mesh Device Firmware Update (DFU) distributor
+Bluetooth mesh: Device Firmware Update (DFU) distributor
 ########################################################
 
 .. contents::

--- a/samples/bluetooth/mesh/dfu/target/README.rst
+++ b/samples/bluetooth/mesh/dfu/target/README.rst
@@ -1,6 +1,6 @@
 .. _ble_mesh_dfu_target:
 
-Bluetooth: Mesh Device Firmware Update (DFU) target
+Bluetooth mesh: Device Firmware Update (DFU) target
 ###################################################
 
 .. contents::

--- a/samples/bluetooth/mesh/light/README.rst
+++ b/samples/bluetooth/mesh/light/README.rst
@@ -1,6 +1,6 @@
 .. _bluetooth_mesh_light:
 
-Bluetooth: Mesh light
+Bluetooth mesh: Light
 #####################
 
 .. contents::

--- a/samples/bluetooth/mesh/light_ctrl/README.rst
+++ b/samples/bluetooth/mesh/light_ctrl/README.rst
@@ -1,6 +1,6 @@
 .. _bluetooth_mesh_light_lc:
 
-Bluetooth: Mesh light fixture
+Bluetooth mesh: Light fixture
 #############################
 
 .. contents::

--- a/samples/bluetooth/mesh/light_dimmer/README.rst
+++ b/samples/bluetooth/mesh/light_dimmer/README.rst
@@ -1,6 +1,6 @@
 .. _bluetooth_mesh_light_dim:
 
-Bluetooth: Mesh light dimmer and scene selector
+Bluetooth mesh: Light dimmer and scene selector
 ###############################################
 
 .. contents::

--- a/samples/bluetooth/mesh/light_switch/README.rst
+++ b/samples/bluetooth/mesh/light_switch/README.rst
@@ -1,6 +1,6 @@
 .. _bluetooth_mesh_light_switch:
 
-Bluetooth: Mesh light switch
+Bluetooth mesh: Light switch
 ############################
 
 .. contents::

--- a/samples/bluetooth/mesh/sensor_client/README.rst
+++ b/samples/bluetooth/mesh/sensor_client/README.rst
@@ -1,6 +1,6 @@
 .. _bluetooth_mesh_sensor_client:
 
-Bluetooth: Mesh sensor observer
+Bluetooth mesh: Sensor observer
 ###############################
 
 .. contents::

--- a/samples/bluetooth/mesh/sensor_server/README.rst
+++ b/samples/bluetooth/mesh/sensor_server/README.rst
@@ -1,6 +1,6 @@
 .. _bluetooth_mesh_sensor_server:
 
-Bluetooth: Mesh sensor
+Bluetooth mesh: Sensor
 ######################
 
 .. contents::

--- a/samples/bluetooth/mesh/silvair_enocean/README.rst
+++ b/samples/bluetooth/mesh/silvair_enocean/README.rst
@@ -1,6 +1,6 @@
 .. _bluetooth_mesh_silvair_enocean:
 
-Bluetooth: Mesh Silvair EnOcean
+Bluetooth mesh: Silvair EnOcean
 ###############################
 
 .. contents::


### PR DESCRIPTION
The list of Bluetooth samples, including the Bluetooth mesh samples, has gotten longer. Bluetooth mesh samples drown a little and are not easily spotted.
Splitting out mesh samples onto a separate page.
