### PR TITLE
applications: Matter Bridge: added support for Generic Switch

### DIFF
--- a/applications/matter_bridge/CMakeLists.txt
+++ b/applications/matter_bridge/CMakeLists.txt
@@ -60,12 +60,13 @@ if(CONFIG_BRIDGED_DEVICE_BT)
     )
     target_include_directories(app PRIVATE src/ble_providers)
 
-if(CONFIG_BRIDGE_ONOFF_LIGHT_BRIDGED_DEVICE)
+if(CONFIG_BRIDGE_ONOFF_LIGHT_BRIDGED_DEVICE AND CONFIG_BRIDGE_GENERIC_SWITCH_BRIDGED_DEVICE)
     target_sources(app PRIVATE
         src/bridged_device_types/onoff_light.cpp
-        src/ble_providers/ble_onoff_light_data_provider.cpp
+        src/bridged_device_types/generic_switch.cpp
+        src/ble_providers/ble_lbs_data_provider.cpp
     )
-endif() # CONFIG_BRIDGE_ONOFF_LIGHT_BRIDGED_DEVICE
+endif() # CONFIG_BRIDGE_ONOFF_LIGHT_BRIDGED_DEVICE AND CONFIG_BRIDGE_GENERIC_SWITCH_BRIDGED_DEVICE
 
 if(CONFIG_BRIDGE_HUMIDITY_SENSOR_BRIDGED_DEVICE)
     target_sources(app PRIVATE
@@ -92,12 +93,14 @@ else()
     )
     target_include_directories(app PRIVATE src/simulated_providers)
 
-if(CONFIG_BRIDGE_ONOFF_LIGHT_BRIDGED_DEVICE)
+if(CONFIG_BRIDGE_ONOFF_LIGHT_BRIDGED_DEVICE AND CONFIG_BRIDGE_GENERIC_SWITCH_BRIDGED_DEVICE)
     target_sources(app PRIVATE
         src/bridged_device_types/onoff_light.cpp
+        src/bridged_device_types/generic_switch.cpp
         src/simulated_providers/simulated_onoff_light_data_provider.cpp
+        src/simulated_providers/simulated_generic_switch_data_provider.cpp
     )
