### PR TITLE
bluetooth: scan: Fix scan filter for appearance

### DIFF
--- a/subsys/bluetooth/scan.c
+++ b/subsys/bluetooth/scan.c
@@ -931,7 +931,7 @@ static bool find_appearance(const uint8_t *data,
 		return false;
 	}
 
-	uint16_t decoded_appearance = sys_get_be16(data);
+	uint16_t decoded_appearance = sys_get_le16(data);
 
 	if (decoded_appearance == *appearance) {
 		return true;


### PR DESCRIPTION
Fix scan filter for appearance, using the wrong byte-order to compare the appearance value.

NCSIDB-1145