### PR TITLE
scripts: quarantine: remove samples/apps due to TF-M FLASH overflow fix

### DIFF
--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -6,13 +6,3 @@
     - None
   platforms:
     - all
-
-- scenarios:
-    - applications.asset_tracker_v2.lwm2m.debug-modem_trace
-    - applications.asset_tracker_v2.lwm2m.debug-modem_trace.sysbuild
-    - sample.cellular.modem_shell.app_fota
-  platforms:
-    - nrf9160dk_nrf9160_ns
-    - nrf9161dk_nrf9161_ns
-    - thingy91_nrf9160_ns
-  comment: "FLASH overflow - https://nordicsemi.atlassian.net/browse/NCSDK-25891"


### PR DESCRIPTION
Remove ATv2 and MOSH configurations from quarantine. They were put into quarantine by PR #13662, which increased memory usage. The fix was made by PR #14034.

Jira: NCSDK-25891