### PR TITLE
Bluetooth: Mesh: Add test to verify metadata extraction output

### DIFF
--- a/tests/subsys/bluetooth/mesh/metadata_extraction/CMakeLists.txt
+++ b/tests/subsys/bluetooth/mesh/metadata_extraction/CMakeLists.txt
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(bt_mesh_metadata_extraction_test)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})
+
+set(script_args ${PROJECT_BINARY_DIR})
+
+if(CONFIG_COMP_DATA_LAYOUT_SINGLE)
+    list(PREPEND script_args --single)
+else()
+    list(PREPEND script_args --multiple)
+endif()
+
+add_custom_target(verify_metadata ALL
+    ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/verify_metadata.py ${script_args}
+    DEPENDS parse_mesh_metadata
+)

--- a/tests/subsys/bluetooth/mesh/metadata_extraction/Kconfig
+++ b/tests/subsys/bluetooth/mesh/metadata_extraction/Kconfig
@@ -1,0 +1,16 @@
+choice COMP_DATA_LAYOUT
+	prompt "Composition data layout"
+	default COMP_DATA_LAYOUT_SINGLE
+
+config COMP_DATA_LAYOUT_SINGLE
+	bool "Single composition data"
+
+config COMP_DATA_LAYOUT_MULTIPLE
+	bool "Multiple composition data as separate variables"
+
+config COMP_DATA_LAYOUT_ARRAY
+	bool "Multiple composition data as an array"
+
+endchoice
+
+source "Kconfig.zephyr"

--- a/tests/subsys/bluetooth/mesh/metadata_extraction/prj.conf
+++ b/tests/subsys/bluetooth/mesh/metadata_extraction/prj.conf
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Bootloader configuration
+CONFIG_BOOTLOADER_MCUBOOT=y
+CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION="1.2.3+4"
+
+# Bluetooth configuration
+CONFIG_BT=y
+CONFIG_BT_OBSERVER=y
+CONFIG_BT_PERIPHERAL=y
+
+# Bluetooth Mesh configuration
+CONFIG_BT_MESH=y
+CONFIG_BT_MESH_DFU_METADATA_ON_BUILD=y
+
+# Set to something other than default to check that it is parsed correctly
+CONFIG_BT_MESH_CRPL=64
+
+# Enable extra mesh features to check that the features field is parsed correctly
+CONFIG_BT_MESH_RELAY=y
+CONFIG_BT_MESH_FRIEND=y
+
+# Bluetooth Mesh models
+CONFIG_BT_MESH_LVL_CLI=y
+CONFIG_BT_MESH_ONOFF_CLI=y

