### PR TITLE
tfm: Kconfig: Enable TF-M logging by default also with minimal conf

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -464,7 +464,10 @@ zcbor
 Trusted Firmware-M
 ==================
 
-|no_changes_yet_note|
+* The minimal TF-M build profile no longer silences TF-M logs by default.
+
+  .. note::
+     This can be a breaking change if the UART instance used by TF-M is already in use, for example by modem trace with a UART backend.
 
 cJSON
 =====

--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -82,7 +82,6 @@ choice TFM_PROFILE_TYPE
 config TFM_PROFILE_TYPE_MINIMAL
 	bool "Use minimal TF-M build"
 	select PSA_DEFAULT_OFF
-	imply TFM_LOG_LEVEL_SILENCE
 	help
 	  Use minimal TF-M build. This will make the TF-M image fit within 32kB.
 	  No configuration of the size of the partition nor the features of the


### PR DESCRIPTION
Stop enabling TFM_LOG_LEVEL_SILENCE from the TFM_PROFILE_TYPE_MINIMAL option.

Without logging it becomes more difficult to debug failures, both in the non-secure image (secure faults), and in TF-M.

I assume we disabled logging at some point due to the 32kB resource usage limit. But my testing shows that we have space for this now, presumably due to some optimization work that we have done.