### PR TITLE
SML table updation, add to CI build and update software maturity yaml file for Monitor, tx injection and promiscuous mode 

### DIFF
--- a/doc/_scripts/software_maturity/software_maturity_features.yaml
+++ b/doc/_scripts/software_maturity/software_maturity_features.yaml
@@ -111,7 +111,12 @@ features:
     TX injection Mode:
       rule: WIFI_NRF700X && NRF700X_RAW_DATA_TX
       boards_and_shields:
+        - SHIELD_NRF7002EK
+        - SHIELD_NRF7002EK_NRF7000
+        - SHIELD_NRF7002EK_NRF7001
+        - SHIELD_NRF7002EB
         - BOARD_NRF7002DK_NRF5340_CPUAPP
+        - BOARD_NRF7002DK_NRF7001_NRF5340_CPUAPP
     Promiscuous Mode:
       rule: WIFI_NRF700X && NRF700X_PROMISC_DATA_RX
       boards_and_shields:

--- a/doc/_scripts/software_maturity/software_maturity_features.yaml
+++ b/doc/_scripts/software_maturity/software_maturity_features.yaml
@@ -102,7 +102,12 @@ features:
     Monitor Mode:
       rule: WIFI_NRF700X && NRF700X_RAW_DATA_RX
       boards_and_shields:
+        - SHIELD_NRF7002EK
+        - SHIELD_NRF7002EK_NRF7000
+        - SHIELD_NRF7002EK_NRF7001
+        - SHIELD_NRF7002EB
         - BOARD_NRF7002DK_NRF5340_CPUAPP
+        - BOARD_NRF7002DK_NRF7001_NRF5340_CPUAPP
     TX injection Mode:
       rule: WIFI_NRF700X && NRF700X_RAW_DATA_TX
       boards_and_shields:

--- a/doc/_scripts/software_maturity/software_maturity_features.yaml
+++ b/doc/_scripts/software_maturity/software_maturity_features.yaml
@@ -120,7 +120,11 @@ features:
     Promiscuous Mode:
       rule: WIFI_NRF700X && NRF700X_PROMISC_DATA_RX
       boards_and_shields:
+        - SHIELD_NRF7002EK
+        - SHIELD_NRF7002EK_NRF7001
+        - SHIELD_NRF7002EB
         - BOARD_NRF7002DK_NRF5340_CPUAPP
+        - BOARD_NRF7002DK_NRF7001_NRF5340_CPUAPP
   trusted_firmware_m:
     Minimal Build: BUILD_WITH_TFM && TFM_PROFILE_TYPE_MINIMAL
     Full build: BUILD_WITH_TFM && TFM_PROFILE_TYPE_NOT_SET && NRF_SECURITY

--- a/samples/wifi/monitor/sample.yaml
+++ b/samples/wifi/monitor/sample.yaml
@@ -16,3 +16,21 @@ tests:
       - nrf5340dk_nrf5340_cpuapp
     platform_allow: nrf5340dk_nrf5340_cpuapp
     tags: ci_build
+  sample.nrf7000.monitor:
+    # For SML only
+    skip: true
+    build_only: true
+    extra_args:
+      SHIELD=nrf7002ek_nrf7000
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf5340dk_nrf5340_cpuapp
+    tags: ci_build
+  sample.nrf7001.monitor:
+    # For SML only
+    skip: true
+    build_only: true
+    integration_platforms:
+      - nrf7002dk_nrf7001_nrf5340_cpuapp
+    platform_allow: nrf7002dk_nrf7001_nrf5340_cpuapp
+    tags: ci_build

--- a/samples/wifi/raw_tx_packet/sample.yaml
+++ b/samples/wifi/raw_tx_packet/sample.yaml
@@ -16,3 +16,21 @@ tests:
       - nrf5340dk_nrf5340_cpuapp
     platform_allow: nrf5340dk_nrf5340_cpuapp
     tags: ci_build
+  sample.nrf7000.raw_tx_packet:
+    # For SML only
+    skip: true
+    build_only: true
+    extra_args:
+      SHIELD=nrf7002ek_nrf7000
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf5340dk_nrf5340_cpuapp
+    tags: ci_build
+  sample.nrf7001.raw_tx_packet:
+    # For SML only
+    skip: true
+    build_only: true
+    integration_platforms:
+      - nrf7002dk_nrf7001_nrf5340_cpuapp
+    platform_allow: nrf7002dk_nrf7001_nrf5340_cpuapp
+    tags: ci_build

--- a/samples/wifi/shell/sample.yaml
+++ b/samples/wifi/shell/sample.yaml
@@ -232,3 +232,10 @@ tests:
       - nrf7002dk_nrf5340_cpuapp
     platform_allow: nrf7002dk_nrf5340_cpuapp
     tags: ci_build
+  sample.nrf7002.raw_tx_packet:
+    build_only: true
+    extra_args: OVERLAY_CONFIG=overlay-raw-tx.conf
+    integration_platforms:
+      - nrf7002dk_nrf5340_cpuapp
+    platform_allow: nrf7002dk_nrf5340_cpuapp
+    tags: ci_build

--- a/samples/wifi/shell/sample.yaml
+++ b/samples/wifi/shell/sample.yaml
@@ -239,3 +239,10 @@ tests:
       - nrf7002dk_nrf5340_cpuapp
     platform_allow: nrf7002dk_nrf5340_cpuapp
     tags: ci_build
+  sample.nrf7002.monitor:
+    build_only: true
+    extra_args: OVERLAY_CONFIG=overlay-monitor-mode.conf
+    integration_platforms:
+      - nrf7002dk_nrf5340_cpuapp
+    platform_allow: nrf7002dk_nrf5340_cpuapp
+    tags: ci_build

--- a/samples/wifi/shell/sample.yaml
+++ b/samples/wifi/shell/sample.yaml
@@ -246,3 +246,10 @@ tests:
       - nrf7002dk_nrf5340_cpuapp
     platform_allow: nrf7002dk_nrf5340_cpuapp
     tags: ci_build
+  sample.nrf7002.promiscuous_mode:
+    build_only: true
+    extra_args: OVERLAY_CONFIG=overlay-promiscuous-mode.conf
+    integration_platforms:
+      - nrf7002dk_nrf5340_cpuapp
+    platform_allow: nrf7002dk_nrf5340_cpuapp
+    tags: ci_build


### PR DESCRIPTION
This set of changes does the following:
1) SML table update for TX injection, Monitor and promiscuous mode
2) add CI build for Monitor, TX injection and promiscuous mode in SHELL sample
3) update Monitor, TX injection and promiscuous mode board and shields support in software_maturity_features.yaml
