### PR TITLE
applications: serial_lte_modem: fix compilation warning

### DIFF
--- a/applications/serial_lte_modem/src/slm_cmux.c
+++ b/applications/serial_lte_modem/src/slm_cmux.c
@@ -78,6 +78,8 @@ static void dlci_pipe_event_handler(struct modem_pipe *pipe,
 				dlci->address, recv_len);
 		}
 		break;
+	case MODEM_PIPE_EVENT_TRANSMIT_IDLE:
+		break;
 	}
 }
 


### PR DESCRIPTION
Nothing is to be done on MODEM_PIPE_EVENT_TRANSMIT_IDLE.