### PR TITLE
partition_manager: Remove pm_config.h inclusions where not needed

### DIFF
--- a/applications/serial_lte_modem/src/main.c
+++ b/applications/serial_lte_modem/src/main.c
@@ -21,7 +21,6 @@
 #include <zephyr/sys/reboot.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/nrf_clock_control.h>
-#include <pm_config.h>
 #include <net/fota_download.h>
 #include "slm_at_host.h"
 #include "slm_at_fota.h"

--- a/applications/serial_lte_modem/src/slm_at_fota.c
+++ b/applications/serial_lte_modem/src/slm_at_fota.c
@@ -13,7 +13,6 @@
 #include <zephyr/net/tls_credentials.h>
 #include <zephyr/net/http/parser_url.h>
 #include <zephyr/device.h>
-#include <zephyr/storage/stream_flash.h>
 #include <zephyr/sys/reboot.h>
 #include <net/fota_download.h>
 #include <fota_download_util.h>
@@ -23,7 +22,6 @@
 #include "slm_settings.h"
 #include "slm_at_host.h"
 #include "slm_at_fota.h"
-#include "pm_config.h"
 
 LOG_MODULE_REGISTER(slm_fota, CONFIG_SLM_LOG_LEVEL);
 

--- a/applications/serial_lte_modem/src/slm_uart_handler.c
+++ b/applications/serial_lte_modem/src/slm_uart_handler.c
@@ -11,7 +11,6 @@
 #include <hal/nrf_gpio.h>
 #include <zephyr/sys/ring_buffer.h>
 #include <zephyr/pm/device.h>
-#include <pm_config.h>
 #include "slm_uart_handler.h"
 #include "slm_at_host.h"
 

--- a/modules/trusted-firmware-m/tfm_boards/src/tfm_platform_system.c
+++ b/modules/trusted-firmware-m/tfm_boards/src/tfm_platform_system.c
@@ -7,7 +7,6 @@
 #include <platform/include/tfm_platform_system.h>
 #include <cmsis.h>
 #include <stdio.h>
-#include <pm_config.h>
 #include <tfm_ioctl_api.h>
 #include <string.h>
 #include <arm_cmse.h>

--- a/subsys/bootloader/bl_storage/bl_storage.c
+++ b/subsys/bootloader/bl_storage/bl_storage.c
@@ -10,7 +10,6 @@
 #include <nrf.h>
 #include <assert.h>
 #include <nrfx_nvmc.h>
-#include <pm_config.h>
 
 #define TYPE_COUNTERS 1 /* Type referring to counter collection. */
 #define COUNTER_DESC_VERSION 1 /* Counter description value for firmware version. */

--- a/subsys/dfu/dfu_target/src/dfu_target_smp.c
+++ b/subsys/dfu/dfu_target/src/dfu_target_smp.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <pm_config.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/dfu/mcuboot.h>
 #include <zephyr/mgmt/mcumgr/mgmt/mgmt.h>


### PR DESCRIPTION
The commit removes pm_config.h inclusions and other storage headers where are not needed or not used.