### PR TITLE
applications: serial_lte_modem: Fix #XSEND after #XSENDTO

### DIFF
--- a/applications/serial_lte_modem/src/slm_at_socket.c
+++ b/applications/serial_lte_modem/src/slm_at_socket.c
@@ -962,7 +962,7 @@ static int socket_datamode_callback(uint8_t op, const uint8_t *data, int len, ui
 		}
 	} else if (op == DATAMODE_EXIT) {
 		LOG_DBG("datamode exit");
-		memset(udp_url, 0x00, sizeof(udp_url));
+		memset(udp_url, 0, sizeof(udp_url));
 	}
 
 	return ret;
@@ -1477,6 +1477,7 @@ int handle_at_sendto(enum at_cmd_type cmd_type)
 				return err;
 			}
 			err = do_sendto(udp_url, udp_port, data, size);
+			memset(udp_url, 0, sizeof(udp_url));
 		} else {
 			err = enter_datamode(socket_datamode_callback);
 		}


### PR DESCRIPTION
For 2.5.1 release.