### PR TITLE
caf/nrf_desktop: Improve DFU over SMP docs

### DIFF
--- a/applications/nrf_desktop/README.rst
+++ b/applications/nrf_desktop/README.rst
@@ -2041,25 +2041,25 @@ Image transfer over SMP
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 If the MCUboot bootloader is selected, the update image can also be transferred in the background either through the :ref:`nrf_desktop_ble_smp` or :ref:`nrf_desktop_dfu_mcumgr`.
-The `nRF Connect for Mobile`_ application uses binary files for the image transfer over the Simple Management Protocol (SMP).
-The :guilabel:`DFU` button appears in the tab of the connected Bluetooth device that supports the image transfer over the SMP.
-After pressing the button, you can select the :file:`*.bin` file used for the firmware update.
+The `nRF Connect Device Manager`_ application uses binary files for the image transfer over the Simple Management Protocol (SMP).
 
-After building your application for configuration with either the :ref:`nrf_desktop_ble_smp` or :ref:`nrf_desktop_dfu_mcumgr` enabled, the following firmware update files are generated in the build directory:
+After building your application with either :ref:`nrf_desktop_ble_smp` or :ref:`nrf_desktop_dfu_mcumgr` enabled, the :file:`dfu_application.zip` archive is generated in the build directory.
+It contains all the firmware update files that are necessary to perform DFU.
+For more information about the contents of update archive, see :ref:`app_build_fota`.
 
- * :file:`zephyr/app_update.bin` - The application image that is bootable from the primary slot.
- * :file:`zephyr/mcuboot_secondary_app_update.bin` - The application image that is bootable from the secondary slot.
-   The file is generated only if the MCUboot bootloader is built in the direct-xip mode.
+To perform DFU using the `nRF Connect Device Manager`_ mobile app, complete the following steps:
 
-If the MCUboot bootloader uses the built-in direct-xip mode, you must upload the image for the slot that is currently unused.
-If the MCUboot bootloader built-in swap mode is used, the :file:`zephyr/app_update.bin` file must always be used.
-The :file:`zephyr/app_update.bin` file is the application image that can be booted from the primary slot.
-In the swap mode, the MCUboot bootloader always moves the new application image to the primary slot before booting it.
+.. include:: /device_guides/working_with_nrf/nrf52/developing.rst
+   :start-after: fota_upgrades_over_ble_nrfcdm_common_dfu_steps_start
+   :end-before: fota_upgrades_over_ble_nrfcdm_common_dfu_steps_end
+
+.. include:: /device_guides/working_with_nrf/nrf52/developing.rst
+   :start-after: fota_upgrades_over_ble_mcuboot_direct_xip_nrfcdm_note_start
+   :end-before: fota_upgrades_over_ble_mcuboot_direct_xip_nrfcdm_note_end
 
 .. note::
   If the :kconfig:option:`CONFIG_MCUMGR_GRP_IMG_REJECT_DIRECT_XIP_MISMATCHED_SLOT` Kconfig option is enabled in the application configuration, the device rejects update image upload for the invalid slot.
   It is recommended to enable the option if the application uses MCUboot in the direct-xip mode.
-  The upload rejection can be used as a simple mechanism of verifying which image update should be used.
 
 Update image verification and application image update
 ------------------------------------------------------

--- a/applications/nrf_desktop/doc/dfu_mcumgr.rst
+++ b/applications/nrf_desktop/doc/dfu_mcumgr.rst
@@ -9,10 +9,8 @@ Device Firmware Upgrade MCUmgr module
 
 The Device Firmware Upgrade MCUmgr module is responsible for performing a Device Firmware Upgrade (DFU) over Simple Management Protocol (SMP).
 
-If you enable the Bluetooth LE as transport, you can perform the DFU using, for example, the `nRF Connect for Mobile`_ application.
-The :guilabel:`DFU` button appears in the tab of the connected Bluetooth device that supports the image transfer over the Simple Management Protocol (SMP).
-After pressing the button, you can select the :file:`*.bin` file used for the firmware update.
-See the :ref:`nrf_desktop_image_transfer_over_smp` section for information about which binary file should be used for the DFU image transfer.
+If you enable the Bluetooth LE as transport, you can perform DFU using, for example, the `nRF Connect Device Manager`_ application.
+See the :ref:`nrf_desktop_image_transfer_over_smp` section for more details.
 
 .. note::
     The Device Firmware Upgrade MCUmgr module implementation is currently marked as experimental because it uses internal MCUmgr API.

--- a/applications/nrf_desktop/doc/smp.rst
+++ b/applications/nrf_desktop/doc/smp.rst
@@ -25,4 +25,4 @@ Implementation details
 **********************
 
 nRF Desktop uses the |smp| from :ref:`lib_caf` (CAF).
-See the :ref:`CAF module <caf_ble_smp>` page for the implementation details and guide on how to perform the firmware update in the `nRF Connect for Mobile`_ application.
+See the :ref:`CAF module <caf_ble_smp>` page for the implementation details and guide on how to perform the firmware update in the `nRF Connect Device Manager`_ application.

