### PR TITLE
doc: bluetooth: mesh: Remove experimental and not adopted sentences

### DIFF
--- a/doc/nrf/device_guides/working_with_nrf/nrf52/developing.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf52/developing.rst
@@ -212,7 +212,6 @@ FOTA in Bluetooth mesh
 When performing a FOTA update when working with the Bluetooth mesh protocol, use one of the following DFU methods:
 
 * DFU over Bluetooth mesh using the Zephyr Bluetooth mesh DFU subsystem.
-  The specification that the Bluetooth mesh DFU subsystem is based on is not adopted yet, and therefore this feature should be used for experimental purposes only.
 * Point-to-point DFU over Bluetooth Low Energy as described in `FOTA over Bluetooth Low Energy`_ above.
 
 For more information about both methods, see :ref:`ug_bt_mesh_fota`.

--- a/doc/nrf/protocols/bt/bt_mesh/dfu_over_bt_mesh.rst
+++ b/doc/nrf/protocols/bt/bt_mesh/dfu_over_bt_mesh.rst
@@ -13,7 +13,6 @@ The DFU specification is implemented in the Zephyr Bluetooth mesh DFU subsystem 
 * :ref:`zephyr:bluetooth_mesh_dfu_cli`
 * :ref:`zephyr:bluetooth_mesh_dfd_srv`
 
-The Bluetooth mesh DFU subsystem is in experimental state.
 For more information about the Zephyr Bluetooth mesh DFU subsystem, see :ref:`zephyr:bluetooth_mesh_dfu`.
 
 The Bluetooth mesh subsystem in |NCS| provides a set of samples that can be used for evaluation of the Bluetooth mesh DFU specification and subsystem:

--- a/doc/nrf/protocols/bt/bt_mesh/fota.rst
+++ b/doc/nrf/protocols/bt/bt_mesh/fota.rst
@@ -6,7 +6,6 @@ Performing Device Firmware Updates (DFU) in Bluetooth mesh
 The |NCS| supports two DFU methods when updating your firmware over-the-air (FOTA) for your Bluetooth mesh devices and applications.
 
 * DFU over Bluetooth® mesh using the Zephyr Bluetooth mesh DFU subsystem that implements the Mesh Device Firmware Update Model specification version 1.0 and Mesh Binary Large Object Transfer Model specification version 1.0.
-  The specification that the Bluetooth mesh DFU subsystem is based on is not adopted yet, and therefore this feature should be used for experimental purposes only.
 * Point-to-point DFU over Bluetooth® Low Energy using the MCUmgr subsystem and the Simple Management Protocol (SMP).
 
 .. toctree::


### PR DESCRIPTION
DFU spec is adopted.
Experimental flag has been removed https://github.com/zephyrproject-rtos/zephyr/pull/64866