### PR TITLE
Update SDC RX and TX PACKET COUNT description

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -163,9 +163,10 @@ config BT_CTLR_SDC_TX_PACKET_COUNT
 	range 1 20
 	help
 	  The number Link Layer ACL TX packets reserved per connection.
-	  With the default count, the application is able to refill the buffers during a connection event.
-	  That is, non-default values should only be used if reduced throughput is accepted, or when the CPU
-	  utilization is so high that the application is not able to provide data fast enough during connection events.
+	  With the default count, the application is expected to be able to refill the buffers during a connection event.
+	  That is, non-default values should only be used when the CPU utilization is so high 
+	  that the application is not able to provide data fast enough during connection events
+	  or if reduced throughput is accepted.
 
 config BT_CTLR_SDC_RX_PACKET_COUNT
 	int "Number of Link Layer ACL RX buffers"
@@ -173,9 +174,10 @@ config BT_CTLR_SDC_RX_PACKET_COUNT
 	range 1 20
 	help
 	  The number Link Layer ACL RX packets reserved per connection.
-	  With the default count, the application is able to empty the buffers during a connection event.
-	  That is, non-default values should only be used if reduced throughput is accepted, or when the CPU
-	  utilization is so high that the application is not able to read data fast enough during connection events.
+	  With the default count, the application is expected to be able to empty the buffers during a connection event.
+	  That is, non-default values (>2) should only be used when the CPU utilization is so high 
+	  that the application is not able to read data fast enough during connection events 
+	  or set to 1 if reduced throughput is accepted.
 
 config BT_CTLR_SDC_SCAN_BUFFER_COUNT
 	int "Number of buffers available in the scanner"


### PR DESCRIPTION
Update the description of BT_CTLR_SDC_RX_PACKET_COUNT and BT_CTLR_SDC_TX_PACKET_COUNT to make it more clear on that the packet count should only be increased if the application is not able to provide/read data to/from the controller. Or set the count  to lower value if the reduced throughput is accepted.

Signed-off-by: Hung Bui <hung.bui@nordicsemi.no>