### PR TITLE
Bluetooth: Mesh: add model metadata

### DIFF
--- a/include/bluetooth/mesh/light_hsl_srv.h
+++ b/include/bluetooth/mesh/light_hsl_srv.h
@@ -34,9 +34,9 @@ struct bt_mesh_light_hsl_srv;
  *  @param[in] _hue_handlers Hue Server model handlers.
  *  @param[in] _sat_handlers Saturation Server model handlers.
  */
-#define BT_MESH_LIGHT_HSL_SRV_INIT(_lightness_srv, _hue_handlers, _sat_handlers)                 \
+#define BT_MESH_LIGHT_HSL_SRV_INIT(_lightness_srv, _hue_handlers, _sat_handlers)                   \
 	{                                                                                          \
-		.lightness = _lightness_srv,                          \
+		.lightness = _lightness_srv,                                                       \
 		.hue = BT_MESH_LIGHT_HUE_SRV_INIT(_hue_handlers),                                  \
 		.sat = BT_MESH_LIGHT_SAT_SRV_INIT(_sat_handlers),                                  \
 	}
@@ -58,6 +58,53 @@ struct bt_mesh_light_hsl_srv;
 			 BT_MESH_MODEL_USER_DATA(struct bt_mesh_light_hsl_srv, \
 						 _srv),                        \
 			 &_bt_mesh_light_hsl_setup_srv_cb)
