### PR TITLE
samples: cellular: modem_shell: Fix sms registration

### DIFF
--- a/samples/cellular/modem_shell/src/sms/sms.c
+++ b/samples/cellular/modem_shell/src/sms/sms.c
@@ -74,7 +74,7 @@ int sms_register(void)
 	}
 
 	handle = sms_register_listener(sms_callback, NULL);
-	if (handle) {
+	if (handle < 0) {
 		mosh_error("sms_register_listener returned err: %d\n", handle);
 		return handle;
 	}


### PR DESCRIPTION
An error was shown for a valid SMS registration when the handle was a positive value instead of zero.
This was likely a leftover from early versions of SMS library which supported just one SMS registration.