### PR TITLE
wifi: l2ac: Fix connection persistence

### DIFF
--- a/subsys/net/l2_wifi_if_conn/l2_wifi_conn.c
+++ b/subsys/net/l2_wifi_if_conn/l2_wifi_conn.c
@@ -83,8 +83,7 @@ static void net_l2_wifi_mgmt_event_handler(struct net_mgmt_event_callback *cb,
 		break;
 	case NET_EVENT_WIFI_DISCONNECT_RESULT:
 		if (conn_mgr_if_get_flag(wifi_iface, CONN_MGR_IF_PERSISTENT)) {
-			k_work_reschedule_for_queue(&wifi_conn_wq, &wifi_conn_work,
-							K_SECONDS(conn_mgr_if_get_timeout(iface)));
+			wifi_conn_timeout_schedule();
 		} else {
 			/* For disconnection that may have been prompted by AP */
 			net_l2_wifi_disconnect(NULL);


### PR DESCRIPTION
If the persistence is enabled and In case WPA supplicant disconnects for seem reason e.g., AP de-auth due to wrong PSK, then L2AC should not issue a disconnect until the connection timeout is hit.

But default timeout is 0, so, we should check before we reschedule the timer to avoid disconnecting immediately, as we have a separate API which properly does this, use it.

Fixes SHEL-2249.