### PR TITLE
doc: wifi: Update radio test documents to reflect new commands

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -230,8 +230,15 @@ nRF IEEE 802.15.4 radio driver
 Wi-Fi
 -----
 
-* Added the :kconfig:option:`NRF_WIFI_FW_PATCH_DFU` Kconfig option that enables DFU support for nRF70 Series devices.
-  This allows firmware patches for signed images to be sent to multi-image targets over Wi-Fi.
+* Added:
+
+  * :kconfig:option:`NRF_WIFI_FW_PATCH_DFU` Kconfig option that enables DFU support for nRF70 Series devices.
+    This allows firmware patches for signed images to be sent to multi-image targets over Wi-Fi.
+  * Support for the CSP package.
+  * Modification to the application of edge backoff.
+    Previously, it was subtracted from the regulatory power limit.
+    Now, backoff is subtracted from the data rate-dependent power ceiling.
+
 
 * Updated:
 
@@ -826,6 +833,13 @@ Wi-Fi samples
 
     * Added ``promiscuous_set`` extension to the Wi-Fi command line.
       It adds the subcommand to configure Promiscuous mode.
+
+* :ref:`wifi_radio_test` sample:
+
+  * Updated:
+
+    * Added support for runtime configuration of antenna gain and edge backoff parameters.
+    * Antenna gain and edge backoff values are not applied if regulatory is bypassed.
 
 Other samples
 -------------

--- a/samples/wifi/radio_test/radio_test_subcommands.rst
+++ b/samples/wifi/radio_test/radio_test_subcommands.rst
@@ -248,8 +248,16 @@ Wi-Fi radio test subcommands
      - 0
      - Configuration
      - Configure WLAN to bypass current regulatory domain in TX test.
-
-
+   * - set_ant_gain
+     - <val> - Antenna gain in dB (Min: 0, Max: 6)
+     - 0
+     - Configuration
+     - <val> is subtracted from the transmit power.
+   * - set_edge_bo
+     - <val> - Edge backoff in dB (Min: 0, Max: 10)
+     - 0
+     - Configuration
+     - If the channel is an edge channel, the value of <val> is subtracted from the transmit power.
 
 
 .. _wifi_radio_test_stats:

--- a/samples/wifi/radio_test/sample_description.rst
+++ b/samples/wifi/radio_test/sample_description.rst
@@ -145,6 +145,35 @@ Testing
               wifi_radio_test tx 1
 
 
+         * To run a continuous OFDM TX traffic sequence with the following configuration:
+
+           * Channel: 1
+           * Frame duration: 2708 µs
+           * Inter-frame gap: 4200 µs
+           * Edge backoff: 3 dB
+           * Antenna gain: 2 dB
+
+           Execute the following sequence of commands:
+
+           .. code-block:: console
+
+              wifi_radio_test init 1
+              wifi_radio_test tx_pkt_rate 12
+              wifi_radio_test tx_pkt_len 4000
+              wifi_radio_test tx_power 10
+              wifi_radio_test tx_pkt_gap 4200
+              wifi_radio_test set_edge_bo 3
+              wifi_radio_test set_ant_gain 2
+              wifi_radio_test tx 1
+
+         .. note::
+
+            Edge backoff and antenna gain are configured in the Kconfig file.
+            To overwrite these backoffs with user-specified backoffs, use the``set_edge_bo`` and ``set_ant_gain`` commands.
+            These backoffs are applied only when the ``bypass_reg_domain`` is set to ``0``.
+
+
+
          * To run a continuous Direct-sequence spread spectrum (DSSS) TX traffic sequence with the following configuration:
 
            * Channel: 14


### PR DESCRIPTION
[SHEL-2521]: The documentation for recently incorporated RF test commands has been updated within the radio test sample. Furthermore, the TX command sequences have been revised to demonstrate the utilization of these newly integrated commands.

[SHEL-2521]: https://nordicsemi.atlassian.net/browse/SHEL-2521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