### PR TITLE
treewide: remove HomeKit from NCS

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -7,18 +7,16 @@ pull_request_rules:
       - -draft
       - -label=DNM
       - or:
-        - label=manifest-homekit
-        - label=manifest-find-my
-        - label=CI-homekit-test
-        - label=CI-find-my-test
+          - label=manifest-find-my
+          - label=CI-find-my-test
       - label!=DNM
       # Prevent Merging is the DNM github action check
       - check-success=Prevent Merging
       # Disable as brach protection rules will handle this. Keeping for future reference
-      #- check-success=CI/Jenkins/twister
-      #- or:
-        #- check-success=CI/Jenkins/integration
-        #- check-neutral=CI/Jenkins/integration
+      # - check-success=CI/Jenkins/twister
+      # - or:
+      # - check-success=CI/Jenkins/integration
+      # - check-neutral=CI/Jenkins/integration
     actions:
       merge:
         method: rebase

--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -286,21 +286,6 @@
   - "modules/nrfxlib/nrf_802154/**/*"
   - "samples/CMakeLists.txt"
 
-"CI-homekit-test":
-  - "drivers/hw_cc310/*"
-  - "drivers/mpsl/**/*"
-  - "dts/bindings/radio_fem/**/*"
-  - "modules/nrfxlib/nrf_802154/**/*"
-  - "samples/nrf5340/multiprotocol_rpmsg/**/*"
-  - "subsys/bluetooth/controller/*"
-  - "subsys/ieee802154/**/*"
-  - "subsys/mpsl/**/*"
-  - "subsys/net/openthread/*"
-  - any:
-      - "subsys/nrf_security/**/*"
-      - "!subsys/nrf_security/doc/**/*"
-      - "!subsys/nrf_security/*.rst"
-
 "CI-thread-test":
   - "samples/openthread/**/*"
   - "subsys/mpsl/**/*"

--- a/doc/_scripts/software_maturity/software_maturity_features.yaml
+++ b/doc/_scripts/software_maturity/software_maturity_features.yaml
@@ -5,7 +5,6 @@ top_table:
   Zigbee: ZIGBEE
   Thread: NET_L2_OPENTHREAD
   LTE: LTE_LINK_CONTROL
-  HomeKit: HOMEKIT
   Matter: CHIP
   Wi-Fi:
     rule: WIFI && WIFI_NRF700X
@@ -64,14 +63,6 @@ features:
     OTA DFU over Matter: CHIP && CHIP_OTA_REQUESTOR
     Matter Sleepy End Device: CHIP && CHIP_ENABLE_SLEEPY_END_DEVICE_SUPPORT &&
       NET_L2_OPENTHREAD && OPENTHREAD_MTD_SED
-  homekit:
-    HomeKit over Bluetooth LE: HOMEKIT && BT && !CONFIG_HAP_HAVE_THREAD
-    HomeKit over Thread FTD: HOMEKIT && BT && OPENTHREAD_FTD
-    HomeKit over Thread MTD SED: HOMEKIT && BT && OPENTHREAD_MTD_SED
-    HomeKit commissioning over Bluetooth LE with QR code: HOMEKIT && BT && !CONFIG_HAP_HAVE_NFC
-    HomeKit commissioning over Bluetooth LE with NFC: HOMEKIT && BT && CONFIG_HAP_HAVE_NFC
-    HomeKit - OTA DFU over Bluetooth LE: HOMEKIT && HOMEKIT_NORDIC_DFU
-    HomeKit - OTA DFU over HomeKit: HOMEKIT && BT && CONFIG_HAP_FIRMWARE_UPDATE
   wifi:
     STA Mode:
       rule: WPA_SUPP && WIFI_NRF700X

--- a/doc/nrf/integrations.rst
+++ b/doc/nrf/integrations.rst
@@ -6,11 +6,10 @@ Integrations
 An |NCS| integration allows for using third-party and Nordic products within the |NCS|.
 Integrations of the following third-party products are documented in their private repositories:
 
-* Apple Homekit
 * Apple Find My
 * ANT
 
-In the case of HomeKit and Find My, MFi licensees can get access to the repository by issuing a Nordic `DevZone`_ private ticket.
+In the case of Find My, MFi licensees can get access to the repository by issuing a Nordic `DevZone`_ private ticket.
 
 The following user guides describe available integrations:
 

