### PR TITLE
matter: samples: Integrated nRF7002 targets with sysbuild

### DIFF
--- a/samples/matter/light_bulb/Kconfig.sysbuild
+++ b/samples/matter/light_bulb/Kconfig.sysbuild
@@ -7,4 +7,7 @@
 source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_MULTIPROTOCOL
-	default y
+	default y if ($(BOARD) = "nrf5340dk_nrf5340_cpuapp")
+
+config NRF_DEFAULT_BLUETOOTH
+	default y if ($(BOARD) = "nrf7002dk_nrf5340_cpuapp")

--- a/samples/matter/light_bulb/sysbuild/hci_rpmsg/prj.conf
+++ b/samples/matter/light_bulb/sysbuild/hci_rpmsg/prj.conf
@@ -1,0 +1,44 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+## Disable serial and UART interface.
+CONFIG_SERIAL=n
+CONFIG_UART_CONSOLE=n
+CONFIG_LOG=n
+
+## RAM usage configuration
+CONFIG_HEAP_MEM_POOL_SIZE=8192
+CONFIG_MAIN_STACK_SIZE=2048
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
+
+## BT configuration
+CONFIG_BT=y
+CONFIG_BT_HCI_RAW=y
+CONFIG_BT_MAX_CONN=1
+CONFIG_BT_CTLR_ASSERT_HANDLER=y
+CONFIG_BT_HCI_RAW_RESERVE=1
+CONFIG_BT_PERIPHERAL=y
+CONFIG_BT_CENTRAL=n
+CONFIG_BT_BUF_ACL_RX_SIZE=502
+CONFIG_BT_BUF_ACL_TX_SIZE=251
+CONFIG_BT_CTLR_DATA_LENGTH_MAX=251
+CONFIG_BT_CTLR_PHY_2M=n
+# Workaround: Unable to allocate command buffer when using K_NO_WAIT since
+# Host number of completed commands does not follow normal flow control.
+CONFIG_BT_BUF_CMD_TX_COUNT=10
+
+# Debug and assert configuration
+CONFIG_ASSERT=y
+CONFIG_DEBUG_INFO=y
+CONFIG_EXCEPTION_STACK_TRACE=y
+CONFIG_RESET_ON_FATAL_ERROR=n
+CONFIG_REBOOT=n
+
+# IPC
+CONFIG_IPC_SERVICE=y
+
+# Other
+CONFIG_MBOX=y

--- a/samples/matter/light_switch/Kconfig.sysbuild
+++ b/samples/matter/light_switch/Kconfig.sysbuild
@@ -7,4 +7,7 @@
 source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_MULTIPROTOCOL
-	default y
+	default y if ($(BOARD) = "nrf5340dk_nrf5340_cpuapp")
+
+config NRF_DEFAULT_BLUETOOTH
+	default y if ($(BOARD) = "nrf7002dk_nrf5340_cpuapp")

--- a/samples/matter/light_switch/sysbuild/hci_rpmsg/prj.conf
+++ b/samples/matter/light_switch/sysbuild/hci_rpmsg/prj.conf
@@ -1,0 +1,44 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+## Disable serial and UART interface.
+CONFIG_SERIAL=n
+CONFIG_UART_CONSOLE=n
+CONFIG_LOG=n
+
+## RAM usage configuration
+CONFIG_HEAP_MEM_POOL_SIZE=8192
+CONFIG_MAIN_STACK_SIZE=2048
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
+
+## BT configuration
+CONFIG_BT=y
+CONFIG_BT_HCI_RAW=y
+CONFIG_BT_MAX_CONN=1
+CONFIG_BT_CTLR_ASSERT_HANDLER=y
+CONFIG_BT_HCI_RAW_RESERVE=1
+CONFIG_BT_PERIPHERAL=y
+CONFIG_BT_CENTRAL=n
+CONFIG_BT_BUF_ACL_RX_SIZE=502
+CONFIG_BT_BUF_ACL_TX_SIZE=251
+CONFIG_BT_CTLR_DATA_LENGTH_MAX=251
+CONFIG_BT_CTLR_PHY_2M=n
+# Workaround: Unable to allocate command buffer when using K_NO_WAIT since
+# Host number of completed commands does not follow normal flow control.
+CONFIG_BT_BUF_CMD_TX_COUNT=10
+
+# Debug and assert configuration
+CONFIG_ASSERT=y
+CONFIG_DEBUG_INFO=y
+CONFIG_EXCEPTION_STACK_TRACE=y
+CONFIG_RESET_ON_FATAL_ERROR=n
+CONFIG_REBOOT=n
+
+# IPC
+CONFIG_IPC_SERVICE=y
+
+# Other
+CONFIG_MBOX=y

