### PR TITLE
toolchain: zephyr-sdk:0.16.5

### DIFF
--- a/scripts/requirements-extra.txt
+++ b/scripts/requirements-extra.txt
@@ -1,5 +1,7 @@
 pygit2<=1.10
+Pillow>=10.2.0
 editdistance>=0.5.0
 PyGithub
-zcbor>=0.5.1
+jinja2>=3.1.3
+zcbor==0.7.0
 nrfcredstore>=1.0.0,<2

--- a/scripts/requirements-fixed.txt
+++ b/scripts/requirements-fixed.txt
@@ -71,6 +71,7 @@ nrfcredstore==1.0.0       # via -r nrf/scripts/requirements-extra.txt
 packaging==23.1           # via -r zephyr/scripts/requirements-base.txt, pytest, python-can, west
 pathspec==0.11.2          # via yamllint
 pillow==10.2.0            # via -r zephyr/scripts/requirements-extras.txt
+pkgutil-resolve-name==1.3.10  # via jsonschema
 platformdirs==3.10.0      # via pylint
 pluggy==1.3.0             # via pytest
 ply==3.11                 # via -r zephyr/scripts/requirements-build-test.txt
@@ -125,7 +126,7 @@ west==1.2.0               # via -r nrf/scripts/requirements-base.txt, -r zephyr/
 wget==3.2                 # via -r nrf/scripts/requirements-ci.txt
 wrapt==1.15.0             # via astroid, deprecated, python-can
 yamllint==1.32.0          # via -r zephyr/scripts/requirements-compliance.txt
-zcbor==0.7.0              # via -r nrf/scripts/requirements-build.txt, -r nrf/scripts/requirements-extra.txt, -r zephyr/scripts/requirements-extras.txt
+zcbor==0.8.1              # via -r nrf/scripts/requirements-build.txt, -r nrf/scripts/requirements-extra.txt, -r zephyr/scripts/requirements-extras.txt
 zipp==3.17.0              # via importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/scripts/requirements-fixed.txt
+++ b/scripts/requirements-fixed.txt
@@ -70,8 +70,7 @@ natsort==8.4.0            # via pyocd
 nrfcredstore==1.0.0       # via -r nrf/scripts/requirements-extra.txt
 packaging==23.1           # via -r zephyr/scripts/requirements-base.txt, pytest, python-can, west
 pathspec==0.11.2          # via yamllint
-pillow==10.2.0            # via -r zephyr/scripts/requirements-extras.txt
-pkgutil-resolve-name==1.3.10  # via jsonschema
+pillow==10.2.0            # via -r nrf/scripts/requirements-extra.txt, -r zephyr/scripts/requirements-extras.txt
 platformdirs==3.10.0      # via pylint
 pluggy==1.3.0             # via pytest
 ply==3.11                 # via -r zephyr/scripts/requirements-build-test.txt

--- a/scripts/requirements-fixed.txt
+++ b/scripts/requirements-fixed.txt
@@ -49,7 +49,7 @@ iniconfig==2.0.0          # via pytest
 intelhex==2.3.0           # via -r bootloader/mcuboot/scripts/requirements.txt, -r nrf/scripts/requirements-build.txt, -r zephyr/scripts/requirements-base.txt, imgtool, lpc-checksum, pyocd
 intervaltree==3.1.0       # via pyocd
 isort==5.12.0             # via pylint
-jinja2==3.1.3             # via gcovr, junit2html
+jinja2==3.1.3             # via -r nrf/scripts/requirements-extra.txt, gcovr, junit2html
 jsonschema==4.19.1        # via -r nrf/scripts/requirements-ci.txt
 jsonschema-specifications==2023.7.1  # via jsonschema
 junit2html==30.1.3        # via -r zephyr/scripts/requirements-extras.txt
@@ -126,7 +126,7 @@ west==1.2.0               # via -r nrf/scripts/requirements-base.txt, -r zephyr/
 wget==3.2                 # via -r nrf/scripts/requirements-ci.txt
 wrapt==1.15.0             # via astroid, deprecated, python-can
 yamllint==1.32.0          # via -r zephyr/scripts/requirements-compliance.txt
-zcbor==0.8.1              # via -r nrf/scripts/requirements-build.txt, -r nrf/scripts/requirements-extra.txt, -r zephyr/scripts/requirements-extras.txt
+zcbor==0.7.0              # via -r nrf/scripts/requirements-build.txt, -r nrf/scripts/requirements-extra.txt, -r zephyr/scripts/requirements-extras.txt
 zipp==3.17.0              # via importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/scripts/tools-versions-darwin.yml
+++ b/scripts/tools-versions-darwin.yml
@@ -15,8 +15,8 @@ west:
 nanopb:
   version: 0.4.6
 zephyr-sdk:
-  version: 0.16.4
-  architectures: # https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.16.4
+  version: 0.16.5
+  architectures: # https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.16.5
     - aarch64-zephyr-elf
     - x86_64-zephyr-elf
     - arm-zephyr-eabi

--- a/scripts/tools-versions-linux.yml
+++ b/scripts/tools-versions-linux.yml
@@ -17,8 +17,8 @@ gn:
 nanopb:
   version: 0.4.6
 zephyr-sdk:
-  version: 0.16.4
-  architectures: # https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.16.4
+  version: 0.16.5
+  architectures: # https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.16.5
     - aarch64-zephyr-elf
     - x86_64-zephyr-elf
     - arm-zephyr-eabi

--- a/scripts/tools-versions-win10.yml
+++ b/scripts/tools-versions-win10.yml
@@ -15,8 +15,8 @@ west:
 nanopb:
   version: 0.4.6
 zephyr-sdk:
-  version: 0.16.4
-  architectures: # https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.16.4
+  version: 0.16.5
+  architectures: # https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.16.5
     - aarch64-zephyr-elf
     - x86_64-zephyr-elf
     - arm-zephyr-eabi


### PR DESCRIPTION
toolchain: zephyr-sdk:0.16.5
pip: upgrade packages with CVE notifications

| Name      | Version | ID                  | Fix Versions |
| --------- | ------- | ------------------- | ------------ |
| gitpython | 3.1.37  | PYSEC-2024-4        | 3.1.41       |
| jinja2    | 3.1.2   | GHSA-h5c8-rqwp-cp95 | 3.1.3        |
| pillow    | 10.0.1  | GHSA-3f63-hfp8-52jq | 10.2.0       |


No fix available yet, added to whitelist. 
| Name      | Version | ID                  | Fix Versions |
| --------- | ------- | ------------------- | ------------ |
| ecdsa     | 0.18.0  | GHSA-wj6h-64fc-37mp |              |