### PR TITLE
samples: crypto: Crypto samples cleanup

### DIFF
--- a/samples/crypto/aes_cbc/sample.yaml
+++ b/samples/crypto/aes_cbc/sample.yaml
@@ -4,12 +4,11 @@ sample:
     using AES CBC mode
   name: AES CBC example
 tests:
-  sample.aes_cbc:
+  sample.aes_cbc.cc3xx:
     tags: introduction psa cc3xx
     platform_allow: >
       nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns
       nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf9161dk_nrf9161 nrf9161dk_nrf9161_ns
-      nrf54h20dk_nrf54h20_cpuapp nrf54l15pdk_nrf54l15_cpuapp nrf54l15pdk_nrf54l15_cpuapp_ns
     harness: console
     harness_config:
       type: multi_line
@@ -23,6 +22,17 @@ tests:
       - nrf52840dk_nrf52840
       - nrf9161dk_nrf9161
       - nrf9161dk_nrf9161_ns
+  sample.aes_cbc.cracen:
+    tags: introduction psa cracen
+    platform_allow: >
+      nrf54h20dk_nrf54h20_cpuapp nrf54l15pdk_nrf54l15_cpuapp nrf54l15pdk_nrf54l15_cpuapp_ns
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - ".*Example finished successfully!.*"
+    integration_platforms:
       - nrf54l15pdk_nrf54l15_cpuapp
       - nrf54l15pdk_nrf54l15_cpuapp_ns
+      # nRF54H uses Oberon+fake entropy until crypto service is available from SDFW
       - nrf54h20dk_nrf54h20_cpuapp

--- a/samples/crypto/aes_ccm/sample.yaml
+++ b/samples/crypto/aes_ccm/sample.yaml
@@ -4,12 +4,11 @@ sample:
     using AES CCM mode
   name: AES CCM example
 tests:
-  sample.aes_ccm:
+  sample.aes_ccm.cc3xx:
     tags: introduction psa cc3xx
     platform_allow: >
       nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns
       nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf9161dk_nrf9161 nrf9161dk_nrf9161_ns
-      nrf54h20dk_nrf54h20_cpuapp nrf54l15pdk_nrf54l15_cpuapp nrf54l15pdk_nrf54l15_cpuapp_ns
     harness: console
     harness_config:
       type: multi_line
@@ -23,6 +22,17 @@ tests:
       - nrf52840dk_nrf52840
       - nrf9161dk_nrf9161
       - nrf9161dk_nrf9161_ns
+  sample.aes_ccm.cracen:
+    tags: introduction psa cracen
+    platform_allow: >
+      nrf54h20dk_nrf54h20_cpuapp nrf54l15pdk_nrf54l15_cpuapp nrf54l15pdk_nrf54l15_cpuapp_ns
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - ".*Example finished successfully!.*"
+    integration_platforms:
       - nrf54l15pdk_nrf54l15_cpuapp
       - nrf54l15pdk_nrf54l15_cpuapp_ns
+      # nRF54H uses Oberon+fake entropy until crypto service is available from SDFW
       - nrf54h20dk_nrf54h20_cpuapp

--- a/samples/crypto/aes_ctr/sample.yaml
+++ b/samples/crypto/aes_ctr/sample.yaml
@@ -4,12 +4,11 @@ sample:
     using AES CTR mode
   name: AES CTR example
 tests:
-  sample.aes_ctr:
+  sample.aes_ctr.cc3xx:
     tags: introduction psa cc3xx
     platform_allow: >
       nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns
       nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf9161dk_nrf9161 nrf9161dk_nrf9161_ns
-      nrf54h20dk_nrf54h20_cpuapp nrf54l15pdk_nrf54l15_cpuapp nrf54l15pdk_nrf54l15_cpuapp_ns
     harness: console
     harness_config:
       type: multi_line
