### PR TITLE
samples: wifi: shutdown: Add an option to disable auto-start

### DIFF
--- a/samples/wifi/shutdown/README.rst
+++ b/samples/wifi/shutdown/README.rst
@@ -57,6 +57,18 @@ The following is an example of the CLI command to demonstrate Wi-Fi shutdown:
 
    west build -b nrf7002dk_nrf5340_cpuapp
 
+Disable auto-start of the Wi-Fi driver
+--------------------------------------
+
+The Wi-Fi network interface is automatically brought up when the Wi-Fi driver is initialized by default.
+You can disable it by setting the :kconfig:option:`CONFIG_WIFI_INIT_AUTO_START` Kconfig option to ``n``.
+
+.. code-block:: console
+
+   west build -b nrf7002dk_nrf5340_cpuapp -DCONFIG_NRF_WIFI_IF_AUTO_START=n
+
+With this configuration, the Wi-Fi network interface is not automatically brought up by the Zephyr networking stack.
+You must press **Button 1** to bring up the Wi-Fi network interface.
 
 Testing
 =======

--- a/samples/wifi/shutdown/src/main.c
+++ b/samples/wifi/shutdown/src/main.c
@@ -250,9 +250,11 @@ int main(void)
 
 	buttons_init();
 
+#ifdef CONFIG_NRF_WIFI_IF_AUTO_START
 	exit_shutdown_mode();
 
 	enter_shutdown_mode();
+#endif
 
 	k_sleep(K_FOREVER);
 


### PR DESCRIPTION
In case the interface auto-start is disabled, Wi-Fi driver initializes and waits for user to bring the interface up. This options is useful for customers that need finer control over when Wi-Fi driver starts comms to nRF70 chipset (depends on driver).

The sample doesn't attempt to bring the Wi-Fi until user presses the button1.

Implements NRF7X-109.