### PR TITLE
kernel: Add NCS boot banner

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,6 @@ set(NRF_DIR ${CMAKE_CURRENT_LIST_DIR} CACHE PATH "NCS root directory")
 # is cached.
 set(CONF_FILE_BUILD_TYPE ${CONF_FILE_BUILD_TYPE} CACHE INTERNAL "The build type")
 
-# Customize the Zephyr kernel version.h using nRF Connect SDK ncs_version.h.
-set(KERNEL_VERSION_CUSTOMIZATION \#include;<ncs_version.h> PARENT_SCOPE)
-
 foreach(runner_ext BIN HEX ELF)
   zephyr_get(NCS_RUNNER_${runner_ext} SYSBUILD)
   if(DEFINED NCS_RUNNER_${runner_ext})
@@ -37,3 +34,4 @@ add_subdirectory(subsys)
 add_subdirectory(modules)
 add_subdirectory(drivers)
 add_subdirectory(tests)
+add_subdirectory(kernel)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ endforeach()
 
 include(cmake/extensions.cmake)
 include(cmake/version.cmake)
+include(cmake/version_app.cmake)
 include(cmake/multi_image.cmake)
 
 zephyr_include_directories(include)

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -102,6 +102,7 @@ Kconfig*                                  @tejlmand
 /include/nfc/                             @anangl @grochu
 /include/sdfw/                            @anhmolt @hakonfam @jonathannilsen
 /include/shell/                           @nordic-krch
+/kernel/                                  @nordicjm
 /lib/bin/                                 @rlubos @lemrey
 /lib/adp536x/                             @nrfconnect/ncs-cia
 /lib/at_cmd_parser/                       @rlubos

--- a/Kconfig.nrf
+++ b/Kconfig.nrf
@@ -111,6 +111,7 @@ config NORDIC_QSPI_NOR_FLASH_LAYOUT_PAGE_SIZE
 config GETOPT
 	default n
 
+rsource "kernel/Kconfig"
 rsource "samples/Kconfig"
 rsource "subsys/Kconfig"
 rsource "modules/Kconfig"

--- a/Kconfig.nrf
+++ b/Kconfig.nrf
@@ -34,10 +34,6 @@ config HIDE_CHILD_PARENT_CONFIG
 	default y if "$(HIDE_CHILD_PARENT_CONFIG)" = "True"
 	default n
 
-# Override boot banner
-config BOOT_BANNER_STRING
-	default "Booting nRF Connect SDK"
-
 # Override configuration from zephyr which sets this to 0x200 if MCUboot is
 # enabled (CONFIG_BOOTLOADER_MCUBOOT), since NCS use partition_manager to
 # get this offset intsead.

--- a/cmake/commit.h.in
+++ b/cmake/commit.h.in
@@ -1,0 +1,12 @@
+#ifndef _@COMMIT_TYPE@_COMMIT_H_
+#define _@COMMIT_TYPE@_COMMIT_H_
+
+/* @templates@ values come from cmake/version.cmake
+ * BUILD_COMMIT related @template@ values will be 'git rev-parse',
+ * alternatively user defined BUILD_VERSION.
+ */
+
+#define @COMMIT_TYPE@_COMMIT                   @@COMMIT_TYPE@_COMMIT@
+#define @COMMIT_TYPE@_COMMIT_STRING            "@@COMMIT_TYPE@_COMMIT@"
+
+#endif /* _@COMMIT_TYPE@_COMMIT_H_ */

--- a/cmake/gen_commit_h.cmake
+++ b/cmake/gen_commit_h.cmake
@@ -1,0 +1,43 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Git QUIET)
+if(GIT_FOUND)
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
+    WORKING_DIRECTORY                ${COMMIT_PATH}
+    OUTPUT_VARIABLE                  ${COMMIT_TYPE}_COMMIT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+    ERROR_VARIABLE                   stderr
+    RESULT_VARIABLE                  return_code
+  )
+
+  if(return_code)
+    message(STATUS "git rev-parse failed: ${stderr}")
+  elseif(NOT "${stderr}" STREQUAL "")
+    message(STATUS "git rev-parse warned: ${stderr}")
+  endif()
+
+  # Limit to 12 characters
+  string(SUBSTRING "${${COMMIT_TYPE}_COMMIT}" 0 12 ${COMMIT_TYPE}_COMMIT)
+endif()
+
+file(READ ${NRF_DIR}/cmake/commit.h.in commit_content)
+string(CONFIGURE "${commit_content}" commit_content)
+string(CONFIGURE "${commit_content}" commit_content)
+
+if(EXISTS ${OUT_FILE})
+  file(READ ${OUT_FILE} current_contents)
+else()
+  set(current_contents "")
+endif()
+
+if(NOT "${current_contents}" STREQUAL "${commit_content}")
+  file(WRITE ${OUT_FILE} "${commit_content}")
+endif()

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -19,5 +19,28 @@ add_custom_command(
     DEPENDS ${NRF_DIR}/VERSION ${git_dependency}
 )
 add_custom_target(ncs_version_h DEPENDS ${PROJECT_BINARY_DIR}/include/generated/ncs_version.h)
