### PR TITLE
manifest: Update Matter SDK revision to pull critical fix.

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -154,7 +154,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: v2.6.0-rc2
+      revision: 7653e6c78d0aab6d9c0fd25408e5a908435955b8
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
The critical fix repairs the problem with stack sizes when both Oberon and CC3XX drivers are enabled.

Ref critical bug: KRKNWK-18616