### PR TITLE
Set feature experimental

### DIFF
--- a/drivers/wifi/nrf700x/Kconfig
+++ b/drivers/wifi/nrf700x/Kconfig
@@ -83,6 +83,7 @@ config NRF700X_RAW_DATA_TX
 
 config NRF700X_RAW_DATA_RX
 	bool "Enable RAW RX sniffer operation in the driver"
+	select EXPERIMENTAL
 	depends on NRF700X_SYSTEM_MODE
 
 config NRF_WIFI_IF_AUTO_START

--- a/drivers/wifi/nrf700x/Kconfig
+++ b/drivers/wifi/nrf700x/Kconfig
@@ -78,6 +78,7 @@ config NRF700X_DATA_TX
 
 config NRF700X_RAW_DATA_TX
 	bool "Enable RAW TX data path in the driver"
+	select EXPERIMENTAL
 	depends on NRF700X_SYSTEM_MODE
 
 config NRF700X_RAW_DATA_RX


### PR DESCRIPTION
This marks both Monitor mode and RAW TX mode as experimental features in the Kconfig