### PR TITLE
net: lib: nrf_cloud: Improve A-GNSS data parsing robustness

### DIFF
--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_agnss.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_agnss.c
@@ -465,6 +465,13 @@ static size_t get_next_agnss_element(struct nrf_cloud_agnss_element *element,
 	 * each element.
 	 */
 	if (elements_left_to_process == 0) {
+		element_type = NRF_CLOUD_AGNSS__TYPE_INVALID;
+
+		if (buf_len == 0) {
+			/* No more data to parse. */
+			return 0;
+		}
+
 		/* Check that there's enough data for type and count. */
 		if (buf_len < NRF_CLOUD_AGNSS_BIN_TYPE_SIZE + NRF_CLOUD_AGNSS_BIN_COUNT_SIZE) {
 			LOG_ERR("Unexpected end of data");
@@ -532,6 +539,7 @@ static size_t get_next_agnss_element(struct nrf_cloud_agnss_element *element,
 	default:
 		LOG_DBG("Unhandled A-GNSS data type: %d", element->type);
 		elements_left_to_process = 0;
+		element_type = NRF_CLOUD_AGNSS__TYPE_INVALID;
 		return 0;
 	}
 
@@ -539,6 +547,7 @@ static size_t get_next_agnss_element(struct nrf_cloud_agnss_element *element,
 	if (buf_len < len) {
 		LOG_ERR("Unexpected end of data");
 		elements_left_to_process = 0;
+		element_type = NRF_CLOUD_AGNSS__TYPE_INVALID;
 		return 0;
 	}
 
@@ -594,12 +603,15 @@ int nrf_cloud_agnss_process(const char *buf, size_t buf_len)
 
 	LOG_DBG("A-GNSS_injection_active LOCKED");
 
-	while (parsed_len < buf_len) {
+	while (parsed_len <= buf_len) {
+		/* get_next_agnss_element() is called once more when the data ends to detect
+		 * that parsing has been finished.
+		 */
 		size_t element_size =
 			get_next_agnss_element(&element, &buf[parsed_len], buf_len - parsed_len);
 
 		if (element_size == 0) {
-			LOG_DBG("Parsing finished\n");
+			LOG_DBG("Parsing finished");
 			break;
 		}
 


### PR DESCRIPTION
If A-GNSS data contained an invalid element count, the parser was left into invalid state and no error was logged. Because of this further parsing attempts failed. Also, the end of parsing was not detected in a successful case and the "Parsing finished" debug log was missing.