### PR TITLE
samples: wifi: Fix SML experimental update for nRF7000 and nRF7001

### DIFF
--- a/samples/wifi/monitor/sample.yaml
+++ b/samples/wifi/monitor/sample.yaml
@@ -17,8 +17,6 @@ tests:
     platform_allow: nrf5340dk_nrf5340_cpuapp
     tags: ci_build
   sample.nrf7000.monitor:
-    # For SML only
-    skip: true
     build_only: true
     extra_args:
       SHIELD=nrf7002ek_nrf7000
@@ -27,8 +25,6 @@ tests:
     platform_allow: nrf5340dk_nrf5340_cpuapp
     tags: ci_build
   sample.nrf7001.monitor:
-    # For SML only
-    skip: true
     build_only: true
     integration_platforms:
       - nrf7002dk_nrf7001_nrf5340_cpuapp

--- a/samples/wifi/raw_tx_packet/sample.yaml
+++ b/samples/wifi/raw_tx_packet/sample.yaml
@@ -17,8 +17,6 @@ tests:
     platform_allow: nrf5340dk_nrf5340_cpuapp
     tags: ci_build
   sample.nrf7000.raw_tx_packet:
-    # For SML only
-    skip: true
     build_only: true
     extra_args:
       SHIELD=nrf7002ek_nrf7000
@@ -27,8 +25,6 @@ tests:
     platform_allow: nrf5340dk_nrf5340_cpuapp
     tags: ci_build
   sample.nrf7001.raw_tx_packet:
-    # For SML only
-    skip: true
     build_only: true
     integration_platforms:
       - nrf7002dk_nrf7001_nrf5340_cpuapp

--- a/samples/wifi/shell/sample.yaml
+++ b/samples/wifi/shell/sample.yaml
@@ -254,8 +254,6 @@ tests:
     platform_allow: nrf7002dk_nrf5340_cpuapp
     tags: ci_build
   sample.nrf7001.promiscuous_mode_7001:
-    # For SML only
-    skip: true
     build_only: true
     extra_args: OVERLAY_CONFIG=overlay-promiscuous-mode.conf
     integration_platforms:

--- a/samples/wifi/softap/sample.yaml
+++ b/samples/wifi/softap/sample.yaml
@@ -17,16 +17,12 @@ tests:
     platform_allow: nrf5340dk_nrf5340_cpuapp
     tags: ci_build
   sample.nrf7001.softap:
-    # For SML only
-    skip: true
     build_only: true
     integration_platforms:
       - nrf7002dk_nrf7001_nrf5340_cpuapp
     platform_allow: nrf7002dk_nrf7001_nrf5340_cpuapp
     tags: ci_build
   sample.nrf7001_eks.softap:
-    # For SML only
-    skip: true
     build_only: true
     extra_args: SHIELD=nrf7002ek_nrf7001
     integration_platforms:


### PR DESCRIPTION
The idea was to skip twister for these variants to save CI time, but still add an entry for SML. But SML in current state needs access to "build.log" and ".config" build artifacts, so, the experimental SML isn't updated properly.

Till we figure out a way to get experimental status without build artifacts, enable these experimental features for boards nRF7000 and nRF7001 in the twister.