### PR TITLE
net: lib: nrf_cloud_coap: Fix ground-fix response error

### DIFF
--- a/samples/cellular/nrf_cloud_multi_service/overlay-coap_nrf_provisioning.conf
+++ b/samples/cellular/nrf_cloud_multi_service/overlay-coap_nrf_provisioning.conf
@@ -34,7 +34,8 @@ CONFIG_SHELL_WILDCARD=n
 CONFIG_NRF_PROVISIONING_CODEC=y
 CONFIG_NRF_PROVISIONING_CBOR=y
 CONFIG_ZCBOR=y
-CONFIG_ZCBOR_CANONICAL=y
+# Not compatible with ground-fix
+CONFIG_ZCBOR_CANONICAL=n
 
 # Include provisioning service certificate as part of the binary.
 # Used only if none has been provisioned

--- a/subsys/net/lib/nrf_cloud/coap/src/coap_codec.c
+++ b/subsys/net/lib/nrf_cloud/coap/src/coap_codec.c
@@ -358,7 +358,7 @@ int coap_codec_ground_fix_resp_decode(struct nrf_cloud_location_result *result,
 	size_t out_len;
 
 	err = cbor_decode_ground_fix_resp(buf, len, &res, &out_len);
-	if (out_len != len) {
+	if (!err && (out_len != len)) {
 		LOG_WRN("Different response length: expected:%zd, decoded:%zd",
 			len, out_len);
 	}

--- a/subsys/net/lib/nrf_provisioning/Kconfig.nrf_provisioning_cbor
+++ b/subsys/net/lib/nrf_provisioning/Kconfig.nrf_provisioning_cbor
@@ -7,7 +7,6 @@ menuconfig NRF_PROVISIONING_CBOR
 	bool "nRF Provisioning CBOR content format"
 	select EXPERIMENTAL
 	depends on ZCBOR
-	depends on ZCBOR_CANONICAL
 
 if NRF_PROVISIONING_CBOR
 


### PR DESCRIPTION
CONFIG_ZCBOR_CANONICAL needs to be disabled or else we receive a ZCBOR_ERR_ADDITIONAL_INVAL error on an otherwise valid response.

This error arose after the upgrade to ZCBOR 8.1 was merged.

Jira: NCSDK-26221