### PR TITLE
drivers: wifi: Fix throughput degradation in BLE

### DIFF
--- a/drivers/wifi/nrf700x/CMakeLists.txt
+++ b/drivers/wifi/nrf700x/CMakeLists.txt
@@ -115,3 +115,10 @@ if (CONFIG_NRF_WIFI_PATCHES_EXT_FLASH)
 # Run patches from the external flash (XIP). No need to copy.
 zephyr_code_relocate(FILES zephyr/src/zephyr_fw_load.c LOCATION EXTFLASH_RODATA NOCOPY)
 endif()
+
+# These are XIP related anomalies and aren't applicable for nRF7002 and cause
+# throughput issues.
+zephyr_compile_definitions_ifdef(CONFIG_NRF700X_ON_QSPI
+	-DNRF53_ERRATA_43_ENABLE_WORKAROUND=0
+	-DNRF52_ERRATA_215_ENABLE_WORKAROUND=0
+)


### PR DESCRIPTION
The anomaly 43 workaround introduces extra delay due to waiting for QSPI ready and causes BLE throughput drops as Wi-Fi driver is waiting and halting the APP.

But this anomaly is only for XIP, so, can be disabled when using QSPI for Wi-Fi comms.

Fixes SHEL-1633.