### PR TITLE
samples: net: wifi: update twister tests

### DIFF
--- a/samples/debug/memfault/sample.yaml
+++ b/samples/debug/memfault/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: Memfault sample
 tests:
-  sample.debug.memfault.lte:
+  sample.debug.memfault:
     build_only: true
     extra_configs:
       - CONFIG_MEMFAULT_NCS_PROJECT_KEY="dummy-key"
@@ -9,19 +9,14 @@ tests:
       - nrf9160dk_nrf9160_ns
       - nrf9161dk_nrf9161_ns
       - thingy91_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns thingy91_nrf9160_ns
-    tags: ci_build
-  sample.debug.memfault.wifi:
-    build_only: true
-    extra_configs:
-      - CONFIG_MEMFAULT_NCS_PROJECT_KEY="dummy-key"
-      - CONFIG_WIFI_CREDENTIALS_STATIC_SSID="dummy-ssid"
-      - CONFIG_WIFI_CREDENTIALS_STATIC_PASSWORD="dummy-password"
-    integration_platforms:
       - nrf7002dk_nrf5340_cpuapp
-    platform_allow: nrf7002dk_nrf5340_cpuapp
+    platform_allow:
+      - nrf9160dk_nrf9160_ns
+      - nrf9161dk_nrf9161_ns
+      - thingy91_nrf9160_ns
+      - nrf7002dk_nrf5340_cpuapp
     tags: ci_build
-  sample.nrf9160.memfault.etb:
+  sample.debug.memfault.etb:
     build_only: true
     extra_configs:
       - CONFIG_MEMFAULT_NCS_PROJECT_KEY="dummy-key"
@@ -30,5 +25,8 @@ tests:
       - nrf9160dk_nrf9160_ns
       - nrf9161dk_nrf9161_ns
       - thingy91_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns thingy91_nrf9160_ns
+    platform_allow:
+      - nrf9160dk_nrf9160_ns
+      - nrf9161dk_nrf9161_ns
+      - thingy91_nrf9160_ns
     tags: ci_build

--- a/samples/net/aws_iot/sample.yaml
+++ b/samples/net/aws_iot/sample.yaml
@@ -15,6 +15,3 @@ tests:
       - nrf9161dk_nrf9161_ns
       - thingy91_nrf9160_ns
       - nrf7002dk_nrf5340_cpuapp
-    extra_configs:
-      - CONFIG_WIFI_CREDENTIALS_STATIC_SSID="ssid"
-      - CONFIG_WIFI_CREDENTIALS_STATIC_PASSWORD="psk"

--- a/samples/net/azure_iot_hub/sample.yaml
+++ b/samples/net/azure_iot_hub/sample.yaml
@@ -1,40 +1,28 @@
 sample:
   name: Azure IoT Hub sample
 tests:
-  sample.net.azure_iot_hub.lte:
+  sample.net.azure_iot_hub:
     build_only: true
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - nrf9161dk_nrf9161_ns
-    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
-    tags: ci_build
-  sample.net.azure_iot_hub.wifi:
-    build_only: true
-    integration_platforms:
       - nrf7002dk_nrf5340_cpuapp
-    platform_allow: nrf7002dk_nrf5340_cpuapp
-    extra_configs:
-      - CONFIG_WIFI_CREDENTIALS_STATIC_SSID="test-ssid"
-      - CONFIG_WIFI_CREDENTIALS_STATIC_PASSWORD="test-password"
+    platform_allow:
+      - nrf9160dk_nrf9160_ns
+      - nrf9161dk_nrf9161_ns
+      - nrf7002dk_nrf5340_cpuapp
     tags: ci_build
-  sample.net.azure_iot_hub.dps.lte:
+  sample.net.azure_iot_hub.dps:
     build_only: true
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - nrf9161dk_nrf9161_ns
-    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
-    extra_args: OVERLAY_CONFIG=overlay-dps.conf
-    extra_configs:
-      - CONFIG_AZURE_IOT_HUB_DPS_ID_SCOPE="test-scope"
-    tags: ci_build
-  sample.net.azure_iot_hub.dps.wifi:
-    build_only: true
-    integration_platforms:
       - nrf7002dk_nrf5340_cpuapp
