### PR TITLE
trusted_storage: Fix error codes for PSA persistent keys

### DIFF
--- a/subsys/trusted_storage/src/storage_backend_settings.c
+++ b/subsys/trusted_storage/src/storage_backend_settings.c
@@ -70,6 +70,8 @@ static psa_status_t error_to_psa_error(int errorno)
 	switch (errorno) {
 	case 0:
 		return PSA_SUCCESS;
+	case -ENOSPC:
+		return PSA_ERROR_INSUFFICIENT_STORAGE;
 	case -ENOENT:
 		return PSA_ERROR_DOES_NOT_EXIST;
 	case -ENODATA:


### PR DESCRIPTION
Aligns the error codes of PSA persistent key generation/importing for TF-M and non TF-M builds. 