### PR TITLE
samples: Add nRF54l15 0.3.0 rev in sample yaml files

### DIFF
--- a/samples/bluetooth/central_and_peripheral_hr/sample.yaml
+++ b/samples/bluetooth/central_and_peripheral_hr/sample.yaml
@@ -10,7 +10,9 @@ tests:
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
       - nrf54l15pdk_nrf54l15_cpuapp
+      - nrf54l15pdk_nrf54l15_cpuapp@0.3.0
       - nrf54h20dk_nrf54h20_cpuapp
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
-      nrf5340dk_nrf5340_cpuapp_ns nrf54l15pdk_nrf54l15_cpuapp nrf54h20dk_nrf54h20_cpuapp
+      nrf5340dk_nrf5340_cpuapp_ns nrf54l15pdk_nrf54l15_cpuapp nrf54l15pdk_nrf54l15_cpuapp@0.3.0
+      nrf54h20dk_nrf54h20_cpuapp
     tags: bluetooth ci_build

--- a/samples/bluetooth/central_hids/sample.yaml
+++ b/samples/bluetooth/central_hids/sample.yaml
@@ -17,7 +17,9 @@ tests:
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
       - nrf54l15pdk_nrf54l15_cpuapp
+      - nrf54l15pdk_nrf54l15_cpuapp@0.3.0
       - nrf54h20dk_nrf54h20_cpuapp
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
-      nrf5340dk_nrf5340_cpuapp_ns nrf54l15pdk_nrf54l15_cpuapp nrf54h20dk_nrf54h20_cpuapp
+      nrf5340dk_nrf5340_cpuapp_ns nrf54l15pdk_nrf54l15_cpuapp nrf54l15pdk_nrf54l15_cpuapp@0.3.0
+      nrf54h20dk_nrf54h20_cpuapp
     tags: bluetooth ci_build

--- a/samples/bluetooth/central_uart/sample.yaml
+++ b/samples/bluetooth/central_uart/sample.yaml
@@ -11,8 +11,9 @@ tests:
       - nrf5340dk_nrf5340_cpuapp_ns
       - nrf21540dk_nrf52840
       - nrf54l15pdk_nrf54l15_cpuapp
+      - nrf54l15pdk_nrf54l15_cpuapp@0.3.0
       - nrf54h20dk_nrf54h20_cpuapp
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf21540dk_nrf52840
-      nrf54l15pdk_nrf54l15_cpuapp nrf54h20dk_nrf54h20_cpuapp
+      nrf54l15pdk_nrf54l15_cpuapp nrf54l15pdk_nrf54l15_cpuapp@0.3.0 nrf54h20dk_nrf54h20_cpuapp
     tags: bluetooth ci_build

--- a/samples/bluetooth/direct_test_mode/sample.yaml
+++ b/samples/bluetooth/direct_test_mode/sample.yaml
@@ -9,9 +9,11 @@ tests:
       - nrf21540dk_nrf52840
       - nrf52840dk_nrf52840
       - nrf54l15pdk_nrf54l15_cpuapp
+      - nrf54l15pdk_nrf54l15_cpuapp@0.3.0
       - nrf54h20dk_nrf54h20_cpurad
     platform_allow: nrf5340dk_nrf5340_cpunet nrf21540dk_nrf52840 nrf52840dk_nrf52840
-                    nrf54l15pdk_nrf54l15_cpuapp nrf54h20dk_nrf54h20_cpurad
+                    nrf54l15pdk_nrf54l15_cpuapp nrf54l15pdk_nrf54l15_cpuapp@0.3.0
+                    nrf54h20dk_nrf54h20_cpurad
     tags: bluetooth ci_build
   sample.bluetooth.direct_test_mode.nrf5340_nrf21540:
     build_only: true

--- a/samples/bluetooth/peripheral_hids_keyboard/sample.yaml
+++ b/samples/bluetooth/peripheral_hids_keyboard/sample.yaml
@@ -17,7 +17,9 @@ tests:
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
       - nrf54l15pdk_nrf54l15_cpuapp
