### PR TITLE
doc: Fix some terms in the docs

### DIFF
--- a/applications/asset_tracker_v2/doc/cloud_module.rst
+++ b/applications/asset_tracker_v2/doc/cloud_module.rst
@@ -188,7 +188,7 @@ If not using the default DPS (Device Provisioning Service) host, ensure that the
 Configurations for LwM2M integration layer
 ------------------------------------------
 
-When building for LwM2M, the cloud module's default configuration is to communicate with AVSystem's `Coiote Device Management`_, with a runtime provisioned `Pre-shared key (PSK)`_ set by the :kconfig:option:`CONFIG_LWM2M_INTEGRATION_PSK` option.
+When building for LwM2M, the cloud module's default configuration is to communicate with AVSystem's `Coiote Device Management`_, with a runtime provisioned `pre-shared key <Pre-shared key (PSK)_>`_ set by the :kconfig:option:`CONFIG_LWM2M_INTEGRATION_PSK` option.
 This enables the device to work with `Coiote Device Management`_ without provisioning the PSK to the modem before running the application.
 To allow the device to communicate with other LwM2M Servers, modify the default configuration by changing the following Kconfig options:
 

--- a/applications/asset_tracker_v2/doc/cloud_wrapper.rst
+++ b/applications/asset_tracker_v2/doc/cloud_wrapper.rst
@@ -53,7 +53,7 @@ The application integrates LwM2M through the following APIs:
 Bootstrapping and credential handling
 -------------------------------------
 
-When the option :kconfig:option:`CONFIG_LWM2M_INTEGRATION_PSK` is enabled, the modem is provisioned at run time after boot with a `Pre-Shared Key (PSK)`_ set by :kconfig:option:`CONFIG_LWM2M_INTEGRATION_PSK`.
+When the option :kconfig:option:`CONFIG_LWM2M_INTEGRATION_PSK` is enabled, the modem is provisioned at run time after boot with a `pre-shared key (PSK) <Pre-Shared Key (PSK)_>`_ set by :kconfig:option:`CONFIG_LWM2M_INTEGRATION_PSK`.
 
 If :kconfig:option:`CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP` is enabled, the PSK is provisioned to a security tag dedicated to the bootstrap server connection.
 During bootstrapping, the application receives a separate newly generated key from the bootstrap server that is provisioned to a security tag dedicated to the management server connection.

--- a/applications/asset_tracker_v2/doc/unit_test.rst
+++ b/applications/asset_tracker_v2/doc/unit_test.rst
@@ -23,9 +23,9 @@ Running the unit test
 
 To run the unit test, you must navigate to the test directory of the respective internal module.
 For example, to run the unit test for :ref:`asset_tracker_v2_debug_module`, navigate to :file:`asset_tracker_v2/tests/debug_module`.
-The unit tests can be executed using West or Twister.
+The unit tests can be executed using west or Twister.
 
-Running unit tests using West
+Running unit tests using west
 =============================
 
 Enter the following west commands to execute the tests on different board targets:

--- a/applications/serial_lte_modem/doc/Generic_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/Generic_AT_commands.rst
@@ -440,7 +440,7 @@ The ``<type>`` parameter can have the following integer values:
 * ``0`` - Root CA certificate (PEM format)
 * ``1`` - Certificate (PEM format)
 * ``2`` - Private key (PEM format)
-* ``3`` - Pre-shared Key (PSK) (ASCII text)
+* ``3`` - Pre-shared key (PSK) (ASCII text)
 * ``4`` - PSK identity (ASCII text)
 
 It is mandatory for *write* and *delete* operations.

--- a/applications/serial_lte_modem/doc/slm_testing.rst
+++ b/applications/serial_lte_modem/doc/slm_testing.rst
@@ -477,7 +477,7 @@ DTLS client
 
 The DTLS client requires connection-based UDP to trigger the DTLS establishment.
 
-Before completing this test, you must update the Pre-shared Key (PSK) and the PSK identity to be used for the TLS connection in the modem.
+Before completing this test, you must update the pre-shared key (PSK) and the PSK identity to be used for the TLS connection in the modem.
 The credentials must use the security tag 16842756.
 
 To store the credentials in the modem, enter the following AT commands:

