### PR TITLE
samples: openthread: enable rebooting to bootloader for nRF52 Dongle

### DIFF
--- a/samples/openthread/cli/README.rst
+++ b/samples/openthread/cli/README.rst
@@ -64,20 +64,21 @@ See `Testing diagnostic module`_ section for an example.
 .. note::
     If you disable the :kconfig:option:`CONFIG_OPENTHREAD_NORDIC_LIBRARY_MASTER` feature set, you can enable the diagnostic module with the :kconfig:option:`CONFIG_OPENTHREAD_DIAG` Kconfig option.
 
-For the ``nrf52840dongle_nrf52840`` build target, diagnostic GPIO commands can also be used.
-They are enabled in the ``openthread_config`` node in the :file:`boards/nrf52840dongle_nrf52840.overlay` file, with the node configured for the **P0.19** pin, which is connected to the **RESET** pin on the nRF52840 Dongle.
-The pin is set in output mode with a low state so that the **RESET** pin is pulled to **GND**, which results in the device rebooting without skipping the bootloader.
+.. _ot_cli_sample_bootloader:
+
+Rebooting to bootloader
+=======================
+
+For the ``nrf52840dongle_nrf52840`` build target, the device can reboot to bootloader by triggering a GPIO pin.
+To enable this behavior, enable the :kconfig:option:`CONFIG_OPENTHREAD_PLATFORM_BOOTLOADER_MODE_GPIO` Kconfig option and configure the Devicetree overlay in the :file:`boards/nrf52840dongle_nrf52840.overlay` file.
+For this sample, the ``bootloader-gpios`` property in the ``openthread_config`` node is pre-configured for the **P0.19** pin, which is connected to the **RESET** pin on the nRF52840 Dongle.
 This functionality is not enabled by other commands, such as ``factoryreset``, as they can only trigger a software reset, skipping the bootloader.
 
-To reboot to the bootloader, run the following commands on the device:
+To reboot to the bootloader, run the following command on the device:
 
 .. code-block:: console
 
-   uart:~$ ot diag start
-   start diagnostics mode
-   status 0x00
-   Done
-   uart:~$ ot diag gpio mode 0 out
+   uart:~$ ot reset bootloader
 
 Configuration
 *************
@@ -122,7 +123,7 @@ Serial transport
 
 The Thread CLI sample supports UART and USB CDC ACM as serial transports.
 By default, it uses USB CDC ACM transport for ``nrf52840dongle_nrf52840``, and UART transport for other build targets.
-To switch to USB transport on targets that use UART by default, :ref:`activate the USB overlay extension <ot_cli_sample_activating_variants>`.
+To switch to USB transport on targets that use UART by default, :ref:`activate the USB snippet <ot_cli_sample_activating_variants>`.
 
 Building and running
 ********************

--- a/samples/openthread/cli/boards/nrf52840dongle_nrf52840.conf
+++ b/samples/openthread/cli/boards/nrf52840dongle_nrf52840.conf
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Nordic Semiconductor
+# Copyright (c) 2024 Nordic Semiconductor
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
@@ -12,3 +12,6 @@ CONFIG_USB_DEVICE_MANUFACTURER="Nordic Semiconductor ASA"
 CONFIG_USB_DEVICE_PRODUCT="Thread CLI"
 CONFIG_USB_DEVICE_VID=0x1915
 CONFIG_USB_DEVICE_PID=0x0000
+
+# Enable resetting to Bootloader using GPIO
+CONFIG_OPENTHREAD_PLATFORM_BOOTLOADER_MODE_GPIO=y

--- a/samples/openthread/cli/boards/nrf52840dongle_nrf52840.overlay
+++ b/samples/openthread/cli/boards/nrf52840dongle_nrf52840.overlay
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021 Nordic Semiconductor ASA
+/* Copyright (c) 2024 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
@@ -21,12 +21,12 @@
 
 	/*
 	 * nRF52840 dongle has pin P0.19 connected to reset. By setting it
-	 * in output mode with low state reset is pulled to GND, which results in
-	 * device rebooting without skipping the bootloader.
-	 * openthread_config node enables doing so using diag GPIO commands.
+	 * in `GPIO_OUTPUT_ACTIVE` mode, reset is pulled to GND,
+	 * which results in device rebooting without skipping the bootloader.
+	 * openthread_config node enables doing so using `ot reset bootloader` command.
 	 */
 	openthread_config: openthread {
 		compatible = "openthread,config";
-		diag-gpios = <&gpio0 19 GPIO_ACTIVE_HIGH>;
+		bootloader-gpios = <&gpio0 19 GPIO_ACTIVE_LOW>;
 	};
 };

--- a/samples/openthread/coprocessor/README.rst
+++ b/samples/openthread/coprocessor/README.rst
@@ -78,6 +78,13 @@ Diagnostic module
 The Co-processor sample enables a diagnostic module in a similar way as described in the :ref:`ot_cli_sample_diag_module` section of the :ref:`ot_cli_sample` sample documentation.
 However, the Co-processor and CLI samples use different commands for the module, as described in the :ref:`ot_coprocessor_testing` section.
 
+Rebooting to bootloader
+=======================
+
+The Co-processor sample enables rebooting to bootloader for the ``nrf52840dongle_nrf52840`` build target, similar to what is described in the :ref:`ot_cli_sample_bootloader` section of the :ref:`ot_cli_sample` sample documentation.
+However, the Co-processor and CLI samples use different commands, as described in the :ref:`ot_coprocessor_testing` section.
+Additionally, the :ref:`ug_thread_tools_ot_apps` should be built with ``-DOT_PLATFORM_BOOTLOADER_MODE=ON`` option.
+
 Configuration
 *************
 

--- a/samples/openthread/coprocessor/boards/nrf52840dongle_nrf52840.conf
+++ b/samples/openthread/coprocessor/boards/nrf52840dongle_nrf52840.conf
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Nordic Semiconductor
+# Copyright (c) 2024 Nordic Semiconductor
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
@@ -10,3 +10,6 @@ CONFIG_USB_DEVICE_VID=0x1915
 CONFIG_USB_DEVICE_PID=0x0000
 
 CONFIG_UART_LINE_CTRL=y
+
+# Enable resetting to Bootloader using GPIO
+CONFIG_OPENTHREAD_PLATFORM_BOOTLOADER_MODE_GPIO=y

--- a/samples/openthread/coprocessor/boards/nrf52840dongle_nrf52840.overlay
+++ b/samples/openthread/coprocessor/boards/nrf52840dongle_nrf52840.overlay
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023 Nordic Semiconductor ASA
+/* Copyright (c) 2024 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
@@ -6,13 +6,13 @@
 / {
 	/*
 	 * nRF52840 dongle has pin P0.19 connected to reset. By setting it
-	 * in output mode with low state reset is pulled to GND, which results in
-	 * device rebooting without skipping the bootloader.
-	 * openthread_config node enables doing so using diag GPIO commands.
+	 * in `GPIO_OUTPUT_ACTIVE` mode, reset is pulled to GND,
+	 * which results in device rebooting without skipping the bootloader.
+	 * openthread_config node enables doing so using `reset bootloader` command.
 	 */
 	openthread_config: openthread {
 		compatible = "openthread,config";
-		diag-gpios = <&gpio0 19 GPIO_ACTIVE_HIGH>;
+		bootloader-gpios = <&gpio0 19 GPIO_ACTIVE_LOW>;
 	};
 
 	chosen {


### PR DESCRIPTION
enable rebooting to bootloader for nRF52 Dongle with `ot reset bootloader` command triggering GPIO pin.