### PR TITLE
applications: serial_lte_modem: fix AT#XGPS documentation example

### DIFF
--- a/applications/serial_lte_modem/doc/GNSS_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/GNSS_AT_commands.rst
@@ -146,7 +146,7 @@ Example
   AT+CFUN=31
 
   OK
-  AT#XGPS=1,0,0,0,0
+  AT#XGPS=1,0,0,0
 
   #XGPS: 1,1
 


### PR DESCRIPTION
One parameter too many.