### PR TITLE
mpsl: fem: fix DT accesses in Kconfig

### DIFF
--- a/subsys/mpsl/fem/Kconfig
+++ b/subsys/mpsl/fem/Kconfig
@@ -60,7 +60,8 @@ choice MPSL_FEM_CHOICE
 config MPSL_FEM_NRF21540_GPIO
 	depends on MPSL_FEM_NRF21540_GPIO_SUPPORT
 	select NRFX_GPIOTE
-	select GPIO if ($(dt_node_has_prop,nrf_radio_fem,mode_gpios) || $(dt_node_has_prop,nrf_radio_fem,ant_sel_gpios))
+	select GPIO if ($(dt_nodelabel_has_prop,nrf_radio_fem,mode-gpios) || \
+		$(dt_nodelabel_has_prop,nrf_radio_fem,ant-sel-gpios))
 	select NRFX_PPI if HAS_HW_NRF_PPI
 	select NRFX_DPPI if HAS_HW_NRF_DPPIC
 	select MPSL_FEM_NCS_SUPPORTED_FEM_USED
@@ -71,7 +72,8 @@ config MPSL_FEM_NRF21540_GPIO
 config MPSL_FEM_NRF21540_GPIO_SPI
 	depends on MPSL_FEM_NRF21540_GPIO_SPI_SUPPORT
 	select NRFX_GPIOTE
-	select GPIO if ($(dt_node_has_prop,nrf_radio_fem,mode_gpios) || $(dt_node_has_prop,nrf_radio_fem,ant_sel_gpios))
+	select GPIO if ($(dt_nodelabel_has_prop,nrf_radio_fem,mode-gpios) || \
+		$(dt_nodelabel_has_prop,nrf_radio_fem,ant-sel-gpios))
 	select NRFX_PPI if HAS_HW_NRF_PPI
 	select NRFX_DPPI if HAS_HW_NRF_DPPIC
 	select PINCTRL


### PR DESCRIPTION
This commit fixes reads of DT properties in MPSL FEM Kconfig.