### PR TITLE
manifest: zephyr: Update sdk-zephyr with QSPI alignment for nrfx_qspi

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v3.4.99-ncs1-1-rc1
+      revision: pull/1424/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Due to changes in nrfx_qspi driver nrf_qspi_nor needs to be aligned to correctly deactivate the QSPI