### PR TITLE
samples: matter: Fix the Last Fabric Removal feature

### DIFF
--- a/applications/matter_bridge/src/app_task.h
+++ b/applications/matter_bridge/src/app_task.h
@@ -22,11 +22,9 @@
 #endif
 
 struct k_timer;
-class AppFabricTableDelegate;
 
 class AppTask {
 public:
-	friend class AppFabricTableDelegate;
 
 	static AppTask &Instance()
 	{

--- a/applications/matter_weather_station/src/app_task.h
+++ b/applications/matter_weather_station/src/app_task.h
@@ -27,11 +27,9 @@
 #endif
 
 struct k_timer;
-class AppFabricTableDelegate;
 
 class AppTask {
 public:
-	friend class AppFabricTableDelegate;
 
 	CHIP_ERROR StartApp();
 

--- a/doc/nrf/protocols/matter/end_product/last_fabric_removal_delegate.rst
+++ b/doc/nrf/protocols/matter/end_product/last_fabric_removal_delegate.rst
@@ -30,6 +30,21 @@ Predefined last fabric removal behaviors
 There are four predefined reactions to the last fabric removal available in the :ref:`matter_samples`.
 All behaviors are implemented as a delegation for the Fabric Table module, and the chosen reaction is run as a callback on each fabric removal.
 
+To enable the predefined behavior in your specific sample based on the :ref:`matter_samples` in the |NCS|, complete the following steps:
+
+1. Include the :file:`fabric_table_delegate.h` header file in the :file:`app_task.cpp` project file:
+
+   .. code-block:: c
+
+      #include "fabric_table_delegate.h"
+
+#. Call the ``AppFabricTableDelegate::Init`` method after the ``chip::Server::GetInstance().Init(initParams)`` invocation within the ``AppTask::Init`` method in the :file:`app_task.cpp` project file:
+
+    .. code-block:: c
+
+      AppFabricTableDelegate::Init();
+
+
 For more information, see the :file:`fabric_table_delegate.h` header file which is located in the Matter samples common directory.
 
 You can choose one of the following reactions to the last fabric removal and instruct the device to:
@@ -89,6 +104,7 @@ To implement the custom Fabric Table delegation, complete the following points:
 .. note::
    Not all actions implemented in the ``OnFabricRemoved`` can be called directly from the method body, and should be delegated to be done in Zephyr thread of Matter.
    This is because the device needs to confirm the removal of the fabric and send the acknowledgment to the Matter controller.
-   To delegate actions to the Zephyr thread of Matter, use the ``chip::DeviceLayer::PlatformMgr().ScheduleWork`` method.
+   To postpone running the chosen action, delegate its invocation to the Zephyr thread of Matter using the ``chip::DeviceLayer::PlatformMgr().ScheduleWork`` method.
+   If the device doesn't complete all activities that need to be done before clearing non-volatile storage, use a timer to delay the action execution.
 
 To see an example implementation of the Fabric Table delegation, see the :file:`fabric_table_delegate.h` file which is located in the Matter samples common directory.

--- a/doc/nrf/protocols/matter/getting_started/advanced_kconfigs.rst
+++ b/doc/nrf/protocols/matter/getting_started/advanced_kconfigs.rst
@@ -135,6 +135,9 @@ To enable one of the reactions to the last fabric removal, set the corresponding
   When the :kconfig:option:`CONFIG_CHIP_FACTORY_RESET_ERASE_NVS` Kconfig option is also set to ``y``, the device will also remove all non-volatile data stored on the device, including application-specific entries.
   This means the device is restored to the factory settings.
 
+To create a delay between  the chosen reaction and the last fabric being removed, set the :kconfig:option:`CONFIG_CHIP_LAST_FABRIC_REMOVED_ACTION_DELAY` Kconfig option to a specific time in milliseconds.
+By default this Kconfig option is set to 500 milliseconds.
+
 .. note::
   The :kconfig:option:`CONFIG_CHIP_FACTORY_RESET_ERASE_NVS` Kconfig option is set to ``y`` by default.
   To disable removing application-specific non-volatile data when the :kconfig:option:`CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_REBOOT` Kconfig option is selected, set the :kconfig:option:`CONFIG_CHIP_FACTORY_RESET_ERASE_NVS` Kconfig option to ``n``.

--- a/samples/matter/common/src/fabric_table_delegate.h
+++ b/samples/matter/common/src/fabric_table_delegate.h
@@ -6,61 +6,72 @@
 
 #pragma once
 
-#include "app_task.h"
-
 #include <app/server/Server.h>
 #include <app/util/attribute-storage.h>
+#include <lib/support/logging/CHIPLogging.h>
 
 #ifdef CONFIG_CHIP_WIFI
 #include <platform/nrfconnect/wifi/WiFiManager.h>
 #endif
 
-class AppFabricTableDelegate : public chip::FabricTable::Delegate
-{
+class AppFabricTableDelegate : public chip::FabricTable::Delegate {
 public:
-    ~AppFabricTableDelegate() { chip::Server::GetInstance().GetFabricTable().RemoveFabricDelegate(this); }
+	~AppFabricTableDelegate() { chip::Server::GetInstance().GetFabricTable().RemoveFabricDelegate(this); }
 
-    /**
-     * @brief Initialize module and add a delegation to the Fabric Table.
-     *
-     * To use the OnFabricRemoved method defined within this class and allow to react on the last fabric removal
-     * this method should be called in the application code.
-     */
-    static void Init()
-    {
+	/**
+	 * @brief Initialize module and add a delegation to the Fabric Table.
+	 *
+	 * To use the OnFabricRemoved method defined within this class and allow to react on the last fabric removal
+	 * this method should be called in the application code.
+	 */
+	static void Init()
+	{
 #ifndef CONFIG_CHIP_LAST_FABRIC_REMOVED_NONE
-        static AppFabricTableDelegate sAppFabricDelegate;
-        chip::Server::GetInstance().GetFabricTable().AddFabricDelegate(&sAppFabricDelegate);
+		static AppFabricTableDelegate sAppFabricDelegate;
+		chip::Server::GetInstance().GetFabricTable().AddFabricDelegate(&sAppFabricDelegate);
+		k_timer_init(&sFabricRemovedTimer, &OnFabricRemovedTimerCallback, nullptr);
 #endif // CONFIG_CHIP_LAST_FABRIC_REMOVED_NONE
-    }
+	}
 
 private:
-    void OnFabricRemoved(const chip::FabricTable & fabricTable, chip::FabricIndex fabricIndex)
-    {
+	void OnFabricRemoved(const chip::FabricTable &fabricTable, chip::FabricIndex fabricIndex)
+	{
+		k_timer_start(&sFabricRemovedTimer, K_MSEC(CONFIG_CHIP_LAST_FABRIC_REMOVED_ACTION_DELAY), K_NO_WAIT);
+	}
+
+	static void OnFabricRemovedTimerCallback(k_timer *timer)
+	{
 #ifndef CONFIG_CHIP_LAST_FABRIC_REMOVED_NONE
-        if (chip::Server::GetInstance().GetFabricTable().FabricCount() == 0)
-        {
+		if (chip::Server::GetInstance().GetFabricTable().FabricCount() == 0) {
+			chip::DeviceLayer::PlatformMgr().ScheduleWork([](intptr_t) {
 #ifdef CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_REBOOT
-            chip::Server::GetInstance().ScheduleFactoryReset();
-#elif defined(CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_ONLY) || defined(CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_PAIRING_START)
-            chip::DeviceLayer::PlatformMgr().ScheduleWork([](intptr_t) {
-                /* Erase Matter data */
-                chip::DeviceLayer::PersistedStorage::KeyValueStoreMgrImpl().DoFactoryReset();
-                /* Erase Network credentials and disconnect */
-                chip::DeviceLayer::ConnectivityMgr().ErasePersistentInfo();
+				chip::Server::GetInstance().ScheduleFactoryReset();
+#elif defined(CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_ONLY) ||                                                           \
+	defined(CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_PAIRING_START)
+				/* Erase Matter data */
+				chip::DeviceLayer::PersistedStorage::KeyValueStoreMgrImpl().DoFactoryReset();
+				/* Erase Network credentials and disconnect */
+				chip::DeviceLayer::ConnectivityMgr().ErasePersistentInfo();
 #ifdef CONFIG_CHIP_WIFI
-                chip::DeviceLayer::WiFiManager::Instance().Disconnect();
-                chip::DeviceLayer::ConnectivityMgr().ClearWiFiStationProvision();
+				chip::DeviceLayer::WiFiManager::Instance().Disconnect();
+				chip::DeviceLayer::ConnectivityMgr().ClearWiFiStationProvision();
 #endif
 #ifdef CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_PAIRING_START
-                /* Start the New BLE advertising */
-                AppEvent event;
-                event.Handler = AppTask::StartBLEAdvertisementHandler;
-                AppTask::Instance().PostEvent(event);
+				/* Start the New BLE advertising */
+				if (!chip::DeviceLayer::ConnectivityMgr().IsBLEAdvertisingEnabled()) {
+					if (CHIP_NO_ERROR == chip::Server::GetInstance()
+								     .GetCommissioningWindowManager()
+								     .OpenBasicCommissioningWindow()) {
+						return;
+					}
+				}
+				ChipLogError(FabricProvisioning, "Could not start Bluetooth LE advertising");
 #endif // CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_PAIRING_START
-            });
 #endif // CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_REBOOT
-        }
+			});
+		}
 #endif // CONFIG_CHIP_LAST_FABRIC_REMOVED_NONE
-    }
+	}
+
+	inline static k_timer sFabricRemovedTimer;
 };

--- a/samples/matter/light_bulb/src/app_task.h
+++ b/samples/matter/light_bulb/src/app_task.h
@@ -24,11 +24,9 @@
 
 struct k_timer;
 struct Identify;
-class AppFabricTableDelegate;
 
 class AppTask {
 public:
-	friend class AppFabricTableDelegate;
 
 	static AppTask &Instance()
 	{

--- a/samples/matter/light_switch/src/app_task.h
+++ b/samples/matter/light_switch/src/app_task.h
@@ -27,11 +27,9 @@
 
 struct k_timer;
 struct Identify;
-class AppFabricTableDelegate;
 
 class AppTask {
 public:
-	friend class AppFabricTableDelegate;
 
 	static AppTask &Instance()
 	{

--- a/samples/matter/lock/src/app_task.h
+++ b/samples/matter/lock/src/app_task.h
@@ -28,11 +28,9 @@
 
 struct k_timer;
 struct Identify;
-class AppFabricTableDelegate;
 
 class AppTask {
 public:
-	friend class AppFabricTableDelegate;
 
 	static AppTask &Instance()
 	{

--- a/samples/matter/template/src/app_task.h
+++ b/samples/matter/template/src/app_task.h
@@ -18,11 +18,9 @@
 #endif
 
 struct k_timer;
-class AppFabricTableDelegate;
 
 class AppTask {
 public:
-	friend class AppFabricTableDelegate;
 
 	static AppTask &Instance()
 	{

--- a/samples/matter/thermostat/src/app_task.h
+++ b/samples/matter/thermostat/src/app_task.h
@@ -25,12 +25,9 @@
 #endif
 
 struct k_timer;
-class AppFabricTableDelegate;
 
 class AppTask {
 public:
-	friend class AppFabricTableDelegate;
-
 	static AppTask &Instance()
 	{
 		static AppTask sAppTask;

--- a/samples/matter/window_covering/src/app_task.h
+++ b/samples/matter/window_covering/src/app_task.h
@@ -28,12 +28,9 @@
 
 struct k_timer;
 struct Identify;
-class AppFabricTableDelegate;
 
 class AppTask {
 public:
-	friend class AppFabricTableDelegate;
-
 	static AppTask &Instance()
 	{
 		static AppTask sAppTask;

--- a/west.yml
+++ b/west.yml
@@ -149,7 +149,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 90100b726206eefc173a5497e16b564c63b5fce6
+      revision: eb5e427fc22fd1247d00ee32499ce0581563f9d6
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
In tests, we noticed that the action on the last Matter fabric removal doesn't work stable. To fix it and improve stability we need to postpone the factory reset to allow the device to finish all needed operations.