### PR TITLE
manifest: Fix the build warning in matter door-lock-server

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -154,7 +154,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: cb2a393b26ef9924f92e8fa6a8ee4a8a95d8e6c2
+      revision: 2ee0a69cd56bf22c297cc6159d6856833684dc0e
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
This commit fixes the uninitialized variable warning appearing when compiling the door lock app.