### PR TITLE
samples: matter: common: Integrate Matter common module with CMake

### DIFF
--- a/applications/matter_bridge/CMakeLists.txt
+++ b/applications/matter_bridge/CMakeLists.txt
@@ -23,44 +23,37 @@ find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 
 project(matter-bridge)
 
-set(COMMON_ROOT ${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common)
-set(NLIO_ROOT ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/third_party/nlio/repo)
+# Enable GNU STD support and initialize the Matter Data Model.
 include(${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/app/enable-gnu-std.cmake)
 include(${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/chip_data_model.cmake)
 
 # NORDIC SDK APP START
+
+# Include all source files that are located in the Matter common directory.
+include(${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common/cmake/source_common.cmake)
+
 target_include_directories(app PRIVATE
     src
     src/bridged_device_types
-    ${COMMON_ROOT}/src
-    ${COMMON_ROOT}/src/bridge/
-    ${COMMON_ROOT}/src/bridge/util
-    ${NLIO_ROOT}/include
-    ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/zzz_generated/app-common
+    ${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common/src/bridge/
+    ${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common/src/bridge/util
 )
 
 target_sources(app PRIVATE
     src/app_task.cpp
     src/main.cpp
     src/bridge_shell.cpp
-    ${COMMON_ROOT}/src/bridge/bridge_manager.cpp
-    ${COMMON_ROOT}/src/bridge/matter_bridged_device.cpp
-    ${COMMON_ROOT}/src/bridge/bridge_storage_manager.cpp
-    ${COMMON_ROOT}/src/bridge/bridged_device_data_provider.cpp
-    ${COMMON_ROOT}/src/binding/binding_handler.cpp
-    src/zap-generated/IMClusterCommandHandler.cpp
-    src/zap-generated/callback-stub.cpp
-    ${COMMON_ROOT}/src/board/led_widget.cpp
-    ${COMMON_ROOT}/src/persistent_storage/persistent_storage_util.cpp
-    ${COMMON_ROOT}/src/app/task_executor.cpp
-    ${COMMON_ROOT}/src/board/board.cpp
-    ${COMMON_ROOT}/src/app/matter_init.cpp
-    ${COMMON_ROOT}/src/app/matter_event_handler.cpp
+    ${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common/src/bridge/bridge_manager.cpp
+    ${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common/src/bridge/matter_bridged_device.cpp
+    ${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common/src/bridge/bridge_storage_manager.cpp
+    ${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common/src/bridge/bridged_device_data_provider.cpp
+    ${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common/src/binding/binding_handler.cpp
+    ${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common/src/persistent_storage/persistent_storage_util.cpp
 )
 
 if(CONFIG_BRIDGED_DEVICE_BT)
     target_sources(app PRIVATE
-        ${COMMON_ROOT}/src/bridge/ble_connectivity_manager.cpp
+         ${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common/src/bridge/ble_connectivity_manager.cpp
         src/ble_providers/ble_bridged_device_factory.cpp
     )
     target_include_directories(app PRIVATE src/ble_providers)
@@ -145,14 +138,6 @@ if(CONFIG_BRIDGE_HUMIDITY_SENSOR_BRIDGED_DEVICE)
 endif() # CONFIG_BRIDGE_HUMIDITY_SENSOR_BRIDGED_DEVICE
 
 endif() # CONFIG_BRIDGED_DEVICE_BT
-
-if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_TRANSPORT_BT)
-    target_sources(app PRIVATE ${COMMON_ROOT}/src/dfu/ota/ota_util.cpp)
-endif()
-
-if(CONFIG_MCUMGR_TRANSPORT_BT)
-    target_sources(app PRIVATE ${COMMON_ROOT}/src/dfu/smp/dfu_over_smp.cpp)
-endif()
 
 chip_configure_data_model(app
     INCLUDE_SERVER

--- a/applications/matter_weather_station/CMakeLists.txt
+++ b/applications/matter_weather_station/CMakeLists.txt
@@ -17,17 +17,17 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(matter-weather-station)
 
-set(COMMON_ROOT ${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common)
-set(NLIO_ROOT ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/third_party/nlio/repo)
+# Enable GNU STD support and initialize the Matter Data Model.
 include(${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/app/enable-gnu-std.cmake)
 include(${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/chip_data_model.cmake)
 
 # NORDIC SDK APP START
+
+# Include all source files that are located in the Matter common directory.
+include(${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common/cmake/source_common.cmake)
+
 target_include_directories(app PRIVATE
     src
-    ${COMMON_ROOT}/src
-    ${NLIO_ROOT}/include
-    ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/zzz_generated/app-common
 )
 
 target_sources(app PRIVATE
@@ -35,23 +35,7 @@ target_sources(app PRIVATE
     src/main.cpp
     src/battery.cpp
     src/buzzer.cpp
-    src/zap-generated/IMClusterCommandHandler.cpp
-    src/zap-generated/callback-stub.cpp
-    ${COMMON_ROOT}/src/board/led_widget.cpp
-    ${COMMON_ROOT}/src/dfu/smp/dfu_over_smp.cpp
-    ${COMMON_ROOT}/src/app/task_executor.cpp
-    ${COMMON_ROOT}/src/board/board.cpp
-    ${COMMON_ROOT}/src/app/matter_init.cpp
-    ${COMMON_ROOT}/src/app/matter_event_handler.cpp
 )
-
-if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_TRANSPORT_BT)
-    target_sources(app PRIVATE ${COMMON_ROOT}/src/dfu/ota/ota_util.cpp)
-endif()
-
-if(CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS)
-    target_sources(app PRIVATE ${COMMON_ROOT}/src/migration/migration_manager.cpp)
-endif()
 
 chip_configure_data_model(app
     INCLUDE_SERVER

--- a/doc/nrf/releases_and_maturity/migration/migration_guide_2.6.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_guide_2.6.rst
@@ -114,6 +114,14 @@ The following changes are recommended for your application to work optimally aft
   * The new API and helper modules have been added to the :file:`samples/matter/common` directory.
     All Matter samples and applications have been changed to use the common software modules.
 
+    The inclusion of common software module source code in the CMake application target has been moved to the :file:`samples/matter/common/cmake/source_common.cmake` file.
+    Source code for specific software modules is added automatically based on the selected Kconfig options.
+    To include all required source code files, add the following line to the :file:`CMakeLists.txt` file in your project directory:
+
+    .. code-block:: console
+
+      include(${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common/cmake/source_common.cmake)
+
     You can follow the new approach and migrate your application to use the common software modules.
     This will significantly reduce the size of the code required to be implemented in the application.
     You can also choose to keep using the previous approach, but due to the structural differences, it may be harder to use Matter samples and applications as a reference for an application using the older approach.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -558,6 +558,7 @@ Matter samples
   * Divided events to application and system events.
   * Defined common LED and button constants in the dedicated board configuration files.
   * Created the Kconfig file for the Matter common directory.
+  * Created a CMake file in the Matter common directory to centralize the sourcing of all common software module source code.
 
 * Disabled :ref:`ug_matter_configuring_read_client` in most Matter samples using the new :kconfig:option:`CONFIG_CHIP_ENABLE_READ_CLIENT` Kconfig option.
 

--- a/samples/matter/common/cmake/source_common.cmake
+++ b/samples/matter/common/cmake/source_common.cmake
@@ -1,0 +1,42 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+set(MATTER_COMMONS_SRC_DIR ${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common/src)
+
+target_include_directories(app PRIVATE
+    ${MATTER_COMMONS_SRC_DIR}
+)
+
+# Set sources that are used by all samples
+target_sources(app PRIVATE
+    ${MATTER_COMMONS_SRC_DIR}/board/led_widget.cpp
+    ${MATTER_COMMONS_SRC_DIR}/board/board.cpp
+    ${MATTER_COMMONS_SRC_DIR}/app/task_executor.cpp
+    ${MATTER_COMMONS_SRC_DIR}/app/matter_init.cpp
+    ${MATTER_COMMONS_SRC_DIR}/app/matter_event_handler.cpp
+)
+
+# Set specific sources that depend on Kconfigs
+if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_TRANSPORT_BT)
+    target_sources(app PRIVATE ${MATTER_COMMONS_SRC_DIR}/dfu/ota/ota_util.cpp)
+endif()
+
+if(CONFIG_PWM)
+    target_sources(app PRIVATE ${MATTER_COMMONS_SRC_DIR}/pwm/pwm_device.cpp)
+endif()
+
+if(CONFIG_MCUMGR_TRANSPORT_BT)
+    zephyr_library_link_libraries(MCUBOOT_BOOTUTIL)
+    target_sources(app PRIVATE ${MATTER_COMMONS_SRC_DIR}/dfu/smp/dfu_over_smp.cpp)
+endif()
+
+if(CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS)
+    target_sources(app PRIVATE ${MATTER_COMMONS_SRC_DIR}/migration/migration_manager.cpp)
+endif()
+
+if(CONFIG_CHIP_NUS)
+    target_sources(app PRIVATE ${MATTER_COMMONS_SRC_DIR}/bt_nus/bt_nus_service.cpp)
+endif()

--- a/samples/matter/light_bulb/CMakeLists.txt
+++ b/samples/matter/light_bulb/CMakeLists.txt
@@ -24,17 +24,17 @@ find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 
 project(matter-light-bulb)
 
-set(COMMON_ROOT ${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common)
-set(NLIO_ROOT ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/third_party/nlio/repo)
+# Enable GNU STD support and initialize the Matter Data Model.
 include(${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/app/enable-gnu-std.cmake)
 include(${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/chip_data_model.cmake)
 
 # NORDIC SDK APP START
+
+# Include all source files that are located in the Matter common directory.
+include(${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common/cmake/source_common.cmake)
+
 target_include_directories(app PRIVATE
     src
-    ${COMMON_ROOT}/src
-    ${NLIO_ROOT}/include
-    ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/zzz_generated/app-common
 )
 
 if(CONFIG_AWS_IOT_INTEGRATION)
@@ -45,28 +45,7 @@ target_sources(app PRIVATE
     src/app_task.cpp
     src/main.cpp
     src/zcl_callbacks.cpp
-    src/zap-generated/IMClusterCommandHandler.cpp
-    src/zap-generated/callback-stub.cpp
-    ${COMMON_ROOT}/src/board/led_widget.cpp
-    ${COMMON_ROOT}/src/pwm/pwm_device.cpp
-    ${COMMON_ROOT}/src/app/task_executor.cpp
-    ${COMMON_ROOT}/src/board/board.cpp
-    ${COMMON_ROOT}/src/app/matter_init.cpp
-    ${COMMON_ROOT}/src/app/matter_event_handler.cpp
 )
-
-if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_TRANSPORT_BT)
-    target_sources(app PRIVATE ${COMMON_ROOT}/src/dfu/ota/ota_util.cpp)
-endif()
-
-if(CONFIG_MCUMGR_TRANSPORT_BT)
-    zephyr_library_link_libraries(MCUBOOT_BOOTUTIL)
-    target_sources(app PRIVATE ${COMMON_ROOT}/src/dfu/smp/dfu_over_smp.cpp)
-endif()
-
-if(CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS)
-    target_sources(app PRIVATE ${COMMON_ROOT}/src/migration/migration_manager.cpp)
-endif()
 
 chip_configure_data_model(app
     INCLUDE_SERVER

--- a/samples/matter/light_switch/CMakeLists.txt
+++ b/samples/matter/light_switch/CMakeLists.txt
@@ -24,17 +24,17 @@ find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 
 project(matter-light-switch)
 
-set(COMMON_ROOT ${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common)
-set(NLIO_ROOT ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/third_party/nlio/repo)
+# Enable GNU STD support and initialize the Matter Data Model.
 include(${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/app/enable-gnu-std.cmake)
 include(${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/chip_data_model.cmake)
 
 # NORDIC SDK APP START
+
+# Include all source files that are located in the Matter common directory.
+include(${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common/cmake/source_common.cmake)
+
 target_include_directories(app PRIVATE
     src
-    ${COMMON_ROOT}/src
-    ${NLIO_ROOT}/include
-    ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/zzz_generated/app-common
 )
 
 target_compile_options(app PRIVATE -Wno-deprecated-declarations)
@@ -44,28 +44,8 @@ target_sources(app PRIVATE
     src/light_switch.cpp
     src/main.cpp
     src/shell_commands.cpp
-    src/zap-generated/IMClusterCommandHandler.cpp
-    src/zap-generated/callback-stub.cpp
-    ${COMMON_ROOT}/src/binding/binding_handler.cpp
-    ${COMMON_ROOT}/src/board/led_widget.cpp
-    ${COMMON_ROOT}/src/board/board.cpp
-    ${COMMON_ROOT}/src/app/task_executor.cpp
-    ${COMMON_ROOT}/src/app/matter_init.cpp
-    ${COMMON_ROOT}/src/app/matter_event_handler.cpp
+    ${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common/src/binding/binding_handler.cpp
 )
-
-if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_TRANSPORT_BT)
-    target_sources(app PRIVATE ${COMMON_ROOT}/src/dfu/ota/ota_util.cpp)
-endif()
-
-if(CONFIG_MCUMGR_TRANSPORT_BT)
-    zephyr_library_link_libraries(MCUBOOT_BOOTUTIL)
-    target_sources(app PRIVATE ${COMMON_ROOT}/src/dfu/smp/dfu_over_smp.cpp)
-endif()
-
-if(CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS)
-    target_sources(app PRIVATE ${COMMON_ROOT}/src/migration/migration_manager.cpp)
-endif()
 
 chip_configure_data_model(app
     INCLUDE_SERVER
@@ -73,5 +53,4 @@ chip_configure_data_model(app
     GEN_DIR src/zap-generated
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/src/light_switch.zap
 )
-
 # NORDIC SDK APP END

--- a/samples/matter/lock/CMakeLists.txt
+++ b/samples/matter/lock/CMakeLists.txt
@@ -11,7 +11,7 @@ set(mcuboot_KCONFIG_ROOT "\\\${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconn
 set(multiprotocol_rpmsg_KCONFIG_ROOT "\\\${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/chip-module/Kconfig.multiprotocol_rpmsg.root")
 set(hci_ipc_KCONFIG_ROOT "\\\${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/chip-module/Kconfig.hci_ipc.root")
 
-# For prj.conf the CONF_FILE is empty. In other case extract the exact file name from the path string.
+# For prj.conf the CONF_FILE is empty. In other cases extract the exact file name from the path string.
 if(CONF_FILE)
     get_filename_component(CONF_FILE_NAME ${CONF_FILE} NAME CACHE)
 endif()
@@ -29,17 +29,17 @@ find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 
 project(matter-lock)
 
-set(COMMON_ROOT ${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common)
-set(NLIO_ROOT ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/third_party/nlio/repo)
+# Enable GNU STD support and initialize the Matter Data Model.
 include(${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/app/enable-gnu-std.cmake)
 include(${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/chip_data_model.cmake)
 
 # NORDIC SDK APP START
+
+# Include all source files that are located in the Matter common directory.
+include(${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common/cmake/source_common.cmake)
+
 target_include_directories(app PRIVATE
     src
-    ${COMMON_ROOT}/src
-    ${NLIO_ROOT}/include
-    ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/zzz_generated/app-common
 )
 
 target_sources(app PRIVATE
@@ -47,38 +47,18 @@ target_sources(app PRIVATE
     src/bolt_lock_manager.cpp
     src/main.cpp
     src/zcl_callbacks.cpp
-    src/zap-generated/callback-stub.cpp
-    src/zap-generated/IMClusterCommandHandler.cpp
-    ${COMMON_ROOT}/src/board/led_widget.cpp
-    ${COMMON_ROOT}/src/app/task_executor.cpp
-    ${COMMON_ROOT}/src/board/board.cpp
-    ${COMMON_ROOT}/src/app/matter_init.cpp
-    ${COMMON_ROOT}/src/app/matter_event_handler.cpp
 )
 
-if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_TRANSPORT_BT)
-    target_sources(app PRIVATE ${COMMON_ROOT}/src/dfu/ota/ota_util.cpp)
-endif()
-
-if(CONFIG_CHIP_NUS)
-    target_sources(app PRIVATE ${COMMON_ROOT}/src/bt_nus/bt_nus_service.cpp)
-endif()
-
-if(CONFIG_MCUMGR_TRANSPORT_BT)
-    zephyr_library_link_libraries(MCUBOOT_BOOTUTIL)
-    target_sources(app PRIVATE ${COMMON_ROOT}/src/dfu/smp/dfu_over_smp.cpp)
-endif()
-
 if(CONFIG_THREAD_WIFI_SWITCHING)
-    target_sources(app PRIVATE src/thread_wifi_switch.cpp)
+    target_sources(app PRIVATE src/thread_wifi_switch.cpp
+        # TODO: Remove the following lines once there is LTO support for the Zephyr library
+        src/zap-generated/callback-stub.cpp
+        src/zap-generated/IMClusterCommandHandler.cpp
+    )
 
     # Enable link-time optimization for the app and WPA supplicant libraries
     target_compile_options(app PRIVATE -flto)
     target_compile_options(..__nrf__modules__hostap PRIVATE -flto)
-endif()
-
-if(CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS)
-    target_sources(app PRIVATE ${COMMON_ROOT}/src/migration/migration_manager.cpp)
 endif()
 
 chip_configure_data_model(app

--- a/samples/matter/template/CMakeLists.txt
+++ b/samples/matter/template/CMakeLists.txt
@@ -24,43 +24,23 @@ find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 
 project(matter-template)
 
-set(COMMON_ROOT ${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common)
-set(NLIO_ROOT ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/third_party/nlio/repo)
+# Enable GNU STD support and initialize the Matter Data Model.
 include(${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/app/enable-gnu-std.cmake)
 include(${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/chip_data_model.cmake)
 
 # NORDIC SDK APP START
+
+# Include all source files that are located in the Matter common directory.
+include(${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common/cmake/source_common.cmake)
+
 target_include_directories(app PRIVATE
     src
-    ${COMMON_ROOT}/src
-    ${NLIO_ROOT}/include
-    ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/zzz_generated/app-common
 )
 
 target_sources(app PRIVATE
     src/app_task.cpp
     src/main.cpp
-    src/zap-generated/IMClusterCommandHandler.cpp
-    src/zap-generated/callback-stub.cpp
-    ${COMMON_ROOT}/src/board/led_widget.cpp
-    ${COMMON_ROOT}/src/app/task_executor.cpp
-    ${COMMON_ROOT}/src/board/board.cpp
-    ${COMMON_ROOT}/src/app/matter_init.cpp
-    ${COMMON_ROOT}/src/app/matter_event_handler.cpp
 )
-
-if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_TRANSPORT_BT)
-    target_sources(app PRIVATE ${COMMON_ROOT}/src/dfu/ota/ota_util.cpp)
-endif()
-
-if(CONFIG_MCUMGR_TRANSPORT_BT)
-    zephyr_library_link_libraries(MCUBOOT_BOOTUTIL)
-    target_sources(app PRIVATE ${COMMON_ROOT}/src/dfu/smp/dfu_over_smp.cpp)
-endif()
-
-if(CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS)
-    target_sources(app PRIVATE ${COMMON_ROOT}/src/migration/migration_manager.cpp)
-endif()
 
 chip_configure_data_model(app
     INCLUDE_SERVER

--- a/samples/matter/thermostat/CMakeLists.txt
+++ b/samples/matter/thermostat/CMakeLists.txt
@@ -24,17 +24,17 @@ find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 
 project(matter-template)
 
-set(COMMON_ROOT ${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common)
-set(NLIO_ROOT ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/third_party/nlio/repo)
+# Enable GNU STD support and initialize the Matter Data Model.
 include(${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/app/enable-gnu-std.cmake)
 include(${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/chip_data_model.cmake)
 
 # NORDIC SDK APP START
+
+# Include all source files that are located in the Matter common directory.
+include(${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common/cmake/source_common.cmake)
+
 target_include_directories(app PRIVATE
     src
-    ${COMMON_ROOT}/src
-    ${NLIO_ROOT}/include
-    ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/zzz_generated/app-common
 )
 
 target_sources(app PRIVATE
@@ -44,28 +44,8 @@ target_sources(app PRIVATE
     src/temperature_manager.cpp
     src/temperature_measurement/sensor.cpp
     src/zcl_callbacks.cpp
-    src/zap-generated/IMClusterCommandHandler.cpp
-    src/zap-generated/callback-stub.cpp
-    ${COMMON_ROOT}/src/binding/binding_handler.cpp
-    ${COMMON_ROOT}/src/board/led_widget.cpp
-    ${COMMON_ROOT}/src/app/task_executor.cpp
-    ${COMMON_ROOT}/src/board/board.cpp
-    ${COMMON_ROOT}/src/app/matter_init.cpp
-    ${COMMON_ROOT}/src/app/matter_event_handler.cpp
+    ${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common/src/binding/binding_handler.cpp
 )
-
-if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_TRANSPORT_BT)
-    target_sources(app PRIVATE ${COMMON_ROOT}/src/dfu/ota/ota_util.cpp)
-endif()
-
-if(CONFIG_MCUMGR_TRANSPORT_BT)
-    zephyr_library_link_libraries(MCUBOOT_BOOTUTIL)
-    target_sources(app PRIVATE ${COMMON_ROOT}/src/dfu/smp/dfu_over_smp.cpp)
-endif()
-
-if(CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS)
-    target_sources(app PRIVATE ${COMMON_ROOT}/src/migration/migration_manager.cpp)
-endif()
 
 chip_configure_data_model(app
     INCLUDE_SERVER

--- a/samples/matter/window_covering/CMakeLists.txt
+++ b/samples/matter/window_covering/CMakeLists.txt
@@ -23,17 +23,17 @@ find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 
 project(matter-window-app)
 
-set(COMMON_ROOT ${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common)
-set(NLIO_ROOT ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/third_party/nlio/repo)
+# Enable GNU STD support and initialize the Matter Data Model.
 include(${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/app/enable-gnu-std.cmake)
 include(${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/chip_data_model.cmake)
 
 # NORDIC SDK APP START
+
+# Include all source files that are located in the Matter common directory.
+include(${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common/cmake/source_common.cmake)
+
 target_include_directories(app PRIVATE
     src
-    ${COMMON_ROOT}/src
-    ${NLIO_ROOT}/include
-    ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/zzz_generated/app-common
 )
 
 target_sources(app PRIVATE
@@ -41,28 +41,7 @@ target_sources(app PRIVATE
     src/window_covering.cpp
     src/main.cpp
     src/zcl_callbacks.cpp
-    src/zap-generated/IMClusterCommandHandler.cpp
-    src/zap-generated/callback-stub.cpp
-    ${COMMON_ROOT}/src/board/led_widget.cpp
-    ${COMMON_ROOT}/src/pwm/pwm_device.cpp
-    ${COMMON_ROOT}/src/app/task_executor.cpp
-    ${COMMON_ROOT}/src/board/board.cpp
-    ${COMMON_ROOT}/src/app/matter_init.cpp
-    ${COMMON_ROOT}/src/app/matter_event_handler.cpp
 )
-
-if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_TRANSPORT_BT)
-    target_sources(app PRIVATE ${COMMON_ROOT}/src/dfu/ota/ota_util.cpp)
-endif()
-
-if(CONFIG_MCUMGR_TRANSPORT_BT)
-    zephyr_library_link_libraries(MCUBOOT_BOOTUTIL)
-    target_sources(app PRIVATE ${COMMON_ROOT}/src/dfu/smp/dfu_over_smp.cpp)
-endif()
-
-if(CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS)
-    target_sources(app PRIVATE ${COMMON_ROOT}/src/migration/migration_manager.cpp)
-endif()
 
 chip_configure_data_model(app
     INCLUDE_SERVER


### PR DESCRIPTION
This commit move cmake directives repeated in all applications/samples to one common cmake file.