### PR TITLE
caf: ble_state_pm: Create KConfig option to select min power level

### DIFF
--- a/doc/nrf/libraries/caf/ble_state_pm.rst
+++ b/doc/nrf/libraries/caf/ble_state_pm.rst
@@ -15,6 +15,9 @@ Configuration
 The module is enabled by selecting :kconfig:option:`CONFIG_CAF_BLE_STATE_PM`.
 It depends on :kconfig:option:`CONFIG_CAF_BLE_STATE` and :kconfig:option:`CONFIG_CAF_POWER_MANAGER`.
 
+The minimum power level is :c:enumerator:`POWER_MANAGER_LEVEL_SUSPENDED` by default, but can be
+instead set to :c:enumerator:`POWER_MANAGER_LEVEL_ALIVE`.
+
 Implementation details
 **********************
 
@@ -24,7 +27,11 @@ It then counts the active connections.
 
 Depending on the count result:
 
-* If there is at least one active connection, the power level is limited to :c:enum:`POWER_MANAGER_LEVEL_SUSPENDED`.
-* If there is no active connection, the limitation on power level is removed.
+* If there is at least one active connection, the power level is limited to one of the following, as selected:
+
+   * :kconfig:option:`CONFIG_CAF_BLE_STATE_PM_MIN_LEVEL_SUSPENDED` - :c:enumerator:`POWER_MANAGER_LEVEL_SUSPENDED`,
+   * :kconfig:option:`CONFIG_CAF_BLE_STATE_PM_MIN_LEVEL_ALIVE` - :c:enumerator:`POWER_MANAGER_LEVEL_ALIVE`,
+
+* If there is no active connection, the limitation on power level is removed (:c:enumerator:`POWER_MANAGER_LEVEL_MAX`).
 
 For more information about the CAF power levels, see the :ref:`caf_power_manager` documentation page.

--- a/subsys/caf/modules/Kconfig.ble_state
+++ b/subsys/caf/modules/Kconfig.ble_state
@@ -45,8 +45,32 @@ config CAF_BLE_STATE_PM
 	default y
 	help
 	  This enables small module that keeps track on active connections.
-	  If there is any active connection the power down modes would be limited to SUSPENDED.
+	  If there is any active connection the power down modes would be limited to
+	  the predefined level, which can be SUSPENDED or ALIVE.
 	  Full POWER OFF mode would be only allowed if we have no active connection.
+
+if CAF_BLE_STATE_PM
+
+choice
+	prompt "Select power level to restrict to when there are active connections"
+	default CAF_BLE_STATE_PM_MIN_LEVEL_SUSPENDED
+	help
+	  Power can be restricted to either SUSPENDED or ALIVE when there are
+	  any active connections.
+
+config CAF_BLE_STATE_PM_MIN_LEVEL_SUSPENDED
+	bool "Suspended"
+	help
+	  Power is restricted to SUSPENDED
+
+config CAF_BLE_STATE_PM_MIN_LEVEL_ALIVE
+	bool "Alive"
+	help
+	  Power is restricted to ALIVE
+
+endchoice
+
+endif # CAF_BLE_STATE_PM
 
 config CAF_BLE_STATE_EXCHANGE_MTU
 	bool "Exchange MTU"

--- a/subsys/caf/modules/ble_state_pm.c
+++ b/subsys/caf/modules/ble_state_pm.c
@@ -13,6 +13,14 @@
 #include <caf/events/power_manager_event.h>
 #include <caf/events/keep_alive_event.h>
 
+#if CONFIG_CAF_BLE_STATE_PM_MIN_LEVEL_SUSPENDED
+	#define PM_MIN_LEVEL POWER_MANAGER_LEVEL_SUSPENDED
+#elif CONFIG_CAF_BLE_STATE_PM_MIN_LEVEL_ALIVE
+	#define PM_MIN_LEVEL POWER_MANAGER_LEVEL_ALIVE
+#else
+	#error "Power level is not defined"
+#endif
+
 
 static bool app_event_handler(const struct app_event_header *aeh)
 {
@@ -26,7 +34,7 @@ static bool app_event_handler(const struct app_event_header *aeh)
 		connection_count++;
 		__ASSERT_NO_MSG(connection_count < UINT_MAX);
 		keep_alive();
-		power_manager_restrict(MODULE_IDX(MODULE), POWER_MANAGER_LEVEL_SUSPENDED);
+		power_manager_restrict(MODULE_IDX(MODULE), PM_MIN_LEVEL);
 		break;
 	case PEER_STATE_DISCONNECTED:
 		__ASSERT_NO_MSG(connection_count > 0);


### PR DESCRIPTION
The minimum power level to restrict power to when there is at least one connection can now be chosen between SUSPENDED or ALIVE thanks to a new KConfig choice option.

Documentation has been updated to reflect this change.