### PR TITLE
manifest: Update Matter SDK to pull fix for reporting PartList

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -149,7 +149,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: v2.5.0-rc1
+      revision: 802f5255d0da74c7d94753a86f26a6ad39cc2f1f
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
The newest version of the Matter SDK contains a fix for reporting the PartList attribute of the Descriptor cluster.