### PR TITLE
manifest: Matter directed scaning with single scan

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -158,7 +158,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 49b5f80170c1a7a7a0c5c59f9f055d8d03e59ffa
+      revision: 8bfa6ae5a51b1bc1498bd4e6b2f6d2bc75e13687
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
This allows to seek only for the SSID of interest and avoid
multiple scan result callbacks in the application.