### PR TITLE
samples: bluetooth: central_uart: Fix memory leak

### DIFF
--- a/samples/bluetooth/central_uart/src/main.c
+++ b/samples/bluetooth/central_uart/src/main.c
@@ -67,12 +67,6 @@ static void ble_data_sent(struct bt_nus_client *nus, uint8_t err,
 {
 	ARG_UNUSED(nus);
 
-	struct uart_data_t *buf;
-
-	/* Retrieve buffer context. */
-	buf = CONTAINER_OF(data, struct uart_data_t, data);
-	k_free(buf);
-
 	k_sem_give(&nus_write_sem);
 
 	if (err) {
@@ -624,5 +618,7 @@ int main(void)
 		if (err) {
 			LOG_WRN("NUS send timeout");
 		}
+
+		k_free(buf);
 	}
 }


### PR DESCRIPTION
On failure to send data using the `bt_nus_client_send` function
the allocated buffer was not freed. This commit fixes that.