### PR TITLE
esb: Enable fast switching for nRF54H20

### DIFF
--- a/doc/nrf/protocols/esb/index.rst
+++ b/doc/nrf/protocols/esb/index.rst
@@ -317,6 +317,12 @@ If the ESB connection is established only between nRF52 and/or nRF53 Series devi
 
 When the value of the ``use_fast_ramp_up`` parameter is ``true``, fast ramp-up is enabled, resulting in reduced ramp-up delay of 40 µs.
 
+Furthermore, for the nRF54H20 SoC, you can activate fast switching using the :kconfig:option:`CONFIG_ESB_FAST_SWITCHING` Kconfig option and enable the ramp-up by setting the ``use_fast_ramp_up`` parameter to ``true``.
+The fast switching option enables direct switching between RX to TX and TX to RX radio states without entering the disable state.
+For the PTX node, this switching occurs after transmitting a packet and before waiting for acknowledgment (TX -> RX).
+For the PRX node, this switching occurs after receiving a packet and before transmitting an acknowledgment (RX -> TX).
+Enabling this feature can improve the responsiveness and efficiency of the radio communication system by reducing latency.
+
 .. _esb_never_disable_tx:
 
 Experimental feature: Never disable transmission stage

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -121,6 +121,7 @@ Enhanced ShockBurst (ESB)
 -------------------------
 
 * Added support for the :ref:`zephyr:nrf54h20dk_nrf54h20` and :ref:`zephyr:nrf54l15pdk_nrf54l15` boards.
+* Added fast switching between radio states for the nRF54H20 SoC.
 
 nRF IEEE 802.15.4 radio driver
 ------------------------------

--- a/samples/esb/esb_prx/sample.yaml
+++ b/samples/esb/esb_prx/sample.yaml
@@ -49,3 +49,12 @@ tests:
       - nrf5340dk_nrf5340_cpunet
     platform_allow: nrf5340dk_nrf5340_cpunet
     tags: esb ci_build
+  sample.esb.prx.fast_switching:
+    build_only: true
+    extra_configs:
+      - CONFIG_ESB_FAST_SWITCHING=y
+    integration_platforms:
+      - nrf54h20dk_nrf54h20_cpurad
+    platform_allow: >
+      nrf54h20dk_nrf54h20_cpurad
+    tags: esb ci_build

--- a/samples/esb/esb_prx/src/main.c
+++ b/samples/esb/esb_prx/src/main.c
@@ -115,6 +115,9 @@ int esb_initialize(void)
 	config.mode = ESB_MODE_PRX;
 	config.event_handler = event_handler;
 	config.selective_auto_ack = true;
