### PR TITLE
manifest: Edge backoff support using RF params

### DIFF
--- a/drivers/wifi/nrf700x/Kconfig
+++ b/drivers/wifi/nrf700x/Kconfig
@@ -285,63 +285,133 @@ config NRF700X_ANT_GAIN_5G_BAND3
 	default 0
 	range 0 6
 
-config NRF700X_BAND_2G_LOWER_EDGE_BACKOFF
-	int "Transmit power backoff (in dB) for lower edge of 2.4 GHz frequency band"
+config NRF700X_BAND_2G_LOWER_EDGE_BACKOFF_DSSS
+	int "DSSS Transmit power backoff (in dB) for lower edge of 2.4 GHz frequency band"
 	default 0
 	range 0 10
 
-config NRF700X_BAND_2G_UPPER_EDGE_BACKOFF
-	int "Transmit power backoff (in dB) for upper edge of 2.4 GHz frequency band"
+config NRF700X_BAND_2G_LOWER_EDGE_BACKOFF_HT
+	int "HT/VHT Transmit power backoff (in dB) for lower edge of 2.4 GHz frequency band"
 	default 0
 	range 0 10
 
-config NRF700X_BAND_UNII_1_LOWER_EDGE_BACKOFF
-	int "Transmit power backoff (in dB) for lower edge of UNII-1 frequency band"
+config NRF700X_BAND_2G_LOWER_EDGE_BACKOFF_HE
+	int "HE Transmit power backoff (in dB) for lower edge of 2.4 GHz frequency band"
 	default 0
 	range 0 10
 
-config NRF700X_BAND_UNII_1_UPPER_EDGE_BACKOFF
-	int "Transmit power backoff (in dB) for upper edge of UNII-1 frequency band"
+config NRF700X_BAND_2G_UPPER_EDGE_BACKOFF_DSSS
+	int "DSSS Transmit power backoff (in dB) for lower edge of 2.4 GHz frequency band"
 	default 0
 	range 0 10
 
-config NRF700X_BAND_UNII_2A_LOWER_EDGE_BACKOFF
-	int "Transmit power backoff (in dB) for lower edge of UNII-2A frequency band"
+config NRF700X_BAND_2G_UPPER_EDGE_BACKOFF_HT
+	int "HT/VHT Transmit power backoff (in dB) for lower edge of 2.4 GHz frequency band"
 	default 0
 	range 0 10
 
-config NRF700X_BAND_UNII_2A_UPPER_EDGE_BACKOFF
-	int "Transmit power backoff (in dB) for upper edge of UNII-2A frequency band"
+config NRF700X_BAND_2G_UPPER_EDGE_BACKOFF_HE
+	int "HE Transmit power backoff (in dB) for lower edge of 2.4 GHz frequency band"
 	default 0
 	range 0 10
 
-config NRF700X_BAND_UNII_2C_LOWER_EDGE_BACKOFF
-	int "Transmit power backoff (in dB) for lower edge of UNII-2C frequency band"
+config NRF700X_BAND_UNII_1_LOWER_EDGE_BACKOFF_HT
+	int "HT/VHT Transmit power backoff (in dB) for lower edge of UNII-1 frequency band"
 	default 0
 	range 0 10
 
-config NRF700X_BAND_UNII_2C_UPPER_EDGE_BACKOFF
-	int "Transmit power backoff (in dB) for upper edge of UNII-2C frequency band"
+config NRF700X_BAND_UNII_1_LOWER_EDGE_BACKOFF_HE
+	int "HE Transmit power backoff (in dB) for lower edge of UNII-1 frequency band"
 	default 0
 	range 0 10
 
-config NRF700X_BAND_UNII_3_LOWER_EDGE_BACKOFF
-	int "Transmit power backoff (in dB) for lower edge of UNII-3 frequency band"
+config NRF700X_BAND_UNII_1_UPPER_EDGE_BACKOFF_HT
+	int "HT/VHT Transmit power backoff (in dB) for upper edge of UNII-1 frequency band"
 	default 0
 	range 0 10
 
