### PR TITLE
manifest: update sdk-zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 22e2d8781ef57c215b49539ae1b16fcd42b331cf
+      revision: pull/1616/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Include following change:

NCSIDB-1249: Build warning when disabling IPv6
https://github.com/nrfconnect/sdk-zephyr/pull/1616