### PR TITLE
suit: Use SOC series insted of SOC_NRF54H20

### DIFF
--- a/subsys/suit/provisioning/soc/Kconfig.nrf54h20
+++ b/subsys/suit/provisioning/soc/Kconfig.nrf54h20
@@ -15,7 +15,7 @@
 
 config SUIT_MPI_SOC_NRF54H20
 	bool
-	default y if SOC_NRF54H20
+	default y if SOC_SERIES_NRF54HX
 
 if SUIT_MPI_SOC_NRF54H20
 


### PR DESCRIPTION
The SOC_NRF54H20 symbol remains unavailable in SDFW.

Ref: NCSDK-NONE