### PR TITLE
suit: migration of SUIT DFU build system to NCS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -40,7 +40,7 @@
 /applications/zigbee_weather_station/     @milewr
 # Boards
 /boards/                                  @anangl
-/boards/arm/thingy91*                     @anangl @nrfconnect/ncs-cia
+/boards/nordic/thingy91*                  @anangl @nrfconnect/ncs-cia
 # All cmake related files
 /cmake/                                   @tejlmand
 /CMakeLists.txt                           @tejlmand

--- a/cmake/sysbuild/suit.cmake
+++ b/cmake/sysbuild/suit.cmake
@@ -1,0 +1,282 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+include(${CMAKE_CURRENT_LIST_DIR}/suit_utilities.cmake)
+
+# Copy input template into destination directory.
+#
+# Usage:
+#   suit_copy_input_templates(<destination_template_directory> <soure_template_path> <output_variable>)
+#
+# Parameters:
+#   'destination_template_directory' - destination directory
+#   'source_template_path' - path to the source template
+#   'output_variable' - variable to store new path to the copied template
+function(suit_copy_input_template destination_template_directory source_template_path output_variable)
+  cmake_path(GET source_template_path FILENAME source_filename)
+  set(destination_template_path "${destination_template_directory}/${source_filename}")
+  if(NOT EXISTS ${source_template_path})
+    message(SEND_ERROR "DFU: Could not find default SUIT template: '${source_template_path}'. Corrupted configuration?")
+    return()
+  endif()
+  if(NOT EXISTS ${destination_template_path})
+    # copy default template and create digest
+    configure_file(${source_template_path} ${destination_template_path} COPYONLY)
+    file(SHA256 ${destination_template_path} checksum_variable)
+    file(WRITE "${destination_template_path}.digest" ${checksum_variable})
+  endif()
+  if(NOT EXISTS "${destination_template_path}.digest")
+    # restore digest removed by user to discard warning about changes in the source template
+    file(SHA256 ${source_template_path} checksum_variable)
+    file(WRITE "${destination_template_path}.digest" ${checksum_variable})
+  endif()
+  cmake_path(GET source_template_path FILENAME copied_filename)
+  set(${output_variable} "${destination_template_directory}/${copied_filename}" PARENT_SCOPE)
+endfunction()
+
+# Check digests for template.
+#
+# Usage:
+#   suit_check_template_digest(<destination_template_directory> <template_path>)
+#
+# Parameters:
+#   'destination_template_directory' - destination directory
+#   'template_path' - path to the source template
+function(suit_check_template_digest destination_template_directory source_template_path)
+    suit_set_absolute_or_relative_path(${source_template_path} ${PROJECT_BINARY_DIR} source_template_path)
+    if(NOT EXISTS ${source_template_path})
+      message(SEND_ERROR "DFU: Could not find default SUIT template: '${source_template_path}'. Corrupted configuration?")
+      return()
+    endif()
+    cmake_path(GET source_template_path FILENAME source_filename)
+    set(input_file "${destination_template_directory}/${source_filename}")
+
+    file(SHA256 ${source_template_path} CHECKSUM_DEFAULT)
+    set(DIGEST_STORAGE "${input_file}.digest")
+    file(STRINGS ${DIGEST_STORAGE} CHECKSUM_STORED)
+    if(NOT ${CHECKSUM_DEFAULT} STREQUAL ${CHECKSUM_STORED})
+      message(SEND_ERROR "DFU: Outdated input SUIT template detected - consider update.\n"
+      "Some changes has been done to the SUIT_ENVELOPE_DEFAULT_TEMPLATE which was used to create your ${input_file}.\n"
+      "Please review these changes and remove ${input_file}.digest file to bypass this error.\n"
+      )
+    endif()
+endfunction()
+
+# Create digest for input file.
+#
+# Usage:
+#   suit_create_digest(<input_file> <output_file>)
+#
+# Parameters:
+#   'input_file' - input file to calculate digest on
+#   'output_file' - output file to store calculated digest
+function(suit_create_digest input_file output_file)
+  file(SHA256 ${input_file} CHECKSUM_VARIABLE)
+  file(WRITE ${output_file} ${CHECKSUM_VARIABLE})
+endfunction()
+
+# Resolve passed absolute or relative path to real path.
+#
+# Usage:
+#   suit_set_absolute_or_relative_path(<path> <relative_root> <output_variable>)
+#
+# Parameters:
+#   'path' - path to resolve
+#   'relative_root' - root folder used in case of relative path
+#   'output_variable' - variable to store results
+function(suit_set_absolute_or_relative_path path relative_root output_variable)
+  if(NOT IS_ABSOLUTE ${path})
+    file(REAL_PATH "${relative_root}/${path}" path)
+  endif()
+  set(${output_variable} "${path}" PARENT_SCOPE)
+endfunction()
+
+# Sign an envelope using SIGN_SCRIPT.
+#
+# Usage:
+#   suit_sign_envelope(<input_file> <output_file>)
+#
+# Parameters:
+#   'input_file' - path to input unsigned envelope
+#   'output_file' - path to output signed envelope
+function(suit_sign_envelope input_file output_file)
+  cmake_path(GET ZEPHYR_NRF_MODULE_DIR PARENT_PATH NRF_DIR_PARENT)
+  sysbuild_get(CONFIG_SUIT_ENVELOPE_SIGN_SCRIPT IMAGE ${DEFAULT_IMAGE} VAR CONFIG_SUIT_ENVELOPE_SIGN_SCRIPT KCONFIG)
+  suit_set_absolute_or_relative_path(${CONFIG_SUIT_ENVELOPE_SIGN_SCRIPT} ${NRF_DIR_PARENT} SIGN_SCRIPT)
+  if(NOT EXISTS ${SIGN_SCRIPT})
+    message(SEND_ERROR "DFU: ${CONFIG_SUIT_ENVELOPE_SIGN_SCRIPT} does not exist. Corrupted configuration?")
+    return()
+  endif()
+  set_property(
+    GLOBAL APPEND PROPERTY SUIT_POST_BUILD_COMMANDS
+    COMMAND ${PYTHON_EXECUTABLE} ${SIGN_SCRIPT}
+    --input-file ${input_file}
+    --output-file ${output_file}
+  )
+endfunction()
+
+# Register SUIT post build commands.
+#
+# Usage:
+#   suit_register_post_build_commands()
+#
+function(suit_register_post_build_commands)
+  get_property(
+    post_build_commands
+    GLOBAL PROPERTY
+    SUIT_POST_BUILD_COMMANDS
+  )
+
+  foreach(image ${IMAGES})
+    sysbuild_get(BINARY_DIR IMAGE ${image} VAR APPLICATION_BINARY_DIR CACHE)
+    sysbuild_get(BINARY_FILE IMAGE ${image} VAR CONFIG_KERNEL_BIN_NAME KCONFIG)
+    list(APPEND dependencies "${BINARY_DIR}/zephyr/${BINARY_FILE}.bin")
+  endforeach()
+
+  add_custom_target(
+    create_suit_artifacts
+    ALL
+    ${post_build_commands}
+    DEPENDS
+    ${dependencies}
+    COMMAND_EXPAND_LISTS
+    COMMENT "Create SUIT artifacts"
+  )
+endfunction()
+
+# Create DFU package/main envelope.
+#
+# Usage:
+#   suit_create_package()
+#
+function(suit_create_package)
+  add_custom_target(
+    suit_prepare_output_folder
+    ALL
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${SUIT_ROOT_DIRECTORY}
+    COMMENT
+    "Create DFU output directory"
+  )
+  set(SUIT_OUTPUT_ARTIFACTS_ITEMS)
+  set(SUIT_OUTPUT_ARTIFACTS_TARGETS)
+  set(CORE_ARGS)
+  set(STORAGE_BOOT_ARGS)
+
+  sysbuild_get(CONFIG_SUIT_ENVELOPE_EDITABLE_TEMPLATES_LOCATION IMAGE ${DEFAULT_IMAGE} VAR CONFIG_SUIT_ENVELOPE_EDITABLE_TEMPLATES_LOCATION KCONFIG)
+  suit_set_absolute_or_relative_path(${CONFIG_SUIT_ENVELOPE_EDITABLE_TEMPLATES_LOCATION} ${PROJECT_BINARY_DIR} INPUT_TEMPLATES_DIRECTORY)
+  sysbuild_get(ENVELOPE_SHALL_BE_SIGNED IMAGE ${DEFAULT_IMAGE} VAR CONFIG_SUIT_ENVELOPE_SIGN KCONFIG)
+  if(NOT DEFINED ENVELOPE_SHALL_BE_SIGNED)
+    set(ENVELOPE_SHALL_BE_SIGNED FALSE)
+  endif()
+
+  foreach(image ${IMAGES})
+    sysbuild_get(INPUT_ENVELOPE_JINJA_FILE IMAGE ${image} VAR CONFIG_SUIT_ENVELOPE_TEMPLATE KCONFIG)
+    sysbuild_get(target IMAGE ${image} VAR CONFIG_SUIT_ENVELOPE_TARGET KCONFIG)
+    sysbuild_get(BINARY_DIR IMAGE ${image} VAR APPLICATION_BINARY_DIR CACHE)
+    sysbuild_get(BINARY_FILE IMAGE ${image} VAR CONFIG_KERNEL_BIN_NAME KCONFIG)
+    suit_copy_input_template(${INPUT_TEMPLATES_DIRECTORY} "${INPUT_ENVELOPE_JINJA_FILE}" ENVELOPE_JINJA_FILE)
+    if(NOT DEFINED ENVELOPE_JINJA_FILE)
+      message(SEND_ERROR "DFU: Creation of SUIT artifacts failed.")
+      return()
+    endif()
+    suit_check_template_digest(${INPUT_TEMPLATES_DIRECTORY} "${INPUT_ENVELOPE_JINJA_FILE}")
+    set(BINARY_FILE "${BINARY_FILE}.bin")
+
+    list(APPEND CORE_ARGS
+      --core ${target},${SUIT_ROOT_DIRECTORY}${target}.bin,${BINARY_DIR}/zephyr/edt.pickle
+    )
+
+    sysbuild_get(CONFIG_SUIT_ENVELOPE_ROOT_ARTIFACT_NAME IMAGE ${DEFAULT_IMAGE} VAR CONFIG_SUIT_ENVELOPE_ROOT_ARTIFACT_NAME KCONFIG)
+    set(ENVELOPE_YAML_FILE ${SUIT_ROOT_DIRECTORY}${target}.yaml)
+    set(ENVELOPE_SUIT_FILE ${SUIT_ROOT_DIRECTORY}${target}.suit)
+
+    suit_copy_artifact_to_output_directory(${target} ${BINARY_DIR}/zephyr/${BINARY_FILE})
+    suit_render_template(${ENVELOPE_JINJA_FILE} ${ENVELOPE_YAML_FILE} "${CORE_ARGS}")
+    suit_create_envelope(${ENVELOPE_YAML_FILE} ${ENVELOPE_SUIT_FILE} ${ENVELOPE_SHALL_BE_SIGNED})
+    list(APPEND STORAGE_BOOT_ARGS
+      --input-envelope ${ENVELOPE_SUIT_FILE}
+    )
+  endforeach()
+
+  sysbuild_get(INPUT_ROOT_ENVELOPE_JINJA_FILE IMAGE ${DEFAULT_IMAGE} VAR CONFIG_SUIT_ENVELOPE_ROOT_TEMPLATE KCONFIG)
+
+  # create root envelope if defined
+  if(DEFINED INPUT_ROOT_ENVELOPE_JINJA_FILE AND NOT INPUT_ROOT_ENVELOPE_JINJA_FILE STREQUAL "")
+    sysbuild_get(ROOT_NAME IMAGE ${DEFAULT_IMAGE} VAR CONFIG_SUIT_ENVELOPE_ROOT_ARTIFACT_NAME KCONFIG)
+    if(NOT DEFINED ROOT_NAME OR ROOT_NAME STREQUAL "")
+      set(ROOT_NAME "root")
+    endif()
+    suit_copy_input_template(${INPUT_TEMPLATES_DIRECTORY} "${INPUT_ROOT_ENVELOPE_JINJA_FILE}" ROOT_ENVELOPE_JINJA_FILE)
+    suit_check_template_digest(${INPUT_TEMPLATES_DIRECTORY} "${INPUT_ROOT_ENVELOPE_JINJA_FILE}")
+    set(ROOT_ENVELOPE_YAML_FILE ${SUIT_ROOT_DIRECTORY}${ROOT_NAME}.yaml)
+    set(ROOT_ENVELOPE_SUIT_FILE ${SUIT_ROOT_DIRECTORY}${ROOT_NAME}.suit)
+    suit_render_template(${ROOT_ENVELOPE_JINJA_FILE} ${ROOT_ENVELOPE_YAML_FILE} "${CORE_ARGS}")
+    suit_create_envelope(${ROOT_ENVELOPE_YAML_FILE} ${ROOT_ENVELOPE_SUIT_FILE} ${ENVELOPE_SHALL_BE_SIGNED})
+      list(APPEND STORAGE_BOOT_ARGS
+        --input-envelope ${ROOT_ENVELOPE_SUIT_FILE}
+      )
+  endif()
+
+  sysbuild_get(DEFAULT_BINARY_DIR IMAGE ${DEFAULT_IMAGE} VAR APPLICATION_BINARY_DIR CACHE)
+  # create all storages in the DEFAULT_IMAGE output directory
+  list(APPEND STORAGE_BOOT_ARGS --storage-output-directory "${DEFAULT_BINARY_DIR}/zephyr" --zephyr-base ${ZEPHYR_BASE} ${CORE_ARGS})
+  set_property(
+    GLOBAL APPEND PROPERTY SUIT_POST_BUILD_COMMANDS
+    COMMAND ${PYTHON_EXECUTABLE}
+    ${SUIT_GENERATOR_BUILD_SCRIPT}
+    storage
+    ${STORAGE_BOOT_ARGS}
+  )
+  suit_setup_merge()
+  suit_register_post_build_commands()
+endfunction()
+
+# Setup task to create final and merged artifact.
+#
+# Usage:
+#   suit_setup_merge()
+#
+function(suit_setup_merge)
+  sysbuild_get(BINARY_DIR IMAGE ${DEFAULT_IMAGE} VAR APPLICATION_BINARY_DIR CACHE)
+  foreach(image ${IMAGES})
+    set(ARTIFACTS_TO_MERGE)
+    sysbuild_get(IMAGE_BINARY_DIR IMAGE ${image} VAR APPLICATION_BINARY_DIR CACHE)
+    sysbuild_get(IMAGE_BINARY_FILE IMAGE ${image} VAR CONFIG_KERNEL_BIN_NAME KCONFIG)
+    sysbuild_get(IMAGE_TARGET_NAME IMAGE ${image} VAR CONFIG_SUIT_ENVELOPE_TARGET KCONFIG)
+
+    sysbuild_get(CONFIG_SUIT_ENVELOPE_OUTPUT_ARTIFACT IMAGE ${image} VAR CONFIG_SUIT_ENVELOPE_OUTPUT_ARTIFACT KCONFIG)
+    sysbuild_get(CONFIG_NRF_REGTOOL_GENERATE_UICR IMAGE ${image} VAR CONFIG_NRF_REGTOOL_GENERATE_UICR KCONFIG)
+    sysbuild_get(CONFIG_SUIT_ENVELOPE_OUTPUT_MPI_MERGE IMAGE ${image} VAR CONFIG_SUIT_ENVELOPE_OUTPUT_MPI_MERGE KCONFIG)
+
+    set(OUTPUT_HEX_FILE "${IMAGE_BINARY_DIR}/zephyr/${CONFIG_SUIT_ENVELOPE_OUTPUT_ARTIFACT}")
+
+    list(APPEND ARTIFACTS_TO_MERGE ${BINARY_DIR}/zephyr/storage_${IMAGE_TARGET_NAME}.hex)
+    list(APPEND ARTIFACTS_TO_MERGE ${IMAGE_BINARY_DIR}/zephyr/${IMAGE_BINARY_FILE}.hex)
+    if(CONFIG_SUIT_ENVELOPE_OUTPUT_MPI_MERGE)
+      list(APPEND ARTIFACTS_TO_MERGE ${BINARY_DIR}/zephyr/suit_mpi_${IMAGE_TARGET_NAME}_merged.hex)
+    endif()
+    if(CONFIG_NRF_REGTOOL_GENERATE_UICR)
+      list(APPEND ARTIFACTS_TO_MERGE ${IMAGE_BINARY_DIR}/zephyr/uicr.hex)
+    endif()
+
+    set_property(
+      GLOBAL APPEND PROPERTY SUIT_POST_BUILD_COMMANDS
+      COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/mergehex.py
+      --overlap replace
+      -o ${OUTPUT_HEX_FILE}
+       ${ARTIFACTS_TO_MERGE}
+      # fixme: uicr_merged is overwritten by new content, runners_yaml_props_target could be used to define
+      #     what shall be flashed, but not sure where to set this! Remove --overlap if ready!
+      #     example usage: set_property(TARGET runners_yaml_props_target PROPERTY hex_file ${merged_hex_file})
+       COMMAND ${CMAKE_COMMAND} -E copy ${OUTPUT_HEX_FILE} ${IMAGE_BINARY_DIR}/zephyr/uicr_merged.hex
+    )
+  endforeach()
+endfunction()
+
+# Enable SUIT envelope generation only if DEFAULT_IMAGE has it enabled.
+sysbuild_get(CONFIG_SUIT_ENVELOPE IMAGE ${DEFAULT_IMAGE} VAR CONFIG_SUIT_ENVELOPE KCONFIG)
+if(CONFIG_SUIT_ENVELOPE)
+  suit_create_package()
+endif()

