### PR TITLE
samples: matter: update manifest and disable Read Client

### DIFF
--- a/applications/matter_bridge/Kconfig
+++ b/applications/matter_bridge/Kconfig
@@ -131,6 +131,10 @@ endif
 config EXPERIMENTAL
 	default y
 
+# Enable Read Client functionality for all build configurations.
+config CHIP_ENABLE_READ_CLIENT
+	default y
+
 source "${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/chip-module/Kconfig.features"
 source "${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/chip-module/Kconfig.defaults"
 source "${ZEPHYR_BASE}/../nrf/samples/matter/common/src/bridge/Kconfig"

--- a/applications/matter_bridge/prj_release.conf
+++ b/applications/matter_bridge/prj_release.conf
@@ -43,3 +43,6 @@ CONFIG_CHIP_NFC_COMMISSIONING=n
 # Enable Factory Data feature
 CONFIG_CHIP_FACTORY_DATA=y
 CONFIG_CHIP_FACTORY_DATA_BUILD=y
+
+# Enable the Read Client for binding purposes
+CONFIG_CHIP_ENABLE_READ_CLIENT=y

--- a/doc/nrf/protocols/matter/getting_started/advanced_kconfigs.rst
+++ b/doc/nrf/protocols/matter/getting_started/advanced_kconfigs.rst
@@ -141,3 +141,12 @@ By default this Kconfig option is set to 1 second.
 .. note::
   The :kconfig:option:`CONFIG_CHIP_FACTORY_RESET_ERASE_NVS` Kconfig option is set to ``y`` by default.
   To disable removing application-specific non-volatile data when the :kconfig:option:`CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_REBOOT` Kconfig option is selected, set the :kconfig:option:`CONFIG_CHIP_FACTORY_RESET_ERASE_NVS` Kconfig option to ``n``.
+
+.. _ug_matter_configuring_read_client:
+
+Read Client functionality
+=========================
+
+The Read Client functionality is used for reading attributes from another device in the Matter network.
+This functionality is disabled by default for Matter samples in the |NCS|, except for ones that need to read attributes from the bound devices, such as the :ref:`matter_light_switch_sample` and :ref:`matter_thermostat_sample` samples, and the :ref:`matter_bridge_app` application.
+Enable the feature if your device needs to be able to access attributes from a different device within the Matter network using, for example, bindings.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -93,6 +93,7 @@ Matter
 ------
 
 * Updated the page about :ref:`ug_matter_device_low_power_configuration` with the information about Intermittently Connected Devices (ICD) configuration.
+* Added a Kconfig option for disabling or enabling :ref:`ug_matter_configuring_read_client`.
 
 Matter fork
 +++++++++++
@@ -359,6 +360,8 @@ Matter samples
   * Divided events to application and system events.
   * Defined common LED and button constants in the dedicated board configuration files.
   * Created the Kconfig file for the Matter common directory.
+
+* Disabled :ref:`ug_matter_configuring_read_client` in most Matter samples using the new :kconfig:option:`CONFIG_CHIP_ENABLE_READ_CLIENT` Kconfig option.
 
 * :ref:`matter_lock_sample` sample:
 

--- a/samples/matter/light_switch/Kconfig
+++ b/samples/matter/light_switch/Kconfig
@@ -41,6 +41,10 @@ config NRF_WIFI_LOW_POWER
 
 endif # CHIP_WIFI
 
+# Enable Read Client functionality for all build configurations.
+config CHIP_ENABLE_READ_CLIENT
+	default y
+
 source "${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/chip-module/Kconfig.features"
 source "${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/chip-module/Kconfig.defaults"
 source "${ZEPHYR_BASE}/../nrf/samples/matter/common/src/Kconfig"

--- a/samples/matter/thermostat/Kconfig
+++ b/samples/matter/thermostat/Kconfig
@@ -30,6 +30,9 @@ config THERMOSTAT_SIMULATED_TEMPERATURE_CHANGE
 	help
 	  If set to true, the simulated temperature is rising. If set to false, the simulated temperature is falling.
 
+# Enable Read Client functionality for all build configurations.
+config CHIP_ENABLE_READ_CLIENT
+	default y
 
 # Sample configuration used for Thread networking
 if NET_L2_OPENTHREAD

--- a/west.yml
+++ b/west.yml
@@ -149,7 +149,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: c84b2c43069a14c047e27f652dedb944d64c0a9c
+      revision: d95eb1d43d6e8247045d549802642ec66ad1d322
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
Disable Read Client functionality for all samples except Matter Light Switch and Matter Bridge App.
It added around 6 kB of free space in some samples.