### PR TITLE
manifest: sdk-nrfxlib: Support for CSP package in Host driver

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -142,7 +142,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 5bc2f4c90989639bf4d6c2275c241523cdfe30c2
+      revision: 622afe102c933c660d20ef811822a71d1c016845
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
[SHEL-2310]: Modify host driver to read package type from OTP. Use this package type information to pick RF parameters.

[SHEL-2310]: https://nordicsemi.atlassian.net/browse/SHEL-2310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