### PR TITLE
mpsl: align to changed nrfx_gpiote driver API

### DIFF
--- a/subsys/mpsl/fem/simple_gpio/mpsl_fem_simple_gpio.c
+++ b/subsys/mpsl/fem/simple_gpio/mpsl_fem_simple_gpio.c
@@ -8,6 +8,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <string.h>
 #include <zephyr/sys/__assert.h>
+#include <soc_nrf_common.h>
 
 #if !defined(CONFIG_MPSL_FEM_PIN_FORWARDER)
 #include <mpsl_fem_config_simple_gpio.h>
@@ -30,16 +31,20 @@ static int fem_simple_gpio_configure(void)
 
 #if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), ctx_gpios)
 	uint8_t ctx_gpiote_channel;
+	const nrfx_gpiote_t ctx_gpiote = NRFX_GPIOTE_INSTANCE(
+		NRF_DT_GPIOTE_INST(DT_NODELABEL(nrf_radio_fem), ctx_gpios));
 
-	if (nrfx_gpiote_channel_alloc(&ctx_gpiote_channel) != NRFX_SUCCESS) {
+	if (nrfx_gpiote_channel_alloc(&ctx_gpiote, &ctx_gpiote_channel) != NRFX_SUCCESS) {
 		return -ENOMEM;
 	}
 #endif
 
 #if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), crx_gpios)
 	uint8_t crx_gpiote_channel;
+	const nrfx_gpiote_t crx_gpiote = NRFX_GPIOTE_INSTANCE(
+		NRF_DT_GPIOTE_INST(DT_NODELABEL(nrf_radio_fem), crx_gpios));
 
-	if (nrfx_gpiote_channel_alloc(&crx_gpiote_channel) != NRFX_SUCCESS) {
+	if (nrfx_gpiote_channel_alloc(&crx_gpiote, &crx_gpiote_channel) != NRFX_SUCCESS) {
 		return -ENOMEM;
 	}
 #endif


### PR DESCRIPTION
`nrfx_gpiote_*` functions must now be called now with a pointer to a specific GPIOTE instance. This commit aligns MPSL FEM simple gpio implementation that was missed earlier.