-config NRF700X_BAND_UNII_3_UPPER_EDGE_BACKOFF
-	int "Transmit power backoff (in dB) for upper edge of UNII-3 frequency band"
+config NRF700X_BAND_UNII_1_UPPER_EDGE_BACKOFF_HE
+	int "HE Transmit power backoff (in dB) for upper edge of UNII-1 frequency band"
 	default 0
 	range 0 10
 
-config NRF700X_BAND_UNII_4_LOWER_EDGE_BACKOFF
-	int "Transmit power backoff (in dB) for lower edge of UNII-4 frequency band"
+config NRF700X_BAND_UNII_2A_LOWER_EDGE_BACKOFF_HT
+	int "HT/VHT Transmit power backoff (in dB) for lower edge of UNII-2A frequency band"
 	default 0
 	range 0 10
 
-config NRF700X_BAND_UNII_4_UPPER_EDGE_BACKOFF
-	int "Transmit power backoff (in dB) for upper edge of UNII-4 frequency band"
+config NRF700X_BAND_UNII_2A_LOWER_EDGE_BACKOFF_HE
+	int "HE Transmit power backoff (in dB) for lower edge of UNII-2A frequency band"
+	default 0
+	range 0 10
+
+config NRF700X_BAND_UNII_2A_UPPER_EDGE_BACKOFF_HT
+	int "HT/VHT Transmit power backoff (in dB) for upper edge of UNII-2A frequency band"
+	default 0
+	range 0 10
+
+config NRF700X_BAND_UNII_2A_UPPER_EDGE_BACKOFF_HE
+	int "HE Transmit power backoff (in dB) for upper edge of UNII-2A frequency band"
+	default 0
+	range 0 10
+
+config NRF700X_BAND_UNII_2C_LOWER_EDGE_BACKOFF_HT
+	int "HT/VHT Transmit power backoff (in dB) for lower edge of UNII-2C frequency band"
+	default 0
+	range 0 10
+
+config NRF700X_BAND_UNII_2C_LOWER_EDGE_BACKOFF_HE
+	int "HE Transmit power backoff (in dB) for lower edge of UNII-2C frequency band"
+	default 0
+	range 0 10
+
+config NRF700X_BAND_UNII_2C_UPPER_EDGE_BACKOFF_HT
+	int "HT/VHT Transmit power backoff (in dB) for upper edge of UNII-2C frequency band"
+	default 0
+	range 0 10
+
+config NRF700X_BAND_UNII_2C_UPPER_EDGE_BACKOFF_HE
+	int "HE Transmit power backoff (in dB) for upper edge of UNII-2C frequency band"
+	default 0
+	range 0 10
+
+config NRF700X_BAND_UNII_3_LOWER_EDGE_BACKOFF_HT
+	int "HT/VHT Transmit power backoff (in dB) for lower edge of UNII-3 frequency band"
+	default 0
+	range 0 10
+
+config NRF700X_BAND_UNII_3_LOWER_EDGE_BACKOFF_HE
+	int "HE Transmit power backoff (in dB) for lower edge of UNII-3 frequency band"
+	default 0
+	range 0 10
+
+config NRF700X_BAND_UNII_3_UPPER_EDGE_BACKOFF_HT
+	int "HT/VHT Transmit power backoff (in dB) for upper edge of UNII-3 frequency band"
+	default 0
+	range 0 10
+
+config NRF700X_BAND_UNII_3_UPPER_EDGE_BACKOFF_HE
+	int "HE Transmit power backoff (in dB) for upper edge of UNII-3 frequency band"
+	default 0
+	range 0 10
+
+config NRF700X_BAND_UNII_4_LOWER_EDGE_BACKOFF_HT
+	int "HT/VHT Transmit power backoff (in dB) for lower edge of UNII-4 frequency band"
+	default 0
+	range 0 10
+
+config NRF700X_BAND_UNII_4_LOWER_EDGE_BACKOFF_HE
+	int "HE Transmit power backoff (in dB) for lower edge of UNII-4 frequency band"
+	default 0
+	range 0 10
+
+config NRF700X_BAND_UNII_4_UPPER_EDGE_BACKOFF_HT
+	int "HT/VHT Transmit power backoff (in dB) for upper edge of UNII-4 frequency band"
+	default 0
+	range 0 10
+
+config NRF700X_BAND_UNII_4_UPPER_EDGE_BACKOFF_HE
+	int "HE Transmit power backoff (in dB) for upper edge of UNII-4 frequency band"
 	default 0
 	range 0 10
 

