### PR TITLE
manifest: sdk-zephyr: Fix Print of SSID in WIFI status

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 92a5b80480bd6b1be9dabb5684162cef3067a85d
+      revision: 2364b332d085341d78e9618125256ae3a5cc71b0
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
While printing SSID in wifi status command,
If the length is maximum(32 character).
It leads to buffer overflow. Changing the Format
Specifiers to print proper SSID.