### PR TITLE
doc: Rename nRF91 AT Commands Reference Guide

### DIFF
--- a/applications/serial_lte_modem/README.rst
+++ b/applications/serial_lte_modem/README.rst
@@ -4,7 +4,11 @@ Serial LTE modem
 ################
 
 The Serial LTE Modem (SLM) application can be used to emulate a stand-alone LTE modem on an nRF91 Series device.
-The application accepts both the modem-specific AT commands documented in the `nRF91 AT Commands Reference Guide <AT Commands Reference Guide_>`_ and proprietary AT commands documented in :ref:`SLM_AT_intro`.
+The application accepts both the modem-specific AT commands and proprietary AT commands.
+The AT commands are documented in the following guides:
+
+* Modem-specific AT commands - `nRF91x1 AT Commands Reference Guide`_  and `nRF9160 AT Commands Reference Guide`_
+* Proprietary AT commands - :ref:`SLM_AT_intro`
 
 See the subpages for how to use the application, how to extend it, and information on the supported AT commands.
 

--- a/applications/serial_lte_modem/doc/AT_commands_intro.rst
+++ b/applications/serial_lte_modem/doc/AT_commands_intro.rst
@@ -28,7 +28,7 @@ There are 3 types of AT commands:
 AT responds to all commands with a final response.
 
 See the following subpages for documentation of the proprietary AT commands.
-The modem-specific AT commands are documented in the `nRF91 AT Commands Reference Guide <AT Commands Reference Guide_>`_.
+The modem-specific AT commands are documented in the `nRF91x1 AT Commands Reference Guide`_  and `nRF9160 AT Commands Reference Guide`_.
 
 .. toctree::
    :maxdepth: 2

--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -16,7 +16,11 @@ The nRF91 Series SiP integrates both a full LTE modem and an application MCU, en
 
 However, if you want to run your application on a different chip and use the nRF91 Series device only as a modem, the serial LTE modem application provides you with an interface for controlling the LTE modem through AT commands.
 
-The application accepts both the modem-specific AT commands documented in the `nRF91 AT Commands Reference Guide <AT Commands Reference Guide_>`_ and the proprietary AT commands documented in the :ref:`SLM_AT_intro` page.
+The application accepts both the modem-specific AT commands and proprietary AT commands.
+The AT commands are documented in the following guides:
+
+* Modem-specific AT commands - `nRF91x1 AT Commands Reference Guide`_  and `nRF9160 AT Commands Reference Guide`_
+* Proprietary AT commands - :ref:`SLM_AT_intro`
 
 Requirements
 ************

--- a/doc/nrf/device_guides/working_with_nrf/nrf91/nrf91_features.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf91/nrf91_features.rst
@@ -95,7 +95,8 @@ LTE modem
 =========
 
 The LTE modem handles LTE communication.
-It is controlled through `AT commands <AT Commands Reference Guide_>`_.
+It is controlled through AT commands.
+The AT commands are documented in the `nRF9160 AT Commands Reference Guide`_.
 
 The firmware for the modem is available as a precompiled binary.
 You can download the firmware from the `nRF9160 product website (compatible downloads)`_.

--- a/doc/nrf/device_guides/working_with_nrf/nrf91/thingy91.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf91/thingy91.rst
@@ -76,8 +76,7 @@ To connect to the Thingy:91 using the nRF Connect Serial Terminal app, complete 
    If the connection is working, the modem responds with OK.
 
 The terminal view shows all of the Asset Tracker v2 debug output as well as the AT commands and their results.
-For information on the available AT commands, see `nRF91 AT Commands Reference Guide <AT Commands Reference Guide_>`_.
-
+For information on the available AT commands, see the `nRF9160 AT Commands Reference Guide`_.
 
 Operating modes
 ***************

--- a/doc/nrf/libraries/modem/lte_lc.rst
+++ b/doc/nrf/libraries/modem/lte_lc.rst
@@ -99,7 +99,7 @@ The following list mentions some of the information that can be extracted from t
 
 .. note::
    Some of the functionalities might not be compatible with certain modem firmware versions.
