### PR TITLE
applications: nrf5340_audio: Hackathon improvements

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/broadcast_source.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/broadcast_source.c
@@ -41,6 +41,8 @@ static struct bt_le_ext_adv *adv;
 static bool initialized;
 static bool delete_broadcast_src;
 
+uint8_t audio_mapping_mask[CONFIG_BT_BAP_BROADCAST_SRC_STREAM_COUNT] = {UINT8_MAX};
+
 #if (CONFIG_AURACAST)
 /* Make sure pba_buf is large enough for a 16bit UUID and meta data
  * (any addition to pba_buf requires an increase of this value)
@@ -359,7 +361,8 @@ int broadcast_source_send(struct le_audio_encoded_audio enc_audio)
 		bap_tx_streams[i] = &cap_streams[i].bap_stream;
 	}
 
-	ret = bt_le_audio_tx_send(bap_tx_streams, enc_audio, ARRAY_SIZE(cap_streams));
+	ret = bt_le_audio_tx_send(bap_tx_streams, audio_mapping_mask, enc_audio,
+				  ARRAY_SIZE(cap_streams));
 	if (ret) {
 		return ret;
 	}
@@ -433,6 +436,7 @@ int broadcast_source_enable(void)
 		/* The channel allocation is set incrementally */
 		bt_audio_codec_allocation_set(stream_params[i].data, stream_params[i].data_len,
 					      BIT(i));
+		audio_mapping_mask[i] = i;
 	}
 
 	/* Create BIGs */

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/bt_le_audio_tx/bt_le_audio_tx.h
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/bt_le_audio_tx/bt_le_audio_tx.h
@@ -19,13 +19,14 @@
  *		Do not call this for each channel.
  *
  * @param bap_streams	Pointer to an array of BAP streams.
+ * @param channel_mask	Pointer to an array of channel masks.
  * @param enc_audio	Encoded audio data.
  * @param streams_to_tx	Number of streams to send.
  *
  * @return 0 if successful, error otherwise.
  */
-int bt_le_audio_tx_send(struct bt_bap_stream **bap_streams, struct le_audio_encoded_audio enc_audio,
-			uint8_t streams_to_tx);
+int bt_le_audio_tx_send(struct bt_bap_stream **bap_streams, uint8_t *channel_mask,
+			struct le_audio_encoded_audio enc_audio, uint8_t streams_to_tx);
 
 /**
  * @brief Resets TX buffers. Must be called when a TX stream is stopped.

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_client.h
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_client.h
@@ -69,7 +69,9 @@ int unicast_client_config_get(struct bt_conn *conn, enum bt_audio_dir dir, uint3
  * @param[in]	conn	Pointer to the connection.
  * @param[in]	dir	Direction of the stream.
  *
- * @return 0 for success, error otherwise.
+ * @retval	-EALREADY	Device has already been discovered.
+ * @retval	-ENOSPC		No more room in headset list.
+ * @retval	0		Success.
  */
 int unicast_client_discover(struct bt_conn *conn, enum unicast_discover_dir dir);
 
@@ -83,16 +85,20 @@ void unicast_client_conn_disconnected(struct bt_conn *conn);
 /**
  * @brief	Start the Bluetooth LE Audio unicast (CIS) client.
  *
+ * @param[in]	dir	Direction of the stream to start.
+ *
  * @return	0 for success, error otherwise.
  */
-int unicast_client_start(void);
+int unicast_client_start(enum bt_audio_dir dir);
 
 /**
  * @brief	Stop the Bluetooth LE Audio unicast (CIS) client.
  *
+ * @param[in]	dir	Direction of the stream to stop.
+ *
  * @return	0 for success, error otherwise.
  */
