### PR TITLE
modules: trusted-firmware-m: Fix include guard

### DIFF
--- a/modules/trusted-firmware-m/tfm_boards/common/tfm_hal_platform.c
+++ b/modules/trusted-firmware-m/tfm_boards/common/tfm_hal_platform.c
@@ -7,7 +7,7 @@
 #if defined(TFM_PARTITION_CRYPTO)
 #include <autoconf.h>
 
-#ifdef CONFIG_CRYPTOCELL_USABLE
+#ifdef CONFIG_HAS_HW_NRF_CC3XX
 #include <nrf_cc3xx_platform.h>
 #include <nrf_cc3xx_platform_ctr_drbg.h>
 #endif


### PR DESCRIPTION
CONFIG_CRYPTOCELL_USABLE is now removed and cannot be used. Replace it with CONFIG_HAS_HW_NRF_CC3XX which is supported.