@@ -23,6 +22,17 @@ tests:
       - nrf52840dk_nrf52840
       - nrf9161dk_nrf9161
       - nrf9161dk_nrf9161_ns
+  sample.aes_ctr.cracen:
+    tags: introduction psa cracen
+    platform_allow: >
+      nrf54h20dk_nrf54h20_cpuapp nrf54l15pdk_nrf54l15_cpuapp nrf54l15pdk_nrf54l15_cpuapp_ns
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - ".*Example finished successfully!.*"
+    integration_platforms:
       - nrf54l15pdk_nrf54l15_cpuapp
       - nrf54l15pdk_nrf54l15_cpuapp_ns
+      # nRF54H uses Oberon+fake entropy until crypto service is available from SDFW
       - nrf54h20dk_nrf54h20_cpuapp

--- a/samples/crypto/aes_gcm/sample.yaml
+++ b/samples/crypto/aes_gcm/sample.yaml
@@ -8,8 +8,6 @@ tests:
     tags: introduction psa cc3xx
     platform_allow: >
       nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp
-      nrf52840dk_nrf52840 nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf9161dk_nrf9161
-      nrf9161dk_nrf9161_ns
     harness: console
     harness_config:
       type: multi_line
@@ -18,16 +16,11 @@ tests:
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp_ns
       - nrf5340dk_nrf5340_cpuapp
-      - nrf9161dk_nrf9161
-      - nrf9161dk_nrf9161_ns
   sample.aes_gcm.oberon:
     tags: introduction psa oberon
     platform_allow: >
-      nrf54h20dk_nrf54h20_cpuapp
-      nrf54l15pdk_nrf54l15_cpuapp
-      nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp
-      nrf52840dk_nrf52840 nrf9160dk_nrf9160_ns nrf9160dk_nrf9160
-      nrf9161dk_nrf9161 nrf9161dk_nrf9161_ns
+      nrf52840dk_nrf52840 nrf9161dk_nrf9161 nrf9161dk_nrf9161_ns
+      nrf9160dk_nrf9160_ns nrf9160dk_nrf9160
     harness: console
     harness_config:
       type: multi_line
@@ -39,14 +32,12 @@ tests:
       - nrf9160dk_nrf9160
       - nrf9161dk_nrf9161
       - nrf9161dk_nrf9161_ns
-      - nrf54l15pdk_nrf54l15_cpuapp
-      - nrf54h20dk_nrf54h20_cpuapp
   sample.aes_gcm.cracen:
     tags: introduction psa cracen
     platform_allow: >
-      nrf54h20dk_nrf54h20_cpuapp
       nrf54l15pdk_nrf54l15_cpuapp
       nrf54l15pdk_nrf54l15_cpuapp_ns
+      nrf54h20dk_nrf54h20_cpuapp
     harness: console
     harness_config:
       type: multi_line
@@ -55,4 +46,5 @@ tests:
     integration_platforms:
       - nrf54l15pdk_nrf54l15_cpuapp
       - nrf54l15pdk_nrf54l15_cpuapp_ns
+      # nRF54H uses Oberon+fake entropy until crypto service is available from SDFW
       - nrf54h20dk_nrf54h20_cpuapp

--- a/samples/crypto/chachapoly/sample.yaml
+++ b/samples/crypto/chachapoly/sample.yaml
@@ -4,14 +4,11 @@ sample:
     Chacha20-Poly1305
   name: Chacha20-Poly1305 example
 tests:
-  sample.chacha_poly:
+  sample.chachapoly.cc3xx:
     tags: introduction psa cc3xx
     platform_allow: >
       nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns
       nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf9161dk_nrf9161 nrf9161dk_nrf9161_ns
-      nrf54h20dk_nrf54h20_cpuapp
-      nrf54l15pdk_nrf54l15_cpuapp
-      nrf54l15pdk_nrf54l15_cpuapp_ns
       nrf52840dk_nrf52840
     harness: console
     harness_config:
