### PR TITLE
cmake: extensions: Add support for FILE_SUFFIX with PM

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -231,47 +231,84 @@ Please provide one of following: CONF_FILES")
   if(NCS_FILE_PM)
     set(PM_FILE_PREFIX pm_static)
 
-    # Prepare search for pm_static_board@ver_build.yml
-    zephyr_build_string(filename
-                        BOARD ${ZEPHYR_FILE_BOARD}
-                        BOARD_REVISION ${ZEPHYR_FILE_BOARD_REVISION}
-                        BUILD ${ZEPHYR_FILE_BUILD}
-    )
-    set(filename_list ${PM_FILE_PREFIX}_${filename})
+    if(DEFINED FILE_SUFFIX)
+      # Prepare search for pm_static_board@ver_suffix.yml
+      zephyr_build_string(filename
+                          BOARD ${ZEPHYR_FILE_BOARD}
+                          BOARD_REVISION ${ZEPHYR_FILE_BOARD_REVISION}
+      )
+      set(filename_list ${PM_FILE_PREFIX}_${filename})
 
-    # Prepare search for pm_static_board_build.yml
-    zephyr_build_string(filename
-                        BOARD ${ZEPHYR_FILE_BOARD}
-                        BUILD ${ZEPHYR_FILE_BUILD}
-    )
-    list(APPEND filename_list ${PM_FILE_PREFIX}_${filename})
+      # Prepare search for pm_static_board_suffix.yml
+      zephyr_build_string(filename
+                          BOARD ${ZEPHYR_FILE_BOARD}
+      )
+      list(APPEND filename_list ${PM_FILE_PREFIX}_${filename})
 
-    # Prepare search for pm_static_build.yml
-    # Note that BOARD argument is used to position suffix accordingly
-    zephyr_build_string(filename
-                        BOARD ${ZEPHYR_FILE_BUILD}
-    )
-    list(APPEND filename_list ${PM_FILE_PREFIX}_${filename})
+      list(APPEND filename_list ${PM_FILE_PREFIX})
+    else()
+      # Prepare search for pm_static_board@ver_build.yml
+      zephyr_build_string(filename
+                          BOARD ${ZEPHYR_FILE_BOARD}
+                          BOARD_REVISION ${ZEPHYR_FILE_BOARD_REVISION}
+                          BUILD ${ZEPHYR_FILE_BUILD}
+      )
+      set(filename_list ${PM_FILE_PREFIX}_${filename})
 
-    # Prepare search for pm_static.yml
-    list(APPEND filename_list ${PM_FILE_PREFIX})
+      # Prepare search for pm_static_board_build.yml
+      zephyr_build_string(filename
+                          BOARD ${ZEPHYR_FILE_BOARD}
+                          BUILD ${ZEPHYR_FILE_BUILD}
+      )
+      list(APPEND filename_list ${PM_FILE_PREFIX}_${filename})
+
+      # Prepare search for pm_static_build.yml
+      # Note that BOARD argument is used to position suffix accordingly
+      zephyr_build_string(filename
+                          BOARD ${ZEPHYR_FILE_BUILD}
+      )
+      list(APPEND filename_list ${PM_FILE_PREFIX}_${filename})
+
+      # Prepare search for pm_static.yml
+      list(APPEND filename_list ${PM_FILE_PREFIX})
+    endif()
+
     list(REMOVE_DUPLICATES filename_list)
 
     foreach(filename ${filename_list})
       if(DEFINED NCS_FILE_DOMAIN)