--- a/drivers/wifi/nrf700x/src/fmac_main.c
+++ b/drivers/wifi/nrf700x/src/fmac_main.c
@@ -461,22 +461,53 @@ void configure_tx_pwr_settings(struct nrf_wifi_tx_pwr_ctrl_params *tx_pwr_ctrl_p
 	tx_pwr_ctrl_params->ant_gain_5g_band1 = CONFIG_NRF700X_ANT_GAIN_5G_BAND1;
 	tx_pwr_ctrl_params->ant_gain_5g_band2 = CONFIG_NRF700X_ANT_GAIN_5G_BAND2;
 	tx_pwr_ctrl_params->ant_gain_5g_band3 = CONFIG_NRF700X_ANT_GAIN_5G_BAND3;
-	tx_pwr_ctrl_params->band_edge_2g_lo = CONFIG_NRF700X_BAND_2G_LOWER_EDGE_BACKOFF;
-	tx_pwr_ctrl_params->band_edge_2g_hi = CONFIG_NRF700X_BAND_2G_UPPER_EDGE_BACKOFF;
-	tx_pwr_ctrl_params->band_edge_5g_unii_1_lo = CONFIG_NRF700X_BAND_UNII_1_LOWER_EDGE_BACKOFF;
-	tx_pwr_ctrl_params->band_edge_5g_unii_1_hi = CONFIG_NRF700X_BAND_UNII_1_UPPER_EDGE_BACKOFF;
-	tx_pwr_ctrl_params->band_edge_5g_unii_2a_lo =
-					CONFIG_NRF700X_BAND_UNII_2A_LOWER_EDGE_BACKOFF;
-	tx_pwr_ctrl_params->band_edge_5g_unii_2a_hi =
-					CONFIG_NRF700X_BAND_UNII_2A_UPPER_EDGE_BACKOFF;
-	tx_pwr_ctrl_params->band_edge_5g_unii_2c_lo =
-					CONFIG_NRF700X_BAND_UNII_2C_LOWER_EDGE_BACKOFF;
-	tx_pwr_ctrl_params->band_edge_5g_unii_2c_hi =
-					CONFIG_NRF700X_BAND_UNII_2C_UPPER_EDGE_BACKOFF;
-	tx_pwr_ctrl_params->band_edge_5g_unii_3_lo = CONFIG_NRF700X_BAND_UNII_3_LOWER_EDGE_BACKOFF;
-	tx_pwr_ctrl_params->band_edge_5g_unii_3_hi = CONFIG_NRF700X_BAND_UNII_3_UPPER_EDGE_BACKOFF;
-	tx_pwr_ctrl_params->band_edge_5g_unii_4_lo = CONFIG_NRF700X_BAND_UNII_4_LOWER_EDGE_BACKOFF;
-	tx_pwr_ctrl_params->band_edge_5g_unii_4_hi = CONFIG_NRF700X_BAND_UNII_4_UPPER_EDGE_BACKOFF;
+	tx_pwr_ctrl_params->band_edge_2g_lo_dss = CONFIG_NRF700X_BAND_2G_LOWER_EDGE_BACKOFF_DSSS;
+	tx_pwr_ctrl_params->band_edge_2g_lo_ht = CONFIG_NRF700X_BAND_2G_LOWER_EDGE_BACKOFF_HT;
+	tx_pwr_ctrl_params->band_edge_2g_lo_he = CONFIG_NRF700X_BAND_2G_LOWER_EDGE_BACKOFF_HE;
+	tx_pwr_ctrl_params->band_edge_2g_hi_dsss = CONFIG_NRF700X_BAND_2G_UPPER_EDGE_BACKOFF_DSSS;
+	tx_pwr_ctrl_params->band_edge_2g_hi_ht = CONFIG_NRF700X_BAND_2G_UPPER_EDGE_BACKOFF_HT;
+	tx_pwr_ctrl_params->band_edge_2g_hi_he = CONFIG_NRF700X_BAND_2G_UPPER_EDGE_BACKOFF_HE;
+	tx_pwr_ctrl_params->band_edge_5g_unii_1_lo_ht =
+		CONFIG_NRF700X_BAND_UNII_1_LOWER_EDGE_BACKOFF_HT;
+	tx_pwr_ctrl_params->band_edge_5g_unii_1_lo_he =
+		CONFIG_NRF700X_BAND_UNII_1_LOWER_EDGE_BACKOFF_HE;
+	tx_pwr_ctrl_params->band_edge_5g_unii_1_hi_ht =
+		CONFIG_NRF700X_BAND_UNII_1_UPPER_EDGE_BACKOFF_HT;
+	tx_pwr_ctrl_params->band_edge_5g_unii_1_hi_he =
+		CONFIG_NRF700X_BAND_UNII_1_UPPER_EDGE_BACKOFF_HE;
+	tx_pwr_ctrl_params->band_edge_5g_unii_2a_lo_ht =
+		CONFIG_NRF700X_BAND_UNII_2A_LOWER_EDGE_BACKOFF_HT;
+	tx_pwr_ctrl_params->band_edge_5g_unii_2a_lo_he =
+		CONFIG_NRF700X_BAND_UNII_2A_LOWER_EDGE_BACKOFF_HE;
+	tx_pwr_ctrl_params->band_edge_5g_unii_2a_hi_ht =
+		CONFIG_NRF700X_BAND_UNII_2A_UPPER_EDGE_BACKOFF_HT;
+	tx_pwr_ctrl_params->band_edge_5g_unii_2a_hi_he =
+		CONFIG_NRF700X_BAND_UNII_2A_UPPER_EDGE_BACKOFF_HE;
+	tx_pwr_ctrl_params->band_edge_5g_unii_2c_lo_ht =
+		CONFIG_NRF700X_BAND_UNII_2C_LOWER_EDGE_BACKOFF_HT;
+	tx_pwr_ctrl_params->band_edge_5g_unii_2c_lo_he =
+		CONFIG_NRF700X_BAND_UNII_2C_LOWER_EDGE_BACKOFF_HE;
+	tx_pwr_ctrl_params->band_edge_5g_unii_2c_hi_ht =
+		CONFIG_NRF700X_BAND_UNII_2C_UPPER_EDGE_BACKOFF_HT;
+	tx_pwr_ctrl_params->band_edge_5g_unii_2c_hi_he =
+		CONFIG_NRF700X_BAND_UNII_2C_UPPER_EDGE_BACKOFF_HE;
+	tx_pwr_ctrl_params->band_edge_5g_unii_3_lo_ht =
+		CONFIG_NRF700X_BAND_UNII_3_LOWER_EDGE_BACKOFF_HT;
+	tx_pwr_ctrl_params->band_edge_5g_unii_3_lo_he =
+		CONFIG_NRF700X_BAND_UNII_3_LOWER_EDGE_BACKOFF_HE;
+	tx_pwr_ctrl_params->band_edge_5g_unii_3_hi_ht =
+		CONFIG_NRF700X_BAND_UNII_3_UPPER_EDGE_BACKOFF_HT;
+	tx_pwr_ctrl_params->band_edge_5g_unii_3_hi_he =
+		CONFIG_NRF700X_BAND_UNII_3_UPPER_EDGE_BACKOFF_HE;
+	tx_pwr_ctrl_params->band_edge_5g_unii_4_lo_ht =
+		CONFIG_NRF700X_BAND_UNII_4_LOWER_EDGE_BACKOFF_HT;
+	tx_pwr_ctrl_params->band_edge_5g_unii_4_lo_he =
+		CONFIG_NRF700X_BAND_UNII_4_LOWER_EDGE_BACKOFF_HE;
+	tx_pwr_ctrl_params->band_edge_5g_unii_4_hi_ht =
+		CONFIG_NRF700X_BAND_UNII_4_UPPER_EDGE_BACKOFF_HT;
+	tx_pwr_ctrl_params->band_edge_5g_unii_4_hi_he =
+		CONFIG_NRF700X_BAND_UNII_4_UPPER_EDGE_BACKOFF_HE;
+
 
 	tx_pwr_ceil_params->max_pwr_2g_dsss =
 			DT_PROP(DT_NODELABEL(nrf70_tx_power_ceiling), max_pwr_2g_dsss);

--- a/samples/wifi/radio_test/src/nrf_wifi_radio_test_shell.c
+++ b/samples/wifi/radio_test/src/nrf_wifi_radio_test_shell.c
@@ -1747,6 +1747,59 @@ out:
 	return ret;
 }
 