-int unicast_client_stop(void);
+int unicast_client_stop(enum bt_audio_dir dir);
 
 /**
  * @brief	Send encoded audio using the Bluetooth LE Audio unicast.

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_server.h
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_server.h
@@ -70,8 +70,10 @@ int unicast_server_disable(void);
 /**
  * @brief	Enable the Bluetooth LE Audio unicast (CIS) server.
  *
+ * @param[in]	location	Location of the unicast_server to be enabled.
+ *
  * @return	0 for success, error otherwise.
  */
-int unicast_server_enable(le_audio_receive_cb rx_cb);
+int unicast_server_enable(le_audio_receive_cb rx_cb, enum bt_audio_location location);
 
 #endif /* _UNICAST_SERVER_H_ */

--- a/applications/nrf5340_audio/src/modules/led.h
+++ b/applications/nrf5340_audio/src/modules/led.h
@@ -9,28 +9,28 @@
 
 #include <stdint.h>
 
-#define LED_APP_RGB 0
-#define LED_NET_RGB 1
-#define LED_APP_1_BLUE 2
+#define LED_APP_RGB	0
+#define LED_NET_RGB	1
+#define LED_APP_1_BLUE	2
 #define LED_APP_2_GREEN 3
 #define LED_APP_3_GREEN 4
 
-#define RED 0
+#define RED   0
 #define GREEN 1
-#define BLUE 2
+#define BLUE  2
 
 #define GRN GREEN
 #define BLU BLUE
 
 enum led_color {
-	LED_COLOR_OFF, /* 000 */
-	LED_COLOR_RED, /* 001 */
-	LED_COLOR_GREEN, /* 010 */
-	LED_COLOR_YELLOW, /* 011 */
-	LED_COLOR_BLUE, /* 100 */
+	LED_COLOR_OFF,	   /* 000 */
+	LED_COLOR_RED,	   /* 001 */
+	LED_COLOR_GREEN,   /* 010 */
+	LED_COLOR_YELLOW,  /* 011 */
+	LED_COLOR_BLUE,	   /* 100 */
 	LED_COLOR_MAGENTA, /* 101 */
-	LED_COLOR_CYAN, /* 110 */
-	LED_COLOR_WHITE, /* 111 */
+	LED_COLOR_CYAN,	   /* 110 */
+	LED_COLOR_WHITE,   /* 111 */
 	LED_COLOR_NUM,
 };
 
