### PR TITLE
doc: openthread: Update Thread tools documentation.

### DIFF
--- a/doc/nrf/protocols/thread/tools.rst
+++ b/doc/nrf/protocols/thread/tools.rst
@@ -281,13 +281,13 @@ Build the OpenThread POSIX applications by performing the following steps:
       ./script/bootstrap
 
 #. Build the applications with the required options.
-   For example, to build the ``ot-cli`` application with support for Thread v1.1, run the following command::
+   For example, to build the ``ot-cli`` application, run the following command::
 
-      ./script/cmake-build posix -DOT_THREAD_VERSION=1.1
+      ./script/cmake-build posix
 
-   Alternatively, to build the ``ot-daemon`` and ``ot-ctl`` applications with support for Thread v1.2, run the following command::
+   Alternatively, to build the ``ot-daemon`` and ``ot-ctl`` applications, run the following command::
 
-      ./script/cmake-build posix -DOT_THREAD_VERSION=1.2 -DOT_DAEMON=ON
+      ./script/cmake-build posix -DOT_DAEMON=ON
 
 You can find the generated applications in :file:`./build/posix/src/posix/`.
 
@@ -298,19 +298,21 @@ Use the following radio URL parameter to connect to an RCP node.
 
 .. code-block:: console
 
-   'spinel+hdlc+uart://\ *ncp_uart_device*\ ?uart-baudrate=\ *baud_rate*'
+   'spinel+hdlc+uart://\ *ncp_uart_device*\ ?uart-baudrate=\ *baud_rate*' -B *backbone_link*
 
 Replace the following parameters:
 
    * *ncp_uart_device* - Specifies the location of the device, for example: :file:`/dev/ttyACM0`.
    * *baud_rate* - Specifies the baud rate to use.
      The Thread Co-Processor sample supports baud rate ``1000000``.
+   * *backbone_link* - Specifies Backbone link for communication with external network.
+     This parameter can be omitted.
 
 For example, to use ``ot-daemon``, enter the following command:
 
 .. code-block:: console
 
-   sudo ./build/posix/src/posix/ot-daemon 'spinel+hdlc+uart:///dev/ttyACM0?uart-baudrate=1000000' --verbose
+   sudo ./build/posix/src/posix/ot-daemon 'spinel+hdlc+uart:///dev/ttyACM0?uart-baudrate=1000000' --verbose -B eth0
 
 And on a separate terminal window:
 
@@ -322,4 +324,4 @@ To use ``ot-cli``, enter the following command instead:
 
 .. code-block:: console
 
-   sudo ./build/posix/src/posix/ot-cli 'spinel+hdlc+uart:///dev/ttyACM0?uart-baudrate=1000000' --verbose
+   sudo ./build/posix/src/posix/ot-cli 'spinel+hdlc+uart:///dev/ttyACM0?uart-baudrate=1000000' --verbose -B eth0


### PR DESCRIPTION
Commit fixes:
	- `ot-daemon` invoke command
	- change default `ot-daemon` build command to build with newest thread version.