### PR TITLE
samples: cellular: nrf_cloud_multi_service: Fix Wi-Fi scanning

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -326,6 +326,10 @@ Cellular samples
 
   * Removed sending GNSS UI service info to nRF Cloud; this is no longer required by the cloud.
 
+* :ref:`nrf_cloud_multi_service` sample:
+
+  * Fixed issue that prevented network connectivity when using Wi-Fi scanning with the nRF91xx.
+
 Cryptography samples
 --------------------
 

--- a/samples/cellular/nrf_cloud_multi_service/overlay-nrf7002ek-wifi-scan-only.conf
+++ b/samples/cellular/nrf_cloud_multi_service/overlay-nrf7002ek-wifi-scan-only.conf
@@ -22,6 +22,9 @@ CONFIG_WIFI_NRF700X_SKIP_LOCAL_ADMIN_MAC=y
 # Also see comments for CONFIG_HEAP_MEM_POOL_SIZE.
 CONFIG_NRF_WIFI_SCAN_MAX_BSS_CNT=20
 CONFIG_NET_L2_ETHERNET=y
+# We need 2 to ensure nrf91_socket gets an IP address regardless of order of net_if array
+CONFIG_NET_IF_MAX_IPV4_COUNT=2
+CONFIG_NET_IF_MAX_IPV6_COUNT=2
 
 # But disable the supplicant, since we don't need connectivity
 CONFIG_WPA_SUPP=n


### PR DESCRIPTION
We need to allocate enough IPv4 and IPv6 address structures so the nrf91_socket always gets a slot, regardless of order that it and nordic_wlan0 are placed in the net_if array.

Jira: IRIS-8626