### PR TITLE
manifest: Bring TF-M with assertion fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -145,7 +145,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: 77828ef1a0ae5f3e1fe21c4d77b14678b0c61bf2
+      revision: dc3651a7f8edb279b2bc8b08f7e945033e4662dd
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter


### PR DESCRIPTION
This brings TF-M with a bugfix which prevented TF-M from booting in debug mode on NRF91 series.