### PR TITLE
trusted_storage: Add Kconfig for custom storage backend

### DIFF
--- a/doc/nrf/libraries/security/trusted_storage.rst
+++ b/doc/nrf/libraries/security/trusted_storage.rst
@@ -97,7 +97,8 @@ Use the Kconfig option :kconfig:option:`CONFIG_TRUSTED_STORAGE_BACKEND` to defin
 If this Kconfig option is set, the configuration defaults to the only currently available option :kconfig:option:`CONFIG_TRUSTED_STORAGE_BACKEND_AEAD` to use an AEAD scheme for encryption and authentication of stored data.
 
 Use the Kconfig option :kconfig:option:`CONFIG_TRUSTED_STORAGE_STORAGE_BACKEND` to define the backend that handles how the data are written to and from the non-volatile storage.
-If this Kconfig option is set, the configuration defaults to the only currently available option :kconfig:option:`CONFIG_TRUSTED_STORAGE_STORAGE_BACKEND_SETTINGS` to use Zephyr's settings subsystem.
+If this Kconfig option is set, the configuration defaults to the :kconfig:option:`CONFIG_TRUSTED_STORAGE_STORAGE_BACKEND_SETTINGS` option to use Zephyr's settings subsystem.
+Alternatively, you can use a custom storage backend by setting the Kconfig option :kconfig:option:`CONFIG_TRUSTED_STORAGE_STORAGE_BACKEND_CUSTOM`.
 
 The following options are used to configure the AEAD backend and its behavior:
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -659,7 +659,9 @@ Libraries for NFC
 Security libraries
 ------------------
 
-|no_changes_yet_note|
+* :ref:`trusted_storage_readme` library:
+
+  * Added the Kconfig option :kconfig:option:`CONFIG_TRUSTED_STORAGE_STORAGE_BACKEND_CUSTOM` that enables use of custom storage backend.
 
 Other libraries
 ---------------

--- a/subsys/trusted_storage/Kconfig
+++ b/subsys/trusted_storage/Kconfig
@@ -162,6 +162,11 @@ config TRUSTED_STORAGE_STORAGE_BACKEND_SETTINGS
 	help
 	  Use the Settings subsystem with NVS to store the assets
 
+config TRUSTED_STORAGE_STORAGE_BACKEND_CUSTOM
+	bool "Custom storage backend"
+	help
+	  Use a custom-made backend to store data in the non-volatile memory.
+
 endchoice # CONFIG_TRUSTED_STORAGE_STORAGE_BACKEND
 
 endif # TRUSTED_STORAGE


### PR DESCRIPTION
Add Kconfig option CONFIG_TRUSTED_STORAGE_STORAGE_BACKEND_CUSTOM This allows to use the non-default Storage backend that uses Settings + NVS