### PR TITLE
applications: Fixed DFU over SMP for Matter bridge

### DIFF
--- a/applications/matter_bridge/src/chip_project_config.h
+++ b/applications/matter_bridge/src/chip_project_config.h
@@ -16,8 +16,3 @@
 #pragma once
 
 #define CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT CONFIG_BRIDGE_MAX_DYNAMIC_ENDPOINTS_NUMBER
-
-/* Disable handling only single connection to avoid stopping Matter service BLE advertising
- * while other BLE bridge-related connections are open.
- */
-#define CHIP_DEVICE_CONFIG_CHIPOBLE_SINGLE_CONNECTION 0

--- a/west.yml
+++ b/west.yml
@@ -149,7 +149,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 3c7f9a68c05916c799429bf726fdf6e0c9439a06
+      revision: 3b8ba59f1f43d84754de4facfac23f46f8d7cc71
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
The DFU over BT SMP was sometimes failing becase advertising restart was not properly handled in the Matter BLEManager, due to the CHIP_DEVICE_CONFIG_CHIPOBLE_SINGLE_CONNECTION flag. Additionally it was required to pull changes in Matter code that removes collissions in handling peripheral and central related BT callbacks.