### PR TITLE
secure_storage: Store data in one file

### DIFF
--- a/samples/crypto/persistent_key_usage/boards/nrf52840dk_nrf52840.conf
+++ b/samples/crypto/persistent_key_usage/boards/nrf52840dk_nrf52840.conf
@@ -2,18 +2,10 @@
 CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
 CONFIG_PSA_CRYPTO_DRIVER_CC3XX=y
 
-# Using the Internal Trused Storage with the settings subsystem with the
-# littlefs backend to store the keys encrypted
 CONFIG_FLASH=y
 CONFIG_FLASH_PAGE_LAYOUT=y
 CONFIG_FLASH_MAP=y
-CONFIG_FILE_SYSTEM=y
-CONFIG_FILE_SYSTEM_LITTLEFS=y
+CONFIG_NVS=y
 CONFIG_SETTINGS=y
-CONFIG_SETTINGS_FILE=y
-CONFIG_SETTINGS_FILE_PATH="/0/settings/run"
+CONFIG_SETTINGS_NVS=y
 CONFIG_SECURE_STORAGE=y
-# The Secure Bootloader is needed to use the HUK
-CONFIG_SECURE_BOOT=y
-# Suppress FS errors on the first reset, with non existing settings file
-CONFIG_FS_LOG_LEVEL_OFF=y

--- a/samples/crypto/persistent_key_usage/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/samples/crypto/persistent_key_usage/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -2,16 +2,10 @@
 CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
 CONFIG_PSA_CRYPTO_DRIVER_CC3XX=y
 
-# Using the Internal Trused Storage with the settings subsystem with the
-# littlefs backend to store the keys encrypted
 CONFIG_FLASH=y
 CONFIG_FLASH_PAGE_LAYOUT=y
 CONFIG_FLASH_MAP=y
-CONFIG_FILE_SYSTEM=y
-CONFIG_FILE_SYSTEM_LITTLEFS=y
+CONFIG_NVS=y
 CONFIG_SETTINGS=y
-CONFIG_SETTINGS_FILE=y
-CONFIG_SETTINGS_FILE_PATH="/0/settings/run"
+CONFIG_SETTINGS_NVS=y
 CONFIG_SECURE_STORAGE=y
-# Suppress FS errors on the first reset, with non existing settings file
-CONFIG_FS_LOG_LEVEL_OFF=y

--- a/samples/crypto/persistent_key_usage/boards/nrf9160dk_nrf9160.conf
+++ b/samples/crypto/persistent_key_usage/boards/nrf9160dk_nrf9160.conf
@@ -2,16 +2,10 @@
 CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
 CONFIG_PSA_CRYPTO_DRIVER_CC3XX=y
 
-# Using the Internal Trused Storage with the settings subsystem with the
-# littlefs backend to store the keys encrypted
 CONFIG_FLASH=y
 CONFIG_FLASH_PAGE_LAYOUT=y
 CONFIG_FLASH_MAP=y
-CONFIG_FILE_SYSTEM=y
-CONFIG_FILE_SYSTEM_LITTLEFS=y
+CONFIG_NVS=y
 CONFIG_SETTINGS=y
-CONFIG_SETTINGS_FILE=y
-CONFIG_SETTINGS_FILE_PATH="/0/settings/run"
+CONFIG_SETTINGS_NVS=y
 CONFIG_SECURE_STORAGE=y
-# Suppress FS errors on the first reset, with non existing settings file
-CONFIG_FS_LOG_LEVEL_OFF=y

--- a/samples/crypto/persistent_key_usage/src/main.c
+++ b/samples/crypto/persistent_key_usage/src/main.c
@@ -73,7 +73,7 @@ int crypto_finish(void)
 	return APP_SUCCESS;
 }
 
-int generate_prersistent_key(void)
+int generate_persistent_key(void)
 {
 	psa_status_t status;
 
@@ -120,7 +120,7 @@ int main(void)
 		return APP_ERROR;
 	}
 
