### PR TITLE
nrf_security: Change select of entropy generator to depends instead

### DIFF
--- a/subsys/nrf_security/Kconfig
+++ b/subsys/nrf_security/Kconfig
@@ -99,7 +99,14 @@ config MBEDTLS_ENTROPY_POLL
 	default y
 	depends on !NRF_CC3XX_PLATFORM
 	depends on !BUILD_WITH_TFM
-	select ENTROPY_GENERATOR
+	depends on ENTROPY_GENERATOR
+	help
+	  Add entropy_poll only if NRF_CC3XX_PLATFORM is not added.
+	  This is because the nrf_cc3xx_platform library contains an
+	  implementation of mbedtls_hardware_poll function.
+	  This file is not useful for TF-M build where entropy should come
+	  from SPE image, using psa_generate_random
+
 
 # Include TLS/DTLS and x509 configurations
 rsource "Kconfig.tls"

--- a/subsys/nrf_security/src/zephyr/CMakeLists.txt
+++ b/subsys/nrf_security/src/zephyr/CMakeLists.txt
@@ -26,9 +26,6 @@ if(CONFIG_MBEDTLS_ENABLE_HEAP)
   )
 endif()
 
-# Add entropy_poll only if NRF_CC3XX_PLATFORM is not added
-# This file is not useful for TF-M build where entropy should come
-# from SPE image, using psa_generate_random
 if(CONFIG_MBEDTLS_ENTROPY_POLL)
   list(APPEND src_zephyr
     ${NRF_SECURITY_ROOT}/src/zephyr/entropy_poll.c


### PR DESCRIPTION
Change select of entropy generator to depends on instead. This is to allow the PSA entropy generator to select nrf-security to provide PSA. To avoid any loops all nrf-security dependencies to entropy-generator needs to be depends instead.