### PR TITLE
applications: Fixed onoff light switch in Matter bridge

### DIFF
--- a/applications/matter_bridge/sample.yaml
+++ b/applications/matter_bridge/sample.yaml
@@ -5,23 +5,31 @@ tests:
   applications.matter_bridge.release:
     build_only: true
     extra_args: CONF_FILE=prj_release.conf
+      CONFIG_BRIDGE_GENERIC_SWITCH_BRIDGED_DEVICE=n
+      CONFIG_BRIDGE_ONOFF_LIGHT_SWITCH_BRIDGED_DEVICE=y
     integration_platforms:
       - nrf7002dk_nrf5340_cpuapp
     platform_allow: nrf7002dk_nrf5340_cpuapp
   applications.matter_bridge.debug:
     build_only: true
+    extra_args: CONFIG_BRIDGE_GENERIC_SWITCH_BRIDGED_DEVICE=n
+      CONFIG_BRIDGE_ONOFF_LIGHT_SWITCH_BRIDGED_DEVICE=y
     integration_platforms:
       - nrf7002dk_nrf5340_cpuapp
     platform_allow: nrf7002dk_nrf5340_cpuapp
   applications.matter_bridge.release.br_ble:
     build_only: true
     extra_args: CONF_FILE=prj_release.conf CONFIG_BRIDGED_DEVICE_BT=y
+      CONFIG_BRIDGE_GENERIC_SWITCH_BRIDGED_DEVICE=n
+      CONFIG_BRIDGE_ONOFF_LIGHT_SWITCH_BRIDGED_DEVICE=y
     integration_platforms:
       - nrf7002dk_nrf5340_cpuapp
     platform_allow: nrf7002dk_nrf5340_cpuapp
   applications.matter_bridge.smp_dfu.br_ble:
     build_only: true
     extra_args: CONFIG_CHIP_DFU_OVER_BT_SMP=y CONFIG_BRIDGED_DEVICE_BT=y
+      CONFIG_BRIDGE_GENERIC_SWITCH_BRIDGED_DEVICE=n
+      CONFIG_BRIDGE_ONOFF_LIGHT_SWITCH_BRIDGED_DEVICE=y
     integration_platforms:
       - nrf7002dk_nrf5340_cpuapp
     platform_allow: nrf7002dk_nrf5340_cpuapp

