### PR TITLE
Added support for DFU of wi-fi firmware patch 

### DIFF
--- a/applications/matter_bridge/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/applications/matter_bridge/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/dt-bindings/ipc_service/static_vrings.h>
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};
+
+/* Set IPC thread priority to the highest value to not collide with other threads. */
+&ipc0 {
+    zephyr,priority = <0 PRIO_COOP>;
+};
+
+/* Disable unused peripherals to reduce power consumption */
+&adc {
+	status = "disabled";
+};
+&i2c1 {
+	status = "disabled";
+};
+&pwm0 {
+	status = "disabled";
+};
+&spi2 {
+	status = "disabled";
+};
+&usbd {
+	status = "disabled";
+};

--- a/applications/matter_bridge/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/applications/matter_bridge/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/applications/matter_bridge/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp_release.overlay
+++ b/applications/matter_bridge/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp_release.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/applications/matter_bridge/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
+++ b/applications/matter_bridge/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
@@ -45,9 +45,33 @@ mcuboot_secondary_1:
   size: 0x40000
   device: MX25R64
   region: external_flash
-external_flash:
+nrf70_wifi_fw_mcuboot_pad:
   address: 0x12F000
-  size: 0x6D1000
+  size: 0x200
+  device: MX25R64
+  region: external_flash
+nrf70_wifi_fw:
+  address: 0x12F200
+  size: 0x20000
+  device: MX25R64
+  region: external_flash
+mcuboot_primary_2:
+  orig_span: &id003
+  - nrf70_wifi_fw_mcuboot_pad
+  - nrf70_wifi_fw
+  span: *id003
+  address: 0x12F000
+  size: 0x21000
+  device: MX25R64
+  region: external_flash
+mcuboot_secondary_2:
+  address: 0x150000
+  size: 0x21000
+  device: MX25R64
+  region: external_flash
+external_flash:
+  address: 0x171000
+  size: 0x68F000
   device: MX25R64
   region: external_flash
 pcd_sram:

--- a/applications/matter_bridge/doc/matter_bridge_description.rst
+++ b/applications/matter_bridge/doc/matter_bridge_description.rst
@@ -468,6 +468,16 @@ Building and running
 
 .. include:: /includes/build_and_run.txt
 
+.. include:: ../../../samples/matter/lock/README.rst
+    :start-after: matter_door_lock_sample_nrf70_firmware_patch_start
+    :end-before: matter_door_lock_sample_nrf70_firmware_patch_end
+
+For example:
+
+   .. code-block:: console
+
+      west build -b nrf5340dk_nrf5340_cpuapp -p -- -DSHIELD=nrf7002ek -DCONFIG_NRF_WIFI_PATCHES_EXT_FLASH_STORE=y -Dmcuboot_CONFIG_UPDATEABLE_IMAGE_NUMBER=3
+
 Selecting a build type
 ======================
 

--- a/applications/matter_bridge/sample.yaml
+++ b/applications/matter_bridge/sample.yaml
@@ -41,3 +41,10 @@ tests:
     integration_platforms:
       - nrf7002dk_nrf5340_cpuapp
     platform_allow: nrf7002dk_nrf5340_cpuapp
+  applications.matter_bridge.nrf70ek:
+    build_only: true
+    extra_args: SHIELD=nrf7002ek CONFIG_NRF_WIFI_PATCHES_EXT_FLASH_STORE=y
+      mcuboot_CONFIG_UPDATEABLE_IMAGE_NUMBER=3
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf5340dk_nrf5340_cpuapp

--- a/doc/nrf/config_and_build/dfu/index.rst
+++ b/doc/nrf/config_and_build/dfu/index.rst
@@ -80,3 +80,4 @@ See the following user guides for an overview of topics related to firmware upda
    :caption: Subpages:
 
    dfu_image_versions
+   nrf70_fw_patch_update

