### PR TITLE
doc: add information about FILE_SUFFIX

### DIFF
--- a/applications/machine_learning/README.rst
+++ b/applications/machine_learning/README.rst
@@ -285,7 +285,7 @@ For example, the configuration files for the Thingy:53 are defined in the :file:
 
 The following configuration files can be defined for any supported board:
 
-* :file:`prj_build_type.conf` - Kconfig configuration file for a build type.
+* :file:`prj_<build_type>.conf` - Kconfig configuration file for a :ref:`custom build type <modifying_build_types>`.
   To support a given build type for the selected board, you must define the configuration file with a proper name.
   See :ref:`nrf_machine_learning_app_configuration_build_types` for more information.
 * :file:`app.overlay` - DTS overlay file specific for the board.
@@ -311,8 +311,8 @@ The Thingy:53 and nRF53 Development Kit use multi-image build with the following
 * Bluetooth HCI RPMsg
 
 You can define the application-specific configuration for the mentioned child images in the board-specific directory in the :file:`applications/machine_learning/configuration/` directory.
-The Kconfig configuration file should be located in subdirectory :file:`child_image/child_image_name` and its name should match the application Kconfig file name, that is contain the build type if necessary
-For example, the :file:`applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/child_image/hci_ipc/prj.conf` file defines configuration of Bluetooth HCI RPMsg for ``debug`` build type on ``thingy53_nrf5340_cpuapp`` board, while the :file:`applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/child_image/hci_ipc/prj_release.conf` file defines configuration of Bluetooth HCI RPMsg for ``release`` build type.
+The Kconfig configuration file should be located in subdirectory :file:`child_image/<child_image_name>` and its name should match the application Kconfig file name, and it should contain the build type if necessary.
+For example, the :file:`applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/child_image/hci_ipc/prj.conf` file defines configuration of Bluetooth HCI RPMsg for the ``debug`` build type on ``thingy53_nrf5340_cpuapp`` board, while the :file:`applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/child_image/hci_ipc/prj_release.conf` file defines configuration of Bluetooth HCI RPMsg for the ``release`` build type.
 See :ref:`ug_multi_image` for detailed information about multi-image builds and child image configuration.
 
 .. _nrf_machine_learning_app_requirements_build_types:
@@ -325,7 +325,7 @@ The nRF Machine Learning application does not use a single :file:`prj.conf` file
 Before you start testing the application, you can select one of the build types supported by the application.
 Not every board supports both mentioned build types.
 
-See :ref:`app_build_additions_build_types` and :ref:`modifying_build_types` for more information about this feature of the |NCS|.
+See :ref:`app_build_additions_build_types` and :ref:`cmake_options` for more information.
 
 The application supports the following build types:
 
@@ -368,13 +368,13 @@ Selecting a build type
 ======================
 
 Before you start testing the application, you can select one of the :ref:`nrf_machine_learning_app_requirements_build_types`.
-See :ref:`modifying_build_types` for detailed steps how to select a build type.
+See :ref:`cmake_options` for information about how to select a build type.
 
 Providing API key
 =================
 
 If the URI of the Edge Impulse zip file requires providing an additional API key, you can provide it using the following CMake definition: :c:macro:`EI_API_KEY_HEADER`.
-This definition is set in a similar way as selected build type.
+This definition is set in a similar way as selecting a build type.
 For more detailed information about building the machine learning model in the |NCS|, see :ref:`ug_edge_impulse`.
 
 .. tip::

--- a/applications/matter_bridge/doc/matter_bridge_description.rst
+++ b/applications/matter_bridge/doc/matter_bridge_description.rst
@@ -440,7 +440,7 @@ The Matter bridge application does not use a single :file:`prj.conf` file.
 Before you start testing the application, you can select one of the build types supported by the application.
 Not every board supports both mentioned build types.
 
-See :ref:`app_build_additions_build_types` and :ref:`modifying_build_types` for more information about this feature of the |NCS|.
+See :ref:`app_build_additions_build_types` and :ref:`cmake_options` for more information.
 
 The application supports the following build types:
 
@@ -482,7 +482,7 @@ Selecting a build type
 ======================
 
 Before you start testing the application, you can select one of the :ref:`matter_bridge_app_build_types`.
-See :ref:`modifying_build_types` for detailed steps how to select a build type.
+See :ref:`cmake_options` for information about how to select a build type.
 
 .. _matter_bridge_testing:
 

--- a/applications/matter_weather_station/README.rst
+++ b/applications/matter_weather_station/README.rst
@@ -130,7 +130,7 @@ The Matter weather station application does not use a single :file:`prj.conf` fi
 Configuration files are provided for different build types, and they are located in the :file:`configuration/thingy53_nrf5340_cpuapp` directory.
 Before you start testing the application, you can select one of the build types supported by the application.
 
-See :ref:`app_build_additions_build_types` and :ref:`modifying_build_types` for more information about this feature of the |NCS|.
+See :ref:`app_build_additions_build_types` and :ref:`cmake_options` for more information.
 
 The application supports the following build types:
 
@@ -189,7 +189,7 @@ Selecting a build type
 ======================
 
 Before you start testing the application, you can select one of the :ref:`matter_weather_station_app_build_types`.
-See :ref:`modifying_build_types` for detailed steps how to select a build type.
+See :ref:`cmake_options` for information about how to select a build type.
 
 Building for the nRF7002 Wi-Fi expansion board
 ==============================================