-endif() # CONFIG_BRIDGE_ONOFF_LIGHT_BRIDGED_DEVICE
+endif() # CONFIG_BRIDGE_ONOFF_LIGHT_BRIDGED_DEVICE AND CONFIG_BRIDGE_GENERIC_SWITCH_BRIDGED_DEVICE
 
 if(CONFIG_BRIDGE_TEMPERATURE_SENSOR_BRIDGED_DEVICE)
     target_sources(app PRIVATE

--- a/applications/matter_bridge/Kconfig
+++ b/applications/matter_bridge/Kconfig
@@ -17,6 +17,10 @@ config BRIDGE_HUMIDITY_SENSOR_BRIDGED_DEVICE
 	bool "Support for Humidity Sensor bridged device"
 	default y
 
+config BRIDGE_GENERIC_SWITCH_BRIDGED_DEVICE
+	bool "Support for Generic Switch bridged device"
+	default y
+
 choice BRIDGED_DEVICE_IMPLEMENTATION
 	prompt "Bridged Device implementation"
 	default BRIDGED_DEVICE_SIMULATED

--- a/applications/matter_bridge/README.rst
+++ b/applications/matter_bridge/README.rst
@@ -46,6 +46,7 @@ The Matter bridge has capability of representing non-Matter bridged devices as d
 The application supports bridging the following Matter device types:
 
 * On/Off Light
+* Generic Switch
 * Temperature Sensor
 * Humidity Sensor
 
@@ -99,7 +100,7 @@ The application supports two bridged device configurations that are mutually exc
 * Bluetooth LE bridged device - This configuration allows to connect a real peripheral Bluetooth LE device to the Matter bridge and represent its functionalities using :ref:`Matter Data Model <ug_matter_overview_data_model>`.
   The application supports the following Bluetooth LE services:
 
-  * Nordic Semiconductor's :ref:`LED Button Service <lbs_readme>` - represented by the Matter On/Off Light device type.
+  * Nordic Semiconductor's :ref:`LED Button Service <lbs_readme>` - represented by the Matter On/Off Light and Generic Switch device types.
   * Zephyr's :ref:`Environmental Sensing Service <peripheral_esp>` - represented by the Matter Temperature Sensor and Humidity Sensor device types.
 
 Depending on the bridged device you want to support in your application, :ref:`enable it using the appropriate Kconfig option <matter_bridge_app_bridged_support_configs>`.
@@ -207,6 +208,7 @@ Adding a simulated bridged device to the Matter bridge
    * *<device_type>* is the Matter device type to use for the bridged device.
      The argument is mandatory and accepts the following values:
 
+      * ``15`` - Generic Switch.
       * ``256`` - On/Off Light.
       * ``770`` - Temperature Sensor.
       * ``775`` - Humidity Sensor.
@@ -220,7 +222,7 @@ Adding a simulated bridged device to the Matter bridge
 
       uart:~$ matter_bridge add 256 "Kitchen Light"
 
-Controlling a simulated OnOff Light bridged device
+Controlling a simulated On/Off Light bridged device
    Use the following command:
 
    .. parsed-literal::
@@ -230,8 +232,8 @@ Controlling a simulated OnOff Light bridged device
 
    In this command:
 
-   * *<new_state>*  is the new state (``0`` - off and ``1`` - on) that will be set on the simulated OnOff Light device.
-   * *<endpoint>*  is the endpoint on which the bridged OnOff Light device is implemented
+   * *<new_state>*  is the new state (``0`` - off and ``1`` - on) that will be set on the simulated On/Off Light device.
+   * *<endpoint>*  is the endpoint on which the bridged On/Off Light device is implemented
 
    Example command:
 
@@ -269,7 +271,10 @@ Adding a Bluetooth LE bridged device to the Matter bridge
    .. code-block:: console
 
       I: Added device to dynamic endpoint 3 (index=0)
+      I: Added device to dynamic endpoint 4 (index=1)
       I: Created 0x100 device type on the endpoint 3
+      I: Created 0xf device type on the endpoint 4
+
 
 Removing a bridged device from the Matter bridge
    Use the following command:
@@ -302,12 +307,12 @@ You can enable the :ref:`matter_bridge_app_bridged_support` by using the followi
 * :kconfig:option:`CONFIG_BRIDGED_DEVICE_SIMULATED` - For the simulated bridged device.
 * :kconfig:option:`CONFIG_BRIDGED_DEVICE_BT` - For the Bluetooth LE bridged device.
 
-The simulated OnOff Light bridged device can operate in the following modes:
+The simulated On/Off Light bridged device can operate in the following modes:
 
 * Autonomous - The simulated device periodically changes its state.
-  To build the simulated OnOff Light data provider in this mode, select the :kconfig:option:`CONFIG_BRIDGED_DEVICE_SIMULATED_ONOFF_AUTOMATIC` Kconfig option.
+  To build the simulated On/Off Light data provider in this mode, select the :kconfig:option:`CONFIG_BRIDGED_DEVICE_SIMULATED_ONOFF_AUTOMATIC` Kconfig option.
 * Controllable - The user can explicitly control the On/Off state by using shell commands.
-  To build the simulated OnOff Light data provider in this mode, select the :kconfig:option:`CONFIG_BRIDGED_DEVICE_SIMULATED_ONOFF_SHELL` Kconfig option.
+  To build the simulated On/Off Light data provider in this mode, select the :kconfig:option:`CONFIG_BRIDGED_DEVICE_SIMULATED_ONOFF_SHELL` Kconfig option.
   This is enabled by default.
 
 Additionally, you can decide how many bridged devices the bridge application will support.
@@ -479,9 +484,14 @@ After building the sample and programming it to your development kit, complete t
                :class: highlight
 
                I: Added device to dynamic endpoint 3 (index=0)
+               I: Added device to dynamic endpoint 4 (index=1)
                I: Created 0x100 device type on the endpoint 3
+               I: Created 0xf device type on the endpoint 4
 
-            For the Environmental Sensor, two endpoints are created: one implements the Temperature Sensor, and the other implements the Humidity Sensor.
+            For the LED Button Service and the Environmental Sensor, two endpoints are created:
+
+            * For the LED Button Service, one implements the On/Off Light Device and the other implements the Generic Switch Device.
+            * For the Environmental Sensor, one implements the Temperature Sensor and the other implements the Humidity Sensor.
 
          #. Write down the value for the bridged device dynamic endpoint ID.
             This is going to be used in the next steps (*<bridged_device_endpoint_ID>*).
@@ -492,6 +502,17 @@ After building the sample and programming it to your development kit, complete t
                :class: highlight
 
                ./chip-tool onoff read on-off *<bridge_node_ID>* *<bridged_device_endpoint_ID>*
+
+
+            Read the value of the *current-position* attribute from the *switch* cluster using the following command:
+
+            .. parsed-literal::
+               :class: highlight
+
+               ./chip-tool switch read current-position *<bridge_node_ID>* *<bridged_device_endpoint_ID>*
+
+            Note that the Generic Switch is implemented as a momentary switch.
+            This means that, in contrast to the latching switch, it remains switched on only as long as the physical button is pressed.
 
             In case of the Environmental Sensor, the current temperature and humidity measurements forwarded by the Bluetooth LE Environmental Sensor can be read as follows:
 

--- a/applications/matter_bridge/src/ble_providers/ble_bridged_device_factory.cpp
+++ b/applications/matter_bridge/src/ble_providers/ble_bridged_device_factory.cpp
@@ -20,6 +20,7 @@ CHIP_ERROR MatterDeviceTypeToBleService(MatterBridgedDevice::DeviceType deviceTy
 {
 	switch (deviceType) {
 	case MatterBridgedDevice::DeviceType::OnOffLight:
+	case MatterBridgedDevice::DeviceType::GenericSwitch:
 		serviceUUid = BleBridgedDeviceFactory::ServiceUuid::LedButtonService;
 		break;
 	case MatterBridgedDevice::DeviceType::TemperatureSensor:
@@ -42,7 +43,8 @@ CHIP_ERROR BleServiceToMatterDeviceType(BleBridgedDeviceFactory::ServiceUuid ser
 			return CHIP_ERROR_BUFFER_TOO_SMALL;
 		}
 		deviceType[0] = MatterBridgedDevice::DeviceType::OnOffLight;
-		count = 1;
+		deviceType[1] = MatterBridgedDevice::DeviceType::GenericSwitch;
+		count = 2;
 	} break;
 	case BleBridgedDeviceFactory::ServiceUuid::EnvironmentalSensorService: {
 		if (maxCount < 2) {
@@ -245,6 +247,15 @@ BleBridgedDeviceFactory::BridgedDeviceFactory &BleBridgedDeviceFactory::GetBridg
 			  return chip::Platform::New<TemperatureSensorDevice>(nodeLabel);
 		  } },
 #endif
+#ifdef CONFIG_BRIDGE_GENERIC_SWITCH_BRIDGED_DEVICE
+		{ MatterBridgedDevice::DeviceType::GenericSwitch,
+		  [checkLabel](const char *nodeLabel) -> MatterBridgedDevice * {
+			  if (!checkLabel(nodeLabel)) {
+				  return nullptr;
+			  }
+			  return chip::Platform::New<GenericSwitchDevice>(nodeLabel);
+		  } },
+#endif
 	};
 	return sBridgedDeviceFactory;
 }
@@ -253,9 +264,9 @@ BleBridgedDeviceFactory::BleDataProviderFactory &BleBridgedDeviceFactory::GetDat
 {
 	static BleDataProviderFactory sDeviceDataProvider
 	{
-#ifdef CONFIG_BRIDGE_ONOFF_LIGHT_BRIDGED_DEVICE
+#if defined(CONFIG_BRIDGE_ONOFF_LIGHT_BRIDGED_DEVICE) && defined(CONFIG_BRIDGE_GENERIC_SWITCH_BRIDGED_DEVICE)
 		{ ServiceUuid::LedButtonService,
-		  [](UpdateAttributeCallback clb) { return chip::Platform::New<BleOnOffLightDataProvider>(clb); } },
+		  [](UpdateAttributeCallback clb) { return chip::Platform::New<BleLBSDataProvider>(clb); } },
 #endif
 #if defined(CONFIG_BRIDGE_TEMPERATURE_SENSOR_BRIDGED_DEVICE) && defined(CONFIG_BRIDGE_HUMIDITY_SENSOR_BRIDGED_DEVICE)
 			{ ServiceUuid::EnvironmentalSensorService, [](UpdateAttributeCallback clb) {

--- a/applications/matter_bridge/src/ble_providers/ble_bridged_device_factory.h
+++ b/applications/matter_bridge/src/ble_providers/ble_bridged_device_factory.h
@@ -11,9 +11,17 @@
 #include "matter_bridged_device.h"
 #include <lib/support/CHIPMem.h>
 
+#if defined(CONFIG_BRIDGE_ONOFF_LIGHT_BRIDGED_DEVICE) && defined(CONFIG_BRIDGE_GENERIC_SWITCH_BRIDGED_DEVICE)
+#include "ble_lbs_data_provider.h"
+
 #ifdef CONFIG_BRIDGE_ONOFF_LIGHT_BRIDGED_DEVICE
-#include "ble_onoff_light_data_provider.h"
 #include "onoff_light.h"
+#endif
+
+#ifdef CONFIG_BRIDGE_GENERIC_SWITCH_BRIDGED_DEVICE
+#include "generic_switch.h"
+#endif
+
 #endif
 
 #ifdef CONFIG_BRIDGE_HUMIDITY_SENSOR_BRIDGED_DEVICE

--- a/applications/matter_bridge/src/ble_providers/ble_lbs_data_provider.h
+++ b/applications/matter_bridge/src/ble_providers/ble_lbs_data_provider.h
@@ -12,16 +12,18 @@
 
 #include <bluetooth/services/lbs.h>
 
-class BleOnOffLightDataProvider : public BLEBridgedDeviceProvider {
+class BleLBSDataProvider : public BLEBridgedDeviceProvider {
 public:
-	explicit BleOnOffLightDataProvider(UpdateAttributeCallback callback) : BLEBridgedDeviceProvider(callback) {}
+	explicit BleLBSDataProvider(UpdateAttributeCallback callback) : BLEBridgedDeviceProvider(callback) {}
 
 	void Init() override;
 	void NotifyUpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId, void *data,
 			       size_t dataSize) override;
 	CHIP_ERROR UpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer) override;
 
-	static void NotifyAttributeChange(intptr_t context);
+	static void NotifyOnOffAttributeChange(intptr_t context);
+	static void NotifySwitchCurrentPositionAttributeChange(intptr_t context);
+
 	static void GattWriteCallback(bt_conn *conn, uint8_t err, bt_gatt_write_params *params);
 	static uint8_t GattNotifyCallback(bt_conn *conn, bt_gatt_subscribe_params *params, const void *data,
 					  uint16_t length);
@@ -34,6 +36,7 @@ private:
 	bool CheckSubscriptionParameters(bt_gatt_subscribe_params *params);
 
 	bool mOnOff = false;
+	uint8_t mCurrentSwitchPosition = false;
 	uint16_t mLedCharacteristicHandle;
 	bt_gatt_write_params mGattWriteParams;
 	uint16_t mButtonCharacteristicHandle;

--- a/applications/matter_bridge/src/bridge_shell.cpp
+++ b/applications/matter_bridge/src/bridge_shell.cpp
@@ -160,7 +160,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		add, NULL,
 		"Adds bridged device. \n"
 		"Usage: add <bridged_device_type> [node_label]\n"
-		"* bridged_device_type - the bridged device's type, e.g. 256 - OnOff Light, 770 - TemperatureSensor, 775 - HumiditySensor\n"
+		"* bridged_device_type - the bridged device's type, e.g. 15 - Generic Switch, 256 - OnOff Light, 770 - TemperatureSensor, 775 - HumiditySensor, \n"
 		"* node_label - the optional bridged device's node label\n",
 		AddBridgedDeviceHandler, 2, 1),
 #endif /* CONFIG_BRIDGED_DEVICE_BT */

--- a/applications/matter_bridge/src/bridged_device_types/generic_switch.cpp
+++ b/applications/matter_bridge/src/bridged_device_types/generic_switch.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "generic_switch.h"
+
+#include <zephyr/logging/log.h>
+
+#include <app-common/zap-generated/ids/Commands.h>
+
+LOG_MODULE_DECLARE(app, CONFIG_CHIP_APP_LOG_LEVEL);
+
+namespace
+{
+DESCRIPTOR_CLUSTER_ATTRIBUTES(descriptorAttrs);
+BRIDGED_DEVICE_BASIC_INFORMATION_CLUSTER_ATTRIBUTES(bridgedDeviceBasicAttrs);
+IDENTIFY_CLUSTER_ATTRIBUTES(identifyAttrs);
+}; /* namespace */
+
+using namespace ::chip;
+using namespace ::chip::app;
+
+DECLARE_DYNAMIC_ATTRIBUTE_LIST_BEGIN(switchAttr)
+DECLARE_DYNAMIC_ATTRIBUTE(Clusters::Switch::Attributes::NumberOfPositions::Id, INT8U, 1, 0),
+	DECLARE_DYNAMIC_ATTRIBUTE(Clusters::Switch::Attributes::CurrentPosition::Id, INT8U, 1, 0),
+	DECLARE_DYNAMIC_ATTRIBUTE_LIST_END();
+
+DECLARE_DYNAMIC_CLUSTER_LIST_BEGIN(genericSwitchClusters)
+DECLARE_DYNAMIC_CLUSTER(Clusters::Switch::Id, switchAttr, nullptr, nullptr),
+	DECLARE_DYNAMIC_CLUSTER(Clusters::Descriptor::Id, descriptorAttrs, nullptr, nullptr),
+	DECLARE_DYNAMIC_CLUSTER(Clusters::BridgedDeviceBasicInformation::Id, bridgedDeviceBasicAttrs, nullptr, nullptr),
+	DECLARE_DYNAMIC_CLUSTER(Clusters::Identify::Id, identifyAttrs, sIdentifyIncomingCommands,
+				nullptr) DECLARE_DYNAMIC_CLUSTER_LIST_END;
+
+DECLARE_DYNAMIC_ENDPOINT(bridgedGenericSwitchEndpoint, genericSwitchClusters);
+
+static constexpr EmberAfDeviceType kBridgedGenericSwitchDeviceTypes[] = {
+	{ static_cast<chip::DeviceTypeId>(MatterBridgedDevice::DeviceType::GenericSwitch),
+	  MatterBridgedDevice::kDefaultDynamicEndpointVersion },
+	{ static_cast<chip::DeviceTypeId>(MatterBridgedDevice::DeviceType::BridgedNode),
+	  MatterBridgedDevice::kDefaultDynamicEndpointVersion }
+};
+
+static constexpr uint8_t kSwitchDataVersionSize = ArraySize(genericSwitchClusters);
+
+GenericSwitchDevice::GenericSwitchDevice(const char *nodeLabel) : MatterBridgedDevice(nodeLabel)
+{
+	mDataVersionSize = kSwitchDataVersionSize;
+	mEp = &bridgedGenericSwitchEndpoint;
+	mDeviceTypeList = kBridgedGenericSwitchDeviceTypes;
+	mDeviceTypeListSize = ARRAY_SIZE(kBridgedGenericSwitchDeviceTypes);
+	mDataVersion = static_cast<DataVersion *>(chip::Platform::MemoryAlloc(sizeof(DataVersion) * mDataVersionSize));
+}
+
+CHIP_ERROR GenericSwitchDevice::HandleRead(ClusterId clusterId, AttributeId attributeId, uint8_t *buffer,
+				     uint16_t maxReadLength)
+{
+	switch (clusterId) {
+	case Clusters::Switch::Id:
+		return HandleReadSwitch(attributeId, buffer, maxReadLength);
+	case Clusters::Identify::Id:
+		return HandleReadIdentify(attributeId, buffer, maxReadLength);
+	default:
+		return CHIP_ERROR_INVALID_ARGUMENT;
+	}
+}
+
+CHIP_ERROR GenericSwitchDevice::HandleReadSwitch(AttributeId attributeId, uint8_t *buffer, uint16_t maxReadLength)
+{
+	switch (attributeId) {
+	case Clusters::Switch::Attributes::NumberOfPositions::Id: {
+		uint8_t numberOfPositions = GetSwitchClusterNumberOfPositions();
+		return CopyAttribute(&numberOfPositions, sizeof(numberOfPositions), buffer, maxReadLength);
+	}
+	case Clusters::Switch::Attributes::CurrentPosition::Id: {
+		return CopyAttribute(&mCurrentPosition, sizeof(mCurrentPosition), buffer, maxReadLength);
+	}
+	case Clusters::Switch::Attributes::ClusterRevision::Id: {
+		uint16_t clusterRevision = GetSwitchClusterRevision();
+		return CopyAttribute(&clusterRevision, sizeof(clusterRevision), buffer, maxReadLength);
+	}
+	case Clusters::Switch::Attributes::FeatureMap::Id: {
+		uint32_t featureMap = GetSwitchClusterFeatureMap();
+		return CopyAttribute(&featureMap, sizeof(featureMap), buffer, maxReadLength);
+	}
+	default:
+		return CHIP_ERROR_INVALID_ARGUMENT;
+	}
+}
+
+CHIP_ERROR GenericSwitchDevice::HandleAttributeChange(chip::ClusterId clusterId, chip::AttributeId attributeId, void *data,
+						size_t dataSize)
+{
+	VerifyOrReturnError(data, CHIP_ERROR_INVALID_ARGUMENT);
+
+	CHIP_ERROR err = CHIP_NO_ERROR;
+
+	switch (clusterId) {
+	case Clusters::BridgedDeviceBasicInformation::Id:
+		return HandleWriteDeviceBasicInformation(clusterId, attributeId, data, dataSize);
+	case Clusters::Identify::Id:
+		return HandleWriteIdentify(attributeId, data, dataSize);
+	case Clusters::Switch::Id: {
+		switch (attributeId) {
+		case Clusters::Switch::Attributes::CurrentPosition::Id: {
+			err = CopyAttribute(data, dataSize, &mCurrentPosition, sizeof(mCurrentPosition));
+			VerifyOrReturnError(err == CHIP_NO_ERROR, err);
+			break;
+		}
+		default:
+			return CHIP_ERROR_INVALID_ARGUMENT;
+		}
+		break;
+	}
+	default:
+		return CHIP_ERROR_INVALID_ARGUMENT;
+	}
+
+	return err;
+}

--- a/applications/matter_bridge/src/bridged_device_types/generic_switch.h
+++ b/applications/matter_bridge/src/bridged_device_types/generic_switch.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#pragma once
+
+#include "matter_bridged_device.h"
+
+class GenericSwitchDevice : public MatterBridgedDevice {
+public:
+	GenericSwitchDevice(const char *nodeLabel);
+
+	MatterBridgedDevice::DeviceType GetDeviceType() const override
+	{
+		return MatterBridgedDevice::DeviceType::GenericSwitch;
+	}
+	CHIP_ERROR HandleRead(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer,
+			      uint16_t maxReadLength) override;
+	CHIP_ERROR HandleAttributeChange(chip::ClusterId clusterId, chip::AttributeId attributeId, void *data,
+					 size_t dataSize) override;
+	CHIP_ERROR HandleWrite(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer) override
+	{
+		return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+	};
+
+private:
+	CHIP_ERROR HandleReadSwitch(chip::AttributeId attributeId, uint8_t *buffer, uint16_t maxReadLength);
+
+	static constexpr uint16_t GetSwitchClusterRevision() { return 1; }
+	/* According to the Matter 1.2 specification: Bit 1 -> MomentarySwitch in the Switch Cluster section. */
+	static constexpr uint32_t GetSwitchClusterFeatureMap() { return 2; }
+	static constexpr uint32_t GetSwitchClusterNumberOfPositions() { return 2; }
+
+	uint8_t mCurrentPosition{};
+};

--- a/applications/matter_bridge/src/simulated_providers/simulated_bridged_device_factory.cpp
+++ b/applications/matter_bridge/src/simulated_providers/simulated_bridged_device_factory.cpp
@@ -66,15 +66,6 @@ SimulatedBridgedDeviceFactory::BridgedDeviceFactory &SimulatedBridgedDeviceFacto
 	};
 
 	static BridgedDeviceFactory sBridgedDeviceFactory{
-#ifdef CONFIG_BRIDGE_HUMIDITY_SENSOR_BRIDGED_DEVICE
-		{ DeviceType::HumiditySensor,
-		  [checkLabel](const char *nodeLabel) -> MatterBridgedDevice * {
-			  if (!checkLabel(nodeLabel)) {
-				  return nullptr;
-			  }
-			  return chip::Platform::New<HumiditySensorDevice>(nodeLabel);
-		  } },
-#endif
 #ifdef CONFIG_BRIDGE_ONOFF_LIGHT_BRIDGED_DEVICE
 		{ DeviceType::OnOffLight,
 		  [checkLabel](const char *nodeLabel) -> MatterBridgedDevice * {
@@ -82,6 +73,15 @@ SimulatedBridgedDeviceFactory::BridgedDeviceFactory &SimulatedBridgedDeviceFacto
 				  return nullptr;
 			  }
 			  return chip::Platform::New<OnOffLightDevice>(nodeLabel);
+		  } },
+#endif
+#ifdef CONFIG_BRIDGE_GENERIC_SWITCH_BRIDGED_DEVICE
+		{ DeviceType::GenericSwitch,
+		  [checkLabel](const char *nodeLabel) -> MatterBridgedDevice * {
+			  if (!checkLabel(nodeLabel)) {
+				  return nullptr;
+			  }
+			  return chip::Platform::New<GenericSwitchDevice>(nodeLabel);
 		  } },
 #endif
 #ifdef CONFIG_BRIDGE_TEMPERATURE_SENSOR_BRIDGED_DEVICE
@@ -93,6 +93,15 @@ SimulatedBridgedDeviceFactory::BridgedDeviceFactory &SimulatedBridgedDeviceFacto
 			  return chip::Platform::New<TemperatureSensorDevice>(nodeLabel);
 		  } },
 #endif
