### PR TITLE
Ble coex review and revamp

### DIFF
--- a/boards/nordic/nrf7002dk/nrf5340_cpuapp_common.dtsi
+++ b/boards/nordic/nrf7002dk/nrf5340_cpuapp_common.dtsi
@@ -104,7 +104,7 @@
 		status0-gpios = <&gpio0 30 GPIO_ACTIVE_HIGH>;
 		grant-gpios = <&gpio0 24 (GPIO_PULL_DOWN | GPIO_ACTIVE_LOW)>;
 		swctrl1-gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
-		btrf-switch-gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
+		srrf-switch-gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
 	};
 
 	nordic_wlan0: nordic_wlan0 {

--- a/boards/nordic/nrf7002dk/nrf5340_cpuapp_nrf7001_common.dtsi
+++ b/boards/nordic/nrf7002dk/nrf5340_cpuapp_nrf7001_common.dtsi
@@ -104,7 +104,7 @@
 		status0-gpios = <&gpio0 30 GPIO_ACTIVE_HIGH>;
 		grant-gpios = <&gpio0 24 (GPIO_PULL_DOWN | GPIO_ACTIVE_LOW)>;
 		swctrl1-gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
-		btrf-switch-gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
+		srrf-switch-gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
 	};
 
 	nordic_wlan0: nordic_wlan0 {

--- a/boards/shields/nrf7002eb/nrf7002eb_coex.overlay
+++ b/boards/shields/nrf7002eb/nrf7002eb_coex.overlay
@@ -10,5 +10,6 @@
 		status0-gpios = <&gpio1 1 GPIO_ACTIVE_HIGH>;
 		req-gpios = <&gpio1 0 GPIO_ACTIVE_HIGH>;
 		grant-gpios = <&edge_connector 15 (GPIO_PULL_DOWN | GPIO_ACTIVE_LOW)>;
+		srrf-switch-gpios = <&gpio1 13 GPIO_ACTIVE_HIGH>;
 	};
 };

--- a/boards/shields/nrf7002ek/nrf7002ek_coex.overlay
+++ b/boards/shields/nrf7002ek/nrf7002ek_coex.overlay
@@ -11,5 +11,6 @@
 		req-gpios = <&arduino_header 9 GPIO_ACTIVE_HIGH>;   /* D3 */
 		grant-gpios = <&arduino_header 10 (GPIO_PULL_DOWN | GPIO_ACTIVE_LOW)>;    /* D4 */
 		swctrl1-gpios = <&arduino_header 12 GPIO_ACTIVE_HIGH>;  /* D6 */
+		srrf-switch-gpios = <&arduino_header 14 GPIO_ACTIVE_HIGH>;  /* D8 */
 	};
 };

--- a/boards/shields/nrf7002ek_nrf7000/nrf7002ek_nrf7000_coex.overlay
+++ b/boards/shields/nrf7002ek_nrf7000/nrf7002ek_nrf7000_coex.overlay
@@ -11,5 +11,6 @@
 		req-gpios = <&arduino_header 9 GPIO_ACTIVE_HIGH>;   /* D3 */
 		grant-gpios = <&arduino_header 10 (GPIO_PULL_DOWN | GPIO_ACTIVE_LOW)>;    /* D4 */
 		swctrl1-gpios = <&arduino_header 12 GPIO_ACTIVE_HIGH>;  /* D6 */
+		srrf-switch-gpios = <&arduino_header 14 GPIO_ACTIVE_HIGH>;  /* D8 */
 	};
 };

--- a/boards/shields/nrf7002ek_nrf7001/nrf7002ek_nrf7001_coex.overlay
+++ b/boards/shields/nrf7002ek_nrf7001/nrf7002ek_nrf7001_coex.overlay
@@ -11,5 +11,6 @@
 		req-gpios = <&arduino_header 9 GPIO_ACTIVE_HIGH>;   /* D3 */
 		grant-gpios = <&arduino_header 10 (GPIO_PULL_DOWN | GPIO_ACTIVE_LOW)>;    /* D4 */
 		swctrl1-gpios = <&arduino_header 12 GPIO_ACTIVE_HIGH>;  /* D6 */
