### PR TITLE
manifest: Fix TX power issue

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -142,7 +142,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: v2.6.0-rc1
+      revision: pull/1238/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
[SHEL-2533]: The problem of TX output power disparity has been resolved, which occurs when the default power is set without utilizing the TX power command, and the power is explicitly set using the TX power command through the Radio test application.

[SHEL-2533]: https://nordicsemi.atlassian.net/browse/SHEL-2533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