### PR TITLE
lib: nrf_modem: os: Wake threads waiting for all context

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -699,6 +699,7 @@ Modem libraries
 
     * The ``lte_net_if`` module now handles the :c:enumerator:`~pdn_event.PDN_EVENT_NETWORK_DETACH` PDN event.
       Not handling this caused permanent connection loss and error message (``ipv4_addr_add, error: -19``) in some situations when reconnecting.
+    * Threads sleeping in the :c:func:`nrf_modem_os_timedwait` function with context ``0`` are now woken by all calls to the :c:func:`nrf_modem_os_event_notify` function.
 
   * Removed:
 

--- a/lib/nrf_modem_lib/nrf_modem_os.c
+++ b/lib/nrf_modem_lib/nrf_modem_os.c
@@ -283,9 +283,11 @@ void nrf_modem_os_event_notify(uint32_t context)
 
 	struct sleeping_thread *thread;
 
-	/* Wake up all sleeping threads. */
 	SYS_SLIST_FOR_EACH_CONTAINER(&sleeping_threads, thread, node) {
-		if ((thread->context == context) || (context == 0)) {
+		/* Wake sleeping thread if context of the thread matches, is 0 or the notify
+		 * context is 0.
+		 */
+		if ((thread->context == context) || (context == 0) || (thread->context == 0)) {
 			k_sem_give(&thread->sem);
 		}
 	}


### PR DESCRIPTION
Wake threads waiting for all context on all event notify calls.