### PR TITLE
doc: nrf5340_audio: note about +20 dBm limitation

### DIFF
--- a/applications/nrf5340_audio/README.rst
+++ b/applications/nrf5340_audio/README.rst
@@ -405,6 +405,10 @@ You can add support for the nRF21540 front-end module (FEM) to this application 
 
 To set the TX power output, use the :ref:`CONFIG_NRF_21540_MAIN_TX_POWER <config_nrf53_audio_app_options>` and :ref:`CONFIG_NRF_21540_PRI_ADV_TX_POWER <config_nrf53_audio_app_options>` Kconfig options.
 
+.. note::
+   When you build the nRF5340 Audio application with the nRF21540 FEM support, the :ref:`lib_bt_ll_acs_nrf53_readme` does not support the +20 dBm setting.
+   This is because of a power class restriction in the controller's QDID.
+
 See :ref:`ug_radio_fem` for more information about FEM in the |NCS|.
 
 .. _nrf53_audio_app_building_script:

--- a/doc/nrf/libraries/bin/bt_ll_acs_nrf53/index.rst
+++ b/doc/nrf/libraries/bin/bt_ll_acs_nrf53/index.rst
@@ -69,6 +69,9 @@ The controller is marked as :ref:`experimental <software_maturity>`.
 This controller and the LE Audio Controller Subsystem for nRF5340 it includes has been tested and works in configurations used by the :ref:`nrf53_audio_app` application (for example, 2 concurrent CIS, or BIS).
 No other configurations than the ones used in the referenced application have been tested or documented for this library.
 
+When you :ref:`build the nRF5340 Audio application with the nRF21540 FEM support <nrf53_audio_app_adding_FEM_support>`, the LE Audio controller for nRF5340 does not support the +20 dBm setting.
+This is because of a power class restriction in the controller's QDID.
+
 Dependencies
 ************
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -38,12 +38,7 @@ IDE and tool support
 Application development
 =======================
 
-|no_changes_yet_note|
-
-RF Front-End Modules
---------------------
-
-* Updated the name of the ``nrf21540_ek`` shield to ``nrf21540ek``.
+This section provides detailed lists of changes to overarching SDK systems and components.
 
 Build system
 ------------
@@ -53,6 +48,11 @@ Build system
 
 * The |NCS| name and version is now displayed instead of the Zephyr version as the default boot banner when applications boot.
   This can be customized in user applications.
+
+nRF Front-End Modules
+---------------------
+
+* Updated the name of the ``nrf21540_ek`` shield to ``nrf21540ek``.
 
 Working with nRF91 Series
 =========================
@@ -620,7 +620,9 @@ Debug libraries
 Binary libraries
 ----------------
 
-|no_changes_yet_note|
+* :ref:`lib_bt_ll_acs_nrf53_readme` library:
+
+  * Added a limitation about the lack of support for the +20 dBm setting when :ref:`building the nRF5340 Audio application with the nRF21540 FEM support <nrf53_audio_app_adding_FEM_support>`.
 
 Bluetooth libraries and services
 --------------------------------


### PR DESCRIPTION
Added a mention of the missing support for +20 dBm when using the controller with the nRF21540 FEM, because of a class restriction in the controller's QDID.
OCT-2735.