### PR TITLE
modules: hostap: Fix RSSI check for STA mode

### DIFF
--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -545,18 +545,17 @@ int z_wpa_supplicant_status(const struct device *dev,
 				status->link_mode = WIFI_LINK_MODE_UNKNOWN;
 			}
 		}
-		if (IS_ENABLED(CONFIG_AP) && status->iface_mode == WIFI_MODE_INFRA) {
+
+		status->rssi = -WPA_INVALID_NOISE;
+		if (status->iface_mode == WIFI_MODE_INFRA) {
 			ret = z_wpa_ctrl_signal_poll(&signal_poll);
 			if (!ret) {
 				status->rssi = signal_poll.rssi;
 			} else {
 				wpa_printf(MSG_WARNING, "%s:Failed to read RSSI\n",
 					__func__);
-				status->rssi = -WPA_INVALID_NOISE;
 				ret = 0;
 			}
-		} else {
-			status->rssi = -WPA_INVALID_NOISE;
 		}
 
 		conn_info = os_zalloc(sizeof(struct wpa_conn_info));


### PR DESCRIPTION
RSSI should only be retrieved for STA mode, but the check was wrong.

Fixes SHEL-2331.