### PR TITLE
nrf_security: enable HUK provisioning during `psa_driver_wrapper_init`

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -181,6 +181,8 @@ Thread
   You can still build all examples with deprecated Mbed TLS support by setting the :kconfig:option:`OPENTHREAD_NRF_SECURITY_CHOICE` Kconfig option to ``y``, but you must build the Thread libraries from sources.
   To :ref:`inherit Thread certification <ug_thread_cert_inheritance_without_modifications>` from Nordic Semiconductor, you must use the PSA Crypto API backend.
 
+* nRF5340 SoC targets that don't include :ref:`Trusted Firmware-M <ug_tfm>` now use Hardware Unique Key (HUK, see the :ref:`lib_hw_unique_key` library) for PSA Internal Trusted Storage (ITS).
+
 See `Thread samples`_ for the list of changes for the Thread samples.
 
 Zigbee

--- a/lib/hw_unique_key/Kconfig
+++ b/lib/hw_unique_key/Kconfig
@@ -50,6 +50,13 @@ config HW_UNIQUE_KEY
 
 if HW_UNIQUE_KEY
 
+config HW_UNIQUE_KEY_WRITE_ON_CRYPTO_INIT
+	bool "Write HUK on crypto_driver initialization"
+	depends on !BUILD_WITH_TFM
+	help
+	  Write the HUK in psa_driver_wrapper_init. For devices without KMU this
+	  still requires the device to reboot and the bootloader to load the HUK
+
 config HW_UNIQUE_KEY_RANDOM
 	bool "Enable writing random HW Unique Keys"
 	depends on MAIN_STACK_SIZE >= 2048 || BUILD_WITH_TFM

--- a/subsys/net/openthread/Kconfig
+++ b/subsys/net/openthread/Kconfig
@@ -64,14 +64,19 @@ config OPENTHREAD_NRF_SECURITY_PSA
 	select TRUSTED_STORAGE
 	# TRUSTED_STORAGE requires Settings
 	select SETTINGS
+	select HW_UNIQUE_KEY_WRITE_ON_CRYPTO_INIT if SOC_NRF5340_CPUAPP
 	depends on !BUILD_WITH_TFM
 
+if (OPENTHREAD_NRF_SECURITY_PSA && (BUILD_WITH_TFM || !SOC_NRF5340_CPUAPP))
+# Temporarily use hash of UID as AEAD Key implementation for non nRF5340 and TFM builds
+# until Hardware Unique Key provisioning (more secure) is implemented for all targets
+
 choice TRUSTED_STORAGE_BACKEND_AEAD_KEY
-# Temporarily use hash of UID as AEAD Key implementation
-# until Hardware Unique Key provisioning (more secure) is implemented
-	default TRUSTED_STORAGE_BACKEND_AEAD_KEY_HASH_UID if OPENTHREAD_NRF_SECURITY_PSA
+	default TRUSTED_STORAGE_BACKEND_AEAD_KEY_HASH_UID
 
 endchoice # TRUSTED_STORAGE_BACKEND_AEAD_KEY
+
+endif # (OPENTHREAD_NRF_SECURITY_PSA && (BUILD_WITH_TFM || !SOC_NRF5340_CPUAPP))
 
 config OPENTHREAD_NRF_SECURITY
 	bool


### PR DESCRIPTION
- enabled HUK provisioning during `psa_driver_wrapper_init` for non-TFM builds
- enabled HUK in OpenThread for non-TFM nrf5340 samples