### PR TITLE
suit: aligned to new storage node names in dts

### DIFF
--- a/subsys/suit/storage/src/suit_storage_nrf54h20.c
+++ b/subsys/suit/storage/src/suit_storage_nrf54h20.c
@@ -13,14 +13,14 @@
 LOG_MODULE_REGISTER(suit_storage, CONFIG_SUIT_LOG_LEVEL);
 
 #define SUIT_STORAGE_NORDIC_ADDRESS suit_plat_mem_nvm_ptr_get(SUIT_STORAGE_NORDIC_OFFSET)
-#define SUIT_STORAGE_NORDIC_OFFSET  FIXED_PARTITION_OFFSET(suit_storage_nordic)
-#define SUIT_STORAGE_NORDIC_SIZE    FIXED_PARTITION_SIZE(suit_storage_nordic)
+#define SUIT_STORAGE_NORDIC_OFFSET  FIXED_PARTITION_OFFSET(cpusec_suit_storage)
+#define SUIT_STORAGE_NORDIC_SIZE    FIXED_PARTITION_SIZE(cpusec_suit_storage)
 #define SUIT_STORAGE_RAD_ADDRESS    suit_plat_mem_nvm_ptr_get(SUIT_STORAGE_RAD_OFFSET)
-#define SUIT_STORAGE_RAD_OFFSET	    FIXED_PARTITION_OFFSET(suit_storage_rad)
-#define SUIT_STORAGE_RAD_SIZE	    FIXED_PARTITION_SIZE(suit_storage_rad)
+#define SUIT_STORAGE_RAD_OFFSET	    FIXED_PARTITION_OFFSET(cpurad_suit_storage)
+#define SUIT_STORAGE_RAD_SIZE	    FIXED_PARTITION_SIZE(cpurad_suit_storage)
 #define SUIT_STORAGE_APP_ADDRESS    suit_plat_mem_nvm_ptr_get(SUIT_STORAGE_APP_OFFSET)
-#define SUIT_STORAGE_APP_OFFSET	    FIXED_PARTITION_OFFSET(suit_storage_app)
-#define SUIT_STORAGE_APP_SIZE	    FIXED_PARTITION_SIZE(suit_storage_app)
+#define SUIT_STORAGE_APP_OFFSET	    FIXED_PARTITION_OFFSET(cpuapp_suit_storage)
+#define SUIT_STORAGE_APP_SIZE	    FIXED_PARTITION_SIZE(cpuapp_suit_storage)
 
 typedef uint8_t suit_storage_digest_t[32];
 

--- a/tests/subsys/suit/orchestrator/orchestrator_sdfw/src/test_boot_mode.c
+++ b/tests/subsys/suit/orchestrator/orchestrator_sdfw/src/test_boot_mode.c
@@ -14,9 +14,9 @@
 #include <zephyr/storage/flash_map.h>
 #include <suit_plat_mem_util.h>
 
-#if DT_NODE_EXISTS(DT_NODELABEL(suit_storage_app))
-#define SUIT_STORAGE_OFFSET FIXED_PARTITION_OFFSET(suit_storage_app)
-#define SUIT_STORAGE_SIZE   FIXED_PARTITION_SIZE(suit_storage_app)
+#if DT_NODE_EXISTS(DT_NODELABEL(cpuapp_suit_storage))
+#define SUIT_STORAGE_OFFSET FIXED_PARTITION_OFFSET(cpuapp_suit_storage)
+#define SUIT_STORAGE_SIZE   FIXED_PARTITION_SIZE(cpuapp_suit_storage)
 #else
 #define SUIT_STORAGE_OFFSET FIXED_PARTITION_OFFSET(suit_storage)
 #define SUIT_STORAGE_SIZE   FIXED_PARTITION_SIZE(suit_storage)

--- a/tests/subsys/suit/orchestrator/orchestrator_sdfw/src/test_init.c
+++ b/tests/subsys/suit/orchestrator/orchestrator_sdfw/src/test_init.c
@@ -14,9 +14,9 @@
 #include <zephyr/storage/flash_map.h>
 #include <suit_plat_mem_util.h>
 
