### PR TITLE
Bluetooth: mesh: samples: add support for nRF52840 dongle

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -402,6 +402,24 @@ Bluetooth Mesh samples
     * An issue where the shell interface was not accessible over UART because UART was used as a transport for MCUmgr SMP protocol.
       Shell is now accessible over RTT.
 
+* :ref:`ble_mesh_dfu_target` sample:
+
+  * Added:
+
+    * Support for the :ref:`zephyr:nrf52840dongle_nrf52840`.
+
+* :ref:`bluetooth_mesh_light_dim` sample:
+
+  * Added:
+
+    * Support for the :ref:`zephyr:nrf52840dongle_nrf52840`.
+
+* :ref:`bluetooth_mesh_light_lc` sample:
+
+  * Added:
+
+    * Support for the :ref:`zephyr:nrf52840dongle_nrf52840`.
+
 Cellular samples
 ----------------
 

--- a/samples/bluetooth/mesh/dfu/target/README.rst
+++ b/samples/bluetooth/mesh/dfu/target/README.rst
@@ -101,7 +101,8 @@ Building and running
 Testing
 =======
 
-This sample has been tested with the nRF52840 DK (nrf52840dk_nrf52840) board.
+After programming the sample to your development kit, you can test it by using a smartphone with `nRF Mesh mobile app`_ installed.
+Testing consists of provisioning the device and configuring it for communication with the mesh models, then performing a Device Firmware Update.
 
 .. _ble_mesh_dfu_target_provisioning:
 
@@ -166,8 +167,11 @@ Only 2 options are supported by this sample:
    In this case, the device unprovisions itself before programming the new firmware.
    The unprovisioning happens before the device reboots, so if the MCUboot fails to validate the new firmware, the device will boot unprovisioned anyway.
 
-In this sample, the device flash is split into fixed partitions using devicetree as defined in :zephyr_file:`nrf52840dk_nrf52840.dts<boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts>`.
-When the DFU transfer starts, the sample stores the new firmware at slot-1 using :ref:`zephyr:flash_map_api`.
+In this sample, the device flash is split into partitions using the :ref:`partition_manager`.
+When the DFU transfer starts, the sample stores the new firmware at the MCUboot secondary slot using the :ref:`zephyr:flash_map_api`.
+
+.. note::
+   For the :ref:`zephyr:nrf52840dongle_nrf52840`, the sample has a static partition management file :file:`pm_static_nrf52840dongle_nrf52840.yml` to reserve the space for the `nRF5 SDK Bootloader`_.
 
 When the DFU transfer ends, the sample requests the MCUboot to replace slot-0 with slot-1 and reboots the device.
 The MCUboot performs the validation of the image located at slot-1.
@@ -185,6 +189,9 @@ Logging
 =======
 
 In this sample, UART and SEGGER RTT are available as logging backends.
+
+.. note::
+   With the :ref:`zephyr:nrf52840dongle_nrf52840`, only logging over UART is available.
 
 Dependencies
 ************

--- a/samples/bluetooth/mesh/dfu/target/pm_static_nrf52840dongle_nrf52840.yml
+++ b/samples/bluetooth/mesh/dfu/target/pm_static_nrf52840dongle_nrf52840.yml
@@ -1,0 +1,95 @@
+# For samples using the MCUboot secure bootloader ONLY.
+
+app:
+  address: 0x1000
+  end_address: 0xDD000
+  region: flash_primary
+  size: 0xD7000
+
+nrf5_mbr:
+  address: 0x0
+  end_address: 0x1000
+  placement:
+    after:
+    - start
+  region: flash_primary
+  size: 0x1000
+
+mcuboot:
+  address: 0x1000
+  end_address: 0x11000
+  placement:
+    before:
+    - mcuboot_primary
+  region: flash_primary
+  size: 0x10000
+mcuboot_pad:
+  address: 0x11000
+  end_address: 0x11200
+  placement:
+    align:
+      start: 0x1000
+    before:
+    - mcuboot_primary_app
+  region: flash_primary
+  size: 0x200
+
+mcuboot_primary:
+  address: 0x11000
+  end_address: 0x77000
+  orig_span: &id001
+  - mcuboot_pad
+  - app
+  region: flash_primary
+  sharers: 0x1
+  size: 0x66000
+  span: *id001
+mcuboot_primary_app:
+  address: 0x11200
+  end_address: 0x77000
+  orig_span: &id002
+  - app
+  region: flash_primary
+  size: 0x65e00
+  span: *id002
+
+mcuboot_secondary:
+  address: 0x77000
+  end_address: 0xDD000
+  placement:
+    after:
+    - mcuboot_primary
+    align:
+      start: 0x1000
+  region: flash_primary
+  share_size:
+  - mcuboot_primary
+  size: 0x66000
+
+settings_storage:
+  address: 0xDD000
+  end_address: 0xE0000
+  placement:
+    align:
+      start: 0x1000
+    before:
+    - end
+  region: flash_primary
+  size: 0x3000
+
+legacy_bootloader_storage:
+  address: 0xE0000
+  end_address: 0x100000
+  placement:
+    align:
+      start: 0x1000
+    before:
+    - end
+  region: flash_primary
+  size: 0x20000
+
+sram_primary:
+  address: 0x20000000
+  end_address: 0x20040000
+  region: sram_primary
+  size: 0x40000

