### PR TITLE
modules: tf-m: Add dependency for HW_UNIQUE_KEY

### DIFF
--- a/lib/hw_unique_key/Kconfig
+++ b/lib/hw_unique_key/Kconfig
@@ -28,9 +28,13 @@ config HW_UNIQUE_KEY_LOAD
 	  area on the first clean boot. On subsequent boots, the bootloader
 	  will fail if no key is present.
 
+config HW_UNIQUE_KEY_SUPPORTED
+	bool
+	default y if HAS_HW_NRF_CC3XX
+
 config HW_UNIQUE_KEY
 	bool "Hardware Unique Keys (HUK)"
-	depends on HAS_HW_NRF_CC310 || HAS_HW_NRF_CC312
+	depends on HW_UNIQUE_KEY_SUPPORTED
 	depends on NRF_CC3XX_PLATFORM || BUILD_WITH_TFM
 	depends on NRF_SECURITY
 	depends on MPU_ALLOW_FLASH_WRITE || BUILD_WITH_TFM

--- a/modules/trusted-firmware-m/Kconfig.tfm.defconfig
+++ b/modules/trusted-firmware-m/Kconfig.tfm.defconfig
@@ -69,7 +69,7 @@ config TFM_PARTITION_PROTECTED_STORAGE
 	# The protected storage partition require HKDF with HMAC and SHA-256 to
 	# derive the storage key and an AEAD encryption algorithm for storage
 	# encryption.
-	select HW_UNIQUE_KEY
+	select HW_UNIQUE_KEY if HW_UNIQUE_KEY_SUPPORTED
 	select PSA_WANT_ALG_HKDF
 	select PSA_WANT_ALG_HMAC
 	select PSA_WANT_ALG_SHA_256

--- a/subsys/secure_storage/Kconfig
+++ b/subsys/secure_storage/Kconfig
@@ -134,6 +134,7 @@ config SECURE_STORAGE_BACKEND_AEAD_KEY_DERIVE_FROM_HUK
 	select HW_UNIQUE_KEY
 	select HW_UNIQUE_KEY_RANDOM
 	select PM_SINGLE_IMAGE
+	depends on HW_UNIQUE_KEY_SUPPORTED
 	help
 	  Use the Hardware Unique Key (HUK) with the UID as label to derive a
 	  new key.


### PR DESCRIPTION
The TFM_PARTITION_PROTECTED_STORAGE selects the
library HW_UNIQUE_KEY which is only availabe on
CryptoCell enabled devices. This adds the required dependency.

The same applies to other options that are selecting HW_UNIQUE_KEY.