### PR TITLE
doc improvement: BT libs and services: terminology alignments

### DIFF
--- a/doc/nrf/libraries/bluetooth_services/adv_prov.rst
+++ b/doc/nrf/libraries/bluetooth_services/adv_prov.rst
@@ -7,20 +7,20 @@ Bluetooth LE advertising providers
    :local:
    :depth: 2
 
-The Bluetooth LE advertising providers subsystem manages advertising data and scan response data.
-The subsystem does not control Bluetooth LE advertising by itself.
+The Bluetooth LE advertising providers library manages advertising data and scan response data.
+It does not control Bluetooth LE advertising by itself.
 
 Overview
 ********
 
-The Bluetooth LE advertising providers subsystem acts as a middleware between data providers and a module that controls Bluetooth advertising.
-The module that controls the Bluetooth advertising can use the subsystem's API to get advertising data and scan response data.
-On the API call, the Bluetooth LE advertising providers subsystem gets data from providers and passes the data to the module that controls Bluetooth advertising.
+The Bluetooth LE advertising providers library acts as a middleware between data providers and a module that controls Bluetooth advertising.
+The module that controls the Bluetooth advertising can use the library's API to get advertising data and scan response data.
+On the API call, the Bluetooth LE advertising providers library gets data from providers and passes the data to the module that controls Bluetooth advertising.
 
 Providers
 =========
 
-The subsystem gets both advertising data and scan response data from providers.
+The library gets both advertising data and scan response data from providers.
 A provider manages a single element that is part of either advertising data or scan response data.
 
 The |NCS| provides a set of predefined data providers.
@@ -42,7 +42,7 @@ Apart from filling the Bluetooth data structure, the provider can also perform a
   The error value of ``-ENOENT`` is used to inform that provider desists from providing data.
   In that case, the provider does not fill in the Bluetooth data structure.
   This error code is not forwarded to the module that controls Bluetooth LE advertising.
-  Other negative values denote provider-specific errors, which are forwarded directly to the module that controls Bluetooth LE advertising.
+  Other negative values denote provider-specific errors that are forwarded directly to the module that controls Bluetooth LE advertising.
 
 The provided Bluetooth data can depend on any of the following options:
 
