### PR TITLE
lwm2m: Fix FOTA cancellation issues

### DIFF
--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
@@ -947,10 +947,10 @@ static int write_dl_uri(uint16_t obj_inst_id, uint16_t res_id, uint16_t res_inst
 
 
 	LOG_DBG("write URI: %s", package_uri);
-
 	state = get_state(obj_inst_id);
+	bool empty_uri = data_len == 0 || strnlen(data, data_len) == 0;
 
-	if (state == STATE_IDLE && data_len > 0) {
+	if (state == STATE_IDLE && !empty_uri) {
 		set_state(obj_inst_id, STATE_DOWNLOADING);
 
 		if (ongoing_obj_id == UNUSED_OBJ_ID) {
@@ -961,7 +961,7 @@ static int write_dl_uri(uint16_t obj_inst_id, uint16_t res_id, uint16_t res_inst
 				set_result(obj_inst_id, RESULT_ADV_CONFLICT_STATE);
 			}
 		}
-	} else if (data_len == 0) {
+	} else if (empty_uri) {
 		if (ongoing_obj_id == UNUSED_OBJ_ID || ongoing_obj_id == obj_inst_id) {
 			ongoing_obj_id = obj_inst_id;
 			/* reset to state idle and result default */

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
@@ -307,7 +307,7 @@ static int write_resource_to_settings(uint16_t inst, uint16_t res, uint8_t *data
 	return 0;
 }
 
-static int write_image_type_to_settings(uint16_t inst, uint16_t img_type)
+static int write_image_type_to_settings(uint16_t inst, int img_type)
 {
 	char path[SETTINGS_FIRM_PATH_LEN];
 
@@ -409,6 +409,9 @@ static int firmware_target_reset(uint16_t obj_inst_id)
 	int dfu_image_type;
 
 	dfu_image_type = target_image_type_get(obj_inst_id);
+	if (dfu_image_type == DFU_TARGET_IMAGE_TYPE_NONE) {
+		return 0;
+	}
 
 	return fota_download_util_image_reset(dfu_image_type);
 }
@@ -643,6 +646,7 @@ static int firmware_update_state(uint16_t obj_inst_id, uint16_t res_id, uint16_t
 			if (ret < 0) {
 				LOG_ERR("Failed to reset DFU target, err: %d", ret);
 			}
+			target_image_type_store(obj_inst_id, DFU_TARGET_IMAGE_TYPE_NONE);
 			init_firmware_variables();
 		}
 		if (update_data.object_instance == obj_inst_id) {


### PR DESCRIPTION
As explained in https://nordicsemi.atlassian.net/browse/NCSDK-26534

Cancelling the FOTA process is now broken.
Two issues found:
1. Empty string might be `"\0"` which is not same as zero length data. This should be handled similarly.
2. LwM2M FOTA utils wrote 16bit value using `sizeof(int)` which caused value to wrap over on certain cases.