+		srrf-switch-gpios = <&arduino_header 14 GPIO_ACTIVE_HIGH>;  /* D8 */
 	};
 };

--- a/drivers/wifi/nrf700x/Kconfig
+++ b/drivers/wifi/nrf700x/Kconfig
@@ -241,14 +241,14 @@ config NRF700X_ON_SPI
 	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF700X_SPI))
 	select SPI
 
-
+# Wi-Fi and SR Coexistence Hardware configuration.
 config NRF700X_SR_COEX
 	bool "Enable Wi-Fi and SR coexistence support"
 	def_bool $(dt_nodelabel_enabled,nrf_radio_coex)
 
-# RF switch based coexistence
+# GPIO configuration to control SR side RF switch position.
 config NRF700X_SR_COEX_RF_SWITCH
-	def_bool $(dt_nodelabel_has_prop,nrf_radio_coex,btrf-switch-gpios)
+	def_bool $(dt_nodelabel_has_prop,nrf_radio_coex,srrf-switch-gpios)
 
 config NRF700X_WORKQ_STACK_SIZE
 	int "Stack size for workqueue"

--- a/drivers/wifi/nrf700x/src/coex.c
+++ b/drivers/wifi/nrf700x/src/coex.c
@@ -43,7 +43,7 @@ static struct nrf_wifi_ctx_zep *rpu_ctx = &rpu_drv_priv_zep.rpu_ctx_zep;
 #ifdef CONFIG_NRF700X_SR_COEX_RF_SWITCH
 	#define NRF_RADIO_COEX_NODE DT_NODELABEL(nrf_radio_coex)
 	static const struct gpio_dt_spec sr_rf_switch_spec =
-	GPIO_DT_SPEC_GET(NRF_RADIO_COEX_NODE, btrf_switch_gpios);
+	GPIO_DT_SPEC_GET(NRF_RADIO_COEX_NODE, srrf_switch_gpios);
 #endif /* CONFIG_NRF700X_SR_COEX_RF_SWITCH */
 
 /* PTA registers configuration of Coexistence Hardware */
@@ -289,3 +289,45 @@ int nrf_wifi_coex_hw_reset(void)
 
 	return 0;
 }
+
+#ifdef CONFIG_NRF700X_SR_COEX_RF_SWITCH
+int sr_gpio_config(void)
+{
+	int ret;
+
+	if (!device_is_ready(sr_rf_switch_spec.port)) {
+		return -ENODEV;
+	}
+
+	ret = gpio_pin_configure_dt(&sr_rf_switch_spec, GPIO_OUTPUT);
+	if (ret) {
+		LOG_ERR("SR GPIO configuration failed %d", ret);
+	}
+
+	return ret;
+}
+
+int sr_gpio_remove(void)
+{
+	int ret;
+
+	ret = gpio_pin_configure_dt(&sr_rf_switch_spec, GPIO_DISCONNECTED);
+	if (ret) {
+		LOG_ERR("SR GPIO remove failed %d", ret);
+	}
+
+	return ret;
+}
+
+int sr_ant_switch(unsigned int ant_switch)
+{
+	int ret;
+
+	ret = gpio_pin_set_dt(&sr_rf_switch_spec, ant_switch & 0x1);
+	if (ret) {
+		LOG_ERR("SR GPIO set failed %d", ret);
+	}
+
+	return ret;
+}
+#endif /* CONFIG_NRF700X_SR_COEX_RF_SWITCH */

--- a/drivers/wifi/nrf700x/src/qspi/inc/rpu_hw_if.h
+++ b/drivers/wifi/nrf700x/src/qspi/inc/rpu_hw_if.h
@@ -55,5 +55,7 @@ int rpu_disable(void);
 
 #ifdef CONFIG_NRF700X_SR_COEX_RF_SWITCH
 int sr_ant_switch(unsigned int ant_switch);
+int sr_gpio_remove(void);
+int sr_gpio_config(void);
 #endif /* CONFIG_NRF700X_SR_COEX_RF_SWITCH */
 #endif /* __RPU_HW_IF_H_ */

