### PR TITLE
lib: nrf_modem: remove deprecated Kconfig options

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-2.2.0.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-2.2.0.rst
@@ -674,8 +674,8 @@ Modem libraries
 
   * Added:
 
-    * The :kconfig:option:`CONFIG_NRF_MODEM_LIB_IPC_IRQ_PRIO_OVERRIDE` Kconfig option to override the IPC IRQ priority from the devicetree.
-    * The :kconfig:option:`CONFIG_NRF_MODEM_LIB_IPC_IRQ_PRIO` Kconfig option to configure the IPC IRQ priority when the Kconfig option :kconfig:option:`CONFIG_NRF_MODEM_LIB_IPC_IRQ_PRIO_OVERRIDE` is enabled.
+    * The ``CONFIG_NRF_MODEM_LIB_IPC_IRQ_PRIO_OVERRIDE`` Kconfig option to override the IPC IRQ priority from the devicetree.
+    * The :kconfig:option:`CONFIG_NRF_MODEM_LIB_IPC_IRQ_PRIO` Kconfig option to configure the IPC IRQ priority when the Kconfig option ``CONFIG_NRF_MODEM_LIB_IPC_IRQ_PRIO_OVERRIDE`` is enabled.
     * The :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_BITRATE` Kconfig option to enable the measurement of the modem trace backend bitrate.
     * The :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_BITRATE_LOG` Kconfig option to enable logging of the modem trace backend bitrate.
     * The :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_BITRATE_LOG` Kconfig option to enable logging of the modem trace bitrate.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -368,6 +368,7 @@ Modem libraries
   * Removed:
 
     * The deprecated Kconfig option ``CONFIG_NRF_MODEM_LIB_SYS_INIT``.
+    * The deprecated Kconfig option ``CONFIG_NRF_MODEM_LIB_IPC_IRQ_PRIO_OVERRIDE``.
 
 |no_changes_yet_note|
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -365,6 +365,10 @@ Modem libraries
    * Updated by renaming ``lte_connectivity`` module to ``lte_net_if``.
      All related Kconfig options have been renamed accordingly.
 
+  * Removed:
+
+    * The deprecated Kconfig option ``CONFIG_NRF_MODEM_LIB_SYS_INIT``.
+
 |no_changes_yet_note|
 
 Libraries for networking

--- a/lib/lte_link_control/Kconfig
+++ b/lib/lte_link_control/Kconfig
@@ -14,7 +14,6 @@ if LTE_LINK_CONTROL
 config LTE_AUTO_INIT_AND_CONNECT
 	select DEPRECATED
 	bool "Auto Initialize and Connect for the LTE link [DEPRECATED]"
-	default y if NRF_MODEM_LIB_SYS_INIT
 	help
 	  Turn on to make the LTE link control to automatically initialize and connect the modem
 	  before the application starts.

--- a/lib/nrf_modem_lib/Kconfig.modemlib
+++ b/lib/nrf_modem_lib/Kconfig.modemlib
@@ -227,8 +227,8 @@ rsource "lte_net_if/Kconfig"
 
 DT_IPC := $(dt_nodelabel_path,ipc)
 config NRF_MODEM_LIB_IPC_IRQ_PRIO
-	int "IPC IRQ priority" if NRF_MODEM_LIB_IPC_IRQ_PRIO_OVERRIDE
-	default $(dt_node_array_prop_int,$(DT_IPC),interrupts,1) if !NRF_MODEM_LIB_IPC_IRQ_PRIO_OVERRIDE
+	int
+	default $(dt_node_array_prop_int,$(DT_IPC),interrupts,1)
 
 module = NRF_MODEM_LIB
 module-str = Modem library
@@ -237,11 +237,3 @@ source "subsys/logging/Kconfig.template.log_config"
 config NRF_MODEM_LIB_LOG_FW_VERSION_UUID
 	depends on LOG
 	bool "Log FW version and UUID during initialization"
-
-comment "Deprecated"
-
-config NRF_MODEM_LIB_IPC_IRQ_PRIO_OVERRIDE
-	bool "Override IPC IRQ priority"
-	select DEPRECATED
-	help
-	  Override the IPC IRQ priority set in device tree

--- a/lib/nrf_modem_lib/Kconfig.modemlib
+++ b/lib/nrf_modem_lib/Kconfig.modemlib
@@ -10,16 +10,6 @@ config HEAP_MEM_POOL_SIZE
 	int
 	default 512
 
-config NRF_MODEM_LIB_SYS_INIT
-	bool "Initialize during SYS_INIT [DEPRECATED]"
-	select DEPRECATED
-	help
-	  Initialize the Modem library automatically during the SYS_INIT sequence.
-	  Please note that initialization is synchronous and can take up to one
-	  minute in case the modem firmware is updated.
-	  This Kconfig option is deprecated. The application should instead use the
-	  nrf_modem_lib_init() function to initialize the modem library.
-
 menu "Memory configuration"
 
 config NRF_MODEM_LIB_HEAP_SIZE

--- a/lib/nrf_modem_lib/trace_backends/flash/Kconfig
+++ b/lib/nrf_modem_lib/trace_backends/flash/Kconfig
@@ -14,9 +14,8 @@ config NRF_MODEM_LIB_TRACE_BACKEND_FLASH
 	depends on FLASH
 	depends on FLASH_MAP
 	help
-	  Use flash trace backend. Note that the backend takes time to erase the flash at
-	  initialization. It is therefore recommended to disable CONFIG_NRF_MODEM_LIB_SYS_INIT when
-	  enabling the flash trace backend.
+	  Use flash trace backend.
+	  Note that the backend takes time to erase the flash during initialization.
 
 endchoice # NRF_MODEM_LIB_TRACE_BACKEND
 

--- a/subsys/dfu/fmfu_fdev/Kconfig
+++ b/subsys/dfu/fmfu_fdev/Kconfig
@@ -7,7 +7,7 @@
 menuconfig FMFU_FDEV
 	bool "Full Modem Firmware Upgrade from flash device"
 	depends on ZCBOR
-	depends on NRF_MODEM_LIB && !NRF_MODEM_LIB_SYS_INIT
+	depends on NRF_MODEM_LIB
 	depends on MBEDTLS_SHA256_C
 
 

--- a/subsys/mgmt/fmfu/Kconfig
+++ b/subsys/mgmt/fmfu/Kconfig
@@ -10,7 +10,7 @@ config MGMT_FMFU
 	bool "Serial Modem Firmware Update support"
 	depends on MCUMGR_TRANSPORT_UART
 	depends on MCUMGR
-	depends on NRF_MODEM_LIB && !NRF_MODEM_LIB_SYS_INIT
+	depends on NRF_MODEM_LIB
 
 module=MGMT_FMFU
 module-dep=LOG


### PR DESCRIPTION
Remove deprecated KConfig options
- `NRF_MODEM_LIB_SYS_INIT`
- `NRF_MODEM_LIB_IPC_PRIO_OVERRIDE`