### PR TITLE
doc improvement: Bluetooth mesh to Mesh fix

### DIFF
--- a/doc/nrf/libraries/bluetooth_services/mesh.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh.rst
@@ -3,7 +3,7 @@
 Bluetooth Mesh profile
 ######################
 
-Bluetooth® mesh is supported for development in |NCS|, through the Zephyr :ref:`zephyr:bluetooth_mesh` implementation.
+Bluetooth® Mesh is supported for development in |NCS|, through the Zephyr :ref:`zephyr:bluetooth_mesh` implementation.
 Nordic Semiconductor's implementation of the Bluetooth Mesh allows applications to use the features provided by the Bluetooth Mesh when running on supported Nordic devices.
 
 The `Bluetooth Mesh profile specification`_ is developed and published by the Bluetooth® Special Interest Group (SIG).

--- a/doc/nrf/libraries/bluetooth_services/mesh/dk_prov.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/dk_prov.rst
@@ -9,7 +9,7 @@ Bluetooth Mesh provisioning handler for Nordic DKs
 
 This application-side module is a basic implementation of the provisioning process handling for Development Kits from Nordic Semiconductor.
 It supports four types of out-of-band (OOB) authentication methods and uses the Hardware Information driver to generate a deterministic UUID to uniquely represent the device.
-For more information about provisioning in Bluetooth® mesh, see the :ref:`zephyr:bluetooth_mesh_provisioning` page in Zephyr.
+For more information about provisioning in Bluetooth® Mesh, see the :ref:`zephyr:bluetooth_mesh_provisioning` page in Zephyr.
 
 Used primarily in :ref:`bt_mesh_samples` applications, this handler acts as a reference implementation for the application-specific part of provisioning.
 It is enabled with the :kconfig:option:`CONFIG_BT_MESH_DK_PROV` option and by calling :c:func:`bt_mesh_dk_prov_init` in main.

--- a/doc/nrf/libraries/bluetooth_services/mesh/gen_prop_srv.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/gen_prop_srv.rst
@@ -52,7 +52,7 @@ Extended models
 
 Generic Admin Property Server and Generic Manufacturer Property Server should both extend the Generic User Property Server.
 This is not handled automatically by the model implementation.
-For this reason, to ensure compliance with the Bluetooth® mesh model specification, a Generic User Property Server must be instantiated in the same element in the device composition data as the Generic Admin or Generic Manufacturer Property Server.
+For this reason, to ensure compliance with the Bluetooth® Mesh model specification, a Generic User Property Server must be instantiated in the same element in the device composition data as the Generic Admin or Generic Manufacturer Property Server.
 
 Persistent storage
 ==================

--- a/doc/nrf/libraries/bluetooth_services/mesh/light_ctl_srv.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/light_ctl_srv.rst
@@ -51,7 +51,7 @@ The Lightness and Light Temperature Server callbacks will pass pointers to :c:me
 .. note::
 
     The Light CTL Server will verify that its internal Light Temperature Server is instantiated on a subsequent element on startup.
-    If the Light Temperature Server is missing or instantiated on the same or a preceding element, the Bluetooth® mesh startup procedure will fail, and the device will not be responsive.
+    If the Light Temperature Server is missing or instantiated on the same or a preceding element, the Bluetooth® Mesh startup procedure will fail, and the device will not be responsive.
 
 States
 ======

--- a/doc/nrf/libraries/bluetooth_services/mesh/light_ctrl_reg_spec.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/light_ctrl_reg_spec.rst
@@ -3,7 +3,7 @@
 Specification-defined illuminance regulator
 ###########################################
 
-This module implements the illuminance regulator defined in the Bluetooth® mesh model specification.
+This module implements the illuminance regulator defined in the Bluetooth® Mesh model specification.
 
 The regulator operates in a compile time configurable update interval between 10 and 100 ms.
 The interval can be configured through the :kconfig:option:`CONFIG_BT_MESH_LIGHT_CTRL_REG_SPEC_INTERVAL` option.