--- a/samples/matter/lock/Kconfig.sysbuild
+++ b/samples/matter/lock/Kconfig.sysbuild
@@ -7,4 +7,7 @@
 source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_MULTIPROTOCOL
-	default y
+	default y if ($(BOARD) = "nrf5340dk_nrf5340_cpuapp")
+
+config NRF_DEFAULT_BLUETOOTH
+	default y if ($(BOARD) = "nrf7002dk_nrf5340_cpuapp")

--- a/samples/matter/lock/sysbuild/hci_rpmsg/prj.conf
+++ b/samples/matter/lock/sysbuild/hci_rpmsg/prj.conf
@@ -1,0 +1,44 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+## Disable serial and UART interface.
+CONFIG_SERIAL=n
+CONFIG_UART_CONSOLE=n
+CONFIG_LOG=n
+
+## RAM usage configuration
+CONFIG_HEAP_MEM_POOL_SIZE=8192
+CONFIG_MAIN_STACK_SIZE=2048
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
+
+## BT configuration
+CONFIG_BT=y
+CONFIG_BT_HCI_RAW=y
+CONFIG_BT_MAX_CONN=1
+CONFIG_BT_CTLR_ASSERT_HANDLER=y
+CONFIG_BT_HCI_RAW_RESERVE=1
+CONFIG_BT_PERIPHERAL=y
+CONFIG_BT_CENTRAL=n
+CONFIG_BT_BUF_ACL_RX_SIZE=502
+CONFIG_BT_BUF_ACL_TX_SIZE=251
+CONFIG_BT_CTLR_DATA_LENGTH_MAX=251
+CONFIG_BT_CTLR_PHY_2M=n
+# Workaround: Unable to allocate command buffer when using K_NO_WAIT since
+# Host number of completed commands does not follow normal flow control.
+CONFIG_BT_BUF_CMD_TX_COUNT=10
+
+# Debug and assert configuration
+CONFIG_ASSERT=y
+CONFIG_DEBUG_INFO=y
+CONFIG_EXCEPTION_STACK_TRACE=y
+CONFIG_RESET_ON_FATAL_ERROR=n
+CONFIG_REBOOT=n
+
+# IPC
+CONFIG_IPC_SERVICE=y
+
+# Other
+CONFIG_MBOX=y

--- a/samples/matter/template/Kconfig.sysbuild
+++ b/samples/matter/template/Kconfig.sysbuild
@@ -7,4 +7,7 @@
 source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_MULTIPROTOCOL
-	default y
+	default y if ($(BOARD) = "nrf5340dk_nrf5340_cpuapp")
+
+config NRF_DEFAULT_BLUETOOTH
+	default y if ($(BOARD) = "nrf7002dk_nrf5340_cpuapp")

