### PR TITLE
doc: matter: fix links to GN binary

### DIFF
--- a/doc/nrf/protocols/matter/getting_started/tools.rst
+++ b/doc/nrf/protocols/matter/getting_started/tools.rst
@@ -53,7 +53,7 @@ If you are updating from the |NCS| version earlier than v1.5.0, see the followin
 
             .. code-block:: console
 
-               wget -O gn.zip https:\ //chrome-infra-packages.appspot.com/dl/gn/gn/linux-amd64/+/latest
+               wget -O gn.zip https://chrome-infra-packages.appspot.com/dl/gn/gn/linux-amd64/+/latest
                unzip gn.zip
                rm gn.zip
 
@@ -82,13 +82,13 @@ If you are updating from the |NCS| version earlier than v1.5.0, see the followin
 
             .. code-block:: console
 
-               curl -o gn.zip -L https:\ //chrome-infra-packages.appspot.com/dl/gn/gn/mac-arm64/+/latest
+               curl -o gn.zip -L https://chrome-infra-packages.appspot.com/dl/gn/gn/mac-arm64/+/latest
 
             * On macOS running on Intel:
 
             .. code-block:: console
 
-               curl -o gn.zip -L https:\ //chrome-infra-packages.appspot.com/dl/gn/gn/mac-amd64/+/latest
+               curl -o gn.zip -L https://chrome-infra-packages.appspot.com/dl/gn/gn/mac-amd64/+/latest
 
          #. Unzip the archive and then delete it:
 


### PR DESCRIPTION
This commit fixes the URL format for GN binary.

I believe extra `\ ` characters are needed when URL is in highlights section, not in the console section.