### PR TITLE
net: lib: nrf_cloud: add config option to control anchor parsing

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -702,6 +702,7 @@ Libraries for networking
     * Support for Wi-Fi anchor names in the :c:struct:`nrf_cloud_location_result` structure.
     * The :kconfig:option:`CONFIG_NRF_CLOUD_LOCATION_ANCHOR_LIST` Kconfig option to enable including Wi-Fi anchor names in the location callback.
     * The :kconfig:option:`CONFIG_NRF_CLOUD_LOCATION_ANCHOR_LIST_BUFFER_SIZE` Kconfig option to control the buffer size used for the anchor names.
+    * The :kconfig:option:`CONFIG_NRF_CLOUD_LOCATION_PARSE_ANCHORS` Kconfig option to control if anchor names are parsed.
 
   * Updated:
 

--- a/include/net/nrf_cloud_location.h
+++ b/include/net/nrf_cloud_location.h
@@ -51,6 +51,9 @@ struct nrf_cloud_anchor_list_node {
 	char name[];
 };
 
+/** Minimum size of the anchor buffer required to hold one maximum length anchor name.
+ *  Multiply this value by your desired number anchor names to obtain your buffer size.
+ */
 #define NRF_CLOUD_ANCHOR_LIST_BUF_MIN_SZ	(sizeof(struct nrf_cloud_anchor_list_node) + \
 						 NRF_CLOUD_LOCATION_ANCHOR_NAME_MAX + 1)
 
@@ -78,7 +81,12 @@ struct nrf_cloud_location_result {
 	 */
 	sys_slist_t anchor_list;
 
-	/** User provided buffer to contain the @ref anchor_list */
+	/** User provided buffer to contain the @ref anchor_list.
+	 *  @kconfig{CONFIG_NRF_CLOUD_LOCATION_PARSE_ANCHORS} must be enabled for anchor data
+	 *  to be parsed.
+	 *  This buffer must point to valid memory or be set to NULL.
+	 *  A valid buffer should have a size of at least @ref NRF_CLOUD_ANCHOR_LIST_BUF_MIN_SZ.
+	 */
 	char *anchor_buf;
 
 	/** Size of provided buffer */

--- a/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_location
+++ b/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_location
@@ -13,6 +13,7 @@ config NRF_CLOUD_LOCATION_ANCHOR_LIST
 	bool "Include the list of anchor names when receiving location results from the callback"
 	depends on NRF_CLOUD_LOCATION
 	depends on WIFI
+	select NRF_CLOUD_LOCATION_PARSE_ANCHORS
 
 config NRF_CLOUD_LOCATION_ANCHOR_LIST_BUFFER_SIZE
 	int "Size of the buffer to contain the anchor name list"
@@ -22,3 +23,8 @@ config NRF_CLOUD_LOCATION_ANCHOR_LIST_BUFFER_SIZE
 	  The maximum length of an anchor name is 32 characters.
 	  Anchor names are returned to the user in a singly-linked list,
 	  which requires 37 bytes for each anchor name on a 32-bit system.
+
+config NRF_CLOUD_LOCATION_PARSE_ANCHORS
+	bool "Parse anchor data in location result"
+	help
+	  If enabled, the anchor buffer in the result structure must be properly initialized.

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec_internal.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec_internal.c
@@ -2828,8 +2828,9 @@ static int nrf_cloud_parse_location_json(const cJSON *const loc_obj,
 		LOG_WRN("Location type not found in message");
 	}
 
-	if (anchor) {
+	if (anchor && IS_ENABLED(CONFIG_NRF_CLOUD_LOCATION_PARSE_ANCHORS)) {
 		nrf_cloud_parse_location_anchors_json(loc_obj, location_out);
+
 	}
 
 	return 0;


### PR DESCRIPTION
Add Kconfig option NRF_CLOUD_LOCATION_PARSE_ANCHORS to control if the anchor names are parsed from the location response data. 
IRIS-8813