### PR TITLE
tfm: Delete deprecated symbol PSA_INITIAL_ATTEST_TOKEN_MAX_SIZE

### DIFF
--- a/modules/trusted-firmware-m/tfm_boards/partition/region_defs.h
+++ b/modules/trusted-firmware-m/tfm_boards/partition/region_defs.h
@@ -26,12 +26,6 @@
 #define SPU_FLASH_REGION_SIZE   (CONFIG_NRF_SPU_FLASH_REGION_SIZE)
 #define SPU_SRAM_REGION_SIZE    (0x00002000)
 
-/* This size of buffer is big enough to store an attestation
- * token produced by initial attestation service
- */
-#define PSA_INITIAL_ATTEST_TOKEN_MAX_SIZE   (0x250)
-
-
 #if !defined(LINK_TO_SECONDARY_PARTITION)
 #ifdef NRF_NS_SECONDARY
 #define S_IMAGE_PRIMARY_PARTITION_OFFSET   (PM_MCUBOOT_PRIMARY_ADDRESS)


### PR DESCRIPTION
PSA_INITIAL_ATTEST_TOKEN_MAX_SIZE was renamed in TF-M, but we didn’t
update our symbol name.

It appears that this symbol is now provided by TF-M's
initial_attestation.h.in and that we should therefore delete, not
rename, this symbol.

Interestingly, it’s documented that region_defs.h should define this,
but no-one is doing so for the new symbol name. The docs are probably
wrong.