### PR TITLE
Bluetooth: Host: Add LE Power Control Request Procedure APIs

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -74,7 +74,8 @@ See `Samples`_ for lists of changes for the protocol-related samples.
 Bluetooth® LE
 -------------
 
-|no_changes_yet_note|
+* Added host extensions for Nordic-only vendor-specific command APIs.
+  Implementation and integration of the host APIs can be found in the :file:`host_extensions.h` header file.
 
 Bluetooth mesh
 --------------

--- a/include/bluetooth/nrf/host_extensions.h
+++ b/include/bluetooth/nrf/host_extensions.h
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/**
+ * @file
+ * @defgroup bt_nrf_host_extensions Bluetooth vendor specific APIs
+ * @{
+ * @brief Bluetooth Host APIs for Nodic-LL vendor-specific commands.
+ */
+
+#ifndef BT_NRF_HOST_EXTENSIONS_H_
+#define BT_NRF_HOST_EXTENSIONS_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/** @brief Set remote (peer) transmit power.
+ *
+ *  @param conn         Connection object.
+ *  @param phy          PHY bit number i.e. [1M, 2M, s8, s2] == [1, 2, 3, 4]
+ *  @param delta        Requested adjustment (in dBm) for the remote to apply to
+ *                      its transmit power.
+ *                      The value can be 0 to utilize the response of the peer to update
+ *                      the information on the transmit power setting of the remote.
+ *                      Note that this is only a request to the peer, which is in control of
+ *                      how, if at all, to apply changes to its transmit power.
+ *
+ *  @return Zero on success or (negative) error code on failure.
+ *  @retval -ENOBUFS HCI command buffer is not available.
+ */
+int bt_conn_set_remote_tx_power_level(struct bt_conn *conn,
+					 enum bt_conn_le_tx_power_phy phy, int8_t delta);
+
+struct bt_conn_set_pcr_params {
+	/** Enable or disable controller-initiated autonomous LE Power Control Request procedure.
+	 *  Disabled by default.
+	 */
+	uint8_t auto_enable;
+	/** Enable or disable Acceptable Power Reduction (APR) handling in controller during
+	 *  LE Power Control Request procedure.
+	 *  Disabled by default.
+	 */
+	uint8_t apr_enable;
+	/** Value used to determine the weight of the previous average of RSSI values.
+	 *  A higher value lowers how much the current RSSI weighs into the average,
+	 *  flattening peaks, which also means the controller reacts slower on RSSI changes.
+	 *  The valid range is [0, 4095].
+	 *  Default value is 2048.
+	 *
+	 *  In the controller, the value is used in an exponential weighted
+	 *  averaging of RSSI in a 12-bit fixed point fraction.
+	 *
+	 *   avg[n] = gamma * avg[n - 1] + (1 - gamma) * rssi[n]
+	 *
+	 *  Here, gamma equals beta/4096, and rssi[n] equals the current RSSI.
+	 *
+	 *  For example, for gamma to be 0.25, set the beta parameter in the command to 1024.
+	 */
+	uint16_t beta;
+	/** The lower limit of the RSSI golden range. The RSSI golden range is explained in
+	 *  Core_v5.4, Vol 6, Part B, Section 5.1.17.1.
+	 *  Default value is -70 dBm.
+	 */
+	int8_t lower_limit;
+	/** The upper limit of the RSSI golden range.
+	 *  Default value is -30 dBm.
+	 */
+	int8_t upper_limit;
+	/** Target RSSI level in dBm units when the average RSSI level is less than
+	 *  the lower limit of the RSSI golden range.
+	 *  Default value is -65 dBm.
+	 */
+	int8_t lower_target_rssi;
+	/** Target RSSI level in dBm units when the average RSSI level is greater than
+	 *  the upper limit of the RSSI golden range.
+	 *  Default value is -35 dBm.
+	 */
+	int8_t upper_target_rssi;
+	/** Duration in milliseconds to wait before initiating a new LE Power Control Request
+	 *  procedure by the controller.
+	 *  It is needed to not repeat send requests for transmit power change without the remote
+	 *  having had the chance to react, as well as to avoid a busy controller.
+	 *  This value should be set depending on needs.
+	 *  0 milliseconds value is an invalid value.
+	 *  Default value is 5000 milliseconds.
+	 */
+	uint16_t wait_period_ms;
+	/** Margin between APR value received from peer in LL_POWER_CONTROL_RSP PDU
+	 *  and actual reduction in Transmit power that is applied locally.
+	 *  The applied decrease in local Transmit power will be
+	 *  (received_apr - apr_margin)
+	 *  if received_apr > apr_margin, otherwise no change.
+	 *  Default value is 5 dB.
+	 */
+	uint8_t apr_margin;
+};
+
+/** @brief Set Power Control request parameter
+ *
+ *  @param params        See @ref bt_conn_set_pcr_params for details.
+ *
+ *  @return Zero on success or (negative) error code on failure.
+ *  @retval -ENOBUFS HCI command buffer is not available.
+ */
+int bt_conn_set_power_control_request_params(struct bt_conn_set_pcr_params *params);
+
+/**
+ * @}
+ */
+
+#endif /* BT_NRF_HOST_EXTENSIONS_H_ */

