### PR TITLE
ci: update labeler to sync labels

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,3 +9,4 @@ jobs:
       - uses: actions/labeler@v5.0.0
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          sync-labels: true


### PR DESCRIPTION
Labeler v5 (by default) does not remove labels when matching files are reverted or no longer changed by the PR. This change will enable the old behavior.