### PR TITLE
doc: extensions: options-from-kconfig: Disable warnings

### DIFF
--- a/doc/_extensions/options_from_kconfig.py
+++ b/doc/_extensions/options_from_kconfig.py
@@ -67,7 +67,7 @@ class OptionsFromKconfig(SphinxDirective):
 
         # kconfiglib wants this env var defined
         os.environ['srctree'] = os.path.dirname(os.path.abspath(__file__))
-        kconfig = kconfiglib.Kconfig(filename=path)
+        kconfig = kconfiglib.Kconfig(filename=path, warn=False)
 
         prefix = self.options.get('prefix', None)
         suffix = self.options.get('suffix', None)


### PR DESCRIPTION
This option currently generates Kconfig warnings. Disable them to avoid polluting the build.