### PR TITLE
samples: cellular: modem_shell: Few small misc items

### DIFF
--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -1783,7 +1783,7 @@ int lte_lc_periodic_search_set(const struct lte_lc_periodic_search_cfg *const cf
  *
  * @retval 0 if a configuration was found and populated to the provided pointer.
  * @retval -EINVAL if input parameter was @c NULL.
- * @retval -ENOENT if no periodic search was not configured.
+ * @retval -ENOENT if periodic search configuration was not set.
  * @retval -EFAULT if an AT command failed.
  * @retval -EBADMSG if the modem responded with an error to an AT command or the
  *         response could not be parsed.

--- a/samples/cellular/modem_shell/src/link/link_shell.c
+++ b/samples/cellular/modem_shell/src/link/link_shell.c
@@ -2169,7 +2169,10 @@ static int link_shell_search(const struct shell *shell, size_t argc, char **argv
 	if (operation == LINK_OPERATION_READ) {
 
 		ret = lte_lc_periodic_search_get(&search_cfg);
-		if (ret) {
+		if (ret == -ENOENT) {
+			mosh_error("Reading search configuration failed: no configuration set");
+			return ret;
+		} else if (ret) {
 			mosh_error("Reading search configuration failed: %d", ret);
 			return ret;
 		}

--- a/samples/cellular/modem_shell/src/sock/sock_shell.c
+++ b/samples/cellular/modem_shell/src/sock/sock_shell.c
@@ -638,6 +638,7 @@ static int cmd_sock_rai(const struct shell *shell, size_t argc, char **argv)
 	bool arg_rai_one_resp = false;
 	bool arg_rai_ongoing = false;
 	bool arg_rai_wait_more = false;
+	int rai_option_count = 0;
 
 	optreset = 1;
 	optind = 1;
@@ -652,18 +653,23 @@ static int cmd_sock_rai(const struct shell *shell, size_t argc, char **argv)
 
 		case SOCK_SHELL_OPT_RAI_LAST:
 			arg_rai_last = true;
+			rai_option_count++;
 			break;
 		case SOCK_SHELL_OPT_RAI_NO_DATA:
 			arg_rai_no_data = true;
+			rai_option_count++;
 			break;
 		case SOCK_SHELL_OPT_RAI_ONE_RESP:
 			arg_rai_one_resp = true;
+			rai_option_count++;
 			break;
 		case SOCK_SHELL_OPT_RAI_ONGOING:
 			arg_rai_ongoing = true;
+			rai_option_count++;
 			break;
 		case SOCK_SHELL_OPT_RAI_WAIT_MORE:
 			arg_rai_wait_more = true;
+			rai_option_count++;
 			break;
 
 		case 'h':
@@ -691,6 +697,12 @@ static int cmd_sock_rai(const struct shell *shell, size_t argc, char **argv)
 		mosh_warn(
 			"RAI is requested but RAI is disabled.\n"
 			"Use 'link rai' command to enable it for socket usage.");
+	}
+
+	if (rai_option_count > 1) {
+		mosh_warn(
+			"%d RAI options set while normally just one should be used at a time. "
+			"Hope you know what you are doing.", rai_option_count);
 	}
 
 	err = sock_rai(


### PR DESCRIPTION
- sock: Warn about the use of many RAI options
- link: a Better error text made when reading search configuration failed due to missing search configuration
