### PR TITLE
drivers: wifi: Rejig RPU latency handling

### DIFF
--- a/drivers/wifi/nrf700x/src/qspi/inc/qspi_if.h
+++ b/drivers/wifi/nrf700x/src/qspi/inc/qspi_if.h
@@ -38,10 +38,10 @@ struct qspi_config {
 	bool enc_enabled;
 	struct k_sem lock;
 	unsigned int addrmask;
-	unsigned char qspi_slave_latency;
 #ifdef CONFIG_NRF700X_ON_QSPI
 	nrf_qspi_encryption_t p_cfg;
 #endif /*CONFIG_NRF700X_ON_QSPI*/
+	unsigned int freq;
 	int test_hlread;
 	char *test_name;
 	int test_start;
@@ -57,8 +57,7 @@ struct qspi_dev {
 	void *config;
 	int (*init)(struct qspi_config *config);
 	int (*write)(unsigned int addr, const void *data, int len);
-	int (*read)(unsigned int addr, void *data, int len);
-	int (*hl_read)(unsigned int addr, void *data, int len);
+	int (*read)(unsigned int addr, void *data, int len, unsigned int latency);
 	void (*hard_reset)(void);
 };
 
@@ -68,9 +67,7 @@ int qspi_init(struct qspi_config *config);
 
 int qspi_write(unsigned int addr, const void *data, int len);
 
-int qspi_read(unsigned int addr, void *data, int len);
-
-int qspi_hl_read(unsigned int addr, void *data, int len);
+int qspi_read(unsigned int addr, void *data, int len, unsigned int latency);
 
 int qspi_deinit(void);
 

--- a/drivers/wifi/nrf700x/src/qspi/inc/rpu_hw_if.h
+++ b/drivers/wifi/nrf700x/src/qspi/inc/rpu_hw_if.h
@@ -16,7 +16,7 @@
 #include <stdlib.h>
 #include <zephyr/drivers/gpio.h>
 
-enum {
+enum NRF70_MEM_REGIONS {
 	SYSBUS = 0,
 	EXT_SYS_BUS,
 	PBUS,
@@ -31,8 +31,11 @@ enum {
 	NUM_MEM_BLOCKS
 };
 
+#define RPU_LATENCY_PKT_RAM 0
+#define RPU_LATENCY_DEFAULT 1
+#define RPU_LATENCY_RF_REG 2
+
 extern char blk_name[][15];
-extern uint32_t rpu_7002_memmap[][3];
 
 int rpu_read(unsigned int addr, void *data, int len);
 int rpu_write(unsigned int addr, const void *data, int len);

--- a/drivers/wifi/nrf700x/src/qspi/inc/spi_if.h
+++ b/drivers/wifi/nrf700x/src/qspi/inc/spi_if.h
@@ -15,9 +15,7 @@ int spim_init(struct qspi_config *config);
 
 int spim_write(unsigned int addr, const void *data, int len);
 
-int spim_read(unsigned int addr, void *data, int len);
-
-int spim_hl_read(unsigned int addr, void *data, int len);
+int spim_read(unsigned int addr, void *data, int len, unsigned int latency);
 
 int spim_cmd_rpu_wakeup_fn(uint32_t data);
 

--- a/drivers/wifi/nrf700x/src/qspi/src/device.c
+++ b/drivers/wifi/nrf700x/src/qspi/src/device.c
@@ -21,15 +21,19 @@
 static struct qspi_config config;
 
 #if defined(CONFIG_NRF700X_ON_QSPI)
-static struct qspi_dev qspi = { .init = qspi_init,
+static struct qspi_dev qspi = {
+			 .config = &config,
+			 .init = qspi_init,
 			 .read = qspi_read,
 			 .write = qspi_write,
-			 .hl_read = qspi_hl_read};
+};
 #else
-static struct qspi_dev spim = { .init = spim_init,
+static struct qspi_dev spim = {
+			 .config = &config,
+			 .init = spim_init,
 			 .read = spim_read,
 			 .write = spim_write,
-			 .hl_read = spim_hl_read};
+};
 #endif
 
 struct qspi_config *qspi_defconfig(void)
@@ -46,8 +50,6 @@ struct qspi_config *qspi_defconfig(void)
 	config.test_name = "QSPI TEST";
 	config.test_hlread = false;
 	config.test_iteration = 0;
-
-	config.qspi_slave_latency = 0;
 
 	config.encryption = config.CMD_CNONCE = false;
 


### PR DESCRIPTION
RPU latency is dependent mainly on memory region and bus frequency, so, move the latency handling to RPU layer and let bus layers take latency as argument, basically this converts to data driven model, easier to maintain and read. For All higher layers this concept is abstracted.

This fixes a crash introduced in commit 2fb13ee104f("drivers: wifi: Move QSPI init to shim").