### PR TITLE
applications: nrf5340_audio: Only build empty_net_core if LL_ACS_nRF53

### DIFF
--- a/applications/nrf5340_audio/CMakeLists.txt
+++ b/applications/nrf5340_audio/CMakeLists.txt
@@ -27,19 +27,21 @@ if(CONFIG_AUDIO_DFU EQUAL 2)
     set(PM_STATIC_YML_FILE ${CMAKE_CURRENT_LIST_DIR}/dfu/conf/pm_dfu_external_flash.yml)
 endif()
 
-if ((CONFIG_AUDIO_DFU EQUAL 1) OR (CONFIG_AUDIO_DFU EQUAL 2))
-    list(APPEND empty_net_core_OVERLAY_CONFIG
-        "${CMAKE_CURRENT_LIST_DIR}/dfu/conf/overlay-empty_net_core.conf"
-    )
+if (CONFIG_BT_LL_ACS_NRF53)
+    if ((CONFIG_AUDIO_DFU EQUAL 1) OR (CONFIG_AUDIO_DFU EQUAL 2))
+        list(APPEND empty_net_core_OVERLAY_CONFIG
+            "${CMAKE_CURRENT_LIST_DIR}/dfu/conf/overlay-empty_net_core.conf"
+        )
 
-    # Disable pretick anomaly workaround. The workaround causes a resource conflict between B0N and
-    # the controller, and as the controller does not use RTC to wake up from sleep it is not
-    # affected by the anomaly.
-    list(APPEND empty_net_core_b0n_CONFIG_SOC_NRF53_RTC_PRETICK n)
+        # Disable pretick anomaly workaround. The workaround causes a resource conflict between B0N and
+        # the controller, and as the controller does not use RTC to wake up from sleep it is not
+        # affected by the anomaly.
+        list(APPEND empty_net_core_b0n_CONFIG_SOC_NRF53_RTC_PRETICK n)
 
-    if (CONFIG_B0N_MINIMAL)
-        set(min_b0n_flag "-m")
-        list(APPEND empty_net_core_b0n_OVERLAY_CONFIG overlay-minimal-size.conf)
+        if (CONFIG_B0N_MINIMAL)
+            set(min_b0n_flag "-m")
+            list(APPEND empty_net_core_b0n_OVERLAY_CONFIG overlay-minimal-size.conf)
+        endif()
     endif()
 endif()
 
@@ -111,21 +113,23 @@ if (CONFIG_HW_CODEC_CIRRUS_LOGIC)
     endif()
 endif()
 
-if ((CONFIG_AUDIO_DFU EQUAL 1) OR (CONFIG_AUDIO_DFU EQUAL 2))
-    set(BLE5_CTR_SIGN_STEP ${APPLICATION_BINARY_DIR}/dummy)
-    file(TO_CMAKE_PATH ${ZEPHYR_NRF_MODULE_DIR}/lib/bin/bt_ll_acs_nrf53/bin CMAKE_STYLE_LL_ACS_NRF53_BIN)
+if (CONFIG_BT_LL_ACS_NRF53)
+    if ((CONFIG_AUDIO_DFU EQUAL 1) OR (CONFIG_AUDIO_DFU EQUAL 2))
+        set(BLE5_CTR_SIGN_STEP ${APPLICATION_BINARY_DIR}/dummy)
+        file(TO_CMAKE_PATH ${ZEPHYR_NRF_MODULE_DIR}/lib/bin/bt_ll_acs_nrf53/bin CMAKE_STYLE_LL_ACS_NRF53_BIN)
 
-    add_custom_command(
-        COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/tools/buildprog/ble5-ctr-rpmsg_sign.py
-        -I ${CMAKE_STYLE_LL_ACS_NRF53_BIN} -b ${APPLICATION_BINARY_DIR} ${min_b0n_flag}
-        OUTPUT ${BLE5_CTR_SIGN_STEP}
-        DEPENDS merged_domains_hex
-        COMMENT "Running post-build ble5-ctr signing step..."
-    )
+        add_custom_command(
+            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/tools/buildprog/ble5-ctr-rpmsg_sign.py
+            -I ${CMAKE_STYLE_LL_ACS_NRF53_BIN} -b ${APPLICATION_BINARY_DIR} ${min_b0n_flag}
+            OUTPUT ${BLE5_CTR_SIGN_STEP}
+            DEPENDS merged_domains_hex
+            COMMENT "Running post-build ble5-ctr signing step..."
+        )
 
-    add_custom_target(
-        post_bin ALL
-        DEPENDS
-        ${BLE5_CTR_SIGN_STEP}
-    )
+        add_custom_target(
+            post_bin ALL
+            DEPENDS
+            ${BLE5_CTR_SIGN_STEP}
+        )
+    endif()
 endif()


### PR DESCRIPTION
- Only use empty_net_core if LL_ACS_nRF53 is chosen
- Only run ble5-ctr-rpmsg_sign.py on LL_ACS_nRF53 images