### PR TITLE
Update print toolchain script

### DIFF
--- a/scripts/print_toolchain_checksum.sh
+++ b/scripts/print_toolchain_checksum.sh
@@ -2,7 +2,7 @@
 
 BASEDIR=$(dirname "$0")
 REQUIREMENTS=$BASEDIR/requirements-fixed.txt
-TOOLS_VERSIONS=$BASEDIR/tools-versions-linux.txt
-TOOLCHAIN_VERSION=$(cat $REQUIREMENTS $TOOLS_VERSIONS | sha256sum | head -c 10)
+TOOLS_VERSIONS=$BASEDIR/tools-versions-linux.yml
+TOOLCHAIN_VERSION=$(cat $REQUIREMENTS $TOOLS_VERSIONS | tr -d '\r' | sha256sum | head -c 10)
 
 echo "${TOOLCHAIN_VERSION}"


### PR DESCRIPTION
If yaml files are present, toolchain bundler uses them instead of txt
 files as source of required tools.