### PR TITLE
samples: ipc: ipc_service: Fix cpunet logging for nrf5340

### DIFF
--- a/samples/ipc/ipc_service/sample.yaml
+++ b/samples/ipc/ipc_service/sample.yaml
@@ -62,7 +62,7 @@ tests:
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
     extra_configs:
-      - ipc_service_CONFIG_APP_IPC_SERVICE_SEND_INTERVAL=1
+      - ipc_service_CONFIG_APP_IPC_SERVICE_SEND_INTERVAL=35
       - remote_CONFIG_APP_IPC_SERVICE_SEND_INTERVAL=200000000
     extra_args:
       SB_CONF_FILE=sysbuild/nrf5340dk_nrf5340_cpunet.conf


### PR DESCRIPTION
This commit gives the network core just enought time to be able to log data as expected in cpuapp_sending test.

JIRA: NCSDK-26392