--- a/samples/matter/template/sysbuild/hci_rpmsg/prj.conf
+++ b/samples/matter/template/sysbuild/hci_rpmsg/prj.conf
@@ -1,0 +1,44 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+## Disable serial and UART interface.
+CONFIG_SERIAL=n
+CONFIG_UART_CONSOLE=n
+CONFIG_LOG=n
+
+## RAM usage configuration
+CONFIG_HEAP_MEM_POOL_SIZE=8192
+CONFIG_MAIN_STACK_SIZE=2048
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
+
+## BT configuration
+CONFIG_BT=y
+CONFIG_BT_HCI_RAW=y
+CONFIG_BT_MAX_CONN=1
+CONFIG_BT_CTLR_ASSERT_HANDLER=y
+CONFIG_BT_HCI_RAW_RESERVE=1
+CONFIG_BT_PERIPHERAL=y
+CONFIG_BT_CENTRAL=n
+CONFIG_BT_BUF_ACL_RX_SIZE=502
+CONFIG_BT_BUF_ACL_TX_SIZE=251
+CONFIG_BT_CTLR_DATA_LENGTH_MAX=251
+CONFIG_BT_CTLR_PHY_2M=n
+# Workaround: Unable to allocate command buffer when using K_NO_WAIT since
+# Host number of completed commands does not follow normal flow control.
+CONFIG_BT_BUF_CMD_TX_COUNT=10
+
+# Debug and assert configuration
+CONFIG_ASSERT=y
+CONFIG_DEBUG_INFO=y
+CONFIG_EXCEPTION_STACK_TRACE=y
+CONFIG_RESET_ON_FATAL_ERROR=n
+CONFIG_REBOOT=n
+
+# IPC
+CONFIG_IPC_SERVICE=y
+
+# Other
+CONFIG_MBOX=y

--- a/samples/matter/thermostat/Kconfig.sysbuild
+++ b/samples/matter/thermostat/Kconfig.sysbuild
@@ -7,4 +7,7 @@
 source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_MULTIPROTOCOL
-	default y
+	default y if ($(BOARD) = "nrf5340dk_nrf5340_cpuapp")
+
+config NRF_DEFAULT_BLUETOOTH
+	default y if ($(BOARD) = "nrf7002dk_nrf5340_cpuapp")

--- a/samples/matter/thermostat/sysbuild/hci_rpmsg/prj.conf
+++ b/samples/matter/thermostat/sysbuild/hci_rpmsg/prj.conf
@@ -1,0 +1,44 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+## Disable serial and UART interface.
+CONFIG_SERIAL=n
+CONFIG_UART_CONSOLE=n
+CONFIG_LOG=n
+
+## RAM usage configuration
+CONFIG_HEAP_MEM_POOL_SIZE=8192
+CONFIG_MAIN_STACK_SIZE=2048
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
+
+## BT configuration
+CONFIG_BT=y
+CONFIG_BT_HCI_RAW=y
+CONFIG_BT_MAX_CONN=1
+CONFIG_BT_CTLR_ASSERT_HANDLER=y
+CONFIG_BT_HCI_RAW_RESERVE=1
+CONFIG_BT_PERIPHERAL=y
+CONFIG_BT_CENTRAL=n
+CONFIG_BT_BUF_ACL_RX_SIZE=502
+CONFIG_BT_BUF_ACL_TX_SIZE=251
+CONFIG_BT_CTLR_DATA_LENGTH_MAX=251
+CONFIG_BT_CTLR_PHY_2M=n
+# Workaround: Unable to allocate command buffer when using K_NO_WAIT since
+# Host number of completed commands does not follow normal flow control.
+CONFIG_BT_BUF_CMD_TX_COUNT=10
+
+# Debug and assert configuration
+CONFIG_ASSERT=y
+CONFIG_DEBUG_INFO=y
+CONFIG_EXCEPTION_STACK_TRACE=y
+CONFIG_RESET_ON_FATAL_ERROR=n
+CONFIG_REBOOT=n
+
+# IPC
+CONFIG_IPC_SERVICE=y
+
+# Other
+CONFIG_MBOX=y

--- a/samples/matter/window_covering/Kconfig.sysbuild
+++ b/samples/matter/window_covering/Kconfig.sysbuild
@@ -7,4 +7,7 @@
 source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_MULTIPROTOCOL
-	default y
+	default y if ($(BOARD) = "nrf5340dk_nrf5340_cpuapp")
+
+config NRF_DEFAULT_BLUETOOTH
+	default y if ($(BOARD) = "nrf7002dk_nrf5340_cpuapp")

