### PR TITLE
applications: nrf5340_audio: doc: Remove buildprog from DFU chapter

### DIFF
--- a/applications/nrf5340_audio/doc/fota.rst
+++ b/applications/nrf5340_audio/doc/fota.rst
@@ -7,14 +7,12 @@ Configuring and testing FOTA upgrades for nRF5340 Audio applications
    :local:
    :depth: 2
 
-All nRF5340 Audio applications share the same configuration and testing procedures for FOTA upgrades.
+The nRF5340 Audio applications all support FOTA upgrades, and the application implementation is based on the procedure described in :ref:`ug_nrf53_developing_ble_fota`.
 
 Requirements for FOTA
 *********************
 
-To test Firmware Over-The-Air (FOTA), you need an Android or iOS device with the `nRF Connect Device Manager`_ app installed.
-
-To enable the external flash DFU and do FOTA upgrades for the application core and the network core at the same time, you need an external flash shield.
+If the application is running on the nRF5340 Audio DK, you need an external flash shield to upgrade both the application and network core at the same time.
 See `Requirements for external flash memory DFU`_ in the nRF5340 Audio DK Hardware documentation for more information.
 
 .. _nrf53_audio_app_configuration_configure_fota:
@@ -22,54 +20,37 @@ See `Requirements for external flash memory DFU`_ in the nRF5340 Audio DK Hardwa
 Configuring FOTA upgrades
 *************************
 
+The nRF5340 Audio application supports two strategies for upgrading the applications on the application and network core: single-image and multi-image.
+You control which of the two strategies is used by setting the Kconfig :kconfig:option:`CONFIG_AUDIO_DFU` to the appropriate setting.
+
+* Single-image upgrade - Uses the internal flash to upgrade either the application core or network core separately.
+  You can select this method by setting :kconfig:option:`CONFIG_AUDIO_DFU` to ``1``.
+* Multi-image upgrade - Uses external flash to upgrade both the application and network core at the same time.
+  You can select this method by setting :kconfig:option:`CONFIG_AUDIO_DFU` to ``2``.
+  See :ref:`multi-image DFU <ug_nrf5340_multi_image_dfu>` for more information about the process.
+
 .. caution::
-	Firmware based on the |NCS| versions earlier than v2.1.0 does not support DFU.
-	FOTA is not available for those versions.
+   Using the single-image upgrade strategy carries risk of the device being in a state where the application core firmware and network core firmware are no longer compatible, which can result in a bricked device.
+   For devices where FOTA is the only DFU method available, multi-image upgrades are recommended to ensure compatibility between the cores.
+   Make sure to evaluate the risks for your device when selecting the FOTA method.
 
-	You can test performing separate application and network core upgrades, but for production, both cores must be updated at the same time.
-	When updates take place in the inter-core communication module (HCI IPC), communication between the cores will break if they are not updated together.
+Updating the SoftDevice
+=======================
 
-You can configure Firmware Over-The-Air (FOTA) upgrades to replace the applications on both the application core and the network core.
-The nRF5340 Audio applications support the following types of DFU flash memory layouts:
-
-* Internal flash memory layout - which supports only single-image DFU.
-* External flash memory layout - which supports :ref:`multi-image DFU <ug_nrf5340_multi_image_dfu>`.
-
-
-Enabling FOTA upgrades
-**********************
-
-The FOTA upgrades are only available when :ref:`nrf53_audio_app_building_script`.
-With the appropriate parameters provided, the :file:`buildprog.py` Python script will add overlay files for the given DFU type.
-To enable the desired FOTA functions:
-
-* To define flash memory layout, include the ``-m internal`` parameter for the internal layout (when using the ``release`` application version) or the ``-m external`` parameter for the external layout (when using either ``release`` or ``debug``).
-* To use the minimal size network core bootloader, add the ``-M`` parameter.
-
-For the full list of parameters and examples, see the :ref:`nrf53_audio_app_building_script_running` section.
-
-FOTA build files
-================
-
-The generated FOTA build files use the following naming patterns:
-
-* For multi-image DFU, the file is called ``dfu_application.zip``.
-  This file updates two cores with one single file.
-* For single-image DFU, the bin file for the application core is called ``app_update.bin``.
-  The bin file for the network core is called ``net_core_app_update.bin``.
-  In this scenario, the cores are updated one by one with two separate files in two actions.
-
-See :ref:`app_build_output_files` for more information about the image files.
+Both FOTA upgrade methods support updating the SoftDevice on the network core.
+However, the current default build options for the SoftDevice create a binary that is too large to run on the network core together with a bootloader.
+To reduce the size of the SoftDevice binary, you can disable unused features in the SoftDevice.
+See :ref:`softdevice_controller` documentation for more information.
 
 Entering the DFU mode
 =====================
 
 The |NCS| uses :ref:`SMP server and mcumgr <zephyr:device_mgmt>` as the DFU backend.
