### PR TITLE
samples: wifi: sr_coex: Fix 5GHz connection

### DIFF
--- a/samples/wifi/sr_coex/src/main.c
+++ b/samples/wifi/sr_coex/src/main.c
@@ -193,6 +193,12 @@ static int __wifi_args_to_params(struct wifi_connect_req_params *params)
 {
 	params->timeout = SYS_FOREVER_MS;
 
+	/* Defaults */
+	params->band = WIFI_FREQ_BAND_UNKNOWN;
+	params->channel = WIFI_CHANNEL_ANY;
+	params->security = WIFI_SECURITY_TYPE_NONE;
+	params->mfp = WIFI_MFP_OPTIONAL;
+
 	/* SSID */
 	params->ssid = CONFIG_STA_SAMPLE_SSID;
 	params->ssid_length = strlen(params->ssid);
@@ -211,10 +217,6 @@ static int __wifi_args_to_params(struct wifi_connect_req_params *params)
 	params->psk = CONFIG_STA_SAMPLE_PASSWORD;
 	params->psk_length = strlen(params->psk);
 #endif
-	params->channel = WIFI_CHANNEL_ANY;
-
-	/* MFP (optional) */
-	params->mfp = WIFI_MFP_OPTIONAL;
 
 	return 0;
 }


### PR DESCRIPTION
Now that WPA supplicant APIs enforce band requirement, need to properly configure the band in the connection as 0 (memset) is 2.4GHz only.