### PR TITLE
lib: lte_link_control: Improve Active-Time and periodic TAU reporting

### DIFF
--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -329,7 +329,7 @@ struct lte_lc_psm_cfg {
 	/** Periodic Tracking Area Update interval in seconds. */
 	int tau;
 
-	/** Active-time (time from RRC idle to PSM) in seconds. */
+	/** Active-time (time from RRC idle to PSM) in seconds or @c -1 if PSM is deactivated. */
 	int active_time;
 };
 
@@ -1466,10 +1466,9 @@ int lte_lc_psm_req(bool enable);
 /**
  * Get the current PSM (Power Saving Mode) configuration.
  *
- * @param[out] tau Periodic TAU interval in seconds. A non-negative integer,
- *                 or @c -1 if timer is deactivated.
+ * @param[out] tau Periodic TAU interval in seconds. A non-negative integer.
  * @param[out] active_time Active time in seconds. A non-negative integer,
- *                         or @c -1 if timer is deactivated.
+ *                         or @c -1 if PSM is deactivated.
  *
  * @retval 0 if successful.
  * @retval -EINVAL if input argument was invalid.

--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -876,7 +876,7 @@ int lte_lc_psm_get(int *tau, int *active_time)
 	 * <phys_cell_id>,<EARFCN>,<rsrp>,<snr>,<NW-provided_eDRX_value>,<Active-Time>,
 	 * <Periodic-TAUext>,<Periodic-TAU>]
 	 * We need to parse the three last parameters, Active-Time, Periodic-TAU-ext and
-	 * Periodic-TAU. N.B. Periodic-TAU will not be present on modem firmwares < 1.2.0.
+	 * Periodic-TAU.
 	 */
 
 	response[0] = '\0';
@@ -928,10 +928,12 @@ int lte_lc_psm_get(int *tau, int *active_time)
 		return -EBADMSG;
 	}
 
-	/* It's ok not to have legacy Periodic-TAU, older FWs don't provide it. */
 	comma_ptr = strchr(comma_ptr + 1, ch);
 	if (comma_ptr) {
 		strncpy(tau_legacy_str, comma_ptr + 2, 8);
+	} else {
+		LOG_ERR("AT command parsing failed");
+		return -EBADMSG;
 	}
 
 	err = parse_psm(active_time_str, tau_ext_str, tau_legacy_str, &psm_cfg);

--- a/lib/lte_link_control/lte_lc_helpers.h
+++ b/lib/lte_link_control/lte_lc_helpers.h
@@ -196,7 +196,7 @@ int parse_edrx(const char *at_response, struct lte_lc_edrx_cfg *cfg);
  *
  * @param active_time_str Pointer to active time string.
  * @param tau_ext_str Pointer to TAU (T3412 extended) string.
- * @param tau_legacy_str Pointer to TAU (T3412) string. Can be NULL.
+ * @param tau_legacy_str Pointer to TAU (T3412) string.
  * @param psm_cfg Pointer to PSM configuraion struct where the parsed values
  *		  are stored.
  *

--- a/tests/lib/lte_lc/src/main.c
+++ b/tests/lib/lte_lc/src/main.c
@@ -394,79 +394,117 @@ void test_parse_psm(void)
 		char *tau_ext;
 		char *tau_legacy;
 	};
