### PR TITLE
Bluetooth: Mesh: Add new Sensor API support to light_ctrl

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -88,6 +88,7 @@ Bluetooth Mesh
     This makes it possible to accurately represent all encodable sensor values.
     The old APIs based on the :c:struct:`sensor_value` type are deprecated, but are still available for backward compatibility, and can be enabled for use by setting the :kconfig:option:`CONFIG_BT_MESH_SENSOR_USE_LEGACY_SENSOR_VALUE` Kconfig option.
   * :ref:`bt_mesh_ug_reserved_ids` with model ID and opcodes for the new :ref:`bt_mesh_le_pair_resp_readme` model.
+  * :ref:`bt_mesh_light_ctrl_readme` APIs to match new Sensor APIs.
 
 Matter
 ------

--- a/include/bluetooth/mesh/light_ctrl.h
+++ b/include/bluetooth/mesh/light_ctrl.h
@@ -225,12 +225,21 @@ enum bt_mesh_light_ctrl_coeff {
 		.accuracy = CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG_ACCURACY,        \
 	}
 
+#ifdef CONFIG_BT_MESH_SENSOR_USE_LEGACY_SENSOR_VALUE
 #define BT_MESH_LIGHT_CTRL_SRV_LUX_INIT                                        \
 	.lux = {                                                               \
 		{ CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG_LUX_STANDBY },             \
 		{ CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG_LUX_ON },                  \
 		{ CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG_LUX_PROLONG }              \
 	}
+#else
+#define BT_MESH_LIGHT_CTRL_SRV_LUX_INIT                                        \
+	.centilux = {                                                          \
+		CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG_LUX_STANDBY,                 \
+		CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG_LUX_ON,                      \
+		CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG_LUX_PROLONG                  \
+	}
+#endif
 #else
 #define BT_MESH_LIGHT_CTRL_SRV_LUX_INIT
 #endif

--- a/include/bluetooth/mesh/light_ctrl_cli.h
+++ b/include/bluetooth/mesh/light_ctrl_cli.h
@@ -93,6 +93,23 @@ struct bt_mesh_light_ctrl_cli_handlers {
 			    struct bt_mesh_msg_ctx *ctx,
 			    const struct bt_mesh_onoff_status *status);
 
