### PR TITLE
docs(memfault): suggest Memfault in NCS docs

### DIFF
--- a/doc/nrf/device_guides/nrf52.rst
+++ b/doc/nrf/device_guides/nrf52.rst
@@ -56,6 +56,9 @@ Zephyr and the |NCS| provide support and contain board definitions for developin
 
 See also :ref:`ug_radio_fem_nrf21540ek` to learn how to use the RF front-end module (FEM) with the nRF52 Series devices.
 
+For remote monitoring of fleets running an nRF52 Series SiP, explore :ref:`Memfault <ug_memfault>`.
+The nRF Connect SDK includes out-of-the-box metrics collected with Memfault for monitoring Bluetooth connectivity such as connection time and Bluetooth thread stack usage.
+
 .. note::
     Despite being supported in :ref:`Zephyr <zephyr:thingy52_nrf52832>`, the |NCS| does not support `Nordic Thingy:52`_.
 

--- a/doc/nrf/device_guides/nrf53.rst
+++ b/doc/nrf/device_guides/nrf53.rst
@@ -27,6 +27,9 @@ Zephyr and the |NCS| provide support and contain board definitions for developin
      - ``thingy53_nrf5340``
      - `Hardware Specification <Nordic Thingy:53 Hardware_>`_
 
+For remote monitoring of fleets running an nRF53 Series SiP, explore :ref:`Memfault <ug_memfault>`.
+The nRF Connect SDK includes out-of-the-box metrics collected with Memfault for monitoring Bluetooth connectivity such as connection time and Bluetooth thread stack usage.
+
 .. toctree::
    :maxdepth: 2
    :caption: Subpages:

--- a/doc/nrf/device_guides/nrf70.rst
+++ b/doc/nrf/device_guides/nrf70.rst
@@ -91,6 +91,8 @@ The following nRF70 Series shields are available and defined in the :file:`nrf/b
 
 Applications can be developed on the nRF7002 DK (PCA10143), which includes the nRF7002 companion IC, or on boards compatible with the nRF7002 EK (PCA63556) or the nRF7002 EB (PCA63561).
 
+For remote monitoring of fleets running an nRF70 Series SiP, explore :ref:`Memfault <ug_memfault>`.
+
 .. toctree::
    :maxdepth: 2
    :caption: Subpages:

--- a/doc/nrf/device_guides/nrf91.rst
+++ b/doc/nrf/device_guides/nrf91.rst
@@ -43,6 +43,9 @@ For more advanced topics related to the nRF9161 DK, see the :ref:`ug_nrf9161` do
 
 If you want to go through a hands-on online training to familiarize yourself with cellular IoT technologies and development of cellular applications, enroll in the `Cellular IoT Fundamentals course`_ in the `Nordic Developer Academy`_.
 
+For remote monitoring of fleets running an nRF91 Series SiP, explore :ref:`Memfault <ug_memfault>`.
+The nRF Connect SDK includes out-of-the-box metrics collected with Memfault for monitoring LTE connectivity such as total bytes sent and received, the network operator, frequency band, and signal quality measurements.
+
 .. toctree::
    :maxdepth: 2
    :caption: Subpages:

--- a/doc/nrf/index.rst
+++ b/doc/nrf/index.rst
@@ -24,11 +24,15 @@ Robust connectivity support
   The |NCS| supports a wide range of connectivity technologies.
   In addition to connectivity technologies :ref:`provided by Zephyr <zephyr:connectivity>`, such as Bluetooth® Low Energy, IPv6, TCP/IP, UDP, LoRa and LoRaWAN, the |NCS| supports ANT, Bluetooth Mesh, Apple Find My, LTE-M/NB-IoT/GPS, Matter, Amazon Sidewalk, Thread, and Wi-Fi®, among others.
 
+IoT fleet observability
+  The |NCS| provides a integration with :ref:`Memfault <ug_memfault>`, an observability platform for IoT devices with debugging, monitoring, and OTA.
+  In addition to crash reporting, Memfault provides out-of-the-box metrics for Nordic devices with Bluetooth and Cellular connectivity.
+
 Scalable and extensible
   The |NCS| is out-of-tree ready and can be used for projects and applications of all sizes and levels of complexity.
 
 Third-party integrations
-  The |NCS| provides integrations with third-party and Nordic products within the SDK, such as AWS, nRF Cloud, Memfault, and more.
+  The |NCS| provides integrations with third-party and Nordic products within the SDK, such as AWS, nRF Cloud, and more.
 
 Varied reference designs
   The |NCS| comes with advanced hardware reference designs for different use cases, ranging from nRF Desktop for Human Interface Devices to nRF5340 Audio for audio devices based on Bluetooth LE Audio specifications.

--- a/doc/nrf/test_and_optimize/debugging.rst
+++ b/doc/nrf/test_and_optimize/debugging.rst
@@ -133,6 +133,14 @@ Use the following steps to enable monitor-mode debugging in the |NCS|:
 
 For more information about monitor-mode debugging, see Zephyr's :ref:`zephyr:debugmon` documentation and SEGGER's `Monitor-mode Debugging <Monitor-mode Debugging_>`_ documentation.
 
+Remote Debugging with Memfault
+******************************
+
+To collect coredumps from a remote device that has been deployed to the field, enable :ref:`Memfault <ug_memfault>`.
+Memfault collects device state at the time of a crash for debugging crashes remotely.
+Additionally, you can use Memfault to collect metrics for monitoring device health, including battery life, memory usage, and CPU usage.
+For more information on enabling Memfault for your project, see :ref:`ug_memfault`.
+
 Other debugging tools
 *********************
 


### PR DESCRIPTION
 ### Summary

 Mention Memfault in the top-level NCS page, device pages, and debugging
 page. The `:ref:` link points to [Memfault's integration page](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/external_comp/memfault.html)
 in the NCS docs.

 ### Test Plan

 - [ ] Build the docs

---

Resolves: MCU-377