### PR TITLE
ext: oberon: Align with the Oberon deliverables

### DIFF
--- a/ext/oberon/psa/core/include/mbedtls/ecp.h
+++ b/ext/oberon/psa/core/include/mbedtls/ecp.h
@@ -306,7 +306,6 @@ mbedtls_ecp_group;
 #endif /* MBEDTLS_ECP_ALT */
 
 #if !defined(MBEDTLS_ECP_MAX_BITS)
-
 /**
  * The maximum size of the groups, that is, of \c N and \c P.
  */
@@ -344,8 +343,7 @@ mbedtls_ecp_group;
 #else
 #error "Missing definition of MBEDTLS_ECP_MAX_BITS"
 #endif
-
-#endif /* !defined(MBEDTLS_ECP_MAX_BITS) */
+#endif
 
 #define MBEDTLS_ECP_MAX_BYTES    ( ( MBEDTLS_ECP_MAX_BITS + 7 ) / 8 )
 #define MBEDTLS_ECP_MAX_PT_LEN   ( 2 * MBEDTLS_ECP_MAX_BYTES + 1 )

--- a/ext/oberon/psa/core/include/mbedtls/memory_buffer_alloc.h
+++ b/ext/oberon/psa/core/include/mbedtls/memory_buffer_alloc.h
@@ -1,0 +1,153 @@
+/**
+ * \file memory_buffer_alloc.h
+ *
+ * \brief Buffer-based memory allocator
+ */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#ifndef MBEDTLS_MEMORY_BUFFER_ALLOC_H
+#define MBEDTLS_MEMORY_BUFFER_ALLOC_H
+
+#include "mbedtls/build_info.h"
+
+#include <stddef.h>
+
+/**
+ * \name SECTION: Module settings
+ *
+ * The configuration options you can set for this module are in this section.
+ * Either change them in mbedtls_config.h or define them on the compiler command line.
+ * \{
+ */
+
+#if !defined(MBEDTLS_MEMORY_ALIGN_MULTIPLE)
+#define MBEDTLS_MEMORY_ALIGN_MULTIPLE       4 /**< Align on multiples of this value */
+#endif
+
+/** \} name SECTION: Module settings */
+
+#define MBEDTLS_MEMORY_VERIFY_NONE         0
+#define MBEDTLS_MEMORY_VERIFY_ALLOC        (1 << 0)
+#define MBEDTLS_MEMORY_VERIFY_FREE         (1 << 1)
+#define MBEDTLS_MEMORY_VERIFY_ALWAYS       (MBEDTLS_MEMORY_VERIFY_ALLOC | MBEDTLS_MEMORY_VERIFY_FREE)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \brief   Initialize use of stack-based memory allocator.
+ *          The stack-based allocator does memory management inside the
+ *          presented buffer and does not call calloc() and free().
+ *          It sets the global mbedtls_calloc() and mbedtls_free() pointers
+ *          to its own functions.
+ *          (Provided mbedtls_calloc() and mbedtls_free() are thread-safe if
+ *           MBEDTLS_THREADING_C is defined)
+ *
+ * \note    This code is not optimized and provides a straight-forward
+ *          implementation of a stack-based memory allocator.
+ *
+ * \param buf   buffer to use as heap
+ * \param len   size of the buffer
+ */
+void mbedtls_memory_buffer_alloc_init( unsigned char *buf, size_t len );
+
+/**
+ * \brief   Free the mutex for thread-safety and clear remaining memory
+ */
+void mbedtls_memory_buffer_alloc_free( void );
+
+/**
+ * \brief   Determine when the allocator should automatically verify the state
+ *          of the entire chain of headers / meta-data.
+ *          (Default: MBEDTLS_MEMORY_VERIFY_NONE)
+ *
+ * \param verify    One of MBEDTLS_MEMORY_VERIFY_NONE, MBEDTLS_MEMORY_VERIFY_ALLOC,
+ *                  MBEDTLS_MEMORY_VERIFY_FREE or MBEDTLS_MEMORY_VERIFY_ALWAYS
+ */
+void mbedtls_memory_buffer_set_verify( int verify );
+
+#if defined(MBEDTLS_MEMORY_DEBUG)
+/**
+ * \brief   Print out the status of the allocated memory (primarily for use
+ *          after a program should have de-allocated all memory)
+ *          Prints out a list of 'still allocated' blocks and their stack
+ *          trace if MBEDTLS_MEMORY_BACKTRACE is defined.
+ */
+void mbedtls_memory_buffer_alloc_status( void );
+
+/**
+ * \brief   Get the number of alloc/free so far.
+ *
+ * \param alloc_count   Number of allocations.
+ * \param free_count    Number of frees.
+ */
+void mbedtls_memory_buffer_alloc_count_get( size_t *alloc_count, size_t *free_count );
+
+/**
+ * \brief   Get the peak heap usage so far
+ *
+ * \param max_used      Peak number of bytes in use or committed. This
+ *                      includes bytes in allocated blocks too small to split
+ *                      into smaller blocks but larger than the requested size.
+ * \param max_blocks    Peak number of blocks in use, including free and used
+ */
+void mbedtls_memory_buffer_alloc_max_get( size_t *max_used, size_t *max_blocks );
+
+/**
+ * \brief   Reset peak statistics
+ */
+void mbedtls_memory_buffer_alloc_max_reset( void );
+
+/**
+ * \brief   Get the current heap usage
+ *
+ * \param cur_used      Current number of bytes in use or committed. This
+ *                      includes bytes in allocated blocks too small to split
+ *                      into smaller blocks but larger than the requested size.
+ * \param cur_blocks    Current number of blocks in use, including free and used
+ */
+void mbedtls_memory_buffer_alloc_cur_get( size_t *cur_used, size_t *cur_blocks );
+#endif /* MBEDTLS_MEMORY_DEBUG */
+
+/**
+ * \brief   Verifies that all headers in the memory buffer are correct
+ *          and contain sane values. Helps debug buffer-overflow errors.
+ *
+ *          Prints out first failure if MBEDTLS_MEMORY_DEBUG is defined.
+ *          Prints out full header information if MBEDTLS_MEMORY_DEBUG
+ *          is defined. (Includes stack trace information for each block if
+ *          MBEDTLS_MEMORY_BACKTRACE is defined as well).
+ *
+ * \return             0 if verified, 1 otherwise
+ */
+int mbedtls_memory_buffer_alloc_verify( void );
+
+#if defined(MBEDTLS_SELF_TEST)
+/**
+ * \brief          Checkup routine
+ *
+ * \return         0 if successful, or 1 if a test failed
+ */
+int mbedtls_memory_buffer_alloc_self_test( int verbose );
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* memory_buffer_alloc.h */

--- a/ext/oberon/psa/core/include/mbedtls/sha256.h
+++ b/ext/oberon/psa/core/include/mbedtls/sha256.h
@@ -1,0 +1,195 @@
+/**
+ * \file sha256.h
+ *
+ * \brief This file contains SHA-224 and SHA-256 definitions and functions.
+ *
+ * The Secure Hash Algorithms 224 and 256 (SHA-224 and SHA-256) cryptographic
+ * hash functions are defined in <em>FIPS 180-4: Secure Hash Standard (SHS)</em>.
+ */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#ifndef MBEDTLS_SHA256_H
+#define MBEDTLS_SHA256_H
+#include "mbedtls/private_access.h"
+
+#include "mbedtls/build_info.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+/** SHA-256 input data was malformed. */
+#define MBEDTLS_ERR_SHA256_BAD_INPUT_DATA                 -0x0074
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if !defined(MBEDTLS_SHA256_ALT)
+// Regular implementation
+//
+
+/**
+ * \brief          The SHA-256 context structure.
+ *
+ *                 The structure is used both for SHA-256 and for SHA-224
+ *                 checksum calculations. The choice between these two is
+ *                 made in the call to mbedtls_sha256_starts().
+ */
+typedef struct mbedtls_sha256_context
+{
+    uint32_t MBEDTLS_PRIVATE(total)[2];          /*!< The number of Bytes processed.  */
+    uint32_t MBEDTLS_PRIVATE(state)[8];          /*!< The intermediate digest state.  */
+    unsigned char MBEDTLS_PRIVATE(buffer)[64];   /*!< The data block being processed. */
+    int MBEDTLS_PRIVATE(is224);                  /*!< Determines which function to use:
+                                     0: Use SHA-256, or 1: Use SHA-224. */
+}
+mbedtls_sha256_context;
+
+#else  /* MBEDTLS_SHA256_ALT */
+#include "sha256_alt.h"
+#endif /* MBEDTLS_SHA256_ALT */
+
+/**
+ * \brief          This function initializes a SHA-256 context.
+ *
+ * \param ctx      The SHA-256 context to initialize. This must not be \c NULL.
+ */
+void mbedtls_sha256_init( mbedtls_sha256_context *ctx );
+
+/**
+ * \brief          This function clears a SHA-256 context.
+ *
+ * \param ctx      The SHA-256 context to clear. This may be \c NULL, in which
+ *                 case this function returns immediately. If it is not \c NULL,
+ *                 it must point to an initialized SHA-256 context.
+ */
+void mbedtls_sha256_free( mbedtls_sha256_context *ctx );
+
+/**
+ * \brief          This function clones the state of a SHA-256 context.
+ *
+ * \param dst      The destination context. This must be initialized.
+ * \param src      The context to clone. This must be initialized.
+ */
+void mbedtls_sha256_clone( mbedtls_sha256_context *dst,
+                           const mbedtls_sha256_context *src );
+
+/**
+ * \brief          This function starts a SHA-224 or SHA-256 checksum
+ *                 calculation.
+ *
+ * \param ctx      The context to use. This must be initialized.
+ * \param is224    This determines which function to use. This must be
+ *                 either \c 0 for SHA-256, or \c 1 for SHA-224.
+ *
+ * \return         \c 0 on success.
+ * \return         A negative error code on failure.
+ */
+int mbedtls_sha256_starts( mbedtls_sha256_context *ctx, int is224 );
+
+/**
+ * \brief          This function feeds an input buffer into an ongoing
+ *                 SHA-256 checksum calculation.
+ *
+ * \param ctx      The SHA-256 context. This must be initialized
+ *                 and have a hash operation started.
+ * \param input    The buffer holding the data. This must be a readable
+ *                 buffer of length \p ilen Bytes.
+ * \param ilen     The length of the input data in Bytes.
+ *
+ * \return         \c 0 on success.
+ * \return         A negative error code on failure.
+ */
+int mbedtls_sha256_update( mbedtls_sha256_context *ctx,
+                           const unsigned char *input,
+                           size_t ilen );
+
+/**
+ * \brief          This function finishes the SHA-256 operation, and writes
+ *                 the result to the output buffer.
+ *
+ * \param ctx      The SHA-256 context. This must be initialized
+ *                 and have a hash operation started.
+ * \param output   The SHA-224 or SHA-256 checksum result.
+ *                 This must be a writable buffer of length \c 32 bytes
+ *                 for SHA-256, \c 28 bytes for SHA-224.
+ *
+ * \return         \c 0 on success.
+ * \return         A negative error code on failure.
+ */
+int mbedtls_sha256_finish( mbedtls_sha256_context *ctx,
+                           unsigned char *output );
+
+/**
+ * \brief          This function processes a single data block within
+ *                 the ongoing SHA-256 computation. This function is for
+ *                 internal use only.
+ *
+ * \param ctx      The SHA-256 context. This must be initialized.
+ * \param data     The buffer holding one block of data. This must
+ *                 be a readable buffer of length \c 64 Bytes.
+ *
+ * \return         \c 0 on success.
+ * \return         A negative error code on failure.
+ */
+int mbedtls_internal_sha256_process( mbedtls_sha256_context *ctx,
+                                     const unsigned char data[64] );
+
+/**
+ * \brief          This function calculates the SHA-224 or SHA-256
+ *                 checksum of a buffer.
+ *
+ *                 The function allocates the context, performs the
+ *                 calculation, and frees the context.
+ *
+ *                 The SHA-256 result is calculated as
+ *                 output = SHA-256(input buffer).
+ *
+ * \param input    The buffer holding the data. This must be a readable
+ *                 buffer of length \p ilen Bytes.
+ * \param ilen     The length of the input data in Bytes.
+ * \param output   The SHA-224 or SHA-256 checksum result.
+ *                 This must be a writable buffer of length \c 32 bytes
+ *                 for SHA-256, \c 28 bytes for SHA-224.
+ * \param is224    Determines which function to use. This must be
+ *                 either \c 0 for SHA-256, or \c 1 for SHA-224.
+ *
+ * \return         \c 0 on success.
+ * \return         A negative error code on failure.
+ */
+int mbedtls_sha256( const unsigned char *input,
+                    size_t ilen,
+                    unsigned char *output,
+                    int is224 );
+
+#if defined(MBEDTLS_SELF_TEST)
+
+/**
+ * \brief          The SHA-224 and SHA-256 checkup routine.
+ *
+ * \return         \c 0 on success.
+ * \return         \c 1 on failure.
+ */
+int mbedtls_sha256_self_test( int verbose );
+
+#endif /* MBEDTLS_SELF_TEST */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* mbedtls_sha256.h */

--- a/ext/oberon/psa/core/include/psa/crypto_config.h
+++ b/ext/oberon/psa/core/include/psa/crypto_config.h
@@ -120,8 +120,9 @@
 #define PSA_USE_HMAC_DRBG_DRIVER                1
 
 /* Hardware driver demonstration */
-#define PSA_USE_DEMO_ENTROPY_DRIVER 1
-// #define PSA_USE_DEMO_HARDWARE_DRIVER            1
-#define PSA_USE_DEMO_OPAQUE_DRIVER  1
+#define PSA_USE_DEMO_ENTROPY_DRIVER             1
+//#define PSA_USE_DEMO_HARDWARE_DRIVER            1
+#define PSA_USE_DEMO_OPAQUE_DRIVER              1
+
 
 #endif /* PSA_CRYPTO_CONFIG_H */

--- a/ext/oberon/psa/core/include/psa/crypto_sizes.h
+++ b/ext/oberon/psa/core/include/psa/crypto_sizes.h
@@ -197,7 +197,6 @@
 /* The maximum size of an ECC key on this implementation, in bits.
  * This is a vendor-specific macro. */
 #ifndef PSA_VENDOR_ECC_MAX_CURVE_BITS
-
 #if defined(PSA_WANT_ECC_SECP_R1_521)           /*!!OM*/
 #define PSA_VENDOR_ECC_MAX_CURVE_BITS 521
 #elif defined(PSA_WANT_ECC_BRAINPOOL_P_R1_512)
@@ -231,7 +230,6 @@
 #else
 #define PSA_VENDOR_ECC_MAX_CURVE_BITS 0
 #endif
-
 #endif
 
 /** This macro returns the maximum supported length of the PSK for the

--- a/ext/oberon/psa/core/library/psa_crypto.c
+++ b/ext/oberon/psa/core/library/psa_crypto.c
@@ -4155,20 +4155,17 @@ psa_status_t psa_pake_set_user(psa_pake_operation_t *operation,
         return PSA_ERROR_BAD_STATE;
     }
 
+
 #ifdef PSA_WANT_ALG_SPAKE2P
     if (operation->alg == PSA_ALG_SPAKE2P) {
-	if (!operation->role_set || (operation->is_second && !operation->peer_set)) {
-	    return PSA_ERROR_BAD_STATE;
-	}
-	if (user_id == NULL && user_id_len != 0) {
-	    return PSA_ERROR_INVALID_ARGUMENT;
-	}
+        if (!operation->role_set || (operation->is_second && !operation->peer_set)) {
+            return PSA_ERROR_BAD_STATE;
+        }
+        if (user_id == NULL && user_id_len != 0) return PSA_ERROR_INVALID_ARGUMENT;
     } else
 #endif
     {
-	if (user_id == NULL || user_id_len == 0) {
-	    return PSA_ERROR_INVALID_ARGUMENT;
-	}
+        if (user_id == NULL || user_id_len == 0) return PSA_ERROR_INVALID_ARGUMENT;
     }
 
     status = psa_driver_wrapper_pake_set_user(operation, user_id, user_id_len);
@@ -4194,18 +4191,14 @@ psa_status_t psa_pake_set_peer(psa_pake_operation_t *operation,
 
 #ifdef PSA_WANT_ALG_SPAKE2P
     if (operation->alg == PSA_ALG_SPAKE2P) {
-	if (!operation->role_set || (!operation->is_second && !operation->user_set)) {
-	    return PSA_ERROR_BAD_STATE;
-	}
-	if (peer_id == NULL && peer_id_len != 0) {
-	    return PSA_ERROR_INVALID_ARGUMENT;
-	}
+        if (!operation->role_set || (!operation->is_second && !operation->user_set)) {
+            return PSA_ERROR_BAD_STATE;
+        }
+        if (peer_id == NULL && peer_id_len != 0) return PSA_ERROR_INVALID_ARGUMENT;
     } else
 #endif
     {
-	if (peer_id == NULL || peer_id_len == 0) {
-	    return PSA_ERROR_INVALID_ARGUMENT;
-	}
+        if (peer_id == NULL || peer_id_len == 0) return PSA_ERROR_INVALID_ARGUMENT;
     }
 
     status = psa_driver_wrapper_pake_set_peer(operation, peer_id, peer_id_len);

--- a/ext/oberon/psa/drivers/oberon_aead.c
+++ b/ext/oberon/psa/drivers/oberon_aead.c
@@ -42,21 +42,19 @@ static psa_status_t oberon_aead_setup(
         if (key_length != 16 && key_length != 24 && key_length != 32) return PSA_ERROR_INVALID_ARGUMENT;
         switch (short_alg) {
 #ifdef PSA_NEED_OBERON_CCM_AES
-		_Static_assert(sizeof operation->ctx >= sizeof(ocrypto_aes_ccm_ctx),
-			       "oberon_aead_operation_t.ctx too small");
-	case PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_CCM, 0):
+        _Static_assert(sizeof operation->ctx >= sizeof(ocrypto_aes_ccm_ctx), "oberon_aead_operation_t.ctx too small");
+        case PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_CCM, 0):
             ocrypto_aes_ccm_init((ocrypto_aes_ccm_ctx*)&operation->ctx, key, key_length, NULL, 0, 0, 0, 0);
             break;
 #endif /* PSA_NEED_OBERON_CCM_AES */
 #ifdef PSA_NEED_OBERON_GCM_AES
-	    _Static_assert(sizeof operation->ctx >= sizeof(ocrypto_aes_gcm_ctx),
-			   "oberon_aead_operation_t.ctx too small");
-	case PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_GCM, 0):
+        _Static_assert(sizeof operation->ctx >= sizeof(ocrypto_aes_gcm_ctx), "oberon_aead_operation_t.ctx too small");
+        case PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_GCM, 0):
             ocrypto_aes_gcm_init((ocrypto_aes_gcm_ctx*)&operation->ctx, key, key_length, NULL);
             break;
 #endif /* PSA_NEED_OBERON_GCM_AES */
-	default:
-	    return PSA_ERROR_NOT_SUPPORTED;
+        default:
+            return PSA_ERROR_NOT_SUPPORTED;
         }
         break;
 #ifdef PSA_NEED_OBERON_CHACHA20_POLY1305
