### PR TITLE
applications: asset_tracker_v2: Fix air pressure value

### DIFF
--- a/applications/asset_tracker_v2/src/ext_sensors/ext_sensors.c
+++ b/applications/asset_tracker_v2/src/ext_sensors/ext_sensors.c
@@ -341,7 +341,13 @@ int ext_sensors_pressure_get(double *ext_press)
 	}
 
 	k_spinlock_key_t key = k_spin_lock(&(press_sensor.lock));
-	*ext_press = sensor_value_to_double(&data) / 1000.0f;
+#if defined(CONFIG_BME680)
+	/* Pressure is in kPascals */
+	*ext_press = sensor_value_to_double(&data) * 1000.0f;
+#else
+	/* Pressure is in Pascals */
+	*ext_press = sensor_value_to_double(&data);
+#endif
 	k_spin_unlock(&(press_sensor.lock), key);
 
 	return 0;


### PR DESCRIPTION
Air pressure value was scaled incorrectly and the values sent to the cloud were not in Pascals. When the BSEC library is used, the value is already in Pascals and no scaling is needed, however the BME680 driver reports the pressure in kPascals.