### PR TITLE
manifest: Update zephyr with nrf54h20 DCACHE enabling

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 046e281be0bdaa45f512981431fe7f20c028aa9a
+      revision: 2f78bc89c92578db48051e54f83f6820f9101909
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update zephyr to enable DCACHE by default for nrf54h20.