### PR TITLE
applications: serial_lte_modem: minor documentation improvements

### DIFF
--- a/applications/serial_lte_modem/doc/AT_commands_intro.rst
+++ b/applications/serial_lte_modem/doc/AT_commands_intro.rst
@@ -35,17 +35,17 @@ The modem-specific AT commands are documented in the `nRF91x1 AT Commands Refere
    :caption: Subpages:
 
    Generic_AT_commands
-   SOCKET_AT_commands
-   TCPUDP_AT_commands
-   ICMP_AT_commands
+   CARRIER_AT_commands
    FOTA_AT_commands
-   SMS_AT_commands
    FTP_AT_commands
    GNSS_AT_commands
-   MQTT_AT_commands
-   HTTPC_AT_commands
-   TWI_AT_commands
    GPIO_AT_commands
-   CARRIER_AT_commands
+   HTTPC_AT_commands
+   ICMP_AT_commands
+   MQTT_AT_commands
    NRFCLOUD_AT_commands
    PPP_AT_commands
+   SMS_AT_commands
+   SOCKET_AT_commands
+   TCPUDP_AT_commands
+   TWI_AT_commands

--- a/applications/serial_lte_modem/doc/CARRIER_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/CARRIER_AT_commands.rst
@@ -7,7 +7,7 @@ LwM2M carrier library AT commands
    :local:
    :depth: 2
 
-The following commands list contains AT commands related to the LwM2M carrier library.
+This page describes AT commands related to the LwM2M carrier library.
 
 Carrier event #XCARRIEREVT
 ==========================

--- a/applications/serial_lte_modem/doc/FOTA_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/FOTA_AT_commands.rst
@@ -7,7 +7,7 @@ FOTA AT commands
    :local:
    :depth: 2
 
-The following commands list contains AT commands related to firmware-over-the-air updates (FOTA) requests.
+This page describes AT commands related to Firmware Over-The-Air (FOTA) updates.
 
 FOTA request #XFOTA
 ===================

--- a/applications/serial_lte_modem/doc/FTP_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/FTP_AT_commands.rst
@@ -7,7 +7,7 @@ FTP AT commands
    :local:
    :depth: 2
 
-The following commands list contains FTP related AT commands.
+This page describes FTP-related AT commands.
 
 FTP client #XFTP
 ================

--- a/applications/serial_lte_modem/doc/GNSS_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/GNSS_AT_commands.rst
@@ -7,7 +7,7 @@ GNSS AT commands
    :local:
    :depth: 2
 
-The following list contains GNSS-related AT commands.
+This page describes GNSS-related AT commands.
 
 Control GNSS
 ============
@@ -299,6 +299,7 @@ Example
   AT#XGPS=?
 
   #XGPS: (0,1),(0,1),<interval>,<timeout>
+
   OK
 
 Delete GNSS data

--- a/applications/serial_lte_modem/doc/GPIO_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/GPIO_AT_commands.rst
@@ -7,7 +7,7 @@ GPIO AT commands
    :local:
    :depth: 2
 
-The following commands list contains AT commands related to the General Purpose Input/Output (GPIO).
+This page describes AT commands related to General Purpose Input/Output (GPIO).
 
 Configure GPIO pins function #XGPIOCFG
 ======================================

--- a/applications/serial_lte_modem/doc/Generic_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/Generic_AT_commands.rst
@@ -7,7 +7,7 @@ Generic AT commands
    :local:
    :depth: 2
 
-The following commands list contains generic AT commands.
+This page describes generic AT commands.
 
 SLM version #XSLMVER
 ====================
@@ -143,7 +143,6 @@ Syntax
 
 The ``<sleep_mode>`` parameter accepts only the following integer values:
 
-* ``0`` - Deprecated.
 * ``1`` - Enter Sleep.
   In this mode, both the SLM service and the LTE connection are terminated.
 
@@ -159,9 +158,8 @@ The ``<sleep_mode>`` parameter accepts only the following integer values:
 
 .. note::
 
-   * This parameter does not accept ``0`` anymore.
-   * If the modem is on, entering Sleep mode sends a ``+CFUN=0`` command to the modem, which causes a non-volatile memory (NVM) write.
-     Take the NVM wear into account, or put the modem in flight mode by issuing a ``AT+CFUN=4`` before Sleep mode.
+   * If the modem is on, entering Sleep mode (by issuing ``AT#XSLEEP=1`` ) sends a ``+CFUN=0`` command to the modem, which causes a write to non-volatile memory (NVM).
+     Take the NVM wear into account, or put the modem in flight mode by issuing ``AT+CFUN=4`` before Sleep mode.
 
 Examples
 ~~~~~~~~

--- a/applications/serial_lte_modem/doc/HTTPC_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/HTTPC_AT_commands.rst
@@ -7,7 +7,7 @@ HTTP client AT commands
    :local:
    :depth: 2
 
-The following commands list contains the HTTP client AT commands.
+This page describes the HTTP client AT commands.
 
 HTTP client connection #XHTTPCCON
 =================================

--- a/applications/serial_lte_modem/doc/ICMP_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/ICMP_AT_commands.rst
@@ -7,7 +7,7 @@ ICMP AT commands
    :local:
    :depth: 2
 
-The following commands list contains ICMP related AT commands.
+This page describes ICMP-related AT commands.
 
 ICMP echo request #XPING
 ========================

--- a/applications/serial_lte_modem/doc/MQTT_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/MQTT_AT_commands.rst
@@ -7,7 +7,7 @@ MQTT client AT commands
    :local:
    :depth: 2
 
-The following commands list contains the AT commands used to operate the MQTT client.
+This page describes the AT commands used to operate the MQTT client.
 
 MQTT event #XMQTTEVT
 ====================

--- a/applications/serial_lte_modem/doc/NRFCLOUD_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/NRFCLOUD_AT_commands.rst
@@ -5,7 +5,7 @@ nRF Cloud AT commands
    :local:
    :depth: 2
 
-The following list contains nRF Cloud-related AT commands.
+The page describes nRF Cloud-related AT commands.
 
 .. _SLM_AT_NRFCLOUD:
 

--- a/applications/serial_lte_modem/doc/SMS_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/SMS_AT_commands.rst
@@ -7,7 +7,7 @@ SMS AT commands
    :local:
    :depth: 2
 
-The following commands list contains SMS-related AT commands.
+This page describes SMS-related AT commands.
 
 SMS support #XSMS
 =================

--- a/applications/serial_lte_modem/doc/SOCKET_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/SOCKET_AT_commands.rst
@@ -7,7 +7,7 @@ Socket AT commands
    :local:
    :depth: 2
 
-The following commands list contains socket-related AT commands.
+This page describes socket-related AT commands.
 The application can open up to 8 sockets and select the active one among them.
 
 For more information on the networking services, see the `Zephyr Network APIs`_.

--- a/applications/serial_lte_modem/doc/TCPUDP_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/TCPUDP_AT_commands.rst
@@ -7,7 +7,7 @@ TCP and UDP AT commands
    :local:
    :depth: 2
 
-The following commands list contains TCP-related and UDP-related AT commands.
+This page describes TCP- and UDP-related AT commands.
 When native TLS is used, you must store the credentials using the ``AT#XCMNG`` AT command.
 
 For more information on the networking services, see the `Zephyr Network APIs`_.

--- a/applications/serial_lte_modem/doc/TWI_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/TWI_AT_commands.rst
@@ -7,7 +7,7 @@ TWI AT commands
    :local:
    :depth: 2
 
-The following commands list contains AT commands related to the two-wire interface (TWI).
+This page describes AT commands related to the Two-Wire Interface (TWI).
 
 List TWI instances #XTWILS
 ==========================

--- a/applications/serial_lte_modem/doc/slm_data_mode.rst
+++ b/applications/serial_lte_modem/doc/slm_data_mode.rst
@@ -147,7 +147,7 @@ CONFIG_SLM_DATAMODE_BUF_SIZE - Buffer size for data mode
 Data mode AT commands
 *********************
 
-The following commands list contains data-mode related AT commands.
+The following command list describes data mode-related AT commands.
 
 Data mode control #XDATACTRL
 ============================

--- a/applications/serial_lte_modem/src/slm_at_host.c
+++ b/applications/serial_lte_modem/src/slm_at_host.c
@@ -459,7 +459,7 @@ static void cmd_send(uint8_t *buf, size_t cmd_length, size_t buf_size)
 	}
 
 	if (cmd_grammar_check(at_cmd, cmd_length) != 0) {
-		LOG_ERR("AT command invalid");
+		LOG_ERR("AT command syntax invalid: %s", at_cmd);
 		rsp_send_error();
 		return;
 	}


### PR DESCRIPTION
- Fix and homogenize the first sentence of the AT command pages.
- Sort the pages by alphabetical order except from the "Generic AT commands" one that remains first.