### PR TITLE
Bluetooth: Mesh: Add core type to metadata JSON

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -79,6 +79,7 @@ Bluetooth Mesh
   * The Kconfig option :kconfig:option:`CONFIG_BT_MESH_DFU_METADATA_ON_BUILD` to no longer depend on the Kconfig option :kconfig:option:`CONFIG_BT_MESH_DFU_METADATA`.
   * The Kconfig option :kconfig:option:`CONFIG_BT_MESH_DFU_CLI` to no longer enable the Kconfig option :kconfig:option:`CONFIG_BT_MESH_DFU_METADATA_ON_BUILD` by default.
     The Kconfig option :kconfig:option:`CONFIG_BT_MESH_DFU_METADATA_ON_BUILD` can still be manually enabled.
+  * The JSON file, added to :file:`dfu_application.zip` during the automatic DFU metadata generation, to now contain a field for the ``core_type`` used when encoding the metadata.
 
 Matter
 ------

--- a/scripts/bluetooth/mesh/mesh_dfu_metadata.py
+++ b/scripts/bluetooth/mesh/mesh_dfu_metadata.py
@@ -367,8 +367,7 @@ def parse_comp_data(elf_path, kconfigs):
     except Exception as err:
         raise Exception("Failed to extract composition data from .elf file") from err
 
-def encoded_metadata_get(version, comp, binary_size):
-    core_type = 1
+def encoded_metadata_get(version, comp, binary_size, core_type):
     elem_cnt = len(comp.elems)
 
     bytestring = bytearray()
@@ -418,14 +417,16 @@ if __name__ == "__main__":
         comps = parse_comp_data(elf_path, kconfigs)
         version = kconfigs.version_parse()
         binary_size = os.path.getsize(os.path.join(args.bin_path, 'app_update.bin'))
+        core_type = 1
 
         json_data = []
 
         for comp in comps:
-            encoded_metadata = encoded_metadata_get(version, comp, binary_size)
+            encoded_metadata = encoded_metadata_get(version, comp, binary_size, core_type)
             json_data.append({
                 "sign_version": version,
                 "binary_size": binary_size,
+                "core_type": core_type,
                 "composition_data": comp.dict_generate(),
                 "composition_hash": str(hex(comp.hash_generate())),
                 "encoded_metadata": str(encoded_metadata.hex()),

--- a/tests/subsys/bluetooth/mesh/metadata_extraction/verify_metadata.py
+++ b/tests/subsys/bluetooth/mesh/metadata_extraction/verify_metadata.py
@@ -51,6 +51,7 @@ def expected_metadata(size):
         {
             'sign_version': {'major': 1, 'minor': 2, 'revision': 3, 'build_number': 4},
             'binary_size': size,
+            'core_type': 1,
             'composition_data': {
                 'cid': 1,
                 'pid': 2,
@@ -67,6 +68,7 @@ def expected_metadata(size):
         {
             'sign_version': {'major': 1, 'minor': 2, 'revision': 3, 'build_number': 4},
             'binary_size': size,
+            'core_type': 1,
             'composition_data': {
                 'cid': 4,
                 'pid': 5,


### PR DESCRIPTION
This adds the core type, used in constructing the encoded metadata string, as a separate field in the JSON file output by the metadata extraction script.