### PR TITLE
samples: peripheral_uart: Fix hard-coded timeout value

### DIFF
--- a/samples/bluetooth/peripheral_uart/src/main.c
+++ b/samples/bluetooth/peripheral_uart/src/main.c
@@ -322,7 +322,7 @@ static int uart_init(void)
 		return err;
 	}
 
-	err = uart_rx_enable(uart, rx->data, sizeof(rx->data), 50);
+	err = uart_rx_enable(uart, rx->data, sizeof(rx->data), UART_WAIT_FOR_RX);
 	if (err) {
 		LOG_ERR("Cannot enable uart reception (err: %d)", err);
 		/* Free the rx buffer only because the tx buffer will be handled in the callback */


### PR DESCRIPTION
Calls to uart_rx_enable() require a timeout argument, for which UART_WAIT_FOR_RX is used in 2 of 3 calls in this application.

The initial init call, however, uses a hardcoded value of 50 (milliseconds) instead of UART_WAIT_FOR_RX which is clearly an oversight.