### PR TITLE
driver: wifi: Make WPA supplicant regulatory aware

### DIFF
--- a/drivers/wifi/nrf700x/src/wpa_supp_if.c
+++ b/drivers/wifi/nrf700x/src/wpa_supp_if.c
@@ -457,11 +457,16 @@ void *nrf_wifi_wpa_supp_dev_init(void *supp_drv_if_ctx, const char *iface_name,
 		return NULL;
 	}
 
+	/* Needed to make sure that during initialization, commands like setting regdomain
+	 * does not access it.
+	 */
+	k_mutex_lock(&vif_ctx_zep->vif_lock, K_FOREVER);
 	vif_ctx_zep->supp_drv_if_ctx = supp_drv_if_ctx;
 
 	memcpy(&vif_ctx_zep->supp_callbk_fns, supp_callbk_fns,
 	       sizeof(vif_ctx_zep->supp_callbk_fns));
 
+	k_mutex_unlock(&vif_ctx_zep->vif_lock);
 	return vif_ctx_zep;
 }
 


### PR DESCRIPTION
[SHEL-2661] If regulatory set is called before WPA supplicant is initialized, then as NM is not registered the calls gets re-routed to driver directly skipping WPA supplicant. In that case, the command should be failed at driver.

[SHEL-2661]: https://nordicsemi.atlassian.net/browse/SHEL-2661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