### PR TITLE
samples: matter: Enable Partition Manager and DFU for nrf54l15.

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -410,6 +410,8 @@ Matter samples
     * :ref:`matter_thermostat_sample` sample.
     * :ref:`matter_window_covering_sample` sample.
 
+    DFU support for the nRF54L15 PDK is available only for the ``release`` build target.
+
 * :ref:`matter_lock_sample` sample:
 
   * Added support for emulation of the nRF7001 Wi-Fi companion IC on the nRF7002 DK.

--- a/samples/matter/common/src/dfu/ota/ota_util.cpp
+++ b/samples/matter/common/src/dfu/ota/ota_util.cpp
@@ -22,7 +22,6 @@ using namespace chip;
 using namespace chip::DeviceLayer;
 
 #if CONFIG_CHIP_OTA_REQUESTOR
-
 namespace
 {
 DefaultOTARequestorStorage sOTARequestorStorage;
@@ -30,9 +29,12 @@ DefaultOTARequestorDriver sOTARequestorDriver;
 chip::BDXDownloader sBDXDownloader;
 chip::DefaultOTARequestor sOTARequestor;
 } /* namespace */
+#endif
 
-namespace Nrf::Matter {
+namespace Nrf::Matter
+{
 
+#if CONFIG_CHIP_OTA_REQUESTOR
 /* compile-time factory method */
 OTAImageProcessorImpl &GetOTAImageProcessor()
 {
@@ -60,7 +62,6 @@ void InitBasicOTARequestor()
 
 void OtaConfirmNewImage()
 {
-
 #ifndef CONFIG_SOC_SERIES_NRF53X
 	/* Check if the image is run in the REVERT mode and eventually
 	confirm it to prevent reverting on the next boot.
@@ -70,13 +71,14 @@ void OtaConfirmNewImage()
 #endif
 
 	OTAImageProcessorImpl &imageProcessor = GetOTAImageProcessor();
-	if(!boot_is_img_confirmed()){
+	if (!boot_is_img_confirmed()) {
 		CHIP_ERROR err = System::MapErrorZephyr(boot_write_img_confirmed());
 		if (CHIP_NO_ERROR == err) {
 			imageProcessor.SetImageConfirmed();
 			ChipLogProgress(SoftwareUpdate, "New firmware image confirmed");
 		} else {
-			ChipLogError(SoftwareUpdate, "Failed to confirm firmware image, it will be reverted on the next boot");
+			ChipLogError(SoftwareUpdate,
+				     "Failed to confirm firmware image, it will be reverted on the next boot");
 		}
 	}
 }

--- a/samples/matter/common/src/dfu/ota/ota_util.h
+++ b/samples/matter/common/src/dfu/ota/ota_util.h
@@ -11,9 +11,12 @@
 #if CONFIG_CHIP_OTA_REQUESTOR
 #include "ota_image_processor_base_impl.h"
 #include <platform/nrfconnect/OTAImageProcessorImpl.h>
+#endif
 
-namespace Nrf::Matter {
+namespace Nrf::Matter
+{
 
+#if CONFIG_CHIP_OTA_REQUESTOR
 /**
  * Select recommended OTA image processor implementation.
  *

--- a/samples/matter/light_bulb/README.rst
+++ b/samples/matter/light_bulb/README.rst
@@ -115,6 +115,10 @@ Device Firmware Upgrade support
     :start-after: matter_door_lock_sample_build_with_dfu_start
     :end-before: matter_door_lock_sample_build_with_dfu_end
 
+.. include:: ../template/README.rst
+    :start-after: matter_template_nrf54l15_build_with_dfu_start
+    :end-before: matter_template_nrf54l15_build_with_dfu_end
+
 FEM support
 ===========
 

--- a/samples/matter/light_bulb/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/light_bulb/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -7,7 +7,7 @@
 # Multirole is the only currently supported role by SoftDevice.
 CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 
-# TODO: Workaround to be removed once DFU will be supported on nRF54L.
+# TODO: Workaround to be removed once DFU and external flash will be supported on nRF54L.
 CONFIG_CHIP_OTA_REQUESTOR=n
 CONFIG_CHIP_QSPI_NOR=n
 

--- a/samples/matter/light_bulb/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
+++ b/samples/matter/light_bulb/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
@@ -7,8 +7,7 @@
 # Multirole is the only currently supported role by SoftDevice.
 CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 
-# TODO: Workaround to be removed once DFU will be supported on nRF54L.
-CONFIG_CHIP_OTA_REQUESTOR=n
+# TODO: Workaround to be removed once external flash will be supported on nRF54L.
 CONFIG_CHIP_QSPI_NOR=n
 
 CONFIG_FPU=n

--- a/samples/matter/light_bulb/child_image/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
+++ b/samples/matter/light_bulb/child_image/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# TODO: Workaround Fprotect is not supported on nRF54l15 yet.
+CONFIG_FPROTECT=n
+# TODO: Workaround, disable memory guard to avoid false faults in application after boot
+CONFIG_HW_STACK_PROTECTION=n
+
+CONFIG_BOOT_WATCHDOG_FEED=n

--- a/samples/matter/light_bulb/pm_static_nrf54l15pdk_nrf54l15_cpuapp_release.yml
+++ b/samples/matter/light_bulb/pm_static_nrf54l15pdk_nrf54l15_cpuapp_release.yml
@@ -1,0 +1,51 @@
+mcuboot:
+  address: 0x0
+  region: flash_primary
+  size: 0x7000
+mcuboot_pad:
+  address: 0x7000
+  region: flash_primary
+  size: 0x800
+app:
+  address: 0x7800
+  region: flash_primary
+  size: 0xb6000
+mcuboot_primary:
+  address: 0x7000
+  orig_span: &id001
+  - app
+  - mcuboot_pad
+  region: flash_primary
+  size: 0xb6800
+  span: *id001
+mcuboot_primary_app:
+  address: 0x7800
+  orig_span: &id002
+  - app
+  region: flash_primary
+  size: 0xb6000
+  span: *id002
+mcuboot_secondary:
+  address: 0xbd800
+  orig_span: &id003
+  - mcuboot_secondary_pad
+  - mcuboot_secondary_app
+  region: flash_primary
+  size: 0xb6800
+  span: *id003
+mcuboot_secondary_pad:
+  region: flash_primary
+  address: 0xbd800
+  size: 0x800
+mcuboot_secondary_app:
+  region: flash_primary
+  address: 0xbe000
+  size: 0xb6000
+factory_data:
+  address: 0x174000
+  region: flash_primary
+  size: 0x1000
+settings_storage:
+  address: 0x175000
+  region: flash_primary
+  size: 0x8000

--- a/samples/matter/light_switch/README.rst
+++ b/samples/matter/light_switch/README.rst
@@ -127,6 +127,10 @@ Device Firmware Upgrade support
     :start-after: matter_door_lock_sample_build_with_dfu_start
     :end-before: matter_door_lock_sample_build_with_dfu_end
 
+.. include:: ../template/README.rst
+    :start-after: matter_template_nrf54l15_build_with_dfu_start
+    :end-before: matter_template_nrf54l15_build_with_dfu_end
+
 Factory data support
 ====================
 

--- a/samples/matter/light_switch/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/light_switch/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -7,7 +7,7 @@
 # Multirole is the only currently supported role by SoftDevice.
 CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 
-# TODO: Workaround to be removed once DFU will be supported on nRF54L.
+# TODO: Workaround to be removed once DFU and external flash will be supported on nRF54L.
 CONFIG_CHIP_OTA_REQUESTOR=n
 CONFIG_CHIP_QSPI_NOR=n
 

--- a/samples/matter/light_switch/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
+++ b/samples/matter/light_switch/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
@@ -7,8 +7,7 @@
 # Multirole is the only currently supported role by SoftDevice.
 CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 
-# TODO: Workaround to be removed once DFU will be supported on nRF54L.
-CONFIG_CHIP_OTA_REQUESTOR=n
+# TODO: Workaround to be removed once external flash will be supported on nRF54L.
 CONFIG_CHIP_QSPI_NOR=n
 
 CONFIG_FPU=n

--- a/samples/matter/light_switch/child_image/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
+++ b/samples/matter/light_switch/child_image/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# TODO: Workaround Fprotect is not supported on nRF54l15 yet.
+CONFIG_FPROTECT=n
+# TODO: Workaround, disable memory guard to avoid false faults in application after boot
+CONFIG_HW_STACK_PROTECTION=n
+
+CONFIG_BOOT_WATCHDOG_FEED=n

--- a/samples/matter/light_switch/pm_static_nrf54l15pdk_nrf54l15_cpuapp_release.yml
+++ b/samples/matter/light_switch/pm_static_nrf54l15pdk_nrf54l15_cpuapp_release.yml
@@ -1,0 +1,51 @@
+mcuboot:
+  address: 0x0
+  region: flash_primary
+  size: 0x7000
+mcuboot_pad:
+  address: 0x7000
+  region: flash_primary
+  size: 0x800
+app:
+  address: 0x7800
+  region: flash_primary
+  size: 0xb6000
+mcuboot_primary:
+  address: 0x7000
+  orig_span: &id001
+  - app
+  - mcuboot_pad
+  region: flash_primary
+  size: 0xb6800
+  span: *id001
+mcuboot_primary_app:
+  address: 0x7800
+  orig_span: &id002
+  - app
+  region: flash_primary
+  size: 0xb6000
+  span: *id002
+mcuboot_secondary:
+  address: 0xbd800
+  orig_span: &id003
+  - mcuboot_secondary_pad
+  - mcuboot_secondary_app
+  region: flash_primary
+  size: 0xb6800
+  span: *id003
+mcuboot_secondary_pad:
+  region: flash_primary
+  address: 0xbd800
+  size: 0x800
+mcuboot_secondary_app:
+  region: flash_primary
+  address: 0xbe000
+  size: 0xb6000
+factory_data:
+  address: 0x174000
+  region: flash_primary
+  size: 0x1000
+settings_storage:
+  address: 0x175000
+  region: flash_primary
+  size: 0x8000

--- a/samples/matter/template/README.rst
+++ b/samples/matter/template/README.rst
@@ -113,6 +113,38 @@ Device Firmware Upgrade support
     :start-after: matter_door_lock_sample_build_with_dfu_start
     :end-before: matter_door_lock_sample_build_with_dfu_end
 
+.. matter_template_nrf54l15_build_with_dfu_start
+
+The Device Firmware Upgrade (DFU) for the nRF54L15 PDK is exclusively available for the ``release`` build configuration and is limited to using the internal MRAM for storage.
+This means that both the currently running firmware and the new firmware to be updated must be stored within the device's internal flash memory.
+Currently, there is no support for utilizing external flash memory for this purpose.
+
+To build the sample with DFU support, use the ``-DCONF_FILE=prj_release.conf`` flag in your CMake build command.
+
+The following is an example command to build the sample with support for OTA DFU only:
+
+.. code-block:: console
+
+    west build -b nrf54l15pdk_nrf54l15_cpuapp -- -DCONF_FILE=prj_release.conf
+
+If you want to build the sample with support for both OTA DFU and SMP DFU, use the following command:
+
+.. code-block:: console
+
+    west build -b nrf54l15pdk_nrf54l15_cpuapp -- -DCONF_FILE=prj_release.conf -DCONFIG_CHIP_DFU_OVER_BT_SMP=y
+
+You can disable DFU support for the ``release`` build configuration to double available application memory space.
+Do this by setting the :kconfig:option:`CONFIG_CHIP_DFU_OVER_BT_SMP`, and :kconfig:option:`CONFIG_CHIP_OTA_REQUESTOR` Kconfig options to ``n``.
+
+For example:
+
+.. code-block:: console
+
+    west build -b nrf54l15pdk_nrf54l15_cpuapp -- -DCONF_FILE=prj_release.conf -DCONFIG_CHIP_DFU_OVER_BT_SMP=n -DCONFIG_CHIP_OTA_REQUESTOR=n
+
+
+.. matter_template_nrf54l15_build_with_dfu_end
+
 FEM support
 ===========
 

--- a/samples/matter/template/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/template/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -7,7 +7,7 @@
 # Multirole is the only currently supported role by SoftDevice.
 CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 
-# TODO: Workaround to be removed once DFU will be supported on nRF54L.
+# TODO: Workaround to be removed once DFU and external flash will be supported on nRF54L.
 CONFIG_CHIP_OTA_REQUESTOR=n
 CONFIG_CHIP_QSPI_NOR=n
 

--- a/samples/matter/template/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
+++ b/samples/matter/template/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
@@ -7,8 +7,7 @@
 # Multirole is the only currently supported role by SoftDevice.
 CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 
-# TODO: Workaround to be removed once DFU will be supported on nRF54L.
-CONFIG_CHIP_OTA_REQUESTOR=n
+# TODO: Workaround to be removed once external flash will be supported on nRF54L.
 CONFIG_CHIP_QSPI_NOR=n
 
 CONFIG_FPU=n

--- a/samples/matter/template/child_image/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
+++ b/samples/matter/template/child_image/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# TODO: Workaround Fprotect is not supported on nRF54l15 yet.
+CONFIG_FPROTECT=n
+# TODO: Workaround, disable memory guard to avoid false faults in application after boot
+CONFIG_HW_STACK_PROTECTION=n
+
+CONFIG_BOOT_WATCHDOG_FEED=n

--- a/samples/matter/template/pm_static_nrf54l15pdk_nrf54l15_cpuapp_release.yml
+++ b/samples/matter/template/pm_static_nrf54l15pdk_nrf54l15_cpuapp_release.yml
@@ -1,0 +1,51 @@
+mcuboot:
+  address: 0x0
+  region: flash_primary
+  size: 0x7000
+mcuboot_pad:
+  address: 0x7000
+  region: flash_primary
+  size: 0x800
+app:
+  address: 0x7800
+  region: flash_primary
+  size: 0xb6000
+mcuboot_primary:
+  address: 0x7000
+  orig_span: &id001
+  - app
+  - mcuboot_pad
+  region: flash_primary
+  size: 0xb6800
+  span: *id001
+mcuboot_primary_app:
+  address: 0x7800
+  orig_span: &id002
+  - app
+  region: flash_primary
+  size: 0xb6000
+  span: *id002
+mcuboot_secondary:
+  address: 0xbd800
+  orig_span: &id003
+  - mcuboot_secondary_pad
+  - mcuboot_secondary_app
+  region: flash_primary
+  size: 0xb6800
+  span: *id003
+mcuboot_secondary_pad:
+  region: flash_primary
+  address: 0xbd800
+  size: 0x800
+mcuboot_secondary_app:
+  region: flash_primary
+  address: 0xbe000
+  size: 0xb6000
+factory_data:
+  address: 0x174000
+  region: flash_primary
+  size: 0x1000
+settings_storage:
+  address: 0x175000
+  region: flash_primary
+  size: 0x8000

--- a/samples/matter/thermostat/README.rst
+++ b/samples/matter/thermostat/README.rst
@@ -138,6 +138,10 @@ Device Firmware Upgrade support
     :start-after: matter_door_lock_sample_build_with_dfu_start
     :end-before: matter_door_lock_sample_build_with_dfu_end
 
+.. include:: ../template/README.rst
+    :start-after: matter_template_nrf54l15_build_with_dfu_start
+    :end-before: matter_template_nrf54l15_build_with_dfu_end
+
 .. _matter_thermostat_network_mode:
 
 Remote testing in a network

--- a/samples/matter/thermostat/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/thermostat/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -7,7 +7,7 @@
 # Multirole is the only currently supported role by SoftDevice.
 CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 
-# TODO: Workaround to be removed once DFU will be supported on nRF54L.
+# TODO: Workaround to be removed once DFU and external flash will be supported on nRF54L.
 CONFIG_CHIP_OTA_REQUESTOR=n
 CONFIG_CHIP_QSPI_NOR=n
 

--- a/samples/matter/thermostat/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
+++ b/samples/matter/thermostat/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
@@ -7,8 +7,7 @@
 # Multirole is the only currently supported role by SoftDevice.
 CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 
-# TODO: Workaround to be removed once DFU will be supported on nRF54L.
-CONFIG_CHIP_OTA_REQUESTOR=n
+# TODO: Workaround to be removed once external flash will be supported on nRF54L.
 CONFIG_CHIP_QSPI_NOR=n
 
 CONFIG_FPU=n

--- a/samples/matter/thermostat/child_image/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
+++ b/samples/matter/thermostat/child_image/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# TODO: Workaround Fprotect is not supported on nRF54l15 yet.
+CONFIG_FPROTECT=n
+# TODO: Workaround, disable memory guard to avoid false faults in application after boot
+CONFIG_HW_STACK_PROTECTION=n
+
+CONFIG_BOOT_WATCHDOG_FEED=n

--- a/samples/matter/thermostat/pm_static_nrf54l15pdk_nrf54l15_cpuapp_release.yml
+++ b/samples/matter/thermostat/pm_static_nrf54l15pdk_nrf54l15_cpuapp_release.yml
@@ -1,0 +1,51 @@
+mcuboot:
+  address: 0x0
+  region: flash_primary
+  size: 0x7000
+mcuboot_pad:
+  address: 0x7000
+  region: flash_primary
+  size: 0x800
+app:
+  address: 0x7800
+  region: flash_primary
+  size: 0xb6000
+mcuboot_primary:
+  address: 0x7000
+  orig_span: &id001
+  - app
+  - mcuboot_pad
+  region: flash_primary
+  size: 0xb6800
+  span: *id001
+mcuboot_primary_app:
+  address: 0x7800
+  orig_span: &id002
+  - app
+  region: flash_primary
+  size: 0xb6000
+  span: *id002
+mcuboot_secondary:
+  address: 0xbd800
+  orig_span: &id003
+  - mcuboot_secondary_pad
+  - mcuboot_secondary_app
+  region: flash_primary
+  size: 0xb6800
+  span: *id003
+mcuboot_secondary_pad:
+  region: flash_primary
+  address: 0xbd800
+  size: 0x800
+mcuboot_secondary_app:
+  region: flash_primary
+  address: 0xbe000
+  size: 0xb6000
+factory_data:
+  address: 0x174000
+  region: flash_primary
+  size: 0x1000
+settings_storage:
+  address: 0x175000
+  region: flash_primary
+  size: 0x8000

--- a/samples/matter/window_covering/README.rst
+++ b/samples/matter/window_covering/README.rst
@@ -98,6 +98,10 @@ Device Firmware Upgrade support
     :start-after: matter_door_lock_sample_build_with_dfu_start
     :end-before: matter_door_lock_sample_build_with_dfu_end
 
+.. include:: ../template/README.rst
+    :start-after: matter_template_nrf54l15_build_with_dfu_start
+    :end-before: matter_template_nrf54l15_build_with_dfu_end
+
 FEM support
 ===========
 

--- a/samples/matter/window_covering/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/window_covering/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -7,7 +7,7 @@
 # Multirole is the only currently supported role by SoftDevice.
 CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 
-# TODO: Workaround to be removed once DFU will be supported on nRF54L.
+# TODO: Workaround to be removed once DFU and external flash will be supported on nRF54L.
 CONFIG_CHIP_OTA_REQUESTOR=n
 CONFIG_CHIP_QSPI_NOR=n
 

--- a/samples/matter/window_covering/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
+++ b/samples/matter/window_covering/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
@@ -7,8 +7,7 @@
 # Multirole is the only currently supported role by SoftDevice.
 CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 
-# TODO: Workaround to be removed once DFU will be supported on nRF54L.
-CONFIG_CHIP_OTA_REQUESTOR=n
+# TODO: Workaround to be removed once external flash will be supported on nRF54L.
 CONFIG_CHIP_QSPI_NOR=n
 
 CONFIG_FPU=n

--- a/samples/matter/window_covering/child_image/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
+++ b/samples/matter/window_covering/child_image/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp_release.conf
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# TODO: Workaround Fprotect is not supported on nRF54l15 yet.
+CONFIG_FPROTECT=n
+# TODO: Workaround, disable memory guard to avoid false faults in application after boot
+CONFIG_HW_STACK_PROTECTION=n
+
+CONFIG_BOOT_WATCHDOG_FEED=n

--- a/samples/matter/window_covering/pm_static_nrf54l15pdk_nrf54l15_cpuapp_release.yml
+++ b/samples/matter/window_covering/pm_static_nrf54l15pdk_nrf54l15_cpuapp_release.yml
@@ -1,0 +1,51 @@
+mcuboot:
+  address: 0x0
+  region: flash_primary
+  size: 0x7000
+mcuboot_pad:
+  address: 0x7000
+  region: flash_primary
+  size: 0x800
+app:
+  address: 0x7800
+  region: flash_primary
+  size: 0xb6000
+mcuboot_primary:
+  address: 0x7000
+  orig_span: &id001
+  - app
+  - mcuboot_pad
+  region: flash_primary
+  size: 0xb6800
+  span: *id001
+mcuboot_primary_app:
+  address: 0x7800
+  orig_span: &id002
+  - app
+  region: flash_primary
+  size: 0xb6000
+  span: *id002
+mcuboot_secondary:
+  address: 0xbd800
+  orig_span: &id003
+  - mcuboot_secondary_pad
+  - mcuboot_secondary_app
+  region: flash_primary
+  size: 0xb6800
+  span: *id003
+mcuboot_secondary_pad:
+  region: flash_primary
+  address: 0xbd800
+  size: 0x800
+mcuboot_secondary_app:
+  region: flash_primary
+  address: 0xbe000
+  size: 0xb6000
+factory_data:
+  address: 0x174000
+  region: flash_primary
+  size: 0x1000
+settings_storage:
+  address: 0x175000
+  region: flash_primary
+  size: 0x8000

--- a/west.yml
+++ b/west.yml
@@ -160,7 +160,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: d769c56c6ad764bfe1c2b5f2111a640775301060
+      revision: 053732b6fe47be1d8620e107156580351ea1fc90
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
Added support for DFU and Partition Manger to nrf54l15 Matter samples for internal MRAM only. It means that the MCUBoot secondary partition is located in the internal MRAM memory. This configuration can be used in the release build type only.

- Created pm_static.yaml with the partitioning map for internal MRAM memory only.
- Enabled Partition Manager
- Enabled DFU over BLE
- Enabled DFU over Matter (OTA)