### PR TITLE
manifest: sdk-zephyr: Pull Wi-Fi state check fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 272786b074227b4abcbe8f954d5bb8acf54f3dd3
+      revision: pull/1593/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Fixes intermittent failures with PS mode or listen interval setting.