### PR TITLE
samples: matter: Disabled Wi-Fi low power mode in Matter samples

### DIFF
--- a/samples/matter/light_switch/Kconfig
+++ b/samples/matter/light_switch/Kconfig
@@ -34,13 +34,6 @@ config OPENTHREAD_DEFAULT_TX_POWER
 
 endif # NET_L2_OPENTHREAD
 
-if CHIP_WIFI
-
-config NRF_WIFI_LOW_POWER
-	default y
-
-endif # CHIP_WIFI
-
 config CHIP_ICD_SUBSCRIPTION_HANDLING
 	default y
 

--- a/samples/matter/lock/Kconfig
+++ b/samples/matter/lock/Kconfig
@@ -92,13 +92,6 @@ config OPENTHREAD_DEFAULT_TX_POWER
 
 endif # NET_L2_OPENTHREAD
 
-if CHIP_WIFI
-
-config NRF_WIFI_LOW_POWER
-	default y
-
-endif # CHIP_WIFI
-
 config CHIP_ICD_SUBSCRIPTION_HANDLING
 	default y
 


### PR DESCRIPTION
Disabled Wi-Fi LPM due to instabilities observed in automated tests.