--- a/doc/nrf/libraries/bluetooth_services/mesh/light_ctrl_srv.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/light_ctrl_srv.rst
@@ -139,7 +139,7 @@ To avoid having a Light Lightness Server running independently forever, the Ligh
 The resume timer can be configured with the :kconfig:option:`CONFIG_BT_MESH_LIGHT_CTRL_SRV_RESUME_DELAY` option, and is disabled by default.
 
 .. note::
-    The resume timer does not exist in the Bluetooth® mesh specification, and may become incompatible with future specification changes.
+    The resume timer does not exist in the Bluetooth® Mesh specification, and may become incompatible with future specification changes.
     Although it does not break the specification or qualification tests in the current iteration of the Bluetooth Mesh specification, its behavior may be unexpected for third party devices, and should be used with caution.
 
 State machine outputs

--- a/doc/nrf/libraries/bluetooth_services/mesh/light_hsl.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/light_hsl.rst
@@ -13,7 +13,7 @@ While easy to visualize and explain to end users, the HSL does not map well to c
 
 The HSL models are best suited for applications where the color of the light is a primary function, such as decorative lighting.
 For applications where illumination is the primary function of the light, and its color and temperature is secondary, the CTL and xyL models might be better alternatives.
-However, neither the Bluetooth® mesh model specification nor the |NCS| put any restrictions on the application areas for the different models.
+However, neither the Bluetooth® Mesh model specification nor the |NCS| put any restrictions on the application areas for the different models.
 Developers may freely use the model best suited for their application.
 
 On the light fixture side, the HSL Server models are separated into three independent models:

--- a/doc/nrf/libraries/bluetooth_services/mesh/model_types.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/model_types.rst
@@ -7,7 +7,7 @@ Bluetooth Mesh models overview
    :local:
    :depth: 2
 
-A Bluetooth® mesh model is a standardized component that defines a series of states and related behaviors.
+A Bluetooth® Mesh model is a standardized component that defines a series of states and related behaviors.
 Models encapsulate a single feature of a mesh node, and expose this feature to the mesh network.
 Each mesh-based product implements several models.
 

--- a/doc/nrf/libraries/bluetooth_services/mesh/sensor.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/sensor.rst
@@ -13,7 +13,7 @@ Bluetooth Mesh sensors
    The Kconfig option is enabled by default in the deprecation period.
    See the documentation for |NCS| versions prior to v2.6.0 for documentation about the old sensor API.
 
-The Bluetooth® mesh specification provides a common scheme for representing all sensors.
+The Bluetooth® Mesh specification provides a common scheme for representing all sensors.
 A single Bluetooth Mesh sensor instance represents a single physical sensor, and a mesh device may present any number of sensors to the network through a Sensor Server model.
 Sensors represent their measurements as a list of sensor channels, as described by the sensor's assigned type.
 
@@ -91,7 +91,7 @@ Each sensor type is assigned its own Device Property ID, as specified in the Blu
 Like the Device Properties, the Sensor types are connected to a Bluetooth GATT Characteristic, which describes the unit, range, resolution and encoding scheme of the sensor type.
 
 .. note::
-   The Bluetooth® mesh specification only allows sensor types that have a Device Property ID in the Bluetooth Mesh device properties specification.
+   The Bluetooth Mesh specification only allows sensor types that have a Device Property ID in the Bluetooth Mesh device properties specification.
    It's not possible to represent vendor specific sensor values.
 
 The sensor types may either be used as the data types of the sensor output values, or as configuration parameters for the sensors.

--- a/doc/nrf/libraries/bluetooth_services/mesh/time_tai.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/time_tai.rst
@@ -18,5 +18,5 @@ This allows applications to calculate the number of seconds between any two TAI 
 
 To convert to UTC, TAI based applications keep track of the UTC leap seconds separately, as well as the time zone and time zone adjustments.
 
-The Bluetooth® mesh Time models share time as a composite state of TAI seconds, 256 subseconds, UTC offset, time zone steps and uncertainty.
+The Bluetooth® Mesh Time models share time as a composite state of TAI seconds, 256 subseconds, UTC offset, time zone steps and uncertainty.
 See :cpp:type:`bt_mesh_time_status` for details.

