### PR TITLE
manifest: zephyr: update zephyr remove weak nrf_802154_clock_hfclk_ready

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 0fa93fad62c1cf6fb1f4c0f8fa30afcb0dbe50aa
+      revision: pull/1545/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This commit updates Zephyr with removed __WEAK-tagged version of nrf_802154_clock_hfclk_ready.