### PR TITLE
lib: lte_link_control/date_time: No AT%XMONITOR or AT%XTIME=1 from AT monitor event handler

### DIFF
--- a/lib/date_time/date_time_core.c
+++ b/lib/date_time/date_time_core.c
@@ -25,10 +25,11 @@ BUILD_ASSERT(CONFIG_DATE_TIME_TOO_OLD_SECONDS <= CONFIG_DATE_TIME_UPDATE_INTERVA
 
 #define DATE_TIME_EVT_TYPE_PREVIOUS 0xFF
 
-static K_SEM_DEFINE(time_fetch_sem, 0, 1);
+K_THREAD_STACK_DEFINE(date_time_stack, CONFIG_DATE_TIME_THREAD_STACK_SIZE);
+struct k_work_q date_time_work_q;
 
-static void date_time_handler(struct k_work *work);
-static K_WORK_DELAYABLE_DEFINE(time_work, date_time_handler);
+static void date_time_update_work_fn(struct k_work *work);
+static K_WORK_DELAYABLE_DEFINE(date_time_update_work, date_time_update_work_fn);
 
 static int64_t date_time_last_update_uptime;
 static date_time_evt_handler_t app_evt_handler;
@@ -59,69 +60,59 @@ static void date_time_core_schedule_update(bool check_pending)
 		/* Don't reschedule time update work in some cases,
 		 * e.g. if time is not obtained and the work is already pending.
 		 */
-		if (check_pending && k_work_delayable_is_pending(&time_work)) {
+		if (check_pending && k_work_delayable_is_pending(&date_time_update_work)) {
 			return;
 		}
 
 		LOG_DBG("New periodic date time update in: %d seconds",
 			CONFIG_DATE_TIME_UPDATE_INTERVAL_SECONDS);
 
-		k_work_reschedule(&time_work, K_SECONDS(CONFIG_DATE_TIME_UPDATE_INTERVAL_SECONDS));
+		k_work_reschedule_for_queue(
+			&date_time_work_q,
+			&date_time_update_work,
+			K_SECONDS(CONFIG_DATE_TIME_UPDATE_INTERVAL_SECONDS));
 	}
 }
 
-static void date_time_update_thread(void)
+static void date_time_update_work_fn(struct k_work *work)
 {
 	int err;
 
-	while (true) {
-		k_sem_take(&time_fetch_sem, K_FOREVER);
+	LOG_DBG("Updating date time UTC...");
 
-		LOG_DBG("Updating date time UTC...");
-
-		err = date_time_core_current_check();
-		if (err == 0) {
-			LOG_DBG("Using previously obtained time");
-			date_time_core_schedule_update(true);
-			date_time_core_notify_event(DATE_TIME_EVT_TYPE_PREVIOUS);
-			continue;
-		}
+	err = date_time_core_current_check();
+	if (err == 0) {
+		LOG_DBG("Using previously obtained time");
+		date_time_core_schedule_update(true);
+		date_time_core_notify_event(DATE_TIME_EVT_TYPE_PREVIOUS);
+		return;
+	}
 
 #if defined(CONFIG_DATE_TIME_MODEM)
-		LOG_DBG("Getting time from cellular network");
-		int tz = DATE_TIME_TZ_INVALID;
-		int64_t date_time_ms_modem = 0;
+	LOG_DBG("Getting time from cellular network");
+	int tz = DATE_TIME_TZ_INVALID;
+	int64_t date_time_ms_modem = 0;
 
-		err = date_time_modem_get(&date_time_ms_modem, &tz);
-		if (err == 0) {
-			date_time_core_store_tz(date_time_ms_modem, DATE_TIME_OBTAINED_MODEM, tz);
-			continue;
-		}
+	err = date_time_modem_get(&date_time_ms_modem, &tz);
+	if (err == 0) {
+		date_time_core_store_tz(date_time_ms_modem, DATE_TIME_OBTAINED_MODEM, tz);
+		return;
+	}
 #endif
 #if defined(CONFIG_DATE_TIME_NTP)
-		LOG_DBG("Getting time from NTP server");
-		int64_t date_time_ms_ntp = 0;
+	LOG_DBG("Getting time from NTP server");
+	int64_t date_time_ms_ntp = 0;
 
-		err = date_time_ntp_get(&date_time_ms_ntp);
-		if (err == 0) {
-			date_time_core_store(date_time_ms_ntp, DATE_TIME_OBTAINED_NTP);
-			continue;
-		}
-#endif
-		LOG_DBG("Did not get time from any time source");
-
-		date_time_core_schedule_update(true);
-		date_time_core_notify_event(DATE_TIME_NOT_OBTAINED);
+	err = date_time_ntp_get(&date_time_ms_ntp);
+	if (err == 0) {
+		date_time_core_store(date_time_ms_ntp, DATE_TIME_OBTAINED_NTP);
+		return;
 	}
-}
+#endif
+	LOG_DBG("Did not get time from any time source");
 
-K_THREAD_DEFINE(time_thread, CONFIG_DATE_TIME_THREAD_STACK_SIZE,
-		date_time_update_thread, NULL, NULL, NULL,
-		K_LOWEST_APPLICATION_THREAD_PRIO, 0, 0);
-
-static void date_time_handler(struct k_work *work)
-{
-	k_sem_give(&time_fetch_sem);
+	date_time_core_schedule_update(true);
+	date_time_core_notify_event(DATE_TIME_NOT_OBTAINED);
 }
 
 void date_time_lte_ind_handler(const struct lte_lc_evt *const evt)
@@ -134,14 +125,12 @@ void date_time_lte_ind_handler(const struct lte_lc_evt *const evt)
 		case LTE_LC_NW_REG_REGISTERED_HOME:
 		case LTE_LC_NW_REG_REGISTERED_ROAMING:
 			if (!date_time_is_valid()) {
-				k_work_reschedule(&time_work, K_SECONDS(1));
+				k_work_reschedule_for_queue(
+					&date_time_work_q,
+					&date_time_update_work,
+					K_SECONDS(1));
 			}
 			break;
-#if defined(CONFIG_DATE_TIME_MODEM)
-		case LTE_LC_NW_REG_SEARCHING:
-			date_time_modem_xtime_subscribe();
-			break;
-#endif
 		default:
 			break;
 		}