@@ -26,6 +23,19 @@ tests:
       - nrf52840dk_nrf52840
       - nrf9161dk_nrf9161
       - nrf9161dk_nrf9161_ns
+  sample.chachapoly.cracen:
+    tags: introduction psa cracen
+    platform_allow: >
+      nrf54h20dk_nrf54h20_cpuapp
+      nrf54l15pdk_nrf54l15_cpuapp
+      nrf54l15pdk_nrf54l15_cpuapp_ns
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - ".*Example finished successfully!.*"
+    integration_platforms:
       - nrf54l15pdk_nrf54l15_cpuapp
       - nrf54l15pdk_nrf54l15_cpuapp_ns
+      # nRF54H uses Oberon+fake entropy until crypto service is available from SDFW
       - nrf54h20dk_nrf54h20_cpuapp

--- a/samples/crypto/ecdh/sample.yaml
+++ b/samples/crypto/ecdh/sample.yaml
@@ -4,12 +4,11 @@ sample:
     key echange which allows two parties to obtain a common secret
   name: ECDH example
 tests:
-  sample.ecdh:
+  sample.ecdh.cc3xx:
     tags: introduction psa cc3xx
     platform_allow: >
       nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns
       nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf9161dk_nrf9161 nrf9161dk_nrf9161_ns
-      nrf54h20dk_nrf54h20_cpuapp nrf54l15pdk_nrf54l15_cpuapp nrf54l15pdk_nrf54l15_cpuapp_ns
     harness: console
     harness_config:
       type: multi_line
@@ -23,6 +22,17 @@ tests:
       - nrf52840dk_nrf52840
       - nrf9161dk_nrf9161
       - nrf9161dk_nrf9161_ns
+  sample.ecdh.cracen:
+    tags: introduction psa cracen
+    platform_allow: >
+      nrf54h20dk_nrf54h20_cpuapp nrf54l15pdk_nrf54l15_cpuapp nrf54l15pdk_nrf54l15_cpuapp_ns
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - ".*Example finished successfully!.*"
+    integration_platforms:
       - nrf54l15pdk_nrf54l15_cpuapp
       - nrf54l15pdk_nrf54l15_cpuapp_ns
+      # nRF54H uses Oberon+fake entropy until crypto service is available from SDFW
       - nrf54h20dk_nrf54h20_cpuapp

--- a/samples/crypto/ecdsa/sample.yaml
+++ b/samples/crypto/ecdsa/sample.yaml
@@ -3,14 +3,11 @@ sample:
     This app provides an example of signing/verifying using ECDSA signatures
   name: ECDSA example
 tests:
-  sample.ecdsa:
+  sample.ecdsa.cc3xx:
     tags: introduction psa cc3xx
     platform_allow: >
       nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns
       nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf9161dk_nrf9161 nrf9161dk_nrf9161_ns
-      nrf54h20dk_nrf54h20_cpuapp
-      nrf54l15pdk_nrf54l15_cpuapp
-      nrf54l15pdk_nrf54l15_cpuapp_ns
     harness: console
     harness_config:
       type: multi_line
@@ -24,6 +21,19 @@ tests:
       - nrf52840dk_nrf52840
       - nrf9161dk_nrf9161
       - nrf9161dk_nrf9161_ns
+  sample.ecdsa.cracen:
+    tags: introduction psa cracen
+    platform_allow: >
+      nrf54h20dk_nrf54h20_cpuapp
+      nrf54l15pdk_nrf54l15_cpuapp
+      nrf54l15pdk_nrf54l15_cpuapp_ns
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - ".*Example finished successfully!.*"
+    integration_platforms:
       - nrf54l15pdk_nrf54l15_cpuapp
       - nrf54l15pdk_nrf54l15_cpuapp_ns
+      # nRF54H uses Oberon+fake entropy until crypto service is available from SDFW
       - nrf54h20dk_nrf54h20_cpuapp

