### PR TITLE
scripts: memory-threshold-list: Add codeowners to the monitored test configurations

### DIFF
--- a/scripts/memory-threshold-list.yaml
+++ b/scripts/memory-threshold-list.yaml
@@ -5,6 +5,9 @@
     - nrf52840dk_nrf52840
   ram_size: 241664
   rom_size: 778240
+  codeowners:
+    - kkasperczyk-no
+    - ArekBalysNordic
 
 - scenarios:
     - sample.matter.lock.debug
@@ -13,6 +16,9 @@
     - nrf52840dk_nrf52840
   ram_size: 241664
   rom_size: 931840
+  codeowners:
+    - kkasperczyk-no
+    - ArekBalysNordic
 
 - scenarios:
     - sample.matter.lock.release
@@ -20,6 +26,9 @@
     - nrf7002dk_nrf5340_cpuapp
   ram_size: 503808
   rom_size: 778240
+  codeowners:
+    - kkasperczyk-no
+    - ArekBalysNordic
 
 - scenarios:
     - sample.matter.lock.debug
@@ -27,6 +36,9 @@
     - nrf7002dk_nrf5340_cpuapp
   ram_size: 503808
   rom_size: 942080
+  codeowners:
+    - kkasperczyk-no
+    - ArekBalysNordic
 
 - scenarios:
     - applications.nrf_desktop.z.*
@@ -34,3 +46,5 @@
     - all
   rom_related_usage: 512
   ram_related_usage: 256
+  codeowners:
+    - MarekPieta


### PR DESCRIPTION
Some changes cause memory bloat indirectly.
Author of commit  may be unaware of this,
and code owners may find out too late about the impact
of proposed changes on memory usage in their areas.

This commit adds information of who is maintaining
a given area. Listed gh accounts will be pinged 
in the automated warning messages.

Jira: NCSDK-21206