### PR TITLE
net: fota_download: Only retry on ECONNRESET

### DIFF
--- a/include/net/download_client.h
+++ b/include/net/download_client.h
@@ -58,11 +58,16 @@ enum download_client_evt_id {
 	 * returning zero from the callback will let the library attempt
 	 * to reconnect to the server and download the last fragment again.
 	 * Otherwise, the application may return any non-zero value
-	 * to stop the download.
+	 * to stop the download. On any other error code than ECONNRESET, the client
+	 * will not attempt to reconnect and ignores the return value.
 	 *
-	 * In case the download is stopped, the application should manually
-	 * disconnect (@ref download_client_disconnect) to clean up the
-	 * network socket as necessary before re-attempting the download.
+	 * In case the download is stopped, and it was started using @ref download_client_get,
+	 * the download client automatically closes the connection. The application should wait for
+	 * DOWNLOAD_CLIENT_EVT_CLOSED before attempting another download.
+	 * If download is stopped, and it was started using @ref download_client_start
+	 * the application should manually disconnect (@ref download_client_disconnect)
+	 * to clean up the network socket and wait for DOWNLOAD_CLIENT_EVT_CLOSED before attempting
+	 * another download.
 	 */
 	DOWNLOAD_CLIENT_EVT_ERROR,
 	/** Download complete. */

--- a/subsys/net/lib/download_client/src/download_client.c
+++ b/subsys/net/lib/download_client/src/download_client.c
@@ -415,8 +415,14 @@ static int client_connect(struct download_client *dl)
 
 	err = connect(dl->fd, &dl->remote_addr, addrlen);
 	if (err) {
-		LOG_ERR("Unable to connect, errno %d", errno);
 		err = -errno;
+		LOG_ERR("Unable to connect, errno %d", -err);
+		/* Make sure that ECONNRESET is not returned as it has a special meaning
+		 * in the download client API
+		 */
+		if (err == -ECONNRESET) {
+			err = -ECONNREFUSED;
+		}
 	}
 
 cleanup:

--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -272,9 +272,7 @@ static int download_client_callback(const struct download_client_evt *event)
 		/* In case of socket errors we can return 0 to retry/continue,
 		 * or non-zero to stop
 		 */
-		if ((socket_retries_left) && ((event->error == -ENOTCONN) ||
-					      (event->error == -ECONNRESET) ||
-					      (event->error == -ETIMEDOUT))) {
+		if ((socket_retries_left) && (event->error == -ECONNRESET)) {
 			LOG_WRN("Download socket error. %d retries left...",
 				socket_retries_left);
 			socket_retries_left--;


### PR DESCRIPTION
Only the ECONNRESET is documented in Download Client as a possibility to rettry.

* Fix up the documentation regarding other error codes.
* Fix the FOTA download so that we don't assume retry.
* Add testcases for download client errors.