### PR TITLE
samples: wifi: scan: Fix pin conflicts with Wi-Fi on nRF9160

### DIFF
--- a/samples/wifi/scan/boards/nrf9160dk_nrf9160_ns.overlay
+++ b/samples/wifi/scan/boards/nrf9160dk_nrf9160_ns.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Disabled because of conflicts on P0.00 and P0.01 - Arduino pins D0 and D1
+ * (iovdd-ctrl-gpios and bucken-gpios in nrf7002ek, respectively). */
+&uart1 {
+	status = "disabled";
+};


### PR DESCRIPTION
UART1 shares few pins with Wi-Fi GPIOs causing boot failure, this is already fixed in shell and location samples, but missed in scan sample.