### PR TITLE
manifest: update sdk-zephyr to have functional support for nRF54H20 PWM

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 4e6070dbdc332a17ae439649e5e6af01a6365290
+      revision: pull/1671/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update sdk-zephyr so functional changes aligning PWM driver to nRF54H20 are available.