### PR TITLE
applications: Added overlays allowing to support more BT conns.

### DIFF
--- a/applications/matter_bridge/overlay-bt_max_connections_app.conf
+++ b/applications/matter_bridge/overlay-bt_max_connections_app.conf
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Set 20 BLE connections, as it is an upper limit supported by the Soft Device Controller.
+CONFIG_BT_MAX_CONN=20
+
+# Set buffer sizes in a consistent way with the ones used by the network core.
+CONFIG_BT_BUF_ACL_RX_SIZE=96
+CONFIG_BT_BUF_ACL_TX_SIZE=96
+CONFIG_BT_CTLR_DATA_LENGTH_MAX=96
+
+# Set MTU size to fit in the single buffer and avoid fragmentation (BUF_SIZE = MTU_SIZE + 4 B of L2CAP header).
+CONFIG_BT_L2CAP_TX_MTU=92
+
+# Set max number of bridged BLE devices, which is CONFIG_BT_MAX_CONN-1, as 1 connection is reserved for Matter.
+CONFIG_BRIDGE_MAX_BRIDGED_DEVICES_NUMBER=19
+
+# Assume that every bridged device uses only 1 endpoint, however it can be increased if specific use case requires it.
+CONFIG_BRIDGE_MAX_DYNAMIC_ENDPOINTS_NUMBER=19

--- a/applications/matter_bridge/overlay-bt_max_connections_net.conf
+++ b/applications/matter_bridge/overlay-bt_max_connections_net.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Set 20 BLE connections, as it is an upper limit supported by the Soft Device Controller
+CONFIG_BT_MAX_CONN=20
+
+# Decrease stack and buffer sizes to free some RAM and support 20 BLE connections
+CONFIG_MAIN_STACK_SIZE=512
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=512
+CONFIG_BT_BUF_ACL_RX_SIZE=96
+CONFIG_BT_BUF_ACL_TX_SIZE=96
+CONFIG_BT_CTLR_DATA_LENGTH_MAX=96


### PR DESCRIPTION
The Matter bridge application is able to support only 10 BT connections on the network core.

Added overlays allowing to increase the number of BT connections by decreasing the size of stacks and BT buffers. Additionally updated the readme to describe how to use it.