### PR TITLE
nrf_rpc: use u32_count_leading_zeros instead of __CLZ

### DIFF
--- a/subsys/nrf_rpc/nrf_rpc_os.c
+++ b/subsys/nrf_rpc/nrf_rpc_os.c
@@ -8,6 +8,7 @@
 #include <nrf_rpc_log.h>
 
 #include "nrf_rpc_os.h"
+#include <zephyr/sys/math_extras.h>
 
 /* Maximum number of remote thread that this implementation allows. */
 #define MAX_REMOTE_THREADS 255
@@ -126,7 +127,7 @@ uint32_t nrf_rpc_os_ctx_pool_reserve(void)
 
 	do {
 		old_mask = atomic_get(&context_mask);
-		number = __CLZ(old_mask);
+		number = u32_count_leading_zeros(old_mask);
 		new_mask = old_mask & ~(0x80000000u >> number);
 	} while (!atomic_cas(&context_mask, old_mask, new_mask));
 


### PR DESCRIPTION
__CLZ is a CMSIS marco and may not always be available in all build configurations, for example when building a minimal configuration with nrf_rpc enabled.

Use Zephyr's u32_count_leading_zeros instead.