### PR TITLE
CODEOWNERS: Add Aegir team to ncs/nrf/modules/trusted-firwmare-m

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -139,6 +139,7 @@ Kconfig*                                  @tejlmand
 /modules/mcuboot/                         @de-nordic @nordicjm
 /modules/cjson/                           @simensrostad @plskeggs @sigvartmh
 /modules/tfm/                             @frkv @Vge0rge @vili-nordic @joerchan @SebastianBoe @mswarowsky
+/modules/trusted-firmware-m/              @frkv @Vge0rge @vili-nordic @joerchan @SebastianBoe @mswarowsky
 /samples/                                 @nrfconnect/ncs-test-leads
 /samples/net/mqtt/                        @simensrostad
 /samples/net/udp/                         @simensrostad


### PR DESCRIPTION
Add Aegir team to ncs/nrf/modules/trusted-firwmare-m as they own this code.