### PR TITLE
doc: openthread: Adding documentation about TCAT.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -74,6 +74,8 @@ Kconfig*                                  @tejlmand
 /doc/nrf/security/                        @greg-fer
 /doc/nrf/test_and_optimize/               @greg-fer
 /doc/nrf/*.rst                            @greg-fer
+# Protocols related docs
+/doc/nrf/protocols/thread/*.rst           @wiba-nordic
 # All subfolders
 /drivers/                                 @anangl
 /drivers/serial/                          @nordic-krch @anangl

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -97,6 +97,7 @@
 .. _`OpenThread CLI Reference - pollperiod command`: https://github.com/openthread/openthread/blob/main/src/cli/README.md#pollperiod
 .. _`Commissioner CLI commands`: https://github.com/openthread/openthread/blob/main/src/cli/README_COMMISSIONER.md
 .. _`Joiner CLI commands`: https://github.com/openthread/openthread/blob/main/src/cli/README_JOINER.md
+.. _`BBTC Client`: https://github.com/nrfconnect/sdk-openthread/tree/main/tools/tcat_ble_client
 
 .. _`Breathe issue #437`: https://github.com/michaeljones/breathe/issues/437
 .. _`Breathe issue #438`: https://github.com/michaeljones/breathe/issues/438

--- a/doc/nrf/protocols/thread/index.rst
+++ b/doc/nrf/protocols/thread/index.rst
@@ -33,3 +33,4 @@ You can find more information about Thread on the `Thread Group`_ pages.
    certification
    device_types
    sed_ssed
+   tcat

--- a/doc/nrf/protocols/thread/tcat.rst
+++ b/doc/nrf/protocols/thread/tcat.rst
@@ -1,0 +1,24 @@
+.. _thread_tcat:
+
+Thread Commissioning Over Authenticated TLS
+###########################################
+
+.. contents::
+   :local:
+   :depth: 2
+
+Thread Commissioning Over Authenticated TLS (TCAT) was developed to address the needs of professional installation and commercial building scenarios.
+It makes it easy to wirelessly onboard Thread devices that are pre-installed in difficult-to-reach places, such as inside a ceiling or embedded in a wall.
+Instead of scanning physical install codes once the pre-installed devices are powered, Thread commissioning can be implemented over authenticated TLS (Transport Layer Security) by exchanging security certificates.
+TCAT can be performed using a mobile device (such as a phone, tablet) while in close proximity to the pre-installed device over a wireless connection such as Bluetooth® Low Energy.
+The |NCS| currently provides experimental support for TCAT.
+To test this feature, build the :ref:`ot_cli_sample` sample with the :ref:`TCAT snippet <ot_cli_sample_activating_variants>` enabled.
+
+After flashing the sample to the device, use the following command to enable TCAT:
+
+.. code-block:: console
+
+   uart:~$ ot tcat start
+
+Currently, `BBTC Client`_ is the only available TCAT commissioner tool, and can be found in the OpenThread repository.
+Refer to the tool's documentation for more information.

--- a/samples/openthread/cli/README.rst
+++ b/samples/openthread/cli/README.rst
@@ -103,6 +103,7 @@ The following snippets are available:
   Not compatible with the ``tcat`` snippet.
 * ``tcat`` - Enables support for Thread comissioning over authenticated TLS.
   Not compatible with the ``multiprotocol`` snippet.
+  For using TCAT, refer to the :ref:`thread_tcat` page.
 * ``tcp`` - Enables experimental TCP support in this sample.
 * ``low_power`` - Enables low power consumption mode in this sample.
 


### PR DESCRIPTION
This commit add TCAT documentation section in NCS Thread related docs.