### PR TITLE
doc: apps and samples: filter by board in VSC

### DIFF
--- a/doc/nrf/applications.rst
+++ b/doc/nrf/applications.rst
@@ -10,6 +10,8 @@ They use interface drivers and libraries from the |NCS| and its set of repositor
 Some applications target custom hardware designed for a specific use case.
 You can also run them on different hardware like a generic development kit, but with limited functionality.
 
+If you want to list applications available for one or more specific boards, `use the nRF Connect for Visual Studio Code extension to filter them <Browse samples_>`_.
+
 .. toctree::
    :maxdepth: 1
    :glob:

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -214,6 +214,7 @@
 .. _`Memory report`: https://nrfconnect.github.io/vscode-nrf-connect/guides/memory_overview.html
 .. _`Kconfig action in the Actions View`: https://nrfconnect.github.io/vscode-nrf-connect/reference/ui_sidebar_actions.html
 .. _`Create a new application`: https://nrfconnect.github.io/vscode-nrf-connect/reference/ui_sidebar_welcome.html#create-a-new-application
+.. _`Browse samples`: https://nrfconnect.github.io/vscode-nrf-connect/reference/ui_sidebar_welcome.html#browse-samples
 
 .. _`SPAKE2+ Python Tool page`: https://project-chip.github.io/connectedhomeip-doc/scripts/tools/spake2p/README.html
 

--- a/doc/nrf/samples.rst
+++ b/doc/nrf/samples.rst
@@ -19,6 +19,8 @@ General information about samples in the |NCS|
      You can change the default behavior by updating the configuration option :kconfig:option:`CONFIG_RESET_ON_FATAL_ERROR`.
    * All samples in the |NCS| are tested and verified in accordance with their :ref:`maturity level <software_maturity>`.
 
+If you want to list samples available for one or more specific boards, `use the nRF Connect for Visual Studio Code extension to filter them <Browse samples_>`_.
+
 .. toctree::
    :maxdepth: 1
    :glob:


### PR DESCRIPTION
Added mention of the Filter by Board feature in the nRF VSC extension. VSC-2387.