### PR TITLE
RFC: partition_manager: cmake/python: Add DTS as input for partition_id

### DIFF
--- a/cmake/partition_manager.cmake
+++ b/cmake/partition_manager.cmake
@@ -312,13 +312,20 @@ set(pm_cmd
   ${region_arguments}
   )
 
+
+set(DTS_ROOT_BINDINGS ${CACHED_DTS_ROOT_BINDINGS})
+
 set(pm_output_cmd
   ${PYTHON_EXECUTABLE}
   ${ZEPHYR_NRF_MODULE_DIR}/scripts/partition_manager_output.py
   --input-partitions ${pm_out_partition_file}
   --input-regions ${pm_out_region_file}
   --config-file ${pm_out_dotconf_file}
+  --dts-file ${ZEPHYR_DTS}
+  --dtc-flags '${EXTRA_DTC_FLAGS_RAW}'
+  --bindings-dirs ${DTS_ROOT_BINDINGS}
   )
+
 
 # Run the partition manager algorithm.
 execute_process(
@@ -688,6 +695,9 @@ to the external flash")
     --input-regions ${pm_out_region_file}
     --header-files ${header_files}
     --images ${prefixed_images}
+    --dts-file ${ZEPHYR_DTS}
+    --dtc-flags '${EXTRA_DTC_FLAGS_RAW}'
+    --bindings-dirs ${DTS_ROOT_BINDINGS}
     )
 
   execute_process(


### PR DESCRIPTION
Sometimes we have issues where the FLASH_AREA_ID used is defined from DTS. This tries to remedie these types of issue to ensure that the FLASH_AREA_IDs for `fixed-partitions` are the same across DTS generated header and Partition Mananger generated header.

This way if you select a partition/flash_area from the DTS define it would map to the correct FLASH_AREA which was defined by partition manager resolving in less conflicts between DTS and PM.

The goal of this patch is to fix the issue regarding using `boot_write_img_confirmed()` function in to confirm MCUBoot images.

Fixes: NCSDK-26693