### PR TITLE
samples: net: Add explicit calls to `conn_mgr_all_if_connect()`

### DIFF
--- a/samples/net/aws_iot/src/main.c
+++ b/samples/net/aws_iot/src/main.c
@@ -238,6 +238,13 @@ static void on_aws_iot_evt_fota_done(const struct aws_iot_evt *const evt)
 			return;
 		}
 
+		err = conn_mgr_all_if_connect(true);
+		if (err) {
+			LOG_ERR("conn_mgr_all_if_connect, error: %d", err);
+			FATAL_ERROR();
+			return;
+		}
+
 	} else if (evt->data.image & DFU_TARGET_IMAGE_TYPE_ANY_APPLICATION) {
 		LOG_INF("Application FOTA done, rebooting");
 		IF_ENABLED(CONFIG_REBOOT, (sys_reboot(0)));
@@ -369,6 +376,13 @@ int main(void)
 	err = conn_mgr_all_if_up(true);
 	if (err) {
 		LOG_ERR("conn_mgr_all_if_up, error: %d", err);
+		FATAL_ERROR();
+		return err;
+	}
+
+	err = conn_mgr_all_if_connect(true);
+	if (err) {
+		LOG_ERR("conn_mgr_all_if_connect, error: %d", err);
 		FATAL_ERROR();
 		return err;
 	}

--- a/samples/net/azure_iot_hub/src/main.c
+++ b/samples/net/azure_iot_hub/src/main.c
@@ -576,6 +576,12 @@ int main(void)
 		return err;
 	}
 
+	err = conn_mgr_all_if_connect(true);
+	if (err) {
+		LOG_ERR("conn_mgr_all_if_connect, error: %d", err);
+		return err;
+	}
+
 #if IS_ENABLED(CONFIG_AZURE_IOT_HUB_SAMPLE_DEVICE_ID_USE_HW_ID)
 	err = hw_id_get(device_id, ARRAY_SIZE(device_id));
 	if (err) {

--- a/samples/net/coap_client/src/main.c
+++ b/samples/net/coap_client/src/main.c
@@ -385,7 +385,6 @@ int main(void)
 		return err;
 	}
 
-
 	/* Start the infinite coap request loop. */
 	coap_loop();
 

--- a/samples/net/mqtt/src/modules/network/network.c
+++ b/samples/net/mqtt/src/modules/network/network.c
@@ -88,6 +88,13 @@ static void network_task(void)
 		return;
 	}
 
+	err = conn_mgr_all_if_connect(true);
+	if (err) {
+		LOG_ERR("conn_mgr_all_if_connect, error: %d", err);
+		SEND_FATAL_ERROR();
+		return;
+	}
+
 	/* Resend connection status if the sample is built for Native Posix.
 	 * This is necessary because the network interface is automatically brought up
 	 * at SYS_INIT() before main() is called.

--- a/samples/net/udp/src/main.c
+++ b/samples/net/udp/src/main.c
@@ -170,6 +170,13 @@ int main(void)
 		return err;
 	}
 
+	err = conn_mgr_all_if_connect(true);
+	if (err) {
+		LOG_ERR("conn_mgr_all_if_connect, error: %d", err);
+		FATAL_ERROR();
+		return err;
+	}
+
 	/* Resend connection status if the sample is built for QEMU x86.
 	 * This is necessary because the network interface is automatically brought up
 	 * at SYS_INIT() before main() is called.


### PR DESCRIPTION
Add explicit calls to `conn_mgr_all_if_connect()` to connect to the network using the Zephyr NET connection manager.

This is needed due to `CONFIG_NRF_MODEM_LIB_NET_IF_AUTO_CONNECT` not being set by default anymore. This ensures that users gets a clear understanding of when connection is attempted by the sample.