### PR TITLE
CODEOWNERS: Assign all Zigbee parts to milewr

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -36,7 +36,7 @@
 /applications/nrf_desktop/                @MarekPieta
 /applications/nrf5340_audio/              @koffes @alexsven @erikrobstad @rick1082 @gWacey
 /applications/serial_lte_modem/           @SeppoTakalo @MarkusLassila @rlubos @tomi-font
-/applications/zigbee_weather_station/     @adsz-nordic @tomchy
+/applications/zigbee_weather_station/     @milewr
 # Boards
 /boards/                                  @anangl
 # All cmake related files
@@ -186,7 +186,7 @@ Kconfig*                                  @tejlmand
 /samples/peripheral/802154_phy_test/      @ankuns @jciupis @ahasztag
 /samples/peripheral/802154_sniffer/       @e-rk
 /samples/tfm/                             @frkv @Vge0rge @vili-nordic @SebastianBoe @mswarowsky
-/samples/zigbee/                          @tomchy @sebastiandraus
+/samples/zigbee/                          @milewr
 /samples/CMakeLists.txt                   @tejlmand
 /samples/nrf5340/netboot/                 @hakonfam
 /samples/nrf5340/multiprotocol_rpmsg/     @hubertmis
@@ -260,7 +260,7 @@ Kconfig*                                  @tejlmand
 /subsys/nrf_security/                     @frkv @Vge0rge @vili-nordic @SebastianBoe @mswarowsky
 /subsys/secure_storage/                   @frkv @Vge0rge @vili-nordic @SebastianBoe @mswarowsky
 /subsys/net_core_monitor/                 @maje-emb
-/subsys/zigbee/                           @tomchy @sebastiandraus
+/subsys/zigbee/                           @milewr
 /tests/                                   @PerMac @katgiadla
 /tests/bluetooth/tester/                  @carlescufi @ludvigsj
 /tests/bluetooth/iso/                     @koffes @alexsven @erikrobstad @rick1082 @gWacey @Frodevan
@@ -323,7 +323,7 @@ Kconfig*                                  @tejlmand
 /tests/subsys/partition_manager/region/   @hakonfam @sigvartmh
 /tests/subsys/pcd/                        @hakonfam @sigvartmh
 /tests/subsys/nrf_profiler/               @pdunaj @MarekPieta
-/tests/subsys/zigbee/                     @tomchy @sebastiandraus
+/tests/subsys/zigbee/                     @milewr
 /tests/tfm/                               @frkv @Vge0rge @vili-nordic @SebastianBoe @mswarowsky @stephen-nordic @magnev
 /tests/unity/                             @nordic-krch
 /zephyr/                                  @carlescufi

--- a/west.yml
+++ b/west.yml
@@ -141,7 +141,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: fd9047562480a35ce1c87a6e632cdb4bfb9140a7
+      revision: 4d2a82b64d98972adf86877029d27cdab8aa0a66
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Replaced tomchy and sebastiandraus with milewr as Zigbee code owner.