### PR TITLE
lib: lte_lc: deprecate `_init_` functions, updates

### DIFF
--- a/applications/asset_tracker_v2/src/modules/modem_module.c
+++ b/applications/asset_tracker_v2/src/modules/modem_module.c
@@ -84,16 +84,6 @@ NRF_MODEM_LIB_ON_INIT(asset_tracker_init_hook, on_modem_lib_init, NULL);
 
 static void on_modem_lib_init(int ret, void *ctx)
 {
-	int err;
-
-	if (ret == 0) {
-		/* LTE LC is uninitialized on every modem shutdown. */
-		err = lte_lc_init();
-		if (err) {
-			LOG_ERR("lte_lc_init, error: %d", err);
-		}
-	}
-
 	k_sem_give(&nrf_modem_initialized);
 }
 

--- a/applications/asset_tracker_v2/src/modules/modem_module.c
+++ b/applications/asset_tracker_v2/src/modules/modem_module.c
@@ -36,9 +36,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(MODULE, CONFIG_MODEM_MODULE_LOG_LEVEL);
 
-BUILD_ASSERT(!IS_ENABLED(CONFIG_LTE_AUTO_INIT_AND_CONNECT),
-		"The Modem module does not support this configuration");
-
 
 struct modem_msg_data {
 	union {

--- a/applications/asset_tracker_v2/tests/location_module/CMakeLists.txt
+++ b/applications/asset_tracker_v2/tests/location_module/CMakeLists.txt
@@ -18,7 +18,9 @@ cmock_handle(${ZEPHYR_NRF_MODULE_DIR}/include/app_event_manager.h)
 cmock_handle(${ZEPHYR_NRF_MODULE_DIR}/subsys/app_event_manager/app_event_manager_priv.h)
 cmock_handle(${ZEPHYR_NRF_MODULE_DIR}/include/date_time.h)
 cmock_handle(${ZEPHYR_NRF_MODULE_DIR}/include/modem/location.h)
-cmock_handle(${ZEPHYR_NRF_MODULE_DIR}/include/modem/lte_lc.h FUNC_EXCLUDE ".*(lte_lc_rai_req|lte_lc_rai_param_set)")
+cmock_handle(${ZEPHYR_NRF_MODULE_DIR}/include/modem/lte_lc.h
+	FUNC_EXCLUDE ".*(lte_lc_rai_req|lte_lc_rai_param_set)"
+	WORD_EXCLUDE "__deprecated")
 cmock_handle(${ZEPHYR_NRFXLIB_MODULE_DIR}/nrf_modem/include/nrf_modem_gnss.h)
 
 # add location_module (the unit under test)

--- a/applications/asset_tracker_v2/tests/lwm2m_codec_helpers/CMakeLists.txt
+++ b/applications/asset_tracker_v2/tests/lwm2m_codec_helpers/CMakeLists.txt
@@ -26,7 +26,9 @@ cmock_handle(${ZEPHYR_BASE}/subsys/net/lib/lwm2m/lwm2m_engine.h lwm2m)
 cmock_handle(${ZEPHYR_BASE}/include/zephyr/net/lwm2m.h lwm2m)
 cmock_handle(${ZEPHYR_NRF_MODULE_DIR}/include/net/lwm2m_client_utils.h lwm2m_client_utils)
 cmock_handle(${ZEPHYR_NRF_MODULE_DIR}/include/net/lwm2m_client_utils_location.h lwm2m_client_utils)
-cmock_handle(${ZEPHYR_NRF_MODULE_DIR}/include/modem/lte_lc.h lte_lc FUNC_EXCLUDE ".*(lte_lc_rai_req|lte_lc_rai_param_set)")
+cmock_handle(${ZEPHYR_NRF_MODULE_DIR}/include/modem/lte_lc.h lte_lc
+	FUNC_EXCLUDE ".*(lte_lc_rai_req|lte_lc_rai_param_set)"
+	WORD_EXCLUDE "__deprecated")
 cmock_handle(${ZEPHYR_NRF_MODULE_DIR}/include/date_time.h date_time)
 
 # Add Unit Under Test source files

--- a/applications/asset_tracker_v2/tests/lwm2m_integration/CMakeLists.txt
+++ b/applications/asset_tracker_v2/tests/lwm2m_integration/CMakeLists.txt
@@ -23,7 +23,9 @@ cmock_handle(${ZEPHYR_BASE}/subsys/net/lib/lwm2m/lwm2m_engine.h lwm2m)
 cmock_handle(${ZEPHYR_BASE}/include/zephyr/net/lwm2m.h lwm2m)
 cmock_handle(${ZEPHYR_NRF_MODULE_DIR}/include/net/lwm2m_client_utils.h lwm2m_client_utils)
 cmock_handle(${ZEPHYR_NRF_MODULE_DIR}/include/net/lwm2m_client_utils_location.h lwm2m_client_utils)
-cmock_handle(${ZEPHYR_NRF_MODULE_DIR}/include/modem/lte_lc.h lte_lc FUNC_EXCLUDE ".*(lte_lc_rai_req|lte_lc_rai_param_set)")
+cmock_handle(${ZEPHYR_NRF_MODULE_DIR}/include/modem/lte_lc.h lte_lc
+	FUNC_EXCLUDE ".*(lte_lc_rai_req|lte_lc_rai_param_set)"
+	WORD_EXCLUDE "__deprecated")
 
 # Add Unit Under Test source files
 target_sources(app PRIVATE ${ASSET_TRACKER_V2_DIR}/src/cloud/lwm2m_integration/lwm2m_integration.c)

--- a/doc/nrf/libraries/modem/lte_lc.rst
+++ b/doc/nrf/libraries/modem/lte_lc.rst
@@ -73,9 +73,9 @@ The following block of code shows how you can use the API to establish an LTE co
 
            printk("Connecting to LTE network. This may take a few minutes...\n");
 
-           err = lte_lc_init_and_connect_async(lte_handler);
+           err = lte_lc_connect_async(lte_handler);
            if (err) {
-                   printk("lte_lc_init_and_connect_async, error: %d\n", err);
+                   printk("lte_lc_connect_async, error: %d\n", err);
                    return 0;
            }
 
@@ -140,9 +140,9 @@ The following code block shows a basic implementation of :c:func:`lte_lc_conn_ev
 
            printk("Connecting to LTE network. This may take a few minutes...\n");
 
-           err = lte_lc_init_and_connect_async(lte_handler);
+           err = lte_lc_connect_async(lte_handler);
            if (err) {
-                   printk("lte_lc_init_and_connect_async, error: %d\n", err);
+                   printk("lte_lc_connect_async, error: %d\n", err);
                    return 0;
            }
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-2.4.0.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-2.4.0.rst
@@ -715,7 +715,7 @@ Modem libraries
     * The library to handle notifications from the modem when eDRX is not used by the current cell.
       The application now receives an :c:enum:`LTE_LC_EVT_EDRX_UPDATE` event with the network mode set to :c:enum:`LTE_LC_LTE_MODE_NONE` in these cases.
       Modem firmware version v1.3.4 or newer is required to receive these events.
-    * The Kconfig option :kconfig:option:`CONFIG_LTE_AUTO_INIT_AND_CONNECT` is now deprecated.
+    * The Kconfig option ``CONFIG_LTE_AUTO_INIT_AND_CONNECT`` is now deprecated.
       The application calls the :c:func:`lte_lc_init_and_connect` function instead.
     * New events added to enumeration :c:enum:`lte_lc_modem_evt` for RACH CE levels and missing IMEI.
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -414,9 +414,21 @@ DFU libraries
 Modem libraries
 ---------------
 
-* :ref:`lte_lc_readme`:
+* :ref:`lte_lc_readme` library:
 
-  * Added the :c:func:`lte_lc_psm_param_set_seconds` function and Kconfig options :kconfig:option:`LTE_PSM_REQ_FORMAT`, :kconfig:option:`CONFIG_LTE_PSM_REQ_RPTAU_SECONDS`, and :kconfig:option:`CONFIG_LTE_PSM_REQ_RAT_SECONDS` to enable setting of PSM parameters in seconds instead of using bit field strings.
+  * Added:
+
+    * The :c:func:`lte_lc_psm_param_set_seconds` function and Kconfig options :kconfig:option:`CONFIG_LTE_PSM_REQ_FORMAT`, :kconfig:option:`CONFIG_LTE_PSM_REQ_RPTAU_SECONDS`, and :kconfig:option:`CONFIG_LTE_PSM_REQ_RAT_SECONDS` to enable setting of PSM parameters in seconds instead of using bit field strings.
+
+  * Updated:
+
+    * The :c:func:`lte_lc_init` function is deprecated.
+    * The :c:func:`lte_lc_deinit` function is deprecated.
+      Use the :c:func:`lte_lc_power_off` function instead.
+    * The :c:func:`lte_lc_init_and_connect` function is deprecated.
+      Use the :c:func:`lte_lc_connect` function instead.
+    * The :c:func:`lte_lc_init_and_connect_async` function is deprecated.
+      Use the :c:func:`lte_lc_connect_async` function instead.
 
   * Removed:
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -418,6 +418,10 @@ Modem libraries
 
   * Added the :c:func:`lte_lc_psm_param_set_seconds` function and Kconfig options :kconfig:option:`LTE_PSM_REQ_FORMAT`, :kconfig:option:`CONFIG_LTE_PSM_REQ_RPTAU_SECONDS`, and :kconfig:option:`CONFIG_LTE_PSM_REQ_RAT_SECONDS` to enable setting of PSM parameters in seconds instead of using bit field strings.
 
+  * Removed:
+
+    * The deprecated Kconfig option ``CONFIG_LTE_AUTO_INIT_AND_CONNECT``.
+
 * :ref:`nrf_modem_lib_readme`:
 
   * Added:

--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -1232,26 +1232,24 @@ int lte_lc_deregister_handler(lte_lc_evt_handler_t handler);
 /**
  * Initialize the library and configure the modem.
  *
+ * @deprecated There is no need to call this function anymore.
+ *
  * @note A follow-up call to lte_lc_connect() or lte_lc_connect_async() must be made to establish
  *       an LTE connection. The library can be initialized only once, and subsequent calls will
  *       return @c 0.
  *
  * @retval 0 if successful.
- * @retval -EFAULT if an AT command failed.
  */
-int lte_lc_init(void);
+__deprecated int lte_lc_init(void);
 
 /**
  * Connect to LTE network.
  *
- * @note Before calling this function, a call to lte_lc_init() must be made, otherwise @c -EPERM is
- *       returned.
  *
  * @note After initialization, the system mode will be set to the default mode selected with Kconfig
  *       and LTE preference set to automatic selection.
  *
  * @retval 0 if successful.
- * @retval -EPERM if the library was not initialized.
  * @retval -EFAULT if an AT command failed.
  * @retval -ETIMEDOUT if a connection attempt timed out before the device was
  *	   registered to a network.
@@ -1261,6 +1259,8 @@ int lte_lc_connect(void);
 
 /**
  * Initialize the library, configure the modem and connect to LTE network.
+ *
+ * @deprecated Use @ref lte_lc_connect instead.
  *
  * The function blocks until connection is established, or the connection attempt times out.
  *
@@ -1273,7 +1273,7 @@ int lte_lc_connect(void);
  *	   registered to a network.
  * @retval -EINPROGRESS if a connection establishment attempt is already in progress.
  */
-int lte_lc_init_and_connect(void);
+__deprecated int lte_lc_init_and_connect(void);
 
 /**
  * Connect to LTE network.
@@ -1294,6 +1294,8 @@ int lte_lc_connect_async(lte_lc_evt_handler_t handler);
 /**
  * Initialize the library, configure the modem and connect to LTE network.
  *
+ * @deprecated Use @ref lte_lc_connect_async instead.
+ *
  * The function returns immediately.
  *
  * @note The library can be initialized only once, and repeated calls will return @c 0.
@@ -1306,15 +1308,17 @@ int lte_lc_connect_async(lte_lc_evt_handler_t handler);
  * @retval -EFAULT if an AT command failed.
  * @retval -EINVAL if no event handler was registered.
  */
-int lte_lc_init_and_connect_async(lte_lc_evt_handler_t handler);
+__deprecated int lte_lc_init_and_connect_async(lte_lc_evt_handler_t handler);
 
 /**
  * Deinitialize the library and power off the modem.
  *
+ * @deprecated Use @ref lte_lc_power_off instead.
+ *
  * @retval 0 if successful.
  * @retval -EFAULT if an AT command failed.
  */
-int lte_lc_deinit(void);
+__deprecated int lte_lc_deinit(void);
 
 /**
  * Set the modem to offline mode.

--- a/lib/date_time/date_time.c
+++ b/lib/date_time/date_time.c
@@ -165,9 +165,6 @@ static int date_time_init(void)
 	return 0;
 }
 
-/* Initialization should be before lte_lc (uses CONFIG_APPLICATION_INIT_PRIORITY)
- * so that we can subscribe to xtime notification if CONFIG_LTE_AUTO_INIT_AND_CONNECT is enabled
- */
 #define DATE_TIME_INIT_PRIO 80
 
 SYS_INIT(date_time_init, APPLICATION, DATE_TIME_INIT_PRIO);

--- a/lib/date_time/date_time.c
+++ b/lib/date_time/date_time.c
@@ -165,6 +165,4 @@ static int date_time_init(void)
 	return 0;
 }
 
-#define DATE_TIME_INIT_PRIO 80
-
-SYS_INIT(date_time_init, APPLICATION, DATE_TIME_INIT_PRIO);
+SYS_INIT(date_time_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);

--- a/lib/lte_link_control/Kconfig
+++ b/lib/lte_link_control/Kconfig
@@ -11,15 +11,6 @@ menuconfig LTE_LINK_CONTROL
 
 if LTE_LINK_CONTROL
 
-config LTE_AUTO_INIT_AND_CONNECT
-	select DEPRECATED
-	bool "Auto Initialize and Connect for the LTE link [DEPRECATED]"
-	help
-	  Turn on to make the LTE link control to automatically initialize and connect the modem
-	  before the application starts.
-	  This Kconfig option is deprecated. Instead, the application should call
-	  lte_lc_init() and lte_lc_connect().
-
 config LTE_SHELL
 	bool "Enable LTE shell commands"
 	default y

--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -1360,18 +1360,6 @@ int lte_lc_system_mode_get(enum lte_lc_system_mode *mode,
 		}
 	}
 
-	if (sys_mode_current != *mode) {
-		LOG_DBG("Current system mode updated from %d to %d",
-			sys_mode_current, *mode);
-		sys_mode_current = *mode;
-	}
-
-	if ((preference != NULL) && (mode_pref_current != *preference)) {
-		LOG_DBG("Current system mode preference updated from %d to %d",
-			mode_pref_current, *preference);
-		mode_pref_current = *preference;
-	}
-
 	return 0;
 }
 

--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -627,13 +627,6 @@ static int init_and_config(void)
 
 	lte_lc_psm_default_config_set();
 
-	/* Listen for RRC connection mode notifications */
-	err = enable_notifications();
-	if (err) {
-		LOG_ERR("Failed to enable notifications");
-		return err;
-	}
-
 	is_initialized = true;
 
 	return 0;

--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -563,27 +563,8 @@ static int enable_notifications(void)
 	/* +CSCON notifications */
 	err = nrf_modem_at_printf(cscon);
 	if (err) {
-		char buf[50];
-
-		/* AT+CSCON is supported from modem firmware v1.1.0, and will
-		 * not work for older versions. If the command fails, RRC
-		 * mode change notifications will not be received. This is not
-		 * considered a critical error, and the error code is therefore
-		 * not returned, while informative log messages are printed.
-		 */
-		LOG_WRN("AT+CSCON failed (%d), RRC notifications are not enabled", err);
-		LOG_WRN("AT+CSCON is supported in nRF9160 modem >= v1.1.0");
-
-		err = nrf_modem_at_cmd(buf, sizeof(buf), "AT+CGMR");
-		if (err == 0) {
-			char *end = strstr(buf, "\r\nOK");
-
-			if (end) {
-				*end = '\0';
-			}
-
-			LOG_WRN("Current modem firmware version: %s", buf);
-		}
+		LOG_WRN("Failed to enable RRC notifications (+CSCON), error %d", err);
+		return -EFAULT;
 	}
 
 	return 0;

--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -87,8 +87,6 @@ K_SEM_DEFINE(ncellmeas_idle_sem, 1, 1);
 /* Network attach semaphore */
 static K_SEM_DEFINE(link, 0, 1);
 
-static const enum lte_lc_system_mode sys_mode_preferred = SYS_MODE_PREFERRED;
-
 /* System mode to use when connecting to LTE network, which can be changed in
  * two ways:
  *	- Automatically to fallback mode (if enabled) when connection to the
@@ -703,10 +701,10 @@ static int connect_lte(bool blocking)
 
 			if (IS_ENABLED(CONFIG_LTE_NETWORK_USE_FALLBACK) &&
 			    (tries > 0)) {
-				if (sys_mode_target == sys_mode_preferred) {
+				if (sys_mode_target == SYS_MODE_PREFERRED) {
 					sys_mode_target = sys_mode_fallback;
 				} else {
-					sys_mode_target = sys_mode_preferred;
+					sys_mode_target = SYS_MODE_PREFERRED;
 				}
 
 				err = lte_lc_func_mode_set(LTE_LC_FUNC_MODE_OFFLINE);

--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -568,31 +568,12 @@ static int enable_notifications(void)
 	return 0;
 }
 
-static void lte_lc_psm_default_config_set(void)
-{
-	if (IS_ENABLED(CONFIG_LTE_PSM_REQ_FORMAT_SECONDS)) {
-		lte_lc_psm_param_set_seconds(
-			CONFIG_LTE_PSM_REQ_RPTAU_SECONDS,
-			CONFIG_LTE_PSM_REQ_RAT_SECONDS);
-		LOG_DBG("PSM configs set from seconds: tau=%s (%ds), rat=%s (%ds)",
-			psm_param_rptau, CONFIG_LTE_PSM_REQ_RPTAU_SECONDS,
-			psm_param_rat, CONFIG_LTE_PSM_REQ_RAT_SECONDS);
-	} else {
-		__ASSERT_NO_MSG(IS_ENABLED(CONFIG_LTE_PSM_REQ_FORMAT_STRING));
-		lte_lc_psm_param_set(CONFIG_LTE_PSM_REQ_RPTAU, CONFIG_LTE_PSM_REQ_RAT);
-		LOG_DBG("PSM configs set from string: tau=%s, rat=%s",
-			psm_param_rptau, psm_param_rat);
-	}
-}
-
 static int init_and_config(void)
 {
 	if (is_initialized) {
 		LOG_DBG("The library is already initialized and configured");
 		return 0;
 	}
-
-	lte_lc_psm_default_config_set();
 
 	is_initialized = true;
 

--- a/lib/lte_link_control/lte_lc_modem_hooks.c
+++ b/lib/lte_link_control/lte_lc_modem_hooks.c
@@ -36,6 +36,30 @@ static void on_modem_init(int err, void *ctx)
 			lte_lc_sys_mode_pref);
 	}
 
+	if (IS_ENABLED(CONFIG_LTE_PSM_REQ_FORMAT_SECONDS)) {
+		err = lte_lc_psm_param_set_seconds(CONFIG_LTE_PSM_REQ_RPTAU_SECONDS,
+						   CONFIG_LTE_PSM_REQ_RAT_SECONDS);
+		if (err) {
+			LOG_ERR("Failed to set PSM params, err %d", err);
+			return;
+		}
+
+		LOG_DBG("PSM configs set from seconds: tau=%ds, rat=%ds",
+			CONFIG_LTE_PSM_REQ_RPTAU_SECONDS,
+			CONFIG_LTE_PSM_REQ_RAT_SECONDS);
+	} else {
+		__ASSERT_NO_MSG(IS_ENABLED(CONFIG_LTE_PSM_REQ_FORMAT_STRING));
+
+		err = lte_lc_psm_param_set(CONFIG_LTE_PSM_REQ_RPTAU, CONFIG_LTE_PSM_REQ_RAT);
+		if (err) {
+			LOG_ERR("Failed to set PSM params, err %d", err);
+			return;
+		}
+
+		LOG_DBG("PSM configs set from string: tau=%s, rat=%s",
+			CONFIG_LTE_PSM_REQ_RPTAU, CONFIG_LTE_PSM_REQ_RAT);
+	}
+
 	/* Request configured PSM and eDRX settings to save power. */
 	err = lte_lc_psm_req(IS_ENABLED(CONFIG_LTE_PSM_REQ));
 	if (err) {

--- a/lib/lte_link_control/lte_lc_modem_hooks.c
+++ b/lib/lte_link_control/lte_lc_modem_hooks.c
@@ -126,5 +126,5 @@ static void on_modem_init(int err, void *ctx)
 
 static void on_modem_shutdown(void *ctx)
 {
-	(void)lte_lc_deinit();
+	(void)lte_lc_power_off();
 }

--- a/lib/lte_link_control/lte_lc_modem_hooks.c
+++ b/lib/lte_link_control/lte_lc_modem_hooks.c
@@ -83,14 +83,6 @@ static void on_modem_init(int err, void *ctx)
 		LOG_ERR("Failed to configure RAI, err %d", err);
 		return;
 	}
-
-#if IS_ENABLED(CONFIG_LTE_AUTO_INIT_AND_CONNECT)
-	err = lte_lc_init_and_connect();
-	if (err) {
-		LOG_ERR("Lte_lc failed to initialize and connect, err %d", err);
-		return;
-	}
-#endif
 }
 
 static void on_modem_shutdown(void *ctx)

--- a/lib/lte_link_control/lte_lc_modem_hooks.c
+++ b/lib/lte_link_control/lte_lc_modem_hooks.c
@@ -16,9 +16,24 @@ NRF_MODEM_LIB_ON_SHUTDOWN(lte_lc_shutdown_hook, on_modem_shutdown, NULL);
 
 static void on_modem_init(int err, void *ctx)
 {
+	extern const enum lte_lc_system_mode lte_lc_sys_mode;
+	extern const enum lte_lc_system_mode_preference lte_lc_sys_mode_pref;
+
 	if (err) {
 		LOG_ERR("Modem library init error: %d, lte_lc not initialized", err);
 		return;
+	}
+
+	if (!IS_ENABLED(CONFIG_LTE_NETWORK_MODE_DEFAULT)) {
+		err = lte_lc_system_mode_set(lte_lc_sys_mode, lte_lc_sys_mode_pref);
+		if (err) {
+			LOG_ERR("Failed to set system mode and mode preference, err %d", err);
+			return;
+		}
+
+		LOG_DBG("System mode set to %d, preference %d",
+			lte_lc_sys_mode,
+			lte_lc_sys_mode_pref);
 	}
 
 	/* Request configured PSM and eDRX settings to save power. */

--- a/lib/nrf_modem_lib/lte_net_if/lte_net_if.c
+++ b/lib/nrf_modem_lib/lte_net_if/lte_net_if.c
@@ -209,13 +209,6 @@ static void connection_timeout_schedule(void)
 	}
 }
 
-static int modem_init(void)
-{
-	LOG_DBG("Initializing nRF Modem Library");
-
-	return nrf_modem_lib_init();
-}
-
 static void on_pdn_activated(void)
 {
 	int ret;
@@ -403,23 +396,8 @@ static void lte_net_if_init(struct conn_mgr_conn_binding *if_conn)
 
 int lte_net_if_enable(void)
 {
-	int ret;
-
 	if (!nrf_modem_is_initialized()) {
-		ret = modem_init();
-		if (ret) {
-			LOG_ERR("modem_init, error: %d", ret);
-			return ret;
-		}
-	}
-
-	/* Calling this function if the link controller has already been initialized is safe,
-	 * as it will return 0 in that case.
-	 */
-	ret = lte_lc_init();
-	if (ret) {
-		LOG_ERR("lte_lc_init, error: %d", ret);
-		return ret;
+		return nrf_modem_lib_init();
 	}
 
 	return 0;

--- a/samples/cellular/battery/src/main.c
+++ b/samples/cellular/battery/src/main.c
@@ -89,9 +89,9 @@ static void low_level_state_update(struct k_work *item)
 	k_sem_take(&state_sem, K_FOREVER);
 
 	if (state == NORMAL_HIGH_BAT) {
-		err = lte_lc_deinit();
+		err = lte_lc_power_off();
 		if (err) {
-			printk("Modem deinitialization failed, err: %d\n", err);
+			printk("Failed to power off modem, err: %d\n", err);
 			return;
 		}
 
@@ -198,11 +198,9 @@ static int modem_init_and_connect(void)
 {
 	int err;
 
-	printk("Initializing modem and connecting...\n");
-
-	err = lte_lc_init_and_connect();
+	err = lte_lc_connect();
 	if (err) {
-		printk("Modem initialization and connect failed, err: %d\n", err);
+		printk("Failed to connect to network, err: %d\n", err);
 		return err;
 	}
 

--- a/samples/cellular/ciphersuites/src/main.c
+++ b/samples/cellular/ciphersuites/src/main.c
@@ -162,7 +162,7 @@ int main(void)
 	}
 
 	printk("Waiting for network.. ");
-	err = lte_lc_init_and_connect();
+	err = lte_lc_connect();
 	if (err) {
 		printk("Failed to connect to the LTE network, err %d\n", err);
 		return 0;

--- a/samples/cellular/gnss/src/main.c
+++ b/samples/cellular/gnss/src/main.c
@@ -446,11 +446,6 @@ static int modem_init(void)
 		date_time_register_handler(date_time_evt_handler);
 	}
 
-	if (lte_lc_init() != 0) {
-		LOG_ERR("Failed to initialize LTE link controller");
-		return -1;
-	}
-
 #if defined(CONFIG_GNSS_SAMPLE_LTE_ON_DEMAND)
 	lte_lc_register_handler(lte_lc_event_handler);
 #elif !defined(CONFIG_GNSS_SAMPLE_ASSISTANCE_NONE)

--- a/samples/cellular/http_update/application_update/src/main.c
+++ b/samples/cellular/http_update/application_update/src/main.c
@@ -256,9 +256,6 @@ static int cert_provision(void)
  */
 static int modem_configure_and_connect(void)
 {
-	BUILD_ASSERT(!IS_ENABLED(CONFIG_LTE_AUTO_INIT_AND_CONNECT),
-		     "This sample does not support auto init and connect");
-
 	int err;
 
 #if defined(CONFIG_USE_HTTPS)

--- a/samples/cellular/http_update/application_update/src/main.c
+++ b/samples/cellular/http_update/application_update/src/main.c
@@ -268,7 +268,7 @@ static int modem_configure_and_connect(void)
 #endif /* CONFIG_USE_HTTPS */
 
 	printk("LTE Link Connecting ...\n");
-	err = lte_lc_init_and_connect_async(lte_lc_handler);
+	err = lte_lc_connect_async(lte_lc_handler);
 	if (err) {
 		printk("LTE link could not be established.");
 		return err;
@@ -293,7 +293,7 @@ static void fota_work_cb(struct k_work *work)
 		break;
 	case UPDATE_APPLY:
 #if !defined(CONFIG_LWM2M_CARRIER)
-		lte_lc_deinit();
+		lte_lc_power_off();
 #endif
 		sys_reboot(SYS_REBOOT_WARM);
 		break;
@@ -379,24 +379,6 @@ static int update_download(void)
 }
 
 #if defined(CONFIG_LWM2M_CARRIER)
-NRF_MODEM_LIB_ON_INIT(carrier_on_modem_lib_init, on_modem_lib_init, NULL);
-
-static void on_modem_lib_init(int ret, void *ctx)
-{
-	ARG_UNUSED(ctx);
-
-	if (ret) {
-		/* Modem initialization failed. */
-		return;
-	}
-
-	/* LTE LC is uninitialized on every modem shutdown. */
-	ret = lte_lc_init();
-	if (ret != 0) {
-		printk("failed to initialize LTE connection");
-		return;
-	}
-}
 
 static void print_err(const lwm2m_carrier_event_t *evt)
 {

--- a/samples/cellular/http_update/modem_delta_update/src/main.c
+++ b/samples/cellular/http_update/modem_delta_update/src/main.c
@@ -261,8 +261,6 @@ static int cert_provision(void)
  */
 static int modem_configure_and_connect(void)
 {
-	BUILD_ASSERT(!IS_ENABLED(CONFIG_LTE_AUTO_INIT_AND_CONNECT),
-			"This sample does not support auto init and connect");
 	int err;
 
 #if defined(CONFIG_USE_HTTPS)

--- a/samples/cellular/http_update/modem_delta_update/src/main.c
+++ b/samples/cellular/http_update/modem_delta_update/src/main.c
@@ -273,7 +273,7 @@ static int modem_configure_and_connect(void)
 #endif /* CONFIG_USE_HTTPS */
 
 	printk("LTE Link Connecting ...\n");
-	err = lte_lc_init_and_connect_async(lte_lc_handler);
+	err = lte_lc_connect_async(lte_lc_handler);
 	if (err) {
 		printk("LTE link could not be established.");
 		return err;
@@ -399,7 +399,7 @@ static void fota_work_cb(struct k_work *work)
 		break;
 	case UPDATE_APPLY:
 		printk("Applying firmware update. This can take a while.\n");
-		lte_lc_deinit();
+		lte_lc_power_off();
 		/* Re-initialize the modem to apply the update. */
 		err = nrf_modem_lib_shutdown();
 		if (err) {

--- a/samples/cellular/http_update/modem_full_update/src/main.c
+++ b/samples/cellular/http_update/modem_full_update/src/main.c
@@ -380,8 +380,6 @@ static int cert_provision(void)
  */
 static int modem_configure_and_connect(void)
 {
-	BUILD_ASSERT(!IS_ENABLED(CONFIG_LTE_AUTO_INIT_AND_CONNECT),
-			"This sample does not support auto init and connect");
 	int err;
 
 #if defined(CONFIG_USE_HTTPS)

--- a/samples/cellular/http_update/modem_full_update/src/main.c
+++ b/samples/cellular/http_update/modem_full_update/src/main.c
@@ -392,7 +392,7 @@ static int modem_configure_and_connect(void)
 #endif /* CONFIG_USE_HTTPS */
 
 	printk("LTE Link Connecting ...\n");
-	err = lte_lc_init_and_connect_async(lte_lc_handler);
+	err = lte_lc_connect_async(lte_lc_handler);
 	if (err) {
 		printk("LTE link could not be established.");
 		return err;

--- a/samples/cellular/location/src/main.c
+++ b/samples/cellular/location/src/main.c
@@ -256,7 +256,6 @@ int main(void)
 
 	printk("Connecting to LTE...\n");
 
-	lte_lc_init();
 	lte_lc_register_handler(lte_event_handler);
 
 	/* Enable PSM. */

--- a/samples/cellular/lte_ble_gateway/src/main.c
+++ b/samples/cellular/lte_ble_gateway/src/main.c
@@ -488,7 +488,7 @@ static void modem_configure(void)
 	display_state = LEDS_LTE_CONNECTING;
 
 	LOG_INF("Establishing LTE link (this may take some time) ...");
-	err = lte_lc_init_and_connect();
+	err = lte_lc_connect();
 	__ASSERT(err == 0, "LTE link could not be established.");
 	display_state = LEDS_LTE_CONNECTED;
 }

--- a/samples/cellular/lwm2m_carrier/src/main.c
+++ b/samples/cellular/lwm2m_carrier/src/main.c
@@ -31,9 +31,6 @@ static void on_modem_lib_init(int ret, void *ctx)
 		return;
 	}
 
-	/* LTE Link Controller is uninitialized on every modem shutdown. */
-	lte_lc_init();
-
 	/* Let the application write the credentials first and then bring the link up. */
 	if (m_first_init) {
 		err = carrier_cert_provision();

--- a/samples/cellular/lwm2m_client/src/main.c
+++ b/samples/cellular/lwm2m_client/src/main.c
@@ -626,13 +626,6 @@ int main(void)
 		return 0;
 	}
 
-	LOG_INF("Initializing modem.");
-	ret = lte_lc_init();
-	if (ret < 0) {
-		LOG_ERR("Unable to init modem (%d)", ret);
-		return 0;
-	}
-
 	lte_lc_register_handler(lte_notify_handler);
 
 	ret = modem_info_init();
@@ -773,8 +766,6 @@ int main(void)
 			/* Enable client reconnect */
 			LOG_INF("Restart modem and client after an update");
 			state_trigger_and_unlock(START);
-			/* Initialize & connect modem */
-			lte_lc_init();
 			modem_connect();
 			break;
 

--- a/samples/cellular/modem_callbacks/src/main.c
+++ b/samples/cellular/modem_callbacks/src/main.c
@@ -43,10 +43,10 @@ int main(void)
 		return 0;
 	}
 
-	printk("Changing functional mode\n");
-	err = lte_lc_init_and_connect();
+	printk("Connecting to network\n");
+	err = lte_lc_connect();
 	if (err) {
-		printk("lte_lc_init_and_connect() failed, err %d\n", err);
+		printk("Connecting to network failed, err %d\n", err);
 	}
 
 	printk("Shutting down modem library\n");

--- a/samples/cellular/modem_shell/src/main.c
+++ b/samples/cellular/modem_shell/src/main.c
@@ -279,7 +279,6 @@ int main(void)
 		return 0;
 	}
 
-	lte_lc_init();
 #if defined(CONFIG_MOSH_PPP)
 	ppp_ctrl_init();
 #endif

--- a/samples/cellular/nidd/src/main.c
+++ b/samples/cellular/nidd/src/main.c
@@ -55,12 +55,6 @@ static void modem_init(void)
 		return;
 	}
 
-	err = lte_lc_init();
-	if (err) {
-		printk("Modem LTE connection initialization failed, error: %d\n", err);
-		return;
-	}
-
 	(void)nrf_modem_at_printf("AT+CMEE=1");
 }
 

--- a/samples/cellular/nrf_cloud_multi_service/src/fota_support.c
+++ b/samples/cellular/nrf_cloud_multi_service/src/fota_support.c
@@ -21,7 +21,7 @@ void fota_reboot(const unsigned int delay_s, const bool error)
 
 #if defined(CONFIG_LTE_LINK_CONTROL)
 	if (error) {
-		(void)lte_lc_deinit();
+		(void)lte_lc_power_off();
 	}
 #endif
 

--- a/samples/cellular/nrf_cloud_multi_service/src/fota_support_coap.c
+++ b/samples/cellular/nrf_cloud_multi_service/src/fota_support_coap.c
@@ -383,7 +383,7 @@ static void handle_download_succeeded_and_reboot(void)
 		LOG_WRN("Failed to set B1 slot flag, BOOT FOTA validation may be incorrect");
 	}
 
-	(void)lte_lc_deinit();
+	(void)lte_lc_power_off();
 
 #if defined(CONFIG_NRF_CLOUD_FOTA_FULL_MODEM_UPDATE)
 	if (job.type == NRF_CLOUD_FOTA_MODEM_FULL) {

--- a/samples/cellular/nrf_cloud_rest_cell_location/src/main.c
+++ b/samples/cellular/nrf_cloud_rest_cell_location/src/main.c
@@ -7,6 +7,7 @@
 #include <zephyr/kernel.h>
 #include <stdio.h>
 #include <modem/nrf_modem_lib.h>
+#include <modem/lte_lc.h>
 #include <nrf_modem_at.h>
 #include <modem/modem_info.h>
 #include <zephyr/sys/reboot.h>
@@ -582,7 +583,7 @@ static void connect_to_network(void)
 
 	k_sem_reset(&lte_connected_sem);
 
-	err = lte_lc_init_and_connect_async(lte_handler);
+	err = lte_lc_connect_async(lte_handler);
 	if (err) {
 		LOG_ERR("Failed to init LTE module, unable to continue, error: %d", err);
 		k_sleep(K_FOREVER);
@@ -596,7 +597,7 @@ static void connect_to_network(void)
 		LOG_INF("Connected to network");
 	} else if (err == -EAGAIN) {
 		LOG_ERR("Failed to connect to network, rebooting in 30s...");
-		(void)lte_lc_deinit();
+		(void)lte_lc_power_off();
 		k_sleep(K_SECONDS(30));
 		sys_reboot(SYS_REBOOT_COLD);
 	} else {

--- a/samples/cellular/nrf_cloud_rest_device_message/src/main.c
+++ b/samples/cellular/nrf_cloud_rest_device_message/src/main.c
@@ -412,7 +412,7 @@ static int connect_to_lte(void)
 
 	k_sem_reset(&lte_connected);
 
-	err = lte_lc_init_and_connect_async(lte_handler);
+	err = lte_lc_connect_async(lte_handler);
 	if (err) {
 		LOG_ERR("Failed to init modem, error: %d", err);
 		return err;

--- a/samples/cellular/nrf_cloud_rest_fota/src/main.c
+++ b/samples/cellular/nrf_cloud_rest_fota/src/main.c
@@ -5,16 +5,17 @@
  */
 
 #include <zephyr/kernel.h>
-#include <modem/nrf_modem_lib.h>
-#include <nrf_modem_at.h>
-#include <modem/modem_info.h>
 #include <zephyr/settings/settings.h>
-#include <net/nrf_cloud.h>
-#include <net/nrf_cloud_rest.h>
 #include <zephyr/sys/reboot.h>
 #include <zephyr/logging/log.h>
-#include <dk_buttons_and_leds.h>
+#include <nrf_modem_at.h>
+#include <modem/nrf_modem_lib.h>
+#include <modem/lte_lc.h>
+#include <modem/modem_info.h>
+#include <net/nrf_cloud.h>
+#include <net/nrf_cloud_rest.h>
 #include <net/fota_download.h>
+#include <dk_buttons_and_leds.h>
 
 LOG_MODULE_REGISTER(nrf_cloud_rest_fota, CONFIG_NRF_CLOUD_REST_FOTA_SAMPLE_LOG_LEVEL);
 
@@ -525,7 +526,7 @@ static int connect_to_network(void)
 
 	k_sem_reset(&lte_connected);
 
-	err = lte_lc_init_and_connect_async(lte_handler);
+	err = lte_lc_connect_async(lte_handler);
 	if (err) {
 		LOG_ERR("Failed to init modem, error: %d", err);
 	} else {
@@ -678,7 +679,7 @@ static void handle_download_succeeded_and_reboot(void)
 	}
 
 	(void)nrf_cloud_rest_disconnect(&rest_ctx);
-	(void)lte_lc_deinit();
+	(void)lte_lc_power_off();
 
 #if defined(CONFIG_NRF_CLOUD_FOTA_FULL_MODEM_UPDATE)
 	if (job.type == NRF_CLOUD_FOTA_MODEM_FULL) {
@@ -722,7 +723,7 @@ static void error_reboot(void)
 {
 	LOG_INF("Rebooting in 30s...");
 	(void)nrf_cloud_rest_disconnect(&rest_ctx);
-	(void)lte_lc_deinit();
+	(void)lte_lc_power_off();
 	k_sleep(K_SECONDS(30));
 	sys_reboot(SYS_REBOOT_COLD);
 }

--- a/samples/cellular/nrf_provisioning/src/main.c
+++ b/samples/cellular/nrf_provisioning/src/main.c
@@ -105,7 +105,7 @@ int main(void)
 	}
 
 	LOG_INF("Establishing LTE link ...");
-	ret = lte_lc_init_and_connect();
+	ret = lte_lc_connect();
 	if (ret) {
 		LOG_ERR("LTE link could not be established (%d)", ret);
 		return 0;

--- a/samples/cellular/pdn/src/main.c
+++ b/samples/cellular/pdn/src/main.c
@@ -117,7 +117,7 @@ int main(void)
 		return 0;
 	}
 
-	err = lte_lc_init_and_connect();
+	err = lte_lc_connect();
 	if (err) {
 		return 0;
 	}

--- a/samples/cellular/sms/src/main.c
+++ b/samples/cellular/sms/src/main.c
@@ -66,7 +66,7 @@ int main(void)
 		return 0;
 	}
 
-	ret = lte_lc_init_and_connect();
+	ret = lte_lc_connect();
 	if (ret) {
 		printk("Lte_lc failed to initialize and connect, err %d", ret);
 		return 0;

--- a/samples/cellular/udp/src/main.c
+++ b/samples/cellular/udp/src/main.c
@@ -163,12 +163,6 @@ int main(void)
 	}
 #endif
 
-	err = lte_lc_init();
-	if (err) {
-		printk("Failed to initialize LTE link control, error: %d\n", err);
-		return -1;
-	}
-
 	err = lte_lc_connect_async(lte_handler);
 	if (err) {
 		printk("Failed to connect to LTE network, error: %d\n", err);

--- a/subsys/caf/modules/net_state_lte.c
+++ b/subsys/caf/modules/net_state_lte.c
@@ -142,12 +142,7 @@ static void lte_lc_evt_handler(const struct lte_lc_evt * const evt)
 
 static int connect_lte(void)
 {
-	int err = lte_lc_init();
-
-	if (err) {
-		LOG_ERR("Failed to initialize LTE");
-		return err;
-	}
+	int err;
 
 	err = lte_lc_connect_async(lte_lc_evt_handler);
 	if (err) {

--- a/tests/lib/lte_lc_api/src/lte_lc_api_test.c
+++ b/tests/lib/lte_lc_api/src/lte_lc_api_test.c
@@ -198,19 +198,11 @@ static void helper_lte_lc_data_clear(void)
 	memset(&test_gci_cells, 0, sizeof(test_gci_cells));
 }
 
-void wrap_lc_init(void)
-{
-	int ret = lte_lc_init();
-
-	TEST_ASSERT_EQUAL(EXIT_SUCCESS, ret);
-}
-
 void setUp(void)
 {
 	mock_nrf_modem_at_Init();
 
 	helper_lte_lc_data_clear();
-	wrap_lc_init();
 	lte_lc_register_handler(lte_lc_event_handler);
 
 	lte_lc_callback_count_occurred = 0;
@@ -224,12 +216,7 @@ void tearDown(void)
 
 	TEST_ASSERT_EQUAL(lte_lc_callback_count_expected, lte_lc_callback_count_occurred);
 
-	__mock_nrf_modem_at_printf_ExpectAndReturn("AT+CFUN=0", EXIT_SUCCESS);
-
 	ret = lte_lc_deregister_handler(lte_lc_event_handler);
-	TEST_ASSERT_EQUAL(EXIT_SUCCESS, ret);
-
-	ret = lte_lc_deinit();
 	TEST_ASSERT_EQUAL(EXIT_SUCCESS, ret);
 
 	mock_nrf_modem_at_Verify();
@@ -268,34 +255,6 @@ void test_lte_lc_register_handler_twice(void)
 	TEST_ASSERT_EQUAL(EXIT_SUCCESS, ret);
 }
 
-void test_lte_lc_deregister_handler_not_initialized(void)
-{
-	int ret;
-
-	__mock_nrf_modem_at_printf_ExpectAndReturn("AT+CFUN=0", EXIT_SUCCESS);
-	ret = lte_lc_deinit();
-	TEST_ASSERT_EQUAL(EXIT_SUCCESS, ret);
-	ret = lte_lc_deregister_handler(NULL);
-	TEST_ASSERT_EQUAL(-EINVAL, ret);
-
-	/* this is just to make the tearDown work again */
-	wrap_lc_init();
-}
-
-void test_lte_lc_deinit_twice(void)
-{
-	int ret;
-
-	__mock_nrf_modem_at_printf_ExpectAndReturn("AT+CFUN=0", EXIT_SUCCESS);
-	ret = lte_lc_deinit();
-	TEST_ASSERT_EQUAL(EXIT_SUCCESS, ret);
-	ret = lte_lc_deinit();
-	TEST_ASSERT_EQUAL(EXIT_SUCCESS, ret);
-
-	/* this is just to make the tearDown work again */
-	wrap_lc_init();
-}
-
 void test_lte_lc_connect_home_already_registered(void)
 {
 	int ret;
@@ -309,20 +268,7 @@ void test_lte_lc_connect_home_already_registered(void)
 	TEST_ASSERT_EQUAL(EXIT_SUCCESS, ret);
 }
 
-void test_lte_lc_init_and_connect_home_already_registered(void)
-{
-	int ret;
-
-	__mock_nrf_modem_at_scanf_ExpectAndReturn(
-		"AT+CEREG?", "+CEREG: %*u,%hu,%*[^,],\"%x\",", 2);
-	__mock_nrf_modem_at_scanf_ReturnVarg_uint16(LTE_LC_NW_REG_REGISTERED_HOME);
-	__mock_nrf_modem_at_scanf_ReturnVarg_uint32(0);
-
-	ret = lte_lc_init_and_connect();
-	TEST_ASSERT_EQUAL(EXIT_SUCCESS, ret);
-}
-
-void test_lte_lc_init_and_connect_async_null(void)
+void test_lte_lc_connect_async_null(void)
 {
 	int ret;
 
@@ -330,7 +276,7 @@ void test_lte_lc_init_and_connect_async_null(void)
 	ret = lte_lc_deregister_handler(lte_lc_event_handler);
 	TEST_ASSERT_EQUAL(EXIT_SUCCESS, ret);
 
-	ret = lte_lc_init_and_connect_async(NULL);
+	ret = lte_lc_connect_async(NULL);
 	TEST_ASSERT_EQUAL(-EINVAL, ret);
 
 	/* Register handler so that tearDown() doesn't cause unnecessary warning log */

--- a/tests/lib/lte_lc_api/src/lte_lc_api_test.c
+++ b/tests/lib/lte_lc_api/src/lte_lc_api_test.c
@@ -374,36 +374,12 @@ void test_lte_lc_normal_fail2(void)
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT+CEREG=5", EXIT_SUCCESS);
 	/* enable_notifications */
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT+CSCON=1", -NRF_ENOMEM);
-	__cmock_nrf_modem_at_cmd_ExpectAnyArgsAndReturn(-NRF_ENOMEM);
-	/* error is ignored */
-	__mock_nrf_modem_at_printf_ExpectAndReturn("AT+CFUN=1", EXIT_SUCCESS);
-
 
 	ret = lte_lc_normal();
-	TEST_ASSERT_EQUAL(EXIT_SUCCESS, ret);
+	TEST_ASSERT_EQUAL(-EFAULT, ret);
 }
 
 void test_lte_lc_normal_fail3(void)
-{
-	int ret;
-	char modem_ver[] = "MODEM_FW_VER_1.0\r\nOK";
-
-	__mock_nrf_modem_at_printf_ExpectAndReturn("AT+CEREG=5", EXIT_SUCCESS);
-	/* enable_notifications */
-	__mock_nrf_modem_at_printf_ExpectAndReturn("AT+CSCON=1", -NRF_ENOMEM);
-
-	/* error is ignored but modem FW version is checked */
-	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT+CGMR", EXIT_SUCCESS);
-	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
-	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
-	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(modem_ver, sizeof(modem_ver));
-
-	__mock_nrf_modem_at_printf_ExpectAndReturn("AT+CFUN=1", EXIT_SUCCESS);
-	ret = lte_lc_normal();
-	TEST_ASSERT_EQUAL(EXIT_SUCCESS, ret);
-}
-
-void test_lte_lc_normal_fail4(void)
 {
 	int ret;
 

--- a/tests/lib/lte_lc_api/src/lte_lc_api_test.c
+++ b/tests/lib/lte_lc_api/src/lte_lc_api_test.c
@@ -208,8 +208,7 @@ void wrap_lc_init(void)
 	__mock_nrf_modem_at_scanf_ReturnVarg_int(0); /* mode_preference */
 
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT%XSYSTEMMODE=1,0,1,0", EXIT_SUCCESS);
-	__mock_nrf_modem_at_printf_ExpectAndReturn("AT+CEREG=5", EXIT_SUCCESS);
-	__mock_nrf_modem_at_printf_ExpectAndReturn("AT+CSCON=1", EXIT_SUCCESS);
+
 	int ret = lte_lc_init();
 
 	TEST_ASSERT_EQUAL(EXIT_SUCCESS, ret);

--- a/tests/lib/lte_lc_api/src/lte_lc_api_test.c
+++ b/tests/lib/lte_lc_api/src/lte_lc_api_test.c
@@ -200,15 +200,6 @@ static void helper_lte_lc_data_clear(void)
 
 void wrap_lc_init(void)
 {
-	__mock_nrf_modem_at_scanf_ExpectAndReturn(
-		"AT%XSYSTEMMODE?", "%%XSYSTEMMODE: %d,%d,%d,%d", 4);
-	__mock_nrf_modem_at_scanf_ReturnVarg_int(1); /* ltem_mode */
-	__mock_nrf_modem_at_scanf_ReturnVarg_int(1); /* nbiot_mode */
-	__mock_nrf_modem_at_scanf_ReturnVarg_int(1); /* gps_mode */
-	__mock_nrf_modem_at_scanf_ReturnVarg_int(0); /* mode_preference */
-
-	__mock_nrf_modem_at_printf_ExpectAndReturn("AT%XSYSTEMMODE=1,0,1,0", EXIT_SUCCESS);
-
 	int ret = lte_lc_init();
 
 	TEST_ASSERT_EQUAL(EXIT_SUCCESS, ret);

--- a/tests/lib/nrf_modem_lib/lte_net_if/CMakeLists.txt
+++ b/tests/lib/nrf_modem_lib/lte_net_if/CMakeLists.txt
@@ -13,7 +13,9 @@ project(lte_net_if)
 zephyr_compile_options(-Wno-deprecated-declarations)
 
 # Create mocks
-cmock_handle(${ZEPHYR_NRF_MODULE_DIR}/include/modem/lte_lc.h FUNC_EXCLUDE ".*(lte_lc_rai_req|lte_lc_rai_param_set)")
+cmock_handle(${ZEPHYR_NRF_MODULE_DIR}/include/modem/lte_lc.h
+	FUNC_EXCLUDE ".*(lte_lc_rai_req|lte_lc_rai_param_set)"
+	WORD_EXCLUDE "__deprecated")
 cmock_handle(${ZEPHYR_NRF_MODULE_DIR}/include/modem/nrf_modem_lib.h FUNC_EXCLUDE ".*nrf_modem_lib_shutdown_wait")
 cmock_handle(${ZEPHYR_NRF_MODULE_DIR}/include/modem/pdn.h)
 cmock_handle(${ZEPHYR_NRFXLIB_MODULE_DIR}/nrf_modem/include/nrf_modem_at.h FUNC_EXCLUDE ".*nrf_modem_at_scanf")

--- a/tests/lib/nrf_modem_lib/lte_net_if/src/main.c
+++ b/tests/lib/nrf_modem_lib/lte_net_if/src/main.c
@@ -49,7 +49,6 @@ static void bring_network_interface_up(void)
 	struct net_if *net_if = net_if_get_default();
 
 	__cmock_nrf_modem_is_initialized_ExpectAndReturn(1);
-	__cmock_lte_lc_init_ExpectAndReturn(0);
 
 	TEST_ASSERT_EQUAL(0, net_if_up(net_if));
 }
@@ -208,7 +207,6 @@ void test_enable_should_init_modem_and_link_controller(void)
 
 	__cmock_nrf_modem_is_initialized_ExpectAndReturn(0);
 	__cmock_nrf_modem_lib_init_ExpectAndReturn(0);
-	__cmock_lte_lc_init_ExpectAndReturn(0);
 
 	TEST_ASSERT_EQUAL(0, net_if_up(net_if));
 }
@@ -219,7 +217,6 @@ void test_enable_should_init_modem_upon_successful_dfu_result(void)
 
 	__cmock_nrf_modem_is_initialized_ExpectAndReturn(0);
 	__cmock_nrf_modem_lib_init_ExpectAndReturn(0);
-	__cmock_lte_lc_init_ExpectAndReturn(0);
 
 	TEST_ASSERT_EQUAL(0, net_if_up(net_if));
 }
@@ -568,7 +565,6 @@ void test_pdn_act_without_cereg_should_not_activate_iface(void)
 	 */
 	__cmock_nrf_modem_is_initialized_IgnoreAndReturn(1);
 	__cmock_lte_lc_func_mode_set_IgnoreAndReturn(0);
-	__cmock_lte_lc_init_IgnoreAndReturn(0);
 
 	/* Take the iface admin-up */
 	net_if_up(net_if);
@@ -606,7 +602,6 @@ void test_pdn_act_with_cereg_should_activate_iface(void)
 	 */
 	__cmock_nrf_modem_is_initialized_IgnoreAndReturn(1);
 	__cmock_lte_lc_func_mode_set_IgnoreAndReturn(0);
-	__cmock_lte_lc_init_IgnoreAndReturn(0);
 
 	/* Take the iface admin-up */
 	net_if_up(net_if);
@@ -652,7 +647,6 @@ void test_cereg_registered_without_pdn_should_not_activate_iface(void)
 	 */
 	__cmock_nrf_modem_is_initialized_IgnoreAndReturn(1);
 	__cmock_lte_lc_func_mode_set_IgnoreAndReturn(0);
-	__cmock_lte_lc_init_IgnoreAndReturn(0);
 
 	/* Take the iface admin-up */
 	net_if_up(net_if);
@@ -686,7 +680,6 @@ void test_cereg_registered_home_with_pdn_should_activate_iface(void)
 	 */
 	__cmock_nrf_modem_is_initialized_IgnoreAndReturn(1);
 	__cmock_lte_lc_func_mode_set_IgnoreAndReturn(0);
-	__cmock_lte_lc_init_IgnoreAndReturn(0);
 
 	/* Take the iface admin-up */
 	net_if_up(net_if);
@@ -731,7 +724,6 @@ void test_cereg_registered_roaming_with_pdn_should_activate_iface(void)
 	 */
 	__cmock_nrf_modem_is_initialized_IgnoreAndReturn(1);
 	__cmock_lte_lc_func_mode_set_IgnoreAndReturn(0);
-	__cmock_lte_lc_init_IgnoreAndReturn(0);
 
 	/* Take the iface admin-up */
 	net_if_up(net_if);
@@ -776,7 +768,6 @@ void test_cereg_searching_should_not_activate_iface(void)
 	 */
 	__cmock_nrf_modem_is_initialized_IgnoreAndReturn(1);
 	__cmock_lte_lc_func_mode_set_IgnoreAndReturn(0);
-	__cmock_lte_lc_init_IgnoreAndReturn(0);
 
 	/* Take the iface admin-up */
 	net_if_up(net_if);
@@ -811,7 +802,6 @@ void test_cereg_searching_should_not_deactivate_iface(void)
 	 */
 	__cmock_nrf_modem_is_initialized_IgnoreAndReturn(1);
 	__cmock_lte_lc_func_mode_set_IgnoreAndReturn(0);
-	__cmock_lte_lc_init_IgnoreAndReturn(0);
 
 	/* Take the iface admin-up */
 	net_if_up(net_if);
@@ -860,7 +850,6 @@ void test_cereg_unregistered_should_deactivate_iface(void)
 	 */
 	__cmock_nrf_modem_is_initialized_IgnoreAndReturn(1);
 	__cmock_lte_lc_func_mode_set_IgnoreAndReturn(0);
-	__cmock_lte_lc_init_IgnoreAndReturn(0);
 
 	/* Take the iface admin-up */
 	net_if_up(net_if);
@@ -909,7 +898,6 @@ void test_pdn_deact_should_deactivate_iface(void)
 	 */
 	__cmock_nrf_modem_is_initialized_IgnoreAndReturn(1);
 	__cmock_lte_lc_func_mode_set_IgnoreAndReturn(0);
-	__cmock_lte_lc_init_IgnoreAndReturn(0);
 
 	/* Take the iface admin-up */
 	net_if_up(net_if);

--- a/tests/subsys/net/lib/lwm2m_fota_utils/src/stubs.c
+++ b/tests/subsys/net/lib/lwm2m_fota_utils/src/stubs.c
@@ -35,7 +35,6 @@ DEFINE_FAKE_VALUE_FUNC(int, modem_key_mgmt_write, nrf_sec_tag_t, enum modem_key_
 		       const void *, size_t);
 DEFINE_FAKE_VALUE_FUNC(int, lte_lc_func_mode_set, enum lte_lc_func_mode);
 DEFINE_FAKE_VALUE_FUNC(int, lte_lc_connect);
-DEFINE_FAKE_VALUE_FUNC(int, lte_lc_deinit);
 DEFINE_FAKE_VALUE_FUNC(int, lte_lc_offline);
 DEFINE_FAKE_VALUE_FUNC(int, lte_lc_func_mode_get, enum lte_lc_func_mode *);
 DEFINE_FAKE_VALUE_FUNC(int, lte_lc_lte_mode_get, enum lte_lc_lte_mode *);

--- a/tests/subsys/net/lib/lwm2m_fota_utils/src/stubs.h
+++ b/tests/subsys/net/lib/lwm2m_fota_utils/src/stubs.h
@@ -33,7 +33,6 @@ DECLARE_FAKE_VALUE_FUNC(int, modem_key_mgmt_write, nrf_sec_tag_t, enum modem_key
 DECLARE_FAKE_VALUE_FUNC(int, lte_lc_func_mode_set, enum lte_lc_func_mode);
 DECLARE_FAKE_VALUE_FUNC(int, lte_lc_connect);
 DECLARE_FAKE_VALUE_FUNC(int, lte_lc_offline);
-DECLARE_FAKE_VALUE_FUNC(int, lte_lc_deinit);
 DECLARE_FAKE_VALUE_FUNC(int, lte_lc_func_mode_get, enum lte_lc_func_mode *);
 DECLARE_FAKE_VALUE_FUNC(int, lte_lc_ptw_set, enum lte_lc_lte_mode, const char *);
 DECLARE_FAKE_VALUE_FUNC(int, lte_lc_psm_param_set, const char *, const char *);
@@ -109,7 +108,6 @@ DECLARE_FAKE_VALUE_FUNC(int, fota_download_util_apply_update, enum dfu_target_im
 		FUNC(modem_info_rsrp_register)                                                     \
 		FUNC(lte_lc_func_mode_set)                                                         \
 		FUNC(lte_lc_connect)                                                               \
-		FUNC(lte_lc_deinit)                                                                \
 		FUNC(lte_lc_offline)                                                               \
 		FUNC(lte_lc_func_mode_get)                                                         \
 		FUNC(lte_lc_lte_mode_get)                                                          \

--- a/tests/subsys/net/lib/nrf_provisioning/CMakeLists.txt
+++ b/tests/subsys/net/lib/nrf_provisioning/CMakeLists.txt
@@ -18,7 +18,9 @@ set(options
 )
 
 cmock_handle(${ZEPHYR_NRF_MODULE_DIR}/include/date_time.h)
-cmock_handle(${ZEPHYR_NRF_MODULE_DIR}/include/modem/lte_lc.h FUNC_EXCLUDE ".*(lte_lc_rai_req|lte_lc_rai_param_set)")
+cmock_handle(${ZEPHYR_NRF_MODULE_DIR}/include/modem/lte_lc.h
+	FUNC_EXCLUDE ".*(lte_lc_rai_req|lte_lc_rai_param_set)"
+	WORD_EXCLUDE "__deprecated")
 cmock_handle(${ZEPHYR_NRF_MODULE_DIR}/include/modem/modem_key_mgmt.h)
 cmock_handle(${ZEPHYR_NRF_MODULE_DIR}/include/modem/modem_info.h)
 cmock_handle(${ZEPHYR_NRF_MODULE_DIR}/include/modem/nrf_modem_lib.h)

--- a/tests/subsys/net/lib/nrf_provisioning/src/main.c
+++ b/tests/subsys/net/lib/nrf_provisioning/src/main.c
@@ -1006,7 +1006,7 @@ void test_provisioning_init_wo_cert_change_valid(void)
 	__cmock_lte_lc_register_handler_ExpectAnyArgs();
 	__cmock_modem_info_init_IgnoreAndReturn(0);
 	__cmock_nrf_modem_lib_init_IgnoreAndReturn(0);
-	__cmock_lte_lc_init_and_connect_IgnoreAndReturn(0);
+	__cmock_lte_lc_connect_IgnoreAndReturn(0);
 
 	__cmock_settings_subsys_init_ExpectAndReturn(0);
 	__cmock_settings_register_ExpectAnyArgsAndReturn(0);
@@ -1018,7 +1018,7 @@ void test_provisioning_init_wo_cert_change_valid(void)
 
 	__cmock_modem_info_init_StopIgnore();
 	__cmock_nrf_modem_lib_init_StopIgnore();
-	__cmock_lte_lc_init_and_connect_StopIgnore();
+	__cmock_lte_lc_connect_StopIgnore();
 }
 
 /*


### PR DESCRIPTION
Removing deprecated features, deprecating more :)
The following are being deprecated:
- lte_lc_init()
- lte_lc_init_and_connect()
- lte_lc_init_and_connect_async()
- lte_lc_deinit()