+#if !defined(CONFIG_BT_MESH_SENSOR_USE_LEGACY_SENSOR_VALUE) || defined(__DOXYGEN__)
+	/** @brief Light LC Property status handler.
+	 *
+	 *  The Light Lightness Control Server's properties are configuration
+	 *  parameters for its behavior. All properties are represented as a
+	 *  single sensor channel.
+	 *
+	 *  @param[in] cli   Client that received the message.
+	 *  @param[in] ctx   Context of the message.
+	 *  @param[in] id    ID of the property.
+	 *  @param[in] value Value of the property.
+	 */
+	void (*prop)(struct bt_mesh_light_ctrl_cli *cli,
+		     struct bt_mesh_msg_ctx *ctx,
+		     enum bt_mesh_light_ctrl_prop id,
+		     const struct bt_mesh_sensor_value *value);
+#else
 	/** @brief Light LC Property status handler.
 	 *
 	 *  The Light Lightness Control Server's properties are configuration
@@ -108,6 +125,7 @@ struct bt_mesh_light_ctrl_cli_handlers {
 		     struct bt_mesh_msg_ctx *ctx,
 		     enum bt_mesh_light_ctrl_prop id,
 		     const struct sensor_value *value);
+#endif
 
 	/** @brief Light LC Regulator Coefficient status handler.
 	 *
@@ -379,6 +397,90 @@ int bt_mesh_light_ctrl_cli_light_onoff_set_unack(
 	struct bt_mesh_light_ctrl_cli *cli, struct bt_mesh_msg_ctx *ctx,
 	const struct bt_mesh_onoff_set *set);
 
+#if !defined(CONFIG_BT_MESH_SENSOR_USE_LEGACY_SENSOR_VALUE) || defined(__DOXYGEN__)
+/** @brief Get a Light Lightness Control Server property value.
+ *
+ *  Properties are the configuration parameters for the Light Lightness Control
+ *  Server. Each property value is represented as a single sensor channel.
+ *
+ *  This call is blocking if the @c rsp buffer is non-NULL. Otherwise, this
+ *  function will return, and the response will be passed to the
+ *  @ref bt_mesh_light_ctrl_cli_handlers::prop callback.
+ *
+ *  @param[in]  cli Client model to send on.
+ *  @param[in]  ctx Message context, or NULL to use the configured publish
+ *                  parameters.
+ *  @param[in]  id  Light Lightness Control Server property to get.
+ *  @param[out] rsp Property value response buffer, or NULL to keep from
+ *                  blocking.
+ *
+ *  @retval 0              Successfully sent the message and populated the @c
+ *                         rsp buffer.
+ *  @retval -EALREADY      A blocking request is already in progress.
+ *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ *                         not configured.
+ *  @retval -EAGAIN        The device has not been provisioned.
+ *  @retval -ETIMEDOUT     The request timed out without a response.
+ */
+int bt_mesh_light_ctrl_cli_prop_get(struct bt_mesh_light_ctrl_cli *cli,
+				    struct bt_mesh_msg_ctx *ctx,
+				    enum bt_mesh_light_ctrl_prop id,
+				    struct bt_mesh_sensor_value *rsp);
+
+/** @brief Set a Light Lightness Control Server property value.
+ *
+ *  Properties are the configuration parameters for the Light Lightness Control
+ *  Server. Each property value is represented as a single sensor channel.
+ *
+ *  This call is blocking if the @c rsp buffer is non-NULL. Otherwise, this
+ *  function will return, and the response will be passed to the
+ *  @ref bt_mesh_light_ctrl_cli_handlers::prop callback.
+ *
+ *  @param[in]  cli Client model to send on.
+ *  @param[in]  ctx Message context, or NULL to use the configured publish
+ *                  parameters.
+ *  @param[in]  id  Light Lightness Control Server property to set.
+ *  @param[in]  val New property value.
+ *  @param[out] rsp Property value response buffer, or NULL to keep from
+ *                  blocking.
+ *
+ *  @retval 0              Successfully sent the message and populated the @c
+ *                         rsp buffer.
+ *  @retval -EALREADY      A blocking request is already in progress.
+ *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ *                         not configured.
+ *  @retval -EAGAIN        The device has not been provisioned.
+ *  @retval -ETIMEDOUT     The request timed out without a response.
+ */
+int bt_mesh_light_ctrl_cli_prop_set(struct bt_mesh_light_ctrl_cli *cli,
+				    struct bt_mesh_msg_ctx *ctx,
+				    enum bt_mesh_light_ctrl_prop id,
+				    const struct bt_mesh_sensor_value *val,
+				    struct bt_mesh_sensor_value *rsp);
+
+/** @brief Set a Light Lightness Control Server property value without
+ *         requesting a response.
+ *
+ *  Properties are the configuration parameters for the Light Lightness Control
+ *  Server. Each property value is represented as a single sensor channel.
+ *
+ *  @param[in]  cli Client model to send on.
+ *  @param[in]  ctx Message context, or NULL to use the configured publish
+ *                  parameters.
+ *  @param[in]  id  Light Lightness Control Server property to set.
+ *  @param[in]  val New property value.
+ *
+ *  @retval 0              Successfully sent the message.
+ *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ *                         not configured.
+ *  @retval -EAGAIN        The device has not been provisioned.
+ */
+int bt_mesh_light_ctrl_cli_prop_set_unack(
+	struct bt_mesh_light_ctrl_cli *cli,
+	struct bt_mesh_msg_ctx *ctx,
+	enum bt_mesh_light_ctrl_prop id,
+	const struct bt_mesh_sensor_value *val);
+#else
 /** @brief Get a Light Lightness Control Server property value.
  *
  *  Properties are the configuration parameters for the Light Lightness Control
@@ -460,6 +562,7 @@ int bt_mesh_light_ctrl_cli_prop_set_unack(struct bt_mesh_light_ctrl_cli *cli,
 					  struct bt_mesh_msg_ctx *ctx,
 					  enum bt_mesh_light_ctrl_prop id,
 					  const struct sensor_value *val);
+#endif
 
 /** @brief Get a Light Lightness Control Server Regulator Coefficient value.
  *

--- a/include/bluetooth/mesh/light_ctrl_srv.h
+++ b/include/bluetooth/mesh/light_ctrl_srv.h
@@ -136,9 +136,14 @@ struct bt_mesh_light_ctrl_srv_cfg {
 	/** State-wise light levels. */
 	uint16_t light[LIGHT_CTRL_STATE_COUNT];
 #if CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG
+#ifdef CONFIG_BT_MESH_SENSOR_USE_LEGACY_SENSOR_VALUE
 	/** Target illuminance values. */
 	struct sensor_value lux[LIGHT_CTRL_STATE_COUNT];
