### PR TITLE
tfm: Add UART pins Thingy91

### DIFF
--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -74,6 +74,7 @@ config TFM_UART0_TXD_PIN
 	default 29 if BOARD_NRF9160DK_NRF9160_NS
 	default 27 if BOARD_NRF9161DK_NRF9161_NS
 	default 20 if BOARD_NRF5340DK_NRF5340_CPUAPP_NS
+	default 18 if BOARD_THINGY91_NRF9160_NS
 	default 4294967295 # 0xffffffff i.e. disconnected
 	help
 	  The GPIO pin the TFM build system will use for UART0 TXD pin.
@@ -87,6 +88,7 @@ config TFM_UART0_RXD_PIN
 	default 28 if BOARD_NRF9160DK_NRF9160_NS
 	default 26 if BOARD_NRF9161DK_NRF9161_NS
 	default 22 if BOARD_NRF5340DK_NRF5340_CPUAPP_NS
+	default 19 if BOARD_THINGY91_NRF9160_NS
 	default 4294967295 # 0xffffffff i.e. disconnected
 	help
 	  The GPIO pin the TFM build system will use for UART0 RXD pin.
@@ -100,6 +102,7 @@ config TFM_UART0_RTS_PIN
 	default 27 if BOARD_NRF9160DK_NRF9160_NS
 	default 14 if BOARD_NRF9161DK_NRF9161_NS
 	default 19 if BOARD_NRF5340DK_NRF5340_CPUAPP_NS
+	default 20 if BOARD_THINGY91_NRF9160_NS
 	default 4294967295 # 0xffffffff i.e. disconnected
 	help
 	  The GPIO pin the TFM build system will use for UART0 RTS pin.
@@ -113,6 +116,7 @@ config TFM_UART0_CTS_PIN
 	default 26 if BOARD_NRF9160DK_NRF9160_NS
 	default 15 if BOARD_NRF9161DK_NRF9161_NS
 	default 21 if BOARD_NRF5340DK_NRF5340_CPUAPP_NS
+	default 21 if BOARD_THINGY91_NRF9160_NS
 	default 4294967295 # 0xffffffff i.e. disconnected
 	help
 	  The GPIO pin the TFM build system will use for UART0 CTS pin.
@@ -132,6 +136,7 @@ config TFM_UART1_TXD_PIN
 	default 1 if BOARD_NRF9160DK_NRF9160_NS
 	default 29 if BOARD_NRF9161DK_NRF9161_NS
 	default 25 if BOARD_NRF5340DK_NRF5340_CPUAPP_NS
+	default 22 if BOARD_THINGY91_NRF9160_NS
 	default 4294967295 # 0xffffffff i.e. disconnected
 	help
 	  The GPIO pin the TFM build system will use for UART1 TXD pin.
@@ -143,6 +148,7 @@ config TFM_UART1_RXD_PIN
 	default 0 if BOARD_NRF9160DK_NRF9160_NS
 	default 28 if BOARD_NRF9161DK_NRF9161_NS
 	default 26 if BOARD_NRF5340DK_NRF5340_CPUAPP_NS
+	default 23 if BOARD_THINGY91_NRF9160_NS
 	default 4294967295 # 0xffffffff i.e. disconnected
 	help
 	  The GPIO pin the TFM build system will use for UART1 RXD pin.
@@ -154,6 +160,7 @@ config TFM_UART1_RTS_PIN
 	default 14 if BOARD_NRF9160DK_NRF9160_NS
 	default 16 if BOARD_NRF9161DK_NRF9161_NS
 	default 5 if BOARD_NRF5340DK_NRF5340_CPUAPP_NS
+	default 24 if BOARD_THINGY91_NRF9160_NS
 	default 4294967295 # 0xffffffff i.e. disconnected
 	help
 	  The GPIO pin the TFM build system will use for UART1 RTS pin.
@@ -165,6 +172,7 @@ config TFM_UART1_CTS_PIN
 	default 15 if BOARD_NRF9160DK_NRF9160_NS
 	default 17 if BOARD_NRF9161DK_NRF9161_NS
 	default 6 if BOARD_NRF5340DK_NRF5340_CPUAPP_NS
+	default 25 if BOARD_THINGY91_NRF9160_NS
 	default 4294967295 # 0xffffffff i.e. disconnected
 	help
 	  The GPIO pin the TFM build system will use for UART1 CTS pin.


### PR DESCRIPTION
Add UART pins for board thingy91_nrf9160_ns to
allow TFM logging to uart.