### PR TITLE
manifest: Update Zephyr to enable basic_pwm example on nRF54L15

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 54b4e400ed8ffe37602112ad719bab4db5ea0087
+      revision: pull/1661/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Updates zephyr pointer.