@@ -56,11 +56,11 @@ Examples of provider implementations can be found in the :file:`subsys/bluetooth
 Advertising control
 ===================
 
-The Bluetooth LE advertising providers subsystem does not control Bluetooth LE advertising by itself.
+The Bluetooth LE advertising providers library does not control Bluetooth LE advertising by itself.
 A separate module that controls Bluetooth advertising is mandatory.
 For example, :ref:`caf_ble_adv`, that is available in the |NCS|.
 An application can use this CAF module or implement an application-specific module that controls Bluetooth advertising.
-The application then uses the Bluetooth LE advertising providers subsystem to manage advertising data and scan response data.
+The application then uses the Bluetooth LE advertising providers library to manage advertising data and scan response data.
 
 Custom module
 -------------
@@ -79,7 +79,7 @@ See mentioned structures' documentation for detailed description of individual m
 Configuration
 *************
 
-Set :kconfig:option:`CONFIG_BT_ADV_PROV` to enable the Bluetooth LE advertising providers subsystem.
+Set the :kconfig:option:`CONFIG_BT_ADV_PROV` Kconfig option to enable the Bluetooth LE advertising providers library.
 
 Predefined providers
 ====================

--- a/doc/nrf/libraries/bluetooth_services/gatt_pool.rst
+++ b/doc/nrf/libraries/bluetooth_services/gatt_pool.rst
@@ -17,14 +17,14 @@ There are different types of attributes that can be registered to create a servi
 * CCC descriptor attribute, used for turning notifications for a characteristic on or off
 * Regular descriptor attribute, used for providing an additional description for a characteristic
 
-The API of the GATT attribute pools module allows to register different types of GATT attributes listed above.
+The API of the GATT attribute pools library allows to register different types of GATT attributes.
 After each registration, a part of the memory is reserved for each attribute.
-You can also unregister unnecessary attributes using the module's API.
+You can also unregister unnecessary attributes using the library's API.
 In this case, the previously reserved memory is released.
 This can be useful when you want to restructure your service by using the Service Changed feature that is supported by the Zephyr Bluetooth® stack (see, for example, the :ref:`hids_readme`).
 
-Additionally, you can adjust the memory footprint of this module to your needs by changing the configuration options for the size of the module's memory pool.
-If you are unsure about the proper values, print the module's statistics to see how the pool utilization level is affected by the chosen configuration.
+Additionally, you can adjust the memory footprint of this library to your needs by changing the configuration options for the size of its memory pool.
+If you are unsure about the proper values, print the statistics to see how the pool utilization level is affected by the chosen configuration.
 
 API documentation
 *****************

--- a/doc/nrf/libraries/bluetooth_services/scan.rst
+++ b/doc/nrf/libraries/bluetooth_services/scan.rst
@@ -1,23 +1,23 @@
 .. _lib_nrf_bt_scan_readme:
 .. _nrf_bt_scan_readme:
 
-Scanning module
-###############
+Bluetooth LE scanning
+#####################
 
 .. contents::
    :local:
    :depth: 2
 
-The scanning module handles the Bluetooth® Low Energy scanning for your application.
+This library handles the Bluetooth® Low Energy scanning for your application.
 
 Overview
 ********
 
-Use the scanning module to find advertising devices and establish connections with them.
-The module can automatically establish connection after a filter match.
+Use the library to find advertising devices and establish connections with them.
+It can automatically establish connection after a filter match.
 It can also receive :ref:`directed advertising packets <lib_nrf_bt_scan_readme_directedadvertising>`.
 
-The scanning module can work in one of the following modes:
+The library can work in one of the following modes:
 
 * Simple mode - Works without filters.
 * Advanced mode - Allows using advanced filters.
@@ -30,10 +30,10 @@ Use the :kconfig:option:`CONFIG_BT_SCAN` Kconfig option to enable the library in
 Blocklist
 =========
 
-Devices can be added to the blocklist, which means that the scanning module ignores these devices and does not generate any events for them.
+Devices can be added to the blocklist, which means that the library ignores these devices and does not generate any events for them.
 Use the :kconfig:option:`CONFIG_BT_SCAN_BLOCKLIST` Kconfig option to enable the blocklist.
 
-In the default configuration, the scanning module allows to add up to two devices to the blocklist.
+In the default configuration, the library allows to add up to two devices to the blocklist.
 To increase the blocklist size, set the :kconfig:option:`CONFIG_BT_SCAN_BLOCKLIST_LEN` Kconfig option.
 Use the :c:func:`bt_scan_blocklist_device_add` function to add a new device to the blocklist.
 To remove all devices from the blocklist, use the :c:func:`bt_scan_blocklist_clear` function.
@@ -43,7 +43,7 @@ To remove all devices from the blocklist, use the :c:func:`bt_scan_blocklist_cle
 Directed advertising
 ====================
 
-To receive directed advertising packets through the scanning module, enable one of the following Kconfig options in Zephyr:
+To receive directed advertising packets through the library, enable one of the following Kconfig options in Zephyr:
 
 * :kconfig:option:`CONFIG_BT_PRIVACY` - Scan with changing addresses.
 * :kconfig:option:`CONFIG_BT_SCAN_WITH_IDENTITY` - Scan with a local identity address.
@@ -51,7 +51,7 @@ To receive directed advertising packets through the scanning module, enable one 
 It is recommended to enable the :kconfig:option:`CONFIG_BT_PRIVACY` Kconfig option to support directed advertising only between bonded peers.
 Use the :kconfig:option:`CONFIG_BT_SCAN_WITH_IDENTITY` Kconfig option only when the :kconfig:option:`CONFIG_BT_PRIVACY` Kconfig option is not available.
 
-When the scanning module is set to the advanced mode and :ref:`filters <lib_nrf_bt_scan_readme_filters>` are set, you can use the ``filter_no_match`` event to check if directed advertising packets have been received.
+When the library is set to the advanced mode and :ref:`filters <lib_nrf_bt_scan_readme_filters>` are set, you can use the ``filter_no_match`` event to check if directed advertising packets have been received.
 They will typically not match any filter as, by specification, they do not contain any advertising data.
 
 If there is no match, you can establish a connection without the need to disable or reconfigure the existing filters.
@@ -66,17 +66,17 @@ The following code sample demonstrates the usage of the ``filter_no_match`` even
 Usage
 *****
 
-You can use the scanning module to execute actions described in the sections below.
+You can use the library to execute actions described in the following sections.
 
 Initializing
 ============
 
