### PR TITLE
nfc: Fix handling 0 size data in nfc_platform

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -650,7 +650,7 @@ Libraries for networking
 Libraries for NFC
 -----------------
 
-|no_changes_yet_note|
+* Fixed an issue with handling zero size data (when receiving empty I-blocks from poller) in the :file:`platform_internal_thread` file.
 
 nRF Security
 ------------

--- a/subsys/nfc/lib/Kconfig
+++ b/subsys/nfc/lib/Kconfig
@@ -51,6 +51,7 @@ config NFC_RING_SIZE
 config NFC_LIB_CTX_MAX_SIZE
 	int "Maximum size of NFC library context in bytes"
 	default 16
+	range 16 255
 	help
 	  Maximum size of the NFC library context in bytes.
 	  The specified size should be divisible by 4.


### PR DESCRIPTION
Fix handling data with 0 size when issuing a callback.

Jira: NCSDK-25211