### PR TITLE
sysbuild: Add missing network core secure boot config and remove undefined code

### DIFF
--- a/subsys/bootloader/cmake/packaging.cmake
+++ b/subsys/bootloader/cmake/packaging.cmake
@@ -22,9 +22,10 @@ if(SB_CONFIG_DFU_MULTI_IMAGE_PACKAGE_BUILD)
   endif()
 
   if(SB_CONFIG_DFU_MULTI_IMAGE_PACKAGE_NET)
+    get_property(image_name GLOBAL PROPERTY DOMAIN_APP_CPUNET)
     list(APPEND dfu_multi_image_ids 1)
-    list(APPEND dfu_multi_image_paths "${PROJECT_BINARY_DIR}/signed_by_b0_${DOMAIN_APP_CPUNET}.bin")
-    list(APPEND dfu_multi_image_targets ${DOMAIN_APP_CPUNET}_extra_byproducts ${DOMAIN_APP_CPUNET}_signed_kernel_hex_target)
+    list(APPEND dfu_multi_image_paths "${PROJECT_BINARY_DIR}/signed_by_b0_${image_name}.bin")
+    list(APPEND dfu_multi_image_targets ${image_name}_extra_byproducts ${image_name}_signed_kernel_hex_target)
   endif()
 
   if(SB_CONFIG_DFU_MULTI_IMAGE_PACKAGE_MCUBOOT)

--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -330,6 +330,22 @@ if(SB_CONFIG_SECURE_BOOT)
                                             # hci, mpsl, thread, etc.
         "${secure_boot_image_dir}/secure_boot.conf"
       )
+    elseif(SB_CONFIG_NETCORE_RPC_HOST)
+      add_overlay_config(
+        ${SB_CONFIG_NETCORE_RPC_HOST_NAME}  # ToDo: Create a common Kconfig setting
+                                            # which can then default to the exact
+                                            # remote image selected, as to work for
+                                            # hci, mpsl, thread, etc.
+        "${secure_boot_image_dir}/secure_boot.conf"
+      )
+    elseif(SB_CONFIG_NETCORE_MULTIPROTOCOL_RPMSG)
+      add_overlay_config(
+        ${SB_CONFIG_NETCORE_MULTIPROTOCOL_RPMSG_NAME} # ToDo: Create a common Kconfig setting
+                                            # which can then default to the exact
+                                            # remote image selected, as to work for
+                                            # hci, mpsl, thread, etc.
+        "${secure_boot_image_dir}/secure_boot.conf"
+      )
     endif()
 
     add_overlay_config(mcuboot "${ZEPHYR_NRF_MODULE_DIR}/subsys/pcd/pcd.conf")

--- a/sysbuild/secureboot.cmake
+++ b/sysbuild/secureboot.cmake
@@ -25,12 +25,6 @@ if(SB_CONFIG_SECURE_BOOT)
         PM_CPUNET_IMAGES
         "b0n"
     )
-
-    if(SB_CONFIG_SECURE_BOOT_DOMAIN_APP)
-      set_property(GLOBAL PROPERTY DOMAIN_APP_CPUNET
-                   "b0n"
-      )
-    endif()
   endif()
 
   if(SB_CONFIG_SECURE_BOOT_APPCORE)
@@ -52,12 +46,6 @@ if(SB_CONFIG_SECURE_BOOT)
         PM_APP_IMAGES
         "b0"
     )
-
-    if(SB_CONFIG_SECURE_BOOT_DOMAIN_APP)
-      set_property(GLOBAL PROPERTY DOMAIN_APP_APP
-                   "b0"
-      )
-    endif()
   endif()
 
   if(SB_CONFIG_SECURE_BOOT_BUILD_S1_VARIANT_IMAGE)


### PR DESCRIPTION
    sysbuild: Add missing network core secure boot configuration
    
    Adds missing network core secure boot configuration for rpc_host
    and multiprotocol_rpc images


    sysbuild: Remove undefined code
    
    Removes code that seemingly has never done anything


    sysbuild: packaging: Fix network core image variables
    
    Fixes not fetching the network core image default image