### PR TITLE
MPSL/SoftDevice Controller: Lower footprint of assertion print

### DIFF
--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -250,8 +250,18 @@ void sdc_assertion_handler(const char *const file, const uint32_t line)
 #else /* !IS_ENABLED(CONFIG_BT_CTLR_ASSERT_HANDLER) */
 void sdc_assertion_handler(const char *const file, const uint32_t line)
 {
+#if defined(CONFIG_ASSERT) && defined(CONFIG_ASSERT_VERBOSE) && !defined(CONFIG_ASSERT_NO_MSG_INFO)
+	__ASSERT(false, "SoftDevice Controller ASSERT: %s, %d\n", file, line);
+#elif defined(CONFIG_LOG)
 	LOG_ERR("SoftDevice Controller ASSERT: %s, %d", file, line);
 	k_oops();
+#elif defined(CONFIG_PRINTK)
+	printk("SoftDevice Controller ASSERT: %s, %d\n", file, line);
+	printk("\n");
+	k_oops();
+#else
+	k_oops();
+#endif
 }
 #endif /* IS_ENABLED(CONFIG_BT_CTLR_ASSERT_HANDLER) */
 

--- a/subsys/mpsl/init/mpsl_init.c
+++ b/subsys/mpsl/init/mpsl_init.c
@@ -189,8 +189,18 @@ void m_assert_handler(const char *const file, const uint32_t line)
 #else /* !IS_ENABLED(CONFIG_MPSL_ASSERT_HANDLER) */
 static void m_assert_handler(const char *const file, const uint32_t line)
 {
+#if defined(CONFIG_ASSERT) && defined(CONFIG_ASSERT_VERBOSE) && !defined(CONFIG_ASSERT_NO_MSG_INFO)
+	__ASSERT(false, "MPSL ASSERT: %s, %d\n", file, line);
+#elif defined(CONFIG_LOG)
 	LOG_ERR("MPSL ASSERT: %s, %d", file, line);
 	k_oops();
+#elif defined(CONFIG_PRINTK)
+	printk("MPSL ASSERT: %s, %d\n", file, line);
+	printk("\n");
+	k_oops();
+#else
+	k_oops();
+#endif
 }
 #endif /* IS_ENABLED(CONFIG_MPSL_ASSERT_HANDLER) */
 


### PR DESCRIPTION
Previously it was a requirement that logging was enabled to print out assertions. As this configuration has significant memory footprint, allow printing the assertion message using verbose assertions or printk if it is enabled.