### PR TITLE
Improve shadow delta handling

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -395,6 +395,7 @@ Cellular samples (renamed from nRF9160 samples)
     * An overlay that allows the sample to be used with Wi-Fi instead of LTE (MQTT only).
     * Reporting of device and connection info to the device shadow.
     * The :file:`overlay_min_coap.conf` and :file:`overlay_min_mqtt.conf` overlay files.
+    * Handling of shadow deltas caused by alert and log configuration changes for CoAP.
 
   * Updated:
 
@@ -405,6 +406,10 @@ Cellular samples (renamed from nRF9160 samples)
     * The sample to remove redundant shadow updates for nRF Cloud.
     * Build instructions, board files, and DTC overlay file so that Wi-Fi scanning works for the nRF9161 DK and the nRF9160 DK.
     * Configuration to enable power saving mode by default.
+
+  * Fixed:
+
+    * Legitimate server side CoAP API errors are not counted now as a reason to disconnect from and reconnect to the cloud, but only communications errors.
 
   * Removed the Kconfig options :kconfig:option:`CONFIG_LTE_INIT_RETRY_TIMEOUT_SECONDS` and :kconfig:option:`CLOUD_CONNECTION_REESTABLISH_DELAY_SECONDS` as they are no longer needed.
 
@@ -800,6 +805,7 @@ Libraries for networking
     * Kconfig option :kconfig:option:`CONFIG_NRF_CLOUD_FOTA_AUTO_START_JOB` for controlling whether a FOTA update job is started automatically or at the request of the application.
     * An event :c:enum:`NRF_CLOUD_EVT_FOTA_JOB_AVAILABLE` that indicates a FOTA update job is available.
     * :c:func:`nrf_cloud_fota_job_start` function that starts a FOTA update job.
+    * :c:func:`nrf_cloud_shadow_delta_response_encode()` to help accept or reject shadow delta desired settings.
 
   * Updated:
 
@@ -807,12 +813,15 @@ Libraries for networking
     * :c:func:`nrf_cloud_obj_location_request_create` to use the new function :c:func:`nrf_cloud_obj_location_request_payload_add`.
     * Retry handling for P-GPS data download errors to retry ``ECONNREFUSED`` errors.
     * By default, Wi-Fi location requests include only the MAC address and RSSI value.
+    * The shadow desired section for the config subsection is no longer deleted.
+      Applications and samples should use the function :c:func:`nrf_cloud_shadow_delta_response_encode()` to prevent recurring deltas.
 
   * Fixed:
 
     * A build issue that occurred when MQTT and P-GPS are enabled and A-GPS is disabled.
     * A bug preventing ``AIR_QUAL`` from being enabled in shadow UI service info.
     * A bug that prevented an MQTT FOTA job from being started.
+    * An invalid value for a shadow delta change to the control section is now rejected by updating the desired section to the previous value.
 
   * Removed:
 

