### PR TITLE
bluetooth: controller: set bits 22 and 23 in supported states

### DIFF
--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -833,7 +833,7 @@ static void le_read_supported_states(uint8_t *buf)
 	 * Initiating State + Passive Scanning
 	 * Initiating State + Active Scanning
 	 */
-	states1 &= ~(BIT(22) | BIT(23));
+	// states1 &= ~(BIT(22) | BIT(23));
 	*buf = states1;
 	*(buf + 4) = states2;
 }


### PR DESCRIPTION
Set bits 22 and 23 for initiating while doing active/passive scanning