### PR TITLE
applications: nrf5340_audio: Define channel_mode for decoder on bidir gw

### DIFF
--- a/applications/nrf5340_audio/src/audio/audio_system.c
+++ b/applications/nrf5340_audio/src/audio/audio_system.c
@@ -54,6 +54,7 @@ static void audio_gateway_configure(void)
 #if (CONFIG_STREAM_BIDIRECTIONAL)
 	sw_codec_cfg.decoder.enabled = true;
 	sw_codec_cfg.decoder.num_ch = 1;
+	sw_codec_cfg.decoder.channel_mode = SW_CODEC_MONO;
 #endif /* (CONFIG_STREAM_BIDIRECTIONAL) */
 
 	if (IS_ENABLED(CONFIG_SW_CODEC_LC3)) {

--- a/applications/nrf5340_audio/src/audio/sw_codec_select.c
+++ b/applications/nrf5340_audio/src/audio/sw_codec_select.c
@@ -87,7 +87,8 @@ int sw_codec_encode(void *pcm_data, size_t pcm_size, uint8_t **encoded_data, siz
 			break;
 		}
 		default:
-			LOG_ERR("Unsupported number of channels: %d", m_config.encoder.num_ch);
+			LOG_ERR("Unsupported channel mode for encoder: %d",
+				m_config.encoder.channel_mode);
 			return -ENODEV;
 		}
 
@@ -183,7 +184,8 @@ int sw_codec_decode(uint8_t const *const encoded_data, size_t encoded_size, bool
 			break;
 		}
 		default:
-			LOG_ERR("Unsupported number of channels: %d", m_config.encoder.num_ch);
+			LOG_ERR("Unsupported channel mode for decoder: %d",
+				m_config.decoder.channel_mode);
 			return -ENODEV;
 		}
 


### PR DESCRIPTION
Fix bug where gateway got error
"Unsupported number of channels"
when doing bidir.