--- a/samples/matter/window_covering/sysbuild/hci_rpmsg/prj.conf
+++ b/samples/matter/window_covering/sysbuild/hci_rpmsg/prj.conf
@@ -1,0 +1,44 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+## Disable serial and UART interface.
+CONFIG_SERIAL=n
+CONFIG_UART_CONSOLE=n
+CONFIG_LOG=n
+
+## RAM usage configuration
+CONFIG_HEAP_MEM_POOL_SIZE=8192
+CONFIG_MAIN_STACK_SIZE=2048
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
+
+## BT configuration
+CONFIG_BT=y
+CONFIG_BT_HCI_RAW=y
+CONFIG_BT_MAX_CONN=1
+CONFIG_BT_CTLR_ASSERT_HANDLER=y
+CONFIG_BT_HCI_RAW_RESERVE=1
+CONFIG_BT_PERIPHERAL=y
+CONFIG_BT_CENTRAL=n
+CONFIG_BT_BUF_ACL_RX_SIZE=502
+CONFIG_BT_BUF_ACL_TX_SIZE=251
+CONFIG_BT_CTLR_DATA_LENGTH_MAX=251
+CONFIG_BT_CTLR_PHY_2M=n
+# Workaround: Unable to allocate command buffer when using K_NO_WAIT since
+# Host number of completed commands does not follow normal flow control.
+CONFIG_BT_BUF_CMD_TX_COUNT=10
+
+# Debug and assert configuration
+CONFIG_ASSERT=y
+CONFIG_DEBUG_INFO=y
+CONFIG_EXCEPTION_STACK_TRACE=y
+CONFIG_RESET_ON_FATAL_ERROR=n
+CONFIG_REBOOT=n
+
+# IPC
+CONFIG_IPC_SERVICE=y
+
+# Other
+CONFIG_MBOX=y

--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -96,6 +96,8 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
     set(board_secure nrf5340dk_nrf5340_cpuapp)
   elseif(BOARD STREQUAL "thingy53_nrf5340_cpuapp_ns")
     set(board_secure thingy53_nrf5340_cpuapp)
+  elseif(BOARD STREQUAL "nrf7002dk_nrf5340_cpuapp_ns")
+    set(board_secure nrf7002dk_nrf5340_cpuapp)
   endif()
 
   if(DEFINED board_secure AND DEFINED BOARD_REVISION)

--- a/sysbuild/Kconfig.mcuboot
+++ b/sysbuild/Kconfig.mcuboot
@@ -83,7 +83,7 @@ endchoice
 
 menuconfig MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION
 	bool "Downgrade prevention using hardware security counters"
-	depends on ($(BOARD) = "nrf5340dk_nrf5340_cpuapp" || $(BOARD) = "nrf5340dk_nrf5340_cpuapp_ns" || $(BOARD) = "thingy53_nrf5340_cpuapp" || $(BOARD) = "thingy53_nrf5340_cpuapp_ns" || $(BOARD) = "nrf9160dk_nrf9160" || $(BOARD) = "nrf9160dk_nrf9160_ns" || $(BOARD) = "thingy91_nrf9160" || $(BOARD) = "thingy91_nrf9160_ns")
+	depends on ($(BOARD) = "nrf5340dk_nrf5340_cpuapp" || $(BOARD) = "nrf5340dk_nrf5340_cpuapp_ns" || $(BOARD) = "thingy53_nrf5340_cpuapp" || $(BOARD) = "thingy53_nrf5340_cpuapp_ns" || $(BOARD) = "nrf9160dk_nrf9160" || $(BOARD) = "nrf9160dk_nrf9160_ns" || $(BOARD) = "thingy91_nrf9160" || $(BOARD) = "thingy91_nrf9160_ns" || $(BOARD) = "nrf7002dk_nrf5340_cpuapp" || $(BOARD) = "nrf7002dk_nrf5340_cpuapp_ns")
 	help
 	  This option can be enabled by the application and will ensure
 	  that the MCUBOOT_HW_DOWNGRADE_PREVENTION Kconfig option is

