### PR TITLE
identity_key: Make identity key abstraction independent of HW backend

### DIFF
--- a/include/identity_key.h
+++ b/include/identity_key.h
@@ -71,6 +71,16 @@ bool identity_key_is_written(void);
  */
 int identity_key_read(uint8_t key[IDENTITY_KEY_SIZE_BYTES]);
 
+/** @brief Function to clear out an identity key after usage
+ *
+ * @details This function will clear out the memory of an identity key.
+ *          This must be called after the identity key is used to ensure that
+ *          it is not leaked in the system.
+ *
+ * @param[in,out]   key         Key to clear out
+ */
+void identity_key_free(uint8_t key[IDENTITY_KEY_SIZE_BYTES]);
+
 /**
  * @brief Function to write a random identity key to KMU
  *

--- a/lib/identity_key/identity_key.c
+++ b/lib/identity_key/identity_key.c
@@ -171,3 +171,8 @@ int identity_key_read(uint8_t key[IDENTITY_KEY_SIZE_BYTES])
 
 	return IDENTITY_KEY_SUCCESS;
 }
+
+void identity_key_free(uint8_t key[IDENTITY_KEY_SIZE_BYTES])
+{
+	nrf_cc3xx_platform_identity_key_free(key);
+}

--- a/samples/keys/identity_key_usage/src/main.c
+++ b/samples/keys/identity_key_usage/src/main.c
@@ -29,12 +29,6 @@ int main(void)
 	uint8_t key[IDENTITY_KEY_SIZE_BYTES];
 	size_t olen;
 
-	err = nrf_cc3xx_platform_init();
-	if (err != NRF_CC3XX_PLATFORM_SUCCESS) {
-		LOG_INF("nrf_cc3xx_platform_init returned error: %d", err);
-		return 0;
-	}
-
 	LOG_INF("Initializing PSA crypto.");
 
 	status = psa_crypto_init();
@@ -68,7 +62,7 @@ int main(void)
 	}
 
 	/* Clear out the local copy of the key to prevent leakage */
-	nrf_cc3xx_platform_identity_key_free(key);
+	identity_key_free(key);
 
 	LOG_INF("Exporting the public key corresponding to the identity key.");
 	status = psa_export_public_key(key_id_out, m_pub_key, sizeof(m_pub_key), &olen);


### PR DESCRIPTION
Add identity_key_free function which calls the
nrf_cc3xx_platform_identity_key_free function.
This makes the identity_key library a complete abstraction over the
nrf_cc3xx_platform library.

Make the identity_key_usage sample independent of the HW backend for
the identity key.
Remove the call for nrf_cc3xx_platform_init as this is handled by
existing initialization code, which also addresses initialization
without entropy.
Use identity_key library function for clearing identity key from
memory.
