### PR TITLE
net: lib: nrf_cloud: rename nct_ to nrfcloud_transport_

### DIFF
--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_transport.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_transport.h
@@ -67,7 +67,7 @@ struct nct_evt {
 int nct_socket_get(void);
 
 /** @brief Initialization routine for the transport. */
-int nct_init(const char * const client_id);
+int nct_initialize(const char * const client_id);
 
 /** @brief Unintialize the transport; reset state and free allocated memory */
 void nct_uninit(void);

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
@@ -129,7 +129,7 @@ int nrf_cloud_init(const struct nrf_cloud_init_param *param)
 #endif
 
 	/* Initialize the transport. */
-	err = nct_init(param->client_id);
+	err = nct_initialize(param->client_id);
 	if (err) {
 		return err;
 	}

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -1031,7 +1031,7 @@ static void nct_mqtt_evt_handler(struct mqtt_client *const mqtt_client,
 	}
 }
 
-int nct_init(const char * const client_id)
+int nct_initialize(const char * const client_id)
 {
 	int err;
 

--- a/tests/subsys/net/lib/nrf_cloud/cloud/src/fakes.h
+++ b/tests/subsys/net/lib/nrf_cloud/cloud/src/fakes.h
@@ -17,7 +17,7 @@ DEFINE_FFF_GLOBALS;
 int poll(struct zsock_pollfd *fds, int nfds, int timeout);
 
 /* Fake functions declaration */
-FAKE_VALUE_FUNC(int, nct_init, const char *);
+FAKE_VALUE_FUNC(int, nct_initialize, const char *);
 FAKE_VALUE_FUNC(int, nfsm_init);
 FAKE_VALUE_FUNC(int, nrf_cloud_codec_init, struct nrf_cloud_os_mem_hooks *);
 FAKE_VOID_FUNC(nrf_cloud_set_app_version, const char *const);
@@ -47,13 +47,13 @@ FAKE_VALUE_FUNC(int, nrf_cloud_obj_cloud_encode, struct nrf_cloud_obj *const);
 FAKE_VALUE_FUNC(int, nrf_cloud_obj_cloud_encoded_free, struct nrf_cloud_obj *const);
 
 /* Custom fakes implementation */
-int fake_nct_init__succeeds(const char *const client_id)
+int fake_nct_initialize__succeeds(const char *const client_id)
 {
 	ARG_UNUSED(client_id);
 	return 0;
 }
 
-int fake_nct_init__fails(const char *const client_id)
+int fake_nct_initialize__fails(const char *const client_id)
 {
 	ARG_UNUSED(client_id);
 	return -ENODEV;

--- a/tests/subsys/net/lib/nrf_cloud/cloud/src/main.c
+++ b/tests/subsys/net/lib/nrf_cloud/cloud/src/main.c
@@ -106,7 +106,7 @@ const struct nrf_cloud_sensor_data sensor_param = {
 void init_cloud_success(void)
 {
 	/* Init the cloud with all fakes */
-	nct_init_fake.custom_fake = fake_nct_init__succeeds;
+	nct_initialize_fake.custom_fake = fake_nct_initialize__succeeds;
 	nfsm_init_fake.custom_fake = fake_nfsm_init__succeeds;
 	nrf_cloud_codec_init_fake.custom_fake = fake_nrf_cloud_codec_init__succeeds;
 	(void)nrf_cloud_init(&init_param);
@@ -193,7 +193,7 @@ void connect_cloud_dc_success(void)
 static void run_before(void *fixture)
 {
 	ARG_UNUSED(fixture);
-	RESET_FAKE(nct_init);
+	RESET_FAKE(nct_initialize);
 	RESET_FAKE(nfsm_init);
 	RESET_FAKE(nrf_cloud_codec_init);
 	RESET_FAKE(nrf_cloud_fota_fmfu_dev_set);
@@ -252,7 +252,7 @@ ZTEST(nrf_cloud_test, test_init_not_idle)
 	 * being successful and check if the second one
 	 * will fail since the state will not be idle
 	 */
-	nct_init_fake.custom_fake = fake_nct_init__succeeds;
+	nct_initialize_fake.custom_fake = fake_nct_initialize__succeeds;
 	nfsm_init_fake.custom_fake = fake_nfsm_init__succeeds;
 	nrf_cloud_codec_init_fake.custom_fake = fake_nrf_cloud_codec_init__succeeds;
 	(void)nrf_cloud_init(&init_param);
@@ -311,7 +311,7 @@ ZTEST(nrf_cloud_test, test_init_success)
 		"nrf_cloud lib should be in the idle state (uninitialized) at the start of test");
 
 	/* Fake internal initialization success */
-	nct_init_fake.custom_fake = fake_nct_init__succeeds;
+	nct_initialize_fake.custom_fake = fake_nct_initialize__succeeds;
 	nfsm_init_fake.custom_fake = fake_nfsm_init__succeeds;
 	nrf_cloud_codec_init_fake.custom_fake = fake_nrf_cloud_codec_init__succeeds;
 
@@ -328,7 +328,7 @@ ZTEST(nrf_cloud_test, test_init_success)
 ZTEST(nrf_cloud_test, test_init_cloud_transport_fail)
 {
 	/* Fake transport initialization failure */
-	nct_init_fake.custom_fake = fake_nct_init__fails;
+	nct_initialize_fake.custom_fake = fake_nct_initialize__fails;
 
 	/* Fake success for the rest of initialization */
 	nfsm_init_fake.custom_fake = fake_nfsm_init__succeeds;
@@ -367,7 +367,7 @@ ZTEST(nrf_cloud_test, test_init_fmfu_init_failed)
 	nrf_cloud_fota_fmfu_dev_set_fake.custom_fake = fake_nrf_cloud_fota_fmfu_dev_set__fails;
 
 	/* Fake success for the rest of initialization */
-	nct_init_fake.custom_fake = fake_nct_init__succeeds;
+	nct_initialize_fake.custom_fake = fake_nct_initialize__succeeds;
 	nfsm_init_fake.custom_fake = fake_nfsm_init__succeeds;
 	nrf_cloud_codec_init_fake.custom_fake = fake_nrf_cloud_codec_init__succeeds;
 


### PR DESCRIPTION
Reason is conflicting naming with zephyr native simulator nct_if.h