### PR TITLE
samples: matter: lock NUS: EOL agnostic commands

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -218,7 +218,9 @@ Keys samples
 Matter samples
 --------------
 
-|no_changes_yet_note|
+* :ref:`matter_lock_sample` sample:
+
+  * Fixed an issue that prevented nRF Toolbox for iOS in version 5.0.9 from controlling the sample using :ref:`nus_service_readme`.
 
 Multicore samples
 -----------------


### PR DESCRIPTION
Implemented support for NUS commands terminated with various EOL (\n, \r, \r\n, none).