### PR TITLE
applications: Fixed pincode command for the Matter bridge

### DIFF
--- a/applications/matter_bridge/src/bridge_shell.cpp
+++ b/applications/matter_bridge/src/bridge_shell.cpp
@@ -199,7 +199,7 @@ static void BluetoothScanResult(Nrf::BLEConnectivityManager::ScannedDevice *devi
 static int InsertBridgedDevicePincodeHandler(const struct shell *shell, size_t argc, char **argv)
 {
 	int bleDeviceIndex = strtoul(argv[0], NULL, 0);
-	unsigned int pincode = strtoul(argv[1], NULL, 0);
+	unsigned int pincode = strtoul(argv[1], NULL, 10);
 
 	bt_addr_le_t address;
 	if (Nrf::BLEConnectivityManager::Instance().GetScannedDeviceAddress(&address, bleDeviceIndex) != CHIP_NO_ERROR) {


### PR DESCRIPTION
Fixed the string to int conversion for the Matter bridge pincode command. Before it was not able to correctly convert pincodes with leading 0 characters.