### PR TITLE
Bluetooth: Mesh: Point to point and Mesh DFU

### DIFF
--- a/doc/nrf/protocols/bt/bt_mesh/dfu_over_ble.rst
+++ b/doc/nrf/protocols/bt/bt_mesh/dfu_over_ble.rst
@@ -15,8 +15,8 @@ See `Discovering Bluetooth Mesh devices in nRF Connect Device Manager`_ for more
 Point-to point DFU over Bluetooth Low Energy in Bluetooth Mesh samples
 **********************************************************************
 
-The :ref:`bluetooth_mesh_light` sample enables support for point-to-point DFU over Bluetooth Low Energy for nRF52 Series development kits.
-See the sample documentation for more details.
+The :ref:`bluetooth_mesh_light`, :ref:`ble_mesh_dfu_target` and :ref:`ble_mesh_dfu_distributor` samples enable support for point-to-point DFU over Bluetooth Low Energy for nRF52 Series development kits.
+See the sample documentation for each of the above mentioned samples for more details.
 
 Point-to-point DFU over Bluetooth Low Energy is supported by default, out-of-the-box, for all samples and applications compatible with :ref:`zephyr:thingy53_nrf5340`.
 See :ref:`thingy53_app_update` for more information about updating firmware image on :ref:`zephyr:thingy53_nrf5340`.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -278,7 +278,10 @@ Bluetooth Mesh samples
 
 * :ref:`ble_mesh_dfu_target` sample:
 
-  * Added a note on how to compile the sample with new Composition Data.
+  * Added
+
+    * A note on how to compile the sample with new Composition Data.
+    * Point-to-point DFU support with overlay file :file:`overlay-ptp_dfu.conf`.
 
 Cellular samples
 ----------------

--- a/samples/bluetooth/mesh/dfu/distributor/README.rst
+++ b/samples/bluetooth/mesh/dfu/distributor/README.rst
@@ -219,6 +219,8 @@ When the Distributor updates itself, the DFU transfer will end immediately after
 
 When this sample is used as a Target, it behaves as described in :ref:`ble_mesh_dfu_target_upgrade`.
 
+This sample also provides support for :ref:`dfu_over_ble`, so it is possible to self-update using the Simple Management Protocol (SMP).
+
 SMP over Bluetooth authentication
 =================================
 

--- a/samples/bluetooth/mesh/dfu/target/CMakeLists.txt
+++ b/samples/bluetooth/mesh/dfu/target/CMakeLists.txt
@@ -6,8 +6,16 @@ project(mesh_dfu_target)
 
 set(dfu_common_dir ${ZEPHYR_NRF_MODULE_DIR}/samples/bluetooth/mesh/dfu/common/src)
 
-include_directories(${dfu_common_dir})
+include_directories(
+	${dfu_common_dir}
+	${ZEPHYR_NRF_MODULE_DIR}/samples/bluetooth/mesh/common
+)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources}
-			${dfu_common_dir}/dfu_target.c)
+	${dfu_common_dir}/dfu_target.c
+)
+
+target_sources_ifdef(CONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU app PRIVATE ${app_sources}
+	${ZEPHYR_NRF_MODULE_DIR}/samples/bluetooth/mesh/common/smp_bt.c
+)

--- a/samples/bluetooth/mesh/dfu/target/README.rst
+++ b/samples/bluetooth/mesh/dfu/target/README.rst
@@ -29,6 +29,14 @@ For uploading an image to the Distributor, this sample also requires a smartphon
 * `nRF Device Manager mobile app for Android`_
 * `nRF Device Manager mobile app for iOS`_
 
+Point-to-point DFU requirements
+*******************************
+
+The configuration overlay :file:`overlay-ptp_dfu.conf` enables the :ref:`dfu_over_ble` feature.
+
+This feature can be used together with Bluetooth Mesh DFU.
+If the Bluetooth Mesh DFU procedure is suspended, failing, or if the Bluetooth Mesh network is not available, the point-to-point DFU feature can be used as a backup option for the DFU process.
+
 Overview
 ********
 

--- a/samples/bluetooth/mesh/dfu/target/overlay-ptp_dfu.conf
+++ b/samples/bluetooth/mesh/dfu/target/overlay-ptp_dfu.conf
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Enable point to point DFU over SMP
+CONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU=y
+CONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU_SPEEDUP=y
+
+# Increase Extended Advertiser Set to advertise BT SMP service
+CONFIG_BT_EXT_ADV_MAX_ADV_SET=6
+
+# One extra connection for mesh GATT/proxy and one for SMP BT.
+CONFIG_BT_MAX_CONN=3
+
+# One extra identity for SMP service
+CONFIG_BT_ID_MAX=2

--- a/samples/bluetooth/mesh/dfu/target/src/main.c
+++ b/samples/bluetooth/mesh/dfu/target/src/main.c
@@ -14,6 +14,9 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/mesh.h>
 #include "dfu_target.h"
+#if defined(CONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU)
+#include "smp_bt.h"
+#endif
 
 static struct bt_mesh_blob_io_flash blob_flash_stream;
 
@@ -116,6 +119,14 @@ static void bt_ready(int err)
 	bt_mesh_prov_enable(BT_MESH_PROV_ADV | BT_MESH_PROV_GATT);
 
 	printk("Mesh initialized\n");
+
+#if defined(CONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU)
+	/* Start advertising SMP BT service. */
+	err = smp_dfu_init();
+	if (err) {
+		printk("SMP initialization failed (err: %d)\n", err);
+	}
+#endif
 
 	/* Confirm the image and mark it as applied after the mesh started. */
 	dfu_target_image_confirm();


### PR DESCRIPTION
Adding point to point DFU together with Mesh DFU
so the point to point DFU can be used as a fallback solution.