--- a/doc/nrf/libraries/bluetooth_services/mesh/vnd/dm.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/vnd/dm.rst
@@ -7,7 +7,7 @@ Distance Measurement models
    :local:
    :depth: 2
 
-The Distance Measurement vendor models allow users to measure distance between different Bluetooth® mesh devices.
+The Distance Measurement vendor models allow users to measure distance between different Bluetooth® Mesh devices.
 
 The Distance Measurement models also feature their own common types, listed below.
 For types common to all models, see :ref:`bt_mesh_models`.

--- a/doc/nrf/libraries/bluetooth_services/mesh/vnd/dm_cli.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/vnd/dm_cli.rst
@@ -27,7 +27,7 @@ None.
 Shell commands
 **************
 
-The Bluetooth® mesh shell subsystem provides a set of commands to interact with the Distance Measurement Client model instantiated on a device.
+The Bluetooth® Mesh shell subsystem provides a set of commands to interact with the Distance Measurement Client model instantiated on a device.
 
 To make these commands available, enable the following Kconfig options:
 

--- a/doc/nrf/libraries/bluetooth_services/mesh/vnd/dm_srv.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/vnd/dm_srv.rst
@@ -7,7 +7,7 @@ Distance Measurement Server
    :local:
    :depth: 2
 
-The Distance Measurement Server vendor model provides capabilities to measure distance between Bluetooth® mesh devices within radio proximity.
+The Distance Measurement Server vendor model provides capabilities to measure distance between Bluetooth® Mesh devices within radio proximity.
 The measurements are conducted through the :ref:`mod_dm` library.
 
 At creation, each Distance Measurement Server instance must be initialized with a memory object that can hold one or more measurement results.

--- a/doc/nrf/protocols/bt/bt_mesh/architecture.rst
+++ b/doc/nrf/protocols/bt/bt_mesh/architecture.rst
@@ -7,7 +7,7 @@ Bluetooth Mesh stack architecture
    :local:
    :depth: 2
 
-The Bluetooth® mesh stack in |NCS| is an extension of the Zephyr Bluetooth® mesh stack.
+The Bluetooth® Mesh stack in |NCS| is an extension of the Zephyr Bluetooth Mesh stack.
 The Zephyr Bluetooth Mesh stack implements the Bluetooth Mesh profile specification (see :ref:`zephyr:bluetooth_mesh`), while |NCS| provides additional model implementations from the Bluetooth Mesh model specification on top of the :ref:`zephyr:bluetooth_mesh_access` API.
 
 .. figure:: images/bt_mesh_basic_architecture.svg

--- a/doc/nrf/protocols/bt/bt_mesh/concepts.rst
+++ b/doc/nrf/protocols/bt/bt_mesh/concepts.rst
@@ -7,7 +7,7 @@ Bluetooth Mesh concepts
    :local:
    :depth: 2
 
-Bluetooth® mesh is a profile specification developed and published by the Bluetooth® Special Interest Group (SIG).
+Bluetooth® Mesh is a profile specification developed and published by the Bluetooth Special Interest Group (SIG).
 This document explains the basic concepts of the Bluetooth Mesh and gives an overview of the operation and capabilities of the profile, as well as the life cycle of a mesh device.
 For more information about the |NCS| implementation of the Bluetooth Mesh, see :ref:`Bluetooth Mesh architecture documentation <mesh_architecture>`.
 

--- a/doc/nrf/protocols/bt/bt_mesh/configuring.rst
+++ b/doc/nrf/protocols/bt/bt_mesh/configuring.rst
@@ -7,7 +7,7 @@ Configuring Bluetooth Mesh in |NCS|
    :local:
    :depth: 2
 
-The Bluetooth® mesh support is controlled by :kconfig:option:`CONFIG_BT_MESH`, which depends on the following configuration options:
+The Bluetooth® Mesh support is controlled by :kconfig:option:`CONFIG_BT_MESH`, which depends on the following configuration options:
 
 * :kconfig:option:`CONFIG_BT` - Enables the Bluetooth subsystem.
 * :kconfig:option:`CONFIG_BT_OBSERVER` - Enables the Bluetooth Observer role.

