### PR TITLE
tfm: Fix TF-M initial attestation missing dependency on RNG

### DIFF
--- a/modules/trusted-firmware-m/Kconfig.tfm.defconfig
+++ b/modules/trusted-firmware-m/Kconfig.tfm.defconfig
@@ -51,12 +51,14 @@ config TFM_PARTITION_INITIAL_ATTESTATION
 	# The initial attestation partition requires ECDSA algorithm with
 	# SHA-256 and uses the Identity Key stored in the KMU.
 	# The identity key is a secp256r1 key pair.
+	# The ECDSA algorithm and the cc3xx boot seed requires RNG.
 	default y if !TFM_PROFILE_TYPE_MINIMAL
 	depends on TFM_NRF_PROVISIONING
 	select PSA_WANT_ALG_SHA_256
 	select PSA_WANT_KEY_TYPE_ECC_KEY_PAIR
 	select PSA_WANT_ALG_ECDSA
 	select PSA_WANT_ECC_SECP_R1_256
+	select PSA_WANT_GENERATE_RANDOM
 	select SECURE_BOOT_STORAGE
 
 config TFM_PARTITION_PROTECTED_STORAGE


### PR DESCRIPTION
Fix TF-M initial attestation missing dependency on RNG. RNG is required during the ECDSA signing.
RNG is required by the tfm_plat_get_boot_seed function.