### PR TITLE
sysbuild: adjust variant image to use existing variant kconfig impl

### DIFF
--- a/cmake/sysbuild/modules/ncs_sysbuild_extensions.cmake
+++ b/cmake/sysbuild/modules/ncs_sysbuild_extensions.cmake
@@ -38,18 +38,8 @@ function(ExternalNcsVariantProject_Add)
   endforeach()
 
   ExternalProject_Get_Property(${VBUILD_VARIANT} BINARY_DIR)
-  ExternalProject_Add_Step(${VBUILD_VARIANT} variant_config
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            ${${VBUILD_APPLICATION}_BINARY_DIR}/zephyr/.config
-            ${BINARY_DIR}/zephyr/.config
-    DEPENDERS build
-    ALWAYS True
-  )
-
-  # Disable menuconfig and friends in variant builds by substitution with a
-  # dummy target that does nothing except returning successfully.
   set_property(TARGET ${VBUILD_VARIANT} APPEND PROPERTY _EP_CMAKE_ARGS
-    -DKCONFIG_TARGETS=variant_config
-    "-DEXTRA_KCONFIG_TARGET_COMMAND_FOR_variant_config=-c\;''"
+    -DCONFIG_NCS_IS_VARIANT_IMAGE=y
+    -DPRELOAD_BINARY_DIR=${${VBUILD_APPLICATION}_BINARY_DIR}
   )
 endfunction()


### PR DESCRIPTION
The ExternalProject_Add_Step() has an undesired side-effect. The variant image would initially be using a regular generated .config which would be replaced with the .config of the original image during build.

Unfortunately the CMake configure of the variant image can in some cases end with a CMake failure, which means the build stage is never reached and thus the .config is never overwritten.

Fix this by copying the .config as part of the CMake configure stage as is available in existing implementation.