### PR TITLE
manifest: zephyr: hotfix for hci_ipc (nRF53)

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 962eb7320fdb76ffe265d8bab7330ad472cb6f28
+      revision: pull/1486/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Updates Zephyr with a fix for nRF53 faulting when calling
`bt_disable()`.