--- a/doc/nrf/device_guides/working_with_nrf/nrf91/nrf9160.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf91/nrf9160.rst
@@ -541,7 +541,7 @@ If your application was built using the |NCS|, you must define partitions using 
 The built-in partition definitions can be found in the :file:`nrf/subsys/partition_manager` folder, and the file names start with ``pm.yml``.
 The files which have ``external_flash`` as their region will have support for storing partitions in the external flash.
 You can also find the configuration option required to place the partition in the external flash region in those files.
-For example, the :file:`pm.yml.pgps` file has an option (:kconfig:option:`CONFIG_PM_PARTITION_REGION_PGPS_EXTERNAL`) to place the PGPS partition in external flash:
+For example, the :file:`pm.yml.pgps` file has an option (:kconfig:option:`CONFIG_PM_PARTITION_REGION_PGPS_EXTERNAL`) to place the P-GPS partition in external flash:
 
 .. code-block:: c
 

--- a/doc/nrf/device_guides/working_with_nrf/nrf91/nrf91_features.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf91/nrf91_features.rst
@@ -70,8 +70,8 @@ The AT commands are documented in the `nRF91x1 AT Commands Reference Guide`_  an
 
 The firmware for the modem is available as a precompiled binary.
 You can download the firmware from the `nRF9161 product website (compatible downloads)`_ or `nRF9160 product website (compatible downloads)`_, depending on the SiP you are using.
-The zip file contains the release notes, and both the full firmware and patches to upgrade from one version to another.
-A delta patch can only upgrade the modem firmware from one specific version to another version (for example, v1.2.1 to v1.2.2).
+The zip file contains the release notes, and both the full firmware and patches to update from one version to another.
+A delta patch can only update the modem firmware from one specific version to another version (for example, v1.2.1 to v1.2.2).
 If you need to perform a major version update (for example, v1.2.x to v1.3.x), you need an external flash with a minimum size of 4 MB.
 
 Different versions of the LTE modem firmware are available, and these versions are certified for the mobile network operators having their own certification programs.
@@ -85,13 +85,13 @@ See the `Mobile network operator certifications`_ for more information.
 .. _nrf91_update_modem_fw:
 .. _nrf9160_update_modem_fw:
 
-Modem firmware upgrade
-======================
+Modem firmware update
+=====================
 
 There are two ways to update the modem firmware:
 
-Full upgrade
-  You can use either a wired or a wireless connection to do a full upgrade of the modem firmware:
+Full update
+  You can use either a wired or a wireless connection to do a full update of the modem firmware:
 
   * When using a wired connection, you can use either the `nRF Connect Programmer`_, which is part of `nRF Connect for Desktop`_, or the `nRF pynrfjprog`_ Python package.
     Both methods use the Simple Management Protocol (SMP) to provide an interface over UART, which enables the device to perform the update.
@@ -102,16 +102,16 @@ Full upgrade
     * You can also use the nRF pynrfjprog Python package to perform the update, as long as a custom application image integrating the ``lib_fmfu_mgmt`` subsystem is included in the existing firmware of the device.
       See the :ref:`fmfu_smp_svr_sample` sample for an example on how to integrate the :ref:`subsystem <lib_fmfu_mgmt>` in your custom application.
 
-  * When using a wireless connection, the upgrade is applied over-the-air (OTA).
+  * When using a wireless connection, the update is applied over-the-air (OTA).
     See :ref:`nrf91_fota` for more information.
 
  See :ref:`nrfxlib:nrf_modem_bootloader` for more information on the full firmware updates of modem using :ref:`nrfxlib:nrf_modem`.
 
 Delta patches
-  Delta patches are upgrades that contain only the difference from the last version.
+  Delta patches are updates that contain only the difference from the last version.
   See :ref:`nrfxlib:nrf_modem_delta_dfu` for more information on delta firmware updates of modem using :ref:`nrfxlib:nrf_modem`.
   When applying a delta patch, you must therefore ensure that this patch works with the current firmware version on your device.
-  Delta patches are applied as firmware over-the-air (FOTA) upgrades.
+  Delta patches are applied as firmware over-the-air (FOTA) updates.
   See :ref:`nrf91_fota` for more information.
 
 .. _nrf91_ug_band_lock:
