### PR TITLE
manifest: Pull in sdk-zephyt with UARTE new tests revert

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 3c68e19f4eb40c472b8be4fdff067c2519f7379f
+      revision: pull/1621/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
The 'uart_elementary' suite must be reverted for now
Signed-off-by: Bartosz Miller <bartosz.miller@nordicsemi.no>