### PR TITLE
scripts: Add memory thresholds' list

### DIFF
--- a/scripts/memory-threshold-list.yaml
+++ b/scripts/memory-threshold-list.yaml
@@ -1,0 +1,36 @@
+- scenarios:
+    - sample.matter.lock.release
+    - sample.matter.light_bulb.release
+  platforms:
+    - nrf52840dk_nrf52840
+  ram_size: 241664
+  rom_size: 778240
+
+- scenarios:
+    - sample.matter.lock.debug
+    - sample.matter.light_bulb.debug
+  platforms:
+    - nrf52840dk_nrf52840
+  ram_size: 241664
+  rom_size: 931840
+
+- scenarios:
+    - sample.matter.lock.release
+  platforms:
+    - nrf7002dk_nrf5340_cpuapp
+  ram_size: 503808
+  rom_size: 778240
+
+- scenarios:
+    - sample.matter.lock.debug
+  platforms:
+    - nrf7002dk_nrf5340_cpuapp
+  ram_size: 503808
+  rom_size: 942080
+
+- scenarios:
+    - applications.nrf_desktop.z.*
+  platforms:
+    - all
+  rom_related_usage: 512
+  ram_related_usage: 256


### PR DESCRIPTION
This commit is part of a solution addressing developers' need to be aware of increases of memory footprints of applications under their maintainership.
The list added in this commit stores information about configurations, whose memory footprints should be monitored in the CI. Additionally, this list contains thresholds passing of which will trigger an automated warning on PRs introducing such changes. This dictionary is used as an input by a script computing memory increases, called by the CI after the twister stage.

jira: NCSDK-23524