### PR TITLE
applications: Matter Bridge: extend CLI with data provider setters

### DIFF
--- a/applications/matter_bridge/Kconfig
+++ b/applications/matter_bridge/Kconfig
@@ -36,6 +36,28 @@ choice BRIDGED_DEVICE_IMPLEMENTATION
 
 endchoice
 
+if BRIDGED_DEVICE_SIMULATED
+
+choice BRIDGED_DEVICE_SIMULATED_ONOFF_IMPLEMENTATION
+	prompt "Simulated bridged onoff device implementation"
+	default BRIDGED_DEVICE_SIMULATED_ONOFF_SHELL
+
+	config BRIDGED_DEVICE_SIMULATED_ONOFF_AUTOMATIC
+		bool "Automatically simulated bridged onoff device"
+		help
+		  Enables using simulated bridged onoff device that
+		  automatically changes its state periodically.
+
+	config BRIDGED_DEVICE_SIMULATED_ONOFF_SHELL
+		bool "Shell controlled simulated bridged onoff device"
+		help
+		  Enables using simulated bridged onoff device that is
+		  controlled by shell commands.
+
+endchoice
+
+endif
+
 if BRIDGED_DEVICE_BT
 
 config BT_CENTRAL

--- a/applications/matter_bridge/README.rst
+++ b/applications/matter_bridge/README.rst
@@ -220,6 +220,28 @@ Adding a simulated bridged device to the Matter bridge
 
       uart:~$ matter_bridge add 256 "Kitchen Light"
 
+Controlling a simulated OnOff Light bridged device
+   Use the following command:
+
+   .. parsed-literal::
+      :class: highlight
+
+      matter_bridge onoff *<new_state>* *<endpoint>*
+
+   In this command:
+
+   * *<new_state>*  is the new state (``0`` - off and ``1`` - on) that will be set on the simulated OnOff Light device.
+   * *<endpoint>*  is the endpoint on which the bridged OnOff Light device is implemented
+
+   Example command:
+
+   .. code-block:: console
+
+      uart:~$ matter_bridge onoff 1 3
+
+   Note that the above command will only work if the :kconfig:option:`CONFIG_BRIDGED_DEVICE_SIMULATED_ONOFF_SHELL` option is selected in the build configuration.
+   If the Kconfig option is not selected, the simulated device changes its state periodically in autonomous manner and can not be controlled by using shell commands.
+
 Adding a Bluetooth LE bridged device to the Matter bridge
    Use the following command:
 
@@ -279,6 +301,14 @@ You can enable the :ref:`matter_bridge_app_bridged_support` by using the followi
 
 * :kconfig:option:`CONFIG_BRIDGED_DEVICE_SIMULATED` - For the simulated bridged device.
 * :kconfig:option:`CONFIG_BRIDGED_DEVICE_BT` - For the Bluetooth LE bridged device.
+
+The simulated OnOff Light bridged device can operate in the following modes:
+
+* Autonomous - The simulated device periodically changes its state.
+  To build the simulated OnOff Light data provider in this mode, select the :kconfig:option:`CONFIG_BRIDGED_DEVICE_SIMULATED_ONOFF_AUTOMATIC` Kconfig option.
+* Controllable - The user can explicitly control the On/Off state by using shell commands.
+  To build the simulated OnOff Light data provider in this mode, select the :kconfig:option:`CONFIG_BRIDGED_DEVICE_SIMULATED_ONOFF_SHELL` Kconfig option.
+  This is enabled by default.
 
 Additionally, you can decide how many bridged devices the bridge application will support.
 The decision will make an impact on the flash and RAM memory usage, and is verified in the compilation stage.

