### PR TITLE
cmake: remove deprecated PYTHON_PREFER setting

### DIFF
--- a/share/ncs-package/cmake/NcsConfig.cmake
+++ b/share/ncs-package/cmake/NcsConfig.cmake
@@ -45,7 +45,6 @@ if(NOT NO_BOILERPLATE)
       set(WEST                     ${NCS_TOOLCHAIN_WEST}    CACHE FILEPATH "NCS Toolchain West")
       set(Python3_EXECUTABLE       ${NCS_TOOLCHAIN_PYTHON}  CACHE FILEPATH "NCS Toolchain Python")
       set(PYTHON_EXECUTABLE        ${NCS_TOOLCHAIN_PYTHON}  CACHE FILEPATH "NCS Toolchain Python")
-      set(PYTHON_PREFER            ${NCS_TOOLCHAIN_PYTHON}  CACHE FILEPATH "NCS Toolchain Python")
 
       if(DEFINED NCS_TOOLCHAIN_PROTOC)
         set(PROTOC                     ${CUSTOM_COMMAND_ENV} ${NCS_TOOLCHAIN_PROTOC} CACHE STRING "NCS Toolchain protoc")


### PR DESCRIPTION
Since ihttps://github.com/zephyrproject-rtos/zephyr/pull/59811 then PYTHON_PREFER has been deprecated in favor of Python3_EXECUTABLE as artifact specifier.

Remove PYTHON_PREFER setting.

This will also remove the CMake deprecation warning being printed during CMake configure time.