### PR TITLE
manifest: pull Matter fix for IPv6 prefixes count

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -149,7 +149,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 350869a29f1f06cb816f2e4f0d5822514dd41562
+      revision: 3b93541c781635bf6882edec4eff8e142f219fd4
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
...to match the maximum number of IPv6 addresses per interface.

Zephyr ipv6_nbr implementation requires the given address to have a matching prefix set on the
interface. Otherwise, the default router is used for sending neighbor advertisement and as a result, 
in case there are multiple routers in the network, the packet can be sent to the invalid interface
(not the one which issued neighbor solicitation).

The detailed analysis of the issue can be found in KRKNWK-17318.