### PR TITLE
applications: Matter Bridge: add support for missing OnOff attributes

### DIFF
--- a/applications/matter_bridge/src/ble_providers/ble_lbs_data_provider.cpp
+++ b/applications/matter_bridge/src/ble_providers/ble_lbs_data_provider.cpp
@@ -171,7 +171,7 @@ CHIP_ERROR BleLBSDataProvider::UpdateState(chip::ClusterId clusterId, chip::Attr
 		return CHIP_NO_ERROR;
 	}
 	default:
-		return CHIP_ERROR_INVALID_ARGUMENT;
+		return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 	}
 
 	return CHIP_NO_ERROR;

--- a/applications/matter_bridge/src/bridged_device_types/humidity_sensor.h
+++ b/applications/matter_bridge/src/bridged_device_types/humidity_sensor.h
@@ -10,21 +10,13 @@
 
 class HumiditySensorDevice : public Nrf::MatterBridgedDevice {
 public:
-	static constexpr uint16_t kRelativeHumidityMeasurementClusterRevision = 3;
-	static constexpr uint32_t kRelativeHumidityMeasurementFeatureMap = 0;
-
 	HumiditySensorDevice(const char *nodeLabel);
 
 	uint16_t GetMeasuredValue() { return mMeasuredValue; }
 	uint16_t GetMinMeasuredValue() { return mMinMeasuredValue; }
 	uint16_t GetMaxMeasuredValue() { return mMaxMeasuredValue; }
-	uint16_t GetRelativeHumidityMeasurementClusterRevision() { return kRelativeHumidityMeasurementClusterRevision; }
-	uint32_t GetRelativeHumidityMeasurementFeatureMap() { return kRelativeHumidityMeasurementFeatureMap; }
 
-	uint16_t GetDeviceType() const override
-	{
-		return Nrf::MatterBridgedDevice::DeviceType::HumiditySensor;
-	}
+	uint16_t GetDeviceType() const override { return Nrf::MatterBridgedDevice::DeviceType::HumiditySensor; }
 	CHIP_ERROR HandleRead(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer,
 			      uint16_t maxReadLength) override;
 	CHIP_ERROR HandleReadRelativeHumidityMeasurement(chip::AttributeId attributeId, uint8_t *buffer,
@@ -35,6 +27,9 @@ public:
 	}
 	CHIP_ERROR HandleAttributeChange(chip::ClusterId clusterId, chip::AttributeId attributeId, void *data,
 					 size_t dataSize) override;
+
+	static constexpr uint16_t GetRelativeHumidityMeasurementClusterRevision() { return 3; }
+	static constexpr uint32_t GetRelativeHumidityMeasurementFeatureMap() { return 0; }
 
 private:
 	void SetMeasuredValue(int16_t value) { mMeasuredValue = value; }

--- a/applications/matter_bridge/src/bridged_device_types/onoff_light.h
+++ b/applications/matter_bridge/src/bridged_device_types/onoff_light.h
@@ -10,27 +10,12 @@
 
 class OnOffLightDevice : public Nrf::MatterBridgedDevice {
 public:
-	static constexpr uint32_t kIdentifyFeatureMap = 0;
-	static constexpr uint16_t kOnOffClusterRevision = 5;
-	static constexpr uint32_t kOnOffFeatureMap = 1;
-	static constexpr uint16_t kGroupsClusterRevision = 4;
-	static constexpr uint32_t kGroupsFeatureMap = 1;
-	static constexpr uint8_t kGroupsNameSupportMap = 0;
-
 	OnOffLightDevice(const char *nodeLabel);
 
 	bool GetOnOff() { return mOnOff; }
 	void Toggle() { mOnOff = !mOnOff; }
-	uint16_t GetOnOffClusterRevision() { return kOnOffClusterRevision; }
-	uint32_t GetOnOffFeatureMap() { return kOnOffFeatureMap; }
-	uint16_t GetGroupsClusterRevision() { return kGroupsClusterRevision; }
-	uint32_t GetGroupsFeatureMap() { return kGroupsFeatureMap; }
-	uint8_t GetGroupsNameSupportMap() { return kGroupsNameSupportMap; }
 
-	uint16_t GetDeviceType() const override
-	{
-		return Nrf::MatterBridgedDevice::DeviceType::OnOffLight;
-	}
+	uint16_t GetDeviceType() const override { return Nrf::MatterBridgedDevice::DeviceType::OnOffLight; }
 	CHIP_ERROR HandleRead(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer,
 			      uint16_t maxReadLength) override;
 	CHIP_ERROR HandleReadOnOff(chip::AttributeId attributeId, uint8_t *buffer, uint16_t maxReadLength);
@@ -39,8 +24,18 @@ public:
 	CHIP_ERROR HandleAttributeChange(chip::ClusterId clusterId, chip::AttributeId attributeId, void *data,
 					 size_t dataSize) override;
 
-private:
-	void SetOnOff(bool onOff) { mOnOff = onOff; }
+	static constexpr uint16_t GetOnOffClusterRevision() { return 5; }
+	static constexpr uint32_t GetOnOffFeatureMap() { return 1; }
+	static constexpr uint16_t GetGroupsClusterRevision() { return 4; }
+	static constexpr uint32_t GetGroupsFeatureMap() { return 1; }
+	static constexpr uint8_t GetGroupsNameSupportMap() { return 0; }
 
-	bool mOnOff = false;
+private:
+	bool mOnOff{ false };
+	bool mGlobalSceneControl{ false };
+	int16_t mOnTime{ 0 };
+	int16_t mOffWaitTime{ 0 };
+	chip::app::Clusters::OnOff::StartUpOnOffEnum mStartUpOnOff{
+		chip::app::Clusters::OnOff::StartUpOnOffEnum::kUnknownEnumValue
+	};
 };

--- a/applications/matter_bridge/src/bridged_device_types/onoff_light_switch.h
+++ b/applications/matter_bridge/src/bridged_device_types/onoff_light_switch.h
@@ -10,22 +10,9 @@
 
 class OnOffLightSwitchDevice : public Nrf::MatterBridgedDevice {
 public:
-	static constexpr uint16_t kOnOffClusterRevision = 4;
-	static constexpr uint32_t kOnOffFeatureMap = 1;
-	static constexpr uint16_t kBindingClusterRevision = 1;
-	static constexpr uint32_t kBindingFeatureMap = 0;
-
 	OnOffLightSwitchDevice(const char *nodeLabel);
 
-	uint16_t GetOnOffClusterRevision() { return kOnOffClusterRevision; }
-	uint32_t GetOnOffFeatureMap() { return kOnOffFeatureMap; }
-	uint16_t GetBindingClusterRevision() { return kBindingClusterRevision; }
-	uint32_t GetBindingFeatureMap() { return kBindingFeatureMap; }
-
-	uint16_t GetDeviceType() const override
-	{
-		return Nrf::MatterBridgedDevice::DeviceType::OnOffLightSwitch;
-	}
+	uint16_t GetDeviceType() const override { return Nrf::MatterBridgedDevice::DeviceType::OnOffLightSwitch; }
 	CHIP_ERROR HandleRead(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer,
 			      uint16_t maxReadLength) override;
 	CHIP_ERROR HandleReadOnOff(chip::AttributeId attributeId, uint8_t *buffer, uint16_t maxReadLength);
@@ -40,5 +27,8 @@ public:
 		return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 	}
 
-private:
+	static constexpr uint16_t GetOnOffClusterRevision() { return 4; }
+	static constexpr uint32_t GetOnOffFeatureMap() { return 1; }
+	static constexpr uint16_t GetBindingClusterRevision() { return 1; }
+	static constexpr uint32_t GetBindingFeatureMap() { return 0; }
 };

