### PR TITLE
wifi: sr_coex: Exclude SR co-ex GPIOs for nRF91 series

### DIFF
--- a/boards/shields/nrf7002eb/boards/nrf52840dk_nrf52840.overlay
+++ b/boards/shields/nrf7002eb/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,5 @@
+/* Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+ #include "../nrf7002eb_coex.overlay"

--- a/boards/shields/nrf7002eb/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/boards/shields/nrf7002eb/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,5 @@
+/* Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+#include "../nrf7002eb_coex.overlay"

--- a/boards/shields/nrf7002eb/boards/thingy53_nrf5340_cpuapp.overlay
+++ b/boards/shields/nrf7002eb/boards/thingy53_nrf5340_cpuapp.overlay
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+ #include "../nrf7002eb_coex.overlay"
+
  /* The below overlays might not be explicitly required but still
   * kept here to warn of the conflicting pins that could hamper
   * functionality later

--- a/boards/shields/nrf7002eb/nrf7002eb.overlay
+++ b/boards/shields/nrf7002eb/nrf7002eb.overlay
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 #include <freq.h>
-#include "nrf7002eb_coex.overlay"
 
 / {
         nordic_wlan0: nordic_wlan0 {

--- a/boards/shields/nrf7002ek/boards/nrf52840dk_nrf52840.overlay
+++ b/boards/shields/nrf7002ek/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,5 @@
+/* Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+ #include "../nrf7002ek_coex.overlay"

--- a/boards/shields/nrf7002ek/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/boards/shields/nrf7002ek/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -2,6 +2,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+#include "../nrf7002ek_coex.overlay"
 
 /* This node by default forwards the UART1 pins to CPUNET, but as UART1 uses
  * same pins as bucken and iovdd-ctrl, we need these pins to be controlled by

--- a/boards/shields/nrf7002ek/boards/thingy53_nrf5340_cpuapp.overlay
+++ b/boards/shields/nrf7002ek/boards/thingy53_nrf5340_cpuapp.overlay
@@ -1,0 +1,5 @@
+/* Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+ #include "../nrf7002ek_coex.overlay"

--- a/boards/shields/nrf7002ek/nrf7002ek.overlay
+++ b/boards/shields/nrf7002ek/nrf7002ek.overlay
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 #include <freq.h>
-#include "nrf7002ek_coex.overlay"
 
 / {
 	nordic_wlan0: nordic_wlan0 {

--- a/boards/shields/nrf7002ek_nrf7000/boards/nrf52840dk_nrf52840.overlay
+++ b/boards/shields/nrf7002ek_nrf7000/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,5 @@
+/* Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+ #include "../nrf7002ek_nrf7000_coex.overlay"

--- a/boards/shields/nrf7002ek_nrf7000/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/boards/shields/nrf7002ek_nrf7000/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -2,6 +2,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+ #include "../nrf7002ek_nrf7000_coex.overlay"
 
 /* This node by default forwards the UART1 pins to CPUNET, but as UART1 uses
  * same pins as bucken and iovdd-ctrl, we need these pins to be controlled by

--- a/boards/shields/nrf7002ek_nrf7000/boards/thingy53_nrf5340_cpuapp.overlay
+++ b/boards/shields/nrf7002ek_nrf7000/boards/thingy53_nrf5340_cpuapp.overlay
@@ -1,0 +1,5 @@
+/* Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+ #include "../nrf7002ek_nrf7000_coex.overlay"

--- a/boards/shields/nrf7002ek_nrf7000/nrf7002ek_nrf7000.overlay
+++ b/boards/shields/nrf7002ek_nrf7000/nrf7002ek_nrf7000.overlay
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 #include <freq.h>
-#include "nrf7002ek_nrf7000_coex.overlay"
 
 / {
         nordic_wlan0: nordic_wlan0 {

--- a/boards/shields/nrf7002ek_nrf7001/boards/nrf52840dk_nrf52840.overlay
+++ b/boards/shields/nrf7002ek_nrf7001/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,5 @@
+/* Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+ #include "../nrf7002ek_nrf7001_coex.overlay"

--- a/boards/shields/nrf7002ek_nrf7001/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/boards/shields/nrf7002ek_nrf7001/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -2,6 +2,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+ #include "../nrf7002ek_nrf7001_coex.overlay"
 
 /* This node by default forwards the UART1 pins to CPUNET, but as UART1 uses
  * same pins as bucken and iovdd-ctrl, we need these pins to be controlled by

--- a/boards/shields/nrf7002ek_nrf7001/boards/thingy53_nrf5340_cpuapp.overlay
+++ b/boards/shields/nrf7002ek_nrf7001/boards/thingy53_nrf5340_cpuapp.overlay
@@ -1,0 +1,5 @@
+/* Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+ #include "../nrf7002ek_nrf7001_coex.overlay"

--- a/boards/shields/nrf7002ek_nrf7001/nrf7002ek_nrf7001.overlay
+++ b/boards/shields/nrf7002ek_nrf7001/nrf7002ek_nrf7001.overlay
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 #include <freq.h>
-#include "nrf7002ek_nrf7001_coex.overlay"
 
 / {
         nordic_wlan0: nordic_wlan0 {

--- a/doc/_scripts/software_maturity/software_maturity_features.yaml
+++ b/doc/_scripts/software_maturity/software_maturity_features.yaml
@@ -86,7 +86,7 @@ features:
         - BOARD_NRF7002DK_NRF5340_CPUAPP
         - BOARD_NRF7002DK_NRF7001_NRF5340_CPUAPP
     Bluetooth LE Co-existence:
-      rule: WIFI_NRF700X && NRF700X_BT_COEX
+      rule: WIFI_NRF700X && NRF700X_SR_COEX
       boards_and_shields:
         - SHIELD_NRF7002EK
         - SHIELD_NRF7002EK_NRF7001

--- a/drivers/wifi/nrf700x/Kconfig
+++ b/drivers/wifi/nrf700x/Kconfig
@@ -263,7 +263,7 @@ config NRF700X_UTIL
 
 config NRF700X_SR_COEX
 	bool "Enable Wi-Fi and SR coexistence support"
-	default y if SOC_NRF5340_CPUAPP_QKAA
+	def_bool $(dt_nodelabel_enabled,nrf_radio_coex)
 
 config NRF700X_QSPI_LOW_POWER
 	bool "Enable low power mode in QSPI"

--- a/drivers/wifi/nrf700x/Kconfig
+++ b/drivers/wifi/nrf700x/Kconfig
@@ -241,6 +241,11 @@ config NRF700X_ON_SPI
 	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF700X_SPI))
 	select SPI
 
+
+config NRF700X_SR_COEX
+	bool "Enable Wi-Fi and SR coexistence support"
+	def_bool $(dt_nodelabel_enabled,nrf_radio_coex)
+
 # RF switch based coexistence
 config NRF700X_SR_COEX_RF_SWITCH
 	def_bool $(dt_nodelabel_has_prop,nrf_radio_coex,btrf-switch-gpios)
@@ -260,10 +265,6 @@ config NRF700X_MAX_TX_PENDING_QLEN
 config NRF700X_UTIL
 	depends on SHELL
 	bool "Enable Utility shell in nRF700x driver"
-
-config NRF700X_SR_COEX
-	bool "Enable Wi-Fi and SR coexistence support"
-	def_bool $(dt_nodelabel_enabled,nrf_radio_coex)
 
 config NRF700X_QSPI_LOW_POWER
 	bool "Enable low power mode in QSPI"

--- a/drivers/wifi/nrf700x/Kconfig
+++ b/drivers/wifi/nrf700x/Kconfig
@@ -242,7 +242,7 @@ config NRF700X_ON_SPI
 	select SPI
 
 # RF switch based coexistence
-config NRF700X_RADIO_COEX
+config NRF700X_SR_COEX_RF_SWITCH
 	def_bool $(dt_nodelabel_has_prop,nrf_radio_coex,btrf-switch-gpios)
 
 config NRF700X_WORKQ_STACK_SIZE

--- a/drivers/wifi/nrf700x/inc/coex.h
+++ b/drivers/wifi/nrf700x/inc/coex.h
@@ -38,7 +38,7 @@ enum nrf_wifi_pta_wlan_op_band {
 int nrf_wifi_coex_config_pta(enum nrf_wifi_pta_wlan_op_band wlan_band, bool separate_antennas,
 	bool is_sr_protocol_ble);
 
-#if defined(CONFIG_NRF700X_RADIO_COEX) || defined(__DOXYGEN__)
+#if defined(CONFIG_NRF700X_SR_COEX_RF_SWITCH) || defined(__DOXYGEN__)
 /**
  * @function   nrf_wifi_config_sr_switch(bool separate_antennas)
  *
@@ -52,7 +52,7 @@ int nrf_wifi_coex_config_pta(enum nrf_wifi_pta_wlan_op_band wlan_band, bool sepa
  *             Returns non-zero upon unsuccessful configuration.
  */
 int nrf_wifi_config_sr_switch(bool separate_antennas);
