### PR TITLE
manifest: Pull Matter fix for unwanted WiFi connection request

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -149,7 +149,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: v2.5.1-rc1
+      revision: 899d21091760d422cc9e0afaa466dd64add8d272
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
This patch pulls the Matter fix for unexpected WiFi connection request that may happen when the SSID of interest is not available at first attempt during commissioning (which results in commissioning failure).