### PR TITLE
samples: cellular: modem_shell: Add support for counting pulses

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -340,6 +340,7 @@ Cellular samples
     * Support for full modem FOTA.
     * Printing of the last reset reason when the sample starts.
     * Support for printing the sample version information using the ``version`` command.
+    * Support for counting pulses from a GPIO pin using the ``gpio_count`` command.
 
   * Removed the nRF7002 EK devicetree overlay file :file:`nrf91xxdk_with_nrf7002ek.overlay`, because UART1 is disabled through the shield configuration.
 

--- a/samples/cellular/modem_shell/CMakeLists.txt
+++ b/samples/cellular/modem_shell/CMakeLists.txt
@@ -33,6 +33,7 @@ add_subdirectory_ifdef(CONFIG_MOSH_PPP src/ppp)
 add_subdirectory_ifdef(CONFIG_MOSH_FOTA src/fota)
 add_subdirectory_ifdef(CONFIG_MOSH_REST src/rest)
 add_subdirectory_ifdef(CONFIG_MOSH_STARTUP_CMDS src/startup_cmd)
+add_subdirectory_ifdef(CONFIG_MOSH_GPIO_COUNT src/gpio_count)
 add_subdirectory_ifdef(CONFIG_NRF_MODEM_LIB_TRACE src/modem_trace)
 add_subdirectory(src/cloud)
 

--- a/samples/cellular/modem_shell/Kconfig
+++ b/samples/cellular/modem_shell/Kconfig
@@ -115,6 +115,13 @@ config MOSH_AT_CMD_MODE
 	bool "Specific AT command mode"
 	default y
 
+config MOSH_GPIO_COUNT
+	bool "GPIO pin pulse counter"
+	default n if BOARD_THINGY91_NRF9160_NS
+	default y
+	help
+	  Tool for counting the number of pulses on a GPIO pin.
+
 config MOSH_PRINT_BUFFER_SIZE
 	int "Buffer size used when printing modem shell output"
 	default 1024

--- a/samples/cellular/modem_shell/README.rst
+++ b/samples/cellular/modem_shell/README.rst
@@ -716,6 +716,8 @@ Examples
 Sleep
 =====
 
+MoSh command: ``sleep``
+
 When pipelining commands using ``th pipeline``, you can use the ``sleep`` command to pause the execution for a given period to allow previous command to return before executing next one.
 See :ref:`pipelining_commands` for usage.
 
@@ -784,6 +786,8 @@ Examples
 UART
 ====
 
+MoSh command: ``uart``
+
 Disable UARTs for power measurement purposes.
 
 * Disable UARTs for 30 seconds:
@@ -803,7 +807,9 @@ Disable UARTs for power measurement purposes.
 Heap usage statistics
 =====================
 
-You can use the ``heap`` command to print kernel and system heap usage statistics.
+MoSh command: ``heap``
+
+You can use the command to print kernel and system heap usage statistics.
 
   .. code-block:: console
 
@@ -818,6 +824,33 @@ You can use the ``heap`` command to print kernel and system heap usage statistic
      size:              248
      free:              160
      allocated:          88
+
+----
+
+GPIO pin pulse counter
+======================
+
+MoSh command: ``gpio_count``
+
+You can use the command to count pulses on a given GPIO pin.
+A rising edge of the signal is counted as a pulse.
+Pulse counting can be enabled only for a single pin at a time.
+When pulse counting is enabled, **LED 2** on the nRF91 Series DKs shows the state of the pin input.
+
+.. note::
+
+   The ``gpio_count enable`` command configures the GPIO pin as input and enables pull down.
+
+.. code-block:: console
+
+   mosh:~$ gpio_count get
+   Number of pulses: 0
+   mosh:~$ gpio_count enable 10
+   mosh:~$ gpio_count get
+   Number of pulses: 42
+   mosh:~$ gpio_count disable
+   mosh:~$ gpio_count get
+   Number of pulses: 42
 
 Configuration
 *************
