### PR TITLE
applications: serial_lte_modem: Disable hwfc with Thingy:91

### DIFF
--- a/applications/serial_lte_modem/boards/thingy91_nrf9160_ns.conf
+++ b/applications/serial_lte_modem/boards/thingy91_nrf9160_ns.conf
@@ -12,3 +12,6 @@
 CONFIG_UART_0_NRF_HW_ASYNC_TIMER=2
 CONFIG_UART_0_NRF_HW_ASYNC=y
 CONFIG_SLM_WAKEUP_PIN=26
+
+# Increase buffer space as hardware flow control is not used with Thingy:91.
+CONFIG_SLM_UART_RX_BUF_SIZE=2048

--- a/applications/serial_lte_modem/boards/thingy91_nrf9160_ns.overlay
+++ b/applications/serial_lte_modem/boards/thingy91_nrf9160_ns.overlay
@@ -12,7 +12,6 @@
 
 &uart0 {
 	status = "okay";
-	hw-flow-control;
 };
 
 &uart2 {


### PR DESCRIPTION
Disable hw-flow-control and increment buffer space to better match with default buffer sizing of Connectivity Bridge.