### PR TITLE
manifest: sdk-zephyr & sdk-mcuboot

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 2bc6913f010a0d9fe1bf26c866b0c8e78fad1315
+      revision: 092fc54f66c01ad1e50bd66580989dcb129ab317
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -131,7 +131,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 650d11c32368d8ddea310fcdf0d52b45d9017f15
+      revision: 3131c92c5109266145fdc0528bf3991d6709a6a6
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR


### PR DESCRIPTION
Configuration for MCUboot and smp_svr which
allows to use nRF54L15pdk external flash as location for the secondary partition.

build commandline:
``` console
west build --sysbuild -b nrf54l15pdk_nrf54l15_cpuapp -d build/smp_svr_54l_NS zephyr/samples/subsys/mgmt/mcumgr/smp_svr/ -- -DEXTRA_CONF_FILE=overlay-bt.conf -DDTC_OVERLAY_FILE=boards/nrf54l15pdk_nrf54l15_cpuapp_ext_flash.overlay -Dmcuboot_EXTRA_DTC_OVERLAY_FILE=boards/nrf54l15pdk_nrf54l15_cpuapp_ext_flash.overlay -Dmcuboot_CONF_FILE=boards/nrf54l15pdk_nrf54l15_cpuapp_ext_flash.conf -DSB_CONFIG_PARTITION_MANAGER=n
```

OR along with `-DFILE_SUFFIX`
```console
west build -d build/smp_svr_54_3 -b nrf54l15pdk_nrf54l15_cpuapp@0.3.0 --sysbuild  zephyr/samples/subsys/mgmt/mcumgr/smp_svr/ -- -DFILE_SUFFIX="ext_flash" -DEXTRA_CONF_FILE=overlay-bt.conf  -DSB_CONFIG_PARTITION_MANAGER=n
```