### PR TITLE
manifest: update zephyr to include npm6001 SWREADY fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: f3f276dd2ecad981a2abf1d87c3d3d0b2e9d5373
+      revision: pull/1534/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Updated the Zephyr revision in manifest to bring npm6001 SWREADY fix from upstream repository.