### PR TITLE
SoftDevice Controller: Update Kconfig entries managing event lengths

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -137,11 +137,15 @@ config BT_CTLR_SDC_MAX_CONN_EVENT_LEN_DEFAULT
 	int "Default max connection event length [us]"
 	default 10000 if BT_ISO && !BT_CTLR_SDC_MAX_CONN_EVENT_LEN_DEFAULT_OVERRIDE
 	default 7500 if !BT_CTLR_SDC_MAX_CONN_EVENT_LEN_DEFAULT_OVERRIDE
-	range 1250 4000000
+	range 0 4000000
 	help
 	  The time set aside for connections on every connection interval in
 	  microseconds. The event length and the connection interval are the
 	  primary parameters for setting the throughput of a connection.
+	  The event length may be set to a value that is shorter than the time needed
+	  for a single packet pair on a given PHY.
+	  In that case the controller will reserve time for receiving 27 bytes and transmitting
+	  the number of bytes configured with BT_CTLR_MIN_VAL_OF_MAX_ACL_TX_PAYLOAD_DEFAULT.
 
 config BT_CTLR_SDC_CENTRAL_ACL_EVENT_SPACING_DEFAULT
 	int "Default central ACL event spacing [us]"

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -154,6 +154,26 @@ config BT_CTLR_SDC_CENTRAL_ACL_EVENT_SPACING_DEFAULT
 	  timeline if the connection interval is longer than the ACL event spacing.
 	  This gap can be used for other scheduling activites like isochronous streams.
 
+config BT_CTLR_MIN_VAL_OF_MAX_ACL_TX_PAYLOAD_DEFAULT
+	int "Default minimum value that will be used as maximum Tx octets for ACL connections"
+	default 27
+	range 10 27
+	depends on BT_ISO && BT_CONN
+	help
+	  This configuration sets the minimum value of maximum ACL payload length that can be sent
+	  in each packet. If the configured event length is shorter than what is required to
+	  send a packet pair of 27 bytes in each direction, the controller will use this value to
+	  determine how much it can reduce the payload size to satisfy the event length requirements.
+	  LL Control PDUs are not affected by this API.
+	  Together with BT_CTLR_SDC_MAX_CONN_EVENT_LEN_DEFAULT this allows the controller to schedule
+	  ACLs events closer together with other activities.
+	  Setting this parameter to a lower value will result in more link layer fragmentation,
+	  reducing the maximum throughput.
+	  Setting this parameter to a value lower than 27 bytes may result in interoperability
+	  issues with older Bluetooth products. It is therefore not recommended to use this API
+	  for applications interacting with devices qualified for Bluetooth Specification 5.1 or
+	  older.
+
 config BT_CTLR_SDC_PERIODIC_ADV_EVENT_LEN_DEFAULT_OVERRIDE
 	bool "Override periodic adv event length default"
 

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -1238,6 +1238,20 @@ static int hci_driver_open(void)
 		}
 	}
 
+#if defined(BT_CTLR_MIN_VAL_OF_MAX_ACL_TX_PAYLOAD_DEFAULT)
+	if (CONFIG_BT_CTLR_MIN_VAL_OF_MAX_ACL_TX_PAYLOAD_DEFAULT != 27) {
+		sdc_hci_cmd_vs_min_val_of_max_acl_tx_payload_set_t params = {
+			.min_val_of_max_acl_tx_payload =
+				CONFIG_config BT_CTLR_MIN_VAL_OF_MAX_ACL_TX_PAYLOAD_DEFAULT
+		};
+		err = sdc_hci_cmd_vs_min_val_of_max_acl_tx_payload_set(&params);
+		if (err) {
+			MULTITHREADING_LOCK_RELEASE();
+			return -ENOTSUP;
+		}
+	}
+#endif
+
 	MULTITHREADING_LOCK_RELEASE();
 
 	return 0;

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -1242,7 +1242,7 @@ static int hci_driver_open(void)
 	if (CONFIG_BT_CTLR_MIN_VAL_OF_MAX_ACL_TX_PAYLOAD_DEFAULT != 27) {
 		sdc_hci_cmd_vs_min_val_of_max_acl_tx_payload_set_t params = {
 			.min_val_of_max_acl_tx_payload =
-				CONFIG_config BT_CTLR_MIN_VAL_OF_MAX_ACL_TX_PAYLOAD_DEFAULT
+				CONFIG_BT_CTLR_MIN_VAL_OF_MAX_ACL_TX_PAYLOAD_DEFAULT
 		};
 		err = sdc_hci_cmd_vs_min_val_of_max_acl_tx_payload_set(&params);
 		if (err) {


### PR DESCRIPTION
* BT_CTLR_SDC_MAX_CONN_EVENT_LEN_DEFAULT can now be set to 0
* New: BT_CTLR_MIN_VAL_OF_MAX_ACL_TX_PAYLOAD_DEFAULT. To allow packing events tighter