--- a/sysbuild/Kconfig.netcore
+++ b/sysbuild/Kconfig.netcore
@@ -4,7 +4,7 @@
 
 config SUPPORT_NETCORE
 	bool
-	default y if ($(BOARD) = "nrf5340dk_nrf5340_cpuapp" || $(BOARD) = "nrf5340dk_nrf5340_cpuapp_ns" || $(BOARD) = "thingy53_nrf5340_cpuapp" || $(BOARD) = "thingy53_nrf5340_cpuapp_ns")
+	default y if ($(BOARD) = "nrf5340dk_nrf5340_cpuapp" || $(BOARD) = "nrf5340dk_nrf5340_cpuapp_ns" || $(BOARD) = "thingy53_nrf5340_cpuapp" || $(BOARD) = "thingy53_nrf5340_cpuapp_ns" || $(BOARD) = "nrf7002dk_nrf5340_cpuapp" || $(BOARD) = "nrf7002dk_nrf5340_cpuapp_ns")
 
 menu "Network core configuration"
 	depends on SUPPORT_NETCORE
@@ -39,10 +39,10 @@ config NRF_DEFAULT_MULTIPROTOCOL
 
 choice NETCORE
 	prompt "Netcore image"
-	default NETCORE_EMPTY if NRF_DEFAULT_EMPTY && ($(BOARD) = "nrf5340dk_nrf5340_cpuapp" || $(BOARD) = "nrf5340dk_nrf5340_cpuapp_ns" || $(BOARD) = "thingy53_nrf5340_cpuapp" || $(BOARD) = "thingy53_nrf5340_cpuapp_ns")
-	default NETCORE_HCI_RPMSG if NRF_DEFAULT_BLUETOOTH && ($(BOARD) = "nrf5340dk_nrf5340_cpuapp" || $(BOARD) = "nrf5340dk_nrf5340_cpuapp_ns" || $(BOARD) = "thingy53_nrf5340_cpuapp" || $(BOARD) = "thingy53_nrf5340_cpuapp_ns")
-	default NETCORE_802154_RPMSG if NRF_DEFAULT_802154 && ($(BOARD) = "nrf5340dk_nrf5340_cpuapp" || $(BOARD) = "nrf5340dk_nrf5340_cpuapp_ns" || $(BOARD) = "thingy53_nrf5340_cpuapp" || $(BOARD) = "thingy53_nrf5340_cpuapp_ns")
-	default NETCORE_MULTIPROTOCOL_RPMSG if NRF_DEFAULT_MULTIPROTOCOL && ($(BOARD) = "nrf5340dk_nrf5340_cpuapp" || $(BOARD) = "nrf5340dk_nrf5340_cpuapp_ns" || $(BOARD) = "thingy53_nrf5340_cpuapp" || $(BOARD) = "thingy53_nrf5340_cpuapp_ns")
+	default NETCORE_EMPTY if NRF_DEFAULT_EMPTY && ($(BOARD) = "nrf5340dk_nrf5340_cpuapp" || $(BOARD) = "nrf5340dk_nrf5340_cpuapp_ns" || $(BOARD) = "thingy53_nrf5340_cpuapp" || $(BOARD) = "thingy53_nrf5340_cpuapp_ns" || $(BOARD) = "nrf7002dk_nrf5340_cpuapp" || $(BOARD) = "nrf7002dk_nrf5340_cpuapp_ns")
+	default NETCORE_HCI_RPMSG if NRF_DEFAULT_BLUETOOTH && ($(BOARD) = "nrf5340dk_nrf5340_cpuapp" || $(BOARD) = "nrf5340dk_nrf5340_cpuapp_ns" || $(BOARD) = "thingy53_nrf5340_cpuapp" || $(BOARD) = "thingy53_nrf5340_cpuapp_ns" || $(BOARD) = "nrf7002dk_nrf5340_cpuapp" || $(BOARD) = "nrf7002dk_nrf5340_cpuapp_ns")
+	default NETCORE_802154_RPMSG if NRF_DEFAULT_802154 && ($(BOARD) = "nrf5340dk_nrf5340_cpuapp" || $(BOARD) = "nrf5340dk_nrf5340_cpuapp_ns" || $(BOARD) = "thingy53_nrf5340_cpuapp" || $(BOARD) = "thingy53_nrf5340_cpuapp_ns" || $(BOARD) = "nrf7002dk_nrf5340_cpuapp" || $(BOARD) = "nrf7002dk_nrf5340_cpuapp_ns")
+	default NETCORE_MULTIPROTOCOL_RPMSG if NRF_DEFAULT_MULTIPROTOCOL && ($(BOARD) = "nrf5340dk_nrf5340_cpuapp" || $(BOARD) = "nrf5340dk_nrf5340_cpuapp_ns" || $(BOARD) = "thingy53_nrf5340_cpuapp" || $(BOARD) = "thingy53_nrf5340_cpuapp_ns" || $(BOARD) = "nrf7002dk_nrf5340_cpuapp" || $(BOARD) = "nrf7002dk_nrf5340_cpuapp_ns")
 	default NETCORE_NONE
 	depends on SUPPORT_NETCORE
 
