### PR TITLE
bluetooth: gatt_dm: Correct the behavior of bt_gatt_dm_attr_next.

### DIFF
--- a/subsys/bluetooth/gatt_dm.c
+++ b/subsys/bluetooth/gatt_dm.c
@@ -558,7 +558,7 @@ const struct bt_gatt_dm_attr *bt_gatt_dm_attr_next(
 	const struct bt_gatt_dm_attr *prev)
 {
 	if (!prev) {
-		prev = dm->attrs;
+		return dm->attrs;
 	}
 
 	if (dm->attrs <= prev) {

--- a/tests/subsys/bluetooth/gatt_dm/src/main.c
+++ b/tests/subsys/bluetooth/gatt_dm/src/main.c
@@ -151,7 +151,7 @@ ZTEST(gatt_tests, test_gatt_DIS_simple_next_attr)
 		      bt_gatt_dm_attr_cnt(dm));
 
 	attr = NULL;
-	for (int i = 13; i <= 16; ++i) {
+	for (int i = 12; i <= 16; ++i) {
 		attr = bt_gatt_dm_attr_next(dm, attr);
 		zassert_not_null(attr, "Attr handle: %d", i);
 		zassert_equal(i, attr->handle, "Attr handle: %d", i);
@@ -194,7 +194,7 @@ ZTEST(gatt_tests, test_gatt_HIDS_simple_next_attr)
 	zassert_not_null(dm, "Device Manager pointer not set");
 
 	attr = NULL;
-	for (int i = 2; i <= 11; ++i) {
+	for (int i = 1; i <= 11; ++i) {
 		attr = bt_gatt_dm_attr_next(dm, attr);
 		zassert_not_null(attr, "Attr handle: %d", i);
 		zassert_equal(i, attr->handle, "Attr handle: %d", i);


### PR DESCRIPTION
Corrected the behavior of skipping the first attribute.
Also corrected the test which also skipped first attribute.

Jira: NCSDK-23749