### PR TITLE
Add missing C++ support in header files

### DIFF
--- a/include/dfu/dfu_target_full_modem.h
+++ b/include/dfu/dfu_target_full_modem.h
@@ -139,6 +139,11 @@ int dfu_target_full_modem_schedule_update(int img_num);
  */
 int dfu_target_full_modem_reset(void);
 
+/**@} */
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* DFU_TARGET_FULL_MODEM_H__ */
 
-/**@} */

--- a/include/net/nrf_cloud_alert.h
+++ b/include/net/nrf_cloud_alert.h
@@ -136,6 +136,7 @@ bool nrf_cloud_alert_control_get(void);
 /** @} */
 
 #ifdef __cplusplus
+}
 #endif
 
 #endif /* NRF_CLOUD_ALERT_H_ */

--- a/include/net/nrf_cloud_pgps.h
+++ b/include/net/nrf_cloud_pgps.h
@@ -370,6 +370,7 @@ int nrf_cloud_pgps_init(struct nrf_cloud_pgps_init_param *param);
 /** @} */
 
 #ifdef __cplusplus
+}
 #endif
 
 #endif /* NRF_CLOUD_PGPS_H_ */


### PR DESCRIPTION
These 3 header files had incomplete C++ support. These changes fixed it for me.

p.s. this came to light when I enabled CONFIG_CPP in prj.conf