### PR TITLE
applications: asset_tracker_v2: Fix requested data in sample request

### DIFF
--- a/applications/asset_tracker_v2/doc/data_module.rst
+++ b/applications/asset_tracker_v2/doc/data_module.rst
@@ -124,6 +124,12 @@ CONFIG_DATA_SAMPLE_NEIGHBOR_CELLS_DEFAULT
    This configuration includes neighbor cell measurements during sampling.
    Enabled by default.
 
+.. _CONFIG_DATA_SAMPLE_WIFI_DEFAULT:
+
+CONFIG_DATA_SAMPLE_WIFI_DEFAULT
+   This configuration includes Wi-Fi APs during sampling.
+   Enabled by default.
+
 Other options:
 
 .. _CONFIG_DATA_GRANT_SEND_ON_CONNECTION_QUALITY:

--- a/applications/asset_tracker_v2/src/main.c
+++ b/applications/asset_tracker_v2/src/main.c
@@ -381,14 +381,17 @@ static void data_get(void)
 
 	/* Specify which data that is to be included in the transmission. */
 	app_module_event->data_list[count++] = APP_DATA_MODEM_DYNAMIC;
-	app_module_event->data_list[count++] = APP_DATA_BATTERY;
-	app_module_event->data_list[count++] = APP_DATA_ENVIRONMENTAL;
-
 	if (!modem_static_sampled) {
 		app_module_event->data_list[count++] = APP_DATA_MODEM_STATIC;
 	}
 
-	if (!app_cfg.no_data.neighbor_cell || !app_cfg.no_data.gnss || !app_cfg.no_data.wifi) {
+	if (IS_ENABLED(CONFIG_SENSOR_MODULE)) {
+		app_module_event->data_list[count++] = APP_DATA_BATTERY;
+		app_module_event->data_list[count++] = APP_DATA_ENVIRONMENTAL;
+	}
+
+	if (IS_ENABLED(CONFIG_LOCATION_MODULE) &&
+	    (!app_cfg.no_data.neighbor_cell || !app_cfg.no_data.gnss || !app_cfg.no_data.wifi)) {
 		app_module_event->data_list[count++] = APP_DATA_LOCATION;
 
 		/* Set application module timeout when location sampling is requested.

--- a/applications/asset_tracker_v2/src/modules/Kconfig.data_module
+++ b/applications/asset_tracker_v2/src/modules/Kconfig.data_module
@@ -169,6 +169,14 @@ config DATA_SAMPLE_NEIGHBOR_CELLS_DEFAULT
 	  data in sample requests sent to other modules. This configuration can be overwritten by
 	  changing the application's real-time configuration using the cloud-side state.
 
+config DATA_SAMPLE_WIFI_DEFAULT
+	bool "Include Wi-Fi APs in sample requests"
+	default y
+	help
+	  If this configuration is enabled the application will by default include Wi-Fi AP data in
+	  sample requests sent to other modules. This configuration can be overwritten by changing
+	  the application's real-time configuration using the cloud-side state.
+
 config DATA_GRANT_SEND_ON_CONNECTION_QUALITY
 	bool "Grant or deny encoding and sending of data based on LTE connection quality"
 	select EXPERIMENTAL

--- a/applications/asset_tracker_v2/src/modules/data_module.c
+++ b/applications/asset_tracker_v2/src/modules/data_module.c
@@ -94,7 +94,8 @@ static struct cloud_data_cfg current_cfg = {
 	.accelerometer_inactivity_threshold	= CONFIG_DATA_ACCELEROMETER_INACT_THRESHOLD,
 	.accelerometer_inactivity_timeout	= CONFIG_DATA_ACCELEROMETER_INACT_TIMEOUT_SECONDS,
 	.no_data.gnss		 = !IS_ENABLED(CONFIG_DATA_SAMPLE_GNSS_DEFAULT),
-	.no_data.neighbor_cell	 = !IS_ENABLED(CONFIG_DATA_SAMPLE_NEIGHBOR_CELLS_DEFAULT)
+	.no_data.neighbor_cell	 = !IS_ENABLED(CONFIG_DATA_SAMPLE_NEIGHBOR_CELLS_DEFAULT),
+	.no_data.wifi		 = !IS_ENABLED(CONFIG_DATA_SAMPLE_WIFI_DEFAULT)
 };
 
 static struct k_work_delayable data_send_work;

--- a/applications/asset_tracker_v2/src/modules/location_module.c
+++ b/applications/asset_tracker_v2/src/modules/location_module.c
@@ -240,12 +240,6 @@ static void search_start(void)
 	int methods_count = 0;
 	struct location_method_config methods_updated[CONFIG_LOCATION_METHODS_LIST_SIZE] = { 0 };
 
-	if (copy_cfg.no_data.neighbor_cell && copy_cfg.no_data.gnss && copy_cfg.no_data.wifi) {
-		SEND_EVENT(location, LOCATION_MODULE_EVT_DATA_NOT_READY);
-		LOG_ERR("All GNSS, cellular and Wi-Fi are configured off");
-		return;
-	}
-
 	/* Set default location configuration configured at compile time */
 	location_config_defaults_set(&config, 0, NULL);
 
@@ -268,6 +262,12 @@ static void search_start(void)
 				       sizeof(struct location_method_config));
 				methods_count++;
 			}
