### PR TITLE
lib: location: Fallback event and more data details

### DIFF
--- a/applications/asset_tracker_v2/src/modules/location_module.c
+++ b/applications/asset_tracker_v2/src/modules/location_module.c
@@ -415,8 +415,8 @@ void location_event_handler(const struct location_event_data *event_data)
 		stats.search_time = (uint32_t)(k_uptime_get() - stats.start_uptime);
 		LOG_DBG("  search time: %d ms", stats.search_time);
 
-		/* Only GNSS result is handled as cellular is handled
-		 * as part of LOCATION_EVT_CELLULAR_EXT_REQUEST
+		/* Only GNSS result is handled as cellular and Wi-Fi are handled
+		 * as part of LOCATION_EVT_CLOUD_LOCATION_EXT_REQUEST
 		 */
 		stats.satellites_tracked = 0;
 		if (event_data->method == LOCATION_METHOD_GNSS) {
@@ -500,6 +500,17 @@ void location_event_handler(const struct location_event_data *event_data)
 		cloud_location_request_pending = true;
 		break;
 #endif
+
+	case LOCATION_EVT_STARTED:
+		LOG_DBG("Location request has been started with '%s' method",
+			location_method_str(event_data->method));
+		break;
+
+	case LOCATION_EVT_FALLBACK:
+		LOG_DBG("Location fallback has occurred from '%s' to '%s'",
+			location_method_str(event_data->method),
+			location_method_str(event_data->fallback.next_method));
+		break;
 
 	default:
 		LOG_DBG("Getting location: Unknown event %d", event_data->id);

--- a/doc/nrf/libraries/modem/location.rst
+++ b/doc/nrf/libraries/modem/location.rst
@@ -122,6 +122,8 @@ The following diagram shows successful cellular positioning.
 The following diagram depicts a failure to find the GNSS fix, followed by a fallback to cloud positioning.
 Since the Wi-Fi and cellular positioning methods are one after another, they are combined to a single cloud positioning request.
 Both Wi-Fi APs and LTE cells are given to the application with a single :c:enum:`LOCATION_EVT_CLOUD_LOCATION_EXT_REQUEST` event.
+The :c:enum:`LOCATION_EVT_STARTED` and the :c:enum:`LOCATION_EVT_FALLBACK` events are sent,
+if the :kconfig:option:`CONFIG_LOCATION_DATA_DETAILS` Kconfig option is set.
 
 .. msc::
   hscale="1.3";
@@ -132,6 +134,7 @@ Both Wi-Fi APs and LTE cells are given to the application with a single :c:enum:
 
   Application => Loclib [label="location_request(&config)\nmethod list: GNSS, Wi-Fi, Cellular"];
   |||;
+  Application << Loclib [label="LOCATION_EVT_STARTED"];
   Application << Loclib [label="LOCATION_EVT_GNSS_ASSISTANCE_REQUEST"];
   Application => Cloud [label="Request A-GNSS data"];
   Application << Cloud [label="A-GNSS data"];
@@ -141,6 +144,7 @@ Both Wi-Fi APs and LTE cells are given to the application with a single :c:enum:
   Loclib rbox Loclib [label="GNSS timeout occurs"];
 
   Loclib rbox Loclib [label="Fallback to cloud positioning"];
+  Application << Loclib [label="LOCATION_EVT_FALLBACK"];
   Loclib rbox Loclib [label="Scan Wi-Fi and LTE networks"];
   |||;
   Application << Loclib [label="LOCATION_EVT_CLOUD_LOCATION_EXT_REQUEST"];

--- a/doc/nrf/libraries/modem/location.rst
+++ b/doc/nrf/libraries/modem/location.rst
@@ -60,6 +60,14 @@ The supported location methods are as follows:
 
 The ``cloud location`` method handles the location methods (cellular and Wi-Fi positioning)
 that scan for technology-specific information and sends it over to the cloud service for location resolution.
+If the following conditions are met, Wi-Fi and cellular scan results are combined into a single cloud request:
+
+* Methods are one after the other in the location request method list.
+* Location request mode is :c:enum:`LOCATION_REQ_MODE_FALLBACK`.
+* Requested cloud service for Wi-Fi and cellular is the same.
+
+A special :c:enum:`LOCATION_METHOD_WIFI_CELLULAR` method can appear within the :c:struct:`location_event_data` structure,
+but it cannot be added into the location configuration passed to the :c:func:`location_request` function.
 
 The default priority order of location methods is GNSS positioning, Wi-Fi positioning and Cellular positioning.
 If any of these methods are disabled, the method is simply omitted from the list.

--- a/doc/nrf/libraries/modem/location.rst
+++ b/doc/nrf/libraries/modem/location.rst
@@ -292,6 +292,10 @@ when :c:func:`location_config_defaults_set` function is called:
 * :kconfig:option:`CONFIG_LOCATION_REQUEST_DEFAULT_CELLULAR_CELL_COUNT`
 * :kconfig:option:`CONFIG_LOCATION_REQUEST_DEFAULT_WIFI_TIMEOUT`
 
+The following option adds more details to the :c:struct:`location_event_data` structure:
+
+* :kconfig:option:`CONFIG_LOCATION_DATA_DETAILS`
+
 Usage
 *****
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -754,6 +754,7 @@ Modem libraries
     * The :c:enumerator:`LOCATION_EVT_STARTED` event to indicate that location request has been started.
       This is for metrics collection purposes and sent only if the :kconfig:option:`CONFIG_LOCATION_DATA_DETAILS` Kconfig option is set.
     * Support for multiple event handlers.
+    * Additional location data details into the :c:struct:`location_data_details` structure hierarchy.
 
   * Updated:
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -756,6 +756,8 @@ Modem libraries
       These are for metrics collection purposes and sent only if the :kconfig:option:`CONFIG_LOCATION_DATA_DETAILS` Kconfig option is set.
     * Support for multiple event handlers.
     * Additional location data details into the :c:struct:`location_data_details` structure hierarchy.
+    * The :c:enumerator:`LOCATION_METHOD_WIFI_CELLULAR` method that cannot be added into the location configuration passed to the :c:func:`location_request()` function,
+      but may occur within the :c:struct:`location_event_data` structure.
 
   * Updated:
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -751,8 +751,9 @@ Modem libraries
 
   * Added:
 
-    * The :c:enumerator:`LOCATION_EVT_STARTED` event to indicate that location request has been started.
-      This is for metrics collection purposes and sent only if the :kconfig:option:`CONFIG_LOCATION_DATA_DETAILS` Kconfig option is set.
+    * The :c:enumerator:`LOCATION_EVT_STARTED` event to indicate that a location request has been started and
+      the :c:enumerator:`LOCATION_EVT_FALLBACK` event to indicate that a fallback from one location method to another has occurred.
+      These are for metrics collection purposes and sent only if the :kconfig:option:`CONFIG_LOCATION_DATA_DETAILS` Kconfig option is set.
     * Support for multiple event handlers.
     * Additional location data details into the :c:struct:`location_data_details` structure hierarchy.
 

--- a/include/modem/location.h
+++ b/include/modem/location.h
@@ -43,6 +43,19 @@ enum location_method {
 	LOCATION_METHOD_GNSS,
 	/** Wi-Fi positioning. */
 	LOCATION_METHOD_WIFI,
+	/**
+	 * Wi-Fi and cellular positioning combined into one cloud request.
+	 *
+	 * Cannot be used in the method list passed to location_request(),
+	 * but this method can appear in the location event (@ref location_event_data.id)
+	 * to indicate that Wi-Fi and cellular positioning methods have been combined
+	 * into a single cloud location method.
+	 *
+	 * If the combined method is desired, set Wi-Fi and cellular methods next to each other
+	 * in the method list passed to location_request(). This also happens by default if
+	 * NULL configuration is passed to location_request().
+	 */
+	LOCATION_METHOD_WIFI_CELLULAR,
 };
 
 /** Location acquisition mode. */
@@ -204,8 +217,8 @@ struct location_data_details_wifi {
  *
  * Only one of the child structures is filled most of the time depending on the method
  * found in @ref location_event_data.method member of the parent structure.
- * There are cases when cellular and Wi-Fi data are combined into a single cloud request
- * in which case data details for both methods are filled.
+ * For a combined method @ref LOCATION_METHOD_WIFI_CELLULAR both @ref cellular and
+ * @ref wifi are filled.
  */
 struct location_data_details {
 	/**
@@ -285,13 +298,7 @@ struct location_data_cloud {
 struct location_event_data {
 	/** Event ID. */
 	enum location_event_id id;
-	/**
-	 * Used location method.
-	 *
-	 * When cellular and Wi-Fi positioning are used and they are combined into a single
-	 * cloud request by the library, the method is not known so there is some uncertainty
-	 * on the reported location method.
-	 */
+	/** Used location method. */
 	enum location_method method;
 
 	/** Event specific data. */

--- a/include/modem/location.h
+++ b/include/modem/location.h
@@ -161,14 +161,64 @@ struct location_datetime {
 struct location_data_details_gnss {
 	/** Number of satellites tracked at the time of event. */
 	uint8_t satellites_tracked;
+	/** Number of satellites used at the time of event. */
+	uint8_t satellites_used;
 	/** PVT data. */
 	struct nrf_modem_gnss_pvt_data_frame pvt_data;
+	/**
+	 * Elapsed GNSS time in milliseconds.
+	 *
+	 * This is the time since last start of GNSS operation until the fix or timeout
+	 * including any time LTE has blocked GNSS.
+	 *
+	 * @ref pvt_data member has ``execution_time``, which indicates cumulative GNSS
+	 * execution time since last start excluding any time LTE has blocked GNSS.
+	 */
+	uint32_t elapsed_time_gnss;
 };
 
-/** Location details. */
+/** Location details for cellular. */
+struct location_data_details_cellular {
+	/** Number of neighbor cells. */
+	uint8_t ncells_count;
+	/** Number of GCI (surrounding) cells. */
+	uint8_t gci_cells_count;
+};
+
+/** Location details for Wi-Fi. */
+struct location_data_details_wifi {
+	/** Number of Wi-Fi APs. */
+	uint16_t ap_count;
+};
+
+/**
+ * Location details.
+ *
+ * Only one of the child structures is filled most of the time depending on the method
+ * found in @ref location_event_data.method member of the parent structure.
+ * There are cases when cellular and Wi-Fi data are combined into a single cloud request
+ * in which case data details for both methods are filled.
+ */
 struct location_data_details {
+	/**
+	 * Elapsed method time in milliseconds.
+	 *
+	 * This is the time from method start until it completes and includes any time
+	 * spent waiting for some conditions to happen before proceeding, such as
+	 * waiting for LTE connection to go idle for some methods.
+	 */
+	uint32_t elapsed_time_method;
+
 	/** Location details for GNSS. */
 	struct location_data_details_gnss gnss;
+#if defined(CONFIG_LOCATION_METHOD_CELLULAR)
+	/** Location details for cellular. */
+	struct location_data_details_cellular cellular;
+#endif
+#if defined(CONFIG_LOCATION_METHOD_WIFI)
+	/** Location details for Wi-Fi. */
+	struct location_data_details_wifi wifi;
+#endif
 };
 #endif
 

--- a/include/modem/location.h
+++ b/include/modem/location.h
@@ -94,6 +94,14 @@ enum location_event_id {
 	 * This event is only sent if @kconfig{CONFIG_LOCATION_DATA_DETAILS} is set.
 	 */
 	LOCATION_EVT_STARTED,
+	/**
+	 * A fallback from one method to another has occurred,
+	 * and the positioning procedure continues.
+	 *
+	 * This event is only sent if @kconfig{CONFIG_LOCATION_DATA_DETAILS} is set and
+	 * @ref location_config.mode is @ref LOCATION_REQ_MODE_FALLBACK.
+	 */
+	LOCATION_EVT_FALLBACK,
 };
 
 /** Result of the external cloud location request. */
@@ -245,6 +253,20 @@ struct location_data_error {
 	/** Data details at the time of error. */
 	struct location_data_details details;
 };
+
+/** Location fallback information. */
+struct location_data_fallback {
+	/** New location method that is tried next. */
+	enum location_method next_method;
+	/**
+	 * Event ID indicating the cause for the fallback.
+	 *
+	 * Either @ref LOCATION_EVT_TIMEOUT and @ref LOCATION_EVT_ERROR.
+	 */
+	enum location_event_id cause;
+	/** Data details at the time of a timeout or an error that caused the fallback. */
+	struct location_data_details details;
+};
 #endif
 
 /** Cloud location information. */
@@ -283,6 +305,15 @@ struct location_event_data {
 		 * Used with events @ref LOCATION_EVT_TIMEOUT and @ref LOCATION_EVT_ERROR.
 		 */
 		struct location_data_error error;
+#endif
+
+#if defined(CONFIG_LOCATION_DATA_DETAILS)
+		/**
+		 * Relevant location data when a fallback to another method occurs
+		 * due to a timeout or an error.
+		 * Used with event @ref LOCATION_EVT_FALLBACK.
+		 */
+		struct location_data_fallback fallback;
 #endif
 
 #if defined(CONFIG_LOCATION_SERVICE_EXTERNAL) && defined(CONFIG_NRF_CLOUD_AGNSS)

--- a/lib/location/location.c
+++ b/lib/location/location.c
@@ -85,7 +85,7 @@ static bool initialized;
 static const char LOCATION_METHOD_CELLULAR_STR[] = "Cellular";
 static const char LOCATION_METHOD_GNSS_STR[] = "GNSS";
 static const char LOCATION_METHOD_WIFI_STR[] = "Wi-Fi";
-static const char LOCATION_METHOD_INTERNAL_WIFI_CELLULAR_STR[] = "Wi-Fi + Cellular";
+static const char LOCATION_METHOD_WIFI_CELLULAR_STR[] = "Wi-Fi + Cellular";
 static const char LOCATION_METHOD_UNKNOWN_STR[] = "Unknown";
 
 int location_handler_register(location_event_handler_t handler)
@@ -299,13 +299,10 @@ const char *location_method_str(enum location_method method)
 	case LOCATION_METHOD_WIFI:
 		return LOCATION_METHOD_WIFI_STR;
 
+	case LOCATION_METHOD_WIFI_CELLULAR:
+		return LOCATION_METHOD_WIFI_CELLULAR_STR;
+
 	default:
-		/* Wi-Fi + Cellular method cannot be checked in switch-case because
-		 * it's not defined in the enum
-		 */
-		if (method == LOCATION_METHOD_INTERNAL_WIFI_CELLULAR) {
-			return LOCATION_METHOD_INTERNAL_WIFI_CELLULAR_STR;
-		}
 		return LOCATION_METHOD_UNKNOWN_STR;
 	}
 }

--- a/lib/location/location_core.c
+++ b/lib/location/location_core.c
@@ -94,7 +94,7 @@ static const struct location_method_api method_cellular_api = {
 	.cancel           = method_cloud_location_cancel,
 	.timeout          = method_cloud_location_cancel,
 #if defined(CONFIG_LOCATION_DATA_DETAILS)
-	.details_get      = NULL,
+	.details_get      = scan_cellular_details_get,
 #endif
 };
 #endif
@@ -108,7 +108,7 @@ static const struct location_method_api method_wifi_api = {
 	.cancel           = method_cloud_location_cancel,
 	.timeout          = method_cloud_location_cancel,
 #if defined(CONFIG_LOCATION_DATA_DETAILS)
-	.details_get      = NULL,
+	.details_get      = scan_wifi_details_get,
 #endif
 
 /** Threshold for cloud location method to select Wi-Fi vs. cellular into the returned event. */
@@ -129,7 +129,7 @@ static const struct location_method_api method_cloud_location_api = {
 	.cancel           = method_cloud_location_cancel,
 	.timeout          = method_cloud_location_cancel,
 #if defined(CONFIG_LOCATION_DATA_DETAILS)
-	.details_get      = NULL,
+	.details_get      = method_cloud_location_details_get,
 #endif
 };
 #endif
@@ -156,6 +156,7 @@ static void location_core_current_event_data_init(enum location_method method)
 	memset(&loc_req_info.current_event_data, 0, sizeof(loc_req_info.current_event_data));
 
 	loc_req_info.current_method = method;
+	loc_req_info.elapsed_time_method_start_timestamp = k_uptime_get();
 }
 
 static void location_core_current_config_clear(void)
@@ -613,6 +614,9 @@ static void location_core_event_details_get(struct location_event_data *event)
 		}
 
 		location_method_api_get(loc_req_info.current_method)->details_get(details);
+
+		details->elapsed_time_method = (uint32_t)
+			(k_uptime_get() - loc_req_info.elapsed_time_method_start_timestamp);
 	}
 #endif
 }

