### PR TITLE
doc: nrf: includes: fix the mapping for the nRF54L15 PDK rev 0.3.0 ta…

### DIFF
--- a/doc/nrf/includes/sample_board_rows.txt
+++ b/doc/nrf/includes/sample_board_rows.txt
@@ -220,4 +220,4 @@
 
 .. nrf54l15pdk_nrf54l15_cpuapp@0.3.0
 
-| :ref:`nRF54L15 PDK <ug_nrf54l15_gs>` | PCA10156 | :ref:`nrf54l15pdk_nrf54l15 <zephyr:nrf54l15pdk_nrf54l15>` | ``nrfl15pdk_nrf54l15_cpuapp@0.3.0`` |
+| :ref:`nRF54L15 PDK <ug_nrf54l15_gs>` | PCA10156 | :ref:`nrf54l15pdk_nrf54l15 <zephyr:nrf54l15pdk_nrf54l15>` | ``nrf54l15pdk_nrf54l15_cpuapp@0.3.0`` |


### PR DESCRIPTION
…rget

Fixed the mapping for the nRF54L15 PDK rev 0.3.0 target in the sample board rows file.