### PR TITLE
manifest: sdk-zephyr: mesh v1b1 PTS tester support and fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 972c7c3ca30d782e797c4ed304239b547057f3e6
+      revision: cafad7403fb4eaf5939c73db2fdfecff2bf65b11
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Adding mesh v1b1 PTS tester and fixes for mesh 1.1 qualification