### PR TITLE
manifest: Update RPU patch to rev #5d9627b143a

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -142,7 +142,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: c9e5de5088be868452e768e7116caeb68afc0bd5
+      revision: c54c11065cf6ec8b58c9466a649a9c3f87519922
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
SHEL-2548:Apply PA, DA and PGA bias based on package type information. 
SHEL-2550:Avoid antenna gain and edge backoff when regulatory domain is bypassed.
SHEL-2546:Added missing functions to the Patch list to disable DPD depending on Temperature measured.