### PR TITLE
applications: nrf5340_audio: Audio datapath sync improvements

### DIFF
--- a/applications/nrf5340_audio/src/audio/audio_datapath.h
+++ b/applications/nrf5340_audio/src/audio/audio_datapath.h
@@ -57,10 +57,9 @@ void audio_datapath_pres_delay_us_get(uint32_t *delay_us);
  * @param size Size of audio data frame in bytes
  * @param sdu_ref_us ISO timestamp reference from BLE controller
  * @param bad_frame Indicating if the audio frame is bad or not
- * @param recv_frame_ts_us Timestamp of when audio frame was received
  */
-void audio_datapath_stream_out(const uint8_t *buf, size_t size, uint32_t sdu_ref_us, bool bad_frame,
-			       uint32_t recv_frame_ts_us);
+void audio_datapath_stream_out(const uint8_t *buf, size_t size, uint32_t sdu_ref_us,
+			       bool bad_frame);
 
 /**
  * @brief Start the audio datapath module

--- a/applications/nrf5340_audio/src/audio/streamctrl_broadcast_sink.c
+++ b/applications/nrf5340_audio/src/audio/streamctrl_broadcast_sink.c
@@ -23,14 +23,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(streamctrl_broadcast_sink, CONFIG_STREAMCTRL_LOG_LEVEL);
 
-struct ble_iso_data {
-	uint8_t data[CONFIG_BT_ISO_RX_MTU];
-	size_t data_size;
-	bool bad_frame;
-	uint32_t sdu_ref;
-	uint32_t recv_frame_ts;
-} __packed;
-
 ZBUS_SUBSCRIBER_DEFINE(button_evt_sub, CONFIG_BUTTON_MSG_SUB_QUEUE_SIZE);
 ZBUS_SUBSCRIBER_DEFINE(le_audio_evt_sub, CONFIG_LE_AUDIO_MSG_SUB_QUEUE_SIZE);
 


### PR DESCRIPTION
- Changes to counter resets, so that the sync mechanisms are run less often.
- Change how the sync error/offset is calculated.