### PR TITLE
doc: config_and_build: reorganize additions in NCS

### DIFF
--- a/applications/machine_learning/README.rst
+++ b/applications/machine_learning/README.rst
@@ -180,37 +180,6 @@ Check the sample Requirements section for the list of supported development kits
 The sample is used to receive data over NUS and forward it to the host computer over UART.
 See `Testing with Thingy:53`_ for how to test this solution.
 
-.. _nrf_machine_learning_app_requirements_build_types:
-
-nRF Machine Learning build types
-================================
-
-The nRF Machine Learning application does not use a single :file:`prj.conf` file.
-Configuration files are provided for different build types for each supported board.
-
-Each board has its own :file:`prj.conf` file, which represents a ``debug`` build type.
-Other build types are covered by dedicated files with the build type added as a suffix to the ``prj`` part, as per the following list.
-For example, the ``release`` build type file name is :file:`prj_release.conf`.
-If a board has other configuration files, for example associated with partition layout or child image configuration, these follow the same pattern.
-
-.. include:: /config_and_build/modifying.rst
-   :start-after: build_types_overview_start
-   :end-before: build_types_overview_end
-
-Before you start testing the application, you can select one of the build types supported by nRF Machine Learning application, depending on your development kit and the building method.
-The application supports the following build types:
-
-* ``debug`` -- Debug version of the application - can be used to verify if the application works correctly.
-* ``release`` -- Release version of the application - can be used to achieve better performance and reduce memory consumption.
-
-Not every board supports both mentioned build types.
-The given board can also support some additional configurations of the nRF Machine Learning application.
-For example, the nRF52840 Development Kit supports ``nus`` configuration that uses :ref:`nus_service_readme` instead of :ref:`zephyr:uart_api` for data forwarding.
-
-.. note::
-    `Selecting a build type`_ is optional.
-    The ``debug`` build type is used by default if no build type is explicitly selected.
-
 User interface
 **************
 
@@ -318,8 +287,7 @@ The following configuration files can be defined for any supported board:
 
 * :file:`prj_build_type.conf` - Kconfig configuration file for a build type.
   To support a given build type for the selected board, you must define the configuration file with a proper name.
-  For example, the :file:`prj_release.conf` defines configuration for ``release`` build type.
-  The :file:`prj.conf` without any suffix defines the ``debug`` build type.
+  See :ref:`nrf_machine_learning_app_configuration_build_types` for more information.
 * :file:`app.overlay` - DTS overlay file specific for the board.
   Defining the DTS overlay file for a given board is optional.
 * :file:`_def` files - These files are defined separately for modules used by the application.
