### PR TITLE
applications: matter: Avoid provider duplicates on the recovery list

### DIFF
--- a/applications/matter_bridge/doc/matter_bridge_description.rst
+++ b/applications/matter_bridge/doc/matter_bridge_description.rst
@@ -400,7 +400,7 @@ Build the target using the following command in the project directory to enable 
 .. parsed-literal::
    :class: highlight
 
-   west build -b nrf7002dk_nrf5340_cpuapp -- -DCONFIG_BRIDGED_DEVICE_BT=y -DOVERLAY_CONFIG="overlay-bt_max_connections_app.conf" -Dhci_ipc_OVERLAY_CONFIG="*absoule_path*/overlay-bt_max_connections_net.conf"
+   west build -b nrf7002dk_nrf5340_cpuapp -- -DCONFIG_BRIDGED_DEVICE_BT=y -DEXTRA_CONF_FILE="overlay-bt_max_connections_app.conf" -Dhci_ipc_EXTRA_CONF_FILE="*absoule_path*/overlay-bt_max_connections_net.conf"
 
 Replace *absolute_path* with the absolute path to the Matter bridge application on your local disk.
 

--- a/applications/matter_bridge/overlay-bt_max_connections_app.conf
+++ b/applications/matter_bridge/overlay-bt_max_connections_app.conf
@@ -10,7 +10,6 @@ CONFIG_BT_MAX_CONN=20
 # Set buffer sizes in a consistent way with the ones used by the network core.
 CONFIG_BT_BUF_ACL_RX_SIZE=84
 CONFIG_BT_BUF_ACL_TX_SIZE=84
-CONFIG_BT_CTLR_DATA_LENGTH_MAX=84
 
 # Set MTU size to fit in the single buffer and avoid fragmentation (BUF_SIZE = MTU_SIZE + 4 B of L2CAP header).
 CONFIG_BT_L2CAP_TX_MTU=80

--- a/applications/matter_bridge/src/bridge_shell.cpp
+++ b/applications/matter_bridge/src/bridge_shell.cpp
@@ -24,14 +24,22 @@ static void BluetoothConnectionSecurityRequest(void *context)
 
 	const struct shell *shell = reinterpret_cast<struct shell *>(context);
 
-	shell_fprintf(shell, SHELL_INFO, "----------------------------------------------------------------------------------------\n");
-	shell_fprintf(shell, SHELL_INFO, "| Bridged Bluetooth LE device authentication                                           |\n");
-	shell_fprintf(shell, SHELL_INFO, "|                                                                                      |\n");
-	shell_fprintf(shell, SHELL_INFO, "| Insert pin code displayed by the Bluetooth LE peripheral device                      |\n");
-	shell_fprintf(shell, SHELL_INFO, "| to authenticate the pairing operation.                                               |\n");
-	shell_fprintf(shell, SHELL_INFO, "|                                                                                      |\n");
-	shell_fprintf(shell, SHELL_INFO, "| To do that, use matter_bridge pincode <ble_device_index> <pincode> shell command.    |\n");
-	shell_fprintf(shell, SHELL_INFO, "----------------------------------------------------------------------------------------\n");
+	shell_fprintf(shell, SHELL_INFO,
+		      "----------------------------------------------------------------------------------------\n");
+	shell_fprintf(shell, SHELL_INFO,
+		      "| Bridged Bluetooth LE device authentication                                           |\n");
+	shell_fprintf(shell, SHELL_INFO,
+		      "|                                                                                      |\n");
+	shell_fprintf(shell, SHELL_INFO,
+		      "| Insert pin code displayed by the Bluetooth LE peripheral device                      |\n");
+	shell_fprintf(shell, SHELL_INFO,
+		      "| to authenticate the pairing operation.                                               |\n");
+	shell_fprintf(shell, SHELL_INFO,
+		      "|                                                                                      |\n");
+	shell_fprintf(shell, SHELL_INFO,
+		      "| To do that, use matter_bridge pincode <ble_device_index> <pincode> shell command.    |\n");
+	shell_fprintf(shell, SHELL_INFO,
+		      "----------------------------------------------------------------------------------------\n");
 }
 #endif /* CONFIG_BRIDGED_DEVICE_BT && CONFIG_BT_SMP */
 
