### PR TITLE
wifi: Bin patch loader

### DIFF
--- a/drivers/wifi/nrf700x/CMakeLists.txt
+++ b/drivers/wifi/nrf700x/CMakeLists.txt
@@ -127,3 +127,16 @@ zephyr_compile_definitions_ifdef(CONFIG_NRF700X_ON_QSPI
 	-DNRF53_ERRATA_43_ENABLE_WORKAROUND=0
 	-DNRF52_ERRATA_215_ENABLE_WORKAROUND=0
 )
+
+# RPU FW patch binaries based on the selected configuration
+zephyr_compile_definitions_ifdef(CONFIG_NRF700X_SYSTEM_MODE
+	-DCONFIG_NRF_WIFI_FW_BIN=${OS_AGNOSTIC_BASE}/fw_bins/default/nrf70.bin
+)
+
+zephyr_compile_definitions_ifdef(CONFIG_NRF700X_RADIO_TEST
+	-DCONFIG_NRF_WIFI_FW_BIN=${OS_AGNOSTIC_BASE}/fw_bins/radio_test/nrf70.bin
+)
+
+zephyr_compile_definitions_ifdef(CONFIG_NRF700X_SCAN_ONLY
+	-DCONFIG_NRF_WIFI_FW_BIN=${OS_AGNOSTIC_BASE}/fw_bins/scan_only/nrf70.bin
+)

--- a/drivers/wifi/nrf700x/Kconfig
+++ b/drivers/wifi/nrf700x/Kconfig
@@ -8,7 +8,7 @@
 DT_COMPAT_NORDIC_NRF700X_QSPI := nordic,nrf700x-qspi
 DT_COMPAT_NORDIC_NRF700X_SPI := nordic,nrf700x-spi
 
-config WIFI_NRF700X
+menuconfig WIFI_NRF700X
 	bool "nRF700x driver"
 	depends on WIFI
 	select NET_L2_WIFI_MGMT if NETWORKING
@@ -29,15 +29,44 @@ config WIFI_NRF700X_BUS_LOG_LEVEL
 	# Enable error by default
 	default 1
 
-# Hidden define for internal use
-config NRF700X_SCAN_ONLY_MODE
-	bool
-	default y if !WPA_SUPP && !NRF700X_RADIO_TEST
+choice NRF700X_OPER_MODES
+	bool "nRF700x operating modes"
+	default NRF700X_SYSTEM_MODE if WPA_SUPP
+	default NRF700X_SCAN_ONLY if !WPA_SUPP
+	help
+	  Select the operating mode of the nRF700x driver
+
+config NRF700X_SYSTEM_MODE
+	bool "Enable nRF700X system mode"
+	depends on WPA_SUPP
+	help
+	  Select this option to enable system mode of the nRF700x driver
+
+config NRF700X_SCAN_ONLY
+	bool "Enable nRF700X scan only mode"
+	help
+	  Select this option to enable scan only mode of the nRF700x driver
+
+config NRF700X_RADIO_TEST
+	bool "Radio test mode of the nRF700x driver"
+
+endchoice
+
+if NRF700X_SYSTEM_MODE
 
 config NRF700X_STA_MODE
 	bool "Enable nRF700X STA mode"
-	depends on WPA_SUPP
-	default y if WPA_SUPP
+	default y
+	help
+		Select this option to enable STA mode of the nRF700x driver
+
+config NRF700X_AP_MODE
+	bool "Enable Access point mode"
+
+config NRF700X_P2P_MODE
+	bool "Enable P2P support in driver"
+
+endif # NRF700X_SYSTEM_MODE
 
 config NRF_WIFI_IF_AUTO_START
 	bool "Enable Wi-Fi interface auto start on boot"
@@ -118,21 +147,9 @@ config NRF700X_MAX_TX_PENDING_QLEN
 	int "Maximum number of pending TX packets"
 	default 18
 
-config NRF700X_RADIO_TEST
-	bool "Radio test mode of the nRF700x driver"
-	depends on !NRF700X_STA_MODE && !NRF700X_AP_MODE && !NRF700X_P2P_MODE && !NRF700X_DATA_TX
-
-config NRF700X_AP_MODE
-	bool "Enable Access point mode"
-	select WPA_SUPP
-
-config NRF700X_P2P_MODE
-	bool "Enable P2P support in driver"
-	select WPA_SUPP
-
 config NRF700X_DATA_TX
 	bool "Enable TX data path in the driver"
-	default y if NRF700X_STA_MODE || NRF700X_AP_MODE || NRF700X_P2P_MODE
+	default y if NRF700X_SYSTEM_MODE
 
 config NRF700X_UTIL
 	depends on SHELL

--- a/drivers/wifi/nrf700x/src/fw_load.c
+++ b/drivers/wifi/nrf700x/src/fw_load.c
@@ -23,32 +23,65 @@
 #endif /* CONFIG_NRF_WIFI_PATCHES_EXT_FLASH */
 
 #include <fmac_main.h>
