### PR TITLE
applications: nrf5340_audio: Remove unused codec struct member

### DIFF
--- a/applications/nrf5340_audio/src/audio/sw_codec_select.h
+++ b/applications/nrf5340_audio/src/audio/sw_codec_select.h
@@ -53,7 +53,6 @@ struct sw_codec_encoder {
 
 struct sw_codec_decoder {
 	bool enabled;
-	bool started;
 	enum sw_codec_channel_mode channel_mode; /* Mono or stereo. */
 	uint8_t num_ch;				 /* Number of decoder channels. */
 	enum audio_channel audio_ch;		 /* Used to choose which channel to use. */


### PR DESCRIPTION
Remove the started variable from struct sw_codec_encoder as it is never used. The variable was introduced in 100db2a.