--- a/samples/bluetooth/mesh/dfu/target/sample.yaml
+++ b/samples/bluetooth/mesh/dfu/target/sample.yaml
@@ -5,5 +5,6 @@ tests:
     build_only: true
     integration_platforms:
       - nrf52840dk_nrf52840
-    platform_allow: nrf52840dk_nrf52840
+      - nrf52840dongle_nrf52840
+    platform_allow: nrf52840dk_nrf52840 nrf52840dongle_nrf52840
     tags: bluetooth ci_build

--- a/samples/bluetooth/mesh/light_ctrl/README.rst
+++ b/samples/bluetooth/mesh/light_ctrl/README.rst
@@ -143,6 +143,9 @@ LEDs:
    :ref:`zephyr:thingy53_nrf5340` supports only one RGB LED.
    Each RGB LED channel is used as separate LED.
 
+.. note::
+   :ref:`zephyr:thingy53_nrf5340` and the :ref:`zephyr:nrf52840dongle_nrf52840` do not support emergency data storage.
+
 Configuration
 *************
 

--- a/samples/bluetooth/mesh/light_ctrl/pm_static_nrf52840dongle_nrf52840.yml
+++ b/samples/bluetooth/mesh/light_ctrl/pm_static_nrf52840dongle_nrf52840.yml
@@ -1,0 +1,40 @@
+# For samples using the build-in Nordic bootloader ONLY.
+
+app:
+  address: 0x1000
+  end_address: 0xD8000
+  region: flash_primary
+  size: 0xD7000
+nrf5_mbr:
+  address: 0x0
+  end_address: 0x1000
+  placement:
+    after:
+    - start
+  region: flash_primary
+  size: 0x1000
+settings_storage:
+  address: 0xD8000
+  end_address: 0xE0000
+  placement:
+    align:
+      start: 0x1000
+    before:
+    - end
+  region: flash_primary
+  size: 0x8000
+legacy_bootloader_storage:
+  address: 0xE0000
+  end_address: 0x100000
+  placement:
+    align:
+      start: 0x1000
+    before:
+    - end
+  region: flash_primary
+  size: 0x20000
+sram_primary:
+  address: 0x20000000
+  end_address: 0x20040000
+  region: sram_primary
+  size: 0x40000

--- a/samples/bluetooth/mesh/light_ctrl/sample.yaml
+++ b/samples/bluetooth/mesh/light_ctrl/sample.yaml
@@ -12,9 +12,10 @@ tests:
       - nrf5340dk_nrf5340_cpuapp_ns
       - thingy53_nrf5340_cpuapp
       - nrf21540dk_nrf52840
+      - nrf52840dongle_nrf52840
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
       nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp
-      nrf21540dk_nrf52840 nrf52833dk_nrf52833
+      nrf21540dk_nrf52840 nrf52833dk_nrf52833 nrf52840dongle_nrf52840
     tags: bluetooth ci_build
   sample.bluetooth.mesh.light_ctrl.emds:
     extra_args: OVERLAY_CONFIG="overlay-emds.conf"