--- a/cmake/sysbuild/suit_utilities.cmake
+++ b/cmake/sysbuild/suit_utilities.cmake
@@ -1,0 +1,81 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+set(SUIT_GENERATOR_BUILD_SCRIPT "${ZEPHYR_SUIT_GENERATOR_MODULE_DIR}/ncs/build.py")
+set(SUIT_GENERATOR_CLI_SCRIPT "${ZEPHYR_SUIT_GENERATOR_MODULE_DIR}/suit_generator/cli.py")
+set(SUIT_OUTPUT_ARTIFACTS_DIRECTORY "DFU")
+
+if(NOT DEFINED SUIT_ROOT_DIRECTORY)
+  set(SUIT_ROOT_DIRECTORY ${APPLICATION_BINARY_DIR}/${SUIT_OUTPUT_ARTIFACTS_DIRECTORY}/)
+endif()
+
+# Copy artifact to the common SUIT output directory.
+#
+# Usage:
+#   suit_copy_artifact_to_output_directory(<target> <artifact>)
+#
+# Parameters:
+#   'target' - target name
+#   'artifact' - path to artifact
+function(suit_copy_artifact_to_output_directory target artifact)
+  cmake_path(GET artifact FILENAME artifact_filename)
+  cmake_path(GET artifact EXTENSION artifact_extension)
+  set(destination_name "${target}${artifact_extension}")
+  set_property(
+    GLOBAL APPEND PROPERTY SUIT_POST_BUILD_COMMANDS
+    COMMAND ${CMAKE_COMMAND} -E copy ${artifact} ${SUIT_ROOT_DIRECTORY}${target}.bin
+  )
+endfunction()
+
+# Render jinja templates using passed arguments.
+# Function uses core_arguments which is list of folowing entries:
+#   --core <target_name>,<locatino_of_firmware_binary_file>,<location_of_edt_file_representing_dts>
+#
+# Usage:
+#   suit_render_template(<input_file> <output_file> <core_arguments>)
+#
+# Parameters:
+#   'input_file' - path to input jinja template
+#   'output_file' - path to output yaml file
+#   'core_arguments' - list of arguments for registered cores
+function(suit_render_template input_file output_file core_arguments)
+  set(TEMPLATE_ARGS)
+  list(APPEND TEMPLATE_ARGS
+    --template-suit ${input_file}
+    --output-suit ${output_file}
+    --zephyr-base ${ZEPHYR_BASE}
+  )
+  list(APPEND TEMPLATE_ARGS ${core_arguments})
+  list(APPEND TEMPLATE_ARGS --artifacts-folder "${SUIT_ROOT_DIRECTORY}")
+   set_property(
+    GLOBAL APPEND PROPERTY SUIT_POST_BUILD_COMMANDS
+    COMMAND ${PYTHON_EXECUTABLE} ${SUIT_GENERATOR_BUILD_SCRIPT}
+    template
+    ${TEMPLATE_ARGS}
+  )
+endfunction()
+
+# Create binary envelope from input yaml file.
+#
+# Usage:
+#   suit_create_envelope(<input_file> <output_file> <create_signature>)
+#
+# Parameters:
+#   'input_file' - path to input yaml configuration
+#   'output_file' - path to output binary suit envelope
+#   'create_signature' - sign the envelope if set to true
+function(suit_create_envelope input_file output_file create_signature)
+  set_property(
+    GLOBAL APPEND PROPERTY SUIT_POST_BUILD_COMMANDS
+    COMMAND ${PYTHON_EXECUTABLE} ${SUIT_GENERATOR_CLI_SCRIPT}
+    create
+    --input-file ${input_file}
+    --output-file ${output_file}
+  )
+  if (create_signature)
+    suit_sign_envelope(${output_file} ${output_file})
+  endif()
+endfunction()

