### PR TITLE
doc: config_and_build: expand cmake section

### DIFF
--- a/doc/nrf/config_and_build/configuring_app/advanced_building.rst
+++ b/doc/nrf/config_and_build/configuring_app/advanced_building.rst
@@ -86,15 +86,6 @@ Optional build parameters
 
 Here are some of the possible options you can use:
 
-* Some applications contain configuration overlay files that enable specific features.
-  These can be added to the ``west build`` command as follows:
-
-  .. parsed-literal::
-     :class: highlight
-
-     west build -b *build_target* -- -DOVERLAY_CONFIG="overlay-feature1.conf;overlay-feature2.conf"
-
-  See :ref:`configuration_permanent_change` and Zephyr's :ref:`zephyr:west-building-cmake-args` for more information.
 * You can include the *directory_name* parameter to build from a directory other than the current directory.
 * You can use the *build_target@board_revision* parameter to get extra devicetree overlays with new features available for a board version.
   The *board_revision* is printed on the label of your DK, just below the PCA number.

--- a/doc/nrf/config_and_build/configuring_app/hardware/index.rst
+++ b/doc/nrf/config_and_build/configuring_app/hardware/index.rst
@@ -10,6 +10,11 @@ Follow the steps in `How to create devicetree files`_ and use one of the followi
 * `Devicetree Visual Editor <How to work with Devicetree Visual Editor_>`_
 * `Devicetree language support`_
 
+Like Kconfig fragment files, devicetree files can also be provided as overlays.
+The devicetree overlay files are named the same as the build target and use the file extension :file:`.overlay`.
+When they are placed in the :file:`boards` folder and the devicetree overlay file name matches the build target, the build system automatically selects and applies the overlay.
+To select them manually, see :ref:`cmake_options`.
+
 The following guides provide information about configuring specific aspects of hardware support related to devicetree.
 Read them together with Zephyr's :ref:`zephyr:hardware_support` and :ref:`zephyr:dt-guide` guides, and the official `Devicetree Specification`_.
 

--- a/doc/nrf/config_and_build/configuring_app/index.rst
+++ b/doc/nrf/config_and_build/configuring_app/index.rst
@@ -14,18 +14,14 @@ Configuring and building an application
 After you have :ref:`created an application <create_application>`, you need to build it in order to be able to program it.
 Just as for creating the application, you can build the application using either the |nRFVSC| or the command line.
 
-.. note::
-    |application_sample_long_path_windows|
-
 .. tabs::
 
    .. group-tab:: nRF Connect for VS Code
 
       For instructions about building with the |nRFVSC|, see `How to build an application`_ in the extension documentation.
 
-      .. note::
-          By default, the extension runs both stages of the CMake build (:ref:`configuration phase and building phase <app_build_system>`).
-          If you want to only set up the build configuration without building it, make sure the :guilabel:`Build after generating configuration` is not selected.
+      By default, the extension runs both stages of the CMake build (:ref:`configuration phase and building phase <app_build_system>`).
+      If you want to only set up the build configuration without building it, make sure the :guilabel:`Build after generating configuration` is not selected.
 
       If you want to build with custom options or scripts, read about `Binding custom tasks to actions`_ in the extension documentation.
 
@@ -62,6 +58,9 @@ Just as for creating the application, you can build the application using either
          For more information on the contents of the build directory, see :ref:`zephyr:build-directory-contents` in the Zephyr documentation.
 
        For more information on building using the command line, see :ref:`Building <zephyr:west-building>` in the Zephyr documentation.
+
+.. note::
+    |application_sample_long_path_windows|
 
 .. toctree::
    :maxdepth: 1

--- a/doc/nrf/config_and_build/configuring_app/kconfig/index.rst
+++ b/doc/nrf/config_and_build/configuring_app/kconfig/index.rst
@@ -54,6 +54,14 @@ This means that this file is available when building the application until you c
       See :ref:`zephyr:menuconfig` in the Zephyr documentation for instructions on how to run menuconfig or guiconfig.
       To locate a specific configuration option, use the **Jump to** field.
 
+.. _configuration_temporary_change_single_build:
+
+Temporary Kconfig changes for a single build
+============================================
+
+You can also apply temporary Kconfig changes to a single build by :ref:`providing the value of a chosen Kconfig option as a CMake option <cmake_options>`.
+The Kconfig option configuration will be available until you clean the build directory pristinely.
+
 .. _configuration_permanent_change:
 
 Permanent Kconfig changes
@@ -61,9 +69,14 @@ Permanent Kconfig changes
 
 To configure your application and maintain the configuration after you clean the build directory pristinely, you need to specify the configuration in one of the permanent configuration files.
 In most of the cases, this means editing the default :file:`prj.conf` file of the application, but you can also use an extra Kconfig fragment file.
-In these files, you can specify different values for configuration options that are defined by a library or board, and you can add configuration options that are specific to your application.
 
-See :ref:`zephyr:setting_configuration_values` in the Zephyr documentation for information on how to change the configuration permanently.
+The Kconfig fragment files are configuration files used for building an application image with or without software support that is enabled by specific Kconfig options.
+In these files, you can specify different values for configuration options that are defined by a library or board, and you can add configuration options that are specific to your application.
+Examples include whether to add networking support or which drivers are needed by the application.
+Kconfig fragments are applied on top of the default :file:`prj.conf` file and use the :file:`.conf` file extension.
+When they are board-specific, they are placed in the :file:`boards` folder, are named :file:`<board>.conf`, and they are applied on top of the default Kconfig file for the specified board.
+
+See :ref:`zephyr:setting_configuration_values` in the Zephyr documentation for information on how to change the configuration permanently and :ref:`how the additional files are applied <zephyr:initial-conf>`.
 
 .. tip::
    Reconfiguring through menuconfig only changes the specific setting and the invisible options that are calculated from it.

--- a/doc/nrf/installation/install_ncs.rst
+++ b/doc/nrf/installation/install_ncs.rst
@@ -312,7 +312,7 @@ Set up the command-line build environment
    This step is only required when working on command line with freestanding applications.
 
 In addition to the steps mentioned above, if you want to build and program your application from the command line, you have to set up your command-line build environment by defining the required environment variables every time you open a new command-line or terminal window.
-See :ref:`zephyr:important-build-vars` for more information about the various relevant environment variables.
+See :ref:`zephyr:env_vars_important` in the Zephyr documentation for more information about the various relevant environment variables.
 
 Define the required environment variables as follows, depending on your operating system:
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -554,6 +554,7 @@ Documentation
 
 * Updated:
 
+  * The :ref:`cmake_options` section on the :ref:`configuring_cmake` page with the list of most common CMake options and more information about how to provide them.
   * The table listing the :ref:`boards included in sdk-zephyr <app_boards_names_zephyr>` with the nRF54L15 PDK and nRF54H20 DK boards.
   * The :ref:`ug_wifi_overview` page by separating the information about Wi-Fi certification into its own :ref:`ug_wifi_certification` page under :ref:`ug_wifi`.
 


### PR DESCRIPTION
Reworked information about CMake variables with link to more details in Zephyr. NCSDK-22324.

----

Originally part of PR #14518 , but separated to make changes go in in smaller PRs.