### PR TITLE
manifest: sdk-hostap: Pull revert of the DHCP workaround

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -111,7 +111,7 @@ manifest:
     - name: hostap
       repo-path: sdk-hostap
       path: modules/lib/hostap
-      revision: 006334c73645bacf4d2ce940fe1e9a0bc5337b15
+      revision: pull/142/head
       userdata:
         ncs:
           upstream-url: https://w1.fi/cgit/hostap/


### PR DESCRIPTION
This removes sending unnecessary dummy frame after connection.