-#if DT_NODE_EXISTS(DT_NODELABEL(suit_storage_app))
-#define SUIT_STORAGE_OFFSET FIXED_PARTITION_OFFSET(suit_storage_app)
-#define SUIT_STORAGE_SIZE   FIXED_PARTITION_SIZE(suit_storage_app)
+#if DT_NODE_EXISTS(DT_NODELABEL(cpuapp_suit_storage))
+#define SUIT_STORAGE_OFFSET FIXED_PARTITION_OFFSET(cpuapp_suit_storage)
+#define SUIT_STORAGE_SIZE   FIXED_PARTITION_SIZE(cpuapp_suit_storage)
 #else
 #define SUIT_STORAGE_OFFSET FIXED_PARTITION_OFFSET(suit_storage)
 #define SUIT_STORAGE_SIZE   FIXED_PARTITION_SIZE(suit_storage)

--- a/tests/subsys/suit/orchestrator/orchestrator_sdfw/src/test_recovery_boot_mode.c
+++ b/tests/subsys/suit/orchestrator/orchestrator_sdfw/src/test_recovery_boot_mode.c
@@ -14,9 +14,9 @@
 #include <zephyr/storage/flash_map.h>
 #include <suit_plat_mem_util.h>
 
-#if DT_NODE_EXISTS(DT_NODELABEL(suit_storage_app))
-#define SUIT_STORAGE_OFFSET FIXED_PARTITION_OFFSET(suit_storage_app)
-#define SUIT_STORAGE_SIZE   FIXED_PARTITION_SIZE(suit_storage_app)
+#if DT_NODE_EXISTS(DT_NODELABEL(cpuapp_suit_storage))
+#define SUIT_STORAGE_OFFSET FIXED_PARTITION_OFFSET(cpuapp_suit_storage)
+#define SUIT_STORAGE_SIZE   FIXED_PARTITION_SIZE(cpuapp_suit_storage)
 #else
 #define SUIT_STORAGE_OFFSET FIXED_PARTITION_OFFSET(suit_storage)
 #define SUIT_STORAGE_SIZE   FIXED_PARTITION_SIZE(suit_storage)

--- a/tests/subsys/suit/orchestrator/orchestrator_sdfw/src/test_recovery_update_mode.c
+++ b/tests/subsys/suit/orchestrator/orchestrator_sdfw/src/test_recovery_update_mode.c
@@ -15,9 +15,9 @@
 #include <zephyr/storage/flash_map.h>
 #include <suit_plat_mem_util.h>
 
-#if DT_NODE_EXISTS(DT_NODELABEL(suit_storage_app))
-#define SUIT_STORAGE_OFFSET FIXED_PARTITION_OFFSET(suit_storage_app)
-#define SUIT_STORAGE_SIZE   FIXED_PARTITION_SIZE(suit_storage_app)
+#if DT_NODE_EXISTS(DT_NODELABEL(cpuapp_suit_storage))
+#define SUIT_STORAGE_OFFSET FIXED_PARTITION_OFFSET(cpuapp_suit_storage)
+#define SUIT_STORAGE_SIZE   FIXED_PARTITION_SIZE(cpuapp_suit_storage)
 #else
 #define SUIT_STORAGE_OFFSET FIXED_PARTITION_OFFSET(suit_storage)
 #define SUIT_STORAGE_SIZE   FIXED_PARTITION_SIZE(suit_storage)

--- a/tests/subsys/suit/orchestrator/orchestrator_sdfw/src/test_update_mode.c
+++ b/tests/subsys/suit/orchestrator/orchestrator_sdfw/src/test_update_mode.c
@@ -16,9 +16,9 @@
 #include <suit_plat_mem_util.h>
 #include <update_magic_values.h>
 