--- a/lib/location/location_core.h
+++ b/lib/location/location_core.h
@@ -7,8 +7,6 @@
 #ifndef LOCATION_CORE_H
 #define LOCATION_CORE_H
 
-#define LOCATION_METHOD_INTERNAL_WIFI_CELLULAR 100
-
 /** Information required to carry out a location request. */
 struct location_request_info {
 	const struct location_wifi_config *wifi;

--- a/lib/location/location_core.h
+++ b/lib/location/location_core.h
@@ -37,6 +37,9 @@ struct location_request_info {
 	/** Whether to perform fallback for current location request processing. */
 	bool execute_fallback;
 
+	/** Uptime at the start of the positioning for the current method. */
+	int64_t elapsed_time_method_start_timestamp;
+
 	/**
 	 * Device uptime when location request timer expires.
 	 * This is used in cloud location method to calculate timeout for the cloud operation.

--- a/lib/location/method_cloud_location.c
+++ b/lib/location/method_cloud_location.c
@@ -197,6 +197,18 @@ int method_cloud_location_get(const struct location_request_info *request)
 	return 0;
 }
 
+#if defined(CONFIG_LOCATION_DATA_DETAILS)
+void method_cloud_location_details_get(struct location_data_details *details)
+{
+#if defined(CONFIG_LOCATION_METHOD_CELLULAR)
+	scan_cellular_details_get(details);
+#endif
+#if defined(CONFIG_LOCATION_METHOD_WIFI)
+	scan_wifi_details_get(details);
+#endif
+}
+#endif
+
 int method_cloud_location_init(void)
 {
 	running = false;

--- a/lib/location/method_cloud_location.c
+++ b/lib/location/method_cloud_location.c
@@ -179,11 +179,11 @@ int method_cloud_location_get(const struct location_request_info *request)
 	method_cloud_location_start_work.wifi_config = NULL;
 	method_cloud_location_start_work.cell_config = NULL;
 	if (request->current_method == LOCATION_METHOD_CELLULAR ||
-	    request->current_method == LOCATION_METHOD_INTERNAL_WIFI_CELLULAR) {
+	    request->current_method == LOCATION_METHOD_WIFI_CELLULAR) {
 		method_cloud_location_start_work.cell_config = request->cellular;
 	}
 	if (request->current_method == LOCATION_METHOD_WIFI ||
-	    request->current_method == LOCATION_METHOD_INTERNAL_WIFI_CELLULAR) {
+	    request->current_method == LOCATION_METHOD_WIFI_CELLULAR) {
 		method_cloud_location_start_work.wifi_config = request->wifi;
 	}
 

--- a/lib/location/method_cloud_location.h
+++ b/lib/location/method_cloud_location.h
@@ -10,5 +10,8 @@
 int method_cloud_location_get(const struct location_request_info *request);
 int method_cloud_location_init(void);
 int method_cloud_location_cancel(void);
+#if defined(CONFIG_LOCATION_DATA_DETAILS)
+void method_cloud_location_details_get(struct location_data_details *details);
+#endif
 
 #endif /* METHOD_CLOUD_LOCATION_H */

--- a/lib/location/scan_cellular.c
+++ b/lib/location/scan_cellular.c
@@ -69,6 +69,14 @@ struct lte_lc_cells_info *scan_cellular_results_get(void)
 	return &scan_cellular_info;
 }
 
+#if defined(CONFIG_LOCATION_DATA_DETAILS)
+void scan_cellular_details_get(struct location_data_details *details)
+{
+	details->cellular.ncells_count = scan_cellular_info.ncells_count;
+	details->cellular.gci_cells_count = scan_cellular_info.gci_cells_count;
+}
+#endif
+
 void scan_cellular_lte_ind_handler(const struct lte_lc_evt *const evt)
 {
 	switch (evt->type) {

--- a/lib/location/scan_cellular.h
+++ b/lib/location/scan_cellular.h
@@ -13,5 +13,8 @@ int scan_cellular_init(void);
 void scan_cellular_execute(int32_t timeout, uint8_t cell_count);
 struct lte_lc_cells_info *scan_cellular_results_get(void);
 int scan_cellular_cancel(void);
+#if defined(CONFIG_LOCATION_DATA_DETAILS)
+void scan_cellular_details_get(struct location_data_details *details);
+#endif
 
 #endif /* SCAN_CELLULAR_H */

--- a/lib/location/scan_wifi.c
+++ b/lib/location/scan_wifi.c
@@ -52,6 +52,13 @@ struct wifi_scan_info *scan_wifi_results_get(void)
 	return &scan_wifi_info;
 }
 
+#if defined(CONFIG_LOCATION_DATA_DETAILS)
+void scan_wifi_details_get(struct location_data_details *details)
+{
+	details->wifi.ap_count = scan_wifi_info.cnt;
+}
+#endif
+
 void scan_wifi_execute(int32_t timeout, struct k_sem *wifi_scan_ready)
 {
 	int ret;

--- a/lib/location/scan_wifi.h
+++ b/lib/location/scan_wifi.h
@@ -13,5 +13,8 @@ int scan_wifi_init(void);
 void scan_wifi_execute(int32_t timeout, struct k_sem *wifi_scan_ready);
 struct wifi_scan_info *scan_wifi_results_get(void);
 int scan_wifi_cancel(void);
+#if defined(CONFIG_LOCATION_DATA_DETAILS)
+void scan_wifi_details_get(struct location_data_details *details);
+#endif
 
 #endif /* SCAN_WIFI_H */

--- a/samples/cellular/modem_shell/src/location/location_shell.c
+++ b/samples/cellular/modem_shell/src/location/location_shell.c
@@ -376,6 +376,7 @@ void location_ctrl_event_handler(const struct location_event_data *event_data)
 			location_method_str(event_data->method),
 			event_data->method);
 		break;
+#if defined(CONFIG_LOCATION_DATA_DETAILS)
 	case LOCATION_EVT_STARTED:
 		mosh_print("Location request has been started:");
 		mosh_print(
@@ -383,6 +384,24 @@ void location_ctrl_event_handler(const struct location_event_data *event_data)
 			location_method_str(event_data->method),
 			event_data->method);
 		break;
+	case LOCATION_EVT_FALLBACK:
+		mosh_print("Location request fallback has occurred:");
+		mosh_print(
+			"  failed method: %s (%d)",
+			location_method_str(event_data->method),
+			event_data->method);
+		mosh_print(
+			"  new method: %s (%d)",
+			location_method_str(event_data->fallback.next_method),
+			event_data->fallback.next_method);
+		mosh_print(
+			"  cause: %s",
+			(event_data->fallback.cause == LOCATION_EVT_TIMEOUT) ? "timeout" :
+			(event_data->fallback.cause == LOCATION_EVT_ERROR) ? "error" :
+			"unknown");
+		location_print_data_details(event_data->method, &event_data->fallback.details);
+		break;
+#endif
 	default:
 		mosh_warn("Unknown event from location library, id %d", event_data->id);
 		break;

--- a/samples/cellular/modem_shell/src/location/location_shell.c
+++ b/samples/cellular/modem_shell/src/location/location_shell.c
@@ -236,13 +236,13 @@ static void location_print_data_details(
 	}
 #endif
 #if defined(CONFIG_LOCATION_METHOD_CELLULAR)
-	if (method == LOCATION_METHOD_CELLULAR) {
+	if (method == LOCATION_METHOD_CELLULAR || method == LOCATION_METHOD_WIFI_CELLULAR) {
 		mosh_print("  neighbor cells: %d", details->cellular.ncells_count);
 		mosh_print("  GCI cells: %d", details->cellular.gci_cells_count);
 	}
 #endif
 #if defined(CONFIG_LOCATION_METHOD_WIFI)
-	if (method == LOCATION_METHOD_WIFI) {
+	if (method == LOCATION_METHOD_WIFI || method == LOCATION_METHOD_WIFI_CELLULAR) {
 		mosh_print("  Wi-Fi APs: %d", details->wifi.ap_count);
 	}
 #endif

--- a/samples/cellular/nrf_cloud_multi_service/src/location_tracking.c
+++ b/samples/cellular/nrf_cloud_multi_service/src/location_tracking.c
@@ -41,6 +41,9 @@ static void location_event_handler(const struct location_event_data *event_data)
 		LOG_DBG("Location Event: GNSS assistance requested");
 		break;
 
+	case LOCATION_EVT_STARTED:
+		break;
+
 	default:
 		LOG_DBG("Location Event: Unknown event");
 		break;

--- a/tests/lib/location/CMakeLists.txt
+++ b/tests/lib/location/CMakeLists.txt
@@ -49,6 +49,10 @@ zephyr_include_directories(${ZEPHYR_NRFXLIB_MODULE_DIR}/nrf_modem/include)
 zephyr_include_directories(${ZEPHYR_NRF_MODULE_DIR}/subsys/net/lib/nrf_cloud/include)
 zephyr_include_directories(${ZEPHYR_NRF_MODULE_DIR}/include/net)
 
+# The test uses double precision floating point numbers. This is not enabled by default in unity
+# unless we set the following define.
+zephyr_compile_definitions(UNITY_INCLUDE_DOUBLE)
+
 target_sources(app PRIVATE src/location_test.c)
 
 target_include_directories(app PRIVATE ${ZEPHYR_NRF_MODULE_DIR}/include/net)

--- a/tests/lib/location/src/location_test.c
+++ b/tests/lib/location/src/location_test.c
@@ -504,11 +504,6 @@ void test_location_method_str(void)
 
 	method = location_method_str(99);
 	TEST_ASSERT_EQUAL_STRING("Unknown", method);
-
-	/* 100 is a hidden internally used LOCATION_METHOD_INTERNAL_WIFI_CELLULAR constant */
-	method = location_method_str(100);
-	TEST_ASSERT_EQUAL_STRING("Wi-Fi + Cellular", method);
-
 }
 
 /********* GNSS POSITIONING TESTS ***********************/
@@ -1347,6 +1342,23 @@ void test_error_too_many_methods(void)
 	/* Check that location_request returns an error with too many methods */
 	location_config_defaults_set(&config, 2, methods);
 	config.methods_count = 4;
+
+	err = location_request(&config);
+	TEST_ASSERT_EQUAL(-EINVAL, err);
+}
+
+/* Test location request with LOCATION_METHOD_WIFI_CELLULAR in method list. */
+void test_error_wifi_cellular_method(void)
+{
+	int err;
+	struct location_config config = { 0 };
+	enum location_method methods[] = {
+		LOCATION_METHOD_GNSS,
+		LOCATION_METHOD_WIFI_CELLULAR,
+		LOCATION_METHOD_CELLULAR};
+
+	/* Check that location_config_defaults_set returns an error with too many methods */
+	location_config_defaults_set(&config, 3, methods);
 
 	err = location_request(&config);
 	TEST_ASSERT_EQUAL(-EINVAL, err);

--- a/tests/lib/location/src/location_test.c
+++ b/tests/lib/location/src/location_test.c
@@ -1391,6 +1391,11 @@ void test_location_request_default(void)
 	test_location_event_data[location_cb_expected].method = LOCATION_METHOD_GNSS;
 	location_cb_expected++;
 #endif
+#if defined(CONFIG_LOCATION_DATA_DETAILS)
+	test_location_event_data[location_cb_expected].id = LOCATION_EVT_FALLBACK;
+	test_location_event_data[location_cb_expected].method = LOCATION_METHOD_GNSS;
+	location_cb_expected++;
+#endif
 	test_location_event_data[location_cb_expected].id = LOCATION_EVT_LOCATION;
 	test_location_event_data[location_cb_expected].method = LOCATION_METHOD_CELLULAR;
 	test_location_event_data[location_cb_expected].location.latitude = 61.50375;
@@ -1460,6 +1465,11 @@ void test_location_request_default(void)
 	__cmock_nrf_modem_gnss_read_ReturnMemThruPtr_buf(&test_pvt_data, sizeof(test_pvt_data));
 	method_gnss_event_handler(NRF_MODEM_GNSS_EVT_PVT);
 
+#if defined(CONFIG_LOCATION_DATA_DETAILS)
+	/* Wait for LOCATION_EVT_FALLBACK */
+	err = k_sem_take(&event_handler_called_sem, K_SECONDS(3));
+	TEST_ASSERT_EQUAL(0, err);
+#endif
 	/***** Fallback to cellular *****/
 
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT%NCELLMEAS=1", 0);

--- a/tests/lib/location/src/location_test.c
+++ b/tests/lib/location/src/location_test.c
@@ -94,11 +94,9 @@ static const char xmonitor_resp_psm_on[] =
 	"\"00100001\",\"00101001\",\"01001001\"";
 #endif
 
-#if !defined(CONFIG_LOCATION_DATA_DETAILS)
 #if !defined(CONFIG_LOCATION_SERVICE_EXTERNAL)
 /* PDN active response */
 static const char cgact_resp_active[] = "+CGACT: 0,1";
-#endif
 #endif
 
 /* Strings for cellular positioning */
@@ -117,7 +115,7 @@ static const char ncellmeas_resp_gci5[] =
 	"\"00011B66\",\"26287\",\"00C3\",65535,0,4300,6,71,30,150345527,0,0,"
 	"\"0002ABCD\",\"26287\",\"00C3\",65535,0,4300,6,71,30,150345527,0,0,"
 	"\"00103425\",\"26244\",\"0056\",65535,0,6400,6,71,30,150345527,0,0,"
-	"\"00076543\",\"26256\",\"00C3\",65535,0,620000,6,71,30,150345527,0,0,"
+	"\"00076543\",\"26256\",\"00C3\",65535,0,62000,6,71,30,150345527,0,0,"
 	"\"00011B08\",\"26295\",\"00B7\",65535,0,2300,9,62,30,150345527,0,0\r\n";
 #endif
 
@@ -281,6 +279,78 @@ static void location_event_data_verify(
 				expected->location.datetime.ms,
 				event_data->location.datetime.ms);
 		}
+#if defined(CONFIG_LOCATION_DATA_DETAILS)
+		if (expected->location.details.elapsed_time_method > 0) {
+			TEST_ASSERT_GREATER_THAN_UINT32(
+				0, event_data->location.details.elapsed_time_method);
+			TEST_ASSERT_LESS_THAN_UINT32(
+				1000, event_data->location.details.elapsed_time_method);
+		}
+
+		TEST_ASSERT_EQUAL(
+			expected->location.details.gnss.satellites_tracked,
+			event_data->location.details.gnss.satellites_tracked);
+		TEST_ASSERT_EQUAL(
+			expected->location.details.gnss.satellites_used,
+			event_data->location.details.gnss.satellites_used);
+
+		if (expected->location.details.gnss.elapsed_time_gnss > 0) {
+			TEST_ASSERT_GREATER_THAN_UINT32(
+				0, event_data->location.details.gnss.elapsed_time_gnss);
+			TEST_ASSERT_LESS_THAN_UINT32(
+				1000, event_data->location.details.gnss.elapsed_time_gnss);
+		}
+
+		TEST_ASSERT_EQUAL(
+			expected->location.details.gnss.pvt_data.flags,
+			event_data->location.details.gnss.pvt_data.flags);
+		TEST_ASSERT_EQUAL_DOUBLE(
+			expected->location.details.gnss.pvt_data.latitude,
+			event_data->location.details.gnss.pvt_data.latitude);
+		TEST_ASSERT_EQUAL_DOUBLE(
+			expected->location.details.gnss.pvt_data.longitude,
+			event_data->location.details.gnss.pvt_data.longitude);
+		TEST_ASSERT_EQUAL_DOUBLE(
+			expected->location.details.gnss.pvt_data.accuracy,
+			event_data->location.details.gnss.pvt_data.accuracy);
+		TEST_ASSERT_EQUAL(
+			expected->location.details.gnss.pvt_data.datetime.year,
+			event_data->location.details.gnss.pvt_data.datetime.year);
+		TEST_ASSERT_EQUAL(
+			expected->location.details.gnss.pvt_data.datetime.month,
+			event_data->location.details.gnss.pvt_data.datetime.month);
+		TEST_ASSERT_EQUAL(
+			expected->location.details.gnss.pvt_data.datetime.day,
+			event_data->location.details.gnss.pvt_data.datetime.day);
+		TEST_ASSERT_EQUAL(
+			expected->location.details.gnss.pvt_data.datetime.hour,
+			event_data->location.details.gnss.pvt_data.datetime.hour);
+		TEST_ASSERT_EQUAL(
+			expected->location.details.gnss.pvt_data.datetime.minute,
+			event_data->location.details.gnss.pvt_data.datetime.minute);
+		TEST_ASSERT_EQUAL(
+			expected->location.details.gnss.pvt_data.datetime.seconds,
+			event_data->location.details.gnss.pvt_data.datetime.seconds);
+		TEST_ASSERT_EQUAL(
+			expected->location.details.gnss.pvt_data.datetime.ms,
+			event_data->location.details.gnss.pvt_data.datetime.ms);
+
+		TEST_ASSERT_EQUAL(
+			expected->location.details.cellular.ncells_count,
+			event_data->location.details.cellular.ncells_count);
+		TEST_ASSERT_EQUAL(
+			expected->location.details.cellular.gci_cells_count,
+			event_data->location.details.cellular.gci_cells_count);
+#if defined(CONFIG_LOCATION_METHOD_WIFI)
+		TEST_ASSERT_EQUAL(
+			expected->location.details.wifi.ap_count,
+			event_data->location.details.wifi.ap_count);
+#endif
+#endif
+		break;
+	case LOCATION_EVT_TIMEOUT:
+	case LOCATION_EVT_ERROR:
+		/* TODO: Verify data: event_data->error.details*/
 		break;
 	case LOCATION_EVT_GNSS_ASSISTANCE_REQUEST:
 		/* TODO: Verify data: event_data->agnss_request */
@@ -527,6 +597,28 @@ void test_location_gnss(void)
 	test_location_event_data[location_cb_expected].method = LOCATION_METHOD_GNSS;
 	location_cb_expected++;
 #endif
+	test_pvt_data.flags = NRF_MODEM_GNSS_PVT_FLAG_FIX_VALID;
+	test_pvt_data.latitude = 61.005;
+	test_pvt_data.longitude = -45.997;
+	test_pvt_data.accuracy = 15.83;
+	test_pvt_data.datetime.year = 2021;
+	test_pvt_data.datetime.month = 8;
+	test_pvt_data.datetime.day = 13;
+	test_pvt_data.datetime.hour = 12;
+	test_pvt_data.datetime.minute = 34;
+	test_pvt_data.datetime.seconds = 56;
+	test_pvt_data.datetime.ms = 789;
+	test_pvt_data.sv[0].sv = 2;
+	test_pvt_data.sv[0].flags = NRF_MODEM_GNSS_SV_FLAG_USED_IN_FIX;
+	test_pvt_data.sv[1].sv = 4;
+	test_pvt_data.sv[1].flags = NRF_MODEM_GNSS_SV_FLAG_USED_IN_FIX;
+	test_pvt_data.sv[2].sv = 6;
+	test_pvt_data.sv[2].flags = NRF_MODEM_GNSS_SV_FLAG_USED_IN_FIX;
+	test_pvt_data.sv[3].sv = 8;
+	test_pvt_data.sv[3].flags = NRF_MODEM_GNSS_SV_FLAG_USED_IN_FIX;
+	test_pvt_data.sv[4].sv = 10;
+	test_pvt_data.sv[4].flags = NRF_MODEM_GNSS_SV_FLAG_USED_IN_FIX;
+
 	test_location_event_data[location_cb_expected].id = LOCATION_EVT_LOCATION;
 	test_location_event_data[location_cb_expected].method = LOCATION_METHOD_GNSS;
 	test_location_event_data[location_cb_expected].location.latitude = 61.005;
@@ -540,19 +632,14 @@ void test_location_gnss(void)
 	test_location_event_data[location_cb_expected].location.datetime.minute = 34;
 	test_location_event_data[location_cb_expected].location.datetime.second = 56;
 	test_location_event_data[location_cb_expected].location.datetime.ms = 789;
+#if defined(CONFIG_LOCATION_DATA_DETAILS)
+	test_location_event_data[location_cb_expected].location.details.gnss.satellites_tracked = 5;
+	test_location_event_data[location_cb_expected].location.details.gnss.satellites_used = 5;
+	test_location_event_data[location_cb_expected].location.details.gnss.elapsed_time_gnss = 50;
+	test_location_event_data[location_cb_expected].location.details.gnss.pvt_data =
+		test_pvt_data;
+#endif
 	location_cb_expected++;
-
-	test_pvt_data.flags = NRF_MODEM_GNSS_PVT_FLAG_FIX_VALID;
-	test_pvt_data.latitude = 61.005;
-	test_pvt_data.longitude = -45.997;
-	test_pvt_data.accuracy = 15.83;
-	test_pvt_data.datetime.year = 2021;
-	test_pvt_data.datetime.month = 8;
-	test_pvt_data.datetime.day = 13;
-	test_pvt_data.datetime.hour = 12;
-	test_pvt_data.datetime.minute = 34;
-	test_pvt_data.datetime.seconds = 56;
-	test_pvt_data.datetime.ms = 789;
 
 	__cmock_nrf_modem_gnss_event_handler_set_ExpectAndReturn(&method_gnss_event_handler, 0);
 
@@ -814,7 +901,6 @@ void cellular_rest_req_resp_handle(int test_event_data_index)
  */
 void test_location_cellular(void)
 {
-#if !defined(CONFIG_LOCATION_DATA_DETAILS)
 	int err;
 	struct location_config config = { 0 };
 	enum location_method methods[] = {LOCATION_METHOD_CELLULAR};
@@ -822,6 +908,12 @@ void test_location_cellular(void)
 	location_config_defaults_set(&config, 1, methods);
 
 	config.methods[0].cellular.cell_count = 1;
+
+#if defined(CONFIG_LOCATION_DATA_DETAILS)
+	test_location_event_data[location_cb_expected].id = LOCATION_EVT_STARTED;
+	test_location_event_data[location_cb_expected].method = LOCATION_METHOD_CELLULAR;
+	location_cb_expected++;
+#endif
 
 #if defined(CONFIG_LOCATION_SERVICE_EXTERNAL)
 	test_location_event_data[location_cb_expected].id = LOCATION_EVT_CLOUD_LOCATION_EXT_REQUEST;
@@ -835,6 +927,11 @@ void test_location_cellular(void)
 	test_location_event_data[location_cb_expected].location.longitude = 23.896979;
 	test_location_event_data[location_cb_expected].location.accuracy = 750.0;
 	test_location_event_data[location_cb_expected].location.datetime.valid = false;
+#if defined(CONFIG_LOCATION_DATA_DETAILS)
+	test_location_event_data[location_cb_expected].location.details.cellular.ncells_count = 1;
+	test_location_event_data[location_cb_expected].location.details.cellular.gci_cells_count =
+		0;
+#endif
 	location_cb_expected++;
 
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT%NCELLMEAS=1", 0);
@@ -858,6 +955,12 @@ void test_location_cellular(void)
 	TEST_ASSERT_EQUAL(0, err);
 	k_sleep(K_MSEC(1));
 
+#if defined(CONFIG_LOCATION_DATA_DETAILS)
+	/* Wait for LOCATION_EVT_STARTED */
+	err = k_sem_take(&event_handler_called_sem, K_SECONDS(3));
+	TEST_ASSERT_EQUAL(0, err);
+#endif
+
 	err = location_request(&config);
 	TEST_ASSERT_EQUAL(-EBUSY, err);
 	k_sleep(K_MSEC(1));
@@ -880,13 +983,11 @@ void test_location_cellular(void)
 	location_cloud_location_ext_result_set(LOCATION_EXT_RESULT_SUCCESS, &location_data);
 	k_sleep(K_MSEC(1));
 #endif
-#endif
 }
 
 /* Test cancelling cellular location request during NCELLMEAS. */
 void test_location_cellular_cancel_during_ncellmeas(void)
 {
-#if !defined(CONFIG_LOCATION_DATA_DETAILS)
 	int err;
 	struct location_config config = { 0 };
 	enum location_method methods[] = {LOCATION_METHOD_CELLULAR};
@@ -894,24 +995,33 @@ void test_location_cellular_cancel_during_ncellmeas(void)
 	location_config_defaults_set(&config, 1, methods);
 	config.methods[0].cellular.cell_count = 2;
 
+#if defined(CONFIG_LOCATION_DATA_DETAILS)
+	test_location_event_data[location_cb_expected].id = LOCATION_EVT_STARTED;
+	test_location_event_data[location_cb_expected].method = LOCATION_METHOD_CELLULAR;
+	location_cb_expected++;
+#endif
+
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT%NCELLMEAS=1", 0);
 
 	err = location_request(&config);
 	TEST_ASSERT_EQUAL(0, err);
 	k_sleep(K_MSEC(1));
 
+#if defined(CONFIG_LOCATION_DATA_DETAILS)
+	err = k_sem_take(&event_handler_called_sem, K_SECONDS(3));
+	TEST_ASSERT_EQUAL(0, err);
+#endif
+
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT%NCELLMEASSTOP", 0);
 
 	err = location_request_cancel();
 	TEST_ASSERT_EQUAL(0, err);
 	k_sleep(K_MSEC(1));
-#endif
 }
 
 /* Test cellular timeout during the 1st NCELLMEAS. */
 void test_location_cellular_timeout_during_1st_ncellmeas(void)
 {
-#if !defined(CONFIG_LOCATION_DATA_DETAILS)
 #if !defined(CONFIG_LOCATION_SERVICE_EXTERNAL)
 	int err;
 	struct location_config config = { 0 };
@@ -922,12 +1032,22 @@ void test_location_cellular_timeout_during_1st_ncellmeas(void)
 	config.methods[0].cellular.cell_count = 1;
 	config.methods[0].cellular.timeout = 1;
 
+#if defined(CONFIG_LOCATION_DATA_DETAILS)
+	test_location_event_data[location_cb_expected].id = LOCATION_EVT_STARTED;
+	test_location_event_data[location_cb_expected].method = LOCATION_METHOD_CELLULAR;
+	location_cb_expected++;
+#endif
 	test_location_event_data[location_cb_expected].id = LOCATION_EVT_LOCATION;
 	test_location_event_data[location_cb_expected].method = LOCATION_METHOD_CELLULAR;
 	test_location_event_data[location_cb_expected].location.latitude = 61.50375;
 	test_location_event_data[location_cb_expected].location.longitude = 23.896979;
 	test_location_event_data[location_cb_expected].location.accuracy = 750.0;
 	test_location_event_data[location_cb_expected].location.datetime.valid = false;
+#if defined(CONFIG_LOCATION_DATA_DETAILS)
+	test_location_event_data[location_cb_expected].location.details.cellular.ncells_count = 1;
+	test_location_event_data[location_cb_expected].location.details.cellular.gci_cells_count =
+		0;
+#endif
 	location_cb_expected++;
 
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT%NCELLMEAS=1", 0);
@@ -956,7 +1076,6 @@ void test_location_cellular_timeout_during_1st_ncellmeas(void)
 	/* Send NCELLMEAS response which further triggers the rest of the location calculation */
 	at_monitor_dispatch(ncellmeas_resp_pci1);
 	k_sleep(K_MSEC(1));
-#endif
 #endif
 }
 
@@ -1024,7 +1143,6 @@ void test_location_cellular_timeout_during_2nd_ncellmeas_backup_timeout(void)
 /* Test successful Wi-Fi location request utilizing HERE service. */
 void test_location_wifi(void)
 {
-#if !defined(CONFIG_LOCATION_DATA_DETAILS)
 #if defined(CONFIG_LOCATION_METHOD_WIFI)
 #if !defined(CONFIG_LOCATION_SERVICE_EXTERNAL)
 	int err;
@@ -1033,12 +1151,20 @@ void test_location_wifi(void)
 
 	location_config_defaults_set(&config, 1, methods);
 
+#if defined(CONFIG_LOCATION_DATA_DETAILS)
+	test_location_event_data[location_cb_expected].id = LOCATION_EVT_STARTED;
+	test_location_event_data[location_cb_expected].method = LOCATION_METHOD_WIFI;
+	location_cb_expected++;
+#endif
 	test_location_event_data[location_cb_expected].id = LOCATION_EVT_LOCATION;
 	test_location_event_data[location_cb_expected].method = LOCATION_METHOD_WIFI;
 	test_location_event_data[location_cb_expected].location.latitude = 51.98765;
 	test_location_event_data[location_cb_expected].location.longitude = 13.12345;
 	test_location_event_data[location_cb_expected].location.accuracy = 50.0;
 	test_location_event_data[location_cb_expected].location.datetime.valid = false;
+#if defined(CONFIG_LOCATION_DATA_DETAILS)
+	test_location_event_data[location_cb_expected].location.details.wifi.ap_count = 2;
+#endif
 
 	location_cb_expected++;
 	net_mgmt_NET_REQUEST_WIFI_SCAN_expected = true;
@@ -1063,6 +1189,11 @@ void test_location_wifi(void)
 	TEST_ASSERT_EQUAL(0, err);
 	k_sleep(K_MSEC(1));
 
+#if defined(CONFIG_LOCATION_DATA_DETAILS)
+	/* Wait for LOCATION_EVT_STARTED */
+	err = k_sem_take(&event_handler_called_sem, K_SECONDS(3));
+	TEST_ASSERT_EQUAL(0, err);
+#endif
 	struct net_mgmt_event_callback cb;
 	const struct wifi_status status = {
 		.status = WIFI_STATUS_CONN_SUCCESS
@@ -1100,7 +1231,6 @@ void test_location_wifi(void)
 	k_sleep(K_MSEC(1));
 #endif
 #endif
-#endif
 }
 
 /* Test timeout during Wi-Fi scan. Only one scan result is received before the timeout and
@@ -1108,7 +1238,6 @@ void test_location_wifi(void)
  */
 void test_location_wifi_timeout(void)
 {
-#if !defined(CONFIG_LOCATION_DATA_DETAILS)
 #if defined(CONFIG_LOCATION_METHOD_WIFI)
 #if !defined(CONFIG_LOCATION_SERVICE_EXTERNAL)
 	int err;
@@ -1118,8 +1247,16 @@ void test_location_wifi_timeout(void)
 	location_config_defaults_set(&config, 1, methods);
 	config.methods[0].wifi.timeout = 1;
 
+#if defined(CONFIG_LOCATION_DATA_DETAILS)
+	test_location_event_data[location_cb_expected].id = LOCATION_EVT_STARTED;
+	test_location_event_data[location_cb_expected].method = LOCATION_METHOD_WIFI;
+	location_cb_expected++;
+#endif
 	test_location_event_data[location_cb_expected].id = LOCATION_EVT_ERROR;
 	test_location_event_data[location_cb_expected].method = LOCATION_METHOD_WIFI;
+#if defined(CONFIG_LOCATION_DATA_DETAILS)
+	test_location_event_data[location_cb_expected].location.details.wifi.ap_count = 2;
+#endif
 	location_cb_expected++;
 
 	net_mgmt_NET_REQUEST_WIFI_SCAN_expected = true;
@@ -1130,6 +1267,11 @@ void test_location_wifi_timeout(void)
 	TEST_ASSERT_EQUAL(0, err);
 	k_sleep(K_MSEC(1));
 
+#if defined(CONFIG_LOCATION_DATA_DETAILS)
+	/* Wait for LOCATION_EVT_STARTED */
+	err = k_sem_take(&event_handler_called_sem, K_SECONDS(3));
+	TEST_ASSERT_EQUAL(0, err);
+#endif
 	struct net_mgmt_event_callback cb;
 	const struct wifi_status status = {
 		.status = WIFI_STATUS_CONN_SUCCESS
@@ -1161,7 +1303,6 @@ void test_location_wifi_timeout(void)
 	cb.info = &status;
 	scan_wifi_net_mgmt_event_handler(&cb, NET_EVENT_WIFI_SCAN_DONE, NULL);
 	k_sleep(K_MSEC(1));
-#endif
 #endif
 #endif
 }
@@ -1241,16 +1382,25 @@ void test_location_pgps_data_process_fail_notsup(void)
 /* Test default location request where fallback from GNSS to cellular occurs. */
 void test_location_request_default(void)
 {
-#if !defined(CONFIG_LOCATION_DATA_DETAILS)
 #if !defined(CONFIG_LOCATION_METHOD_WIFI)
 #if !defined(CONFIG_LOCATION_SERVICE_EXTERNAL)
 	int err;
 
+#if defined(CONFIG_LOCATION_DATA_DETAILS)
+	test_location_event_data[location_cb_expected].id = LOCATION_EVT_STARTED;
+	test_location_event_data[location_cb_expected].method = LOCATION_METHOD_GNSS;
+	location_cb_expected++;
+#endif
 	test_location_event_data[location_cb_expected].id = LOCATION_EVT_LOCATION;
 	test_location_event_data[location_cb_expected].method = LOCATION_METHOD_CELLULAR;
 	test_location_event_data[location_cb_expected].location.latitude = 61.50375;
 	test_location_event_data[location_cb_expected].location.longitude = 23.896979;
 	test_location_event_data[location_cb_expected].location.accuracy = 750.0;
+#if defined(CONFIG_LOCATION_DATA_DETAILS)
+	test_location_event_data[location_cb_expected].location.details.cellular.ncells_count = 1;
+	test_location_event_data[location_cb_expected].location.details.cellular.gci_cells_count =
+		3;
+#endif
 	location_cb_expected++;
 
 	test_pvt_data.flags = NRF_MODEM_GNSS_PVT_FLAG_FIX_VALID;
@@ -1287,6 +1437,12 @@ void test_location_request_default(void)
 
 	err = location_request(NULL);
 	TEST_ASSERT_EQUAL(0, err);
+
+#if defined(CONFIG_LOCATION_DATA_DETAILS)
+	/* Wait for LOCATION_EVT_STARTED */
+	err = k_sem_take(&event_handler_called_sem, K_SECONDS(3));
+	TEST_ASSERT_EQUAL(0, err);
+#endif
 
 #if !defined(CONFIG_LOCATION_TEST_AGNSS)
 	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
@@ -1338,9 +1494,9 @@ void test_location_request_default(void)
 
 	cellular_rest_req_resp_handle(location_cb_expected - 1);
 
+	/* Although 5 cells are returned, we only request 4 including service cell so 3 GCI cells */
 	at_monitor_dispatch(ncellmeas_resp_gci5);
 	k_sleep(K_MSEC(1));
-#endif
 #endif
 #endif
 }
@@ -1352,7 +1508,6 @@ void test_location_request_default(void)
  */
 void test_location_request_mode_all_cellular_gnss(void)
 {
-#if !defined(CONFIG_LOCATION_DATA_DETAILS)
 #if !defined(CONFIG_LOCATION_SERVICE_EXTERNAL)
 	int err;
 
@@ -1365,13 +1520,48 @@ void test_location_request_mode_all_cellular_gnss(void)
 	config.methods[0].cellular.cell_count = 1;
 	config.methods[1].gnss.timeout = -10;
 
+#if defined(CONFIG_LOCATION_DATA_DETAILS)
+	test_location_event_data[location_cb_expected].id = LOCATION_EVT_STARTED;
+	test_location_event_data[location_cb_expected].method = LOCATION_METHOD_CELLULAR;
+	location_cb_expected++;
+#endif
+
 	test_location_event_data[location_cb_expected].id = LOCATION_EVT_LOCATION;
 	test_location_event_data[location_cb_expected].method = LOCATION_METHOD_CELLULAR;
 	test_location_event_data[location_cb_expected].location.latitude = 61.50375;
 	test_location_event_data[location_cb_expected].location.longitude = 23.896979;
 	test_location_event_data[location_cb_expected].location.accuracy = 750.0;
+#if defined(CONFIG_LOCATION_DATA_DETAILS)
+	test_location_event_data[location_cb_expected].location.details.cellular.ncells_count = 1;
+	test_location_event_data[location_cb_expected].location.details.cellular.gci_cells_count =
+		0;
+#endif
 	location_cb_expected++;
 	location_cb_expected_2++;
+
+	test_pvt_data.flags = NRF_MODEM_GNSS_PVT_FLAG_FIX_VALID;
+	test_pvt_data.latitude = 60.987;
+	test_pvt_data.longitude = -45.997;
+	test_pvt_data.accuracy = 15.83;
+	test_pvt_data.datetime.year = 2021;
+	test_pvt_data.datetime.month = 8;
+	test_pvt_data.datetime.day = 2;
+	test_pvt_data.datetime.hour = 12;
+	test_pvt_data.datetime.minute = 34;
+	test_pvt_data.datetime.seconds = 23;
+	test_pvt_data.datetime.ms = 789;
+	test_pvt_data.sv[0].sv = 2;
+	test_pvt_data.sv[0].flags = NRF_MODEM_GNSS_SV_FLAG_USED_IN_FIX;
+	test_pvt_data.sv[1].sv = 4;
+	test_pvt_data.sv[1].flags = NRF_MODEM_GNSS_SV_FLAG_USED_IN_FIX;
+	test_pvt_data.sv[2].sv = 6;
+	test_pvt_data.sv[2].flags = 0;
+	test_pvt_data.sv[3].sv = 8;
+	test_pvt_data.sv[3].flags = NRF_MODEM_GNSS_SV_FLAG_USED_IN_FIX;
+	test_pvt_data.sv[4].sv = 10;
+	test_pvt_data.sv[4].flags = NRF_MODEM_GNSS_SV_FLAG_USED_IN_FIX;
+	test_pvt_data.sv[5].sv = 12;
+	test_pvt_data.sv[5].flags = 0;
 
 	test_location_event_data[location_cb_expected].id = LOCATION_EVT_LOCATION;
 	test_location_event_data[location_cb_expected].method = LOCATION_METHOD_GNSS;
@@ -1386,6 +1576,13 @@ void test_location_request_mode_all_cellular_gnss(void)
 	test_location_event_data[location_cb_expected].location.datetime.minute = 34;
 	test_location_event_data[location_cb_expected].location.datetime.second = 23;
 	test_location_event_data[location_cb_expected].location.datetime.ms = 789;
+#if defined(CONFIG_LOCATION_DATA_DETAILS)
+	test_location_event_data[location_cb_expected].location.details.gnss.satellites_tracked = 6;
+	test_location_event_data[location_cb_expected].location.details.gnss.satellites_used = 4;
+	test_location_event_data[location_cb_expected].location.details.gnss.elapsed_time_gnss = 50;
+	test_location_event_data[location_cb_expected].location.details.gnss.pvt_data =
+		test_pvt_data;
+#endif
 	location_cb_expected++;
 	location_cb_expected_2++;
 
@@ -1405,6 +1602,13 @@ void test_location_request_mode_all_cellular_gnss(void)
 	err = location_request(&config);
 	TEST_ASSERT_EQUAL(0, err);
 
+#if defined(CONFIG_LOCATION_DATA_DETAILS)
+	/* Wait for LOCATION_EVT_STARTED */
+	err = k_sem_take(&event_handler_called_sem, K_SECONDS(3));
+	TEST_ASSERT_EQUAL(0, err);
+	err = k_sem_take(&event_handler_called_sem_2, K_SECONDS(3));
+	TEST_ASSERT_EQUAL(0, err);
+#endif
 	cellular_rest_req_resp_handle(location_cb_expected - 2);
 
 	/* Select cellular service to be used */
@@ -1429,19 +1633,6 @@ void test_location_request_mode_all_cellular_gnss(void)
 	TEST_ASSERT_EQUAL(0, err);
 
 	/***** Then GNSS positioning *****/
-	test_pvt_data.flags = NRF_MODEM_GNSS_PVT_FLAG_FIX_VALID;
-	test_pvt_data.latitude = 60.987;
-	test_pvt_data.longitude = -45.997;
-	test_pvt_data.accuracy = 15.83;
-	test_pvt_data.datetime.year = 2021;
-	test_pvt_data.datetime.month = 8;
-	test_pvt_data.datetime.day = 2;
-	test_pvt_data.datetime.hour = 12;
-	test_pvt_data.datetime.minute = 34;
-	test_pvt_data.datetime.seconds = 23;
-	test_pvt_data.datetime.ms = 789;
-	test_pvt_data.flags = NRF_MODEM_GNSS_PVT_FLAG_FIX_VALID;
-
 	__cmock_nrf_modem_gnss_event_handler_set_ExpectAndReturn(&method_gnss_event_handler, 0);
 
 #if defined(CONFIG_LOCATION_TEST_AGNSS)
@@ -1489,7 +1680,6 @@ void test_location_request_mode_all_cellular_gnss(void)
 	method_gnss_event_handler(NRF_MODEM_GNSS_EVT_PVT);
 	k_sleep(K_MSEC(1));
 #endif
-#endif
 }
 
 /* Test location request error/timeout with :
@@ -1499,7 +1689,6 @@ void test_location_request_mode_all_cellular_gnss(void)
  */
 void test_location_request_mode_all_cellular_error_gnss_timeout(void)
 {
-#if !defined(CONFIG_LOCATION_DATA_DETAILS)
 	int err;
 
 	struct location_config config = { 0 };
@@ -1510,6 +1699,11 @@ void test_location_request_mode_all_cellular_error_gnss_timeout(void)
 	config.methods[0].cellular.cell_count = 1;
 	config.methods[1].gnss.timeout = 100;
 
+#if defined(CONFIG_LOCATION_DATA_DETAILS)
+	test_location_event_data[location_cb_expected].id = LOCATION_EVT_STARTED;
+	test_location_event_data[location_cb_expected].method = LOCATION_METHOD_CELLULAR;
+	location_cb_expected++;
+#endif
 	test_location_event_data[location_cb_expected].id = LOCATION_EVT_ERROR;
 	test_location_event_data[location_cb_expected].method = LOCATION_METHOD_CELLULAR;
 	location_cb_expected++;
@@ -1529,6 +1723,11 @@ void test_location_request_mode_all_cellular_error_gnss_timeout(void)
 	err = location_request(&config);
 	TEST_ASSERT_EQUAL(0, err);
 
+#if defined(CONFIG_LOCATION_DATA_DETAILS)
+	/* Wait for LOCATION_EVT_STARTED */
+	err = k_sem_take(&event_handler_called_sem, K_SECONDS(3));
+	TEST_ASSERT_EQUAL(0, err);
+#endif
 	/* Wait for location_event_handler call for 3 seconds.
 	 * If it doesn't happen, next assert will fail the test.
 	 */
@@ -1576,7 +1775,6 @@ void test_location_request_mode_all_cellular_error_gnss_timeout(void)
 
 	at_monitor_dispatch("+CSCON: 0");
 	k_sleep(K_MSEC(1));
-#endif
 }
 
 /********* TESTS PERIODIC POSITIONING REQUESTS ***********************/


### PR DESCRIPTION
Adding LOCATION_EVT_FALLBACK to be sent when a methods times out or fails and a new method is tried.
Adding `satellites_used` and `search_time` for GNSS details. Also creating Wi-Fi and cellular details with number of APs and cells.
Adding a new method type `LOCATION_METHOD_WIFI_CELLULAR` that cannot be used in the method list for location request but may occur in the events.

Jira: NCSDK-25618