### PR TITLE
bt: bas_client: Fix CONTAINER_OF invocation

### DIFF
--- a/subsys/bluetooth/services/bas_client.c
+++ b/subsys/bluetooth/services/bas_client.c
@@ -181,7 +181,7 @@ static void bas_read_value_handler(struct k_work *work)
 	struct bt_bas_client *bas;
 
 	bas = CONTAINER_OF(work, struct bt_bas_client,
-			     periodic_read.read_work);
+			     periodic_read.read_work.work);
 
 	if (!atomic_get(&bas->periodic_read.interval)) {
 		/* disabled */


### PR DESCRIPTION
The bas_client used the k_delayed_work struct instead of the k_work struct to resolve the bt_bas_client with CONTAINER_OF. As k_work is the first member in k_delayed_work, this isn't an active bug, but zephyrproject-rtos/zephyr#61962 adds a static assert for this, which starts failing in the upmerge.