--- a/drivers/wifi/nrf700x/src/qspi/src/rpu_hw_if.c
+++ b/drivers/wifi/nrf700x/src/qspi/src/rpu_hw_if.c
@@ -35,12 +35,6 @@ GPIO_DT_SPEC_GET(NRF7002_NODE, iovdd_ctrl_gpios);
 static const struct gpio_dt_spec bucken_spec =
 GPIO_DT_SPEC_GET(NRF7002_NODE, bucken_gpios);
 
-#ifdef CONFIG_NRF700X_SR_COEX_RF_SWITCH
-#define NRF_RADIO_COEX_NODE DT_NODELABEL(nrf_radio_coex)
-static const struct gpio_dt_spec sr_rf_switch_spec =
-GPIO_DT_SPEC_GET(NRF_RADIO_COEX_NODE, btrf_switch_gpios);
-#endif /* CONFIG_NRF700X_SR_COEX_RF_SWITCH */
-
 char blk_name[][15] = { "SysBus",   "ExtSysBus",	   "PBus",	   "PKTRAM",
 			       "GRAM",	   "LMAC_ROM",	   "LMAC_RET_RAM", "LMAC_SRC_RAM",
 			       "UMAC_ROM", "UMAC_RET_RAM", "UMAC_SRC_RAM" };
@@ -175,45 +169,6 @@ out:
 	return ret;
 }
 
-
-static int sr_gpio_config(void)
-{
-#ifdef CONFIG_NRF700X_SR_COEX_RF_SWITCH
-	int ret;
-
-	if (!device_is_ready(sr_rf_switch_spec.port)) {
-		return -ENODEV;
-	}
-
-	ret = gpio_pin_configure_dt(&sr_rf_switch_spec, GPIO_OUTPUT);
-	if (ret) {
-		LOG_ERR("SR GPIO configuration failed %d", ret);
-		return ret;
-	}
-
-	return ret;
-#else
-	return 0;
-#endif /* CONFIG_NRF700X_SR_COEX_RF_SWITCH */
-}
-
-static int sr_gpio_remove(void)
-{
-#ifdef CONFIG_NRF700X_SR_COEX_RF_SWITCH
-	int ret;
-
-	ret = gpio_pin_configure_dt(&sr_rf_switch_spec, GPIO_DISCONNECTED);
-	if (ret) {
-		LOG_ERR("SR GPIO remove failed %d", ret);
-		return ret;
-	}
-
-	return ret;
-#else
-	return 0;
-#endif
-}
-
 static int rpu_gpio_config(void)
 {
 	int ret;
@@ -318,21 +273,6 @@ static int rpu_pwroff(void)
 
 	return ret;
 }
-
-#ifdef CONFIG_NRF700X_SR_COEX_RF_SWITCH
-int sr_ant_switch(unsigned int ant_switch)
-{
-	int ret;
-
-	ret = gpio_pin_set_dt(&sr_rf_switch_spec, ant_switch & 0x1);
-	if (ret) {
-		LOG_ERR("SR GPIO set failed %d", ret);
-		return ret;
-	}
-
-	return ret;
-}
-#endif /* CONFIG_NRF700X_SR_COEX_RF_SWITCH */
 
 int rpu_read(unsigned int addr, void *data, int len)
 {
@@ -481,22 +421,26 @@ int rpu_init(void)
 
 	CALL_RPU_FUNC(rpu_gpio_config);
 
+#ifdef CONFIG_NRF700X_SR_COEX_RF_SWITCH
 	ret = sr_gpio_config();
 	if (ret) {
-		goto rpu_gpio_remove;
+		goto remove_sr_gpio;
 	}
-
+#endif
 	ret = rpu_pwron();
 	if (ret) {
-		goto sr_gpio_remove;
+		goto remove_rpu_gpio;
 	}
 
 	return 0;
 
-sr_gpio_remove:
-	sr_gpio_remove();
-rpu_gpio_remove:
+remove_rpu_gpio:
 	rpu_gpio_remove();
+
+#ifdef CONFIG_NRF700X_SR_COEX_RF_SWITCH
+remove_sr_gpio:
+	sr_gpio_remove();
+#endif
 out:
 	return ret;
 }
