### PR TITLE
manifest: update sdk-zephyr, nrf53/nrf54

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -54,6 +54,7 @@ Working with nRF54L Series
 ==========================
 
 * Added the :ref:`ug_nrf54l15_gs` page.
+* Changed the default value for the Kconfig option :kconfig:option:`CONFIG_CLOCK_CONTROL_NRF_ACCURACY` from 500 to 250 if :kconfig:option:`CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC` is used.
 
 Working with nRF52 Series
 =========================
@@ -64,8 +65,7 @@ Working with nRF53 Series
 =========================
 
 * Added the :ref:`features_nrf53` page.
-
-|no_changes_yet_note|
+* Changed the default value for the Kconfig option :kconfig:option:`CONFIG_CLOCK_CONTROL_NRF_ACCURACY` from 500 to 250 if :kconfig:option:`CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC` is used.
 
 Working with RF front-end modules
 =================================

--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 3733e7097909ae964e60cf66e4d51ade975ddcae
+      revision: f50ad41dd6ea61d36bece05171768e12f5ceb5a3
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull inn update of RC accuracy nRF devices.