### PR TITLE
lib: nrf_modem: remove lte_net_if `_NET_IF_DOWN` flag

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -438,13 +438,17 @@ Modem libraries
   * Added:
 
     * A mention about enabling TF-M logging while using modem traces in the :ref:`modem_trace_module`.
-    * The :kconfig:option:`CONFIG_NRF_MODEM_LIB_NET_IF_DOWN_DEFAULT_LTE_DISCONNECT` Kconfig option, allowing the :c:enumerator:`nrf_modem_lib_net_if_options.NRF_MODEM_LIB_NET_IF_DOWN` option to be set to :c:enumerator:`~nrf_modem_lib_net_if_down_options.NRF_MODEM_LIB_NET_IF_DOWN_LTE_DISCONNECT` at build time.
+    * The :kconfig:option:`CONFIG_NRF_MODEM_LIB_NET_IF_DOWN_DEFAULT_LTE_DISCONNECT` option, allowing the user to change the behavior of the driver's :c:func:`net_if_down` implementation at build time.
 
   * Updated by renaming ``lte_connectivity`` module to ``lte_net_if``.
     All related Kconfig options have been renamed accordingly.
   * Changed the default value of the :kconfig:option:`CONFIG_NRF_MODEM_LIB_NET_IF_AUTO_START`, :kconfig:option:`CONFIG_NRF_MODEM_LIB_NET_IF_AUTO_CONNECT`, and :kconfig:option:`CONFIG_NRF_MODEM_LIB_NET_IF_AUTO_DOWN` Kconfig options from enabled to disabled.
 
-  * Removed the deprecated Kconfig options ``CONFIG_NRF_MODEM_LIB_SYS_INIT`` and ``CONFIG_NRF_MODEM_LIB_IPC_IRQ_PRIO_OVERRIDE``.
+  * Removed:
+
+    * The deprecated Kconfig option ``CONFIG_NRF_MODEM_LIB_SYS_INIT``.
+    * The deprecated Kconfig option ``CONFIG_NRF_MODEM_LIB_IPC_IRQ_PRIO_OVERRIDE``.
+    * The ``NRF_MODEM_LIB_NET_IF_DOWN`` flag support in the ``lte_net_if`` network interface driver.
 
 * :ref:`lib_modem_slm`:
 

