### PR TITLE
lib: dk_buttons_and_leds: Add no interrupts mode for buttons

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -1225,6 +1225,13 @@ Other libraries
 
   * Added the :c:func:`date_time_now_local` function to the API.
 
+* :ref:`dk_buttons_and_leds_readme` library:
+
+  * Added an experimental no interrupts mode for button handling.
+    To enable this mode, use the :kconfig:option:`CONFIG_DK_LIBRARY_BUTTON_NO_ISR` Kconfig option.
+    You can use this mode as a workaround to avoid using the GPIO interrupts.
+    However, it increases the power consumption.
+
 Common Application Framework (CAF)
 ----------------------------------
 

--- a/lib/dk_buttons_and_leds/Kconfig
+++ b/lib/dk_buttons_and_leds/Kconfig
@@ -12,11 +12,33 @@ if DK_LIBRARY
 
 config DK_LIBRARY_BUTTON_SCAN_INTERVAL
 	int "Scanning interval of buttons in milliseconds"
+	default 50 if DK_LIBRARY_BUTTON_NO_ISR
 	default 10
 
 config DK_LIBRARY_DYNAMIC_BUTTON_HANDLERS
 	bool "Enable the runtime assignable button handler API"
 	default y
+
+config DK_LIBRARY_BUTTON_NO_ISR
+	bool "Poll buttons unconditionally (no interrupts) [EXPERIMENTAL]"
+	select EXPERIMENTAL
+	help
+	  With this option disabled, the module periodically scans all the
+	  available buttons until no button is pressed. If no button is
+	  pressed, the module uses GPIO interrupts to detect the first button
+	  press. On the first button press, the module switches back to
+	  periodically scanning buttons.
+
+	  Enable this option to avoid relying on GPIO interrupts at all and
+	  to unconditionally scan all buttons periodically. Please note that
+	  the constant scanning activity increases the overall power
+	  consumption of the system.
+
+	  For example, in case the application uses Button 3 or 4, the option
+	  must be set for the nRF54L15 PDK (PCA10156) revisions
+	  v0.2.0 AA0-ES2, v0.2.0 AA0-ES3, and v0.2.1 AB0-ES5.
+	  These versions of the PDK have Buttons 3 and 4 connected to
+	  the GPIO port which does not support interrupts.
 
 module = DK_LIBRARY
 module-str = DK library

--- a/lib/dk_buttons_and_leds/dk_buttons_and_leds.c
+++ b/lib/dk_buttons_and_leds/dk_buttons_and_leds.c
@@ -129,7 +129,9 @@ static void buttons_scan_fn(struct k_work *work)
 	static bool initial_run = true;
 	uint32_t button_scan;
 
-	if (irq_enabled) {
+	__ASSERT_NO_MSG(!IS_ENABLED(CONFIG_DK_LIBRARY_BUTTON_NO_ISR) || !irq_enabled);
+
+	if (!IS_ENABLED(CONFIG_DK_LIBRARY_BUTTON_NO_ISR) && irq_enabled) {
 		/* Disable GPIO interrupts for edge triggered devices.
 		 * Devices that are configured with active high interrupts are already disabled.
 		 */
@@ -157,7 +159,7 @@ static void buttons_scan_fn(struct k_work *work)
 
 	last_button_scan = button_scan;
 
-	if (button_scan != 0) {
+	if (IS_ENABLED(CONFIG_DK_LIBRARY_BUTTON_NO_ISR) || (button_scan != 0)) {
 		k_work_reschedule(&buttons_scan,
 		  K_MSEC(CONFIG_DK_LIBRARY_BUTTON_SCAN_INTERVAL));
 	} else {
@@ -257,29 +259,31 @@ int dk_buttons_init(button_handler_t button_handler)
 		}
 	}
 
-	uint32_t pin_mask = 0;
+	if (!IS_ENABLED(CONFIG_DK_LIBRARY_BUTTON_NO_ISR)) {
+		uint32_t pin_mask = 0;
 
-	for (size_t i = 0; i < ARRAY_SIZE(buttons); i++) {
-		/* Module starts in scanning mode and will switch to
-		 * callback mode if no button is pressed.
-		 */
-		err = gpio_pin_interrupt_configure_dt(&buttons[i],
-						      GPIO_INT_DISABLE);
-		if (err) {
-			LOG_ERR("Cannot disable callbacks()");
-			return err;
+		for (size_t i = 0; i < ARRAY_SIZE(buttons); i++) {
+			/* Module starts in scanning mode and will switch to
+			 * callback mode if no button is pressed.
+			 */
+			err = gpio_pin_interrupt_configure_dt(&buttons[i],
+							      GPIO_INT_DISABLE);
+			if (err) {
+				LOG_ERR("Cannot disable callbacks()");
+				return err;
+			}
+
+			pin_mask |= BIT(buttons[i].pin);
 		}
 
-		pin_mask |= BIT(buttons[i].pin);
-	}
+		gpio_init_callback(&gpio_cb, button_pressed, pin_mask);
 
-	gpio_init_callback(&gpio_cb, button_pressed, pin_mask);
-
-	for (size_t i = 0; i < ARRAY_SIZE(buttons); i++) {
-		err = gpio_add_callback(buttons[i].port, &gpio_cb);
-		if (err) {
-			LOG_ERR("Cannot add callback");
-			return err;
+		for (size_t i = 0; i < ARRAY_SIZE(buttons); i++) {
+			err = gpio_add_callback(buttons[i].port, &gpio_cb);
+			if (err) {
+				LOG_ERR("Cannot add callback");
+				return err;
+			}
 		}
 	}
 


### PR DESCRIPTION
Add no interrupts mode for buttons (CONFIG_DK_LIBRARY_BUTTON_NO_ISR). This option avoids relying on GPIO interrupts at all and unconditionally periodically scan all of the buttons.

It can be used on the nRF54L15 PDK revision 0.2.X, where buttons 3 and 4 are connected to GPIO PORT2 which does not support GPIOTE. Because of that, the PDK cannot rely on GPIO interrupts for the mentioned buttons.

Jira: NCSDK-23210