### PR TITLE
applications: asset_tracker_v2: Update LwM2M P-GPS configuration

### DIFF
--- a/applications/asset_tracker_v2/src/modules/Kconfig.cloud_module
+++ b/applications/asset_tracker_v2/src/modules/Kconfig.cloud_module
@@ -15,12 +15,8 @@ if CLOUD_MODULE
 CLOUD_SERVICE_SELECTOR := choice
 
 # nRF Cloud A-GNSS is enabled by default when building for all supported cloud transport services.
-# For LwM2M builds, A-GNSS is disabled if P-GPS is enabled.
-# This is because the two methods are currently mutually exclusive for LwM2M builds.
-# For the other cloud configurations, A-GNSS and P-GPS can coexist.
 config NRF_CLOUD_AGNSS
 	depends on LOCATION_MODULE
-	default n if NRF_CLOUD_PGPS && LWM2M_INTEGRATION
 	default y
 
 # Enable MQTT clean session by default. This is to ensure that the configured cloud MQTT service


### PR DESCRIPTION
Previously, A-GNSS and P-GPS were not supported at the same time with LwM2M. This is no longer true, so the configuration has been updated accordingly.