### PR TITLE
doc: wifi: replace "nRF70 Series Wi-Fi driver" with nRF Wi-Fi driver

### DIFF
--- a/doc/nrf/device_guides/working_with_nrf/nrf70/developing/fw_patches_ext_flash.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf70/developing/fw_patches_ext_flash.rst
@@ -15,10 +15,10 @@ This guide explains the available options for having the nRF70 Series firmware p
 Overview
 ********
 
-By default the nRF70 Series firmware patches are built as part of the nRF Wi-Fi® host driver code, residing in on-chip memory.
+By default the nRF70 Series firmware patches are built as part of the nRF Wi-Fi driver code, residing in on-chip memory.
 The firmware patches include code that is executed on the nRF70 Series device.
 The size of the firmware patches may be considerably large, which limits the amount of on-chip code memory available for the user application.
-In order to increase the amount of on-chip memory available for user applications, the nRF70 Series Wi-Fi driver supports the option of using external memory, if that is available.
+In order to increase the amount of on-chip memory available for user applications, the nRF Wi-Fi driver supports the option of using external memory, if that is available.
 
 Prerequisites
 =============

--- a/doc/nrf/device_guides/working_with_nrf/nrf70/developing/stack_partitioning.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf70/developing/stack_partitioning.rst
@@ -8,7 +8,7 @@ Networking stack partitioning
    :depth: 2
 
 The nRF70 Series of wireless companion ICs implement the Physical (PHY) and Medium Access Control (MAC) layers of the IEEE 802.11 protocol stack.
-The higher layers of the networking stack, namely, the Wi-Fi driver and supplicant, the TCP/IP stack, and the networking application layers, run on the host device.
+The higher layers of the networking stack, namely, the nRF Wi-Fi driver and supplicant, the TCP/IP stack, and the networking application layers, run on the host device.
 Data transfer between the host and the nRF70 companion device can occur through either SPI or QSPI interfaces.
 
 The following figure illustrates the partitioning of the Wi-Fi stack between the nRF70 Series device and the host device:

--- a/doc/nrf/device_guides/working_with_nrf/nrf70/gs.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf70/gs.rst
@@ -25,7 +25,7 @@ Overview
 The nRF7002 DK (PCA10143) is a single-board development kit for evaluation and development on the nRF7002, a Wi-Fi companion :term:`Integrated Circuit (IC)` to Nordic Semiconductor's nRF5340 System-on-Chip (SoC) host processor.
 
 The nRF7002 is an IEEE 802.11ax (Wi-Fi 6) compliant solution that implements the Wi-Fi physical layer and Medium Access Control (MAC) layer protocols.
-It implements the Wi-Fi driver software on the nRF5340 host processor communicating over the QSPI bus.
+It implements the nRF Wi-Fi driver software on the nRF5340 host processor communicating over the QSPI bus.
 
 The nRF5340 host is a dual-core SoC based on the Arm® Cortex®-M33 architecture.
 It has the following features:

--- a/doc/nrf/drivers/wifi/nrf700x/nrf700x.rst
+++ b/doc/nrf/drivers/wifi/nrf700x/nrf700x.rst
@@ -1,39 +1,39 @@
 .. _nrf700x_wifi:
 
-nRF70 Series Wi-Fi driver
-#########################
+nRF Wi-Fi driver
+################
 
 .. contents::
    :local:
    :depth: 2
 
-This driver implements the Wi-Fi® protocol for the nRF70 FullMAC Series of devices.
+The nRF Wi-Fi driver implements the Wi-Fi® protocol for the nRF70 FullMAC Series of devices.
 FullMAC devices implement the Wi-Fi protocol in the chipset.
 The driver configures the chipset and transfers the frames to and from the device to the networking stack.
 
-nRF70 Series device is a companion IC and can be used with any Nordic Semiconductor System-on-Chips (SoCs) such as the nRF53 and nRF91 Series SoCs.
+nRF70 Series device is a companion IC and can be used with any Nordic Semiconductor System-on-Chips (SoCs), such as the nRF53 and nRF91 Series SoCs.
 
 You can enable the driver by using the :kconfig:option:`CONFIG_WIFI_NRF700X` Kconfig option.
 
 Architecture
 *************
 
