### PR TITLE
applications: serial_lte_modem: GNSS NMEA output on its own CMUX channel

### DIFF
--- a/applications/serial_lte_modem/Kconfig
+++ b/applications/serial_lte_modem/Kconfig
@@ -181,6 +181,10 @@ config SLM_CMUX_AUTOMATIC_FALLBACK_ON_PPP_STOPPAGE
 
 endif
 
+module = SLM
+module-str = serial modem
+source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
+
 rsource "src/ftp_c/Kconfig"
 rsource "src/mqtt_c/Kconfig"
 rsource "src/http_c/Kconfig"
@@ -189,9 +193,5 @@ rsource "src/gpio/Kconfig"
 rsource "src/lwm2m_carrier/Kconfig"
 rsource "src/gnss/Kconfig"
 rsource "src/nativetls/Kconfig"
-
-module = SLM
-module-str = serial modem
-source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
 
 endmenu

--- a/applications/serial_lte_modem/doc/CMUX_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/CMUX_AT_commands.rst
@@ -58,8 +58,9 @@ Syntax
    AT#XCMUX[=<AT_channel>]
 
 The ``<AT_channel>`` parameter is an integer used to indicate the address of the AT channel.
-If specified, it must be between 1 and the total number of channels.
 The AT channel denotes the CMUX channel where AT data (commands, responses, notifications) is exchanged.
+If specified, it must be 1, unlesss :ref:`PPP <CONFIG_SLM_PPP>` is enabled.
+If PPP is enabled, it can also be 2 (to allocate the first CMUX channel to PPP).
 If not specified, the previously used address is used.
 If no address has been previously specified, the default address is 1.
 

--- a/applications/serial_lte_modem/doc/GNSS_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/GNSS_AT_commands.rst
@@ -55,22 +55,21 @@ It can have one of the following values:
 * Ranging from ``10`` to ``65535`` - Periodic navigation mode.
   The fix interval is set to the specified value.
 
-In continuous navigation mode, the ``<timeout>`` parameter must be omitted.
-In single-fix and periodic navigation modes, the ``<timeout>`` parameter indicates the maximum time in seconds that the GNSS receiver is allowed to run while trying to produce a valid Position, Velocity, and Time (PVT) estimate.
+``timeout`` is an integer that indicates the maximum time in seconds that the GNSS receiver is allowed to run while trying to produce a valid Position, Velocity, and Time (PVT) estimate.
+It can only be specified in single-fix and periodic navigation modes.
+
 It can be one of the following:
 
 * ``0`` - The GNSS receiver runs indefinitely until a valid PVT estimate is produced.
 * Any positive integer - The GNSS receiver is turned off after the specified time is up, even if a valid PVT estimate was not produced.
 * Omitted - In single-fix or periodic navigation mode, the timeout defaults to 60 seconds.
 
+In periodic navigation mode, the ``<interval>`` and ``<timeout>`` parameters are temporarily ignored during the first fix.
+
 .. note::
 
    When ``<cloud_assistance>`` is disabled, no request is made to nRF Cloud for assistance data.
    However, if it has been previously enabled and used, such data may remain locally and will be used if still valid.
-
-.. note::
-
-   In periodic navigation mode, the ``<interval>`` and ``<timeout>`` parameters are temporarily ignored during the first fix (for up to 60 seconds).
 
 .. note::
 

--- a/applications/serial_lte_modem/doc/nRF91_as_Zephyr_modem.rst
+++ b/applications/serial_lte_modem/doc/nRF91_as_Zephyr_modem.rst
@@ -20,8 +20,8 @@ This is only possible on the nRF9160 DK, not on the other nRF91 Series DKs.
 
 .. note::
 
-   As of |NCS| |release|, Zephyr's GNSS driver does not support the nRF91 Series running SLM.
-   This functionality is part of planned future work.
+   As of |NCS| |release|, it is not yet possible to make use of the nRF91 Series' GNSS functionality when Zephyr's cellular modem driver controls the SiP.
+   Also, the driver's support of power saving features is quite limited, only allowing complete power off of the SiP.
 
 Configuration
 *************

