### PR TITLE
test-spec: descope samples and tests from many CIs

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: a8dec43b92d373e00bc33ef957c0c7bc5f6989d1
+      revision: pull/1513/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Descope samples and tests from many CIs, since the majority are not affecting the functionality of protocols and applications. Samples that may affect the overall performance and functionality, should be enabled specifically.