### PR TITLE
applications: asset_tracker_v2: Remove typecast and use int16 function

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/lwm2m/lwm2m_codec_helpers.c
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/lwm2m/lwm2m_codec_helpers.c
@@ -685,8 +685,8 @@ int lwm2m_codec_helpers_set_modem_dynamic_data(struct cloud_data_modem_dynamic *
 		return err;
 	}
 
-	err = lwm2m_set_s8(&LWM2M_OBJ(LWM2M_OBJECT_CONNECTIVITY_MONITORING_ID, 0, RSS),
-			   (int8_t)modem_dynamic->rsrp);
+	err = lwm2m_set_s16(&LWM2M_OBJ(LWM2M_OBJECT_CONNECTIVITY_MONITORING_ID, 0, RSS),
+			    modem_dynamic->rsrp);
 	if (err) {
 		return err;
 	}

--- a/applications/asset_tracker_v2/tests/lwm2m_codec_helpers/src/lwm2m_codec_helpers_test.c
+++ b/applications/asset_tracker_v2/tests/lwm2m_codec_helpers/src/lwm2m_codec_helpers_test.c
@@ -560,7 +560,7 @@ void test_codec_helpers_set_modem_dynamic_data(void)
 	__cmock_lwm2m_set_res_buf_ExpectAnyArgsAndReturn(0);
 	__cmock_lwm2m_set_res_buf_ExpectAnyArgsAndReturn(0);
 
-	__cmock_lwm2m_set_s8_ExpectAndReturn(
+	__cmock_lwm2m_set_s16_ExpectAndReturn(
 		&LWM2M_OBJ(LWM2M_OBJECT_CONNECTIVITY_MONITORING_ID, 0, RSS),
 		modem_dynamic.rsrp, 0);
 


### PR DESCRIPTION
The storage type for RSRP in the connmon object is now int16_t so there is no need to cast to int8_t anymore.

Without this change, encoding fails due to size mismatch when updating the object.

Fixes NCSDK-24120