--- a/subsys/suit/provisioning/soc/Kconfig.nrf54h20
+++ b/subsys/suit/provisioning/soc/Kconfig.nrf54h20
@@ -142,7 +142,7 @@ rsource "Kconfig.template.manifest_config"
 
 config SUIT_MPI_RAD_AREA_PATH
 	string "Path to the file with all radio domain MPI configurations"
-	default "suit_mpi_radiocore_merged.hex"
+	default "suit_mpi_radio_merged.hex"
 
 config SUIT_MPI_RAD_AREA_ADDRESS
 	hex

--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -55,6 +55,10 @@ function(include_provision_hex)
   include(${ZEPHYR_NRF_MODULE_DIR}/cmake/sysbuild/provision_hex.cmake)
 endfunction()
 
+function(include_suit)
+  include(${ZEPHYR_NRF_MODULE_DIR}/cmake/sysbuild/suit.cmake)
+endfunction()
+
 function(include_packaging)
   include(${ZEPHYR_NRF_MODULE_DIR}/cmake/sysbuild/b0_mcuboot_signing.cmake)
   include(${ZEPHYR_NRF_MODULE_DIR}/subsys/bootloader/cmake/packaging.cmake)
@@ -295,6 +299,7 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_post_cmake)
   set_property(GLOBAL PROPERTY DOMAIN_APP_APP ${DEFAULT_IMAGE})
 
   include_packaging()
