### PR TITLE
samples: cellular: modem_shell: Add sock connect --keep_open

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -485,6 +485,7 @@ Cellular samples
     * Support for PDN CID 0 in the ``-I`` argument for the ``sock connect`` command.
     * Support for listing interface addresses using the ``link ifaddrs`` command.
     * Support for the ``MSG_WAITACK`` send flag using the ``sock send`` command.
+    * Support for connect with ``SO_KEEPOPEN`` using the ``sock connect`` command.
 
   * Removed:
 

--- a/samples/cellular/modem_shell/src/sock/sock.c
+++ b/samples/cellular/modem_shell/src/sock/sock.c
@@ -527,6 +527,7 @@ int sock_open_and_connect(
 	bool secure,
 	uint32_t sec_tag,
 	bool session_cache,
+	bool keep_open,
 	int peer_verify,
 	char *peer_hostname)
 {
@@ -613,6 +614,14 @@ int sock_open_and_connect(
 	if (bind_port > 0) {
 		err = sock_bind(fd, family, bind_port);
 		if (err) {
+			goto connect_error;
+		}
+	}
+
+	if (keep_open) {
+		err = setsockopt(fd, SOL_SOCKET, SO_KEEPOPEN, &(int){1}, sizeof(int));
+		if (err) {
+			mosh_error("Unable to set option SO_KEEPOPEN, errno %d", errno);
 			goto connect_error;
 		}
 	}

--- a/samples/cellular/modem_shell/src/sock/sock.h
+++ b/samples/cellular/modem_shell/src/sock/sock.h
@@ -25,7 +25,7 @@ int sock_getaddrinfo(int family, int type, char *hostname, int pdn_cid);
 int sock_open_and_connect(
 	int family, int type, char *address, int port,
 	int bind_port, int pdn_cid, bool secure, uint32_t sec_tag,
-	bool session_cache, int peer_verify,
+	bool session_cache, bool keep_open, int peer_verify,
 	char *peer_hostname);
 
 int sock_send_data(

--- a/samples/cellular/modem_shell/src/sock/sock_shell.c
+++ b/samples/cellular/modem_shell/src/sock/sock_shell.c
@@ -38,7 +38,7 @@ enum sock_shell_command {
 
 static const char sock_connect_usage_str[] =
 	"Usage: sock connect -a <address> -p <port>\n"
-	"       [-f <family>] [-t <type>] [-b <port>] [-I <cid>]\n"
+	"       [-f <family>] [-t <type>] [-b <port>] [-I <cid>] [-K]\n"
 	"       [-S] [-T <sec_tag>] [-c] [-V <level>] [-H <hostname>]\n"
 	"Options:\n"
 	"  -a, --address, [str]      Address as ip address or hostname\n"
@@ -50,6 +50,7 @@ static const char sock_connect_usage_str[] =
 	"  -b, --bind_port, [int]    Local port to bind the socket to\n"
 	"  -I, --cid, [int]          Use this option to bind socket to specific\n"
 	"                            PDN CID. See link command for available CIDs.\n"
+	"  -K, --keep_open           Keep socket open when its PDN connection is lost.\n"
 	"  -S, --secure,             Enable secure connection (TLS 1.2/DTLS 1.2).\n"
 	"  -T, --sec_tag, [int]      Security tag for TLS certificate(s).\n"
 	"  -c, --cache,              Enable TLS session cache.\n"
@@ -195,6 +196,7 @@ static struct option long_options[] = {
 	{ "start",          no_argument,       0, 'r' },
 	{ "blocking",       required_argument, 0, 'B' },
 	{ "wait_ack",       no_argument,       0, 'W' },
+	{ "keep_open",      no_argument,       0, 'K' },
 	{ "print_format",   required_argument, 0, 'P' },
 	{ "packet_number_prefix", no_argument, 0, SOCK_SHELL_OPT_PACKET_NUMBER_PREFIX },
 	{ "rai_last",       no_argument,       0, SOCK_SHELL_OPT_RAI_LAST },
@@ -206,7 +208,7 @@ static struct option long_options[] = {
 	{ 0,                0,                 0, 0   }
 };
 
-static const char short_options[] = "i:I:a:p:f:t:b:ST:cV:H:d:l:e:s:xrB:WP:h";
+static const char short_options[] = "i:I:a:p:f:t:b:ST:cV:H:d:l:e:s:xrB:WKP:h";
 
 static void sock_print_usage(enum sock_shell_command command)
 {
@@ -348,6 +350,7 @@ static int cmd_sock_connect(const struct shell *shell, size_t argc, char **argv)
 	bool arg_secure = false;
 	uint32_t arg_sec_tag = 0;
 	bool arg_session_cache = false;
+	bool arg_keep_open = false;
 	int arg_peer_verify = 2;
 	char arg_peer_hostname[SOCK_MAX_ADDR_LEN + 1];
 
@@ -430,6 +433,9 @@ static int cmd_sock_connect(const struct shell *shell, size_t argc, char **argv)
 				return -EINVAL;
 			}
 			break;
+		case 'K':
+			arg_keep_open = true;
+			break;
 		case 'S': /* Security */
 			arg_secure = true;
 			break;
@@ -490,6 +496,7 @@ static int cmd_sock_connect(const struct shell *shell, size_t argc, char **argv)
 		arg_secure,
 		arg_sec_tag,
 		arg_session_cache,
+		arg_keep_open,
 		arg_peer_verify,
 		arg_peer_hostname);
 


### PR DESCRIPTION
Add an option to sock connect to keep socket open when its PDN connection is lost. This is useful to keep DTLS connections when network is lost for a short period.