+      - nrf54l15pdk_nrf54l15_cpuapp@0.3.0
       - nrf54h20dk_nrf54h20_cpuapp
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
-      nrf5340dk_nrf5340_cpuapp_ns nrf54l15pdk_nrf54l15_cpuapp nrf54h20dk_nrf54h20_cpuapp
+      nrf5340dk_nrf5340_cpuapp_ns nrf54l15pdk_nrf54l15_cpuapp nrf54l15pdk_nrf54l15_cpuapp@0.3.0
+      nrf54h20dk_nrf54h20_cpuapp
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_hids_mouse/sample.yaml
+++ b/samples/bluetooth/peripheral_hids_mouse/sample.yaml
@@ -17,9 +17,11 @@ tests:
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
       - nrf54l15pdk_nrf54l15_cpuapp
+      - nrf54l15pdk_nrf54l15_cpuapp@0.3.0
       - nrf54h20dk_nrf54h20_cpuapp
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
-      nrf5340dk_nrf5340_cpuapp_ns nrf54l15pdk_nrf54l15_cpuapp nrf54h20dk_nrf54h20_cpuapp
+      nrf5340dk_nrf5340_cpuapp_ns nrf54l15pdk_nrf54l15_cpuapp nrf54l15pdk_nrf54l15_cpuapp@0.3.0
+      nrf54h20dk_nrf54h20_cpuapp
     tags: bluetooth ci_build
   sample.bluetooth.peripheral_hids_mouse.ble_rpc:
     build_only: true

--- a/samples/bluetooth/peripheral_lbs/sample.yaml
+++ b/samples/bluetooth/peripheral_lbs/sample.yaml
@@ -12,10 +12,12 @@ tests:
       - thingy53_nrf5340_cpuapp
       - thingy53_nrf5340_cpuapp_ns
       - nrf54l15pdk_nrf54l15_cpuapp
+      - nrf54l15pdk_nrf54l15_cpuapp@0.3.0
       - nrf54h20dk_nrf54h20_cpuapp
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp
-      thingy53_nrf5340_cpuapp_ns nrf54l15pdk_nrf54l15_cpuapp nrf54h20dk_nrf54h20_cpuapp
+      thingy53_nrf5340_cpuapp_ns nrf54l15pdk_nrf54l15_cpuapp nrf54l15pdk_nrf54l15_cpuapp@0.3.0
+      nrf54h20dk_nrf54h20_cpuapp
     tags: bluetooth ci_build
   sample.bluetooth.peripheral_lbs_minimal:
     build_only: true

--- a/samples/bluetooth/peripheral_uart/sample.yaml
+++ b/samples/bluetooth/peripheral_uart/sample.yaml
@@ -7,7 +7,7 @@ tests:
     platform_allow: nrf52dk_nrf52832 nrf52833dk_nrf52833 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp
       thingy53_nrf5340_cpuapp_ns nrf21540dk_nrf52840 nrf54l15pdk_nrf54l15_cpuapp
-      nrf54h20dk_nrf54h20_cpuapp
+      nrf54l15pdk_nrf54l15_cpuapp@0.3.0 nrf54h20dk_nrf54h20_cpuapp
     integration_platforms:
       - nrf52dk_nrf52832
       - nrf52833dk_nrf52833
@@ -18,6 +18,7 @@ tests:
       - thingy53_nrf5340_cpuapp_ns
       - nrf21540dk_nrf52840
       - nrf54l15pdk_nrf54l15_cpuapp
+      - nrf54l15pdk_nrf54l15_cpuapp@0.3.0
       - nrf54h20dk_nrf54h20_cpuapp
     tags: bluetooth ci_build
   sample.bluetooth.peripheral_uart.sysbuild:

