### PR TITLE
manifest: update sdk-zephyr revision to have updated hal_nordic

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 281acd0dacaa20711d68cbdabae48ebf76264b87
+      revision: ed0fc63d8fb4eeb2094ae802259bc87e8a88f5d1
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Updated hal_nordic contains a fix to out-of-bounds array access in the nrfx_gpiote driver for nRF52820 device.