### PR TITLE
Fix sysbuild showing child/parent config options and add alternative zephyr test configuration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -326,3 +326,6 @@ Kconfig*                                  @tejlmand
 /tests/tfm/                               @frkv @Vge0rge @vili-nordic @joerchan @SebastianBoe @mswarowsky @stephen-nordic @magnev
 /tests/unity/                             @nordic-krch
 /zephyr/                                  @carlescufi
+
+# CI test alt config
+/alt-test-config/                         @nordicjm

--- a/Kconfig.nrf
+++ b/Kconfig.nrf
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Nordic Semiconductor
+# Copyright (c) 2018-2023 Nordic Semiconductor
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
@@ -27,6 +27,12 @@ rsource "modules/trusted-firmware-m/Kconfig.psa.defconfig"
 endif # BUILD_WITH_TFM
 
 menu "Nordic nRF Connect"
+
+# Hides child parent configuration options
+config HIDE_CHILD_PARENT_CONFIG
+	bool
+	default y if "$(HIDE_CHILD_PARENT_CONFIG)" = "True"
+	default n
 
 # Override boot banner
 config BOOT_BANNER_STRING

--- a/alt-test-config/samples/boards/nrf/nrf53_sync_rtc/sample.yaml
+++ b/alt-test-config/samples/boards/nrf/nrf53_sync_rtc/sample.yaml
@@ -1,0 +1,27 @@
+sample:
+  description: This app shows how RTCs are synchronized
+      on nrf53 cores.
+  name: nRF53 Synchronized RTC sample
+common:
+  sysbuild: true
+  extra_args:
+    - SB_CONFIG_PARTITION_MANAGER=n
+tests:
+  sample.boards.nrf.nrf53_sync_rtc.real_hw:
+    platform_allow:
+      - nrf5340dk_nrf5340_cpuapp
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp
+    harness: remote
+  sample.boards.nrf.nrf53_sync_rtc.simu:
+    platform_allow:
+      - nrf5340bsim_nrf5340_cpuapp
+    harness: console
+    harness_config:
+      type: multi_line
+      ordered: false
+      regex:
+        - "main: Synchronization using mbox driver"
+        - "sync_rtc: Updated timestamp to synchronized RTC by .* ticks"
+        - "main: IPC send at .* ticks"
+        - "main: Local timestamp: .*, application core timestamp:"

--- a/alt-test-config/samples/drivers/mbox/sample.yaml
+++ b/alt-test-config/samples/drivers/mbox/sample.yaml
@@ -1,0 +1,28 @@
+sample:
+  name: MBOX IPC sample
+common:
+  sysbuild: true
+  tags: mbox
+  extra_args:
+    - SB_CONFIG_PARTITION_MANAGER=n
+tests:
+  sample.drivers.mbox.real_hw:
+    platform_allow:
+      - nrf5340dk_nrf5340_cpuapp
+      - adp_xc7k_ae350
+      - mimxrt595_evk_cm33
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp
+    harness: remote
+  sample.drivers.mbox.simu:
+    platform_allow:
+      - nrf5340bsim_nrf5340_cpuapp
+    harness: console
+    harness_config:
+      type: multi_line
+      ordered: false
+      regex:
+        - "Ping \\(on channel 0\\)"
+        - "Pong \\(on channel 0\\)"
+        - "Ping \\(on channel 1\\)"
+        - "Pong \\(on channel 1\\)"

--- a/alt-test-config/samples/subsys/ipc/ipc_service/icmsg/sample.yaml
+++ b/alt-test-config/samples/subsys/ipc/ipc_service/icmsg/sample.yaml
@@ -1,0 +1,12 @@
+sample:
+  name: IPC Service example integration (icmsg backend)
+tests:
+  sample.ipc.icmsg:
+    platform_allow: nrf5340dk_nrf5340_cpuapp
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp
+    tags: ipc
+    sysbuild: true
+    harness: remote
+    extra_args:
+      - SB_CONFIG_PARTITION_MANAGER=n

--- a/alt-test-config/samples/subsys/ipc/ipc_service/multi_endpoint/sample.yaml
+++ b/alt-test-config/samples/subsys/ipc/ipc_service/multi_endpoint/sample.yaml
@@ -1,0 +1,22 @@
+sample:
+  name: IPC Service example integration (icmsg multi endpoint backend)
+tests:
+  sample.ipc.multi_endpoint:
+    platform_allow: nrf5340dk_nrf5340_cpuapp
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp
+    tags: ipc
+    sysbuild: true
+    harness: remote
+    extra_args:
+      - SB_CONFIG_PARTITION_MANAGER=n
+  sample.ipc.multi_endpoint.icbmsg:
+    platform_allow: nrf5340dk_nrf5340_cpuapp
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp
+    tags: ipc
+    sysbuild: true
+    extra_args:
+      - DTC_OVERLAY_FILE=boards/nrf5340dk_nrf5340_cpuapp_icbmsg.overlay
+      - remote_DTC_OVERLAY_FILE=boards/nrf5340dk_nrf5340_cpunet_icbmsg.overlay
+      - SB_CONFIG_PARTITION_MANAGER=n

