### PR TITLE
samples: matter: Fix device state updating

### DIFF
--- a/applications/matter_weather_station/src/app_task.cpp
+++ b/applications/matter_weather_station/src/app_task.cpp
@@ -300,6 +300,10 @@ void AppTask::UpdateLedState()
 		return;
 	}
 
+	Instance().mGreenLED->Set(false);
+	Instance().mBlueLED->Set(false);
+	Instance().mRedLED->Set(false);
+
 	switch (Nrf::GetBoard().GetDeviceState()) {
 	case Nrf::DeviceState::DeviceAdvertisingBLE:
 		Instance().mBlueLED->Blink(Nrf::LedConsts::StatusLed::Disconnected::kOn_ms,

--- a/samples/matter/common/src/board/board.cpp
+++ b/samples/matter/common/src/board/board.cpp
@@ -72,7 +72,6 @@ void Board::UpdateDeviceState(DeviceState state)
 {
 	if (mState != state) {
 		mState = state;
-		ResetAllLeds();
 		mLedStateHandler();
 	}
 }


### PR DESCRIPTION
In the UpdateDeviceState there was a mistake because we should not reset all LEDs in each state update.