### PR TITLE
gazell improvement

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -179,6 +179,10 @@ Gazell
   * :kconfig:option:`CONFIG_GAZELL_PAIRING_USER_CONFIG_ENABLE` and :kconfig:option:`CONFIG_GAZELL_PAIRING_USER_CONFIG_FILE`.
     The options allow to use user-specific file as Gazell pairing configuration header to override the pairing configuration.
 
+* Fixed:
+
+  * Clear system address and host id in RAM when :c:func:`gzp_erase_pairing_data` is called.
+
 Enhanced ShockBurst (ESB)
 -------------------------
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -171,6 +171,14 @@ Zigbee
 
 |no_changes_yet_note|
 
+Gazell
+------
+
+* Added:
+
+  * :kconfig:option:`CONFIG_GAZELL_PAIRING_USER_CONFIG_ENABLE` and :kconfig:option:`CONFIG_GAZELL_PAIRING_USER_CONFIG_FILE`.
+    The options allow to use user-specific file as Gazell pairing configuration header to override the pairing configuration.
+
 Enhanced ShockBurst (ESB)
 -------------------------
 

--- a/include/gzp.h
+++ b/include/gzp.h
@@ -15,7 +15,11 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <nrf_gzll.h>
+#if defined(CONFIG_GAZELL_PAIRING_USER_CONFIG_ENABLE)
+#include CONFIG_GAZELL_PAIRING_USER_CONFIG_FILE
+#else
 #include "gzp_config.h"
+#endif /* CONFIG_GAZELL_PAIRING_USER_CONFIG_ENABLE */
 
 #ifdef __cplusplus
 extern "C" {

--- a/subsys/gazell/Kconfig
+++ b/subsys/gazell/Kconfig
@@ -34,7 +34,19 @@ config GAZELL_PAIRING_HOST
 	bool "Host"
 	depends on ENTROPY_GENERATOR
 
-endchoice
+endchoice # GAZELL_PAIRING_ROLE
+
+config GAZELL_PAIRING_USER_CONFIG_ENABLE
+	bool "Use application-specific Gazell Pairing configuration file"
+
+if GAZELL_PAIRING_USER_CONFIG_ENABLE
+config GAZELL_PAIRING_USER_CONFIG_FILE
+	string "Gazell Pairing configuration file name"
+	default "gzp_user_config.h"
+	help
+	  Modify the file name to use an application-specific Gazell Pairing configuration file.
+
+endif # GAZELL_PAIRING_USER_CONFIG_ENABLE
 
 if GAZELL_PAIRING_DEVICE
 

--- a/subsys/gazell/gzp_device.c
+++ b/subsys/gazell/gzp_device.c
@@ -513,11 +513,25 @@ SETTINGS_STATIC_HANDLER_DEFINE(nrf_gzp_device, GZP_DEVICE_DB_NAME, NULL, setting
 
 #endif
 
+#ifdef CONFIG_GAZELL_PAIRING_CRYPT
+
+static void gzp_clear_host_id(void)
+{
+	memset(gzp_host_id, 0xff, GZP_HOST_ID_LENGTH);
+}
+
+#endif
+
+static void gzp_clear_sys_addr(void)
+{
+	memset(gzp_system_address, 0xff, GZP_SYSTEM_ADDRESS_WIDTH);
+}
+
 void gzp_init(void)
 {
-	memset(gzp_system_address, 0xFF, sizeof(gzp_system_address));
+	gzp_clear_sys_addr();
 #ifdef CONFIG_GAZELL_PAIRING_CRYPT
-	memset(gzp_host_id, 0xFF, sizeof(gzp_host_id));
+	gzp_clear_host_id();
 #endif
 
 	gzp_init_internal();
@@ -530,15 +544,18 @@ void gzp_init(void)
 	(void)gzp_update_radio_params(gzp_system_address);
 }
 
-
 void gzp_erase_pairing_data(void)
 {
 #ifdef CONFIG_GAZELL_PAIRING_SETTINGS
 	settings_delete(db_key_sys_addr);
 #ifdef CONFIG_GAZELL_PAIRING_CRYPT
 	settings_delete(db_key_host_id);
-#endif
-#endif
+#endif /* CONFIG_GAZELL_PAIRING_CRYPT */
+#endif /* CONFIG_GAZELL_PAIRING_SETTINGS */
+	gzp_clear_sys_addr();
+#ifdef CONFIG_GAZELL_PAIRING_CRYPT
+	gzp_clear_host_id();
+#endif /* CONFIG_GAZELL_PAIRING_CRYPT */
 }
 
 /* Set user callback context.


### PR DESCRIPTION
Gazell improvement for nrf_desktop integration.
The PR includes the following change.

- gzp_config header overrides to make application change host id and secret key without modifying subsys.
- Clear host id and sys address in memory without handling it in application.