### PR TITLE
manifest: Update sdk-mcuboot with cleanup for NRF54l

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -131,7 +131,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 0b5810de95eb93bbd4fba8e20a2152b33880fc43
+      revision: 0611b4c3feba6328e09b19f23a879dbc78b5d174
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR


### PR DESCRIPTION
Update sdk-mcuboot version to bring in cleanup of UARTE20 and UARTE30, for the nrf54l15 SoC.