### PR TITLE
doc: wifi: replace gsg links to developing ug

### DIFF
--- a/doc/nrf/includes/sample_board_rows.txt
+++ b/doc/nrf/includes/sample_board_rows.txt
@@ -168,27 +168,27 @@
 
 .. nrf7002dk_nrf5340_cpuapp
 
-| :ref:`nRF7002 DK <nrf7002dk_nrf5340>` | PCA10143 | :ref:`nrf7002dk_nrf5340 <nrf7002dk_nrf5340>` | ``nrf7002dk_nrf5340_cpuapp`` |
+| :ref:`nRF7002 DK <ug_nrf70_developing>` | PCA10143 | :ref:`nrf7002dk_nrf5340 <ug_nrf70_developing>` | ``nrf7002dk_nrf5340_cpuapp`` |
 
 .. nrf7002dk_nrf5340_cpuapp_ns
 
-| :ref:`nRF7002 DK <nrf7002dk_nrf5340>` | PCA10143 | :ref:`nrf7002dk_nrf5340 <nrf7002dk_nrf5340>` | ``nrf7002dk_nrf5340_cpuapp_ns`` |
+| :ref:`nRF7002 DK <ug_nrf70_developing>` | PCA10143 | :ref:`nrf7002dk_nrf5340 <ug_nrf70_developing>` | ``nrf7002dk_nrf5340_cpuapp_ns`` |
 
 .. nrf7002dk_nrf5340_cpunet
 
-| :ref:`nRF7002 DK <nrf7002dk_nrf5340>` | PCA10143 | :ref:`nrf7002dk_nrf5340 <nrf7002dk_nrf5340>` | ``nrf7002dk_nrf5340_cpunet`` |
+| :ref:`nRF7002 DK <ug_nrf70_developing>` | PCA10143 | :ref:`nrf7002dk_nrf5340 <ug_nrf70_developing>` | ``nrf7002dk_nrf5340_cpunet`` |
 
 .. nrf7002dk_nrf7001_nrf5340_cpuapp
 
-| :ref:`nRF7002 DK (emulating nRF7001) <nrf7002dk_nrf5340>` | PCA10143 | :ref:`nrf7002dk_nrf7001_nrf5340 <nrf7002dk_nrf5340>` | ``nrf7002dk_nrf7001_nrf5340_cpuapp`` |
+| :ref:`nRF7002 DK (emulating nRF7001) <ug_nrf70_developing>` | PCA10143 | :ref:`nrf7002dk_nrf7001_nrf5340 <ug_nrf70_developing>` | ``nrf7002dk_nrf7001_nrf5340_cpuapp`` |
 
 .. nrf7002dk_nrf7001_nrf5340_cpuapp_ns
 
-| :ref:`nRF7002 DK (emulating nRF7001) <nrf7002dk_nrf5340>` | PCA10143 | :ref:`nrf7002dk_nrf7001_nrf5340 <nrf7002dk_nrf5340>` | ``nrf7002dk_nrf7001_nrf5340_cpuapp_ns`` |
+| :ref:`nRF7002 DK (emulating nRF7001) <ug_nrf70_developing>` | PCA10143 | :ref:`nrf7002dk_nrf7001_nrf5340 <ug_nrf70_developing>` | ``nrf7002dk_nrf7001_nrf5340_cpuapp_ns`` |
 
 .. nrf7002dk_nrf7001_nrf5340_cpunet
 
-| :ref:`nRF7002 DK (emulating nRF7001) <nrf7002dk_nrf5340>` | PCA10143 | :ref:`nrf7002dk_nrf7001_nrf5340 <nrf7002dk_nrf5340>` | ``nrf7002dk_nrf7001_nrf5340_cpunet`` |
+| :ref:`nRF7002 DK (emulating nRF7001) <ug_nrf70_developing>` | PCA10143 | :ref:`nrf7002dk_nrf7001_nrf5340 <ug_nrf70_developing>` | ``nrf7002dk_nrf7001_nrf5340_cpunet`` |
 
 .. nrf54h20dk_nrf54h20_cpuapp
 


### PR DESCRIPTION
Replaced the Getting Started page links
to Developing with nRF70 Series page
for nRF70 Series devices in the
sample_board_rows.txt.

NCSDK-25668