### PR TITLE
net: lib: nrf_cloud: Fix P-GPS non-MQTT download retries

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -916,6 +916,7 @@ Libraries for networking
 * :ref:`lib_nrf_cloud_pgps` library:
 
   * Fixed a bug in prediction set update when the :kconfig:option:`CONFIG_NRF_CLOUD_PGPS_REPLACEMENT_THRESHOLD` Kconfig option was set to non-zero value.
+  * Fixed a bug in handling errors when downloading P-GPS data that prevented retries until after a reboot.
 
 * :ref:`lib_nrf_provisioning` library:
 


### PR DESCRIPTION
The function nrf_cloud_pgps_request_reset() resets the state to one that nrf_cloud_pgps_loading() considered a loading state. This prevented the next opportunity to download again from issuing another PGPS_EVT_REQUEST.

Only set the state to PGPS_NONE on unrecoverable errors.

Jira: NCSDK-25969