### PR TITLE
scripts: add integration quarantine part 8

### DIFF
--- a/scripts/quarantine_integration.yaml
+++ b/scripts/quarantine_integration.yaml
@@ -1037,3 +1037,48 @@
   platforms:
     - qemu_cortex_m3
   comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - lib.fprotect.sys_init_fprotect
+    - drivers.fprotect.positive
+    - drivers.fprotect.negative
+  platforms:
+    - nrf52840dk_nrf52840
+    - nrf52dk_nrf52832
+    - nrf5340dk_nrf5340_cpuapp
+    - nrf9160dk_nrf9160
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - fw_info.core
+  platforms:
+    - nrf52840dk_nrf52840
+    - nrf52dk_nrf52832
+    - nrf5340dk_nrf5340_cpuapp
+    - nrf9160dk_nrf9160
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - flash_patch.flash_patch_off
+    - flash_patch.flash_patch_on
+  platforms:
+    - nrf52833dk_nrf52833
+    - nrf52840dk_nrf52840
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - lpuart.two_chip_test_busy_sim
+    - lpuart.two_chip_test_debug
+  platforms:
+    - nrf9160dk_nrf52840
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - lpuart.loopback_busy_sim
+    - lpuart.loopback_busy_sim_no_hfxo
+    - lpuart.loopback_no_hfxo
+    - lpuart.two_chip_test_busy_sim
+    - lpuart.two_chip_test_debug
+  platforms:
+    - nrf9160dk_nrf9160
+  comment: "Configurations excluded to limit resources usage in integration builds"


### PR DESCRIPTION
To limit integration scope.
For:
nrf/tests/drivers/fprotect
nrf/tests/subsys/fw_info
nrf/tests/drivers/flash_patch
nrf/tests/drivers/lpuart