### PR TITLE
Bluetooth: Mesh: Add sensor value utils

### DIFF
--- a/subsys/bluetooth/mesh/sensor.h
+++ b/subsys/bluetooth/mesh/sensor.h
@@ -151,8 +151,8 @@ typedef struct bt_mesh_sensor_value sensor_value_type;
 		  (_value)->val2 <= (_end)->val2)))
 #else
 #define SENSOR_VALUE_IN_RANGE(_value, _start, _end) (                          \
-		(_value)->format->compare((_value), (_start)) >= 0 &&          \
-		(_value)->format->compare((_end), (_value)) >= 0)
+		(_value)->format->cb->compare((_value), (_start)) >= 0 &&      \
+		(_value)->format->cb->compare((_end), (_value)) >= 0)
 
 /** @brief Check if a value change breaks the delta threshold.
  *

--- a/subsys/bluetooth/mesh/sensor_cli.c
+++ b/subsys/bluetooth/mesh/sensor_cli.c
@@ -243,7 +243,7 @@ yield_ack:
 			(rsp->col->start.val1 != entry.column.start.val1 ||
 			 rsp->col->start.val2 != entry.column.start.val2)) {
 #else
-			col_format->compare(rsp->col_start, &entry.column.start) != 0) {
+			col_format->cb->compare(rsp->col_start, &entry.column.start) != 0) {
 #endif
 			return 0;
 		}

--- a/subsys/bluetooth/mesh/sensor_srv.c
+++ b/subsys/bluetooth/mesh/sensor_srv.c
@@ -230,7 +230,7 @@ column_get(const struct bt_mesh_sensor_series *series,
 		if (series->columns[i].start.val1 == val->val1 &&
 		    series->columns[i].start.val2 == val->val2) {
 #else
-		if (val->format->compare(&series->columns[i].start, val) == 0) {
+		if (val->format->cb->compare(&series->columns[i].start, val) == 0) {
 #endif
 			return &series->columns[i];
 		}


### PR DESCRIPTION
This adds utility functions for converting struct bt_mesh_sensor_value
values to and from float and sensor value, and to string.

Signed-off-by: Ludvig Jordet <ludvig.jordet@nordicsemi.no>