### PR TITLE
samples: cellular: modem_shell: Add command for changing UART baudrate

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -354,6 +354,7 @@ Cellular samples
     * Printing of the last reset reason when the sample starts.
     * Support for printing the sample version information using the ``version`` command.
     * Support for counting pulses from a GPIO pin using the ``gpio_count`` command.
+    * Support for changing shell UART baudrate using the ``uart baudrate`` command.
 
   * Removed the nRF7002 EK devicetree overlay file :file:`nrf91xxdk_with_nrf7002ek.overlay`, because UART1 is disabled through the shield configuration.
 

--- a/samples/cellular/modem_shell/README.rst
+++ b/samples/cellular/modem_shell/README.rst
@@ -788,7 +788,7 @@ UART
 
 MoSh command: ``uart``
 
-Disable UARTs for power measurement purposes.
+Disable UARTs for power measurement purposes or change shell UART baudrate.
 
 * Disable UARTs for 30 seconds:
 
@@ -801,6 +801,12 @@ Disable UARTs for power measurement purposes.
   .. code-block:: console
 
      uart during_sleep disable
+
+* Change shell UART baudrate to 921600:
+
+  .. code-block:: console
+
+     uart baudrate 921600
 
 ----
 

--- a/samples/cellular/modem_shell/src/uart/uart_shell.c
+++ b/samples/cellular/modem_shell/src/uart/uart_shell.c
@@ -12,6 +12,7 @@
 #include <zephyr/pm/device.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/shell/shell_uart.h>
+#include <zephyr/drivers/uart.h>
 #include <modem/lte_lc.h>
 #include <modem/nrf_modem_lib_trace.h>
 
@@ -155,6 +156,38 @@ static int cmd_uart_enable_when_sleep(void)
 	return 0;
 }
 
+static int cmd_uart_baudrate(const struct shell *shell, size_t argc, char **argv)
+{
+	int err;
+	int baudrate;
+	struct uart_config cfg;
+
+	baudrate = atoi(argv[1]);
+	if (baudrate < 0 || baudrate > 1000000) {
+		mosh_error("Invalid baudrate: %d", baudrate);
+
+		return -EINVAL;
+	}
+
+	err = uart_config_get(shell_uart_dev, &cfg);
+	if (err) {
+		mosh_error("Failed to read UART configuration, error: %d", err);
+
+		return -ENOEXEC;
+	}
+
+	cfg.baudrate = baudrate;
+
+	err = uart_configure(shell_uart_dev, &cfg);
+	if (err) {
+		mosh_error("Failed to set UART configuration, error: %d", err);
+
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_uart_during_sleep,
 	SHELL_CMD_ARG(enable, NULL, "Enable UARTs during sleep mode.",
@@ -179,11 +212,18 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_uart,
 		"Disable UARTs during the modem sleep mode. UARTs are re-enabled once the modem "
 		"exits sleep mode.",
 		mosh_print_help_shell),
+	SHELL_CMD_ARG(
+		baudrate,
+		NULL,
+		"<baudrate>\nSet shell UART baudrate.",
+		cmd_uart_baudrate,
+		2,
+		0),
 	SHELL_SUBCMD_SET_END
 );
 
 SHELL_CMD_REGISTER(
 	uart,
 	&sub_uart,
-	"Commands for disabling UARTs for power measurement.",
+	"Commands for disabling UARTs for power measurement and setting shell UART baudrate.",
 	mosh_print_help_shell);


### PR DESCRIPTION
Added `uart baudrate` subcommand for changing the shell UART baudrate at runtime.