### PR TITLE
manifest: Update zephyr with nrf54l15 counter marking

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 3733e7097909ae964e60cf66e4d51ade975ddcae
+      revision: pull/1663/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update zephyr with marking nrf54l15pdk with counter tag so that counter tests can run on this board.