### PR TITLE
net: lib: nrf_cloud: fix auto info section send

### DIFF
--- a/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_shadow_info
+++ b/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_shadow_info
@@ -39,6 +39,7 @@ config NRF_CLOUD_SEND_DEVICE_STATUS_CONN_INF
 
 config NRF_CLOUD_SEND_SERVICE_INFO_FOTA
 	bool "Send FOTA service info on initial connection"
+	default y if NRF_CLOUD_FOTA
 	help
 	  Add supported FOTA types to the "serviceInfo" section.
 	  If your application does not support certain FOTA types, this option should be disabled and the application should set its supported FOTA types in the shadow.

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec_internal.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec_internal.h
@@ -171,14 +171,15 @@ int nrf_cloud_shadow_control_process(struct nrf_cloud_obj_shadow_data *const inp
 int nrf_cloud_coap_shadow_default_process(struct nrf_cloud_obj_shadow_data *const input,
 					  struct nrf_cloud_data *const response_out);
 
-/** @brief Get the info sections that are enabled to be sent to the device's shadow on
+/** @brief Encode the info sections that are enabled to be sent to the device's shadow on
  * initial connection. The sections are enabled based on the configuration options that
  * set the Kconfig @kconfig{CONFIG_NRF_CLOUD_SEND_SHADOW_INFO} symbol.
  *
  * @retval 0		Success.
- * @retval -ENODEV	CONFIG_NRF_CLOUD_SEND_SHADOW_INFO is disabled.
+ * @retval -ENODEV	No info sections are enabled, no data encoded.
+ * @return Any other negative value indicates an error.
  */
-int nrf_cloud_shadow_info_enabled_sections_get(struct nrf_cloud_device_status *const ds);
+int nrf_cloud_enabled_info_sections_json_encode(cJSON * const obj, const char * const app_ver);
 
 /** @brief Encode the device status data into a JSON formatted buffer to be saved to
  * the device shadow.


### PR DESCRIPTION
Fix the behavior of the automatic shadow info section sending.
Only send section data if the config is enabled.
Do not clear section data if the config is disabled. 
IRIS-6851