### PR TITLE
matter: Increase default retry interval for Thread

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -95,6 +95,7 @@ Matter
 ------
 
 * Added support for merging the generated factory data HEX file with the firmware HEX file by using the devicetree configuration, when Partition Manager is not enabled in the project.
+* Updated default MRP retry intervals for Thread devices to two seconds to reduce the number of spurious retransmissions in Thread networks.
 
 Matter fork
 +++++++++++

--- a/samples/matter/light_bulb/src/chip_project_config.h
+++ b/samples/matter/light_bulb/src/chip_project_config.h
@@ -14,11 +14,3 @@
  */
 
 #pragma once
-
-/*
- * Switching from Thread child to router may cause a few second packet stall.
- * Until this is improved in OpenThread we need to increase the retransmission
- * interval to survive the stall.
- */
-#define CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL (1000_ms32)
-#define CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL (1000_ms32)

--- a/west.yml
+++ b/west.yml
@@ -160,7 +160,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: aaf689381ccc012aee4cc8a41ce232f65f0baa9d
+      revision: d769c56c6ad764bfe1c2b5f2111a640775301060
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
The current 800ms is not enough in real setups, where Thread routers must serve as intermediate hops for many parallel conversations. Bump this to 2s.