### PR TITLE
hw_unique_key: Enable TF-M and Cracen

### DIFF
--- a/lib/hw_unique_key/Kconfig
+++ b/lib/hw_unique_key/Kconfig
@@ -30,9 +30,7 @@ config HW_UNIQUE_KEY_LOAD
 
 config HW_UNIQUE_KEY_SUPPORTED
 	bool
-	# NCSDK-22601: HW_UNIQUE_KEY is not yet supported with both CRACEN
-	# and TF-M enabled
-	default y if HAS_HW_NRF_CC3XX || (CRACEN_HW_PRESENT && !BUILD_WITH_TFM)
+	default y if HAS_HW_NRF_CC3XX || CRACEN_HW_PRESENT
 
 config HW_UNIQUE_KEY
 	bool "Hardware Unique Keys (HUK)"


### PR DESCRIPTION
Enables hw_unique_key library on TF-M with Cracen.

Support was added in https://github.com/nrfconnect/sdk-nrf/pull/14885, but missed configuration update when rebasing.