### PR TITLE
doc: wifi: Add Wi-Fi certification page

### DIFF
--- a/doc/nrf/device_guides/working_with_nrf/nrf70/gs.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf70/gs.rst
@@ -23,6 +23,8 @@ Overview
 ********
 
 The nRF7002 DK (PCA10143) is a single-board development kit for evaluation and development on the nRF7002, a Wi-Fi companion :term:`Integrated Circuit (IC)` to Nordic Semiconductor's nRF5340 System-on-Chip (SoC) host processor.
+It is certified for the Wi-Fi Alliance® `certification program <Wi-Fi Certification_>`_ in the Connectivity, Security, and Optimization categories.
+See :ref:`ug_wifi_certification` for detailed information.
 
 The nRF7002 is an IEEE 802.11ax (Wi-Fi 6) compliant solution that implements the Wi-Fi physical layer and Medium Access Control (MAC) layer protocols.
 It implements the nRF Wi-Fi driver software on the nRF5340 host processor communicating over the QSPI bus.

--- a/doc/nrf/protocols/wifi/index.rst
+++ b/doc/nrf/protocols/wifi/index.rst
@@ -29,6 +29,7 @@ If you want to go through an online training course to familiarize yourself with
    :caption: Subpages:
 
    wifi.rst
+   wifi_certification
    station_mode/index
    scan_mode/index
    sap_mode/index

--- a/doc/nrf/protocols/wifi/wifi.rst
+++ b/doc/nrf/protocols/wifi/wifi.rst
@@ -1,7 +1,7 @@
+.. _ug_wifi_overview:
+
 Wi-Fi overview
 ##############
-
-.. _ug_wifi_overview:
 
 .. contents::
    :local:
@@ -139,16 +139,3 @@ The range of supported rates is vast, ranging from 86 Mbps for a single antenna 
 Wi-Fi has traditionally been single user (SU) based, which means that during any particular on-air packet transmission, the communication is between two users (excluding broadcast/multicast scenarios where the same information is delivered to multiple users).
 With the advent of Wi-Fi 6 (and to some extent Wi-Fi 5), multiuser (MU) support has been introduced.
 Through both MIMO and Orthogonal Frequency Division Multiple Access (OFDMA) techniques (and even a combination of both), it is now possible to send unique information to multiple users in the same on-air packet transmission, both in the downlink and uplink direction.
-
-.. _ug_wifi_certification:
-
-Wi-Fi certification
-*******************
-
-The Wi-Fi Alliance offers full `certification program <Wi-Fi Certification_>`_ that validates the interoperability of a Wi-Fi end product with other Wi-Fi Certified equipment.
-The program offers three different paths of certification to Contributor-level `members of the Wi-Fi Alliance <Join Wi-Fi Alliance_>`_.
-Implementer-level members can take advantage of the program by implementing Wi-Fi modules that have been previously certified by a Contributor-level member, for example one of the `Nordic third-party modules`_.
-
-For details about the Wi-Fi certification program and the available paths for the nRF70 Series, read the `Wi-Fi Alliance Certification for nRF70 Series`_ document.
-
-For instructions on how to specifically use the QuickTrack certification path, see the :ref:`wifi_wfa_qt_app_sample` page.

--- a/doc/nrf/protocols/wifi/wifi_certification.rst
+++ b/doc/nrf/protocols/wifi/wifi_certification.rst
@@ -1,0 +1,30 @@
+.. _ug_wifi_certification:
+
+Wi-Fi certification
+###################
+
+.. contents::
+   :local:
+   :depth: 2
+
+The Wi-Fi Alliance® offers a full `certification program <Wi-Fi Certification_>`_ that validates the interoperability of a Wi-Fi® end product with other Wi-Fi certified equipment.
+The program offers three different paths of certification to Contributor-level `members of the Wi-Fi Alliance <Join Wi-Fi Alliance_>`_.
+Implementer-level members can take advantage of the program by implementing Wi-Fi modules that have been previously certified by a Contributor-level member, for example, one of the `Nordic third-party modules`_.
+
+Qualified solution
+******************
+
+Nordic Semiconductor supports programs and paths to create qualified solutions that you can use to accelerate the Wi-Fi certification of their end products.
+As a solution provider, it creates qualified solutions and qualified solution variants for its product evaluation platforms based on the nRF70 Series devices and the |NCS|.
+This enables you to use the QuickTrack Wi-Fi certification process.
+
+Wi-Fi certification paths
+*************************
+
+An end product based on an nRF70 Series device can achieve Wi-Fi certification through the QuickTrack or Derivative paths.
+The QuickTrack certification path is applicable for all end products designed from either the Nordic Semiconductor qualified solutions or qualified solution variant evaluation platforms, where limited modifications are allowed.
+Derivative certification is applicable for end products based on third-party Wi-Fi CERTIFIED™ modules containing an nRF70 Series IC without any modification.
+
+For details about the Wi-Fi certification program and the available paths for the nRF70 Series, read the `Wi-Fi Alliance Certification for nRF70 Series`_ document.
+
+For instructions on how to specifically use the QuickTrack certification path, see the :ref:`wifi_wfa_qt_app_sample` page.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -547,5 +547,6 @@ Documentation
 * Updated:
 
   * The table listing the :ref:`boards included in sdk-zephyr <app_boards_names_zephyr>` with the nRF54L15 PDK and nRF54H20 DK boards.
+  * The :ref:`ug_wifi_overview` page by separating the information about Wi-Fi certification into its own :ref:`ug_wifi_certification` page under :ref:`ug_wifi`.
 
 * Added the :ref:`ug_coremark` page.


### PR DESCRIPTION
Added Wi-Fi certification page under the Wi-Fi protocols. Moved the Wi-Fi certification section from the Overview page to the new page.
Added certification info to the nRF7002 DK gsg.

SHEL-1666