### PR TITLE
doc: Change securely generating credentials link

### DIFF
--- a/doc/nrf/external_comp/nrf_cloud.rst
+++ b/doc/nrf/external_comp/nrf_cloud.rst
@@ -123,7 +123,7 @@ A device can successfully connect to `nRF Cloud`_ using MQTT if the following re
 
   For more details about the scripts, refer to the `nRF Cloud Utilities documentation`_.
 
-  See `Securely generating credentials on the nRF9160`_  and `nRF Cloud Provisioning`_ for more details.
+  See `Securely generating credentials`_  and `nRF Cloud Provisioning`_ for more details.
 
 
 |NCS| library support

--- a/doc/nrf/includes/nrf_cloud_rest_sample_requirements.txt
+++ b/doc/nrf/includes/nrf_cloud_rest_sample_requirements.txt
@@ -4,7 +4,7 @@ This sample uses the `nRF Cloud REST API`_, which requires that your device has 
 
 .. requirement_keysign_moreinfo_start
 
-(See `nRF Cloud REST API`_ and `Securely generating credentials on the nRF9160`_ for more details on this requirement).
+(See `nRF Cloud REST API`_ and `Securely generating credentials`_ for more details on this requirement).
 
 If you are using nRF9160 DK, modem version v1.3.x or later is required.
 Your nRF9160 DK may ship with modem firmware older than v1.3.x, so verify that you have the latest installed.
@@ -20,7 +20,7 @@ To obtain and register a valid signing key, you can do one of the following:
 
 * Provision your device on nRF Cloud using Just-In-Time Provisioning (JITP) (detailed below).
 * Provision your device on nRF Cloud with preconnect provisioning (detailed in `nRF Cloud Provisioning`_).
-* Install or generate a private key on your device and register its public key with nRF Cloud (detailed in `Securely generating credentials on the nRF9160`_).
+* Install or generate a private key on your device and register its public key with nRF Cloud (detailed in `Securely generating credentials`_).
 
 To provision your device on nRF Cloud using JITP, complete the following steps:
 

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -1026,7 +1026,7 @@
 .. _`nRF Cloud FOTA`: https://docs.nrfcloud.com/Devices/FirmwareUpdate/FOTAOverview.html
 .. _`nRF Cloud MQTT FOTA`: https://docs.nrfcloud.com/Devices/FirmwareUpdate/FOTAOverview.html#mqtt-job-execution-notifications
 .. _`nRF Cloud Getting Started FOTA documentation`: https://docs.nrfcloud.com/Devices/FirmwareUpdate/FOTATutorial.html
-.. _`Securely generating credentials on the nRF9160`: https://docs.nrfcloud.com/Devices/Security/Credentials.html
+.. _`Securely generating credentials`: https://docs.nrfcloud.com/Devices/Security/Credentials.html
 .. _`nRF Cloud provisioning configuration`: https://docs.nrfcloud.com/SecurityServices/ProvisioningService/ProvisioningConfiguration/ProvisioningConfigurationPortal.html
 .. _`nRF Cloud Provisioning Service`: https://docs.nrfcloud.com/SecurityServices/ProvisioningService/ProvisioningOverview.html
 .. _`nRF Cloud REST API`:


### PR DESCRIPTION
Change the securely generated credentials link
to match with the cloud document, as now we have
support for nRF9161.

NCSDK-23335