### PR TITLE
manifest: update sdk-zephyr removing experimental for ISO controller

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 88f1d4fca1dbe5b319d8c6eab16835c61778d184
+      revision: pull/1517/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
The sample improvements make it easier to use the
Bluetooth Isochronous Channels samples.