-#endif /* CONFIG_NRF700X_RADIO_COEX */
+#endif /* CONFIG_NRF700X_SR_COEX_RF_SWITCH */
 
 /**
  * @function   nrf_wifi_coex_config_non_pta(bool separate_antennas)

--- a/drivers/wifi/nrf700x/src/coex.c
+++ b/drivers/wifi/nrf700x/src/coex.c
@@ -40,11 +40,11 @@ static struct nrf_wifi_ctx_zep *rpu_ctx = &rpu_drv_priv_zep.rpu_ctx_zep;
 /* copied from uccp530_77_registers.h of UCCP toolkit */
 #define ABS_PMB_WLAN_MAC_CTRL_PULSED_SOFTWARE_RESET 0xA5009A00UL
 
-#ifdef CONFIG_NRF700X_RADIO_COEX
+#ifdef CONFIG_NRF700X_SR_COEX_RF_SWITCH
 	#define NRF_RADIO_COEX_NODE DT_NODELABEL(nrf_radio_coex)
 	static const struct gpio_dt_spec sr_rf_switch_spec =
 	GPIO_DT_SPEC_GET(NRF_RADIO_COEX_NODE, btrf_switch_gpios);
-#endif /* CONFIG_NRF700X_RADIO_COEX */
+#endif /* CONFIG_NRF700X_SR_COEX_RF_SWITCH */
 
 /* PTA registers configuration of Coexistence Hardware */
 /* Separate antenna configuration, WLAN in 2.4GHz. For BLE protocol. */
