### PR TITLE
manifest: Update zephyr and hal_nordic with nrf54l15 uart support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 5c484901b955fb78e97b9f76cb51fd38433fd4f2
+      revision: pull/1608/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update zephyr and hal_nordic with cherry-picks from upstream and upstream PRs to support UART test suits on nrf54l15pdk (and limited support for nrf54h20dk).