@@ -319,7 +319,7 @@ The onboarding information representation depends on your commissioner setup.
 For this application, the data payload, which includes the device discriminator and setup PIN code, is encoded and shared using an NFC tag.
 When using the debug configuration, you can also get this type of information from the USB interface logs.
 
-Alternatively, depending on your build type and selected configuration overlay, you can also use one of the following :ref:`onboarding information formats <ug_matter_network_topologies_commissioning_onboarding_formats>` to provide the commissioner with the data required:
+Alternatively, depending on your build type and selected overlay, you can also use one of the following :ref:`onboarding information formats <ug_matter_network_topologies_commissioning_onboarding_formats>` to provide the commissioner with the data required:
 
 * For the debug and release build types:
 

--- a/applications/nrf5340_audio/doc/building.rst
+++ b/applications/nrf5340_audio/doc/building.rst
@@ -209,14 +209,14 @@ Complete the following steps to build the application:
    #. Choose the application version by using one of the following options:
 
       * For the debug version: No build flag needed.
-      * For the release version: ``-DCONF_FILE="prj_release.conf"``
+      * For the release version: ``-DFILE_SUFFIX=release``
 
 #. Build the application using the standard :ref:`build steps <building>` for the command line.
    For example, if you want to build the firmware for the application core as a headset using the ``release`` application version, you can run the following command from the :file:`applications/nrf5340_audio/` directory:
 
    .. code-block:: console
 
-      west build -b nrf5340_audio_dk_nrf5340_cpuapp --pristine -- -DCONFIG_AUDIO_DEV=1 -DCONF_FILE="prj_release.conf"
+      west build -b nrf5340_audio_dk_nrf5340_cpuapp --pristine -- -DCONFIG_AUDIO_DEV=1 -DFILE_SUFFIX=release
 
    Unlike when :ref:`nrf53_audio_app_building_script`, this command creates the build files directly in the :file:`build` directory.
    This means that you first need to program the headset development kits before you build and program gateway development kits.

--- a/applications/nrf5340_audio/doc/configuration.rst
+++ b/applications/nrf5340_audio/doc/configuration.rst
@@ -76,7 +76,7 @@ You can use one of the following options, depending on how you decide to build t
 
   .. code-block:: console
 
-     west build -b nrf5340_audio_dk_nrf5340_cpuapp --pristine -- -DCONFIG_AUDIO_DEV=1 -DSHIELD=nrf21540ek_fwd -DCONF_FILE=prj_release.conf
+     west build -b nrf5340_audio_dk_nrf5340_cpuapp --pristine -- -DCONFIG_AUDIO_DEV=1 -DSHIELD=nrf21540ek_fwd -DFILE_SUFFIX=release
 
 To set the TX power output, use the ``CONFIG_NRF_21540_MAIN_TX_POWER`` and ``CONFIG_NRF_21540_PRI_ADV_TX_POWER`` Kconfig options.
 

--- a/applications/nrf_desktop/description.rst
+++ b/applications/nrf_desktop/description.rst
@@ -382,7 +382,7 @@ The nRF Desktop application does not use a single :file:`prj.conf` file.
 Before you start testing the application, you can select one of the build types supported by the application.
 Not every board supports all of the mentioned build types.
 
-See :ref:`app_build_additions_build_types` and :ref:`modifying_build_types` for more information about this feature of the |NCS|.
+See :ref:`app_build_additions_build_types` and :ref:`cmake_options` for more information.
 
 The application supports the following build types:
 
@@ -900,7 +900,7 @@ Selecting a build type
 ======================
 
 Before you start testing the application, you can select one of the :ref:`nrf_desktop_requirements_build_types`, depending on your development kit.
-See :ref:`modifying_build_types` for detailed steps how to select a build type.
+See :ref:`cmake_options` for information about how to select a build type.
 
 .. note::
    If nRF Desktop is built with `Fast Pair`_ support, you must provide Fast Pair Model ID and Anti Spoofing private key as CMake options.

--- a/applications/zigbee_weather_station/README.rst
+++ b/applications/zigbee_weather_station/README.rst
@@ -62,11 +62,11 @@ LED (LD1):
    Shows the overall state of the device and its connectivity.
    The following states are possible:
 
-   * ``release`` build type
+   * ``release`` configuration
 
      * Even flashing (red color, 500 ms on/500 ms off) - The device is in the Identify mode (after network commissioning).
 
-   * ``debug`` build type
+   * ``debug`` configuration
 
      * Constant light (blue) - The device is connected to a Zigbee network.
      * Even flashing (red color, 500 ms on/500 ms off) - The device is in the Identify mode (after network commissioning).
@@ -91,7 +91,7 @@ Button (SW3):
 
 USB port:
    Used for getting logs from the device.
-   It is enabled only for the ``debug`` build type of the application.
+   It is enabled only for the ``debug`` configuration of the application.
    See the :ref:`zigbee_weather_station_app_select_build_type` section to learn how to select the debug configuration.
 
 Configuration
@@ -131,22 +131,22 @@ CONFIG_WEATHER_CHECK_PERIOD_SECONDS - How often sensor data is read
 
 .. _zigbee_weather_station_app_build_types:
 
-Zigbee weather station build types
-==================================
+Zigbee weather station configurations
+=====================================
 
 The Zigbee weather station application does not use a single :file:`prj.conf` file.
-Configuration files are provided for different build types, and they are located in the :file:`configuration/thingy53_nrf5340_cpuapp` directory.
-Before you start testing the application, you can select one of the build types supported by the application.
+The application includes different configurations, with files for each configuration located in the :file:`configuration/thingy53_nrf5340_cpuapp` directory.
+Before you start testing, you can select one of the configurations using the :makevar:`FILE_SUFFIX` variable.
 
