### PR TITLE
Bluetooth: Mesh: Fix sysbuild configuration for mesh samples

### DIFF
--- a/doc/nrf/protocols/bt/bt_mesh/configuring.rst
+++ b/doc/nrf/protocols/bt/bt_mesh/configuring.rst
@@ -13,6 +13,11 @@ The Bluetooth® mesh support is controlled by :kconfig:option:`CONFIG_BT_MESH`, 
 * :kconfig:option:`CONFIG_BT_OBSERVER` - Enables the Bluetooth Observer role.
 * :kconfig:option:`CONFIG_BT_PERIPHERAL` - Enables the Bluetooth Peripheral role.
 
+When the Bluetooth LE Controller is located on a separate image (like on the :ref:`zephyr:nrf5340dk_nrf5340` and :ref:`zephyr:thingy53_nrf5340` boards), the following configuration must be applied to the Bluetooth LE Controller configuration:
+
+* :kconfig:option:`CONFIG_BT_EXT_ADV` =y.
+* :kconfig:option:`CONFIG_BT_EXT_ADV_MAX_ADV_SET` =5.
+
 Optional features configuration
 *******************************
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -444,11 +444,43 @@ Bluetooth Mesh samples
 
     * Support for the :ref:`zephyr:nrf52840dongle_nrf52840`.
 
+  * Fixed:
+
+    * Building with :ref:`zephyr:sysbuild` for the :ref:`zephyr:nrf5340dk_nrf5340` and :ref:`zephyr:thingy53_nrf5340` boards.
+
 * :ref:`bluetooth_mesh_light_lc` sample:
 
   * Added:
 
     * Support for the :ref:`zephyr:nrf52840dongle_nrf52840`.
+
+  * Fixed:
+
+    * Building with :ref:`zephyr:sysbuild` for the :ref:`zephyr:nrf5340dk_nrf5340` and :ref:`zephyr:thingy53_nrf5340` boards.
+
+* :ref:`bluetooth_mesh_light` sample:
+
+  * Fixed:
+
+    * Building with :ref:`zephyr:sysbuild` for the :ref:`zephyr:nrf5340dk_nrf5340` and :ref:`zephyr:thingy53_nrf5340` boards.
+
+* :ref:`bluetooth_mesh_light_switch` sample:
+
+  * Fixed:
+
+    * Building with :ref:`zephyr:sysbuild` for the :ref:`zephyr:nrf5340dk_nrf5340` and :ref:`zephyr:thingy53_nrf5340` boards.
+
+* :ref:`bluetooth_mesh_sensor_server` sample:
+
+  * Fixed:
+
+    * Building with :ref:`zephyr:sysbuild` for the :ref:`zephyr:nrf5340dk_nrf5340` and :ref:`zephyr:thingy53_nrf5340` boards.
+
+* :ref:`bluetooth_mesh_silvair_enocean` sample:
+
+  * Fixed:
+
+    * Building with :ref:`zephyr:sysbuild` for the :ref:`zephyr:nrf5340dk_nrf5340` board.
 
 Cellular samples
 ----------------

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -91,6 +91,7 @@ Bluetooth Mesh
   * :ref:`bt_mesh_ug_reserved_ids` with model ID and opcodes for the new :ref:`bt_mesh_le_pair_resp_readme` model.
   * :ref:`bt_mesh_light_ctrl_readme` APIs to match new Sensor APIs.
   * :ref:`ug_bt_mesh_configuring` with the recommendation on how to configure persistent storage to increase performance.
+  * :ref:`ug_bt_mesh_configuring` with the required configuration for the network core.
   * Fixed an issue when the Time Server model rewrites TTL to zero forever during the unsolicited Time Status publication.
 
 Matter

--- a/samples/bluetooth/mesh/light/sysbuild/hci_ipc/prj.conf
+++ b/samples/bluetooth/mesh/light/sysbuild/hci_ipc/prj.conf
@@ -29,3 +29,8 @@ CONFIG_BT_CTLR_LE_ENC=n
 CONFIG_BT_CTLR_CHAN_SEL_2=n
 CONFIG_BT_CTLR_MIN_USED_CHAN=n
 CONFIG_BT_CTLR_PRIVACY=n
+
+# Enables the extended advertising API support and the necessary amount of advertising sets
+# in the Bluetooth controller on the network core required by the Bluetooth Mesh.
+CONFIG_BT_EXT_ADV=y
+CONFIG_BT_EXT_ADV_MAX_ADV_SET=5

