### PR TITLE
applications: nrf_desktop: Allow using GPIO1 in wheel

### DIFF
--- a/applications/nrf_desktop/doc/wheel.rst
+++ b/applications/nrf_desktop/doc/wheel.rst
@@ -25,7 +25,7 @@ Configuration
 Enable the module with the :ref:`CONFIG_DESKTOP_WHEEL_ENABLE <config_desktop_app_options>` Kconfig option.
 
 For detecting rotation, the wheel module uses Zephyr's QDEC driver.
-The module can be enabled only when QDEC is configured in DTS (that is, :kconfig:option:`CONFIG_QDEC_NRFX` is set).
+You can enable the module only when QDEC is configured in DTS and the Zephyr's QDEC driver is enabled with the :kconfig:option:`CONFIG_QDEC_NRFX` Kconfig option.
 
 The QDEC DTS configuration specifies how many steps are done during one full angle.
 The sensor reports the rotation data in angle degrees.

--- a/applications/nrf_desktop/src/hw_interface/Kconfig.wheel
+++ b/applications/nrf_desktop/src/hw_interface/Kconfig.wheel
@@ -10,6 +10,7 @@ menu "Wheel configuration"
 config DESKTOP_WHEEL_ENABLE
 	bool "Enable wheel hardware interface"
 	depends on QDEC_NRFX
+	depends on PINCTRL
 	help
 	  This option enables wheel hardware interface for nRF Desktop application.
 	  Wheel hardware interface is responsible for generating events related to rotation of the

--- a/applications/nrf_desktop/src/hw_interface/wheel.c
+++ b/applications/nrf_desktop/src/hw_interface/wheel.c
@@ -13,9 +13,7 @@
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/pm/device.h>
-#ifdef CONFIG_PINCTRL
 #include <pinctrl_soc.h>
-#endif
 
 #include <app_event_manager.h>
 #include "wheel_event.h"
@@ -39,7 +37,6 @@ enum state {
 	STATE_SUSPENDED
 };
 
-#ifdef CONFIG_PINCTRL
 #define QDEC_PIN_INIT(node_id, prop, idx) \
 	NRF_GET_PIN(DT_PROP_BY_IDX(node_id, prop, idx)),
 
@@ -50,12 +47,6 @@ static const uint32_t qdec_pin[] = {
 		DT_FOREACH_PROP_ELEM, psels, QDEC_PIN_INIT
 	)
 };
