### PR TITLE
samples: cellular: modem_shell: Add handling for LwM2M location assistance errors

### DIFF
--- a/lib/location/method_gnss.c
+++ b/lib/location/method_gnss.c
@@ -1274,7 +1274,7 @@ int method_gnss_init(void)
 #endif
 	lte_lc_register_handler(method_gnss_lte_ind_handler);
 
-#if !defined(CONFIG_LOCATION_METHOD_CELLULAR)
+#if !defined(CONFIG_LOCATION_METHOD_CELLULAR) && defined(CONFIG_NRF_CLOUD_AGNSS)
 	/* Cellular location method is disabled, but GNSS method uses the cellular scan
 	 * functionality for A-GNSS request. The module needs to be initialized explicitly, because
 	 * init is not called by core.

--- a/samples/cellular/modem_shell/src/location/location_srv_ext_lwm2m.c
+++ b/samples/cellular/modem_shell/src/location/location_srv_ext_lwm2m.c
@@ -19,89 +19,22 @@
 #define GROUND_FIX_LONGITUDE		3
 #define GROUND_FIX_ACCURACY		4
 
-#if defined(CONFIG_NRF_CLOUD_AGNSS)
-void location_srv_ext_agnss_handle(const struct nrf_modem_gnss_agnss_data_frame *agnss_req)
-{
-	int err;
-
-	if (!cloud_lwm2m_is_connected()) {
-		mosh_error("LwM2M not connected, can't request A-GNSS data");
-		return;
-	}
-
-	location_assistance_agnss_set_mask(agnss_req);
-
-	while ((err = location_assistance_agnss_request_send(cloud_lwm2m_client_ctx_get())) ==
-	       -EAGAIN) {
-		/* LwM2M client utils library is currently handling a P-GPS data request, need to
-		 * wait until it has been completed.
-		 */
-		k_sleep(K_SECONDS(1));
-	}
-	if (err) {
-		mosh_error("Failed to request A-GNSS data, err: %d", err);
-	}
-}
-#endif /* CONFIG_NRF_CLOUD_AGNSS */
-
-#if defined(CONFIG_NRF_CLOUD_PGPS)
-void location_srv_ext_pgps_handle(const struct gps_pgps_request *pgps_req)
-{
-	int err = -1;
-
-	if (!cloud_lwm2m_is_connected()) {
-		mosh_error("LwM2M not connected, can't request P-GPS data");
-		return;
-	}
-
-	err = location_assist_pgps_set_prediction_count(pgps_req->prediction_count);
-	err |= location_assist_pgps_set_prediction_interval(pgps_req->prediction_period_min);
-	location_assist_pgps_set_start_gps_day(pgps_req->gps_day);
-	err |= location_assist_pgps_set_start_time(pgps_req->gps_time_of_day);
-	if (err) {
-		mosh_error("Failed to set P-GPS request parameters");
-		return;
-	}
-
-	while ((err = location_assistance_pgps_request_send(cloud_lwm2m_client_ctx_get())) ==
-	       -EAGAIN) {
-		/* LwM2M client utils library is currently handling an A-GNSS data request, need to
-		 * wait until it has been completed.
-		 */
-		k_sleep(K_SECONDS(1));
-	}
-	if (err) {
-		mosh_error("Failed to request P-GPS data, err: %d", err);
-	}
-}
-#endif /* CONFIG_NRF_CLOUD_PGPS */
-
 #if defined(CONFIG_LOCATION_METHOD_CELLULAR)