@@ -899,6 +932,11 @@ CONFIG_MOSH_CLOUD_MQTT
 CONFIG_MOSH_AT_CMD_MODE
    Enable AT command mode feature in modem shell.
 
+.. _CONFIG_MOSH_GPIO_COUNT:
+
+CONFIG_MOSH_GPIO_COUNT
+   Enable GPIO pin pulse counter feature in modem shell.
+
 .. note::
    You may not be able to use all features at the same time due to memory restrictions.
    To see which features are enabled simultaneously, check the configuration files and overlays.
@@ -943,6 +981,8 @@ The LEDs have the following functions:
 
 LED 1 (nRF91 Series DKs)/Purple LED (Thingy:91):
    Lit for five seconds when the current location has been successfully retrieved by using the ``location get`` command.
+LED 2 (nRF91 Series DKs):
+   Indicates the state of the GPIO pin when pulse counting has been enabled using the ``gpio_count enable`` command.
 LED 3 (nRF91 Series DKs)/Blue LED (Thingy:91):
    Indicates the LTE registration status.
 

--- a/samples/cellular/modem_shell/src/gpio_count/CMakeLists.txt
+++ b/samples/cellular/modem_shell/src/gpio_count/CMakeLists.txt
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+target_include_directories(app PRIVATE .)
+
+target_sources(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/gpio_count.c)
+target_sources(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/gpio_count_shell.c)

