### PR TITLE
applications: nrf5340_audio: Use clock control to turn on HFClock

### DIFF
--- a/applications/nrf5340_audio/src/utils/nrf5340_audio_dk.c
+++ b/applications/nrf5340_audio/src/utils/nrf5340_audio_dk.c
@@ -32,10 +32,6 @@ static int hfclock_config_and_start(void)
 		return ret;
 	}
 
-	nrfx_clock_hfclk_start();
-	while (!nrfx_clock_hfclk_is_running()) {
-	}
-
 	return 0;
 }
 


### PR DESCRIPTION
- Use clock control to enable high freq clock
- OCT-2847