### PR TITLE
lib: lte_link_control: Support for PSM config in seconds

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -359,6 +359,10 @@ DFU libraries
 Modem libraries
 ---------------
 
+* :ref:`lte_lc_readme`:
+
+  * Added the :c:func:`lte_lc_psm_param_set_seconds` function and Kconfig options :kconfig:option:`LTE_PSM_REQ_FORMAT`, :kconfig:option:`CONFIG_LTE_PSM_REQ_RPTAU_SECONDS`, and :kconfig:option:`CONFIG_LTE_PSM_REQ_RAT_SECONDS` to enable setting of PSM parameters in seconds instead of using bit field strings.
+
 * :ref:`nrf_modem_lib_readme`:
 
    * Added a mention about enabling TF-M logging while using modem traces in the :ref:`modem_trace_module`.

--- a/lib/lte_link_control/Kconfig
+++ b/lib/lte_link_control/Kconfig
@@ -69,9 +69,27 @@ config LTE_PSM_REQ
 	  the modem is initialized. This will cause the modem to include a PSM request in
 	  every subsequent LTE attach request.
 
+choice LTE_PSM_REQ_FORMAT
+	prompt "Format for PSM configuration"
+	default LTE_PSM_REQ_FORMAT_STRING
+	help
+	  Select the format in which default parameters for PSM are given.
+
+config LTE_PSM_REQ_FORMAT_STRING
+	bool "Use PSM configs given as bit field strings"
+	help
+	  Use LTE_PSM_REQ_RPTAU and LTE_PSM_REQ_RAT.
+
+config LTE_PSM_REQ_FORMAT_SECONDS
+	bool "Use PSM configs given in seconds"
+	help
+	  Use LTE_PSM_REQ_RPTAU_SECONDS and LTE_PSM_REQ_RAT_SECONDS.
+
+endchoice
+
 config LTE_PSM_REQ_RPTAU
 	string "Requested periodic TAU for PSM"
-	default "00000011"
+	default "00000011" # 30 minutes
 	help
 	  Power saving mode setting for requested periodic TAU.
 	  See 3GPP 27.007 Ch. 7.38.
@@ -79,11 +97,27 @@ config LTE_PSM_REQ_RPTAU
 
 config LTE_PSM_REQ_RAT
 	string "Requested active time for PSM"
-	default "00100001"
+	default "00100001" # 1 minute
 	help
 	  Power saving mode setting for requested active time.
 	  See 3GPP 27.007 Ch. 7.38.
 	  And 3GPP 24.008 Ch. 10.5.7.3 for data format.
+
+config LTE_PSM_REQ_RPTAU_SECONDS
+	int "Requested periodic TAU for PSM in seconds"
+	default 1800
+	help
+	  Power saving mode setting for requested periodic TAU in seconds.
+	  See lte_lc_psm_param_set_seconds() on limitations although any
+	  non-negative value can be given.
+
+config LTE_PSM_REQ_RAT_SECONDS
+	int "Requested active time for PSM in seconds"
+	default 60
+	help
+	  Power saving mode setting for requested active time in seconds.
+	  See lte_lc_psm_param_set_seconds() on limitations although any
+	  non-negative value can be given.
 
 config LTE_PROPRIETARY_PSM_REQ
 	bool "Enable use of proprietary PSM"

--- a/lib/lte_link_control/lte_lc_helpers.h
+++ b/lib/lte_link_control/lte_lc_helpers.h
@@ -206,6 +206,17 @@ int parse_edrx(const char *at_response, struct lte_lc_edrx_cfg *cfg);
 int parse_psm(const char *active_time_str, const char *tau_ext_str,
 	      const char *tau_legacy_str, struct lte_lc_psm_cfg *psm_cfg);
 
