### PR TITLE
samples: matter: Extended BT bridge recovery implementation

### DIFF
--- a/applications/matter_bridge/prj.conf
+++ b/applications/matter_bridge/prj.conf
@@ -28,6 +28,9 @@ CONFIG_MPU_STACK_GUARD=y
 CONFIG_RESET_ON_FATAL_ERROR=n
 CONFIG_CHIP_LIB_SHELL=y
 
+# Reduce assert verbosity to save flash space.
+CONFIG_ASSERT_NO_FILE_INFO=y
+
 # Disable NFC commissioning
 CONFIG_CHIP_NFC_COMMISSIONING=n
 

--- a/applications/matter_bridge/src/bridge_shell.cpp
+++ b/applications/matter_bridge/src/bridge_shell.cpp
@@ -178,9 +178,9 @@ static int SimulatedBridgedDeviceOnOffLightSwitchWriteHandler(const struct shell
 #endif
 
 #ifdef CONFIG_BRIDGED_DEVICE_BT
-static void BluetoothScanResult(Nrf::BLEConnectivityManager::ScannedDevice *devices, uint8_t count, void *context)
+static void BluetoothScanResult(Nrf::BLEConnectivityManager::ScanResult & result, void *context)
 {
-	if (!devices || !context) {
+	if (!result.mDevices || !context) {
 		return;
 	}
 
@@ -190,11 +190,11 @@ static void BluetoothScanResult(Nrf::BLEConnectivityManager::ScannedDevice *devi
 	shell_fprintf(shell, SHELL_INFO, "---------------------------------------------------------------------\n");
 	shell_fprintf(shell, SHELL_INFO, "| Index |      Address      |                   UUID                 \n");
 	shell_fprintf(shell, SHELL_INFO, "---------------------------------------------------------------------\n");
-	for (int i = 0; i < count; i++) {
+	for (int i = 0; i < result.mCount; i++) {
 		shell_fprintf(shell, SHELL_INFO, "| %d     | %02x:%02x:%02x:%02x:%02x:%02x | 0x%04x (%s)\n", i,
-			      devices[i].mAddr.a.val[5], devices[i].mAddr.a.val[4], devices[i].mAddr.a.val[3],
-			      devices[i].mAddr.a.val[2], devices[i].mAddr.a.val[1], devices[i].mAddr.a.val[0],
-			      devices[i].mUuid, BleBridgedDeviceFactory::GetUuidString(devices[i].mUuid));
+			      result.mDevices[i].mAddr.a.val[5], result.mDevices[i].mAddr.a.val[4], result.mDevices[i].mAddr.a.val[3],
+			      result.mDevices[i].mAddr.a.val[2], result.mDevices[i].mAddr.a.val[1], result.mDevices[i].mAddr.a.val[0],
+			      result.mDevices[i].mUuid, BleBridgedDeviceFactory::GetUuidString(result.mDevices[i].mUuid));
 	}
 }
 

--- a/samples/matter/common/src/bridge/Kconfig
+++ b/samples/matter/common/src/bridge/Kconfig
@@ -22,9 +22,9 @@ config BRIDGE_AGGREGATOR_ENDPOINT_ID
 
 if BRIDGED_DEVICE_BT
 
-config BRIDGE_BT_RECOVERY_INTERVAL_MS
-	int "Time (in ms) between recovery attempts when the BLE connection to the bridged device is lost"
-	default 1000
+config BRIDGE_BT_RECOVERY_MAX_INTERVAL
+	int "Maximum time (in s) between recovery attempts when the BLE connection to the bridged device is lost"
+	default 300
 
 config BRIDGE_BT_RECOVERY_SCAN_TIMEOUT_MS
 	int "Time (in ms) within which the Bridge will try to re-establish a connection to the lost BT LE device"

--- a/samples/matter/common/src/bridge/ble_bridged_device.h
+++ b/samples/matter/common/src/bridge/ble_bridged_device.h
@@ -14,7 +14,8 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/gatt.h>
 
-namespace Nrf {
+namespace Nrf
+{
 
 struct BLEBridgedDeviceProvider;
 
@@ -66,7 +67,7 @@ public:
 	bool IsInitiallyConnected() { return mDevice.mInitiallyConnected; }
 
 	/**
-	 * @brief Confirm that the @ref mFirstConnectionCallback has been already called .
+	 * @brief Confirm that the @ref mFirstConnectionCallback has been already called.
 	 *
 	 * This method informs the bridged device that the @ref mFirstConnectionCallback has been called
 	 * and connection has been established successfully.
@@ -76,8 +77,35 @@ public:
 
 	bt_addr_le_t GetBtAddress() { return mDevice.mAddr; }
 
+	/**
+	 * @brief Get a number of failed recovery attempts for this provider.
+	 */
+	uint16_t GetFailedRecoveryAttempts() { return mFailedRecoveryAttempts; }
+
+	/**
+	 * @brief Inform provider that recovery attempt for it failed.
+	 *
+	 * This method increments the number of failed recovery attempts.
+	 *
+	 */
+	void NotifyFailedRecovery()
+	{
+		if (mFailedRecoveryAttempts < UINT16_MAX) {
+			mFailedRecoveryAttempts++;
+		}
+	}
+
+	/**
+	 * @brief Inform provider that recovery attempt for it succeeded.
+	 *
+	 * This method resets the number of failed recovery attempts.
+	 *
+	 */
+	void NotifySuccessfulRecovery() { mFailedRecoveryAttempts = 0; }
+
 protected:
 	BLEBridgedDevice mDevice = { 0 };
+	uint16_t mFailedRecoveryAttempts = 0;
 };
 
 } /* namespace Nrf */


### PR DESCRIPTION
The bridge BT recovery mechanism was refactored to:
* add backoff mechanism, which makes it scan the less frequently, the longer there are no lost devices detected
* optimize the recovery time by not repeating scan operation before adding every device