### PR TITLE
[bluetooth] avoid waiting with K_FOREVER on buffer

### DIFF
--- a/include/mpsl/mpsl_work.h
+++ b/include/mpsl/mpsl_work.h
@@ -49,6 +49,11 @@ static inline int mpsl_work_submit(struct k_work *work)
 	return k_work_submit_to_queue(&mpsl_work_q, work);
 }
 
+static inline int mpsl_work_schedule(struct k_work_delayable *work, k_timeout_t delay)
+{
+	return k_work_reschedule_for_queue(&mpsl_work_q, work, delay);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -196,9 +196,15 @@ void sdc_assertion_handler(const char *const file, const uint32_t line)
 #endif /* IS_ENABLED(CONFIG_BT_CTLR_ASSERT_HANDLER) */
 
 static struct k_work receive_work;
+static struct k_work_delayable receive_work_delayable;
 static inline void receive_signal_raise(void)
 {
 	mpsl_work_submit(&receive_work);
+}
+
+static inline void receive_signal_raise_delayable(void)
+{
+	mpsl_work_schedule(&receive_work_delayable, K_MSEC(10));
 }
 
 static int cmd_handle(struct net_buf *cmd)
@@ -276,16 +282,16 @@ static int hci_driver_send(struct net_buf *buf)
 	return err;
 }
 
-static void data_packet_process(uint8_t *hci_buf)
+static bool data_packet_process(uint8_t *hci_buf)
 {
-	struct net_buf *data_buf = bt_buf_get_rx(BT_BUF_ACL_IN, K_FOREVER);
+	struct net_buf *data_buf = bt_buf_get_rx(BT_BUF_ACL_IN, K_NO_WAIT);
 	struct bt_hci_acl_hdr *hdr = (void *)hci_buf;
 	uint16_t hf, handle, len;
 	uint8_t flags, pb, bc;
 
 	if (!data_buf) {
 		LOG_ERR("No data buffer available");
-		return;
+		return true;
 	}
 
 	len = sys_le16_to_cpu(hdr->len);
@@ -300,6 +306,7 @@ static void data_packet_process(uint8_t *hci_buf)
 
 	net_buf_add_mem(data_buf, &hci_buf[0], len + sizeof(*hdr));
 	bt_recv(data_buf);
+	return false;
 }
 
 static bool event_packet_is_discardable(const uint8_t *hci_buf)
@@ -344,7 +351,7 @@ static bool event_packet_is_discardable(const uint8_t *hci_buf)
 	}
 }
 
-static void event_packet_process(uint8_t *hci_buf)
+static bool event_packet_process(uint8_t *hci_buf)
 {
 	bool discardable = event_packet_is_discardable(hci_buf);
 	struct bt_hci_evt_hdr *hdr = (void *)hci_buf;
@@ -373,53 +380,62 @@ static void event_packet_process(uint8_t *hci_buf)
 		LOG_DBG("Event (0x%02x) len %u", hdr->evt, hdr->len);
 	}
 
-	evt_buf = bt_buf_get_evt(hdr->evt, discardable,
-				 discardable ? K_NO_WAIT : K_FOREVER);
+	evt_buf = bt_buf_get_evt(hdr->evt, discardable, K_NO_WAIT);
 
 	if (!evt_buf) {
 		if (discardable) {
 			LOG_DBG("Discarding event");
-			return;
+			return false;
 		}
 
 		LOG_ERR("No event buffer available");
-		return;
+		return true;
 	}
 
 	net_buf_add_mem(evt_buf, &hci_buf[0], hdr->len + sizeof(*hdr));
 	bt_recv(evt_buf);
+	return false;
 }
 
 static bool fetch_and_process_hci_msg(uint8_t *p_hci_buffer)
 {
 	int errcode;
-	sdc_hci_msg_type_t msg_type;
-
-	errcode = MULTITHREADING_LOCK_ACQUIRE();
-	if (!errcode) {
-		errcode = hci_internal_msg_get(p_hci_buffer, &msg_type);
-		MULTITHREADING_LOCK_RELEASE();
+	static sdc_hci_msg_type_t msg_type;
+	/*msg_type == 0 means we should fetch a new event from sdc.*/
+	if (msg_type == 0)
+	{
+		errcode = MULTITHREADING_LOCK_ACQUIRE();
+		if (!errcode) {
+			errcode = hci_internal_msg_get(p_hci_buffer, &msg_type);
+			MULTITHREADING_LOCK_RELEASE();
+		}
+		if (errcode) {
+			msg_type = 0;
+			return false;
+		}
 	}
 
-	if (errcode) {
-		return false;
-	}
-
+	bool retry_later = false;
 	if (msg_type == SDC_HCI_MSG_TYPE_EVT) {
-		event_packet_process(p_hci_buffer);
+		retry_later = event_packet_process(p_hci_buffer);
 	} else if (msg_type == SDC_HCI_MSG_TYPE_DATA) {
-		data_packet_process(p_hci_buffer);
+		retry_later = data_packet_process(p_hci_buffer);
 	} else {
 		if (!IS_ENABLED(CONFIG_BT_CTLR_SDC_SILENCE_UNEXPECTED_MSG_TYPE)) {
 			LOG_ERR("Unexpected msg_type: %u. This if-else needs a new branch",
 				msg_type);
 		}
 	}
-
+	if (retry_later)
+	{
+		receive_signal_raise_delayable();
+		return false;
+	}
+	msg_type = 0;
 	return true;
 }
 
-void hci_driver_receive_process(void)
+void hci_driver_receive_process()
 {
 #if defined(CONFIG_BT_BUF_EVT_DISCARDABLE_COUNT)
 	static uint8_t hci_buf[MAX(BT_BUF_RX_SIZE,
@@ -978,6 +994,7 @@ static int hci_driver_open(void)
 	}
 
 	MULTITHREADING_LOCK_RELEASE();
+	k_work_init_delayable(&receive_work_delayable, receive_work_handler);
 
 	return 0;
 }


### PR DESCRIPTION
To avoid deadlocks, if we don't have a buffer,
wait 10ms and retry then. keep packet on stack
in the meantime.

reopening of https://github.com/nrfconnect/sdk-nrf/pull/9556