### PR TITLE
samples: matter: common initialization module

### DIFF
--- a/applications/matter_bridge/CMakeLists.txt
+++ b/applications/matter_bridge/CMakeLists.txt
@@ -54,6 +54,7 @@ target_sources(app PRIVATE
     ${COMMON_ROOT}/src/persistent_storage_util.cpp
     ${COMMON_ROOT}/src/task_executor.cpp
     ${COMMON_ROOT}/src/board.cpp
+    ${COMMON_ROOT}/src/matter_init.cpp
 )
 
 if(CONFIG_BRIDGED_DEVICE_BT)

--- a/applications/matter_bridge/src/app_task.h
+++ b/applications/matter_bridge/src/app_task.h
@@ -10,16 +10,6 @@
 
 #include <platform/CHIPDeviceLayer.h>
 
-#if CONFIG_CHIP_FACTORY_DATA
-#include <platform/nrfconnect/FactoryDataProvider.h>
-#else
-#include <platform/nrfconnect/DeviceInstanceInfoProviderImpl.h>
-#endif
-
-#ifdef CONFIG_MCUMGR_TRANSPORT_BT
-#include "dfu_over_smp.h"
-#endif
-
 class AppTask {
 public:
 
@@ -34,10 +24,6 @@ public:
 private:
 	CHIP_ERROR Init();
 
-	static void ChipEventHandler(const chip::DeviceLayer::ChipDeviceEvent *event, intptr_t arg);
+	static void MatterEventHandler(const chip::DeviceLayer::ChipDeviceEvent *event, intptr_t arg);
 	static CHIP_ERROR RestoreBridgedDevices();
-
-#if CONFIG_CHIP_FACTORY_DATA
-	chip::DeviceLayer::FactoryDataProvider<chip::DeviceLayer::InternalFlashFactoryData> mFactoryDataProvider;
-#endif
 };

--- a/applications/matter_weather_station/CMakeLists.txt
+++ b/applications/matter_weather_station/CMakeLists.txt
@@ -47,6 +47,7 @@ target_sources(app PRIVATE
     ${COMMON_ROOT}/src/dfu_over_smp.cpp
     ${COMMON_ROOT}/src/task_executor.cpp
     ${COMMON_ROOT}/src/board.cpp
+    ${COMMON_ROOT}/src/matter_init.cpp
 )
 
 if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_TRANSPORT_BT)

--- a/applications/matter_weather_station/src/app_task.cpp
+++ b/applications/matter_weather_station/src/app_task.cpp
@@ -5,44 +5,37 @@
  */
 
 #include "app_task.h"
+
 #include "board.h"
 #include "task_executor.h"
 
 #include "battery.h"
 #include "buzzer.h"
-#include "fabric_table_delegate.h"
 #include "led_widget.h"
-#include <platform/CHIPDeviceLayer.h>
+#include "matter_init.h"
 
 #include <DeviceInfoProviderImpl.h>
-
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/clusters/ota-requestor/OTATestEventTriggerDelegate.h>
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
-#include <app/util/attribute-storage.h>
-#include <credentials/DeviceAttestationCredsProvider.h>
-#include <credentials/examples/DeviceAttestationCredsExample.h>
-
-#ifdef CONFIG_CHIP_WIFI
-#include <app/clusters/network-commissioning/network-commissioning.h>
-#include <platform/nrfconnect/wifi/NrfWiFiDriver.h>
-#endif
 
 #ifdef CONFIG_CHIP_OTA_REQUESTOR
 #include "ota_util.h"
 #endif
 
-#include <dk_buttons_and_leds.h>
+#ifdef CONFIG_MCUMGR_TRANSPORT_BT
+#include "dfu_over_smp.h"
+#endif
+
 #include <zephyr/drivers/sensor.h>
-#include <zephyr/kernel.h>
-#include <zephyr/logging/log.h>
 
 using namespace ::chip;
-using namespace ::chip::Credentials;
 using namespace ::chip::DeviceLayer;
 using namespace ::chip::app;
+
+#include <zephyr/logging/log.h>
 
 LOG_MODULE_DECLARE(app);
 
@@ -88,13 +81,7 @@ constexpr size_t kIdentifyTimerIntervalMs = 500;
 k_timer sMeasurementsTimer;
 k_timer sIdentifyTimer;
 
-/* NOTE! This key is for test/certification only and should not be available in production devices!
- * If CONFIG_CHIP_FACTORY_DATA is enabled, this value is read from the factory data.
- */
-uint8_t sTestEventTriggerEnableKey[TestEventTriggerDelegate::kEnableKeyLength] = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55,
-										   0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb,
-										   0xcc, 0xdd, 0xee, 0xff };
-chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
+const device *sBme688SensorDev = DEVICE_DT_GET_ONE(bosch_bme680);
 
 /* Add identify for all endpoints */
 Identify sIdentifyTemperature = { chip::EndpointId{ kTemperatureMeasurementEndpointId }, AppTask::OnIdentifyStart,
@@ -104,172 +91,32 @@ Identify sIdentifyHumidity = { chip::EndpointId{ kHumidityMeasurementEndpointId 
 Identify sIdentifyPressure = { chip::EndpointId{ kPressureMeasurementEndpointId }, AppTask::OnIdentifyStart,
 			       AppTask::OnIdentifyStop, Clusters::Identify::IdentifyTypeEnum::kAudibleBeep };
 
-const device *sBme688SensorDev = DEVICE_DT_GET_ONE(bosch_bme680);
-} /* namespace */
+/* NOTE! This key is for test/certification only and should not be available in production devices!
+ * If CONFIG_CHIP_FACTORY_DATA is enabled, this value is read from the factory data.
+ */
+uint8_t sTestEventTriggerEnableKey[TestEventTriggerDelegate::kEnableKeyLength] = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55,
+										   0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb,
+										   0xcc, 0xdd, 0xee, 0xff };
+chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 
-#ifdef CONFIG_CHIP_WIFI
-app::Clusters::NetworkCommissioning::Instance
-	sWiFiCommissioningInstance(0, &(NetworkCommissioning::NrfWiFiDriver::Instance()));
-#endif
+OTATestEventTriggerDelegate sTestEventTriggerDelegate{ ByteSpan(sTestEventTriggerEnableKey) };
+CommonCaseDeviceServerInitParams sServerInitParams{};
 
-CHIP_ERROR AppTask::Init()
-{
-	/* Initialize CHIP stack */
-	LOG_INF("Init CHIP stack");
-
-	CHIP_ERROR err = chip::Platform::MemoryInit();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("Platform::MemoryInit() failed");
-		return err;
-	}
-
-	err = PlatformMgr().InitChipStack();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("PlatformMgr().InitChipStack() failed");
-		return err;
-	}
-
-#if defined(CONFIG_NET_L2_OPENTHREAD)
-	err = ThreadStackMgr().InitThreadStack();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("ThreadStackMgr().InitThreadStack() failed");
-		return err;
-	}
-
-#ifdef CONFIG_OPENTHREAD_MTD_SED
-	err = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_SleepyEndDevice);
-#else
-	err = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_MinimalEndDevice);
-#endif
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("ConnectivityMgr().SetThreadDeviceType() failed");
-		return err;
-	}
-
-#elif defined(CONFIG_CHIP_WIFI)
-	sWiFiCommissioningInstance.Init();
-#else
-	return CHIP_ERROR_INTERNAL;
-#endif /* CONFIG_NET_L2_OPENTHREAD */
-
-	/* Set references for RGB LED */
-	mRedLED = &GetBoard().GetLED(DeviceLeds::LED1);
-	mGreenLED = &GetBoard().GetLED(DeviceLeds::LED2);
-	mBlueLED = &GetBoard().GetLED(DeviceLeds::LED3);
-
-	if (!GetBoard().Init(nullptr, UpdateLedState)) {
-		LOG_ERR("User interface initialization failed.");
-		return CHIP_ERROR_INCORRECT_STATE;
-	}
-
-	if (!device_is_ready(sBme688SensorDev)) {
-		LOG_ERR("BME688 sensor device not ready");
-		return chip::System::MapErrorZephyr(-ENODEV);
-	}
-
-	int ret = BatteryMeasurementInit();
-	if (ret) {
-		LOG_ERR("Battery measurement init failed");
-		return chip::System::MapErrorZephyr(ret);
-	}
-
-	ret = BatteryMeasurementEnable();
-	if (ret) {
-		LOG_ERR("Enabling battery measurement failed");
-		return chip::System::MapErrorZephyr(ret);
-	}
-
-	ret = BatteryChargeControlInit();
-	if (ret) {
-		LOG_ERR("Battery charge control init failed");
-		return chip::System::MapErrorZephyr(ret);
-	}
-
-	ret = BuzzerInit();
-	if (ret) {
-		LOG_ERR("Buzzer init failed");
-		return chip::System::MapErrorZephyr(ret);
-	}
-
-#ifdef CONFIG_CHIP_OTA_REQUESTOR
-	/* OTA image confirmation must be done before the factory data init. */
-	OtaConfirmNewImage();
-#endif
-
-#ifdef CONFIG_MCUMGR_TRANSPORT_BT
-	/* Initialize DFU over SMP */
-	GetDFUOverSMP().Init();
-	GetDFUOverSMP().ConfirmNewImage();
-	GetDFUOverSMP().StartServer();
-#endif
-
-/* Get factory data */
 #ifdef CONFIG_CHIP_FACTORY_DATA
-	ReturnErrorOnFailure(mFactoryDataProvider.Init());
-	SetDeviceInstanceInfoProvider(&mFactoryDataProvider);
-	SetDeviceAttestationCredentialsProvider(&mFactoryDataProvider);
-	SetCommissionableDataProvider(&mFactoryDataProvider);
-	/* Read EnableKey from the factory data. */
+CHIP_ERROR CustomFactoryDataInit()
+{
 	MutableByteSpan enableKey(sTestEventTriggerEnableKey);
-	err = mFactoryDataProvider.GetEnableKey(enableKey);
+	auto *factoryDataProvider = Nordic::Matter::GetFactoryDataProvider();
+	VerifyOrReturnError(factoryDataProvider, CHIP_ERROR_INTERNAL);
+	CHIP_ERROR err = factoryDataProvider->GetEnableKey(enableKey);
 	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("mFactoryDataProvider.GetEnableKey() failed. Could not delegate a test event trigger");
+		LOG_ERR("FactoryDataProvider::GetEnableKey() failed. Could not delegate a test event trigger");
 		memset(sTestEventTriggerEnableKey, 0, sizeof(sTestEventTriggerEnableKey));
 	}
-#else
-	SetDeviceInstanceInfoProvider(&DeviceInstanceInfoProviderMgrImpl());
-	SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
+	return CHIP_NO_ERROR;
+}
 #endif
