### PR TITLE
net: lib: nrf_cloud: Add control over CoAP message reliability

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -349,6 +349,7 @@ Cellular samples
 
     * A generic processing example for application-specific shadow data.
     * Configuration and overlay files to enable MCUboot to use the external flash on the nRF1961 DK.
+    * A :kconfig:option:`CONFIG_COAP_ALWAYS_CONFIRM` Kconfig option to select CON or NON CoAP transfers for functions that previously used NON transfers only.
 
   * Fixed:
 
@@ -733,6 +734,16 @@ Libraries for networking
     * The :c:func:`nrf_cloud_coap_shadow_delta_process` function to include a parameter for application-specific shadow data.
     * The :c:func:`nrf_cloud_coap_shadow_delta_process` function to process default shadow data added by nRF Cloud, which is not used by CoAP.
     * The CDDL file for AGNSS to align with cloud changes and regenerated the AGNSS encoder accordingly.
+    * The following functions to accept a ``confirmable`` parameter:
+
+      * :c:func:`nrf_cloud_coap_bytes_send`
+      * :c:func:`nrf_cloud_coap_obj_send`
+      * :c:func:`nrf_cloud_coap_sensor_send`
+      * :c:func:`nrf_cloud_coap_message_send`
+      * :c:func:`nrf_cloud_coap_json_message_send`
+      * :c:func:`nrf_cloud_coap_location_send`
+
+      This parameter determines whether CoAP CON or NON messages are used.
 
 * :ref:`lib_nrf_cloud_log` library:
 

