### PR TITLE
samples: Add nRF9161 Wi-Fi tests to twister

### DIFF
--- a/samples/wifi/scan/sample.yaml
+++ b/samples/wifi/scan/sample.yaml
@@ -16,14 +16,20 @@ tests:
       - nrf5340dk_nrf5340_cpuapp
       - nrf52840dk_nrf52840
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf5340dk_nrf5340_cpuapp nrf52840dk_nrf52840 nrf9160dk_nrf9160_ns
+      - nrf9161dk_nrf9161_ns
+    platform_allow:
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf52840dk_nrf52840
+      - nrf9160dk_nrf9160_ns
+      - nrf9161dk_nrf9161_ns
     tags: ci_build
   sample.nrf7002_eks.raw_scan:
     build_only: true
     extra_args: SHIELD=nrf7002ek CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS=y
     integration_platforms:
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
+      - nrf9161dk_nrf9161_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     tags: ci_build
   sample.nrf7000_eks.scan:
     build_only: true

--- a/samples/wifi/shell/sample.yaml
+++ b/samples/wifi/shell/sample.yaml
@@ -95,13 +95,6 @@ tests:
       - nrf7002dk_nrf5340_cpuapp
     platform_allow: nrf7002dk_nrf5340_cpuapp
     tags: ci_build
-  sample.nrf7002.shell.scan_only_9160:
-    build_only: true
-    extra_args: OVERLAY_CONFIG=overlay-scan-only.conf SHIELD=nrf7002ek
-    integration_platforms:
-      - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
-    tags: ci_build
   sample.nrf7000.shell.scan_only_91:
     build_only: true
     extra_args: OVERLAY_CONFIG=overlay-scan-only.conf SHIELD=nrf7002ek_nrf7000 CONFIG_WPA_SUPP=n
@@ -109,13 +102,6 @@ tests:
       - nrf9160dk_nrf9160_ns
       - nrf9161dk_nrf9161_ns
     platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
-    tags: ci_build
-  sample.nrf7001.shell.scan_only_9160:
-    build_only: true
-    extra_args: OVERLAY_CONFIG=overlay-scan-only.conf SHIELD=nrf7002ek_nrf7001
-    integration_platforms:
-      - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
     tags: ci_build
   sample.nrf7002.shell.otbr:
     build_only: true

--- a/samples/wifi/shell/sample.yaml
+++ b/samples/wifi/shell/sample.yaml
@@ -102,12 +102,13 @@ tests:
       - nrf9160dk_nrf9160_ns
     platform_allow: nrf9160dk_nrf9160_ns
     tags: ci_build
-  sample.nrf7000.shell.scan_only_9160:
+  sample.nrf7000.shell.scan_only_91:
     build_only: true
     extra_args: OVERLAY_CONFIG=overlay-scan-only.conf SHIELD=nrf7002ek_nrf7000 CONFIG_WPA_SUPP=n
     integration_platforms:
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
+      - nrf9161dk_nrf9161_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     tags: ci_build
   sample.nrf7001.shell.scan_only_9160:
     build_only: true


### PR DESCRIPTION
Apart from checking the build these are also needed for generating memory footprints.