-
-	/* Initialize timers */
-	k_timer_init(
-		&sMeasurementsTimer, [](k_timer *) { TaskExecutor::PostTask([] { MeasurementsTimerHandler(); }); },
-		nullptr);
-	k_timer_init(
-		&sIdentifyTimer, [](k_timer *) { TaskExecutor::PostTask([] { IdentifyTimerHandler(); }); }, nullptr);
-	k_timer_start(&sMeasurementsTimer, K_MSEC(kMeasurementsIntervalMs), K_MSEC(kMeasurementsIntervalMs));
-
-	/* Initialize CHIP server */
-	static chip::CommonCaseDeviceServerInitParams initParams;
-	static OTATestEventTriggerDelegate testEventTriggerDelegate{ ByteSpan(sTestEventTriggerEnableKey) };
-	(void)initParams.InitializeStaticResourcesBeforeServerInit();
-
-	initParams.testEventTriggerDelegate = &testEventTriggerDelegate;
-	ReturnErrorOnFailure(chip::Server::GetInstance().Init(initParams));
-
-	gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());
-	chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
-	AppFabricTableDelegate::Init();
-
-	ConfigurationMgr().LogDeviceConfig();
-	PrintOnboardingCodes(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
-
-	/*
-	 * Add CHIP event handler and start CHIP thread.
-	 * Note that all the initialization code should happen prior to this point
-	 * to avoid data races between the main and the CHIP threads.
-	 */
-	PlatformMgr().AddEventHandler(ChipEventHandler, 0);
-
-	err = PlatformMgr().StartEventLoopTask();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("PlatformMgr().StartEventLoopTask() failed");
-		return err;
-	}
-
-	return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR AppTask::StartApp()
-{
-	ReturnErrorOnFailure(Init());
-
-	while (true) {
-		TaskExecutor::DispatchNextTask();
-	}
-
-	return CHIP_NO_ERROR;
-}
+} /* namespace */
 
 void AppTask::MeasurementsTimerHandler()
 {
@@ -474,7 +321,7 @@ void AppTask::UpdateClustersState()
 	UpdatePowerSourceClusterState();
 }
 
-void AppTask::ChipEventHandler(const ChipDeviceEvent *event, intptr_t /* arg */)
+void AppTask::MatterEventHandler(const ChipDeviceEvent *event, intptr_t /* arg */)
 {
 	bool isNetworkProvisioned = false;
 
@@ -554,4 +401,79 @@ void AppTask::UpdateLedState()
 	default:
 		break;
 	}
+}
+
+CHIP_ERROR AppTask::Init()
+{
+	/* Initialize Matter stack */
+	sServerInitParams.testEventTriggerDelegate = &sTestEventTriggerDelegate;
+	Nordic::Matter::InitData initConfig{ .mServerInitParams = &sServerInitParams };
+#ifdef CONFIG_CHIP_FACTORY_DATA
+	initConfig.mPostServerInitClbk = CustomFactoryDataInit;
+#endif
+	ReturnErrorOnFailure(Nordic::Matter::PrepareServer(MatterEventHandler, initConfig));
+
+	/* Set references for RGB LED */
+	mRedLED = &GetBoard().GetLED(DeviceLeds::LED1);
+	mGreenLED = &GetBoard().GetLED(DeviceLeds::LED2);
+	mBlueLED = &GetBoard().GetLED(DeviceLeds::LED3);
+
+	if (!GetBoard().Init(nullptr, UpdateLedState)) {
+		LOG_ERR("User interface initialization failed.");
+		return CHIP_ERROR_INCORRECT_STATE;
+	}
+
+	if (!device_is_ready(sBme688SensorDev)) {
+		LOG_ERR("BME688 sensor device not ready");
+		return chip::System::MapErrorZephyr(-ENODEV);
+	}
+
+	int ret = BatteryMeasurementInit();
+	if (ret) {
+		LOG_ERR("Battery measurement init failed");
+		return chip::System::MapErrorZephyr(ret);
+	}
+
+	ret = BatteryMeasurementEnable();
+	if (ret) {
+		LOG_ERR("Enabling battery measurement failed");
+		return chip::System::MapErrorZephyr(ret);
+	}
+
+	ret = BatteryChargeControlInit();
+	if (ret) {
+		LOG_ERR("Battery charge control init failed");
+		return chip::System::MapErrorZephyr(ret);
+	}
+
+	ret = BuzzerInit();
+	if (ret) {
+		LOG_ERR("Buzzer init failed");
+		return chip::System::MapErrorZephyr(ret);
+	}
+
+	/* Initialize timers */
+	k_timer_init(
+		&sMeasurementsTimer, [](k_timer *) { TaskExecutor::PostTask([] { MeasurementsTimerHandler(); }); },
+		nullptr);
+	k_timer_init(
+		&sIdentifyTimer, [](k_timer *) { TaskExecutor::PostTask([] { IdentifyTimerHandler(); }); }, nullptr);
+	k_timer_start(&sMeasurementsTimer, K_MSEC(kMeasurementsIntervalMs), K_MSEC(kMeasurementsIntervalMs));
+
+#ifdef CONFIG_MCUMGR_TRANSPORT_BT
+	GetDFUOverSMP().StartServer();
+#endif
+
+	return Nordic::Matter::StartServer();
+}
+
+CHIP_ERROR AppTask::StartApp()
+{
+	ReturnErrorOnFailure(Init());
+
+	while (true) {
+		TaskExecutor::DispatchNextTask();
+	}
+
+	return CHIP_NO_ERROR;
 }

--- a/applications/matter_weather_station/src/app_task.h
+++ b/applications/matter_weather_station/src/app_task.h
@@ -11,16 +11,6 @@
 #include <app/clusters/identify-server/identify-server.h>
 #include <platform/CHIPDeviceLayer.h>
 
-#ifdef CONFIG_MCUMGR_TRANSPORT_BT
-#include "dfu_over_smp.h"
-#endif
-
-#if CONFIG_CHIP_FACTORY_DATA
-#include <platform/nrfconnect/FactoryDataProvider.h>
-#else
-#include <platform/nrfconnect/DeviceInstanceInfoProviderImpl.h>
-#endif
-
 class AppTask {
 public:
 	static AppTask &Instance()
@@ -46,14 +36,9 @@ private:
 
 	static void MeasurementsTimerHandler();
 	static void IdentifyTimerHandler();
-	static void ChipEventHandler(const chip::DeviceLayer::ChipDeviceEvent *event, intptr_t arg);
+	static void MatterEventHandler(const chip::DeviceLayer::ChipDeviceEvent *event, intptr_t arg);
 
 	LEDWidget *mRedLED;
 	LEDWidget *mGreenLED;
 	LEDWidget *mBlueLED;
-
-
-#if CONFIG_CHIP_FACTORY_DATA
-	chip::DeviceLayer::FactoryDataProvider<chip::DeviceLayer::InternalFlashFactoryData> mFactoryDataProvider;
-#endif
 };

