### PR TITLE
quarantine: Stop testing redundant tests

### DIFF
--- a/scripts/quarantine_zephyr.yaml
+++ b/scripts/quarantine_zephyr.yaml
@@ -116,6 +116,12 @@
   comment: "Won't be fixed - https://nordicsemi.atlassian.net/browse/NCSDK-18853"
 
 - scenarios:
+    - sample.tfm.regression_ipc_lvl1
+    - sample.tfm.regression_ipc_lvl2
+    - sample.tfm.regression_sfn
+  comment: "Won't be fixed - We have our own copy of these regression tests in nrf"
+
+- scenarios:
     - sample.drivers.crypto.mbedtls
   platforms:
     - nrf9160dk_nrf9160_ns


### PR DESCRIPTION
Stop testing redundant tests. They are failing and don't provide enough value to be maintained.