### PR TITLE
drivers: sensor: bme68x_iaq: Add support for SPI bus

### DIFF
--- a/drivers/sensor/bme68x_iaq/Kconfig
+++ b/drivers/sensor/bme68x_iaq/Kconfig
@@ -8,7 +8,8 @@ config BME68X_IAQ
 	bool "Use Bosch BSEC library"
 	depends on !BME680
 	depends on SETTINGS && !SETTINGS_NONE
-	depends on I2C
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BME680),i2c)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BME680),spi)
 	help
 	  Enable the use of Bosch BSEC library.
 	  This configuration depends on the BME680 Zephyr driver being disabled.

--- a/drivers/sensor/bme68x_iaq/bme68x_iaq.h
+++ b/drivers/sensor/bme68x_iaq/bme68x_iaq.h
@@ -7,12 +7,33 @@
 /* NCS Integration for BME68X + BSEC */
 
 #include <zephyr/kernel.h>
+#include <zephyr/devicetree.h>
+
 #include "bsec_interface.h"
 #include "bme68x.h"
 #include <drivers/bme68x_iaq.h>
 
 #ifndef ZEPHYR_DRIVERS_SENSOR_BME68X_NCS
 #define ZEPHYR_DRIVERS_SENSOR_BME68X_NCS
+
+#define DT_DRV_COMPAT bosch_bme680
+
+#define BME68x_BUS_SPI DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
+#define BME68x_BUS_I2C DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
+
+
+#if BME68x_BUS_SPI
+	#include <zephyr/drivers/spi.h>
+#elif BME68x_BUS_I2C
+	#include <zephyr/drivers/i2c.h>
+#else
+	#error "Unsupported bus for Bsec BME68x"
+#endif
+
+#if BME68x_BUS_SPI
+#define BME68x_SPI_OPERATION \
+	(SPI_WORD_SET(8) | SPI_TRANSFER_MSB | SPI_MODE_CPOL | SPI_MODE_CPHA | SPI_OP_MODE_MASTER)
+#endif
 
 struct bme_sample_result {
 	double temperature;
@@ -22,7 +43,11 @@ struct bme_sample_result {
 };
 
 struct bme68x_iaq_config {
+#if BME68x_BUS_SPI
+	const struct spi_dt_spec spi;
+#elif BME68x_BUS_I2C
 	const struct i2c_dt_spec i2c;
+#endif
 };
 
 struct bme68x_iaq_data {

--- a/samples/sensor/bme68x_iaq/boards/nrf9160dk_nrf9160_ns.overlay
+++ b/samples/sensor/bme68x_iaq/boards/nrf9160dk_nrf9160_ns.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+ &arduino_spi {
+	status = "okay";
+
+        bme680@0 {
+                compatible = "bosch,bme680";
+                reg = <0x0 >;
+		spi-max-frequency = <DT_FREQ_M(8)>;
+        };
+};

--- a/samples/sensor/bme68x_iaq/sample.yaml
+++ b/samples/sensor/bme68x_iaq/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: BME68X Sensor Sample
 tests:
-  sample.sensor.bme68x:
+  sample.sensor.bme68x.i2c:
     depends_on: i2c
     harness: sensor
     integration_platforms:
@@ -35,3 +35,9 @@ tests:
       ordered: true
       regex:
         - "(\\d+\\.\\d+); press: (\\d+\\.\\d+); humidity: (\\d+\\.\\d+); iaq: (\\d+)"
+  sample.sensor.bme68x.spi:
+    depends_on: spi
+    harness: sensor
+    platform_allow: >-
+      nrf9160dk_nrf9160_ns
+    tags: sensors


### PR DESCRIPTION
Adds support for a bme680x sensor SPI bus.