### PR TITLE
samples: caf_sensor_manager: Add nrf54h20 configuration

### DIFF
--- a/samples/caf_sensor_manager/Kconfig.sysbuild
+++ b/samples/caf_sensor_manager/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+
+config REMOTE_BOARD
+	string "The board used for remote target"

--- a/samples/caf_sensor_manager/boards/nrf54h20pdk_nrf54h20_cpuapp_multicore.conf
+++ b/samples/caf_sensor_manager/boards/nrf54h20pdk_nrf54h20_cpuapp_multicore.conf
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+################################################################################
+
+CONFIG_EVENT_MANAGER_PROXY=y
+CONFIG_IPC_SERVICE=y
+CONFIG_MBOX=y
+
+CONFIG_CAF_SENSOR_DATA_AGGREGATOR_EVENTS=y

--- a/samples/caf_sensor_manager/boards/nrf54h20pdk_nrf54h20_cpuapp_multicore.overlay
+++ b/samples/caf_sensor_manager/boards/nrf54h20pdk_nrf54h20_cpuapp_multicore.overlay
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	sensor_stub: sensor_stub {
+		compatible = "nordic,sensor-stub";
+		generator = "sensor_stub_gen";
+		status = "okay";
+	};
+
+	agg0: agg0 {
+		compatible = "caf,aggregator";
+		sensor_descr = "accel_sim_xyz";
+		buf_data_length = <240>;
+		sample_size = <3>;
+	};
+};
+
+/* Enabled nodes required by IPC
+ * Two mboxes, one for each sides and one ipc instance
+ */
+
+&cpuapp_bellboard {
+	status = "okay";
+};
+
+&cpuppr_vevif {
+       status = "okay";
+};
+
+ipc0: &cpuapp_cpuppr_ipc {
+	status = "okay";
+};
+
+/* UART and RAM3 instance used by PPR should be enabled at build time
+ * using nordic-ppr snippet.
+ */

--- a/samples/caf_sensor_manager/boards/nrf54h20pdk_nrf54h20_cpuapp_singlecore.conf
+++ b/samples/caf_sensor_manager/boards/nrf54h20pdk_nrf54h20_cpuapp_singlecore.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+################################################################################
+
+CONFIG_CAF_SENSOR_MANAGER=y
+CONFIG_CAF_SENSOR_MANAGER_THREAD_STACK_SIZE=512
+CONFIG_CAF_SENSOR_DATA_AGGREGATOR=y
+
+CONFIG_SENSOR=y
+CONFIG_SENSOR_STUB=y
+
+CONFIG_CAF_INIT_LOG_SENSOR_EVENTS=y

--- a/samples/caf_sensor_manager/boards/nrf54h20pdk_nrf54h20_cpuapp_singlecore.overlay
+++ b/samples/caf_sensor_manager/boards/nrf54h20pdk_nrf54h20_cpuapp_singlecore.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	sensor_stub: sensor_stub {
+		compatible = "nordic,sensor-stub";
+		generator = "sensor_stub_gen";
+		status = "okay";
+	};
+
+	agg0: agg0 {
+		compatible = "caf,aggregator";
+		sensor_descr = "accel_sim_xyz";
+		buf_data_length = <240>;
+		sample_size = <3>;
+		status = "okay";
+	};
+};
+
+/* UART and RAM3 instance used by PPR should be enabled at build time
+ * using nordic-ppr snippet.
+ */

--- a/samples/caf_sensor_manager/remote/boards/nrf54h20pdk_nrf54h20_cpuppr.conf
+++ b/samples/caf_sensor_manager/remote/boards/nrf54h20pdk_nrf54h20_cpuppr.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+################################################################################
+
+CONFIG_OPENAMP=n
+
+CONFIG_ASSERT=n
+CONFIG_BOOT_BANNER=n
+CONFIG_HEAP_MEM_POOL_SIZE=512
+CONFIG_SIZE_OPTIMIZATIONS=y
+
+CONFIG_CAF_INIT_LOG_SENSOR_EVENTS=y