--- a/doc/nrf/config_and_build/dfu/nrf70_fw_patch_update.rst
+++ b/doc/nrf/config_and_build/dfu/nrf70_fw_patch_update.rst
@@ -1,0 +1,211 @@
+.. _ug_nrf70_fw_patch_update:
+
+nRF70 Series firmware patch update
+##################################
+
+.. contents::
+   :local:
+   :depth: 2
+
+This guide explains the available option for updating the nRF70 Series firmware patches that reside in the external memory using the Device Firmware Updates (DFU) procedure.
+
+.. note::
+    External memory refers to the memory that is outside the System-on-Chip (SoC), for example, an external flash memory chip, or an external nonvolatile memory (NVM) chip.
+
+.. note::
+    Currently, you cannot build an example with the both :kconfig:option:`CONFIG_NRF_WIFI_PATCHES_EXT_FLASH_STORE` and :kconfig:option:`CONFIG_XIP_SPLIT_IMAGE` Kconfig options enabled.
+    To enable XIP support use the :kconfig:option:`CONFIG_NRF_WIFI_PATCHES_EXT_FLASH_XIP` Kconfig option instead of the :kconfig:option:`CONFIG_NRF_WIFI_PATCHES_EXT_FLASH_STORE` Kconfig option.
+
+Overview
+========
+
+By default, the patch is located in the on-chip memory as part of the nRF Wi-Fi driver code.
+However, you have the option to store it in external memory, which frees up space in the on-chip memory.
+If the patch is situated outside the SoC memory space, it will not be updated automatically during a regular firmware update of the application core.
+In such cases, you must enable the DFU procedure specifically for the nRF70 Series firmware patch on your device.
+
+To learn more about the firmware patch located in the external memory, see the :ref:`ug_nrf70_developing_fw_patch_ext_flash` guide.
+
+Prerequisites
+=============
+
+To use this feature, ensure that the following prerequisites are met:
+
+* The external memory is available and properly configured in the device tree.
+* The external memory has sufficient capacity to accommodate the firmware patches.
+  This includes additional space for potential patch upgrades, such as those required for DFU.
+  The combined size of all firmware patches should not exceed 128 kB.
+* MCUboot is enabled, and the :kconfig:option:`CONFIG_BOOTLOADER_MCUBOOT` Kconfig option is set to ``y``.
+
+Supported platforms
+===================
+
+The following platforms are supported:
+
+* nRF5340 DK with nRF7002 EK as a shield
+
+Preparing the application
+=========================
+
+The DFU procedure for the nRF70 Series firmware patch, when located in external memory, requires the creation of additional MCUboot partitions.
+This can be accomplished using the Partition Manager by defining the necessary partition layout in the Partition Manager configuration file specific to your application.
+For instructions on configuring basic partitions with the Partition Manager, refer to the :ref:`partition_manager` documentation.
+
+The instructions in this guide assume you are using the Partition Manager and its associated configuration files.
+
+.. _nrf70_fw_patch_update_mcuboot_partitions:
+
+Defining nRF70 Series MCUboot partitions
+----------------------------------------
+
+The number of MCUboot partitions required depends on the platform being used and its memory layout.
+In addition to a partition dedicated to the nRF70 Series firmware patch, you will need to create specific partitions based on the platform:
+
+* For applications that are based on a single image, define a new partition with the number ``1``.
+* For multi-image builds, define the subsequent partition to follow the last existing one.
+
+Below are examples of MCUboot partition names for updating the nRF70 Series firmware patch, which vary depending on the platform and the number of cores used:
+
+* For the nRF5340 DK in a single-core variant (without the network core): ``mcuboot_primary_1`` and ``mcuboot_secondary_1``.
+* For the nRF5340 DK in a multi-core variant (with the network core): ``mcuboot_primary_2`` and ``mcuboot_secondary_2``.
+
+.. _nrf70_fw_patch_update_adding_partitions:
+
+Adding nRF70 Series firmware patch partitions
+---------------------------------------------
+
+The examples below assume that there are two existing MCUboot partitions (for the application and network cores) and that the starting address of the free external memory space is ``0x12f000``.
+
+To add the required partitions for the nRF70 Series firmware patch update, complete the following steps:
+
+1. Create the ``nrf70_wifi_fw_mcuboot_pad`` partition for the MCUboot header.
+
+   This partition should start from the first available address in the external memory space and have a size equal to the MCUboot image header length.
+
+   For example:
+
+    .. code-block:: console
+
+        nrf70_wifi_fw_mcuboot_pad:
+            address: 0x12f000
+            size: 0x200
+            device: MX25R64
+            region: external_flash
+
+#. Create the ``nrf70_wifi_fw`` partition for the firmware patch.
+
+   This partition should start from the end address of the previously created MCUboot header partition and have a size of 128 kB (``0x20000``).
+
+   For example:
+
+    .. code-block:: console
+
+        nrf70_wifi_fw:
+            address: 0x12f200
+            size: 0x20000
+            device: MX25R64
+            region: external_flash
+
+#. Create the ``mcuboot_primary_X`` partition for MCUboot where ``X`` represents the appropriate partition number as described previously.
+
+   This partition should have the same starting address as the ``nrf70_wifi_fw_mcuboot_pad`` partition, and a size of 132 kB + 200 B aligned to the device's sector size.
+   It includes both the MCUboot header and the nRF70 Series firmware patch.
+
+   For example, the MX25R64 device has a sector size of 4 kB, so the following configuration can be used:
+
+    .. code-block:: console
+
+        mcuboot_primary_2:
+            orig_span: &id003
+            - nrf70_wifi_fw_mcuboot_pad
+            - nrf70_wifi_fw
+            span: *id003
+            address: 0x12F000
+            size: 0x21000
+            device: MX25R64
+            region: external_flash
+
+#. Create the ``mcuboot_secondary_X`` partition for MCUboot, where ``X`` represents the appropriate partition number as described in the :ref:`nrf70_fw_patch_update_mcuboot_partitions` section.
+
+   This partition should start at the address immediately following the end of the ``mcuboot_primary_X`` partition and have the same size as the primary partition.
+   This partition will be used to store the new nRF70 Series firmware patch during the DFU procedure.
+
+   For example:
+
+    .. code-block:: console
+
+        mcuboot_secondary_2:
+            address: 0x150000
+            size: 0x21000
+            device: MX25R64
+            region: external_flash
+
+#. Update the ``external_flash`` partition to allocate all available memory space to it.
+
+   For example:
+
+    .. code-block:: console
+
+        external_flash:
+            address: 0x171000
+            size: 0x68F000
+            device: MX25R64
+            region: external_flash
+
+.. note::
+    The actual configuration syntax for the Partition Manager will depend on the specific system and tools being used.
+    The example provided is for illustrative purposes and may need to be adjusted to fit the actual configuration file format and syntax required by the Partition Manager in use.
+
+Configuring build system
+------------------------
+
+To enable the DFU procedure for the nRF70 Series firmware patch, complete the following steps depending on the platform:
+
+* For the nRF5340 DK without the network core:
+
+    1. Set the :kconfig:option:`CONFIG_NRF_WIFI_FW_PATCH_DFU`` Kconfig option to ``y``.
+    #. Set the :kconfig:option:`CONFIG_UPDATEABLE_IMAGE_NUMBER`` Kconfig option to ``2``.
+    #. For the MCUBoot child image, set the :kconfig:option:`CONFIG_UPDATEABLE_IMAGE_NUMBER`` Kconfig option to ``2``.
+
+* For the nRF5340 DK with the network core:
+
+    1. Set the :kconfig:option:`CONFIG_NRF_WIFI_FW_PATCH_DFU`` Kconfig option to ``y``.
+    #. Set the :kconfig:option:`CONFIG_UPDATEABLE_IMAGE_NUMBER`` Kconfig option to ``3``.
+    #. For the MCUBoot child image, set the :kconfig:option:`CONFIG_UPDATEABLE_IMAGE_NUMBER`` Kconfig option to ``3``.
+
+For example, to build the sample with the DFU procedure for the nRF70 Series firmware patch on the nRF5340 DK platform, which includes the network core image, run the following commands:
+
+.. tabs::
+
+   .. group-tab:: West
+
+        .. code-block:: console
+
+            west build -d nrf5340dk_nrf5340_cpuapp -d -- -DSHIELD=nrf7002ek -DCONFIG_PARTITION_MANAGER_ENABLED=y -DCONFIG_NRF_WIFI_PATCHES_EXT_FLASH_STORE=y -DCONFIG_NRF_WIFI_FW_PATCH_DFU=y -DCONFIG_UPDATEABLE_IMAGE_NUMBER=3 -Dmcuboot_CONFIG_UPDATEABLE_IMAGE_NUMBER=3
+
+   .. group-tab:: CMake
+
+        .. code-block:: console
+
+            cmake -GNinja -Bbuild -DBOARD=nrf5340dk_nrf5340_cpuapp -DSHIELD=nrf7002ek -DCONFIG_PARTITION_MANAGER_ENABLED=y -DCONFIG_NRF_WIFI_PATCHES_EXT_FLASH_STORE=y -DCONFIG_NRF_WIFI_FW_PATCH_DFU=y -DCONFIG_UPDATEABLE_IMAGE_NUMBER=3 -Dmcuboot_CONFIG_UPDATEABLE_IMAGE_NUMBER=3 sample
+            ninja -C build
+
+   .. group-tab:: nRF Connect for VS Code
+
+        1. When `building an application <How to build an application_>`_ as described in the |nRFVSC| documentation, follow the steps for setting up the build configuration.
+        #. In the Add Build Configuration screen, click the Add argument button under the Extra CMake argument section.
+        #. Add the following Kconfig options:
+
+        .. code-block:: console
+
+            -- -DSHIELD=nrf7002ek -DCONFIG_PARTITION_MANAGER_ENABLED=y -DCONFIG_NRF_WIFI_PATCHES_EXT_FLASH_STORE=y -DCONFIG_NRF_WIFI_FW_PATCH_DFU=y -DCONFIG_UPDATEABLE_IMAGE_NUMBER=3 -Dmcuboot_CONFIG_UPDATEABLE_IMAGE_NUMBER=3
+
+If you want to use the :ref:`ug_multi_image` feature, you need to set the :kconfig:option:`CONFIG_DFU_MULTI_IMAGE_MAX_IMAGE_COUNT` Kconfig option to one of the following values:
+
+* For the nRF5340 DK without the network core: ``2``
+* For the nRF5340 DK with the network core: ``3``
+
+Performing the update of the nRF70 Series firmware patch
+========================================================
+
+To perform the update of the nRF70 Series firmware patch, you can use all available DFU alternatives described on the main :ref:`ug_fw_update` page.