-static int location_ctrl_lwm2m_cell_result_cb(uint16_t obj_inst_id,
-					      uint16_t res_id, uint16_t res_inst_id,
-					      uint8_t *data, uint16_t data_len,
-					      bool last_block, size_t total_size)
+static void location_srv_ext_ground_fix_result_handle(int32_t result_code)
 {
 	int err;
-	int32_t result;
 	struct location_data location = {0};
 	double temp_accuracy;
 
-	if (data_len != sizeof(int32_t)) {
-		mosh_error("Unexpected data length in callback");
-		err = -1;
-		goto exit;
-	}
-
-	result = (int32_t)*data;
-	switch (result) {
+	switch (result_code) {
 	case LOCATION_ASSIST_RESULT_CODE_OK:
 		break;
 
 	case LOCATION_ASSIST_RESULT_CODE_PERMANENT_ERR:
 	case LOCATION_ASSIST_RESULT_CODE_TEMP_ERR:
+	case LOCATION_ASSIST_RESULT_CODE_NO_RESP_ERR:
 	default:
-		mosh_error("LwM2M server failed to get location");
+		mosh_error("Getting location using LwM2M failed, result: %d", result_code);
 		err = -1;
 		goto exit;
 	}
@@ -134,10 +67,112 @@ exit:
 	} else {
 		location_cloud_location_ext_result_set(LOCATION_EXT_RESULT_SUCCESS, &location);
 	}
-
-	return err;
 }
+#endif /* CONFIG_LOCATION_METHOD_CELLULAR */
 
+#if defined(CONFIG_NRF_CLOUD_AGNSS) || defined(CONFIG_NRF_CLOUD_PGPS)
+static void location_srv_ext_gnss_assistance_result_handle(int32_t result_code)
+{
+	switch (result_code) {
+	case LOCATION_ASSIST_RESULT_CODE_OK:
+		break;
+
+	case LOCATION_ASSIST_RESULT_CODE_PERMANENT_ERR:
+	case LOCATION_ASSIST_RESULT_CODE_TEMP_ERR:
+	case LOCATION_ASSIST_RESULT_CODE_NO_RESP_ERR:
+	default:
+		mosh_error("Getting GNSS assistance data using LwM2M failed, result: %d",
+			   result_code);
+		break;
+	}
+}
+#endif /* CONFIG_NRF_CLOUD_AGNSS || CONFIG_NRF_CLOUD_PGPS */
+
+#if defined(CONFIG_LOCATION_METHOD_CELLULAR) || defined(CONFIG_NRF_CLOUD_AGNSS) || \
+	defined(CONFIG_NRF_CLOUD_PGPS)
+static void location_srv_ext_assistance_result_cb(uint16_t object_id, int32_t result_code)
+{
+	switch (object_id) {
+#if defined(CONFIG_LOCATION_METHOD_CELLULAR)
+	case GROUND_FIX_OBJECT_ID:
+		location_srv_ext_ground_fix_result_handle(result_code);
+		break;
+#endif /* CONFIG_LOCATION_METHOD_CELLULAR */
+
+#if defined(CONFIG_NRF_CLOUD_AGNSS) || defined(CONFIG_NRF_CLOUD_PGPS)
+	case GNSS_ASSIST_OBJECT_ID:
+		location_srv_ext_gnss_assistance_result_handle(result_code);
+		break;
+#endif /* CONFIG_NRF_CLOUD_AGNSS || CONFIG_NRF_CLOUD_PGPS */
+
+	default:
+		break;
+	}
+}
+#endif /* CONFIG_LOCATION_METHOD_CELLULAR || CONFIG_NRF_CLOUD_AGNSS || CONFIG_NRF_CLOUD_PGPS */
+
+#if defined(CONFIG_NRF_CLOUD_AGNSS)
+void location_srv_ext_agnss_handle(const struct nrf_modem_gnss_agnss_data_frame *agnss_req)
+{
+	int err;
+
+	if (!cloud_lwm2m_is_connected()) {
+		mosh_error("LwM2M not connected, can't request A-GNSS data");
+		return;
+	}
+
+	location_assistance_set_result_code_cb(location_srv_ext_assistance_result_cb);
+
+	location_assistance_agnss_set_mask(agnss_req);
+
+	while ((err = location_assistance_agnss_request_send(cloud_lwm2m_client_ctx_get())) ==
+	       -EAGAIN) {
+		/* LwM2M client utils library is currently handling a P-GPS data request, need to
+		 * wait until it has been completed.
+		 */
+		k_sleep(K_SECONDS(1));
+	}
+	if (err) {
+		mosh_error("Failed to request A-GNSS data, err: %d", err);
+	}
+}
+#endif /* CONFIG_NRF_CLOUD_AGNSS */
+
+#if defined(CONFIG_NRF_CLOUD_PGPS)
+void location_srv_ext_pgps_handle(const struct gps_pgps_request *pgps_req)
+{
+	int err = -1;
+
+	if (!cloud_lwm2m_is_connected()) {
+		mosh_error("LwM2M not connected, can't request P-GPS data");
+		return;
+	}
+
+	location_assistance_set_result_code_cb(location_srv_ext_assistance_result_cb);
+
+	err = location_assist_pgps_set_prediction_count(pgps_req->prediction_count);
+	err |= location_assist_pgps_set_prediction_interval(pgps_req->prediction_period_min);
+	location_assist_pgps_set_start_gps_day(pgps_req->gps_day);
+	err |= location_assist_pgps_set_start_time(pgps_req->gps_time_of_day);
+	if (err) {
+		mosh_error("Failed to set P-GPS request parameters");
+		return;
+	}
+
+	while ((err = location_assistance_pgps_request_send(cloud_lwm2m_client_ctx_get())) ==
+	       -EAGAIN) {
+		/* LwM2M client utils library is currently handling an A-GNSS data request, need to
+		 * wait until it has been completed.
+		 */
+		k_sleep(K_SECONDS(1));
+	}
+	if (err) {
+		mosh_error("Failed to request P-GPS data, err: %d", err);
+	}
+}
+#endif /* CONFIG_NRF_CLOUD_PGPS */
+
+#if defined(CONFIG_LOCATION_METHOD_CELLULAR)
 void location_srv_ext_cellular_handle(
 	const struct lte_lc_cells_info *cell_info,
 	bool cloud_resp_enabled)