@@ -527,8 +471,9 @@ int rpu_disable(void)
 
 	CALL_RPU_FUNC(rpu_pwroff);
 	CALL_RPU_FUNC(rpu_gpio_remove);
+#ifdef CONFIG_NRF700X_SR_COEX_RF_SWITCH
 	CALL_RPU_FUNC(sr_gpio_remove);
-
+#endif
 	qdev = NULL;
 	cfg = NULL;
 

--- a/dts/bindings/radio_coex/nordic,nrf700x-coex.yaml
+++ b/dts/bindings/radio_coex/nordic,nrf700x-coex.yaml
@@ -36,9 +36,9 @@ properties:
             GPIO of the SOC controlling the Priority (STATUS1) pin (in 4-wire
             coex case) of the nRF7002
 
-    btrf-switch-gpios:
+    srrf-switch-gpios:
         type: phandle-array
         required: false
         description: |
-            GPIO of the RF Switch to control BLE RF output to either BLE Antenna
+            GPIO of the RF Switch to control SR RF output to either SR Antenna
             or shared Antenna with Wi-Fi

--- a/dts/bindings/radio_coex/nordic,nrf700x-coex.yaml
+++ b/dts/bindings/radio_coex/nordic,nrf700x-coex.yaml
@@ -10,35 +10,33 @@ compatible: "nordic,nrf700x-coex"
 include: base.yaml
 
 properties:
-    req-gpios:
-        type: phandle-array
-        required: true
-        description: |
-            GPIO of the SOC connected to the PTA's REQUEST pin.
+  req-gpios:
+    type: phandle-array
+    required: true
+    description: |
+        GPIO of the SOC connected to the PTA's REQUEST pin.
 
-    status0-gpios:
-        type: phandle-array
-        required: true
-        description: |
-            GPIO of the SOC connected to the PTA's PRIORITY pin.
-            This GPIO is also used to indicate direction (TX/RX).
+  status0-gpios:
+    type: phandle-array
+    required: true
+    description: |
+        GPIO of the SOC connected to the PTA's PRIORITY pin.
+        This GPIO is also used to indicate direction (TX/RX).
 
-    grant-gpios:
-        type: phandle-array
-        required: true
-        description: |
-            GPIO of the SOC connected to the PTA's GRANT pin.
+  grant-gpios:
+    type: phandle-array
+    required: true
+    description: |
+        GPIO of the SOC connected to the PTA's GRANT pin.
 
-    swctrl1-gpios:
-        type: phandle-array
-        required: false
-        description: |
-            GPIO of the SOC controlling the Priority (STATUS1) pin (in 4-wire
-            coex case) of the nRF7002
+  swctrl1-gpios:
+    type: phandle-array
+    description: |
+        GPIO of the SOC controlling the Priority (STATUS1) pin (in 4-wire
+        coex case) of the nRF7002
 
-    srrf-switch-gpios:
-        type: phandle-array
-        required: false
-        description: |
-            GPIO of the RF Switch to control SR RF output to either SR Antenna
-            or shared Antenna with Wi-Fi
+  srrf-switch-gpios:
+    type: phandle-array
+    description: |
+        GPIO of the RF Switch to control SR RF output to either SR Antenna
+        or shared Antenna with Wi-Fi

--- a/samples/wifi/ble_coex/src/main.c
+++ b/samples/wifi/ble_coex/src/main.c
@@ -478,6 +478,10 @@ int main(void)
 		LOG_INF("Disconnecting BLE\n");
 		bt_throughput_test_exit();
 	}
+
+	/* Disable coexistence hardware */
+	nrf_wifi_coex_hw_reset();
+
 	LOG_INF("\nCoexistence test complete\n");
 
 	return 0;


### PR DESCRIPTION
[SHEL-2535] Rename bt* to sr*. Avoid duplication of functions
and restructure the code.

[SHEL-2535]: https://nordicsemi.atlassian.net/browse/SHEL-2535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