### PR TITLE
applications: nrf5340_audio: Use bt_hci_get_ver_str()

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/bt_management/controller_config/bt_mgmt_ctlr_cfg.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/controller_config/bt_mgmt_ctlr_cfg.c
@@ -147,20 +147,6 @@ static void wdt_timeout_cb(int channel_id, void *user_data)
 	ERR_CHK_MSG(-ETIMEDOUT, "Controller not responsive");
 }
 
-static const char *bt_spec_ver_str(uint8_t version_number)
-{
-	const char * const bt_ver_str[] = {
-		"1.0b", "1.1", "1.2", "2.0", "2.1", "3.0", "4.0", "4.1", "4.2",
-		"5.0", "5.1", "5.2", "5.3", "5.4"
-	};
-
-	if (version_number < ARRAY_SIZE(bt_ver_str)) {
-		return bt_ver_str[version_number];
-	}
-
-	return "unknown";
-}
-
 int bt_mgmt_ctlr_cfg_manufacturer_get(bool print_version, uint16_t *manufacturer)
 {
 	int ret;
@@ -180,7 +166,7 @@ int bt_mgmt_ctlr_cfg_manufacturer_get(bool print_version, uint16_t *manufacturer
 		} else if (rp->manufacturer == COMPANY_ID_NORDIC) {
 			/* NOTE: The string below is used by the Nordic CI system */
 			LOG_INF("Controller: SoftDevice: Version %s (0x%02x), Revision %d",
-				bt_spec_ver_str(rp->hci_version),
+				bt_hci_get_ver_str(rp->hci_version),
 				rp->hci_version,
 				rp->hci_revision);
 		} else {


### PR DESCRIPTION
The added API replaces an internal copy.