### PR TITLE
docs: azure-iot-hub: rework docs

### DIFF
--- a/doc/nrf/includes/cert-flashing.txt
+++ b/doc/nrf/includes/cert-flashing.txt
@@ -1,4 +1,4 @@
-To provision the certificates and the private key to the cellular modem, complete the following steps:
+To provision the certificates and the private key to the nRF91 Series modem, complete the following steps:
 
 1. `Download nRF Connect for Desktop`_.
 #. Update the modem firmware on the onboard modem of the nRF91 Series device to the latest version by following the steps in :ref:`nrf9160_gs_updating_fw_modem`.

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -886,6 +886,7 @@
 .. _`Add certificates to the DPS instance`: https://docs.microsoft.com/en-us/azure/iot-dps/how-to-verify-certificates
 .. _`Registering the device with Azure IoT Hub`: https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-create-through-portal#register-a-new-device-in-the-iot-hub
 .. _`Azure IoT TLS: Critical changes`: https://techcommunity.microsoft.com/t5/internet-of-things-blog/azure-iot-tls-critical-changes-are-almost-here-and-why-you/ba-p/2393169
+.. _`Azure CLI`: https://learn.microsoft.com/en-us/cli/azure/install-azure-cli
 
 .. _`Windows Hardware Lab Kit`: https://docs.microsoft.com/en-us/windows-hardware/test/hlk/
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -947,6 +947,12 @@ Libraries for networking
   * Updated the library to use the :ref:`lib_mqtt_helper` library.
     This simplifies the handling of the MQTT stack.
 
+* :ref:`lib_azure_iot_hub` library:
+
+  * Improved the documentation on IoT Hub configuration and credentials storage.
+    The documentation now contains more details on how to use the Azure CLI to set up an IoT Hub.
+    The documentation on credential provisioning has also been updated, both for nRF91 Series devices and nRF70 Series devices.
+
 * :ref:`lib_download_client` library:
 
   * Added:


### PR DESCRIPTION
Reworking the Azure IoT Hub documentation
so it has a step by step guide in order to
faster get started with the library and
azure IoT Hub sample.
Also added description on how to provision
credentials for nrf7002.