--- a/samples/esb/esb_prx/sample.yaml
+++ b/samples/esb/esb_prx/sample.yaml
@@ -21,6 +21,7 @@ tests:
       - nrf21540dk_nrf52840
       - nrf54h20dk_nrf54h20_cpurad
       - nrf54l15pdk_nrf54l15_cpuapp
+      - nrf54l15pdk_nrf54l15_cpuapp@0.3.0
     platform_allow: >
       nrf52dk_nrf52832
       nrf52833dk_nrf52833
@@ -30,6 +31,7 @@ tests:
       nrf21540dk_nrf52840
       nrf54h20dk_nrf54h20_cpurad
       nrf54l15pdk_nrf54l15_cpuapp
+      nrf54l15pdk_nrf54l15_cpuapp@0.3.0
     tags: esb ci_build
   sample.esb.prx.dynamic_irq:
     build_only: true

--- a/samples/esb/esb_ptx/sample.yaml
+++ b/samples/esb/esb_ptx/sample.yaml
@@ -21,6 +21,7 @@ tests:
       - nrf21540dk_nrf52840
       - nrf54h20dk_nrf54h20_cpurad
       - nrf54l15pdk_nrf54l15_cpuapp
+      - nrf54l15pdk_nrf54l15_cpuapp@0.3.0
     platform_allow: >
       nrf52dk_nrf52832
       nrf52833dk_nrf52833
@@ -30,6 +31,7 @@ tests:
       nrf21540dk_nrf52840
       nrf54h20dk_nrf54h20_cpurad
       nrf54l15pdk_nrf54l15_cpuapp
+      nrf54l15pdk_nrf54l15_cpuapp@0.3.0
     tags: esb ci_build
   sample.esb.ptx.dynamic_irq:
     build_only: true

--- a/samples/nfc/record_launch_app/sample.yaml
+++ b/samples/nfc/record_launch_app/sample.yaml
@@ -11,6 +11,7 @@ tests:
       - nrf5340dk_nrf5340_cpuapp_ns
       - nrf54h20dk_nrf54h20_cpuapp
       - nrf54l15pdk_nrf54l15_cpuapp
+      - nrf54l15pdk_nrf54l15_cpuapp@0.3.0
     platform_allow: >
       nrf52840dk_nrf52840
       nrf52dk_nrf52832
@@ -18,4 +19,5 @@ tests:
       nrf5340dk_nrf5340_cpuapp_ns
       nrf54h20dk_nrf54h20_cpuapp
       nrf54l15pdk_nrf54l15_cpuapp
+      nrf54l15pdk_nrf54l15_cpuapp@0.3.0
     tags: ci_build

--- a/samples/nfc/record_text/sample.yaml
+++ b/samples/nfc/record_text/sample.yaml
@@ -11,6 +11,7 @@ tests:
       - nrf5340dk_nrf5340_cpuapp_ns
       - nrf54h20dk_nrf54h20_cpuapp
       - nrf54l15pdk_nrf54l15_cpuapp
+      - nrf54l15pdk_nrf54l15_cpuapp@0.3.0
     platform_allow: >
       nrf52840dk_nrf52840
       nrf52dk_nrf52832
@@ -18,4 +19,5 @@ tests:
       nrf5340dk_nrf5340_cpuapp_ns
       nrf54h20dk_nrf54h20_cpuapp
       nrf54l15pdk_nrf54l15_cpuapp
+      nrf54l15pdk_nrf54l15_cpuapp@0.3.0
     tags: ci_build

--- a/samples/nfc/shell/sample.yaml
+++ b/samples/nfc/shell/sample.yaml
@@ -11,6 +11,7 @@ tests:
       - nrf5340dk_nrf5340_cpuapp_ns
       - nrf54h20dk_nrf54h20_cpuapp
       - nrf54l15pdk_nrf54l15_cpuapp
+      - nrf54l15pdk_nrf54l15_cpuapp@0.3.0
     platform_allow: >
       nrf52840dk_nrf52840
       nrf52dk_nrf52832
