### PR TITLE
Bluetooth: Controller: New default event length and spacing for ISO

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -136,7 +136,7 @@ config BT_CTLR_SDC_MAX_CONN_EVENT_LEN_DEFAULT_OVERRIDE
 
 config BT_CTLR_SDC_MAX_CONN_EVENT_LEN_DEFAULT
 	int "Default max connection event length [us]"
-	default 10000 if BT_ISO && !BT_CTLR_SDC_MAX_CONN_EVENT_LEN_DEFAULT_OVERRIDE
+	default 0 if BT_ISO && !BT_CTLR_SDC_MAX_CONN_EVENT_LEN_DEFAULT_OVERRIDE
 	default 7500 if !BT_CTLR_SDC_MAX_CONN_EVENT_LEN_DEFAULT_OVERRIDE
 	range 0 4000000
 	help
@@ -150,6 +150,7 @@ config BT_CTLR_SDC_MAX_CONN_EVENT_LEN_DEFAULT
 
 config BT_CTLR_SDC_CENTRAL_ACL_EVENT_SPACING_DEFAULT
 	int "Default central ACL event spacing [us]"
+	default 30000 if BT_ISO
 	default BT_CTLR_SDC_MAX_CONN_EVENT_LEN_DEFAULT
 	help
 	  On the central, sets the time ACL connections are spaced apart assuming that


### PR DESCRIPTION
When ISO is enabled, we want to set asside as much time as possible for ISO activities.

By setting BT_CTLR_SDC_MAX_CONN_EVENT_LEN_DEFAULT=0, we ensure that the ACL will utilize as little time as possible and avoid increasing the data length capabilities.

The BT_CTLR_SDC_CENTRAL_ACL_EVENT_SPACING_DEFAULT needs to be updated accordingly - we want the ACLs to be spaced apart to avoid scheduling conflicts. By selecting the value of 30 ms, we ensure that:
 - The ACLs are non-overlapping given that they are using an interval which is greater than 30 ms.
 - The ACL events are not overlapping with ISO events, given that the ISO interval is a multiple of 7.5 ms or 10 ms.