### PR TITLE
event_manager: Remove unexpected reboot on alloc fail

### DIFF
--- a/subsys/app_event_manager/app_event_manager.c
+++ b/subsys/app_event_manager/app_event_manager.c
@@ -121,11 +121,7 @@ void * __weak app_event_manager_alloc(size_t size)
 	if (unlikely(!event)) {
 		LOG_ERR("Application Event Manager OOM error\n");
 		__ASSERT_NO_MSG(false);
-		if (IS_ENABLED(CONFIG_REBOOT)) {
-			sys_reboot(SYS_REBOOT_WARM);
-		} else {
-			k_panic();
-		}
+		k_panic();
 		return NULL;
 	}
 


### PR DESCRIPTION
Having the application reboot unexpectedly is ... unexpected. By convention, any function that is an allocator is expected to return `null` if it is unable to allocate the requested memory.

Remove the confusing reboot, and instead return `NULL` so that the application can decide what to do.