### PR TITLE
doc: scripts: software_maturity: Added PMIC section

### DIFF
--- a/doc/_scripts/software_maturity/software_maturity_features.yaml
+++ b/doc/_scripts/software_maturity/software_maturity_features.yaml
@@ -99,6 +99,11 @@ features:
     Immutable Bootloader as part of build: SECURE_BOOT
   hw_unique_key:
     Key Derivation from Hardware Unique Key: HW_UNIQUE_KEY
+  power_management:
+    nPM1100: REGULATOR_NPM1100
+    nPM1300: MFD_NPM1300
+    nPM6001: MFD_NPM6001
+
 display_names:
   SHIELD_NRF7002EK: nRF7002 EK
   SHIELD_NRF7002EK_NRF7000: nRF7002 EK in nRF7000 emulation mode


### PR DESCRIPTION
Add power management software maturity features.

software_maturity_scanner.py only runs on main nightly, so the new feature table will not be usable until after it has been merged.
Adding this information to the software maturity document will be handled as a later PR. 