### PR TITLE
net: lwm2m_client_utils: Location assintance retry update

### DIFF
--- a/doc/nrf/libraries/networking/lwm2m_location_assistance.rst
+++ b/doc/nrf/libraries/networking/lwm2m_location_assistance.rst
@@ -128,9 +128,10 @@ It can have three different values:
 * ``-1`` - A permanent error in the server needs fixing.
   The library will reject further requests and the device must be rebooted after the issue has been resolved in the server.
 * ``1``  - Due to a temporary error in the server, the device needs to retry sending the request after a while.
+* ``2`` - When no response has been received from the server in LOCATION_ASSISTANT_RESULT_TIMEOUT seconds.
 
 The library has a resend handler for the temporary error code.
-You can initialize it with the :c:func:`location_assistance_init_resend_handler` function.
+You can initialize it with the :c:func:`location_assistance_retry_init` function.
 It uses an exponential backoff for scheduling the resends.
 
 The library has a callback handler for the result code.

--- a/include/net/lwm2m_client_utils_location.h
+++ b/include/net/lwm2m_client_utils_location.h
@@ -32,14 +32,16 @@
 #define LOCATION_ASSIST_RESULT_CODE_OK			0
 #define LOCATION_ASSIST_RESULT_CODE_PERMANENT_ERR	-1
 #define LOCATION_ASSIST_RESULT_CODE_TEMP_ERR		1
+#define LOCATION_ASSIST_RESULT_CODE_NO_RESP_ERR		2
 
 /**
  * @typedef location_assistance_result_code_cb_t
  * @brief Callback for location assistance result.
  *
- * This callback is called whenever there is a new result in the location assistance and the
- * location assistance resend handler has been initialized.
+ * This callback is called whenever there is a new result in the location assistance from Ground
+ * or GNSS location object.
  *
+ * @param object_id   Object identifier GROUND_FIX_OBJECT_ID or GNSS_ASSIST_OBJECT_ID
  * @param result_code Contains following possible result codes:
  *                    LOCATION_ASSIST_RESULT_CODE_OK when there are no problems
  *                    LOCATION_ASSIST_RESULT_CODE_PERMANENT_ERR when there is a permanent error
@@ -47,10 +49,12 @@
  *                    longer send any requests. Device needs reboot for assistance library to
  *                    resume operation.
  *                    LOCATION_ASSIST_RESULT_CODE_TEMP_ERR when there is a temporary error between
- *                    LwM2M-server and the nRF Cloud. The library automatically uses exponential
+ *                    LwM2M server and the nRF Cloud. The library automatically uses exponential
  *                    backoff for the retries.
+ *                    LOCATION_ASSIST_RESULT_CODE_NO_RESP_ERR when no response has been received
+ *                    from the server in LOCATION_ASSISTANT_RESULT_TIMEOUT seconds.
  */
-typedef void (*location_assistance_result_code_cb_t)(int32_t result_code);
+typedef void (*location_assistance_result_code_cb_t)(uint16_t object_id, int32_t result_code);
 
 /**
  * @brief Set the location assistance result code calback
@@ -100,10 +104,9 @@ int location_assistance_pgps_request_send(struct lwm2m_ctx *ctx);
  *        Handler will handle the result code from server and schedule resending in
  *        case of temporary error in server using an exponential backoff.
  *
- * @return Returns a negative error code (errno.h) indicating
- *         reason of failure or 0 for success.
+ * @param enable_resend Set to true to allow retrying.
  */
