### PR TITLE
samples: Bluetooth: Mesh: add nrf54l support for Chat sample

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -185,7 +185,9 @@ Bluetooth samples
 Bluetooth Mesh samples
 ----------------------
 
-|no_changes_yet_note|
+* :ref:`bt_mesh_chat` sample:
+
+   * Added support for the :ref:`zephyr:nrf54l15pdk_nrf54l15` board.
 
 Cellular samples
 ----------------

--- a/samples/bluetooth/mesh/chat/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/bluetooth/mesh/chat/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+################################################################################
+# Application overlay - nrf54l15
+
+CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE=n

--- a/samples/bluetooth/mesh/chat/sample.yaml
+++ b/samples/bluetooth/mesh/chat/sample.yaml
@@ -8,5 +8,7 @@ tests:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
       - nrf21540dk_nrf52840
+      - nrf54l15pdk_nrf54l15_cpuapp
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf21540dk_nrf52840
+        nrf54l15pdk_nrf54l15_cpuapp
     tags: bluetooth ci_build


### PR DESCRIPTION
Add support of nrf54l15pdk_nrf54l15_cpuapp in mesh Chat sample.