### PR TITLE
samples: net: https_client: disable auto connect for nRF9161DK

### DIFF
--- a/samples/net/https_client/boards/nrf9161dk_nrf9161_ns.conf
+++ b/samples/net/https_client/boards/nrf9161dk_nrf9161_ns.conf
@@ -19,6 +19,8 @@ CONFIG_NET_IPV6_MLD=n
 
 # Connection Manager and Connectivity layer
 CONFIG_LTE_CONNECTIVITY=y
+# Has to be disabled in order to write certificates
+CONFIG_LTE_CONNECTIVITY_AUTO_CONNECT=n
 CONFIG_NRF_MODEM_LIB_ON_FAULT_APPLICATION_SPECIFIC=y
 
 # Turn off automatic behavior to give more control to the application


### PR DESCRIPTION
The CONFIG_LTE_CONNECTIVITY_AUTO_CONNECT Kconfig has to be disabled for the nRF9161DK in order to write certificates.