### PR TITLE
doc: cc3xx: Add limitation of rng driver

### DIFF
--- a/doc/nrf/libraries/security/nrf_security/doc/driver_config.rst
+++ b/doc/nrf/libraries/security/nrf_security/doc/driver_config.rst
@@ -630,6 +630,9 @@ The PSA drivers using the Arm CryptoCell peripheral is enabled by default for nR
 
 For devices without a hardware-accelerated cryptographic engine, entropy is provided by the nRF RNG peripheral. PRNG support is provided by the Oberon PSA driver, which is implemented using software.
 
+.. note::
+   * When using CryptoCell only 1024 bytes can be requested at a time.
+
 Hash configurations
 *******************
 


### PR DESCRIPTION
The cryptocell driver can only produce 1024 random bytes per request, so we should list tis limitation

Ref: NCSDK-24840