### PR TITLE
treewide: Replace all uses of CONCAT with _CONCAT

### DIFF
--- a/drivers/serial/uart_ipc.c
+++ b/drivers/serial/uart_ipc.c
@@ -191,7 +191,7 @@ static const struct uart_driver_api uart_ipc_api = {
 };
 
 #define UART_IPC_DEVICE(idx)                                                                    \
-	static const struct uart_ipc_config CONCAT(uart_ipc_config_, idx) = {                   \
+	static const struct uart_ipc_config _CONCAT(uart_ipc_config_, idx) = {                  \
 		.ipc = DEVICE_DT_GET(DT_INST_PHANDLE(idx, ipc)),                                \
 		.ept_name = DT_INST_PROP(idx, ept_name)                                         \
 	};                                                                                      \
@@ -199,13 +199,13 @@ static const struct uart_driver_api uart_ipc_api = {
 	RING_BUF_DECLARE(ipc_uart_tx_buf_##idx, CONFIG_IPC_UART_TX_RING_BUFFER_SIZE);           \
 	RING_BUF_DECLARE(ipc_uart_rx_buf_##idx, CONFIG_IPC_UART_RX_RING_BUFFER_SIZE);           \
                                                                                                 \
-	static struct uart_ipc_data CONCAT(uart_ipc_data_, idx) = {                             \
-		.tx_ringbuf = &CONCAT(ipc_uart_tx_buf_, idx),                                   \
-		.rx_ringbuf = &CONCAT(ipc_uart_rx_buf_, idx)                                    \
+	static struct uart_ipc_data _CONCAT(uart_ipc_data_, idx) = {                            \
+		.tx_ringbuf = &_CONCAT(ipc_uart_tx_buf_, idx),                                  \
+		.rx_ringbuf = &_CONCAT(ipc_uart_rx_buf_, idx)                                   \
 	};                                                                                      \
                                                                                                 \
 	DEVICE_DT_INST_DEFINE(idx, ipc_uart_init, NULL,                                         \
-			      &CONCAT(uart_ipc_data_, idx), &CONCAT(uart_ipc_config_, idx),     \
+			      &_CONCAT(uart_ipc_data_, idx), &_CONCAT(uart_ipc_config_, idx),   \
 			      POST_KERNEL, CONFIG_IPC_UART_INIT_PRIORITY, &uart_ipc_api);
 
 DT_INST_FOREACH_STATUS_OKAY(UART_IPC_DEVICE)

--- a/include/bluetooth/conn_ctx.h
+++ b/include/bluetooth/conn_ctx.h
@@ -34,9 +34,9 @@ extern "C" {
 			  (_max_clients),                                      \
 			  CONFIG_BT_CONN_CTX_MEM_BUF_ALIGN);                   \
 	K_MUTEX_DEFINE(_name##_mutex);                                         \
-	static struct bt_conn_ctx_lib CONCAT(_name, _ctx_lib) =                \
+	static struct bt_conn_ctx_lib _CONCAT(_name, _ctx_lib) =                \
 	{                                                                      \
-		.mem_slab = &CONCAT(_name, _mem_slab),                         \
+		.mem_slab = &_CONCAT(_name, _mem_slab),                         \
 		.mutex = &_name##_mutex                                        \
 	}
 

--- a/include/bluetooth/services/hids.h
+++ b/include/bluetooth/services/hids.h
@@ -57,7 +57,7 @@ extern "C" {
 	static struct bt_hids _name =				       \
 	{								       \
 		.gp = BT_GATT_POOL_INIT(CONFIG_BT_HIDS_ATTR_MAX),	       \
-		.conn_ctx = &CONCAT(_name, _ctx_lib),			       \
+		.conn_ctx = &_CONCAT(_name, _ctx_lib),			       \
 	}
 
 

--- a/include/bluetooth/services/nsms.h
+++ b/include/bluetooth/services/nsms.h
@@ -107,27 +107,27 @@ ssize_t bt_nsms_status_read(struct bt_conn *conn,
  * @param _len_max     Maximal size of the message. The size of the message buffer.
  */
 #define BT_NSMS_DEF(_nsms, _name, _slevel, _status_init, _len_max)                      \
-	static K_MUTEX_DEFINE(CONCAT(_nsms, _status_mtx));                              \
-	static char CONCAT(_nsms, _status_buf)[_len_max] = _status_init;                \
-	static const struct bt_nsms_status_str CONCAT(_nsms, _status_str) = {           \
-		.mtx = &CONCAT(_nsms, _status_mtx),                                     \
+	static K_MUTEX_DEFINE(_CONCAT(_nsms, _status_mtx));                             \
+	static char _CONCAT(_nsms, _status_buf)[_len_max] = _status_init;               \
+	static const struct bt_nsms_status_str _CONCAT(_nsms, _status_str) = {          \
+		.mtx = &_CONCAT(_nsms, _status_mtx),                                    \
 		.size = (_len_max),                                                     \
-		.buf = CONCAT(_nsms, _status_buf)                                       \
+		.buf = _CONCAT(_nsms, _status_buf)                                      \
 	};                                                                              \
-	BT_NSMS_SERVICE_DEF(CONCAT(_nsms, _svc),                                        \
+	BT_NSMS_SERVICE_DEF(_CONCAT(_nsms, _svc),                                       \
 		BT_GATT_PRIMARY_SERVICE(BT_UUID_NSMS_SERVICE),                          \
 			BT_GATT_CHARACTERISTIC(BT_UUID_NSMS_STATUS,                     \
 					       BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY, \
 					       _BT_NSMS_CH_READ_PERM(_slevel),          \
 					       bt_nsms_status_read,                     \
 					       NULL,                                    \
-					       (void *)&CONCAT(_nsms, _status_str)),    \
+					       (void *)&_CONCAT(_nsms, _status_str)),   \
 			BT_GATT_CCC(NULL, _BT_NSMS_CH_READ_PERM(_slevel) |              \
 					  _BT_NSMS_CH_WRITE_PERM(_slevel)),             \
 			BT_GATT_CUD(_name, _BT_NSMS_CH_READ_PERM(_slevel)),             \
 	);                                                                              \
 	static const struct bt_nsms _nsms = {                                           \
-		.status_attr = &CONCAT(_nsms, _svc).attrs[2],                           \
+		.status_attr = &_CONCAT(_nsms, _svc).attrs[2],                          \
 	}
 
 /**@brief Set status


### PR DESCRIPTION
One of the ARM architure files, defined since long ago CONCAT having the exact same purpose as Zephyr's _CONCAT. Unfortunately this header is included almost always and the macro defined in all ARM based platforms,
which seems to have lead to many uses of this macro instead of _CONCAT.

Fix it by using _CONCAT instead, so that code works also with other architectures.

-----

Related to:
- https://github.com/zephyrproject-rtos/zephyr/pull/64839
- https://github.com/zephyrproject-rtos/zephyr/issues/64841