--- a/include/net/nrf_cloud_coap.h
+++ b/include/net/nrf_cloud_coap.h
@@ -125,22 +125,28 @@ int nrf_cloud_coap_pgps_url_get(struct nrf_cloud_rest_pgps_request const *const 
 /**
  * @brief Send a sensor value to nRF Cloud.
  *
- *  The CoAP message is sent as a non-confirmable CoAP message.
+ *  The sensor message is sent either as a non-confirmable or confirmable CoAP message.
+ *  Use non-confirmable when sending low priority information for which some data loss is
+ *  acceptable.
  *
- * @param[in]     app_id The app_id identifying the type of data. See the values in nrf_cloud_defs.h
- *                       that begin with  NRF_CLOUD_JSON_APPID_. You may also use custom names.
+ * @param[in]     app_id The app ID identifying the type of data. See the values
+ *                       that begin with NRF_CLOUD_JSON_APPID_ in nrf_cloud_defs.h. You may
+ *                       also use custom names.
  * @param[in]     value  Sensor reading.
  * @param[in]     ts_ms  Timestamp the data was measured, or NRF_CLOUD_NO_TIMESTAMP.
+ * @param[in]     confirmable Select whether to use a CON or NON CoAP transfer.
  *
  * @retval 0 If successful.
  *          Otherwise, a (negative) error code is returned.
  */
-int nrf_cloud_coap_sensor_send(const char *app_id, double value, int64_t ts_ms);
+int nrf_cloud_coap_sensor_send(const char *app_id, double value, int64_t ts_ms, bool confirmable);
 
 /**
- * @brief Send a message string to nRF Cloud.
+ * @brief Send a message to nRF Cloud.
  *
- *  The CoAP message is sent as a non-confirmable CoAP message.
+ *  The JSON or CBOR message is sent either as a non-confirmable or confirmable CoAP message.
+ *  Use non-confirmable when sending low priority information for which some data loss is
+ *  acceptable.
  *
  * @param[in]     app_id     The app_id identifying the type of data. See the values in
  *                           nrf_cloud_defs.h that begin with  NRF_CLOUD_JSON_APPID_.
@@ -148,39 +154,45 @@ int nrf_cloud_coap_sensor_send(const char *app_id, double value, int64_t ts_ms);
  * @param[in]     message    The string to send.
  * @param[in]     json       Set true if the data should be sent in JSON format, otherwise CBOR.
  * @param[in]     ts_ms      Timestamp the data was measured, or NRF_CLOUD_NO_TIMESTAMP.
+ * @param[in]     confirmable Select whether to use a CON or NON CoAP transfer.
  *
  * @retval 0 If successful.
  *          Otherwise, a (negative) error code is returned.
  */
-int nrf_cloud_coap_message_send(const char *app_id, const char *message, bool json, int64_t ts_ms);
+int nrf_cloud_coap_message_send(const char *app_id, const char *message, bool json, int64_t ts_ms,
+				bool confirmable);
 
 /**
  * @brief Send a preencoded JSON message to nRF Cloud.
  *
- *  The CoAP message is sent as a non-confirmable CoAP message.
+ *  The JSON message is sent either as a non-confirmable or confirmable CoAP message.
+ *  Use non-confirmable when sending low priority information for which some data loss is
+ *  acceptable.
  *
  * @param[in]     message    The string to send.
  * @param[in]     bulk       Set true if message is an array of JSON messages
  *                           to be sent to the bulk topic.
+ * @param[in]     confirmable Select whether to use a CON or NON CoAP transfer.
  *
  * @retval 0 If successful.
  *          Otherwise, a (negative) error code is returned.
  */
-int nrf_cloud_coap_json_message_send(const char *message, bool bulk);
+int nrf_cloud_coap_json_message_send(const char *message, bool bulk, bool confirmable);
 
 /**
  * @brief Send the device location in the @ref nrf_cloud_gnss_data PVT field to nRF Cloud.
  *
- *  The CoAP message is sent as a non-confirmable CoAP message. Only
+ *  The location message is sent as either a non-confirmable or confirmable CoAP message. Only
  *  @ref NRF_CLOUD_GNSS_TYPE_PVT is supported.
  *
  * @param[in]     gnss A pointer to an @ref nrf_cloud_gnss_data struct indicating the device
  *                     location, usually as determined by the GNSS unit.
+ * @param[in]     confirmable Select whether to use a CON or NON CoAP transfer.
  *
  * @retval 0 If successful.
  *          Otherwise, a (negative) error code is returned.
  */
-int nrf_cloud_coap_location_send(const struct nrf_cloud_gnss_data * const gnss);
+int nrf_cloud_coap_location_send(const struct nrf_cloud_gnss_data * const gnss, bool confirmable);
 
 /**
  * @brief Request device location from nRF Cloud.
@@ -302,10 +314,11 @@ int nrf_cloud_coap_shadow_delta_process(const struct nrf_cloud_data *in_data,
  *
  * @param[in]     buf buffer with binary string.
  * @param[in]     buf_len  length of buf in bytes.
+ * @param[in]     confirmable Select whether to use a CON or NON CoAP transfer.
  * @retval 0 If successful.
  *          Otherwise, a (negative) error code is returned.
  */
-int nrf_cloud_coap_bytes_send(uint8_t *buf, size_t buf_len);
+int nrf_cloud_coap_bytes_send(uint8_t *buf, size_t buf_len, bool confirmable);
 
 /**
  * @brief Send an nRF Cloud object
@@ -317,11 +330,12 @@ int nrf_cloud_coap_bytes_send(uint8_t *buf, size_t buf_len);
  *
  * @param[in]     obj An nRF Cloud object. Will be encoded first if obj->enc_src is
  * NRF_CLOUD_ENC_SRC_NONE.
+ * @param[in]     confirmable Select whether to use a CON or NON CoAP transfer.
  *
  * @return 0 if the request succeeded, a positive value indicating a CoAP result code,
  * or a negative error number.
  */
-int nrf_cloud_coap_obj_send(struct nrf_cloud_obj *const obj);
+int nrf_cloud_coap_obj_send(struct nrf_cloud_obj *const obj, bool confirmable);
 
 /** @} */
 

--- a/samples/cellular/nrf_cloud_multi_service/Kconfig
+++ b/samples/cellular/nrf_cloud_multi_service/Kconfig
@@ -285,6 +285,12 @@ config COAP_SHADOW_THREAD_STACK_SIZE
 
 endif
 
+config COAP_SEND_CONFIRMABLE
+	bool "Send device messages as confirmable"
+	help
+	  Ensures all CoAP transfers, even for often less important messages such
+	  as sensor data, are sent as confirmable messages.
+
 endif
 
 endmenu

--- a/samples/cellular/nrf_cloud_multi_service/src/message_queue.c
+++ b/samples/cellular/nrf_cloud_multi_service/src/message_queue.c
@@ -136,7 +136,7 @@ static int consume_device_message(void)
 	ret = nrf_cloud_send(&mqtt_msg);
 
 #elif defined(CONFIG_NRF_CLOUD_COAP)
-	ret = nrf_cloud_coap_obj_send(queued_msg);
+	ret = nrf_cloud_coap_obj_send(queued_msg, IS_ENABLED(CONFIG_COAP_SEND_CONFIRMABLE));
 
 #endif /* CONFIG_NRF_CLOUD_COAP */
 

--- a/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap.c
+++ b/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap.c
@@ -214,7 +214,7 @@ int nrf_cloud_coap_pgps_url_get(struct nrf_cloud_rest_pgps_request const *const 
 #endif /* CONFIG_NRF_CLOUD_PGPS */
 
 
-int nrf_cloud_coap_bytes_send(uint8_t *buf, size_t buf_len)
+int nrf_cloud_coap_bytes_send(uint8_t *buf, size_t buf_len, bool confirmable)
 {
 	int err = 0;
 
@@ -223,7 +223,7 @@ int nrf_cloud_coap_bytes_send(uint8_t *buf, size_t buf_len)
 	}
 
 	err = nrf_cloud_coap_post(COAP_D2C_RAW_RSC, NULL, buf, buf_len,
-				  COAP_CONTENT_FORMAT_APP_OCTET_STREAM, false, NULL, NULL);
+				  COAP_CONTENT_FORMAT_APP_OCTET_STREAM, confirmable, NULL, NULL);
 	if (err) {
 		LOG_ERR("Failed to send POST request: %d", err);
 	}
@@ -231,7 +231,7 @@ int nrf_cloud_coap_bytes_send(uint8_t *buf, size_t buf_len)
 }
 
 
