### PR TITLE
net: nrf_provisioning: Add boolean, integer and byte string support to ProvisioningCommand: config

### DIFF
--- a/subsys/net/lib/nrf_provisioning/include/nrf_provisioning_cbor_decode.h
+++ b/subsys/net/lib/nrf_provisioning/include/nrf_provisioning_cbor_decode.h
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 /*
- * Generated using zcbor version 0.6.0
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of CONFIG_NRF_PROVISIONING_CBOR_RECORDS
  */
@@ -16,14 +16,25 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <string.h>
-#include "zcbor_decode.h"
 #include "nrf_provisioning_cbor_decode_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #if DEFAULT_MAX_QTY != CONFIG_NRF_PROVISIONING_CBOR_RECORDS
 #error "The type file was generated with a different default_max_qty than this file"
 #endif
 
-int cbor_decode_commands(const uint8_t *payload, size_t payload_len, struct commands *result,
-			 size_t *payload_len_out);
+
+int cbor_decode_commands(
+		const uint8_t *payload, size_t payload_len,
+		struct commands *result,
+		size_t *payload_len_out);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* NRF_PROVISIONING_CBOR_DECODE_H__ */

--- a/subsys/net/lib/nrf_provisioning/include/nrf_provisioning_cbor_decode_types.h
+++ b/subsys/net/lib/nrf_provisioning/include/nrf_provisioning_cbor_decode_types.h
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 /*
- * Generated using zcbor version 0.6.0
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of CONFIG_NRF_PROVISIONING_CBOR_RECORDS
  */
@@ -15,8 +15,11 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
-#include <string.h>
-#include "zcbor_decode.h"
+#include <zcbor_common.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** Which value for --default-max-qty this file was created with.
  *
@@ -31,17 +34,28 @@ struct at_command {
 	struct zcbor_string _at_command_set_command;
 	struct zcbor_string _at_command_parameters;
 	uint32_t _at_command_ignore_cme_errors_uint[6];
-	uint_fast32_t _at_command_ignore_cme_errors_uint_count;
+	size_t _at_command_ignore_cme_errors_uint_count;
 };
 
