### PR TITLE
manifest: Update sdk-zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 41e471d2b5746e49ca1dd6c1ba91a45c1f6d269b
+      revision: 281acd0dacaa20711d68cbdabae48ebf76264b87
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This brings in https://github.com/nrfconnect/sdk-zephyr/pull/1342.