### PR TITLE
samples: matter: Made IsGroup binding parameter optional

### DIFF
--- a/applications/matter_bridge/src/simulated_providers/simulated_onoff_light_switch_data_provider.cpp
+++ b/applications/matter_bridge/src/simulated_providers/simulated_onoff_light_switch_data_provider.cpp
@@ -22,7 +22,8 @@ void SimulatedOnOffLightSwitchDataProvider::NotifyUpdateState(chip::ClusterId cl
 {
 }
 
-void ProcessCommand(const EmberBindingTableEntry &aBinding, OperationalDeviceProxy *aDevice, Nrf::Matter::BindingHandler::BindingData &aData)
+void ProcessCommand(const EmberBindingTableEntry &aBinding, OperationalDeviceProxy *aDevice,
+		    Nrf::Matter::BindingHandler::BindingData &aData)
 {
 	CHIP_ERROR ret = CHIP_NO_ERROR;
 

--- a/samples/matter/common/src/binding/binding_handler.cpp
+++ b/samples/matter/common/src/binding/binding_handler.cpp
@@ -69,9 +69,19 @@ namespace Nrf::Matter
 		VerifyOrReturn(context != nullptr, LOG_ERR("Invalid context for device handler"));
 		BindingData *data = static_cast<BindingData *>(context);
 
-		if (binding.type == EMBER_MULTICAST_BINDING && data->IsGroup) {
+		if (binding.type == EMBER_MULTICAST_BINDING) {
+
+			if (data->IsGroup.HasValue() && !data->IsGroup.Value()) {
+				return;
+			}
+
 			data->InvokeCommandFunc(binding, nullptr, *data);
-		} else if (binding.type == EMBER_UNICAST_BINDING && !(data->IsGroup)) {
+		} else if (binding.type == EMBER_UNICAST_BINDING) {
+
+			if (data->IsGroup.HasValue() && data->IsGroup.Value()) {
+				return;
+			}
+
 			data->InvokeCommandFunc(binding, deviceProxy, *data);
 		}
 	}
@@ -96,18 +106,6 @@ namespace Nrf::Matter
 		BindingManager::GetInstance().RegisterBoundDeviceChangedHandler(DeviceChangedCallback);
 		BindingManager::GetInstance().RegisterBoundDeviceContextReleaseHandler(DeviceContextReleaseHandler);
 		BindingHandler::PrintBindingTable();
-	}
-
-	bool BindingHandler::IsGroupBound()
-	{
-		BindingTable &bindingTable = BindingTable::GetInstance();
-
-		for (auto &entry : bindingTable) {
-			if (EMBER_MULTICAST_BINDING == entry.type) {
-				return true;
-			}
-		}
-		return false;
 	}
 
 	void BindingHandler::PrintBindingTable()

--- a/samples/matter/common/src/binding/binding_handler.h
+++ b/samples/matter/common/src/binding/binding_handler.h
@@ -10,65 +10,63 @@
 #include <app/CommandSender.h>
 #include <app/clusters/bindings/BindingManager.h>
 #include <controller/InvokeInteraction.h>
+#include <lib/core/Optional.h>
 #include <platform/CHIPDeviceLayer.h>
 
 namespace Nrf::Matter
 {
-	class BindingHandler {
-	public:
-		struct BindingData;
-		using InvokeCommand = void (*)(const EmberBindingTableEntry &, chip::OperationalDeviceProxy *,
-					       BindingData &);
-		struct BindingData {
-			chip::EndpointId EndpointId;
-			chip::CommandId CommandId;
-			chip::ClusterId ClusterId;
-			InvokeCommand InvokeCommandFunc;
-			uint8_t Value;
-			bool IsGroup{ false };
-			bool CaseSessionRecovered{ false };
-		};
-
-		/**
-		 * @brief Initialaize internal actions
+class BindingHandler {
+public:
+	struct BindingData;
+	using InvokeCommand = void (*)(const EmberBindingTableEntry &, chip::OperationalDeviceProxy *, BindingData &);
+	struct BindingData {
+		chip::EndpointId EndpointId;
+		chip::CommandId CommandId;
+		chip::ClusterId ClusterId;
+		InvokeCommand InvokeCommandFunc;
+		uint8_t Value;
+		/* It can be optionally forced to apply specific command only to the group (groupcast) or only to the specific
+		 * device (unicast). The default behavior is to send data to all targets defined in the binding table.
 		 */
-		static void Init();
-		/**
-		 * @brief Print out to the log, binding table components and it's size
-		 */
-		static void PrintBindingTable();
-		/**
-		 * @brief Gives information about group binding
-		 *
-		 * @return True when group is bound
-		 */
-		static bool IsGroupBound();
-		/**
-		 * @brief Runs binding function with proper binding data, depending on the give bindingData param.
-		 *
-		 * @param bindingData BindingData structure which contain binding infroamtion
-		 */
-		static void RunBoundClusterAction(BindingData *bindingData);
-		/**
-		 * @brief Method which should be called after proper binding command execution
-		 *
-		 * @param bindingData BindingData structure which contain binding infroamtion
-		 */
-		static void OnInvokeCommandSucces(BindingData *bindingData);
-		/**
-		 * @brief Method which should be called after failed binding command execution
-		 *
-		 * @param bindingData BindingData structure which contain binding infroamtion
-		 * @param error CHIP_ERROR returned by the failed chip binding action
-		 */
-		static void OnInvokeCommandFailure(BindingData *bindingData, CHIP_ERROR error);
-
-	private:
-		static void DeviceWorkerHandler(intptr_t context);
-		static void DeviceChangedCallback(const EmberBindingTableEntry &binding,
-						  chip::OperationalDeviceProxy *deviceProxy, void *context);
-		static void DeviceContextReleaseHandler(void *context);
-		static void InitInternal();
+		chip::Optional<bool> IsGroup;
+		bool CaseSessionRecovered{ false };
 	};
+
+	/**
+	 * @brief Initialaize internal actions
+	 */
+	static void Init();
+	/**
+	 * @brief Print out to the log, binding table components and it's size
+	 */
+	static void PrintBindingTable();
+
+	/**
+	 * @brief Runs binding function with proper binding data, depending on the give bindingData param.
+	 *
+	 * @param bindingData BindingData structure which contain binding infroamtion
+	 */
+	static void RunBoundClusterAction(BindingData *bindingData);
+	/**
+	 * @brief Method which should be called after proper binding command execution
+	 *
+	 * @param bindingData BindingData structure which contain binding infroamtion
+	 */
+	static void OnInvokeCommandSucces(BindingData *bindingData);
+	/**
+	 * @brief Method which should be called after failed binding command execution
+	 *
+	 * @param bindingData BindingData structure which contain binding infroamtion
+	 * @param error CHIP_ERROR returned by the failed chip binding action
+	 */
+	static void OnInvokeCommandFailure(BindingData *bindingData, CHIP_ERROR error);
+
+private:
+	static void DeviceWorkerHandler(intptr_t context);
+	static void DeviceChangedCallback(const EmberBindingTableEntry &binding,
+					  chip::OperationalDeviceProxy *deviceProxy, void *context);
+	static void DeviceContextReleaseHandler(void *context);
+	static void InitInternal();
+};
 
 } /* namespace Nrf::Matter */

