### PR TITLE
CODEOWNERS: remove duplicate entry

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -138,6 +138,7 @@ Kconfig*                                  @tejlmand
 /modules/hostap/                          @krish2718 @jukkar @rado17 @sachinthegreen @rlubos
 /modules/mcuboot/                         @de-nordic @nordicjm
 /modules/cjson/                           @simensrostad @plskeggs @sigvartmh
+/modules/tfm/                             @frkv @Vge0rge @vili-nordic @joerchan @SebastianBoe @mswarowsky
 /samples/                                 @nrfconnect/ncs-test-leads
 /samples/net/mqtt/                        @simensrostad
 /samples/net/udp/                         @simensrostad
@@ -248,8 +249,6 @@ Kconfig*                                  @tejlmand
 /subsys/nonsecure/                        @frkv @Vge0rge @vili-nordic @joerchan @SebastianBoe @mswarowsky
 /subsys/nrf_security/                     @frkv @Vge0rge @vili-nordic @joerchan @SebastianBoe @mswarowsky
 /subsys/net_core_monitor/                 @maje-emb
-/modules/                                 @tejlmand
-/modules/tfm/                             @frkv @Vge0rge @vili-nordic @joerchan @SebastianBoe @mswarowsky
 /subsys/zigbee/                           @tomchy @sebastiandraus
 /tests/                                   @gopiotr
 /tests/bluetooth/tester/                  @carlescufi @ludvigsj


### PR DESCRIPTION
Remove duplicate entry of /modules/ that caused previous more specific entries to be overwritten. Also moved /modules/tfm/ next to the other /modules/ entries.