### PR TITLE
samples: udp: Change sample.yaml to build for ns target

### DIFF
--- a/samples/net/udp/sample.yaml
+++ b/samples/net/udp/sample.yaml
@@ -8,13 +8,13 @@ tests:
       - nrf9161dk_nrf9161_ns
       - nrf9151dk_nrf9151_ns
       - thingy91_nrf9160_ns
-      - nrf7002dk_nrf5340_cpuapp
+      - nrf7002dk_nrf5340_cpuapp_ns
     platform_allow:
       - nrf9160dk_nrf9160_ns
       - nrf9161dk_nrf9161_ns
       - nrf9151dk_nrf9151_ns
       - thingy91_nrf9160_ns
-      - nrf7002dk_nrf5340_cpuapp
+      - nrf7002dk_nrf5340_cpuapp_ns
     tags: ci_build
   sample.net.udp.emulation:
     build_only: true


### PR DESCRIPTION
The UDP sample was recently updated with support for building for the non-secure target nrf7002dk_nrf5340_cpuapp_ns. But this was not updated in sample.yaml file. This is now fixed.