-#endif
+#else
+	/** Target illuminance values, in centilux */
+	uint32_t centilux[LIGHT_CTRL_STATE_COUNT];
+#endif /* CONFIG_BT_MESH_SENSOR_USE_LEGACY_SENSOR_VALUE */
+#endif /* CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG */
 };
 
 /** @brief Light Lightness Control Server instance.
@@ -154,8 +159,13 @@ struct bt_mesh_light_ctrl_srv {
 	struct {
 		/** Initial light level */
 		uint16_t initial_light;
+#ifdef CONFIG_BT_MESH_SENSOR_USE_LEGACY_SENSOR_VALUE
 		/** Initial illumination level */
 		struct sensor_value initial_lux;
+#else
+		/** Initial illumination level, in centilux */
+		uint32_t initial_centilux;
+#endif
 		/** Fade duration */
 		uint32_t duration;
 	} fade;

--- a/subsys/bluetooth/mesh/light_ctrl_cli.c
+++ b/subsys/bluetooth/mesh/light_ctrl_cli.c
@@ -7,9 +7,10 @@
 #include <bluetooth/mesh/light_ctrl_cli.h>
 #include "model_utils.h"
 #include "light_ctrl_internal.h"
+#include "sensor.h"
 
 union prop_value {
-	struct sensor_value prop;
+	sensor_value_type prop;
 	float coeff;
 };
 struct prop_status_ctx {
@@ -365,7 +366,11 @@ int bt_mesh_light_ctrl_cli_light_onoff_set_unack(
 int bt_mesh_light_ctrl_cli_prop_get(struct bt_mesh_light_ctrl_cli *cli,
 				    struct bt_mesh_msg_ctx *ctx,
 				    enum bt_mesh_light_ctrl_prop id,
+#ifdef CONFIG_BT_MESH_SENSOR_USE_LEGACY_SENSOR_VALUE
 				    struct sensor_value *rsp)
+#else
+				    struct bt_mesh_sensor_value *rsp)
+#endif
 {
 	struct prop_status_ctx ack = {
 		.id = id,
@@ -398,8 +403,14 @@ int bt_mesh_light_ctrl_cli_prop_get(struct bt_mesh_light_ctrl_cli *cli,
 int bt_mesh_light_ctrl_cli_prop_set(struct bt_mesh_light_ctrl_cli *cli,
 				    struct bt_mesh_msg_ctx *ctx,
 				    enum bt_mesh_light_ctrl_prop id,
+#ifdef CONFIG_BT_MESH_SENSOR_USE_LEGACY_SENSOR_VALUE
 				    const struct sensor_value *val,
 				    struct sensor_value *rsp)
+#else
+				    const struct bt_mesh_sensor_value *val,
+				    struct bt_mesh_sensor_value *rsp)
+
+#endif
 {
 	const struct bt_mesh_sensor_format *format;
 	struct prop_status_ctx ack = {
@@ -445,7 +456,11 @@ int bt_mesh_light_ctrl_cli_prop_set(struct bt_mesh_light_ctrl_cli *cli,
 int bt_mesh_light_ctrl_cli_prop_set_unack(struct bt_mesh_light_ctrl_cli *cli,
 					  struct bt_mesh_msg_ctx *ctx,
 					  enum bt_mesh_light_ctrl_prop id,
+#ifdef CONFIG_BT_MESH_SENSOR_USE_LEGACY_SENSOR_VALUE
 					  const struct sensor_value *val)
+#else
+					  const struct bt_mesh_sensor_value *val)
+#endif
 {
 	const struct bt_mesh_sensor_format *format;
 	int err;

--- a/subsys/bluetooth/mesh/light_ctrl_internal.h
+++ b/subsys/bluetooth/mesh/light_ctrl_internal.h
@@ -48,6 +48,7 @@ prop_format_get(enum bt_mesh_light_ctrl_prop id)
 	}
 }
 
+#ifdef CONFIG_BT_MESH_SENSOR_USE_LEGACY_SENSOR_VALUE
 static inline int prop_encode(struct net_buf_simple *buf,
 			      enum bt_mesh_light_ctrl_prop id,
 			      const struct sensor_value *val)
@@ -75,6 +76,7 @@ static inline int prop_decode(struct net_buf_simple *buf,
 
 	return sensor_ch_decode(buf, format, val);
 }
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This adds support for running the light_ctrl model when the new Sensor
API is enabled.

Some API signatures in the light_ctrl_cli have been changed to use the
new bt_mesh_sensor_value when the new API is enabled.

Signed-off-by: Ludvig Jordet <ludvig.jordet@nordicsemi.no>