### PR TITLE
manifest: update nrfxlib for modem lib v2.6.1

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -142,7 +142,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: v2.6.0-rc2
+      revision: 13cd978b22d192447537a60f7fae5fe092930dc4
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Update manifest for sdk-nrfxlib for modem lib v2.6.1.