### PR TITLE
manifest: Update tf-m for nrf91 fix

### DIFF
--- a/subsys/nonsecure/Kconfig
+++ b/subsys/nonsecure/Kconfig
@@ -279,7 +279,7 @@ config NRF_GPIOTE0_SECURE
 config NRF_GPIO0_PIN_MASK_SECURE
 	hex "Set GPIO0 PERM mask for Secure"
 	default 0x00000000
-	depends on HAS_HW_NRF_GPIO0 && !NRF_GPIO0_SECURE
+	depends on $(dt_nodelabel_has_compat,gpio0,$(DT_COMPAT_NORDIC_NRF_GPIO)) && !NRF_GPIO0_SECURE
 	help
 	  GPIO is implemented with split security. If it has been configured as
 	  non-secure it can be accessed by both secure and non-secure accesses.
@@ -290,7 +290,7 @@ config NRF_GPIO0_PIN_MASK_SECURE
 config NRF_GPIO1_PIN_MASK_SECURE
 	hex "Set GPIO1 PERM mask for Secure"
 	default 0x00000000
-	depends on HAS_HW_NRF_GPIO1 && !NRF_GPIO1_SECURE
+	depends on $(dt_nodelabel_has_compat,gpio1,$(DT_COMPAT_NORDIC_NRF_GPIO)) && !NRF_GPIO1_SECURE
 	help
 	  GPIO is implemented with split security. If it has been configured as
 	  non-secure it can be accessed by both secure and non-secure accesses.

--- a/west.yml
+++ b/west.yml
@@ -145,7 +145,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: v1.8.0-ncs1
+      revision: 1ceee76478554927bbe18dd206dfac5ea40ff100
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter


### PR DESCRIPTION
Fix nrf91 I2S and PDM peripherals not configured as non-secure.