### PR TITLE
ci: manifest: update checkout action and do not keep credentials

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -13,11 +13,12 @@ jobs:
     name: Manifest
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: ncs/nrf
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Manifest
         uses: zephyrproject-rtos/action-manifest@16c4cfa380ae2b6fa3daddb1a35032e69422a20f


### PR DESCRIPTION
Use the latest checkout action, and do not keep GH credentials on the file system after checkout (they are not needed).