### PR TITLE
applications: asset_tracker_v2: Cleanup P-GPS integration

### DIFF
--- a/applications/asset_tracker_v2/doc/cloud_module.rst
+++ b/applications/asset_tracker_v2/doc/cloud_module.rst
@@ -82,7 +82,7 @@ nRF Cloud A-GNSS and P-GPS
 ==========================
 
 When the cloud module is configured to communicate with `AWS IoT Core`_, `Azure IoT Hub`_, or an `LwM2M`_ server, it supports processing of received A-GNSS and P-GPS data using the :ref:`lib_nrf_cloud_agnss` and :ref:`lib_nrf_cloud_pgps` libraries.
-This enables the cloud service to fetch A-GNSS and P-GPS data directly from `nRF Cloud`_ using REST calls and relay this data to an nRF91 Series SiP using the pre-established cloud connection.
+This enables the cloud service to fetch A-GNSS and P-GPS data directly from `nRF Cloud`_ and relay this data to an nRF91 Series SiP using the pre-established cloud connection.
 By reusing the pre-established connection, the application saves overhead related to maintaining multiple connections at the same time.
 When configuring the application to communicate with nRF Cloud, A-GNSS and P-GPS data are received directly from the service, and not by proxy.
 For more information, see `nRF Cloud Location Services <nRF Cloud Location Services documentation_>`_.
@@ -114,7 +114,7 @@ Reconnection is implemented with a binary backoff based on the following lookup 
 .. code-block:: c
 
    static struct cloud_backoff_delay_lookup backoff_delay[] = {
-      { 32 }, { 64 }, { 128 }, { 256 }, { 512 },
+      { 32 }, { 64 }, { 128 }, { 256 }, { 512 }, { 1024 },
       { 2048 }, { 4096 }, { 8192 }, { 16384 }, { 32768 },
       { 65536 }, { 131072 }, { 262144 }, { 524288 }, { 1048576 }
    };

--- a/applications/asset_tracker_v2/doc/data_module.rst
+++ b/applications/asset_tracker_v2/doc/data_module.rst
@@ -10,9 +10,6 @@ Data module
 The data module gathers data that has been sampled by other modules in the system and stores it into ring buffers.
 It keeps track of data requested by the :ref:`asset_tracker_v2_app_module` and decides when data is sent to the cloud.
 
-.. note::
-   The data module will undergo substantial refactoring soon. Hence, some of its features are not currently documented.
-
 Features
 ********
 

--- a/applications/asset_tracker_v2/src/events/data_module_event.c
+++ b/applications/asset_tracker_v2/src/events/data_module_event.c
@@ -28,8 +28,6 @@ static char *get_evt_type_str(enum data_module_event_type type)
 		return "DATA_EVT_IMPACT_DATA_SEND";
 	case DATA_EVT_CLOUD_LOCATION_DATA_SEND:
 		return "DATA_EVT_CLOUD_LOCATION_DATA_SEND";
-	case DATA_EVT_AGNSS_REQUEST_DATA_SEND:
-		return "DATA_EVT_AGNSS_REQUEST_DATA_SEND";
 	case DATA_EVT_CONFIG_INIT:
 		return "DATA_EVT_CONFIG_INIT";
 	case DATA_EVT_CONFIG_READY:

--- a/applications/asset_tracker_v2/src/events/data_module_event.h
+++ b/applications/asset_tracker_v2/src/events/data_module_event.h
@@ -77,15 +77,6 @@ enum data_module_event_type {
 	 */
 	DATA_EVT_CLOUD_LOCATION_DATA_SEND,
 
-	/** Send A-GNSS request.
-	 *  The event has an associated payload of type @ref data_module_data_buffers in
-	 *  the `data.buffer` member.
-	 *
-	 *  If a non LwM2M build is used the data is heap allocated and must be freed after use by
-	 *  calling k_free() on `data.buffer.buf`.
-	 */
-	DATA_EVT_AGNSS_REQUEST_DATA_SEND,
-
 	/** Send the initial device configuration.
 	 *  The event has an associated payload of type @ref cloud_data_cfg in
 	 *  the `data.cfg` member.

--- a/applications/asset_tracker_v2/src/modules/data_module.c
+++ b/applications/asset_tracker_v2/src/modules/data_module.c
@@ -11,14 +11,6 @@
 #if defined(CONFIG_DATA_GRANT_SEND_ON_CONNECTION_QUALITY)
 #include <modem/lte_lc.h>
 #endif
-#include <modem/modem_info.h>
-#if defined(CONFIG_NRF_CLOUD_AGNSS)
-#include <net/nrf_cloud_agnss.h>
-#endif
-
-#if defined(CONFIG_NRF_CLOUD_PGPS)
-#include <net/nrf_cloud_pgps.h>
-#endif
 
 #include "cloud/cloud_codec/cloud_codec.h"
 
@@ -131,14 +123,6 @@ enum coneval_supported_data_type {
 	CLOUD_LOCATION,
 	COUNT,
 };
-
-/* Whether `agnss_request_buffer` has A-GNSS request buffered for sending when connection to
- * cloud has been re-established.
- */
-bool agnss_request_buffered;
-
-/* Buffered A-GNSS request. */
-struct nrf_modem_gnss_agnss_data_frame agnss_request_buffer;
 
 /* Data module message queue. */
 #define DATA_QUEUE_ENTRY_COUNT		10
@@ -667,101 +651,6 @@ static void data_encode(void)
 	}
 }
 
