### PR TITLE
manifest: Update zephyr for hci_uart_async

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: fabddf3a622625f39a71b9bb0377569e2fe230be
+      revision: f1ee732cab5ebaa83ddf94f0d4c6f734d2684ea7
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update sdk-zephyr to pull in samples/bluetooth/hci_uart_async.