### PR TITLE
doc: getting started: Update system-wide instructions

### DIFF
--- a/doc/nrf/installation/install_ncs.rst
+++ b/doc/nrf/installation/install_ncs.rst
@@ -276,6 +276,7 @@ For more information about the repository and development model, see the :ref:`d
          .. code-block:: console
 
             west zephyr-export
+
 ..
 
 If you used the default locations, your directory structure now looks similar to this:
@@ -368,38 +369,140 @@ To install the |NCS| system-wide, complete the following steps:
 
       .. note::
 
-         Use a command prompt window with administrator rights to ensure that Python is initialized.
+         It is easy to run into Python package incompatibilities when installing dependencies at a system or user level.
+         This situation can happen, for example, if working on multiple Zephyr versions or other projects using Python on the same machine.
+
+         For this reason, it is suggested to use `Python virtual environments`_.
 
       .. tabs::
 
          .. group-tab:: Windows
 
-            Enter the following command in a command-line window:
+            .. tabs::
 
-            .. code-block:: console
+               .. group-tab:: Install within virtual environment
 
-               pip3 install west
+                  #. Create a new virtual environment:
 
-            .. note::
-               Ensure the west location is added to the path in environmental variables.
+                     .. code-block:: bat
+
+                        cd %HOMEPATH%
+                        python -m venv ncs\.venv
+
+                  #. Activate the virtual environment:
+
+                     .. code-block:: bat
+
+                        ncs\.venv\Scripts\activate.bat
+
+                     Once activated your shell will be prefixed with ``(.venv)``.
+                     The virtual environment can be deactivated at any time by running ``deactivate``.
+
+                     .. note::
+
+                        Remember to activate the virtual environment every time you start working.
+
+                  #. Install west:
+
+                     .. code-block:: bat
+
+                        pip3 install west
+
+               .. group-tab:: Install globally
+
+                  #. Install west:
+
+                     .. code-block:: bat
+
+                        pip3 install -U west
 
          .. group-tab:: Linux
 
-            Enter the following command in a terminal window:
+            .. tabs::
 
-            .. code-block:: console
+               .. group-tab:: Install within virtual environment
 
-               pip3 install --user west
-               echo 'export PATH=~/.local/bin:"$PATH"' >> ~/.bashrc
-               source ~/.bashrc
+                  #. Use ``apt`` to install Python ``venv`` package:
+
+                     .. code-block:: bash
+
+                        sudo apt install python3-venv
+
+                  #. Create a new virtual environment:
+
+                     .. code-block:: bash
+
+                        python3 -m venv ~/ncs/.venv
+
+                  #. Activate the virtual environment:
+
+                     .. code-block:: bash
+
+                        source ~/ncs/.venv/bin/activate
+
+                     Once activated, your shell will be prefixed with ``(.venv)``.
+                     The virtual environment can be deactivated at any time by running ``deactivate``.
+
+                     .. note::
+
+                        Remember to activate the virtual environment every time you start working.
+
+                  #. Install west:
+
+                     .. code-block:: bash
+
+                        pip3 install west
+
+               .. group-tab:: Install globally
+
+                  #. Install west and make sure :file:`~/.local/bin` is on your :envvar:`PATH` :ref:`environment variable <env_vars>`:
+
+                     .. code-block:: bash
+
+                        pip3 install --user -U west
+                        echo 'export PATH=~/.local/bin:"$PATH"' >> ~/.bashrc
+                        source ~/.bashrc
 
          .. group-tab:: macOS
 
-            Enter the following command in a terminal window:
+            .. tabs::
 
-            .. code-block:: console
+               .. group-tab:: Install within virtual environment
 
-               pip3 install west
+                  #. Create a new virtual environment:
+
+                     .. code-block:: bash
+
+                        python3 -m venv ~/ncs/.venv
+
+                  #. Activate the virtual environment:
+
+                     .. code-block:: bash
+
+                        source ~/ncs/.venv/bin/activate
+
+                     Once activated, your shell will be prefixed with ``(.venv)``.
+                     The virtual environment can be deactivated at any time by running ``deactivate``.
+
+                     .. note::
+
+                        Remember to activate the virtual environment every time you start working.
+
+                  #. Install west:
+
+                     .. code-block:: bash
+
+                        pip3 install west
+
+               .. group-tab:: Install globally
+
+                  #. Install west:
+
+                     .. code-block:: bash
+
+                        pip3 install -U west
+
+            ..
 
       ..
 
@@ -407,7 +510,7 @@ To install the |NCS| system-wide, complete the following steps:
 
 #. Get the |NCS| code as described in :ref:`cloning_the_repositories` for the command line.
    (You can skip step 2.)
-   When you first install the |NCS|, it is recommended to install the latest released versions of the SDK.
+   When you first install the |NCS|, it is recommended to install the latest released version of the SDK.
 #. Install the Python dependencies.
    Expand the section below to see the commands.
 
@@ -422,110 +525,33 @@ To install the |NCS| system-wide, complete the following steps:
 
          .. group-tab:: Windows
 
-            1. Use the following command to install the Python ``venv`` package:
+            #. Enter the following commands in a ``cmd.exe`` terminal window in the :file:`ncs` folder:
 
                .. code-block:: bash
 
-                  pip install virtualenv
-
-            #. Create a new virtual environment:
-
-               .. code-block:: bash
-
-                  cd %HOMEPATH%
-                  python -m venv ncs\.venv
-
-            #. Activate the virtual environment:
-
-               .. code-block:: bash
-
-                  :: cmd.exe
-                  ncs\.venv\Scripts\activate.bat
-
-               Once activated, your shell will be prefixed with ``(.venv)``.
-               You can deactivate the virtual environment at any time by running ``deactivate``.
-
-               .. note::
-
-                  Remember to activate the virtual environment every time you start working.
-
-            #. Enter the following commands in a command-line window in the :file:`ncs` folder:
-
-               .. code-block:: bash
-
-                  pip install -r zephyr\scripts\requirements.txt
-                  pip install -r nrf\scripts\requirements.txt
-                  pip install -r bootloader\mcuboot\scripts\requirements.txt
+                  pip3 install -r zephyr\scripts\requirements.txt
+                  pip3 install -r nrf\scripts\requirements.txt
+                  pip3 install -r bootloader\mcuboot\scripts\requirements.txt
 
          .. group-tab:: Linux
 
-            1. Use the following command to install the Python ``venv`` package:
-
-               .. code-block:: bash
-
-                  sudo apt install python3-venv
-
-            #. Create a new virtual environment:
-
-               .. code-block:: bash
-
-                  python3 -m venv ~/ncs/.venv
-
-            #. Activate the virtual environment:
-
-               .. code-block:: bash
-
-                  source ~/ncs/.venv/bin/activate
-
-               Once activated, your shell will be prefixed with ``(.venv)``.
-               You can deactivate the virtual environment at any time by running ``deactivate``.
-
-               .. note::
-
-                  Remember to activate the virtual environment every time you start working.
-
             #. Enter the following commands in a terminal window in the :file:`ncs` folder:
 
                .. code-block:: bash
 
-                  pip install -r zephyr/scripts/requirements.txt
-                  pip install -r nrf/scripts/requirements.txt
-                  pip install -r bootloader/mcuboot/scripts/requirements.txt
+                  pip3 install -r zephyr/scripts/requirements.txt
+                  pip3 install -r nrf/scripts/requirements.txt
+                  pip3 install -r bootloader/mcuboot/scripts/requirements.txt
 
          .. group-tab:: macOS
 
-            1. Use the following command to install the Python ``venv`` package:
-
-               .. code-block:: bash
-
-                  sudo apt install python3-venv
-
-            #. Create a new virtual environment:
-
-               .. code-block:: bash
-
-                  python3 -m venv ~/ncs/.venv
-
-            #. Activate the virtual environment:
-
-               .. code-block:: bash
-
-                  source ~/ncs/.venv/bin/activate
-
-               Once activated, your shell will be prefixed with ``(.venv)``.
-               You can deactivate the virtual environment at any time by running ``deactivate``.
-
-               .. note::
-
-                  Remember to activate the virtual environment every time you start working.
-
             #. Enter the following commands in a terminal window in the :file:`ncs` folder:
 
                .. code-block:: bash
 
-                  pip install -r zephyr/scripts/requirements.txt
-                  pip install -r nrf/scripts/requirements.txt
-                  pip install -r bootloader/mcuboot/scripts/requirements.txt
+                  pip3 install -r zephyr/scripts/requirements.txt
+                  pip3 install -r nrf/scripts/requirements.txt
+                  pip3 install -r bootloader/mcuboot/scripts/requirements.txt
 
       ..
 

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -1176,11 +1176,17 @@
 .. _`mosquitto.org server CA`: https://test.mosquitto.org/ssl/mosquitto.org.crt
 .. _`test.mosquitto.org`: https://test.mosquitto.org
 
-.. ###: visualstudio.com
+.. ### visualstudio.com
 
 .. _`nRF Connect for VS Code Extension Pack`: https://marketplace.visualstudio.com/items?itemName=nordic-semiconductor.nrf-connect-extension-pack
 .. _`VSMQTT`: https://marketplace.visualstudio.com/items?itemName=rpdswtk.vsmqtt
 .. _`Visual Studio Code download page`: https://code.visualstudio.com/download
+
+.. ### python.org
+
+.. _`Python virtual environments`: https://docs.python.org/3/library/venv.html
+.. _`Windows Python Path`: https://docs.python.org/3/using/windows.html#finding-the-python-executable
+.. _`Python's Path.glob`: https://docs.python.org/3/library/pathlib.html#pathlib.Path.glob
 
 .. ### Source: other (2 links or less from the same URL)
 
