### PR TITLE
manifest: Updated Matter repository revision to pull v2.5.2 fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -149,7 +149,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: v2.5.1
+      revision: c32a583d5fdf1916f64e5fa36ed0b28575b4a69e
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
Updated Matter fork version to pull fixes for the DNS and memory leaks required for the v2.5.2.