### PR TITLE
quarantine: windows: Update quarantine for Windows CI

### DIFF
--- a/scripts/quarantine_windows_mac.yaml
+++ b/scripts/quarantine_windows_mac.yaml
@@ -25,3 +25,9 @@
     - applications.asset_tracker_v2.cloud.cloud_codec.json_common.azure
     - applications.asset_tracker_v2.cloud.cloud_codec.json_common.aws
   comment: "ruby package not available in Windows toolchain"
+
+- scenarios:
+    - applications.asset_tracker_v2.*.sysbuild
+  platforms:
+    - nrf9160dk_nrf9160_ns
+  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-26461"


### PR DESCRIPTION
Asset_tracker tests with sysbuild are failing on Windows. The root cause it not yet known. However, those are not assured to work before the sysbuild is full ported to NCS.