### PR TITLE
applications: nrf_desktop: Add DT alias to configure QDEC in wheel

### DIFF
--- a/applications/nrf_desktop/doc/wheel.rst
+++ b/applications/nrf_desktop/doc/wheel.rst
@@ -26,6 +26,8 @@ Enable the module with the :ref:`CONFIG_DESKTOP_WHEEL_ENABLE <config_desktop_app
 
 For detecting rotation, the wheel module uses Zephyr's QDEC driver.
 You can enable the module only when QDEC is configured in DTS and the Zephyr's QDEC driver is enabled with the :kconfig:option:`CONFIG_QDEC_NRFX` Kconfig option.
+If your board supports multiple QDEC instances (for example ``nrf54l15pdk_nrf54l15_cpuapp``), you also need to specify the used QDEC instance with the ``nrfdesktop-wheel-qdec`` DT alias.
+If your board supports only one QDEC instance, the module relies on the ``qdec`` DT label and you do not need to define the DT alias.
 
 The QDEC DTS configuration specifies how many steps are done during one full angle.
 The sensor reports the rotation data in angle degrees.

--- a/applications/nrf_desktop/src/hw_interface/wheel.c
+++ b/applications/nrf_desktop/src/hw_interface/wheel.c
@@ -37,13 +37,21 @@ enum state {
 	STATE_SUSPENDED
 };
 
+#if DT_NODE_HAS_STATUS(DT_ALIAS(nrfdesktop_wheel_qdec), okay)
+  #define QDEC_DT_NODE_ID	DT_ALIAS(nrfdesktop_wheel_qdec)
+#elif DT_NODE_HAS_STATUS(DT_NODELABEL(qdec), okay)
+  #define QDEC_DT_NODE_ID	DT_NODELABEL(qdec)
+#else
+  #error DT node for QDEC must be specified.
+#endif
+
 #define QDEC_PIN_INIT(node_id, prop, idx) \
 	NRF_GET_PIN(DT_PROP_BY_IDX(node_id, prop, idx)),
 
 /* obtan qdec pins from default state */
 static const uint32_t qdec_pin[] = {
 	DT_FOREACH_CHILD_VARGS(
-		DT_PINCTRL_BY_NAME(DT_NODELABEL(qdec), default, 0),
+		DT_PINCTRL_BY_NAME(QDEC_DT_NODE_ID, default, 0),
 		DT_FOREACH_PROP_ELEM, psels, QDEC_PIN_INIT
 	)
 };
@@ -53,7 +61,7 @@ static const struct sensor_trigger qdec_trig = {
 	.chan = SENSOR_CHAN_ROTATION,
 };
 
-static const struct device *qdec_dev = DEVICE_DT_GET(DT_NODELABEL(qdec));
+static const struct device *qdec_dev = DEVICE_DT_GET(QDEC_DT_NODE_ID);
 static struct gpio_callback gpio_cbs[ARRAY_SIZE(qdec_pin)];
 static struct k_spinlock lock;
 static struct k_work_delayable idle_timeout;
@@ -208,7 +216,7 @@ static void wakeup_cb(const struct device *gpio_dev, struct gpio_callback *cb,
 
 static int setup_wakeup(void)
 {
-	int enable_pin = DT_PROP(DT_NODELABEL(qdec), enable_pin);
+	int enable_pin = DT_PROP(QDEC_DT_NODE_ID, enable_pin);
 	const struct device *port = map_gpio_port(enable_pin);
 	gpio_pin_t pin = map_gpio_pin(enable_pin);
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -148,9 +148,14 @@ nRF Machine Learning (Edge Impulse)
 nRF Desktop
 -----------
 
-* Added support for the nRF54L15 PDK with the ``nrf54l15pdk_nrf54l15_cpuapp`` board target.
-  The PDK can act as a sample mouse or keyboard.
-  It supports the Bluetooth LE HID data transport and uses SoftDevice Link Layer with Low Latency Packet Mode (LLPM) enabled.
+* Added:
+
+  * Support for the nRF54L15 PDK with the ``nrf54l15pdk_nrf54l15_cpuapp`` board target.
+    The PDK can act as a sample mouse or keyboard.
+    It supports the Bluetooth LE HID data transport and uses SoftDevice Link Layer with Low Latency Packet Mode (LLPM) enabled.
+  * The ``nrfdesktop-wheel-qdec`` DT alias support to :ref:`nrf_desktop_wheel`.
+    You must use the alias to specify the QDEC instance used for scroll wheel, if your board supports multiple QDEC instances (for example ``nrf54l15pdk_nrf54l15_cpuapp``).
+    You do not need to define the alias if your board supports only one QDEC instance, because in that case, the wheel module can rely on the ``qdec`` DT label provided by the board.
 
 Thingy:53: Matter weather station
 ---------------------------------


### PR DESCRIPTION
Change adds DT alias that allows to configure QDEC instance used in wheel application module. This is needed to use the module for platforms that support multiple QDEC instances and do not provide "qdec" DT label.

Jira: NCSDK-26468