### PR TITLE
ppi_trace: add ppi_trace_dppi_ch_trace function

### DIFF
--- a/include/debug/ppi_trace.h
+++ b/include/debug/ppi_trace.h
@@ -6,6 +6,8 @@
 #ifndef __PPI_TRACE_H
 #define __PPI_TRACE_H
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -44,6 +46,25 @@ void *ppi_trace_config(uint32_t pin, uint32_t evt);
  * @return Handle, or NULL if the configuration failed.
  */
 void *ppi_trace_pair_config(uint32_t pin, uint32_t start_evt, uint32_t stop_evt);
+
+/** @brief Configure and enable a PPI trace pin for tracing a DPPI channel.
+ *
+ * This function allows to trace DPPI triggers without knowing any events being the source of the
+ * trigger. Configuration of events so that they publish to the given DPPI and enabling the DPPI is
+ * out of scope of this function and must be done externally.
+ * This function allows also to trace DPPI channels which are triggered by multiple events or
+ * the set of events publishing to the DPPI channel changes in run-time.
+ *
+ * @note Supported only on platforms equipped with DPPI.
+ *
+ * @param pin		Pin to use for tracing.
+ * @param dppi_ch	DPPI channel number to be traced on the pin.
+ *
+ * @retval 0		The configuration succeeded.
+ * @retval -ENOMEM	The configuration failed, due to lack of necessary resources.
+ * @retval -ENOTSUP	The function is not supported on current hardware platform.
+ */
+int ppi_trace_dppi_ch_trace(uint32_t pin, uint32_t dppi_ch);
 
 /** @brief Enable PPI trace pin.
  *

--- a/subsys/debug/ppi_trace/ppi_trace.c
+++ b/subsys/debug/ppi_trace/ppi_trace.c
@@ -196,6 +196,33 @@ void *ppi_trace_pair_config(uint32_t pin, uint32_t start_evt, uint32_t stop_evt)
 #endif
 }
 
+int ppi_trace_dppi_ch_trace(uint32_t pin, uint32_t dppi_ch)
+{
+#ifdef DPPI_PRESENT
+	uint32_t task;
+	int gpiote_ch;
+	nrf_gpiote_task_t task_id;
+
+	gpiote_ch = gpiote_channel_alloc(pin);
+	if (gpiote_ch < 0) {
+		LOG_ERR("Failed to allocate GPIOTE channel.");
+		return -ENOMEM;
+	}
+
+	task_id = offsetof(NRF_GPIOTE_Type, TASKS_OUT[gpiote_ch]);
+	task = nrf_gpiote_task_address_get(NRF_GPIOTE, task_id);
+
+	*SUBSCRIBE_ADDR(task) = DPPIC_SUBSCRIBE_CHG_EN_EN_Msk | dppi_ch;
+
+	return 0;
+#else
+	(void)pin;
+	(void)dppi_ch;
+
+	return -ENOTSUP;
+#endif
+}
+
 static uint32_t ppi_channel_mask_get(void *handle)
 {
 	return IS_PAIR(handle) ?


### PR DESCRIPTION
For current `ppi_trace_config` it is impossible to trace events for which PUBLISH register is overwritten in run-time after `ppi_trace_config` is called. This function allows also to trace just one event and does not allow to trace many-to-one topologies which are possible with use of DPPIs.

To overcome above limitations `ppi_trace_dppi_ch_trace` is added. In contrast to `ppi_trace_config` the function `ppi_trace_dppi_ch_trace` focuses on tracing rather the DPPI channel leaving the preparation of event network publishing to it to a user.