### PR TITLE
samples: cellular: modem_shell: ppp: fixes

### DIFF
--- a/samples/cellular/modem_shell/src/link/link_shell_pdn.c
+++ b/samples/cellular/modem_shell/src/link/link_shell_pdn.c
@@ -60,7 +60,12 @@ void link_pdn_event_handler(uint8_t cid, enum pdn_event event, int reason)
 			/* Notify PPP side about the default PDN activation status */
 			if (event == PDN_EVENT_ACTIVATED) {
 				ppp_ctrl_default_pdn_active(true);
-			} else if (event == PDN_EVENT_DEACTIVATED) {
+			} else if (event == PDN_EVENT_DEACTIVATED ||
+				   event == PDN_EVENT_NETWORK_DETACH) {
+				/* 3GPP 27.007 ch 10.1.19 for +CGEV: ME DETACH
+				 * This implies that all active contexts have been deactivated.
+				 * These are not reported separately.
+				 */
 				ppp_ctrl_default_pdn_active(false);
 			}
 #endif

--- a/samples/cellular/modem_shell/src/ppp/ppp_ctrl.c
+++ b/samples/cellular/modem_shell/src/ppp/ppp_ctrl.c
@@ -225,14 +225,6 @@ static void ppp_ctrl_net_mgmt_event_handler(struct net_mgmt_event_callback *cb,
 		}
 		break;
 	}
-	case NET_EVENT_PPP_CARRIER_ON: {
-		mosh_print("PPP carrier ON");
-		break;
-	}
-	case NET_EVENT_PPP_CARRIER_OFF: {
-		mosh_print("PPP carrier OFF");
-		break;
-	}
 	default:
 		break;
 	}
@@ -283,8 +275,6 @@ static void ppp_ctrl_net_mgmt_events_subscribe(void)
 				     ppp_ctrl_net_mgmt_event_handler,
 				     (NET_EVENT_IF_UP |
 				      NET_EVENT_IF_DOWN |
-				      NET_EVENT_PPP_CARRIER_ON |
-				      NET_EVENT_PPP_CARRIER_OFF |
 				      NET_EVENT_PPP_PHASE_RUNNING |
 				      NET_EVENT_PPP_PHASE_DEAD));
 
@@ -511,9 +501,9 @@ clear:
 
 void ppp_ctrl_stop(void)
 {
+	ppp_up = false;
 	ppp_ctrl_stop_net_if();
 	ppp_ctrl_close_sckts();
 
 	mosh_print("PPP: stopped");
-	ppp_up = false;
 }


### PR DESCRIPTION
Following fixes to mosh PPP functionality:
- Consecutive `ppp down` and _ppp up_ again wasn't working always correctly. Will work even better when Zephyr PR is included in ncs: https://github.com/zephyrproject-rtos/zephyr/pull/67731
With that also PC side notices `ppp down`.
- mosh ppp side is notified about the PDN detach.
