### PR TITLE
applications: serial_lte_modem: second half implementation of PPP

### DIFF
--- a/applications/serial_lte_modem/Kconfig
+++ b/applications/serial_lte_modem/Kconfig
@@ -162,6 +162,10 @@ config SLM_FULL_FOTA
 
 config SLM_PPP
 	bool "PPP support in SLM"
+	help
+	  When enabled, SLM automatically brings up/down the PPP link
+	  when the LTE link (default PDN) is connected/disconnected,
+	  regardless of what is done with AT#XPPP.
 
 rsource "src/ftp_c/Kconfig"
 rsource "src/mqtt_c/Kconfig"

--- a/applications/serial_lte_modem/doc/AT_commands_intro.rst
+++ b/applications/serial_lte_modem/doc/AT_commands_intro.rst
@@ -48,3 +48,4 @@ The modem-specific AT commands are documented in the `nRF91x1 AT Commands Refere
    GPIO_AT_commands
    CARRIER_AT_commands
    NRFCLOUD_AT_commands
+   PPP_AT_commands

--- a/applications/serial_lte_modem/doc/PPP_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/PPP_AT_commands.rst
@@ -1,0 +1,95 @@
+.. _SLM_AT_PPP:
+
+PPP AT commands
+****************
+
+.. contents::
+   :local:
+   :depth: 2
+
+This page describes PPP-related AT commands.
+
+Control PPP #XPPP
+=================
+
+Set command
+-----------
+
+The set command allows you to start and stop PPP.
+
+Syntax
+~~~~~~
+
+::
+
+   #XPPP=<op>
+
+* The ``<op>`` parameter can be the following:
+
+  * ``0`` - Stop PPP.
+  * ``1`` - Start PPP.
+    If PPP is already started, it is first stopped before being started again.
+
+.. note::
+
+   PPP is automatically started and stopped when the default PDN connection is established and lost, respectively.
+   This happens even if PPP has previously been stopped or started with this command.
+
+Read command
+------------
+
+The read command allows you to get the status of PPP.
+
+Syntax
+~~~~~~
+
+::
+
+   #XPPP?
+
+Response syntax
+~~~~~~~~~~~~~~~
+
+::
+
+   #XPPP: <running>,<peer_connected>
+
+* The ``<running>`` parameter is an integer that indicates whether PPP is running.
+  It is ``1`` for running or ``0`` for stopped.
+
+* The ``<peer_connected>`` parameter is an integer that indicates whether a peer is connected to PPP.
+  It is ``1`` for connected or ``0`` for not connected.
+
+Test command
+------------
+
+The test command is not supported.
+
+Example
+-------
+
+::
+
+  AT+CFUN=1
+
+  OK
+  // Wait for network registration. PPP is automatically started.
+  AT#XPPP?
+
+  #XPPP: 1,0
+
+  OK
+  // Have the peer connect to SLM's PPP. The read command shows that a peer is connected.
+  AT#XPPP?
+
+  #XPPP: 1,1
+
+  OK
+  AT+CFUN=4
+
+  OK
+  AT#XPPP?
+
+  #XPPP: 0,0
+
+  OK

--- a/applications/serial_lte_modem/src/slm_at_host.c
+++ b/applications/serial_lte_modem/src/slm_at_host.c
@@ -658,6 +658,14 @@ AT_MONITOR(at_notify, ANY, notification_handler);
 static void notification_handler(const char *notification)
 {
 	if (get_slm_mode() == SLM_AT_COMMAND_MODE) {
+
+#if defined(CONFIG_SLM_PPP)
+		if (!slm_fwd_cgev_notifs
+		 && !strncmp(notification, "+CGEV: ", strlen("+CGEV: "))) {
+			/* CGEV notifications are silenced. Do not forward them. */
+			return;
+		}
+#endif
 		(void)slm_uart_tx_write(CRLF_STR, strlen(CRLF_STR), true, true);
 		(void)slm_uart_tx_write(notification, strlen(notification), true, false);
 	}

--- a/applications/serial_lte_modem/src/slm_ppp.c
+++ b/applications/serial_lte_modem/src/slm_ppp.c
@@ -7,6 +7,8 @@
 #include "slm_ppp.h"
 #include "slm_at_host.h"
 #include "slm_util.h"
+#include <modem/at_cmd_custom.h>
+#include <modem/lte_lc.h>
 #include <modem/pdn.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/ppp.h>
@@ -14,6 +16,12 @@
 #include <assert.h>
 
 LOG_MODULE_REGISTER(slm_ppp, CONFIG_SLM_LOG_LEVEL);
+
+/* This keeps track of whether the user is registered to the CGEV notifications.
+ * We need them to know when to start/stop the PPP link, but that should not
+ * influence what the user receives, so we do the filtering based on this.
+ */
+bool slm_fwd_cgev_notifs;
 
 static const struct device *ppp_uart_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_ppp_uart));
 static int ppp_iface_idx;
@@ -25,6 +33,10 @@ static struct sockaddr_ll ppp_zephyr_dst_addr;
 static struct k_thread ppp_data_passing_thread_id;
 static K_THREAD_STACK_DEFINE(ppp_data_passing_thread_stack, KB(2));
 static void ppp_data_passing_thread(void*, void*, void*);
+
+static struct k_work ppp_restart_work;
+
+static bool ppp_peer_connected;
 
 /* We use only the default PDP context. */
 enum { PDP_CID = 0 };
@@ -192,8 +204,155 @@ static void slm_ppp_stop(void)
 	LOG_INF("PPP stopped.");
 }
 
+/* Automatically starts/stops PPP when the default PDN connection goes up/down. */
+static void pdp_ctx_event_handler(uint8_t cid, enum pdn_event event, int reason)
+{
+	switch (event) {
+	case PDN_EVENT_ACTIVATED:
+		LOG_INF("Connection up. Starting PPP.");
+		k_work_submit_to_queue(&slm_work_q, &ppp_restart_work);
+		break;
+	case PDN_EVENT_DEACTIVATED:
+		if (slm_ppp_is_started()) {
+			LOG_INF("Connection down. Stopping PPP.");
+			slm_ppp_stop();
+		} else {
+			LOG_DBG("Connection down.");
+		}
+		break;
+	default:
+		LOG_DBG("Default PDN connection event %d received.", event);
+		break;
+	}
+}
+
+/* We need to receive CGEV notifications at all times.
+ * CGEREP AT commands are intercepted to prevent the user
+ * from unsubcribing us and make that behavior invisible.
+ */
+AT_CMD_CUSTOM(at_cgerep_interceptor, "AT+CGEREP", at_cgerep_callback);
+
+static int at_cgerep_callback(char *buf, size_t len, char *at_cmd)
+{
+	int ret;
+	unsigned int subscribe;
+	const bool set_cmd = (sscanf(at_cmd, "AT+CGEREP=%u", &subscribe) == 1);
+
+	/* The modem interprets AT+CGEREP and AT+CGEREP= as AT+CGEREP=0.
+	 * Prevent those forms, only allowing AT+CGEREP=0, for simplicty.
+	 */
+	if (!set_cmd && (!strcmp(at_cmd, "AT+CGEREP") || !strcmp(at_cmd, "AT+CGEREP="))) {
+		LOG_ERR("The syntax %s is disallowed. Use AT+CGEREP=0 instead.", at_cmd);
+		return -EINVAL;
+	}
+	if (!set_cmd || subscribe) {
+		/* Forward the command to the modem only if not unsubscribing. */
+		ret = slm_util_at_cmd_no_intercept(buf, len, at_cmd);
+		if (ret) {
+			return ret;
+		}
+		/* Modify the output of the read command to reflect the user's
+		 * subscription status, not that of the SLM.
+		 */
+		if (at_cmd[strlen("AT+CGEREP")] == '?') {
+			const size_t mode_idx = strlen("+CGEREP: ");
+
+			if (mode_idx < len) {
+				/* +CGEREP: <mode>,<bfr> */
+				buf[mode_idx] = '0' + slm_fwd_cgev_notifs;
+			}
+		}
+	} else { /* AT+CGEREP=0 */
+		snprintf(buf, len, "%s", "OK\r\n");
+	}
+
+	if (set_cmd) {
+		slm_fwd_cgev_notifs = subscribe;
+	}
+	return 0;
+}
+
+static void subscribe_cgev_notifications(void)
+{
+	char buf[sizeof("\r\nOK")];
+
+	/* Bypass the CGEREP interception above as it is meant for commands received externally. */
+	const int ret = slm_util_at_cmd_no_intercept(buf, sizeof(buf), "AT+CGEREP=1");
+
+	if (ret) {
+		LOG_ERR("Failed to subscribe to +CGEV notifications (%d).", ret);
+	}
+}
+
+/* Notification subscriptions are reset on CFUN=0.
+ * We intercept CFUN set commands to automatically subscribe.
+ */
+AT_CMD_CUSTOM(at_cfun_set_interceptor, "AT+CFUN=", at_cfun_set_callback);
+
+static int at_cfun_set_callback(char *buf, size_t len, char *at_cmd)
+{
+	unsigned int mode;
+	const int ret = slm_util_at_cmd_no_intercept(buf, len, at_cmd);
+
+	/* sscanf() doesn't match if this is a test command (it also gets intercepted). */
+	if (ret || sscanf(at_cmd, "AT+CFUN=%u", &mode) != 1) {
+		/* The functional mode cannot have changed. */
+		return ret;
+	}
+
+	if (mode == LTE_LC_FUNC_MODE_NORMAL || mode == LTE_LC_FUNC_MODE_ACTIVATE_LTE) {
+		subscribe_cgev_notifications();
+	} else if (mode == LTE_LC_FUNC_MODE_POWER_OFF) {
+		/* Unsubscribe the user as would normally happen. */
+		slm_fwd_cgev_notifs = false;
+	}
+	return 0;
+}
+
+static void ppp_restarter(struct k_work *)
+{
+	slm_ppp_stop();
+
+	const int ret = slm_ppp_start();
+
+	if (ret) {
+		LOG_ERR("Failed to start PPP (%d).", ret);
+	}
+}
+
+static void ppp_net_mgmt_event_handler(struct net_mgmt_event_callback *cb,
+				       uint32_t mgmt_event, struct net_if *iface)
+{
+	switch (mgmt_event) {
+	case NET_EVENT_PPP_PHASE_RUNNING:
+		LOG_INF("Peer connected.");
+		ppp_peer_connected = true;
+		break;
+	case NET_EVENT_PPP_PHASE_DEAD:
+		LOG_DBG("Peer not connected.");
+		/* This event can come without prior NET_EVENT_PPP_PHASE_RUNNING. */
+		if (!ppp_peer_connected) {
+			break;
+		}
+		ppp_peer_connected = false;
+		/* Also ignore this event when it is received after PPP has been stopped. */
+		if (!slm_ppp_is_started()) {
+			break;
+		}
+		/* For the peer to be able to successfully reconnect
+		 * (handshake issues observed with pppd and Windows dial-up),
+		 * for some reason the Zephhyr PPP link needs to be restarted.
+		 */
+		LOG_INF("Peer disconnected. Restarting PPP...");
+		k_work_submit_to_queue(&slm_work_q, &ppp_restart_work);
+		break;
+	}
+}
+
 int slm_ppp_init(void)
 {
+	static struct net_mgmt_event_callback ppp_net_mgmt_event_cb;
+
 	if (!device_is_ready(ppp_uart_dev)) {
 		return -EAGAIN;
 	}
@@ -205,6 +364,14 @@ int slm_ppp_init(void)
 		return -ENODEV;
 	}
 	net_if_flag_set(ppp_iface, NET_IF_POINTOPOINT);
+
+	pdn_default_ctx_cb_reg(pdp_ctx_event_handler);
+
+	net_mgmt_init_event_callback(&ppp_net_mgmt_event_cb, ppp_net_mgmt_event_handler,
+				     NET_EVENT_PPP_PHASE_RUNNING | NET_EVENT_PPP_PHASE_DEAD);
+	net_mgmt_add_event_callback(&ppp_net_mgmt_event_cb);
+
+	k_work_init(&ppp_restart_work, ppp_restarter);
 
 	LOG_DBG("PPP initialized.");
 	return 0;
@@ -221,6 +388,10 @@ int handle_at_ppp(enum at_cmd_type cmd_type)
 		OP_COUNT
 	};
 
+	if (cmd_type == AT_CMD_TYPE_READ_COMMAND) {
+		rsp_send("\r\n#XPPP: %u,%u\r\n", slm_ppp_is_started(), ppp_peer_connected);
+		return 0;
+	}
 	if (cmd_type != AT_CMD_TYPE_SET_COMMAND
 	 || at_params_valid_count_get(&slm_at_param_list) != 2) {
 		return -EINVAL;

--- a/applications/serial_lte_modem/src/slm_ppp.h
+++ b/applications/serial_lte_modem/src/slm_ppp.h
@@ -7,6 +7,10 @@
 #define SLM_PPP_
 
 #include <modem/at_cmd_parser.h>
+#include <stdbool.h>
+
+/* Whether to forward CGEV notifications to the SLM UART. */
+extern bool slm_fwd_cgev_notifs;
 
 /** @retval 0 on success. */
 int slm_ppp_init(void);


### PR DESCRIPTION
This adds auto-start functionality so that the PPP link goes up/down when the network connection goes up/down.

Also, auto-restart is performed when the PPP peer disconnects so that reconnection can happen successfully.

Documentation for the #XPPP AT command is added. The rest is not yet documented as this is still a work in progress.