### PR TITLE
applications: nrf5340_audio: Fix netcore scheduler

### DIFF
--- a/applications/nrf5340_audio/CMakeLists.txt
+++ b/applications/nrf5340_audio/CMakeLists.txt
@@ -31,6 +31,7 @@ if ((CONFIG_AUDIO_DFU EQUAL 1) OR (CONFIG_AUDIO_DFU EQUAL 2))
     list(APPEND empty_net_core_OVERLAY_CONFIG
         "${CMAKE_CURRENT_LIST_DIR}/dfu/conf/overlay-empty_net_core.conf"
     )
+    list(APPEND empty_net_core_b0n_CONFIG_SYS_CLOCK_EXISTS n)
     if (CONFIG_B0N_MINIMAL)
         set(min_b0n_flag "-m")
         list(APPEND empty_net_core_b0n_OVERLAY_CONFIG overlay-minimal-size.conf)


### PR DESCRIPTION
Turn off sys clock related kconfig to prevent network core scheduler abnormal.