### PR TITLE
samples: matter: Fix Kconfig paths

### DIFF
--- a/applications/matter_bridge/Kconfig
+++ b/applications/matter_bridge/Kconfig
@@ -158,6 +158,6 @@ config CHIP_ENABLE_READ_CLIENT
 
 source "${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/chip-module/Kconfig.features"
 source "${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/chip-module/Kconfig.defaults"
-source "${ZEPHYR_BASE}/../nrf/samples/matter/common/src/bridge/Kconfig"
-source "${ZEPHYR_BASE}/../nrf/samples/matter/common/src/Kconfig"
+source "${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common/src/bridge/Kconfig"
+source "${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common/src/Kconfig"
 source "Kconfig.zephyr"

--- a/applications/matter_weather_station/Kconfig
+++ b/applications/matter_weather_station/Kconfig
@@ -39,5 +39,5 @@ endif # NET_L2_OPENTHREAD
 
 source "${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/chip-module/Kconfig.features"
 source "${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/chip-module/Kconfig.defaults"
-source "${ZEPHYR_BASE}/../nrf/samples/matter/common/src/Kconfig"
+source "${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common/src/Kconfig"
 source "Kconfig.zephyr"

--- a/samples/matter/light_bulb/Kconfig
+++ b/samples/matter/light_bulb/Kconfig
@@ -20,6 +20,6 @@ endif # NET_L2_OPENTHREAD
 
 source "${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/chip-module/Kconfig.features"
 source "${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/chip-module/Kconfig.defaults"
-source "${ZEPHYR_BASE}/../nrf/samples/matter/common/src/Kconfig"
+source "${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common/src/Kconfig"
 source "Kconfig.zephyr"
 rsource "src/aws_iot_integration/Kconfig"

--- a/samples/matter/light_switch/Kconfig
+++ b/samples/matter/light_switch/Kconfig
@@ -47,5 +47,5 @@ config CHIP_ENABLE_READ_CLIENT
 
 source "${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/chip-module/Kconfig.features"
 source "${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/chip-module/Kconfig.defaults"
-source "${ZEPHYR_BASE}/../nrf/samples/matter/common/src/Kconfig"
+source "${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common/src/Kconfig"
 source "Kconfig.zephyr"

--- a/samples/matter/lock/Kconfig
+++ b/samples/matter/lock/Kconfig
@@ -81,5 +81,5 @@ endif # CHIP_WIFI
 
 source "${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/chip-module/Kconfig.features"
 source "${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/chip-module/Kconfig.defaults"
-source "${ZEPHYR_BASE}/../nrf/samples/matter/common/src/Kconfig"
+source "${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common/src/Kconfig"
 source "Kconfig.zephyr"

--- a/samples/matter/template/Kconfig
+++ b/samples/matter/template/Kconfig
@@ -20,5 +20,5 @@ endif # NET_L2_OPENTHREAD
 
 source "${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/chip-module/Kconfig.features"
 source "${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/chip-module/Kconfig.defaults"
-source "${ZEPHYR_BASE}/../nrf/samples/matter/common/src/Kconfig"
+source "${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common/src/Kconfig"
 source "Kconfig.zephyr"

--- a/samples/matter/thermostat/Kconfig
+++ b/samples/matter/thermostat/Kconfig
@@ -42,7 +42,7 @@ endchoice
 
 endif # NET_L2_OPENTHREAD
 
-source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.features"
-source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.defaults"
-source "${ZEPHYR_BASE}/../nrf/samples/matter/common/src/Kconfig"
+source "${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/chip-module/Kconfig.features"
+source "${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/chip-module/Kconfig.defaults"
+source "${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common/src/Kconfig"
 source "Kconfig.zephyr"

--- a/samples/matter/window_covering/Kconfig
+++ b/samples/matter/window_covering/Kconfig
@@ -21,5 +21,5 @@ config OPENTHREAD_DEFAULT_TX_POWER
 
 source "${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/chip-module/Kconfig.features"
 source "${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/chip-module/Kconfig.defaults"
-source "${ZEPHYR_BASE}/../nrf/samples/matter/common/src/Kconfig"
+source "${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common/src/Kconfig"
 source "Kconfig.zephyr"


### PR DESCRIPTION
Avoid using ZEPHYR_BASE in relative paths when sourcing Kconfig. Use ZEPHYR_NRF_MODULE_DIR instead.