### PR TITLE
samples: net: azure_iot_hub: Reword log messages for device twin

### DIFF
--- a/samples/net/azure_iot_hub/src/main.c
+++ b/samples/net/azure_iot_hub/src/main.c
@@ -91,6 +91,8 @@ static int event_interval_get(char *buf)
 	 */
 	desired_obj = cJSON_GetObjectItem(root_obj, "desired");
 	if (desired_obj == NULL) {
+		LOG_DBG("Incoming device twin document contains only the 'desired' object");
+
 		desired_obj = root_obj;
 	}
 
@@ -98,7 +100,8 @@ static int event_interval_get(char *buf)
 	event_interval_obj = cJSON_GetObjectItem(desired_obj,
 						 "telemetryInterval");
 	if (event_interval_obj == NULL) {
-		LOG_INF("No 'telemetryInterval' object in the device twin");
+		LOG_DBG("No 'telemetryInterval' object found in the device twin document");
+
 		goto clean_exit;
 	}
 


### PR DESCRIPTION
* Reduce log level to DBG for the message logged when a `telemetryInterval` object is not found in the incoming device twin document. This is a common occurrence and the log message is confusing when for instance receiveing FOTA metadata.

* Add DBG level log message for when the incoming device twin document contains only a `desired` object.