### PR TITLE
net: lib: nrf_cloud: Update A-GPS cddl

### DIFF
--- a/subsys/net/lib/nrf_cloud/coap/cddl/nrf_cloud_coap_agps.cddl
+++ b/subsys/net/lib/nrf_cloud/coap/cddl/nrf_cloud_coap_agps.cddl
@@ -11,7 +11,7 @@
 type = rtAssistance/custom
 
 agps_req = {
-	? types => [1*10 int],
+	? types => [1*14 int],
 	eci => uint,
 	? filtered => bool,
 	? mask => uint,

--- a/subsys/net/lib/nrf_cloud/coap/include/agps_encode_types.h
+++ b/subsys/net/lib/nrf_cloud/coap/include/agps_encode_types.h
@@ -28,7 +28,7 @@ extern "C" {
 #define DEFAULT_MAX_QTY 10
 
 struct agps_req_types_ {
-	int32_t _agps_req_types_int[10];
+	int32_t _agps_req_types_int[14];
 	size_t _agps_req_types_int_count;
 };
 

--- a/subsys/net/lib/nrf_cloud/coap/src/agps_encode.c
+++ b/subsys/net/lib/nrf_cloud/coap/src/agps_encode.c
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2023 Nordic Semiconductor ASA
- * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ * Copyright (c) 2023 Nordic Semiconductor ASA SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  *
  * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
@@ -36,12 +35,12 @@ static bool encode_repeated_agps_req_types(zcbor_state_t *state,
 
 	bool tmp_result =
 		((((zcbor_uint32_put(state, (1)))) &&
-		  (zcbor_list_start_encode(state, 10) &&
-		   ((zcbor_multi_encode_minmax(1, 10, &(*input)._agps_req_types_int_count,
+		  (zcbor_list_start_encode(state, 14) &&
+		   ((zcbor_multi_encode_minmax(1, 14, &(*input)._agps_req_types_int_count,
 					       (zcbor_encoder_t *)zcbor_int32_encode, state,
 					       (&(*input)._agps_req_types_int), sizeof(int32_t))) ||
 		    (zcbor_list_map_end_force_encode(state), false)) &&
-		   zcbor_list_end_encode(state, 10))));
+		   zcbor_list_end_encode(state, 14))));
 
 	if (!tmp_result) {
 		zcbor_trace();


### PR DESCRIPTION
The number of types of A-GPS elements has increased to support QZSS, so the nrf_cloud/coap/cddl/nrf_cloud_coap_agps.cddl has been changed to match, and the encoder has  been regenerated.