@@ -229,7 +229,7 @@ int nrf_wifi_coex_config_pta(enum nrf_wifi_pta_wlan_op_band wlan_band, bool sepa
 
 	return 0;
 }
-#ifdef CONFIG_NRF700X_RADIO_COEX
+#ifdef CONFIG_NRF700X_SR_COEX_RF_SWITCH
 int nrf_wifi_config_sr_switch(bool separate_antennas)
 {
 	int ret;
@@ -255,7 +255,7 @@ int nrf_wifi_config_sr_switch(bool separate_antennas)
 
 	return 0;
 }
-#endif /* CONFIG_NRF700X_RADIO_COEX */
+#endif /* CONFIG_NRF700X_SR_COEX_RF_SWITCH */
 
 int nrf_wifi_coex_hw_reset(void)
 {

--- a/drivers/wifi/nrf700x/src/qspi/inc/rpu_hw_if.h
+++ b/drivers/wifi/nrf700x/src/qspi/inc/rpu_hw_if.h
@@ -53,7 +53,7 @@ int rpu_init(void);
 int rpu_enable(void);
 int rpu_disable(void);
 
-#ifdef CONFIG_NRF700X_RADIO_COEX
+#ifdef CONFIG_NRF700X_SR_COEX_RF_SWITCH
 int sr_ant_switch(unsigned int ant_switch);
-#endif /* CONFIG_NRF700X_RADIO_COEX */
+#endif /* CONFIG_NRF700X_SR_COEX_RF_SWITCH */
 #endif /* __RPU_HW_IF_H_ */

--- a/drivers/wifi/nrf700x/src/qspi/src/rpu_hw_if.c
+++ b/drivers/wifi/nrf700x/src/qspi/src/rpu_hw_if.c
@@ -35,11 +35,11 @@ GPIO_DT_SPEC_GET(NRF7002_NODE, iovdd_ctrl_gpios);
 static const struct gpio_dt_spec bucken_spec =
 GPIO_DT_SPEC_GET(NRF7002_NODE, bucken_gpios);
 
-#ifdef CONFIG_NRF700X_RADIO_COEX
+#ifdef CONFIG_NRF700X_SR_COEX_RF_SWITCH
 #define NRF_RADIO_COEX_NODE DT_NODELABEL(nrf_radio_coex)
 static const struct gpio_dt_spec sr_rf_switch_spec =
 GPIO_DT_SPEC_GET(NRF_RADIO_COEX_NODE, btrf_switch_gpios);
-#endif /* CONFIG_NRF700X_RADIO_COEX */
+#endif /* CONFIG_NRF700X_SR_COEX_RF_SWITCH */
 
 char blk_name[][15] = { "SysBus",   "ExtSysBus",	   "PBus",	   "PKTRAM",
 			       "GRAM",	   "LMAC_ROM",	   "LMAC_RET_RAM", "LMAC_SRC_RAM",
@@ -178,7 +178,7 @@ out:
 
 static int sr_gpio_config(void)
 {
-#ifdef CONFIG_NRF700X_RADIO_COEX
+#ifdef CONFIG_NRF700X_SR_COEX_RF_SWITCH
 	int ret;
 
 	if (!device_is_ready(sr_rf_switch_spec.port)) {
@@ -194,12 +194,12 @@ static int sr_gpio_config(void)
 	return ret;
 #else
 	return 0;
-#endif /* CONFIG_NRF700X_RADIO_COEX */
+#endif /* CONFIG_NRF700X_SR_COEX_RF_SWITCH */
 }
 
 static int sr_gpio_remove(void)
 {
-#ifdef CONFIG_NRF700X_RADIO_COEX
+#ifdef CONFIG_NRF700X_SR_COEX_RF_SWITCH
 	int ret;
 
 	ret = gpio_pin_configure_dt(&sr_rf_switch_spec, GPIO_DISCONNECTED);
@@ -318,7 +318,7 @@ static int rpu_pwroff(void)
 	return ret;
 }
 
-#ifdef CONFIG_NRF700X_RADIO_COEX
+#ifdef CONFIG_NRF700X_SR_COEX_RF_SWITCH
 int sr_ant_switch(unsigned int ant_switch)
 {
 	int ret;
@@ -331,7 +331,7 @@ int sr_ant_switch(unsigned int ant_switch)
 
 	return ret;
 }
-#endif /* CONFIG_NRF700X_RADIO_COEX */
+#endif /* CONFIG_NRF700X_SR_COEX_RF_SWITCH */
 
 int rpu_read(unsigned int addr, void *data, int len)
 {

--- a/samples/wifi/ble_coex/src/main.c
+++ b/samples/wifi/ble_coex/src/main.c
@@ -365,14 +365,14 @@ int main(void)
 	LOG_INF("test_wlan = %d and test_ble = %d\n", test_wlan, test_ble);
 
 
-#ifdef CONFIG_NRF700X_RADIO_COEX
+#ifdef CONFIG_NRF700X_SR_COEX_RF_SWITCH
 	/* Configure SR side (nRF5340 side) switch for nRF700x DK */
 	ret = nrf_wifi_config_sr_switch(separate_antennas);
 	if (ret != 0) {
 		LOG_ERR("Unable to configure SR side switch: %d\n", ret);
 		goto err;
 	}
-#endif /* CONFIG_NRF700X_RADIO_COEX */
+#endif /* CONFIG_NRF700X_SR_COEX_RF_SWITCH */
 
 	if (test_wlan) {
 		/* Wi-Fi connection */

--- a/samples/wifi/radio_test/src/nrf_wifi_radio_test_shell.c
+++ b/samples/wifi/radio_test/src/nrf_wifi_radio_test_shell.c
@@ -1352,7 +1352,7 @@ static int nrf_wifi_radio_test_set_rx(const struct shell *shell,
 	return 0;
 }
 
-#ifdef CONFIG_NRF700X_RADIO_COEX
+#ifdef CONFIG_NRF700X_SR_COEX_RF_SWITCH
 static int nrf_wifi_radio_test_sr_ant_switch_ctrl(const struct shell *shell,
 					     size_t argc,
 					     const char *argv[])
@@ -1370,7 +1370,7 @@ static int nrf_wifi_radio_test_sr_ant_switch_ctrl(const struct shell *shell,
 
 	return sr_ant_switch(val);
 }
-#endif /* CONFIG_NRF700X_RADIO_COEX */
+#endif /* CONFIG_NRF700X_SR_COEX_RF_SWITCH */
 
 
 static int nrf_wifi_radio_test_rx_cap(const struct shell *shell,
@@ -2327,7 +2327,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      nrf_wifi_radio_test_set_rx,
 		      2,
 		      0),
-#ifdef CONFIG_NRF700X_RADIO_COEX
+#ifdef CONFIG_NRF700X_SR_COEX_RF_SWITCH
 	SHELL_CMD_ARG(sr_ant_switch_ctrl,
 		      NULL,
 		      "0 - Switch set to use the BLE antenna\n"
@@ -2335,7 +2335,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      nrf_wifi_radio_test_sr_ant_switch_ctrl,
 		      2,
 		      0),
-#endif /* CONFIG_NRF700X_RADIO_COEX */
+#endif /* CONFIG_NRF700X_SR_COEX_RF_SWITCH */
 	SHELL_CMD_ARG(rx_lna_gain,
 		      NULL,
 		      "<val> - LNA gain to be configured.\n"


### PR DESCRIPTION
GPIOs are limited, so, exclude the SR co-ex GPIOs if they aren't necessary.

Tried to avoid duplication by including a common definitions, this also gives us flexibility in the future to go custom way. Also, used the per-board overlays so that co-ex overlays are picked without user intervention (If user needs to explicitly enable co-ex then a simple snippet would suffice rather than too many per-board files).