### PR TITLE
manifest: pull Matter implementation of extended BLE advertising

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -154,7 +154,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 623ef0a639167458d86ae83414aa78285e90b34d
+      revision: c86d08ac32077d52d4e29551ac2bce39e63020bf
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
This patch pulls the code that implements the extended advertising Matter feature that can be enabled with
CONFIG_CHIP_DEVICE_CONFIG_BLE_EXT_ADVERTISING.