### PR TITLE
doc: add config option to bootloader extflash

### DIFF
--- a/doc/nrf/config_and_build/bootloaders/bootloader_external_flash.rst
+++ b/doc/nrf/config_and_build/bootloaders/bootloader_external_flash.rst
@@ -13,14 +13,27 @@ When using MCUboot, you can store the storage partition for the secondary slot i
 * Single-byte read and write.
 * Writing data from the internal flash memory to the external flash memory.
 
+To enable external flash with MCUboot, complete the following steps:
+
+1. Follow the instructions in :ref:`pm_external_flash`, which enables external flash use in the nRF5340 DK's DTS file.
+
+#. Enable the :kconfig:option:`CONFIG_PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY` Kconfig option.
+   (Depending on the build configuration, this option will be set to ``y`` automatically.)
+
+#. Update the ``CONFIG_BOOT_MAX_IMG_SECTORS`` `MCUboot Kconfig option <https://github.com/nrfconnect/sdk-mcuboot/blob/main/boot/zephyr/Kconfig#L370>`_ accordingly for child images.
+   This option defines the maximum number of image sectors MCUboot can handle, as MCUboot typically increases slot sizes when external flash is enabled.
+   Otherwise the ``CONFIG_BOOT_MAX_IMG_SECTORS`` Kconfig option defaults to the value used for internal flash, and the application may not boot if the value is set too low.
+
+   (The image sector size is the same as the flash erase-block-size across all |NCS| integrated memory.)
+
 .. note::
 
-   The Partition Manager will only support run-time access to flash partitions defined in regions placed on external flash devices that have drivers compiled in.
-   Partition Manager cannot determine which partitions will be used at runtime, but only those that have drivers enabled, and those are included into the partition map.
+   The :ref:`partition_manager` will only support run-time access to flash partitions defined in regions placed on external flash devices that have drivers compiled in.
+   The Partition Manager cannot determine which partitions will be used at runtime, but only those that have drivers enabled, and those are included into the partition map.
    Lack of partition access will cause MCUboot to fail at runtime.
    For more details on configuring and enabling access to external flash devices, see :ref:`pm_external_flash`.
 
-The QSPI NOR flash memory driver supports these features, and it can access the QSPI external flash memory of the nRF52840 DK and nRF5340 DK.
+The Quad Serial Peripheral Interface (QSPI) NOR flash memory driver supports these features, and it can access the QSPI external flash memory of the nRF52840 DK and nRF5340 DK.
 
 See the test in :file:`tests/modules/mcuboot/external_flash` for reference.
 This test passes both devicetree overlay files and Kconfig fragments to the MCUboot child image through its :file:`child_image` folder.
@@ -46,6 +59,10 @@ This error could be caused by the following issues:
     See :ref:`pm_external_flash` for details.
 
   * An out-of-tree external flash driver is not selecting :kconfig:option:`CONFIG_PM_EXTERNAL_FLASH_HAS_DRIVER`, resulting in partitions for images located in the external flash memory being not accessible.
+    See :ref:`pm_external_flash` for details.
+
+  * Insufficient value set for the ``CONFIG_BOOT_MAX_IMG_SECTORS`` Kconfig option, as MCUboot typically increases slot sizes when external flash is enabled.
+    See `MCUboot's Kconfig options used in Zephyr <https://github.com/nrfconnect/sdk-mcuboot/blob/main/boot/zephyr/Kconfig#L370>`_ for details.
 
 The compilation could fail, reporting a linker error similar to following:
 


### PR DESCRIPTION
[NCSIDB-1160](https://nordicsemi.atlassian.net/browse/NCSIDB-1160)
Add config option to troubleshooting section of Bootloaders > Using external flash memory partitions.


[NCSIDB-1160]: https://nordicsemi.atlassian.net/browse/NCSIDB-1160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