### PR TITLE
doc: nrf: changelog: Add an entry for nRF70 debug doc

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -596,6 +596,10 @@ cJSON
 Documentation
 =============
 
+* Added
+
+  * A page on :ref:`ug_nrf70_developing_debugging` in the :ref:`ug_nrf70_developing` user guide.
+
 * Updated:
 
   * The :ref:`installation` section: by replacing two separate pages about installing the |NCS| with just one (:ref:`install_ncs`).


### PR DESCRIPTION
This was missed when the doc was added.