### PR TITLE
doc: fix gpio code

### DIFF
--- a/doc/nrf/config_and_build/configuring_app/hardware/use_gpio_pin_directly.rst
+++ b/doc/nrf/config_and_build/configuring_app/hardware/use_gpio_pin_directly.rst
@@ -103,8 +103,8 @@ To initialize the defined GPIO pin structures, use the ``GPIO_DT_SPEC_INST_GET_B
 
    #include <zephyr/drivers/gpio.h>
    static const struct gpio_dt_spec pin_dbg0 =
-       GPIO_DT_SPEC_GET_OR(DT_NODELABEL(user_dbg_pin), gpios, 0, {0});
+       GPIO_DT_SPEC_GET_BY_IDX_OR(DT_NODELABEL(user_dbg_pin), gpios, 0, {0});
    static const struct gpio_dt_spec pin_dbg1 =
-	   GPIO_DT_SPEC_GET_OR(DT_NODELABEL(user_dbg_pin), gpios, 1, {0});
+	   GPIO_DT_SPEC_GET_BY_IDX_OR(DT_NODELABEL(user_dbg_pin), gpios, 1, {0});
 
 The rest of the GPIO pin operations follow the same process in case of declaring a single pin.


### PR DESCRIPTION
[NCSDK-26162](https://nordicsemi.atlassian.net/browse/NCSDK-26162)
Fix typo in GPIO doc code block

[NCSDK-26162]: https://nordicsemi.atlassian.net/browse/NCSDK-26162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