### PR TITLE
net: lib: nrf_cloud_pgps: Fix bug in prediction set update

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -671,6 +671,10 @@ Libraries for networking
     * The :c:func:`nrf_cloud_obj_object_add` function to reset the added object on success.
     * Custom shadow data is now passed to the application during shadow update events.
 
+* :ref:`lib_nrf_cloud_pgps` library:
+
+  * Fixed a bug in prediction set update when the :kconfig:option:`CONFIG_NRF_CLOUD_PGPS_REPLACEMENT_THRESHOLD` Kconfig option was set to non-zero value.
+
 * :ref:`lib_nrf_provisioning` library:
 
   * Renamed nRF Device provisioning to :ref:`lib_nrf_provisioning`.

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps_utils.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps_utils.c
@@ -328,18 +328,21 @@ void npgps_free_block(int block)
 	pool.block_used[block] = false;
 }
 
-int npgps_get_block_extent(int block)
+int npgps_get_block_extent(int store_block)
 {
-	int i;
-	int len = 0;
+	/* Start counting from 1, because the first block has already been marked as being used. */
+	int len = 1;
 
-	for (i = 0; i < num_blocks; i++) {
-		if (pool.block_used[block]) {
+	store_block++;
+	while (store_block < num_blocks) {
+		if (pool.block_used[store_block]) {
 			break;
 		}
-		block = (block + 1) % num_blocks;
+
 		len++;
+		store_block++;
 	}
+
 	return len;
 }
 


### PR DESCRIPTION
Fixed a bug which caused the prediction set update to fail. The failure happened when all downloaded predictions could not be written to flash sequentially.

NCSDK-25224