### PR TITLE
modules: tf-m: Fix 9161 building issue

### DIFF
--- a/modules/trusted-firmware-m/tfm_boards/nrf9120/CMakeLists.txt
+++ b/modules/trusted-firmware-m/tfm_boards/nrf9120/CMakeLists.txt
@@ -19,6 +19,9 @@ install(FILES       ${Trusted\ Firmware\ M_SOURCE_DIR}/platform/ext/target/nordi
         DESTINATION ${INSTALL_PLATFORM_NS_DIR}/common/nrf9120)
 
 install(FILES       config.cmake
+        DESTINATION ${INSTALL_PLATFORM_NS_DIR})
+
+install(FILES       ../common/config.cmake
         DESTINATION ${INSTALL_PLATFORM_NS_DIR}/../common/)
 
 install(DIRECTORY   ${Trusted\ Firmware\ M_SOURCE_DIR}/platform/ext/target/nordic_nrf/nrf9161dk_nrf9161/tests


### PR DESCRIPTION
The config.cmake for nRF9120 (used also for nRF9161) was not placed in the correct path for the non secure application. This mainly affected the TF-M regression tests since they use the non secure application building from TF-M.

Ref: NCSDK-26131