### PR TITLE
applications: nrf5340_audio: Improve broadcast sink error handling

### DIFF
--- a/applications/nrf5340_audio/src/audio/streamctrl_broadcast_sink.c
+++ b/applications/nrf5340_audio/src/audio/streamctrl_broadcast_sink.c
@@ -82,7 +82,7 @@ static void button_msg_sub_thread(void)
 
 		if (msg.button_action != BUTTON_PRESS) {
 			LOG_WRN("Unhandled button action");
-			return;
+			continue;
 		}
 
 		switch (msg.button_pin) {

--- a/applications/nrf5340_audio/src/bluetooth/bt_management/scanning/bt_mgmt_scan_for_broadcast.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/scanning/bt_mgmt_scan_for_broadcast.c
@@ -112,6 +112,10 @@ static void periodic_adv_sync(const struct bt_le_scan_recv_info *info, uint32_t 
 	ret = bt_le_per_adv_sync_create(&param, &pa_sync);
 	if (ret) {
 		LOG_ERR("Could not sync to PA: %d", ret);
+		ret = bt_mgmt_pa_sync_delete(pa_sync);
+		if (ret) {
+			LOG_ERR("Could not delete PA sync: %d", ret);
+		}
 		return;
 	}
 }


### PR DESCRIPTION
* Delete PA sync if creating failed.
* Do not return if bt_bap_broadcast_sink_delete() return -EBADMSG.