--- a/samples/cellular/modem_shell/src/gpio_count/gpio_count.c
+++ b/samples/cellular/modem_shell/src/gpio_count/gpio_count.c
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/gpio.h>
+
+#include <dk_buttons_and_leds.h>
+
+#include "mosh_defines.h"
+#include "mosh_print.h"
+
+#define GPIO_PIN_INVALID -1
+
+static const struct device *const gpio_dev = DEVICE_DT_GET(DT_NODELABEL(gpio0));
+
+static struct gpio_callback gpio_callback;
+static uint32_t gpio_pulse_count;
+static int32_t gpio_pin = GPIO_PIN_INVALID;
+
+static void gpio_handler(const struct device *port, struct gpio_callback *cb, gpio_port_pins_t pins)
+{
+	ARG_UNUSED(port);
+	ARG_UNUSED(cb);
+
+	int value;
+
+	if (gpio_pin == GPIO_PIN_INVALID || pins != gpio_callback.pin_mask) {
+		return;
+	}
+
+	value = gpio_pin_get(gpio_dev, gpio_pin);
+	if (value) {
+		gpio_pulse_count++;
+#if defined(CONFIG_DK_LIBRARY) && !defined(CONFIG_BOARD_THINGY91_NRF9160_NS)
+		dk_set_led_on(GPIO_STATUS_LED);
+	} else {
+		dk_set_led_off(GPIO_STATUS_LED);
+#endif
+	}
+}
+
+int gpio_count_enable(uint8_t pin)
+{
+	int err;
+
+	if (gpio_pin != GPIO_PIN_INVALID) {
+		mosh_error("GPIO pin pulse counting already enabled");
+
+		return -ENOEXEC;
+	}
+
+	gpio_pin = pin;
+	gpio_pulse_count = 0;
+
+	err = gpio_pin_configure(gpio_dev, gpio_pin, GPIO_INPUT | GPIO_PULL_DOWN);
+	if (err) {
+		mosh_error("Failed to configure GPIO pin, error: %d\n", err);
+
+		return -ENOEXEC;
+	}
+
+	err = gpio_pin_interrupt_configure(gpio_dev, gpio_pin, GPIO_INT_EDGE_BOTH);
+	if (err) {
+		mosh_error("Failed to configure GPIO pin interrupt, error: %d\n", err);
+
+		return -ENOEXEC;
+	}
+
+	gpio_init_callback(&gpio_callback, gpio_handler, 1U << gpio_pin);
+
+	err = gpio_add_callback(gpio_dev, &gpio_callback);
+	if (err) {
+		mosh_error("Failed to add GPIO callback, error: %d\n", err);
+
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
+
+int gpio_count_disable(void)
+{
+	int err;
+
+	if (gpio_pin == GPIO_PIN_INVALID) {
+		mosh_error("GPIO pin pulse counting not enabled");
+
+		return -ENOEXEC;
+	}
+
+	err = gpio_remove_callback(gpio_dev, &gpio_callback);
+	if (err) {
+		mosh_error("Failed to remove GPIO callback, error: %d", err);
+	}
+
+	gpio_pin = GPIO_PIN_INVALID;
+
+	return 0;
+}
+
+uint32_t gpio_count_get(void)
+{
+	return gpio_pulse_count;
+}
+
+void gpio_count_reset(void)
+{
+	gpio_pulse_count = 0;
+}

--- a/samples/cellular/modem_shell/src/gpio_count/gpio_count.h
+++ b/samples/cellular/modem_shell/src/gpio_count/gpio_count.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef MOSH_GPIO_COUNT_H
+#define MOSH_GPIO_COUNT_H
+
+#include <zephyr/types.h>
+
+int gpio_count_enable(uint8_t pin);
+int gpio_count_disable(void);
+uint32_t gpio_count_get(void);
+void gpio_count_reset(void);
+
+#endif /* MOSH_GPIO_COUNT_H */

--- a/samples/cellular/modem_shell/src/gpio_count/gpio_count_shell.c
+++ b/samples/cellular/modem_shell/src/gpio_count/gpio_count_shell.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/shell/shell.h>
+#include <zephyr/drivers/gpio.h>
+
+#include "mosh_print.h"
+#include "gpio_count.h"
+
+static int cmd_gpio_count_enable(const struct shell *shell, size_t argc, char **argv)
+{
+	int gpio_pin;
+
+	gpio_pin = atoi(argv[1]);
+	if (gpio_pin < 0 || gpio_pin >= GPIO_MAX_PINS_PER_PORT) {
+		mosh_error("Invalid pin value: %d", gpio_pin);
+
+		return -EINVAL;
+	}
+
+	return gpio_count_enable(gpio_pin);
+}
+
+static int cmd_gpio_count_disable(const struct shell *shell, size_t argc, char **argv)
+{
+	return gpio_count_disable();
+}
+
+static int cmd_gpio_count_get(const struct shell *shell, size_t argc, char **argv)
+{
+	mosh_print("Number of pulses: %d", gpio_count_get());
+
+	return 0;
+}
+
+static int cmd_gpio_count_reset(const struct shell *shell, size_t argc, char **argv)
+{
+	gpio_count_reset();
+
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_gpio_count,
+	SHELL_CMD_ARG(
+		enable, NULL,
+		"<gpio pin number>\nEnable pulse counting for a GPIO pin.",
+		cmd_gpio_count_enable, 2, 0),
+	SHELL_CMD_ARG(
+		disable, NULL,
+		"Disable pulse counting.",
+		cmd_gpio_count_disable, 1, 0),
+	SHELL_CMD_ARG(
+		get, NULL,
+		"Get the number of pulses.",
+		cmd_gpio_count_get, 1, 0),
+	SHELL_CMD_ARG(
+		reset, NULL,
+		"Reset the number of pulses.",
+		cmd_gpio_count_reset, 1, 0),
+	SHELL_SUBCMD_SET_END);
+
+SHELL_CMD_REGISTER(gpio_count, &sub_gpio_count, "Commands for GPIO pin pulse counter.",
+		   mosh_print_help_shell);

--- a/samples/cellular/modem_shell/src/mosh_defines.h
+++ b/samples/cellular/modem_shell/src/mosh_defines.h
@@ -22,6 +22,7 @@ enum mosh_signals {
 };
 
 #define LOCATION_STATUS_LED            DK_LED1
+#define GPIO_STATUS_LED                DK_LED2
 #define REGISTERED_STATUS_LED          DK_LED3
 
 #endif /* MOSH_DEFINES_H */


### PR DESCRIPTION
Added command `gpio_count` to count pulses on a GPIO pin. When pulse counting has been enabled, LED 2 on nRF91 Series DKs also shows the state of the pin input.