### PR TITLE
[backport-v2.5] manifest: Update zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: c82a387602c2c283cb1a7e6503afc799eedae2cd
+      revision: 29f3cba65da003bac6057a6e61ff8de43c2cc620
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull in a fix in pinctrl that prevents the nrf_qspi_nor driver from failing to initialize when the flash chip is configured to work in non-Quad mode.