### PR TITLE
doc: Matter bridge: More missing Kconfigs

### DIFF
--- a/applications/matter_bridge/doc/matter_bridge_description.rst
+++ b/applications/matter_bridge/doc/matter_bridge_description.rst
@@ -381,13 +381,6 @@ CONFIG_BRIDGED_DEVICE_IMPLEMENTATION
    CONFIG_BRIDGED_DEVICE_BT
       Implement a Bluetooth LE bridged device.
 
-.. _CONFIG_BRIDGE_BT_MINIMUM_SECURITY_LEVEL:
-
-CONFIG_BRIDGE_BT_MINIMUM_SECURITY_LEVEL
-   Set the minimum Bluetooth security level of bridged devices that the bridge device will accept.
-   Bridged devices using this or a higher level will be allowed to connect to the bridge.
-   See the :ref:`matter_bridge_app_bt_security` section for more information.
-
 .. _CONFIG_BRIDGE_HUMIDITY_SENSOR_BRIDGED_DEVICE:
 
 CONFIG_BRIDGE_HUMIDITY_SENSOR_BRIDGED_DEVICE
@@ -438,6 +431,35 @@ CONFIG_BRIDGED_DEVICE_SIMULATED_ONOFF_IMPLEMENTATION
    CONFIG_BRIDGED_DEVICE_SIMULATED_ONOFF_SHELL
       Shell-controlled simulated OnOff device.
       The state of the simulated device is changed using shell commands.
+
+If you selected the Bluetooth LE device implementation using the :ref:`CONFIG_BRIDGED_DEVICE_BT <CONFIG_BRIDGED_DEVICE_BT>` Kconfig option, also check and configure the following options:
+
+.. _CONFIG_BRIDGE_BT_MAX_SCANNED_DEVICES:
+
+CONFIG_BRIDGE_BT_MAX_SCANNED_DEVICES
+   Set the maximum amount of scanned devices.
+
+.. _CONFIG_BRIDGE_BT_MINIMUM_SECURITY_LEVEL:
+
+CONFIG_BRIDGE_BT_MINIMUM_SECURITY_LEVEL
+   Set the minimum Bluetooth security level of bridged devices that the bridge device will accept.
+   Bridged devices using this or a higher level will be allowed to connect to the bridge.
+   See the :ref:`matter_bridge_app_bt_security` section for more information.
+
+.. _CONFIG_BRIDGE_BT_RECOVERY_MAX_INTERVAL:
+
+CONFIG_BRIDGE_BT_RECOVERY_MAX_INTERVAL
+   Set the maximum time (in seconds) between recovery attempts when the Bluetooth LE connection to the bridged device is lost.
+
+.. _CONFIG_BRIDGE_BT_RECOVERY_SCAN_TIMEOUT_MS:
+
+CONFIG_BRIDGE_BT_RECOVERY_SCAN_TIMEOUT_MS
+   Set the time (in milliseconds) within which the Bridge will try to re-establish a connection to the lost Bluetooth LE device.
+
+.. _CONFIG_BRIDGE_BT_SCAN_TIMEOUT_MS:
+
+CONFIG_BRIDGE_BT_SCAN_TIMEOUT_MS
+   Set the Bluetooth LE scan timeout in milliseconds.
 
 The following options affect how many bridged devices the application supports.
 See the :ref:`matter_bridge_app_bridged_support_configs` section for more information.


### PR DESCRIPTION
A couple of application-specific Kconfigs got left out from the previous batch.