### PR TITLE
tools: add riscv64-zephyr-elf to toolchain

### DIFF
--- a/scripts/requirements-build.txt
+++ b/scripts/requirements-build.txt
@@ -1,7 +1,7 @@
 cbor2>=5.4.2.post1
 clang-format
 ecdsa
-cryptography>=36.0.0
+cryptography>=42.0.0
 imagesize>=1.2.0
 intelhex
 pylint

--- a/scripts/requirements-fixed.txt
+++ b/scripts/requirements-fixed.txt
@@ -24,7 +24,7 @@ click==8.0.3              # via -r bootloader/mcuboot/scripts/requirements.txt, 
 cmsis-pack-manager==0.5.2  # via pyocd
 colorama==0.4.6           # via -r zephyr/scripts/requirements-build-test.txt, pyocd, west
 coverage==7.3.1           # via -r zephyr/scripts/requirements-build-test.txt
-cryptography==41.0.6      # via -r bootloader/mcuboot/scripts/requirements.txt, -r nrf/scripts/requirements-build.txt, imgtool, pyjwt
+cryptography==42.0.2      # via -r bootloader/mcuboot/scripts/requirements.txt, -r nrf/scripts/requirements-build.txt, imgtool, pyjwt
 deprecated==1.2.14        # via pygithub
 dill==0.3.7               # via pylint
 docopt==0.6.2             # via pykwalify

--- a/scripts/tools-versions-darwin.yml
+++ b/scripts/tools-versions-darwin.yml
@@ -20,5 +20,6 @@ zephyr-sdk:
     - aarch64-zephyr-elf
     - x86_64-zephyr-elf
     - arm-zephyr-eabi
+    - riscv64-zephyr-elf
 doxygen:
   version: 1.9.2

--- a/scripts/tools-versions-linux.yml
+++ b/scripts/tools-versions-linux.yml
@@ -22,6 +22,7 @@ zephyr-sdk:
     - aarch64-zephyr-elf
     - x86_64-zephyr-elf
     - arm-zephyr-eabi
+    - riscv64-zephyr-elf
 ccache:
   version: 4.8.2
 dfu_util:

--- a/scripts/tools-versions-win10.yml
+++ b/scripts/tools-versions-win10.yml
@@ -20,5 +20,6 @@ zephyr-sdk:
     - aarch64-zephyr-elf
     - x86_64-zephyr-elf
     - arm-zephyr-eabi
+    - riscv64-zephyr-elf
 doxygen:
   version: 1.9.2


### PR DESCRIPTION
This compiler is used for nRF54 code samples.