### PR TITLE
manifest: Bring in MCUmgr fix for MCUBOOT_BOOTLOADER_NO_DOWNGRADE

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: b8f9cb9f9f4a7759e31ec0399b731258e9583a7a
+      revision: pull/1567/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
The commit updates Zephyr to brin in fix where
CONFIG_MCUBOOT_BOOTLOADER_NO_DOWNGRADE check in code has been missing the CONFIG_ prefix, making the selection of the Kconfig option ineffective.