### PR TITLE
test-spec: Trigger Sidewalk on nrf_security changes

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -471,3 +471,7 @@
   - "subsys/fw_info/*"
   - "subsys/pcd/**/*"
   - "subsys/bluetooth/controller/*"
+  - any:
+      - "subsys/nrf_security/**/*"
+      - "!subsys/nrf_security/doc/**/*"
+      - "!subsys/nrf_security/*.rst"


### PR DESCRIPTION
Add subsys/nrf_security entry in test-spec.yml file as Sidewalk relays on crypto