-   To check if a desired feature is compatible with a certain modem firmware version, see nRF9160 `AT Commands Reference Guide`_.
+   To check if a desired feature is compatible with a certain modem firmware version, see the AT commands that are documented in the `nRF91x1 AT Commands Reference Guide`_  or `nRF9160 AT Commands Reference Guide`_ depending on the SiP you are using.
 
 Enabling power-saving features
 ==============================

--- a/doc/nrf/libraries/modem/modem_battery.rst
+++ b/doc/nrf/libraries/modem/modem_battery.rst
@@ -12,7 +12,8 @@ The modem battery library is used to get battery voltage information or notifica
 The library issues AT commands to perform the following actions:
 
 * Retrieve the battery voltage measured by the modem.
-* Set the `battery voltage low level <Battery voltage low level %XVBATLOWLVL_>`_ for the modem.
+* Set the battery voltage low level for the modem using the ``%XVBATLOWLVL`` command.
+  See the `Battery voltage low level %XVBATLOWLVL`_  section in the nRF9160 AT Commands Reference Guide or the same section in the `nRF91x1 AT Commands Reference Guide`_ depending on the SiP you are using.
 * Subscribe to or unsubscribe from unsolicited notifications on modem battery voltage low level.
 * Configure the power-off warnings from the modem (possible with modem firmware v1.3.1 and higher).
 

--- a/doc/nrf/libraries/modem/modem_key_mgmt.rst
+++ b/doc/nrf/libraries/modem/modem_key_mgmt.rst
@@ -8,7 +8,8 @@ Modem key management
    :depth: 2
 
 The modem key management library provides functions to manage the credentials stored in the nRF9160 LTE modem.
-The library uses AT commands (`Credential storage management %CMNG`_) to add, update, and delete credentials.
+The library uses credential storage management to add, update, and delete credentials using the ``%CMNG`` command.
+See the `Credential storage management %CMNG`_ section in the nRF9160 AT Commands Reference Guide or the same section in the `nRF91x1 AT Commands Reference Guide`_ depending on the SiP you are using.
 
 Each set of keys and certificates that is stored in the modem is identified by a security tag (``sec_tag``).
 You specify this tag when adding the credentials and use it when you update or delete them.

--- a/doc/nrf/libraries/modem/pdn.rst
+++ b/doc/nrf/libraries/modem/pdn.rst
@@ -16,8 +16,10 @@ It provides an API for the following purposes:
 
 The library uses several AT commands, and it relies on the following two types of AT notifications to work:
 
-* Packet domain events notifications (``+CGEV``) - Subscribed by using the `AT+CGEREP set command`_ (``AT+CGEREP=1``)
-* Notifications for unsolicited reporting of error codes sent by the network (``+CNEC``) - Subscribed by using the `AT+CNEC set command`_ (``AT+CNEC=16``)
+* Packet domain events notifications (``+CGEV``) - Subscribed by using the ``AT+CGEREP=1`` command.
+  See the `AT+CGEREP set command`_ section in the nRF9160 AT Commands Reference Guide or the same section in the `nRF91x1 AT Commands Reference Guide`_ depending on the SiP you are using.
+* Notifications for unsolicited reporting of error codes sent by the network (``+CNEC``) - Subscribed by using the ``AT+CNEC=16`` command.
+  See the `AT+CNEC set command`_ section in the nRF9160 AT Commands Reference Guide or the same section in the `nRF91x1 AT Commands Reference Guide`_ depending on the SiP you are using.
 
 If the application uses the :ref:`lte_lc_readme` library to change the modem's functional mode, the PDN library automatically subscribes to the necessary AT notifications.
 This includes automatically resubscribing to the notifications upon functional mode changes.
@@ -35,7 +37,7 @@ Following are the AT commands that are used by the library:
 * ``AT%XGETPDNID``- To retrieve the PDN ID for a given PDP context
 * ``AT+CGAUTH`` - To set the PDN connection authentication parameters
 
-For more information about these commands, see `Packet Domain AT commands`_.
+For more information about these commands, see `Packet Domain AT commands`_ in the nRF9160 AT Commands Reference Guide or the same section in the `nRF91x1 AT Commands Reference Guide`_ depending on the SiP you are using.
 
 The application can create PDP contexts by using the :c:func:`pdn_ctx_create` function, and a callback can be assigned to receive the events pertaining to the state and connectivity of the PDP contexts.
 The application can use the :c:func:`pdn_default_ctx_cb_reg` function to register an event handler for events pertaining the default PDP context, and the :c:func:`pdn_default_ctx_cb_dereg` to deregister it.

