### PR TITLE
doc: wifi: add link to Wi-Fi DevAcademy course

### DIFF
--- a/doc/nrf/device_guides/working_with_nrf/nrf70/gs.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf70/gs.rst
@@ -9,13 +9,15 @@ Getting started with nRF70 Series
 
 This page gets you started with your nRF70 Series devices using the |NCS|.
 
+If you want to go through an online training course to familiarize yourself with Wi-Fi® and the development of Wi-Fi applications, enroll in the `Wi-Fi Fundamentals course`_ in the `Nordic Developer Academy`_.
+
 Supported development boards
 ****************************
 
 nRF7002 DK
 ==========
 
-The nRF7002 DK (PCA10143) is a single-board development kit for evaluation and development on the nRF7002, a Wi-Fi® companion :term:`Integrated Circuit (IC)` to Nordic Semiconductor's nRF5340 System-on-Chip (SoC) host processor.
+The nRF7002 DK (PCA10143) is a single-board development kit for evaluation and development on the nRF7002, a Wi-Fi companion :term:`Integrated Circuit (IC)` to Nordic Semiconductor's nRF5340 System-on-Chip (SoC) host processor.
 
 Overview
 --------

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -660,6 +660,7 @@
 .. _`nRF Connect SDK Fundamentals course`: https://academy.nordicsemi.com/courses/nrf-connect-sdk-fundamentals/
 .. _`Cellular IoT Fundamentals course`: https://academy.nordicsemi.com/courses/cellular-iot-fundamentals/
 .. _`Bluetooth LE Fundamentals course`: https://academy.nordicsemi.com/courses/bluetooth-low-energy-fundamentals/
+.. _`Wi-Fi Fundamentals course`: https://academy.nordicsemi.com/courses/wi-fi-fundamentals/
 
 .. ### Source: devzone.nordicsemi.com
 

--- a/doc/nrf/protocols/wifi/index.rst
+++ b/doc/nrf/protocols/wifi/index.rst
@@ -9,6 +9,7 @@ The Wi-Fi Alliance is responsible for the Wi-Fi CERTIFIED accreditation program,
 
 Wi-Fi is an evolving standard, with new IEEE 802.11 standards being incorporated every 4-6 years, along with the corresponding Wi-Fi Alliance certification program.
 The branding *Wi-Fi 6* is defined by the Wi-Fi Alliance, and aligns with the IEEE 802.11ax specification, but includes all previous versions of the IEEE 802.11 specifications dating back to the introduction of Wi-Fi in 1997.
+
 The evolution from the base standard started with the introduction of IEEE 802.11b and IEEE 802.11a in 1999, IEEE 802.11g in 2003, IEEE 802.11n in 2008 (and subsequently branded Wi-Fi 4), IEEE 802.11ac in 2014 (subsequently branded Wi-Fi 5), and finally IEEE 802.11ax in 2019, branded Wi-Fi 6.
 These standards operate in the unlicensed spectrum of the 2.4 GHz and 5 GHz bands.
 However, 11b and 11g are only applicable in the 2.4 GHz band, while 11a and 11ac are only applicable in the 5 GHz band.
@@ -21,6 +22,8 @@ For nRF70 series documentation, see the following:
 * :ref:`wifi_samples` for the available samples.
 * `Product specification for nRF70 Series devices`_ for the supported features.
 * `Guidelines and application notes for nRF70 Series devices`_.
+
+If you want to go through an online training course to familiarize yourself with Wi-Fi and the development of Wi-Fi applications, enroll in the `Wi-Fi Fundamentals course`_ in the `Nordic Developer Academy`_.
 
 .. toctree::
    :maxdepth: 1

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -675,6 +675,7 @@ Documentation
   * Integration steps in the :ref:`ug_bt_fast_pair` guide.
     Reorganized extension-specific content into dedicated subsections.
   * The :ref:`ug_nrf70_developing_powersave_power_save_mode` section in the :ref:`ug_nrf70_developing_powersave` user guide.
+  * The :ref:`nrf7002dk_nrf5340` page with a link to the `Wi-Fi Fundamentals course`_ in the `Nordic Developer Academy`_.
 
 * Removed the Welcome to the |NCS| page.
   This page is replaced with existing :ref:`ncs_introduction` page.


### PR DESCRIPTION
Added a link to the Wi-Fi course on the Getting started and Protocols pages.