### PR TITLE
samples: wifi: Fix 5GHz connection

### DIFF
--- a/samples/wifi/raw_tx_packet/src/wifi_connection.c
+++ b/samples/wifi/raw_tx_packet/src/wifi_connection.c
@@ -167,6 +167,12 @@ static int __wifi_args_to_params(struct wifi_connect_req_params *params)
 {
 	params->timeout = SYS_FOREVER_MS;
 
+	/* Defaults */
+	params->band = WIFI_FREQ_BAND_UNKNOWN;
+	params->channel = WIFI_CHANNEL_ANY;
+	params->security = WIFI_SECURITY_TYPE_NONE;
+	params->mfp = WIFI_MFP_OPTIONAL;
+
 	/* SSID */
 	params->ssid = CONFIG_RAW_TX_PACKET_SAMPLE_SSID;
 	params->ssid_length = strlen(params->ssid);
@@ -185,10 +191,6 @@ static int __wifi_args_to_params(struct wifi_connect_req_params *params)
 	params->psk = CONFIG_RAW_TX_PACKET_SAMPLE_PASSWORD;
 	params->psk_length = strlen(params->psk);
 #endif
-	params->channel = WIFI_CHANNEL_ANY;
-
-	/* MFP (optional) */
-	params->mfp = WIFI_MFP_OPTIONAL;
 
 	return 0;
 }

--- a/samples/wifi/twt/src/main.c
+++ b/samples/wifi/twt/src/main.c
@@ -341,6 +341,12 @@ static int __wifi_args_to_params(struct wifi_connect_req_params *params)
 		params->timeout = SYS_FOREVER_MS;
 	}
 
+	/* Defaults */
+	params->band = WIFI_FREQ_BAND_UNKNOWN;
+	params->channel = WIFI_CHANNEL_ANY;
+	params->security = WIFI_SECURITY_TYPE_NONE;
+	params->mfp = WIFI_MFP_OPTIONAL;
+
 	/* SSID */
 	params->ssid = CONFIG_TWT_SAMPLE_SSID;
 	params->ssid_length = strlen(params->ssid);
@@ -359,10 +365,6 @@ static int __wifi_args_to_params(struct wifi_connect_req_params *params)
 	params->psk = CONFIG_TWT_SAMPLE_PASSWORD;
 	params->psk_length = strlen(params->psk);
 #endif
-	params->channel = WIFI_CHANNEL_ANY;
-
-	/* MFP (optional) */
-	params->mfp = WIFI_MFP_OPTIONAL;
 
 	return 0;
 }


### PR DESCRIPTION
Now that WPA supplicant APIs enforce band requirement, need to properly configure the band in the connection as 0 (memset) is 2.4GHz only.