+
+#ifdef CONFIG_BT_MESH_LARGE_COMP_DATA_SRV
+/** @def BT_MESH_MODEL_LIGHT_HSL_SRV_WITH_METADATA
+ *
+ *  @brief Light HSL Server model composition data entry.
+ *
+ *  @param[in] _srv Pointer to a @ref bt_mesh_light_hsl_srv instance.
+ *  @param[in] _metadata Pointer to a @ref bt_mesh_models_metadata_entry.
+ */
+#define BT_MESH_MODEL_LIGHT_HSL_SRV_WITH_METADATA(_srv, _metadata)             \
+	BT_MESH_MODEL_METADATA_CB(BT_MESH_MODEL_ID_LIGHT_HSL_SRV,              \
+			 _bt_mesh_light_hsl_srv_op, &(_srv)->pub,              \
+			 BT_MESH_MODEL_USER_DATA(struct bt_mesh_light_hsl_srv, \
+						 _srv),                        \
+			 &_bt_mesh_light_hsl_srv_cb, &_metadata),              \
+	BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_LIGHT_HSL_SETUP_SRV,                 \
+			 _bt_mesh_light_hsl_setup_srv_op, NULL,                \
+			 BT_MESH_MODEL_USER_DATA(struct bt_mesh_light_hsl_srv, \
+						 _srv),                        \
+			 &_bt_mesh_light_hsl_setup_srv_cb)
+#endif
+
+/** Light HSL Hue Range Metadata ID. */
+#define BT_MESH_LIGHT_HSL_HUE_RANGE_METADATA_ID 0x0005
+
+/** Light HSL Saturation Range Metadata ID. */
+#define BT_MESH_LIGHT_HSL_SAT_RANGE_METADATA_ID 0x0006
+
+/**
+ *  Light HSL Hue Range Metadata entry.
+ *
+ *  @param range_min Minimum boundary of range (16-bit)
+ *  @param range_max Maximum boundary of range (16-bit)
+ */
+#define BT_MESH_LIGHT_HSL_HUE_RANGE_METADATA(range_min, range_max)                                 \
+	BT_MESH_MODELS_METADATA_ENTRY(4, BT_MESH_LIGHT_HSL_HUE_RANGE_METADATA_ID,                  \
+				      ((uint16_t[]){(range_min), (range_max)}))
+
+/**
+ *  Light HSL Saturation Range Metadata entry.
+ *
+ *  @param range_min Minimum boundary of range (16-bit)
+ *  @param range_max Maximum boundary of range (16-bit)
+ */
+#define BT_MESH_LIGHT_HSL_SAT_RANGE_METADATA(range_min, range_max)                                 \
+	BT_MESH_MODELS_METADATA_ENTRY(4, BT_MESH_LIGHT_HSL_SAT_RANGE_METADATA_ID,                  \
+				      ((uint16_t[]){(range_min), (range_max)}))
 
 /**
  * Light HSL Server instance.

--- a/include/bluetooth/mesh/light_temp_srv.h
+++ b/include/bluetooth/mesh/light_temp_srv.h
@@ -58,6 +58,36 @@ struct bt_mesh_light_temp_srv;
 		BT_MESH_MODEL_USER_DATA(struct bt_mesh_light_temp_srv, _srv),  \
 		&_bt_mesh_light_temp_srv_cb)
 
+#ifdef CONFIG_BT_MESH_LARGE_COMP_DATA_SRV
+/** @def BT_MESH_MODEL_LIGHT_TEMP_SRV_WITH_METADATA
+ *
+ * @brief Light CTL Temperature Server model composition data entry.
+ *
+ * @param[in] _srv Pointer to a @ref bt_mesh_light_temp_srv instance.
+ * @param[in] _metadata Pointer to a @ref bt_mesh_models_metadata_entry.
+ */
+#define BT_MESH_MODEL_LIGHT_TEMP_SRV_WITH_METADATA(_srv, _metadata)            \
+	BT_MESH_MODEL_LVL_SRV(&(_srv)->lvl),                                   \
+	BT_MESH_MODEL_METADATA_CB(                                             \
+		BT_MESH_MODEL_ID_LIGHT_CTL_TEMP_SRV,                           \
+		_bt_mesh_light_temp_srv_op, &(_srv)->pub,                      \
+		BT_MESH_MODEL_USER_DATA(struct bt_mesh_light_temp_srv, _srv),  \
+		&_bt_mesh_light_temp_srv_cb, &_metadata)
+#endif
+
+/** Light CTL Temperature Range Metadata ID. */
+#define BT_MESH_LIGHT_CTL_TEMP_RANGE_METADATA_ID 0x0004
+
+/**
+ *  Light CTL Temperature Range Metadata entry.
+ *
+ *  @param range_min Minimum boundary of range (16-bit)
+ *  @param range_max Maximum boundary of range (16-bit)
+ */
+#define BT_MESH_LIGHT_CTL_TEMP_RANGE_METADATA(range_min, range_max)                                \
+	BT_MESH_MODELS_METADATA_ENTRY(4, BT_MESH_LIGHT_CTL_TEMP_RANGE_METADATA_ID,                 \
+				      ((uint16_t[]){(range_min), (range_max)}))
+
 /** Light CTL Temperature Server state access handlers. */
 struct bt_mesh_light_temp_srv_handlers {
 	/** @brief Set the Light Temperature state.

--- a/include/bluetooth/mesh/lightness_srv.h
+++ b/include/bluetooth/mesh/lightness_srv.h
@@ -65,6 +65,53 @@ struct bt_mesh_lightness_srv;
 						 _srv),                        \
 			 &_bt_mesh_lightness_setup_srv_cb)
 
+#ifdef CONFIG_BT_MESH_LARGE_COMP_DATA_SRV
+/** @def BT_MESH_MODEL_LIGHTNESS_SRV_WITH_METADATA
+ *
+ * @brief Light Lightness model entry with metadata.
+ *
+ * @param[in] _srv Pointer to a @ref bt_mesh_lightness_srv instance.
+ * @param[in] _metadata Pointer to a @ref bt_mesh_models_metadata_entry.
+ */
+#define BT_MESH_MODEL_LIGHTNESS_SRV_WITH_METADATA(_srv, _metadata)                                 \
+	BT_MESH_MODEL_LVL_SRV(&(_srv)->lvl),                                                       \
+	BT_MESH_MODEL_PONOFF_SRV(&(_srv)->ponoff),                                                 \
+	BT_MESH_MODEL_METADATA_CB(                                                                 \
+			BT_MESH_MODEL_ID_LIGHT_LIGHTNESS_SRV, _bt_mesh_lightness_srv_op,           \
+			&(_srv)->pub, BT_MESH_MODEL_USER_DATA(struct bt_mesh_lightness_srv, _srv), \
+			&_bt_mesh_lightness_srv_cb, &_metadata),                                   \
+	BT_MESH_MODEL_CB(                                                                          \
+			BT_MESH_MODEL_ID_LIGHT_LIGHTNESS_SETUP_SRV,                                \
+			_bt_mesh_lightness_setup_srv_op, NULL,                                     \
+			BT_MESH_MODEL_USER_DATA(struct bt_mesh_lightness_srv, _srv),               \
+			&_bt_mesh_lightness_setup_srv_cb)
+#endif
+
+/** The Light Purpose Metadata ID. */
+#define BT_MESH_LIGHT_PURPOSE_METADATA_ID 0x0002
+
+/** Light Lightness Range Metadata ID. */
+#define BT_MESH_LIGHT_LIGHTNESS_RANGE_METADATA_ID 0x0003
+
+/**
+ *  Define the Light Purpose Metadata entry.
+ *
+ *  @param light_purpose 16-bit light purpose value.
+ */
+#define BT_MESH_LIGHT_PURPOSE_METADATA(light_purpose)                                              \
+	BT_MESH_MODELS_METADATA_ENTRY(2, BT_MESH_LIGHT_PURPOSE_METADATA_ID,                        \
+				      ((uint16_t[]){(light_purpose)}))
+
+/**
+ *  Light Lightness Range Metadata entry.
+ *
+ *  @param range_min Minimum boundary of range (16-bit)
+ *  @param range_max Maximum boundary of range (16-bit)
+ */
+#define BT_MESH_LIGHT_LIGHTNESS_RANGE_METADATA(range_min, range_max)                               \
+	BT_MESH_MODELS_METADATA_ENTRY(4, BT_MESH_LIGHT_LIGHTNESS_RANGE_METADATA_ID,                \
+				      ((uint16_t[]){(range_min), (range_max)}))
+
 /** Collection of handler callbacks for the Light Lightness Server. */
 struct bt_mesh_lightness_srv_handlers {
 	/** @brief Set the Light state.

--- a/include/bluetooth/mesh/sensor_srv.h
+++ b/include/bluetooth/mesh/sensor_srv.h
@@ -58,6 +58,38 @@ struct bt_mesh_sensor_srv;
 					      _srv),                           \
 			 &_bt_mesh_sensor_setup_srv_cb)
 
+#ifdef CONFIG_BT_MESH_LARGE_COMP_DATA_SRV
+/** @def BT_MESH_MODEL_SENSOR_SRV_WITH_METADATA
+ *
+ *  @brief Sensor Server model composition data entry with metadata.
+ *
+ *  @param[in] _srv Pointer to a @ref bt_mesh_sensor_srv instance.
+ *  @param[in] _metadata Pointer to a @ref bt_mesh_models_metadata_entry.
+ */
+#define BT_MESH_MODEL_SENSOR_SRV_WITH_METADATA(_srv, _metadata)                                    \
+	BT_MESH_MODEL_METADATA_CB(BT_MESH_MODEL_ID_SENSOR_SRV, _bt_mesh_sensor_srv_op,             \
+				  &(_srv)->pub,                                                    \
+				  BT_MESH_MODEL_USER_DATA(struct bt_mesh_sensor_srv, _srv),        \
+				  &_bt_mesh_sensor_srv_cb, &_metadata),                     \
+	BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_SENSOR_SETUP_SRV, _bt_mesh_sensor_setup_srv_op,          \
+			 &(_srv)->setup_pub,                                                       \
+			 BT_MESH_MODEL_USER_DATA(struct bt_mesh_sensor_srv, _srv),                 \
+			 &_bt_mesh_sensor_setup_srv_cb)
+#endif
+
+/** Sensor Properties Metadata ID. */
+#define BT_MESH_SENSOR_PROP_METADATA_ID 0x0001
+
+/**
+ *  Sensor Properties Metadata entry.
+ *
+ *  @param[in] ... list of 16-bit sensor property IDs split by comma.
+ */
+#define BT_MESH_SENSOR_PROP_METADATA(...)                                                          \
+	BT_MESH_MODELS_METADATA_ENTRY(2 * ARRAY_SIZE(((uint16_t[]){__VA_ARGS__})),                 \
+				      BT_MESH_SENSOR_PROP_METADATA_ID,                             \
+				      ((uint16_t[]){__VA_ARGS__}))
+
 /** Sensor server instance. */
 struct bt_mesh_sensor_srv {
 	/** Sensors owned by this server. */

--- a/include/bluetooth/mesh/time_srv.h
+++ b/include/bluetooth/mesh/time_srv.h
@@ -59,6 +59,48 @@ struct tm;
 		struct bt_mesh_time_srv, _srv),                                \
 		&_bt_mesh_time_setup_srv_cb)
 
