### PR TITLE
applications: serial_lte_modem: document the Zephyr modem compatibility

### DIFF
--- a/applications/serial_lte_modem/Kconfig
+++ b/applications/serial_lte_modem/Kconfig
@@ -175,7 +175,7 @@ if SLM_CMUX && SLM_PPP
 config SLM_CMUX_AUTOMATIC_FALLBACK_ON_PPP_STOPPAGE
 	bool "AT channel automatic fallback to DLCI 1 when PPP stops."
 	help
-	  This is mainly intended for compatibility with Zephyr's generic modem driver.
+	  This is mainly intended for compatibility with Zephyr's cellular modem driver.
 	  If enabled, when PPP stops (which happens automatically when the LTE link goes down)
 	  CMUX will make the AT channel be on DLCI 1. This only has an effect if it had been
 	  configured to be elsewhere, e.g. with AT#XCMUX=2.

--- a/applications/serial_lte_modem/README.rst
+++ b/applications/serial_lte_modem/README.rst
@@ -8,7 +8,7 @@ The application accepts both the modem-specific AT commands and proprietary AT c
 The AT commands are documented in the following guides:
 
 * Modem-specific AT commands - `nRF91x1 AT Commands Reference Guide`_  and `nRF9160 AT Commands Reference Guide`_
-* Proprietary AT commands - :ref:`SLM_AT_intro`
+* Proprietary AT commands - :ref:`SLM_AT_commands`
 
 See the subpages for how to use the application, how to extend it, and information on the supported AT commands.
 
@@ -17,7 +17,8 @@ See the subpages for how to use the application, how to extend it, and informati
    :caption: Subpages:
 
    doc/slm_description
+   doc/nRF91_as_Zephyr_modem
    doc/slm_testing
    doc/slm_extending
    doc/slm_data_mode
-   doc/AT_commands_intro
+   doc/AT_commands

--- a/applications/serial_lte_modem/doc/AT_commands.rst
+++ b/applications/serial_lte_modem/doc/AT_commands.rst
@@ -1,4 +1,4 @@
-.. _SLM_AT_intro:
+.. _SLM_AT_commands:
 
 SLM-specific AT commands
 ########################

