### PR TITLE
samples: matter: Fixed crash after exceeding providers number

### DIFF
--- a/samples/matter/common/src/bridge/bridge_manager.h
+++ b/samples/matter/common/src/bridge/bridge_manager.h
@@ -163,6 +163,19 @@ private:
 
 	using DeviceMap = FiniteMap<BridgedDevicePair, kMaxBridgedDevices>;
 
+	/**
+	 * @brief Add pair of single bridged device and its data provider using optional index and endpoint id.
+	 * The method takes care of releasing the memory allocated for the data provider and bridged device objects
+	 * in case of adding process failure.
+	 *
+	 * @param device address of valid bridged device object
+	 * @param dataProvider address of valid data provider object
+	 * @param devicesPairIndex index object that will be filled with pair's index
+	 * assigned by the bridge
+	 * @param endpointId value of endpoint id required to be assigned
+	 * @return CHIP_NO_ERROR on success
+	 * @return other error code on failure
+	 */
 	CHIP_ERROR AddSingleDevice(MatterBridgedDevice *device, BridgedDeviceDataProvider *dataProvider,
 				   chip::Optional<uint8_t> &devicesPairIndex, uint16_t endpointId);
 	CHIP_ERROR SafelyRemoveDevice(uint8_t index);


### PR DESCRIPTION
The Matter bridge application crashes after adding provider that exceeds the max allowed number. It happens only if the max number of allowed bridged endpoints is bigger and would allow to complete this operation.

Removed unique pointers used to manage the objects lifetime, as AddSingleDevice method already releases the memory, what leads to double-delete operations and application crash.