### PR TITLE
samples: cellular: mss: Wait for connection before printing connected.

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -188,6 +188,14 @@ Cellular samples (renamed from nRF9160 samples)
     * Printing of the last reset reason when the sample starts.
     * Support for printing the sample version information using the ``version`` command.
 
+* :ref:`nrf_cloud_multi_service` sample:
+
+  * Fixed:
+
+    * The sample now waits for a successful connection before printing ``Connected to nRF Cloud!``.
+
+|no_changes_yet_note|
+
 Cryptography samples
 --------------------
 


### PR DESCRIPTION
MSS does not wait for connection success before printing "Connected to nRF Cloud".

This commit fixes this by making the connect_cloud function correctly block until connection either succeeds or fails.

IRIS-7090