--- a/applications/serial_lte_modem/doc/CMUX_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/CMUX_AT_commands.rst
@@ -14,6 +14,13 @@ For example, it can be used to exchange AT data and have a :ref:`Point-to-Point 
 
 .. note::
 
+   To use the nRF91 Series SiP as a standalone modem in Zephyr, see :ref:`slm_as_zephyr_modem`.
+
+CMUX is enabled in SLM by compiling it with the appropriate configuration files, depending on your use case.
+See the :ref:`slm_config_files` section for more information.
+
+.. note::
+
    SLM does not have an equivalent to the ``AT+CMUX`` command described in 3GPP TS 27.007.
    Here is how SLM's implementation of CMUX relates to the standard command's parameters:
 

--- a/applications/serial_lte_modem/doc/PPP_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/PPP_AT_commands.rst
@@ -9,6 +9,10 @@ PPP AT commands
 
 This page describes AT commands related to the Point-to-Point Protocol (PPP).
 
+.. note::
+
+   To use the nRF91 Series SiP as a standalone modem in Zephyr, see :ref:`slm_as_zephyr_modem`.
+
 PPP is enabled in SLM by compiling it with the appropriate configuration files, depending on your use case (with or without CMUX).
 See the :ref:`slm_config_files` section for more information.
 
@@ -112,18 +116,16 @@ For the process described here, SLM's UARTs must be connected to the Linux host.
 
 1. Get PPP running on SLM.
    To do this, start SLM and issue an ``AT+CFUN=1`` command.
-
 #. Make sure that the network registration succeeds and that PPP is started successfully.
    To do this, either look at SLM's logs, or issue an ``AT#XPPP?`` command, which returns ``#XPPP: 1,0`` when PPP has started successfully.
-
 #. Run the following command on the Linux host:
 
    .. code-block:: console
 
       $ sudo pppd -detach <PPP_UART_dev> <baud_rate> noauth crtscts novj nodeflate nobsdcomp debug +ipv6 usepeerdns noipdefault defaultroute defaultroute6 ipv6cp-restart 5 ipcp-restart 5
 
-   Replace ``<PPP_UART_dev>`` by the device file assigned to the PPP UART and ``<baud_rate>`` by the baud rate of the UART that PPP is using.
-   Typically, when ``uart1`` is assigned to be the PPP UART (in the devicetree overlay), the device file assigned to it is :file:`/dev/ttyACM2` for an nRF9160 DK, and :file:`/dev/ttyACM2` for the other nRF91 Series DKs.
+   Replace ``<PPP_UART_dev>`` by the device file assigned to the PPP UART and ``<baud_rate>`` by the baud rate of the UART that PPP is using (which is set in the :file:`overlay-ppp-without-cmux.overlay` file).
+   Typically, when ``uart1`` is assigned to be the PPP UART (in the devicetree overlay), the device file assigned to it is :file:`/dev/ttyACM2` for an nRF9160 DK, and :file:`/dev/ttyACM1` for the other nRF91 Series DKs.
 
 #. After the PPP link negotiation has completed successfully, a new network interface will be available, typically ``ppp0``.
    This network interface will allow sending and receiving IP traffic through the modem of the nRF91 Series SiP running SLM.

--- a/applications/serial_lte_modem/doc/nRF91_as_Zephyr_modem.rst
+++ b/applications/serial_lte_modem/doc/nRF91_as_Zephyr_modem.rst
@@ -1,0 +1,136 @@
+.. _slm_as_zephyr_modem:
+
+nRF91 Series as a Zephyr-compatible modem
+#########################################
+
+.. contents::
+   :local:
+   :depth: 2
+
+Overview
+********
+
+Starting with |NCS| v2.6.0, the Serial LTE Modem (SLM) application can be used to turn an nRF91 Series SiP into a standalone modem that can be used through Zephyr's cellular modem driver.
+This means that the controlling chip can run a Zephyr application that seamlessly uses Zephyr's IP stack instead of offloaded sockets via AT commands.
+
+This is made possible by SLM's support of CMUX and PPP and Zephyr's cellular modem driver.
+
+The :ref:`nRF52840 SoC present in the nRF9160 DK <zephyr:nrf9160dk_nrf52840>` can even be made to be the controlling chip with the appropriate configuration (described below).
+This is only possible on the nRF9160 DK, not on the other nRF91 Series DKs.
+
+.. note::
+
+   As of |NCS| |release|, Zephyr's GNSS driver does not support the nRF91 Series running SLM.
+   This functionality is part of planned future work.
+
+Configuration
+*************
+
+Both SLM and the Zephyr application running on the controlling chip must be compiled with the appropriate configuration to make them work together.
+
+For that, Kconfig fragments and devicetree overlays must be added to the compilation command.
+
+See the :ref:`slm_config_files` section for information on how to compile with additional configuration files and a description of some of the mentioned Kconfig fragments.
+
+nRF91 Series SiP running SLM
+============================
+
+The following configuration files must be included:
+
+* :file:`overlay-cmux.conf` - To enable CMUX.
+* :file:`overlay-ppp.conf` - To enable PPP.
+* :file:`overlay-zephyr-modem.conf` - To tailor SLM to how Zephyr's cellular modem driver works.
+  This enables the :ref:`CONFIG_SLM_START_SLEEP <CONFIG_SLM_START_SLEEP>` Kconfig option, which makes the nRF91 Series SiP start only when the :ref:`power pin <CONFIG_SLM_POWER_PIN>` is toggled.
+
+In addition, if the controlling chip is an external MCU, the following files must also be included:
+
+* :file:`overlay-zephyr-modem-external-mcu.conf`- To define the power pin.
+  Make sure to update the defined pin so that it matches your setup.
+* :file:`overlay-external-mcu.overlay` - To configure which UART SLM will use.
+  The actual configuration of the UART is defined in the :file:`*_ns.overlay` overlay file matching your board in the :file:`boards` directory.
+  Make sure to update the UART configuration (pins, baud rate) so that it matches your setup.
+  You can do this by modifying the properties of the node of the UART to be used, by editing either :file:`overlay-external-mcu.overlay` or the overlay file matching your board in the :file:`boards` directory.
+
+Or, if the controlling chip is the nRF52840 of the nRF9160 DK, the following files must also be included:
+
+* :file:`overlay-zephyr-modem-nrf9160dk-nrf52840.conf` - To define the power pin.
+* :file:`overlay-zephyr-modem-nrf9160dk-nrf52840.overlay` - To configure the UART to be routed between the nRF9160 and the nRF52840 of the DK.
+
+Finally, if you want more verbose logging that includes the AT commands and responses, you can enable debug logging by uncommenting ``CONFIG_SLM_LOG_LEVEL_DBG=y`` in the :file:`prj.conf` configuration file.
+
+Controlling chip running Zephyr
+===============================
+
+Configuration files found in Zephyr's :zephyr:code-sample:`cellular-modem` sample are a good starting point.
+
+Specifically, regardless of what the controlling chip is, the Kconfig options found in the following files are needed:
+
+* :file:`prj.conf` - This file enables various Zephyr APIs, most of which are needed for proper functioning of the application.
+* :file:`boards/nrf9160dk_nrf52840.conf` - This file tailors the configuration of the modem subsystem and driver to the SLM.
+  It makes the application's logs be output on UART 0 and also enables the debug logs of the cellular modem driver.
+  If you do not want the debug logs output by the driver, you may turn them off by removing ``CONFIG_MODEM_LOG_LEVEL_DBG=y``.
+
+In addition, depending on what the controlling chip is, the following devicetree overlay files are also needed.
+They define the modem along with the UART it is connected to and its power pin.
+
+If the controlling chip is an external MCU:
+
+* :file:`boards/nrf9160dk_nrf9160_ns.overlay` - The UART configuration and power pin can be customized according to your setup.
+
+If the controlling chip is the nRF52840 of the nRF9160 DK:
+
+* :file:`boards/nrf9160dk_nrf52840.overlay` - The UART and power pin are configured to be routed to the nRF9160.
+
+Developing the Zephyr application
+*********************************
+
+To get started developing the Zephyr application running on the controlling chip, look at the code of Zephyr's :zephyr:code-sample:`cellular-modem` sample to see how the modem is managed and used.
+You can even compile, flash and run the sample to verify proper operation of the modem.
+
+Flashing and running
+********************
+
+When built with the Zephyr-compatible modem configuration, SLM will put the nRF91 Series SiP to deep sleep when powered on.
+Zephyr's cellular modem driver running on the controlling chip will take care of waking up the nRF91 Series SiP, so it is advised to first flash SLM to the nRF91 Series SiP.
+
+However, before flashing the SLM built with the Zephyr-compatible modem configuration, make sure that the nRF91 Series modem has been set to the desired system mode.
+For this, you will need a regular SLM running in the nRF91 Series SiP to be able to run AT commands manually.
+To set the modem to the desired system mode, issue an ``AT%XSYSTEMMODE`` command followed by an ``AT+CFUN=0`` command so that the modem saves the system mode to NVM.
+For example, to enable only LTE-M, issue the following command: ``AT%XSYSTEMMODE=0,1,0,0``
+You need to do this because the modem's system mode is not automatically set at any point, so the one already configured will be used.
+
+Additionally, if the controlling chip is an external MCU:
+
+* Make sure that the UART and the power pin are wired according to how they are configured in both the external MCU and the nRF91 Series SiP.
+
+Or if the controlling chip is the nRF52840 of the nRF9160 DK:
+
+* Make sure that the **PROG/DEBUG SW10** switch on the DK is set to **NRF91** when flashing SLM, and to **NRF52** when flashing the Zephyr application.
+  The switch also affects which chip is reset when the Reset button is pressed.
+* No wiring is needed as the routing between the pins happens internally.
+
+To observe the operation sequence, you can view the application logs coming from both chips.
+
+By default, SLM will output its logs through RTT, and the Zephyr application running on the controlling chip through its UART 0.
+The RTT logs can be seen with an RTT client such as ``JLinkRTTViewer``.
+If SLM is running on the nRF9160 DK, the **PROG/DEBUG SW10** switch needs to be set to **NRF91** to be able to receive the RTT logs.
+However, for convenience you may want to redirect SLM's logs to the SiP's UART 0 so that you do not need to reconnect the RTT client every time the board is reset.
+See the :ref:`slm_additional_config` section for information on how to do this.
+
+The logs output via UART can be seen by connecting to the appropriate UART with a serial communication program.
+Under Linux, if the controlling chip is the nRF52840 of the nRF9160 DK, the device file of its UART 0 will typically be :file:`/dev/ttyACM1`.
+
+After both applications have been flashed to their respective chips and you are connected to receive logs, you can reset the controlling chip.
+When the Zephyr application starts up, the following happens:
+
+* If power management is enabled (the :kconfig:option:`CONFIG_PM_DEVICE` Kconfig option is set to ``y``): when the application powers on the modem (by calling ``pm_device_action_run(<dev>, PM_DEVICE_ACTION_RESUME)`` as the sample does), the cellular modem driver will toggle the modem's power pin to wake it up.
+
+  If power management is not enabled, the cellular modem driver will automatically proceed and expect SLM to already be started and in a pristine state.
+  In this case, SLM should be compiled with the :ref:`CONFIG_SLM_START_SLEEP <CONFIG_SLM_START_SLEEP>` Kconfig option set to ``n``, and :ref:`CONFIG_SLM_POWER_PIN <CONFIG_SLM_POWER_PIN>` can be left undefined.
+
+* The cellular modem driver will start sending AT commands to SLM.
+  It will enable the network status notifications, gather some information from the modem, enable CMUX, and set the modem to normal mode (with an ``AT+CFUN=1`` command).
+  This will result in SLM's PPP starting automatically when the network registration is complete.
+
+* From this point onwards, once the Zephyr application has brought up the driver's network interface, it will be able to send and receive IP traffic through it.
+  The :zephyr:code-sample:`cellular-modem` sample does this.

--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -20,7 +20,7 @@ The application accepts both the modem-specific AT commands and proprietary AT c
 The AT commands are documented in the following guides:
 
 * Modem-specific AT commands - `nRF91x1 AT Commands Reference Guide`_  and `nRF9160 AT Commands Reference Guide`_
-* Proprietary AT commands - :ref:`SLM_AT_intro`
+* Proprietary AT commands - :ref:`SLM_AT_commands`
 
 Requirements
 ************
@@ -36,7 +36,7 @@ Configuration
 
 |config|
 
-.. _slm_config:
+.. _slm_config_options:
 
 Configuration options
 =====================
@@ -261,6 +261,8 @@ CONFIG_SLM_UART_TX_BUF_SIZE - Send buffer size for UART.
    This option defines the size of the buffer for sending (TX) UART traffic.
    The default value is 256.
 
+.. _slm_additional_config:
+
 Additional configuration
 ========================
 
@@ -284,9 +286,20 @@ Configuration files
 
 You can find the configuration files in the :file:`applications/serial_lte_modem` directory.
 
+In general, they have an ``overlay-`` prefix, and a :file:`.conf` or :file:`.overlay` extension for Kconfig or devicetree overlays, respectively.
+Board-specific configuration files are named :file:`<BOARD>` with a :file:`.conf` or :file:`.overlay` extension and are located in the :file:`boards` directory.
+When the name of the board-specific configuration file matches the build target, the overlay is automatically included by the build system.
+
+See :ref:`app_build_system`: for more information on the |NCS| configuration system.
+
+.. important::
+
+  When adding Kconfig fragments and devicetree overlays, make sure to use the ``-DEXTRA_CONF_FILE`` and ``-DEXTRA_DTC_OVERLAY_FILE`` CMake parameters, respectively.
+  Otherwise, if ``-DCONF_FILE`` or ``-DDTC_OVERLAY_FILE`` is used, all the configuration files that normally get picked up automatically will have to be included explicitly.
+
 The following configuration files are provided:
 
-* :file:`prj.conf` - This configuration file contains the standard configuration for the serial LTE modem application.
+* :file:`prj.conf` - This configuration file contains the standard configuration for the serial LTE modem application and is included by default by the build system.
 
 * :file:`overlay-native_tls.conf` - This configuration file contains additional configuration options that are required to use :ref:`slm_native_tls`.
   You can include it by adding ``-DEXTRA_CONF_FILE=overlay-native_tls.conf`` to your build command.
@@ -302,13 +315,16 @@ The following configuration files are provided:
   See :ref:`SLM_AT_CMUX` for more information.
 
 * :file:`overlay-ppp.conf` - Configuration file that adds support for the Point-to-Point Protocol (PPP).
-  This disables most of the IP-based protocols available through AT commands (such as FTP and MQTT) as it is expected that the external MCU's own IP stack is used instead.
+  This disables most of the IP-based protocols available through AT commands (such as FTP and MQTT) as it is expected that the controlling chip's own IP stack is used instead.
   See :ref:`CONFIG_SLM_PPP <CONFIG_SLM_PPP>` and :ref:`SLM_AT_PPP` for more information.
 
 * :file:`overlay-ppp-without-cmux.overlay` - Devicetree overlay file that configures the UART to be used by PPP.
   This configuration file should be included when building SLM with PPP and without CMUX, in addition to :file:`overlay-ppp.conf`.
   It can be customized to fit your configuration (UART, baud rate, and so on).
   By default, it sets the baud rate of the PPP UART to 1 000 000.
+
+* :file:`overlay-zephyr-modem.conf`, :file:`overlay-zephyr-modem-external-mcu.conf`, :file:`overlay-zephyr-modem-nrf9160dk-nrf52840.conf`, :file:`overlay-external-mcu.overlay`,  and :file:`overlay-zephyr-modem-nrf9160dk-nrf52840.overlay` - These configuration files are used when compiling SLM to turn an nRF91 Series SiP into a Zephyr-compatible standalone modem.
+   See :ref:`slm_as_zephyr_modem` for more information.
 
 * :file:`boards/nrf9160dk_nrf9160_ns.conf` - Configuration file specific for the nRF9160 DK.
   This file is automatically merged with the :file:`prj.conf` file when you build for the ``nrf9160dk_nrf9160_ns`` build target.
@@ -318,14 +334,6 @@ The following configuration files are provided:
 
 * :file:`boards/thingy91_nrf9160_ns.conf` - Configuration file specific for Thingy:91.
   This file is automatically merged with the :file:`prj.conf` file when you build for the ``thingy91_nrf9160_ns`` build target.
-
-In general, Kconfig overlays have an ``overlay-`` prefix and a :file:`.conf` extension.
-Board-specific configuration files are named :file:`<BOARD>.conf` and are located in the :file:`boards` folder.
-DTS overlay files are named as the build target they are meant to be used with, and use the file extension :file:`.overlay`.
-They are also placed in the :file:`boards` folder.
-When the DTS overlay filename matches the build target, the overlay is automatically chosen and applied by the build system.
-
-See :ref:`app_build_system`: for more information on the |NCS| configuration system.
 
 .. _slm_native_tls:
 
@@ -408,7 +416,7 @@ To connect to an nRF91 Series DK with a PC:
          :alt: Teraterm configuration for sending AT commands through UART
 
       When using PuTTY, you must set the :ref:`CONFIG_SLM_CR_TERMINATION <CONFIG_SLM_CR_TERMINATION>` SLM configuration option instead.
-      See :ref:`application configuration <slm_config>` for more details.
+      See :ref:`slm_config_options` for more details.
 
 .. slm_connecting_91dk_pc_instr_end
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-1.9.0.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-1.9.0.rst
@@ -277,7 +277,7 @@ nRF9160: Serial LTE modem
       * Additional configuration section by adding information about the configuration files for Thingy:91.
 
   * SLM UART #XSLMUART section in :ref:`SLM_AT_gen`.
-  * :ref:`slm_config` with the configuration option related to SLM UART.
+  * :ref:`slm_config_options` with the configuration option related to SLM UART.
 
 
 Samples

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -290,6 +290,8 @@ Serial LTE modem
 
 * Added:
 
+  * Support for Zephyr's cellular modem driver which allows a Zephyr application running on an external MCU to seamlessly use Zephyr's IP stack instead of AT commands for connectivity.
+    See :ref:`slm_as_zephyr_modem` for more information.
   * Support for the CMUX protocol in order to multiplex multiple data streams through a single serial link.
     The ``#XCMUX`` AT command is added to set up CMUX.
   * Support for PPP in order to use the external MCU's own IP stack instead of offloaded sockets used via AT commands.

--- a/samples/cellular/slm_shell/README.rst
+++ b/samples/cellular/slm_shell/README.rst
@@ -95,7 +95,7 @@ References
 
 * `nRF91x1 AT Commands Reference Guide`_
 * `nRF9160 AT Commands Reference Guide`_
-* :ref:`SLM_AT_intro`
+* :ref:`SLM_AT_commands`
 
 Dependencies
 ************


### PR DESCRIPTION
Document the newly introduced support for Zephyr's generic modem driver.