### PR TITLE
matter: pull LTO build fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -149,7 +149,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: v2.5.0
+      revision: 11caca066822255996b56694439307afd6736b61
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
Fix undefined reference errors when building Matter apps with link time optimization.