--- a/samples/matter/common/src/matter_init.cpp
+++ b/samples/matter/common/src/matter_init.cpp
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "matter_init.h"
+
+#include "fabric_table_delegate.h"
+
+#ifdef CONFIG_CHIP_OTA_REQUESTOR
+#include "ota_util.h"
+#endif
+
+#ifdef CONFIG_MCUMGR_TRANSPORT_BT
+#include "dfu_over_smp.h"
+#endif
+
+#include <app/clusters/network-commissioning/network-commissioning.h>
+#include <app/server/OnboardingCodesUtil.h>
+#include <credentials/examples/DeviceAttestationCredsExample.h>
+
+LOG_MODULE_DECLARE(app, CONFIG_CHIP_APP_LOG_LEVEL);
+
+using namespace ::chip::DeviceLayer;
+using namespace ::chip::Credentials;
+using namespace ::chip::app;
+using namespace ::chip;
+
+/* Definitions of default Matter interface implementations from InitData aggregate. */
+CommonCaseDeviceServerInitParams Nordic::Matter::InitData::sServerInitParamsDefault{};
+
+#ifdef CONFIG_CHIP_WIFI
+Clusters::NetworkCommissioning::Instance Nordic::Matter::InitData::sWiFiCommissioningInstance{
+	0, &(NetworkCommissioning::NrfWiFiDriver::Instance())
+};
+#endif
+
+#if CONFIG_CHIP_FACTORY_DATA
+FactoryDataProvider<InternalFlashFactoryData> Nordic::Matter::InitData::sDefaultFactoryDataProvider{};
+#endif
+namespace
+{
+/* Local instance of the initialization data that is overwritten by an application. */
+Nordic::Matter::InitData sLocalInitData
+{
+	.mNetworkingInstance = nullptr, .mServerInitParams = nullptr, .mDeviceInfoProvider = nullptr,
+#if CONFIG_CHIP_FACTORY_DATA
+	.mFactoryDataProvider = nullptr,
+#endif
+	.mPreServerInitClbk = nullptr, .mPostServerInitClbk = nullptr
+};
+
+/* Synchronization primitives */
+K_MUTEX_DEFINE(sInitMutex);
+K_CONDVAR_DEFINE(sInitCondVar);
+CHIP_ERROR sInitResult;
+bool sInitDone{ false };
+
+/* RAII utility to implement automatic cleanup and signalling. */
+struct InitGuard {
+	InitGuard()
+	{
+		sInitDone = false;
+		k_mutex_lock(&sInitMutex, K_FOREVER);
+	}
+	~InitGuard()
+	{
+		sInitDone = true;
+		k_condvar_signal(&sInitCondVar);
+		k_mutex_unlock(&sInitMutex);
+	}
+
+	static void Wait()
+	{
+		k_mutex_lock(&sInitMutex, K_FOREVER);
+		if (!sInitDone) {
+			k_condvar_wait(&sInitCondVar, &sInitMutex, K_FOREVER);
+		}
+		k_mutex_unlock(&sInitMutex);
+	}
+};
+
+/* Local helper functions. */
+#if defined(CONFIG_NET_L2_OPENTHREAD)
+CHIP_ERROR ConfigureThreadRole()
+{
+	using ThreadRole = ConnectivityManager::ThreadDeviceType;
+
+	ThreadRole threadRole{ ThreadRole::kThreadDeviceType_MinimalEndDevice };
+#ifdef CONFIG_OPENTHREAD_MTD_SED
+#ifdef CONFIG_CHIP_THREAD_SSED
+	threadRole = ThreadRole::kThreadDeviceType_SynchronizedSleepyEndDevice;
+#else
+	threadRole = ThreadRole::kThreadDeviceType_SleepyEndDevice;
+#endif /* CONFIG_CHIP_THREAD_SSED */
+#elif defined(CONFIG_OPENTHREAD_FTD)
+	threadRole = ThreadRole::kThreadDeviceType_Router;
+#endif /* CONFIG_OPENTHREAD_MTD_SED */
+
+	return ConnectivityMgr().SetThreadDeviceType(threadRole);
+}
+#endif /* CONFIG_NET_L2_OPENTHREAD */
+
+#define VerifyInitResultOrReturn(ec, msg)                                                                              \
+	VerifyOrReturn(ec == CHIP_NO_ERROR, LOG_ERR(msg " [Error: %d]", sInitResult.Format()))
+
+#define VerifyInitResultOrReturnError(ec, msg)                                                                         \
+	VerifyOrReturnError(ec == CHIP_NO_ERROR, ec, LOG_ERR(msg " [Error: %d]", sInitResult.Format()))
+
+void DoInitChipServer(intptr_t arg)
+{
+	InitGuard guard;
+	LOG_INF("Init CHIP stack");
+
+	if (sLocalInitData.mPreServerInitClbk) {
+		sInitResult = sLocalInitData.mPreServerInitClbk();
+		VerifyInitResultOrReturn(sInitResult, "Custom pre server initialization failed");
+	}
+
+#if defined(CONFIG_NET_L2_OPENTHREAD)
+	sInitResult = ThreadStackMgr().InitThreadStack();
+	VerifyInitResultOrReturn(sInitResult, "ThreadStackMgr().InitThreadStack() failed");
+
+	sInitResult = ConfigureThreadRole();
+	VerifyInitResultOrReturn(sInitResult, "Cannot configure Thread role");
+
+#elif defined(CONFIG_CHIP_WIFI)
+	if (!sLocalInitData.mNetworkingInstance) {
+		sInitResult = CHIP_ERROR_INTERNAL;
+		VerifyInitResultOrReturn(sInitResult, "No valid commissioning instance");
+	}
+	sLocalInitData.mNetworkingInstance->Init();
+#else
+	sInitResult = CHIP_ERROR_INTERNAL;
+	VerifyInitResultOrReturn(sInitResult, "No valid L2 network backend selected");
+#endif /* CONFIG_NET_L2_OPENTHREAD */
+
+#ifdef CONFIG_CHIP_OTA_REQUESTOR
+	/* OTA image confirmation must be done before the factory data init. */
+	OtaConfirmNewImage();
+#endif
+
+#ifdef CONFIG_MCUMGR_TRANSPORT_BT
+	/* Initialize DFU over SMP */
+	GetDFUOverSMP().Init();
+	GetDFUOverSMP().ConfirmNewImage();
+#endif
+
+	/* Initialize CHIP server */
+#if CONFIG_CHIP_FACTORY_DATA
+	if (sLocalInitData.mFactoryDataProvider) {
+		sInitResult = sLocalInitData.mFactoryDataProvider->Init();
+		VerifyInitResultOrReturn(sInitResult, "FactoryDataProvider::Init() failed");
+	}
+
+	SetDeviceInstanceInfoProvider(sLocalInitData.mFactoryDataProvider);
+	SetDeviceAttestationCredentialsProvider(sLocalInitData.mFactoryDataProvider);
+	SetCommissionableDataProvider(sLocalInitData.mFactoryDataProvider);
+#else
+	SetDeviceInstanceInfoProvider(&DeviceInstanceInfoProviderMgrImpl());
+	SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
+	/* The default CommissionableDataProvider is set internally in the GenericConfigurationManagerImpl::Init(). */
+#endif
+
+	VerifyOrReturn(sLocalInitData.mServerInitParams, LOG_ERR("No valid server initialization parameters"));
+	sInitResult = sLocalInitData.mServerInitParams->InitializeStaticResourcesBeforeServerInit();
+	VerifyInitResultOrReturn(sInitResult, "InitializeStaticResourcesBeforeServerInit() failed");
+
+	sInitResult = PlatformMgr().AddEventHandler(reinterpret_cast<PlatformManager::EventHandlerFunct>(arg), 0);
+	VerifyInitResultOrReturn(sInitResult, "Cannot register CHIP event handler");
+
+	SetDeviceInfoProvider(sLocalInitData.mDeviceInfoProvider);
+
+	sInitResult = Server::GetInstance().Init(*sLocalInitData.mServerInitParams);
+	VerifyInitResultOrReturn(sInitResult, "Server::Init() failed");
+
+	ConfigurationMgr().LogDeviceConfig();
+	PrintOnboardingCodes(RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
+	AppFabricTableDelegate::Init();
+
+	if (sLocalInitData.mPostServerInitClbk) {
+		sInitResult = sLocalInitData.mPostServerInitClbk();
+		VerifyInitResultOrReturn(sInitResult, "Custom post server initialization failed");
+	}
+}
+
+CHIP_ERROR WaitForReadiness()
+{
+	InitGuard::Wait();
+	return sInitResult;
+}
+} // namespace
+
+/* Public API */
+namespace Nordic
+{
+namespace Matter
+{
+	CHIP_ERROR PrepareServer(PlatformManager::EventHandlerFunct matterEventHandler, const InitData &initData)
+	{
+		sLocalInitData = initData;
+
+		/* Before we schedule anything to execute in the CHIP thread, the platform memory
+		   and the stack itself must be initialized first. */
+		CHIP_ERROR err = Platform::MemoryInit();
+		VerifyInitResultOrReturnError(err, "Platform::MemoryInit() failed");
+		err = PlatformMgr().InitChipStack();
+		VerifyInitResultOrReturnError(err, "PlatformMgr().InitChipStack() failed");
+
+		/* Schedule all CHIP initializations to the CHIP thread for better synchronization. */
+		return PlatformMgr().ScheduleWork(DoInitChipServer, reinterpret_cast<intptr_t>(matterEventHandler));
+	}
+
+	CHIP_ERROR StartServer()
+	{
+		CHIP_ERROR err = PlatformMgr().StartEventLoopTask();
+		VerifyInitResultOrReturnError(err, "PlatformMgr().StartEventLoopTask() failed");
+		return WaitForReadiness();
+	}
+
+#if CONFIG_CHIP_FACTORY_DATA
+	FactoryDataProviderBase *GetFactoryDataProvider()
+	{
+		return sLocalInitData.mFactoryDataProvider;
+	}
+#endif
+
+} // namespace Matter
+} // namespace Nordic

--- a/samples/matter/common/src/matter_init.h
+++ b/samples/matter/common/src/matter_init.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#pragma once
+
+#include <DeviceInfoProviderImpl.h>
+#include <app/clusters/network-commissioning/network-commissioning.h>
+#include <app/server/Server.h>
+#include <lib/core/Optional.h>
+#include <lib/support/Variant.h>
+#include <platform/PlatformManager.h>
+
+#ifdef CONFIG_CHIP_WIFI
+#include <platform/nrfconnect/wifi/NrfWiFiDriver.h>
+#endif
+
+#if CONFIG_CHIP_FACTORY_DATA
+#include <platform/nrfconnect/FactoryDataProvider.h>
+#else
+#include <platform/nrfconnect/DeviceInstanceInfoProviderImpl.h>
+#endif
+
+namespace Nordic
+{
+namespace Matter
+{
+	using CustomInit = CHIP_ERROR (*)(void);
+
+	/** @brief Matter initialization data.
+	 *
+	 * This structure contains all user specific implementations of Matter interfaces
+	 * and custom initialization callbacks that must be initialized in the Matter thread.
+	 */
+	struct InitData {
+		/** @brief Pointer to the user provided NetworkCommissioning instance. */
+#ifdef CONFIG_CHIP_WIFI
+		chip::app::Clusters::NetworkCommissioning::Instance *mNetworkingInstance{ &sWiFiCommissioningInstance };
+#else
+		chip::app::Clusters::NetworkCommissioning::Instance *mNetworkingInstance{ nullptr };
+#endif
+		/** @brief Pointer to the user provided custom server initialization parameters. */
+		chip::CommonCaseDeviceServerInitParams *mServerInitParams{ &sServerInitParamsDefault };
+		/** @brief Pointer to the user provided custom device info provider implementation. */
+		chip::DeviceLayer::DeviceInfoProviderImpl *mDeviceInfoProvider{ nullptr };
+#if CONFIG_CHIP_FACTORY_DATA
+		/** @brief Pointer to the user provided FactoryDataProvider implementation. */
+		chip::DeviceLayer::FactoryDataProviderBase *mFactoryDataProvider{ &sDefaultFactoryDataProvider };
+#endif
+		/** @brief Custom code to execute in the Matter main event loop before the server initialization. */
+		CustomInit mPreServerInitClbk{ nullptr };
+		/** @brief Custom code to execute in the Matter main event loop after the server initialization. */
+		CustomInit mPostServerInitClbk{ nullptr };
+
+		/** @brief Default implementation static objects that will be stripped by the compiler when above
+		 * pointers are overwritten by the application. */
+#ifdef CONFIG_CHIP_WIFI
+		static chip::app::Clusters::NetworkCommissioning::Instance sWiFiCommissioningInstance;
+#endif
+		static chip::CommonCaseDeviceServerInitParams sServerInitParamsDefault;
+#if CONFIG_CHIP_FACTORY_DATA
+		static chip::DeviceLayer::FactoryDataProvider<chip::DeviceLayer::InternalFlashFactoryData>
+			sDefaultFactoryDataProvider;
+#endif
+	};
+
+	/**
+	 * @brief Prepare Matter server.
+	 *
+	 * This function schedules initialization of all Matter server components including memory, networking backed
+	 * and factory data in the Matter thread. After this function is used, the StartServer() must be called to
+	 * start the Matter thread, eventually execute the initialization and wait to synchronize the caller's thread
+	 * with the Matter thread.
+	 *
+	 * If the initData argument is not provided, the default configuration is applied.
+	 *
+	 * @param matterEventHandler callback that implements handling of events propagated by the Matter server
+	 * @param initData optional initialization data
+	 * @return CHIP_NO_ERROR on success, other error code otherwise
+	 */
+	CHIP_ERROR PrepareServer(chip::DeviceLayer::PlatformManager::EventHandlerFunct matterEventHandler,
+				 const InitData &initData = InitData{});
+
+	/**
+	 * @brief Start Matter server and wait until it is initialized.
+	 *
+	 * This is a blocking function which starts the Matter event loop task (CHIP thread)
+	 * and waits until all Matter server components are initialized.
+	 *
+	 * @return CHIP_NO_ERROR on success, other error code otherwise
+	 */
+	CHIP_ERROR StartServer();
+
+#if CONFIG_CHIP_FACTORY_DATA
+	/**
+	 * @brief Get the currently set FactoryDataProvider.
+	 *
+	 * Returns generic pointer to the FactoryDataProvider object that was
+	 * either set externally by the user or internally by default initialization.
+	 *
+	 * @return pointer to the stored FactoryDataProviderBase
+	 */
+	chip::DeviceLayer::FactoryDataProviderBase *GetFactoryDataProvider();
+#endif
+
+} // namespace Matter
+} // namespace Nordic

--- a/samples/matter/light_bulb/CMakeLists.txt
+++ b/samples/matter/light_bulb/CMakeLists.txt
@@ -51,6 +51,7 @@ target_sources(app PRIVATE
     ${COMMON_ROOT}/src/pwm_device.cpp
     ${COMMON_ROOT}/src/task_executor.cpp
     ${COMMON_ROOT}/src/board.cpp
+    ${COMMON_ROOT}/src/matter_init.cpp
 )
 
 if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_TRANSPORT_BT)

