### PR TITLE
doc: bluetooth: mesh: update sensor docs to new API

### DIFF
--- a/doc/nrf/libraries/bluetooth_services/mesh/light_ctrl_cli.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/light_ctrl_cli.rst
@@ -7,6 +7,13 @@ Light Lightness Control Client
    :local:
    :depth: 2
 
+.. note::
+   This model interacts with the new sensor API introduced as of |NCS| v2.6.0.
+   As a consequence, parts of the model API have been changed as well.
+   The old API is deprecated, but still available by enabling the Kconfig option :kconfig:option:`CONFIG_BT_MESH_SENSOR_USE_LEGACY_SENSOR_VALUE`.
+   The Kconfig option is enabled by default in the deprecation period.
+   See the documentation for |NCS| versions prior to v2.6.0 for documentation about the old sensor API.
+
 The Light Lightness Control (LC) Client configures and interacts with the :ref:`bt_mesh_light_ctrl_srv_readme`.
 
 The Light LC Client creates a single model instance in the mesh composition data, and it can send messages to both the Light LC Server and the Light LC Setup Server, as long as it has the right application keys.

--- a/doc/nrf/libraries/bluetooth_services/mesh/light_ctrl_srv.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/light_ctrl_srv.rst
@@ -7,6 +7,13 @@ Light Lightness Control Server
    :local:
    :depth: 2
 
+.. note::
+   This model interacts with the new sensor API introduced as of |NCS| v2.6.0.
+   As a consequence, parts of the model API have been changed as well.
+   The old API is deprecated, but still available by enabling the Kconfig option :kconfig:option:`CONFIG_BT_MESH_SENSOR_USE_LEGACY_SENSOR_VALUE`.
+   The Kconfig option is enabled by default in the deprecation period.
+   See the documentation for |NCS| versions prior to v2.6.0 for documentation about the old sensor API.
+
 The Light Lightness Control (LC) Server controls a single :ref:`bt_mesh_lightness_srv_readme` instance on the same device with a state machine.
 
 The state machine defines common behavior for a light fixture through three states, each with its own timing parameters and light levels.

--- a/doc/nrf/libraries/bluetooth_services/mesh/sensor_cli.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/sensor_cli.rst
@@ -7,6 +7,12 @@ Sensor Client
    :local:
    :depth: 2
 
+.. note::
+   A new sensor API is introduced as of |NCS| v2.6.0.
+   The old API is deprecated, but still available by enabling the Kconfig option :kconfig:option:`CONFIG_BT_MESH_SENSOR_USE_LEGACY_SENSOR_VALUE`.
+   The Kconfig option is enabled by default in the deprecation period.
+   See the documentation for |NCS| versions prior to v2.6.0 for documentation about the old sensor API.
+
 The Sensor Client model reads and configures the sensors exposed by :ref:`bt_mesh_sensor_srv_readme` models.
 
 Unlike the Sensor Server model, the Sensor Client only creates a single model instance in the mesh composition data.

--- a/doc/nrf/libraries/bluetooth_services/mesh/sensor_srv.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/sensor_srv.rst
@@ -7,6 +7,12 @@ Sensor Server
    :local:
    :depth: 2
 
+.. note::
+   A new sensor API is introduced as of |NCS| v2.6.0.
+   The old API is deprecated, but still available by enabling the Kconfig option :kconfig:option:`CONFIG_BT_MESH_SENSOR_USE_LEGACY_SENSOR_VALUE`.
+   The Kconfig option is enabled by default in the deprecation period.
+   See the documentation for |NCS| versions prior to v2.6.0 for documentation about the old sensor API.
+
 The Sensor Server model holds a list of sensors, and exposes them to the mesh network.
 There may be multiple Sensor Server models on a single mesh node, and each model may hold up to 47 sensors.
 

--- a/doc/nrf/libraries/bluetooth_services/mesh/sensor_types.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/sensor_types.rst
@@ -1,13 +1,13 @@
 .. _bt_mesh_sensor_types_readme:
 