--- a/doc/nrf/introduction.rst
+++ b/doc/nrf/introduction.rst
@@ -26,7 +26,7 @@ The |NCS| has the following distinguishing features:
 
 **Robust connectivity support**
    The |NCS| supports a wide range of connectivity technologies.
-   In addition to connectivity technologies :ref:`provided by Zephyr <zephyr:connectivity>`, such as Bluetooth® Low Energy, IPv6, TCP/IP, UDP, LoRa and LoRaWAN, the |NCS| supports ANT, Bluetooth mesh, Apple Find My, Apple HomeKit, LTE-M/NB-IoT/GPS, Matter, Amazon Sidewalk, Thread, and Wi-Fi®, among others.
+   In addition to connectivity technologies :ref:`provided by Zephyr <zephyr:connectivity>`, such as Bluetooth® Low Energy, IPv6, TCP/IP, UDP, LoRa and LoRaWAN, the |NCS| supports ANT, Bluetooth mesh, Apple Find My, LTE-M/NB-IoT/GPS, Matter, Amazon Sidewalk, Thread, and Wi-Fi®, among others.
 
 **Scalable and extensible**
    The |NCS| is out-of-tree ready and can be used for projects and applications of all sizes and levels of complexity.

--- a/doc/nrf/releases_and_maturity/repository_revisions.rst
+++ b/doc/nrf/releases_and_maturity/repository_revisions.rst
@@ -6,4 +6,4 @@
 The following table lists all the repositories (and their respective revisions) that are included as part of |NCS| |version| release:
 
 .. manifest-revisions-table::
-   :show-first: zephyr, nrfxlib, mcuboot, trusted-firmware-m, find-my, homekit, matter, nrf-802154, mbedtls, memfault-firmware-sdk
+   :show-first: zephyr, nrfxlib, mcuboot, trusted-firmware-m, find-my, matter, nrf-802154, mbedtls, memfault-firmware-sdk

--- a/doc/nrf/releases_and_maturity/software_maturity.rst
+++ b/doc/nrf/releases_and_maturity/software_maturity.rst
@@ -213,15 +213,6 @@ The following table indicates the software maturity levels of the support for ea
 
   .. sml-table:: bluetooth
 
-HomeKit features support
-************************
-
-The following table indicates the software maturity levels of the support for each HomeKit feature:
-
-.. toggle::
-
-  .. sml-table:: homekit
-
 Thread features support
 ***********************
 

--- a/scripts/tag_west_repos.sh
+++ b/scripts/tag_west_repos.sh
@@ -44,7 +44,6 @@ declare -A PROJECT_TAGS
 # nrfx/nRF/srcx repositories: vX.Y.Z(-rcN)
 PROJECT_TAGS[nrfxlib]=""
 PROJECT_TAGS[find-my]=""
-PROJECT_TAGS[homekit]=""
 PROJECT_TAGS[matter]=""
 PROJECT_TAGS[nrf-802154]=""
 

--- a/west.yml
+++ b/west.yml
@@ -45,7 +45,7 @@ manifest:
   defaults:
     remote: ncs
 
-  group-filter: [-homekit, -nrf-802154, -dragoon, -find-my, -ant, -babblesim, -sidewalk, -bsec]
+  group-filter: [-nrf-802154, -dragoon, -find-my, -ant, -babblesim, -sidewalk, -bsec]
 
   # "projects" is a list of git repositories which make up the NCS
   # source code.
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 908794942947d049b61603b728f8f15af17e4873
+      revision: fabddf3a622625f39a71b9bb0377569e2fe230be
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -141,7 +141,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: v2.5.0
+      revision: c230f914828d2ecf44a9f28922b40804216f0408
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
@@ -193,11 +193,6 @@ manifest:
       submodules: true
       groups:
         - sidewalk
-    - name: homekit
-      repo-path: sdk-homekit
-      revision: v2.5.0
-      groups:
-        - homekit
     - name: find-my
       repo-path: sdk-find-my
       revision: b972afd32f2b6ab028320badb2e35f857b8fc158


### PR DESCRIPTION
With the introduction of Matter, all HomeKit customers are recommended to use Matter for new designs of smart home products. As a result, HomeKit Accessory Development Kit has been deprecated and removed from NCS.

Depends on:
- [x] https://github.com/nrfconnect/sdk-nrfxlib/pull/1102
- [x] https://github.com/nrfconnect/sdk-zephyr/pull/1368