### PR TITLE
wiif: Fix missing l2 TX fix

### DIFF
--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/default/fmac_api.c
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/default/fmac_api.c
@@ -530,7 +530,8 @@ struct nrf_wifi_fmac_priv *nrf_wifi_fmac_init(struct nrf_wifi_data_config_params
 			def_priv->rx_buf_pools[pool_idx].buf_sz + RX_BUF_HEADROOM;
 	}
 
-	hal_cfg_params.max_tx_frm_sz = CONFIG_NRF_WIFI_IFACE_MTU + TX_BUF_HEADROOM;
+	hal_cfg_params.max_tx_frm_sz = CONFIG_NRF_WIFI_IFACE_MTU + NRF_WIFI_FMAC_ETH_HDR_LEN +
+					TX_BUF_HEADROOM;
 
 	hal_cfg_params.max_cmd_size = MAX_NRF_WIFI_UMAC_CMD_SIZE;
 	hal_cfg_params.max_event_size = MAX_EVENT_POOL_LEN;


### PR DESCRIPTION
commit f55be0c93eb("drivers: wifi: Fix missing L2 header in max MSDU calculation") missed backporting the fix to the FMAC.

Fixes SHEL-2216.