### PR TITLE
samples: cellular: http_update: Support 1.3.6 on nRF9160

### DIFF
--- a/samples/cellular/http_update/modem_delta_update/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/cellular/http_update/modem_delta_update/boards/nrf9160dk_nrf9160_ns.conf
@@ -4,6 +4,6 @@
 #
 
 # Modem firmware version configuration
-CONFIG_SUPPORTED_BASE_VERSION="mfw_nrf9160_1.3.5"
-CONFIG_DOWNLOAD_FILE_BASE_TO_FOTA_TEST="mfw_nrf9160_update_from_1.3.5_to_1.3.5-FOTA-TEST.bin"
-CONFIG_DOWNLOAD_FILE_FOTA_TEST_TO_BASE="mfw_nrf9160_update_from_1.3.5-FOTA-TEST_to_1.3.5.bin"
+CONFIG_SUPPORTED_BASE_VERSION="mfw_nrf9160_1.3.6"
+CONFIG_DOWNLOAD_FILE_BASE_TO_FOTA_TEST="mfw_nrf9160_update_from_1.3.6_to_1.3.6-FOTA-TEST.bin"
+CONFIG_DOWNLOAD_FILE_FOTA_TEST_TO_BASE="mfw_nrf9160_update_from_1.3.6-FOTA-TEST_to_1.3.6.bin"


### PR DESCRIPTION
The modem FW image is already in server, so we should support it.