### PR TITLE
Add missing Carrier library event logs

### DIFF
--- a/applications/asset_tracker_v2/src/modules/modem_module.c
+++ b/applications/asset_tracker_v2/src/modules/modem_module.c
@@ -426,6 +426,12 @@ int lwm2m_carrier_event_handler(const lwm2m_carrier_event_t *evt)
 		 */
 		return 1;
 	}
+	case LWM2M_CARRIER_EVENT_MODEM_DOMAIN:
+		LOG_INF("LWM2M_CARRIER_EVENT_MODEM_DOMAIN");
+		break;
+	case LWM2M_CARRIER_EVENT_APP_DATA:
+		LOG_INF("LWM2M_CARRIER_EVENT_APP_DATA");
+		break;
 	case LWM2M_CARRIER_EVENT_MODEM_INIT:
 		LOG_INF("LWM2M_CARRIER_EVENT_MODEM_INIT");
 		err = nrf_modem_lib_init();

--- a/applications/serial_lte_modem/src/lwm2m_carrier/slm_at_carrier.c
+++ b/applications/serial_lte_modem/src/lwm2m_carrier/slm_at_carrier.c
@@ -258,6 +258,9 @@ int lwm2m_carrier_event_handler(const lwm2m_carrier_event_t *event)
 		/* Return -1 to defer the reboot until the application decides to do so. */
 		err = -1;
 		break;
+	case LWM2M_CARRIER_EVENT_MODEM_DOMAIN:
+		LOG_DBG("LWM2M_CARRIER_EVENT_MODEM_DOMAIN");
+		break;
 	case LWM2M_CARRIER_EVENT_APP_DATA:
 		LOG_DBG("LWM2M_CARRIER_EVENT_APP_DATA");
 		on_event_app_data(event);

--- a/samples/cellular/http_update/application_update/src/main.c
+++ b/samples/cellular/http_update/application_update/src/main.c
@@ -473,6 +473,12 @@ int lwm2m_carrier_event_handler(const lwm2m_carrier_event_t *event)
 	case LWM2M_CARRIER_EVENT_REBOOT:
 		printk("LWM2M_CARRIER_EVENT_REBOOT\n");
 		break;
+	case LWM2M_CARRIER_EVENT_MODEM_DOMAIN:
+		printk("LWM2M_CARRIER_EVENT_MODEM_DOMAIN\n");
+		break;
+	case LWM2M_CARRIER_EVENT_APP_DATA:
+		printk("LWM2M_CARRIER_EVENT_APP_DATA\n");
+		break;
 	case LWM2M_CARRIER_EVENT_MODEM_INIT:
 		printk("LWM2M_CARRIER_EVENT_MODEM_INIT\n");
 		err = nrf_modem_lib_init();

--- a/samples/cellular/lwm2m_carrier/src/main.c
+++ b/samples/cellular/lwm2m_carrier/src/main.c
@@ -157,6 +157,12 @@ int lwm2m_carrier_event_handler(const lwm2m_carrier_event_t *event)
 	case LWM2M_CARRIER_EVENT_REBOOT:
 		printk("LWM2M_CARRIER_EVENT_REBOOT\n");
 		break;
+	case LWM2M_CARRIER_EVENT_MODEM_DOMAIN:
+		printk("LWM2M_CARRIER_EVENT_MODEM_DOMAIN\n");
+		break;
+	case LWM2M_CARRIER_EVENT_APP_DATA:
+		printk("LWM2M_CARRIER_EVENT_APP_DATA\n");
+		break;
 	case LWM2M_CARRIER_EVENT_MODEM_INIT:
 		printk("LWM2M_CARRIER_EVENT_MODEM_INIT\n");
 		err = nrf_modem_lib_init();

--- a/samples/cellular/modem_shell/src/shell.c
+++ b/samples/cellular/modem_shell/src/shell.c
@@ -144,6 +144,12 @@ int lwm2m_carrier_event_handler(const lwm2m_carrier_event_t *event)
 	case LWM2M_CARRIER_EVENT_REBOOT:
 		mosh_print("LwM2M carrier event: reboot");
 		break;
+	case LWM2M_CARRIER_EVENT_MODEM_DOMAIN:
+		mosh_print("LwM2M carrier event: modem domain");
+		break;
+	case LWM2M_CARRIER_EVENT_APP_DATA:
+		mosh_print("LwM2M carrier event: app data");
+		break;
 	case LWM2M_CARRIER_EVENT_MODEM_INIT:
 		mosh_print("LwM2M carrier event: modem init");
 		err = nrf_modem_lib_init();


### PR DESCRIPTION
Add logs for the events `LWM2M_CARRIER_EVENT_MODEM_DOMAIN` and `LWM2M_CARRIER_EVENT_APP_DATA` to the samples and applications where these were missing.