### PR TITLE
samples: bluetooth: Enable TIMER0 for nrf5340 audio DK

### DIFF
--- a/samples/bluetooth/iso_time_sync/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
+++ b/samples/bluetooth/iso_time_sync/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
@@ -4,5 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+CONFIG_NRFX_TIMER0=y
 CONFIG_NRFX_RTC0=y
 CONFIG_NRFX_DPPI=y


### PR DESCRIPTION
Enable TIMER0 for fixing compile error when using nrf5340 audio DK.
Signed-off-by: Jui-Chou Chung <jui-chou.chung@nordicsemi.no>