### PR TITLE
applications: asset_tracker_v2: Power optimize LTE usage

### DIFF
--- a/applications/asset_tracker_v2/overlay-lwm2m.conf
+++ b/applications/asset_tracker_v2/overlay-lwm2m.conf
@@ -26,24 +26,64 @@ CONFIG_LWM2M_RW_SENML_CBOR_RECORDS=45
 CONFIG_ZCBOR=y
 CONFIG_ZCBOR_CANONICAL=y
 
-# Enable TLS session caching to prevent doing a full TLS handshake for every send.
+# Enable DTLS Connection Identifier and TLS session caching
+# to prevent doing a full TLS handshake for every send.
 CONFIG_LWM2M_TLS_SESSION_CACHING=y
+CONFIG_LWM2M_DTLS_CID=y
 
-# Set uptime to once every 12 hours.
+# Set uptime to 12 hours.
+# Update every 60 minutes (3600 s)
 CONFIG_LWM2M_ENGINE_DEFAULT_LIFETIME=43200
+CONFIG_LWM2M_UPDATE_PERIOD=3600
+CONFIG_LWM2M_SECONDS_TO_UPDATE_EARLY=60
 
 # LwM2M Queue Mode
 CONFIG_LWM2M_QUEUE_MODE_ENABLED=y
-CONFIG_LWM2M_RD_CLIENT_SUSPEND_SOCKET_AT_IDLE=y
+CONFIG_LWM2M_RD_CLIENT_STOP_POLLING_AT_IDLE=y
 # Sets the duration that the lwm2m engine will be polling for data after transmission before
 # the socket is closed.
 CONFIG_LWM2M_QUEUE_MODE_UPTIME=30
 
-## Set Requested Active Time (RAT) to 60 seconds. Preferably a little bit longer than the
-## configured LWM2M_QUEUE_MODE_UPTIME. Due to NAT/firewall UDP connections are usually
-## closed within 30-60 seconds so there is in general no point in setting a longer
-## Queue mode uptime / LTE PSM active time.
-CONFIG_LTE_PSM_REQ_RAT="00100001"
+# Configure PSM mode
+CONFIG_LTE_PSM_REQ=y
+# Request periodic TAU of 3600 seconds (60 minutes)
+CONFIG_LTE_PSM_REQ_RPTAU="00000110"
+
+# Set Requested Active Time (RAT) to 30 seconds. Preferably same as the
+# configured LWM2M_QUEUE_MODE_UPTIME. Due to NAT/firewall UDP connections are usually
+# closed within 30-60 seconds so there is in general no point in setting a longer
+# Queue mode uptime / LTE PSM active time.
+CONFIG_LTE_PSM_REQ_RAT="00001111"
+
+# Request eDRX mode
+CONFIG_LTE_EDRX_REQ=y
+
+# Requested eDRX cycle length for LTE-M and NB-IoT
+# This should be fine-tuned for the network and the chosen server.
+# Lowest value is  the most responsive, but uses more energy during the active eDRX period.
+# Longer period may cause more CoAP packet drops on server requests.
+# "0000" is 5.12 s
+# "0001" is 10.24 s
+# "0010" is 20.48 s.
+CONFIG_LTE_EDRX_REQ_VALUE_LTE_M="0000"
+CONFIG_LTE_EDRX_REQ_VALUE_NBIOT="0000"
+
+# Request Paging time window of 1.28 seconds for LTE-M
+CONFIG_LTE_PTW_VALUE_LTE_M="0000"
+
+# Request Paging time window of 2.56 seconds for NB-IoT
+CONFIG_LTE_PTW_VALUE_NBIOT="0000"
+
+# Get notification before Tracking Area Update (TAU). Notification triggers registration
+# update and TAU will be sent with the update which decreases power consumption.
+CONFIG_LTE_LC_TAU_PRE_WARNING_NOTIFICATIONS=y
+
+# Optimize powersaving by using tickless mode in LwM2M engine
+CONFIG_NET_SOCKETPAIR=y
+CONFIG_LWM2M_TICKLESS=y
+
+# Enable Release Assistance Indication
+CONFIG_LWM2M_CLIENT_UTILS_RAI=y
 
 # Use LwM2M client bootstrap server.
 # CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP=y

