### PR TITLE
doc: fixing API links in NCF TNEP library docs

### DIFF
--- a/doc/nrf/libraries/nfc/tnep/ch.rst
+++ b/doc/nrf/libraries/nfc/tnep/ch.rst
@@ -52,10 +52,10 @@ The NFC Poller Device responds with the Handover Select Message after having rec
 If the NFC Tag Device takes the role of the Handover Selector, then the NFC Tag Device does not add any NDEF records defined in this specification into the TNEP status message.
 The TNEP status message follows the Service Select message and the NFC Tag Device waits for a Handover Request Message from the NFC Poller Device.
 
-The NFC Tag Device role is defined by callback sets in structure :c:type:`nfc_tnep_ch_cb` passed to :cpp:func:`nfc_tnep_ch_service_init`.
+The NFC Tag Device role is defined by callback set in the :c:struct:`nfc_tnep_ch_cb` structure and passed to the :c:func:`nfc_tnep_ch_service_init` function.
 
-   * Handover Selector role. Set :cpp:member:`request_msg_recv`.
-   * Handover Requester role. Set :cpp:member:`request_msg_prepare` and :cpp:member:`select_msg_recv`.
+   * Handover Selector role. Set :c:member:`nfc_tnep_ch_cb.request_msg_recv`.
+   * Handover Requester role. Set :c:member:`nfc_tnep_ch_cb.request_msg_prepare` and :c:member:`nfc_tnep_ch_cb.select_msg_recv`.
 
 NFC Tag Device
 **************

--- a/doc/nrf/libraries/nfc/tnep/poller.rst
+++ b/doc/nrf/libraries/nfc/tnep/poller.rst
@@ -38,12 +38,12 @@ The polling device can use single response communication mode to exchange the ND
 Exchanging data is possible only when a service is selected.
 The data is exchanged in the NDEF read procedure or the NDEF write procedure.
 
-To exchange data, use :c:func:`nfc_tnep_poller_svc_update` or :c:func:`nfc_tnep_poller_on_ndef_read`.
+To exchange data, use :c:func:`nfc_tnep_poller_svc_write` or :c:func:`nfc_tnep_poller_on_ndef_read`.
 
 .. note::
     These operations are asynchronous.
 
-When the polling device finishes the NDEF read procedure or the NDEF write procedure, the application should inform the library about this by calling :c:func:`nfc_tnep_poller_on_ndef_read` or :c:func:`nfc_tnep_poller_on_ndef_update`, respectively.
+When the polling device finishes the NDEF read procedure or the NDEF write procedure, the application should inform the library about this by calling :c:func:`nfc_tnep_poller_on_ndef_read` or :c:func:`nfc_tnep_poller_on_ndef_write`, respectively.
 
 API documentation
 *****************

--- a/doc/nrf/libraries/nfc/tnep/tag.rst
+++ b/doc/nrf/libraries/nfc/tnep/tag.rst
@@ -20,7 +20,7 @@ Configuring NDEF message buffers
 ================================
 
 The tag library communicates with the :ref:`nrfxlib:type_4_tag` library using NDEF message buffers.
-The buffers are initialized all at the same time by :c:func:`nfc_tnep_tag_tx_msg_buffer_register`.
+The buffers are initialized all at the same time by the :c:func:`nfc_tnep_tag_tx_msg_buffer_register` function.
 
 To use the NDEF message buffers, you must configure the following elements:
 
@@ -29,7 +29,7 @@ To use the NDEF message buffers, you must configure the following elements:
 
 The buffers must be linked with the tag layer in the application.
 
-When the polling device writes a new NDEF message to the tag buffer, the application must inform the tag library by calling :c:func:`nfc_tnep_tag_rx_msg_indicate`.
+When the polling device writes a new NDEF message to the tag buffer, the application must inform the tag library by calling the :c:func:`nfc_tnep_tag_rx_msg_indicate` function.
 
 Defining TNEP services
 ======================
@@ -48,8 +48,8 @@ When calling the :c:func:`nfc_tnep_tag_initial_msg_create` function, the service
 A Service Parameter record contains parameters for communicating with the service.
 You can also encode additional NDEF records into the Initial TNEP message in the following way:
 
-#. Pass a callback to :c:func:`nfc_tnep_tag_initial_msg_create`.
-#. Define an additional record inside the callback and call :c:func:`nfc_tnep_initial_msg_encode`.
+#. Pass a callback to the :c:func:`nfc_tnep_tag_initial_msg_create` function.
+#. Define an additional record inside the callback and call the :c:func:`nfc_tnep_initial_msg_encode` function.
 
 See the following code for an example of the Initial message encoding:
 
@@ -96,7 +96,7 @@ Receiving new messages
 **********************
 
 When a new NDEF message appears in the buffer and it contains a Service Select record, the application can select this service.
-To do this, the application should inform the TNEP tag library of the received NDEF message by calling :c:func:`nfc_tnep_tag_rx_msg_indicate`.
+To do this, the application should inform the TNEP tag library of the received NDEF message by calling the :c:func:`nfc_tnep_tag_rx_msg_indicate` function.
 The tag library will then change its state to Service Selected.
 From that point, the service description message will no longer be provided.
 
@@ -104,10 +104,10 @@ After the successful service selection, the select callback function of the serv
 If the tag library was already in Service Selected state when receiving the NDEF message with the Service Select record, the deselect callback of the previous service is called before the select callback of the new service.
 
 When the library is in the Service Selected state, the service's new message callback is called after successfully processing the new message.
-Application data can be added to the reply message with :c:func:`nfc_tnep_tag_tx_msg_app_data`.
-This function can be called from the Service Selected callback or from any other context, for example a different thread.
+Application data can be added to the reply message using the :c:func:`nfc_tnep_tag_tx_msg_app_data` function.
+It can be called from the Service Selected callback or from any other context, for example a different thread.
 
-If the tag application has no more data, it will reply by using :c:func:`nfc_tnep_tag_tx_msg_no_app_data`.
+If the tag application has no more data, it will reply by using the :c:func:`nfc_tnep_tag_tx_msg_no_app_data` function.
 If the application does not reply before the expiration on the time period specified by the service's initialization parameters, the service will be deselected by the polling device.
 
 The following code demonstrates how to exchange NDEF messages using the tag library after initialization:


### PR DESCRIPTION
A few API links were not working due to
incorrect formatting.
Fixed them and some language, as well.