### PR TITLE
samples: cellular: modem_shell: Take LwM2M tickless mode into use

### DIFF
--- a/samples/cellular/modem_shell/overlay-lwm2m.conf
+++ b/samples/cellular/modem_shell/overlay-lwm2m.conf
@@ -61,6 +61,10 @@ CONFIG_LWM2M_DTLS_SUPPORT=y
 
 # Enable LwM2M Queue Mode
 CONFIG_LWM2M_QUEUE_MODE_ENABLED=y
+# Optimize power usage by using tickless mode in LwM2M engine
+CONFIG_LWM2M_TICKLESS=y
+# Required by tickless mode
+CONFIG_NET_SOCKETPAIR=y
 # Enable TLS session caching to prevent doing a full TLS handshake for every send.
 CONFIG_LWM2M_TLS_SESSION_CACHING=y
 # Socket close is skipped at RX off idle state to optimize power consumption.
@@ -78,8 +82,8 @@ CONFIG_LWM2M_SECONDS_TO_UPDATE_EARLY=600
 # Support HEX style PSK values (double the size + NULL char)
 CONFIG_LWM2M_SECURITY_KEY_SIZE=33
 
-# Extend CoAP retry timeout to 4 seconds for LTE/LTE-M
-CONFIG_COAP_INIT_ACK_TIMEOUT_MS=4000
+# Extend CoAP retry timeout to 15 seconds
+CONFIG_COAP_INIT_ACK_TIMEOUT_MS=15000
 
 # Enable CoAP extended option length
 CONFIG_COAP_EXTENDED_OPTIONS_LEN=y

--- a/samples/cellular/modem_shell/src/cloud/cloud_lwm2m.c
+++ b/samples/cellular/modem_shell/src/cloud/cloud_lwm2m.c
@@ -209,6 +209,9 @@ static void cloud_lwm2m_init(void)
 				       sizeof(CONFIG_MOSH_LWM2M_PSK), true,
 				       endpoint_name);
 	}
+
+	/* Disable unnecessary time updates. */
+	lwm2m_update_device_service_period(0);
 }
 
 static void cloud_lwm2m_rd_client_update_lifetime(int srv_obj_inst)


### PR DESCRIPTION
Made LwM2M configuration more power efficient by taking tickless mode into use.