--- a/doc/nrf/libraries/networking/nrf_provisioning.rst
+++ b/doc/nrf/libraries/networking/nrf_provisioning.rst
@@ -100,7 +100,7 @@ The TLS handshake happens twice:
 * Before requesting commands.
 * After the execution of the commands, to report the results.
 
-If you are using `AT commands <AT Commands Reference Guide_>`_, the library shuts down the modem for writing data to the modem's non-volatile memory.
+If you are using AT commands, the library shuts down the modem for writing data to the modem's non-volatile memory.
 Once the memory writes are complete, the connection is re-established to report the results back to the server.
 The results are reported back to the server when either all the commands succeed or when an error occurs.
 If an error occurs, the results of all the commands that are successfully executed before the error and the erroneous result are reported back to the server.

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -497,7 +497,8 @@
 .. _`Device programming section in the nRF9160 DK User Guide`: https://infocenter.nordicsemi.com/topic/ug_nrf91_dk/UG/nrf91_DK/mcu_device_programming.html
 .. _`VDD supply rail section in the nRF9160 DK User Guide`: https://infocenter.nordicsemi.com/topic/ug_nrf91_dk/UG/nrf91_DK/power_sources_vdd.html
 
-.. _`AT Commands Reference Guide`: https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/intro.html
+.. _`AT Commands Reference Guide`:
+.. _`nRF9160 AT Commands Reference Guide`: https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/intro.html
 .. _`band lock section in the AT Commands reference document`: https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/mob_termination_ctrl_status/xbandlock.html
 .. _`system mode section in the AT Commands reference document`: https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/mob_termination_ctrl_status/xsystemmode.html
 .. _`Credential storage management %CMNG`: https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/security/cmng.html
@@ -509,6 +510,8 @@
 .. _`Modem trace AT command documentation`: https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/mob_termination_ctrl_status/xmodemtrace.html
 .. _`Battery voltage low level %XVBATLOWLVL`: https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/mob_termination_ctrl_status/xvbatlowlvl.html
 .. _`Debugging nRF5340 with SES`: https://infocenter.nordicsemi.com/topic/ug_gsg_ncs/UG/gsg/debug.html?cp=1_1_0_7
+
+.. _`nRF91x1 AT Commands Reference Guide`: https://www.nordicsemi.com/-/media/Software-and-other-downloads/SiP/nRF91x1-SiP/v0.8-nRF91x1_CIoT_and_Positioning-AT-Commands-reference-guide.pdf
 
 .. _`nRF5340 Product Specification`: https://infocenter.nordicsemi.com/topic/ps_nrf5340/keyfeatures_html5.html
 .. _`nRF5340 DK User Guide`: https://infocenter.nordicsemi.com/topic/ug_nrf5340_dk/UG/dk/intro.html
@@ -582,7 +585,7 @@
 .. _`Mobile network operator certifications`: https://infocenter.nordicsemi.com/topic/comp_matrix_nrf9160/COMP/nrf9160/nrf9160_operator_certifications.html
 .. _`Modem firmware compatibility matrix`: https://infocenter.nordicsemi.com/topic/comp_matrix_nrf9160/COMP/nrf9160/nrf9160_modem_fw.html
 
-.. _`Power saving mode setting section in AT commands reference document`: https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/nw_service/cpsms.html
+.. _`Power saving mode setting`: https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/nw_service/cpsms.html
 .. _`Measuring current on nRF9160 DK`: https://infocenter.nordicsemi.com/topic/ug_nrf91_dk/UG/nrf91_DK/hw_measure_current.html
 .. _`Release Assistance Indication (RAI)`: https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/nw_service/xrai.html
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -1062,3 +1062,4 @@ Documentation
   * The :ref:`ug_nrf9160_gs` instructions to use `Cellular Monitor`_ instead of Programmer for :ref:`nrf9160_gs_updating_fw`.
     The instructions for using Programmer were moved to the :ref:`ug_nrf9160` page.
   * Replaced LTE Link Monitor and Trace Collector apps with `nRF Connect Serial Terminal`_ and `Cellular Monitor`_ apps.
