### PR TITLE
net: nrf_provisioning: Add new API to set provisioning interval 

### DIFF
--- a/doc/nrf/libraries/networking/nrf_provisioning.rst
+++ b/doc/nrf/libraries/networking/nrf_provisioning.rst
@@ -156,10 +156,11 @@ The feature is enabled by selecting :kconfig:option:`CONFIG_NRF_PROVISIONING_SHE
    uart:~$ nrf_provisioning
    nrf_provisioning - nRF Provisioning commands
    Subcommands:
-     init   :Start the client
-     now    :Do provisioning now
-     token  :Get the attestation token
-     uuid   :Get device UUID
+     init: Start the client
+     now: Do provisioning now
+     token: Get the attestation token
+     uuid: Get device UUID
+     interval: Set provisioning interval
 
 Dependencies
 ************

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -363,6 +363,10 @@ Libraries for networking
   * Changed the library to read certificates as standard PEM format. Previously the certificates had to be manually converted to string format before compiling the application.
   * Replaced the ``CONFIG_MQTT_HELPER_CERTIFICATES_FILE`` Kconfig option with :kconfig:option:`CONFIG_MQTT_HELPER_CERTIFICATES_FOLDER`. The new option specifies the folder where the certificates are stored.
 
+* :ref:`lib_nrf_provisioning` library:
+
+   * Added the :c:func:`nrf_provisioning_set_interval` function to set the interval between provisioning attempts.
+
 Libraries for NFC
 -----------------
 

--- a/include/net/nrf_provisioning.h
+++ b/include/net/nrf_provisioning.h
@@ -106,6 +106,13 @@ int nrf_provisioning_init(struct nrf_provisioning_mm_change *mmode,
  */
 int nrf_provisioning_trigger_manually(void);
 
+/**
+ * @brief Set provisioning interval.
+ *
+ * @param interval Provisioning interval in seconds.
+ */
+void nrf_provisioning_set_interval(int interval);
+
 /** @} */
 
 #ifdef __cplusplus

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_coap.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_coap.c
@@ -134,7 +134,7 @@ static int dtls_setup(int fd)
 	}
 
 	/* Enable connection ID */
-	uint32_t dtls_cid = TLS_DTLS_CID_ENABLED;
+	uint32_t dtls_cid = TLS_DTLS_CID_SUPPORTED;
 
 	err = zsock_setsockopt(fd, SOL_TLS, TLS_DTLS_CID, &dtls_cid, sizeof(dtls_cid));
 	if (err) {

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_shell.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_shell.c
@@ -23,6 +23,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define NRF_PROVISIONING_HELP_INIT "Start the client"
 #define NRF_PROVISIONING_HELP_TOKEN "Get the attestation token"
 #define NRF_PROVISIONING_HELP_UUID "Get device UUID"
+#define NRF_PROVISIONING_HELP_INTERVAL "Set provisioning interval"
 
 static int cmd_now(const struct shell *sh, size_t argc, char **argv)
 {
@@ -73,12 +74,29 @@ static int cmd_uuid(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
+static int cmd_interval(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(sh);
+	ARG_UNUSED(argc);
+
+	if (argc < 2) {
+		shell_error(sh, "No interval provided");
+		shell_print(sh, "Usage: nrf_provisioning interval <seconds>");
+		return -EINVAL;
+	}
+
+	nrf_provisioning_set_interval(atoi(argv[1]));
+
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_nrf_provisioning,
 	SHELL_CMD(init, NULL, NRF_PROVISIONING_HELP_INIT, cmd_init),
 	SHELL_CMD(now, NULL, NRF_PROVISIONING_HELP_NOW, cmd_now),
 	SHELL_CMD(token, NULL, NRF_PROVISIONING_HELP_TOKEN, cmd_token),
 	SHELL_CMD(uuid, NULL, NRF_PROVISIONING_HELP_UUID, cmd_uuid),
+	SHELL_CMD(interval, NULL, NRF_PROVISIONING_HELP_INTERVAL, cmd_interval),
 
 	SHELL_SUBCMD_SET_END);
 


### PR DESCRIPTION
Add new API and shell command to set provisioning interval.
Change DTLS CID from enabled to supported .
Update documentation and change log.