### PR TITLE
manifest: Bring in ZSAI to sdk-zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: ff85910bf8ed1aac0571bca0e7f206782234efbb
+      revision: pull/1373/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Brings in support for Zephyr Storage Access Interface.