-The following figure illustrates the architecture of the nRF70 Series Wi-Fi driver.
+The following figure illustrates the architecture of the nRF Wi-Fi driver.
 
 .. figure:: /images/nrf700x_wifi_driver.svg
-   :alt: nRF70 Series Wi-Fi driver block diagram
+   :alt: nRF Wi-Fi driver block diagram
    :align: center
    :figclass: align-center
 
-   nRF70 Series Wi-Fi driver architecture overview
+   nRF Wi-Fi driver architecture overview
 
 Design overview
 ***************
 
-The nRF70 Series Wi-Fi driver follows an OS agnostic design, and the driver implementation is split into OS agnostic and OS (Zephyr) specific code.
+The nRF Wi-Fi driver follows an OS agnostic design, and the driver implementation is split into OS agnostic and OS (Zephyr) specific code.
 The OS agnostic code is located in the :file:`drivers/wifi/nrf700x/osal/` folder and the OS specific code is located in the :file:`drivers/wifi/nrf700x/zephyr/` folder.
 
-The driver supports two modes of operations:
+The driver supports two modes of operation:
 
 Wi-Fi mode
 ==========
@@ -43,21 +43,19 @@ It is implemented as a network interface driver.
 The driver supports the following IEEE 802.11 features:
 
 * Wi-Fi 6 (802.11ax) support
-* WPA3/WPA2 personal security
+* WPA3™/WPA2™ personal security
 * IEEE 802.11 Power Save modes
-* Scan only mode
-* IEEE 802.11 Station (STA) mode
+* Scan-only mode
+* IEEE 802.11 :term:`Station mode (STA)`
+* :term:`Software-enabled Access Point (SoftAP or SAP)` mode
 
-The following features are in the driver code but not yet supported:
+The Wi-Fi Direct® mode feature is in the driver code but is not yet supported.
 
-* IEEE 802.11 AP mode (Soft AP)
-* Wi-Fi Direct mode
-
-Except for scan only mode, the driver uses host access point daemon (hostapd) to implement AP Media Access Control (MAC) Sublayer Management Entity (AP MLME) and wpa_supplicant to implement 802.1X supplicant.
+Except for scan-only mode, the driver uses the host access point daemon (hostapd) to implement AP Media Access Control (MAC) Sublayer Management Entity (AP MLME) and wpa_supplicant to implement 802.1X supplicant.
 
 Radio Test mode
 ===============
-The nRF70 Series Wi-Fi driver supports Radio Test mode, which you can use to test the RF performance of the nRF70 Series device.
+The nRF Wi-Fi driver supports Radio Test mode, which you can use to test the RF performance of the nRF70 Series device.
 This is a build time option that you can enable using the :kconfig:option:`CONFIG_NRF700X_RADIO_TEST` Kconfig option.
 
 For more details about using this driver in Radio Test mode, see :ref:`wifi_radio_test`.
@@ -66,15 +64,15 @@ Driver to nRF70 Series device communication
 *******************************************
 
 The driver communicates with the nRF70 Series device using the QSPI/SPI interface.
-The driver uses the QSPI/SPI interface to send commands to the nRF70 Series device, and to transfer the data to and from the device.
-The nRF7002 DK uses QSPI whereas the nRF7002 EK uses SPI.
+The driver uses the QSPI/SPI interface to send commands to the nRF70 Series device, and to transfer data to and from the device.
+The nRF7002 DK uses QSPI, whereas the nRF7002 EK uses SPI.
 
 To connect the nRF7002 EK to the SoC, the ``nrf7002ek`` shield is required.
 
 Configuration
 *************
 
-The nRF70 Series Wi-Fi driver has the following configuration options:
+The nRF Wi-Fi driver has the following configuration options:
 
 Kconfig configuration
 =====================
@@ -150,7 +148,7 @@ The following table lists the parameters (8-bit unsigned values) defined in the 
 API documentation
 *****************
 
-After the nRF70 Series driver has been initialized, the application will see it as an Ethernet interface.
+After the nRF Wi-Fi driver has been initialized, the application will see it as an Ethernet interface.
 To use the Ethernet interface, the application can use `Zephyr Network APIs`_.
 
 See the :ref:`nrfxlib:nrf_wifi_api` to learn more about various modes of low-level API.


### PR DESCRIPTION
Replaced "nRF70 Series Wi-Fi driver" with "nRF Wi-Fi driver" in user guides under "Working with nRF70 Series".