### PR TITLE
bluetooth: controller: deselect BT_CTLR_ECDH

### DIFF
--- a/samples/bluetooth/central_hids/child_image/hci_ipc.conf
+++ b/samples/bluetooth/central_hids/child_image/hci_ipc.conf
@@ -1,9 +1,7 @@
 #
-# Copyright (c) 2021 Nordic Semiconductor
+# Copyright (c) 2024 Nordic Semiconductor
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-CONFIG_BT_MAX_CONN=2
-CONFIG_BT_CENTRAL=n
 CONFIG_BT_CTLR_SDC_ECDH=y

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -13,7 +13,6 @@ config BT_LL_SOFTDEVICE
 	select MPSL
 	select ZERO_LATENCY_IRQS if !SOC_SERIES_BSIM_NRFXX
 	select BT_CTLR_LE_ENC_SUPPORT
-	select BT_CTLR_ECDH_SUPPORT
 	select BT_CTLR_EXT_REJ_IND_SUPPORT
 	select BT_CTLR_PRIVACY_SUPPORT
 	select BT_CTLR_EXT_SCAN_FP_SUPPORT
@@ -44,6 +43,14 @@ config BT_LL_SOFTDEVICE
 	  Use SoftDevice Link Layer implementation.
 
 endchoice
+
+config BT_CTLR_SDC_ECDH
+	prompt "Support for DH key generation in SDC"
+	bool
+	default y if BT_SMP
+	select BT_CTLR_ECDH_SUPPORT
+	help
+		Adds support for DH key generation to SDC.
 
 config BT_CTLR_DF_SUPPORT
 	select BT_CTLR_DF_CTE_TX_SUPPORT


### PR DESCRIPTION
It's rarely, if ever, used by the app. It also uses considerable memory. Places that need it can still select it.