### PR TITLE
doc improvement: add gloss entry

### DIFF
--- a/doc/nrf/glossary.rst
+++ b/doc/nrf/glossary.rst
@@ -610,6 +610,9 @@ Glossary
       It does not require a repository.
       Sometimes it is improperly used as a synonym of :term:`commit <Commit>`.
 
+   Peripheral CPU Device Firmware Update (PCD)
+      A library that adds functionality for transferring DFU images from the application core to the network core on the nRF5340 SoC.
+
    Peripheral Processor (PPR, pronounced “Pepper”)
       A processor that is located in the low-leakage portion of the Global Domain and is primarily intended to:
 

--- a/doc/nrf/libraries/dfu/pcd.rst
+++ b/doc/nrf/libraries/dfu/pcd.rst
@@ -7,7 +7,7 @@ Peripheral CPU DFU (PCD)
    :local:
    :depth: 2
 
-The peripheral CPU DFU (PCD) library provides functionality for transferring DFU images from the application core to the network core on the nRF5340 System on Chip (SoC).
+The peripheral CPU DFU (PCD) library provides functionality for transferring DFU images from the application core to the network core on the nRF5340 System-on-Chip (SoC).
 
 Overview
 ********


### PR DESCRIPTION
Adds PCD to the glossary (as requested [here](https://github.com/nrfconnect/sdk-nrf/pull/14226#discussion_r1507107714))

Fix SoC typo in PCD lib page