### PR TITLE
lib: fatal_error: Remove dead code

### DIFF
--- a/lib/fatal_error/fatal_error.c
+++ b/lib/fatal_error/fatal_error.c
@@ -20,16 +20,8 @@ void k_sys_fatal_error_handler(unsigned int reason,
 	ARG_UNUSED(reason);
 
 	LOG_PANIC();
-
-	if (IS_ENABLED(CONFIG_RESET_ON_FATAL_ERROR)) {
-		LOG_ERR("Resetting system");
-		sys_arch_reboot(0);
-	} else {
-		LOG_ERR("Halting system");
-		for (;;) {
-			/* Spin endlessly */
-		}
-	}
+	LOG_ERR("Resetting system");
+	sys_arch_reboot(0);
 
 	CODE_UNREACHABLE;
 }


### PR DESCRIPTION
The fatal_error.c file is compiled only if CONFIG_RESET_ON_FATAL_ERROR is enabled. The removed check is not needed.