### PR TITLE
manifest: Pulled fix for the Matter over Thread DNS resolution

### DIFF
--- a/doc/nrf/releases_and_maturity/known_issues.rst
+++ b/doc/nrf/releases_and_maturity/known_issues.rst
@@ -323,6 +323,15 @@ Matter
 
 The issues in this section are related to the :ref:`ug_matter` protocol.
 
+.. rst-class:: v2-5-1 v2-5-0 v2-4-2 v2-4-1 v2-4-0
+
+KRKNWK-18256: The Matter over Thread device may crash during the processing of the DNS resolve response
+  The Matter core implementation handles DNS resolve responses for the Thread platform in a wrong way.
+  If the DNS resolve response contains a TXT record with data size equal to 0 (either it is not present or its Time-To-Live (TTL) is equal to 0), the Matter device's application crashes.
+  The application behavior for the responses containing a TXT record with data size not equal to 0 is correct.
+
+  **Workaround:** Manually cherry-pick and apply the commit with the fix to ``sdk-connectedhomeip`` (commit hash: TODO).
+
 .. rst-class:: v2-5-1 v2-5-0 v2-4-2 v2-4-1 v2-4-0 v2-3-0 v2-2-0
 
 KRKNWK-18221: Memory leak in the deferred attribute persister

--- a/west.yml
+++ b/west.yml
@@ -151,7 +151,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 1a15f4cdb4d6c1f431a12064625df06fe45e660a
+      revision: 4997cd70ed53735e302186e7eda1bb28a216199a
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
There was a bug discovered that in specific scenarios lead to Matter over Thread device application crash while processing DNS resolve response.

This PR pulls commit with a fix and adds known issues entry that describes the problem.