### PR TITLE
samples: bluetooth: peripheral_uart: add support for 54l15

### DIFF
--- a/samples/bluetooth/peripheral_uart/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/bluetooth/peripheral_uart/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable the unspupported UART0 driver
+CONFIG_NRFX_UARTE0=n

--- a/samples/bluetooth/peripheral_uart/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
+++ b/samples/bluetooth/peripheral_uart/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,nus-uart = &uart30;
+	};
+};
+
+&uart30 {
+	status = "okay";
+};

--- a/samples/bluetooth/peripheral_uart/sample.yaml
+++ b/samples/bluetooth/peripheral_uart/sample.yaml
@@ -6,7 +6,7 @@ tests:
     build_only: true
     platform_allow: nrf52dk_nrf52832 nrf52833dk_nrf52833 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp
-      thingy53_nrf5340_cpuapp_ns nrf21540dk_nrf52840
+      thingy53_nrf5340_cpuapp_ns nrf21540dk_nrf52840 nrf54l15pdk_nrf54l15_cpuapp
     integration_platforms:
       - nrf52dk_nrf52832
       - nrf52833dk_nrf52833
@@ -16,6 +16,7 @@ tests:
       - thingy53_nrf5340_cpuapp
       - thingy53_nrf5340_cpuapp_ns
       - nrf21540dk_nrf52840
+      - nrf54l15pdk_nrf54l15_cpuapp
     tags: bluetooth ci_build
   sample.bluetooth.peripheral_uart.sysbuild:
     build_only: true


### PR DESCRIPTION
Add support to bt peripheral uart sample for 54l15
Signed-off-by: Pierce Lowe <pierce.lowe@nordicsemi.no>