--- a/doc/nrf/device_guides/working_with_nrf/nrf70/developing/fw_patches_ext_flash.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf70/developing/fw_patches_ext_flash.rst
@@ -186,3 +186,11 @@ For example, for nrfjprog:
 .. code-block:: console
 
     nrfjprog -f nrf53 -s 0 --program build/zephyr/merged.hex ---sectorerase --qspisectorerase --verify --reset
+
+Updating firmware patches
+=========================
+
+You can update the firmware patches using all available DFU alternatives described in the main :ref:`ug_fw_update` page.
+To do it, you need to use MCUboot bootloader and create proper partitions to allow storing and replacing the firmware patches.
+
+To learn how to prepare your application and perform the firmware patch update, see the :ref:`ug_nrf70_fw_patch_update` page.

--- a/drivers/wifi/nrf700x/CMakeLists.txt
+++ b/drivers/wifi/nrf700x/CMakeLists.txt
@@ -181,16 +181,19 @@ if(CONFIG_NRF_WIFI_PATCHES_EXT_FLASH_STORE)
         ${CMAKE_BINARY_DIR}/zephyr/nrf70.hex
         $<TARGET_PROPERTY:partition_manager,nrf70_wifi_fw_XIP_ABS_ADDR>
       )
-    set_property(
-      GLOBAL PROPERTY
-      nrf70_wifi_fw_PM_HEX_FILE
-      ${CMAKE_BINARY_DIR}/zephyr/nrf70.hex
-      )
-    set_property(
-      GLOBAL PROPERTY
-      nrf70_wifi_fw_PM_TARGET
-      nrf70_wifi_fw_patch_target
-      )
+    # Delegate merging WiFi FW patch to mcuboot because we need to merge signed hex instead of raw nrf70.hex.
+    if(NOT CONFIG_NRF_WIFI_FW_PATCH_DFU)
+      set_property(
+        GLOBAL PROPERTY
+        nrf70_wifi_fw_PM_HEX_FILE
+        ${CMAKE_BINARY_DIR}/zephyr/nrf70.hex
+        )
+      set_property(
+        GLOBAL PROPERTY
+        nrf70_wifi_fw_PM_TARGET
+        nrf70_wifi_fw_patch_target
+        )
+    endif()
   else()
     dt_nodelabel(nrf70_fw_node NODELABEL "nrf70_fw_partition")
     if(NOT DEFINED nrf70_fw_node)

