### PR TITLE
samples: Bluetooth: Mesh: remove partial erase warning for nrf52832

### DIFF
--- a/samples/bluetooth/mesh/ble_peripheral_lbs_coex/boards/nrf52dk_nrf52832.conf
+++ b/samples/bluetooth/mesh/ble_peripheral_lbs_coex/boards/nrf52dk_nrf52832.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+################################################################################
+# Application overlay - nrf52dk_nrf52832
+
+CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE=n

--- a/samples/bluetooth/mesh/chat/boards/nrf52dk_nrf52832.conf
+++ b/samples/bluetooth/mesh/chat/boards/nrf52dk_nrf52832.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+################################################################################
+# Application overlay - nrf52dk_nrf52832
+
+CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE=n

--- a/samples/bluetooth/mesh/light/boards/nrf52dk_nrf52832.conf
+++ b/samples/bluetooth/mesh/light/boards/nrf52dk_nrf52832.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+################################################################################
+# Application overlay - nrf52dk_nrf52832
+
+CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE=n

--- a/samples/bluetooth/mesh/light_ctrl/boards/nrf52dk_nrf52832.conf
+++ b/samples/bluetooth/mesh/light_ctrl/boards/nrf52dk_nrf52832.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+################################################################################
+# Application overlay - nrf52dk_nrf52832
+
+CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE=n

--- a/samples/bluetooth/mesh/light_dimmer/boards/nrf52dk_nrf52832.conf
+++ b/samples/bluetooth/mesh/light_dimmer/boards/nrf52dk_nrf52832.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+################################################################################
+# Application overlay - nrf52dk_nrf52832
+
+CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE=n

--- a/samples/bluetooth/mesh/light_switch/boards/nrf52dk_nrf52832.conf
+++ b/samples/bluetooth/mesh/light_switch/boards/nrf52dk_nrf52832.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+################################################################################
+# Application overlay - nrf52dk_nrf52832
+
+CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE=n

--- a/samples/bluetooth/mesh/sensor_client/boards/nrf52dk_nrf52832.conf
+++ b/samples/bluetooth/mesh/sensor_client/boards/nrf52dk_nrf52832.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+################################################################################
+# Application overlay - nrf52dk_nrf52832
+
+CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE=n

--- a/samples/bluetooth/mesh/sensor_server/boards/nrf52dk_nrf52832.conf
+++ b/samples/bluetooth/mesh/sensor_server/boards/nrf52dk_nrf52832.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+################################################################################
+# Application overlay - nrf52dk_nrf52832
+
+CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE=n

--- a/samples/bluetooth/mesh/silvair_enocean/boards/nrf52dk_nrf52832.conf
+++ b/samples/bluetooth/mesh/silvair_enocean/boards/nrf52dk_nrf52832.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+################################################################################
+# Application overlay - nrf52dk_nrf52832
+
+CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE=n


### PR DESCRIPTION
nrf52832 doesn't support partial erase functionality. Enabling the feature by default generates warning for the platform.