### PR TITLE
nrf_security: cc3xx: Kconfig: Change dependencies for DRBG

### DIFF
--- a/subsys/nrf_security/src/drivers/Kconfig
+++ b/subsys/nrf_security/src/drivers/Kconfig
@@ -129,12 +129,14 @@ config PSA_USE_CC3XX_CTR_DRBG_DRIVER
 	default y
 	depends on PSA_USE_CTR_DRBG_DRIVER
 	depends on CRYPTOCELL_USABLE
+	depends on BUILD_WITH_TFM || NRF_CC3XX_PLATFORM
 
 config PSA_USE_CC3XX_HMAC_DRBG_DRIVER
 	bool
 	default y
 	depends on PSA_USE_HMAC_DRBG_DRIVER
 	depends on CRYPTOCELL_USABLE
+	depends on BUILD_WITH_TFM || NRF_CC3XX_PLATFORM
 
 endmenu
 


### PR DESCRIPTION
Change CC3XX DRBG dependencies from CRYPTOCELL_USABLE to NRF_CC3XX_PLATFORM.

NRF_CC3XX_PLATFORM is more restrictive than CRYPTOCELL_USABLE.

This prevents invalid configurations where the CC3XX platform is disabled while the CC3XX DRBG driver (which uses the platform) is enabled.