### PR TITLE
manifest: Update nrfxlib revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -141,7 +141,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 741729d16c8ab0dd537d802d480180786951acad
+      revision: pull/1083/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Brings in a SoftDevice Controller library with ISO support. Enabling the ISO support will be done in a separate PR.