### PR TITLE
doc: nrf_security: Add RSA key size support table

### DIFF
--- a/doc/nrf/libraries/security/nrf_security/doc/driver_config.rst
+++ b/doc/nrf/libraries/security/nrf_security/doc/driver_config.rst
@@ -794,23 +794,23 @@ RSA key size configuration
 
 To enable RSA key size support, set one or more of the Kconfig options in the following table:
 
-+--------------------+-----------------------------------------------------+
-| RSA key size       | Configuration option                                |
-+====================+=====================================================+
-| 1024 bits          | :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_1024` |
-+--------------------+-----------------------------------------------------+
-| 1536 bits          | :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_1536` |
-+--------------------+-----------------------------------------------------+
-| 2048 bits          | :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_2048` |
-+--------------------+-----------------------------------------------------+
-| 3072 bits          | :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_3072` |
-+--------------------+-----------------------------------------------------+
-| 4096 bits          | :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_4096` |
-+--------------------+-----------------------------------------------------+
-| 6144 bits          | :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_6144` |
-+--------------------+-----------------------------------------------------+
-| 8192 bits          | :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_8192` |
-+--------------------+-----------------------------------------------------+
++--------------------+-----------------------------------------------------+--------------------------+---------------------------+---------------------------+
+| RSA key size       | Configuration option                                | nrf_cc3xx driver support | nrf_oberon driver support | nrf_cracen driver support |
++====================+=====================================================+==========================+===========================+===========================+
+| 1024 bits          | :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_1024` | Supported                | Supported                 | Not supported             |
++--------------------+-----------------------------------------------------+--------------------------+---------------------------+---------------------------+
+| 1536 bits          | :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_1536` | Supported                | Supported                 | Not supported             |
++--------------------+-----------------------------------------------------+--------------------------+---------------------------+---------------------------+
+| 2048 bits          | :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_2048` | Supported                | Supported                 | Supported                 |
++--------------------+-----------------------------------------------------+--------------------------+---------------------------+---------------------------+
+| 3072 bits          | :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_3072` | Supported (CC312 only)   | Supported                 | Supported                 |
++--------------------+-----------------------------------------------------+--------------------------+---------------------------+---------------------------+
+| 4096 bits          | :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_4096` | Not supported            | Supported                 | Supported                 |
++--------------------+-----------------------------------------------------+--------------------------+---------------------------+---------------------------+
+| 6144 bits          | :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_6144` | Not supported            | Supported                 | Not supported             |
++--------------------+-----------------------------------------------------+--------------------------+---------------------------+---------------------------+
+| 8192 bits          | :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_8192` | Not supported            | Supported                 | Not supported             |
++--------------------+-----------------------------------------------------+--------------------------+---------------------------+---------------------------+
 
 .. note::
    All RSA key size configurations are introduced by :ref:`nrf_security` and are not described by the PSA Crypto specification.


### PR DESCRIPTION
Extend the table with RSA key sizes to list the support by different crypto  backends

Ref: NCSDK-22536