### PR TITLE
matter: Increase default retry interval for Thread

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -86,7 +86,7 @@ Bluetooth mesh
 Matter
 ------
 
-|no_changes_yet_note|
+* Updated default MRP retry intervals for Thread devices to two seconds to reduce the number of spurious retransmissions in Thread networks.
 
 Matter fork
 +++++++++++

--- a/samples/matter/light_bulb/src/chip_project_config.h
+++ b/samples/matter/light_bulb/src/chip_project_config.h
@@ -14,11 +14,3 @@
  */
 
 #pragma once
-
-/*
- * Switching from Thread child to router may cause a few second packet stall.
- * Until this is improved in OpenThread we need to increase the retransmission
- * interval to survive the stall.
- */
-#define CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL (1000_ms32)
-#define CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL (1000_ms32)

--- a/west.yml
+++ b/west.yml
@@ -149,7 +149,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: c9acb13af88375d2c0d95bb0488be20d780514fd
+      revision: 08da36c7c1ad424cc9f2d7526119d4b8463b52a9
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
The current 800ms is not enough in real setups, where Thread routers must serve as intermediate hops for many parallel conversations. Bump this to 2s.