### PR TITLE
net: lwm2m_client_utils: Use DTLS_CID_SUPPORTED

### DIFF
--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_security.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_security.c
@@ -705,7 +705,7 @@ static int set_socketoptions(struct lwm2m_ctx *ctx)
 
 	if (IS_ENABLED(CONFIG_LWM2M_CLIENT_UTILS_DTLS_CID)) {
 		/* Enable CID */
-		uint32_t dtls_cid = NRF_SO_SEC_DTLS_CID_ENABLED;
+		uint32_t dtls_cid = NRF_SO_SEC_DTLS_CID_SUPPORTED;
 
 		ret = zsock_setsockopt(ctx->sock_fd, SOL_TLS, TLS_DTLS_CID, &dtls_cid,
 				       sizeof(dtls_cid));


### PR DESCRIPTION
Use SUPPORTED instead of ENABLED for the Connection Identifier settings.

This causes modem to send zero length CID to server, indicating that we support CID but don't require one for the reponse packets.
If server supports CID, it will generate one for us that we use for uplink packets.

There is really no benefit for using CID on both
direction. Using it uplink direction is enough.