### PR TITLE
samples: cellular: modem_shell: ping: cross-border fix

### DIFF
--- a/samples/cellular/modem_shell/src/ping/icmp_ping.h
+++ b/samples/cellular/modem_shell/src/ping/icmp_ping.h
@@ -55,6 +55,8 @@ struct icmp_ping_shell_cmd_argv {
 	uint32_t interval;
 	bool force_ipv6;
 	bool rai;
+
+	int64_t pdn_ctx_info_read_uptime;
 };
 
 /**


### PR DESCRIPTION
Re-reading PDN ctx info if receiving new reg status home/roaming indication during pinging.
DUT couldn't send ping are crossing border from Sweden to Denmark. DUT IP address was changing when running ping but mosh ping set source and destination IP just once, at the beginning of the sequence. Now, src/dst are set if receiving new reg status indication from lte_lc. 
Jira: MOSH-526, MOSH-547