-#else
-static const uint32_t qdec_pin[] = {
-	DT_PROP(DT_NODELABEL(qdec), a_pin),
-	DT_PROP(DT_NODELABEL(qdec), b_pin)
-};
-#endif
 
 static const struct sensor_trigger qdec_trig = {
 	.type = SENSOR_TRIG_DATA_READY,

--- a/applications/nrf_desktop/src/hw_interface/wheel.c
+++ b/applications/nrf_desktop/src/hw_interface/wheel.c
@@ -25,7 +25,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(MODULE, CONFIG_DESKTOP_WHEEL_LOG_LEVEL);
 
-
+#define PINS_PER_GPIO_PORT	32
 #define SENSOR_IDLE_TIMEOUT \
 	(CONFIG_DESKTOP_WHEEL_SENSOR_IDLE_TIMEOUT * MSEC_PER_SEC) /* ms */
 
@@ -54,8 +54,7 @@ static const struct sensor_trigger qdec_trig = {
 };
 
 static const struct device *qdec_dev = DEVICE_DT_GET(DT_NODELABEL(qdec));
-static const struct device *const gpio_dev = DEVICE_DT_GET(DT_NODELABEL(gpio0));
-static struct gpio_callback gpio_cbs[2];
+static struct gpio_callback gpio_cbs[ARRAY_SIZE(qdec_pin)];
 static struct k_spinlock lock;
 static struct k_work_delayable idle_timeout;
 static bool qdec_triggered;
@@ -63,6 +62,39 @@ static enum state state;
 
 static int enable_qdec(enum state next_state);
 
+
+static const struct device *map_gpio_port(int pin_number)
+{
+	__ASSERT_NO_MSG(pin_number >= 0);
+
+	size_t port_idx = pin_number / PINS_PER_GPIO_PORT;
+	const struct device *dev = NULL;
+
+	switch (port_idx) {
+	case 0:
+		dev = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(gpio0));
+		break;
+
+	case 1:
+		dev = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(gpio1));
+		break;
+
+	default:
+		break;
+	}
+
+	/* Assert proper configuration. */
+	__ASSERT_NO_MSG(dev);
+
+	return dev;
+}
+
+static gpio_pin_t map_gpio_pin(int pin_number)
+{
+	__ASSERT_NO_MSG(pin_number >= 0);
+
+	return pin_number % PINS_PER_GPIO_PORT;
+}
 
 static void data_ready_handler(const struct device *dev, const struct sensor_trigger *trig)
 {
@@ -111,8 +143,11 @@ static int wakeup_int_ctrl_nolock(bool enable)
 	 * being fired before others are still not set up.
 	 */
 	for (size_t i = 0; (i < ARRAY_SIZE(qdec_pin)) && !err; i++) {
+		const struct device *port = map_gpio_port(qdec_pin[i]);
+		gpio_pin_t pin = map_gpio_pin(qdec_pin[i]);
+
 		if (enable) {
-			int val = gpio_pin_get_raw(gpio_dev, qdec_pin[i]);
+			int val = gpio_pin_get_raw(port, pin);
 
 			if (val < 0) {
 				LOG_ERR("Cannot read pin %zu", i);
@@ -120,12 +155,11 @@ static int wakeup_int_ctrl_nolock(bool enable)
 				continue;
 			}
 
-			err = gpio_pin_interrupt_configure(gpio_dev,
-				qdec_pin[i],
-				val ? GPIO_INT_LEVEL_LOW : GPIO_INT_LEVEL_HIGH);
+			err = gpio_pin_interrupt_configure(port, pin,
+							   val ? GPIO_INT_LEVEL_LOW :
+								 GPIO_INT_LEVEL_HIGH);
 		} else {
-			err = gpio_pin_interrupt_configure(gpio_dev, qdec_pin[i],
-							   GPIO_INT_DISABLE);
+			err = gpio_pin_interrupt_configure(port, pin, GPIO_INT_DISABLE);
 		}
 
 		if (err) {
@@ -174,23 +208,27 @@ static void wakeup_cb(const struct device *gpio_dev, struct gpio_callback *cb,
 
 static int setup_wakeup(void)
 {
-	int err = gpio_pin_configure(gpio_dev,
-				     DT_PROP(DT_NODELABEL(qdec), enable_pin),
-				     GPIO_OUTPUT);
+	int enable_pin = DT_PROP(DT_NODELABEL(qdec), enable_pin);
+	const struct device *port = map_gpio_port(enable_pin);
+	gpio_pin_t pin = map_gpio_pin(enable_pin);
+
+	int err = gpio_pin_configure(port, pin, GPIO_OUTPUT);
 	if (err) {
 		LOG_ERR("Cannot configure enable pin");
 		return err;
 	}
 
-	err = gpio_pin_set_raw(gpio_dev,
-			       DT_PROP(DT_NODELABEL(qdec), enable_pin), 0);
+	err = gpio_pin_set_raw(port, pin, 0);
 	if (err) {
 		LOG_ERR("Failed to set enable pin");
 		return err;
 	}
 
 	for (size_t i = 0; i < ARRAY_SIZE(qdec_pin); i++) {
-		err = gpio_pin_configure(gpio_dev, qdec_pin[i], GPIO_INPUT);
+		const struct device *port = map_gpio_port(qdec_pin[i]);
+		gpio_pin_t pin = map_gpio_pin(qdec_pin[i]);
+
+		err = gpio_pin_configure(port, pin, GPIO_INPUT);
 
 		if (err) {
 			LOG_ERR("Cannot configure pin %zu", i);
@@ -302,20 +340,23 @@ static int init(void)
 		return -ENODEV;
 	}
 
-	if (!device_is_ready(gpio_dev)) {
-		LOG_ERR("GPIO device not ready");
-		return -ENODEV;
-	}
-
-	BUILD_ASSERT(ARRAY_SIZE(qdec_pin) == ARRAY_SIZE(gpio_cbs),
-		      "Invalid array size");
 	int err = 0;
 
 	for (size_t i = 0; (i < ARRAY_SIZE(qdec_pin)) && !err; i++) {
-		gpio_init_callback(&gpio_cbs[i], wakeup_cb, BIT(qdec_pin[i]));
-		err = gpio_add_callback(gpio_dev, &gpio_cbs[i]);
-		if (err) {
-			LOG_ERR("Cannot configure cb (pin:%zu)", i);
+		const struct device *port = map_gpio_port(qdec_pin[i]);
+		gpio_pin_t pin = map_gpio_pin(qdec_pin[i]);
+
+		if (!device_is_ready(port)) {
+			LOG_ERR("GPIO port %p not ready", (void *)port);
+			err = -ENODEV;
+		}
+
+		if (!err) {
+			gpio_init_callback(&gpio_cbs[i], wakeup_cb, BIT(pin));
+			err = gpio_add_callback(port, &gpio_cbs[i]);
+			if (err) {
+				LOG_ERR("Cannot configure cb (pin:%zu)", i);
+			}
 		}
 	}
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -328,11 +328,16 @@ nRF Desktop
     The option is enabled by default by the nRF Desktop application.
     Force power down on disconnection with reason ``0x15`` (Remote Device Terminated due to Power Off) is triggered to avoid waking up HID host until user input is detected.
 
-* Added the :ref:`CONFIG_DESKTOP_HID_STATE_SUBSCRIBER_COUNT <config_desktop_app_options>` Kconfig option to the :ref:`nrf_desktop_hid_state`.
-  The option allows to configure a maximum number of simultaneously supported HID data subscribers.
-  By default, the value of this Kconfig option is set to ``1``.
-  Make sure to align the value in your application configuration.
-  For example, to allow subscribing for HID reports simultaneously from :ref:`nrf_desktop_hids` and :ref:`nrf_desktop_usb_state` (a single USB HID instance), you must set the value of this Kconfig option to ``2``.
+* Added:
+
+  * The :ref:`CONFIG_DESKTOP_HID_STATE_SUBSCRIBER_COUNT <config_desktop_app_options>` Kconfig option to the :ref:`nrf_desktop_hid_state`.
+    The option allows to configure a maximum number of simultaneously supported HID data subscribers.
+    By default, the value of this Kconfig option is set to ``1``.
+    Make sure to align the value in your application configuration.
+    For example, to allow subscribing for HID reports simultaneously from the :ref:`nrf_desktop_hids` and :ref:`nrf_desktop_usb_state` (a single USB HID instance), you must set the value of this Kconfig option to ``2``.
+  * The pin control (:kconfig:option:`CONFIG_PINCTRL`) dependency to the :ref:`nrf_desktop_wheel`.
+    The dependency simplifies accessing **A** and **B** QDEC pins in the wheel module's implementation.
+    The pin control is selected by the QDEC driver (:kconfig:option:`CONFIG_QDEC_NRFX`).
 
 Thingy:53: Matter weather station
 ---------------------------------

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -327,6 +327,7 @@ nRF Desktop
   * The default value of newly introduced :kconfig:option:`CONFIG_CAF_BLE_ADV_POWER_DOWN_ON_DISCONNECTION_REASON_0X15` Kconfig option.
     The option is enabled by default by the nRF Desktop application.
     Force power down on disconnection with reason ``0x15`` (Remote Device Terminated due to Power Off) is triggered to avoid waking up HID host until user input is detected.
+  * The :ref:`nrf_desktop_wheel` configuration to allow using **GPIO1** for scroll wheel.
 
 * Added:
 


### PR DESCRIPTION
Change updates application module's configuration to allow using GPIO1 in wheel.

Jira: NCSDK-26115