@@ -1269,9 +1275,7 @@
 
 .. _`BH1749NUC-E`: https://fscdn.rohm.com/en/products/databook/datasheet/ic/sensor/light/bh1749nuc-e.pdf
 
-.. _`Python virtual environments`: https://docs.python.org/3/library/venv.html
-.. _`Windows Python Path`: https://docs.python.org/3/using/windows.html#finding-the-python-executable
-.. _`Python's Path.glob`: https://docs.python.org/3/library/pathlib.html#pathlib.Path.glob
+
 
 .. _`CMock`: https://www.throwtheswitch.org/cmock
 .. _`Unity`: https://www.throwtheswitch.org/unity

--- a/doc/nrf/protocols/matter/getting_started/tools.rst
+++ b/doc/nrf/protocols/matter/getting_started/tools.rst
@@ -20,7 +20,7 @@ GN tool
 To build and develop Matter applications, you need the `GN`_ meta-build system.
 This system generates the Ninja files that the |NCS| uses.
 
-The GN is automatically installed with the |NCS|'s toolchain when you :ref:`install the |NCS| <install_ncs>`.
+The GN is automatically installed with the |NCS|'s toolchain when you :ref:`install the nRF Connect SDK <install_ncs>`.
 If you are updating from the |NCS| version earlier than v1.5.0, see the following GN installation instructions.
 
 .. toggle:: GN installation instructions
