### PR TITLE
manifest: update zephyr nrf5340_cpunet easydma-maxcnt-bits

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 9aa5cc1391f01d02c72e2d44cc636e5edd7899d6
+      revision: f6e704ceefa7330d061eb9a5579e670d26524708
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
The required property easydma-maxcnt-bits was missing for nrf5340_cpunet. This commit brings in zephyr with the fix.