### PR TITLE
lib: date_time: Add local time API function

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -985,6 +985,10 @@ Other libraries
   * Added more default LTE metrics, such as band, operator, RSRP, and kilobytes sent and received.
   * Updated the default metric names to follow the standard |NCS| variable name convention.
 
+* :ref:`lib_date_time` library:
+
+  * Added the :c:func:`date_time_now_local()` function to the API.
+
 Common Application Framework (CAF)
 ----------------------------------
 

--- a/include/date_time.h
+++ b/include/date_time.h
@@ -91,6 +91,21 @@ int date_time_uptime_to_unix_time_ms(int64_t *uptime);
  */
 int date_time_now(int64_t *unix_time_ms);
 
+/** @brief Get the current date time in local time.
+ *
+ *  @note If the function fails, the passed in variable retains its
+ *        old value.
+ *
+ *  @param[out] local_time_ms Pointer to a variable to store the current date
+ *                            time.
+ *
+ *  @return 0        If the operation was successful.
+ *  @return -ENODATA If the library does not have a valid date time.
+ *  @return -EAGAIN  If the library has the date time, but not a valid timezone.
+ *  @return -EINVAL  If the passed in pointer is NULL.
+ */
+int date_time_now_local(int64_t *local_time_ms);
+
 /** @brief Convenience function that checks if the library has obtained
  *	   an initial valid date time.
  *
@@ -103,6 +118,17 @@ int date_time_now(int64_t *unix_time_ms);
  *  @return false The library has not obtained an initial date time.
  */
 bool date_time_is_valid(void);
+
+/** @brief Check if the library has obtained
+ *	   an initial valid date time and timezone.
+ *
+ *  @note If this function returns false there is no point of
+ *	  subsequent calls to date_time_now_local().
+ *
+ *  @return true  The library has obtained a local date time.
+ *  @return false The library has not obtained a local date time.
+ */
+bool date_time_is_valid_local(void);
 
 /** @brief Register an event handler for Date time library events.
  *

--- a/lib/date_time/date_time.c
+++ b/lib/date_time/date_time.c
@@ -126,9 +126,28 @@ int date_time_now(int64_t *unix_time_ms)
 	return err;
 }
 
+int date_time_now_local(int64_t *local_time_ms)
+{
+	if (local_time_ms == NULL) {
+		LOG_ERR("The passed in pointer cannot be NULL");
+		return -EINVAL;
+	}
+	if (!date_time_is_valid()) {
+		LOG_WRN("Valid time not currently available");
+		return -ENODATA;
+	}
+
+	return date_time_core_now_local(local_time_ms);
+}
+
 bool date_time_is_valid(void)
 {
 	return date_time_core_is_valid();
+}
+
+bool date_time_is_valid_local(void)
+{
+	return date_time_core_is_valid_local();
 }
 
 void date_time_register_handler(date_time_evt_handler_t evt_handler)

--- a/lib/date_time/date_time_core.h
+++ b/lib/date_time/date_time_core.h
@@ -7,14 +7,19 @@
 #ifndef DATE_TIME_CORE_H_
 #define DATE_TIME_CORE_H_
 
+#define DATE_TIME_TZ_INVALID 99
+
 void date_time_core_init(void);
 int date_time_core_now(int64_t *unix_time_ms);
+int date_time_core_now_local(int64_t *local_time_ms);
 int date_time_core_update_async(date_time_evt_handler_t evt_handler);
 void date_time_core_register_handler(date_time_evt_handler_t evt_handler);
 bool date_time_core_is_valid(void);
+bool date_time_core_is_valid_local(void);
 void date_time_core_clear(void);
 
 void date_time_core_store(int64_t curr_time_ms, enum date_time_evt_type time_source);
+void date_time_core_store_tz(int64_t curr_time_ms, enum date_time_evt_type time_source, int tz);
 int date_time_core_current_check(void);
 
 #endif /* DATE_TIME_CORE_H_ */

--- a/lib/date_time/date_time_modem.c
+++ b/lib/date_time/date_time_modem.c
@@ -32,10 +32,11 @@ static bool modem_valid_network_time;
 static bool modem_valid_network_time = true;
 #endif /* defined(CONFIG_DATE_TIME_AUTO_UPDATE) */
 
