### PR TITLE
shields: wifi: Modify default SPI clock frequency

### DIFF
--- a/boards/shields/nrf7002ek/nrf7002ek.overlay
+++ b/boards/shields/nrf7002ek/nrf7002ek.overlay
@@ -12,7 +12,7 @@
 		compatible = "nordic,nrf700x-spi";
 		status = "okay";
 		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(8)>;
+		spi-max-frequency = <DT_FREQ_M(16)>;
 
 		iovdd-ctrl-gpios = <&arduino_header 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;    /* D0 */
 		bucken-gpios = <&arduino_header 7 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;        /* D1 */

--- a/boards/shields/nrf7002ek_nrf7000/nrf7002ek_nrf7000.overlay
+++ b/boards/shields/nrf7002ek_nrf7000/nrf7002ek_nrf7000.overlay
@@ -12,7 +12,7 @@
 		compatible = "nordic,nrf700x-spi";
 		status = "okay";
 		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(8)>;
+		spi-max-frequency = <DT_FREQ_M(16)>;
 
 		iovdd-ctrl-gpios = <&arduino_header 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;    /* D0 */
 		bucken-gpios = <&arduino_header 7 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;        /* D1 */

--- a/boards/shields/nrf7002ek_nrf7001/nrf7002ek_nrf7001.overlay
+++ b/boards/shields/nrf7002ek_nrf7001/nrf7002ek_nrf7001.overlay
@@ -12,7 +12,7 @@
 		compatible = "nordic,nrf700x-spi";
 		status = "okay";
 		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(8)>;
+		spi-max-frequency = <DT_FREQ_M(16)>;
 
 		iovdd-ctrl-gpios = <&arduino_header 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;    /* D0 */
 		bucken-gpios = <&arduino_header 7 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;        /* D1 */


### PR DESCRIPTION
Make the default SPI clock frequency as 16MHz on all nRF7002 EK shields