### PR TITLE
manifest: sdk-zephyr: Update I2S driver to generate master clock

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: a8dec43b92d373e00bc33ef957c0c7bc5f6989d1
+      revision: ea1fd932d014b49f27482463ce291b5697df9b38
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This makes it possible for nRF I2S to provide master clock even when operating in I2S Slave mode.