### PR TITLE
applications: Fixed pincode shell command in the Matter bridge

### DIFF
--- a/applications/matter_bridge/doc/matter_bridge_description.rst
+++ b/applications/matter_bridge/doc/matter_bridge_description.rst
@@ -280,14 +280,14 @@ Adding a Bluetooth LE bridged device to the Matter bridge
 
    .. code-block:: console
 
-      ---------------------------------------------------------------------
-      | Bridged Bluetooth LE device authentication                        |
-      |                                                                   |
-      | Insert pin code displayed by the Bluetooth LE peripheral device   |
-      | to authenticate the pairing operation.                            |
-      |                                                                   |
-      | To do that, use matter_bridge pincode <pincode> shell command.    |
-      ---------------------------------------------------------------------
+      ----------------------------------------------------------------------------------------
+      | Bridged Bluetooth LE device authentication                                           |
+      |                                                                                      |
+      | Insert pin code displayed by the Bluetooth LE peripheral device                      |
+      | to authenticate the pairing operation.                                               |
+      |                                                                                      |
+      | To do that, use matter_bridge pincode <ble_device_index> <pincode> shell command.    |
+      ----------------------------------------------------------------------------------------
 
    To complete the adding process, you must use the ``pincode`` command to insert the authentication pincode displayed by the bridged device.
 
@@ -297,15 +297,18 @@ Inserting a Bluetooth LE authentication pincode
    .. parsed-literal::
       :class: highlight
 
-      matter_bridge pincode *<ble_pincode>*
+      matter_bridge pincode *<ble_device_index>* *<ble_pincode>*
 
-   In this command, *<ble_pincode>* is the Bluetooth LE authentication pincode of the bridged device to be paired.
+   In this command:
+
+   * *<ble_device_index>* is the Bluetooth LE device index on the list returned by the ``scan`` command.
+   * *<ble_pincode>* is the Bluetooth LE authentication pincode of the bridged device to be paired.
 
    Example command:
 
    .. code-block:: console
 
-      uart:~$ matter_bridge pincode 305051
+      uart:~$ matter_bridge pincode 0 305051
 
    The terminal output is similar to the following one:
 
@@ -558,14 +561,14 @@ After building the sample and programming it to your development kit, complete t
                :class: highlight
 
                I: Connected: C7:44:0F:3E:BB:F0 (random)
-               ---------------------------------------------------------------------
-               | Bridged Bluetooth LE device authentication                        |
-               |                                                                   |
-               | Insert pin code displayed by the Bluetooth LE peripheral device   |
-               | to authenticate the pairing operation.                            |
-               |                                                                   |
-               | To do that, use matter_bridge pincode <pincode> shell command.    |
-               ---------------------------------------------------------------------
+               ----------------------------------------------------------------------------------------
+               | Bridged Bluetooth LE device authentication                                           |
+               |                                                                                      |
+               | Insert pin code displayed by the Bluetooth LE peripheral device                      |
+               | to authenticate the pairing operation.                                               |
+               |                                                                                      |
+               | To do that, use matter_bridge pincode <ble_device_index> <pincode> shell command.    |
+               ----------------------------------------------------------------------------------------
 
          #. Write down the authentication pincode value from the Bluetooth LE bridged device terminal.
             The terminal output is similar to the following one:
@@ -583,13 +586,13 @@ After building the sample and programming it to your development kit, complete t
             .. parsed-literal::
                :class: highlight
 
-               uart:~$ matter_bridge pincode *<bluetooth_authentication_pincode>*
+               uart:~$ matter_bridge pincode *<bluetooth_device_index>* *<bluetooth_authentication_pincode>*
 
-            For example, if you want to add a new Bluetooth LE bridged device with pincode ``350501``, use the following command:
+            For example, if you want to add a new Bluetooth LE bridged device with index ``1`` and pincode ``350501``, use the following command:
 
             .. code-block:: console
 
-               uart:~$ matter_bridge pincode 350501
+               uart:~$ matter_bridge pincode 1 350501
 
             The terminal output is similar to the following one:
 

