### PR TITLE
applications: Matter Bridge: Fixed a crash when subscribing to LBS

### DIFF
--- a/applications/matter_bridge/src/ble_providers/ble_environmental_data_provider.cpp
+++ b/applications/matter_bridge/src/ble_providers/ble_environmental_data_provider.cpp
@@ -155,12 +155,16 @@ void BleEnvironmentalDataProvider::Subscribe()
 	mGattTemperatureSubscribeParams.value_handle = mTemperatureCharacteristicHandle;
 	mGattTemperatureSubscribeParams.value = BT_GATT_CCC_NOTIFY;
 	mGattTemperatureSubscribeParams.notify = BleEnvironmentalDataProvider::GattTemperatureNotifyCallback;
+	mGattTemperatureSubscribeParams.subscribe = nullptr;
+	mGattTemperatureSubscribeParams.write = nullptr;
 
 	/* Configure subscription for the humidity characteristic */
 	mGattHumiditySubscribeParams.ccc_handle = mCccHumidityHandle;
 	mGattHumiditySubscribeParams.value_handle = mHumidityCharacteristicHandle;
 	mGattHumiditySubscribeParams.value = BT_GATT_CCC_NOTIFY;
 	mGattHumiditySubscribeParams.notify = BleEnvironmentalDataProvider::GattHumidityNotifyCallback;
+	mGattHumiditySubscribeParams.subscribe = nullptr;
+	mGattHumiditySubscribeParams.write = nullptr;
 
 	if (CheckSubscriptionParameters(&mGattTemperatureSubscribeParams)) {
 		int err = bt_gatt_subscribe(mDevice.mConn, &mGattTemperatureSubscribeParams);

--- a/applications/matter_bridge/src/ble_providers/ble_lbs_data_provider.cpp
+++ b/applications/matter_bridge/src/ble_providers/ble_lbs_data_provider.cpp
@@ -139,6 +139,8 @@ void BleLBSDataProvider::Subscribe()
 	mGattSubscribeParams.value_handle = mButtonCharacteristicHandle;
 	mGattSubscribeParams.value = BT_GATT_CCC_NOTIFY;
 	mGattSubscribeParams.notify = BleLBSDataProvider::GattNotifyCallback;
+	mGattSubscribeParams.subscribe = nullptr;
+	mGattSubscribeParams.write = nullptr;
 
 	if (CheckSubscriptionParameters(&mGattSubscribeParams)) {
 		int err = bt_gatt_subscribe(mDevice.mConn, &mGattSubscribeParams);

--- a/applications/matter_bridge/src/ble_providers/ble_lbs_data_provider.h
+++ b/applications/matter_bridge/src/ble_providers/ble_lbs_data_provider.h
@@ -38,10 +38,10 @@ private:
 	bool mOnOff = false;
 	uint8_t mCurrentSwitchPosition = false;
 	uint16_t mLedCharacteristicHandle;
-	bt_gatt_write_params mGattWriteParams;
+	bt_gatt_write_params mGattWriteParams{};
 	uint16_t mButtonCharacteristicHandle;
 	uint16_t mCccHandle;
-	bt_gatt_subscribe_params mGattSubscribeParams;
+	bt_gatt_subscribe_params mGattSubscribeParams{};
 
 	uint8_t mGattWriteDataBuffer[sizeof(mOnOff)];
 };

--- a/samples/matter/common/src/bridge/ble_connectivity_manager.cpp
+++ b/samples/matter/common/src/bridge/ble_connectivity_manager.cpp
@@ -158,9 +158,6 @@ void BLEConnectivityManager::DiscoveryCompletedHandler(bt_gatt_dm *dm, void *con
 	discoveryResult = true;
 exit:
 	if (provider) {
-		VerifyOrReturn(provider->ParseDiscoveredData(dm) == 0,
-			       LOG_ERR("Cannot parse the GATT discovered data."));
-
 		if (!provider->IsInitiallyConnected()) {
 			/* Provider is not initalized it so we need to call the first connection callback */
 			provider->GetBLEBridgedDevice().mFirstConnectionCallback(
@@ -170,6 +167,9 @@ exit:
 
 		VerifyOrReturn(CHIP_NO_ERROR == provider->NotifyReachableStatusChange(true),
 			       LOG_WRN("The device has not been notified about the status change."));
+
+		VerifyOrReturn(provider->ParseDiscoveredData(dm) == 0,
+			       LOG_ERR("Cannot parse the GATT discovered data."));
 	}
 
 	bt_gatt_dm_data_release(dm);


### PR DESCRIPTION
* The crash was caused by the uninitialized bt_gatt_subscribe_params structure that implied function calls from random memory location in GATT implementation internals.
* The crash was not a case for ESP, because there we had a default initialization of class members added.
* Added proper initializaton of GATT related structures to the LSB data provider to avoid mentioned crash.
* Moved ParseDiscoveredData call after the connection callback is executed, as it makes more sense to accept and forward BLE notifications only when we have the connection handled and Matter device counterpart ready.