### PR TITLE
samples: matter: Enable mandatory thermostat attributes in zap

### DIFF
--- a/samples/matter/thermostat/src/thermostat.matter
+++ b/samples/matter/thermostat/src/thermostat.matter
@@ -1395,6 +1395,8 @@ server cluster Thermostat = 513 {
   readonly attribute int16s absMaxHeatSetpointLimit = 4;
   readonly attribute int16s absMinCoolSetpointLimit = 5;
   readonly attribute int16s absMaxCoolSetpointLimit = 6;
+  attribute int16s occupiedCoolingSetpoint = 17;
+  attribute int16s occupiedHeatingSetpoint = 18;
   attribute access(write: manage) int16s minHeatSetpointLimit = 21;
   attribute access(write: manage) int16s maxHeatSetpointLimit = 22;
   attribute access(write: manage) int16s minCoolSetpointLimit = 23;
@@ -1794,6 +1796,8 @@ endpoint 1 {
     ram      attribute absMaxHeatSetpointLimit default = 3000;
     ram      attribute absMinCoolSetpointLimit default = 1600;
     ram      attribute absMaxCoolSetpointLimit default = 3200;
+    ram      attribute occupiedCoolingSetpoint default = 2600;
+    ram      attribute occupiedHeatingSetpoint default = 2000;
     ram      attribute minHeatSetpointLimit default = 700;
     ram      attribute maxHeatSetpointLimit default = 3000;
     ram      attribute minCoolSetpointLimit default = 1600;

--- a/samples/matter/thermostat/src/thermostat.zap
+++ b/samples/matter/thermostat/src/thermostat.zap
@@ -19,17 +19,17 @@
   "package": [
     {
       "pathRelativity": "relativeToZap",
+      "path": "../../../../../modules/lib/matter/src/app/zap-templates/app-templates.json",
+      "type": "gen-templates-json",
+      "version": "chip-v1"
+    },
+    {
+      "pathRelativity": "relativeToZap",
       "path": "../../../../../modules/lib/matter/src/app/zap-templates/zcl/zcl.json",
       "type": "zcl-properties",
       "category": "matter",
       "version": 1,
       "description": "Matter SDK ZCL data"
-    },
-    {
-      "pathRelativity": "relativeToZap",
-      "path": "../../../../../modules/lib/matter/src/app/zap-templates/app-templates.json",
-      "type": "gen-templates-json",
-      "version": "chip-v1"
     }
   ],
   "endpointTypes": [
@@ -4624,6 +4624,38 @@
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "3200",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "OccupiedCoolingSetpoint",
+              "code": 17,
+              "mfgCode": null,
+              "side": "server",
+              "type": "int16s",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "2600",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "OccupiedHeatingSetpoint",
+              "code": 18,
+              "mfgCode": null,
+              "side": "server",
+              "type": "int16s",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "2000",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/samples/matter/thermostat/src/zap-generated/CHIPClusters.h
+++ b/samples/matter/thermostat/src/zap-generated/CHIPClusters.h
@@ -29,7 +29,6 @@ namespace chip
 {
 namespace Controller
 {
-
 	class DLL_EXPORT IdentifyCluster : public ClusterBase {
 	public:
 		IdentifyCluster(Messaging::ExchangeManager &exchangeManager, const SessionHandle &session,

--- a/samples/matter/thermostat/src/zap-generated/IMClusterCommandHandler.cpp
+++ b/samples/matter/thermostat/src/zap-generated/IMClusterCommandHandler.cpp
@@ -34,15 +34,12 @@ namespace chip
 {
 namespace app
 {
-
 	// Cluster specific command parsing
 
 	namespace Clusters
 	{
-
 		namespace AdministratorCommissioning
 		{
-
 			void DispatchServerCommand(CommandHandler *apCommandObj,
 						   const ConcreteCommandPath &aCommandPath, TLV::TLVReader &aDataTlv)
 			{
@@ -107,7 +104,6 @@ namespace app
 
 		namespace GeneralCommissioning
 		{
-
 			void DispatchServerCommand(CommandHandler *apCommandObj,
 						   const ConcreteCommandPath &aCommandPath, TLV::TLVReader &aDataTlv)
 			{
@@ -172,7 +168,6 @@ namespace app
 
 		namespace GeneralDiagnostics
 		{
-
 			void DispatchServerCommand(CommandHandler *apCommandObj,
 						   const ConcreteCommandPath &aCommandPath, TLV::TLVReader &aDataTlv)
 			{
@@ -217,7 +212,6 @@ namespace app
 
 		namespace GroupKeyManagement
 		{
-
 			void DispatchServerCommand(CommandHandler *apCommandObj,
 						   const ConcreteCommandPath &aCommandPath, TLV::TLVReader &aDataTlv)
 			{
@@ -291,7 +285,6 @@ namespace app
 
 		namespace Groups
 		{
-
 			void DispatchServerCommand(CommandHandler *apCommandObj,
 						   const ConcreteCommandPath &aCommandPath, TLV::TLVReader &aDataTlv)
 			{
@@ -380,7 +373,6 @@ namespace app
 
 		namespace Identify
 		{
-
 			void DispatchServerCommand(CommandHandler *apCommandObj,
 						   const ConcreteCommandPath &aCommandPath, TLV::TLVReader &aDataTlv)
 			{
@@ -424,7 +416,6 @@ namespace app
 
 		namespace OtaSoftwareUpdateRequestor
 		{
-
 			void DispatchServerCommand(CommandHandler *apCommandObj,
 						   const ConcreteCommandPath &aCommandPath, TLV::TLVReader &aDataTlv)
 			{
@@ -469,7 +460,6 @@ namespace app
 
 		namespace OperationalCredentials
 		{
-
 			void DispatchServerCommand(CommandHandler *apCommandObj,
 						   const ConcreteCommandPath &aCommandPath, TLV::TLVReader &aDataTlv)
 			{
@@ -583,7 +573,6 @@ namespace app
 
 		namespace Thermostat
 		{
-
 			void DispatchServerCommand(CommandHandler *apCommandObj,
 						   const ConcreteCommandPath &aCommandPath, TLV::TLVReader &aDataTlv)
 			{
@@ -627,7 +616,6 @@ namespace app
 
 		namespace ThreadNetworkDiagnostics
 		{
-
 			void DispatchServerCommand(CommandHandler *apCommandObj,
 						   const ConcreteCommandPath &aCommandPath, TLV::TLVReader &aDataTlv)
 			{

--- a/samples/matter/thermostat/src/zap-generated/endpoint_config.h
+++ b/samples/matter/thermostat/src/zap-generated/endpoint_config.h
@@ -49,11 +49,13 @@
 #define GENERATED_DEFAULTS_COUNT (1)
 
 // This is an array of EmberAfAttributeMinMaxValue structures.
-#define GENERATED_MIN_MAX_DEFAULT_COUNT 6
+#define GENERATED_MIN_MAX_DEFAULT_COUNT 8
 #define GENERATED_MIN_MAX_DEFAULTS                                                                                     \
 	{                                                                                                              \
 		/* Endpoint: 1, Cluster: Thermostat (server) */                                                        \
-		{ (uint16_t)0x2BC, (uint16_t)-0x6AB3, (uint16_t)0x7FFF }, /* MinHeatSetpointLimit */                   \
+		{ (uint16_t)0xA28, (uint16_t)-0x6AB3, (uint16_t)0x7FFF }, /* OccupiedCoolingSetpoint */                \
+			{ (uint16_t)0x7D0, (uint16_t)-0x6AB3, (uint16_t)0x7FFF }, /* OccupiedHeatingSetpoint */        \
+			{ (uint16_t)0x2BC, (uint16_t)-0x6AB3, (uint16_t)0x7FFF }, /* MinHeatSetpointLimit */           \
 			{ (uint16_t)0xBB8, (uint16_t)-0x6AB3, (uint16_t)0x7FFF }, /* MaxHeatSetpointLimit */           \
 			{ (uint16_t)0x640, (uint16_t)-0x6AB3, (uint16_t)0x7FFF }, /* MinCoolSetpointLimit */           \
 			{ (uint16_t)0xC80, (uint16_t)-0x6AB3, (uint16_t)0x7FFF }, /* MaxCoolSetpointLimit */           \
@@ -64,7 +66,7 @@
 	}
 
 // This is an array of EmberAfAttributeMetadata structures.
-#define GENERATED_ATTRIBUTE_COUNT 190
+#define GENERATED_ATTRIBUTE_COUNT 192
 #define GENERATED_ATTRIBUTES                                                                                                          \
 	{                                                                                                                             \
 		/* Endpoint: 0, Cluster: Descriptor (server) */                                                                       \
@@ -456,18 +458,22 @@
 											   */                                         \
 			{ ZAP_SIMPLE_DEFAULT(3200), 0x00000006, 2, ZAP_TYPE(INT16S), 0 }, /* AbsMaxCoolSetpointLimit                  \
 											   */                                         \
-			{ ZAP_MIN_MAX_DEFAULTS_INDEX(0), 0x00000015, 2, ZAP_TYPE(INT16S),                                             \
+			{ ZAP_MIN_MAX_DEFAULTS_INDEX(0), 0x00000011, 2, ZAP_TYPE(INT16S),                                             \
+			  ZAP_ATTRIBUTE_MASK(MIN_MAX) | ZAP_ATTRIBUTE_MASK(WRITABLE) }, /* OccupiedCoolingSetpoint */                 \
+			{ ZAP_MIN_MAX_DEFAULTS_INDEX(1), 0x00000012, 2, ZAP_TYPE(INT16S),                                             \
+			  ZAP_ATTRIBUTE_MASK(MIN_MAX) | ZAP_ATTRIBUTE_MASK(WRITABLE) }, /* OccupiedHeatingSetpoint */                 \
+			{ ZAP_MIN_MAX_DEFAULTS_INDEX(2), 0x00000015, 2, ZAP_TYPE(INT16S),                                             \
 			  ZAP_ATTRIBUTE_MASK(MIN_MAX) | ZAP_ATTRIBUTE_MASK(WRITABLE) }, /* MinHeatSetpointLimit */                    \
-			{ ZAP_MIN_MAX_DEFAULTS_INDEX(1), 0x00000016, 2, ZAP_TYPE(INT16S),                                             \
+			{ ZAP_MIN_MAX_DEFAULTS_INDEX(3), 0x00000016, 2, ZAP_TYPE(INT16S),                                             \
 			  ZAP_ATTRIBUTE_MASK(MIN_MAX) | ZAP_ATTRIBUTE_MASK(WRITABLE) }, /* MaxHeatSetpointLimit */                    \
-			{ ZAP_MIN_MAX_DEFAULTS_INDEX(2), 0x00000017, 2, ZAP_TYPE(INT16S),                                             \
+			{ ZAP_MIN_MAX_DEFAULTS_INDEX(4), 0x00000017, 2, ZAP_TYPE(INT16S),                                             \
 			  ZAP_ATTRIBUTE_MASK(MIN_MAX) | ZAP_ATTRIBUTE_MASK(WRITABLE) }, /* MinCoolSetpointLimit */                    \
-			{ ZAP_MIN_MAX_DEFAULTS_INDEX(3), 0x00000018, 2, ZAP_TYPE(INT16S),                                             \
+			{ ZAP_MIN_MAX_DEFAULTS_INDEX(5), 0x00000018, 2, ZAP_TYPE(INT16S),                                             \
 			  ZAP_ATTRIBUTE_MASK(MIN_MAX) | ZAP_ATTRIBUTE_MASK(WRITABLE) }, /* MaxCoolSetpointLimit */                    \
-			{ ZAP_MIN_MAX_DEFAULTS_INDEX(4), 0x0000001B, 1, ZAP_TYPE(ENUM8),                                              \
+			{ ZAP_MIN_MAX_DEFAULTS_INDEX(6), 0x0000001B, 1, ZAP_TYPE(ENUM8),                                              \
 			  ZAP_ATTRIBUTE_MASK(MIN_MAX) | ZAP_ATTRIBUTE_MASK(WRITABLE) }, /* ControlSequenceOfOperation                 \
 											 */                                           \
-			{ ZAP_MIN_MAX_DEFAULTS_INDEX(5), 0x0000001C, 1, ZAP_TYPE(ENUM8),                                              \
+			{ ZAP_MIN_MAX_DEFAULTS_INDEX(7), 0x0000001C, 1, ZAP_TYPE(ENUM8),                                              \
 			  ZAP_ATTRIBUTE_MASK(MIN_MAX) | ZAP_ATTRIBUTE_MASK(WRITABLE) }, /* SystemMode */                              \
 			{ ZAP_SIMPLE_DEFAULT(0x3), 0x0000FFFC, 4, ZAP_TYPE(BITMAP32), 0 }, /* FeatureMap */                           \
 			{ ZAP_SIMPLE_DEFAULT(6), 0x0000FFFD, 2, ZAP_TYPE(INT16U), 0 }, /* ClusterRevision */                          \
@@ -859,8 +865,8 @@
       /* Endpoint: 1, Cluster: Thermostat (server) */ \
       .clusterId = 0x00000201, \
       .attributes = ZAP_ATTRIBUTE_INDEX(177), \
-      .attributeCount = 13, \
-      .clusterSize = 26, \
+      .attributeCount = 15, \
+      .clusterSize = 30, \
       .mask = ZAP_CLUSTER_MASK(SERVER) | ZAP_CLUSTER_MASK(INIT_FUNCTION) | ZAP_CLUSTER_MASK(PRE_ATTRIBUTE_CHANGED_FUNCTION), \
       .functions = chipFuncArrayThermostatServer, \
       .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 65 ), \
@@ -871,7 +877,7 @@
   { \
       /* Endpoint: 1, Cluster: Temperature Measurement (client) */ \
       .clusterId = 0x00000402, \
-      .attributes = ZAP_ATTRIBUTE_INDEX(190), \
+      .attributes = ZAP_ATTRIBUTE_INDEX(192), \
       .attributeCount = 0, \
       .clusterSize = 0, \
       .mask = ZAP_CLUSTER_MASK(CLIENT), \
@@ -890,7 +896,7 @@
 // This is an array of EmberAfEndpointType structures.
 #define GENERATED_ENDPOINT_TYPES                                                                                       \
 	{                                                                                                              \
-		{ ZAP_CLUSTER_INDEX(0), 14, 104 }, { ZAP_CLUSTER_INDEX(14), 7, 52 },                                   \
+		{ ZAP_CLUSTER_INDEX(0), 14, 104 }, { ZAP_CLUSTER_INDEX(14), 7, 56 },                                   \
 	}
 
 // Largest attribute size is needed for various buffers
@@ -903,7 +909,7 @@ static_assert(ATTRIBUTE_LARGEST <= CHIP_CONFIG_MAX_ATTRIBUTE_STORE_ELEMENT_SIZE,
 #define ATTRIBUTE_SINGLETONS_SIZE (35)
 
 // Total size of attribute storage
-#define ATTRIBUTE_MAX_SIZE (156)
+#define ATTRIBUTE_MAX_SIZE (160)
 
 // Number of fixed endpoints
 #define FIXED_ENDPOINT_COUNT (2)
@@ -924,10 +930,7 @@ static_assert(ATTRIBUTE_LARGEST <= CHIP_CONFIG_MAX_ATTRIBUTE_STORE_ELEMENT_SIZE,
 // Array of device types
 #define FIXED_DEVICE_TYPES                                                                                             \
 	{                                                                                                              \
-		{ 0x00000016, 2 },                                                                                     \
-		{                                                                                                      \
-			0x00000301, 2                                                                                  \
-		}                                                                                                      \
+		{ 0x00000016, 2 }, { 0x00000301, 2 }                                                                   \
 	}
 
 // Array of device type offsets


### PR DESCRIPTION
Enabled mandatory thermostat attributes: occupied cooling setpoint and occupied heating setpoint.