+  * Renamed nRF91 AT Commands Reference Guide to `nRF9160 AT Commands Reference Guide`_, and added references to the `nRF91x1 AT Commands Reference Guide`_ in the documentation.

--- a/samples/cellular/at_client/README.rst
+++ b/samples/cellular/at_client/README.rst
@@ -27,7 +27,7 @@ This facilitates the reading of responses or analyzing of events related to the 
 You can initiate the commands manually from a terminal such as the `nRF Connect Serial Terminal`_, or visually using the `Cellular Monitor`_ app.
 Both apps are part of `nRF Connect for Desktop`_.
 
-For more information on the AT commands, see the `AT Commands Reference Guide`_.
+For more information on the AT commands, see the `nRF91x1 AT Commands Reference Guide`_  or `nRF9160 AT Commands Reference Guide`_ depending on the SiP you are using.
 
 .. include:: /libraries/modem/nrf_modem_lib/nrf_modem_lib_trace.rst
    :start-after: modem_lib_sending_traces_UART_start
@@ -87,8 +87,8 @@ Following is a sample output of the command :command:`AT%XMONITOR`:
 References
 **********
 
-`AT Commands Reference Guide`_
-
+* `nRF91x1 AT Commands Reference Guide`_
+* `nRF9160 AT Commands Reference Guide`_
 
 Dependencies
 ************

--- a/samples/cellular/lwm2m_client/provisioning.rst
+++ b/samples/cellular/lwm2m_client/provisioning.rst
@@ -24,7 +24,7 @@ Programming the AT Client sample
 ********************************
 
 You must program the :ref:`at_client_sample` sample to your device to control the security tags in the modem.
-See `nRF91 AT Commands Reference Guide <AT Commands Reference Guide_>`_ for documentation on each AT command.
+See the `nRF91x1 AT Commands Reference Guide`_  or `nRF9160 AT Commands Reference Guide`_ for documentation on each AT command.
 Also, you must provision the bootstrap credentials for the security tag (that you have specified in :kconfig:option:`CONFIG_LWM2M_CLIENT_UTILS_BOOTSTRAP_TLS_TAG` Kconfig option) to the cellular modem.
 
 Provisioning the identity and security credentials
@@ -32,13 +32,14 @@ Provisioning the identity and security credentials
 
 To provision the credentials, complete the following steps:
 
-1. Ensure that you have removed the previous security tags from the modem by issuing the `AT%CMNG <Credential storage management %CMNG_>`_ command:
+1. Ensure that you have removed the previous security tags from the modem by issuing the ``AT%CMNG`` command:
 
    .. code-block:: none
 
       AT%CMNG=3,<TAG>,3
       AT%CMNG=3,<TAG>,4
 
+   See the `Credential storage management %CMNG`_ section in the nRF9160 AT Commands Reference Guide or the same section in the `nRF91x1 AT Commands Reference Guide`_ depending on the SiP you are using.
 
 #. Identify the device IMEI by issuing the command ``AT+CGSN``:
 

--- a/samples/cellular/modem_shell/README.rst
+++ b/samples/cellular/modem_shell/README.rst
@@ -41,10 +41,11 @@ LTE link control changes and queries the state of the LTE connection.
 Many of the changes are applied when going to online mode for the next time.
 You can store some link subcommand parameters into settings, which are persistent between sessions.
 
-3GPP Release 14 features are enabled by default, which means they are set when going into normal mode and when booting up.
-For the list of supported features, refer to `3GPP Release 14 features AT command`_.
+For nRF9160, 3GPP Release 14 features are enabled by default, which means they are set when going into normal mode and when booting up.
 To disable these features in normal mode,  use the ``link funmode --normal_no_rel14`` command.
 During autoconnect in bootup, use the ``link nmodeauto --enable_no_rel14`` command.
+For the list of supported features, refer to the `3GPP Release 14 features AT command`_ section in the nRF9160 AT Commands Reference Guide.
+For nRF91x1, 3GPP Release 14 features are always enabled and cannot be disabled.
 
 Examples
 --------