-struct properties_tstrtstr {
-	struct zcbor_string _config_properties_tstrtstr_key;
-	struct zcbor_string _properties_tstrtstr;
+struct properties_tstrunion_ {
+	struct zcbor_string _config_properties_tstrunion_key;
+	union {
+		struct zcbor_string _properties_tstrunion_tstr;
+		bool _properties_tstrunion_bool;
+		int32_t _properties_tstrunion_int;
+		struct zcbor_string _properties_tstrunion_bstr;
+	};
+	enum {
+		_properties_tstrunion_tstr,
+		_properties_tstrunion_bool,
+		_properties_tstrunion_int,
+		_properties_tstrunion_bstr,
+	} _properties_tstrunion_choice;
 };
 
 struct config {
-	struct properties_tstrtstr _properties_tstrtstr[100];
-	uint_fast32_t _properties_tstrtstr_count;
+	struct properties_tstrunion_ _properties_tstrunion[100];
+	size_t _properties_tstrunion_count;
 };
 
 struct command {
@@ -59,7 +73,11 @@ struct command {
 
 struct commands {
 	struct command _commands__command[CONFIG_NRF_PROVISIONING_CBOR_RECORDS];
-	uint_fast32_t _commands__command_count;
+	size_t _commands__command_count;
 };
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* NRF_PROVISIONING_CBOR_DECODE_TYPES_H__ */

--- a/subsys/net/lib/nrf_provisioning/include/nrf_provisioning_cbor_encode.h
+++ b/subsys/net/lib/nrf_provisioning/include/nrf_provisioning_cbor_encode.h
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 /*
- * Generated using zcbor version 0.6.0
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 1234567890
  */
@@ -16,14 +16,25 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <string.h>
-#include "zcbor_encode.h"
 #include "nrf_provisioning_cbor_encode_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #if DEFAULT_MAX_QTY != CONFIG_NRF_PROVISIONING_CBOR_RECORDS
 #error "The type file was generated with a different default_max_qty than this file"
 #endif
 
-int cbor_encode_responses(uint8_t *payload, size_t payload_len, const struct responses *input,
-			  size_t *payload_len_out);
+
+int cbor_encode_responses(
+		uint8_t *payload, size_t payload_len,
+		const struct responses *input,
+		size_t *payload_len_out);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* NRF_PROVISIONING_CBOR_ENCODE_H__ */

--- a/subsys/net/lib/nrf_provisioning/include/nrf_provisioning_cbor_encode_types.h
+++ b/subsys/net/lib/nrf_provisioning/include/nrf_provisioning_cbor_encode_types.h
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 /*
- * Generated using zcbor version 0.6.0
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 1234567890
  */
@@ -15,8 +15,11 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
-#include <string.h>
-#include "zcbor_encode.h"
+#include <zcbor_common.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** Which value for --default-max-qty this file was created with.
  *
@@ -52,7 +55,11 @@ struct response {
 
 struct responses {
 	struct response _responses__response[CONFIG_NRF_PROVISIONING_CBOR_RECORDS];
-	uint_fast32_t _responses__response_count;
+	size_t _responses__response_count;
 };
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* NRF_PROVISIONING_CBOR_ENCODE_TYPES_H__ */

--- a/subsys/net/lib/nrf_provisioning/nrf_provisioning_cbor.cddl
+++ b/subsys/net/lib/nrf_provisioning/nrf_provisioning_cbor.cddl
@@ -17,7 +17,7 @@ at_command = (
 
 config = (
     object_type: 1,
-    properties: {0*100 tstr => tstr}    ; key value pair properties
+    properties: {0*100 tstr => tstr / bool / int / bstr}    ; key value pair properties
 )
 
 finished = (

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning.c
@@ -205,7 +205,6 @@ static int nrf_provisioning_set(const char *key, size_t len_rd,
 		return 0;
 	}
 
-
 	return -ENOENT;
 }
 

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_cbor_decode.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_cbor_decode.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 /*
- * Generated using zcbor version 0.6.0
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of CONFIG_NRF_PROVISIONING_CBOR_RECORDS
  */
@@ -21,8 +21,8 @@
 #endif
 
 static bool decode_at_command(zcbor_state_t *state, struct at_command *result);
-static bool decode_repeated_properties_tstrtstr(zcbor_state_t *state,
-						struct properties_tstrtstr *result);
+static bool decode_repeated_properties_tstrunion(zcbor_state_t *state,
+						 struct properties_tstrunion_ *result);
 static bool decode_config(zcbor_state_t *state, struct config *result);
 static bool decode_command(zcbor_state_t *state, struct command *result);
 static bool decode_commands(zcbor_state_t *state, struct commands *result);
@@ -43,23 +43,40 @@ static bool decode_at_command(zcbor_state_t *state, struct at_command *result)
 		      (zcbor_list_map_end_force_decode(state), false)) &&
 		     zcbor_list_end_decode(state))))));
 
-	if (!tmp_result)
+	if (!tmp_result) {
 		zcbor_trace();
+	}
 
 	return tmp_result;
 }
 
