### PR TITLE
applications: nrf5340_audio: Issues after upmerge

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/broadcast_source.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/broadcast_source.c
@@ -67,10 +67,6 @@ ZBUS_CHAN_DEFINE(le_audio_chan, struct le_audio_msg, NULL, NULL, ZBUS_OBSERVERS_
 #error Unsupported LC3 codec preset for broadcast
 #endif /* CONFIG_BT_AUDIO_BROADCAST_CONFIGURABLE */
 
-#define STANDARD_QUALITY_16KHZ 16000
-#define STANDARD_QUALITY_24KHZ 24000
-#define HIGH_QUALITY_48KHZ     48000
-
 static struct bt_cap_broadcast_source *broadcast_source;
 static struct bt_cap_stream cap_streams[CONFIG_BT_BAP_BROADCAST_SRC_STREAM_COUNT];
 static struct bt_bap_lc3_preset lc3_preset = BT_BAP_LC3_BROADCAST_PRESET_NRF5340_AUDIO;
@@ -182,9 +178,10 @@ static void public_broadcast_features_set(uint8_t *features)
 		*features |= 0x01;
 	}
 
-	if (freq == STANDARD_QUALITY_16KHZ || freq == STANDARD_QUALITY_24KHZ) {
+	if (freq == BT_AUDIO_CODEC_CONFIG_LC3_FREQ_16KHZ ||
+	    freq == BT_AUDIO_CODEC_CONFIG_LC3_FREQ_24KHZ) {
 		*features |= 0x02;
-	} else if (freq == HIGH_QUALITY_48KHZ) {
+	} else if (freq == BT_AUDIO_CODEC_CONFIG_LC3_FREQ_48KHZ) {
 		*features |= 0x04;
 	} else {
 		LOG_WRN("%dkHz is not compatible with Auracast, choose 16kHz, 24kHz or 48kHz",

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.c
@@ -34,3 +34,76 @@ bool le_audio_ep_state_check(struct bt_bap_ep *ep, enum bt_bap_ep_state state)
 
 	return false;
 }
+
+int le_audio_freq_hz_get(const struct bt_audio_codec_cfg *codec, int *freq_hz)
+{
+	int ret;
+
+	ret = bt_audio_codec_cfg_get_freq(codec);
+	if (ret < 0) {
+		*freq_hz = 0;
+		return ret;
+	}
+
+	ret = bt_audio_codec_cfg_freq_to_freq_hz(ret);
+	if (ret < 0) {
+		*freq_hz = 0;
+		return ret;
+	}
+
+	*freq_hz = ret;
+
+	return 0;
+}
+
+int le_audio_duration_us_get(const struct bt_audio_codec_cfg *codec, int *frame_dur_us)
+{
+	int ret;
+
+	ret = bt_audio_codec_cfg_get_frame_dur(codec);
+	if (ret < 0) {
+		*frame_dur_us = 0;
+		return ret;
+	}
+
+	ret = bt_audio_codec_cfg_frame_dur_to_frame_dur_us(ret);
+	if (ret < 0) {
+		*frame_dur_us = 0;
+		return ret;
+	}
+
+	*frame_dur_us = ret;
+
+	return 0;
+}
+
+int le_audio_octets_per_frame_get(const struct bt_audio_codec_cfg *codec, uint32_t *octets_per_sdu)
+{
+	int ret;
+
+	ret = bt_audio_codec_cfg_get_octets_per_frame(codec);
+	if (ret < 0) {
+		*octets_per_sdu = 0;
+		return ret;
+	}
+
+	*octets_per_sdu = ret;
+
+	return 0;
+}
+
+int le_audio_frame_blocks_per_sdu_get(const struct bt_audio_codec_cfg *codec,
+				      uint32_t *frame_blks_per_sdu)
+{
+	int ret;
+
+	ret = bt_audio_codec_cfg_get_frame_blocks_per_sdu(codec, true);
+	if (ret < 0) {
+		*frame_blks_per_sdu = 0;
+		return ret;
+	}
+
+	*frame_blks_per_sdu = ret;
+
+	return 0;
+}

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.h
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.h
@@ -63,12 +63,53 @@ struct le_audio_encoded_audio {
  *		If the endpoint is NULL, it is not in the
  *		given state, and this function returns false.
  *
- * @param[in]	ep	The endpoint to check.
- * @param[in]	state	The state to check for.
+ * @param[in]	ep       The endpoint to check.
+ * @param[in]	state    The state to check for.
  *
  * @retval	true	The endpoint is in the given state.
  * @retval	false	Otherwise.
  */
 bool le_audio_ep_state_check(struct bt_bap_ep *ep, enum bt_bap_ep_state state);
+
+/**
+ * @brief	Decode the audio sampling frequency in the codec configuration.
+ *
+ * @param[in]	codec		The audio codec structure.
+ * @param[out]	freq_hz		Pointer to the sampling frequency in Hz.
+ *
+ * @return	0 for success, error otherwise.
+ */
+int le_audio_freq_hz_get(const struct bt_audio_codec_cfg *codec, int *freq_hz);
+
+/**
+ * @brief	Decode the audio frame duration in us in the codec configuration.
+ *
+ * @param[in]	codec			The audio codec structure.
+ * @param[out]	frame_dur_us	Pointer to the frame duration in us.
+ *
+ * @return	0 for success, error otherwise.
+ */
+int le_audio_duration_us_get(const struct bt_audio_codec_cfg *codec, int *frame_dur_us);
+
+/**
+ * @brief	Decode the number of octets per frame in the codec configuration.
+ *
+ * @param[in]	codec			The audio codec structure.
+ * @param[out]	octets_per_sdu	Pointer to the number of octets per SDU.
+ *
+ * @return	0 for success, error otherwise.
+ */
+int le_audio_octets_per_frame_get(const struct bt_audio_codec_cfg *codec, uint32_t *octets_per_sdu);
+
+/**
+ * @brief	Decode the number of frame blocks per SDU in the codec configuration.
+ *
+ * @param[in]	codec				The audio codec structure.
+ * @param[out]	frame_blks_per_sdu	Pointer to the number of frame blocks per SDU.
+ *
+ * @return	0 for success, error otherwise.
+ */
+int le_audio_frame_blocks_per_sdu_get(const struct bt_audio_codec_cfg *codec,
+				      uint32_t *frame_blks_per_sdu);
 
 #endif /* _LE_AUDIO_H_ */


### PR DESCRIPTION
OCT-2852

After the upmerge, some of the prints where incorrect and there was a increase in the files built. 

The printing issue was due to the change in the return data from bt_audio_codec_cfg_get_freq() and bt_audio_codec_cfg_get_frame_dur(). These now return the frequency and duration as  enums IDs from bt_audio_codec_config_freq and bt_audio_codec_config_frame_dur respectively. Previously these functions returned the Hz and us values. Two new functions have been included that read the IDs and convert them to the required format. 

The number of build files has increased as the CMSIS-DSP library is build with all functions. The functions are in separate files and where optionally built by CONFIGs. These CONFIGs have been removed and the complete library is now built. Resulting in a  vastly increased number of files to built.
