### PR TITLE
treewide: align headers c++ guards fixes

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/cloud_codec.h
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/cloud_codec.h
@@ -535,10 +535,10 @@ void cloud_codec_populate_modem_dynamic_buffer(
 				int *head_modem_buf,
 				size_t buffer_count);
 
-/**
- * @}
- */
 #ifdef __cplusplus
 }
 #endif
+/**
+ * @}
+ */
 #endif

--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/json_common.h
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/json_common.h
@@ -11,8 +11,7 @@
 #ifndef JSON_COMMON_H__
 #define JSON_COMMON_H__
 
-/**@file
- *
+/**
  * @defgroup JSON common json_common
  * @brief    Module containing common JSON encoding functions.
  * @{

--- a/applications/asset_tracker_v2/src/ext_sensors/ext_sensors.h
+++ b/applications/asset_tracker_v2/src/ext_sensors/ext_sensors.h
@@ -11,8 +11,7 @@
 #ifndef EXT_SENSORS_H__
 #define EXT_SENSORS_H__
 
-/**@file
- *
+/**
  * @defgroup External sensors ext_sensors
  * @brief    Module that manages external sensors.
  * @{

--- a/applications/asset_tracker_v2/src/modules/modules_common.h
+++ b/applications/asset_tracker_v2/src/modules/modules_common.h
@@ -137,6 +137,10 @@ int module_start(struct module_data *module);
  */
 uint32_t module_active_count_get(void);
 
+#ifdef __cplusplus
+}
+#endif
+
 /**
  *@}
  */

--- a/applications/nrf_desktop/configuration/common/motion_sensor.h
+++ b/applications/nrf_desktop/configuration/common/motion_sensor.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef _MOTION_SENSOR_H_
 #define _MOTION_SENSOR_H_
 

--- a/applications/nrf_desktop/src/util/chmap_filter/include/chmap_filter.h
+++ b/applications/nrf_desktop/src/util/chmap_filter/include/chmap_filter.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef _CHMAP_FILTER_H_
 #define _CHMAP_FILTER_H_
 

