### PR TITLE
applications: nrf5340_audio: Fix doc build

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.h
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.h
@@ -49,6 +49,7 @@
  * @param	bad_frame	Indicating if the frame is a bad frame or not.
  * @param	sdu_ref		ISO timestamp.
  * @param	channel_index	Audio channel index.
+ * @param	desired_size	The expected data size.
  */
 typedef void (*le_audio_receive_cb)(const uint8_t *const data, size_t size, bool bad_frame,
 				    uint32_t sdu_ref, enum audio_channel channel_index,

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_server.h
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_server.h
@@ -70,6 +70,7 @@ int unicast_server_disable(void);
 /**
  * @brief	Enable the Bluetooth LE Audio unicast (CIS) server.
  *
+ * @param[in]	rx_cb		Callback for handling received data.
  * @param[in]	location	Location of the unicast_server to be enabled.
  *
  * @return	0 for success, error otherwise.

--- a/applications/nrf5340_audio/src/modules/led.h
+++ b/applications/nrf5340_audio/src/modules/led.h
@@ -92,9 +92,6 @@ int led_off(uint8_t led_unit);
  *
  * @note This will parse the .dts files and configure all LEDs.
  *
- * @param[in]	led_override	Override the default center LED color.
- * @param[in]	color		The color to set center LED to.
- *
  * @return	0 on success.
  *		-EPERM if already initialized.
  *		-ENXIO if a LED is missing unit number in dts.


### PR DESCRIPTION
- Remove parameters that are not used in led.h
- OCT-3003