### PR TITLE
doc: Add board configurator info in the nRF9161 guide

### DIFF
--- a/doc/nrf/device_guides/working_with_nrf/nrf91/nrf9161.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf91/nrf9161.rst
@@ -24,6 +24,8 @@ The board controller controls signal switches on the nRF9161 DK and can be used 
 For a complete list of configuration options available, see the nRF9161 DK board control section in the nRF9161 DK User Guide.
 
 The nRF5340 IMCU comes preprogrammed with J-Link SEGGER OB and board controller firmware.
+If you want to change the default configuration of the DK, you can use the Board Configurator app in `nRF Connect for Desktop`_ .
+See the `nRF Connect Board Configurator`_ documentation for instructions on how to change the configuration of the DK.
 
 .. _nrf9161_ug_updating_cloud_certificate:
 

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -1372,3 +1372,5 @@
 .. _`Setting up the SDK for Amazon Sidewalk`: https://nrfconnect.github.io/sdk-sidewalk/setting_up_sidewalk_environment/setting_up_sdk.html
 
 .. _`Community Best Practice for Copyright Notice`: https://www.linuxfoundation.org/blog/copyright-notices-in-open-source-software-projects/
+
+.. _`nRF Connect Board Configurator`: https://docs.nordicsemi.com/bundle/nrf-connect-board-configurator/page/index.html


### PR DESCRIPTION
Add content and links of Board Configurator
in the developing with guide for nRF9161.
NCSDK-25358