-int date_time_modem_get(int64_t *date_time_ms)
+int date_time_modem_get(int64_t *date_time_ms, int *date_time_tz)
 {
 	int rc;
 	struct tm date_time;
+	int tz = DATE_TIME_TZ_INVALID;
 
 #if defined(CONFIG_DATE_TIME_NTP)
 	if (!modem_valid_network_time) {
@@ -53,17 +54,18 @@ int date_time_modem_get(int64_t *date_time_ms)
 	 * "+CCLK: \"20/02/25,17:15:02+04\"\r\n\000{"
 	 */
 	rc = nrf_modem_at_scanf("AT+CCLK?",
-		"+CCLK: \"%u/%u/%u,%u:%u:%u",
+		"+CCLK: \"%u/%u/%u,%u:%u:%u%d",
 		&date_time.tm_year,
 		&date_time.tm_mon,
 		&date_time.tm_mday,
 		&date_time.tm_hour,
 		&date_time.tm_min,
-		&date_time.tm_sec
+		&date_time.tm_sec,
+		&tz
 	);
 
-	/* Want to match 6 args */
-	if (rc != 6) {
+	/* Want to match 6 or 7 args */
+	if (rc != 6 && rc != 7) {
 		LOG_WRN("Did not get time from cellular network (error: %d). "
 			"This is normal as some cellular networks don't provide it or "
 			"time may not be available yet.", rc);
@@ -76,6 +78,7 @@ int date_time_modem_get(int64_t *date_time_ms)
 	date_time.tm_mon = date_time.tm_mon - 1;
 
 	*date_time_ms = (int64_t)timeutil_timegm64(&date_time) * 1000;
+	*date_time_tz = tz;
 
 	LOG_DBG("Time obtained from cellular network");
 
@@ -107,10 +110,11 @@ static void date_time_at_xtime_handler(const char *notif)
 {
 	struct tm date_time;
 	int64_t date_time_ms;
-	uint8_t time_buf[6];
+	uint8_t time_buf[7];
 	size_t time_buf_len;
 	char *time_str_start;
 	int err;
+	int tz;
 
 	if (notif == NULL) {
 		return;
@@ -147,7 +151,7 @@ static void date_time_at_xtime_handler(const char *notif)
 	}
 
 	time_str_start += 2;
-	time_buf_len = hex2bin(time_str_start, 12, time_buf, sizeof(time_buf));
+	time_buf_len = hex2bin(time_str_start, 14, time_buf, sizeof(time_buf));
 
 	if (time_buf_len < sizeof(time_buf)) {
 		LOG_ERR("%%XTIME notification decoding failed (ret=%d): %s", time_buf_len, notif);
@@ -161,6 +165,11 @@ static void date_time_at_xtime_handler(const char *notif)
 	date_time.tm_min  = semioctet_to_dec(time_buf[4]);
 	date_time.tm_sec  = semioctet_to_dec(time_buf[5]);
 
+	tz = semioctet_to_dec(time_buf[6] & 0xF7);
+	if (time_buf[6] & 0x08) {
+		tz = -tz;
+	}
+
 	/* Relative to 1900, as per POSIX */
 	date_time.tm_year = date_time.tm_year + 2000 - 1900;
 	/* Range is 0-11, as per POSIX */
@@ -170,11 +179,11 @@ static void date_time_at_xtime_handler(const char *notif)
 
 	LOG_DBG("Time obtained from cellular network (XTIME notification)");
 
-	date_time_core_store(date_time_ms, DATE_TIME_OBTAINED_MODEM);
+	date_time_core_store_tz(date_time_ms, DATE_TIME_OBTAINED_MODEM, tz);
 }
 #endif /* defined(CONFIG_DATE_TIME_AUTO_UPDATE) */
 
-void date_time_modem_store(struct tm *ltm)
+void date_time_modem_store(struct tm *ltm, int tz)
 {
 	int ret;
 
@@ -190,14 +199,13 @@ void date_time_modem_store(struct tm *ltm)
 		 *   "AT+CCLK="18/12/06,22:10:00+08"
 		 */
 
-		/* Time zone is not known and it's mandatory so setting to zero.
-		 * POSIX year is relative to 1900 which doesn't affect as last two digits are taken
+		/* POSIX year is relative to 1900 which doesn't affect as last two digits are taken
 		 * with modulo 100.
 		 * POSIX month is in range 0-11 so adding 1.
 		 */
-		ret = nrf_modem_at_printf("AT+CCLK=\"%02u/%02u/%02u,%02u:%02u:%02u+%02u\"",
+		ret = nrf_modem_at_printf("AT+CCLK=\"%02u/%02u/%02u,%02u:%02u:%02u%+03d\"",
 			ltm->tm_year % 100, ltm->tm_mon + 1, ltm->tm_mday,
-			ltm->tm_hour, ltm->tm_min, ltm->tm_sec, 0);
+			ltm->tm_hour, ltm->tm_min, ltm->tm_sec, tz);
 		if (ret) {
 			LOG_ERR("Setting modem time failed, %d", ret);
 			return;

--- a/lib/date_time/date_time_modem.h
+++ b/lib/date_time/date_time_modem.h
@@ -7,8 +7,8 @@
 #ifndef DATE_TIME_MODEM_H_
 #define DATE_TIME_MODEM_H_
 
-int date_time_modem_get(int64_t *date_time_ms);
-void date_time_modem_store(struct tm *ltm);
+int date_time_modem_get(int64_t *date_time_ms, int *tz);
+void date_time_modem_store(struct tm *ltm, int tz);
 void date_time_modem_xtime_subscribe(void);
 
 #endif /* DATE_TIME_MODEM_H_ */


### PR DESCRIPTION
This provides a substitute for localtime() since it isn't implemented in Zephyr's minimal libc. The resulting timestamp can be used with <ctime> or <chrono> for manipulation and logging.