--- a/tests/subsys/bluetooth/mesh/metadata_extraction/src/main.c
+++ b/tests/subsys/bluetooth/mesh/metadata_extraction/src/main.c
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/** @file
+ *  @brief Bluetooth Mesh DFU Target role sample
+ */
+#include <zephyr/kernel.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/mesh.h>
+#include <bluetooth/mesh/models.h>
+
+
+static struct bt_mesh_health_srv health_srv;
+
+BT_MESH_HEALTH_PUB_DEFINE(health_pub, 0);
+
+static struct bt_mesh_model models[] = {
+	BT_MESH_MODEL_CFG_SRV,
+	BT_MESH_MODEL_HEALTH_SRV(&health_srv, &health_pub),
+};
+
+static struct bt_mesh_elem elements[] = {
+	BT_MESH_ELEM(1, models, BT_MESH_MODEL_NONE),
+};
+
+#ifndef CONFIG_COMP_DATA_LAYOUT_SINGLE
+static struct bt_mesh_onoff_cli onoff_cli;
+static struct bt_mesh_lvl_cli lvl_cli;
+
+static struct bt_mesh_model extra_models[] = {
+	BT_MESH_MODEL_ONOFF_CLI(&onoff_cli),
+	BT_MESH_MODEL_LVL_CLI(&lvl_cli),
+};
+
+static struct bt_mesh_elem elements_alt[] = {
+	BT_MESH_ELEM(1, models, BT_MESH_MODEL_NONE),
+	BT_MESH_ELEM(2, extra_models, BT_MESH_MODEL_NONE),
+};
+#endif
+
+#ifdef CONFIG_COMP_DATA_LAYOUT_ARRAY
+const struct bt_mesh_comp comp[2] = {
+	{
+		.cid = 1,
+		.pid = 2,
+		.vid = 3,
+		.elem = elements,
+		.elem_count = ARRAY_SIZE(elements),
+	},
+	{
+		.cid = 4,
+		.pid = 5,
+		.vid = 6,
+		.elem = elements_alt,
+		.elem_count = ARRAY_SIZE(elements_alt),
+	},
+};
+#else /* defined(COMP_DATA_LAYOUT_SINGLE) || defined(COMP_DATA_LAYOUT_MULTIPLE) */
+static const struct bt_mesh_comp comp = {
+	.cid = 1,
+	.pid = 2,
+	.vid = 3,
+	.elem = elements,
+	.elem_count = ARRAY_SIZE(elements),
+};
+#ifdef CONFIG_COMP_DATA_LAYOUT_MULTIPLE
+static const struct bt_mesh_comp comp_alt = {
+	.cid = 4,
+	.pid = 5,
+	.vid = 6,
+	.elem = elements_alt,
+	.elem_count = ARRAY_SIZE(elements_alt),
+};
+#endif /* CONFIG_COMP_DATA_LAYOUT_MULTIPLE */
+#endif /* defined(COMP_DATA_LAYOUT_SINGLE) || defined(COMP_DATA_LAYOUT_MULTIPLE) */
+
+static const uint8_t dev_uuid[16];
+
+static const struct bt_mesh_prov prov = {
+	.uuid = dev_uuid,
+};
+
+#ifndef CONFIG_COMP_DATA_LAYOUT_SINGLE
+/* Since the value of this variable is never changed by the code, the compiler
+ * might optimize it out, including any conditions that depend on it (and by
+ * by extension, the entire alternate composition data structure). To prevent
+ * this, the `volatile` qualifier is used.
+ */
+volatile bool use_alt;
+#endif
+
+static void bt_ready(int err)
+{
+	if (err) {
+		return;
+	}
+
+#ifdef CONFIG_COMP_DATA_LAYOUT_ARRAY
+	if (use_alt) {
+		bt_mesh_init(&prov, &comp[1]);
+	} else {
+		bt_mesh_init(&prov, &comp[0]);
+	}
+#else /* defined(COMP_DATA_LAYOUT_SINGLE) || defined(COMP_DATA_LAYOUT_MULTIPLE) */
+#ifdef CONFIG_COMP_DATA_LAYOUT_MULTIPLE
+	if (use_alt) {
+		bt_mesh_init(&prov, &comp_alt);
+	} else
+#endif /* CONFIG_COMP_DATA_LAYOUT_MULTIPLE */
+	{
+		bt_mesh_init(&prov, &comp);
+	}
+#endif /* defined(COMP_DATA_LAYOUT_SINGLE) || defined(COMP_DATA_LAYOUT_MULTIPLE) */
+}
+
+int main(void)
+{
+	bt_enable(bt_ready);
+
+	return 0;
+}

--- a/tests/subsys/bluetooth/mesh/metadata_extraction/testcase.yaml
+++ b/tests/subsys/bluetooth/mesh/metadata_extraction/testcase.yaml
@@ -1,0 +1,16 @@
+common:
+  build_only: true
+  platform_allow: nrf52840dk_nrf52840
+  tags: bluetooth ci_build
+  integration_platforms:
+    - nrf52840dk_nrf52840
+tests:
+  bluetooth.mesh.metadata_extraction_single:
+    extra_configs:
+      - CONFIG_COMP_DATA_LAYOUT_SINGLE=y
+  bluetooth.mesh.metadata_extraction_multiple:
+    extra_configs:
+      - CONFIG_COMP_DATA_LAYOUT_MULTIPLE=y
+  bluetooth.mesh.metadata_extraction_array:
+    extra_configs:
+      - CONFIG_COMP_DATA_LAYOUT_ARRAY=y

