### PR TITLE
[backport-v2.6] manifest: update Zephyr revision

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -95,7 +95,7 @@ The following list summarizes the most important changes inherited from the upst
 Thread
 ------
 
-|no_changes_yet_note|
+* Fixed ``otPlatCryptoPbkdf2GenerateKey`` API implementation to allow a fallback to legacy MbedTLS implementation instead of returning ``OT_ERROR_NOT_CAPABLE``.
 
 Zigbee
 ------

--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v3.5.99-ncs1
+      revision: d5ed38ace67cbca8c790b3001643ad1bb97c5de0
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull a fix for PBKDF2 key generation API in OpenThread

KRKNWK-18797