### PR TITLE
manifest: Update sdk-zephyr to bring compiler error fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 06088342cb531ee470c7f64c8c7c0e10d75de8fc
+      revision: 47f8b98ba0efe5fee10fcc3ed08842ba2e83fd55
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Bring in the commit needed to resolve an unused argument compiler error in the logging module.