### PR TITLE
samples: cellular: MSS: Secure credentials storage for Wi-Fi

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -406,6 +406,8 @@ Cellular samples
       It no longer sends a device status update on initial connection; this is now handled by the :ref:`lib_nrf_cloud` library.
     * Increased the :kconfig:option:`CONFIG_AT_HOST_STACK_SIZE` and :kconfig:option:`CONFIG_AT_MONITOR_HEAP_SIZE` Kconfig options to 2048 bytes since nRF Cloud credentials are sometimes longer than 1024 bytes.
     * The sample reboot logic is now in a dedicated file so that it can be used in multiple locations.
+    * The Wi-Fi connectivity overlay now uses the PSA Protected Storage backend of the :ref:`TLS Credentials Subsystem <zephyr:sockets_tls_credentials_subsys>` instead of the volatile backend.
+    * The Wi-Fi connectivity overlay now enables the :ref:`TLS Credentials Shell <zephyr:tls_credentials_shell>` for run-time credential installation.
 
   * Removed the nRF7002 EK devicetree overlay file :file:`nrf91xxdk_with_nrf7002ek.overlay`, because UART1 is disabled through the shield configuration.
 

--- a/samples/cellular/nrf_cloud_multi_service/overlay_nrf7002ek_wifi_no_lte.conf
+++ b/samples/cellular/nrf_cloud_multi_service/overlay_nrf7002ek_wifi_no_lte.conf
@@ -5,7 +5,7 @@
 #
 
 # Note that this overlay is not compatible with nrf91 Series! Use something such as the nrf5340 as
-# the host microcontroller.
+# the host microcontroller. It also requires the use of an _ns board / non-secure target.
 
 ## Disable Modem/LTE/nrf91-specific features
 CONFIG_NRF_MODEM_LIB=n
@@ -31,12 +31,49 @@ CONFIG_BOOTLOADER_MCUBOOT=n
 CONFIG_IMG_MANAGER=n
 CONFIG_MCUBOOT_IMG_MANAGER=n
 
+## Enable TFM and Trusted Execution so that we can use Protected Storage for credentials storage.
+## Please note that even when using Protected Storage, credentials are still retrieved into insecure
+## memory when in use.
+CONFIG_BUILD_WITH_TFM=y
+CONFIG_TRUSTED_EXECUTION_NONSECURE=y
+CONFIG_TFM_BUILD_NS=y
+
+## Enable Protected Storage
+CONFIG_TFM_PARTITION_PROTECTED_STORAGE=y
+
+## Configure TFM Profile. The NOT_SET profile will enable all features.
+## We then reduce some settings to save flash and RAM.
+CONFIG_TFM_PROFILE_TYPE_NOT_SET=y
+CONFIG_TFM_CRYPTO_CONC_OPER_NUM=1
+CONFIG_TFM_CRYPTO_ASYM_SIGN_MODULE_ENABLED=n
+
+## Configure TFM partitions
+CONFIG_PM_PARTITION_SIZE_TFM_INTERNAL_TRUSTED_STORAGE=0x2000
+CONFIG_PM_PARTITION_SIZE_TFM_OTP_NV_COUNTERS=0x2000
+CONFIG_PM_PARTITION_SIZE_TFM_PROTECTED_STORAGE=0x4000
+CONFIG_PM_PARTITION_SIZE_TFM_SRAM=0xC000
+# This is larger than needed under normal conditions, but is the minimum size necessary to
+# support enabling CONFIG_DEBUG_OPTIMIZATIONS (useful for debugging)
+CONFIG_PM_PARTITION_SIZE_TFM=0x24000
+
+## Configure credentials shells and dependencies
+CONFIG_SHELL=y
+CONFIG_WIFI_CREDENTIALS_SHELL=y
+CONFIG_TLS_CREDENTIALS_SHELL=y
+CONFIG_TLS_CREDENTIALS_BACKEND_PROTECTED_STORAGE=y
+# Increased stack size needed for wifi_cred auto_connect command
+CONFIG_SHELL_STACK_SIZE=4096
+# nRFCloud credentials can exceed 1024 bytes
+CONFIG_TLS_CREDENTIALS_SHELL_CRED_BUF_SIZE=2048
+# Needed by the TLS credentials shell
+CONFIG_BASE64=y
+
 ## Disable LTE-event-driven date_time updates (the date_time library will still periodically
 ## refresh its timestamp, this setting only controls whether LTE-event-driven date_time updates
 ## are enabled)
 CONFIG_DATE_TIME_AUTO_UPDATE=n
 
-## Disable LED patterns since enabling WiFi shield takes control of two LEDs
+## Disable LED patterns since the WiFi shield is not compatible
 CONFIG_LED_INDICATION_DISABLED=y
 
 ## Disable LTE conn_mgr bindings
@@ -73,6 +110,8 @@ CONFIG_FLASH_PAGE_LAYOUT=y
 CONFIG_FLASH_MAP=y
 
 ## Enable Wi-Fi networking and native networking stack
+# Note: WPA_SUPP requires 24kB of unused RAM in the final build.
+# Memory allocations in this overlay are fine-tuned with that fact in mind.
 CONFIG_WPA_SUPP=y
 CONFIG_NET_L2_ETHERNET=y
 CONFIG_NET_NATIVE=y
