### PR TITLE
samples: matter: SMP DFU added to thread wi-fi switched lock sample

### DIFF
--- a/samples/matter/lock/sample.yaml
+++ b/samples/matter/lock/sample.yaml
@@ -26,11 +26,11 @@ tests:
       - nrf21540dk_nrf52840
     platform_allow: >
       nrf52840dk_nrf52840 nrf21540dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
-  sample.matter.lock.thread_wifi_switched:
+  sample.matter.lock.thread_wifi_switched.smp_dfu:
     build_only: true
     extra_args: SHIELD=nrf7002ek multiprotocol_rpmsg_SHIELD=nrf7002ek_coex
       CONF_FILE=prj_thread_wifi_switched.conf CONFIG_NRF_WIFI_PATCHES_EXT_FLASH_STORE=y
-      mcuboot_CONFIG_UPDATEABLE_IMAGE_NUMBER=3
+      mcuboot_CONFIG_UPDATEABLE_IMAGE_NUMBER=3 CONFIG_CHIP_DFU_OVER_BT_SMP=y
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
     platform_allow: nrf5340dk_nrf5340_cpuapp


### PR DESCRIPTION
This commit adds config enabling smp dfu on thread wifi swithed lock sample.