### PR TITLE
samples: Bluetooth: Mesh: no more tinycrypt in tfm psa based mesh

### DIFF
--- a/samples/bluetooth/mesh/light/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
+++ b/samples/bluetooth/mesh/light/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
@@ -6,4 +6,9 @@
 ################################################################################
 # Application overlay - nrf5340dk non secure image
 
+# The option adds TinyCrypt based bt_rand.
+CONFIG_BT_HOST_CRYPTO=n
+# The option adds GATT caching feature that is based on TinyCrypt.
+CONFIG_BT_GATT_CACHING=n
+
 CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE=n

--- a/samples/bluetooth/mesh/light_ctrl/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
+++ b/samples/bluetooth/mesh/light_ctrl/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
@@ -6,4 +6,9 @@
 ################################################################################
 # Application overlay - nrf5340dk non secure image
 
+# The option adds TinyCrypt based bt_rand.
+CONFIG_BT_HOST_CRYPTO=n
+# The option adds GATT caching feature that is based on TinyCrypt.
+CONFIG_BT_GATT_CACHING=n
+
 CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE=n

--- a/samples/bluetooth/mesh/light_dimmer/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
+++ b/samples/bluetooth/mesh/light_dimmer/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
@@ -6,4 +6,9 @@
 ################################################################################
 # Application overlay - nrf5340dk non secure image
 
+# The option adds TinyCrypt based bt_rand.
+CONFIG_BT_HOST_CRYPTO=n
+# The option adds GATT caching feature that is based on TinyCrypt.
+CONFIG_BT_GATT_CACHING=n
+
 CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE=n

--- a/samples/bluetooth/mesh/light_switch/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
+++ b/samples/bluetooth/mesh/light_switch/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
@@ -6,4 +6,9 @@
 ################################################################################
 # Application overlay - nrf5340dk non secure image
 
+# The option adds TinyCrypt based bt_rand.
+CONFIG_BT_HOST_CRYPTO=n
+# The option adds GATT caching feature that is based on TinyCrypt.
+CONFIG_BT_GATT_CACHING=n
+
 CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE=n


### PR DESCRIPTION
Changes disable all host functionality that uses
tinycrypt in mesh samples.