### PR TITLE
manifest: sdk-nrfxlib: Pull nRF70 v2.6 patch update rev#352850030ab

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -142,7 +142,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: v2.6.0
+      revision: 4425e78c3535b555cce054c28dd5761a5570bcab
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Update nRF70 release/v2.6 firmware patch.

Fixes SHEL-2684.