### PR TITLE
tests: suit: Remove labels from DTS overlays

### DIFF
--- a/tests/subsys/suit/cache_pool_digest/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/subsys/suit/cache_pool_digest/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -29,7 +29,6 @@
 		#size-cells = < 0x1 >;
 
 		dfu_partition: partition@19d000 {
-			label = "dfu_partition";
 			reg = < 0x19d000 DT_SIZE_K(1) >;
 		};
 

--- a/tests/subsys/suit/cache_sink/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/subsys/suit/cache_sink/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -18,7 +18,6 @@
 		#size-cells = < 0x1 >;
 
 		dfu_partition: partition@19d000 {
-			label = "dfu_partition";
 			reg = < 0x19d000 DT_SIZE_K(1) >;
 		};
 

--- a/tests/subsys/suit/envelope_decoder/boards/native_posix.overlay
+++ b/tests/subsys/suit/envelope_decoder/boards/native_posix.overlay
@@ -12,13 +12,11 @@
 
 		/* Use the last 40KB of NVM as suit storage. */
 		suit_storage: partition@f6000 {
-			label = "suit_storage";
 			reg = <0xf6000 DT_SIZE_K(40)>;
 		};
 
 		/* Use the second half of NVM as DFU partition. */
 		dfu_partition: partition@80000 {
-			label = "dfu_partition";
 			reg = <0x80000 DT_SIZE_K(472)>;
 		};
 	};

--- a/tests/subsys/suit/envelope_decoder/boards/native_posix_64.overlay
+++ b/tests/subsys/suit/envelope_decoder/boards/native_posix_64.overlay
@@ -12,13 +12,11 @@
 
 		/* Use the last 40KB of NVM as suit storage. */
 		suit_storage: partition@f6000 {
-			label = "suit_storage";
 			reg = <0xf6000 DT_SIZE_K(40)>;
 		};
 
 		/* Use the second half of NVM as DFU partition. */
 		dfu_partition: partition@80000 {
-			label = "dfu_partition";
 			reg = <0x80000 DT_SIZE_K(472)>;
 		};
 	};

--- a/tests/subsys/suit/fetch_integrated_payload_flash/boards/native_posix.overlay
+++ b/tests/subsys/suit/fetch_integrated_payload_flash/boards/native_posix.overlay
@@ -12,7 +12,6 @@
 
 		/* Use the last 40KB of NVM as suit storage. */
 		suit_storage: partition@f6000 {
-			label = "suit_storage";
 			reg = <0xf6000 DT_SIZE_K(40)>;
 		};
 	};

--- a/tests/subsys/suit/fetch_integrated_payload_flash/boards/native_posix_64.overlay
+++ b/tests/subsys/suit/fetch_integrated_payload_flash/boards/native_posix_64.overlay
@@ -12,7 +12,6 @@
 
 		/* Use the last 40KB of NVM as suit storage. */
 		suit_storage: partition@f6000 {
-			label = "suit_storage";
 			reg = <0xf6000 DT_SIZE_K(40)>;
 		};
 	};

--- a/tests/subsys/suit/fetch_integrated_payload_flash/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/subsys/suit/fetch_integrated_payload_flash/boards/nrf52840dk_nrf52840.overlay
@@ -12,7 +12,6 @@
 
 		/* Use the last 40KB of NVM as suit storage. */
 		suit_storage: partition@f6000 {
-			label = "suit_storage";
 			reg = <0xf6000 DT_SIZE_K(40)>;
 		};
 	};

--- a/tests/subsys/suit/flash_sink/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/subsys/suit/flash_sink/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -18,7 +18,6 @@
 		#size-cells = < 0x1 >;
 
 		dfu_partition: partition@19d000 {
-			label = "dfu_partition";
 			reg = < 0x19d000 DT_SIZE_K(1) >;
 		};
 

