### PR TITLE
samples: cellular: modem_shell: Error message improvements

### DIFF
--- a/samples/cellular/modem_shell/src/sock/sock_shell.c
+++ b/samples/cellular/modem_shell/src/sock/sock_shell.c
@@ -606,7 +606,7 @@ static int cmd_sock_send(const struct shell *shell, size_t argc, char **argv)
 
 			if (blocking != 0 && blocking != 1) {
 				mosh_error(
-					"Blocking (%d) must be either '0' (false) or '1' (true)",
+					"Blocking (%s) must be either '0' (false) or '1' (true)",
 					optarg);
 				return -EINVAL;
 			}
@@ -687,7 +687,7 @@ static int cmd_sock_recv(const struct shell *shell, size_t argc, char **argv)
 
 			if (blocking != 0 && blocking != 1) {
 				mosh_error(
-					"Blocking (%d) must be either '0' (false) or '1' (true)",
+					"Blocking (%s) must be either '0' (false) or '1' (true)",
 					optarg);
 				return -EINVAL;
 			}


### PR DESCRIPTION
Retry sending random data only when send() fails with EAGAIN. Other errors should not trigger retry because this could cause an infinite send loop.

Always print error from send(), except from when having EAGAIN in non-blocking mode (which is a normal case). The TCP send flow control issue have been fixed.

Fixed print format for wrong blocking mode value in send and recv.
Align some error messages printing errno.