### PR TITLE
wifi: Fix L2AC non-initial associations

### DIFF
--- a/subsys/net/lib/wifi_mgmt_ext/wifi_mgmt_ext.c
+++ b/subsys/net/lib/wifi_mgmt_ext/wifi_mgmt_ext.c
@@ -94,6 +94,9 @@ static int add_network_from_credentials_struct_personal(struct wifi_credentials_
 	}
 
 	z_wpa_cli_cmd_v("enable_network %d", resp.network_id);
+
+	z_wpa_cli_cmd_v("select_network %d", resp.network_id);
+
 	return ret;
 }
 


### PR DESCRIPTION
For the initial network no explicit select is needed. Once a Wi-Fi network is removed, then just adding and enable of the network won't suffice, we need to select the network for the WPA supplicant to start the association process.

This fixes a basic bug for non-initial associations.