### PR TITLE
[backport-v2.5] manifest: Pull sdk-zephyr TCP queueing fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 20d347899fef71940c24fb9a3f13e5dde7232c6b
+      revision: 7f2097d04600e5b13b04c7e9219fcc3ce626fd7d
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull fixes for TCP queueing to prevent TX window overflow.

Jira: NRF7X-103