--- a/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.h
+++ b/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.h
@@ -12,6 +12,7 @@
  * @brief Vendor-specific AT command for FTP and TFTP services.
  * @{
  */
+
 /**
  * @brief Initialize FTP AT command parser.
  *

--- a/applications/serial_lte_modem/src/http_c/slm_at_httpc.h
+++ b/applications/serial_lte_modem/src/http_c/slm_at_httpc.h
@@ -12,6 +12,7 @@
  * @brief Vendor-specific AT command for HTTP service.
  * @{
  */
+
 /**
  * @brief HTTPC raw data send.
  *

--- a/applications/serial_lte_modem/src/mqtt_c/slm_at_mqtt.h
+++ b/applications/serial_lte_modem/src/mqtt_c/slm_at_mqtt.h
@@ -12,6 +12,7 @@
  * @brief Vendor-specific AT command for MQTT service.
  * @{
  */
+
 /**
  * @brief Initialize MQTT AT command parser.
  *

--- a/applications/serial_lte_modem/src/slm_at_cmng.h
+++ b/applications/serial_lte_modem/src/slm_at_cmng.h
@@ -12,6 +12,7 @@
  * @brief Vendor-specific AT command for CMNG service.
  * @{
  */
+
 /**
  * @brief Initialize CMNG AT command parser.
  *

--- a/applications/serial_lte_modem/src/slm_at_icmp.h
+++ b/applications/serial_lte_modem/src/slm_at_icmp.h
@@ -12,6 +12,7 @@
  * @brief Vendor-specific AT command for ICMP service.
  * @{
  */
+
 /**
  * @brief Initialize ICMP AT command parser.
  *

--- a/applications/serial_lte_modem/src/slm_at_sms.h
+++ b/applications/serial_lte_modem/src/slm_at_sms.h
@@ -12,6 +12,7 @@
  * @brief Vendor-specific AT command for SMS service.
  * @{
  */
+
 /**
  * @brief Initialize SMS AT command parser.
  *

--- a/applications/serial_lte_modem/src/slm_at_tcp_proxy.h
+++ b/applications/serial_lte_modem/src/slm_at_tcp_proxy.h
@@ -12,6 +12,7 @@
  * @brief Vendor-specific AT command for TCP proxy service.
  * @{
  */
+
 /**
  * @brief Initialize TCP proxy AT command parser.
  *

--- a/applications/serial_lte_modem/src/slm_at_udp_proxy.h
+++ b/applications/serial_lte_modem/src/slm_at_udp_proxy.h
@@ -12,6 +12,7 @@
  * @brief Vendor-specific AT command for UDP proxy service.
  * @{
  */
+
 /**
  * @brief Initialize UDP proxy AT command parser.
  *

--- a/applications/serial_lte_modem/src/slm_settings.h
+++ b/applications/serial_lte_modem/src/slm_settings.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef SLM_SETTINGS_
 #define SLM_SETTINGS_
 

--- a/ext/iperf3/iperf_api.h
+++ b/ext/iperf3/iperf_api.h
@@ -453,7 +453,7 @@ enum {
     /* Stream errors */
     IECREATESTREAM = 200,   // Unable to create a new stream (check herror/perror)
     IEINITSTREAM = 201,     // Unable to initialize stream (check herror/perror)
-    IESTREAMLISTEN = 202,   // Unable to start stream listener (check perror) 
+    IESTREAMLISTEN = 202,   // Unable to start stream listener (check perror)
     IESTREAMCONNECT = 203,  // Unable to connect stream (check herror/perror)
     IESTREAMACCEPT = 204,   // Unable to accepte stream connection (check perror)
     IESTREAMWRITE = 205,    // Unable to write to stream socket (check perror)

--- a/include/bluetooth/conn_ctx.h
+++ b/include/bluetooth/conn_ctx.h
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#ifndef BT_CONN_CTX_H_
+#define BT_CONN_CTX_H_
+
 /**
  * @file
  * @defgroup bt_conn_ctx Bluetooth connection context library API
  * @{
  * @brief API for the Bluetooth connection context library.
  */
-
-#ifndef BT_CONN_CTX_H_
-#define BT_CONN_CTX_H_
 
 #include <zephyr/kernel.h>
 #include <zephyr/sys/__assert.h>

--- a/include/bluetooth/enocean.h
+++ b/include/bluetooth/enocean.h
@@ -3,15 +3,16 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
+#ifndef BT_ENOCEAN_H__
+#define BT_ENOCEAN_H__
+
 /**
  * @file
  * @defgroup bt_enocean Bluetooth EnOcean library API
  * @{
  * @brief API for interacting with EnOcean Bluetooth wall switches and sensors
  */
-
-#ifndef BT_ENOCEAN_H__
-#define BT_ENOCEAN_H__
 
 #include <zephyr/bluetooth/bluetooth.h>
 

--- a/include/bluetooth/mesh/dk_prov.h
+++ b/include/bluetooth/mesh/dk_prov.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 /**
  * @file
  * @brief Bluetooth mesh provisioning handler for Nordic DKs.

--- a/include/bluetooth/mesh/gen_lvl_cli.h
+++ b/include/bluetooth/mesh/gen_lvl_cli.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 /**
  * @file
  * @defgroup bt_mesh_lvl_cli Generic Level Client model

--- a/include/bluetooth/mesh/gen_plvl.h
+++ b/include/bluetooth/mesh/gen_plvl.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 /**
  * @file
  * @defgroup bt_mesh_plvl Generic Power Level Models

--- a/include/bluetooth/mesh/gen_ponoff.h
+++ b/include/bluetooth/mesh/gen_ponoff.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 /**
  * @file
  * @defgroup bt_mesh_ponoff Generic Power OnOff Models

--- a/include/bluetooth/mesh/gen_ponoff_srv.h
+++ b/include/bluetooth/mesh/gen_ponoff_srv.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 /**
  * @file
  * @defgroup bt_mesh_ponoff_srv Generic Power OnOff Server model

--- a/include/bluetooth/mesh/gen_prop_cli.h
+++ b/include/bluetooth/mesh/gen_prop_cli.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 /**
  * @file
  * @defgroup bt_mesh_prop_cli Generic Property Client model

--- a/include/bluetooth/mesh/light_ctl.h
+++ b/include/bluetooth/mesh/light_ctl.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 /**
  * @file
  * @defgroup bt_mesh_light_ctl Light CTL models

--- a/include/bluetooth/mesh/light_hsl.h
+++ b/include/bluetooth/mesh/light_hsl.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 /**
  * @file
  * @defgroup bt_mesh_light_hsl Light HSL models

--- a/include/bluetooth/mesh/light_xyl.h
+++ b/include/bluetooth/mesh/light_xyl.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 /**
  * @file
  * @defgroup bt_mesh_light_xyl Light xyL models

--- a/include/bluetooth/mesh/model_types.h
+++ b/include/bluetooth/mesh/model_types.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 /**
  * @file
  * @defgroup bt_mesh_model_types Common model types

--- a/include/bluetooth/mesh/properties.h
+++ b/include/bluetooth/mesh/properties.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 /**
  * @file
  * @defgroup bt_mesh_properties Bluetooth mesh properties

--- a/include/bluetooth/mesh/sensor.h
+++ b/include/bluetooth/mesh/sensor.h
@@ -586,6 +586,6 @@ const char *bt_mesh_sensor_ch_str(const struct sensor_value *ch);
 }
 #endif
 
-/** @} */
-
 #endif /* BT_MESH_SENSOR_H__ */
+
+/** @} */

--- a/include/bluetooth/mesh/sensor_cli.h
+++ b/include/bluetooth/mesh/sensor_cli.h
@@ -670,6 +670,6 @@ extern const struct bt_mesh_model_cb _bt_mesh_sensor_cli_cb;
 }
 #endif
 
-/** @} */
-
 #endif /* BT_MESH_SENSOR_CLI_H__ */
+
+/** @} */

--- a/include/bluetooth/mesh/sensor_srv.h
+++ b/include/bluetooth/mesh/sensor_srv.h
@@ -151,6 +151,6 @@ extern const struct bt_mesh_model_op _bt_mesh_sensor_setup_srv_op[];
 }
 #endif
 
-/** @} */
-
 #endif /* BT_MESH_SENSOR_SRV_H__ */
+
+/** @} */

--- a/include/bluetooth/mesh/sensor_types.h
+++ b/include/bluetooth/mesh/sensor_types.h
@@ -1340,10 +1340,10 @@ extern const struct bt_mesh_sensor_type
 
 /** @} */
 
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* BT_MESH_SENSOR_TYPES_H__ */
+
+/** @} */

--- a/include/bluetooth/mesh/time.h
+++ b/include/bluetooth/mesh/time.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 /**
  * @file
  * @defgroup bt_mesh_time Time Models

--- a/include/bluetooth/scan.h
+++ b/include/bluetooth/scan.h
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-/**@file
+#ifndef BT_SCAN_H_
+#define BT_SCAN_H_
+
+/**
+ * @file
  * @defgroup nrf_bt_scan BT Scanning module
  * @{
  * @brief BT Scanning module
@@ -20,10 +24,6 @@
  * @note The Scanning Module also supports applications with a
  *       multicentral link.
  */
-
-
-#ifndef BT_SCAN_H_
-#define BT_SCAN_H_
 
 #include <zephyr/types.h>
 #include <zephyr/sys/slist.h>
@@ -566,6 +566,6 @@ void bt_scan_blocklist_clear(void);
 }
 #endif
 
-#endif /* BT_SCAN_H_ */
-
 /** @} */
+
+#endif /* BT_SCAN_H_ */

