### PR TITLE
doc: Add nrf54l15 entry in sample rows

### DIFF
--- a/doc/nrf/includes/sample_board_rows.txt
+++ b/doc/nrf/includes/sample_board_rows.txt
@@ -202,14 +202,6 @@
 
 | Native Simulator | | native_sim | ``native_sim`` |
 
-.. nrf54h20dk_nrf54h20_cpuapp@soc1
-
-| :ref:`nRF54H20 PDK <ug_nrf54h20_gs>` | | ``nrf54h20pdk_nrf54h20_cpuapp`` | ``nrf54h20pdk_nrf54h20_cpuapp@soc1`` |
-
-.. nrf54h20pdk_nrf54h20_cpurad@soc1
-
-| :ref:`nRF54H20 PDK <ug_nrf54h20_gs>` | | ``nrf54h20pdk_nrf54h20_cpurad`` | ``nrf54h20pdk_nrf54h20_cpurad@soc1`` |
-
 .. nrf54h20pdk_nrf54h20_cpuapp
 
 | :ref:`nRF54H20 PDK <ug_nrf54h20_gs>` | | ``nrf54h20pdk_nrf54h20_cpuapp`` | ``nrf54h20pdk_nrf54h20_cpuapp`` |
@@ -218,6 +210,6 @@
 
 | :ref:`nRF54H20 PDK <ug_nrf54h20_gs>` | | ``nrf54h20pdk_nrf54h20_cpurad`` | ``nrf54h20pdk_nrf54h20_cpurad`` |
 
-.. nrf54l15pdk_nrf54l15_cpuapp@soc1
+.. nrf54l15pdk_nrf54l15_cpuapp
 
-| :ref:`nRF54L15 PDK <ug_nrf54l15_gs>` | | ``nrf54l15pdk_nrf54l15_cpuapp`` | ``nrf54l15pdk_nrf54l15_cpuapp@soc1`` |
+| :ref:`nRF54L15 PDK <ug_nrf54l15_gs>` | | ``nrf54l15pdk_nrf54l15_cpuapp`` | ``nrf54l15pdk_nrf54l15_cpuapp`` |


### PR DESCRIPTION
Add nrf54l15_cpuapp (without soc1) entry
in the sample_board_rows file.