### PR TITLE
lib: pdn: Init PDN before adding it to the list

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -876,9 +876,18 @@ Modem libraries
 
 * :ref:`pdn_readme` library:
 
-   * Added the :c:func:`pdn_dynamic_params_get` function to retrieve dynamic parameters of an active PDN connection.
-   * Fixed a potential issue where the library tries to free the PDN context twice, causing the application to crash.
-   * Updated the library to add PDP auto configuration to the :c:enumerator:`LTE_LC_FUNC_MODE_POWER_OFF` event.
+   * Added:
+
+     * The :c:func:`pdn_dynamic_params_get` function to retrieve dynamic parameters of an active PDN connection.
+
+   * Fixed:
+
+     * A potential issue where the library tries to free the PDN context twice, causing the application to crash.
+     * A potential crash when an AT notification arrives during :c:func:`pdn_ctx_create`. The callback was only initialised after adding it to the list.
+
+   * Updated:
+
+     * The library to add PDP auto configuration to the :c:enumerator:`LTE_LC_FUNC_MODE_POWER_OFF` event.
 
 * :ref:`lib_at_host` library:
 

--- a/lib/pdn/pdn.c
+++ b/lib/pdn/pdn.c
@@ -86,6 +86,9 @@ static struct pdn *pdn_ctx_new(void)
 		return NULL;
 	}
 
+	pdn->context_id = INT8_MAX;
+	pdn->callback = NULL;
+
 	k_mutex_lock(&list_mutex, K_FOREVER);
 	sys_slist_append(&pdn_contexts, &pdn->node);
 	k_mutex_unlock(&list_mutex);


### PR DESCRIPTION
If we do not do this a list lookup will find this PDN. If the context_id happens to be valid and the callback not null then we will crash.