### PR TITLE
doc: simplify mentions of west flash --erase

### DIFF
--- a/applications/matter_weather_station/README.rst
+++ b/applications/matter_weather_station/README.rst
@@ -234,12 +234,7 @@ You can generate new factory data set when building for the target board by invo
    west build -b thingy53_nrf5340_cpuapp -- -DOVERLAY_CONFIG=overlay-factory_data.conf
 
 This command builds the application with default certificates.
-After building the target, the generated :file:`factory_data.hex` file will be merged with the application target HEX file, so you can use the regular command to flash it to the device:
-
-.. parsed-literal::
-   :class: highlight
-
-   west flash --erase
+After building the target, the generated :file:`factory_data.hex` file will be merged with the application target HEX file, so you can use the :ref:`regular command to flash it to the device <programming>`.
 
 If you want to use Vendor ID, Product ID or other data that is not reserved for tests, you need custom test certificates.
 To build with custom certificates, you need to :ref:`install CHIP Certificate Tool <ug_matter_gs_tools_cert_installation>`.

--- a/doc/nrf/config_and_build/programming.rst
+++ b/doc/nrf/config_and_build/programming.rst
@@ -23,7 +23,9 @@ Building with |VSC|
 *******************
 
 For instructions about building with the |nRFVSC|, see `How to build an application`_.
-If you want to build and program with custom options, read about the advanced `Custom launch and debug configurations`_ and `Application-specific flash options`_.
+If you want to build and program with custom options, read about the advanced `Custom launch and debug configurations`_.
+
+For information about how to flash and erase in the |nRFVSC|, read about the `Application-specific flash options`_.
 
 .. note::
    |ncs_oot_sample_note|
@@ -88,7 +90,7 @@ After completing the :ref:`manual <build_environment_cli>` or :ref:`automatic <a
 
          west flash --erase
 
-      This command clears the full flash memory before programming, which is the recommended approach.
+      This command erases the full flash memory before programming, which is the recommended approach.
       If the application depends on other flash memory areas (for example, if it uses the :ref:`zephyr:settings_api` partition where bonding information is stored), erasing the full kit before programming ensures that these areas are updated with the new content.
 
       As an alternative, you can also clear only those flash memory pages that are to be overwritten with the new application.

--- a/doc/nrf/protocols/thread/tools.rst
+++ b/doc/nrf/protocols/thread/tools.rst
@@ -120,12 +120,7 @@ To program the nRF device with the RCP application, complete the following steps
 
       .. tab:: nRF52840 Development Kit (UART transport)
 
-         a. Program the image using :ref:`west`:
-
-            .. code-block:: console
-
-               west flash --erase
-
+         a. Program the image using the :ref:`regular command <programming>`.
          #. Disable the Mass Storage feature on the device, so that it does not interfere with the core RCP functionalities.
             Also, force Hardware Flow Control to avoid potential race conditions related to the auto-detection:
 

--- a/samples/bootloader/README.rst
+++ b/samples/bootloader/README.rst
@@ -86,36 +86,7 @@ Because of these design constraints, the following limitations apply:
 .. note::
    On the nRF9160 and nRF5340, the UICR can only be erased by erasing the entire flash memory.
 
-To erase the entire flash memory, do the following:
-
-.. tabs::
-
-   .. tab:: Command Line
-
-      Using west:
-
-      .. code-block:: console
-
-         west flash --erase
-
-      Using nrfjprog:
-
-      .. code-block:: console
-
-         nrfjprog -f NRF91 --eraseall
-
-   .. tab:: |VSC|
-
-      Using the :guilabel:`Actions View` in |nRFVSC|:
-
-         1. Go to the :guilabel:`Actions View`.
-         #. Move the cursor over the :guilabel:`Flash` action.
-         #. Click :guilabel:`Erase And Flash To Board` on the right side of the :guilabel:`Flash` action.
-
-      Using the |VSC| Command Palette:
-
-         1. Open the |VSC| Command Palette.
-         #. Type ``Erase and Flash to Board`` and select the highlighted option.
+For information how to erase the entire flash memory when flashing, see :ref:`programming`.
 
 .. _bootloader_flash_layout:
 


### PR DESCRIPTION
Removed mentions of `west flash --erase` from pages other than hardware guides. Replaced mentions with links to the programming guide. NCSIDB-1053.