### PR TITLE
lib: location: Fix compile issue without cellular

### DIFF
--- a/lib/location/scan_cellular.c
+++ b/lib/location/scan_cellular.c
@@ -69,7 +69,7 @@ struct lte_lc_cells_info *scan_cellular_results_get(void)
 	return &scan_cellular_info;
 }
 
-#if defined(CONFIG_LOCATION_DATA_DETAILS)
+#if defined(CONFIG_LOCATION_METHOD_CELLULAR) && defined(CONFIG_LOCATION_DATA_DETAILS)
 void scan_cellular_details_get(struct location_data_details *details)
 {
 	details->cellular.ncells_count = scan_cellular_info.ncells_count;


### PR DESCRIPTION
When the following config was set, scan_cellular.c didn't compile because it tried to use cellular details:
CONFIG_LOCATION_DATA_DETAILS=y
CONFIG_LOCATION_METHOD_CELLULAR=n
CONFIG_LOCATION_METHOD_GNSS=y

scan_cellular.c is also compile for GNSS as it uses NCELLMEAS to obtain current cell.