-    platform_allow: nrf7002dk_nrf5340_cpuapp
+    platform_allow:
+      - nrf9160dk_nrf9160_ns
+      - nrf9161dk_nrf9161_ns
+      - nrf7002dk_nrf5340_cpuapp
     extra_args: OVERLAY_CONFIG=overlay-dps.conf
     extra_configs:
       - CONFIG_AZURE_IOT_HUB_DPS_ID_SCOPE="test-scope"
-      - CONFIG_WIFI_CREDENTIALS_STATIC_SSID="test-ssid"
-      - CONFIG_WIFI_CREDENTIALS_STATIC_PASSWORD="test-password"
     tags: ci_build

--- a/samples/net/coap_client/sample.yaml
+++ b/samples/net/coap_client/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: nRF CoAP client sample
 tests:
-  sample.cellular.coap_client:
+  sample.net.coap_client:
     build_only: true
     build_on_all: true
     integration_platforms:
@@ -14,7 +14,4 @@ tests:
       - nrf9161dk_nrf9161_ns
       - thingy91_nrf9160_ns
       - nrf7002dk_nrf5340_cpuapp
-    extra_configs:
-      - CONFIG_WIFI_CREDENTIALS_STATIC_SSID="test-ssid"
-      - CONFIG_WIFI_CREDENTIALS_STATIC_PASSWORD="test-password"
     tags: ci_build

--- a/samples/net/download/overlay-tfm.conf
+++ b/samples/net/download/overlay-tfm.conf
@@ -1,7 +1,0 @@
-#
-# Copyright (c) 2021 Nordic Semiconductor ASA
-#
-# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
-#
-
-CONFIG_FPU=n

--- a/samples/net/download/sample.yaml
+++ b/samples/net/download/sample.yaml
@@ -7,9 +7,12 @@ tests:
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - nrf9161dk_nrf9161_ns
-    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
+    platform_allow:
+      - nrf9160dk_nrf9160_ns
+      - nrf9161dk_nrf9161_ns
+      - nrf7002dk_nrf5340_cpuapp
     tags: ci_build
-  sample.net.download_client.lte:
+  sample.net.download_client:
     build_only: true
     extra_configs:
       - CONFIG_SHELL=y
@@ -19,17 +22,9 @@ tests:
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - nrf9161dk_nrf9161_ns
-    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
-    tags: ci_build
-  sample.net.download_client.wifi:
-    build_only: true
-    extra_configs:
-      - CONFIG_SHELL=y
-      - CONFIG_DOWNLOAD_CLIENT_SHELL=y
-      - CONFIG_SAMPLE_COMPUTE_HASH=y
-      - CONFIG_WIFI_CREDENTIALS_STATIC_SSID="test-ssid"
-      - CONFIG_WIFI_CREDENTIALS_STATIC_PASSWORD="test-password"
-    integration_platforms:
       - nrf7002dk_nrf5340_cpuapp
-    platform_allow: nrf7002dk_nrf5340_cpuapp
+    platform_allow:
+      - nrf9160dk_nrf9160_ns
+      - nrf9161dk_nrf9161_ns
+      - nrf7002dk_nrf5340_cpuapp
     tags: ci_build

--- a/samples/net/download/sample.yaml
+++ b/samples/net/download/sample.yaml
@@ -1,17 +1,6 @@
 sample:
   name: Download sample
 tests:
-  sample.net.download.tfm.lte:
-    build_only: true
-    extra_args: OVERLAY_CONFIG="overlay-tfm.conf"
-    integration_platforms:
-      - nrf9160dk_nrf9160_ns
-      - nrf9161dk_nrf9161_ns
-    platform_allow:
-      - nrf9160dk_nrf9160_ns
-      - nrf9161dk_nrf9161_ns
-      - nrf7002dk_nrf5340_cpuapp
-    tags: ci_build
   sample.net.download_client:
     build_only: true
     extra_configs:

