### PR TITLE
drivers/mpsl/flash_synch: MPSL choice for nRF54L15

### DIFF
--- a/drivers/mpsl/flash_sync/Kconfig
+++ b/drivers/mpsl/flash_sync/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-if SOC_FLASH_NRF
+if SOC_FLASH_NRF || SOC_FLASH_NRF_RRAM
 
 choice SOC_FLASH_NRF_RADIO_SYNC_CHOICE
 	prompt "Nordic nRFx flash driver synchronization"


### PR DESCRIPTION
Made MPSL based synchronization mechanism available for nRF54L15 too.