+	if (IS_ENABLED(CONFIG_ESB_FAST_SWITCHING)) {
+		config.use_fast_ramp_up = true;
+	}
 
 	err = esb_init(&config);
 	if (err) {

--- a/samples/esb/esb_ptx/sample.yaml
+++ b/samples/esb/esb_ptx/sample.yaml
@@ -49,3 +49,12 @@ tests:
       - nrf5340dk_nrf5340_cpunet
     platform_allow: nrf5340dk_nrf5340_cpunet
     tags: esb ci_build
+  sample.esb.ptx.fast_switching:
+    build_only: true
+    extra_configs:
+      - CONFIG_ESB_FAST_SWITCHING=y
+    integration_platforms:
+      - nrf54h20dk_nrf54h20_cpurad
+    platform_allow: >
+      nrf54h20dk_nrf54h20_cpurad
+    tags: esb ci_build

--- a/samples/esb/esb_ptx/src/main.c
+++ b/samples/esb/esb_ptx/src/main.c
@@ -109,6 +109,9 @@ int esb_initialize(void)
 	config.event_handler = event_handler;
 	config.mode = ESB_MODE_PTX;
 	config.selective_auto_ack = true;
+	if (IS_ENABLED(CONFIG_ESB_FAST_SWITCHING)) {
+		config.use_fast_ramp_up = true;
+	}
 
 	err = esb_init(&config);
 

--- a/subsys/esb/Kconfig
+++ b/subsys/esb/Kconfig
@@ -148,6 +148,20 @@ config ESB_NEVER_DISABLE_TX
 	  the radio emitter needs to be turned off to enable the radio receiver.
 	  This reduces delay between consecutive transmissions but consumes more energy.
 
+config ESB_FAST_SWITCHING
+	select EXPERIMENTAL
+	depends on !ESB_NEVER_DISABLE_TX && SOC_NRF54H20_CPURAD
+	bool "Fast radio TX/RX and RX/TX switching [EXPERIMENTAL]"
+	help
+	  This option enables fast switching between transmit (TX) and receive (RX) modes
+	  and vice versa for ESB configurations.
+	  For the PTX node, this switching occurs after transmitting a packet and before waiting
+	  for acknowledgment (TX -> RX).
+	  For the PRX node, this switching occurs after receiving a packet and before
+	  transmitting an acknowledgment (RX -> TX).
+	  Enabling this feature can improve the responsiveness and efficiency of the radio
+	  communication system by reducing the latency.
+
 module=ESB
 module-str=ESB
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"

--- a/subsys/esb/esb_dppi.c
+++ b/subsys/esb/esb_dppi.c
@@ -20,7 +20,7 @@ LOG_MODULE_DECLARE(esb, CONFIG_ESB_LOG_LEVEL);
 static uint8_t radio_address_timer_stop;
 static uint8_t timer_compare0_radio_disable;
 static uint8_t timer_compare1_radio_txen;
-static uint8_t disabled_egu;
+static uint8_t disabled_phy_end_egu;
 static uint8_t egu_timer_start;
 static uint8_t egu_ramp_up;
 static uint8_t radio_end_timer_start;
@@ -45,7 +45,13 @@ void esb_ppi_for_txrx_set(bool rx, bool timer_start)
 	nrf_dppi_subscribe_set(ESB_DPPIC,
 				nrf_dppi_group_disable_task_get((uint8_t)ramp_up_dppi_group),
 				egu_ramp_up);
-	nrf_egu_subscribe_set(ESB_EGU, ESB_EGU_TASK, disabled_egu);
+
+	nrf_egu_subscribe_set(ESB_EGU, ESB_EGU_TASK, disabled_phy_end_egu);
+
+	if (IS_ENABLED(CONFIG_ESB_FAST_SWITCHING)) {
+		nrf_radio_subscribe_set(NRF_RADIO, rx ? NRF_RADIO_TASK_TXEN : NRF_RADIO_TASK_RXEN,
+					disabled_phy_end_egu);
+	}
 
 	if (timer_start) {
 		nrf_timer_subscribe_set(ESB_NRF_TIMER_INSTANCE, NRF_TIMER_TASK_START,
@@ -78,6 +84,10 @@ void esb_ppi_for_txrx_clear(bool rx, bool timer_start)
 
 	nrf_dppi_channels_remove_from_group(ESB_DPPIC, BIT(egu_ramp_up), ramp_up_dppi_group);
 
+	if (IS_ENABLED(CONFIG_ESB_FAST_SWITCHING)) {
+		nrf_radio_subscribe_clear(NRF_RADIO, rx ? NRF_RADIO_TASK_TXEN :
+							  NRF_RADIO_TASK_RXEN);
+	}
 
 	if (timer_start) {
 		nrf_timer_subscribe_clear(ESB_NRF_TIMER_INSTANCE, NRF_TIMER_TASK_START);
@@ -109,7 +119,11 @@ void esb_ppi_for_retransmission_set(void)
 			      timer_compare1_radio_txen);
 
 	nrf_radio_subscribe_set(NRF_RADIO, NRF_RADIO_TASK_TXEN, timer_compare1_radio_txen);
-	nrf_egu_subscribe_set(ESB_EGU, ESB_EGU_TASK, disabled_egu);
+	nrf_egu_subscribe_set(ESB_EGU, ESB_EGU_TASK, disabled_phy_end_egu);
+
+	if (IS_ENABLED(CONFIG_ESB_FAST_SWITCHING)) {
+		nrf_radio_subscribe_set(NRF_RADIO, NRF_RADIO_TASK_RXEN, disabled_phy_end_egu);
+	}
 
 	nrf_dppi_channels_enable(ESB_DPPIC, BIT(timer_compare1_radio_txen));
 }
@@ -122,6 +136,10 @@ void esb_ppi_for_retransmission_clear(void)
 
 	nrf_radio_subscribe_clear(NRF_RADIO, NRF_RADIO_TASK_TXEN);
 	nrf_egu_subscribe_clear(ESB_EGU, ESB_EGU_TASK);
+
+	if (IS_ENABLED(CONFIG_ESB_FAST_SWITCHING)) {
+		nrf_radio_subscribe_clear(NRF_RADIO, NRF_RADIO_TASK_RXEN);
+	}
 }
 
 void esb_ppi_for_wait_for_ack_set(void)
@@ -185,7 +203,7 @@ void esb_ppi_for_wait_for_rx_clear(void)
 
 uint32_t esb_ppi_radio_disabled_get(void)
 {
-	return disabled_egu;
+	return disabled_phy_end_egu;
 }
 
 int esb_ppi_init(void)
@@ -197,7 +215,7 @@ int esb_ppi_init(void)
 	radio_address_timer_stop = ESB_DPPI_FIRST_FIXED_CHANNEL + 0;
 	timer_compare0_radio_disable = ESB_DPPI_FIRST_FIXED_CHANNEL + 1;
 	timer_compare1_radio_txen = ESB_DPPI_FIRST_FIXED_CHANNEL + 2;
-	disabled_egu = ESB_DPPI_FIRST_FIXED_CHANNEL + 3;
+	disabled_phy_end_egu = ESB_DPPI_FIRST_FIXED_CHANNEL + 3;
 	egu_timer_start = ESB_DPPI_FIRST_FIXED_CHANNEL + 4;
 	egu_ramp_up = ESB_DPPI_FIRST_FIXED_CHANNEL + 5;
 	radio_end_timer_start = ESB_DPPI_FIRST_FIXED_CHANNEL + 6;
@@ -222,7 +240,7 @@ int esb_ppi_init(void)
 		goto error;
 	}
 
