### PR TITLE
applications: nrf5340_audio: Add direction to zbus from bt_stream

### DIFF
--- a/applications/nrf5340_audio/broadcast_source/main.c
+++ b/applications/nrf5340_audio/broadcast_source/main.c
@@ -137,6 +137,8 @@ static void le_audio_msg_sub_thread(void)
 		case LE_AUDIO_EVT_STREAMING:
 			LOG_DBG("LE audio evt streaming");
 
+			audio_system_encoder_start();
+
 			if (strm_state == STATE_STREAMING) {
 				LOG_DBG("Got streaming event in streaming state");
 				break;
@@ -151,6 +153,8 @@ static void le_audio_msg_sub_thread(void)
 
 		case LE_AUDIO_EVT_NOT_STREAMING:
 			LOG_DBG("LE audio evt not_streaming");
+
+			audio_system_encoder_stop();
 
 			if (strm_state == STATE_PAUSED) {
 				LOG_DBG("Got not_streaming event in paused state");

--- a/applications/nrf5340_audio/include/nrf5340_audio_common.h
+++ b/applications/nrf5340_audio/include/nrf5340_audio_common.h
@@ -7,6 +7,8 @@
 #ifndef _NRF5340_AUDIO_COMMON_H_
 #define _NRF5340_AUDIO_COMMON_H_
 
+#include <zephyr/bluetooth/audio/audio.h>
+
 #define ZBUS_READ_TIMEOUT_MS	K_MSEC(100)
 #define ZBUS_ADD_OBS_TIMEOUT_MS K_MSEC(200)
 
@@ -34,6 +36,7 @@ struct le_audio_msg {
 	enum le_audio_evt_type event;
 	struct bt_conn *conn;
 	struct bt_le_per_adv_sync *pa_sync;
+	enum bt_audio_dir dir;
 };
 
 struct sdu_ref_msg {

--- a/applications/nrf5340_audio/src/audio/audio_system.h
+++ b/applications/nrf5340_audio/src/audio/audio_system.h
@@ -12,69 +12,82 @@
 #include <stdint.h>
 
 /**
- * @brief Toggle a test tone on and off.
+ * @brief	Start the execution of the encoder thread.
+ */
+void audio_system_encoder_start(void);
+
+/**
+ * @brief	Stop the encoder thread from executing.
  *
- * @param[in] freq Desired frequency of tone. Off if set to 0.
+ * @note	Using this allows the encode thread to always be enabled,
+ *		but disables the execution when not needed, saving power.
+ */
+void audio_system_encoder_stop(void);
+
+/**
+ * @brief	Toggle a test tone on and off.
  *
- * @note A stream must already be running to use this feature.
+ * @note	A stream must already be running to use this feature.
  *
- * @return -ENOMEM	The frequency is too low (buffer overflow).
- * @return 0		Success.
+ * @param[in]	freq	Desired frequency of tone. Off if set to 0.
+ *
+ * @retval	-ENOMEM	The frequency is too low (buffer overflow).
+ * @retval	0	Success.
  */
 int audio_system_encode_test_tone_set(uint32_t freq);
 
 /**
- * @brief Step through different test tones.
+ * @brief	Step through different test tones.
  *
- * @note A stream must already be running to use this feature.
- * Will step through test tones: 1 kHz, 2 kHz, 4 kHz and off.
+ * @note	A stream must already be running to use this feature.
+ *		Will step through test tones: 1 kHz, 2 kHz, 4 kHz and off.
  *
- * @return 0 on success, error otherwise.
+ * @return	0 on success, error otherwise.
  */
 int audio_system_encode_test_tone_step(void);
 
 /**
- * @brief Decode data and then add it to TX FIFO buffer.
+ * @brief	Decode data and then add it to TX FIFO buffer.
  *
  * @param[in]	encoded_data		Pointer to encoded data.
  * @param[in]	encoded_data_size	Size of encoded data.
  * @param[in]	bad_frame		Indication on missed or incomplete frame.
  *
- * @return 0 on success, error otherwise.
+ * @return	0 on success, error otherwise.
  */
 int audio_system_decode(void const *const encoded_data, size_t encoded_data_size, bool bad_frame);
 
 /**
- * @brief Initialize and start both HW and SW audio codec.
+ * @brief	Initialize and start both HW and SW audio codec.
  */
 void audio_system_start(void);
 
 /**
- * @brief Stop all activities related to audio.
+ * @brief	Stop all activities related to audio.
  */
 void audio_system_stop(void);
 
 /**
- * @brief Drop oldest block from the fifo_rx buffer.
+ * @brief	Drop oldest block from the fifo_rx buffer.
  *
- * @note  This can be used to reduce latency by adjusting the timing of the completed frame
- *        that was sampled in relation to the connection interval in Bluetooth LE.
+ * @note	This can be used to reduce latency by adjusting the timing of the completed frame
+ *		that was sampled in relation to the connection interval in Bluetooth LE.
  *
- * @return 0 on success, -ECANCELED otherwise.
+ * @return	0 on success, -ECANCELED otherwise.
  */
 int audio_system_fifo_rx_block_drop(void);
 
 /**
- * @brief Get number of decoder channels
+ * @brief	Get number of decoder channels.
  *
- * @return Number of decoder channels
+ * @return	Number of decoder channels.
  */
 int audio_system_decoder_num_ch_get(void);
 
 /**
- * @brief Initialize the audio_system
+ * @brief	Initialize the audio_system.
  *
- * @return 0 on success, error otherwise.
+ * @return	0 on success, error otherwise.
  */
 int audio_system_init(void);
 

--- a/applications/nrf5340_audio/src/audio/sw_codec_select.h
+++ b/applications/nrf5340_audio/src/audio/sw_codec_select.h
@@ -52,6 +52,7 @@ struct sw_codec_encoder {
 
 struct sw_codec_decoder {
 	bool enabled;
+	bool started;
 	enum sw_codec_channel_mode channel_mode; /* Mono or stereo. */
 	uint8_t num_ch;				 /* Number of decoder channels. */
 	enum audio_channel audio_ch;		 /* Used to choose which channel to use. */

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/bt_le_audio_tx/bt_le_audio_tx.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/bt_le_audio_tx/bt_le_audio_tx.c
@@ -215,8 +215,7 @@ int bt_le_audio_tx_send(struct bt_bap_stream **bap_streams, struct le_audio_enco
 	}
 
 	if (ts_common_acquired) {
-		if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) &&
-		    !IS_ENABLED(CONFIG_STREAM_BIDIRECTIONAL)) {
+		if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT)) {
 			struct sdu_ref_msg msg;
 
 			msg.timestamp = ts_common;

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.c
@@ -7,6 +7,7 @@
 #include "le_audio.h"
 
 #include <zephyr/bluetooth/audio/bap.h>
+#include <zephyr/bluetooth/audio/audio.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(le_audio, CONFIG_BLE_LOG_LEVEL);
@@ -106,4 +107,19 @@ int le_audio_frame_blocks_per_sdu_get(const struct bt_audio_codec_cfg *codec,
 	*frame_blks_per_sdu = ret;
 
 	return 0;
+}
+
+int le_audio_stream_dir_get(struct bt_bap_stream const *const stream)
+{
+	int ret;
+	struct bt_bap_ep_info ep_info;
+
+	ret = bt_bap_ep_get_info(stream->ep, &ep_info);
+
+	if (ret) {
+		LOG_WRN("Failed to get ep_info");
+		return ret;
+	}
+
+	return ep_info.dir;
 }

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.h
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.h
@@ -111,5 +111,16 @@ int le_audio_octets_per_frame_get(const struct bt_audio_codec_cfg *codec, uint32
  */
 int le_audio_frame_blocks_per_sdu_get(const struct bt_audio_codec_cfg *codec,
 				      uint32_t *frame_blks_per_sdu);
+/*
+ * @brief	Get the direction of the @p stream provided
+ *
+ * @param	stream	Stream to check direction for.
+ *
+ * @retval	BT_AUDIO_DIR_SINK	sink direction.
+ * @retval	BT_AUDIO_DIR_SOURCE	source direction.
+ * @retval	Negative value		Failed to get ep_info from host.
+ *
+ */
+int le_audio_stream_dir_get(struct bt_bap_stream const *const stream);
 
 #endif /* _LE_AUDIO_H_ */

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_client.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_client.c
@@ -102,13 +102,15 @@ static struct bt_bap_lc3_preset lc3_preset_source = BT_BAP_LC3_UNICAST_PRESET_NR
 
 static bool playing_state = true;
 
-static void le_audio_event_publish(enum le_audio_evt_type event, struct bt_conn *conn)
+static void le_audio_event_publish(enum le_audio_evt_type event, struct bt_conn *conn,
+				   enum bt_audio_dir dir)
 {
 	int ret;
 	struct le_audio_msg msg;
 
 	msg.event = event;
 	msg.conn = conn;
+	msg.dir = dir;
 
 	ret = zbus_chan_pub(&le_audio_chan, &msg, LE_AUDIO_ZBUS_EVENT_WAIT_TIME);
 	ERR_CHK(ret);
@@ -441,7 +443,7 @@ static void unicast_client_location_cb(struct bt_conn *conn, enum bt_audio_dir d
 		}
 	} else {
 		LOG_WRN("Channel location not supported");
-		le_audio_event_publish(LE_AUDIO_EVT_NO_VALID_CFG, conn);
+		le_audio_event_publish(LE_AUDIO_EVT_NO_VALID_CFG, conn, dir);
 	}
 }
 
@@ -831,6 +833,13 @@ static void stream_enabled_cb(struct bt_bap_stream *stream)
 	int ret;
 	uint8_t channel_index;
 	struct worker_data work_data;
+	enum bt_audio_dir dir;
+
+	dir = le_audio_stream_dir_get(stream);
+	if (dir <= 0) {
+		LOG_ERR("Failed to get dir of stream %p", stream);
+		return;
+	}
 
 	LOG_DBG("Stream enabled: %p", stream);
 
@@ -840,7 +849,7 @@ static void stream_enabled_cb(struct bt_bap_stream *stream)
 		return;
 	}
 
-	if (stream->ep->dir == BT_AUDIO_DIR_SINK &&
+	if (dir == BT_AUDIO_DIR_SINK &&
 	    le_audio_ep_state_check(headsets[channel_index].sink_stream.ep,
 				    BT_BAP_EP_STATE_ENABLING)) {
 		if (!k_work_delayable_is_pending(&headsets[channel_index].stream_start_sink_work)) {
@@ -861,7 +870,7 @@ static void stream_enabled_cb(struct bt_bap_stream *stream)
 		}
 	}
 
-	if (stream->ep->dir == BT_AUDIO_DIR_SOURCE &&
+	if (dir == BT_AUDIO_DIR_SOURCE &&
 	    le_audio_ep_state_check(headsets[channel_index].source_stream.ep,
 				    BT_BAP_EP_STATE_ENABLING)) {
 		if (!k_work_delayable_is_pending(
@@ -889,6 +898,13 @@ static void stream_started_cb(struct bt_bap_stream *stream)
 {
 	int ret;
 	uint8_t channel_index;
+	enum bt_audio_dir dir;
+
+	dir = le_audio_stream_dir_get(stream);
+	if (dir <= 0) {
+		LOG_ERR("Failed to get dir of stream %p", stream);
+		return;
+	}
 
 	ret = channel_index_get(stream->conn, &channel_index);
 	if (ret) {
@@ -900,7 +916,7 @@ static void stream_started_cb(struct bt_bap_stream *stream)
 	/* NOTE: The string below is used by the Nordic CI system */
 	LOG_INF("Stream %p started", (void *)stream);
 
-	le_audio_event_publish(LE_AUDIO_EVT_STREAMING, stream->conn);
+	le_audio_event_publish(LE_AUDIO_EVT_STREAMING, stream->conn, dir);
 }
 
 static void stream_metadata_updated_cb(struct bt_bap_stream *stream)
@@ -932,12 +948,14 @@ static void stream_stopped_cb(struct bt_bap_stream *stream, uint8_t reason)
 	if (stream == &headsets[AUDIO_CH_L].sink_stream) {
 		if (!le_audio_ep_state_check(headsets[AUDIO_CH_R].sink_stream.ep,
 					     BT_BAP_EP_STATE_STREAMING)) {
-			le_audio_event_publish(LE_AUDIO_EVT_NOT_STREAMING, stream->conn);
+			le_audio_event_publish(LE_AUDIO_EVT_NOT_STREAMING, stream->conn,
+					       BT_AUDIO_DIR_SINK);
 		}
 	} else if (stream == &headsets[AUDIO_CH_R].sink_stream) {
 		if (!le_audio_ep_state_check(headsets[AUDIO_CH_L].sink_stream.ep,
 					     BT_BAP_EP_STATE_STREAMING)) {
-			le_audio_event_publish(LE_AUDIO_EVT_NOT_STREAMING, stream->conn);
+			le_audio_event_publish(LE_AUDIO_EVT_NOT_STREAMING, stream->conn,
+					       BT_AUDIO_DIR_SINK);
 		}
 	} else {
 		LOG_WRN("Unknown stream");
@@ -952,14 +970,16 @@ static void stream_released_cb(struct bt_bap_stream *stream)
 	if (stream == &headsets[AUDIO_CH_L].sink_stream) {
 		if (!le_audio_ep_state_check(headsets[AUDIO_CH_R].sink_stream.ep,
 					     BT_BAP_EP_STATE_STREAMING)) {
-			le_audio_event_publish(LE_AUDIO_EVT_NOT_STREAMING, stream->conn);
+			le_audio_event_publish(LE_AUDIO_EVT_NOT_STREAMING, stream->conn,
+					       BT_AUDIO_DIR_SINK);
 		}
 
 		LOG_DBG("Left sink stream released");
 	} else if (stream == &headsets[AUDIO_CH_R].sink_stream) {
 		if (!le_audio_ep_state_check(headsets[AUDIO_CH_L].sink_stream.ep,
 					     BT_BAP_EP_STATE_STREAMING)) {
-			le_audio_event_publish(LE_AUDIO_EVT_NOT_STREAMING, stream->conn);
+			le_audio_event_publish(LE_AUDIO_EVT_NOT_STREAMING, stream->conn,
+					       BT_AUDIO_DIR_SINK);
 		}
 
 		LOG_DBG("Right sink stream released");
@@ -1042,9 +1062,10 @@ static void work_stream_start(struct k_work *work)
 			ret = bt_bap_stream_start(&headsets[work_data.channel_index].source_stream);
 		}
 	} else {
-		LOG_ERR("Trying to use unknown direction");
+		LOG_ERR("Trying to use unknown direction: %d", work_data.dir);
 		le_audio_event_publish(LE_AUDIO_EVT_NO_VALID_CFG,
-				       headsets[work_data.channel_index].headset_conn);
+				       headsets[work_data.channel_index].headset_conn,
+				       work_data.dir);
 
 		return;
 	}
@@ -1076,7 +1097,8 @@ static void work_stream_start(struct k_work *work)
 		 * possible to start stream
 		 */
 		le_audio_event_publish(LE_AUDIO_EVT_NO_VALID_CFG,
-				       headsets[work_data.channel_index].headset_conn);
+				       headsets[work_data.channel_index].headset_conn,
+				       work_data.dir);
 	}
 }
 
@@ -1174,7 +1196,7 @@ int unicast_client_stop(void)
 	int ret_left = 0;
 	int ret_right = 0;
 
-	le_audio_event_publish(LE_AUDIO_EVT_NOT_STREAMING, NULL);
+	le_audio_event_publish(LE_AUDIO_EVT_NOT_STREAMING, NULL, 0);
 
 	if (le_audio_ep_state_check(headsets[AUDIO_CH_L].sink_stream.ep,
 				    BT_BAP_EP_STATE_STREAMING)) {

--- a/applications/nrf5340_audio/unicast_client/main.c
+++ b/applications/nrf5340_audio/unicast_client/main.c
@@ -23,7 +23,7 @@
 #include "le_audio_rx.h"
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(streamctrl_unicast_client, CONFIG_STREAMCTRL_LOG_LEVEL);
+LOG_MODULE_REGISTER(main, CONFIG_MAIN_LOG_LEVEL);
 
 static enum stream_state strm_state = STATE_PAUSED;
 
@@ -225,6 +225,10 @@ static void le_audio_msg_sub_thread(void)
 				break;
 			}
 
+			if (msg.dir == BT_AUDIO_DIR_SINK) {
+				audio_system_encoder_start();
+			}
+
 			audio_system_start();
 			stream_state_set(STATE_STREAMING);
 
@@ -238,6 +242,10 @@ static void le_audio_msg_sub_thread(void)
 			if (strm_state == STATE_PAUSED) {
 				LOG_DBG("Got not_streaming event in paused state");
 				break;
+			}
+
+			if (msg.dir == BT_AUDIO_DIR_SINK) {
+				audio_system_encoder_stop();
 			}
 
 			stream_state_set(STATE_PAUSED);

--- a/applications/nrf5340_audio/unicast_server/main.c
+++ b/applications/nrf5340_audio/unicast_server/main.c
@@ -25,7 +25,7 @@
 #include "le_audio_rx.h"
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(streamctrl_unicast_server, CONFIG_STREAMCTRL_LOG_LEVEL);
+LOG_MODULE_REGISTER(main, CONFIG_MAIN_LOG_LEVEL);
 
 ZBUS_SUBSCRIBER_DEFINE(button_evt_sub, CONFIG_BUTTON_MSG_SUB_QUEUE_SIZE);
 
@@ -187,6 +187,10 @@ static void le_audio_msg_sub_thread(void)
 		case LE_AUDIO_EVT_STREAMING:
 			LOG_DBG("LE audio evt streaming");
 
+			if (msg.dir == BT_AUDIO_DIR_SOURCE) {
+				audio_system_encoder_start();
+			}
+
 			if (strm_state == STATE_STREAMING) {
 				LOG_DBG("Got streaming event in streaming state");
 				break;
@@ -205,6 +209,10 @@ static void le_audio_msg_sub_thread(void)
 			if (strm_state == STATE_PAUSED) {
 				LOG_DBG("Got not_streaming event in paused state");
 				break;
+			}
+
+			if (msg.dir == BT_AUDIO_DIR_SOURCE) {
+				audio_system_encoder_stop();
 			}
 
 			stream_state_set(STATE_PAUSED);


### PR DESCRIPTION
- Send direction from bt_stream to main.
- Differentiate between timestamp used for pres and drift compensation
- Change log in main files to prefix main
- Add helper function for getting stream direction
- Turn on just-in-time for bidirectional gateways

- OCT-2875