### PR TITLE
manifest: update sdk-zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: f50ad41dd6ea61d36bece05171768e12f5ceb5a3
+      revision: pull/1673/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
The new zephyr revision changes the SPI DW driver to properly configure the EXMIF peripheral.