### PR TITLE
samples: cellular: modem_shell: Flag reset reason printing

### DIFF
--- a/samples/cellular/modem_shell/src/main.c
+++ b/samples/cellular/modem_shell/src/main.c
@@ -237,7 +237,13 @@ int main(void)
 
 	__ASSERT(mosh_shell != NULL, "Failed to get shell backend");
 
-	mosh_print_reset_reason();
+	/* Reset reason can only be read once, because the register needs to be cleared after
+	 * reading. Memfault implementation reads the reset reason before modem_shell, so the
+	 * register would always be empty.
+	 */
+	if (!IS_ENABLED(CONFIG_MEMFAULT)) {
+		mosh_print_reset_reason();
+	}
 
 	mosh_print_version_info();
 


### PR DESCRIPTION
Reset reason can only be read once, because the register needs to be cleared after reading. Memfault implementation reads the reset reason before modem_shell, so the register was always empty and the reset reason was not correctly printed. Added flagging for reset reason printing to skip it when Memfault is enabled.