### PR TITLE
samples: hello_world: fix build

### DIFF
--- a/samples/multicore/hello_world/Kconfig
+++ b/samples/multicore/hello_world/Kconfig
@@ -7,4 +7,5 @@
 source "Kconfig.zephyr"
 
 config BOARD_ENABLE_CPUNET
+	bool
 	default y if (BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF5340DK_NRF5340_CPUAPP_NS)


### PR DESCRIPTION
It failed due to the Kconfig warning "BOARD_ENABLE_CPUNET defined without a type".