### PR TITLE
samples: matter: Introduced initial support for nRF54L15

### DIFF
--- a/samples/matter/light_bulb/README.rst
+++ b/samples/matter/light_bulb/README.rst
@@ -39,7 +39,7 @@ IPv6 network support
 
 The development kits for this sample offer the following IPv6 network support for Matter:
 
-* Matter over Thread is supported for ``nrf52840dk_nrf52840``, ``nrf5340dk_nrf5340_cpuapp``, and ``nrf21540dk_nrf52840``.
+* Matter over Thread is supported for ``nrf52840dk_nrf52840``, ``nrf5340dk_nrf5340_cpuapp``, ``nrf21540dk_nrf52840``, and ``nrf54l15pdk_nrf54l15``.
 * Matter over Wi-Fi is supported for ``nrf5340dk_nrf5340_cpuapp`` with the ``nrf7002ek`` shield attached or for ``nrf7002dk_nrf5340_cpuapp``.
 
 Overview

--- a/samples/matter/light_bulb/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/light_bulb/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# TODO: Workaround to be removed once PWM will be supported on nRF54L.
+CONFIG_PWM=n
+
+# Multirole is the only currently supported role by SoftDevice.
+CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
+
+# TODO: Workaround to be removed once DFU will be supported on nRF54L.
+CONFIG_CHIP_OTA_REQUESTOR=n
+CONFIG_CHIP_QSPI_NOR=n
+
+CONFIG_FPROTECT=n
+CONFIG_LOG_MODE_DEFERRED=y
+CONFIG_FPU=n
+CONFIG_PM=n
+CONFIG_HWINFO_NRF=n
+
+CONFIG_NRF_802154_TEMPERATURE_UPDATE=n
+
+# TODO: Workaround that disables factory data until it will be supported.
+CONFIG_CHIP_FACTORY_DATA=n
+CONFIG_CHIP_FACTORY_DATA_BUILD=n
+
+# TODO: Workaround for buttons on nRF54L15 PDK in revision 0.2.x. To be removed for a PDK in higher revisions.
+CONFIG_DK_LIBRARY_BUTTON_NO_ISR=y

--- a/samples/matter/light_bulb/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
+++ b/samples/matter/light_bulb/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		zephyr,console = &uart30;
+		zephyr,shell-uart = &uart30;
+	};
+
+	aliases {
+		factory-data = &factory_data;
+		factory-data-memory-region = &rram0;
+	};
+};
+
+/delete-node/ &rram0;
+
+&rram_controller {
+	reg = < 0x5004b000 0x17d000 >;
+
+	rram0: rram@0 {
+		compatible = "soc-nv-flash";
+		erase-block-size = < 0x1000 >;
+		write-block-size = < 0x10 >;
+		reg = < 0x0 0x17d000 >;
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = < 0x1 >;
+			#size-cells = < 0x1 >;
+			boot_partition: partition@0 {
+				label = "mcuboot";
+				reg = < 0x0 0x10000 >;
+			};
+			slot0_partition: partition@10000 {
+				label = "image-0";
+				reg = < 0x10000 0xefe00 >;
+			};
+			storage_partition: partition@ffe00 {
+				label = "storage";
+				reg = < 0xffe00 0x8000 >;
+			};
+			factory_data: partition@107e00 {
+				label = "factory-data";
+				reg = < 0x107e00 0x1000 >;
+			};
+		};
+	};
+};
+
+&uart30 {
+	status = "okay";
+};

--- a/samples/matter/light_bulb/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
+++ b/samples/matter/light_bulb/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# TODO: Workaround to be removed once PWM will be supported on nRF54L.
+CONFIG_PWM=n
+
+# Multirole is the only currently supported role by SoftDevice.
+CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
+
+# TODO: Workaround to be removed once DFU will be supported on nRF54L.
+CONFIG_CHIP_OTA_REQUESTOR=n
+CONFIG_CHIP_QSPI_NOR=n
+
+CONFIG_FPROTECT=n
+CONFIG_LOG_MODE_DEFERRED=y
+CONFIG_FPU=n
+CONFIG_PM=n
+CONFIG_HWINFO_NRF=n
+
+CONFIG_NRF_802154_TEMPERATURE_UPDATE=n
+
+# TODO: Workaround that disables factory data until it will be supported.
+CONFIG_CHIP_FACTORY_DATA=n
+CONFIG_CHIP_FACTORY_DATA_BUILD=n
+
+# TODO: Workaround for buttons on nRF54L15 PDK in revision 0.2.x. To be removed for a PDK in higher revisions.
+CONFIG_DK_LIBRARY_BUTTON_NO_ISR=y

