### PR TITLE
mcuboot:  kconfig: Select secure boot crypto when using external

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -128,7 +128,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: v1.10.99-ncs1-rc1
+      revision: pull/281/head
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR.git


### PR DESCRIPTION
When using external crypto in MCUBoot secure boot crypto needs to be selected to expose the functions to MCUBoot.

Ref. NCSDK-23994