### PR TITLE
applications: serial_lte_modem: allow modem AT command interception

### DIFF
--- a/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.c
+++ b/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.c
@@ -283,10 +283,10 @@ static int do_ftp_verbose(void)
 		return ret;
 	}
 
-	if (slm_util_cmd_casecmp(vb_mode, "ON")) {
+	if (slm_util_casecmp(vb_mode, "ON")) {
 		ftp_verbose_on = true;
 		rsp_send("\r\nVerbose mode on\r\n");
-	} else if (slm_util_cmd_casecmp(vb_mode, "OFF")) {
+	} else if (slm_util_casecmp(vb_mode, "OFF")) {
 		ftp_verbose_on = false;
 		rsp_send("\r\nVerbose mode off\r\n");
 	} else {

--- a/applications/serial_lte_modem/src/ftp_c/slm_at_tftp.c
+++ b/applications/serial_lte_modem/src/ftp_c/slm_at_tftp.c
@@ -169,9 +169,9 @@ int handle_at_tftp(enum at_cmd_type cmd_type)
 			if (err) {
 				return err;
 			}
-			if (!slm_util_cmd_casecmp(mode, "netascii") &&
-			    !slm_util_cmd_casecmp(mode, "octet") &&
-			    !slm_util_cmd_casecmp(mode, "mail")) {
+			if (!slm_util_casecmp(mode, "netascii") &&
+			    !slm_util_casecmp(mode, "octet") &&
+			    !slm_util_casecmp(mode, "mail")) {
 				return -EINVAL;
 			}
 		} else {

--- a/applications/serial_lte_modem/src/gnss/slm_at_gnss.c
+++ b/applications/serial_lte_modem/src/gnss/slm_at_gnss.c
@@ -99,15 +99,15 @@ static bool is_gnss_activated(void)
 	int cfun_mode = 0;
 
 	/*parse %XSYSTEMMODE=<LTE_M_support>,<NB_IoT_support>,<GNSS_support>,<LTE_preference> */
-	if (nrf_modem_at_scanf("AT%XSYSTEMMODE?",
-			       "%XSYSTEMMODE: %*d,%*d,%d", &activated) == 1) {
+	if (slm_util_at_scanf("AT%XSYSTEMMODE?",
+			       "%%XSYSTEMMODE: %*d,%*d,%d", &activated) == 1) {
 		if (activated == 0) {
 			return false;
 		}
 	}
 
 	/*parse +CFUN: <fun> */
-	if (nrf_modem_at_scanf("AT+CFUN?", "+CFUN: %d", &cfun_mode) == 1) {
+	if (slm_util_at_scanf("AT+CFUN?", "+CFUN: %d", &cfun_mode) == 1) {
 		if (cfun_mode == 1 || cfun_mode == 31) {
 			return true;
 		}

--- a/applications/serial_lte_modem/src/lwm2m_carrier/slm_at_carrier.c
+++ b/applications/serial_lte_modem/src/lwm2m_carrier/slm_at_carrier.c
@@ -213,7 +213,7 @@ int lwm2m_carrier_event_handler(const lwm2m_carrier_event_t *event)
 	case LWM2M_CARRIER_EVENT_LTE_POWER_OFF:
 		LOG_DBG("LWM2M_CARRIER_EVENT_LTE_POWER_OFF");
 		/* TODO: defer setting the modem to minimum funtional mode. */
-		err = nrf_modem_at_printf("AT+CFUN=0");
+		err = slm_util_at_printf("AT+CFUN=0");
 		break;
 	case LWM2M_CARRIER_EVENT_BOOTSTRAPPED:
 		LOG_DBG("LWM2M_CARRIER_EVENT_BOOTSTRAPPED");
@@ -414,9 +414,9 @@ static int do_carrier_device_error(void)
 		return ret;
 	}
 
-	if (slm_util_cmd_casecmp(operation, "ADD")) {
+	if (slm_util_casecmp(operation, "ADD")) {
 		return lwm2m_carrier_error_code_add(error_code);
-	} else if (slm_util_cmd_casecmp(operation, "REMOVE")) {
+	} else if (slm_util_casecmp(operation, "REMOVE")) {
 		return lwm2m_carrier_error_code_remove(error_code);
 	}
 
@@ -453,11 +453,11 @@ static int do_carrier_device_mem_free(void)
 		return ret;
 	}
 
-	if (slm_util_cmd_casecmp(operation, "read")) {
+	if (slm_util_casecmp(operation, "read")) {
 		memory = lwm2m_carrier_memory_free_read();
 
 		rsp_send("\r\n#XCARRIER: %d\r\n", memory);
-	} else if (slm_util_cmd_casecmp(operation, "write")) {
+	} else if (slm_util_casecmp(operation, "write")) {
 		ret = at_params_int_get(&slm_at_param_list, 3, &memory);
 		if (ret) {
 			return ret;
@@ -519,7 +519,7 @@ static int do_carrier_device_timezone(void)
 		return ret;
 	}
 
-	if (slm_util_cmd_casecmp(operation, "READ")) {
+	if (slm_util_casecmp(operation, "READ")) {
 		const char *timezone;
 
 		timezone = lwm2m_carrier_timezone_read();
@@ -531,7 +531,7 @@ static int do_carrier_device_timezone(void)
 		}
 
 		return 0;
-	} else if (slm_util_cmd_casecmp(operation, "WRITE")) {
+	} else if (slm_util_casecmp(operation, "WRITE")) {
 		char timezone[64];
 
 		size = sizeof(timezone);
@@ -593,13 +593,13 @@ static int do_carrier_device_utc_offset(void)
 		return ret;
 	}
 
-	if (slm_util_cmd_casecmp(operation, "READ")) {
+	if (slm_util_casecmp(operation, "READ")) {
 		utc_offset = lwm2m_carrier_utc_offset_read();
 
 		rsp_send("\r\n#XCARRIER: %d\r\n", utc_offset);
 
 		return 0;
-	} else if (slm_util_cmd_casecmp(operation, "WRITE")) {
+	} else if (slm_util_casecmp(operation, "WRITE")) {
 		ret = at_params_int_get(&slm_at_param_list, 3, &utc_offset);
 		if (ret) {
 			return ret;
@@ -626,14 +626,14 @@ static int do_carrier_device_utc_time(void)
 		return ret;
 	}
 
-	if (slm_util_cmd_casecmp(operation, "READ")) {
+	if (slm_util_casecmp(operation, "READ")) {
 		utc_time = lwm2m_carrier_utc_time_read();
 		print_utc_time(time_str, utc_time);
 
 		rsp_send("\r\n#XCARRIER: %s\r\n", time_str);
 
 		return 0;
-	} else if (slm_util_cmd_casecmp(operation, "WRITE")) {
+	} else if (slm_util_casecmp(operation, "WRITE")) {
 		ret = at_params_int_get(&slm_at_param_list, 3, &utc_time);
 		if (ret) {
 			return ret;
@@ -790,7 +790,7 @@ static int do_carrier_portfolio(void)
 		}
 	}
 
-	if (slm_util_cmd_casecmp(operation, "READ") && (param_count > 4)) {
+	if (slm_util_casecmp(operation, "READ") && (param_count > 4)) {
 		ret = lwm2m_carrier_identity_read(instance_id, identity_type, buffer, &buf_len);
 		if (ret) {
 			return ret;
@@ -799,7 +799,7 @@ static int do_carrier_portfolio(void)
 		rsp_send("\r\n#XCARRIER: %s\r\n", buffer);
 
 		return 0;
-	} else if (slm_util_cmd_casecmp(operation, "WRITE") && (param_count > 4)) {
+	} else if (slm_util_casecmp(operation, "WRITE") && (param_count > 4)) {
 		size = sizeof(buffer);
 
 		ret = util_string_get(&slm_at_param_list, 5, buffer, &size);
@@ -808,7 +808,7 @@ static int do_carrier_portfolio(void)
 		}
 
 		return lwm2m_carrier_identity_write(instance_id, identity_type, buffer);
-	} else if (slm_util_cmd_casecmp(operation, "CREATE")) {
+	} else if (slm_util_casecmp(operation, "CREATE")) {
 		return lwm2m_carrier_portfolio_instance_create(instance_id);
 	}
 

--- a/applications/serial_lte_modem/src/main.c
+++ b/applications/serial_lte_modem/src/main.c
@@ -356,34 +356,34 @@ int lte_auto_connect(void)
 #include "slm_auto_connect.h"
 	};
 
-	err = nrf_modem_at_scanf("AT+CEREG?", "+CEREG: %d", &stat);
+	err = slm_util_at_scanf("AT+CEREG?", "+CEREG: %d", &stat);
 	if (err != 1 || (stat == 1 || stat == 5)) {
 		return 0;
 	}
 
 	LOG_INF("lte auto connect");
-	err = nrf_modem_at_printf("AT%%XSYSTEMMODE=%d,%d,%d,%d", cfg.lte_m_support,
+	err = slm_util_at_printf("AT%%XSYSTEMMODE=%d,%d,%d,%d", cfg.lte_m_support,
 				  cfg.nb_iot_support, cfg.gnss_support, cfg.lte_preference);
 	if (err) {
 		LOG_ERR("Failed to configure system mode: %d", err);
 		return err;
 	}
 	if (cfg.pdp_config) {
-		err = nrf_modem_at_printf("AT+CGDCONT=0,%s,%s", cfg.pdn_fam, cfg.pdn_apn);
+		err = slm_util_at_printf("AT+CGDCONT=0,%s,%s", cfg.pdn_fam, cfg.pdn_apn);
 		if (err) {
 			LOG_ERR("Failed to configure PDN: %d", err);
 			return err;
 		}
 	}
 	if (cfg.pdp_config && cfg.pdn_auth != 0) {
-		err = nrf_modem_at_printf("AT+CGAUTH=0,%d,%s,%s", cfg.pdn_auth,
+		err = slm_util_at_printf("AT+CGAUTH=0,%d,%s,%s", cfg.pdn_auth,
 					  cfg.pdn_username, cfg.pdn_password);
 		if (err) {
 			LOG_ERR("Failed to configure AUTH: %d", err);
 			return err;
 		}
 	}
-	err = nrf_modem_at_printf("AT+CFUN=1");
+	err = slm_util_at_printf("AT+CFUN=1");
 	if (err) {
 		LOG_ERR("Failed to turn on radio: %d", err);
 		return err;

--- a/applications/serial_lte_modem/src/slm_at_fota.c
+++ b/applications/serial_lte_modem/src/slm_at_fota.c
@@ -216,13 +216,13 @@ static int do_fota_start(int op, const char *file_uri, int sec_tag,
 	}
 
 	/* start HTTP(S) FOTA */
-	if (slm_util_cmd_casecmp(schema, SCHEMA_HTTPS)) {
+	if (slm_util_casecmp(schema, SCHEMA_HTTPS)) {
 		if (sec_tag == INVALID_SEC_TAG) {
 			LOG_ERR("Missing sec_tag");
 			return -EINVAL;
 		}
 		ret = fota_download_start_with_image_type(hostname, path, sec_tag, pdn_id, 0, type);
-	} else if (slm_util_cmd_casecmp(schema, SCHEMA_HTTP)) {
+	} else if (slm_util_casecmp(schema, SCHEMA_HTTP)) {
 		ret = fota_download_start_with_image_type(hostname, path, -1, pdn_id, 0, type);
 	} else {
 		ret = -EINVAL;
@@ -428,20 +428,20 @@ void slm_fota_init_state(void)
 
 void slm_fota_post_process(void)
 {
+	if (slm_fota_stage != FOTA_STAGE_COMPLETE && slm_fota_stage != FOTA_STAGE_ACTIVATE) {
+		return;
+	}
 	LOG_INF("FOTA result %d,%d,%d", slm_fota_stage, slm_fota_status, slm_fota_info);
 
-	if (slm_fota_stage == FOTA_STAGE_COMPLETE || slm_fota_stage == FOTA_STAGE_ACTIVATE) {
-		/* report final result of last fota */
-		if (slm_fota_status == FOTA_STATUS_OK) {
-			rsp_send("\r\n#XFOTA: %d,%d\r\n", slm_fota_stage, slm_fota_status);
-		} else {
-			rsp_send("\r\n#XFOTA: %d,%d,%d\r\n", slm_fota_stage, slm_fota_status,
-				slm_fota_info);
-		}
-
-		slm_fota_init_state();
-		slm_settings_fota_save();
+	if (slm_fota_status == FOTA_STATUS_OK) {
+		rsp_send("\r\n#XFOTA: %d,%d\r\n", slm_fota_stage, slm_fota_status);
+	} else {
+		rsp_send("\r\n#XFOTA: %d,%d,%d\r\n", slm_fota_stage, slm_fota_status,
+			slm_fota_info);
 	}
+
+	slm_fota_init_state();
+	slm_settings_fota_save();
 }
 
 #if defined(CONFIG_SLM_FULL_FOTA)

--- a/applications/serial_lte_modem/src/slm_at_host.h
+++ b/applications/serial_lte_modem/src/slm_at_host.h
@@ -53,9 +53,13 @@ int slm_at_host_init(void);
 
 /**
  * @brief Uninitialize AT host for serial LTE modem
- *
  */
 void slm_at_host_uninit(void);
+
+/**
+ * @brief Runs the SLM-proprietary @c at_cmd if it is one.
+ */
+int slm_at_parse(const char *cmd_str, size_t cmd_name_len);
 
 /**
  * @brief Send AT command response
@@ -72,7 +76,6 @@ void rsp_send_ok(void);
 
 /**
  * @brief Send AT command response of ERROR
- *
  */
 void rsp_send_error(void);
 

--- a/applications/serial_lte_modem/src/slm_at_socket.c
+++ b/applications/serial_lte_modem/src/slm_at_socket.c
@@ -423,7 +423,7 @@ static int do_secure_socketopt_set_str(int option, const char *value)
 		/** Write-only socket option to set hostname. It accepts a string containing
 		 *  the hostname (may be NULL to disable hostname verification).
 		 */
-		if (slm_util_cmd_casecmp(value, "NULL")) {
+		if (slm_util_casecmp(value, "NULL")) {
 			ret = setsockopt(sock.fd, SOL_TLS, option, NULL, 0);
 		} else {
 			ret = setsockopt(sock.fd, SOL_TLS, option, value, strlen(value));

--- a/applications/serial_lte_modem/src/slm_defines.h
+++ b/applications/serial_lte_modem/src/slm_defines.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <zephyr/net/net_ip.h>
-#include <nrf_socket.h>
+#ifndef SLM_DEFINES_
+#define SLM_DEFINES_
 
-#ifndef SLM_AT_DEFINES_
-#define SLM_AT_DEFINES_
+#include <nrf_socket.h>
+#include "slm_trap_macros.h"
 
 #define INVALID_SOCKET       -1
 #define INVALID_SEC_TAG      -1
@@ -35,4 +35,4 @@
 #define SLM_NRF52_BLK_SIZE   4096 /** nRF52 flash block size for write operation */
 #define SLM_NRF52_BLK_TIME   2000 /** nRF52 flash block write time in millisecond (1.x second) */
 
-#endif /* SLM_AT_DEFINES_ */
+#endif

--- a/applications/serial_lte_modem/src/slm_native_tls.h
+++ b/applications/serial_lte_modem/src/slm_native_tls.h
@@ -16,6 +16,7 @@
 #include <zephyr/types.h>
 #include <zephyr/net/tls_credentials.h>
 #include <modem/modem_key_mgmt.h>
+#include "slm_trap_macros.h"
 
 #define MAX_SLM_SEC_TAG (INT_MAX/10)
 #define MIN_SLM_SEC_TAG 0

--- a/applications/serial_lte_modem/src/slm_settings.h
+++ b/applications/serial_lte_modem/src/slm_settings.h
@@ -12,6 +12,7 @@
  * @brief Utility functions for serial LTE modem settings.
  * @{
  */
+#include "slm_trap_macros.h"
 
 /**
  * @brief Loads the SLM settings from NVM.

--- a/applications/serial_lte_modem/src/slm_trap_macros.h
+++ b/applications/serial_lte_modem/src/slm_trap_macros.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef SLM_TRAP_MACROS_
+#define SLM_TRAP_MACROS_
+
+/** These functions are disallowed for the modem AT command
+ *  interception (using at_cmd_custom lib) to work properly.
+ *  For that, all the AT commands must go through @c nrf_modem_at_cmd() except
+ *  when forwarding intercepted AT commands from within the callbacks.
+ *  Alternatives to these functions are available in slm_util.h.
+ */
+#define nrf_modem_at_printf(...) function_disallowed_use_slm_util_alternative(void)
+#define nrf_modem_at_scanf(...) function_disallowed_use_slm_util_alternative(void)
+#define nrf_modem_at_cmd_async(...) function_disallowed(void)
+
+#endif

--- a/applications/serial_lte_modem/src/slm_uart_handler.c
+++ b/applications/serial_lte_modem/src/slm_uart_handler.c
@@ -12,7 +12,6 @@
 #include <zephyr/sys/ring_buffer.h>
 #include <zephyr/pm/device.h>
 #include <pm_config.h>
-#include "slm_settings.h"
 #include "slm_uart_handler.h"
 
 #include <zephyr/logging/log.h>

--- a/applications/serial_lte_modem/src/slm_uart_handler.h
+++ b/applications/serial_lte_modem/src/slm_uart_handler.h
@@ -12,6 +12,8 @@
  * @brief UART handler for serial LTE modem
  * @{
  */
+#include "slm_trap_macros.h"
+
 #define UART_RX_MARGIN_MS	10
 
 #define HEXDUMP_LIMIT		16

--- a/applications/serial_lte_modem/src/slm_util.c
+++ b/applications/serial_lte_modem/src/slm_util.c
@@ -7,14 +7,122 @@
 #include <string.h>
 #include <errno.h>
 #include <stdio.h>
+#include <nrf_errno.h>
 #include "slm_util.h"
 #include "slm_at_host.h"
 
-LOG_LEVEL_SET(CONFIG_SLM_LOG_LEVEL);
+LOG_MODULE_REGISTER(slm_util, CONFIG_SLM_LOG_LEVEL);
 
-/**
- * @brief Compare string ignoring case
+static bool cmd_name_has_lower(const char *cmd)
+{
+	for (size_t i = 0; cmd[i] != '\0'; ++i) {
+		const char c = cmd[i];
+
+		/* Set/test command names are delimited by '=', read by '?'. */
+		if (c == '=' || c == '?') {
+			break;
+		} else if (islower(c)) {
+			LOG_ERR("FIX ME: AT command \"%s\" must be all-uppercase.", cmd);
+			return true;
+		}
+	}
+	return false;
+}
+
+int slm_util_at_printf(const char *fmt, ...)
+{
+	int ret;
+	char buf[128];
+	va_list args;
+
+	va_start(args, fmt);
+	ret = vsnprintf(buf, sizeof(buf), fmt, args);
+	va_end(args);
+	if (ret >= sizeof(buf)) {
+		LOG_ERR("AT command \"%.16s...\" would get truncated from %u to %u bytes. "
+			"The buffer needs to be made bigger.", buf, ret, sizeof(buf) - 1);
+		return -E2BIG;
+	}
+
+	/* AT command interception is case-sensitive. */
+	if (cmd_name_has_lower(buf)) {
+		return -EINVAL;
+	}
+
+	/* Even though we are not interested in the AT response, it must fit
+	 * into the provided buffer so that the response code is returned.
+	 */
+	ret = nrf_modem_at_cmd(buf, sizeof(buf), "%s", buf);
+	if (ret == -NRF_E2BIG) {
+		/* Unlikely, but in that case the response code most likely didn't
+		 * make it into the buffer, so searching for it would be fruitless.
+		 */
+		LOG_ERR("AT response to \"%s\" didn't fit into %u bytes. "
+			"The buffer needs to be made bigger.", fmt, sizeof(buf) - 1);
+	}
+	return ret;
+}
+
+int slm_util_at_scanf(const char *cmd, const char *fmt, ...)
+{
+	char buf[128];
+	va_list args;
+	int ret;
+
+	/* AT command interception is case-sensitive. */
+	if (cmd_name_has_lower(cmd)) {
+		return -EINVAL;
+	}
+
+	ret = nrf_modem_at_cmd(buf, sizeof(buf), "%s", cmd);
+	if (ret == -NRF_E2BIG) {
+		LOG_ERR("AT response to \"%s\" truncated to %u bytes. "
+			"The buffer needs to be made bigger.", cmd, sizeof(buf) - 1);
+		buf[sizeof(buf) - 1] = '\0';
+	} else if (ret < 0) {
+		return ret;
+	}
+
+	va_start(args, fmt);
+	ret = vsscanf(buf, fmt, args);
+	va_end(args);
+
+	if (ret == 0) {
+		ret = -NRF_EBADMSG;
+	}
+	return ret;
+}
+
+int slm_util_at_cmd_fwd_from_cb(char *buf, size_t len, char *at_cmd)
+{
+/* This gets called by interception callbacks invoked by nrf_modem_at_cmd().
+ * Here nrf_modem_at_cmd() must be bypassed because it would otherwise call
+ * the same interception callbacks and infinite recursion would happen.
  */
+#undef nrf_modem_at_printf
+	const int ret = nrf_modem_at_printf("%s", at_cmd);
+
+/* Restore the trap macro after the only place where this function is
+ * allowed to be used so that other code does not accidentally use it.
+ */
+#define nrf_modem_at_printf nrf_modem_at_scanf
+
+	if (ret < 0) {
+		LOG_ERR("Forwarding of \"%s\" failed (%d).", at_cmd, ret);
+		return ret;
+	}
+
+	const int err = nrf_modem_at_err_type(ret);
+
+	if (!ret || err == NRF_MODEM_AT_ERROR) {
+		snprintf(buf, len, "%s\r\n", ret ? "ERROR" : "OK");
+	} else {
+		snprintf(buf, len, "+CM%c ERROR: %d\r\n",
+			err == NRF_MODEM_AT_CME_ERROR ? 'E' : 'S', nrf_modem_at_err(ret));
+	}
+	return ret;
+}
+
 bool slm_util_casecmp(const char *str1, const char *str2)
 {
 	int str2_len = strlen(str2);
@@ -32,40 +140,6 @@ bool slm_util_casecmp(const char *str1, const char *str2)
 	return true;
 }
 
-
-/**
- * @brief Compare name of AT command ignoring case
- */
-bool slm_util_cmd_casecmp(const char *cmd, const char *slm_cmd)
-{
-	int i;
-	int slm_cmd_len = strlen(slm_cmd);
-
-	if (strlen(cmd) < slm_cmd_len) {
-		return false;
-	}
-
-	for (i = 0; i < slm_cmd_len; i++) {
-		if (toupper((int)*(cmd + i)) != toupper((int)*(slm_cmd + i))) {
-			return false;
-		}
-	}
-#if defined(CONFIG_SLM_CR_LF_TERMINATION)
-	if (strlen(cmd) > (slm_cmd_len + 2)) {
-#else
-	if (strlen(cmd) > (slm_cmd_len + 1)) {
-#endif
-		char ch = *(cmd + i);
-		/* With parameter, SET TEST, "="; READ, "?" */
-		return ((ch == '=') || (ch == '?'));
-	}
-
-	return true;
-}
-
-/**
- * @brief Detect hexdecimal string data type
- */
 bool slm_util_hexstr_check(const uint8_t *data, uint16_t data_len)
 {
 	for (int i = 0; i < data_len; i++) {
@@ -81,9 +155,6 @@ bool slm_util_hexstr_check(const uint8_t *data, uint16_t data_len)
 	return true;
 }
 
-/**
- * @brief Encode hex array to hexdecimal string (ASCII text)
- */
 int slm_util_htoa(const uint8_t *hex, uint16_t hex_len, char *ascii, uint16_t ascii_len)
 {
 	if (hex == NULL || ascii == NULL) {
@@ -100,9 +171,6 @@ int slm_util_htoa(const uint8_t *hex, uint16_t hex_len, char *ascii, uint16_t as
 	return (hex_len * 2);
 }
 
-/**
- * @brief Decode hexdecimal string (ASCII text) to hex array
- */
 int slm_util_atoh(const char *ascii, uint16_t ascii_len, uint8_t *hex, uint16_t hex_len)
 {
 	char hex_str[3];
@@ -129,9 +197,6 @@ int slm_util_atoh(const char *ascii, uint16_t ascii_len, uint8_t *hex, uint16_t 
 	return (ascii_len / 2);
 }
 
-/**
- * @brief Get string value from AT command with length check
- */
 int util_string_get(const struct at_param_list *list, size_t index, char *value, size_t *len)
 {
 	int ret;
@@ -150,9 +215,6 @@ int util_string_get(const struct at_param_list *list, size_t index, char *value,
 	return -ENOMEM;
 }
 
-/**
- * @brief Get float value from string value input in AT command.
- */
 int util_string_to_float_get(const struct at_param_list *list, size_t index, float *value)
 {
 	int ret;
@@ -169,9 +231,6 @@ int util_string_to_float_get(const struct at_param_list *list, size_t index, flo
 	return 0;
 }
 
-/**
- * @brief Get double value from string value input in AT command.
- */
 int util_string_to_double_get(const struct at_param_list *list, size_t index, double *value)
 {
 	int ret;
@@ -188,9 +247,6 @@ int util_string_to_double_get(const struct at_param_list *list, size_t index, do
 	return 0;
 }
 
-/**
- * @brief use AT command to get IPv4 and/or IPv6 address for specified PDN
- */
 void util_get_ip_addr(int cid, char *addr4, char *addr6)
 {
 	int ret;
@@ -205,7 +261,7 @@ void util_get_ip_addr(int cid, char *addr4, char *addr6)
 	 * PDN type "IPV6": PDP_addr_1 is <IPv6>, max 46(INET6_ADDRSTRLEN),':', digits, 'A'~'F'
 	 * PDN type "IPV4V6": <IPv4>,<IPv6> or <IPV4> or <IPv6>
 	 */
-	ret = nrf_modem_at_scanf(cmd, "+CGPADDR: %*d,\"%46[.:0-9A-F]\",\"%46[:0-9A-F]\"",
+	ret = slm_util_at_scanf(cmd, "+CGPADDR: %*d,\"%46[.:0-9A-F]\",\"%46[:0-9A-F]\"",
 				 addr1, addr2);
 	if (ret <= 0) {
 		return;
@@ -225,9 +281,6 @@ void util_get_ip_addr(int cid, char *addr4, char *addr6)
 	}
 }
 
-/**
- * @brief Convert string to integer
- */
 int util_str_to_int(const char *str_buf, int base, int *output)
 {
 	int temp;
@@ -245,9 +298,6 @@ int util_str_to_int(const char *str_buf, int base, int *output)
 	return 0;
 }
 
-/**
- * @brief Resolve remote host by hostname or IP address
- */
 #define PORT_MAX_SIZE    5 /* 0xFFFF = 65535 */
 #define PDN_ID_MAX_SIZE  2 /* 0..10 */
 

--- a/applications/serial_lte_modem/src/slm_util.h
+++ b/applications/serial_lte_modem/src/slm_util.h
@@ -21,6 +21,23 @@
 
 extern struct k_work_q slm_work_q; /* SLM's work queue. */
 
+/** Replacement for @c nrf_modem_at_printf() that cannot be
+ *  used so that the AT command interception works properly.
+ */
+int slm_util_at_printf(const char *fmt, ...);
+
+/** Replacement for @c nrf_modem_at_scanf() that cannot be
+ *  used so that the AT command interception works properly.
+ */
+int slm_util_at_scanf(const char *cmd, const char *fmt, ...);
+
+/** Forwards an intercepted AT command to the modem library.
+ *  @warning This must and can only be called from interception callbacks.
+ *  @note As of now this only returns the AT response code from the modem.
+ *  @return The AT response code as an integer and its string representation in @c buf.
+ */
+int slm_util_at_cmd_fwd_from_cb(char *buf, size_t len, char *at_cmd);
+
 /**
  * @brief Compare string ignoring case
  *
@@ -30,16 +47,6 @@ extern struct k_work_q slm_work_q; /* SLM's work queue. */
  * @return true If two commands match, false if not.
  */
 bool slm_util_casecmp(const char *str1, const char *str2);
-
-/**
- * @brief Compare name of AT command ignoring case
- *
- * @param cmd Command string received from UART
- * @param slm_cmd Propreiatry command supported by SLM
- *
- * @return true If two commands match, false if not.
- */
-bool slm_util_cmd_casecmp(const char *cmd, const char *slm_cmd);
 
 /**
  * @brief Detect hexdecimal string data type

--- a/lib/at_cmd_custom/at_cmd_custom.c
+++ b/lib/at_cmd_custom/at_cmd_custom.c
@@ -26,7 +26,8 @@ static int at_cmd_custom_sys_init(void)
 	extern struct nrf_modem_at_cmd_custom _nrf_modem_at_cmd_custom_list_end[];
 
 	err = nrf_modem_at_cmd_custom_set(_nrf_modem_at_cmd_custom_list_start, CMD_COUNT);
-	LOG_INF("Custom AT commands enabled with %d entries.", CMD_COUNT);
+	LOG_INF("Custom AT commands enabled with %d entr%s.",
+		CMD_COUNT, CMD_COUNT > 1 ? "ies" : "y");
 
 	return err;
 }
@@ -39,7 +40,6 @@ int at_cmd_custom_respond(char *buf, size_t buf_size,
 	size_t buf_size_required;
 
 	if (buf == NULL) {
-		LOG_ERR("%s called with NULL buffer", __func__);
 		return -NRF_EFAULT;
 	}
 
@@ -47,9 +47,9 @@ int at_cmd_custom_respond(char *buf, size_t buf_size,
 	buf_size_required = vsnprintf(buf, buf_size, response, args);
 	va_end(args);
 
-	if (buf_size_required > buf_size) {
-		LOG_ERR("%s: formatted response exceeds the response buffer (%d > %d)",
-		__func__, buf_size_required, buf_size);
+	if (buf_size_required >= buf_size) {
+		LOG_WRN("formatted response too big for the response buffer (%d >= %d)",
+			buf_size_required, buf_size);
 		return -NRF_E2BIG;
 	}
 


### PR DESCRIPTION
For the interception to catch all AT commands, they all need to be sent through nrf_modem_at_cmd() because this is the only function covered by the modem library's callback feature.

This was already the case for AT commands received externally, but not for AT commands sent from the SLM code.

This implements alternative functions to nrf_modem_at_printf() and nrf_modem_at_scanf() as well as trap macros to prevent their use.

Also, because the interception is case-sensitive, all the AT commands sent are now all-uppercase.