### PR TITLE
Bluetooth: Controller: Require TEMP for temperature HCI command

### DIFF
--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -620,7 +620,9 @@ static void vs_zephyr_supported_commands(sdc_hci_vs_zephyr_supported_commands_t 
 	cmds->write_bd_addr = 1;
 	cmds->read_static_addresses = 1;
 	cmds->read_key_hierarchy_roots = 1;
+#ifdef CONFIG_DT_HAS_NORDIC_NRF_TEMP_ENABLED
 	cmds->read_chip_temperature = 1;
+#endif
 
 #if defined(CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL)
 	cmds->write_tx_power_level = 1;
@@ -1532,9 +1534,11 @@ static uint8_t vs_cmd_put(uint8_t const *const cmd, uint8_t *const raw_event_out
 	case SDC_HCI_OPCODE_CMD_VS_ZEPHYR_WRITE_BD_ADDR:
 		return sdc_hci_cmd_vs_zephyr_write_bd_addr((void *)cmd_params);
 
+#if defined(CONFIG_DT_HAS_NORDIC_NRF_TEMP_ENABLED)
 	case SDC_HCI_OPCODE_CMD_VS_ZEPHYR_READ_CHIP_TEMP:
 		*param_length_out += sizeof(sdc_hci_cmd_vs_zephyr_read_chip_temp_return_t);
 		return sdc_hci_cmd_vs_zephyr_read_chip_temp((void *)event_out_params);
+#endif
 
 #if defined(CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL)
 	case SDC_HCI_OPCODE_CMD_VS_ZEPHYR_WRITE_TX_POWER:


### PR DESCRIPTION
The "Zephyr Read Chip Temperature" HCI command will only work if the internal temperature sensor is available.