### PR TITLE
net: lib: nrf_cloud: Improve FOTA build order

### DIFF
--- a/subsys/net/lib/nrf_cloud/CMakeLists.txt
+++ b/subsys/net/lib/nrf_cloud/CMakeLists.txt
@@ -9,8 +9,7 @@ zephyr_library_sources(
 	src/nrf_cloud_log.c
 	src/nrf_cloud_codec.c
 	src/nrf_cloud_mem.c
-	src/nrf_cloud_client_id.c
-	src/nrf_cloud_fota_common.c)
+	src/nrf_cloud_client_id.c)
 zephyr_library_sources_ifdef(
 	CONFIG_NRF_CLOUD_ALERT
 	src/nrf_cloud_alert.c)
@@ -45,11 +44,13 @@ zephyr_library_sources_ifdef(
 zephyr_library_sources_ifdef(
 	CONFIG_NRF_CLOUD_FOTA
 	src/nrf_cloud_fota.c
+	src/nrf_cloud_fota_common.c
 	src/nrf_cloud_download.c)
 zephyr_library_sources_ifdef(
-  CONFIG_NRF_CLOUD_FOTA_POLL
-  src/nrf_cloud_download.c
-  src/nrf_cloud_fota_poll.c)
+	CONFIG_NRF_CLOUD_FOTA_POLL
+	src/nrf_cloud_download.c
+	src/nrf_cloud_fota_common.c
+	src/nrf_cloud_fota_poll.c)
 zephyr_library_sources_ifdef(
 	CONFIG_NRF_CLOUD_REST
 	src/nrf_cloud_rest.c)

--- a/tests/subsys/net/lib/nrf_cloud/fota_common/CMakeLists.txt
+++ b/tests/subsys/net/lib/nrf_cloud/fota_common/CMakeLists.txt
@@ -18,6 +18,13 @@ FILE(GLOB app_sources src/main.c)
 endif()
 target_sources(app PRIVATE ${app_sources})
 
+if (NOT CONFIG_NRF_CLOUD_FOTA)
+	target_sources(app
+		PRIVATE
+		${ZEPHYR_NRF_MODULE_DIR}/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota_common.c
+	)
+endif()
+
 target_include_directories(app
 	PRIVATE
 	src


### PR DESCRIPTION
Only include nrf_cloud_fota_common.c in build when actually needed.

Jira: NCSDK-26679