### PR TITLE
drivers: wifi: Fix QSPI initialiation

### DIFF
--- a/drivers/wifi/nrf700x/src/qspi/inc/rpu_hw_if.h
+++ b/drivers/wifi/nrf700x/src/qspi/inc/rpu_hw_if.h
@@ -49,6 +49,7 @@ int rpu_rdsr2(void);
 int rpu_rdsr1(void);
 int rpu_clks_on(void);
 
+int rpu_init(void);
 int rpu_enable(void);
 int rpu_disable(void);
 

--- a/drivers/wifi/nrf700x/src/qspi/src/rpu_hw_if.c
+++ b/drivers/wifi/nrf700x/src/qspi/src/rpu_hw_if.c
@@ -468,7 +468,7 @@ int rpu_clks_on(void)
 		} \
 	} while (0)
 
-int rpu_enable(void)
+int rpu_init(void)
 {
 	int ret;
 
@@ -487,6 +487,20 @@ int rpu_enable(void)
 		goto ble_gpio_remove;
 	}
 
+	return 0;
+
+ble_gpio_remove:
+	ble_gpio_remove();
+rpu_gpio_remove:
+	rpu_gpio_remove();
+out:
+	return ret;
+}
+
+int rpu_enable(void)
+{
+	int ret;
+
 	ret = rpu_wakeup();
 	if (ret) {
 		goto rpu_pwroff;
@@ -498,14 +512,8 @@ int rpu_enable(void)
 	}
 
 	return 0;
-
 rpu_pwroff:
 	rpu_pwroff();
-ble_gpio_remove:
-	ble_gpio_remove();
-rpu_gpio_remove:
-	rpu_gpio_remove();
-out:
 	return ret;
 }
 

--- a/drivers/wifi/nrf700x/src/shim.c
+++ b/drivers/wifi/nrf700x/src/shim.c
@@ -578,6 +578,12 @@ static void *zep_shim_bus_qspi_dev_add(void *os_qspi_priv, void *osal_qspi_dev_c
 	int ret;
 	enum nrf_wifi_status status;
 
+	ret = rpu_init();
+	if (ret) {
+		LOG_ERR("%s: RPU init failed with error %d", __func__, ret);
+		return NULL;
+	}
+
 	status = qdev->init(qspi_defconfig());
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		LOG_ERR("%s: QSPI device init failed", __func__);


### PR DESCRIPTION
QSPI initialization reads QSPI slave registers, and if RPU isn't powered on this causes undefined behaviour (works on DK, but doesn't work on customer board with different QSPI).

Fix this by dividing the RPU configuration into init and enable, init doesn't use QSPI, and both QSPI init and RPU enable use QSPI.

Fixes SHEL-2375.