### PR TITLE
net: lib: nrf_cloud: fix encoding of "doReply" flag

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -887,6 +887,7 @@ Libraries for networking
     * A bug preventing ``AIR_QUAL`` from being enabled in shadow UI service info.
     * A bug that prevented an MQTT FOTA job from being started.
     * An invalid value for a shadow delta change to the control section is now rejected by updating the desired section to the previous value.
+    * Encoding of the "doReply" flag in the :c:func:`nrf_cloud_obj_location_request_create` function.
 
   * Removed:
 

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec.c
@@ -923,15 +923,15 @@ int nrf_cloud_obj_location_request_create(struct nrf_cloud_obj *const obj,
 		goto cleanup;
 	}
 
-	/* By default, nRF Cloud will send the location to the device */
-	if (!request_loc &&
-	    nrf_cloud_obj_num_add(obj, NRF_CLOUD_LOCATION_KEY_DOREPLY, 0, true)) {
-		err = -ENOMEM;
+	err = nrf_cloud_obj_init(&data_obj);
+	if (err) {
 		goto cleanup;
 	}
 
-	err = nrf_cloud_obj_init(&data_obj);
-	if (err) {
+	/* By default, nRF Cloud will send the location to the device */
+	if (!request_loc &&
+	    nrf_cloud_obj_num_add(&data_obj, NRF_CLOUD_LOCATION_KEY_DOREPLY, 0, false)) {
+		err = -ENOMEM;
 		goto cleanup;
 	}
 


### PR DESCRIPTION
The "doReply" flag should be placed inside the "data" object, not at the root level.
IRIS-7363