### PR TITLE
manifest: update sdk-zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 5d7a30bb2fa0bc6130e0e054821a0daa7043a736
+      revision: 8ba9711786a4cd6eea313b900130633f8b36145b
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull in the latest fix in ieee802154 driver nRF5 implementation.