+/* @brief Encode Periodic TAU timer and active time strings.
+ *
+ * @param[out] tau_ext_str TAU (T3412 extended) string. Must be at least 9 bytes.
+ * @param[out] active_time_str Active time string buffer. Must be at least 9 bytes.
+ * @param rptau[in] Requested Periodic TAU value to be encoded.
+ * @param rat[in] Requested active time value to be encoded.
+ *
+ * @retval 0 if PSM configuration was successfully parsed.
+ * @retval -EINVAL if parsing failed.
+ */
+int encode_psm(char *tau_ext_str, char *active_time_str, int rptau, int rat);
 
 /* @brief Parses an CEREG response and returns network registration status,
  *	  cell information, LTE mode and pSM configuration.

--- a/tests/lib/lte_lc/src/main.c
+++ b/tests/lib/lte_lc/src/main.c
@@ -472,6 +472,84 @@ void test_parse_psm(void)
 	TEST_ASSERT_EQUAL(32, psm_cfg.active_time);
 }
 
+void test_encode_psm(void)
+{
+	int err;
+	char tau_ext_str[9] = "";
+	char active_time_str[9] = "";
+
+	err = encode_psm(tau_ext_str, active_time_str, 11400, 60);
+	TEST_ASSERT_EQUAL(0, err);
+	TEST_ASSERT_EQUAL_STRING("00010011", tau_ext_str);
+	TEST_ASSERT_EQUAL_STRING("00011110", active_time_str);
+
+	memset(tau_ext_str, 0, sizeof(tau_ext_str));
+	memset(active_time_str, 0, sizeof(active_time_str));
+
+	/* Test value -1 */
+	err = encode_psm(tau_ext_str, active_time_str, -1, -1);
+	TEST_ASSERT_EQUAL(0, err);
+	TEST_ASSERT_EQUAL_STRING("", tau_ext_str);
+	TEST_ASSERT_EQUAL_STRING("", active_time_str);
+
+	memset(tau_ext_str, 0, sizeof(tau_ext_str));
+	memset(active_time_str, 0, sizeof(active_time_str));
+
+	/* Test too big TAU */
+	err = encode_psm(tau_ext_str, active_time_str, 35712001, 61);
+	TEST_ASSERT_EQUAL(-EINVAL, err);
+	TEST_ASSERT_EQUAL_STRING("", tau_ext_str);
+	TEST_ASSERT_EQUAL_STRING("00011111", active_time_str);
+
+	memset(tau_ext_str, 0, sizeof(tau_ext_str));
+	memset(active_time_str, 0, sizeof(active_time_str));
+
+	/* Test too big active time */
+	err = encode_psm(tau_ext_str, active_time_str, 61, 11161);
+	TEST_ASSERT_EQUAL(-EINVAL, err);
+	TEST_ASSERT_EQUAL_STRING("01111111", tau_ext_str);
+	TEST_ASSERT_EQUAL_STRING("", active_time_str);
+
+	memset(tau_ext_str, 0, sizeof(tau_ext_str));
+	memset(active_time_str, 0, sizeof(active_time_str));
+
+	/* Test value 1 rounding to 2*/
+	err = encode_psm(tau_ext_str, active_time_str, 1, 1);
+	TEST_ASSERT_EQUAL(0, err);
+	TEST_ASSERT_EQUAL_STRING("01100001", tau_ext_str);
+	TEST_ASSERT_EQUAL_STRING("00000001", active_time_str);
+
+	memset(tau_ext_str, 0, sizeof(tau_ext_str));
+	memset(active_time_str, 0, sizeof(active_time_str));
+
+	/* Test maximum values */
+	err = encode_psm(tau_ext_str, active_time_str, 35712000, 11160);
+	TEST_ASSERT_EQUAL(0, err);
+	TEST_ASSERT_EQUAL_STRING("11011111", tau_ext_str);
+	TEST_ASSERT_EQUAL_STRING("01011111", active_time_str);
+
+	memset(tau_ext_str, 0, sizeof(tau_ext_str));
+	memset(active_time_str, 0, sizeof(active_time_str));
+
+	/****************************************/
+	err = encode_psm(tau_ext_str, active_time_str, 123456, 89);
+	TEST_ASSERT_EQUAL(0, err);
+	TEST_ASSERT_EQUAL_STRING("01000100", tau_ext_str);
+	TEST_ASSERT_EQUAL_STRING("00100010", active_time_str);
+
+	memset(tau_ext_str, 0, sizeof(tau_ext_str));
+	memset(active_time_str, 0, sizeof(active_time_str));
+
+	/****************************************/
+	err = encode_psm(tau_ext_str, active_time_str, 62, 63);
+	TEST_ASSERT_EQUAL(0, err);
+	TEST_ASSERT_EQUAL_STRING("01111111", tau_ext_str);
+	TEST_ASSERT_EQUAL_STRING("00100010", active_time_str);
+
+	memset(tau_ext_str, 0, sizeof(tau_ext_str));
+	memset(active_time_str, 0, sizeof(active_time_str));
+}
+
 void test_parse_mdmev(void)
 {
 	int err;

--- a/tests/lib/lte_lc_api/src/lte_lc_api_test.c
+++ b/tests/lib/lte_lc_api/src/lte_lc_api_test.c
@@ -555,6 +555,45 @@ void test_lte_lc_psm_req_disable_success(void)
 	TEST_ASSERT_EQUAL(EXIT_SUCCESS, ret);
 }
 
+void test_lte_lc_psm_param_set_seconds_enable_both_set(void)
+{
+	int ret;
+
+	ret = lte_lc_psm_param_set_seconds(60, 600);
+	TEST_ASSERT_EQUAL(EXIT_SUCCESS, ret);
+
+	/* TODO: We need custom nrf_modem_at_printf mock to verify the content */
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CPSMS=1,,,\"%s\",\"%s\"", EXIT_SUCCESS);
+	ret = lte_lc_psm_req(true);
+	TEST_ASSERT_EQUAL(EXIT_SUCCESS, ret);
+}
+
+void test_lte_lc_psm_param_set_seconds_enable_both_zero(void)
+{
+	int ret;
+
+	ret = lte_lc_psm_param_set_seconds(0, 0);
+	TEST_ASSERT_EQUAL(EXIT_SUCCESS, ret);
+
+	/* TODO: We need custom nrf_modem_at_printf mock to verify the content */
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CPSMS=1,,,\"%s\",\"%s\"", EXIT_SUCCESS);
+	ret = lte_lc_psm_req(true);
+	TEST_ASSERT_EQUAL(EXIT_SUCCESS, ret);
+}
+
+void test_lte_lc_psm_param_set_seconds_enable_both_default(void)
+{
+	int ret;
+
+	ret = lte_lc_psm_param_set_seconds(-1, -1);
+	TEST_ASSERT_EQUAL(EXIT_SUCCESS, ret);
+
+	/* TODO: We need custom nrf_modem_at_printf mock to verify the content */
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CPSMS=1", EXIT_SUCCESS);
+	ret = lte_lc_psm_req(true);
+	TEST_ASSERT_EQUAL(EXIT_SUCCESS, ret);
+}
+
 void test_lte_lc_edrx_param_set_wrong_mode(void)
 {
 	int ret;


### PR DESCRIPTION
A new function for giving periodic TAU and active time in seconds. The library will handle conversion to bit field string representation specified in AT Commands Reference Guide, and 3GPP 24.008 Ch. 10.5.7.4a and Ch. 10.5.7.3.

Jira: NCSDK-23286