### PR TITLE
Download client IPv6 to IPv4 fallback improvements

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -708,6 +708,12 @@ Libraries for networking
   * Updated the library to use the :ref:`lib_mqtt_helper` library.
     This simplifies the handling of the MQTT stack.
 
+* :ref:`lib_download_client` library:
+
+  * Changed:
+
+    * IPv6 to IPv4 fallback is done when both DNS request and TCP/TLS connect fails.
+
 * :ref:`lib_nrf_cloud_coap` library:
 
   * Added:

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -710,9 +710,19 @@ Libraries for networking
 
 * :ref:`lib_download_client` library:
 
+  * Added:
+
+    * The ``family`` parameter to the :c:struct:`download_client_cfg` structure.
+      This is used to optimize the download sequence when the device only support IPv4 or IPv6.
+
   * Changed:
 
+    * IPv6 support changed from compile time to runtime, and is default enabled.
     * IPv6 to IPv4 fallback is done when both DNS request and TCP/TLS connect fails.
+
+  * Removed:
+
+    * The :kconfig:option:`CONFIG_DOWNLOAD_CLIENT_IPV6` Kconfig option is removed.
 
 * :ref:`lib_nrf_cloud_coap` library:
 

--- a/include/net/download_client.h
+++ b/include/net/download_client.h
@@ -114,6 +114,11 @@ struct download_client_cfg {
 	 * Zero is the default PDN.
 	 */
 	uint8_t pdn_id;
+	/**
+	 * Address family to be used for the download, AF_INET6 or AF_INET.
+	 * Set to AF_UNSPEC (0) to fallback to AF_INET if AF_INET6 does not work.
+	 */
+	int family;
 	/** Maximum fragment size to download. 0 indicates that values
 	 * configured using Kconfig shall be used.
 	 */

--- a/subsys/net/lib/download_client/Kconfig
+++ b/subsys/net/lib/download_client/Kconfig
@@ -135,12 +135,6 @@ config DOWNLOAD_CLIENT_RANGE_REQUESTS
 	  but also gives time to the application to process the fragments as they are
 	  downloaded, instead of having to keep up to speed while downloading the whole file.
 
-config DOWNLOAD_CLIENT_IPV6
-	bool "Use IPv6 when possible"
-	help
-	  Prefer IPv6 protocol but fallback to
-	  IPv4 when the hostname can't be resolved.
-
 config DOWNLOAD_CLIENT_CID
 	bool "Use DTLS Connection-ID"
 	help

--- a/subsys/net/lib/download_client/src/download_client.c
+++ b/subsys/net/lib/download_client/src/download_client.c
@@ -429,15 +429,15 @@ static int client_connect(struct download_client *dl)
 		type |= SOCK_NATIVE_TLS;
 	}
 
-	/* Attempt IPv6 connection if configured, fallback to IPv4 */
-	if (IS_ENABLED(CONFIG_DOWNLOAD_CLIENT_IPV6)) {
+	/* Attempt IPv6 connection if configured, fallback to IPv4 on error */
+	if ((dl->config.family == AF_UNSPEC) || (dl->config.family == AF_INET6)) {
 		err = host_lookup(dl->host, AF_INET6, dl->config.pdn_id, &dl->remote_addr);
 		if (!err) {
 			err = client_socket_connect(dl, type, port);
 		}
 	}
 
-	if (err || !IS_ENABLED(CONFIG_DOWNLOAD_CLIENT_IPV6)) {
+	if (((dl->config.family == AF_UNSPEC) && err) || (dl->config.family == AF_INET)) {
 		err = host_lookup(dl->host, AF_INET, dl->config.pdn_id, &dl->remote_addr);
 		if (!err) {
 			err = client_socket_connect(dl, type, port);

--- a/subsys/net/lib/download_client/src/download_client.c
+++ b/subsys/net/lib/download_client/src/download_client.c
@@ -14,6 +14,7 @@
 #include <zephyr/posix/netdb.h>
 #include <zephyr/posix/sys/time.h>
 #include <zephyr/posix/sys/socket.h>
+#include <arpa/inet.h>
 #else
 #include <zephyr/net/socket.h>
 #endif
@@ -339,7 +340,18 @@ static int client_socket_connect(struct download_client *dl, int type, uint16_t 
 		}
 	}
 
-	LOG_INF("Connecting to %s", dl->host);
+	if (IS_ENABLED(CONFIG_LOG)) {
+		char ip_addr_str[NET_IPV6_ADDR_LEN];
+		void *sin_addr;
+
+		if (dl->remote_addr.sa_family == AF_INET6) {
+			sin_addr = &((struct sockaddr_in6 *)&dl->remote_addr)->sin6_addr;
+		} else {
+			sin_addr = &((struct sockaddr_in *)&dl->remote_addr)->sin_addr;
+		}
+		inet_ntop(dl->remote_addr.sa_family, sin_addr, ip_addr_str, sizeof(ip_addr_str));
+		LOG_INF("Connecting to %s", ip_addr_str);
+	}
 	LOG_DBG("fd %d, addrlen %d, fam %s, port %d",
 		dl->fd, addrlen, str_family(dl->remote_addr.sa_family), port);
 


### PR DESCRIPTION
Change the IPv6 to IPv4 fallback to also try to connect before doing the fallback. This will fix two known issues:
  1. A DNS request for an IPv6 address may be successful even if the device does not have an IPv6 address.
  2. The host is not reachable using IPv6 because of a network routing issue.

Change IPv6 support from compile time to runtime.
  * Default attempt IPv6 connection first and fallback to IPv4 if DNS lookup or connect fails.
  * Add configuration to struct download_client_cfg for the device to optimize the download sequence when it only support IPv4 or IPv6.
  * Remove CONFIG_DOWNLOAD_CLIENT_IPV6.

Change the "Connecting to" log from repeating the full URL to show the resolved IP address. This will also show IP version used.