### PR TITLE
samples: matter:  Repair bindings via uart in Light Switch Sample

### DIFF
--- a/samples/matter/common/src/binding_handler.cpp
+++ b/samples/matter/common/src/binding_handler.cpp
@@ -21,6 +21,7 @@ void BindingHandler::Init()
 void BindingHandler::RunBoundClusterAction(BindingData *bindingData)
 {
 	VerifyOrReturn(bindingData != nullptr, LOG_ERR("Invalid binding data"));
+	VerifyOrReturn(bindingData->InvokeCommandFunc != nullptr, LOG_ERR("No valid InvokeCommandFunc assigned"););
 
 	DeviceLayer::PlatformMgr().ScheduleWork(DeviceWorkerHandler, reinterpret_cast<intptr_t>(bindingData));
 }

--- a/samples/matter/light_switch/src/light_switch.h
+++ b/samples/matter/light_switch/src/light_switch.h
@@ -31,6 +31,9 @@ public:
 	void InitiateActionSwitch(Action action);
 	void DimmerChangeBrightness();
 	chip::EndpointId GetLightSwitchEndpointId() { return mLightSwitchEndpoint; }
+	static void SwitchChangedHandler(const EmberBindingTableEntry &binding,
+					 chip::OperationalDeviceProxy *deviceProxy,
+					 BindingHandler::BindingData &bindingData);
 
 	static LightSwitch &GetInstance()
 	{
@@ -39,9 +42,6 @@ public:
 	}
 
 private:
-	static void SwitchChangedHandler(const EmberBindingTableEntry &binding,
-					 chip::OperationalDeviceProxy *deviceProxy,
-					 BindingHandler::BindingData &bindingData);
 	static void OnOffProcessCommand(chip::CommandId commandId, const EmberBindingTableEntry &binding,
 					chip::OperationalDeviceProxy *device, BindingHandler::BindingData &bindingData);
 	static void LevelControlProcessCommand(chip::CommandId commandId, const EmberBindingTableEntry &binding,

--- a/samples/matter/light_switch/src/shell_commands.cpp
+++ b/samples/matter/light_switch/src/shell_commands.cpp
@@ -69,6 +69,7 @@ namespace Unicast
 		data->EndpointId = LightSwitch::GetInstance().GetLightSwitchEndpointId();
 		data->CommandId = Clusters::OnOff::Commands::On::Id;
 		data->ClusterId = Clusters::OnOff::Id;
+		data->InvokeCommandFunc = LightSwitch::SwitchChangedHandler;
 
 		BindingHandler::RunBoundClusterAction(data);
 		return CHIP_NO_ERROR;
@@ -80,6 +81,7 @@ namespace Unicast
 		data->EndpointId = LightSwitch::GetInstance().GetLightSwitchEndpointId();
 		data->CommandId = Clusters::OnOff::Commands::Off::Id;
 		data->ClusterId = Clusters::OnOff::Id;
+		data->InvokeCommandFunc = LightSwitch::SwitchChangedHandler;
 
 		BindingHandler::RunBoundClusterAction(data);
 		return CHIP_NO_ERROR;
@@ -91,6 +93,7 @@ namespace Unicast
 		data->EndpointId = LightSwitch::GetInstance().GetLightSwitchEndpointId();
 		data->CommandId = Clusters::OnOff::Commands::Toggle::Id;
 		data->ClusterId = Clusters::OnOff::Id;
+		data->InvokeCommandFunc = LightSwitch::SwitchChangedHandler;
 
 		BindingHandler::RunBoundClusterAction(data);
 		return CHIP_NO_ERROR;
@@ -135,6 +138,7 @@ namespace Group
 		data->EndpointId = LightSwitch::GetInstance().GetLightSwitchEndpointId();
 		data->CommandId = Clusters::OnOff::Commands::On::Id;
 		data->ClusterId = Clusters::OnOff::Id;
+		data->InvokeCommandFunc = LightSwitch::SwitchChangedHandler;
 		data->IsGroup = true;
 
 		BindingHandler::RunBoundClusterAction(data);
@@ -147,6 +151,7 @@ namespace Group
 		data->EndpointId = LightSwitch::GetInstance().GetLightSwitchEndpointId();
 		data->CommandId = Clusters::OnOff::Commands::Off::Id;
 		data->ClusterId = Clusters::OnOff::Id;
+		data->InvokeCommandFunc = LightSwitch::SwitchChangedHandler;
 		data->IsGroup = true;
 
 		BindingHandler::RunBoundClusterAction(data);
@@ -159,6 +164,7 @@ namespace Group
 		data->EndpointId = LightSwitch::GetInstance().GetLightSwitchEndpointId();
 		data->CommandId = Clusters::OnOff::Commands::Toggle::Id;
 		data->ClusterId = Clusters::OnOff::Id;
+		data->InvokeCommandFunc = LightSwitch::SwitchChangedHandler;
 		data->IsGroup = true;
 
 		BindingHandler::RunBoundClusterAction(data);


### PR DESCRIPTION
After the unification of the matter-binding mechanism in the BindingData struct there is an additional callback for invoking the command function.
It must be assigned because it is used within the
BindingManager module.

Moreover, the RunBoundClusterAction method must check whether the InvokeCommandFunc is not NULL and does not allow doing any binding action otherwise..

The InvokeCommandFunc callback was not being assigned when we used UART CLI to send on/off command requests which cused a crash.