### PR TITLE
manifest: Update Matter SDK revision to pull new crypto changes

### DIFF
--- a/applications/matter_weather_station/CMakeLists.txt
+++ b/applications/matter_weather_station/CMakeLists.txt
@@ -49,6 +49,10 @@ if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_TRANSPORT_BT)
     target_sources(app PRIVATE ${COMMON_ROOT}/src/dfu/ota/ota_util.cpp)
 endif()
 
+if(CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS)
+    target_sources(app PRIVATE ${COMMON_ROOT}/src/migration/migration_manager.cpp)
+endif()
+
 chip_configure_data_model(app
     INCLUDE_SERVER
     BYPASS_IDL

--- a/doc/nrf/protocols/matter/index.rst
+++ b/doc/nrf/protocols/matter/index.rst
@@ -45,6 +45,11 @@ The |NCS| allows you to develop applications with different versions of Matter, 
    The Matter SDK version is taken as the base for the `dedicated Matter fork`_, which can then include additional changes for each |NCS| release.
    These changes are listed in the Matter fork section of the |NCS| :ref:`release_notes`.
 
+.. important::
+   For Matter over Thread samples, starting with |NCS| v2.6.0, the default cryptography backend is Arm PSA Crypto API instead of Mbed TLS, which was used in earlier versions.
+   To :ref:`inherit Thread certification <ug_matter_device_certification_reqs_dependent>` from Nordic Semiconductor, you must use the PSA Crypto API backend.
+   See the :ref:`migration guide <migration_2.6>` to learn about all changes if you are migrating from an earlier version of the |NCS|.
+
 For more information about Matter compatibility, see :ref:`ug_matter_overview_dev_model_support` and :ref:`supported Matter features per SoC <software_maturity_protocol_matter>`.
 
 See :ref:`matter_samples` for the list of available samples, :ref:`Matter Weather Station <matter_weather_station_app>` or :ref:`Matter bridge <matter_bridge_app>` for specific Matter application.

--- a/doc/nrf/releases_and_maturity/migration/migration_guide_2.6.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_guide_2.6.rst
@@ -30,11 +30,21 @@ The following changes are mandatory to make your application work in the same wa
       * The ``CONFIG_CHIP_SED_ACTIVE_INTERVAL`` Kconfig option was renamed to :kconfig:option:`CONFIG_CHIP_ICD_FAST_POLLING_INTERVAL`.
       * The ``CONFIG_CHIP_SED_ACTIVE_THRESHOLD`` Kconfig option was renamed to :kconfig:option:`CONFIG_CHIP_ICD_ACTIVE_MODE_THRESHOLD`.
 
-* For Matter over Thread samples, starting from this release, the cryptography backend enabled by default is PSA Crypto API instead of mbedTLS.
+* For Matter over Thread samples, starting from this release, the cryptography backend enabled by default is PSA Crypto API instead of Mbed TLS.
   Be aware of the change and consider the following when migrating to |NCS| v2.6.0:
 
-  * You can keep using mbedTLS API as the cryptography backend by disabling PSA Crypto API.
+  * You can keep using Mbed TLS API as the cryptography backend by disabling PSA Crypto API.
     You can disable it by setting the :kconfig:option:`CONFIG_CHIP_CRYPTO_PSA` Kconfig option to ``n``.
+  * Thread libraries will be built with PSA Crypto API enabled without Mbed TLS support.
+    This means that if you set the :kconfig:option:`CONFIG_CHIP_CRYPTO_PSA` Kconfig option to ``n``, you must also build the Thread libraries from sources.
+
+    To :ref:`inherit Thread certification <ug_matter_device_certification_reqs_dependent>` from Nordic Semiconductor, you must use the PSA Crypto API backend.
+  * The device can automatically migrate all operational keys from the Matter's generic persistent storage to the PSA ITS secure storage.
+    This means that all keys needed to establish the secure connection between Matter nodes will be moved to the PSA ITS secure storage.
+    To enable operational keys migration, set the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS` Kconfig option to ``y``.
+
+    The default reaction to migration failure in |NCS| Matter samples is a factory reset of the device.
+    To change the default reaction, set the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_FACTORY_RESET_ON_KEY_MIGRATION_FAILURE` Kconfig option to ``n`` and implement the reaction in your Matter event handler.
   * When the Device Attestation Certificate (DAC) private key exists in the factory data set, it can migrate to the PSA ITS secure storage.
 
     You can also have the DAC private key replaced by zeros in the factory data partition by setting the :kconfig:option:`CONFIG_CHIP_CRYPTO_PSA_MIGRATE_DAC_PRIV_KEY` Kconfig option to ``y``.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -98,6 +98,9 @@ Bluetooth Mesh
 Matter
 ------
 
+* For devices that use Matter over Thread, the default cryptography backend is now Arm PSA Crypto API instead of Mbed TLS, which was used in earlier versions.
+  You can still build all examples with deprecated Mbed TLS support by setting the :kconfig:option:`CONFIG_CHIP_CRYPTO_PSA` Kconfig option to ``n``, but you must build the Thread libraries from sources.
+  To :ref:`inherit Thread certification <ug_matter_device_certification_reqs_dependent>` from Nordic Semiconductor, you must use the PSA Crypto API backend.
 * Updated the page about :ref:`ug_matter_device_low_power_configuration` with the information about Intermittently Connected Devices (ICD) configuration.
 
 * Added:
@@ -115,6 +118,14 @@ Matter
     By default, the thermostat sample generates simulated temperature measurements.
     The generated measurements simulate local temperature changes.
     Additionally, you can enable periodic outdoor temperature measurements by binding the thermostat with an external temperature sensor device.
+
+  * Migration of the Node Operational Key Pair (NOK) from the generic Matter persistent storage to the PSA ITS secure storage.
+    All existing NOKs for all Matter fabrics will be migrated to the PSA ITS secure storage at boot.
+    After the migration, generic Matter persistent storage entries in the settings storage will be removed and no longer available.
+    To enable operational keys migration, set the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS` Kconfig option to ``y``.
+
+    In |NCS| Matter samples, the default reaction to migration failure is a factory reset of the device.
+    To change the default reaction, set the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_FACTORY_RESET_ON_KEY_MIGRATION_FAILURE` Kconfig option to ``n``.
 
 Matter fork
 +++++++++++

--- a/samples/matter/common/src/Kconfig
+++ b/samples/matter/common/src/Kconfig
@@ -23,3 +23,19 @@ config NCS_SAMPLE_MATTER_CUSTOM_BLUETOOTH_ADVERTISING
 	help
 	  Disable the default Bluetooth advertising start which is defined in the board.cpp file and
 	  allow to use the custom one.
+
+config NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS
+	bool "Enable operational keys migration feature"
+	depends on CHIP_CRYPTO_PSA
+	help
+	  Enables migration of the operational keys stored in the persistent storage to the PSA ITS secure storage.
+	  Enable this feature while updating the firmware of in-field devices that run Mbed TLS cryptography backend
+	  to the firmware based on PSA Crypto API.
+
+config NCS_SAMPLE_MATTER_FACTORY_RESET_ON_KEY_MIGRATION_FAILURE
+	bool "Perform factory reset if the operational key migration failed"
+	default y
+	depends on NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS
+	help
+	  Allow device to perform factory reset if the operational key for Fabric has not been migrated
+	  properly to PSA ITS storage.

--- a/samples/matter/common/src/app/matter_init.h
+++ b/samples/matter/common/src/app/matter_init.h
@@ -19,7 +19,11 @@
 #include <platform/nrfconnect/wifi/NrfWiFiDriver.h>
 #endif
 
-#if CONFIG_CHIP_FACTORY_DATA
+#ifdef CONFIG_CHIP_CRYPTO_PSA
+#include <crypto/PSAOperationalKeystore.h>
+#endif
+
+#ifdef CONFIG_CHIP_FACTORY_DATA
 #include <platform/nrfconnect/FactoryDataProvider.h>
 #else
 #include <platform/nrfconnect/DeviceInstanceInfoProviderImpl.h>
@@ -47,7 +51,7 @@ struct InitData {
 	chip::CommonCaseDeviceServerInitParams *mServerInitParams{ &sServerInitParamsDefault };
 	/** @brief Pointer to the user provided custom device info provider implementation. */
 	chip::DeviceLayer::DeviceInfoProviderImpl *mDeviceInfoProvider{ nullptr };
-#if CONFIG_CHIP_FACTORY_DATA
+#ifdef CONFIG_CHIP_FACTORY_DATA
 	/** @brief Pointer to the user provided FactoryDataProvider implementation. */
 	chip::DeviceLayer::FactoryDataProviderBase *mFactoryDataProvider{ &sDefaultFactoryDataProvider };
 #endif
@@ -62,9 +66,12 @@ struct InitData {
 	static chip::app::Clusters::NetworkCommissioning::Instance sWiFiCommissioningInstance;
 #endif
 	static chip::CommonCaseDeviceServerInitParams sServerInitParamsDefault;
-#if CONFIG_CHIP_FACTORY_DATA
+#ifdef CONFIG_CHIP_FACTORY_DATA
 	static chip::DeviceLayer::FactoryDataProvider<chip::DeviceLayer::InternalFlashFactoryData>
 		sDefaultFactoryDataProvider;
+#endif
+#ifdef CONFIG_CHIP_CRYPTO_PSA
+	static chip::Crypto::PSAOperationalKeystore sPSAOperationalKeystore;
 #endif
 };
 
@@ -94,7 +101,7 @@ CHIP_ERROR PrepareServer(const InitData &initData = InitData{});
  */
 CHIP_ERROR StartServer();
 
-#if CONFIG_CHIP_FACTORY_DATA
+#ifdef CONFIG_CHIP_FACTORY_DATA
 /**
  * @brief Get the currently set FactoryDataProvider.
  *

--- a/samples/matter/common/src/migration/migration_manager.cpp
+++ b/samples/matter/common/src/migration/migration_manager.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "migration_manager.h"
+
+#include <crypto/OperationalKeystore.h>
+#include <crypto/PersistentStorageOperationalKeystore.h>
+
+namespace Nrf::Matter
+{
+namespace Migration
+{
+#ifdef CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS
+	CHIP_ERROR MoveOperationalKeysFromKvsToIts(chip::PersistentStorageDelegate *storage,
+						   chip::Crypto::OperationalKeystore *keystore)
+	{
+		CHIP_ERROR err = CHIP_NO_ERROR;
+
+		VerifyOrReturnError(keystore && storage, CHIP_ERROR_INVALID_ARGUMENT);
+
+		/* Initialize the obsolete Operational Keystore*/
+		chip::PersistentStorageOperationalKeystore obsoleteKeystore;
+		err = obsoleteKeystore.Init(storage);
+		VerifyOrReturnError(err == CHIP_NO_ERROR, err);
+
+		/* Migrate all obsolete Operational Keys to PSA ITS */
+		for (const chip::FabricInfo &fabric : chip::Server::GetInstance().GetFabricTable()) {
+			err = keystore->MigrateOpKeypairForFabric(fabric.GetFabricIndex(), obsoleteKeystore);
+			if (CHIP_NO_ERROR != err) {
+				break;
+			}
+		}
+
+#ifdef CONFIG_NCS_SAMPLE_MATTER_FACTORY_RESET_ON_KEY_MIGRATION_FAILURE
+		if (CHIP_NO_ERROR != err) {
+			chip::Server::GetInstance().ScheduleFactoryReset();
+			/* Return a success to not block the Matter event Loop and allow to call scheduled factory
+			 * reset. */
+			err = CHIP_NO_ERROR;
+		}
+#endif /* CONFIG_NCS_SAMPLE_MATTER_FACTORY_RESET_ON_KEY_MIGRATION_FAILURE */
+
+		return err;
+	}
+#endif /* CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS */
+} /* namespace Migration */
+} /* namespace Nrf::Matter */

