### PR TITLE
modules: hostap: Fix log level for an expected print

### DIFF
--- a/modules/hostap/src/supp_main.c
+++ b/modules/hostap/src/supp_main.c
@@ -328,7 +328,7 @@ static void iface_event_handler(struct net_mgmt_event_callback *cb,
 		}
 
 		if (!found) {
-			wpa_printf(MSG_ERROR, "No matching prefix found");
+			wpa_printf(MSG_DEBUG, "No matching prefix found for %s", ifname);
 			return;
 		}
 	}


### PR DESCRIPTION
In presence of non-Wi-Fi interfaces such as netusb, thread etc this print pops up as error, but it's an expected behaviour, we should silently ignore non-Wi-Fi interfaces. Convert to a debug print.

Also, improve the print by logging the interface name in question.

Fixes SHEL-2569.