+#ifdef CONFIG_BRIDGE_HUMIDITY_SENSOR_BRIDGED_DEVICE
+		{ DeviceType::HumiditySensor,
+		  [checkLabel](const char *nodeLabel) -> MatterBridgedDevice * {
+			  if (!checkLabel(nodeLabel)) {
+				  return nullptr;
+			  }
+			  return chip::Platform::New<HumiditySensorDevice>(nodeLabel);
+		  } },
+#endif
 	};
 	return sBridgedDeviceFactory;
 }
@@ -100,22 +109,28 @@ SimulatedBridgedDeviceFactory::BridgedDeviceFactory &SimulatedBridgedDeviceFacto
 SimulatedBridgedDeviceFactory::SimulatedDataProviderFactory &SimulatedBridgedDeviceFactory::GetDataProviderFactory()
 {
 	static SimulatedDataProviderFactory sDeviceDataProvider{
-#ifdef CONFIG_BRIDGE_HUMIDITY_SENSOR_BRIDGED_DEVICE
-		{ DeviceType::HumiditySensor,
-		  [](UpdateAttributeCallback clb) {
-			  return chip::Platform::New<SimulatedHumiditySensorDataProvider>(clb);
-		  } },
-#endif
 #ifdef CONFIG_BRIDGE_ONOFF_LIGHT_BRIDGED_DEVICE
 		{ DeviceType::OnOffLight,
 		  [](UpdateAttributeCallback clb) {
 			  return chip::Platform::New<SimulatedOnOffLightDataProvider>(clb);
 		  } },
 #endif
+#ifdef CONFIG_BRIDGE_GENERIC_SWITCH_BRIDGED_DEVICE
+		{ DeviceType::GenericSwitch,
+		  [](UpdateAttributeCallback clb) {
+			  return chip::Platform::New<SimulatedGenericSwitchDataProvider>(clb);
+		  } },
+#endif
 #ifdef CONFIG_BRIDGE_TEMPERATURE_SENSOR_BRIDGED_DEVICE
 		{ DeviceType::TemperatureSensor,
 		  [](UpdateAttributeCallback clb) {
 			  return chip::Platform::New<SimulatedTemperatureSensorDataProvider>(clb);
+		  } },
+#endif
+#ifdef CONFIG_BRIDGE_HUMIDITY_SENSOR_BRIDGED_DEVICE
+		{ DeviceType::HumiditySensor,
+		  [](UpdateAttributeCallback clb) {
+			  return chip::Platform::New<SimulatedHumiditySensorDataProvider>(clb);
 		  } },
 #endif
 	};

--- a/applications/matter_bridge/src/simulated_providers/simulated_bridged_device_factory.h
+++ b/applications/matter_bridge/src/simulated_providers/simulated_bridged_device_factory.h
@@ -11,19 +11,25 @@
 #include "matter_bridged_device.h"
 #include <lib/support/CHIPMem.h>
 
-#ifdef CONFIG_BRIDGE_HUMIDITY_SENSOR_BRIDGED_DEVICE
-#include "humidity_sensor.h"
-#include "simulated_humidity_sensor_data_provider.h"
+#ifdef CONFIG_BRIDGE_ONOFF_LIGHT_BRIDGED_DEVICE
+#include "onoff_light.h"
+#include "simulated_generic_switch_data_provider.h"
+#include "simulated_onoff_light_data_provider.h"
 #endif
 
 #ifdef CONFIG_BRIDGE_ONOFF_LIGHT_BRIDGED_DEVICE
-#include "onoff_light.h"
-#include "simulated_onoff_light_data_provider.h"
+#include "generic_switch.h"
+#include "simulated_generic_switch_data_provider.h"
 #endif
 
 #ifdef CONFIG_BRIDGE_TEMPERATURE_SENSOR_BRIDGED_DEVICE
 #include "simulated_temperature_sensor_data_provider.h"
 #include "temperature_sensor.h"
+#endif
+
+#ifdef CONFIG_BRIDGE_HUMIDITY_SENSOR_BRIDGED_DEVICE
+#include "humidity_sensor.h"
+#include "simulated_humidity_sensor_data_provider.h"
 #endif
 
 namespace SimulatedBridgedDeviceFactory

--- a/applications/matter_bridge/src/simulated_providers/simulated_generic_switch_data_provider.cpp
+++ b/applications/matter_bridge/src/simulated_providers/simulated_generic_switch_data_provider.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "simulated_generic_switch_data_provider.h"
+
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_DECLARE(app, CONFIG_CHIP_APP_LOG_LEVEL);
+
+using namespace ::chip;
+using namespace ::chip::app;
+
+void SimulatedGenericSwitchDataProvider::Init()
+{
+	k_timer_init(&mTimer, SimulatedGenericSwitchDataProvider::TimerTimeoutCallback, nullptr);
+	k_timer_user_data_set(&mTimer, this);
+	k_timer_start(&mTimer, K_MSEC(kSwitchChangePositionIntervalMs), K_MSEC(kSwitchChangePositionIntervalMs));
+}
+
+void SimulatedGenericSwitchDataProvider::NotifyUpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId,
+							   void *data, size_t dataSize)
+{
+	if (mUpdateAttributeCallback) {
+		mUpdateAttributeCallback(*this, Clusters::Switch::Id, Clusters::Switch::Attributes::CurrentPosition::Id,
+					 data, dataSize);
+	}
+}
+
+CHIP_ERROR SimulatedGenericSwitchDataProvider::UpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId,
+							   uint8_t *buffer)
+{
+	if (clusterId != Clusters::Switch::Id) {
+		return CHIP_ERROR_INVALID_ARGUMENT;
+	}
+
+	LOG_INF("Updating state of the SimulatedGenericSwitchDataProvider, cluster ID: %u, attribute ID: %u.",
+		clusterId, attributeId);
+
+	switch (attributeId) {
+	case Clusters::Switch::Attributes::CurrentPosition::Id: {
+		memcpy(&mCurrentSwitchPosition, buffer, sizeof(mCurrentSwitchPosition));
+		NotifyUpdateState(clusterId, attributeId, &mCurrentSwitchPosition, sizeof(mCurrentSwitchPosition));
+		return CHIP_NO_ERROR;
+	}
+	default:
+		return CHIP_ERROR_INVALID_ARGUMENT;
+	}
+
+	return CHIP_NO_ERROR;
+}
+
+void SimulatedGenericSwitchDataProvider::TimerTimeoutCallback(k_timer *timer)
+{
+	if (!timer || !timer->user_data) {
+		return;
+	}
+
+	SimulatedGenericSwitchDataProvider *provider =
+		reinterpret_cast<SimulatedGenericSwitchDataProvider *>(timer->user_data);
+
+	/* Toggle switch state to emulate user's manual interactions. */
+	provider->mCurrentSwitchPosition = !provider->mCurrentSwitchPosition;
+
+	LOG_INF("SimulatedGenericSwitchDataProvider: Updated switch position to %d", provider->mCurrentSwitchPosition);
+
+	DeviceLayer::PlatformMgr().ScheduleWork(NotifyAttributeChange, reinterpret_cast<intptr_t>(provider));
+}
+
+void SimulatedGenericSwitchDataProvider::NotifyAttributeChange(intptr_t context)
+{
+	SimulatedGenericSwitchDataProvider *provider = reinterpret_cast<SimulatedGenericSwitchDataProvider *>(context);
+
+	provider->NotifyUpdateState(Clusters::Switch::Id, Clusters::Switch::Attributes::CurrentPosition::Id,
+				    &provider->mCurrentSwitchPosition, sizeof(provider->mCurrentSwitchPosition));
+}

