### PR TITLE
lib: location: Add LOCATION_EVT_STARTED

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -666,6 +666,9 @@ Modem libraries
 
 * :ref:`lib_location` library:
 
+  * Added the :c:enumerator:`LOCATION_EVT_STARTED` event to indicate that location request has been started.
+    This is for metrics collection purposes and sent only if the :kconfig:option:`CONFIG_LOCATION_DATA_DETAILS` Kconfig option is set.
+
   * Updated:
 
     * The use of neighbor cell measurements for cellular positioning.

--- a/include/modem/location.h
+++ b/include/modem/location.h
@@ -64,25 +64,36 @@ enum location_event_id {
 	/**
 	 * Application has indicated that getting location has been completed,
 	 * the result is not known, and the Location library does not need to care about it.
+	 *
 	 * This event can occur only if @kconfig{CONFIG_LOCATION_SERVICE_EXTERNAL} is set.
 	 */
 	LOCATION_EVT_RESULT_UNKNOWN,
 	/**
-	 * GNSS is requesting A-GNSS data. Application should obtain the data and send it to
-	 * location_agnss_data_process().
+	 * GNSS is requesting A-GNSS data.
+	 *
+	 * Application should obtain the data and send it to location_agnss_data_process().
 	 */
 	LOCATION_EVT_GNSS_ASSISTANCE_REQUEST,
 	/**
-	 * GNSS is requesting P-GPS data. Application should obtain the data and send it to
-	 * location_pgps_data_process().
+	 * GNSS is requesting P-GPS data.
+	 *
+	 * Application should obtain the data and send it to location_pgps_data_process().
 	 */
 	LOCATION_EVT_GNSS_PREDICTION_REQUEST,
 	/**
 	 * Cloud location request with neighbor cell and/or Wi-Fi access point information
-	 * is available. The application should send the information to cloud services and
-	 * then call location_cloud_location_ext_result_set().
+	 * is available.
+	 *
+	 * The application should send the information to cloud services and then call
+	 * location_cloud_location_ext_result_set().
 	 */
-	LOCATION_EVT_CLOUD_LOCATION_EXT_REQUEST
+	LOCATION_EVT_CLOUD_LOCATION_EXT_REQUEST,
+	/**
+	 * Location request has been started.
+	 *
+	 * This event is only sent if @kconfig{CONFIG_LOCATION_DATA_DETAILS} is set.
+	 */
+	LOCATION_EVT_STARTED,
 };
 
 /** Result of the external cloud location request. */
@@ -90,8 +101,10 @@ enum location_ext_result {
 	/** Cloud location request was successful. */
 	LOCATION_EXT_RESULT_SUCCESS,
 	/**
-	 * The result of the cloud location request is unknown. From the fallback functionality
-	 * perspective, this is handled similarly to @ref LOCATION_EXT_RESULT_ERROR.
+	 * The result of the cloud location request is unknown.
+	 *
+	 * From the fallback functionality perspective, this is handled similarly to
+	 * @ref LOCATION_EXT_RESULT_ERROR.
 	 */
 	LOCATION_EXT_RESULT_UNKNOWN,
 	/** Cloud location request failed. */
@@ -112,6 +125,7 @@ enum location_accuracy {
 enum location_service {
 	/**
 	 * Use any location service that has been configured to be available.
+	 *
 	 * This is useful when only one service is configured but can also be used
 	 * even if several services are available.
 	 */

--- a/samples/cellular/modem_shell/src/location/location_shell.c
+++ b/samples/cellular/modem_shell/src/location/location_shell.c
@@ -327,6 +327,9 @@ void location_ctrl_event_handler(const struct location_event_data *event_data)
 	case LOCATION_EVT_RESULT_UNKNOWN:
 		mosh_print("Location request completed, but the result is not known");
 		break;
+	case LOCATION_EVT_STARTED:
+		mosh_print("Location request has been started");
+		break;
 	default:
 		mosh_warn("Unknown event from location library, id %d", event_data->id);
 		break;


### PR DESCRIPTION
Added event when location request has been started. This is useful when collecting metrics from positioning procedure. This event is only sent when CONFIG_LOCATION_DATA_DETAILS=y