-
 add_dependencies(version_h ncs_version_h)
+
+add_custom_command(
+  OUTPUT ${PROJECT_BINARY_DIR}/include/generated/ncs_commit.h
+  COMMAND ${CMAKE_COMMAND} -DZEPHYR_BASE=${ZEPHYR_BASE} -DNRF_DIR=${NRF_DIR}
+    -DOUT_FILE=${PROJECT_BINARY_DIR}/include/generated/ncs_commit.h
+    -DCOMMIT_TYPE=NCS
+    -DCOMMIT_PATH=${NRF_DIR}
+    -P ${ZEPHYR_NRF_MODULE_DIR}/cmake/gen_commit_h.cmake
+    DEPENDS ${NRF_DIR}/VERSION ${git_dependency}
+)
+add_custom_target(ncs_commit_h DEPENDS ${PROJECT_BINARY_DIR}/include/generated/ncs_commit.h)
+add_dependencies(version_h ncs_commit_h)
+
+add_custom_command(
+  OUTPUT ${PROJECT_BINARY_DIR}/include/generated/zephyr_commit.h
+  COMMAND ${CMAKE_COMMAND} -DZEPHYR_BASE=${ZEPHYR_BASE} -DNRF_DIR=${NRF_DIR}
+    -DOUT_FILE=${PROJECT_BINARY_DIR}/include/generated/zephyr_commit.h
+    -DCOMMIT_TYPE=ZEPHYR
+    -DCOMMIT_PATH=${ZEPHYR_BASE}
+    -P ${ZEPHYR_NRF_MODULE_DIR}/cmake/gen_commit_h.cmake
+    DEPENDS ${ZEPHYR_BASE}/VERSION ${git_dependency}
+)
+add_custom_target(zephyr_commit_h DEPENDS ${PROJECT_BINARY_DIR}/include/generated/zephyr_commit.h)
+add_dependencies(version_h zephyr_commit_h)

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -28,7 +28,7 @@ add_custom_command(
     -DCOMMIT_TYPE=NCS
     -DCOMMIT_PATH=${NRF_DIR}
     -P ${ZEPHYR_NRF_MODULE_DIR}/cmake/gen_commit_h.cmake
-    DEPENDS ${NRF_DIR}/VERSION ${git_dependency}
+    DEPENDS ${NRF_DIR}/VERSION ${NRF_DIR}/.git ${NRF_DIR}/.git/index
 )
 add_custom_target(ncs_commit_h DEPENDS ${PROJECT_BINARY_DIR}/include/generated/ncs_commit.h)
 add_dependencies(version_h ncs_commit_h)
@@ -40,7 +40,7 @@ add_custom_command(
     -DCOMMIT_TYPE=ZEPHYR
     -DCOMMIT_PATH=${ZEPHYR_BASE}
     -P ${ZEPHYR_NRF_MODULE_DIR}/cmake/gen_commit_h.cmake
-    DEPENDS ${ZEPHYR_BASE}/VERSION ${git_dependency}
+    DEPENDS ${ZEPHYR_BASE}/VERSION ${ZEPHYR_BASE}/.git ${git_dependency}
 )
 add_custom_target(zephyr_commit_h DEPENDS ${PROJECT_BINARY_DIR}/include/generated/zephyr_commit.h)
 add_dependencies(version_h zephyr_commit_h)

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -1,12 +1,6 @@
 math(EXPR NCS_VERSION_CODE "(${NCS_VERSION_MAJOR} << 16) + (${NCS_VERSION_MINOR} << 8)  + (${NCS_VERSION_PATCH})")
 math(EXPR NCS_VERSION_NUMBER ${NCS_VERSION_CODE} OUTPUT_FORMAT HEXADECIMAL)
 
