### PR TITLE
doc: Asset Tracker v2: adding modules wrapper page

### DIFF
--- a/applications/asset_tracker_v2/README.rst
+++ b/applications/asset_tracker_v2/README.rst
@@ -9,7 +9,7 @@ Asset Tracker v2
 
 The Asset Tracker v2 is a real-time configurable ultra-low power capable application firmware for the nRF91 Series :term:`System in Package (SiP)`.
 
-See the subpages for detailed documentation on the application and its internal modules:
+See the subpages for detailed documentation on the application and its modules:
 
 .. _asset_tracker_v2_subpages:
 
@@ -21,15 +21,4 @@ See the subpages for detailed documentation on the application and its internal 
    doc/app_behavior
    doc/firmware_architecture
    doc/lwm2m_carrier_library
-   doc/app_module
-   doc/data_module
-   doc/cloud_module
-   doc/cloud_wrapper
-   doc/debug_module
-   doc/location_module
-   doc/modem_module
-   doc/sensor_module
-   doc/ui_module
-   doc/util_module
-   doc/modules_common
-   doc/unit_test
+   doc/modules

--- a/applications/asset_tracker_v2/doc/firmware_architecture.rst
+++ b/applications/asset_tracker_v2/doc/firmware_architecture.rst
@@ -1,4 +1,4 @@
-.. _asset_tracker_v2_internal_modules:
+.. _asset_tracker_v2_architecture:
 
 Firmware architecture
 #####################
@@ -21,21 +21,10 @@ It also shows the modules with thread and the modules without thread.
 
     Relationship between modules and the Application Event Manager
 
-Internal modules
-****************
+Application modules
+*******************
 
-The application comprises of the following modules:
-
-* :ref:`asset_tracker_v2_app_module`
-* :ref:`asset_tracker_v2_data_module`
-* :ref:`asset_tracker_v2_cloud_module`
-* :ref:`asset_tracker_v2_sensor_module`
-* :ref:`asset_tracker_v2_location_module`
-* :ref:`asset_tracker_v2_ui_module`
-* :ref:`asset_tracker_v2_util_module`
-* :ref:`asset_tracker_v2_debug_module`
-* :ref:`asset_tracker_v2_modem_module`
-
+The application consists of a set of modules.
 Each module documentation contains information about its API, dependencies, states, and state transitions.
 
 The application has two types of modules:
@@ -59,7 +48,7 @@ The messages are then queued in the case of the cloud module or processed direct
 
     Event handling in modules
 
-For more information about each module and its configuration, see the respective :ref:`module documentation <asset_tracker_v2_subpages>`.
+For more information about the modules and their configuration, see the :ref:`asset_tracker_v2_modules`.
 
 Thread usage
 ************

--- a/applications/asset_tracker_v2/doc/modules.rst
+++ b/applications/asset_tracker_v2/doc/modules.rst
@@ -1,0 +1,28 @@
+.. _asset_tracker_v2_modules:
+
+Application modules
+###################
+
+The Asset Tracker v2 application consists of a set of modules.
+See :ref:`asset_tracker_v2_architecture` for more information on how the application is structured.
+
+Some of the modules have a set of :ref:`asset_tracker_unit_test`.
+
+See the subpages for detailed documentation on the modules:
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Subpages:
+
+   app_module
+   data_module
+   cloud_module
+   cloud_wrapper
+   debug_module
+   location_module
+   modem_module
+   sensor_module
+   ui_module
+   util_module
+   modules_common
+   unit_test


### PR DESCRIPTION
To clean up the ToC for the Asset Tracker v2 docs, added a separate wrapper page for the modules.