### PR TITLE
bl_storage: Fix nv_counters bug with FIH

### DIFF
--- a/doc/nrf/releases_and_maturity/known_issues.rst
+++ b/doc/nrf/releases_and_maturity/known_issues.rst
@@ -2442,6 +2442,16 @@ Bootloader
 
 The issues in this section are related to :ref:`Bootloaders <app_bootloaders>`.
 
+.. rst-class:: v2-4-0 v2-4-1 v2-4-2
+
+NCSDK-23761: MCUboot fails to boot when both the :kconfig:option:`CONFIG_MCUBOOT_HW_DOWNGRADE_PREVENTION` and :kconfig:option:`CONFIG_BOOT_FIH_PROFILE_LOW` Kconfig options are enabled.
+  The MCUboot downgrade prevention mechanism relies on platform-specific implementation of hardware security counters.
+  The |NCS| implementation of the hardware security counters is not compatible with the fault injection hardening code (FIH) of MCUboot.
+  In the |NCS|, the Kconfig option :kconfig:option:`CONFIG_BOOT_FIH_PROFILE_LOW` of MCUboot is enabled by default for TF-M builds.
+  You can enable the MCUboot Kconfig option :kconfig:option:`CONFIG_MCUBOOT_HW_DOWNGRADE_PREVENTION` in the |NCS| using the option :kconfig:option:`CONFIG_MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION`.
+
+  **Workaround:** To fix the issue, disable either the :kconfig:option:`CONFIG_MCUBOOT_HW_DOWNGRADE_PREVENTION` or :kconfig:option:`CONFIG_BOOT_FIH_PROFILE_LOW` Kconfig option in MCUboot.
+
 .. rst-class:: v2-4-2 v2-4-1 v2-4-0 v2-3-0
 
 SHEL-1352: Incorrect base address used in the OTP TX trim coefficients


### PR DESCRIPTION
The NRF non-volatile counters function boot_nv_security_counter_get is called by MCUBOOT using the macro FIH_CALL(). When the fault injection protection is enabled this macro increases a counter in MCUBOOT which is expected to be the same before and after the call to the function. The counter is increased by FIH_CALL() and is expected to get decreased by the FIH_RET() macro. This means that all the functions which are called by FIH_CALL() need to return with FIH_RET(), otherwise the fault injection protection will stop the execution.

This change fixes a bug with our implementation of nv_counters which didn't return FIH_RET(). This had as a consequence that when the hardware downgrade prevention and the fault injection protection was enabled in MCUBOOT:
CONFIG_MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION=y
CONFIG_BOOT_FIH_PROFILE_LOW=y

MCUBOOT could not boot anymore.

Ref: NCSDK-23761