### PR TITLE
esb: Enable fast radio channel switching for nRF54H20

### DIFF
--- a/doc/nrf/protocols/esb/index.rst
+++ b/doc/nrf/protocols/esb/index.rst
@@ -318,10 +318,12 @@ If the ESB connection is established only between nRF52 and/or nRF53 Series devi
 When the value of the ``use_fast_ramp_up`` parameter is ``true``, fast ramp-up is enabled, resulting in reduced ramp-up delay of 40 µs.
 
 Furthermore, for the nRF54H20 SoC, you can activate fast switching using the :kconfig:option:`CONFIG_ESB_FAST_SWITCHING` Kconfig option and enable the ramp-up by setting the ``use_fast_ramp_up`` parameter to ``true``.
-The fast switching option enables direct switching between RX to TX and TX to RX radio states without entering the disable state.
+The fast switching option enables direct switching between RX to TX and TX to RX radio states without entering the ``DISABLED`` state.
 For the PTX node, this switching occurs after transmitting a packet and before waiting for acknowledgment (TX -> RX).
 For the PRX node, this switching occurs after receiving a packet and before transmitting an acknowledgment (RX -> TX).
 Enabling this feature can improve the responsiveness and efficiency of the radio communication system by reducing latency.
+
+Enabling the :kconfig:option:`CONFIG_ESB_FAST_CHANNEL_SWITCHING` Kconfig for the nRF54H20 SoC allows radio channel switching in RX radio state without transitioning to the ``DISABLED`` state.
 
 .. _esb_never_disable_tx:
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -134,6 +134,7 @@ Enhanced ShockBurst (ESB)
 
 * Added support for the :ref:`zephyr:nrf54h20dk_nrf54h20` and :ref:`nRF54L15 PDK <ug_nrf54l15_gs>` boards.
 * Added fast switching between radio states for the nRF54H20 SoC.
+* Added fast radio channel switching for the nRF54H20 SoC.
 
 nRF IEEE 802.15.4 radio driver
 ------------------------------

--- a/samples/esb/esb_prx/sample.yaml
+++ b/samples/esb/esb_prx/sample.yaml
@@ -53,6 +53,7 @@ tests:
     build_only: true
     extra_configs:
       - CONFIG_ESB_FAST_SWITCHING=y
+      - CONFIG_ESB_FAST_CHANNEL_SWITCHING=y
     integration_platforms:
       - nrf54h20dk_nrf54h20_cpurad
     platform_allow: >

--- a/samples/esb/esb_ptx/sample.yaml
+++ b/samples/esb/esb_ptx/sample.yaml
@@ -53,6 +53,7 @@ tests:
     build_only: true
     extra_configs:
       - CONFIG_ESB_FAST_SWITCHING=y
+      - CONFIG_ESB_FAST_CHANNEL_SWITCHING=y
     integration_platforms:
       - nrf54h20dk_nrf54h20_cpurad
     platform_allow: >

--- a/subsys/esb/Kconfig
+++ b/subsys/esb/Kconfig
@@ -162,6 +162,15 @@ config ESB_FAST_SWITCHING
 	  Enabling this feature can improve the responsiveness and efficiency of the radio
 	  communication system by reducing the latency.
 
+config ESB_FAST_CHANNEL_SWITCHING
+	select EXPERIMENTAL
+	depends on SOC_NRF54H20_CPURAD
+	bool "Fast radio channel switching [EXPERIMENTAL]"
+	help
+	  This option enables fast radio channel switching.
+	  Allows the radio channel to be changed in RX radio state
+	  without the need to switch the radio to DISABLE state.
+
 module=ESB
 module-str=ESB
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"


### PR DESCRIPTION
Adds fast radio channel switching.
Allows the radio channel to be changed in RX radio mode
without the need to switch the radio to DISABLE mode.