### PR TITLE
doc: fix minor error in Thingy:91 documentation

### DIFF
--- a/doc/nrf/device_guides/working_with_nrf/nrf91/nrf9160_gs.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf91/nrf9160_gs.rst
@@ -157,7 +157,7 @@ Make sure you are logged in to the `nRF Cloud`_ portal and have an activated SIM
 
       nRF Cloud - Add LTE Device
 
-   * **Device ID:** The device ID is composed of *nrf-* and the 15-digit :term:`International Mobile (Station) Equipment Identity (IMEI)` number that is printed on the label of your nRF9160 DK.
+   * **Device ID:** The device ID is composed of *nrf-* and the 15-digit :term:`International Mobile (Station) Equipment Identity (IMEI)` number that is printed on the label of your |DK|.
      For example, *nrf-123456789012345*.
      It is case sensitive, so make sure all the letters are lower-case.
    * **PIN/HWID:** The ownership code is the PIN or the hardware ID of your device, and it is found on the label of your |DK|.

--- a/doc/nrf/device_guides/working_with_nrf/nrf91/thingy91.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf91/thingy91.rst
@@ -122,34 +122,36 @@ When developing with your Thingy:91, it is recommended to use an external debug 
    The external debug probe must support Arm Cortex-M33, such as the nRF9160 DK.
    You need a 10-pin 2x5 socket-socket 1.27 mm IDC (:term:`Serial Wire Debug (SWD)`) JTAG cable to connect to the external debug probe.
 
-Download and extract the latest application and modem firmware from the `Thingy:91 Downloads <Thingy:91 product website (downloads)_>`_ page.
+Download and extract the latest application and modem firmware from the `Thingy:91 Downloads`_ page.
 
 The downloaded ZIP archive contains the following firmware:
 
 Application firmware
   The :file:`img_app_bl` folder contains full firmware images for different applications.
-  The guides in this section use the images for the :ref:`connectivity_bridge` and :ref:`asset_tracker_v2` applications.
-  Connectivity bridge provides bridge functionality for the hardware, and Asset Tracker v2 simulates sensor data and transmits it to Nordic Semiconductor's cloud solution, `nRF Cloud`_.
-
-  The data is transmitted using either LTE-M or NB-IoT.
-  Asset Tracker v2 first attempts to use LTE-M, then NB-IoT.
-  Check with your SIM card provider for the mode they support at your location.
-  For the iBasis SIM card provided with the nRF9160 DK, see `iBasis IoT network coverage`_.
+  The guides for programming through an external debug probe in this section use the images in this folder.
 
 Application firmware for Device Firmware Update (DFU)
   The images in the :file:`img_fota_dfu_bin` and :file:`img_fota_dfu_hex` folders contain firmware images for DFU.
-  These images are not used in the guides in this section.
+  The guides for programming through USB in this section use the images in the :file:`img_fota_dfu_hex` folder.
 
 Modem firmware
   The modem firmware is in a ZIP archive instead of a folder.
   The archive is named :file:`mfw_nrf9160_` followed by the firmware version number.
   Do not unzip this file.
 
+The :file:`CONTENTS.txt` file in the extracted folder contains the location and names of the different firmware images.
+
+The instructions in this section show you how to program the :ref:`connectivity_bridge` and :ref:`asset_tracker_v2` applications, as well as the modem firmware.
+Connectivity bridge provides bridge functionality for the hardware, and Asset Tracker v2 simulates sensor data and transmits it to Nordic Semiconductor's cloud solution, `nRF Cloud`_.
+
+The data is transmitted using either LTE-M or NB-IoT.
+Asset Tracker v2 first attempts to use LTE-M, then NB-IoT.
+Check with your SIM card provider for the mode they support at your location.
+For the iBasis SIM card provided with the Thingy:91, see `iBasis IoT network coverage`_.
+
 .. tip::
    For a more compact nRF Cloud firmware application, you can build and install the :ref:`nrf_cloud_multi_service` sample.
    See the :ref:`building_pgming` section for more information.
-
-The :file:`CONTENTS.txt` file in the extracted folder contains the location and names of the different firmware images.
 
 .. note::
    To update the Thingy:91 through USB, the nRF9160 SiP and nRF52840 SoC bootloaders must be factory-compatible.

--- a/doc/nrf/device_guides/working_with_nrf/nrf91/thingy91_gsg.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf91/thingy91_gsg.rst
@@ -158,7 +158,7 @@ To update the firmware on the Thingy:91, complete the following steps:
 
 #. Click :guilabel:`Continue` to move to the next step.
 
-   The **Program Mode Firmware (Optional)** changes to the **Program Asset Tracker V2** window.
+   The **Program Mode Firmware (Optional)** window changes to the **Program Asset Tracker V2** window.
 
 #. Switch off the Thingy:91.
 #. Press **SW3** while switching **SW1** to the **ON** position to enable MCUboot mode.
@@ -178,6 +178,9 @@ To update the firmware on the Thingy:91, complete the following steps:
    a. Click :guilabel:`Start` to begin the modem trace.
       The button changes to :guilabel:`Stop` and is greyed out.
    #. Click :guilabel:`Refresh dashboard` to refresh the information.
+
+      If the information does not load, switch the Thingy:91 off and on, select the device from the :guilabel:`SELECT DEVICE` drop-down, and click :guilabel:`Start` to begin the modem trace again.
+
    #. Copy the ICCID by clicking on the **ICCID** label or the displayed ICCID number in the **Sim** section.
 
       .. figure:: images/cellularmonitor_iccid.png
@@ -238,6 +241,8 @@ Make sure you are logged in to the portal.
 
       nRF Cloud - Add SIM
 
+   The **Add SIM** page opens in the **Verify SIM Card** view.
+
 #. Complete the following steps on the **Add SIM** page to activate your iBasis SIM card:
 
    .. figure:: images/nrfcloud_activating_sim.png
@@ -258,6 +263,11 @@ Make sure you are logged in to the portal.
       Reveal the PUK by scratching off the area on the back of the SIM card.
    #. Accept the Terms and the Privacy Policy.
    #. Click the :guilabel:`Activate SIM` button.
+
+      The **Add SIM** page changes to the **Activate SIM Card** view.
+
+   #. Fill in the required information.
+   #. Click :guilabel:`Save` to complete the activation.
 
 After the SIM card is activated, you can add your |DK| to nRF Cloud.
 

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -420,6 +420,7 @@
 .. _`Nordic Thingy:52`: https://www.nordicsemi.com/Software-and-tools/Prototyping-platforms/Nordic-Thingy-52
 .. _`Nordic Thingy:91`: https://www.nordicsemi.com/Software-and-tools/Prototyping-platforms/Nordic-Thingy-91
 .. _`Thingy:91 product page`: https://www.nordicsemi.com/Products/Development-hardware/Nordic-Thingy-91
+.. _`Thingy:91 Downloads`:
 .. _`Thingy:91 product website (downloads)`: https://www.nordicsemi.com/Software-and-tools/Prototyping-platforms/Nordic-Thingy-91/Download#infotabs
 
 .. _`nRF21540 DK product page`: https://www.nordicsemi.com/Products/Low-power-short-range-wireless/nRF21540


### PR DESCRIPTION
The Getting started documentation had small errors. This fixes those errors.