### PR TITLE
lib: location: Wait RRC idle before GCI search

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -440,9 +440,12 @@ Modem libraries
 
 * :ref:`lib_location` library:
 
-  * Updated the use of neighbor cell measurements for cellular positioning.
-    Previously, 1-2 searches were performed and now 1-3 will be done depending on the requested number of cells and the number of found cells.
-    Also, only GCI cells are counted towards the requested number of cells, and normal neighbors are ignored from this perspective.
+  * Updated:
+
+    * The use of neighbor cell measurements for cellular positioning.
+      Previously, 1-2 searches were performed and now 1-3 will be done depending on the requested number of cells and the number of found cells.
+      Also, only GCI cells are counted towards the requested number of cells, and normal neighbors are ignored from this perspective.
+    * Cellular positioning not to use GCI search when the device is in RRC connected mode, because the modem cannot search for GCI cells in that mode.
 
 * :ref:`lte_lc_readme` library:
 


### PR DESCRIPTION
Since GCI search won't return GCI cells but only normal neighbors in RRC connected mode, we will wait for RRC idle mode for 10s and proceed to GCI searches when RRC idle mode is reached. If RRC is still connected after 10s, GCI searches are skipped and we use results from NCELLMEAS=1 for cellular positioning.

Jira: NCSDK-24814