### PR TITLE
manifest: sdk-zephyr: Pull changes for Wi-Fi mode

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: d62a2c576ac0a2bd164b355cbd95aa00ede869c5
+      revision: 06088342cb531ee470c7f64c8c7c0e10d75de8fc
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This pull brings in the fix for Wi-Fi mode get command from upstream zephyr to sdk-zehyr