### PR TITLE
samples: cellular: modem_shell: Increase CONFIG_AT_MONITOR_HEAP_SIZE

### DIFF
--- a/samples/cellular/modem_shell/prj.conf
+++ b/samples/cellular/modem_shell/prj.conf
@@ -89,10 +89,15 @@ CONFIG_NRF_MODEM_LIB_ON_FAULT_APPLICATION_SPECIFIC=y
 # AT monitor library
 CONFIG_AT_MONITOR=y
 
-# Increase AT monitor heap because %NCELLMEAS notifications can be long.
-# Note: with legacy NCELLMEAS types, 512 is enough, but with GCI search types
-# it could be even longer: theoretical maximum of 4020 bytes.
-CONFIG_AT_MONITOR_HEAP_SIZE=1024
+# Increase AT monitor heap because of the two use cases:
+# - %NCELLMEAS notifications can be closer to a kilobyte
+#   Note: with legacy NCELLMEAS types, 512 is enough, but with GCI search types
+#         it could be even longer: theoretical maximum of 4020 bytes.
+# - When AT+COPS=? is used for network search, it'll block and at the same time AT notifications
+#   can be coming in, and some of them may trigger new AT commands which cannot be executed.
+#   All this will reserve notificatons from AT monitor heap. While there will always be a chance
+#   this heap is too small, 1kB has caused issues.
+CONFIG_AT_MONITOR_HEAP_SIZE=2048
 
 # PDN library
 CONFIG_PDN=y


### PR DESCRIPTION
AT+COPS=? network search may cause system work queue getting stuck as follows:
- AT+COPS=? is issued
- +CEREG notification is received
- +CEREG will trigger another AT command (AT%XMONITOR)
- AT%XMONITOR cannot be started before AT+COPS=? completes
- System work queue is blocked
- Incoming AT notifications are reserved and sending them is put to system work queue
- AT monitor heap runs out if there are too many notifications before AT+COPS=? completes

Jira: MOSH-551