### PR TITLE
samples: cellular: modem_trace_flash: doc: fix

### DIFF
--- a/samples/cellular/modem_trace_flash/README.rst
+++ b/samples/cellular/modem_trace_flash/README.rst
@@ -83,7 +83,6 @@ Testing
 After programming the sample and board controller firmware (as mentioned in Requirements section) to your development kit, test it by performing the following steps:
 
 #. |connect_kit|
-#. |connect_terminal|
 #. Open the `Cellular Monitor`_ desktop application and connect the DK.
 #. Select :guilabel:`Autoselect` from the **Modem trace database** drop-down menu, or a modem firmware version that is programmed on the DK.
 #. Select :guilabel:`Reset device on start`.


### PR DESCRIPTION
Remove `|connect_terminal|` entry to prevent having two serial terminals connected to the device at the same time when choosing the nRF Connect for Desktop Serial Terminal app. Having two serial terminals connected to the device will cause a garbled output.