### PR TITLE
applications: Matter Bridge: make adding new devices more flexible

### DIFF
--- a/samples/matter/common/src/bridge/util/bridge_util.h
+++ b/samples/matter/common/src/bridge/util/bridge_util.h
@@ -125,12 +125,12 @@ template <typename T, std::size_t N> struct FiniteMap {
 	}
 	std::size_t FreeSlots() { return N - mElementsCount; }
 
-	bool ValueDuplicated(const T &value, uint16_t *key, uint8_t &numberOfDuplicates)
+	uint8_t GetDuplicatesCount(const T &value, uint16_t *key)
 	{
 		/* Find the first duplicated item and return its key,
 		 so that the application can handle the duplicate by itself. */
 		*key = kInvalidKey;
-		numberOfDuplicates = 0;
+		uint8_t numberOfDuplicates = 0;
 		for (auto it = std::begin(mMap); it != std::end(mMap); ++it) {
 			if (it->value == value) {
 				*(key++) = it->key;
@@ -138,8 +138,7 @@ template <typename T, std::size_t N> struct FiniteMap {
 			}
 		}
 
-		/* We must find at least two matching items. */
-		return (numberOfDuplicates > 1) ? true : false;
+		return numberOfDuplicates;
 	}
 
 	Item mMap[N];


### PR DESCRIPTION
This patch allows to add different Matter devices tied to the same data provider
in multiple steps - up till now it has to be added in a single call.