--- a/samples/matter/light_bulb/src/app_task.h
+++ b/samples/matter/light_bulb/src/app_task.h
@@ -11,16 +11,6 @@
 
 #include <platform/CHIPDeviceLayer.h>
 
-#if CONFIG_CHIP_FACTORY_DATA
-#include <platform/nrfconnect/FactoryDataProvider.h>
-#else
-#include <platform/nrfconnect/DeviceInstanceInfoProviderImpl.h>
-#endif
-
-#ifdef CONFIG_MCUMGR_TRANSPORT_BT
-#include "dfu_over_smp.h"
-#endif
-
 struct k_timer;
 struct Identify;
 
@@ -55,7 +45,7 @@ private:
 	static void LightingActionEventHandler(const LightingEvent &event);
 	static void ButtonEventHandler(ButtonState state, ButtonMask hasChanged);
 
-	static void ChipEventHandler(const chip::DeviceLayer::ChipDeviceEvent *event, intptr_t arg);
+	static void MatterEventHandler(const chip::DeviceLayer::ChipDeviceEvent *event, intptr_t arg);
 
 	static void ActionInitiated(PWMDevice::Action_t action, int32_t actor);
 	static void ActionCompleted(PWMDevice::Action_t action, int32_t actor);
@@ -65,7 +55,4 @@ private:
 #endif
 
 	PWMDevice mPWMDevice;
-#if CONFIG_CHIP_FACTORY_DATA
-	chip::DeviceLayer::FactoryDataProvider<chip::DeviceLayer::InternalFlashFactoryData> mFactoryDataProvider;
-#endif
 };

--- a/samples/matter/light_switch/CMakeLists.txt
+++ b/samples/matter/light_switch/CMakeLists.txt
@@ -48,8 +48,9 @@ target_sources(app PRIVATE
     src/zap-generated/callback-stub.cpp
     ${COMMON_ROOT}/src/binding_handler.cpp
     ${COMMON_ROOT}/src/led_widget.cpp
-    ${COMMON_ROOT}/src/board.cpp
     ${COMMON_ROOT}/src/task_executor.cpp
+    ${COMMON_ROOT}/src/board.cpp
+    ${COMMON_ROOT}/src/matter_init.cpp
 )
 
 if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_TRANSPORT_BT)

--- a/samples/matter/light_switch/src/app_task.cpp
+++ b/samples/matter/light_switch/src/app_task.cpp
@@ -6,41 +6,24 @@
 
 #include "app_task.h"
 
-#include "fabric_table_delegate.h"
 #include "light_switch.h"
+#include "matter_init.h"
 #include "task_executor.h"
-
-#include <platform/CHIPDeviceLayer.h>
 
 #include "board.h"
 #include <app/clusters/identify-server/identify-server.h>
 #include <app/server/OnboardingCodesUtil.h>
-#include <app/server/Server.h>
-#include <credentials/DeviceAttestationCredsProvider.h>
-#include <credentials/examples/DeviceAttestationCredsExample.h>
-#include <lib/support/CHIPMem.h>
-#include <lib/support/CodeUtils.h>
-#include <lib/support/SafeInt.h>
-
-#include <system/SystemError.h>
-
-#ifdef CONFIG_CHIP_WIFI
-#include <app/clusters/network-commissioning/network-commissioning.h>
-#include <platform/nrfconnect/wifi/NrfWiFiDriver.h>
-#endif
 
 #ifdef CONFIG_CHIP_OTA_REQUESTOR
 #include "ota_util.h"
 #endif
 
-#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 
 LOG_MODULE_DECLARE(app, CONFIG_CHIP_APP_LOG_LEVEL);
 
 using namespace ::chip;
 using namespace ::chip::app;
-using namespace ::chip::Credentials;
 using namespace ::chip::DeviceLayer;
 
 namespace
@@ -59,119 +42,6 @@ bool sWasDimmerTriggered = false;
 
 #define APPLICATION_BUTTON_MASK DK_BTN2_MSK
 } /* namespace */
-
-#ifdef CONFIG_CHIP_WIFI
-app::Clusters::NetworkCommissioning::Instance
-	sWiFiCommissioningInstance(0, &(NetworkCommissioning::NrfWiFiDriver::Instance()));
-#endif
-
-CHIP_ERROR AppTask::Init()
-{
-	/* Initialize CHIP stack */
-	LOG_INF("Init CHIP stack");
-
-	CHIP_ERROR err = chip::Platform::MemoryInit();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("Platform::MemoryInit() failed");
-		return err;
-	}
-
-	err = PlatformMgr().InitChipStack();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("PlatformMgr().InitChipStack() failed");
-		return err;
-	}
-
-#if defined(CONFIG_NET_L2_OPENTHREAD)
-	err = ThreadStackMgr().InitThreadStack();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("ThreadStackMgr().InitThreadStack() failed: %s", ErrorStr(err));
-		return err;
-	}
-
-#ifdef CONFIG_OPENTHREAD_MTD_SED
-	err = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_SleepyEndDevice);
-#else
-	err = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_MinimalEndDevice);
-#endif /* CONFIG_OPENTHREAD_MTD_SED */
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("ConnectivityMgr().SetThreadDeviceType() failed: %s", ErrorStr(err));
-		return err;
-	}
-
-#elif defined(CONFIG_CHIP_WIFI)
-	sWiFiCommissioningInstance.Init();
-#else
-	return CHIP_ERROR_INTERNAL;
-#endif /* CONFIG_NET_L2_OPENTHREAD */
-
-	/* Initialize application timers */
-	k_timer_init(&sDimmerPressKeyTimer, AppTask::UserTimerTimeoutCallback, nullptr);
-	k_timer_init(&sDimmerTimer, AppTask::UserTimerTimeoutCallback, nullptr);
-
-#ifdef CONFIG_CHIP_OTA_REQUESTOR
-	/* OTA image confirmation must be done before the factory data init. */
-	OtaConfirmNewImage();
-#endif
-
-#ifdef CONFIG_MCUMGR_TRANSPORT_BT
-	/* Initialize DFU over SMP */
-	GetDFUOverSMP().Init();
-	GetDFUOverSMP().ConfirmNewImage();
-#endif
-
-	/* Initialize CHIP server */
-#if CONFIG_CHIP_FACTORY_DATA
-	ReturnErrorOnFailure(mFactoryDataProvider.Init());
-	SetDeviceInstanceInfoProvider(&mFactoryDataProvider);
-	SetDeviceAttestationCredentialsProvider(&mFactoryDataProvider);
-	SetCommissionableDataProvider(&mFactoryDataProvider);
-#else
-	SetDeviceInstanceInfoProvider(&DeviceInstanceInfoProviderMgrImpl());
-	SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
-#endif
-
-	static CommonCaseDeviceServerInitParams initParams;
-	(void)initParams.InitializeStaticResourcesBeforeServerInit();
-
-	ReturnErrorOnFailure(chip::Server::GetInstance().Init(initParams));
-	ConfigurationMgr().LogDeviceConfig();
-	PrintOnboardingCodes(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
-	AppFabricTableDelegate::Init();
-
-	LightSwitch::GetInstance().Init(kLightSwitchEndpointId);
-
-	if (!GetBoard().Init(ButtonEventHandler)) {
-		LOG_ERR("User interface initialization failed.");
-		return CHIP_ERROR_INCORRECT_STATE;
-	}
-
-	/*
-	 * Add CHIP event handler and start CHIP thread.
-	 * Note that all the initialization code should happen prior to this point to avoid data races
-	 * between the main and the CHIP threads.
-	 */
-	PlatformMgr().AddEventHandler(ChipEventHandler, 0);
-
-	err = PlatformMgr().StartEventLoopTask();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("PlatformMgr().StartEventLoopTask() failed");
-		return err;
-	}
-
-	return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR AppTask::StartApp()
-{
-	ReturnErrorOnFailure(Init());
-
-	while (true) {
-		TaskExecutor::DispatchNextTask();
-	}
-
-	return CHIP_NO_ERROR;
-}
 
 void AppTask::DimmerTriggerEventHandler()
 {
@@ -212,7 +82,7 @@ void AppTask::IdentifyStopHandler(Identify *)
 	TaskExecutor::PostTask([] { GetBoard().GetLED(DeviceLeds::LED2).Set(false); });
 }
 
-void AppTask::ChipEventHandler(const ChipDeviceEvent *event, intptr_t /* arg */)
+void AppTask::MatterEventHandler(const ChipDeviceEvent *event, intptr_t /* arg */)
 {
 	bool isNetworkProvisioned = false;
 
@@ -318,4 +188,36 @@ void AppTask::UserTimerTimeoutCallback(k_timer *timer)
 	}
 
 	TaskExecutor::PostTask([timerType]() { TimerEventHandler(timerType); });
+}
+
+CHIP_ERROR AppTask::Init()
+{
+	/* Initialize Matter stack */
+	ReturnErrorOnFailure(
+		Nordic::Matter::PrepareServer(MatterEventHandler, Nordic::Matter::InitData{ .mPostServerInitClbk = [] {
+						      LightSwitch::GetInstance().Init(kLightSwitchEndpointId);
+						      return CHIP_NO_ERROR;
+					      } }));
+
+	/* Initialize application timers */
+	k_timer_init(&sDimmerPressKeyTimer, AppTask::UserTimerTimeoutCallback, nullptr);
+	k_timer_init(&sDimmerTimer, AppTask::UserTimerTimeoutCallback, nullptr);
+
+	if (!GetBoard().Init(ButtonEventHandler)) {
+		LOG_ERR("User interface initialization failed.");
+		return CHIP_ERROR_INCORRECT_STATE;
+	}
+
+	return Nordic::Matter::StartServer();
+}
+
+CHIP_ERROR AppTask::StartApp()
+{
+	ReturnErrorOnFailure(Init());
+
+	while (true) {
+		TaskExecutor::DispatchNextTask();
+	}
+
+	return CHIP_NO_ERROR;
 }

--- a/samples/matter/light_switch/src/app_task.h
+++ b/samples/matter/light_switch/src/app_task.h
@@ -10,16 +10,6 @@
 
 #include <platform/CHIPDeviceLayer.h>
 
-#if CONFIG_CHIP_FACTORY_DATA
-#include <platform/nrfconnect/FactoryDataProvider.h>
-#else
-#include <platform/nrfconnect/DeviceInstanceInfoProviderImpl.h>
-#endif
-
-#ifdef CONFIG_MCUMGR_TRANSPORT_BT
-#include "dfu_over_smp.h"
-#endif
-
 struct k_timer;
 struct Identify;
 