--- a/include/bluetooth/services/bas_client.h
+++ b/include/bluetooth/services/bas_client.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef __BAS_C_H
 #define __BAS_C_H
 

--- a/include/bluetooth/services/latency.h
+++ b/include/bluetooth/services/latency.h
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#ifndef BT_LATENCY_H_
+#define BT_LATENCY_H_
+
 /**
  * @file
  * @defgroup bt_latency Bluetooth LE GATT Latency Service API
  * @{
  * @brief API for the Bluetooth LE GATT Latency Service.
  */
-
-#ifndef BT_LATENCY_H_
-#define BT_LATENCY_H_
 
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/conn.h>

--- a/include/bluetooth/services/latency_client.h
+++ b/include/bluetooth/services/latency_client.h
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#ifndef BT_LATENCY_CLIENT_H_
+#define BT_LATENCY_CLIENT_H_
+
 /**
  * @file
  * @defgroup bt_latency_c Bluetooth LE GATT Latency Client API
  * @{
  * @brief API for the Bluetooth LE GATT Latency Client.
  */
-
-#ifndef BT_LATENCY_CLIENT_H_
-#define BT_LATENCY_CLIENT_H_
 
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/conn.h>

--- a/include/bluetooth/services/throughput.h
+++ b/include/bluetooth/services/throughput.h
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#ifndef BT_THROUGHPUT_H_
+#define BT_THROUGHPUT_H_
+
 /**
  * @file
  * @defgroup bt_throughput Bluetooth LE GATT Throughput Service API
  * @{
  * @brief API for the Bluetooth LE GATT Throughput Service.
  */
-
-#ifndef BT_THROUGHPUT_H_
-#define BT_THROUGHPUT_H_
 
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/conn.h>

--- a/include/bluetooth/services/wifi_provisioning.h
+++ b/include/bluetooth/services/wifi_provisioning.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef WIFI_PROVISIONING_H_
 #define WIFI_PROVISIONING_H_
 

--- a/include/caf/events/factory_reset_event.h
+++ b/include/caf/events/factory_reset_event.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef _FACTORY_RESET_EVENT_H_
 #define _FACTORY_RESET_EVENT_H_
 

--- a/include/caf/events/force_power_down_event.h
+++ b/include/caf/events/force_power_down_event.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef _FORCE_POWER_DOWN_EVENT_H_
 #define _FORCE_POWER_DOWN_EVENT_H_
 

--- a/include/caf/events/keep_alive_event.h
+++ b/include/caf/events/keep_alive_event.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef _KEEP_ALIVE_EVENT_H_
 #define _KEEP_ALIVE_EVENT_H_
 

--- a/include/caf/events/module_state_event.h
+++ b/include/caf/events/module_state_event.h
@@ -14,6 +14,7 @@
  * @brief CAF Module State Event.
  */
 
+
 #include <zephyr/sys/atomic.h>
 #include <app_event_manager.h>
 #include <app_event_manager_profiler_tracer.h>
@@ -323,8 +324,8 @@ static inline void module_set_state(enum module_state state)
 }
 #endif
 
-#endif /* defined(MODULE) && !defined(MODULE_NAME) */
-
 /**
  * @}
  */
+
+#endif /* defined(MODULE) && !defined(MODULE_NAME) */

--- a/include/caf/events/power_manager_event.h
+++ b/include/caf/events/power_manager_event.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef _POWER_MANAGER_EVENT_H_
 #define _POWER_MANAGER_EVENT_H_
 

--- a/include/caf/events/sensor_data_aggregator_event.h
+++ b/include/caf/events/sensor_data_aggregator_event.h
@@ -43,15 +43,15 @@ struct sensor_data_aggregator_release_buffer_event {
 	const char *sensor_descr;
 };
 
-/**
- * @}
- */
-
 APP_EVENT_TYPE_DECLARE(sensor_data_aggregator_event);
 APP_EVENT_TYPE_DECLARE(sensor_data_aggregator_release_buffer_event);
 
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* _AGGREGATOR_EVENT_H_ */

--- a/include/debug/cpu_load.h
+++ b/include/debug/cpu_load.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef __CPU_LOAD_H
 #define __CPU_LOAD_H
 

--- a/include/debug/ppi_trace.h
+++ b/include/debug/ppi_trace.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef __PPI_TRACE_H
 #define __PPI_TRACE_H
 

--- a/include/dfu/dfu_multi_image.h
+++ b/include/dfu/dfu_multi_image.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#ifndef DFU_MULTI_IMAGE_H__
+#define DFU_MULTI_IMAGE_H__
+
 /**
  * @defgroup dfu_multi_image DFU Multi Image
  * @brief Provides an API for writing DFU Multi Image package
@@ -36,9 +39,6 @@
  *
  * @{
  */
-
-#ifndef DFU_MULTI_IMAGE_H__
-#define DFU_MULTI_IMAGE_H__
 
 #include <stdbool.h>
 #include <stddef.h>

--- a/include/dfu/dfu_target_modem_delta.h
+++ b/include/dfu/dfu_target_modem_delta.h
@@ -90,6 +90,10 @@ int dfu_target_modem_delta_schedule_update(int img_num);
  */
 int dfu_target_modem_delta_reset(void);
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* DFU_TARGET_MODEM_H__ */
 
 /**@} */

--- a/include/dfu/dfu_target_stream.h
+++ b/include/dfu/dfu_target_stream.h
@@ -108,6 +108,10 @@ int dfu_target_stream_done(bool successful);
  */
 int dfu_target_stream_reset(void);
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* DFU_TARGET_STREAM_H__ */
 
 /**@} */

--- a/include/dfu/pcd.h
+++ b/include/dfu/pcd.h
@@ -143,6 +143,10 @@ int pcd_network_core_app_version(uint8_t *buf, size_t len);
 int pcd_find_fw_version(void);
 #endif /* CONFIG_PCD_READ_NETCORE_APP_VERSION */
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* PCD_H__ */
 
 /**@} */

