### PR TITLE
manifest: Update zephyr to remove hardcoding of cc3xx variant to SoC

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: b9253f60e83c046fa432d49b157e1536af1f1ab2
+      revision: pull/1253/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update zephyr to remove hardcoding of cc3xx variant for SoC in Kconfig and instead pull this information from the DTS.