-To initialize the module, call the :c:func:`bt_scan_init` function.
+To initialize the library, call the :c:func:`bt_scan_init` function.
 
 You can also call the function without an initialization structure.
 When you pass the initialization structure as ``NULL``, the default static configuration is used.
 
-This configuration is also used when you initialize the module with a structure that has ``NULL`` pointers set for scan and connection parameters.
+This configuration is also used when you initialize the library with a structure that has ``NULL`` pointers set for scan and connection parameters.
 
 Scanning
 ========
@@ -91,7 +91,7 @@ Call the following functions to perform basic scanning activities:
 
 * :c:func:`bt_scan_stop` - Stop scanning manually.
 
-  Scanning stops automatically if the module established the connection.
+  Scanning stops automatically if the library established the connection.
 
 * :c:func:`bt_scan_start` - Resume scanning.
 
@@ -156,11 +156,11 @@ This might result in a loop of the connection and disconnection events.
 To avoid that, enable the :kconfig:option:`CONFIG_BT_SCAN_CONN_ATTEMPTS_FILTER` Kconfig option that limits the number of the connection attempts.
 
 This filter automatically tracks the connected devices and counts all disconnection events for them.
-If the number of disconnections is greater than or equal to the number of the allowed attempts, the scanning module ignores this device.
+If the number of disconnections is greater than or equal to the number of the allowed attempts, the library ignores this device.
 
-Filtered devices must be removed manually from the filter array through the :c:func:`bt_scan_conn_attempts_filter_clear` function.
+You must remove the filtered devices manually from the filter array through the :c:func:`bt_scan_conn_attempts_filter_clear` function.
 Use this function before each scan starts, unless your application has different requirements.
-If the filter array is full, the scanning module overwrites the oldest device with the new one.
+If the filter array is full, the library overwrites the oldest device with the new one.
 
 In the default configuration, the filter allows to add two devices and limits the connection attempts to two.
 To increase the number of devices, set the :kconfig:option:`CONFIG_BT_SCAN_CONN_ATTEMPTS_FILTER_LEN` Kconfig option.

--- a/doc/nrf/libraries/bluetooth_services/services/ams_client.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/ams_client.rst
@@ -7,8 +7,8 @@ Apple Media Service (AMS) Client
    :local:
    :depth: 2
 
-This module implements the Apple Media Service (AMS) client.
-This client can be used as a Media Remote (MR) to interact with a Media Source (MS).
+This library implements the Apple Media Service (AMS) client.
+You can use this library as a Media Remote (MR) to interact with a Media Source (MS).
 The MS is typically an iOS device.
 For detailed information about the Apple Media Service, see `Apple Developer Documentation <Apple Media Service Reference_>`_.
 

--- a/doc/nrf/libraries/bluetooth_services/services/ancs_client.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/ancs_client.rst
@@ -7,7 +7,7 @@ Apple Notification Center Service (ANCS) Client
    :local:
    :depth: 2
 
-The ANCS Client module is used for implementation of the Apple Notification Center Service (ANCS) client.
+The ANCS Client library is used for implementation of the Apple Notification Center Service (ANCS) client.
 
 .. note::
 
@@ -21,7 +21,7 @@ The ANCS client can be used as a Notification Consumer (NC) that receives data n
 The NP is typically an iOS device that is acting as a server.
 For detailed information about the Apple Notification Center Service, see `Apple Developer Documentation <Apple Notification Center Service Specification_>`_.
 
-In this module, iOS notifications are received through the GATT notifications.
+In this library, iOS notifications are received through the GATT notifications.
 
 .. note::
 
@@ -35,9 +35,9 @@ In this module, iOS notifications are received through the GATT notifications.
 Configuration
 *************
 
-Upon initializing the module, add different iOS notification attributes you want to receive for iOS notifications (see :c:func:`bt_ancs_register_attr`).
+Upon initializing the library, add different iOS notification attributes you want to receive for iOS notifications (see :c:func:`bt_ancs_register_attr`).
 
-Once a connection is established with a central device, the module needs a service discovery to discover the ANCS server handles.
+Once a connection is established with a central device, the library needs a service discovery to discover the ANCS server handles.
 If this succeeds, the handles for the ANCS server must be assigned to an ANCS client instance using the :c:func:`bt_ancs_handles_assign` function.
 
 The application can now subscribe to iOS notifications with :c:func:`bt_ancs_subscribe_notification_source`.
