### PR TITLE
Bluetooth: Update sdk-zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 533baa16b5a6750cf59a7ce7257bc09bcac09637
+      revision: pull/1376/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
To include zephyr API's for Le Power Control Request Feature.
See sdk-zephyr PR:
 - https://github.com/nrfconnect/sdk-zephyr/pull/1376