### PR TITLE
manifest: sdk-zephyr: Pull fix for compliance with multi-user setup

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v3.4.99-ncs1
+      revision: pull/1102/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This should fix compliance on a multi-user server.

@udaynordic @srkanordic Once this is merged then compliance should work on our firmware build server.