### PR TITLE
lib: lte_link_control: Fix persistent LTE connect failure

### DIFF
--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -652,7 +652,8 @@ static int connect_lte(bool blocking)
 	err = lte_lc_nw_reg_status_get(&reg_status);
 	if (err) {
 		LOG_ERR("Failed to get current registration status");
-		return -EFAULT;
+		err = -EFAULT;
+		goto exit;
 	}
 
 	/* Do not attempt to register with an LTE network if the device already is registered.


### PR DESCRIPTION
Fixed a bug which would have caused connecting to LTE always fail after a failing attempt to read the current LTE registration status. Recovery would have required a reboot, but fortunately reading the LTE registration status should always succeed.

NRF91-1905