### PR TITLE
Bluetooth: set configuration for HCI ISO data timestamps

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -497,5 +497,16 @@ config BT_CTLR_SDC_SILENCE_UNEXPECTED_MSG_TYPE
 	help
 	  Convenience config to silence unexpected incoming msg type
 
+config BT_CTLR_SDC_IGNORE_HCI_ISO_DATA_TS_FROM_HOST
+	bool "Configure the controller to ignore timestamps in HCI ISO data packets."
+	depends on BT_CTLR_PERIPHERAL_ISO || BT_CTLR_CENTRAL_ISO || BT_CTLR_ADV_ISO
+	select DEPRECATED
+	help
+	  Configures the SoftDevice Controller to ignore timestamps on HCI ISO data packets.
+	  The only use-case for this option is if the host uses timestamps which are not based
+	  on the clock of the controller. Instead of this configuration, the host should
+	  not add timestamps to the HCI ISO data packets if the timestamp is not based on the clock
+	  of the controller.
+
 endmenu
 endif  # BT_LL_SOFTDEVICE

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -830,6 +830,13 @@ static int configure_supported_features(void)
 		}
 	}
 
+	if (IS_ENABLED(CONFIG_BT_CTLR_SDC_IGNORE_HCI_ISO_DATA_TS_FROM_HOST)) {
+		err = sdc_iso_host_timestamps_ignore(true);
+		if (err) {
+			return -ENOTSUP;
+		}
+	}
+
 	if (IS_ENABLED(CONFIG_BT_CTLR_SYNC_ISO)) {
 		err = sdc_support_bis_sink();
 		if (err) {


### PR DESCRIPTION
If the host uses timestamps for HCI ISO data packets which are not based on the controller's clock, the controller needs to be configured accordingly.

Added a KConfig which exposes this possibility.