@@ -178,7 +186,7 @@ static int SimulatedBridgedDeviceOnOffLightSwitchWriteHandler(const struct shell
 #endif
 
 #ifdef CONFIG_BRIDGED_DEVICE_BT
-static void BluetoothScanResult(Nrf::BLEConnectivityManager::ScanResult & result, void *context)
+static void BluetoothScanResult(Nrf::BLEConnectivityManager::ScanResult &result, void *context)
 {
 	if (!result.mDevices || !context) {
 		return;
@@ -192,9 +200,11 @@ static void BluetoothScanResult(Nrf::BLEConnectivityManager::ScanResult & result
 	shell_fprintf(shell, SHELL_INFO, "---------------------------------------------------------------------\n");
 	for (int i = 0; i < result.mCount; i++) {
 		shell_fprintf(shell, SHELL_INFO, "| %d     | %02x:%02x:%02x:%02x:%02x:%02x | 0x%04x (%s)\n", i,
-			      result.mDevices[i].mAddr.a.val[5], result.mDevices[i].mAddr.a.val[4], result.mDevices[i].mAddr.a.val[3],
-			      result.mDevices[i].mAddr.a.val[2], result.mDevices[i].mAddr.a.val[1], result.mDevices[i].mAddr.a.val[0],
-			      result.mDevices[i].mUuid, BleBridgedDeviceFactory::GetUuidString(result.mDevices[i].mUuid));
+			      result.mDevices[i].mAddr.a.val[5], result.mDevices[i].mAddr.a.val[4],
+			      result.mDevices[i].mAddr.a.val[3], result.mDevices[i].mAddr.a.val[2],
+			      result.mDevices[i].mAddr.a.val[1], result.mDevices[i].mAddr.a.val[0],
+			      result.mDevices[i].mUuid,
+			      BleBridgedDeviceFactory::GetUuidString(result.mDevices[i].mUuid));
 	}
 }
 
@@ -219,7 +229,7 @@ static int InsertBridgedDevicePincodeHandler(const struct shell *shell, size_t a
 
 static int ScanBridgedDeviceHandler(const struct shell *shell, size_t argc, char **argv)
 {
-	shell_fprintf(shell, SHELL_INFO, "Scanning for 10 s ...\n");
+	shell_fprintf(shell, SHELL_INFO, "Scanning for %d s ...\n", CONFIG_BRIDGE_BT_SCAN_TIMEOUT_MS / 1000);
 
 	Nrf::BLEConnectivityManager::Instance().Scan(BluetoothScanResult, const_cast<struct shell *>(shell));
 
@@ -278,7 +288,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD_ARG(pincode, NULL,
 		      "Insert pincode for Bluetooth LE device pairing. \n"
 		      "Usage: pincode <ble_device_index> <pincode>\n"
-			  "* ble_device_index - the Bluetooth LE device's index on the list returned by the scan command\n"
+		      "* ble_device_index - the Bluetooth LE device's index on the list returned by the scan command\n"
 		      "* pincode - is a pin required for Bluetooth LE pairing authentication\n",
 		      InsertBridgedDevicePincodeHandler, 3, 0),
 #endif /* CONFIG_BT_SMP */

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -167,7 +167,10 @@ Thingy:53: Matter weather station
 Matter Bridge
 -------------
 
-|no_changes_yet_note|
+* Added:
+
+   The :kconfig:option:`CONFIG_BRIDGE_BT_MAX_SCANNED_DEVICES` kconfig option to set the maximum number of scanned Bluetooth LE devices.
+   The :kconfig:option:`CONFIG_BRIDGE_BT_SCAN_TIMEOUT_MS` kconfig option to set the scan timeout.
 
 IPC radio firmware
 ------------------

--- a/samples/matter/common/src/bridge/Kconfig
+++ b/samples/matter/common/src/bridge/Kconfig
@@ -30,6 +30,14 @@ config BRIDGE_BT_RECOVERY_SCAN_TIMEOUT_MS
 	int "Time (in ms) within which the Bridge will try to re-establish a connection to the lost BT LE device"
 	default 2000
 
+config BRIDGE_BT_MAX_SCANNED_DEVICES
+	int "Maximum amount of scanned devices"
+	default 16
+
+config BRIDGE_BT_SCAN_TIMEOUT_MS
+	int "Bluetooth scan timeout in milliseconds"
+	default 10000
+
 config BRIDGE_BT_MINIMUM_SECURITY_LEVEL
 	int "Minimum Bluetooth security level of bridged devices that will be accepted by the bridge device"
 	default 2

--- a/samples/matter/common/src/bridge/ble_connectivity_manager.h
+++ b/samples/matter/common/src/bridge/ble_connectivity_manager.h
@@ -26,8 +26,8 @@ struct BLEBridgedDeviceProvider;
 
 class BLEConnectivityManager {
 public:
-	static constexpr uint16_t kScanTimeoutMs = 10000;
-	static constexpr uint16_t kMaxScannedDevices = 16;
+	static constexpr uint16_t kScanTimeoutMs = CONFIG_BRIDGE_BT_SCAN_TIMEOUT_MS;
+	static constexpr uint16_t kMaxScannedDevices = CONFIG_BRIDGE_BT_MAX_SCANNED_DEVICES;
 	/* One BT connection is reserved for the Matter service purposes. */
 	static constexpr uint16_t kMaxConnectedDevices = CONFIG_BT_MAX_CONN - 1;
 	static constexpr uint8_t kMaxServiceUuids = CONFIG_BT_SCAN_UUID_CNT;
@@ -86,8 +86,9 @@ private:
 		void NotifyProviderToRecover(BLEBridgedDeviceProvider *provider);
 
 	private:
-		BLEBridgedDeviceProvider *GetProvider(sys_slist_t *list);
-		bool PutProvider(BLEBridgedDeviceProvider *provider, sys_slist_t *list);
+		static bool EntryExists(BLEBridgedDeviceProvider *provider, sys_slist_t *list);
+		static BLEBridgedDeviceProvider *GetProvider(sys_slist_t *list);
+		static bool PutProvider(BLEBridgedDeviceProvider *provider, sys_slist_t *list);
 		bool IsNeeded() { return !sys_slist_is_empty(&mListToRecover); }
 		void StartTimer();
 		void CancelTimer() { k_timer_stop(&mRecoveryTimer); }


### PR DESCRIPTION
We need to ensure that the BLE provider doesn't exist on the recovery list to avoid putting it there once again.