### PR TITLE
Doc: Add missing changelog about Mesh samples nrf54 support

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -230,6 +230,14 @@ Bluetooth Mesh samples
 
   * Added support for the :ref:`zephyr:nrf54l15pdk_nrf54l15` board.
 
+* :ref:`bluetooth_mesh_light_dim` sample:
+
+  * Added support for the :ref:`zephyr:nrf54l15pdk_nrf54l15` board.
+
+* :ref:`bluetooth_mesh_light` sample:
+
+  * Added support for the :ref:`zephyr:nrf54l15pdk_nrf54l15` board.
+
 Cellular samples
 ----------------
 


### PR DESCRIPTION
This adds missing changelog entries about Mesh samples which have had nRF54L15 PDK support added.