### PR TITLE
samples: peripheral: lpuart: Decrease current draw on nRF21540 DK 2.0.0

### DIFF
--- a/samples/peripheral/lpuart/boards/nrf21540dk_nrf52840.overlay
+++ b/samples/peripheral/lpuart/boards/nrf21540dk_nrf52840.overlay
@@ -13,6 +13,21 @@
 	};
 };
 
+&uart0_default {
+	/* Disconnect CTS and RTS lines from pins.
+	 * This is a temporary workaround for increased current consumption
+	 * observed on nRF21540 v2.0.0 only (~450 uA more than on v1.0.0).
+	 */
+	group1 {
+		psels = <NRF_PSEL(UART_TX, 0, 20)>,
+			<NRF_PSEL_DISCONNECTED(UART_RTS)>;
+	};
+	group2 {
+		psels = <NRF_PSEL(UART_RX, 0, 22)>,
+			<NRF_PSEL_DISCONNECTED(UART_CTS)>;
+	};
+};
+
 &uart0 {
 	disable-rx;
 };


### PR DESCRIPTION
Disconnect CTS and RTS lines from pins.
This is a temporary workaround for increased current consumption observed on nRF21540 v2.0.0 only (~450 uA more than on v1.0.0).

Ref: NCSDK-24113