--- a/subsys/bluetooth/CMakeLists.txt
+++ b/subsys/bluetooth/CMakeLists.txt
@@ -17,3 +17,5 @@ add_subdirectory_ifdef(CONFIG_BT_MESH mesh)
 add_subdirectory_ifdef(CONFIG_BT_NRF_SERVICES services)
 
 add_subdirectory_ifdef(CONFIG_BT_RPC rpc)
+
+add_subdirectory(host_extensions)

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -37,6 +37,7 @@ config BT_LL_SOFTDEVICE
 	select BT_CTLR_PHY_CODED_SUPPORT if HAS_HW_NRF_RADIO_BLE_CODED
 	select BT_HAS_HCI_VS
 	select BT_CTLR_DF_SUPPORT if HAS_HW_NRF_RADIO_DFE
+	select BT_CTLR_LE_POWER_CONTROL_SUPPORT
 	depends on (SOC_SERIES_BSIM_NRFXX || SOC_SERIES_NRF52X || SOC_NRF5340_CPUNET)
 	help
 	  Use SoftDevice Link Layer implementation.
@@ -366,12 +367,6 @@ config BT_CTLR_ECDH_IN_MPSL_WORK
 	  This saves RAM at the cost of delaying MPSL work.
 
 endif # BT_CTLR_ECDH
-
-config BT_CTLR_LE_POWER_CONTROL
-	bool "LE Power Control"
-	help
-	  Enable support for LE Power Control feature that defined in the Bluetooth
-	  Core specification, Version 5.3 | Vol 6, Part B, Section 4.6.31.
 
 config BT_CTLR_SDC_EVENT_TRIGGER
 	bool "Event Trigger"

--- a/subsys/bluetooth/host_extensions/CMakeLists.txt
+++ b/subsys/bluetooth/host_extensions/CMakeLists.txt
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+zephyr_sources_ifdef(CONFIG_BT_TRANSMIT_POWER_CONTROL host_extensions.c)

--- a/subsys/bluetooth/host_extensions/hci_types_host_extensions.h
+++ b/subsys/bluetooth/host_extensions/hci_types_host_extensions.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/**
+ * @file
+ * @defgroup bt_nrf_host_extensions Bluetooth vendor specific APIs
+ * @{
+ * @brief Bluetooth Host APIs for Nodic-LL vendor-specific commands.
+ */
+
+#ifndef BT_HCI_TYPES_HOST_EXTENSIONS_H_
+#define BT_HCI_TYPES_HOST_EXTENSIONS_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#define BT_HCI_OP_SET_REMOTE_TX_POWER	BT_OP(BT_OGF_VS, 0x010A)
+
+struct bt_hci_set_remote_tx_power_level {
+	uint16_t handle;
+	uint8_t  phy;
+	int8_t	 delta;
+} __packed;
+
+#define BT_HCI_OP_SET_POWER_CONTROL_REQUEST_PARAMS	BT_OP(BT_OGF_VS, 0x0110)
+
+struct bt_hci_cp_set_power_control_request_param {
+	uint8_t auto_enable;
+	uint8_t apr_enable;
+	uint16_t beta;
+	int8_t lower_limit;
+	int8_t upper_limit;
+	int8_t lower_target_rssi;
+	int8_t upper_target_rssi;
+	uint16_t wait_period_ms;
+	uint8_t apr_margin;
+} __packed;
+
+/**
+ * @}
+ */
+
+#endif /* BT_HCI_TYPES_HOST_EXTENSIONS_H_ */

