### PR TITLE
doc improvement: samples: add peripheral and keys groups

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -1185,6 +1185,7 @@ Documentation
 
 * Updated:
 
+  * :ref:`samples` with separate sections for :ref:`keys_samples` and :ref:`peripheral_samples`, which were previously listed in :ref:`other_samples`.
   * The :ref:`emds_readme` library documentation with :ref:`emds_readme_application_integration` section about the formula used to compute the required storage time at shutdown in a worst case scenario.
   * The structure of the :ref:`nrf_modem_lib_readme` documentation.
   * The structure of the |NCS| documentation at its top level, with the following major changes:

--- a/doc/nrf/samples.rst
+++ b/doc/nrf/samples.rst
@@ -33,11 +33,13 @@ General information about samples in the |NCS|
    samples/edge
    samples/esb
    samples/gazell
+   samples/keys
    samples/matter
    samples/multicore
    samples/net
    samples/nfc
    samples/nrf5340
+   samples/peripheral
    samples/pmic
    samples/sensor
    samples/tfm

--- a/doc/nrf/samples/keys.rst
+++ b/doc/nrf/samples/keys.rst
@@ -1,0 +1,11 @@
+.. _keys_samples:
+
+Keys samples
+############
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Subpages
+   :glob:
+
+   ../../../samples/keys/*/README

--- a/doc/nrf/samples/other.rst
+++ b/doc/nrf/samples/other.rst
@@ -10,7 +10,4 @@ Other samples
 
    ../../../samples/*/README
    ../../../samples/ipc/*/README
-   ../../../samples/keys/*/README
    ../../../samples/mpsl/*/README
-   ../../../samples/peripheral/*/README
-   ../../../samples/sensor/*/README

--- a/doc/nrf/samples/peripheral.rst
+++ b/doc/nrf/samples/peripheral.rst
@@ -1,0 +1,11 @@
+.. _peripheral_samples:
+
+Peripheral samples
+##################
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Subpages
+   :glob:
+
+   ../../../samples/peripheral/*/README


### PR DESCRIPTION
Added separate sections for peripheral and keys samples under Samples. Removed duplicated entry for sensor samples introduced with #11103.