### PR TITLE
lib: at_monitor: assert when out of memory for notifications

### DIFF
--- a/lib/at_monitor/at_monitor.c
+++ b/lib/at_monitor/at_monitor.c
@@ -75,8 +75,8 @@ void at_monitor_dispatch(const char *notif)
 
 	at_notif = k_heap_alloc(&at_monitor_heap, sz_needed, K_NO_WAIT);
 	if (!at_notif) {
-		LOG_WRN("No heap space for incoming notification: %s",
-			notif);
+		LOG_WRN("No heap space for incoming notification: %s", notif);
+		__ASSERT(at_notif, "No heap space for incoming notification: %s", notif);
 		return;
 	}
 


### PR DESCRIPTION
Make sure this situation is well visible during development.