### PR TITLE
doc: Zigbee: orphan ZCL clusters page

### DIFF
--- a/doc/nrf/protocols/zigbee/adding_clusters.rst
+++ b/doc/nrf/protocols/zigbee/adding_clusters.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _ug_zigee_adding_clusters:
 
 Adding ZCL clusters to application

--- a/doc/nrf/protocols/zigbee/index.rst
+++ b/doc/nrf/protocols/zigbee/index.rst
@@ -33,6 +33,5 @@ See also :ref:`zigbee_samples` for the list of available Zigbee samples and :ref
    configuring
    configuring_libraries
    configuring_zboss_traces
-   adding_clusters
    other_ecosystems
    tools


### PR DESCRIPTION
The Adding ZCL clusters to application page in the Zigbee documentation has been outdated for some while now. This orphans the page so it isn't visible in the table of contents until the page can be updated.