### PR TITLE
manifest: Pulled fix for the Matter over Wi-Fi mdns prefixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -151,7 +151,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: e13071ab2d07bbbe1718181fa82197f6b27744a3
+      revision: e54423d63ed09b9a03e68c75cebf6dab7a676d00
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
Pulled a fix from Matter that solves problem with update of mDNS records after new IPv6 prefix assignment.