### PR TITLE
net: lib: nrf_cloud: client cert not req'd for coap

### DIFF
--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_credentials.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_credentials.c
@@ -32,7 +32,8 @@ int nrf_cloud_credentials_configured_check(void)
 		}
 	}
 
-	if (IS_ENABLED(CONFIG_NRF_CLOUD_MQTT) || IS_ENABLED(CONFIG_NRF_CLOUD_COAP)) {
+	/* A client certificate is required for MQTT for the mutual-TLS connection */
+	if (IS_ENABLED(CONFIG_NRF_CLOUD_MQTT)) {
 		if (!cs.client_cert) {
 			LOG_ERR("Client Certificate not found in sec tag %d", cs.sec_tag);
 			ret = -ENOTSUP;


### PR DESCRIPTION
Removed the client certificate check for CoAP builds in nrf_cloud_credentials_check().
Only a CA and private key are required for the CoAP connection.
IRIS-7978