### PR TITLE
bootloader: bl_boot: Fix disabling of UARTs

### DIFF
--- a/subsys/bootloader/bl_boot/bl_boot.c
+++ b/subsys/bootloader/bl_boot/bl_boot.c
@@ -10,32 +10,29 @@
 #include <fw_info.h>
 #include <fprotect.h>
 #include <hal/nrf_clock.h>
-#ifdef CONFIG_UART_NRFX
 #ifdef CONFIG_UART_NRFX_UART
 #include <hal/nrf_uart.h>
 #endif
-#if CONFIG_UART_NRFX_UARTE
+#ifdef CONFIG_UART_NRFX_UARTE
 #include <hal/nrf_uarte.h>
-#endif
 #endif
 
 static void uninit_used_peripherals(void)
 {
-#if defined(HAS_HW_NRF_UART0)
+#ifdef CONFIG_UART_NRFX
+#if defined(CONFIG_HAS_HW_NRF_UART0)
 	nrf_uart_disable(NRF_UART0);
-#elif defined(HAS_HW_NRF_UARTE0)
+#elif defined(CONFIG_HAS_HW_NRF_UARTE0)
 	nrf_uarte_disable(NRF_UARTE0);
 #endif
-#if defined(HAS_HW_NRF_UART1)
-	nrf_uart_disable(NRF_UART1);
-#elif defined(HAS_HW_NRF_UARTE1)
+#if defined(CONFIG_HAS_HW_NRF_UARTE1)
 	nrf_uarte_disable(NRF_UARTE1);
 #endif
-#if defined(HAS_HW_NRF_UART2)
-	nrf_uart_disable(NRF_UART2);
-#elif defined(HAS_HW_NRF_UARTE2)
+#if defined(CONFIG_HAS_HW_NRF_UARTE2)
 	nrf_uarte_disable(NRF_UARTE2);
 #endif
+#endif /* CONFIG_UART_NRFX */
+
 	nrf_clock_int_disable(NRF_CLOCK, 0xFFFFFFFF);
 }
 


### PR DESCRIPTION
This is a follow-up to commit 56d117d442c9148c75c621359e22283ffd7caef0 ("bootloader: bl_boot: update UART Kconfigs").

- add missing `CONFIG_` prefixes to `HAS_HW_NRF_*` symbols
- remove invalid entries that refer to non-existing peripherals (UART1 and UART2)
- move `#ifdef CONFIG_UART_NRFX` to the function, where it is actually needed (`CONFIG_UART_NRFX_UART` and `CONFIG_UART_NRFX_UARTE` imply `CONFIG_UART_NRFX`, as they cannot be defined otherwise, so there is no need for that additional `#ifdef` in inclusions).