--- a/drivers/wifi/nrf700x/Kconfig
+++ b/drivers/wifi/nrf700x/Kconfig
@@ -159,6 +159,30 @@ config NRF_WIFI_FW_PATCH_INTEGRITY_CHECK
 	  SHA-256 verification algorithm.This option impacts the loading time of the
 	  nRF70 FW patches but protects against corrupted FW patches.
 
+config NRF_WIFI_FW_PATCH_DFU
+	bool "Direct Firmware Update of nRF70 FW patch"
+	depends on PARTITION_MANAGER_ENABLED
+	depends on BOOTLOADER_MCUBOOT
+	depends on !XIP_SPLIT_IMAGE
+	help
+	  Enabling this option adds support for Device Firmware Update (DFU)
+	  for the nRF70 Series Firmware Patch.
+
+	  This feature requires the addition of an MCUBoot partition pair:
+	  a primary and a secondary partition. These partitions are used to
+	  store the new firmware patch. The specific partition numbers to be used
+	  depend on the number of partitions already in use.
+
+	  The "nrf70_wifi_fw" partition must be added to the newly created
+	  MCUBoot primary partition. Once this Kconfig option is enabled,
+	  the nRF70.hex file will be signed by MCUBoot. The signed image
+	  will then be merged with the application image and flashed onto
+	  the target board.
+
+	  Ensure that the required MCUBoot partitions are properly configured
+	  before enabling this option. Refer to the documentation for detailed
+	  instructions on partition configuration and the DFU process.
+
 # TC is the default but Wi-Fi uses MbedTLS, so, to avoid loading another library.
 if NRF_WIFI_FW_PATCH_INTEGRITY_CHECK
 choice FLASH_AREA_CHECK_INTEGRITY_BACKEND

