### PR TITLE
boards: thingy91x_nrf5340: Update reset of nRF5340 CPU net

### DIFF
--- a/boards/arm/thingy91x_nrf5340/nrf5340_cpunet_reset.c
+++ b/boards/arm/thingy91x_nrf5340/nrf5340_cpunet_reset.c
@@ -9,6 +9,7 @@
 #include <zephyr/logging/log.h>
 
 #include <soc.h>
+#include <hal/nrf_reset.h>
 
 LOG_MODULE_REGISTER(thingy91x_nrf5340_cpuapp, CONFIG_LOG_DEFAULT_LEVEL);
 
@@ -47,7 +48,7 @@ static int remoteproc_mgr_boot(void)
 	 */
 
 	/* Release the Network MCU, 'Release force off signal' */
-	NRF_RESET->NETWORK.FORCEOFF = RESET_NETWORK_FORCEOFF_FORCEOFF_Release;
+	nrf_reset_network_force_off(NRF_RESET, false);
 
 	LOG_DBG("Network MCU released.");
 #endif /* !CONFIG_TRUSTED_EXECUTION_SECURE */


### PR DESCRIPTION
This patch updates the reset of the nRF5340 CPU net to use the nrfx driver. This is done to ensure that the
necessary workarounds are applied.