### PR TITLE
boards: shields: nrf21540ek alter default BLE TX power

### DIFF
--- a/boards/shields/nrf21540ek/Kconfig.defconfig
+++ b/boards/shields/nrf21540ek/Kconfig.defconfig
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+if SHIELD_NRF21540EK
+
+if BT_CTLR
+
+config BT_CTLR_TX_PWR_ANTENNA
+	default MPSL_FEM_NRF21540_TX_GAIN_DB
+
+endif # BT_CTLR
+
+endif # SHIELD_NRF21540EK


### PR DESCRIPTION
The Kconfig.defconfig file is added to nrf21540ek shield support. When shield is applied the BT_CTLR_TX_PWR_ANTENNA is updated to value `0 + MPSL_FEM_NRF21540_TX_GAIN_DB` dBm.