### PR TITLE
scripts: add integration quarantine part 3

### DIFF
--- a/scripts/quarantine_integration.yaml
+++ b/scripts/quarantine_integration.yaml
@@ -485,3 +485,99 @@
   platforms:
     - thingy53_nrf5340_cpuapp_ns
   comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - sample.cellular.nrf7002ek_wifi.scan
+  platforms:
+    - nrf9160dk_nrf9160_ns
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - sample.cellular.nrf_cloud_multi_service.mqtt
+  platforms:
+    - nrf9161dk_nrf9161_ns
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - sample.cellular.nrf_cloud_multi_service.coap
+  platforms:
+    - thingy91_nrf9160_ns
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - sample.cellular.nrf_cloud_rest_device_message
+  platforms:
+    - nrf9160dk_nrf9160_ns
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - sample.cellular.nrf_cloud_rest_cell_pos
+  platforms:
+    - nrf9160dk_nrf9160_ns
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - sample.cellular.nrf_cloud_rest_fota
+  platforms:
+    - nrf9160dk_nrf9160_ns
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - examples.nrfx_temp.blocking
+  platforms:
+    - nrf52dk_nrf52832
+    - nrf5340dk_nrf5340_cpunet
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - examples.nrfx_temp.non_blocking
+  platforms:
+    - nrf52840dk_nrf52840
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - examples.nrfx_spim.blocking
+    - examples.nrfx_pwm.common_mode
+    - examples.nrfx_gppi.fork
+  platforms:
+    - nrf9160dk_nrf9160
+    - nrf5340dk_nrf5340_cpuapp
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - examples.nrfx_spim.non_blocking
+    - examples.nrfx_pwm.grouped_mode
+    - examples.nrfx_gppi.one_to_one
+    - examples.nrfx_twim_twis.blocking
+  platforms:
+    - nrf52dk_nrf52832
+    - nrf52840dk_nrf52840
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - examples.nrfx_spim_spis.non_blocking
+    - examples.nrfx_saadc.simple_blocking
+    - examples.nrfx_saadc.simple_non_blocking
+    - examples.nrfx_twim_twis.txtx
+  platforms:
+    - nrf52840dk_nrf52840
+    - nrf52dk_nrf52832
+    - nrf5340dk_nrf5340_cpuapp
+    - nrf9160dk_nrf9160
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - examples.nrfx_twim_twis.txrx
+  platforms:
+    - nrf52840dk_nrf52840
+    - nrf5340dk_nrf5340_cpuapp
+    - nrf9160dk_nrf9160
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - examples.nrfx_twim_twis.non_blocking
+  platforms:
+    - nrf5340dk_nrf5340_cpuapp
+    - nrf52dk_nrf52832
+    - nrf9160dk_nrf9160
+  comment: "Configurations excluded to limit resources usage in integration builds"


### PR DESCRIPTION
To limit integration scope.
For:
nrf/samples/cellular/nrf_cloud_multi_service
nrf/samples/cellular/nrf_cloud_rest_device_message nrf/samples/cellular/nrf_cloud_rest_cell_location
nrf/samples/cellular/nrf_cloud_rest_fota