### PR TITLE
doc: wifi: remove "experimental" comment from Radio sample

### DIFF
--- a/samples/wifi/radio_test/radio_test_subcommands.rst
+++ b/samples/wifi/radio_test/radio_test_subcommands.rst
@@ -226,7 +226,7 @@ Wi-Fi radio test subcommands
      - N/A
      - N/A
      - Action
-     - Compute optimal XO value. Note: This is still experimental and to be used at own risk.
+     - Compute optimal XO trim value.
    * - get_stats
      - N/A
      - N/A


### PR DESCRIPTION
Remove the "Experimental" comment from compute_optimal_xo_val description.

SHEL-2429