### PR TITLE
lib: bin: lwm2m_carrier: Fix lwm2m_carrier_thread size

### DIFF
--- a/lib/bin/lwm2m_carrier/Kconfig
+++ b/lib/bin/lwm2m_carrier/Kconfig
@@ -279,6 +279,7 @@ config LWM2M_CARRIER_WORKQ_STACK_SIZE
 
 config LWM2M_CARRIER_THREAD_STACK_SIZE
 	int "LwM2M carrier thread stack size"
+	default 2048 if NEWLIB_LIBC
 	default 1536
 	help
 	  Stack size for the LwM2M carrier thread.


### PR DESCRIPTION
The lwm2m_carrier_thread stack size must be bigger when building with NEWLIB libc.