### PR TITLE
Applications: nrf5340_audio: synchronize L and R with SDC.

### DIFF
--- a/applications/nrf5340_audio/src/modules/audio_sync_timer.h
+++ b/applications/nrf5340_audio/src/modules/audio_sync_timer.h
@@ -18,6 +18,13 @@
 uint32_t audio_sync_timer_capture(void);
 
 /**
+ * @brief Add some documentation :)
+ * 
+ * @retval
+*/
+uint32_t audio_sync_frame_send_timer_capture(void);
+
+/**
  * @brief Returns the last captured value of the sync timer.
  *
  * The captured time is corresponding to the I2S frame start.


### PR DESCRIPTION
Use timestamps in SDUs to synchronize the left and right channels. The approach to synchronize the left and right channels are the following. If two channels send their first SDU simultaneously, it is without a timestamp as the controller cannot provide a timestamp value using read_iso_tx_sync until after the first SDU has been sent. The first two SDUs will be given a timestamp by the controller. This timestamp is based on time of arrival. Unfortunate timings can lead to the two timestamps belonging to different CIG reference points. In this situation, read_iso_tx_sync will return different tx timestamps for the two channels. The channel that is behind must use the timestamp of the channel that is in front in time to catch up and synchronize.