--- a/modules/mcuboot/CMakeLists.txt
+++ b/modules/mcuboot/CMakeLists.txt
@@ -707,6 +707,64 @@ CONFIG_BOOT_BUILD_DIRECT_XIP_VARIANT cannot be used with CONFIG_XIP_SPLIT_IMAGE.
       endif()
     endif()
 
+    # Targets for adding nrf70 wifi firmware patch. This workflow creates the nrf70_signed.hex and nrf70_update.bin files that can be
+    # used in DFU process, and multi-image DFU process.
+    if(CONFIG_NRF_WIFI_FW_PATCH_DFU)
+      set(nrf70_binary_name nrf70_update.bin)
+
+      sign(
+        SIGNED_BIN_FILE_IN ${PROJECT_BINARY_DIR}/nrf70.hex
+        SIGNED_HEX_FILE_NAME_PREFIX ${PROJECT_BINARY_DIR}/nrf70
+        SLOT_SIZE $<TARGET_PROPERTY:partition_manager,PM_NRF70_WIFI_FW_SIZE>
+        SIGNED_HEX_FILE_OUT nrf70_signed_hex
+        SIGNED_BIN_FILE_OUT nrf70_signed_bin
+        SIGNED_HEX_TEST_FILE_OUT nrf70_signed_test_hex
+        DEPENDS ${PROJECT_BINARY_DIR}/nrf70.hex
+      )
+
+      add_custom_target(mcuboot_nrf70_target
+        DEPENDS
+        ${nrf70_signed_hex}
+        ${nrf70_signed_bin}
+        ${nrf70_signed_test_hex}
+      )
+
+      set_property(GLOBAL PROPERTY
+        nrf70_wifi_fw_PM_HEX_FILE
+        ${nrf70_signed_hex}
+      )
+
+      set_property(GLOBAL PROPERTY
+        nrf70_wifi_fw_PM_TARGET
+        mcuboot_nrf70_target
+      )
+
+      add_dependencies(
+        mcuboot_sign_target
+        mcuboot_nrf70_target
+      )
+
+      # Add nrf70 update file to the existing bin files list before generating the zip file.
+      list(APPEND generate_bin_files
+        ${PROJECT_BINARY_DIR}/${nrf70_binary_name}
+      )
+
+      if(CONFIG_NRF53_UPGRADE_NETWORK_CORE)
+        list(APPEND generate_script_params
+         "${nrf70_binary_name}image_index=2"
+         "${nrf70_binary_name}slot_index_primary=5"
+         "${nrf70_binary_name}slot_index_secondary=6"
+        )
+      else()
+        list(APPEND generate_script_params
+          "${nrf70_binary_name}image_index=1"
+          "${nrf70_binary_name}slot_index_primary=3"
+          "${nrf70_binary_name}slot_index_secondary=4"
+        )
+      endif()
+
+    endif()
+
     generate_dfu_zip(
       OUTPUT ${PROJECT_BINARY_DIR}/dfu_application.zip
       BIN_FILES ${generate_bin_files}
@@ -821,6 +879,16 @@ CONFIG_DFU_MULTI_IMAGE_PACKAGE_BUILD cannot be used with CONFIG_XIP_SPLIT_IMAGE.
     list(APPEND dfu_multi_image_ids -2 -1)
     list(APPEND dfu_multi_image_paths "${s0_bin_path}" "${s1_bin_path}")
     list(APPEND dfu_multi_image_targets signed_s0_target signed_s1_target)
+  endif()
+
+  if(CONFIG_NRF_WIFI_FW_PATCH_DFU)
+    if (CONFIG_DFU_MULTI_IMAGE_PACKAGE_NET)
+      list(APPEND dfu_multi_image_ids 2)
+    else()
+      list(APPEND dfu_multi_image_ids 1)
+    endif()
+    list(APPEND dfu_multi_image_paths "${PROJECT_BINARY_DIR}/${nrf70_binary_name}")
+    list(APPEND dfu_multi_image_targets mcuboot_nrf70_target)
   endif()
 
   dfu_multi_image_package(dfu_multi_image_pkg

--- a/samples/matter/lock/CMakeLists.txt
+++ b/samples/matter/lock/CMakeLists.txt
@@ -16,13 +16,12 @@ if(CONF_FILE)
     get_filename_component(CONF_FILE_NAME ${CONF_FILE} NAME CACHE)
 endif()
 
-if(NOT CONF_FILE_NAME STREQUAL "prj_no_dfu.conf")
-    set(PM_STATIC_YML_FILE ${CMAKE_CURRENT_SOURCE_DIR}/configuration/${BOARD}/pm_static_dfu.yml)
-endif()
-
 if(CONF_FILE_NAME STREQUAL "prj_thread_wifi_switched.conf")
+    set(PM_STATIC_YML_FILE ${CMAKE_CURRENT_SOURCE_DIR}/configuration/${BOARD}/pm_static_dfu_wifi_ext_patch.yml)
     # TODO: Add Kconfig for adding custom Matter compilation flags
     set(CHIP_CFLAGS "-flto")
+elseif(NOT CONF_FILE_NAME STREQUAL "prj_no_dfu.conf")
+    set(PM_STATIC_YML_FILE ${CMAKE_CURRENT_SOURCE_DIR}/configuration/${BOARD}/pm_static_dfu.yml)
 endif()
 
 find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})

