### PR TITLE
net: lib: nrf_cloud: Update CoAP to support QZSS

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -809,6 +809,7 @@ Libraries for networking
     * The :c:func:`nrf_cloud_coap_shadow_delta_process` function to include a parameter for application-specific shadow data.
     * The :c:func:`nrf_cloud_coap_shadow_delta_process` function to process default shadow data added by nRF Cloud, which is not used by CoAP.
     * The CDDL file for AGNSS to align with cloud changes and regenerated the AGNSS encoder accordingly.
+    * To allow QZSS constellation assistance requests from AGNSS.
     * The following functions to accept a ``confirmable`` parameter:
 
       * :c:func:`nrf_cloud_coap_bytes_send`

--- a/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap.c
+++ b/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap.c
@@ -119,11 +119,6 @@ int nrf_cloud_coap_agnss_data_get(struct nrf_cloud_rest_agnss_request const *con
 	size_t len = sizeof(buffer);
 	int err;
 
-	/* QZSS assistance is not yet supported with CoAP, make sure we only ask for GPS. */
-	if (request->type == NRF_CLOUD_REST_AGNSS_REQ_CUSTOM) {
-		request->agnss_req->system_count = 1;
-	}
-
 	err = coap_codec_agnss_encode(request, buffer, &len,
 				     COAP_CONTENT_FORMAT_APP_CBOR);
 	if (err) {

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_agnss.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_agnss.c
@@ -119,16 +119,8 @@ int nrf_cloud_agnss_request(const struct nrf_modem_gnss_agnss_data_frame *reques
 
 static bool qzss_assistance_is_supported(void)
 {
-	char resp[32];
-
-	if (nrf_modem_at_cmd(resp, sizeof(resp), "AT+CGMM") == 0) {
-		/* nRF9160 does not support QZSS assistance, while nRF91x1 do. */
-		if (strstr(resp, "nRF9160") != NULL) {
-			return false;
-		}
-	}
-
-	return true;
+	/* Assume that all cellular products other than the nRF9160 support this. */
+	return (IS_ENABLED(CONFIG_NRF_MODEM_LIB) && !IS_ENABLED(CONFIG_SOC_NRF9160));
 }
 
 int nrf_cloud_agnss_request_all(void)


### PR DESCRIPTION
Remove code that blocked QZSS requests over CoAP.

Change the qzss_assistance_is_supported() function to check at compile-time instead of at runtime.

This PR is a repeat of an earlier one that was reverted due to lack of cloud support at that time. A later PR to enable QZSS over CoAP addressed other issues but missed restoring the present PR's changes.