### PR TITLE
modules: hostap: Fix channel comparison

### DIFF
--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -207,7 +207,7 @@ static int wpa_supp_band_chan_compat(struct wpa_supplicant *wpa_s, uint8_t band,
 	}
 
 	for (i = 0; i < mode->num_channels; i++) {
-		if (mode->channels[i].freq == channel) {
+		if (mode->channels[i].chan == channel) {
 			return mode->channels[i].freq;
 		}
 	}


### PR DESCRIPTION
Due to a typo, channel and frequency were compared causing the connection to fail for any combination.