### PR TITLE
ci: Add a new Wi-Fi QA required label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -23,3 +23,9 @@
   - "samples/bluetooth/mesh/*"
   - "doc/nrf/libraries/bluetooth_services/mesh/*"
   - "doc/nrf/ug_bt_mesh*"
+
+"wifi-qa-required":
+  - "drivers/wifi/**/*"
+  - "samples/wifi/**/*"
+  - "modules/hostap/**/*"
+  - "modules/lib/hostap/**/*"


### PR DESCRIPTION
This should be automatically added for nrf Wi-Fi related changes. This is used to enforce a mandatory QA upvote even though it is ready to be merged.

We are seeing an issue where the PRs are getting merged as they pass all mandatory checks but QA hasn't had a chance to verify it. So, this label which is enabled by default can be used similar to `doc-required`, and if its trivial and developer is confident enough then the label can be manually removed.