### PR TITLE
Bluetooth: Controller: New config for central event spacing

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -143,6 +143,17 @@ config BT_CTLR_SDC_MAX_CONN_EVENT_LEN_DEFAULT
 	  microseconds. The event length and the connection interval are the
 	  primary parameters for setting the throughput of a connection.
 
+config BT_CTLR_SDC_CENTRAL_ACL_EVENT_SPACING_DEFAULT
+	int "Default central ACL event spacing [us]"
+	default BT_CTLR_SDC_MAX_CONN_EVENT_LEN_DEFAULT
+	help
+	  On the central, sets the time ACL connections are spaced apart assuming that
+	  they are using the same connection interval.
+	  This configuration allows the application to set a different value for event spacing
+	  than BT_CTLR_SDC_MAX_CONN_EVENT_LEN_DEFAULT. This will result in holes in the scheduling
+	  timeline if the connection interval is longer than the ACL event spacing.
+	  This gap can be used for other scheduling activites like isochronous streams.
+
 config BT_CTLR_SDC_PERIODIC_ADV_EVENT_LEN_DEFAULT_OVERRIDE
 	bool "Override periodic adv event length default"
 

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -1184,6 +1184,18 @@ static int hci_driver_open(void)
 		}
 	}
 
+	if (IS_ENABLED(CONFIG_BT_CENTRAL)) {
+		sdc_hci_cmd_vs_central_acl_event_spacing_set_t params = {
+			.central_acl_event_spacing_us =
+				CONFIG_BT_CTLR_SDC_CENTRAL_ACL_EVENT_SPACING_DEFAULT
+		};
+		err = sdc_hci_cmd_vs_central_acl_event_spacing_set(&params);
+		if (err) {
+			MULTITHREADING_LOCK_RELEASE();
+			return -ENOTSUP;
+		}
+	}
+
 	MULTITHREADING_LOCK_RELEASE();
 
 	return 0;

--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -640,7 +640,9 @@ static void vs_supported_commands(sdc_hci_vs_supported_vs_commands_t *cmds)
 	cmds->set_auto_power_control_request_param = 1;
 	cmds->set_power_control_apr_handling = 1;
 	cmds->set_power_control_request_params = 1;
-
+#endif
+#if defined(CONFIG_BT_CENTRAL)
+	cmds->central_acl_event_spacing_set = 1;
 #endif
 }
 #endif	/* CONFIG_BT_HCI_VS */
@@ -1559,6 +1561,10 @@ static uint8_t vs_cmd_put(uint8_t const * const cmd,
 		return sdc_hci_cmd_vs_set_power_control_apr_handling((void *)cmd_params);
 	case SDC_HCI_OPCODE_CMD_VS_SET_POWER_CONTROL_REQUEST_PARAMS:
 		return sdc_hci_cmd_vs_set_power_control_request_params((void *)cmd_params);
+#endif
+#ifdef CONFIG_BT_CENTRAL
+	case SDC_HCI_OPCODE_CMD_VS_CENTRAL_ACL_EVENT_SPACING_SET:
+		return sdc_hci_cmd_vs_central_acl_event_spacing_set((void *)cmd_params);
 #endif
 	default:
 		return BT_HCI_ERR_UNKNOWN_CMD;


### PR DESCRIPTION
CONFIG_BT_CTLR_SDC_CENTRAL_ACL_EVENT_SPACING_DEFAULT allows the user to set the central ACL event spacing and event length separately.

Read the API docs for more information.