### PR TITLE
Asset tracker: Fix LwM2M device data

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/lwm2m/lwm2m_codec_helpers.c
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/lwm2m/lwm2m_codec_helpers.c
@@ -263,23 +263,23 @@ int lwm2m_codec_helpers_setup_resources(void)
 	}
 
 	err = lwm2m_set_res_buf(&LWM2M_OBJ(IPSO_OBJECT_TEMP_SENSOR_ID, 0, SENSOR_UNITS_RID),
-				BME680_TEMP_UNIT, (uint16_t)strlen(BME680_TEMP_UNIT),
-				(uint16_t)strlen(BME680_TEMP_UNIT), LWM2M_RES_DATA_FLAG_RO);
+				BME680_TEMP_UNIT, (uint16_t)strlen(BME680_TEMP_UNIT) + 1,
+				(uint16_t)strlen(BME680_TEMP_UNIT) + 1, LWM2M_RES_DATA_FLAG_RO);
 	if (err) {
 		return err;
 	}
 	err = lwm2m_set_res_buf(&LWM2M_OBJ(IPSO_OBJECT_HUMIDITY_SENSOR_ID, 0,
 					   SENSOR_UNITS_RID),
-				BME680_HUMID_UNIT, (uint16_t)strlen(BME680_HUMID_UNIT),
-				(uint16_t)strlen(BME680_HUMID_UNIT),
+				BME680_HUMID_UNIT, (uint16_t)strlen(BME680_HUMID_UNIT) + 1,
+				(uint16_t)strlen(BME680_HUMID_UNIT) + 1,
 				LWM2M_RES_DATA_FLAG_RO);
 	if (err) {
 		return err;
 	}
 
 	err = lwm2m_set_res_buf(&LWM2M_OBJ(IPSO_OBJECT_PRESSURE_ID, 0, SENSOR_UNITS_RID),
-				BME680_PRESSURE_UNIT, (uint16_t)strlen(BME680_PRESSURE_UNIT),
-				(uint16_t)strlen(BME680_PRESSURE_UNIT),
+				BME680_PRESSURE_UNIT, (uint16_t)strlen(BME680_PRESSURE_UNIT) + 1,
+				(uint16_t)strlen(BME680_PRESSURE_UNIT) + 1,
 				LWM2M_RES_DATA_FLAG_RO);
 	if (err) {
 		return err;
@@ -293,8 +293,8 @@ int lwm2m_codec_helpers_setup_resources(void)
 
 	err = lwm2m_set_res_buf(
 		&LWM2M_OBJ(IPSO_OBJECT_PUSH_BUTTON_ID, BUTTON1_OBJ_INST_ID, APPLICATION_TYPE_RID),
-		BUTTON1_APP_NAME, (uint16_t)strlen(BUTTON1_APP_NAME),
-		(uint16_t)strlen(BUTTON1_APP_NAME), LWM2M_RES_DATA_FLAG_RO);
+		BUTTON1_APP_NAME, (uint16_t)strlen(BUTTON1_APP_NAME) + 1,
+		(uint16_t)strlen(BUTTON1_APP_NAME) + 1, LWM2M_RES_DATA_FLAG_RO);
 	if (err) {
 		return err;
 	}
