### PR TITLE
applications: machine_learning: Allow running ML model with no anomaly

### DIFF
--- a/applications/machine_learning/src/modules/ml_runner.c
+++ b/applications/machine_learning/src/modules/ml_runner.c
@@ -67,8 +67,10 @@ static void submit_result(void)
 
 	int err = ei_wrapper_get_next_classification_result(&evt->label, &evt->value, NULL);
 
-	if (!err) {
+	if (!err && ei_wrapper_classifier_has_anomaly()) {
 		err = ei_wrapper_get_anomaly(&evt->anomaly);
+	} else {
+		evt->anomaly = 0.0;
 	}
 
 	__ASSERT_NO_MSG(!err);

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -146,7 +146,7 @@ nRF5340 Audio
 nRF Machine Learning (Edge Impulse)
 -----------------------------------
 
-|no_changes_yet_note|
+* Updated the ``ml_runner`` application module to allow running a machine learning model without anomaly support.
 
 nRF Desktop
 -----------


### PR DESCRIPTION
Change updates ML runner application module to allow running ML model without anomaly support.

Jira: NCSDK-25938