### PR TITLE
modules: hostap: Fix band selection

### DIFF
--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -314,7 +314,7 @@ static int wpas_add_and_config_network(struct wpa_supplicant *wpa_s,
 		}
 
 		if (chan_list) {
-			_wpa_cli_cmd_v("set_network %d freq_list%s", resp.network_id, chan_list);
+			_wpa_cli_cmd_v("set_network %d scan_freq%s", resp.network_id, chan_list);
 			k_free(chan_list);
 		}
 	}


### PR DESCRIPTION
If user selects a band, then we should restrict scanning channels to that band, but using freq_list will only filter the results.

Fixes SHEL-2626.