### PR TITLE
modules: hostap: Increase the stack size for net_mgmt

### DIFF
--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -205,7 +205,7 @@ config BSS_MAX_IDLE_TIME
 # Control interface is stack heavy (buffers + snprintfs)
 # Making calls to RPU from net_mgmt callbacks (status - RSSI)
 config NET_MGMT_EVENT_STACK_SIZE
-	default 4096
+	default 4200
 
 config NET_SOCKETS_POLL_MAX
 	default 6


### PR DESCRIPTION
Due to recent changes in hostap to move few buffers from heap->stack (to improve the reliability of allocations) this has increased the stack size and with another recent change to increase the max polling sockets this puts over the 4096 stack size for net_mgmt causing stack overflow.

Increase the stack size for net_mgmt to fix SHEL-2640 and SHEL-2676.