### PR TITLE
net: lib: download_client: Change log level

### DIFF
--- a/subsys/net/lib/download_client/src/download_client.c
+++ b/subsys/net/lib/download_client/src/download_client.c
@@ -264,7 +264,7 @@ static int host_lookup(const char *host, int family, uint8_t pdn_id,
 	}
 
 	if (err) {
-		LOG_WRN("Failed to resolve hostname %s on %s",
+		LOG_DBG("Failed to resolve hostname %s on %s",
 			hostname, str_family(family));
 		return -EHOSTUNREACH;
 	}


### PR DESCRIPTION
Change log level for failure to resolve hostname
on a specific ip familiy, from warning to debug.

This is quite typical for services to not support
a specific family. AWS S3 for instance doesnt support IPv6.