--- a/samples/matter/light_bulb/sample.yaml
+++ b/samples/matter/light_bulb/sample.yaml
@@ -9,7 +9,9 @@ tests:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf7002dk_nrf5340_cpuapp
+      - nrf54l15pdk_nrf54l15_cpuapp
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
+      nrf54l15pdk_nrf54l15_cpuapp
   sample.matter.light_bulb.ffs:
     build_only: true
     extra_args: >
@@ -19,7 +21,9 @@ tests:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf7002dk_nrf5340_cpuapp
+      - nrf54l15pdk_nrf54l15_cpuapp
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
+      nrf54l15pdk_nrf54l15_cpuapp
   sample.matter.light_bulb.debug.nrf21540ek:
     build_only: true
     extra_args: SHIELD=nrf21540ek
@@ -37,10 +41,12 @@ tests:
     build_only: true
     extra_args: CONFIG_CHIP_PERSISTENT_SUBSCRIPTIONS=y
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
+      nrf54l15pdk_nrf54l15_cpuapp
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf7002dk_nrf5340_cpuapp
+      - nrf54l15pdk_nrf54l15_cpuapp
   sample.matter.light_bulb.aws:
     build_only: true
     extra_args: EXTRA_CONF_FILE="overlay-aws-iot-integration.conf"