--- a/samples/cellular/nrf_cloud_multi_service/README.rst
+++ b/samples/cellular/nrf_cloud_multi_service/README.rst
@@ -37,7 +37,8 @@ This sample implements or demonstrates the following features:
 * Error-tolerant use of the nRF Cloud CoAP API using the :ref:`lib_nrf_cloud_coap` CoAP library.
 * Error-tolerant use of the `nRF Cloud MQTT API`_ using the :ref:`lib_nrf_cloud` library.
 * Support for `Firmware-Over-The-Air (FOTA) update service <nRF Cloud Getting Started FOTA documentation_>`_ using the `nRF Cloud`_ portal.
-* Support for `modem AT commands <AT Commands Reference Guide_>`_ over UART using the :ref:`lib_at_host` library.
+* Support for modem AT commands over UART using the :ref:`lib_at_host` library.
+  See `nRF91x1 AT Commands Reference Guide`_ or `nRF9160 AT Commands Reference Guide`_ documentation on each AT command.
 * Support for remote execution of modem AT commands using application-specific device messages.
 * Periodic cellular, Wi-Fi, and GNSS location tracking using the :ref:`lib_location` library.
 * Periodic temperature sensor sampling on your `Nordic Thingy:91`_, or fake temperature  measurements on your `Nordic nRF9161 DK`_, or `Nordic nRF9160 DK`_.

--- a/samples/cellular/pdn/README.rst
+++ b/samples/cellular/pdn/README.rst
@@ -29,7 +29,8 @@ Finally, the sample prints the PDP context IDs and PDN IDs of both the default P
 
 .. note::
    The sample uses the :ref:`lte_lc_readme` library to change the modem's functional mode.
-   Hence, the :ref:`pdn_readme` library can automatically register to the necessary packet domain events notifications using the `AT+CGEREP=1 <AT+CGEREP set command_>`_ AT command, and notifications for unsolicited reporting of error codes sent by the network using the `AT+CNEC=16 <AT+CNEC set command_>`_ AT command.
+   Hence, the :ref:`pdn_readme` library can automatically register to the necessary packet domain events notifications using the ``AT+CGEREP=1`` AT command, and notifications for unsolicited reporting of error codes sent by the network using the ``AT+CNEC=16`` AT command.
+   See the `AT+CGEREP set command`_  and the `AT+CNEC set command` sections, respectively, in the nRF9160 AT Commands Reference Guide or the same sections in the `nRF91x1 AT Commands Reference Guide`_ depending on the SiP you are using.
    If your application does not use the :ref:`lte_lc_readme` library to change the modem's functional mode, you have to subscribe to these notifications manually before the functional mode is changed.
 
 .. include:: /libraries/modem/nrf_modem_lib/nrf_modem_lib_trace.rst

--- a/samples/cellular/slm_shell/README.rst
+++ b/samples/cellular/slm_shell/README.rst
@@ -93,9 +93,9 @@ The following table shows how to connect PCA10143 UART_2 to nRF9160 UART_2 for c
 References
 **********
 
-`AT Commands Reference Guide`_
-
-:ref:`SLM_AT_intro`
+* `nRF91x1 AT Commands Reference Guide`_
+* `nRF9160 AT Commands Reference Guide`_
+* :ref:`SLM_AT_intro`
 
 Dependencies
 ************

--- a/samples/cellular/udp/README.rst
+++ b/samples/cellular/udp/README.rst
@@ -110,7 +110,7 @@ The following configurations are recommended for low power behavior:
    before the device enters PSM.
 
 PSM and eDRX timers are set with binary strings that signify a time duration in seconds.
-See `Power saving mode setting section in AT commands reference document`_ for a conversion chart of these timer values.
+For a conversion chart of these timer values, see the `Power saving mode setting`_ section in the nRF9160 AT Commands Reference Guide or the same section in the `nRF91x1 AT Commands Reference Guide`_ depending on the SiP you are using.
 
 .. note::
    The availability of power saving features or timers is entirely dependent on the cellular network.

--- a/west.yml
+++ b/west.yml
@@ -141,7 +141,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 7096d02995dc7ea140340aa473ff1754d7257292
+      revision: 410ca110e209c1c1050d613d1f61c6eab6d171df
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
* Rename "nRF91 AT Commands Reference Guide" to "nRF9160 AT Commands".
* Add AT Commands Reference Guide for the nRF9161 DK.