### PR TITLE
manifest: Update sdk-connectedhomip revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -154,7 +154,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 2d33edfab9d29c364a492ecad65893fde40f4f17
+      revision: 1e9f9b28141f663c3be1fdfa0c128cd774c35c89
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
This commit pulls bugfix for Network Commissioning cluster certification issues as well as critical issue with connection error handling.

ref.: KRKNWK-18610