--- a/samples/matter/light_bulb/src/zcl_callbacks.cpp
+++ b/samples/matter/light_bulb/src/zcl_callbacks.cpp
@@ -29,8 +29,14 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath &a
 
 	if (clusterId == OnOff::Id && attributeId == OnOff::Attributes::OnOff::Id) {
 		ChipLogProgress(Zcl, "Cluster OnOff: attribute OnOff set to %" PRIu8 "", *value);
-		AppTask::Instance().GetPWMDevice().InitiateAction(*value ? Nrf::PWMDevice::ON_ACTION : Nrf::PWMDevice::OFF_ACTION,
+
+#if defined(CONFIG_PWM)
+		AppTask::Instance().GetPWMDevice().InitiateAction(*value ? Nrf::PWMDevice::ON_ACTION :
+									   Nrf::PWMDevice::OFF_ACTION,
 								  static_cast<int32_t>(LightingActor::Remote), value);
+#else
+		Nrf::GetBoard().GetLED(Nrf::DeviceLeds::LED2).Set(*value);
+#endif
 
 #ifdef CONFIG_AWS_IOT_INTEGRATION
 		aws_iot_integration_attribute_set(ATTRIBUTE_ID_ONOFF, *value);
@@ -38,12 +44,14 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath &a
 
 	} else if (clusterId == LevelControl::Id && attributeId == LevelControl::Attributes::CurrentLevel::Id) {
 		ChipLogProgress(Zcl, "Cluster LevelControl: attribute CurrentLevel set to %" PRIu8 "", *value);
+#if defined(CONFIG_PWM)
 		if (AppTask::Instance().GetPWMDevice().IsTurnedOn()) {
 			AppTask::Instance().GetPWMDevice().InitiateAction(
 				Nrf::PWMDevice::LEVEL_ACTION, static_cast<int32_t>(LightingActor::Remote), value);
 		} else {
 			ChipLogDetail(Zcl, "LED is off. Try to use move-to-level-with-on-off instead of move-to-level");
 		}
+#endif
 
 #ifdef CONFIG_AWS_IOT_INTEGRATION
 		aws_iot_integration_attribute_set(ATTRIBUTE_ID_LEVEL_CONTROL, *value);
@@ -75,9 +83,13 @@ void emberAfOnOffClusterInitCallback(EndpointId endpoint)
 	status = Attributes::OnOff::Get(endpoint, &storedValue);
 	if (status == EMBER_ZCL_STATUS_SUCCESS) {
 		/* Set actual state to the cluster state that was last persisted */
+#if defined(CONFIG_PWM)
 		AppTask::Instance().GetPWMDevice().InitiateAction(
 			storedValue ? Nrf::PWMDevice::ON_ACTION : Nrf::PWMDevice::OFF_ACTION,
 			static_cast<int32_t>(LightingActor::Remote), reinterpret_cast<uint8_t *>(&storedValue));
+#else
+		Nrf::GetBoard().GetLED(Nrf::DeviceLeds::LED2).Set(storedValue);
+#endif
 	}
 
 	AppTask::Instance().UpdateClusterState();

--- a/samples/matter/light_switch/README.rst
+++ b/samples/matter/light_switch/README.rst
@@ -43,7 +43,7 @@ IPv6 network support
 
 The development kits for this sample offer the following IPv6 network support for Matter:
 
-* Matter over Thread is supported for ``nrf52840dk_nrf52840``, ``nrf5340dk_nrf5340_cpuapp``, and ``nrf21540dk_nrf52840``.
+* Matter over Thread is supported for ``nrf52840dk_nrf52840``, ``nrf5340dk_nrf5340_cpuapp``, ``nrf21540dk_nrf52840``, and ``nrf54l15pdk_nrf54l15``.
 * Matter over Wi-Fi is supported for ``nrf5340dk_nrf5340_cpuapp`` with the ``nrf7002ek`` shield attached or for ``nrf7002dk_nrf5340_cpuapp``.
 
 Overview

--- a/samples/matter/light_switch/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/light_switch/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Multirole is the only currently supported role by SoftDevice.
+CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
+
+# TODO: Workaround to be removed once DFU will be supported on nRF54L.
+CONFIG_CHIP_OTA_REQUESTOR=n
+CONFIG_CHIP_QSPI_NOR=n
+
+CONFIG_FPROTECT=n
+CONFIG_LOG_MODE_DEFERRED=y
+CONFIG_FPU=n
+CONFIG_PM=n
+CONFIG_HWINFO_NRF=n
+
+CONFIG_NRF_802154_TEMPERATURE_UPDATE=n
+
+# TODO: Workaround that disables factory data until it will be supported.
+CONFIG_CHIP_FACTORY_DATA=n
+CONFIG_CHIP_FACTORY_DATA_BUILD=n
+
+# TODO: Workaround for buttons on nRF54L15 PDK in revision 0.2.x. To be removed for a PDK in higher revisions.
+CONFIG_DK_LIBRARY_BUTTON_NO_ISR=y

--- a/samples/matter/light_switch/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
+++ b/samples/matter/light_switch/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		zephyr,console = &uart30;
+		zephyr,shell-uart = &uart30;
+	};
+
+	aliases {
+		factory-data = &factory_data;
+		factory-data-memory-region = &rram0;
+	};
+};
+
+/delete-node/ &rram0;
+
+&rram_controller {
+	reg = < 0x5004b000 0x17d000 >;
+
+	rram0: rram@0 {
+		compatible = "soc-nv-flash";
+		erase-block-size = < 0x1000 >;
+		write-block-size = < 0x10 >;
+		reg = < 0x0 0x17d000 >;
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = < 0x1 >;
+			#size-cells = < 0x1 >;
+			boot_partition: partition@0 {
+				label = "mcuboot";
+				reg = < 0x0 0x10000 >;
+			};
+			slot0_partition: partition@10000 {
+				label = "image-0";
+				reg = < 0x10000 0xefe00 >;
+			};
+			storage_partition: partition@ffe00 {
+				label = "storage";
+				reg = < 0xffe00 0x8000 >;
+			};
+			factory_data: partition@107e00 {
+				label = "factory-data";
+				reg = < 0x107e00 0x1000 >;
+			};
+		};
+	};
+};
+
+&uart30 {
+	status = "okay";
+};

