### PR TITLE
net: openthread: remove deprecated config config `IEEE802154_2015`

### DIFF
--- a/subsys/net/openthread/Kconfig.defconfig
+++ b/subsys/net/openthread/Kconfig.defconfig
@@ -168,10 +168,6 @@ config NRF_802154_ENCRYPTION
 	bool
 	default y
 
-config IEEE802154_2015
-	bool
-	default y
-
 config NET_PKT_TXTIME
 	bool
 	default y


### PR DESCRIPTION
Removing deprecated config `IEEE802154_2015`.