### PR TITLE
doc: ap_protect: clarify default setting

### DIFF
--- a/doc/_utils/redirects.py
+++ b/doc/_utils/redirects.py
@@ -61,6 +61,7 @@ NRF = [
     ("test_and_optimize/testing_unity_cmock", "test_and_optimize/test_framework/testing_unity_cmock"),
     ("ug_tfm", "security/tfm"),
     ("app_dev/tfm/index", "security/tfm"),
+    ("app_dev/ap_protect/index", "security/ap_protect"),
     ("app_build_system", "config_and_build/config_and_build_system"),
     ("app_dev/build_and_config_system/index", "config_and_build/config_and_build_system"),
     ("ug_radio_coex", "device_guides/wifi_coex"),

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -72,6 +72,11 @@ Working with RF front-end modules
 
 |no_changes_yet_note|
 
+Security
+========
+
+* Added information about the default Kconfig option setting for :ref:`enabling access port protection mechanism in the nRF Connect SDK<app_approtect_ncs>`.
+
 Protocols
 =========
 

--- a/doc/nrf/security/ap_protect.rst
+++ b/doc/nrf/security/ap_protect.rst
@@ -141,8 +141,10 @@ Based on the available implementation types, you can configure the access port p
        The MDK will close the debug AHB-AP, but not lock it, so the AHB-AP can be reopened by the firmware.
        Reopening the AHB-AP should be preceded by a handshake operation over UART, CTRL-AP Mailboxes, or some other communication channel.
      - Hardware and software
-   * - Open
-     - :kconfig:option:`CONFIG_NRF_APPROTECT_USE_UICR` (:kconfig:option:`CONFIG_NRF_SECURE_APPROTECT_USE_UICR` for Secure AP-Protect)
+   * - Open (default)
+     - | :kconfig:option:`CONFIG_NRF_APPROTECT_USE_UICR` (:kconfig:option:`CONFIG_NRF_SECURE_APPROTECT_USE_UICR` for Secure AP-Protect)
+       |
+       | This option is set to ``y`` by default in the |NCS|.
      - In this state, AP-Protect follows the UICR register. If the UICR is open, meaning ``UICR.APPROTECT`` has the value ``Disabled``, the AP-Protect will be disabled. (The exact value, placement, the enumeration name, and format varies between nRF Series families.)
      - Hardware; hardware and software
 
@@ -171,6 +173,7 @@ Enabling AP-Protect with :kconfig:option:`CONFIG_NRF_APPROTECT_USE_UICR`
 ========================================================================
 
 Setting the :kconfig:option:`CONFIG_NRF_APPROTECT_USE_UICR` Kconfig option to ``y`` and compiling the firmware makes the AP-Protect disabled by default.
+This is the default setting in the |NCS|.
 
 You can start debugging the firmware without additional steps needed.
 


### PR DESCRIPTION
Added information about which Kconfig option is the default in the NCS. NCSDK-22526.

----

- [x] Changelog entry before merge.