--- a/tests/subsys/suit/orchestrator/orchestrator_sdfw/boards/native_posix.overlay
+++ b/tests/subsys/suit/orchestrator/orchestrator_sdfw/boards/native_posix.overlay
@@ -12,7 +12,6 @@
 
 		/* Use the last 40KB of NVM as suit storage. */
 		suit_storage: partition@f6000 {
-			label = "suit_storage";
 			reg = <0xf6000 DT_SIZE_K(40)>;
 		};
 	};

--- a/tests/subsys/suit/orchestrator/orchestrator_sdfw/boards/native_posix_64.overlay
+++ b/tests/subsys/suit/orchestrator/orchestrator_sdfw/boards/native_posix_64.overlay
@@ -12,7 +12,6 @@
 
 		/* Use the last 40KB of NVM as suit storage. */
 		suit_storage: partition@f6000 {
-			label = "suit_storage";
 			reg = <0xf6000 DT_SIZE_K(40)>;
 		};
 	};

--- a/tests/subsys/suit/orchestrator/orchestrator_sdfw/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/subsys/suit/orchestrator/orchestrator_sdfw/boards/nrf52840dk_nrf52840.overlay
@@ -12,7 +12,6 @@
 
 		/* Use the last 40KB of NVM as suit storage. */
 		suit_storage: partition@f6000 {
-			label = "suit_storage";
 			reg = <0xf6000 DT_SIZE_K(40)>;
 		};
 	};

--- a/tests/subsys/suit/sink_selector/boards/native_posix.overlay
+++ b/tests/subsys/suit/sink_selector/boards/native_posix.overlay
@@ -11,7 +11,6 @@
 		#size-cells = < 0x1 >;
 
 		dfu_partition: partition@f5000 {
-			label = "dfu_partition";
 			reg = < 0xf5000 DT_SIZE_K(4) >;
 		};
 
@@ -25,7 +24,6 @@
 
 		/* Use the last 8KB of NVM as suit storage. */
 		suit_storage: partition@fe000 {
-			label = "suit_storage";
 			reg = <0xfe000 DT_SIZE_K(8)>;
 		};
 	};

--- a/tests/subsys/suit/sink_selector/boards/native_posix_64.overlay
+++ b/tests/subsys/suit/sink_selector/boards/native_posix_64.overlay
@@ -11,7 +11,6 @@
 		#size-cells = < 0x1 >;
 
 		dfu_partition: partition@f5000 {
-			label = "dfu_partition";
 			reg = < 0xf5000 DT_SIZE_K(4) >;
 		};
 
@@ -25,7 +24,6 @@
 
 		/* Use the last 8KB of NVM as suit storage. */
 		suit_storage: partition@fe000 {
-			label = "suit_storage";
 			reg = <0xfe000 DT_SIZE_K(8)>;
 		};
 	};

--- a/tests/subsys/suit/storage/boards/native_posix.overlay
+++ b/tests/subsys/suit/storage/boards/native_posix.overlay
@@ -12,7 +12,6 @@
 
 		/* Use the last 44KB of NVM as suit storage. */
 		suit_storage: partition@f5000 {
-			label = "suit_storage";
 			reg = <0xf5000 DT_SIZE_K(44)>;
 		};
 	};

--- a/tests/subsys/suit/storage/boards/native_posix_64.overlay
+++ b/tests/subsys/suit/storage/boards/native_posix_64.overlay
@@ -12,7 +12,6 @@
 
 		/* Use the last 44KB of NVM as suit storage. */
 		suit_storage: partition@f5000 {
-			label = "suit_storage";
 			reg = <0xf5000 DT_SIZE_K(44)>;
 		};
 	};

--- a/tests/subsys/suit/storage/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/subsys/suit/storage/boards/nrf52840dk_nrf52840.overlay
@@ -12,7 +12,6 @@
 
 		/* Use the last 44KB of NVM as suit storage. */
 		suit_storage: partition@f5000 {
-			label = "suit_storage";
 			reg = <0xf5000 DT_SIZE_K(44)>;
 		};
 	};


### PR DESCRIPTION
Labes on partiions in NCS are nor needed nor allowed on all platforms.

Ref: NCSDK-NONE