### PR TITLE
manifest: Update zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 54b4e400ed8ffe37602112ad719bab4db5ea0087
+      revision: 3733e7097909ae964e60cf66e4d51ade975ddcae
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull in a fix in pinctrl that prevents the nrf_qspi_nor driver from failing to initialize when the flash chip is configured to work in non-Quad mode.