### PR TITLE
manifest: sdk-zephyr: Pull DHCPv4 server implementation

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 9c754a80d072e415d54fc6dd45235359b016433b
+      revision: pull/1459/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull DHCPv4 server implementation to sdk-zephyr.