--- a/samples/matter/common/src/migration/migration_manager.h
+++ b/samples/matter/common/src/migration/migration_manager.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#pragma once
+
+#include <app/server/Server.h>
+
+namespace Nrf::Matter
+{
+namespace Migration
+{
+#ifdef CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS
+	/**
+	 * @brief Migrate all stored Operational Keys from the persistent storage (KVS) to secure PSA ITS.
+	 *
+	 * This function will schedule a factory reset automatically if the
+	 * CONFIG_NCS_SAMPLE_MATTER_FACTORY_RESET_ON_KEY_MIGRATION_FAILURE
+	 * Kconfig option is set to 'y'. In this case, the function returns CHIP_NO_ERROR to not block any further
+	 * operations until the scheduled factory reset is done.
+	 *
+	 * @note This function should be called just after Matter Server Init to avoid problems with further CASE
+	 * session re-establishments.
+	 * @param storage
+	 * @param keystore
+	 * @retval CHIP_NO_ERROR if all keys have been migrated properly to PSA ITS or if the error occurs, but
+	 * 		   the CONFIG_NCS_SAMPLE_MATTER_FACTORY_RESET_ON_KEY_MIGRATION_FAILURE kconfig is set to 'y'.
+	 * @retval CHIP_ERROR_INVALID_ARGUMENT when keystore or storage are not defined.
+	 * @retval Other CHIP_ERROR codes related to internal Migration operations.
+	 */
+	CHIP_ERROR MoveOperationalKeysFromKvsToIts(chip::PersistentStorageDelegate *storage,
+						   chip::Crypto::OperationalKeystore *keystore);
+#endif
+} /* namespace Migration */
+} /* namespace Nrf::Matter */

