### PR TITLE
applications: nrf5340_audio: Update error check for scanning

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/bt_management/scanning/bt_mgmt_scan_for_conn.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/scanning/bt_mgmt_scan_for_conn.c
@@ -192,7 +192,7 @@ int bt_mgmt_scan_for_conn_start(struct bt_le_scan_param *scan_param, char const 
 	} else {
 		/* Already scanning, stop current scan to update param in case it has changed */
 		ret = bt_le_scan_stop();
-		if (ret) {
+		if (ret && ret != -EALREADY) {
 			LOG_ERR("Failed to stop scan: %d", ret);
 			return ret;
 		}


### PR DESCRIPTION
Update the error check for scanning for bypassing the scan start/stop already return code.
OCT-2858
Signed-off-by: Jui-Chou Chung <jui-chou.chung@nordicsemi.no>