### PR TITLE
samples: cellular: modem_shell: Add printing of reset reason

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -181,7 +181,12 @@ Bluetooth mesh samples
 Cellular samples (renamed from nRF9160 samples)
 -----------------------------------------------
 
-|no_changes_yet_note|
+* :ref:`modem_shell_application` sample:
+
+  * Added:
+
+    * Printing of the last reset reason when the sample starts.
+    * Support for printing the sample version information using the ``version`` command.
 
 Cryptography samples
 --------------------

--- a/samples/cellular/modem_shell/src/shell.c
+++ b/samples/cellular/modem_shell/src/shell.c
@@ -214,6 +214,13 @@ int heap_shell(const struct shell *shell, size_t argc, char **argv)
 	return 0;
 }
 
+int version_shell(const struct shell *shell, size_t argc, char **argv)
+{
+	mosh_print_version_info();
+
+	return 0;
+}
+
 #if defined(CONFIG_MOSH_IPERF3)
 static int cmd_iperf3(const struct shell *shell, size_t argc, char **argv)
 {
@@ -243,3 +250,7 @@ SHELL_CMD_ARG_REGISTER(sleep, NULL,
 SHELL_CMD_ARG_REGISTER(heap, NULL,
 	"Print heap usage statistics.",
 	heap_shell, 1, 0);
+
+SHELL_CMD_ARG_REGISTER(version, NULL,
+	"Print application version information.",
+	version_shell, 1, 0);

--- a/samples/cellular/modem_shell/src/utils/mosh_print.c
+++ b/samples/cellular/modem_shell/src/utils/mosh_print.c
@@ -170,3 +170,31 @@ int mosh_print_help_shell(const struct shell *shell, size_t argc, char **argv)
 
 	return ret;
 }
+
+void mosh_print_version_info(void)
+{
+	/* shell_print() is not used here, because this function is called early during
+	 * application startup and the shell might not be ready yet.
+	 */
+#if defined(APP_VERSION)
+	printk("\nMOSH version:       %s", STRINGIFY(APP_VERSION));
+#else
+	printk("\nMOSH version:       unknown");
+#endif
+
+#if defined(BUILD_ID)
+	printk("\nMOSH build id:      v%s", STRINGIFY(BUILD_ID));
+#else
+	printk("\nMOSH build id:      custom");
+#endif
+
+#if defined(BUILD_VARIANT)
+#if defined(BRANCH_NAME)
+	printk("\nMOSH build variant: %s/%s\n\n", STRINGIFY(BRANCH_NAME), STRINGIFY(BUILD_VARIANT));
+#else
+	printk("\nMOSH build variant: %s\n\n", STRINGIFY(BUILD_VARIANT));
+#endif
+#else
+	printk("\nMOSH build variant: dev\n\n");
+#endif
+}

--- a/samples/cellular/modem_shell/src/utils/mosh_print.h
+++ b/samples/cellular/modem_shell/src/utils/mosh_print.h
@@ -53,4 +53,7 @@ void mosh_fprintf_valist(enum mosh_print_level print_level, const char *fmt, va_
 /** Print error level information to output. */
 #define mosh_error(fmt, ...) mosh_fprintf(MOSH_PRINT_LEVEL_ERROR, fmt, ##__VA_ARGS__)
 
+/** Print application version information. */
+void mosh_print_version_info(void);
+
 #endif


### PR DESCRIPTION
Added printing of last reset reason(s) when the application starts.

Added new shell command `version` which prints the application version information.

MOSH-468