### PR TITLE
samples: wifi: Initialize wifi_connect_req_params structure

### DIFF
--- a/samples/wifi/raw_tx_packet/src/wifi_connection.c
+++ b/samples/wifi/raw_tx_packet/src/wifi_connection.c
@@ -196,7 +196,7 @@ static int __wifi_args_to_params(struct wifi_connect_req_params *params)
 static int wifi_connect(void)
 {
 	struct net_if *iface = NULL;
-	static struct wifi_connect_req_params cnx_params;
+	static struct wifi_connect_req_params cnx_params = { 0 };
 
 	iface = net_if_get_first_wifi();
 	if (!iface) {

--- a/samples/wifi/sr_coex/src/main.c
+++ b/samples/wifi/sr_coex/src/main.c
@@ -224,7 +224,7 @@ static int __wifi_args_to_params(struct wifi_connect_req_params *params)
 static int wifi_connect(void)
 {
 	struct net_if *iface = net_if_get_default();
-	static struct wifi_connect_req_params cnx_params;
+	static struct wifi_connect_req_params cnx_params = { 0 };
 
 	__wifi_args_to_params(&cnx_params);
 

--- a/samples/wifi/sta/src/main.c
+++ b/samples/wifi/sta/src/main.c
@@ -247,7 +247,7 @@ static int __wifi_args_to_params(struct wifi_connect_req_params *params)
 static int wifi_connect(void)
 {
 	struct net_if *iface = net_if_get_default();
-	static struct wifi_connect_req_params cnx_params;
+	static struct wifi_connect_req_params cnx_params = { 0 };
 
 	context.connected = false;
 	context.connect_result = false;

--- a/samples/wifi/twt/src/main.c
+++ b/samples/wifi/twt/src/main.c
@@ -370,7 +370,7 @@ static int __wifi_args_to_params(struct wifi_connect_req_params *params)
 static int wifi_connect(void)
 {
 	struct net_if *iface = net_if_get_default();
-	static struct wifi_connect_req_params cnx_params;
+	static struct wifi_connect_req_params cnx_params = { 0 };
 
 	context.connected = false;
 	context.connect_result = false;


### PR DESCRIPTION
This fix addresses the issue where update to the channel value was not taking effect.

Fixes SHEL-2417.