### PR TITLE
doc: sml: add display names to dependency list

### DIFF
--- a/doc/_scripts/software_maturity/software_maturity_features.yaml
+++ b/doc/_scripts/software_maturity/software_maturity_features.yaml
@@ -102,3 +102,10 @@ features:
     Immutable Bootloader as part of build: SECURE_BOOT
   hw_unique_key:
     Key Derivation from Hardware Unique Key: HW_UNIQUE_KEY
+display_names:
+  SHIELD_NRF7002EK: nRF7002 EK
+  SHIELD_NRF7002EK_NRF7000: nRF7002 EK in nRF7000 emulation mode
+  SHIELD_NRF7002EK_NRF7001: nRF7002 EK in nRF7001 emulation mode
+  SHIELD_NRF7002EB: nRF7002 EB
+  BOARD_NRF7002DK_NRF5340_CPUAPP: nRF7002 DK
+  BOARD_NRF7002DK_NRF7001_NRF5340_CPUAPP: nRF7002 DK in nRF7001 emulation mode


### PR DESCRIPTION
Added the possibility to add a display name for each listed KConfig symbol dependency in the `boards_and_shields` section of the input file to the SML scanner. If no display name is given, the previous substring is used instead.