### PR TITLE
caf: modules: ble_adv: Power down on disconnection with reason 0x15

### DIFF
--- a/applications/nrf_desktop/src/modules/Kconfig.caf_ble_adv.default
+++ b/applications/nrf_desktop/src/modules/Kconfig.caf_ble_adv.default
@@ -19,6 +19,14 @@ config DESKTOP_BLE_ADV
 
 if DESKTOP_BLE_ADV
 
+config CAF_BLE_ADV_POWER_DOWN_ON_DISCONNECTION_REASON_0X15
+	default y
+	help
+	  nRF Desktop peripherals power down and suspend Bluetooth advertising
+	  when bonded peer disconnects with reason 0x15 (Remote Device
+	  Terminated due to Power Off) to avoid waking up the HID host until
+	  user input is detected.
+
 config CAF_BLE_ADV_DIRECT_ADV
 	default n
 	help

--- a/doc/nrf/libraries/caf/ble_adv.rst
+++ b/doc/nrf/libraries/caf/ble_adv.rst
@@ -19,6 +19,7 @@ The following Kconfig options are available for this module:
 
 * :kconfig:option:`CONFIG_CAF_BLE_ADV`
 * :kconfig:option:`CONFIG_CAF_BLE_ADV_PM_EVENTS`
+* :kconfig:option:`CONFIG_CAF_BLE_ADV_POWER_DOWN_ON_DISCONNECTION_REASON_0X15`
 * :kconfig:option:`CONFIG_CAF_BLE_ADV_DIRECT_ADV`
 * :kconfig:option:`CONFIG_CAF_BLE_ADV_FAST_ADV`
 * :kconfig:option:`CONFIG_CAF_BLE_ADV_FAST_ADV_TIMEOUT`
@@ -98,6 +99,17 @@ This is done to ensure that the user does not try to connect to the device that 
 
    The :kconfig:option:`CONFIG_CAF_BLE_ADV_GRACE_PERIOD` is enabled by default if the Swift Pair advertising data provider is enabled in the configuration.
 
+Force power down on bonded peer power off
+-----------------------------------------
+
+You can use the :kconfig:option:`CONFIG_CAF_BLE_ADV_POWER_DOWN_ON_DISCONNECTION_REASON_0X15` Kconfig option to force power down when a bonded peer disconnects with reason ``0x15`` (Remote Device Terminated due to Power Off).
+On a Bluetooth LE peer event (:c:struct:`ble_peer_event`) reporting :c:enumerator:`PEER_STATE_DISCONNECTED` (:c:member:`ble_peer_event.state`) with reason ``0x15`` (:c:member:`ble_peer_event.reason`), the module performs the following:
+
+ * Instantly stops Bluetooth LE advertising (the module enters power down state).
+ * Submits a force power down event (:c:struct:`force_power_down_event`).
+
+You can use this feature to prevent a bonded peer from waking up until activity on the peripheral is detected.
+
 Implementation details
 **********************
 
@@ -127,7 +139,7 @@ The Bluetooth LE bond module broadcasts information related to bond control usin
 The |ble_adv| reacts on :c:struct:`ble_peer_operation_event` related to the Bluetooth peer change or erase advertising.
 The module performs one of the following operations:
 
-* If there is a peer connected over Bluetooth, the |ble_adv| triggers disconnection and submits a :c:struct:`ble_peer_event` with :c:member:`ble_peer_event.state` set to :c:enum:`PEER_STATE_DISCONNECTING` to let other application modules prepare for the planned disconnection.
+* If there is a peer connected over Bluetooth, the |ble_adv| triggers disconnection and submits a :c:struct:`ble_peer_event` with :c:member:`ble_peer_event.state` set to :c:enumerator:`PEER_STATE_DISCONNECTING` to let other application modules prepare for the planned disconnection.
 * Otherwise, the Bluetooth advertising with the newly selected Bluetooth local identity is started.
 
 Avoiding connection requests from unbonded centrals when bonded

--- a/doc/nrf/libraries/caf/ble_state.rst
+++ b/doc/nrf/libraries/caf/ble_state.rst
@@ -54,22 +54,14 @@ Connection state change
 =======================
 
 The module propagates information about the connection state changes using :c:struct:`ble_peer_event`.
-In this event, :c:member:`ble_peer_event.id` is a pointer to the connection object and :c:member:`ble_peer_event.state` is the connection state.
 
 .. figure:: images/caf_ble_state_transitions.svg
    :alt: Bluetooth connection state handling in CAF
 
    Bluetooth connection state handling in CAF
 
