### PR TITLE
samples: wifi: shell: Fix regulatory domain setting reference

### DIFF
--- a/samples/wifi/shell/README.rst
+++ b/samples/wifi/shell/README.rst
@@ -426,7 +426,7 @@ To test the SAP mode, the sample must be built using the configuration overlay :
 
       wifi reg_domain <ISO/IEC 3166-1 alpha2>
 
-   For example, to set the regulatory domain to US, use the following command:
+   For example, to set the regulatory domain to IN, use the following command:
 
    .. code-block:: console
 


### PR DESCRIPTION
Correct the display of the `Set regulatory domain` command in the testing SAP mode procedure section of the shell sample documentation.

Fixes SHEL-2732