### PR TITLE
samples: Bluetooth: Mesh: add nrf54l support for Distributor sample

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -416,6 +416,10 @@ Bluetooth Mesh samples
 
   * Added a section about the :ref:`occupancy mode <bluetooth_mesh_light_lc_occupancy_mode>`.
 
+* :ref:`ble_mesh_dfu_distributor` sample:
+
+  * Added support for the :ref:`nRF54L15 PDK <ug_nrf54l15_gs>` board.
+
 Cellular samples
 ----------------
 

--- a/samples/bluetooth/mesh/dfu/distributor/README.rst
+++ b/samples/bluetooth/mesh/dfu/distributor/README.rst
@@ -116,8 +116,6 @@ Building and running
 Testing
 =======
 
-This sample has been tested with the nRF52840 DK (nrf52840dk/nrf52840) board.
-
 .. _ble_mesh_dfu_distributor_provisioning:
 
 Provisioning the device
@@ -170,7 +168,7 @@ The management subsystem uses the Simple Management Protocol (SMP), provided by 
 This sample supports Bluetooth Low Energy and UART as the SMP transport.
 See :ref:`zephyr:device_mgmt` for more information about Mcumgr and SMP.
 
-In this sample, the device flash is split into fixed partitions using devicetree as defined in :zephyr_file:`nrf52840dk_nrf52840.dts<boards/nordic/nrf52840dk/nrf52840dk_nrf52840.dts>`.
+In this sample, the device flash is split into fixed partitions using devicetree as defined in :zephyr_file:`nrf52840dk_nrf52840.dts<boards/nordic/nrf52840dk/nrf52840dk_nrf52840.dts>`  and :zephyr_file:`nrf54l15pdk_nrf54l15_cpuapp.dts<boards/nordic/nrf54l15pdk_nrf54l15/nrf54l15pdk_nrf54l15_cpuapp.dts>`.
 The firmware image that is to be distributed over Bluetooth Mesh network should be stored at slot-1.
 The sample uses :ref:`zephyr:flash_map_api` to read the firmware image from slot-1 when distributes it to Target nodes.
 

--- a/samples/bluetooth/mesh/dfu/distributor/README.rst
+++ b/samples/bluetooth/mesh/dfu/distributor/README.rst
@@ -10,8 +10,6 @@ Bluetooth Mesh: Device Firmware Update (DFU) distributor
 The Bluetooth® Mesh DFU distributor sample demonstrates how device firmware can be distributed over a Bluetooth Mesh network.
 The sample implements the Firmware Distribution role of the :ref:`Bluetooth Mesh DFU subsystem <zephyr:bluetooth_mesh_dfu>`.
 
-The specification that the Bluetooth Mesh DFU subsystem is based on is not adopted yet, and therefore this feature should be used for experimental purposes only.
-
 Requirements
 ************
 

--- a/samples/bluetooth/mesh/dfu/distributor/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/bluetooth/mesh/dfu/distributor/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+################################################################################
+# Application overlay - nrf54l15
+
+CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE=n

--- a/samples/bluetooth/mesh/dfu/distributor/sample.yaml
+++ b/samples/bluetooth/mesh/dfu/distributor/sample.yaml
@@ -5,12 +5,14 @@ tests:
     build_only: true
     integration_platforms:
       - nrf52840dk/nrf52840
-    platform_allow: nrf52840dk/nrf52840
+      - nrf54l15pdk/nrf54l15/cpuapp
+    platform_allow: nrf52840dk/nrf52840 nrf54l15pdk/nrf54l15/cpuapp
     tags: bluetooth ci_build
   sample.bluetooth.mesh_dfu_distributor.smp_bt_auth:
     build_only: true
     integration_platforms:
       - nrf52840dk/nrf52840
-    platform_allow: nrf52840dk/nrf52840
+      - nrf54l15pdk/nrf54l15/cpuapp
+    platform_allow: nrf52840dk/nrf52840 nrf54l15pdk/nrf54l15/cpuapp
     extra_args: OVERLAY_CONFIG=overlay-smp-bt-auth.conf
     tags: bluetooth ci_build


### PR DESCRIPTION
Add support for nrf54l15pdk_nrf54l15_cpuapp in Mesh DFU Distributor sample.

Removes statement from Distributor sample README which says that the DFU spec is not yet adopted.