@@ -350,8 +348,8 @@ psa_status_t oberon_aead_encrypt(
         if (key_length != 16 && key_length != 24 && key_length != 32) return PSA_ERROR_INVALID_ARGUMENT;
         switch (PSA_ALG_AEAD_WITH_SHORTENED_TAG(alg, 0)) {
 #ifdef PSA_NEED_OBERON_CCM_AES
-	case PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_CCM, 0):
-	    if (tag_length < 4 || tag_length > 16 || (tag_length & 1)) return PSA_ERROR_INVALID_ARGUMENT;
+        case PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_CCM, 0):
+            if (tag_length < 4 || tag_length > 16 || (tag_length & 1)) return PSA_ERROR_INVALID_ARGUMENT;
             if (nonce_length < 7 || nonce_length > 13) return PSA_ERROR_INVALID_ARGUMENT;
             ocrypto_aes_ccm_init(&ctx.ccm,
                 key, key_length, nonce, nonce_length,
@@ -364,8 +362,8 @@ psa_status_t oberon_aead_encrypt(
             break;
 #endif /* PSA_NEED_OBERON_CCM_AES */
 #ifdef PSA_NEED_OBERON_GCM_AES
-	case PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_GCM, 0):
-	    if (tag_length < 4 || tag_length > 16 || nonce_length == 0) return PSA_ERROR_INVALID_ARGUMENT;
+        case PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_GCM, 0):
+            if (tag_length < 4 || tag_length > 16 || nonce_length == 0) return PSA_ERROR_INVALID_ARGUMENT;
             ocrypto_aes_gcm_init(&ctx.gcm, key, key_length, NULL);
             ocrypto_aes_gcm_init_iv(&ctx.gcm, nonce, nonce_length);
             if (additional_data_length) {
@@ -375,8 +373,8 @@ psa_status_t oberon_aead_encrypt(
             ocrypto_aes_gcm_final_enc(&ctx.gcm, ciphertext + plaintext_length, tag_length);
             break;
 #endif /* PSA_NEED_OBERON_GCM_AES */
-	default:
-	    return PSA_ERROR_NOT_SUPPORTED;
+        default:
+            return PSA_ERROR_NOT_SUPPORTED;
         }
         break;
 #ifdef PSA_NEED_OBERON_CHACHA20_POLY1305
@@ -432,8 +430,8 @@ psa_status_t oberon_aead_decrypt(
         if (key_length != 16 && key_length != 24 && key_length != 32) return PSA_ERROR_INVALID_ARGUMENT;
         switch (PSA_ALG_AEAD_WITH_SHORTENED_TAG(alg, 0)) {
 #ifdef PSA_NEED_OBERON_CCM_AES
-	case PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_CCM, 0):
-	    if (tag_length < 4 || tag_length > 16 || (tag_length & 1)) return PSA_ERROR_INVALID_ARGUMENT;
+        case PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_CCM, 0):
+            if (tag_length < 4 || tag_length > 16 || (tag_length & 1)) return PSA_ERROR_INVALID_ARGUMENT;
             if (nonce_length < 7 || nonce_length > 13) return PSA_ERROR_INVALID_ARGUMENT;
             ocrypto_aes_ccm_init(&ctx.ccm,
                 key, key_length, nonce, nonce_length,
@@ -446,8 +444,8 @@ psa_status_t oberon_aead_decrypt(
             break;
 #endif /* PSA_NEED_OBERON_CCM_AES */
 #ifdef PSA_NEED_OBERON_GCM_AES
-	case PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_GCM, 0):
-	    if (tag_length < 4 || tag_length > 16 || nonce_length == 0) return PSA_ERROR_INVALID_ARGUMENT;
+        case PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_GCM, 0):
+            if (tag_length < 4 || tag_length > 16 || nonce_length == 0) return PSA_ERROR_INVALID_ARGUMENT;
             ocrypto_aes_gcm_init(&ctx.gcm, key, key_length, NULL);
             ocrypto_aes_gcm_init_iv(&ctx.gcm, nonce, nonce_length);
             if (additional_data_length) {
@@ -457,8 +455,8 @@ psa_status_t oberon_aead_decrypt(
             res = ocrypto_aes_gcm_final_dec(&ctx.gcm, ciphertext + pt_length, tag_length);
             break;
 #endif /* PSA_NEED_OBERON_GCM_AES */
-	default:
-	    return PSA_ERROR_NOT_SUPPORTED;
+        default:
+            return PSA_ERROR_NOT_SUPPORTED;
         }
         break;
 #ifdef PSA_NEED_OBERON_CHACHA20_POLY1305

--- a/ext/oberon/psa/drivers/oberon_aead.h
+++ b/ext/oberon/psa/drivers/oberon_aead.h
@@ -20,9 +20,9 @@ extern "C" {
 typedef struct {
     struct {
 #if defined(PSA_NEED_OBERON_GCM_AES)
-	    uint32_t a[77];
+        uint32_t a[77];
 #elif defined(PSA_NEED_OBERON_CCM_AES)
-	    uint32_t a[73];
+        uint32_t a[73];
 #else /* PSA_NEED_OBERON_CHACHA20_POLY1305 */
         uint32_t a[51];
 #endif

--- a/ext/oberon/psa/drivers/oberon_asymmetric_encrypt.c
+++ b/ext/oberon/psa/drivers/oberon_asymmetric_encrypt.c
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+
 #include "psa/crypto.h"
 #include "oberon_asymmetric_encrypt.h"
 
@@ -12,62 +13,78 @@
 #include "oberon_rsa.h"
 #endif
 
-psa_status_t oberon_asymmetric_encrypt(const psa_key_attributes_t *attributes, const uint8_t *key,
-				       size_t key_length, psa_algorithm_t alg, const uint8_t *input,
-				       size_t input_length, const uint8_t *salt, size_t salt_length,
-				       uint8_t *output, size_t output_size, size_t *output_length)
+
+psa_status_t oberon_asymmetric_encrypt(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg,
+    const uint8_t *input, size_t input_length,
+    const uint8_t *salt, size_t salt_length,
+    uint8_t *output, size_t output_size, size_t *output_length)
 {
-	psa_key_type_t type = psa_get_key_type(attributes);
+    psa_key_type_t type = psa_get_key_type(attributes);
 
 #ifdef PSA_NEED_OBERON_RSA_ANY_CRYPT
-	if (PSA_KEY_TYPE_IS_RSA(type)) {
-		return oberon_rsa_encrypt(attributes, key, key_length, alg, input, input_length,
-					  salt, salt_length, output, output_size, output_length);
-	} else
+    if (PSA_KEY_TYPE_IS_RSA(type)) {
+        return oberon_rsa_encrypt(
+            attributes, key, key_length,
+            alg,
+            input, input_length,
+            salt, salt_length,
+            output, output_size, output_length);
+    } else
 #endif /* PSA_NEED_OBERON_RSA_ANY_CRYPT */
 
-	{
-		(void)key;
-		(void)key_length;
-		(void)alg;
-		(void)input;
-		(void)input_length;
-		(void)salt;
-		(void)salt_length;
-		(void)output;
-		(void)output_size;
-		(void)output_length;
-		(void)type;
-		return PSA_ERROR_NOT_SUPPORTED;
-	}
+    {
+        (void)key;
+        (void)key_length;
+        (void)alg;
+        (void)input;
+        (void)input_length;
+        (void)salt;
+        (void)salt_length;
+        (void)output;
+        (void)output_size;
+        (void)output_length;
+        (void)type;
+        return PSA_ERROR_NOT_SUPPORTED;
+    }
 }
 
-psa_status_t oberon_asymmetric_decrypt(const psa_key_attributes_t *attributes, const uint8_t *key,
-				       size_t key_length, psa_algorithm_t alg, const uint8_t *input,
-				       size_t input_length, const uint8_t *salt, size_t salt_length,
-				       uint8_t *output, size_t output_size, size_t *output_length)
+psa_status_t oberon_asymmetric_decrypt(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg,
+    const uint8_t *input, size_t input_length,
+    const uint8_t *salt, size_t salt_length,
+    uint8_t *output, size_t output_size, size_t *output_length)
 {
-	psa_key_type_t type = psa_get_key_type(attributes);
+    psa_key_type_t type = psa_get_key_type(attributes);
 
 #ifdef PSA_NEED_OBERON_RSA_ANY_CRYPT
-	if (PSA_KEY_TYPE_IS_RSA(type)) {
-		return oberon_rsa_decrypt(attributes, key, key_length, alg, input, input_length,
-					  salt, salt_length, output, output_size, output_length);
-	} else
+    if (PSA_KEY_TYPE_IS_RSA(type)) {
+        return oberon_rsa_decrypt(
+            attributes, key, key_length,
+            alg,
+            input, input_length,
+            salt, salt_length,
+            output, output_size, output_length);
+    } else
 #endif /* PSA_NEED_OBERON_RSA_ANY_CRYPT */
 
-	{
-		(void)key;
-		(void)key_length;
-		(void)alg;
-		(void)input;
-		(void)input_length;
-		(void)salt;
-		(void)salt_length;
-		(void)output;
-		(void)output_size;
-		(void)output_length;
-		(void)type;
-		return PSA_ERROR_NOT_SUPPORTED;
-	}
+    {
+        (void)key;
+        (void)key_length;
+        (void)alg;
+        (void)input;
+        (void)input_length;
+        (void)salt;
+        (void)salt_length;
+        (void)output;
+        (void)output_size;
+        (void)output_length;
+        (void)type;
+        return PSA_ERROR_NOT_SUPPORTED;
+    }
 }
+

--- a/ext/oberon/psa/drivers/oberon_asymmetric_encrypt.h
+++ b/ext/oberon/psa/drivers/oberon_asymmetric_encrypt.h
@@ -5,26 +5,34 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+
 #ifndef OBERON_ASYMMETRIC_ENCRYPT_H
 #define OBERON_ASYMMETRIC_ENCRYPT_H
 
 #include <psa/crypto_driver_common.h>
 
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-psa_status_t oberon_asymmetric_encrypt(const psa_key_attributes_t *attributes,
-				       const uint8_t *key_buffer, size_t key_buffer_size,
-				       psa_algorithm_t alg, const uint8_t *input,
-				       size_t input_length, const uint8_t *salt, size_t salt_length,
-				       uint8_t *output, size_t output_size, size_t *output_length);
 
-psa_status_t oberon_asymmetric_decrypt(const psa_key_attributes_t *attributes,
-				       const uint8_t *key_buffer, size_t key_buffer_size,
-				       psa_algorithm_t alg, const uint8_t *input,
-				       size_t input_length, const uint8_t *salt, size_t salt_length,
-				       uint8_t *output, size_t output_size, size_t *output_length);
+    psa_status_t oberon_asymmetric_encrypt(
+        const psa_key_attributes_t *attributes,
+        const uint8_t *key_buffer, size_t key_buffer_size,
+        psa_algorithm_t alg,
+        const uint8_t *input, size_t input_length,
+        const uint8_t *salt, size_t salt_length,
+        uint8_t *output, size_t output_size, size_t *output_length);
+
+    psa_status_t oberon_asymmetric_decrypt(
+        const psa_key_attributes_t *attributes,
+        const uint8_t *key_buffer, size_t key_buffer_size,
+        psa_algorithm_t alg,
+        const uint8_t *input, size_t input_length,
+        const uint8_t *salt, size_t salt_length,
+        uint8_t *output, size_t output_size, size_t *output_length);
+
 
 #ifdef __cplusplus
 }

--- a/ext/oberon/psa/drivers/oberon_asymmetric_signature.c
+++ b/ext/oberon/psa/drivers/oberon_asymmetric_signature.c
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+
 #include "psa/crypto.h"
 #include "oberon_asymmetric_signature.h"
 
@@ -15,127 +16,153 @@
 #include "oberon_rsa.h"
 #endif
 
-psa_status_t oberon_sign_hash(const psa_key_attributes_t *attributes, const uint8_t *key,
-			      size_t key_length, psa_algorithm_t alg, const uint8_t *hash,
-			      size_t hash_length, uint8_t *signature, size_t signature_size,
-			      size_t *signature_length)
+
+psa_status_t oberon_sign_hash(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg,
+    const uint8_t *hash, size_t hash_length,
+    uint8_t *signature, size_t signature_size, size_t *signature_length)
 {
-	psa_key_type_t type = psa_get_key_type(attributes);
+    psa_key_type_t type = psa_get_key_type(attributes);
 
 #ifdef PSA_NEED_OBERON_ECDSA_SIGN
-	if (PSA_KEY_TYPE_IS_ECC(type)) {
-		return oberon_ecdsa_sign_hash(attributes, key, key_length, alg, hash, hash_length,
-					      signature, signature_size, signature_length);
-	} else
+    if (PSA_KEY_TYPE_IS_ECC(type)) {
+        return oberon_ecdsa_sign_hash(
+            attributes, key, key_length,
+            alg,
+            hash, hash_length,
+            signature, signature_size, signature_length);
+    } else
 #endif /* PSA_NEED_OBERON_ECDSA_SIGN */
 
 #ifdef PSA_NEED_OBERON_RSA_ANY_SIGN
-		if (PSA_KEY_TYPE_IS_RSA(type)) {
-		return oberon_rsa_sign_hash(attributes, key, key_length, alg, hash, hash_length,
-					    signature, signature_size, signature_length);
-	} else
+    if (PSA_KEY_TYPE_IS_RSA(type)) {
+        return oberon_rsa_sign_hash(
+            attributes, key, key_length,
+            alg,
+            hash, hash_length,
+            signature, signature_size, signature_length);
+    } else
 #endif /* PSA_NEED_OBERON_RSA_ANY_SIGN */
 
-	{
-		(void)key;
-		(void)key_length;
-		(void)alg;
-		(void)hash;
-		(void)hash_length;
-		(void)signature;
-		(void)signature_size;
-		(void)signature_length;
-		(void)type;
-		return PSA_ERROR_NOT_SUPPORTED;
-	}
+    {
+        (void)key;
+        (void)key_length;
+        (void)alg;
+        (void)hash;
+        (void)hash_length;
+        (void)signature;
+        (void)signature_size;
+        (void)signature_length;
+        (void)type;
+        return PSA_ERROR_NOT_SUPPORTED;
+    }
 }
 
-psa_status_t oberon_sign_message(const psa_key_attributes_t *attributes, const uint8_t *key,
-				 size_t key_length, psa_algorithm_t alg, const uint8_t *input,
-				 size_t input_length, uint8_t *signature, size_t signature_size,
-				 size_t *signature_length)
+psa_status_t oberon_sign_message(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg,
+    const uint8_t *input, size_t input_length,
+    uint8_t *signature, size_t signature_size, size_t *signature_length)
 {
-	psa_key_type_t type = psa_get_key_type(attributes);
+    psa_key_type_t type = psa_get_key_type(attributes);
 
 #ifdef PSA_NEED_OBERON_ECDSA_SIGN
-	if (PSA_KEY_TYPE_IS_ECC(type)) {
-		return oberon_ecdsa_sign_message(attributes, key, key_length, alg, input,
-						 input_length, signature, signature_size,
-						 signature_length);
-	} else
+    if (PSA_KEY_TYPE_IS_ECC(type)) {
+        return oberon_ecdsa_sign_message(
+            attributes, key, key_length,
+            alg,
+            input, input_length,
+            signature, signature_size, signature_length);
+    } else
 #endif /* PSA_NEED_OBERON_ECDSA_SIGN */
 
-	{
-		(void)key;
-		(void)key_length;
-		(void)alg;
-		(void)input;
-		(void)input_length;
-		(void)signature;
-		(void)signature_size;
-		(void)signature_length;
-		(void)type;
-		return PSA_ERROR_NOT_SUPPORTED;
-	}
+    {
+        (void)key;
+        (void)key_length;
+        (void)alg;
+        (void)input;
+        (void)input_length;
+        (void)signature;
+        (void)signature_size;
+        (void)signature_length;
+        (void)type;
+        return PSA_ERROR_NOT_SUPPORTED;
+    }
 }
 
-psa_status_t oberon_verify_hash(const psa_key_attributes_t *attributes, const uint8_t *key,
-				size_t key_length, psa_algorithm_t alg, const uint8_t *hash,
-				size_t hash_length, const uint8_t *signature,
-				size_t signature_length)
+psa_status_t oberon_verify_hash(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg,
+    const uint8_t *hash, size_t hash_length,
+    const uint8_t *signature, size_t signature_length)
 {
-	psa_key_type_t type = psa_get_key_type(attributes);
+    psa_key_type_t type = psa_get_key_type(attributes);
 
 #ifdef PSA_NEED_OBERON_ECDSA_SIGN
-	if (PSA_KEY_TYPE_IS_ECC(type)) {
-		return oberon_ecdsa_verify_hash(attributes, key, key_length, alg, hash, hash_length,
-						signature, signature_length);
-	} else
+    if (PSA_KEY_TYPE_IS_ECC(type)) {
+        return oberon_ecdsa_verify_hash(
+            attributes, key, key_length,
+            alg,
+            hash, hash_length,
+            signature, signature_length);
+    } else
 #endif /* PSA_NEED_OBERON_ECDSA_SIGN */
 
 #ifdef PSA_NEED_OBERON_RSA_ANY_SIGN
-		if (PSA_KEY_TYPE_IS_RSA(type)) {
-		return oberon_rsa_verify_hash(attributes, key, key_length, alg, hash, hash_length,
-					      signature, signature_length);
-	} else
+    if (PSA_KEY_TYPE_IS_RSA(type)) {
+        return oberon_rsa_verify_hash(
+            attributes, key, key_length,
+            alg,
+            hash, hash_length,
+            signature, signature_length);
+    } else
 #endif /* PSA_NEED_OBERON_RSA_ANY_SIGN */
 
-	{
-		(void)key;
-		(void)key_length;
-		(void)alg;
-		(void)hash;
-		(void)hash_length;
-		(void)signature;
-		(void)signature_length;
-		(void)type;
-		return PSA_ERROR_NOT_SUPPORTED;
-	}
+    {
+        (void)key;
+        (void)key_length;
+        (void)alg;
+        (void)hash;
+        (void)hash_length;
+        (void)signature;
+        (void)signature_length;
+        (void)type;
+        return PSA_ERROR_NOT_SUPPORTED;
+    }
 }
 
-psa_status_t oberon_verify_message(const psa_key_attributes_t *attributes, const uint8_t *key,
-				   size_t key_length, psa_algorithm_t alg, const uint8_t *input,
-				   size_t input_length, const uint8_t *signature,
-				   size_t signature_length)
+psa_status_t oberon_verify_message(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg,
+    const uint8_t *input, size_t input_length,
+    const uint8_t *signature, size_t signature_length)
 {
-	psa_key_type_t type = psa_get_key_type(attributes);
+    psa_key_type_t type = psa_get_key_type(attributes);
 
 #ifdef PSA_NEED_OBERON_ECDSA_SIGN
-	if (PSA_KEY_TYPE_IS_ECC(type)) {
-		return oberon_ecdsa_verify_message(attributes, key, key_length, alg, input,
-						   input_length, signature, signature_length);
-	} else
+    if (PSA_KEY_TYPE_IS_ECC(type)) {
+        return oberon_ecdsa_verify_message(
+            attributes, key, key_length,
+            alg,
+            input, input_length,
+            signature, signature_length);
+    } else
 #endif /* PSA_NEED_OBERON_ECDSA_SIGN */
 
-	{
-		(void)key;
-		(void)key_length;
-		(void)alg;
-		(void)input;
-		(void)input_length;
-		(void)signature;
-		(void)signature_length;
-		(void)type;
-		return PSA_ERROR_NOT_SUPPORTED;
-	}
+    {
+        (void)key;
+        (void)key_length;
+        (void)alg;
+        (void)input;
+        (void)input_length;
+        (void)signature;
+        (void)signature_length;
+        (void)type;
+        return PSA_ERROR_NOT_SUPPORTED;
+    }
 }

--- a/ext/oberon/psa/drivers/oberon_asymmetric_signature.h
+++ b/ext/oberon/psa/drivers/oberon_asymmetric_signature.h
@@ -5,34 +5,46 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+
 #ifndef OBERON_ASYMMETRIC_SIGNATURE_H
 #define OBERON_ASYMMETRIC_SIGNATURE_H
 
 #include <psa/crypto_driver_common.h>
 
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-psa_status_t oberon_sign_message(const psa_key_attributes_t *attributes, const uint8_t *key,
-				 size_t key_length, psa_algorithm_t alg, const uint8_t *input,
-				 size_t input_length, uint8_t *signature, size_t signature_size,
-				 size_t *signature_length);
 
-psa_status_t oberon_sign_hash(const psa_key_attributes_t *attributes, const uint8_t *key,
-			      size_t key_length, psa_algorithm_t alg, const uint8_t *hash,
-			      size_t hash_length, uint8_t *signature, size_t signature_size,
-			      size_t *signature_length);
+psa_status_t oberon_sign_message(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg,
+    const uint8_t *input, size_t input_length,
+    uint8_t *signature, size_t signature_size, size_t *signature_length);
 
-psa_status_t oberon_verify_message(const psa_key_attributes_t *attributes, const uint8_t *key,
-				   size_t key_length, psa_algorithm_t alg, const uint8_t *input,
-				   size_t input_length, const uint8_t *signature,
-				   size_t signature_length);
+psa_status_t oberon_sign_hash(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg,
+    const uint8_t *hash, size_t hash_length,
+    uint8_t *signature, size_t signature_size, size_t *signature_length);
 
-psa_status_t oberon_verify_hash(const psa_key_attributes_t *attributes, const uint8_t *key,
-				size_t key_length, psa_algorithm_t alg, const uint8_t *hash,
-				size_t hash_length, const uint8_t *signature,
-				size_t signature_length);
+psa_status_t oberon_verify_message(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg,
+    const uint8_t *input, size_t input_length,
+    const uint8_t *signature, size_t signature_length);
+
+psa_status_t oberon_verify_hash(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg,
+    const uint8_t *hash, size_t hash_length,
+    const uint8_t *signature, size_t signature_length);
+
 
 #ifdef __cplusplus
 }

--- a/ext/oberon/psa/drivers/oberon_cipher.c
+++ b/ext/oberon/psa/drivers/oberon_cipher.c
@@ -14,13 +14,13 @@
 #if defined(PSA_NEED_OBERON_CTR_AES) || defined(PSA_NEED_OBERON_CCM_STAR_NO_TAG_AES)
 #include "ocrypto_aes_ctr.h"
 #endif
-#if defined(PSA_NEED_OBERON_CBC_PKCS7_AES) || defined(PSA_NEED_OBERON_CBC_NO_PADDING_AES) ||       \
-	defined(PSA_NEED_OBERON_ECB_NO_PADDING_AES)
+#if defined(PSA_NEED_OBERON_CBC_PKCS7_AES) || defined(PSA_NEED_OBERON_CBC_NO_PADDING_AES) || defined(PSA_NEED_OBERON_ECB_NO_PADDING_AES)
 #include "ocrypto_aes_cbc_pkcs.h"
 #endif
 #ifdef PSA_NEED_OBERON_STREAM_CIPHER_CHACHA20
 #include "ocrypto_chacha20.h"
 #endif
+
 
 #ifdef PSA_NEED_OBERON_CCM_STAR_NO_TAG_AES
 static void oberon_aes_ccm_star_set_iv(
@@ -35,6 +35,7 @@ static void oberon_aes_ccm_star_set_iv(
     ocrypto_aes_ctr_init(ctx, NULL, 0, counter);
 }
 #endif /* PSA_NEED_OBERON_CCM_STAR_NO_TAG_AES */
+
 
 static psa_status_t oberon_cipher_setup(
     oberon_cipher_operation_t *operation,
@@ -58,36 +59,32 @@ static psa_status_t oberon_cipher_setup(
 
     switch (alg) {
 #if defined(PSA_NEED_OBERON_CTR_AES) || defined(PSA_NEED_OBERON_CCM_STAR_NO_TAG_AES)
-	_Static_assert(sizeof operation->ctx >= sizeof(ocrypto_aes_ctr_ctx),
-		       "oberon_cipher_operation_t.ctx too small");
+    _Static_assert(sizeof operation->ctx >= sizeof(ocrypto_aes_ctr_ctx), "oberon_cipher_operation_t.ctx too small");
 #ifdef PSA_NEED_OBERON_CTR_AES
     case PSA_ALG_CTR:
 #endif /* PSA_NEED_OBERON_CTR_AES */
 #ifdef PSA_NEED_OBERON_CCM_STAR_NO_TAG_AES
     case PSA_ALG_CCM_STAR_NO_TAG:
 #endif /* PSA_NEED_OBERON_CCM_STAR_NO_TAG_AES */
-	ocrypto_aes_ctr_init((ocrypto_aes_ctr_ctx *)operation->ctx, key, key_length, NULL);
-	break;
+        ocrypto_aes_ctr_init((ocrypto_aes_ctr_ctx*)operation->ctx, key, key_length, NULL);
+        break;
 #endif /* PSA_NEED_OBERON_CTR_AES || PSA_NEED_OBERON_CCM_STAR_NO_TAG_AES */
 #ifdef PSA_NEED_OBERON_CBC_PKCS7_AES
-	_Static_assert(sizeof operation->ctx >= sizeof(ocrypto_aes_cbc_pkcs_ctx),
-		       "oberon_cipher_operation_t.ctx too small");
+    _Static_assert(sizeof operation->ctx >= sizeof(ocrypto_aes_cbc_pkcs_ctx), "oberon_cipher_operation_t.ctx too small");
     case PSA_ALG_CBC_PKCS7:
         ocrypto_aes_cbc_pkcs_init((ocrypto_aes_cbc_pkcs_ctx*)operation->ctx, key, key_length, NULL, decrypt);
         break;
 #endif /* PSA_NEED_OBERON_CBC_PKCS7_AES */
 #if defined(PSA_NEED_OBERON_CBC_NO_PADDING_AES) || defined(PSA_NEED_OBERON_ECB_NO_PADDING_AES)
-	_Static_assert(sizeof operation->ctx >= sizeof(ocrypto_aes_cbc_pkcs_ctx),
-		       "oberon_cipher_operation_t.ctx too small");
+    _Static_assert(sizeof operation->ctx >= sizeof(ocrypto_aes_cbc_pkcs_ctx), "oberon_cipher_operation_t.ctx too small");
 #ifdef PSA_NEED_OBERON_CBC_NO_PADDING_AES
     case PSA_ALG_CBC_NO_PADDING:
 #endif /* PSA_NEED_OBERON_CBC_NO_PADDING_AES */
 #ifdef PSA_NEED_OBERON_ECB_NO_PADDING_AES
     case PSA_ALG_ECB_NO_PADDING:
 #endif /* PSA_NEED_OBERON_ECB_NO_PADDING_AES */
-	ocrypto_aes_cbc_pkcs_init((ocrypto_aes_cbc_pkcs_ctx *)operation->ctx, key, key_length, NULL,
-				  decrypt * 2);
-	break;
+        ocrypto_aes_cbc_pkcs_init((ocrypto_aes_cbc_pkcs_ctx*)operation->ctx, key, key_length, NULL, decrypt * 2);
+        break;
 #endif /* PSA_NEED_OBERON_CBC_NO_PADDING_AES || PSA_NEED_OBERON_ECB_NO_PADDING_AES */
     default:
         (void)key;
@@ -147,10 +144,8 @@ psa_status_t oberon_cipher_set_iv(
 #ifdef PSA_NEED_OBERON_CBC_NO_PADDING_AES
     case PSA_ALG_CBC_NO_PADDING:
 #endif /* PSA_NEED_OBERON_CBC_NO_PADDING_AES */
-	if (iv_length != 16) {
-		return PSA_ERROR_INVALID_ARGUMENT;
-	}
-	ocrypto_aes_cbc_pkcs_init((ocrypto_aes_cbc_pkcs_ctx*)operation->ctx, NULL, 0, iv, 0);
+        if (iv_length != 16) return PSA_ERROR_INVALID_ARGUMENT;
+        ocrypto_aes_cbc_pkcs_init((ocrypto_aes_cbc_pkcs_ctx*)operation->ctx, NULL, 0, iv, 0);
         break;
 #endif /* PSA_NEED_OBERON_CBC_PKCS7_AES || PSA_NEED_OBERON_CBC_NO_PADDING_AES */
     default:
@@ -184,15 +179,12 @@ psa_status_t oberon_cipher_update(
 #ifdef PSA_NEED_OBERON_CCM_STAR_NO_TAG_AES
     case PSA_ALG_CCM_STAR_NO_TAG:
 #endif /* PSA_NEED_OBERON_CCM_STAR_NO_TAG_AES */
-	if (output_size < input_length) {
-		return PSA_ERROR_BUFFER_TOO_SMALL;
-	}
-	ocrypto_aes_ctr_update((ocrypto_aes_ctr_ctx*)operation->ctx, output, input, input_length);
+        if (output_size < input_length) return PSA_ERROR_BUFFER_TOO_SMALL;
+        ocrypto_aes_ctr_update((ocrypto_aes_ctr_ctx*)operation->ctx, output, input, input_length);
         *output_length = input_length;
         break;
 #endif /* PSA_NEED_OBERON_CTR_AES || PSA_NEED_OBERON_CCM_STAR_NO_TAG_AES */
-#if defined(PSA_NEED_OBERON_CBC_PKCS7_AES) || defined(PSA_NEED_OBERON_CBC_NO_PADDING_AES) ||       \
-	defined(PSA_NEED_OBERON_ECB_NO_PADDING_AES)
+#if defined(PSA_NEED_OBERON_CBC_PKCS7_AES) || defined(PSA_NEED_OBERON_CBC_NO_PADDING_AES) || defined(PSA_NEED_OBERON_ECB_NO_PADDING_AES)
 #ifdef PSA_NEED_OBERON_CBC_PKCS7_AES
     case PSA_ALG_CBC_PKCS7:
 #endif /* PSA_NEED_OBERON_CBC_PKCS7_AES */
@@ -202,14 +194,12 @@ psa_status_t oberon_cipher_update(
 #ifdef PSA_NEED_OBERON_ECB_NO_PADDING_AES
     case PSA_ALG_ECB_NO_PADDING:
 #endif /* PSA_NEED_OBERON_ECB_NO_PADDING_AES */
-	out_len = ocrypto_aes_cbc_pkcs_output_size((ocrypto_aes_cbc_pkcs_ctx *)operation->ctx,
-						   input_length);
-	if (output_size < out_len) return PSA_ERROR_BUFFER_TOO_SMALL;
+        out_len = ocrypto_aes_cbc_pkcs_output_size((ocrypto_aes_cbc_pkcs_ctx*)operation->ctx, input_length);
+        if (output_size < out_len) return PSA_ERROR_BUFFER_TOO_SMALL;
         ocrypto_aes_cbc_pkcs_update((ocrypto_aes_cbc_pkcs_ctx*)operation->ctx, output, input, input_length);
         *output_length = out_len;
         break;
-#endif /* PSA_NEED_OBERON_CBC_PKCS7_AES || PSA_NEED_OBERON_CBC_NO_PADDING_AES ||                   \
-	  PSA_NEED_OBERON_ECB_NO_PADDING_AES */
+#endif /* PSA_NEED_OBERON_CBC_PKCS7_AES || PSA_NEED_OBERON_CBC_NO_PADDING_AES || PSA_NEED_OBERON_ECB_NO_PADDING_AES */
     default:
         (void)input;
         (void)input_length;
@@ -253,10 +243,10 @@ psa_status_t oberon_cipher_finish(
 #ifdef PSA_NEED_OBERON_ECB_NO_PADDING_AES
     case PSA_ALG_ECB_NO_PADDING:
 #endif /* PSA_NEED_OBERON_ECB_NO_PADDING_AES */
-	if (ocrypto_aes_cbc_pkcs_output_size((ocrypto_aes_cbc_pkcs_ctx *)operation->ctx, 15) > 0) {
-	    return PSA_ERROR_INVALID_ARGUMENT;
-	}
-	break;
+        if (ocrypto_aes_cbc_pkcs_output_size((ocrypto_aes_cbc_pkcs_ctx *)operation->ctx, 15) > 0) {
+            return PSA_ERROR_INVALID_ARGUMENT;
+        }
+        break;
 #endif /* PSA_NEED_OBERON_CBC_NO_PADDING_AES || PSA_NEED_OBERON_ECB_NO_PADDING_AES */
     default:
         (void)output;
@@ -281,8 +271,7 @@ typedef union {
 #if defined(PSA_NEED_OBERON_CTR_AES) || defined(PSA_NEED_OBERON_CCM_STAR_NO_TAG_AES)
     ocrypto_aes_ctr_ctx ctr;
 #endif
-#if defined(PSA_NEED_OBERON_CBC_PKCS7_AES) || defined(PSA_NEED_OBERON_CBC_NO_PADDING_AES) ||       \
-	defined(PSA_NEED_OBERON_ECB_NO_PADDING_AES)
+#if defined(PSA_NEED_OBERON_CBC_PKCS7_AES) || defined(PSA_NEED_OBERON_CBC_NO_PADDING_AES) || defined(PSA_NEED_OBERON_ECB_NO_PADDING_AES)
     ocrypto_aes_cbc_pkcs_ctx cbc;
 #endif
 #ifdef PSA_NEED_OBERON_STREAM_CIPHER_CHACHA20

--- a/ext/oberon/psa/drivers/oberon_ec_keys.c
+++ b/ext/oberon/psa/drivers/oberon_ec_keys.c
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+
 #include <string.h>
 
 #include "psa/crypto.h"
@@ -27,310 +28,252 @@
 #include "ocrypto_ed25519.h"
 #endif /* PSA_NEED_OBERON_KEY_MANAGEMENT_TWISTED_EDWARDS_255 */
 
-psa_status_t oberon_export_ec_public_key(const psa_key_attributes_t *attributes, const uint8_t *key,
-					 size_t key_length, uint8_t *data, size_t data_size,
-					 size_t *data_length)
+
+psa_status_t oberon_export_ec_public_key(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    uint8_t *data, size_t data_size, size_t *data_length)
 {
-	int res;
-	size_t bits = psa_get_key_bits(attributes);
-	psa_key_type_t type = psa_get_key_type(attributes);
+    int res;
+    size_t bits = psa_get_key_bits(attributes);
+    psa_key_type_t type = psa_get_key_type(attributes);
 
-	if (PSA_KEY_TYPE_IS_PUBLIC_KEY(type)) {
-		if (key_length > data_size) {
-			return PSA_ERROR_BUFFER_TOO_SMALL;
-		}
-		memcpy(data, key, key_length);
-		*data_length = key_length;
-		return PSA_SUCCESS;
-	}
+    if (PSA_KEY_TYPE_IS_PUBLIC_KEY(type)) {
+        if (key_length > data_size) return PSA_ERROR_BUFFER_TOO_SMALL;
+        memcpy(data, key, key_length);
+        *data_length = key_length;
+        return PSA_SUCCESS;
+    }
 
-	switch (type) {
+    switch (type) {
 #ifdef PSA_NEED_OBERON_KEY_MANAGEMENT_SECP
-	case PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1):
-		if (data_size < key_length * 2 + 1) {
-			return PSA_ERROR_BUFFER_TOO_SMALL;
-		}
-		*data_length = key_length * 2 + 1;
-		data[0] = 0x04;
-		switch (bits) {
+    case PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1):
+        if (data_size < key_length * 2 + 1) return PSA_ERROR_BUFFER_TOO_SMALL;
+        *data_length = key_length * 2 + 1;
+        data[0] = 0x04;
+        switch (bits) {
 #ifdef PSA_NEED_OBERON_KEY_MANAGEMENT_SECP_R1_224
-		case 224:
-			res = ocrypto_ecdh_p224_public_key(&data[1], key);
-			break;
+        case 224:
+            res = ocrypto_ecdh_p224_public_key(&data[1], key);
+            break;
 #endif /* PSA_NEED_OBERON_KEY_MANAGEMENT_SECP_R1_224 */
 #ifdef PSA_NEED_OBERON_KEY_MANAGEMENT_SECP_R1_256
-		case 256:
-			res = ocrypto_ecdh_p256_public_key(&data[1], key);
-			break;
+        case 256:
+            res = ocrypto_ecdh_p256_public_key(&data[1], key);
+            break;
 #endif /* PSA_NEED_OBERON_KEY_MANAGEMENT_SECP_R1_256 */
 #ifdef PSA_NEED_OBERON_KEY_MANAGEMENT_SECP_R1_384
-		case 384:
-			res = ocrypto_ecdh_p384_public_key(&data[1], key);
-			break;
+        case 384:
+            res = ocrypto_ecdh_p384_public_key(&data[1], key);
+            break;
 #endif /* PSA_NEED_OBERON_KEY_MANAGEMENT_SECP_R1_384 */
-		default:
-			return PSA_ERROR_NOT_SUPPORTED;
-		}
-		if (res) {
-			return PSA_ERROR_INVALID_ARGUMENT;
-		}
-		break;
+        default:
+            return PSA_ERROR_NOT_SUPPORTED;
+        }
+        if (res) return PSA_ERROR_INVALID_ARGUMENT;
+        break;
 #endif /* PSA_NEED_OBERON_KEY_MANAGEMENT_SECP */
 #ifdef PSA_NEED_OBERON_KEY_MANAGEMENT_MONTGOMERY_255
-	case PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_MONTGOMERY):
-		if (bits != 255) {
-			return PSA_ERROR_NOT_SUPPORTED;
-		}
-		if (data_size < key_length) {
-			return PSA_ERROR_BUFFER_TOO_SMALL;
-		}
-		*data_length = key_length;
-		ocrypto_curve25519_scalarmult_base(data, key);
-		break;
+    case PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_MONTGOMERY):
+        if (bits != 255) return PSA_ERROR_NOT_SUPPORTED;
+        if (data_size < key_length) return PSA_ERROR_BUFFER_TOO_SMALL;
+        *data_length = key_length;
+        ocrypto_curve25519_scalarmult_base(data, key);
+        break;
 #endif /* PSA_NEED_OBERON_KEY_MANAGEMENT_MONTGOMERY_255 */
 #ifdef PSA_NEED_OBERON_KEY_MANAGEMENT_TWISTED_EDWARDS_255
-	case PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_TWISTED_EDWARDS):
-		if (bits != 255) {
-			return PSA_ERROR_NOT_SUPPORTED;
-		}
-		if (data_size < key_length) {
-			return PSA_ERROR_BUFFER_TOO_SMALL;
-		}
-		*data_length = key_length;
-		ocrypto_ed25519_public_key(data, key);
-		break;
+    case PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_TWISTED_EDWARDS):
+        if (bits != 255) return PSA_ERROR_NOT_SUPPORTED;
+        if (data_size < key_length) return PSA_ERROR_BUFFER_TOO_SMALL;
+        *data_length = key_length;
+        ocrypto_ed25519_public_key(data, key);
+        break;
 #endif /* PSA_NEED_OBERON_KEY_MANAGEMENT_TWISTED_EDWARDS_255 */
-	default:
-		(void)res;
-		return PSA_ERROR_NOT_SUPPORTED;
-	}
+    default:
+        (void)res;
+        return PSA_ERROR_NOT_SUPPORTED;
+    }
 
-	return PSA_SUCCESS;
+    return PSA_SUCCESS;
 }
 
-psa_status_t oberon_import_ec_key(const psa_key_attributes_t *attributes, const uint8_t *data,
-				  size_t data_length, uint8_t *key, size_t key_size,
-				  size_t *key_length, size_t *key_bits)
+psa_status_t oberon_import_ec_key(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *data, size_t data_length,
+    uint8_t *key, size_t key_size, size_t *key_length,
+    size_t *key_bits)
 {
-	int res;
-	size_t bits = psa_get_key_bits(attributes);
-	psa_key_type_t type = psa_get_key_type(attributes);
+    int res;
+    size_t bits = psa_get_key_bits(attributes);
+    psa_key_type_t type = psa_get_key_type(attributes);
 
-	switch (type) {
+    switch (type) {
 #ifdef PSA_NEED_OBERON_KEY_MANAGEMENT_SECP
-	case PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1):
-		if (bits == 0) {
-			bits = PSA_BYTES_TO_BITS(data_length);
+    case PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1):
+        if (bits == 0) {
+            bits = PSA_BYTES_TO_BITS(data_length);
 #ifdef PSA_NEED_OBERON_KEY_MANAGEMENT_P521
-			if (bits == 528) {
-				bits = 521;
-			}
+            if (bits == 528) bits = 521;
 #endif
-		}
-		switch (bits) {
+        }
+        switch (bits) {
 #ifdef PSA_NEED_OBERON_KEY_MANAGEMENT_SECP_R1_224
-		case 224:
-			if (data_length != 28) {
-				return PSA_ERROR_INVALID_ARGUMENT;
-			}
-			if (!oberon_ct_compare_zero(data, 28)) {
-				return PSA_ERROR_INVALID_ARGUMENT;
-			}
-			res = ocrypto_ecdh_p224_secret_key_check(data);
-			break;
+        case 224:
+            if (data_length != 28) return PSA_ERROR_INVALID_ARGUMENT;
+            if (!oberon_ct_compare_zero(data, 28)) return PSA_ERROR_INVALID_ARGUMENT;
+            res = ocrypto_ecdh_p224_secret_key_check(data);
+            break;
 #endif /* PSA_NEED_OBERON_KEY_MANAGEMENT_SECP_R1_224 */
 #ifdef PSA_NEED_OBERON_KEY_MANAGEMENT_SECP_R1_256
-		case 256:
-			if (data_length != 32) {
-				return PSA_ERROR_INVALID_ARGUMENT;
-			}
-			if (!oberon_ct_compare_zero(data, 32)) {
-				return PSA_ERROR_INVALID_ARGUMENT;
-			}
-			res = ocrypto_ecdh_p256_secret_key_check(data);
-			break;
+        case 256:
+            if (data_length != 32) return PSA_ERROR_INVALID_ARGUMENT;
+            if (!oberon_ct_compare_zero(data, 32)) return PSA_ERROR_INVALID_ARGUMENT;
+            res = ocrypto_ecdh_p256_secret_key_check(data);
+            break;
 #endif /* PSA_NEED_OBERON_KEY_MANAGEMENT_SECP_R1_256 */
 #ifdef PSA_NEED_OBERON_KEY_MANAGEMENT_SECP_R1_384
-		case 384:
-			if (data_length != 48) {
-				return PSA_ERROR_INVALID_ARGUMENT;
-			}
-			if (!oberon_ct_compare_zero(data, 48)) {
-				return PSA_ERROR_INVALID_ARGUMENT;
-			}
-			res = ocrypto_ecdh_p384_secret_key_check(data);
-			break;
+        case 384:
+            if (data_length != 48) return PSA_ERROR_INVALID_ARGUMENT;
+            if (!oberon_ct_compare_zero(data, 48)) return PSA_ERROR_INVALID_ARGUMENT;
+            res = ocrypto_ecdh_p384_secret_key_check(data);
+            break;
 #endif /* PSA_NEED_OBERON_KEY_MANAGEMENT_SECP_R1_384 */
-		default:
-			return PSA_ERROR_NOT_SUPPORTED;
-		}
-		if (res) {
-			return PSA_ERROR_INVALID_ARGUMENT; // out of range
-		}
-		break;
-	case PSA_KEY_TYPE_ECC_PUBLIC_KEY(PSA_ECC_FAMILY_SECP_R1):
-		if (bits == 0) {
-			if ((data_length & 1) == 0) {
-				return PSA_ERROR_INVALID_ARGUMENT;
-			}
-			bits = PSA_BYTES_TO_BITS(data_length >> 1);
+        default:
+            return PSA_ERROR_NOT_SUPPORTED;
+        }
+        if (res) return PSA_ERROR_INVALID_ARGUMENT; // out of range
+        break;
+    case PSA_KEY_TYPE_ECC_PUBLIC_KEY(PSA_ECC_FAMILY_SECP_R1):
+        if (bits == 0) {
+            if ((data_length & 1) == 0) return PSA_ERROR_INVALID_ARGUMENT;
+            bits = PSA_BYTES_TO_BITS(data_length >> 1);
 #ifdef PSA_NEED_OBERON_KEY_MANAGEMENT_P521
-			if (bits == 528) {
-				bits = 521;
-			}
+            if (bits == 528) bits = 521;
 #endif
-		}
-		switch (bits) {
+        }
+        switch (bits) {
 #ifdef PSA_NEED_OBERON_KEY_MANAGEMENT_SECP_R1_224
-		case 224:
-			if (data_length != 57 || data[0] != 0x04) {
-				return PSA_ERROR_INVALID_ARGUMENT;
-			}
-			res = ocrypto_ecdh_p224_public_key_check(&data[1]);
-			break;
+        case 224:
+            if (data_length != 57 || data[0] != 0x04) return PSA_ERROR_INVALID_ARGUMENT;
+            res = ocrypto_ecdh_p224_public_key_check(&data[1]);
+            break;
 #endif /* PSA_NEED_OBERON_KEY_MANAGEMENT_SECP_R1_224 */
 #ifdef PSA_NEED_OBERON_KEY_MANAGEMENT_SECP_R1_256
-		case 256:
-			if (data_length != 65 || data[0] != 0x04) {
-				return PSA_ERROR_INVALID_ARGUMENT;
-			}
-			res = ocrypto_ecdh_p256_public_key_check(&data[1]);
-			break;
+        case 256:
+            if (data_length != 65 || data[0] != 0x04) return PSA_ERROR_INVALID_ARGUMENT;
+            res = ocrypto_ecdh_p256_public_key_check(&data[1]);
+            break;
 #endif /* PSA_NEED_OBERON_KEY_MANAGEMENT_SECP_R1_256 */
 #ifdef PSA_NEED_OBERON_KEY_MANAGEMENT_SECP_R1_384
-		case 384:
-			if (data_length != 97 || data[0] != 0x04) {
-				return PSA_ERROR_INVALID_ARGUMENT;
-			}
-			res = ocrypto_ecdh_p384_public_key_check(&data[1]);
-			break;
+        case 384:
+            if (data_length != 97 || data[0] != 0x04) return PSA_ERROR_INVALID_ARGUMENT;
+            res = ocrypto_ecdh_p384_public_key_check(&data[1]);
+            break;
 #endif /* PSA_NEED_OBERON_KEY_MANAGEMENT_SECP_R1_384 */
-		default:
-			return PSA_ERROR_NOT_SUPPORTED;
-		}
-		if (res) {
-			return PSA_ERROR_INVALID_ARGUMENT; // point not on curve
-		}
-		break;
+        default:
+            return PSA_ERROR_NOT_SUPPORTED;
+        }
+        if (res) return PSA_ERROR_INVALID_ARGUMENT; // point not on curve
+        break;
 #endif /* PSA_NEED_OBERON_KEY_MANAGEMENT_SECP */
-#if defined(PSA_NEED_OBERON_KEY_MANAGEMENT_MONTGOMERY) ||                                          \
-	defined(PSA_NEED_OBERON_KEY_MANAGEMENT_TWISTED_EDWARDS)
+#if defined(PSA_NEED_OBERON_KEY_MANAGEMENT_MONTGOMERY) || defined(PSA_NEED_OBERON_KEY_MANAGEMENT_TWISTED_EDWARDS)
 #ifdef PSA_NEED_OBERON_KEY_MANAGEMENT_MONTGOMERY_255
-	case PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_MONTGOMERY):
-	case PSA_KEY_TYPE_ECC_PUBLIC_KEY(PSA_ECC_FAMILY_MONTGOMERY):
+    case PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_MONTGOMERY):
+    case PSA_KEY_TYPE_ECC_PUBLIC_KEY(PSA_ECC_FAMILY_MONTGOMERY):
 #endif /* PSA_NEED_OBERON_KEY_MANAGEMENT_MONTGOMERY_255 */
 #ifdef PSA_NEED_OBERON_KEY_MANAGEMENT_TWISTED_EDWARDS_255
-	case PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_TWISTED_EDWARDS):
-	case PSA_KEY_TYPE_ECC_PUBLIC_KEY(PSA_ECC_FAMILY_TWISTED_EDWARDS):
+    case PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_TWISTED_EDWARDS):
+    case PSA_KEY_TYPE_ECC_PUBLIC_KEY(PSA_ECC_FAMILY_TWISTED_EDWARDS):
 #endif /* PSA_NEED_OBERON_KEY_MANAGEMENT_TWISTED_EDWARDS_255 */
-		if (bits == 0) {
-			if (data_length == 32) {
-				bits = 255;
-			} else {
-				return PSA_ERROR_NOT_SUPPORTED;
-			}
-		}
-		if (data_length != PSA_BITS_TO_BYTES(bits)) {
-			return PSA_ERROR_INVALID_ARGUMENT;
-		}
-		switch (bits) {
-		case 255:
-			break;
-		default:
-			return PSA_ERROR_NOT_SUPPORTED;
-		}
-		break;
-#endif /* PSA_NEED_OBERON_KEY_MANAGEMENT_MONTGOMERY ||                                             \
-	  PSA_NEED_OBERON_KEY_MANAGEMENT_TWISTED_EDWARDS */
-	default:
-		(void)res;
-		return PSA_ERROR_NOT_SUPPORTED;
-	}
+        if (bits == 0) {
+            if (data_length == 32) bits = 255;
+            else return PSA_ERROR_NOT_SUPPORTED;
+        }
+        if (data_length != PSA_BITS_TO_BYTES(bits)) return PSA_ERROR_INVALID_ARGUMENT;
+        switch (bits) {
+        case 255:
+            break;
+        default:
+            return PSA_ERROR_NOT_SUPPORTED;
+        }
+        break;
+#endif /* PSA_NEED_OBERON_KEY_MANAGEMENT_MONTGOMERY || PSA_NEED_OBERON_KEY_MANAGEMENT_TWISTED_EDWARDS */
+    default:
+        (void)res;
+        return PSA_ERROR_NOT_SUPPORTED;
+    }
 
-	if (*key_bits != 0 && *key_bits != bits) {
-		return PSA_ERROR_INVALID_ARGUMENT;
-	}
-	if (key_size < data_length) {
-		return PSA_ERROR_BUFFER_TOO_SMALL;
-	}
-	memcpy(key, data, data_length);
-	if (type == PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_MONTGOMERY)) {
-		// enforce constant bits
-		key[0] = (uint8_t)(key[0] & 0xF8);
-		key[31] = (uint8_t)((key[31] & 0x7F) | 0x40);
-	}
-	*key_length = data_length;
-	*key_bits = bits;
-	return PSA_SUCCESS;
+    if (*key_bits != 0 && *key_bits != bits) return PSA_ERROR_INVALID_ARGUMENT;
+    if (key_size < data_length) return PSA_ERROR_BUFFER_TOO_SMALL;
+    memcpy(key, data, data_length);
+    if (type == PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_MONTGOMERY)) {
+        // enforce constant bits
+        key[0]  = (uint8_t)(key[0] & 0xF8);
+        key[31] = (uint8_t)((key[31] & 0x7F) | 0x40);
+    }
+    *key_length = data_length;
+    *key_bits = bits;
+    return PSA_SUCCESS;
 }
 
