### PR TITLE
bluetooth: controller: increase default tx buffers for PAwR adv

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -464,7 +464,7 @@ config BT_CTLR_SDC_PAWR_ADV_COUNT
 config BT_CTLR_SDC_PERIODIC_ADV_RSP_TX_BUFFER_COUNT
 	int "Number of PAwR advertiser TX buffers"
 	range 1 128
-	default 1
+	default 3
 	help
 	  Maximum number of subevent indications that can be buffered at a time.
 	  When using a larger value the controller will send data requests for more


### PR DESCRIPTION
The current default is way too small. It's expected that most realistic applications will want at least 3.