### PR TITLE
Add ability save a wav recording

### DIFF
--- a/applications/nrf5340_audio/src/audio/CMakeLists.txt
+++ b/applications/nrf5340_audio/src/audio/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(app PRIVATE
 	       ${CMAKE_CURRENT_SOURCE_DIR}/audio_datapath.c
 	       ${CMAKE_CURRENT_SOURCE_DIR}/sw_codec_select.c
 	       ${CMAKE_CURRENT_SOURCE_DIR}/le_audio_rx.c
+		   ${CMAKE_CURRENT_SOURCE_DIR}/wav_file.c
 )
 
 if (CONFIG_BT_BAP_BROADCAST_SINK)

--- a/applications/nrf5340_audio/src/audio/Kconfig
+++ b/applications/nrf5340_audio/src/audio/Kconfig
@@ -170,6 +170,12 @@ config AUDIO_MUTE
 	  Use button 5 to mute audio instead of
 	  doing a user defined action.
 
+config AUDIO_SAVE_WAV
+	bool "Save a 10 second wav file instead of mute"
+	default n
+	help
+	  Use button 5 to save a wav file.
+
 if AUDIO_HEADSET_CHANNEL_COMPILE_TIME
 
 config AUDIO_HEADSET_CHANNEL
@@ -295,6 +301,10 @@ source "subsys/logging/Kconfig.template.log_config"
 
 module = LE_AUDIO_RX
 module-str = le-audio-rx
+source "subsys/logging/Kconfig.template.log_config"
+
+module = WAV_FILE
+module-str = audio-system
 source "subsys/logging/Kconfig.template.log_config"
 
 endmenu # Log levels

--- a/applications/nrf5340_audio/src/audio/audio_datapath.c
+++ b/applications/nrf5340_audio/src/audio/audio_datapath.c
@@ -13,6 +13,8 @@
 #include <zephyr/kernel.h>
 #include <zephyr/shell/shell.h>
 #include <nrfx_clock.h>
+#include <contin_array.h>
+#include <pcm_mix.h>
 
 #include "nrf5340_audio_common.h"
 #include "macros_common.h"
@@ -21,9 +23,9 @@
 #include "sw_codec_select.h"
 #include "audio_system.h"
 #include "tone.h"
-#include "contin_array.h"
-#include "pcm_mix.h"
 #include "streamctrl.h"
+#include "sd_card.h"
+#include "wav_file.h"
 #include "audio_sync_timer.h"
 #include "sd_card_playback.h"
 
@@ -857,6 +859,139 @@ void audio_datapath_pres_delay_us_get(uint32_t *delay_us)
 	*delay_us = ctrl_blk.pres_comp.pres_delay_us;
 }
 
