### PR TITLE
applications: Fixed BT max connection overlay for Matter bridge

### DIFF
--- a/applications/matter_bridge/overlay-bt_max_connections_app.conf
+++ b/applications/matter_bridge/overlay-bt_max_connections_app.conf
@@ -17,6 +17,7 @@ CONFIG_BT_L2CAP_TX_MTU=80
 
 # Set max number of bridged BLE devices, which is CONFIG_BT_MAX_CONN-1, as 1 connection is reserved for Matter.
 CONFIG_BRIDGE_MAX_BRIDGED_DEVICES_NUMBER=19
+CONFIG_BT_MAX_PAIRED=19
 
 # Assume that every bridged device uses only 1 endpoint, however it can be increased if specific use case requires it.
 CONFIG_BRIDGE_MAX_DYNAMIC_ENDPOINTS_NUMBER=19


### PR DESCRIPTION
The overlay for max number of BT connections does not increase max number of paired devices, so BT SMP module does not allow to connect the expected number.