### PR TITLE
Bluetooth: Mesh: Clarify buttons description in sensor client sample

### DIFF
--- a/samples/bluetooth/mesh/sensor_client/README.rst
+++ b/samples/bluetooth/mesh/sensor_client/README.rst
@@ -92,16 +92,16 @@ Buttons:
 Once the provisioning procedure has completed, the buttons will have the following functionality:
 
 Button 1:
-   Sends a get message for a setting.
+   Sends a get message for the :c:var:`bt_mesh_sensor_dev_op_temp_range_spec` setting of the :c:var:`bt_mesh_sensor_present_dev_op_temp` sensor.
 
 Button 2:
-   Sends a set message for a setting, switching between the ranges specified in the :c:var:`temp_ranges` variable.
+   Sends a set message for the :c:var:`bt_mesh_sensor_dev_op_temp_range_spec` setting of the :c:var:`bt_mesh_sensor_present_dev_op_temp` sensor, switching between the ranges specified in the :c:var:`temp_ranges` variable.
 
 Button 3:
    Sends a get message for a descriptor, requesting information about the :c:var:`bt_mesh_sensor_present_dev_op_temp` sensor.
 
 Button 4:
-   Sends a set message for a sensor setting, switching between the ranges specified in the :c:var:`presence_motion_threshold` variable.
+   Sends a set message for the :c:var:`bt_mesh_sensor_motion_threshold` setting of the :c:var:`bt_mesh_sensor_presence_detected` sensor, switching between the ranges specified in the :c:var:`presence_motion_threshold` variable.
 
 Terminal:
    All sensor values gathered from the server are printed over UART.


### PR DESCRIPTION
This commit should add some clarity in what each button does in the sensor_client sample.