### PR TITLE
applications: nrf5340_audio: Fix bonding test with SDC

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/Kconfig
+++ b/applications/nrf5340_audio/src/bluetooth/Kconfig
@@ -71,4 +71,18 @@ module-str = ble
 source "subsys/logging/Kconfig.template.log_config"
 
 endmenu # Log levels
+
+#----------------------------------------------------------------------------#
+menu "Testing"
+
+config TESTING_BLE_ADDRESS_RANDOM
+	bool "Random address and bonding clear on every restart [EXPERIMENTAL]"
+	default n
+	select EXPERIMENTAL
+	help
+	  If enabled the system will generate a new address on every
+	  restart (i.e. reset, re-flash). Any bonding information will
+	  be cleared. This is only for testing purposes.
+
+endmenu # Testing
 endmenu # Bluetooth


### PR DESCRIPTION
OCT-2846

For bonding testing, only the Bluetooth address must change after each re-flash of the tester device. This also requires the bonding information on the tester to be cleared. A new testing menu for the Bluetooth has been added with a config to select the additional testing code within bt_mgmt.c to perform the desired tester actions.