### PR TITLE
samples: lwm2m-client: Enable TLV on AVSystem overlays

### DIFF
--- a/samples/cellular/lwm2m_client/overlay-avsystem-bootstrap.conf
+++ b/samples/cellular/lwm2m_client/overlay-avsystem-bootstrap.conf
@@ -1,3 +1,7 @@
 CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP=y
 CONFIG_LWM2M_CLIENT_UTILS_SERVER="coaps://eu.iot.avsystem.cloud:5694"
 CONFIG_LWM2M_SECURITY_INSTANCE_COUNT=3
+
+# Enable TLV, AVSystem uses this as a default.
+# Can be disabled once device dialect is changed from server side.
+CONFIG_LWM2M_RW_OMA_TLV_SUPPORT=y

--- a/samples/cellular/lwm2m_client/overlay-avsystem.conf
+++ b/samples/cellular/lwm2m_client/overlay-avsystem.conf
@@ -1,1 +1,5 @@
 CONFIG_LWM2M_CLIENT_UTILS_SERVER="coaps://eu.iot.avsystem.cloud:5684"
+
+# Enable TLV, AVSystem uses this as a default.
+# Can be disabled once device dialect is changed from server side.
+CONFIG_LWM2M_RW_OMA_TLV_SUPPORT=y


### PR DESCRIPTION
AVSystem uses TLV on its default settings.