### PR TITLE
modules: memfault: Report unkown operator if modem doesn't give one 

### DIFF
--- a/lib/modem_info/modem_info.c
+++ b/lib/modem_info/modem_info.c
@@ -974,8 +974,8 @@ int modem_info_get_operator(char *buf, size_t buf_size)
 				buf);
 
 	if (ret != 1) {
-		/* Warning instead of error because it is not always reported */
-		LOG_WRN("No valid operator");
+		/* Debug instead of error because it is not always reported */
+		LOG_DBG("No valid operator name found");
 		return map_nrf_modem_at_scanf_error(ret);
 	}
 

--- a/modules/memfault-firmware-sdk/memfault_lte_metrics.c
+++ b/modules/memfault-firmware-sdk/memfault_lte_metrics.c
@@ -221,7 +221,12 @@ void memfault_lte_metrics_update(void)
 
 	err = modem_info_get_operator(operator_name, sizeof(operator_name));
 	if (err != 0) {
-		LOG_WRN("Network operator collection failed, error: %d", err);
+		LOG_DBG("Network operator name was not reported by the modem");
+
+		err = MEMFAULT_METRIC_SET_STRING(ncs_lte_operator, "Not available");
+		if (err) {
+			LOG_ERR("Failed to set ncs_lte_operator");
+		}
 	} else {
 		err = MEMFAULT_METRIC_SET_STRING(ncs_lte_operator, operator_name);
 		if (err) {


### PR DESCRIPTION
Set the Memfault metric `ncs_lte_operator` to "Not reported" when
the modem does not provide an operator name to the application.