### PR TITLE
applications: Matter Bridge is no more experimental

### DIFF
--- a/applications/matter_bridge/Kconfig
+++ b/applications/matter_bridge/Kconfig
@@ -152,9 +152,6 @@ config BRIDGE_HUMIDITY_SENSOR_MAX_MEASURED_VALUE
 
 endif
 
-config EXPERIMENTAL
-	default y
-
 # Enable Read Client functionality for all build configurations.
 config CHIP_ENABLE_READ_CLIENT
 	default y

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -234,6 +234,7 @@ Applications
 
 This section provides detailed lists of changes by :ref:`application <applications>`.
 
+* The Matter Bridge application is now supported instead of experimental.
 * Added the :ref:`ipc_radio` application.
 
 Asset Tracker v2


### PR DESCRIPTION
This commit deletes EXPERIMENTAL symbol for the matter bridge application.