### PR TITLE
applications: nrf5340_audio: Revert to adv after short burst of dir_adv

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/bt_management/advertising/Kconfig
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/advertising/Kconfig
@@ -48,7 +48,7 @@ config BLE_ACL_EXT_ADV_INT_MAX
 
 config EXT_ADV_BUF_MAX
 	int "Maximum number of extended advertising data parameters"
-	default 10
+	default 15
 
 config EXT_ADV_UUID_BUF_MAX
 	int "Maximum number of UUIDs to add to extended advertisements"

--- a/applications/nrf5340_audio/src/bluetooth/bt_management/advertising/bt_mgmt_adv.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/advertising/bt_mgmt_adv.c
@@ -25,12 +25,11 @@ ZBUS_CHAN_DECLARE(bt_mgmt_chan);
 #endif
 
 static struct k_work adv_work;
-
+static bool dir_adv_timed_out;
 static struct bt_le_ext_adv *ext_adv;
 
 static const struct bt_data *adv_local;
 static size_t adv_local_size;
-
 static const struct bt_data *per_adv_local;
 static size_t per_adv_local_size;
 
@@ -130,7 +129,7 @@ static int direct_adv_create(bt_addr_le_t addr)
 	struct bt_le_adv_param adv_param;
 	struct bt_le_ext_adv_info ext_adv_info;
 
-	adv_param = *BT_LE_ADV_CONN_DIR_LOW_DUTY(&addr);
+	adv_param = *BT_LE_ADV_CONN_DIR(&addr);
 	adv_param.id = BT_ID_DEFAULT;
 	adv_param.options |= BT_LE_ADV_OPT_DIR_ADDR_RPA;
 
@@ -170,10 +169,15 @@ static int extended_adv_create(void)
 		return -ENXIO;
 	}
 
