### PR TITLE
ci: pip-requirements workflow fix mail

### DIFF
--- a/.github/workflows/pip-requirements.yml
+++ b/.github/workflows/pip-requirements.yml
@@ -73,5 +73,5 @@ jobs:
           diff_path: scripts
           diff_file: requirements-fixed.txt
           reaction_emote: "${{ env.REACT_EMOTE }}"
-          git_user_name: "NordicBuilder"
+          git_user_name: "Nordic Builder"
           git_user_email: "NordicBuilder@github.com"


### PR DESCRIPTION
* The git user name for the auto commit needs to be formated with 'firstname' 'lastname' for the compliance check


Currently the auto commit to pip requirements changes are failing at the compliance check.