### PR TITLE
manifest: Update nrfxlib revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -141,7 +141,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 370d5515a70f54be0ea3fc197109b722b22c4f01
+      revision: 3266a76862560101783bf117b4d4939fce642783
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Update manifest of nrfxlib. Changes are in nrf_wifi which removes the extra line in logs.