### PR TITLE
samples: matter: Added support for including wi-fi firmware patch

### DIFF
--- a/samples/matter/lock/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/samples/matter/lock/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_UPDATEABLE_IMAGE_NUMBER=3

--- a/samples/matter/lock/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/samples/matter/lock/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_MCUBOOT_VERIFY_IMG_ADDRESS=n
+CONFIG_UPDATEABLE_IMAGE_NUMBER=3

--- a/samples/matter/lock/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
+++ b/samples/matter/lock/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
@@ -50,9 +50,22 @@ nrf70_wifi_fw:
   size: 0x20000
   device: MX25R64
   region: external_flash
-external_flash:
+mcuboot_primary_2:
+  orig_span: &id003
+  - nrf70_wifi_fw
+  span: *id003
+  address: 0x12f000
+  size: 0x20000
+  device: MX25R64
+  region: external_flash
+mcuboot_secondary_2:
   address: 0x14F000
-  size: 0x6B1000
+  size: 0x20000
+  device: MX25R64
+  region: external_flash
+external_flash:
+  address: 0x16F000
+  size: 0x691000
   device: MX25R64
   region: external_flash
 pcd_sram:

--- a/samples/matter/lock/sample.yaml
+++ b/samples/matter/lock/sample.yaml
@@ -40,3 +40,11 @@ tests:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+  sample.matter.lock.thread_wifi_switched_ext_patch:
+    build_only: true
+    extra_args: SHIELD=nrf7002ek multiprotocol_rpmsg_SHIELD=nrf7002ek_coex
+      CONF_FILE=prj_thread_wifi_switched.conf CONFIG_NRF_WIFI_PATCHES_EXT_FLASH_STORE=y 
+      CONFIG_NRF_WIFI_FW_FLASH_CHUNK_SIZE=8192
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf5340dk_nrf5340_cpuapp

--- a/west.yml
+++ b/west.yml
@@ -39,6 +39,8 @@ manifest:
       url-base: https://github.com/BabbleSim
     - name: bosch
       url-base: https://github.com/boschsensortec
+    - name: arbl
+      url-base: https://github.com/ArekBalysNordic
 
   # If not otherwise specified, the projects below should be obtained
   # from the ncs remote.
@@ -129,7 +131,8 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: a9d5fa76a6840f8934b2aaaf51e290f91eb3f991
+      remote: arbl
+      revision: skip_3rd_validation
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR.git


### PR DESCRIPTION
This commit enables twister CI for nrf5340 + nRF70EK + wifi fw patch on external flash in Matter Wifi/Thread switchable doorlock sample.