### PR TITLE
wifi: Fix channel selection

### DIFF
--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -276,9 +276,6 @@ int z_wpa_supplicant_connect(const struct device *dev,
 		}
 	}
 
-	/* enable and select network */
-	_wpa_cli_cmd_v("enable_network %d", resp.network_id);
-
 	if (params->channel != WIFI_CHANNEL_ANY) {
 		int freq = chan_to_freq(params->channel);
 
@@ -292,6 +289,8 @@ int z_wpa_supplicant_connect(const struct device *dev,
 			resp.network_id, freq);
 	}
 
+	/* enable and select network */
+	_wpa_cli_cmd_v("enable_network %d", resp.network_id);
 	_wpa_cli_cmd_v("select_network %d", resp.network_id);
 
 	wpa_supp_api_ctrl.dev = dev;


### PR DESCRIPTION
Enabling a network would trigger a scan. Since frequency is being set after enable_network, first scan is issued without any specific frequency.

Fixes SHEL-2417.