### PR TITLE
applications: nrf5340_audio:Fixed changing broadcast source runtime i…

### DIFF
--- a/applications/nrf5340_audio/include/nrf5340_audio_common.h
+++ b/applications/nrf5340_audio/include/nrf5340_audio_common.h
@@ -34,6 +34,7 @@ struct le_audio_msg {
 	enum le_audio_evt_type event;
 	struct bt_conn *conn;
 	struct bt_le_per_adv_sync *pa_sync;
+	uint8_t sync_lost_reason;
 };
 
 struct sdu_ref_msg {

--- a/applications/nrf5340_audio/src/bluetooth/bt_management/scanning/bt_mgmt_scan_for_broadcast.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/scanning/bt_mgmt_scan_for_broadcast.c
@@ -220,11 +220,13 @@ static void pa_sync_terminated_cb(struct bt_le_per_adv_sync *sync,
 
 	LOG_DBG("Periodic advertising sync lost");
 
-	msg.event = BT_MGMT_PA_SYNC_LOST;
-	msg.pa_sync = sync;
+	if (info->reason != BT_HCI_ERR_LOCALHOST_TERM_CONN) {
+		msg.event = BT_MGMT_PA_SYNC_LOST;
+		msg.pa_sync = sync;
 
-	ret = zbus_chan_pub(&bt_mgmt_chan, &msg, K_NO_WAIT);
-	ERR_CHK(ret);
+		ret = zbus_chan_pub(&bt_mgmt_chan, &msg, K_NO_WAIT);
+		ERR_CHK(ret);
+	}
 }
 
 static struct bt_le_per_adv_sync_cb sync_callbacks = {

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/broadcast_sink.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/broadcast_sink.c
@@ -53,6 +53,7 @@ static struct audio_codec_info audio_codec_info[CONFIG_BT_BAP_BROADCAST_SNK_STRE
 static uint32_t bis_index_bitfields[CONFIG_BT_BAP_BROADCAST_SNK_STREAM_COUNT];
 
 static struct bt_le_per_adv_sync *pa_sync_stored;
+static uint8_t stream_stopped_reason;
 
 static struct active_audio_stream active_stream;
 
@@ -118,6 +119,7 @@ static void le_audio_event_publish(enum le_audio_evt_type event)
 
 	if (event == LE_AUDIO_EVT_SYNC_LOST) {
 		msg.pa_sync = pa_sync_stored;
+		msg.sync_lost_reason = stream_stopped_reason;
 		pa_sync_stored = NULL;
 	}
 
@@ -191,11 +193,12 @@ static void stream_started_cb(struct bt_bap_stream *stream)
 
 static void stream_stopped_cb(struct bt_bap_stream *stream, uint8_t reason)
 {
+	stream_stopped_reason = reason;
 
 	switch (reason) {
 	case BT_HCI_ERR_LOCALHOST_TERM_CONN:
 		LOG_INF("Stream stopped by user");
-		le_audio_event_publish(LE_AUDIO_EVT_NOT_STREAMING);
+		le_audio_event_publish(LE_AUDIO_EVT_SYNC_LOST);
 
 		break;
 


### PR DESCRIPTION
…ssue

* Delete PA sync before switch broadcaster
* Only trigger scan in PA sync lost if reason is not from local

OCT-2806
Signed-off-by: Jui-Chou Chung <jui-chou.chung@nordicsemi.no>