### PR TITLE
board: thingy91x_nrf9151: Add support for expansion board

### DIFF
--- a/boards/nordic/thingy91x/thingy91x_nrf9151_common.dts
+++ b/boards/nordic/thingy91x/thingy91x_nrf9151_common.dts
@@ -88,6 +88,10 @@
 
 &gpio0 {
 	status = "okay";
+	exp-board-power-enable {
+		gpio-hog;
+		gpios = <3 GPIO_ACTIVE_HIGH>;
+	};
 };
 
 /* PWM0 is intended for RGB LED control */


### PR DESCRIPTION
This patch adds support for using the expansion board. When using the expansion board, the corresponding power-enable pin must be asserted.
The most convenient way to do this is the HOG feature.