### PR TITLE
lib: lte_link_control: Improve logging

### DIFF
--- a/lib/lte_link_control/lte_lc_helpers.c
+++ b/lib/lte_link_control/lte_lc_helpers.c
@@ -18,7 +18,7 @@
 
 #include "lte_lc_helpers.h"
 
-LOG_MODULE_REGISTER(lte_lc_helpers, CONFIG_LTE_LINK_CONTROL_LOG_LEVEL);
+LOG_MODULE_DECLARE(lte_lc, CONFIG_LTE_LINK_CONTROL_LOG_LEVEL);
 
 static K_MUTEX_DEFINE(list_mtx);
 

--- a/lib/lte_link_control/lte_lc_modem_hooks.c
+++ b/lib/lte_link_control/lte_lc_modem_hooks.c
@@ -9,7 +9,7 @@
 #include <modem/nrf_modem_lib.h>
 #include <zephyr/logging/log.h>
 
-LOG_MODULE_DECLARE(lte_lc);
+LOG_MODULE_DECLARE(lte_lc, CONFIG_LTE_LINK_CONTROL_LOG_LEVEL);
 
 NRF_MODEM_LIB_ON_INIT(lte_lc_init_hook, on_modem_init, NULL);
 NRF_MODEM_LIB_ON_SHUTDOWN(lte_lc_shutdown_hook, on_modem_shutdown, NULL);


### PR DESCRIPTION
Moved all logging from the library under one logging module. Added missing log level configuration, so that logging level can be configured at build time for the whole library.