### PR TITLE
quarantine: Add native_sim to quarantine for Windows

### DIFF
--- a/scripts/quarantine_windows_mac.yaml
+++ b/scripts/quarantine_windows_mac.yaml
@@ -9,6 +9,7 @@
 
 - platforms:
     - native_posix
+    - native_sim
     - qemu_cortex_m3
     - qemu_x86
   comment: "Cannot build samples for Native POSIX and QEMU on Windows OS"


### PR DESCRIPTION
Native_sim is an enhanced implementation of native_posix and is not available on Windows, causing several tests to fail, instead of being skipped.