### PR TITLE
manifest: sdk-zephyr: Fix scope for PMIC samples tests

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 9c754a80d072e415d54fc6dd45235359b016433b
+      revision: pull/1458/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Fix PMIC samples change scope in sdk-zephyr (removed leading slashes)