### PR TITLE
samples: cellular: modem_shell: location: Ext service cellular fix

### DIFF
--- a/samples/cellular/modem_shell/src/location/location_srv_ext_nrf_cloud.c
+++ b/samples/cellular/modem_shell/src/location/location_srv_ext_nrf_cloud.c
@@ -106,7 +106,7 @@ static int location_srv_ext_nrf_cloud_location_get(
 	int err;
 	nrf_cloud_location_response_t callback = NULL;
 	struct nrf_cloud_location_config conf = {
-		.do_reply = (callback != NULL),
+		.do_reply = false,
 		.fallback = true,
 		.hi_conf = false
 	};
@@ -115,6 +115,7 @@ static int location_srv_ext_nrf_cloud_location_get(
 
 	if (location) {
 		callback = location_srv_ext_nrf_cloud_location_ready_cb;
+		conf.do_reply = true;
 	}
 
 	mosh_print("Sending positioning request to cloud via MQTT");


### PR DESCRIPTION
PR #13417 introduced a bug where location is never requested back to the device with external nRF Cloud service config on MQTT.