### PR TITLE
lib: fatal_error: Fix Kconfig option default

### DIFF
--- a/lib/fatal_error/Kconfig
+++ b/lib/fatal_error/Kconfig
@@ -6,7 +6,7 @@
 
 menuconfig RESET_ON_FATAL_ERROR
 	bool "Reset on fatal error"
-	default y if !DEBUG && !BOARD_NATIVE_POSIX && !QEMU_TARGET && !ZTEST
+	default y if !DEBUG && !BOARD_NATIVE_POSIX && !QEMU_TARGET && !TEST
 	select REBOOT
 	help
 	  Enable using the fatal error handler defined for Nordic DKs.


### PR DESCRIPTION
Some tests that were not using ZTEST (but were tests with CONFIG_TEST=y) were failing to compile because this gets default y when n is expected. Broadening default value dependency to check for TEST instead of ZTEST.

Jira: NCSDK-6850.