### PR TITLE
doc: samples: Zephyr examples testing note

### DIFF
--- a/doc/nrf/samples.rst
+++ b/doc/nrf/samples.rst
@@ -7,10 +7,9 @@ The |NCS| provides samples that specifically target Nordic Semiconductor devices
 
 Samples showcase a single feature or library, while :ref:`applications` include a variety of libraries to implement a specific use case.
 
-Zephyr also provides a variety of application samples and demos.
-Documentation for those is available in Zephyr's :ref:`zephyr:samples-and-demos` section.
-For very simple samples, see the :ref:`zephyr:basic-sample`.
-Those samples are a good starting point for understanding how to put together your own application.
+Zephyr also provides a variety of :ref:`zephyr:samples-and-demos`, including very simple :ref:`zephyr:basic-sample`.
+These samples are a good starting point for understanding how to put together your own application.
+However, Zephyr samples and applications are not tested and verified to work with the |NCS| releases.
 
 General information about samples in the |NCS|
    * |ncs_unchanged_samples_note|
@@ -18,6 +17,7 @@ General information about samples in the |NCS|
    * All samples in the |NCS| use :ref:`lib_fatal_error` library and are configured to perform a system reset if a fatal error occurs.
      This behavior is different from how fatal errors are handled in the Zephyr samples.
      You can change the default behavior by updating the configuration option :kconfig:option:`CONFIG_RESET_ON_FATAL_ERROR`.
+   * All samples in the |NCS| are tested and verified in accordance with their :ref:`maturity level <software_maturity>`.
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Added a note requested by PMT that states that the Zephyr examples are not tested by Nordic Semiconductor to work with the NCS releases. NCSDK-23685.