-psa_status_t oberon_generate_ec_key(const psa_key_attributes_t *attributes, uint8_t *key,
-				    size_t key_size, size_t *key_length)
+psa_status_t oberon_generate_ec_key(
+    const psa_key_attributes_t *attributes,
+    uint8_t *key, size_t key_size, size_t *key_length)
 {
-	int res;
-	psa_status_t status;
-	size_t bits = psa_get_key_bits(attributes);
-	psa_key_type_t type = psa_get_key_type(attributes);
-	size_t length = PSA_BITS_TO_BYTES(bits);
+    int res;
+    psa_status_t status;
+    size_t bits = psa_get_key_bits(attributes);
+    psa_key_type_t type = psa_get_key_type(attributes);
+    size_t length = PSA_BITS_TO_BYTES(bits);
 
-	if (key_size < length) {
-		return PSA_ERROR_BUFFER_TOO_SMALL;
-	}
-	*key_length = length;
+    if (key_size < length) return PSA_ERROR_BUFFER_TOO_SMALL;
+    *key_length = length;
 
-	switch (type) {
+    switch (type) {
 #ifdef PSA_NEED_OBERON_KEY_MANAGEMENT_SECP
-	case PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1):
-		do {
-			status = psa_generate_random(key, length);
-			if (status) {
-				return status;
-			}
-			if (!oberon_ct_compare_zero(key, length)) {
-				continue;
-			}
-			switch (bits) {
+    case PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1):
+        do {
+            status = psa_generate_random(key, length);
+            if (status) return status;
+            if (!oberon_ct_compare_zero(key, length)) continue;
+            switch (bits) {
 #ifdef PSA_NEED_OBERON_KEY_MANAGEMENT_SECP_R1_224
-			case 224:
-				res = ocrypto_ecdh_p224_secret_key_check(key);
-				break;
+            case 224:
+                res = ocrypto_ecdh_p224_secret_key_check(key);
+                break;
 #endif /* PSA_NEED_OBERON_KEY_MANAGEMENT_SECP_R1_224 */
 #ifdef PSA_NEED_OBERON_KEY_MANAGEMENT_SECP_R1_256
-			case 256:
-				res = ocrypto_ecdh_p256_secret_key_check(key);
-				break;
+            case 256:
+                res = ocrypto_ecdh_p256_secret_key_check(key);
+                break;
 #endif /* PSA_NEED_OBERON_KEY_MANAGEMENT_SECP_R1_256 */
 #ifdef PSA_NEED_OBERON_KEY_MANAGEMENT_SECP_R1_384
-			case 384:
-				res = ocrypto_ecdh_p384_secret_key_check(key);
-				break;
+            case 384:
+                res = ocrypto_ecdh_p384_secret_key_check(key);
+                break;
 #endif /* PSA_NEED_OBERON_KEY_MANAGEMENT_SECP_R1_384 */
-			default:
-				return PSA_ERROR_NOT_SUPPORTED;
-			}
-		} while (res);
-		break;
+            default:
+                return PSA_ERROR_NOT_SUPPORTED;
+            }
+        } while (res);
+        break;
 #endif /* PSA_NEED_OBERON_KEY_MANAGEMENT_SECP */
 #ifdef PSA_NEED_OBERON_KEY_MANAGEMENT_MONTGOMERY_255
-	case PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_MONTGOMERY):
-		if (bits != 255) {
-			return PSA_ERROR_NOT_SUPPORTED;
-		}
-		return psa_generate_random(key, length);
+    case PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_MONTGOMERY):
+        if (bits != 255) return PSA_ERROR_NOT_SUPPORTED;
+        return psa_generate_random(key, length);
 #endif /* PSA_NEED_OBERON_KEY_MANAGEMENT_MONTGOMERY_255 */
 #ifdef PSA_NEED_OBERON_KEY_MANAGEMENT_TWISTED_EDWARDS_255
