### PR TITLE
nrf_security: mbedtls: define MBEDTLS_CIPHER_C when WANT_ALG_CMAC

### DIFF
--- a/subsys/nrf_security/configs/nrf-config.h
+++ b/subsys/nrf_security/configs/nrf-config.h
@@ -64,6 +64,7 @@ extern "C" {
 /* Required for OPENTHREAD_NRF_SECURITY_PSA_CHOICE (KRKNWK-18015) */
 #if defined(PSA_WANT_ALG_CMAC)
 #define MBEDTLS_CMAC_C
+#define MBEDTLS_CIPHER_C
 #define MBEDTLS_AES_C
 #endif
 


### PR DESCRIPTION
mbedtls only requires that either AES or DES is enabled when CMAC is enabled.

But oberon requires that CIPHER is also enabled.

Fix this missing dependency to fix a check_config.h error I had at some point.

I don't know why we are translating from PSA to legacy or why ARM and Oberon have different check_config.h.

See "MBEDTLS_CMAC_C defined, but not all prerequisites" in oberon's and mbedtls's check_config.h files.