### PR TITLE
Bluetooth: Remove dep on ZLI for BSIM platform

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -11,7 +11,7 @@ choice BT_LL_CHOICE
 config BT_LL_SOFTDEVICE
 	bool "SoftDevice Link Layer"
 	select MPSL
-	select ZERO_LATENCY_IRQS
+	select ZERO_LATENCY_IRQS if !SOC_SERIES_BSIM_NRFXX
 	select BT_CTLR_LE_ENC_SUPPORT
 	select BT_CTLR_ECDH_SUPPORT
 	select BT_CTLR_EXT_REJ_IND_SUPPORT

--- a/west.yml
+++ b/west.yml
@@ -142,7 +142,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 167fa4334ca40e501946b213ef7a62005db4ecce
+      revision: 6e0de3e77484c2a8dcda004615b967542d107f90
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
ZERO_LATENCY_IRQS now has direct deps on cortex-m arch. Also pull in updated nrfxlib w/ same fix for MPSL.