### PR TITLE
manifest: update sdk-zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 3c68e19f4eb40c472b8be4fdff067c2519f7379f
+      revision: 22e2d8781ef57c215b49539ae1b16fcd42b331cf
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Include following change:
NRFX-5624: Run zephyr/samples/sensor/qdec on nrf54l15
https://github.com/nrfconnect/sdk-zephyr/pull/1614