### PR TITLE
manifest: sdk-hostap: Pull in fixes from MAIN

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -111,7 +111,7 @@ manifest:
     - name: hostap
       repo-path: sdk-hostap
       path: modules/lib/hostap
-      revision: d82c309c2e7eea5f08bbc1ac9e2f4c4622fbe998
+      revision: eb6119524273f65f64a7710fbd876c829094a216
       userdata:
         ncs:
           upstream-url: https://w1.fi/cgit/hostap/


### PR DESCRIPTION
* Fix for SHEL-2196
* Fix for SHEL-2212
* WPA3 failure in low-memory conditions

Note: As the changes from 2.5.0 are all critical fixes, not creating a v2.5 maintenance branch.