### PR TITLE
Bluetooth: Mesh: Make prop_format_get public

### DIFF
--- a/include/bluetooth/mesh/light_ctrl.h
+++ b/include/bluetooth/mesh/light_ctrl.h
@@ -14,6 +14,7 @@
 #define BT_MESH_LIGHT_CTRL_H__
 
 #include <bluetooth/mesh/properties.h>
+#include <bluetooth/mesh/sensor_types.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -182,6 +183,44 @@ enum bt_mesh_light_ctrl_coeff {
 	 */
 	BT_MESH_LIGHT_CTRL_COEFF_KPU = BT_MESH_PROP_ID_LIGHT_CTRL_REG_KPU,
 };
+
+/** @brief Get the sensor format for the given Light Lightness Control property ID.
+ *
+ *  @param[in] id Light Lightness Control property ID.
+ *
+ *  @return The associated sensor format, or NULL if the ID is unknown.
+ */
+static inline const struct bt_mesh_sensor_format *
+bt_mesh_lc_prop_format_get(uint16_t id)
+{
+	switch (id) {
+	case BT_MESH_LIGHT_CTRL_PROP_ILLUMINANCE_ON:
+	case BT_MESH_LIGHT_CTRL_PROP_ILLUMINANCE_PROLONG:
+	case BT_MESH_LIGHT_CTRL_PROP_ILLUMINANCE_STANDBY:
+		return &bt_mesh_sensor_format_illuminance;
+	case BT_MESH_LIGHT_CTRL_PROP_LIGHTNESS_ON:
+	case BT_MESH_LIGHT_CTRL_PROP_LIGHTNESS_PROLONG:
+	case BT_MESH_LIGHT_CTRL_PROP_LIGHTNESS_STANDBY:
+		return &bt_mesh_sensor_format_perceived_lightness;
+	case BT_MESH_LIGHT_CTRL_PROP_REG_ACCURACY:
+		return &bt_mesh_sensor_format_percentage_8;
+	case BT_MESH_LIGHT_CTRL_COEFF_KID:
+	case BT_MESH_LIGHT_CTRL_COEFF_KIU:
+	case BT_MESH_LIGHT_CTRL_COEFF_KPD:
+	case BT_MESH_LIGHT_CTRL_COEFF_KPU:
+		return &bt_mesh_sensor_format_coefficient;
+	case BT_MESH_LIGHT_CTRL_PROP_TIME_FADE_PROLONG:
+	case BT_MESH_LIGHT_CTRL_PROP_TIME_FADE_ON:
+	case BT_MESH_LIGHT_CTRL_PROP_TIME_FADE_STANDBY_AUTO:
+	case BT_MESH_LIGHT_CTRL_PROP_TIME_FADE_STANDBY_MANUAL:
+	case BT_MESH_LIGHT_CTRL_PROP_TIME_OCCUPANCY_DELAY:
+	case BT_MESH_LIGHT_CTRL_PROP_TIME_PROLONG:
+	case BT_MESH_LIGHT_CTRL_PROP_TIME_ON:
+		return &bt_mesh_sensor_format_time_millisecond_24;
+	default:
+		return NULL;
+	}
+}
 
 /** @cond INTERNAL_HIDDEN */
 #define BT_MESH_LIGHT_CTRL_OP_MODE_GET BT_MESH_MODEL_OP_2(0x82, 0x91)

--- a/subsys/bluetooth/mesh/light_ctrl_cli.c
+++ b/subsys/bluetooth/mesh/light_ctrl_cli.c
@@ -6,7 +6,6 @@
 
 #include <bluetooth/mesh/light_ctrl_cli.h>
 #include "model_utils.h"
