### PR TITLE
applications: nrf5340_audio: Only accept supported sample rate

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.c
@@ -140,3 +140,68 @@ int le_audio_stream_dir_get(struct bt_bap_stream const *const stream)
 
 	return ep_info.dir;
 }
+
+bool le_audio_bitrate_check(const struct bt_audio_codec_cfg *codec)
+{
+	int ret;
+	uint32_t octets_per_sdu;
+
+	ret = le_audio_octets_per_frame_get(codec, &octets_per_sdu);
+	if (ret) {
+		LOG_ERR("Error retrieving octets per frame: %d", ret);
+		return false;
+	}
+
+	if (octets_per_sdu < LE_AUDIO_SDU_SIZE_OCTETS(CONFIG_LC3_BITRATE_MIN)) {
+		LOG_WRN("Bitrate too low");
+		return false;
+	} else if (octets_per_sdu > LE_AUDIO_SDU_SIZE_OCTETS(CONFIG_LC3_BITRATE_MAX)) {
+		LOG_WRN("Bitrate too high");
+		return false;
+	}
+
+	return true;
+}
+
+bool le_audio_freq_check(const struct bt_audio_codec_cfg *codec)
+{
+	int ret;
+	uint32_t frequency_hz;
+
+	ret = le_audio_freq_hz_get(codec, &frequency_hz);
+	if (ret) {
+		LOG_ERR("Error retrieving sampling rate: %d", ret);
+		return false;
+	}
+
+	switch (frequency_hz) {
+	case 8000U:
+		return (BT_AUDIO_CODEC_CAP_FREQ_8KHZ & (BT_AUDIO_CODEC_CAPABILIY_FREQ));
+	case 11025U:
+		return (BT_AUDIO_CODEC_CAP_FREQ_11KHZ & (BT_AUDIO_CODEC_CAPABILIY_FREQ));
+	case 16000U:
+		return (BT_AUDIO_CODEC_CAP_FREQ_16KHZ & (BT_AUDIO_CODEC_CAPABILIY_FREQ));
+	case 22050U:
+		return (BT_AUDIO_CODEC_CAP_FREQ_22KHZ & (BT_AUDIO_CODEC_CAPABILIY_FREQ));
+	case 24000U:
+		return (BT_AUDIO_CODEC_CAP_FREQ_24KHZ & (BT_AUDIO_CODEC_CAPABILIY_FREQ));
+	case 32000U:
+		return (BT_AUDIO_CODEC_CAP_FREQ_32KHZ & (BT_AUDIO_CODEC_CAPABILIY_FREQ));
+	case 44100U:
+		return (BT_AUDIO_CODEC_CAP_FREQ_44KHZ & (BT_AUDIO_CODEC_CAPABILIY_FREQ));
+	case 48000U:
+		return (BT_AUDIO_CODEC_CAP_FREQ_48KHZ & (BT_AUDIO_CODEC_CAPABILIY_FREQ));
+	case 88200U:
+		return (BT_AUDIO_CODEC_CAP_FREQ_88KHZ & (BT_AUDIO_CODEC_CAPABILIY_FREQ));
+	case 96000U:
+		return (BT_AUDIO_CODEC_CAP_FREQ_96KHZ & (BT_AUDIO_CODEC_CAPABILIY_FREQ));
+	case 176400U:
+		return (BT_AUDIO_CODEC_CAP_FREQ_176KHZ & (BT_AUDIO_CODEC_CAPABILIY_FREQ));
+	case 192000U:
+		return (BT_AUDIO_CODEC_CAP_FREQ_192KHZ & (BT_AUDIO_CODEC_CAPABILIY_FREQ));
+	case 384000U:
+		return (BT_AUDIO_CODEC_CAP_FREQ_384KHZ & (BT_AUDIO_CODEC_CAPABILIY_FREQ));
+	default:
+		return false;
+	}
+}

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.h
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.h
@@ -32,14 +32,14 @@
 #endif /* CONFIG_SAMPLE_RATE_CONVERTER */
 
 #define BT_BAP_LC3_PRESET_CONFIGURABLE(_loc, _stream_context, _bitrate)                            \
