### PR TITLE
manifest: sdk-nrfxlib: Pull Wi-Fi test spec update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -141,7 +141,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: abf0e67166c7f6d19b501fb3ef20ccb9a9d35042
+      revision: pull/1116/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Fix issue of Wi-Fi tests not being run for OS agnostic driver changes.