### PR TITLE
manifest: update nrfxlib revision with test spec update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -142,7 +142,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: e90ca54b7a593a747dcad8050ca5bba35b6f1592
+      revision: 67ffc12f54a0d8bea680296f52ae8d33588f779e
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Few CIs are removed from mpsl&sdc test scope, due to the fact that many ble scenarios are already covered in ble CI