### PR TITLE
Allow build-time configuration of NRF_MODEM_LIB_NET_IF_DOWN

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -413,10 +413,14 @@ Modem libraries
 
 * :ref:`nrf_modem_lib_readme`:
 
-   * Added a mention about enabling TF-M logging while using modem traces in the :ref:`modem_trace_module`.
-   * Updated by renaming ``lte_connectivity`` module to ``lte_net_if``.
-     All related Kconfig options have been renamed accordingly.
-   * Changed the default value of the :kconfig:option:`CONFIG_NRF_MODEM_LIB_NET_IF_AUTO_START`, :kconfig:option:`CONFIG_NRF_MODEM_LIB_NET_IF_AUTO_CONNECT`, and :kconfig:option:`CONFIG_NRF_MODEM_LIB_NET_IF_AUTO_DOWN` Kconfig options from enabled to disabled.
+  * Added:
+
+    * A mention about enabling TF-M logging while using modem traces in the :ref:`modem_trace_module`.
+    * The :kconfig:option:`CONFIG_NRF_MODEM_LIB_NET_IF_DOWN_DEFAULT_LTE_DISCONNECT` option, allowing the :c:enumerator:`nrf_modem_lib_net_if_options.NRF_MODEM_LIB_NET_IF_DOWN` option to be set to :c:enumerator:`~nrf_modem_lib_net_if_down_options.NRF_MODEM_LIB_NET_IF_DOWN_LTE_DISCONNECT` at build time.
+
+  * Updated by renaming ``lte_connectivity`` module to ``lte_net_if``.
+    All related Kconfig options have been renamed accordingly.
+  * Changed the default value of the :kconfig:option:`CONFIG_NRF_MODEM_LIB_NET_IF_AUTO_START`, :kconfig:option:`CONFIG_NRF_MODEM_LIB_NET_IF_AUTO_CONNECT`, and :kconfig:option:`CONFIG_NRF_MODEM_LIB_NET_IF_AUTO_DOWN` Kconfig options from enabled to disabled.
 
   * Removed:
 

