### PR TITLE
net: lwm2m_client_utils: Advanced FOTA push fix

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -871,6 +871,8 @@ Libraries for networking
     * The ``location_assist_agps_request_set()`` function has been renamed to :c:func:`location_assist_agnss_request_set`.
     * The ``location_assist_agps_set_elevation_mask()`` function has been renamed to :c:func:`location_assist_agnss_set_elevation_mask`.
     * The ``location_assist_agps_get_elevation_mask()`` function has been renamed to :c:func:`location_assist_agnss_get_elevation_mask`.
+    * The advanced LwM2M FOTA object to accept zero length of a firmware package for reset state and result resources.
+      This fixes an interoperability issue with AVSystem's Coiote Device Management server related to firmware update by push-mode.
 
 * :ref:`lib_aws_fota` library:
 

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_adv_firmware.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_adv_firmware.c
@@ -255,18 +255,18 @@ static int package_write_cb(uint16_t obj_inst_id, uint16_t res_id, uint16_t res_
 	lwm2m_engine_set_data_cb_t callback;
 
 	state = lwm2m_adv_firmware_get_update_state(obj_inst_id);
-	if (state == STATE_IDLE) {
-		lwm2m_adv_firmware_set_update_state(obj_inst_id, STATE_DOWNLOADING);
-	} else if (data_len == 0U || (data_len == 1U && data[0] == '\0')) {
-		if (state == STATE_DOWNLOADED || state == STATE_DOWNLOADING) {
-			/* reset to state idle and result default */
-			lwm2m_adv_firmware_set_update_result(obj_inst_id, RESULT_DEFAULT);
-			LOG_DBG("Update canceled by writing %d bytes", data_len);
-			return 0;
+	if (data_len == 0U || (data_len == 1U && data[0] == '\0')) {
+		if (state == STATE_UPDATING) {
+			/* Cancel at Updating state is not accepted */
+			LOG_WRN("Download has already completed");
+			return -EPERM;
 		}
-		LOG_WRN("Download has already completed");
-		return -EPERM;
 
+		lwm2m_adv_firmware_set_update_result(obj_inst_id, RESULT_DEFAULT);
+		return 0;
+
+	} else if (state == STATE_IDLE) {
+		lwm2m_adv_firmware_set_update_state(obj_inst_id, STATE_DOWNLOADING);
 	} else if (state != STATE_DOWNLOADING) {
 		LOG_WRN("Cannot download: state = %d", state);
 		return -EPERM;

--- a/tests/subsys/net/lib/lwm2m_fota_utils/src/firmware.c
+++ b/tests/subsys/net/lib/lwm2m_fota_utils/src/firmware.c
@@ -699,13 +699,18 @@ ZTEST(lwm2m_client_utils_firmware, test_firmware_update)
 
 ZTEST(lwm2m_client_utils_firmware, test_firmware_push_update)
 {
-	int rc;
+	int rc, inavalid_cancel;
 	uint8_t test_dummy_data[32];
 	uint8_t state;
 
+#if defined(CONFIG_LWM2M_CLIENT_UTILS_ADV_FIRMWARE_UPDATE_OBJ_SUPPORT)
+	inavalid_cancel = 0;
+#else
+	inavalid_cancel = -EINVAL;
+#endif
 	dfu_target_mcuboot_identify_fake.return_val = false;
 	rc = post_write_to_resource(app_instance, LWM2M_FOTA_PACKAGE_ID, NULL, 0, false, 0);
-	zassert_equal(rc, -EINVAL, "wrong return value");
+	zassert_equal(rc, inavalid_cancel, "wrong return value");
 
 	rc = post_write_to_resource(app_instance, LWM2M_FOTA_PACKAGE_ID, test_dummy_data, 32, false,
 				    64);


### PR DESCRIPTION
Fixed interoperability issue with AVSystem Coiote server for do Firmware update with Push-mode.
Server cancel at idle state was not accepted and cause failure to FOTA process.