--- a/samples/matter/lock/README.rst
+++ b/samples/matter/lock/README.rst
@@ -96,6 +96,25 @@ Instead, the factory reset and recommissioning to a Matter fabric allows the dev
 
 See `Matter door lock build types`_, `Selecting a build type`_, and :ref:`matter_lock_sample_switching_thread_wifi` for more information about how to configure and test this feature with this sample.
 
+Wi-Fi firmware on external memory
+---------------------------------
+
+.. matter_door_lock_sample_nrf70_firmware_patch_start
+
+You can program a portion of the application code related to the nRF70 Series' Wi-Fi firmware onto an external memory to free up space in the on-chip memory.
+This option is available only when building for the nRF5340 DK with the nRF7002 EK shield attached.
+To prepare an application to use this feature, you need to create additional MCUboot partitions.
+To learn how to configure MCUboot partitions, see the :ref:`nrf70_fw_patch_update_adding_partitions` guide.
+To enable this feature for Matter, set the :kconfig:option:`CONFIG_NRF_WIFI_FW_PATCH_DFU` Kconfig option to ``y`` for the application (in the application :file:`prj.conf`) and the :kconfig:option:`CONFIG_UPDATEABLE_IMAGE_NUMBER` Kconfig option to ``3`` for the MCUBoot child image (in its own :file:`prj.conf`).
+
+.. matter_door_lock_sample_nrf70_firmware_patch_end
+
+For example:
+
+   .. code-block:: console
+
+      west build -b nrf5340dk_nrf5340_cpuapp -p -- -DSHIELD=nrf7002ek -Dmultiprotocol_rpmsg_SHIELD=nrf7002ek_coex -DCONF_FILE=prj_thread_wifi_switched.conf -DCONFIG_NRF_WIFI_PATCHES_EXT_FLASH_STORE=y -Dmcuboot_CONFIG_UPDATEABLE_IMAGE_NUMBER=3
+
 .. _matter_lock_sample_ble_nus:
 
 Matter Bluetooth LE with Nordic UART Service

