### PR TITLE
Allow to disable Partition Manager for a project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,9 @@ endforeach()
 
 include(cmake/extensions.cmake)
 include(cmake/version.cmake)
-include(cmake/multi_image.cmake)
+if (NOT SYSBUILD OR CONFIG_PRE_SELECT_PARTITION_MANAGER)
+  include(cmake/multi_image.cmake)
+endif()
 
 zephyr_include_directories(include)
 

--- a/modules/mcuboot/CMakeLists.txt
+++ b/modules/mcuboot/CMakeLists.txt
@@ -2,9 +2,9 @@ add_subdirectory(${ZEPHYR_MCUBOOT_MODULE_DIR}/boot/bootutil/zephyr
                  ${CMAKE_CURRENT_BINARY_DIR}/boot/bootutil/zephyr
 )
 
-if(SYSBUILD)
+if(SYSBUILD OR NOT CONFIG_PRE_SELECT_PARTITION_MANAGER)
   # Code below is partition manager w/ child image support, thus return when
-  # sysbuild is used.
+  # sysbuild is used or Partition Manager has been disabled.
   return()
 endif()
 

--- a/modules/mcuboot/Kconfig
+++ b/modules/mcuboot/Kconfig
@@ -30,11 +30,13 @@ config BOOT_BUILD_DIRECT_XIP_VARIANT
 	help
 	  Build a variant of the 'app' image which can be used for DIRECT_XIP.
 
-# The name of this configuration needs to match the requirements set by the
-# script `partition_manager.py`. See `pm.yml` in the application directory
-# of MCUBoot.
-module=MCUBOOT
-source "${ZEPHYR_BASE}/../nrf/subsys/partition_manager/Kconfig.template.build_strategy"
+if PRE_SELECT_PARTITION_MANAGER
+	# The name of this configuration needs to match the requirements set by the
+	# script `partition_manager.py`. See `pm.yml` in the application directory
+	# of MCUBoot.
+	module=MCUBOOT
+	source "${ZEPHYR_BASE}/../nrf/subsys/partition_manager/Kconfig.template.build_strategy"
+endif
 
 menuconfig MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION
 	bool "Downgrade prevention using hardware security counters"

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -4,6 +4,12 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+# If Partition Manager has been disabled, then multi-image is not supported
+# either, as it depends on the Partition Manager to function.
+if (NOT CONFIG_PARTITION_MANAGER_ENABLED)
+  return()
+endif()
+
 if (CONFIG_SECURE_BOOT)
   if (CONFIG_SOC_NRF5340_CPUNET)
     # Share some information which is used when generating the zip file

--- a/subsys/partition_manager/Kconfig
+++ b/subsys/partition_manager/Kconfig
@@ -6,8 +6,22 @@
 
 menu "Partition Manager"
 
+config PRE_SELECT_PARTITION_MANAGER
+	bool "Pre-select Partition Manager for project [DO NOT EDIT]"
+	default y
+	help
+	  Use partition manager for specified project.
+	  This should be set from command line before project is built
+	  for the first time, otherwise the Partition Manager and
+	  multi-image support may be already included for a project.
+	  When set to n it directs all partition references to DTS and
+	  disables the multi-image support, so what you will get is
+	  build of the specified project only with partition definitions
+	  taken from the DTS.
+
 config PARTITION_MANAGER_ENABLED
 	bool "Partition manager is enabled (read-only option)"
+	default y if PRE_SELECT_PARTITION_MANAGER
 	help
 	  Option which can be checked to see whether or not the
 	  partition manager is enabled in the current build. Note that this

--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: f50ad41dd6ea61d36bece05171768e12f5ceb5a3
+      revision: pull/1652/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Commits that allow disabling Partition Manager, and multi-image, build for any project that is not built with sysbuild.

For example issuing:
```
 west build -d builds/hello_world -b nrf52840dk_nrf52840 zephyr/samples/hello_world/ -DCONFIG_BOOTLOADER_MCUBOOT=y -DCONFIG_PRE_SELECT_PARTITION_MANAGER=n
```
will build Hello World sample with sdk-nrf, with MCUboot support but with multi-image disabled, and only the Hello worl will be built.
Then you can built the MCUboot without partition manager using:
```
west build -d builds/mcuboot -b nrf52840dk_nrf52840 bootloader/mcuboot/boot/zephyr/ -DCONFIG_PRE_SELECT_PARTITION_MANAGER=n
```