### PR TITLE
manifest: Update sdk-zephyr with fix for appling workaround in nrfx_qspi

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 20d347899fef71940c24fb9a3f13e5dde7232c6b
+      revision: 2c45751bfc6c98965e5c1b6cce66d37de875498b
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
The patch pulls in zephyr revision with fixed order of appling workaround for anomalies.