### PR TITLE
manifest: sdk-zephyr: Fix quarantine and test plan interaction

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 962eb7320fdb76ffe265d8bab7330ad472cb6f28
+      revision: a8dec43b92d373e00bc33ef957c0c7bc5f6989d1
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Needed before 2.6 to unlock development. Without it a quarantine is ignored with dynamic scope and  known errors blocks PRs