--- a/samples/crypto/ecjpake/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/crypto/ecjpake/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -1,3 +1,0 @@
-CONFIG_PSA_CRYPTO_DRIVER_OBERON=y
-
-# Use Oberon until until NCSDK-26303 is complete

--- a/samples/crypto/ecjpake/sample.yaml
+++ b/samples/crypto/ecjpake/sample.yaml
@@ -2,14 +2,16 @@ sample:
   description: This app provides an example of EC J-PAKE
   name: EC J-PAKE example
 tests:
-  sample.ecjpake:
+  sample.ecjpake.oberon:
     tags: introduction psa oberon
     platform_allow: >
       nrf5340dk_nrf5340_cpuapp
-      nrf9160dk_nrf9160 nrf52840dk_nrf52840
+      nrf5340dk_nrf5340_cpuapp_ns
+      nrf9160dk_nrf9160
+      nrf9160dk_nrf9160_ns
+      nrf52840dk_nrf52840
       nrf9161dk_nrf9161
-      nrf54l15pdk_nrf54l15_cpuapp
-      nrf54h20dk_nrf54h20_cpuapp
+      nrf9161dk_nrf9161_ns
     harness: console
     harness_config:
       type: multi_line
@@ -17,8 +19,25 @@ tests:
         - ".*Example finished successfully!.*"
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuapp_ns
       - nrf9160dk_nrf9160
+      - nrf9160dk_nrf9160_ns
       - nrf9161dk_nrf9161
+      - nrf9161dk_nrf9161_ns
       - nrf52840dk_nrf52840
+  sample.ecjpake.cracen:
+    tags: introduction psa cracen
+    platform_allow: >
+      nrf54l15pdk_nrf54l15_cpuapp
+      nrf54l15pdk_nrf54l15_cpuapp_ns
+      nrf54h20dk_nrf54h20_cpuapp
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - ".*Example finished successfully!.*"
+    integration_platforms:
       - nrf54l15pdk_nrf54l15_cpuapp
+      - nrf54l15pdk_nrf54l15_cpuapp_ns
+      # nRF54H uses Oberon+fake entropy until crypto service is available from SDFW
       - nrf54h20dk_nrf54h20_cpuapp

--- a/samples/crypto/eddsa/sample.yaml
+++ b/samples/crypto/eddsa/sample.yaml
@@ -3,12 +3,11 @@ sample:
     This app provides an example of signing/verifying using EdDSA signatures
   name: EdDSA example
 tests:
-  sample.eddsa:
+  sample.eddsa.cc3xx:
     tags: introduction psa cc3xx
     platform_allow: >
       nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns
       nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf9161dk_nrf9161 nrf9161dk_nrf9161_ns
-      nrf54l15pdk_nrf54l15_cpuapp nrf54l15pdk_nrf54l15_cpuapp_ns
     harness: console
     harness_config:
       type: multi_line
@@ -22,5 +21,17 @@ tests:
       - nrf52840dk_nrf52840
       - nrf9161dk_nrf9161
       - nrf9161dk_nrf9161_ns
+  sample.eddsa.cracen:
+    tags: introduction psa cracen
+    platform_allow: >
+      nrf54l15pdk_nrf54l15_cpuapp nrf54l15pdk_nrf54l15_cpuapp_ns nrf54h20dk_nrf54h20_cpuapp
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - ".*Example finished successfully!.*"
+    integration_platforms:
       - nrf54l15pdk_nrf54l15_cpuapp
       - nrf54l15pdk_nrf54l15_cpuapp_ns
+      # nRF54H uses Oberon+fake entropy until crypto service is available from SDFW
+      - nrf54h20dk_nrf54h20_cpuapp

--- a/samples/crypto/hkdf/sample.yaml
+++ b/samples/crypto/hkdf/sample.yaml
@@ -2,13 +2,11 @@ sample:
   description: HMAC key derivation function example
   name: HKDF example
 tests:
-  sample.hkdf:
+  sample.hkdf.cc3xx:
     tags: introduction psa cc3xx
     platform_allow: >
       nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns
       nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf9161dk_nrf9161 nrf9161dk_nrf9161_ns
-      nrf54h20dk_nrf54h20_cpuapp
-      nrf54l15pdk_nrf54l15_cpuapp nrf54l15pdk_nrf54l15_cpuapp_ns
     harness: console
     harness_config:
       type: multi_line
@@ -22,6 +20,18 @@ tests:
       - nrf52840dk_nrf52840
       - nrf9161dk_nrf9161
       - nrf9161dk_nrf9161_ns
+  sample.hkdf.cracen:
+    tags: introduction psa cracen
+    platform_allow: >
+      nrf54h20dk_nrf54h20_cpuapp
+      nrf54l15pdk_nrf54l15_cpuapp nrf54l15pdk_nrf54l15_cpuapp_ns
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - ".*Example finished successfully!.*"
+    integration_platforms:
       - nrf54l15pdk_nrf54l15_cpuapp
       - nrf54l15pdk_nrf54l15_cpuapp_ns
+      # nRF54H uses Oberon+fake entropy until crypto service is available from SDFW
       - nrf54h20dk_nrf54h20_cpuapp

--- a/samples/crypto/hmac/sample.yaml
+++ b/samples/crypto/hmac/sample.yaml
@@ -4,12 +4,11 @@ sample:
     using the SHA256 hashing algorithm decryption using AES CBC mode
   name: HMAC example
 tests:
-  sample.hmac:
+  sample.hmac.cc3xx:
     tags: introduction psa cc3xx
     platform_allow: >
       nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns
       nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf9161dk_nrf9161 nrf9161dk_nrf9161_ns
-        nrf54h20dk_nrf54h20_cpuapp nrf54l15pdk_nrf54l15_cpuapp nrf54l15pdk_nrf54l15_cpuapp_ns
     harness: console
     harness_config:
       type: multi_line
@@ -23,6 +22,17 @@ tests:
       - nrf52840dk_nrf52840
       - nrf9161dk_nrf9161
       - nrf9161dk_nrf9161_ns
+  sample.hmac.cracen:
+    tags: introduction psa cracen
+    platform_allow: >
+      nrf54h20dk_nrf54h20_cpuapp nrf54l15pdk_nrf54l15_cpuapp nrf54l15pdk_nrf54l15_cpuapp_ns
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - ".*Example finished successfully!.*"
+    integration_platforms:
       - nrf54l15pdk_nrf54l15_cpuapp
       - nrf54l15pdk_nrf54l15_cpuapp_ns
+      # nRF54H uses Oberon+fake entropy until crypto service is available from SDFW
       - nrf54h20dk_nrf54h20_cpuapp

--- a/samples/crypto/pbkdf2/sample.yaml
+++ b/samples/crypto/pbkdf2/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: HMAC key derivation function example
   name: PBKDF2 example
 tests:
-  sample.pbkdf2:
+  sample.pbkdf2.cc3xx:
     tags: introduction psa cc3xx
     platform_allow: >
       nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf9161dk_nrf9161
@@ -20,3 +20,17 @@ tests:
       - nrf52840dk_nrf52840
       - nrf9161dk_nrf9161
       - nrf9161dk_nrf9161_ns
+  sample.pbkdf2.cracen:
+    tags: introduction psa cracen
+    platform_allow: >
+      nrf54h20dk_nrf54h20_cpuapp nrf54l15pdk_nrf54l15_cpuapp nrf54l15pdk_nrf54l15_cpuapp_ns
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - ".*Example finished successfully!.*"
+    integration_platforms:
+      # nRF54H uses Oberon+fake entropy until crypto service is available from SDFW
+      - nrf54h20dk_nrf54h20_cpuapp
+      - nrf54l15pdk_nrf54l15_cpuapp
+      - nrf54l15pdk_nrf54l15_cpuapp_ns

