### PR TITLE
samples: psa_tls: Fix resource leak error

### DIFF
--- a/samples/crypto/psa_tls/src/psa_dtls_functions_client.c
+++ b/samples/crypto/psa_tls/src/psa_dtls_functions_client.c
@@ -147,11 +147,10 @@ void process_psa_tls(void)
 			ret = psa_tls_send_buffer(sock, recv_buffer, received);
 			if (ret != 0) {
 				LOG_ERR("DTLS Failed to send. Err: %d", errno);
-				break;
+			} else {
+				LOG_INF("DTLS replied with %d bytes", received);
+				LOG_INF("Closing DTLS connection");
 			}
-
-			LOG_INF("DTLS replied with %d bytes", received);
-			LOG_INF("Closing DTLS connection");
 		}
 
 		(void)close(sock);


### PR DESCRIPTION
In case psa_tls_send_buffer fails break ended the while loop without closing the socket, which is a potential resource leak and causes a coverity warning.
Also this way didn't allow any reconnect try, therefore changed the code to not stoop the processing loop and just make the logging output conditional