-Unlike the CIS and BIS modes for gateway and headsets, the DFU mode is advertising using the SMP server service.
-For this reason, to enter the DFU mode, you must long press **BTN 4** during each device startup to have the nRF5340 Audio DK enter the DFU mode.
+The SMP server service is separated from CIS and BIS services, and is only advertised when the application is in the DFU mode.
+To enter the DFU mode, press **BTN 4** on the nRF5340 Audio DK during startup.
 
 To identify the devices before the DFU takes place, the DFU mode advertising names mention the device type directly.
-The names follow the pattern in which the device *ROLE* is inserted before the ``_DFU`` suffix.
+The names follow the pattern in which the device role is inserted between the device name and the ``_DFU`` suffix.
 For example:
 
 * Gateway: ``NRF5340_AUDIO_GW_DFU``
@@ -86,44 +67,6 @@ The first part of these names is based on :kconfig:option:`CONFIG_BT_DEVICE_NAME
 .. _nrf53_audio_unicast_client_app_testing_steps_fota:
 
 Testing FOTA upgrades
-*********************
+=====================
 
-`nRF Connect Device Manager`_ can be used for testing FOTA upgrades.
-The procedure for upgrading the firmware is identical for all applications.
-
-Testing FOTA upgrades on a headset device
-=========================================
-
-You can test upgrading the firmware on both cores at the same time on a headset device by completing the following steps:
-
-1. Make sure you have :ref:`configured the application for FOTA <nrf53_audio_app_configuration_configure_fota>`.
-#. Install `nRF Connect Device Manager`_ on your Android or iOS device.
-#. Connect an external flash shield to the headset.
-#. Make sure the headset runs a firmware that supports DFU using external flash memory.
-   One way of doing this is to connect the headset to the USB port, turn it on, and then run this command:
-
-   .. code-block:: console
-
-      python buildprog.py -c both -b debug -d headset --pristine -m external -p
-
-   .. note::
-      When using the FOTA related functionality in the :file:`buildprog.py` script on Linux, the ``python`` command must execute Python 3.
-
-#. Use the :file:`buildprog.py` script to create a zip file that contains new firmware for both cores:
-
-   .. code-block:: console
-
-      python buildprog.py -c both -b debug -d headset --pristine -m external
-
-#. Transfer the generated file to your Android or iOS device, depending on the DFU scenario.
-   See the `FOTA build files`_ section for information about FOTA file name patterns.
-   For transfer, you can use cloud services like Google Drive for Android or iCloud for iOS.
-#. Enter the DFU mode by pressing and holding down **RESET** and **BTN 4** at the same time, and then releasing **RESET** while continuing to hold down **BTN 4** for a couple more seconds.
-#. Open `nRF Connect Device Manager`_ and look for ``NRF5340_AUDIO_HL_DFU`` in the scanned devices window.
-   The headset is left by default.
-#. Tap on :guilabel:`NRF5340_AUDIO_HL_DFU` and then on the downward arrow icon at the bottom of the screen.
-#. In the :guilabel:`Firmware Upgrade` section, tap :guilabel:`SELECT FILE`.
-#. Select the file you transferred to the device.
-#. Tap :guilabel:`START` and check :guilabel:`Confirm only` in the notification.
-#. Tap :guilabel:`START` again to start the DFU process.
-#. When the DFU has finished, verify that the new application core and network core firmware works properly.
+To test FOTA for the nRF5340 Audio application, ensure the application is in the DFU mode, and then follow the testing steps in the FOTA over Bluetooth Low Energy section of :ref:`ug_nrf53_developing_ble_fota` (you can skip the configuration steps).

--- a/doc/nrf/device_guides/working_with_nrf/nrf53/nrf5340.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf53/nrf5340.rst
@@ -537,6 +537,7 @@ See the following instructions.
          Therefore, you must recover the network core first.
          Otherwise, if you recover the application core first and the network core last, the binary written to the application core is deleted and readback protection is enabled again after a reset.
 
+.. _ug_nrf53_developing_ble_fota:
 .. include:: ../nrf52/developing.rst
    :start-after: fota_upgrades_intro_start
    :end-before: fota_upgrades_intro_end


### PR DESCRIPTION
Remove instructions using the buildprog script from DFU chapter. Update the DFU chapter to explain how to build the application with DFU support for SDC.