### PR TITLE
doc: improve fota info with NCS pages interlinking

### DIFF
--- a/doc/nrf/config_and_build/dfu/index.rst
+++ b/doc/nrf/config_and_build/dfu/index.rst
@@ -103,8 +103,13 @@ Device-specific DFU guides
 
 See the following pages for device-specific guides related to DFU:
 
-* :ref:`qspi_xip` - for the nRF5340 SoC
-* :ref:`ug_nrf70_fw_patch_update` - for nRF70 Series devices
+* :ref:`Developing with nRF52 Series <ug_nrf52_developing_ble_fota>` - for how to do firmware over-the-air (FOTA) updates with nRF52 Series devices.
+
+* :ref:`Developing with nRF5340 DK <ug_nrf53_developing_ble_fota>` - for how to do FOTA updates and serial recovery with the nRF5340 SoC.
+
+  * :ref:`qspi_xip` - for external execute in place (XIP) for the nRF5340 SoC.
+
+* :ref:`ug_nrf70_fw_patch_update` - for nRF70 Series devices.
 
 See the following user guides for an overview of topics related to general firmware updates with the |NCS|:
 

--- a/doc/nrf/device_guides/working_with_nrf/nrf52/developing.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf52/developing.rst
@@ -20,6 +20,7 @@ To get started with your nRF52 Series DK, follow the steps in the :ref:`ug_nrf52
 If you are not familiar with the |NCS| and its development environment, see :ref:`installation` and :ref:`configuration_and_build` documentation.
 
 .. _ug_nrf52_developing_ble_fota:
+
 .. fota_upgrades_intro_start
 
 FOTA updates
@@ -27,6 +28,7 @@ FOTA updates
 
 |fota_upgrades_def|
 You can also use FOTA updates to replace the application.
+See the :ref:`app_dfu` page for general Device Firmware Update (DFU) information, such as supported methods for sending and receiving updates on the device.
 
 .. note::
    For the possibility of introducing an upgradable bootloader, refer to :ref:`ug_bootloader_adding`.
@@ -61,7 +63,7 @@ To enable support for FOTA updates, do the following:
 .. fota_upgrades_over_ble_mandatory_mcuboot_start
 
 * Use MCUboot as the upgradable bootloader (:kconfig:option:`CONFIG_BOOTLOADER_MCUBOOT` must be enabled).
-  For more information, go to the :doc:`mcuboot:index-ncs` page.
+  For more information, go to the :ref:`ug_bootloader_adding` page.
 
 .. fota_upgrades_over_ble_mandatory_mcuboot_end
 

--- a/doc/nrf/device_guides/working_with_nrf/nrf53/nrf5340.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf53/nrf5340.rst
@@ -538,6 +538,7 @@ See the following instructions.
          Otherwise, if you recover the application core first and the network core last, the binary written to the application core is deleted and readback protection is enabled again after a reset.
 
 .. _ug_nrf53_developing_ble_fota:
+
 .. include:: ../nrf52/developing.rst
    :start-after: fota_upgrades_intro_start
    :end-before: fota_upgrades_intro_end


### PR DESCRIPTION
[NCSIDB-1158](https://nordicsemi.atlassian.net/browse/NCSIDB-1158)
Improve FOTA docs with interlinks to NCS docs and existing guides within "Working with nRF52/nRF53..." pages,
and existing Device Firmware Updates page

[NCSIDB-1158]: https://nordicsemi.atlassian.net/browse/NCSIDB-1158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