### PR TITLE
Add nRF54L15 support in BLE samples

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -215,6 +215,10 @@ Bluetooth samples
 
   * Added support for the :ref:`zephyr:nrf54l15pdk_nrf54l15` board.
 
+* :ref:`peripheral_hids_keyboard` sample:
+
+  * Added support for the :ref:`zephyr:nrf54l15pdk_nrf54l15` board.
+
 Bluetooth Mesh samples
 ----------------------
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -207,6 +207,10 @@ Bluetooth samples
 
   * Added support for the :ref:`zephyr:nrf54l15pdk_nrf54l15` board.
 
+* :ref:`bluetooth_central_hids` sample:
+
+  * Added support for the :ref:`zephyr:nrf54l15pdk_nrf54l15` board.
+
 Bluetooth Mesh samples
 ----------------------
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -211,6 +211,10 @@ Bluetooth samples
 
   * Added support for the :ref:`zephyr:nrf54l15pdk_nrf54l15` board.
 
+* :ref:`peripheral_hids_mouse` sample:
+
+  * Added support for the :ref:`zephyr:nrf54l15pdk_nrf54l15` board.
+
 Bluetooth Mesh samples
 ----------------------
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -203,6 +203,10 @@ Bluetooth samples
 
     * Added support for the :ref:`zephyr:nrf54l15pdk_nrf54l15` board.
 
+* :ref:`peripheral_lbs` sample:
+
+  * Added support for the :ref:`zephyr:nrf54l15pdk_nrf54l15` board.
+
 Bluetooth Mesh samples
 ----------------------
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -219,6 +219,10 @@ Bluetooth samples
 
   * Added support for the :ref:`zephyr:nrf54l15pdk_nrf54l15` board.
 
+* :ref:`central_and_peripheral_hrs` sample:
+
+  * Added support for the :ref:`zephyr:nrf54l15pdk_nrf54l15` board.
+
 Bluetooth Mesh samples
 ----------------------
 

--- a/samples/bluetooth/central_and_peripheral_hr/sample.yaml
+++ b/samples/bluetooth/central_and_peripheral_hr/sample.yaml
@@ -9,6 +9,7 @@ tests:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
+      - nrf54l15pdk_nrf54l15_cpuapp
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
-      nrf5340dk_nrf5340_cpuapp_ns
+      nrf5340dk_nrf5340_cpuapp_ns nrf54l15pdk_nrf54l15_cpuapp
     tags: bluetooth ci_build

--- a/samples/bluetooth/central_hids/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/bluetooth/central_hids/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Workaround:
+# The nRF54L15 PDK (PCA10156) revisions v0.2.0 AA0-ES2, v0.2.0 AA0-ES3,
+# and v0.2.1 AB0-ES5 have Buttons 3 and 4 connected to the GPIO port
+# which does not support interrupts.
+CONFIG_DK_LIBRARY_BUTTON_NO_ISR=y

--- a/samples/bluetooth/central_hids/sample.yaml
+++ b/samples/bluetooth/central_hids/sample.yaml
@@ -16,6 +16,7 @@ tests:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
+      - nrf54l15pdk_nrf54l15_cpuapp
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
-      nrf5340dk_nrf5340_cpuapp_ns
+      nrf5340dk_nrf5340_cpuapp_ns nrf54l15pdk_nrf54l15_cpuapp
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_hids_keyboard/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/bluetooth/peripheral_hids_keyboard/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Workaround:
+# The nRF54L15 PDK (PCA10156) revisions v0.2.0 AA0-ES2, v0.2.0 AA0-ES3,
+# and v0.2.1 AB0-ES5 have Buttons 3 and 4 connected to the GPIO port
+# which does not support interrupts.
+CONFIG_DK_LIBRARY_BUTTON_NO_ISR=y

--- a/samples/bluetooth/peripheral_hids_keyboard/sample.yaml
+++ b/samples/bluetooth/peripheral_hids_keyboard/sample.yaml
@@ -16,6 +16,7 @@ tests:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
+      - nrf54l15pdk_nrf54l15_cpuapp
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
-      nrf5340dk_nrf5340_cpuapp_ns
+      nrf5340dk_nrf5340_cpuapp_ns nrf54l15pdk_nrf54l15_cpuapp
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_hids_mouse/README.rst
+++ b/samples/bluetooth/peripheral_hids_mouse/README.rst
@@ -66,6 +66,9 @@ Setup
 
 The HID service specification does not require encryption (:kconfig:option:`CONFIG_BT_HIDS_DEFAULT_PERM_RW_ENCRYPT`), but some systems disconnect from the HID devices that do not support security.
 
