### PR TITLE
manifest: update zephyr to pull new Bluetooth GATT API

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: d142e4b062d5e5c9f107d2702ee7db7f065292e0
+      revision: e4e6dc87bafd8f3e9c2562fc55dbfa4f8185b14b
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Updated the Zephyr revision in the manifest file to pull the new Bluetooth GATT API.