### PR TITLE
manifest: Update zephyr with SPI tests for nrf54h and nrf54l

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: c22c9c258ce776b88dac8a917ab13f46a4c7db85
+      revision: a49a583e33618d906e0be2b1da2525fe47ece5df
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update zephyr with support for nrf54h and nrf54l in spi_loopback. Update zephyr with spi_slave test supported on nrf54h and nrf54l.