@@ -347,7 +315,45 @@ The Kconfig configuration file should be located in subdirectory :file:`child_im
 For example, the :file:`applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/child_image/hci_rpmsg/prj.conf` file defines configuration of Bluetooth HCI RPMsg for ``debug`` build type on ``thingy53_nrf5340_cpuapp`` board, while the :file:`applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/child_image/hci_rpmsg/prj_release.conf` file defines configuration of Bluetooth HCI RPMsg for ``release`` build type.
 See :ref:`ug_multi_image` for detailed information about multi-image builds and child image configuration.
 
+.. _nrf_machine_learning_app_requirements_build_types:
 .. _nrf_machine_learning_app_configuration_build_types:
+
+nRF Machine Learning build types
+================================
+
+The nRF Machine Learning application does not use a single :file:`prj.conf` file.
+Before you start testing the application, you can select one of the build types supported by the application, depending on your development kit and the building method.
+Not every board supports both mentioned build types.
+
+See :ref:`app_build_additions_build_types` and :ref:`modifying_build_types` for more information about this feature of the |NCS|.
+
+The application supports the following build types:
+
+.. list-table:: nRF Machine Learning build types
+   :widths: auto
+   :header-rows: 1
+
+   * - Build type
+     - File name
+     - Supported board
+     - Description
+   * - Debug
+     - :file:`prj.conf`
+     - All from `Requirements`_
+     - | Debug version of the application; can be used to verify if the application works correctly.
+       | Used by default if no build type is explicitly selected.
+   * - Release
+     - :file:`prj_release.conf`
+     - ``nrf52840dk_nrf52840``
+     - Release version of the application; can be used to achieve better performance and reduce memory consumption.
+   * - NUS
+     - :file:`prj_nus.conf`
+     - ``nrf52840dk_nrf52840``
+     - Debug version of the application that uses :ref:`nus_service_readme` instead of :ref:`zephyr:uart_api` for data forwarding.
+   * - RTT
+     - :file:`prj_rtt.conf`
+     - ``thingy53_nrf5340_cpuapp`` and ``thingy53_nrf5340_cpuapp_ns``
+     - Debug version of the application that uses RTT for printing logs instead of USB CDC.
 
 Building and running
 ********************
@@ -363,28 +369,7 @@ Selecting a build type
 ======================
 
 Before you start testing the application, you can select one of the :ref:`nrf_machine_learning_app_requirements_build_types`, depending on your development kit and building method.
-
-Selecting a build type in |VSC|
--------------------------------
-
-.. include:: /config_and_build/modifying.rst
-   :start-after: build_types_selection_vsc_start
-   :end-before: build_types_selection_vsc_end
-
-Selecting a build type from command line
-----------------------------------------
-
-.. include:: /config_and_build/modifying.rst
-   :start-after: build_types_selection_cmd_start
-   :end-before: build_types_selection_cmd_end
-
-.. note::
-   If the selected board does not support the selected build type, the build is interrupted.
-   For example, if the ``nus`` build type is not supported by the selected board, the following notification appears:
-
-   .. code-block:: console
-
-      Configuration file for build type ``nus`` is missing.
+See :ref:`modifying_build_types` for detailed steps how to select a build type.
 
 Providing API key
 =================

--- a/applications/matter_bridge/doc/matter_bridge_description.rst
+++ b/applications/matter_bridge/doc/matter_bridge_description.rst
@@ -131,35 +131,6 @@ If the Bluetooth LE advertising times out, you can re-enable it manually by pres
 Additionally, the controller must get the `Onboarding information`_ from the Matter accessory device and provision the device into the network.
 For details, see the `Testing`_ section.
 
-.. _matter_bridge_app_build_types:
-
-Matter bridge build types
-=========================
-
-The bridge application uses different configuration files depending on the supported features.
-Configuration files are provided for different build types and they are located in the application root directory.
-
-The :file:`prj.conf` file represents a ``debug`` build type.
-Other build types are covered by dedicated files with the build type added as a suffix to the ``prj`` part, as per the following list.
-For example, the ``release`` build type file name is :file:`prj_release.conf`.
-If a board has other configuration files, for example associated with partition layout or child image configuration, these follow the same pattern.
-
-.. include:: /config_and_build/modifying.rst
-   :start-after: build_types_overview_start
-   :end-before: build_types_overview_end
-
-Before you start testing the application, you can select one of the build types supported by the sample.
-This sample supports the following build types:
-
-* ``debug`` -- Debug version of the application.
-  You can use this version to enable additional features for verifying the application behavior, such as logs.
-* ``release`` -- Release version of the application.
-  You can use this version to enable only the necessary application functionalities to optimize its performance.
-
-.. note::
-    `Selecting a build type`_ is optional.
-    The ``debug`` build type is used by default if no build type is explicitly selected.
-
 User interface
 **************
 
@@ -382,6 +353,37 @@ Build the target using the following command in the project directory to enable 
 
 Replace *absolute_path* with the absolute path to the Matter bridge application on your local disk.
 
+.. _matter_bridge_app_build_types:
+
+Matter bridge build types
+=========================
+
+The Matter bridge application does not use a single :file:`prj.conf` file.
+Before you start testing the application, you can select one of the build types supported by the application, depending on your development kit and the building method.
+Not every board supports both mentioned build types.
+
+See :ref:`app_build_additions_build_types` and :ref:`modifying_build_types` for more information about this feature of the |NCS|.
+
+The application supports the following build types:
+
+.. list-table:: Matter bridge build types
+   :widths: auto
+   :header-rows: 1
+
+   * - Build type
+     - File name
+     - Supported board
+     - Description
+   * - Debug
+     - :file:`prj.conf`
+     - All from `Requirements`_
+     - | Debug version of the application; can be used to enable additional features for verifying the application behavior, such as logs.
+       | Used by default if no build type is explicitly selected.
+   * - Release
+     - :file:`prj_release.conf`
+     - All from `Requirements`_
+     - Release version of the application; can be used to enable only the necessary application functionalities to optimize its performance.
+
 Building and running
 ********************
 
@@ -393,37 +395,7 @@ Selecting a build type
 ======================
 
 Before you start testing the application, you can select one of the :ref:`matter_bridge_app_build_types`, depending on your building method.
-
-Selecting a build type in |VSC|
--------------------------------
-
-.. include:: /config_and_build/modifying.rst
-   :start-after: build_types_selection_vsc_start
-   :end-before: build_types_selection_vsc_end
-
-Selecting a build type from command line
-----------------------------------------
-
-.. include:: /config_and_build/modifying.rst
-   :start-after: build_types_selection_cmd_start
-   :end-before: For example, you can replace the
-
-For example, you can replace the *selected_build_type* variable to build the ``release`` firmware for ``nrf7002dk_nrf5340_cpuapp`` by running the following command in the project directory:
-
-.. parsed-literal::
-   :class: highlight
-
-   west build -b nrf7002dk_nrf5340_cpuapp -d build_nrf7002dk_nrf5340_cpuapp -- -DCONF_FILE=prj_release.conf
-
-The ``build_nrf7002dk_nrf5340_cpuapp`` parameter specifies the output directory for the build files.
-
-.. note::
-   If the selected board does not support the selected build type, the build is interrupted.
-   For example, if the ``shell`` build type is not supported by the selected board, the following notification appears:
-
-   .. code-block:: console
-
-      File not found: ./ncs/nrf/applications/matter_bridge/configuration/nrf7002dk_nrf5340_cpuapp/prj_shell.conf
+See :ref:`modifying_build_types` for detailed steps how to select a build type.
 
 .. _matter_bridge_testing:
 

--- a/applications/matter_weather_station/README.rst
+++ b/applications/matter_weather_station/README.rst
@@ -127,36 +127,40 @@ Matter weather station build types
 ==================================
 
 The Matter weather station application does not use a single :file:`prj.conf` file.
-Configuration files are provided for different build types and they are located in the :file:`configuration/thingy53_nrf5340_cpuapp` directory.
+Configuration files are provided for different build types, and they are located in the :file:`configuration/thingy53_nrf5340_cpuapp` directory.
+Before you start testing the application, you can select one of the build types supported by the application, depending on the building method.
 
-The :file:`prj.conf` file represents a ``debug`` build type.
-Other build types are covered by dedicated files with the build type added as a suffix to the ``prj`` part, as per the following list.
-For example, the ``release`` build type file name is :file:`prj_release.conf`.
-If a board has other configuration files, for example associated with partition layout or child image configuration, these follow the same pattern.
+See :ref:`app_build_additions_build_types` and :ref:`modifying_build_types` for more information about this feature of the |NCS|.
 
-.. include:: /config_and_build/modifying.rst
-   :start-after: build_types_overview_start
-   :end-before: build_types_overview_end
+The application supports the following build types:
 
-Before you start testing the application, you can select one of the build types supported by Matter weather station application, depending on the building method.
-This application supports the following build types:
+.. list-table:: Matter weather station build types
+   :widths: auto
+   :header-rows: 1
 
-* ``debug`` - Debug version of the application.
-  You can use this version to enable additional features for verifying the application behavior, such as logs or command-line shell.
-* ``release`` - Release version of the application.
-  You can use this version to enable only the necessary application functionalities to optimize its performance.
-
-.. note::
-    Currently, this application supports only the ``release`` build type when `Building for the nRF7002 Wi-Fi expansion board`_.
-
-.. note::
-    `Selecting a build type`_ is optional.
-    The ``debug`` build type is used by default if no build type is explicitly selected.
+   * - Build type
+     - File name
+     - Supported board
+     - Description
+   * - Debug
+     - :file:`prj.conf`
+     - All from `Requirements`_
+     - | Debug version of the application; can be used to enable additional features for verifying the application behavior, such as logs or command-line shell.
+       | Used by default if no build type is explicitly selected.
+   * - Release
+     - :file:`prj_release.conf`
+     - All from `Requirements`_
+     - | Release version of the application; can be used to enable only the necessary application functionalities to optimize its performance.
+       |
+       | .. note::
+       |     Currently, this application supports only the ``release`` build type when `Building for the nRF7002 Wi-Fi expansion board`_.
 
 .. _matter_weather_station_app_build_configuration_overlays:
 
 Matter weather station build configuration overlays
 ===================================================
+
+The application comes with the following overlays:
 
 * ``overlay-factory_data`` - factory data storage support enabled.
   You can use this optional configuration overlay to enable reading necessary factory data from a separate partition in the device non-volatile memory.
@@ -179,37 +183,7 @@ Selecting a build type
 ======================
 
 Before you start testing the application, you can select one of the :ref:`matter_weather_station_app_build_types`, depending on your building method.
-
-Selecting a build type in |VSC|
--------------------------------
-
-.. include:: /config_and_build/modifying.rst
-   :start-after: build_types_selection_vsc_start
-   :end-before: build_types_selection_vsc_end
-
-Selecting a build type from command line
-----------------------------------------
-
-.. include:: /config_and_build/modifying.rst
-   :start-after: build_types_selection_cmd_start
-   :end-before: For example, you can replace the
-
-For example, you can replace the *selected_build_type* variable to build the ``release`` firmware for ``thingy53_nrf5340_cpuapp`` by running the following command in the project directory:
-
-.. parsed-literal::
-   :class: highlight
-
-   west build -b thingy53_nrf5340_cpuapp -d build_thingy53_nrf5340_cpuapp -- -DCONF_FILE=prj_release.conf
-
-The ``build_thingy53_nrf5340_cpuapp`` parameter specifies the output directory for the build files.
-
-.. note::
-   If the selected board does not support the selected build type, the build is interrupted.
-   For example, if the ``shell`` build type is not supported by the selected board, the following notification appears:
-
-   .. code-block:: console
-
-      File not found: ./ncs/nrf/applications/matter_weather_station/configuration/thingy53_nrf5340_cpuapp/prj_shell.conf
+See :ref:`modifying_build_types` for detailed steps how to select a build type.
 
 Building for the nRF7002 Wi-Fi expansion board
 ==============================================

--- a/applications/matter_weather_station/README.rst
+++ b/applications/matter_weather_station/README.rst
@@ -153,7 +153,7 @@ The application supports the following build types:
      - | Release version of the application; can be used to enable only the necessary application functionalities to optimize its performance.
        |
        | .. note::
-       |     Currently, this application supports only the ``release`` build type when `Building for the nRF7002 Wi-Fi expansion board`_.
+       |     Currently, this application supports only the release build type when `Building for the nRF7002 Wi-Fi expansion board`_.
 
 .. _matter_weather_station_app_build_configuration_overlays:
 

--- a/applications/nrf_desktop/README.rst
+++ b/applications/nrf_desktop/README.rst
@@ -316,7 +316,6 @@ Requirements
 The nRF Desktop application supports several development kits related to the following hardware reference designs.
 Depending on what development kit you use, you need to select the respective configuration file and :ref:`build type <nrf_desktop_requirements_build_types>`.
 
-
 .. tabs::
 
    .. tab:: Gaming mouse
@@ -377,41 +376,76 @@ Check :ref:`nrf_desktop_porting_guide` for details.
 nRF Desktop build types
 =======================
 
-The nRF Desktop does not use a single :file:`prj.conf` file.
-Configuration files are provided for different build types for each supported board.
+The nRF Desktop application does not use a single :file:`prj.conf` file.
+Before you start testing the application, you can select one of the build types supported by the application, depending on your development kit and the building method.
+Not every board supports all of the mentioned build types.
 
-Each board has its own :file:`prj.conf` file, which represents a ``debug`` build type.
-Other build types are covered by dedicated files with the build type added as a suffix to the ``prj`` part, as per the following list.
-For example, the ``release`` build type file name is :file:`prj_release.conf`.
-If a board has other configuration files, for example associated with partition layout or child image configuration, these follow the same pattern.
+See :ref:`app_build_additions_build_types` and :ref:`modifying_build_types` for more information about this feature of the |NCS|.
 
-.. include:: /config_and_build/modifying.rst
-   :start-after: build_types_overview_start
-   :end-before: build_types_overview_end
+The application supports the following build types:
+
+.. list-table:: nRF Desktop build types
+   :widths: auto
+   :header-rows: 1
+
+   * - Build type
+     - File name
+     - Supported board
+     - Description
+   * - Debug
+     - :file:`prj.conf`
+     - All from `Requirements`_
+     - | Debug version of the application; the same as the release build type, but with debug options enabled.
+       | Used by default if no build type is explicitly selected.
+   * - Release
+     - :file:`prj_release.conf`
+     - All from `Requirements`_
+     - Release version of the application with no debugging features.
+   * - Debug Fast Pair
+     - :file:`prj_fast_pair.conf`
+     - ``nrf52840dk_nrf52840``, ``nrf52840gmouse_nrf52840``
+     - Debug version of the application with `Fast Pair`_ support.
+   * - Release Fast Pair
+     - :file:`prj_release_fast_pair.conf`
+     - ``nrf52kbd_nrf52832``, ``nrf52840gmouse_nrf52840``
+     - Release version of the application with `Fast Pair`_ support.
+   * - Dongle
+     - :file:`prj_dongle.conf`
+     - ``nrf52840dk_nrf52840``
+     - Debug version of the application that lets you generate the application with the dongle role.
+   * - Keyboard
+     - :file:`prj_keyboard.conf`
+     - ``nrf52840dk_nrf52840``
+     - Debug version of the application that lets you generate the application with the keyboard role.
+   * - MCUboot QSPI
+     - :file:`prj_mcuboot_qspi.conf`
+     - ``nrf52840dk_nrf52840``
+     - Debug version of the application that uses MCUboot with the secondary slot in the external QSPI FLASH.
+   * - MCUboot SMP
+     - :file:`prj_mcuboot_smp.conf`
+     - ``nrf52840dk_nrf52840``, ``nrf52840gmouse_nrf52840``
+     - | Debug version of the application that enables MCUmgr with DFU support and offers support for the MCUboot DFU procedure over SMP.
+       | See the :ref:`nrf_desktop_bootloader_background_dfu` section for more information.
+   * - WWCB
+     - :file:`prj_wwcb.conf`
+     - ``nrf52840dk_nrf52840``
+     - Debug version of the application with the support for the B0 bootloader enabled for `Works With ChromeBook (WWCB)`_.
+   * - Triple Bluetooth® LE connection
+     - :file:`prj_3bleconn.conf`
+     - ``nrf52840dongle_nrf52840``
+     - Debug version of the application with the support for up to three simultaneous Bluetooth® LE connections.
+   * - Quadruple LLPM connection
+     - :file:`prj_4llpmconn.conf`
+     - ``nrf52840dongle_nrf52840``
+     - Debug version of the application with the support for up to four simultaneous Bluetooth® LE connections, in Low Latency Packet Mode.
+   * - Release quadruple LLPM connection
+     - :file:`prj_release_4llpmconn.conf`
+     - ``nrf52840dongle_nrf52840``
+     - Release version of the application with the support for up to four simultaneous Bluetooth® LE connections, in Low Latency Packet Mode.
 
 .. note::
-    `Selecting a build type`_ is optional.
-    The ``debug`` build type is used by default in nRF Desktop if no build type is explicitly selected.
-
-The following build types are available for various boards in the nRF Desktop:
-
-* Bootloader-enabled configurations with support for :ref:`serial recovery DFU <nrf_desktop_bootloader_serial_dfu>` or :ref:`background DFU <nrf_desktop_bootloader_background_dfu>` are set as default if they fit in non-volatile memory.
-  See :ref:`nrf_desktop_board_configuration_files` for details about which boards have bootloader included in their default configuration.
-* ``release`` - Release version of the application with no debugging features.
-* ``debug`` - Debug version of the application; the same as the ``release`` build type, but with debug options enabled.
-* ``wwcb`` - ``debug`` build type with the support for the B0 bootloader enabled for `Works With ChromeBook (WWCB)`_.
-
-In nRF Desktop, not every development kit can support every build type mentioned above.
-If the given build type is not supported on the selected DK, an error message will appear when `Building and running`_.
-For example, if the ``wwcb`` build type is not supported on the selected DK, the following notification appears:
-
-.. code-block:: console
-
-   File not found: ./ncs/nrf/applications/nrf_desktop/configuration/nrf52dmouse_nrf52832/prj_wwcb.conf
-
-|nrf_desktop_build_type_conf|
-For example, the nRF52840 Development Kit supports the ``keyboard`` configuration, which is defined in the :file:`prj_keyboard.conf` file in the :file:`configuration/nrf52840dk_nrf52840` directory.
-This configuration lets you generate the application with the keyboard role.
+    Bootloader-enabled configurations with support for :ref:`serial recovery DFU <nrf_desktop_bootloader_serial_dfu>` or :ref:`background DFU <nrf_desktop_bootloader_background_dfu>` are set as default if they fit in non-volatile memory.
+    See :ref:`nrf_desktop_board_configuration_files` for details about which boards have bootloader included in their default configuration.
 
 See :ref:`nrf_desktop_porting_guide` for detailed information about the application configuration and how to create build type files for your hardware.
 
@@ -866,20 +900,7 @@ Selecting a build type
 ======================
 
 Before you start testing the application, you can select one of the :ref:`nrf_desktop_requirements_build_types`, depending on your development kit and building method.
-
-Selecting a build type in |VSC|
--------------------------------
-
-.. include:: /config_and_build/modifying.rst
-   :start-after: build_types_selection_vsc_start
-   :end-before: build_types_selection_vsc_end
-
-Selecting a build type from command line
-----------------------------------------
-
-.. include:: /config_and_build/modifying.rst
-   :start-after: build_types_selection_cmd_start
-   :end-before: build_types_selection_cmd_end
+See :ref:`modifying_build_types` for detailed steps how to select a build type.
 
 .. note::
    If nRF Desktop is built with `Fast Pair`_ support, you must provide Fast Pair Model ID and Anti Spoofing private key as CMake options.
@@ -1208,7 +1229,7 @@ The application configuration files define both a set of options with which the 
 Include the following files in this directory:
 
 Mandatory configuration files
-    * Application configuration file for the ``debug`` (:file:`prj.conf`) :ref:`build type <nrf_desktop_requirements_build_types>`.
+    * Application configuration file for the :ref:`debug build type <nrf_desktop_requirements_build_types>` (:file:`prj.conf`).
     * Configuration files for the selected modules.
 
 Optional configuration files
@@ -1299,7 +1320,7 @@ Adding a new board
 ==================
 
 When adding a new board for the first time, focus on a single configuration.
-Moreover, keep the default ``debug`` build type that the application is built with, and do not add any additional build type parameters.
+Moreover, keep the default debug build type that the application is built with, and do not add any additional build type parameters.
 The following procedure uses the gaming mouse configuration as an example.
 
 Zephyr support for a board
@@ -1610,7 +1631,7 @@ When the :kconfig:option:`CONFIG_PARTITION_MANAGER_ENABLED` Kconfig option is en
 The nRF Desktop configurations use static configurations of partitions to ensure that the partition layout will not change between builds.
 
 Add the :file:`pm_static_${BUILD_TYPE}.yml` file to the project's board configuration directory to define the static Partition Manager configuration for given board and build type.
-For example, to define the static partition layout for the nrf52840dk_nrf52840 board and ``release`` build type, you would need to add the :file:`pm_static_release.yml` file into the :file:`applicatons/nrf_desktop/configuration/nrf52840dk_nrf52840` directory.
+For example, to define the static partition layout for the nrf52840dk_nrf52840 board and release build type, you would need to add the :file:`pm_static_release.yml` file into the :file:`applicatons/nrf_desktop/configuration/nrf52840dk_nrf52840` directory.
 
 Take into account the following points:
 

--- a/applications/zigbee_weather_station/README.rst
+++ b/applications/zigbee_weather_station/README.rst
@@ -136,32 +136,34 @@ Zigbee weather station build types
 
 The Zigbee weather station application does not use a single :file:`prj.conf` file.
 Configuration files are provided for different build types, and they are located in the :file:`configuration/thingy53_nrf5340_cpuapp` directory.
+Before you start testing the application, you can select one of the build types supported by the application, depending on the building method.
 
-The :file:`prj.conf` file represents a ``debug`` build type.
-Other build types are covered by dedicated files with the build type added as a suffix to the ``prj`` part, as per the following list.
-For example, the ``release`` build type file name is :file:`prj_release.conf`.
-If a board has other configuration files, for example associated with partition layout or child image configuration, these follow the same pattern.
+See :ref:`app_build_additions_build_types` and :ref:`modifying_build_types` for more information about this feature of the |NCS|.
 
-.. include:: /config_and_build/modifying.rst
-   :start-after: build_types_overview_start
-   :end-before: build_types_overview_end
+The application supports the following build types:
 
-Before you start testing the application, you can select one of the build types supported by the Zigbee weather station application, depending on the building method.
-This application supports the following build types:
+.. list-table:: Zigbee weather station build types
+   :widths: auto
+   :header-rows: 1
 
-* ``debug`` - Debug version of the application.
-  Use this version to enable additional features for verifying the application behavior, such as logs.
-* ``release`` - Release version of the application.
-  Use this version to enable only the necessary application functionalities to optimize its performance.
+   * - Build type
+     - File name
+     - Supported board
+     - Description
+   * - Debug
+     - :file:`prj.conf`
+     - All from `Requirements`_
+     - | Debug version of the application; can be used to enable additional features for verifying the application behavior, such as logs.
+       | Used by default if no build type is explicitly selected.
+   * - Release
+     - :file:`prj_release.conf`
+     - All from `Requirements`_
+     - Release version of the application; can be used to enable only the necessary application functionalities to optimize its performance.
 
-.. note::
-   :ref:`zigbee_weather_station_app_select_build_type` is optional.
-   The ``debug`` build type is used by default if no build type is explicitly selected.
+Logging in the debug build type
+-------------------------------
 
-Logging in the ``debug`` build type
-===================================
-
-In the ``debug`` build type, the application also uses serial console over USB for logging.
+In the debug build type, the application also uses serial console over USB for logging.
 Besides initialization logs, the following sets of measurement-related data are logged after a measurements update:
 
 * Values measured by sensor.
@@ -191,37 +193,7 @@ Selecting a build type
 ======================
 
 Before you start testing the application, you can select one of the :ref:`zigbee_weather_station_app_build_types`, depending on your building method.
-
-Selecting a build type in |VSC|
--------------------------------
-
-.. include:: /config_and_build/modifying.rst
-   :start-after: build_types_selection_vsc_start
-   :end-before: build_types_selection_vsc_end
-
-Selecting a build type from command line
-----------------------------------------
-
-.. include:: /config_and_build/modifying.rst
-   :start-after: build_types_selection_cmd_start
-   :end-before: For example, you can replace the
-
-For example, you can replace the *selected_build_type* variable to build the ``release`` firmware for ``thingy53_nrf5340_cpuapp`` by running the following command in the project directory:
-
-.. parsed-literal::
-   :class: highlight
-
-   west build -b thingy53_nrf5340_cpuapp -d build_thingy53_nrf5340_cpuapp -- -DCONF_FILE=prj_release.conf
-
-The ``build_thingy53_nrf5340_cpuapp`` parameter specifies the output directory for the build files.
-
-.. note::
-   If the selected board does not support the selected build type, the build is interrupted.
-   For example, if the ``shell`` build type is not supported by the selected board, the following notification appears:
-
-   .. code-block:: console
-
-      File not found: ./ncs/nrf/applications/zigbee_weather_station/configuration/thingy53_nrf5340_cpuapp/prj_shell.conf
+See :ref:`modifying_build_types` for detailed steps how to select a build type.
 
 .. _zigbee_weather_station_app_testing:
 

--- a/doc/nrf/config_and_build/modifying.rst
+++ b/doc/nrf/config_and_build/modifying.rst
@@ -205,14 +205,15 @@ The *<buildtype>* can be any string, but it is common to use ``release`` and ``d
 
 For information about how to set variables, see :ref:`zephyr:important-build-vars` in the Zephyr documentation.
 
-The Partition Manager's :ref:`static configuration <ug_pm_static>` can also be made dependent on the build type.
-When the build type has been inferred, the file :file:`pm_static_<buildtype>.yml` will have precedence over :file:`pm_static.yml`.
+The following software components can be made dependent on the build type:
 
-The :ref:`child image Kconfig configuration <ug_multi_image_permanent_changes>` can also be made dependent on the build type.
-The child image Kconfig overlay file is named :file:`child_image/<child_image_name>.conf` instead of :file:`prj.conf`, but otherwise follows the same pattern as the parent Kconfig.
+* The Partition Manager's :ref:`static configuration <ug_pm_static>`.
+  When the build type has been inferred, the file :file:`pm_static_<buildtype>.yml` will have precedence over :file:`pm_static.yml`.
+* The :ref:`child image Kconfig configuration <ug_multi_image_permanent_changes>`.
+  The child image Kconfig overlay file is named :file:`child_image/<child_image_name>.conf` instead of :file:`prj.conf`, but otherwise follows the same pattern as the parent Kconfig.
 
-Alternatively, the child image Kconfig configuration file can be introduced as :file:`child_image/<child_image_name>/prj.conf` and follow the same pattern as the parent Kconfig.
-For example, :file:`child_image/mcuboot/prj_release.conf` can be used to define ``release`` build type for ``mcuboot`` child image.
+  Alternatively, the child image Kconfig configuration file can be introduced as :file:`child_image/<child_image_name>/prj.conf` and follow the same pattern as the parent Kconfig.
+  For example, :file:`child_image/mcuboot/prj_release.conf` can be used to define ``release`` build type for ``mcuboot`` child image.
 
 .. build_types_overview_end
 
@@ -256,3 +257,10 @@ The Devicetree configuration is not affected by the build type.
       The ``build_nrf52840dk_nrf52840`` parameter specifies the output directory for the build files.
 
       .. build_types_selection_cmd_end
+
+If the selected board does not support the selected build type, the build is interrupted.
+For example, for the :ref:`nrf_machine_learning_app` application, if the ``nus`` build type is not supported by the selected board, the following notification appears:
+
+.. code-block:: console
+
+   Configuration file for build type ``nus`` is missing.

--- a/doc/nrf/documentation/glossary.rst
+++ b/doc/nrf/documentation/glossary.rst
@@ -91,6 +91,11 @@ Glossary
       The different sources can include source files such as :file:`main.c` and configuration input files such as :ref:`Devicetree <configure_application_hw>` and :ref:`Kconfig <configure_application_sw>` files.
       The build scripts are then used during the :ref:`configuration_system_overview_build` to create the application firmware.
 
+   Build type
+      A build type is a feature that defines the way in which the configuration files are to be handled.
+      The |NCS| provides support for :ref:`app_build_additions_build_types`.
+      Selecting a specific build type can result in a different structure of the :term:`build configuration`.
+
    Carrier-sense Multiple Access with Collision Avoidance (CSMA/CA)
       A network multiple access method in which carrier sensing is used, but nodes attempt to avoid collisions by beginning transmission only after the channel is sensed to be idle.
 

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -961,6 +961,7 @@
 .. _`CMake documentation`: https://cmake.org/cmake/help/latest/
 .. _`VERBOSE`: https://cmake.org/cmake/help/latest/envvar/VERBOSE.html
 .. _`CMAKE_BUILD_PARALLEL_LEVEL`: https://cmake.org/cmake/help/latest/envvar/CMAKE_BUILD_PARALLEL_LEVEL.html
+.. _`CMAKE_BUILD_TYPE`: https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html
 
 .. _`generator expressions`: https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -789,6 +789,7 @@ Documentation
   * The :ref:`configuration_and_build` section:
 
     * :ref:`app_build_system` gathers conceptual information about the build and configuration system previously listed on several other pages.
+      The :ref:`app_build_additions` section on this page now provides more information about :ref:`app_build_additions_build_types` specific to the |NCS|.
     * New reference page :ref:`app_build_output_files` gathers information previously listed on several other pages.
     * :ref:`app_dfu` and :ref:`app_bootloaders` are now separate sections, with the DFU section summarizing the available DFU methods in a table.
 

--- a/doc/nrf/releases_and_maturity/software_maturity.rst
+++ b/doc/nrf/releases_and_maturity/software_maturity.rst
@@ -25,12 +25,7 @@ Experimental
    The feature can be used for development, but it is not recommended for production.
    This means that the feature is incomplete in functionality or verification and can be expected to change in future releases.
    The feature is made available in its current state, but the design and interfaces can change between release tags.
-   The feature is also labeled as ``EXPERIMENTAL`` in Kconfig files to indicate this status.
-
-   .. note::
-      By default, the build system generates build warnings to indicate when features labeled ``EXPERIMENTAL`` are included in builds.
-      To disable these warnings, disable the :kconfig:option:`CONFIG_WARN_EXPERIMENTAL` Kconfig option.
-      See :ref:`app_build_additions` for details.
+   The feature is also labeled as :ref:`experimental in Kconfig files <app_build_additions_experimental>` and a build warning is generated to indicate this status.
 
 See the following table for more details:
 

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -124,9 +124,6 @@
 .. |net_state| replace:: network state module
 .. |nrf_desktop_module_event_note| replace:: See the :ref:`nrf_desktop_architecture` for more information about the event-based communication in the nRF Desktop application and about how to read this table.
 .. |nrf_desktop_command_note_with_dfu_lock| replace:: With the :ref:`CONFIG_DESKTOP_DFU_LOCK <config_desktop_app_options>` option enabled, the device only executes this command when it holds the DFU owner status.
-.. |nrf_desktop_build_type_conf| replace:: In addition to these build types, some boards can have additional build type configurations that you can use to generate an application in a specific variant.
-   Such board-specific configurations use dedicated :file:`prj_*build_type*.conf` files, where the name of the configuration replaces the ``*build_type*`` part in the file name.
-   Given the potential number of such configurations, they are not listed above and you can read the description of each of them in the respective configuration file.
 .. |nRF_Desktop_confirmation_effect| replace:: After the confirmation, Bluetooth advertising using a new local identity is started.
    When a new Bluetooth Central device successfully connects and bonds, the old bond is removed and the new bond is used instead.
    If the new peer does not connect in the predefined period of time, the advertising ends and the application switches back to the old peer.


### PR DESCRIPTION
Moved and expanded information in "Additions in the NCS" section of the build and config overview page. 
Edited build type sections.
Replaced includes with links in some application readme files.
NCSDK-22324.