--- a/samples/matter/lock/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu_wifi_ext_patch.yml
+++ b/samples/matter/lock/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu_wifi_ext_patch.yml
@@ -45,9 +45,33 @@ mcuboot_secondary_1:
   size: 0x40000
   device: MX25R64
   region: external_flash
-external_flash:
+nrf70_wifi_fw_mcuboot_pad:
   address: 0x12F000
-  size: 0x6D1000
+  size: 0x200
+  device: MX25R64
+  region: external_flash
+nrf70_wifi_fw:
+  address: 0x12F200
+  size: 0x20000
+  device: MX25R64
+  region: external_flash
+mcuboot_primary_2:
+  orig_span: &id003
+  - nrf70_wifi_fw_mcuboot_pad
+  - nrf70_wifi_fw
+  span: *id003
+  address: 0x12F000
+  size: 0x21000
+  device: MX25R64
+  region: external_flash
+mcuboot_secondary_2:
+  address: 0x150000
+  size: 0x21000
+  device: MX25R64
+  region: external_flash
+external_flash:
+  address: 0x171000
+  size: 0x68F000
   device: MX25R64
   region: external_flash
 pcd_sram:

--- a/samples/matter/lock/sample.yaml
+++ b/samples/matter/lock/sample.yaml
@@ -29,7 +29,8 @@ tests:
   sample.matter.lock.thread_wifi_switched:
     build_only: true
     extra_args: SHIELD=nrf7002ek multiprotocol_rpmsg_SHIELD=nrf7002ek_coex
-      CONF_FILE=prj_thread_wifi_switched.conf
+      CONF_FILE=prj_thread_wifi_switched.conf CONFIG_NRF_WIFI_PATCHES_EXT_FLASH_STORE=y
+      mcuboot_CONFIG_UPDATEABLE_IMAGE_NUMBER=3
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
     platform_allow: nrf5340dk_nrf5340_cpuapp

--- a/west.yml
+++ b/west.yml
@@ -154,7 +154,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: efdae04affa42dc81d51f6473fc0e148115e90b3
+      revision: 0b7d6e4909f070d20e0f5532927a7241f5de9364
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
This commit allows performing Direct Firmware Update of Wi-Fi firmware patch that is located in the external memory.
This solution requires an additional MCUBoot partition pair (primary and secondary) and including the nrf70_wifi_fw partition within the primary partition.

- Added Kconfig option to enable DFU support: NRF_WIFI_FW_PATCH_DFU
- Aligned mcuboot's CMakeLists.txt file to sign the nrf70 FW patch
image and create the signed hex.
- Added WiFi FW patch singed image to the multi-image target.

-Aligned Matter samples

TODO:

- [x] Documentation of the new feature
- [x] Align Matter configs