### PR TITLE
manifest: matter: Initial version of PSA Crypto in Matter

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -94,6 +94,8 @@ Matter
 
 * Updated the page about :ref:`ug_matter_device_low_power_configuration` with the information about Intermittently Connected Devices (ICD) configuration.
 * Added a Kconfig option for disabling or enabling :ref:`ug_matter_configuring_read_client`.
+* Added support for PSA Crypto API for devices that use Matter over Thread.
+  It is enabled by default and can be disabled by setting the :kconfig:option:`CONFIG_CHIP_CRYPTO_PSA` Kconfig option to ``n``.
 
 Matter fork
 +++++++++++

--- a/west.yml
+++ b/west.yml
@@ -149,7 +149,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: d95eb1d43d6e8247045d549802642ec66ad1d322
+      revision: f185cba99f4c5e025cf944517e6f9e5e5f38a502
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
PSA Crypto API can be enabled in Matter samples by adding selecting `CONFIG_CHIP_CRYPTO_PSA` to y.