### PR TITLE
Bluetooth: Controller: Define BT_CTLR_SDC_CONN_EVENT_EXTEND_DEFAULT and disable it for 802.15.4

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -143,10 +143,23 @@ config BT_CTLR_SDC_MAX_CONN_EVENT_LEN_DEFAULT
 	  The time set aside for connections on every connection interval in
 	  microseconds. The event length and the connection interval are the
 	  primary parameters for setting the throughput of a connection.
+	  When connection event extension is enabled, more time may be used.
 	  The event length may be set to a value that is shorter than the time needed
 	  for a single packet pair on a given PHY.
 	  In that case the controller will reserve time for receiving 27 bytes and transmitting
 	  the number of bytes configured with BT_CTLR_MIN_VAL_OF_MAX_ACL_TX_PAYLOAD_DEFAULT.
+
+config BT_CTLR_SDC_CONN_EVENT_EXTEND_DEFAULT
+	bool "Enable connection event extension by default"
+	default y
+	help
+	  When Extended Connection Events are disabled, the maximum connection event length is
+	  configured with BT_CTLR_SDC_MAX_CONN_EVENT_LEN_DEFAULT.
+	  When Extended Connection Events are enabled, the controller
+	  will extend the connection event as much as possible, if
+	  - Either of the peers has more data to send.
+	    See also: Core v5.6, Vol 6, Part B, Section 4.5.6.
+	  - There are no conflicts with other roles of equal or higher priority.
 
 config BT_CTLR_SDC_CENTRAL_ACL_EVENT_SPACING_DEFAULT
 	int "Default central ACL event spacing [us]"

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -151,7 +151,7 @@ config BT_CTLR_SDC_MAX_CONN_EVENT_LEN_DEFAULT
 
 config BT_CTLR_SDC_CONN_EVENT_EXTEND_DEFAULT
 	bool "Enable connection event extension by default"
-	default y
+	default y if !NRF_802154_RADIO_DRIVER
 	help
 	  When Extended Connection Events are disabled, the maximum connection event length is
 	  configured with BT_CTLR_SDC_MAX_CONN_EVENT_LEN_DEFAULT.

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -1197,7 +1197,7 @@ static int hci_driver_open(void)
 		}
 
 		sdc_hci_cmd_vs_conn_event_extend_t event_extend_params = {
-			.enable = CONFIG_BT_CTLR_SDC_CONN_EVENT_EXTEND_DEFAULT
+			.enable = IS_ENABLED(CONFIG_BT_CTLR_SDC_CONN_EVENT_EXTEND_DEFAULT)
 		};
 		err = sdc_hci_cmd_vs_conn_event_extend(&event_extend_params);
 		if (err) {

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -1195,6 +1195,15 @@ static int hci_driver_open(void)
 			MULTITHREADING_LOCK_RELEASE();
 			return -ENOTSUP;
 		}
+
+		sdc_hci_cmd_vs_conn_event_extend_t event_extend_params = {
+			.enable = CONFIG_BT_CTLR_SDC_CONN_EVENT_EXTEND_DEFAULT
+		};
+		err = sdc_hci_cmd_vs_conn_event_extend(&event_extend_params);
+		if (err) {
+			MULTITHREADING_LOCK_RELEASE();
+			return -ENOTSUP;
+		}
 	}
 
 	if (IS_ENABLED(CONFIG_BT_CENTRAL)) {


### PR DESCRIPTION
Define CONFIG_BT_CTLR_SDC_CONN_EVENT_EXTEND_DEFAULT to allow
users to enable and disable connection event extension in a simpler
way.

We do not want to enable connection event extension when
802.15.4 protocols are enabled as we would like to reserve as much time
as possible for those protocols.

Disabling the setting has no practical consequence when connected
to a single Bluetooth device, but it improves performance
significantly when connected to two or more Bluetooth devices.

Ref: DRGN-21305