--- a/include/modem/nrf_modem_lib.h
+++ b/include/modem/nrf_modem_lib.h
@@ -196,25 +196,6 @@ struct nrf_modem_lib_shutdown_cb {
  */
 void nrf_modem_fault_handler(struct nrf_modem_fault_info *fault_info);
 
-#if defined(CONFIG_NRF_MODEM_LIB_NET_IF) || defined(__DOXYGEN__)
-/** @brief Options used to specify desired behavior when the network interface is brought down by
- *	   calling net_if_down().
- */
-enum nrf_modem_lib_net_if_down_options {
-	/** Shutdown modem - GNSS functionality will not be preserved. */
-	NRF_MODEM_LIB_NET_IF_DOWN_MODEM_SHUTDOWN = 1,
-
-	/** Disconnect from LTE - GNSS functionality will be preserved. */
-	NRF_MODEM_LIB_NET_IF_DOWN_LTE_DISCONNECT
-};
-
-/** @brief Option types used to specify library behavior. */
-enum nrf_modem_lib_net_if_options {
-	/** Sets desired behavior when net_if_down() is called. */
-	NRF_MODEM_LIB_NET_IF_DOWN = 1,
-};
-#endif
-
 #if defined(CONFIG_NRF_MODEM_LIB_FAULT_STRERROR) || defined(__DOXYGEN__)
 /**
  * @brief Retrieve a statically allocated textual description of a given fault.

--- a/lib/nrf_modem_lib/lte_net_if/Kconfig
+++ b/lib/nrf_modem_lib/lte_net_if/Kconfig
@@ -70,9 +70,7 @@ config NRF_MODEM_LIB_NET_IF_DOWN_DEFAULT_LTE_DISCONNECT
 	bool "Disconnect on iface down"
 	help
 	 If this option is set, the LTE iface will disconnect LTE instead of shutting down the
-	 modem when going down. This option sets the default value for the
-	 NRF_MODEM_LIB_NET_IF_DOWN connectivity option. The value can still be changed at runtime
-	 by calling conn_mgr_if_set_opt().
+	 modem when being brought down.
 
 module = NRF_MODEM_LIB_NET_IF
 module-str = Modem network interface

--- a/tests/lib/nrf_modem_lib/lte_net_if/src/main.c
+++ b/tests/lib/nrf_modem_lib/lte_net_if/src/main.c
@@ -82,9 +82,6 @@ void setUp(void)
 	pdn_event_handler_callback(0, PDN_EVENT_DEACTIVATED, 0);
 	lte_lc_event_handler_callback(&cereg_evt);
 
-	/* Let events propagate */
-	k_sleep(K_MSEC(10));
-
 	/* Remove IP addresses if any */
 	if (net_if_ipv6_get_global_addr(NET_ADDR_PREFERRED, &net_if)) {
 		net_if_config_ipv6_put(net_if);
@@ -99,9 +96,6 @@ void setUp(void)
 
 	/* Take iface down */
 	(void)net_if_down(net_if);
-
-	/* Let events propagate */
-	k_sleep(K_MSEC(10));
 
 	/* Stop ignoring mocked functions*/
 	__cmock_nrf_modem_is_initialized_StopIgnore();
@@ -311,9 +305,6 @@ void test_pdn_events_should_trigger_ipv4_address_changes(void)
 	/* Verify IPv4 was added */
 	TEST_ASSERT_TRUE(net_if_ipv4_get_global_addr(net_if, NET_ADDR_PREFERRED));
 
-	/* Let events fire */
-	k_sleep(K_MSEC(10));
-
 	/* Dectivate PDN */
 	pdn_event_handler_callback(0, PDN_EVENT_DEACTIVATED, 0);
 
@@ -360,9 +351,6 @@ void test_pdn_events_should_trigger_ipv6_address_changes(void)
 
 	/* Verify IPv6 was added */
 	TEST_ASSERT_TRUE(net_if_ipv6_get_global_addr(NET_ADDR_PREFERRED, &net_if));
-
-	/* Let events fire */
-	k_sleep(K_MSEC(10));
 
 	/* Dectivate PDN */
 	pdn_event_handler_callback(0, PDN_EVENT_DEACTIVATED, 0);
@@ -418,9 +406,6 @@ void test_pdn_act_without_cereg_should_not_activate_iface(void)
 	/* Fire PDN active */
 	pdn_event_handler_callback(0, PDN_EVENT_ACTIVATED, 0);
 
-	/* Let events fire */
-	k_sleep(K_MSEC(10));
-
 	/* Check that iface remains inactive */
 	TEST_ASSERT_TRUE(net_if_is_dormant(net_if));
 }
@@ -448,9 +433,6 @@ void test_pdn_act_with_cereg_should_activate_iface(void)
 	cereg_evt.nw_reg_status = LTE_LC_NW_REG_REGISTERED_HOME;
 	lte_lc_event_handler_callback(&cereg_evt);
 
-	/* Let events fire */
-	k_sleep(K_MSEC(10));
-
 	/* Check that the iface is still dormant. */
 	TEST_ASSERT_TRUE(net_if_is_dormant(net_if));
 
@@ -461,9 +443,6 @@ void test_pdn_act_with_cereg_should_activate_iface(void)
 
 	/* Fire PDN active */
 	pdn_event_handler_callback(0, PDN_EVENT_ACTIVATED, 0);
-
-	/* Let events fire */
-	k_sleep(K_MSEC(10));
 
 	/* Check that iface becomes active */
 	TEST_ASSERT_FALSE(net_if_is_dormant(net_if));
@@ -496,9 +475,6 @@ void test_cereg_registered_without_pdn_should_not_activate_iface(void)
 	cereg_evt.nw_reg_status = LTE_LC_NW_REG_REGISTERED_HOME;
 	lte_lc_event_handler_callback(&cereg_evt);
 
-	/* Let events fire */
-	k_sleep(K_MSEC(10));
-
 	/* Check that iface remains inactive */
 	TEST_ASSERT_TRUE(net_if_is_dormant(net_if));
 }
@@ -530,18 +506,12 @@ void test_cereg_registered_home_with_pdn_should_activate_iface(void)
 	/* Fire PDN active */
 	pdn_event_handler_callback(0, PDN_EVENT_ACTIVATED, 0);
 
-	/* Let events fire */
-	k_sleep(K_MSEC(10));
-
 	/* Check that the iface is still dormant. */
 	TEST_ASSERT_TRUE(net_if_is_dormant(net_if));
 
 	/* Fire CEREG registered (home) */
 	cereg_evt.nw_reg_status = LTE_LC_NW_REG_REGISTERED_HOME;
 	lte_lc_event_handler_callback(&cereg_evt);
-
-	/* Let events fire */
-	k_sleep(K_MSEC(10));
 
 	/* Check that iface becomes active */
 	TEST_ASSERT_FALSE(net_if_is_dormant(net_if));
@@ -574,18 +544,12 @@ void test_cereg_registered_roaming_with_pdn_should_activate_iface(void)
 	/* Fire PDN active */
 	pdn_event_handler_callback(0, PDN_EVENT_ACTIVATED, 0);
 
