### PR TITLE
doc: Minor fixes to app, sample, and lib

### DIFF
--- a/applications/asset_tracker_v2/doc/asset_tracker_v2_description.rst
+++ b/applications/asset_tracker_v2/doc/asset_tracker_v2_description.rst
@@ -105,8 +105,10 @@ The application provides predefined configuration files for typical use cases.
 Following are the available configuration files:
 
 * :file:`prj.conf` - Configuration file for all build targets.
-* :file:`boards/<BOARD>.conf` - Configuration overlay file specific for <BOARD>.
+* :file:`boards/<BOARD>.conf` - Configuration file specific for a build target specified with **<BOARD>**, where **<BOARD>** is the build target, for example ``nrf9161dk_nrf9161_ns``.
   This file is automatically merged with the :file:`prj.conf` file when you build for that target.
+
+The :file:`include/<BOARD>/led_state_def.h` header file describes the LED behavior of the CAF LEDs module.
 
 Overlay configurations files that enable specific features:
 
@@ -126,8 +128,6 @@ Custom DTC overlay file for enabling a specific feature:
 * :file:`nrf91xxdk_with_nrf7002ek` - Configuration file that enables Wi-Fi scanning with nRF7002 EK.
 
 Multiple overlay files can be included to enable multiple features at the same time.
-
-Header file that describes the LED behavior of the CAF LEDs module: file:`include/<BOARD>/led_state_def.h`.
 
 .. note::
 

--- a/doc/nrf/device_guides/working_with_nrf/nrf91/nrf9161.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf91/nrf9161.rst
@@ -23,7 +23,7 @@ The nRF9161 DK contains an nRF5340 Interface MCU (IMCU), which acts both as an o
 The board controller controls signal switches on the nRF9161 DK and can be used to route the nRF9161 SiP pins to different components on the DK, such as pin headers, external memory, a SIM card or eSIM.
 For a complete list of configuration options available, see the nRF9161 DK board control section in the nRF9161 DK User Guide.
 
-The nRF5340 IMCU comes preprogrammed with J-Link Segger OB and board controller firmware.
+The nRF5340 IMCU comes preprogrammed with J-Link SEGGER OB and board controller firmware.
 
 .. _nrf9161_ug_updating_cloud_certificate:
 

--- a/doc/nrf/libraries/modem/nrf_modem_lib/nrf_modem_lib_trace.rst
+++ b/doc/nrf/libraries/modem/nrf_modem_lib/nrf_modem_lib_trace.rst
@@ -173,7 +173,7 @@ To enable modem traces with RTT, enable the :kconfig:option:`CONFIG_NRF_MODEM_LI
 
 The traces can be captured using the J-Link RTT logger software.
 This produces a RAW binary trace file with a ``.log`` extension.
-The RAW binary trace file can be converted to PCAP with the :guilabel:`Convert RAW trace to PCAP` option in the Trace Collector application of `nRF Connect for Desktop`_.
+The RAW binary trace file can be converted to PCAP with the :guilabel:`Open trace file in Wireshark` option in the `Cellular Monitor`_ app of `nRF Connect for Desktop`_.
 By default, files with the ``.log`` extension are not shown.
 
 .. _adding_custom_modem_trace_backends:

--- a/samples/cellular/modem_trace_flash/README.rst
+++ b/samples/cellular/modem_trace_flash/README.rst
@@ -86,7 +86,6 @@ After programming the sample and board controller firmware (as mentioned in Requ
 #. Open the `Cellular Monitor`_ desktop application and connect the DK.
 #. Select :guilabel:`Autoselect` from the **Modem trace database** drop-down menu, or a modem firmware version that is programmed on the DK.
 #. Select :guilabel:`Reset device on start`.
-#. Deselect :guilabel:`Refresh dashboard on start`.
 #. Make sure that either :guilabel:`Open in Wireshark` or :guilabel:`Save trace file to disk` is selected.
 #. Click :guilabel:`Open Serial Terminal` and keep the terminal window open (optional).
 #. Click :guilabel:`Start` to begin the modem trace.


### PR DESCRIPTION
Minor fixes to the following:

* Asset tracker - formating update after upmerge
* Modem_trace_flash - Removed a step from testing as the action is automatically done when Wireshark window is open
* developing with guide - minor fix
* Modem lib - Update for modem trace