### PR TITLE
Update failure stats for raw tx failure

### DIFF
--- a/drivers/wifi/nrf700x/src/net_if.c
+++ b/drivers/wifi/nrf700x/src/net_if.c
@@ -982,6 +982,9 @@ int nrf_wifi_stats_get(const struct device *dev, struct net_stats_wifi *zstats)
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
 	struct nrf_wifi_ctx_zep *rpu_ctx_zep = NULL;
 	struct nrf_wifi_vif_ctx_zep *vif_ctx_zep = NULL;
+#ifdef CONFIG_NRF700X_RAW_DATA_TX
+	struct nrf_wifi_fmac_dev_ctx_def *def_dev_ctx = NULL;
+#endif /* CONFIG_NRF700X_RAW_DATA_TX */
 	struct rpu_op_stats stats;
 	int ret = -1;
 
@@ -1034,6 +1037,10 @@ int nrf_wifi_stats_get(const struct device *dev, struct net_stats_wifi *zstats)
 	zstats->multicast.rx = stats.fw.umac.interface_data_stats.rx_multicast_pkt_count;
 	zstats->multicast.tx = stats.fw.umac.interface_data_stats.tx_multicast_pkt_count;
 
+#ifdef CONFIG_NRF700X_RAW_DATA_TX
+	def_dev_ctx = wifi_dev_priv(rpu_ctx_zep->rpu_ctx);
+	zstats->errors.tx += def_dev_ctx->raw_pkt_stats.raw_pkt_send_failure;
+#endif /* CONFIG_NRF700X_RAW_DATA_TX */
 	ret = 0;
 unlock:
 	k_mutex_unlock(&vif_ctx_zep->vif_lock);

--- a/west.yml
+++ b/west.yml
@@ -142,7 +142,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: b59f7fdb594e4d4e29d6a0b5b24c3ee4aa38627b
+      revision: 2bdf611d8227c7a0cac12cc355f7b867ec0b3e82
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
This set of changes pulls in raw tx failure count updation when tx done from firmware indicates failure