### PR TITLE
application: matter: Fix Matter Weather Station LEDs

### DIFF
--- a/applications/matter_weather_station/src/app_task.cpp
+++ b/applications/matter_weather_station/src/app_task.cpp
@@ -304,6 +304,7 @@ void AppTask::UpdateLedState()
 	case Nrf::DeviceState::DeviceAdvertisingBLE:
 		Instance().mBlueLED->Blink(Nrf::LedConsts::StatusLed::Disconnected::kOn_ms,
 					   Nrf::LedConsts::StatusLed::Disconnected::kOff_ms);
+		break;
 	case Nrf::DeviceState::DeviceDisconnected:
 		Instance().mGreenLED->Blink(Nrf::LedConsts::StatusLed::Disconnected::kOn_ms,
 					    Nrf::LedConsts::StatusLed::Disconnected::kOff_ms);

--- a/applications/matter_weather_station/src/chip_project_config.h
+++ b/applications/matter_weather_station/src/chip_project_config.h
@@ -38,16 +38,4 @@
 	  0x39, 0xa0, 0xf7, 0xb4, 0x86, 0x10, 0x32, 0x33, 0x01, 0xc2, 0xe4, 0x0f,		\
 	  0xe0, 0x4b, 0x9c, 0x2d, 0x4d, 0x41, 0x13, 0xfd, 0xc3, 0x11, 0xe1, 0x00,		\
 	  0x34, 0xa4, 0xe1, 0x7c, 0x09, 0x27, 0x45, 0x7b };
-#else
-/* Use a default pairing code if one hasn't been provisioned in flash. */
-#define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE 20202021
-#define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR 0xF00
-
-/* Configure device configuration with exemplary data */
-#define CHIP_DEVICE_CONFIG_DEVICE_VENDOR_NAME "Nordic"
-#define CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_NAME "WeatherStation"
-#define CHIP_DEVICE_CONFIG_DEFAULT_DEVICE_PRODUCT_REVISION_STRING "Prerelease weather station device"
-#define CHIP_DEVICE_CONFIG_DEFAULT_DEVICE_PRODUCT_REVISION 1
-#define CHIP_DEVICE_CONFIG_DEVICE_FIRMWARE_REVISION_STRING "Prerelease weather station firmware"
-#define CHIP_DEVICE_CONFIG_DEVICE_FIRMWARE_REVISION 1
 #endif

--- a/samples/matter/common/src/board/board.cpp
+++ b/samples/matter/common/src/board/board.cpp
@@ -72,6 +72,7 @@ void Board::UpdateDeviceState(DeviceState state)
 {
 	if (mState != state) {
 		mState = state;
+		ResetAllLeds();
 		mLedStateHandler();
 	}
 }
@@ -293,8 +294,12 @@ void Board::DefaultMatterEventHandler(const ChipDeviceEvent *event, intptr_t /* 
 
 	switch (event->Type) {
 	case DeviceEventType::kCHIPoBLEAdvertisingChange:
-		if (ConnectivityMgr().NumBLEConnections() != 0) {
+		if (isNetworkProvisioned) {
+			sInstance.UpdateDeviceState(DeviceState::DeviceProvisioned);
+		} else if (ConnectivityMgr().NumBLEConnections() != 0) {
 			sInstance.UpdateDeviceState(DeviceState::DeviceConnectedBLE);
+		} else {
+			sInstance.UpdateDeviceState(DeviceState::DeviceAdvertisingBLE);
 		}
 		break;
 #if defined(CONFIG_NET_L2_OPENTHREAD)


### PR DESCRIPTION
Led Updates were handled wrongly and due to that Matter Weather Station signalized bad states.

Removed also redundant configs to not override Configs anymore.