### PR TITLE
manifest: Update zephyr to fix flash samples and tests with TF-M

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: b3979ec709df026fc655286f1a58be30b0f688e0
+      revision: pull/1415/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update zephyr to fix flash samples and tests with TF-M. These need to use a valid flash partition configured as non-secure.