-if(DEFINED BUILD_VERSION)
-  set(ncs_banner_version BUILD_VERSION)
-else()
-  set(ncs_banner_version NCS_BUILD_VERSION)
-endif()
-
 add_custom_command(
   OUTPUT ${PROJECT_BINARY_DIR}/include/generated/ncs_version.h
   COMMAND ${CMAKE_COMMAND} -DZEPHYR_BASE=${ZEPHYR_BASE}
@@ -21,7 +15,6 @@ add_custom_command(
     -DNCS_VERSION_MINOR=${NCS_VERSION_MINOR}
     -DNCS_PATCHLEVEL=${NCS_VERSION_PATCH}
     -DNCS_VERSION_STRING=${NCS_VERSION}
-    -DNCS_VERSION_CUSTOMIZATION="\#define;BANNER_VERSION;STRINGIFY\(${ncs_banner_version}\)"
     -P ${ZEPHYR_BASE}/cmake/gen_version_h.cmake
     DEPENDS ${NRF_DIR}/VERSION ${git_dependency}
 )

--- a/cmake/version_app.cmake
+++ b/cmake/version_app.cmake
@@ -1,0 +1,45 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+if(${APP_VERSION_NUMBER})
+  find_package(Git QUIET)
+  if(GIT_FOUND)
+    execute_process(
+      COMMAND ${GIT_EXECUTABLE} rev-parse --absolute-git-dir
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+      OUTPUT_VARIABLE app_git_dir
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_STRIP_TRAILING_WHITESPACE
+      ERROR_VARIABLE stderr
+      RESULT_VARIABLE return_code)
+    if(return_code)
+      message(WARNING "APP_VERSION: git rev-parse failed: ${stderr}")
+    else()
+      if(NOT "${stderr}" STREQUAL "")
+        message(WARNING "APP_VERSION: git rev-parse warned: ${stderr}")
+      else()
+        set(APP_GIT_INDEX ${app_git_dir}/index)
+      endif()
+    endif()
+  endif()
+
+  if(DEFINED APP_GIT_INDEX)
+    add_custom_command(
+      OUTPUT ${PROJECT_BINARY_DIR}/include/generated/app_commit.h
+      COMMAND ${CMAKE_COMMAND} -DZEPHYR_BASE=${ZEPHYR_BASE} -DNRF_DIR=${NRF_DIR}
+        -DOUT_FILE=${PROJECT_BINARY_DIR}/include/generated/app_commit.h
+        -DCOMMIT_TYPE=APP
+        -DCOMMIT_PATH=${CMAKE_SOURCE_DIR}
+        -P ${ZEPHYR_NRF_MODULE_DIR}/cmake/gen_commit_h.cmake
+        DEPENDS ${CMAKE_SOURCE_DIR}/VERSION ${APP_GIT_INDEX}
+    )
+    add_custom_target(app_commit_h DEPENDS ${PROJECT_BINARY_DIR}/include/generated/app_commit.h)
+    add_dependencies(version_h app_commit_h)
+
+    # Add a compile definition so that the commit can be printed
+    zephyr_compile_definitions(NCS_APPLICATION_BOOT_BANNER_GIT_REPO)
+  endif()
+endif()

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+if(CONFIG_NCS_BOOT_BANNER)
+  zephyr_sources(banner.c)
+endif()

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -1,0 +1,35 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+menu "General Kernel Options"
+
+menuconfig NCS_BOOT_BANNER
+	bool "NCS boot banner"
+	depends on BOOT_BANNER
+	default y
+	help
+	  This option provided an enhanced boot banner output that can include application name
+	  and version (if set), NCS version and underlying zephyr version.
+
+if NCS_BOOT_BANNER
+
+config NCS_APPLICATION_BOOT_BANNER_STRING
+	string "Boot banner string" if "$(APP_VERSION_EXTENDED_STRING)" != ""
+	default "My Application" if "$(APP_VERSION_EXTENDED_STRING)" != ""
+	help
+	  Use this option to set the application boot banner.
+
+config NCS_NCS_BOOT_BANNER_STRING
+	string
+	default "nRF Connect SDK"
+
+config NCS_ZEPHYR_BOOT_BANNER_STRING
+	string
+	default "Zephyr OS"
+
+endif # NCS_BOOT_BANNER
+
+endmenu

--- a/kernel/banner.c
+++ b/kernel/banner.c
@@ -8,10 +8,15 @@
 #include <zephyr/init.h>
 #include <zephyr/device.h>
 #include <version.h>
+#include <zephyr_commit.h>
 #include <ncs_version.h>
+#include <ncs_commit.h>
 
 #if defined(CONFIG_NCS_APPLICATION_BOOT_BANNER_STRING)
 #include <app_version.h>
+#if defined(NCS_APPLICATION_BOOT_BANNER_GIT_REPO)
+#include <app_commit.h>
+#endif
 #endif
 
 #if defined(CONFIG_NCS_APPLICATION_BOOT_BANNER_STRING)
@@ -29,16 +34,22 @@ void boot_banner(void)
 
 #if defined(CONFIG_NCS_APPLICATION_BOOT_BANNER_STRING)
 	printk("*** Booting " CONFIG_NCS_APPLICATION_BOOT_BANNER_STRING " v"
-	       APP_VERSION_STRING " ***\n");
+	       APP_VERSION_STRING
+#if defined(NCS_APPLICATION_BOOT_BANNER_GIT_REPO)
+	       "-" APP_COMMIT_STRING
+#else
+	       " - unknown commit"
+#endif
+	       " ***\n");
 #endif
 
 #if defined(CONFIG_NCS_NCS_BOOT_BANNER_STRING)
 	printk("*** " NCS_PREFIX CONFIG_NCS_NCS_BOOT_BANNER_STRING " v"
-	       NCS_VERSION_STRING " ***\n");
+	       NCS_VERSION_STRING "-" NCS_COMMIT_STRING " ***\n");
 #endif
 
 #if defined(CONFIG_NCS_ZEPHYR_BOOT_BANNER_STRING)
 	printk("*** Using " CONFIG_NCS_ZEPHYR_BOOT_BANNER_STRING " v"
-	       KERNEL_VERSION_STRING " ***\n");
+	       KERNEL_VERSION_STRING "-" ZEPHYR_COMMIT_STRING " ***\n");
 #endif
 }

