### PR TITLE
subsys: dfu: dfu_target: fix reset of uninitialized targets

### DIFF
--- a/subsys/dfu/dfu_target/src/dfu_target.c
+++ b/subsys/dfu/dfu_target/src/dfu_target.c
@@ -177,6 +177,8 @@ int dfu_target_reset(void)
 		return err;
 	}
 
+	current_target = NULL;
+
 	return 0;
 }
 

--- a/subsys/dfu/dfu_target/src/dfu_target_stream.c
+++ b/subsys/dfu/dfu_target/src/dfu_target_stream.c
@@ -219,16 +219,23 @@ int dfu_target_stream_done(bool successful)
 
 int dfu_target_stream_reset(void)
 {
-	int ret;
+	int err;
 
 	stream.buf_bytes = 0;
 	stream.bytes_written = 0;
 
+	/* No flash device specified, nothing to erase. */
+	if (stream.fdev == NULL) {
+		current_id = NULL;
+		return 0;
+	}
+
 	/* Erase just the first page. Stream write will take care of erasing remaining pages
 	 * on a next buffered_write round
 	 */
-	ret = stream_flash_erase_page(&stream, stream.offset);
+	err = stream_flash_erase_page(&stream, stream.offset);
 
 	current_id = NULL;
-	return ret;
+
+	return err;
 }


### PR DESCRIPTION
* Unset the current DFU target on successful reset.
* Do not trigger a flash erase if stream reset is triggered on an unspecified flash device. This can happen after reset is done on a DFU target that failed to initialize properly.