### PR TITLE
manifest: sdk-zephyr: update hal_nordic to restore APPROTECT on nRF91

### DIFF
--- a/scripts/quarantine_zephyr.yaml
+++ b/scripts/quarantine_zephyr.yaml
@@ -93,20 +93,35 @@
   comment: "Fixed with https://github.com/zephyrproject-rtos/zephyr/pull/68463"
 
 - scenarios:
-    - examples.nrfx_gppi.fork
-    - examples.nrfx_gppi.one_to_one
-    - examples.nrfx_saadc.simple_blocking
-    - examples.nrfx_saadc.simple_non_blocking
-    - examples.nrfx_saadc.advanced_blocking
-    - examples.nrfx_saadc.advanced_non_blocking_internal_timer
+    - examples.nrfx_uarte.tx_rx_non_blocking
+  platforms:
+    - nrf9160dk_nrf9160
+    - nrf52840dk_nrf52840
+  comment: "https://nordicsemi.atlassian.net/browse/NRFX-3395"
+
+- scenarios:
+    - examples.nrfx_uarte.rx_double_buffered
+  platforms:
+    - nrf52840dk_nrf52840
+    - nrf9160dk_nrf9160
+    - nrf5340dk_nrf5340_cpuapp
+    - nrf52833dk_nrf52833
+  comment: "https://nordicsemi.atlassian.net/browse/NRFX-3468"
+
+- scenarios:
+    - examples.nrfx_uarte.tx_rx_non_blocking
+  platforms:
+    - nrf5340dk_nrf5340_cpuapp
+    - nrf52833dk_nrf52833
+  comment: "https://nordicsemi.atlassian.net/browse/NRFX-3468"
+
+- scenarios:
     - examples.nrfx_saadc.maximum_performance
   platforms:
-    - nrf52dk_nrf52832
-    - nrf52833dk_nrf52833
     - nrf52840dk_nrf52840
-    - nrf5340dk_nrf5340_cpuapp
+    - nrf52833dk_nrf52833
     - nrf9160dk_nrf9160
-  comment: "nrfx samples alignment to nrfx 3.2 - https://nordicsemi.atlassian.net/browse/NRFX-5188"
+  comment: "https://nordicsemi.atlassian.net/browse/NRFX-3813"
 
 # ---------------------------------   Won't fix section -----------------------------------
 

--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: acb2e8c364292eeda394760fb470e24537d033c3
+      revision: 258a846cfb5d1cb8100d19dc67653c37b451033d
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Updated hal_nordic restores APPROTECT handling on nRF91 target. Align nrfx samples to the updated GPIOTE API on the occasion.