+static char pcm_data1[CONFIG_AUDIO_SAMPLE_RATE_HZ *
+		      CONFIG_AUDIO_BIT_DEPTH_OCTETS]; // 96kb can hold one second.
+static char pcm_data2[CONFIG_AUDIO_SAMPLE_RATE_HZ *
+		      CONFIG_AUDIO_BIT_DEPTH_OCTETS]; // 96kb can hold one second.
+static char *pcm_data = NULL;
+static size_t pcm_data_used = 0;
+static size_t pcm_data_duration = 0;
+static size_t wav_file_bytes = 0;
+static struct fs_file_t wav_file;
+static bool wav_file_open = false;
+static bool save_busy = false;
+
+struct save_wave_msg {
+	const char *buffer;
+	uint32_t size;
+};
+
+ZBUS_CHAN_DEFINE(save_wav_channel,	       /* Name */
+		 struct save_wave_msg,	       /* Message type */
+		 NULL,			       /* Validator */
+		 NULL,			       /* User data */
+		 ZBUS_OBSERVERS(save_wav_sub), /* observers */
+		 ZBUS_MSG_INIT(0));	       /* Initial value */
+
+ZBUS_SUBSCRIBER_DEFINE(save_wav_sub, 1);
+
+static void save_wav_task(void)
+{
+	const struct zbus_channel *chan;
+	struct save_wave_msg msg;
+
+	while (!zbus_sub_wait(&save_wav_sub, &chan, K_FOREVER)) {
+		if (&save_wav_channel == chan) {
+			zbus_chan_read(&save_wav_channel, &msg, K_MSEC(500));
+			if (wav_file_open) {
+				save_busy = true;
+				int ret = write_wav_data(&wav_file, msg.buffer, msg.size);
+				save_busy = false;
+				if (ret != 0) {
+					LOG_ERR("Failed to write to file, rc=%d", ret);
+					return;
+				}
+
+				if (pcm_data_duration == 0) {
+					// close the file!
+					// bugbug: I would prefer to do this to fix up the wav
+					// header now that we know the size of the file but seek is
+					// not working. write_wav_header(wav_file_bytes);
+					sd_card_close(&wav_file);
+					wav_file_open = false;
+					LOG_INF("Saved %d bytes to wav file.", wav_file_bytes);
+				}
+			}
+		}
+	}
+}
+
+#ifdef CONFIG_AUDIO_SAVE_WAV
+K_THREAD_DEFINE(subscriber_task_id, CONFIG_MAIN_STACK_SIZE, save_wav_task, NULL, NULL, NULL, 3, 0,
+		0);
+#endif
+
+void audio_datapath_pcm_save_data(const char *pcm_buffer, size_t size)
+{
+	struct save_wave_msg msg;
+	const size_t pcm_data_size = sizeof(pcm_data1);
+	if (pcm_data_used + size > pcm_data_size) {
+		if (save_busy) {
+			LOG_ERR("sd save is not keeping up");
+			return;
+		}
+		msg.buffer = pcm_data;
+		msg.size = pcm_data_used;
+
+		// toggle buffers so sd card write can happen in parallel with collecting
+		// the next buffer.
+		if (pcm_data == pcm_data1) {
+			pcm_data = pcm_data2;
+		} else {
+			pcm_data = pcm_data1;
+		}
+
+		if (pcm_data_used >= pcm_data_duration) {
+			pcm_data_duration = 0; // done!
+		} else {
+			pcm_data_duration -= pcm_data_used;
+		}
+		wav_file_bytes += pcm_data_used;
+
+		// do the save on a separate thread so it doesn't block our PDM read thread.
+		int ret = zbus_chan_pub(&save_wav_channel, &msg, K_NO_WAIT);
+		if (ret) {
+			LOG_ERR("Failed to publish save wav msg, ret: %d", ret);
+		}
+
+		pcm_data_used = 0;
+	}
+	memcpy(&pcm_data[pcm_data_used], pcm_buffer, size);
+	pcm_data_used += size;
+}
+
+int audio_datapath_save_wav(const char *filename, uint32_t duration_seconds)
+{
+	pcm_data_used = 0;
+	pcm_data = pcm_data1;
+	pcm_data_duration =
+		duration_seconds * CONFIG_AUDIO_SAMPLE_RATE_HZ * CONFIG_AUDIO_BIT_DEPTH_OCTETS;
+	wav_file_bytes = 0;
+
+	if (wav_file_open) {
+		sd_card_close(&wav_file);
+		wav_file_open = false;
+	}
+
+	int err = sd_card_open_for_write(filename, &wav_file);
+	if (err != 0) {
+		pcm_data_duration = 0;
+		LOG_ERR("Failed to open file, rc=%d", err);
+		return err;
+	} else {
+		wav_file_open = true;
+		write_wav_header(
+			&wav_file,
+			320000, // hard coded header because fs_seek doesn't seem to be working.
+			CONFIG_AUDIO_SAMPLE_RATE_HZ * 2, // bugbug: somehow the lc3 decoded data is
+			// returning twice as much data as expected...?
+			CONFIG_AUDIO_BIT_DEPTH_OCTETS,
+			1 // 1 channel
+		);
+	}
+	return 0;
+}
+
 void audio_datapath_stream_out(const uint8_t *buf, size_t size, uint32_t sdu_ref_us, bool bad_frame,
 			       uint32_t recv_frame_ts_us)
 {
@@ -936,6 +1071,10 @@ void audio_datapath_stream_out(const uint8_t *buf, size_t size, uint32_t sdu_ref
 		LOG_WRN("Decoded audio has wrong size");
 		/* Discard frame */
 		return;
+	}
+
+	if (pcm_data_duration > 0) {
+		audio_datapath_pcm_save_data(ctrl_blk.decoded_data, pcm_size);
 	}
 
 	/*** Add audio data to FIFO buffer ***/

--- a/applications/nrf5340_audio/src/audio/audio_datapath.h
+++ b/applications/nrf5340_audio/src/audio/audio_datapath.h
@@ -87,4 +87,14 @@ int audio_datapath_stop(void);
  */
 int audio_datapath_init(void);
 
+/**
+ * @brief Save received PCM audio to sd card.
+ *
+ * @param[in]	filename	        Name of wav file to create on sd card.
+ * @param[in]	duration_seconds	Length of recording in seconds.
+ *
+ * @return 0 on success, error otherwise.
+ */
+int audio_datapath_save_wav(const char* filename, uint32_t duration_seconds);
+
 #endif /* _AUDIO_DATAPATH_H_ */

--- a/applications/nrf5340_audio/src/audio/streamctrl_unicast_client.c
+++ b/applications/nrf5340_audio/src/audio/streamctrl_unicast_client.c
@@ -13,6 +13,7 @@
 #include "button_assignments.h"
 #include "macros_common.h"
 #include "audio_system.h"
+#include "audio_datapath.h"
 #include "button_handler.h"
 #include "le_audio.h"
 #include "bt_mgmt.h"
@@ -179,7 +180,10 @@ static void button_msg_sub_thread(void)
 			break;
 
 		case BUTTON_5:
-			if (IS_ENABLED(CONFIG_AUDIO_MUTE)) {
+			if (IS_ENABLED(CONFIG_AUDIO_SAVE_WAV)) {
+				audio_datapath_save_wav("test.wav", 10);
+			}
+			else if (IS_ENABLED(CONFIG_AUDIO_MUTE)) {
 				ret = bt_rend_volume_mute(false);
 				if (ret) {
 					LOG_WRN("Failed to mute, ret: %d", ret);

--- a/applications/nrf5340_audio/src/audio/wav_file.c
+++ b/applications/nrf5340_audio/src/audio/wav_file.c
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include "wav_file.h"
+
+LOG_MODULE_REGISTER(audio_wavfile, CONFIG_WAV_FILE_LOG_LEVEL);
+
+int write_wav_header(struct fs_file_t *wav_file, uint32_t size, uint16_t sample_rate,
+		     uint16_t bytes_per_sample, uint16_t num_channels)
+{
+	struct wav_header wav_file_header;
+	wav_file_header.riff_header[0] = 'R';
+	wav_file_header.riff_header[1] = 'I';
+	wav_file_header.riff_header[2] = 'F';
+	wav_file_header.riff_header[3] = 'F';
+	wav_file_header.wav_size = size + 0x24;
+	wav_file_header.wav_header[0] = 'W';
+	wav_file_header.wav_header[1] = 'A';
+	wav_file_header.wav_header[2] = 'V';
+	wav_file_header.wav_header[3] = 'E';
+	wav_file_header.fmt_header[0] = 'f';
+	wav_file_header.fmt_header[1] = 'm';
+	wav_file_header.fmt_header[2] = 't';
+	wav_file_header.fmt_header[3] = ' ';
+	wav_file_header.wav_chunk_size = 16;
+	wav_file_header.audio_format = WAV_FORMAT_PCM;
+	wav_file_header.num_channels = 1;
+	wav_file_header.sample_rate = sample_rate;
+	wav_file_header.byte_rate = sample_rate * bytes_per_sample * num_channels;
+	wav_file_header.block_alignment = bytes_per_sample * num_channels;
+	wav_file_header.bit_depth = bytes_per_sample * 8;
+	wav_file_header.data_header[0] = 'd';
+	wav_file_header.data_header[1] = 'a';
+	wav_file_header.data_header[2] = 't';
+	wav_file_header.data_header[3] = 'a';
+	wav_file_header.data_bytes = size;
+
+	off_t position = fs_tell(wav_file);
+
+	// seek back to the beginning to rewrite the header.
+	// BUGBUG: this seek doesn't seem to be working?
+	int ret = fs_seek(wav_file, 0, FS_SEEK_SET);
+	if (ret) {
+		LOG_ERR("Seek file pointer failed");
+		return ret;
+	}
+
+	ret = write_wav_data(wav_file, (char *)&wav_file_header, sizeof(wav_file_header));
+
+	// seek back to where we were.
+	fs_seek(wav_file, position, FS_SEEK_SET);
+	return ret;
+}
+
+int read_wav_header(struct fs_file_t *wav_file, struct wav_header *header)
+{
+	int ret = fs_read(wav_file, header, sizeof(struct wav_header));
+	if (ret < 0) {
+		LOG_ERR("Read file failed: %d", ret);
+	}
+	return ret;
+}
+
+int write_wav_data(struct fs_file_t *wav_file, const char *buffer, uint32_t size)
+{
+	int ret = fs_write(wav_file, buffer, size);
+	if (ret < 0) {
+		LOG_ERR("Write file failed: %d", ret);
+		return ret;
+	}
+	return 0;
+}

--- a/applications/nrf5340_audio/src/audio/wav_file.h
+++ b/applications/nrf5340_audio/src/audio/wav_file.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef _WAV_FILE_H_
+#define _WAV_FILE_H_
+
+#include <stdint.h>
+#include <stddef.h>
+#include <zephyr/fs/fs.h>
+
+#define WAV_FORMAT_PCM 1
+
+/* WAV header */
+struct wav_header {
+	/* RIFF Header */
+	char riff_header[4];
+	uint32_t wav_size;  /* File size excluding first eight bytes */
+	char wav_header[4]; /* Contains "WAVE" */
+	/* Format Header */
+	char fmt_header[4];
+	uint32_t wav_chunk_size; /* Should be 16 for PCM */
+	short audio_format;	 /* Should be 1 for PCM */
+	short num_channels;
+	uint32_t sample_rate;
+	uint32_t byte_rate;
+	short block_alignment; /* num_channels * Bytes Per Sample */
+	short bit_depth;
+
+	/* Data */
+	char data_header[4];
+	uint32_t data_bytes; /* Number of bytes in data */
+} __packed;		     // 44 bytes
+
+int read_wav_header(struct fs_file_t *wav_file, struct wav_header *header);
+
+int write_wav_header(struct fs_file_t *wav_file, uint32_t size, uint16_t sample_rate,
+		     uint16_t bytes_per_sample, uint16_t num_channels);
+
+int write_wav_data(struct fs_file_t *wav_file, const char *buffer, uint32_t size);
+
+#endif

--- a/applications/nrf5340_audio/src/modules/sd_card.c
+++ b/applications/nrf5340_audio/src/modules/sd_card.c
@@ -282,6 +282,53 @@ int sd_card_open(char const *const filename, struct fs_file_t *f_seg_read_entry)
 	return 0;
 }
 
+int sd_card_open_for_write(char const *const filename, struct fs_file_t *f_seg_write_entry)
+{
+	int ret;
+	char abs_path_name[PATH_MAX_LEN + 1] = SD_ROOT_PATH;
+	size_t avilable_path_space = PATH_MAX_LEN - strlen(SD_ROOT_PATH);
+
+	ret = k_sem_take(&m_sem_sd_oper_ongoing, K_MSEC(K_SEM_OPER_TIMEOUT_MS));
+	if (ret) {
+		LOG_ERR("Sem take failed. Ret: %d", ret);
+		return ret;
+	}
+
+	if (!sd_init_success) {
+		k_sem_give(&m_sem_sd_oper_ongoing);
+		return -ENODEV;
+	}
+
+	if (strlen(filename) > CONFIG_FS_FATFS_MAX_LFN) {
+		LOG_ERR("Filename is too long");
+		k_sem_give(&m_sem_sd_oper_ongoing);
+		return -ENAMETOOLONG;
+	}
+
+	if ((strlen(abs_path_name) + strlen(filename)) > PATH_MAX_LEN) {
+		LOG_ERR("Filepath is too long");
+		k_sem_give(&m_sem_sd_oper_ongoing);
+		return -EINVAL;
+	}
+
+	strncat(abs_path_name, filename, avilable_path_space);
+
+	LOG_INF("abs path name:\t%s", abs_path_name);
+
+	fs_file_t_init(f_seg_write_entry);
+
+	fs_unlink(abs_path_name);
+
+	ret = fs_open(f_seg_write_entry, abs_path_name, FS_O_WRITE | FS_O_CREATE | FS_O_APPEND);
+	if (ret) {
+		LOG_ERR("Open file failed: %d", ret);
+		k_sem_give(&m_sem_sd_oper_ongoing);
+		return ret;
+	}
+
+	return 0;
+}
+
 int sd_card_read(char *buf, size_t *size, struct fs_file_t *f_seg_read_entry)
 {
 	int ret;
@@ -299,6 +346,25 @@ int sd_card_read(char *buf, size_t *size, struct fs_file_t *f_seg_read_entry)
 	}
 
 	*size = ret;
+
+	return 0;
+}
+
+int sd_card_write(const char *buf, size_t size, struct fs_file_t *f_seg_write_entry)
+{
+	int ret;
+
+	if (!(k_sem_count_get(&m_sem_sd_oper_ongoing) <= 0)) {
+		LOG_ERR("SD operation not ongoing");
+		return -EPERM;
+	}
+
+	ret = fs_write(f_seg_write_entry, buf, size);
+	if (ret < 0) {
+		LOG_ERR("Write file failed: %d", ret);
+		k_sem_give(&m_sem_sd_oper_ongoing);
+		return ret;
+	}
 
 	return 0;
 }

--- a/applications/nrf5340_audio/src/modules/sd_card.h
+++ b/applications/nrf5340_audio/src/modules/sd_card.h
@@ -36,7 +36,7 @@ int sd_card_list_files(char const *const path, char *buf, size_t *buf_size);
  * @note	If the file already exists, data will be appended to the end of the file.
  *
  * @param[in]		filename	Name of the target file for writing, the default
- *					location is the root directoy of SD card, accept
+ *					location is the root directory of SD card, accept
 					absolute path under root of SD card.
  * @param[in]		data		which is going to be written into the file.
  * @param[in, out]	size		Pointer to the number of bytes which is going to be written.
@@ -86,6 +86,23 @@ int sd_card_open_read_close(char const *const filename, char *const buf, size_t 
 int sd_card_open(char const *const filename, struct fs_file_t *f_seg_read_entry);
 
 /**
+ * @brief	Open file on SD card for writing new file.
+ *
+ * @param[in]		filename		Name of file to create. Default
+ *						location is the root directory of SD card.
+ *						Absolute path under root of SD card is accepted.
+ * @param[in, out]	f_seg_write_entry	Pointer to a file object.
+ *						The pointer gets initialized and ready for use.
+ *
+ *
+ * @retval	0 on success.
+ * @retval	-EPERM SD card operation is ongoing somewhere else.
+ * @retval	-ENODEV SD init failed. SD likely not inserted.
+ * @retval	Otherwise, error from underlying drivers.
+ */
+int sd_card_open_for_write(char const *const filename, struct fs_file_t *f_seg_write_entry);
+
+/**
  * @brief	Read segment on the open file on the SD card.
  *
  * @param[out]		buf			Pointer to the buffer to write the read data into.
@@ -104,6 +121,22 @@ int sd_card_open(char const *const filename, struct fs_file_t *f_seg_read_entry)
  * @retval	Otherwise, error from underlying drivers.
  */
 int sd_card_read(char *buf, size_t *size, struct fs_file_t *f_seg_read_entry);
+
+/**
+ * @brief	Write segment on the open file on the SD card.
+ *
+ * @param[out]		buf			Pointer to the buffer to write.
+ * @param[in, out]	size			Number of bytes to be written to file.
+ * @param[in, out]	f_seg_read_entry	Pointer to a file object. After call to this
+ *						function, the pointer gets updated and can be used
+ *						as entry in next function call.
+ *
+ * @retval	0 on success.
+ * @retval	-EPERM SD card operation is not ongoing.
+ * @retval	-ENODEV SD init failed. SD likely not inserted.
+ * @retval	Otherwise, error from underlying drivers.
+ */
+int sd_card_write(const char *buf, size_t size, struct fs_file_t *f_seg_read_entry);
 
 /**
  * @brief	Close the file opened by the sd_card_segment_read_open function.


### PR DESCRIPTION
This PR adds a `AUDIO_SAVE_WAV` that can be used to change the behavior of `BUTTON_5` so that it saves a 10 second wav file recording of the PCM data being received over LE audio stream to the SD card.

This turned out to be a handy debugging tool when I was trying to record the exact PCM data without any microphone line noise that you get when you use an audio jack on the nrf5340 audio DK for recording.

It uses 2 1 second buffers so it can save from a thread in parallel with receiving new data over LE audio.  This way it could save an unlimited amount of audio, currently hard coded to 10 seconds which is sufficient for most quick tests.  Which buffer to save is communicated in a new zbus message to ensure that the task saves the right buffer.

You get the following logging output when you press the button:

```
HL [00:00:31.748,443] <inf> audio_datapath: Saved 320000 bytes to wav file.
HL [00:00:37.205,871] <inf> sd_card: abs path name:     /SD:/test.wav
```

There are a couple of open issues I'd love some help with:

1.  See bugbug in audio_datapath.c where I'm finding that "fs_seek" is not working.  What I really want to do in write_wav_header is seek to the beginning of the file with `fs_seek(wav_file, 0, FS_SEEK_SET);` and that way I can "patch" the wav header at the end before closing the file because it is only really at that point that we know for sure how many bytes were written which is needed in the wav_size and data_bytes fields of the wave header.  When I tried this code, the last call to write_wav_header did not modify the header instead it wrote another header to the end of the file.  Is there some problem with fs_seek? There were no seek errors in the logs...

2. I'm saving the output of `sw_codec_decode` but to be honest I didn't fully understand lines 1037-1052 in audio_datapath.c (some comments would be nice).  This seems to be breaking up the resulting `ctrl_blk.decoded_data` into chunks.  Not sure why, maybe that's just in preparation for how the i2s output to the headphones works?  But when I save the `ctrl_blk.decoded_data` directly to the wav file I end up with twice as much data as expected and it plays back super slowly at very low pitch.  I had to double the wav_file_hedaer.sample_rate for the audio to sound correct.  I'm not sure why.  For example, in this branch I'm recording at 16kHz, I had to wite sample_rate 32khz to my wav file.  Perhaps sw_codec_decode returns stereo in a weird way even though this is a mono-channel at this point, and that's what lines 1037-1052 is dealing with? I don't know...  any pointers would be appreciated.

3. I see that the "main" branch seems to have moved to a new version of Zephyr, so I can't build main right now using the version that comes with v2.5.0.  A pristine build of main gives me the error:
    
    ```
    warning: ZBUS_MSG_SUBSCRIBER (defined at F:/git/sdk-nrf/applications/nrf5340_audio\Kconfig.defaults:56) 
    defined without a type
    ````

    So where do I find the build/test instructions for the main branch?

Attached is a zip file containing the resulting wav files, the original without the `sample_rate  * 2` fix, then the fixed version.  The fixed version then is only 5 seconds, whereas I was supposed to be saving 10 seconds of audio.  Note that during this recording I was listening to the ear buds connected to the headset jack and the audio sounded great, so I know the LE audio was correct.

[test.zip](https://github.com/nrfconnect/sdk-nrf/files/13519088/test.zip)
