### PR TITLE
samples: wifi: Remove wpa_cli configuration

### DIFF
--- a/samples/wifi/shell/prj.conf
+++ b/samples/wifi/shell/prj.conf
@@ -94,4 +94,3 @@ CONFIG_SETTINGS_NVS=y
 # design in net_mgmt. So, use a higher timeout for a crowded
 # environment.
 CONFIG_NET_MGMT_EVENT_QUEUE_TIMEOUT=5000
-CONFIG_WPA_CLI=y


### PR DESCRIPTION
The wpa_cli configuration was put accidentally.
Remove it from shell sample.