### PR TITLE
lib: nrf_cloud: add nrf_cloud_coap_bytes_send

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -670,6 +670,7 @@ Libraries for networking
 
     * Automatic selection of proprietary PSM mode when building for the SOC_NRF9161_LACA.
     * Support for bulk transfers to the :c:func:`nrf_cloud_coap_json_message_send` function.
+    * Support for raw transfers to the :c:func:`nrf_cloud_coap_bytes_send` function.
 
   * Updated:
 

--- a/include/net/nrf_cloud_coap.h
+++ b/include/net/nrf_cloud_coap.h
@@ -298,6 +298,16 @@ int nrf_cloud_coap_shadow_delta_process(const struct nrf_cloud_data *in_data,
 					struct nrf_cloud_obj *const delta_out);
 
 /**
+ * @brief Send raw bytes to nRF Cloud.
+ *
+ * @param[in]     buf buffer with binary string.
+ * @param[in]     buf_len  length of buf in bytes.
+ * @retval 0 If successful.
+ *          Otherwise, a (negative) error code is returned.
+ */
+int nrf_cloud_coap_bytes_send(uint8_t *buf, size_t buf_len);
+
+/**
  * @brief Send an nRF Cloud object
  *
  * This only supports sending of the CoAP CBOR or JSON type objects or a pre-encoded CBOR buffer.

--- a/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap.c
+++ b/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap.c
@@ -32,6 +32,7 @@ LOG_MODULE_REGISTER(nrf_cloud_coap, CONFIG_NRF_CLOUD_COAP_LOG_LEVEL);
 #define COAP_D2C_RSC "msg/d2c"
 #define COAP_D2C_BULK_RSC "msg/d/%s/d2c/bulk"
 #define COAP_D2C_RSC_MAX_LEN MAX(sizeof(COAP_D2C_RSC), sizeof(COAP_D2C_BULK_RSC))
+#define COAP_D2C_RAW_RSC "/msg/d2c/raw"
 
 #define MAX_COAP_PAYLOAD_SIZE (CONFIG_COAP_CLIENT_BLOCK_SIZE - \
 			       CONFIG_COAP_CLIENT_MESSAGE_HEADER_SIZE)
@@ -211,6 +212,24 @@ int nrf_cloud_coap_pgps_url_get(struct nrf_cloud_rest_pgps_request const *const 
 	return err;
 }
 #endif /* CONFIG_NRF_CLOUD_PGPS */
+
+
+int nrf_cloud_coap_bytes_send(uint8_t *buf, size_t buf_len)
+{
+	int err = 0;
+
+	if (!nrf_cloud_coap_is_connected()) {
+		return -EACCES;
+	}
+
+	err = nrf_cloud_coap_post(COAP_D2C_RAW_RSC, NULL, buf, buf_len,
+				  COAP_CONTENT_FORMAT_APP_OCTET_STREAM, false, NULL, NULL);
+	if (err) {
+		LOG_ERR("Failed to send POST request: %d", err);
+	}
+	return err;
+}
+
 
 int nrf_cloud_coap_obj_send(struct nrf_cloud_obj *const obj)
 {


### PR DESCRIPTION
This patch adds a method to nRF Cloud CoAP to send raw bytes. (tested on dev stage)