### PR TITLE
kconfig: tfm: Conditionally set NRF_CC3XX_PLATFORM and ZEROIZE_ALT

### DIFF
--- a/subsys/nrf_security/tfm/CMakeLists.txt
+++ b/subsys/nrf_security/tfm/CMakeLists.txt
@@ -56,8 +56,10 @@ set(CONFIG_MBEDTLS_MD_C                             False)
 # Platform cannot be selected when building for TF-M, because TF-M itself has
 # control of the CryptoCell. Therefore, specifically for building TF-M we
 # enable it manually.
-set(CONFIG_NRF_CC3XX_PLATFORM                       True)
-set(CONFIG_MBEDTLS_PLATFORM_ZEROIZE_ALT             True)
+if(CONFIG_HAS_HW_NRF_CC3XX)
+  set(CONFIG_NRF_CC3XX_PLATFORM                       True)
+  set(CONFIG_MBEDTLS_PLATFORM_ZEROIZE_ALT             True)
+endif()
 
 # Disable threading for TF-M SPM image
 set(CONFIG_MBEDTLS_THREADING_ALT                    False)


### PR DESCRIPTION
It is only the platforms with CC3XX that need NRF_CC3XX_PLATFORM so make this conditional.

Also, only set MBEDTLS_PLATFORM_ZEROIZE_ALT on CC3XX platforms because it is the CC3XX binary that provides this function.