### PR TITLE
matter: enable NVS lookup cache settings optimization

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -149,7 +149,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 3b93541c781635bf6882edec4eff8e142f219fd4
+      revision: ba4b30a246e95e3023e562bc5d00a5a6771feca5
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
Pull Zephyr noup change that adds the NVS lookup cache hash function optimized for NVS used as the settings backend. Pull Matter change that enables the hash function for Matter applications, by default.