### PR TITLE
manifest: update sdk-zephyr (nRF54L15 RRAM flash driver)

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: c5c7fb3967905dcaef1035ac8d5b234176a2cc0a
+      revision: 1d09dda4feb77fa36549cd32cf88dd13d0abeb4e
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Updated version includes nRF54L15 SoC's RRAM flash driver