--- a/samples/matter/light_bulb/CMakeLists.txt
+++ b/samples/matter/light_bulb/CMakeLists.txt
@@ -64,6 +64,10 @@ if(CONFIG_MCUMGR_TRANSPORT_BT)
     target_sources(app PRIVATE ${COMMON_ROOT}/src/dfu/smp/dfu_over_smp.cpp)
 endif()
 
+if(CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS)
+    target_sources(app PRIVATE ${COMMON_ROOT}/src/migration/migration_manager.cpp)
+endif()
+
 chip_configure_data_model(app
     INCLUDE_SERVER
     BYPASS_IDL

--- a/samples/matter/light_switch/CMakeLists.txt
+++ b/samples/matter/light_switch/CMakeLists.txt
@@ -63,6 +63,10 @@ if(CONFIG_MCUMGR_TRANSPORT_BT)
     target_sources(app PRIVATE ${COMMON_ROOT}/src/dfu/smp/dfu_over_smp.cpp)
 endif()
 
+if(CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS)
+    target_sources(app PRIVATE ${COMMON_ROOT}/src/migration/migration_manager.cpp)
+endif()
+
 chip_configure_data_model(app
     INCLUDE_SERVER
     BYPASS_IDL

--- a/samples/matter/lock/CMakeLists.txt
+++ b/samples/matter/lock/CMakeLists.txt
@@ -77,6 +77,10 @@ if(CONFIG_THREAD_WIFI_SWITCHING)
     target_compile_options(..__nrf__modules__hostap PRIVATE -flto)
 endif()
 
+if(CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS)
+    target_sources(app PRIVATE ${COMMON_ROOT}/src/migration/migration_manager.cpp)
+endif()
+
 chip_configure_data_model(app
     INCLUDE_SERVER
     BYPASS_IDL

--- a/samples/matter/template/CMakeLists.txt
+++ b/samples/matter/template/CMakeLists.txt
@@ -53,6 +53,10 @@ if(CONFIG_CHIP_OTA_REQUESTOR)
     target_sources(app PRIVATE ${COMMON_ROOT}/src/dfu/ota/ota_util.cpp)
 endif()
 
+if(CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS)
+    target_sources(app PRIVATE ${COMMON_ROOT}/src/migration/migration_manager.cpp)
+endif()
+
 chip_configure_data_model(app
     INCLUDE_SERVER
     BYPASS_IDL

--- a/samples/matter/template/sample.yaml
+++ b/samples/matter/template/sample.yaml
@@ -4,6 +4,7 @@ sample:
 tests:
   sample.matter.template.debug:
     build_only: true
+    extra_args: CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS=y
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
@@ -12,6 +13,7 @@ tests:
   sample.matter.template.release:
     build_only: true
     extra_args: CONF_FILE=prj_release.conf
+      CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS=y
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp

--- a/samples/matter/thermostat/CMakeLists.txt
+++ b/samples/matter/thermostat/CMakeLists.txt
@@ -63,6 +63,10 @@ if(CONFIG_MCUMGR_TRANSPORT_BT)
     target_sources(app PRIVATE ${COMMON_ROOT}/src/dfu/smp/dfu_over_smp.cpp)
 endif()
 
+if(CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS)
+    target_sources(app PRIVATE ${COMMON_ROOT}/src/migration/migration_manager.cpp)
+endif()
+
 chip_configure_data_model(app
     INCLUDE_SERVER
     BYPASS_IDL

--- a/samples/matter/window_covering/CMakeLists.txt
+++ b/samples/matter/window_covering/CMakeLists.txt
@@ -60,6 +60,10 @@ if(CONFIG_MCUMGR_TRANSPORT_BT)
     target_sources(app PRIVATE ${COMMON_ROOT}/src/dfu/smp/dfu_over_smp.cpp)
 endif()
 
+if(CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS)
+    target_sources(app PRIVATE ${COMMON_ROOT}/src/migration/migration_manager.cpp)
+endif()
+
 chip_configure_data_model(app
     INCLUDE_SERVER
     BYPASS_IDL

--- a/west.yml
+++ b/west.yml
@@ -154,7 +154,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: b6a5e9a6aff7d6f0ea4a47a0ed5b0f2ac3181c24
+      revision: 288b64af79b92d0a5412181eb87fa3a5e0368cab
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
In this commit added a mechanism that migrates all existing operational keys from mbedTLS-related settings storage to the PSA ITS secure storage.

After the migration the entries in the settings storage will not be avaliable anymore.