### PR TITLE
manifest: Update zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: c441a8dc1291faf8972964f2f944dfe2129a5ede
+      revision: fda9e48e5d953cf436fa0d0d50f0df9ca0127632
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull in a fix in RX timeout handling in the uarte_nrfx_uart driver.