### PR TITLE
manifest: Add connection event for wrong key

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -112,7 +112,7 @@ manifest:
     - name: hostap
       repo-path: sdk-hostap
       path: modules/lib/hostap
-      revision: dda5457ad2cfce99e333980c7764c8d480ae4010
+      revision: e46a24a0aa7ff24d06fb20695c61943d99a0a88a
       userdata:
         ncs:
           upstream-url: https://w1.fi/cgit/hostap/


### PR DESCRIPTION
When there is a wrong password for AP, the
send_wifi_mgmt_conn_event is missing for WRONG_KEY.
[SHEL-2627] https://nordicsemi.atlassian.net/browse/SHEL-2627

[SHEL-2627]: https://nordicsemi.atlassian.net/browse/SHEL-2627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