### PR TITLE
applications: nrf_desktop: Add support for nRF54L PDK (documentation)

### DIFF
--- a/applications/nrf_desktop/board_configuration.rst
+++ b/applications/nrf_desktop/board_configuration.rst
@@ -101,3 +101,15 @@ Sample dongle (``nrf5340dk_nrf5340``)
       * Bluetooth uses Nordic Semiconductor's SoftDevice link layer without LLPM and is configured to act as a central.
         Input data comes from Bluetooth and is retransmitted to USB.
       * The configuration with the B0 bootloader is set as default.
+
+Sample mouse or keyboard (``nrf54l15pdk_nrf54l15_cpuapp``)
+      * The configuration uses the nRF54L15 Preview Development Kit (PDK).
+      * The build types allow to build the application as a mouse or a keyboard.
+      * Inputs are simulated based on the hardware button presses.
+        On the PDK PCA10156, revision v0.2.1 AB0-ES5, GPIOs assigned to **Button 3** and **Button 4** do not support interrupts.
+        Because of this, the application cannot use those buttons.
+      * Only Bluetooth LE transport is enabled.
+        Bluetooth LE is configured to use Nordic Semiconductor's SoftDevice Link Layer and Low Latency Packet Mode (LLPM).
+      * In debug configurations, logs are provided through the UART.
+        For detailed information on working with the nRF54L15 PDK, see the :ref:`ug_nrf54l15_gs` documentation.
+      * Configurations do not enable bootloader and do not support a firmware update.

--- a/applications/nrf_desktop/description.rst
+++ b/applications/nrf_desktop/description.rst
@@ -363,7 +363,7 @@ Depending on the development kit you use, you need to select the respective conf
 
       .. table-from-rows:: /includes/sample_board_rows.txt
          :header: heading
-         :rows: nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf52833dk_nrf52820, nrf5340dk_nrf5340_cpuapp
+         :rows: nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf52833dk_nrf52820, nrf5340dk_nrf5340_cpuapp, nrf54l15pdk_nrf54l15_cpuapp
 
       Depending on the configuration, a DK may act either as mouse, keyboard or dongle.
       For information about supported configurations for each board, see the :ref:`nrf_desktop_board_configuration_files` section.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -148,7 +148,9 @@ nRF Machine Learning (Edge Impulse)
 nRF Desktop
 -----------
 
-|no_changes_yet_note|
+* Added support for the nRF54L15 PDK with the ``nrf54l15pdk_nrf54l15_cpuapp`` board target.
+  The PDK can act as a sample mouse or keyboard.
+  It supports the Bluetooth LE HID data transport and uses SoftDevice Link Layer with Low Latency Packet Mode (LLPM) enabled.
 
 Thingy:53: Matter weather station
 ---------------------------------


### PR DESCRIPTION
PR adds documentation for nRF54L PDK support in nRF Desktop.

Jira: NCSDK-26216