### PR TITLE
doc: nrf: Added page about Matter ecosystems certification

### DIFF
--- a/doc/_utils/redirects.py
+++ b/doc/_utils/redirects.py
@@ -118,6 +118,7 @@ NRF = [
     ("ug_matter_device_attestation","protocols/matter/end_product/attestation"),
     ("ug_matter_device_bootloader","protocols/matter/end_product/bootloader"),
     ("ug_matter_device_certification","protocols/matter/end_product/certification"),
+    ("ug_matter_ecosystems_certification","protocols/matter/end_product/ecosystems_certification"),
     ("ug_matter_device_dcl","protocols/matter/end_product/dcl"),
     ("ug_matter_device_factory_provisioning","protocols/matter/end_product/factory_provisioning"),
     ("ug_matter_intro_device","protocols/matter/end_product/index"),

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -874,6 +874,7 @@
 .. _`AWS IoT Core`: https://aws.amazon.com/iot-core/
 
 .. _`Understanding Frustration-Free Setup`: https://developer.amazon.com/docs/frustration-free-setup/understanding-ffs.html
+.. _`Matter Simple Setup`: https://developer.amazon.com/docs/frustration-free-setup/matter-simple-setup-getting-started.html
 .. _`Matter Simple Setup for Wi-Fi Overview`: https://developer.amazon.com/docs/frustration-free-setup/matter-simple-setup-for-wifi-overview.html
 .. _`Matter Simple Setup for Thread Overview`: https://developer.amazon.com/docs/frustration-free-setup/matter-simple-setup-for-thread-overview.html
 .. _`Amazon Alexa integration with Matter`: https://developer.amazon.com/en-US/docs/alexa/smarthome/matter-support.html
@@ -1103,6 +1104,7 @@
 .. _`Google Chrome browser`: https://www.google.com/chrome
 
 .. _`Google Home integration with Matter`: https://developers.home.google.com/matter
+.. _`Works with Google Home`: https://developers.home.google.com/matter/certification#wwgh_certification
 
 .. ### Source: ubuntu.com
 

--- a/doc/nrf/protocols/matter/end_product/ecosystems_certification.rst
+++ b/doc/nrf/protocols/matter/end_product/ecosystems_certification.rst
@@ -1,0 +1,62 @@
+.. _ug_matter_ecosystems_certification:
+
+Ecosystems certification
+########################
+
+.. contents::
+   :local:
+   :depth: 2
+
+The Matter stack provided in the |NCS| works with commercial ecosystems that are compatible with the official Matter implementation.
+A Matter product can be called compatible with the Matter implementation once it has passed relevant Matter certification.
+
+Some of the ecosystem providers offer additional certification programs to verify that Matter product is able to work with that provider's applications and supports their features.
+Once the Matter product passes the certification for the ecosystem, the appropriate information can be placed on the product's packaging.
+
+.. _ug_matter_google_certification:
+
+Works with Google Home certification
+************************************
+
+The `Works with Google Home`_ certification program ensures that a Matter product supports Matter features in the same extent as the Google Home application.
+A product that passed all the certification test cases is allowed to use the Works with Google Home badge.
+
+The Matter samples delivered in the |NCS| have not received official certificates, as certification can only be obtained for final products.
+However, they have been tested against the Works with Google Home certification test cases and have successfully passed all of them.
+The following is a full list of Matter samples that were verified to pass the Works with Google certification test cases:
+
+* :ref:`matter_lock_sample`
+* :ref:`matter_light_bulb_sample`
+* :ref:`matter_thermostat_sample`
+* :ref:`matter_window_covering_sample`
+* :ref:`matter_weather_station_app`
+
+.. _ug_matter_amazon_certification:
+
+Amazon Frustration-Free Setup certification
+*******************************************
+
+Frustration-Free Setup (FFS) is Amazon's proprietary feature that uses Amazon cloud services to provide the onboarding information necessary to commission the Matter device to a Matter fabric.
+The commissioning process is automatically triggered by the Amazon commissioner and it does not require any user interaction.
+The process starts when the commissioner detects the accessory's Bluetooth LE advertising messages in the proprietary format.
+
+For more information about the FFS and how to enable it in Matter samples, see the :ref:`Amazon Frustration-Free Setup configuration<ug_matter_configuring_ffs>` section of the :ref:`ug_matter_device_advanced_kconfigs` page.
+
+FFS requires passing the additional certification test cases for Matter called `Matter Simple Setup`_.
+There are two types of certification:
+
+* Default - For standard products or for the creation of a reference design.
+* Simplified - For products using a certified reference design.
+
+The Matter platform provided in the |NCS| was tested against the FFS certification test cases and passed them in several variants.
+This means that if you create a Matter product based on the |NCS|, you can approach the simplified certification path.
+You can do this by filling the Reference APID field when you register your product on Amazon's developer page.
+Use one of the following values:
+
++----------------------------------------------------+-----------------------+
+| Matter platform variant                            | Reference Design APID |
++====================================================+=======================+
+| :ref:`nRF52840 DK <ug_nrf52>` (Matter over Thread) | ZNwt                  |
++----------------------------------------------------+-----------------------+
+| :ref:`nRF5340 DK <ug_nrf5340>` (Matter over Thread)| xzNd                  |
++----------------------------------------------------+-----------------------+

--- a/doc/nrf/protocols/matter/end_product/index.rst
+++ b/doc/nrf/protocols/matter/end_product/index.rst
@@ -19,7 +19,7 @@ Watch the following video for an overview of the Matter end product development 
    </h1>
 
 The pages that follow deal with the preparation of the device for market launch, starting with :ref:`ug_matter_device_prerequisites` and the reference to the :ref:`ug_matter_device_factory_provisioning` guide.
-Finally, we discuss topics related to Matter certification (:ref:`ug_matter_device_attestation`, :ref:`ug_matter_device_dcl`, :ref:`ug_matter_device_certification`, and :ref:`ug_matter_device_configuring_cd`) and :ref:`ug_matter_device_bootloader`.
+Finally, we discuss topics related to Matter certification (:ref:`ug_matter_device_attestation`, :ref:`ug_matter_device_dcl`, :ref:`ug_matter_device_certification`, :ref:`ug_matter_ecosystems_certification`, and :ref:`ug_matter_device_configuring_cd`) and :ref:`ug_matter_device_bootloader`.
 
 .. toctree::
    :maxdepth: 1
@@ -30,6 +30,7 @@ Finally, we discuss topics related to Matter certification (:ref:`ug_matter_devi
    attestation
    dcl
    certification
+   ecosystems_certification
    bootloader
    security
    configuring_cd

--- a/doc/nrf/protocols/matter/getting_started/advanced_kconfigs.rst
+++ b/doc/nrf/protocols/matter/getting_started/advanced_kconfigs.rst
@@ -82,6 +82,8 @@ Some of these can be configured using the Kconfig options listed below:
 * :kconfig:option:`CONFIG_CHIP_ROTATING_DEVICE_ID` enables an optional rotating device identifier feature that provides an additional unique identifier for each device.
   This identifier is similar to the serial number, but it additionally changes at predefined times to protect against long-term tracking of the device.
 
+.. _ug_matter_configuring_ffs:
+
 Amazon Frustration-Free Setup support
 =====================================
 
@@ -97,6 +99,12 @@ To enable the FFS support, set the following configuration options to meet the A
 * :kconfig:option:`CONFIG_CHIP_ROTATING_DEVICE_ID` to ``y``.
 * :kconfig:option:`CONFIG_CHIP_DEVICE_TYPE` to the appropriate value, depending on the device used.
   The value must be compliant with the Matter Device Type Identifier.
+
+Every Matter device must use an unique device identifier for rotating device identifier calculation purpose.
+By default, the identifier is set to a random value and stored in the factory data partition.
+You can choose your own unique identifier value instead by setting the :kconfig:option:`CONFIG_CHIP_DEVICE_GENERATE_ROTATING_DEVICE_UID` Kconfig option to ``n`` and using the :kconfig:option:`CONFIG_CHIP_DEVICE_ROTATING_DEVICE_UID` Kconfig option.
+When using your own identifier, the value can be stored in either firmware or factory data.
+For more information about the factory data generation, see the :ref:`Matter Device Factory Provisioning<ug_matter_device_factory_provisioning>` page.
 
 To read more about the FFS technology and its compatibility with Matter, see the following pages in the Amazon developer documentation:
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -117,6 +117,7 @@ Matter
     * Perform a factory reset of the device (:kconfig:option:`CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_ONLY`).
     * Perform a factory reset of the device and start Bluetooth LE advertising (:kconfig:option:`CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_PAIRING_START`).
     * Perform a factory reset of the device and then reboot the device (:kconfig:option:`CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_REBOOT`).
+  * Page about :ref:`ug_matter_ecosystems_certification`.
 
 * Updated:
 


### PR DESCRIPTION
Added dedicated page describing how to certify the Matter product for the specific ecosystem cases. Additionally extended the FFS configuration with the information about the rotating device uid selection.