### PR TITLE
samples: bluetooth: Update nRF54l15 UART instance

### DIFF
--- a/samples/bluetooth/central_uart/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
+++ b/samples/bluetooth/central_uart/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
@@ -6,11 +6,6 @@
 
 / {
 	chosen {
-		zephyr,console = &uart30;
-		nordic,nus-uart = &uart30;
+		nordic,nus-uart = &uart20;
 	};
-};
-
-&uart30 {
-	status = "okay";
 };

--- a/samples/bluetooth/direct_test_mode/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
+++ b/samples/bluetooth/direct_test_mode/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
@@ -6,11 +6,11 @@
 
 / {
 	chosen {
-		ncs,dtm-uart = &uart30;
+		ncs,dtm-uart = &uart20;
 	};
 };
 
-&uart30 {
+&uart20 {
 	status = "okay";
 	current-speed = <19200>;
 };

--- a/samples/bluetooth/peripheral_uart/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
+++ b/samples/bluetooth/peripheral_uart/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
@@ -6,10 +6,6 @@
 
 / {
 	chosen {
-		nordic,nus-uart = &uart30;
+		nordic,nus-uart = &uart20;
 	};
-};
-
-&uart30 {
-	status = "okay";
 };


### PR DESCRIPTION
Align nRF54l15 UART instance with one used
in upstream Zephyr in Peripheral and Central
UART samples.
