### PR TITLE
applications: nrf5340_audio: Add timeout when creating PA sync

### DIFF
--- a/applications/nrf5340_audio/include/nrf5340_audio_common.h
+++ b/applications/nrf5340_audio/include/nrf5340_audio_common.h
@@ -7,8 +7,8 @@
 #ifndef _NRF5340_AUDIO_COMMON_H_
 #define _NRF5340_AUDIO_COMMON_H_
 
-#define ZBUS_READ_TIMEOUT_MS				     K_MSEC(100)
-#define ZBUS_ADD_OBS_TIMEOUT_MS				     K_MSEC(200)
+#define ZBUS_READ_TIMEOUT_MS	K_MSEC(100)
+#define ZBUS_ADD_OBS_TIMEOUT_MS K_MSEC(200)
 
 /***** Messages for zbus ******/
 
@@ -33,6 +33,7 @@ enum le_audio_evt_type {
 struct le_audio_msg {
 	enum le_audio_evt_type event;
 	struct bt_conn *conn;
+	struct bt_le_per_adv_sync *pa_sync;
 };
 
 struct sdu_ref_msg {

--- a/applications/nrf5340_audio/src/audio/Kconfig
+++ b/applications/nrf5340_audio/src/audio/Kconfig
@@ -356,7 +356,7 @@ config BUTTON_MSG_SUB_STACK_SIZE
 
 config LE_AUDIO_MSG_SUB_STACK_SIZE
 	int "Stack size for LE Audio subscriber"
-	default 1250
+	default 2048
 
 config CONTENT_CONTROL_MSG_SUB_STACK_SIZE
 	int "Stack size for content control subscriber"

--- a/applications/nrf5340_audio/src/audio/streamctrl_broadcast_sink.c
+++ b/applications/nrf5340_audio/src/audio/streamctrl_broadcast_sink.c
@@ -244,24 +244,16 @@ static void le_audio_msg_sub_thread(void)
 		case LE_AUDIO_EVT_SYNC_LOST:
 			LOG_INF("Sync lost");
 
+			ret = bt_mgmt_pa_sync_delete(msg.pa_sync);
+			if (ret) {
+				LOG_WRN("Failed to delete PA sync");
+			}
+
 			if (strm_state == STATE_STREAMING) {
 				stream_state_set(STATE_PAUSED);
 				audio_system_stop();
 				ret = led_on(LED_APP_1_BLUE);
 				ERR_CHK(ret);
-			}
-
-			if (IS_ENABLED(CONFIG_BT_OBSERVER)) {
-				ret = bt_mgmt_scan_start(0, 0, BT_MGMT_SCAN_TYPE_BROADCAST, NULL);
-				if (ret) {
-					if (ret != -EALREADY) {
-						LOG_ERR("Failed to restart scanning: %d", ret);
-					}
-					break;
-				}
-
-				/* NOTE: The string below is used by the Nordic CI system */
-				LOG_INF("Restarted scanning for broadcaster");
 			}
 
 			break;

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/broadcast_sink.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/broadcast_sink.c
@@ -52,6 +52,8 @@ static struct bt_bap_stream audio_streams[CONFIG_BT_BAP_BROADCAST_SNK_STREAM_COU
 static struct audio_codec_info audio_codec_info[CONFIG_BT_BAP_BROADCAST_SNK_STREAM_COUNT];
 static uint32_t bis_index_bitfields[CONFIG_BT_BAP_BROADCAST_SNK_STREAM_COUNT];
 
+static struct bt_le_per_adv_sync *pa_sync_stored;
+
 static struct active_audio_stream active_stream;
 
 /* The values of sync_stream_cnt and active_stream_index must never become larger
@@ -113,6 +115,11 @@ static void le_audio_event_publish(enum le_audio_evt_type event)
 {
 	int ret;
 	struct le_audio_msg msg;
+
+	if (event == LE_AUDIO_EVT_SYNC_LOST) {
+		msg.pa_sync = pa_sync_stored;
+		pa_sync_stored = NULL;
+	}
 
 	msg.event = event;
 
@@ -192,6 +199,8 @@ static void stream_stopped_cb(struct bt_bap_stream *stream, uint8_t reason)
 
 		break;
 
+	case BT_HCI_ERR_CONN_FAIL_TO_ESTAB:
+		/* Fall-through */
 	case BT_HCI_ERR_CONN_TIMEOUT:
 		LOG_INF("Stream sync lost");
 		k_work_submit(&bis_cleanup_work);
@@ -494,6 +503,8 @@ int broadcast_sink_pa_sync_set(struct bt_le_per_adv_sync *pa_sync, uint32_t broa
 		LOG_WRN("Failed to create sink: %d", ret);
 		return ret;
 	}
+
+	pa_sync_stored = pa_sync;
 
 	return 0;
 }


### PR DESCRIPTION
- Delete PA sync if BIG sync is lost
- Restart scanning if PA sync create times out
- Increase stack size to account for additional pa_sync_delete