### PR TITLE
net: lib: download_client: Report correct connect() error

### DIFF
--- a/subsys/net/lib/download_client/src/download_client.c
+++ b/subsys/net/lib/download_client/src/download_client.c
@@ -414,10 +414,13 @@ static int client_connect(struct download_client *dl)
 		dl->fd, addrlen, str_family(dl->remote_addr.sa_family), port);
 
 	err = connect(dl->fd, &dl->remote_addr, addrlen);
+	if (err) {
+		LOG_ERR("Unable to connect, errno %d", errno);
+		err = -errno;
+	}
 
 cleanup:
 	if (err) {
-		LOG_ERR("Unable to connect, errno %d", -err);
 		error_evt_send(dl, -err);
 
 		/* Unable to connect, close socket */

--- a/subsys/net/lib/download_client/src/download_client.c
+++ b/subsys/net/lib/download_client/src/download_client.c
@@ -738,8 +738,8 @@ static int handle_disconnect(struct download_client *client)
 	if (client->fd != -1) {
 		err = close(client->fd);
 		if (err) {
-			err = errno;
-			LOG_ERR("Failed to close socket, errno %d", err);
+			LOG_ERR("Failed to close socket, errno %d", errno);
+			err = -errno;
 		}
 	}
 

--- a/tests/subsys/net/lib/download_client/src/mock/socket.c
+++ b/tests/subsys/net/lib/download_client/src/mock/socket.c
@@ -93,7 +93,7 @@ static int mock_socket_offload_connect(void *obj, const struct sockaddr *addr, s
 {
 	k_sleep(K_MSEC(50));
 	errno = ztest_get_return_value();
-	return -errno;
+	return errno ? -1 : 0;
 }
 
 static int mock_socket_offload_listen(void *obj, int backlog)


### PR DESCRIPTION
When connect() fails the return value is -1. Use errno to report error in error_evt_send().