### PR TITLE
Remove raw tx config check for mode

### DIFF
--- a/drivers/wifi/nrf700x/CMakeLists.txt
+++ b/drivers/wifi/nrf700x/CMakeLists.txt
@@ -75,6 +75,14 @@ zephyr_library_sources_ifdef(CONFIG_NET_L2_WIFI_MGMT
   src/wifi_mgmt_scan.c
 )
 
+zephyr_library_sources_ifdef(CONFIG_NRF700X_SYSTEM_MODE
+  src/wifi_mgmt.c
+)
+
+zephyr_library_sources_ifdef(CONFIG_NRF700X_SCAN_ONLY
+  src/wifi_mgmt_scan.c
+)
+
 zephyr_library_sources_ifdef(CONFIG_NRF700X_RADIO_TEST
   ${OS_AGNOSTIC_BASE}/fw_if/umac_if/src/radio_test/fmac_api.c
   ${OS_AGNOSTIC_BASE}/fw_if/umac_if/src/fmac_util.c

--- a/drivers/wifi/nrf700x/Kconfig
+++ b/drivers/wifi/nrf700x/Kconfig
@@ -38,12 +38,14 @@ choice NRF700X_OPER_MODES
 
 config NRF700X_SYSTEM_MODE
 	bool "Enable nRF700X system mode"
+	select NET_L2_WIFI_MGMT
 	depends on WPA_SUPP
 	help
 	  Select this option to enable system mode of the nRF700x driver
 
 config NRF700X_SCAN_ONLY
 	bool "Enable nRF700X scan only mode"
+	select NET_L2_WIFI_MGMT
 	help
 	  Select this option to enable scan only mode of the nRF700x driver
 

--- a/drivers/wifi/nrf700x/inc/wifi_mgmt.h
+++ b/drivers/wifi/nrf700x/inc/wifi_mgmt.h
@@ -51,10 +51,12 @@ void nrf_wifi_event_proc_get_power_save_info(void *vif_ctx,
 		struct nrf_wifi_umac_event_power_save_info *ps_info,
 		unsigned int event_len);
 
-#ifdef CONFIG_NRF700X_RAW_DATA_TX
+#ifdef CONFIG_NRF700X_SYSTEM_MODE
 int nrf_wifi_mode(const struct device *dev,
 		  struct wifi_mode_info *mode);
+#endif
 
+#ifdef CONFIG_NRF700X_RAW_DATA_TX
 int nrf_wifi_channel(const struct device *dev,
 		     struct wifi_channel_info *channel);
 #endif /* CONFIG_NRF700X_RAW_DATA_TX */

--- a/drivers/wifi/nrf700x/src/fmac_main.c
+++ b/drivers/wifi/nrf700x/src/fmac_main.c
@@ -31,6 +31,7 @@
 #include <wifi_mgmt.h>
 #include <wpa_supp_if.h>
 #else
+#include <wifi_mgmt.h>
 #include <wifi_mgmt_scan.h>
 #endif /* CONFIG_WPA_SPP */
 #include <zephyr/net/conn_mgr_connectivity.h>
@@ -725,8 +726,10 @@ static struct wifi_mgmt_ops nrf_wifi_mgmt_ops = {
 	.reg_domain = nrf_wifi_reg_domain,
 	.get_power_save_config = nrf_wifi_get_power_save_config,
 #endif /* CONFIG_NRF700X_STA_MODE */
-#ifdef CONFIG_NRF700X_RAW_DATA_TX
+#ifdef CONFIG_NRF700X_SYSTEM_MODE
 	.mode = nrf_wifi_mode,
+#endif
+#ifdef CONFIG_NRF700X_RAW_DATA_TX
 	.channel = nrf_wifi_channel,
 #endif /* CONFIG_NRF700X_RAW_DATA_TX */
 };

--- a/drivers/wifi/nrf700x/src/wifi_mgmt.c
+++ b/drivers/wifi/nrf700x/src/wifi_mgmt.c
@@ -685,7 +685,7 @@ void nrf_wifi_event_proc_twt_sleep_zep(void *vif_ctx,
 	}
 }
 
-#ifdef CONFIG_NRF700X_RAW_DATA_TX
+#ifdef CONFIG_NRF700X_SYSTEM_MODE
 int nrf_wifi_mode(const struct device *dev,
 		  struct wifi_mode_info *mode)
 {
@@ -744,7 +744,9 @@ int nrf_wifi_mode(const struct device *dev,
 out:
 	return ret;
 }
+#endif
 
+#ifdef CONFIG_NRF700X_RAW_DATA_TX
 int nrf_wifi_channel(const struct device *dev,
 		     struct wifi_channel_info *channel)
 {

--- a/west.yml
+++ b/west.yml
@@ -142,7 +142,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: a9a80f315618c78a68c3f7d917de0db182ac121d
+      revision: 328ce793412e18315e4871c574e2ba823982d24d
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
This code removes CONFIG_NRF700X_RAW_DATA_TX for setting mode.