### PR TITLE
bluetooth: controller: Add HCI commands for LE Path Loss Monitoring

### DIFF
--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -539,6 +539,8 @@ void hci_internal_supported_commands(sdc_hci_ip_supported_commands_t *cmds)
 	cmds->hci_le_enhanced_read_transmit_power_level = 1;
 	cmds->hci_le_read_remote_transmit_power_level = 1;
 	cmds->hci_le_set_transmit_power_reporting_enable = 1;
+	cmds->hci_le_set_path_loss_reporting_parameters = 1;
+	cmds->hci_le_set_path_loss_reporting_enable = 1;
 	/* NOTE: The DTM commands are *not* supported by the SoftDevice
 	 * controller. See doc/nrf/known_issues.rst.
 	 */
@@ -739,6 +741,7 @@ void hci_internal_le_supported_features(
 #if defined(CONFIG_BT_CTLR_LE_POWER_CONTROL)
 	features->params.le_power_control_request = 1;
 	features->params.le_power_change_indication = 1;
+	features->params.le_path_loss_monitoring = 1;
 #endif
 
 #if defined(CONFIG_BT_CTLR_ADV_PERIODIC_ADI_SUPPORT)
@@ -1298,6 +1301,16 @@ static uint8_t le_controller_cmd_put(uint8_t const * const cmd,
 			sizeof(sdc_hci_cmd_le_set_transmit_power_reporting_enable_return_t);
 		return sdc_hci_cmd_le_set_transmit_power_reporting_enable((void *)cmd_params,
 									  (void *)event_out_params);
+
+	case SDC_HCI_OPCODE_CMD_LE_SET_PATH_LOSS_REPORTING_PARAMS:
+		*param_length_out += sizeof(sdc_hci_cmd_le_set_path_loss_reporting_params_return_t);
+		return sdc_hci_cmd_le_set_path_loss_reporting_params((void *)cmd_params,
+								     (void *)event_out_params);
+
+	case SDC_HCI_OPCODE_CMD_LE_SET_PATH_LOSS_REPORTING_ENABLE:
+		*param_length_out += sizeof(sdc_hci_cmd_le_set_path_loss_reporting_enable_return_t);
+		return sdc_hci_cmd_le_set_path_loss_reporting_enable((void *)cmd_params,
+								     (void *)event_out_params);
 #endif
 
 #if defined(CONFIG_BT_CTLR_LE_POWER_CONTROL) || defined(CONFIG_BT_CTLR_ADV_EXT)


### PR DESCRIPTION
This PR introduces commands and feature bits for the LE Path Loss Monitoring feature.

Adds support for the following HCI commands:
- sdc_hci_cmd_le_set_path_loss_reporting_params
- sdc_hci_cmd_le_set_path_loss_reporting_enable