### PR TITLE
samples: matter: update versioning scheme for Matter applications

### DIFF
--- a/doc/nrf/protocols/matter/end_product/versioning.rst
+++ b/doc/nrf/protocols/matter/end_product/versioning.rst
@@ -72,7 +72,7 @@ Add the following Kconfig options to change the version:
 * :kconfig:option:`CONFIG_CHIP_DEVICE_SOFTWARE_VERSION` to set to the version number.
 * :kconfig:option:`CONFIG_CHIP_DEVICE_SOFTWARE_VERSION_STRING` to set the version string.
 
-Additionally, since Nordic chips use MCUboot Image Tool, you need to also edit the :kconfig:option:`CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION` Kconfig option, with a value in the following format: ``"MAJOR . MINOR . PATCHLEVEL . TWEAK"``.
+Additionally, since Nordic chips use MCUboot Image Tool, you need to also edit the :kconfig:option:`CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION` Kconfig option, with a value in the following format: ``"MAJOR . MINOR . PATCHLEVEL + TWEAK"``.
 
 For example:
 
@@ -82,7 +82,7 @@ For example:
    CONFIG_CHIP_DEVICE_SOFTWARE_VERSION_STRING="2.5.99+0"
    CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION="2.5.99+0"
 
-Where ``33907456`` is 0x02056300, the hexadecimal versioning of 2.5.99.0.
+Where ``33907456`` is 0x02056300, the hexadecimal versioning of 2.5.99+0.
 
 .. _ug_matter_dfu_smp:
 

--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 17d9e0f7bdfda0a4c88e6ba880d2b0a7314c6cf7
+      revision: f3f276dd2ecad981a2abf1d87c3d3d0b2e9d5373
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -154,7 +154,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: e3dd453b9bd82ee33b258cd2be94abeca9ba62c0
+      revision: 324ff7699e65c2120af6a6c665b6ccf63cda71d9
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
This commit changes the default string representation of version to include the tweak.