--- a/samples/matter/common/src/bridge/bridged_device_data_provider.h
+++ b/samples/matter/common/src/bridge/bridged_device_data_provider.h
@@ -11,7 +11,8 @@
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/util/attribute-storage.h>
 
-namespace Nrf {
+namespace Nrf
+{
 
 class BridgedDeviceDataProvider {
 public:

--- a/samples/matter/light_switch/src/light_switch.cpp
+++ b/samples/matter/light_switch/src/light_switch.cpp
@@ -53,7 +53,6 @@ void LightSwitch::InitiateActionSwitch(Action action)
 			Platform::Delete(data);
 			return;
 		}
-		data->IsGroup = Nrf::Matter::BindingHandler::IsGroupBound();
 		Nrf::Matter::BindingHandler::RunBoundClusterAction(data);
 	}
 }
@@ -74,7 +73,6 @@ void LightSwitch::DimmerChangeBrightness()
 			sBrightness = 0;
 		}
 		data->Value = (uint8_t)sBrightness;
-		data->IsGroup = Nrf::Matter::BindingHandler::IsGroupBound();
 		Nrf::Matter::BindingHandler::RunBoundClusterAction(data);
 	}
 }
@@ -82,7 +80,7 @@ void LightSwitch::DimmerChangeBrightness()
 void LightSwitch::SwitchChangedHandler(const EmberBindingTableEntry &binding, OperationalDeviceProxy *deviceProxy,
 				       Nrf::Matter::BindingHandler::BindingData &bindingData)
 {
-	if (binding.type == EMBER_MULTICAST_BINDING && bindingData.IsGroup) {
+	if (binding.type == EMBER_MULTICAST_BINDING) {
 		switch (bindingData.ClusterId) {
 		case Clusters::OnOff::Id:
 			OnOffProcessCommand(bindingData.CommandId, binding, nullptr, bindingData);
@@ -94,7 +92,7 @@ void LightSwitch::SwitchChangedHandler(const EmberBindingTableEntry &binding, Op
 			ChipLogError(NotSpecified, "Invalid binding group command data");
 			break;
 		}
-	} else if (binding.type == EMBER_UNICAST_BINDING && !bindingData.IsGroup) {
+	} else if (binding.type == EMBER_UNICAST_BINDING) {
 		switch (bindingData.ClusterId) {
 		case Clusters::OnOff::Id:
 			OnOffProcessCommand(bindingData.CommandId, binding, deviceProxy, bindingData);

--- a/samples/matter/light_switch/src/shell_commands.cpp
+++ b/samples/matter/light_switch/src/shell_commands.cpp
@@ -71,6 +71,7 @@ namespace Unicast
 		data->CommandId = Clusters::OnOff::Commands::On::Id;
 		data->ClusterId = Clusters::OnOff::Id;
 		data->InvokeCommandFunc = LightSwitch::SwitchChangedHandler;
+		data->IsGroup.SetValue(false);
 
 		Nrf::Matter::BindingHandler::RunBoundClusterAction(data);
 		return CHIP_NO_ERROR;
@@ -84,6 +85,7 @@ namespace Unicast
 		data->CommandId = Clusters::OnOff::Commands::Off::Id;
 		data->ClusterId = Clusters::OnOff::Id;
 		data->InvokeCommandFunc = LightSwitch::SwitchChangedHandler;
+		data->IsGroup.SetValue(false);
 
 		Nrf::Matter::BindingHandler::RunBoundClusterAction(data);
 		return CHIP_NO_ERROR;
@@ -97,6 +99,7 @@ namespace Unicast
 		data->CommandId = Clusters::OnOff::Commands::Toggle::Id;
 		data->ClusterId = Clusters::OnOff::Id;
 		data->InvokeCommandFunc = LightSwitch::SwitchChangedHandler;
+		data->IsGroup.SetValue(false);
 
 		Nrf::Matter::BindingHandler::RunBoundClusterAction(data);
 		return CHIP_NO_ERROR;
@@ -143,7 +146,7 @@ namespace Group
 		data->CommandId = Clusters::OnOff::Commands::On::Id;
 		data->ClusterId = Clusters::OnOff::Id;
 		data->InvokeCommandFunc = LightSwitch::SwitchChangedHandler;
-		data->IsGroup = true;
+		data->IsGroup.SetValue(true);
 
 		Nrf::Matter::BindingHandler::RunBoundClusterAction(data);
 		return CHIP_NO_ERROR;
@@ -157,7 +160,7 @@ namespace Group
 		data->CommandId = Clusters::OnOff::Commands::Off::Id;
 		data->ClusterId = Clusters::OnOff::Id;
 		data->InvokeCommandFunc = LightSwitch::SwitchChangedHandler;
-		data->IsGroup = true;
+		data->IsGroup.SetValue(true);
 
 		Nrf::Matter::BindingHandler::RunBoundClusterAction(data);
 		return CHIP_NO_ERROR;
@@ -171,7 +174,7 @@ namespace Group
 		data->CommandId = Clusters::OnOff::Commands::Toggle::Id;
 		data->ClusterId = Clusters::OnOff::Id;
 		data->InvokeCommandFunc = LightSwitch::SwitchChangedHandler;
-		data->IsGroup = true;
+		data->IsGroup.SetValue(true);
 
 		Nrf::Matter::BindingHandler::RunBoundClusterAction(data);
 		return CHIP_NO_ERROR;

--- a/samples/matter/thermostat/src/temperature_measurement/sensor.cpp
+++ b/samples/matter/thermostat/src/temperature_measurement/sensor.cpp
@@ -87,7 +87,6 @@ void TemperatureSensor::ExternalMeasurement()
 	Nrf::Matter::BindingHandler::BindingData *data = Platform::New<Nrf::Matter::BindingHandler::BindingData>();
 	data->ClusterId = Clusters::TemperatureMeasurement::Id;
 	data->EndpointId = mTemperatureMeasurementEndpointId;
-	data->IsGroup = BindingHandler::IsGroupBound();
 	data->InvokeCommandFunc = ExternalTemperatureMeasurementReadHandler;
 	BindingHandler::RunBoundClusterAction(data);
 }


### PR DESCRIPTION
The BindingData structure requires setting IsGroup argument, which can be used to apply specific command to only a part of binding entries (groups only or unicast only). This can be useful, but the default behavior should be sending command to all targets present in the binding table.

Changed IsGroup field to be optional. If it's not present the command will be sent to all targets. Otherwise the old filtering scheme will be used.