### PR TITLE
manifest: update sdk-zephyr to have PWM support for nRF54 Series

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 22e2d8781ef57c215b49539ae1b16fcd42b331cf
+      revision: 66fec84a3e19b7661aa0300d257d07eaf9b5a287
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Updated sdk-zephyr revision contains PWM support for nRF54H20 and nRF54L15 devices.