### PR TITLE
applications: serial_lte_modem: fix FTP data reception

### DIFF
--- a/applications/serial_lte_modem/doc/FTP_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/FTP_AT_commands.rst
@@ -49,6 +49,12 @@ The ``<cmd>`` command is a string, and can be used as follows:
 The values of the parameters depend on the command string used.
 When using the ``put``, ``uput`` and ``mput`` commands, if the ``<data>`` attribute is not specified, SLM enters ``slm_data_mode``.
 
+.. note::
+   The maximum size of the data that can be received when using the commands ``ls`` and ``get`` is limited by the size of the internal FTP buffer, which is 2048 bytes.
+   The size can be adjusted by modifying the declaration of ``ftp_data_buf`` in :file:`src/ftp_c/slm_at_ftp.c`.
+
+   If more data than can be handled is received after issuing an ``ls`` or ``get`` command, the data will be truncated to the maximum supported size.
+
 Response syntax
 ~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Fix a too early return of ftp_client lib functions. They now return only when the data transfer is complete.

Additionally, feed the received data to UART in chunks to allow receiving data bigger than the size of the UART buffer (2048 bytes) *if* the size of the ring buffer (ftp_data_buf) is increased, because it is currently the limiting factor.

NCSDK-20213