-int nrf_cloud_coap_obj_send(struct nrf_cloud_obj *const obj)
+int nrf_cloud_coap_obj_send(struct nrf_cloud_obj *const obj, bool confirmable)
 {
 	if (!nrf_cloud_coap_is_connected()) {
 		return -EACCES;
@@ -275,7 +275,7 @@ int nrf_cloud_coap_obj_send(struct nrf_cloud_obj *const obj)
 				  obj->encoded_data.ptr, obj->encoded_data.len,
 				  (obj->type == NRF_CLOUD_OBJ_TYPE_COAP_CBOR) ?
 				   COAP_CONTENT_FORMAT_APP_CBOR : COAP_CONTENT_FORMAT_APP_JSON,
-				  false, NULL, NULL);
+				  confirmable, NULL, NULL);
 	if (err) {
 		LOG_ERR("Failed to send POST request: %d", err);
 	}
@@ -287,7 +287,7 @@ int nrf_cloud_coap_obj_send(struct nrf_cloud_obj *const obj)
 	return err;
 }
 
-int nrf_cloud_coap_sensor_send(const char *app_id, double value, int64_t ts_ms)
+int nrf_cloud_coap_sensor_send(const char *app_id, double value, int64_t ts_ms, bool confirmable)
 {
 	__ASSERT_NO_MSG(app_id != NULL);
 	if (!nrf_cloud_coap_is_connected()) {
@@ -305,7 +305,7 @@ int nrf_cloud_coap_sensor_send(const char *app_id, double value, int64_t ts_ms)
 		return err;
 	}
 	err = nrf_cloud_coap_post(COAP_D2C_RSC, NULL, buffer, len,
-				  COAP_CONTENT_FORMAT_APP_CBOR, false, NULL, NULL);
+				  COAP_CONTENT_FORMAT_APP_CBOR, confirmable, NULL, NULL);
 	if (err < 0) {
 		LOG_ERR("Failed to send POST request: %d", err);
 	} else if (err > 0) {
@@ -314,7 +314,8 @@ int nrf_cloud_coap_sensor_send(const char *app_id, double value, int64_t ts_ms)
 	return err;
 }
 
