### PR TITLE
bootloader: enable prebuilt B0 users to configure `BOOTLOADER_PROVISION_HEX`

### DIFF
--- a/subsys/bootloader/Kconfig
+++ b/subsys/bootloader/Kconfig
@@ -32,7 +32,10 @@ config SECURE_BOOT
 	  verifies the signature of the app.
 
 config BOOTLOADER_PROVISION_HEX
-	bool
+	# A conditional prompt here enables users with pre-built B0 binaries
+	# to disable generation and merge of provision.hex and use their own
+	# pre-built provision.hex
+	bool "Generate provision.hex for NSIB" if B0_BUILD_STRATEGY_USE_HEX_FILE
 	default y if SECURE_BOOT
 	default y if MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION
 	help


### PR DESCRIPTION
The current default for `CONFIG_BOOTLOADER_PROVISION_HEX` merges a provision.hex which is incompatible with prebuilt B0 binaries from NCS versions <=2.1.3. This is because v2.1.3 was the last version without support for PRoT Lifecycle State and Implementation ID.

B0 binaries built from those versions expect a different offset for the public key hashes in OTP, so are incompatible with the generated provision.hex in versions >=v2.2.0

Please find here my [original devzone ticket](https://devzone.nordicsemi.com/f/nordic-q-a/110077/migration-from-ncs-v2-1-3-to-v2-6-0-with-prebuilt-b0-binaries) which I believe necessitates this change.