### PR TITLE
net: lib: download_client: Only forward full buffers to app

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -777,6 +777,7 @@ Libraries for networking
 
     * IPv6 support changed from compile time to runtime, and is default enabled.
     * IPv6 to IPv4 fallback is done when both DNS request and TCP/TLS connect fails.
+    * HTTP downloads forward data fragments to a callback only when the buffer is full.
 
   * Removed:
 

--- a/subsys/net/lib/download_client/src/download_client.c
+++ b/subsys/net/lib/download_client/src/download_client.c
@@ -695,11 +695,9 @@ static int handle_received(struct download_client *dl, ssize_t len)
 	if (dl->proto == IPPROTO_TCP || dl->proto == IPPROTO_TLS_1_2) {
 		rc = http_parse(dl, len);
 		if (rc > 0 &&
-		    (IS_ENABLED(CONFIG_DOWNLOAD_CLIENT_RANGE_REQUESTS) || !dl->http.has_header)) {
-			/* Wait for more data (fragment/header).
-			 * Unranged request (normal GET) should start forwarding the data
-			 * once HTTP headers are received. Ranged-GET should receive full
-			 * buffer(fragment) before sending an event.
+		    (!dl->http.has_header || dl->offset < sizeof(dl->buf))) {
+			/* Wait for more data (full buffer).
+			 * Forward only full buffers to callback.
 			 */
 			return 1;
 		}


### PR DESCRIPTION
When receiving data from HTTP stream, we might end up in a situation where we have received just few bytes more than an HTTP header.
Forwarding too little data to the callback may cause problems on libraries that try to detect the download type from the first bytes.
Prevent this by always trying to fetch full buffer, until we forward that to the callback.