### PR TITLE
manifest: sdk-hostap: Pull fix for non-zephyr code

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -112,7 +112,7 @@ manifest:
     - name: hostap
       repo-path: sdk-hostap
       path: modules/lib/hostap
-      revision: 3f3b7c45620b6f9710c884ea84d3e1811362117d
+      revision: 1bdc2a130a94e025273e256456ad51c6fdd8d563
       userdata:
         ncs:
           upstream-url: https://w1.fi/cgit/hostap/


### PR DESCRIPTION
Revert accidental change to non-zephyr code.