### PR TITLE
Buffer Overflow fix

### DIFF
--- a/samples/wifi/raw_tx_packet/src/wifi_connection.c
+++ b/samples/wifi/raw_tx_packet/src/wifi_connection.c
@@ -68,7 +68,7 @@ static int cmd_wifi_status(void)
 		       wifi_mode_txt(status.iface_mode));
 		LOG_INF("Link Mode: %s",
 		       wifi_link_mode_txt(status.link_mode));
-		LOG_INF("SSID: %-32s", status.ssid);
+		LOG_INF("SSID: %.32s", status.ssid);
 		LOG_INF("BSSID: %s",
 		       net_sprint_ll_addr_buf(
 				status.bssid, WIFI_MAC_ADDR_LEN,

--- a/samples/wifi/scan/src/main.c
+++ b/samples/wifi/scan/src/main.c
@@ -122,6 +122,7 @@ static void handle_wifi_scan_result(struct net_mgmt_event_callback *cb)
 	const struct wifi_scan_result *entry =
 		(const struct wifi_scan_result *)cb->info;
 	uint8_t mac_string_buf[sizeof("xx:xx:xx:xx:xx:xx")];
+	uint8_t ssid_print[WIFI_SSID_MAX_LEN + 1];
 
 	scan_result++;
 
@@ -130,12 +131,15 @@ static void handle_wifi_scan_result(struct net_mgmt_event_callback *cb)
 		       "Num", "SSID", "(len)", "Chan", "RSSI", "Security", "BSSID");
 	}
 
+	strncpy(ssid_print, entry->ssid, sizeof(ssid_print) - 1);
+	ssid_print[sizeof(ssid_print) - 1] = '\0';
+
 #if defined CONFIG_WIFI_NRF700X_SKIP_LOCAL_ADMIN_MAC
-	__ASSERT(!local_mac_check(entry->mac), "Locally administered MAC found: %s\n", entry->ssid);
+	__ASSERT(!local_mac_check(entry->mac), "Locally administered MAC found: %s\n", ssid_print);
 #endif /* CONFIG_WIFI_NRF700X_SKIP_LOCAL_ADMIN_MAC */
 
 	printk("%-4d | %-32s %-5u | %-4u | %-4d | %-5s | %s\n",
-	       scan_result, entry->ssid, entry->ssid_length,
+	       scan_result, ssid_print, entry->ssid_length,
 	       entry->channel, entry->rssi,
 	       wifi_security_txt(entry->security),
 	       ((entry->mac_length) ?

--- a/samples/wifi/shutdown/src/main.c
+++ b/samples/wifi/shutdown/src/main.c
@@ -50,6 +50,7 @@ static void handle_wifi_scan_result(struct net_mgmt_event_callback *cb)
 	const struct wifi_scan_result *entry =
 		(const struct wifi_scan_result *)cb->info;
 	uint8_t mac_string_buf[sizeof("xx:xx:xx:xx:xx:xx")];
+	uint8_t ssid_print[WIFI_SSID_MAX_LEN + 1];
 
 	scan_result++;
 
@@ -58,8 +59,11 @@ static void handle_wifi_scan_result(struct net_mgmt_event_callback *cb)
 		       "Num", "SSID", "(len)", "Chan", "RSSI", "Security", "BSSID");
 	}
 
+	strncpy(ssid_print, entry->ssid, sizeof(ssid_print) - 1);
+	ssid_print[sizeof(ssid_print) - 1] = '\0';
+
 	printk("%-4d | %-32s %-5u | %-4u | %-4d | %-5s | %s\n",
-	       scan_result, entry->ssid, entry->ssid_length,
+	       scan_result, ssid_print, entry->ssid_length,
 	       entry->channel, entry->rssi,
 	       (entry->security == WIFI_SECURITY_TYPE_PSK ? "WPA/WPA2" : "Open    "),
 	       ((entry->mac_length) ?

--- a/samples/wifi/sr_coex/src/main.c
+++ b/samples/wifi/sr_coex/src/main.c
@@ -100,7 +100,7 @@ static int cmd_wifi_status(void)
 		       wifi_mode_txt(status.iface_mode));
 		LOG_INF("Link Mode: %s\n",
 		       wifi_link_mode_txt(status.link_mode));
-		LOG_INF("SSID: %-32s\n", status.ssid);
+		LOG_INF("SSID: %.32s\n", status.ssid);
 		LOG_INF("BSSID: %s\n",
 		       net_sprint_ll_addr_buf(
 				status.bssid, WIFI_MAC_ADDR_LEN,

--- a/samples/wifi/sta/src/main.c
+++ b/samples/wifi/sta/src/main.c
@@ -114,7 +114,7 @@ static int cmd_wifi_status(void)
 		       wifi_mode_txt(status.iface_mode));
 		LOG_INF("Link Mode: %s",
 		       wifi_link_mode_txt(status.link_mode));
-		LOG_INF("SSID: %-32s", status.ssid);
+		LOG_INF("SSID: %.32s", status.ssid);
 		LOG_INF("BSSID: %s",
 		       net_sprint_ll_addr_buf(
 				status.bssid, WIFI_MAC_ADDR_LEN,

--- a/samples/wifi/twt/src/main.c
+++ b/samples/wifi/twt/src/main.c
@@ -151,7 +151,7 @@ static int cmd_wifi_status(void)
 		       wifi_mode_txt(status.iface_mode));
 		LOG_INF("Link Mode: %s",
 		       wifi_link_mode_txt(status.link_mode));
-		LOG_INF("SSID: %-32s", status.ssid);
+		LOG_INF("SSID: %.32s", status.ssid);
 		LOG_INF("BSSID: %s",
 		       net_sprint_ll_addr_buf(
 				status.bssid, WIFI_MAC_ADDR_LEN,


### PR DESCRIPTION
The samples are showing junk character in SSID because of the length of ssid is maximum(32 character) which leads to buffer overflow.