### PR TITLE
Bluetooth: Mesh: Fix parsing Kconfig with multiple equals signs

### DIFF
--- a/scripts/bluetooth/mesh/mesh_dfu_metadata.py
+++ b/scripts/bluetooth/mesh/mesh_dfu_metadata.py
@@ -153,7 +153,7 @@ class KConfig(dict):
                 for line in config:
                     if not line.startswith("CONFIG_"):
                         continue
-                    kconfig, value = line.split("=")
+                    kconfig, value = line.split("=", 1)
                     configs[kconfig] = value.strip()
                 return configs
         except Exception as err :


### PR DESCRIPTION
This fixes in particular parsing such Kconfig option: CONFIG_MODEM_ANTENNA_AT_MAGPIO="AT%XMAGPIO=1,0,0,1,1,1574,1577"