### PR TITLE
ci: quarantine `sample.matter.light_bulb.memory_profiling` for MacOS

### DIFF
--- a/scripts/quarantine_windows_mac.yaml
+++ b/scripts/quarantine_windows_mac.yaml
@@ -31,3 +31,9 @@
   platforms:
     - nrf9160dk_nrf9160_ns
   comment: "https://nordicsemi.atlassian.net/browse/NCSDK-26461"
+
+- scenarios:
+    - sample.matter.light_bulb.memory_profiling
+  platforms:
+    - nrf7002dk_nrf5340_cpuapp
+  comment: "https://nordicsemi.atlassian.net/browse/KRKNWK-18792"


### PR DESCRIPTION
This sample overflows FLASH region.  The Matter team will investigate 
﻿
Signed-off-by: Thomas Stilwell <thomas.stilwell@nordicsemi.no>