@@ -89,42 +128,44 @@ CONFIG_MBEDTLS=y
 CONFIG_MBEDTLS_ENABLE_HEAP=y
 CONFIG_MBEDTLS_RSA_C=y
 CONFIG_MBEDTLS_SSL_SERVER_NAME_INDICATION=y
-CONFIG_MBEDTLS_HEAP_SIZE=120000
+CONFIG_MBEDTLS_HEAP_SIZE=100000
+
+## Disable unneeded MBEDTLS features to save flash and RAM
+CONFIG_MBEDTLS_CHACHA20_C=n
+CONFIG_MBEDTLS_CHACHA20_C=n
+CONFIG_MBEDTLS_CHACHAPOLY_C=n
+CONFIG_MBEDTLS_POLY1305_C=n
+CONFIG_MBEDTLS_SHA1_C=n
+CONFIG_MBEDTLS_MAC_SHA256_ENABLED=n
+CONFIG_MBEDTLS_CIPHER_MODE_CBC=n
+CONFIG_MBEDTLS_CIPHER_MODE_CFB=n
+CONFIG_MBEDTLS_CIPHER_MODE_OFB=n
+CONFIG_MBEDTLS_SSL_SRV_C=n
+CONFIG_MBEDTLS_SSL_COOKIE_C=n
 
 ## Enable Wi-Fi location tracking
 CONFIG_LOCATION_TRACKING_WIFI=y
 CONFIG_LOCATION_METHOD_WIFI=y
-# Align this with CONFIG_LOCATION_METHOD_WIFI_SCANNING_RESULTS_MAX_CNT.
-# Also see comments for CONFIG_HEAP_MEM_POOL_SIZE.
-# We set this to 30 in this overlay so that
-# CONFIG_HEAP_MEM_POOL_SIZE can be small enough to leave at least 24kB of unused RAM in the final
-# build, which is required by WPA_supp
-CONFIG_NRF_WIFI_SCAN_MAX_BSS_CNT=30
-CONFIG_LOCATION_METHOD_WIFI_SCANNING_RESULTS_MAX_CNT=30
+# Keep CONFIG_NRF_WIFI_SCAN_MAX_BSS_CNT and CONFIG_LOCATION_METHOD_WIFI_SCANNING_RESULTS_MAX_CNT
+# set to the same value.
+CONFIG_NRF_WIFI_SCAN_MAX_BSS_CNT=20
+CONFIG_LOCATION_METHOD_WIFI_SCANNING_RESULTS_MAX_CNT=20
+# Add 256 bytes for each additional scanning result, assuming sane SSID lengths
+CONFIG_HEAP_MEM_POOL_SIZE=130000
 
-## Enable shell and WIFI_CREDENTIALS shell
-CONFIG_SHELL=y
-CONFIG_WIFI_CREDENTIALS_SHELL=y
-# Increased stack size needed for wifi_cred auto_connect command
-CONFIG_SHELL_STACK_SIZE=4096
-
-## Resource allocation tweaks needed to support Wi-Fi.
+## Miscellaneous resource allocation tweaks needed to support Wi-Fi.
 CONFIG_MAIN_STACK_SIZE=2048
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
 CONFIG_NET_MGMT_EVENT_STACK_SIZE=4096
 CONFIG_NRF_CLOUD_CONNECTION_POLL_THREAD_STACK_SIZE=8192
 CONFIG_APPLICATION_THREAD_STACK_SIZE=3072
 CONFIG_MESSAGE_THREAD_STACK_SIZE=3072
+CONFIG_CONNECTION_THREAD_STACK_SIZE=4096
 CONFIG_DATE_TIME_THREAD_STACK_SIZE=2048
 CONFIG_NET_TX_STACK_SIZE=2048
 CONFIG_NET_RX_STACK_SIZE=2048
 CONFIG_POSIX_MAX_FDS=16
 CONFIG_NET_SOCKETS_POLL_MAX=8
-# Heap allocation should be changed when CONFIG_LOCATION_METHOD_WIFI_SCANNING_RESULTS_MAX_CNT
-# and CONFIG_NRF_WIFI_SCAN_MAX_BSS_CNT (which should be the same value) are changed. With the limit at 30,
-# this could be set as low as 130000. Add 256 bytes for each additional scanning result, assuming
-# sane SSID lengths. We set the heap much higher in case of long SSIDs.
-CONFIG_HEAP_MEM_POOL_SIZE=130000
 
 # Disable PICOLIBC since hostap currently is not compatible with it
 CONFIG_NEWLIB_LIBC=y

--- a/samples/cellular/nrf_cloud_multi_service/sample.yaml
+++ b/samples/cellular/nrf_cloud_multi_service/sample.yaml
@@ -51,7 +51,7 @@ tests:
   sample.cellular.nrf7002ek_wifi.conn:
     build_only: true
     integration_platforms:
-      - nrf5340dk_nrf5340_cpuapp
-    platform_allow: nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuapp_ns
+    platform_allow: nrf5340dk_nrf5340_cpuapp_ns
     extra_args: SHIELD=nrf7002ek EXTRA_CONF_FILE="overlay_nrf7002ek_wifi_no_lte.conf"
     tags: ci_build


### PR DESCRIPTION
This commit alters the Wi-Fi connectivity overlay so that:
- TFM Protected Storage is used for cert storage instead of hard-coded certs
- TLS Credentials shell is enabled, allowing for easy cert installation

Documentations is also updated accordingly.

Finally, a few mistakes in the sample docs are corrected here as well.

IRIS-7728