### PR TITLE
samples: cellular: udp: cleanup and add way to shutdown modem

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -99,6 +99,7 @@
   - "samples/cellular/mqtt_simple/**/*"
   - "samples/cellular/pdn/**/*"
   - "samples/cellular/sms/**/*"
+  - "samples/cellular/udp/**/*"
   - "subsys/net/lib/download_client/**/*"
 
 "CI-lwm2m-test":
@@ -219,7 +220,6 @@
   - "lib/date_time/**/*"
   - "drivers/sensor/sensor_sim/**/*"
   - "applications/asset_tracker_v2/**/*"
-  - "samples/cellular/udp/**/*"
   - "samples/net/aws_iot/**/*"
   - "samples/net/azure_iot_hub/**/*"
   - "samples/net/udp/**/*"

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -316,6 +316,10 @@ Cellular samples
 
   * Added the configuration overlay file :file:`overlay-supl.conf` for building the sample with SUPL assistance support.
 
+* :ref:`udp` sample:
+
+  * Added the :ref:`CONFIG_UDP_DATA_UPLOAD_ITERATIONS <CONFIG_UDP_DATA_UPLOAD_ITERATIONS>` Kconfig option for configuring the number of data transmissions to the server.
+
 Cryptography samples
 --------------------
 

--- a/samples/cellular/udp/Kconfig
+++ b/samples/cellular/udp/Kconfig
@@ -14,6 +14,14 @@ config UDP_DATA_UPLOAD_FREQUENCY_SECONDS
 	int "How often data is transmitted to the server"
 	default 900
 
+config UDP_DATA_UPLOAD_ITERATIONS
+	int "Number of data transmissions to the server before shutdown"
+	range -1 2147483647
+	default -1
+	help
+	  Number of data transmissions to the server before shutdown.
+	  Set to -1 to transmit indefinitely.
+
 config UDP_SERVER_ADDRESS_STATIC
 	string "UDP server IP address"
 	default "8.8.8.8"

--- a/samples/cellular/udp/README.rst
+++ b/samples/cellular/udp/README.rst
@@ -62,6 +62,12 @@ CONFIG_UDP_DATA_UPLOAD_SIZE_BYTES - UDP data upload size configuration
 CONFIG_UDP_DATA_UPLOAD_FREQUENCY_SECONDS - UDP data upload frequency configuration
    This configuration option sets the frequency with which the sample transmits data to the server.
 
+.. _CONFIG_UDP_DATA_UPLOAD_ITERATIONS:
+
+CONFIG_UDP_DATA_UPLOAD_ITERATIONS - UDP data upload iterations configuration
+   This configuration option sets the number of times the sample transmits data to the server before shutting down.
+   Set to ``-1`` to transmit indefinitely.
+
 .. _CONFIG_UDP_SERVER_ADDRESS_STATIC:
 
 CONFIG_UDP_SERVER_ADDRESS_STATIC - UDP Server IP Address configuration

--- a/samples/cellular/udp/src/main.c
+++ b/samples/cellular/udp/src/main.c
@@ -18,7 +18,7 @@ static struct sockaddr_storage host_addr;
 static struct k_work_delayable socket_transmission_work;
 static int data_upload_iterations = CONFIG_UDP_DATA_UPLOAD_ITERATIONS;
 
-K_SEM_DEFINE(lte_connected, 0, 1);
+K_SEM_DEFINE(lte_connected_sem, 0, 1);
 K_SEM_DEFINE(modem_shutdown_sem, 0, 1);
 
 static void socket_transmission_work_fn(struct k_work *work)
@@ -98,7 +98,7 @@ static void lte_handler(const struct lte_lc_evt *const evt)
 		printk("Network registration status: %s\n",
 		       evt->nw_reg_status == LTE_LC_NW_REG_REGISTERED_HOME ?
 		       "Connected - home" : "Connected - roaming");
-		k_sem_give(&lte_connected);
+		k_sem_give(&lte_connected_sem);
 		break;
 	case LTE_LC_EVT_PSM_UPDATE:
 		printk("PSM parameter update: TAU: %d s, Active time: %d s\n",
@@ -183,7 +183,7 @@ int main(void)
 		return -1;
 	}
 
-	k_sem_take(&lte_connected, K_FOREVER);
+	k_sem_take(&lte_connected_sem, K_FOREVER);
 
 	err = socket_connect();
 	if (err) {


### PR DESCRIPTION
This commit adds a new Kconfig option for configuring
the number of data transmissions to the server.
Shutdown the modem library when there are no more
transmissions to execute.
Moved sample to `CI-iot-samples-test` plan.