### PR TITLE
doc: update CI to upload doc to dev server

### DIFF
--- a/.github/workflows/docpublish.yml
+++ b/.github/workflows/docpublish.yml
@@ -57,6 +57,8 @@ jobs:
             sftp -v -i zoomin_key nordic@upload-v1.zoominsoftware.io <<EOF
             cd docs-be.nordicsemi.com/sphinx-html/incoming
             put ${file}
+            cd nordic-be-dev.zoominsoftware.io/sphinx-html/incoming
+            put ${file}
             quit
           EOF
           done


### PR DESCRIPTION
Change Github workflow so that latest doc is not only uploaded to official site but also to dev server.