### PR TITLE
manifest: update sdk-zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 86bf8d3d8b6033acba65d17933cf1091a552c1b0
+      revision: 17d9e0f7bdfda0a4c88e6ba880d2b0a7314c6cf7
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This commit updates sdk-zephyr to pull in the latest changes in ieee802154_nrf5 driver.