### PR TITLE
Revert "samples: peripheral_fast_pair: Disable CCC Lazy Loading to allow for rebond"

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -34,7 +34,6 @@
 .. _`Zephyr pull request #29618`: https://github.com/zephyrproject-rtos/zephyr/pull/29618
 .. _`Zephyr issue #27356`: https://github.com/zephyrproject-rtos/zephyr/issues/27356
 .. _`Zephyr issue #38516`: https://github.com/zephyrproject-rtos/zephyr/issues/38516
-.. _`Zephyr issue #61033`: https://github.com/zephyrproject-rtos/zephyr/issues/61033
 .. _`Zephyr SDK`: https://github.com/zephyrproject-rtos/sdk-ng/releases
 .. _`BSEC license`: https://www.bosch-sensortec.com/media/boschsensortec/downloads/software/bme688_development_software/2023_04/license_terms_bme688_bme680_bsec.pdf
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -342,7 +342,6 @@ Bluetooth samples
 * :ref:`peripheral_fast_pair` sample:
 
   * Added automatic switching to the Fast Pair not discoverable advertising mode with the hide UI indication instead of removing the Fast Pair advertising payload when all bond slots are taken.
-  * Updated by disabling the :kconfig:option:`CONFIG_BT_SETTINGS_CCC_LAZY_LOADING` Kconfig option as a workaround fix for the `Zephyr issue #61033`_.
   * Fixed an issue where the sample was unable to advertise in Fast Pair not discoverable advertising mode when it had five Account Keys written.
 
 Bluetooth mesh samples

--- a/samples/bluetooth/peripheral_fast_pair/prj.conf
+++ b/samples/bluetooth/peripheral_fast_pair/prj.conf
@@ -52,10 +52,6 @@ CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL=-14
 # update which triggers an invalid procedure collision.
 CONFIG_BT_AUTO_PHY_UPDATE=n
 
-# Disable CCC Lazy Loading as a workaround fix for the rebond issue that is present because of the
-# following Zephyr issue: https://github.com/zephyrproject-rtos/zephyr/issues/61033.
-CONFIG_BT_SETTINGS_CCC_LAZY_LOADING=n
-
 CONFIG_BT_ID_MAX=1
 CONFIG_BT_MAX_CONN=1
 CONFIG_BT_MAX_PAIRED=8


### PR DESCRIPTION
This reverts commit 2b3c8971bea2fef5da40cb1b9b6a30ea0babce9a, because the Zephyr issue is already fixed.