### PR TITLE
lib: location: Skip GNSS if not in RRC idle

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -521,6 +521,7 @@ Modem libraries
       Previously, 1-2 searches were performed and now 1-3 will be done depending on the requested number of cells and the number of found cells.
       Also, only GCI cells are counted towards the requested number of cells, and normal neighbors are ignored from this perspective.
     * Cellular positioning not to use GCI search when the device is in RRC connected mode, because the modem cannot search for GCI cells in that mode.
+    * GNSS is not started at all if the device does not enter RRC idle mode within two minutes.
 
 * :ref:`lte_lc_readme` library:
 


### PR DESCRIPTION
If timeout for waiting for RRC idle mode expires and we are still in RRC connected mode, let's not try to get GNSS fix. It will only spend time and power without getting a fix. We also spend the location request timer and fallbacks are not even tried.

In addition, lowering the waiting time for getting to RRC idle mode and PSM from 5mins to 2mins.