### PR TITLE
[backport-v2.6] manifest: Update zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 2bc4d2c8192e891bf09ba72845fa737ddb42666d
+      revision: 3758bcbfa5cd749d977e2600b6687104b8948243
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull in a fix in pinctrl that prevents the nrf_qspi_nor driver from failing to initialize when the flash chip is configured to work in non-Quad mode.