### PR TITLE
sample: aws_iot: Dummy credential format

### DIFF
--- a/samples/net/aws_iot/certs/ca-cert.pem
+++ b/samples/net/aws_iot/certs/ca-cert.pem
@@ -1,3 +1,3 @@
-"-----BEGIN CA CERTIFICATE-----\n"
-"-----CERTIFICATE-----\n"
-"-----END CA CERTIFICATE-----\n"
+"-----BEGIN CERTIFICATE-----\n"
+"-----certificate-----\n"
+"-----END CERTIFICATE-----\n"

--- a/samples/net/aws_iot/certs/client-cert.pem
+++ b/samples/net/aws_iot/certs/client-cert.pem
@@ -1,3 +1,3 @@
-"-----BEGIN CLIENT CERTIFICATE-----\n"
-"-----CERTIFICATE-----\n"
-"-----END CLIENT CERTIFICATE-----\n"
+"-----BEGIN CERTIFICATE-----\n"
+"-----certificate-----\n"
+"-----END CERTIFICATE-----\n"

--- a/samples/net/aws_iot/certs/private-key.pem
+++ b/samples/net/aws_iot/certs/private-key.pem
@@ -1,3 +1,3 @@
-"-----BEGIN PRIVATE KEY-----\n"
-"-----KEY-----\n"
-"-----END PRIVATE KEY-----\n"
+"-----BEGIN RSA PRIVATE KEY-----\n"
+"-----key-----\n"
+"-----END RSA PRIVATE KEY-----\n"


### PR DESCRIPTION
Change the dummy credential file format according to credentials as generated by AWS IoT, to avoid mistake in copying certificate and private key.