### PR TITLE
manifest: Update sdk-zephyr with bt_hci_get_ver_str()

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: d36ea76f95b7b50cc31b45f207b2716ea4302cb8
+      revision: 2b912a70f905022a1ef891161b5f6c977980c87a
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This API can be used to reduce code duplication.