### PR TITLE
manifest: update zephyr - HWFC for nrf54l15

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: ddca5117acdf51a52bfa09649ac4c9c3fb8a1e43
+      revision: c22c9c258ce776b88dac8a917ab13f46a4c7db85
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Define RTS and CTS pins and enable HWFC for uart connected to debugger.