### PR TITLE
manifest: sdk-zephyr: Pull networking locking fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: ac5a9860b73bdbde2e8ba936fdc35a5e7654189c
+      revision: 9ed7de1afad3ebc08a3ce379bee0bbbbd9702414
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This pulls in networking locking fixes to provide consistent locking.