### PR TITLE
matter: optimize the size of packet buffers

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -103,6 +103,7 @@ Matter
 
 * Updated default MRP retry intervals for Thread devices to two seconds to reduce the number of spurious retransmissions in Thread networks.
 * Increased the number of available packet buffers in the Matter stack to avoid packet allocation issues.
+* Optimized the size of packet buffers in the Matter stack to reduce the RAM utilization.
 
 Matter fork
 +++++++++++

--- a/west.yml
+++ b/west.yml
@@ -160,7 +160,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: d76797e8cb75fae4063c524369e7da419b3c1ed3
+      revision: pull/434/head
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
Pull the change that optimizes the size of packet buffers used by Matter, especially Matter over Thread.