### PR TITLE
applications: serial_lte_modem: Fix socket options.

### DIFF
--- a/applications/serial_lte_modem/doc/SOCKET_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/SOCKET_AT_commands.rst
@@ -520,10 +520,6 @@ Syntax
 
     * ``<value>`` is an integer that indicates the send timeout in seconds.
 
-  * ``25`` - :c:macro:`SO_BINDTODEVICE` (set-only).
-
-    * ``<value>`` is an integer that indicates the PDP context ID to bind to.
-
   * ``30`` - :c:macro:`SO_SILENCE_ALL`.
 
     * ``<value>`` is an integer that indicates whether ICMP echo replies for IPv4 and IPv6 are disabled.
@@ -538,6 +534,10 @@ Syntax
 
     * ``<value>`` is an integer that indicates whether ICMP echo replies for IPv6 are enabled.
       It is ``0`` for disabled or ``1`` for enabled.
+
+  * ``40`` - :c:macro:`SO_BINDTOPDN` (set-only).
+
+    * ``<value>`` is an integer that indicates the packet data network ID to bind to.
 
   * ``50`` - :c:macro:`SO_RAI_NO_DATA` (set-only).
     Immediately release the RRC.
@@ -663,12 +663,7 @@ Syntax
 
     * ``<value>`` can be any integer value.
 
-  * ``14`` - :c:macro:`TLS_DTLS_HANDSHAKE_TIMEO`.
-
-    * ``<value>`` is an integer that indicates the DTLS handshake timeout in seconds.
-      It can be one of the following values: ``1``, ``3``, ``7``, ``15``, ``31``, ``63``, ``123``.
-
-  * ``17`` - :c:macro:`TLS_DTLS_CID`.
+  * ``14`` - :c:macro:`TLS_DTLS_CID` (set-only).
 
     * ``<value>`` is an integer that indicates the DTLS connection identifier setting.
       It can be one of the following values:
@@ -680,11 +675,16 @@ Syntax
     This option is only supported with modem firmware 1.3.5 and newer.
     See :ref:`nrfxlib:dtls_cid_setting` for more details regarding the allowed values.
 
-  * ``18`` - :c:macro:`TLS_DTLS_CID_STATUS` (get-only).
+  * ``15`` - :c:macro:`TLS_DTLS_CID_STATUS` (get-only).
     It is the DTLS connection identifier status.
     It can be retrieved after the DTLS handshake.
     This option is only supported with modem firmware 1.3.5 and newer.
     See :ref:`nrfxlib:dtls_cid_status` for more details regarding the returned values.
+
+  * ``18`` - :c:macro:`TLS_DTLS_HANDSHAKE_TIMEO`.
+
+    * ``<value>`` is an integer that indicates the DTLS handshake timeout in seconds.
+      It can be one of the following values: ``1``, ``3``, ``7``, ``15``, ``31``, ``63``, ``123``.
 
 See `nRF socket options`_ for explanation of the supported options.
 

--- a/applications/serial_lte_modem/src/slm_at_socket.c
+++ b/applications/serial_lte_modem/src/slm_at_socket.c
@@ -101,7 +101,7 @@ static int find_avail_socket(void)
 	return -ENOENT;
 }
 
-static int bind_to_device(uint16_t cid)
+static int bind_to_pdn(uint16_t cid)
 {
 	int ret = 0;
 
@@ -143,7 +143,7 @@ static int do_socket_open(void)
 
 	sock.fd = ret;
 	/* Explicitly bind to secondary PDP context if required */
-	ret = bind_to_device(sock.cid);
+	ret = bind_to_pdn(sock.cid);
 	if (ret) {
 		close(sock.fd);
 		return ret;
@@ -180,7 +180,7 @@ static int do_secure_socket_open(int peer_verify)
 	}
 	sock.fd = ret;
 	/* Explicitly bind to secondary PDP context if required */
-	ret = bind_to_device(sock.cid);
+	ret = bind_to_pdn(sock.cid);
 	if (ret) {
 		close(sock.fd);
 		return ret;

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -240,6 +240,7 @@ Serial LTE modem
   * Modem FOTA to only need a modem reset to apply the firmware update.
     The full chip reset (using the ``#XRESET`` AT command) remains supported.
   * ``#XGPSDEL`` AT command to disallow deleting local clock (TCXO) frequency offset data because it is an internal value that should not be deleted when simulating a cold start.
+  * Socket option ``TLS_DTLS_HANDSHAKE_TIMEO`` to a new name value.
 
 * Removed:
 


### PR DESCRIPTION
Numbering has changed for: TLS_DTLS_CID, TLS_DTLS_CID_STATUS and TLS_DTLS_HANDSHAKE_TIMEO.

Edit: If these keep on changing, we should consider string names for options.

Edit edit: SO_BINDTODEVICE has been replaced with SO_BINDTOPDN.