### PR TITLE
samples: cellular: modem_shell: Make sec_tag unsigned

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -427,6 +427,7 @@ Cellular samples
     * The ``send`` subcommand to use the :c:func:`send` function for non-secure datagram sockets that are connected and have a peer address set.
     * The ``modem_trace`` command has been moved to :ref:`nrf_modem_lib_readme`.
       See :ref:`modem_trace_shell_command` for information about modem trace commands.
+    * The sample to allow TLS/DTLS security tag values up to ``4294967295``.
 
 * :ref:`nrf_cloud_multi_service` sample:
 

--- a/samples/cellular/modem_shell/src/sock/sock.c
+++ b/samples/cellular/modem_shell/src/sock/sock.c
@@ -237,7 +237,7 @@ static int sock_validate_parameters(
 	int bind_port,
 	int pdn_cid,
 	bool secure,
-	int sec_tag)
+	uint32_t sec_tag)
 {
 	/* Validate family parameter */
 	if (family != AF_INET && family != AF_INET6 && family != AF_PACKET) {
@@ -350,19 +350,19 @@ static int sock_getaddrinfo_req(
 
 static int sock_set_tls_options(
 	int fd,
-	int sec_tag,
+	uint32_t sec_tag,
 	bool session_cache,
 	int peer_verify,
 	char *peer_hostname)
 {
 	int err;
-	sec_tag_t sec_tag_list[] = { sec_tag };
+	uint32_t sec_tag_list[] = { sec_tag };
 	uint8_t cache;
 	uint32_t verify;
 
 	/* Security tag */
 	err = setsockopt(fd, SOL_TLS, TLS_SEC_TAG_LIST, sec_tag_list,
-			 sizeof(sec_tag_t) * ARRAY_SIZE(sec_tag_list));
+			 sizeof(uint32_t) * ARRAY_SIZE(sec_tag_list));
 	if (err) {
 		mosh_error("Unable to set security tag, errno %d", errno);
 		err = errno;
@@ -524,7 +524,7 @@ int sock_open_and_connect(
 	int bind_port,
 	int pdn_cid,
 	bool secure,
-	int sec_tag,
+	uint32_t sec_tag,
 	bool session_cache,
 	int peer_verify,
 	char *peer_hostname)
@@ -537,7 +537,7 @@ int sock_open_and_connect(
 		   "pdn_cid=%d, address=%s",
 		   family, type, port, bind_port, pdn_cid, address);
 	if (secure) {
-		mosh_print("                        secure=%d, sec_tag=%d, session_cache=%d, "
+		mosh_print("                        secure=%d, sec_tag=%u, session_cache=%d, "
 			   "peer_verify=%d, peer_hostname=%s",
 			   secure, sec_tag, session_cache, peer_verify, peer_hostname);
 	}

--- a/samples/cellular/modem_shell/src/sock/sock.h
+++ b/samples/cellular/modem_shell/src/sock/sock.h
@@ -24,7 +24,7 @@ int sock_getaddrinfo(int family, int type, char *hostname, int pdn_cid);
 
 int sock_open_and_connect(
 	int family, int type, char *address, int port,
-	int bind_port, int pdn_cid, bool secure, int sec_tag,
+	int bind_port, int pdn_cid, bool secure, uint32_t sec_tag,
 	bool session_cache, int peer_verify,
 	char *peer_hostname);
 

--- a/samples/cellular/modem_shell/src/sock/sock_shell.c
+++ b/samples/cellular/modem_shell/src/sock/sock_shell.c
@@ -341,7 +341,7 @@ static int cmd_sock_connect(const struct shell *shell, size_t argc, char **argv)
 	int arg_bind_port = 0;
 	int arg_pdn_cid = 0;
 	bool arg_secure = false;
-	int arg_sec_tag = -1;
+	uint32_t arg_sec_tag = 0;
 	bool arg_session_cache = false;
 	int arg_peer_verify = 2;
 	char arg_peer_hostname[SOCK_MAX_ADDR_LEN + 1];
@@ -429,11 +429,12 @@ static int cmd_sock_connect(const struct shell *shell, size_t argc, char **argv)
 			arg_secure = true;
 			break;
 		case 'T': /* Security tag */
-			arg_sec_tag = atoi(optarg);
-			if (arg_sec_tag < 0) {
+			err = 0;
+			arg_sec_tag = shell_strtoul(optarg, 10, &err);
+			if (err) {
 				mosh_error(
-					"Valid range for security tag (%d) is 0 ... 2147483647.",
-					arg_sec_tag);
+					"Valid range for security tag (%s) is 0 .. %u.",
+					optarg, UINT32_MAX);
 				return -EINVAL;
 			}
 			break;


### PR DESCRIPTION
Allow security tag values up to 4294967295.