### PR TITLE
boards: arm: thingy91: Do not enable uart1 by default

### DIFF
--- a/applications/connectivity_bridge/app.overlay
+++ b/applications/connectivity_bridge/app.overlay
@@ -4,6 +4,10 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+&uart1 {
+	status = "okay";
+};
+
 &zephyr_udc0 {
 	cdc_acm_uart0: cdc_acm_uart0 {
 		compatible = "zephyr,cdc-acm-uart";

--- a/boards/arm/thingy91_nrf52840/thingy91_nrf52840.dts
+++ b/boards/arm/thingy91_nrf52840/thingy91_nrf52840.dts
@@ -60,7 +60,7 @@
 
 &uart1 {
 	current-speed = <1000000>;
-	status = "okay";
+	status = "disabled";
 	pinctrl-0 = <&uart1_default>;
 	pinctrl-1 = <&uart1_sleep>;
 	pinctrl-names = "default", "sleep";

--- a/boards/arm/thingy91_nrf9160/thingy91_nrf9160_common.dts
+++ b/boards/arm/thingy91_nrf9160/thingy91_nrf9160_common.dts
@@ -203,7 +203,7 @@
 
 &uart1 {
 	current-speed = <1000000>;
-	status = "okay";
+	status = "disabled";
 	pinctrl-0 = <&uart1_default>;
 	pinctrl-1 = <&uart1_sleep>;
 	pinctrl-names = "default", "sleep";


### PR DESCRIPTION
uart1 was enabled by default which was causing initialization in bootloader. It impacted application which was using uart1 because probably it was not uninitialized by the bootloader.

Ref: NCSIDB-1073.