### PR TITLE
manifest: Update sdk-zephyr with nrfx 3.1 with fixes for NCS 2.5.1

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 90a72daae2c8715d760d974a7d294aa2eb6b38c4
+      revision: pull/1399/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pulls in switch of the remote for hal_nordic to nrfconnect/sdk-hal_nordic which contains hal_nordic with nrfx 3.1.0 with MDK 8.58.0 + minor fixes requested for the release