### PR TITLE
application: serial_lte_modem: fix compilation with CONFIG_LOG=n

### DIFF
--- a/applications/serial_lte_modem/src/ftp_c/slm_at_tftp.c
+++ b/applications/serial_lte_modem/src/ftp_c/slm_at_tftp.c
@@ -50,8 +50,7 @@ static int do_tftp_get(int family, const char *server, uint16_t port, const char
 	struct tftpc client = {
 		.callback = tftp_callback
 	};
-	ret = util_resolve_host(0, server, port, family,
-		Z_LOG_OBJECT_PTR(slm_tftp), &client.server);
+	ret = util_resolve_host(0, server, port, family, &client.server);
 	if (ret) {
 		return -EAGAIN;
 	}
@@ -94,8 +93,7 @@ static int do_tftp_put(int family, const char *server, uint16_t port, const char
 		.callback = tftp_callback
 	};
 
-	ret = util_resolve_host(0, server, port, family,
-		Z_LOG_OBJECT_PTR(slm_tftp), &client.server);
+	ret = util_resolve_host(0, server, port, family, &client.server);
 	if (ret) {
 		return -EAGAIN;
 	}

--- a/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
+++ b/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
@@ -304,8 +304,7 @@ static int do_http_connect(void)
 	}
 
 	/* Connect to HTTP server */
-	ret = util_resolve_host(0, httpc.host, httpc.port, httpc.family,
-		Z_LOG_OBJECT_PTR(slm_httpc), &sa);
+	ret = util_resolve_host(0, httpc.host, httpc.port, httpc.family, &sa);
 	if (ret) {
 		goto exit_cli;
 	}

--- a/applications/serial_lte_modem/src/mqtt_c/slm_at_mqtt.c
+++ b/applications/serial_lte_modem/src/mqtt_c/slm_at_mqtt.c
@@ -304,8 +304,7 @@ static int broker_init(void)
 		.sa_family = AF_UNSPEC
 	};
 
-	err = util_resolve_host(0, mqtt_broker_url, mqtt_broker_port, ctx.family,
-		Z_LOG_OBJECT_PTR(slm_mqtt), &sa);
+	err = util_resolve_host(0, mqtt_broker_url, mqtt_broker_port, ctx.family, &sa);
 	if (err) {
 		return -EAGAIN;
 	}

--- a/applications/serial_lte_modem/src/slm_at_socket.c
+++ b/applications/serial_lte_modem/src/slm_at_socket.c
@@ -624,7 +624,7 @@ static int do_connect(const char *url, uint16_t port)
 	};
 
 	LOG_DBG("connect %s:%d", url, port);
-	ret = util_resolve_host(sock.cid, url, port, sock.family, Z_LOG_OBJECT_PTR(slm_sock), &sa);
+	ret = util_resolve_host(sock.cid, url, port, sock.family, &sa);
 	if (ret) {
 		return -EAGAIN;
 	}
@@ -817,7 +817,7 @@ static int do_sendto(const char *url, uint16_t port, const uint8_t *data, int da
 	};
 
 	LOG_DBG("sendto %s:%d", url, port);
-	ret = util_resolve_host(sock.cid, url, port, sock.family, Z_LOG_OBJECT_PTR(slm_sock), &sa);
+	ret = util_resolve_host(sock.cid, url, port, sock.family, &sa);
 	if (ret) {
 		return -EAGAIN;
 	}
@@ -855,8 +855,7 @@ static int do_sendto_datamode(const uint8_t *data, int datalen)
 	};
 
 	LOG_DBG("sendto %s:%d", udp_url, udp_port);
-	ret = util_resolve_host(sock.cid, udp_url, udp_port, sock.family,
-		Z_LOG_OBJECT_PTR(slm_sock), &sa);
+	ret = util_resolve_host(sock.cid, udp_url, udp_port, sock.family, &sa);
 	if (ret) {
 		return -EAGAIN;
 	}

--- a/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
@@ -278,7 +278,7 @@ static int do_tcp_client_connect(const char *url, uint16_t port)
 	}
 
 	/* Connect to remote host */
-	ret = util_resolve_host(0, url, port, proxy.family, Z_LOG_OBJECT_PTR(slm_tcp), &sa);
+	ret = util_resolve_host(0, url, port, proxy.family, &sa);
 	if (ret) {
 		goto exit_cli;
 	}

--- a/applications/serial_lte_modem/src/slm_at_udp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_udp_proxy.c
@@ -228,7 +228,7 @@ static int do_udp_client_connect(const char *url, uint16_t port)
 	}
 
 	/* Connect to remote host */
-	ret = util_resolve_host(0, url, port, proxy.family, Z_LOG_OBJECT_PTR(slm_udp), &sa);
+	ret = util_resolve_host(0, url, port, proxy.family, &sa);
 	if (ret) {
 		goto cli_exit;
 	}

--- a/applications/serial_lte_modem/src/slm_util.c
+++ b/applications/serial_lte_modem/src/slm_util.c
@@ -348,8 +348,7 @@ int util_str_to_int(const char *str_buf, int base, int *output)
 #define PORT_MAX_SIZE    5 /* 0xFFFF = 65535 */
 #define PDN_ID_MAX_SIZE  2 /* 0..10 */
 
-int util_resolve_host(int cid, const char *host, uint16_t port, int family,
-	LOG_INSTANCE_PTR_DECLARE(log_inst), struct sockaddr *sa)
+int util_resolve_host(int cid, const char *host, uint16_t port, int family, struct sockaddr *sa)
 {
 	int err;
 	char service[PORT_MAX_SIZE + PDN_ID_MAX_SIZE + 2];
@@ -384,7 +383,7 @@ int util_resolve_host(int cid, const char *host, uint16_t port, int family,
 		} else {
 			errstr = gai_strerror(err);
 		}
-		LOG_INST_ERR(log_inst, "getaddrinfo() error (%d): %s", err, errstr);
+		LOG_ERR("getaddrinfo() error (%d): %s", err, errstr);
 	}
 	return err;
 }

--- a/applications/serial_lte_modem/src/slm_util.h
+++ b/applications/serial_lte_modem/src/slm_util.h
@@ -179,15 +179,13 @@ int util_str_to_int(const char *str, int base, int *output);
  * @param[in] host Name or IP address of remote host.
  * @param[in] port Service port of remote host.
  * @param[in] family Desired address family for the returned address.
- * @param[in] log_inst The log instance of the module calling this function.
  * @param[out] sa The returned address.
  *
  * @retval 0 If the operation was successful.
  *           Otherwise, an errno code or a dns_resolve_status enum value
  *           (defined in `zephyr/net/dns_resolve.h`).
  */
-int util_resolve_host(int cid, const char *host, uint16_t port, int family,
-	Z_LOG_INSTANCE_STRUCT *log_inst, struct sockaddr *sa);
+int util_resolve_host(int cid, const char *host, uint16_t port, int family, struct sockaddr *sa);
 /** @} */
 
 #endif /* SLM_UTIL_ */


### PR DESCRIPTION
Don't pass log instances around.