### PR TITLE
bluetooth: fast_pair: Align cooperative thread approach

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -798,6 +798,10 @@ Bluetooth libraries and services
   * Updated:
 
     * Improved the :ref:`bt_fast_pair_readme` library documentation to include the description of the missing Kconfig options.
+    * Strengthen requirements regarding the thread context of Fast Pair API calls.
+      More functions are required to be called in the cooperative thread context.
+    * The :c:func:`bt_fast_pair_info_cb_register` function is now not allowed to be called when the Fast Pair is enabled.
+      The :c:func:`bt_fast_pair_info_cb_register` function can only be called before enabling the Fast Pair with the :c:func:`bt_fast_pair_enable` function.
 
 * :ref:`bt_mesh` library:
 

--- a/include/bluetooth/services/fast_pair.h
+++ b/include/bluetooth/services/fast_pair.h
@@ -13,6 +13,9 @@
  * @defgroup bt_fast_pair Fast Pair API
  * @brief Fast Pair API
  *
+ * The Fast Pair subsystem needs the Bluetooth GATT operations to be run from the cooperative
+ * thread context. It requires proper configuration of the CONFIG_BT_RECV_CONTEXT Kconfig option.
+ *
  * @{
  */
 
@@ -181,6 +184,8 @@ bool bt_fast_pair_is_ready(void);
  * This function can only be called if Fast Pair was previously enabled with the
  * @ref bt_fast_pair_enable API.
  *
+ * This function must be called in the cooperative thread context.
+ *
  * @param[in] fp_adv_config	Fast Pair advertising config.
  *
  * @return Fast Pair advertising data buffer size in bytes if the operation was successful.
@@ -196,7 +201,7 @@ size_t bt_fast_pair_adv_data_size(struct bt_fast_pair_adv_config fp_adv_config);
  * The buffer size must be at least @ref bt_fast_pair_adv_data_size. Caller shall also make sure
  * that Account Key write from a connected Fast Pair Seeker would not preempt generating Fast Pair
  * not discoverable advertising data. To achieve this, this function and
- * @ref bt_fast_pair_adv_data_size should be called from context with cooperative priority.
+ * @ref bt_fast_pair_adv_data_size must be called from context with cooperative priority.
  *
  * This function can only be called if Fast Pair was previously enabled with the
  * @ref bt_fast_pair_enable API.
@@ -257,6 +262,11 @@ int bt_fast_pair_battery_set(enum bt_fast_pair_battery_comp battery_comp,
  *  persist in the memory after this function exits, as it is used directly without the copy
  *  operation. It is possible to register only one instance of callbacks with this API.
  *
+ *  This function can only be called before enabling Fast Pair with the @ref bt_fast_pair_enable
+ *  API.
+ *
+ *  This function must be called in the cooperative thread context.
+ *
  *  @param cb Callback struct.
  *
  *  @return Zero on success or negative error code otherwise
@@ -269,6 +279,8 @@ int bt_fast_pair_info_cb_register(const struct bt_fast_pair_info_cb *cb);
  * outage, the reset is automatically resumed at the stage of initializing the Fast Pair storage
  * when calling the @ref bt_fast_pair_enable API. It prevents the Fast Pair storage from ending in
  * unwanted state after the reset interruption.
+ *
+ * This function must be called in the cooperative thread context.
  *
  * @return 0 if the operation was successful. Otherwise, a (negative) error code is returned.
  */

--- a/subsys/bluetooth/services/fast_pair/fp_advertising.c
+++ b/subsys/bluetooth/services/fast_pair/fp_advertising.c
@@ -95,6 +95,10 @@ static size_t bt_fast_pair_adv_data_size_discoverable(void)
 
 size_t bt_fast_pair_adv_data_size(struct bt_fast_pair_adv_config fp_adv_config)
 {
+	/* It is assumed that this function executes in the cooperative thread context. */
+	__ASSERT_NO_MSG(!k_is_preempt_thread());
+	__ASSERT_NO_MSG(!k_is_in_isr());
+
 	if (!bt_fast_pair_is_ready()) {
 		return 0;
 	}
@@ -227,6 +231,10 @@ static int fp_adv_data_fill_discoverable(struct net_buf_simple *buf)
 int bt_fast_pair_adv_data_fill(struct bt_data *bt_adv_data, uint8_t *buf, size_t buf_size,
 			       struct bt_fast_pair_adv_config fp_adv_config)
 {
+	/* It is assumed that this function executes in the cooperative thread context. */
+	__ASSERT_NO_MSG(!k_is_preempt_thread());
+	__ASSERT_NO_MSG(!k_is_in_isr());
+
 	if (!bt_fast_pair_is_ready()) {
 		LOG_ERR("Fast Pair not enabled");
 		return -EACCES;

--- a/subsys/bluetooth/services/fast_pair/fp_gatt_service.c
+++ b/subsys/bluetooth/services/fast_pair/fp_gatt_service.c
@@ -511,6 +511,10 @@ static ssize_t write_key_based_pairing(struct bt_conn *conn,
 
 	NET_BUF_SIMPLE_DEFINE(rsp, FP_CRYPTO_AES128_BLOCK_LEN);
 
+	/* It is assumed that this function executes in the cooperative thread context. */
+	__ASSERT_NO_MSG(!k_is_preempt_thread());
+	__ASSERT_NO_MSG(!k_is_in_isr());
+
 	if (!bt_fast_pair_is_ready()) {
 		res = BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
 		LOG_INF("Key-based Pairing write: res=%d conn=%p, "
@@ -635,6 +639,10 @@ static ssize_t write_passkey(struct bt_conn *conn,
 	NET_BUF_SIMPLE_DEFINE(req, FP_CRYPTO_AES128_BLOCK_LEN);
 	NET_BUF_SIMPLE_DEFINE(rsp, FP_CRYPTO_AES128_BLOCK_LEN);
 
+	/* It is assumed that this function executes in the cooperative thread context. */
+	__ASSERT_NO_MSG(!k_is_preempt_thread());
+	__ASSERT_NO_MSG(!k_is_in_isr());
+
 	if (!bt_fast_pair_is_ready()) {
 		res = BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
 		LOG_INF("Passkey write: res=%d conn=%p, "
@@ -700,6 +708,10 @@ static ssize_t write_account_key(struct bt_conn *conn,
 	int err = 0;
 	ssize_t res = len;
 
+	/* It is assumed that this function executes in the cooperative thread context. */
+	__ASSERT_NO_MSG(!k_is_preempt_thread());
+	__ASSERT_NO_MSG(!k_is_in_isr());
+
 	if (!bt_fast_pair_is_ready()) {
 		res = BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
 		LOG_INF("Account Key write: res=%d conn=%p, "
@@ -757,6 +769,10 @@ static ssize_t write_additional_data(struct bt_conn *conn,
 	int err = 0;
 	ssize_t res = len;
 
+	/* It is assumed that this function executes in the cooperative thread context. */
+	__ASSERT_NO_MSG(!k_is_preempt_thread());
+	__ASSERT_NO_MSG(!k_is_in_isr());
+
 	if (!bt_fast_pair_is_ready()) {
 		res = BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
 		LOG_INF("Additional Data write: res=%d conn=%p, "
@@ -801,6 +817,14 @@ finish:
 
 int bt_fast_pair_info_cb_register(const struct bt_fast_pair_info_cb *cb)
 {
+	/* It is assumed that this function executes in the cooperative thread context. */
+	__ASSERT_NO_MSG(!k_is_preempt_thread());
+	__ASSERT_NO_MSG(!k_is_in_isr());
+
+	if (bt_fast_pair_is_ready()) {
+		return -EACCES;
+	}
+
 	if (!cb) {
 		return -EINVAL;
 	}

--- a/subsys/bluetooth/services/fast_pair/fp_storage_integration.c
+++ b/subsys/bluetooth/services/fast_pair/fp_storage_integration.c
@@ -15,6 +15,10 @@ LOG_MODULE_DECLARE(fast_pair, CONFIG_BT_FAST_PAIR_LOG_LEVEL);
 
 int bt_fast_pair_factory_reset(void)
 {
+	/* It is assumed that this function executes in the cooperative thread context. */
+	__ASSERT_NO_MSG(!k_is_preempt_thread());
+	__ASSERT_NO_MSG(!k_is_in_isr());
+
 	return fp_storage_factory_reset();
 }
 


### PR DESCRIPTION
Specifies which functions from Fast Pair API must be run from cooperative thread context and adds assertions for it.

Jira: NCSDK-25120

Release notes will be updated after https://github.com/nrfconnect/sdk-nrf/pull/14170 merge to not generate conflicts.