### PR TITLE
Pin link to Azure FOTA tutorial

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -885,7 +885,7 @@
 .. _`Windows 11`: https://www.microsoft.com/software-download/windows11
 .. _`Windows 10`: https://www.microsoft.com/en-us/software-download/windows10
 
-.. _`Azure Firmware Over The Air (FOTA)`: https://docs.microsoft.com/en-us/azure/iot-hub/tutorial-firmware-update
+.. _`Azure Firmware Over The Air (FOTA)`: https://web.archive.org/web/20200804235440/https://docs.microsoft.com/en-us/azure/iot-hub/tutorial-firmware-update
 .. _`Azure IoT Hub`: https://docs.microsoft.com/en-us/azure/iot-hub/
 .. _`Creating an Azure IoT Hub instance using the Azure portal`: https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-create-through-portal
 .. _`Azure IoT Hub Device Provisioning Service (DPS)`: https://docs.microsoft.com/en-us/azure/iot-dps/


### PR DESCRIPTION
Azure completely changed the content of the linked
page which creates the impression that the Azure
FOTA library implements Azure Device Update for
IoT Hub. This is not the case.