### PR TITLE
manifest: pull hostap image size optimizaton

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -112,7 +112,7 @@ manifest:
     - name: hostap
       repo-path: sdk-hostap
       path: modules/lib/hostap
-      revision: dda5457ad2cfce99e333980c7764c8d480ae4010
+      revision: pull/161/head
       userdata:
         ncs:
           upstream-url: https://w1.fi/cgit/hostap/


### PR DESCRIPTION
This pulls in a patch that strips off helper
strings from the wpa commands that occupy FLASH,
but are not really used in some configurations.

It saves 730 bytes for Matter that will allow to unblock the nightly CI plans (Matter Bridge image stopped fitting into FLASH slot).