### PR TITLE
net: lib: nrf_cloud: fix FOTA settings handling

### DIFF
--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_fota.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_fota.h
@@ -213,9 +213,10 @@ int nrf_cloud_fota_ble_job_update(
 	const struct nrf_cloud_fota_ble_job * const ble_job,
 	const enum nrf_cloud_fota_status status);
 
-/** @brief Initialize FOTA settings handling.
+/** @brief Initialize FOTA settings handling. Saved FOTA job data will
+ * be loaded into the provided structure.
  *
- *  @param job Pointer to FOTA job settings structure. The pointer must remain valid.
+ *  @param job Pointer to FOTA job settings structure.
  *
  *  @retval 0 If successful.
  *           Otherwise, a (negative) error code is returned.
@@ -224,7 +225,7 @@ int nrf_cloud_fota_settings_load(struct nrf_cloud_settings_fota_job *job);
 
 /** @brief Save FOTA job info.
  *
- *  @param job Pointer to FOTA job settings structure. The pointer must remain valid.
+ *  @param job Pointer to FOTA job settings structure.
  *
  *  @retval 0 If successful.
  *           Otherwise, a (negative) error code is returned.

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota.c
@@ -198,11 +198,6 @@ int nrf_cloud_fota_init(nrf_cloud_fota_callback_t cb)
 		return 0;
 	}
 
-	ret = nrf_cloud_fota_settings_load(&saved_job);
-	if (ret != 0) {
-		return ret;
-	}
-
 	/* Ensure the codec is initialized */
 	(void)nrf_cloud_codec_init(NULL);
 
@@ -215,6 +210,7 @@ int nrf_cloud_fota_init(nrf_cloud_fota_callback_t cb)
 		fota_dl_initialized = true;
 	}
 
+	/* Load FOTA settings and validate any pending job */
 	ret = nrf_cloud_fota_pending_job_validate(NULL);
 
 	/* This function returns 0 on success.


### PR DESCRIPTION
When the base nRF Cloud MQTT settings are loaded, the FOTA settings are also loaded. Previously, the pointer was not yet set, resulting in an assertion.
Updated to ignore if the pointer was not set.
Removed duplicate settings loading in nrf_cloud_fota. Updated nrf_cloud_fota_settings_load to always load the settings instead of just once.
IRIS-7756