### PR TITLE
manifest: sdk-zephyr: add nrf5340 audio dk NET arduino header define

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 2977baaec1238116c8fb8ae76757afc173e1dc07
+      revision: 86bf8d3d8b6033acba65d17933cf1091a552c1b0
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Cherry-pick for adding nRF5340 audio DK NET arduino header. OCT-NONE
Signed-off-by: Jui-Chou Chung <jui-chou.chung@nordicsemi.no>