--- a/samples/crypto/persistent_key_usage/sample.yaml
+++ b/samples/crypto/persistent_key_usage/sample.yaml
@@ -5,12 +5,11 @@ sample:
     to the PSA keystore.
   name: Persistent key example
 tests:
-  sample.persistent_key_usage:
+  sample.persistent_key_usage.cc3xx:
     tags: introduction psa cc3xx
     platform_allow: >
       nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns
       nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf9161dk_nrf9161 nrf9161dk_nrf9161_ns
-      nrf54l15pdk_nrf54l15_cpuapp
     harness: console
     harness_config:
       type: multi_line
@@ -24,4 +23,14 @@ tests:
       - nrf52840dk_nrf52840
       - nrf9161dk_nrf9161
       - nrf9161dk_nrf9161_ns
+  sample.persistent_key_usage.cracen:
+    tags: introduction psa cracen
+    platform_allow: >
+      nrf54l15pdk_nrf54l15_cpuapp
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - ".*Example finished successfully!.*"
+    integration_platforms:
       - nrf54l15pdk_nrf54l15_cpuapp

--- a/samples/crypto/rng/sample.yaml
+++ b/samples/crypto/rng/sample.yaml
@@ -2,12 +2,11 @@ sample:
   description: This app provides an example of how to produce random numbers
   name: RNG example
 tests:
-  sample.rng:
+  sample.rng.cc3xx:
     tags: introduction psa cc3xx
     platform_allow: >
       nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns
       nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf9161dk_nrf9161 nrf9161dk_nrf9161_ns
-      nrf54h20dk_nrf54h20_cpuapp nrf54l15pdk_nrf54l15_cpuapp nrf54l15pdk_nrf54l15_cpuapp_ns
     harness: console
     harness_config:
       type: multi_line
@@ -21,6 +20,17 @@ tests:
       - nrf52840dk_nrf52840
       - nrf9161dk_nrf9161
       - nrf9161dk_nrf9161_ns
+  sample.rng.cracen:
+    tags: introduction psa cracen
+    platform_allow: >
+      nrf54h20dk_nrf54h20_cpuapp nrf54l15pdk_nrf54l15_cpuapp nrf54l15pdk_nrf54l15_cpuapp_ns
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - ".*Example finished successfully!.*"
+    integration_platforms:
       - nrf54l15pdk_nrf54l15_cpuapp
       - nrf54l15pdk_nrf54l15_cpuapp_ns
+      # nRF54H uses Oberon+fake entropy until crypto service is available from SDFW
       - nrf54h20dk_nrf54h20_cpuapp

--- a/samples/crypto/rsa/sample.yaml
+++ b/samples/crypto/rsa/sample.yaml
@@ -3,12 +3,11 @@ sample:
     This app provides an example of performing RSA signing and verification
   name: RSA example
 tests:
-  sample.rsa:
+  sample.rsa.cc3xx:
     tags: introduction psa cc3xx
     platform_allow: >
       nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns
       nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf9161dk_nrf9161 nrf9161dk_nrf9161_ns
-      nrf54l15pdk_nrf54l15_cpuapp nrf54l15pdk_nrf54l15_cpuapp_ns
     harness: console
     harness_config:
       type: multi_line
@@ -21,6 +20,18 @@ tests:
       - nrf9160dk_nrf9160
       - nrf52840dk_nrf52840
       - nrf9161dk_nrf9161
+      - nrf9161dk_nrf9161_ns
+  sample.rsa.cracen:
+    tags: introduction psa cracen
+    platform_allow: >
+      nrf54l15pdk_nrf54l15_cpuapp nrf54l15pdk_nrf54l15_cpuapp_ns nrf54h20dk_nrf54h20_cpuapp
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - ".*Example finished successfully!.*"
+    integration_platforms:
       - nrf54l15pdk_nrf54l15_cpuapp
       - nrf54l15pdk_nrf54l15_cpuapp_ns