-	struct psm_strings disabled = {
+	struct psm_strings psm_disabled_tau_ext = {
+		.active_time = "11100000",
+		.tau_ext = "00001000",
+		.tau_legacy = "11100000",
+	};
+	struct psm_strings psm_disabled_tau_legacy = {
 		.active_time = "11100000",
 		.tau_ext = "11100000",
-		.tau_legacy = "11100000",
+		.tau_legacy = "01001010",
 	};
 	struct psm_strings tau_legacy = {
 		.active_time = "00001000",
 		.tau_ext = "11100000",
 		.tau_legacy = "00101010",
 	};
-	struct psm_strings no_tau_legacy = {
+	struct psm_strings invalid_no_tau = {
 		.active_time = "00001000",
 		.tau_ext = "11100000",
+		.tau_legacy = "11100000",
 	};
 	struct psm_strings invalid_values = {
 		.active_time = "0001111111",
 		.tau_ext = "00001",
+		.tau_legacy = "111",
 	};
 	struct psm_strings valid_values_0 = {
 		.active_time = "01000001",
 		.tau_ext = "01000010",
+		.tau_legacy = "11100000",
 	};
 	struct psm_strings valid_values_1 = {
 		.active_time = "00100100",
 		.tau_ext = "00001000",
+		.tau_legacy = "11100000",
 	};
 	struct psm_strings valid_values_2 = {
 		.active_time = "00010000",
 		.tau_ext = "10111011",
+		.tau_legacy = "11100000",
 	};
 
-	err = parse_psm(disabled.active_time, disabled.tau_ext, disabled.tau_legacy, &psm_cfg);
+	err = parse_psm(psm_disabled_tau_ext.active_time,
+			psm_disabled_tau_ext.tau_ext,
+			psm_disabled_tau_ext.tau_legacy,
+			&psm_cfg);
 	TEST_ASSERT_EQUAL(0, err);
-	TEST_ASSERT_EQUAL(-1, psm_cfg.tau);
+	TEST_ASSERT_EQUAL(4800, psm_cfg.tau);
 	TEST_ASSERT_EQUAL(-1, psm_cfg.active_time);
 
 	memset(&psm_cfg, 0, sizeof(psm_cfg));
 
-	err = parse_psm(tau_legacy.active_time, tau_legacy.tau_ext, tau_legacy.tau_legacy,
-				&psm_cfg);
+	err = parse_psm(psm_disabled_tau_legacy.active_time,
+			psm_disabled_tau_legacy.tau_ext,
+			psm_disabled_tau_legacy.tau_legacy,
+			&psm_cfg);
+	TEST_ASSERT_EQUAL(0, err);
+	TEST_ASSERT_EQUAL(3600, psm_cfg.tau);
+	TEST_ASSERT_EQUAL(-1, psm_cfg.active_time);
+
+	memset(&psm_cfg, 0, sizeof(psm_cfg));
+
+	err = parse_psm(tau_legacy.active_time,
+			tau_legacy.tau_ext,
+			tau_legacy.tau_legacy,
+			&psm_cfg);
 	TEST_ASSERT_EQUAL(0, err);
 	TEST_ASSERT_EQUAL(600, psm_cfg.tau);
 	TEST_ASSERT_EQUAL(16, psm_cfg.active_time);
 
 	memset(&psm_cfg, 0, sizeof(psm_cfg));
 
-	err = parse_psm(no_tau_legacy.active_time, no_tau_legacy.tau_ext, NULL, &psm_cfg);
-	TEST_ASSERT_EQUAL(0, err);
-	TEST_ASSERT_EQUAL(-1, psm_cfg.tau);
-	TEST_ASSERT_EQUAL(16, psm_cfg.active_time);
-
-	memset(&psm_cfg, 0, sizeof(psm_cfg));
-
-	err = parse_psm(invalid_values.active_time, invalid_values.tau_ext, NULL, &psm_cfg);
+	err = parse_psm(invalid_no_tau.active_time,
+			invalid_no_tau.tau_ext,
+			invalid_no_tau.tau_legacy,
+			&psm_cfg);
 	TEST_ASSERT_EQUAL(-EINVAL, err);
 
 	memset(&psm_cfg, 0, sizeof(psm_cfg));
 
-	err = parse_psm(valid_values_0.active_time, valid_values_0.tau_ext, NULL, &psm_cfg);
+	err = parse_psm(invalid_values.active_time,
+			invalid_values.tau_ext,
+			invalid_values.tau_legacy,
+			&psm_cfg);
+	TEST_ASSERT_EQUAL(-EINVAL, err);
+
+	memset(&psm_cfg, 0, sizeof(psm_cfg));
+
+	err = parse_psm(valid_values_0.active_time,
+			valid_values_0.tau_ext,
+			valid_values_0.tau_legacy,
+			&psm_cfg);
 	TEST_ASSERT_EQUAL(0, err);
 	TEST_ASSERT_EQUAL(72000, psm_cfg.tau);
 	TEST_ASSERT_EQUAL(360, psm_cfg.active_time);
 
 	memset(&psm_cfg, 0, sizeof(psm_cfg));
 
-	err = parse_psm(valid_values_1.active_time, valid_values_1.tau_ext, NULL, &psm_cfg);
+	err = parse_psm(valid_values_1.active_time,
+			valid_values_1.tau_ext,
+			valid_values_1.tau_legacy,
+			&psm_cfg);
 	TEST_ASSERT_EQUAL(0, err);
 	TEST_ASSERT_EQUAL(4800, psm_cfg.tau);
 	TEST_ASSERT_EQUAL(240, psm_cfg.active_time);
 
 	memset(&psm_cfg, 0, sizeof(psm_cfg));
 
-	err = parse_psm(valid_values_2.active_time, valid_values_2.tau_ext, NULL, &psm_cfg);
+	err = parse_psm(valid_values_2.active_time,
+			valid_values_2.tau_ext,
+			valid_values_2.tau_legacy,
+			&psm_cfg);
 	TEST_ASSERT_EQUAL(0, err);
 	TEST_ASSERT_EQUAL(1620, psm_cfg.tau);
 	TEST_ASSERT_EQUAL(32, psm_cfg.active_time);


### PR DESCRIPTION
Improved Active-Time and periodic TAU interval descriptions in the API.

Improved periodic TAU interval parsing from `AT%XMONITOR` response. TAU is always reported either using T3412 extended or T3412 (legacy) timer by the network. If the TAU interval is missing, the API returns an error instead of `-1`, because periodic TAUs can not be disabled.