### PR TITLE
Bluetooth: Host: allow reducing initiator priority

### DIFF
--- a/include/bluetooth/nrf/host_extensions.h
+++ b/include/bluetooth/nrf/host_extensions.h
@@ -107,6 +107,15 @@ struct bt_conn_set_pcr_params {
  */
 int bt_conn_set_power_control_request_params(struct bt_conn_set_pcr_params *params);
 
+/** @brief Reduce the priority of the initiator when following AUX packets.
+ *
+ *  @param reduce Set to true to reduce the priority. Set to false to restore the default priority.
+ *
+ *  @return Zero on success or (negative) error code on failure.
+ *  @retval -ENOBUFS HCI command buffer is not available.
+ */
+int bt_nrf_host_extension_reduce_initator_aux_channel_priority(bool reduce);
+
 /**
  * @}
  */

--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -1667,6 +1667,9 @@ static uint8_t vs_cmd_put(uint8_t const *const cmd, uint8_t *const raw_event_out
 		return sdc_hci_cmd_vs_scan_accept_ext_adv_packets_set(
 			(sdc_hci_cmd_vs_scan_accept_ext_adv_packets_set_t const *)cmd_params);
 #endif
+		case SDC_HCI_OPCODE_CMD_VS_SET_ROLE_PRIORITY:
+			return sdc_hci_cmd_vs_set_role_priority(
+				(sdc_hci_cmd_vs_set_role_priority_t const *) cmd_params);
 	default:
 		return BT_HCI_ERR_UNKNOWN_CMD;
 	}

--- a/subsys/bluetooth/host_extensions/CMakeLists.txt
+++ b/subsys/bluetooth/host_extensions/CMakeLists.txt
@@ -4,4 +4,4 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-zephyr_sources_ifdef(CONFIG_BT_TRANSMIT_POWER_CONTROL host_extensions.c)
+zephyr_sources(host_extensions.c)

--- a/subsys/bluetooth/host_extensions/host_extensions.c
+++ b/subsys/bluetooth/host_extensions/host_extensions.c
@@ -9,15 +9,20 @@
  * Adding them in nrf is better maintainable.
  */
 
-#if defined(CONFIG_BT_TRANSMIT_POWER_CONTROL)
+#include <stdbool.h>
 
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/hci.h>
 #include <../subsys/bluetooth/host/conn_internal.h>
 
-#include "hci_types_host_extensions.h"
+#if defined(CONFIG_BT_LL_SOFTDEVICE)
+#include <sdc_hci_vs.h>
+#endif /* CONFIG_BT_LL_SOFTDEVICE */
+
 #include <bluetooth/nrf/host_extensions.h>
+
+#if defined(CONFIG_BT_TRANSMIT_POWER_CONTROL)
 
 /* Write Remote Transmit Power Level HCI command */
 int bt_conn_set_remote_tx_power_level(struct bt_conn *conn,
@@ -72,3 +77,27 @@ int bt_conn_set_power_control_request_params(struct bt_conn_set_pcr_params *para
 	return bt_hci_cmd_send_sync(BT_HCI_OP_SET_POWER_CONTROL_REQUEST_PARAMS, buf, NULL);
 }
 #endif /* CONFIG_BT_TRANSMIT_POWER_CONTROL */
+
+#if defined(CONFIG_BT_LL_SOFTDEVICE)
+#if defined(CONFIG_BT_CTLR_ADV_EXT)
+int bt_nrf_host_extension_reduce_initator_aux_channel_priority(bool reduce)
+{
+	sdc_hci_cmd_vs_set_role_priority_t *cmd;
+	struct net_buf *buf;
+
+	buf = bt_hci_cmd_create(SDC_HCI_OPCODE_CMD_VS_SET_ROLE_PRIORITY, sizeof(*cmd));
+	if (!buf) {
+		return -ENOBUFS;
+	}
+
+	cmd = net_buf_add(buf, sizeof(*cmd));
+	*cmd = (sdc_hci_cmd_vs_set_role_priority_t) {
+	  .handle_type = SDC_HCI_VS_SET_ROLE_PRIORITY_HANDLE_TYPE_INITIATOR_SECONDARY_CHANNEL,
+	  .handle = 0x0,
+	  .priority = reduce ? 5 : 0xff
+	};
+
+	return bt_hci_cmd_send_sync(SDC_HCI_OPCODE_CMD_VS_SET_ROLE_PRIORITY, buf, NULL);
+}
+#endif /* CONFIG_BT_CTLR_ADV_EXT */
+#endif /* CONFIG_BT_LL_SOFTDEVICE */


### PR DESCRIPTION
By default, the initiator in the SoftDevice Controller operates at a higher priority than other BT roles. This may result in unwanted scheduling conflicts with other roles.
On the primary channel, the initiator can be scheduled such that conflicts can be avoided, by choosing an interval that is equal or a multiple of the interval of other roles. However, the secondary channel timings are set by the peer device. This new host extension allows to (temporarily) reduce the priority the initiator uses when following AUX pointers.