### PR TITLE
samples: cellular: MSS: Fix CoAP FOTA thread startup

### DIFF
--- a/samples/cellular/nrf_cloud_multi_service/src/main.c
+++ b/samples/cellular/nrf_cloud_multi_service/src/main.c
@@ -36,7 +36,7 @@ K_THREAD_DEFINE(con_thread, CONFIG_CONNECTION_THREAD_STACK_SIZE, cloud_connectio
 		NULL, NULL, NULL, 0, 0, 0);
 
 #if defined(CONFIG_NRF_CLOUD_COAP)
-#if defined(CONFIG_NRF_CLOUD_COAP_FOTA)
+#if defined(CONFIG_COAP_FOTA)
 /* Define, and automatically start the CoAP FOTA check thread. See fota_support_coap.c */
 K_THREAD_DEFINE(coap_fota, CONFIG_COAP_FOTA_THREAD_STACK_SIZE, coap_fota_thread_fn,
 		NULL, NULL, NULL, 0, 0, 0);


### PR DESCRIPTION
Small typo in preprocessor directives is causing the coap_fota thread to never start.

Fix this typo by updating CONFIG_NRF_CLOUD_COAP_FOTA to CONFIG_COAP_FOTA