### PR TITLE
drivers: wifi: Add a config option for AP dead detection timeout

### DIFF
--- a/drivers/wifi/nrf700x/Kconfig
+++ b/drivers/wifi/nrf700x/Kconfig
@@ -395,3 +395,11 @@ config NRF_WIFI_OP_BAND
 	  1 - 2.4GHz
 	  2 - 5GHz
 	  3 - All ( 2.4GHz and 5GHz )
+
+config NRF_WIFI_AP_DEAD_DETECT_TIMEOUT
+	int "Access point dead detection timeout in seconds"
+	range 1 30
+	default 20
+	help
+		The number of seconds after which AP is declared dead if no beacons
+		are received from the AP. Used to detect AP silently going down e.g., power off.

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/cmd.c
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/cmd.c
@@ -148,6 +148,7 @@ enum nrf_wifi_status umac_cmd_init(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 #ifdef CONFIG_NRF700X_TCP_IP_CHECKSUM_OFFLOAD
 	umac_cmd_data->tcp_ip_checksum_offload = 1;
 #endif /* CONFIG_NRF700X_TCP_IP_CHECKSUM_OFFLOAD */
+	umac_cmd_data->discon_timeout = CONFIG_NRF_WIFI_AP_DEAD_DETECT_TIMEOUT;
 
 	nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv, "RPU LPM type: %s\n",
 		umac_cmd_data->sys_params.sleep_enable == 2 ? "HW" :


### PR DESCRIPTION
This is handy esp. in crowded channel environments to avoid false AP dead detections, the default is chosen accordingly.

Implements SHEL-2689.