### PR TITLE
ext: oberon: Add a client view of the multipart contexts

### DIFF
--- a/ext/oberon/psa/core/include/psa/crypto_platform.h
+++ b/ext/oberon/psa/core/include/psa/crypto_platform.h
@@ -101,4 +101,14 @@ typedef struct {
 } mbedtls_psa_external_random_context_t;
 #endif /* MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG */
 
+#if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
+/** The type of the client handle used in context structures
+ *
+ * When a client view of the multipart context structures is required,
+ * this handle is used to keep a mapping with the service side of the
+ * context which contains the actual data.
+ */
+typedef uint32_t mbedtls_psa_client_handle_t;
+#endif
+
 #endif /* PSA_CRYPTO_PLATFORM_H */

--- a/ext/oberon/psa/core/include/psa/crypto_struct.h
+++ b/ext/oberon/psa/core/include/psa/crypto_struct.h
@@ -79,6 +79,9 @@ extern "C" {
 #include "psa/crypto_driver_contexts_primitives.h"
 
 struct psa_hash_operation_s {
+#if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
+    mbedtls_psa_client_handle_t handle;
+#else
     /** Unique ID indicating which driver got assigned to do the
      * operation. Since driver contexts are driver-specific, swapping
      * drivers halfway through the operation is not supported.
@@ -87,9 +90,10 @@ struct psa_hash_operation_s {
      * any driver (i.e. the driver context is not active, in use). */
     unsigned int MBEDTLS_PRIVATE(id);
     psa_driver_hash_context_t MBEDTLS_PRIVATE(ctx);
+#endif
 };
 
-#define PSA_HASH_OPERATION_INIT { 0, { 0 } }
+#define PSA_HASH_OPERATION_INIT {}
 static inline struct psa_hash_operation_s psa_hash_operation_init(void)
 {
     const struct psa_hash_operation_s v = PSA_HASH_OPERATION_INIT;
@@ -97,6 +101,9 @@ static inline struct psa_hash_operation_s psa_hash_operation_init(void)
 }
 
 struct psa_cipher_operation_s {
+#if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
+    mbedtls_psa_client_handle_t handle;
+#else
     /** Unique ID indicating which driver got assigned to do the
      * operation. Since driver contexts are driver-specific, swapping
      * drivers halfway through the operation is not supported.
@@ -111,9 +118,10 @@ struct psa_cipher_operation_s {
     uint8_t MBEDTLS_PRIVATE(default_iv_length);
 
     psa_driver_cipher_context_t MBEDTLS_PRIVATE(ctx);
+#endif
 };
 
-#define PSA_CIPHER_OPERATION_INIT { 0, 0, 0, 0, { 0 } }
+#define PSA_CIPHER_OPERATION_INIT {}
 static inline struct psa_cipher_operation_s psa_cipher_operation_init(void)
 {
     const struct psa_cipher_operation_s v = PSA_CIPHER_OPERATION_INIT;
@@ -125,6 +133,9 @@ static inline struct psa_cipher_operation_s psa_cipher_operation_init(void)
 #include "psa/crypto_driver_contexts_composites.h"
 
 struct psa_mac_operation_s {
+#if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
+    mbedtls_psa_client_handle_t handle;
+#else
     /** Unique ID indicating which driver got assigned to do the
      * operation. Since driver contexts are driver-specific, swapping
      * drivers halfway through the operation is not supported.
@@ -135,9 +146,10 @@ struct psa_mac_operation_s {
     uint8_t MBEDTLS_PRIVATE(mac_size);
     unsigned int MBEDTLS_PRIVATE(is_sign) : 1;
     psa_driver_mac_context_t MBEDTLS_PRIVATE(ctx);
+#endif
 };
 
-#define PSA_MAC_OPERATION_INIT { 0, 0, 0, { 0 } }
+#define PSA_MAC_OPERATION_INIT {}
 static inline struct psa_mac_operation_s psa_mac_operation_init(void)
 {
     const struct psa_mac_operation_s v = PSA_MAC_OPERATION_INIT;
@@ -145,6 +157,9 @@ static inline struct psa_mac_operation_s psa_mac_operation_init(void)
 }
 
 struct psa_aead_operation_s {
+#if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
+    mbedtls_psa_client_handle_t handle;
+#else
 
     /** Unique ID indicating which driver got assigned to do the
      * operation. Since driver contexts are driver-specific, swapping
@@ -167,9 +182,10 @@ struct psa_aead_operation_s {
     unsigned int MBEDTLS_PRIVATE(is_encrypt) : 1;
 
     psa_driver_aead_context_t MBEDTLS_PRIVATE(ctx);
+#endif
 };
 
-#define PSA_AEAD_OPERATION_INIT { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0 } }
+#define PSA_AEAD_OPERATION_INIT {}
 static inline struct psa_aead_operation_s psa_aead_operation_init(void)
 {
     const struct psa_aead_operation_s v = PSA_AEAD_OPERATION_INIT;
@@ -181,6 +197,9 @@ static inline struct psa_aead_operation_s psa_aead_operation_init(void)
 #include "psa/crypto_driver_contexts_key_derivation.h"
 
 struct psa_key_derivation_s {  /*!!OM*/
+#if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
+    mbedtls_psa_client_handle_t handle;
+#else
     /** Unique ID indicating which driver got assigned to do the
      * operation. Since driver contexts are driver-specific, swapping
      * drivers halfway through the operation is not supported.
@@ -205,9 +224,10 @@ struct psa_key_derivation_s {  /*!!OM*/
     size_t MBEDTLS_PRIVATE(capacity);
 
     psa_driver_key_derivation_context_t MBEDTLS_PRIVATE(ctx);
+#endif
 };
 
-#define PSA_KEY_DERIVATION_OPERATION_INIT { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0 } }
+#define PSA_KEY_DERIVATION_OPERATION_INIT {}
 static inline struct psa_key_derivation_s psa_key_derivation_operation_init(
     void)
 {
@@ -470,6 +490,9 @@ struct psa_crypto_driver_pake_inputs_s {
 };
 
 struct psa_pake_operation_s {  /*!!OM*/
+#if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
+    mbedtls_psa_client_handle_t handle;
+#else
     /** Unique ID indicating which driver got assigned to do the
     * operation. Since driver contexts are driver-specific, swapping
     * drivers halfway through the operation is not supported.
@@ -490,10 +513,11 @@ struct psa_pake_operation_s {  /*!!OM*/
 
     psa_crypto_driver_pake_inputs_t MBEDTLS_PRIVATE(inputs);
     psa_driver_pake_context_t MBEDTLS_PRIVATE(ctx);
+#endif
 };
 
 /* This only zeroes out the first byte in the union, the rest is unspecified. */
-#define PSA_PAKE_OPERATION_INIT { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { }, { } }
+#define PSA_PAKE_OPERATION_INIT {}
 static inline struct psa_pake_operation_s psa_pake_operation_init(void)
 {
     const struct psa_pake_operation_s v = PSA_PAKE_OPERATION_INIT;
@@ -504,6 +528,9 @@ static inline struct psa_pake_operation_s psa_pake_operation_init(void)
  * \brief The context for PSA interruptible hash signing.
  */
 struct psa_sign_hash_interruptible_operation_s {
+#if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
+    mbedtls_psa_client_handle_t handle;
+#else
     /** Unique ID indicating which driver got assigned to do the
      * operation. Since driver contexts are driver-specific, swapping
      * drivers halfway through the operation is not supported.
@@ -517,9 +544,10 @@ struct psa_sign_hash_interruptible_operation_s {
     unsigned int MBEDTLS_PRIVATE(error_occurred) : 1;
 
     uint32_t MBEDTLS_PRIVATE(num_ops);
+#endif
 };
 
-#define PSA_SIGN_HASH_INTERRUPTIBLE_OPERATION_INIT { 0, 0, 0, 0 }
+#define PSA_SIGN_HASH_INTERRUPTIBLE_OPERATION_INIT {}
 
 static inline struct psa_sign_hash_interruptible_operation_s
 psa_sign_hash_interruptible_operation_init(void)
@@ -534,6 +562,9 @@ psa_sign_hash_interruptible_operation_init(void)
  * \brief The context for PSA interruptible hash verification.
  */
 struct psa_verify_hash_interruptible_operation_s {
+#if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
+    mbedtls_psa_client_handle_t handle;
+#else
     /** Unique ID indicating which driver got assigned to do the
      * operation. Since driver contexts are driver-specific, swapping
      * drivers halfway through the operation is not supported.
@@ -547,9 +578,10 @@ struct psa_verify_hash_interruptible_operation_s {
     unsigned int MBEDTLS_PRIVATE(error_occurred) : 1;
 
     uint32_t MBEDTLS_PRIVATE(num_ops);
+#endif
 };
 
-#define PSA_VERIFY_HASH_INTERRUPTIBLE_OPERATION_INIT { 0, 0, 0, 0 }
+#define PSA_VERIFY_HASH_INTERRUPTIBLE_OPERATION_INIT {}
 
 static inline struct psa_verify_hash_interruptible_operation_s
 psa_verify_hash_interruptible_operation_init(void)


### PR DESCRIPTION
This is similar to https://github.com/Mbed-TLS/mbedtls/pull/8729