### PR TITLE
samples: lwm2m_carrier: Fix use of implicitly defined function

### DIFF
--- a/samples/cellular/lwm2m_carrier/src/main.c
+++ b/samples/cellular/lwm2m_carrier/src/main.c
@@ -6,11 +6,11 @@
 
 #include <zephyr/kernel.h>
 #include <modem/nrf_modem_lib.h>
+#include <modem/lte_lc.h>
 
 #ifdef CONFIG_LWM2M_CARRIER
 #include <lwm2m_carrier.h>
 #include "carrier_certs.h"
-#include <modem/lte_lc.h>
 
 NRF_MODEM_LIB_ON_INIT(main_init_hook, on_modem_lib_init, NULL);
 


### PR DESCRIPTION
Fix use of implicitly defined function lte_lc_connect_async. When LWM2M_CARRIER is not enabled the header file is not included.