### PR TITLE
samples: matter: Enable Test Event Triggers by default

### DIFF
--- a/doc/nrf/protocols/matter/end_product/test_event_triggers.rst
+++ b/doc/nrf/protocols/matter/end_product/test_event_triggers.rst
@@ -37,7 +37,7 @@ Default test event triggers
 ***************************
 
 You can use the pre-defined common test event triggers in your application.
-To enable them, set the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_TEST_EVENT_TRIGGERS_REGISTER_DEFAULTS` Kconfig option to ``y``.
+To disable them, set the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_TEST_EVENT_TRIGGERS_REGISTER_DEFAULTS` Kconfig option to ``n``.
 
 The following table lists the available triggers and their activation codes:
 
@@ -264,6 +264,9 @@ For example, you can register and use the ``OTATestEventTriggerHandler`` handler
 
 Usage
 *****
+
+The Matter test event triggers feature is enabled by default for all Matter samples.
+To disable it, set the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_TEST_EVENT_TRIGGERS` kconfig option to ``n``.
 
 To trigger a specific event on the device, run the following command:
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -373,7 +373,7 @@ Matter samples
 
 * Added:
 
-  * Test event triggers to all Matter samples.
+  * Test event triggers to all Matter samples and enabled them by default.
     By utilizing the test event triggers, you can simulate various operational conditions and responses in your Matter device without the need for external setup.
 
     To get started with using test event triggers in your Matter samples and to understand the capabilities of this feature, refer to the :ref:`ug_matter_test_event_triggers` page.

--- a/samples/matter/common/src/Kconfig
+++ b/samples/matter/common/src/Kconfig
@@ -56,6 +56,7 @@ config NCS_SAMPLE_MATTER_SETTINGS_SHELL
 
 config NCS_SAMPLE_MATTER_TEST_EVENT_TRIGGERS
 	bool "Test event triggers support"
+	default y
 	help
 	  Enables support for test event triggers for the specific use-cases.
 
@@ -69,6 +70,7 @@ config NCS_SAMPLE_MATTER_TEST_EVENT_TRIGGERS_MAX
 config NCS_SAMPLE_MATTER_TEST_EVENT_TRIGGERS_REGISTER_DEFAULTS
 	bool "Register default triggers for Matter sample"
 	depends on NCS_SAMPLE_MATTER_TEST_EVENT_TRIGGERS
+	default y
 	help
 	  Automatically register default triggers such as factory reset,
 	  device reboot, OTA start query.


### PR DESCRIPTION
Enabled Test Event Triggers feature by default in all Matter samples and applications. Enabled also the pre-defined test event triggers.