### PR TITLE
nrf_security: Always enabled MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER

### DIFF
--- a/subsys/nrf_security/CMakeLists.txt
+++ b/subsys/nrf_security/CMakeLists.txt
@@ -19,12 +19,6 @@ set(mbedtls_target    mbedtls)
 # Populate ARM_MBEDTLS_PATH with the value of ZEPHYR_MBEDTLS_MODULE_DIR
 set(ARM_MBEDTLS_PATH ${ZEPHYR_MBEDTLS_MODULE_DIR})
 
-# MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER must be disabled for Zephyr
-# builds or when MBEDTLS_USE_PSA_CRYPTO is enabled (e.g. for TLS/DTLS
-# and x.509 support) Note: This configuration is internal and may be
-# removed with a new mbed TLS version
-set(CONFIG_MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER     False)
-
 if(CONFIG_BUILD_WITH_TFM)
   # TF-M is enabled and we are not inside the TF-M build system.
   # Thus, do not build regular `mbedcrypto` library, instead export

--- a/subsys/nrf_security/Kconfig.psa
+++ b/subsys/nrf_security/Kconfig.psa
@@ -16,6 +16,7 @@ if MBEDTLS_PSA_CRYPTO_C
 
 config MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER
 	bool
+	default y
 
 osource "modules/mbedtls/Kconfig.psa"
 


### PR DESCRIPTION
The cryptocell binaries are build with this option enabled.  As this option changes the size of psa_core_key_attributes_t  it also should also be enabled when the core is build, else the some of the struct members will be misaligned.

Ref: NCSDK-23764