--- a/samples/matter/light_switch/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
+++ b/samples/matter/light_switch/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Multirole is the only currently supported role by SoftDevice.
+CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
+
+# TODO: Workaround to be removed once DFU will be supported on nRF54L.
+CONFIG_CHIP_OTA_REQUESTOR=n
+CONFIG_CHIP_QSPI_NOR=n
+
+CONFIG_FPROTECT=n
+CONFIG_LOG_MODE_DEFERRED=y
+CONFIG_FPU=n
+CONFIG_PM=n
+CONFIG_HWINFO_NRF=n
+
+CONFIG_NRF_802154_TEMPERATURE_UPDATE=n
+
+# TODO: Workaround that disables factory data until it will be supported.
+CONFIG_CHIP_FACTORY_DATA=n
+CONFIG_CHIP_FACTORY_DATA_BUILD=n
+
+# TODO: Workaround for buttons on nRF54L15 PDK in revision 0.2.x. To be removed for a PDK in higher revisions.
+CONFIG_DK_LIBRARY_BUTTON_NO_ISR=y

--- a/samples/matter/light_switch/sample.yaml
+++ b/samples/matter/light_switch/sample.yaml
@@ -9,20 +9,26 @@ tests:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf7002dk_nrf5340_cpuapp
+      - nrf54l15pdk_nrf54l15_cpuapp
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
+      nrf54l15pdk_nrf54l15_cpuapp
   sample.matter.light_switch.debug:
     build_only: true
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf7002dk_nrf5340_cpuapp
+      - nrf54l15pdk_nrf54l15_cpuapp
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
+      nrf54l15pdk_nrf54l15_cpuapp
   # Sample to execute load tests
   sample.matter.light_switch.persistent_subscriptions:
     build_only: true
     extra_args: CONFIG_CHIP_PERSISTENT_SUBSCRIPTIONS=y
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
+      nrf54l15pdk_nrf54l15_cpuapp
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf7002dk_nrf5340_cpuapp
+      - nrf54l15pdk_nrf54l15_cpuapp

--- a/samples/matter/template/README.rst
+++ b/samples/matter/template/README.rst
@@ -32,7 +32,7 @@ IPv6 network support
 
 The development kits for this sample offer the following IPv6 network support for Matter:
 
-* Matter over Thread is supported for ``nrf52840dk_nrf52840``, ``nrf5340dk_nrf5340_cpuapp``, and ``nrf21540dk_nrf52840``.
+* Matter over Thread is supported for ``nrf52840dk_nrf52840``, ``nrf5340dk_nrf5340_cpuapp``, ``nrf21540dk_nrf52840``, and ``nrf54l15pdk_nrf54l15``.
 * Matter over Wi-Fi is supported for ``nrf5340dk_nrf5340_cpuapp`` with the ``nrf7002ek`` shield attached or for ``nrf7002dk_nrf5340_cpuapp``.
 
 Overview

--- a/samples/matter/template/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/template/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Multirole is the only currently supported role by SoftDevice.
+CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
+
+# TODO: Workaround to be removed once DFU will be supported on nRF54L.
+CONFIG_CHIP_OTA_REQUESTOR=n
+CONFIG_CHIP_QSPI_NOR=n
+
+CONFIG_FPROTECT=n
+CONFIG_LOG_MODE_DEFERRED=y
+CONFIG_FPU=n
+CONFIG_PM=n
+CONFIG_HWINFO_NRF=n
+
+CONFIG_NRF_802154_TEMPERATURE_UPDATE=n
+
+# TODO: Workaround that disables factory data until it will be supported.
+CONFIG_CHIP_FACTORY_DATA=n
+CONFIG_CHIP_FACTORY_DATA_BUILD=n
+
+# TODO: Workaround for buttons on nRF54L15 PDK in revision 0.2.x. To be removed for a PDK in higher revisions.
+CONFIG_DK_LIBRARY_BUTTON_NO_ISR=y

--- a/samples/matter/template/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
+++ b/samples/matter/template/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		zephyr,console = &uart30;
+		zephyr,shell-uart = &uart30;
+	};
+
+	aliases {
+		factory-data = &factory_data;
+		factory-data-memory-region = &rram0;
+	};
+};
+
+/delete-node/ &rram0;
+
+&rram_controller {
+	reg = < 0x5004b000 0x17d000 >;
+
+	rram0: rram@0 {
+		compatible = "soc-nv-flash";
+		erase-block-size = < 0x1000 >;
+		write-block-size = < 0x10 >;
+		reg = < 0x0 0x17d000 >;
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = < 0x1 >;
+			#size-cells = < 0x1 >;
+			boot_partition: partition@0 {
+				label = "mcuboot";
+				reg = < 0x0 0x10000 >;
+			};
+			slot0_partition: partition@10000 {
+				label = "image-0";
+				reg = < 0x10000 0xefe00 >;
+			};
+			storage_partition: partition@ffe00 {
+				label = "storage";
+				reg = < 0xffe00 0x8000 >;
+			};
+			factory_data: partition@107e00 {
+				label = "factory-data";
+				reg = < 0x107e00 0x1000 >;
+			};
+		};
+	};
+};
+
+&uart30 {
+	status = "okay";
+};

