### PR TITLE
Introduce a config option for station mode

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -114,7 +114,7 @@ manifest:
     - name: hostap
       repo-path: sdk-hostap
       path: modules/lib/hostap
-      revision: e2b94fdfa8ffce51e7f6d096c858b71b2d8c1a14
+      revision: pull/164/head
       userdata:
         ncs:
           upstream-url: https://w1.fi/cgit/hostap/


### PR DESCRIPTION
Introduce a config option for station mode which can be used to include station-only features during compile time.