### PR TITLE
samples: cellular: nrf_cloud_multi_service: heap size related config updates

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -447,6 +447,7 @@ Cellular samples (renamed from nRF9160 samples)
     * The sample to remove redundant shadow updates for nRF Cloud.
     * Build instructions, board files, and DTC overlay file so that Wi-Fi scanning works for the nRF9161 DK and the nRF9160 DK.
     * Configuration to enable power saving mode by default.
+    * Reduced the default value of :kconfig:option:`CONFIG_MAX_OUTGOING_MESSAGES` to prevent potential heap issues.
 
   * Fixed:
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -452,6 +452,7 @@ Cellular samples (renamed from nRF9160 samples)
   * Fixed:
 
     * Legitimate server side CoAP API errors are not counted now as a reason to disconnect from and reconnect to the cloud, but only communications errors.
+    * Increased the value of :kconfig:option:`CONFIG_HEAP_MEM_POOL_SIZE` in the full modem FOTA overlay to prevent a boot loop on full modem image installation.
 
   * Removed the Kconfig options :kconfig:option:`CONFIG_LTE_INIT_RETRY_TIMEOUT_SECONDS` and :kconfig:option:`CLOUD_CONNECTION_REESTABLISH_DELAY_SECONDS` as they are no longer needed.
 

--- a/samples/cellular/nrf_cloud_multi_service/Kconfig
+++ b/samples/cellular/nrf_cloud_multi_service/Kconfig
@@ -60,10 +60,11 @@ config LED_THREAD_STACK_SIZE
 
 config MAX_OUTGOING_MESSAGES
 	int "Outgoing message maximum"
-	default 64
+	default 50
 	help
 	  Sets the maximum number of device messages which may be enqueued
 	  before further messages are dropped.
+	  Increasing this value may require an increase to CONFIG_HEAP_MEM_POOL_SIZE.
 
 config MAX_CONSECUTIVE_SEND_FAILURES
 	int "Max outgoing consecutive send failures"

--- a/samples/cellular/nrf_cloud_multi_service/overlay_full_modem_fota.conf
+++ b/samples/cellular/nrf_cloud_multi_service/overlay_full_modem_fota.conf
@@ -14,3 +14,6 @@ CONFIG_DFU_TARGET_FULL_MODEM_USE_EXT_PARTITION=y
 CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y
 CONFIG_PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY=n
 CONFIG_PM_SINGLE_IMAGE=y
+# FMFU requires additional heap space.
+# If the heap is too small, a boot loop can occur when the full modem image is installed.
+CONFIG_HEAP_MEM_POOL_SIZE=47250

--- a/samples/cellular/nrf_cloud_multi_service/src/message_queue.c
+++ b/samples/cellular/nrf_cloud_multi_service/src/message_queue.c
@@ -49,6 +49,14 @@ static int enqueue_device_message(struct nrf_cloud_obj *const msg_obj, const boo
 	}
 
 	struct nrf_cloud_obj *q_msg = msg_obj;
+	uint32_t msgs_in_q = k_msgq_num_used_get(&device_message_queue);
+
+	LOG_DBG("Messages queue status: %u/%u", msgs_in_q, CONFIG_MAX_OUTGOING_MESSAGES);
+
+	if (msgs_in_q == CONFIG_MAX_OUTGOING_MESSAGES) {
+		LOG_WRN("Message queue is full");
+		return -ENOSPC;
+	}
 
 	if (create_copy) {
 		/* Allocate a new nrf_cloud_obj structure for the message queue.
@@ -115,6 +123,7 @@ static int consume_device_message(void)
 	 * message sending.
 	 */
 	LOG_DBG("Attempting to transmit enqueued device message");
+	LOG_DBG("Messages remaining in queue: %u", k_msgq_num_used_get(&device_message_queue));
 
 #if defined(CONFIG_NRF_CLOUD_MQTT)
 	struct nrf_cloud_tx_data mqtt_msg = {


### PR DESCRIPTION
Reduce the message queue size to prevent potential heap issues.
IRIS-7393

Increased the value CONFIG_HEAP_MEM_POOL_SIZE in the full modem
FOTA overlay to prevent a boot loop on full modem image installation.
IRIS-7377