@@ -44,14 +44,14 @@ enum led_color {
  *
  * @note A led unit is defined as an RGB LED or a monochrome LED.
  *
- * @param led_unit	Selected LED unit. Defines are located in board.h
+ * @param led_unit	Selected LED unit. Defines are located in board.h.
  * @note		If the given LED unit is an RGB LED, color must be
  *			provided as a single vararg. See led_color.
  *			For monochrome LEDs, the vararg will be ignored.
  *			Using a LED unit assigned to another core will do nothing and return 0.
- * @return		0 on success
- *			-EPERM if the module has not been initialised
- *			-EINVAL if the color argument is illegal
+ * @return		0 on success.
+ *			-EPERM if the module has not been initialized.
+ *			-EINVAL if the color argument is illegal.
  *			Other errors from underlying drivers.
  */
 int led_blink(uint8_t led_unit, ...);
@@ -61,14 +61,14 @@ int led_blink(uint8_t led_unit, ...);
  *
  * @note A led unit is defined as an RGB LED or a monochrome LED.
  *
- * @param led_unit	Selected LED unit. Defines are located in board.h
+ * @param led_unit	Selected LED unit. Defines are located in board.h.
  * @note		If the given LED unit is an RGB LED, color must be
  *			provided as a single vararg. See led_color.
  *			For monochrome LEDs, the vararg will be ignored.
-*			Using a LED unit assigned to another core will do nothing and return 0.
- * @return		0 on success
- *			-EPERM if the module has not been initialised
- *			-EINVAL if the color argument is illegal
+ *			Using a LED unit assigned to another core will do nothing and return 0.
+ * @return		0 on success.
+ *			-EPERM if the module has not been initialized.
+ *			-EINVAL if the color argument is illegal.
  *			Other errors from underlying drivers.
  */
 int led_on(uint8_t led_unit, ...);
@@ -79,23 +79,26 @@ int led_on(uint8_t led_unit, ...);
  * @note A led unit is defined as an RGB LED or a monochrome LED.
  *		Using a LED unit assigned to another core will do nothing and return 0.
  *
- * @param led_unit	Selected LED unit. Defines are located in board.h
- * @return		0 on success
- *			-EPERM if the module has not been initialised
- *			-EINVAL if the color argument is illegal
+ * @param led_unit	Selected LED unit. Defines are located in board.h.
+ * @return		0 on success.
+ *			-EPERM if the module has not been initialized.
+ *			-EINVAL if the color argument is illegal.
  *			Other errors from underlying drivers.
  */
 int led_off(uint8_t led_unit);
 
 /**
- * @brief Initialise the LED module
+ * @brief Initialise the LED module.
  *
  * @note This will parse the .dts files and configure all LEDs.
  *
- * @return	0 on success
- *		-EPERM if already initialsed
- *		-ENXIO if a LED is missing unit number in dts
- *		-ENODEV if a LED is missing color identifier
+ * @param[in]	led_override	Override the default center LED color.
+ * @param[in]	color		The color to set center LED to.
+ *
+ * @return	0 on success.
+ *		-EPERM if already initialized.
+ *		-ENXIO if a LED is missing unit number in dts.
+ *		-ENODEV if a LED is missing color identifier.
  */
 int led_init(void);
 

--- a/applications/nrf5340_audio/src/utils/nrf5340_audio_dk.c
+++ b/applications/nrf5340_audio/src/utils/nrf5340_audio_dk.c
@@ -55,16 +55,13 @@ static int leds_set(void)
 	} else {
 		ret = led_on(LED_APP_RGB, LED_COLOR_MAGENTA);
 	}
+#elif (CONFIG_AUDIO_DEV == GATEWAY)
+	ret = led_on(LED_APP_RGB, LED_COLOR_GREEN);
+#endif /* (CONFIG_AUDIO_DEV == HEADSET) */
 
 	if (ret) {
 		return ret;
 	}
-#elif (CONFIG_AUDIO_DEV == GATEWAY)
-	ret = led_on(LED_APP_RGB, LED_COLOR_GREEN);
-	if (ret) {
-		return ret;
-	}
-#endif /* (CONFIG_AUDIO_DEV == HEADSET) */
 
 	return 0;
 }

--- a/applications/nrf5340_audio/src/utils/nrf5340_audio_dk.h
+++ b/applications/nrf5340_audio/src/utils/nrf5340_audio_dk.h
@@ -4,9 +4,16 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#ifndef _NRF5340_AUDIO_DK_H_
+#define _NRF5340_AUDIO_DK_H_
+
+#include "led.h"
+
 /**
- * @brief	Initialize the hardware related modules on the nRF5340 Audio DK/PCA10121
+ * @brief	Initialize the hardware related modules on the nRF5340 Audio DK/PCA10121.
  *
  * @return	0 if successful, error otherwise.
  */
 int nrf5340_audio_dk_init(void);
+
+#endif /* _NRF5340_AUDIO_DK_H_ */

--- a/applications/nrf5340_audio/unicast_client/main.c
+++ b/applications/nrf5340_audio/unicast_client/main.c
@@ -75,11 +75,11 @@ static void content_control_msg_sub_thread(void)
 
 		switch (msg.event) {
 		case MEDIA_START:
-			unicast_client_start();
+			unicast_client_start(BT_AUDIO_DIR_SINK);
 			break;
 
 		case MEDIA_STOP:
-			unicast_client_stop();
+			unicast_client_stop(BT_AUDIO_DIR_SINK);
 			break;
 
 		default:


### PR DESCRIPTION
- Set channel for unicast_server from main
- Remove hard-coded dependencies on BT_RX
- Check both sink and source stream states
- Choose direction to start/stop for unicast
- OCT-NONE