### PR TITLE
lib: location: Use NCELLMEAS=3,X

### DIFF
--- a/doc/nrf/libraries/modem/location.rst
+++ b/doc/nrf/libraries/modem/location.rst
@@ -47,8 +47,9 @@ The supported location methods are as follows:
 * Cellular positioning
 
   * Uses :ref:`lte_lc_readme` for getting a list of nearby cellular base stations.
-  * Neighbor cell measurement is performed with :c:enum:`LTE_LC_NEIGHBOR_SEARCH_TYPE_EXTENDED_COMPLETE` search type.
-    A GCI search with :c:enum:`LTE_LC_NEIGHBOR_SEARCH_TYPE_GCI_EXTENDED_LIGHT` search type is performed if the previous search did not find enough cells.
+  * Neighbor cell measurement is performed with :c:enum:`LTE_LC_NEIGHBOR_SEARCH_TYPE_EXTENDED_LIGHT` search type.
+    If more than one cell is requested, a GCI search with :c:enum:`LTE_LC_NEIGHBOR_SEARCH_TYPE_GCI_DEFAULT` search type is performed to find the cells based on the history information.
+    If a sufficient number of cells still has not been found, a GCI search with :c:enum:`LTE_LC_NEIGHBOR_SEARCH_TYPE_GCI_EXTENDED_LIGHT` search type is performed.
     For more details on GCI search, see :c:member:`location_cellular_config.cell_count`.
   * The ``cloud location`` method handles sending cell information to the selected location service and getting the calculated location back to the device.
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -417,6 +417,12 @@ DFU libraries
 Modem libraries
 ---------------
 
+* :ref:`lib_location` library:
+
+  * Updated the use of neighbor cell measurements for cellular positioning.
+    Previously, 1-2 searches were performed and now 1-3 will be done depending on the requested number of cells and the number of found cells.
+    Also, only GCI cells are counted towards the requested number of cells, and normal neighbors are ignored from this perspective.
+
 * :ref:`lte_lc_readme` library:
 
   * Added:

--- a/include/modem/location.h
+++ b/include/modem/location.h
@@ -371,16 +371,17 @@ struct location_cellular_config {
 	 *
 	 * Maximum value is 15.
 	 *
-	 * Zero indicates that only normal neighbor cell search is performed but no GCI search.
-	 *
-	 * If there are less than requested number of neighbor cells (including current cell),
-	 * GCI (surrounding) cells are requested also.
+	 * The number of cells mean GCI cells including current cell.
+	 * Normal neighbor cells are received and used but they do not count towards the cell count.
+	 * If the number of cells is bigger than one, GCI (surrounding) cells are requested.
+	 * Hence, zero and one mean that only normal neighbor cell search is performed
+	 * but no GCI search.
 	 *
 	 * Note that even if there are a lot of cells available, the number of cells
 	 * used for positioning may be lower than the requested number of cells due to
 	 * the behavior of the search algorithm. Also, the number of cells used for
 	 * positioning may be higher than the requested number of cells if there are
-	 * more neighbor cells (including current cell).
+	 * more cells in the history information (including current cell).
 	 */
 	uint8_t cell_count;
 };

--- a/tests/lib/location/prj.conf
+++ b/tests/lib/location/prj.conf
@@ -16,6 +16,9 @@ CONFIG_LOCATION_METHOD_CELLULAR=y
 CONFIG_LOCATION_SERVICE_HERE=y
 CONFIG_LOCATION_SERVICE_HERE_API_KEY="MyApiKey"
 
+# Increase AT monitor heap because %NCELLMEAS notifications can be large
+CONFIG_AT_MONITOR_HEAP_SIZE=512
+
 CONFIG_MOCK_NRF_MODEM_AT=y
 
 # Enable logs if you want to explore them


### PR DESCRIPTION
Change neighbor cell searches as follows:
- Do NCELLMEAS=1
- If more than one cell is requested, do NCELLMEAS=3,15
- If not enough GCI cells are found (by default 3), do NCELLMEAS=4,X, where X=3 by default

Even more significant change compared to the algorithm is that the cell count is not taking normal neighbors into account but only the current cell and GCI cells.

Jira: NCSDK-24585