### PR TITLE
bluetooth: controller: Put ECDH driver in the MPSL work queue by default

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -370,6 +370,7 @@ config BT_CTLR_ECDH_STACK_SIZE
 config BT_CTLR_ECDH_IN_MPSL_WORK
 	bool "ECDH processing in MPSL workqueue"
 	depends on BT_CTLR_ECDH_LIB_OBERON
+	default y if !BT_SMP
 	help
 	  Run the ECDH processing in the MPSL workqueue instead of in a
 	  dedicated pre-emptible thread.


### PR DESCRIPTION
Puts the SDC ECDH driver in the MPSL work queue by default, unless SMP is used.