### PR TITLE
applications: asset_tracker_v2: Use signed 16 flavor for RSRP resource

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/lwm2m/lwm2m_codec_helpers.c
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/lwm2m/lwm2m_codec_helpers.c
@@ -924,8 +924,8 @@ int lwm2m_codec_helpers_set_neighbor_cell_data(struct cloud_data_neighbor_cells 
 		return err;
 	}
 
-	err = lwm2m_set_s8(&LWM2M_OBJ(LWM2M_OBJECT_CONNECTIVITY_MONITORING_ID, 0, RSS),
-			   (int8_t)neighbor_cells->cell_data.current_cell.rsrp);
+	err = lwm2m_set_s16(&LWM2M_OBJ(LWM2M_OBJECT_CONNECTIVITY_MONITORING_ID, 0, RSS),
+			    neighbor_cells->cell_data.current_cell.rsrp);
 	if (err) {
 		return err;
 	}

--- a/applications/asset_tracker_v2/tests/lwm2m_codec_helpers/src/lwm2m_codec_helpers_test.c
+++ b/applications/asset_tracker_v2/tests/lwm2m_codec_helpers/src/lwm2m_codec_helpers_test.c
@@ -716,7 +716,7 @@ void test_codec_helpers_set_neighbor_cell_data(void)
 	__cmock_lwm2m_update_signal_meas_objects_ExpectAndReturn(
 		(const struct lte_lc_cells_info *)cells, 0);
 
-	__cmock_lwm2m_set_s8_ExpectAndReturn(
+	__cmock_lwm2m_set_s16_ExpectAndReturn(
 		&LWM2M_OBJ(LWM2M_OBJECT_CONNECTIVITY_MONITORING_ID, 0, RSS),
 		ncell.cell_data.current_cell.rsrp, 0);
 


### PR DESCRIPTION
Use signed 16 flavor for RSRP resource. The storage variable for RSRP has been changed in the connmon object. This is needed to avoid an error returned when writing to the variable using the signed 8 flavor.