### PR TITLE
Bluetooth: Mesh: Fix sysbuild build in DFU samples

### DIFF
--- a/samples/bluetooth/mesh/dfu/distributor/sysbuild.conf
+++ b/samples/bluetooth/mesh/dfu/distributor/sysbuild.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+SB_CONFIG_BOOTLOADER_MCUBOOT=y

--- a/samples/bluetooth/mesh/dfu/target/sysbuild.conf
+++ b/samples/bluetooth/mesh/dfu/target/sysbuild.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+SB_CONFIG_BOOTLOADER_MCUBOOT=y


### PR DESCRIPTION
enable MCUBOOT build in sysbuild to build DFU samples.