-int location_assistance_init_resend_handler(void);
+void location_assistance_retry_init(bool enable_resend);
 
 /**
  * @brief Initialize the location assistance event handler

--- a/samples/cellular/lwm2m_client/src/main.c
+++ b/samples/cellular/lwm2m_client/src/main.c
@@ -317,7 +317,7 @@ static int lwm2m_setup(void)
 #endif
 #if defined(CONFIG_LWM2M_CLIENT_UTILS_LOCATION_ASSISTANCE)
 	location_event_handler_init(&client);
-	location_assistance_init_resend_handler();
+	location_assistance_retry_init(true);
 #endif
 #if defined(CONFIG_LWM2M_CLIENT_UTILS_CELL_CONN_OBJ_SUPPORT)
 	lwm2m_init_cellular_connectivity_object();

--- a/subsys/net/lib/lwm2m_client_utils/CMakeLists.txt
+++ b/subsys/net/lib/lwm2m_client_utils/CMakeLists.txt
@@ -20,6 +20,8 @@ zephyr_library_sources_ifdef(CONFIG_LWM2M_CLIENT_UTILS_GNSS_ASSIST_OBJ_SUPPORT
 			     lwm2m/gnss_assistance_obj.c)
 zephyr_library_sources_ifdef(CONFIG_LWM2M_CLIENT_UTILS_LOCATION_ASSISTANCE
 			     location/location_assistance.c)
+zephyr_library_sources_ifdef(CONFIG_LWM2M_CLIENT_UTILS_LOCATION_ASSISTANCE
+			     location/location_retry_timer.c)
 zephyr_library_sources_ifdef(CONFIG_LWM2M_CLIENT_UTILS_RAI
 			     lwm2m/lwm2m_rai.c)
 zephyr_library_sources(lwm2m/lwm2m_lte_notification.c)

--- a/subsys/net/lib/lwm2m_client_utils/location/location_retry_timer.c
+++ b/subsys/net/lib/lwm2m_client_utils/location/location_retry_timer.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
+
+#include <net/lwm2m_client_utils_location.h>
+#include <zephyr/net/lwm2m.h>
+
+#include "location_assistance.h"
+
+void location_retry_timer_cancel(struct assistance_retry_data *retry_info)
+{
+	int status = k_work_delayable_busy_get(&retry_info->worker);
+
+	retry_info->timeout_period = 0;
+	if (status && !(status & K_WORK_RUNNING)) {
+		k_work_cancel_delayable(&retry_info->worker);
+	}
+}
+
+void location_retry_timer_start(struct assistance_retry_data *retry_info)
+{
+	/* Init or cancel worker */
+	location_retry_timer_cancel(retry_info);
+	retry_info->timeout_period = LOCATION_ASSISTANT_RESULT_TIMEOUT;
+	k_work_schedule(&retry_info->worker, K_SECONDS(LOCATION_ASSISTANT_UPDATE_PERIOD));
+}
+
+void location_retry_timer_temp_error(struct assistance_retry_data *retry_info)
+{
+	retry_info->temp_error = true;
+	k_work_schedule(&retry_info->worker, K_SECONDS(retry_info->retry_seconds));
+	if (retry_info->retry_seconds < LOCATION_ASSISTANT_MAXIMUM_RETRY_INTERVAL) {
+		retry_info->retry_seconds *= 2;
+	}
+}
+
+void location_retry_timer_ok(struct assistance_retry_data *retry_info)
+{
+	retry_info->retry_seconds = 0;
+	retry_info->temp_error = false;
+}
+
+bool location_retry_timer_timeout(struct assistance_retry_data *retry_info)
+{
+
+	if (!retry_info->timeout_period) {
+		return true;
+	}
+
+	if (retry_info->timeout_period > LOCATION_ASSISTANT_UPDATE_PERIOD) {
+		retry_info->timeout_period -= LOCATION_ASSISTANT_UPDATE_PERIOD;
+		k_work_schedule(&retry_info->worker, K_SECONDS(LOCATION_ASSISTANT_UPDATE_PERIOD));
+		/* Trigger update for possible pending data at server */
+		lwm2m_rd_client_update();
+		return false;
+	}
+
+	retry_info->timeout_period = 0;
+	return true;
+}
+
+bool location_retry_timer_report_no_response(struct assistance_retry_data *retry_info)
+{
+	if (retry_info->retry_left) {
+		retry_info->retry_left--;
+		return false;
+	}
+	return true;
+}

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/gnss_assistance_obj.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/gnss_assistance_obj.c
@@ -199,6 +199,12 @@ void gnss_assistance_prepare_download(void)
 	request_ongoing = true;
 }
 
