### PR TITLE
doc: rename nRF Device provisioning library

### DIFF
--- a/doc/nrf/libraries/networking/nrf_provisioning.rst
+++ b/doc/nrf/libraries/networking/nrf_provisioning.rst
@@ -1,7 +1,7 @@
 .. _lib_nrf_provisioning:
 
-nRF Device provisioning
-#######################
+nRF Cloud device provisioning
+#############################
 
 .. contents::
    :local:

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -577,6 +577,7 @@ Libraries for networking
 
 * :ref:`lib_nrf_provisioning` library:
 
+  * Renamed nRF Device provisioning to :ref:`lib_nrf_provisioning`.
   * Updated the device mode callback to send an event when the provisioning state changes.
 
 * :ref:`lib_nrf_cloud_fota` library:


### PR DESCRIPTION
The library is used only with nRF Cloud.
Thus, renaming it to nRF Cloud device provisioning.