@@ -154,6 +143,17 @@ void date_time_lte_ind_handler(const struct lte_lc_evt *const evt)
 
 void date_time_core_init(void)
 {
+	struct k_work_queue_config cfg = {
+		.name = "date_time_work_q",
+	};
+
+	k_work_queue_start(
+		&date_time_work_q,
+		date_time_stack,
+		CONFIG_DATE_TIME_THREAD_STACK_SIZE,
+		K_LOWEST_APPLICATION_THREAD_PRIO,
+		&cfg);
+
 	if (IS_ENABLED(CONFIG_DATE_TIME_AUTO_UPDATE) && IS_ENABLED(CONFIG_LTE_LINK_CONTROL)) {
 		lte_lc_register_handler(date_time_lte_ind_handler);
 	}
@@ -203,7 +203,7 @@ int date_time_core_update_async(date_time_evt_handler_t evt_handler)
 		LOG_DBG("No handler registered");
 	}
 
-	k_sem_give(&time_fetch_sem);
+	k_work_reschedule_for_queue(&date_time_work_q, &date_time_update_work, K_NO_WAIT);
 
 	return 0;
 }

--- a/lib/date_time/date_time_core.c
+++ b/lib/date_time/date_time_core.c
@@ -31,6 +31,8 @@ struct k_work_q date_time_work_q;
 static void date_time_update_work_fn(struct k_work *work);
 static K_WORK_DELAYABLE_DEFINE(date_time_update_work, date_time_update_work_fn);
 
+static K_WORK_DEFINE(date_time_update_manual_work, date_time_update_work_fn);
+
 static int64_t date_time_last_update_uptime;
 static date_time_evt_handler_t app_evt_handler;
 
@@ -203,7 +205,8 @@ int date_time_core_update_async(date_time_evt_handler_t evt_handler)
 		LOG_DBG("No handler registered");
 	}
 
-	k_work_reschedule_for_queue(&date_time_work_q, &date_time_update_work, K_NO_WAIT);
+	/* Cannot reschedule date_time_update_work because it would mess up normal update cycle */
+	k_work_submit_to_queue(&date_time_work_q, &date_time_update_manual_work);
 
 	return 0;
 }

