### PR TITLE
tfm: 54l: Use a more reasonable amount of RAM by default for TFM

### DIFF
--- a/modules/trusted-firmware-m/Kconfig.tfm.pm
+++ b/modules/trusted-firmware-m/Kconfig.tfm.pm
@@ -11,6 +11,10 @@ config PM_PARTITION_SIZE_TFM_SRAM
 	prompt "Memory reserved for TFM_RAM" if !TFM_PROFILE_TYPE_MINIMAL
 	default 0x8000 if TFM_PROFILE_TYPE_MINIMAL
 	default 0x18000 if SOC_SERIES_NRF91X && TFM_REGRESSION_S
+	# It has been observed for 54L that when Matter is enabled, then
+	# assigning 0x16000 of RAM to TFM will not leave enough RAM for
+	# Matter. So we use 0x13000 of RAM on 54L.
+	default 0x13000 if SOC_SERIES_NRF54LX
 	default 0x16000 if SOC_SERIES_NRF91X
 	default 0x30000
 	help


### PR DESCRIPTION
Reduce the default amount of RAM for TFM from 200kB to 65kB.

This makes it possible to fit TF-M with other applications that use a lot of RAM, like Matter.