### PR TITLE
drivers: wifi: Fix duplicated logger object names

### DIFF
--- a/drivers/wifi/nrf700x/src/qspi/src/qspi_if.c
+++ b/drivers/wifi/nrf700x/src/qspi/src/qspi_if.c
@@ -102,7 +102,7 @@ static void qspi_device_uninit(const struct device *dev);
 #define QSPI_SCK_DELAY 0
 #define WORD_SIZE 4
 
-LOG_MODULE_DECLARE(wifi_nrf, CONFIG_WIFI_NRF700X_BUS_LOG_LEVEL);
+LOG_MODULE_DECLARE(wifi_nrf_bus, CONFIG_WIFI_NRF700X_BUS_LOG_LEVEL);
 
 /**
  * @brief QSPI buffer structure

--- a/drivers/wifi/nrf700x/src/qspi/src/rpu_hw_if.c
+++ b/drivers/wifi/nrf700x/src/qspi/src/rpu_hw_if.c
@@ -22,7 +22,7 @@
 #include "qspi_if.h"
 #include "spi_if.h"
 
-LOG_MODULE_DECLARE(wifi_nrf, CONFIG_WIFI_NRF700X_BUS_LOG_LEVEL);
+LOG_MODULE_REGISTER(wifi_nrf_bus, CONFIG_WIFI_NRF700X_BUS_LOG_LEVEL);
 
 #define NRF7002_NODE DT_NODELABEL(nrf700x)
 

--- a/drivers/wifi/nrf700x/src/qspi/src/spi_if.c
+++ b/drivers/wifi/nrf700x/src/qspi/src/spi_if.c
@@ -17,7 +17,7 @@
 #include "qspi_if.h"
 #include "spi_if.h"
 
-LOG_MODULE_DECLARE(wifi_nrf, CONFIG_WIFI_NRF700X_BUS_LOG_LEVEL);
+LOG_MODULE_DECLARE(wifi_nrf_bus, CONFIG_WIFI_NRF700X_BUS_LOG_LEVEL);
 
 #define NRF7002_NODE DT_NODELABEL(nrf700x)
 


### PR DESCRIPTION
Fixed Wi-Fi driver bus layer logger registering (duplicated logger symbol with different log levels)

@krish2718 the problem with Wi-Fi driver is not visible in Wi-Fi samples because they use the same default
value for both `CONFIG_WIFI_NRF700X_LOG_LEVEL` and `CONFIG_WIFI_NRF700X_BUS_LOG_LEVEL`.
Note that it was not reproducible with LOG_MODE_MINIMAL, because this mode does not really use log objects.