### PR TITLE
drivers: wifi: Fix SR switch configuration

### DIFF
--- a/drivers/wifi/nrf700x/Kconfig
+++ b/drivers/wifi/nrf700x/Kconfig
@@ -239,7 +239,7 @@ config NRF700X_ON_SPI
 
 # RF switch based coexistence
 config NRF700X_RADIO_COEX
-	def_bool $(dt_nodelabel_has_prop,nrf_radio_coex,bt-rf-switch-gpios)
+	def_bool $(dt_nodelabel_has_prop,nrf_radio_coex,btrf-switch-gpios)
 
 config NRF700X_WORKQ_STACK_SIZE
 	int "Stack size for workqueue"


### PR DESCRIPTION
Short Range(SR) side RF switch configuration is not happening as expected because of the typo in Wi-Fi driver Kconfig.

Fixes SHEL-2572.