### PR TITLE
applications: nrf5340_audio: Only run just-in-time for CIS unidir

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/bt_le_audio_tx/bt_le_audio_tx.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/bt_le_audio_tx/bt_le_audio_tx.c
@@ -172,7 +172,8 @@ int bt_le_audio_tx_send(struct bt_bap_stream **bap_streams, struct le_audio_enco
 	}
 
 	if (ts != 0 && got_tx_sync_ts) {
-		if (!IS_ENABLED(CONFIG_STREAM_BIDIRECTIONAL)) {
+		if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) &&
+		    !IS_ENABLED(CONFIG_STREAM_BIDIRECTIONAL)) {
 			struct sdu_ref_msg msg;
 
 			msg.timestamp = ts;


### PR DESCRIPTION
- Check config for unicast_client and not bidir
- OCT-NONE