### PR TITLE
doc: nrf: samples: include all readme files except for mesh folder

### DIFF
--- a/doc/nrf/samples/bl.rst
+++ b/doc/nrf/samples/bl.rst
@@ -8,5 +8,4 @@ Bluetooth samples
    :caption: Subpages
    :glob:
 
-   ../../../samples/bluetooth/*/README
-   ../../../samples/bluetooth/fast_pair/*/README
+   ../../../samples/bluetooth/**/[!mesh]*/*README


### PR DESCRIPTION
The new matching pattern includes all README files from Bluetooth folders and their subfolders, while excluding the README files inside the mesh folder, with just a single pattern.