### PR TITLE
scripts: memory-threshold-list: add codeowners for multiprotocol_rpmsg

### DIFF
--- a/scripts/memory-threshold-list.yaml
+++ b/scripts/memory-threshold-list.yaml
@@ -48,3 +48,14 @@
   ram_related_usage: 256
   codeowners:
     - MarekPieta
+
+- scenarios:
+    - sample.nrf5340.multiprotocol_rpmsg
+  platforms:
+    - nrf5340dk_nrf5340_cpunet
+  ram_size: 55296
+  rom_size: 235929
+  codeowners:
+    - ankuns
+    - dawidprzybylo
+    - jciupis


### PR DESCRIPTION
Add absolute limits for RAM and ROM usage for multiprotocol_rpmsg sample for nRF5340 network core:
* RAM: at least 10kB must be free
* ROM: at least 10% of the available memory must be free