### PR TITLE
sysbuild: Prevent running PM on some boards

### DIFF
--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -278,14 +278,14 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_post_cmake)
   if(SB_CONFIG_PARTITION_MANAGER)
     # Run partition manager for each image before running CMake.
     include(${ZEPHYR_NRF_MODULE_DIR}/cmake/sysbuild/partition_manager.cmake OPTIONAL)
-  endif()
 
-  # Set PM variables up that applications need prior to PM having ran
-  get_property(PM_MCUBOOT_PRIMARY_SIZE TARGET partition_manager PROPERTY PM_MCUBOOT_PRIMARY_SIZE)
-  get_property(PM_MCUBOOT_PAD_SIZE TARGET partition_manager PROPERTY PM_MCUBOOT_PAD_SIZE)
+    # Set PM variables up that applications need prior to PM having ran
+    get_property(PM_MCUBOOT_PRIMARY_SIZE TARGET partition_manager PROPERTY PM_MCUBOOT_PRIMARY_SIZE)
+    get_property(PM_MCUBOOT_PAD_SIZE TARGET partition_manager PROPERTY PM_MCUBOOT_PAD_SIZE)
 
-  if(SB_CONFIG_SUPPORT_NETCORE AND NOT SB_CONFIG_NETCORE_EMPTY)
-    get_property(PM_MCUBOOT_PRIMARY_1_SIZE TARGET partition_manager PROPERTY PM_MCUBOOT_PRIMARY_1_SIZE)
+    if(SB_CONFIG_SUPPORT_NETCORE AND NOT SB_CONFIG_NETCORE_EMPTY)
+      get_property(PM_MCUBOOT_PRIMARY_1_SIZE TARGET partition_manager PROPERTY PM_MCUBOOT_PRIMARY_1_SIZE)
+    endif()
   endif()
 
   foreach(image ${IMAGES})

--- a/sysbuild/Kconfig.sysbuild
+++ b/sysbuild/Kconfig.sysbuild
@@ -8,7 +8,7 @@
 
 menuconfig PARTITION_MANAGER
 	bool "Partition Manager"
-	default y
+	default y if ($(BOARD) != "qemu_cortex_m0" && $(BOARD) != "qemu_cortex_m3" && $(BOARD) != "native_posix" && $(BOARD) != "native_posix_64")
 
 config PM_MCUBOOT_PAD
 	hex "Memory reserved for MCUBOOT_PAD"


### PR DESCRIPTION
Prevents running PM (by default) on some boards which are either native (linux) or emulated