### PR TITLE
Bluetooth: Update sdk-zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: f3f276dd2ecad981a2abf1d87c3d3d0b2e9d5373
+      revision: e88d540cfc964c156a56cf2d074a415f0376a22d
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
To have tx power level defines available for nrf54x

This is the manifest update to include https://github.com/nrfconnect/sdk-zephyr/pull/1533 