### PR TITLE
samples: wifi: scan: Rectify the Kconfig options for dwell_time

### DIFF
--- a/doc/nrf/protocols/wifi/scan_mode/scan_operation.rst
+++ b/doc/nrf/protocols/wifi/scan_mode/scan_operation.rst
@@ -130,19 +130,13 @@ The following controls can fine-tune the time taken and power consumed by a scan
        | Run time:
        | :c:member:`wifi_scan_params.bands`
    * - Forced passive scan
-     - | Build time:
-       | :kconfig:option:`CONFIG_WIFI_MGMT_FORCED_PASSIVE_SCAN`
-       | Run time:
+     - | Run time:
        | :c:member:`wifi_scan_params.scan_type`
    * - Active dwell time
-     - | Build time:
-       | :kconfig:option:`CONFIG_WIFI_MGMT_SCAN_DWELL_TIME_ACTIVE`
-       | Run time:
+     - | Run time:
        | :c:member:`wifi_scan_params.dwell_time_active`
    * - Passive dwell time
-     - | Build time:
-       | :kconfig:option:`CONFIG_WIFI_MGMT_SCAN_DWELL_TIME_PASSIVE`
-       | Run time:
+     - | Run time:
        | :c:member:`wifi_scan_params.dwell_time_passive`
    * - Channel control
      - | Build time:
@@ -164,14 +158,10 @@ The scan robustness (the number of APs scanned) can be controlled by using the f
    * - Feature
      - Configuration parameters
    * - Active dwell time
-     - | Build time:
-       | :kconfig:option:`CONFIG_WIFI_MGMT_SCAN_DWELL_TIME_ACTIVE`
-       | Run time:
+     - | Run time:
        | :c:member:`wifi_scan_params.dwell_time_active`
    * - Passive dwell time
-     - | Build time:
-       | :kconfig:option:`CONFIG_WIFI_MGMT_SCAN_DWELL_TIME_PASSIVE`
-       | Run time:
+     - | Run time:
        | :c:member:`wifi_scan_params.dwell_time_passive`
 
 Impact of scan controls

--- a/doc/nrf/releases_and_maturity/migration/migration_guide_2.6.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_guide_2.6.rst
@@ -108,10 +108,7 @@ The following changes are mandatory to make your application work in the same wa
      If your application uses scan operations, they need to be updated to remove the dependency on the following options:
 
       * ``CONFIG_WIFI_MGMT_SCAN_BANDS``
-      * ``CONFIG_WIFI_MGMT_SCAN_DWELL_TIME_ACTIVE``
-      * ``CONFIG_WIFI_MGMT_SCAN_DWELL_TIME_PASSIVE``
       * ``CONFIG_WIFI_MGMT_SCAN_SSID_FILT``
-      * ``CONFIG_WIFI_MGMT_SCAN_MAX_BSS_CNT``
       * ``CONFIG_WIFI_MGMT_SCAN_CHAN``
 
   * Instead of the ``CONFIG_WIFI_MGMT_SCAN_MAX_BSS_CNT`` Kconfig option, a new :kconfig:option:`CONFIG_NRF_WIFI_SCAN_MAX_BSS_CNT` Kconfig option is added.

--- a/samples/wifi/scan/src/main.c
+++ b/samples/wifi/scan/src/main.c
@@ -52,13 +52,13 @@ const struct wifi_scan_params tests[] = {
 #ifdef CONFIG_WIFI_SCAN_PROFILE_ACTIVE
 	{
 	.scan_type = WIFI_SCAN_TYPE_ACTIVE,
-	.dwell_time_active = CONFIG_WIFI_MGMT_SCAN_DWELL_TIME_ACTIVE
+	.dwell_time_active = CONFIG_WIFI_SCAN_DWELL_TIME_ACTIVE
 	},
 #endif
 #ifdef CONFIG_WIFI_SCAN_PROFILE_PASSIVE
 	{
 	.scan_type = WIFI_SCAN_TYPE_PASSIVE,
-	.dwell_time_passive = CONFIG_WIFI_MGMT_SCAN_DWELL_TIME_PASSIVE
+	.dwell_time_passive = CONFIG_WIFI_SCAN_DWELL_TIME_PASSIVE
 	},
 #endif
 #ifdef CONFIG_WIFI_SCAN_PROFILE_2_4GHz_ACTIVE


### PR DESCRIPTION
Correct the Kconfig options that are assigned to dwell_time in test profiles defined for active scan and passive scan. Update the corresponding documentation as well.