### PR TITLE
samples: matter: replace std::function with custom task

### DIFF
--- a/samples/matter/common/src/Kconfig
+++ b/samples/matter/common/src/Kconfig
@@ -11,6 +11,13 @@ config NCS_SAMPLE_MATTER_APP_TASK_QUEUE_SIZE
 	  Define the maximum size of the queue dedicated for application tasks that
 	  have to be run in the application thread context.
 
+config NCS_SAMPLE_MATTER_APP_TASK_MAX_SIZE
+	int "Maximum size of application task in bytes"
+	default 16
+	help
+	  Defines the maximum size of a functor that can be put in the application
+	  thread's task queue.
+
 config NCS_SAMPLE_MATTER_CUSTOM_BLUETOOTH_ADVERTISING
 	bool "Define the custom behavior of the Bluetooth advertisement in the application code"
 	help

--- a/samples/matter/common/src/app/task_executor.h
+++ b/samples/matter/common/src/app/task_executor.h
@@ -6,17 +6,55 @@
 
 #pragma once
 
-#include <functional>
+#include <type_traits>
 
 namespace Nrf
 {
-	using Task = std::function<void()>;
+
+	/**
+	 * @brief Task to be executed in the application thread.
+	 *
+	 * The Task encompasses a functor that returns void and takes no arguments.
+	 *
+	 * This class resembles \c std::function<void()> but it is trivially copyable
+	 * and uses static storage only. This enables the task to be passed using
+	 * a lightweight, type-agnostic message queue, but the task can only hold
+	 * a trivially copyable functor of a limited size, configurable using
+	 * \c CONFIG_NCS_SAMPLE_MATTER_APP_TASK_MAX_SIZE Kconfig option.
+	 */
+	class Task {
+	public:
+		Task() = default;
+
+		template <typename Functor> Task(const Functor &functor)
+		{
+			// Ensure that the functor can be safely serialized
+			static_assert(std::is_trivially_copyable_v<Functor>, "Task must be trivially copyable");
+			static_assert(sizeof(functor) <= sizeof(mStorage), "Task storage too small");
+			static_assert(alignof(Storage) % alignof(Functor) == 0, "Task storage has insufficient alignment");
+
+			// Ensure that the functor's destructor can be ignored
+			static_assert(std::is_trivially_destructible_v<Functor>, "Task must be trivially destructible");
+
+			new (&mStorage) Functor(functor);
+			mHandler = [](const Storage &storage) { (*reinterpret_cast<const Functor *>(&storage))(); };
+		}
+
+		void operator()() const { mHandler(mStorage); }
+
+	private:
+		using Storage = std::aligned_storage_t<CONFIG_NCS_SAMPLE_MATTER_APP_TASK_MAX_SIZE, alignof(void *)>;
+		using Handler = void (*)(const Storage &storage);
+
+		Storage mStorage;
+		Handler mHandler;
+	};
 
 	/**
 	 * @brief Post a task to the task queue.
 	 *
-	 * The Task is a function that returns void and enters no arguments.
-	 * The task can be posted as a lambda function with all the required arguments captured.
+	 * The Task encompasses a functor that returns void and takes no arguments.
+	 * The task can be constructed with a lambda function with all the required arguments captured.
 	 *
 	 * For example to post a task within which you need to run the method defined as "MyMethod",
 	 * and it has an argument defined as "uint32_t" see the following example:
@@ -26,12 +64,12 @@ namespace Nrf
 	 * uint32_t myNumber;
 	 * PostTask([myNumber]{ MyMethod(myNumber) };)
 	 *
-	 * @param task the Task function to be posted to the task queue
+	 * @param task the Task to be posted to the application thread's task queue
 	 */
 	void PostTask(const Task &task);
 
 	/**
-	 * @brief Dispatch an next available task.
+	 * @brief Dispatch the next available task.
 	 *
 	 * This is a blocking method that should be called in an application thread.
 	 * Dispatching events relies on constant waiting for the next event posted in the


### PR DESCRIPTION
std::function<void()> is currently used as a task that is to be executed in the application thread, but this class is not trivially copyable so passing it over Zephyr's msgq may lead to resource leaks or other unexpected behavior in certain circumstances (for example, when a functor that std::function is initialized with is big enough that it cannot fit in the std::function static storage and must be allocated on heap).

Replace std::function with a lightweight replacement that ensures that it is only used with simple lambda functions that can be safely serialized.