--- a/doc/nrf/protocols/bt/bt_mesh/fota.rst
+++ b/doc/nrf/protocols/bt/bt_mesh/fota.rst
@@ -3,10 +3,10 @@
 Performing Device Firmware Updates (DFU) in Bluetooth Mesh
 ##########################################################
 
-The |NCS| supports two DFU methods when updating your firmware over-the-air (FOTA) for your Bluetooth Mesh devices and applications.
+The |NCS| supports two DFU methods when updating your firmware over-the-air (FOTA) for your Bluetooth® Mesh devices and applications.
 
-* DFU over Bluetooth® mesh using the Zephyr Bluetooth Mesh DFU subsystem that implements the Mesh Device Firmware Update Model specification version 1.0 and Mesh Binary Large Object Transfer Model specification version 1.0.
-* Point-to-point DFU over Bluetooth® Low Energy using the MCUmgr subsystem and the Simple Management Protocol (SMP).
+* DFU over Bluetooth Mesh using the Zephyr Bluetooth Mesh DFU subsystem that implements the Mesh Device Firmware Update Model specification version 1.0 and Mesh Binary Large Object Transfer Model specification version 1.0.
+* Point-to-point DFU over Bluetooth Low Energy using the MCUmgr subsystem and the Simple Management Protocol (SMP).
 
 .. toctree::
    :maxdepth: 1

--- a/doc/nrf/protocols/bt/bt_mesh/index.rst
+++ b/doc/nrf/protocols/bt/bt_mesh/index.rst
@@ -3,10 +3,10 @@
 Bluetooth Mesh
 ##############
 
-The |NCS| provides support for developing applications using the Bluetooth® mesh protocol.
+The |NCS| provides support for developing applications using the Bluetooth® Mesh protocol.
 The support is based on Zephyr's :ref:`bluetooth_mesh` implementation.
 
-The `Bluetooth Mesh profile specification`_ is developed and published by the Bluetooth® Special Interest Group (SIG).
+The `Bluetooth Mesh profile specification`_ is developed and published by the Bluetooth Special Interest Group (SIG).
 It allows one-to-one, one-to-many, and many-to-many communication, using the Bluetooth LE protocol to exchange messages between the nodes on the network.
 All nodes in a Bluetooth Mesh network can communicate with each other, as long as there is a chain of nodes between them to relay the messages.
 The messages are encrypted with two layers of 128-bit AES-CCM encryption, allowing secure communication between thousands of devices.

--- a/doc/nrf/protocols/bt/bt_mesh/model_config_app.rst
+++ b/doc/nrf/protocols/bt/bt_mesh/model_config_app.rst
@@ -7,7 +7,7 @@ Configuring mesh models using the nRF Mesh mobile app
    :local:
    :depth: 2
 
-The Bluetooth® mesh :ref:`samples <samples>` use the nRF Mesh mobile app to perform provisioning and configuration.
+The Bluetooth® Mesh :ref:`samples <samples>` use the nRF Mesh mobile app to perform provisioning and configuration.
 
 Binding a model to an application key
 *************************************

--- a/doc/nrf/protocols/bt/bt_mesh/node_removal.rst
+++ b/doc/nrf/protocols/bt/bt_mesh/node_removal.rst
@@ -7,7 +7,7 @@ Removing a node from a mesh network
    :local:
    :depth: 2
 
-In certain circumstances, a need may arise to remove a node from a Bluetooth® mesh network.
+In certain circumstances, a need may arise to remove a node from a Bluetooth® Mesh network.
 This can be done by unprovisioning the node using the Config Node Reset message.
 
 Though the unprovisioning of the node is a straightforward procedure, some additional steps need to be taken to maintain the security of the network.

--- a/doc/nrf/protocols/bt/bt_mesh/supported_features.rst
+++ b/doc/nrf/protocols/bt/bt_mesh/supported_features.rst
@@ -3,7 +3,7 @@
 Supported Bluetooth Mesh features
 #################################
 
