### PR TITLE
cmake: create store / restore functions for NCS prefixed variables

### DIFF
--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -4,12 +4,30 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+function(store_ncs_vars)
+  get_property(ncs_vars DIRECTORY ${SYSBUILD_CURRENT_CMAKE_DIR} PROPERTY VARIABLES)
+  list(FILTER ncs_vars INCLUDE REGEX "NCS_.*")
+  foreach(var ${ncs_vars})
+    set_property(GLOBAL APPEND PROPERTY NCS_VARS ${var})
+    set_property(GLOBAL PROPERTY ${var} ${${var}})
+  endforeach()
+endfunction()
+
+function(restore_ncs_vars)
+  get_property(ncs_vars GLOBAL PROPERTY NCS_VARS)
+  foreach(var ${ncs_vars})
+    get_property(var_value GLOBAL PROPERTY ${var})
+    set(${var} ${var_value} PARENT_SCOPE)
+  endforeach()
+endfunction()
+
 function(include_provision_hex)
   include(${ZEPHYR_NRF_MODULE_DIR}/subsys/bootloader/cmake/provision_hex.cmake)
 endfunction()
 
 function(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
   cmake_parse_arguments(PRE_CMAKE "" "" "IMAGES" ${ARGN})
+  restore_ncs_vars()
 
   foreach(image ${PRE_CMAKE_IMAGES})
     if(SB_CONFIG_PARTITION_MANAGER)
@@ -29,6 +47,7 @@ endfunction(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
 # Sysbuild function hooks used by nRF Connect SDK
 function(${SYSBUILD_CURRENT_MODULE_NAME}_post_cmake)
   cmake_parse_arguments(POST_CMAKE "" "" "IMAGES" ${ARGN})
+  restore_ncs_vars()
 
   set_property(GLOBAL PROPERTY DOMAIN_APP_APP ${DEFAULT_IMAGE})
 
@@ -50,7 +69,7 @@ endfunction(${SYSBUILD_CURRENT_MODULE_NAME}_post_cmake)
 
 # Enable use of partition manager with sysbuild.
 # Consider if this shoulc come through Sysbuild Kconfig flag.
-set(NCS_SYSBUILD_PARTITION_MANAGER TRUE PARENT_SCOPE)
+set(NCS_SYSBUILD_PARTITION_MANAGER TRUE)
 
 include(${CMAKE_CURRENT_LIST_DIR}/extensions.cmake)
 
@@ -79,3 +98,5 @@ endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/netcore.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/secureboot.cmake)
+
+store_ncs_vars()


### PR DESCRIPTION
Introduce two new functions in NCS sysbuild code:
- store_ncs_vars
- restore_ncs_vars

the store_ncs_vars() pushes all CMake variables prefixed with NCS_` which exists in the top-level sdk-nrf sysbuild CMake file to a property and upon calls to sysbuild hooks, those NCS variables are restored.

This allows CMake code in sdk-nrf to share CMake variables between sysbuild configure stages.