--- a/include/esb.h
+++ b/include/esb.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef __ESB_H
 #define __ESB_H
 

--- a/include/mgmt/fmfu_mgmt.h
+++ b/include/mgmt/fmfu_mgmt.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#ifndef FMFU_MGMT_H__
+#define FMFU_MGMT_H__
+
 /** @file fmfu_mgmt.h
  * @defgroup fmfu_mgmt MCUMgr module for full Modem Firmware Upgrade
  * @{
@@ -16,9 +19,6 @@
  * The command values are 0 for get_hash and 1 for firmware_upload
  *
  */
-
-#ifndef FMFU_MGMT_H__
-#define FMFU_MGMT_H__
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/mgmt/fmfu_mgmt_stat.h
+++ b/include/mgmt/fmfu_mgmt_stat.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#ifndef MGMT_FMFU_STAT_H__
+#define MGMT_FMFU_STAT_H__
+
 /** @file fmfu_mgmt_stat.h
  * @defgroup fmfu_mgmt_stat MCUMgr hooks for Full Modem Firmware Upgrade stats
  * @{
@@ -13,9 +16,6 @@
  * SMP protocol MTU and frame size.
  *
  */
-
-#ifndef MGMT_FMFU_STAT_H__
-#define MGMT_FMFU_STAT_H__
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/modem/at_cmd_parser.h
+++ b/include/modem/at_cmd_parser.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef AT_CMD_PARSER_H__
 #define AT_CMD_PARSER_H__
 

--- a/include/modem/at_params.h
+++ b/include/modem/at_params.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef AT_PARAMS_H__
 #define AT_PARAMS_H__
 

--- a/include/modem/location.h
+++ b/include/modem/location.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef LOCATION_H_
 #define LOCATION_H_
 

--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef LTE_LC_H__
 #define LTE_LC_H__
 

--- a/include/modem/lte_lc_trace.h
+++ b/include/modem/lte_lc_trace.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef LTE_LC_TRACE_H__
 #define LTE_LC_TRACE_H__
 

--- a/include/modem/modem_attest_token.h
+++ b/include/modem/modem_attest_token.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef MODEM_ATTEST_TOKEN_H__
 #define MODEM_ATTEST_TOKEN_H__
 

--- a/include/modem/modem_battery.h
+++ b/include/modem/modem_battery.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef ZEPHYR_INCLUDE_MODEM_BATTERY_H_
 #define ZEPHYR_INCLUDE_MODEM_BATTERY_H_
 

--- a/include/modem/modem_jwt.h
+++ b/include/modem/modem_jwt.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef MODEM_JWT_H__
 #define MODEM_JWT_H__
 

--- a/include/modem/modem_slm.h
+++ b/include/modem/modem_slm.h
@@ -193,11 +193,10 @@ static inline void slm_monitor_resume(struct slm_monitor_entry *mon)
 	mon->paused = MON_ACTIVE;
 }
 
-
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif
+
+/** @} */
 
 #endif /* MODEM_SLM_H_ */

--- a/include/net/azure_iot_hub_dps.h
+++ b/include/net/azure_iot_hub_dps.h
@@ -129,12 +129,12 @@ int azure_iot_hub_dps_device_id_delete(void);
  */
 int azure_iot_hub_dps_reset(void);
 
-/**
- *@}
- */
-
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ *@}
+ */
 
 #endif /* AZURE_IOT_HUB_DPS__ */

--- a/include/net/coap_utils.h
+++ b/include/net/coap_utils.h
@@ -1,14 +1,15 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
 /**
  * @file
  * @defgroup coap_utils CoAP communication BSD socket API based
  * @{
  */
 
-/*
- * Copyright (c) 2020 Nordic Semiconductor ASA
- *
- * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
- */
 #ifndef __COAP_UTILS_H__
 #define __COAP_UTILS_H__
 
@@ -39,7 +40,7 @@ int coap_send_request(enum coap_method method, const struct sockaddr *addr,
 		      const char *const *uri_path_options, uint8_t *payload,
 		      uint16_t payload_size, coap_reply_t reply_cb);
 
-#endif
+#endif /* __COAP_UTILS_H__ */
 
 /**
  * @}

--- a/include/net/icalendar_parser.h
+++ b/include/net/icalendar_parser.h
@@ -137,10 +137,10 @@ int ical_parser_init(struct icalendar_parser *ical,
 size_t ical_parser_parse(struct icalendar_parser *ical,
 			const char *data, size_t len);
 
+/**@} */
+
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* ICAL_PARSER_H__ */
-
-/**@} */

--- a/include/net/mqtt_helper.h
+++ b/include/net/mqtt_helper.h
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#ifndef MQTT_HELPER__
+#define MQTT_HELPER__
+
 /**
  * @defgroup mqtt_helper MQTT helper library
  * @{
  * @brief Convenience library that simplifies Zephyr MQTT API and socket handling.
  */
-
-#ifndef MQTT_HELPER__
-#define MQTT_HELPER__
 
 #include <stdio.h>
 #include <zephyr/net/mqtt.h>

