### PR TITLE
applications: nrf_desktop: Remove dfu_slot_id function from dfu module

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -188,7 +188,8 @@ nRF Machine Learning (Edge Impulse)
 nRF Desktop
 -----------
 
-|no_changes_yet_note|
+* Updated the :ref:`nrf_desktop_dfu` to use :ref:`partition_manager` definitions for determining currently booted image slot in build time.
+  The other image slot is used to store an application update image.
 
 Thingy:53: Matter weather station
 ---------------------------------


### PR DESCRIPTION
The currently booted image slot can be determined in build time. The commit also increases flexibility of bootloader integration.

Jira: NCSDK-24197