### PR TITLE
manifest: Update Zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: be22816677ec99e6deb93b9977c403b625ab0448
+      revision: pull/1339/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull Zephyr changes with Bluetooth Host fix related to missing run-time role check in smp when device enabled both BT_PERIPHERAL and BT_CENTRAL.

Jira: NCSDK-23710