@@ -51,9 +41,5 @@ private:
 	static void CancelTimer(Timer);
 	static void UserTimerTimeoutCallback(k_timer *timer);
 
-	static void ChipEventHandler(const chip::DeviceLayer::ChipDeviceEvent *event, intptr_t arg);
-
-#if CONFIG_CHIP_FACTORY_DATA
-	chip::DeviceLayer::FactoryDataProvider<chip::DeviceLayer::InternalFlashFactoryData> mFactoryDataProvider;
-#endif
+	static void MatterEventHandler(const chip::DeviceLayer::ChipDeviceEvent *event, intptr_t arg);
 };

--- a/samples/matter/lock/CMakeLists.txt
+++ b/samples/matter/lock/CMakeLists.txt
@@ -52,6 +52,7 @@ target_sources(app PRIVATE
     ${COMMON_ROOT}/src/led_widget.cpp
     ${COMMON_ROOT}/src/task_executor.cpp
     ${COMMON_ROOT}/src/board.cpp
+    ${COMMON_ROOT}/src/matter_init.cpp
 )
 
 if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_TRANSPORT_BT)

--- a/samples/matter/lock/src/app_task.cpp
+++ b/samples/matter/lock/src/app_task.cpp
@@ -5,36 +5,21 @@
  */
 
 #include "app_task.h"
-#include "task_executor.h"
 
 #include "bolt_lock_manager.h"
-#include "fabric_table_delegate.h"
-
-#ifdef CONFIG_MCUMGR_TRANSPORT_BT
-#include "dfu_over_smp.h"
-#endif
+#include "task_executor.h"
 
 #ifdef CONFIG_CHIP_NUS
 #include "bt_nus_service.h"
 #endif
 
-#include <platform/CHIPDeviceLayer.h>
+#include "matter_init.h"
 
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/clusters/door-lock-server/door-lock-server.h>
 #include <app/clusters/identify-server/identify-server.h>
 #include <app/server/OnboardingCodesUtil.h>
-#include <app/server/Server.h>
-#include <credentials/DeviceAttestationCredsProvider.h>
-#include <credentials/examples/DeviceAttestationCredsExample.h>
-#include <lib/support/CHIPMem.h>
-#include <lib/support/CodeUtils.h>
-#include <system/SystemError.h>
-
-#ifdef CONFIG_CHIP_WIFI
-#include <app/clusters/network-commissioning/network-commissioning.h>
-#include <platform/nrfconnect/wifi/NrfWiFiDriver.h>
-#endif
+#include <platform/CHIPDeviceLayer.h>
 
 #ifdef CONFIG_CHIP_OTA_REQUESTOR
 #include "ota_util.h"
@@ -44,16 +29,12 @@
 #include "thread_wifi_switch.h"
 #endif
 
-#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
-
-#include <app/InteractionModelEngine.h>
 
 LOG_MODULE_DECLARE(app, CONFIG_CHIP_APP_LOG_LEVEL);
 
 using namespace ::chip;
 using namespace ::chip::app;
-using namespace ::chip::Credentials;
 using namespace ::chip::DeviceLayer;
 
 namespace
@@ -77,137 +58,6 @@ constexpr uint32_t kSwitchTransportTimeout = 10000;
 
 Identify sIdentify = { kLockEndpointId, AppTask::IdentifyStartHandler, AppTask::IdentifyStopHandler,
 		       Clusters::Identify::IdentifyTypeEnum::kVisibleIndicator };
-
-#ifdef CONFIG_CHIP_WIFI
-app::Clusters::NetworkCommissioning::Instance
-	sWiFiCommissioningInstance(0, &(NetworkCommissioning::NrfWiFiDriver::Instance()));
-#endif
-
-CHIP_ERROR AppTask::Init()
-{
-	/* Initialize CHIP stack */
-	LOG_INF("Init CHIP stack");
-
-	CHIP_ERROR err = chip::Platform::MemoryInit();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("Platform::MemoryInit() failed");
-		return err;
-	}
-
-	err = PlatformMgr().InitChipStack();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("PlatformMgr().InitChipStack() failed");
-		return err;
-	}
-
-#if defined(CONFIG_NET_L2_OPENTHREAD)
-	err = ThreadStackMgr().InitThreadStack();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("ThreadStackMgr().InitThreadStack() failed: %s", ErrorStr(err));
-		return err;
-	}
-
-#ifdef CONFIG_OPENTHREAD_MTD_SED
-	err = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_SleepyEndDevice);
-#else
-	err = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_MinimalEndDevice);
-#endif /* CONFIG_OPENTHREAD_MTD_SED */
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("ConnectivityMgr().SetThreadDeviceType() failed: %s", ErrorStr(err));
-		return err;
-	}
-#endif /* CONFIG_NET_L2_OPENTHREAD */
-
-#ifdef CONFIG_THREAD_WIFI_SWITCHING
-	err = ThreadWifiSwitch::StartCurrentTransport();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("ThreadWifiSwitch::StartCurrentTransport() failed: %" CHIP_ERROR_FORMAT, err.Format());
-		return err;
-	}
-#elif defined(CONFIG_CHIP_WIFI)
-	sWiFiCommissioningInstance.Init();
-#endif
-
-	if (!GetBoard().Init(ButtonEventHandler)) {
-		LOG_ERR("User interface initialization failed.");
-		return CHIP_ERROR_INCORRECT_STATE;
-	}
-
-#ifdef CONFIG_THREAD_WIFI_SWITCHING
-	k_timer_init(&sSwitchTransportTimer, &AppTask::SwitchTransportTimerTimeoutCallback, nullptr);
-#endif
-
-#ifdef CONFIG_CHIP_NUS
-	/* Initialize Nordic UART Service for Lock purposes */
-	if (!GetNUSService().Init(kLockNUSPriority, kAdvertisingIntervalMin, kAdvertisingIntervalMax)) {
-		ChipLogError(Zcl, "Cannot initialize NUS service");
-	}
-	GetNUSService().RegisterCommand("Lock", sizeof("Lock"), NUSLockCallback, nullptr);
-	GetNUSService().RegisterCommand("Unlock", sizeof("Unlock"), NUSUnlockCallback, nullptr);
-	if (!GetNUSService().StartServer()) {
-		LOG_ERR("GetNUSService().StartServer() failed");
-	}
-#endif
-
-	/* Initialize lock manager */
-	BoltLockMgr().Init(LockStateChanged);
-
-#ifdef CONFIG_CHIP_OTA_REQUESTOR
-	/* OTA image confirmation must be done before the factory data init. */
-	OtaConfirmNewImage();
-#endif
-
-#ifdef CONFIG_MCUMGR_TRANSPORT_BT
-	/* Initialize DFU over SMP */
-	GetDFUOverSMP().Init();
-	GetDFUOverSMP().ConfirmNewImage();
-#endif
-
-	/* Initialize CHIP server */
-#if CONFIG_CHIP_FACTORY_DATA
-	ReturnErrorOnFailure(mFactoryDataProvider.Init());
-	SetDeviceInstanceInfoProvider(&mFactoryDataProvider);
-	SetDeviceAttestationCredentialsProvider(&mFactoryDataProvider);
-	SetCommissionableDataProvider(&mFactoryDataProvider);
-#else
-	SetDeviceInstanceInfoProvider(&DeviceInstanceInfoProviderMgrImpl());
-	SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
-#endif
-
-	static chip::CommonCaseDeviceServerInitParams initParams;
-	(void)initParams.InitializeStaticResourcesBeforeServerInit();
-
-	ReturnErrorOnFailure(chip::Server::GetInstance().Init(initParams));
-	ConfigurationMgr().LogDeviceConfig();
-	PrintOnboardingCodes(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
-	AppFabricTableDelegate::Init();
-
-	/*
-	 * Add CHIP event handler and start CHIP thread.
-	 * Note that all the initialization code should happen prior to this point to avoid data races
-	 * between the main and the CHIP threads.
-	 */
-	PlatformMgr().AddEventHandler(ChipEventHandler, 0);
-
-	err = PlatformMgr().StartEventLoopTask();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("PlatformMgr().StartEventLoopTask() failed");
-		return err;
-	}
-
-	return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR AppTask::StartApp()
-{
-	ReturnErrorOnFailure(Init());
-
-	while (true) {
-		TaskExecutor::DispatchNextTask();
-	}
-
-	return CHIP_NO_ERROR;
-}
 
 void AppTask::IdentifyStartHandler(Identify *)
 {
@@ -269,7 +119,7 @@ void AppTask::SwitchTransportTriggerHandler(const SwitchButtonAction &action)
 }
 #endif
 
-void AppTask::ChipEventHandler(const ChipDeviceEvent *event, intptr_t /* arg */)
+void AppTask::MatterEventHandler(const ChipDeviceEvent *event, intptr_t /* arg */)
 {
 	bool isNetworkProvisioned = false;
 
@@ -413,3 +263,61 @@ void AppTask::NUSUnlockCallback(void *context)
 	}
 }
 #endif
+
+CHIP_ERROR AppTask::Init()
+{
+	/* Initialize Matter stack */
+#ifdef CONFIG_THREAD_WIFI_SWITCHING
+	/* In the Thread/Wi-Fi switchable mode, it is the ThreadWifiSwitch module that owns the NetworkCommissioning
+	   instances, so offload the initialization module from controlling that by explicitly setting the
+	   mNetworkingInstance parameter to nullptr. Otherwise, the initialization module instantiates the
+	   NetworkCommissioning object and handles it by default internally. */
+	ReturnErrorOnFailure(Nordic::Matter::PrepareServer(MatterEventHandler,
+							   Nordic::Matter::InitData{ .mNetworkingInstance = nullptr }));
+#else
+	ReturnErrorOnFailure(Nordic::Matter::PrepareServer(MatterEventHandler));
+#endif
+
+	if (!GetBoard().Init(ButtonEventHandler)) {
+		LOG_ERR("User interface initialization failed.");
+		return CHIP_ERROR_INCORRECT_STATE;
+	}
+
+#ifdef CONFIG_THREAD_WIFI_SWITCHING
+	CHIP_ERROR err = ThreadWifiSwitch::StartCurrentTransport();
+	if (err != CHIP_NO_ERROR) {
+		LOG_ERR("ThreadWifiSwitch::StartCurrentTransport() failed: %" CHIP_ERROR_FORMAT, err.Format());
+		return err;
+	}
+
+	k_timer_init(&sSwitchTransportTimer, &AppTask::SwitchTransportTimerTimeoutCallback, nullptr);
+#endif
+
+#ifdef CONFIG_CHIP_NUS
+	/* Initialize Nordic UART Service for Lock purposes */
+	if (!GetNUSService().Init(kLockNUSPriority, kAdvertisingIntervalMin, kAdvertisingIntervalMax)) {
+		ChipLogError(Zcl, "Cannot initialize NUS service");
+	}
+	GetNUSService().RegisterCommand("Lock", sizeof("Lock"), NUSLockCallback, nullptr);
+	GetNUSService().RegisterCommand("Unlock", sizeof("Unlock"), NUSUnlockCallback, nullptr);
+	if (!GetNUSService().StartServer()) {
+		LOG_ERR("GetNUSService().StartServer() failed");
+	}
+#endif
+
+	/* Initialize lock manager */
+	BoltLockMgr().Init(LockStateChanged);
+
+	return Nordic::Matter::StartServer();
+}
+
+CHIP_ERROR AppTask::StartApp()
+{
+	ReturnErrorOnFailure(Init());
+
+	while (true) {
+		TaskExecutor::DispatchNextTask();
+	}
+
+	return CHIP_NO_ERROR;
+}