-	ret = bt_le_ext_adv_set_data(ext_adv, adv_local, adv_local_size, NULL, 0);
-	if (ret) {
-		LOG_ERR("Failed to set advertising data: %d", ret);
-		return ret;
+	if (dir_adv_timed_out) {
+		/* If the directed adv has timed out it means we only need to update the adv data */
+		bt_le_adv_update_data(adv_local, adv_local_size, NULL, 0);
+	} else {
+		ret = bt_le_ext_adv_set_data(ext_adv, adv_local, adv_local_size, NULL, 0);
+		if (ret) {
+			LOG_ERR("Failed to set advertising data: %d", ret);
+			return ret;
+		}
 	}
 
 	if (per_adv_local != NULL && IS_ENABLED(CONFIG_BT_PER_ADV)) {
@@ -217,21 +221,27 @@ static void advertising_process(struct k_work *work)
 
 	bt_addr_le_t addr;
 
-	if (!k_msgq_get(&bonds_queue, &addr, K_NO_WAIT)) {
+	if (!k_msgq_get(&bonds_queue, &addr, K_NO_WAIT) && !dir_adv_timed_out) {
 		ret = direct_adv_create(addr);
 		if (ret) {
 			LOG_WRN("Failed to create direct advertisement: %d", ret);
 			return;
 		}
+
+		ret = bt_le_ext_adv_start(
+			ext_adv,
+			BT_LE_EXT_ADV_START_PARAM(BT_GAP_ADV_HIGH_DUTY_CYCLE_MAX_TIMEOUT, 0));
 	} else {
 		ret = extended_adv_create();
 		if (ret) {
 			LOG_WRN("Failed to create extended advertisement: %d", ret);
 			return;
 		}
+
+		dir_adv_timed_out = false;
+		ret = bt_le_ext_adv_start(ext_adv, BT_LE_EXT_ADV_START_DEFAULT);
 	}
 
-	ret = bt_le_ext_adv_start(ext_adv, BT_LE_EXT_ADV_START_DEFAULT);
 	if (ret) {
 		LOG_ERR("Failed to start advertising set. Err: %d", ret);
 		return;
@@ -254,6 +264,29 @@ static void advertising_process(struct k_work *work)
 
 	/* NOTE: The string below is used by the Nordic CI system */
 	LOG_INF("Advertising successfully started");
+}
+
+void bt_mgmt_dir_adv_timed_out(void)
+{
+	int ret;
+
+	dir_adv_timed_out = true;
+
+	LOG_DBG("Clearing ext_adv");
+
+	ret = bt_le_ext_adv_delete(ext_adv);
+	if (ret) {
+		LOG_ERR("Failed to clear ext_adv");
+	}
+
+	ret = bt_le_ext_adv_create(LE_AUDIO_EXTENDED_ADV_CONN_NAME, &adv_cb, &ext_adv);
+	if (ret) {
+		LOG_ERR("Unable to create a connectable extended advertising set: %d", ret);
+		return;
+	}
+
+	/* Restart normal advertising */
+	bt_mgmt_adv_start(NULL, 0, NULL, 0, true);
 }
 
 int bt_mgmt_adv_start(const struct bt_data *adv, size_t adv_size, const struct bt_data *per_adv,

--- a/applications/nrf5340_audio/src/bluetooth/bt_management/advertising/bt_mgmt_adv_internal.h
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/advertising/bt_mgmt_adv_internal.h
@@ -14,4 +14,12 @@
  */
 void bt_mgmt_adv_init(void);
 
+/**
+ * @brief	Handle timed-out directed advertisement.
+ *
+ *		This function deletes the old ext_adv and creates a new one.
+ *		It also sets the dir_adv_timed_out flag and restarts advertisement.
+ */
+void bt_mgmt_dir_adv_timed_out(void);
+
 #endif /* _BT_MGMT_ADV_INTERNAL_H_ */

--- a/applications/nrf5340_audio/src/bluetooth/bt_management/bt_mgmt.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/bt_mgmt.c
@@ -79,6 +79,19 @@ static void connected_cb(struct bt_conn *conn, uint8_t err)
 	uint8_t num_conn = 0;
 	struct bt_mgmt_msg msg;
 
+	if (err == BT_HCI_ERR_ADV_TIMEOUT && IS_ENABLED(CONFIG_BT_PERIPHERAL)) {
+		LOG_INF("Directed adv timed out with no connection, reverting to normal adv");
+
+		bt_mgmt_dir_adv_timed_out();
+
+		ret = bt_mgmt_adv_start(NULL, 0, NULL, 0, true);
+		if (ret) {
+			LOG_ERR("Failed to restart advertising: %d", ret);
+		}
+
+		return;
+	}
+
 	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err) {

--- a/applications/nrf5340_audio/src/bluetooth/bt_management/bt_mgmt.h
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/bt_mgmt.h
@@ -19,6 +19,11 @@
 				BT_LE_ADV_OPT_USE_NAME,                                            \
 			CONFIG_BLE_ACL_EXT_ADV_INT_MIN, CONFIG_BLE_ACL_EXT_ADV_INT_MAX, NULL)
 
+#define LE_AUDIO_EXTENDED_ADV_CONN_NAME_FILTER                                                     \
+	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV | BT_LE_ADV_OPT_CONNECTABLE |                        \
+				BT_LE_ADV_OPT_USE_NAME | BT_LE_ADV_OPT_FILTER_CONN,                \
+			CONFIG_BLE_ACL_EXT_ADV_INT_MIN, CONFIG_BLE_ACL_EXT_ADV_INT_MAX, NULL)
+
 #define LE_AUDIO_PERIODIC_ADV                                                                      \
 	BT_LE_PER_ADV_PARAM(CONFIG_BLE_ACL_PER_ADV_INT_MIN, CONFIG_BLE_ACL_PER_ADV_INT_MAX,        \
 			    BT_LE_PER_ADV_OPT_NONE)

--- a/applications/nrf5340_audio/src/bluetooth/bt_management/scanning/bt_mgmt_scan_for_conn.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/scanning/bt_mgmt_scan_for_conn.c
@@ -149,6 +149,11 @@ static void scan_recv_cb(const struct bt_le_scan_recv_info *info, struct net_buf
 		/* Note: May lead to connection creation */
 		if (bonded_num < CONFIG_BT_MAX_PAIRED) {
 			bt_data_parse(ad, device_name_check, (void *)info->addr);
+		} else {
+			/* All bonded slots are taken, so we will only
+			 * accept previously bonded devices
+			 */
+			bt_foreach_bond(BT_ID_DEFAULT, bond_connect, (void *)info->addr);
 		}
 		break;
 	default:

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/Kconfig.defaults
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/Kconfig.defaults
@@ -13,6 +13,9 @@ config BT_BONDABLE
 config BT_PRIVACY
 	default y
 
+config BT_FILTER_ACCEPT_LIST
+	default y
+
 config BT_SMP
 	default y
 

--- a/applications/nrf5340_audio/unicast_server/Kconfig.defaults
+++ b/applications/nrf5340_audio/unicast_server/Kconfig.defaults
@@ -6,7 +6,10 @@
 
 ## ACL related configs ##
 config BT_MAX_CONN
-	default 1
+	default 4
+
+config BT_MAX_PAIRED
+	default 4
 
 config BT_PERIPHERAL
 	default y

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -254,6 +254,8 @@ Serial LTE modem
 nRF5340 Audio
 -------------
 
+* Added support for Filter Accept List and enabled as default.
+
 * Updated:
 
   * Sending of the ISO data, which is now done in a single file :file:`bt_le_audio_tx`.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -256,8 +256,9 @@ nRF5340 Audio
 
 * Updated:
 
-  * ISO data sending has been refactored, and is now done in a single file: bt_le_audio_tx.
-  * Split the generic applications into their own samples with separate main.c files
+  * Sending of the ISO data, which is now done in a single file :file:`bt_le_audio_tx`.
+  * Application structure, which is now split into four separate, generic applications with separate :file:`main.c` files.
+  * Advertising process by reverting back to slower advertising after a short burst (1.28 s) of directed advertising.
 
 
 nRF Machine Learning (Edge Impulse)


### PR DESCRIPTION
- If already bonded, do a short burst of directed advertising before reverting back to a slower pace advertising
- OCT-2618