### PR TITLE
manifest: Update zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: cac385035be59178826590a46db63f5d3d800e66
+      revision: 86146714949810fd451dace302bd42ea4ecb3927
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull in a set of recent fixes and improvements in the nrf_qspi_nor driver, in particular the one that fixes the XIP initialization so that it works without any other QSPI transfer performed before.