--- a/samples/matter/lock/src/app_task.h
+++ b/samples/matter/lock/src/app_task.h
@@ -10,14 +10,6 @@
 #include "bolt_lock_manager.h"
 #include "led_widget.h"
 
-#include <platform/CHIPDeviceLayer.h>
-
-#if CONFIG_CHIP_FACTORY_DATA
-#include <platform/nrfconnect/FactoryDataProvider.h>
-#else
-#include <platform/nrfconnect/DeviceInstanceInfoProviderImpl.h>
-#endif
-
 #ifdef CONFIG_MCUMGR_TRANSPORT_BT
 #include "dfu_over_smp.h"
 #endif
@@ -48,7 +40,7 @@ private:
 
 	static void LockActionEventHandler();
 	static void ButtonEventHandler(ButtonState state, ButtonMask hasChanged);
-	static void ChipEventHandler(const chip::DeviceLayer::ChipDeviceEvent *event, intptr_t arg);
+	static void MatterEventHandler(const chip::DeviceLayer::ChipDeviceEvent *event, intptr_t arg);
 	static void LockStateChanged(BoltLockManager::State state, BoltLockManager::OperationSource source);
 
 #ifdef CONFIG_THREAD_WIFI_SWITCHING
@@ -60,9 +52,5 @@ private:
 #ifdef CONFIG_CHIP_NUS
 	static void NUSLockCallback(void *context);
 	static void NUSUnlockCallback(void *context);
-#endif
-
-#if CONFIG_CHIP_FACTORY_DATA
-	chip::DeviceLayer::FactoryDataProvider<chip::DeviceLayer::InternalFlashFactoryData> mFactoryDataProvider;
 #endif
 };

--- a/samples/matter/template/CMakeLists.txt
+++ b/samples/matter/template/CMakeLists.txt
@@ -45,6 +45,7 @@ target_sources(app PRIVATE
     ${COMMON_ROOT}/src/led_widget.cpp
     ${COMMON_ROOT}/src/task_executor.cpp
     ${COMMON_ROOT}/src/board.cpp
+    ${COMMON_ROOT}/src/matter_init.cpp
 )
 
 if(CONFIG_CHIP_OTA_REQUESTOR)

--- a/samples/matter/template/src/app_task.cpp
+++ b/samples/matter/template/src/app_task.cpp
@@ -5,143 +5,26 @@
  */
 
 #include "app_task.h"
-#include "fabric_table_delegate.h"
-#include "task_executor.h"
-#include "board.h"
 
-#include <platform/CHIPDeviceLayer.h>
+#include "board.h"
+#include "matter_init.h"
+#include "task_executor.h"
 
 #include <app/server/OnboardingCodesUtil.h>
-#include <app/server/Server.h>
-#include <credentials/DeviceAttestationCredsProvider.h>
-#include <credentials/examples/DeviceAttestationCredsExample.h>
-#include <lib/support/CHIPMem.h>
-#include <lib/support/CodeUtils.h>
-#include <system/SystemError.h>
-
-#ifdef CONFIG_CHIP_WIFI
-#include <app/clusters/network-commissioning/network-commissioning.h>
-#include <platform/nrfconnect/wifi/NrfWiFiDriver.h>
-#endif
 
 #ifdef CONFIG_CHIP_OTA_REQUESTOR
 #include "ota_util.h"
 #endif
 
-#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 
 LOG_MODULE_DECLARE(app, CONFIG_CHIP_APP_LOG_LEVEL);
 
 using namespace ::chip;
 using namespace ::chip::app;
-using namespace ::chip::Credentials;
 using namespace ::chip::DeviceLayer;
 
-#ifdef CONFIG_CHIP_WIFI
-app::Clusters::NetworkCommissioning::Instance
-	sWiFiCommissioningInstance(0, &(NetworkCommissioning::NrfWiFiDriver::Instance()));
-#endif
-
-CHIP_ERROR AppTask::Init()
-{
-	/* Initialize CHIP stack */
-	LOG_INF("Init CHIP stack");
-
-	CHIP_ERROR err = chip::Platform::MemoryInit();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("Platform::MemoryInit() failed");
-		return err;
-	}
-
-	err = PlatformMgr().InitChipStack();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("PlatformMgr().InitChipStack() failed");
-		return err;
-	}
-
-#if defined(CONFIG_NET_L2_OPENTHREAD)
-	err = ThreadStackMgr().InitThreadStack();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("ThreadStackMgr().InitThreadStack() failed: %s", ErrorStr(err));
-		return err;
-	}
-
-#ifdef CONFIG_OPENTHREAD_MTD_SED
-	err = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_SleepyEndDevice);
-#elif CONFIG_OPENTHREAD_MTD
-	err = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_MinimalEndDevice);
-#else
-	err = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_Router);
-#endif /* CONFIG_OPENTHREAD_MTD_SED */
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("ConnectivityMgr().SetThreadDeviceType() failed: %s", ErrorStr(err));
-		return err;
-	}
-
-#elif defined(CONFIG_CHIP_WIFI)
-	sWiFiCommissioningInstance.Init();
-#else
-	return CHIP_ERROR_INTERNAL;
-#endif /* CONFIG_NET_L2_OPENTHREAD */
-
-	if (!GetBoard().Init()) {
-		LOG_ERR("User interface initialization failed.");
-		return CHIP_ERROR_INCORRECT_STATE;
-	}
-
-#ifdef CONFIG_CHIP_OTA_REQUESTOR
-	/* OTA image confirmation must be done before the factory data init. */
-	OtaConfirmNewImage();
-#endif
-
-	/* Initialize CHIP server */
-#if CONFIG_CHIP_FACTORY_DATA
-	ReturnErrorOnFailure(mFactoryDataProvider.Init());
-	SetDeviceInstanceInfoProvider(&mFactoryDataProvider);
-	SetDeviceAttestationCredentialsProvider(&mFactoryDataProvider);
-	SetCommissionableDataProvider(&mFactoryDataProvider);
-#else
-	SetDeviceInstanceInfoProvider(&DeviceInstanceInfoProviderMgrImpl());
-	SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
-#endif
-
-	static chip::CommonCaseDeviceServerInitParams initParams;
-	(void)initParams.InitializeStaticResourcesBeforeServerInit();
-
-	ReturnErrorOnFailure(chip::Server::GetInstance().Init(initParams));
-	ConfigurationMgr().LogDeviceConfig();
-	PrintOnboardingCodes(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
-	AppFabricTableDelegate::Init();
-
-	/*
-	 * Add CHIP event handler and start CHIP thread.
-	 * Note that all the initialization code should happen prior to this point to avoid data races
-	 * between the main and the CHIP threads.
-	 */
-	PlatformMgr().AddEventHandler(ChipEventHandler, 0);
-
-	err = PlatformMgr().StartEventLoopTask();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("PlatformMgr().StartEventLoopTask() failed");
-		return err;
-	}
-
-	return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR AppTask::StartApp()
-{
-	ReturnErrorOnFailure(Init());
-
-	while (true) {
-		TaskExecutor::DispatchNextTask();
-	}
-
-	return CHIP_NO_ERROR;
-}
-
-void AppTask::ChipEventHandler(const ChipDeviceEvent *event, intptr_t /* arg */)
+void AppTask::MatterEventHandler(const ChipDeviceEvent *event, intptr_t /* arg */)
 {
 	bool isNetworkProvisioned = false;
 
@@ -161,7 +44,8 @@ void AppTask::ChipEventHandler(const ChipDeviceEvent *event, intptr_t /* arg */)
 		isNetworkProvisioned = ConnectivityMgr().IsThreadProvisioned() && ConnectivityMgr().IsThreadEnabled();
 #elif defined(CONFIG_CHIP_WIFI)
 	case DeviceEventType::kWiFiConnectivityChange:
-		isNetworkProvisioned = ConnectivityMgr().IsWiFiStationProvisioned() && ConnectivityMgr().IsWiFiStationEnabled();
+		isNetworkProvisioned =
+			ConnectivityMgr().IsWiFiStationProvisioned() && ConnectivityMgr().IsWiFiStationEnabled();
 #if CONFIG_CHIP_OTA_REQUESTOR
 		if (event->WiFiConnectivityChange.Result == kConnectivity_Established) {
 			InitBasicOTARequestor();
@@ -177,4 +61,28 @@ void AppTask::ChipEventHandler(const ChipDeviceEvent *event, intptr_t /* arg */)
 	default:
 		break;
 	}
+}
+
+CHIP_ERROR AppTask::Init()
+{
+	/* Initialize Matter stack */
+	ReturnErrorOnFailure(Nordic::Matter::PrepareServer(MatterEventHandler));
+
+	if (!GetBoard().Init()) {
+		LOG_ERR("User interface initialization failed.");
+		return CHIP_ERROR_INCORRECT_STATE;
+	}
+
+	return Nordic::Matter::StartServer();
+}
+
+CHIP_ERROR AppTask::StartApp()
+{
+	ReturnErrorOnFailure(Init());
+
+	while (true) {
+		TaskExecutor::DispatchNextTask();
+	}
+
+	return CHIP_NO_ERROR;
 }

--- a/samples/matter/template/src/app_task.h
+++ b/samples/matter/template/src/app_task.h
@@ -8,12 +8,6 @@
 
 #include <platform/CHIPDeviceLayer.h>
 
-#if CONFIG_CHIP_FACTORY_DATA
-#include <platform/nrfconnect/FactoryDataProvider.h>
-#else
-#include <platform/nrfconnect/DeviceInstanceInfoProviderImpl.h>
-#endif
-
 struct k_timer;
 
 class AppTask {
@@ -29,9 +23,5 @@ public:
 private:
 	CHIP_ERROR Init();
 
-	static void ChipEventHandler(const chip::DeviceLayer::ChipDeviceEvent *event, intptr_t arg);
-
-#if CONFIG_CHIP_FACTORY_DATA
-	chip::DeviceLayer::FactoryDataProvider<chip::DeviceLayer::InternalFlashFactoryData> mFactoryDataProvider;
-#endif
+	static void MatterEventHandler(const chip::DeviceLayer::ChipDeviceEvent *event, intptr_t arg);
 };

