### PR TITLE
mainfest: Pull in sdk-zephyr with UARTE new tests commit revert

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 70729fcad3c56dd6f84e82c5f2b0b62e99b4301c
+      revision: 26c7f37b9e4efe371ee40873fb409cacd30cdf11
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Reverts:
"[nrf fromlist] tests: Extend tests coverage for UARTE driver"