### PR TITLE
subsy/bootloader/bl_boot: uninitialized UARTE pins

### DIFF
--- a/subsys/bootloader/bl_boot/bl_boot.c
+++ b/subsys/bootloader/bl_boot/bl_boot.c
@@ -15,6 +15,27 @@
 #endif
 #ifdef CONFIG_UART_NRFX_UARTE
 #include <hal/nrf_uarte.h>
+#include <hal/nrf_gpio.h>
+#endif
+
+#ifdef CONFIG_UART_NRFX_UARTE
+static void uninit_used_uarte(NRF_UARTE_Type *p_reg)
+{
+	uint32_t pin[4];
+
+	nrf_uarte_disable(p_reg);
+
+	pin[0] = nrf_uarte_tx_pin_get(p_reg);
+	pin[1] = nrf_uarte_rx_pin_get(p_reg);
+	pin[2] = nrf_uarte_rts_pin_get(p_reg);
+	pin[3] = nrf_uarte_cts_pin_get(p_reg);
+
+	for (int i = 0; i < 4; i++) {
+		if (pin[i] != NRF_UARTE_PSEL_DISCONNECTED) {
+			nrf_gpio_cfg_default(pin[i]);
+		}
+	}
+}
 #endif
 
 static void uninit_used_peripherals(void)
@@ -23,13 +44,13 @@ static void uninit_used_peripherals(void)
 #if defined(CONFIG_HAS_HW_NRF_UART0)
 	nrf_uart_disable(NRF_UART0);
 #elif defined(CONFIG_HAS_HW_NRF_UARTE0)
-	nrf_uarte_disable(NRF_UARTE0);
+	uninit_used_uarte(NRF_UARTE0);
 #endif
 #if defined(CONFIG_HAS_HW_NRF_UARTE1)
-	nrf_uarte_disable(NRF_UARTE1);
+	uninit_used_uarte(NRF_UARTE1);
 #endif
 #if defined(CONFIG_HAS_HW_NRF_UARTE2)
-	nrf_uarte_disable(NRF_UARTE2);
+	uninit_used_uarte(NRF_UARTE2);
 #endif
 #endif /* CONFIG_UART_NRFX */
 


### PR DESCRIPTION
These pins might be source of the current leakage, which actually is observed on PCA 10095 2.0.1

Added procedure for setting these pins to default state.

Ref.: NCSDK-26253