### PR TITLE
manifest: sdk-zephyr: Fix DPPI support for nRF54L15

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: a8dec43b92d373e00bc33ef957c0c7bc5f6989d1
+      revision: 8cd3e479cb0036748361e284da6bd02a9dd8657d
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Add required files for DPPIC support for nRF54L15.