### PR TITLE
applications: nrf5340_audio: Fix CIS TWS MIC stream disappeared

### DIFF
--- a/applications/nrf5340_audio/unicast_client/main.c
+++ b/applications/nrf5340_audio/unicast_client/main.c
@@ -255,6 +255,17 @@ static void le_audio_msg_sub_thread(void)
 			ERR_CHK(ret);
 			break;
 
+		case LE_AUDIO_EVT_NO_VALID_CFG:
+			LOG_WRN("No valid configurations found or CIS establishment failed, will "
+				"disconnect");
+
+			ret = bt_mgmt_conn_disconnect(msg.conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+			if (ret) {
+				LOG_ERR("Failed to disconnect: %d", ret);
+			}
+
+			break;
+
 		default:
 			LOG_WRN("Unexpected/unhandled le_audio event: %d", msg.event);
 			break;


### PR DESCRIPTION
Fixed the issue that CIS gateway might not setup MIC stream properly. There could be a chance the sink stream setup failed, but before the retry, the source stream from same ISO setup properly which also setup the sink. This cause the state out of sync for retrying, and leads to retry mechanism failed.
OCT-NONE
Signed-off-by: Jui-Chou Chung <jui-chou.chung@nordicsemi.no>