--- a/applications/matter_bridge/src/bridge_shell.cpp
+++ b/applications/matter_bridge/src/bridge_shell.cpp
@@ -24,14 +24,14 @@ static void BluetoothConnectionSecurityRequest(void *context)
 
 	const struct shell *shell = reinterpret_cast<struct shell *>(context);
 
-	shell_fprintf(shell, SHELL_INFO, "---------------------------------------------------------------------\n");
-	shell_fprintf(shell, SHELL_INFO, "| Bridged Bluetooth LE device authentication                        |\n");
-	shell_fprintf(shell, SHELL_INFO, "|                                                                   |\n");
-	shell_fprintf(shell, SHELL_INFO, "| Insert pin code displayed by the Bluetooth LE peripheral device   |\n");
-	shell_fprintf(shell, SHELL_INFO, "| to authenticate the pairing operation.                            |\n");
-	shell_fprintf(shell, SHELL_INFO, "|                                                                   |\n");
-	shell_fprintf(shell, SHELL_INFO, "| To do that, use matter_bridge pincode <pincode> shell command.    |\n");
-	shell_fprintf(shell, SHELL_INFO, "---------------------------------------------------------------------\n");
+	shell_fprintf(shell, SHELL_INFO, "----------------------------------------------------------------------------------------\n");
+	shell_fprintf(shell, SHELL_INFO, "| Bridged Bluetooth LE device authentication                                           |\n");
+	shell_fprintf(shell, SHELL_INFO, "|                                                                                      |\n");
+	shell_fprintf(shell, SHELL_INFO, "| Insert pin code displayed by the Bluetooth LE peripheral device                      |\n");
+	shell_fprintf(shell, SHELL_INFO, "| to authenticate the pairing operation.                                               |\n");
+	shell_fprintf(shell, SHELL_INFO, "|                                                                                      |\n");
+	shell_fprintf(shell, SHELL_INFO, "| To do that, use matter_bridge pincode <ble_device_index> <pincode> shell command.    |\n");
+	shell_fprintf(shell, SHELL_INFO, "----------------------------------------------------------------------------------------\n");
 }
 #endif /* CONFIG_BRIDGED_DEVICE_BT && CONFIG_BT_SMP */
 
@@ -201,8 +201,8 @@ static void BluetoothScanResult(Nrf::BLEConnectivityManager::ScannedDevice *devi
 #ifdef CONFIG_BT_SMP
 static int InsertBridgedDevicePincodeHandler(const struct shell *shell, size_t argc, char **argv)
 {
-	int bleDeviceIndex = strtoul(argv[0], NULL, 0);
-	unsigned int pincode = strtoul(argv[1], NULL, 10);
+	int bleDeviceIndex = strtoul(argv[1], NULL, 0);
+	unsigned int pincode = strtoul(argv[2], NULL, 10);
 
 	bt_addr_le_t address;
 	if (Nrf::BLEConnectivityManager::Instance().GetScannedDeviceAddress(&address, bleDeviceIndex) !=
@@ -277,9 +277,10 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 #ifdef CONFIG_BT_SMP
 	SHELL_CMD_ARG(pincode, NULL,
 		      "Insert pincode for Bluetooth LE device pairing. \n"
-		      "Usage: pincode <pincode>\n"
+		      "Usage: pincode <ble_device_index> <pincode>\n"
+			  "* ble_device_index - the Bluetooth LE device's index on the list returned by the scan command\n"
 		      "* pincode - is a pin required for Bluetooth LE pairing authentication\n",
-		      InsertBridgedDevicePincodeHandler, 2, 0),
+		      InsertBridgedDevicePincodeHandler, 3, 0),
 #endif /* CONFIG_BT_SMP */
 #endif /* CONFIG_BRIDGED_DEVICE_BT */
 	SHELL_SUBCMD_SET_END);


### PR DESCRIPTION
The bridge pincode command has a bug that makes it use incorrect BT index and in result does not allow to insert pincode for devices with index different than 0.