-	/* Let events fire */
-	k_sleep(K_MSEC(10));
-
 	/* Check that the iface is still dormant. */
 	TEST_ASSERT_TRUE(net_if_is_dormant(net_if));
 
 	/* Fire CEREG registered (roaming) */
 	cereg_evt.nw_reg_status = LTE_LC_NW_REG_REGISTERED_ROAMING;
 	lte_lc_event_handler_callback(&cereg_evt);
-
-	/* Let events fire */
-	k_sleep(K_MSEC(10));
 
 	/* Check that iface becomes active */
 	TEST_ASSERT_FALSE(net_if_is_dormant(net_if));
@@ -616,9 +580,6 @@ void test_cereg_searching_should_not_activate_iface(void)
 	/* Fire CEREG searching */
 	cereg_evt.nw_reg_status = LTE_LC_NW_REG_SEARCHING;
 	lte_lc_event_handler_callback(&cereg_evt);
-
-	/* Let events fire */
-	k_sleep(K_MSEC(10));
 
 	/* Check that iface remains active */
 	TEST_ASSERT_TRUE(net_if_is_dormant(net_if));
@@ -656,18 +617,12 @@ void test_cereg_searching_should_not_deactivate_iface(void)
 	cereg_evt.nw_reg_status = LTE_LC_NW_REG_REGISTERED_HOME;
 	lte_lc_event_handler_callback(&cereg_evt);
 
-	/* Let events fire */
-	k_sleep(K_MSEC(10));
-
 	/* Check that the iface is active. */
 	TEST_ASSERT_FALSE(net_if_is_dormant(net_if));
 
 	/* Fire CEREG searching */
 	cereg_evt.nw_reg_status = LTE_LC_NW_REG_SEARCHING;
 	lte_lc_event_handler_callback(&cereg_evt);
-
-	/* Let events fire */
-	k_sleep(K_MSEC(10));
 
 	/* Check that iface remains active */
 	TEST_ASSERT_FALSE(net_if_is_dormant(net_if));
@@ -704,18 +659,12 @@ void test_cereg_unregistered_should_deactivate_iface(void)
 	cereg_evt.nw_reg_status = LTE_LC_NW_REG_REGISTERED_HOME;
 	lte_lc_event_handler_callback(&cereg_evt);
 
-	/* Let events fire */
-	k_sleep(K_MSEC(10));
-
 	/* Check that the iface is active. */
 	TEST_ASSERT_FALSE(net_if_is_dormant(net_if));
 
 	/* Fire CEREG unregistered */
 	cereg_evt.nw_reg_status = LTE_LC_NW_REG_UNKNOWN;
 	lte_lc_event_handler_callback(&cereg_evt);
-
-	/* Let events fire */
-	k_sleep(K_MSEC(10));
 
 	/* Check that iface becomes inactive */
 	TEST_ASSERT_TRUE(net_if_is_dormant(net_if));
@@ -752,17 +701,11 @@ void test_pdn_deact_should_deactivate_iface(void)
 	cereg_evt.nw_reg_status = LTE_LC_NW_REG_REGISTERED_HOME;
 	lte_lc_event_handler_callback(&cereg_evt);
 
-	/* Let events fire */
-	k_sleep(K_MSEC(10));
-
 	/* Check that the iface is active. */
 	TEST_ASSERT_FALSE(net_if_is_dormant(net_if));
 
 	/* Fire PDN inactive */
 	pdn_event_handler_callback(0, PDN_EVENT_DEACTIVATED, 0);
-
-	/* Let events fire */
-	k_sleep(K_MSEC(10));
 
 	/* Check that iface becomes inactive */
 	TEST_ASSERT_TRUE(net_if_is_dormant(net_if));


### PR DESCRIPTION
This driver has a flag controlling the behavior of `net_if_down()`. One value of the flag lets `net_if_down()` bring the interface down, the other lets `net_if_down()` disconnect from the network. This flag can be set at run-time.

The application has at its disposal a dedicated API to bring the interface down, i.e. `net_if_down()`, and a dedicated API
to disconnect, i.e. `conn_mgr_disconnect()`.

Thus there is not need to change the behavior of `net_if_down()` based on a run-time flag to perform another API's operation.
At run-time, the application shall call one of the two functions to achieve the desired behavior.

However, the application may want to align `net_if_down()` behavior with that of other interfaces for the purpose of behaving similarly when `net_if_down()` is called outside of the application, e.g. in a library.

For that purpose, a build time configuration option to control the behavior of `net_if_down()` is desirable.
This configuration option has been introduced recently and remains untouched.

This patch removes the `_NET_IF_DOWN` flag support from the `lte_net_if` network interface driver that
controls the runtime behavior of `net_if_down`.