### PR TITLE
lib: bin: lwm2m_carrier: Prevent illegal Carrier library configuration

### DIFF
--- a/lib/bin/lwm2m_carrier/os/lwm2m_carrier.c
+++ b/lib/bin/lwm2m_carrier/os/lwm2m_carrier.c
@@ -240,6 +240,11 @@ void lwm2m_carrier_thread_run(void)
 		return;
 	}
 
+	/* Prevent an illegal configuration of the LwM2M carrier library. */
+	if (config.server_binding == 'N') {
+		config.server_uri = "";
+	}
+
 	/* Run the LwM2M carrier library.
 	 *
 	 * Note: can also pass NULL to initialize with default settings


### PR DESCRIPTION
Prevent an illegal combination of configured server binding and server URI in the LwM2M Carrier library