### PR TITLE
manifest: Pulled fix for mcuboot configuration in Matter

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -160,7 +160,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: d76797e8cb75fae4063c524369e7da419b3c1ed3
+      revision: e734b7924bf2b6bdc78e20d8416267f42ba95675
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
Updated Matter manifest version to pull the mcuboot configuration fix that does not allo to change external flash backends between SPI and QSPI (and opposite).