### PR TITLE
doc: nrf21540: fix typo in shield name

### DIFF
--- a/applications/nrf5340_audio/README.rst
+++ b/applications/nrf5340_audio/README.rst
@@ -396,12 +396,12 @@ Adding FEM support
 You can add support for the nRF21540 front-end module (FEM) to this application by using one of the following options, depending on how you decide to build the application:
 
 * If you opt for :ref:`nrf53_audio_app_building_script`, add the ``--nrf21540`` to the script's building command.
-* If you opt for :ref:`nrf53_audio_app_building_standard`, add the ``-DSHIELD=nrf21540ek_fwd`` to the ``west build`` command.
+* If you opt for :ref:`nrf53_audio_app_building_standard`, add the ``-DSHIELD=nrf21540_ek_fwd`` to the ``west build`` command.
   For example:
 
   .. code-block:: console
 
-     west build -b nrf5340_audio_dk_nrf5340_cpuapp --pristine -- -DCONFIG_AUDIO_DEV=1 -DSHIELD=nrf21540ek_fwd -DCONF_FILE=prj_release.conf
+     west build -b nrf5340_audio_dk_nrf5340_cpuapp --pristine -- -DCONFIG_AUDIO_DEV=1 -DSHIELD=nrf21540_ek_fwd -DCONF_FILE=prj_release.conf
 
 To set the TX power output, use the :ref:`CONFIG_NRF_21540_MAIN_TX_POWER <config_nrf53_audio_app_options>` and :ref:`CONFIG_NRF_21540_PRI_ADV_TX_POWER <config_nrf53_audio_app_options>` Kconfig options.
 

--- a/applications/nrf_desktop/README.rst
+++ b/applications/nrf_desktop/README.rst
@@ -842,7 +842,7 @@ The command for ``nrf5340dk_nrf5340_cpuapp`` with ``nrf21540ek`` shield would lo
 
 .. code-block:: console
 
-   west build -b nrf5340dk_nrf5340_cpuapp -- -DSHIELD=nrf21540ek_fwd -Dhci_rpmsg_SHIELD=nrf21540ek -DCONFIG_CAF_BLE_USE_LLPM=n
+   west build -b nrf5340dk_nrf5340_cpuapp -- -DSHIELD=nrf21540_ek_fwd -Dhci_rpmsg_SHIELD=nrf21540ek -DCONFIG_CAF_BLE_USE_LLPM=n
 
 For detailed information about building an application using the nRF21540 EK, see the :ref:`ug_radio_fem_nrf21540ek_programming` section in the Working with RF Front-end modules documentation.
 

--- a/doc/nrf/device_guides/working_with_fem.rst
+++ b/doc/nrf/device_guides/working_with_fem.rst
@@ -622,13 +622,13 @@ See :ref:`cmake_options`.
 
 When building for a board with an additional network core, like the nRF5340, add the ``-DSHIELD`` variable with the *childImageName_* parameter between ``-D`` and ``SHIELD`` to build for the network core.
 In this case, the application core is only responsible for forwarding to the network core the pins needed to control the nRF21540 .
-The application core can be set up to forward the needed pins using the ``-DSHIELD=nrf21540ek_fwd`` setting.
+The application core can be set up to forward the needed pins using the ``-DSHIELD=nrf21540_ek_fwd`` setting.
 For example:
 
 .. parsed-literal::
    :class: highlight
 
-   west build -b nrf5340dk_nrf5340_cpuapp -- -DSHIELD=nrf21540ek_fwd -Dmultiprotocol_rpmsg_SHIELD=nrf21540ek
+   west build -b nrf5340dk_nrf5340_cpuapp -- -DSHIELD=nrf21540_ek_fwd -Dmultiprotocol_rpmsg_SHIELD=nrf21540ek
 
 In this command, the *childImageName_* parameter has the ``multiprotocol_rpmsg_`` value and builds a multiprotocol application with support for 802.15.4 and Bluetooth.
 The *childImageName_* parameter can take the following values:


### PR DESCRIPTION
Fixed -DSHIELD=nrf21540ek_fwd to -DSHIELD=nrf21540_ek_fwd. Reported by a customer.