### PR TITLE
manifest: update sdk-zephyr to have i2c test

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 54b4e400ed8ffe37602112ad719bab4db5ea0087
+      revision: ee43b9ac08c6351aeaee6089fb28c659151596d6
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
New i2c test allows to verify i2c driver correctness on nRF devices.