### PR TITLE
drivers: wifi: Fix crash in 2.4GHz association

### DIFF
--- a/drivers/wifi/nrf700x/src/wpa_supp_if.c
+++ b/drivers/wifi/nrf700x/src/wpa_supp_if.c
@@ -2271,8 +2271,17 @@ int nrf_wifi_wpa_supp_sta_add(void *if_priv, struct hostapd_sta_add_params *para
 	sta_info.sta_flags2.nrf_wifi_mask = sta_info.sta_flags2.nrf_wifi_set |
 		nrf_wifi_sta_flags_to_nrf(params->flags_mask);
 
-	memcpy(sta_info.ht_capability, params->ht_capabilities, sizeof(sta_info.ht_capability));
-	memcpy(sta_info.vht_capability, params->vht_capabilities, sizeof(sta_info.vht_capability));
+	if (params->ht_capabilities) {
+		memcpy(sta_info.ht_capability,
+			   params->ht_capabilities,
+			   sizeof(sta_info.ht_capability));
+	}
+
+	if (params->vht_capabilities) {
+		memcpy(sta_info.vht_capability,
+			   params->vht_capabilities,
+			   sizeof(sta_info.vht_capability));
+	}
 
 	memcpy(sta_info.mac_addr, params->addr, sizeof(sta_info.mac_addr));
 


### PR DESCRIPTION
As VHT is 5GHz only, the VHT capabilities are NULL and causes a crash, add NULL checks for both VHT and HT.