### PR TITLE
actions: Use NordicBuilder user to add CI-trusted-author

### DIFF
--- a/.github/workflows/reapply-ci-trusted-author.yml
+++ b/.github/workflows/reapply-ci-trusted-author.yml
@@ -1,4 +1,6 @@
 name: Reapply CI-trusted-author label
+# We want to use NordicBuilder instead of github-actions[bot] user
+# github-actions[bot] is not trusted collaborator and labels added by it does not trigger Jenkins builds
 
 on:
   pull_request_target:
@@ -13,11 +15,11 @@ jobs:
       - name: Remove CI-trusted-author label
         run: gh pr edit ${{ github.event.pull_request.number }} --remove-label "CI-trusted-author"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.NCS_JENKINS_TOKEN }}
           GH_REPO: ${{ github.repository }}
 
       - name: Add CI-trusted-author label
         run: gh pr edit ${{ github.event.pull_request.number }} --add-label "CI-trusted-author"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.NCS_JENKINS_TOKEN }}
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
Bot github-actions[bot] is not trusted collaborator and labels added by it does not trigger Jenkins builds

Tested here: https://github.com/nrfconnect/sdk-nrf/pull/14396

When it's merged, labels will be added by NordicBuilder instead of github_actions bot:
Previously:
![image](https://github.com/nrfconnect/sdk-nrf/assets/51634207/a03be26d-c94b-4511-8a6b-c83edfab0a8c)
Now:
![image](https://github.com/nrfconnect/sdk-nrf/assets/51634207/b44ffd9d-6180-4997-97d9-3b6f745c6e3e)

