### PR TITLE
manifest: sdk-hostap: Pull OOM fixes in WPA cli

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -112,7 +112,7 @@ manifest:
     - name: hostap
       repo-path: sdk-hostap
       path: modules/lib/hostap
-      revision: ecebc52715feb1605b7aab0cb13004be287db884
+      revision: 3f3b7c45620b6f9710c884ea84d3e1811362117d
       userdata:
         ncs:
           upstream-url: https://w1.fi/cgit/hostap/


### PR DESCRIPTION
Use stack over heap to avoid OOM during runtime.