### PR TITLE
application: serial_lte_modem: BUG-FIX GNSS scheduled download

### DIFF
--- a/applications/serial_lte_modem/doc/GNSS_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/GNSS_AT_commands.rst
@@ -70,7 +70,7 @@ It can be one of the following:
 
 .. note::
 
-   In periodic navigation mode, the ``<interval>`` and ``<timeout>`` parameters are temporarily ignored during the first fix (for up to 60 seconds) and when the GNSS module determines it needs to download ephemerides or almanacs from the broadcast.
+   In periodic navigation mode, the ``<interval>`` and ``<timeout>`` parameters are temporarily ignored during the first fix (for up to 60 seconds).
 
 .. note::
 

--- a/applications/serial_lte_modem/src/gnss/slm_at_gnss.c
+++ b/applications/serial_lte_modem/src/gnss/slm_at_gnss.c
@@ -179,21 +179,6 @@ static void on_gnss_evt_agnss_req(void)
 static int gnss_startup(void)
 {
 	int ret;
-	uint8_t use_case;
-
-	use_case = NRF_MODEM_GNSS_USE_CASE_MULTIPLE_HOT_START;
-	if (gnss_cloud_assistance) {
-		/* When A-GNSS/P-GPS is used there should always be
-		 * valid almanacs/ephemerides so disable the scheduled
-		 * downloads from the sky in periodic navigation mode.
-		 */
-		use_case |= NRF_MODEM_GNSS_USE_CASE_SCHED_DOWNLOAD_DISABLE;
-	}
-	ret = nrf_modem_gnss_use_case_set(use_case);
-	if (ret) {
-		LOG_ERR("Failed to set GNSS use case (%d).", ret);
-		return ret;
-	}
 
 #if defined(CONFIG_SLM_NRF_CLOUD)
 
@@ -676,6 +661,20 @@ int handle_at_gps(enum at_cmd_type cmd_type)
 			err = nrf_modem_gnss_fix_interval_set(interval);
 			if (err) {
 				LOG_ERR("Failed to set GNSS fix interval (%d).", err);
+				return err;
+			}
+
+			/* Disable scheduled downloads for periodical tracking */
+			if (interval >= 10) {
+				err = nrf_modem_gnss_use_case_set(
+						NRF_MODEM_GNSS_USE_CASE_MULTIPLE_HOT_START |
+						NRF_MODEM_GNSS_USE_CASE_SCHED_DOWNLOAD_DISABLE);
+			} else {
+				err = nrf_modem_gnss_use_case_set(
+						NRF_MODEM_GNSS_USE_CASE_MULTIPLE_HOT_START);
+			}
+			if (err) {
+				LOG_ERR("Failed to set use case, error: %d", err);
 				return err;
 			}
 


### PR DESCRIPTION
Currently GNSS scheduled download is disabled for SLM AGPS/PGPS periodical tracking to save power as AGPS/PGPS data has the info.

There is a need to disable it for SLM GPS periodical tracking as well, due to scheduled download would generate fixes not according to the interval configuration, i.e. fix per second.

From mfw_2.0 the fix by scheduled download will be flagged and the libmodem GNSS could filter the unwanted fix.