### PR TITLE
scripts: Update minimum required toolchain for the v2.6.0 release

### DIFF
--- a/scripts/ncs-toolchain-version-minimum.txt
+++ b/scripts/ncs-toolchain-version-minimum.txt
@@ -1,3 +1,3 @@
 # This file specifies the minimum nRF Connect SDK Toolchain that will be
 # working with this release.
-nrf-connect-sdk-toolchain=2.5.20231017
+nrf-connect-sdk-toolchain=2.6.20240304


### PR DESCRIPTION
'2.6.20240304' is pointer to 'v2.6.0-rc2' in toolchain-manager index. 
This is required by [CMAKE_VERSION](https://cmake.org/cmake/help/latest/variable/CMAKE_VERSION.html)
