### PR TITLE
Fix build issue for promiscuous mode

### DIFF
--- a/drivers/wifi/nrf700x/inc/wifi_mgmt.h
+++ b/drivers/wifi/nrf700x/inc/wifi_mgmt.h
@@ -65,9 +65,9 @@ int nrf_wifi_channel(const struct device *dev,
 		     struct wifi_channel_info *channel);
 #endif /* CONFIG_NRF700X_RAW_DATA_TX || CONFIG_NRF700X_RAW_DATA_RX */
 
-#ifdef CONFIG_NRF700X_RAW_DATA_RX
+#if defined(CONFIG_NRF700X_RAW_DATA_RX) || defined(CONFIG_NRF700X_PROMISC_DATA_RX)
 int nrf_wifi_filter(const struct device *dev,
 		    struct wifi_filter_info *filter);
-#endif /* CONFIG_NRF700X_RAW_DATA_RX */
+#endif /* CONFIG_NRF700X_RAW_DATA_RX || CONFIG_NRF700X_PROMISC_DATA_RX */
 
 #endif /*  __ZEPHYR_WIFI_MGMT_H__ */

--- a/west.yml
+++ b/west.yml
@@ -142,7 +142,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 1cc0c0f1da921533b77c212d469f2f113af25c32
+      revision: 7e55e183267df60538924be9379fc7e7d4a16071
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
filter settings have been missed from being placed under CONFIG_NRF700X_PROMISC_DATA_RX check. enable filter code for Promiscuous mode