### PR TITLE
[DRAFT] Get rid of FEM gain

### DIFF
--- a/include/fem_al/fem_al.h
+++ b/include/fem_al/fem_al.h
@@ -34,6 +34,12 @@ enum fem_antenna {
 	FEM_ANTENNA_2
 };
 
+/**@brief Type holding Tx power control to be applied to front-end module.
+ * 
+ * @note The value stored in this type is specific to the FEM type in use.
+ */
+typedef uint32_t fem_tx_power_control;
+
 /**@brief Initialize the front-end module.
  *
  * @param[in] timer_instance Pointer to a 1-us resolution timer instance.
@@ -68,17 +74,17 @@ int fem_power_up(void);
  */
 int fem_power_down(void);
 
-/**@brief Configure Tx gain of the front-end module in arbitrary units.
+/**@brief Configure Tx power control of the front-end module.
  *
- * @param[in] gain Tx gain in arbitrary units specific for used front-end module implementation.
+ * @param[in] tx_power_control Tx power control specific to the front-end module implementation.
  *                 For nRF21540 GPIO/SPI, this is a register value.
  *                 For nRF21540 GPIO, this is MODE pin value.
- *                 Check your front-end module product specification for gain value range.
+ *                 Check your front-end module product specification for Tx power control value range.
  *
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.
  */
-int fem_tx_gain_set(uint32_t gain);
+int fem_tx_power_control_set(fem_tx_power_control tx_power_control);
 
 /**@brief Get the default radio ramp-up time for reception or transmission with a given data rate
  *        and modulation.
@@ -145,11 +151,11 @@ uint32_t fem_radio_tx_ramp_up_delay_get(bool fast, nrf_radio_mode_t mode);
  */
 uint32_t fem_radio_rx_ramp_up_delay_get(bool fast, nrf_radio_mode_t mode);
 
-/**@brief Set the front-end module gain and returns output power to be set on the radio peripheral
- *        to get requested output power.
+/**@brief Set the front-end module Tx power control and returns output power
+ *        to be set on the radio peripheral to get requested output power.
  *
  * This function calculates power value for RADIO peripheral register and
- * sets front-end module gain value.
+ * sets front-end module Tx power control value.
  *
  * @note If the exact value of @p power cannot be achieved, this function attempts to use less
  *       power to not exceed the limits.
@@ -204,11 +210,11 @@ static inline int8_t fem_tx_output_power_max_get(uint16_t freq_mhz)
 	return fem_tx_output_power_check(INT8_MAX, freq_mhz, true);
 }
 
-/**@brief Get the front-end module default Tx gain.
+/**@brief Get the front-end module default Tx output power.
  *
- * @return The front-end module default Tx gain value.
+ * @return The front-end module default Tx output power value.
  */
-uint32_t fem_default_tx_gain_get(void);
+int8_t fem_default_tx_output_power_get(void);
 
 /**@brief Apply the workaround for the Errata 254, 255, 256, 257 when appropriate.
  *

--- a/lib/fem_al/fem_al.c
+++ b/lib/fem_al/fem_al.c
@@ -198,37 +198,26 @@ int fem_rx_configure(uint32_t ramp_up_time)
 	return 0;
 }
 
-int fem_tx_gain_set(uint32_t gain)
+int fem_tx_power_control_set(fem_tx_power_control tx_power_control)
 {
 	int32_t err;
-	mpsl_fem_gain_t fem_gain = { 0 };
+	mpsl_fem_pa_power_control_t fem_pa_power_control = { 0 };
 
 	/* Fallback to FEM specific function. It can be used for checking the valid output power
 	 * range.
 	 */