@@ -82,6 +82,7 @@ Use the following functions to perform activities related to notifications:
 
 Samples using the library
 *************************
+
 The :ref:`peripheral_ancs_client` sample uses this library.
 
 Dependencies

--- a/doc/nrf/libraries/bluetooth_services/services/bas_client.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/bas_client.rst
@@ -7,9 +7,9 @@ GATT Battery Service (BAS) Client
    :local:
    :depth: 2
 
-The Battery Service Client can be used to retrieve information about the battery level from a device that provides a Battery Service Server.
+You can use the Battery Service Client to retrieve information about the battery level from a device that provides a Battery Service Server.
 
-The client supports a simple `Battery Service <Battery Service Specification_>`_ with one characteristic.
+The library supports a simple `Battery Service <Battery Service Specification_>`_ with one characteristic.
 The Battery Level Characteristic holds the battery level in percentage units.
 
 
@@ -47,7 +47,7 @@ Getting the last known value
 
   .. note::
      The internally stored value is updated every time a notification or read response is received.
-     If no value is received from the server, the get function returns :c:macro:`BT_BAS_VAL_INVALID`.
+     If no value is received from the server, the ``get`` function returns :c:macro:`BT_BAS_VAL_INVALID`.
 
 .. _bas_client_readme_periodic:
 

--- a/doc/nrf/libraries/bluetooth_services/services/bms.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/bms.rst
@@ -7,7 +7,7 @@ GATT Bond Management Service (BMS)
    :local:
    :depth: 2
 
-This module implements the Bond Management Service with the corresponding set of characteristics defined in the `Bond Management Service Specification`_.
+This library implements the Bond Management Service with the corresponding set of characteristics defined in the `Bond Management Service Specification`_.
 
 You can configure the service to support your desired feature set of bond management operations.
 All the BMS features in the "LE transport only" mode are supported:
@@ -16,7 +16,7 @@ All the BMS features in the "LE transport only" mode are supported:
  * Delete all bonds on the Server.
  * Delete all bonds on the Server except the one of the requesting device.
 
-You can enable each feature when initializing the module.
+You can enable each feature when initializing the library.
 
 Authorization
 *************
@@ -27,7 +27,7 @@ When required, the Client's request to execute a bond management operation must 
 The Server compares the code with its local version and accepts the request only if the codes match.
 
 If you use at least one BMS feature that requires authorization, you need to provide a callback with comparison logic for the authorization codes.
-You can set this callback when initializing the module.
+You can set this callback when initializing the library.
 
 Deleting the bonds
 ******************

--- a/doc/nrf/libraries/bluetooth_services/services/cgms.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/cgms.rst
@@ -10,7 +10,7 @@ GATT Continuous Glucose Monitoring Service (CGMS)
 Overview
 ********
 
-This module implements the Continuous Glucose Monitoring Service with the corresponding set of characteristics defined in the `Continuous Glucose Monitoring Service Specification`_.
+This library implements the Continuous Glucose Monitoring Service with the corresponding set of characteristics defined in the `Continuous Glucose Monitoring Service Specification`_.
 
 Supported features
 ==================
@@ -21,9 +21,9 @@ Configuration
 *************
 
 Set the maximum number of glucose measurement records stored in the device using the :kconfig:option:`CONFIG_BT_CGMS_MAX_MEASUREMENT_RECORD` Kconfig option.
-The value of should be large enough to hold all records generated in a session.
+The value should be large enough to hold all records generated in a session.
 
-Set the logging level of the CGMS module using the :kconfig:option:`CONFIG_BT_CGMS_LOG_LEVEL_CHOICE` Kconfig option.
+Set the logging level of the CGMS library using the :kconfig:option:`CONFIG_BT_CGMS_LOG_LEVEL_CHOICE` Kconfig option.
 
 Usage
 *****

--- a/doc/nrf/libraries/bluetooth_services/services/cts_client.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/cts_client.rst
@@ -7,7 +7,7 @@ GATT Current Time Service (CTS) Client
    :local:
    :depth: 2
 
-The CTS Client module can be used to retrieve the current time from a connected peer that is running the GATT server with the `Current Time Service <Current Time Service Specification_>`_.
+You can use the CTS Client library to retrieve the current time from a connected peer that is running the GATT server with the `Current Time Service <Current Time Service Specification_>`_.
 
 The CTS Client is used in the :ref:`peripheral_cts_client` sample.
 

