### PR TITLE
net: lwm2m_client_utils: use modem_info to find HW version

### DIFF
--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_adv_firmware.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_adv_firmware.c
@@ -564,7 +564,7 @@ int lwm2m_adv_firmware_create_inst(const char *component, lwm2m_engine_set_data_
 		return ret;
 	}
 
-	len = strlen(component);
+	len = strlen(component) + 1;
 	ret = lwm2m_set_res_buf(&LWM2M_OBJ(LWM2M_OBJECT_ADV_FIRMWARE_ID, idx,
 				FIRMWARE_COMPONENT_NAME_ID), (void *)component, len, len,
 				LWM2M_RES_DATA_FLAG_RO);

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
@@ -15,6 +15,7 @@
 #include <zephyr/net/lwm2m.h>
 #include <modem/nrf_modem_lib.h>
 #include <modem/modem_key_mgmt.h>
+#include <modem/modem_info.h>
 #include <net/fota_download.h>
 #include <fota_download_util.h>
 #include <lwm2m_util.h>
@@ -1266,8 +1267,13 @@ int lwm2m_init_firmware_cb(lwm2m_firmware_event_cb_t cb)
 		"application", firmware_block_received_cb, firmware_update_cb);
 	lwm2m_firmware_object_setup_init(application_obj_id);
 
-	modem_obj_id = lwm2m_adv_firmware_create_inst(
-		"modem:" CONFIG_SOC, firmware_block_received_cb, firmware_update_cb);
+	static char hw_buf[sizeof("modem:nRF91__ ____ ___ ")];
+
+	strcat(hw_buf, "modem:");
+	modem_info_get_hw_version(hw_buf + strlen("modem:"), sizeof(hw_buf) - strlen("modem:"));
+
+	modem_obj_id = lwm2m_adv_firmware_create_inst(hw_buf, firmware_block_received_cb,
+						      firmware_update_cb);
 	lwm2m_firmware_object_setup_init(modem_obj_id);
 
 	lwm2m_adv_modem_firmware_versions_set();

--- a/tests/subsys/net/lib/lwm2m_fota_utils/src/stubs.c
+++ b/tests/subsys/net/lib/lwm2m_fota_utils/src/stubs.c
@@ -55,6 +55,7 @@ DEFINE_FAKE_VALUE_FUNC(int, modem_info_init);
 DEFINE_FAKE_VALUE_FUNC(int, modem_info_params_init, struct modem_param_info *);
 DEFINE_FAKE_VALUE_FUNC(int, modem_info_params_get, struct modem_param_info *);
 DEFINE_FAKE_VALUE_FUNC(int, modem_info_rsrp_register, rsrp_cb_t);
+DEFINE_FAKE_VALUE_FUNC(int, modem_info_get_hw_version, char *, uint8_t);
 DEFINE_FAKE_VOID_FUNC(engine_trigger_update, bool);
 DEFINE_FAKE_VALUE_FUNC(int, dfu_target_mcuboot_set_buf, uint8_t *, size_t);
 DEFINE_FAKE_VALUE_FUNC(int, nrf_modem_lib_shutdown);

--- a/tests/subsys/net/lib/lwm2m_fota_utils/src/stubs.h
+++ b/tests/subsys/net/lib/lwm2m_fota_utils/src/stubs.h
@@ -51,6 +51,7 @@ DECLARE_FAKE_VOID_FUNC(engine_trigger_update, bool);
 DECLARE_FAKE_VALUE_FUNC(int, modem_info_init);
 DECLARE_FAKE_VALUE_FUNC(int, modem_info_params_init, struct modem_param_info *);
 DECLARE_FAKE_VALUE_FUNC(int, modem_info_params_get, struct modem_param_info *);
+DECLARE_FAKE_VALUE_FUNC(int, modem_info_get_hw_version, char *, uint8_t);
 DECLARE_FAKE_VALUE_FUNC(int, lte_lc_lte_mode_get, enum lte_lc_lte_mode *);
 DECLARE_FAKE_VALUE_FUNC(int, modem_info_rsrp_register, rsrp_cb_t);
 DECLARE_FAKE_VALUE_FUNC(int, dfu_target_mcuboot_set_buf, uint8_t *, size_t);
@@ -92,6 +93,7 @@ DECLARE_FAKE_VALUE_FUNC(int, fota_download_util_download_cancel);
 DECLARE_FAKE_VALUE_FUNC(int, fota_download_util_image_schedule, enum dfu_target_image_type);
 DECLARE_FAKE_VALUE_FUNC(int, fota_download_util_image_reset, enum dfu_target_image_type);
 DECLARE_FAKE_VALUE_FUNC(int, fota_download_util_apply_update, enum dfu_target_image_type);
+
 
 /* List of fakes used by this unit tester */
 #define DO_FOREACH_FAKE(FUNC)                                                                      \
@@ -155,13 +157,14 @@ DECLARE_FAKE_VALUE_FUNC(int, fota_download_util_apply_update, enum dfu_target_im
 		FUNC(lwm2m_notify_observer_path)                                                   \
 		FUNC(engine_remove_observer_by_id)                                                 \
 		FUNC(lwm2m_firmware_start_transfer)                                                \
-		FUNC(fota_download_util_stream_init)                                             \
-		FUNC(fota_download_util_dfu_target_init)                                         \
-		FUNC(fota_download_util_download_start)                                          \
-		FUNC(fota_download_util_download_cancel)                                         \
-		FUNC(fota_download_util_image_schedule)                                          \
-		FUNC(fota_download_util_image_reset)                                             \
-		FUNC(fota_download_util_apply_update)                                            \
+		FUNC(fota_download_util_stream_init)                                               \
+		FUNC(fota_download_util_dfu_target_init)                                           \
+		FUNC(fota_download_util_download_start)                                            \
+		FUNC(fota_download_util_download_cancel)                                           \
+		FUNC(fota_download_util_image_schedule)                                            \
+		FUNC(fota_download_util_image_reset)                                               \
+		FUNC(fota_download_util_apply_update)                                              \
+		FUNC(modem_info_get_hw_version)                                                    \
 	} while (0)
 
 #endif


### PR DESCRIPTION
In LwM2M Device object, as well as Advanced firmware object, we have modem hardware type visible.
Query this information from modem_info library, instead of using build-in values.
This allows same FW to run on 9161 and 9151 and we still see from server side which HW is used.