### PR TITLE
drivers: wifi: Fix QSPI crash

### DIFF
--- a/drivers/wifi/nrf700x/src/qspi/inc/qspi_if.h
+++ b/drivers/wifi/nrf700x/src/qspi/inc/qspi_if.h
@@ -81,6 +81,7 @@ int gpio_request_irq(int pin, struct gpio_callback *button_cb_data, void (*irq_h
 struct qspi_config *qspi_defconfig(void);
 
 struct qspi_dev *qspi_dev(void);
+struct qspi_config *qspi_get_config(void);
 
 int qspi_cmd_sleep_rpu(const struct device *dev);
 

--- a/drivers/wifi/nrf700x/src/qspi/src/device.c
+++ b/drivers/wifi/nrf700x/src/qspi/src/device.c
@@ -65,6 +65,11 @@ struct qspi_config *qspi_defconfig(void)
 	return &config;
 }
 
+struct qspi_config *qspi_get_config(void)
+{
+	return &config;
+}
+
 struct qspi_dev *qspi_dev(void)
 {
 #if CONFIG_NRF700X_ON_QSPI

--- a/drivers/wifi/nrf700x/src/qspi/src/rpu_hw_if.c
+++ b/drivers/wifi/nrf700x/src/qspi/src/rpu_hw_if.c
@@ -473,6 +473,7 @@ int rpu_enable(void)
 	int ret;
 
 	qdev = qspi_dev();
+	cfg = qspi_get_config();
 
 	CALL_RPU_FUNC(rpu_gpio_config);
 
@@ -517,6 +518,7 @@ int rpu_disable(void)
 	CALL_RPU_FUNC(ble_gpio_remove);
 
 	qdev = NULL;
+	cfg = NULL;
 
 out:
 	return ret;


### PR DESCRIPTION
This fixes a crash introduced in commit 2fb13ee104f("drivers: wifi: Move QSPI init to shim"). The QSPI/SPI configuration isn't proper assigned but used in RPU layer.