### PR TITLE
applications: serial_lte_modem: Allow building on older DK

### DIFF
--- a/applications/serial_lte_modem/boards/nrf9160dk_nrf9160_ns.overlay
+++ b/applications/serial_lte_modem/boards/nrf9160dk_nrf9160_ns.overlay
@@ -53,10 +53,3 @@
 		};
 	};
 };
-
-/* Enable external flash */
-&spi3 {
-	mx25r64: mx25r6435f@1 {
-		status = "okay";
-	};
-};

--- a/applications/serial_lte_modem/boards/nrf9160dk_nrf9160_ns_0_14_0.overlay
+++ b/applications/serial_lte_modem/boards/nrf9160dk_nrf9160_ns_0_14_0.overlay
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Enable external flash */
+&arduino_spi {
+	mx25r64: mx25r6435f@1 {
+		status = "okay";
+	};
+};

--- a/applications/serial_lte_modem/doc/FOTA_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/FOTA_AT_commands.rst
@@ -35,7 +35,8 @@ Syntax
   * ``3`` - Start FOTA for full modem update.
     Can only be used when the :file:`overlay-full_fota.conf` configuration file is used.
 
-    Not supported on the :ref:`Thingy:91 <thingy91_ug_intro>` as it lacks an external flash to store the firmware image.
+    Not supported on the :ref:`Thingy:91 <thingy91_ug_intro>` or nRF9160 DK board revisions older than 0.14.0 as they lack an external flash to store the firmware image.
+    See :ref:`nrf9160_board_revisions` for more details.
 
   * ``7`` - Read modem DFU area size and firmware image offset (for modem delta update).
   * ``9`` - Erase modem DFU area (for modem delta update).

--- a/applications/serial_lte_modem/overlay-full_fota.conf
+++ b/applications/serial_lte_modem/overlay-full_fota.conf
@@ -4,6 +4,9 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+# This overlay requires a board with an external flash.
+# For nRF9160 DKs, only revisions 0.14.0 and later have one.
+
 # Enable external flash for full FOTA
 CONFIG_SPI_NOR=y
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -203,6 +203,8 @@ Serial LTE modem
       Set to ``TLS_PEER_VERIFY_REQUIRED`` by default.
     * Set the ``TLS_HOSTNAME`` socket option to ``NULL`` to disable the hostname verification.
 
+  * Allow building the application for nRF9160 DK board revision older than 0.14.0.
+
 * Removed Kconfig options ``CONFIG_SLM_CUSTOMIZED`` and ``CONFIG_SLM_SOCKET_RX_MAX``.
 
 nRF5340 Audio


### PR DESCRIPTION
nRF9160 DK board revision 0.14 added external flash that is required for Full Modem FOTA.

Separate overlays for board revisions so we can build for older DK without using the flash.