### PR TITLE
net: lib: nrf_cloud_coap: Enable SO_KEEPOPEN

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -521,10 +521,13 @@ Cellular samples
   * Fixed:
 
     * An issue that prevented network connectivity when using Wi-Fi scanning with the nRF91xx.
+    * An issue that caused the CoAP shadow polling thread to run too often if no data received.
 
   * Added:
 
     * The ability to control the state of the test counter using the config section in the device shadow.
+    * Handling of L4 disconnect where CoAP connection is paused and socket is kept open, then resumed when L4 reconnects.
+    * Checking in CoAP FOTA and shadow polling threads to improve recovery from communications failures.
 
 * :ref:`udp` sample:
 
@@ -878,6 +881,7 @@ Libraries for networking
 
     * The :c:func:`nrf_cloud_coap_shadow_desired_update` function to allow devices to reject invalid shadow deltas.
     * Support for IPv6 connections.
+    * The ``SO_KEEPOPEN`` socket option to keep the socket open even during PDN disconnect and reconnect.
 
 * :ref:`lib_lwm2m_client_utils` library:
 

--- a/samples/cellular/nrf_cloud_multi_service/src/cloud_connection.h
+++ b/samples/cellular/nrf_cloud_multi_service/src/cloud_connection.h
@@ -68,6 +68,12 @@ void register_general_dev_msg_handler(dev_msg_handler_cb_t handler_cb);
 void disconnect_cloud(void);
 
 /**
+ * @brief Report a communications error so the cloud_connection can evaluate and
+ * recover.
+ */
+void cloud_transport_error_detected(void);
+
+/**
  * @brief Cloud connection thread function.
  *
  * This function manages the cloud connection thread. Once called, it begins monitoring network

--- a/samples/cellular/nrf_cloud_multi_service/src/fota_support_coap.c
+++ b/samples/cellular/nrf_cloud_multi_service/src/fota_support_coap.c
@@ -84,9 +84,12 @@ int coap_fota_thread_fn(void)
 			LOG_DBG("Retrying in %d minute(s)",
 				CONFIG_COAP_FOTA_JOB_CHECK_RATE_MINUTES);
 			k_sleep(K_MINUTES(CONFIG_COAP_FOTA_JOB_CHECK_RATE_MINUTES));
-		} else {
-			k_sleep(K_SECONDS(FOTA_THREAD_DELAY_S));
+			continue;
 		}
+		if (err == -ENOENT) {
+			cloud_transport_error_detected();
+		}
+		k_sleep(K_SECONDS(FOTA_THREAD_DELAY_S));
 	}
 	return 0;
 }

--- a/samples/cellular/nrf_cloud_multi_service/src/location_tracking.c
+++ b/samples/cellular/nrf_cloud_multi_service/src/location_tracking.c
@@ -11,6 +11,7 @@
 #include <date_time.h>
 #include <modem/lte_lc.h>
 
+#include "cloud_connection.h"
 #include "location_tracking.h"
 
 LOG_MODULE_REGISTER(location_tracking, CONFIG_MULTI_SERVICE_LOG_LEVEL);
@@ -31,6 +32,12 @@ static void location_event_handler(const struct location_event_data *event_data)
 
 	case LOCATION_EVT_TIMEOUT:
 		LOG_DBG("Location Event: Timed out");
+		if (event_data->method != LOCATION_METHOD_GNSS) {
+			/* GNSS can timeout due to obstructed satellite signals. Other methods
+			 * timeout when there is a communications error with the cloud.
+			 */
+			cloud_transport_error_detected();
+		}
 		break;
 
 	case LOCATION_EVT_ERROR:

--- a/samples/cellular/nrf_cloud_multi_service/src/shadow_support_coap.c
+++ b/samples/cellular/nrf_cloud_multi_service/src/shadow_support_coap.c
@@ -158,9 +158,13 @@ int coap_shadow_thread_fn(void)
 			LOG_INF("Checking shadow again in %d seconds",
 				CONFIG_COAP_SHADOW_CHECK_RATE_SECONDS);
 			k_sleep(K_SECONDS(CONFIG_COAP_SHADOW_CHECK_RATE_SECONDS));
-		} else {
-			k_sleep(K_SECONDS(SHADOW_THREAD_DELAY_S));
+			continue;
 		}
+		if (err == -ETIMEDOUT) {
+			cloud_transport_error_detected();
+		}
+		LOG_DBG("check_shadow() returned %d", err);
+		k_sleep(K_SECONDS(SHADOW_THREAD_DELAY_S));
 	}
 	return 0;
 }

--- a/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_coap
+++ b/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_coap
@@ -36,6 +36,14 @@ config NRF_CLOUD_COAP_GF_CONF
 	  configuration values do_reply, fallback, and hi_conf. When the cloud
 	  support is ready, NRF_CLOUD_COAP_GF_CONF can be set true.
 
