### PR TITLE
doc: matter: Extended low power configuration with ICD information 

### DIFF
--- a/doc/nrf/protocols/matter/index.rst
+++ b/doc/nrf/protocols/matter/index.rst
@@ -20,9 +20,9 @@ The |NCS| allows you to develop applications with different versions of Matter, 
 +--------------------------+-----------------------------------------------------+------------------------+
 | nRF Connect SDK version  | Matter specification version                        | `Matter SDK version`_  |
 +==========================+=====================================================+========================+
-| v2.5.99 (latest)         | :ref:`1.1.0 <ug_matter_overview_dev_model_support>` | 1.1.0.1                |
-+--------------------------+                                                     |                        |
-| |release|                |                                                     |                        |
+| v2.5.99 (latest)         | :ref:`1.2.0 <ug_matter_overview_dev_model_support>` | 1.2.0.1                |
++--------------------------+-----------------------------------------------------+------------------------+
+| |release|                | :ref:`1.1.0 <ug_matter_overview_dev_model_support>` | 1.1.0.1                |
 +--------------------------+                                                     |                        |
 | v2.4.2                   |                                                     |                        |
 +--------------------------+                                                     |                        |

--- a/doc/nrf/protocols/matter/overview/data_model.rst
+++ b/doc/nrf/protocols/matter/overview/data_model.rst
@@ -259,6 +259,16 @@ Sensor device types
 |                   | to a lighting device such as a color light, is capable of being used         |                     |                                       |
 |                   | to switch the device on or off.                                              |                     |                                       |
 +-------------------+------------------------------------------------------------------------------+---------------------+---------------------------------------+
+| Smoke/CO Alarm    | A Smoke/CO Alarm device is capable of sensing smoke, carbon monoxide,        | Certifiable         |                                       |
+|                   | or both. It is capable of issuing a visual and audible alert to indicate     |                     |                                       |
+|                   | elevated concentration of smoke or carbon monoxide. Smoke/CO Alarms          |                     |                                       |
+|                   | are capable of monitoring themselves and issuing visual and audible alerts   |                     |                                       |
+|                   | for hardware faults, critical low battery conditions, and end of service.    |                     |                                       |
+|                   | Optionally, some of the audible alerts can be temporarily silenced.          |                     |                                       |
+|                   | Smoke/CO Alarms are capable of performing a self-test which performs         |                     |                                       |
+|                   | a diagnostic of the primary sensor and issuing a cycle of the audible        |                     |                                       |
+|                   | and visual life safety alarm indications.                                    |                     |                                       |
++-------------------+------------------------------------------------------------------------------+---------------------+---------------------------------------+
 
 .. _ug_matter_device_types_closures:
 
@@ -303,6 +313,55 @@ HVAC device types
 +-------------------+------------------------------------------------------------------------------+---------------------+---------------------------------------+
 | Fan               | A Fan device capable of controlling a fan in a heating or cooling system.    | Provisional         |                                       |
 +-------------------+------------------------------------------------------------------------------+---------------------+---------------------------------------+
+| Air Purifier      | An Air Purifier is a standalone device that is designed to clean the air in  | Certifiable         |                                       |
+|                   | a room. It has a fan to control the air speed while it is operating.         |                     |                                       |
+|                   | Optionally, it can report on the condition of its filters.                   |                     |                                       |
++-------------------+------------------------------------------------------------------------------+---------------------+---------------------------------------+
+| Air Quality       | An Air Quality Sensor is a device designed to monitor and measure various    | Certifiable         |                                       |
+| Sensor            | parameters related to the quality of ambient air in indoor or outdoor        |                     |                                       |
+|                   | environments.                                                                |                     |                                       |
++-------------------+------------------------------------------------------------------------------+---------------------+---------------------------------------+
+
+.. _ug_matter_device_types_appliance:
+
+Appliance device types
+======================
+
++--------------------+------------------------------------------------------------------------------+---------------------+---------------------------------------+
+| Device type        | Description (from Device Library Specification)                              | State of the device | Dedicated sample in the |NCS|         |
++====================+==============================================================================+=====================+=======================================+
+| Laundry Washer     | A Laundry Washer represents a device that is capable of laundering consumer  | Certifiable         |                                       |
+|                    | items. Any laundry washer product may utilize this device type.              |                     |                                       |
++--------------------+------------------------------------------------------------------------------+---------------------+---------------------------------------+
+| Refidgerator       | A Refrigerator represents a device that contains one or more cabinets that   | Certifiable         |                                       |
+|                    | are capable of chilling or freezing food. Examples of consumer products that |                     |                                       |
+|                    | may make use of this device type include refrigerators, freezers, and wine   |                     |                                       |
+|                    | coolers.                                                                     |                     |                                       |
++--------------------+------------------------------------------------------------------------------+---------------------+---------------------------------------+
+| Room Air           | A Room Air Conditioner is a device with the primary function of controlling  | Certifiable         |                                       |
+| Conditioner        | the air temperature in a single room.                                        |                     |                                       |
++--------------------+------------------------------------------------------------------------------+---------------------+---------------------------------------+
+| Temperature        | A Temperature Controlled Cabinet only exists composed as part of another     | Certifiable         |                                       |
+| Controlled         | device type. It represents a single cabinet chilling or freezing food        |                     |                                       |
+| Cabinet            | in a refrigerator, freezer, wine chiller or other similar device.            |                     |                                       |
++--------------------+------------------------------------------------------------------------------+---------------------+---------------------------------------+
+| Dishwasher         | A Dishwasher is a device that is generally installed in residential homes    | Certifiable         |                                       |
+|                    | and is capable of washing dishes, cutlery, and other items associated        |                     |                                       |
+|                    | with food preparation and consumption. The device can be permanently         |                     |                                       |
+|                    | installed or portable and can have variety of filling and draining methods.  |                     |                                       |
++--------------------+------------------------------------------------------------------------------+---------------------+---------------------------------------+
+
+.. _ug_matter_device_types_robotic:
+
+Robotic device types
+======================
+
++--------------------+------------------------------------------------------------------------------+---------------------+---------------------------------------+
+| Device type        | Description (from Device Library Specification)                              | State of the device | Dedicated sample in the |NCS|         |
++====================+==============================================================================+=====================+=======================================+
+| Robotic Vacuum     | A Robotic Vacuum Cleaner is a device that is capable of cleaning consumer    | Certifiable         |                                       |
+| Cleaner            | floor.                                                                       |                     |                                       |
++--------------------+------------------------------------------------------------------------------+---------------------+---------------------------------------+
 
 .. _ug_matter_device_types_utility:
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -84,7 +84,9 @@ Bluetooth mesh
 Matter
 ------
 
