### PR TITLE
samples: matter: Improve Matter memory profiling.

### DIFF
--- a/applications/matter_bridge/sample.yaml
+++ b/applications/matter_bridge/sample.yaml
@@ -48,3 +48,11 @@ tests:
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
     platform_allow: nrf5340dk_nrf5340_cpuapp
+  applications.matter_bridge.memory_profiling:
+    build_only: true
+    extra_args: CONFIG_BRIDGE_GENERIC_SWITCH_BRIDGED_DEVICE=n
+      CONFIG_BRIDGE_ONOFF_LIGHT_SWITCH_BRIDGED_DEVICE=y
+      CONFIG_CHIP_MEMORY_PROFILING=y
+    integration_platforms:
+      - nrf7002dk_nrf5340_cpuapp
+    platform_allow: nrf7002dk_nrf5340_cpuapp

--- a/samples/matter/common/src/Kconfig
+++ b/samples/matter/common/src/Kconfig
@@ -42,6 +42,7 @@ config NCS_SAMPLE_MATTER_FACTORY_RESET_ON_KEY_MIGRATION_FAILURE
 
 config NCS_SAMPLE_MATTER_SETTINGS_SHELL
 	bool "Settings shell for Matter purposes"
+	default y if CHIP_MEMORY_PROFILING
 	depends on SHELL
 	depends on NVS
 	help

--- a/samples/matter/light_bulb/sample.yaml
+++ b/samples/matter/light_bulb/sample.yaml
@@ -47,3 +47,11 @@ tests:
     platform_allow: nrf7002dk_nrf5340_cpuapp
     integration_platforms:
       - nrf7002dk_nrf5340_cpuapp
+  sample.matter.light_bulb.memory_profiling:
+    build_only: true
+    extra_args: CONFIG_CHIP_MEMORY_PROFILING=y
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf7002dk_nrf5340_cpuapp

--- a/scripts/quarantine_integration.yaml
+++ b/scripts/quarantine_integration.yaml
@@ -13,6 +13,7 @@
     - sample.matter.thermostat.release
     - sample.matter.window_cover.release
     - sample.matter.thermostat.ext_temp
+    - sample.matter.light_bulb.memory_profiling
   platforms:
     - nrf52840dk_nrf52840
   comment: "Configurations excluded to limit resources usage in integration builds"
@@ -30,6 +31,7 @@
     - sample.matter.thermostat.release
     - sample.matter.window_cover.release
     - sample.matter.thermostat.ext_temp
+    - sample.matter.light_bulb.memory_profiling
   platforms:
     - nrf5340dk_nrf5340_cpuapp
   comment: "Configurations excluded to limit resources usage in integration builds"
@@ -50,6 +52,8 @@
     - sample.matter.thermostat.release
     - applications.matter_bridge.release
     - sample.matter.thermostat.ext_temp
+    - applications.matter_bridge.memory_profiling
+    - sample.matter.light_bulb.memory_profiling
   platforms:
     - nrf7002dk_nrf5340_cpuapp
   comment: "Configurations excluded to limit resources usage in integration builds"

--- a/west.yml
+++ b/west.yml
@@ -158,7 +158,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 70be330c014ae2067be1f641b365c19c2a6e4680
+      revision: f91ffce859d713de231902b250632609b24ec681
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
Enabled NCS_SAMPLE_MATTER_SETTINGS_SHELL if CHIP_MEMORY_PROFILING is set.
Disabled SHELL_MINIMAL when the memory profiling is enabled.