+#if defined(CONFIG_BT_MESH_LARGE_COMP_DATA_SRV)
+/** @def BT_MESH_MODEL_TIME_SRV_WITH_METADATA
+ *
+ * @brief Time Server model composition data entry with metadata.
+ *
+ * @param[in] _srv Pointer to a @ref bt_mesh_time_srv instance.
+ * @param[in] _metadata Pointer to a @ref bt_mesh_models_metadata_entry.
+ */
+#define BT_MESH_MODEL_TIME_SRV_WITH_METADATA(_srv, _metadata)                                      \
+	BT_MESH_MODEL_METADATA_CB(BT_MESH_MODEL_ID_TIME_SRV, _bt_mesh_time_srv_op, &(_srv)->pub,   \
+				  BT_MESH_MODEL_USER_DATA(struct bt_mesh_time_srv, _srv),          \
+				  &_bt_mesh_time_srv_cb, &_metadata),                              \
+	BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_TIME_SETUP_SRV, _bt_mesh_time_setup_srv_op,              \
+			 &(_srv)->setup_pub,                                                       \
+			 BT_MESH_MODEL_USER_DATA(struct bt_mesh_time_srv, _srv),                   \
+			 &_bt_mesh_time_setup_srv_cb)
+#endif
+
+/** Clock Accuracy Metadata ID. */
+#define BT_MESH_CLOCK_ACCURACY_METADATA_ID 0x0007
+
+/** Timekeeping Reserve Metadata ID. */
+#define BT_MESH_TIMEKEEPING_RESERVE_METADATA_ID 0x0008
+
+/**
+ *  Clock Accuracy Metadata entry.
+ *
+ *  @param clock_accuracy 24-bit clock accuracy value.
+ */
+#define BT_MESH_CLOCK_ACCURACY_METADATA(clock_accuracy)                                            \
+	BT_MESH_MODELS_METADATA_ENTRY(3, BT_MESH_CLOCK_ACCURACY_METADATA_ID,                       \
+				      ((uint8_t[]){BT_BYTES_LIST_LE24(clock_accuracy)}))
+
+/**
+ *  Timekeeping Reserve Metadata entry.
+ *
+ *  @param timekeeping_reserve 24-bit timekeeping reserve value.
+ */
+#define BT_MESH_TIMEKEEPING_RESERVE_METADATA(timekeeping_reserve)                                  \
+	BT_MESH_MODELS_METADATA_ENTRY(3, BT_MESH_TIMEKEEPING_RESERVE_METADATA_ID,                  \
+				      ((uint8_t[]){BT_BYTES_LIST_LE24(timekeeping_reserve)}))
+
 /** Time srv update types */
 enum bt_mesh_time_update_types {
 	/** Status update */

--- a/samples/bluetooth/mesh/light_ctrl/prj.conf
+++ b/samples/bluetooth/mesh/light_ctrl/prj.conf
@@ -55,6 +55,7 @@ CONFIG_BT_MESH_MODEL_EXTENSION_LIST_SIZE=18
 # Enabling BT_MESH_NLC_PERF_CONF enables support for 3 application keys by
 # default. Therefore, allow up to 3 application key bindings per model instance.
 CONFIG_BT_MESH_MODEL_KEY_COUNT=3
+CONFIG_BT_MESH_LARGE_COMP_DATA_SRV=y
 
 # Bluetooth Mesh models
 CONFIG_BT_MESH_LIGHT_CTRL_SRV=y


### PR DESCRIPTION
PR adds metadata to:
            - Light Lightness Server
            - Light CTL Temperature Server
            - Light HSL Server
            - Sensor server
            - Time Server
as well as health and lightness server metadata usage in light_ctrl sample