### PR TITLE
Samples: Bluetooth: Mesh: Fix dfu target version comparison

### DIFF
--- a/samples/bluetooth/mesh/dfu/common/src/dfu_target.c
+++ b/samples/bluetooth/mesh/dfu/common/src/dfu_target.c
@@ -56,13 +56,13 @@ static bool is_firmware_newer(struct mcuboot_img_sem_ver *new, struct mcuboot_im
 
 	if (new->minor > cur->minor) {
 		return true;
-	} else if (new->minor > cur->minor) {
+	} else if (new->minor < cur->minor) {
 		return false;
 	}
 
 	if (new->revision > cur->revision) {
 		return true;
-	} else if (new->revision > cur->revision) {
+	} else if (new->revision < cur->revision) {
 		return false;
 	}
 


### PR DESCRIPTION
This fixes an incorrect comparison of minor and revision parts of the version number when checking if the incoming firmware is newer than the current in the DFU target implementation for the Mesh samples.