### PR TITLE
net: lib: nrf_cloud: fix build issue with FOTA poll support

### DIFF
--- a/doc/nrf/libraries/networking/nrf_cloud.rst
+++ b/doc/nrf/libraries/networking/nrf_cloud.rst
@@ -274,3 +274,12 @@ nRF Cloud common definitions
 .. doxygengroup:: nrf_cloud_defs
    :project: nrf
    :members:
+
+nRF Cloud FOTA poll for REST and CoAP
+****************************************
+
+| Header file: :file:`include/net/nrf_cloud_fota_poll.h`
+
+.. doxygengroup:: nrf_cloud_fota_poll
+   :project: nrf
+   :members:

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -589,6 +589,7 @@ Cellular samples
 
   * Added credential check before connecting to network.
   * Changed the sample use the functions in the :file:`nrf_cloud_fota_poll.c` and :file:`nrf_cloud_fota_common.c` files.
+  * Increased the :kconfig:option:`CONFIG_AT_HOST_STACK_SIZE` Kconfig option to 2048 bytes since nRF Cloud credentials are sometimes longer than 1024 bytes.
 
 * :ref:`nrf_cloud_rest_cell_pos_sample` sample:
 
@@ -1180,7 +1181,10 @@ Libraries for networking
 
 * :ref:`lib_nrf_cloud_fota` library:
 
-  * Added the :file:`nrf_cloud_fota_poll.c` file to consolidate the FOTA polling code from the :ref:`nrf_cloud_multi_service` and :ref:`nrf_cloud_rest_fota` samples.
+  * Added:
+
+    * The :file:`nrf_cloud_fota_poll.c` file to consolidate the FOTA polling code from the :ref:`nrf_cloud_multi_service` and :ref:`nrf_cloud_rest_fota` samples.
+    * The :file:`nrf_cloud_fota_poll.h` file.
 
 * :ref:`lib_mqtt_helper` library:
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -589,11 +589,10 @@ Cellular samples
 
   * Added credential check before connecting to network.
   * Changed the sample use the functions in the :file:`nrf_cloud_fota_poll.c` and :file:`nrf_cloud_fota_common.c` files.
-  * Increased the :kconfig:option:`CONFIG_AT_HOST_STACK_SIZE` Kconfig option to 2048 bytes since nRF Cloud credentials are sometimes longer than 1024 bytes.
 
 * :ref:`nrf_cloud_rest_cell_pos_sample` sample:
 
-  * Increased the :kconfig:option:`CONFIG_AT_HOST_STACK_SIZE` and :kconfig:option:`CONFIG_AT_MONITOR_HEAP_SIZE` Kconfig options to 2048 bytes since nRF Cloud credentials are sometimes longer than 1024 bytes.
+  * Increased the :kconfig:option:`CONFIG_AT_HOST_STACK_SIZE` Kconfig option to 2048 bytes since nRF Cloud credentials are sometimes longer than 1024 bytes.
 
   * Added:
 
@@ -636,6 +635,7 @@ Cellular samples
 * :ref:`nrf_cloud_rest_device_message` sample:
 
   * Updated the :file:`overlay-nrf_provisioning.conf` overlay to specify UUID-style device IDs for compatibility with nRF Cloud auto-onboarding.
+  * Increased the :kconfig:option:`CONFIG_AT_HOST_STACK_SIZE` and :kconfig:option:`CONFIG_AT_MONITOR_HEAP_SIZE` Kconfig options to 2048 bytes since nRF Cloud credentials are sometimes longer than 1024 bytes.
 
 Cryptography samples
 --------------------

--- a/include/net/nrf_cloud.h
+++ b/include/net/nrf_cloud.h
@@ -661,28 +661,6 @@ struct nrf_cloud_init_param {
 	const char *application_version;
 };
 
-enum nrf_cloud_fota_reboot_status {
-	FOTA_REBOOT_REQUIRED,	/** Reboot to install update. */
-	FOTA_REBOOT_SUCCESS,	/** Reboot to complete FOTA job. */
-	FOTA_REBOOT_FAIL,	/** Reboot because FOTA job failed. */
-	FOTA_REBOOT_SYS_ERROR	/** Reboot because fatal system error occurred. */
-};
-
-/**
- * @brief  Event handler registered with the module to handle asynchronous
- * events from the module.
- *
- * @param[in]  status The reason for the reboot request.
- */
-typedef void (*fota_reboot_handler_t)(enum nrf_cloud_fota_reboot_status status);
-
-struct nrf_cloud_fota_poll_ctx {
-	struct nrf_cloud_rest_context *rest_ctx;
-	const char *device_id;
-	fota_reboot_handler_t reboot_fn;
-	bool full_modem_fota_supported;
-};
-
 /**
  * @brief Initialize the module.
  *
@@ -1016,10 +994,6 @@ bool nrf_cloud_fota_is_type_enabled(const enum nrf_cloud_fota_type type);
  * @return A negative value indicates an error starting the job.
  */
 int nrf_cloud_fota_job_start(void);
