### PR TITLE
lib: modem_key_mgmt: Protect shared buffer with mutex

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -734,6 +734,10 @@ Modem libraries
   * Added the :kconfig:option:`CONFIG_AT_HOST_STACK_SIZE` Kconfig option.
     This option allows the stack size of the AT host workqueue thread to be adjusted.
 
+* :ref:`modem_key_mgmt` library:
+
+  * Fixed a potential race condition, where two threads might corrupt a shared response buffer.
+
 Libraries for networking
 ------------------------
 


### PR DESCRIPTION
Add mutex to protect the scratch_buf so it would be thread safe.