-The connection state can be set to one of the following values:
-
-* :c:enum:`PEER_STATE_CONNECTED` - Bluetooth stack successfully connected to the remote peer.
-* :c:enum:`PEER_STATE_CONN_FAILED` - Bluetooth stack failed to connect the remote peer.
-* :c:enum:`PEER_STATE_SECURED` - Bluetooth stack set the connection security to at least level 2 (that is, encryption and no authentication).
-* :c:enum:`PEER_STATE_DISCONNECTED` - Bluetooth stack disconnected from the remote peer.
-
 Other application modules can call :c:func:`bt_conn_disconnect` to disconnect the remote peer.
-The application module can submit a :c:struct:`ble_peer_event` with :c:member:`ble_peer_event.state` set to :c:enum:`PEER_STATE_DISCONNECTING` to let other application modules prepare for the disconnection.
+The application module can submit a :c:struct:`ble_peer_event` with :c:member:`ble_peer_event.state` set to :c:enumerator:`PEER_STATE_DISCONNECTING` to let other application modules prepare for the disconnection.
 
 Connection parameter change
 ===========================

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -305,6 +305,9 @@ nRF Desktop
   * The default value of the newly introduced :kconfig:option:`CONFIG_BT_ADV_PROV_DEVICE_NAME_PAIRING_MODE_ONLY` Kconfig option.
     The option is disabled by default by the nRF Desktop application.
     The Bluetooth device name is provided in the scan response also outside of pairing mode for backwards compatibility.
+  * The default value of newly introduced :kconfig:option:`CONFIG_CAF_BLE_ADV_POWER_DOWN_ON_DISCONNECTION_REASON_0X15` Kconfig option.
+    The option is enabled by default by the nRF Desktop application.
+    Force power down on disconnection with reason ``0x15`` (Remote Device Terminated due to Power Off) is triggered to avoid waking up HID host until user input is detected.
 
 * Added the :ref:`CONFIG_DESKTOP_HID_STATE_SUBSCRIBER_COUNT <config_desktop_app_options>` Kconfig option to the :ref:`nrf_desktop_hid_state`.
   The option allows to configure a maximum number of simultaneously supported HID data subscribers.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -994,6 +994,8 @@ Common Application Framework (CAF)
 
   * Updated the dependencies of the :kconfig:option:`CONFIG_CAF_BLE_USE_LLPM` Kconfig option.
     The option can be enabled even when the Bluetooth controller is not enabled as part of the application that uses :ref:`caf_ble_state`.
+  * Added :c:member:`ble_peer_event.reason` to inform about reason code related to state of the Bluetooth LE peer.
+    The field is used to propagate information about error code related to a connection establishment failure and disconnection reason.
 
 Shell libraries
 ---------------

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -997,6 +997,11 @@ Common Application Framework (CAF)
   * Added :c:member:`ble_peer_event.reason` to inform about reason code related to state of the Bluetooth LE peer.
     The field is used to propagate information about error code related to a connection establishment failure and disconnection reason.
 
+* :ref:`caf_ble_adv`:
+
+  * Added the :kconfig:option:`CONFIG_CAF_BLE_ADV_POWER_DOWN_ON_DISCONNECTION_REASON_0X15` Kconfig option.
+    You can use this option to force system power down when a bonded peer disconnects with reason ``0x15`` (Remote Device Terminated due to Power Off).
+
 Shell libraries
 ---------------
 

--- a/include/caf/events/ble_common_event.h
+++ b/include/caf/events/ble_common_event.h
@@ -115,6 +115,13 @@ struct ble_peer_event {
 	/** State of the Bluetooth LE peer. */
 	enum peer_state state;
 
+	/** Reason code related to state of the Bluetooth LE peer. The field is used only for
+	 *  PEER_STATE_CONN_FAILED (error code related to connection establishment failure),
+	 *  PEER_STATE_DISCONNECTING, PEER_STATE_DISCONNECTED (disconnection reason). Other peer
+	 *  states do not use this field and set the value to zero.
+	 */
+	uint8_t reason;
+
 	/** ID used to identify Bluetooth connection - pointer to the bt_conn. */
 	void *id;
 };

--- a/subsys/caf/events/ble_common_event.c
+++ b/subsys/caf/events/ble_common_event.c
@@ -27,8 +27,8 @@ static void log_ble_peer_event(const struct app_event_header *aeh)
 
 	__ASSERT_NO_MSG(event->state < PEER_STATE_COUNT);
 
