### PR TITLE
doc: Known issues version fix

### DIFF
--- a/doc/nrf/releases_and_maturity/known_issues.rst
+++ b/doc/nrf/releases_and_maturity/known_issues.rst
@@ -22,7 +22,7 @@ A known issue can list one or both of the following entries:
   Sometimes, they are discovered later and added over time.
 
 .. version-filter::
-  :default: v2-5-1
+  :default: v2-5-2
   :container: dl/dt
   :tags: [("wontfix", "Won't fix")]
 


### PR DESCRIPTION
The Known issues page defaults to 2.5.1.
Fixed it to point to 2.5.2.