### PR TITLE
codeowners: Add entry for hostap module

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -135,6 +135,7 @@ Kconfig*                                  @tejlmand
 /lib/pcm_stream_channel_modifier/         @koffes @alexsven @erikrobstad @rick1082 @gWacey
 /lib/tone/                                @koffes @alexsven @erikrobstad @rick1082 @gWacey
 /modules/                                 @tejlmand
+/modules/hostap/                          @krish2718 @jukkar @rado17 @sachinthegreen @rlubos
 /modules/mcuboot/                         @de-nordic @nordicjm
 /modules/cjson/                           @simensrostad @plskeggs @sigvartmh
 /samples/                                 @nrfconnect/ncs-test-leads


### PR DESCRIPTION
This was missed when the module was introduced.

@rlubos let me know if you want me to add as well, initially I wanted to duplicate https://github.com/nrfconnect/sdk-hostap/blob/main/CODEOWNERS but then as @jukkar  started working hostap I have replaced you with him. We should probably have the same list of people on both, @carlescufi WDYT?