### PR TITLE
application: serial_lte_modem: Support nRF9131 EK

### DIFF
--- a/applications/serial_lte_modem/boards/nrf9131ek_nrf9131_ns.conf
+++ b/applications/serial_lte_modem/boards/nrf9131ek_nrf9131_ns.conf
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Configuration file for nRF9131EK.
+# This file is merged with prj.conf in the application folder, and options
+# set here will take precedence if they are present in both files.
+
+CONFIG_UART_0_NRF_HW_ASYNC_TIMER=2
+CONFIG_UART_0_NRF_HW_ASYNC=y
+CONFIG_SLM_POWER_PIN=28
+CONFIG_SLM_INDICATE_PIN=0

--- a/applications/serial_lte_modem/boards/nrf9131ek_nrf9131_ns.overlay
+++ b/applications/serial_lte_modem/boards/nrf9131ek_nrf9131_ns.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		ncs,slm-uart = &uart0;
+	};
+};
+
+&uart0 {
+	status = "okay";
+	hw-flow-control;
+};

--- a/applications/serial_lte_modem/sample.yaml
+++ b/applications/serial_lte_modem/sample.yaml
@@ -7,6 +7,7 @@ tests:
       - nrf9160dk_nrf9160_ns
       - nrf9161dk_nrf9161_ns
       - nrf9151dk_nrf9151_ns
+      - nrf9131ek_nrf9131_ns
       - thingy91_nrf9160_ns
       - thingy91x_nrf9151_ns
     integration_platforms:
@@ -21,6 +22,7 @@ tests:
       - nrf9160dk_nrf9160_ns
       - nrf9161dk_nrf9161_ns
       - nrf9151dk_nrf9151_ns
+      - nrf9131ek_nrf9131_ns
       - thingy91_nrf9160_ns
       - thingy91x_nrf9151_ns
     integration_platforms:
@@ -35,6 +37,7 @@ tests:
       - nrf9160dk_nrf9160_ns
       - nrf9161dk_nrf9161_ns
       - nrf9151dk_nrf9151_ns
+      - nrf9131ek_nrf9131_ns
       - thingy91_nrf9160_ns
       - thingy91x_nrf9151_ns
     integration_platforms:


### PR DESCRIPTION
Add the overlay files to support nRF9131 EK.
NOTE UART_2 cannot be used as I2C_2 is in use on the EK.