--- a/kernel/banner.c
+++ b/kernel/banner.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
+#include <zephyr/device.h>
+#include <version.h>
+#include <ncs_version.h>
+
+#if defined(CONFIG_NCS_APPLICATION_BOOT_BANNER_STRING)
+#include <app_version.h>
+#endif
+
+#if defined(CONFIG_NCS_APPLICATION_BOOT_BANNER_STRING)
+#define NCS_PREFIX "Using "
+#else
+#define NCS_PREFIX "Booting "
+#endif
+
+void boot_banner(void)
+{
+#if defined(CONFIG_BOOT_DELAY) && (CONFIG_BOOT_DELAY > 0)
+	printk("*** Delaying boot by " STRINGIFY(CONFIG_BOOT_DELAY) "ms... ***\n");
+	k_busy_wait(CONFIG_BOOT_DELAY * USEC_PER_MSEC);
+#endif
+
+#if defined(CONFIG_NCS_APPLICATION_BOOT_BANNER_STRING)
+	printk("*** Booting " CONFIG_NCS_APPLICATION_BOOT_BANNER_STRING " v"
+	       APP_VERSION_STRING " ***\n");
+#endif
+
+#if defined(CONFIG_NCS_NCS_BOOT_BANNER_STRING)
+	printk("*** " NCS_PREFIX CONFIG_NCS_NCS_BOOT_BANNER_STRING " v"
+	       NCS_VERSION_STRING " ***\n");
+#endif
+
+#if defined(CONFIG_NCS_ZEPHYR_BOOT_BANNER_STRING)
+	printk("*** Using " CONFIG_NCS_ZEPHYR_BOOT_BANNER_STRING " v"
+	       KERNEL_VERSION_STRING " ***\n");
+#endif
+}


### PR DESCRIPTION
Adds an enhanced boot banner which can be configured to show application name and version, NCS version, and underlying zephyr version.