### PR TITLE
applications: nrf5340_audio: compaitability issue fix for Android14

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/Kconfig.defaults
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/Kconfig.defaults
@@ -80,11 +80,18 @@ config BT_DEVICE_APPEARANCE
 config BT_GAP_PERIPHERAL_PREF_PARAMS
 	default n
 
+config BT_GATT_AUTO_SEC_REQ
+	default n
+
 config BT_VCP_VOL_REND
 	default y
 
 config BT_MCC
 	default n if WALKIE_TALKIE_DEMO
+	default y
+
+config BT_PAC_SNK_NOTIFIABLE
+	# For fixing compatibility issue with Android 14
 	default y
 
 config BT_PACS_SNK_CONTEXT
@@ -108,6 +115,9 @@ config BT_AUDIO_TX
 
 config BT_AUDIO_RX
 	default y
+
+config BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE
+	default 25
 
 endif # AUDIO_DEV = 1 (HEADSET)
 


### PR DESCRIPTION
Fix the compaitability issues for Android14 by:
* Disable automatic security re-establishment request in peripheral.
* Enable sink PAC notification.
* Enlarge the codec config max metadata size. 

OCT-2755
Signed-off-by: Jui-Chou Chung <jui-chou.chung@nordicsemi.no>