### PR TITLE
emds: exclude write time measurement for nrf54

### DIFF
--- a/tests/subsys/emds/emds_flash/src/main.c
+++ b/tests/subsys/emds/emds_flash/src/main.c
@@ -668,7 +668,9 @@ ZTEST(emds_flash_tests, test_write_speed)
 	toc = k_uptime_ticks();
 	store_time_us = k_ticks_to_us_ceil64(toc - tic);
 	printk("Storing 1024 bytes took: %lldus\n", store_time_us);
+#if !defined CONFIG_SOC_FLASH_NRF_RRAM /* TODO: Fix it with NCSDK-26922 */
 	zassert_true(store_time_us < 13000, "Storing 1024 bytes took to long time");
+#endif
 }
 
 ZTEST_SUITE(emds_flash_tests, NULL, fs_init, NULL, NULL, NULL);


### PR DESCRIPTION
Commit excludes writing time measurement for nrf54l. There are no still RRAM programming digits in documentation.