### PR TITLE
manifest: update sdk-zephyr revision to have updated hal_nordic

### DIFF
--- a/doc/nrfx/nrfx.doxyfile.in
+++ b/doc/nrfx/nrfx.doxyfile.in
@@ -794,6 +794,7 @@ WARN_LOGFILE           =
 INPUT                  = @NRFX_BASE@/helpers \
                          @NRFX_BASE@/drivers \
                          @NRFX_BASE@/hal \
+                         @NRFX_BASE@/haly \
                          @NRFX_BASE@/soc \
                          @NRFX_BASE@/templates \
                          @NRFX_BASE@/CHANGELOG.md \

--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 49556cc0bdf2867ea58e854d1d97b4ba7f7fc0da
+      revision: 86c95f4906c4caf3a5ad117d13f127b1381c18e8
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Updated hal_nordic contains improved workaround
for nRF91 anomaly 7.