### PR TITLE
crypto: Use Matter version of SPAKE2+

### DIFF
--- a/ext/oberon/psa/drivers/oberon_spake2p.c
+++ b/ext/oberon/psa/drivers/oberon_spake2p.c
@@ -149,7 +149,7 @@ static psa_status_t oberon_get_confirmation_keys(
     // get K_shared
 #ifdef SPAKE2P_USE_VERSION_04
     hash_len >>= 1; // K_confirm and confirm size is hash_len / 2
-    memcpy(op->shared, data + hash_len, hash_len);
+    memcpy(op->shared, V + hash_len, hash_len);
 #else
     status = psa_driver_wrapper_key_derivation_setup(&kdf_op, PSA_ALG_HKDF(op->hash_alg));
     if (status) goto exit;

--- a/subsys/nrf_security/cmake/psa_crypto_config.cmake
+++ b/subsys/nrf_security/cmake/psa_crypto_config.cmake
@@ -254,6 +254,7 @@ kconfig_check_and_set_base_to_one(PSA_NEED_OBERON_SHA_384)
 kconfig_check_and_set_base_to_one(PSA_NEED_OBERON_SHA_512)
 kconfig_check_and_set_base_to_one(PSA_NEED_OBERON_TLS12_PRF)
 kconfig_check_and_set_base_to_one(PSA_NEED_OBERON_TLS12_PSK_TO_MS)
+set(SPAKE2P_USE_VERSION_04 ${CONFIG_PSA_CRYPTO_SPAKE2P_USE_VERSION_04})
 
 # Convert NRF_RNG driver configuration
 kconfig_check_and_set_base_to_one(PSA_NEED_NRF_RNG_ENTROPY_DRIVER)

--- a/subsys/nrf_security/configs/psa_crypto_config.h.template
+++ b/subsys/nrf_security/configs/psa_crypto_config.h.template
@@ -267,6 +267,9 @@
 #cmakedefine PSA_NEED_OBERON_TLS12_PSK_TO_MS                    @PSA_NEED_OBERON_TLS12_PSK_TO_MS@
 #cmakedefine PSA_NEED_OBERON_JPAKE_DRIVER                       @PSA_NEED_OBERON_JPAKE_DRIVER@
 
+/* Use Matter compatible version of Spake2+ in Oberon code. */
+#cmakedefine SPAKE2P_USE_VERSION_04                             @SPAKE2_USE_VERSION_04@
+
 #cmakedefine PSA_NEED_NRF_RNG_ENTROPY_DRIVER                    @PSA_NEED_NRF_RNG_ENTROPY_DRIVER@
 
 /* Nordic specific */

--- a/subsys/nrf_security/src/drivers/Kconfig
+++ b/subsys/nrf_security/src/drivers/Kconfig
@@ -205,6 +205,12 @@ config PSA_MAX_RSA_KEY_BITS
 
 endmenu
 
+# Temporary configuration of SPAKE2+ version
+config PSA_CRYPTO_SPAKE2P_USE_VERSION_04
+	bool
+	prompt "Use SPAKE2P Version 04"
+	depends on PSA_CRYPTO_DRIVER_OBERON
+	depends on PSA_WANT_ALG_SPAKE2P
 
 rsource "Kconfig.psa_accel"
 


### PR DESCRIPTION
Set's the define in Oberon could so Matter compatible of SPAKE2+ is used.