@@ -307,12 +307,11 @@ int lwm2m_codec_helpers_setup_resources(void)
 	}
 
 	if (CONFIG_LWM2M_IPSO_PUSH_BUTTON_INSTANCE_COUNT == 2) {
-		err = lwm2m_set_res_buf(&LWM2M_OBJ(IPSO_OBJECT_PUSH_BUTTON_ID,
-							  BUTTON2_OBJ_INST_ID,
-							  APPLICATION_TYPE_RID),
-					       BUTTON2_APP_NAME, (uint16_t)strlen(BUTTON2_APP_NAME),
-					       (uint16_t)strlen(BUTTON2_APP_NAME),
-					       LWM2M_RES_DATA_FLAG_RO);
+		err = lwm2m_set_res_buf(&LWM2M_OBJ(IPSO_OBJECT_PUSH_BUTTON_ID, BUTTON2_OBJ_INST_ID,
+						   APPLICATION_TYPE_RID),
+					BUTTON2_APP_NAME, (uint16_t)strlen(BUTTON2_APP_NAME) + 1,
+					(uint16_t)strlen(BUTTON2_APP_NAME) + 1,
+					LWM2M_RES_DATA_FLAG_RO);
 		if (err) {
 			return err;
 		}
@@ -669,8 +668,8 @@ int lwm2m_codec_helpers_set_modem_dynamic_data(struct cloud_data_modem_dynamic *
 
 	err = lwm2m_set_res_buf(&LWM2M_OBJ(LWM2M_OBJECT_CONNECTIVITY_MONITORING_ID,
 					   0, IP_ADDRESSES, 0),
-				modem_dynamic->ip, (uint16_t)strlen(modem_dynamic->ip),
-				(uint16_t)strlen(modem_dynamic->ip),
+				modem_dynamic->ip, (uint16_t)strlen(modem_dynamic->ip) + 1,
+				(uint16_t)strlen(modem_dynamic->ip) + 1,
 				LWM2M_RES_DATA_FLAG_RO);
 	if (err) {
 		return err;
@@ -678,8 +677,8 @@ int lwm2m_codec_helpers_set_modem_dynamic_data(struct cloud_data_modem_dynamic *
 
 	err = lwm2m_set_res_buf(&LWM2M_OBJ(LWM2M_OBJECT_CONNECTIVITY_MONITORING_ID,
 					   0, APN, 0),
-				modem_dynamic->apn, (uint16_t)strlen(modem_dynamic->apn),
-				(uint16_t)strlen(modem_dynamic->apn),
+				modem_dynamic->apn, (uint16_t)strlen(modem_dynamic->apn) + 1,
+				(uint16_t)strlen(modem_dynamic->apn) + 1,
 				LWM2M_RES_DATA_FLAG_RO);
 	if (err) {
 		return err;
@@ -739,8 +738,8 @@ int lwm2m_codec_helpers_set_modem_static_data(struct cloud_data_modem_static *mo
 
 	err = lwm2m_set_res_buf(&LWM2M_OBJ(LWM2M_OBJECT_DEVICE_ID, 0, MODEL_NUMBER_RID),
 				CONFIG_BOARD,
-				(uint16_t)strlen(CONFIG_BOARD),
-				(uint16_t)strlen(CONFIG_BOARD),
+				(uint16_t)sizeof(CONFIG_BOARD),
+				(uint16_t)sizeof(CONFIG_BOARD),
 				LWM2M_RES_DATA_FLAG_RO);
 	if (err) {
 		return err;
@@ -748,8 +747,8 @@ int lwm2m_codec_helpers_set_modem_static_data(struct cloud_data_modem_static *mo
 
 	err = lwm2m_set_res_buf(&LWM2M_OBJ(LWM2M_OBJECT_DEVICE_ID, 0, HARDWARE_VERSION_RID),
 				CONFIG_SOC,
-				(uint16_t)strlen(CONFIG_SOC),
-				(uint16_t)strlen(CONFIG_SOC),
+				(uint16_t)sizeof(CONFIG_SOC),
+				(uint16_t)sizeof(CONFIG_SOC),
 				LWM2M_RES_DATA_FLAG_RO);
 	if (err) {
 		return err;
@@ -757,8 +756,8 @@ int lwm2m_codec_helpers_set_modem_static_data(struct cloud_data_modem_static *mo
 
 	err = lwm2m_set_res_buf(&LWM2M_OBJ(LWM2M_OBJECT_DEVICE_ID, 0, MANUFACTURER_RID),
 				CONFIG_CLOUD_CODEC_MANUFACTURER,
-				(uint16_t)strlen(CONFIG_CLOUD_CODEC_MANUFACTURER),
-				(uint16_t)strlen(CONFIG_CLOUD_CODEC_MANUFACTURER),
+				(uint16_t)sizeof(CONFIG_CLOUD_CODEC_MANUFACTURER),
+				(uint16_t)sizeof(CONFIG_CLOUD_CODEC_MANUFACTURER),
 				LWM2M_RES_DATA_FLAG_RO);
 	if (err) {
 		return err;
@@ -766,8 +765,8 @@ int lwm2m_codec_helpers_set_modem_static_data(struct cloud_data_modem_static *mo
 
 	err = lwm2m_set_res_buf(&LWM2M_OBJ(LWM2M_OBJECT_DEVICE_ID, 0, FIRMWARE_VERSION_RID),
 				modem_static->appv,
-				(uint16_t)strlen(modem_static->appv),
-				(uint16_t)strlen(modem_static->appv),
+				(uint16_t)strlen(modem_static->appv) + 1,
+				(uint16_t)strlen(modem_static->appv) + 1,
 				LWM2M_RES_DATA_FLAG_RO);
 	if (err) {
 		return err;
@@ -775,8 +774,8 @@ int lwm2m_codec_helpers_set_modem_static_data(struct cloud_data_modem_static *mo
 
 	err = lwm2m_set_res_buf(&LWM2M_OBJ(LWM2M_OBJECT_DEVICE_ID, 0, SOFTWARE_VERSION_RID),
 				modem_static->fw,
-				(uint16_t)strlen(modem_static->fw),
-				(uint16_t)strlen(modem_static->fw),
+				(uint16_t)strlen(modem_static->fw) + 1,
+				(uint16_t)strlen(modem_static->fw) + 1,
 				LWM2M_RES_DATA_FLAG_RO);
 	if (err) {
 		return err;
@@ -785,8 +784,8 @@ int lwm2m_codec_helpers_set_modem_static_data(struct cloud_data_modem_static *mo
 	err = lwm2m_set_res_buf(&LWM2M_OBJ(LWM2M_OBJECT_DEVICE_ID, 0,
 					   DEVICE_SERIAL_NUMBER_ID),
 				modem_static->imei,
-				(uint16_t)strlen(modem_static->imei),
-				(uint16_t)strlen(modem_static->imei),
+				(uint16_t)strlen(modem_static->imei) + 1,
+				(uint16_t)strlen(modem_static->imei) + 1,
 				LWM2M_RES_DATA_FLAG_RO);
 	if (err) {
 		return err;

--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/lwm2m/lwm2m_codec_helpers.c
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/lwm2m/lwm2m_codec_helpers.c
@@ -240,6 +240,33 @@ int lwm2m_codec_helpers_setup_resources(void)
 		return err;
 	}
 
+	err = lwm2m_set_res_buf(&LWM2M_OBJ(LWM2M_OBJECT_DEVICE_ID, 0, MODEL_NUMBER_RID),
+				CONFIG_BOARD,
+				(uint16_t)sizeof(CONFIG_BOARD),
+				(uint16_t)sizeof(CONFIG_BOARD),
+				LWM2M_RES_DATA_FLAG_RO);
+	if (err) {
+		return err;
+	}
+
+	err = lwm2m_set_res_buf(&LWM2M_OBJ(LWM2M_OBJECT_DEVICE_ID, 0, HARDWARE_VERSION_RID),
+				CONFIG_SOC,
+				(uint16_t)sizeof(CONFIG_SOC),
+				(uint16_t)sizeof(CONFIG_SOC),
+				LWM2M_RES_DATA_FLAG_RO);
+	if (err) {
+		return err;
+	}
+
+	err = lwm2m_set_res_buf(&LWM2M_OBJ(LWM2M_OBJECT_DEVICE_ID, 0, MANUFACTURER_RID),
+				CONFIG_CLOUD_CODEC_MANUFACTURER,
+				(uint16_t)sizeof(CONFIG_CLOUD_CODEC_MANUFACTURER),
+				(uint16_t)sizeof(CONFIG_CLOUD_CODEC_MANUFACTURER),
+				LWM2M_RES_DATA_FLAG_RO);
+	if (err) {
+		return err;
+	}
+
 #if defined(CONFIG_CLOUD_CODEC_LWM2M_THINGY91_SENSORS)
 	err = lwm2m_set_res_buf(&LWM2M_OBJ(IPSO_OBJECT_PRESSURE_ID, 0, TIMESTAMP_RID),
 				&pressure_ts, sizeof(pressure_ts),
@@ -734,33 +761,6 @@ int lwm2m_codec_helpers_set_modem_static_data(struct cloud_data_modem_static *mo
 
 	if (!modem_static->queued) {
 		return -ENODATA;
-	}
-
-	err = lwm2m_set_res_buf(&LWM2M_OBJ(LWM2M_OBJECT_DEVICE_ID, 0, MODEL_NUMBER_RID),
-				CONFIG_BOARD,
-				(uint16_t)sizeof(CONFIG_BOARD),
-				(uint16_t)sizeof(CONFIG_BOARD),
-				LWM2M_RES_DATA_FLAG_RO);
-	if (err) {
-		return err;
-	}
-
-	err = lwm2m_set_res_buf(&LWM2M_OBJ(LWM2M_OBJECT_DEVICE_ID, 0, HARDWARE_VERSION_RID),
-				CONFIG_SOC,
-				(uint16_t)sizeof(CONFIG_SOC),
-				(uint16_t)sizeof(CONFIG_SOC),
-				LWM2M_RES_DATA_FLAG_RO);
-	if (err) {
-		return err;
-	}
-
-	err = lwm2m_set_res_buf(&LWM2M_OBJ(LWM2M_OBJECT_DEVICE_ID, 0, MANUFACTURER_RID),
-				CONFIG_CLOUD_CODEC_MANUFACTURER,
-				(uint16_t)sizeof(CONFIG_CLOUD_CODEC_MANUFACTURER),
-				(uint16_t)sizeof(CONFIG_CLOUD_CODEC_MANUFACTURER),
-				LWM2M_RES_DATA_FLAG_RO);
-	if (err) {
-		return err;
 	}
 
 	err = lwm2m_set_res_buf(&LWM2M_OBJ(LWM2M_OBJECT_DEVICE_ID, 0, FIRMWARE_VERSION_RID),

--- a/applications/asset_tracker_v2/tests/lwm2m_codec_helpers/src/lwm2m_codec_helpers_test.c
+++ b/applications/asset_tracker_v2/tests/lwm2m_codec_helpers/src/lwm2m_codec_helpers_test.c
@@ -112,6 +112,20 @@ void test_codec_helpers_setup_resource_buffers(void)
 		LWM2M_RES_DATA_FLAG_RW, 0);
 
 	__cmock_lwm2m_set_res_buf_ExpectAndReturn(
+		&LWM2M_OBJ(LWM2M_OBJECT_DEVICE_ID, 0, MODEL_NUMBER_RID), CONFIG_BOARD,
+		sizeof(CONFIG_BOARD), sizeof(CONFIG_BOARD), LWM2M_RES_DATA_FLAG_RO, 0);
+
+	__cmock_lwm2m_set_res_buf_ExpectAndReturn(
+		&LWM2M_OBJ(LWM2M_OBJECT_DEVICE_ID, 0, HARDWARE_VERSION_RID), CONFIG_SOC,
+		sizeof(CONFIG_SOC), sizeof(CONFIG_SOC), LWM2M_RES_DATA_FLAG_RO, 0);
+
+	__cmock_lwm2m_set_res_buf_ExpectAndReturn(
+		&LWM2M_OBJ(LWM2M_OBJECT_DEVICE_ID, 0, MANUFACTURER_RID),
+		CONFIG_CLOUD_CODEC_MANUFACTURER, sizeof(CONFIG_CLOUD_CODEC_MANUFACTURER),
+		sizeof(CONFIG_CLOUD_CODEC_MANUFACTURER), LWM2M_RES_DATA_FLAG_RO, 0);
+
+
+	__cmock_lwm2m_set_res_buf_ExpectAndReturn(
 		&LWM2M_OBJ(IPSO_OBJECT_PRESSURE_ID, 0, TIMESTAMP_RID),
 		&pressure_ts, sizeof(pressure_ts), sizeof(pressure_ts),
 		LWM2M_RES_DATA_FLAG_RW, 0);
@@ -597,19 +611,6 @@ void test_codec_helpers_set_modem_static_data(void)
 		.ts = 1000,
 		.queued = true,
 	};
-
-	__cmock_lwm2m_set_res_buf_ExpectAndReturn(
-		&LWM2M_OBJ(LWM2M_OBJECT_DEVICE_ID, 0, MODEL_NUMBER_RID), CONFIG_BOARD,
-		strlen(CONFIG_BOARD) + 1, strlen(CONFIG_BOARD) + 1, LWM2M_RES_DATA_FLAG_RO, 0);
-
-	__cmock_lwm2m_set_res_buf_ExpectAndReturn(
-		&LWM2M_OBJ(LWM2M_OBJECT_DEVICE_ID, 0, HARDWARE_VERSION_RID), CONFIG_SOC,
-		strlen(CONFIG_SOC) + 1, strlen(CONFIG_SOC) + 1, LWM2M_RES_DATA_FLAG_RO, 0);
-
-	__cmock_lwm2m_set_res_buf_ExpectAndReturn(
-		&LWM2M_OBJ(LWM2M_OBJECT_DEVICE_ID, 0, MANUFACTURER_RID),
-		CONFIG_CLOUD_CODEC_MANUFACTURER, strlen(CONFIG_CLOUD_CODEC_MANUFACTURER) + 1,
-		strlen(CONFIG_CLOUD_CODEC_MANUFACTURER) + 1, LWM2M_RES_DATA_FLAG_RO, 0);
 
 	__cmock_lwm2m_set_res_buf_ExpectAndReturn(
 		&LWM2M_OBJ(LWM2M_OBJECT_DEVICE_ID, 0, FIRMWARE_VERSION_RID), modem_static.appv,

--- a/applications/asset_tracker_v2/tests/lwm2m_codec_helpers/src/lwm2m_codec_helpers_test.c
+++ b/applications/asset_tracker_v2/tests/lwm2m_codec_helpers/src/lwm2m_codec_helpers_test.c
@@ -128,20 +128,22 @@ void test_codec_helpers_setup_resource_buffers(void)
 
 	__cmock_lwm2m_set_res_buf_ExpectAndReturn(
 		&LWM2M_OBJ(IPSO_OBJECT_TEMP_SENSOR_ID, 0, SENSOR_UNITS_RID), BME680_TEMP_UNIT,
-		strlen(BME680_TEMP_UNIT), strlen(BME680_TEMP_UNIT), LWM2M_RES_DATA_FLAG_RO, 0);
-
-	__cmock_lwm2m_set_res_buf_ExpectAndReturn(
-		&LWM2M_OBJ(IPSO_OBJECT_HUMIDITY_SENSOR_ID, 0, SENSOR_UNITS_RID), BME680_HUMID_UNIT,
-		strlen(BME680_HUMID_UNIT), strlen(BME680_HUMID_UNIT), LWM2M_RES_DATA_FLAG_RO, 0);
-
-	__cmock_lwm2m_set_res_buf_ExpectAndReturn(
-		&LWM2M_OBJ(IPSO_OBJECT_PRESSURE_ID, 0, SENSOR_UNITS_RID), BME680_PRESSURE_UNIT,
-		strlen(BME680_PRESSURE_UNIT), strlen(BME680_PRESSURE_UNIT), LWM2M_RES_DATA_FLAG_RO,
+		strlen(BME680_TEMP_UNIT) + 1, strlen(BME680_TEMP_UNIT) + 1, LWM2M_RES_DATA_FLAG_RO,
 		0);
 
 	__cmock_lwm2m_set_res_buf_ExpectAndReturn(
+		&LWM2M_OBJ(IPSO_OBJECT_HUMIDITY_SENSOR_ID, 0, SENSOR_UNITS_RID), BME680_HUMID_UNIT,
+		strlen(BME680_HUMID_UNIT) + 1, strlen(BME680_HUMID_UNIT) + 1,
+		LWM2M_RES_DATA_FLAG_RO, 0);
+
+	__cmock_lwm2m_set_res_buf_ExpectAndReturn(
+		&LWM2M_OBJ(IPSO_OBJECT_PRESSURE_ID, 0, SENSOR_UNITS_RID), BME680_PRESSURE_UNIT,
+		strlen(BME680_PRESSURE_UNIT) + 1, strlen(BME680_PRESSURE_UNIT) + 1,
+		LWM2M_RES_DATA_FLAG_RO, 0);
+
+	__cmock_lwm2m_set_res_buf_ExpectAndReturn(
 		&LWM2M_OBJ(IPSO_OBJECT_PUSH_BUTTON_ID, BUTTON1_OBJ_INST_ID, APPLICATION_TYPE_RID),
-		BUTTON1_APP_NAME, strlen(BUTTON1_APP_NAME), strlen(BUTTON1_APP_NAME),
+		BUTTON1_APP_NAME, strlen(BUTTON1_APP_NAME) + 1, strlen(BUTTON1_APP_NAME) + 1,
 		LWM2M_RES_DATA_FLAG_RO, 0);
 
 	__cmock_lwm2m_set_res_buf_ExpectAndReturn(
@@ -151,7 +153,7 @@ void test_codec_helpers_setup_resource_buffers(void)
 
 	__cmock_lwm2m_set_res_buf_ExpectAndReturn(
 		&LWM2M_OBJ(IPSO_OBJECT_PUSH_BUTTON_ID, BUTTON2_OBJ_INST_ID, APPLICATION_TYPE_RID),
-		BUTTON2_APP_NAME, strlen(BUTTON2_APP_NAME), strlen(BUTTON2_APP_NAME),
+		BUTTON2_APP_NAME, strlen(BUTTON2_APP_NAME) + 1, strlen(BUTTON2_APP_NAME) + 1,
 		LWM2M_RES_DATA_FLAG_RO, 0);
 
 	__cmock_lwm2m_set_res_buf_ExpectAndReturn(
@@ -598,28 +600,31 @@ void test_codec_helpers_set_modem_static_data(void)
 
 	__cmock_lwm2m_set_res_buf_ExpectAndReturn(
 		&LWM2M_OBJ(LWM2M_OBJECT_DEVICE_ID, 0, MODEL_NUMBER_RID), CONFIG_BOARD,
-		strlen(CONFIG_BOARD), strlen(CONFIG_BOARD), LWM2M_RES_DATA_FLAG_RO, 0);
+		strlen(CONFIG_BOARD) + 1, strlen(CONFIG_BOARD) + 1, LWM2M_RES_DATA_FLAG_RO, 0);
 
 	__cmock_lwm2m_set_res_buf_ExpectAndReturn(
 		&LWM2M_OBJ(LWM2M_OBJECT_DEVICE_ID, 0, HARDWARE_VERSION_RID), CONFIG_SOC,
-		strlen(CONFIG_SOC), strlen(CONFIG_SOC), LWM2M_RES_DATA_FLAG_RO, 0);
+		strlen(CONFIG_SOC) + 1, strlen(CONFIG_SOC) + 1, LWM2M_RES_DATA_FLAG_RO, 0);
 
 	__cmock_lwm2m_set_res_buf_ExpectAndReturn(
 		&LWM2M_OBJ(LWM2M_OBJECT_DEVICE_ID, 0, MANUFACTURER_RID),
-		CONFIG_CLOUD_CODEC_MANUFACTURER, strlen(CONFIG_CLOUD_CODEC_MANUFACTURER),
-		strlen(CONFIG_CLOUD_CODEC_MANUFACTURER), LWM2M_RES_DATA_FLAG_RO, 0);
+		CONFIG_CLOUD_CODEC_MANUFACTURER, strlen(CONFIG_CLOUD_CODEC_MANUFACTURER) + 1,
+		strlen(CONFIG_CLOUD_CODEC_MANUFACTURER) + 1, LWM2M_RES_DATA_FLAG_RO, 0);
 
 	__cmock_lwm2m_set_res_buf_ExpectAndReturn(
 		&LWM2M_OBJ(LWM2M_OBJECT_DEVICE_ID, 0, FIRMWARE_VERSION_RID), modem_static.appv,
-		strlen(modem_static.appv), strlen(modem_static.appv), LWM2M_RES_DATA_FLAG_RO, 0);
+		strlen(modem_static.appv) + 1, strlen(modem_static.appv) + 1,
+		LWM2M_RES_DATA_FLAG_RO, 0);
 
 	__cmock_lwm2m_set_res_buf_ExpectAndReturn(
 		&LWM2M_OBJ(LWM2M_OBJECT_DEVICE_ID, 0, SOFTWARE_VERSION_RID), modem_static.fw,
-		strlen(modem_static.fw), strlen(modem_static.fw), LWM2M_RES_DATA_FLAG_RO, 0);
+		strlen(modem_static.fw) + 1, strlen(modem_static.fw) + 1, LWM2M_RES_DATA_FLAG_RO,
+		0);
 
 	__cmock_lwm2m_set_res_buf_ExpectAndReturn(
 		&LWM2M_OBJ(LWM2M_OBJECT_DEVICE_ID, 0, DEVICE_SERIAL_NUMBER_ID), modem_static.imei,
-		strlen(modem_static.imei), strlen(modem_static.imei), LWM2M_RES_DATA_FLAG_RO, 0);
+		strlen(modem_static.imei) + 1, strlen(modem_static.imei) + 1,
+		LWM2M_RES_DATA_FLAG_RO, 0);
 
 	TEST_ASSERT_EQUAL(0, lwm2m_codec_helpers_set_modem_static_data(&modem_static));
 }


### PR DESCRIPTION
Two issues were found on Asset Tracker when LwM2M protocol is used:
* Device data is initialized only after we have registered to server. This might lead to situation that server fetch empty strings from Device object. Move few initialization calls to setup function.
* String terminator was not counted in the buffer length. This is a bug as `lwm2m_set_res_buf()` requires full buffer, not just `strlen()`. Some payload codecs have been ignoring this, but current CBOR codec seem to strip last character from strings.

This does not completely fix Asset Tracker v2 as I am not familiar with the state machines. Someone should go through the state machine and ensure that following data is filled up before we register to server:
* lwm2m_codec_helpers_set_modem_dynamic_data
* lwm2m_codec_helpers_set_modem_static_data
* lwm2m_codec_helpers_set_battery_data
* lwm2m_codec_helpers_set_sensor_data
* lwm2m_codec_helpers_set_user_interface_data
* lwm2m_codec_helpers_set_neighbor_cell_data

All that data will appear visible on Coiote after it runs full device data refresh on registration. If you write that data later, it only shows on server, if you do SEND or if  the data is marked as observed.
