### PR TITLE
applications: nrf5340_audio: Low down ACL SUP timeout

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/bt_management/scanning/Kconfig
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/scanning/Kconfig
@@ -37,7 +37,7 @@ config BLE_ACL_SLAVE_LATENCY
 
 config BLE_ACL_SUP_TIMEOUT
 	int "Bluetooth LE Supervision Timeout (x*10ms)"
-	default 100
+	default 40
 
 endmenu # Connection
 


### PR DESCRIPTION
Low down the ACL supervision timeout to avoid the quick reset devices cause security issue.
OCT-NONE
Signed-off-by: Jui-Chou Chung <jui-chou.chung@nordicsemi.no>