### PR TITLE
manifest: update sdk-zephyr to have GRTC driver test

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: c22c9c258ce776b88dac8a917ab13f46a4c7db85
+      revision: 05d72f27f9494aadd6cda8b09f23c17951170091
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Updated sdk-zephyr revision contains GRTC driver test, that can be used to verify if it works correctly in NCS context.