### PR TITLE
doc: extensions: software_maturity_table: skip missing features

### DIFF
--- a/doc/_extensions/software_maturity_table.py
+++ b/doc/_extensions/software_maturity_table.py
@@ -148,7 +148,7 @@ class SoftwareMaturityTable(SphinxDirective):
         default_values = {}
 
         if table_type != "top_level" and table_type not in table_info["features"]:
-            logger.error(f"No information present for requested feature '{table_type}'")
+            logger.debug(f"No information present for requested feature '{table_type}'")
             return []
 
         all_socs = table_info["all_socs"]


### PR DESCRIPTION
If a feature is not available (e.g. homekit), just log it as a debug message but do not error, so the build can continue.