### PR TITLE
applications: nrf5340_audio: Disconnect MCP and ISO stream

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/bt_content_control/bt_content_ctrl.h
+++ b/applications/nrf5340_audio/src/bluetooth/bt_content_control/bt_content_ctrl.h
@@ -57,6 +57,14 @@ int bt_content_ctrl_discover(struct bt_conn *conn);
 int bt_content_ctrl_uuid_populate(struct net_buf_simple *uuid_buf);
 
 /**
+ * @brief	Check if the media player is playing.
+ *
+ * @retval	true	Media player is in a playing state.
+ * @retval	false	Media player is not in a playing state.
+ */
+bool bt_content_ctlr_media_state_playing(void);
+
+/**
  * @brief	Initialize the content control module.
  *
  * @return	0 for success, error otherwise.

--- a/applications/nrf5340_audio/src/bluetooth/bt_content_control/media/bt_content_ctrl_media.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_content_control/media/bt_content_ctrl_media.c
@@ -442,6 +442,15 @@ int bt_content_ctrl_media_pause(struct bt_conn *conn)
 	return 0;
 }
 
+bool bt_content_ctlr_media_state_playing(void)
+{
+	if (media_player_state == BT_MCS_MEDIA_STATE_PLAYING) {
+		return true;
+	}
+
+	return false;
+}
+
 int bt_content_ctrl_media_conn_disconnected(struct bt_conn *conn)
 {
 	int idx = mcc_peer_index_get(conn);
@@ -465,9 +474,6 @@ int bt_content_ctrl_media_client_init(void)
 	}
 
 	static struct bt_mcc_cb mcc_cb;
-
-
-
 
 	mcc_cb.discover_mcs = mcc_discover_mcs_cb;
 #if defined(CONFIG_BT_MCC_SET_MEDIA_CONTROL_POINT)

--- a/applications/nrf5340_audio/unicast_server/main.c
+++ b/applications/nrf5340_audio/unicast_server/main.c
@@ -88,13 +88,13 @@ static void button_msg_sub_thread(void)
 				break;
 			}
 
-			if (strm_state == STATE_STREAMING) {
+			if (bt_content_ctlr_media_state_playing()) {
 				ret = bt_content_ctrl_stop(NULL);
 				if (ret) {
 					LOG_WRN("Could not stop: %d", ret);
 				}
 
-			} else if (strm_state == STATE_PAUSED) {
+			} else if (!bt_content_ctlr_media_state_playing()) {
 				ret = bt_content_ctrl_start(NULL);
 				if (ret) {
 					LOG_WRN("Could not start: %d", ret);


### PR DESCRIPTION
- Use the media player state to decide between play/pause in main on unicast_server and not the state of the streaming.
- OCT-2715