--- a/samples/matter/template/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
+++ b/samples/matter/template/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Multirole is the only currently supported role by SoftDevice.
+CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
+
+# TODO: Workaround to be removed once DFU will be supported on nRF54L.
+CONFIG_CHIP_OTA_REQUESTOR=n
+CONFIG_CHIP_QSPI_NOR=n
+
+CONFIG_FPROTECT=n
+CONFIG_LOG_MODE_DEFERRED=y
+CONFIG_FPU=n
+CONFIG_PM=n
+CONFIG_HWINFO_NRF=n
+
+CONFIG_NRF_802154_TEMPERATURE_UPDATE=n
+
+# TODO: Workaround that disables factory data until it will be supported.
+CONFIG_CHIP_FACTORY_DATA=n
+CONFIG_CHIP_FACTORY_DATA_BUILD=n
+
+# TODO: Workaround for buttons on nRF54L15 PDK in revision 0.2.x. To be removed for a PDK in higher revisions.
+CONFIG_DK_LIBRARY_BUTTON_NO_ISR=y

--- a/samples/matter/template/sample.yaml
+++ b/samples/matter/template/sample.yaml
@@ -9,7 +9,9 @@ tests:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf7002dk_nrf5340_cpuapp
+      - nrf54l15pdk_nrf54l15_cpuapp
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
+      nrf54l15pdk_nrf54l15_cpuapp
   sample.matter.template.release:
     build_only: true
     extra_args: CONF_FILE=prj_release.conf
@@ -18,7 +20,9 @@ tests:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf7002dk_nrf5340_cpuapp
+      - nrf54l15pdk_nrf54l15_cpuapp
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
+      nrf54l15pdk_nrf54l15_cpuapp
   sample.matter.template.smp_dfu:
     build_only: true
     extra_args: CONFIG_CHIP_DFU_OVER_BT_SMP=y
@@ -35,4 +39,6 @@ tests:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf7002dk_nrf5340_cpuapp
+      - nrf54l15pdk_nrf54l15_cpuapp
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
+      nrf54l15pdk_nrf54l15_cpuapp

--- a/samples/matter/thermostat/README.rst
+++ b/samples/matter/thermostat/README.rst
@@ -35,7 +35,7 @@ IPv6 network support
 
 The development kits for this sample offer the following IPv6 network support for Matter:
 
-* Matter over Thread is supported for ``nrf52840dk_nrf52840`` and ``nrf5340dk_nrf5340_cpuapp``.
+* Matter over Thread is supported for ``nrf52840dk_nrf52840``, ``nrf5340dk_nrf5340_cpuapp``, and ``nrf54l15pdk_nrf54l15``.
 * Matter over Wi-Fi is supported for ``nrf5340dk_nrf5340_cpuapp`` with the ``nrf7002_ek`` shield attached or for ``nrf7002dk_nrf5340_cpuapp``.
 
 Overview

--- a/samples/matter/thermostat/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/thermostat/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Multirole is the only currently supported role by SoftDevice.
+CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
+
+# TODO: Workaround to be removed once DFU will be supported on nRF54L.
+CONFIG_CHIP_OTA_REQUESTOR=n
+CONFIG_CHIP_QSPI_NOR=n
+
+CONFIG_FPROTECT=n
+CONFIG_LOG_MODE_DEFERRED=y
+CONFIG_FPU=n
+CONFIG_PM=n
+CONFIG_HWINFO_NRF=n
+
+CONFIG_NRF_802154_TEMPERATURE_UPDATE=n
+
+# TODO: Workaround that disables factory data until it will be supported.
+CONFIG_CHIP_FACTORY_DATA=n
+CONFIG_CHIP_FACTORY_DATA_BUILD=n
+
+# TODO: Workaround for buttons on nRF54L15 PDK in revision 0.2.x. To be removed for a PDK in higher revisions.
+CONFIG_DK_LIBRARY_BUTTON_NO_ISR=y