+config NRF_CLOUD_COAP_KEEPOPEN
+	bool "Enable SO_KEEPOPEN to prevent unnecessary socket closures"
+	default y
+	depends on SOC_NRF9161_LACA || SOC_NRF9151_LACA || SOC_NRF9131_LACA
+	help
+	  Improve benefit from using DTLS Connection ID by keeping the socket
+	  open when temporary LTE PDN connection loss occurs.
+
 if WIFI
 
 config NRF_CLOUD_COAP_SEND_SSIDS

--- a/subsys/net/lib/nrf_cloud/coap/include/nrf_cloud_coap_transport.h
+++ b/subsys/net/lib/nrf_cloud/coap/include/nrf_cloud_coap_transport.h
@@ -35,11 +35,13 @@ struct coap_client_option {};
 #endif
 
 struct nrf_cloud_coap_client {
+	struct k_mutex mutex;
 	struct coap_client cc;
 	int sock;
 	bool initialized;
 	bool authenticated;
 	bool cid_saved;
+	bool paused;
 };
 
 #define NRF_CLOUD_COAP_PROXY_RSC "proxy"

--- a/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap.c
+++ b/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap.c
@@ -424,7 +424,9 @@ static void get_location_callback(int16_t result_code,
 		struct nrf_cloud_location_result *result = user;
 
 		loc_err = 0;
-		result->type = LOCATION_TYPE__INVALID;
+		if (result) {
+			result->type = LOCATION_TYPE__INVALID;
+		}
 	}
 }
 
@@ -585,6 +587,7 @@ static void get_shadow_callback(int16_t result_code,
 				size_t offset, const uint8_t *payload, size_t len,
 				bool last_block, void *user)
 {
+	__ASSERT_NO_MSG(user != NULL);
 	struct get_shadow_data *data = (struct get_shadow_data *)user;
 
 	if (result_code != COAP_RESPONSE_CODE_CONTENT) {

--- a/subsys/net/lib/nrf_cloud/coap/src/nrfc_dtls.c
+++ b/subsys/net/lib/nrf_cloud/coap/src/nrfc_dtls.c
@@ -172,16 +172,23 @@ int nrfc_dtls_setup(int sock)
 		LOG_ERR("Failed to enable session cache, errno: %d", -errno);
 		err = -errno;
 	}
+
+	if (IS_ENABLED(CONFIG_NRF_CLOUD_COAP_KEEPOPEN)) {
+		err = setsockopt(sock, SOL_SOCKET, SO_KEEPOPEN, &(int){1}, sizeof(int));
+		if (err) {
+			LOG_ERR("Failed to set SO_KEEPOPEN: %d", -errno);
+			err = -errno;
+		}
+	}
 	return err;
 }
 
 int nrfc_dtls_session_save(int sock)
 {
-	int dummy = 0;
 	int err;
 
 	LOG_DBG("Save DTLS CID session");
-	err = setsockopt(sock, SOL_TLS, TLS_DTLS_CONN_SAVE, &dummy, sizeof(dummy));
+	err = setsockopt(sock, SOL_TLS, TLS_DTLS_CONN_SAVE, &(int){0}, sizeof(int));
 	if (err) {
 		LOG_DBG("Failed to save DTLS CID session, errno %d", -errno);
 		err = -errno;
@@ -191,11 +198,10 @@ int nrfc_dtls_session_save(int sock)
 
 int nrfc_dtls_session_load(int sock)
 {
-	int dummy = 1;
 	int err;
 
 	LOG_DBG("Load DTLS CID session");
-	err = setsockopt(sock, SOL_TLS, TLS_DTLS_CONN_LOAD, &dummy, sizeof(dummy));
+	err = setsockopt(sock, SOL_TLS, TLS_DTLS_CONN_LOAD, &(int){1}, sizeof(int));
 	if (err) {
 		LOG_DBG("Failed to load DTLS CID session, errno %d", -errno);
 		err = -errno;


### PR DESCRIPTION
Enable the SO_KEEPOPEN socket option to reduce the need to close and reopen the socket and perform DTLS negotiation whenever the PDN disconnects and reconnects or LTE goes offline and online.

Store paused condition whether session pause/resume succeeded or not. Use to determine if ready to perform a request. Set a finite timeout for callback from NON transfers. When CoAP socket is paused, prevent outgoing requests. Fix error handling in client_transfer() so serial_sem is not left open. Cancel ongoing coap_client requests when pausing or disconnecting. If we cannot save the CID when pausing, we will need to do a full reconnect. When receiving a callback, validate the user_data thoroughly. Initialize the result code to an error value rather thanstart uninitialized.

Jira: IRIS-8593