### PR TITLE
manifest: zephyr: Update sdk-zephyr with modified filter for spi_flash

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v3.4.99-ncs1-1-rc1
+      revision: 83980fe1679441be9b0e1db556a353f6118fe14f
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pulls changed filter in spi_flash sample that allows to run Nordics' SoCs in the Twister. Before that they were filtered out for the sample.