### PR TITLE
applications: serial_lte_modem: add optional path to #XCARRIEREVT

### DIFF
--- a/applications/serial_lte_modem/doc/CARRIER_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/CARRIER_AT_commands.rst
@@ -24,7 +24,7 @@ Syntax
 
 ::
 
-   #XCARRIEREVT: <evt_type>,<info>
+   #XCARRIEREVT: <evt_type>,<info>[,<path>]
    <data>
 
 * The ``<evt_type>`` value is an integer indicating the type of the event.
@@ -51,6 +51,9 @@ Syntax
   * ``0`` - Success or nothing to report.
   * *Negative value* - Failure or request to defer an application reboot or modem functional mode change.
   * *Positive value* - Number of bytes received through the App Data Container object or the Binary App Data Container object.
+
+* The ``<path>`` value is a string only present in an event of type ``11``.
+  It describes the URI path of the resource or the resource instance that received the data.
 
 * The ``<data>`` parameter is a string that contains the data received through the App Data Container object or the Binary App Data container object.
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -170,6 +170,7 @@ Serial LTE modem
   * ``#XMQTTCFG`` AT command to configure MQTT client before connecting to the broker.
   * The :ref:`CONFIG_SLM_AUTO_CONNECT <CONFIG_SLM_AUTO_CONNECT>` Kconfig option to support automatic LTE connection at start-up or reset.
   * The :ref:`CONFIG_SLM_CUSTOMER_VERSION <CONFIG_SLM_CUSTOMER_VERSION>` Kconfig option for customers to define their own version string after customization.
+  * The optional ``path`` parameter to the ``#XCARRIEREVT`` AT notification.
 
 * Updated:
 


### PR DESCRIPTION
LWM2M_CARRIER_EVENT_APP_DATA event now carries path information, as it applies to more than a single object. To eliminate the possible ambiguity, an optional URI path parameter is added to the #XCARRIEREVT AT notification.