### PR TITLE
manifest: pull west debug support for nRF54H20 PDK

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 226b676f94f6d0999b3199a6723057f533754ac7
+      revision: pull/1570/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
west debug|debugserver can be used for nRF54H20 PDK (with known limitations).