--- a/applications/matter_bridge/src/ble_providers/ble_environmental_data_provider.cpp
+++ b/applications/matter_bridge/src/ble_providers/ble_environmental_data_provider.cpp
@@ -270,7 +270,8 @@ uint8_t BleEnvironmentalDataProvider::HumidityGATTReadCallback(bt_conn *conn, ui
 	VerifyOrReturnValue(provider, BT_GATT_ITER_STOP, LOG_ERR("Invalid provider object"));
 
 	if (!att_err && (read_len == sizeof(provider->mHumidityValue))) {
-		const uint16_t newValue = *(static_cast<const uint16_t *>(data));
+		uint16_t newValue{};
+		memcpy(&newValue, data, sizeof(newValue));
 		if (newValue != provider->mHumidityValue) {
 			provider->mHumidityValue = newValue;
 			DeviceLayer::PlatformMgr().ScheduleWork(NotifyHumidityAttributeChange,

--- a/applications/matter_bridge/src/simulated_providers/simulated_humidity_sensor_data_provider.h
+++ b/applications/matter_bridge/src/simulated_providers/simulated_humidity_sensor_data_provider.h
@@ -10,22 +10,22 @@
 
 class SimulatedHumiditySensorDataProvider : public BridgedDeviceDataProvider {
 public:
-	static constexpr uint16_t kMeasurementsIntervalMs = 10000;
-	static constexpr uint16_t kMinRandomTemperature = 30;
-	static constexpr uint16_t kMaxRandomTemperature = 50;
-
 	SimulatedHumiditySensorDataProvider(UpdateAttributeCallback callback) : BridgedDeviceDataProvider(callback) {}
 	~SimulatedHumiditySensorDataProvider() { k_timer_stop(&mTimer); }
-
 	void Init() override;
 	void NotifyUpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId, void *data,
 			       size_t dataSize) override;
 	CHIP_ERROR UpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer) override;
 
-	static void TimerTimeoutCallback(k_timer *timer);
 	static void NotifyAttributeChange(intptr_t context);
 
 private:
+	static void TimerTimeoutCallback(k_timer *timer);
+
+	static constexpr uint16_t kMeasurementsIntervalMs = 10000;
+	static constexpr uint16_t kMinRandomTemperature = 30;
+	static constexpr uint16_t kMaxRandomTemperature = 50;
+
 	k_timer mTimer;
 	uint16_t mHumidity = 0;
 };

--- a/applications/matter_bridge/src/simulated_providers/simulated_onoff_light_data_provider.cpp
+++ b/applications/matter_bridge/src/simulated_providers/simulated_onoff_light_data_provider.cpp
@@ -15,9 +15,11 @@ using namespace ::chip::app;
 
 void SimulatedOnOffLightDataProvider::Init()
 {
+#ifdef CONFIG_BRIDGED_DEVICE_SIMULATED_ONOFF_AUTOMATIC
 	k_timer_init(&mTimer, SimulatedOnOffLightDataProvider::TimerTimeoutCallback, nullptr);
 	k_timer_user_data_set(&mTimer, this);
 	k_timer_start(&mTimer, K_MSEC(kOnOffIntervalMs), K_MSEC(kOnOffIntervalMs));
+#endif
 }
 
 void SimulatedOnOffLightDataProvider::NotifyUpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId,
@@ -41,7 +43,7 @@ CHIP_ERROR SimulatedOnOffLightDataProvider::UpdateState(chip::ClusterId clusterI
 
 	switch (attributeId) {
 	case Clusters::OnOff::Attributes::OnOff::Id: {
-		mOnOff = *buffer;
+		memcpy(&mOnOff, buffer, sizeof(mOnOff));
 		NotifyUpdateState(clusterId, attributeId, &mOnOff, sizeof(mOnOff));
 		return CHIP_NO_ERROR;
 	}
@@ -52,6 +54,7 @@ CHIP_ERROR SimulatedOnOffLightDataProvider::UpdateState(chip::ClusterId clusterI
 	return CHIP_NO_ERROR;
 }
 
+#ifdef CONFIG_BRIDGED_DEVICE_SIMULATED_ONOFF_AUTOMATIC
 void SimulatedOnOffLightDataProvider::TimerTimeoutCallback(k_timer *timer)
 {
 	if (!timer || !timer->user_data) {
@@ -68,6 +71,7 @@ void SimulatedOnOffLightDataProvider::TimerTimeoutCallback(k_timer *timer)
 
 	DeviceLayer::PlatformMgr().ScheduleWork(NotifyAttributeChange, reinterpret_cast<intptr_t>(provider));
 }
+#endif
 
 void SimulatedOnOffLightDataProvider::NotifyAttributeChange(intptr_t context)
 {

--- a/applications/matter_bridge/src/simulated_providers/simulated_onoff_light_data_provider.h
+++ b/applications/matter_bridge/src/simulated_providers/simulated_onoff_light_data_provider.h
@@ -10,20 +10,26 @@
 
 class SimulatedOnOffLightDataProvider : public BridgedDeviceDataProvider {
 public:
-	static constexpr uint16_t kOnOffIntervalMs = 30000;
-
 	SimulatedOnOffLightDataProvider(UpdateAttributeCallback callback) : BridgedDeviceDataProvider(callback) {}
-	~SimulatedOnOffLightDataProvider() { k_timer_stop(&mTimer); }
+	~SimulatedOnOffLightDataProvider()
+	{
+#ifdef CONFIG_BRIDGED_DEVICE_SIMULATED_ONOFF_AUTOMATIC
+		k_timer_stop(&mTimer);
+#endif
+	}
 
 	void Init() override;
 	void NotifyUpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId, void *data,
 			       size_t dataSize) override;
 	CHIP_ERROR UpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer) override;
 
-	static void TimerTimeoutCallback(k_timer *timer);
+private:
 	static void NotifyAttributeChange(intptr_t context);
 
-private:
+#ifdef CONFIG_BRIDGED_DEVICE_SIMULATED_ONOFF_AUTOMATIC
+	static void TimerTimeoutCallback(k_timer *timer);
+	static constexpr uint16_t kOnOffIntervalMs = 30000;
 	k_timer mTimer;
+#endif
 	bool mOnOff = false;
 };

--- a/applications/matter_bridge/src/simulated_providers/simulated_temperature_sensor_data_provider.h
+++ b/applications/matter_bridge/src/simulated_providers/simulated_temperature_sensor_data_provider.h
@@ -12,10 +12,6 @@
 
 class SimulatedTemperatureSensorDataProvider : public BridgedDeviceDataProvider {
 public:
-	static constexpr uint16_t kMeasurementsIntervalMs = 10000;
-	static constexpr int16_t kMinRandomTemperature = -10;
-	static constexpr int16_t kMaxRandomTemperature = 10;
-
 	SimulatedTemperatureSensorDataProvider(UpdateAttributeCallback callback) : BridgedDeviceDataProvider(callback)
 	{
 	}
@@ -26,10 +22,15 @@ public:
 			       size_t dataSize) override;
 	CHIP_ERROR UpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer) override;
 
-	static void TimerTimeoutCallback(k_timer *timer);
+private:
 	static void NotifyAttributeChange(intptr_t context);
 
-private:
+	static constexpr uint16_t kMeasurementsIntervalMs = 10000;
+	static constexpr int16_t kMinRandomTemperature = -10;
+	static constexpr int16_t kMaxRandomTemperature = 10;
+
+	static void TimerTimeoutCallback(k_timer *timer);
+
 	k_timer mTimer;
 	int16_t mTemperature = 0;
 };

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -208,7 +208,10 @@ Thingy:53: Matter weather station
 Matter Bridge
 -------------
 
-* Added support for groupcast communication to the On/Off Light device implementation.
+* Added:
+
+  * Support for groupcast communication to the On/Off Light device implementation.
+  * Support for controlling the OnOff Light simulated data provider by using shell commands.
 
 Samples
 =======

--- a/samples/matter/common/src/bridge/bridge_manager.cpp
+++ b/samples/matter/common/src/bridge/bridge_manager.cpp
@@ -255,7 +255,7 @@ CHIP_ERROR BridgeManager::AddSingleDevice(MatterBridgedDevice *device, BridgedDe
 
 					return err;
 				} else {
-					/* Failing Insert metod means the BridgedDevicePair destructor will be called
+					/* Failing Insert method means the BridgedDevicePair destructor will be called
 					 * and pointers wiped out. It's not safe to iterate further. */
 					return CHIP_ERROR_INTERNAL;
 				}
@@ -279,7 +279,8 @@ CHIP_ERROR BridgeManager::CreateEndpoint(uint8_t index, uint16_t endpointId)
 	EmberAfStatus ret = emberAfSetDynamicEndpoint(
 		index, endpointId, storedDevice->mEp,
 		Span<DataVersion>(storedDevice->mDataVersion, storedDevice->mDataVersionSize),
-		Span<const EmberAfDeviceType>(storedDevice->mDeviceTypeList, storedDevice->mDeviceTypeListSize), kAggregatorEndpointId);
+		Span<const EmberAfDeviceType>(storedDevice->mDeviceTypeList, storedDevice->mDeviceTypeListSize),
+		kAggregatorEndpointId);
 
 	if (ret == EMBER_ZCL_STATUS_SUCCESS) {
 		LOG_INF("Added device to dynamic endpoint %d (index=%d)", endpointId, index);
@@ -396,6 +397,17 @@ void BridgeManager::HandleUpdate(BridgedDeviceDataProvider &dataProvider, Cluste
 			}
 		}
 	}
