### PR TITLE
app_event_manager: Improve OOM error handling

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -371,6 +371,11 @@ Other libraries
 
 * Added the :ref:`lib_uart_async_adapter` library.
 
+* :ref:`app_event_manager`:
+
+  * Added the :kconfig:option:`CONFIG_APP_EVENT_MANAGER_REBOOT_ON_EVENT_ALLOC_FAIL` Kconfig option.
+    The option allows to select between system reboot or kernel panic on event allocation failure for default event allocator.
+
 Common Application Framework (CAF)
 ----------------------------------
 

--- a/subsys/app_event_manager/Kconfig
+++ b/subsys/app_event_manager/Kconfig
@@ -12,6 +12,16 @@ menuconfig APP_EVENT_MANAGER
 
 if APP_EVENT_MANAGER
 
+config APP_EVENT_MANAGER_REBOOT_ON_EVENT_ALLOC_FAIL
+	bool "Reboot on event allocation failure"
+	depends on REBOOT
+	default y
+	help
+	  The default event allocator triggers assertion failure on event
+	  allocation failure. Then, depending on the value of this Kconfig
+	  option, the default allocator either triggers a system reboot or
+	  kernel panic.
+
 config APP_EVENT_MANAGER_SHOW_EVENTS
 	bool "Show events"
 	depends on LOG

--- a/subsys/app_event_manager/app_event_manager.c
+++ b/subsys/app_event_manager/app_event_manager.c
@@ -121,7 +121,7 @@ void * __weak app_event_manager_alloc(size_t size)
 	if (unlikely(!event)) {
 		LOG_ERR("Application Event Manager OOM error\n");
 		__ASSERT_NO_MSG(false);
-		if (IS_ENABLED(CONFIG_REBOOT)) {
+		if (IS_ENABLED(CONFIG_APP_EVENT_MANAGER_REBOOT_ON_EVENT_ALLOC_FAIL)) {
 			sys_reboot(SYS_REBOOT_WARM);
 		} else {
 			k_panic();


### PR DESCRIPTION
Change improves out of memory error handling for default application event allocator. The CONFIG_APP_EVENT_MANAGER_REBOOT_ON_EVENT_ALLOC_FAIL Kconfig option was introduced to allow user to select between system reboot or kernel panic.