--- a/samples/caf_sensor_manager/remote/boards/nrf54h20pdk_nrf54h20_cpuppr.overlay
+++ b/samples/caf_sensor_manager/remote/boards/nrf54h20pdk_nrf54h20_cpuppr.overlay
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+ / {
+	chosen {
+		zephyr,sram = &cpuppr_code_data;
+	};
+
+	sensor_stub: sensor_stub {
+		compatible = "nordic,sensor-stub";
+		generator = "sensor_stub_gen";
+		status = "okay";
+	};
+
+	agg0: agg0 {
+		compatible = "caf,aggregator";
+		sensor_descr = "accel_sim_xyz";
+		buf_data_length = <240>;
+		sample_size = <3>;
+		memory-region = <&ram3x_agg_area0>;
+	};
+};
+
+/* Place aggregator buffers in PPR memory region. */
+
+&cpuppr_ram3x_region {
+	#address-cells = <1>;
+	#size-cells = <1>;
+	ranges = <0x0 0x2fc00000 0x7000>;
+
+	cpuppr_code_data: memory@0 {
+		reg = <0x0 0x6a00>;
+	};
+
+	ram3x_agg_area0: memory@6a00 {
+		reg = <0x6a00 0x600>;
+	};
+};
+
+/* Enabled nodes required by IPC
+ * Two mboxes, one for each sides and one ipc instance
+ */
+
+&cpuppr_vevif {
+	status = "okay";
+};
+
+&cpuapp_bellboard {
+	status = "okay";
+};
+
+ipc0: &cpuapp_cpuppr_ipc {
+	status = "okay";
+};

--- a/samples/caf_sensor_manager/sample.yaml
+++ b/samples/caf_sensor_manager/sample.yaml
@@ -1,6 +1,7 @@
 sample:
   description: Sample showing CAF sensor manager usage
   name: CAF sensor manager sample
+
 tests:
   sample.caf_sensor_manager.correctness_test:
     build_only: false
@@ -57,3 +58,27 @@ tests:
         - "main state:READY"
         - "Send sensor buffer desc address:"
         - "sensor_data_aggregator_release_buffer_event"
+  sample.caf_sensor_manager.nrf54h20.multicore:
+    build_only: true
+    sysbuild: true
+    platform_allow:
+      - nrf54h20pdk_nrf54h20_cpuapp
+    integration_platforms:
+      - nrf54h20pdk_nrf54h20_cpuapp
+    extra_args:
+      SB_CONF_FILE=sysbuild/nrf54h20pdk_nrf54h20_cpuppr.conf
+      caf_sensor_manager_SNIPPET=nordic-ppr
+      caf_sensor_manager_OVERLAY_CONFIG=boards/nrf54h20pdk_nrf54h20_cpuapp_multicore.conf
+      caf_sensor_manager_DTC_OVERLAY_FILE=boards/nrf54h20pdk_nrf54h20_cpuapp_multicore.overlay
+      remote_OVERLAY_CONFIG=boards/nrf54h20pdk_nrf54h20_cpuppr.conf
+      remote_DTC_OVERLAY_FILE=boards/nrf54h20pdk_nrf54h20_cpuppr.overlay
+  sample.caf_sensor_manager.nrf54h20.singlecore:
+    build_only: true
+    sysbuild: true
+    platform_allow:
+      - nrf54h20pdk_nrf54h20_cpuapp
+    integration_platforms:
+      - nrf54h20pdk_nrf54h20_cpuapp
+    extra_args:
+      caf_sensor_manager_OVERLAY_CONFIG=boards/nrf54h20pdk_nrf54h20_cpuapp_singlecore.conf
+      caf_sensor_manager_DTC_OVERLAY_FILE=boards/nrf54h20pdk_nrf54h20_cpuapp_singlecore.overlay

--- a/samples/caf_sensor_manager/sysbuild.cmake
+++ b/samples/caf_sensor_manager/sysbuild.cmake
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+if("${SB_CONFIG_REMOTE_BOARD}" STREQUAL "")
+  return()
+endif()
+
+message(STATUS "Building remote firmware for ${SB_CONFIG_REMOTE_BOARD}")
+
+# Add remote project
+ExternalZephyrProject_Add(
+  APPLICATION remote
+  SOURCE_DIR ${APP_DIR}/remote
+  BOARD ${SB_CONFIG_REMOTE_BOARD}
+)
+
+# Add a dependency so that the remote sample will be built and flashed first
+add_dependencies(caf_sensor_manager remote)
+# Add dependency so that the remote image is flashed first.
+sysbuild_add_dependencies(FLASH caf_sensor_manager remote)

--- a/samples/caf_sensor_manager/sysbuild/nrf54h20pdk_nrf54h20_cpuppr.conf
+++ b/samples/caf_sensor_manager/sysbuild/nrf54h20pdk_nrf54h20_cpuppr.conf
@@ -1,0 +1,1 @@
+SB_CONFIG_REMOTE_BOARD="nrf54h20pdk_nrf54h20_cpuppr"


### PR DESCRIPTION
Add two configurations for nRF54H20.
One with a single core operation and another with PPR working as a remote provider of sensor data.

nRF54H20 requires sysbuild.