### PR TITLE
doc: Add missing APIs to CAF

### DIFF
--- a/doc/nrf/libraries/caf/caf_overview.rst
+++ b/doc/nrf/libraries/caf/caf_overview.rst
@@ -130,6 +130,16 @@ CAF Bluetooth LE common events
    :project: nrf
    :members:
 
+CAF Bluetooth LE SMP events
+===========================
+
+| Header file: :file:`include/caf/events/ble_smp_event.h`
+| Source file: :file:`subsys/caf/events/ble_smp_event.c`
+
+.. doxygengroup:: ble_smp_event
+   :project: nrf
+   :members:
+
 CAF button events
 =================
 
@@ -187,6 +197,16 @@ CAF module state events
 | Source file: :file:`subsys/caf/events/module_state_event.c`
 
 .. doxygengroup:: caf_module_state_event
+   :project: nrf
+   :members:
+
+CAF net state events
+====================
+
+| Header file: :file:`include/caf/events/net_state_event.h`
+| Source file: :file:`subsys/caf/events/net_state_event.c`
+
+.. doxygengroup:: net_state_event
    :project: nrf
    :members:
 

--- a/doc/nrf/libraries/caf/net_state.rst
+++ b/doc/nrf/libraries/caf/net_state.rst
@@ -29,9 +29,9 @@ The module generates the :c:struct:`net_state_event`.
 The event reports the current network state using :c:enum:`net_state`.
 The following network states are available:
 
-* :c:enum:`NET_STATE_DISABLED` - Network interface is disabled.
-* :c:enum:`NET_STATE_DISCONNECTED` - Network interface is ready to connect but waiting for connection.
-* :c:enum:`NET_STATE_CONNECTED` - Network interface is connected.
+* :c:enumerator:`NET_STATE_DISABLED` - Network interface is disabled.
+* :c:enumerator:`NET_STATE_DISCONNECTED` - Network interface is ready to connect but waiting for connection.
+* :c:enumerator:`NET_STATE_CONNECTED` - Network interface is connected.
 
-:c:enum:`NET_STATE_CONNECTED` means that IP packets can be transmitted.
+:c:enumerator:`NET_STATE_CONNECTED` means that IP packets can be transmitted.
 For example, in case of a Thread network, this means not only that the connection to the mesh network is established, but also that the Border Router is working and it is possible to transfer data.


### PR DESCRIPTION
Added APIs of the following events
to CAF docs:

* CAF Bluetooth LE SMP events
* CAF net state events