### PR TITLE
net: lwm2m_client_utils: Fix LAC reporting on ConnMonn v1.3

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -658,6 +658,7 @@ Libraries for networking
     * :c:func:`lwm2m_init_connmon`
 
   * :c:func:`lwm2m_init_firmware` is deprecated in favour of :c:func:`lwm2m_init_firmware_cb` that allows application to set a callback to receive FOTA events.
+  * Fixed an issue where the Location Area Code was not updated when the Connection Monitor object version 1.3 was enabled.
 
 Libraries for NFC
 -----------------

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_connmon.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_connmon.c
@@ -30,7 +30,8 @@ LOG_MODULE_REGISTER(lwm2m_connmon, CONFIG_LWM2M_CLIENT_UTILS_LOG_LEVEL);
 #define CONNMON_CELLID				8
 #define CONNMON_SMNC				9
 #define CONNMON_SMCC				10
-#if defined(CONFIG_LWM2M_CONNMON_OBJECT_VERSION_1_2)
+#if defined(CONFIG_LWM2M_CONNMON_OBJECT_VERSION_1_2) ||                                            \
+	defined(CONFIG_LWM2M_CONNMON_OBJECT_VERSION_1_3)
 #define CONNMON_SIGNAL_SNR			11
 #define CONNMON_LAC				12
 #endif
@@ -106,7 +107,7 @@ static void modem_data_update(struct k_work *work)
 		      modem_param.network.mnc.value);
 	lwm2m_set_u16(&LWM2M_OBJ(LWM2M_OBJECT_CONNECTIVITY_MONITORING_ID, 0, CONNMON_SMCC),
 		      modem_param.network.mcc.value);
-#if defined(CONFIG_LWM2M_CONNMON_OBJECT_VERSION_1_2)
+#if defined(CONNMON_LAC)
 	lwm2m_set_u16(&LWM2M_OBJ(LWM2M_OBJECT_CONNECTIVITY_MONITORING_ID, 0, CONNMON_LAC),
 		      modem_param.network.area_code.value);
 #endif


### PR DESCRIPTION
Fix reporting on Connection Monitor object version 1.3.