@@ -87,6 +87,7 @@ config NETCORE_EMPTY_BOARD
 	string
 	default "nrf5340dk_nrf5340_cpunet" if ($(BOARD) = "nrf5340dk_nrf5340_cpuapp" || $(BOARD) = "nrf5340dk_nrf5340_cpuapp_ns")
 	default "thingy53_nrf5340_cpunet" if ($(BOARD) = "thingy53_nrf5340_cpuapp" || $(BOARD) = "thingy53_nrf5340_cpuapp_ns")
+	default "nrf7002dk_nrf5340_cpunet" if ($(BOARD) = "nrf7002dk_nrf5340_cpuapp" || $(BOARD) = "nrf7002dk_nrf5340_cpuapp_ns")
 	depends on NETCORE_EMPTY
 	help
 	  Remote board when building this sample.
@@ -94,11 +95,11 @@ config NETCORE_EMPTY_BOARD
 
 config NETCORE_EMPTY_DOMAIN
 	string
-	default "CPUNET" if (NETCORE_EMPTY_BOARD = "nrf5340dk_nrf5340_cpunet" || NETCORE_EMPTY_BOARD = "thingy53_nrf5340_cpunet")
+	default "CPUNET" if (NETCORE_EMPTY_BOARD = "nrf5340dk_nrf5340_cpunet" || NETCORE_EMPTY_BOARD = "thingy53_nrf5340_cpunet" || NETCORE_EMPTY_BOARD = "nrf7002dk_nrf5340_cpunet")
 
 config NETCORE_EMPTY_DOMAIN_APP
 	bool
-	default y if (NETCORE_EMPTY_BOARD = "nrf5340dk_nrf5340_cpunet" || NETCORE_EMPTY_BOARD = "thingy53_nrf5340_cpunet")
+	default y if (NETCORE_EMPTY_BOARD = "nrf5340dk_nrf5340_cpunet" || NETCORE_EMPTY_BOARD = "thingy53_nrf5340_cpunet" || NETCORE_EMPTY_BOARD = "nrf7002dk_nrf5340_cpunet")
 
 config NETCORE_HCI_RPMSG_NAME
 	string
@@ -111,6 +112,7 @@ config NETCORE_HCI_RPMSG_BOARD
 	string
 	default "nrf5340dk_nrf5340_cpunet" if ($(BOARD) = "nrf5340dk_nrf5340_cpuapp" || $(BOARD) = "nrf5340dk_nrf5340_cpuapp_ns")
 	default "thingy53_nrf5340_cpunet" if ($(BOARD) = "thingy53_nrf5340_cpuapp" || $(BOARD) = "thingy53_nrf5340_cpuapp_ns")
