### PR TITLE
tfm: __assert.h: Fix include

### DIFF
--- a/modules/trusted-firmware-m/tfm_boards/include/zephyr/sys/__assert.h
+++ b/modules/trusted-firmware-m/tfm_boards/include/zephyr/sys/__assert.h
@@ -17,6 +17,7 @@
 
 #include <autoconf.h>
 #include "tfm_sp_log.h"
+#include "utilities.h"
 
 #ifdef CONFIG_ASSERT
 /* Use same print mode as non-secure. */


### PR DESCRIPTION
__assert.h declares the macro

\#define __ASSERT_POST_ACTION() tfm_core_panic()

which references tfm_core_panic().

But __assert.h is not including utilities.h which is the header that provides tfm_core_panic.

Fix the include dependency.