### PR TITLE
samples: matter: Fix memory leak in Window Covering

### DIFF
--- a/samples/matter/window_covering/src/window_covering.cpp
+++ b/samples/matter/window_covering/src/window_covering.cpp
@@ -287,4 +287,6 @@ void WindowCovering::DoPostAttributeChange(intptr_t aArg)
 	VerifyOrReturn(data != nullptr);
 
 	PostAttributeChange(data->mEndpoint, data->mAttributeId);
+
+	chip::Platform::Delete(data);
 }


### PR DESCRIPTION
We were leaking 8 bytes each time the new attribute change was reported by the WindowCovering Server. It was resulting in running out of heap when stressing the device (by sending multiple up-or-open/down-or-close commands).

More specifically the `ChipCertificateSet::Init()` was failing to allocate the ~1k certificate buffer during CASE session
establishment after ~8 up-or-open/down-or-close sequences having been sent before.