### PR TITLE
lib: nrf_modem: Initialize CFUN hooks with modem library

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -337,7 +337,9 @@ DFU libraries
 Modem libraries
 ---------------
 
-|no_changes_yet_note|
+* :ref:`nrf_modem_lib_readme`:
+
+  * Fixed an issue with the CFUN hooks when the Modem library is initialized during ``SYS_INIT`` at kernel level and makes calls to the :ref:`nrf_modem_at` interface before the application level initialization is done.
 
 Libraries for networking
 ------------------------

--- a/lib/nrf_modem_lib/cfun_hooks.c
+++ b/lib/nrf_modem_lib/cfun_hooks.c
@@ -12,6 +12,8 @@
 
 LOG_MODULE_DECLARE(nrf_modem, CONFIG_NRF_MODEM_LIB_LOG_LEVEL);
 
+NRF_MODEM_LIB_ON_INIT(cfun_init_hook, on_modem_init, NULL);
+
 static void cfun_callback(int mode)
 {
 	STRUCT_SECTION_FOREACH(nrf_modem_lib_at_cfun_cb, e) {
@@ -20,11 +22,7 @@ static void cfun_callback(int mode)
 	}
 }
 
-static int nrf_modem_lib_cfun_hooks_init(void)
+static void on_modem_init(int err, void *ctx)
 {
 	nrf_modem_at_cfun_handler_set(cfun_callback);
-
-	return 0;
 }
-
-SYS_INIT(nrf_modem_lib_cfun_hooks_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);


### PR DESCRIPTION
This fixes an issue if the modem library is initialized on SYS_INIT at kernel level and makes calls to AT commands before the application level initialization is done.