### PR TITLE
Bluetooth: mesh: Add model correspond relation

### DIFF
--- a/include/bluetooth/mesh/gen_loc_srv.h
+++ b/include/bluetooth/mesh/gen_loc_srv.h
@@ -47,10 +47,10 @@ struct bt_mesh_loc_srv;
 			 BT_MESH_MODEL_USER_DATA(struct bt_mesh_loc_srv,       \
 						 _srv),                        \
 			 &_bt_mesh_loc_srv_cb),                                \
-		BT_MESH_MODEL(BT_MESH_MODEL_ID_GEN_LOCATION_SETUPSRV,          \
-			      _bt_mesh_loc_setup_srv_op, NULL,                 \
-			      BT_MESH_MODEL_USER_DATA(struct bt_mesh_loc_srv,  \
-						      _srv))
+		BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_GEN_LOCATION_SETUPSRV,                           \
+				 _bt_mesh_loc_setup_srv_op, NULL,                                  \
+				 BT_MESH_MODEL_USER_DATA(struct bt_mesh_loc_srv, _srv),            \
+				 &_bt_mesh_loc_setup_srv_cb)
 
 /** Location Server handler functions. */
 struct bt_mesh_loc_srv_handlers {
@@ -198,6 +198,7 @@ int bt_mesh_loc_srv_local_pub(struct bt_mesh_loc_srv *srv,
 extern const struct bt_mesh_model_op _bt_mesh_loc_srv_op[];
 extern const struct bt_mesh_model_op _bt_mesh_loc_setup_srv_op[];
 extern const struct bt_mesh_model_cb _bt_mesh_loc_srv_cb;
+extern const struct bt_mesh_model_cb _bt_mesh_loc_setup_srv_cb;
 /** @endcond */
 
 #ifdef __cplusplus

--- a/include/bluetooth/mesh/light_temp_srv.h
+++ b/include/bluetooth/mesh/light_temp_srv.h
@@ -128,6 +128,10 @@ struct bt_mesh_light_temp_srv {
 	struct bt_mesh_lvl_srv lvl;
 	/** Model entry. */
 	struct bt_mesh_model *model;
+	/** Pointer to the corresponding CTL server, if it has one.
+	 *  Is set automatically by the CTL server.
+	 */
+	const struct bt_mesh_light_ctl_srv *ctl;
 	/** Publish parameters. */
 	struct bt_mesh_model_pub pub;
 	/** Transaction ID tracker for the set messages. */

--- a/subsys/bluetooth/mesh/gen_loc_srv.c
+++ b/subsys/bluetooth/mesh/gen_loc_srv.c
@@ -259,6 +259,24 @@ const struct bt_mesh_model_cb _bt_mesh_loc_srv_cb = {
 	.reset = bt_mesh_loc_srv_reset,
 };
 
+static int bt_mesh_loc_setup_srv_init(struct bt_mesh_model *model)
+{
+	struct bt_mesh_loc_srv *srv = model->user_data;
+#if defined(CONFIG_BT_MESH_COMP_PAGE_1)
+	int err = bt_mesh_model_correspond(model, srv->model);
+
+	if (err) {
+		return err;
+	}
+#endif
+
+	return bt_mesh_model_extend(model, srv->model);
+}
+
+const struct bt_mesh_model_cb _bt_mesh_loc_setup_srv_cb = {
+	.init = bt_mesh_loc_setup_srv_init,
+};
+
 int bt_mesh_loc_srv_global_pub(struct bt_mesh_loc_srv *srv,
 			       struct bt_mesh_msg_ctx *ctx,
 			       const struct bt_mesh_loc_global *global)

--- a/subsys/bluetooth/mesh/gen_plvl_srv.c
+++ b/subsys/bluetooth/mesh/gen_plvl_srv.c
@@ -783,6 +783,13 @@ static int bt_mesh_plvl_setup_srv_init(struct bt_mesh_model *model)
 		return err;
 	}
 
+#if defined(CONFIG_BT_MESH_COMP_PAGE_1)
+	err = bt_mesh_model_correspond(model, srv->plvl_model);
+	if (err) {
+		return err;
+	}
+#endif
+
 	return bt_mesh_model_extend(model, srv->plvl_model);
 }
 

--- a/subsys/bluetooth/mesh/gen_ponoff_srv.c
+++ b/subsys/bluetooth/mesh/gen_ponoff_srv.c
@@ -378,9 +378,15 @@ static int bt_mesh_ponoff_setup_srv_init(struct bt_mesh_model *model)
 		return err;
 	}
 
+#if defined(CONFIG_BT_MESH_COMP_PAGE_1)
+	err = bt_mesh_model_correspond(model, srv->ponoff_model);
+	if (err) {
+		return err;
+	}
+#endif
+
 	return bt_mesh_model_extend(model, srv->dtt.model);
 }
