### PR TITLE
applications: nrf5340_audio: Reduce PA_SYNC_SKIP

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/bt_management/scanning/bt_mgmt_scan_for_broadcast.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/scanning/bt_mgmt_scan_for_broadcast.c
@@ -24,7 +24,7 @@ LOG_MODULE_DECLARE(bt_mgmt_scan);
  * an invalid broadcast ID.
  */
 #define INVALID_BROADCAST_ID 0xFFFFFFFF
-#define PA_SYNC_SKIP	     5
+#define PA_SYNC_SKIP	     2
 /* Similar to retries for connections */
 #define SYNC_RETRY_COUNT     6
 


### PR DESCRIPTION
- Reducing PA_SYNC_SKIP from 5 to 2

Since the timeout is set to PA_interval * 6 we shouldn't set the PA_SYNC_SKIP to 5, meaning we only have one shot at getting the PA per every 6 intervals