### PR TITLE
manifest: remove .git suffixes from repository paths

### DIFF
--- a/doc/_extensions/manifest_revisions_table.py
+++ b/doc/_extensions/manifest_revisions_table.py
@@ -63,6 +63,9 @@ class ManifestRevisionsTable(SphinxDirective):
             URL for the revision.
         """
 
+        # remove .git from base_url, if present
+        base_url = base_url.split(".git")[0]
+
         if re.match(r"^[0-9a-f]{40}$", rev):
             return f"{base_url}/commit/{rev}"
 

--- a/doc/_extensions/manifest_revisions_table.py
+++ b/doc/_extensions/manifest_revisions_table.py
@@ -66,10 +66,24 @@ class ManifestRevisionsTable(SphinxDirective):
         # remove .git from base_url, if present
         base_url = base_url.split(".git")[0]
 
-        if re.match(r"^[0-9a-f]{40}$", rev):
-            return f"{base_url}/commit/{rev}"
+        if "github.com" in base_url:
+            commit_fmt = base_url + "/commit/{rev}"
+            tag_fmt = base_url + "/releases/tag/{rev}"
+        elif "projecttools.nordicsemi.no" in base_url:
+            m = re.match(r"^(.*)/scm/(.*)/(.*)$", base_url)
+            if not m:
+                raise ExtensionError(f"Invalid base URL: {base_url}")
 
-        return f"{base_url}/releases/tag/{rev}"
+            base_url = f"{m.group(1)}/projects/{m.group(2)}/repos/{m.group(3)}"
+            commit_fmt = base_url + "/commits/{rev}"
+            tag_fmt = commit_fmt
+        else:
+            raise ExtensionError(f"Unsupported SCM: {base_url}")
+
+        if re.match(r"^[0-9a-f]{40}$", rev):
+            return commit_fmt.format(rev=rev)
+
+        return tag_fmt.format(rev=rev)
 
     def run(self) -> List[nodes.Element]:
         # parse show-first option

--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 8d93a161567dcc525771f70692587e6a37947b71
+      revision: 226b676f94f6d0999b3199a6723057f533754ac7
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -132,7 +132,7 @@ manifest:
       revision: v2.0.99-ncs1-rc1
       path: bootloader/mcuboot
     - name: qcbor
-      url: https://github.com/laurencelundblade/QCBOR.git
+      url: https://github.com/laurencelundblade/QCBOR
       revision: 751d36583a9ce1a640900c57e13c9b6b8f3a2ba2
       path: modules/tee/tf-m/qcbor
     - name: mbedtls


### PR DESCRIPTION
.git suffix cannot be used to form valid URLs.