### PR TITLE
cmake: Fix file overlays replacing existing overlays

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -101,12 +101,12 @@ endfunction()
 
 # Convenience macro to add configuration overlays to child image.
 macro(add_overlay_config image overlay_file)
-  add_overlay(${image} ${overlay_file} OVERLAY_CONFIG)
+  add_overlay(${image} ${overlay_file} EXTRA_CONF_FILE)
 endmacro()
 
 # Convenience macro to add device tree overlays to child image.
 macro(add_overlay_dts image overlay_file)
-  add_overlay(${image} ${overlay_file} DTC_OVERLAY_FILE)
+  add_overlay(${image} ${overlay_file} EXTRA_DTC_OVERLAY_FILE)
 endmacro()
 
 # Add a partition manager configuration file to the build.

--- a/sysbuild/extensions.cmake
+++ b/sysbuild/extensions.cmake
@@ -30,10 +30,10 @@ endfunction()
 
 # Convenience macro to add configuration overlays to image.
 macro(add_overlay_config image overlay_file)
-  add_overlay(${image} ${overlay_file} OVERLAY_CONFIG)
+  add_overlay(${image} ${overlay_file} EXTRA_CONF_FILE)
 endmacro()
 
 # Convenience macro to add device tree overlays to image.
 macro(add_overlay_dts image overlay_file)
-  add_overlay(${image} ${overlay_file} DTC_OVERLAY_FILE)
+  add_overlay(${image} ${overlay_file} EXTRA_DTC_OVERLAY_FILE)
 endmacro()


### PR DESCRIPTION
```
Fixes an issues whereby adding file overlays to child images/sysbuild images would replace files that should be present, e.g. <board>.overlay, instead of appending to them
```