+	default "nrf7002dk_nrf5340_cpunet" if ($(BOARD) = "nrf7002dk_nrf5340_cpuapp" || $(BOARD) = "nrf7002dk_nrf5340_cpuapp_ns")
 	depends on NETCORE_HCI_RPMSG
 	help
 	  Remote board when building this sample.
@@ -118,11 +120,11 @@ config NETCORE_HCI_RPMSG_BOARD
 
 config NETCORE_HCI_RPMSG_DOMAIN
 	string
-	default "CPUNET" if (NETCORE_HCI_RPMSG_BOARD = "nrf5340dk_nrf5340_cpunet" || NETCORE_HCI_RPMSG_BOARD = "thingy53_nrf5340_cpunet")
+	default "CPUNET" if (NETCORE_HCI_RPMSG_BOARD = "nrf5340dk_nrf5340_cpunet" || NETCORE_HCI_RPMSG_BOARD = "thingy53_nrf5340_cpunet" || NETCORE_HCI_RPMSG_BOARD = "nrf7002dk_nrf5340_cpunet")
 
 config NETCORE_HCI_RPMSG_DOMAIN_APP
 	bool
-	default y if (NETCORE_HCI_RPMSG_BOARD = "nrf5340dk_nrf5340_cpunet" || NETCORE_HCI_RPMSG_BOARD = "thingy53_nrf5340_cpunet")
+	default y if (NETCORE_HCI_RPMSG_BOARD = "nrf5340dk_nrf5340_cpunet" || NETCORE_HCI_RPMSG_BOARD = "thingy53_nrf5340_cpunet" || NETCORE_HCI_RPMSG_BOARD = "nrf7002dk_nrf5340_cpunet")
 
 config NETCORE_802154_RPMSG_NAME
 	string
@@ -135,6 +137,7 @@ config NETCORE_802154_RPMSG_BOARD
 	string
 	default "nrf5340dk_nrf5340_cpunet" if ($(BOARD) = "nrf5340dk_nrf5340_cpuapp" || $(BOARD) = "nrf5340dk_nrf5340_cpuapp_ns")
 	default "thingy53_nrf5340_cpunet" if ($(BOARD) = "thingy53_nrf5340_cpuapp" || $(BOARD) = "thingy53_nrf5340_cpuapp_ns")
+	default "nrf7002dk_nrf5340_cpunet" if ($(BOARD) = "nrf7002dk_nrf5340_cpuapp" || $(BOARD) = "nrf7002dk_nrf5340_cpuapp_ns")
 	depends on NETCORE_802154_RPMSG
 	help
 	  Remote board when building this sample.
@@ -142,11 +145,11 @@ config NETCORE_802154_RPMSG_BOARD
 
 config NETCORE_802154_RPMSG_DOMAIN
 	string
-	default "CPUNET" if (NETCORE_802154_RPMSG_BOARD = "nrf5340dk_nrf5340_cpunet" || NETCORE_802154_RPMSG_BOARD = "thingy53_nrf5340_cpunet")
+	default "CPUNET" if (NETCORE_802154_RPMSG_BOARD = "nrf5340dk_nrf5340_cpunet" || NETCORE_802154_RPMSG_BOARD = "thingy53_nrf5340_cpunet" || NETCORE_802154_RPMSG_BOARD = "nrf7002dk_nrf5340_cpunet")
 
 config NETCORE_802154_RPMSG_DOMAIN_APP
 	bool
-	default y if (NETCORE_802154_RPMSG_BOARD = "nrf5340dk_nrf5340_cpunet" || NETCORE_802154_RPMSG_BOARD = "thingy53_nrf5340_cpunet")
+	default y if (NETCORE_802154_RPMSG_BOARD = "nrf5340dk_nrf5340_cpunet" || NETCORE_802154_RPMSG_BOARD = "thingy53_nrf5340_cpunet" || NETCORE_802154_RPMSG_BOARD = "nrf7002dk_nrf5340_cpunet")
 
 config NETCORE_MULTIPROTOCOL_RPMSG_NAME
 	string
