### PR TITLE
applications: nrf_desktop: Fix `empty_rd` handling in HID state module

### DIFF
--- a/applications/nrf_desktop/src/modules/hid_state.c
+++ b/applications/nrf_desktop/src/modules/hid_state.c
@@ -824,6 +824,13 @@ static bool update_report(struct report_data *rd)
 {
 	bool update_needed = false;
 
+	/* Update report is never needed for the empty report data. Empty report data does not link
+	 * to subscriber too (`linked_rs` field is set to NULL).
+	 */
+	if (rd == &empty_rd) {
+		return update_needed;
+	}
+
 	while (!update_needed && !eventq_is_empty(&rd->eventq)) {
 		/* There are enqueued events to handle. */
 		struct item_event *event = eventq_get(&rd->eventq);


### PR DESCRIPTION
Change fixes `empty_rd` handling in `update_report` function. The `empty_rd` does not link to a subscriber (`linked_rs` is set to `NULL`). Because of that, it's not allowed to access `report_state` through `linked_rs` pointer. Since `empty_rd` contains no data (the event queue is always empty), we can use an early return here.

Jira: NCSDK-25928