### PR TITLE
applications: nrf5340_audio: Fix coverity issues

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/bt_management/bt_mgmt.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/bt_mgmt.c
@@ -282,7 +282,7 @@ static int random_static_addr_cfg(void)
 
 static int local_identity_addr_print(void)
 {
-	size_t num_ids;
+	size_t num_ids = 0;
 	bt_addr_le_t addrs[CONFIG_BT_ID_MAX];
 	char addr_str[BT_ADDR_LE_STR_LEN];
 

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_client.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_client.c
@@ -25,7 +25,6 @@
 #include "macros_common.h"
 #include "nrf5340_audio_common.h"
 #include "le_audio.h"
-#include "channel_assignment.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(unicast_client, CONFIG_UNICAST_CLIENT_LOG_LEVEL);

--- a/applications/nrf5340_audio/src/modules/audio_usb.c
+++ b/applications/nrf5340_audio/src/modules/audio_usb.c
@@ -75,7 +75,7 @@ static void data_received(const struct device *dev, struct net_buf *buffer, size
 		return;
 	}
 
-	if (buffer == NULL || size == 0) {
+	if (buffer == NULL || size == 0 || buffer->data == NULL) {
 		/* This should never happen */
 		ERR_CHK(-EINVAL);
 	}


### PR DESCRIPTION
- Remove unused header include
- Check pointer for NULL reference
- Initialize variable before use
- Remove deprecated config
- Use uint16_t for sw_codec_lc3 size

 OCT-2670