-	case PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_TWISTED_EDWARDS):
-		if (bits != 255) {
-			return PSA_ERROR_NOT_SUPPORTED;
-		}
-		return psa_generate_random(key, length);
+    case PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_TWISTED_EDWARDS):
+        if (bits != 255) return PSA_ERROR_NOT_SUPPORTED;
+        return psa_generate_random(key, length);
 #endif /* PSA_NEED_OBERON_KEY_MANAGEMENT_TWISTED_EDWARDS_255 */
-	default:
-		(void)key;
-		(void)res;
-		(void)status;
-		return PSA_ERROR_NOT_SUPPORTED;
-	}
+    default:
+        (void)key;
+        (void)res;
+        (void)status;
+        return PSA_ERROR_NOT_SUPPORTED;
+    }
 
-	return PSA_SUCCESS;
+    return PSA_SUCCESS;
 }

--- a/ext/oberon/psa/drivers/oberon_ec_keys.h
+++ b/ext/oberon/psa/drivers/oberon_ec_keys.h
@@ -5,25 +5,33 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+
 #ifndef OBERON_EC_KEYS_H
 #define OBERON_EC_KEYS_H
 
 #include <psa/crypto_driver_common.h>
 
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-psa_status_t oberon_export_ec_public_key(const psa_key_attributes_t *attributes, const uint8_t *key,
-					 size_t key_length, uint8_t *data, size_t data_size,
-					 size_t *data_length);
 
-psa_status_t oberon_import_ec_key(const psa_key_attributes_t *attributes, const uint8_t *data,
-				  size_t data_length, uint8_t *key, size_t key_size,
-				  size_t *key_length, size_t *bits);
+psa_status_t oberon_export_ec_public_key(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    uint8_t *data, size_t data_size, size_t *data_length);
 
-psa_status_t oberon_generate_ec_key(const psa_key_attributes_t *attributes, uint8_t *key,
-				    size_t key_size, size_t *key_length);
+psa_status_t oberon_import_ec_key(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *data, size_t data_length,
+    uint8_t *key, size_t key_size, size_t *key_length,
+    size_t *bits);
+
+psa_status_t oberon_generate_ec_key(
+    const psa_key_attributes_t *attributes,
+    uint8_t *key, size_t key_size, size_t *key_length);
+
 
 #ifdef __cplusplus
 }

--- a/ext/oberon/psa/drivers/oberon_ecdh.c
+++ b/ext/oberon/psa/drivers/oberon_ecdh.c
@@ -22,10 +22,13 @@
 #include "ocrypto_curve25519.h"
 #endif /* PSA_NEED_OBERON_ECDH_MONTGOMERY_255 */
 
