### PR TITLE
wifi: nRF70 enable verbose logging

### DIFF
--- a/drivers/wifi/nrf700x/Kconfig
+++ b/drivers/wifi/nrf700x/Kconfig
@@ -78,6 +78,7 @@ config NET_MGMT_EVENT_STACK_SIZE
 
 config NRF700X_LOG_VERBOSE
 	bool "Maintains the verbosity of information in logs"
+	default y
 
 module = WIFI_NRF700X
 module-dep = LOG

--- a/drivers/wifi/nrf700x/osal/os_if/inc/osal_api.h
+++ b/drivers/wifi/nrf700x/osal/os_if/inc/osal_api.h
@@ -16,7 +16,7 @@
 #include "osal_structs.h"
 
 #ifndef CONFIG_NRF700X_LOG_VERBOSE
-#define __func__ ""
+#define __func__ "<snipped>"
 #endif /* CONFIG_NRF700X_LOG_VERBOSE */
 
 /**


### PR DESCRIPTION
Should be merged after https://github.com/nrfconnect/sdk-nrf/pull/12634 to avoid Matter failures as this increases memory.