### PR TITLE
Mqtt helper password

### DIFF
--- a/include/net/mqtt_helper.h
+++ b/include/net/mqtt_helper.h
@@ -72,6 +72,7 @@ struct mqtt_helper_conn_params {
 	struct mqtt_helper_buf hostname;
 	struct mqtt_helper_buf device_id;
 	struct mqtt_helper_buf user_name;
+	struct mqtt_helper_buf password;
 };
 
 /** @brief Initialize the MQTT helper.

--- a/samples/net/mqtt/doc/description.rst
+++ b/samples/net/mqtt/doc/description.rst
@@ -69,6 +69,18 @@ CONFIG_MQTT_SAMPLE_TRANSPORT_CLIENT_ID - MQTT client ID
 	This configuration sets the MQTT client ID name.
 	If not set, the client ID will default to the modem's IMEI number for nRF91 Series devices, MAC address for nRF70 Series devices, or a random number for Native Posix.
 
+.. _CONFIG_MQTT_SAMPLE_TRANSPORT_USER_NAME:
+
+CONFIG_MQTT_SAMPLE_TRANSPORT_USER_NAME - MQTT client username
+	This configuration sets the MQTT client username for password based authentication. It must be provided if password is provided.
+   Not set by default.
+
+.. _CONFIG_MQTT_SAMPLE_TRANSPORT_PASSWORD:
+
+CONFIG_MQTT_SAMPLE_TRANSPORT_PASSWORD - MQTT client password
+	This configuration sets the MQTT client password for password based authentication. 
+   Not set by default.
+
 .. _CONFIG_MQTT_SAMPLE_TRANSPORT_PUBLISH_TOPIC:
 
 CONFIG_MQTT_SAMPLE_TRANSPORT_PUBLISH_TOPIC - MQTT publish topic

--- a/samples/net/mqtt/src/modules/transport/Kconfig.transport
+++ b/samples/net/mqtt/src/modules/transport/Kconfig.transport
@@ -34,6 +34,19 @@ config MQTT_SAMPLE_TRANSPORT_BROKER_HOSTNAME
 	string "MQTT broker hostname"
 	default "test.mosquitto.org"
 
+config MQTT_SAMPLE_TRANSPORT_USER_NAME
+	string "MQTT client user name"
+	default ""
+	help
+	  username used for password based authentication
+
+config MQTT_SAMPLE_TRANSPORT_PASSWORD
+	string "MQTT Client password"
+	default ""
+	help
+	  set password for password based authentication. If password is provided then 
+	  username must also be provided.
+
 config MQTT_SAMPLE_TRANSPORT_CLIENT_ID
 	string "MQTT Client ID"
 	default ""

--- a/samples/net/mqtt/src/modules/transport/Kconfig.transport
+++ b/samples/net/mqtt/src/modules/transport/Kconfig.transport
@@ -38,13 +38,13 @@ config MQTT_SAMPLE_TRANSPORT_USER_NAME
 	string "MQTT client user name"
 	default ""
 	help
-	  username used for password based authentication
+	  Username used for password based authentication.
 
 config MQTT_SAMPLE_TRANSPORT_PASSWORD
 	string "MQTT Client password"
 	default ""
 	help
-	  set password for password based authentication. If password is provided then 
+	  Set password for password based authentication. If password is provided then 
 	  username must also be provided.
 
 config MQTT_SAMPLE_TRANSPORT_CLIENT_ID

--- a/samples/net/mqtt/src/modules/transport/transport.c
+++ b/samples/net/mqtt/src/modules/transport/transport.c
@@ -189,6 +189,10 @@ static void connect_work_fn(struct k_work *work)
 		.hostname.size = strlen(CONFIG_MQTT_SAMPLE_TRANSPORT_BROKER_HOSTNAME),
 		.device_id.ptr = client_id,
 		.device_id.size = strlen(client_id),
+		.user_name.ptr = CONFIG_MQTT_SAMPLE_TRANSPORT_USER_NAME,
+		.user_name.size = strlen(CONFIG_MQTT_SAMPLE_TRANSPORT_USER_NAME),
+		.password.ptr = CONFIG_MQTT_SAMPLE_TRANSPORT_PASSWORD,
+		.password.size = strlen(CONFIG_MQTT_SAMPLE_TRANSPORT_PASSWORD)
 	};
 
 	err = client_id_get(client_id, sizeof(client_id));

--- a/subsys/net/lib/mqtt_helper/mqtt_helper.c
+++ b/subsys/net/lib/mqtt_helper/mqtt_helper.c
@@ -429,6 +429,11 @@ static int client_connect(struct mqtt_helper_conn_params *conn_params)
 		.size = conn_params->user_name.size,
 	};
 
+	struct mqtt_utf8 password = {
+		.utf8 = conn_params->password.ptr,
+		.size = conn_params->password.size,
+	};
+
 	mqtt_client_init(&mqtt_client);
 
 	err = broker_init(&broker, conn_params);
@@ -440,7 +445,6 @@ static int client_connect(struct mqtt_helper_conn_params *conn_params)
 	mqtt_client.evt_cb	        = mqtt_evt_handler;
 	mqtt_client.client_id.utf8      = conn_params->device_id.ptr;
 	mqtt_client.client_id.size      = conn_params->device_id.size;
-	mqtt_client.password	        = NULL;
 	mqtt_client.protocol_version    = MQTT_VERSION_3_1_1;
 	mqtt_client.rx_buf	        = rx_buffer;
 	mqtt_client.rx_buf_size	        = sizeof(rx_buffer);
@@ -452,6 +456,7 @@ static int client_connect(struct mqtt_helper_conn_params *conn_params)
 	mqtt_client.transport.type	= MQTT_TRANSPORT_NON_SECURE;
 #endif /* CONFIG_MQTT_LIB_TLS */
 	mqtt_client.user_name	        = conn_params->user_name.size > 0 ? &user_name : NULL;
+	mqtt_client.password	        = conn_params->password.size > 0 ? &password : NULL;
 
 #if defined(CONFIG_MQTT_LIB_TLS)
 	struct mqtt_sec_config *tls_cfg = &(mqtt_client.transport).tls.config;

--- a/subsys/net/lib/mqtt_helper/mqtt_helper.c
+++ b/subsys/net/lib/mqtt_helper/mqtt_helper.c
@@ -428,7 +428,6 @@ static int client_connect(struct mqtt_helper_conn_params *conn_params)
 		.utf8 = conn_params->user_name.ptr,
 		.size = conn_params->user_name.size,
 	};
-
 	struct mqtt_utf8 password = {
 		.utf8 = conn_params->password.ptr,
 		.size = conn_params->password.size,


### PR DESCRIPTION
- added support for password based authentication in the mqtt_helper library.
- enabled the kconfig options in the mqtt sample for setting username and password.

These changes were originally made in this PR https://github.com/nrfconnect/sdk-nrf/pull/10498 as part of changed to add IPV6 support. However it was closed without merging and a new PR https://github.com/nrfconnect/sdk-nrf/pull/10519 was made only related to IPV6. therefore creating a new pull request to enable password based authentication support in the mqtt_helper.