### PR TITLE
snippets: add snippet for tfm logging on shared uart

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -205,6 +205,7 @@ Kconfig*                                  @tejlmand
 /share/zephyrbuild-package/               @tejlmand
 /share/ncs-package/                       @tejlmand
 /snippets/nrf91-modem-trace-uart/         @eivindj-nordic
+/snippets/tfm-enable-share-uart/          @KajaKoren
 /subsys/bluetooth/                        @alwa-nordic @jori-nordic @carlescufi @KAGA164
 /subsys/bluetooth/mesh/                   @ludvigsj
 /subsys/bluetooth/controller/             @rugeGerritsen

--- a/applications/asset_tracker_v2/sample.yaml
+++ b/applications/asset_tracker_v2/sample.yaml
@@ -159,9 +159,9 @@ tests:
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - thingy91_nrf9160_ns
-    extra_args: >
+    extra_args:
       EXTRA_CONF_FILE="overlay-lwm2m.conf;overlay-debug.conf"
-      SNIPPET="nrf91-modem-trace-uart"
+      SNIPPET="nrf91-modem-trace-uart;tfm-enable-share-uart"
     tags: ci_build
   applications.asset_tracker_v2.lwm2m.memfault:
     build_only: true

--- a/doc/nrf/device_guides/working_with_nrf/nrf91/nrf9160.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf91/nrf9160.rst
@@ -429,6 +429,19 @@ To build with the |nRFVSC|, specify ``-DSNIPPET="nrf91-modem-trace-uart" [...]``
 
 See :ref:`cmake_options` for more details.
 
+.. _tfm_enable_share_uart:
+
+Shared UART for application and TF-M logging
+============================================
+
+If you want to activate TF-M logging while having modem traces enabled, it can be useful to direct the TF-M logs to the UART (**UART0**) used by the application.
+To activate both modem traces and TF-M logs, use the following command:
+
+.. parsed-literal::
+   :class: highlight
+
+   west build --board *build target* -S nrf91-modem-trace-uart -S tfm-enable-share-uart
+
 .. _nrf9160_gs_testing_cellular:
 
 Testing the cellular connection with the AT Client sample

--- a/doc/nrf/libraries/modem/nrf_modem_lib/nrf_modem_lib_trace.rst
+++ b/doc/nrf/libraries/modem/nrf_modem_lib/nrf_modem_lib_trace.rst
@@ -101,6 +101,9 @@ This is done by adding the :ref:`modem trace UART snippet <nrf91_modem_trace_uar
 
 Use the `Cellular Monitor`_ app for capturing and analyzing modem traces.
 
+TF-M logging must use the same UART as the application.
+For more details, see :ref:`shared TF-M logging <tfm_enable_share_uart>`.
+
 .. modem_lib_sending_traces_UART_end
 
 .. _modem_trace_backend_uart_custom_board:

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -338,6 +338,10 @@ DFU libraries
 Modem libraries
 ---------------
 
+* :ref:`nrf_modem_lib_readme`:
+
+   * Added a mention about enabling TF-M logging while using modem traces in the :ref:`modem_trace_module`.
+
 |no_changes_yet_note|
 
 Libraries for networking
@@ -448,5 +452,9 @@ cJSON
 
 Documentation
 =============
+
+* :ref:`ug_nrf9160`:
+
+   *  Section :ref:tfm_enable_share_uart in the :ref:uge_nrf9160 page.
 
 |no_changes_yet_note|

--- a/snippets/tfm-enable-share-uart/overlay-tfm-enable-share-uart.conf
+++ b/snippets/tfm-enable-share-uart/overlay-tfm-enable-share-uart.conf
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# TFM logging over uart0
+CONFIG_TFM_LOG_LEVEL_SILENCE=n
+CONFIG_TFM_SECURE_UART0=y
+CONFIG_TFM_SECURE_UART_SHARE_INSTANCE=y
+CONFIG_TFM_EXCEPTION_INFO_DUMP=y
+CONFIG_TFM_SPM_LOG_LEVEL_DEBUG=y

--- a/snippets/tfm-enable-share-uart/snippet.yml
+++ b/snippets/tfm-enable-share-uart/snippet.yml
@@ -1,0 +1,3 @@
+name: tfm-enable-share-uart
+append:
+  EXTRA_CONF_FILE: overlay-tfm-enable-share-uart.conf


### PR DESCRIPTION
Add snippet for tfm loggging sharing the same uart as the application utilizes. This allows the same configuration to be used for all samples without duplicationg it.

sharing the uart with the application can be useful when modem traces occupies the other uart.