### PR TITLE
doc: nrf5340audio: minor additions and fixes

### DIFF
--- a/applications/nrf5340_audio/doc/firmware_architecture.rst
+++ b/applications/nrf5340_audio/doc/firmware_architecture.rst
@@ -19,27 +19,6 @@ The applications use the same code base, but use different :file:`main.c` files 
 You might need to configure and program two applications for testing the interoperability, depending on your use case.
 See the testing steps for each of the application for more information.
 
-.. _nrf53_audio_app_overview_differences:
-
-Differences between apps
-************************
-
-The following table summarizes the differences between the available nRF5340 Audio applications.
-
-.. list-table:: Differences between nRF5340 Audio applications
-   :header-rows: 1
-
-   * - Application
-     - LE Audio mode and role
-   * - :ref:`Unicast client<nrf53_audio_unicast_client_app>`
-     - CIS gateway
-   * - :ref:`Unicast server<nrf53_audio_unicast_server_app>`
-     - CIS headset
-   * - :ref:`Broadcast sink<nrf53_audio_broadcast_sink_app>`
-     - BIS gateway
-   * - :ref:`Broadcast source<nrf53_audio_broadcast_source_app>`
-     - BIS headset
-
 .. _nrf53_audio_app_overview_modes:
 
 Application modes

--- a/applications/nrf5340_audio/doc/requirements.rst
+++ b/applications/nrf5340_audio/doc/requirements.rst
@@ -62,5 +62,5 @@ For each application, only one of the following :file:`.conf` files is included 
   See :ref:`nrf53_audio_app_building` for details.
 
 In addition, the application features the :file:`child_image` directory with an experimental :file:`hci_ipc.conf`.
-This file is a work-in-progress implementation of the SoftDevice Controller that has not been thoroughly tested and is currently not meant for production.
+This file is a work-in-progress implementation of the :ref:`SoftDevice Controller for LE Isochronous Channels <nrfxlib:softdevice_controller_iso>` that has not been thoroughly tested and is currently not meant for production.
 The application is only tested using :ref:`lib_bt_ll_acs_nrf53_readme`.

--- a/applications/nrf5340_audio/index.rst
+++ b/applications/nrf5340_audio/index.rst
@@ -8,6 +8,32 @@ The nRF5340 Audio applications demonstrate audio playback over isochronous chann
 .. note::
    nRF5340 Audio applications and their DFU/FOTA functionality are marked as :ref:`experimental <software_maturity>`.
 
+The following table summarizes the differences between the available nRF5340 Audio applications.
+
+.. list-table:: Differences between nRF5340 Audio applications
+   :header-rows: 1
+
+   * - Application
+     - LE Audio mode and role
+     - Minimum amount of nRF5340 Audio DKs recommended for testing
+     - FEM support
+   * - :ref:`Unicast client<nrf53_audio_unicast_client_app>`
+     - CIS gateway
+     - 3
+     - ✔
+   * - :ref:`Unicast server<nrf53_audio_unicast_server_app>`
+     - CIS headset
+     - 3
+     - ✔
+   * - :ref:`Broadcast sink<nrf53_audio_broadcast_sink_app>`
+     - BIS gateway
+     - 2
+     -
+   * - :ref:`Broadcast source<nrf53_audio_broadcast_source_app>`
+     - BIS headset
+     - 2
+     - ✔
+
 See the subpages for detailed documentation of each of the nRF5340 applications and their internal modules:
 
 .. _nrf53_audio_app_subpages:

--- a/doc/nrf/libraries/bin/bt_ll_acs_nrf53/index.rst
+++ b/doc/nrf/libraries/bin/bt_ll_acs_nrf53/index.rst
@@ -9,8 +9,8 @@ LE Audio controller for nRF5340
 
 The LE Audio controller for nRF5340 is a link layer controller for the nRF5340 network core and is meant to be used with LE Audio applications.
 
-This controller is compatible with the HCI RPMsg driver provided by the |NCS| Bluetooth® :ref:`bt_hci_drivers` core.
-When the communication between the application and the network core on a device is handled by the HCI RPMsg driver, this link layer controller can be used to handle time critical low level communication and the radio.
+This controller is compatible with the HCI IPC driver provided by the |NCS| Bluetooth® :ref:`bt_hci_drivers` core.
+When the communication between the application and the network core on a device is handled by the HCI IPC driver, this link layer controller can be used to handle time critical low level communication and the radio.
 
 .. note::
    The LE Audio controller for nRF5340 is under development and is provided in the :ref:`experimental state <software_maturity>`.


### PR DESCRIPTION
Added link to SD Controller LE ISO Channels.
Moved the table about differences.
Fixed naming of HCI RPMsg.