--- a/applications/matter_bridge/src/bridge_shell.cpp
+++ b/applications/matter_bridge/src/bridge_shell.cpp
@@ -153,8 +153,8 @@ static int SimulatedBridgedDeviceOnOffLightSwitchWriteHandler(const struct shell
 	uint8_t value = strtoul(argv[1], nullptr, 0);
 	chip::EndpointId endpointId = strtoul(argv[2], nullptr, 0);
 
-	DeviceType deviceType{};
-	auto *provider = BridgeManager().Instance().GetProvider(endpointId, deviceType);
+	uint16_t deviceType{};
+	auto *provider = Nrf::BridgeManager().Instance().GetProvider(endpointId, deviceType);
 
 	if (provider) {
 		if ((0 == strcmp(command, "onoff_switch") && deviceType != DeviceType::OnOffLightSwitch)) {

--- a/applications/matter_bridge/src/bridged_device_types/onoff_light_switch.cpp
+++ b/applications/matter_bridge/src/bridged_device_types/onoff_light_switch.cpp
@@ -53,14 +53,14 @@ DECLARE_DYNAMIC_CLUSTER(Clusters::OnOff::Id, onOffClientAttrs, ZAP_CLUSTER_MASK(
 
 DECLARE_DYNAMIC_ENDPOINT(bridgedLightSwitchEndpoint, bridgedLightSwitchClusters);
 
-static constexpr uint8_t kBridgedOnOffLightSwitchEndpointVersion = 2
+static constexpr uint8_t kBridgedOnOffLightSwitchEndpointVersion = 2;
 
-	static constexpr EmberAfDeviceType kBridgedLightSwitchDeviceTypes[] = {
-		{ static_cast<chip::DeviceTypeId>(MatterBridgedDevice::DeviceType::OnOffLightSwitch),
-		  kBridgedOnOffLightSwitchEndpointVersion },
-		{ static_cast<chip::DeviceTypeId>(MatterBridgedDevice::DeviceType::BridgedNode),
-		  MatterBridgedDevice::kDefaultDynamicEndpointVersion }
-	};
+static constexpr EmberAfDeviceType kBridgedLightSwitchDeviceTypes[] = {
+	{ static_cast<chip::DeviceTypeId>(MatterBridgedDevice::DeviceType::OnOffLightSwitch),
+	  kBridgedOnOffLightSwitchEndpointVersion },
+	{ static_cast<chip::DeviceTypeId>(MatterBridgedDevice::DeviceType::BridgedNode),
+	  MatterBridgedDevice::kDefaultDynamicEndpointVersion }
+};
 
 static constexpr uint8_t kLightSwitchDataVersionSize = ArraySize(bridgedLightSwitchClusters);
 

--- a/applications/matter_bridge/src/bridged_device_types/onoff_light_switch.h
+++ b/applications/matter_bridge/src/bridged_device_types/onoff_light_switch.h
@@ -22,7 +22,7 @@ public:
 	uint16_t GetBindingClusterRevision() { return kBindingClusterRevision; }
 	uint32_t GetBindingFeatureMap() { return kBindingFeatureMap; }
 
-	Nrf::MatterBridgedDevice::DeviceType GetDeviceType() const override
+	uint16_t GetDeviceType() const override
 	{
 		return Nrf::MatterBridgedDevice::DeviceType::OnOffLightSwitch;
 	}

--- a/applications/matter_bridge/src/simulated_providers/simulated_onoff_light_switch_data_provider.cpp
+++ b/applications/matter_bridge/src/simulated_providers/simulated_onoff_light_switch_data_provider.cpp
@@ -22,26 +22,18 @@ void SimulatedOnOffLightSwitchDataProvider::NotifyUpdateState(chip::ClusterId cl
 {
 }
 
-void ProcessCommand(CommandId aCommandId, const EmberBindingTableEntry &aBinding, OperationalDeviceProxy *aDevice,
-		    void *aContext)
+void ProcessCommand(const EmberBindingTableEntry &aBinding, OperationalDeviceProxy *aDevice, Nrf::Matter::BindingHandler::BindingData &aData)
 {
 	CHIP_ERROR ret = CHIP_NO_ERROR;
-	Matter::BindingHandler::BindingData *data =
-		reinterpret_cast<Matter::BindingHandler::BindingData *>(aContext);
 
-	auto onSuccess = [dataRef = data](const ConcreteCommandPath &commandPath, const StatusIB &status,
-					  const auto &dataResponse) {
-		LOG_DBG("Binding command applied successfully!");
+	auto onSuccess = [dataRef = Platform::New<Nrf::Matter::BindingHandler::BindingData>(aData)](
+				 const ConcreteCommandPath &commandPath, const StatusIB &status,
+				 const auto &dataResponse) { Matter::BindingHandler::OnInvokeCommandSucces(dataRef); };
 
-		/* If session was recovered and communication works, reset flag to the initial state. */
-		if (dataRef->CaseSessionRecovered) {
-			dataRef->CaseSessionRecovered = false;
-		}
-	};
-
-	auto onFailure = [dataRef = *data](CHIP_ERROR aError) mutable {
-		Matter::BindingHandler::OnInvokeCommandFailure(dataRef, aError);
-	};
+	auto onFailure =
+		[dataRef = Platform::New<Nrf::Matter::BindingHandler::BindingData>(aData)](CHIP_ERROR aError) mutable {
+			Matter::BindingHandler::OnInvokeCommandFailure(dataRef, aError);
+		};
 
 	if (aDevice) {
 		/* We are validating connection is ready once here instead of multiple times in each case statement


### PR DESCRIPTION
The binding support was refactored for the onoff light switch in a wrong way and CI didn't caught it, because the build was not in twister.

Fixed the implementation and added configuration including onoff switch to sample.yaml.