### PR TITLE
manifest: update twister to pass pytest parameters

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 2364b332d085341d78e9618125256ae3a5cc71b0
+      revision: ad95bc81b8b9d44431c092a3cee4e7204dfceba4
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Bring the commits needed by twister to pass parameters to pytest subprocess. It allows to select a specific testcase from a test suite.