-	err = nrfx_dppi_channel_alloc(&disabled_egu);
+	err = nrfx_dppi_channel_alloc(&disabled_phy_end_egu);
 	if (err != NRFX_SUCCESS) {
 		goto error;
 	}
@@ -252,8 +270,11 @@ int esb_ppi_init(void)
 
 #endif /* defined(ESB_DPPI_FIXED) */
 
-	nrf_radio_publish_set(NRF_RADIO, NRF_RADIO_EVENT_DISABLED, disabled_egu);
-	nrf_dppi_channels_enable(ESB_DPPIC, BIT(disabled_egu));
+	nrf_radio_publish_set(NRF_RADIO, NRF_RADIO_EVENT_DISABLED, disabled_phy_end_egu);
+	if (IS_ENABLED(CONFIG_ESB_FAST_SWITCHING)) {
+		nrf_radio_publish_set(NRF_RADIO, NRF_RADIO_EVENT_PHYEND, disabled_phy_end_egu);
+	}
+	nrf_dppi_channels_enable(ESB_DPPIC, BIT(disabled_phy_end_egu));
 
 	return 0;
 
@@ -267,7 +288,7 @@ error:
 void esb_ppi_disable_all(void)
 {
 	uint32_t channels_mask = (BIT(egu_ramp_up) |
-				  BIT(disabled_egu) |
+				  BIT(disabled_phy_end_egu) |
 				  BIT(egu_timer_start) |
 				  BIT(radio_address_timer_stop) |
 				  BIT(timer_compare0_radio_disable) |
@@ -282,8 +303,11 @@ void esb_ppi_deinit(void)
 {
 	nrfx_err_t err;
 
-	nrf_dppi_channels_disable(ESB_DPPIC, BIT(disabled_egu));
+	nrf_dppi_channels_disable(ESB_DPPIC, BIT(disabled_phy_end_egu));
 	nrf_radio_publish_clear(NRF_RADIO, NRF_RADIO_EVENT_DISABLED);
+	if (IS_ENABLED(CONFIG_ESB_FAST_SWITCHING)) {
+		nrf_radio_publish_clear(NRF_RADIO, NRF_RADIO_EVENT_PHYEND);
+	}
 
 #if defined(ESB_DPPI_FIXED)
 
@@ -306,7 +330,7 @@ void esb_ppi_deinit(void)
 		goto error;
 	}
 
-	err = nrfx_dppi_channel_free(disabled_egu);
+	err = nrfx_dppi_channel_free(disabled_phy_end_egu);
 	if (err != NRFX_SUCCESS) {
 		goto error;
 	}

--- a/subsys/esb/esb_peripherals.h
+++ b/subsys/esb/esb_peripherals.h
@@ -36,6 +36,8 @@ extern "C" {
 	#define ESB_RADIO_EVENT_END NRF_RADIO_EVENT_PHYEND
 	#define ESB_SHORT_DISABLE_MASK NRF_RADIO_SHORT_PHYEND_DISABLE_MASK
 
+	#define ESB_RADIO_INT_END_MASK NRF_RADIO_INT_PHYEND_MASK
+
 #elif defined(CONFIG_SOC_SERIES_NRF54LX)
 
 	/** The ESB EVT IRQ is using EGU on nRF54 devices. */
@@ -55,6 +57,7 @@ extern "C" {
 	#define ESB_RADIO_EVENT_END NRF_RADIO_EVENT_PHYEND
 	#define ESB_SHORT_DISABLE_MASK NRF_RADIO_SHORT_PHYEND_DISABLE_MASK
 
+	#define ESB_RADIO_INT_END_MASK NRF_RADIO_INT_PHYEND_MASK
 #else
 
 	/** The ESB event IRQ number when running on the nRF52 and nRF53 device. */
@@ -72,6 +75,8 @@ extern "C" {
 	/** nRF52 and nRF53 device has just one kind of end event. */
 	#define ESB_RADIO_EVENT_END NRF_RADIO_EVENT_END
 	#define ESB_SHORT_DISABLE_MASK NRF_RADIO_SHORT_END_DISABLE_MASK
+
+	#define ESB_RADIO_INT_END_MASK NRF_RADIO_INT_END_MASK
 
 #endif
 

--- a/subsys/esb/esb_ppi_api.h
+++ b/subsys/esb/esb_ppi_api.h
@@ -35,6 +35,10 @@ extern "C" {
  *           |
  *           \----> self disable
  *
+ *      if (fast_switching)
+ *                    1
+ *      RADIO_PHYEND ---> RADIO_TASK_TXEN/RXEN
+ *
  * @param[in] rx Radio Rx mode, otherwise Tx mode.
  * @param[in] timer_start Indicates whether the timer is to be started on the EGU event.
  */


### PR DESCRIPTION
PR introduces fast switching between RX to TX and TX to RX radio states without entering the disable state.
