### PR TITLE
modules: memfault: Enable user-provided heartbeat collect

### DIFF
--- a/include/memfault_ncs.h
+++ b/include/memfault_ncs.h
@@ -36,6 +36,14 @@ extern "C" {
  */
 int memfault_ncs_device_id_set(const char *device_id, size_t len);
 
+/** @brief Trigger NCS metrics collection. Called by default from NCS
+ *	   memfault_metrics_heartbeat_collect_data(), but can instead be called
+ *	   from user's implementation of
+ *	   memfault_metrics_heartbeat_collect_data(), see
+ *	   CONFIG_MEMFAULT_NCS_IMPLEMENT_METRICS_COLLECTION Kconfig option.
+ */
+void memfault_ncs_metrics_collect_data(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/modules/memfault-firmware-sdk/Kconfig
+++ b/modules/memfault-firmware-sdk/Kconfig
@@ -169,6 +169,14 @@ config MEMFAULT_NCS_USE_DEFAULT_METRICS
 	select MEMFAULT_METRICS_EXTRA_DEFS_FILE
 	default y if (MEMFAULT_NCS_STACK_METRICS || MEMFAULT_NCS_LTE_METRICS || MEMFAULT_NCS_BT_METRICS)
 
+config MEMFAULT_NCS_IMPLEMENT_METRICS_COLLECTION
+	bool "Implement metrics collection"
+	depends on MEMFAULT_NCS_USE_DEFAULT_METRICS
+	default y
+	help
+	  Implement the Memfault 'memfault_metrics_heartbeat_collect_data()' function
+	  for the selected metrics. Disable this to override the implementation.
+
 config MEMFAULT_NCS_ETB_CAPTURE
 	bool "Enable ETB trace capture"
 	depends on ETB_TRACE

--- a/modules/memfault-firmware-sdk/memfault_ncs_metrics.c
+++ b/modules/memfault-firmware-sdk/memfault_ncs_metrics.c
@@ -92,11 +92,7 @@ int memfault_ncs_metrics_thread_add(struct memfault_ncs_metrics_thread *thread)
 	return 0;
 }
 
-/* Overriding weak implementation in Memfault SDK.
- * The function is run on every heartbeat and can be used to get fresh updates
- * of metrics.
- */
-void memfault_metrics_heartbeat_collect_data(void)
+void memfault_ncs_metrics_collect_data(void)
 {
 	if (IS_ENABLED(CONFIG_MEMFAULT_NCS_STACK_METRICS)) {
 		k_thread_foreach_unlocked(stack_check, NULL);
@@ -110,6 +106,17 @@ void memfault_metrics_heartbeat_collect_data(void)
 		memfault_lte_metrics_update();
 	}
 }
+
+#if defined(CONFIG_MEMFAULT_NCS_IMPLEMENT_METRICS_COLLECTION)
+/* Overriding weak implementation in Memfault SDK.
+ * The function is run on every heartbeat and can be used to get fresh updates
+ * of metrics.
+ */
+void memfault_metrics_heartbeat_collect_data(void)
+{
+	memfault_ncs_metrics_collect_data();
+}
+#endif
 
 void memfault_ncs_metrics_init(void)
 {


### PR DESCRIPTION
Permit overriding the built-in NCS
`memfault_metrics_heartbeat_collect_data()` with a custom version.

Application will need to select
`CONFIG_MEMFAULT_NCS_IMPLEMENT_METRICS_COLLECTION=n`, then implement the function elsewhere.

Expose the `memfault_ncs_metrics_collect_data()` data collection function so a user can run that in addition to their own metrics.