### PR TITLE
samples: wifi: shell: Fix OTBR flash overflow

### DIFF
--- a/samples/wifi/shell/overlay-openthread.conf
+++ b/samples/wifi/shell/overlay-openthread.conf
@@ -27,3 +27,10 @@ CONFIG_LOG_MODE_MINIMAL=y
 
 # Log only errors/hard faults
 CONFIG_LOG_MAX_LEVEL=1
+
+
+# Consumes more memory
+CONFIG_WIFI_CREDENTIALS=n
+CONFIG_FLASH=n
+CONFIG_NVS=n
+CONFIG_SETTINGS=n


### PR DESCRIPTION
Due to recent Zephyr changes OTBR flash overflowed, so, temporarily disable Wi-Fi credentials and dependent modules to make some room.