-int nrf_cloud_coap_message_send(const char *app_id, const char *message, bool json, int64_t ts_ms)
+int nrf_cloud_coap_message_send(const char *app_id, const char *message, bool json, int64_t ts_ms,
+				bool confirmable)
 {
 	if (!nrf_cloud_coap_is_connected()) {
 		return -EACCES;
@@ -340,7 +341,7 @@ int nrf_cloud_coap_message_send(const char *app_id, const char *message, bool js
 	err = nrf_cloud_coap_post(COAP_D2C_RSC, NULL, buffer, len,
 				  json ? COAP_CONTENT_FORMAT_APP_JSON :
 					 COAP_CONTENT_FORMAT_APP_CBOR,
-				  false, NULL, NULL);
+				  confirmable, NULL, NULL);
 	if (err < 0) {
 		LOG_ERR("Failed to send POST request: %d", err);
 	} else if (err > 0) {
@@ -349,7 +350,7 @@ int nrf_cloud_coap_message_send(const char *app_id, const char *message, bool js
 	return err;
 }
 
-int nrf_cloud_coap_json_message_send(const char *message, bool bulk)
+int nrf_cloud_coap_json_message_send(const char *message, bool bulk, bool confirmable)
 {
 	if (!nrf_cloud_coap_is_connected()) {
 		return -EACCES;
@@ -364,7 +365,7 @@ int nrf_cloud_coap_json_message_send(const char *message, bool bulk)
 	err = nrf_cloud_coap_post(resource,
 				  NULL, message, len,
 				  COAP_CONTENT_FORMAT_APP_JSON,
-				  false, NULL, NULL);
+				  confirmable, NULL, NULL);
 	if (err < 0) {
 		LOG_ERR("Failed to send POST request: %d", err);
 	} else if (err > 0) {
@@ -373,7 +374,7 @@ int nrf_cloud_coap_json_message_send(const char *message, bool bulk)
 	return err;
 }
 
-int nrf_cloud_coap_location_send(const struct nrf_cloud_gnss_data *gnss)
+int nrf_cloud_coap_location_send(const struct nrf_cloud_gnss_data *gnss, bool confirmable)
 {
 	__ASSERT_NO_MSG(gnss != NULL);
 	if (!nrf_cloud_coap_is_connected()) {
@@ -395,7 +396,7 @@ int nrf_cloud_coap_location_send(const struct nrf_cloud_gnss_data *gnss)
 		return err;
 	}
 	err = nrf_cloud_coap_post(COAP_D2C_RSC, NULL, buffer, len,
-				  COAP_CONTENT_FORMAT_APP_CBOR, false, NULL, NULL);
+				  COAP_CONTENT_FORMAT_APP_CBOR, confirmable, NULL, NULL);
 	if (err < 0) {
 		LOG_ERR("Failed to send POST request: %d", err);
 	} else if (err > 0) {

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_alert.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_alert.c
@@ -169,7 +169,7 @@ int nrf_cloud_alert_send(enum nrf_cloud_alert_type type,
 	}
 
 	/* send to d2c topic */
-	err = nrf_cloud_coap_json_message_send(data.ptr, false);
+	err = nrf_cloud_coap_json_message_send(data.ptr, false, true);
 	if (!err) {
 		LOG_DBG("Send alert via CoAP");
 	} else {

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec.c
@@ -761,12 +761,16 @@ int nrf_cloud_obj_gnss_msg_create(struct nrf_cloud_obj *const obj,
 	}
 
 	int ret;
+	const char *msg_type;
 
 	NRF_CLOUD_OBJ_DEFINE(pvt_obj, obj->type);
 
 	/* Add the app ID, message type, and timestamp */
-	ret = nrf_cloud_obj_msg_init(obj, NRF_CLOUD_JSON_APPID_VAL_GNSS,
-				     NRF_CLOUD_JSON_MSG_TYPE_VAL_DATA);
+	msg_type = (IS_ENABLED(CONFIG_NRF_CLOUD_COAP) &&
+		    (obj->type == NRF_CLOUD_OBJ_TYPE_COAP_CBOR)) ?
+			NULL : NRF_CLOUD_JSON_MSG_TYPE_VAL_DATA;
+
+	ret = nrf_cloud_obj_msg_init(obj, NRF_CLOUD_JSON_APPID_VAL_GNSS, msg_type);
 	if (ret) {
 		goto cleanup;
 	}

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_log.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_log.c
@@ -265,7 +265,7 @@ int nrf_cloud_log_send(int log_level, const char *fmt, ...)
 		LOG_INF("Failed to take semaphore");
 		return err; /* Caller should try again; busy or other error */
 	}
-	err = nrf_cloud_coap_json_message_send(output.data.ptr, false);
+	err = nrf_cloud_coap_json_message_send(output.data.ptr, false, true);
 	k_sem_give(&ncl_active);
 	nrf_cloud_free((void *)output.data.ptr);
 

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_log_backend.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_log_backend.c
@@ -401,7 +401,7 @@ static int send_ring_buffer(void)
 			}
 		} while (err == -EBUSY);
 	} else if (IS_ENABLED(CONFIG_NRF_CLOUD_COAP)) {
-		err = nrf_cloud_coap_json_message_send(output.data.ptr, true);
+		err = nrf_cloud_coap_json_message_send(output.data.ptr, true, true);
 	} else {
 		err = -ENODEV;
 	}


### PR DESCRIPTION
Add a bool confirmable flag to all the nrf_cloud_coap functions which previously assumed NON transfers were sufficient.

Update the nrf_cloud_multi_service sample with a Kconfig setting to enable use off CON transfers all the time.

Update nrf_cloud_alert.c and nrf_cloud_log_backend.c to choose CON transfers.

Jira: IRIS-8081