### PR TITLE
applications: nrf_desktop: Fix LED labels on nRF52840DK

### DIFF
--- a/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/app.overlay
+++ b/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/app.overlay
@@ -34,7 +34,7 @@
 		pwm_led2: led_pwm_2 {
 			status = "okay";
 			pwms = <&pwm2 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
-			label = "LED Caps Lock";
+			label = "LED Num Lock";
 		};
 	};
 
@@ -45,7 +45,7 @@
 		pwm_led3: led_pwm_3 {
 			status = "okay";
 			pwms = <&pwm3 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
-			label = "LED Num Lock";
+			label = "LED Caps Lock";
 		};
 	};
 };


### PR DESCRIPTION
Change fixes labels of "Num Lock" and "Caps Lock" LEDs.