### PR TITLE
applications: nrf5340_audio: Only enable empty_core for ACS_NRF53

### DIFF
--- a/applications/nrf5340_audio/dfu/conf/Kconfig.dfu
+++ b/applications/nrf5340_audio/dfu/conf/Kconfig.dfu
@@ -24,7 +24,7 @@ if AUDIO_DFU = 1 || AUDIO_DFU = 2
 # Empty net core image is needed when DFU is enabled
 config NCS_SAMPLE_EMPTY_NET_CORE_CHILD_IMAGE
 	bool "Dummy Net core application"
-	default y
+	default y if BT_LL_ACS_NRF53
 
 config AUDIO_DFU_ENABLE
 	bool

--- a/applications/nrf5340_audio/sample.yaml
+++ b/applications/nrf5340_audio/sample.yaml
@@ -17,30 +17,6 @@ tests:
     platform_exclude: nrf5340_audio_dk_nrf5340_cpuapp_ns
     tags: ci_build
     extra_args: CONF_FILE="prj_release.conf" CONFIG_AUDIO_DEV=2
-  applications.nrf5340_audio.hs_d_i:
-    build_only: true
-    platform_allow: nrf5340_audio_dk_nrf5340_cpuapp
-    platform_exclude: nrf5340_audio_dk_nrf5340_cpuapp_ns
-    tags: ci_build
-    extra_args: CONF_FILE="prj_release.conf" CONFIG_AUDIO_DEV=1 CONFIG_AUDIO_DFU=1
-  applications.nrf5340_audio.gw_d_i:
-    build_only: true
-    platform_allow: nrf5340_audio_dk_nrf5340_cpuapp
-    platform_exclude: nrf5340_audio_dk_nrf5340_cpuapp_ns
-    tags: ci_build
-    extra_args: CONF_FILE="prj_release.conf" CONFIG_AUDIO_DEV=2 CONFIG_AUDIO_DFU=1
-  applications.nrf5340_audio.hs_d_e:
-    build_only: true
-    platform_allow: nrf5340_audio_dk_nrf5340_cpuapp
-    platform_exclude: nrf5340_audio_dk_nrf5340_cpuapp_ns
-    tags: ci_build
-    extra_args: CONF_FILE="prj_release.conf" CONFIG_AUDIO_DEV=1 CONFIG_AUDIO_DFU=2
-  applications.nrf5340_audio.gw_d_e:
-    build_only: true
-    platform_allow: nrf5340_audio_dk_nrf5340_cpuapp
-    platform_exclude: nrf5340_audio_dk_nrf5340_cpuapp_ns
-    tags: ci_build
-    extra_args: CONF_FILE="prj_release.conf" CONFIG_AUDIO_DEV=2 CONFIG_AUDIO_DFU=2
   applications.nrf5340_audio.headset_sd_card_playback:
     build_only: true
     platform_allow: nrf5340_audio_dk_nrf5340_cpuapp


### PR DESCRIPTION
- Only change default to y if building for LL_ACS_NRF53
- OCT-2839