### PR TITLE
cmake: define edge_impulse as a static imported library

### DIFF
--- a/lib/edge_impulse/CMakeLists.txt
+++ b/lib/edge_impulse/CMakeLists.txt
@@ -68,6 +68,9 @@ ExternalProject_Add(edge_impulse_project
     USES_TERMINAL_BUILD True
 )
 add_dependencies(edge_impulse_project zephyr_generated_headers)
+add_library(edge_impulse_imported STATIC IMPORTED)
+set_target_properties(edge_impulse_imported PROPERTIES IMPORTED_LOCATION ${EDGE_IMPULSE_LIBRARY})
+target_link_libraries(edge_impulse_imported INTERFACE kernel)
 
 # This targets remove the `edge_impulse_project-download` stamp file, which
 # causes the Edge impulse library to be fetched on each build invocation.
@@ -106,7 +109,7 @@ target_include_directories(edge_impulse INTERFACE
                            ${EDGE_IMPULSE_SOURCE_DIR}/edge-impulse-sdk/CMSIS/Core/Include
 )
 
-target_link_libraries(edge_impulse INTERFACE ${EDGE_IMPULSE_LIBRARY})
+target_link_libraries(edge_impulse INTERFACE edge_impulse_imported)
 
 add_dependencies(edge_impulse
                  zephyr_interface

--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -3,6 +3,6 @@
 # https://docs.zephyrproject.org/latest/guides/test/twister.html#quarantine
 # To have an empty list use:
 - scenarios:
-    - edge_impulse.ei_wrapper
+    - None
   platforms:
-    - qemu_cortex_m3
+    - all


### PR DESCRIPTION
The edge impulse library is created using ExternalProject_Add.
This means the library is not a regular CMake library but an imported
library.

In general CMake is happy to link directly to a library using its path,
however in the edge_impulse library case, the edge_impulse itself
needs to link against the Zephyr kernel library as it calls kernel
functions. Therefore a link dependency to Zephyr kernel lib must be
created and to do so, edge impulse must be a known library target.
A static imported Edge impulse pointing to the external project
generated library file is created so that a CMake library target exists.

Jira: NCSDK-24520
