### PR TITLE
manifest: sdk-zephyr: Pull build failure fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 8d93a161567dcc525771f70692587e6a37947b71
+      revision: 7d195f1a20bdb1da597e92e6b88382c6e8aa0cf7
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Due to the build warning twister is failing.

Fixes SHEL-2574.