-	BT_BAP_LC3_PRESET(                                                                         \
-		BT_AUDIO_CODEC_LC3_CONFIG(CONFIG_BT_AUDIO_PREF_SAMPLE_RATE_VALUE,                  \
-					  BT_AUDIO_CODEC_CFG_DURATION_10, _loc,                    \
-					  LE_AUDIO_SDU_SIZE_OCTETS(_bitrate), 1, _stream_context), \
-		BT_AUDIO_CODEC_QOS_UNFRAMED(10000u, LE_AUDIO_SDU_SIZE_OCTETS(_bitrate),            \
-					    CONFIG_BT_AUDIO_RETRANSMITS,                           \
-					    CONFIG_BT_AUDIO_MAX_TRANSPORT_LATENCY_MS,              \
-					    CONFIG_BT_AUDIO_PRESENTATION_DELAY_US))
+	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG(CONFIG_BT_AUDIO_PREF_SAMPLE_RATE_VALUE,        \
+						    BT_AUDIO_CODEC_CFG_DURATION_10, _loc,          \
+						    LE_AUDIO_SDU_SIZE_OCTETS(_bitrate), 1,         \
+						    _stream_context),                              \
+			  BT_AUDIO_CODEC_QOS_UNFRAMED(10000u, LE_AUDIO_SDU_SIZE_OCTETS(_bitrate),  \
+						      CONFIG_BT_AUDIO_RETRANSMITS,                 \
+						      CONFIG_BT_AUDIO_MAX_TRANSPORT_LATENCY_MS,    \
+						      CONFIG_BT_AUDIO_PRESENTATION_DELAY_US))
 
 /**
  * @brief Callback for receiving Bluetooth LE Audio data.
@@ -131,9 +131,9 @@ int le_audio_frame_blocks_per_sdu_get(const struct bt_audio_codec_cfg *codec,
 int le_audio_bitrate_get(const struct bt_audio_codec_cfg *const codec, uint32_t *bitrate);
 
 /**
- * @brief	Get the direction of the @p stream provided
+ * @brief	Get the direction of the @p stream provided.
  *
- * @param	stream	Stream to check direction for.
+ * @param[in]	stream	Stream to check direction for.
  *
  * @retval	BT_AUDIO_DIR_SINK	sink direction.
  * @retval	BT_AUDIO_DIR_SOURCE	source direction.
@@ -141,5 +141,25 @@ int le_audio_bitrate_get(const struct bt_audio_codec_cfg *const codec, uint32_t 
  *
  */
 int le_audio_stream_dir_get(struct bt_bap_stream const *const stream);
+
+/**
+ * @brief	Check that the bitrate is within the supported range.
+ *
+ * @param[in]	codec	The audio codec structure.
+ *
+ * retval	true	The bitrate is in the supported range.
+ * retval	false	Otherwise.
+ */
+bool le_audio_bitrate_check(const struct bt_audio_codec_cfg *codec);
+
+/**
+ * @brief	Check that the sample rate is supported.
+ *
+ * @param[in]	codec	The audio codec structure.
+ *
+ * retval	true	The sample rate is supported.
+ * retval	false	Otherwise.
+ */
+bool le_audio_freq_check(const struct bt_audio_codec_cfg *codec);
 
 #endif /* _LE_AUDIO_H_ */

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_server.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_server.c
@@ -238,6 +238,7 @@ static int lc3_config_cb(struct bt_conn *conn, const struct bt_bap_ep *ep, enum 
 			 const struct bt_audio_codec_cfg *codec, struct bt_bap_stream **stream,
 			 struct bt_audio_codec_qos_pref *const pref, struct bt_bap_ascs_rsp *rsp)
 {
+	int ret;
 	LOG_DBG("LC3 config callback");
 
 	for (int i = 0; i < ARRAY_SIZE(audio_streams); i++) {
@@ -246,21 +247,15 @@ static int lc3_config_cb(struct bt_conn *conn, const struct bt_bap_ep *ep, enum 
 		if (!audio_stream->conn) {
 			LOG_DBG("ASE Codec Config stream %p", (void *)audio_stream);
 
-			int ret;
-			uint32_t octets_per_sdu;
-
-			ret = le_audio_octets_per_frame_get(codec, &octets_per_sdu);
-			if (ret) {
-				LOG_ERR("Error retrieving octets frame:, %d", ret);
-				return ret;
+			ret = le_audio_bitrate_check(codec);
+			if (!ret) {
+				LOG_WRN("Bitrate check failed");
+				return -EINVAL;
 			}
 
-			if (octets_per_sdu > LE_AUDIO_SDU_SIZE_OCTETS(CONFIG_LC3_BITRATE_MAX)) {
-				LOG_ERR("Too high bitrate");
-				return -EINVAL;
-			} else if (octets_per_sdu <
-				   LE_AUDIO_SDU_SIZE_OCTETS(CONFIG_LC3_BITRATE_MIN)) {
-				LOG_ERR("Too low bitrate");
+			ret = le_audio_freq_check(codec);
+			if (!ret) {
+				LOG_WRN("Sample rate not supported");
 				return -EINVAL;
 			}
 


### PR DESCRIPTION
- Check the sample rate for BIS/CIS and reject if not supported
- Fixed bug where right headset wouldn't sync to a single BIS in BIG
- OCT-2716