### PR TITLE
Enable UART runtime configuration

### DIFF
--- a/lib/nrf_modem_lib/trace_backends/uart/Kconfig
+++ b/lib/nrf_modem_lib/trace_backends/uart/Kconfig
@@ -35,6 +35,7 @@ config NRF_MODEM_LIB_TRACE_BACKEND_UART_ZEPHYR
 	bool "UART"
 	depends on SERIAL
 	depends on UART_ASYNC_API
+	select UART_USE_RUNTIME_CONFIGURE
 	help
 	  Modem tracing with UART require the chosen `nordic,modem-trace-uart`
 	  to be set in the Device tree.

--- a/samples/cellular/modem_shell/prj.conf
+++ b/samples/cellular/modem_shell/prj.conf
@@ -56,6 +56,9 @@ CONFIG_DEVMEM_SHELL=n
 # Device power management
 CONFIG_PM_DEVICE=y
 
+# Needed for changing the UART baudrate at runtime
+CONFIG_UART_USE_RUNTIME_CONFIGURE=y
+
 # Modem info
 CONFIG_MODEM_INFO=y
 


### PR DESCRIPTION
The default value for `CONFIG_UART_USE_RUNTIME_CONFIGURE` has been changed, so it needs to be explicitly enabled for those who need `uart_config_get()`.