### PR TITLE
tests: samples: Add platform_allow section to configs without it

### DIFF
--- a/samples/app_event_manager/sample.yaml
+++ b/samples/app_event_manager/sample.yaml
@@ -15,6 +15,14 @@ common:
 tests:
   sample.app_event_manager:
     build_only: false
+    platform_allow:
+      - qemu_cortex_m3
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuapp_ns
+      - nrf9160dk_nrf9160_ns
+      - nrf21540dk_nrf52840
     integration_platforms:
       - qemu_cortex_m3
       - nrf52dk_nrf52832
@@ -25,6 +33,14 @@ tests:
       - nrf21540dk_nrf52840
   sample.app_event_manager_shell:
     build_only: false
+    platform_allow:
+      - qemu_cortex_m3
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuapp_ns
+      - nrf9160dk_nrf9160_ns
+      - nrf21540dk_nrf52840
     integration_platforms:
       - qemu_cortex_m3
       - nrf52dk_nrf52832

--- a/samples/app_event_manager_profiler_tracer/sample.yaml
+++ b/samples/app_event_manager_profiler_tracer/sample.yaml
@@ -5,6 +5,11 @@ tests:
   sample.app_event_manager_profiler_tracer:
     build_only: true
     platform_exclude: native_posix
+    platform_allow:
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf9160dk_nrf9160_ns
+      - nrf21540dk_nrf52840
     integration_platforms:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840

--- a/samples/edge_impulse/data_forwarder/sample.yaml
+++ b/samples/edge_impulse/data_forwarder/sample.yaml
@@ -4,6 +4,12 @@ sample:
 tests:
   sample.ei_data_forwarder:
     build_only: true
+    platform_allow:
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuapp_ns
+      - nrf9160dk_nrf9160_ns
     integration_platforms:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840

--- a/samples/edge_impulse/wrapper/sample.yaml
+++ b/samples/edge_impulse/wrapper/sample.yaml
@@ -12,6 +12,13 @@ common:
       - "Value: 0[.]0[0-9]+\tLabel: idle"
       - "Anomaly: (-[0-9]+[.][0-9]+)|(0[.]0[0-9]+)"
     type: multi_line
+  platform_allow:
+    - nrf52dk_nrf52832
+    - nrf52840dk_nrf52840
+    - nrf5340dk_nrf5340_cpuapp
+    - nrf5340dk_nrf5340_cpuapp_ns
+    - nrf9160dk_nrf9160_ns
+    - qemu_cortex_m3
   integration_platforms:
     - nrf52dk_nrf52832
     - nrf52840dk_nrf52840

--- a/samples/nrf_profiler/sample.yaml
+++ b/samples/nrf_profiler/sample.yaml
@@ -9,5 +9,10 @@ tests:
       - nrf52840dk_nrf52840
       - nrf9160dk_nrf9160_ns
       - nrf21540dk_nrf52840
+    platform_allow:
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf9160dk_nrf9160_ns
+      - nrf21540dk_nrf52840
     platform_exclude: native_posix qemu_x86 qemu_cortex_m3
     tags: ci_build

--- a/samples/peripheral/lpuart/sample.yaml
+++ b/samples/peripheral/lpuart/sample.yaml
@@ -4,6 +4,13 @@ sample:
 tests:
   sample.peripheral.lpuart:
     build_only: true
+    platform_allow:
+      - nrf52dk_nrf52832
+      - nrf52833dk_nrf52833
+      - nrf52840dk_nrf52840
+      - nrf9160dk_nrf9160_ns
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf21540dk_nrf52840
     integration_platforms:
       - nrf52dk_nrf52832
       - nrf52833dk_nrf52833

--- a/tests/drivers/nrfx_integration_test/testcase.yaml
+++ b/tests/drivers/nrfx_integration_test/testcase.yaml
@@ -3,6 +3,13 @@ tests:
     build_only: true
     filter: CONFIG_HAS_NRFX
     tags: drivers ci_build
+    platform_allow:
+      - nrf52840dk_nrf52840
+      - nrf9160dk_nrf9160
+      - nrf9160dk_nrf9160_ns
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuapp_ns
+      - nrf5340dk_nrf5340_cpunet
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf9160dk_nrf9160
@@ -16,6 +23,9 @@ tests:
     tags: drivers ci_build
     extra_configs:
       - CONFIG_NRFX_AND_BT_LL_SOFTDEVICE=y
+    platform_allow:
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpunet
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpunet
@@ -25,6 +35,9 @@ tests:
     tags: drivers ci_build
     extra_configs:
       - CONFIG_NRFX_AND_BT_LL_SW_SPLIT=y
+    platform_allow:
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpunet
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpunet

--- a/tests/lib/edge_impulse/testcase.yaml
+++ b/tests/lib/edge_impulse/testcase.yaml
@@ -1,6 +1,11 @@
 tests:
   edge_impulse.ei_wrapper:
     platform_exclude: native_posix qemu_x86
+    platform_allow:
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf9160dk_nrf9160_ns
+      - qemu_cortex_m3
     integration_platforms:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840

--- a/tests/subsys/app_event_manager/testcase.yaml
+++ b/tests/subsys/app_event_manager/testcase.yaml
@@ -1,5 +1,10 @@
 tests:
   app_event_manager.core:
+    platform_allow:
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf9160dk_nrf9160_ns
+      - qemu_cortex_m3
     integration_platforms:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
@@ -8,6 +13,11 @@ tests:
     tags: app_event_manager
   app_event_manager.size_enabled:
     extra_args: OVERLAY_CONFIG=overlay-event_size.conf
+    platform_allow:
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf9160dk_nrf9160_ns
+      - qemu_cortex_m3
     integration_platforms:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840

