### PR TITLE
samples: Bluetooth: mesh: Add nrf54l15 support in BLE coex sample

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -206,6 +206,10 @@ Bluetooth Mesh samples
 
    * Added support for the :ref:`zephyr:nrf54l15pdk_nrf54l15` board.
 
+* :ref:`bluetooth_ble_peripheral_lbs_coex` sample:
+
+   * Added support for the :ref:`zephyr:nrf54l15pdk_nrf54l15` board.
+
 * :ref:`bt_mesh_chat` sample:
 
    * Added support for the :ref:`zephyr:nrf54l15pdk_nrf54l15` board.

--- a/samples/bluetooth/mesh/ble_peripheral_lbs_coex/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/bluetooth/mesh/ble_peripheral_lbs_coex/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+################################################################################
+# Application overlay - nrf54l15
+
+CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE=n

--- a/samples/bluetooth/mesh/ble_peripheral_lbs_coex/sample.yaml
+++ b/samples/bluetooth/mesh/ble_peripheral_lbs_coex/sample.yaml
@@ -9,5 +9,7 @@ tests:
       - nrf52840dk_nrf52840
       - nrf52833dk_nrf52833
       - nrf21540dk_nrf52840
+      - nrf54l15pdk_nrf54l15_cpuapp
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf21540dk_nrf52840
+        nrf54l15pdk_nrf54l15_cpuapp
     tags: bluetooth ci_build


### PR DESCRIPTION
Adds mesh BLE coex sample support for the nrf54l15 board and updates documentation.