-See :ref:`app_build_additions_build_types` and :ref:`modifying_build_types` for more information about this feature of the |NCS|.
+See :ref:`app_build_file_suffixes` and :ref:`cmake_options` for more information.
 
-The application supports the following build types:
+The application supports the following configurations:
 
-.. list-table:: Zigbee weather station build types
+.. list-table:: Zigbee weather station configurations
    :widths: auto
    :header-rows: 1
 
-   * - Build type
+   * - Configuration
      - File name
      - Supported board
      - Description
@@ -159,10 +159,10 @@ The application supports the following build types:
      - All from `Requirements`_
      - Release version of the application; can be used to enable only the necessary application functionalities to optimize its performance.
 
-Logging in the debug build type
--------------------------------
+Logging in the debug configuration
+----------------------------------
 
-In the debug build type, the application also uses serial console over USB for logging.
+In the debug configuration, the application also uses serial console over USB for logging.
 Besides initialization logs, the following sets of measurement-related data are logged after a measurements update:
 
 * Values measured by sensor.
@@ -188,11 +188,11 @@ Building and running
 
 .. _zigbee_weather_station_app_select_build_type:
 
-Selecting a build type
-======================
+Selecting application configuration
+===================================
 
 Before you start testing the application, you can select one of the :ref:`zigbee_weather_station_app_build_types`.
-See :ref:`modifying_build_types` for detailed steps how to select a build type.
+See :ref:`cmake_options` for information about how to select a suffixed configuration.
 
 .. _zigbee_weather_station_app_testing:
 
@@ -200,9 +200,9 @@ Testing
 =======
 
 .. Note::
-   * Part of the testing procedure assumes you are using the ``debug`` :ref:`build type <zigbee_weather_station_app_build_types>`, as it provides more feedback with **LED (LD1)** and logs through the USB console.
+   * Part of the testing procedure assumes you are using the ``debug`` :ref:`configuration <zigbee_weather_station_app_build_types>`, as it provides more feedback with **LED (LD1)** and logs through the USB console.
 
-     These steps related to the ``debug`` build type mention the ``debug`` build type and are not required if you are using the ``release`` build type.
+     These steps related to the ``debug`` configuration mention the ``debug`` configuration and are not required if you are using the ``release`` configuration.
    * The provided measurement data values depend on the Thingy:53 device's surrounding conditions.
    * If you want to capture packets with Wireshark, install `nRF Sniffer for 802.15.4`_ and `configure Wireshark for use with Zigbee <Configuring Wireshark for Zigbee_>`_.
 
@@ -210,7 +210,7 @@ Testing
 
 After programming the application to your device, complete the following steps to test it:
 
-1. ``debug`` build type: |connect_generic|
+1. ``debug`` configuration: |connect_generic|
    The connection is needed for gathering logs from the Zigbee weather station application.
 #. Turn on the :ref:`Zigbee shell <zigbee_shell_sample>` sample programmed as the network coordinator to one of the compatible development kits.
    See the :ref:`zigbee_shell_sample_testing` section of the sample to learn how to set it up as a coordinator.
@@ -245,7 +245,7 @@ After programming the application to your device, complete the following steps t
 
 #. When the device joins the network, **LED (LD1)** lights up with a constant blue color.
 
-   Additionally, with the ``debug`` build type and console used for logging, output similar to the following appears:
+   Additionally, with the ``debug`` configuration and console used for logging, output similar to the following appears:
 
    .. code-block:: console
 