--- a/samples/matter/thermostat/CMakeLists.txt
+++ b/samples/matter/thermostat/CMakeLists.txt
@@ -49,8 +49,8 @@ target_sources(app PRIVATE
     ${COMMON_ROOT}/src/led_widget.cpp
     ${COMMON_ROOT}/src/task_executor.cpp
     ${COMMON_ROOT}/src/board.cpp
+    ${COMMON_ROOT}/src/matter_init.cpp
 )
-
 
 if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_TRANSPORT_BT)
     target_sources(app PRIVATE ${COMMON_ROOT}/src/ota_util.cpp)

--- a/samples/matter/thermostat/src/app_task.cpp
+++ b/samples/matter/thermostat/src/app_task.cpp
@@ -5,45 +5,28 @@
  */
 
 #include "app_task.h"
-#include "fabric_table_delegate.h"
+
+#include "matter_init.h"
 #include "task_executor.h"
 
 #include "temp_sensor_manager.h"
 #include "temperature_manager.h"
 
-#include <platform/CHIPDeviceLayer.h>
-
 #include <app-common/zap-generated/attributes/Accessors.h>
-#include <app/DeferredAttributePersistenceProvider.h>
 #include <app/clusters/identify-server/identify-server.h>
 #include <app/server/OnboardingCodesUtil.h>
-#include <app/server/Server.h>
-#include <credentials/DeviceAttestationCredsProvider.h>
-#include <credentials/examples/DeviceAttestationCredsExample.h>
-#include <lib/support/CHIPMem.h>
-#include <lib/support/CodeUtils.h>
-#include <system/SystemError.h>
-
-#ifdef CONFIG_CHIP_WIFI
-#include <app/clusters/network-commissioning/network-commissioning.h>
-#include <platform/nrfconnect/wifi/NrfWiFiDriver.h>
-#endif
 
 #ifdef CONFIG_CHIP_OTA_REQUESTOR
 #include "ota_util.h"
 #endif
 
-#include <dk_buttons_and_leds.h>
-#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 
 LOG_MODULE_DECLARE(app, CONFIG_MATTER_LOG_LEVEL);
 
 using namespace ::chip;
 using namespace ::chip::app;
-using namespace ::chip::Credentials;
 using namespace ::chip::DeviceLayer;
-
 namespace
 {
 constexpr EndpointId kThermostatEndpointId = 1;
@@ -53,126 +36,6 @@ Identify sIdentify = { kThermostatEndpointId, AppTask::IdentifyStartHandler, App
 
 #define TEMPERATURE_BUTTON_MASK DK_BTN2_MSK
 } // namespace
-
-#ifdef CONFIG_CHIP_WIFI
-app::Clusters::NetworkCommissioning::Instance
-	sWiFiCommissioningInstance(0, &(NetworkCommissioning::NrfWiFiDriver::Instance()));
-#endif
-
-CHIP_ERROR AppTask::Init()
-{
-	/* Initialize CHIP stack */
-
-	CHIP_ERROR err = chip::Platform::MemoryInit();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("Platform::MemoryInit() failed");
-		return err;
-	}
-
-	err = PlatformMgr().InitChipStack();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("PlatformMgr().InitChipStack() failed");
-		return err;
-	}
-
-#if defined(CONFIG_NET_L2_OPENTHREAD)
-	err = ThreadStackMgr().InitThreadStack();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("ThreadStackMgr().InitThreadStack() failed: %s", ErrorStr(err));
-		return err;
-	}
-
-#ifdef CONFIG_OPENTHREAD_MTD_SED
-	err = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_SleepyEndDevice);
-#elif CONFIG_OPENTHREAD_MTD
-	err = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_MinimalEndDevice);
-#else
-	err = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_Router);
-#endif /* CONFIG_OPENTHREAD_MTD_SED */
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("ConnectivityMgr().SetThreadDeviceType() failed: %s", ErrorStr(err));
-		return err;
-	}
-
-#elif defined(CONFIG_CHIP_WIFI)
-	sWiFiCommissioningInstance.Init();
-#else
-	return CHIP_ERROR_INTERNAL;
-#endif /* CONFIG_NET_L2_OPENTHREAD */
-
-	if (!GetBoard().Init(ButtonEventHandler)) {
-		LOG_ERR("User interface initialization failed.");
-		return CHIP_ERROR_INCORRECT_STATE;
-	}
-
-#ifdef CONFIG_CHIP_OTA_REQUESTOR
-	/* OTA image confirmation must be done before the factory data init. */
-	OtaConfirmNewImage();
-#endif
-
-#ifdef CONFIG_MCUMGR_TRANSPORT_BT
-	/* Initialize DFU over SMP */
-	GetDFUOverSMP().Init();
-	GetDFUOverSMP().ConfirmNewImage();
-#endif
-
-	/* Initialize CHIP server */
-#if CONFIG_CHIP_FACTORY_DATA
-	ReturnErrorOnFailure(mFactoryDataProvider.Init());
-	SetDeviceInstanceInfoProvider(&mFactoryDataProvider);
-	SetDeviceAttestationCredentialsProvider(&mFactoryDataProvider);
-	SetCommissionableDataProvider(&mFactoryDataProvider);
-#else
-	SetDeviceInstanceInfoProvider(&DeviceInstanceInfoProviderMgrImpl());
-	SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
-#endif
-
-	static chip::CommonCaseDeviceServerInitParams initParams;
-	(void)initParams.InitializeStaticResourcesBeforeServerInit();
-
-	ReturnErrorOnFailure(chip::Server::GetInstance().Init(initParams));
-	ConfigurationMgr().LogDeviceConfig();
-	PrintOnboardingCodes(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
-	AppFabricTableDelegate::Init();
-
-	err = TempSensorManager::Instance().Init();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("TempSensorManager Init fail");
-		return err;
-	}
-
-	err = TemperatureManager::Instance().Init();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("TempMgr Init fail");
-		return err;
-	}
-
-	/*
-	 * Add CHIP event handler and start CHIP thread.
-	 * Note that all the initialization code should happen prior to this point to avoid data races
-	 * between the main and the CHIP threads.
-	 */
-	PlatformMgr().AddEventHandler(ChipEventHandler, 0);
-
-	err = PlatformMgr().StartEventLoopTask();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("PlatformMgr().StartEventLoopTask() failed");
-		return err;
-	}
-
-	return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR AppTask::StartApp()
-{
-	ReturnErrorOnFailure(Init());
-
-	while (true) {
-		TaskExecutor::DispatchNextTask();
-	}
-
-	return CHIP_NO_ERROR;
-}
 
 void AppTask::IdentifyStartHandler(Identify *)
 {
@@ -187,9 +50,8 @@ void AppTask::IdentifyStopHandler(Identify *)
 void AppTask::ButtonEventHandler(ButtonState state, ButtonMask hasChanged)
 {
 	if (TEMPERATURE_BUTTON_MASK & hasChanged) {
-		TemperatureButtonAction action = (TEMPERATURE_BUTTON_MASK & state) ?
-							      TemperatureButtonAction::Pushed :
-							      TemperatureButtonAction::Released;
+		TemperatureButtonAction action = (TEMPERATURE_BUTTON_MASK & state) ? TemperatureButtonAction::Pushed :
+										     TemperatureButtonAction::Released;
 		TaskExecutor::PostTask([action] { ThermostatHandler(action); });
 	}
 }
@@ -201,7 +63,7 @@ void AppTask::ThermostatHandler(const TemperatureButtonAction &action)
 	}
 }
 
-void AppTask::ChipEventHandler(const ChipDeviceEvent *event, intptr_t /* arg */)
+void AppTask::MatterEventHandler(const ChipDeviceEvent *event, intptr_t /* arg */)
 {
 	bool isNetworkProvisioned = false;
 
@@ -233,7 +95,8 @@ void AppTask::ChipEventHandler(const ChipDeviceEvent *event, intptr_t /* arg */)
 		isNetworkProvisioned = ConnectivityMgr().IsThreadProvisioned() && ConnectivityMgr().IsThreadEnabled();
 #elif defined(CONFIG_CHIP_WIFI)
 	case DeviceEventType::kWiFiConnectivityChange:
-		isNetworkProvisioned = ConnectivityMgr().IsWiFiStationProvisioned() && ConnectivityMgr().IsWiFiStationEnabled();
+		isNetworkProvisioned =
+			ConnectivityMgr().IsWiFiStationProvisioned() && ConnectivityMgr().IsWiFiStationEnabled();
 #if CONFIG_CHIP_OTA_REQUESTOR
 		if (event->WiFiConnectivityChange.Result == kConnectivity_Established) {
 			InitBasicOTARequestor();
@@ -249,4 +112,40 @@ void AppTask::ChipEventHandler(const ChipDeviceEvent *event, intptr_t /* arg */)
 	default:
 		break;
 	}
+}
+
+CHIP_ERROR AppTask::Init()
+{
+	/* Initialize Matter stack */
+	ReturnErrorOnFailure(
+		Nordic::Matter::PrepareServer(MatterEventHandler, Nordic::Matter::InitData{ .mPostServerInitClbk = [] {
+						      CHIP_ERROR err = TemperatureManager::Instance().Init();
+						      if (err != CHIP_NO_ERROR) {
+							      LOG_ERR("TempMgr Init fail");
+						      }
+						      return err;
+					      } }));
+
+	if (!GetBoard().Init(ButtonEventHandler)) {
+		LOG_ERR("User interface initialization failed.");
+		return CHIP_ERROR_INCORRECT_STATE;
+	}
+
+	CHIP_ERROR err = TempSensorManager::Instance().Init();
+	if (err != CHIP_NO_ERROR) {
+		LOG_ERR("TempSensorManager Init fail");
+		return err;
+	}
+	return Nordic::Matter::StartServer();
+}
+
+CHIP_ERROR AppTask::StartApp()
+{
+	ReturnErrorOnFailure(Init());
+
+	while (true) {
+		TaskExecutor::DispatchNextTask();
+	}
+
+	return CHIP_NO_ERROR;
 }

--- a/samples/matter/thermostat/src/app_task.h
+++ b/samples/matter/thermostat/src/app_task.h
@@ -10,18 +10,7 @@
 
 #include <platform/CHIPDeviceLayer.h>
 
-#include <app/clusters/identify-server/identify-server.h>
-#include <platform/nrfconnect/DeviceInstanceInfoProviderImpl.h>
-
-#if CONFIG_CHIP_FACTORY_DATA
-#include <platform/nrfconnect/FactoryDataProvider.h>
-#else
-#include <platform/nrfconnect/DeviceInstanceInfoProviderImpl.h>
-#endif
-
-#ifdef CONFIG_MCUMGR_TRANSPORT_BT
-#include "dfu_over_smp.h"
-#endif
+struct Identify;
 
 enum class TemperatureButtonAction : uint8_t { Pushed, Released };
 
