### PR TITLE
modules: trusted-firmware-m: HMAC DRBG for minimal

### DIFF
--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -286,6 +286,7 @@ config TFM_PROFILE_TYPE_MINIMAL
 	bool "TF-M build profile: minimal"
 	select PSA_DEFAULT_OFF
 	select PSA_WANT_GENERATE_RANDOM
+	select PSA_WANT_ALG_HMAC_DRBG
 	help
 	  Minimal TF-M build profile. This will make the TF-M image fit within 32kB.
 	  No configuration of the size of the partition nor the features of the

--- a/subsys/nrf_security/cmake/legacy_crypto_config.cmake
+++ b/subsys/nrf_security/cmake/legacy_crypto_config.cmake
@@ -227,10 +227,6 @@ kconfig_check_and_set_base_depends(MBEDTLS_ECDSA_DETERMINISTIC
   PSA_WANT_ALG_HMAC_DRBG
 )
 
-kconfig_check_and_set_base_depends(MBEDTLS_HMAC_DRBG_C
-  PSA_WANT_ALG_HMAC_DRBG
-)
-
 Kconfig_check_and_set_base_depends(MBEDTLS_ECP_DP_SECP192R1_ENABLED
   PSA_WANT_ECC_SECP_R1_192
 )


### PR DESCRIPTION
Enable HMAC DRBG when we build TFM with minimal profile since it reduces the ROM usage.

Ref: NCSDK-25891