### PR TITLE
tests: Add quarantine for no optimizations plan

### DIFF
--- a/scripts/quarantine_no_optimization.yaml
+++ b/scripts/quarantine_no_optimization.yaml
@@ -1,0 +1,8 @@
+# The configurations resulting as a product of scenarios and platforms
+# will be skipped if quarantine is used. More details here:
+# https://docs.zephyrproject.org/latest/guides/test/twister.html#quarantine
+# To have an empty list use:
+- scenarios:
+    - net.lib.aws_iot
+  platforms:
+    - native_posix


### PR DESCRIPTION
A nightly plan has a stage where tests are built executed on native_posix with NO_OPTIMIZATIONS confg. This stage requires its own quarantine.