### PR TITLE
applications: nrf5340_audio: change SMP log level

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/bt_management/bt_mgmt.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/bt_mgmt.c
@@ -212,10 +212,10 @@ static void security_changed_cb(struct bt_conn *conn, bt_security_t level, enum 
 	struct bt_mgmt_msg msg;
 
 	if (err) {
-		LOG_ERR("Security failed: level %d err %d", level, err);
+		LOG_WRN("Security failed: level %d err %d", level, err);
 		ret = bt_conn_disconnect(conn, err);
 		if (ret) {
-			LOG_ERR("Failed to disconnect %d", ret);
+			LOG_WRN("Failed to disconnect %d", ret);
 		}
 	} else {
 		LOG_DBG("Security changed: level %d", level);


### PR DESCRIPTION
Update the SMP log level, since SMP failed could happen during power on/off testing, which should not block us from continuing the test.
OCT-NONE
Signed-off-by: Jui-Chou Chung <jui-chou.chung@nordicsemi.no>