### PR TITLE
manifest: matter: pull fix for insufficient resources

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -102,6 +102,7 @@ Matter
   * Support for the unified Persistent Storage API, including the implementation of the PSA Persistent Storage.
 
 * Updated default MRP retry intervals for Thread devices to two seconds to reduce the number of spurious retransmissions in Thread networks.
+* Increased the number of available packet buffers in the Matter stack to avoid packet allocation issues.
 
 Matter fork
 +++++++++++

--- a/west.yml
+++ b/west.yml
@@ -160,7 +160,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 053732b6fe47be1d8620e107156580351ea1fc90
+      revision: d76797e8cb75fae4063c524369e7da419b3c1ed3
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
This commit increases number of available packet buffers in the system.