--- a/doc/nrf/config_and_build/configuring_app/advanced_building.rst
+++ b/doc/nrf/config_and_build/configuring_app/advanced_building.rst
@@ -22,70 +22,12 @@ For example, to turn off optimizations, select :kconfig:option:`CONFIG_NO_OPTIMI
 
 Compiler options not controlled by the Zephyr build system can be controlled through the :kconfig:option:`CONFIG_COMPILER_OPT` Kconfig option.
 
-.. _gs_modifying_build_types:
-.. _modifying_build_types:
-
-Configuring build types
-***********************
-
-When the ``CONF_FILE`` variable contains a single file and this file name follows the naming pattern :file:`prj_<buildtype>.conf`, then the build type will be inferred to be *<buildtype>*.
-The build type cannot be set explicitly.
-The *<buildtype>* can be any string, but it is common to use ``release`` and ``debug``.
-
-For information about how to set variables, see :ref:`zephyr:important-build-vars` in the Zephyr documentation.
-
-The following software components can be made dependent on the build type:
-
-* The Partition Manager's :ref:`static configuration <ug_pm_static>`.
-  When the build type has been inferred, the file :file:`pm_static_<buildtype>.yml` will have precedence over :file:`pm_static.yml`.
-* The :ref:`child image Kconfig configuration <ug_multi_image_permanent_changes>`.
-  Certain child image configuration files located in the :file:`child_image/` directory can be defined per build type.
-
-The devicetree configuration is not affected by the build type.
-
-.. note::
-    For an example of an application that uses build types, see the :ref:`nrf_desktop` application (:ref:`nrf_desktop_requirements_build_types`) or the :ref:`nrf_machine_learning_app` application (:ref:`nrf_machine_learning_app_requirements_build_types`).
-
-.. tabs::
-
-   .. group-tab:: nRF Connect for VS Code
-
-      To select the build type in the |nRFVSC|:
-
-      1. When `building an application <How to build an application_>`_ as described in the |nRFVSC| documentation, follow the steps for setting up the build configuration.
-      #. In the **Add Build Configuration** screen, select the desired :file:`.conf` file from the :guilabel:`Configuration` drop-down menu.
-      #. Fill in other configuration options, if applicable, and click :guilabel:`Build Configuration`.
-
-   .. group-tab:: Command line
-
-      To select the build type when building the application from command line, specify the build type by adding the following parameter to the ``west build`` command:
-
-      .. parsed-literal::
-         :class: highlight
-
-         -- -DCONF_FILE=prj_\ *selected_build_type*\.conf
-
-      For example, you can replace the *selected_build_type* variable to build the ``release`` firmware for ``nrf52840dk_nrf52840`` by running the following command in the project directory:
-
-      .. parsed-literal::
-         :class: highlight
-
-         west build -b nrf52840dk_nrf52840 -d build_nrf52840dk_nrf52840 -- -DCONF_FILE=prj_release.conf
-
-      The ``build_nrf52840dk_nrf52840`` parameter specifies the output directory for the build files.
-
-If the selected board does not support the selected build type, the build is interrupted.
-For example, for the :ref:`nrf_machine_learning_app` application, if the ``nus`` build type is not supported by the selected board, the following notification appears:
-
-.. code-block:: console
-
-   Configuration file for build type ``nus`` is missing.
-
 Optional build parameters
 *************************
 
 Here are some of the possible options you can use:
 
+* You can provide :ref:`custom CMake options <cmake_options>` to the build command.
 * You can include the *directory_name* parameter to build from a directory other than the current directory.
 * You can use the *build_target@board_revision* parameter to get extra devicetree overlays with new features available for a board version.
   The *board_revision* is printed on the label of your DK, just below the PCA number.

--- a/doc/nrf/config_and_build/configuring_app/cmake/index.rst
+++ b/doc/nrf/config_and_build/configuring_app/cmake/index.rst
@@ -75,13 +75,23 @@ The following table lists the most common ones used in the |NCS|:
    * - :makevar:`SHIELD`
      - Select one of the supported :ref:`shields <shield_names_nrf>` for building the firmware.
      - ``-DSHIELD=<shield_build_target>``
+   * - :makevar:`FILE_SUFFIX`
+     - | Select one of the available :ref:`suffixed configurations <zephyr:application-file-suffixes>`, if the application or sample supports any.
+       | See :ref:`app_build_file_suffixes` for more information about their usage and limitations in the |NCS|.
+       | This variable is gradually replacing :makevar:`CONF_FILE`.
+     - ``-DFILE_SUFFIX=<configuration_suffix>``
    * - :makevar:`CONF_FILE`
-     - Select one of the available :ref:`build types <modifying_build_types>`, if the application or sample supports any.
+     - | Select one of the available :ref:`build types <modifying_build_types>`, if the application or sample supports any.
+       | This variable is deprecated and is being gradually replaced by :makevar:`FILE_SUFFIX`, but :ref:`still required for some applications <modifying_build_types>`.
      - ``-DCONF_FILE=prj_<build_type_name>.conf``
    * - ``-S`` (west) or :makevar:`SNIPPET` (CMake)
      - | Select one of the :ref:`zephyr:snippets` to add to the application firmware during the build.
        | The west argument ``-S`` is more commonly used.
-     - ``-S <name_of_snippet>`` or ``-DSNIPPET=<name_of_snippet``
+     - | ``-S <name_of_snippet>``
+       | ``-DSNIPPET=<name_of_snippet>``
+   * - :makevar:`PM_STATIC_YML_FILE`
+     - Select a :ref:`static configuration file <ug_pm_static>` for the Partition Manager script.
+     - ``-DPM_STATIC_YML_FILE=pm_static_<suffix>.yml``
 
 You can use these parameters in both the |nRFVSC| and the command line.
 
@@ -95,7 +105,7 @@ This is how you can specify them:
       See `How to build an application`_ in the |nRFVSC| documentation.
       You can specify the additional configuration variables when `setting up a build configuration <How to build an application_>`_:
 
-      * :makevar:`CONF_FILE` - Select the build type in the :guilabel:`Configuration` menu.
+      * :makevar:`FILE_SUFFIX` (and :makevar:`CONF_FILE`) - Select the configuration in the :guilabel:`Configuration` menu.
       * :makevar:`EXTRA_CONF_FILE` - Add the Kconfig fragment file in the :guilabel:`Kconfig fragments` menu.
       * :makevar:`EXTRA_DTC_OVERLAY_FILE` - Add the devicetree overlays in the :guilabel:`Devicetree overlays` menu.
       * Other variables - Provide CMake arguments in the :guilabel:`Extra CMake arguments` field, preceded by ``--``.
@@ -114,6 +124,53 @@ This is how you can specify them:
          west build -p -b nrf9161dk_nrf9161_ns -- -DSHIELD=nrf7002ek -DEXTRA_CONF_FILE=overlay-nrf7002ek-wifi-scan-only.conf
 
 See :ref:`configuration_permanent_change` and Zephyr's :ref:`zephyr:west-building-cmake-args` for more information.
+
+Examples of commands
+--------------------
+
+**Providing a CMake variable for build types**
+
+  .. toggle::
+
+     .. tabs::
+
+        .. group-tab:: nRF Connect for VS Code
+
+            To select the build type in the |nRFVSC|:
+
+            1. When `building an application <How to build an application_>`_ as described in the |nRFVSC| documentation, follow the steps for setting up the build configuration.
+            #. In the **Add Build Configuration** screen, select the desired :file:`.conf` file from the :guilabel:`Configuration` drop-down menu.
+            #. Fill in other configuration options, if applicable, and click :guilabel:`Build Configuration`.
+
+        .. group-tab:: Command line
+
+            To select the build type when building the application from command line, specify the build type by adding the following parameter to the ``west build`` command:
+
+            .. parsed-literal::
+              :class: highlight
+
+              -- -DCONF_FILE=prj_\ *selected_build_type*\.conf
+
+            For example, you can replace the *selected_build_type* variable to build the ``release`` firmware for ``nrf52840dk_nrf52840`` by running the following command in the project directory:
+
+            .. parsed-literal::
+              :class: highlight
+
+              west build -b nrf52840dk_nrf52840 -d build_nrf52840dk_nrf52840 -- -DCONF_FILE=prj_release.conf
+
+            The ``build_nrf52840dk_nrf52840`` parameter specifies the output directory for the build files.
+        ..
+
+     ..
+
+     If the selected board does not support the selected build type, the build is interrupted.
+     For example, for the :ref:`nrf_machine_learning_app` application, if the ``nus`` build type is not supported by the selected board, the following notification appears:
+
+     .. code-block:: console
+
+        Configuration file for build type ``nus`` is missing.
+
+  ..
 
 .. _cmake_options_images:
 

--- a/doc/nrf/config_and_build/multi_image.rst
+++ b/doc/nrf/config_and_build/multi_image.rst
@@ -274,7 +274,7 @@ If your application includes multiple child images, then you can combine all the
   .. parsed-literal::
     :class: highlight
 
-     cmake -DCONFIG_VARIABLEONE=val -D\ *childimageone*\_EXTRA_CONF_FILE=\ *extrafragment.conf*\ -Dquz_CONF_FILE=\ *myfile.conf*\ [...]
+    cmake -DCONFIG_VARIABLEONE=val -D\ *childimageone*\_EXTRA_CONF_FILE=\ *extrafragment.conf*\ -Dquz_CONF_FILE=\ *myfile.conf*\ [...]
 
 See :ref:`ug_bootloader` for more details.
 
@@ -332,7 +332,7 @@ Permanent configuration changes to child images
 -----------------------------------------------
 
 You can make a project automatically pass Kconfig configuration files, fragments, and devicetree overlays to child images by placing them under a predefined path.
-For example, in the |NCS| applications and samples that use different :ref:`build types for configuration <gs_modifying_build_types>`, the :file:`child_image` folder in the application source directory is often used to apply :ref:`permanent configuration changes <configuration_permanent_change>`.
+For example, in the |NCS| applications and samples that use different :ref:`build types <app_build_additions_build_types>`, the :file:`child_image` folder in the application source directory is often used to apply :ref:`permanent configuration changes <configuration_permanent_change>`.
 
 The listing below describes how to leverage this functionality, where ``ACI_NAME`` is the name of the child image to which the configuration will be applied.
 
@@ -341,9 +341,9 @@ The listing below describes how to leverage this functionality, where ``ACI_NAME
     :start-at: It is possible for a sample to use a custom set of Kconfig fragments for a
     :end-before: set(ACI_CONF_DIR ${APPLICATION_CONFIG_DIR}/child_image)
 
-When you are :ref:`modifying_build_types` and the build type has been inferred, the child image Kconfig overlay file is searched at :file:`child_image/<ACI_NAME>_<buildtype>.conf`.
+When you are using :ref:`app_build_additions_build_types` and the configuration name has been inferred, the child image Kconfig overlay file is searched at :file:`child_image/<ACI_NAME>_<name>.conf`.
 Alternatively, the child image Kconfig configuration file can be introduced as :file:`child_image/<ACI_NAME>/prj.conf` and follow the same pattern as the parent Kconfig.
-For example, :file:`child_image/mcuboot/prj_release.conf` can be used to define ``release`` build type for ``mcuboot`` child image.
+For example, :file:`child_image/mcuboot/prj_release.conf` can be used to define the ``release`` build type for the ``mcuboot`` child image.
 
 Child image targets
 ===================

--- a/doc/nrf/device_guides/working_with_nrf/nrf54h/ug_nrf54h20_debugging.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf54h/ug_nrf54h20_debugging.rst
@@ -26,11 +26,11 @@ Set the following Kconfig options to ``y`` for the images running on the cores y
 * :kconfig:option:`CONFIG_DEBUG_THREAD_INFO` - This option adds additional information to the thread object so that the debugger can discover the threads.
   This will work for any debugger.
 
-Debug build types
-*****************
+Debug configurations
+********************
 
-Some applications and samples provide a specific build type that enables additional debug functionalities.
-You can select build types when you are :ref:`configuring the build settings <gs_modifying_build_types>`.
+Some applications and samples provide a specific configuration that enables additional debug functionalities.
+You can select custom configurations when you are :ref:`configuring the build settings <cmake_options>`.
 
 Debugging multiple cores
 ************************

--- a/doc/nrf/device_guides/working_with_nrf/nrf54h/ug_nrf54h20_matter_thread.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf54h/ug_nrf54h20_matter_thread.rst
@@ -186,7 +186,7 @@ To build the sample with Matter over Wi-Fi support run the following command:
 
 .. code-block:: console
 
-   west build -b nrf54h20dk_nrf54h20_cpuapp -- -DCONF_FILE=prj_no_dfu.conf -DSHIELD=nrf700x_nrf54h20dk -DCONFIG_CHIP_WIFI=y
+   west build -b nrf54h20dk_nrf54h20_cpuapp -- -DSHIELD=nrf700x_nrf54h20dk -DCONFIG_CHIP_WIFI=y
 
 
 .. _ug_nrf54h20_matter_thread_suit_dfu:

--- a/doc/nrf/glossary.rst
+++ b/doc/nrf/glossary.rst
@@ -103,8 +103,11 @@ Glossary
 
    Build type
       A build type is a feature that defines the way in which the configuration files are to be handled.
-      The |NCS| provides support for :ref:`app_build_additions_build_types`.
-      Selecting a specific build type can result in a different structure of the :term:`build configuration`.
+      The |NCS| provides support for handling :ref:`app_build_additions_build_types`
+      :ref:`Selecting a specific build type <cmake_options>` can result in a different structure of the :term:`build configuration`.
+
+      .. note::
+           Build types are deprecated and are being gradually replaced by Zephyr's :ref:`file suffixes <modifying_build_types>` and :ref:`zephyr:sysbuild`.
 
    Carrier-sense Multiple Access with Collision Avoidance (CSMA/CA)
       A network multiple access method in which carrier sensing is used, but nodes attempt to avoid collisions by beginning transmission only after the channel is sensed to be idle.

--- a/doc/nrf/releases_and_maturity/migration/migration_guide_2.7.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_guide_2.7.rst
@@ -21,6 +21,8 @@ This document describes the changes required or recommended when migrating your 
       * Change1 and description
       * Change2 and description
 
+.. _migration_2.7_required:
+
 Required changes
 ****************
 
@@ -73,6 +75,8 @@ FEM abstraction layer
     The function :c:func:`fem_tx_power_control_set` replaces the function :c:func:`fem_tx_gain_set`.
     The function :c:func:`fem_default_tx_output_power_get` replaces the function :c:func:`fem_default_tx_gain_get`.
 
+.. _migration_2.7_recommended:
+
 Recommended changes
 *******************
 
@@ -81,7 +85,16 @@ The following changes are recommended for your application to work optimally aft
 Samples and applications
 ========================
 
-This section describes the changes related to samples and applications.
+* For applications using build types (without Partition Manager or child images):
+
+  * The :makevar:`CONF_FILE` used for :ref:`app_build_additions_build_types` is now deprecated and is being replaced with the :makevar:`FILE_SUFFIX` variable, inherited from Zephyr.
+    You can read more about it in :ref:`app_build_file_suffixes`, :ref:`cmake_options`, and the :ref:`related Zephyr documentation <zephyr:application-file-suffixes>`.
+
+    If your application uses build types, it is recommended to update the :file:`sample.yaml` to use the new variable instead of :makevar:`CONF_FILE`.
+
+    .. note::
+        :ref:`Partition Manager's static configuration <ug_pm_static>` and :ref:`child image Kconfig configuration <ug_multi_image_permanent_changes>` are not yet compatible with :makevar:`FILE_SUFFIX`.
+        Read more about this in the note in :ref:`app_build_file_suffixes`.
 
 Matter
 ------

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -35,6 +35,11 @@ IDE and tool support
 
 |no_changes_yet_note|
 