+  include_suit()
 
   if(SB_CONFIG_SECURE_BOOT OR SB_CONFIG_MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION)
     include_provision_hex()
@@ -313,7 +318,6 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_post_cmake)
       get_property(PM_MCUBOOT_PRIMARY_1_SIZE TARGET partition_manager PROPERTY PM_MCUBOOT_PRIMARY_1_SIZE)
     endif()
   endif()
-
   foreach(image ${IMAGES})
     configure_cache(IMAGE ${image})
   endforeach()

--- a/west.yml
+++ b/west.yml
@@ -239,7 +239,7 @@ manifest:
           upstream-sha: c6eaeda5a1c1c5dbb24dce7e027340cb8893a77b
           compare-by-default: false
     - name: suit-generator
-      revision: 60afbb26d3a00e5b2243f1304ba2bc4a6722960d
+      revision: ea2e37461ca822d91aea683edd75470a43f5efe2
       path: modules/lib/suit-generator
     - name: suit-processor
       revision: 5603911b75f037dc3822fd95542c3435c0bf812d


### PR DESCRIPTION
Migration of SUIT from  NEXT to NCS.

`sdsc bundle` (ver>=2) need to be downloaded to be able to build configurations listed above if SUIT_ENVELOPE_NORDIC_TOP_DIRECTORY is overwriten by some path, `CONFIG_SUIT_ENVELOPE_NORDIC_TOP_DIRECTORY` points to folder in which bundle is unpacked (nordic-top.suit manifest is available)

SUIT build system can be tested using multicore/hello_world sample:
```
west build -b nrf54h20dk/nrf54h20/cpuapp -p --sysbuild -- -DSB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf -DCONFIG_SUIT_ENVELOPE=y -DCONFIG_SUIT_ENVELOPE_NORDIC_TOP_DIRECTORY=\"/work/nordic-top/\" -DCONFIG_SUIT_MPI_GENERATE=y
```

With signing enabled (example key_private.pem need to be copied into modules/lib/suit-generator/ncs/ directory):
```
west build -b nrf54h20dk/nrf54h20/cpuapp -p --sysbuild -- -DSB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf -DCONFIG_SUIT_ENVELOPE=y -DCONFIG_SUIT_ENVELOPE_NORDIC_TOP_DIRECTORY=\"/work/nordic-top/\" -DCONFIG_SUIT_MPI_GENERATE=y -DCONFIG_SUIT_ENVELOPE_SIGN=y
```

Signing is done by example script defined using SUIT_ENVELOPE_SIGN_SCRIPT

Ref: NCSDK-26629

Signed-off-by: Robert Stypa <robert.stypa@nordicsemi.no>