### PR TITLE
bluetooth: Add VS cmd for the connection event trigger feature

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -345,6 +345,16 @@ config BT_CTLR_LE_POWER_CONTROL
 	  Enable support for LE Power Control feature that defined in the Bluetooth
 	  Core specification, Version 5.3 | Vol 6, Part B, Section 4.6.31.
 
+config BT_CTLR_SDC_EVENT_TRIGGER
+	bool "Event Trigger"
+	help
+	  Enable support for the Event Trigger feature.
+	  The event trigger is a proprietary SDC feature which can be used
+	  to perform tasks in synchronization with radio activity.
+	  When enabled, this feature will trigger a (D)PPI task at the start of radio events.
+	  When used for connections, the connection event trigger can be configured to trigger
+	  every N connection events starting from a given connection event counter.
+
 config BT_CTLR_SDC_ISO_RX_PDU_BUFFER_COUNT
 	int "BT_CTLR_SDC_ISO_RX_PDU_BUFFER_COUNT"
 	depends on BT_CTLR_SYNC_ISO || BT_CTLR_CONN_ISO

--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -644,6 +644,14 @@ static void vs_supported_commands(sdc_hci_vs_supported_vs_commands_t *cmds)
 #if defined(CONFIG_BT_CENTRAL)
 	cmds->central_acl_event_spacing_set = 1;
 #endif
+
+#if defined(CONFIG_BT_CTLR_SDC_EVENT_TRIGGER)
+	cmds->set_conn_event_trigger = 1;
+#endif
+
+#if defined(CONFIG_BT_CONN)
+	cmds->get_next_conn_event_counter = 1;
+#endif
 }
 #endif	/* CONFIG_BT_HCI_VS */
 
@@ -1565,6 +1573,16 @@ static uint8_t vs_cmd_put(uint8_t const * const cmd,
 #ifdef CONFIG_BT_CENTRAL
 	case SDC_HCI_OPCODE_CMD_VS_CENTRAL_ACL_EVENT_SPACING_SET:
 		return sdc_hci_cmd_vs_central_acl_event_spacing_set((void *)cmd_params);
+#endif
+#if defined(CONFIG_BT_CTLR_SDC_EVENT_TRIGGER)
+	case SDC_HCI_OPCODE_CMD_VS_SET_CONN_EVENT_TRIGGER:
+		return sdc_hci_cmd_vs_set_conn_event_trigger((void *)cmd_params);
+#endif
+#if defined(CONFIG_BT_CONN)
+	case SDC_HCI_OPCODE_CMD_VS_GET_NEXT_CONN_EVENT_COUNTER:
+		*param_length_out += sizeof(sdc_hci_cmd_vs_get_next_conn_event_counter_return_t);
+		return sdc_hci_cmd_vs_get_next_conn_event_counter((void *)cmd_params,
+							    (void *)event_out_params);
 #endif
 	default:
 		return BT_HCI_ERR_UNKNOWN_CMD;


### PR DESCRIPTION
Connection event triggers are an old feature from SoftDevice which we've decided to port to NCS.