--- a/lib/date_time/date_time_modem.h
+++ b/lib/date_time/date_time_modem.h
@@ -9,6 +9,5 @@
 
 int date_time_modem_get(int64_t *date_time_ms, int *tz);
 void date_time_modem_store(struct tm *ltm, int tz);
-void date_time_modem_xtime_subscribe(void);
 
 #endif /* DATE_TIME_MODEM_H_ */

--- a/lib/lte_link_control/lte_lc_helpers.h
+++ b/lib/lte_link_control/lte_lc_helpers.h
@@ -227,6 +227,7 @@ int encode_psm(char *tau_ext_str, char *active_time_str, int rptau, int rat);
  *		     Can be NULL.
  * @param cell Pointer to cell information struct. Can be NULL.
  * @param lte_mode Pointer to LTE mode struct. Can be NULL.
+ * @param psm_cfg Pointer to PSM configuration struct. Can be NULL.
  *
  * @return Zero on success or (negative) error code otherwise.
  */
@@ -234,7 +235,8 @@ int parse_cereg(const char *at_response,
 		bool is_notif,
 		enum lte_lc_nw_reg_status *reg_status,
 		struct lte_lc_cell *cell,
-		enum lte_lc_lte_mode *lte_mode);
+		enum lte_lc_lte_mode *lte_mode,
+		struct lte_lc_psm_cfg *psm_cfg);
 
 /* @brief Parses an XT3412 response and extracts the time until next TAU.
  *

--- a/samples/cellular/modem_shell/prj.conf
+++ b/samples/cellular/modem_shell/prj.conf
@@ -91,15 +91,10 @@ CONFIG_NRF_MODEM_LIB_ON_FAULT_APPLICATION_SPECIFIC=y
 # AT monitor library
 CONFIG_AT_MONITOR=y
 
-# Increase AT monitor heap because of the two use cases:
-# - %NCELLMEAS notifications can be closer to a kilobyte
-#   Note: with legacy NCELLMEAS types, 512 is enough, but with GCI search types
-#         it could be even longer: theoretical maximum of 4020 bytes.
-# - When AT+COPS=? is used for network search, it'll block and at the same time AT notifications
-#   can be coming in, and some of them may trigger new AT commands which cannot be executed.
-#   All this will reserve notificatons from AT monitor heap. While there will always be a chance
-#   this heap is too small, 1kB has caused issues.
-CONFIG_AT_MONITOR_HEAP_SIZE=2048
+# Increase AT monitor heap because %NCELLMEAS notifications can be long.
+# Note: with legacy NCELLMEAS types, 512 is enough, but with GCI search types
+# it could be even longer: theoretical maximum of 4020 bytes.
+CONFIG_AT_MONITOR_HEAP_SIZE=1024
 
 # Custom AT commands
 CONFIG_AT_CMD_CUSTOM=y

--- a/tests/lib/lte_lc/src/main.c
+++ b/tests/lib/lte_lc/src/main.c
@@ -89,86 +89,86 @@ void test_parse_cereg(void)
 	/* For CEREG reads, we only check the network status, as that's the only
 	 * functionality that is exposed.
 	 */
-	err = parse_cereg(at_response_0, false, &status, NULL, NULL);
+	err = parse_cereg(at_response_0, false, &status, NULL, NULL, NULL);
 	TEST_ASSERT_EQUAL(0, err);
 	TEST_ASSERT_EQUAL(LTE_LC_NW_REG_NOT_REGISTERED, status);
 
-	err = parse_cereg(at_response_1, false, &status, &cell, &mode);
+	err = parse_cereg(at_response_1, false, &status, &cell, &mode, NULL);
 	TEST_ASSERT_EQUAL(0, err);
 	TEST_ASSERT_EQUAL(LTE_LC_NW_REG_REGISTERED_HOME, status);
 	TEST_ASSERT_EQUAL(0x01020304, cell.id);
 	TEST_ASSERT_EQUAL(0x0A0B, cell.tac);
 
-	err = parse_cereg(at_response_2, false, &status, NULL, NULL);
+	err = parse_cereg(at_response_2, false, &status, NULL, NULL, NULL);
 	TEST_ASSERT_EQUAL(0, err);
 	TEST_ASSERT_EQUAL(LTE_LC_NW_REG_SEARCHING, status);
 
