### PR TITLE
modules: hostap: Reduce WPA supplicant heap when MbedTLS heap is enabled

### DIFF
--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -24,6 +24,8 @@ if WPA_SUPP
 
 config COMMON_LIBC_MALLOC_ARENA_SIZE
 	default 40000 if WPA_SUPP_AP
+	# 8192 for MbedTLS heap
+	default 21808 if MBEDTLS_ENABLE_HEAP
 	# 30K is mandatory, but might need more for long duration use cases
 	default 30000
 


### PR DESCRIPTION
If MbedTLS uses its own heap which is a static heap (not libc heap), then WPA supplicant heap usage will come down, so, reduce 8K (minimum MbedTLS heap for Wi-Fi) from the libc heap size.

Fixes SHEL-2560.