-static bool decode_repeated_properties_tstrtstr(zcbor_state_t *state,
-						struct properties_tstrtstr *result)
+static bool decode_repeated_properties_tstrunion(zcbor_state_t *state,
+						 struct properties_tstrunion_ *result)
 {
 	zcbor_print("%s\r\n", __func__);
+	bool int_res;
 
-	bool tmp_result =
-		((((zcbor_tstr_decode(state, (&(*result)._config_properties_tstrtstr_key)))) &&
-		  (zcbor_tstr_decode(state, (&(*result)._properties_tstrtstr)))));
+	bool tmp_result = ((
+		((zcbor_tstr_decode(state, (&(*result)._config_properties_tstrunion_key)))) &&
+		(zcbor_union_start_code(state) &&
+		 (int_res =
+			  ((((zcbor_tstr_decode(state, (&(*result)._properties_tstrunion_tstr)))) &&
+			    (((*result)._properties_tstrunion_choice = _properties_tstrunion_tstr),
+			     true)) ||
+			   (((zcbor_bool_decode(state, (&(*result)._properties_tstrunion_bool)))) &&
+			    (((*result)._properties_tstrunion_choice = _properties_tstrunion_bool),
+			     true)) ||
+			   (((zcbor_int32_decode(state, (&(*result)._properties_tstrunion_int)))) &&
+			    (((*result)._properties_tstrunion_choice = _properties_tstrunion_int),
+			     true)) ||
+			   (((zcbor_bstr_decode(state, (&(*result)._properties_tstrunion_bstr)))) &&
+			    (((*result)._properties_tstrunion_choice = _properties_tstrunion_bstr),
+			     true))),
+		  zcbor_union_end_code(state), int_res))));
 
-	if (!tmp_result)
+	if (!tmp_result) {
 		zcbor_trace();
+	}
 
 	return tmp_result;
 }
@@ -71,15 +88,16 @@ static bool decode_config(zcbor_state_t *state, struct config *result)
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (1)))) &&
 		   ((zcbor_map_start_decode(state) &&
-		     ((zcbor_multi_decode(0, 100, &(*result)._properties_tstrtstr_count,
-					  (zcbor_decoder_t *)decode_repeated_properties_tstrtstr,
-					  state, (&(*result)._properties_tstrtstr),
-					  sizeof(struct properties_tstrtstr))) ||
+		     ((zcbor_multi_decode(0, 100, &(*result)._properties_tstrunion_count,
+					  (zcbor_decoder_t *)decode_repeated_properties_tstrunion,
+					  state, (&(*result)._properties_tstrunion),
+					  sizeof(struct properties_tstrunion_))) ||
 		      (zcbor_list_map_end_force_decode(state), false)) &&
 		     zcbor_map_end_decode(state))))));
 
-	if (!tmp_result)
+	if (!tmp_result) {
 		zcbor_trace();
+	}
 
 	return tmp_result;
 }
@@ -108,8 +126,9 @@ static bool decode_command(zcbor_state_t *state, struct command *result)
 		  (zcbor_list_map_end_force_decode(state), false)) &&
 		 zcbor_list_end_decode(state))));
 
-	if (!tmp_result)
+	if (!tmp_result) {
 		zcbor_trace();
+	}
 
 	return tmp_result;
 }
@@ -127,8 +146,9 @@ static bool decode_commands(zcbor_state_t *state, struct commands *result)
 		    (zcbor_list_map_end_force_decode(state), false)) &&
 		   zcbor_list_end_decode(state))));
 
-	if (!tmp_result)
+	if (!tmp_result) {
 		zcbor_trace();
+	}
 
 	return tmp_result;
 }
@@ -136,7 +156,7 @@ static bool decode_commands(zcbor_state_t *state, struct commands *result)
 int cbor_decode_commands(const uint8_t *payload, size_t payload_len, struct commands *result,
 			 size_t *payload_len_out)
 {
-	zcbor_state_t states[6];
+	zcbor_state_t states[7];
 
 	zcbor_new_state(states, sizeof(states) / sizeof(zcbor_state_t), payload, payload_len, 1);
 

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_cbor_encode.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_cbor_encode.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 /*
- * Generated using zcbor version 0.6.0
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 1234567890
  */
@@ -34,8 +34,9 @@ static bool encode_error_response(zcbor_state_t *state, const struct error_respo
 		   ((zcbor_uint32_encode(state, (&(*input)._error_response_cme_error)))) &&
 		   ((zcbor_tstr_encode(state, (&(*input)._error_response_message)))))));
 
