### PR TITLE
workflow: Increase the speed of compliance workflow by doing narrow west update

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -50,8 +50,7 @@ jobs:
         # debug
         git log  --pretty=oneline | head -n 10
         west init -l .
-        west update
-        west zephyr-export
+        west update --narrow -o=--depth=1
 
     - name: Run CODEOWNERS test
       id: codeowners


### PR DESCRIPTION
Change compliance workflow to do a narrow west update so that the
workflow runs faster.

It now takes roughly 1.5 to 2.5 minutes to complete instead of about 3.5 to 5.5 minutes