### PR TITLE
doc: FEM user guide: clarify the purpose of the simple 2-pin mode.

### DIFF
--- a/doc/nrf/device_guides/working_with_fem.rst
+++ b/doc/nrf/device_guides/working_with_fem.rst
@@ -40,7 +40,7 @@ The MPSL library provides the following GPIO interface implementations:
 
 * :ref:`ug_radio_fem_nrf21540_spi_gpio` - For the nRF21540 GPIO+SPI implementation that uses a 3-pin interface and an SPI interface with the nRF21540.
 * :ref:`ug_radio_fem_nrf21540_gpio` - For the nRF21540 GPIO implementation that uses a 3-pin interface with the nRF21540.
-* :ref:`ug_radio_fem_skyworks` - For the Simple GPIO implementation that uses a 2-pin interface with the SKY66112-11 device.
+* :ref:`ug_radio_fem_skyworks` - For the implementation that uses a 2-pin interface with the SKY66112-11 device and other compatible front-end modules.
 
 To use these implementations, your application must use a protocol driver that enables the FEM feature.
 
@@ -437,8 +437,8 @@ The following properties are optional and you can add them to the devicetree nod
 
 .. _ug_radio_fem_skyworks:
 
-Adding support for Skyworks front-end module
-============================================
+Adding support for front-end modules using Simple GPIO interface
+================================================================
 
 You can use the Skyworks range extenders with nRF52 and nRF53 Series devices.
 SKY66112-11 is one of many FEM devices that support the 2-pin PA/LNA interface.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -35,21 +35,6 @@ IDE and tool support
 
 |no_changes_yet_note|
 
-Application development
-=======================
-
-This section provides detailed lists of changes to overarching SDK systems and components.
-
-Build system
-------------
-
-|no_changes_yet_note|
-
-nRF Front-End Modules
----------------------
-
-|no_changes_yet_note|
-
 Working with nRF91 Series
 =========================
 
@@ -70,6 +55,11 @@ Working with nRF53 Series
 =========================
 
 |no_changes_yet_note|
+
+Working with RF front-end modules
+=================================
+
+* Added a clarification that the Simple GPIO implementation is intended for multiple front-end modules (not just one specific device) in the :ref:`ug_radio_fem_sw_support_mpsl` section of the :ref:`ug_radio_fem` guide.
 
 Protocols
 =========


### PR DESCRIPTION
The documentation stated that the 2-pin a.k.a "Simple GPIO" implementation was intended just for SKY66112-11 device specifically while actually it should work for many devices that use the same interface.