### PR TITLE
doc: bluetooth: mesh: Clarify that DFU shell using app requires Android

### DIFF
--- a/doc/nrf/protocols/bt/bt_mesh/dfu_over_bt_mesh.rst
+++ b/doc/nrf/protocols/bt/bt_mesh/dfu_over_bt_mesh.rst
@@ -26,7 +26,7 @@ For the complete list of commands, see the :ref:`zephyr:bluetooth_mesh_shell_dfd
 
 The commands can be executed in two ways:
 
-* Through the shell management subsystem of MCU manager (for example, using the nRF Connect Device Manager mobile application or :ref:`Mcumgr command-line tool <zephyr:mcumgr_cli>`).
+* Through the shell management subsystem of MCU manager (for example, using the nRF Connect Device Manager mobile application on Android or :ref:`Mcumgr command-line tool <zephyr:mcumgr_cli>`).
 * By accessing the :ref:`zephyr:shell_api` module over UART.
 
 Provisioning and configuring the devices


### PR DESCRIPTION
Add a clarification that only the nRF Connect Device Manager app on Android supports shell access, used for Mesh DFU.