### PR TITLE
sample: wifi: Fix softap sample name

### DIFF
--- a/samples/wifi/softap/sample.yaml
+++ b/samples/wifi/softap/sample.yaml
@@ -9,7 +9,7 @@ tests:
       - nrf7002dk_nrf5340_cpuapp
     platform_allow: nrf7002dk_nrf5340_cpuapp
     tags: ci_build
-  sample.nrf7002_eks.sta:
+  sample.nrf7002_eks.softap:
     build_only: true
     extra_args: SHIELD=nrf7002ek
     integration_platforms:


### PR DESCRIPTION
The changed name looks like a copy-paste error from the sta sample and was causing errors due to name duplication