--- a/tests/subsys/bluetooth/mesh/metadata_extraction/verify_metadata.py
+++ b/tests/subsys/bluetooth/mesh/metadata_extraction/verify_metadata.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+import json
+import os
+import sys
+from zipfile import ZipFile
+
+
+def assert_metadata_equal(json_data, expected, msg="Metadata not equal to expected"):
+    """
+    Check metadata instance for equality, printing diff on error
+    """
+    diff_lines = [msg]
+
+    def list_diff(json, expected, path=''):
+        if len(json) != len(expected):
+            diff_lines.append(f"Expected {path} to have length {len(expected)} but got {len(json)}")
+        else:
+            for i, json_item in enumerate(json):
+                diff(json_item, expected[i], f"{path}[{i}]")
+
+    def dict_diff(json, expected, path=''):
+        for key in set(json) | set(expected):
+            full_path = path + key
+            if key not in expected:
+                diff_lines.append(f"Unexpected key {full_path} in JSON")
+            elif key not in json:
+                diff_lines.append(f"Key {full_path} missing from JSON")
+            else:
+                diff(json[key], expected[key], full_path)
+
+    def diff(json, expected, path=''):
+        if json != expected:
+            if isinstance(json, dict) and isinstance(expected, dict):
+                dict_diff(json, expected, f"{path}.")
+            elif isinstance(json, list) and isinstance(expected, list):
+                list_diff(json, expected, path)
+            else:
+                diff_lines.append(f"Expected {path} == {expected} but got {json}")
+
+    if json_data != expected:
+        dict_diff(json_data, expected)
+        raise AssertionError('\n'.join(diff_lines))
+
+
+def expected_metadata(size):
+    encoded_size = size.to_bytes(3, 'little').hex()
+    return [
+        {
+            'sign_version': {'major': 1, 'minor': 2, 'revision': 3, 'build_number': 4},
+            'binary_size': size,
+            'composition_data': {
+                'cid': 1,
+                'pid': 2,
+                'vid': 3,
+                'crpl': 64,
+                'features': 5,
+                'elements': [
+                    {'location': 1, 'sig_models': [0, 2], 'vendor_models': []}
+                ]
+            },
+            'composition_hash': '0x587a2fb',
+            'encoded_metadata': f'0102030004000000{encoded_size}01fba287050100'
+        },
+        {
+            'sign_version': {'major': 1, 'minor': 2, 'revision': 3, 'build_number': 4},
+            'binary_size': size,
+            'composition_data': {
+                'cid': 4,
+                'pid': 5,
+                'vid': 6,
+                'crpl': 64,
+                'features': 5,
+                'elements': [
+                    {'location': 1, 'sig_models': [0, 2], 'vendor_models': []},
+                    {'location': 2, 'sig_models': [4097, 4099], 'vendor_models': []}
+                ]
+            },
+            'composition_hash': '0x13f1a143',
+            'encoded_metadata': f'0102030004000000{encoded_size}0143a1f1130200'
+        }
+    ]
+
+
+if __name__ == '__main__':
+    comp_data_layout = sys.argv[1]
+    bin_dir = sys.argv[2]
+    zip_path = os.path.join(bin_dir, "zephyr", "dfu_application.zip")
+
+    binary_size = os.path.getsize(os.path.join(bin_dir, "zephyr", "app_update.bin"))
+    expected = expected_metadata(binary_size)
+
+    with ZipFile(zip_path) as zip_file:
+        json_string = zip_file.read('ble_mesh_metadata.json').decode()
+
+    json_data = json.loads(json_string)
+
+    if comp_data_layout == '--single':
+        assert not isinstance(json_data, list), "Expected single metadata but got multiple."
+        assert_metadata_equal(json_data, expected[0])
+    elif comp_data_layout == '--multiple':
+        assert not isinstance(json_data, dict), "Expected multiple metadata but got one."
+        assert len(json_data) == len(expected), (f"Expected {len(expected)} metadatas "
+                                                          f"but got {len(json_data)}")
+        for i, data in enumerate(json_data):
+            assert_metadata_equal(data, expected[i], f"Metadata[{i}] not equal to expected")
+    else:
+        raise ValueError('Unknown comp data layout')


### PR DESCRIPTION
This adds build-only tests with targets with verious layouts of composition data, and runs a verification script as part of the build.

Currently tested:
  - Single composition data variables
  - Multiple composition data variables
  - Array containing multiple composition data