### PR TITLE
doc: debugging: Document how to use Monitor-mode debugging

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -698,6 +698,8 @@
 
 .. _`SEGGER SystemView`: https://www.segger.com/products/development-tools/systemview/
 
+.. _`Monitor-mode Debugging`: https://www.segger.com/products/debug-probes/j-link/technology/monitor-mode-debugging/
+
 .. ### Source: bluetooth.org and bluetooth.com
 
 .. _`Bluetooth Core Specification`: https://www.bluetooth.com/specifications/specs/

--- a/doc/nrf/test_and_optimize/testing.rst
+++ b/doc/nrf/test_and_optimize/testing.rst
@@ -147,6 +147,26 @@ To build Trusted Firmware-M with debug symbols, set the :kconfig:option:`CONFIG_
 
 nRF Debug in the |nRFVSC| automatically loads the Trusted Firmware-M debug symbols.
 
+Enabling non-halting debugging with Cortex-M Debug Monitor
+==========================================================
+
+The debugging process can run in two modes.
+The halt-mode debugging stops the CPU when a debug request occurs.
+The monitor-mode debugging lets a CPU debug parts of an application while crucial functions continue.
+Unlike halt-mode, the monitor-mode is useful for scenarios like PWM motor control or Bluetooth, where halting the entire application is risky.
+The CPU takes debug interrupts, running a monitor code for J-Link communication and user-defined functions.
+
+Use the following steps to enable monitor-mode debugging in the |NCS|:
+
+1. In the application configuration file, set the Kconfig options :kconfig:option:`CONFIG_CORTEX_M_DEBUG_MONITOR_HOOK` and :kconfig:option:`CONFIG_SEGGER_DEBUGMON`.
+2. Attach the debugger to the application.
+3. Depending on debugger you are using, enable monitor-mode debugging:
+
+  * For nRF Debug in |nRFVSC|, enter ``-exec monitor exec SetMonModeDebug=1`` in the debug console.
+  * For debugging using Ozone, enter ``Exec.Command("SetMonModeDebug = 1");`` in the console.
+
+For more information about monitor-mode debugging, see Zephyr's :ref:`zephyr:debugmon` documentation and SEGGER's `Monitor-mode Debugging <Monitor-mode Debugging_>`_ documentation.
+
 Debug configuration
 ===================
 


### PR DESCRIPTION
Monitor-mode debugging greatly enhances the debugging experience of Bluetooth applications and other applications where timing-critical code needs to continue execution when paused on a break-point.

This commit adds a section about this topic under the section `Testing and debugging an application`. This section should make it more visible to users how Monitor-mode debugging can be used in the context of the nRF Connect SDK with the tools provided by us.

References to documentation provided by the Zephyr project and SEGGER are added for users that want to get a deeper insight on how this works and how it can be used.