@@ -190,34 +190,34 @@ For more information on the implementation of a custom trace backend, see :ref:`
 .. _nrf91_fota:
 .. _nrf9160_fota:
 
-FOTA upgrades
-*************
+FOTA updates
+************
 
 |fota_upgrades_def|
-FOTA upgrades can be used to apply delta patches to the :ref:`lte_modem` firmware, full :ref:`lte_modem` firmware upgrades, and to replace the upgradable bootloader or the application.
+FOTA updates can be used to apply delta patches to the :ref:`lte_modem` firmware, full :ref:`lte_modem` firmware updates, and to replace the upgradable bootloader or the application.
 
 .. note::
-   Even though the Trusted Firmware-M and the application are two individually compiled components, they are treated as a single binary blob in the context of firmware upgrades.
+   Even though the Trusted Firmware-M and the application are two individually compiled components, they are treated as a single binary blob in the context of firmware updates.
    Any reference to the application in this section is meant to indicate the application including the Trusted Firmware-M.
 
-To perform a FOTA upgrade, complete the following steps:
+To perform a FOTA updates, complete the following steps:
 
-1. Make sure that your application supports FOTA upgrades.
+1. Make sure that your application supports FOTA updates.
 
-   To download and apply FOTA upgrades, your application must use the :ref:`lib_fota_download` library.
-   This library determines the type of upgrade by inspecting the header of the firmware and invokes the :ref:`lib_dfu_target` library to apply the firmware upgrade.
-   In its default configuration, the DFU target library is set to support all the types of FOTA upgrades except full modem firmware upgrades, but you can freely enable or disable the support for specific targets.
+   To download and apply FOTA updates, your application must use the :ref:`lib_fota_download` library.
+   This library determines the type of update by inspecting the header of the firmware and invokes the :ref:`lib_dfu_target` library to apply the firmware update.
+   In its default configuration, the DFU target library is set to support all the types of FOTA updates except full modem firmware updates, but you can freely enable or disable the support for specific targets.
    In addition, the following requirements apply:
 
    * To upgrade the application, you must use :doc:`mcuboot:index-ncs` as the upgradable bootloader (:kconfig:option:`CONFIG_BOOTLOADER_MCUBOOT` must be enabled).
    * If you want to upgrade the upgradable bootloader, you must use the :ref:`bootloader` (:kconfig:option:`CONFIG_SECURE_BOOT must be enabled`).
-   * If you want to upgrade the modem firmware through modem delta updates, you do not need to use MCUboot or the immutable bootloader, because the modem firmware upgrade is handled by the modem itself.
-   * If you want to perform a full modem firmware upgrade, an |external_flash_size| is required.
+   * If you want to update the modem firmware through modem delta updates, you do not need to use MCUboot or the immutable bootloader, because the modem firmware update is handled by the modem itself.
+   * If you want to perform a full modem firmware update, an |external_flash_size| is required.
 
 #. Create a binary file that contains the new image.
 
    .. note::
-      This step does not apply for upgrades of the modem firmware.
+      This step does not apply for updates of the modem firmware.
       You can download delta patches and full binaries of the modem firmware from the `nRF9161 product website (compatible downloads)`_ or `nRF9160 product website (compatible downloads)`_, depending on the SiP you are using.
 
    |fota_upgrades_building|
@@ -232,10 +232,10 @@ To perform a FOTA upgrade, complete the following steps:
 
 The full FOTA procedure depends on where the binary files are hosted for download.
 
-FOTA upgrades using nRF Cloud
-=============================
+FOTA updates using nRF Cloud
+============================
 
-FOTA upgrades can be managed through a comprehensive management portal on `nRF Cloud`_, either fully hosted on nRF Cloud or accessible from a customer cloud using the `nRF Cloud REST API`_.
+FOTA updates can be managed through a comprehensive management portal on `nRF Cloud`_, either fully hosted on nRF Cloud or accessible from a customer cloud using the `nRF Cloud REST API`_.
 If you are using nRF Cloud, see the `nRF Cloud Getting Started FOTA documentation`_ for instructions.
 
 Currently, delta modem firmware FOTA files are available in nRF Cloud under :guilabel:`Firmware Updates` in the :guilabel:`Device Management` tab on the left.
@@ -244,10 +244,10 @@ If you intend to obtain FOTA files from nRF Cloud, see the additional requiremen
 You can upload custom application binaries to nRF Cloud for application FOTA updates.
 After :ref:`nrf9160_gs_connecting_dk_to_cloud`, you can upload the files to your nRF Cloud account as a bundle after navigating to :guilabel:`Device Management` on the left and clicking :guilabel:`Firmware Updates`.
 
-FOTA upgrades using other cloud services
+FOTA updates using other cloud services
 ========================================
 
-FOTA upgrades can alternatively be hosted from a customer-developed cloud services such as solutions based on AWS and Azure.
+FOTA updates can alternatively be hosted from a customer-developed cloud services such as solutions based on AWS and Azure.
 If you are uploading the files to an Amazon Web Services Simple Storage Service (AWS S3) bucket, see the :ref:`lib_aws_fota` documentation for instructions.
 Samples are provided in |NCS| for AWS (:ref:`aws_iot` sample) and Azure (:ref:`azure_iot_hub` sample).
 

--- a/doc/nrf/external_comp/avsystem.rst
+++ b/doc/nrf/external_comp/avsystem.rst
@@ -176,7 +176,7 @@ Applications and samples
 
 The following application uses the AVSystem integration in |NCS|:
 
-* :ref:`asset_tracker_v2` - The :ref:`asset_tracker_v2_cloud_module` is set to communicate with AVSystem's Coiote Device Management, with a runtime provisioned Pre-shared key (PSK) set by the ``CONFIG_LWM2M_INTEGRATION_PSK`` Kconfig option.
+* :ref:`asset_tracker_v2` - The :ref:`asset_tracker_v2_cloud_module` is set to communicate with AVSystem's Coiote Device Management, with a runtime provisioned pre-shared key (PSK) set by the ``CONFIG_LWM2M_INTEGRATION_PSK`` Kconfig option.
   For more information, see :ref:`assettracker_v2_cloudmodule_lwm2m`.
 
 The following samples use the AVSystem integration in |NCS|:

--- a/doc/nrf/glossary.rst
+++ b/doc/nrf/glossary.rst
@@ -936,15 +936,15 @@ Glossary
       See :ref:`zephyr:west`.
 
    West manifest file
-      The main file describing the contents of a :term:`West` workspace, which is located in the :term:`West manifest repository`.
+      The main file describing the contents of a :term:`west <West>` workspace, which is located in the :term:`west manifest repository <West manifest repository>`.
       In the |NCS| and Zephyr, it is named :file:`west.yml`.
 
    West manifest repository
-      A :term:`repository <Repository>` that contains a :term:`West manifest file` and can be used to configure a west workspace.
+      A :term:`repository <Repository>` that contains a :term:`west manifest file <West manifest file>` and can be used to configure a west workspace.
       See :ref:`dm_repo_types`.
 
    West project
-      Any of the listed :term:`repositories <Repository>` inside a :term:`West manifest file`.
+      Any of the listed :term:`repositories <Repository>` inside a :term:`west manifest file <West manifest file>`.
 
    Wi-Fi Protected Access® (WPA)
       A security protocol developed by Wi-Fi Alliance.

--- a/doc/nrf/protocols/bt/bt_mesh/concepts.rst
+++ b/doc/nrf/protocols/bt/bt_mesh/concepts.rst
@@ -266,7 +266,7 @@ The Bluetooth Mesh profile specification defines a range of out-of-band authenti
 
 * Blinking of lights
 * Output and input of passphrases
-* Static authentication against a pre-shared key
+* Static authentication against a pre-shared key (PSK)
 
 To secure the provisioning procedure, elliptic curve Diffie-Helman (ECDH) public key cryptography is used.
 After a device has been provisioned, it is part of the network and all its messages are considered authenticated.

--- a/doc/nrf/releases_and_maturity/known_issues.rst
+++ b/doc/nrf/releases_and_maturity/known_issues.rst
@@ -2799,7 +2799,7 @@ The combination of nRF Secure Immutable Bootloader and MCUboot fails to upgrade 
 .. rst-class:: v1-4-2 v1-4-1 v1-4-0
 
 NRF91-989: Unable to bootstrap after changing SIMs
-  In some cases, swapping the SIM card might trigger the bootstrap Pre-Shared Key to be deleted from the device.
+  In some cases, swapping the SIM card might trigger the bootstrap pre-shared key (PSK) to be deleted from the device.
   This can prevent future bootstraps from succeeding.
 
   **Affected platforms:** nRF9160

--- a/samples/cellular/lwm2m_carrier/provisioning.rst
+++ b/samples/cellular/lwm2m_carrier/provisioning.rst
@@ -40,7 +40,7 @@ To pre-program the certificates, use one of the following methods:
 
 Other samples and applications like :ref:`asset_tracker_v2` and :ref:`modem_shell_application` with the carrier library integration do not write any certificates in the application.
 
-Pre-shared Key (PSK)
+Pre-shared key (PSK)
 ********************
 
 In live (production) environment, the correct PSK is generated and stored in the modem depending on which operator network the device is in.

--- a/samples/cellular/lwm2m_carrier/sample_description.rst
+++ b/samples/cellular/lwm2m_carrier/sample_description.rst
@@ -86,7 +86,7 @@ Server options
 
 .. _CONFIG_CARRIER_APP_PSK:
 
-CONFIG_CARRIER_APP_PSK - Configuration for Pre-Shared Key
+CONFIG_CARRIER_APP_PSK - Configuration for a pre-shared key (PSK)
    The sample configuration is used to set the hexadecimal representation of the PSK used when registering the device with the server.
    The PSK is stored in the security tag specified in :kconfig:option:`CONFIG_LWM2M_CARRIER_SERVER_SEC_TAG`.
 

--- a/samples/cellular/lwm2m_client/sample_description.rst
+++ b/samples/cellular/lwm2m_client/sample_description.rst
@@ -164,7 +164,7 @@ You need to provide the following information to the LwM2M Server before you can
 
 * Client endpoint
 * Identity
-* `Pre-Shared Key (PSK)`_
+* `Pre-shared key (PSK) <Pre-Shared Key (PSK)_>`_
 
 See :ref:`server setup <server_setup_lwm2m_client>` for instructions on providing the information to the server.
 
@@ -312,7 +312,7 @@ Server options
 
 .. _CONFIG_APP_LWM2M_PSK:
 
-CONFIG_APP_LWM2M_PSK - Configuration for Pre-Shared Key
+CONFIG_APP_LWM2M_PSK - Configuration for the PSK
    The sample configuration sets the hexadecimal representation of the PSK used when registering the device with the server.
    To prevent provisioning of the key to the modem, set this option to an empty string.
 

--- a/samples/cellular/nrf_cloud_multi_service/README.rst
+++ b/samples/cellular/nrf_cloud_multi_service/README.rst
@@ -1139,7 +1139,7 @@ Then, complete the following steps for each device you wish to onboard:
 
    This script also installs any nRF Cloud root CA certificates required in a single chain to the :kconfig:option:`CONFIG_NRF_CLOUD_SEC_TAG` security tag (``sec_tag``).
    CoAP connections use one root CA certificate, whereas HTTPS and MQTT use another.
-   Devices using CoAP need both installed, since HTTPS is used for FOTA and PGPS on CoAP devices.
+   Devices using CoAP need both installed, since HTTPS is used for FOTA and P-GPS on CoAP devices.
 
    If the script succeeds, you should see the following output:
 

--- a/samples/crypto/psa_tls/README.rst
+++ b/samples/crypto/psa_tls/README.rst
@@ -11,7 +11,7 @@ The PSA TLS sample shows how to perform a TLS handshake and send encrypted messa
 
 .. note::
 
-   Datagram Transport Layer Security (DTLS) and Pre-shared key (PSK) are currently not supported.
+   Datagram Transport Layer Security (DTLS) and pre-shared key (PSK) are currently not supported.
 
 For information about CMSE and the difference between the two environments, see :ref:`app_boards_spe_nspe`.
 

--- a/samples/debug/memfault/README.rst
+++ b/samples/debug/memfault/README.rst
@@ -231,7 +231,7 @@ Before testing, ensure that your device is configured with the project key of yo
 Dependencies
 ************
 
-The sample requires the Memfault SDK, which is part of |NCS|'s West manifest, and will be downloaded automatically when ``west update`` is run.
+The sample requires the Memfault SDK, which is part of |NCS|'s west manifest, and will be downloaded automatically when ``west update`` is run.
 
 This sample uses the following |NCS| libraries and drivers:
 


### PR DESCRIPTION
Fixed the following terms:

* west
* P-GPS
* pre-shared key (PSK)
* Fota upgrade -> fota update in the nRF91 Series
working with guide to be consistent across all 
doc-sets.