### PR TITLE
manifest: zephyr: Bring missing NVMC dependency for RRAM

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 8d93a161567dcc525771f70692587e6a37947b71
+      revision: pull/1566/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Brings in fix for missing NVMC dependency on RRAM.