### PR TITLE
lwm2m: Fix supported protocols list for FOTA

### DIFF
--- a/samples/cellular/lwm2m_client/overlay-avsystem-bootstrap.conf
+++ b/samples/cellular/lwm2m_client/overlay-avsystem-bootstrap.conf
@@ -5,3 +5,7 @@ CONFIG_LWM2M_SECURITY_INSTANCE_COUNT=3
 # Enable TLV, AVSystem uses this as a default.
 # Can be disabled once device dialect is changed from server side.
 CONFIG_LWM2M_RW_OMA_TLV_SUPPORT=y
+
+# AVSystem FOTA defaults to CoAPS so use the same security tag than where our
+# DTLS credentials are stored.
+CONFIG_LWM2M_CLIENT_UTILS_DOWNLOADER_SEC_TAG=35724861

--- a/samples/cellular/lwm2m_client/overlay-avsystem.conf
+++ b/samples/cellular/lwm2m_client/overlay-avsystem.conf
@@ -3,3 +3,7 @@ CONFIG_LWM2M_CLIENT_UTILS_SERVER="coaps://eu.iot.avsystem.cloud:5684"
 # Enable TLV, AVSystem uses this as a default.
 # Can be disabled once device dialect is changed from server side.
 CONFIG_LWM2M_RW_OMA_TLV_SUPPORT=y
+
+# AVSystem FOTA defaults to CoAPS so use the same security tag than where our
+# DTLS credentials are stored.
+CONFIG_LWM2M_CLIENT_UTILS_DOWNLOADER_SEC_TAG=35724861


### PR DESCRIPTION
## net: lwm2m_client_utils: Fix supported protocols list for FOTA

FOTA object has list of supported protocols.
We assumed that when CA chain is present in certain sec_tag,
we can use HTTPS or CoAPS. This is OK.

But AVSystem uses mutual DTLS authentication on CoAPS so
the sec_tag we use, might not have CA chain at all.
So when only PSK credentials are present, claim that we
support CoAPS but not HTTPS.

## samples: lwm2m_client: Use same security tag for FOTA and DTLS

AVSystem FOTA defaults to CoAPS so use same security tag where our
DTLS credentials are stored.
