### PR TITLE
applications: asset_tracker_v2: Remove testcase

### DIFF
--- a/applications/asset_tracker_v2/tests/ui_module/testcase.yaml
+++ b/applications/asset_tracker_v2/tests/ui_module/testcase.yaml
@@ -1,8 +1,7 @@
 tests:
   asset_tracker_v2.ui_module_test.tester:
-    platform_allow: native_sim qemu_cortex_m3 nrf9160dk_nrf9160_ns
+    platform_allow: native_sim nrf9160dk_nrf9160_ns
     integration_platforms:
       - native_sim
-      - qemu_cortex_m3
       - nrf9160dk_nrf9160_ns
     tags: ui_module


### PR DESCRIPTION
Remove testcase for qemu cortex m3.
We already support native sim which is sufficient.

NCSDK-26369