### PR TITLE
net: lib_ fota_download: Return errors from URI parsing

### DIFF
--- a/subsys/net/lib/download_client/CMakeLists.txt
+++ b/subsys/net/lib/download_client/CMakeLists.txt
@@ -20,3 +20,5 @@ zephyr_library_sources_ifdef(
 	CONFIG_DOWNLOAD_CLIENT_SHELL
 	src/shell.c
 )
+
+zephyr_include_directories(./include)

--- a/subsys/net/lib/download_client/include/download_client_internal.h
+++ b/subsys/net/lib/download_client/include/download_client_internal.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef DOWNLOAD_CLIENT_INTERNAL_H
+#define DOWNLOAD_CLIENT_INTERNAL_H
+
+#include <net/download_client.h>
+
+int url_parse_port(const char *url, uint16_t *port);
+int url_parse_proto(const char *url, int *proto, int *type);
+int url_parse_host(const char *url, char *host, size_t len);
+int url_parse_file(const char *url, char *file, size_t len);
+int http_parse(struct download_client *client, size_t len);
+int http_get_request_send(struct download_client *client);
+
+int coap_block_init(struct download_client *client, size_t from);
+int coap_get_recv_timeout(struct download_client *dl);
+int coap_initiate_retransmission(struct download_client *dl);
+int coap_parse(struct download_client *client, size_t len);
+int coap_request_send(struct download_client *client);
+
+int socket_send(const struct download_client *client, size_t len, int timeout);
+
+#endif /* DOWNLOAD_CLIENT_INTERNAL_H */

--- a/subsys/net/lib/download_client/src/download_client.c
+++ b/subsys/net/lib/download_client/src/download_client.c
@@ -22,6 +22,7 @@
 #include <zephyr/net/tls_credentials.h>
 #include <net/download_client.h>
 #include <zephyr/logging/log.h>
+#include "download_client_internal.h"
 
 LOG_MODULE_REGISTER(download_client, CONFIG_DOWNLOAD_CLIENT_LOG_LEVEL);
 
@@ -29,19 +30,6 @@ LOG_MODULE_REGISTER(download_client, CONFIG_DOWNLOAD_CLIENT_LOG_LEVEL);
 #define SIN(A) ((struct sockaddr_in *)(A))
 
 #define HOSTNAME_SIZE CONFIG_DOWNLOAD_CLIENT_MAX_HOSTNAME_SIZE
-
-int url_parse_port(const char *url, uint16_t *port);
-int url_parse_proto(const char *url, int *proto, int *type);
-int url_parse_host(const char *url, char *host, size_t len);
-
-int http_parse(struct download_client *client, size_t len);
-int http_get_request_send(struct download_client *client);
-
-int coap_block_init(struct download_client *client, size_t from);
-int coap_get_recv_timeout(struct download_client *dl);
-int coap_initiate_retransmission(struct download_client *dl);
-int coap_parse(struct download_client *client, size_t len);
-int coap_request_send(struct download_client *client);
 
 static int handle_disconnect(struct download_client *client);
 static int error_evt_send(const struct download_client *dl, int error);

--- a/subsys/net/lib/download_client/src/http.c
+++ b/subsys/net/lib/download_client/src/http.c
@@ -11,6 +11,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/__assert.h>
 #include <net/download_client.h>
+#include "download_client_internal.h"
 
 LOG_MODULE_DECLARE(download_client, CONFIG_DOWNLOAD_CLIENT_LOG_LEVEL);
 
@@ -41,10 +42,6 @@ LOG_MODULE_DECLARE(download_client, CONFIG_DOWNLOAD_CLIENT_LOG_LEVEL);
 	"\r\n"
 
 extern char *strnstr(const char *haystack, const char *needle, size_t haystack_sz);
