### PR TITLE
manifest: sdk-zephyr: Fix the max channels in scan

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 5d7a30bb2fa0bc6130e0e054821a0daa7043a736
+      revision: 9c754a80d072e415d54fc6dd45235359b016433b
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Fix the maximum channels allow for scan command
input. Also, example in scan arguments.