### PR TITLE
tests: net: download_client: Fix crashing test

### DIFF
--- a/tests/subsys/net/lib/download_client/src/mock/socket.c
+++ b/tests/subsys/net/lib/download_client/src/mock/socket.c
@@ -15,8 +15,8 @@ struct mock_socket_iface_data {
 	struct net_if *iface;
 } mock_socket_iface_data;
 
-struct net_if_api mock_if_api = {
-	.init = mock_socket_iface_init,
+struct offloaded_if_api mock_if_api = {
+	.iface_api.init = mock_socket_iface_init,
 };
 
 /* All the functions contains a delay of 50 msec to avoid endless loops in

--- a/tests/subsys/net/lib/download_client/src/mock/socket.h
+++ b/tests/subsys/net/lib/download_client/src/mock/socket.h
@@ -7,9 +7,10 @@
 #define _SOCKET_H_
 
 #include <zephyr/kernel.h>
+#include <zephyr/net/offloaded_netdev.h>
 
 extern struct mock_socket_iface_data mock_socket_iface_data;
-extern struct net_if_api mock_if_api;
+extern struct offloaded_if_api mock_if_api;
 
 int mock_nrf_modem_lib_socket_offload_init(const struct device *arg);
 bool mock_socket_is_supported(int family, int type, int proto);


### PR DESCRIPTION
Offloaded interfaces should no longer register net_if_api, but rather offloaded_if_api now. Using the former can cause a crash when accessing offloaded-specific function, which is exactly the case in download_client tests.