### PR TITLE
manifest: sdk-zephyr: Add overlay files to Zephyr LwM2M sample

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 962eb7320fdb76ffe265d8bab7330ad472cb6f28
+      revision: pull/1460/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Add nRF91x and nRF700x support to Zephyr lwm2m_client sample by providing overlay configuration files.