-Bluetooth Mesh sensor types
-###########################
+Bluetooth Mesh sensor formats and sensor types
+##############################################
 
 .. contents::
    :local:
    :depth: 2
 
-All sensor types are collected in :file:`include/bluetooth/mesh/sensor_types.h`, and are divided into the categories listed in the page index.
+All sensor formats and sensor types are collected in the :file:`include/bluetooth/mesh/sensor_types.h` file, and are divided into the categories listed in the page index.
 
 To keep the total flash usage down, the sensor types are only instantiated if they're referenced by the application.
 This behavior can be overridden by enabling :kconfig:option:`CONFIG_BT_MESH_SENSOR_ALL_TYPES`.
@@ -17,16 +17,86 @@ Sensor types can be forced into the build by the :c:macro:`BT_MESH_SENSOR_TYPE_F
 
 Sensor types may only be declared in the ``bt_mesh_sensor_types`` static linker section.
 
-See :ref:`bt_mesh_sensor_types` for information on how to use these sensor types when initializing and using sensors.
+See :ref:`bt_mesh_sensor_types` for information on how to use these sensor types and formats when initializing and using sensors.
 
 .. doxygengroup:: bt_mesh_sensor_types
    :project: nrf
    :content-only:
 
+.. _bt_mesh_sensor_types_formats_readme:
+
+Sensor formats
+**************
+
+.. _bt_mesh_sensor_formats_percentage_readme:
+
+Percentage sensor formats
+=========================
+
+.. doxygengroup:: bt_mesh_sensor_formats_percentage
+   :project: nrf
+   :members:
+   :content-only:
+
+.. _bt_mesh_sensor_formats_environmental_readme:
+
+Environmental sensor formats
+============================
+
+.. doxygengroup:: bt_mesh_sensor_formats_environmental
+   :project: nrf
+   :members:
+   :content-only:
+
+.. _bt_mesh_sensor_formats_time_readme:
+
+Time sensor formats
+===================
+
+.. doxygengroup:: bt_mesh_sensor_formats_time
+   :project: nrf
+   :members:
+   :content-only:
+
+.. _bt_mesh_sensor_formats_electrical_readme:
+
+Electrical sensor formats
+=========================
+
+.. doxygengroup:: bt_mesh_sensor_formats_electrical
+   :project: nrf
+   :members:
+   :content-only:
+
+.. _bt_mesh_sensor_formats_lighting_readme:
+
+Lighting sensor formats
+=======================
+
+.. doxygengroup:: bt_mesh_sensor_formats_lighting
+   :project: nrf
+   :members:
+   :content-only:
+
+.. _bt_mesh_sensor_formats_miscellaneous_readme:
+
+Miscellaneous sensor formats
+============================
+
+.. doxygengroup:: bt_mesh_sensor_formats_miscellaneous
+   :project: nrf
+   :members:
+   :content-only:
+
+.. _bt_mesh_sensor_types_types_readme:
+
+Sensor types
+************
+
 .. _bt_mesh_sensor_types_occupancy_readme:
 
 Occupancy sensor types
-**********************
+======================
 
 .. doxygengroup:: bt_mesh_sensor_types_occupancy
    :project: nrf
@@ -36,7 +106,7 @@ Occupancy sensor types
 .. _bt_mesh_sensor_types_ambient_temperature_readme:
 
 Ambient temperature sensor types
-********************************
+================================
 
 .. doxygengroup:: bt_mesh_sensor_types_ambient_temperature
    :project: nrf
@@ -46,7 +116,7 @@ Ambient temperature sensor types
 .. _bt_mesh_sensor_types_environmental_readme:
 
 Environmental sensor types
-**************************
+==========================
 
 .. doxygengroup:: bt_mesh_sensor_types_environmental
    :project: nrf
@@ -56,7 +126,7 @@ Environmental sensor types
 .. _bt_mesh_sensor_types_device_operating_temperature_readme:
 
 Device operating temperature sensor types
-*****************************************
+=========================================
 
 .. doxygengroup:: bt_mesh_sensor_types_device_operating_temperature
    :project: nrf
@@ -66,7 +136,7 @@ Device operating temperature sensor types
 .. _bt_mesh_sensor_types_electrical_input_readme:
 
 Electrical input sensor types
-*****************************
+=============================
 
 .. doxygengroup:: bt_mesh_sensor_types_electrical_input
    :project: nrf
@@ -76,7 +146,7 @@ Electrical input sensor types
 .. _bt_mesh_sensor_types_energy_management_readme:
 
 Energy management sensor types
-******************************
+==============================
 
 .. doxygengroup:: bt_mesh_sensor_types_energy_management
    :project: nrf
@@ -86,7 +156,7 @@ Energy management sensor types
 .. _bt_mesh_sensor_types_photometry_readme:
 
 Photometry sensor types
-***********************
+=======================
 
 .. doxygengroup:: bt_mesh_sensor_types_photometry
    :project: nrf
@@ -96,7 +166,7 @@ Photometry sensor types
 .. _bt_mesh_sensor_types_power_supply_output_readme:
 
 Power supply output sensor types
-********************************
+================================
 
 .. doxygengroup:: bt_mesh_sensor_types_power_supply_output
    :project: nrf
@@ -106,7 +176,7 @@ Power supply output sensor types
 .. _bt_mesh_sensor_types_warranty_and_service_readme:
 
 Warranty and Service sensor types
-*********************************
+=================================
 
 .. doxygengroup:: bt_mesh_sensor_types_warranty_and_service
    :project: nrf

--- a/include/bluetooth/mesh/sensor.h
+++ b/include/bluetooth/mesh/sensor.h
@@ -279,7 +279,11 @@ struct bt_mesh_sensor_column {
 	struct bt_mesh_sensor_value width;
 };
 
-/** Sensor format callbacks. */
+/** Sensor format callbacks.
+ *
+ *  (For internal use, applications should use the conversion functions provided
+ *  in sensor.h instead.)
+ */
 struct bt_mesh_sensor_format_cb {
 	/** @brief Perform a delta check between two @ref bt_mesh_sensor_value
 	 *         instances.
@@ -332,9 +336,9 @@ struct bt_mesh_sensor_format_cb {
 	 *  If @c val has a value that cannot be represented by the format,
 	 *  @c sensor_val will be set to the value clamped to the range
 	 *  supported by the format, and this function will return -ERANGE. This
-	 *  will clamp to "Greater than or equal to the maximum value" and "Less
-	 *  than or equal to the minimum value" if these are supported by the
-	 *  format.
+	 *  will clamp to "Greater than or equal to the maximum value" and
+	 *  "Less than or equal to the minimum value" if these are supported by
+	 *  the format.
 	 *
 	 *  If this function returns an error code other than -ERANGE,
 	 *  @c sensor_val is not modified.
@@ -368,9 +372,9 @@ struct bt_mesh_sensor_format_cb {
 	 *  If @c val has a value that cannot be represented by the format,
 	 *  @c sensor_val will be set to the value clamped to the range
 	 *  supported by the format, and this function will return -ERANGE. This
-	 *  will clamp to "Greater than or equal to the maximum value" and "Less
-	 *  than or equal to the minimum value" if these are supported by the
-	 *  format.
+	 *  will clamp to "Greater than or equal to the maximum value" and
+	 *  "Less than or equal to the minimum value" if these are supported by
+	 *  the format.
 	 *
 	 *  If this function returns an error code other than -ERANGE,
 	 *  @c sensor_val is not modified.
@@ -448,7 +452,11 @@ struct bt_mesh_sensor_format_cb {
 
 /** Sensor channel value format. */
 struct bt_mesh_sensor_format {
-	/** Callbacks used for this format. */
+	/** Callbacks used for this format.
+	 *
+	 *  (For internal use. Applications should use the conversion functions
+	 *  in sensor.h)
+	 */
 	struct bt_mesh_sensor_format_cb *cb;
 	/** User data pointer. Used internally by the sensor types. */
 	void *user_data;
@@ -645,8 +653,9 @@ int bt_mesh_sensor_value_compare(const struct bt_mesh_sensor_value *a,
 
 /** @brief Returns true if @c status is a value which can be represented by a
  *         number, meaning one of @c BT_MESH_SENSOR_VALUE_NUMBER,
- *         @c BT_MESH_SENSOR_VALUE_MIN_OR_LESS and
- *         @c BT_MESH_SENSOR_VALUE_MAX_OR_GREATER.
+ *         @c BT_MESH_SENSOR_VALUE_MIN_OR_LESS,
+ *         @c BT_MESH_SENSOR_VALUE_MAX_OR_GREATER and
+ *         @c BT_MESH_SENSOR_VALUE_CLAMPED
  *
  *  @param[in] status The value to check.
  *
@@ -681,8 +690,9 @@ bt_mesh_sensor_value_to_float(const struct bt_mesh_sensor_value *sensor_val,
  *  If @c val has a value that cannot be represented by the format,
  *  @c sensor_val will be set to the value clamped to the range supported by
  *  the format, and this function will return -ERANGE. This will clamp to
- *  "Greater than or equal to the maximum value" and "Less than or equal to the
- *  minimum value" if these are supported by the format.
+ *  "Greater than or equal to the maximum value" and
+ *  "Less than or equal to the minimum value" if these are supported by the
+ *  format.
  *
  *  If this function returns an error code other than -ERANGE, @c sensor_val is
  *  not modified.
@@ -719,8 +729,9 @@ bt_mesh_sensor_value_to_micro(
  *  If @c val has a value that cannot be represented by the format,
  *  @c sensor_val will be set to the value clamped to the range supported by
  *  the format, and this function will return -ERANGE. This will clamp to
- *  "Greater than or equal to the maximum value" and "Less than or equal to the
- *  minimum value" if these are supported by the format.
+ *  "Greater than or equal to the maximum value" and
+ *  "Less than or equal to the minimum value" if these are supported by the
+ *  format.
  *
  *  If this function returns an error code other than -ERANGE, @c sensor_val is
  *  not modified.
@@ -759,8 +770,9 @@ bt_mesh_sensor_value_to_sensor_value(
  *  If @c val has a value that cannot be represented by the format,
  *  @c sensor_val will be set to the value clamped to the range supported by
  *  the format, and this function will return -ERANGE. This will clamp to
- *  "Greater than or equal to the maximum value" and "Less than or equal to the
- *  minimum value" if these are supported by the format.
+ *  "Greater than or equal to the maximum value" and
+ *  "Less than or equal to the minimum value" if these are supported by the
+ *  format.
  *
  *  If this function returns an error code other than -ERANGE, @c sensor_val is
  *  not modified.
@@ -828,6 +840,9 @@ bool bt_mesh_sensor_value_in_column(const struct bt_mesh_sensor_value *value,
 
 /** @brief Get a human readable representation of a single sensor channel.
  *
+ *  @note This prints float values internally for most formats, which requires
+ *  @kconfig{CONFIG_CBPRINTF_FP_SUPPORT} to be enabled.
+ *
  *  @param[in]  ch  Sensor channel to represent.
  *  @param[out] str String buffer to fill. Should be @ref
  *                  BT_MESH_SENSOR_CH_STR_LEN bytes long.
@@ -840,6 +855,9 @@ int bt_mesh_sensor_ch_to_str(const struct bt_mesh_sensor_value *ch, char *str,
 			     size_t len);
 
 /** @brief Get a human readable representation of a single sensor channel.
+ *
+ *  @note This prints float values internally for most formats, which requires
+ *  @kconfig{CONFIG_CBPRINTF_FP_SUPPORT} to be enabled.
  *
  *  @note This function is not thread safe.
  *


### PR DESCRIPTION
This updates the sensor and light ctrl documentation to align with the new Sensor API. It also adds a note about the API change and information about the documention for the old API being available in the previous NCS release to relevant locations.