### PR TITLE
ci: fix node.js deprecation warning

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -8,18 +8,26 @@
 # first branch.
 
 "manifest":
-  - "west.yml"
+- changed-files:
+  - any-glob-to-any-file:
+    - "west.yml"
 
 "doc-required":
-  - "doc/**/*"
-  - "**/*.rst"
+- changed-files:
+  - any-glob-to-any-file:
+    - "doc/**/*"
+    - "**/*.rst"
 
 "changelog-entry-required":
-  - all: ["!doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst"]
+- all:
+  - changed-files:
+    - all-globs-to-all-files: ["!doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst"]
 
 "ble mesh":
-  - "subsys/bluetooth/mesh/*"
-  - "include/bluetooth/mesh/*"
-  - "samples/bluetooth/mesh/*"
-  - "doc/nrf/libraries/bluetooth_services/mesh/*"
-  - "doc/nrf/ug_bt_mesh*"
+- changed-files:
+  - any-glob-to-any-file:
+    - "subsys/bluetooth/mesh/*"
+    - "include/bluetooth/mesh/*"
+    - "samples/bluetooth/mesh/*"
+    - "doc/nrf/libraries/bluetooth_services/mesh/*"
+    - "doc/nrf/ug_bt_mesh*"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,6 +6,6 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v3.0.0
+      - uses: actions/labeler@v5.0.0
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/license-reusable.yml
+++ b/.github/workflows/license-reusable.yml
@@ -56,7 +56,7 @@ jobs:
         fetch-depth: 0
 
     - name: cache-pip
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-doc-pip

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@v9
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-pr-message: 'This pull request has been marked as stale because it has been open (more than) 60 days with no activity. Remove the stale label or add a comment saying that you would like to have the label removed otherwise this pull request will automatically be closed in 14 days. Note, that you can always re-open a closed pull request at any time.'


### PR DESCRIPTION
There are node.js deprecation warnings in GH Actions. This change will update actions to newer versions.