+static int nrf_wifi_radio_test_set_ant_gain(const struct shell *shell,
+					    size_t argc,
+					    const char *argv[])
+{
+	char *ptr = NULL;
+	unsigned long ant_gain = 0;
+
+	ant_gain = strtoul(argv[1], &ptr, 10);
+
+	if ((ant_gain < 0) || (ant_gain > 6)) {
+		shell_fprintf(shell,
+			      SHELL_ERROR,
+			      "Invalid antenna gain setting\n");
+		return -ENOEXEC;
+	}
+
+	if (!check_test_in_prog(shell)) {
+		return -ENOEXEC;
+	}
+
+	memset(&ctx->conf_params.rf_params[ANT_GAIN_2G_OFST],
+	       ant_gain,
+	       NUM_ANT_GAIN);
+
+	return 0;
+}
+
+static int nrf_wifi_radio_test_set_edge_bo(const struct shell *shell,
+					   size_t argc,
+					   const char *argv[])
+{
+	char *ptr = NULL;
+	unsigned long edge_bo = 0;
+
+	edge_bo = strtoul(argv[1], &ptr, 10);
+
+	if ((edge_bo < 0) || (edge_bo > 10)) {
+		shell_fprintf(shell,
+			      SHELL_ERROR,
+			      "Invalid edge backoff setting\n");
+		return -ENOEXEC;
+	}
+
+	if (!check_test_in_prog(shell)) {
+		return -ENOEXEC;
+	}
+
+	memset(&ctx->conf_params.rf_params[BAND_2G_LW_ED_BKF_DSSS_OFST],
+	       edge_bo,
+	       NUM_EDGE_BACKOFF);
+
+	return 0;
+}
 
 static int nrf_wifi_radio_test_show_cfg(const struct shell *shell,
 					size_t argc,
@@ -2388,6 +2441,18 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 			   "maximum TX power of channel in the configured regulatory domain.\n"
 		      "1 - Configured TX power value will be used for the channel.				",
 		      nrf_wifi_radio_test_set_bypass_reg,
+		      2,
+		      0),
+	SHELL_CMD_ARG(set_ant_gain,
+		      NULL,
+		      "<val> - Value in dB",
+		      nrf_wifi_radio_test_set_ant_gain,
+		      2,
+		      0),
+	SHELL_CMD_ARG(set_edge_bo,
+		      NULL,
+		      "<val> - Value in dB",
+		      nrf_wifi_radio_test_set_edge_bo,
 		      2,
 		      0),
 	SHELL_SUBCMD_SET_END);

--- a/west.yml
+++ b/west.yml
@@ -142,7 +142,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 502ce15474c2619e3ef9291588357dd2ddf31fb0
+      revision: 319739c30e3310d58d45b4b04d11de217c9b8a14
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
[SHEL-2481]: Support for applying frame format dependent edge backoff
in PHY firmware.

[SHEL-2481]: https://nordicsemi.atlassian.net/browse/SHEL-2481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