### PR TITLE
manifest: sdk-zephyr: Pull fixes for Wi-Fi shell string args

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: f6e704ceefa7330d061eb9a5579e670d26524708
+      revision: pull/1434/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Fixes case sensitivity in processing string args.

Fixes SHEL-2360.