### PR TITLE
lib: supl: Add dependency to newlib C library

### DIFF
--- a/doc/nrf/libraries/others/supl_os_client.rst
+++ b/doc/nrf/libraries/others/supl_os_client.rst
@@ -100,6 +100,11 @@ Configuration
 To enable the SUPL client library, set :kconfig:option:`CONFIG_SUPL_CLIENT_LIB` to ``y``.
 See :ref:`configure_application` for information on how to change configuration options.
 
+.. note::
+
+   The SUPL client library requires that the newlib C library is used.
+   You can enable it using the :kconfig:option:`CONFIG_NEWLIB_LIBC` Kconfig option.
+
 Resource initialization and ownership
 =====================================
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -302,6 +302,10 @@ Cellular samples
 
   * Added event handling for events from device mode callback.
 
+* :ref:`gnss_sample` sample:
+
+  * Added the configuration overlay file :file:`overlay-supl.conf` for building the sample with SUPL assistance support.
+
 Cryptography samples
 --------------------
 

--- a/lib/supl/Kconfig
+++ b/lib/supl/Kconfig
@@ -6,5 +6,6 @@
 
 config SUPL_CLIENT_LIB
 	bool "SUPL Client library"
+	depends on NEWLIB_LIBC
 	help
 	  A library for accessing A-GNSS data using the SUPL protocol.

--- a/samples/cellular/gnss/overlay-supl.conf
+++ b/samples/cellular/gnss/overlay-supl.conf
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# SUPL overlay configuration
+
+# Enable SUPL assistance for GNSS sample
+CONFIG_GNSS_SAMPLE_ASSISTANCE_SUPL=y
+
+# SUPL client library requires that the newlib C library is used
+CONFIG_NEWLIB_LIBC=y
+CONFIG_NEWLIB_LIBC_FLOAT_PRINTF=y


### PR DESCRIPTION
The SUPL client library requires the newlib C library. Added dependency to newlib in the Kconfig.

Added a configuration overlay file for building the GNSS sample with SUPL assistance support.

test-sdk-nrf: sdk-nrf-pr-13462