### PR TITLE
manifest: sdk-zephyr: EAD support in BT shell

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v3.5.99-ncs1
+      revision: aa2eeb1a34df2d9abcdb46c9b85aafbf8fbc768f
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Bring in commit to support EAD in the BT shell.