### PR TITLE
drivers: mpsl: Fix for simulation

### DIFF
--- a/drivers/mpsl/flash_sync/flash_sync_mpsl.c
+++ b/drivers/mpsl/flash_sync/flash_sync_mpsl.c
@@ -142,9 +142,18 @@ void nrf_flash_sync_set_context(uint32_t duration)
 
 static bool is_in_fault_isr(void)
 {
+#if defined(CONFIG_ARM)
 	int32_t irqn = __get_IPSR() - 16;
 
 	return (irqn >= HardFault_IRQn && irqn <= UsageFault_IRQn);
+#elif defined(CONFIG_ARCH_POSIX)
+	/* Faults of this type cause the program to exit in the POSIX
+	 * architecture, therefore we cannot be in one.
+	 */
+	return false;
+#else
+#error "Architecture not supported, please implement me"
+#endif
 }
 
 bool nrf_flash_sync_is_required(void)


### PR DESCRIPTION
1cd8b82110b3dc4d344b52f58bb149d3edaf9134
introduced a check to see if the flash operation
is running on a hardfault or not.

But that check works only in ARM devices.

Let's fix it by adding a variant for the
POSIX architecture and an error for other
architectures.

-----

Related to https://github.com/nrfconnect/sdk-nrf/pull/12533