### PR TITLE
Bluetooth: Controller: add vs tx timestamp support

### DIFF
--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -663,6 +663,9 @@ static void vs_supported_commands(sdc_hci_vs_supported_vs_commands_t *cmds)
 #if defined(CONFIG_BT_CONN)
 	cmds->min_val_of_max_acl_tx_payload_set = 1;
 #endif
+#if defined(CONFIG_BT_CTLR_ISO_TX_BUFFERS)
+	cmds->iso_read_tx_timestamp = 1;
+#endif
 }
 #endif	/* CONFIG_BT_HCI_VS */
 
@@ -1602,6 +1605,13 @@ static uint8_t vs_cmd_put(uint8_t const *const cmd, uint8_t *const raw_event_out
 	case SDC_HCI_OPCODE_CMD_VS_MIN_VAL_OF_MAX_ACL_TX_PAYLOAD_SET:
 		return sdc_hci_cmd_vs_min_val_of_max_acl_tx_payload_set((void *)cmd_params);
 #endif
+#if defined(CONFIG_BT_CTLR_ISO_TX_BUFFERS)
+	case SDC_HCI_OPCODE_CMD_VS_ISO_READ_TX_TIMESTAMP:
+		*param_length_out += sizeof(sdc_hci_cmd_vs_iso_read_tx_timestamp_return_t);
+		return sdc_hci_cmd_vs_iso_read_tx_timestamp(
+			(sdc_hci_cmd_vs_iso_read_tx_timestamp_t const *)cmd_params,
+			(sdc_hci_cmd_vs_iso_read_tx_timestamp_return_t *)event_out_params);
+#endif /* CONFIG_BT_CTLR_ISO_TX_BUFFERS */
 	default:
 		return BT_HCI_ERR_UNKNOWN_CMD;
 	}


### PR DESCRIPTION
Add support for vendor specific hci command iso_read_tx_timestamp.