### PR TITLE
manifest: sdk-hostap: Pull fix for socket unregister

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -113,7 +113,7 @@ manifest:
     - name: hostap
       repo-path: sdk-hostap
       path: modules/lib/hostap
-      revision: c382d9819a2c6eea5cd00279f33d5abc4bbc8601
+      revision: pull/148/head
       userdata:
         ncs:
           upstream-url: https://w1.fi/cgit/hostap/


### PR DESCRIPTION
Fixes issues with stress test (SHEL-2283) where the socket is unregistered but the peer is still connected.