### PR TITLE
doc: wifi: Adding link to precompiled scan sample

### DIFF
--- a/doc/nrf/device_guides/working_with_nrf/nrf70/gs.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf70/gs.rst
@@ -30,8 +30,8 @@ It implements the nRF Wi-Fi driver software on the nRF5340 host processor commun
 The nRF5340 host is a dual-core SoC based on the Arm® Cortex®-M33 architecture.
 It has the following features:
 
-* A full-featured Arm Cortex-M33F core with DSP instructions, FPU, and Armv8-M Security Extension, running at up to 128 MHz, referred to as the *application core*.
-* A secondary Arm Cortex-M33 core, with a reduced feature set, running at a fixed 64 MHz, referred to as the *network core*.
+* A full-featured Arm Cortex-M33F core with DSP instructions, FPU, and Armv8-M Security Extension, running at up to 128 MHz, referred to as the application core.
+* A secondary Arm Cortex-M33 core, with a reduced feature set, running at a fixed 64 MHz, referred to as the network core.
 
 The ``nrf7002dk_nrf5340_cpuapp`` build target provides support for the application core on the nRF5340 SoC.
 The ``nrf7002dk_nrf5340_cpunet`` build target provides support for the network core on the nRF5340 SoC.
@@ -143,26 +143,26 @@ The connections and IOs supported by the development kit are listed in this sect
 LED
 ^^^
 
-* LED1 (green) = P1.06
-* LED2 (green) = P1.07
+* **LED 1** (green) = **P1.06**
+* **LED 2** (green) = **P1.07**
 
 Push buttons
 ^^^^^^^^^^^^
 
-* BUTTON1 = SW1 = P1.08
-* BUTTON2 = SW2 = P1.09
-* BOOT = SW5 = boot/reset
+* **Button 1** = **SW1** = **P1.08**
+* **Button 2** = **SW2** = **P1.09**
+* **BOOT** = **SW5** = boot/reset
 
 Wi-Fi control
 ^^^^^^^^^^^^^
 
-* BUCKEN = P0.12
-* IOVDD CONTROL = P0.31
-* HOST IRQ = P0.23
-* COEX_REQ = P0.28
-* COEX_STATUS0 = P0.30
-* COEX_STATUS1 = P0.29
-* COEX_GRANT = P0.24
+* BUCKEN = **P0.12**
+* IOVDD CONTROL = **P0.31**
+* HOST IRQ = **P0.23**
+* COEX_REQ = **P0.28**
+* COEX_STATUS0 = **P0.30**
+* COEX_STATUS1 = **P0.29**
+* COEX_GRANT = **P0.24**
 
 Security components
 -------------------
@@ -220,7 +220,7 @@ To program the precompiled sample to your development kit, complete the followin
 1. Open the Programmer app.
 #. Connect the nRF7002 DK to the computer with a micro-USB cable and turn on the DK.
 
-   **LED5** starts blinking.
+   **LED 5** starts blinking.
 
 #. Click **SELECT DEVICE** and select the DK from the drop-down list.
 

--- a/doc/nrf/device_guides/working_with_nrf/nrf70/gs.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf70/gs.rst
@@ -210,7 +210,7 @@ Programming the sample
 **********************
 
 You must program and run a precompiled version of the :ref:`wifi_scan_sample` sample on your development kit to test the functions.
-Download the precompiled version of the sample from the nRF7002 DK Downloads page.
+Download the precompiled version of the sample from the `nRF7002 DK Downloads`_ page.
 
 After downloading the zip archive, extract it to a folder of your choice.
 The archive contains the HEX file used to program the sample to your DK.

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -454,6 +454,8 @@
 .. _`nRF5340 DK Downloads`: https://www.nordicsemi.com/Products/Development-hardware/nRF5340-DK/Download?lang=en#infotabs
 .. _`nRF5340 DK product page`: https://www.nordicsemi.com/Products/Development-hardware/nRF5340-DK/
 
+.. _`nRF7002 DK Downloads`: https://www.nordicsemi.com/Products/Development-hardware/nRF7002-DK/Download?lang=en#infotabs
+
 .. _`Nordic Thingy:53`:
 .. _`Thingy:53 product page`: https://www.nordicsemi.com/thingy53
 .. _`Nordic Thingy:53 Downloads`: https://www.nordicsemi.com/Products/Development-hardware/Nordic-Thingy-53/Downloads#infotabs


### PR DESCRIPTION
Added link to the precompiled version of the
scan sample in the Getting started with nRF7002 DK UG.

NCSDK-25710