### PR TITLE
samples: wifi: softap: Modify default values for SoftAP configuration

### DIFF
--- a/samples/wifi/softap/Kconfig
+++ b/samples/wifi/softap/Kconfig
@@ -49,14 +49,14 @@ config SOFTAP_SAMPLE_CHANNEL
 
 config SOFTAP_SAMPLE_SSID
 	string "SoftAP SSID"
-	default "MySoftAP"
+	default "Myssid"
 	help
 	  Set the SSID (Service Set Identifier) for the SoftAP.
 	  This is the name that will be broadcasted for client(s) to connect.
 
 choice  SOFTAP_SAMPLE_KEY_MGMT_SELECT
 	prompt "Security option for SoftAP"
-	default SOFTAP_SAMPLE_KEY_MGMT_WPA3
+	default SOFTAP_SAMPLE_KEY_MGMT_WPA2
 
 config SOFTAP_SAMPLE_KEY_MGMT_NONE
 	bool "Open security"
@@ -81,6 +81,7 @@ endchoice
 
 config SOFTAP_SAMPLE_PASSWORD
 	string "Passphrase (WPA2) or password (WPA3)"
+	default "Mypassword"
 	help
 	  Set the password for SoftAP.
 

--- a/samples/wifi/softap/README.rst
+++ b/samples/wifi/softap/README.rst
@@ -31,6 +31,7 @@ You can enable the SoftAP mode by setting the below configuration options in the
 .. note::
 
    The SoftAP mode operation is dictated by regulatory requirements.
+   It is mandatory to set the regulatory domain to a specific country when operating in the 5 GHz frequency band.
 
 You can set the regulatory domain using the below configuration option:
 


### PR DESCRIPTION
Update default settings for SoftAP to use WPA2 security by default.