### PR TITLE
bluetooth: fast_pair: Expose Model ID before Fast Pair is ready

### DIFF
--- a/subsys/bluetooth/services/fast_pair/Kconfig.fast_pair
+++ b/subsys/bluetooth/services/fast_pair/Kconfig.fast_pair
@@ -117,6 +117,18 @@ config BT_FAST_PAIR_REGISTRATION_DATA
 	help
 	  Add Fast Pair registration data source files.
 
+if BT_FAST_PAIR_REGISTRATION_DATA
+
+config BT_FAST_PAIR_REGISTRATION_DATA_INIT_PRIORITY
+	int
+	range 0 9
+	default 3
+	help
+	  Fast Pair registration data module initialization priority.
+	  Used when registering initialization function to Fast Pair activation module.
+
+endif # BT_FAST_PAIR_REGISTRATION_DATA
+
 config BT_FAST_PAIR_BATTERY
 	bool
 	default y

--- a/subsys/bluetooth/services/fast_pair/fp_registration_data.c
+++ b/subsys/bluetooth/services/fast_pair/fp_registration_data.c
@@ -51,7 +51,7 @@ static bool is_enabled;
 
 int fp_reg_data_get_model_id(uint8_t *buf, size_t size)
 {
-	__ASSERT_NO_MSG(bt_fast_pair_is_ready());
+	__ASSERT_NO_MSG(is_enabled);
 
 	int err;
 	const struct flash_area *fa;
@@ -170,5 +170,5 @@ static int fp_reg_data_uninit(void)
 	return 0;
 }
 
-FP_ACTIVATION_MODULE_REGISTER(fp_reg_data, FP_ACTIVATION_INIT_PRIORITY_DEFAULT, fp_reg_data_init,
-			      fp_reg_data_uninit);
+FP_ACTIVATION_MODULE_REGISTER(fp_reg_data, CONFIG_BT_FAST_PAIR_REGISTRATION_DATA_INIT_PRIORITY,
+			      fp_reg_data_init, fp_reg_data_uninit);

--- a/subsys/bluetooth/services/fast_pair/include/common/fp_registration_data.h
+++ b/subsys/bluetooth/services/fast_pair/include/common/fp_registration_data.h
@@ -14,8 +14,6 @@
  * @defgroup fp_registration_data Fast Pair registration data
  * @brief Internal API for Fast Pair registration data
  *
- * The module must be initialized with @ref bt_fast_pair_enable before using API functions.
- *
  * @{
  */
 
@@ -39,6 +37,8 @@ extern "C" {
 int fp_reg_data_get_model_id(uint8_t *buf, size_t size);
 
 /** Get Fast Pair anti-spoofing private key.
+ *
+ * The module must be initialized with @ref bt_fast_pair_enable before using this function.
  *
  * @param[out] buf  Pointer to the buffer to be filled with the anti-spoofing private key.
  * @param[in]  size Buffer length (in bytes). The buffer must be at least


### PR DESCRIPTION
Add possibility to read Fast Pair Model ID before calling bt_fast_pair_enable().

Jira: NCSDK-25424