+}
+
+BridgedDeviceDataProvider *BridgeManager::GetProvider(EndpointId endpoint, MatterBridgedDevice::DeviceType &deviceType)
+{
+	uint16_t endpointIndex = emberAfGetDynamicIndexFromEndpoint(endpoint);
+	if (Instance().mDevicesMap.Contains(endpointIndex)) {
+		BridgedDevicePair &bridgedDevices = Instance().mDevicesMap[endpointIndex];
+		deviceType = bridgedDevices.mDevice->GetDeviceType();
+		return bridgedDevices.mProvider;
+	}
+	return nullptr;
 }
 
 EmberAfStatus emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId,

--- a/samples/matter/common/src/bridge/bridge_manager.h
+++ b/samples/matter/common/src/bridge/bridge_manager.h
@@ -95,6 +95,15 @@ public:
 		return CHIP_NO_ERROR;
 	}
 
+	/**
+	 * @brief Get the data provider stored on the specified endpoint.
+	 *
+	 * @param endpoint endpoint on which the bridged device is stored
+	 * @param[out] deviceType a type of the bridged device
+	 * @return pointer to the data provider bridged with the device on the specified endpoint
+	 */
+	BridgedDeviceDataProvider *GetProvider(chip::EndpointId endpoint, MatterBridgedDevice::DeviceType &deviceType);
+
 	static CHIP_ERROR HandleRead(uint16_t index, chip::ClusterId clusterId,
 				     const EmberAfAttributeMetadata *attributeMetadata, uint8_t *buffer,
 				     uint16_t maxReadLength);

--- a/samples/matter/common/src/bridge/matter_bridged_device.cpp
+++ b/samples/matter/common/src/bridge/matter_bridged_device.cpp
@@ -68,7 +68,7 @@ CHIP_ERROR MatterBridgedDevice::HandleWriteIdentify(chip::AttributeId attributeI
 	switch (attributeId) {
 	case Clusters::Identify::Attributes::IdentifyTime::Id:
 		if (data && dataSize == sizeof(mIdentifyTime)) {
-			mIdentifyTime = (*reinterpret_cast<decltype(mIdentifyTime) *>(data));
+			memcpy(&mIdentifyTime, data, sizeof(mIdentifyTime));
 			/* Externally stored attribute was updated, now we need to notify identify-server to
 			   leverage the Identify cluster implementation */
 			app::ConcreteAttributePath attributePath{ mEndpointId, Clusters::Identify::Id, attributeId };


### PR DESCRIPTION
* added new Kconfig options allowing to select if the simulated OnOff data provider 
  generates data autonomously or is controlled from CLI
* fixed unaligned copying of the generic data (void*)
* extended the documentation with the description of new Kconfigs