### PR TITLE
manifest: update upstream SHA for Matter

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -169,7 +169,7 @@ manifest:
       userdata:
         ncs:
           upstream-url: https://github.com/project-chip/connectedhomeip
-          upstream-sha: 8f66f4215bc0708efc8cc73bda80620e67d8955f
+          upstream-sha: 181b0cb14ff007ec912f2ba6627e05dfb066c008
           compare-by-default: false
     - name: nrf-802154
       repo-path: sdk-nrf-802154


### PR DESCRIPTION
Update upstream SHA for sdk-connectedhomeip project to be able to get a correct list of downstream patches with `west ncs-loot matter` command.