### PR TITLE
applications: Fixed setting parent ep id for the Matter bridge

### DIFF
--- a/samples/matter/common/src/bridge/Kconfig
+++ b/samples/matter/common/src/bridge/Kconfig
@@ -16,6 +16,10 @@ config BRIDGE_MAX_BRIDGED_DEVICES_NUMBER_PER_PROVIDER
 	int "Maximum number of endpoints paired to the one non-Matter provider device"
 	default 2
 
+config BRIDGE_AGGREGATOR_ENDPOINT_ID
+	int "Id of an endpoint implementing Aggregator device type functionality"
+	default 1
+
 if BRIDGED_DEVICE_BT
 
 config BRIDGE_BT_RECOVERY_INTERVAL_MS

--- a/samples/matter/common/src/bridge/bridge_manager.cpp
+++ b/samples/matter/common/src/bridge/bridge_manager.cpp
@@ -279,7 +279,7 @@ CHIP_ERROR BridgeManager::CreateEndpoint(uint8_t index, uint16_t endpointId)
 	EmberAfStatus ret = emberAfSetDynamicEndpoint(
 		index, endpointId, storedDevice->mEp,
 		Span<DataVersion>(storedDevice->mDataVersion, storedDevice->mDataVersionSize),
-		Span<const EmberAfDeviceType>(storedDevice->mDeviceTypeList, storedDevice->mDeviceTypeListSize));
+		Span<const EmberAfDeviceType>(storedDevice->mDeviceTypeList, storedDevice->mDeviceTypeListSize), kAggregatorEndpointId);
 
 	if (ret == EMBER_ZCL_STATUS_SUCCESS) {
 		LOG_INF("Added device to dynamic endpoint %d (index=%d)", endpointId, index);

--- a/samples/matter/common/src/bridge/bridge_manager.h
+++ b/samples/matter/common/src/bridge/bridge_manager.h
@@ -14,6 +14,7 @@ class BridgeManager {
 public:
 	static constexpr uint8_t kMaxBridgedDevices = CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;
 	static constexpr uint8_t kMaxBridgedDevicesPerProvider = CONFIG_BRIDGE_MAX_BRIDGED_DEVICES_NUMBER_PER_PROVIDER;
+	static constexpr chip::EndpointId kAggregatorEndpointId = CONFIG_BRIDGE_AGGREGATOR_ENDPOINT_ID;
 
 	using LoadStoredBridgedDevicesCallback = CHIP_ERROR (*)();
 


### PR DESCRIPTION
Currently in the Matter bridge the dynamic endpoints doesn't have parent id set, which makes them do not work with some commercial ecosystems. This change fixes it by setting parent endpoint it to 1 (Aggregator).