-	APP_EVENT_MANAGER_LOG(aeh, "id=%p %s", event->id,
-			state_name[event->state]);
+	APP_EVENT_MANAGER_LOG(aeh, "id=%p %s reason=%" PRIu8,
+			      event->id, state_name[event->state], event->reason);
 }
 
 static void profile_ble_peer_event(struct log_event_buf *buf,
@@ -38,11 +38,12 @@ static void profile_ble_peer_event(struct log_event_buf *buf,
 
 	nrf_profiler_log_encode_uint32(buf, (uint32_t)event->id);
 	nrf_profiler_log_encode_uint8(buf, event->state);
+	nrf_profiler_log_encode_uint8(buf, event->reason);
 }
 
 APP_EVENT_INFO_DEFINE(ble_peer_event,
-		  ENCODE(NRF_PROFILER_ARG_U32, NRF_PROFILER_ARG_U8),
-		  ENCODE("conn_id", "state"),
+		  ENCODE(NRF_PROFILER_ARG_U32, NRF_PROFILER_ARG_U8, NRF_PROFILER_ARG_U8),
+		  ENCODE("conn_id", "state", "reason"),
 		  profile_ble_peer_event);
 
 APP_EVENT_TYPE_DEFINE(ble_peer_event,

--- a/subsys/caf/modules/Kconfig.ble_adv
+++ b/subsys/caf/modules/Kconfig.ble_adv
@@ -18,6 +18,15 @@ config CAF_BLE_ADV_PM_EVENTS
 	depends on CAF_PM_EVENTS
 	default y
 
+config CAF_BLE_ADV_POWER_DOWN_ON_DISCONNECTION_REASON_0X15
+	bool "Force power down on disconnection with reason 0x15"
+	depends on CAF_BLE_ADV_PM_EVENTS
+	select CAF_FORCE_POWER_DOWN_EVENTS
+	help
+	  Force power down when a bonded peer disconnects with reason 0x15
+	  (Remote Device Terminated due to Power Off). The module instantly
+	  stops Bluetooth LE advertising and submits a force_power_down event.
+
 config CAF_BLE_ADV_DIRECT_ADV
 	bool "Advertise to bonded peer directly"
 	depends on SETTINGS

--- a/subsys/caf/modules/ble_adv.c
+++ b/subsys/caf/modules/ble_adv.c
@@ -762,7 +762,8 @@ static void update_peer_is_rpa(enum peer_rpa new_peer_rpa)
 
 static void disconnect_peer(struct bt_conn *conn)
 {
-	int err = bt_conn_disconnect(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+	uint8_t reason = BT_HCI_ERR_REMOTE_USER_TERM_CONN;
+	int err = bt_conn_disconnect(conn, reason);
 
 	if (!err) {
 		/* Submit event to let other application modules prepare for
@@ -772,6 +773,7 @@ static void disconnect_peer(struct bt_conn *conn)
 
 		event->id = conn;
 		event->state = PEER_STATE_DISCONNECTING;
+		event->reason = reason;
 		APP_EVENT_SUBMIT(event);
 
 		LOG_INF("Peer disconnecting");

--- a/subsys/caf/modules/ble_state.c
+++ b/subsys/caf/modules/ble_state.c
@@ -95,6 +95,7 @@ static void connected(struct bt_conn *conn, uint8_t error)
 
 		event->id = conn;
 		event->state = PEER_STATE_CONN_FAILED;
+		event->reason = error;
 		APP_EVENT_SUBMIT(event);
 
 		if (IS_ENABLED(CONFIG_LOG)) {
@@ -130,6 +131,7 @@ static void connected(struct bt_conn *conn, uint8_t error)
 
 	event->id = conn;
 	event->state = PEER_STATE_CONNECTED;
+	event->reason = 0;
 	APP_EVENT_SUBMIT(event);
 
 	broadcast_init_conn_params(conn);
@@ -210,6 +212,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 
 	event->id = conn;
 	event->state = PEER_STATE_DISCONNECTED;
+	event->reason = reason;
 	APP_EVENT_SUBMIT(event);
 }
 
@@ -252,8 +255,10 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 	}
 
 	struct ble_peer_event *event = new_ble_peer_event();
+
 	event->id = conn;
 	event->state = PEER_STATE_SECURED;
+	event->reason = 0;
 	APP_EVENT_SUBMIT(event);
 
 	if (IS_ENABLED(CONFIG_CAF_BLE_STATE_EXCHANGE_MTU)) {


### PR DESCRIPTION
Force power down if bonded peer disconnects with reason 0x15 (Remote Device Terminated due to Power Off).

PR also adds broadcasting reason to ble_peer_event and integrates the new feature to nRF Desktop application.

Jira: NCSDK-24458