### PR TITLE
applications: nrf5340_audio: Enable CONFIG_BT_AUDIO_USE_BROADCAST_NAME_ALT

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/broadcast_source.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/broadcast_source.c
@@ -215,8 +215,15 @@ static int adv_create(void)
 		broadcast_id = CONFIG_BT_AUDIO_BROADCAST_ID_FIXED;
 	}
 
-	ext_ad[0] = (struct bt_data)BT_DATA(BT_DATA_BROADCAST_NAME, CONFIG_BT_AUDIO_BROADCAST_NAME,
-					    sizeof(CONFIG_BT_AUDIO_BROADCAST_NAME) - 1);
+	if (IS_ENABLED(CONFIG_BT_AUDIO_USE_BROADCAST_NAME_ALT)) {
+		ext_ad[0] = (struct bt_data)BT_DATA(BT_DATA_BROADCAST_NAME,
+						    CONFIG_BT_AUDIO_BROADCAST_NAME_ALT,
+						    sizeof(CONFIG_BT_AUDIO_BROADCAST_NAME_ALT) - 1);
+	} else {
+		ext_ad[0] = (struct bt_data)BT_DATA(BT_DATA_BROADCAST_NAME,
+						    CONFIG_BT_AUDIO_BROADCAST_NAME,
+						    sizeof(CONFIG_BT_AUDIO_BROADCAST_NAME) - 1);
+	}
 
 	/* Setup extended advertising data */
 	net_buf_simple_add_le16(&brdcst_id_buf, BT_UUID_BROADCAST_AUDIO_VAL);


### PR DESCRIPTION

- Replace missing code for setting alternate name for broadcaster