### PR TITLE
manifest: mcuboot: Boot even if EXT_ABI is not provided

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -128,7 +128,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: v1.10.99-ncs1-rc1
+      revision: b80046d57c768fd9297f7921b323396359c5c2ca
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR.git


### PR DESCRIPTION
Boot application even if EXT_ABI is not provided.

Ref. NCSDK-24132

There is another PR with mcuboot manifest update: https://github.com/nrfconnect/sdk-nrf/pull/12409.