--- a/include/modem/nrf_modem_lib.h
+++ b/include/modem/nrf_modem_lib.h
@@ -196,7 +196,7 @@ struct nrf_modem_lib_shutdown_cb {
  */
 void nrf_modem_fault_handler(struct nrf_modem_fault_info *fault_info);
 
-#if defined(CONFIG_NRF_MODEM_LIB_NET_IF)
+#if defined(CONFIG_NRF_MODEM_LIB_NET_IF) || defined(__DOXYGEN__)
 /** @brief Options used to specify desired behavior when the network interface is brought down by
  *	   calling net_if_down().
  */

--- a/lib/nrf_modem_lib/lte_net_if/Kconfig
+++ b/lib/nrf_modem_lib/lte_net_if/Kconfig
@@ -66,6 +66,14 @@ config NRF_MODEM_LIB_NET_IF_AUTO_DOWN
 	 down when it stops trying to connect. This option sets the default value, the option has
 	 a corresponding flag that can be set at run time by calling conn_mgr_if_set_flag().
 
+config NRF_MODEM_LIB_NET_IF_DOWN_DEFAULT_LTE_DISCONNECT
+	bool "Disconnect on iface down"
+	help
+	 If this option is set, the LTE iface will disconnect LTE instead of shutting down the
+	 modem when going down. This option sets the default value for the
+	 NRF_MODEM_LIB_NET_IF_DOWN connectivity option. The value can still be changed at runtime
+	 by calling conn_mgr_if_set_opt().
+
 module = NRF_MODEM_LIB_NET_IF
 module-str = Modem network interface
 source "subsys/logging/Kconfig.template.log_config"

--- a/lib/nrf_modem_lib/lte_net_if/lte_net_if.c
+++ b/lib/nrf_modem_lib/lte_net_if/lte_net_if.c
@@ -361,30 +361,15 @@ static void lte_net_if_init(struct conn_mgr_conn_binding *if_conn)
 	}
 
 	if (!IS_ENABLED(CONFIG_NRF_MODEM_LIB_NET_IF_AUTO_CONNECT)) {
-		ret = conn_mgr_if_set_flag(if_conn->iface, CONN_MGR_IF_NO_AUTO_CONNECT, true);
-		if (ret) {
-			LOG_ERR("conn_mgr_if_set_flag, error: %d", ret);
-			net_mgmt_event_notify(NET_EVENT_CONN_IF_FATAL_ERROR, if_conn->iface);
-			return;
-		}
+		conn_mgr_binding_set_flag(if_conn, CONN_MGR_IF_NO_AUTO_CONNECT, true);
 	}
 
 	if (!IS_ENABLED(CONFIG_NRF_MODEM_LIB_NET_IF_AUTO_DOWN)) {
-		ret = conn_mgr_if_set_flag(if_conn->iface, CONN_MGR_IF_NO_AUTO_DOWN, true);
-		if (ret) {
-			LOG_ERR("conn_mgr_if_set_flag, error: %d", ret);
-			net_mgmt_event_notify(NET_EVENT_CONN_IF_FATAL_ERROR, if_conn->iface);
-			return;
-		}
+		conn_mgr_binding_set_flag(if_conn, CONN_MGR_IF_NO_AUTO_DOWN, true);
 	}
 
 	if (IS_ENABLED(CONFIG_NRF_MODEM_LIB_NET_IF_CONNECTION_PERSISTENCE)) {
-		ret = conn_mgr_if_set_flag(if_conn->iface, CONN_MGR_IF_PERSISTENT, true);
-		if (ret) {
-			LOG_ERR("conn_mgr_if_set_flag, error: %d", ret);
-			net_mgmt_event_notify(NET_EVENT_CONN_IF_FATAL_ERROR, if_conn->iface);
-			return;
-		}
+		conn_mgr_binding_set_flag(if_conn, CONN_MGR_IF_PERSISTENT, true);
 	}
 
 	/* Set default values for timeouts */

--- a/lib/nrf_modem_lib/lte_net_if/lte_net_if.c
+++ b/lib/nrf_modem_lib/lte_net_if/lte_net_if.c
@@ -344,10 +344,22 @@ static void lte_net_if_init(struct conn_mgr_conn_binding *if_conn)
 {
 	int ret;
 	int timeout = CONFIG_NRF_MODEM_LIB_NET_IF_CONNECT_TIMEOUT_SECONDS;
+	uint8_t down_mode;
 
 	net_if_dormant_on(if_conn->iface);
 
-	/* Apply requested flag overrides */
+	/* Apply requested option and flag overrides */
+	if (IS_ENABLED(CONFIG_NRF_MODEM_LIB_NET_IF_DOWN_DEFAULT_LTE_DISCONNECT)) {
+		down_mode = NRF_MODEM_LIB_NET_IF_DOWN_LTE_DISCONNECT;
+		ret = conn_mgr_if_set_opt(if_conn->iface, NRF_MODEM_LIB_NET_IF_DOWN,
+					  (const void *)&down_mode, sizeof(down_mode));
+		if (ret) {
+			LOG_ERR("conn_mgr_if_set_opt, error: %d", ret);
+			net_mgmt_event_notify(NET_EVENT_CONN_IF_FATAL_ERROR, if_conn->iface);
+			return;
+		}
+	}
+
 	if (!IS_ENABLED(CONFIG_NRF_MODEM_LIB_NET_IF_AUTO_CONNECT)) {
 		ret = conn_mgr_if_set_flag(if_conn->iface, CONN_MGR_IF_NO_AUTO_CONNECT, true);
 		if (ret) {


### PR DESCRIPTION
This PR adds a KConfig option which allows the default value of the NRF_MODEM_LIB_NET_IF_DOWN option to be changed at build time.

Also, while I was in the area, I updated the flag overrides to use a newly available API