### PR TITLE
applications: serial_lte_modem: Add 9151 overlay files

### DIFF
--- a/applications/serial_lte_modem/boards/nrf9151dk_nrf9151_ns.conf
+++ b/applications/serial_lte_modem/boards/nrf9151dk_nrf9151_ns.conf
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Configuration file for nRF9151DK.
+# This file is merged with prj.conf in the application folder, and options
+# set here will take precedence if they are present in both files.
+
+# Use UART_0 (when working with PC terminal)
+# unmask the following config
+CONFIG_UART_0_NRF_HW_ASYNC_TIMER=2
+CONFIG_UART_0_NRF_HW_ASYNC=y
+CONFIG_SLM_WAKEUP_PIN=8
+CONFIG_SLM_INDICATE_PIN=0
+
+# Use UART_2 (when working with external MCU)
+# unmask the following config
+#CONFIG_UART_2_NRF_HW_ASYNC_TIMER=2
+#CONFIG_UART_2_NRF_HW_ASYNC=y
+#CONFIG_SLM_WAKEUP_PIN=31
+#CONFIG_SLM_INDICATE_PIN=30

--- a/applications/serial_lte_modem/boards/nrf9151dk_nrf9151_ns.overlay
+++ b/applications/serial_lte_modem/boards/nrf9151dk_nrf9151_ns.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+ #include "nrf9161dk_nrf9161_ns.overlay"


### PR DESCRIPTION
Add overlay files for nrf9151dk_nrf9151_ns.

These are identical to 9161 overlay files.