-	err = parse_cereg(at_response_3, false, &status, NULL, NULL);
+	err = parse_cereg(at_response_3, false, &status, NULL, NULL, NULL);
 	TEST_ASSERT_EQUAL(0, err);
 	TEST_ASSERT_EQUAL(LTE_LC_NW_REG_REGISTRATION_DENIED, status);
 
-	err = parse_cereg(at_response_4, false, &status, NULL, NULL);
+	err = parse_cereg(at_response_4, false, &status, NULL, NULL, NULL);
 	TEST_ASSERT_EQUAL(0, err);
 	TEST_ASSERT_EQUAL(LTE_LC_NW_REG_UNKNOWN, status);
 
-	err = parse_cereg(at_response_5, false, &status, NULL, NULL);
+	err = parse_cereg(at_response_5, false, &status, NULL, NULL, NULL);
 	TEST_ASSERT_EQUAL(0, err);
 	TEST_ASSERT_EQUAL(LTE_LC_NW_REG_REGISTERED_ROAMING, status);
 
-	err = parse_cereg(at_response_90, false, &status, NULL, NULL);
+	err = parse_cereg(at_response_90, false, &status, NULL, NULL, NULL);
 	TEST_ASSERT_EQUAL(0, err);
 	TEST_ASSERT_EQUAL(LTE_LC_NW_REG_UICC_FAIL, status);
 
-	err = parse_cereg(at_response_wrong, false, &status, NULL, NULL);
+	err = parse_cereg(at_response_wrong, false, &status, NULL, NULL, NULL);
 	TEST_ASSERT_NOT_EQUAL_MESSAGE(0, err, "parse_cereg should have failed");
 
 	/* For CEREG notifications, we test the parser function, which
 	 * implicitly also tests parse_nw_reg_status() for notifications.
 	 */
-	err = parse_cereg(at_notif_0, true, &status, &cell, &mode);
+	err = parse_cereg(at_notif_0, true, &status, &cell, &mode, NULL);
 	TEST_ASSERT_EQUAL(0, err);
 	TEST_ASSERT_EQUAL(LTE_LC_NW_REG_NOT_REGISTERED, status);
 
-	err = parse_cereg(at_notif_1, true, &status, &cell, &mode);
+	err = parse_cereg(at_notif_1, true, &status, &cell, &mode, NULL);
 	TEST_ASSERT_EQUAL(0, err);
 	TEST_ASSERT_EQUAL(LTE_LC_NW_REG_REGISTERED_HOME, status);
 	TEST_ASSERT_EQUAL(0x01020304, cell.id);
 	TEST_ASSERT_EQUAL(0x0A0B, cell.tac);
 	TEST_ASSERT_EQUAL(9, mode);
 
-	err = parse_cereg(at_notif_2, true, &status, &cell, &mode);
+	err = parse_cereg(at_notif_2, true, &status, &cell, &mode, NULL);
 	TEST_ASSERT_EQUAL(0, err);
 	TEST_ASSERT_EQUAL(LTE_LC_NW_REG_SEARCHING, status);
 	TEST_ASSERT_EQUAL(0x01020304, cell.id);
 	TEST_ASSERT_EQUAL(0x0A0B, cell.tac);
 	TEST_ASSERT_EQUAL(9, mode);
 
-	err = parse_cereg(at_notif_3, true, &status, &cell, &mode);
+	err = parse_cereg(at_notif_3, true, &status, &cell, &mode, NULL);
 	TEST_ASSERT_EQUAL(0, err);
 	TEST_ASSERT_EQUAL(LTE_LC_NW_REG_REGISTRATION_DENIED, status);
 	TEST_ASSERT_EQUAL(0x01020304, cell.id);
 	TEST_ASSERT_EQUAL(0x0A0B, cell.tac);
 	TEST_ASSERT_EQUAL(9, mode);
 
-	err = parse_cereg(at_notif_4, true, &status, &cell, &mode);
+	err = parse_cereg(at_notif_4, true, &status, &cell, &mode, NULL);
 	TEST_ASSERT_EQUAL(0, err);
 	TEST_ASSERT_EQUAL(LTE_LC_NW_REG_UNKNOWN, status);
 	TEST_ASSERT_EQUAL(0xFFFFFFFF, cell.id);
 	TEST_ASSERT_EQUAL(0xFFFF, cell.tac);
 	TEST_ASSERT_EQUAL(9, mode);
 
