### PR TITLE
modules/mcuboot: Fix incorrect size used for signing external image

### DIFF
--- a/modules/mcuboot/CMakeLists.txt
+++ b/modules/mcuboot/CMakeLists.txt
@@ -478,7 +478,7 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
     sign(
       SIGNED_BIN_FILE_IN ${PROJECT_BINARY_DIR}/qspi_flash.hex
       SIGNED_HEX_FILE_NAME_PREFIX ${PROJECT_BINARY_DIR}/qspi_flash
-      SLOT_SIZE $<TARGET_PROPERTY:partition_manager,PM_MCUBOOT_PRIMARY_SIZE>
+      SLOT_SIZE $<TARGET_PROPERTY:partition_manager,PM_MCUBOOT_PRIMARY_2_SIZE>
       SIGNED_HEX_FILE_OUT qspi_flash_signed_hex
       SIGNED_BIN_FILE_OUT qspi_flash_signed_bin
       ${sign_dependencies}


### PR DESCRIPTION
The image signing has been taking, as --slot-size parameter, size of primary internal slot rather than expected external slot it has been signing image for.