### PR TITLE
manifest: smp_svr@nRF54l15pdk with external flash

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: c22c9c258ce776b88dac8a917ab13f46a4c7db85
+      revision: 849d51f27998807371199e36cf7995652b4864a1
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -131,7 +131,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 86af2de75205ec5f2c846a2393934360de22fde4
+      revision: 78bc87c46a9501cacd57003271968a554d30e0ee
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR


### PR DESCRIPTION
Configuration for MCUboot and smp_svr which
allows to use nRF54L15pdk external flash as location for the secondary partition.


~~west build  -b nrf54l15pdk_nrf54l15_cpuapp -d build/smp_svr_54l zephyr/samples/subsys/mgmt/mcumgr/smp_svr/ -- -DEXTRA_CONF_FILE=overlay-bt.conf -DCONFIG_PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY=y -DCONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y  -DDTC_OVERLAY_FILE=boards/nrf54l15pdk_ext_flash.overlay -Dmcuboot_EXTRA_DTC_OVERLAY_FILE=~/codedev/NCS/zephyr/samples/subsys/mgmt/mcumgr/smp_svr/boards/nrf54l15pdk_ext_flash.overlay -Dmcuboot_CONF_FILE=boards/nrf54l15pdk_ext_flash.conf~~


~~For transferring extra overlay an absolute path must be used as build system can't handle any relative path for subimages.~~


Build commndline:
``` console
west build  -b nrf54l15pdk_nrf54l15_cpuapp -d build/smp_svr_54l zephyr/samples/subsys/mgmt/mcumgr/smp_svr/ -- -DEXTRA_CONF_FILE=overlay-bt.conf -DCONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y  -DDTC_OVERLAY_FILE=boards/nrf54l15pdk_nrf54l15_cpuapp_ext_flash.overlay -Dmcuboot_EXTRA_DTC_OVERLAY_FILE=boards/nrf54l15pdk_nrf54l15_cpuapp_ext_flash.overlay -Dmcuboot_CONF_FILE=boards/nrf54l15pdk_nrf54l15_cpuapp_ext_flash.conf
```
or
``` console
west build  -b nrf54l15pdk_nrf54l15_cpuapp -d build/smp_svr_54l_3 zephyr/samples/subsys/mgmt/mcumgr/smp_svr -T sample.mcumgr.smp_svr.bt.nrf54l15pdk.ext_flash
```
