### PR TITLE
samples: matter: Repair the common LED handling module

### DIFF
--- a/samples/matter/common/src/board.cpp
+++ b/samples/matter/common/src/board.cpp
@@ -67,20 +67,36 @@ void Board::UpdateDeviceState(DeviceState state)
 {
 	if (mState != state) {
 		mState = state;
-		ResetAllLeds();
 		mLedStateHandler();
 	}
 }
 
 void Board::ResetAllLeds()
 {
-	sInstance.mLED1.Set(false);
-	sInstance.mLED2.Set(false);
+	mLED1SavedState = mLED1.GetState();
+	mLED2SavedState = mLED2.GetState();
+	mLED1.Set(false);
+	mLED2.Set(false);
 #if NUMBER_OF_LEDS == 3
-	sInstance.mLED3.Set(false);
+	mLED3SavedState = mLED3.GetState();
+	mLED3.Set(false);
 #elif NUMBER_OF_LEDS == 4
-	sInstance.mLED3.Set(false);
-	sInstance.mLED4.Set(false);
+	mLED3SavedState = mLED3.GetState();
+	mLED4SavedState = mLED4.GetState();
+	mLED3.Set(false);
+	mLED4.Set(false);
+#endif
+}
+
+void Board::RestoreAllLedsState()
+{
+	mLED1.Set(mLED1SavedState);
+	mLED2.Set(mLED2SavedState);
+#if NUMBER_OF_LEDS == 3
+	mLED3.Set(mLED3SavedState);
+#elif NUMBER_OF_LEDS == 4
+	mLED3.Set(mLED3SavedState);
+	mLED4.Set(mLED4SavedState);
 #endif
 }
 
@@ -106,6 +122,8 @@ void Board::UpdateStatusLED()
 	 * rate of 100ms.
 	 *
 	 * Otherwise, blink the LED for a very short time. */
+	sInstance.mLED1.Set(false);
+
 	switch (sInstance.mState) {
 	case DeviceState::DeviceDisconnected:
 		sInstance.mLED1.Blink(LedConsts::StatusLed::Disconnected::kOn_ms,
@@ -219,8 +237,8 @@ void Board::FunctionHandler(const ButtonAction &action)
 			sInstance.CancelTimer();
 			sInstance.mFunction = BoardFunctions::None;
 		} else if (sInstance.mFunctionTimerActive && sInstance.mFunction == BoardFunctions::FactoryReset) {
-			sInstance.ResetAllLeds();
 			sInstance.CancelTimer();
+			sInstance.RestoreAllLedsState();
 			sInstance.mLedStateHandler();
 			sInstance.mFunction = BoardFunctions::None;
 			LOG_INF("Factory reset has been canceled");

--- a/samples/matter/common/src/board.h
+++ b/samples/matter/common/src/board.h
@@ -103,17 +103,23 @@ private:
 	static void LEDStateUpdateHandler(LEDWidget &ledWidget);
 	static void UpdateLedStateEventHandler(const LEDEvent &event);
 	void ResetAllLeds();
+	void RestoreAllLedsState();
 
 	LEDWidget mLED1;
 	LEDWidget mLED2;
+	bool mLED1SavedState;
+	bool mLED2SavedState;
 	k_timer mFunctionTimer;
 	DeviceState mState = DeviceState::DeviceDisconnected;
 	LedStateHandler mLedStateHandler = UpdateStatusLED;
 #if NUMBER_OF_LEDS == 3
 	LEDWidget mLED3;
+	bool mLED3SavedState;
 #elif NUMBER_OF_LEDS == 4
 	LEDWidget mLED3;
 	LEDWidget mLED4;
+	bool mLED3SavedState;
+	bool mLED4SavedState;
 #endif
 
 	/* Function Timer */


### PR DESCRIPTION
After the recent samples' refactor we noticed a problem with the LED handling module. The LED state has to be saved before calling the ResetAllLeds method and restored after finishing some actions.