### PR TITLE
manifest: pull nRF54H20 extended DT from Zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: c5c7fb3967905dcaef1035ac8d5b234176a2cc0a
+      revision: 88f1d4fca1dbe5b319d8c6eab16835c61778d184
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
So that more peripherals are accessible.