-        if(EXISTS ${NCS_FILE_CONF_FILES}/${filename}_${NCS_FILE_DOMAIN}.yml)
-          set(${NCS_FILE_PM} ${NCS_FILE_CONF_FILES}/${filename}_${NCS_FILE_DOMAIN}.yml PARENT_SCOPE)
-          break()
+        if(DEFINED FILE_SUFFIX)
+          set(filename_check ${NCS_FILE_CONF_FILES}/${filename}_${NCS_FILE_DOMAIN}.yml)
+          zephyr_file_suffix(filename_check SUFFIX ${FILE_SUFFIX})
+
+          if(EXISTS ${filename_check})
+            set(${NCS_FILE_PM} ${filename_check} PARENT_SCOPE)
+            break()
+          endif()
+
+        else()
+          if(EXISTS ${NCS_FILE_CONF_FILES}/${filename}_${NCS_FILE_DOMAIN}.yml)
+            set(${NCS_FILE_PM} ${NCS_FILE_CONF_FILES}/${filename}_${NCS_FILE_DOMAIN}.yml PARENT_SCOPE)
+            break()
+          endif()
         endif()
       endif()
 
-      if(EXISTS ${NCS_FILE_CONF_FILES}/${filename}.yml)
-        set(${NCS_FILE_PM} ${NCS_FILE_CONF_FILES}/${filename}.yml PARENT_SCOPE)
-        break()
+      if(DEFINED FILE_SUFFIX)
+        set(filename_check ${NCS_FILE_CONF_FILES}/${filename}.yml)
+        zephyr_file_suffix(filename_check SUFFIX ${FILE_SUFFIX})
+        if(EXISTS ${filename_check})
+          set(${NCS_FILE_PM} ${filename_check} PARENT_SCOPE)
+          break()
+        endif()
+      else()
+        if(EXISTS ${NCS_FILE_CONF_FILES}/${filename}.yml)
+          set(${NCS_FILE_PM} ${NCS_FILE_CONF_FILES}/${filename}.yml PARENT_SCOPE)
+          break()
+        endif()
       endif()
     endforeach()
   endif()
-
 endfunction()
 
 #

--- a/cmake/multi_image.cmake
+++ b/cmake/multi_image.cmake
@@ -341,7 +341,13 @@ function(add_child_image_from_source)
       # Check for configuration fragment. The contents of these are appended
       # to the project configuration, as opposed to the CONF_FILE which is used
       # as the base configuration.
-      if(NOT "${CONF_FILE_BUILD_TYPE}" STREQUAL "")
+      if(DEFINED ${ACI_NAME}_FILE_SUFFIX)
+        # Child/parent image does not support a prefix for the main application, therefore only
+        # use child image configuration with suffixes if specifically commanded with an argument
+        # targeting this child image
+        set(child_image_conf_fragment ${ACI_CONF_DIR}/${ACI_NAME}.conf)
+        zephyr_file_suffix(child_image_conf_fragment SUFFIX ${${ACI_NAME}_FILE_SUFFIX})
+      elseif(NOT "${CONF_FILE_BUILD_TYPE}" STREQUAL "")
         set(child_image_conf_fragment ${ACI_CONF_DIR}/${ACI_NAME}_${CONF_FILE_BUILD_TYPE}.conf)
       else()
         set(child_image_conf_fragment ${ACI_CONF_DIR}/${ACI_NAME}.conf)

--- a/cmake/partition_manager.cmake
+++ b/cmake/partition_manager.cmake
@@ -26,6 +26,10 @@ endmacro()
 # Load static configuration if found.
 # Try user defined file first, then file found in configuration directory,
 # finally file from board directory.
+if(SYSBUILD)
+  zephyr_get(PM_STATIC_YML_FILE SYSBUILD GLOBAL)
+endif()
+
 if(DEFINED PM_STATIC_YML_FILE)
   string(CONFIGURE "${PM_STATIC_YML_FILE}" user_def_pm_static)
 endif()


### PR DESCRIPTION
    Adds FILE_SUFFIX support to partition manager so that the correct
    configuration will be used instead of the default


and


    cmake: partition_manager: Fix missing sysbuild static PM file
    
    Fixes an issue whereby when a static PM file is defined on the
    command line when building with sysbuild, it would be completely
    absent


and


    cmake: multi_image: Add FILE_SUFFIX support
    
    Adds FILE_SUFFIX support to child/parent image, this diverges from
    how it operates in sysbuild due to child/parent's inability to have
    a named prefix for the main application, and requires that child
    images have the child name prefix for FILE_SUFFIX to be applied
