### PR TITLE
bluetooth: adv_prov: device_name: Add device name only in pairing mode

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -273,6 +273,7 @@
   - "include/nrf_profiler.h"
   - "scripts/hid_configurator/**/*"
   - "subsys/bluetooth/services/**/*"
+  - "subsys/bluetooth/adv_prov/**/*"
   - "subsys/bluetooth/*"
   - "subsys/caf/**/*"
   - "subsys/app_event_manager/**/*"

--- a/applications/nrf_desktop/src/modules/Kconfig.caf_ble_adv.default
+++ b/applications/nrf_desktop/src/modules/Kconfig.caf_ble_adv.default
@@ -43,6 +43,12 @@ config BT_ADV_PROV_GAP_APPEARANCE
 config BT_ADV_PROV_DEVICE_NAME
 	default y
 
+config BT_ADV_PROV_DEVICE_NAME_PAIRING_MODE_ONLY
+	default n
+	help
+	  nRF Desktop provides device name also outside of pairing mode. This is
+	  done for backwards compatibility.
+
 config BT_ADV_PROV_SWIFT_PAIR
 	default y
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -705,6 +705,12 @@ Bluetooth libraries and services
 
   * Added the :c:func:`bt_scan_update_connect_if_match` function to update the autoconnect flag after a filter match.
 
+* :ref:`bt_le_adv_prov_readme`:
+
+  * Updated the default behavior of the Bluetooth device name provider (:kconfig:option:`CONFIG_BT_ADV_PROV_DEVICE_NAME`).
+    By default, the device name is provided only in the pairing mode (:c:member:`bt_le_adv_prov_adv_state.pairing_mode`).
+    You can disable the newly introduced Kconfig option (:kconfig:option:`CONFIG_BT_ADV_PROV_DEVICE_NAME_PAIRING_MODE_ONLY`) to provide the device name also when the device is not in the pairing mode.
+
 Bootloader libraries
 --------------------
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -297,6 +297,9 @@ nRF Desktop
     Disabling this Kconfig option improves the debugging experience.
   * The MCUboot, B0, and HCI RPMsg child images release configurations to explicitly enable the :kconfig:option:`CONFIG_RESET_ON_FATAL_ERROR` Kconfig option.
     Enabling this Kconfig option improves the reliability of the firmware.
+  * The default value of the newly introduced :kconfig:option:`CONFIG_BT_ADV_PROV_DEVICE_NAME_PAIRING_MODE_ONLY` Kconfig option.
+    The option is disabled by default by the nRF Desktop application.
+    The Bluetooth device name is provided in the scan response also outside of pairing mode for backwards compatibility.
 
 * Added the :ref:`CONFIG_DESKTOP_HID_STATE_SUBSCRIBER_COUNT <config_desktop_app_options>` Kconfig option to the :ref:`nrf_desktop_hid_state`.
   The option allows to configure a maximum number of simultaneously supported HID data subscribers.

--- a/subsys/bluetooth/adv_prov/providers/Kconfig.device_name
+++ b/subsys/bluetooth/adv_prov/providers/Kconfig.device_name
@@ -7,9 +7,16 @@
 menuconfig BT_ADV_PROV_DEVICE_NAME
 	bool "Bluetooth device name"
 	help
-	  Adds Bluetooth device name to scan response data.
+	  Adds Bluetooth device name to scan response data or advertising data.
 
 if BT_ADV_PROV_DEVICE_NAME
+
+config BT_ADV_PROV_DEVICE_NAME_PAIRING_MODE_ONLY
+	bool "Provide device name only in pairing mode"
+	default y
+	help
+	  If the option is enabled, the Bluetooth device name is not provided
+	  outside of pairing mode.
 
 config BT_ADV_PROV_DEVICE_NAME_SD
 	bool "Move device name to scan response"

--- a/subsys/bluetooth/adv_prov/providers/device_name.c
+++ b/subsys/bluetooth/adv_prov/providers/device_name.c
@@ -13,8 +13,12 @@
 static int get_data(struct bt_data *d, const struct bt_le_adv_prov_adv_state *state,
 		    struct bt_le_adv_prov_feedback *fb)
 {
-	ARG_UNUSED(state);
 	ARG_UNUSED(fb);
+
+	if (IS_ENABLED(CONFIG_BT_ADV_PROV_DEVICE_NAME_PAIRING_MODE_ONLY) &&
+	    !state->pairing_mode) {
+		return -ENOENT;
+	}
 
 	const char *name = bt_get_name();
 


### PR DESCRIPTION
Change updates device name provider to, by default, provide data only if advertising in pairing mode. Introduced a new Kconfig option that allows to keep old behavior (always providing device name).

Jira: NCSDK-25593