### PR TITLE
treewide: doc: fast_pair: correct the outdated Kconfig names

### DIFF
--- a/doc/nrf/external_comp/bt_fast_pair.rst
+++ b/doc/nrf/external_comp/bt_fast_pair.rst
@@ -177,7 +177,7 @@ Apart from the callback registration and enabling the Fast Pair subsystem, no ad
 Personalized Name extension
 ===========================
 
-To support the Personalized Name extension, ensure that the :kconfig:option:`CONFIG_BT_FAST_PAIR_EXT_PN` Kconfig option is enabled in your project.
+To support the Personalized Name extension, ensure that the :kconfig:option:`CONFIG_BT_FAST_PAIR_PN` Kconfig option is enabled in your project.
 This extension is enabled by default.
 
 .. rst-class:: numbered-step

--- a/doc/nrf/libraries/bluetooth_services/services/fast_pair.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/fast_pair.rst
@@ -23,7 +23,7 @@ The implementation in the |NCS| follows these requirements.
 The Fast Pair service also contains additional GATT characteristics under the following conditions:
 
 * The Additional Data GATT characteristic is enabled when an extension requires it.
-  Currently, only the Personalized Name extension (:kconfig:option:`CONFIG_BT_FAST_PAIR_EXT_PN`) requires this characteristic.
+  Currently, only the Personalized Name extension (:kconfig:option:`CONFIG_BT_FAST_PAIR_PN`) requires this characteristic.
 
 Configuration
 *************


### PR DESCRIPTION
Corrected the outdated Fast Pair configuration names in the documenation.

Ref: NCSDK-26591