### PR TITLE
Bluetooth: Mesh: Process Occupancy when OCC Mode is off

### DIFF
--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -667,6 +667,11 @@ static void delayed_action_timeout(struct k_work *work)
 		turn_off(srv, &transition, true);
 	} else if (atomic_test_and_clear_bit(&srv->flags, FLAG_OCC_PENDING) &&
 		   (srv->state == LIGHT_CTRL_STATE_ON ||
+		    srv->state == LIGHT_CTRL_STATE_PROLONG ||
+		    (/* Fade Standby Auto */
+		     srv->state == LIGHT_CTRL_STATE_STANDBY &&
+		     !atomic_test_bit(&srv->flags, FLAG_ON) &&
+		     atomic_test_bit(&srv->flags, FLAG_TRANSITION)) ||
 		    atomic_test_bit(&srv->flags, FLAG_OCC_MODE))) {
 		turn_on(srv, NULL, true);
 	}


### PR DESCRIPTION
Fixes a bug that got introduced in PR #12651 due to different handling of occupancy messages. Previously the 'delayed_action_timeout()' function was not processing occupancy when Occupancy Mode was off.

Now the function would, additionally, process the occupancy event in FADE, PROLONG, and FADE STANDBY AUTO.

Local checks:

PTS tests pass:
```
 1/16   MMDL      MMDL/SR/LLC/BV-01-C    ←[32mPASS           89.018                  ←[0m
 2/16   MMDL      MMDL/SR/LLC/BV-02-C    ←[32mPASS           95.787                  ←[0m
 3/16   MMDL      MMDL/SR/LLC/BV-03-C    ←[32mPASS           94.119                  ←[0m
 4/16   MMDL      MMDL/SR/LLC/BV-04-C    ←[32mPASS           175.578                  ←[0m
 5/16   MMDL      MMDL/SR/LLC/BV-05-C    ←[32mPASS           75.379                  ←[0m
 6/16   MMDL      MMDL/SR/LLC/BV-06-C    ←[32mPASS           83.075                  ←[0m
 7/16   MMDL      MMDL/SR/LLC/BV-07-C    ←[32mPASS           82.836                  ←[0m
 8/16   MMDL      MMDL/SR/LLC/BV-08-C    ←[32mPASS           89.547                  ←[0m
 9/16   MMDL      MMDL/SR/LLC/BV-09-C    ←[32mPASS           79.592                  ←[0m
10/16   MMDL      MMDL/SR/LLC/BV-10-C    ←[32mPASS           119.392                  ←[0m
11/16   MMDL      MMDL/SR/LLC/BV-11-C    ←[32mPASS           348.027                  ←[0m
12/16   MMDL      MMDL/SR/LLC/BV-12-C    ←[32mPASS           248.553                  ←[0m
13/16   MMDL      MMDL/SR/LLC/BV-13-C    ←[32mPASS           130.979                  ←[0m
14/16   MMDL      MMDL/SR/LLCS/BV-01-C   ←[32mPASS           122.607                  ←[0m
15/16   MMDL      MMDL/SR/LLCS/BV-02-C   ←[32mPASS           93.354                  ←[0m
16/16   MMDL      MMDL/SR/LLCS/BI-01-C   ←[32mPASS           102.45                  ←[0m
```

System tests pass:
```
----------------------------------------------------------------------
Ran 15 tests in 505.370s
 
OK
```