--- a/samples/bluetooth/mesh/light_ctrl/sysbuild/hci_ipc/prj.conf
+++ b/samples/bluetooth/mesh/light_ctrl/sysbuild/hci_ipc/prj.conf
@@ -29,3 +29,8 @@ CONFIG_BT_CTLR_LE_ENC=n
 CONFIG_BT_CTLR_CHAN_SEL_2=n
 CONFIG_BT_CTLR_MIN_USED_CHAN=n
 CONFIG_BT_CTLR_PRIVACY=n
+
+# Enables the extended advertising API support and the necessary amount of advertising sets
+# in the Bluetooth controller on the network core required by the Bluetooth Mesh.
+CONFIG_BT_EXT_ADV=y
+CONFIG_BT_EXT_ADV_MAX_ADV_SET=5

--- a/samples/bluetooth/mesh/light_dimmer/sysbuild/hci_ipc/prj.conf
+++ b/samples/bluetooth/mesh/light_dimmer/sysbuild/hci_ipc/prj.conf
@@ -29,3 +29,8 @@ CONFIG_BT_CTLR_LE_ENC=n
 CONFIG_BT_CTLR_CHAN_SEL_2=n
 CONFIG_BT_CTLR_MIN_USED_CHAN=n
 CONFIG_BT_CTLR_PRIVACY=n
+
+# Enables the extended advertising API support and the necessary amount of advertising sets
+# in the Bluetooth controller on the network core required by the Bluetooth Mesh.
+CONFIG_BT_EXT_ADV=y
+CONFIG_BT_EXT_ADV_MAX_ADV_SET=5

--- a/samples/bluetooth/mesh/light_switch/sysbuild/hci_ipc/prj.conf
+++ b/samples/bluetooth/mesh/light_switch/sysbuild/hci_ipc/prj.conf
@@ -29,3 +29,8 @@ CONFIG_BT_CTLR_LE_ENC=n
 CONFIG_BT_CTLR_CHAN_SEL_2=n
 CONFIG_BT_CTLR_MIN_USED_CHAN=n
 CONFIG_BT_CTLR_PRIVACY=n
+
+# Enables the extended advertising API support and the necessary amount of advertising sets
+# in the Bluetooth controller on the network core required by the Bluetooth Mesh.
+CONFIG_BT_EXT_ADV=y
+CONFIG_BT_EXT_ADV_MAX_ADV_SET=5

--- a/samples/bluetooth/mesh/sensor_server/sysbuild/hci_ipc/prj.conf
+++ b/samples/bluetooth/mesh/sensor_server/sysbuild/hci_ipc/prj.conf
@@ -29,3 +29,8 @@ CONFIG_BT_CTLR_LE_ENC=n
 CONFIG_BT_CTLR_CHAN_SEL_2=n
 CONFIG_BT_CTLR_MIN_USED_CHAN=n
 CONFIG_BT_CTLR_PRIVACY=n
+
+# Enables the extended advertising API support and the necessary amount of advertising sets
+# in the Bluetooth controller on the network core required by the Bluetooth Mesh.
+CONFIG_BT_EXT_ADV=y
+CONFIG_BT_EXT_ADV_MAX_ADV_SET=5

--- a/samples/bluetooth/mesh/silvair_enocean/sysbuild/hci_ipc/prj.conf
+++ b/samples/bluetooth/mesh/silvair_enocean/sysbuild/hci_ipc/prj.conf
@@ -29,3 +29,8 @@ CONFIG_BT_CTLR_LE_ENC=n
 CONFIG_BT_CTLR_CHAN_SEL_2=n
 CONFIG_BT_CTLR_MIN_USED_CHAN=n
 CONFIG_BT_CTLR_PRIVACY=n
+
+# Enables the extended advertising API support and the necessary amount of advertising sets
+# in the Bluetooth controller on the network core required by the Bluetooth Mesh.
+CONFIG_BT_EXT_ADV=y
+CONFIG_BT_EXT_ADV_MAX_ADV_SET=5


### PR DESCRIPTION
This PR enables the extended advertising API support and the necessary amount of advertising sets in the Bluetooth controller on the network core required by the Bluetooth Mesh when a sample is build with
`--sysbuild` option.

This PR also describes which options must be enabled on the network core for the bluetooth controller to work with mesh.