### PR TITLE
tests: Resolve duplicates in test names

### DIFF
--- a/tests/subsys/net/lib/lwm2m_client_utils/src/cellconn.c
+++ b/tests/subsys/net/lib/lwm2m_client_utils/src/cellconn.c
@@ -56,7 +56,7 @@ static void copy_event_handler(lte_lc_evt_handler_t hd)
 
 ZTEST_SUITE(lwm2m_client_utils_cellconn, NULL, NULL, NULL, NULL, NULL);
 
-ZTEST(lwm2m_client_utils_cellconn, test_init)
+ZTEST(lwm2m_client_utils_cellconn, test_init_cellconn)
 {
 	int rc;
 

--- a/tests/subsys/net/lib/lwm2m_client_utils/src/connmon.c
+++ b/tests/subsys/net/lib/lwm2m_client_utils/src/connmon.c
@@ -145,7 +145,7 @@ ZTEST(lwm2m_client_utils_connmon, test_modem_info_params_init_fail)
 	zassert_equal(rc, modem_info_params_init_fake.return_val, "wrong return value");
 }
 
-ZTEST(lwm2m_client_utils_connmon, test_init)
+ZTEST(lwm2m_client_utils_connmon, test_init_connmon)
 {
 	setup();
 

--- a/tests/subsys/net/lib/lwm2m_client_utils/src/security.c
+++ b/tests/subsys/net/lib/lwm2m_client_utils/src/security.c
@@ -397,7 +397,7 @@ ZTEST(lwm2m_client_utils_security, test_init_get_buf_fails)
 	zassert_equal(rc, -4, "wrong return value");
 }
 
-ZTEST(lwm2m_client_utils_security, test_init)
+ZTEST(lwm2m_client_utils_security, test_init_security)
 {
 	/* Normal case */
 	int rc;


### PR DESCRIPTION
3 test cases were named "init" which affected twister results. Ztest added 3 tests under the same name, parsed result of one of them and the rest were obtaining status null in the json report. With the new names all 3 tests are reported individually.