### PR TITLE
lib: location: Make wifi_scan_ready semaphore to static

### DIFF
--- a/lib/location/method_cloud_location.c
+++ b/lib/location/method_cloud_location.c
@@ -36,6 +36,10 @@ struct method_cloud_location_start_work_args {
 static struct method_cloud_location_start_work_args method_cloud_location_start_work;
 static bool running;
 
+#if defined(CONFIG_LOCATION_METHOD_WIFI)
+static K_SEM_DEFINE(wifi_scan_ready, 0, 1);
+#endif
+
 static void method_cloud_location_positioning_work_fn(struct k_work *work)
 {
 	struct method_cloud_location_start_work_args *work_data =
@@ -45,10 +49,9 @@ static void method_cloud_location_positioning_work_fn(struct k_work *work)
 	struct wifi_scan_info *scan_wifi_info = NULL;
 	struct lte_lc_cells_info *scan_cellular_info = NULL;
 	int err = 0;
-#if defined(CONFIG_LOCATION_METHOD_WIFI)
-	struct k_sem wifi_scan_ready;
 
-	k_sem_init(&wifi_scan_ready, 0, 1);
+#if defined(CONFIG_LOCATION_METHOD_WIFI)
+	k_sem_reset(&wifi_scan_ready);
 
 	if (wifi_config != NULL) {
 		scan_wifi_execute(wifi_config->timeout, &wifi_scan_ready);


### PR DESCRIPTION
Semaphore wifi_scan_ready has been reserved from the stack. This doesn't sound good when it's used from different threads. Moving it to static RAM.

Jira: NCSDK-26707