### PR TITLE
manifest: sdk-zephyr: ensure the sh is valid before call shell_printf

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 9568c08251ee2fa29520ebe998762b72ccec4ecd
+      revision: d0effecc0cbcce1fc40659577237265ce1817ae3
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
It is possible that the `sh` was not set before use. This change adds a NULL check for `sh` in the following macros: PR, PR_SHELL, PR_ERROR, PR_INFO, and PR_WARNING.