### PR TITLE
doc: fix links to Matter resource kit

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -1166,15 +1166,15 @@
 .. _`Zigbee Cluster Library specification`: https://zigbeealliance.org/wp-content/uploads/2019/12/07-5123-06-zigbee-cluster-library-specification.pdf
 
 .. _`Matter Resource Kit`:
-.. _`CSA Matter Resource Kit`: https://groups.csa-iot.org/wg/all-users/home/matter-resource-kit
+.. _`CSA Matter Resource Kit`: https://community.csa-iot.org/page/matter-resource-kit
 .. _`Connectivity Standards Alliance Certification Policy`: https://csa-iot.org/wp-content/uploads/2021/12/07-4842-14-ptsc-certification-policy.pdf
 .. _`CSA's Testing Providers`: https://csa-iot.org/certification/testing-providers/
 .. _`CSA's Certification Team`: https://csa-iot.org/contact-us/
 .. _`Connectivity Standards Alliance members`: https://csa-iot.org/members/
 .. _`Join CSA`: https://csa-iot.org/become-member/
-.. _`CSA Member Resources page`: https://groups.csa-iot.org/wg/all-users/home/member-resources
 .. _`Matter Attestation Form`: https://groups.csa-iot.org/wg/members-all/document/folder/2255
 .. _`Matter Attestation of Security template`: https://groups.csa-iot.org/wg/members-all/document/27432
+.. _`PICS Tool`: https://picstool.csa-iot.org/
 .. _`Connectivity Standards Alliance Certification Web Tool`: https://zigbeecertifiedproducts.knack.com/zigbee-certified#home/
 .. _`CSA Certified Products Database`: https://csa-iot.org/csa-iot_products/
 .. _`CSA blog post`: https://csa-iot.org/newsroom/matter-1-1-release-enhancements-for-developers-and-devices/

--- a/doc/nrf/protocols/matter/end_product/certification.rst
+++ b/doc/nrf/protocols/matter/end_product/certification.rst
@@ -99,7 +99,7 @@ Application
 ===========
 
 Once you have obtained the test report for your Matter component, you can apply for the certification to CSA.
-You can do this online from the `CSA Member Resources page`_ using the different Certification and Testing tools to submit the required documentation.
+You can do this online from the `CSA Matter Resource Kit`_ using the different Certification and Testing tools to submit the required documentation.
 
 Application requirements
 ------------------------
@@ -129,7 +129,7 @@ Certification document templates from Nordic Semiconductor
 PICS
 ++++
 
-You can generate the PICS in the XML format using CSA's PICS Tool, available from `CSA Member Resources page`_.
+You can generate the PICS in the XML format using the `PICS Tool`_, which is provided by CSA.
 
 Dependent Transport Attestation
 +++++++++++++++++++++++++++++++


### PR DESCRIPTION
CSA has changed the structure of their website.
This fixes the affected links in our documentation.

KRKNWK-18898