-#include "light_ctrl_internal.h"
 #include "sensor.h"
 
 union prop_value {
@@ -134,7 +133,7 @@ static int handle_prop(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx
 		       net_buf_simple_pull_mem(buf, sizeof(float)),
 		       sizeof(float));
 	} else {
-		format = prop_format_get(id);
+		format = bt_mesh_lc_prop_format_get(id);
 		if (!format) {
 			return -ENOENT;
 		}
@@ -424,7 +423,7 @@ int bt_mesh_light_ctrl_cli_prop_set(struct bt_mesh_light_ctrl_cli *cli,
 	bt_mesh_model_msg_init(&buf, BT_MESH_LIGHT_CTRL_OP_PROP_SET);
 	net_buf_simple_add_le16(&buf, id);
 
-	format = prop_format_get(id);
+	format = bt_mesh_lc_prop_format_get(id);
 	if (!format) {
 		return -EINVAL;
 	}
@@ -471,7 +470,7 @@ int bt_mesh_light_ctrl_cli_prop_set_unack(struct bt_mesh_light_ctrl_cli *cli,
 	bt_mesh_model_msg_init(&buf, BT_MESH_LIGHT_CTRL_OP_PROP_SET_UNACK);
 	net_buf_simple_add_le16(&buf, id);
 
-	format = prop_format_get(id);
+	format = bt_mesh_lc_prop_format_get(id);
 	if (!format) {
 		return -EINVAL;
 	}

--- a/subsys/bluetooth/mesh/light_ctrl_internal.h
+++ b/subsys/bluetooth/mesh/light_ctrl_internal.h
@@ -14,45 +14,12 @@
 
 #include <bluetooth/mesh/light_ctrl.h>
 #include <bluetooth/mesh/sensor.h>
-#include <bluetooth/mesh/sensor_types.h>
 #include <bluetooth/mesh/properties.h>
 #include "sensor.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-static inline const struct bt_mesh_sensor_format *
-prop_format_get(uint16_t id)
-{
-	switch (id) {
-	case BT_MESH_LIGHT_CTRL_PROP_ILLUMINANCE_ON:
-	case BT_MESH_LIGHT_CTRL_PROP_ILLUMINANCE_PROLONG:
-	case BT_MESH_LIGHT_CTRL_PROP_ILLUMINANCE_STANDBY:
-		return &bt_mesh_sensor_format_illuminance;
-	case BT_MESH_LIGHT_CTRL_PROP_LIGHTNESS_ON:
-	case BT_MESH_LIGHT_CTRL_PROP_LIGHTNESS_PROLONG:
-	case BT_MESH_LIGHT_CTRL_PROP_LIGHTNESS_STANDBY:
-		return &bt_mesh_sensor_format_perceived_lightness;
-	case BT_MESH_LIGHT_CTRL_PROP_REG_ACCURACY:
-		return &bt_mesh_sensor_format_percentage_8;
-	case BT_MESH_LIGHT_CTRL_COEFF_KID:
-	case BT_MESH_LIGHT_CTRL_COEFF_KIU:
-	case BT_MESH_LIGHT_CTRL_COEFF_KPD:
-	case BT_MESH_LIGHT_CTRL_COEFF_KPU:
-		return &bt_mesh_sensor_format_coefficient;
-	case BT_MESH_LIGHT_CTRL_PROP_TIME_FADE_PROLONG:
-	case BT_MESH_LIGHT_CTRL_PROP_TIME_FADE_ON:
-	case BT_MESH_LIGHT_CTRL_PROP_TIME_FADE_STANDBY_AUTO:
-	case BT_MESH_LIGHT_CTRL_PROP_TIME_FADE_STANDBY_MANUAL:
-	case BT_MESH_LIGHT_CTRL_PROP_TIME_OCCUPANCY_DELAY:
-	case BT_MESH_LIGHT_CTRL_PROP_TIME_PROLONG:
-	case BT_MESH_LIGHT_CTRL_PROP_TIME_ON:
-		return &bt_mesh_sensor_format_time_millisecond_24;
-	default:
-		return NULL;
-	}
-}
 
 #ifdef CONFIG_BT_MESH_SENSOR_USE_LEGACY_SENSOR_VALUE
 static inline int prop_encode(struct net_buf_simple *buf,
@@ -61,7 +28,7 @@ static inline int prop_encode(struct net_buf_simple *buf,
 {
 	const struct bt_mesh_sensor_format *format;
 
-	format = prop_format_get(id);
+	format = bt_mesh_lc_prop_format_get(id);
 	if (!format) {
 		return -ENOENT;
 	}
@@ -75,7 +42,7 @@ static inline int prop_decode(struct net_buf_simple *buf,
 {
 	const struct bt_mesh_sensor_format *format;
 
-	format = prop_format_get(id);
+	format = bt_mesh_lc_prop_format_get(id);
 	if (!format) {
 		return -ENOENT;
 	}

--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -1152,7 +1152,7 @@ static int prop_get(struct net_buf_simple *buf,
 	struct bt_mesh_sensor_value sensor_val;
 	int err;
 	int64_t micro = 0;
-	const struct bt_mesh_sensor_format *format = prop_format_get(id);
+	const struct bt_mesh_sensor_format *format = bt_mesh_lc_prop_format_get(id);
 
 	if (!format) {
 		return -ENOENT;
@@ -1253,7 +1253,7 @@ static int prop_set(struct net_buf_simple *buf,
 {
 	struct bt_mesh_sensor_value val;
 	int err;
-	const struct bt_mesh_sensor_format *format = prop_format_get(id);
+	const struct bt_mesh_sensor_format *format = bt_mesh_lc_prop_format_get(id);
 	enum bt_mesh_sensor_value_status status;
 
 	if (!format) {

--- a/tests/bluetooth/tester/src/mmdl.c
+++ b/tests/bluetooth/tester/src/mmdl.c
@@ -16,7 +16,6 @@
 #include <sensor.h>
 #include <time_internal.h>
 #include <lightness_internal.h>
-#include <light_ctrl_internal.h>
 
 #define LOG_LEVEL CONFIG_BT_MESH_LOG_LEVEL
 #include "zephyr/logging/log.h"
@@ -3325,7 +3324,7 @@ static void light_lc_property_get(uint8_t *data, uint16_t len)
 		goto fail;
 	}
 
-	format = prop_format_get(id);
+	format = bt_mesh_lc_prop_format_get(id);
 	if (!format) {
 		LOG_ERR("Invalid format");
 		goto fail;
@@ -3381,7 +3380,7 @@ static void light_lc_property_set(uint8_t *data, uint16_t len)
 
 	net_buf_simple_init_with_data(buf, &cmd->val, sizeof(cmd->val));
 
-	format = prop_format_get(id);
+	format = bt_mesh_lc_prop_format_get(id);
 	if (!format) {
 		LOG_ERR("Invalid format");
 		goto fail;

--- a/tests/subsys/bluetooth/mesh/light_ctrl/src/main.c
+++ b/tests/subsys/bluetooth/mesh/light_ctrl/src/main.c
@@ -10,7 +10,7 @@
 #include <bluetooth/mesh/models.h>
 #include <bluetooth/mesh/light_ctrl_srv.h>
 #include <bluetooth/mesh/light_ctrl_reg_spec.h>
-#include "light_ctrl_internal.h"
+#include "sensor.h"
 
 #define FLAGS_CONFIGURATION (BIT(FLAG_STARTED) | BIT(FLAG_OCC_MODE))
 


### PR DESCRIPTION
Moves the `prop_format_get` function to public light control header to allow access to the sensor formats for
use with the new sensor API.