### PR TITLE
doc: nrf: handle script name change

### DIFF
--- a/doc/nrf/external_comp/nrf_cloud.rst
+++ b/doc/nrf/external_comp/nrf_cloud.rst
@@ -119,7 +119,7 @@ A device can successfully connect to `nRF Cloud`_ using MQTT if the following re
      * It creates a device certificate and signs it with the specified CA.
      * It writes the device certificate and AWS CA certificate to the device.
 
-  #. Run the `nrf_cloud_provision.py`_ script to provision and associate the device with your nRF Cloud account.
+  #. Run the `nrf_cloud_onboard.py`_ script to onboard the device to your nRF Cloud account.
 
   For more details about the scripts, refer to the `nRF Cloud Utilities documentation`_.
 

--- a/doc/nrf/libraries/networking/nrf_cloud_coap.rst
+++ b/doc/nrf/libraries/networking/nrf_cloud_coap.rst
@@ -52,7 +52,7 @@ Requirements
 
 You must first preprovision the device on nRF Cloud as follows:
 
-1. Use the `device_credentials_installer.py`_ and `nrf_cloud_provision.py`_ scripts.
+1. Use the `device_credentials_installer.py`_ and `nrf_cloud_onboard.py`_ scripts.
 #. Specify the ``--coap`` option to ``device_credentials_installer.py`` to have the proper root CA certificates installed in the device.
 
 Call the :c:func:`nrf_cloud_coap_init` function once to initialize the library.

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -143,7 +143,7 @@
 
 .. _`nRF Cloud JSON protocol schemas`: https://github.com/nRFCloud/application-protocols
 .. _`device_credentials_installer.py`: https://github.com/nRFCloud/utils/blob/master/python/modem-firmware-1.3%2B/device_credentials_installer.py
-.. _`nrf_cloud_provision.py`: https://github.com/nRFCloud/utils/blob/master/python/modem-firmware-1.3%2B/README.md#nrf-cloud-device-provisioning
+.. _`nrf_cloud_onboard.py`: https://github.com/nRFCloud/utils/blob/master/python/modem-firmware-1.3%2B/README.md#nrf-cloud-device-onboarding
 .. _`nRF Cloud Utilities Create CA Cert`: https://github.com/nRFCloud/utils/blob/master/python/modem-firmware-1.3%2B/README.md#create-ca-cert
 .. _`nRF Cloud Utilities Create Device Credentials`: https://github.com/nRFCloud/utils/blob/master/python/modem-firmware-1.3%2B/README.md#create-device-credentials
 .. _`nRF Cloud Utilities Prerequisites`: https://github.com/nRFCloud/utils/blob/master/python/modem-firmware-1.3%2B/README.md#prerequisites


### PR DESCRIPTION
The nrf_cloud_provision.py script has been renamed to nrf_cloud_onboard.py.
IRIS-7817