+Build and configuration system
+==============================
+
+* Added documentation about the :ref:`file suffix feature from Zephyr <app_build_file_suffixes>` with a related information in the :ref:`migration guide <migration_2.7_recommended>`.
+
 Working with nRF91 Series
 =========================
 
@@ -373,7 +378,7 @@ Matter samples
   * The :file:`configuration` directory which contained the Partition Manager configuration file.
     It has been replaced replace with :file:`pm_static_<BOARD>` Partition Manager configuration files for all required target boards in the samples' directories.
   * The :file:`prj_no_dfu.conf` file.
-  * Support for ``no_dfu`` build type for nRF5350 DK, nRF52840 DK and nRF7002 DK.
+  * Support for the ``no_dfu`` build type for the nRF5350 DK, the nRF52840 DK, and the nRF7002 DK.
 
 * Added:
 

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -203,3 +203,7 @@
    The generated :file:`.inc` file is then included in the code, where it is provisioned to the modem.
 
 .. |build_target| replace:: Replace the *build_target* with the build target of the nRF91 Series device you are using (see the Requirements section).
+
+.. |file_suffix_partition_manager_exception| replace:: The Partition Manager's :ref:`static configuration <ug_pm_static>` does not yet support the :makevar:`FILE_SUFFIX` variable.
+   To ensure that the file :file:`pm_static_<suffix>.yml` will have precedence over :file:`pm_static.yml` when building for a selected :makevar:`FILE_SUFFIX`, make sure to also provide the :makevar:`PM_STATIC_YML_FILE` variable set to :file:`pm_static_<suffix>.yml`.
+   Alternatively, you can use the previously used :makevar:`CONF_FILE` variable (which is now deprecated), until support for it is removed.

