### PR TITLE
manifest: tf-m: Add LFXO and CTRL-AP support on 54L

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -152,7 +152,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: 914545280fd8d8f65141398734685b924de10ad2
+      revision: 7b734feaad68ae53d98dbdd916d80d45ffda9a9f
     - name: psa-arch-tests
       repo-path: sdk-psa-arch-tests
       path: modules/tee/tf-m/psa-arch-tests


### PR DESCRIPTION
Configuring XL1 and XL2 Pin, which are needed for
low-frequency crystal oscillator (LFXO)

Ref: NCSDK-26595
Ref: NCSDK-25047
Ref: NCSDK-20678