### PR TITLE
applications: MatterBridge: added support for mandatory clusters

### DIFF
--- a/applications/matter_bridge/src/bridged_device_types/humidity_sensor.cpp
+++ b/applications/matter_bridge/src/bridged_device_types/humidity_sensor.cpp
@@ -10,6 +10,7 @@ namespace
 {
 DESCRIPTOR_CLUSTER_ATTRIBUTES(descriptorAttrs);
 BRIDGED_DEVICE_BASIC_INFORMATION_CLUSTER_ATTRIBUTES(bridgedDeviceBasicAttrs);
+IDENTIFY_CLUSTER_ATTRIBUTES(identifyAttrs);
 }; /* namespace */
 
 using namespace ::chip;
@@ -27,7 +28,8 @@ DECLARE_DYNAMIC_ATTRIBUTE(Clusters::RelativeHumidityMeasurement::Attributes::Mea
 DECLARE_DYNAMIC_CLUSTER_LIST_BEGIN(bridgedHumidityClusters)
 DECLARE_DYNAMIC_CLUSTER(Clusters::RelativeHumidityMeasurement::Id, humiSensorAttrs, nullptr, nullptr),
 	DECLARE_DYNAMIC_CLUSTER(Clusters::Descriptor::Id, descriptorAttrs, nullptr, nullptr),
-	DECLARE_DYNAMIC_CLUSTER(Clusters::BridgedDeviceBasicInformation::Id, bridgedDeviceBasicAttrs, nullptr,
+	DECLARE_DYNAMIC_CLUSTER(Clusters::BridgedDeviceBasicInformation::Id, bridgedDeviceBasicAttrs, nullptr, nullptr),
+	DECLARE_DYNAMIC_CLUSTER(Clusters::Identify::Id, identifyAttrs, sIdentifyIncomingCommands,
 				nullptr) DECLARE_DYNAMIC_CLUSTER_LIST_END;
 
 DECLARE_DYNAMIC_ENDPOINT(bridgedHumidityEndpoint, bridgedHumidityClusters);
@@ -56,7 +58,8 @@ CHIP_ERROR HumiditySensorDevice::HandleRead(ClusterId clusterId, AttributeId att
 	switch (clusterId) {
 	case Clusters::RelativeHumidityMeasurement::Id:
 		return HandleReadRelativeHumidityMeasurement(attributeId, buffer, maxReadLength);
-		break;
+	case Clusters::Identify::Id:
+		return HandleReadIdentify(attributeId, buffer, maxReadLength);
 	default:
 		return CHIP_ERROR_INVALID_ARGUMENT;
 	}
@@ -102,6 +105,8 @@ CHIP_ERROR HumiditySensorDevice::HandleAttributeChange(chip::ClusterId clusterId
 	switch (clusterId) {
 	case Clusters::BridgedDeviceBasicInformation::Id:
 		return HandleWriteDeviceBasicInformation(clusterId, attributeId, data, dataSize);
+	case Clusters::Identify::Id:
+		return HandleWriteIdentify(attributeId, data, dataSize);
 	case Clusters::RelativeHumidityMeasurement::Id: {
 		switch (attributeId) {
 		case Clusters::RelativeHumidityMeasurement::Attributes::MeasuredValue::Id: {

--- a/applications/matter_bridge/src/bridged_device_types/humidity_sensor.h
+++ b/applications/matter_bridge/src/bridged_device_types/humidity_sensor.h
@@ -10,7 +10,7 @@
 
 class HumiditySensorDevice : public MatterBridgedDevice {
 public:
-	static constexpr uint16_t kRelativeHumidityMeasurementClusterRevision = 1;
+	static constexpr uint16_t kRelativeHumidityMeasurementClusterRevision = 4;
 	static constexpr uint32_t kRelativeHumidityMeasurementFeatureMap = 0;
 
 	HumiditySensorDevice(const char *nodeLabel);

--- a/applications/matter_bridge/src/bridged_device_types/onoff_light.cpp
+++ b/applications/matter_bridge/src/bridged_device_types/onoff_light.cpp
@@ -16,6 +16,7 @@ namespace
 {
 DESCRIPTOR_CLUSTER_ATTRIBUTES(descriptorAttrs);
 BRIDGED_DEVICE_BASIC_INFORMATION_CLUSTER_ATTRIBUTES(bridgedDeviceBasicAttrs);
+IDENTIFY_CLUSTER_ATTRIBUTES(identifyAttrs);
 }; /* namespace */
 
 using namespace ::chip;
@@ -32,7 +33,8 @@ constexpr CommandId onOffIncomingCommands[] = {
 };
 
 DECLARE_DYNAMIC_ATTRIBUTE_LIST_BEGIN(groupsAttrs)
-DECLARE_DYNAMIC_ATTRIBUTE(Clusters::Groups::Attributes::NameSupport::Id, BITMAP8, 1, 0), DECLARE_DYNAMIC_ATTRIBUTE_LIST_END();
+DECLARE_DYNAMIC_ATTRIBUTE(Clusters::Groups::Attributes::NameSupport::Id, BITMAP8, 1, 0),
+	DECLARE_DYNAMIC_ATTRIBUTE_LIST_END();
 
 constexpr CommandId groupsIncomingCommands[] = {
 	app::Clusters::Groups::Commands::AddGroup::Id,
@@ -48,7 +50,8 @@ DECLARE_DYNAMIC_CLUSTER_LIST_BEGIN(bridgedLightClusters)
 DECLARE_DYNAMIC_CLUSTER(Clusters::OnOff::Id, onOffAttrs, onOffIncomingCommands, nullptr),
 	DECLARE_DYNAMIC_CLUSTER(Clusters::Descriptor::Id, descriptorAttrs, nullptr, nullptr),
 	DECLARE_DYNAMIC_CLUSTER(Clusters::Groups::Id, groupsAttrs, groupsIncomingCommands, nullptr),
-	DECLARE_DYNAMIC_CLUSTER(Clusters::BridgedDeviceBasicInformation::Id, bridgedDeviceBasicAttrs, nullptr,
+	DECLARE_DYNAMIC_CLUSTER(Clusters::BridgedDeviceBasicInformation::Id, bridgedDeviceBasicAttrs, nullptr, nullptr),
+	DECLARE_DYNAMIC_CLUSTER(Clusters::Identify::Id, identifyAttrs, sIdentifyIncomingCommands,
 				nullptr) DECLARE_DYNAMIC_CLUSTER_LIST_END;
 
 DECLARE_DYNAMIC_ENDPOINT(bridgedLightEndpoint, bridgedLightClusters);
@@ -77,10 +80,10 @@ CHIP_ERROR OnOffLightDevice::HandleRead(ClusterId clusterId, AttributeId attribu
 	switch (clusterId) {
 	case Clusters::OnOff::Id:
 		return HandleReadOnOff(attributeId, buffer, maxReadLength);
-		break;
 	case Clusters::Groups::Id:
 		return HandleReadGroups(attributeId, buffer, maxReadLength);
-		break;
+	case Clusters::Identify::Id:
+		return HandleReadIdentify(attributeId, buffer, maxReadLength);
 	default:
 		return CHIP_ERROR_INVALID_ARGUMENT;
 	}
@@ -153,6 +156,8 @@ CHIP_ERROR OnOffLightDevice::HandleAttributeChange(chip::ClusterId clusterId, ch
 	switch (clusterId) {
 	case Clusters::BridgedDeviceBasicInformation::Id:
 		return HandleWriteDeviceBasicInformation(clusterId, attributeId, data, dataSize);
+	case Clusters::Identify::Id:
+		return HandleWriteIdentify(attributeId, data, dataSize);
 	case Clusters::OnOff::Id: {
 		switch (attributeId) {
 		case Clusters::OnOff::Attributes::OnOff::Id: {

--- a/applications/matter_bridge/src/bridged_device_types/onoff_light.h
+++ b/applications/matter_bridge/src/bridged_device_types/onoff_light.h
@@ -7,11 +7,10 @@
 #pragma once
 
 #include "matter_bridged_device.h"
-
 class OnOffLightDevice : public MatterBridgedDevice {
 public:
-	static constexpr uint16_t kOnOffClusterRevision = 1;
-	static constexpr uint32_t kOnOffFeatureMap = 0;
+	static constexpr uint16_t kOnOffClusterRevision = 4;
+	static constexpr uint32_t kOnOffFeatureMap = 1;
 	static constexpr uint16_t kGroupsClusterRevision = 4;
 	static constexpr uint32_t kGroupsFeatureMap = 0;
 	static constexpr uint8_t kGroupsNameSupportMap = 0;

--- a/applications/matter_bridge/src/bridged_device_types/temperature_sensor.cpp
+++ b/applications/matter_bridge/src/bridged_device_types/temperature_sensor.cpp
@@ -10,6 +10,7 @@ namespace
 {
 DESCRIPTOR_CLUSTER_ATTRIBUTES(descriptorAttrs);
 BRIDGED_DEVICE_BASIC_INFORMATION_CLUSTER_ATTRIBUTES(bridgedDeviceBasicAttrs);
+IDENTIFY_CLUSTER_ATTRIBUTES(identifyAttrs);
 }; /* namespace */
 
 using namespace ::chip;
@@ -25,7 +26,8 @@ DECLARE_DYNAMIC_ATTRIBUTE(Clusters::TemperatureMeasurement::Attributes::Measured
 DECLARE_DYNAMIC_CLUSTER_LIST_BEGIN(bridgedTemperatureClusters)
 DECLARE_DYNAMIC_CLUSTER(Clusters::TemperatureMeasurement::Id, tempSensorAttrs, nullptr, nullptr),
 	DECLARE_DYNAMIC_CLUSTER(Clusters::Descriptor::Id, descriptorAttrs, nullptr, nullptr),
-	DECLARE_DYNAMIC_CLUSTER(Clusters::BridgedDeviceBasicInformation::Id, bridgedDeviceBasicAttrs, nullptr,
+	DECLARE_DYNAMIC_CLUSTER(Clusters::BridgedDeviceBasicInformation::Id, bridgedDeviceBasicAttrs, nullptr, nullptr),
+	DECLARE_DYNAMIC_CLUSTER(Clusters::Identify::Id, identifyAttrs, sIdentifyIncomingCommands,
 				nullptr) DECLARE_DYNAMIC_CLUSTER_LIST_END;
 
 DECLARE_DYNAMIC_ENDPOINT(bridgedTemperatureEndpoint, bridgedTemperatureClusters);
@@ -54,7 +56,8 @@ CHIP_ERROR TemperatureSensorDevice::HandleRead(ClusterId clusterId, AttributeId 
 	switch (clusterId) {
 	case Clusters::TemperatureMeasurement::Id:
 		return HandleReadTemperatureMeasurement(attributeId, buffer, maxReadLength);
-		break;
+	case Clusters::Identify::Id:
+		return HandleReadIdentify(attributeId, buffer, maxReadLength);
 	default:
 		return CHIP_ERROR_INVALID_ARGUMENT;
 	}
@@ -100,6 +103,8 @@ CHIP_ERROR TemperatureSensorDevice::HandleAttributeChange(chip::ClusterId cluste
 	switch (clusterId) {
 	case Clusters::BridgedDeviceBasicInformation::Id:
 		return HandleWriteDeviceBasicInformation(clusterId, attributeId, data, dataSize);
+	case Clusters::Identify::Id:
+		return HandleWriteIdentify(attributeId, data, dataSize);
 	case Clusters::TemperatureMeasurement::Id: {
 		switch (attributeId) {
 		case Clusters::TemperatureMeasurement::Attributes::MeasuredValue::Id: {

--- a/applications/matter_bridge/src/bridged_device_types/temperature_sensor.h
+++ b/applications/matter_bridge/src/bridged_device_types/temperature_sensor.h
@@ -10,7 +10,7 @@
 
 class TemperatureSensorDevice : public MatterBridgedDevice {
 public:
-	static constexpr uint16_t kTemperatureMeasurementClusterRevision = 1;
+	static constexpr uint16_t kTemperatureMeasurementClusterRevision = 4;
 	static constexpr uint32_t kTemperatureMeasurementFeatureMap = 0;
 
 	TemperatureSensorDevice(const char *nodeLabel);

--- a/samples/matter/common/src/bridge/bridge_manager.cpp
+++ b/samples/matter/common/src/bridge/bridge_manager.cpp
@@ -341,8 +341,8 @@ CHIP_ERROR BridgeManager::HandleRead(uint16_t index, ClusterId clusterId,
 	case Clusters::BridgedDeviceBasicInformation::Id:
 		return device->HandleReadBridgedDeviceBasicInformation(attributeMetadata->attributeId, buffer,
 								       maxReadLength);
-	case Clusters::Descriptor::Id:
-		return device->HandleReadDescriptor(attributeMetadata->attributeId, buffer, maxReadLength);
+	case Clusters::Identify::Id:
+		return device->HandleReadIdentify(attributeMetadata->attributeId, buffer, maxReadLength);
 	default:
 		break;
 	}
@@ -363,6 +363,11 @@ CHIP_ERROR BridgeManager::HandleWrite(uint16_t index, ClusterId clusterId,
 
 	/* Verify if the device is reachable or we should return prematurely. */
 	VerifyOrReturnError(device->GetIsReachable(), CHIP_ERROR_INCORRECT_STATE);
+
+	/* Handle Identify cluster write - for now it does not imply updating the provider's state */
+	if (clusterId == Clusters::Identify::Id) {
+		return device->HandleWriteIdentify(attributeMetadata->attributeId, buffer, attributeMetadata->size);
+	}
 
 	CHIP_ERROR err = device->HandleWrite(clusterId, attributeMetadata->attributeId, buffer);
 

--- a/samples/matter/common/src/bridge/matter_bridged_device.h
+++ b/samples/matter/common/src/bridge/matter_bridged_device.h
@@ -8,6 +8,7 @@
 
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
+#include <app/clusters/identify-server/identify-server.h>
 #include <app/util/attribute-storage.h>
 
 /* Definitions of  helper macros that are used across all bridged device types to create common mandatory clusters in a
@@ -38,6 +39,35 @@
 			0), /* feature map */                                                                          \
 		DECLARE_DYNAMIC_ATTRIBUTE_LIST_END();
 
+/* Declare Bridged Device Identify cluster attributes */
+
+constexpr chip::CommandId sIdentifyIncomingCommands[] = {
+	chip::app::Clusters::Identify::Commands::Identify::Id,
+	chip::kInvalidCommandId,
+};
+
+#define IDENTIFY_CLUSTER_ATTRIBUTES(identifyAttrs)                                                                     \
+	DECLARE_DYNAMIC_ATTRIBUTE_LIST_BEGIN(identifyAttrs)                                                            \
+	DECLARE_DYNAMIC_ATTRIBUTE(chip::app::Clusters::Identify::Attributes::IdentifyTime::Id, INT16U, 2,              \
+				  ZAP_ATTRIBUTE_MASK(WRITABLE)), /* identify time*/                                    \
+		DECLARE_DYNAMIC_ATTRIBUTE(chip::app::Clusters::Identify::Attributes::IdentifyType::Id, ENUM8, 1,       \
+					  0), /* identify type */                                                      \
+		DECLARE_DYNAMIC_ATTRIBUTE(chip::app::Clusters::Identify::Attributes::FeatureMap::Id, BITMAP32, 4,      \
+					  0), /* feature map */                                                        \
+		DECLARE_DYNAMIC_ATTRIBUTE_LIST_END();
+
+inline void IdentifyStartDefaultCb(Identify *identify)
+{
+	VerifyOrReturn(identify);
+	ChipLogProgress(DeviceLayer, "Starting bridged device identify on endpoint %d", identify->mEndpoint);
+}
+
+inline void IdentifyStopDefaultCb(Identify *identify)
+{
+	VerifyOrReturn(identify);
+	ChipLogProgress(DeviceLayer, "Stopping bridged device identify on endpoint %d", identify->mEndpoint);
+}
+
 class MatterBridgedDevice {
 public:
 	enum DeviceType : uint16_t {
@@ -46,12 +76,14 @@ public:
 		TemperatureSensor = 0x0302,
 		HumiditySensor = 0x0307
 	};
-
+	using IdentifyType = chip::app::Clusters::Identify::IdentifyTypeEnum;
 	static constexpr uint8_t kDefaultDynamicEndpointVersion = 1;
 	static constexpr uint8_t kNodeLabelSize = 32;
 	static constexpr uint8_t kDescriptorAttributeArraySize = 254;
 
 	explicit MatterBridgedDevice(const char *nodeLabel)
+		: mIdentifyServer(mEndpointId, IdentifyStartDefaultCb, IdentifyStopDefaultCb,
+				  IdentifyType::kVisibleIndicator)
 	{
 		if (nodeLabel) {
 			memcpy(mNodeLabel, nodeLabel, strlen(nodeLabel));
@@ -59,7 +91,12 @@ public:
 	}
 	virtual ~MatterBridgedDevice() { chip::Platform::MemoryFree(mDataVersion); }
 
-	void Init(chip::EndpointId endpoint) { mEndpointId = endpoint; }
+	void Init(chip::EndpointId endpoint)
+	{
+		mEndpointId = endpoint;
+		mIdentifyServer.mEndpoint = mEndpointId;
+		ConfigureIdentifyServer(&mIdentifyServer);
+	}
 	chip::EndpointId GetEndpointId() const { return mEndpointId; }
 
 	virtual DeviceType GetDeviceType() const = 0;
@@ -68,22 +105,23 @@ public:
 	virtual CHIP_ERROR HandleWrite(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer) = 0;
 	virtual CHIP_ERROR HandleAttributeChange(chip::ClusterId clusterId, chip::AttributeId attributeId, void *data,
 						 size_t dataSize) = 0;
-	CHIP_ERROR CopyAttribute(void *attribute, size_t attributeSize, void *buffer, uint16_t maxBufferSize);
+
+	virtual void ConfigureIdentifyServer(Identify *identifyServer){};
+	CHIP_ERROR CopyAttribute(const void *attribute, size_t attributeSize, void *buffer, uint16_t maxBufferSize);
 	CHIP_ERROR HandleWriteDeviceBasicInformation(chip::ClusterId clusterId, chip::AttributeId attributeId,
 						     void *data, size_t dataSize);
 	CHIP_ERROR HandleReadBridgedDeviceBasicInformation(chip::AttributeId attributeId, uint8_t *buffer,
 							   uint16_t maxReadLength);
-	CHIP_ERROR HandleReadDescriptor(chip::AttributeId attributeId, uint8_t *buffer, uint16_t maxReadLength);
+
+	CHIP_ERROR HandleReadIdentify(chip::AttributeId attributeId, uint8_t *buffer, uint16_t maxReadLength);
+	CHIP_ERROR HandleWriteIdentify(chip::AttributeId attributeId, void *data, size_t dataSize);
 
 	bool GetIsReachable() const { return mIsReachable; }
 	const char *GetNodeLabel() const { return mNodeLabel; }
-	uint16_t GetBridgedDeviceBasicInformationClusterRevision()
-	{
-		return kBridgedDeviceBasicInformationClusterRevision;
-	}
-	uint32_t GetBridgedDeviceBasicInformationFeatureMap() { return kBridgedDeviceBasicInformationFeatureMap; }
-	uint16_t GetDescriptorClusterRevision() { return kDescriptorClusterRevision; }
-	uint32_t GetDescriptorFeatureMap() { return kDescrtiptorFeatureMap; }
+	static constexpr uint16_t GetBridgedDeviceBasicInformationClusterRevision() { return 2; }
+	static constexpr uint32_t GetBridgedDeviceBasicInformationFeatureMap() { return 0; }
+	static constexpr uint16_t GetIdentifyClusterRevision() { return 4; }
+	static constexpr uint32_t GetIdentifyClusterFeatureMap() { return 1; }
 
 	static void NotifyAttributeChange(intptr_t context);
 
@@ -96,14 +134,11 @@ public:
 protected:
 	void SetIsReachable(bool isReachable) { mIsReachable = isReachable; }
 
-	chip::EndpointId mEndpointId;
+	chip::EndpointId mEndpointId{};
 
 private:
-	static constexpr uint16_t kBridgedDeviceBasicInformationClusterRevision = 1;
-	static constexpr uint32_t kBridgedDeviceBasicInformationFeatureMap = 0;
-	static constexpr uint16_t kDescriptorClusterRevision = 1;
-	static constexpr uint32_t kDescrtiptorFeatureMap = 0;
-
 	bool mIsReachable = true;
 	char mNodeLabel[kNodeLabelSize] = "";
+	Identify mIdentifyServer;
+	uint16_t mIdentifyTime{};
 };


### PR DESCRIPTION
* implemented Identify cluster on all bridged devices
* aligned mandatory clusters' configuration
* removed redundant Descriptor cluster implementation