### PR TITLE
applications: nrf5340_audio: Rail the presentation delay.

### DIFF
--- a/applications/nrf5340_audio/src/audio/Kconfig
+++ b/applications/nrf5340_audio/src/audio/Kconfig
@@ -34,14 +34,16 @@ config AUDIO_MIN_PRES_DLY_US
 	int "The minimum presentation delay"
 	default 3000
 	help
-	  The minimum presentation delay in micro seconds determined by
-	  the audio system processing and the minimum buffering.
+	  The minimum allowable presentation delay in microseconds.
+	  This needs to allow time for decoding and internal routing.
+	  For 48kHz sampling rate and 96kbps bitrate this is about 4000 us.
 
 config AUDIO_MAX_PRES_DLY_US
 	int "The maximum presentation delay"
 	default 60000
 	help
-	  The maximum presentation delay in micro seconds.
+	  The maximum allowable presentation delay in microseconds.
+	  Increasing this will also increase the FIFO buffers to allow buffering.
 
 choice AUDIO_SYSTEM_SAMPLE_RATE
 	prompt "System audio sample rate"
@@ -107,21 +109,6 @@ config AUDIO_BIT_DEPTH_OCTETS
 	default 4 if AUDIO_BIT_DEPTH_32
 	help
 	  Bit depth of one sample in storage given in octets.
-
-config AUDIO_MIN_PRES_DLY_US
-	int "The minimum presentation delay"
-	default 4000
-	help
-	  The minimum allowable presentation delay in microseconds.
-	  This needs to allow time for decoding and internal routing.
-	  For 48kHz sampling rate and 96kbps bitrate this is about 4000 us.
-
-config AUDIO_MAX_PRES_DLY_US
-	int "The maximum presentation delay"
-	default 60000
-	help
-	  The maximum allowable presentation delay in microseconds.
-	  Increasing this will also increase the FIFO buffers to allow buffering.
 
 choice AUDIO_SOURCE_GATEWAY
 	prompt "Audio source for gateway"

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.c
@@ -51,6 +51,33 @@ bool le_audio_ep_state_check(struct bt_bap_ep *ep, enum bt_bap_ep_state state)
 	return false;
 }
 
+bool le_audio_ep_qos_configured(struct bt_bap_ep const *const ep)
+{
+	int ret;
+	struct bt_bap_ep_info ep_info;
+
+	if (ep == NULL) {
+		LOG_DBG("EP is NULL");
+		/* If an endpoint is NULL it is not in any of the states */
+		return false;
+	}
+
+	ret = bt_bap_ep_get_info(ep, &ep_info);
+	if (ret) {
+		LOG_WRN("Unable to get info for ep");
+		return false;
+	}
+
+	if (ep_info.state == BT_BAP_EP_STATE_QOS_CONFIGURED ||
+	    ep_info.state == BT_BAP_EP_STATE_ENABLING ||
+	    ep_info.state == BT_BAP_EP_STATE_STREAMING ||
+	    ep_info.state == BT_BAP_EP_STATE_DISABLING) {
+		return true;
+	}
+
+	return false;
+}
+
 int le_audio_freq_hz_get(const struct bt_audio_codec_cfg *codec, int *freq_hz)
 {
 	int ret;

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.h
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.h
@@ -90,6 +90,17 @@ int le_audio_ep_state_get(struct bt_bap_ep *ep, uint8_t *state);
 bool le_audio_ep_state_check(struct bt_bap_ep *ep, enum bt_bap_ep_state state);
 
 /**
+ * @brief	Check if an endpoint has had the QoS configured.
+ *		If the endpoint is NULL, it is not in the state, and this function returns false.
+ *
+ * @param[in]	ep       The endpoint to check.
+ *
+ * @retval	true	The endpoint QoS is configured.
+ * @retval	false	Otherwise.
+ */
+bool le_audio_ep_qos_configured(struct bt_bap_ep const *const ep);
+
+/**
  * @brief	Decode the audio sampling frequency in the codec configuration.
  *
  * @param[in]	codec		Pointer to the audio codec structure.


### PR DESCRIPTION
OCT--2976
	
Ensure the preferred presentation delay is within the range of the	min and max delays, rail if not.
Search for the presentation delay function updated to search over the end points for the direction.