@@ -159,6 +162,7 @@ config NETCORE_MULTIPROTOCOL_RPMSG_BOARD
 	string
 	default "nrf5340dk_nrf5340_cpunet" if ($(BOARD) = "nrf5340dk_nrf5340_cpuapp" || $(BOARD) = "nrf5340dk_nrf5340_cpuapp_ns")
 	default "thingy53_nrf5340_cpunet" if ($(BOARD) = "thingy53_nrf5340_cpuapp" || $(BOARD) = "thingy53_nrf5340_cpuapp_ns")
+	default "nrf7002dk_nrf5340_cpunet" if ($(BOARD) = "nrf7002dk_nrf5340_cpuapp" || $(BOARD) = "nrf7002dk_nrf5340_cpuapp_ns")
 	depends on NETCORE_MULTIPROTOCOL_RPMSG
 	help
 	  Remote board when building this sample.
@@ -166,11 +170,11 @@ config NETCORE_MULTIPROTOCOL_RPMSG_BOARD
 
 config NETCORE_MULTIPROTOCOL_RPMSG_DOMAIN
 	string
-	default "CPUNET" if (NETCORE_MULTIPROTOCOL_RPMSG_BOARD = "nrf5340dk_nrf5340_cpunet" || NETCORE_MULTIPROTOCOL_RPMSG_BOARD = "thingy53_nrf5340_cpunet")
+	default "CPUNET" if (NETCORE_MULTIPROTOCOL_RPMSG_BOARD = "nrf5340dk_nrf5340_cpunet" || NETCORE_MULTIPROTOCOL_RPMSG_BOARD = "thingy53_nrf5340_cpunet" || NETCORE_MULTIPROTOCOL_RPMSG_BOARD = "nrf7002dk_nrf5340_cpunet")
 
 config NETCORE_MULTIPROTOCOL_RPMSG_DOMAIN_APP
 	bool
-	default y if (NETCORE_MULTIPROTOCOL_RPMSG_BOARD = "nrf5340dk_nrf5340_cpunet" || NETCORE_MULTIPROTOCOL_RPMSG_BOARD = "thingy53_nrf5340_cpunet")
+	default y if (NETCORE_MULTIPROTOCOL_RPMSG_BOARD = "nrf5340dk_nrf5340_cpunet" || NETCORE_MULTIPROTOCOL_RPMSG_BOARD = "thingy53_nrf5340_cpunet" || NETCORE_MULTIPROTOCOL_RPMSG_BOARD = "nrf7002dk_nrf5340_cpunet")
 
 config NETCORE_APP_UPDATE
 	bool "Network core updates"

--- a/sysbuild/Kconfig.secureboot
+++ b/sysbuild/Kconfig.secureboot
@@ -25,6 +25,7 @@ config SECURE_BOOT_NETWORK_BOARD
 	string
 	default "nrf5340dk_nrf5340_cpunet" if SECURE_BOOT_NETCORE && ($(BOARD) = "nrf5340dk_nrf5340_cpuapp" || $(BOARD) = "nrf5340dk_nrf5340_cpuapp_ns")
 	default "thingy53_nrf5340_cpunet" if SECURE_BOOT_NETCORE && ($(BOARD) = "thingy53_nrf5340_cpuapp" || $(BOARD) = "thingy53_nrf5340_cpuapp_ns")
+	default "nrf7002dk_nrf5340_cpunet" if SECURE_BOOT_NETCORE && ($(BOARD) = "nrf7002dk_nrf5340_cpuapp" || $(BOARD) = "nrf7002dk_nrf5340_cpuapp")
 	depends on SECURE_BOOT_NETCORE
 	help
 	  Remote board when building this sample.


### PR DESCRIPTION
- added support for nRF7002 DK to the sysbuild scripts
- adapted Matter samples configuration to support nRF7002 DK builds with sysbuild