### PR TITLE
applications: nrf5340_audio: Extended codec cfg max metadata size

### DIFF
--- a/applications/nrf5340_audio/broadcast_sink/Kconfig.defaults
+++ b/applications/nrf5340_audio/broadcast_sink/Kconfig.defaults
@@ -50,6 +50,8 @@ config BT_PAC_SNK
 config BT_AUDIO_RX
 	default y
 
+config BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE
+	default 80
 
 ## Audio related configs ##
 config AUDIO_MUTE


### PR DESCRIPTION
Enlarge codec cfg max metadata size to prevent compatibility issue. 
OCT-NONE
Signed-off-by: Jui-Chou Chung <jui-chou.chung@nordicsemi.no>