### PR TITLE
samples: cellular: mss: Deactivate GNSS during provisioning

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -371,6 +371,7 @@ Cellular samples
     * A generic processing example for application-specific shadow data.
     * Configuration and overlay files to enable MCUboot to use the external flash on the nRF1961 DK.
     * A :kconfig:option:`CONFIG_COAP_ALWAYS_CONFIRM` Kconfig option to select CON or NON CoAP transfers for functions that previously used NON transfers only.
+    * Support for the :ref:`lib_nrf_provisioning` library.
 
   * Fixed:
 


### PR DESCRIPTION
Deactivate GNSS during certificate installation so that modem does not reject installation commands. This can sometimes happen if GNSS is not explicitly disabled and is in use prior to the cert installation provisioning command execution.

IRIS-8139