### PR TITLE
wifi: Fix SyntaxError on Windows

### DIFF
--- a/drivers/wifi/nrf700x/CMakeLists.txt
+++ b/drivers/wifi/nrf700x/CMakeLists.txt
@@ -176,10 +176,11 @@ if(CONFIG_NRF_WIFI_PATCHES_EXT_FLASH_STORE)
     )
     add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/zephyr/nrf70.hex
       COMMAND ${Python3_EXECUTABLE}
-        -c 'import sys\; import intelhex\; intelhex.bin2hex(sys.argv[1], sys.argv[2], int(sys.argv[3])) '
+        -c "import sys; import intelhex; intelhex.bin2hex(sys.argv[1], sys.argv[2], int(sys.argv[3])) "
         ${NRF70_PATCH}
         ${CMAKE_BINARY_DIR}/zephyr/nrf70.hex
         $<TARGET_PROPERTY:partition_manager,nrf70_wifi_fw_XIP_ABS_ADDR>
+        VERBATIM
       )
     # Delegate merging WiFi FW patch to mcuboot because we need to merge signed hex instead of raw nrf70.hex.
     if(NOT CONFIG_NRF_WIFI_FW_PATCH_DFU)

--- a/scripts/quarantine_windows_mac.yaml
+++ b/scripts/quarantine_windows_mac.yaml
@@ -39,13 +39,6 @@
   comment: "https://nordicsemi.atlassian.net/browse/SHEL-2579"
 
 - scenarios:
-    - applications.matter_bridge.nrf70ek
-    - sample.matter.lock.thread_wifi_switched
-  platforms:
-    - nrf5340dk_nrf5340_cpuapp
-  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-26462"
-
-- scenarios:
     - sample.caf_sensor_manager.nrf54h20.multicore
     - sample.cellular.modem_shell.modem_trace_shell_ext_flash
     - sample.event_manager_proxy.nrf54h20pdk_cpuapp.icmsg


### PR DESCRIPTION
Using single quotes causes issues while building samples on Windows.