-      - nrf9161dk_nrf9161_ns
+      # nRF54H uses Oberon+fake entropy until crypto service is available from SDFW
+      - nrf54h20dk_nrf54h20_cpuapp

--- a/samples/crypto/sha256/sample.yaml
+++ b/samples/crypto/sha256/sample.yaml
@@ -2,12 +2,11 @@ sample:
   description: This app provides an example of hashing using SHA256
   name: SHA256 example
 tests:
-  sample.sha256:
+  sample.sha256.cc3xx:
     tags: introduction psa cc3xx
     platform_allow: >
       nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns
       nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf9161dk_nrf9161 nrf9161dk_nrf9161_ns
-      nrf54h20dk_nrf54h20_cpuapp nrf54l15pdk_nrf54l15_cpuapp nrf54l15pdk_nrf54l15_cpuapp_ns
     harness: console
     harness_config:
       type: multi_line
@@ -21,6 +20,17 @@ tests:
       - nrf9161dk_nrf9161_ns
       - nrf9161dk_nrf9161
       - nrf52840dk_nrf52840
+  sample.sha256.cracen:
+    tags: introduction psa cracen
+    platform_allow: >
+        nrf54h20dk_nrf54h20_cpuapp nrf54l15pdk_nrf54l15_cpuapp nrf54l15pdk_nrf54l15_cpuapp_ns
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - ".*Example finished successfully!.*"
+    integration_platforms:
+      # nRF54H uses Oberon+fake entropy until crypto service is available from SDFW
       - nrf54h20dk_nrf54h20_cpuapp
       - nrf54l15pdk_nrf54l15_cpuapp
       - nrf54l15pdk_nrf54l15_cpuapp_ns

--- a/samples/crypto/spake2p/sample.yaml
+++ b/samples/crypto/spake2p/sample.yaml
@@ -2,14 +2,13 @@ sample:
   description: This app provides an example of Spake2+
   name: Spake2+ example
 tests:
-  sample.spake2p:
+  sample.spake2p.oberon:
     tags: introduction psa oberon
     platform_allow: >
-      nrf5340dk_nrf5340_cpuapp
+      nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns
       nrf9160dk_nrf9160 nrf52840dk_nrf52840
-      nrf9161dk_nrf9161
-      nrf54l15pdk_nrf54l15_cpuapp
-      nrf54h20dk_nrf54h20_cpuapp
+      nrf9161dk_nrf9161 nrf9160dk_nrf9160_ns
+      nrf9161dk_nrf9161_ns
     harness: console
     harness_config:
       type: multi_line
@@ -17,8 +16,25 @@ tests:
         - ".*Example finished successfully!.*"
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuapp_ns
       - nrf9160dk_nrf9160
+      - nrf9160dk_nrf9160_ns
       - nrf9161dk_nrf9161
+      - nrf9161dk_nrf9161_ns
       - nrf52840dk_nrf52840
+  sample.spake2p.cracen:
+    tags: introduction psa cracen
+    platform_allow: >
+      nrf54l15pdk_nrf54l15_cpuapp
+      nrf54l15pdk_nrf54l15_cpuapp_ns
+      nrf54h20dk_nrf54h20_cpuapp
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - ".*Example finished successfully!.*"
+    integration_platforms:
       - nrf54l15pdk_nrf54l15_cpuapp
+      - nrf54l15pdk_nrf54l15_cpuapp_ns
+      # nRF54H uses Oberon+fake entropy until crypto service is available from SDFW
       - nrf54h20dk_nrf54h20_cpuapp


### PR DESCRIPTION
- Use correct tags when running on CC3xx/CRACEN/Oberon
- Add _ns boards for ecjpake and spake2p
- Use CRACEN for ecjpake on nRF54L15

test_crypto: PR-625