### PR TITLE
manifest: Add CI-run-zephyr-twister test spec

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 2b912a70f905022a1ef891161b5f6c977980c87a
+      revision: ede86123951b7f824f91f6ebd1ea15f307f9a208
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
CI-run-zephyr-twister is used to determine if twister tests from sdk-zephyr should be run on PR to sdk-nrf repository.