### PR TITLE
bt: kconfig: Support BT_CTLR_ECDH_LIB_OBERON with TFM

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -354,9 +354,6 @@ choice BT_CTLR_ECDH_LIB
 
 config BT_CTLR_ECDH_LIB_OBERON
 	select NRF_OBERON
-	# TODO: Fix ocrypto header not available in these configurations
-	depends on !BUILD_WITH_TFM
-	depends on !OBERON_BACKEND
 	depends on !SOC_SERIES_BSIM_NRFXX
 	bool "nRF Oberon (SW)"
 


### PR DESCRIPTION
Support BT_CTLR_ECDH_LIB_OBERON with TFM and with an "OBERON_BACKEND".

I don't see why this shouldn't be supported.