-The Bluetooth® mesh in |NCS| supports all mandatory features of the `Bluetooth Mesh profile specification`_ and the `Bluetooth Mesh model specification`_, as well as most of the optional features.
+The Bluetooth® Mesh in |NCS| supports all mandatory features of the `Bluetooth Mesh profile specification`_ and the `Bluetooth Mesh model specification`_, as well as most of the optional features.
 
 The following features are supported by Zephyr's :ref:`zephyr:bluetooth_mesh`:
 

--- a/doc/nrf/protocols/bt/bt_mesh/vendor_model/dev_overview.rst
+++ b/doc/nrf/protocols/bt/bt_mesh/vendor_model/dev_overview.rst
@@ -7,7 +7,7 @@ Vendor model development overview
    :local:
    :depth: 2
 
-To implement a new Bluetooth® mesh model, apply the steps described in this step-by-step model development process overview.
+To implement a new Bluetooth® Mesh model, apply the steps described in this step-by-step model development process overview.
 
 Defining a model identifier
 ***************************
@@ -22,7 +22,7 @@ As defined by the `Bluetooth Mesh profile specification`_, the vendor model iden
     #define YOUR_COMPANY_ID 0x1234
     #define YOUR_MODEL_ID   0x5678
 
-The Company ID must be registered with the Bluetooth® Special Interest Group (SIG), and the vendor owning the Company ID may freely allocate the model IDs for its Company ID.
+The Company ID must be registered with the Bluetooth Special Interest Group (SIG), and the vendor owning the Company ID may freely allocate the model IDs for its Company ID.
 See `Bluetooth SIG company identifiers`_ for a list of Company IDs.
 
 Adding the model to the node composition data

--- a/doc/nrf/protocols/bt/bt_mesh/vendor_model/index.rst
+++ b/doc/nrf/protocols/bt/bt_mesh/vendor_model/index.rst
@@ -3,7 +3,7 @@
 Creating a new model
 ####################
 
-You may create your own vendor-specific models for Bluetooth® mesh.
+You may create your own vendor-specific models for Bluetooth® Mesh.
 These will enable your devices to provide custom behavior not covered by the already defined standard models.
 The following sections describe the basics of creating new models for the Bluetooth Mesh in |NCS|, based on the concepts and principles defined in :ref:`mesh_concepts` and :ref:`Access API <zephyr:bluetooth_mesh_access>`.
 It is recommended that you have read and understood these concepts and principles, before proceeding with the model development.

--- a/samples/bluetooth/mesh/ble_peripheral_lbs_coex/README.rst
+++ b/samples/bluetooth/mesh/ble_peripheral_lbs_coex/README.rst
@@ -7,7 +7,7 @@ Bluetooth Mesh: Coexistence with other LE services
    :local:
    :depth: 2
 
-This sample demonstrates how to combine Bluetooth® mesh and another Bluetooth Low Energy (LE) service in a single application.
+This sample demonstrates how to combine Bluetooth® Mesh and another Bluetooth Low Energy (LE) service in a single application.
 
 Requirements
 ************

--- a/samples/bluetooth/mesh/chat/README.rst
+++ b/samples/bluetooth/mesh/chat/README.rst
@@ -7,7 +7,7 @@ Bluetooth Mesh: Chat
    :local:
    :depth: 2
 
-The Bluetooth® mesh chat sample demonstrates how to use the mesh network to facilitate communication between nodes by text, using the :ref:`bt_mesh_chat_client_model`.
+The Bluetooth® Mesh chat sample demonstrates how to use the mesh network to facilitate communication between nodes by text, using the :ref:`bt_mesh_chat_client_model`.
 
 See the subpages for detailed documentation on the sample and its internal model.
 

--- a/samples/bluetooth/mesh/chat/sample_description.rst
+++ b/samples/bluetooth/mesh/chat/sample_description.rst
@@ -7,7 +7,7 @@ Sample description
    :local:
    :depth: 2
 
