### PR TITLE
applications: serial_lte_modem: ignore obsolete settings

### DIFF
--- a/applications/serial_lte_modem/src/slm_settings.c
+++ b/applications/serial_lte_modem/src/slm_settings.c
@@ -60,8 +60,10 @@ static int settings_set(const char *name, size_t len, settings_read_cb read_cb, 
 			return 0;
 #endif
 	}
-
-	return -ENOENT;
+	/* Simply ignore obsolete settings that are not in use anymore.
+	 * settings_delete() does not completely remove settings.
+	 */
+	return 0;
 }
 
 static struct settings_handler slm_settings_conf = {


### PR DESCRIPTION
Settings that were previously saved but have been removed from the code should not provoke error logs that may cause concern to the end user.
Simply ignore unrecognized settings from the slm subtree.