-
 
 const struct bt_mesh_model_cb _bt_mesh_ponoff_setup_srv_cb = {
 	.init = bt_mesh_ponoff_setup_srv_init,

--- a/subsys/bluetooth/mesh/light_ctl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctl_srv.c
@@ -407,6 +407,7 @@ static int bt_mesh_light_ctl_srv_init(struct bt_mesh_model *model)
 	struct bt_mesh_light_ctl_srv *srv = model->user_data;
 
 	srv->model = model;
+	srv->temp_srv.ctl = srv;
 	srv->pub.msg = &srv->pub_buf;
 	srv->pub.update = update_handler;
 	net_buf_simple_init_with_data(&srv->pub_buf, srv->pub_data,
@@ -477,6 +478,13 @@ static int bt_mesh_light_ctl_setup_srv_init(struct bt_mesh_model *model)
 	if (err) {
 		return err;
 	}
+
+#if defined(CONFIG_BT_MESH_COMP_PAGE_1)
+	err = bt_mesh_model_correspond(model, srv->model);
+	if (err) {
+		return err;
+	}
+#endif
 
 	return bt_mesh_model_extend(model, srv->lightness_srv.lightness_setup_model);
 }

--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -1726,6 +1726,13 @@ static int lc_setup_srv_init(struct bt_mesh_model *model)
 		return err;
 	}
 
+#if defined(CONFIG_BT_MESH_COMP_PAGE_1)
+	err = bt_mesh_model_correspond(srv->setup_srv, srv->model);
+	if (err) {
+		return err;
+	}
+#endif
+
 	srv->setup_pub.msg = &srv->setup_pub_buf;
 	net_buf_simple_init_with_data(&srv->setup_pub_buf, srv->setup_pub_data,
 				      sizeof(srv->setup_pub_data));

--- a/subsys/bluetooth/mesh/light_hsl_srv.c
+++ b/subsys/bluetooth/mesh/light_hsl_srv.c
@@ -583,6 +583,13 @@ static int bt_mesh_light_hsl_setup_srv_init(struct bt_mesh_model *model)
 		return err;
 	}
 
+#if defined(CONFIG_BT_MESH_COMP_PAGE_1)
+	err = bt_mesh_model_correspond(model, srv->model);
+	if (err) {
+		return err;
+	}
+#endif
+
 	lightness_setup_srv = bt_mesh_model_find(bt_mesh_model_elem(model),
 						 BT_MESH_MODEL_ID_LIGHT_LIGHTNESS_SETUP_SRV);
 

--- a/subsys/bluetooth/mesh/light_hue_srv.c
+++ b/subsys/bluetooth/mesh/light_hue_srv.c
@@ -448,6 +448,7 @@ static int hue_srv_pub_update(struct bt_mesh_model *model)
 static int hue_srv_init(struct bt_mesh_model *model)
 {
 	struct bt_mesh_light_hue_srv *srv = model->user_data;
+	int err;
 
 	srv->model = model;
 	srv->pub.update = hue_srv_pub_update;
@@ -459,14 +460,23 @@ static int hue_srv_init(struct bt_mesh_model *model)
 	srv->emds_entry.entry.id = EMDS_MODEL_ID(model);
 	srv->emds_entry.entry.data = (uint8_t *)&srv->transient;
 	srv->emds_entry.entry.len = sizeof(srv->transient);
-	int err = emds_entry_add(&srv->emds_entry);
+	err = emds_entry_add(&srv->emds_entry);
 
 	if (err) {
 		return err;
 	}
 #endif
 
-	return bt_mesh_model_extend(model, srv->lvl.model);
+#if defined(CONFIG_BT_MESH_COMP_PAGE_1)
+	err = bt_mesh_model_correspond(srv->hsl->model, model);
+
+	if (err) {
+		return err;
+	}
+#endif
+
+	err = bt_mesh_model_extend(model, srv->lvl.model);
+	return err;
 }
 
 static int hue_srv_settings_set(struct bt_mesh_model *model, const char *name,

--- a/subsys/bluetooth/mesh/light_sat_srv.c
+++ b/subsys/bluetooth/mesh/light_sat_srv.c
@@ -379,6 +379,7 @@ static int sat_srv_pub_update(struct bt_mesh_model *model)
 static int sat_srv_init(struct bt_mesh_model *model)
 {
 	struct bt_mesh_light_sat_srv *srv = model->user_data;
+	int err;
 
 	srv->model = model;
 	srv->pub.update = sat_srv_pub_update;
@@ -390,14 +391,23 @@ static int sat_srv_init(struct bt_mesh_model *model)
 	srv->emds_entry.entry.id = EMDS_MODEL_ID(model);
 	srv->emds_entry.entry.data = (uint8_t *)&srv->transient;
 	srv->emds_entry.entry.len = sizeof(srv->transient);
-	int err = emds_entry_add(&srv->emds_entry);
+	err = emds_entry_add(&srv->emds_entry);
 
 	if (err) {
 		return err;
 	}
 #endif
 
-	return bt_mesh_model_extend(model, srv->lvl.model);
+#if defined(CONFIG_BT_MESH_COMP_PAGE_1)
+	err = bt_mesh_model_correspond(srv->hsl->model, model);
+
+	if (err) {
+		return err;
+	}
+#endif
+
+	err = bt_mesh_model_extend(model, srv->lvl.model);
+	return err;
 }
 
 static int sat_srv_settings_set(struct bt_mesh_model *model, const char *name,

--- a/subsys/bluetooth/mesh/light_xyl_srv.c
+++ b/subsys/bluetooth/mesh/light_xyl_srv.c
@@ -645,6 +645,13 @@ static int bt_mesh_light_xyl_setup_srv_init(struct bt_mesh_model *model)
 		return err;
 	}
 
+#if defined(CONFIG_BT_MESH_COMP_PAGE_1)
+	err = bt_mesh_model_correspond(model, srv->model);
+	if (err) {
+		return err;
+	}
+#endif
+
 	lightness_setup_srv = bt_mesh_model_find(bt_mesh_model_elem(model),
 						 BT_MESH_MODEL_ID_LIGHT_LIGHTNESS_SETUP_SRV);
 

--- a/subsys/bluetooth/mesh/lightness_srv.c
+++ b/subsys/bluetooth/mesh/lightness_srv.c
@@ -978,6 +978,13 @@ static int bt_mesh_lightness_setup_srv_init(struct bt_mesh_model *model)
 		return err;
 	}
 