+		}
+
+		if (methods_count == 0) {
+			SEND_EVENT(location, LOCATION_MODULE_EVT_DATA_NOT_READY);
+			LOG_INF("All location methods are disabled at run-time");
+			return;
 		}
 
 		config.methods_count = methods_count;

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -168,7 +168,9 @@ This section provides detailed lists of changes by :ref:`application <applicatio
 Asset Tracker v2
 ----------------
 
-  * Removed nRF7002 EK DTC overlay file ``nrf91xxdk_with_nrf7002ek.overlay`` because UART1 is disabled through the shield configuration.
+* Added the :kconfig:option:`CONFIG_DATA_SAMPLE_WIFI_DEFAULT` Kconfig option to configure whether Wi-Fi APs are included in sample requests by default.
+
+* Removed the nRF7002 EK devicetree overlay file :file:`nrf91xxdk_with_nrf7002ek.overlay`, because UART1 is disabled through the shield configuration.
 
 Serial LTE modem
 ----------------
@@ -270,7 +272,7 @@ Cellular samples
 
 * :ref:`location_sample` sample:
 
-  * Removed nRF7002 EK DTC overlay file ``nrf91xxdk_with_nrf7002ek.overlay`` because UART1 is disabled through the shield configuration.
+  * Removed the nRF7002 EK devicetree overlay file :file:`nrf91xxdk_with_nrf7002ek.overlay`, because UART1 is disabled through the shield configuration.
 
 * :ref:`modem_shell_application` sample:
 
@@ -279,7 +281,7 @@ Cellular samples
     * Printing of the last reset reason when the sample starts.
     * Support for printing the sample version information using the ``version`` command.
 
-  * Removed nRF7002 EK DTC overlay file ``nrf91xxdk_with_nrf7002ek.overlay`` because UART1 is disabled through the shield configuration.
+  * Removed the nRF7002 EK devicetree overlay file :file:`nrf91xxdk_with_nrf7002ek.overlay`, because UART1 is disabled through the shield configuration.
 
 * :ref:`nrf_cloud_multi_service` sample:
 
@@ -297,7 +299,7 @@ Cellular samples
     * The sample now explicitly uses the :c:func:`conn_mgr_all_if_connect` function to start network connectivity, instead of the :kconfig:option:`CONFIG_NRF_MODEM_LIB_NET_IF_AUTO_START` and :kconfig:option:`CONFIG_NRF_MODEM_LIB_NET_IF_AUTO_CONNECT` Kconfig options.
     * The sample to use the FOTA support functions in the :file:`nrf_cloud_fota_poll.c` and :file:`nrf_cloud_fota_common.c` files.
 
-  * Removed nRF7002 EK DTC overlay file ``nrf91xxdk_with_nrf7002ek.overlay`` because UART1 is disabled through the shield configuration.
+  * Removed the nRF7002 EK devicetree overlay file :file:`nrf91xxdk_with_nrf7002ek.overlay`, because UART1 is disabled through the shield configuration.
 
 * :ref:`nrf_cloud_rest_fota` sample:
 


### PR DESCRIPTION
Removed location from sample request when the Location module is disabled. Earlier also location was requested and because of this the sending of data was delayed until sampling timed out.

Removed battery and environmental data sampling when Sensor module is disabled.

Improved handling of case where all configured location methods are disabled using the run-time configuration.

Added missing Kconfig option for Wi-Fi sampling default value.