-#if defined(CONFIG_NRF_CLOUD_AGNSS) && !defined(CONFIG_NRF_CLOUD_MQTT)
-static int get_modem_info(struct modem_param_info *const modem_info)
-{
-	__ASSERT_NO_MSG(modem_info != NULL);
-
-	int err = modem_info_init();
-
-	if (err) {
-		LOG_ERR("Could not initialize modem info module, error: %d", err);
-		return err;
-	}
-
-	err = modem_info_params_init(modem_info);
-	if (err) {
-		LOG_ERR("Could not initialize modem info parameters, error: %d", err);
-		return err;
-	}
-
-	err = modem_info_params_get(modem_info);
-	if (err) {
-		LOG_ERR("Could not obtain cell information, error: %d", err);
-		return err;
-	}
-
-	return 0;
-}
-
-/**
- * @brief Combine and encode modem network parameters together with the incoming A-GNSS data request
- *	  types to form the A-GNSS request.
- *
- * @param[in] incoming_request Pointer to a structure containing A-GNSS data types that has been
- *			       requested by the modem. If incoming_request is NULL, all A-GNSS data
- *			       types are requested.
- *
- * @return 0 on success, otherwise a negative error code indicating reason of failure.
- */
-static int agnss_request_encode(struct nrf_modem_gnss_agnss_data_frame *incoming_request)
-{
-	int err;
-	struct cloud_codec_data codec = {0};
-	static struct modem_param_info modem_info = {0};
-	static struct cloud_data_agnss_request cloud_agnss_request = {0};
-
-	err = get_modem_info(&modem_info);
-	if (err) {
-		return err;
-	}
-
-	if (incoming_request == NULL) {
-		const uint32_t mask = IS_ENABLED(CONFIG_NRF_CLOUD_PGPS) ? 0u : 0xFFFFFFFFu;
-
-		LOG_DBG("Requesting all A-GNSS elements");
-		cloud_agnss_request.request.data_flags =
-					NRF_MODEM_GNSS_AGNSS_GPS_UTC_REQUEST |
-					NRF_MODEM_GNSS_AGNSS_KLOBUCHAR_REQUEST |
-					NRF_MODEM_GNSS_AGNSS_NEQUICK_REQUEST |
-					NRF_MODEM_GNSS_AGNSS_GPS_SYS_TIME_AND_SV_TOW_REQUEST |
-					NRF_MODEM_GNSS_AGNSS_POSITION_REQUEST |
-					NRF_MODEM_GNSS_AGNSS_INTEGRITY_REQUEST;
-		cloud_agnss_request.request.system_count = 1;
-		cloud_agnss_request.request.system[0].sv_mask_ephe = mask;
-		cloud_agnss_request.request.system[0].sv_mask_alm = mask;
-	} else {
-		cloud_agnss_request.request = *incoming_request;
-	}
-
-	cloud_agnss_request.mcc = modem_info.network.mcc.value;
-	cloud_agnss_request.mnc = modem_info.network.mnc.value;
-	cloud_agnss_request.cell = modem_info.network.cellid_dec;
-	cloud_agnss_request.area = modem_info.network.area_code.value;
-	cloud_agnss_request.queued = true;
-
-	err = cloud_codec_encode_agnss_request(&codec, &cloud_agnss_request);
-	switch (err) {
-	case 0:
-		LOG_DBG("A-GNSS request encoded successfully");
-		data_send(DATA_EVT_AGNSS_REQUEST_DATA_SEND, &codec);
-		break;
-	case -ENOTSUP:
-		LOG_ERR("Encoding of A-GNSS requests are not supported by the configured codec");
-		break;
-	case -ENODATA:
-		LOG_DBG("No A-GNSS request data to encode, error: %d", err);
-		break;
-	default:
-		LOG_ERR("Error encoding A-GNSS request: %d", err);
-		SEND_ERROR(data, DATA_EVT_ERROR, err);
-		break;
-	}
-
-	return err;
-}
-#endif /* CONFIG_NRF_CLOUD_AGNSS && !CONFIG_NRF_CLOUD_MQTT */
-
 static void config_get(void)
 {
 	SEND_EVENT(data, DATA_EVT_CONFIG_GET);
@@ -1053,88 +942,17 @@ static void new_config_handle(struct cloud_data_cfg *new_config)
 	config_send();
 }
 
