### PR TITLE
Bluetooth: Controller: Add VS command for setting max tx payload

### DIFF
--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -659,6 +659,10 @@ static void vs_supported_commands(sdc_hci_vs_supported_vs_commands_t *cmds)
 #if defined(CONFIG_BT_CTLR_SDC_PAWR_ADV)
 	cmds->allow_parallel_connection_establishments = 1;
 #endif
+
+#if defined(CONFIG_BT_CONN)
+	cmds->min_val_of_max_acl_tx_payload_set = 1;
+#endif
 }
 #endif	/* CONFIG_BT_HCI_VS */
 
@@ -1593,6 +1597,10 @@ static uint8_t vs_cmd_put(uint8_t const *const cmd, uint8_t *const raw_event_out
 #if defined(CONFIG_BT_CTLR_SDC_PAWR_ADV)
 	case SDC_HCI_OPCODE_CMD_VS_ALLOW_PARALLEL_CONNECTION_ESTABLISHMENTS:
 		return sdc_hci_cmd_vs_allow_parallel_connection_establishments((void *)cmd_params);
+#endif
+#if defined(CONFIG_BT_CONN)
+	case SDC_HCI_OPCODE_CMD_VS_MIN_VAL_OF_MAX_ACL_TX_PAYLOAD_SET:
+		return sdc_hci_cmd_vs_min_val_of_max_acl_tx_payload_set((void *)cmd_params);
 #endif
 	default:
 		return BT_HCI_ERR_UNKNOWN_CMD;


### PR DESCRIPTION
Add the vendor specific command handler for
SDC_HCI_OPCODE_CMD_VS_MIN_VAL_OF_MAX_ACL_TX_PAYLOAD_SET.

Previously it was only possible to set a fixed value for this using a Kconfig entry.

This command sets the minimum value of maximum ACL payload length that can be sent in each packet. If the configured event length is shorter than what is required to send a packet pair of 27 bytes in each direction, the controller will use this value to determine how much it can reduce the payload size to satisfy the event length requirements LL Control PDUs are not affected by this API.