### PR TITLE
applications: nrf5340_audio: We should improve how the SIRK is set

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/Kconfig
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/Kconfig
@@ -122,6 +122,23 @@ config BT_AUDIO_BITRATE_UNICAST_SRC
 	help
 	  Bitrate for the unicast source ISO stream.
 
+config BT_SET_IDENTITY_RESOLVING_KEY_DEFAULT
+	string
+	default "NRF5340_TWS_DEMO"
+	help
+	  Default string to configure the Set Identify Resolving Key (SIRK), must
+	  be changed before production uniquely for each coordinated set.
+
+config BT_SET_IDENTITY_RESOLVING_KEY
+	string "String used to configure the SIRK"
+	depends on TRANSPORT_CIS && BT_BAP_UNICAST_SERVER
+	default BT_SET_IDENTITY_RESOLVING_KEY_DEFAULT
+	help
+	  Defines a string to configure the Set Identify Resolving Key (SIRK), must
+	  be changed before production uniquely for each coordinated set. The SIRK
+	  must be 16 characters (16 bytes).
+
+
 #----------------------------------------------------------------------------#
 menu "Log levels"
 


### PR DESCRIPTION
OCT-2723

Set the default SIRK and test this against the SIRK to be used. A warning will be logged if these are the same.
