### PR TITLE
Add crypto-related configuration options

### DIFF
--- a/modules/tfm/zephyr/CMakeLists.txt
+++ b/modules/tfm/zephyr/CMakeLists.txt
@@ -160,6 +160,13 @@ if (CONFIG_TFM_NRF_PROVISIONING)
     )
 endif()
 
+if (CONFIG_TFM_PSA_FRAMEWORK_HAS_MM_IOVEC)
+  set_property(TARGET zephyr_property_target
+    APPEND PROPERTY TFM_CMAKE_OPTIONS
+    -DPSA_FRAMEWORK_HAS_MM_IOVEC=ON
+    )
+endif()
+
 if (CONFIG_NFCT_PINS_AS_GPIOS)
   set_property(TARGET zephyr_property_target
   APPEND PROPERTY TFM_CMAKE_OPTIONS

--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -356,4 +356,12 @@ config TFM_NRF_PROVISIONING
 	  provisioning lifecycle state in order to boot. See provisioning
 	  guide for more details.
 
+config TFM_PSA_FRAMEWORK_HAS_MM_IOVEC
+	bool
+	prompt "TF-M MM-IOVEC"
+	depends on TFM_ISOLATION_LEVEL = 1
+	help
+	  Memory-mapped iovecs provide direct mapping of client input and output vectors into
+	  the Secure Partition.
+
 endif # BUILD_WITH_TFM

--- a/subsys/nrf_security/Kconfig.psa
+++ b/subsys/nrf_security/Kconfig.psa
@@ -74,6 +74,16 @@ config MBEDTLS_USE_PSA_CRYPTO
 	help
 	  Corresponds to MBEDTLS_USE_PSA_CRYPTO setting in mbed TLS config file.
 
+config MBEDTLS_PSA_KEY_SLOT_COUNT
+	int "Number of PSA key slots available"
+	default 32
+	range 1 64
+	help
+	  Describes the number of available PSA key slots. A key slot is used in PSA
+	  for each transparent key in use. So this number defines the sum of volatile and
+	  transparent keys that we can have open concurrently.
+	  The default value comes from MBedTLS.
+
 config PSA_ITS_ENCRYPTED
 	bool
 	depends on MBEDTLS_PSA_CRYPTO_STORAGE_C

--- a/subsys/nrf_security/cmake/psa_crypto_config.cmake
+++ b/subsys/nrf_security/cmake/psa_crypto_config.cmake
@@ -193,6 +193,7 @@ kconfig_check_and_set_base_to_one(MBEDTLS_PSA_CRYPTO_STORAGE_C)
 kconfig_check_and_set_base_to_one(MBEDTLS_PSA_CRYPTO_DRIVERS)
 kconfig_check_and_set_base_to_one(MBEDTLS_PSA_CRYPTO_CLIENT)
 kconfig_check_and_set_base_to_one(MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG)
+kconfig_check_and_set_base_int(MBEDTLS_PSA_KEY_SLOT_COUNT)
 
 # TF-M
 kconfig_check_and_set_base_to_one(MBEDTLS_PSA_CRYPTO_SPM)

--- a/subsys/nrf_security/configs/legacy_crypto_config.h.template
+++ b/subsys/nrf_security/configs/legacy_crypto_config.h.template
@@ -3091,7 +3091,7 @@ it is (2^48 - 1), our restriction is :  (int - 0xFFFF - 0xF).*/
  * If this option is unset, the library will fall back to a default value of
  * 32 keys.
  */
-//#define MBEDTLS_PSA_KEY_SLOT_COUNT 32
+#cmakedefine MBEDTLS_PSA_KEY_SLOT_COUNT              @MBEDTLS_PSA_KEY_SLOT_COUNT@
 
 /* SSL Cache options */
 //#define MBEDTLS_SSL_CACHE_DEFAULT_TIMEOUT       86400 /**< 1 day  */

--- a/subsys/nrf_security/configs/psa_crypto_config.h.template
+++ b/subsys/nrf_security/configs/psa_crypto_config.h.template
@@ -223,6 +223,7 @@
 #cmakedefine MBEDTLS_PSA_CRYPTO_DRIVERS                         @MBEDTLS_PSA_CRYPTO_DRIVERS@
 #cmakedefine MBEDTLS_PSA_CRYPTO_CLIENT
 #cmakedefine MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG
+#cmakedefine MBEDTLS_PSA_KEY_SLOT_COUNT                         @MBEDTLS_PSA_KEY_SLOT_COUNT@
 
 /* TF-M */
 #cmakedefine MBEDTLS_PSA_CRYPTO_SPM


### PR DESCRIPTION
Adds a configuration option to set the TF-M MM-IOVEC through Kconfig.

Also adds a configuration to set MBEDTLS_PSA_KEY_SLOT_COUNT through Kconfig.