### PR TITLE
applications: serial_lte_modem: add reference overlays for Zephyr modem driver

### DIFF
--- a/applications/serial_lte_modem/overlay-external-mcu.overlay
+++ b/applications/serial_lte_modem/overlay-external-mcu.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		ncs,slm-uart = &uart2;
+	};
+};
+
+&uart2 {
+	status = "okay";
+};
+
+/* uart0 is not needed if no logging is received there. */
+&uart0 {
+	status = "disabled";
+};

--- a/applications/serial_lte_modem/overlay-zephyr-modem-external-mcu.conf
+++ b/applications/serial_lte_modem/overlay-zephyr-modem-external-mcu.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Make sure that this value is in accordance with your setup, updating it as needed.
+CONFIG_SLM_POWER_PIN=30

--- a/applications/serial_lte_modem/overlay-zephyr-modem-nrf9160dk-nrf52840.conf
+++ b/applications/serial_lte_modem/overlay-zephyr-modem-nrf9160dk-nrf52840.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# nRF52 <=> nRF91 interface pin 4 (see https://docs.nordicsemi.com/bundle/ug_nrf91_dk/page/UG/nrf91_DK/board_controller.html)
+CONFIG_SLM_POWER_PIN=22

--- a/applications/serial_lte_modem/overlay-zephyr-modem-nrf9160dk-nrf52840.overlay
+++ b/applications/serial_lte_modem/overlay-zephyr-modem-nrf9160dk-nrf52840.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <nrf9160dk_uart1_on_if0_3.dtsi>
+
+/ {
+	chosen {
+		ncs,slm-uart = &uart1;
+	};
+};
+
+&uart1 {
+        current-speed = <115200>;
+        hw-flow-control;
+};

--- a/applications/serial_lte_modem/overlay-zephyr-modem.conf
+++ b/applications/serial_lte_modem/overlay-zephyr-modem.conf
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# The nRF91 is power-managed by Zephyr's modem_cellular driver running on the other chip.
+CONFIG_SLM_START_SLEEP=y
+
+CONFIG_SLM_CMUX_AUTOMATIC_FALLBACK_ON_PPP_STOPPAGE=y


### PR DESCRIPTION
Documentation will follow.