--- a/samples/matter/thermostat/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
+++ b/samples/matter/thermostat/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		zephyr,console = &uart30;
+		zephyr,shell-uart = &uart30;
+	};
+
+	aliases {
+		factory-data = &factory_data;
+		factory-data-memory-region = &rram0;
+	};
+};
+
+/delete-node/ &rram0;
+
+&rram_controller {
+	reg = < 0x5004b000 0x17d000 >;
+
+	rram0: rram@0 {
+		compatible = "soc-nv-flash";
+		erase-block-size = < 0x1000 >;
+		write-block-size = < 0x10 >;
+		reg = < 0x0 0x17d000 >;
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = < 0x1 >;
+			#size-cells = < 0x1 >;
+			boot_partition: partition@0 {
+				label = "mcuboot";
+				reg = < 0x0 0x10000 >;
+			};
+			slot0_partition: partition@10000 {
+				label = "image-0";
+				reg = < 0x10000 0xefe00 >;
+			};
+			storage_partition: partition@ffe00 {
+				label = "storage";
+				reg = < 0xffe00 0x8000 >;
+			};
+			factory_data: partition@107e00 {
+				label = "factory-data";
+				reg = < 0x107e00 0x1000 >;
+			};
+		};
+	};
+};
+
+&uart30 {
+	status = "okay";
+};

--- a/samples/matter/thermostat/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
+++ b/samples/matter/thermostat/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Multirole is the only currently supported role by SoftDevice.
+CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
+
+# TODO: Workaround to be removed once DFU will be supported on nRF54L.
+CONFIG_CHIP_OTA_REQUESTOR=n
+CONFIG_CHIP_QSPI_NOR=n
+
+CONFIG_FPROTECT=n
+CONFIG_LOG_MODE_DEFERRED=y
+CONFIG_FPU=n
+CONFIG_PM=n
+CONFIG_HWINFO_NRF=n
+
+CONFIG_NRF_802154_TEMPERATURE_UPDATE=n
+
+# TODO: Workaround that disables factory data until it will be supported.
+CONFIG_CHIP_FACTORY_DATA=n
+CONFIG_CHIP_FACTORY_DATA_BUILD=n
+
+# TODO: Workaround for buttons on nRF54L15 PDK in revision 0.2.x. To be removed for a PDK in higher revisions.
+CONFIG_DK_LIBRARY_BUTTON_NO_ISR=y

--- a/samples/matter/thermostat/sample.yaml
+++ b/samples/matter/thermostat/sample.yaml
@@ -8,7 +8,9 @@ tests:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf7002dk_nrf5340_cpuapp
+      - nrf54l15pdk_nrf54l15_cpuapp
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
+      nrf54l15pdk_nrf54l15_cpuapp
   sample.matter.thermostat.release:
     build_only: true
     extra_args: CONF_FILE=prj_release.conf
@@ -16,4 +18,6 @@ tests:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf7002dk_nrf5340_cpuapp
+      - nrf54l15pdk_nrf54l15_cpuapp
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
+      nrf54l15pdk_nrf54l15_cpuapp

--- a/scripts/quarantine_integration.yaml
+++ b/scripts/quarantine_integration.yaml
@@ -51,6 +51,18 @@
   comment: "Configurations excluded to limit resources usage in integration builds"
 
 - scenarios:
+    - sample.matter.light_bulb.persistent_subscriptions
+    - sample.matter.light_switch.persistent_subscriptions
+    - sample.matter.light_bulb.release
+    - sample.matter.light_switch.release
+    - sample.matter.template.mgrt_dac
+    - sample.matter.thermostat.debug
+    - sample.matter.thermostat.release
+  platforms:
+    - nrf54l15pdk_nrf54l15_cpuapp
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
     - sample.nrf7002.iot_devices
     - sample.nrf7002.high_performance
     - sample.nrf7002.memory_optimized


### PR DESCRIPTION
Added support for nRF54L15 platform in the following samples:
* Light Bulb
* Light Switch
* Template
* Thermostat

Additionally, modified light bulb sample to use PWM conditionally to address the fact that nRF54L does not support PWM yet.