### PR TITLE
bluetooth: controller: add vs command set_power_control_request_params

### DIFF
--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -639,6 +639,8 @@ static void vs_supported_commands(sdc_hci_vs_supported_vs_commands_t *cmds)
 	cmds->write_remote_tx_power = 1;
 	cmds->set_auto_power_control_request_param = 1;
 	cmds->set_power_control_apr_handling = 1;
+	cmds->set_power_control_request_params = 1;
+
 #endif
 }
 #endif	/* CONFIG_BT_HCI_VS */
@@ -1555,6 +1557,8 @@ static uint8_t vs_cmd_put(uint8_t const * const cmd,
 		return sdc_hci_cmd_vs_set_auto_power_control_request_param((void *)cmd_params);
 	case SDC_HCI_OPCODE_CMD_VS_SET_POWER_CONTROL_APR_HANDLING:
 		return sdc_hci_cmd_vs_set_power_control_apr_handling((void *)cmd_params);
+	case SDC_HCI_OPCODE_CMD_VS_SET_POWER_CONTROL_REQUEST_PARAMS:
+		return sdc_hci_cmd_vs_set_power_control_request_params((void *)cmd_params);
 #endif
 	default:
 		return BT_HCI_ERR_UNKNOWN_CMD;


### PR DESCRIPTION
This HCI command will replace the existing commands vs_set_auto_power_control_request_param and
vs_set_power_control_apr_handling. The two existing commands are interdependent.