### PR TITLE
manifest: sdk-zephyr: Fix print of ssid overflow

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 352bf882873d9666c88d693296ce778ff1aa44ec
+      revision: pull/1487/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
WIFI scan result shows junk character in SSID because of buffer overflow. Fix the print of ssid in wifi scan.