### PR TITLE
doc: fix macro name not surrounded by backticks

### DIFF
--- a/doc/nrf/libraries/others/app_event_manager.rst
+++ b/doc/nrf/libraries/others/app_event_manager.rst
@@ -141,7 +141,7 @@ To create a source file for the event type you defined in the header file:
 1. Include the header file for the new event type in your source file.
 #. Define the event type with the :c:macro:`APP_EVENT_TYPE_DEFINE` macro.
    Pass the name of the event type as declared in the header along with additional parameters.
-   For example, you can provide a function that logs a string version of the event data by using the :c:macro:APP_EVENT_MANAGER_LOG macro.
+   For example, you can provide a function that logs a string version of the event data by using the :c:macro:`APP_EVENT_MANAGER_LOG` macro.
    The :c:macro:`APP_EVENT_TYPE_DEFINE` macro adds flags as a last parameter.
    These flags are constant and can only be set using :c:macro:`APP_EVENT_FLAGS_CREATE` on :c:macro:`APP_EVENT_TYPE_DEFINE` macro.
    To not set any flag, use the :c:macro:`APP_EVENT_FLAGS_CREATE` macro without any argument.


### PR DESCRIPTION
Simple documentation fix where a macro name was not displaying correctly due to not being surrounded by backticks.