### PR TITLE
applications: asset_tracker_v2: Cancelling previous location request

### DIFF
--- a/applications/asset_tracker_v2/src/modules/location_module.c
+++ b/applications/asset_tracker_v2/src/modules/location_module.c
@@ -30,14 +30,6 @@ BUILD_ASSERT(CONFIG_AT_MONITOR_HEAP_SIZE >= 1024,
 	    "CONFIG_AT_MONITOR_HEAP_SIZE must be >= 1024 to fit neighbor cell measurements "
 	    "and other notifications at the same time");
 
-/* Use a timeout of 90 seconds for GNSS search. */
-#define DATA_FETCH_TIMEOUT_GNSS_SEARCH 90
-
-/* Use a timeout of 11 seconds to accommodate for neighbour cell measurements
- * that can take up to 10.24 seconds.
- */
-#define DATA_FETCH_TIMEOUT_NEIGHBORHOOD_SEARCH 11
-
 struct location_msg_data {
 	union {
 		struct app_module_event app;
@@ -79,6 +71,13 @@ static struct module_stats {
 	/* Number of satellites tracked at the time of a GNSS fix or a timeout. */
 	uint8_t satellites_tracked;
 } stats;
+
+/* Indicates whether cloud location request is pending towards cloud service, that is,
+ * LOCATION_EVT_CLOUD_LOCATION_EXT_REQUEST has been received but not responded yet.
+ * This is specifically needed when cloud connection doesn't exist and there is a
+ * new sampling request. We can then cancel previous location request and do a new one.
+ */
+static bool cloud_location_request_pending;
 
 static struct module_data self = {
 	.name = "location",
@@ -296,6 +295,7 @@ static void search_start(void)
 
 static void inactive_send(void)
 {
+	cloud_location_request_pending = false;
 	SEND_EVENT(location, LOCATION_MODULE_EVT_INACTIVE);
 }
 
@@ -501,6 +501,7 @@ void location_event_handler(const struct location_event_data *event_data)
 	case LOCATION_EVT_CLOUD_LOCATION_EXT_REQUEST:
 		LOG_DBG("Getting cloud location request");
 		send_cloud_location_update(&event_data->cloud_location_request);
+		cloud_location_request_pending = true;
 		break;
 #endif
 
@@ -574,6 +575,16 @@ static void on_state_running_location_search(struct location_msg_data *msg)
 
 	if (IS_EVENT(msg, app, APP_EVT_DATA_GET)) {
 		if (!location_data_requested(msg->module.app.data_list, msg->module.app.count)) {
+			return;
+		}
+
+		/* If cloud location request is pending data and cloud modules,
+		 * we'll cancel current location request and start a new one
+		 */
+		if (cloud_location_request_pending) {
+			location_request_cancel();
+			cloud_location_request_pending = false;
+			search_start();
 			return;
 		}
 


### PR DESCRIPTION
When there is no cloud connection, the data won’t be sent to cloud but ATv2 is waiting for the cloud response. This causes location library to wait for the feedback too and hence further location requests are blocked until this ongoing request times out (5mins by default). The issue occurs after cloud wrapper is able to respond differently (success, fail, unknown) to LOCATION_EVT_CLOUD_LOCATION_EXT_REQUEST:
PR https://github.com/nrfconnect/sdk-nrf/pull/12116

This change checks if there is a cloud request pending when new sampling starts and cancels previous location request.

Jira: NCSDK-24105