### PR TITLE
net: lib: nrf_cloud: deprecate ui service info section

### DIFF
--- a/applications/serial_lte_modem/src/nrfcloud/slm_at_nrfcloud.c
+++ b/applications/serial_lte_modem/src/nrfcloud/slm_at_nrfcloud.c
@@ -19,9 +19,6 @@
 
 LOG_MODULE_REGISTER(slm_nrfcloud, CONFIG_SLM_LOG_LEVEL);
 
-#define SERVICE_INFO_GNSS \
-	"{\"state\":{\"reported\":{\"device\": {\"serviceInfo\":{\"ui\":[\"GNSS\"]}}}}}"
-
 #define MODEM_AT_RSP \
 	"{\"appId\":\"MODEM\", \"messageType\":\"RSP\", \"data\":\"%s\"}"
 
@@ -298,23 +295,6 @@ static int do_cloud_send_msg(const char *message, int len)
 
 static void on_cloud_evt_ready(void)
 {
-	int err;
-
-	if (slm_nrf_cloud_send_location) {
-		struct nrf_cloud_tx_data msg = {
-			.data.ptr = SERVICE_INFO_GNSS,
-			.data.len = strlen(SERVICE_INFO_GNSS),
-			.topic_type = NRF_CLOUD_TOPIC_STATE,
-			.qos = MQTT_QOS_0_AT_MOST_ONCE
-		};
-
-		/* Update nRF Cloud with GPS service info signifying GPS capabilities. */
-		err = nrf_cloud_send(&msg);
-		if (err) {
-			LOG_WRN("Failed to send message to cloud, error: %d", err);
-		}
-	}
-
 	slm_nrf_cloud_ready = true;
 	rsp_send("\r\n#XNRFCLOUD: %d,%d\r\n", slm_nrf_cloud_ready, slm_nrf_cloud_send_location);
 #if defined(CONFIG_NRF_CLOUD_LOCATION)

--- a/doc/nrf/libraries/networking/nrf_cloud.rst
+++ b/doc/nrf/libraries/networking/nrf_cloud.rst
@@ -210,20 +210,6 @@ Sending sensor data
 *******************
 The library offers two functions, :c:func:`nrf_cloud_sensor_data_send` and :c:func:`nrf_cloud_sensor_data_stream` (lowest QoS), for sending sensor data to the cloud.
 
-To view sensor data on nRF Cloud, the device must first inform the cloud what types of sensor data to display.
-The device passes this information by writing a ``ui`` field, containing an array of sensor types, into the ``serviceInfo`` field in the device's shadow.
-The :c:func:`nrf_cloud_service_info_json_encode` function can be used to generate the proper JSON data to enable FOTA.
-Additionally, the :c:func:`nrf_cloud_shadow_device_status_update` function can be used to generate the JSON data and perform the shadow update.
-
-Following are the supported UI types on nRF Cloud:
-
-* ``GNSS``
-* ``FLIP``
-* ``TEMP``
-* ``HUMIDITY``
-* ``AIR_PRESS``
-* ``RSRP``
-
 .. _lib_nrf_cloud_unlink:
 
 Removing the link between device and user

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -519,6 +519,9 @@ Libraries for networking
   * Updated:
 
     * Improved FOTA job status reporting.
+    * Deprecated :kconfig:option:`NRF_CLOUD_SEND_SERVICE_INFO_UI` and its related UI Kconfig options.
+    * Deprecated the :c:struct:`nrf_cloud_svc_info_ui` structure contained in the :c:struct:`nrf_cloud_svc_info` structure.
+      nRF Cloud no longer uses the UI section in the shadow.
 
 * :ref:`lib_mqtt_helper` library:
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -146,8 +146,11 @@ Asset Tracker v2
 Serial LTE modem
 ----------------
 
-* Removed mention of Termite and Teraterm terminal emulators from the documentation.
-  The recommended approach is to use one of the emulators listed on the :ref:`test_and_optimize` page.
+* Removed:
+
+  * Mention of Termite and Teraterm terminal emulators from the documentation.
+    The recommended approach is to use one of the emulators listed on the :ref:`test_and_optimize` page.
+  * Sending GNSS UI service info to nRF Cloud; this is no longer required by the cloud.
 
 * Updated:
 
@@ -294,6 +297,21 @@ Cellular samples
 * :ref:`modem_shell_application` sample:
 
   * Removed ESP8266 Wi-Fi DTC and Kconfig overlay files.
+
+* :ref:`nrf_cloud_rest_cell_pos_sample` sample:
+
+  * Removed:
+
+    * The button press interface for enabling the device location card on the nRF Cloud website.
+      The card is now automatically displayed.
+
+  * Added:
+
+    * The :kconfig:option:`CONFIG_REST_CELL_SEND_DEVICE_STATUS` Kconfig option to control sending device status on initial connection.
+
+* :ref:`modem_shell_application` sample:
+
+  * Removed sending GNSS UI service info to nRF Cloud; this is no longer required by the cloud.
 
 Cryptography samples
 --------------------

--- a/include/net/nrf_cloud.h
+++ b/include/net/nrf_cloud.h
@@ -439,7 +439,7 @@ struct nrf_cloud_svc_info_fota {
 	uint8_t _rsvd:4;
 };
 
-/** @brief Controls which values are added to the UI array in the "serviceInfo" shadow section */
+/** @brief DEPRECATED - No longer used by nRF Cloud */
 struct nrf_cloud_svc_info_ui {
 	/* Items with UI support on nRF Cloud */
 	/** Temperature */
@@ -504,7 +504,8 @@ struct nrf_cloud_modem_info {
 struct nrf_cloud_svc_info {
 	/** Specify FOTA components to enable, set to NULL to remove the FOTA entry */
 	struct nrf_cloud_svc_info_fota *fota;
-	/** Specify UI components to enable, set to NULL to remove the UI entry */
+
+	/** DEPRECATED - nRF Cloud no longer requires the device to set UI values in the shadow */
 	struct nrf_cloud_svc_info_ui *ui;
 };
 

--- a/samples/cellular/modem_shell/src/cloud/cloud_rest_shell.c
+++ b/samples/cellular/modem_shell/src/cloud/cloud_rest_shell.c
@@ -66,12 +66,6 @@ static int cmd_cloud_rest_shadow_device_status_update(const struct shell *shell,
 						      char **argv)
 {
 	int err;
-	struct nrf_cloud_svc_info_ui ui_info = {
-		.gnss = IS_ENABLED(CONFIG_MOSH_LOCATION), /* Show map on nrf cloud */
-	};
-	struct nrf_cloud_svc_info service_info = {
-		.ui = &ui_info
-	};
 	struct nrf_cloud_modem_info modem_info = {
 		.device = NRF_CLOUD_INFO_SET,
 		.network = NRF_CLOUD_INFO_SET,
@@ -80,7 +74,8 @@ static int cmd_cloud_rest_shadow_device_status_update(const struct shell *shell,
 	};
 	struct nrf_cloud_device_status device_status = {
 		.modem = &modem_info,
-		.svc = &service_info
+		/* Deprecated: The service info "ui" section is no longer used by nRF Cloud */
+		.svc = NULL
 	};
 	char device_id[NRF_CLOUD_CLIENT_ID_MAX_LEN + 1];
 #define REST_RX_BUF_SZ 300 /* No payload in response, "just" headers */

--- a/samples/cellular/nrf_cloud_rest_cell_location/Kconfig
+++ b/samples/cellular/nrf_cloud_rest_cell_location/Kconfig
@@ -41,6 +41,10 @@ config REST_CELL_DEFAULT_FALLBACK_VAL
 config REST_CELL_DEFAULT_HICONF_VAL
 	bool "Default value for the hi_conf configuration flag"
 
+config REST_CELL_SEND_DEVICE_STATUS
+	bool "Send device status to nRF Cloud on initial connection"
+	default y
+
 endmenu
 
 menu "Zephyr Kernel"

--- a/samples/cellular/nrf_cloud_rest_cell_location/README.rst
+++ b/samples/cellular/nrf_cloud_rest_cell_location/README.rst
@@ -53,13 +53,6 @@ If you have the option :ref:`CONFIG_REST_CELL_LOCATION_DO_JITP <CONFIG_REST_CELL
 This is useful when initially provisioning and associating a device on nRF Cloud.
 You only need to do this once for each device.
 
-If you have not requested for JITP before starting up your device, the sample asks if the location card on the nRF Cloud portal should be enabled in the device's shadow.
-This is only valid for provisioned devices.
-Press **button 1** to perform the shadow update.
-The location card displays the device's location on a map.
-This is not required for the sample to function.
-You only need to do this once for each device.
-
 After the sample completes any requested JITP or shadow updates, pressing the **button 1** toggles between single-cell and multi-cell mode.
 
 Set the :ref:`CONFIG_REST_CELL_CHANGE_CONFIG <CONFIG_REST_CELL_CHANGE_CONFIG>` Kconfig config value to try all combinations of the :c:struct:`nrf_cloud_location_config` structure values ``hi_conf`` and ``fallback``.
@@ -99,6 +92,11 @@ CONFIG_REST_CELL_DEFAULT_FALLBACK_VAL - Enable fallback to coarse location
 
 CONFIG_REST_CELL_DEFAULT_HICONF_VAL - Enable high confidence result
    Enable a 95% confidence interval for the location, instead of the default 68%.
+
+.. _CONFIG_REST_CELL_SEND_DEVICE_STATUS:
+
+CONFIG_REST_CELL_SEND_DEVICE_STATUS - Send device status
+   Send device status to nRF Cloud on initial connection.
 
 .. include:: /libraries/modem/nrf_modem_lib/nrf_modem_lib_trace.rst
    :start-after: modem_lib_sending_traces_UART_start

--- a/samples/cellular/nrf_cloud_rest_fota/src/main.c
+++ b/samples/cellular/nrf_cloud_rest_fota/src/main.c
@@ -206,7 +206,7 @@ static void send_device_status(void)
 
 	struct nrf_cloud_svc_info svc_inf = {
 		.fota = &fota,
-		/* No UI components are required for this sample */
+		/* Deprecated: The "ui" section is no longer used by nRF Cloud */
 		.ui = NULL
 	};
 

--- a/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_shadow_info
+++ b/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_shadow_info
@@ -50,44 +50,54 @@ config NRF_CLOUD_SEND_SERVICE_INFO_FOTA
 	    NRF_CLOUD_FOTA_TYPE_MODEM_FULL_SUPPORTED
 
 menuconfig NRF_CLOUD_SEND_SERVICE_INFO_UI
-	bool "Send UI service info initial connection"
+	bool "Send UI service info initial connection [DEPRECATED]"
+	select DEPRECATED
 	help
-	  Add supported UI types to the "serviceInfo" section.
-	  The UI types control which cards are displayed on nRF Cloud in the device page.
-	  Common types are enabled by default.
+	  This option is deprecated.
+	  nRF Cloud no longer uses the UI section in the shadow.
+	  Cards are displayed based on the messages sent by the device.
 
 if NRF_CLOUD_SEND_SERVICE_INFO_UI
 
 config NRF_CLOUD_ENABLE_SVC_INF_UI_MAP
-	bool "Enable map card on nRF Cloud"
+	bool "Enable map card on nRF Cloud [DEPRECATED]"
+	select DEPRECATED
 	default y
 
 config NRF_CLOUD_ENABLE_SVC_INF_UI_RSRP
-	bool "Enable RSRP card on nRF Cloud"
+	bool "Enable RSRP card on nRF Cloud [DEPRECATED]"
+	select DEPRECATED
 	default y if NRF_MODEM_LIB
 
 config NRF_CLOUD_ENABLE_SVC_INF_UI_LOGS
-	bool "Enable log card on nRF Cloud"
+	bool "Enable log card on nRF Cloud [DEPRECATED]"
+	select DEPRECATED
 	default y if NRF_CLOUD_LOG_TEXT_LOGGING_ENABLED
 
 config NRF_CLOUD_ENABLE_SVC_INF_UI_BIN_LOGS
-	bool "Enable binary (dictionary-based) log card on nRF Cloud"
+	bool "Enable binary (dictionary-based) log card on nRF Cloud [DEPRECATED]"
+	select DEPRECATED
 	default y if NRF_CLOUD_LOG_DICTIONARY_LOGGING_ENABLED
 
 config NRF_CLOUD_ENABLE_SVC_INF_UI_TEMP
-	bool "Enable temperature card on nRF Cloud"
+	bool "Enable temperature card on nRF Cloud [DEPRECATED]"
+	select DEPRECATED
 
 config NRF_CLOUD_ENABLE_SVC_INF_UI_HUMID
-	bool "Enable humidity card on nRF Cloud"
+	bool "Enable humidity card on nRF Cloud [DEPRECATED]"
+	select DEPRECATED
 
 config NRF_CLOUD_ENABLE_SVC_INF_UI_AIR_PRESSURE
-	bool "Enable air pressure card on nRF Cloud"
+	bool "Enable air pressure card on nRF Cloud [DEPRECATED]"
+	select DEPRECATED
 
 config NRF_CLOUD_ENABLE_SVC_INF_UI_AIR_QUALITY
-	bool "Enable air quality card on nRF Cloud"
+	bool "Enable air quality card on nRF Cloud [DEPRECATED]"
+	select DEPRECATED
 
 config NRF_CLOUD_ENABLE_SVC_INF_UI_ORIENTATION
-	bool "Enable orientation (flip) card on nRF Cloud"
+	bool "Enable orientation (flip) card on nRF Cloud [DEPRECATED]"
+	select DEPRECATED
 
 endif # NRF_CLOUD_SEND_SERVICE_INFO_UI
 
@@ -99,8 +109,7 @@ config NRF_CLOUD_SEND_SHADOW_INFO
 		      NRF_CLOUD_SEND_DEVICE_STATUS_NETWORK || \
 		      NRF_CLOUD_SEND_DEVICE_STATUS_SIM || \
 		      NRF_CLOUD_SEND_DEVICE_STATUS_CONN_INF || \
-		      NRF_CLOUD_SEND_SERVICE_INFO_FOTA || \
-		      NRF_CLOUD_SEND_SERVICE_INFO_UI)
+		      NRF_CLOUD_SEND_SERVICE_INFO_FOTA)
 	help
 	  This symbol is y when at least one option to send an info section is enabled.
 


### PR DESCRIPTION
nRF Cloud no longer uses the UI service info section in the device shadow.
Mark UI-related Kconfig options as deprecated.
Remove the UI section from the shadow instead of updating it.

Update samples to no longer send UI service info.

IRIS-8636