### PR TITLE
shell: Align log message queue size for backends

### DIFF
--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -23,7 +23,7 @@ source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
 default-timeout = 100
 source "${ZEPHYR_BASE}/subsys/shell/Kconfig.template.shell_log_queue_timeout"
 
-default-size = 10
+default-size = 512
 source "${ZEPHYR_BASE}/subsys/shell/Kconfig.template.shell_log_queue_size"
 
 choice
@@ -149,7 +149,7 @@ source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
 default-timeout = 100
 source "${ZEPHYR_BASE}/subsys/shell/Kconfig.template.shell_log_queue_timeout"
 
-default-size = 10
+default-size = 512
 source "${ZEPHYR_BASE}/subsys/shell/Kconfig.template.shell_log_queue_size"
 
 endif #SHELL_IPC
@@ -236,7 +236,7 @@ source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
 default-timeout = 100
 source "${ZEPHYR_BASE}/subsys/shell/Kconfig.template.shell_log_queue_timeout"
 
-default-size = 10
+default-size = 512
 source "${ZEPHYR_BASE}/subsys/shell/Kconfig.template.shell_log_queue_size"
 
 


### PR DESCRIPTION
Zephyr commit 188d2dfcca7 introduced changes where the log buffer size 
is not hardcoded, but calculated based on the LOG_MESSAGE_QUEUE_SIZE configuration.
This commit aligns the log queue size.