### PR TITLE
subsys: pcd: Fix build error 'CONFIG_FW_INFO_MAGIC_LEN' undeclared here

### DIFF
--- a/subsys/pcd/src/pcd.c
+++ b/subsys/pcd/src/pcd.c
@@ -10,7 +10,9 @@
 #include <zephyr/logging/log.h>
 
 #ifdef CONFIG_PCD_NET
+#ifdef CONFIG_PCD_READ_NETCORE_APP_VERSION
 #include <fw_info_bare.h>
+#endif
 #include <zephyr/storage/stream_flash.h>
 #endif
 


### PR DESCRIPTION
Fix build error 'CONFIG_FW_INFO_MAGIC_LEN' undeclared here. Including the fw_info_bare.h header file without CONFIG_FW_INFO enabled causes issues in struct definition array size, and in static inline functions.