@@ -41,11 +30,7 @@ public:
 private:
 	CHIP_ERROR Init();
 
-	static void ChipEventHandler(const chip::DeviceLayer::ChipDeviceEvent *event, intptr_t arg);
+	static void MatterEventHandler(const chip::DeviceLayer::ChipDeviceEvent *event, intptr_t arg);
 	static void ButtonEventHandler(ButtonState state, ButtonMask hasChanged);
 	static void ThermostatHandler(const TemperatureButtonAction &action);
-
-#if CONFIG_CHIP_FACTORY_DATA
-	chip::DeviceLayer::FactoryDataProvider<chip::DeviceLayer::InternalFlashFactoryData> mFactoryDataProvider;
-#endif
 };

--- a/samples/matter/window_covering/CMakeLists.txt
+++ b/samples/matter/window_covering/CMakeLists.txt
@@ -47,6 +47,7 @@ target_sources(app PRIVATE
     ${COMMON_ROOT}/src/pwm_device.cpp
     ${COMMON_ROOT}/src/task_executor.cpp
     ${COMMON_ROOT}/src/board.cpp
+    ${COMMON_ROOT}/src/matter_init.cpp
 )
 
 if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_TRANSPORT_BT)

--- a/samples/matter/window_covering/src/app_task.cpp
+++ b/samples/matter/window_covering/src/app_task.cpp
@@ -6,30 +6,23 @@
 
 #include "app_task.h"
 
-#include "fabric_table_delegate.h"
+#include "matter_init.h"
 #include "task_executor.h"
 #include "window_covering.h"
 
 #include <app/clusters/identify-server/identify-server.h>
 #include <app/server/OnboardingCodesUtil.h>
-#include <app/server/Server.h>
-#include <app/util/attribute-storage.h>
-#include <credentials/DeviceAttestationCredsProvider.h>
-#include <credentials/examples/DeviceAttestationCredsExample.h>
 
 #ifdef CONFIG_CHIP_OTA_REQUESTOR
 #include "ota_util.h"
 #endif
 
-#include <dk_buttons_and_leds.h>
-#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 
 LOG_MODULE_DECLARE(app, CONFIG_CHIP_APP_LOG_LEVEL);
 
 using namespace ::chip;
 using namespace ::chip::app;
-using namespace ::chip::Credentials;
 using namespace ::chip::DeviceLayer;
 
 namespace
@@ -40,106 +33,6 @@ Identify sIdentify = { WindowCovering::Endpoint(), AppTask::IdentifyStartHandler
 #define OPEN_BUTTON_MASK DK_BTN2_MSK
 #define CLOSE_BUTTON_MASK DK_BTN3_MSK
 } /* namespace */
-
-CHIP_ERROR AppTask::Init()
-{
-	/* Initialize CHIP stack */
-	LOG_INF("Init CHIP stack");
-
-	CHIP_ERROR err = chip::Platform::MemoryInit();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("Platform::MemoryInit() failed");
-		return err;
-	}
-
-	err = PlatformMgr().InitChipStack();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("PlatformMgr().InitChipStack() failed");
-		return err;
-	}
-
-	err = ThreadStackMgr().InitThreadStack();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("ThreadStackMgr().InitThreadStack() failed: %s", ErrorStr(err));
-		return err;
-	}
-
-#if CONFIG_CHIP_THREAD_SSED
-	err = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_SynchronizedSleepyEndDevice);
-#elif CONFIG_OPENTHREAD_MTD_SED
-	err = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_SleepyEndDevice);
-#else
-	err = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_MinimalEndDevice);
-#endif
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("ConnectivityMgr().SetThreadDeviceType() failed: %s", ErrorStr(err));
-		return err;
-	}
-
-	if (!GetBoard().Init(ButtonEventHandler)) {
-		LOG_ERR("User interface initialization failed.");
-		return CHIP_ERROR_INCORRECT_STATE;
-	}
-
-#ifdef CONFIG_CHIP_OTA_REQUESTOR
-	/* OTA image confirmation must be done before the factory data init. */
-	OtaConfirmNewImage();
-#endif
-
-#ifdef CONFIG_MCUMGR_TRANSPORT_BT
-	/* Initialize DFU over SMP */
-	GetDFUOverSMP().Init();
-	GetDFUOverSMP().ConfirmNewImage();
-#endif
-
-	/* Initialize CHIP server */
-#if CONFIG_CHIP_FACTORY_DATA
-	ReturnErrorOnFailure(mFactoryDataProvider.Init());
-	SetDeviceInstanceInfoProvider(&mFactoryDataProvider);
-	SetDeviceAttestationCredentialsProvider(&mFactoryDataProvider);
-	SetCommissionableDataProvider(&mFactoryDataProvider);
-#else
-	SetDeviceInstanceInfoProvider(&DeviceInstanceInfoProviderMgrImpl());
-	SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
-#endif
-
-	static CommonCaseDeviceServerInitParams initParams;
-	(void)initParams.InitializeStaticResourcesBeforeServerInit();
-
-	ReturnErrorOnFailure(chip::Server::GetInstance().Init(initParams));
-	ConfigurationMgr().LogDeviceConfig();
-	PrintOnboardingCodes(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
-	AppFabricTableDelegate::Init();
-
-	/*
-	 * Add CHIP event handler and start CHIP thread.
-	 * Note that all the initialization code should happen prior to this point to avoid data races
-	 * between the main and the CHIP threads.
-	 */
-	PlatformMgr().AddEventHandler(ChipEventHandler, 0);
-
-	err = PlatformMgr().StartEventLoopTask();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("PlatformMgr().StartEventLoopTask() failed");
-		return err;
-	}
-
-	WindowCovering::Instance().PositionLEDUpdate(WindowCovering::MoveType::LIFT);
-	WindowCovering::Instance().PositionLEDUpdate(WindowCovering::MoveType::TILT);
-
-	return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR AppTask::StartApp()
-{
-	ReturnErrorOnFailure(Init());
-
-	while (true) {
-		TaskExecutor::DispatchNextTask();
-	}
-
-	return CHIP_NO_ERROR;
-}
 
 void AppTask::IdentifyStartHandler(Identify *)
 {
@@ -222,7 +115,7 @@ void AppTask::ToggleMoveType()
 	mMoveTypeRecentlyChanged = true;
 }
 
-void AppTask::ChipEventHandler(const ChipDeviceEvent *event, intptr_t /* arg */)
+void AppTask::MatterEventHandler(const ChipDeviceEvent *event, intptr_t /* arg */)
 {
 	bool isNetworkProvisioned = false;
 
@@ -260,4 +153,33 @@ void AppTask::ChipEventHandler(const ChipDeviceEvent *event, intptr_t /* arg */)
 	default:
 		break;
 	}
+}
+
+CHIP_ERROR AppTask::Init()
+{
+	/* Initialize Matter stack */
+	ReturnErrorOnFailure(Nordic::Matter::PrepareServer(
+		MatterEventHandler, Nordic::Matter::InitData{ .mPostServerInitClbk = [] {
+			WindowCovering::Instance().PositionLEDUpdate(WindowCovering::MoveType::LIFT);
+			WindowCovering::Instance().PositionLEDUpdate(WindowCovering::MoveType::TILT);
+			return CHIP_NO_ERROR;
+		} }));
+
+	if (!GetBoard().Init(ButtonEventHandler)) {
+		LOG_ERR("User interface initialization failed.");
+		return CHIP_ERROR_INCORRECT_STATE;
+	}
+
+	return Nordic::Matter::StartServer();
+}
+
+CHIP_ERROR AppTask::StartApp()
+{
+	ReturnErrorOnFailure(Init());
+
+	while (true) {
+		TaskExecutor::DispatchNextTask();
+	}
+
+	return CHIP_NO_ERROR;
 }

--- a/samples/matter/window_covering/src/app_task.h
+++ b/samples/matter/window_covering/src/app_task.h
@@ -11,16 +11,6 @@
 
 #include <platform/CHIPDeviceLayer.h>
 
-#if CONFIG_CHIP_FACTORY_DATA
-#include <platform/nrfconnect/FactoryDataProvider.h>
-#else
-#include <platform/nrfconnect/DeviceInstanceInfoProviderImpl.h>
-#endif
-
-#ifdef CONFIG_MCUMGR_TRANSPORT_BT
-#include "dfu_over_smp.h"
-#endif
-
 struct Identify;
 
 enum class WindowButtonAction : uint8_t { Pressed, Released };
@@ -45,7 +35,7 @@ private:
 	static void OpenHandler(const WindowButtonAction &action);
 	static void CloseHandler(const WindowButtonAction &action);
 
-	static void ChipEventHandler(const chip::DeviceLayer::ChipDeviceEvent *event, intptr_t arg);
+	static void MatterEventHandler(const chip::DeviceLayer::ChipDeviceEvent *event, intptr_t arg);
 	static void ButtonEventHandler(ButtonState state, ButtonMask hasChanged);
 
 	OperationalState mMoveType{ OperationalState::MovingUpOrOpen };
@@ -53,8 +43,4 @@ private:
 	bool mOpenButtonIsPressed{ false };
 	bool mCloseButtonIsPressed{ false };
 	bool mMoveTypeRecentlyChanged{ false };
-
-#if CONFIG_CHIP_FACTORY_DATA
-	chip::DeviceLayer::FactoryDataProvider<chip::DeviceLayer::InternalFlashFactoryData> mFactoryDataProvider;
-#endif
 };

--- a/samples/matter/window_covering/src/window_covering.cpp
+++ b/samples/matter/window_covering/src/window_covering.cpp
@@ -17,7 +17,6 @@
 
 LOG_MODULE_DECLARE(app, CONFIG_CHIP_APP_LOG_LEVEL);
 
-using namespace ::chip::Credentials;
 using namespace ::chip::DeviceLayer;
 using namespace chip::app::Clusters::WindowCovering;
 

--- a/west.yml
+++ b/west.yml
@@ -149,7 +149,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 50a62b4a4e48ee113eb8114e2307c9835094044d
+      revision: 496275a1cd657f31a4943fdf77acbdacd957a818
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
* Added common initialization module for all Matter samples to reduce maintenance effort and simplify code
* Documented Matter::Init module API
* Adapted all Matter samples and applications
* Cleaned up includes

- [x] Fix CI builds
- [x] Adapt Weather Station application
- [x] Make the Matter::Init module more flexible by extending InitData with other Matter interfaces
- [x] Test more thoroughly (commissioned weather station to Google ecosystem, tested multiple build configurations, integration passed, tested Matter Bridge BLE connections and loading of stored devices after reboot)
- [x] Cleanup namespaces
- [x] Avoid instantiating unused default static objects
- [x] Stress test with nightly suite (nighty plan is green: https://jenkins-ncs.nordicsemi.no/view/z_CHIP/job/latest/job/acc/job/test-fw-nrfconnect-chip/job/master/87/)