### PR TITLE
lib: modem_key_mgmt: Return errors from _mgmt_exists()

### DIFF
--- a/lib/modem_key_mgmt/modem_key_mgmt.c
+++ b/lib/modem_key_mgmt/modem_key_mgmt.c
@@ -300,5 +300,5 @@ int modem_key_mgmt_exists(nrf_sec_tag_t sec_tag,
 
 out:
 	k_mutex_unlock(&key_mgmt_mutex);
-	return 0;
+	return err;
 }


### PR DESCRIPTION
After adding a mutext to protect the internal buffer, the modem_key_mgmt_exists() contained a mistake that it always returned zero, instead of erro code from AT command.