-	if (fem_api->tx_gain_validate) {
-		err = fem_api->tx_gain_validate(gain);
+	if (fem_api->tx_power_control_validate) {
+		err = fem_api->tx_power_control_validate(tx_power_control);
 		if (err) {
 			return err;
 		}
 	}
 
-	if (!fem_api->tx_default_gain_get) {
-		/* Should not happen. */
-		__ASSERT(false, "Missing FEM specific function for getting default Tx gain");
-		return -EFAULT;
-	}
+	fem_pa_power_control.private_setting = tx_power_control;
 
-	/* We need to pass valid gain db value for given front-end module to have possibility to set
-	 * gain value directly in arbitrary value defined in your front-end module
-	 * product specification. In this case the default Tx gain value will be used.
-	 */
-	fem_gain.gain_db = fem_api->tx_default_gain_get();
-	fem_gain.private_setting = gain;
-
-	err = mpsl_fem_pa_gain_set(&fem_gain);
+	err = mpsl_fem_pa_power_control_set(&fem_pa_power_control);
 	if (err) {
-		printk("Failed to set front-end module gain (err %d)\n", err);
+		printk("Failed to set front-end module Tx power control (err %d)\n", err);
 		return -EINVAL;
 	}
 
@@ -268,10 +257,10 @@ int8_t fem_tx_output_power_prepare(int8_t power, int8_t *radio_tx_power, uint16_
 
 	*radio_tx_power = power_split.radio_tx_power;
 
-	err = mpsl_fem_pa_gain_set(&power_split.fem);
+	err = mpsl_fem_pa_power_control_set(&power_split.fem);
 	if (err) {
 		/* Should not happen */
-		printk("Failed to set front-end module gain (err %d)\n", err);
+		printk("Failed to set front-end module Tx power control (err %d)\n", err);
 		__ASSERT_NO_MSG(false);
 	}
 
@@ -285,10 +274,10 @@ int8_t fem_tx_output_power_check(int8_t power, uint16_t freq_mhz, bool tx_power_
 	return mpsl_fem_tx_power_split(power, &power_split, freq_mhz, tx_power_ceiling);
 }
 
-uint32_t fem_default_tx_gain_get(void)
+int8_t fem_default_tx_output_power_get(void)
 {
-	if (fem_api->tx_default_gain_get) {
-		return fem_api->tx_default_gain_get();
+	if (fem_api->default_tx_output_power_get) {
+		return fem_api->default_tx_output_power_get();
 	}
 
 	return 0;

--- a/lib/fem_al/fem_interface.h
+++ b/lib/fem_al/fem_interface.h
@@ -28,8 +28,8 @@ extern "C" {
 struct fem_interface_api {
 	int (*power_up)(void);
 	int (*power_down)(void);
-	int (*tx_gain_validate)(uint32_t gain);
-	uint32_t (*tx_default_gain_get)(void);
+	int (*tx_power_control_validate)(fem_tx_power_control tx_power_control);
+	int8_t (*default_tx_output_power_get)(void);
 	uint32_t (*default_active_delay_calculate)(bool rx, nrf_radio_mode_t mode);
 	int (*antenna_select)(enum fem_antenna ant);
 };

--- a/lib/fem_al/generic_fem.c
+++ b/lib/fem_al/generic_fem.c
@@ -148,7 +148,7 @@ static int generic_fem_power_down(void)
 	return err;
 }
 
-static uint32_t tx_default_gain_get(void)
+static int8_t default_tx_output_power_get(void)
 {
 	return DT_PROP(DT_NODELABEL(nrf_radio_fem), tx_gain_db);
 }
@@ -188,7 +188,7 @@ static const struct fem_interface_api generic_fem_api = {
 	.power_up = generic_fem_power_up,
 	.power_down = generic_fem_power_down,
 	.antenna_select = generic_fem_antenna_select,
-	.tx_default_gain_get = tx_default_gain_get,
+	.default_tx_output_power_get = default_tx_output_power_get,
 };
 
 static int generic_fem_setup(void)

--- a/lib/fem_al/nrf21540.c
+++ b/lib/fem_al/nrf21540.c
@@ -64,16 +64,16 @@ static int nrf21540_init(void)
 	return 0;
 }
 
-static int tx_gain_validate(uint32_t gain)
+static int tx_power_control_validate(fem_tx_power_control tx_power_control)
 {
 	if (IS_ENABLED(CONFIG_MPSL_FEM_NRF21540_GPIO_SPI)) {
-		return (gain > NRF21540_TX_GAIN_MAX) ? -EINVAL : 0;
+		return (tx_power_control > NRF21540_TX_GAIN_MAX) ? -EINVAL : 0;
 	} else {
-		return ((gain == 0) || (gain == 1)) ? 0 : -EINVAL;
+		return ((tx_power_control == 0) || (tx_power_control == 1)) ? 0 : -EINVAL;
 	}
 }
 
-static uint32_t tx_default_gain_get(void)
+static int8_t default_tx_output_power_get(void)
 {
 	return CONFIG_MPSL_FEM_NRF21540_TX_GAIN_DB;
 }
@@ -108,8 +108,8 @@ static int nrf21540_antenna_select(enum fem_antenna ant)
 #endif /* DT_NODE_HAS_PROP(NRF21540_NODE, ant_sel_gpios) */
 
 static const struct fem_interface_api nrf21540_api = {
-	.tx_gain_validate = tx_gain_validate,
-	.tx_default_gain_get = tx_default_gain_get,
+	.tx_power_control_validate = tx_power_control_validate,
+	.default_tx_output_power_get = default_tx_output_power_get,
 	.antenna_select = nrf21540_antenna_select
 };
 

--- a/samples/bluetooth/direct_test_mode/README.rst
+++ b/samples/bluetooth/direct_test_mode/README.rst
@@ -152,7 +152,7 @@ The behavior of the commands vary depending on the hardware configuration and Kc
      Additionally, you can use following vendor-specific commands:
 
       * The ``SET_TX_POWER`` command sets the SoC TX output power.
-      * The ``FEM_GAIN_SET`` command sets the front-end module gain.
+      * The ``FEM_TX_POWER_CONTROL_SET`` command sets the front-end module gain.
 
 Bluetooth Direction Finding support
 ===================================
@@ -289,9 +289,10 @@ Vendor-specific commands can be divided into different categories as follows:
      * ``0`` - ANT1 enabled, ANT2 disabled
      * ``1`` - ANT1 disabled, ANT2 enabled
 
-* If the **Length** field is set to ``4`` (symbol ``FEM_GAIN_SET``), the **Frequency** field sets the front-end module (FEM) TX gain value in arbitrary units.
+* If the **Length** field is set to ``4`` (symbol ``FEM_TX_POWER_CONTROL_SET``), the **Frequency** field sets the front-end module (FEM) TX power control value and is specific to the FEM type in use.
   The valid gain values are specified in your product-specific front-end module (FEM).
-  For example, in the nRF21540 front-end module, the gain range is 0 - 31.
+  For example, in the nRF21540 front-end module with GPIO interface, the tx power control range is 0 (POUTA) to 1 (POUTB).
+  For example, in the nRF21540 front-end module with GPIO?SPI, the tx power control range is 0 - 31 and is the value of TX_GAIN field of CONFREG0 register.
 * If the **Length** field is set to ``5`` (symbol ``FEM_ACTIVE_DELAY_SET``), the **Frequency** field sets the front-end module (FEM) activation delay in microseconds relative to the radio start.
   By default, this value is set to ``radio ramp-up time - front-end module (FEM) TX/RX settling time``.
 * If the **Length** field is set to ``6`` (symbol ``FEM_DEFAULT_PARAMS_SET``) and the **Frequency** field to any value, the front-end module parameters, such as ``antenna output``, ``gain``, and ``delay``, are set to their default values.
@@ -309,7 +310,7 @@ Vendor-specific commands can be divided into different categories as follows:
    When you build the DTM sample with support for front-end modules and the :ref:`CONFIG_DTM_POWER_CONTROL_AUTOMATIC <CONFIG_DTM_POWER_CONTROL_AUTOMATIC>` Kconfig option is enabled, the following vendor-specific command are not available:
 
    * ``SET_TX_POWER``
-   * ``FEM_GAIN_SET``
+   * ``FEM_TX_POWER_CONTROL_SET``
 
    You can disable the :ref:`CONFIG_DTM_POWER_CONTROL_AUTOMATIC <CONFIG_DTM_POWER_CONTROL_AUTOMATIC>` Kconfig option if you want to set the SoC output power and the front-end module gain by separate commands.
    The official DTM command ``0x09`` for setting power level takes into account the SoC output power and the front-end module gain to set the total requested output power.

--- a/samples/peripheral/radio_test/README.rst
+++ b/samples/peripheral/radio_test/README.rst
@@ -43,7 +43,7 @@ nRF21540 front-end module
 
 .. include:: /includes/sample_dtm_radio_test_fem.txt
 
-You can configure the nRF21540 front-end module (FEM) transmitted power gain, antenna output and activation delay using the main shell commands of the :ref:`radio_test_ui`.
+You can configure the nRF21540 front-end module (FEM) transmitted power control, antenna output and activation delay using the main shell commands of the :ref:`radio_test_ui`.
 
 Skyworks front-end module
 =========================
@@ -152,13 +152,13 @@ The behavior of the commands vary depending on the hardware configuration and Kc
 
   * The ``output_power`` command sets the total output power, including front-end module gain.
   * The ``total_output_power`` command sets the total output power, including front-end module gain with a value in dBm unit provided by user.
-  * For these commands, the radio peripheral and FEM gain is calculated and set automatically to meet your requirements.
+  * For these commands, the radio peripheral and FEM transmit power control is calculated and set automatically to meet your requirements.
   * If an exact output power value cannot be set, a lower value is used.
 
 * Radio Test with front-end module support and manual Tx output power control (the :kconfig:option:`CONFIG_RADIO_TEST_POWER_CONTROL_AUTOMATIC` Kconfig option is disabled):
 
   * The ``output_power`` command sets the SoC output command with a subcommands set.
-  * The ``fem`` command with the ``tx_gain`` subcommand sets the front-end module gain to an arbitrary value for given front-end module.
+  * The ``fem`` command with the ``tx_power_control`` subcommand sets the front-end module transmit power control to a value for given specific front-end module.
   * You can use this configuration to perform tests on your hardware design.
 
 Building and running

--- a/samples/peripheral/radio_test/src/radio_cmd.c
+++ b/samples/peripheral/radio_test/src/radio_cmd.c
@@ -66,7 +66,7 @@ static struct radio_param_config {
 	.delay_ms = 10,
 	.duty_cycle = 50,
 #if CONFIG_FEM
-	.fem.gain = FEM_USE_DEFAULT_GAIN
+	.fem.tx_power_control = FEM_USE_DEFAULT_TX_POWER_CONTROL
 #endif /* CONFIG_FEM */
 };
 
@@ -224,8 +224,7 @@ static int cmd_tx_carrier_start(const struct shell *shell, size_t argc,
 	test_config.params.unmodulated_tx.txpower = config.txpower;
 	test_config.params.unmodulated_tx.channel = config.channel_start;
 #if CONFIG_FEM
-	test_config.fem.ramp_up_time = config.fem.ramp_up_time;
-	test_config.fem.gain = config.fem.gain;
+	test_config.fem = config.fem;
 #endif /* CONFIG_FEM */
 	radio_test_start(&test_config);
 
@@ -263,8 +262,7 @@ static int cmd_tx_modulated_carrier_start(const struct shell *shell,
 	test_config.params.modulated_tx.channel = config.channel_start;
 	test_config.params.modulated_tx.pattern = config.tx_pattern;
 #if CONFIG_FEM
-	test_config.fem.ramp_up_time = config.fem.ramp_up_time;
-	test_config.fem.gain = config.fem.gain;
+	test_config.fem = config.fem;
 #endif /* CONFIG_FEM */
 
 	if (argc == 2) {
@@ -316,8 +314,7 @@ static int cmd_duty_cycle_set(const struct shell *shell, size_t argc,
 	test_config.params.modulated_tx_duty_cycle.duty_cycle =
 		config.duty_cycle;
 #if CONFIG_FEM
-	test_config.fem.ramp_up_time = config.fem.ramp_up_time;
-	test_config.fem.gain = config.fem.gain;
+	test_config.fem = config.fem;
 #endif /* CONFIG_FEM */
 
 	radio_test_start(&test_config);
@@ -527,8 +524,7 @@ static int cmd_rx_sweep_start(const struct shell *shell, size_t argc,
 	test_config.params.rx_sweep.channel_end = config.channel_end;
 	test_config.params.rx_sweep.delay_ms = config.delay_ms;
 #if CONFIG_FEM
-	test_config.fem.ramp_up_time = config.fem.ramp_up_time;
-	test_config.fem.gain = config.fem.gain;
+	test_config.fem = config.fem;
 #endif /* CONFIG_FEM */
 
 	radio_test_start(&test_config);
@@ -550,8 +546,7 @@ static int cmd_tx_sweep_start(const struct shell *shell, size_t argc,
 	test_config.params.tx_sweep.delay_ms = config.delay_ms;
 	test_config.params.tx_sweep.txpower = config.txpower;
 #if CONFIG_FEM
-	test_config.fem.ramp_up_time = config.fem.ramp_up_time;
-	test_config.fem.gain = config.fem.gain;
+	test_config.fem = config.fem;
 #endif /* CONFIG_FEM */
 
 	radio_test_start(&test_config);
@@ -579,8 +574,7 @@ static int cmd_rx_start(const struct shell *shell, size_t argc, char **argv)
 	test_config.params.rx.channel = config.channel_start;
 	test_config.params.rx.pattern = config.tx_pattern;
 #if CONFIG_FEM
-	test_config.fem.ramp_up_time = config.fem.ramp_up_time;
-	test_config.fem.gain = config.fem.gain;
+	test_config.fem = config.fem;
 #endif /* CONFIG_FEM */
 
 	radio_test_start(&test_config);
@@ -928,10 +922,10 @@ static int cmd_fem(const struct shell *shell, size_t argc, char **argv)
 }
 
 #if !CONFIG_RADIO_TEST_POWER_CONTROL_AUTOMATIC
-static int cmd_fem_gain_set(const struct shell *shell, size_t argc,
+static int cmd_fem_tx_power_control_set(const struct shell *shell, size_t argc,
 			    char **argv)
 {
-	uint32_t gain;
+	uint32_t tx_power_control;
 
 	if (argc == 1) {
 		shell_help(shell);
@@ -943,11 +937,11 @@ static int cmd_fem_gain_set(const struct shell *shell, size_t argc,
 		return -EINVAL;
 	}
 
-	gain = atoi(argv[1]);
+	tx_power_control = atoi(argv[1]);
 
-	config.fem.gain = gain;
+	config.fem.tx_power_control = tx_power_control;
 
-	shell_print(shell, "Front-end module (FEM) Tx gain set to %d", gain);
+	shell_print(shell, "Front-end module (FEM) Tx power control set to %u", tx_power_control);
 
 	return 0;
 }
@@ -1091,9 +1085,9 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_fem_antenna,
 
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_fem,
 #if !CONFIG_RADIO_TEST_POWER_CONTROL_AUTOMATIC
-	SHELL_CMD(tx_gain, NULL,
-		  "Set the front-end module (FEM) Tx gain in an arbitrary units <gain>",
-		  cmd_fem_gain_set),
+	SHELL_CMD(tx_power_control, NULL,
+		  "Set the front-end module (FEM) Tx power control specific to the FEM in use <tx_power_control>.",
+		  cmd_fem_tx_power_control_set),
 #endif /* !CONFIG_RADIO_TEST_POWER_CONTROL_AUTOMATIC */
 	SHELL_CMD(antenna, &sub_fem_antenna,
 		  "Select the front-end module (FEM) antenna <sub_cmd>",
@@ -1197,7 +1191,7 @@ static int radio_cmd_init(void)
 	/* When front-end module is used, set output power to the front-end module
 	 * default gain.
 	 */
-	config.txpower = fem_default_tx_gain_get();
+	config.txpower = fem_default_tx_output_power_get();
 #endif /* CONFIG_RADIO_TEST_POWER_CONTROL_AUTOMATIC */
 
 	return radio_test_init(&test_config);

--- a/samples/peripheral/radio_test/src/radio_test.c
+++ b/samples/peripheral/radio_test/src/radio_test.c
@@ -286,12 +286,12 @@ static int fem_configure(bool rx, nrf_radio_mode_t mode,
 	}
 
 	if ((!IS_ENABLED(CONFIG_RADIO_TEST_POWER_CONTROL_AUTOMATIC)) &&
-	    (fem->gain != FEM_USE_DEFAULT_GAIN) &&
+	    (fem->tx_power_control != FEM_USE_DEFAULT_TX_POWER_CONTROL) &&
 	    !sweep_processing) {
-		err = fem_tx_gain_set(fem->gain);
+		err = fem_tx_power_control_set(fem->tx_power_control);
 		if (err) {
-			printk("%d: out of range FEM gain value or setting gain is not supported\n",
-				fem->gain);
+			printk("%u: out of range FEM Tx power control value or setting Tx power control is not supported\n",
+				fem->tx_power_control);
 			return err;
 		}
 	}
@@ -644,8 +644,8 @@ static void radio_sweep_start(uint8_t channel, uint32_t delay_ms)
 	(void)fem_power_up();
 
 	if ((!IS_ENABLED(CONFIG_RADIO_TEST_POWER_CONTROL_AUTOMATIC)) &&
-	    fem.gain != FEM_USE_DEFAULT_GAIN) {
-		(void)fem_tx_gain_set(fem.gain);
+	    fem.tx_power_control != FEM_USE_DEFAULT_TX_POWER_CONTROL) {
+		(void)fem_tx_power_control_set(fem.tx_power_control);
 	}
 #endif /* CONFIG_FEM */
 
@@ -725,8 +725,7 @@ static void radio_modulated_tx_carrier_duty_cycle(uint8_t mode, int8_t txpower,
 void radio_test_start(const struct radio_test_config *config)
 {
 #if CONFIG_FEM
-	fem.ramp_up_time = config->fem.ramp_up_time;
-	fem.gain = config->fem.gain;
+	fem = config->fem;
 #endif /* CONFIG_FEM */
 
 	switch (config->type) {

--- a/samples/peripheral/radio_test/src/radio_test.h
+++ b/samples/peripheral/radio_test/src/radio_test.h
@@ -9,6 +9,7 @@
 
 #include <zephyr/types.h>
 #include <hal/nrf_radio.h>
+#include <fem_al/fem_al.h>
 
 #ifdef NRF53_SERIES
 #ifndef RADIO_TXPOWER_TXPOWER_Pos3dBm
@@ -33,7 +34,7 @@
 /** IEEE 802.15.4 maximum channel. */
 #define IEEE_MAX_CHANNEL	26
 
-#define FEM_USE_DEFAULT_GAIN 0xFF
+#define FEM_USE_DEFAULT_TX_POWER_CONTROL 0xFF
 
 /**@brief Radio transmit and address pattern. */
 enum transmit_pattern {
@@ -73,11 +74,11 @@ struct radio_test_fem {
 	/* Front-end module radio ramp-up time in microseconds. */
 	uint32_t ramp_up_time;
 
-	/* Front-end module TX gain in arbitrary unit specific to given front-end module.
+	/* Front-end module TX power control specific to given front-end module.
 	 * For nRF21540 GPIO/SPI, this is a register value.
 	 * For nRF21540 GPIO, this is MODE pin value.
 	 */
-	uint8_t gain;
+	fem_tx_power_control tx_power_control;
 };
 
 /**@brief Radio test configuration. */

--- a/west.yml
+++ b/west.yml
@@ -142,7 +142,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 167fa4334ca40e501946b213ef7a62005db4ecce
+      revision: pull/1264/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m

--- a/west.yml
+++ b/west.yml
@@ -174,7 +174,7 @@ manifest:
     - name: nrf-802154
       repo-path: sdk-nrf-802154
       path: nrf-802154
-      revision: v2.6.0
+      revision: pull/463/head
       groups:
         - nrf-802154
     - name: dragoon


### PR DESCRIPTION
DO NOT MERGE.

This PR brings in sdc,mpsl,nrf_802154 with change to FEM API.

The MPSL FEM public API is changed. The `mpsl_fem_pa_gain_set` has been replaced by `mpsl_fem_pa_tx_control_set`. There is no more possibility of setting "gain". The real gain of FEM depends on many factors including but not limited to input power of the FEM, frequency, temperature, and the way the FEM is controlled.
The "gain" (attempted to be FEM type-independent) is turned into "pa_power_control" parameter which is FEM type-specific.

The SDC & nrf_802154 are aligned and are not affected in their public interface in any way (just aligned to mentioned API change).

The radio_test and direct_test_mode are changed only when `CONFIG_RADIO_TEST_POWER_CONTROL_AUTOMATIC=n`
The **radio_test sample** changes: the cli command
`fem tx_gain <gain>` makes no more sense and is turned into:
`fem tx_power_control <tx_power_control>` which is FEM type-specific.

The **direct_test_mode** sample is changed:
`FEM_GAIN_SET` which attempted to set FEM type-independent "gain" of the FEM makes no more sense and is turned into:
`FEM_TX_POWER_CONTROL_SET` allowing to set the FEM tx power control signalling which is again FEM type-specific.