### PR TITLE
applications: matter: Add Bluetooth LE state indications

### DIFF
--- a/applications/matter_bridge/doc/matter_bridge_description.rst
+++ b/applications/matter_bridge/doc/matter_bridge_description.rst
@@ -156,6 +156,20 @@ Button 1:
       Releasing the button within a 3-second window of the initiation cancels the factory reset procedure.
 
 .. include:: ../../../samples/matter/lock/README.rst
+    :start-after: matter_door_lock_sample_led1_start
+    :end-before: matter_door_lock_sample_led1_end
+
+LED 2:
+   If the :kconfig:option:`CONFIG_BRIDGED_DEVICE_BT` kconfig option is set to ``y``, shows the current state of Bridge's Bluetooth LE connectivity.
+   The following states are possible:
+
+   * Turned Off - The Bridge device is in the idle state and has no Bluetooth LE devices paired.
+   * Solid On - The Bridge device is in the idle state and all connections to the Bluetooth LE bridged devices are stable.
+   * Slow Even Flashing (1000 ms on / 1000 ms off) - The Bridge device lost connection to at least one Bluetooth LE bridged device.
+   * Even Flashing (300 ms on / 300 ms off) - The scan for Bluetooth LE devices is in progress.
+   * Fast Even Flashing (100 ms on / 100 ms off) - The Bridge device is connecting to the Bluetooth LE device and waiting for the Bluetooth LE authentication PIN code.
+
+.. include:: ../../../samples/matter/lock/README.rst
     :start-after: matter_door_lock_sample_jlink_start
     :end-before: matter_door_lock_sample_jlink_end
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -326,6 +326,8 @@ Matter Bridge
   * Support for bindings to the On/Off Light Switch device implementation.
   * Guide about extending the application by adding support for a new Matter device type, a new Bluetooth LE service or a new protocol.
   * Support for Bluetooth LE Security Manager Protocol that allows to establish secure session with bridged Bluetooth LE devices.
+  * Callback to indicate the current state of Bluetooth LE Connectivity Manager.
+    The current state is shown by LED 2.
 
 Samples
 =======

--- a/samples/matter/common/src/board/board.cpp
+++ b/samples/matter/common/src/board/board.cpp
@@ -290,7 +290,7 @@ void Board::StartBLEAdvertisement()
 
 void Board::DefaultMatterEventHandler(const ChipDeviceEvent *event, intptr_t /* unused */)
 {
-	bool isNetworkProvisioned = false;
+	static bool isNetworkProvisioned = false;
 
 	switch (event->Type) {
 	case DeviceEventType::kCHIPoBLEAdvertisingChange:


### PR DESCRIPTION
- BLE connectivity manager now supports registering callbacks for state change. The callback can be defined in the application to indicate the current state using for example LEDs, LCDs, etc.

- There are several states defined:
	- Idle
	- Scanning
	- Pairing
	- LostDevice

- Implemented Indication for Bridge sample utilizing LED 2 located on the nRF7002DK board.