### PR TITLE
modules/mcuboot/nrf53_hooks: fix boot_image_check_hook()

### DIFF
--- a/modules/mcuboot/hooks/nrf53_hooks.c
+++ b/modules/mcuboot/hooks/nrf53_hooks.c
@@ -88,13 +88,13 @@ int boot_read_image_header_hook(int img_index, int slot, struct image_header *im
 	return BOOT_HOOK_REGULAR;
 }
 
-fih_int boot_image_check_hook(int img_index, int slot)
+fih_ret boot_image_check_hook(int img_index, int slot)
 {
 	if (img_index == 1 && slot == 0) {
 		FIH_RET(FIH_SUCCESS);
 	}
 
-	FIH_RET(fih_int_encode(BOOT_HOOK_REGULAR));
+	FIH_RET(FIH_BOOT_HOOK_REGULAR);
 }
 
 int boot_perform_update_hook(int img_index, struct image_header *img_head,


### PR DESCRIPTION
boot_image_check_hook() implementation shall return fih_ret value type. The function should return FIH_BOOT_HOOK_REGULAR instead of BOOT_HOOK_REGULAR.

If the Fault Injection Hardening (FIH) is enabled then fih_int type is different than fih_ret type. Also BOOT_HOOK_REGULAR and FIH_BOOT_HOOK_REGULAR are not the same things.

ref. NCSDK-24203

Consequence of this is that when FIH is enabled, the standard boot_image_check() call is never performed by the mcuboot (for real images) and subsequent checks gets BOOT_HOOK_REGULAR as its results. In mcuboot loader.c this prematurely cause identification of invalid image.