-	err = parse_cereg(at_notif_5, true, &status, &cell, &mode);
+	err = parse_cereg(at_notif_5, true, &status, &cell, &mode, NULL);
 	TEST_ASSERT_EQUAL(0, err);
 	TEST_ASSERT_EQUAL(LTE_LC_NW_REG_REGISTERED_ROAMING, status);
 	TEST_ASSERT_EQUAL(0x01020304, cell.id);
 	TEST_ASSERT_EQUAL(0x0A0B, cell.tac);
 	TEST_ASSERT_EQUAL(9, mode);
 
-	err = parse_cereg(at_notif_90, true, &status, &cell, &mode);
+	err = parse_cereg(at_notif_90, true, &status, &cell, &mode, NULL);
 	TEST_ASSERT_EQUAL(0, err);
 	TEST_ASSERT_EQUAL(LTE_LC_NW_REG_UICC_FAIL, status);
 
-	err = parse_cereg(at_notif_wrong, true, &status, &cell, &mode);
+	err = parse_cereg(at_notif_wrong, true, &status, &cell, &mode, NULL);
 	TEST_ASSERT_NOT_EQUAL_MESSAGE(0, err, "parse_cereg should have failed");
 }
 

--- a/tests/lib/lte_lc_api/src/lte_lc_api_test.c
+++ b/tests/lib/lte_lc_api/src/lte_lc_api_test.c
@@ -313,16 +313,6 @@ void test_lte_lc_connect_success(void)
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT+CSCON=1", 0);
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT+CFUN=1", 0);
 
-	static const char xmonitor_resp[] =
-		"%XMONITOR: 1,\"Operator\",\"OP\",\"20065\",\"002F\",7,20,\"0012BEEF\","
-		"334,6200,66,44,\"\","
-		"\"00000101\",\"00010011\",\"01001001\"";
-	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
-	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
-	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
-	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
-		(char *)xmonitor_resp, sizeof(xmonitor_resp));
-
 	/* AT commands triggered by lte_lc_offline() */
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT+CFUN=4", 0);
 
@@ -355,7 +345,7 @@ void test_lte_lc_connect_success(void)
 	test_event_data[6].lte_mode = LTE_LC_LTE_MODE_NONE;
 
 	/* Schedule +CEREG notification to be dispatched while lte_lc_connect() blocks */
-	strcpy(at_notif, "+CEREG: 1,\"002F\",\"0012BEEF\",7\r\n");
+	strcpy(at_notif, "+CEREG: 1,\"002F\",\"0012BEEF\",7,,,\"00000101\",\"00010011\"\r\n");
 	k_work_schedule(&at_notif_dispatch_work, K_MSEC(1));
 
 	ret = lte_lc_connect();
@@ -405,7 +395,7 @@ void test_lte_lc_connect_fallback(void)
 	static const char xmonitor_resp[] =
 		"%XMONITOR: 5,\"Operator\",\"OP\",\"20065\",\"003F\",9,20,\"0013BEEF\","
 		"334,6200,66,44,\"\","
-		"\"11100000\",\"00101000\",\"11100000\"";
+		"\"11100000\",\"11100000\",\"00111000\"";
 	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
 	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
 	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
@@ -429,7 +419,7 @@ void test_lte_lc_connect_fallback(void)
 	test_event_data[2].lte_mode = LTE_LC_LTE_MODE_NBIOT;
 
 	test_event_data[3].type = LTE_LC_EVT_PSM_UPDATE;
-	test_event_data[3].psm_cfg.tau = 28800;
+	test_event_data[3].psm_cfg.tau = 1440;
 	test_event_data[3].psm_cfg.active_time = -1;
 
 	/* De-registration */
@@ -449,12 +439,12 @@ void test_lte_lc_connect_fallback(void)
 	TEST_ASSERT_EQUAL(0, ret);
 
 	/* Schedule +CEREG notification to be dispatched after timeout to trigger fallback */
-	strcpy(at_notif, "+CEREG: 5,\"003F\",\"0013BEEF\",9\r\n");
+	strcpy(at_notif, "+CEREG: 5,\"003F\",\"0013BEEF\",9,,,\"11100000\",\"11100000\"\r\n");
 	k_work_schedule(&at_notif_dispatch_work, K_MSEC(1100));
 
 	ret = lte_lc_connect();
 	TEST_ASSERT_EQUAL(0, ret);
