### PR TITLE
manifest: sdk-zephyr: Update hal_nordic revision to have nrfx 3.4.0

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: ecb16c791d10fdab4a41bd3dc790610dff5e9520
+      revision: pull/1578/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Updated hal_nordic revision contains nrfx 3.4.0 release, which implement support for nRF54H20 and nRF54L15 devices.