### PR TITLE
applications: nrf5340_audio: Disable pres-comp for CIS bidir gateway

### DIFF
--- a/applications/nrf5340_audio/src/audio/audio_datapath.c
+++ b/applications/nrf5340_audio/src/audio/audio_datapath.c
@@ -1065,7 +1065,17 @@ int audio_datapath_init(void)
 	audio_i2s_init();
 	ctrl_blk.datapath_initialized = true;
 	ctrl_blk.drift_comp.enabled = true;
-	ctrl_blk.pres_comp.enabled = true;
+	if (IS_ENABLED(CONFIG_STREAM_BIDIRECTIONAL) && (CONFIG_AUDIO_DEV == GATEWAY) &&
+	    IS_ENABLED(CONFIG_BT_LL_ACS_NRF53)) {
+		/* Disable presentation compensation feature for microphone return on gateway when
+		 * using Audio Controller Subsystem. Also, since there's only one stream output from
+		 * gateway for now, so no need to have presentation compensation.
+		 */
+		ctrl_blk.pres_comp.enabled = false;
+	} else {
+		ctrl_blk.pres_comp.enabled = true;
+	}
+
 	ctrl_blk.pres_comp.pres_delay_us = CONFIG_BT_AUDIO_PRESENTATION_DELAY_US;
 
 	return 0;


### PR DESCRIPTION
Disable the pres-comp feature on TWS CIS bidir gateway when using audio subsystem controller.
OCT-2867
Signed-off-by: Jui-Chou Chung <jui-chou.chung@nordicsemi.no>