### PR TITLE
matter: fix Wi-Fi TX tokens configuration

### DIFF
--- a/doc/nrf/protocols/matter/getting_started/advanced_kconfigs.rst
+++ b/doc/nrf/protocols/matter/getting_started/advanced_kconfigs.rst
@@ -136,7 +136,7 @@ To enable one of the reactions to the last fabric removal, set the corresponding
   This means the device is restored to the factory settings.
 
 To create a delay between  the chosen reaction and the last fabric being removed, set the :kconfig:option:`CONFIG_CHIP_LAST_FABRIC_REMOVED_ACTION_DELAY` Kconfig option to a specific time in milliseconds.
-By default this Kconfig option is set to 500 milliseconds.
+By default this Kconfig option is set to 1 second.
 
 .. note::
   The :kconfig:option:`CONFIG_CHIP_FACTORY_RESET_ERASE_NVS` Kconfig option is set to ``y`` by default.

--- a/west.yml
+++ b/west.yml
@@ -149,7 +149,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 1d4ecfee38850ff9c40c1a7144519c32a72aaa3a
+      revision: fd9be717210fa386277f1fdd19115c1ed48ccad0
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
This commit brings changes in sdk-connectedhomeip that fixes the incorrect value of Wi-Fi TX tokens, as well as increases the delay before factory reset is done.

It depends on the #12802 which fixes more generic issues.