### PR TITLE
manifest: Update sdk-zephyr with fix GRTC tests

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 25fbeabe900442d0568090765851aa452c4d8947
+      revision: 1a8f9cb0b324a6dde08ee7a9f544b97d2cbc8a1b
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull in sdk-zephyr revision for fixing tests/drivers/timer/nrf_grtc.