--- a/doc/nrf/test_and_optimize/debugging.rst
+++ b/doc/nrf/test_and_optimize/debugging.rst
@@ -41,11 +41,11 @@ You can also set these options to ``y`` manually.
 There are many more Kconfig options for debugging that are specific to different modules.
 For details, see the respective documentation pages of the modules.
 
-Debug build types
-=================
+Debug suffixes and build types
+==============================
 
-Some applications and samples provide a specific build type that enables additional debug functionalities.
-You can select build types when you are :ref:`configuring the build settings <modifying_build_types>`.
+Some applications and samples provide a specific configuration that enables additional debug functionalities, either as :ref:`file suffixes <app_build_file_suffixes>` or :ref:`app_build_additions_build_types`.
+You can select custom configurations when you are :ref:`configuring the build settings <cmake_options>`.
 
 Debug logging
 =============

--- a/samples/bluetooth/peripheral_lbs/README.rst
+++ b/samples/bluetooth/peripheral_lbs/README.rst
@@ -93,14 +93,14 @@ Building and running
 Minimal build
 =============
 
-You can build the sample with a minimum configuration as a demonstration of how to reduce code size and RAM usage, using the ``-DCONF_FILE='prj_minimal.conf'`` flag in your build.
+You can build the sample with a minimum configuration as a demonstration of how to reduce code size and RAM usage, using the ``-DFILE_SUFFIX=minimal`` flag in your build.
 
 See :ref:`cmake_options` for instructions on how to add this option to your build.
 For example, when building on the command line, you can add the option as follows:
 
 .. code-block:: console
 