-#if DT_NODE_EXISTS(DT_NODELABEL(suit_storage_app))
-#define SUIT_STORAGE_OFFSET FIXED_PARTITION_OFFSET(suit_storage_app)
-#define SUIT_STORAGE_SIZE   FIXED_PARTITION_SIZE(suit_storage_app)
+#if DT_NODE_EXISTS(DT_NODELABEL(cpuapp_suit_storage))
+#define SUIT_STORAGE_OFFSET FIXED_PARTITION_OFFSET(cpuapp_suit_storage)
+#define SUIT_STORAGE_SIZE   FIXED_PARTITION_SIZE(cpuapp_suit_storage)
 #else
 #define SUIT_STORAGE_OFFSET FIXED_PARTITION_OFFSET(suit_storage)
 #define SUIT_STORAGE_SIZE   FIXED_PARTITION_SIZE(suit_storage)

--- a/tests/subsys/suit/storage/src/test_envelopes.c
+++ b/tests/subsys/suit/storage/src/test_envelopes.c
@@ -8,9 +8,9 @@
 #include <suit_storage.h>
 #include <suit_plat_mem_util.h>
 
-#if DT_NODE_EXISTS(DT_NODELABEL(suit_storage_app))
-#define SUIT_STORAGE_OFFSET FIXED_PARTITION_OFFSET(suit_storage_app)
-#define SUIT_STORAGE_SIZE   FIXED_PARTITION_SIZE(suit_storage_app)
+#if DT_NODE_EXISTS(DT_NODELABEL(cpuapp_suit_storage))
+#define SUIT_STORAGE_OFFSET FIXED_PARTITION_OFFSET(cpuapp_suit_storage)
+#define SUIT_STORAGE_SIZE   FIXED_PARTITION_SIZE(cpuapp_suit_storage)
 #else
 #define SUIT_STORAGE_OFFSET FIXED_PARTITION_OFFSET(suit_storage)
 #define SUIT_STORAGE_SIZE   FIXED_PARTITION_SIZE(suit_storage)

--- a/tests/subsys/suit/storage/src/test_report.c
+++ b/tests/subsys/suit/storage/src/test_report.c
@@ -8,9 +8,9 @@
 #include <suit_storage.h>
 #include <suit_plat_mem_util.h>
 
-#if DT_NODE_EXISTS(DT_NODELABEL(suit_storage_nordic))
-#define SUIT_STORAGE_OFFSET	      FIXED_PARTITION_OFFSET(suit_storage_nordic)
-#define SUIT_STORAGE_SIZE	      FIXED_PARTITION_SIZE(suit_storage_nordic)
+#if DT_NODE_EXISTS(DT_NODELABEL(cpusec_suit_storage))
+#define SUIT_STORAGE_OFFSET	      FIXED_PARTITION_OFFSET(cpusec_suit_storage)
+#define SUIT_STORAGE_SIZE	      FIXED_PARTITION_SIZE(cpusec_suit_storage)
 #define SUIT_STORAGE_REPORT_SLOTS     1
 #define SUIT_STORAGE_REPORT_SLOT_SIZE (160 - SUIT_STORAGE_REPORT_FLAG_SIZE)
 #else

--- a/tests/subsys/suit/storage/src/test_update.c
+++ b/tests/subsys/suit/storage/src/test_update.c
@@ -9,9 +9,9 @@
 #include <suit_plat_mem_util.h>
 #include <update_magic_values.h>
 
-#if DT_NODE_EXISTS(DT_NODELABEL(suit_storage_app))
-#define SUIT_STORAGE_OFFSET FIXED_PARTITION_OFFSET(suit_storage_app)
-#define SUIT_STORAGE_SIZE   FIXED_PARTITION_SIZE(suit_storage_app)
+#if DT_NODE_EXISTS(DT_NODELABEL(cpuapp_suit_storage))
+#define SUIT_STORAGE_OFFSET FIXED_PARTITION_OFFSET(cpuapp_suit_storage)
+#define SUIT_STORAGE_SIZE   FIXED_PARTITION_SIZE(cpuapp_suit_storage)
 #else
 #define SUIT_STORAGE_OFFSET FIXED_PARTITION_OFFSET(suit_storage)
 #define SUIT_STORAGE_SIZE   FIXED_PARTITION_SIZE(suit_storage)