--- a/samples/bluetooth/mesh/light_dimmer/README.rst
+++ b/samples/bluetooth/mesh/light_dimmer/README.rst
@@ -54,8 +54,8 @@ This mobile application is also used to configure key bindings, and publication 
 After provisioning and configuring the mesh models supported by the sample in the `nRF Mesh mobile app`_, **Button 1** on the Mesh Light Dimmer device can be used to control the configured network nodes' LEDs, while **Button 2** can be used to store and restore scenes on the network nodes.
 
 .. note::
-  When running this sample on a Thingy:53, the scene selection functionality will not be available as the device only has one button.
-  The Thingy:53's single button will have the dimming and on/off functionality as described for **Button 1** in this documentation.
+  When running this sample on Thingy:53 or the :ref:`zephyr:nrf52840dongle_nrf52840`, the scene selection functionality will not be available as the device only has one button.
+  The single button of Thingy:53 and the dongle will be used for dimming and the on/off functionality as described for **Button 1** in this documentation.
 
 Provisioning
 ============
@@ -115,6 +115,9 @@ Button 2:
    Each press of the button will recall the next scene, meaning, the first press will recall scene 2, the next press will recall scene 3, and so on, before wrapping around back to scene 1.
 
    On long press and release, **Button 2** will publish a Scene Store message using the configured publication parameters of its model instance, and store the current LED state of all the targets under the scene with the most recently recalled scene number.
+
+.. note::
+   :ref:`zephyr:thingy53_nrf5340` and the :ref:`zephyr:nrf52840dongle_nrf52840` only support dimming and the on/off functionality, not the scene selection functionality.
 
 LEDs:
    Show the OOB authentication value during provisioning if the "Push button" OOB method is used.

--- a/samples/bluetooth/mesh/light_dimmer/pm_static_nrf52840dongle_nrf52840.yml
+++ b/samples/bluetooth/mesh/light_dimmer/pm_static_nrf52840dongle_nrf52840.yml
@@ -1,0 +1,40 @@
+# For samples using the build-in Nordic bootloader ONLY.
+
+app:
+  address: 0x1000
+  end_address: 0xD8000
+  region: flash_primary
+  size: 0xD7000
+nrf5_mbr:
+  address: 0x0
+  end_address: 0x1000
+  placement:
+    after:
+    - start
+  region: flash_primary
+  size: 0x1000
+settings_storage:
+  address: 0xD8000
+  end_address: 0xE0000
+  placement:
+    align:
+      start: 0x1000
+    before:
+    - end
+  region: flash_primary
+  size: 0x8000
+legacy_bootloader_storage:
+  address: 0xE0000
+  end_address: 0x100000
+  placement:
+    align:
+      start: 0x1000
+    before:
+    - end
+  region: flash_primary
+  size: 0x20000
+sram_primary:
+  address: 0x20000000
+  end_address: 0x20040000
+  region: sram_primary
+  size: 0x40000

--- a/samples/bluetooth/mesh/light_dimmer/sample.yaml
+++ b/samples/bluetooth/mesh/light_dimmer/sample.yaml
@@ -12,7 +12,8 @@ tests:
       - nrf5340dk_nrf5340_cpuapp_ns
       - thingy53_nrf5340_cpuapp
       - nrf21540dk_nrf52840
+      - nrf52840dongle_nrf52840
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
       nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp
-      nrf21540dk_nrf52840 nrf52833dk_nrf52833
+      nrf21540dk_nrf52840 nrf52833dk_nrf52833 nrf52840dongle_nrf52840
     tags: bluetooth ci_build

--- a/scripts/bluetooth/mesh/mesh_dfu_metadata.py
+++ b/scripts/bluetooth/mesh/mesh_dfu_metadata.py
@@ -357,7 +357,7 @@ def parse_comp_data(elf_path, kconfigs):
         raise Exception("Failed to extract composition data from .elf file") from err
 
 def encoded_metadata_get(version, comp, binary_size):
-    core_type = 0 # FIX ME: For now, hardcoded to application core
+    core_type = 1 # FIX ME: For now, hardcoded to application core
     elem_cnt = len(comp.elems)
 
     bytestring = bytearray()


### PR DESCRIPTION
* Added dongle support for:
  * Light Dimmer and Light Fixture samples
  * DFU target sample
* Fixed hardcoded core type in mesh_dfu_metadata.py
* Updated docs