### PR TITLE
applications: serial_lte_modem: Fix native TLS with 2.6.0

### DIFF
--- a/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
@@ -516,8 +516,8 @@ client_events:
 			/* Process POLLIN first to get the data, even if there are errors. */
 			if ((fds[1].revents & POLLIN) == POLLIN) {
 				ret = recv(fds[1].fd, (void *)slm_data_buf,
-					   sizeof(slm_data_buf), 0);
-				if (ret < 0) {
+					   sizeof(slm_data_buf), MSG_DONTWAIT);
+				if (ret < 0 && errno != EAGAIN) {
 					LOG_ERR("recv() error: %d", -errno);
 					tcpsvr_terminate_connection(-errno);
 					fds[1].fd = INVALID_SOCKET;
@@ -603,8 +603,8 @@ static void tcpcli_thread_func(void *p1, void *p2, void *p3)
 		if ((fds.revents & POLLIN) != POLLIN) {
 			continue;
 		}
-		ret = recv(fds.fd, (void *)slm_data_buf, sizeof(slm_data_buf), 0);
-		if (ret < 0) {
+		ret = recv(fds.fd, (void *)slm_data_buf, sizeof(slm_data_buf), MSG_DONTWAIT);
+		if (ret < 0 && errno != EAGAIN) {
 			LOG_WRN("recv() error: %d", -errno);
 			continue;
 		}


### PR DESCRIPTION
Avoid blocking call to recv with native TLS. It is not returning correctly after the remote end terminates the connection.