### PR TITLE
manifest: sdk-zephyr: ble mesh adv and tfm psa usage improvements

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: ac5a9860b73bdbde2e8ba936fdc35a5e7654189c
+      revision: 533baa16b5a6750cf59a7ce7257bc09bcac09637
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Patch from upstream with improvements of adv and
tfm psa usage to run them on CI on regular base
as well as improve system tests.