--- a/doc/nrf/libraries/bluetooth_services/services/dfu_smp.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/dfu_smp.rst
@@ -7,11 +7,11 @@ GATT DFU SMP Service Client
    :local:
    :depth: 2
 
-This module implements a Simple Management Protocol (SMP) Service Client that can be used in the context of Device Firmware Updates (DFU).
+This library implements a Simple Management Protocol (SMP) Service Client that you can use in the context of Device Firmware Updates (DFU).
 SMP is a basic transfer encoding for use with the `mcumgr`_ management protocol.
 See `SMP over Bluetooth`_ for the service specification.
 
-The SMP Client module can be used to interact with Zephyr's :zephyr:code-sample:`smp-svr`.
+You can use the SMP Client library to interact with Zephyr's :zephyr:code-sample:`smp-svr`.
 
 The SMP Client implements only the service.
 It does not provide any functionality to process or interpret SMP commands and responses.

--- a/doc/nrf/libraries/bluetooth_services/services/fast_pair.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/fast_pair.rst
@@ -28,16 +28,16 @@ The Fast Pair service also contains additional GATT characteristics under the fo
 Configuration
 *************
 
-Set the :kconfig:option:`CONFIG_BT_FAST_PAIR` Kconfig option to enable the module.
+Set the :kconfig:option:`CONFIG_BT_FAST_PAIR` Kconfig option to enable the service.
 
-The following Kconfig options are also available for this module:
+The following Kconfig options are also available for this service:
 
 * :kconfig:option:`CONFIG_BT_FAST_PAIR_STORAGE_USER_RESET_ACTION` - The option enables user reset action that is executed together with the Fast Pair factory reset operation.
   See the :ref:`ug_bt_fast_pair_factory_reset_custom_user_reset_action` for more details.
 * :kconfig:option:`CONFIG_BT_FAST_PAIR_STORAGE_ACCOUNT_KEY_MAX` - The option configures maximum number of stored Account Keys.
 * :kconfig:option:`CONFIG_BT_FAST_PAIR_CRYPTO_TINYCRYPT`, :kconfig:option:`CONFIG_BT_FAST_PAIR_CRYPTO_MBEDTLS`, :kconfig:option:`CONFIG_BT_FAST_PAIR_CRYPTO_OBERON`, and :kconfig:option:`CONFIG_BT_FAST_PAIR_CRYPTO_PSA` - These options are used to select the cryptographic backend for Fast Pair.
   The Oberon backend is used by default.
-  The Mbed TLS backend uses Mbed TLS crypto APIs, which are now considered legacy APIs.
+  The Mbed TLS backend uses Mbed TLS crypto APIs that are now considered legacy APIs.
 * :kconfig:option:`CONFIG_BT_FAST_PAIR_PN` - The option enables the `Fast Pair Personalized Name extension`_.
 
   * :kconfig:option:`CONFIG_BT_FAST_PAIR_STORAGE_PN_LEN_MAX` - The option specifies the maximum length of a stored Fast Pair Personalized Name.

--- a/doc/nrf/libraries/bluetooth_services/services/gattp.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/gattp.rst
@@ -7,7 +7,7 @@ Generic Attribute (GATT) Profile
    :local:
    :depth: 2
 
-The GATT Profile module can be used to receive service changed indications from a connected peer.
+You can use the GATT Profile library to receive service changed indications from a connected peer.
 It is used in the :ref:`peripheral_ancs_client` sample.
 
 API documentation

--- a/doc/nrf/libraries/bluetooth_services/services/hids.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/hids.rst
@@ -7,14 +7,14 @@ GATT Human Interface Device (HID) Service
    :local:
    :depth: 2
 
-This module implements the Human Interface Device Service with the corresponding set of characteristics.
+This library implements the Human Interface Device Service (HIDS) with the corresponding set of characteristics.
 When initialized, it adds the HID Service and a set of characteristics, according to the `HID Service Specification`_ and the user requirements, to the Zephyr Bluetooth® stack database.
 
 If enabled, a notification of Input Report characteristics is sent when the application calls the corresponding :c:func:`bt_hids_inp_rep_send` function.
 
 You can register dedicated event handlers for most of the HIDS characteristics to be notified about changes in their values.
 
