### PR TITLE
manifest: Update connectedhomeip to remove deprecated symbols

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -149,7 +149,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 608a53eeec7271097f9875fea7f0ea8363308d41
+      revision: pull/347/head
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
This commit changes deprecated symbols in chip