### PR TITLE
tests: Update quarantine for build with no optimization

### DIFF
--- a/scripts/quarantine_no_optimization.yaml
+++ b/scripts/quarantine_no_optimization.yaml
@@ -5,4 +5,4 @@
 # - scenarios:
 #     - None
 - scenarios:
-    - None
+    - unity.nrf91_sockets_test


### PR DESCRIPTION
Due to a failure of unity.nrf91_sockets_test test