### PR TITLE
samples: bluetooth: mesh: Add nRF54L15 support to Light Switch

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -203,6 +203,10 @@ Bluetooth Mesh samples
 
    * Added support for the :ref:`zephyr:nrf54l15pdk_nrf54l15` board.
 
+* :ref:`bluetooth_mesh_light_switch` sample:
+
+  * Added support for the :ref:`zephyr:nrf54l15pdk_nrf54l15` board.
+
 Cellular samples
 ----------------
 

--- a/samples/bluetooth/mesh/light_switch/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/bluetooth/mesh/light_switch/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+################################################################################
+# Application overlay - nrf54l15
+
+CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE=n

--- a/samples/bluetooth/mesh/light_switch/overlay-lpn.conf
+++ b/samples/bluetooth/mesh/light_switch/overlay-lpn.conf
@@ -18,6 +18,7 @@ CONFIG_BT_MESH_ADV_EXT_GATT_SEPARATE=n
 CONFIG_SERIAL=n
 CONFIG_CONSOLE=n
 CONFIG_UART_CONSOLE=n
+CONFIG_LOG=n
 
 # While enabled, secure beacons will be advertised periodically.
 # This consumes power, and is not required for an LPN node.

--- a/samples/bluetooth/mesh/light_switch/overlay-lpn.conf
+++ b/samples/bluetooth/mesh/light_switch/overlay-lpn.conf
@@ -16,6 +16,7 @@ CONFIG_BT_MESH_ADV_EXT_GATT_SEPARATE=n
 
 # Serial communication consumes considerable power
 CONFIG_SERIAL=n
+CONFIG_CONSOLE=n
 CONFIG_UART_CONSOLE=n
 
 # While enabled, secure beacons will be advertised periodically.

--- a/samples/bluetooth/mesh/light_switch/sample.yaml
+++ b/samples/bluetooth/mesh/light_switch/sample.yaml
@@ -12,9 +12,10 @@ tests:
       - nrf5340dk_nrf5340_cpuapp_ns
       - thingy53_nrf5340_cpuapp
       - nrf21540dk_nrf52840
+      - nrf54l15pdk_nrf54l15_cpuapp
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
       nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp
-      nrf21540dk_nrf52840 nrf52833dk_nrf52833
+      nrf21540dk_nrf52840 nrf52833dk_nrf52833 nrf54l15pdk_nrf54l15_cpuapp
     tags: bluetooth ci_build
   sample.bluetooth.mesh.light_switch.lpn:
     build_only: true
@@ -22,6 +23,8 @@ tests:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
       - nrf52833dk_nrf52833
+      - nrf54l15pdk_nrf54l15_cpuapp
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52833dk_nrf52833
+      nrf54l15pdk_nrf54l15_cpuapp
     extra_args: OVERLAY_CONFIG=overlay-lpn.conf
     tags: bluetooth ci_build


### PR DESCRIPTION
This PR adds support for nRF54L15 in Light Switch sample. It also disables `CONFIG_CONSOLE` and `CONFIG_LOG` in `overlay-lpn.conf` as they aren't needed in that configuration and cause build warning and issues on nRF54L15.