### PR TITLE
scripts: upgrade cmake version to 3.21.0

### DIFF
--- a/scripts/tools-versions-darwin.yml
+++ b/scripts/tools-versions-darwin.yml
@@ -3,7 +3,7 @@ python:
 git:
   version: 2.37.3
 cmake:
-  version: 3.20.5
+  version: 3.21.0
 ninja:
   version: 1.10.2
 gperf:

--- a/scripts/tools-versions-linux.yml
+++ b/scripts/tools-versions-linux.yml
@@ -3,7 +3,7 @@ python:
 git:
   version: 2.37.3
 cmake:
-  version: 3.20.6
+  version: 3.21.0
 ninja:
   version: 1.10.2
 gperf:

--- a/scripts/tools-versions-win10.yml
+++ b/scripts/tools-versions-win10.yml
@@ -3,7 +3,7 @@ python:
 git:
   version: 2.37.3.windows.1
 cmake:
-  version: 3.20.6
+  version: 3.21.0
 ninja:
   version: 1.10.2
 gperf:


### PR DESCRIPTION
Currently used 3.20.6 cmake version does not allow for applying cmake policies necessary for armclang compiler