### PR TITLE
manifest: Pull in sdk-zephyr with new I2s tests

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 5c484901b955fb78e97b9f76cb51fd38433fd4f2
+      revision: c90430fac16392db6d5a724c1c6faf1248f3a093
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Add more tests cases in the i2s driver error management area
Signed-off-by: Bartosz Miller <bartosz.miller@nordicsemi.no>