### PR TITLE
applications: nrf5340_audio: Send correct disconnect reason on auth f…

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/bt_content_control/bt_content_ctrl.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_content_control/bt_content_ctrl.c
@@ -86,7 +86,10 @@ int bt_content_ctrl_conn_disconnected(struct bt_conn *conn)
 
 	if (IS_ENABLED(CONFIG_BT_MCC)) {
 		ret = bt_content_ctrl_media_conn_disconnected(conn);
-		if (ret) {
+		/* Try to reset MCS state. -ESRCH is returned if MCS hasn't been discovered
+		 * yet, and shouldn't cause an error print
+		 */
+		if (ret && ret != -ESRCH) {
 			LOG_ERR("bt_content_ctrl_media_conn_disconnected failed with %d", ret);
 		}
 	}

--- a/applications/nrf5340_audio/src/bluetooth/bt_management/bt_mgmt.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/bt_mgmt.c
@@ -221,7 +221,7 @@ static void security_changed_cb(struct bt_conn *conn, bt_security_t level, enum 
 
 	if (err) {
 		LOG_WRN("Security failed: level %d err %d", level, err);
-		ret = bt_conn_disconnect(conn, err);
+		ret = bt_conn_disconnect(conn, BT_HCI_ERR_AUTH_FAIL);
 		if (ret) {
 			LOG_WRN("Failed to disconnect %d", ret);
 		}


### PR DESCRIPTION
…ailed

- Use 0x05 when disconnecting after security failed
- Don't try to disconnect MCS if it hasn't started yet
- OCT-2970