### PR TITLE
drivers: wifi: Fix a crash in case Wi-Fi init fails

### DIFF
--- a/drivers/wifi/nrf700x/src/fmac_main.c
+++ b/drivers/wifi/nrf700x/src/fmac_main.c
@@ -109,7 +109,7 @@ struct nrf_wifi_vif_ctx_zep *nrf_wifi_get_vif_ctx(struct net_if *iface)
 	struct nrf_wifi_vif_ctx_zep *vif_ctx_zep = NULL;
 	struct nrf_wifi_ctx_zep *rpu_ctx = &rpu_drv_priv_zep.rpu_ctx_zep;
 
-	if (!iface || !rpu_ctx) {
+	if (!iface || !rpu_ctx || !rpu_ctx->rpu_ctx) {
 		return NULL;
 	}
 


### PR DESCRIPTION
In case Wi-Fi interface init fails and we get a multicast event, the RPU context is NULL causing a crash.

Add a NULL check for RPU context.