--- a/subsys/bluetooth/host_extensions/host_extensions.c
+++ b/subsys/bluetooth/host_extensions/host_extensions.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/*
+ * Purpose of this file is to add nordic-LL only vendor-specific commands.
+ * Adding them in nrf is better maintainable.
+ */
+
+#if defined(CONFIG_BT_TRANSMIT_POWER_CONTROL)
+
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/hci.h>
+#include <../subsys/bluetooth/host/conn_internal.h>
+
+#include "hci_types_host_extensions.h"
+#include <bluetooth/nrf/host_extensions.h>
+
+/* Write Remote Transmit Power Level HCI command */
+int bt_conn_set_remote_tx_power_level(struct bt_conn *conn,
+				       enum bt_conn_le_tx_power_phy phy, int8_t delta)
+{
+	struct bt_hci_set_remote_tx_power_level *cp;
+	struct net_buf *buf;
+
+	if (!phy) {
+		return -EINVAL;
+	}
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_SET_REMOTE_TX_POWER, sizeof(*cp));
+	if (!buf) {
+		return -ENOBUFS;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	cp->handle = sys_cpu_to_le16(conn->handle);
+	cp->phy = phy;
+	cp->delta = delta;
+
+	return bt_hci_cmd_send_sync(BT_HCI_OP_SET_REMOTE_TX_POWER, buf, NULL);
+}
+
+/* Set LE Power Control Feature Parameters */
+int bt_conn_set_power_control_request_params(struct bt_conn_set_pcr_params *params)
+{
+	struct bt_hci_cp_set_power_control_request_param *cp;
+	struct net_buf *buf;
+
+	if (!params->wait_period_ms) {
+		return -EINVAL;
+	}
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_SET_POWER_CONTROL_REQUEST_PARAMS, sizeof(*cp));
+	if (!buf) {
+		return -ENOBUFS;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	cp->auto_enable = params->auto_enable;
+	cp->apr_enable = params->apr_enable;
+	cp->beta = sys_cpu_to_le16(params->beta);
+	cp->lower_limit = params->lower_limit;
+	cp->upper_limit = params->upper_limit;
+	cp->lower_target_rssi = params->lower_target_rssi;
+	cp->upper_target_rssi = params->upper_target_rssi;
+	cp->wait_period_ms = sys_cpu_to_le16(params->wait_period_ms);
+	cp->apr_margin = params->apr_margin;
+
+	return bt_hci_cmd_send_sync(BT_HCI_OP_SET_POWER_CONTROL_REQUEST_PARAMS, buf, NULL);
+}
+#endif /* CONFIG_BT_TRANSMIT_POWER_CONTROL */

--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 0c7fcf3c32a712f5003def83a3607404850dc9e2
+      revision: f8dc8ac55203667f5137e4d4e245de4277db4980
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This commits adds the vendor-specific API's for the LE Power Control Request Feature in Zephyr.

The support of feature is provided with the controller-based feature selection with BT_CTLR_LE_POWER_CONTROL_SUPPORT and is selectable via BT_TRANSMIT_POWER_CONTROL.

With the new APIs, the applications will:
be able to request a tx power change on remote device be able to set automatic Power Control Request when out of golden range of RSSI be able to set APR handling of remote apr to use in local tx power setting

Vendor-specific HCI commands:
Write remote transmit power level
Set LE Power Control Request parameters