--- a/include/net/nrf_cloud.h
+++ b/include/net/nrf_cloud.h
@@ -603,11 +603,13 @@ struct nrf_cloud_gw_data {
  */
 enum nrf_cloud_ctrl_status {
 	/** Data not present in shadow. */
-	NRF_CLOUD_CTRL_NOT_PRESENT = 0,
+	NRF_CLOUD_CTRL_NOT_PRESENT,
 	/** This was not a delta, so no need to send update back. */
-	NRF_CLOUD_CTRL_NO_REPLY = 1,
+	NRF_CLOUD_CTRL_NO_REPLY,
 	/** Send shadow update confirmation back. */
-	NRF_CLOUD_CTRL_REPLY = 2,
+	NRF_CLOUD_CTRL_REPLY,
+	/** Reject values -- update desired section, not reported. */
+	NRF_CLOUD_CTRL_REJECT
 };
 
 /** @brief Data to control behavior of the nrf_cloud library from the

--- a/include/net/nrf_cloud_coap.h
+++ b/include/net/nrf_cloud_coap.h
@@ -278,6 +278,19 @@ int nrf_cloud_coap_shadow_device_status_update(const struct nrf_cloud_device_sta
 int nrf_cloud_coap_shadow_service_info_update(const struct nrf_cloud_svc_info * const svc_inf);
 
 /**
+ * @brief Process any elements of the shadow relevant to this library.
+ *
+ * One such element is the control section, which specifies the log level and turns
+ * alerts on and off.
+ *
+ * @param[in] in_data A pointer to a structure with the length and a pointer to the delta received.
+ *
+ * @return 0 if the request succeeded, a positive value indicating a CoAP result code,
+ * or a negative error number.
+ */
+int nrf_cloud_coap_shadow_delta_process(const struct nrf_cloud_data *in_data);
+
+/**
  * @brief Send an nRF Cloud object
  *
  * This only supports sending of the CoAP CBOR or JSON type or a pre-encoded CBOR buffer.

--- a/include/net/nrf_cloud_codec.h
+++ b/include/net/nrf_cloud_codec.h
@@ -645,6 +645,43 @@ int nrf_cloud_error_msg_decode(const char * const buf,
 			       const char * const msg_type,
 			       enum nrf_cloud_error * const err);
 
+/**
+ *  @brief Encode the response to the shadow delta update.
+ *
+ *  A delta update occurs when the shadow's "desired" and "reported" sections do not match.
+ *  The JSON for a delta update contains the actual delta data in a "state" object, along
+ *  with some additional information.
+ *  Example:
+ *     {"version":123,"timestamp":1695404679, "state":{"myData":{"myValue":1}}, ...}
+ *
+ *  The application must inspect the delta and either accept or reject the changes.
+ *
+ *  If accepting, the delta should be passed unmodified into this function as
+ *  the input_obj parameter, with the accept flag set to true.
+ *  Example input_obj:
+ *      "myData":{"myValue":1}
+ *
+ *  If rejecting, the delta should be modified with the correct data and passed
+ *  into this function as the input_obj parameter, with the accept flag set to false.
+ *  Example input_obj:
+ *      "myData":{"myValue":3}
+ *
+ *  A value can be removed from the shadow by setting it to null.
+ *  Example input_obj:
+ *      "myData":{"myValue":null}
+ *  The output parameter can then be sent to nRF Cloud using nrf_cloud_coap_shadow_state_update()
+ *  when using CoAP or nrf_cloud_send() when using MQTT.
+ *
+ *  @param[in]  input_obj  Shadow fragment to encode for sending.
+ *  @param[in]  accept     Flag to indicate whether to accept (place in reported section) or reject
+ *                         (place in desired section).
+ *  @param[out] output     Pointer to and length of a buffer containing the JSON-formatted
+ *                         text to send.
+ */
+int nrf_cloud_shadow_delta_response_encode(cJSON *input_obj,
+					   bool accept,
+					   struct nrf_cloud_data *const output);
+
 /** @} */
 
 #ifdef __cplusplus

--- a/samples/cellular/nrf_cloud_multi_service/Kconfig
+++ b/samples/cellular/nrf_cloud_multi_service/Kconfig
@@ -310,7 +310,7 @@ config COAP_SHADOW_CHECK_RATE_SECONDS
 
 config COAP_SHADOW_THREAD_STACK_SIZE
 	int "CoAP Shadow Thread Stack Size (bytes)"
-	default 2048
+	default 3072
 	help
 	  Sets the stack size (in bytes) for the CoAP shadow thread of the
 	  sample.

--- a/samples/cellular/nrf_cloud_multi_service/src/message_queue.c
+++ b/samples/cellular/nrf_cloud_multi_service/src/message_queue.c
@@ -131,7 +131,7 @@ static int consume_device_message(void)
 
 #endif /* CONFIG_NRF_CLOUD_COAP */
 
-	if (ret) {
+	if (ret < 0) {
 		LOG_ERR("Transmission of enqueued device message failed, nrf_cloud_send "
 			"gave error: %d. The message will be re-enqueued and tried again "
 			"later.", ret);

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec_internal.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec_internal.h
@@ -118,11 +118,6 @@ int nrf_cloud_data_endpoint_decode(const struct nrf_cloud_data *input,
 int nrf_cloud_state_encode(uint32_t reported_state, const bool update_desired_topic,
 			   const bool add_dev_status, struct nrf_cloud_data *output);
 
-/** @brief Search input for config and encode response if necessary. */
-int nrf_cloud_shadow_config_response_encode(struct nrf_cloud_data const *const input,
-					    struct nrf_cloud_data *const output,
-					    bool *const has_config);
-
 /** @brief Parse input for control section, and return contents and status of it. */
 int nrf_cloud_shadow_control_decode(struct nrf_cloud_data const *const input,
 				    enum nrf_cloud_ctrl_status *status,
@@ -130,7 +125,15 @@ int nrf_cloud_shadow_control_decode(struct nrf_cloud_data const *const input,
 
 /** @brief Encode response that we have accepted a shadow delta. */
 int nrf_cloud_shadow_control_response_encode(struct nrf_cloud_ctrl_data const *const data,
+					     bool accept,
 					     struct nrf_cloud_data *const output);
+
+/** @brief Parse shadow delta for control section. Act on any changes to logging or alerts.
+ * If needed, generate output JSON to send back to cloud to confirm change.
+ */
+int nrf_cloud_device_control_update(const struct nrf_cloud_data *const in_data,
+				    struct nrf_cloud_data *out_data,
+				    enum nrf_cloud_ctrl_status *status);
 
 /** @brief Encode the device status data into a JSON formatted buffer to be saved to
  * the device shadow.

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -1205,8 +1205,10 @@ int nct_cc_send(const struct nct_cc_data *cc_data)
 
 	publish.message_id = get_message_id(cc_data->message_id);
 
-	LOG_DBG("mqtt_publish: id = %d opcode = %d len = %d", publish.message_id,
-		cc_data->opcode, cc_data->data.len);
+	LOG_DBG("mqtt_publish: id = %d opcode = %d len = %d, topic: %*s", publish.message_id,
+		cc_data->opcode, cc_data->data.len,
+		publish.message.topic.topic.size,
+		publish.message.topic.topic.utf8);
 
 	int err = mqtt_publish(&nct.client, &publish);
 


### PR DESCRIPTION
nRF Cloud Multi Service Sample:
Enable PSM by default.
Increase connection_mgr stack size to prevent crashes with Wi-Fi.
Do not count server-side CoAP errors against send_failure_count, or else we disconnect from the cloud for no reason.
Clean up check_shadow function.

nRF Cloud Library:
Make logging and alert control section usable for CoAP in addition to MQTT.
Add error checking and handling to bad shadow delta values for control section.
Add nrf_cloud_shadow_delta_response_encode() for library users to accept or reject custom shadow deltas.
Improve error logging for CoAP so that server side errors get displayed.  An example is the JSON error returned when a customer exceeds their monthly quota for messages or location services.

Jira: IRIS-6800
