### PR TITLE
manifest: Update Zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 9c754a80d072e415d54fc6dd45235359b016433b
+      revision: a8136cb27e83a594085a0f95d533c20ccd23354c
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update sdk-zephyr to latest version

---

* ~The twister CI failure in the coap test is unrelated and fixed here:
https://github.com/nrfconnect/sdk-nrf/pull/13687~
* ~The documentation build failure is unrelated, fixes here:
https://github.com/nrfconnect/sdk-nrf/pull/13691#event-11556179245~
