### PR TITLE
Revert "net: lib: nrf_cloud: Update CoAP to support QZSS"

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -555,7 +555,6 @@ Libraries for networking
 
     * The :c:func:`nrf_cloud_coap_shadow_delta_process` function to include a parameter for application-specific shadow data.
     * The :c:func:`nrf_cloud_coap_shadow_delta_process` function to process default shadow data added by nRF Cloud, which is not used by CoAP.
-    * To use new AGNSS endpoint that adds support for the QZSS constellation.
 
 * :ref:`lib_nrf_cloud_log` library:
 

--- a/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap.c
+++ b/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap.c
@@ -24,7 +24,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(nrf_cloud_coap, CONFIG_NRF_CLOUD_COAP_LOG_LEVEL);
 
-#define COAP_AGPS_RSC "loc/agnss"
+#define COAP_AGPS_RSC "loc/agps"
 #define COAP_PGPS_RSC "loc/pgps"
 #define COAP_GND_FIX_RSC "loc/ground-fix"
 #define COAP_FOTA_GET_RSC "fota/exec/current"
@@ -117,6 +117,11 @@ int nrf_cloud_coap_agnss_data_get(struct nrf_cloud_rest_agnss_request const *con
 	static uint8_t buffer[AGNSS_GET_CBOR_MAX_SIZE];
 	size_t len = sizeof(buffer);
 	int err;
+
+	/* QZSS assistance is not yet supported with CoAP, make sure we only ask for GPS. */
+	if (request->type == NRF_CLOUD_REST_AGNSS_REQ_CUSTOM) {
+		request->agnss_req->system_count = 1;
+	}
 
 	err = coap_codec_agnss_encode(request, buffer, &len,
 				     COAP_CONTENT_FORMAT_APP_CBOR);

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_agnss.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_agnss.c
@@ -58,11 +58,11 @@ bool nrf_cloud_agnss_request_in_progress(void)
 #if IS_ENABLED(CONFIG_NRF_CLOUD_AGNSS)
 int nrf_cloud_agnss_request(const struct nrf_modem_gnss_agnss_data_frame *request)
 {
-	/* GPS data needed is always expected to be present and first in list. */
+	/* GPS data need is always expected to be present and first in list. */
 	__ASSERT(request->system_count > 0,
-		 "GNSS system data needed not found");
+		 "GNSS system data need not found");
 	__ASSERT(request->system[0].system_id == NRF_MODEM_GNSS_SYSTEM_GPS,
-		 "GPS data needed not found");
+		 "GPS data need not found");
 
 #if IS_ENABLED(CONFIG_NRF_CLOUD_MQTT)
 	if (nfsm_get_current_state() != STATE_DC_CONNECTED) {
@@ -119,8 +119,16 @@ int nrf_cloud_agnss_request(const struct nrf_modem_gnss_agnss_data_frame *reques
 
 static bool qzss_assistance_is_supported(void)
 {
-	/* Assume that all cellular products other than the nRF9160 support this. */
-	return (IS_ENABLED(CONFIG_NRF_MODEM_LIB) && !IS_ENABLED(CONFIG_SOC_NRF9160));
+	char resp[32];
+
+	if (nrf_modem_at_cmd(resp, sizeof(resp), "AT+CGMM") == 0) {
+		/* nRF9160 does not support QZSS assistance, while nRF91x1 do. */
+		if (strstr(resp, "nRF9160") != NULL) {
+			return false;
+		}
+	}
+
+	return true;
 }
 
 int nrf_cloud_agnss_request_all(void)


### PR DESCRIPTION
This reverts commit 43dcee5b87298781746df22bb6fcae76cd3c35d8.

The agnss resource is not yet deployed to the
production server.