-|no_changes_yet_note|
+* Updated:
+
+  * Page about :ref:`ug_matter_device_low_power_configuration` with the information about Intermittently Connected Devices (ICD) configuration.
 
 Matter fork
 +++++++++++
@@ -96,14 +98,27 @@ The following list summarizes the most important changes inherited from the upst
 * Added:
 
    * Support for the Intermittently Connected Devices (ICD) Management cluster.
-   * The Kconfig options :kconfig:option:`CONFIG_CHIP_ICD_IDLE_MODE_INTERVAL`, :kconfig:option:`CONFIG_CHIP_ICD_ACTIVE_MODE_INTERVAL` and :kconfig:option:`CONFIG_CHIP_ICD_CLIENTS_PER_FABRIC` to manage ICD configuration.
+   * The Kconfig options :kconfig:option:`CONFIG_CHIP_ICD_IDLE_MODE_DURATION`, :kconfig:option:`CONFIG_CHIP_ICD_ACTIVE_MODE_DURATION` and :kconfig:option:`CONFIG_CHIP_ICD_CLIENTS_PER_FABRIC` to manage ICD configuration.
+   * New device types:
+
+     * Refidgerator
+     * Room Air Conditioner
+     * Dishwasher
+     * Laundry Washer
+     * Robotic Vacuum Cleaner
+     * Smoke CO Alarm
+     * Air Quality Sensor
+     * Air Purifier
+     * Fan
+
+   * Product Appearance attribute in the Basic Information cluster that allows describing the product's color and finish.
 
 * Updated:
 
-   * Renamed the :kconfig:option:`CONFIG_CHIP_ENABLE_SLEEPY_END_DEVICE_SUPPORT` Kconfig option to :kconfig:option:`CONFIG_CHIP_ENABLE_ICD_SUPPORT`.
-   * Renamed the :kconfig:option:`CONFIG_CHIP_SED_IDLE_INTERVAL` Kconfig option to :kconfig:option:`CONFIG_CHIP_ICD_SLOW_POLL_INTERVAL`.
-   * Renamed the :kconfig:option:`CONFIG_CHIP_SED_ACTIVE_INTERVAL` Kconfig option to :kconfig:option:`CONFIG_CHIP_ICD_FAST_POLLING_INTERVAL`.
-   * Renamed the :kconfig:option:`CONFIG_CHIP_SED_ACTIVE_THRESHOLD` Kconfig option to :kconfig:option:`CONFIG_CHIP_ICD_ACTIVE_MODE_THRESHOLD`.
+   * Renamed the ``CONFIG_CHIP_ENABLE_SLEEPY_END_DEVICE_SUPPORT`` Kconfig option to :kconfig:option:`CONFIG_CHIP_ENABLE_ICD_SUPPORT`.
+   * Renamed the ``CONFIG_CHIP_SED_IDLE_INTERVAL`` Kconfig option to :kconfig:option:`CONFIG_CHIP_ICD_SLOW_POLL_INTERVAL`.
+   * Renamed the ``CONFIG_CHIP_SED_ACTIVE_INTERVAL`` Kconfig option to :kconfig:option:`CONFIG_CHIP_ICD_FAST_POLLING_INTERVAL`.
+   * Renamed the ``CONFIG_CHIP_SED_ACTIVE_THRESHOLD`` Kconfig option to :kconfig:option:`CONFIG_CHIP_ICD_ACTIVE_MODE_THRESHOLD`.
 
 
 Thread

--- a/west.yml
+++ b/west.yml
@@ -149,7 +149,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 1a5e5e5da4b5fcc01f40d163929c8add096d112a
+      revision: 599f334e6f865deb7ed452dbc7d63648f822094e
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
Added information about ICD and their configuration to the low power configuration guide. Also updated the list of changes
introduced with the Matter v1.2.