-The Bluetooth® mesh chat sample demonstrates how the mesh network can be used to facilitate communication between nodes by text, using the :ref:`bt_mesh_chat_client_model`.
+The Bluetooth® Mesh chat sample demonstrates how the mesh network can be used to facilitate communication between nodes by text, using the :ref:`bt_mesh_chat_client_model`.
 
 Requirements
 ************

--- a/samples/bluetooth/mesh/dfu/distributor/README.rst
+++ b/samples/bluetooth/mesh/dfu/distributor/README.rst
@@ -7,7 +7,7 @@ Bluetooth Mesh: Device Firmware Update (DFU) distributor
    :local:
    :depth: 2
 
-The Bluetooth® mesh DFU distributor sample demonstrates how device firmware can be distributed over a Bluetooth Mesh network.
+The Bluetooth® Mesh DFU distributor sample demonstrates how device firmware can be distributed over a Bluetooth Mesh network.
 The sample implements the Firmware Distribution role of the :ref:`Bluetooth Mesh DFU subsystem <zephyr:bluetooth_mesh_dfu>`.
 
 The specification that the Bluetooth Mesh DFU subsystem is based on is not adopted yet, and therefore this feature should be used for experimental purposes only.

--- a/samples/bluetooth/mesh/dfu/target/README.rst
+++ b/samples/bluetooth/mesh/dfu/target/README.rst
@@ -7,7 +7,7 @@ Bluetooth Mesh: Device Firmware Update (DFU) target
    :local:
    :depth: 2
 
-The Bluetooth® mesh DFU target sample demonstrates how to update device firmware over Bluetooth Mesh network.
+The Bluetooth® Mesh DFU target sample demonstrates how to update device firmware over Bluetooth Mesh network.
 The sample implements the Target role of the :ref:`Bluetooth Mesh DFU subsystem <zephyr:bluetooth_mesh_dfu>`.
 
 The specification that the Bluetooth Mesh DFU subsystem is based on is not adopted yet, and therefore this feature should be used for experimental purposes only.

--- a/samples/bluetooth/mesh/light/README.rst
+++ b/samples/bluetooth/mesh/light/README.rst
@@ -7,7 +7,7 @@ Bluetooth Mesh: Light
    :local:
    :depth: 2
 
-The Bluetooth® mesh light sample demonstrates how to set up a mesh server model application, and control LEDs with Bluetooth Mesh using the :ref:`bt_mesh_onoff_readme`.
+The Bluetooth® Mesh light sample demonstrates how to set up a mesh server model application, and control LEDs with Bluetooth Mesh using the :ref:`bt_mesh_onoff_readme`.
 
 .. note::
    This sample is self-contained, and can be tested on its own.

--- a/samples/bluetooth/mesh/light_ctrl/README.rst
+++ b/samples/bluetooth/mesh/light_ctrl/README.rst
@@ -7,7 +7,7 @@ Bluetooth Mesh: Light fixture
    :local:
    :depth: 2
 
-The Bluetooth® mesh light fixture sample demonstrates how to set up a light control mesh server model application, and control a dimmable LED with Bluetooth Mesh using the :ref:`bt_mesh_onoff_readme`.
+The Bluetooth® Mesh light fixture sample demonstrates how to set up a light control mesh server model application, and control a dimmable LED with Bluetooth Mesh using the :ref:`bt_mesh_onoff_readme`.
 
 This sample demonstrates how to implement the following :ref:`ug_bt_mesh_nlc`:
 

--- a/samples/bluetooth/mesh/light_dimmer/README.rst
+++ b/samples/bluetooth/mesh/light_dimmer/README.rst
@@ -7,7 +7,7 @@ Bluetooth Mesh: Light dimmer and scene selector
    :local:
    :depth: 2
 