--- a/applications/matter_bridge/src/simulated_providers/simulated_generic_switch_data_provider.h
+++ b/applications/matter_bridge/src/simulated_providers/simulated_generic_switch_data_provider.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#pragma once
+
+#include "bridged_device_data_provider.h"
+
+class SimulatedGenericSwitchDataProvider : public BridgedDeviceDataProvider {
+public:
+	SimulatedGenericSwitchDataProvider(UpdateAttributeCallback callback) : BridgedDeviceDataProvider(callback) {}
+	~SimulatedGenericSwitchDataProvider() { k_timer_stop(&mTimer); }
+
+	void Init() override;
+	void NotifyUpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId, void *data,
+			       size_t dataSize) override;
+	CHIP_ERROR UpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer) override;
+
+private:
+	static void NotifyAttributeChange(intptr_t context);
+
+	static void TimerTimeoutCallback(k_timer *timer);
+	static constexpr uint16_t kSwitchChangePositionIntervalMs = 30000;
+	k_timer mTimer;
+
+	bool mCurrentSwitchPosition = false;
+};

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -219,6 +219,7 @@ Matter Bridge
 
   * Support for groupcast communication to the On/Off Light device implementation.
   * Support for controlling the OnOff Light simulated data provider by using shell commands.
+  * Support for Matter Generic Switch bridged device type.
 
 Samples
 =======

--- a/samples/matter/common/src/bridge/matter_bridged_device.h
+++ b/samples/matter/common/src/bridge/matter_bridged_device.h
@@ -74,7 +74,8 @@ public:
 		BridgedNode = 0x0013,
 		OnOffLight = 0x0100,
 		TemperatureSensor = 0x0302,
-		HumiditySensor = 0x0307
+		HumiditySensor = 0x0307,
+		GenericSwitch = 0x000F
 	};
 	using IdentifyType = chip::app::Clusters::Identify::IdentifyTypeEnum;
 	static constexpr uint8_t kDefaultDynamicEndpointVersion = 1;


### PR DESCRIPTION
* implemented new Matter device type: Generic Switch that is based on the Switch cluster
* combined the Generic Switch with the LBS BT device implementation
* updated documentation
* updated changelog