### PR TITLE
modules: hostap: Fix WFA mandatory features

### DIFF
--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -21,6 +21,15 @@ menuconfig WPA_SUPP
 
 if WPA_SUPP
 
+# Hidden as these are mandatory for WFA certification
+config WPA_SUPP_WMM_AC
+	bool
+	default y
+
+config WPA_SUPP_MBO
+	bool
+	default y
+
 # Memory optimizations
 config WPA_SUPP_ADVANCED_FEATURES
 	bool "Enable advanced features"
@@ -30,14 +39,6 @@ if WPA_SUPP_ADVANCED_FEATURES
 
 config WPA_SUPP_ROBUST_AV
 	bool "Robust Audio Video streaming support"
-	default y
-
-config WPA_SUPP_WMM_AC
-	bool "WMM admission control"
-	default y
-
-config WPA_SUPP_MBO
-	bool "Agile Multiband support"
 	default y
 
 config WPA_SUPP_WNM


### PR DESCRIPTION
MBO and WMM-AC are mandatory for WFA certification, so, cannot be disabled for memory saving.