### PR TITLE
Add user guide to new Fast Pair enable API

### DIFF
--- a/applications/nrf_desktop/doc/fast_pair_app.rst
+++ b/applications/nrf_desktop/doc/fast_pair_app.rst
@@ -64,5 +64,5 @@ This allows the module to update the Fast Pair advertising payload just before t
 The module is a subscriber for :c:struct:`ble_dongle_peer_event`.
 This allows the module to remove the Fast Pair advertising payload when the application identity of the dongle peer is used.
 
-The module registers the global application's Bluetooth authentication callbacks (:c:struct:`bt_conn_auth_cb`) on application start.
+The module registers the global application's Bluetooth authentication callbacks (:c:struct:`bt_conn_auth_cb`) and enables the :ref:`bt_fast_pair_readme` (:c:func:`bt_fast_pair_enable`) after :ref:`caf_settings_loader` loads Zephyr's :ref:`zephyr:settings_api`.
 The callbacks are used to reject normal Bluetooth pairing when outside of the pairing mode.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -742,6 +742,9 @@ Bluetooth libraries and services
 
 * :ref:`bt_fast_pair_readme` library:
 
+  * Added the :c:func:`bt_fast_pair_enable`, :c:func:`bt_fast_pair_disable`, :c:func:`bt_fast_pair_is_ready` functions to handle the Fast Pair subsystem readiness.
+    In order to use the Fast Pair service, the Fast Pair subsystem must be enabled with the :c:func:`bt_fast_pair_enable` function.
+
   * Updated:
 
     * Improved the :ref:`bt_fast_pair_readme` library documentation to include the description of the missing Kconfig options.

--- a/include/bluetooth/services/fast_pair.h
+++ b/include/bluetooth/services/fast_pair.h
@@ -266,8 +266,9 @@ int bt_fast_pair_info_cb_register(const struct bt_fast_pair_info_cb *cb);
 /** Perform a reset to the default factory settings for Google Fast Pair Service.
  *
  * Clears the Fast Pair storage. If the reset operation is interrupted by system reboot or power
- * outage, the reset is automatically resumed at the stage of loading the Fast Pair storage.
- * It prevents the Fast Pair storage from ending in unwanted state after the reset interruption.
+ * outage, the reset is automatically resumed at the stage of initializing the Fast Pair storage
+ * when calling the @ref bt_fast_pair_enable API. It prevents the Fast Pair storage from ending in
+ * unwanted state after the reset interruption.
  *
  * @return 0 if the operation was successful. Otherwise, a (negative) error code is returned.
  */


### PR DESCRIPTION
Aligns the Fast Pair documentation after new Fast Pair enable API was introduced via this PR: https://github.com/nrfconnect/sdk-nrf/pull/13315.