### PR TITLE
doc: releases: Add changelog for nRF54L15 PDK support in input_device

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -195,6 +195,10 @@ Bluetooth samples
 
 * Added the :ref:`bluetooth_isochronous_time_synchronization` sample showcasing time-synchronized processing of isochronous data.
 
+* :ref:`fast_pair_input_device` sample:
+
+    * Added support for the :ref:`zephyr:nrf54l15pdk_nrf54l15` board.
+
 Bluetooth Mesh samples
 ----------------------
 


### PR DESCRIPTION
Added changelog entry for the nRF54L15 PDK support in the Fast Pair Input Device sample.

Jira: NCSDK-26517