### PR TITLE
partition_manager: Fix nRF54L support

### DIFF
--- a/cmake/partition_manager.cmake
+++ b/cmake/partition_manager.cmake
@@ -206,7 +206,7 @@ elseif (DEFINED CONFIG_SOC_NRF5340_CPUAPP)
   set(otp_size 764)  # 191 * 4
 endif()
 
-if (DEFINED CONFIG_SOC_PLATFORM_NRF54L)
+if (DEFINED CONFIG_SOC_SERIES_NRF54LX)
   set(soc_nvs_controller rram_controller)
   set(soc_nvs_controller_driver_kc CONFIG_SOC_FLASH_NRF_RRAM)
 else()

--- a/modules/mcuboot/boot/zephyr/Kconfig
+++ b/modules/mcuboot/boot/zephyr/Kconfig
@@ -15,11 +15,11 @@ partition-size=0x1e000
 source "${ZEPHYR_BASE}/../nrf/subsys/partition_manager/Kconfig.template.partition_config"
 
 partition=MCUBOOT_PAD
-if SOC_PLATFORM_NRF54L
+if SOC_SERIES_NRF54LX
 	partition-size=0x800
 source "${ZEPHYR_BASE}/../nrf/subsys/partition_manager/Kconfig.template.partition_config"
 endif
-if !SOC_PLATFORM_NRF54L
+if !SOC_SERIES_NRF54LX
 	partition-size=0x200
 source "${ZEPHYR_BASE}/../nrf/subsys/partition_manager/Kconfig.template.partition_config"
 endif


### PR DESCRIPTION
Change fixes references to a Kconfig option that does not exist.

Jira: NCSDK-26123