### PR TITLE
manifest: Update Matter revision to pull PSA Crypto changes

### DIFF
--- a/doc/nrf/releases_and_maturity/migration/migration_guide_2.6.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_guide_2.6.rst
@@ -30,6 +30,16 @@ The following changes are mandatory to make your application work in the same wa
       * The ``CONFIG_CHIP_SED_ACTIVE_INTERVAL`` Kconfig option was renamed to :kconfig:option:`CONFIG_CHIP_ICD_FAST_POLLING_INTERVAL`.
       * The ``CONFIG_CHIP_SED_ACTIVE_THRESHOLD`` Kconfig option was renamed to :kconfig:option:`CONFIG_CHIP_ICD_ACTIVE_MODE_THRESHOLD`.
 
+* For Matter over Thread samples, starting from this release, the cryptography backend enabled by default is PSA Crypto API instead of mbedTLS.
+  Be aware of the change and consider the following when migrating to |NCS| v2.6.0:
+
+  * You can keep using mbedTLS API as the cryptography backend by disabling PSA Crypto API.
+    You can disable it by setting the :kconfig:option:`CONFIG_CHIP_CRYPTO_PSA` Kconfig option to ``n``.
+  * When the Device Attestation Certificate (DAC) private key exists in the factory data set, it can migrate to the PSA ITS secure storage.
+
+    You can also have the DAC private key replaced by zeros in the factory data partition by setting the :kconfig:option:`CONFIG_CHIP_CRYPTO_PSA_MIGRATE_DAC_PRIV_KEY` Kconfig option to ``y``.
+    This functionality is experimental.
+
 * For samples using Wi-Fi features:
 
   * A few Kconfig options related to scan operations have been removed in the current release.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -93,9 +93,16 @@ Matter
 ------
 
 * Updated the page about :ref:`ug_matter_device_low_power_configuration` with the information about Intermittently Connected Devices (ICD) configuration.
-* Added a Kconfig option for disabling or enabling :ref:`ug_matter_configuring_read_client`.
-* Added support for PSA Crypto API for devices that use Matter over Thread.
-  It is enabled by default and can be disabled by setting the :kconfig:option:`CONFIG_CHIP_CRYPTO_PSA` Kconfig option to ``n``.
+
+* Added:
+
+  * A Kconfig option for disabling or enabling :ref:`ug_matter_configuring_read_client`.
+  * Support for PSA Crypto API for devices that use Matter over Thread.
+    It is enabled by default and can be disabled by setting the :kconfig:option:`CONFIG_CHIP_CRYPTO_PSA` Kconfig option to ``n``.
+  * Migration of the Device Attestation Certificate (DAC) private key from the factory data set to the PSA ITS secure storage.
+
+    The DAC private key can be removed from the factory data set after the migration.
+    You can enable this experimental functionality by setting the :kconfig:option:`CONFIG_CHIP_CRYPTO_PSA_MIGRATE_DAC_PRIV_KEY` Kconfig option to ``y``.
 
 Matter fork
 +++++++++++

--- a/west.yml
+++ b/west.yml
@@ -149,7 +149,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 5f7a9f6a42257301c5f70b6bf78716357551d54d
+      revision: 50a62b4a4e48ee113eb8114e2307c9835094044d
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
We need a mechanism to move the DAC private key from the factory data set to PSA ITS NVM storage during the first boot of the device.

The DAC private key will not exist in the factory data anymore after it moves and is protected from overwriting.

This feature is available only if the CONFIG_CHIP_CRYPTO_PSA config is set to y.