### PR TITLE
applications: nrf_desktop: Use watchdog0 alias in watchdog module

### DIFF
--- a/applications/nrf_desktop/doc/watchdog.rst
+++ b/applications/nrf_desktop/doc/watchdog.rst
@@ -27,6 +27,7 @@ Configuration
 
 The module uses Zephyr's :ref:`zephyr:watchdog_api` driver.
 For this reason, it automatically selects the :kconfig:option:`CONFIG_WATCHDOG` option.
+The ``watchdog0`` DTS alias determines the watchdog instance used by the module.
 
 The module is enabled by the :ref:`CONFIG_DESKTOP_WATCHDOG_ENABLE <config_desktop_app_options>` option.
 

--- a/applications/nrf_desktop/src/modules/watchdog.c
+++ b/applications/nrf_desktop/src/modules/watchdog.c
@@ -23,7 +23,7 @@ struct wdt_data_storage {
 };
 
 static struct wdt_data_storage wdt_data = {
-	.wdt = DEVICE_DT_GET(DT_NODELABEL(wdt)),
+	.wdt = DEVICE_DT_GET(DT_ALIAS(watchdog0)),
 };
 
 static void watchdog_feed_worker(struct k_work *work_desc)

--- a/boards/arm/nrf52810dmouse_nrf52810/nrf52810dmouse_nrf52810.dts
+++ b/boards/arm/nrf52810dmouse_nrf52810/nrf52810dmouse_nrf52810.dts
@@ -18,6 +18,11 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 	};
+
+	/* These aliases are provided for compatibility with samples */
+	aliases {
+		watchdog0 = &wdt0;
+	};
 };
 
 &adc {

--- a/boards/arm/nrf52810dmouse_nrf52810/nrf52810dmouse_nrf52810.yaml
+++ b/boards/arm/nrf52810dmouse_nrf52810/nrf52810dmouse_nrf52810.yaml
@@ -9,5 +9,6 @@ toolchain:
 supported:
   - ble
   - gpio
+  - watchdog
 ram: 24
 flash: 192

--- a/boards/arm/nrf52820dongle_nrf52820/nrf52820dongle_nrf52820.dts
+++ b/boards/arm/nrf52820dongle_nrf52820/nrf52820dongle_nrf52820.dts
@@ -59,6 +59,7 @@
 		led1-blue  = &led1_blue;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led1_blue;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/nrf52820dongle_nrf52820/nrf52820dongle_nrf52820.yaml
+++ b/boards/arm/nrf52820dongle_nrf52820/nrf52820dongle_nrf52820.yaml
@@ -11,3 +11,4 @@ toolchain:
   - netif:openthread
 supported:
   - gpio
+  - watchdog

--- a/boards/arm/nrf52833dongle_nrf52833/nrf52833dongle_nrf52833.dts
+++ b/boards/arm/nrf52833dongle_nrf52833/nrf52833dongle_nrf52833.dts
@@ -59,6 +59,7 @@
 		led1-blue  = &led1_blue;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led1_blue;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/nrf52833dongle_nrf52833/nrf52833dongle_nrf52833.yaml
+++ b/boards/arm/nrf52833dongle_nrf52833/nrf52833dongle_nrf52833.yaml
@@ -10,4 +10,5 @@ toolchain:
   - xtools
 supported:
   - gpio
+  - watchdog
   - netif:openthread

--- a/boards/arm/nrf52840gmouse_nrf52840/nrf52840gmouse_nrf52840.dts
+++ b/boards/arm/nrf52840gmouse_nrf52840/nrf52840gmouse_nrf52840.dts
@@ -18,6 +18,11 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 	};
+
+	/* These aliases are provided for compatibility with samples */
+	aliases {
+		watchdog0 = &wdt0;
+	};
 };
 
 &gpiote {

--- a/boards/arm/nrf52840gmouse_nrf52840/nrf52840gmouse_nrf52840.yaml
+++ b/boards/arm/nrf52840gmouse_nrf52840/nrf52840gmouse_nrf52840.yaml
@@ -11,5 +11,6 @@ supported:
   - usb_device
   - ble
   - gpio
+  - watchdog
   - ieee802154
   - netif:openthread

--- a/boards/arm/nrf52dmouse_nrf52832/nrf52dmouse_nrf52832.dts
+++ b/boards/arm/nrf52dmouse_nrf52832/nrf52dmouse_nrf52832.dts
@@ -18,6 +18,11 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 	};
+
+	/* These aliases are provided for compatibility with samples */
+	aliases {
+		watchdog0 = &wdt0;
+	};
 };
 
 &adc {

--- a/boards/arm/nrf52dmouse_nrf52832/nrf52dmouse_nrf52832.yaml
+++ b/boards/arm/nrf52dmouse_nrf52832/nrf52dmouse_nrf52832.yaml
@@ -9,5 +9,6 @@ toolchain:
 supported:
   - ble
   - gpio
+  - watchdog
 ram: 64
 flash: 512

--- a/boards/arm/nrf52kbd_nrf52832/nrf52kbd_nrf52832.dts
+++ b/boards/arm/nrf52kbd_nrf52832/nrf52kbd_nrf52832.dts
@@ -18,6 +18,11 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 	};
+
+	/* These aliases are provided for compatibility with samples */
+	aliases {
+		watchdog0 = &wdt0;
+	};
 };
 
 &adc {

--- a/boards/arm/nrf52kbd_nrf52832/nrf52kbd_nrf52832.yaml
+++ b/boards/arm/nrf52kbd_nrf52832/nrf52kbd_nrf52832.yaml
@@ -10,3 +10,4 @@ flash: 512
 supported:
   - ble
   - gpio
+  - watchdog

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -211,6 +211,8 @@ nRF Desktop
   * Changed the term *flash memory* to *non-volatile memory* for generalization purposes.
   * The :ref:`nrf_desktop_usb_state` to use the :c:func:`usb_hid_set_proto_code` function to set the HID Boot Interface protocol code.
     The ``CONFIG_USB_HID_PROTOCOL_CODE`` Kconfig option is deprecated and a dedicated API needs to be used instead.
+  * The :ref:`nrf_desktop_watchdog` to use ``watchdog0`` DTS alias instead of ``wdt`` DTS node label.
+    Using the alias makes the configuration of the module more flexible.
 
 Thingy:53: Matter weather station
 ---------------------------------


### PR DESCRIPTION
Using the alias makes module's configuration more flexible.

Jira: NCSDK-25080