### PR TITLE
manifest: sdk-zephyr: apply modem cherry picks

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: a8dec43b92d373e00bc33ef957c0c7bc5f6989d1
+      revision: c5c7fb3967905dcaef1035ac8d5b234176a2cc0a
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
To get the generic modem driver support for nRF91 series (w/ SLM).