### PR TITLE
lib: location: gnss: Fix setting of 'running' variable

### DIFF
--- a/lib/location/method_gnss.c
+++ b/lib/location/method_gnss.c
@@ -1273,9 +1273,9 @@ int method_gnss_location_get(const struct location_request_info *request)
 		return err;
 	}
 
-	k_work_submit_to_queue(location_core_work_queue_get(), &method_gnss_prepare_work);
-
 	running = true;
+
+	k_work_submit_to_queue(location_core_work_queue_get(), &method_gnss_prepare_work);
 
 	return 0;
 }


### PR DESCRIPTION
In method_gnss_location_get(), 'running' variable is set after submitting method_gnss_prepare_work_fn() into location_api_workq. It has been seen that 'running' is not set when
method_gnss_prepare_work_fn() is executed meaning that location_request() was called from a lower priority thread than location_api_workq. We need to set 'running' before submitting method_gnss_prepare_work_fn() into location_api_workq.

Jira: NCSDK-27001