### PR TITLE
net: lib: nrf_cloud: Prevent simultaneous FOTA and PGPS DL

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -976,6 +976,7 @@ Libraries for networking
 
   * Fixed a bug in prediction set update when the :kconfig:option:`CONFIG_NRF_CLOUD_PGPS_REPLACEMENT_THRESHOLD` Kconfig option was set to non-zero value.
   * Fixed a bug in handling errors when downloading P-GPS data that prevented retries until after a reboot.
+  * Fixed a bug in handling errors when downloading P-GPS data does not begin due to active FOTA download.
 
 * :ref:`lib_nrf_provisioning` library:
 

--- a/subsys/net/lib/nrf_cloud/CMakeLists.txt
+++ b/subsys/net/lib/nrf_cloud/CMakeLists.txt
@@ -45,6 +45,7 @@ zephyr_library_sources_ifdef(
 	src/nrf_cloud_download.c)
 zephyr_library_sources_ifdef(
   CONFIG_NRF_CLOUD_FOTA_POLL
+  src/nrf_cloud_download.c
   src/nrf_cloud_fota_poll.c)
 zephyr_library_sources_ifdef(
 	CONFIG_NRF_CLOUD_REST

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_pgps_utils.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_pgps_utils.h
@@ -66,6 +66,7 @@ int npgps_get_time(int64_t *gps_sec, uint16_t *gps_day, uint32_t *gps_time_of_da
 /* flash block allocation functions */
 int ngps_block_pool_init(uint32_t base_address, int num);
 int npgps_alloc_block(void);
+void npgps_undo_alloc_block(int block);
 void npgps_free_block(int block);
 int npgps_get_block_extent(int block);
 void npgps_reset_block_pool(void);


### PR DESCRIPTION
The FOTA poll thread was using fota_download_start_with_image_type() directly rather than nrf_cloud_download_start() which  coordinates downloads to prevent multiple simultaneous ones.

Switch to nrf_cloud_download_start(). Debug handling of aborting the P-GPS download at the start -- the first allocated block was
not freed. 

Jira: IRIS-8255

**NOTE** this is stacked on top of https://github.com/nrfconnect/sdk-nrf/pull/14082. Merge that one first, then I can rebase and push this one.