### PR TITLE
modules: hostap: Add support for WPA Auto security 

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -534,7 +534,10 @@ Zigbee samples
 Wi-Fi samples
 -------------
 
-|no_changes_yet_note|
+* :ref:`wifi_shell_sample` sample:
+
+  * Modified ``connect`` command to provide better control over connection parameters.
+  * Added ``Auto-Security-Personal`` mode to the ``connect`` command.
 
 Other samples
 -------------

--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -365,6 +365,17 @@ static int wpas_add_and_config_network(struct wpa_supplicant *wpa_s,
 				_wpa_cli_cmd_v("set_network %d proto WPA",
 					resp.network_id);
 			}
+		} else if (params->security == WIFI_SECURITY_TYPE_WPA_AUTO_PERSONAL) {
+			if (params->sae_password) {
+				_wpa_cli_cmd_v("set_network %d sae_password \"%s\"",
+						resp.network_id, params->sae_password);
+			}
+			_wpa_cli_cmd_v("set_network %d psk \"%s\"",
+					resp.network_id, params->psk);
+			_wpa_cli_cmd_v("set_network %d key_mgmt WPA-PSK WPA-PSK-SHA256 SAE",
+					resp.network_id);
+			_wpa_cli_cmd_v("set_network %d proto WPA RSN",
+						resp.network_id);
 		} else {
 			ret = -1;
 			wpa_printf(MSG_ERROR, "Unsupported security type: %d",

--- a/samples/wifi/shell/README.rst
+++ b/samples/wifi/shell/README.rst
@@ -114,16 +114,18 @@ Supported CLI commands
        | 2:1,6-11,14_5:36,149-165,44
        | [-h, --help] : Print out the help for the scan command.
    * - connect
-     - | Connect to a Wi-Fi AP with the following parameters:
-       | "<SSID>"
-       | [channel number/band: > 0:Channel, 0:any channel,
-       | < 0:band (-2:2.4GHz, -5:5GHz, -6:6GHz]
-       | [PSK: valid only for secure SSIDs]
-       | [Security type: valid only for secure SSIDs]
-       | 0:None, 1:WPA2-PSK, 2:WPA2-PSK-256, 3:SAE, 4:WAPI, 5:EAP, 6:WEP, 7:
-       | WPA-PSK
-       | [MFP (optional: needs security type to be specified)]
+     - | Connect to a Wi-Fi AP
+       | <-s --ssid \"<SSID>\">: SSID.
+       | [-c --channel]: Channel that needs to be scanned for connection. 0:any channel
+       | [-b, --band] 0: any band (2:2.4GHz, 5:5GHz, 6:6GHz)
+       | [-p, --psk]: Passphrase (valid only for secure SSIDs)
+       | [-k, --key-mgmt]: Key management type.
+       | 0:None, 1:WPA2-PSK, 2:WPA2-PSK-256, 3:SAE, 4:WAPI, 5:EAP, 6:WEP,
+       | 7:WPA-PSK, 8: WPA-Auto-Personal
+       | [-w, --ieee-80211w]: MFP (optional: needs security type to be specified)
        | : 0:Disable, 1:Optional, 2:Required.
+       | [-m, --bssid]: MAC address of the AP (BSSID).
+       | [-h, --help]: Print out the help for the connect command.
    * - disconnect
      - Disconnect from the Wi-Fi AP
    * - status


### PR DESCRIPTION
Support WPA Auto security mode wherein supplicant can
implicitly choose one of WPA, WPA2 and WPA3 for association
with a network.

Fixes SHEL-1131.