### PR TITLE
applications: nrf5340_audio: Move bitrate calculation into le_audio

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/broadcast_sink.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/broadcast_sink.c
@@ -178,8 +178,11 @@ static void get_codec_info(const struct bt_audio_codec_cfg *codec,
 			return;
 		}
 
-		codec_info->bitrate =
-			(codec_info->octets_per_sdu * 8 * 1000000) / codec_info->frame_duration_us;
+		ret = le_audio_bitrate_get(codec, &codec_info->bitrate);
+		if (ret) {
+			LOG_ERR("Error calculating bitrate: %d", ret);
+			return;
+		}
 
 		ret = le_audio_frame_blocks_per_sdu_get(codec, &codec_info->blocks_per_sdu);
 		if (codec_info->octets_per_sdu < 0) {

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.c
@@ -109,6 +109,31 @@ int le_audio_frame_blocks_per_sdu_get(const struct bt_audio_codec_cfg *codec,
 	return 0;
 }
 
+int le_audio_bitrate_get(const struct bt_audio_codec_cfg *const codec, uint32_t *bitrate)
+{
+	int ret;
+	int dur_us;
+
+	ret = le_audio_duration_us_get(codec, &dur_us);
+	if (ret) {
+		*bitrate = 0;
+		return ret;
+	}
+
+	int frames_per_sec = 1000000 / dur_us;
+	int octets_per_sdu;
+
+	ret = le_audio_octets_per_frame_get(codec, &octets_per_sdu);
+	if (ret) {
+		*bitrate = 0;
+		return ret;
+	}
+
+	*bitrate = frames_per_sec * (octets_per_sdu * 8);
+
+	return 0;
+}
+
 int le_audio_stream_dir_get(struct bt_bap_stream const *const stream)
 {
 	int ret;

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.h
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.h
@@ -111,7 +111,19 @@ int le_audio_octets_per_frame_get(const struct bt_audio_codec_cfg *codec, uint32
  */
 int le_audio_frame_blocks_per_sdu_get(const struct bt_audio_codec_cfg *codec,
 				      uint32_t *frame_blks_per_sdu);
-/*
+
+/**
+ * @brief	Get the bitrate for the codec configuration.
+ *
+ * @details	Decodes the audio frame duration and the number of octets per fram from the codec
+ *		configuration, and calculates the bitrate.
+ *
+ * @param[in]	codec	The audio codec structure.
+ * @param[out]	bitrate	Pointer to the bitrate in bps.
+ */
+int le_audio_bitrate_get(const struct bt_audio_codec_cfg *const codec, uint32_t *bitrate);
+
+/**
  * @brief	Get the direction of the @p stream provided
  *
  * @param	stream	Stream to check direction for.


### PR DESCRIPTION
Move calculation of the codec bitrate into le_audio module to reduce code duplication.

The integration of sample rate conversion will introduce the bitrate calculation in three more places, so the gain from creating a function for this will increase when that is merged.