### PR TITLE
scripts: add integration quarantine part 5

### DIFF
--- a/scripts/quarantine_integration.yaml
+++ b/scripts/quarantine_integration.yaml
@@ -581,3 +581,13 @@
     - nrf52dk_nrf52832
     - nrf9160dk_nrf9160
   comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - sample.gazell.gzp_dynamic_pairing.device.build
+    - sample.gazell.gzll_ack_payload.host.build
+    - sample.gazell.gzll_ack_payload.device.build
+    - sample.gazell.gzp_dynamic_pairing.host.build
+  platforms:
+    - nrf52840dk_nrf52840
+    - nrf52833dk_nrf52833
+  comment: "Configurations excluded to limit resources usage in integration builds"


### PR DESCRIPTION
To limit integration scope.
For:
nrf/samples/gazell