-
-int nrf_cloud_fota_poll_init(struct nrf_cloud_fota_poll_ctx *ctx);
-int nrf_cloud_fota_poll_start(struct nrf_cloud_fota_poll_ctx *ctx);
-int nrf_cloud_fota_poll_process(struct nrf_cloud_fota_poll_ctx *ctx);
 
 /**
  * @brief Check if credentials exist in the configured location.

--- a/include/net/nrf_cloud_fota_poll.h
+++ b/include/net/nrf_cloud_fota_poll.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef NRF_CLOUD_FOTA_POLL_H_
+#define NRF_CLOUD_FOTA_POLL_H_
+
+/** @file nrf_cloud_fota_poll.h
+ * @brief Module to provide nRF Cloud FOTA assistance for applications
+ *        connecting to nRF Cloud using REST or CoAP.
+ */
+
+#include <net/nrf_cloud_rest.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @defgroup nrf_cloud_fota_poll nRF Cloud FOTA poll
+ * @{
+ */
+
+enum nrf_cloud_fota_reboot_status {
+	FOTA_REBOOT_REQUIRED,	/** Reboot to install update. */
+	FOTA_REBOOT_SUCCESS,	/** Reboot to complete FOTA job. */
+	FOTA_REBOOT_FAIL,	/** Reboot because FOTA job failed. */
+	FOTA_REBOOT_SYS_ERROR	/** Reboot because fatal system error occurred. */
+};
+
+/**
+ * @brief  Event handler registered with the module to handle asynchronous
+ * events from the module.
+ *
+ * @param[in]  status The reason for the reboot request.
+ */
+typedef void (*fota_reboot_handler_t)(enum nrf_cloud_fota_reboot_status status);
+
+struct nrf_cloud_fota_poll_ctx {
+	struct nrf_cloud_rest_context *rest_ctx;
+	const char *device_id;
+	fota_reboot_handler_t reboot_fn;
+	bool full_modem_fota_supported;
+};
+
+/**
+ * @brief Initialize nRF Cloud FOTA polling assistance.
+ *        Must be called before any other module functions.
+ *
+ * @param[in] ctx Pointer to context used for FOTA polling operations.
+ *
+ * @retval 0       If successful.
+ * @retval -EINVAL Invalid ctx.
+ * @return         A negative value indicates an error.
+ */
+int nrf_cloud_fota_poll_init(struct nrf_cloud_fota_poll_ctx *ctx);
+
+/**
+ * @brief Process/validate a pending FOTA update job.
+ *        This may initiate a reboot through the context's reboot function.
+ *
+ * @param[in] ctx Pointer to context used for FOTA polling operations.
+ *
+ * @retval -EINVAL Invalid ctx or module is not initialized.
+ * @return         If successful, the pending FOTA job type is returned @ref nrf_cloud_fota_type.
+ *                 NRF_CLOUD_FOTA_TYPE__INVALID indicates no pending FOTA job.
+ */
+int nrf_cloud_fota_poll_process_pending(struct nrf_cloud_fota_poll_ctx *ctx);
+
+/**
+ * @brief Perform the following FOTA tasks:
+ *        Report the status of an in progress FOTA job.
+ *        Check for a queued FOTA job.
+ *        Execute FOTA job.
+ *        Save status and request reboot.
+ *
+ * @param[in] ctx Pointer to context used for FOTA polling operations.
+ *
+ * @retval -EINVAL          Invalid ctx or module is not initialized.
+ * @retval -ENOTRECOVERABLE Error performing FOTA action.
+ * @retval -EBUSY           A reboot was requested but not performed by the application.
+ * @retval -EFAULT          A FOTA job was not successful.
+ * @retval -ENOENT          A FOTA job has finished and its status has been reported to the cloud.
+ * @retval -EAGAIN          No FOTA job exists.
+ */
+int nrf_cloud_fota_poll_process(struct nrf_cloud_fota_poll_ctx *ctx);
+
+/** @} */
+
+#ifdef __cplusplus
+#endif
+
+#endif /* NRF_CLOUD_FOTA_POLL_H_ */

--- a/samples/cellular/nrf_cloud_multi_service/src/cloud_connection.c
+++ b/samples/cellular/nrf_cloud_multi_service/src/cloud_connection.c
@@ -527,11 +527,6 @@ static int setup_cloud(void)
 		LOG_ERR("Error initializing FOTA: %d", err);
 		return err;
 	}
-	err = coap_fota_begin();
-	if (err) {
-		LOG_ERR("Error starting FOTA: %d", err);
-		return err;
-	}
 #endif /* CONFIG_COAP_FOTA */
 	err = nrf_cloud_coap_init();
 	if (err) {

--- a/samples/cellular/nrf_cloud_multi_service/src/fota_support_coap.h
+++ b/samples/cellular/nrf_cloud_multi_service/src/fota_support_coap.h
@@ -8,8 +8,6 @@
 #define FOTA_SUPPORT_COAP_H
 
 int coap_fota_init(void);
-int coap_fota_begin(void);
-
 int coap_fota_thread_fn(void);
 
 #endif /* FOTA_SUPPORT_COAP_H */

--- a/samples/cellular/nrf_cloud_rest_fota/prj.conf
+++ b/samples/cellular/nrf_cloud_rest_fota/prj.conf
@@ -48,8 +48,10 @@ CONFIG_NRF_MODEM_LIB=y
 CONFIG_LTE_LINK_CONTROL=y
 
 # AT Host library - Used to send AT commands directy from an UART terminal and to allow
-#		    integration with nRF Connect for Desktop LTE Link monitor application.
+#		    integration with nRF Connect for Desktop applications.
 CONFIG_AT_HOST_LIBRARY=y
+# Extended AT host stack size since some nrf_cloud credentials are longer than 1024 bytes.
+CONFIG_AT_HOST_STACK_SIZE=2048
 
 # Modem info
 CONFIG_MODEM_INFO=y


### PR DESCRIPTION
The nrf_cloud_rest_fota sample failed to build when JITP
was enabled.

Update the nrf_cloud_fota_poll module to allow for the
pending job type to be accessed by the application.
Moved fota_download_init into nrf_cloud_fota_poll_init.
Added function comments and moved into nrf_cloud_fota_poll.h

Increased AT host stack size for the nrf_cloud_rest_fota
sample.

Also, corrected changelog entries from https://github.com/nrfconnect/sdk-nrf/pull/13545.

IRIS-8444