--- a/include/net/nrf_cloud_os.h
+++ b/include/net/nrf_cloud_os.h
@@ -37,10 +37,10 @@ struct nrf_cloud_os_mem_hooks {
  */
 void nrf_cloud_os_mem_hooks_init(struct nrf_cloud_os_mem_hooks *hooks);
 
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif
+
+/** @} */
 
 #endif /* NRF_CLOUD_OS_H__ */

--- a/include/net/nrf_provisioning.h
+++ b/include/net/nrf_provisioning.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 /**
  * @file nrf_provisioning.h
  *

--- a/include/net/rest_client.h
+++ b/include/net/rest_client.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#ifndef REST_CLIENT_H__
+#define REST_CLIENT_H__
+
 /**
  * @file rest_client.h
  *
@@ -13,9 +16,6 @@
  *
  * @details Provide REST client functionality.
  */
-
-#ifndef REST_CLIENT_H__
-#define REST_CLIENT_H__
 
 #include <zephyr/kernel.h>
 #include <zephyr/net/http/client.h>

--- a/include/nfc/ndef/ch.h
+++ b/include/nfc/ndef/ch.h
@@ -556,12 +556,12 @@ int nfc_ndef_ch_cr_rec_payload_encode(const struct nfc_ndef_ch_cr_rec *nfc_rec_c
  */
 #define NFC_NDEF_CR_RECORD_DESC(_name) NFC_NDEF_GENERIC_RECORD_DESC(_name)
 
-/**
- *@}
- */
-
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* NFC_NDEF_CH_H_ */

--- a/include/nfc/ndef/launchapp_msg.h
+++ b/include/nfc/ndef/launchapp_msg.h
@@ -50,12 +50,12 @@ int nfc_launchapp_msg_encode(uint8_t  const *android_package_name,
 			     uint8_t  *buf,
 			     size_t   *len);
 
-/**
- * @}
- */
-
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
  #endif // NFC_LAUNCHAPP_MSG_H__

--- a/include/nfc/ndef/launchapp_rec.h
+++ b/include/nfc/ndef/launchapp_rec.h
@@ -68,12 +68,12 @@ extern const uint8_t ndef_android_launchapp_rec_type[NFC_ANDROID_REC_TYPE_LENGTH
  */
 #define NFC_NDEF_ANDROID_LAUNCHAPP_RECORD_DESC(name) NFC_NDEF_RECORD_BIN_DATA(name)
 
-/**
- *@}
- */
-
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif // NFC_LAUNCHAPP_REC

--- a/include/nfc/ndef/msg_parser.h
+++ b/include/nfc/ndef/msg_parser.h
@@ -93,13 +93,12 @@ int nfc_ndef_msg_parse(uint8_t  *result_buf,
  */
 void nfc_ndef_msg_printout(const struct nfc_ndef_msg_desc *msg_desc);
 
-/**
- * @}
- */
-
-
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* NFC_NDEF_MSG_PARSER_H_ */

--- a/include/nfc/ndef/record_parser.h
+++ b/include/nfc/ndef/record_parser.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef NFC_NDEF_RECORD_PARSER_H_
 #define NFC_NDEF_RECORD_PARSER_H_
 
@@ -59,7 +60,6 @@ void nfc_ndef_record_printout(uint32_t num,
 /**
  * @}
  */
-
 
 #ifdef __cplusplus
 }

--- a/include/nfc/ndef/text_rec.h
+++ b/include/nfc/ndef/text_rec.h
@@ -131,10 +131,10 @@ extern const uint8_t nfc_ndef_text_rec_type_field[];
  */
 #define NFC_NDEF_TEXT_RECORD_DESC(name) NFC_NDEF_GENERIC_RECORD_DESC(name)
 
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif
+
+/** @} */
 
 #endif /* NFC_NDEF_TEXT_REC_H_ */

--- a/include/nfc/ndef/tnep_rec.h
+++ b/include/nfc/ndef/tnep_rec.h
@@ -223,12 +223,12 @@ int nfc_ndef_tnep_rec_svc_param_payload(struct nfc_ndef_tnep_rec_svc_param *payl
 
 #define NFC_NDEF_TNEP_RECORD_DESC(_name) NFC_NDEF_GENERIC_RECORD_DESC(_name)
 
-/**
- * @}
- */
-
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* NFC_NDEF_TNEP_REC_H_ */

--- a/include/nfc/ndef/uri_msg.h
+++ b/include/nfc/ndef/uri_msg.h
@@ -51,12 +51,12 @@ int nfc_ndef_uri_msg_encode(enum nfc_ndef_uri_rec_id uri_id_code,
 			    uint8_t *buf,
 			    uint32_t *len);
 
-/**
- * @}
- */
-
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* NFC_NDEF_URI_MSG_H */

--- a/include/nfc/ndef/uri_rec.h
+++ b/include/nfc/ndef/uri_rec.h
@@ -152,10 +152,10 @@ int nfc_ndef_uri_rec_payload_encode(struct nfc_ndef_uri_rec_payload *input,
  */
 #define NFC_NDEF_URI_RECORD_DESC(name) NFC_NDEF_GENERIC_RECORD_DESC(name)
 
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif
+
+/** @} */
 
 #endif /* NFC_NDEF_URI_REC_H_ */

--- a/include/nfc/t2t/parser.h
+++ b/include/nfc/t2t/parser.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef NFC_T2T_PARSER_H_
 #define NFC_T2T_PARSER_H_
 

--- a/include/nfc/t2t/tlv_block.h
+++ b/include/nfc/t2t/tlv_block.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef NFC_T2T_TLV_BLOCK_H_
 #define NFC_T2T_TLV_BLOCK_H_
 
@@ -80,13 +81,12 @@ struct nfc_t2t_tlv_block {
 /** Predefined length of the LOCK CONTROL and MEMORY CONTROL blocks. */
 #define NFC_T2T_TLV_LOCK_MEMORY_CTRL_LEN    3
 
-/**
- * @}
- */
-
-
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* NFC_T2T_TLV_BLOCK_H_ */

--- a/include/nfc/t4t/apdu.h
+++ b/include/nfc/t4t/apdu.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef NFC_T4T_APDU_H_
 #define NFC_T4T_APDU_H_
 
@@ -167,12 +168,12 @@ static inline void nfc_t4t_apdu_resp_clear(struct nfc_t4t_apdu_resp *resp_apdu)
 	memset(resp_apdu, 0, sizeof(struct nfc_t4t_apdu_resp));
 }
 
-/**
- * @}
- */
-
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* NFC_T4T_APDU_H_ */

--- a/include/nfc/t4t/cc_file.h
+++ b/include/nfc/t4t/cc_file.h
@@ -135,12 +135,12 @@ int nfc_t4t_cc_file_content_set(struct nfc_t4t_cc_file *t4t_cc_file,
  */
 void nfc_t4t_cc_file_printout(const struct nfc_t4t_cc_file *t4t_cc_file);
 
-/**
- *@}
- */
-
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ *@}
+ */
 
 #endif /* NFC_T4T_CC_FILE_H_ */

--- a/include/nfc/t4t/tlv_block.h
+++ b/include/nfc/t4t/tlv_block.h
@@ -124,12 +124,12 @@ int nfc_t4t_tlv_block_parse(struct nfc_t4t_tlv_block *file_control_tlv,
  */
 void nfc_t4t_tlv_block_printout(uint8_t num, const struct nfc_t4t_tlv_block *t4t_tlv_block);
 
-/**
- *@}
- */
-
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ *@}
+ */
 
 #endif /* NFC_T4T_TLV_BLOCK_H_ */

--- a/include/qos.h
+++ b/include/qos.h
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#ifndef QOS_H__
+#define QOS_H__
+
 /**
  * @defgroup qos Quality of Service library
  * @{
  * @brief QoS library that provides functionality to store and handle acknowledgment of multiple
  *	  in-flight messages.
  */
-
-#ifndef QOS_H__
-#define QOS_H__
 
 #include <zephyr/kernel.h>
 #include <stdbool.h>

--- a/include/sensor/paw3212.h
+++ b/include/sensor/paw3212.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef ZEPHYR_INCLUDE_PAW3212_H_
 #define ZEPHYR_INCLUDE_PAW3212_H_
 
@@ -51,12 +52,12 @@ enum paw3212_attribute {
 	PAW3212_ATTR_SLEEP3_SAMPLE_TIME,
 };
 
-#ifdef __cplusplus
-}
-#endif
-
 /**
  * @}
  */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZEPHYR_INCLUDE_PAW3212_H_ */

--- a/include/sensor/pmw3360.h
+++ b/include/sensor/pmw3360.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef ZEPHYR_INCLUDE_PMW3360_H_
 #define ZEPHYR_INCLUDE_PMW3360_H_
 
@@ -51,13 +52,12 @@ enum pmw3360_attribute {
 	PMW3360_ATTR_REST3_SAMPLE_TIME,
 };
 
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }
 #endif
-
-/**
- * @}
- */
 
 #endif /* ZEPHYR_INCLUDE_PMW3360_H_ */

--- a/include/zigbee/zigbee_app_utils.h
+++ b/include/zigbee/zigbee_app_utils.h
@@ -265,10 +265,10 @@ bool was_factory_reset_done(void);
 
 #endif /* CONFIG_ZIGBEE_FACTORY_RESET */
 
-#endif /* ZIGBEE_APP_UTILS_H__ */
-
 #ifdef __cplusplus
 }
 #endif
 
 /**@} */
+
+#endif /* ZIGBEE_APP_UTILS_H__ */

--- a/include/zigbee/zigbee_logger_eprxzcl.h
+++ b/include/zigbee/zigbee_logger_eprxzcl.h
@@ -46,10 +46,10 @@ extern "C" {
  */
 zb_uint8_t zigbee_logger_eprxzcl_ep_handler(zb_bufid_t bufid);
 
-#endif /* ZIGBEE_COMMON_ZIGBEE_LOGGER_EPRXZCL_H_ */
-
 #ifdef __cplusplus
 }
 #endif
 
 /**@} */
+
+#endif /* ZIGBEE_COMMON_ZIGBEE_LOGGER_EPRXZCL_H_ */

--- a/include/zigbee/zigbee_shell.h
+++ b/include/zigbee/zigbee_shell.h
@@ -73,10 +73,10 @@ zb_bool_t zb_shell_debug_get(void);
 zb_bool_t zb_shell_nvram_enabled(void);
 #endif /* CONFIG_ZIGBEE_SHELL_DEBUG_CMD */
 
-#endif /* ZIGBEE_SHELL_H__ */
-
 #ifdef __cplusplus
 }
 #endif
 
 /**@} */
+
+#endif /* ZIGBEE_SHELL_H__ */

--- a/lib/bin/lwm2m_carrier/include/lwm2m_carrier.h
+++ b/lib/bin/lwm2m_carrier/include/lwm2m_carrier.h
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#ifndef LWM2M_CARRIER_H__
+#define LWM2M_CARRIER_H__
+
 /**
  * @file lwm2m_carrier.h
  *
  * @defgroup lwm2m_carrier_api LwM2M carrier library API
  * @{
  */
-
-#ifndef LWM2M_CARRIER_H__
-#define LWM2M_CARRIER_H__
 
 #include <stdint.h>
 #include <stddef.h>

--- a/lib/bin/lwm2m_carrier/include/lwm2m_os.h
+++ b/lib/bin/lwm2m_carrier/include/lwm2m_os.h
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#ifndef LWM2M_OS_H__
+#define LWM2M_OS_H__
+
 /**
  * @file lwm2m_os.h
  *
  * @defgroup lwm2m_carrier_os LWM2M OS layer
  * @{
  */
-
-#ifndef LWM2M_OS_H__
-#define LWM2M_OS_H__
 
 #include <stddef.h>
 #include <stdint.h>

--- a/modules/hostap/src/supp_main.h
+++ b/modules/hostap/src/supp_main.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef __SUPP_MAIN_H_
 #define __SUPP_MAIN_H_
 

--- a/samples/bluetooth/direct_test_mode/src/dtm.h
+++ b/samples/bluetooth/direct_test_mode/src/dtm.h
@@ -365,5 +365,3 @@ int dtm_test_end(uint16_t *pack_cnt);
 #endif
 
 #endif /* DTM_H_ */
-
-/** @} */

--- a/samples/bluetooth/mesh/dfu/common/src/dfu_target.h
+++ b/samples/bluetooth/mesh/dfu/common/src/dfu_target.h
@@ -1,11 +1,11 @@
-/** @file
- *  @brief Bluetooth Mesh DFU Target role handler
- */
-
 /*
  * Copyright (c) 2021 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/** @file
+ *  @brief Bluetooth Mesh DFU Target role handler
  */
 
 #ifndef DFU_TARGET_H__

--- a/samples/bluetooth/mesh/light_dimmer/src/model_handler.c
+++ b/samples/bluetooth/mesh/light_dimmer/src/model_handler.c
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 /**
  * @file
  * @brief Model handler for the Light Dimmer Controller.

--- a/samples/bluetooth/mesh/light_switch/src/model_handler.c
+++ b/samples/bluetooth/mesh/light_switch/src/model_handler.c
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 /**
  * @file
  * @brief Model handler for the light switch.

--- a/samples/bluetooth/mesh/silvair_enocean/src/model_handler.c
+++ b/samples/bluetooth/mesh/silvair_enocean/src/model_handler.c
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 /**
  * @file
  * @brief Model handler for the Silvair EnOcean sample.

--- a/samples/cellular/lwm2m_client/src/ui/include/ui_input.h
+++ b/samples/cellular/lwm2m_client/src/ui/include/ui_input.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef UI_INPUT_H__
 #define UI_INPUT_H__
 

--- a/samples/net/mqtt/src/common/message_channel.h
+++ b/samples/net/mqtt/src/common/message_channel.h
@@ -37,4 +37,8 @@ enum network_status {
 
 ZBUS_CHAN_DECLARE(TRIGGER_CHAN, PAYLOAD_CHAN, NETWORK_CHAN, FATAL_ERROR_CHAN);
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* _MESSAGE_CHANNEL_H_ */

--- a/samples/openthread/coprocessor/src/nrf_802154_radio_wrapper.h
+++ b/samples/openthread/coprocessor/src/nrf_802154_radio_wrapper.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef __NRF_802154_RADIO_WRAPPER_H__
 #define __NRF_802154_RADIO_WRAPPER_H__
 
@@ -40,4 +41,4 @@ uint16_t nrf_802154_radio_wrapper_hw_capabilities_get(void);
 }
 #endif
 
-#endif
+#endif /* __NRF_802154_RADIO_WRAPPER_H__ */

--- a/samples/openthread/coprocessor/src/user_vendor_hook.cpp
+++ b/samples/openthread/coprocessor/src/user_vendor_hook.cpp
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 /**
  * @file
  *   This file shows how to implement the NCP vendor hook.

--- a/samples/wifi/twt/modules/traffic_gen/inc/traffic_gen_tcp.h
+++ b/samples/wifi/twt/modules/traffic_gen/inc/traffic_gen_tcp.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef __TRAFFIC_GEN_TCP_H__
 #define __TRAFFIC_GEN_TCP_H__
 

--- a/subsys/bluetooth/mesh/light_ctl_internal.h
+++ b/subsys/bluetooth/mesh/light_ctl_internal.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 /**
  * @file
  * @brief Internal Light CTL API

--- a/subsys/bluetooth/mesh/light_hsl_internal.h
+++ b/subsys/bluetooth/mesh/light_hsl_internal.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 /**
  * @file
  * @brief Internal Light HSL API

--- a/subsys/bluetooth/mesh/lightness_internal.h
+++ b/subsys/bluetooth/mesh/lightness_internal.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 /**
  * @file
  * @brief Light Lightness model internal defines

--- a/subsys/bluetooth/mesh/model_utils.h
+++ b/subsys/bluetooth/mesh/model_utils.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 /**
  * @file
  * @defgroup bt_mesh_model_utils Model utility functions.

--- a/subsys/bluetooth/mesh/sensor.h
+++ b/subsys/bluetooth/mesh/sensor.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 /**
  * @file
  * @brief Internal sensor API

--- a/subsys/bluetooth/mesh/time_internal.h
+++ b/subsys/bluetooth/mesh/time_internal.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 /**
  * @file
  * @brief Internal time API

--- a/subsys/bluetooth/mesh/time_util.h
+++ b/subsys/bluetooth/mesh/time_util.h
@@ -43,5 +43,3 @@ int ts_to_tai(struct bt_mesh_time_tai *tai, const struct tm *timeptr);
 #endif
 
 #endif /* BT_MESH_TIME_UTIL */
-
-/** @} */

--- a/subsys/bluetooth/services/cgms/cgms_internal.h
+++ b/subsys/bluetooth/services/cgms/cgms_internal.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef BT_CGMS_INTERNAL_H_
 #define BT_CGMS_INTERNAL_H_
 

--- a/subsys/bluetooth/services/wifi_prov/wifi_prov_internal.h
+++ b/subsys/bluetooth/services/wifi_prov/wifi_prov_internal.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef WIFI_PROV_INTERNAL_H
 #define WIFI_PROV_INTERNAL_H
 

--- a/subsys/bootloader/bl_validation/bl_validation_internal.h
+++ b/subsys/bootloader/bl_validation/bl_validation_internal.h
@@ -47,4 +47,4 @@ static bool region_within(uint32_t inner_start, uint32_t inner_end,
 }
 #endif
 
-#endif
+#endif /* BL_VALIDATION_INTERNAL_H__ */

--- a/subsys/net/lib/aws_fota/include/aws_fota_json.h
+++ b/subsys/net/lib/aws_fota/include/aws_fota_json.h
@@ -4,6 +4,9 @@
  *SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#ifndef AWS_FOTA_JSON_H__
+#define AWS_FOTA_JSON_H__
+
 /**@file aws_fota_json.h
  *
  * @defgroup aws_fota_json
@@ -11,9 +14,6 @@
  * @brief  Library for parsing AWS Jobs json payloads.
  *
  */
-
-#ifndef AWS_FOTA_JSON_H__
-#define AWS_FOTA_JSON_H__
 
 #ifdef __cplusplus
 extern "C" {

--- a/subsys/net/lib/ftp_client/src/ftp_commands.h
+++ b/subsys/net/lib/ftp_client/src/ftp_commands.h
@@ -103,5 +103,3 @@ extern "C" {
 #endif
 
 #endif /* FTP_COMMANDS_ */
-
-/**@} */

--- a/subsys/net/lib/mcumgr_smp_client/include/mcumgr_smp_client.h
+++ b/subsys/net/lib/mcumgr_smp_client/include/mcumgr_smp_client.h
@@ -89,4 +89,12 @@ int mcumgr_smp_client_erase(void);
  */
 int mcumgr_smp_client_confirm_image(void);
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* MCUMGR_SMP_CLIENT_H_ */
+
+/**
+ *@}
+ */

--- a/subsys/net/lib/nrf_provisioning/include/nrf_provisioning_http.h
+++ b/subsys/net/lib/nrf_provisioning/include/nrf_provisioning_http.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 /**
  * @file nrf_provisioning_http.h
  *

--- a/subsys/net/lib/nrf_provisioning/include/nrf_provisioning_internal.h
+++ b/subsys/net/lib/nrf_provisioning/include/nrf_provisioning_internal.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef NRF_PROVISIONING_INTERNAL_H__
 #define NRF_PROVISIONING_INTERNAL_H__
 

--- a/subsys/net/lib/nrf_provisioning/include/nrf_provisioning_jwt.h
+++ b/subsys/net/lib/nrf_provisioning/include/nrf_provisioning_jwt.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 /**
  * @file nrf_provisioning_jwt.h
  *

--- a/subsys/net_core_monitor/common.h
+++ b/subsys/net_core_monitor/common.h
@@ -7,7 +7,6 @@
 #ifndef COMMON_H_
 #define COMMON_H_
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -25,9 +24,5 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-/**
- * @}
- */
 
 #endif /* COMMON_H_ */

--- a/subsys/nfc/lib/platform_internal.h
+++ b/subsys/nfc/lib/platform_internal.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef NFC_PLATFORM_INTERNAL_H_
 #define NFC_PLATFORM_INTERNAL_H_
 
@@ -32,12 +33,12 @@ extern "C" {
  */
 int nfc_platform_internal_init(nfc_lib_cb_resolve_t cb_rslv);
 
-/**
- * @}
- */
-
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* NFC_PLATFORM_INTERNAL_H_ */

--- a/subsys/nfc/ndef/msg_parser_local.h
+++ b/subsys/nfc/ndef/msg_parser_local.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef NFC_NDEF_MSG_PARSER_LOCAL_H_
 #define NFC_NDEF_MSG_PARSER_LOCAL_H_
 
@@ -82,12 +83,12 @@ int nfc_ndef_msg_parser_internal(struct nfc_ndef_parser_memo_desc *parser_memo_d
 				 const uint8_t *nfc_data,
 				 uint32_t *nfc_data_len);
 
-/**
- * @}
- */
-
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* NFC_NDEF_MSG_PARSER_LOCAL_H_ */

--- a/subsys/nrf_security/src/psa/psa_native_its_backend.h
+++ b/subsys/nrf_security/src/psa/psa_native_its_backend.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef PSA_NATIVE_ITS_BACKEND_H
 #define PSA_NATIVE_ITS_BACKEND_H
 

--- a/tests/subsys/net/lib/download_client/src/mock/dl_coap.h
+++ b/tests/subsys/net/lib/download_client/src/mock/dl_coap.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef _DL_COAP_H_
 #define _DL_COAP_H_
 

--- a/tests/subsys/net/lib/download_client/src/mock/dl_http.h
+++ b/tests/subsys/net/lib/download_client/src/mock/dl_http.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef _DL_HTTP_H_
 #define _DL_HTTP_H_
 

--- a/tests/subsys/net/lib/download_client/src/mock/socket.h
+++ b/tests/subsys/net/lib/download_client/src/mock/socket.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef _SOCKET_H_
 #define _SOCKET_H_
 

--- a/tests/subsys/net/lib/nrf_provisioning/include/coap_client.h
+++ b/tests/subsys/net/lib/nrf_provisioning/include/coap_client.h
@@ -1,16 +1,17 @@
-/** @file
- * @brief CoAP client API
- *
- * An API for applications to do CoAP requests
- */
-
 /*
  * Copyright (c) 2023 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef ZEPHYR_INCLUDE_NET_COAP_CLIENT_H_
 #define ZEPHYR_INCLUDE_NET_COAP_CLIENT_H_
+
+/** @file
+ * @brief CoAP client API
+ *
+ * An API for applications to do CoAP requests
+ */
 
 /**
  * @brief CoAP client API

--- a/tests/subsys/net/lib/nrf_provisioning/include/nrf_modem_at.h
+++ b/tests/subsys/net/lib/nrf_provisioning/include/nrf_modem_at.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 /**
  * @file nrf_modem_at.h
  *

--- a/tests/unity/example_test/src/example_test.h
+++ b/tests/unity/example_test/src/example_test.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef EXAMPLE_TEST_H_
 #define EXAMPLE_TEST_H_
 

--- a/tests/unity/example_test/src/uut/uut.h
+++ b/tests/unity/example_test/src/uut/uut.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef __UUT_H
 #define __UUT_H
 

--- a/tests/unity/unity_config.h
+++ b/tests/unity/unity_config.h
@@ -2,6 +2,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef UNITY_CONFIG_H__
 #define UNITY_CONFIG_H__
 

--- a/tests/unity/wrap_test/src/call/call.h
+++ b/tests/unity/wrap_test/src/call/call.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef __CALL_H
 #define __CALL_H
 


### PR DESCRIPTION
* Make sure all C++ C includes have an end.
* Correct order of ifdefs and doxygen so that they are in the correct order. The order is not aligned from file to file, though it is corrected per file.
* Added space after license in some headers and source files.