### PR TITLE
lib: location: Increase HTTP receive buffer with HERE

### DIFF
--- a/lib/location/Kconfig
+++ b/lib/location/Kconfig
@@ -91,6 +91,7 @@ if LOCATION_METHOD_CELLULAR || LOCATION_METHOD_WIFI
 
 config LOCATION_SERVICE_CLOUD_RECV_BUF_SIZE
 	int "Receive buffer size"
+	default 1024 if LOCATION_SERVICE_HERE
 	default 512
 	help
 	  Size of the buffer used to store the response from the location service.


### PR DESCRIPTION
Increased HTTP receive buffer size when HERE location service is used. If resolving the location failed, the response from the server was too large to fit in the receive buffer.