### PR TITLE
Promiscuous mode shell command

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -778,6 +778,9 @@ Wi-Fi samples
     * Added ``raw_tx`` extension to the Wi-Fi command line.
       It adds the subcommands to configure and send raw TX packets.
 
+    * Added ``promiscuous_set`` extension to the Wi-Fi command line.
+      It adds the subcommand to configure Promiscuous mode.
+
 * Added the :ref:`wifi_softap_sample` sample that demonstrates how to start a nRF70 Series device in :term:`Software-enabled Access Point (SoftAP or SAP)` mode.
 * Added the :ref:`wifi_raw_tx_packet_sample` sample that demonstrates how to transmit raw TX packets.
 

--- a/samples/wifi/shell/CMakeLists.txt
+++ b/samples/wifi/shell/CMakeLists.txt
@@ -19,4 +19,9 @@ target_sources_ifdef(CONFIG_NRF700X_RAW_DATA_TX
 	PRIVATE
 	src/wifi_raw_tx_pkt_shell.c)
 
+target_sources_ifdef(CONFIG_NRF700X_PROMISC_DATA_RX
+	app
+	PRIVATE
+	src/wifi_promiscuous_shell.c)
+
 target_sources(app PRIVATE src/main.c)

--- a/samples/wifi/shell/README.rst
+++ b/samples/wifi/shell/README.rst
@@ -312,6 +312,24 @@ It adds the following subcommands to configure and send raw TX packets:
 
 For more information, see :ref:`ug_nrf70_developing_raw_ieee_80211_packet_transmission`.
 
+``promiscuous_set`` is an extension to the Wi-Fi command line.
+It adds the following subcommand to configure Promiscuous mode:
+
+.. list-table:: Promiscuous mode shell subcommand
+   :header-rows: 1
+
+   * - Subcommand
+     - Description
+     - Valid values
+   * - mode
+     - | Enable or Disable Promiscuous mode
+       | [-h, --help]: Print out the help for the mode command
+     - | Valid values:
+       | 1 - Enable
+       | 0 - Disable
+
+For more information, see :ref:`ug_nrf70_developing_promiscuous_packet_reception`.
+
 Testing STA mode
 ================
 

--- a/samples/wifi/shell/src/wifi_promiscuous_shell.c
+++ b/samples/wifi/shell/src/wifi_promiscuous_shell.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/** @file
+ * @brief Wi-Fi Promiscuous mode shell
+ */
+
+#include <stdlib.h>
+#include <zephyr/shell/shell.h>
+#include <zephyr/posix/unistd.h>
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(promiscuous_mode, CONFIG_LOG_DEFAULT_LEVEL);
+
+#include "net_private.h"
+
+static int cmd_wifi_promisc(const struct shell *sh, size_t argc, char *argv[])
+{
+	struct net_if *iface = NULL;
+	bool mode_val = 0;
+
+	if (argc != 2) {
+		shell_help(sh);
+		return -ENOEXEC;
+	}
+
+	if (strcmp(argv[1], "-h") == 0) {
+		shell_help(sh);
+		return 0;
+	} else if ((strcmp(argv[1], "1") == 0) || (strcmp(argv[1], "0") == 0)) {
+		mode_val = atoi(argv[1]);
+	} else {
+		LOG_ERR("Entered wrong input");
+		shell_help(sh);
+		return -ENOEXEC;
+	}
+
+	iface = net_if_get_first_wifi();
+	if (!iface) {
+		LOG_ERR("Failed to get Wi-Fi iface");
+		return -ENOEXEC;
+	}
+
+	if (net_eth_promisc_mode(iface, mode_val)) {
+		LOG_ERR("Promiscuous mode %s failed", mode_val ? "enabling" : "disabling");
+	}
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	promisc_cmd,
+	SHELL_CMD_ARG(mode, NULL,
+		      "This command may be used to enable or disable promiscuous mode\n"
+		      "[enable: 1, disable: 0]\n"
+		      "[-h, --help] : Print out the help for the mode command\n"
+		      "Usage: promiscuous_set mode 1 or 0\n",
+		      cmd_wifi_promisc,
+		      2, 0),
+	SHELL_SUBCMD_SET_END
+);
+
+SHELL_CMD_REGISTER(promiscuous_set,
+		   &promisc_cmd,
+		   "Promiscuous mode command (To set promiscuous mode)",
+		   NULL);


### PR DESCRIPTION
This set of changes adds a promiscuous mode shell command to shell sample to configure promiscuous mode for the nRF Wi-Fi driver.