### PR TITLE
manifest: update sdk-zephyr revision with BT fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 9c754a80d072e415d54fc6dd45235359b016433b
+      revision: d142e4b062d5e5c9f107d2702ee7db7f065292e0
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pulls in a fix related to Bluetooth Isochronous channels.