### PR TITLE
Lwm2m modem firmware udate

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/lwm2m_integration/lwm2m_integration.c
+++ b/applications/asset_tracker_v2/src/cloud/lwm2m_integration/lwm2m_integration.c
@@ -288,6 +288,10 @@ static int lwm2m_firmware_event_cb(struct lwm2m_fota_event *event)
 			event->failure.update_failure);
 		cloud_wrap_evt.type = CLOUD_WRAP_EVT_FOTA_ERROR;
 		break;
+	case LWM2M_FOTA_UPDATE_MODEM_RECONNECT_REQ:
+		/* FOTA requests modem re-initialization and client re-connection */
+		/* Return -1 to cause normal system reboot */
+		return -1;
 	}
 
 	cloud_wrapper_notify_event(&cloud_wrap_evt);

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -201,7 +201,11 @@ This section provides detailed lists of changes by :ref:`application <applicatio
 Asset Tracker v2
 ----------------
 
-* Added support for the nRF9161 development kit.
+* Added:
+
+  * Support for the nRF9161 development kit.
+  * A handler for a new LwM2M modem firmware callback event c:member:`LWM2M_FOTA_UPDATE_MODEM_RECONNECT_REQ`.
+    The handler may return ``-1`` to keep the default behavior of system reset after the modem update.
 
 * Updated:
 
@@ -457,6 +461,9 @@ Cellular samples (renamed from nRF9160 samples)
     * An overlay for enabling proprietary Power Saving Mode (PSM).
       This will fix a case where a battery-operated device joins a network that does not support PSM.
       This fulfills the proprietary PSM requirements of modem firmware v2.0.0.
+      Including a new overlay file for enabling this and devicetree overlay files for UART2 and MCUboot recovery mode.
+    * A handler for a new LwM2M modem firmware callback event :c:member:`LWM2M_FOTA_UPDATE_MODEM_RECONNECT_REQ` to request for reconnecting the modem and client after firmware update
+    * A new state :c:member:`RECONNECT_AFTER_UPDATE` that initializes the modem to trigger LwM2M client re-connection.
 
   * Updated the sample to use tickless operating mode from Zephyr's LwM2M engine, which does not cause device wake-up in 500 ms interval anymore.
     This allows the device to achieve two µA of current usage while in PSM sleep mode.
@@ -819,6 +826,7 @@ Libraries for networking
     * Support for MCUmgr SMP client to perform a FOTA on an external SoC.
     * Advanced LwM2M FOTA support for an external MCU with DFU SMP target.
     * FOTA download Utils API integrated to the library.
+    * A new LwM2M modem firmware callback event type :c:member:`LWM2M_FOTA_UPDATE_MODEM_RECONNECT_REQ` to request re-connection after modem firmware update.
 
   * Updated Zephyr's LwM2M Connectivity Monitor object to use a 16-bit value for radio signal strength so that it does not roll over on values smaller than -126 dBm.
 
@@ -854,8 +862,12 @@ Libraries for networking
 
 * :ref:`lib_fota_download` library:
 
-  * Added support for DFU SMP target with new Utils API that in turn supports downloading, scheduling and activating images in all FOTA DFU targets.
-  * Updated the library to verify whether the download started with the same URI and resumed the interrupted download.
+  * Added:
+
+    * Support for DFU SMP target with new Utils API that in turn supports downloading, scheduling and activating images in all FOTA DFU targets.
+    * Support for full and delta modem firmware update without a reboot.
+    * Added support for Delta Modem and Full modem firmware update without a reboot.
+    * Updated the library, which now verifies whether the download started with the same URI and resumes the interrupted download.
 
 * :ref:`lib_nrf_cloud_alert` library:
 

--- a/include/net/lwm2m_client_utils.h
+++ b/include/net/lwm2m_client_utils.h
@@ -153,6 +153,8 @@ enum lwm2m_fota_event_id {
 	LWM2M_FOTA_DOWNLOAD_FINISHED,
 	/** Request for update new image */
 	LWM2M_FOTA_UPDATE_IMAGE_REQ,
+	/** Request to reconnect the modem and LwM2M client*/
+	LWM2M_FOTA_UPDATE_MODEM_RECONNECT_REQ,
 	/** Fota process fail or cancelled  */
 	LWM2M_FOTA_UPDATE_ERROR
 };
@@ -165,7 +167,7 @@ struct lwm2m_fota_download_start {
 
 /** Event data for id LWM2M_FOTA_DOWNLOAD_FINISHED. */
 struct lwm2m_fota_download_finished {
-	/** Object Instance  id for event */
+	/** Object Instance ID for event */
 	uint16_t obj_inst_id;
 	/** DFU type */
 	int dfu_type;
@@ -173,22 +175,28 @@ struct lwm2m_fota_download_finished {
 
 /** Event data for id LWM2M_FOTA_UPDATE_IMAGE_REQ. */
 struct lwm2m_fota_update_request {
-	/** Object Instance  id for event */
+	/** Object Instance ID for event */
 	uint16_t obj_inst_id;
 	/** DFU type */
 	int dfu_type;
 };
 
-/** Event data for id LWM2M_FOTA_UPDATE_ERROR. */
+/** Event data for ID LWM2M_FOTA_UPDATE_MODEM_RECONNECT_REQ. */
+struct lwm2m_fota_reconnect {
+	/** Object Instance ID for event */
+	uint16_t obj_inst_id;
+};
+
+/** Event data for ID LWM2M_FOTA_UPDATE_ERROR. */
 struct lwm2m_fota_update_failure {
-	/** Object Instance  id for event */
+	/** Object Instance ID for event */
 	uint16_t obj_inst_id;
 	/** FOTA failure result */
 	uint8_t update_failure;
 };
 
 struct lwm2m_fota_event {
-	/** Fota event id and indicate used Data structure */
+	/** Fota event ID and indicate used Data structure */
 	enum lwm2m_fota_event_id id;
 	union {
 		/** LWM2M_FOTA_DOWNLOAD_START */
@@ -197,6 +205,8 @@ struct lwm2m_fota_event {
 		struct lwm2m_fota_download_finished download_ready;
 		/** LWM2M_FOTA_UPDATE_IMAGE_REQ */
 		struct lwm2m_fota_update_request update_req;
+		/** LWM2M_FOTA_UPDATE_MODEM_RECONNECT_REQ */
+		struct lwm2m_fota_reconnect reconnect_req;
 		/** LWM2M_FOTA_UPDATE_ERROR */
 		struct lwm2m_fota_update_failure failure;
 	};
@@ -207,8 +217,8 @@ struct lwm2m_fota_event {
  *
  * @param[in] event LwM2M Firmware Update object event structure
  *
- * Callback is used for indicating firmware update states and to prepare application ready
- * for update.
+ * This callback is used for indicating firmware update states, to prepare the application
+ * for an update, and to request for reconnecting the modem after the firmware update.
  *
  * Event handler is getting event callback when Firmware update utils library change states.
  *
@@ -220,6 +230,13 @@ struct lwm2m_fota_event {
  * Callback handler may return zero to grant permission for update. Otherwise it may
  * return negative error code to cancel the update or positive value to indicate that
  * update should be postponed that amount of seconds.
+ *
+ * LWM2M_FOTA_UPDATE_MODEM_RECONNECT_REQ: Request a reconnect and initialize the modem after a
+ * firmware update.
+ * The callback handler may return 0 to indicate that the application is handling the reconnect.
+ * Modem initialization and LwM2M client re-connection needs to be handled outside of the callback
+ * context.
+ * Otherwise, return -1 to indicate that the device is rebooting
  *
  * LWM2M_FOTA_UPDATE_ERROR: Indicate that FOTA process have failed or cancelled.
  *

--- a/subsys/net/lib/fota_download/src/util/fota_download_delta_modem.c
+++ b/subsys/net/lib/fota_download/src/util/fota_download_delta_modem.c
@@ -26,7 +26,6 @@ int fota_download_apply_delta_modem_update(void)
 	int ret;
 	int result;
 
-	lte_lc_deinit();
 	nrf_modem_lib_shutdown();
 	ret = nrf_modem_lib_init();
 

--- a/subsys/net/lib/fota_download/src/util/fota_download_full_modem.c
+++ b/subsys/net/lib/fota_download/src/util/fota_download_full_modem.c
@@ -43,7 +43,24 @@ int fota_download_full_modem_apply_update(void)
 		return ret;
 	}
 	LOG_INF("Modem firmware update completed");
-	return 0;
+
+	/* Shuttdown modem from bootloader mode */
+	ret = nrf_modem_lib_shutdown();
+	if (ret != 0) {
+		LOG_ERR("nrf_modem_lib_shutdown() failed: %d\n", ret);
+		return ret;
+	}
+
+	/* Initialize Modem with new Image */
+	ret = nrf_modem_lib_init();
+
+	LOG_INF("Modem init %d", ret);
+	if (ret != 0) {
+		LOG_ERR("nrf_modem_lib_init() failed: %d\n", ret);
+		return ret;
+	}
+
+	return ret;
 }
 
 int fota_download_full_modem_stream_params_init(void)

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_adv_firmware.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_adv_firmware.c
@@ -258,7 +258,7 @@ static int package_write_cb(uint16_t obj_inst_id, uint16_t res_id, uint16_t res_
 	if (state == STATE_IDLE) {
 		lwm2m_adv_firmware_set_update_state(obj_inst_id, STATE_DOWNLOADING);
 	} else if (data_len == 0U || (data_len == 1U && data[0] == '\0')) {
-		if (state == STATE_DOWNLOADED || STATE_DOWNLOADING) {
+		if (state == STATE_DOWNLOADED || state == STATE_DOWNLOADING) {
 			/* reset to state idle and result default */
 			lwm2m_adv_firmware_set_update_result(obj_inst_id, RESULT_DEFAULT);
 			LOG_DBG("Update canceled by writing %d bytes", data_len);

--- a/tests/subsys/net/lib/lwm2m_fota_utils/src/firmware.c
+++ b/tests/subsys/net/lib/lwm2m_fota_utils/src/firmware.c
@@ -308,6 +308,9 @@ static int lwm2m_firmware_event(struct lwm2m_fota_event *event)
 		fota_event.failure.obj_inst_id = event->failure.obj_inst_id;
 		fota_event.failure.update_failure = event->failure.update_failure;
 		break;
+	case LWM2M_FOTA_UPDATE_MODEM_RECONNECT_REQ:
+		fota_event.reconnect_req.obj_inst_id = event->reconnect_req.obj_inst_id;
+		break;
 	}
 
 	return 0;
@@ -766,7 +769,7 @@ ZTEST(lwm2m_client_utils_firmware, test_firmware_multinstace_download)
 	printf("State %d\r\n", state);
 	zassert_equal(state, STATE_DOWNLOADED, "wrong result value");
 
-	/* Test linkek update with unknown object link */
+	/* Test linked update with unknown object link */
 	rc = lwm2m_firmware_update(app_instance, link_modem_instance2,
 				   sizeof(link_modem_instance2));
 	printf("Update %d\r\n", rc);


### PR DESCRIPTION
Fota_download:

- Updated Delta & Full modem utils apply update to support reconnect after update

LwM2M client utils library:

- Added support for update modem firmware without reboot.
- New FOTA CB event type for request modem init and connect.

LwM2M Client:

- LwM2M client sample support new event for init modem and connect Client again to server.
- New state for Modem init and client reconnect

Asset Tarcker v2:

- Added handler for new event but keeps original functionality still system reboot.