-
+	k_sleep(K_MSEC(1));
 	ret = lte_lc_offline();
 	TEST_ASSERT_EQUAL(0, ret);
 
@@ -1045,11 +1035,6 @@ void test_lte_lc_cereg(void)
 {
 	strcpy(at_notif, "+CEREG: 1,\"4321\",\"12345678\",7,,,\"11100000\",\"00010011\"\r\n");
 
-	static const char xmonitor_resp[] =
-		"%XMONITOR: 1,\"Operator\",\"OP\",\"20065\",\"4321\",7,20,\"12345678\","
-		"334,6200,66,44,\"\","
-		"\"11100000\",\"00010011\",\"01001001\"";
-
 	lte_lc_callback_count_expected = 4;
 
 	test_event_data[0].type = LTE_LC_EVT_NW_REG_STATUS;
@@ -1075,6 +1060,43 @@ void test_lte_lc_cereg(void)
 	test_event_data[3].psm_cfg.tau = 11400;
 	test_event_data[3].psm_cfg.active_time = -1;
 
+	at_monitor_dispatch(at_notif);
+}
+
+void test_lte_lc_cereg_with_xmonitor(void)
+{
+	strcpy(at_notif, "+CEREG: 5,\"4321\",\"87654321\",9,,,\"11100000\",\"11100000\"\r\n");
+
+	static const char xmonitor_resp[] =
+		"%XMONITOR: 1,\"Operator\",\"OP\",\"20065\",\"4321\",9,20,\"12345678\","
+		"334,6200,66,44,\"\","
+		"\"11100000\",\"11100000\",\"01001001\"";
+
+	lte_lc_callback_count_expected = 4;
+
+	test_event_data[0].type = LTE_LC_EVT_NW_REG_STATUS;
+	test_event_data[0].nw_reg_status = LTE_LC_NW_REG_REGISTERED_ROAMING;
+
+	test_event_data[1].type = LTE_LC_EVT_CELL_UPDATE;
+	test_event_data[1].cell.mcc = 0;
+	test_event_data[1].cell.mnc = 0;
+	test_event_data[1].cell.id = 0x87654321;
+	test_event_data[1].cell.tac = 0x4321;
+	test_event_data[1].cell.earfcn = 0;
+	test_event_data[1].cell.timing_advance = 0;
+	test_event_data[1].cell.timing_advance_meas_time = 0;
+	test_event_data[1].cell.measurement_time = 0;
+	test_event_data[1].cell.phys_cell_id = 0;
+	test_event_data[1].cell.rsrp = 0;
+	test_event_data[1].cell.rsrq = 0;
+
+	test_event_data[2].type = LTE_LC_EVT_LTE_MODE_UPDATE;
+	test_event_data[2].lte_mode = LTE_LC_LTE_MODE_NBIOT;
+
+	test_event_data[3].type = LTE_LC_EVT_PSM_UPDATE;
+	test_event_data[3].psm_cfg.tau = 3240;
+	test_event_data[3].psm_cfg.active_time = -1;
+
 	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
 	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
 	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
@@ -1082,6 +1104,7 @@ void test_lte_lc_cereg(void)
 		(char *)xmonitor_resp, sizeof(xmonitor_resp));
 
 	at_monitor_dispatch(at_notif);
+	k_sleep(K_MSEC(1));
 }
 
 /* Test the following CEREG syntax:


### PR DESCRIPTION
Components shouldn't be sending AT commands from system work queue because other AT commands might be ongoing, and the 2nd command will be stuck until the first one completes.

If there is an AT command ongoing by other apps/libraries, and CEREG is received from AT monitor:

- lte_lc will query for PSM parameters using `AT%XMONITOR` when we go to connected state (status 1 or 5). This was done in AT monitor event handler, which is executed in the system workqueue.
- date_time library is sending `AT%XTIME=1` whenever modem goes to search state (CEREG: 2). This happens in lte_lc event handler which is called from at_monitor in system work queue.

As the event handlers are not executed, AT monitor heap will run out and assert.

AT%XMONITOR is moved to an own work queue within lte_lc.
`AT%XTIME=1` is moved to an own work queue within date_time.

We are now also able to revert increase of CONFIG_AT_MONITOR_HEAP_SIZE from 1kB to 2kB in modem shell.

Jira: MOSH-551