-	if (!tmp_result)
+	if (!tmp_result) {
 		zcbor_trace();
+	}
 
 	return tmp_result;
 }
@@ -47,8 +48,9 @@ static bool encode_at_response(zcbor_state_t *state, const struct at_response *i
 	bool tmp_result = (((((zcbor_uint32_put(state, (100)))) &&
 			     ((zcbor_tstr_encode(state, (&(*input)._at_response_message)))))));
 
-	if (!tmp_result)
+	if (!tmp_result) {
 		zcbor_trace();
+	}
 
 	return tmp_result;
 }
@@ -57,27 +59,28 @@ static bool encode_response(zcbor_state_t *state, const struct response *input)
 {
 	zcbor_print("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((zcbor_list_start_encode(state, 4) &&
-		   ((((zcbor_tstr_encode(state, (&(*input)._response__correlation)))) &&
-		     ((((*input)._response_union_choice == _response_union__error_response) ?
-			       ((encode_error_response(
-				       state, (&(*input)._response_union__error_response)))) :
-			       (((*input)._response_union_choice == _response_union__at_response) ?
-					((encode_at_response(
-						state, (&(*input)._response_union__at_response)))) :
-					(((*input)._response_union_choice ==
-					  _response_union__config_ack) ?
-						 ((zcbor_uint32_put(state, (101)))) :
-						 (((*input)._response_union_choice ==
-						   _response_union__finished_ack) ?
-							  ((zcbor_uint32_put(state, (102)))) :
-							  false)))))) ||
-		    (zcbor_list_map_end_force_encode(state), false)) &&
-		   zcbor_list_end_encode(state, 4))));
+	bool tmp_result = ((
+		(zcbor_list_start_encode(state, 4) &&
+		 ((((zcbor_tstr_encode(state, (&(*input)._response__correlation)))) &&
+		   ((((*input)._response_union_choice == _response_union__error_response)
+			     ? ((encode_error_response(
+				       state, (&(*input)._response_union__error_response))))
+			     : (((*input)._response_union_choice == _response_union__at_response)
+					? ((encode_at_response(
+						  state, (&(*input)._response_union__at_response))))
+					: (((*input)._response_union_choice ==
+					    _response_union__config_ack)
+						   ? ((zcbor_uint32_put(state, (101))))
+						   : (((*input)._response_union_choice ==
+						       _response_union__finished_ack)
+							      ? ((zcbor_uint32_put(state, (102))))
+							      : false)))))) ||
+		  (zcbor_list_map_end_force_encode(state), false)) &&
+		 zcbor_list_end_encode(state, 4))));
 
-	if (!tmp_result)
+	if (!tmp_result) {
 		zcbor_trace();
+	}
 
 	return tmp_result;
 }
@@ -86,8 +89,7 @@ static bool encode_responses(zcbor_state_t *state, const struct responses *input
 {
 	zcbor_print("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((zcbor_list_start_encode(state, DEFAULT_MAX_QTY) &&
+	bool tmp_result = (((zcbor_list_start_encode(state, DEFAULT_MAX_QTY) &&
 			     ((zcbor_multi_encode_minmax(
 				      1, DEFAULT_MAX_QTY, &(*input)._responses__response_count,
 				      (zcbor_encoder_t *)encode_response, state,
@@ -95,8 +97,9 @@ static bool encode_responses(zcbor_state_t *state, const struct responses *input
 			      (zcbor_list_map_end_force_encode(state), false)) &&
 			     zcbor_list_end_encode(state, DEFAULT_MAX_QTY))));
 
-	if (!tmp_result)
+	if (!tmp_result) {
 		zcbor_trace();
+	}
 
 	return tmp_result;
 }


### PR DESCRIPTION
Add boolean, integer and byte stream types to config command in .cddl file.
Regenerate cbor codecs with zcbor version 0.70 and update write_config() to support new config types.
Add test cases.