### PR TITLE
lib: lte_link_control: add name to LTE priority symbol

### DIFF
--- a/lib/lte_link_control/Kconfig
+++ b/lib/lte_link_control/Kconfig
@@ -177,7 +177,7 @@ config LTE_NETWORK_MODE_LTE_M_NBIOT_GPS
 
 endchoice
 
-choice
+choice LTE_NETWORK_MODE_PREFERENCE
 	prompt "LTE mode preference"
 	default LTE_MODE_PREFERENCE_AUTO
 	help


### PR DESCRIPTION
Add a name to the LTE mode priority symbol so that the default can be updated by other kconfig files.
`LTE_MODE_PREFERENCE` would be preferred to align with the choice options, but this is already taken by the final integer symbol.