### PR TITLE
nrf_security: Do not select ENTROPY_GENERATOR from NRF_SECURITY

### DIFF
--- a/Kconfig.nrf
+++ b/Kconfig.nrf
@@ -82,11 +82,6 @@ config MCUMGR_TRANSPORT_NETBUF_SIZE
 config BT_BUF_CMD_TX_COUNT
 	default 10 if SOC_NRF5340_CPUAPP || SOC_NRF5340_CPUNET
 
-# Set ENTROPY_GENERATOR to true for TF-M builds with enabled
-# RNG provided from secure services.
-config ENTROPY_GENERATOR
-	default y if BUILD_WITH_TFM
-
 config INIT_ARCH_HW_AT_BOOT
 	default y
 	help

--- a/drivers/hw_cc3xx/hw_cc3xx.c
+++ b/drivers/hw_cc3xx/hw_cc3xx.c
@@ -23,8 +23,12 @@ static int hw_cc3xx_init_internal(void)
 	int res;
 
 	/* Initialize the cc3xx HW with or without RNG support */
-#if CONFIG_ENTROPY_CC3XX
+
+	/* Using same configurations as the users of entropy, see NCSDK-24914. */
+#if CONFIG_ENTROPY_CC3XX || defined(CONFIG_PSA_NEED_CC3XX_CTR_DRBG_DRIVER)
 	res = nrf_cc3xx_platform_init();
+#elif defined(CONFIG_PSA_NEED_CC3XX_HMAC_DRBG_DRIVER)
+	res = nrf_cc3xx_platform_init_hmac_drbg();
 #else
 	res = nrf_cc3xx_platform_init_no_rng();
 #endif

--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -286,6 +286,7 @@ choice TFM_PROFILE_TYPE
 config TFM_PROFILE_TYPE_MINIMAL
 	bool "Use minimal TF-M build"
 	select PSA_DEFAULT_OFF
+	select PSA_WANT_GENERATE_RANDOM
 	help
 	  Use minimal TF-M build. This will make the TF-M image fit within 32kB.
 	  No configuration of the size of the partition nor the features of the

--- a/modules/trusted-firmware-m/tfm_boards/common/tfm_hal_platform.c
+++ b/modules/trusted-firmware-m/tfm_boards/common/tfm_hal_platform.c
@@ -5,7 +5,7 @@
  */
 
 #if defined(TFM_PARTITION_CRYPTO)
-#include "common.h"
+#include <autoconf.h>
 #include <nrf_cc3xx_platform.h>
 #include <nrf_cc3xx_platform_ctr_drbg.h>
 #endif
@@ -33,9 +33,9 @@ static enum tfm_hal_status_t crypto_platform_init(void)
 #if !CRYPTO_RNG_MODULE_ENABLED
 	err = nrf_cc3xx_platform_init_no_rng();
 #else
-#if defined(PSA_WANT_ALG_CTR_DRBG)
+#if defined(CONFIG_PSA_NEED_CC3XX_CTR_DRBG_DRIVER)
 	err = nrf_cc3xx_platform_init();
-#elif defined (PSA_WANT_ALG_HMAC_DRBG)
+#elif defined(CONFIG_PSA_NEED_CC3XX_HMAC_DRBG_DRIVER)
 	err = nrf_cc3xx_platform_init_hmac_drbg();
 #else
 	#error "Please enable either PSA_WANT_ALG_CTR_DRBG or PSA_WANT_ALG_HMAC_DRBG"

--- a/subsys/bluetooth/services/fast_pair/fp_crypto/Kconfig.fp_crypto
+++ b/subsys/bluetooth/services/fast_pair/fp_crypto/Kconfig.fp_crypto
@@ -32,6 +32,7 @@ config BT_FAST_PAIR_CRYPTO_MBEDTLS
 	bool "Fast Pair with MbedTLS cryptographic backend"
 	select NORDIC_SECURITY_BACKEND
 	select MBEDTLS_ENABLE_HEAP
+	select ENTROPY_GENERATOR
 	help
 	  Select MbedTLS cryptographic backend for Fast Pair.
 

--- a/subsys/nrf_security/Kconfig
+++ b/subsys/nrf_security/Kconfig
@@ -35,7 +35,6 @@ config NRF_SECURITY
 	prompt "Enable nRF Security" if !PSA_PROMPTLESS
 	depends on SOC_FAMILY_NRF
 	default y if BUILD_WITH_TFM
-	select ENTROPY_GENERATOR
 	select DISABLE_MBEDTLS_BUILTIN if MBEDTLS
 	help
 	  Set this configuration to enable nRF Security. This provides
@@ -100,6 +99,7 @@ config MBEDTLS_ENTROPY_POLL
 	default y
 	depends on !NRF_CC3XX_PLATFORM
 	depends on !BUILD_WITH_TFM
+	select ENTROPY_GENERATOR
 
 # Include TLS/DTLS and x509 configurations
 rsource "Kconfig.tls"

--- a/subsys/nrf_security/Kconfig
+++ b/subsys/nrf_security/Kconfig
@@ -95,6 +95,12 @@ config MBEDTLS_HEAP_SIZE
 	  Ensure to adjust the heap size according to the need of the
 	  application.
 
+config MBEDTLS_ENTROPY_POLL
+	bool
+	default y
+	depends on !NRF_CC3XX_PLATFORM
+	depends on !BUILD_WITH_TFM
+
 # Include TLS/DTLS and x509 configurations
 rsource "Kconfig.tls"
 

--- a/subsys/nrf_security/src/drivers/zephyr/Kconfig
+++ b/subsys/nrf_security/src/drivers/zephyr/Kconfig
@@ -7,6 +7,8 @@
 config PSA_NEED_NRF_RNG_ENTROPY_DRIVER
 	bool
 	default y
+	# Cannot select entropy-generator without creating a loop to ENTROPY_PSA_CRYPTO_RNG
+	depends on ENTROPY_GENERATOR
 	select PSA_ACCEL_GET_ENTROPY
 	depends on HAS_HW_NRF_RNG
 	depends on (!PSA_USE_CC3XX_CTR_DRBG_DRIVER && !PSA_USE_CC3XX_HMAC_DRBG_DRIVER) && \

--- a/subsys/nrf_security/src/zephyr/CMakeLists.txt
+++ b/subsys/nrf_security/src/zephyr/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 # Add entropy_poll only if NRF_CC3XX_PLATFORM is not added
 # This file is not useful for TF-M build where entropy should come
 # from SPE image, using psa_generate_random
-if(NOT CONFIG_NRF_CC3XX_PLATFORM AND NOT CONFIG_BUILD_WITH_TFM)
+if(CONFIG_MBEDTLS_ENTROPY_POLL)
   list(APPEND src_zephyr
     ${NRF_SECURITY_ROOT}/src/zephyr/entropy_poll.c
   )

--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: f721e835805a6e6bae6e7c491f3d4369d64412e4
+      revision: 92a5b80480bd6b1be9dabb5684162cef3067a85d
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -197,7 +197,7 @@ manifest:
         - sidewalk
     - name: find-my
       repo-path: sdk-find-my
-      revision: 57be5750a612061874052c2c9afb3bbb8d76bafc
+      revision: e6beafa2147ecd848b51422210b978cd7e6d3d27
       groups:
         - find-my
     - name: azure-sdk-for-c


### PR DESCRIPTION
test-sdk-nrf: test_jc_ent_gen