### PR TITLE
samples: matter: Fixed BT bridge recovery procedure

### DIFF
--- a/samples/matter/common/src/bridge/ble_connectivity_manager.cpp
+++ b/samples/matter/common/src/bridge/ble_connectivity_manager.cpp
@@ -182,9 +182,12 @@ exit:
 		Instance().UpdateStateFlag(State::Pairing, false);
 #endif
 	}
-	/* Trigger the connection callback to inform the application that the connection procedure failed. */
-	provider->GetBLEBridgedDevice().mFirstConnectionCallback(
-		false, provider->GetBLEBridgedDevice().mFirstConnectionCallbackContext);
+
+	if (!provider->IsInitiallyConnected()) {
+		/* Trigger the connection callback to inform the application that the connection procedure failed. */
+		provider->GetBLEBridgedDevice().mFirstConnectionCallback(
+			false, provider->GetBLEBridgedDevice().mFirstConnectionCallbackContext);
+	}
 }
 
 void BLEConnectivityManager::DisconnectionHandler(bt_conn *conn, uint8_t reason)

--- a/samples/matter/common/src/bridge/ble_connectivity_manager.h
+++ b/samples/matter/common/src/bridge/ble_connectivity_manager.h
@@ -272,6 +272,7 @@ private:
 	bt_le_conn_param *GetScannedDeviceConnParams(bt_addr_le_t address);
 	State GetCurrentState();
 	void UpdateStateFlag(State state, bool enabled);
+	void UpdateRecovery();
 
 	StateChangedCallback mStateChangedCb = nullptr;
 	uint8_t mStateBitmask = 0;


### PR DESCRIPTION
This PR includes two fixes for the BT bridge recovery:
* usage fault in case of re-connection failure (this is a condition directly caused by the second problem)
* GATT discovery failure if some device was recovered soon after recovering the previous one (e.g. in case of bridge reboot) 