--- a/alt-test-config/samples/subsys/ipc/ipc_service/static_vrings/sample.yaml
+++ b/alt-test-config/samples/subsys/ipc/ipc_service/static_vrings/sample.yaml
@@ -1,0 +1,12 @@
+sample:
+  name: IPC Service example integration (OpenAMP static_vrings backend)
+tests:
+  sample.ipc.static_vrings:
+    platform_allow: nrf5340dk_nrf5340_cpuapp
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp
+    tags: ipc
+    sysbuild: true
+    harness: remote
+    extra_args:
+      - SB_CONFIG_PARTITION_MANAGER=n

--- a/alt-test-config/samples/subsys/logging/multidomain/sample.yaml
+++ b/alt-test-config/samples/subsys/logging/multidomain/sample.yaml
@@ -1,0 +1,33 @@
+sample:
+  name: Logging in multi-domain environment
+common:
+  sysbuild: true
+  tags: ipc
+  extra_args:
+    - SB_CONFIG_PARTITION_MANAGER=n
+tests:
+  sample.logging.multidomain.ipc_static_vrings.hw:
+    platform_allow:
+      - nrf5340dk_nrf5340_cpuapp
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp
+    build_only: true
+  sample.logging.multidomain.ipc_static_vrings.simu:
+    platform_allow:
+      - nrf5340bsim_nrf5340_cpuapp
+    integration_platforms:
+      - nrf5340bsim_nrf5340_cpuapp
+    harness: console
+    harness_config:
+      type: multi_line
+      ordered: false
+      regex:
+        - "IPC-service REMOTE \\[INST 1\\] demo started"
+        - "app: loop: 0"
+        - "app: ipc open"
+        - "app: wait for bound"
+        - "app: bounded"
+        - "app: REMOTE \\[1\\]: 0"
+        - "app: HOST \\[1\\]: 1"
+        - "IPC-service REMOTE \\[INST 1\\] demo ended."
+        - "app: IPC-service HOST \\[INST 1\\] demo ended."

--- a/alt-test-config/tests/boot/mcuboot_recovery_retention/testcase.yaml
+++ b/alt-test-config/tests/boot/mcuboot_recovery_retention/testcase.yaml
@@ -1,0 +1,42 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+common:
+  sysbuild: true
+  timeout: 10
+  harness: console
+  harness_config:
+    type: multi_line
+    regex:
+      - "mcuboot_status: 0"
+      - "mcuboot_status: 1"
+      - "mcuboot_status: 2"
+      - "Waiting..."
+      - "mcuboot_status: 0"
+      - "mcuboot_status: 1"
+      - "mcuboot_status: 8"
+      - "Starting bootloader"
+      - "Secondary image: magic"
+      - "Boot source: none"
+  extra_args:
+    - SB_CONFIG_PARTITION_MANAGER=n
+tests:
+  bootloader.mcuboot.recovery.retention:
+    platform_allow: nrf52840dk_nrf52840
+    tags:
+      - mcuboot
+      - sysbuild
+      - recovery
+  bootloader.mcuboot.recovery.retention.mem:
+    platform_allow: nrf52840dk_nrf52840
+    extra_args:
+      - OVERLAY_CONFIG="boards/nrf52840dk_nrf52840_mem.conf"
+      - DTC_OVERLAY_FILE="boards/nrf52840dk_nrf52840_mem.overlay"
+      - mcuboot_TARGET_OVERLAY_CONFIG="boards/nrf52840dk_nrf52840_mem.conf"
+      - mcuboot_TARGET_DTC_OVERLAY_FILE="boards/nrf52840dk_nrf52840_mem.overlay"
+    tags:
+      - mcuboot
+      - sysbuild
+      - recovery