-#include <rpu_fw_patches.h>
+
+/* INCBIN macro Taken from https://gist.github.com/mmozeiko/ed9655cf50341553d282 */
+#define STR2(x) #x
+#define STR(x) STR2(x)
+
+#ifdef __APPLE__
+#define USTR(x) "_" STR(x)
+#else
+#define USTR(x) STR(x)
+#endif
+
+#ifdef _WIN32
+#define INCBIN_SECTION ".rdata, \"dr\""
+#elif defined __APPLE__
+#define INCBIN_SECTION "__TEXT,__const"
+#else
+#define INCBIN_SECTION ".rodata"
+#endif
+
+/* this aligns start address to 16 and terminates byte array with explicit 0
+ * which is not really needed, feel free to change it to whatever you want/need
+ */
+#define INCBIN(prefix, name, file) \
+	__asm__(".section " INCBIN_SECTION "\n" \
+			".global " USTR(prefix) "_" STR(name) "_start\n" \
+			".balign 16\n" \
+			USTR(prefix) "_" STR(name) "_start:\n" \
+			".incbin \"" file "\"\n" \
+			\
+			".global " STR(prefix) "_" STR(name) "_end\n" \
+			".balign 1\n" \
+			USTR(prefix) "_" STR(name) "_end:\n" \
+			".byte 0\n" \
+	); \
+	extern __aligned(16)    const char prefix ## _ ## name ## _start[]; \
+	extern                  const char prefix ## _ ## name ## _end[];
+
+INCBIN(_bin, nrf70_fw, STR(CONFIG_NRF_WIFI_FW_BIN));
 
 enum nrf_wifi_status nrf_wifi_fw_load(void *rpu_ctx)
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
-	struct nrf_wifi_fmac_fw_info fw_info;
+	struct nrf_wifi_fmac_fw_info fw_info = { 0 };
 #if defined(CONFIG_NRF_WIFI_PATCHES_EXT_FLASH) && defined(CONFIG_NORDIC_QSPI_NOR)
 	const struct device *flash_dev = DEVICE_DT_GET(DT_INST(0, nordic_qspi_nor));
 #endif /* CONFIG_NRF_WIFI_PATCHES_EXT_FLASH */
 
-	memset(&fw_info, 0, sizeof(fw_info));
-	fw_info.lmac_patch_pri.data = (void *) nrf_wifi_lmac_patch_pri_bimg;
-	fw_info.lmac_patch_pri.size = sizeof(nrf_wifi_lmac_patch_pri_bimg);
-	fw_info.lmac_patch_sec.data = (void *) nrf_wifi_lmac_patch_sec_bin;
-	fw_info.lmac_patch_sec.size = sizeof(nrf_wifi_lmac_patch_sec_bin);
-	fw_info.umac_patch_pri.data = (void *) nrf_wifi_umac_patch_pri_bimg;
-	fw_info.umac_patch_pri.size = sizeof(nrf_wifi_umac_patch_pri_bimg);
-	fw_info.umac_patch_sec.data = (void *) nrf_wifi_umac_patch_sec_bin;
-	fw_info.umac_patch_sec.size = sizeof(nrf_wifi_umac_patch_sec_bin);
+	status = nrf_wifi_fmac_fw_parse(rpu_ctx, (const uint8_t *)_bin_nrf70_fw_start,
+					_bin_nrf70_fw_end - _bin_nrf70_fw_start, &fw_info);
+	if (status != NRF_WIFI_STATUS_SUCCESS) {
+		LOG_ERR("%s: nrf_wifi_fmac_fw_parse failed", __func__);
+		return status;
+	}
 
 #if defined(CONFIG_NRF_WIFI_PATCHES_EXT_FLASH) && defined(CONFIG_NORDIC_QSPI_NOR)
 	nrf_qspi_nor_xip_enable(flash_dev, true);
 #endif /* CONFIG_NRF_WIFI */
 	/* Load the FW patches to the RPU */
-	status = nrf_wifi_fmac_fw_load(rpu_ctx,
-				       &fw_info);
+	status = nrf_wifi_fmac_fw_load(rpu_ctx, &fw_info);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		printf("%s: nrf_wifi_fmac_fw_load failed\n", __func__);

--- a/drivers/wifi/nrf700x/src/fw_load.c
+++ b/drivers/wifi/nrf700x/src/fw_load.c
@@ -12,7 +12,6 @@
  * by disabling XIP and enabling it again after use. This means no LOG_* macros
  * (buffered) or buffered printk can be used in this file, else it will crash.
  */
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -21,6 +20,9 @@
 #if defined(CONFIG_NRF_WIFI_PATCHES_EXT_FLASH) && defined(CONFIG_NORDIC_QSPI_NOR)
 #include <zephyr/drivers/flash/nrf_qspi_nor.h>
 #endif /* CONFIG_NRF_WIFI_PATCHES_EXT_FLASH */
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(wifi_nrf, CONFIG_WIFI_NRF700X_LOG_LEVEL);
 
 #include <fmac_main.h>
 
@@ -84,7 +86,7 @@ enum nrf_wifi_status nrf_wifi_fw_load(void *rpu_ctx)
 	status = nrf_wifi_fmac_fw_load(rpu_ctx, &fw_info);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		printf("%s: nrf_wifi_fmac_fw_load failed\n", __func__);
+		LOG_ERR("%s: nrf_wifi_fmac_fw_load failed", __func__);
 	}
 
 #if defined(CONFIG_NRF_WIFI_PATCHES_EXT_FLASH) && defined(CONFIG_NORDIC_QSPI_NOR)

--- a/west.yml
+++ b/west.yml
@@ -141,7 +141,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: e3e83c0a8969aceb553c648f4bb140f005648f92
+      revision: 712a6aac342a70ebec5d84bb4b670241684fe405
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Removes C based patch headers support and instead adds support for binary based patch.