-psa_status_t oberon_ecdh(const psa_key_attributes_t *attributes, const uint8_t *key,
-			 size_t key_length, psa_algorithm_t alg, const uint8_t *peer_key,
-			 size_t peer_key_length, uint8_t *output, size_t output_size,
-			 size_t *output_length)
+
+psa_status_t oberon_ecdh(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg,
+    const uint8_t *peer_key, size_t peer_key_length,
+    uint8_t *output, size_t output_size, size_t *output_length)
 {
     int res = 0;
     size_t bits = psa_get_key_bits(attributes);
@@ -35,34 +38,32 @@ psa_status_t oberon_ecdh(const psa_key_attributes_t *attributes, const uint8_t *
     *output_length = key_length;
 
     switch (psa_get_key_type(attributes)) {
-#if defined(PSA_NEED_OBERON_ECDH_SECP_R1_224) || defined(PSA_NEED_OBERON_ECDH_SECP_R1_256) ||      \
-	defined(PSA_NEED_OBERON_ECDH_SECP_R1_384)
+#if defined(PSA_NEED_OBERON_ECDH_SECP_R1_224) || defined(PSA_NEED_OBERON_ECDH_SECP_R1_256) || defined(PSA_NEED_OBERON_ECDH_SECP_R1_384)
     case PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1):
         if (peer_key_length != key_length * 2 + 1) return PSA_ERROR_INVALID_ARGUMENT;
         if (peer_key[0] != 0x04) return PSA_ERROR_INVALID_ARGUMENT;
         switch (bits) {
 #ifdef PSA_NEED_OBERON_ECDH_SECP_R1_224
-	case 224:
-		res = ocrypto_ecdh_p224_common_secret(output, key, &peer_key[1]);
-		break;
+        case 224:
+            res = ocrypto_ecdh_p224_common_secret(output, key, &peer_key[1]);
+            break;
 #endif /* PSA_NEED_OBERON_ECDH_SECP_R1_224 */
 #ifdef PSA_NEED_OBERON_ECDH_SECP_R1_256
-	case 256:
-		res = ocrypto_ecdh_p256_common_secret(output, key, &peer_key[1]);
-		break;
+        case 256:
+            res = ocrypto_ecdh_p256_common_secret(output, key, &peer_key[1]);
+            break;
 #endif /* PSA_NEED_OBERON_ECDH_SECP_R1_256 */
 #ifdef PSA_NEED_OBERON_ECDH_SECP_R1_384
-	case 384:
-		res = ocrypto_ecdh_p384_common_secret(output, key, &peer_key[1]);
-		break;
+        case 384:
+            res = ocrypto_ecdh_p384_common_secret(output, key, &peer_key[1]);
+            break;
 #endif /* PSA_NEED_OBERON_ECDH_SECP_R1_384 */
-	default:
-		return PSA_ERROR_NOT_SUPPORTED;
+        default:
+            return PSA_ERROR_NOT_SUPPORTED;
         }
         if (res) return PSA_ERROR_INVALID_ARGUMENT;
         break;
-#endif /* PSA_NEED_OBERON_ECDH_SECP_R1_224 || PSA_NEED_OBERON_ECDH_SECP_R1_256 ||                  \
-	  PSA_NEED_OBERON_ECDH_SECP_R1_384 */
+#endif /* PSA_NEED_OBERON_ECDH_SECP_R1_224 || PSA_NEED_OBERON_ECDH_SECP_R1_256 || PSA_NEED_OBERON_ECDH_SECP_R1_384 */
 #ifdef PSA_NEED_OBERON_ECDH_MONTGOMERY_255
     case PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_MONTGOMERY):
         if (bits != 255) return PSA_ERROR_NOT_SUPPORTED;
@@ -76,8 +77,8 @@ psa_status_t oberon_ecdh(const psa_key_attributes_t *attributes, const uint8_t *
         (void)peer_key;
         (void)peer_key_length;
         (void)output;
-	(void)res;
-	return PSA_ERROR_NOT_SUPPORTED;
+        (void)res;
+        return PSA_ERROR_NOT_SUPPORTED;
     }
 
     return PSA_SUCCESS;

--- a/ext/oberon/psa/drivers/oberon_ecdh.h
+++ b/ext/oberon/psa/drivers/oberon_ecdh.h
@@ -16,10 +16,14 @@
 extern "C" {
 #endif
 
-psa_status_t oberon_ecdh(const psa_key_attributes_t *attributes, const uint8_t *key,
-			 size_t key_length, psa_algorithm_t alg, const uint8_t *peer_key,
-			 size_t peer_key_length, uint8_t *output, size_t output_size,
-			 size_t *output_length);
+
+psa_status_t oberon_ecdh(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg,
+    const uint8_t *peer_key, size_t peer_key_length,
+    uint8_t *output, size_t output_size, size_t *output_length);
+
 
 #ifdef __cplusplus
 }

--- a/ext/oberon/psa/drivers/oberon_ecdsa.c
+++ b/ext/oberon/psa/drivers/oberon_ecdsa.c
@@ -25,6 +25,7 @@
 #include "ocrypto_ed25519.h"
 #endif /* PSA_NEED_OBERON_PURE_EDDSA_TWISTED_EDWARDS_255 */
 
+
 #ifdef PSA_NEED_OBERON_ECDSA_SIGN
 static int ecdsa_sign_hash(
     const uint8_t *key, size_t key_length,
@@ -51,11 +52,11 @@ static int ecdsa_sign_hash(
         break;
 #endif /* PSA_NEED_OBERON_ECDSA_SECP_R1_384 */
     default:
-	(void)key;
-	(void)hash;
-	(void)ek;
-	(void)signature;
-	res = 1;
+        (void)key;
+        (void)hash;
+        (void)ek;
+        (void)signature;
+        res = 1;
     }
 
     return res;
@@ -163,10 +164,12 @@ static psa_status_t deterministic_ecdsa_sign_hash(
 }
 #endif /* PSA_NEED_OBERON_ECDSA_DETERMINISTIC */
 
-psa_status_t oberon_ecdsa_sign_hash(const psa_key_attributes_t *attributes, const uint8_t *key,
-				    size_t key_length, psa_algorithm_t alg, const uint8_t *hash,
-				    size_t hash_length, uint8_t *signature, size_t signature_size,
-				    size_t *signature_length)
+psa_status_t oberon_ecdsa_sign_hash(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg,
+    const uint8_t *hash, size_t hash_length,
+    uint8_t *signature, size_t signature_size, size_t *signature_length)
 {
     int res;
     psa_status_t status;
@@ -201,17 +204,17 @@ psa_status_t oberon_ecdsa_sign_hash(const psa_key_attributes_t *attributes, cons
 #endif /* PSA_NEED_OBERON_ECDSA_RANDOMIZED */
 
 #ifdef PSA_NEED_OBERON_ECDSA_DETERMINISTIC
-	    if (PSA_ALG_IS_DETERMINISTIC_ECDSA(alg)) {
-	psa_algorithm_t hash_alg = PSA_ALG_SIGN_GET_HASH(alg);
-	return deterministic_ecdsa_sign_hash(hash_alg, hash, key, key_length, ek, signature);
+    if (PSA_ALG_IS_DETERMINISTIC_ECDSA(alg)) {
+        psa_algorithm_t hash_alg = PSA_ALG_SIGN_GET_HASH(alg);
+        return deterministic_ecdsa_sign_hash(hash_alg, hash, key, key_length, ek, signature);
     } else
 #endif /* PSA_NEED_OBERON_ECDSA_DETERMINISTIC */
 
     {
-	(void)key;
-	(void)alg;
-	(void)signature;
-	(void)ek;
+        (void)key;
+        (void)alg;
+        (void)signature;
+        (void)ek;
         (void)status;
         (void)res;
         return PSA_ERROR_INVALID_ARGUMENT; //  PSA_ERROR_NOT_SUPPORTED;
@@ -220,10 +223,12 @@ psa_status_t oberon_ecdsa_sign_hash(const psa_key_attributes_t *attributes, cons
     return PSA_SUCCESS;
 }
 
-psa_status_t oberon_ecdsa_sign_message(const psa_key_attributes_t *attributes, const uint8_t *key,
-				       size_t key_length, psa_algorithm_t alg, const uint8_t *input,
-				       size_t input_length, uint8_t *signature,
-				       size_t signature_size, size_t *signature_length)
+psa_status_t oberon_ecdsa_sign_message(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg,
+    const uint8_t *input, size_t input_length,
+    uint8_t *signature, size_t signature_size, size_t *signature_length)
 {
 #if defined(PSA_NEED_OBERON_PURE_EDDSA_TWISTED_EDWARDS_448)
     uint8_t pub_key[56];
@@ -257,10 +262,12 @@ psa_status_t oberon_ecdsa_sign_message(const psa_key_attributes_t *attributes, c
     }
 }
 
-psa_status_t oberon_ecdsa_verify_hash(const psa_key_attributes_t *attributes, const uint8_t *key,
-				      size_t key_length, psa_algorithm_t alg, const uint8_t *hash,
-				      size_t hash_length, const uint8_t *signature,
-				      size_t signature_length)
+psa_status_t oberon_ecdsa_verify_hash(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg,
+    const uint8_t *hash, size_t hash_length,
+    const uint8_t *signature, size_t signature_length)
 {
     int res;
     uint8_t ext_hash[PSA_BITS_TO_BYTES(PSA_VENDOR_ECC_MAX_CURVE_BITS)];
@@ -292,31 +299,31 @@ psa_status_t oberon_ecdsa_verify_hash(const psa_key_attributes_t *attributes, co
         if (signature_length != 2 * length) return PSA_ERROR_INVALID_SIGNATURE;
         switch (length) {
 #ifdef PSA_NEED_OBERON_ECDSA_SECP_R1_224
-	case 28:
-	    if (type == PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1)) {
+        case 28:
+            if (type == PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1)) {
                 ocrypto_ecdsa_p224_public_key(key_buf, key);
             }
             res = ocrypto_ecdsa_p224_verify_hash(signature, hash, pub_key);
             break;
 #endif /* PSA_NEED_OBERON_ECDSA_SECP_R1_224 */
 #ifdef PSA_NEED_OBERON_ECDSA_SECP_R1_256
-	case 32:
-	    if (type == PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1)) {
+        case 32:
+            if (type == PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1)) {
                 ocrypto_ecdsa_p256_public_key(key_buf, key);
             }
             res = ocrypto_ecdsa_p256_verify_hash(signature, hash, pub_key);
             break;
 #endif /* PSA_NEED_OBERON_ECDSA_SECP_R1_256 */
 #ifdef PSA_NEED_OBERON_ECDSA_SECP_R1_384
-	case 48:
-	    if (type == PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1)) {
+        case 48:
+            if (type == PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1)) {
                 ocrypto_ecdsa_p384_public_key(key_buf, key);
             }
             res = ocrypto_ecdsa_p384_verify_hash(signature, hash, pub_key);
             break;
 #endif /* PSA_NEED_OBERON_ECDSA_SECP_R1_384 */
-	default:
-	    (void)signature;
+        default:
+            (void)signature;
             return PSA_ERROR_NOT_SUPPORTED;
         }
     } else {
@@ -327,10 +334,12 @@ psa_status_t oberon_ecdsa_verify_hash(const psa_key_attributes_t *attributes, co
     return PSA_SUCCESS;
 }
 
-psa_status_t oberon_ecdsa_verify_message(const psa_key_attributes_t *attributes, const uint8_t *key,
-					 size_t key_length, psa_algorithm_t alg,
-					 const uint8_t *input, size_t input_length,
-					 const uint8_t *signature, size_t signature_length)
+psa_status_t oberon_ecdsa_verify_message(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg,
+    const uint8_t *input, size_t input_length,
+    const uint8_t *signature, size_t signature_length)
 {
     int res;
 #if defined(PSA_NEED_OBERON_PURE_EDDSA_TWISTED_EDWARDS_448)

--- a/ext/oberon/psa/drivers/oberon_ecdsa.h
+++ b/ext/oberon/psa/drivers/oberon_ecdsa.h
@@ -16,25 +16,35 @@
 extern "C" {
 #endif
 
-psa_status_t oberon_ecdsa_sign_message(const psa_key_attributes_t *attributes, const uint8_t *key,
-				       size_t key_length, psa_algorithm_t alg, const uint8_t *input,
-				       size_t input_length, uint8_t *signature,
-				       size_t signature_size, size_t *signature_length);
 
-psa_status_t oberon_ecdsa_sign_hash(const psa_key_attributes_t *attributes, const uint8_t *key,
-				    size_t key_length, psa_algorithm_t alg, const uint8_t *hash,
-				    size_t hash_length, uint8_t *signature, size_t signature_size,
-				    size_t *signature_length);
+psa_status_t oberon_ecdsa_sign_message(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg,
+    const uint8_t *input, size_t input_length,
+    uint8_t *signature, size_t signature_size, size_t *signature_length);
 
-psa_status_t oberon_ecdsa_verify_message(const psa_key_attributes_t *attributes, const uint8_t *key,
-					 size_t key_length, psa_algorithm_t alg,
-					 const uint8_t *input, size_t input_length,
-					 const uint8_t *signature, size_t signature_length);
+psa_status_t oberon_ecdsa_sign_hash(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg,
+    const uint8_t *hash, size_t hash_length,
+    uint8_t *signature, size_t signature_size, size_t *signature_length);
 
-psa_status_t oberon_ecdsa_verify_hash(const psa_key_attributes_t *attributes, const uint8_t *key,
-				      size_t key_length, psa_algorithm_t alg, const uint8_t *hash,
-				      size_t hash_length, const uint8_t *signature,
-				      size_t signature_length);
+psa_status_t oberon_ecdsa_verify_message(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg,
+    const uint8_t *input, size_t input_length,
+    const uint8_t *signature, size_t signature_length);
+
+psa_status_t oberon_ecdsa_verify_hash(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg,
+    const uint8_t *hash, size_t hash_length,
+    const uint8_t *signature, size_t signature_length);
+
 
 #ifdef __cplusplus
 }

--- a/ext/oberon/psa/drivers/oberon_helpers.c
+++ b/ext/oberon/psa/drivers/oberon_helpers.c
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+
+
 #include "oberon_helpers.h"
 
 

--- a/ext/oberon/psa/drivers/oberon_key_agreement.c
+++ b/ext/oberon/psa/drivers/oberon_key_agreement.c
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+
 #include "psa/crypto.h"
 #include "oberon_key_agreement.h"
 
@@ -12,30 +13,36 @@
 #include "oberon_ecdh.h"
 #endif /* PSA_NEED_OBERON_ECDH */
 
-psa_status_t oberon_key_agreement(const psa_key_attributes_t *attributes, const uint8_t *key,
-				  size_t key_length, psa_algorithm_t alg, const uint8_t *peer_key,
-				  size_t peer_key_length, uint8_t *output, size_t output_size,
-				  size_t *output_length)
+
+psa_status_t oberon_key_agreement(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg,
+    const uint8_t *peer_key, size_t peer_key_length,
+    uint8_t *output, size_t output_size, size_t *output_length)
 {
-	psa_key_type_t type = psa_get_key_type(attributes);
+    psa_key_type_t type = psa_get_key_type(attributes);
 
 #ifdef PSA_NEED_OBERON_ECDH
-	if (PSA_KEY_TYPE_IS_ECC(type)) {
-		return oberon_ecdh(attributes, key, key_length, alg, peer_key, peer_key_length,
-				   output, output_size, output_length);
-	} else
+    if (PSA_KEY_TYPE_IS_ECC(type)) {
+        return oberon_ecdh(
+            attributes, key, key_length,
+            alg,
+            peer_key, peer_key_length,
+            output, output_size, output_length);
+    } else
 #endif /* PSA_NEED_OBERON_ECDH */
 
-	{
-		(void)type;
-		(void)key;
-		(void)key_length;
-		(void)alg;
-		(void)peer_key;
-		(void)peer_key_length;
-		(void)output;
-		(void)output_size;
-		(void)output_length;
-		return PSA_ERROR_NOT_SUPPORTED;
-	}
+    {
+        (void)type;
+        (void)key;
+        (void)key_length;
+        (void)alg;
+        (void)peer_key;
+        (void)peer_key_length;
+        (void)output;
+        (void)output_size;
+        (void)output_length;
+        return PSA_ERROR_NOT_SUPPORTED;
+    }
 }

--- a/ext/oberon/psa/drivers/oberon_key_agreement.h
+++ b/ext/oberon/psa/drivers/oberon_key_agreement.h
@@ -5,19 +5,25 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+
 #ifndef OBERON_KEY_AGREEMENT_H
 #define OBERON_KEY_AGREEMENT_H
 
 #include <psa/crypto_driver_common.h>
 
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-psa_status_t oberon_key_agreement(const psa_key_attributes_t *attributes, const uint8_t *key,
-				  size_t key_length, psa_algorithm_t alg, const uint8_t *peer_key,
-				  size_t peer_key_length, uint8_t *output, size_t output_size,
-				  size_t *output_length);
+
+psa_status_t oberon_key_agreement(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg,
+    const uint8_t *peer_key, size_t peer_key_length,
+    uint8_t *output, size_t output_size, size_t *output_length);
+
 
 #ifdef __cplusplus
 }

--- a/ext/oberon/psa/drivers/oberon_key_derivation.c
+++ b/ext/oberon/psa/drivers/oberon_key_derivation.c
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+
 #include <string.h>
 
 #include "psa/crypto.h"
@@ -12,599 +13,502 @@
 #include "oberon_helpers.h"
 #include "psa_crypto_driver_wrappers.h"
 
+
 #if defined(PSA_NEED_OBERON_HKDF) || defined(PSA_NEED_OBERON_PBKDF2_AES_CMAC_PRF_128)
-static const uint8_t zero[PSA_HASH_MAX_SIZE] = {0};
+static const uint8_t zero[PSA_HASH_MAX_SIZE] = { 0 };
 #endif
 
-#if defined(PSA_NEED_OBERON_HKDF) || defined(PSA_NEED_OBERON_PBKDF2_HMAC) ||                       \
-	defined(PSA_NEED_OBERON_PBKDF2_AES_CMAC_PRF_128)
-static psa_status_t oberon_setup_mac(oberon_key_derivation_operation_t *operation,
-				     const uint8_t *key, size_t key_length)
-{
-	psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
-	psa_set_key_type(&attributes, operation->key_type);
-	psa_set_key_bits(&attributes, PSA_BYTES_TO_BITS(key_length));
-	psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_SIGN_MESSAGE);
 
-	memset(&operation->mac_op, 0, sizeof operation->mac_op);
-	return psa_driver_wrapper_mac_sign_setup(&operation->mac_op, &attributes, key, key_length,
-						 operation->mac_alg);
+#if defined(PSA_NEED_OBERON_HKDF) || defined(PSA_NEED_OBERON_PBKDF2_HMAC) || defined(PSA_NEED_OBERON_PBKDF2_AES_CMAC_PRF_128)
+static psa_status_t oberon_setup_mac(
+    oberon_key_derivation_operation_t *operation,
+    const uint8_t *key, size_t key_length)
+{
+    psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+    psa_set_key_type(&attributes, operation->key_type);
+    psa_set_key_bits(&attributes, PSA_BYTES_TO_BITS(key_length));
+    psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_SIGN_MESSAGE);
+    
+    memset(&operation->mac_op, 0, sizeof operation->mac_op);
+    return psa_driver_wrapper_mac_sign_setup(
+        &operation->mac_op,
+        &attributes, key, key_length,
+        operation->mac_alg);
 }
 #endif
 
-#ifdef PSA_NEED_OBERON_PBKDF2_HMAC
-static psa_status_t oberon_hash_key(oberon_key_derivation_operation_t *operation,
-				    const uint8_t *data, size_t data_length)
-{
-	psa_status_t status;
-	size_t length;
 
-	memset(&operation->hash_op, 0, sizeof operation->hash_op);
-	status = psa_driver_wrapper_hash_setup(&operation->hash_op,
-					       PSA_ALG_HMAC_GET_HASH(operation->mac_alg));
-	if (status) {
-		goto exit;
-	}
-	status = psa_driver_wrapper_hash_update(&operation->hash_op, data, data_length);
-	if (status) {
-		goto exit;
-	}
-	status = psa_driver_wrapper_hash_finish(&operation->hash_op, operation->key,
-						operation->block_length, &length);
+#ifdef PSA_NEED_OBERON_PBKDF2_HMAC
+static psa_status_t oberon_hash_key(
+    oberon_key_derivation_operation_t *operation,
+    const uint8_t *data, size_t data_length)
+{
+    psa_status_t status;
+    size_t length;
+
+    memset(&operation->hash_op, 0, sizeof operation->hash_op);
+    status = psa_driver_wrapper_hash_setup(&operation->hash_op, PSA_ALG_HMAC_GET_HASH(operation->mac_alg));
+    if (status) goto exit;
+    status = psa_driver_wrapper_hash_update(&operation->hash_op, data, data_length);
+    if (status) goto exit;
+    status = psa_driver_wrapper_hash_finish(&operation->hash_op, operation->key, operation->block_length, &length);
 
 exit:
-	psa_driver_wrapper_hash_abort(&operation->hash_op);
-	return status;
+    psa_driver_wrapper_hash_abort(&operation->hash_op);
+    return status;
 }
 #endif /* PSA_NEED_OBERON_PBKDF2_HMAC */
 
-psa_status_t oberon_key_derivation_setup(oberon_key_derivation_operation_t *operation,
-					 psa_algorithm_t alg)
+
+psa_status_t oberon_key_derivation_setup(
+    oberon_key_derivation_operation_t *operation,
+    psa_algorithm_t alg)
 {
 #ifdef PSA_NEED_OBERON_PBKDF2_AES_CMAC_PRF_128
-	if (alg == PSA_ALG_PBKDF2_AES_CMAC_PRF_128) {
-		operation->block_length = PSA_BLOCK_CIPHER_BLOCK_LENGTH(PSA_KEY_TYPE_AES);
-		operation->mac_alg = PSA_ALG_CMAC;
-		operation->key_type = PSA_KEY_TYPE_AES;
-		operation->alg = OBERON_PBKDF2_CMAC_ALG;
-	} else
+    if (alg == PSA_ALG_PBKDF2_AES_CMAC_PRF_128) {
+        operation->block_length = PSA_BLOCK_CIPHER_BLOCK_LENGTH(PSA_KEY_TYPE_AES);
+        operation->mac_alg = PSA_ALG_CMAC;
+        operation->key_type = PSA_KEY_TYPE_AES;
+        operation->alg = OBERON_PBKDF2_CMAC_ALG;
+    } else
 #endif /* PSA_NEED_OBERON_PBKDF2_AES_CMAC_PRF_128 */
 
-	{
-		// all olthers are HMAC based
-		psa_algorithm_t hash = PSA_ALG_HKDF_GET_HASH(alg);
-		unsigned hash_length = PSA_HASH_LENGTH(hash);
-		if (hash_length == 0) {
-			return PSA_ERROR_NOT_SUPPORTED;
-		}
-		operation->block_length = (uint8_t)hash_length;
-		operation->mac_alg = PSA_ALG_HMAC(hash);
-		operation->key_type = PSA_KEY_TYPE_HMAC;
+    {
+        // all olthers are HMAC based
+        psa_algorithm_t hash = PSA_ALG_HKDF_GET_HASH(alg);
+        unsigned hash_length = PSA_HASH_LENGTH(hash);
+        if (hash_length == 0) return PSA_ERROR_NOT_SUPPORTED;
+        operation->block_length = (uint8_t)hash_length;
+        operation->mac_alg = PSA_ALG_HMAC(hash);
+        operation->key_type = PSA_KEY_TYPE_HMAC;
 
 #ifdef PSA_NEED_OBERON_HKDF
-		if (PSA_ALG_IS_HKDF(alg)) {
-			operation->info_length = 0;
-			operation->alg = OBERON_HKDF_ALG;
-		} else
+        if (PSA_ALG_IS_HKDF(alg)) {
+            operation->info_length = 0;
+            operation->alg = OBERON_HKDF_ALG;
+        } else
 #endif /* PSA_NEED_OBERON_HKDF */
 
 #ifdef PSA_NEED_OBERON_HKDF_EXTRACT
-			if (PSA_ALG_IS_HKDF_EXTRACT(alg)) {
-			operation->info_length = 0;
-			operation->alg = OBERON_HKDF_EXTRACT_ALG;
-		} else
+        if (PSA_ALG_IS_HKDF_EXTRACT(alg)) {
+            operation->info_length = 0;
+            operation->alg = OBERON_HKDF_EXTRACT_ALG;
+        } else
 #endif /* PSA_NEED_OBERON_HKDF_EXTRACT */
 
 #ifdef PSA_NEED_OBERON_HKDF_EXPAND
-			if (PSA_ALG_IS_HKDF_EXPAND(alg)) {
-			psa_algorithm_t hash = PSA_ALG_HKDF_GET_HASH(alg);
-			unsigned hash_length = PSA_HASH_LENGTH(hash);
-			if (hash_length == 0) {
-				return PSA_ERROR_NOT_SUPPORTED;
-			}
-			operation->info_length = 0;
-			operation->alg = OBERON_HKDF_EXPAND_ALG;
-		} else
+        if (PSA_ALG_IS_HKDF_EXPAND(alg)) {
+            psa_algorithm_t hash = PSA_ALG_HKDF_GET_HASH(alg);
+            unsigned hash_length = PSA_HASH_LENGTH(hash);
+            if (hash_length == 0) return PSA_ERROR_NOT_SUPPORTED;
+            operation->info_length = 0;
+            operation->alg = OBERON_HKDF_EXPAND_ALG;
+        } else
 #endif /* PSA_NEED_OBERON_HKDF_EXPAND */
 
 #ifdef PSA_NEED_OBERON_TLS12_PRF
-			if (PSA_ALG_IS_TLS12_PRF(alg)) {
-			operation->alg = OBERON_TLS12_PRF_ALG;
-		} else
+        if (PSA_ALG_IS_TLS12_PRF(alg)) {
+            operation->alg = OBERON_TLS12_PRF_ALG;
+        } else
 #endif /* PSA_NEED_OBERON_TLS12_PRF */
 
 #ifdef PSA_NEED_OBERON_TLS12_PSK_TO_MS
-			if (PSA_ALG_IS_TLS12_PSK_TO_MS(alg)) {
-			operation->alg = OBERON_TLS12_PSK_TO_MS_ALG;
-			operation->count = 0;
-		} else
+        if (PSA_ALG_IS_TLS12_PSK_TO_MS(alg)) {
+            operation->alg = OBERON_TLS12_PSK_TO_MS_ALG;
+            operation->count = 0;
+        } else
 #endif /* PSA_NEED_OBERON_TLS12_PSK_TO_MS */
 
 #ifdef PSA_NEED_OBERON_PBKDF2_HMAC
-			if (PSA_ALG_IS_PBKDF2_HMAC(alg)) {
-			operation->alg = OBERON_PBKDF2_HMAC_ALG;
-		} else
+        if (PSA_ALG_IS_PBKDF2_HMAC(alg)) {
+            operation->alg = OBERON_PBKDF2_HMAC_ALG;
+        } else
 #endif /* PSA_NEED_OBERON_PBKDF2_HMAC */
 
 #ifdef PSA_NEED_OBERON_TLS12_ECJPAKE_TO_PMS
-			if (alg == PSA_ALG_TLS12_ECJPAKE_TO_PMS) {
-			operation->alg = OBERON_ECJPAKE_TO_PMS_ALG;
-		} else
+        if (alg == PSA_ALG_TLS12_ECJPAKE_TO_PMS) {
+            operation->alg = OBERON_ECJPAKE_TO_PMS_ALG;
+        } else
 #endif /* PSA_NEED_OBERON_TLS12_ECJPAKE_TO_PMS */
 
-		{
-			(void)alg;
-			return PSA_ERROR_NOT_SUPPORTED;
-		}
-	}
+        {
+            (void)alg;
+            return PSA_ERROR_NOT_SUPPORTED;
+        }
+    }
 
-	operation->salt_length = 0;
-	operation->data_length = 0;
-	operation->index = 1;
-	return PSA_SUCCESS;
+    operation->salt_length = 0;
+    operation->data_length = 0;
+    operation->index = 1;
+    return PSA_SUCCESS;
 }
 
-psa_status_t oberon_key_derivation_set_capacity(oberon_key_derivation_operation_t *operation,
-						size_t capacity)
+psa_status_t oberon_key_derivation_set_capacity(
+    oberon_key_derivation_operation_t *operation,
+    size_t capacity)
 {
-	(void)operation;
-	(void)capacity;
-	return PSA_SUCCESS;
+    (void)operation;
+    (void)capacity;
+    return PSA_SUCCESS;
 }
 
-psa_status_t oberon_key_derivation_input_bytes(oberon_key_derivation_operation_t *operation,
-					       psa_key_derivation_step_t step, const uint8_t *data,
-					       size_t data_length)
+psa_status_t oberon_key_derivation_input_bytes(
+    oberon_key_derivation_operation_t *operation,
+    psa_key_derivation_step_t step,
+    const uint8_t *data, size_t data_length)
 {
-	psa_status_t status;
-	size_t length;
+    psa_status_t status;
+    size_t length;
 
-	switch (step) {
+    switch (step) {
 
-	case PSA_KEY_DERIVATION_INPUT_SALT:
-		if (data_length) {
-			if (operation->alg == OBERON_HKDF_ALG ||
-			    operation->alg == OBERON_HKDF_EXTRACT_ALG) {
+    case PSA_KEY_DERIVATION_INPUT_SALT:
+        if (data_length) {
+            if (operation->alg == OBERON_HKDF_ALG || operation->alg == OBERON_HKDF_EXTRACT_ALG) {
 #if defined(PSA_NEED_OBERON_HKDF) || defined(PSA_NEED_OBERON_HKDF_EXTRACT)
-				status = oberon_setup_mac(operation, data, data_length);
-				if (status) {
-					goto exit;
-				}
-				operation->salt_length = (uint16_t)data_length;
+                status = oberon_setup_mac(operation, data, data_length);
+                if (status) goto exit;
+                operation->salt_length = (uint16_t)data_length;
 #endif /* PSA_NEED_OBERON_HKDF || PSA_NEED_OBERON_HKDF_EXTRACT */
-			} else {
+            } else {
 #if defined(PSA_NEED_OBERON_PBKDF2_HMAC) || defined(PSA_NEED_OBERON_PBKDF2_AES_CMAC_PRF_128)
-				length = operation->salt_length + data_length;
-				if (length < data_length || length > sizeof operation->info) {
-					return PSA_ERROR_INSUFFICIENT_MEMORY;
-				}
-				memcpy(operation->info + operation->salt_length, data, data_length);
-				operation->salt_length = (uint16_t)length;
+                length = operation->salt_length + data_length;
+                if (length < data_length || length > sizeof operation->info) return PSA_ERROR_INSUFFICIENT_MEMORY;
+                memcpy(operation->info + operation->salt_length, data, data_length);
+                operation->salt_length = (uint16_t)length;
 #endif /* PSA_NEED_OBERON_PBKDF2_HMAC || PSA_NEED_OBERON_PBKDF2_AES_CMAC_PRF_128 */
-			}
-		}
-		return PSA_SUCCESS;
+            }
+        }
+        return PSA_SUCCESS;
 
 #if defined(PSA_NEED_OBERON_TLS12_PSK_TO_MS)
-	case PSA_KEY_DERIVATION_INPUT_OTHER_SECRET:
-		if (data_length) {
-			if (data_length >
-			    sizeof operation->key - PSA_TLS12_PSK_TO_MS_PSK_MAX_SIZE - 4) {
-				return PSA_ERROR_INSUFFICIENT_MEMORY;
-			}
-			memcpy(operation->key + 2, data, data_length);
-		}
-		operation->key_length = (uint16_t)data_length;
-		operation->count = 1;
-		return PSA_SUCCESS;
+    case PSA_KEY_DERIVATION_INPUT_OTHER_SECRET:
+        if (data_length) {
+            if (data_length > sizeof operation->key - PSA_TLS12_PSK_TO_MS_PSK_MAX_SIZE - 4) return PSA_ERROR_INSUFFICIENT_MEMORY;
+            memcpy(operation->key + 2, data, data_length);
+        }
+        operation->key_length = (uint16_t)data_length;
+        operation->count = 1;
+        return PSA_SUCCESS;
 #endif /* PSA_NEED_OBERON_TLS12_PSK_TO_MS */
 
-#if defined(PSA_NEED_OBERON_HKDF) || defined(PSA_NEED_OBERON_HKDF_EXTRACT) ||                      \
-	defined(PSA_NEED_OBERON_HKDF_EXPAND) || defined(PSA_NEED_OBERON_TLS12_PRF) ||              \
-	defined(PSA_NEED_OBERON_TLS12_PSK_TO_MS) || defined(PSA_NEED_OBERON_TLS12_ECJPAKE_TO_PMS)
-	case PSA_KEY_DERIVATION_INPUT_SECRET:
-		switch (operation->alg) {
+#if defined(PSA_NEED_OBERON_HKDF) || defined(PSA_NEED_OBERON_HKDF_EXTRACT) || \
+    defined(PSA_NEED_OBERON_HKDF_EXPAND) || defined(PSA_NEED_OBERON_TLS12_PRF) || \
+    defined(PSA_NEED_OBERON_TLS12_PSK_TO_MS) || defined(PSA_NEED_OBERON_TLS12_ECJPAKE_TO_PMS)
+    case PSA_KEY_DERIVATION_INPUT_SECRET:
+        switch (operation->alg) {
 #ifdef PSA_NEED_OBERON_HKDF_EXPAND
-		case OBERON_HKDF_EXPAND_ALG:
-			// skip extract phase
-			if (data_length != operation->block_length) {
-				return PSA_ERROR_INVALID_ARGUMENT;
-			}
-			memcpy(operation->key, data, data_length);
-			return PSA_SUCCESS;
+        case OBERON_HKDF_EXPAND_ALG:
+            // skip extract phase
+            if (data_length != operation->block_length) return PSA_ERROR_INVALID_ARGUMENT;
+            memcpy(operation->key, data, data_length);
+            return PSA_SUCCESS;
 #endif /* PSA_NEED_OBERON_HKDF_EXPAND */
 #ifdef PSA_NEED_OBERON_TLS12_PRF
-		case OBERON_TLS12_PRF_ALG:
-			if (data_length > sizeof operation->key) {
-				return PSA_ERROR_INSUFFICIENT_MEMORY;
-			}
-			memcpy(operation->key, data, data_length);
-			operation->key_length = (uint16_t)data_length;
-			return PSA_SUCCESS;
+        case OBERON_TLS12_PRF_ALG:
+            if (data_length > sizeof operation->key) return PSA_ERROR_INSUFFICIENT_MEMORY;
+            memcpy(operation->key, data, data_length);
+            operation->key_length = (uint16_t)data_length;
+            return PSA_SUCCESS;
 #endif /* PSA_NEED_OBERON_TLS12_PRF */
 #ifdef PSA_NEED_OBERON_TLS12_PSK_TO_MS
-		case OBERON_TLS12_PSK_TO_MS_ALG:
-			if (data_length > PSA_TLS12_PSK_TO_MS_PSK_MAX_SIZE) {
-				return PSA_ERROR_INVALID_ARGUMENT;
-			}
-			length = operation->key_length; // other secret length
-			if (operation->count == 0) {
-				// plain PSK: set other secret to data_length zeroes
-				memset(operation->key + 2, 0, data_length);
-				length = data_length;
-			}
-			operation->key[0] = (uint8_t)(length >> 8);
-			operation->key[1] = (uint8_t)length;
-			operation->key[length + 2] = (uint8_t)(data_length >> 8);
-			operation->key[length + 3] = (uint8_t)data_length;
-			memcpy(operation->key + length + 4, data, data_length);
-			operation->key_length =
-				(uint16_t)(length + data_length + 4); // total secret length
-			return PSA_SUCCESS;
+        case OBERON_TLS12_PSK_TO_MS_ALG:
+            if (data_length > PSA_TLS12_PSK_TO_MS_PSK_MAX_SIZE) return PSA_ERROR_INVALID_ARGUMENT;
+            length = operation->key_length; // other secret length
+            if (operation->count == 0) {
+                // plain PSK: set other secret to data_length zeroes
+                memset(operation->key + 2, 0, data_length);
+                length = data_length;
+            }
+            operation->key[0] = (uint8_t)(length >> 8);
+            operation->key[1] = (uint8_t)length;
+            operation->key[length + 2] = (uint8_t)(data_length >> 8);
+            operation->key[length + 3] = (uint8_t)data_length;
+            memcpy(operation->key + length + 4, data, data_length);
+            operation->key_length = (uint16_t)(length + data_length + 4); // total secret length
+            return PSA_SUCCESS;
 #endif /* PSA_NEED_OBERON_TLS12_PSK_TO_MS */
 #ifdef PSA_NEED_OBERON_TLS12_ECJPAKE_TO_PMS
-		case OBERON_ECJPAKE_TO_PMS_ALG:
-			if (data_length != PSA_TLS12_ECJPAKE_TO_PMS_INPUT_SIZE || data[0] != 0x04) {
-				return PSA_ERROR_INVALID_ARGUMENT; // P256 point
-			}
-			memcpy(operation->key, &data[1], 32); // input.x
-			operation->key_length = (uint16_t)32;
-			return PSA_SUCCESS;
+        case OBERON_ECJPAKE_TO_PMS_ALG:
+            if (data_length != PSA_TLS12_ECJPAKE_TO_PMS_INPUT_SIZE || data[0] != 0x04) {
+                return PSA_ERROR_INVALID_ARGUMENT; // P256 point
+            }
+            memcpy(operation->key, &data[1], 32); // input.x
+            operation->key_length = (uint16_t)32;
+            return PSA_SUCCESS;
 #endif /* PSA_NEED_OBERON_TLS12_ECJPAKE_TO_PMS */
-		default:
+        default:
 #if defined(PSA_NEED_OBERON_HKDF) || defined(PSA_NEED_OBERON_HKDF_EXTRACT)
-			if (operation->salt_length == 0) {
-				// set zero salt
-				status = oberon_setup_mac(operation, zero, operation->block_length);
-				if (status) {
-					goto exit;
-				}
-			}
-			// add secret
-			status = psa_driver_wrapper_mac_update(&operation->mac_op, data,
-							       data_length);
-			if (status) {
-				goto exit;
-			}
-			// HKDF extract
-			status = psa_driver_wrapper_mac_sign_finish(
-				&operation->mac_op, operation->key, operation->block_length,
-				&length);
-			if (status) {
-				goto exit;
-			}
+            if (operation->salt_length == 0) {
+                // set zero salt
+                status = oberon_setup_mac(operation, zero, operation->block_length);
+                if (status) goto exit;
+            }
+            // add secret
+            status = psa_driver_wrapper_mac_update(&operation->mac_op, data, data_length);
+            if (status) goto exit;
+            // HKDF extract
+            status = psa_driver_wrapper_mac_sign_finish(&operation->mac_op, operation->key, operation->block_length, &length);
+            if (status) goto exit;
 #endif /* PSA_NEED_OBERON_HKDF || PSA_NEED_OBERON_HKDF_EXTRACT */
-			return PSA_SUCCESS;
-		}
-#endif /* PSA_NEED_OBERON_HKDF || PSA_NEED_OBERON_HKDF_EXTRACT || PSA_NEED_OBERON_HKDF_EXPAND ||   \
-	  PSA_NEED_OBERON_TLS12 */
+            return PSA_SUCCESS;
+        }
+#endif /* PSA_NEED_OBERON_HKDF || PSA_NEED_OBERON_HKDF_EXTRACT || PSA_NEED_OBERON_HKDF_EXPAND || PSA_NEED_OBERON_TLS12 */
 
-#if defined(PSA_NEED_OBERON_HKDF) || defined(PSA_NEED_OBERON_HKDF_EXTRACT) ||                      \
-	defined(PSA_NEED_OBERON_HKDF_EXPAND)
-	case PSA_KEY_DERIVATION_INPUT_INFO:
-		if (data_length > sizeof operation->info) {
-			return PSA_ERROR_INSUFFICIENT_MEMORY;
-		}
-		memcpy(operation->info, data, data_length);
-		operation->info_length = (uint16_t)data_length;
-		return PSA_SUCCESS;
+#if defined(PSA_NEED_OBERON_HKDF) || defined(PSA_NEED_OBERON_HKDF_EXTRACT) || defined(PSA_NEED_OBERON_HKDF_EXPAND)
+    case PSA_KEY_DERIVATION_INPUT_INFO:
+        if (data_length > sizeof operation->info) return PSA_ERROR_INSUFFICIENT_MEMORY;
+        memcpy(operation->info, data, data_length);
+        operation->info_length = (uint16_t)data_length;
+        return PSA_SUCCESS;
 #endif /* PSA_NEED_OBERON_HKDF || PSA_NEED_OBERON_HKDF_EXTRACT || PSA_NEED_OBERON_HKDF_EXPAND */
 
 #if defined(PSA_NEED_OBERON_PBKDF2_HMAC) || defined(PSA_NEED_OBERON_PBKDF2_AES_CMAC_PRF_128)
-	case PSA_KEY_DERIVATION_INPUT_PASSWORD:
-		if (operation->alg == OBERON_PBKDF2_HMAC_ALG) {
+    case PSA_KEY_DERIVATION_INPUT_PASSWORD:
+        if (operation->alg == OBERON_PBKDF2_HMAC_ALG) {
 #ifdef PSA_NEED_OBERON_PBKDF2_HMAC
-			size_t hash_block_size = PSA_HASH_BLOCK_LENGTH(operation->mac_alg);
-			if (data_length > hash_block_size) {
-				// key = H(password)
-				status = oberon_hash_key(operation, data, data_length);
-				if (status) {
-					return status; // no cleanup needed
-				}
-				operation->key_length = (uint16_t)operation->block_length;
-			} else {
-				memcpy(operation->key, data, data_length);
-				operation->key_length = (uint16_t)data_length;
-			}
+            size_t hash_block_size = PSA_HASH_BLOCK_LENGTH(operation->mac_alg);
+            if (data_length > hash_block_size) {
+                // key = H(password)
+                status = oberon_hash_key(operation, data, data_length);
+                if (status) return status; // no cleanup needed
+                operation->key_length = (uint16_t)operation->block_length;
+            } else {
+                memcpy(operation->key, data, data_length);
+                operation->key_length = (uint16_t)data_length;
+            }
 #endif /* PSA_NEED_OBERON_PBKDF2_HMAC */
-		} else {
+        } else {
 #ifdef PSA_NEED_OBERON_PBKDF2_AES_CMAC_PRF_128
-			if (data_length == 16) {
-				memcpy(operation->key, data, 16);
-			} else {
-				// key = mac(zero, password)
-				status = oberon_setup_mac(operation, zero, 16); // zero key
-				if (status) {
-					goto exit;
-				}
-				status = psa_driver_wrapper_mac_update(&operation->mac_op, data,
-								       data_length);
-				if (status) {
-					goto exit;
-				}
-				status = psa_driver_wrapper_mac_sign_finish(
-					&operation->mac_op, operation->key, 16, &length);
-				if (status) {
-					goto exit;
-				}
-			}
-			operation->key_length = 16;
+            if (data_length == 16) {
+                memcpy(operation->key, data, 16);
+            } else {
+                // key = mac(zero, password)
+                status = oberon_setup_mac(operation, zero, 16); // zero key
+                if (status) goto exit;
+                status = psa_driver_wrapper_mac_update(&operation->mac_op, data, data_length);
+                if (status) goto exit;
+                status = psa_driver_wrapper_mac_sign_finish(&operation->mac_op, operation->key, 16, &length);
+                if (status) goto exit;
+            }
+            operation->key_length = 16;
 #endif /* PSA_NEED_OBERON_PBKDF2_AES_CMAC_PRF_128 */
-		}
-		return PSA_SUCCESS;
+        }
+        return PSA_SUCCESS;
 #endif /* PSA_NEED_OBERON_PBKDF2_HMAC || PSA_NEED_OBERON_PBKDF2_AES_CMAC_PRF_128 */
 
 #if defined(PSA_NEED_OBERON_TLS12_PRF) || defined(PSA_NEED_OBERON_TLS12_PSK_TO_MS)
-	case PSA_KEY_DERIVATION_INPUT_SEED:
-		if (data_length > sizeof operation->info) {
-			return PSA_ERROR_INSUFFICIENT_MEMORY;
-		}
-		memcpy(operation->info, data, data_length);
-		operation->info_length = (uint16_t)data_length;
-		return PSA_SUCCESS;
-	case PSA_KEY_DERIVATION_INPUT_LABEL:
-		// seed = label || seed
-		length = operation->info_length + data_length;
-		if (length < data_length || length > sizeof operation->info) {
-			return PSA_ERROR_INSUFFICIENT_MEMORY;
-		}
-		memmove(operation->info + data_length, operation->info, operation->info_length);
-		memcpy(operation->info, data, data_length);
-		operation->info_length = (uint16_t)length;
-		return PSA_SUCCESS;
+    case PSA_KEY_DERIVATION_INPUT_SEED:
+        if (data_length > sizeof operation->info) return PSA_ERROR_INSUFFICIENT_MEMORY;
+        memcpy(operation->info, data, data_length);
+        operation->info_length = (uint16_t)data_length;
+        return PSA_SUCCESS;
+    case PSA_KEY_DERIVATION_INPUT_LABEL:
+        // seed = label || seed
+        length = operation->info_length + data_length;
+        if (length < data_length || length > sizeof operation->info) return PSA_ERROR_INSUFFICIENT_MEMORY;
+        memmove(operation->info + data_length, operation->info, operation->info_length);
+        memcpy(operation->info, data, data_length);
+        operation->info_length = (uint16_t)length;
+        return PSA_SUCCESS;
 #endif /* PSA_NEED_OBERON_TLS12_PRF || PSA_NEED_OBERON_TLS12_PSK_TO_MS */
 
-	default:
-		(void)data;
-		(void)data_length;
-		(void)status;
-		(void)length;
-		return PSA_ERROR_INVALID_ARGUMENT;
-	}
+    default:
+        (void)data;
+        (void)data_length;
+        (void)status;
+        (void)length;
+        return PSA_ERROR_INVALID_ARGUMENT;
+    }
 
-#if defined(PSA_NEED_OBERON_HKDF) || defined(PSA_NEED_OBERON_HKDF_EXTRACT) ||                      \
-	defined(PSA_NEED_OBERON_PBKDF2_AES_CMAC_PRF_128)
+#if defined(PSA_NEED_OBERON_HKDF) || defined(PSA_NEED_OBERON_HKDF_EXTRACT) || \
+    defined(PSA_NEED_OBERON_PBKDF2_AES_CMAC_PRF_128)
 exit:
-	psa_driver_wrapper_mac_abort(&operation->mac_op);
-	return status;
+    psa_driver_wrapper_mac_abort(&operation->mac_op);
+    return status;
 #endif
 }
 
-psa_status_t oberon_key_derivation_input_integer(oberon_key_derivation_operation_t *operation,
-						 psa_key_derivation_step_t step, uint64_t value)
+psa_status_t oberon_key_derivation_input_integer(
+    oberon_key_derivation_operation_t *operation,
+    psa_key_derivation_step_t step,
+    uint64_t value)
 {
-	switch (step) {
+    switch (step) {
 #if defined(PSA_NEED_OBERON_PBKDF2_HMAC) || defined(PSA_NEED_OBERON_PBKDF2_AES_CMAC_PRF_128)
-	case PSA_KEY_DERIVATION_INPUT_COST:
-		operation->count = (uint32_t)value;
-		return PSA_SUCCESS;
+    case PSA_KEY_DERIVATION_INPUT_COST:
+        operation->count = (uint32_t)value;
+        return PSA_SUCCESS;
 #endif /* PSA_NEED_OBERON_PBKDF2_HMAC || PSA_NEED_OBERON_PBKDF2_AES_CMAC_PRF_128 */
-	default:
-		(void)operation;
-		(void)value;
-		return PSA_ERROR_INVALID_ARGUMENT;
-	}
+    default:
+        (void)operation;
+        (void)value;
+        return PSA_ERROR_INVALID_ARGUMENT;
+    }
 }
 
-psa_status_t oberon_key_derivation_output_bytes(oberon_key_derivation_operation_t *operation,
-						uint8_t *output, size_t output_length)
+psa_status_t oberon_key_derivation_output_bytes(
+    oberon_key_derivation_operation_t *operation,
+    uint8_t *output, size_t output_length)
 {
-	psa_status_t status;
-	size_t block_length = operation->block_length;
-	size_t data_length = operation->data_length;
-	size_t i, length;
-	uint8_t u[PSA_HASH_MAX_SIZE];
-	uint8_t idx[4];
+    psa_status_t status;
+    size_t block_length = operation->block_length;
+    size_t data_length = operation->data_length;
+    size_t i, length;
+    uint8_t u[PSA_HASH_MAX_SIZE];
+    uint8_t idx[4];
 
-	if (output_length == 0) {
-		return PSA_SUCCESS;
-	}
+    if (output_length == 0) return PSA_SUCCESS;
 
-	if (data_length) {
-		if (data_length >= output_length) {
-			memcpy(output, operation->data + block_length - data_length, output_length);
-			operation->data_length = (uint8_t)(data_length - output_length);
-			return PSA_SUCCESS;
-		} else {
-			memcpy(output, operation->data + block_length - data_length, data_length);
-			output += data_length;
-			output_length -= data_length;
-		}
-	}
-
-	// KDF expand
-	for (;;) {
-		switch (operation->alg) {
+    if (data_length) {
+        if (data_length >= output_length) {
+            memcpy(output, operation->data + block_length - data_length, output_length);
+            operation->data_length = (uint8_t)(data_length - output_length);
+            return PSA_SUCCESS;
+        } else {
+            memcpy(output, operation->data + block_length - data_length, data_length);
+            output += data_length;
+            output_length -= data_length;
+        }
+    }
+    
+    // KDF expand
+    for (;;) {
+        switch (operation->alg) {
 
 #ifdef PSA_NEED_OBERON_HKDF_EXTRACT
-		case OBERON_HKDF_EXTRACT_ALG:
-			// skip expand phase
-			memcpy(operation->data, operation->key, block_length);
-			break;
+        case OBERON_HKDF_EXTRACT_ALG:
+            // skip expand phase
+            memcpy(operation->data, operation->key, block_length);
+            break;
 #endif /* PSA_NEED_OBERON_HKDF_EXTRACT */
 
 #if defined(PSA_NEED_OBERON_HKDF) || defined(PSA_NEED_OBERON_HKDF_EXPAND)
-		case OBERON_HKDF_ALG:
-		case OBERON_HKDF_EXPAND_ALG:
-			status = oberon_setup_mac(operation, operation->key, block_length); // prk
-			if (status) {
-				goto exit;
-			}
-			// T(i-1)
-			if (operation->index > 1) {
-				status = psa_driver_wrapper_mac_update(
-					&operation->mac_op, operation->data, block_length);
-				if (status) {
-					goto exit;
-				}
-			}
-			// info
-			status = psa_driver_wrapper_mac_update(&operation->mac_op, operation->info,
-							       operation->info_length);
-			if (status) {
-				goto exit;
-			}
-			// i
-			idx[0] = (uint8_t)operation->index;
-			status = psa_driver_wrapper_mac_update(&operation->mac_op, idx, 1);
-			if (status) {
-				goto exit;
-			}
-			status = psa_driver_wrapper_mac_sign_finish(
-				&operation->mac_op, operation->data, block_length, &length);
-			if (status) {
-				goto exit;
-			}
-			break;
+        case OBERON_HKDF_ALG:
+        case OBERON_HKDF_EXPAND_ALG:
+            status = oberon_setup_mac(operation, operation->key, block_length); // prk
+            if (status) goto exit;
+            // T(i-1)
+            if (operation->index > 1) {
+                status = psa_driver_wrapper_mac_update(&operation->mac_op, operation->data, block_length);
+                if (status) goto exit;
+            }
+            // info
+            status = psa_driver_wrapper_mac_update(&operation->mac_op, operation->info, operation->info_length);
+            if (status) goto exit;
+            // i
+            idx[0] = (uint8_t)operation->index;
+            status = psa_driver_wrapper_mac_update(&operation->mac_op, idx, 1);
+            if (status) goto exit;
+            status = psa_driver_wrapper_mac_sign_finish(&operation->mac_op, operation->data, block_length, &length);
+            if (status) goto exit;
+            break;
 #endif /* PSA_NEED_OBERON_HKDF || PSA_NEED_OBERON_HKDF_EXPAND */
 
 #if defined(PSA_NEED_OBERON_TLS12_PRF) || defined(PSA_NEED_OBERON_TLS12_PSK_TO_MS)
-		case OBERON_TLS12_PRF_ALG:
-		case OBERON_TLS12_PSK_TO_MS_ALG:
-			// A(i) = HMAC(A(i-1))
-			status = oberon_setup_mac(operation, operation->key, operation->key_length);
-			if (status) {
-				goto exit;
-			}
-			if (operation->index == 1) {
-				status = psa_driver_wrapper_mac_update(
-					&operation->mac_op, operation->info,
-					operation->info_length); // A(0)
-			} else {
-				status = psa_driver_wrapper_mac_update(
-					&operation->mac_op, operation->a, block_length); // A(i)
-			}
-			if (status) {
-				goto exit;
-			}
-			status = psa_driver_wrapper_mac_sign_finish(
-				&operation->mac_op, operation->a, block_length, &length);
-			if (status) {
-				goto exit;
-			}
-			// P_hash() = HMAC(A(i) || seed)
-			status = oberon_setup_mac(operation, operation->key, operation->key_length);
-			if (status) {
-				goto exit;
-			}
-			status = psa_driver_wrapper_mac_update(&operation->mac_op, operation->a,
-							       block_length); // A(i)
-			if (status) {
-				goto exit;
-			}
-			status = psa_driver_wrapper_mac_update(&operation->mac_op, operation->info,
-							       operation->info_length); // seed
-			if (status) {
-				goto exit;
-			}
-			status = psa_driver_wrapper_mac_sign_finish(
-				&operation->mac_op, operation->data, block_length, &length);
-			if (status) {
-				goto exit;
-			}
-			break;
+        case OBERON_TLS12_PRF_ALG:
+        case OBERON_TLS12_PSK_TO_MS_ALG:
+            // A(i) = HMAC(A(i-1))
+            status = oberon_setup_mac(operation, operation->key, operation->key_length);
+            if (status) goto exit;
+            if (operation->index == 1) {
+                status = psa_driver_wrapper_mac_update(&operation->mac_op, operation->info, operation->info_length); // A(0)
+            } else {
+                status = psa_driver_wrapper_mac_update(&operation->mac_op, operation->a, block_length); // A(i)
+            }
+            if (status) goto exit;
+            status = psa_driver_wrapper_mac_sign_finish(&operation->mac_op, operation->a, block_length, &length);
+            if (status) goto exit;
+            // P_hash() = HMAC(A(i) || seed)
+            status = oberon_setup_mac(operation, operation->key, operation->key_length);
+            if (status) goto exit;
+            status = psa_driver_wrapper_mac_update(&operation->mac_op, operation->a, block_length); // A(i)
+            if (status) goto exit;
+            status = psa_driver_wrapper_mac_update(&operation->mac_op, operation->info, operation->info_length); // seed
+            if (status) goto exit;
+            status = psa_driver_wrapper_mac_sign_finish(&operation->mac_op, operation->data, block_length, &length);
+            if (status) goto exit;
+            break;
 #endif /* PSA_NEED_OBERON_TLS12_PRF || PSA_NEED_OBERON_TLS12_PSK_TO_MS */
 
 #if defined(PSA_NEED_OBERON_PBKDF2_HMAC) || defined(PSA_NEED_OBERON_PBKDF2_AES_CMAC_PRF_128)
 #ifdef PSA_NEED_OBERON_PBKDF2_HMAC
-		case OBERON_PBKDF2_HMAC_ALG:
+        case OBERON_PBKDF2_HMAC_ALG:
 #endif /* PSA_NEED_OBERON_PBKDF2_HMAC */
 #ifdef PSA_NEED_OBERON_PBKDF2_AES_CMAC_PRF_128
-		case OBERON_PBKDF2_CMAC_ALG:
+        case OBERON_PBKDF2_CMAC_ALG:
 #endif /* PSA_NEED_OBERON_PBKDF2_AES_CMAC_PRF_128 */
-			// U1 = mac(password, salt || int32be(i))
-			status = oberon_setup_mac(operation, operation->key, operation->key_length);
-			if (status) {
-				goto exit;
-			}
-			status = psa_driver_wrapper_mac_update(&operation->mac_op, operation->info,
-							       operation->salt_length);
-			if (status) {
-				goto exit;
-			}
-			idx[0] = (uint8_t)(operation->index >> 24);
-			idx[1] = (uint8_t)(operation->index >> 16);
-			idx[2] = (uint8_t)(operation->index >> 8);
-			idx[3] = (uint8_t)(operation->index);
-			status = psa_driver_wrapper_mac_update(&operation->mac_op, idx, 4);
-			if (status) {
-				goto exit;
-			}
-			status = psa_driver_wrapper_mac_sign_finish(&operation->mac_op, u,
-								    block_length, &length);
-			if (status) {
-				goto exit;
-			}
-			memcpy(operation->data, u, block_length);
-			for (i = 1; i < operation->count; i++) {
-				// Ui = mac(password, Ui-1)
-				status = oberon_setup_mac(operation, operation->key,
-							  operation->key_length);
-				if (status) {
-					goto exit;
-				}
-				status = psa_driver_wrapper_mac_update(&operation->mac_op, u,
-								       block_length);
-				if (status) {
-					goto exit;
-				}
-				status = psa_driver_wrapper_mac_sign_finish(&operation->mac_op, u,
-									    block_length, &length);
-				if (status) {
-					goto exit;
-				}
-				// Ti ^= Ui
-				oberon_xor(operation->data, operation->data, u, block_length);
-			}
-			break;
+            // U1 = mac(password, salt || int32be(i))
+            status = oberon_setup_mac(operation, operation->key, operation->key_length);
+            if (status) goto exit;
+            status = psa_driver_wrapper_mac_update(&operation->mac_op, operation->info, operation->salt_length);
+            if (status) goto exit;
+            idx[0] = (uint8_t)(operation->index >> 24);
+            idx[1] = (uint8_t)(operation->index >> 16);
+            idx[2] = (uint8_t)(operation->index >> 8);
+            idx[3] = (uint8_t)(operation->index);
+            status = psa_driver_wrapper_mac_update(&operation->mac_op, idx, 4);
+            if (status) goto exit;
+            status = psa_driver_wrapper_mac_sign_finish(&operation->mac_op, u, block_length, &length);
+            if (status) goto exit;
+            memcpy(operation->data, u, block_length);
+            for (i = 1; i < operation->count; i++) {
+                // Ui = mac(password, Ui-1)
+                status = oberon_setup_mac(operation, operation->key, operation->key_length);
+                if (status) goto exit;
+                status = psa_driver_wrapper_mac_update(&operation->mac_op, u, block_length);
+                if (status) goto exit;
+                status = psa_driver_wrapper_mac_sign_finish(&operation->mac_op, u, block_length, &length);
+                if (status) goto exit;
+                // Ti ^= Ui
+                oberon_xor(operation->data, operation->data, u, block_length);
+            }
+            break;
 #endif /* PSA_NEED_OBERON_PBKDF2_HMAC || PSA_NEED_OBERON_PBKDF2_AES_CMAC_PRF_128 */
 
 #ifdef PSA_NEED_OBERON_TLS12_ECJPAKE_TO_PMS
-		case OBERON_ECJPAKE_TO_PMS_ALG:
-			if (output_length != PSA_TLS12_ECJPAKE_TO_PMS_DATA_SIZE) {
-				return PSA_ERROR_INVALID_ARGUMENT;
-			}
-			return psa_driver_wrapper_hash_compute(PSA_ALG_SHA_256, operation->key, 32,
-							       output, output_length, &length);
+        case OBERON_ECJPAKE_TO_PMS_ALG:
+            if (output_length != PSA_TLS12_ECJPAKE_TO_PMS_DATA_SIZE) return PSA_ERROR_INVALID_ARGUMENT;
+            return psa_driver_wrapper_hash_compute(PSA_ALG_SHA_256, operation->key, 32, output, output_length, &length);
 #endif /* PSA_NEED_OBERON_TLS12_ECJPAKE_TO_PMS */
 
-		default:
-			(void)i;
-			(void)u;
-			(void)idx;
-			(void)length;
-			(void)status;
-			return PSA_ERROR_BAD_STATE;
-		}
-		operation->index++;
-		if (output_length > block_length) {
-			memcpy(output, operation->data, block_length);
-			output += block_length;
-			output_length -= block_length;
-		} else {
-			memcpy(output, operation->data, output_length);
-			operation->data_length = (uint8_t)(block_length - output_length);
-			return PSA_SUCCESS;
-		}
-	}
+        default:
+            (void)i;
+            (void)u;
+            (void)idx;
+            (void)length;
+            (void)status;
+            return PSA_ERROR_BAD_STATE;
+        }
+        operation->index++;
+        if (output_length > block_length) {
+            memcpy(output, operation->data, block_length);
+            output += block_length;
+            output_length -= block_length;
+        } else {
+            memcpy(output, operation->data, output_length);
+            operation->data_length = (uint8_t)(block_length - output_length);
+            return PSA_SUCCESS;
+        }
+    }
 
-#if defined(PSA_NEED_OBERON_HKDF) || defined(PSA_NEED_OBERON_HKDF_EXPAND) ||                       \
-	defined(PSA_NEED_OBERON_PBKDF2_HMAC) ||                                                    \
-	defined(PSA_NEED_OBERON_PBKDF2_AES_CMAC_PRF_128) || defined(PSA_NEED_OBERON_TLS12_PRF) ||  \
-	defined(PSA_NEED_OBERON_TLS12_PSK_TO_MS)
+#if defined(PSA_NEED_OBERON_HKDF) || defined(PSA_NEED_OBERON_HKDF_EXPAND) || \
+    defined(PSA_NEED_OBERON_PBKDF2_HMAC) || defined(PSA_NEED_OBERON_PBKDF2_AES_CMAC_PRF_128) || \
+    defined(PSA_NEED_OBERON_TLS12_PRF) || defined(PSA_NEED_OBERON_TLS12_PSK_TO_MS)
 exit:
-	psa_driver_wrapper_mac_abort(&operation->mac_op);
-	return status;
+    psa_driver_wrapper_mac_abort(&operation->mac_op);
+    return status;
 #endif
 }
 
-psa_status_t oberon_key_derivation_abort(oberon_key_derivation_operation_t *operation)
+psa_status_t oberon_key_derivation_abort(
+    oberon_key_derivation_operation_t *operation )
 {
-	switch (operation->alg) {
-	case OBERON_HKDF_ALG:
-	case OBERON_HKDF_EXTRACT_ALG:
-		return psa_driver_wrapper_mac_abort(&operation->mac_op);
-	default:
-		return PSA_SUCCESS;
-	}
+    switch (operation->alg) {
+    case OBERON_HKDF_ALG:
+    case OBERON_HKDF_EXTRACT_ALG:
+        return psa_driver_wrapper_mac_abort(&operation->mac_op);
+    default:
+        return PSA_SUCCESS;
+    }
 }

--- a/ext/oberon/psa/drivers/oberon_key_derivation.h
+++ b/ext/oberon/psa/drivers/oberon_key_derivation.h
@@ -5,72 +5,85 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+
 #ifndef OBERON_KEY_DERIVATION_H
 #define OBERON_KEY_DERIVATION_H
 
 #include <psa/crypto_driver_common.h>
 #include <psa/crypto_struct.h>
 
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#define OBERON_KDF_MAX_INFO_BYTES      256
-#define OBERON_TLS12_PRF_MAX_KEY_BYTES 516
+
+#define OBERON_KDF_MAX_INFO_BYTES  256
+#define OBERON_TLS12_PRF_MAX_KEY_BYTES  516
+
 
 typedef enum {
-	OBERON_HKDF_ALG = 1,
-	OBERON_HKDF_EXTRACT_ALG = 2,
-	OBERON_HKDF_EXPAND_ALG = 3,
-	OBERON_PBKDF2_HMAC_ALG = 4,
-	OBERON_PBKDF2_CMAC_ALG = 5,
-	OBERON_TLS12_PRF_ALG = 6,
-	OBERON_TLS12_PSK_TO_MS_ALG = 7,
-	OBERON_ECJPAKE_TO_PMS_ALG = 8,
+    OBERON_HKDF_ALG = 1,
+    OBERON_HKDF_EXTRACT_ALG = 2,
+    OBERON_HKDF_EXPAND_ALG = 3,
+    OBERON_PBKDF2_HMAC_ALG = 4,
+    OBERON_PBKDF2_CMAC_ALG = 5,
+    OBERON_TLS12_PRF_ALG = 6,
+    OBERON_TLS12_PSK_TO_MS_ALG = 7,
+    OBERON_ECJPAKE_TO_PMS_ALG = 8,
 } oberon_kdf_alg;
 
 typedef struct {
-	union {
-		psa_mac_operation_t mac_op;
-		psa_hash_operation_t hash_op;
-	};
-	uint8_t data[PSA_HASH_MAX_SIZE];
-	uint8_t info[OBERON_KDF_MAX_INFO_BYTES];
+    union {
+        psa_mac_operation_t  mac_op;
+        psa_hash_operation_t hash_op;
+    };
+    uint8_t         data[PSA_HASH_MAX_SIZE];
+    uint8_t         info[OBERON_KDF_MAX_INFO_BYTES];
 #if defined(PSA_NEED_OBERON_TLS12_PRF) || defined(PSA_NEED_OBERON_TLS12_PSK_TO_MS)
-	uint8_t key[OBERON_TLS12_PRF_MAX_KEY_BYTES];
-	uint8_t a[PSA_HASH_MAX_SIZE];
+    uint8_t         key[OBERON_TLS12_PRF_MAX_KEY_BYTES];
+    uint8_t         a[PSA_HASH_MAX_SIZE];
 #else
-	uint8_t key[PSA_HMAC_MAX_HASH_BLOCK_SIZE];
+    uint8_t         key[PSA_HMAC_MAX_HASH_BLOCK_SIZE];
 #endif
-	psa_algorithm_t mac_alg;
-	psa_key_type_t key_type;
-	uint8_t data_length;
-	uint8_t block_length;
-	uint16_t salt_length;
-	uint16_t info_length;
-	uint16_t key_length;
-	uint32_t index;
-	uint32_t count;
-	oberon_kdf_alg alg;
+    psa_algorithm_t mac_alg;
+    psa_key_type_t  key_type;
+    uint8_t         data_length;
+    uint8_t         block_length;
+    uint16_t        salt_length;
+    uint16_t        info_length;
+    uint16_t        key_length;
+    uint32_t        index;
+    uint32_t        count;
+    oberon_kdf_alg  alg;
 } oberon_key_derivation_operation_t;
 
-psa_status_t oberon_key_derivation_setup(oberon_key_derivation_operation_t *operation,
-					 psa_algorithm_t alg);
 
-psa_status_t oberon_key_derivation_set_capacity(oberon_key_derivation_operation_t *operation,
-						size_t capacity);
+psa_status_t oberon_key_derivation_setup(
+    oberon_key_derivation_operation_t *operation,
+    psa_algorithm_t alg);
 
-psa_status_t oberon_key_derivation_input_bytes(oberon_key_derivation_operation_t *operation,
-					       psa_key_derivation_step_t step, const uint8_t *data,
-					       size_t data_length);
+psa_status_t oberon_key_derivation_set_capacity(
+    oberon_key_derivation_operation_t *operation,
+    size_t capacity);
 
-psa_status_t oberon_key_derivation_input_integer(oberon_key_derivation_operation_t *operation,
-						 psa_key_derivation_step_t step, uint64_t value);
+psa_status_t oberon_key_derivation_input_bytes(
+    oberon_key_derivation_operation_t *operation,
+    psa_key_derivation_step_t step,
+    const uint8_t *data, size_t data_length);
 
-psa_status_t oberon_key_derivation_output_bytes(oberon_key_derivation_operation_t *operation,
-						uint8_t *output, size_t output_length);
+psa_status_t oberon_key_derivation_input_integer(
+    oberon_key_derivation_operation_t *operation,
+    psa_key_derivation_step_t step,
+    uint64_t value);
 
-psa_status_t oberon_key_derivation_abort(oberon_key_derivation_operation_t *operation);
+psa_status_t oberon_key_derivation_output_bytes(
+    oberon_key_derivation_operation_t *operation,
+    uint8_t *output, size_t output_length);
+
+psa_status_t oberon_key_derivation_abort(
+    oberon_key_derivation_operation_t *operation );
+
 
 #ifdef __cplusplus
 }

--- a/ext/oberon/psa/drivers/oberon_key_management.c
+++ b/ext/oberon/psa/drivers/oberon_key_management.c
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+
 #include "psa/crypto.h"
 #include "oberon_key_management.h"
 
@@ -15,85 +16,96 @@
 #include "oberon_rsa.h"
 #endif /* PSA_NEED_OBERON_KEY_MANAGEMENT_RSA */
 
-psa_status_t oberon_export_public_key(const psa_key_attributes_t *attributes, const uint8_t *key,
-				      size_t key_length, uint8_t *data, size_t data_size,
-				      size_t *data_length)
+
+psa_status_t oberon_export_public_key(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    uint8_t *data, size_t data_size, size_t *data_length)
 {
-	psa_key_type_t type = psa_get_key_type(attributes);
+    psa_key_type_t type = psa_get_key_type(attributes);
 
 #ifdef PSA_NEED_OBERON_KEY_MANAGEMENT_ECC
-	if (PSA_KEY_TYPE_IS_ECC(type)) {
-		return oberon_export_ec_public_key(attributes, key, key_length, data, data_size,
-						   data_length);
-	} else
+    if (PSA_KEY_TYPE_IS_ECC(type)) {
+        return oberon_export_ec_public_key(
+            attributes, key, key_length,
+            data, data_size, data_length);
+    } else
 #endif /* PSA_NEED_OBERON_KEY_MANAGEMENT_ECC */
 
 #ifdef PSA_NEED_OBERON_KEY_MANAGEMENT_RSA
-		if (PSA_KEY_TYPE_IS_RSA(type)) {
-		return oberon_export_rsa_public_key(attributes, key, key_length, data, data_size,
-						    data_length);
-	} else
+    if (PSA_KEY_TYPE_IS_RSA(type)) {
+        return oberon_export_rsa_public_key(
+            attributes, key, key_length,
+            data, data_size, data_length);
+    } else
 #endif /* PSA_NEED_OBERON_RSAC_KEY_PAIR */
 
-	{
-		(void)key;
-		(void)key_length;
-		(void)data;
-		(void)data_size;
-		(void)data_length;
-		(void)type;
-		return PSA_ERROR_NOT_SUPPORTED;
-	}
+    {
+        (void)key;
+        (void)key_length;
+        (void)data;
+        (void)data_size;
+        (void)data_length;
+        (void)type;
+        return PSA_ERROR_NOT_SUPPORTED;
+    }
 }
 
-psa_status_t oberon_import_key(const psa_key_attributes_t *attributes, const uint8_t *data,
-			       size_t data_length, uint8_t *key, size_t key_size,
-			       size_t *key_length, size_t *key_bits)
+psa_status_t oberon_import_key(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *data, size_t data_length,
+    uint8_t *key, size_t key_size, size_t *key_length,
+    size_t *key_bits)
 {
-	psa_key_type_t type = psa_get_key_type(attributes);
+    psa_key_type_t type = psa_get_key_type(attributes);
 
 #ifdef PSA_NEED_OBERON_KEY_MANAGEMENT_ECC
-	if (PSA_KEY_TYPE_IS_ECC(type)) {
-		return oberon_import_ec_key(attributes, data, data_length, key, key_size,
-					    key_length, key_bits);
-	} else
+    if (PSA_KEY_TYPE_IS_ECC(type)) {
+        return oberon_import_ec_key(
+            attributes, data, data_length,
+            key, key_size, key_length, key_bits);
+    } else
 #endif /* PSA_NEED_OBERON_KEY_MANAGEMENT_ECC */
 
 #ifdef PSA_NEED_OBERON_KEY_MANAGEMENT_RSA
-		if (PSA_KEY_TYPE_IS_RSA(type)) {
-		return oberon_import_rsa_key(attributes, data, data_length, key, key_size,
-					     key_length, key_bits);
-	} else
+    if (PSA_KEY_TYPE_IS_RSA(type)) {
+        return oberon_import_rsa_key(
+            attributes, data, data_length,
+            key, key_size, key_length, key_bits);
+    } else
 #endif /* PSA_NEED_OBERON_KEY_MANAGEMENT_RSA */
 
-	{
-		(void)data;
-		(void)data_length;
-		(void)key;
-		(void)key_size;
-		(void)key_length;
-		(void)key_bits;
-		(void)type;
-		return PSA_ERROR_NOT_SUPPORTED;
-	}
+    {
+        (void)data;
+        (void)data_length;
+        (void)key;
+        (void)key_size;
+        (void)key_length;
+        (void)key_bits;
+        (void)type;
+        return PSA_ERROR_NOT_SUPPORTED;
+    }
 }
 
-psa_status_t oberon_generate_key(const psa_key_attributes_t *attributes, uint8_t *key,
-				 size_t key_size, size_t *key_length)
+psa_status_t oberon_generate_key(
+    const psa_key_attributes_t *attributes,
+    uint8_t *key, size_t key_size, size_t *key_length)
 {
-	psa_key_type_t type = psa_get_key_type(attributes);
+    psa_key_type_t type = psa_get_key_type(attributes);
 
 #ifdef PSA_NEED_OBERON_KEY_MANAGEMENT_ECC
-	if (PSA_KEY_TYPE_IS_ECC(type)) {
-		return oberon_generate_ec_key(attributes, key, key_size, key_length);
-	} else
+    if (PSA_KEY_TYPE_IS_ECC(type)) {
+        return oberon_generate_ec_key(
+            attributes,
+            key, key_size, key_length);
+    } else
 #endif /* PSA_NEED_OBERON_KEY_MANAGEMENT_ECC */
 
-	{
-		(void)key;
-		(void)key_size;
-		(void)key_length;
-		(void)type;
-		return PSA_ERROR_NOT_SUPPORTED;
-	}
+    {
+        (void)key;
+        (void)key_size;
+        (void)key_length;
+        (void)type;
+        return PSA_ERROR_NOT_SUPPORTED;
+    }
 }

--- a/ext/oberon/psa/drivers/oberon_key_management.h
+++ b/ext/oberon/psa/drivers/oberon_key_management.h
@@ -5,25 +5,33 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+
 #ifndef OBERON_KEY_MANAGEMENT_H
 #define OBERON_KEY_MANAGEMENT_H
 
 #include <psa/crypto_driver_common.h>
 
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-psa_status_t oberon_export_public_key(const psa_key_attributes_t *attributes, const uint8_t *key,
-				      size_t key_length, uint8_t *data, size_t data_size,
-				      size_t *data_length);
 
-psa_status_t oberon_import_key(const psa_key_attributes_t *attributes, const uint8_t *data,
-			       size_t data_length, uint8_t *key, size_t key_size,
-			       size_t *key_length, size_t *bits);
+psa_status_t oberon_export_public_key(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    uint8_t *data, size_t data_size, size_t *data_length);
 
-psa_status_t oberon_generate_key(const psa_key_attributes_t *attributes, uint8_t *key,
-				 size_t key_size, size_t *key_length);
+psa_status_t oberon_import_key(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *data, size_t data_length,
+    uint8_t *key, size_t key_size, size_t *key_length,
+    size_t *bits);
+
+psa_status_t oberon_generate_key(
+    const psa_key_attributes_t *attributes,
+    uint8_t *key, size_t key_size, size_t *key_length);
+
 
 #ifdef __cplusplus
 }

--- a/ext/oberon/psa/drivers/oberon_pake.c
+++ b/ext/oberon/psa/drivers/oberon_pake.c
@@ -5,231 +5,256 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+
 #include <string.h>
 
 #include "psa/crypto.h"
 #include "oberon_pake.h"
 
-psa_status_t oberon_pake_setup(oberon_pake_operation_t *operation,
-			       const psa_pake_cipher_suite_t *cipher_suite)
-{
-	operation->alg = cipher_suite->algorithm;
 
-	switch (operation->alg) {
+psa_status_t oberon_pake_setup(
+    oberon_pake_operation_t *operation,
+    const psa_pake_cipher_suite_t *cipher_suite)
+{
+    operation->alg = cipher_suite->algorithm;
+
+    switch (operation->alg) {
 #ifdef PSA_NEED_OBERON_JPAKE
-	case PSA_ALG_JPAKE:
-		return oberon_jpake_setup(&operation->ctx.oberon_jpake_ctx, cipher_suite);
+    case PSA_ALG_JPAKE:
+        return oberon_jpake_setup(
+            &operation->ctx.oberon_jpake_ctx, cipher_suite);
 #endif /* PSA_NEED_OBERON_JPAKE */
 #ifdef PSA_NEED_OBERON_SPAKE2P
-	case PSA_ALG_SPAKE2P:
-		return oberon_spake2p_setup(&operation->ctx.oberon_spake2p_ctx, cipher_suite);
+    case PSA_ALG_SPAKE2P:
+        return oberon_spake2p_setup(
+            &operation->ctx.oberon_spake2p_ctx, cipher_suite);
 #endif /* PSA_NEED_OBERON_SPAKE2P */
 #ifdef PSA_NEED_OBERON_SRP_6
-	case PSA_ALG_SRP_6:
-		return oberon_srp_setup(&operation->ctx.oberon_srp_ctx, cipher_suite);
+    case PSA_ALG_SRP_6:
+        return oberon_srp_setup(
+            &operation->ctx.oberon_srp_ctx, cipher_suite);
 #endif /* PSA_NEED_OBERON_SRP_6 */
-	default:
-		(void)cipher_suite;
-		return PSA_ERROR_NOT_SUPPORTED;
-	}
+    default:
+        (void)cipher_suite;
+        return PSA_ERROR_NOT_SUPPORTED;
+    }
 }
 
-psa_status_t oberon_pake_set_password_key(oberon_pake_operation_t *operation,
-					  const psa_key_attributes_t *attributes,
-					  const uint8_t *password, size_t password_length)
+psa_status_t oberon_pake_set_password_key(
+    oberon_pake_operation_t *operation,
+    const psa_key_attributes_t *attributes,
+    const uint8_t *password, size_t password_length)
 {
-	switch (operation->alg) {
+    switch (operation->alg) {
 #ifdef PSA_NEED_OBERON_JPAKE
-	case PSA_ALG_JPAKE:
-		return oberon_jpake_set_password_key(&operation->ctx.oberon_jpake_ctx, attributes,
-						     password, password_length);
+    case PSA_ALG_JPAKE:
+        return oberon_jpake_set_password_key(
+            &operation->ctx.oberon_jpake_ctx, attributes, password, password_length);
 #endif /* PSA_NEED_OBERON_JPAKE */
 #ifdef PSA_NEED_OBERON_SPAKE2P
-	case PSA_ALG_SPAKE2P:
-		return oberon_spake2p_set_password_key(&operation->ctx.oberon_spake2p_ctx,
-						       attributes, password, password_length);
+    case PSA_ALG_SPAKE2P:
+        return oberon_spake2p_set_password_key(
+            &operation->ctx.oberon_spake2p_ctx, attributes, password, password_length);
 #endif /* PSA_NEED_OBERON_SPAKE2P */
 #ifdef PSA_NEED_OBERON_SRP_6
-	case PSA_ALG_SRP_6:
-		return oberon_srp_set_password_key(&operation->ctx.oberon_srp_ctx, attributes,
-						   password, password_length);
+    case PSA_ALG_SRP_6:
+        return oberon_srp_set_password_key(
+            &operation->ctx.oberon_srp_ctx, attributes, password, password_length);
 #endif /* PSA_NEED_OBERON_SRP_6 */
-	default:
-		(void)attributes;
-		(void)password;
-		(void)password_length;
-		return PSA_ERROR_BAD_STATE;
-	}
+    default:
+        (void)attributes;
+        (void)password;
+        (void)password_length;
+        return PSA_ERROR_BAD_STATE;
+    }
 }
 
-psa_status_t oberon_pake_set_user(oberon_pake_operation_t *operation, const uint8_t *user_id,
-				  size_t user_id_len)
+psa_status_t oberon_pake_set_user(
+    oberon_pake_operation_t *operation,
+    const uint8_t *user_id, size_t user_id_len)
 {
-	switch (operation->alg) {
+    switch (operation->alg) {
 #ifdef PSA_NEED_OBERON_JPAKE
-	case PSA_ALG_JPAKE:
-		return oberon_jpake_set_user(&operation->ctx.oberon_jpake_ctx, user_id,
-					     user_id_len);
+    case PSA_ALG_JPAKE:
+        return oberon_jpake_set_user(
+            &operation->ctx.oberon_jpake_ctx, user_id, user_id_len);
 #endif /* PSA_NEED_OBERON_JPAKE */
 #ifdef PSA_NEED_OBERON_SPAKE2P
-	case PSA_ALG_SPAKE2P:
-		return oberon_spake2p_set_user(&operation->ctx.oberon_spake2p_ctx, user_id,
-					       user_id_len);
+    case PSA_ALG_SPAKE2P:
+        return oberon_spake2p_set_user(
+            &operation->ctx.oberon_spake2p_ctx, user_id, user_id_len);
 #endif /* PSA_NEED_OBERON_SPAKE2P */
 #ifdef PSA_NEED_OBERON_SRP_6
-	case PSA_ALG_SRP_6:
-		return oberon_srp_set_user(&operation->ctx.oberon_srp_ctx, user_id, user_id_len);
+    case PSA_ALG_SRP_6:
+        return oberon_srp_set_user(
+            &operation->ctx.oberon_srp_ctx, user_id, user_id_len);
 #endif /* PSA_NEED_OBERON_SRP_6 */
-	default:
-		(void)user_id;
-		(void)user_id_len;
-		return PSA_ERROR_BAD_STATE;
-	}
+    default:
+        (void)user_id;
+        (void)user_id_len;
+        return PSA_ERROR_BAD_STATE;
+    }
 }
 
-psa_status_t oberon_pake_set_peer(oberon_pake_operation_t *operation, const uint8_t *peer_id,
-				  size_t peer_id_len)
+psa_status_t oberon_pake_set_peer(
+    oberon_pake_operation_t *operation,
+    const uint8_t *peer_id, size_t peer_id_len)
 {
-	switch (operation->alg) {
+    switch (operation->alg) {
 #ifdef PSA_NEED_OBERON_JPAKE
-	case PSA_ALG_JPAKE:
-		return oberon_jpake_set_peer(&operation->ctx.oberon_jpake_ctx, peer_id,
-					     peer_id_len);
+    case PSA_ALG_JPAKE:
+        return oberon_jpake_set_peer(
+            &operation->ctx.oberon_jpake_ctx,  peer_id, peer_id_len);
 #endif /* PSA_NEED_OBERON_JPAKE */
 #ifdef PSA_NEED_OBERON_SPAKE2P
-	case PSA_ALG_SPAKE2P:
-		return oberon_spake2p_set_peer(&operation->ctx.oberon_spake2p_ctx, peer_id,
-					       peer_id_len);
+    case PSA_ALG_SPAKE2P:
+        return oberon_spake2p_set_peer(
+            &operation->ctx.oberon_spake2p_ctx, peer_id, peer_id_len);
 #endif /* PSA_NEED_OBERON_SPAKE2P */
 #ifdef PSA_NEED_OBERON_SRP_6
-	case PSA_ALG_SRP_6:
-		return PSA_ERROR_NOT_SUPPORTED; // no peer id in SRP
-#endif						/* PSA_NEED_OBERON_SRP_6 */
-	default:
-		(void)peer_id;
-		(void)peer_id_len;
-		return PSA_ERROR_BAD_STATE;
-	}
+    case PSA_ALG_SRP_6:
+        return PSA_ERROR_NOT_SUPPORTED;  // no peer id in SRP
+#endif /* PSA_NEED_OBERON_SRP_6 */
+    default:
+        (void)peer_id;
+        (void)peer_id_len;
+        return PSA_ERROR_BAD_STATE;
+    }
 }
 
-psa_status_t oberon_pake_set_role(oberon_pake_operation_t *operation, psa_pake_role_t role)
+psa_status_t oberon_pake_set_role(
+    oberon_pake_operation_t *operation,
+    psa_pake_role_t role)
 {
-	switch (operation->alg) {
+    switch (operation->alg) {
 #ifdef PSA_NEED_OBERON_JPAKE
-	case PSA_ALG_JPAKE:
-		return oberon_jpake_set_role(&operation->ctx.oberon_jpake_ctx, role);
+    case PSA_ALG_JPAKE:
+        return oberon_jpake_set_role(
+            &operation->ctx.oberon_jpake_ctx, role);
 #endif /* PSA_NEED_OBERON_JPAKE */
 #ifdef PSA_NEED_OBERON_SPAKE2P
-	case PSA_ALG_SPAKE2P:
-		return oberon_spake2p_set_role(&operation->ctx.oberon_spake2p_ctx, role);
+    case PSA_ALG_SPAKE2P:
+        return oberon_spake2p_set_role(
+            &operation->ctx.oberon_spake2p_ctx, role);
 #endif /* PSA_NEED_OBERON_SPAKE2P */
 #ifdef PSA_NEED_OBERON_SRP_6
-	case PSA_ALG_SRP_6:
-		return oberon_srp_set_role(&operation->ctx.oberon_srp_ctx, role);
+    case PSA_ALG_SRP_6:
+        return oberon_srp_set_role(
+            &operation->ctx.oberon_srp_ctx, role);
 #endif /* PSA_NEED_OBERON_SRP_6 */
-	default:
-		(void)role;
-		return PSA_ERROR_BAD_STATE;
-	}
+    default:
+        (void)role;
+        return PSA_ERROR_BAD_STATE;
+    }
 }
 
-psa_status_t oberon_pake_output(oberon_pake_operation_t *operation, psa_pake_step_t step,
-				uint8_t *output, size_t output_size, size_t *output_length)
+psa_status_t oberon_pake_output(
+    oberon_pake_operation_t *operation,
+    psa_pake_step_t step,
+    uint8_t *output, size_t output_size, size_t *output_length)
 {
-	switch (operation->alg) {
+    switch (operation->alg) {
 #ifdef PSA_NEED_OBERON_JPAKE
-	case PSA_ALG_JPAKE:
-		return oberon_jpake_output(&operation->ctx.oberon_jpake_ctx, step, output,
-					   output_size, output_length);
+    case PSA_ALG_JPAKE:
+        return oberon_jpake_output(
+            &operation->ctx.oberon_jpake_ctx, step, output, output_size, output_length);
 #endif /* PSA_NEED_OBERON_JPAKE */
 #ifdef PSA_NEED_OBERON_SPAKE2P
-	case PSA_ALG_SPAKE2P:
-		return oberon_spake2p_output(&operation->ctx.oberon_spake2p_ctx, step, output,
-					     output_size, output_length);
+    case PSA_ALG_SPAKE2P:
+        return oberon_spake2p_output(
+            &operation->ctx.oberon_spake2p_ctx, step, output, output_size, output_length);
 #endif /* PSA_NEED_OBERON_SPAKE2P */
 #ifdef PSA_NEED_OBERON_SRP_6
-	case PSA_ALG_SRP_6:
-		return oberon_srp_output(&operation->ctx.oberon_srp_ctx, step, output, output_size,
-					 output_length);
+    case PSA_ALG_SRP_6:
+        return oberon_srp_output(
+            &operation->ctx.oberon_srp_ctx, step, output, output_size, output_length);
 #endif /* PSA_NEED_OBERON_SRP_6 */
-	default:
-		(void)step;
-		(void)output;
-		(void)output_size;
-		(void)output_length;
-		return PSA_ERROR_BAD_STATE;
-	}
+    default:
+        (void)step;
+        (void)output;
+        (void)output_size;
+        (void)output_length;
+        return PSA_ERROR_BAD_STATE;
+    }
 }
 
-psa_status_t oberon_pake_input(oberon_pake_operation_t *operation, psa_pake_step_t step,
-			       const uint8_t *input, size_t input_length)
+psa_status_t oberon_pake_input(
+    oberon_pake_operation_t *operation,
+    psa_pake_step_t step,
+    const uint8_t *input, size_t input_length)
 {
-	switch (operation->alg) {
+    switch (operation->alg) {
 #ifdef PSA_NEED_OBERON_JPAKE
-	case PSA_ALG_JPAKE:
-		return oberon_jpake_input(&operation->ctx.oberon_jpake_ctx, step, input,
-					  input_length);
+    case PSA_ALG_JPAKE:
+        return oberon_jpake_input(
+            &operation->ctx.oberon_jpake_ctx, step, input, input_length);
 #endif /* PSA_NEED_OBERON_JPAKE */
 #ifdef PSA_NEED_OBERON_SPAKE2P
-	case PSA_ALG_SPAKE2P:
-		return oberon_spake2p_input(&operation->ctx.oberon_spake2p_ctx, step, input,
-					    input_length);
+    case PSA_ALG_SPAKE2P:
+        return oberon_spake2p_input(
+            &operation->ctx.oberon_spake2p_ctx, step, input, input_length);
 #endif /* PSA_NEED_OBERON_SPAKE2P */
 #ifdef PSA_NEED_OBERON_SRP_6
-	case PSA_ALG_SRP_6:
-		return oberon_srp_input(&operation->ctx.oberon_srp_ctx, step, input, input_length);
+    case PSA_ALG_SRP_6:
+        return oberon_srp_input(
+            &operation->ctx.oberon_srp_ctx, step, input, input_length);
 #endif /* PSA_NEED_OBERON_SRP_6 */
-	default:
-		(void)step;
-		(void)input;
-		(void)input_length;
-		return PSA_ERROR_BAD_STATE;
-	}
+    default:
+        (void)step;
+        (void)input;
+        (void)input_length;
+        return PSA_ERROR_BAD_STATE;
+    }
 }
 
-psa_status_t oberon_pake_get_implicit_key(oberon_pake_operation_t *operation, uint8_t *output,
-					  size_t output_size, size_t *output_length)
+psa_status_t oberon_pake_get_implicit_key(
+    oberon_pake_operation_t *operation,
+    uint8_t *output, size_t output_size, size_t *output_length)
 {
-	switch (operation->alg) {
+    switch (operation->alg) {
 #ifdef PSA_NEED_OBERON_JPAKE
-	case PSA_ALG_JPAKE:
-		return oberon_jpake_get_implicit_key(&operation->ctx.oberon_jpake_ctx, output,
-						     output_size, output_length);
+    case PSA_ALG_JPAKE:
+        return oberon_jpake_get_implicit_key(
+            &operation->ctx.oberon_jpake_ctx, output, output_size, output_length);
 #endif /* PSA_NEED_OBERON_JPAKE */
 #ifdef PSA_NEED_OBERON_SPAKE2P
-	case PSA_ALG_SPAKE2P:
-		return oberon_spake2p_get_implicit_key(&operation->ctx.oberon_spake2p_ctx, output,
-						       output_size, output_length);
+    case PSA_ALG_SPAKE2P:
+        return oberon_spake2p_get_implicit_key(
+            &operation->ctx.oberon_spake2p_ctx, output, output_size, output_length);
 #endif /* PSA_NEED_OBERON_SPAKE2P */
 #ifdef PSA_NEED_OBERON_SRP_6
-	case PSA_ALG_SRP_6:
-		return oberon_srp_get_implicit_key(&operation->ctx.oberon_srp_ctx, output,
-						   output_size, output_length);
+    case PSA_ALG_SRP_6:
+        return oberon_srp_get_implicit_key(
+            &operation->ctx.oberon_srp_ctx, output, output_size, output_length);
 #endif /* PSA_NEED_OBERON_SRP_6 */
-	default:
-		(void)output;
-		(void)output_size;
-		(void)output_length;
-		return PSA_ERROR_BAD_STATE;
-	}
+    default:
+        (void)output;
+        (void)output_size;
+        (void)output_length;
+        return PSA_ERROR_BAD_STATE;
+    }
 }
 
-psa_status_t oberon_pake_abort(oberon_pake_operation_t *operation)
+psa_status_t oberon_pake_abort(
+    oberon_pake_operation_t *operation)
 {
-	switch (operation->alg) {
+    switch (operation->alg) {
 #ifdef PSA_NEED_OBERON_JPAKE
-	case PSA_ALG_JPAKE:
-		return oberon_jpake_abort(&operation->ctx.oberon_jpake_ctx);
+    case PSA_ALG_JPAKE:
+        return oberon_jpake_abort(
+            &operation->ctx.oberon_jpake_ctx);
 #endif /* PSA_NEED_OBERON_JPAKE */
 #ifdef PSA_NEED_OBERON_SPAKE2P
-	case PSA_ALG_SPAKE2P:
-		return oberon_spake2p_abort(&operation->ctx.oberon_spake2p_ctx);
+    case PSA_ALG_SPAKE2P:
+        return oberon_spake2p_abort(
+            &operation->ctx.oberon_spake2p_ctx);
 #endif /* PSA_NEED_OBERON_SPAKE2P */
 #ifdef PSA_NEED_OBERON_SRP_6
-	case PSA_ALG_SRP_6:
-		return oberon_srp_abort(&operation->ctx.oberon_srp_ctx);
+    case PSA_ALG_SRP_6:
+        return oberon_srp_abort(
+            &operation->ctx.oberon_srp_ctx);
 #endif /* PSA_NEED_OBERON_SRP_6 */
-	default:
-		return PSA_ERROR_BAD_STATE;
-	}
+    default:
+        return PSA_ERROR_BAD_STATE;
+    }
 }

--- a/ext/oberon/psa/drivers/oberon_pake.h
+++ b/ext/oberon/psa/drivers/oberon_pake.h
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+
 #ifndef OBERON_PAKE_H
 #define OBERON_PAKE_H
 
@@ -20,51 +21,67 @@
 #include "oberon_srp.h"
 #endif
 
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+
 typedef struct {
-	psa_algorithm_t alg;
-	union {
-		unsigned dummy; /* Make sure this union is always non-empty */
+    psa_algorithm_t alg;
+    union {
+        unsigned dummy; /* Make sure this union is always non-empty */
 #ifdef PSA_NEED_OBERON_JPAKE
-		oberon_jpake_operation_t oberon_jpake_ctx;
+        oberon_jpake_operation_t oberon_jpake_ctx;
 #endif
 #ifdef PSA_NEED_OBERON_SPAKE2P
-		oberon_spake2p_operation_t oberon_spake2p_ctx;
+        oberon_spake2p_operation_t oberon_spake2p_ctx;
 #endif
 #ifdef PSA_NEED_OBERON_SRP_6
-		oberon_srp_operation_t oberon_srp_ctx;
+        oberon_srp_operation_t oberon_srp_ctx;
 #endif
-	} ctx;
+    } ctx;
 } oberon_pake_operation_t;
 
-psa_status_t oberon_pake_setup(oberon_pake_operation_t *operation,
-			       const psa_pake_cipher_suite_t *cipher_suite);
 
-psa_status_t oberon_pake_set_password_key(oberon_pake_operation_t *operation,
-					  const psa_key_attributes_t *attributes,
-					  const uint8_t *password, size_t password_length);
+psa_status_t oberon_pake_setup(
+    oberon_pake_operation_t *operation,
+    const psa_pake_cipher_suite_t *cipher_suite);
 
-psa_status_t oberon_pake_set_user(oberon_pake_operation_t *operation, const uint8_t *user_id,
-				  size_t user_id_len);
+psa_status_t oberon_pake_set_password_key(
+    oberon_pake_operation_t *operation,
+    const psa_key_attributes_t *attributes,
+    const uint8_t *password, size_t password_length);
 
-psa_status_t oberon_pake_set_peer(oberon_pake_operation_t *operation, const uint8_t *peer_id,
-				  size_t peer_id_len);
+psa_status_t oberon_pake_set_user(
+    oberon_pake_operation_t *operation,
+    const uint8_t *user_id, size_t user_id_len);
 
-psa_status_t oberon_pake_set_role(oberon_pake_operation_t *operation, psa_pake_role_t role);
+psa_status_t oberon_pake_set_peer(
+    oberon_pake_operation_t *operation,
+    const uint8_t *peer_id, size_t peer_id_len);
 
-psa_status_t oberon_pake_output(oberon_pake_operation_t *operation, psa_pake_step_t step,
-				uint8_t *output, size_t output_size, size_t *output_length);
+psa_status_t oberon_pake_set_role(
+    oberon_pake_operation_t *operation,
+    psa_pake_role_t role);
 
-psa_status_t oberon_pake_input(oberon_pake_operation_t *operation, psa_pake_step_t step,
-			       const uint8_t *input, size_t input_length);
+psa_status_t oberon_pake_output(
+    oberon_pake_operation_t *operation,
+    psa_pake_step_t step,
+    uint8_t *output, size_t output_size, size_t *output_length);
 
-psa_status_t oberon_pake_get_implicit_key(oberon_pake_operation_t *operation, uint8_t *output,
-					  size_t output_size, size_t *output_length);
+psa_status_t oberon_pake_input(
+    oberon_pake_operation_t *operation,
+    psa_pake_step_t step,
+    const uint8_t *input, size_t input_length);
 
-psa_status_t oberon_pake_abort(oberon_pake_operation_t *operation);
+psa_status_t oberon_pake_get_implicit_key(
+    oberon_pake_operation_t *operation,
+    uint8_t *output, size_t output_size, size_t *output_length);
+
+psa_status_t oberon_pake_abort(
+    oberon_pake_operation_t *operation);
+
 
 #ifdef __cplusplus
 }

--- a/ext/oberon/psa/drivers/oberon_rsa.c
+++ b/ext/oberon/psa/drivers/oberon_rsa.c
@@ -914,10 +914,13 @@ psa_status_t oberon_rsa_verify_hash(
     }
 }
 
-psa_status_t oberon_rsa_encrypt(const psa_key_attributes_t *attributes, const uint8_t *key,
-				size_t key_length, psa_algorithm_t alg, const uint8_t *input,
-				size_t input_length, const uint8_t *salt, size_t salt_length,
-				uint8_t *output, size_t output_size, size_t *output_length)
+psa_status_t oberon_rsa_encrypt(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg,
+    const uint8_t *input, size_t input_length,
+    const uint8_t *salt, size_t salt_length,
+    uint8_t *output, size_t output_size, size_t *output_length)
 {
     psa_status_t status;
     size_t bits = psa_get_key_bits(attributes);
@@ -978,10 +981,13 @@ psa_status_t oberon_rsa_encrypt(const psa_key_attributes_t *attributes, const ui
     return PSA_SUCCESS;
 }
 
-psa_status_t oberon_rsa_decrypt(const psa_key_attributes_t *attributes, const uint8_t *key,
-				size_t key_length, psa_algorithm_t alg, const uint8_t *input,
-				size_t input_length, const uint8_t *salt, size_t salt_length,
-				uint8_t *output, size_t output_size, size_t *output_length)
+psa_status_t oberon_rsa_decrypt(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg,
+    const uint8_t *input, size_t input_length,
+    const uint8_t *salt, size_t salt_length,
+    uint8_t *output, size_t output_size, size_t *output_length)
 {
     int res;
     psa_status_t status;

--- a/ext/oberon/psa/drivers/oberon_rsa.h
+++ b/ext/oberon/psa/drivers/oberon_rsa.h
@@ -43,17 +43,23 @@ extern "C" {
         const uint8_t *hash, size_t hash_length,
         const uint8_t *signature, size_t signature_length);
 
-    psa_status_t oberon_rsa_encrypt(const psa_key_attributes_t *attributes,
-				    const uint8_t *key_buffer, size_t key_buffer_size,
-				    psa_algorithm_t alg, const uint8_t *input, size_t input_length,
-				    const uint8_t *salt, size_t salt_length, uint8_t *output,
-				    size_t output_size, size_t *output_length);
 
-    psa_status_t oberon_rsa_decrypt(const psa_key_attributes_t *attributes,
-				    const uint8_t *key_buffer, size_t key_buffer_size,
-				    psa_algorithm_t alg, const uint8_t *input, size_t input_length,
-				    const uint8_t *salt, size_t salt_length, uint8_t *output,
-				    size_t output_size, size_t *output_length);
+    psa_status_t oberon_rsa_encrypt(
+        const psa_key_attributes_t *attributes,
+        const uint8_t *key_buffer, size_t key_buffer_size,
+        psa_algorithm_t alg,
+        const uint8_t *input, size_t input_length,
+        const uint8_t *salt, size_t salt_length,
+        uint8_t *output, size_t output_size, size_t *output_length);
+
+    psa_status_t oberon_rsa_decrypt(
+        const psa_key_attributes_t *attributes,
+        const uint8_t *key_buffer, size_t key_buffer_size,
+        psa_algorithm_t alg,
+        const uint8_t *input, size_t input_length,
+        const uint8_t *salt, size_t salt_length,
+        uint8_t *output, size_t output_size, size_t *output_length);
+
 
 #ifdef __cplusplus
 }

--- a/ext/oberon/psa/drivers/oberon_spake2p.c
+++ b/ext/oberon/psa/drivers/oberon_spake2p.c
@@ -282,17 +282,17 @@ psa_status_t oberon_spake2p_set_user(
     if (operation->role == PSA_PAKE_ROLE_CLIENT) {
         // prover = user
         if (user_id_len > sizeof operation->prover) return PSA_ERROR_INSUFFICIENT_MEMORY;
-	if (user_id_len) {
-		memcpy(operation->prover, user_id, user_id_len);
-	}
-	operation->prover_len = (uint8_t)user_id_len;
+        if (user_id_len) {
+            memcpy(operation->prover, user_id, user_id_len);
+        }
+        operation->prover_len = (uint8_t)user_id_len;
     } else {
         // verifier = user
         if (user_id_len > sizeof operation->verifier) return PSA_ERROR_INSUFFICIENT_MEMORY;
-	if (user_id_len) {
-		memcpy(operation->verifier, user_id, user_id_len);
-	}
-	operation->verifier_len = (uint8_t)user_id_len;
+        if (user_id_len) {
+            memcpy(operation->verifier, user_id, user_id_len);
+        }
+        operation->verifier_len = (uint8_t)user_id_len;
     }
 
     return PSA_SUCCESS;
@@ -305,17 +305,17 @@ psa_status_t oberon_spake2p_set_peer(
     if (operation->role == PSA_PAKE_ROLE_CLIENT) {
         // verifier = peer
         if (peer_id_len > sizeof operation->verifier) return PSA_ERROR_INSUFFICIENT_MEMORY;
-	if (peer_id_len) {
-		memcpy(operation->verifier, peer_id, peer_id_len);
-	}
-	operation->verifier_len = (uint8_t)peer_id_len;
+        if (peer_id_len) {
+            memcpy(operation->verifier, peer_id, peer_id_len);
+        }
+        operation->verifier_len = (uint8_t)peer_id_len;
     } else {
         // prover = peer
         if (peer_id_len > sizeof operation->prover) return PSA_ERROR_INSUFFICIENT_MEMORY;
-	if (peer_id_len) {
-		memcpy(operation->prover, peer_id, peer_id_len);
-	}
-	operation->prover_len = (uint8_t)peer_id_len;
+        if (peer_id_len) {
+            memcpy(operation->prover, peer_id, peer_id_len);
+        }
+        operation->prover_len = (uint8_t)peer_id_len;
     }
 
     return PSA_SUCCESS;


### PR DESCRIPTION
This aligns the Oberon PSA core and driver code with the Oberon deliverables.
All the modified files don't have any functional change, it's only code structure changes.

There are two new files, the sha256.h and the
memory_buffer_alloc.h. These were added to align
with the deliverable and they should not make any difference since they are identical to the same files in sdk-mbedtls.

Ref: NCSDK-24707