### PR TITLE
manifest: update zephyr with latest hal_nordic

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: aa2eeb1a34df2d9abcdb46c9b85aafbf8fbc768f
+      revision: 3abe0f7f364787d02cabdaa5e3445d2e85febe57
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This commit brings zephyr with hal_nordic updated with nrfx and nrf_802154 radio driver.