### PR TITLE
manifest: pull recent vital Matter SDK patches

### DIFF
--- a/applications/matter_bridge/src/bridged_device_types/onoff_light.cpp
+++ b/applications/matter_bridge/src/bridged_device_types/onoff_light.cpp
@@ -8,6 +8,8 @@
 
 #include <zephyr/logging/log.h>
 
+#include <app-common/zap-generated/ids/Commands.h>
+
 LOG_MODULE_DECLARE(app, CONFIG_CHIP_APP_LOG_LEVEL);
 
 namespace

--- a/samples/matter/common/src/bridge/bridged_device_data_provider.h
+++ b/samples/matter/common/src/bridge/bridged_device_data_provider.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <app-common/zap-generated/ids/Attributes.h>
+#include <app-common/zap-generated/ids/Clusters.h>
 #include <app/util/attribute-storage.h>
 
 class BridgedDeviceDataProvider {

--- a/samples/matter/common/src/bridge/matter_bridged_device.h
+++ b/samples/matter/common/src/bridge/matter_bridged_device.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <app-common/zap-generated/ids/Attributes.h>
+#include <app-common/zap-generated/ids/Clusters.h>
 #include <app/util/attribute-storage.h>
 
 /* Definitions of  helper macros that are used across all bridged device types to create common mandatory clusters in a

--- a/west.yml
+++ b/west.yml
@@ -149,7 +149,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: ba4b30a246e95e3023e562bc5d00a5a6771feca5
+      revision: 96ea9333bb49c6b0cc381f3082d987223205e2a3
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
This PR pulls important commits cherry-picked from the Matter SDK:
- Matter shell refinements
- compilation time optimization
- root certification expiration fixes
- RAM size optimization
- performance improvements
- subscriptions and reporting fixes
- Matter spec conformance fixes
- configuration fix