### PR TITLE
applications: asset_tracker_v2: Use path relative to Zephyr SDK

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/Kconfig.lwm2m_integration
+++ b/applications/asset_tracker_v2/src/cloud/Kconfig.lwm2m_integration
@@ -6,7 +6,7 @@
 
 module = LWM2M_INTEGRATION
 module-prompt = "LwM2M integration [Experimental]"
-orsource "../../../../subsys/net/lib/Kconfig.cloud_$(CLOUD_SERVICE_SELECTOR)"
+osource "$(ZEPHYR_NRF_MODULE_DIR)/subsys/net/lib/Kconfig.cloud_$(CLOUD_SERVICE_SELECTOR)"
 
 config $(module)
 	bool


### PR DESCRIPTION
Use path relative to Zephyr SDK to support out of tree builds.