### PR TITLE
net: lib: download_client: Suppress extra DNS warnings

### DIFF
--- a/subsys/net/lib/download_client/src/download_client.c
+++ b/subsys/net/lib/download_client/src/download_client.c
@@ -381,6 +381,7 @@ cleanup:
 static int client_connect(struct download_client *dl)
 {
 	int err;
+	int ns_err;
 	int type;
 	uint16_t port;
 
@@ -443,19 +444,26 @@ static int client_connect(struct download_client *dl)
 		type |= SOCK_NATIVE_TLS;
 	}
 
+	err = -1;
+	ns_err = -1;
+
 	/* Attempt IPv6 connection if configured, fallback to IPv4 on error */
 	if ((dl->config.family == AF_UNSPEC) || (dl->config.family == AF_INET6)) {
-		err = host_lookup(dl->host, AF_INET6, dl->config.pdn_id, &dl->remote_addr);
-		if (!err) {
+		ns_err = host_lookup(dl->host, AF_INET6, dl->config.pdn_id, &dl->remote_addr);
+		if (!ns_err) {
 			err = client_socket_connect(dl, type, port);
 		}
 	}
 
 	if (((dl->config.family == AF_UNSPEC) && err) || (dl->config.family == AF_INET)) {
-		err = host_lookup(dl->host, AF_INET, dl->config.pdn_id, &dl->remote_addr);
-		if (!err) {
+		ns_err = host_lookup(dl->host, AF_INET, dl->config.pdn_id, &dl->remote_addr);
+		if (!ns_err) {
 			err = client_socket_connect(dl, type, port);
 		}
+	}
+	if (ns_err) {
+		LOG_ERR("DNS lookup failed %s", dl->host);
+		err = ns_err;
 	}
 
 cleanup:


### PR DESCRIPTION
Trying to query IPv6 address on IPv4 network is not necessary error, so change the log level from WRN to DBG.

Then error is show if both queries have failed.