### PR TITLE
samples: matter: fix lock switchable buffer allocation

### DIFF
--- a/samples/matter/lock/Kconfig
+++ b/samples/matter/lock/Kconfig
@@ -64,6 +64,11 @@ config THREAD_WIFI_SWITCHING_CLI_SUPPORT
 	default n
 	select CHIP_LIB_SHELL
 
+# We need more heap size for image swap buffers
+config CHIP_MALLOC_SYS_HEAP_SIZE
+	default 30720 if CHIP_WIFI
+	default 10240 if NET_L2_OPENTHREAD
+
 endif
 
 # Sample configuration used for Thread networking

--- a/samples/matter/lock/src/software_images_swapper.cpp
+++ b/samples/matter/lock/src/software_images_swapper.cpp
@@ -31,6 +31,7 @@ int SoftwareImagesSwapper::Swap(const ImageLocation &source, SoftwareImagesSwapD
 
 	uint8_t *dfuImageBuffer = (uint8_t *)malloc(kBufferSize);
 	if (!dfuImageBuffer) {
+		LOG_ERR("Cannot allocate application DFU image buffer");
 		return -ENOMEM;
 	}
 
@@ -79,6 +80,7 @@ int SoftwareImagesSwapper::SwapImage(uint32_t address, uint32_t size, uint8_t id
 
 	uint8_t *flashImageBuffer = (uint8_t *)malloc(kBufferSize);
 	if (!flashImageBuffer) {
+		LOG_ERR("Cannot allocate application flash image buffer");
 		return -ENOMEM;
 	}
 


### PR DESCRIPTION
We need to increase the static heap by 2k (1k is not enough) for both WiFi
and Thread variants to allow buffer allocations when swapping images.