### PR TITLE
samples: matter: add memory profiling configuration for nRF54L15

### DIFF
--- a/samples/matter/light_bulb/sample.yaml
+++ b/samples/matter/light_bulb/sample.yaml
@@ -57,7 +57,9 @@ tests:
     build_only: true
     extra_args: CONFIG_CHIP_MEMORY_PROFILING=y
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
+      nrf54l15pdk_nrf54l15_cpuapp
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf7002dk_nrf5340_cpuapp
+      - nrf54l15pdk_nrf54l15_cpuapp


### PR DESCRIPTION
Add configuration to enable memory profile testing for nRF54L15