+void gnss_assistance_download_cancel(void)
+{
+	bytes_downloaded = 0;
+	request_ongoing = false;
+}
+
 bool location_assist_gnss_is_busy(void)
 {
 	return request_ongoing;

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/ground_fix_obj.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/ground_fix_obj.c
@@ -68,6 +68,12 @@ static int ground_fix_result_code_cb(uint16_t obj_inst_id, uint16_t res_id,
 				     uint16_t data_len, bool last_block,
 				     size_t total_size)
 {
+	if (data_len != sizeof(int32_t)) {
+		return -EINVAL;
+	}
+
+	result =  *(int32_t *)data;
+
 	if (result_code_cb) {
 		result_code_cb(result);
 	}

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/include/gnss_assistance_obj.h
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/include/gnss_assistance_obj.h
@@ -15,6 +15,7 @@ typedef void (*gnss_assistance_get_result_code_cb_t)(int32_t result_code);
 void gnss_assistance_set_result_code_cb(gnss_assistance_get_result_code_cb_t cb);
 
 void gnss_assistance_prepare_download(void);
+void gnss_assistance_download_cancel(void);
 int location_assist_agnss_alloc_buf(size_t buf_size);
 bool location_assist_gnss_is_busy(void);
 int location_assist_gnss_type_set(int assistance_type);

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/include/location_assistance.h
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/include/location_assistance.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef LWM2M_CLIENT_UTILS_LOCATION_ASSISTANCE_INTERNAL_H__
+#define LWM2M_CLIENT_UTILS_LOCATION_ASSISTANCE_INTERNAL_H__
+
+#include <zephyr/kernel.h>
+
+#define LOCATION_ASSISTANT_RESULT_TIMEOUT 180
+
+#define LOCATION_ASSISTANT_UPDATE_PERIOD 60
+#define LOCATION_ASSISTANT_INITIAL_RETRY_INTERVAL 675
+#define LOCATION_ASSISTANT_MAXIMUM_RETRY_INTERVAL 86400
+
+struct assistance_retry_data {
+	struct k_work_delayable worker;
+	int timeout_period;
+	int retry_left;
+	int retry_seconds;
+	bool temp_error;
+};
+
+void location_retry_timer_cancel(struct assistance_retry_data *retry_info);
+void location_retry_timer_start(struct assistance_retry_data *retry_info);
+void location_retry_timer_temp_error(struct assistance_retry_data *retry_info);
+void location_retry_timer_ok(struct assistance_retry_data *retry_info);
+bool location_retry_timer_timeout(struct assistance_retry_data *retry_info);
+bool location_retry_timer_report_no_response(struct assistance_retry_data *retry_info);
+
+#endif /* LWM2M_CLIENT_UTILS_LOCATION_ASSISTANCE_INTERNAL_H__ */


### PR DESCRIPTION
Removed location_assistance_init_resend_handler() and added location_assistance_retry_init() for dynamically
support resend handler functionality.

Updated location_assistance_set_result_code_cb: added Object id for indicate which Location object result code is updated.

New result code LOCATION_ASSIST_RESULT_CODE_NO_RESP_ERR which will be informed if server is not send any response.

Updated  assistance data request for do trigger lwm2m registration update in 60 seconds period for fixing to get pending requested data. After 3 minute Assistance data will be re-sended if re-send is enabled other wise LOCATION_ASSIST_RESULT_CODE_NO_RESP_ERR.

Updated Unit test and added test for timeout and re-send.

Signed-off-by: Juha Heiskanen <juha.heiskanen@nordicsemi.no>