### PR TITLE
applications: serial_lte_modem: allow slm_util_at_cmd to receive AT response contents

### DIFF
--- a/applications/serial_lte_modem/src/slm_util.h
+++ b/applications/serial_lte_modem/src/slm_util.h
@@ -31,12 +31,14 @@ int slm_util_at_printf(const char *fmt, ...);
  */
 int slm_util_at_scanf(const char *cmd, const char *fmt, ...);
 
-/** Forwards an intercepted AT command to the modem library.
- *  @warning This must and can only be called from interception callbacks.
- *  @note As of now this only returns the AT response code from the modem.
- *  @return The AT response code as an integer and its string representation in @c buf.
+/** Forwards an AT command to the modem while bypassing interception.
+ *  @warning This must only be called from code that needs to bypass
+ *  AT command interception, such as from interception callbacks themselves.
+ *  @note This is only capable of handling AT responses that are
+ *  at most two lines long (including the line that holds the result code).
+ *  @return Like @c nrf_modem_at_cmd().
  */
-int slm_util_at_cmd_fwd_from_cb(char *buf, size_t len, char *at_cmd);
+int slm_util_at_cmd_no_intercept(char *buf, size_t len, const char *at_cmd);
 
 /**
  * @brief Compare string ignoring case


### PR DESCRIPTION
Using nrf_modem_at_scanf() instead of nrf_modem_at_printf() allows to parse some of the AT response contents.
With some gymnastics we are effectively able to receive AT responses of up to two lines, which covers most use cases.

This need was discovered when realizing that interception of AT write commands also intercepts the corresponding test commands. Test commands have one response line of usage explanation, which must be forwarded properly to the caller.