### PR TITLE
manifest: update zephyr to fix UBSAN warnings

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: d2d7e710544d094bf45d480b209d91a1134502f1
+      revision: e9bb83320a4cd303135203fae18136a71e87f26e
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
brings a new revision of Zephyr with several
UBSAN warnings fixed in Bluetooth Host
and new hw models for babblesim with UBSAN
warnings fixed and other improvements