@@ -76,45 +76,33 @@ If you are updating from the |NCS| version earlier than v1.5.0, see the followin
 
                mkdir ${HOME}/gn && cd ${HOME}/gn
 
-         #. Install the wget tool:
-
-            .. code-block:: console
-
-               brew install wget
-
          #. Download the GN binary archive and extract it by using the following commands:
 
-            * For 64-bit ARM (M1 and M2) host architecture:
+            * On macOS running on Apple Silicon:
 
             .. code-block:: console
 
-               wget -O gn.zip https:\ //chrome-infra-packages.appspot.com/dl/gn/gn/mac-arm64/+/latest
-               unzip gn.zip
-               rm gn.zip
+               curl -o gn.zip -L https:\ //chrome-infra-packages.appspot.com/dl/gn/gn/mac-arm64/+/latest
 
-            * For 64-bit AMD (Intel) host architecture:
+            * On macOS running on Intel:
 
             .. code-block:: console
 
-               wget -O gn.zip https:\ //chrome-infra-packages.appspot.com/dl/gn/gn/mac-amd64/+/latest
+               curl -o gn.zip -L https:\ //chrome-infra-packages.appspot.com/dl/gn/gn/mac-amd64/+/latest
+
+         #. Unzip the archive and then delete it:
+
+            .. code-block:: console
+
                unzip gn.zip
                rm gn.zip
 
          #. Add the location of the GN tool to the system :envvar:`PATH`.
-            For example, if you are using ``bash``, run the following commands:
 
-            a. Create the :file:`.bash_profile` file if you do not have it already:
+            .. code-block:: console
 
-               .. code-block:: console
-
-                  touch ${HOME}/.bash_profile
-
-            #. Add the location of the GN tool to :file:`.bash_profile`:
-
-               .. code-block:: console
-
-                  echo 'export PATH=${HOME}/gn:"$PATH"' >> ${HOME}/.bash_profile
-                  source ${HOME}/.bash_profile
+               (echo; echo 'export PATH="'${HOME}'/gn:$PATH"') >> ~/.zprofile
+               source ~/.zprofile
 
 .. _ug_matter_gs_tools_controller:
 

--- a/doc/nrf/releases_and_maturity/developing/adding_code.rst
+++ b/doc/nrf/releases_and_maturity/developing/adding_code.rst
@@ -40,7 +40,7 @@ In such case, you must obtain a copy of the |NCS| on your file system and then m
 
 To obtain a copy of the |NCS|, you can use one of the following methods:
 
-* :ref:`Install the |NCS| <install_ncs>` using the |nRFVSC| and download the desired |NCS| version.
+* :ref:`Install the nRF Connect SDK <install_ncs>` using the |nRFVSC| and download the desired |NCS| version.
   This corresponds to steps 2 and 3 on the linked page.
 * Follow the instructions in the :ref:`dm-wf-get-ncs` section of the documentation.
   This requires you to install Git and west, but you can then ignore them from that point onwards.


### PR DESCRIPTION
This includes pulling some changes from upstream Zephyr that clarify the installation on macOS, aside from reworking the system-wide installation instructions.