--- a/applications/matter_bridge/src/bridged_device_types/temperature_sensor.h
+++ b/applications/matter_bridge/src/bridged_device_types/temperature_sensor.h
@@ -10,21 +10,13 @@
 
 class TemperatureSensorDevice : public Nrf::MatterBridgedDevice {
 public:
-	static constexpr uint16_t kTemperatureMeasurementClusterRevision = 4;
-	static constexpr uint32_t kTemperatureMeasurementFeatureMap = 0;
-
 	TemperatureSensorDevice(const char *nodeLabel);
 
 	int16_t GetMeasuredValue() { return mMeasuredValue; }
 	int16_t GetMinMeasuredValue() { return mMinMeasuredValue; }
 	int16_t GetMaxMeasuredValue() { return mMaxMeasuredValue; }
-	uint16_t GetTemperatureMeasurementClusterRevision() { return kTemperatureMeasurementClusterRevision; }
-	uint32_t GetTemperatureMeasurementFeatureMap() { return kTemperatureMeasurementFeatureMap; }
 
-	uint16_t GetDeviceType() const override
-	{
-		return Nrf::MatterBridgedDevice::DeviceType::TemperatureSensor;
-	}
+	uint16_t GetDeviceType() const override { return Nrf::MatterBridgedDevice::DeviceType::TemperatureSensor; }
 	CHIP_ERROR HandleRead(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer,
 			      uint16_t maxReadLength) override;
 	CHIP_ERROR HandleReadTemperatureMeasurement(chip::AttributeId attributeId, uint8_t *buffer,
@@ -35,6 +27,9 @@ public:
 	}
 	CHIP_ERROR HandleAttributeChange(chip::ClusterId clusterId, chip::AttributeId attributeId, void *data,
 					 size_t dataSize) override;
+
+	static constexpr uint16_t GetTemperatureMeasurementClusterRevision() { return 4; }
+	static constexpr uint32_t GetTemperatureMeasurementFeatureMap() { return 0; }
 
 private:
 	void SetMeasuredValue(int16_t value) { mMeasuredValue = value; }

--- a/applications/matter_bridge/src/simulated_providers/simulated_generic_switch_data_provider.cpp
+++ b/applications/matter_bridge/src/simulated_providers/simulated_generic_switch_data_provider.cpp
@@ -47,7 +47,7 @@ CHIP_ERROR SimulatedGenericSwitchDataProvider::UpdateState(chip::ClusterId clust
 		return CHIP_NO_ERROR;
 	}
 	default:
-		return CHIP_ERROR_INVALID_ARGUMENT;
+		return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 	}
 
 	return CHIP_NO_ERROR;

