### PR TITLE
samples: bluetooth: delete bond when disconnecting.

### DIFF
--- a/samples/bluetooth/throughput/src/main.c
+++ b/samples/bluetooth/throughput/src/main.c
@@ -308,6 +308,12 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	printk("Disconnected (reason 0x%02x)\n", reason);
 
 	test_ready = false;
+
+	err = bt_unpair(BT_ID_DEFAULT, NULL);
+	if (err) {
+		printk("Cannot remove bonds (err %d)\n", err);
+	}
+
 	if (default_conn) {
 		bt_conn_unref(default_conn);
 		default_conn = NULL;


### PR DESCRIPTION
Some tests test that you can reconnect after one device resets. To do that now that sample is encrypted,
 you need to delete the bond on the device that doesnt reset.