### PR TITLE
github: Disable additional check for Kconfig with no modules

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -76,7 +76,7 @@ jobs:
         git log --pretty=oneline | head -n 10
         # For now we run KconfigBasic, but we should transition to Kconfig
         $ZEPHYR_BASE/scripts/ci/check_compliance.py --annotate -e Kconfig \
-        -c origin/${BASE_REF}..
+        -e KconfigBasicNoModules -c origin/${BASE_REF}..
 
     - name: upload-results
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
The new KconfigNoModules check was added here:
https://github.com/zephyrproject-rtos/zephyr/pull/59210

Zephyr counterpart: https://github.com/nrfconnect/sdk-zephyr/pull/1330