-The Bluetooth® mesh light dimmer and scene selector sample demonstrates how to set up a light dimmer and scene selector application, and control dimmable LEDs with Bluetooth Mesh using the :ref:`bt_mesh_lvl_readme`, the :ref:`bt_mesh_onoff_readme`, and the :ref:`bt_mesh_scene_readme`.
+The Bluetooth® Mesh light dimmer and scene selector sample demonstrates how to set up a light dimmer and scene selector application, and control dimmable LEDs with Bluetooth Mesh using the :ref:`bt_mesh_lvl_readme`, the :ref:`bt_mesh_onoff_readme`, and the :ref:`bt_mesh_scene_readme`.
 The sample provides the following functionality:
 
   * On/off and dim up/down using one button

--- a/samples/bluetooth/mesh/light_switch/README.rst
+++ b/samples/bluetooth/mesh/light_switch/README.rst
@@ -8,7 +8,7 @@ Bluetooth Mesh: Light switch
    :depth: 2
 
 The :ref:`ug_bt_mesh` light switch sample can be used to change the state of light sources on other devices within the same mesh network.
-It also demonstrates how to use Bluetooth® mesh models by using the Generic OnOff Client model in an application.
+It also demonstrates how to use Bluetooth® Mesh models by using the Generic OnOff Client model in an application.
 
 Use the light switch sample with the :ref:`bluetooth_mesh_light` sample to demonstrate its function in a Bluetooth Mesh network.
 

--- a/samples/bluetooth/mesh/sensor_client/README.rst
+++ b/samples/bluetooth/mesh/sensor_client/README.rst
@@ -7,7 +7,7 @@ Bluetooth Mesh: Sensor observer
    :local:
    :depth: 2
 
-The Bluetooth® mesh sensor observer sample demonstrates how to set up a basic Bluetooth Mesh :ref:`bt_mesh_sensor_cli_readme` model application that gets sensor data from one :ref:`bt_mesh_sensor_srv_readme` model.
+The Bluetooth® Mesh sensor observer sample demonstrates how to set up a basic Bluetooth Mesh :ref:`bt_mesh_sensor_cli_readme` model application that gets sensor data from one :ref:`bt_mesh_sensor_srv_readme` model.
 Five different sensor types are used to showcase different ways for the server to publish data.
 In addition, the samples demonstrate usage of both :ref:`single-channel sensor types and sensor series types <bt_mesh_sensor_types_channels>`, as well as how to add and write to a sensor setting.
 

--- a/samples/bluetooth/mesh/sensor_server/README.rst
+++ b/samples/bluetooth/mesh/sensor_server/README.rst
@@ -7,7 +7,7 @@ Bluetooth Mesh: Sensor
    :local:
    :depth: 2
 
-The Bluetooth® mesh sensor sample demonstrates how to set up a basic mesh Sensor Server model application that provides sensor data to one :ref:`bt_mesh_sensor_cli_readme` model.
+The Bluetooth® Mesh sensor sample demonstrates how to set up a basic mesh Sensor Server model application that provides sensor data to one :ref:`bt_mesh_sensor_cli_readme` model.
 Five different sensor types are used to showcase different ways for the server to publish data.
 In addition, the samples demonstrate usage of both :ref:`single-channel sensor types and sensor series types <bt_mesh_sensor_types_channels>`, as well as how to add and write to a sensor setting.
 

--- a/samples/bluetooth/mesh/silvair_enocean/README.rst
+++ b/samples/bluetooth/mesh/silvair_enocean/README.rst
@@ -8,7 +8,7 @@ Bluetooth Mesh: Silvair EnOcean
    :depth: 2
 
 You can use the :ref:`ug_bt_mesh` Silvair EnOcean sample to change the state of light sources on other devices within the same mesh network.
-It also demonstrates how to use Bluetooth® mesh models by using the Silvair EnOcean Proxy Server model in an application.
+It also demonstrates how to use Bluetooth® Mesh models by using the Silvair EnOcean Proxy Server model in an application.
 
 Use the Silvair EnOcean sample with the :ref:`bluetooth_mesh_light_lc` sample to demonstrate its function in a Bluetooth Mesh network.
 


### PR DESCRIPTION
Previously we changed Bluetooth mesh to Bluetooth Mesh to be in compliance with SIG.
Occurrences where Bluetooth is trademarked managed to slip.