### PR TITLE
samples: bluetooth: fast_pair: input_device: Add init nRF54L support 

### DIFF
--- a/samples/bluetooth/fast_pair/input_device/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/bluetooth/fast_pair/input_device/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Workaround:
+# The nRF54L15 PDK (PCA10156) revisions v0.2.0 AA0-ES2, v0.2.0 AA0-ES3,
+# and v0.2.1 AB0-ES5 have Buttons 3 and 4 connected to the GPIO port
+# which does not support interrupts.
+CONFIG_DK_LIBRARY_BUTTON_NO_ISR=y

--- a/samples/bluetooth/fast_pair/input_device/sample.yaml
+++ b/samples/bluetooth/fast_pair/input_device/sample.yaml
@@ -9,9 +9,10 @@ tests:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
+      - nrf54l15pdk_nrf54l15_cpuapp
     tags: bluetooth ci_build
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
-      nrf5340dk_nrf5340_cpuapp_ns
+      nrf5340dk_nrf5340_cpuapp_ns nrf54l15pdk_nrf54l15_cpuapp
   sample.bluetooth.fast_pair.input_device.sysbuild:
     build_only: true
     sysbuild: true
@@ -20,6 +21,7 @@ tests:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
+      - nrf54l15pdk_nrf54l15_cpuapp
     tags: bluetooth ci_build
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
-      nrf5340dk_nrf5340_cpuapp_ns
+      nrf5340dk_nrf5340_cpuapp_ns nrf54l15pdk_nrf54l15_cpuapp


### PR DESCRIPTION
Depends on: 
* https://github.com/nrfconnect/sdk-nrf/pull/14285 -> buttons workaround
* https://github.com/nrfconnect/sdk-nrf/pull/14368 -> partition manager for nRF54L fix
* https://github.com/nrfconnect/sdk-nrf/pull/14409 -> partition manager for nRF54L support in sysbuild


Jira: NCSDK-26123