### PR TITLE
cmake: sysbuild: image_signing: Fix imgtool variable

### DIFF
--- a/cmake/sysbuild/image_signing.cmake
+++ b/cmake/sysbuild/image_signing.cmake
@@ -68,7 +68,7 @@ function(zephyr_mcuboot_tasks)
     return()
   endif()
 
-  set(imgtool_sign imgtool sign --version ${CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION} --align 4 --slot-size @PM_MCUBOOT_PRIMARY_SIZE@ --pad-header --header-size @PM_MCUBOOT_PAD_SIZE@ CACHE STRING "imgtool sign command")
+  set(imgtool_sign ${imgtool_path} sign --version ${CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION} --align 4 --slot-size @PM_MCUBOOT_PRIMARY_SIZE@ --pad-header --header-size @PM_MCUBOOT_PAD_SIZE@ CACHE STRING "imgtool sign command")
 
   # Arguments to imgtool.
   if(NOT CONFIG_MCUBOOT_EXTRA_IMGTOOL_ARGS STREQUAL "")


### PR DESCRIPTION
Fixes not using the located imgtool path tool when invoking the command