### PR TITLE
samples: wifi: scan: Don't use highest CPU

### DIFF
--- a/samples/wifi/scan/src/main.c
+++ b/samples/wifi/scan/src/main.c
@@ -327,11 +327,6 @@ int main(void)
 
 	net_mgmt_add_event_callback(&wifi_shell_mgmt_cb);
 
-#if defined(CLOCK_FEATURE_HFCLK_DIVIDE_PRESENT) || NRF_CLOCK_HAS_HFCLK192M
-	/* For now hardcode to 128MHz */
-	nrfx_clock_divider_set(NRF_CLOCK_DOMAIN_HFCLK,
-			       NRF_CLOCK_HFCLK_DIV_1);
-#endif
 	k_sleep(K_SECONDS(1));
 	printk("Starting %s with CPU frequency: %d MHz\n", CONFIG_BOARD, SystemCoreClock / MHZ(1));
 


### PR DESCRIPTION
Scan sample doesn't need 128MHz, default CPU clock of 64MHz is good enough.