--- a/applications/asset_tracker_v2/src/cloud/lwm2m_integration/lwm2m_integration.c
+++ b/applications/asset_tracker_v2/src/cloud/lwm2m_integration/lwm2m_integration.c
@@ -109,6 +109,8 @@ static void rd_client_event(struct lwm2m_ctx *client, enum lwm2m_rd_client_event
 	struct cloud_wrap_event cloud_wrap_evt = { 0 };
 	bool notify = false;
 
+	lwm2m_utils_connection_manage(client, &client_event);
+
 	switch (client_event) {
 	case LWM2M_RD_CLIENT_EVENT_NONE:
 		LOG_DBG("LWM2M_RD_CLIENT_EVENT_NONE");

--- a/applications/asset_tracker_v2/tests/lwm2m_integration/src/lwm2m_integration_test.c
+++ b/applications/asset_tracker_v2/tests/lwm2m_integration/src/lwm2m_integration_test.c
@@ -148,6 +148,7 @@ void test_lwm2m_integration_connect(void)
 	uint32_t current_lifetime_expected = 0;
 	uint32_t new_lifetime_expected = CONFIG_LWM2M_ENGINE_DEFAULT_LIFETIME;
 
+	__cmock_lwm2m_utils_connection_manage_Ignore();
 	__cmock_lwm2m_rd_client_start_AddCallback(&rd_client_set_callback_stub);
 
 	/* After the uut has been put into state CONNECTED, the lwm2m lifetime resource is
@@ -357,12 +358,14 @@ void test_lwm2m_integration_registration_failure(void)
 
 void test_lwm2m_integration_registration_update_failure(void)
 {
+	__cmock_lwm2m_utils_connection_manage_Ignore();
 	rd_client_callback(&client, LWM2M_RD_CLIENT_EVENT_REG_TIMEOUT);
 	TEST_ASSERT_EQUAL(CLOUD_WRAP_EVT_CONNECTING, last_cb_type);
 }
 
 void test_lwm2m_integration_registration_update_success(void)
 {
+	__cmock_lwm2m_utils_connection_manage_Ignore();
 	rd_client_callback(&client, LWM2M_RD_CLIENT_EVENT_REG_TIMEOUT);
 	TEST_ASSERT_EQUAL(CLOUD_WRAP_EVT_CONNECTING, last_cb_type);
 
@@ -372,12 +375,14 @@ void test_lwm2m_integration_registration_update_success(void)
 
 void test_lwm2m_integration_deregistration_failure(void)
 {
+	__cmock_lwm2m_utils_connection_manage_Ignore();
 	rd_client_callback(&client, LWM2M_RD_CLIENT_EVENT_DEREGISTER_FAILURE);
 	TEST_ASSERT_EQUAL(CLOUD_WRAP_EVT_ERROR, last_cb_type);
 }
 
 void test_lwm2m_integration_network_error(void)
 {
+	__cmock_lwm2m_utils_connection_manage_Ignore();
 	rd_client_callback(&client, LWM2M_RD_CLIENT_EVENT_NETWORK_ERROR);
 	TEST_ASSERT_EQUAL(CLOUD_WRAP_EVT_ERROR, last_cb_type);
 }

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -219,6 +219,17 @@ Asset Tracker v2
   * The :kconfig:option:`NRF_CLOUD_SEND_SERVICE_INFO_FOTA` and :kconfig:option:`NRF_CLOUD_SEND_SERVICE_INFO_UI` Kconfig options.
     The application no longer sends a device shadow update; this is now handled by the :ref:`lib_nrf_cloud` library.
 
+* Updated:
+
+  * The following power optimizations to the LwM2M configuration overlay:
+
+    * Enable DTLS Connection Identifier.
+    * Perform LwM2M update once an hour and request for similar update interval of periodic tracking area from the LTE network.
+    * Request the same active time as the QUEUE mode polling time.
+    * Enable eDRX with shortest possible interval and a short paging window.
+    * Enable tickless mode in the LwM2M engine.
+    * Enable LTE Release Assist Indicator.
+
 * Removed the nRF7002 EK devicetree overlay file :file:`nrf91xxdk_with_nrf7002ek.overlay`, because UART1 is disabled through the shield configuration.
 
 Serial LTE modem


### PR DESCRIPTION
Asset Tracker seem to be lacking some of the power optimizations that have been done in LwM2M engine and LwM2M client sample, so I'll create this draft PR to propose these into the Asset Tracker as well.
Our LwM2M client sample uses all of these already.

Configure various LwM2M related settings to optimize power usage of the device:
* Enable DTLS Connection Identifier
* Keep sockets open while in QUEUE_RX_OFF (Stop polling)
* Do update once a hour and try to request similar periodic tracking area update intervall from LTE network.
* Do LwM2M Udate when LTE Tracking area update is requested.
* Request same active time as our QUEUE mode polling time is.
* Enable eDRX with smallest interval and short paging window. This is responsive so CoAP timeouts usually don't happen.
* Enable LwM2M engine's tickless mode.
* Enable LTE Release Assist Indicator. This helps especially in Nb-IOT.

Please review carefully if these fit the application specific logic. I did not do extensive testing but initial trial seem to indicate that these work OK.

I still see some problems on Ground Fix queries going into some weird loop. It is triggering LwM2M update more often than required. It seem unrelated, but makes testing this change annoying.