+#if defined(CONFIG_BT_MESH_COMP_PAGE_1)
+	err = bt_mesh_model_correspond(model, srv->lightness_model);
+	if (err) {
+		return err;
+	}
+#endif
+
 	return bt_mesh_model_extend(model, srv->ponoff.ponoff_setup_model);
 }
 

--- a/subsys/bluetooth/mesh/scene_srv.c
+++ b/subsys/bluetooth/mesh/scene_srv.c
@@ -843,6 +843,13 @@ static int scene_setup_srv_init(struct bt_mesh_model *model)
 		return err;
 	}
 
+#if defined(CONFIG_BT_MESH_COMP_PAGE_1)
+	err = bt_mesh_model_correspond(srv->setup_mod, srv->model);
+	if (err) {
+		return err;
+	}
+#endif
+
 	return bt_mesh_model_extend(srv->setup_mod, srv->model);
 }
 

--- a/subsys/bluetooth/mesh/scheduler_srv.c
+++ b/subsys/bluetooth/mesh/scheduler_srv.c
@@ -821,6 +821,13 @@ const struct bt_mesh_model_cb _bt_mesh_scheduler_srv_cb = {
 static int scheduler_setup_srv_init(struct bt_mesh_model *model)
 {
 	struct bt_mesh_scheduler_srv *srv = model->user_data;
+#if defined(CONFIG_BT_MESH_COMP_PAGE_1)
+	int err = bt_mesh_model_correspond(model, srv->model);
+
+	if (err) {
+		return err;
+	}
+#endif
 
 	return bt_mesh_model_extend(model, srv->model);
 }

--- a/subsys/bluetooth/mesh/sensor_srv.c
+++ b/subsys/bluetooth/mesh/sensor_srv.c
@@ -1124,6 +1124,13 @@ const struct bt_mesh_model_cb _bt_mesh_sensor_srv_cb = {
 static int sensor_setup_srv_init(struct bt_mesh_model *model)
 {
 	struct bt_mesh_sensor_srv *srv = model->user_data;
+#if defined(CONFIG_BT_MESH_COMP_PAGE_1)
+	int err = bt_mesh_model_correspond(model, srv->model);
+
+	if (err) {
+		return err;
+	}
+#endif
 
 	return bt_mesh_model_extend(model, srv->model);
 }

--- a/subsys/bluetooth/mesh/time_srv.c
+++ b/subsys/bluetooth/mesh/time_srv.c
@@ -470,6 +470,13 @@ const struct bt_mesh_model_cb _bt_mesh_time_srv_cb = {
 static int bt_mesh_time_setup_srv_init(struct bt_mesh_model *model)
 {
 	struct bt_mesh_time_srv *srv = model->user_data;
+#if defined(CONFIG_BT_MESH_COMP_PAGE_1)
+	int err = bt_mesh_model_correspond(model, srv->model);
+
+	if (err) {
+		return err;
+	}
+#endif
 
 	return bt_mesh_model_extend(model, srv->model);
 }


### PR DESCRIPTION
Adds correspond relationship to models as specified in MshMDL1.1. Requires the KCONFIG CONFIG_BT_MESH_COMP_PAGE_1
to register correspondence.

Adds an init callback for Generic Location Setup Server to register model extension and correspondence to Generic Location Server.

Adds a field to the 'bt_mesh_light_temp_srv' struct in 'light_temp_srv.h' which contains the address of the corresponding Light CTL server (used to register correspondence).

Signed-off-by: Håvard Reierstad <haavard.reierstad@nordicsemi.no>