### PR TITLE
doc: distro: Update to Golioth's Firmware SDK

### DIFF
--- a/doc/nrf/dev_model_and_contributions/ncs_distro.rst
+++ b/doc/nrf/dev_model_and_contributions/ncs_distro.rst
@@ -47,7 +47,7 @@ This approach is essentially identical to the previous one.
 However, the :ref:`module repository <zephyr:modules>` you create will not be part of the |NCS| official distribution by default.
 Instead, you will need to host your own documentation explaining how to add the module you make available to user's :ref:`own manifest <dm_workflow_4>`.
 
-An example of this approach is the `Golioth Zephyr SDK`_, which is set up as a `Zephyr module <Golioth module.yml_>`_ that a user can add to their own manifest.
+An example of this approach is the `Golioth Firmware SDK`_, which is set up as a `Zephyr module <Golioth module.yml_>`_ that a user can add to their own manifest.
 
 Providing a west manifest
 *************************
@@ -58,7 +58,7 @@ It will then in turn import the |NCS| `west manifest file`_.
 
 A good starting point for such an approach is the Nordic-provided `ncs-example-application`_ repository.
 It contains all the necessary integration with |NCS| and example functionality (a driver, library, subsystem, test, etc.) to serve as a reference for your own distribution's manifest repository.
-Just like in the previous approach, Golioth provides an example of such a west manifest, `west-ncs.yml <Golioth west-ncs.yml_>`_ along with a `guide document <Golioth README nRF Connect SDK_>`_.
+Just like in the previous approach, Golioth provides an example of such a west manifest, `west-ncs.yml <Golioth west-ncs.yml_>`_ along with a `guide document <Golioth Firmware SDK NCS doc_>`_.
 
 Forking the |NCS|
 *****************

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -65,10 +65,10 @@
 .. _`Memfault entry in the manifest`: https://github.com/nrfconnect/sdk-nrf/blob/20f40501f69bc9bfd2b321704917da1769411936/west.yml#L170-L173
 .. _`ANT entry in the manifest`: https://github.com/nrfconnect/sdk-nrf/blob/20f40501f69bc9bfd2b321704917da1769411936/west.yml#L182-L187
 
-.. _`Golioth Zephyr SDK`: https://github.com/golioth/golioth-zephyr-sdk
-.. _`Golioth module.yml`: https://github.com/golioth/golioth-zephyr-sdk/blob/v0.5.0/zephyr/module.yml
-.. _`Golioth west-ncs.yml`: https://github.com/golioth/golioth-zephyr-sdk/blob/v0.5.0/west-ncs.yml
-.. _`Golioth README nRF Connect SDK`: https://github.com/golioth/golioth-zephyr-sdk/tree/v0.5.0#using-with-nrf-connect-sdk
+.. _`Golioth Firmware SDK`: https://github.com/golioth/golioth-firmware-sdk
+.. _`Golioth module.yml`: https://github.com/golioth/golioth-firmware-sdk/blob/v0.10.0/zephyr/module.yml
+.. _`Golioth west-ncs.yml`: https://github.com/golioth/golioth-firmware-sdk/blob/v0.10.0/west-ncs.yml
+.. _`Golioth Firmware SDK NCS doc`: https://github.com/golioth/golioth-firmware-sdk/tree/main/examples/zephyr#using-with-nordics-nrf-connect-sdk
 
 .. _`nrfx`: https://github.com/NordicSemiconductor/nrfx/
 .. _`Changelog for nrfx 2.2.0`: https://github.com/NordicSemiconductor/nrfx/blob/master/CHANGELOG.md#user-content-220---2020-04-28


### PR DESCRIPTION
The old Golioth Zephyr SDK is deprecated, and they now offer the larger Firmware SDK. Update the doc to reflect this.