### PR TITLE
samples: crypto: Remove use of deprecated PSA type psa_key_handle_t

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -186,6 +186,11 @@ Cellular samples (renamed from nRF9160 samples)
 Cryptography samples
 --------------------
 
+* Updated:
+
+  * All crypto samples to use ``psa_key_id_t`` instead of ``psa_key_handle_t``.
+    These concepts have been merged and ``psa_key_handle_t`` is removed from the PSA API specification.
+
 |no_changes_yet_note|
 
 Debug samples

--- a/samples/crypto/aes_cbc/src/main.c
+++ b/samples/crypto/aes_cbc/src/main.c
@@ -45,7 +45,7 @@ static uint8_t m_plain_text[NRF_CRYPTO_EXAMPLE_AES_MAX_TEXT_SIZE] = {
 static uint8_t m_encrypted_text[NRF_CRYPTO_EXAMPLE_AES_MAX_TEXT_SIZE];
 static uint8_t m_decrypted_text[NRF_CRYPTO_EXAMPLE_AES_MAX_TEXT_SIZE];
 
-static psa_key_handle_t key_handle;
+static psa_key_id_t key_id;
 /* ====================================================================== */
 
 int crypto_init(void)
@@ -65,7 +65,7 @@ int crypto_finish(void)
 	psa_status_t status;
 
 	/* Destroy the key handle */
-	status = psa_destroy_key(key_handle);
+	status = psa_destroy_key(key_id);
 	if (status != PSA_SUCCESS) {
 		LOG_INF("psa_destroy_key failed! (Error: %d)", status);
 		return APP_ERROR;
@@ -92,7 +92,7 @@ int generate_key(void)
 	/* Generate a random key. The key is not exposed to the application,
 	 * we can use it to encrypt/decrypt using the key handle
 	 */
-	status = psa_generate_key(&key_attributes, &key_handle);
+	status = psa_generate_key(&key_attributes, &key_id);
 	if (status != PSA_SUCCESS) {
 		LOG_INF("psa_generate_key failed! (Error: %d)", status);
 		return APP_ERROR;
@@ -115,7 +115,7 @@ int encrypt_cbc_aes(void)
 	LOG_INF("Encrypting using AES CBC MODE...");
 
 	/* Setup the encryption operation */
-	status = psa_cipher_encrypt_setup(&operation, key_handle, PSA_ALG_CBC_NO_PADDING);
+	status = psa_cipher_encrypt_setup(&operation, key_id, PSA_ALG_CBC_NO_PADDING);
 	if (status != PSA_SUCCESS) {
 		LOG_INF("psa_cipher_encrypt_setup failed! (Error: %d)", status);
 		return APP_ERROR;
@@ -166,7 +166,7 @@ int decrypt_cbc_aes(void)
 	LOG_INF("Decrypting using AES CBC MODE...");
 
 	/* Setup the decryption operation */
-	status = psa_cipher_decrypt_setup(&operation, key_handle, PSA_ALG_CBC_NO_PADDING);
+	status = psa_cipher_decrypt_setup(&operation, key_id, PSA_ALG_CBC_NO_PADDING);
 	if (status != PSA_SUCCESS) {
 		LOG_INF("psa_cipher_decrypt_setup failed! (Error: %d)", status);
 		return APP_ERROR;

--- a/samples/crypto/aes_ccm/src/main.c
+++ b/samples/crypto/aes_ccm/src/main.c
@@ -58,7 +58,7 @@ static uint8_t m_encrypted_text[NRF_CRYPTO_EXAMPLE_AES_MAX_TEXT_SIZE +
 
 static uint8_t m_decrypted_text[NRF_CRYPTO_EXAMPLE_AES_MAX_TEXT_SIZE];
 
-static psa_key_handle_t key_handle;
+static psa_key_id_t key_id;
 /* ====================================================================== */
 
 int crypto_init(void)
@@ -78,7 +78,7 @@ int crypto_finish(void)
 	psa_status_t status;
 
 	/* Destroy the key handle */
-	status = psa_destroy_key(key_handle);
+	status = psa_destroy_key(key_id);
 	if (status != PSA_SUCCESS) {
 		LOG_INF("psa_destroy_key failed! (Error: %d)", status);
 		return APP_ERROR;
@@ -105,7 +105,7 @@ int generate_key(void)
 	/* Generate a random key. The key is not exposed to the application,
 	 * we can use it to encrypt/decrypt using the key handle
 	 */
-	status = psa_generate_key(&key_attributes, &key_handle);
+	status = psa_generate_key(&key_attributes, &key_id);
 	if (status != PSA_SUCCESS) {
 		LOG_INF("psa_generate_key failed! (Error: %d)", status);
 		return APP_ERROR;
@@ -127,7 +127,7 @@ int encrypt_ccm_aes(void)
 	LOG_INF("Encrypting using AES CCM MODE...");
 
 	/* Encrypt the plaintext and create the authentication tag */
-	status = psa_aead_encrypt(key_handle,
+	status = psa_aead_encrypt(key_id,
 							  PSA_ALG_CCM,
 							  m_nonce,
 							  sizeof(m_nonce),
@@ -163,7 +163,7 @@ int decrypt_ccm_aes(void)
 	LOG_INF("Decrypting using AES CCM MODE...");
 
 	/* Decrypt the encrypted data and authenticate the tag */
-	status = psa_aead_decrypt(key_handle,
+	status = psa_aead_decrypt(key_id,
 							  PSA_ALG_CCM,
 							  m_nonce,
 							  sizeof(m_nonce),

--- a/samples/crypto/aes_ctr/src/main.c
+++ b/samples/crypto/aes_ctr/src/main.c
@@ -46,7 +46,7 @@ static uint8_t m_plain_text[NRF_CRYPTO_EXAMPLE_AES_MAX_TEXT_SIZE] = {
 static uint8_t m_encrypted_text[NRF_CRYPTO_EXAMPLE_AES_MAX_TEXT_SIZE];
 static uint8_t m_decrypted_text[NRF_CRYPTO_EXAMPLE_AES_MAX_TEXT_SIZE];
 
-static psa_key_handle_t key_handle;
+static psa_key_id_t key_id;
 /* ====================================================================== */
 
 int crypto_init(void)
@@ -66,7 +66,7 @@ int crypto_finish(void)
 	psa_status_t status;
 
 	/* Destroy the key handle */
-	status = psa_destroy_key(key_handle);
+	status = psa_destroy_key(key_id);
 	if (status != PSA_SUCCESS) {
 		LOG_INF("psa_destroy_key failed! (Error: %d)", status);
 		return APP_ERROR;
@@ -94,7 +94,7 @@ int generate_key(void)
 	/* Generate a random key. The key is not exposed to the application,
 	 * we can use it to encrypt/decrypt using the key handle
 	 */
-	status = psa_generate_key(&key_attributes, &key_handle);
+	status = psa_generate_key(&key_attributes, &key_id);
 	if (status != PSA_SUCCESS) {
 		LOG_INF("psa_generate_key failed! (Error: %d)", status);
 		return APP_ERROR;
@@ -117,7 +117,7 @@ int encrypt_ctr_aes(void)
 	LOG_INF("Encrypting using AES CTR MODE...");
 
 	/* Setup the encryption operation */
-	status = psa_cipher_encrypt_setup(&operation, key_handle, PSA_ALG_CTR);
+	status = psa_cipher_encrypt_setup(&operation, key_id, PSA_ALG_CTR);
 	if (status != PSA_SUCCESS) {
 		LOG_INF("psa_cipher_encrypt_setup failed! (Error: %d)", status);
 		return APP_ERROR;
@@ -177,7 +177,7 @@ int decrypt_ctr_aes(void)
 	LOG_INF("Decrypting using AES CTR MODE...");
 
 	/* Setup the decryption operation */
-	status = psa_cipher_decrypt_setup(&operation, key_handle, PSA_ALG_CTR);
+	status = psa_cipher_decrypt_setup(&operation, key_id, PSA_ALG_CTR);
 	if (status != PSA_SUCCESS) {
 		LOG_INF("psa_cipher_decrypt_setup failed! (Error: %d)", status);
 		return APP_ERROR;

--- a/samples/crypto/aes_gcm/src/main.c
+++ b/samples/crypto/aes_gcm/src/main.c
@@ -57,7 +57,7 @@ static uint8_t m_encrypted_text[NRF_CRYPTO_EXAMPLE_AES_MAX_TEXT_SIZE +
 
 static uint8_t m_decrypted_text[NRF_CRYPTO_EXAMPLE_AES_MAX_TEXT_SIZE];
 
-static psa_key_handle_t key_handle;
+static psa_key_id_t key_id;
 /* ====================================================================== */
 
 int crypto_init(void)
@@ -78,7 +78,7 @@ int crypto_finish(void)
 	psa_status_t status;
 
 	/* Destroy the key handle */
-	status = psa_destroy_key(key_handle);
+	status = psa_destroy_key(key_id);
 	if (status != PSA_SUCCESS) {
 		LOG_INF("psa_destroy_key failed! (Error: %d)", status);
 		return APP_ERROR;
@@ -105,7 +105,7 @@ int generate_key(void)
 	/* Generate a random key. The key is not exposed to the application,
 	 * we can use it to encrypt/decrypt using the key handle
 	 */
-	status = psa_generate_key(&key_attributes, &key_handle);
+	status = psa_generate_key(&key_attributes, &key_id);
 	if (status != PSA_SUCCESS) {
 		LOG_INF("psa_generate_key failed! (Error: %d)", status);
 		return APP_ERROR;
@@ -134,7 +134,7 @@ int encrypt_aes_gcm(void)
 	}
 
 	/* Encrypt the plaintext and create the authentication tag */
-	status = psa_aead_encrypt(key_handle,
+	status = psa_aead_encrypt(key_id,
 				  PSA_ALG_GCM,
 				  m_iv,
 				  sizeof(m_iv),
@@ -167,7 +167,7 @@ int decrypt_aes_gcm(void)
 	LOG_INF("Decrypting using AES GCM MODE...");
 
 	/* Decrypt and authenticate the encrypted data */
-	status = psa_aead_decrypt(key_handle,
+	status = psa_aead_decrypt(key_id,
 				  PSA_ALG_GCM,
 				  m_iv,
 				  sizeof(m_iv),

--- a/samples/crypto/chachapoly/src/main.c
+++ b/samples/crypto/chachapoly/src/main.c
@@ -57,7 +57,7 @@ static uint8_t m_encrypted_text[NRF_CRYPTO_EXAMPLE_CHACHAPOLY_TEXT_SIZE +
 
 static uint8_t m_decrypted_text[NRF_CRYPTO_EXAMPLE_CHACHAPOLY_TEXT_SIZE];
 
-psa_key_handle_t key_handle;
+psa_key_id_t key_id;
 /* ====================================================================== */
 
 int crypto_init(void)
@@ -77,7 +77,7 @@ int crypto_finish(void)
 	psa_status_t status;
 
 	/* Destroy the key handle */
-	status = psa_destroy_key(key_handle);
+	status = psa_destroy_key(key_id);
 	if (status != PSA_SUCCESS) {
 		LOG_INF("psa_destroy_key failed! (Error: %d)", status);
 		return APP_ERROR;
@@ -101,7 +101,7 @@ int generate_key(void)
 	/* Generate a random key. The key is not exposed to the application,
 	 * we can use it to encrypt/decrypt using the key handle
 	 */
-	status = psa_generate_key(&key_attributes, &key_handle);
+	status = psa_generate_key(&key_attributes, &key_id);
 	if (status != PSA_SUCCESS) {
 		LOG_INF("psa_generate_key failed! (Error: %d)", status);
 		return APP_ERROR;
@@ -130,7 +130,7 @@ int encrypt_chachapoly(void)
 	}
 
 	/* Perform the authenticated encryption */
-	status = psa_aead_encrypt(key_handle,
+	status = psa_aead_encrypt(key_id,
 				  PSA_ALG_CHACHA20_POLY1305,
 				  m_nonce,
 				  sizeof(m_nonce),
@@ -163,7 +163,7 @@ int decrypt_chachapoly(void)
 	LOG_INF("Decrypting using Chacha20-Poly1305 ...");
 
 	/* Decrypt and authenticate the encrypted data */
-	status = psa_aead_decrypt(key_handle,
+	status = psa_aead_decrypt(key_id,
 				  PSA_ALG_CHACHA20_POLY1305,
 				  m_nonce,
 				  sizeof(m_nonce),

--- a/samples/crypto/hkdf/src/main.c
+++ b/samples/crypto/hkdf/src/main.c
@@ -65,8 +65,8 @@ static uint8_t m_expected_output_key[NRF_CRYPTO_EXAMPLE_HKDF_OUTPUT_KEY_SIZE] = 
 	0x00, 0x72, 0x08, 0xd5, 0xb8, 0x87, 0x18, 0x58, 0x65
 };
 
-psa_key_handle_t input_key_handle;
-psa_key_handle_t output_key_handle;
+psa_key_id_t input_key_id;
+psa_key_id_t output_key_id;
 /* ====================================================================== */
 
 int crypto_init(void)
@@ -86,13 +86,13 @@ int crypto_finish(void)
 	psa_status_t status;
 
 	/* Destroy the key handle */
-	status = psa_destroy_key(input_key_handle);
+	status = psa_destroy_key(input_key_id);
 	if (status != PSA_SUCCESS) {
 		LOG_INF("psa_destroy_key failed! (Error: %d)", status);
 		return APP_ERROR;
 	}
 
-	status = psa_destroy_key(output_key_handle);
+	status = psa_destroy_key(output_key_id);
 	if (status != PSA_SUCCESS) {
 		LOG_INF("psa_destroy_key failed! (Error: %d)", status);
 		return APP_ERROR;
@@ -118,7 +118,7 @@ int import_input_key(void)
 	status = psa_import_key(&key_attributes,
 				m_input_key,
 				sizeof(m_input_key),
-				&input_key_handle);
+				&input_key_id);
 	if (status != PSA_SUCCESS) {
 		LOG_INF("psa_import_key failed! (Error: %d)", status);
 		return APP_ERROR;
@@ -133,7 +133,7 @@ int export_derived_key(void)
 	psa_status_t status;
 	int cmp_status;
 	/* Export the generated key content to verify it's value */
-	status = psa_export_key(output_key_handle, m_output_key, sizeof(m_output_key), &olen);
+	status = psa_export_key(output_key_id, m_output_key, sizeof(m_output_key), &olen);
 	if (status != PSA_SUCCESS) {
 		LOG_INF("psa_export_key failed! (Error: %d)", status);
 		return APP_ERROR;
@@ -190,7 +190,7 @@ int derive_hkdf(void)
 
 	/* Set the master key for the operation */
 	status = psa_key_derivation_input_key(
-		&operation, PSA_KEY_DERIVATION_INPUT_SECRET, input_key_handle);
+		&operation, PSA_KEY_DERIVATION_INPUT_SECRET, input_key_id);
 	if (status != PSA_SUCCESS) {
 		LOG_INF("psa_key_derivation_input_key failed! (Error: %d)", status);
 		return APP_ERROR;
@@ -206,8 +206,8 @@ int derive_hkdf(void)
 		return APP_ERROR;
 	}
 
-	/* Store the derived key in the keystore slot pointed by out_key_handle */
-	status = psa_key_derivation_output_key(&key_attributes, &operation, &output_key_handle);
+	/* Store the derived key in the keystore slot pointed by out_key_id */
+	status = psa_key_derivation_output_key(&key_attributes, &operation, &output_key_id);
 	if (status != PSA_SUCCESS) {
 		LOG_INF("psa_key_derivation_output_key failed! (Error: %d)", status);
 		return APP_ERROR;

--- a/samples/crypto/hmac/src/main.c
+++ b/samples/crypto/hmac/src/main.c
@@ -43,7 +43,7 @@ static uint8_t m_plain_text[NRF_CRYPTO_EXAMPLE_HMAC_TEXT_SIZE] = {
 
 static uint8_t hmac[NRF_CRYPTO_EXAMPLE_HMAC_KEY_SIZE];
 
-static psa_key_handle_t key_handle;
+static psa_key_id_t key_id;
 /* ====================================================================== */
 
 int crypto_init(void)
@@ -63,7 +63,7 @@ int crypto_finish(void)
 	psa_status_t status;
 
 	/* Destroy the key handle */
-	status = psa_destroy_key(key_handle);
+	status = psa_destroy_key(key_id);
 	if (status != PSA_SUCCESS) {
 		LOG_INF("psa_destroy_key failed! (Error: %d)", status);
 		return APP_ERROR;
@@ -91,7 +91,7 @@ int generate_key(void)
 	/* Generate a random key. The key is not exposed to the application,
 	 * we can use it to encrypt/decrypt using the key handle
 	 */
-	status = psa_generate_key(&key_attributes, &key_handle);
+	status = psa_generate_key(&key_attributes, &key_id);
 	if (status != PSA_SUCCESS) {
 		LOG_INF("psa_generate_key failed! (Error: %d)", status);
 		return APP_ERROR;
@@ -114,7 +114,7 @@ int hmac_sign(void)
 	LOG_INF("Signing using HMAC ...");
 
 	/* Initialize the HMAC signing operation */
-	status = psa_mac_sign_setup(&operation, key_handle, PSA_ALG_HMAC(PSA_ALG_SHA_256));
+	status = psa_mac_sign_setup(&operation, key_id, PSA_ALG_HMAC(PSA_ALG_SHA_256));
 	if (status != PSA_SUCCESS) {
 		LOG_INF("psa_mac_sign_setup failed! (Error: %d)", status);
 		return APP_ERROR;
@@ -149,7 +149,7 @@ int hmac_verify(void)
 	LOG_INF("Verifying the HMAC signature...");
 
 	/* Initialize the HMAC verification operation */
-	status = psa_mac_verify_setup(&operation, key_handle, PSA_ALG_HMAC(PSA_ALG_SHA_256));
+	status = psa_mac_verify_setup(&operation, key_id, PSA_ALG_HMAC(PSA_ALG_SHA_256));
 	if (status != PSA_SUCCESS) {
 		LOG_INF("psa_mac_verify_setup failed! (Error: %d)", status);
 		return APP_ERROR;

--- a/samples/crypto/persistent_key_usage/src/main.c
+++ b/samples/crypto/persistent_key_usage/src/main.c
@@ -38,7 +38,7 @@ LOG_MODULE_REGISTER(persistent_key_usage, LOG_LEVEL_DBG);
 #define SAMPLE_PERS_KEY_ID PSA_KEY_ID_USER_MIN
 
 
-static psa_key_handle_t key_handle;
+static psa_key_id_t key_id;
 /* ====================================================================== */
 
 int crypto_init(void)
@@ -58,7 +58,7 @@ int crypto_finish(void)
 	psa_status_t status;
 
 	/* Destroy the key handle */
-	status = psa_destroy_key(key_handle);
+	status = psa_destroy_key(key_id);
 	if (status != PSA_SUCCESS) {
 		LOG_INF("psa_destroy_key failed! (Error: %d)", status);
 		return APP_ERROR;
@@ -86,9 +86,9 @@ int generate_prersistent_key(void)
 	psa_set_key_id(&key_attributes, SAMPLE_PERS_KEY_ID);
 
 	/* Generate a random AES key with persistent lifetime. The key can be used for
-	 * encryption/decryption using the key_handle.
+	 * encryption/decryption using the key_id.
 	 */
-	status = psa_generate_key(&key_attributes, &key_handle);
+	status = psa_generate_key(&key_attributes, &key_id);
 	if (status != PSA_SUCCESS) {
 		LOG_INF("psa_generate_key failed! (Error: %d)", status);
 		return APP_ERROR;

--- a/samples/crypto/rsa/src/main.c
+++ b/samples/crypto/rsa/src/main.c
@@ -47,8 +47,8 @@ static char m_pub_key[NRF_CRYPTO_EXAMPLE_RSA_PUBLIC_KEY_SIZE];
 static char m_signature[NRF_CRYPTO_EXAMPLE_RSA_SIGNATURE_SIZE];
 static char m_hash[32];
 
-static psa_key_handle_t keypair_handle;
-static psa_key_handle_t pub_key_handle;
+static psa_key_id_t keypair_handle;
+static psa_key_id_t pub_key_id;
 /* ====================================================================== */
 
 int crypto_init(void)
@@ -74,7 +74,7 @@ int crypto_finish(void)
 		return APP_ERROR;
 	}
 
-	status = psa_destroy_key(pub_key_handle);
+	status = psa_destroy_key(pub_key_id);
 	if (status != PSA_SUCCESS) {
 		LOG_INF("psa_destroy_key failed! (Error: %d)", status);
 		return APP_ERROR;
@@ -137,7 +137,7 @@ int import_rsa_pub_key(void)
 	psa_set_key_type(&key_attributes, PSA_KEY_TYPE_RSA_PUBLIC_KEY);
 	psa_set_key_bits(&key_attributes, 2048);
 
-	status = psa_import_key(&key_attributes, m_pub_key, sizeof(m_pub_key), &pub_key_handle);
+	status = psa_import_key(&key_attributes, m_pub_key, sizeof(m_pub_key), &pub_key_id);
 	if (status != PSA_SUCCESS) {
 		LOG_INF("psa_import_key failed! (Error: %d)", status);
 		return APP_ERROR;
@@ -192,7 +192,7 @@ int verify_message_rsa(void)
 	LOG_INF("Verifying RSA signature...");
 
 	/* Verify the hash */
-	status = psa_verify_hash(pub_key_handle,
+	status = psa_verify_hash(pub_key_id,
 				 PSA_ALG_RSA_PKCS1V15_SIGN(PSA_ALG_SHA_256),
 				 m_hash,
 				 sizeof(m_hash),


### PR DESCRIPTION
Remove use of deprecated PSA type psa_key_handle_t. This concept has been merged with psa_key_id_t and this type should be used instead.