### PR TITLE
applications: nrf5340_audio: Error print in sent callback

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_client.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_client.c
@@ -715,11 +715,16 @@ static void stream_sent_cb(struct bt_bap_stream *stream)
 	int ret;
 	uint8_t channel_index;
 
-	ret = channel_index_get(stream->conn, &channel_index);
-	if (ret) {
-		LOG_ERR("Channel index not found");
+	if (le_audio_ep_state_check(stream->ep, BT_BAP_EP_STATE_STREAMING)) {
+
+		ret = channel_index_get(stream->conn, &channel_index);
+		if (ret) {
+			LOG_ERR("Channel index not found");
+		} else {
+			ERR_CHK(bt_le_audio_tx_stream_sent(channel_index));
+		}
 	} else {
-		ERR_CHK(bt_le_audio_tx_stream_sent(channel_index));
+		LOG_WRN("Not in streaming state");
 	}
 }
 


### PR DESCRIPTION
OCT-2822

The disconnect and reconnect of a headset, causes the gateway to print an error in the stream sent callback. The error only occurs when the gateway is streaming. This is caused by the disconnect interrupting the send data process and when the sent callback is executed the connection can not be found, as it has been closed. 

Adding a test of the streaming state to the sent callback before the channel index is retrieved and tested solves the issue.