### PR TITLE
subsys: dfu: dfu_target: Do not clear configured flag

### DIFF
--- a/samples/cellular/http_update/modem_full_update/src/main.c
+++ b/samples/cellular/http_update/modem_full_update/src/main.c
@@ -420,13 +420,6 @@ static int update_download(void)
 {
 	int err;
 	const char *file;
-
-	err = fota_download_init(fota_dl_handler);
-	if (err != 0) {
-		printk("fota_download_init() failed, err %d\n", err);
-		return err;
-	}
-
 	const struct dfu_target_full_modem_params params = {
 		.buf = fmfu_buf,
 		.len = sizeof(fmfu_buf),
@@ -437,8 +430,14 @@ static int update_download(void)
 		}
 	};
 
-	err = dfu_target_full_modem_cfg(&params);
+	err = fota_download_init(fota_dl_handler);
 	if (err != 0) {
+		printk("fota_download_init() failed, err %d\n", err);
+		return err;
+	}
+
+	err = dfu_target_full_modem_cfg(&params);
+	if (err != 0 && err != -EALREADY) {
 		printk("dfu_target_full_modem_cfg failed: %d\n", err);
 		return err;
 	}

--- a/subsys/dfu/dfu_target/src/dfu_target_full_modem.c
+++ b/subsys/dfu/dfu_target/src/dfu_target_full_modem.c
@@ -151,7 +151,5 @@ int dfu_target_full_modem_reset(void)
 		return -EPERM;
 	}
 
-	configured = false;
-
 	return dfu_target_stream_reset();
 }


### PR DESCRIPTION
Do not clear configured flag on dfu_target_full_modem_reset().

Fixes an issue with MoSh after #11036 