### PR TITLE
samples: matter: Enable factory data support on nRF54L15 target.

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -83,7 +83,7 @@ Bluetooth Mesh
 Matter
 ------
 
-|no_changes_yet_note|
+* Added support for merging the generated factory data HEX file with the firmware HEX file by using the devicetree configuration, when Partition Manager is not enabled in the project.
 
 Matter fork
 +++++++++++

--- a/samples/matter/light_bulb/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/light_bulb/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -22,9 +22,8 @@ CONFIG_HWINFO_NRF=n
 
 CONFIG_NRF_802154_TEMPERATURE_UPDATE=n
 
-# TODO: Workaround that disables factory data until it will be supported.
-CONFIG_CHIP_FACTORY_DATA=n
-CONFIG_CHIP_FACTORY_DATA_BUILD=n
+# TODO: Workaround to be removed once Zephyr's CONFIG_FPROTECT is supported on nRF54L
+CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT=n
 
 # TODO: Workaround for buttons on nRF54L15 PDK in revision 0.2.x. To be removed for a PDK in higher revisions.
 CONFIG_DK_LIBRARY_BUTTON_NO_ISR=y

--- a/samples/matter/light_bulb/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
+++ b/samples/matter/light_bulb/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
@@ -22,9 +22,8 @@ CONFIG_HWINFO_NRF=n
 
 CONFIG_NRF_802154_TEMPERATURE_UPDATE=n
 
-# TODO: Workaround that disables factory data until it will be supported.
-CONFIG_CHIP_FACTORY_DATA=n
-CONFIG_CHIP_FACTORY_DATA_BUILD=n
+# TODO: Workaround to be removed once Zephyr's CONFIG_FPROTECT is supported on nRF54L
+CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT=n
 
 # TODO: Workaround for buttons on nRF54L15 PDK in revision 0.2.x. To be removed for a PDK in higher revisions.
 CONFIG_DK_LIBRARY_BUTTON_NO_ISR=y

--- a/samples/matter/light_switch/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/light_switch/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -19,9 +19,8 @@ CONFIG_HWINFO_NRF=n
 
 CONFIG_NRF_802154_TEMPERATURE_UPDATE=n
 
-# TODO: Workaround that disables factory data until it will be supported.
-CONFIG_CHIP_FACTORY_DATA=n
-CONFIG_CHIP_FACTORY_DATA_BUILD=n
+# TODO: Workaround to be removed once Zephyr's CONFIG_FPROTECT is supported on nRF54L
+CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT=n
 
 # TODO: Workaround for buttons on nRF54L15 PDK in revision 0.2.x. To be removed for a PDK in higher revisions.
 CONFIG_DK_LIBRARY_BUTTON_NO_ISR=y

--- a/samples/matter/light_switch/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
+++ b/samples/matter/light_switch/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
@@ -19,9 +19,8 @@ CONFIG_HWINFO_NRF=n
 
 CONFIG_NRF_802154_TEMPERATURE_UPDATE=n
 
-# TODO: Workaround that disables factory data until it will be supported.
-CONFIG_CHIP_FACTORY_DATA=n
-CONFIG_CHIP_FACTORY_DATA_BUILD=n
+# TODO: Workaround to be removed once Zephyr's CONFIG_FPROTECT is supported on nRF54L
+CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT=n
 
 # TODO: Workaround for buttons on nRF54L15 PDK in revision 0.2.x. To be removed for a PDK in higher revisions.
 CONFIG_DK_LIBRARY_BUTTON_NO_ISR=y

--- a/samples/matter/template/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/template/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -19,9 +19,8 @@ CONFIG_HWINFO_NRF=n
 
 CONFIG_NRF_802154_TEMPERATURE_UPDATE=n
 
-# TODO: Workaround that disables factory data until it will be supported.
-CONFIG_CHIP_FACTORY_DATA=n
-CONFIG_CHIP_FACTORY_DATA_BUILD=n
+# TODO: Workaround to be removed once Zephyr's CONFIG_FPROTECT is supported on nRF54L
+CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT=n
 
 # TODO: Workaround for buttons on nRF54L15 PDK in revision 0.2.x. To be removed for a PDK in higher revisions.
 CONFIG_DK_LIBRARY_BUTTON_NO_ISR=y

--- a/samples/matter/template/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
+++ b/samples/matter/template/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
@@ -11,7 +11,6 @@ CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 CONFIG_CHIP_OTA_REQUESTOR=n
 CONFIG_CHIP_QSPI_NOR=n
 
-CONFIG_FPROTECT=n
 CONFIG_LOG_MODE_DEFERRED=y
 CONFIG_FPU=n
 CONFIG_PM=n
@@ -19,9 +18,8 @@ CONFIG_HWINFO_NRF=n
 
 CONFIG_NRF_802154_TEMPERATURE_UPDATE=n
 
-# TODO: Workaround that disables factory data until it will be supported.
-CONFIG_CHIP_FACTORY_DATA=n
-CONFIG_CHIP_FACTORY_DATA_BUILD=n
+# TODO: Workaround to be removed once Zephyr's CONFIG_FPROTECT is supported on nRF54L
+CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT=n
 
 # TODO: Workaround for buttons on nRF54L15 PDK in revision 0.2.x. To be removed for a PDK in higher revisions.
 CONFIG_DK_LIBRARY_BUTTON_NO_ISR=y

--- a/samples/matter/thermostat/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/thermostat/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -19,9 +19,8 @@ CONFIG_HWINFO_NRF=n
 
 CONFIG_NRF_802154_TEMPERATURE_UPDATE=n
 
-# TODO: Workaround that disables factory data until it will be supported.
-CONFIG_CHIP_FACTORY_DATA=n
-CONFIG_CHIP_FACTORY_DATA_BUILD=n
+# TODO: Workaround to be removed once Zephyr's CONFIG_FPROTECT is supported on nRF54L
+CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT=n
 
 # TODO: Workaround for buttons on nRF54L15 PDK in revision 0.2.x. To be removed for a PDK in higher revisions.
 CONFIG_DK_LIBRARY_BUTTON_NO_ISR=y

--- a/samples/matter/thermostat/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
+++ b/samples/matter/thermostat/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
@@ -19,9 +19,8 @@ CONFIG_HWINFO_NRF=n
 
 CONFIG_NRF_802154_TEMPERATURE_UPDATE=n
 
-# TODO: Workaround that disables factory data until it will be supported.
-CONFIG_CHIP_FACTORY_DATA=n
-CONFIG_CHIP_FACTORY_DATA_BUILD=n
+# TODO: Workaround to be removed once Zephyr's CONFIG_FPROTECT is supported on nRF54L
+CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT=n
 
 # TODO: Workaround for buttons on nRF54L15 PDK in revision 0.2.x. To be removed for a PDK in higher revisions.
 CONFIG_DK_LIBRARY_BUTTON_NO_ISR=y

--- a/west.yml
+++ b/west.yml
@@ -160,7 +160,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: eda827619fb7f9fbadd7e9df60b910553c27891c
+      revision: 83caae1c335c002350ebaaff822139e1de5ac796
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
- Allowed merging the factory data .hex file with the firmware .hex file without utilizing partition manager.
- Enabled factory data support in all required matter samples for nrf54l15 target.