### PR TITLE
[backport-v2.5] manifest: Update zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 20d347899fef71940c24fb9a3f13e5dde7232c6b
+      revision: pull/1401/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull in a fix in the XIP enabling function in the nrf_qspi_nor driver so that XIP works without any other QSPI transfer performed before.