### PR TITLE
drivers: wifi: Correct frame dependent edge backoffs comment

### DIFF
--- a/drivers/wifi/nrf700x/Kconfig
+++ b/drivers/wifi/nrf700x/Kconfig
@@ -301,17 +301,17 @@ config NRF700X_BAND_2G_LOWER_EDGE_BACKOFF_HE
 	range 0 10
 
 config NRF700X_BAND_2G_UPPER_EDGE_BACKOFF_DSSS
-	int "DSSS Transmit power backoff (in dB) for lower edge of 2.4 GHz frequency band"
+	int "DSSS Transmit power backoff (in dB) for upper edge of 2.4 GHz frequency band"
 	default 0
 	range 0 10
 
 config NRF700X_BAND_2G_UPPER_EDGE_BACKOFF_HT
-	int "HT/VHT Transmit power backoff (in dB) for lower edge of 2.4 GHz frequency band"
+	int "HT/VHT Transmit power backoff (in dB) for upper edge of 2.4 GHz frequency band"
 	default 0
 	range 0 10
 
 config NRF700X_BAND_2G_UPPER_EDGE_BACKOFF_HE
-	int "HE Transmit power backoff (in dB) for lower edge of 2.4 GHz frequency band"
+	int "HE Transmit power backoff (in dB) for upper edge of 2.4 GHz frequency band"
 	default 0
 	range 0 10
 


### PR DESCRIPTION
[SHEL-2587] Updating frame dependent edge backoffs comments

[SHEL-2587]: https://nordicsemi.atlassian.net/browse/SHEL-2587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