### PR TITLE
samples: net: add graceful bring down of network interfaces

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -449,6 +449,10 @@ Networking samples
 
   * Updated the sample to gracefully bring down the network interfaces.
 
+* :ref:`download_sample` sample:
+
+  * Updated the sample to gracefully bring down the network interfaces.
+
 NFC samples
 -----------
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -445,6 +445,10 @@ Networking samples
       The documentation is now found in the :ref:`networking_samples` section.
     * The sample to use the :ref:`coap_client_interface` library.
 
+* :ref:`https_client` sample:
+
+  * Updated the sample to gracefully bring down the network interfaces.
+
 NFC samples
 -----------
 

--- a/samples/net/download/src/main.c
+++ b/samples/net/download/src/main.c
@@ -221,6 +221,7 @@ static int callback(const struct download_client_evt *event)
 #endif /* CONFIG_SAMPLE_COMPUTE_HASH */
 
 		(void)conn_mgr_if_disconnect(net_if);
+		(void)conn_mgr_all_if_down(true);
 		printk("Bye\n");
 		return 0;
 
@@ -230,6 +231,7 @@ static int callback(const struct download_client_evt *event)
 			/* With ECONNRESET, allow library to attempt a reconnect by returning 0 */
 		} else {
 			(void)conn_mgr_if_disconnect(net_if);
+			(void)conn_mgr_all_if_down(true);
 			/* Stop download */
 			return -1;
 		}

--- a/samples/net/https_client/src/main.c
+++ b/samples/net/https_client/src/main.c
@@ -337,5 +337,10 @@ int main(void)
 		printk("conn_mgr_all_if_disconnect, error: %d\n", err);
 	}
 
+	err = conn_mgr_all_if_down(true);
+	if (err) {
+		printk("conn_mgr_all_if_down, error: %d\n", err);
+	}
+
 	return 0;
 }


### PR DESCRIPTION
For some devices, like the nrf91 series, it's important to gracefully bring down the network interface post-sample execution. This is fundamental for CI where many samples are executed and a lack of graceful bring down may lead to [reset loop restriction](https://infocenter.nordicsemi.com/index.jsp?topic=%2Fnwp_042%2FWP%2Fnwp_042%2Fintro.html) being triggered.