### PR TITLE
manifest: zephyr sdk-update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: a503870a7a7f6f0b1f9a8213998c0a4ed066b194
+      revision: 09eb172fafde2bcd727e6310d453e70a2e1e8da5
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Fix MCUboot's application image confirmation issue.

Ref.: NCSDK-26693