### PR TITLE
actions: oss: disable tf-m oss-history check

### DIFF
--- a/.github/workflows/oss-history.yml
+++ b/.github/workflows/oss-history.yml
@@ -31,4 +31,4 @@ jobs:
         uses: nrfconnect/action-oss-history@main
         with:
           workspace: 'ncs'
-          args: -p zephyr -p mcuboot -p trusted-firmware-m -p hostap -p wfa-qt-control-app
+          args: -p zephyr -p mcuboot -p hostap -p wfa-qt-control-app


### PR DESCRIPTION
This does the same as commit
20e50c32958465916240b167a07bee9e82af02bc
which was reverted by
8042ef1ed8a2d128f7ad1683e1ea2efd4d59b371

Pull request #13662 is bringing in a lot of commits from upstream tf-m
that are not present in the revision of tf-m in zephyr/west.yml, and
the script is getting confused.

In particular, it thinks that all of the new upstream commits are
actually downstream out-of-tree commits. Then it tries to reapply them
onto the old upstream. This fails, and the action fails.

Signed-off-by: Markus Swarowsky <markus.swarowsky@nordicsemi.no>