--- a/applications/serial_lte_modem/src/gnss/Kconfig
+++ b/applications/serial_lte_modem/src/gnss/Kconfig
@@ -3,6 +3,19 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 
+config SLM_GNSS_OUTPUT_NMEA_ON_CMUX_CHANNEL
+	bool "Output NMEA messages on a dedicated CMUX channel"
+	depends on SLM_CMUX
+
+config SLM_GNSS_OUTPUT_NMEA_SATELLITES
+	bool "Output NMEA satellite messages (GSV, GSA)"
+	default y if SLM_LOG_LEVEL_DBG
+	depends on SLM_LOG_LEVEL_DBG || SLM_GNSS_OUTPUT_NMEA_ON_CMUX_CHANNEL
+	help
+	  If enabled, NMEA messages that pertain to the satellites will be output
+	  along with the other NMEA messages. Those are output in debug logs, and
+	  can also be output to a dedicated CMUX channel.
+
 config SLM_PGPS_INJECT_FIX_DATA
 	bool "Inject the data obtained when acquiring a fix"
 	default y
@@ -10,7 +23,7 @@ config SLM_PGPS_INJECT_FIX_DATA
 	depends on SLM_NRF_CLOUD
 	depends on NRF_CLOUD_PGPS
 	help
-	  If activated, when a fix is acquired the current location and time will
+	  If enabled, when a fix is acquired the current location and time will
 	  be passed to the P-GPS subsystem.
 	  It allows to speed up the time it takes to acquire the next fix when
 	  A-GNSS is disabled or unavailable.

--- a/applications/serial_lte_modem/src/slm_cmux.h
+++ b/applications/serial_lte_modem/src/slm_cmux.h
@@ -6,15 +6,21 @@
 #ifndef SLM_CMUX_
 #define SLM_CMUX_
 
-#include <modem/at_cmd_parser.h>
+struct modem_pipe;
 
 void slm_cmux_init(void);
 
+/* CMUX channels that are used by other modules. */
+enum cmux_channel {
 #if defined(CONFIG_SLM_PPP)
-struct modem_pipe;
-struct modem_pipe *slm_cmux_reserve_ppp_channel(void);
-
-void slm_cmux_release_ppp_channel(void);
-#endif /* CONFIG_SLM_PPP */
+	CMUX_PPP_CHANNEL,
+#endif
+#if defined(CONFIG_SLM_GNSS_OUTPUT_NMEA_ON_CMUX_CHANNEL)
+	CMUX_GNSS_CHANNEL,
+#endif
+	CMUX_EXT_CHANNEL_COUNT
+};
+struct modem_pipe *slm_cmux_reserve(enum cmux_channel);
+void slm_cmux_release(enum cmux_channel);
 
 #endif

--- a/applications/serial_lte_modem/src/slm_ppp.c
+++ b/applications/serial_lte_modem/src/slm_ppp.c
@@ -234,7 +234,7 @@ static int ppp_start_internal(void)
 	}
 
 #if defined(CONFIG_SLM_CMUX)
-	ppp_pipe = slm_cmux_reserve_ppp_channel();
+	ppp_pipe = slm_cmux_reserve(CMUX_PPP_CHANNEL);
 	/* The pipe opening is managed by CMUX. */
 #endif
 
@@ -298,7 +298,7 @@ static void ppp_stop_internal(void)
 	modem_ppp_release(&ppp_module);
 
 #if defined(CONFIG_SLM_CMUX)
-	slm_cmux_release_ppp_channel();
+	slm_cmux_release(CMUX_PPP_CHANNEL);
 #endif
 
 	net_if_carrier_off(ppp_iface);

--- a/applications/serial_lte_modem/src/slm_uart_handler.c
+++ b/applications/serial_lte_modem/src/slm_uart_handler.c
@@ -160,9 +160,7 @@ static void rx_recovery(void)
 		return;
 	}
 
-	if (atomic_cas(&recovery_state, RECOVERY_ONGOING, RECOVERY_IDLE)) {
-		LOG_DBG("UART RX enabled");
-	}
+	atomic_cas(&recovery_state, RECOVERY_ONGOING, RECOVERY_IDLE);
 }
 
 static void rx_process(struct k_work *work)
@@ -256,11 +254,7 @@ static void uart_callback(const struct device *dev, struct uart_event *evt, void
 			rx_buf_unref(evt->data.rx_buf.buf);
 		}
 		break;
-	case UART_RX_STOPPED:
-		LOG_DBG("UART_RX_STOPPED (%d)", evt->data.rx_stop.reason);
-		break;
 	case UART_RX_DISABLED:
-		LOG_DBG("UART_RX_DISABLED");
 		if (atomic_cas(&recovery_state, RECOVERY_IDLE, RECOVERY_ONGOING)) {
 			k_work_submit((struct k_work *)&rx_process_work);
 		}


### PR DESCRIPTION
Allow GNSS NMEA sentences to be output on a dedicated CMUX channel.
    
This is for the still in-progress integration of SLM with Zephyr's GNSS (and cellular) driver.
