### PR TITLE
applications: serial_lte_modem: set range for data buffer length

### DIFF
--- a/applications/serial_lte_modem/src/lwm2m_carrier/Kconfig
+++ b/applications/serial_lte_modem/src/lwm2m_carrier/Kconfig
@@ -12,7 +12,8 @@ if SLM_CARRIER
 
 config SLM_CARRIER_APP_DATA_BUFFER_LEN
 	int "Size of the buffer for setting application data"
-	default 512
+	default 768
+	range 128 768
 	help
 	  Specifies maximum application data size to be set in the App Data Container,
 	  the Binary App Data Container or the Event Log objects.


### PR DESCRIPTION
Defined a maximum range for SLM_CARRIER_APP_DATA_BUFFER_LEN to prevent stack overflow on the system work queue, whose size is configured independently, and to conform with a requirement from one of the operators.