### PR TITLE
samples: matter: Fix network events for WiFi/Thread switched

### DIFF
--- a/samples/matter/common/src/board/board.cpp
+++ b/samples/matter/common/src/board/board.cpp
@@ -312,19 +312,22 @@ void Board::DefaultMatterEventHandler(const ChipDeviceEvent *event, intptr_t /* 
 #if defined(CONFIG_NET_L2_OPENTHREAD)
 	case DeviceEventType::kThreadStateChange:
 		isNetworkProvisioned = ConnectivityMgr().IsThreadProvisioned() && ConnectivityMgr().IsThreadEnabled();
-#elif defined(CONFIG_CHIP_WIFI)
+	break;
+#endif /* CONFIG_NET_L2_OPENTHREAD */
+#if defined(CONFIG_CHIP_WIFI)
 	case DeviceEventType::kWiFiConnectivityChange:
 		isNetworkProvisioned =
 			ConnectivityMgr().IsWiFiStationProvisioned() && ConnectivityMgr().IsWiFiStationEnabled();
-#endif /* CONFIG_NET_L2_OPENTHREAD */
-		if (isNetworkProvisioned) {
-			sInstance.UpdateDeviceState(DeviceState::DeviceProvisioned);
-		} else {
-			sInstance.UpdateDeviceState(DeviceState::DeviceDisconnected);
-		}
 		break;
+#endif /* CONFIG_CHIP_WIFI */
 	default:
 		break;
+	}
+
+	if (isNetworkProvisioned) {
+		sInstance.UpdateDeviceState(DeviceState::DeviceProvisioned);
+	} else {
+		sInstance.UpdateDeviceState(DeviceState::DeviceDisconnected);
 	}
 }
 


### PR DESCRIPTION
Matter Network events that come from Thread or WiFi were being handled wrongly in the common board module.

When we can use Thread and WiFi on the same device there must not be elsif for choosing thread and WiFi during handling Matter Event.