### PR TITLE
manifest: sdk-zephyr: Pull TX-Injection code changes for l2 ethernet

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: b3c97b010983e5523d90f9140b8e657b06a2ea3f
+      revision: f923004850f7ae85f2b02bf339edc69a4e9b0172
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This pull brings in changes to move tx injection into l2 ethernet. It also brings in changes to remove tx-injection and promiscuous mode from wifi shell