### PR TITLE
Bluetooth: Mesh: Remove unneeded dependency from metadata extraction

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -74,7 +74,11 @@ Bluetooth® LE
 Bluetooth Mesh
 --------------
 
-|no_changes_yet_note|
+* Updated:
+
+  * The Kconfig option :kconfig:option:`CONFIG_BT_MESH_DFU_METADATA_ON_BUILD` to no longer depend on the Kconfig option :kconfig:option:`CONFIG_BT_MESH_DFU_METADATA`.
+  * The Kconfig option :kconfig:option:`CONFIG_BT_MESH_DFU_CLI` to no longer enable the Kconfig option :kconfig:option:`CONFIG_BT_MESH_DFU_METADATA_ON_BUILD` by default.
+    The Kconfig option :kconfig:option:`CONFIG_BT_MESH_DFU_METADATA_ON_BUILD` can still be manually enabled.
 
 Matter
 ------

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -129,9 +129,8 @@ endchoice
 
 config BT_MESH_DFU_METADATA_ON_BUILD
 	bool "Generate DFU metadata on build"
-	default y if BT_MESH_DFU_SRV || BT_MESH_DFU_CLI
+	default y if BT_MESH_DFU_SRV
 	depends on SIGN_IMAGES
-	depends on BT_MESH_DFU_METADATA
 	help
 	  Generate a JSON file containing all DFU related metadata upon
 	  application build. The JSON will be added to dfu application zip


### PR DESCRIPTION
Make it possible to extract metadata at build time even if BT_MESH_DFU_METADATA is not enabled in the image. There is no need to have this enabled in the new firmware for it to make sense, as long as it is enable in the firmware currently running on the target. Removing the dependency allows things like removing Mesh DFU support by performing a Mesh DFU update, or changing metadata schemes by performing a DFU update.

Also remove the default y for BT_MESH_DFU_CLI. It makes no sense to enable it by default for distributor images, unless they support self-update, in which case they would also enable BT_MESH_DFU_SRV.