### PR TITLE
manifest: Pull sdk-zephyr TCP queueing fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 1687aaaac27cce09921a015a3f63c79666ebdc37
+      revision: e8c9775db7c7dbdb833e025038d6067983ae4cad
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull fixes for TCP queueing to prevent TX window overflow.