### PR TITLE
partition_manager: NRF54L support for MCUboot added

### DIFF
--- a/cmake/partition_manager.cmake
+++ b/cmake/partition_manager.cmake
@@ -206,6 +206,14 @@ elseif (DEFINED CONFIG_SOC_NRF5340_CPUAPP)
   set(otp_size 764)  # 191 * 4
 endif()
 
+if (DEFINED CONFIG_SOC_PLATFORM_NRF54L)
+  set(soc_nvs_controller rram_controller)
+  set(soc_nvs_controller_driver_kc CONFIG_SOC_FLASH_NRF_RRAM)
+else()
+  set(soc_nvs_controller flash_controller)
+  set(soc_nvs_controller_driver_kc CONFIG_SOC_FLASH_NRF)
+endif()
+
 add_region(
   NAME sram_primary
   SIZE ${CONFIG_PM_SRAM_SIZE}
@@ -229,8 +237,8 @@ add_region(
   SIZE ${flash_size}
   BASE ${CONFIG_FLASH_BASE_ADDRESS}
   PLACEMENT complex
-  DEVICE flash_controller
-  DEFAULT_DRIVER_KCONFIG CONFIG_SOC_FLASH_NRF
+  DEVICE ${soc_nvs_controller}
+  DEFAULT_DRIVER_KCONFIG ${soc_nvs_controller_driver_kc}
   )
 
 dt_chosen(ext_flash_dev PROPERTY nordic,pm-ext-flash)

--- a/modules/mcuboot/boot/zephyr/Kconfig
+++ b/modules/mcuboot/boot/zephyr/Kconfig
@@ -15,8 +15,14 @@ partition-size=0x1e000
 source "${ZEPHYR_BASE}/../nrf/subsys/partition_manager/Kconfig.template.partition_config"
 
 partition=MCUBOOT_PAD
-partition-size=0x200
+if SOC_PLATFORM_NRF54L
+	partition-size=0x800
 source "${ZEPHYR_BASE}/../nrf/subsys/partition_manager/Kconfig.template.partition_config"
+endif
+if !SOC_PLATFORM_NRF54L
+	partition-size=0x200
+source "${ZEPHYR_BASE}/../nrf/subsys/partition_manager/Kconfig.template.partition_config"
+endif
 
 config PM_PARTITION_SIZE_MCUBOOT
 	hex


### PR DESCRIPTION
Changes to Kconfig and CMake that allow MCUboot to work with NRF54L. The Kconfig has been changed to change size of MCUboot header and CMake to properly invoke partition manager script with RRAM as NVM.