### PR TITLE
manifest: Update sdk-zephyr with nrfx 3.1 with fixes for NCS 2.5.1

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -128,7 +128,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: v1.10.99-ncs1
+      revision: edfe1e1465dbc698bf9a195816247913490ab391
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR.git

--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v3.4.99-ncs1
+      revision: 20d347899fef71940c24fb9a3f13e5dde7232c6b
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pulls in switch of the remote for hal_nordic to nrfconnect/sdk-hal_nordic which contains hal_nordic with nrfx 3.1.0 with MDK 8.58.0 + minor fixes requested for the release