### PR TITLE
drivers: wifi: Provide option to disable beamforming

### DIFF
--- a/drivers/wifi/nrf700x/Kconfig
+++ b/drivers/wifi/nrf700x/Kconfig
@@ -351,3 +351,7 @@ endif # NETWORKING
 config WIFI_MGMT_SCAN_SSID_FILT_MAX
 	default 2
 endif
+
+config NRF_WIFI_BEAMFORMING
+	bool "Enable Wi-Fi beamforming. Enabling beamforming can provide slight improvement in performance where as disabling it can provide better power saving in low network activity applications"
+	default y

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/default/fmac_api.h
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/default/fmac_api.h
@@ -915,6 +915,7 @@ void nrf_wifi_fmac_dev_rem(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx);
  * @param sleep_type Type of RPU sleep.
  * @param phy_calib PHY calibration flags to be passed to the RPU.
  * @param op_band Operating band of the RPU.
+ * @param beamforming Enable/disable Wi-Fi beamforming.
  * @param tx_pwr_ctrl_params TX power control parameters to be passed to the RPU.
  * @param tx_pwr_ceil_params TX power ceil parameters for both frequency bands.
  *
@@ -928,14 +929,15 @@ void nrf_wifi_fmac_dev_rem(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx);
  * @retval	NRF_WIFI_STATUS_FAIL On failure to execute command
  */
 enum nrf_wifi_status nrf_wifi_fmac_dev_init(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
-			unsigned char *rf_params_usr,
+					    unsigned char *rf_params_usr,
 #if defined(CONFIG_NRF_WIFI_LOW_POWER) || defined(__DOXYGEN__)
-			int sleep_type,
+					    int sleep_type,
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
-			unsigned int phy_calib,
-			enum op_band op_band,
-			struct nrf_wifi_tx_pwr_ctrl_params *tx_pwr_ctrl_params,
-			struct nrf_wifi_tx_pwr_ceil_params *tx_pwr_ceil_params);
+					    unsigned int phy_calib,
+					    enum op_band op_band,
+					    bool beamforming,
+					    struct nrf_wifi_tx_pwr_ctrl_params *tx_pwr_ctrl_params,
+					    struct nrf_wifi_tx_pwr_ceil_params *tx_pwr_ceil_params);
 
 
 /**

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fmac_cmd.h
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fmac_cmd.h
@@ -37,6 +37,7 @@ enum nrf_wifi_status umac_cmd_init(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
 				   unsigned int phy_calib,
 				   enum op_band op_band,
+				   bool beamforming,
 				   struct nrf_wifi_tx_pwr_ctrl_params *tx_pwr_ctrl_params);
 
 enum nrf_wifi_status umac_cmd_deinit(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx);

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/radio_test/fmac_api.h
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/radio_test/fmac_api.h
@@ -236,7 +236,8 @@ void nrf_wifi_fmac_dev_rem_rt(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx);
  * @param sleep_type Type of RPU sleep.
  * @param phy_calib PHY calibration flags to be passed to the RPU.
  * @param op_band Operating band of the RPU.
- * @param tx_pwr_ctrl_params TX power control parameters to be passed to the RPU.
+ * @param beamforming Enable/disable Wi-Fi beamforming.
+ * @param tx_pwr_ctrl TX power control parameters to be passed to the RPU.
  *
  * This function initializes the firmware of an RPU instance.
  *
@@ -245,11 +246,12 @@ void nrf_wifi_fmac_dev_rem_rt(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx);
  */
 enum nrf_wifi_status nrf_wifi_fmac_dev_init_rt(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 #if defined(CONFIG_NRF_WIFI_LOW_POWER) || defined(__DOXYGEN__)
-			int sleep_type,
+					       int sleep_type,
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
-			unsigned int phy_calib,
-			enum op_band op_band,
-			struct nrf_wifi_tx_pwr_ctrl_params *tx_pwr_ctrl_params);
+					       unsigned int phy_calib,
+					       enum op_band op_band,
+					       bool beamforming,
+					       struct nrf_wifi_tx_pwr_ctrl_params *tx_pwr_ctrl);
 
 
 /**

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/cmd.c
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/cmd.c
@@ -97,6 +97,7 @@ enum nrf_wifi_status umac_cmd_init(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
 				   unsigned int phy_calib,
 				   enum op_band op_band,
+				   bool beamforming,
 				   struct nrf_wifi_tx_pwr_ctrl_params *tx_pwr_ctrl_params)
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
@@ -187,6 +188,9 @@ enum nrf_wifi_status umac_cmd_init(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 #ifdef CONFIG_NRF700X_RPU_EXTEND_TWT_SP
 	 umac_cmd_data->feature_flags |= TWT_EXTEND_SP_EDCA;
 #endif
+	if (!beamforming) {
+		umac_cmd_data->disable_beamforming = 1;
+	}
 
 	 status = nrf_wifi_hal_ctrl_cmd_send(fmac_dev_ctx->hal_dev_ctx,
 					    umac_cmd,

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/default/fmac_api.c
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/default/fmac_api.c
@@ -212,6 +212,7 @@ static enum nrf_wifi_status nrf_wifi_fmac_fw_init(struct nrf_wifi_fmac_dev_ctx *
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
 						  unsigned int phy_calib,
 						  enum op_band op_band,
+						  bool beamforming,
 						  struct nrf_wifi_tx_pwr_ctrl_params *tx_pwr_ctrl)
 {
 	unsigned long start_time_us = 0;
@@ -252,6 +253,7 @@ static enum nrf_wifi_status nrf_wifi_fmac_fw_init(struct nrf_wifi_fmac_dev_ctx *
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
 			       phy_calib,
 			       op_band,
+			       beamforming,
 			       tx_pwr_ctrl);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
@@ -352,6 +354,7 @@ enum nrf_wifi_status nrf_wifi_fmac_dev_init(struct nrf_wifi_fmac_dev_ctx *fmac_d
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
 					    unsigned int phy_calib,
 					    enum op_band op_band,
+					    bool beamforming,
 					    struct nrf_wifi_tx_pwr_ctrl_params *tx_pwr_ctrl_params,
 					    struct nrf_wifi_tx_pwr_ceil_params *tx_pwr_ceil_params)
 {
@@ -431,6 +434,7 @@ enum nrf_wifi_status nrf_wifi_fmac_dev_init(struct nrf_wifi_fmac_dev_ctx *fmac_d
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
 				       phy_calib,
 				       op_band,
+				       beamforming,
 				       tx_pwr_ctrl_params);
 
 	if (status == NRF_WIFI_STATUS_FAIL) {

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/radio_test/fmac_api.c
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/radio_test/fmac_api.c
@@ -34,6 +34,7 @@ static enum nrf_wifi_status nrf_wifi_fmac_fw_init_rt(struct nrf_wifi_fmac_dev_ct
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
 						  unsigned int phy_calib,
 						  enum op_band op_band,
+						  bool beamforming,
 						  struct nrf_wifi_tx_pwr_ctrl_params *tx_pwr_ctrl)
 {
 	unsigned long start_time_us = 0;
@@ -45,6 +46,7 @@ static enum nrf_wifi_status nrf_wifi_fmac_fw_init_rt(struct nrf_wifi_fmac_dev_ct
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
 			       phy_calib,
 			       op_band,
+			       beamforming,
 			       tx_pwr_ctrl);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
@@ -96,6 +98,7 @@ enum nrf_wifi_status nrf_wifi_fmac_dev_init_rt(struct nrf_wifi_fmac_dev_ctx *fma
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
 					    unsigned int phy_calib,
 					    enum op_band op_band,
+					    bool beamforming,
 					    struct nrf_wifi_tx_pwr_ctrl_params *tx_pwr_ctrl_params)
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
@@ -119,11 +122,12 @@ enum nrf_wifi_status nrf_wifi_fmac_dev_init_rt(struct nrf_wifi_fmac_dev_ctx *fma
 
 	status = nrf_wifi_fmac_fw_init_rt(fmac_dev_ctx,
 #ifdef CONFIG_NRF_WIFI_LOW_POWER
-				       sleep_type,
+					  sleep_type,
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
-				       phy_calib,
-				       op_band,
-				       tx_pwr_ctrl_params);
+					  phy_calib,
+					  op_band,
+					  beamforming,
+					  tx_pwr_ctrl_params);
 
 	if (status == NRF_WIFI_STATUS_FAIL) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,

--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_fmac_main.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_fmac_main.c
@@ -545,6 +545,7 @@ enum nrf_wifi_status nrf_wifi_fmac_dev_add_zep(struct nrf_wifi_drv_priv_zep *drv
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
 					NRF_WIFI_DEF_PHY_CALIB,
 					op_band,
+					IS_ENABLED(CONFIG_NRF_WIFI_BEAMFORMING),
 					&tx_pwr_ctrl_params);
 #else
 	status = nrf_wifi_fmac_dev_init(rpu_ctx_zep->rpu_ctx,
@@ -554,6 +555,7 @@ enum nrf_wifi_status nrf_wifi_fmac_dev_add_zep(struct nrf_wifi_drv_priv_zep *drv
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
 					NRF_WIFI_DEF_PHY_CALIB,
 					op_band,
+					IS_ENABLED(CONFIG_NRF_WIFI_BEAMFORMING),
 					&tx_pwr_ctrl_params,
 					&tx_pwr_ceil_params);
 #endif /* CONFIG_NRF700X_RADIO_TEST */


### PR DESCRIPTION
Provide a Kconfig option and driver API to disable beamforming.