### PR TITLE
manifest: Update sdk-zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: d06a1a7d77b564b331b24db2f3cca58076ef28e9
+      revision: pull/1615/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Brings in change where inclusion of partition manager in cmake/modules/kernel.cmake depends on
SB_CONFIG_PARTITION_MANAGER=y