--- a/tests/subsys/bluetooth/fast_pair/storage/account_key_storage/testcase.yaml
+++ b/tests/subsys/bluetooth/fast_pair/storage/account_key_storage/testcase.yaml
@@ -1,5 +1,11 @@
 tests:
   fast_pair.storage.account_key_storage.default:
+    platform_allow:
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf9160dk_nrf9160_ns
+      - qemu_cortex_m3
     integration_platforms:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
@@ -7,22 +13,32 @@ tests:
       - nrf9160dk_nrf9160_ns
       - qemu_cortex_m3
   fast_pair.storage.account_key_storage.6keys:
+    platform_allow:
+      - qemu_cortex_m3
     integration_platforms:
       - qemu_cortex_m3
     extra_args: CONFIG_BT_FAST_PAIR_STORAGE_ACCOUNT_KEY_MAX=6
   fast_pair.storage.account_key_storage.7keys:
+    platform_allow:
+      - qemu_cortex_m3
     integration_platforms:
       - qemu_cortex_m3
     extra_args: CONFIG_BT_FAST_PAIR_STORAGE_ACCOUNT_KEY_MAX=7
   fast_pair.storage.account_key_storage.8keys:
+    platform_allow:
+      - qemu_cortex_m3
     integration_platforms:
       - qemu_cortex_m3
     extra_args: CONFIG_BT_FAST_PAIR_STORAGE_ACCOUNT_KEY_MAX=8
   fast_pair.storage.account_key_storage.9keys:
+    platform_allow:
+      - qemu_cortex_m3
     integration_platforms:
       - qemu_cortex_m3
     extra_args: CONFIG_BT_FAST_PAIR_STORAGE_ACCOUNT_KEY_MAX=9
   fast_pair.storage.account_key_storage.10keys:
+    platform_allow:
+      - qemu_cortex_m3
     integration_platforms:
       - qemu_cortex_m3
     extra_args: CONFIG_BT_FAST_PAIR_STORAGE_ACCOUNT_KEY_MAX=10

--- a/tests/subsys/bluetooth/fast_pair/storage/factory_reset/testcase.yaml
+++ b/tests/subsys/bluetooth/fast_pair/storage/factory_reset/testcase.yaml
@@ -1,38 +1,56 @@
 tests:
   fast_pair.storage.factory_reset.default:
     platform_exclude: native_posix
+    platform_allow:
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf9160dk_nrf9160_ns
     integration_platforms:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf9160dk_nrf9160_ns
   fast_pair.storage.factory_reset.no_reboot:
+    platform_allow:
+      - native_posix
+      - nrf52840dk_nrf52840
     integration_platforms:
       - native_posix
       - nrf52840dk_nrf52840
     extra_args: CONFIG_REBOOT=n
   fast_pair.storage.factory_reset.6keys:
     platform_exclude: native_posix
+    platform_allow:
+      - nrf52840dk_nrf52840
     integration_platforms:
       - nrf52840dk_nrf52840
     extra_args: CONFIG_BT_FAST_PAIR_STORAGE_ACCOUNT_KEY_MAX=6
   fast_pair.storage.factory_reset.7keys:
     platform_exclude: native_posix
+    platform_allow:
+      - nrf52840dk_nrf52840
     integration_platforms:
       - nrf52840dk_nrf52840
     extra_args: CONFIG_BT_FAST_PAIR_STORAGE_ACCOUNT_KEY_MAX=7
   fast_pair.storage.factory_reset.8keys:
     platform_exclude: native_posix
+    platform_allow:
+      - nrf52840dk_nrf52840
     integration_platforms:
       - nrf52840dk_nrf52840
     extra_args: CONFIG_BT_FAST_PAIR_STORAGE_ACCOUNT_KEY_MAX=8
   fast_pair.storage.factory_reset.9keys:
     platform_exclude: native_posix
+    platform_allow:
+      - nrf52840dk_nrf52840
     integration_platforms:
       - nrf52840dk_nrf52840
     extra_args: CONFIG_BT_FAST_PAIR_STORAGE_ACCOUNT_KEY_MAX=9
   fast_pair.storage.factory_reset.10keys:
     platform_exclude: native_posix
+    platform_allow:
+      - nrf52840dk_nrf52840
     integration_platforms:
       - nrf52840dk_nrf52840
     extra_args: CONFIG_BT_FAST_PAIR_STORAGE_ACCOUNT_KEY_MAX=10

--- a/tests/subsys/nrf_profiler/testcase.yaml
+++ b/tests/subsys/nrf_profiler/testcase.yaml
@@ -1,6 +1,10 @@
 tests:
   nrf_profiler.core:
     platform_exclude: native_posix qemu_x86 qemu_cortex_m3
+    platform_allow:
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf9160dk_nrf9160_ns
     integration_platforms:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840

--- a/tests/unity/example_test/testcase.yaml
+++ b/tests/unity/example_test/testcase.yaml
@@ -3,3 +3,5 @@ tests:
     tags: example
     integration_platforms:
       - native_posix
+    platform_allow:
+      - native_posix

--- a/tests/unity/wrap_test/testcase.yaml
+++ b/tests/unity/wrap_test/testcase.yaml
@@ -1,5 +1,7 @@
 tests:
   unity.wrap_test:
     tags: wrap_test
+    platform_allow:
+      - native_posix
     integration_platforms:
       - native_posix


### PR DESCRIPTION
Entries in platform_allow are copies of integration_platforms. This change is needed for dynamic scope optimization for twister. A test_plan.py script selects which configurations to add to the scope. If a test is modified, it is scoped for all applicable platforms. This means for cases in the commit, selecting >600 platforms available in the upstream and nrf. Platform_allow works as a filter limiting the scope.