-   west build samples/bluetooth/peripheral_lbs -- -DCONF_FILE='prj_minimal.conf'
+   west build samples/bluetooth/peripheral_lbs -- -DFILE_SUFFIX=minimal
 
 .. _peripheral_lbs_testing:
 

--- a/samples/event_manager_proxy/README.rst
+++ b/samples/event_manager_proxy/README.rst
@@ -54,11 +54,11 @@ By default, the Event Manager Proxy sample uses the OpenAMP backend provided by 
 You can instead select the ICMSG backend configuration, which has smaller memory requirements.
 
 The ICMSG backend configuration is provided in the :file:`prj_icmsg.conf` file.
-To provide the ICMSG backend configuration, specify the ``-DCONF_FILE=prj_icmsg.conf`` parameter along with the build command when building the sample:
+To provide the ICMSG backend configuration, specify the ``-DFILE_SUFFIX=icmsg`` parameter along with the build command when building the sample:
 
    .. code-block:: console
 
-      west build -p -b nrf5340dk_nrf5340_cpuapp -- -DCONF_FILE=prj_icmsg.conf
+      west build -p -b nrf5340dk_nrf5340_cpuapp -- -DFILE_SUFFIX=icmsg
 
 Building and running
 ********************

--- a/samples/matter/light_bulb/README.rst
+++ b/samples/matter/light_bulb/README.rst
@@ -85,7 +85,7 @@ The sample does not use a single :file:`prj.conf` file.
 Configuration files are provided for different build types, and they are located in the sample root directory.
 Before you start testing the application, you can select one of the build types supported by the application.
 
-See :ref:`app_build_additions_build_types` and :ref:`modifying_build_types` for more information about this feature of the |NCS|.
+See :ref:`app_build_additions_build_types` and :ref:`cmake_options` for more information.
 
 The sample supports the following build types:
 
@@ -237,7 +237,7 @@ Selecting a build type
 ======================
 
 Before you start testing the application, you can select one of the :ref:`matter_light_bulb_build_types`.
-See :ref:`modifying_build_types` for detailed steps how to select a build type.
+See :ref:`cmake_options` for information about how to select a build type.
 
 Testing
 =======

--- a/samples/matter/light_switch/README.rst
+++ b/samples/matter/light_switch/README.rst
@@ -254,7 +254,7 @@ Selecting a build type
 ======================
 
 Before you start testing the application, you can select one of the `Matter light switch build types`_.
-See :ref:`modifying_build_types` for detailed steps how to select a build type.
+See :ref:`cmake_options` for information about how to select a build type.
 
 Testing
 *******

--- a/samples/matter/lock/README.rst
+++ b/samples/matter/lock/README.rst
@@ -159,7 +159,7 @@ The sample does not use a single :file:`prj.conf` file.
 Configuration files are provided for different build types, and they are located in the sample root directory.
 Before you start testing the application, you can select one of the build types supported by the application.
 
-See :ref:`app_build_additions_build_types` and :ref:`modifying_build_types` for more information about this feature of the |NCS|.
+See :ref:`app_build_additions_build_types` and :ref:`cmake_options` for more information.
 
 The sample supports the following build types:
 
@@ -353,7 +353,7 @@ Selecting a build type
 ======================
 
 Before you start testing the application, you can select one of the :ref:`matter_lock_sample_configuration_build_types`.
-See :ref:`modifying_build_types` for detailed steps how to select a build type.
+See :ref:`cmake_options` for information about how to select a build type.
 
 Testing
 =======

--- a/samples/matter/template/README.rst
+++ b/samples/matter/template/README.rst
@@ -151,7 +151,7 @@ Selecting a build type
 ======================
 
 Before you start testing the application, you can select one of the `Matter template build types`_.
-See :ref:`modifying_build_types` for detailed steps how to select a build type.
+See :ref:`cmake_options` for information about how to select a build type.
 
 Testing
 =======

--- a/samples/matter/thermostat/README.rst
+++ b/samples/matter/thermostat/README.rst
@@ -110,7 +110,7 @@ The sample does not use a single :file:`prj.conf` file.
 Configuration files are provided for different build types, and they are located in the sample root directory.
 Before you start testing the application, you can select one of the build types supported by the application.
 
-See :ref:`app_build_additions_build_types` and :ref:`modifying_build_types` for more information about this feature of the |NCS|.
+See :ref:`app_build_additions_build_types` and :ref:`cmake_options` for more information.
 
 The sample supports the following build types:
 
