### PR TITLE
manifest: matter: Update Matter SDK to pull workaround

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -160,7 +160,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: d76797e8cb75fae4063c524369e7da419b3c1ed3
+      revision: pull/433/head
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
The newest Matter SDK revision contains a workaround for Crypto PSA operations.