### PR TITLE
samples: matter: Add SMP DFU to template sample

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -476,6 +476,12 @@ Matter samples
 
   * Added support for `AWS IoT Core`_.
 
+* :ref:`matter_template_sample` sample:
+
+  * Added support for DFU over Bluetooth LE SMP.
+    The functionality is disabled by default.
+    To enable it, set the :kconfig:option:`CONFIG_CHIP_DFU_OVER_BT_SMP` Kconfig option to ``y``.
+
 * :ref:`matter_lock_sample` sample:
 
   * Fixed an issue that prevented nRF Toolbox for iOS in version 5.0.9 from controlling the sample using :ref:`nus_service_readme`.

--- a/samples/matter/template/CMakeLists.txt
+++ b/samples/matter/template/CMakeLists.txt
@@ -49,8 +49,13 @@ target_sources(app PRIVATE
     ${COMMON_ROOT}/src/app/matter_event_handler.cpp
 )
 
-if(CONFIG_CHIP_OTA_REQUESTOR)
+if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_TRANSPORT_BT)
     target_sources(app PRIVATE ${COMMON_ROOT}/src/dfu/ota/ota_util.cpp)
+endif()
+
+if(CONFIG_MCUMGR_TRANSPORT_BT)
+    zephyr_library_link_libraries(MCUBOOT_BOOTUTIL)
+    target_sources(app PRIVATE ${COMMON_ROOT}/src/dfu/smp/dfu_over_smp.cpp)
 endif()
 
 if(CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS)

--- a/samples/matter/template/sample.yaml
+++ b/samples/matter/template/sample.yaml
@@ -19,6 +19,15 @@ tests:
       - nrf5340dk_nrf5340_cpuapp
       - nrf7002dk_nrf5340_cpuapp
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
+  sample.matter.template.smp_dfu:
+    build_only: true
+    extra_args: CONFIG_CHIP_DFU_OVER_BT_SMP=y
+      CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS=y
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf7002dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
   sample.matter.template.mgrt_dac:
     build_only: true
     extra_args: CONFIG_CHIP_CRYPTO_PSA_MIGRATE_DAC_PRIV_KEY=y


### PR DESCRIPTION
Bluetooth LE SMP DFU has been added to the template sample, but it is disabled by default.