-The HIDS module must be notified about the incoming connect and disconnect events using the dedicated API.
+The HIDS library must be notified about the incoming connect and disconnect events using the dedicated API.
 This is done to synchronize the connection state of HIDS with the top module that uses it.
 
 .. note::
@@ -37,7 +37,7 @@ In such case, the Bluetooth stack automatically notifies connected peers about t
 Multiclient support
 *******************
 
-The HIDS module can handle multiple connected peers at the same time.
+The HIDS library can handle multiple connected peers at the same time.
 The server allocates context data for each connected client.
 The context data is then used to store the values of HIDS characteristics.
 These values are unique for each connected peer.
@@ -46,7 +46,7 @@ While sending notifications, you can also target a specific client by providing 
 Report masking
 **************
 
-The HIDS module can consist of reports that are used to transmit differential data.
+The HIDS library can consist of reports that are used to transmit differential data.
 One example of such a report type is a mouse report.
 In a mouse report, mouse movement data represents the position change along the X or Y axis and should only be interpreted once by the HID host.
 After receiving a notification from the HID device, the client should not be able to get any non-zero value from the differential data part of the report by using the GATT Read Request on its characteristic.

--- a/doc/nrf/libraries/bluetooth_services/services/hogp.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/hogp.rst
@@ -7,7 +7,7 @@ GATT Human Interface Device Service (HIDS) Client
    :local:
    :depth: 2
 
-The HIDS Client uses the :ref:`gatt_dm_readme` module to acquire all attribute handles that are required to interact with the HIDS server.
+The HIDS Client uses the :ref:`gatt_dm_readme` to acquire all attribute handles that are required to interact with the HIDS server.
 
 Overview
 ********
@@ -30,7 +30,7 @@ Use the following Kconfig options to configure the library:
 Usage
 *****
 
-You can use the GATT HIDS Client module to interact with a connected HIDS server.
+You can use the GATT HIDS Client library to interact with a connected HIDS server.
 
 Retrieving the HIDS Client readiness state
 ==========================================

--- a/doc/nrf/libraries/bluetooth_services/services/latency.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/latency.rst
@@ -8,7 +8,7 @@ GATT Latency Service
    :depth: 2
 
 The GATT Latency Service is a custom service containing a single writable characteristic.
-This characteristic can be used to calculate the round-trip time of a GATT Write operation.
+You can use this characteristic to calculate the round-trip time of a GATT Write operation.
 
 Service UUID
 ************

--- a/doc/nrf/libraries/bluetooth_services/services/latency_client.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/latency_client.rst
@@ -7,14 +7,14 @@ GATT Latency Client
    :local:
    :depth: 2
 
-The Latency Client can be used to interact with a connected peer that is running the Latency service with the :ref:`latency_readme`.
+You can use the Latency Client to interact with a connected peer that is running the Latency service with the :ref:`latency_readme`.
 It writes data to the Latency characteristic and waits for a response to count the time spent of a GATT Write operation.
 
 Latency Characteristic
 **********************
 
 To request latency data from the Latency Characteristic, use the :c:func:`bt_latency_request` function.
-The request sending procedure is asynchronous, so the request data to be sent must remain valid until a dedicated callback notifies you that the Write Request has been completed.
+The request sending procedure is asynchronous, so the request data to be sent must remain valid until a dedicated callback notifies you that the write request has been completed.
 
 API documentation
 *****************

--- a/doc/nrf/libraries/bluetooth_services/services/mds.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/mds.rst
@@ -34,7 +34,7 @@ Configuration
 
 Set the :kconfig:option:`CONFIG_BT_MDS` Kconfig option to enable the service.
 
-The following configuration options are available for this module:
+The following configuration options are available for this service:
 
    * :kconfig:option:`CONFIG_BT_MDS_MAX_URI_LENGTH` sets the maximum length of the URI to which diagnostic data should be forwarded.
      The URI contains the device ID.
@@ -54,7 +54,7 @@ Implementation details
 The implementation uses :c:macro:`BT_GATT_SERVICE_DEFINE` to statically define and register the Memfault Diagnostic GATT service.
 The service automatically checks if there is data available to be sent with the interval defined by the :kconfig:option:`CONFIG_BT_MDS_DATA_POLL_INTERVAL` and sends it using the notification mechanism.
 No application input is required to send diagnostic data.
