### PR TITLE
bluetooth: guarantee XTAL in all timeslot users

### DIFF
--- a/drivers/mpsl/flash_sync/flash_sync_mpsl.c
+++ b/drivers/mpsl/flash_sync/flash_sync_mpsl.c
@@ -183,7 +183,6 @@ int nrf_flash_sync_exe(struct flash_op_desc *op_desc)
 
 	mpsl_timeslot_request_t *req = &_context.timeslot_request;
 	req->request_type = MPSL_TIMESLOT_REQ_TYPE_EARLIEST;
-	req->params.earliest.hfclk = MPSL_TIMESLOT_HFCLK_CFG_NO_GUARANTEE;
 	req->params.earliest.priority = MPSL_TIMESLOT_PRIORITY_NORMAL;
 	req->params.earliest.length_us =
 		_context.request_length_us + TIMESLOT_LENGTH_SLACK_US;

--- a/samples/mpsl/timeslot/src/main.c
+++ b/samples/mpsl/timeslot/src/main.c
@@ -45,14 +45,12 @@ enum mpsl_timeslot_call {
 /* Timeslot requests */
 static mpsl_timeslot_request_t timeslot_request_earliest = {
 	.request_type = MPSL_TIMESLOT_REQ_TYPE_EARLIEST,
-	.params.earliest.hfclk = MPSL_TIMESLOT_HFCLK_CFG_NO_GUARANTEE,
 	.params.earliest.priority = MPSL_TIMESLOT_PRIORITY_NORMAL,
 	.params.earliest.length_us = TIMESLOT_LENGTH_US,
 	.params.earliest.timeout_us = 1000000
 };
 static mpsl_timeslot_request_t timeslot_request_normal = {
 	.request_type = MPSL_TIMESLOT_REQ_TYPE_NORMAL,
-	.params.normal.hfclk = MPSL_TIMESLOT_HFCLK_CFG_NO_GUARANTEE,
 	.params.normal.priority = MPSL_TIMESLOT_PRIORITY_NORMAL,
 	.params.normal.distance_us = TIMESLOT_REQUEST_DISTANCE_US,
 	.params.normal.length_us = TIMESLOT_LENGTH_US

--- a/subsys/dm/dm.c
+++ b/subsys/dm/dm.c
@@ -105,7 +105,6 @@ struct {
 /* Timeslot request */
 static mpsl_timeslot_request_t timeslot_request_earliest = {
 	.request_type = MPSL_TIMESLOT_REQ_TYPE_EARLIEST,
-	.params.earliest.hfclk = MPSL_TIMESLOT_HFCLK_CFG_NO_GUARANTEE,
 	.params.earliest.priority = MPSL_TIMESLOT_PRIORITY_HIGH,
 	.params.earliest.length_us = MPSL_TIMESLOT_LENGTH_MIN_US,
 	.params.earliest.timeout_us = 70000,
@@ -113,7 +112,6 @@ static mpsl_timeslot_request_t timeslot_request_earliest = {
 
 static mpsl_timeslot_request_t timeslot_request_normal = {
 	.request_type = MPSL_TIMESLOT_REQ_TYPE_NORMAL,
-	.params.normal.hfclk = MPSL_TIMESLOT_HFCLK_CFG_XTAL_GUARANTEED,
 	.params.normal.priority = MPSL_TIMESLOT_PRIORITY_HIGH,
 };
 


### PR DESCRIPTION
It's expected that using the MPSL_TIMESLOT_HFCLK_CFG_NO_GUARANTEE option has little benefit to the user