### PR TITLE
compliance: extend image exclusions in the checker

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -42,5 +42,7 @@
 --exclude doc/nrf/images
 --exclude doc/nrf/.*/images
 --exclude doc/nrf/.*/.*/images
+--exclude doc/nrf/.*/.*/.*/images
+--exclude doc/nrf/.*/.*/.*/.*/images
 --exclude applications/nrf5340_audio/src/utils/macros
 --exclude lib/bin/lwm2m_carrier/include


### PR DESCRIPTION
The checker still checked images that were deeper
in the path. Extending the exclusion.

Ref: https://github.com/nrfconnect/sdk-nrf/pull/10772