-However, if you pass :c:struct:`bt_mds_cb` to the :c:func:`bt_mds_cb_register` function, the application needs to confirm that the connected client can access the diagnostic data every time the client performs a read or write operation on the service characteristic.
+However, if you pass :c:struct:`bt_mds_cb` to the :c:func:`bt_mds_cb_register` function, the application needs to confirm that the connected client can access the diagnostic data every time the client performs a ``read`` or ``write`` operation on the service characteristic.
 
 Use the :c:func:`bt_mds_cb_register` function to register callbacks the service.
 

--- a/doc/nrf/libraries/bluetooth_services/services/nus_client.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/nus_client.rst
@@ -7,8 +7,8 @@ Nordic UART Service (NUS) Client
    :local:
    :depth: 2
 
-The Nordic UART Service Client module can be used to interact with a connected peer that is running the GATT server with the :ref:`nus_service_readme`.
-The client uses the :ref:`gatt_dm_readme` module to acquire the attribute handles that are necessary to interact with the RX and TX Characteristics.
+You can use the Nordic UART Service Client library to interact with a connected peer that is running the GATT server with the :ref:`nus_service_readme`.
+The client uses the :ref:`gatt_dm_readme` library to acquire the attribute handles that are necessary to interact with the RX and TX Characteristics.
 
 The NUS Service Client is used in the :ref:`central_uart` sample.
 
@@ -16,15 +16,15 @@ The NUS Service Client is used in the :ref:`central_uart` sample.
 RX Characteristic
 *****************
 
-To send data to the RX Characteristic, use the :c:func:`bt_nus_client_send` function of this module.
-The sending procedure is asynchronous, so the data to be sent must remain valid until a dedicated callback notifies you that the Write Request has been completed.
+To send data to the RX Characteristic, use the :c:func:`bt_nus_client_send` function of this library.
+The sending procedure is asynchronous, so the data to be sent must remain valid until a dedicated callback notifies you that the write request has been completed.
 
 TX Characteristic
 *****************
 
 To receive data coming from the TX Characteristic, enable notifications after the service discovery.
 After that, you can request to disable notifications again by returning the ``STOP`` value in the callback that is used to handle incoming data.
-Another dedicated callback is triggered when your request has been completed, to inform you that you have unsubscribed successfully.
+Another dedicated callback is triggered when your request has been completed, to inform that you have unsubscribed successfully.
 
 API documentation
 *****************

--- a/doc/nrf/libraries/bluetooth_services/services/rscs.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/rscs.rst
@@ -7,7 +7,7 @@ Running Speed and Cadence Service (RSCS)
    :local:
    :depth: 2
 
-This module implements the Running Speed and Cadence Service with the corresponding set of characteristics defined in the `Running Speed and Cadence Service Specification`_.
+This library implements the Running Speed and Cadence Service with the corresponding set of characteristics defined in the `Running Speed and Cadence Service Specification`_.
 
 The RSCS is used in the :ref:`peripheral_rscs` sample.
 

--- a/doc/nrf/libraries/bluetooth_services/services/wifi_prov.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/wifi_prov.rst
@@ -7,10 +7,10 @@ Wi-Fi Provisioning Service
    :local:
    :depth: 2
 
-This module implements a Bluetooth® GATT service for Wi-Fi® provisioning.
-This library is to be used with the :ref:`wifi_provisioning` sample.
+This library implements a Bluetooth® GATT service for Wi-Fi® provisioning.
+It is to be used with the :ref:`wifi_provisioning` sample.
 The Wi-Fi Provisioning Service forms a complete reference solution, together with the mobile application.
-You can find details in the documentation of the :ref:`wifi_provisioning` sample.
+For details, see the :ref:`wifi_provisioning` sample documentation.
 
 Overview
 ********
@@ -146,7 +146,7 @@ The service uses four message types:
   * If the command is ``SET_CONFIG``, when the Wi-Fi status changes (for example, from disconnected to connected), the configurator receives a result message with the new status.
     Meanwhile, the Wi-Fi credentials are stored in the non-volatile memory of the device.
 
-See all definitions in :file:`./common/proto`.
+See all definitions in the :file:`.subsys/bluetooth/services/wifi_prov/proto/common.proto` file.
 
 Operations
 ==========


### PR DESCRIPTION
Aligning the terminology in the library and service docs. Subsystem and module to library. Also some minor language fixes.

Ref: NCSDK-25270