### PR TITLE
lib: nrf_modem: fault: add initialization retry limit

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -720,6 +720,7 @@ Modem libraries
   * Updated by renaming ``lte_connectivity`` module to ``lte_net_if``.
     All related Kconfig options have been renamed accordingly.
   * Changed the default value of the :kconfig:option:`CONFIG_NRF_MODEM_LIB_NET_IF_AUTO_START`, :kconfig:option:`CONFIG_NRF_MODEM_LIB_NET_IF_AUTO_CONNECT`, and :kconfig:option:`CONFIG_NRF_MODEM_LIB_NET_IF_AUTO_DOWN` Kconfig options from enabled to disabled.
+  * The :kconfig:option:`CONFIG_NRF_MODEM_LIB_ON_FAULT_RESET_MODEM_RETRIES` Kconfig option to choose the number of times the modem fault handler will attempt to initialize the modem after a fault.
 
   * Fixed:
 

--- a/lib/nrf_modem_lib/Kconfig.modemlib
+++ b/lib/nrf_modem_lib/Kconfig.modemlib
@@ -217,6 +217,17 @@ config NRF_MODEM_LIB_ON_FAULT_APPLICATION_SPECIFIC
 
 endchoice # NRF_MODEM_LIB_ON_FAULT
 
+if NRF_MODEM_LIB_ON_FAULT_RESET_MODEM
+
+config NRF_MODEM_LIB_ON_FAULT_RESET_MODEM_RETRIES
+	int "Retry limit"
+	default 3
+	help
+	  The number of times the fault handler will attempt to initialize the modem if unsuccessful.
+	  The retry counter is cleared on a successful initialization.
+
+endif # NRF_MODEM_LIB_ON_FAULT_RESET_MODEM
+
 config NRF_MODEM_LIB_FAULT_STRERROR
 	bool "Compile fault reason table"
 	help


### PR DESCRIPTION
Add a limit to the number of times the application will try to reinit the modem after a fault. This is usefull when a fault occurs during initialization.