### PR TITLE
feat(version): report NCS version on boot

### DIFF
--- a/modules/memfault-firmware-sdk/config/memfault_metrics_heartbeat_extra.def
+++ b/modules/memfault-firmware-sdk/config/memfault_metrics_heartbeat_extra.def
@@ -1,4 +1,6 @@
-/* Definitions for optional metrics. */
+/* Definitions for metrics. */
+
+MEMFAULT_METRICS_STRING_KEY_DEFINE(ncs_version, sizeof("00.00.00") - 1)
 
 #if defined(CONFIG_MODEM_INFO)
 #include <modem/modem_info.h>

--- a/modules/memfault-firmware-sdk/memfault_ncs_metrics.c
+++ b/modules/memfault-firmware-sdk/memfault_ncs_metrics.c
@@ -11,6 +11,7 @@
 #include <modem/lte_lc_trace.h>
 #include <memfault/metrics/metrics.h>
 #include <memfault/core/platform/overrides.h>
+#include <memfault/ports/ncs/version.h>
 
 #include <zephyr/logging/log.h>
 
@@ -120,6 +121,16 @@ void memfault_metrics_heartbeat_collect_data(void)
 
 void memfault_ncs_metrics_init(void)
 {
+	/* Always collect NCS version */
+	char version[sizeof("00.00.00")];
+
+	/* Ensure null-termination */
+	version[sizeof(version) - 1] = '\0';
+
+	sprintf(version, "%d.%d.%d", NCS_VERSION_MAJOR, NCS_VERSION_MINOR, NCS_PATCHLEVEL);
+	MEMFAULT_METRIC_SET_STRING(ncs_version, version);
+	LOG_DBG("NCS version: %s", version);
+
 	if (IS_ENABLED(CONFIG_MEMFAULT_NCS_LTE_METRICS)) {
 		memfault_lte_metrics_init();
 	}


### PR DESCRIPTION
### Summary

The NCS version is now reported on boot. This metric is
useful when debugging issues that are dependent on the
NCS version.

### Test Plan

Enable debug logs and flashed a thingy91,
confirming correct version recorded

```
[00:00:00.563,140] <dbg> memfault_ncs_metrics: memfault_ncs_metrics_init: NCS version: 2.6.99
```