### PR TITLE
samples: cellular: multi service: Revert Wi-Fi overlay to NEWLIB_LIBC

### DIFF
--- a/samples/cellular/nrf_cloud_multi_service/overlay_nrf7002ek_wifi_no_lte.conf
+++ b/samples/cellular/nrf_cloud_multi_service/overlay_nrf7002ek_wifi_no_lte.conf
@@ -125,3 +125,8 @@ CONFIG_NET_SOCKETS_POLL_MAX=8
 # this could be set as low as 130000. Add 256 bytes for each additional scanning result, assuming
 # sane SSID lengths. We set the heap much higher in case of long SSIDs.
 CONFIG_HEAP_MEM_POOL_SIZE=130000
+
+# Disable PICOLIBC since hostap currently is not compatible with it
+CONFIG_NEWLIB_LIBC=y
+CONFIG_NEWLIB_LIBC_FLOAT_PRINTF=y
+CONFIG_PICOLIBC=n


### PR DESCRIPTION
Revert Wi-Fi overlay to using NEWLIB_LIBC, since hostap currently is not compatible with PICOLIB_C

IRIS-7397