@@ -18,4 +19,5 @@ tests:
       nrf5340dk_nrf5340_cpuapp_ns
       nrf54h20dk_nrf54h20_cpuapp
       nrf54l15pdk_nrf54l15_cpuapp
+      nrf54l15pdk_nrf54l15_cpuapp@0.3.0
     tags: ci_build

--- a/samples/nfc/system_off/sample.yaml
+++ b/samples/nfc/system_off/sample.yaml
@@ -10,10 +10,12 @@ tests:
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
       - nrf54l15pdk_nrf54l15_cpuapp
+      - nrf54l15pdk_nrf54l15_cpuapp@0.3.0
     platform_allow: >
       nrf52840dk_nrf52840
       nrf52dk_nrf52832
       nrf5340dk_nrf5340_cpuapp
       nrf5340dk_nrf5340_cpuapp_ns
       nrf54l15pdk_nrf54l15_cpuapp
+      nrf54l15pdk_nrf54l15_cpuapp@0.3.0
     tags: ci_build

--- a/samples/nfc/tnep_tag/sample.yaml
+++ b/samples/nfc/tnep_tag/sample.yaml
@@ -11,6 +11,7 @@ tests:
       - nrf5340dk_nrf5340_cpuapp_ns
       - nrf54h20dk_nrf54h20_cpuapp
       - nrf54l15pdk_nrf54l15_cpuapp
+      - nrf54l15pdk_nrf54l15_cpuapp@0.3.0
     platform_allow: >
       nrf52840dk_nrf52840
       nrf52dk_nrf52832
@@ -18,4 +19,5 @@ tests:
       nrf5340dk_nrf5340_cpuapp_ns
       nrf54h20dk_nrf54h20_cpuapp
       nrf54l15pdk_nrf54l15_cpuapp
+      nrf54l15pdk_nrf54l15_cpuapp@0.3.0
     tags: ci_build

--- a/samples/nfc/writable_ndef_msg/sample.yaml
+++ b/samples/nfc/writable_ndef_msg/sample.yaml
@@ -11,6 +11,7 @@ tests:
       - nrf5340dk_nrf5340_cpuapp_ns
       - nrf54h20dk_nrf54h20_cpuapp
       - nrf54l15pdk_nrf54l15_cpuapp
+      - nrf54l15pdk_nrf54l15_cpuapp@0.3.0
     platform_allow: >
       nrf52840dk_nrf52840
       nrf52dk_nrf52832
@@ -18,4 +19,5 @@ tests:
       nrf5340dk_nrf5340_cpuapp_ns
       nrf54h20dk_nrf54h20_cpuapp
       nrf54l15pdk_nrf54l15_cpuapp
+      nrf54l15pdk_nrf54l15_cpuapp@0.3.0
     tags: ci_build

--- a/samples/peripheral/radio_test/sample.yaml
+++ b/samples/peripheral/radio_test/sample.yaml
@@ -10,10 +10,11 @@ tests:
       - nrf5340dk_nrf5340_cpunet
       - nrf7002dk_nrf5340_cpunet
       - nrf54l15pdk_nrf54l15_cpuapp
+      - nrf54l15pdk_nrf54l15_cpuapp@0.3.0
       - nrf54h20dk_nrf54h20_cpurad
     platform_allow: >
       nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpunet nrf7002dk_nrf5340_cpunet
-      nrf54l15pdk_nrf54l15_cpuapp nrf54h20dk_nrf54h20_cpurad
+      nrf54l15pdk_nrf54l15_cpuapp nrf54h20dk_nrf54h20_cpurad nrf54l15pdk_nrf54l15_cpuapp@0.3.0
     tags: ci_build
   sample.peripheral.radio_test.nrf5340_nrf21540:
     build_only: true


### PR DESCRIPTION
Add entry about support for nrf54l15dk_nrf54l15_cpuapp@0.3.0 revision in all samples yaml files that support it.