--- a/doc/nrf/device_guides/working_with_nrf/nrf52/developing.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf52/developing.rst
@@ -125,11 +125,15 @@ See how to build the :ref:`peripheral_lbs` sample with MCUboot in direct-xip mod
 Both the :kconfig:option:`CONFIG_MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP` and :kconfig:option:`CONFIG_MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP_WITH_REVERT` Kconfig options automatically enable :kconfig:option:`CONFIG_BOOT_BUILD_DIRECT_XIP_VARIANT`, which allows to build application update images for both slots.
 To see which files are built when the option is enabled, go to the :ref:`app_build_mcuboot_output` page.
 
+.. fota_upgrades_over_ble_mcuboot_direct_xip_nrfcdm_note_start
+
 .. note::
    Support for FOTA updates with MCUboot in the direct-xip mode is available since the following versions of the `nRF Connect Device Manager`_ mobile app:
 
    * Version ``1.8.0`` on Android.
    * Version ``1.4.0`` on iOS.
+
+.. fota_upgrades_over_ble_mcuboot_direct_xip_nrfcdm_note_end
 
 .. fota_upgrades_over_ble_mcuboot_direct_xip_information_end
 
@@ -140,9 +144,14 @@ Testing steps
 
 To perform a FOTA update, complete the following steps:
 
-1. Create a binary file that contains the new image.
+.. fota_upgrades_over_ble_nrfcdm_common_dfu_steps_start
 
-   |fota_upgrades_building|
+1. Generate the DFU package by building your application with the FOTA support over Bluetooth Low Energy.
+   You can find the generated :file:`dfu_application.zip` archive in the following directory :file:`<build_dir>/zephyr`.
+
+   .. note::
+      For each image included in the DFU-generated package, use a higher version number than your currently active firmware.
+      Otherwise, the DFU target may reject the FOTA process due to a downgrade prevention mechanism.
 
 #. Download the :file:`dfu_application.zip` archive to your device.
    See :ref:`app_build_fota` for more information about the contents of update archive.
@@ -163,6 +172,8 @@ To perform a FOTA update, complete the following steps:
       * If you are using an iOS device, tap the selected mode in the pop-up window.
 
    #. Wait for the DFU to finish and then verify that the application works properly.
+
+.. fota_upgrades_over_ble_nrfcdm_common_dfu_steps_end
 
 FOTA update sample
 ==================

--- a/doc/nrf/libraries/caf/ble_smp.rst
+++ b/doc/nrf/libraries/caf/ble_smp.rst
@@ -47,22 +47,20 @@ After the previously submitted event is processed, the module submits a subseque
 The application user must not perform more than one firmware upgrade at a time.
 The modification of the data by multiple application modules can result in a broken image that is going to be rejected by the bootloader.
 
-You can perform the DFU using, for example, the `nRF Connect for Mobile`_ application.
-The :guilabel:`DFU` button appears in the tab of the connected Bluetooth device that supports the image transfer over the Simple Management Protocol (SMP).
-After pressing the button, you can select the :file:`*.bin` file used for the firmware update.
+After building your application with the |smp| enabled, the :file:`dfu_application.zip` archive is generated in the build directory.
+It contains all the firmware update files that are necessary to perform DFU.
+For more information about the contents of update archive, see :ref:`app_build_fota`.
 
-After building your application for configuration with the |smp| enabled, the following firmware update files are generated in the build directory:
+To perform DFU using the `nRF Connect Device Manager`_ mobile app, complete the following steps:
 
- * :file:`zephyr/app_update.bin` - The application image that is bootable from the primary slot.
- * :file:`zephyr/mcuboot_secondary_app_update.bin` - The application image that is bootable from the secondary slot.
-   The file is generated only if the MCUboot bootloader is built in the direct-xip mode.
+.. include:: /device_guides/working_with_nrf/nrf52/developing.rst
+   :start-after: fota_upgrades_over_ble_nrfcdm_common_dfu_steps_start
+   :end-before: fota_upgrades_over_ble_nrfcdm_common_dfu_steps_end
 
-If the MCUboot bootloader is built in the direct-xip mode, you must upload the image to the slot that is currently unused.
-If the MCUboot bootloader is built in the swap mode instead, you must use the :file:`zephyr/app_update.bin` file.
-In the swap mode, the MCUboot bootloader always moves the new application image to the primary slot before booting it.
-For more information about the MCUboot configuration, see the :ref:`MCUboot <mcuboot:mcuboot_wrapper>` documentation.
+.. include:: /device_guides/working_with_nrf/nrf52/developing.rst
+   :start-after: fota_upgrades_over_ble_mcuboot_direct_xip_nrfcdm_note_start
+   :end-before: fota_upgrades_over_ble_mcuboot_direct_xip_nrfcdm_note_end
 
 .. note::
   If the :kconfig:option:`CONFIG_MCUMGR_GRP_IMG_REJECT_DIRECT_XIP_MISMATCHED_SLOT` Kconfig option is enabled in the application configuration, the device rejects an update image upload for the invalid slot.
   It is recommended to enable the option if the application uses MCUboot in the direct-xip mode.
-  The upload rejection can be used as a simple mechanism of verifying which image update should be used.


### PR DESCRIPTION
Switch from nRF Connect for Mobile to nRF Connect Device Manager
as the app for DFU purposes.
Switch from using *.bin files to dfu_application.zip and let
the mobile app handle the details.

Jira: NCSDK-24144