@@ -186,7 +186,7 @@ Selecting a build type
 ======================
 
 Before you start testing the application, you can select one of the `Matter thermostat build types`_, depending on your building method.
-See :ref:`modifying_build_types` for detailed steps how to select a build type.
+See :ref:`cmake_options` for information about how to select a build type.
 
 .. _matter_thermostat_testing:
 

--- a/samples/matter/window_covering/README.rst
+++ b/samples/matter/window_covering/README.rst
@@ -168,7 +168,7 @@ Selecting a build type
 ======================
 
 Before you start testing the application, you can select one of the `Matter window covering build types`_.
-See :ref:`modifying_build_types` for detailed steps how to select a build type.
+See :ref:`cmake_options` for information about how to select a build type.
 
 Testing
 =======

--- a/samples/zigbee/light_switch/README.rst
+++ b/samples/zigbee/light_switch/README.rst
@@ -110,7 +110,7 @@ For example, when building from the command line, use the following command:
 
 .. code-block:: console
 
-   west build samples/zigbee/light_switch -b nrf52840dk_nrf52840 -- -DCONF_FILE='prj_fota.conf'
+   west build samples/zigbee/light_switch -b nrf52840dk_nrf52840 -- -DFILE_SUFFIX=fota
 
 Alternatively, you can :ref:`configure Zigbee FOTA manually <ug_zigbee_configuring_components_ota>`.
 

--- a/samples/zigbee/ncp/README.rst
+++ b/samples/zigbee/ncp/README.rst
@@ -91,13 +91,13 @@ The ``uart0`` pins are configured by devicetree overlay files for each supported
 Communication through USB
 -------------------------
 
-To change the communication channel from the default UART to nRF USB CDC ACM ``cdc_acm_uart0``, use the :file:`prj_usb.conf` configuration file and add the ``-DCONF_FILE='prj_usb.conf'`` flag to the build command.
+To change the communication channel from the default UART to nRF USB CDC ACM ``cdc_acm_uart0``, use the :file:`prj_usb.conf` configuration file and add the ``-DFILE_SUFFIX=usb`` flag to the build command.
 See :ref:`cmake_options` for instructions on how to add this flag to your build.
 For example, when building from the command line, use the following command:
 
 .. code-block:: console
 
-   west build samples/zigbee/ncp -b nrf52840dk_nrf52840 -- -DCONF_FILE='prj_usb.conf'
+   west build samples/zigbee/ncp -b nrf52840dk_nrf52840 -- -DFILE_SUFFIX=usb
 
 The USB device VID and PID are configured by the sample's Kconfig file.
 

--- a/samples/zigbee/shell/README.rst
+++ b/samples/zigbee/shell/README.rst
@@ -56,7 +56,7 @@ These interfaces are completely independent one from another and can be used sim
 For information about setup, see :ref:`testing`.
 
 The Zigbee Shell sample uses UART as the default shell backend.
-To change the shell backend from the default UART to the nRF USB CDC ACM, use the :file:`prj_usb.conf` configuration file and add the ``-DCONF_FILE='prj_usb.conf'`` flag when building the sample.
+To change the shell backend from the default UART to the nRF USB CDC ACM, use the :file:`prj_usb.conf` configuration file and add the ``-DFILE_SUFFIX=usb`` flag when building the sample.
 With such configuration, Zephyr logs are printed only to the backend that the shell is using.
 You can enable the UART backend for the logger, so that Zephyr logs are printed to both the shell backend and the UART.
 To do this, enable the :kconfig:option:`CONFIG_LOG_BACKEND_UART` Kconfig option.

--- a/scripts/partition_manager/partition_manager.rst
+++ b/scripts/partition_manager/partition_manager.rst
@@ -772,16 +772,19 @@ This file is similar to the regular :file:`pm.yml` configuration files, except t
 
 You can set ``PM_STATIC_YML_FILE`` to contain exactly the static configuration you want to use.
 
+.. important::
+    |file_suffix_partition_manager_exception|
+
 If you do not set ``PM_STATIC_YML_FILE``, the build system will use the following order to look for files in your application source directory to use as a static configuration layout:
 
-* If build type is used (see :ref:`modifying_build_types`), the following order applies:
+* If a :term:`build type` is used, the following order applies:
 
   1. If the file :file:`pm_static_<board>_<revision>_<buildtype>.yml` exists, it will be used.
   #. Otherwise, if the file :file:`pm_static_<board>_<buildtype>.yml` exists, it will be used.
   #. Otherwise, if the file :file:`pm_static_<buildtype>.yml` exists, it will be used.
   #. Otherwise, if the file :file:`pm_static.yml` exists, it will be used.
 
-* If build type is not used, then the same order as above applies, except that *<buildtype>* is not part of the file name:
+* If a build type is not used, then the same order as above applies, except that *<buildtype>* is not part of the file name:
 
   1. If the file :file:`pm_static_<board>_<revision>.yml` exists, it will be used.
   #. Otherwise, if the file :file:`pm_static_<board>.yml` exists, it will be used.


### PR DESCRIPTION
Added information about FILE_SUFFIX variable in build and config
section. Added deprecation info to sections about build types.
Replaced mentions of build types with mention of file suffixes
in some samples and apps. Updated build and configuration section.
Added an important note about missing support for Partition Manager.
NCSDK-22324.

----

Related Zephyr PR: https://github.com/zephyrproject-rtos/zephyr/pull/66141

----

- [x] Squash to 1 commit.