### PR TITLE
samples: Align partitioning to free space

### DIFF
--- a/samples/tfm/tfm_psa_template/child_image/mcuboot/prj.conf
+++ b/samples/tfm/tfm_psa_template/child_image/mcuboot/prj.conf
@@ -24,3 +24,6 @@ CONFIG_BOOT_SIGNATURE_TYPE_ECDSA_P256=y
 CONFIG_BOOT_SIGNATURE_TYPE_RSA=n
 ### Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
+
+### Make MCUboot 0x200 smaller to make it fit inside an SPU region
+CONFIG_PM_PARTITION_SIZE_MCUBOOT=0xbe00


### PR DESCRIPTION
Remove two EMPTY_ partitions by aligning MCUboot inside SPU regions.