-
-int url_parse_host(const char *url, char *host, size_t len);
-int url_parse_file(const char *url, char *file, size_t len);
-int socket_send(const struct download_client *client, size_t len, int timeout);
 
 int http_get_request_send(struct download_client *client)
 {

--- a/subsys/net/lib/fota_download/CMakeLists.txt
+++ b/subsys/net/lib/fota_download/CMakeLists.txt
@@ -28,3 +28,5 @@ zephyr_library_sources_ifdef(CONFIG_DFU_TARGET_SMP
 zephyr_include_directories(./include)
 zephyr_include_directories_ifdef(CONFIG_SECURE_BOOT
   ${ZEPHYR_NRF_MODULE_DIR}/subsys/dfu/include)
+zephyr_include_directories_ifdef(CONFIG_DOWNLOAD_CLIENT
+  ${ZEPHYR_NRF_MODULE_DIR}/subsys/net/lib/download_client/include)

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
@@ -828,10 +828,9 @@ static void fota_download_callback(const struct fota_download_evt *evt)
 		LOG_INF("FOTA download failed, target %d", dfu_image_type);
 		target_image_type_store(ongoing_obj_id, dfu_image_type);
 		switch (evt->cause) {
-		/* No error, used when event ID is not FOTA_DOWNLOAD_EVT_ERROR. */
-		case FOTA_DOWNLOAD_ERROR_CAUSE_NO_ERROR:
-			set_result(ongoing_obj_id, RESULT_CONNECTION_LOST);
-			break;
+		/* Connecting to the FOTA server failed. */
+		case FOTA_DOWNLOAD_ERROR_CAUSE_CONNECT_FAILED:
+			/* FALLTHROUGH */
 		/* Downloading the update failed. The download may be retried. */
 		case FOTA_DOWNLOAD_ERROR_CAUSE_DOWNLOAD_FAILED:
 			set_result(ongoing_obj_id, RESULT_CONNECTION_LOST);
@@ -894,6 +893,9 @@ static void lwm2m_start_download_image(uint8_t *data, uint16_t obj_instance)
 		break;
 	case -EINVAL:
 		set_result(obj_instance, RESULT_INVALID_URI);
+		break;
+	case -EPROTONOSUPPORT:
+		set_result(obj_instance, RESULT_UNSUP_PROTO);
 		break;
 	case -EBUSY:
 		/* Failed to init MCUBoot or download client */

--- a/tests/subsys/net/lib/download_client/CMakeLists.txt
+++ b/tests/subsys/net/lib/download_client/CMakeLists.txt
@@ -24,6 +24,10 @@ add_library(download_client STATIC
         ${ZEPHYR_NRF_MODULE_DIR}/subsys/net/lib/download_client/src/download_client.c
         ${ZEPHYR_NRF_MODULE_DIR}/subsys/net/lib/download_client/src/parse.c
         )
+target_include_directories(download_client
+        PRIVATE
+        ${ZEPHYR_NRF_MODULE_DIR}/subsys/net/lib/download_client/include
+        )
 
 target_link_libraries(download_client PUBLIC zephyr_interface)
 target_link_libraries(app PRIVATE download_client)

--- a/tests/subsys/net/lib/fota_download/CMakeLists.txt
+++ b/tests/subsys/net/lib/fota_download/CMakeLists.txt
@@ -25,6 +25,7 @@ target_include_directories(app
   ${ZEPHYR_NRF_MODULE_DIR}/subsys/net/lib/fota_download/include
   ${ZEPHYR_NRF_MODULE_DIR}/include/net/
   ${ZEPHYR_NRF_MODULE_DIR}/subsys/dfu/include
+  ${ZEPHYR_NRF_MODULE_DIR}/subsys/net/lib/download_client/include
   . # To get 'pm_config.h'
   )
 

--- a/tests/subsys/net/lib/lwm2m_fota_utils/src/firmware.c
+++ b/tests/subsys/net/lib/lwm2m_fota_utils/src/firmware.c
@@ -543,7 +543,7 @@ ZTEST(lwm2m_client_utils_firmware, test_firmware_pull_failures_cb)
 	printf("State %d\r\n", state);
 	zassert_equal(state, STATE_DOWNLOADING, "wrong result value");
 	zassert_not_null(firmware_fota_download_cb, "Fota client cb is NULL");
-	pull_callback_event_stub(FOTA_DOWNLOAD_EVT_ERROR, FOTA_DOWNLOAD_ERROR_CAUSE_NO_ERROR);
+	pull_callback_event_stub(FOTA_DOWNLOAD_EVT_ERROR, FOTA_DOWNLOAD_ERROR_CAUSE_CONNECT_FAILED);
 	result = get_app_result();
 	state = get_app_state();
 	zassert_equal(result, RESULT_CONNECTION_LOST, "wrong result value");

--- a/tests/subsys/net/lib/mcumgr_smp_client/CMakeLists.txt
+++ b/tests/subsys/net/lib/mcumgr_smp_client/CMakeLists.txt
@@ -17,10 +17,12 @@ target_sources(app
   ${ZEPHYR_NRF_MODULE_DIR}/subsys/net/lib/mcumgr_smp_client/src/mcumgr_smp_client.c
   ${ZEPHYR_NRF_MODULE_DIR}/subsys/net/lib/fota_download/src/util/fota_download_util.c
   ${ZEPHYR_NRF_MODULE_DIR}/subsys/net/lib/fota_download/src/util/fota_download_smp.c
+  ${ZEPHYR_NRF_MODULE_DIR}/subsys/net/lib/download_client/src/parse.c
   )
 
 set(includes
 "src/"
+${ZEPHYR_NRF_MODULE_DIR}/subsys/net/lib/download_client/include
 )
 
 target_include_directories(app


### PR DESCRIPTION
Parse URI before starting the download client
and return parsing failures from _start().

Also, check that download_client parses the protocol,
which means that it knows the protocol.

NCSDK-26790