### PR TITLE
applications: nrf5340_audio: Disable auto resubscribe for unicast server

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/Kconfig.defaults
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/Kconfig.defaults
@@ -80,6 +80,9 @@ config BT_DEVICE_APPEARANCE
 config BT_GAP_PERIPHERAL_PREF_PARAMS
 	default n
 
+config BT_GATT_AUTO_RESUBSCRIBE
+	default n
+
 config BT_GATT_AUTO_SEC_REQ
 	default n
 


### PR DESCRIPTION
Set BT_GATT_AUTO_RESUBSCRIBE to n for unicast server, which prevents compatibility issue with Android 14. 
OCT-2755
Signed-off-by: Jui-Chou Chung <jui-chou.chung@nordicsemi.no>