### PR TITLE
applications: serial_lte_modem: New external flash chip for nRF9161dk

### DIFF
--- a/applications/serial_lte_modem/boards/nrf9161dk_nrf9161_ns.overlay
+++ b/applications/serial_lte_modem/boards/nrf9161dk_nrf9161_ns.overlay
@@ -54,9 +54,37 @@
 	};
 };
 
-/* Enable external flash */
+/* Enable external flash for nRF9161dk version 0.7.0 and older */
 &spi3 {
 	gd25lb256: gd25lb256e3ir@1 {
 		status = "okay";
 	};
 };
+
+/* Note! From nRF9161dk hardware version 0.7.1 this external flash is used.
+ * As long as gd25wb256 is not defined in
+ * zephyr/boards/arm/nrf9161dk_nrf9161/nrf9161dk_nrf9161_common.dtsi the whole configuration has
+ * to be defined here. When zephyr has the configuration, only 'status = "okay";' line is required
+ * as defined above.
+ */
+/*
+&spi3 {
+	gd25wb256: gd25wb256e3ir@1 {
+		compatible = "jedec,spi-nor";
+		status = "okay";
+		reg = <1>;
+		spi-max-frequency = <8000000>;
+		size = <268435456>;
+		has-dpd;
+		t-enter-dpd = <3000>;
+		t-exit-dpd = <40000>;
+		sfdp-bfp = [
+			e5 20 f3 ff  ff ff ff 0f  44 eb 08 6b  08 3b 42 bb
+			ee ff ff ff  ff ff 00 ff  ff ff 00 ff  0c 20 0f 52
+			10 d8 00 ff  44 7a c9 fe  83 67 26 62  ec 82 18 44
+			7a 75 7a 75  04 c4 d5 5c  00 06 74 00  08 50 00 01
+			];
+		jedec-id = [c8 65 19];
+	};
+};
+*/


### PR DESCRIPTION
- New external flash chip has defined in the device tree
- Not activated yet