### PR TITLE
doc: Matter: improve Matter versions table

### DIFF
--- a/doc/nrf/protocols/matter/overview/dev_model.rst
+++ b/doc/nrf/protocols/matter/overview/dev_model.rst
@@ -34,23 +34,25 @@ For more information about Matter architecture and Matter in the |NCS|, read :re
 Supported Matter versions in the |NCS|
 ======================================
 
-The following table lists Matter versions supported in the |NCS|, with a brief overview of changes and the release date.
+The following table lists Matter versions supported in the |NCS|, with a brief overview of changes.
+The table also lists the release date for that Matter specification version, and the version of the |NCS| that added support for it.
 
-+-----------------+----------------------------------------------------------------------------------------------------------+---------------------+
-| Matter version  | Overview of changes                                                                                      | Release date        |
-+=================+==========================================================================================================+=====================+
-| 1.2.0           | - Introduced support for the ICD Management cluster.                                                     | October 23, 2023    |
-|                 | - Added the Product Appearance attribute in the Basic Information cluster.                               |                     |
-|                 | - Added nine new :ref:`device types <ug_matter_device_types>`:                                           |                     |
-|                 |   Refrigerator, Room Air Conditioner, Dishwasher, Laundry Washer, Robotic Vacuum Cleaner,                |                     |
-|                 |   Smoke CO Alarm, Air Quality Sensor, Air Purifier, and Fan.                                             |                     |
-+-----------------+----------------------------------------------------------------------------------------------------------+---------------------+
-| 1.1.0           | - Improved Intermittently Connected Device (ICD) support:                                                | May 18, 2023        |
-|                 |   more :ref:`ug_matter_configuring_optional_persistent_subscriptions`.                                   |                     |
-|                 | - Enhancements and bug fixes for Matter Specification, Certification Test Plan, and the Matter SDK.      |                     |
-+-----------------+----------------------------------------------------------------------------------------------------------+---------------------+
-| 1.0.0           | Initial version of the Matter specification.                                                             | November 2, 2022    |
-+-----------------+----------------------------------------------------------------------------------------------------------+---------------------+
++-----------------+----------------------------------------------------------------------------------------------------------+-----------------------+------------------+
+|                 |                                                                                                          | Specification         | |NCS| version    |
+| Matter version  | Overview of changes                                                                                      | release date          |                  |
++=================+==========================================================================================================+=======================+==================+
+| 1.2.0           | - Introduced support for the ICD Management cluster.                                                     | October 23, 2023      | v2.6.0           |
+|                 | - Added the Product Appearance attribute in the Basic Information cluster.                               |                       |                  |
+|                 | - Added nine new :ref:`device types <ug_matter_device_types>`:                                           |                       |                  |
+|                 |   Refrigerator, Room Air Conditioner, Dishwasher, Laundry Washer, Robotic Vacuum Cleaner,                |                       |                  |
+|                 |   Smoke CO Alarm, Air Quality Sensor, Air Purifier, and Fan.                                             |                       |                  |
++-----------------+----------------------------------------------------------------------------------------------------------+-----------------------+------------------+
+| 1.1.0           | - Improved Intermittently Connected Device (ICD) support:                                                | May 18, 2023          | v2.4.0           |
+|                 |   more :ref:`ug_matter_configuring_optional_persistent_subscriptions`.                                   |                       |                  |
+|                 | - Enhancements and bug fixes for Matter Specification, Certification Test Plan, and the Matter SDK.      |                       |                  |
++-----------------+----------------------------------------------------------------------------------------------------------+-----------------------+------------------+
+| 1.0.0           | Initial version of the Matter specification.                                                             | October 4, 2022       | v2.1.2           |
++-----------------+----------------------------------------------------------------------------------------------------------+-----------------------+------------------+
 
 .. _ug_matter_overview_dev_model_ecosystems:
 


### PR DESCRIPTION
The Release date column of the Matter versions table could be read as meaning the release date for support in the NCS. This makes the column clearer, and adds another column that specifies the version of the NCS that added support for the given Matter specification version.