### PR TITLE
Applications: nrf5340_audio: synchronize L-R channels with SDC.

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_client.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_client.c
@@ -1153,7 +1153,8 @@ static void disconnected_headset_cleanup(uint8_t chan_idx)
 	headsets[chan_idx].num_source_eps = 0;
 }
 
-static int iso_stream_send(uint8_t const *const data, size_t size, struct le_audio_headset *headset)
+static int iso_stream_send(uint8_t const *const data, size_t size, struct le_audio_headset *headset,
+			   uint32_t timestamp)
 {
 	int ret;
 	struct net_buf *buf;
@@ -1190,8 +1191,7 @@ static int iso_stream_send(uint8_t const *const data, size_t size, struct le_aud
 	atomic_inc(&headset->iso_tx_pool_alloc);
 
 	ret = bt_bap_stream_send(&headset->sink_stream, buf,
-				 get_and_incr_seq_num(&headset->sink_stream),
-				 BT_ISO_TIMESTAMP_NONE);
+				 get_and_incr_seq_num(&headset->sink_stream), timestamp);
 	if (ret < 0) {
 		LOG_WRN("Failed to send audio data to %s: %d", headset->ch_name, ret);
 		net_buf_unref(buf);
@@ -1308,10 +1308,23 @@ int unicast_client_stop(void)
 
 int unicast_client_send(struct le_audio_encoded_audio enc_audio)
 {
-	int ret;
+	int ret = 1;
 	size_t data_size_pr_stream;
 	struct bt_iso_tx_info tx_info = {0};
 	struct sdu_ref_msg msg;
+	static bool all_chan_ts_synced;
+
+	/* When only one channel is streaming,
+	 * there is no need to synchronize so data on this channel will be sent without
+	 * timestamp.
+	 * At the time when the other channel is set in streaming state,
+	 * the channels must be synchronized. This is achieved by first sending one SDU
+	 * without a timestamp on one channel. Read_iso_tx_sync will now return this SDU's P->C SDU
+	 * synchronization reference, which determines when the SDU will be sent. This P->C SDU
+	 * synchronization reference can be used as a timestamp for the SDU on the other channel,
+	 * ensuring that they both will have the same P->C SDU synchronization reference, and sent
+	 * at the same time.
+	 */
 
 	if ((enc_audio.num_ch == 1) || (enc_audio.num_ch == ARRAY_SIZE(headsets))) {
 		data_size_pr_stream = enc_audio.size / enc_audio.num_ch;
@@ -1325,22 +1338,90 @@ int unicast_client_send(struct le_audio_encoded_audio enc_audio)
 		return -EINVAL;
 	}
 
-	if (ep_state_check(headsets[AUDIO_CH_L].sink_stream.ep, BT_BAP_EP_STATE_STREAMING)) {
-		ret = bt_iso_chan_get_tx_sync(&headsets[AUDIO_CH_L].sink_stream.ep->iso->chan,
-					      &tx_info);
-	} else if (ep_state_check(headsets[AUDIO_CH_R].sink_stream.ep, BT_BAP_EP_STATE_STREAMING)) {
-		ret = bt_iso_chan_get_tx_sync(&headsets[AUDIO_CH_R].sink_stream.ep->iso->chan,
-					      &tx_info);
-	} else {
+	if (!ep_state_check(headsets[AUDIO_CH_L].sink_stream.ep, BT_BAP_EP_STATE_STREAMING) &&
+	    !ep_state_check(headsets[AUDIO_CH_R].sink_stream.ep, BT_BAP_EP_STATE_STREAMING)) {
 		/* This can happen if a headset is reset and the state in
 		 * streamctrl hasn't had time to update yet
 		 */
 		LOG_DBG("No headset in stream state");
 		return -ECANCELED;
-	}
+	} else if (ep_state_check(headsets[AUDIO_CH_L].sink_stream.ep, BT_BAP_EP_STATE_STREAMING) &&
+		   ep_state_check(headsets[AUDIO_CH_R].sink_stream.ep, BT_BAP_EP_STATE_STREAMING) &&
+		   !all_chan_ts_synced) {
+		/* We are transitioning from state where only one channel was streaming.
+		 * We know this because both channels are not synced. All channels needs to sync.
+		 */
 
-	if (ret) {
-		LOG_DBG("Error getting ISO TX anchor point: %d", ret);
+		ret = iso_stream_send(enc_audio.data, data_size_pr_stream, &headsets[AUDIO_CH_L],
+				      BT_ISO_TIMESTAMP_NONE);
+		if (ret) {
+			LOG_DBG("Failed to send data to left channel");
+		}
+
+		ret = bt_iso_chan_get_tx_sync(&headsets[AUDIO_CH_L].sink_stream.ep->iso->chan,
+					      &tx_info);
+
+		if (ret) {
+			LOG_DBG("Error getting ISO TX anchor point: %d", ret);
+		}
+		LOG_WRN("Syncing channels, left sync %u", tx_info.ts);
+
+		ret = iso_stream_send(enc_audio.data, data_size_pr_stream, &headsets[AUDIO_CH_R],
+				      tx_info.ts);
+
+		if (ret) {
+			LOG_DBG("Failed to send data to right channel");
+		}
+
+		all_chan_ts_synced = true;
+
+	} else {
+
+		bool all_channels_in_stream_state = true;
+
+		if (ep_state_check(headsets[AUDIO_CH_L].sink_stream.ep,
+				   BT_BAP_EP_STATE_STREAMING)) {
+
+			ret = iso_stream_send(enc_audio.data, data_size_pr_stream,
+					      &headsets[AUDIO_CH_L], BT_ISO_TIMESTAMP_NONE);
+			if (ret) {
+				LOG_DBG("Failed to send data to left channel");
+			}
+
+			ret = bt_iso_chan_get_tx_sync(
+				&headsets[AUDIO_CH_L].sink_stream.ep->iso->chan, &tx_info);
+		} else {
+			all_channels_in_stream_state = false;
+		}
+
+		if (ep_state_check(headsets[AUDIO_CH_R].sink_stream.ep,
+				   BT_BAP_EP_STATE_STREAMING)) {
+
+			if (enc_audio.num_ch == 1) {
+				ret = iso_stream_send(enc_audio.data, data_size_pr_stream,
+						      &headsets[AUDIO_CH_R], BT_ISO_TIMESTAMP_NONE);
+			} else {
+				ret = iso_stream_send(&enc_audio.data[data_size_pr_stream],
+						      data_size_pr_stream, &headsets[AUDIO_CH_R],
+						      BT_ISO_TIMESTAMP_NONE);
+			}
+			if (ret) {
+				LOG_DBG("Failed to send data to right channel");
+			}
+
+			ret = bt_iso_chan_get_tx_sync(
+				&headsets[AUDIO_CH_R].sink_stream.ep->iso->chan, &tx_info);
+		} else {
+			all_channels_in_stream_state = false;
+		}
+
+		if (!all_channels_in_stream_state) {
+			all_chan_ts_synced = false;
+		}
+
+		if (ret) {
+			LOG_DBG("Error getting ISO TX anchor point: %d", ret);
+		}
 	}
 
 	if (tx_info.ts != 0 && !ret) {
@@ -1352,26 +1433,6 @@ int unicast_client_send(struct le_audio_encoded_audio enc_audio)
 			if (ret) {
 				LOG_WRN("Failed to publish timestamp: %d", ret);
 			}
-		}
-	}
-
-	if (ep_state_check(headsets[AUDIO_CH_L].sink_stream.ep, BT_BAP_EP_STATE_STREAMING)) {
-		ret = iso_stream_send(enc_audio.data, data_size_pr_stream, &headsets[AUDIO_CH_L]);
-		if (ret) {
-			LOG_DBG("Failed to send data to left channel");
-		}
-	}
-
-	if (ep_state_check(headsets[AUDIO_CH_R].sink_stream.ep, BT_BAP_EP_STATE_STREAMING)) {
-		if (enc_audio.num_ch == 1) {
-			ret = iso_stream_send(enc_audio.data, data_size_pr_stream,
-					      &headsets[AUDIO_CH_R]);
-		} else {
-			ret = iso_stream_send(&enc_audio.data[data_size_pr_stream],
-					      data_size_pr_stream, &headsets[AUDIO_CH_R]);
-		}
-		if (ret) {
-			LOG_DBG("Failed to send data to right channel");
 		}
 	}
 

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_server.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_server.c
@@ -592,6 +592,7 @@ int unicast_server_send(struct le_audio_encoded_audio enc_audio)
 	net_buf_add_mem(buf, enc_audio.data, enc_audio.size);
 
 	atomic_inc(&iso_tx_pool_alloc);
+	/* No need to use timestamps here, as there is for now only one channel being sent back. */
 	ret = bt_bap_stream_send(sources[0].stream, buf, sources[0].seq_num++,
 				 BT_ISO_TIMESTAMP_NONE);
 	if (ret < 0) {


### PR DESCRIPTION
Use timestamps in SDUs to to synchronize L-R channels using SDC. When only one channel is streaming, there is no need to synchronize so data on this channel will be sent without timestamp. At the time when the other channel is set in streaming state, the channels must be synchronized. This is achieved by first sending one SDU without a timestamp on one channel. Read_iso_tx_sync will now return this SDU's P->C SDU synchronization reference, which determines when the SDU will be sent. This P->C SDU synchronization reference can be used as a timestamp for the SDU on the other channel, ensuring that they both will have the same P->C SDU synchronization reference, and sent at the same time.