### PR TITLE
actions: oss: enable tf-m oss-history check

### DIFF
--- a/.github/workflows/oss-history.yml
+++ b/.github/workflows/oss-history.yml
@@ -31,4 +31,4 @@ jobs:
         uses: nrfconnect/action-oss-history@main
         with:
           workspace: 'ncs'
-          args: -p zephyr -p mcuboot -p hostap -p wfa-qt-control-app
+          args: -p zephyr -p mcuboot -p trusted-firmware-m -p hostap -p wfa-qt-control-app


### PR DESCRIPTION
Re-enable the  trusted-firmware-m after it had to be disabled here: in commit 6f98e9d810664977a9a5eee94fbb5697b51bfcc0.

It works again after the upmerge

Ref: NCSDK-26099