+.. note::
+   If you want to pair the device with a computer running MacOS, set the :kconfig:option:`CONFIG_BT_HIDS_DEFAULT_PERM_RW_AUTHEN` Kconfig option to ``y``.
+
 Building and running
 ********************
 

--- a/samples/bluetooth/peripheral_hids_mouse/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/bluetooth/peripheral_hids_mouse/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Workaround:
+# The nRF54L15 PDK (PCA10156) revisions v0.2.0 AA0-ES2, v0.2.0 AA0-ES3,
+# and v0.2.1 AB0-ES5 have Buttons 3 and 4 connected to the GPIO port
+# which does not support interrupts.
+CONFIG_DK_LIBRARY_BUTTON_NO_ISR=y

--- a/samples/bluetooth/peripheral_hids_mouse/sample.yaml
+++ b/samples/bluetooth/peripheral_hids_mouse/sample.yaml
@@ -16,8 +16,9 @@ tests:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
+      - nrf54l15pdk_nrf54l15_cpuapp
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
-      nrf5340dk_nrf5340_cpuapp_ns
+      nrf5340dk_nrf5340_cpuapp_ns nrf54l15pdk_nrf54l15_cpuapp
     tags: bluetooth ci_build
   sample.bluetooth.peripheral_hids_mouse.ble_rpc:
     build_only: true
@@ -36,8 +37,8 @@ tests:
     tags: bluetooth ci_build
   # Build integration regression protection.
   sample.nrf_security.bluetooth.integration:
-      build_only: True
-      extra_args: CONFIG_NRF_SECURITY=y CONFIG_BOOTLOADER_MCUBOOT=y
-      platform_allow: nrf5340dk_nrf5340_cpuapp
-      integration_platforms:
-          - nrf5340dk_nrf5340_cpuapp
+    build_only: true
+    extra_args: CONFIG_NRF_SECURITY=y CONFIG_BOOTLOADER_MCUBOOT=y
+    platform_allow: nrf5340dk_nrf5340_cpuapp
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp

--- a/samples/bluetooth/peripheral_lbs/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
+++ b/samples/bluetooth/peripheral_lbs/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/*
+ * The sample does not use Buttons 3 and 4.
+ * Buttons 3 and 4 in PDK are connected to the GPIO port, which does not support interrupts.
+ */
+
+/ {
+	aliases {
+		/delete-property/ sw2;
+		/delete-property/ sw3;
+	};
+	buttons {
+		/delete-node/ button_2;
+		/delete-node/ button_3;
+	};
+};

--- a/samples/bluetooth/peripheral_lbs/sample.yaml
+++ b/samples/bluetooth/peripheral_lbs/sample.yaml
@@ -11,9 +11,10 @@ tests:
       - nrf5340dk_nrf5340_cpuapp_ns
       - thingy53_nrf5340_cpuapp
       - thingy53_nrf5340_cpuapp_ns
-    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810
+      - nrf54l15pdk_nrf54l15_cpuapp
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp
-      thingy53_nrf5340_cpuapp_ns
+      thingy53_nrf5340_cpuapp_ns nrf54l15pdk_nrf54l15_cpuapp
     tags: bluetooth ci_build
   sample.bluetooth.peripheral_lbs_minimal:
     build_only: true
@@ -34,9 +35,10 @@ tests:
       - nrf5340dk_nrf5340_cpuapp_ns
       - thingy53_nrf5340_cpuapp
       - thingy53_nrf5340_cpuapp_ns
-    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810
+      - nrf54l15pdk_nrf54l15_cpuapp
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp
-      thingy53_nrf5340_cpuapp_ns
+      thingy53_nrf5340_cpuapp_ns nrf54l15pdk_nrf54l15_cpuapp
     tags: bluetooth ci_build
   sample.bluetooth.peripheral_lbs_bt_ota_dfu:
     build_only: true


### PR DESCRIPTION
Adds support for samples: 
- central_hids
- peripheral_hids_mouse
- peripheral_hids_keyboard
- central_and_peripheral_hr
- peripheral_lbs