### PR TITLE
lib: wifi_credentials: add support for setting MFP

### DIFF
--- a/include/net/wifi_credentials.h
+++ b/include/net/wifi_credentials.h
@@ -29,7 +29,10 @@ extern "C" {
 #define WIFI_CREDENTIALS_FLAG_2_4GHz		BIT(2)
 /* this entry can use the 5 GHz band */
 #define WIFI_CREDENTIALS_FLAG_5GHz		BIT(3)
-
+/* this entry requires management frame protection */
+#define WIFI_CREDENTIALS_FLAG_MFP_REQUIRED	BIT(4)
+/* this entry disables management frame protection */
+#define WIFI_CREDENTIALS_FLAG_MFP_DISABLED	BIT(5)
 
 #define WIFI_CREDENTIALS_MAX_PASSWORD_LEN\
 	MAX(WIFI_PSK_MAX_LEN, CONFIG_WIFI_CREDENTIALS_SAE_PASSWORD_LENGTH)

--- a/subsys/net/lib/wifi_credentials/wifi_credentials_shell.c
+++ b/subsys/net/lib/wifi_credentials/wifi_credentials_shell.c
@@ -69,6 +69,14 @@ static void print_network_info(void *cb_arg, const char *ssid, size_t ssid_len)
 	if (creds.header.flags & WIFI_CREDENTIALS_FLAG_FAVORITE) {
 		shell_fprintf(shell, SHELL_VT100_COLOR_DEFAULT, ", favorite");
 	}
+
+	if (creds.header.flags & WIFI_CREDENTIALS_FLAG_MFP_REQUIRED) {
+		shell_fprintf(shell, SHELL_VT100_COLOR_DEFAULT, ", MFP_REQUIRED");
+	} else if (creds.header.flags & WIFI_CREDENTIALS_FLAG_MFP_DISABLED) {
+		shell_fprintf(shell, SHELL_VT100_COLOR_DEFAULT, ", MFP_DISABLED");
+	} else {
+		shell_fprintf(shell, SHELL_VT100_COLOR_DEFAULT, ", MFP_OPTIONAL");
+	}
 	shell_fprintf(shell, SHELL_VT100_COLOR_DEFAULT, "\n");
 }
 
@@ -180,8 +188,19 @@ static int cmd_add_network(const struct shell *shell, size_t argc, char *argv[])
 
 	if (arg_idx < argc) {
 		/* look for favorite flag */
-		if (strcmp("favorite", argv[arg_idx]) == 0) {
+		if (strncmp("favorite", argv[arg_idx], strlen("favorite")) == 0) {
 			creds.header.flags |= WIFI_CREDENTIALS_FLAG_FAVORITE;
+			++arg_idx;
+		}
+	}
+
+	if (arg_idx < argc) {
+		/* look for mfp_disabled flag */
+		if (strncmp("mfp_disabled", argv[arg_idx], strlen("mfp_disabled")) == 0) {
+			creds.header.flags |= WIFI_CREDENTIALS_FLAG_MFP_DISABLED;
+			++arg_idx;
+		} else if (strncmp("mfp_required", argv[arg_idx], strlen("mfp_required")) == 0) {
+			creds.header.flags |= WIFI_CREDENTIALS_FLAG_MFP_REQUIRED;
 			++arg_idx;
 		}
 	}
@@ -199,7 +218,8 @@ help:
 		    " [psk/password]"
 		    " [bssid]"
 		    " [{2.4GHz, 5GHz}]"
-		    " [favorite]");
+		    " [favorite]"
+		    " [mfp_disabled|mfp_required]");
 	return -EINVAL;
 }
 

--- a/subsys/net/lib/wifi_mgmt_ext/wifi_mgmt_ext.c
+++ b/subsys/net/lib/wifi_mgmt_ext/wifi_mgmt_ext.c
@@ -70,7 +70,6 @@ static int __stored_creds_to_params(struct wifi_credentials_personal *creds,
 
 	/* Defaults */
 	params->security = creds->header.type;
-	params->mfp = WIFI_MFP_OPTIONAL;
 	params->channel = WIFI_CHANNEL_ANY;
 	params->timeout = CONFIG_WIFI_MGMT_EXT_CONNECTION_TIMEOUT;
 
@@ -85,6 +84,15 @@ static int __stored_creds_to_params(struct wifi_credentials_personal *creds,
 		params->band = WIFI_FREQ_BAND_5_GHZ;
 	} else {
 		params->band = WIFI_FREQ_BAND_UNKNOWN;
+	}
+
+	/* MFP setting (default: optional) */
+	if (creds->header.flags & WIFI_CREDENTIALS_FLAG_MFP_DISABLED) {
+		params->mfp = WIFI_MFP_DISABLE;
+	} else if (creds->header.flags & WIFI_CREDENTIALS_FLAG_MFP_REQUIRED) {
+		params->mfp = WIFI_MFP_REQUIRED;
+	} else {
+		params->mfp = WIFI_MFP_OPTIONAL;
 	}
 
 	return 0;


### PR DESCRIPTION
This patch adds management frame protection settings to the wifi_credentials library.