### PR TITLE
samples: openthread: disable `mx25r64` in OpenThread samples

### DIFF
--- a/samples/openthread/cli/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/openthread/cli/boards/nrf52840dk_nrf52840.overlay
@@ -1,7 +1,11 @@
-/* Copyright (c) 2020 Nordic Semiconductor ASA
+/* Copyright (c) 2023 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
+&mx25r64 {
+	status = "disabled";
+};
 
 &uart0 {
 	status = "okay";

--- a/samples/openthread/cli/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/openthread/cli/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,8 @@
+/* Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&mx25r64 {
+	status = "disabled";
+};

--- a/samples/openthread/cli/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/openthread/cli/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -1,0 +1,8 @@
+/* Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&mx25r64 {
+	status = "disabled";
+};

--- a/samples/openthread/coap_client/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/openthread/coap_client/boards/nrf52840dk_nrf52840.overlay
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 Nordic Semiconductor ASA
+/* Copyright (c) 2023 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
@@ -39,6 +39,9 @@
 	status = "disabled";
 };
 &qspi {
+	status = "disabled";
+};
+&mx25r64 {
 	status = "disabled";
 };
 &usbd {

--- a/samples/openthread/coap_client/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/openthread/coap_client/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,8 @@
+/* Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&mx25r64 {
+	status = "disabled";
+};

--- a/samples/openthread/coap_client/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/openthread/coap_client/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -1,0 +1,8 @@
+/* Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&mx25r64 {
+	status = "disabled";
+};

--- a/samples/openthread/coap_server/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/openthread/coap_server/boards/nrf52840dk_nrf52840.overlay
@@ -1,7 +1,11 @@
-/* Copyright (c) 2020 Nordic Semiconductor ASA
+/* Copyright (c) 2023 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
+&mx25r64 {
+	status = "disabled";
+};
 
 / {
 	/*

--- a/samples/openthread/coap_server/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/openthread/coap_server/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,8 @@
+/* Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&mx25r64 {
+	status = "disabled";
+};

--- a/samples/openthread/coap_server/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/openthread/coap_server/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -1,0 +1,8 @@
+/* Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&mx25r64 {
+	status = "disabled";
+};

--- a/samples/openthread/coprocessor/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/openthread/coprocessor/boards/nrf52840dk_nrf52840.overlay
@@ -1,7 +1,11 @@
-/* Copyright (c) 2020 Nordic Semiconductor ASA
+/* Copyright (c) 2023 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
+&mx25r64 {
+	status = "disabled";
+};
 
 &uart0 {
 	current-speed = <1000000>;


### PR DESCRIPTION
`mx25r64` is used to enable nrf_qspi_nor in nrf samples. It is not used in OpenThread and should be disabled by default.

In the future, disabling `mx25r64` will be handled directly in boards `.dts` zephyr files, but until then, we should disable it in project overlays.