--- a/alt-test-config/tests/boot/test_mcuboot/testcase.yaml
+++ b/alt-test-config/tests/boot/test_mcuboot/testcase.yaml
@@ -1,0 +1,37 @@
+common:
+  sysbuild: true
+  harness: console
+  harness_config:
+    type: multi_line
+    regex:
+      - "I: Starting bootloader"
+      - "Launching primary slot application on (.*)"
+      - "Secondary application ready for swap, rebooting"
+      - "I: Starting swap using (.*)"
+      - "Swapped application booted on (.*)"
+  extra_args:
+    - SB_CONFIG_PARTITION_MANAGER=n
+tests:
+  bootloader.mcuboot:
+    tags: mcuboot
+    platform_allow:
+      - frdm_k64f
+      - mimxrt1020_evk
+      - mimxrt1024_evk
+      - mimxrt1050_evk
+      - mimxrt1060_evk
+      - mimxrt1064_evk
+      - mimxrt1160_evk_cm7
+      - mimxrt1170_evk_cm7
+      - mimxrt595_evk_cm33
+      - mimxrt685_evk_cm33
+      - nrf52840dk_nrf52840
+    integration_platforms:
+      - frdm_k64f
+      - nrf52840dk_nrf52840
+  bootloader.mcuboot.assert:
+    tags: mcuboot
+    platform_allow:
+      - b_u585i_iot02a
+    extra_configs:
+      - CONFIG_ASSERT=y

--- a/scripts/ci/license_allow_list.yaml
+++ b/scripts/ci/license_allow_list.yaml
@@ -45,6 +45,7 @@ Apache-2.0: |
   ^nrf/tests/bluetooth/tester/src/main.c$
   ^nrf/subsys/nrf_security/src/legacy
   ^nrf/modules/trusted-firmware-m/fault.c
+  ^nrf/alt-test-config/
 curl: "^nrf/ext/"
 MIT: "^nrf/ext/"
 BSD-3-CLAUSE: |

--- a/subsys/partition_manager/Kconfig.template.build_strategy
+++ b/subsys/partition_manager/Kconfig.template.build_strategy
@@ -1,3 +1,5 @@
+if !HIDE_CHILD_PARENT_CONFIG
+
 choice
 	prompt "$(module) build strategy"
 	default $(module)_BUILD_STRATEGY_FROM_SOURCE
@@ -28,3 +30,5 @@ config $(module)_BUILD_STRATEGY_FROM_SOURCE
 	select PARTITION_MANAGER_ENABLED
 
 endchoice
+
+endif

--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -184,8 +184,10 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
       )
     endif()
 
-    # Use NCS signing script with support for PM
-    set(${DEFAULT_IMAGE}_SIGNING_SCRIPT "${ZEPHYR_NRF_MODULE_DIR}/cmake/sysbuild/image_signing.cmake" CACHE INTERNAL "MCUboot signing script" FORCE)
+    if(SB_CONFIG_PARTITION_MANAGER)
+      # Use NCS signing script with support for PM
+      set(${DEFAULT_IMAGE}_SIGNING_SCRIPT "${ZEPHYR_NRF_MODULE_DIR}/cmake/sysbuild/image_signing.cmake" CACHE INTERNAL "MCUboot signing script" FORCE)
+    endif()
 
     set(imgtool_extra)
     if(SB_CONFIG_MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION)

--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -68,6 +68,14 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
   cmake_parse_arguments(PRE_CMAKE "" "" "IMAGES" ${ARGN})
   restore_ncs_vars()
 
+  if(NOT SB_CONFIG_PARTITION_MANAGER)
+    # Disable any Kconfigs for child images in the main application
+    foreach(config NCS_SAMPLE_EMPTY_APP_CORE_CHILD_IMAGE NCS_INCLUDE_RPMSG_CHILD_IMAGE NCS_SAMPLE_REMOTE_SHELL_CHILD_IMAGE
+            NCS_SAMPLE_DTM_REMOTE_HCI_CHILD_IMAGE NCS_SAMPLE_PERIPHERAL_RADIO_TEST_CHILD_IMAGE PM_SINGLE_IMAGE)
+      set_config_bool(${DEFAULT_IMAGE} CONFIG_${config} n)
+    endforeach()
+  endif()
+
   foreach(image ${PRE_CMAKE_IMAGES})
     if(SB_CONFIG_PARTITION_MANAGER)
       set_config_bool(${image} CONFIG_PARTITION_MANAGER_ENABLED y)


### PR DESCRIPTION
    sysbuild: Disable child image Kconfigs when PM is disabled
    
    Prevents PM being enabled when it should be disabled in zephyr
    tests by disabling child image Kconfigs that enable the PM
    Kconfig option


    sysbuild: Hide child/parent Kconfig options
    
    Disables configuration options for child/parent images


    sysbuild: Do not set signing script if PM is disabled
    
    Leave the default zephyr signing script if partition manager is
    not enabled when using sysbuild


    alt-test-config: Add alternative zephyr test configuration
    
    Adds alternative test configuration files that will be used
    instead of the zephyr ones to ensure partition manager is
    disabled. Base files taken from zephyr commit
    23cf38934c0f68861e403b22bc3dd0ce6efbfa39


Hiding child/parent Kconfig will not work as requires commit from ongoing upmerge in sdk-zephyr