--- a/samples/net/https_client/sample.yaml
+++ b/samples/net/https_client/sample.yaml
@@ -1,21 +1,16 @@
 sample:
   name: HTTPS client sample
 tests:
-  sample.net.https_client.lte:
+  sample.net.https_client:
     build_only: true
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - nrf9161dk_nrf9161_ns
-    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
-    tags: ci_build
-  sample.net.https_client.wifi:
-    build_only: true
-    integration_platforms:
       - nrf7002dk_nrf5340_cpuapp
-    platform_allow: nrf7002dk_nrf5340_cpuapp
-    extra_configs:
-      - CONFIG_WIFI_CREDENTIALS_STATIC_SSID="test-ssid"
-      - CONFIG_WIFI_CREDENTIALS_STATIC_PASSWORD="test-password"
+    platform_allow:
+      - nrf9160dk_nrf9160_ns
+      - nrf9161dk_nrf9161_ns
+      - nrf7002dk_nrf5340_cpuapp
     tags: ci_build
   sample.net.https_client.lte.tfm-mbedtls:
     build_only: true

--- a/samples/net/mqtt/sample.yaml
+++ b/samples/net/mqtt/sample.yaml
@@ -16,10 +16,6 @@ tests:
       - nrf7002dk_nrf5340_cpuapp
       - native_posix
     tags: ci_build
-    extra_configs:
-      - CONFIG_WIFI_CREDENTIALS_STATIC_SSID="ssid"
-      - CONFIG_WIFI_CREDENTIALS_STATIC_PASSWORD="psk"
-      - CONFIG_WIFI_CREDENTIALS_STATIC_TYPE_PSK=y
   sample.net.mqtt.nrf70.tls:
     build_only: true
     build_on_all: true
@@ -28,10 +24,6 @@ tests:
     platform_allow: nrf7002dk_nrf5340_cpuapp
     tags: ci_build
     extra_args: EXTRA_CONF_FILE=overlay-tls-nrf70.conf
-    extra_configs:
-      - CONFIG_WIFI_CREDENTIALS_STATIC_SSID="ssid"
-      - CONFIG_WIFI_CREDENTIALS_STATIC_PASSWORD="psk"
-      - CONFIG_WIFI_CREDENTIALS_STATIC_TYPE_PSK=y
   sample.net.mqtt.nrf91.tls:
     build_only: true
     build_on_all: true

--- a/samples/net/udp/sample.yaml
+++ b/samples/net/udp/sample.yaml
@@ -1,26 +1,18 @@
 sample:
   name: UDP sample
 tests:
-  sample.net.udp.wifi:
-    build_only: true
-    integration_platforms:
-      - nrf7002dk_nrf5340_cpuapp
-    platform_allow:
-      - nrf7002dk_nrf5340_cpuapp
-    tags: ci_build
-    extra_configs:
-      - CONFIG_WIFI_CREDENTIALS_STATIC_SSID="ssid"
-      - CONFIG_WIFI_CREDENTIALS_STATIC_PASSWORD="psk"
-  sample.net.udp.lte:
+  sample.net.udp:
     build_only: true
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - nrf9161dk_nrf9161_ns
       - thingy91_nrf9160_ns
+      - nrf7002dk_nrf5340_cpuapp
     platform_allow:
       - nrf9160dk_nrf9160_ns
       - nrf9161dk_nrf9161_ns
       - thingy91_nrf9160_ns
+      - nrf7002dk_nrf5340_cpuapp
     tags: ci_build
   sample.net.udp.emulation:
     build_only: true


### PR DESCRIPTION
samples built for wifi is no longer using static credentials as default.
the static credential configs are now removed from twister tests.