### PR TITLE
nrf_security: Fix nrf_security enabling options with MBEDTLS disabled

### DIFF
--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -80,6 +80,7 @@ choice WPA_SUPP_CRYPTO_BACKEND
 # and one for the PSA crypto.
 config WPA_SUPP_CRYPTO_PSA
 	bool "PSA Crypto support for WiFi"
+	select MBEDTLS
 	select NRF_SECURITY
 	select PSA_WANT_KEY_TYPE_AES
 	select PSA_WANT_ALG_CMAC

--- a/subsys/nrf_security/Kconfig
+++ b/subsys/nrf_security/Kconfig
@@ -107,7 +107,7 @@ rsource "Kconfig.legacy"
 endif # NRF_SECURITY
 
 menu "Zephyr legacy configurations"
-	depends on !MBEDTLS_BUILTIN
+	depends on MBEDTLS_LIBRARY_NRF_SECURITY
 
 config MBEDTLS_TLS_VERSION_1_2
 	bool "Enable support for TLS 1.2 (DTLS 1.2)"

--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: c441a8dc1291faf8972964f2f944dfe2129a5ede
+      revision: 1687aaaac27cce09921a015a3f63c79666ebdc37
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Fix nrf_security enabling MBEDTLS options such as
MBEDTLS_MAC_SHA256_ENABLED when MBEDTLS itself is disabled.

Instead of enabling these options when not using MBEDTLS_BUILTIN only enabling these when the option to use the NRF_SECURITY mbedtls implementation choice.