### PR TITLE
manifest: matter: Lock thread stack before factory reset

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -154,7 +154,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 288b64af79b92d0a5412181eb87fa3a5e0368cab
+      revision: 4936f9fa2be9e6cd16b02e4fcb9a7aff611f4981
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
This commit fix problem with interruption done by thread stack while preforming factory reset.