-/**
- * @brief Function that requests A-GNSS and P-GPS data upon receiving a request from the
- *        location module.
- *
- * @param[in] incoming_request Pointer to a structure containing A-GNSS data types that has been
- *			       requested by the modem. If incoming_request is NULL, all A-GNSS data
- *			       types are requested.
- */
-static void agnss_request_handle(struct nrf_modem_gnss_agnss_data_frame *incoming_request)
-{
-	int err;
-
-#if defined(CONFIG_NRF_CLOUD_AGNSS)
-#if defined(CONFIG_NRF_CLOUD_MQTT)
-	/* If CONFIG_NRF_CLOUD_MQTT is enabled, the nRF Cloud MQTT transport library will be used
-	 * to send the request.
-	 */
-	err = (incoming_request == NULL) ? nrf_cloud_agnss_request_all() :
-					   nrf_cloud_agnss_request(incoming_request);
-	if (err) {
-		LOG_WRN("Failed to request A-GNSS data, error: %d", err);
-		LOG_DBG("This is expected to fail if we are not in a connected state");
-	} else {
-		if (nrf_cloud_agnss_request_in_progress()) {
-			LOG_DBG("A-GNSS request sent");
-			return;
-		}
-		LOG_DBG("No A-GNSS data requested");
-		/* Continue so P-GPS, if enabled, can be requested. */
-	}
-#else
-	/* If the nRF Cloud MQTT transport library is not enabled, we will have to create an
-	 * A-GNSS request and send out an event containing the request for the cloud module to pick
-	 * up and send to the cloud that is currently used.
-	 */
-	err = (incoming_request == NULL) ? agnss_request_encode(NULL) :
-					   agnss_request_encode(incoming_request);
-	if (err) {
-		LOG_WRN("Failed to request A-GNSS data, error: %d", err);
-	} else {
-		LOG_DBG("A-GNSS request sent");
-		return;
-	}
-#endif
-#endif
-
-#if defined(CONFIG_NRF_CLOUD_PGPS)
-	/* A-GNSS data is not expected to be received. Proceed to schedule a callback when
-	 * P-GPS data for current time is available.
-	 */
-	err = nrf_cloud_pgps_notify_prediction();
-	if (err) {
-		LOG_ERR("Requesting notification of prediction availability, error: %d", err);
-	}
-#endif
-
-	(void)err;
-}
-
 /* Message handler for STATE_CLOUD_DISCONNECTED. */
 static void on_cloud_state_disconnected(struct data_msg_data *msg)
 {
 	if (IS_EVENT(msg, cloud, CLOUD_EVT_CONNECTED)) {
 		state_set(STATE_CLOUD_CONNECTED);
-		if (agnss_request_buffered) {
-			LOG_DBG("Handle buffered A-GNSS request");
-			agnss_request_handle(&agnss_request_buffer);
-			agnss_request_buffered = false;
-		}
 		return;
 	}
 
 	if (IS_EVENT(msg, cloud, CLOUD_EVT_CONFIG_EMPTY) &&
 	    IS_ENABLED(CONFIG_NRF_CLOUD_MQTT)) {
 		config_send();
-	}
-
-	if (IS_EVENT(msg, location, LOCATION_MODULE_EVT_AGNSS_NEEDED)) {
-		LOG_DBG("A-GNSS request buffered");
-		agnss_request_buffered = true;
-		agnss_request_buffer = msg->module.location.data.agnss_request;
-		return;
 	}
 }
 
@@ -1168,11 +986,6 @@ static void on_cloud_state_connected(struct data_msg_data *msg)
 
 	if (IS_EVENT(msg, cloud, CLOUD_EVT_CONFIG_EMPTY)) {
 		config_send();
-		return;
-	}
-
-	if (IS_EVENT(msg, location, LOCATION_MODULE_EVT_AGNSS_NEEDED)) {
-		agnss_request_handle(&msg->module.location.data.agnss_request);
 		return;
 	}
 }

--- a/lib/location/location_core.c
+++ b/lib/location/location_core.c
@@ -509,10 +509,7 @@ void location_core_event_cb_agnss_request(const struct nrf_modem_gnss_agnss_data
 {
 	struct location_event_data agnss_request_event_data;
 
-	LOG_DBG("Request A-GNSS data from application: ephe 0x%08x, alm 0x%08x, data_flags 0x%02x",
-		(uint32_t)request->system[0].sv_mask_ephe,
-		(uint32_t)request->system[0].sv_mask_alm,
-		request->data_flags);
+	LOG_DBG("Request A-GNSS data from application");
 
 	agnss_request_event_data.id = LOCATION_EVT_GNSS_ASSISTANCE_REQUEST;
 	agnss_request_event_data.method = LOCATION_METHOD_GNSS;


### PR DESCRIPTION
Moved P-GPS request handling from data module to cloud module. Simplified P-GPS request handling and aligned P-GPS and A-GNSS implementations.

Added a missing value to cloud module backoff delay table.

Did a couple of minor documentation fixes.

NCSDK-18093