### PR TITLE
manifest: update zephyr with nrf53 pretick power usage fix 2

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 8c7463b5230ce09b74d75e1b963d0c262d92fa73
+      revision: 1d4a51c2a893f84d17fcf78adb0bdbabe33e71e7
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
It might happen that while some interrupt handler other than for RTC0 or RTC1 (e.g. for RADIO) is executed, the scheduled pretick CC triggers. This starts pretick pulses due to the loop through IPC. The change in pretick schedule did not stop the pretick pulses going through IPC loop, what caused heavy increase in power consumption.

This commit fixes this behavior by bringing in zephyr with the fix.