@@ -149,12 +184,7 @@ void location_srv_ext_cellular_handle(
 		goto exit;
 	}
 
-	err = lwm2m_register_post_write_callback(&LWM2M_OBJ(GROUND_FIX_OBJECT_ID, 0,
-							    GROUND_FIX_RESULT_CODE),
-						 location_ctrl_lwm2m_cell_result_cb);
-	if (err) {
-		mosh_error("Failed to register post write callback, err: %d", err);
-	}
+	location_assistance_set_result_code_cb(location_srv_ext_assistance_result_cb);
 
 	ground_fix_set_report_back(cloud_resp_enabled);
 
@@ -180,6 +210,7 @@ exit:
 }
 #endif /* CONFIG_LOCATION_METHOD_CELLULAR */
 
+#if defined(CONFIG_LOCATION_METHOD_WIFI) || defined(CONFIG_LOCATION_METHOD_CELLULAR)
 void location_srv_ext_cloud_location_handle(
 	const struct location_data_cloud *cloud_location_request,
 	bool cloud_resp_enabled)
@@ -190,8 +221,11 @@ void location_srv_ext_cloud_location_handle(
 	}
 #endif /* CONFIG_LOCATION_METHOD_WIFI */
 
+#if defined(CONFIG_LOCATION_METHOD_CELLULAR)
 	if (cloud_location_request->cell_data != NULL) {
 		location_srv_ext_cellular_handle(
 			cloud_location_request->cell_data, cloud_resp_enabled);
 	}
+#endif /* CONFIG_LOCATION_METHOD_CELLULAR */
 }
+#endif /* CONFIG_LOCATION_METHOD_WIFI || CONFIG_LOCATION_METHOD_CELLULAR */


### PR DESCRIPTION
Took LwM2M location assistance result callback into use. Added printing of an error if the location assistance request fails.

Fixed a Location library compilation error when both `CONFIG_LOCATION_METHOD_CELLULAR` and `CONFIG_NRF_CLOUD_AGNSS` are disabled.