--- a/applications/matter_bridge/src/simulated_providers/simulated_onoff_light_data_provider.cpp
+++ b/applications/matter_bridge/src/simulated_providers/simulated_onoff_light_data_provider.cpp
@@ -49,7 +49,7 @@ CHIP_ERROR SimulatedOnOffLightDataProvider::UpdateState(chip::ClusterId clusterI
 		return CHIP_NO_ERROR;
 	}
 	default:
-		return CHIP_ERROR_INVALID_ARGUMENT;
+		return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 	}
 
 	return CHIP_NO_ERROR;

--- a/applications/matter_bridge/src/simulated_providers/simulated_onoff_light_switch_data_provider.cpp
+++ b/applications/matter_bridge/src/simulated_providers/simulated_onoff_light_switch_data_provider.cpp
@@ -61,8 +61,12 @@ void ProcessCommand(const EmberBindingTableEntry &aBinding, OperationalDevicePro
 CHIP_ERROR SimulatedOnOffLightSwitchDataProvider::UpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId,
 							      uint8_t *buffer)
 {
-	if (clusterId != Clusters::OnOff::Id || attributeId != Clusters::OnOff::Attributes::OnOff::Id) {
+	if (clusterId != Clusters::OnOff::Id) {
 		return CHIP_ERROR_INVALID_ARGUMENT;
+	}
+
+	if (attributeId != Clusters::OnOff::Attributes::OnOff::Id) {
+		return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 	}
 
 	bool mOnOff;

--- a/samples/matter/common/src/bridge/bridge_manager.cpp
+++ b/samples/matter/common/src/bridge/bridge_manager.cpp
@@ -397,8 +397,12 @@ CHIP_ERROR BridgeManager::HandleWrite(uint16_t index, ClusterId clusterId,
 
 	/* After updating MatterBridgedDevice state, forward request to the non-Matter device. */
 	if (err == CHIP_NO_ERROR) {
-		return Instance().mDevicesMap[index].mProvider->UpdateState(clusterId, attributeMetadata->attributeId,
-									    buffer);
+		CHIP_ERROR updateError = Instance().mDevicesMap[index].mProvider->UpdateState(
+			clusterId, attributeMetadata->attributeId, buffer);
+		/* This is acceptable that not all writable attributes can be reflected in the provider device. */
+		if (updateError != CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE) {
+			return updateError;
+		}
 	}
 	return err;
 }

--- a/samples/matter/common/src/bridge/bridged_device_data_provider.h
+++ b/samples/matter/common/src/bridge/bridged_device_data_provider.h
@@ -34,6 +34,8 @@ public:
 	virtual void Init() = 0;
 	virtual void NotifyUpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId, void *data,
 				       size_t dataSize) = 0;
+
+	/* This method shall return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE for attributes that cannot be updated. */
 	virtual CHIP_ERROR UpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer) = 0;
 
 	CHIP_ERROR NotifyReachableStatusChange(bool isReachable);


### PR DESCRIPTION
* Added read/write support for missing OnOff cluster attributes to conform with the spec
* Slightly refactored constants in bridge device classes
* Fixed the case when an attribute update is not supported on the provider side