### PR TITLE
samples: CoreMark: Increase CoreMark iterations for moonlight platforms

### DIFF
--- a/modules/coremark/Kconfig
+++ b/modules/coremark/Kconfig
@@ -13,7 +13,7 @@ if COREMARK
 config COREMARK_ITERATIONS
 	int "Number of iterations to run"
 	range 10 10000
-	default 1000
+	default 2000
 	help
 	  Specify the number of iterations to run the benchmark.
 	  CoreMark should execute for at least 10 seconds to have valid results.

--- a/samples/benchmarks/coremark/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/benchmarks/coremark/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -3,4 +3,4 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 
-CONFIG_BOARD_ENABLE_CPUNET=y
+CONFIG_COREMARK_ITERATIONS=4000

--- a/samples/benchmarks/coremark/prj.conf
+++ b/samples/benchmarks/coremark/prj.conf
@@ -6,8 +6,6 @@
 # Common coremark configuration
 CONFIG_COREMARK=y
 
-CONFIG_COREMARK_ITERATIONS=2000
-
 # Increse if number of threads increases.
 CONFIG_MAIN_STACK_SIZE=4096
 


### PR DESCRIPTION
Increase iterations in order to meet required test duration of 10s.

Jira: none