### PR TITLE
net: lib: nrf_cloud: CoAP invalid delta rejection

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -388,6 +388,8 @@ Libraries for networking
 
   * Updated to request proprietary PSM mode for ``SOC_NRF9151_LACA`` and ``SOC_NRF9131_LACA`` in addition to ``SOC_NRF9161_LACA``.
 
+  * Added the :c:func:`nrf_cloud_coap_shadow_desired_update` function to allow devices to reject invalid shadow deltas.
+
 Libraries for NFC
 -----------------
 

--- a/include/net/nrf_cloud_coap.h
+++ b/include/net/nrf_cloud_coap.h
@@ -26,6 +26,17 @@ extern "C" {
 
 /**
  * @defgroup nrf_cloud_coap nRF CoAP API
+ *
+ * @brief The functions in this library can return either positive or negative return values.
+ *
+ * @details Negative values are standard device-side errors defined in errno.h. These indicate
+ * a failure to send the request to the cloud for various reasons, such as the device
+ * is not connected to the cloud or the request contains invalid parameters.
+ *
+ * Positive values are cloud-side errors (CoAP result codes). These indicate the
+ * cloud received the request but rejected it. This can occur either because of the
+ * request itself or because of a cloud-side error. See the specific result code for
+ * details. These are defined in zephyr/net/coap.h.
  * @{
  */
 
@@ -44,7 +55,10 @@ int nrf_cloud_coap_init(void);
  *
  * @param app_ver Version to report to the shadow; can be NULL.
  *
- * @return 0 if authorized successfully, otherwise, a negative error number.
+ * @return 0 if authorized successfully, otherwise, an error number.
+ *           Negative values are device-side errors defined in errno.h.
+ *           Positive values are cloud-side errors (CoAP result codes)
+ *           defined in zephyr/net/coap.h.
  */
 int nrf_cloud_coap_connect(const char * const app_ver);
 
@@ -105,7 +119,8 @@ int nrf_cloud_coap_disconnect(void);
  *          request type.
  *  @retval -ENOBUFS will be returned, and an error message printed, if there is not enough
  *          buffer space to store retrieved A-GNSS data.
- * @retval 0 If successful.
+ * @return 0 If successful. Positive values are cloud-side errors (CoAP result codes)
+ *           defined in zephyr/net/coap.h.
  */
 int nrf_cloud_coap_agnss_data_get(struct nrf_cloud_rest_agnss_request const *const request,
 				  struct nrf_cloud_rest_agnss_result *result);
@@ -120,8 +135,10 @@ int nrf_cloud_coap_agnss_data_get(struct nrf_cloud_rest_agnss_request const *con
  * @param[in,out] file_location Structure that will contain the host and path to
  *                              the prediction file.
  *
- * @retval 0 If successful.
- *          Otherwise, a (negative) error code is returned.
+ * @return 0 If successful, nonzero if failed.
+ *           Negative values are device-side errors defined in errno.h.
+ *           Positive values are cloud-side errors (CoAP result codes)
+ *           defined in zephyr/net/coap.h.
  */
 int nrf_cloud_coap_pgps_url_get(struct nrf_cloud_rest_pgps_request const *const request,
 				 struct nrf_cloud_pgps_result *file_location);
@@ -140,8 +157,10 @@ int nrf_cloud_coap_pgps_url_get(struct nrf_cloud_rest_pgps_request const *const 
  * @param[in]     ts_ms  Timestamp the data was measured, or NRF_CLOUD_NO_TIMESTAMP.
  * @param[in]     confirmable Select whether to use a CON or NON CoAP transfer.
  *
- * @retval 0 If successful.
- *          Otherwise, a (negative) error code is returned.
+ * @return 0 If successful, nonzero if failed.
+ *           Negative values are device-side errors defined in errno.h.
+ *           Positive values are cloud-side errors (CoAP result codes)
+ *           defined in zephyr/net/coap.h.
  */
 int nrf_cloud_coap_sensor_send(const char *app_id, double value, int64_t ts_ms, bool confirmable);
 
@@ -160,8 +179,10 @@ int nrf_cloud_coap_sensor_send(const char *app_id, double value, int64_t ts_ms, 
  * @param[in]     ts_ms      Timestamp the data was measured, or NRF_CLOUD_NO_TIMESTAMP.
  * @param[in]     confirmable Select whether to use a CON or NON CoAP transfer.
  *
- * @retval 0 If successful.
- *          Otherwise, a (negative) error code is returned.
+ * @return 0 If successful, nonzero if failed.
+ *           Negative values are device-side errors defined in errno.h.
+ *           Positive values are cloud-side errors (CoAP result codes)
+ *           defined in zephyr/net/coap.h.
  */
 int nrf_cloud_coap_message_send(const char *app_id, const char *message, bool json, int64_t ts_ms,
 				bool confirmable);
@@ -178,8 +199,10 @@ int nrf_cloud_coap_message_send(const char *app_id, const char *message, bool js
  *                           to be sent to the bulk topic.
  * @param[in]     confirmable Select whether to use a CON or NON CoAP transfer.
  *
- * @retval 0 If successful.
- *          Otherwise, a (negative) error code is returned.
+ * @return 0 If successful, nonzero if failed.
+ *           Negative values are device-side errors defined in errno.h.
+ *           Positive values are cloud-side errors (CoAP result codes)
+ *           defined in zephyr/net/coap.h.
  */
 int nrf_cloud_coap_json_message_send(const char *message, bool bulk, bool confirmable);
 
@@ -193,8 +216,10 @@ int nrf_cloud_coap_json_message_send(const char *message, bool bulk, bool confir
  *                     location, usually as determined by the GNSS unit.
  * @param[in]     confirmable Select whether to use a CON or NON CoAP transfer.
  *
- * @retval 0 If successful.
- *          Otherwise, a (negative) error code is returned.
+ * @return 0 If successful, nonzero if failed.
+ *           Negative values are device-side errors defined in errno.h.
+ *           Positive values are cloud-side errors (CoAP result codes)
+ *           defined in zephyr/net/coap.h.
  */
 int nrf_cloud_coap_location_send(const struct nrf_cloud_gnss_data * const gnss, bool confirmable);
 
@@ -206,8 +231,10 @@ int nrf_cloud_coap_location_send(const struct nrf_cloud_gnss_data * const gnss, 
  * @param[in]     request Data to be provided in API call.
  * @param[in,out] result Location information.
  *
- * @return 0 if the request succeeded, a positive value indicating a CoAP result code,
- * or a negative error number.
+ * @return 0 If successful, nonzero if failed.
+ *           Negative values are device-side errors defined in errno.h.
+ *           Positive values are cloud-side errors (CoAP result codes)
+ *           defined in zephyr/net/coap.h.
  */
 int nrf_cloud_coap_location_get(struct nrf_cloud_rest_location_request const *const request,
 				struct nrf_cloud_location_result *const result);
@@ -220,8 +247,10 @@ int nrf_cloud_coap_location_get(struct nrf_cloud_rest_location_request const *co
  *                    @ref nrf_cloud_coap_fota_job_free to free the memory
  *                    allocated by this function.
  *
- * @return 0 if the request succeeded, a positive value indicating a CoAP result code,
- * or a negative error number.
+ * @return 0 If successful, nonzero if failed.
+ *           Negative values are device-side errors defined in errno.h.
+ *           Positive values are cloud-side errors (CoAP result codes)
+ *           defined in zephyr/net/coap.h.
  */
 int nrf_cloud_coap_fota_job_get(struct nrf_cloud_fota_job_info *const job);
 
@@ -241,8 +270,10 @@ void nrf_cloud_coap_fota_job_free(struct nrf_cloud_fota_job_info *const job);
  * @param[in]     details Null-terminated string containing details of the
  *                job, such as an error description.
  *
- * @return 0 if the request succeeded, a positive value indicating a CoAP result code,
- * or a negative error number.
+ * @return 0 If successful, nonzero if failed.
+ *           Negative values are device-side errors defined in errno.h.
+ *           Positive values are cloud-side errors (CoAP result codes)
+ *           defined in zephyr/net/coap.h.
  */
 int nrf_cloud_coap_fota_job_update(const char *const job_id,
 	const enum nrf_cloud_fota_status status, const char * const details);
@@ -258,28 +289,50 @@ int nrf_cloud_coap_fota_job_update(const char *const job_id,
  * @param[in]     delta   True to request only changes in the shadow, if any; otherwise,
  *                        all of desired part.
  *
- * @return 0 if the request succeeded, a positive value indicating a CoAP result code,
- * or a negative error number.
+ * @return 0 If successful, nonzero if failed.
+ *           Negative values are device-side errors defined in errno.h.
+ *           Positive values are cloud-side errors (CoAP result codes)
+ *           defined in zephyr/net/coap.h.
  */
 int nrf_cloud_coap_shadow_get(char *buf, size_t buf_len, bool delta);
 
 /**
- * @brief Update the device's "state" in the shadow via the UpdateDeviceState endpoint.
+ * @brief Update the device's "reported state" in the shadow through the state/update CoAP resource.
+ * This is used both to report the current state of the device as well as to accept settings
+ * changes received in a shadow delta.
  *
  * @param[in]     shadow_json Null-terminated JSON string to be written to the device's shadow.
  *
- * @return 0 if the request succeeded, a positive value indicating a CoAP result code,
- * or a negative error number.
+ * @return 0 If successful, nonzero if failed.
+ *           Negative values are device-side errors defined in errno.h.
+ *           Positive values are cloud-side errors (CoAP result codes)
+ *           defined in zephyr/net/coap.h.
  */
 int nrf_cloud_coap_shadow_state_update(const char * const shadow_json);
 
 /**
- * @brief Update the device status in the shadow.
+ * @brief Update the device's "desired state" in the shadow through the state/desired CoAP resource.
+ * Normally, this is only used to silence a shadow delta that is incompatible with the device,
+ * by overwriting the invalid desired values with the reported values.
+ *
+ * @param[in]     shadow_json Null-terminated JSON string to be written to the device's shadow.
+ *
+ * @return 0 If successful, nonzero if failed.
+ *           Negative values are device-side errors defined in errno.h.
+ *           Positive values are cloud-side errors (CoAP result codes)
+ *           defined in zephyr/net/coap.h.
+ */
+int nrf_cloud_coap_shadow_desired_update(const char * const shadow_json);
+
+/**
+ * @brief Update the device status in the shadow's reported state section.
  *
  * @param[in]     dev_status Device status to be encoded.
  *
- * @return 0 if the request succeeded, a positive value indicating a CoAP result code,
- * or a negative error number.
+ * @return 0 If successful, nonzero if failed.
+ *           Negative values are device-side errors defined in errno.h.
+ *           Positive values are cloud-side errors (CoAP result codes)
+ *           defined in zephyr/net/coap.h.
  */
 int nrf_cloud_coap_shadow_device_status_update(const struct nrf_cloud_device_status
 					       *const dev_status);
@@ -289,8 +342,10 @@ int nrf_cloud_coap_shadow_device_status_update(const struct nrf_cloud_device_sta
  *
  * @param[in]     svc_inf Service info items to be updated in the shadow.
  *
- * @return 0 if the request succeeded, a positive value indicating a CoAP result code,
- * or a negative error number.
+ * @return 0 If successful, nonzero if failed.
+ *           Negative values are device-side errors defined in errno.h.
+ *           Positive values are cloud-side errors (CoAP result codes)
+ *           defined in zephyr/net/coap.h.
  */
 int nrf_cloud_coap_shadow_service_info_update(const struct nrf_cloud_svc_info * const svc_inf);
 
@@ -319,8 +374,10 @@ int nrf_cloud_coap_shadow_delta_process(const struct nrf_cloud_data *in_data,
  * @param[in]     buf buffer with binary string.
  * @param[in]     buf_len  length of buf in bytes.
  * @param[in]     confirmable Select whether to use a CON or NON CoAP transfer.
- * @retval 0 If successful.
- *          Otherwise, a (negative) error code is returned.
+ * @return 0 If successful, nonzero if failed.
+ *           Negative values are device-side errors defined in errno.h.
+ *           Positive values are cloud-side errors (CoAP result codes)
+ *           defined in zephyr/net/coap.h.
  */
 int nrf_cloud_coap_bytes_send(uint8_t *buf, size_t buf_len, bool confirmable);
 
@@ -336,8 +393,10 @@ int nrf_cloud_coap_bytes_send(uint8_t *buf, size_t buf_len, bool confirmable);
  * NRF_CLOUD_ENC_SRC_NONE.
  * @param[in]     confirmable Select whether to use a CON or NON CoAP transfer.
  *
- * @return 0 if the request succeeded, a positive value indicating a CoAP result code,
- * or a negative error number.
+ * @return 0 If successful, nonzero if failed.
+ *           Negative values are device-side errors defined in errno.h.
+ *           Positive values are cloud-side errors (CoAP result codes)
+ *           defined in zephyr/net/coap.h.
  */
 int nrf_cloud_coap_obj_send(struct nrf_cloud_obj *const obj, bool confirmable);
 

--- a/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap_transport.c
+++ b/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap_transport.c
@@ -317,7 +317,7 @@ int nrf_cloud_coap_connect(const char * const app_ver)
 	}
 
 	err = nrf_cloud_coap_authenticate();
-	if (err < 0) {
+	if (err) {
 		goto fail;
 	}
 

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec_internal.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec_internal.c
@@ -4056,9 +4056,7 @@ int nrf_cloud_coap_shadow_default_process(struct nrf_cloud_obj_shadow_data *cons
 int nrf_cloud_shadow_control_process(struct nrf_cloud_obj_shadow_data *const input,
 				     struct nrf_cloud_data *const response_out)
 {
-	if (!input) {
-		return -EINVAL;
-	}
+	__ASSERT_NO_MSG(input != NULL);
 
 	NRF_CLOUD_OBJ_JSON_DEFINE(ctrl_obj);
 	enum nrf_cloud_ctrl_status ctrl_status = NRF_CLOUD_CTRL_NOT_PRESENT;
@@ -4123,6 +4121,9 @@ int nrf_cloud_shadow_control_process(struct nrf_cloud_obj_shadow_data *const inp
 		if (err) {
 			LOG_ERR("nrf_cloud_shadow_control_response_encode failed %d", err);
 			return -EIO;
+		}
+		if (ctrl_status == NRF_CLOUD_CTRL_REJECT) {
+			return -EINVAL;
 		}
 	}
 


### PR DESCRIPTION
Use the state/desired resource to modify the desired section of the shadow. This is usually used to reject a shadow delta value that the application cannot
accept.

Jira: IRIS-8338