### PR TITLE
Enable nfct-pins-as-gpios for 5340 non secure

### DIFF
--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -187,7 +187,10 @@ if (CONFIG_TFM_PSA_FRAMEWORK_HAS_MM_IOVEC)
     )
 endif()
 
-if (CONFIG_NFCT_PINS_AS_GPIOS)
+# Get the nfct-pins-as-gpios property from the device tree
+dt_prop(nfct_pins_as_gpios_dt PATH "/uicr" PROPERTY "nfct-pins-as-gpios")
+
+if (CONFIG_NFCT_PINS_AS_GPIOS OR DEFINED ${nfct_pins_as_gpios_dt})
   set_property(TARGET zephyr_property_target
   APPEND PROPERTY TFM_CMAKE_OPTIONS
     -DCONFIG_NFCT_PINS_AS_GPIOS=${CONFIG_NFCT_PINS_AS_GPIOS}

--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: f3f276dd2ecad981a2abf1d87c3d3d0b2e9d5373
+      revision: fa9c0f3f38643f716bc708a0dbe629daae5ee99e
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Allows the NRF5340 non-secure target to configure configure the nfct pins through device tree, like the secure only target.