--- a/tests/subsys/suit/storage_nrf54h20/boards/native_posix.overlay
+++ b/tests/subsys/suit/storage_nrf54h20/boards/native_posix.overlay
@@ -15,17 +15,17 @@
 
 		/* Use the last 32 kB of SecDom SUIT NVM storage. */
 		/* Use the first 4kB as area reserved for Secure domain. */
-		suit_storage_nordic: partition@1e7000 {
+		cpusec_suit_storage: partition@1e7000 {
 			reg = <0x1e7000 DT_SIZE_K(4)>;
 		};
 
 		/* Use the next 4kB as area reserved for Radio domain. */
-		suit_storage_rad: partition@1e8000 {
+		cpurad_suit_storage: partition@1e8000 {
 			reg = <0x1e8000 DT_SIZE_K(4)>;
 		};
 
 		/* Use the next 8kB as area reserved for Application domain. */
-		suit_storage_app: partition@1e9000 {
+		cpuapp_suit_storage: partition@1e9000 {
 			reg = <0x1e9000 DT_SIZE_K(8)>;
 		};
 	};

--- a/tests/subsys/suit/storage_nrf54h20/src/test_common.h
+++ b/tests/subsys/suit/storage_nrf54h20/src/test_common.h
@@ -10,14 +10,14 @@
 #define TEST_COMMON_H__
 
 #define SUIT_STORAGE_NORDIC_ADDRESS suit_plat_mem_nvm_ptr_get(SUIT_STORAGE_NORDIC_OFFSET)
-#define SUIT_STORAGE_NORDIC_OFFSET  FIXED_PARTITION_OFFSET(suit_storage_nordic)
-#define SUIT_STORAGE_NORDIC_SIZE    FIXED_PARTITION_SIZE(suit_storage_nordic)
+#define SUIT_STORAGE_NORDIC_OFFSET  FIXED_PARTITION_OFFSET(cpusec_suit_storage)
+#define SUIT_STORAGE_NORDIC_SIZE    FIXED_PARTITION_SIZE(cpusec_suit_storage)
 #define SUIT_STORAGE_RAD_ADDRESS    suit_plat_mem_nvm_ptr_get(SUIT_STORAGE_RAD_OFFSET)
-#define SUIT_STORAGE_RAD_OFFSET	    FIXED_PARTITION_OFFSET(suit_storage_rad)
-#define SUIT_STORAGE_RAD_SIZE	    FIXED_PARTITION_SIZE(suit_storage_rad)
+#define SUIT_STORAGE_RAD_OFFSET	    FIXED_PARTITION_OFFSET(cpurad_suit_storage)
+#define SUIT_STORAGE_RAD_SIZE	    FIXED_PARTITION_SIZE(cpurad_suit_storage)
 #define SUIT_STORAGE_APP_ADDRESS    suit_plat_mem_nvm_ptr_get(SUIT_STORAGE_APP_OFFSET)
-#define SUIT_STORAGE_APP_OFFSET	    FIXED_PARTITION_OFFSET(suit_storage_app)
-#define SUIT_STORAGE_APP_SIZE	    FIXED_PARTITION_SIZE(suit_storage_app)
+#define SUIT_STORAGE_APP_OFFSET	    FIXED_PARTITION_OFFSET(cpuapp_suit_storage)
+#define SUIT_STORAGE_APP_SIZE	    FIXED_PARTITION_SIZE(cpuapp_suit_storage)
 
 #define SUIT_STORAGE_APP_NVV_ADDRESS suit_plat_mem_nvm_ptr_get(SUIT_STORAGE_APP_NVV_OFFSET)
 #define SUIT_STORAGE_APP_NVV_OFFSET  (SUIT_STORAGE_APP_OFFSET + 0x380)


### PR DESCRIPTION
The names were changed in dts to match the new convention, this commit aligns the code.