-	status = generate_prersistent_key();
+	status = generate_persistent_key();
 	if (status != APP_SUCCESS) {
 		LOG_INF(APP_ERROR_MESSAGE);
 		return APP_ERROR;

--- a/samples/crypto/persistent_key_usage/src/secure_storage_init.c
+++ b/samples/crypto/persistent_key_usage/src/secure_storage_init.c
@@ -6,34 +6,14 @@
 
 #include "settings/settings_file.h"
 #include <zephyr/device.h>
-#include <zephyr/fs/fs.h>
-#include <zephyr/fs/littlefs.h>
 #include <zephyr/logging/log.h>
-
-#define STORAGE_PARTITION    storage_partition
-#define STORAGE_PARTITION_ID FIXED_PARTITION_ID(STORAGE_PARTITION)
 
 LOG_MODULE_REGISTER(persistent_key_usage_secure_storage, LOG_LEVEL_DBG);
 
-/* LittleFS work area strcut */
-FS_LITTLEFS_DECLARE_DEFAULT_CONFIG(cstorage);
-static struct fs_mount_t littlefs_mnt = {
-	.type = FS_LITTLEFS,
-	.fs_data = &cstorage,
-	.storage_dev = (void *)STORAGE_PARTITION_ID,
-	.mnt_point = "/0",
-};
-
 static int setup_settings_backend(void)
 {
-	int rc;
+	int rc = settings_subsys_init();
 
-	rc = fs_mount(&littlefs_mnt);
-	if (rc != 0) {
-		LOG_ERR("%s failed (ret %d)", __func__, rc);
-		return rc;
-	}
-	rc = settings_subsys_init();
 	if (rc != 0) {
 		LOG_ERR("%s failed (ret %d)", __func__, rc);
 		return rc;

--- a/subsys/secure_storage/Kconfig
+++ b/subsys/secure_storage/Kconfig
@@ -158,9 +158,9 @@ choice SECURE_STORAGE_STORAGE_BACKEND
 
 config SECURE_STORAGE_STORAGE_BACKEND_SETTINGS
 	bool "Settings storage backend"
-	depends on SETTINGS
+	depends on SETTINGS_NVS
 	help
-	  Use the Settings subsystem to store the assets
+	  Use the Settings subsystem with NVS to store the assets
 
 endchoice # CONFIG_SECURE_STORAGE_STORAGE_BACKEND
 

--- a/subsys/secure_storage/src/aead/aead_crypt_psa_chachapoly.c
+++ b/subsys/secure_storage/src/aead/aead_crypt_psa_chachapoly.c
@@ -19,12 +19,6 @@ psa_status_t secure_storage_aead_init(void)
 	return psa_crypto_init();
 }
 
-size_t secure_storage_aead_get_encrypted_size(size_t data_size)
-{
-	return PSA_AEAD_ENCRYPT_OUTPUT_SIZE(PSA_KEY_TYPE_CHACHA20, PSA_ALG_CHACHA20_POLY1305,
-					    data_size);
-}
-
 static psa_status_t secure_storage_aead_psa_crypt(psa_key_usage_t key_usage, const void *key_buf,
 						  size_t key_len, const void *nonce_buf,
 						  size_t nonce_len, const void *add_buf,

--- a/subsys/secure_storage/src/storage_backend.h
+++ b/subsys/secure_storage/src/storage_backend.h
@@ -10,16 +10,15 @@
 #include <psa/error.h>
 #include <psa/storage_common.h>
 
-/* Gets an object of the exact object_size size */
-psa_status_t storage_get_object(const psa_storage_uid_t uid, const char *prefix, const char *suffix,
-				uint8_t *object_data, const size_t object_size);
+/* Gets an object up to object_size size */
+psa_status_t storage_get_object(const psa_storage_uid_t uid, const char *prefix, void *object_data,
+				const size_t object_size, size_t *object_length);
 
 /* Writes an object */
-psa_status_t storage_set_object(const psa_storage_uid_t uid, const char *prefix, char *suffix,
-				const uint8_t *object_data, const size_t object_size);
+psa_status_t storage_set_object(const psa_storage_uid_t uid, const char *prefix,
+				const void *object_data, const size_t object_size);
 
 /* Deletes an object */
-psa_status_t storage_remove_object(const psa_storage_uid_t uid, const char *prefix,
-				   const char *suffix);
+psa_status_t storage_remove_object(const psa_storage_uid_t uid, const char *prefix);
 
 #endif /* __STORAGE_BACKEND_H_*/


### PR DESCRIPTION
Instead of spreading nonce, size, flags and data over several files these are now stored in one blob. This should solve issues related to cleanup when one of the storage operation fails.

Ref: NCSDK-25493

test-sdk-nrf: test-pr-13893