### PR TITLE
RFC: Bluetooth: Host: introduce priority sets

### DIFF
--- a/include/bluetooth/nrf/host_extensions.h
+++ b/include/bluetooth/nrf/host_extensions.h
@@ -107,6 +107,32 @@ struct bt_conn_set_pcr_params {
  */
 int bt_conn_set_power_control_request_params(struct bt_conn_set_pcr_params *params);
 
+enum bt_ctlr_priority_levels {
+  BT_CTLR_PRIORITY_FIRST = 1,
+  BT_CTLR_PRIORITY_SECOND = 2,
+  BT_CTLR_PRIORITY_THIRD = 3,
+  BT_CTLR_PRIORITY_FOURTH = 4,
+  BT_CTLR_PRIORITY_FIFTH = 5,
+
+  BT_CTLR_PRIORITY_DEFAULT = 0xff
+};
+
+struct bt_ctlr_priority_set {
+	enum bt_ctlr_priority_levels scan_init_auxiliary_channel_priority;
+};
+
+#define BT_CTLR_PRIORITY_SET_HIGH_PRIORITY_CONNECT \
+{ \
+	.scan_init_auxiliary_channel_priority = BT_CTLR_PRIORITY_SECOND \
+}
+
+#define BT_CTLR_PRIORITY_DEFAULT \
+{ \
+	.scan_init_auxiliary_channel_priority = BT_CTLR_PRIORITY_DEFAULT \
+}
+
+int bt_scan_reduce_scanner_initator_aux_channel_priority(struct bt_ctlr_priority_set *priority_set);
+
 /**
  * @}
  */

--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -1640,6 +1640,8 @@ static uint8_t vs_cmd_put(uint8_t const *const cmd, uint8_t *const raw_event_out
 		return sdc_hci_cmd_vs_cis_subevent_length_set(
 			(sdc_hci_cmd_vs_cis_subevent_length_set_t const *)cmd_params);
 #endif
+		case SDC_HCI_OPCODE_CMD_VS_SET_ROLE_PRIORITY:
+			return sdc_hci_cmd_vs_set_role_priority((sdc_hci_cmd_vs_set_role_priority_t const *) cmd_params);
 	default:
 		return BT_HCI_ERR_UNKNOWN_CMD;
 	}

--- a/subsys/bluetooth/host_extensions/CMakeLists.txt
+++ b/subsys/bluetooth/host_extensions/CMakeLists.txt
@@ -4,4 +4,4 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-zephyr_sources_ifdef(CONFIG_BT_TRANSMIT_POWER_CONTROL host_extensions.c)
+zephyr_sources(host_extensions.c)

--- a/subsys/bluetooth/host_extensions/hci_types_host_extensions.h
+++ b/subsys/bluetooth/host_extensions/hci_types_host_extensions.h
@@ -39,6 +39,14 @@ struct bt_hci_cp_set_power_control_request_param {
 	uint8_t apr_margin;
 } __packed;
 
+#define BT_HCI_OP_SET_ROLE_PRIORITY	BT_OP(BT_OGF_VS, 0x011B)
+
+struct bt_hci_set_role_priority {
+    uint8_t handle_type;
+    uint16_t handle;
+    uint8_t priority;
+} __packed;
+
 /**
  * @}
  */

--- a/subsys/bluetooth/host_extensions/host_extensions.c
+++ b/subsys/bluetooth/host_extensions/host_extensions.c
@@ -9,7 +9,7 @@
  * Adding them in nrf is better maintainable.
  */
 
-#if defined(CONFIG_BT_TRANSMIT_POWER_CONTROL)
+#include <stdbool.h>
 
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/bluetooth/conn.h>
@@ -18,6 +18,8 @@
 
 #include "hci_types_host_extensions.h"
 #include <bluetooth/nrf/host_extensions.h>
+
+#if defined(CONFIG_BT_TRANSMIT_POWER_CONTROL)
 
 /* Write Remote Transmit Power Level HCI command */
 int bt_conn_set_remote_tx_power_level(struct bt_conn *conn,
@@ -72,3 +74,25 @@ int bt_conn_set_power_control_request_params(struct bt_conn_set_pcr_params *para
 	return bt_hci_cmd_send_sync(BT_HCI_OP_SET_POWER_CONTROL_REQUEST_PARAMS, buf, NULL);
 }
 #endif /* CONFIG_BT_TRANSMIT_POWER_CONTROL */
+
+#if defined(CONFIG_BT_CTLR_ADV_EXT)
+int bt_scan_reduce_scanner_initator_aux_channel_priority(struct bt_ctlr_priority_set *priority_set)
+{
+	struct bt_hci_set_role_priority *cmd;
+	struct net_buf *buf;
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_SET_ROLE_PRIORITY, sizeof(*cmd));
+	if (!buf) {
+		return -ENOBUFS;
+	}
+
+	cmd = net_buf_add(buf, sizeof(*cmd));
+	*cmd = (struct bt_hci_set_role_priority) {
+	  .handle_type = 0x4,
+	  .handle = 0x0,
+	  .priority = (uint8_t) priority_set->scan_init_auxiliary_channel_priority
+    };
+
+	return bt_hci_cmd_send_sync(BT_HCI_OP_SET_ROLE_PRIORITY, buf, NULL);
+}
+#endif /* CONFIG_BT_CTLR_ADV_EXT */


### PR DESCRIPTION
In order to better adapt to the needs of the application, add a host API that allows to change the priorities in the controller. These configuration sets are tested internally and have a specific purpose.

Initially, add a configuration which gives more priority to the initiator, in order to improve connection setup latency.