### PR TITLE
manifest: update zephyr to update bsim hw models

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 2a88dad0458cf2fd4f9f62ffe3c464fbd6db9919
+      revision: pull/1484/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
brings a new revision of Zephyr with
new revision of babblesim hw models
with several UBSAN warnings fixed