### PR TITLE
doc: fast_pair: Align the doc due to Google Nearby Console redesign

### DIFF
--- a/applications/nrf_desktop/README.rst
+++ b/applications/nrf_desktop/README.rst
@@ -886,19 +886,23 @@ Selecting a build type from command line
 
    * NCS keyboard - The Fast Pair Provider meant to be used with keyboards:
 
-      * Device name: NCS keyboard
+      * Device Name: NCS keyboard
       * Model ID: ``0x52FF02``
-      * Anti-spoofing key (base64, uncompressed): ``8E8ulwhSIp/skZeg27xmWv2SxRxTOagypHrf2OdrhGY=``
-      * Type: Input device
-      * Additional features: Data only connection, Support personalized name, Ringing device unsupported
+      * Anti-Spoofing Private Key (base64, uncompressed): ``8E8ulwhSIp/skZeg27xmWv2SxRxTOagypHrf2OdrhGY=``
+      * Device Type: Input Device
+      * Notification Type: Fast Pair
+      * Data-Only connection: true
+      * No Personalized Name: false
 
    * NCS gaming mouse - Fast Pair Provider meant to be used with gaming mice:
 
-      * Device name: NCS gaming mouse
+      * Device Name: NCS gaming mouse
       * Model ID: ``0x8E717D``
-      * Anti-spoofing key (base64, uncompressed): ``dZxFzP7X9CcfLPC0apyRkmgsh3n2EbWo9NFNXfVuxAM=``
-      * Type: Input device
-      * Additional features: Data only connection, Support personalized name, Ringing device unsupported
+      * Anti-Spoofing Private Key (base64, uncompressed): ``dZxFzP7X9CcfLPC0apyRkmgsh3n2EbWo9NFNXfVuxAM=``
+      * Device Type: Input Device
+      * Notification Type: Fast Pair
+      * Data-Only connection: true
+      * No Personalized Name: false
 
    See :ref:`ug_bt_fast_pair_provisioning` documentation for the following information:
 

--- a/samples/bluetooth/peripheral_fast_pair/README.rst
+++ b/samples/bluetooth/peripheral_fast_pair/README.rst
@@ -64,11 +64,13 @@ By default, if Model ID and Anti-Spoofing Private Key are not specified, the fol
 
 * NCS Fast Pair demo - The input device Fast Pair provider:
 
-   * Device name: NCS Fast Pair demo
+   * Device Name: NCS Fast Pair demo
    * Model ID: ``0x2A410B``
-   * Anti-spoofing key (base64, uncompressed): ``Unoh+nycK/ZJ7k3dHsdcNpiP1SfOy0P/Lx5XixyYois=``
-   * Type: Input device
-   * Additional features: Data only connection, Support personalized name, Ringing device unsupported
+   * Anti-Spoofing Private Key (base64, uncompressed): ``Unoh+nycK/ZJ7k3dHsdcNpiP1SfOy0P/Lx5XixyYois=``
+   * Device Type: Input Device
+   * Notification Type: Fast Pair
+   * Data-Only connection: true
+   * No Personalized Name: false
 
 See :ref:`ug_bt_fast_pair_provisioning` in the Fast Pair user guide for details.
 


### PR DESCRIPTION
Aligns the Fast Pair documentation due to Google Nearby Console redesign.

Jira: NCSDK-22647