### PR TITLE
doc: extensions: page_filter: append tag container to parent

### DIFF
--- a/doc/_extensions/static/page_filter.mjs
+++ b/doc/_extensions/static/page_filter.mjs
@@ -76,7 +76,7 @@ function createFilterTags(dropdown, elementType, filterTags) {
 
     var tagDiv = document.createElement("div");
     tagDiv.classList.add("filtertag-container");
-    containerParent.insertBefore(tagDiv, containerParent.children[1]);
+    containerParent.append(tagDiv);
 
     filterClasses.forEach((className) => {
 


### PR DESCRIPTION
The filtertag-container was not always inserted as the last element in the parent container.