### PR TITLE
manifest: update zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 883c3709f9c8fd845a8dfa39d2583d5c665a915b
+      revision: 1da00e0c84f7da2f4017f4efde99e479d40e5e6e
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
pull fix for ACK header IE config

skip checks in ACK header IE config if `EnableCsl()` has been called with arguments:

- `aCslPeriod` == 0
- `aShortAddr` == IEEE802154_NO_SHORT_ADDRESS_ASSIGNED
- `aExtAddr` == NULL

This happens during RCP startup in `Radio::Init()` implementation. It will be fixed on OT level, but this commit is needed to prevent coprocessor samples from asserting on boot.