### PR TITLE
applications: nrf5340_audio: Use CAP procedures for unicast_server

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/broadcast_source.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/broadcast_source.c
@@ -427,8 +427,6 @@ int broadcast_source_enable(void)
 		stream_params[i].stream = &cap_streams[i];
 
 		bt_cap_stream_ops_register(stream_params[i].stream, &stream_ops);
-		/* TODO: Remove this once the fixed call above has been upstreamed */
-		bt_bap_stream_cb_register(&stream_params[i].stream->bap_stream, &stream_ops);
 
 		stream_params[i].data_len = ARRAY_SIZE(bis_codec_data[i]);
 		stream_params[i].data = bis_codec_data[i];

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.c
@@ -12,24 +12,39 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(le_audio, CONFIG_BLE_LOG_LEVEL);
 
-/*TODO: Create helper function in host to perform this action. */
-bool le_audio_ep_state_check(struct bt_bap_ep *ep, enum bt_bap_ep_state state)
+int le_audio_ep_state_get(struct bt_bap_ep *ep, uint8_t *state)
 {
 	int ret;
 	struct bt_bap_ep_info ep_info;
 
 	if (ep == NULL) {
 		/* If an endpoint is NULL it is not in any of the states */
-		return false;
+		return -EINVAL;
 	}
 
 	ret = bt_bap_ep_get_info(ep, &ep_info);
 	if (ret) {
 		LOG_WRN("Unable to get info for ep");
+		return ret;
+	}
+
+	*state = ep_info.state;
+
+	return 0;
+}
+
+/*TODO: Create helper function in host to perform this action. */
+bool le_audio_ep_state_check(struct bt_bap_ep *ep, enum bt_bap_ep_state state)
+{
+	int ret;
+	uint8_t ep_state;
+
+	ret = le_audio_ep_state_get(ep, &ep_state);
+	if (ret) {
 		return false;
 	}
 
-	if (ep_info.state == state) {
+	if (ep_state == state) {
 		return true;
 	}
 

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.h
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.h
@@ -67,6 +67,16 @@ struct le_audio_encoded_audio {
 };
 
 /**
+ * @brief	Get the current state of an endpoint.
+ *
+ * @param[in]	ep       The endpoint to check.
+ * @param[out]	state    The state of the endpoint.
+ *
+ * @return	0 for success, error otherwise.
+ */
+int le_audio_ep_state_get(struct bt_bap_ep *ep, uint8_t *state);
+
+/**
  * @brief	Check if an endpoint is in the given state.
  *		If the endpoint is NULL, it is not in the
  *		given state, and this function returns false.

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_client.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_client.c
@@ -19,7 +19,8 @@
 #include <zephyr/bluetooth/audio/bap_lc3_preset.h>
 #include <../subsys/bluetooth/audio/bap_iso.h>
 
-/* TODO: Remove when a get_info function is implemented in host */
+/* TODO: Remove when a qos_pref_get function has been added in host */
+/* https://github.com/zephyrproject-rtos/zephyr/issues/72359 */
 #include <../subsys/bluetooth/audio/bap_endpoint.h>
 
 #include "macros_common.h"
@@ -37,37 +38,31 @@ ZBUS_CHAN_DEFINE(le_audio_chan, struct le_audio_msg, NULL, NULL, ZBUS_OBSERVERS_
 #define CIS_CONN_RETRY_TIMES	   5
 #define CIS_CONN_RETRY_DELAY_MS	   500
 
-struct le_audio_headset {
+struct le_audio_unicast_server {
 	char *ch_name;
-	uint8_t num_sink_eps;
-	uint8_t num_source_eps;
-	struct bt_bap_stream sink_stream;
-	bool waiting_for_sink_disc;
-	struct bt_bap_ep *sink_ep;
-	struct bt_audio_codec_cap sink_codec_cap[CONFIG_CODEC_CAP_COUNT_MAX];
-	struct bt_bap_stream source_stream;
-	bool waiting_for_source_disc;
-	struct bt_bap_ep *source_ep;
-	struct bt_audio_codec_cap source_codec_cap[CONFIG_CODEC_CAP_COUNT_MAX];
-	struct bt_conn *headset_conn;
-	struct k_work_delayable stream_start_sink_work;
-	struct k_work_delayable stream_start_source_work;
+	struct bt_conn *device_conn;
 	enum bt_audio_location location;
 	bool qos_reconfigure;
 	uint32_t reconfigure_pd;
+	/* Sink variables */
+	bool waiting_for_sink_disc;
+	struct bt_audio_codec_cap sink_codec_cap[CONFIG_CODEC_CAP_COUNT_MAX];
+	uint8_t num_sink_eps;
+	struct bt_bap_ep *sink_ep;
+	struct bt_cap_stream cap_sink_stream;
+	/* Source variables */
+	bool waiting_for_source_disc;
+	struct bt_audio_codec_cap source_codec_cap[CONFIG_CODEC_CAP_COUNT_MAX];
+	uint8_t num_source_eps;
+	struct bt_bap_ep *source_ep;
+	struct bt_cap_stream cap_source_stream;
 };
 
 struct discover_dir {
 	struct bt_conn *conn;
-	bool source;
 	bool sink;
+	bool source;
 };
-
-struct worker_data {
-	uint8_t channel_index;
-	enum bt_audio_dir dir;
-	uint8_t retries;
-} __aligned(4);
 
 struct temp_cap_storage {
 	struct bt_conn *conn;
@@ -76,22 +71,19 @@ struct temp_cap_storage {
 	struct bt_audio_codec_cap codec[CONFIG_CODEC_CAP_COUNT_MAX];
 };
 
-static struct le_audio_headset headsets[CONFIG_BT_MAX_CONN];
+static struct le_audio_unicast_server unicast_servers[CONFIG_BT_MAX_CONN];
 
-K_MSGQ_DEFINE(kwork_msgq, sizeof(struct worker_data),
-	      2 * (CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT +
-		   CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT),
-	      sizeof(uint32_t));
+K_MSGQ_DEFINE(cap_start_msgq, sizeof(uint8_t), CONFIG_BT_MAX_CONN, sizeof(uint8_t));
 
 static struct temp_cap_storage temp_cap[CONFIG_BT_MAX_CONN];
 
-/* Make sure that we have at least one headset device per CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK */
-BUILD_ASSERT(ARRAY_SIZE(headsets) >= CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT,
-	     "We need to have at least one headset device per ASE SINK");
+/* Make sure that we have at least one unicast_server per CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK */
+BUILD_ASSERT(ARRAY_SIZE(unicast_servers) >= CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT,
+	     "We need to have at least one unicast_server per ASE SINK");
 
-/* Make sure that we have at least one headset device per CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
-BUILD_ASSERT(ARRAY_SIZE(headsets) >= CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT,
-	     "We need to have at least one headset device per ASE SOURCE");
+/* Make sure that we have at least one unicast_server per CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
+BUILD_ASSERT(ARRAY_SIZE(unicast_servers) >= CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT,
+	     "We need to have at least one unicast_server per ASE SOURCE");
 
 static le_audio_receive_cb receive_cb;
 
@@ -133,31 +125,90 @@ static void le_audio_event_publish(enum le_audio_evt_type event, struct bt_conn 
 	ERR_CHK(ret);
 }
 
+static void cap_start_worker(struct k_work *work)
+{
+	int ret;
+	uint8_t device_index;
+
+	/* Check msgq for a pending start procedure */
+	ret = k_msgq_get(&cap_start_msgq, &device_index, K_NO_WAIT);
+	if (ret) {
+		LOG_ERR("Failed to get device index for pending cap start procedure: %d", ret);
+		return;
+	}
+
+	struct bt_cap_unicast_audio_start_stream_param
+		cap_stream_params[CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT +
+				  CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT];
+
+	struct bt_cap_unicast_audio_start_param param;
+
+	param.stream_params = cap_stream_params;
+	param.count = 0;
+	param.type = BT_CAP_SET_TYPE_AD_HOC;
+
+	if (unicast_servers[device_index].sink_ep) {
+		cap_stream_params[param.count].member.member =
+			unicast_servers[device_index].device_conn;
+		cap_stream_params[param.count].stream =
+			&unicast_servers[device_index].cap_sink_stream;
+		cap_stream_params[param.count].ep = unicast_servers[device_index].sink_ep;
+		cap_stream_params[param.count].codec_cfg = &lc3_preset_sink.codec_cfg;
+		param.count++;
+	}
+
+	if (unicast_servers[device_index].source_ep) {
+		cap_stream_params[param.count].member.member =
+			unicast_servers[device_index].device_conn;
+		cap_stream_params[param.count].stream =
+			&unicast_servers[device_index].cap_source_stream;
+		cap_stream_params[param.count].ep = unicast_servers[device_index].source_ep;
+		cap_stream_params[param.count].codec_cfg = &lc3_preset_source.codec_cfg;
+		param.count++;
+	}
+
+	ret = bt_cap_initiator_unicast_audio_start(&param);
+	if (ret == -EBUSY) {
+		/* Try again once the ongoing start procedure is completed */
+		ret = k_msgq_put(&cap_start_msgq, &device_index, K_NO_WAIT);
+		if (ret) {
+			LOG_ERR("Failed to put device_index on the queue: %d", ret);
+		}
+	} else if (ret) {
+		LOG_ERR("Failed to start unicast sink audio: %d", ret);
+	}
+}
+K_WORK_DEFINE(cap_start_work, cap_start_worker);
+
 /**
- * @brief  Get the common presentation delay for all headsets.
+ * @brief  Get the common presentation delay for all unicast_servers.
  *
- * @param[in]	index		The index of the headset to test against.
+ * @param[in]	index		The index of the device to test against.
  * @param[out]	pres_dly_us	Pointer to where the presentation delay will be stored.
  *
  * @retval	0	Operation successful.
  * @retval	-EINVAL	Any error.
  */
-static int headset_pres_delay_find(uint8_t index, uint32_t *pres_dly_us)
+static int device_pres_delay_find(uint8_t index, uint32_t *pres_dly_us)
 {
-	uint32_t pres_dly_min = headsets[index].sink_ep->qos_pref.pd_min;
-	uint32_t pres_dly_max = headsets[index].sink_ep->qos_pref.pd_max;
-	uint32_t pref_dly_min = headsets[index].sink_ep->qos_pref.pref_pd_min;
-	uint32_t pref_dly_max = headsets[index].sink_ep->qos_pref.pref_pd_max;
+	uint32_t pres_dly_min = unicast_servers[index].sink_ep->qos_pref.pd_min;
+	uint32_t pres_dly_max = unicast_servers[index].sink_ep->qos_pref.pd_max;
+	uint32_t pref_dly_min = unicast_servers[index].sink_ep->qos_pref.pref_pd_min;
+	uint32_t pref_dly_max = unicast_servers[index].sink_ep->qos_pref.pref_pd_max;
 
 	LOG_DBG("Index: %d, Pref min: %d, pref max: %d, pres_min: %d, pres_max: %d", index,
 		pref_dly_min, pref_dly_max, pres_dly_min, pres_dly_max);
 
-	for (int i = 0; i < ARRAY_SIZE(headsets); i++) {
-		if (headsets[i].sink_ep != NULL) {
-			pres_dly_min = MAX(pres_dly_min, headsets[i].sink_ep->qos_pref.pd_min);
-			pres_dly_max = MIN(pres_dly_max, headsets[i].sink_ep->qos_pref.pd_max);
-			pref_dly_min = MAX(pref_dly_min, headsets[i].sink_ep->qos_pref.pref_pd_min);
-			pref_dly_max = MIN(pref_dly_max, headsets[i].sink_ep->qos_pref.pref_pd_max);
+	for (int i = 0; i < ARRAY_SIZE(unicast_servers); i++) {
+		if (unicast_servers[i].sink_ep != NULL) {
+			pres_dly_min =
+				MAX(pres_dly_min, unicast_servers[i].sink_ep->qos_pref.pd_min);
+			pres_dly_max =
+				MIN(pres_dly_max, unicast_servers[i].sink_ep->qos_pref.pd_max);
+			pref_dly_min =
+				MAX(pref_dly_min, unicast_servers[i].sink_ep->qos_pref.pref_pd_min);
+			pref_dly_max =
+				MIN(pref_dly_max, unicast_servers[i].sink_ep->qos_pref.pref_pd_max);
 		}
 	}
 
@@ -201,23 +252,23 @@ static int headset_pres_delay_find(uint8_t index, uint32_t *pres_dly_us)
 }
 
 /**
- * @brief	Get channel index based on connection.
+ * @brief	Get device index based on connection.
  *
  * @param[in]	conn	The connection to search for.
- * @param[out]	index	The channel index.
+ * @param[out]	index	The device index.
  *
  * @retval	0	Operation successful.
  * @retval	-EINVAL	There is no match.
  */
-static int channel_index_get(const struct bt_conn *conn, uint8_t *index)
+static int device_index_get(const struct bt_conn *conn, uint8_t *index)
 {
 	if (conn == NULL) {
 		LOG_ERR("No connection provided");
 		return -EINVAL;
 	}
 
-	for (int i = 0; i < ARRAY_SIZE(headsets); i++) {
-		if (headsets[i].headset_conn == conn) {
+	for (int i = 0; i < ARRAY_SIZE(unicast_servers); i++) {
+		if (unicast_servers[i].device_conn == conn) {
 			*index = i;
 			return 0;
 		}
@@ -228,24 +279,24 @@ static int channel_index_get(const struct bt_conn *conn, uint8_t *index)
 	return -EINVAL;
 }
 
-static int channel_index_vacant_get(const struct bt_conn *conn, uint8_t *index)
+static int device_index_vacant_get(const struct bt_conn *conn, uint8_t *index)
 {
 
-	for (int i = 0; i < ARRAY_SIZE(headsets); i++) {
-		if (headsets[i].headset_conn == conn) {
+	for (int i = 0; i < ARRAY_SIZE(unicast_servers); i++) {
+		if (unicast_servers[i].device_conn == conn) {
 			LOG_WRN("Device has already been discovered");
 			return -EALREADY;
 		}
 	}
 
-	for (int i = 0; i < ARRAY_SIZE(headsets); i++) {
-		if (headsets[i].headset_conn == NULL) {
+	for (int i = 0; i < ARRAY_SIZE(unicast_servers); i++) {
+		if (unicast_servers[i].device_conn == NULL) {
 			*index = i;
 			return 0;
 		}
 	}
 
-	LOG_WRN("No more room in headset list");
+	LOG_WRN("No more room in device list");
 	return -ENOSPC;
 }
 
@@ -266,9 +317,9 @@ static void supported_sample_rates_print(uint16_t supported_sample_rates, enum b
 	}
 
 	if (dir == BT_AUDIO_DIR_SINK) {
-		LOG_DBG("Headset supports: %s kHz in sink direction", supported_str);
+		LOG_DBG("Unicast_server supports: %s kHz in sink direction", supported_str);
 	} else if (dir == BT_AUDIO_DIR_SOURCE) {
-		LOG_DBG("Headset supports: %s kHz in source direction", supported_str);
+		LOG_DBG("Unicast_server supports: %s kHz in source direction", supported_str);
 	}
 }
 
@@ -491,14 +542,14 @@ static bool source_parse_cb(struct bt_data *data, void *user_data)
 }
 
 /**
- * @brief	Check if the gateway can support the headset codec capabilities.
+ * @brief	Check if the gateway can support the codec capabilities.
  *
  * @note	Currently only the sampling frequency is checked.
  *
  * @param[in]	cap_array	The array of pointers to codec capabilities.
  * @param[in]	num_caps	The size of cap_array.
  * @param[in]	dir		Direction of the capabilities to check.
- * @param[in]	index		Channel index.
+ * @param[in]	index		Device index.
  *
  * @return	True if valid codec capability found, false otherwise.
  */
@@ -568,46 +619,61 @@ static void bt_audio_codec_allocation_set(struct bt_audio_codec_cfg *codec_cfg,
 	}
 }
 
-static int update_sink_stream_qos(struct le_audio_headset *headset, uint32_t pres_delay_us)
+static int update_cap_sink_stream_qos(struct le_audio_unicast_server *unicast_server,
+				      uint32_t pres_delay_us)
 {
 	int ret;
 
-	if (headset->sink_stream.ep == NULL) {
+	if (unicast_server->cap_sink_stream.bap_stream.ep == NULL) {
 		return -ESRCH;
 	}
 
-	if (headset->sink_stream.qos == NULL) {
-		LOG_WRN("No QoS found for %p", &headset->sink_stream);
+	if (unicast_server->cap_sink_stream.bap_stream.qos == NULL) {
+		LOG_WRN("No QoS found for %p", (void *)&unicast_server->cap_sink_stream.bap_stream);
 		return -ENXIO;
 	}
 
-	if (headset->sink_stream.qos->pd != pres_delay_us) {
+	if (unicast_server->cap_sink_stream.bap_stream.qos->pd != pres_delay_us) {
+		struct bt_cap_unicast_audio_stop_param param;
+		struct bt_cap_stream *streams[2];
+
+		param.streams = streams;
+		param.count = 0;
+		param.type = BT_CAP_SET_TYPE_AD_HOC;
+
 		if (playing_state &&
-		    le_audio_ep_state_check(headset->sink_stream.ep, BT_BAP_EP_STATE_STREAMING)) {
-			LOG_DBG("Update streaming %s headset, connection %p, stream %p",
-				headset->ch_name, &headset->headset_conn, &headset->sink_stream);
+		    le_audio_ep_state_check(unicast_server->cap_sink_stream.bap_stream.ep,
+					    BT_BAP_EP_STATE_STREAMING)) {
+			LOG_DBG("Update streaming %s unicast_server, connection %p, stream %p",
+				unicast_server->ch_name, (void *)&unicast_server->device_conn,
+				(void *)&unicast_server->cap_sink_stream.bap_stream);
 
-			headset->qos_reconfigure = true;
-			headset->reconfigure_pd = pres_delay_us;
+			unicast_server->qos_reconfigure = true;
+			unicast_server->reconfigure_pd = pres_delay_us;
 
-			ret = bt_bap_stream_disable(&headset->sink_stream);
-			if (ret) {
-				LOG_ERR("Unable to disable stream: %d", ret);
-				return ret;
-			}
+			streams[param.count] = &unicast_server->cap_sink_stream;
+			param.count++;
 		} else {
-			LOG_DBG("Reset %s headset, connection %p, stream %p", headset->ch_name,
-				&headset->headset_conn, &headset->sink_stream);
+			LOG_DBG("Reset %s unicast_server, connection %p, stream %p",
+				unicast_server->ch_name, (void *)&unicast_server->device_conn,
+				(void *)&unicast_server->cap_sink_stream.bap_stream);
+			unicast_server->cap_sink_stream.bap_stream.qos->pd = pres_delay_us;
+		}
 
-			headset->sink_stream.qos->pd = pres_delay_us;
+		if (playing_state &&
+		    le_audio_ep_state_check(unicast_server->cap_source_stream.bap_stream.ep,
+					    BT_BAP_EP_STATE_STREAMING)) {
+			unicast_server->qos_reconfigure = true;
+			unicast_server->reconfigure_pd = pres_delay_us;
 
-			ret = bt_bap_stream_qos(headset->headset_conn, unicast_group);
-			if (ret && ret != -EINVAL) {
-				/* ret == -EINVAL means that the stream is not ready to
-				 * be configured yet
-				 */
-				LOG_ERR("Unable to configure %s headset: %d", headset->ch_name,
-					ret);
+			streams[param.count] = &unicast_server->cap_source_stream;
+			param.count++;
+		}
+
+		if (param.count > 0) {
+			ret = bt_cap_initiator_unicast_audio_stop(&param);
+			if (ret) {
+				LOG_ERR("Failed to stop streams: %d", ret);
 				return ret;
 			}
 		}
@@ -622,21 +688,21 @@ static void unicast_client_location_cb(struct bt_conn *conn, enum bt_audio_dir d
 	int ret;
 	uint8_t index;
 
-	ret = channel_index_get(conn, &index);
+	ret = device_index_get(conn, &index);
 
 	if (ret) {
-		LOG_ERR("Channel index not found");
+		LOG_ERR("Device index not found");
 		return;
 	}
 
 	if ((loc & BT_AUDIO_LOCATION_FRONT_LEFT) || (loc & BT_AUDIO_LOCATION_SIDE_LEFT) ||
 	    (loc == BT_AUDIO_LOCATION_MONO_AUDIO)) {
-		headsets[index].location = BT_AUDIO_LOCATION_FRONT_LEFT;
-		headsets[index].ch_name = "LEFT";
+		unicast_servers[index].location = BT_AUDIO_LOCATION_FRONT_LEFT;
+		unicast_servers[index].ch_name = "LEFT";
 
 	} else if ((loc & BT_AUDIO_LOCATION_FRONT_RIGHT) || (loc & BT_AUDIO_LOCATION_SIDE_RIGHT)) {
-		headsets[index].location = BT_AUDIO_LOCATION_FRONT_RIGHT;
-		headsets[index].ch_name = "RIGHT";
+		unicast_servers[index].location = BT_AUDIO_LOCATION_FRONT_RIGHT;
+		unicast_servers[index].ch_name = "RIGHT";
 	} else {
 		LOG_WRN("Channel location not supported: %d", loc);
 		le_audio_event_publish(LE_AUDIO_EVT_NO_VALID_CFG, conn, dir);
@@ -714,9 +780,9 @@ static void pac_record_cb(struct bt_conn *conn, enum bt_audio_dir dir,
 static void endpoint_cb(struct bt_conn *conn, enum bt_audio_dir dir, struct bt_bap_ep *ep)
 {
 	int ret;
-	uint8_t channel_index = 0;
+	uint8_t device_index = 0;
 
-	ret = channel_index_get(conn, &channel_index);
+	ret = device_index_get(conn, &device_index);
 	if (ret) {
 		LOG_ERR("Unknown connection, should not reach here");
 		return;
@@ -724,36 +790,36 @@ static void endpoint_cb(struct bt_conn *conn, enum bt_audio_dir dir, struct bt_b
 
 	if (dir == BT_AUDIO_DIR_SINK) {
 		if (ep != NULL) {
-			if (headsets[channel_index].num_sink_eps > 0) {
+			if (unicast_servers[device_index].num_sink_eps > 0) {
 				LOG_WRN("More than one sink endpoint found, idx 0 is used "
 					"by default");
 				return;
 			}
 
-			headsets[channel_index].sink_ep = ep;
-			headsets[channel_index].num_sink_eps++;
+			unicast_servers[device_index].sink_ep = ep;
+			unicast_servers[device_index].num_sink_eps++;
 			return;
 		}
 
-		if (headsets[channel_index].sink_ep == NULL) {
+		if (unicast_servers[device_index].sink_ep == NULL) {
 			LOG_WRN("No sink endpoints found");
 		}
 
 		return;
 	} else if (dir == BT_AUDIO_DIR_SOURCE) {
 		if (ep != NULL) {
-			if (headsets[channel_index].num_source_eps > 0) {
+			if (unicast_servers[device_index].num_source_eps > 0) {
 				LOG_WRN("More than one source endpoint found, idx 0 is "
 					"used by default");
 				return;
 			}
 
-			headsets[channel_index].source_ep = ep;
-			headsets[channel_index].num_source_eps++;
+			unicast_servers[device_index].source_ep = ep;
+			unicast_servers[device_index].num_source_eps++;
 			return;
 		}
 
-		if (headsets[channel_index].source_ep == NULL) {
+		if (unicast_servers[device_index].source_ep == NULL) {
 			LOG_WRN("No source endpoints found");
 		}
 
@@ -766,10 +832,10 @@ static void endpoint_cb(struct bt_conn *conn, enum bt_audio_dir dir, struct bt_b
 static void discover_cb(struct bt_conn *conn, int err, enum bt_audio_dir dir)
 {
 	int ret;
-	uint8_t channel_index;
+	uint8_t device_index;
 	uint8_t temp_cap_index;
 
-	ret = channel_index_get(conn, &channel_index);
+	ret = device_index_get(conn, &device_index);
 	if (ret) {
 		LOG_ERR("Unknown connection, should not reach here");
 		return;
@@ -778,27 +844,11 @@ static void discover_cb(struct bt_conn *conn, int err, enum bt_audio_dir dir)
 	if (err == BT_ATT_ERR_ATTRIBUTE_NOT_FOUND) {
 		if (dir == BT_AUDIO_DIR_SINK) {
 			LOG_WRN("No sinks found");
-			headsets[channel_index].waiting_for_sink_disc = false;
+			unicast_servers[device_index].waiting_for_sink_disc = false;
 		} else if (dir == BT_AUDIO_DIR_SOURCE) {
 			LOG_WRN("No sources found");
-			headsets[channel_index].waiting_for_source_disc = false;
-			/**
-			 * We usually wait until both sink and source has been discovered
-			 * before configuring, but since no source was found and we have a
-			 * sink, we need to configure that.
-			 */
-			if (headsets[channel_index].sink_ep != NULL) {
-				ret = bt_bap_stream_config(conn,
-							   &headsets[channel_index].sink_stream,
-							   headsets[channel_index].sink_ep,
-							   &lc3_preset_sink.codec_cfg);
-				if (ret) {
-					LOG_ERR("Could not configure sink stream, ret = %d", ret);
-				}
-			}
+			unicast_servers[device_index].waiting_for_source_disc = false;
 		}
-
-		return;
 	} else if (err) {
 		LOG_ERR("Discovery failed: %d", err);
 		return;
@@ -811,39 +861,39 @@ static void discover_cb(struct bt_conn *conn, int err, enum bt_audio_dir dir)
 	}
 
 	for (int i = 0; i < CONFIG_CODEC_CAP_COUNT_MAX; i++) {
-		if (dir == BT_AUDIO_DIR_SINK) {
-			memcpy(&headsets[channel_index].sink_codec_cap[i],
+		if (dir == BT_AUDIO_DIR_SINK && !err) {
+			memcpy(&unicast_servers[device_index].sink_codec_cap[i],
 			       &temp_cap[temp_cap_index].codec[i],
 			       sizeof(struct bt_audio_codec_cap));
-		} else if (dir == BT_AUDIO_DIR_SOURCE) {
-			memcpy(&headsets[channel_index].source_codec_cap[i],
+		} else if (dir == BT_AUDIO_DIR_SOURCE && !err) {
+			memcpy(&unicast_servers[device_index].source_codec_cap[i],
 			       &temp_cap[temp_cap_index].codec[i],
 			       sizeof(struct bt_audio_codec_cap));
 		}
 	}
 
-	if (dir == BT_AUDIO_DIR_SINK) {
-		if (valid_codec_cap_check(headsets[channel_index].sink_codec_cap,
+	if (dir == BT_AUDIO_DIR_SINK && !err) {
+		if (valid_codec_cap_check(unicast_servers[device_index].sink_codec_cap,
 					  temp_cap[temp_cap_index].num_caps, BT_AUDIO_DIR_SINK,
-					  channel_index)) {
+					  device_index)) {
 			bt_audio_codec_allocation_set(&lc3_preset_sink.codec_cfg,
-						      headsets[channel_index].location);
+						      unicast_servers[device_index].location);
 		} else {
 			/* NOTE: The string below is used by the Nordic CI system */
-			LOG_WRN("No valid codec capability found for %s headset sink",
-				headsets[channel_index].ch_name);
-			headsets[channel_index].sink_ep = NULL;
+			LOG_WRN("No valid codec capability found for %s sink",
+				unicast_servers[device_index].ch_name);
+			unicast_servers[device_index].sink_ep = NULL;
 		}
-	} else if (dir == BT_AUDIO_DIR_SOURCE) {
-		if (valid_codec_cap_check(headsets[channel_index].source_codec_cap,
+	} else if (dir == BT_AUDIO_DIR_SOURCE && !err) {
+		if (valid_codec_cap_check(unicast_servers[device_index].source_codec_cap,
 					  temp_cap[temp_cap_index].num_caps, BT_AUDIO_DIR_SOURCE,
-					  channel_index)) {
+					  device_index)) {
 			bt_audio_codec_allocation_set(&lc3_preset_source.codec_cfg,
-						      headsets[channel_index].location);
+						      unicast_servers[device_index].location);
 		} else {
-			LOG_WRN("No valid codec capability found for %s headset source",
-				headsets[channel_index].ch_name);
-			headsets[channel_index].source_ep = NULL;
+			LOG_WRN("No valid codec capability found for %s source",
+				unicast_servers[device_index].ch_name);
+			unicast_servers[device_index].source_ep = NULL;
 		}
 	}
 
@@ -853,9 +903,9 @@ static void discover_cb(struct bt_conn *conn, int err, enum bt_audio_dir dir)
 	temp_cap[temp_cap_index].num_caps = 0;
 
 	if (dir == BT_AUDIO_DIR_SINK) {
-		headsets[channel_index].waiting_for_sink_disc = false;
+		unicast_servers[device_index].waiting_for_sink_disc = false;
 
-		if (headsets[channel_index].waiting_for_source_disc) {
+		if (unicast_servers[device_index].waiting_for_source_disc) {
 			ret = bt_bap_unicast_client_discover(conn, BT_AUDIO_DIR_SOURCE);
 			if (ret) {
 				LOG_WRN("Failed to discover source: %d", ret);
@@ -864,52 +914,45 @@ static void discover_cb(struct bt_conn *conn, int err, enum bt_audio_dir dir)
 			return;
 		}
 	} else if (dir == BT_AUDIO_DIR_SOURCE) {
-		headsets[channel_index].waiting_for_source_disc = false;
+		unicast_servers[device_index].waiting_for_source_disc = false;
 	}
 
-	if (headsets[channel_index].sink_ep) {
-		ret = bt_bap_stream_config(conn, &headsets[channel_index].sink_stream,
-					   headsets[channel_index].sink_ep,
-					   &lc3_preset_sink.codec_cfg);
-		if (ret) {
-			LOG_ERR("Could not configure sink stream, ret = %d", ret);
-		}
+	if (!playing_state) {
+		/* Since we are not in a playing state we return before starting the new streams */
+		return;
 	}
 
-	if (headsets[channel_index].source_ep) {
-		ret = bt_bap_stream_config(conn, &headsets[channel_index].source_stream,
-					   headsets[channel_index].source_ep,
-					   &lc3_preset_source.codec_cfg);
-		if (ret) {
-			LOG_ERR("Could not configure source stream, ret = %d", ret);
-		}
+	ret = k_msgq_put(&cap_start_msgq, &device_index, K_NO_WAIT);
+	if (ret) {
+		LOG_ERR("Failed to put device_index on the queue: %d", ret);
+		return;
 	}
+
+	k_work_submit(&cap_start_work);
 }
-
-static struct bt_bap_unicast_client_cb unicast_client_cbs = {
-	.location = unicast_client_location_cb,
-	.available_contexts = available_contexts_cb,
-	.pac_record = pac_record_cb,
-	.endpoint = endpoint_cb,
-	.discover = discover_cb,
-};
 
 #if (CONFIG_BT_AUDIO_TX)
 static void stream_sent_cb(struct bt_bap_stream *stream)
 {
 	int ret;
-	uint8_t channel_index;
+	uint8_t device_index;
+	uint8_t state;
 
-	if (le_audio_ep_state_check(stream->ep, BT_BAP_EP_STATE_STREAMING)) {
+	ret = le_audio_ep_state_get(stream->ep, &state);
+	if (ret) {
+		return;
+	}
 
-		ret = channel_index_get(stream->conn, &channel_index);
+	if (state == BT_BAP_EP_STATE_STREAMING) {
+
+		ret = device_index_get(stream->conn, &device_index);
 		if (ret) {
-			LOG_ERR("Channel index not found");
+			LOG_ERR("Device index not found");
 		} else {
-			ERR_CHK(bt_le_audio_tx_stream_sent(channel_index));
+			ERR_CHK(bt_le_audio_tx_stream_sent(device_index));
 		}
 	} else {
-		LOG_WRN("Not in streaming state");
+		LOG_WRN("Not in streaming state: %d", state);
 	}
 }
 #endif /* CONFIG_BT_AUDIO_TX */
@@ -918,181 +961,111 @@ static void stream_configured_cb(struct bt_bap_stream *stream,
 				 const struct bt_audio_codec_qos_pref *pref)
 {
 	int ret;
-	uint8_t channel_index;
+	uint8_t device_index;
 	uint32_t new_pres_dly_us;
+	enum bt_audio_dir dir;
 
-	ret = channel_index_get(stream->conn, &channel_index);
+	ret = device_index_get(stream->conn, &device_index);
 	if (ret) {
-		LOG_ERR("Channel index not found");
+		LOG_ERR("Device index not found");
 		return;
 	}
 
-	if (stream->ep->dir == BT_AUDIO_DIR_SINK) {
+	dir = le_audio_stream_dir_get(stream);
+	if (dir <= 0) {
+		LOG_ERR("Failed to get dir of stream %p", (void *)stream);
+		return;
+	}
+
+	if (dir == BT_AUDIO_DIR_SINK) {
 		/* NOTE: The string below is used by the Nordic CI system */
-		LOG_INF("%s sink stream configured", headsets[channel_index].ch_name);
-		le_audio_print_codec(headsets[channel_index].sink_stream.codec_cfg,
-				     stream->ep->dir);
-	} else if (stream->ep->dir == BT_AUDIO_DIR_SOURCE) {
-		LOG_INF("%s source stream configured", headsets[channel_index].ch_name);
-		le_audio_print_codec(headsets[channel_index].source_stream.codec_cfg,
-				     stream->ep->dir);
+		LOG_INF("%s sink stream configured", unicast_servers[device_index].ch_name);
+		le_audio_print_codec(
+			unicast_servers[device_index].cap_sink_stream.bap_stream.codec_cfg, dir);
+	} else if (dir == BT_AUDIO_DIR_SOURCE) {
+		LOG_INF("%s source stream configured", unicast_servers[device_index].ch_name);
+		le_audio_print_codec(
+			unicast_servers[device_index].cap_source_stream.bap_stream.codec_cfg, dir);
 	} else {
-		LOG_WRN("Endpoint direction not recognized: %d", stream->ep->dir);
+		LOG_ERR("Endpoint direction not recognized: %d", dir);
 		return;
 	}
-	LOG_DBG("Configured Stream info: %s, %p, dir %d", headsets[channel_index].ch_name,
-		(void *)stream, stream->ep->dir);
+	LOG_DBG("Configured Stream info: %s, %p, dir %d", unicast_servers[device_index].ch_name,
+		(void *)stream, dir);
 
-	ret = headset_pres_delay_find(channel_index, &new_pres_dly_us);
+	ret = device_pres_delay_find(device_index, &new_pres_dly_us);
 	if (ret) {
 		LOG_ERR("Cannot get a valid presentation delay");
 		return;
 	}
 
-	if (headsets[channel_index].waiting_for_source_disc) {
+	if (unicast_servers[device_index].waiting_for_source_disc) {
 		return;
 	}
 
-	if (le_audio_ep_state_check(headsets[channel_index].sink_stream.ep,
+	if (le_audio_ep_state_check(unicast_servers[device_index].cap_sink_stream.bap_stream.ep,
 				    BT_BAP_EP_STATE_CODEC_CONFIGURED)) {
-		for (int i = 0; i < ARRAY_SIZE(headsets); i++) {
-			if (i != channel_index && headsets[i].headset_conn != NULL) {
-				ret = update_sink_stream_qos(&headsets[i], new_pres_dly_us);
+		for (int i = 0; i < ARRAY_SIZE(unicast_servers); i++) {
+			if (i != device_index && unicast_servers[i].device_conn != NULL) {
+				ret = update_cap_sink_stream_qos(&unicast_servers[i],
+								 new_pres_dly_us);
 				if (ret && ret != -ESRCH) {
 					LOG_ERR("Presentation delay not set for %s "
-						"headset: %d",
-						headsets[channel_index].ch_name, ret);
+						"device: %d",
+						unicast_servers[device_index].ch_name, ret);
 				}
 			}
 		}
 
-		LOG_DBG("Set %s headset, connection %p, stream %p", headsets[channel_index].ch_name,
-			&headsets[channel_index].headset_conn,
-			&headsets[channel_index].sink_stream);
+		LOG_DBG("Set %s, connection %p, stream %p", unicast_servers[device_index].ch_name,
+			(void *)&unicast_servers[device_index].device_conn,
+			(void *)&unicast_servers[device_index].cap_sink_stream.bap_stream);
 
-		headsets[channel_index].sink_stream.qos->pd = new_pres_dly_us;
+		unicast_servers[device_index].cap_sink_stream.bap_stream.qos->pd = new_pres_dly_us;
 	}
 
-	le_audio_event_publish(LE_AUDIO_EVT_CONFIG_RECEIVED, stream->conn, stream->ep->dir);
+	le_audio_event_publish(LE_AUDIO_EVT_CONFIG_RECEIVED, stream->conn, dir);
 
 	/* Make sure both sink and source ep (if both are discovered) are configured before
 	 * QoS
 	 */
-	if ((headsets[channel_index].sink_ep != NULL &&
-	     !le_audio_ep_state_check(headsets[channel_index].sink_stream.ep,
+	if ((unicast_servers[device_index].sink_ep != NULL &&
+	     !le_audio_ep_state_check(unicast_servers[device_index].cap_sink_stream.bap_stream.ep,
 				      BT_BAP_EP_STATE_CODEC_CONFIGURED)) ||
-	    (headsets[channel_index].source_ep != NULL &&
-	     !le_audio_ep_state_check(headsets[channel_index].source_stream.ep,
+	    (unicast_servers[device_index].source_ep != NULL &&
+	     !le_audio_ep_state_check(unicast_servers[device_index].cap_source_stream.bap_stream.ep,
 				      BT_BAP_EP_STATE_CODEC_CONFIGURED))) {
 		return;
-	}
-
-	ret = bt_bap_stream_qos(headsets[channel_index].headset_conn, unicast_group);
-	if (ret) {
-		LOG_ERR("QoS not set for %s headset: %d", headsets[channel_index].ch_name, ret);
 	}
 }
 
 static void stream_qos_set_cb(struct bt_bap_stream *stream)
 {
 	int ret;
-	uint8_t channel_index;
+	uint8_t device_index;
 
-	ret = channel_index_get(stream->conn, &channel_index);
+	LOG_DBG("QoS set cb");
 
-	if (headsets[channel_index].qos_reconfigure) {
-		LOG_DBG("Reconfiguring: %s to PD: %d", headsets[channel_index].ch_name,
-			headsets[channel_index].reconfigure_pd);
+	ret = device_index_get(stream->conn, &device_index);
+	if (ret) {
+		return;
+	}
 
-		headsets[channel_index].qos_reconfigure = false;
-		headsets[channel_index].sink_stream.qos->pd =
-			headsets[channel_index].reconfigure_pd;
+	if (unicast_servers[device_index].qos_reconfigure) {
+		LOG_DBG("Reconfiguring: %s to PD: %d", unicast_servers[device_index].ch_name,
+			unicast_servers[device_index].reconfigure_pd);
 
-		ret = bt_bap_stream_qos(headsets[channel_index].headset_conn, unicast_group);
-		if (ret) {
-			LOG_ERR("Unable to reconfigure %s: %d", headsets[channel_index].ch_name,
-				ret);
-		}
+		unicast_servers[device_index].qos_reconfigure = false;
+		unicast_servers[device_index].cap_sink_stream.bap_stream.qos->pd =
+			unicast_servers[device_index].reconfigure_pd;
 	} else {
-		LOG_DBG("Set %s to PD: %d", headsets[channel_index].ch_name, stream->qos->pd);
-
-		if (playing_state) {
-			ret = bt_bap_stream_enable(stream, lc3_preset_sink.codec_cfg.meta,
-						   lc3_preset_sink.codec_cfg.meta_len);
-			if (ret) {
-				LOG_ERR("Unable to enable stream: %d", ret);
-				return;
-			}
-
-			LOG_INF("Enable stream %p", stream);
-		}
+		LOG_DBG("Set %s to PD: %d", unicast_servers[device_index].ch_name, stream->qos->pd);
 	}
 }
 
 static void stream_enabled_cb(struct bt_bap_stream *stream)
 {
-	int ret;
-	uint8_t channel_index;
-	struct worker_data work_data;
-	enum bt_audio_dir dir;
-
-	dir = le_audio_stream_dir_get(stream);
-	if (dir <= 0) {
-		LOG_ERR("Failed to get dir of stream %p", stream);
-		return;
-	}
-
-	LOG_DBG("Stream enabled: %p", stream);
-
-	ret = channel_index_get(stream->conn, &channel_index);
-	if (ret) {
-		LOG_ERR("Error getting channel index");
-		return;
-	}
-
-	if (dir == BT_AUDIO_DIR_SINK &&
-	    le_audio_ep_state_check(headsets[channel_index].sink_stream.ep,
-				    BT_BAP_EP_STATE_ENABLING)) {
-		if (!k_work_delayable_is_pending(&headsets[channel_index].stream_start_sink_work)) {
-			work_data.channel_index = channel_index;
-			work_data.retries = 0;
-			work_data.dir = BT_AUDIO_DIR_SINK;
-
-			LOG_DBG("k_msg_put: ch: %d, dir: %d, retries %d", work_data.channel_index,
-				work_data.dir, work_data.retries);
-
-			ret = k_msgq_put(&kwork_msgq, &work_data, K_NO_WAIT);
-			if (ret) {
-				LOG_ERR("No space in the queue for work_data");
-				return;
-			}
-
-			k_work_schedule(&headsets[channel_index].stream_start_sink_work, K_NO_WAIT);
-		}
-	}
-
-	if (dir == BT_AUDIO_DIR_SOURCE &&
-	    le_audio_ep_state_check(headsets[channel_index].source_stream.ep,
-				    BT_BAP_EP_STATE_ENABLING)) {
-		if (!k_work_delayable_is_pending(
-			    &headsets[channel_index].stream_start_source_work)) {
-			work_data.channel_index = channel_index;
-			work_data.retries = 0;
-			work_data.dir = BT_AUDIO_DIR_SOURCE;
-
-			LOG_DBG("k_msg_put: ch: %d, dir: %d, retries %d", work_data.channel_index,
-				work_data.dir, work_data.retries);
-
-			ret = k_msgq_put(&kwork_msgq, &work_data, K_NO_WAIT);
-			if (ret) {
-				LOG_ERR("No space in the queue for work_data");
-				return;
-			}
-
-			k_work_schedule(&headsets[channel_index].stream_start_source_work,
-					K_NO_WAIT);
-		}
-	}
+	LOG_WRN("Stream enabled: %p", (void *)stream);
 }
 
 static void stream_started_cb(struct bt_bap_stream *stream)
@@ -1102,18 +1075,18 @@ static void stream_started_cb(struct bt_bap_stream *stream)
 
 	dir = le_audio_stream_dir_get(stream);
 	if (dir <= 0) {
-		LOG_ERR("Failed to get dir of stream %p", stream);
+		LOG_ERR("Failed to get dir of stream %p", (void *)stream);
 		return;
 	}
 
 	if (IS_ENABLED(CONFIG_BT_AUDIO_TX)) {
-		uint8_t channel_index;
+		uint8_t device_index;
 
-		ret = channel_index_get(stream->conn, &channel_index);
+		ret = device_index_get(stream->conn, &device_index);
 		if (ret) {
-			LOG_ERR("Channel index not found");
+			LOG_ERR("Device index not found");
 		} else {
-			ERR_CHK(bt_le_audio_tx_stream_started(channel_index));
+			ERR_CHK(bt_le_audio_tx_stream_started(device_index));
 		}
 	}
 
@@ -1141,22 +1114,22 @@ static void stream_stopped_cb(struct bt_bap_stream *stream, uint8_t reason)
 	LOG_INF("Stream %p stopped. Reason %d", (void *)stream, reason);
 
 	if (IS_ENABLED(CONFIG_BT_AUDIO_TX)) {
-		uint8_t channel_index;
+		uint8_t device_index;
 
-		ret = channel_index_get(stream->conn, &channel_index);
+		ret = device_index_get(stream->conn, &device_index);
 		if (ret) {
-			LOG_ERR("Channel index not found");
+			LOG_ERR("Device index not found");
 		} else {
-			ret = bt_le_audio_tx_stream_stopped(channel_index);
+			ret = bt_le_audio_tx_stream_stopped(device_index);
 			ERR_CHK(ret);
 		}
 	}
 
 	/* Check if the other streams are streaming, send event if not */
-	for (int i = 0; i < ARRAY_SIZE(headsets); i++) {
-		if (le_audio_ep_state_check(headsets[i].sink_stream.ep,
+	for (int i = 0; i < ARRAY_SIZE(unicast_servers); i++) {
+		if (le_audio_ep_state_check(unicast_servers[i].cap_sink_stream.bap_stream.ep,
 					    BT_BAP_EP_STATE_STREAMING) ||
-		    le_audio_ep_state_check(headsets[i].source_stream.ep,
+		    le_audio_ep_state_check(unicast_servers[i].cap_source_stream.bap_stream.ep,
 					    BT_BAP_EP_STATE_STREAMING)) {
 			return;
 		}
@@ -1170,8 +1143,10 @@ static void stream_released_cb(struct bt_bap_stream *stream)
 	LOG_DBG("Audio Stream %p released", (void *)stream);
 
 	/* Check if the other streams are streaming, send event if not */
-	for (int i = 0; i < ARRAY_SIZE(headsets); i++) {
-		if (le_audio_ep_state_check(headsets[i].source_stream.ep,
+	for (int i = 0; i < ARRAY_SIZE(unicast_servers); i++) {
+		if (le_audio_ep_state_check(unicast_servers[i].cap_sink_stream.bap_stream.ep,
+					    BT_BAP_EP_STATE_STREAMING) ||
+		    le_audio_ep_state_check(unicast_servers[i].cap_source_stream.bap_stream.ep,
 					    BT_BAP_EP_STATE_STREAMING)) {
 			return;
 		}
@@ -1186,7 +1161,7 @@ static void stream_recv_cb(struct bt_bap_stream *stream, const struct bt_iso_rec
 {
 	int ret;
 	bool bad_frame = false;
-	uint8_t channel_index;
+	uint8_t device_index;
 
 	if (receive_cb == NULL) {
 		LOG_ERR("The RX callback has not been set");
@@ -1197,13 +1172,13 @@ static void stream_recv_cb(struct bt_bap_stream *stream, const struct bt_iso_rec
 		bad_frame = true;
 	}
 
-	ret = channel_index_get(stream->conn, &channel_index);
+	ret = device_index_get(stream->conn, &device_index);
 	if (ret) {
-		LOG_ERR("Channel index not found");
+		LOG_ERR("Device index not found");
 		return;
 	}
 
-	receive_cb(buf->data, buf->len, bad_frame, info->ts, channel_index,
+	receive_cb(buf->data, buf->len, bad_frame, info->ts, device_index,
 		   bt_audio_codec_cfg_get_octets_per_frame(stream->codec_cfg));
 }
 #endif /* (CONFIG_BT_AUDIO_RX) */
@@ -1225,105 +1200,102 @@ static struct bt_bap_stream_ops stream_ops = {
 #endif /* (CONFIG_BT_AUDIO_TX) */
 };
 
-static void work_stream_start(struct k_work *work)
+static struct bt_bap_unicast_client_cb unicast_client_cbs = {
+	.location = unicast_client_location_cb,
+	.available_contexts = available_contexts_cb,
+	.pac_record = pac_record_cb,
+	.endpoint = endpoint_cb,
+	.discover = discover_cb,
+};
+
+static void disconnected_cleanup(uint8_t chan_idx)
+{
+	unicast_servers[chan_idx].device_conn = NULL;
+	unicast_servers[chan_idx].sink_ep = NULL;
+	memset(unicast_servers[chan_idx].sink_codec_cap, 0,
+	       sizeof(unicast_servers[chan_idx].sink_codec_cap));
+	unicast_servers[chan_idx].source_ep = NULL;
+	memset(unicast_servers[chan_idx].source_codec_cap, 0,
+	       sizeof(unicast_servers[chan_idx].source_codec_cap));
+
+	unicast_servers[chan_idx].num_sink_eps = 0;
+	unicast_servers[chan_idx].num_source_eps = 0;
+}
+
+static void unicast_discovery_complete_cb(struct bt_conn *conn, int err,
+					  const struct bt_csip_set_coordinator_csis_inst *csis_inst)
+{
+	if (err) {
+		LOG_WRN("Got err: %d from conn: %p", err, (void *)conn);
+	}
+
+	LOG_WRN("Unicast discovery complete cb");
+	LOG_WRN("\tErr: %d, set_size: %d, key: %s", err, csis_inst->info.set_size,
+		csis_inst->info.set_sirk);
+}
+
+static void unicast_start_complete_cb(int err, struct bt_conn *conn)
 {
 	int ret;
-	struct worker_data work_data;
+	uint8_t device_index;
 
-	ret = k_msgq_get(&kwork_msgq, &work_data, K_NO_WAIT);
-	if (ret) {
-		LOG_ERR("Cannot get info for start stream");
-		return;
+	if (err) {
+		LOG_WRN("Failed start_complete for conn: %p, err: %d", (void *)conn, err);
 	}
 
-	LOG_DBG("k_msg_get: ch: %d, dir: %d, retries %d", work_data.channel_index, work_data.dir,
-		work_data.retries);
-
-	if (work_data.dir == BT_AUDIO_DIR_SINK) {
-		if (!le_audio_ep_state_check(headsets[work_data.channel_index].sink_stream.ep,
-					     BT_BAP_EP_STATE_STREAMING)) {
-			ret = bt_bap_stream_start(&headsets[work_data.channel_index].sink_stream);
-		}
-	} else if (work_data.dir == BT_AUDIO_DIR_SOURCE) {
-		if (!le_audio_ep_state_check(headsets[work_data.channel_index].source_stream.ep,
-					     BT_BAP_EP_STATE_STREAMING)) {
-			ret = bt_bap_stream_start(&headsets[work_data.channel_index].source_stream);
-		}
+	LOG_DBG("Unicast start complete cb");
+	ret = k_msgq_peek(&cap_start_msgq, &device_index);
+	if (ret == 0) {
+		/* Pending start procedure found, call k_work */
+		k_work_submit(&cap_start_work);
 	} else {
-		LOG_ERR("Trying to use unknown direction: %d", work_data.dir);
-		le_audio_event_publish(LE_AUDIO_EVT_NO_VALID_CFG,
-				       headsets[work_data.channel_index].headset_conn,
-				       work_data.dir);
-
-		return;
-	}
-
-	work_data.retries++;
-
-	if ((ret == -EBUSY) && (work_data.retries < CIS_CONN_RETRY_TIMES)) {
-		LOG_DBG("Got connect error from stream %d Retrying. code: %d count: %d",
-			work_data.channel_index, ret, work_data.retries);
-		LOG_DBG("k_msg_put: ch: %d, dir: %d, retries %d", work_data.channel_index,
-			work_data.dir, work_data.retries);
-		ret = k_msgq_put(&kwork_msgq, &work_data, K_NO_WAIT);
-		if (ret) {
-			LOG_ERR("No space in the queue for work_data");
-			return;
-		}
-		/* Delay added to prevent controller overloading */
-		if (work_data.dir == BT_AUDIO_DIR_SINK) {
-			k_work_reschedule(&headsets[work_data.channel_index].stream_start_sink_work,
-					  K_MSEC(CIS_CONN_RETRY_DELAY_MS));
-		} else if (work_data.dir == BT_AUDIO_DIR_SOURCE) {
-			k_work_reschedule(
-				&headsets[work_data.channel_index].stream_start_source_work,
-				K_MSEC(CIS_CONN_RETRY_DELAY_MS));
-		}
-	} else if (ret != 0) {
-		LOG_WRN("Failed to establish CIS, ret = %d", ret);
-		/** The connection could have invalid configs, or abnormal behavior cause
-		 * the CIS failed to establish. Sending an event for triggering
-		 * disconnection could clean up the abnormal state and restart the
-		 * connection.
-		 */
-		le_audio_event_publish(LE_AUDIO_EVT_NO_VALID_CFG,
-				       headsets[work_data.channel_index].headset_conn,
-				       work_data.dir);
-	} else if (k_msgq_peek(&kwork_msgq, &work_data) != -ENOMSG) {
-		if (work_data.dir == BT_AUDIO_DIR_SINK &&
-		    !k_work_delayable_is_pending(
-			    &headsets[work_data.channel_index].stream_start_sink_work)) {
-			k_work_reschedule(&headsets[work_data.channel_index].stream_start_sink_work,
-					  K_MSEC(CIS_CONN_RETRY_DELAY_MS));
-		} else if (work_data.dir == BT_AUDIO_DIR_SOURCE &&
-			   !k_work_delayable_is_pending(
-				   &headsets[work_data.channel_index].stream_start_source_work)) {
-			k_work_reschedule(
-				&headsets[work_data.channel_index].stream_start_source_work,
-				K_MSEC(CIS_CONN_RETRY_DELAY_MS));
-		}
+		LOG_DBG("No outstanding work");
 	}
 }
 
-static void disconnected_headset_cleanup(uint8_t chan_idx)
+static void unicast_update_complete_cb(int err, struct bt_conn *conn)
 {
-	headsets[chan_idx].headset_conn = NULL;
-	k_work_cancel_delayable(&headsets[chan_idx].stream_start_sink_work);
-	headsets[chan_idx].sink_ep = NULL;
-	memset(headsets[chan_idx].sink_codec_cap, 0, sizeof(headsets[chan_idx].sink_codec_cap));
-	k_work_cancel_delayable(&headsets[chan_idx].stream_start_source_work);
-	headsets[chan_idx].source_ep = NULL;
-	memset(headsets[chan_idx].source_codec_cap, 0, sizeof(headsets[chan_idx].source_codec_cap));
+	if (err) {
+		LOG_WRN("Failed update_complete for conn: %p, err: %d", (void *)conn, err);
+	}
 
-	headsets[chan_idx].num_sink_eps = 0;
-	headsets[chan_idx].num_source_eps = 0;
+	LOG_DBG("Unicast update complete cb");
 }
+
+static void unicast_stop_complete_cb(int err, struct bt_conn *conn)
+{
+	int ret;
+
+	if (err) {
+		LOG_WRN("Failed stop_complete for conn: %p, err: %d", (void *)conn, err);
+	}
+
+	LOG_DBG("Unicast stop complete cb");
+
+	/* Check for reconfigurable sink streams */
+	for (int i = 0; i < ARRAY_SIZE(unicast_servers); i++) {
+		if (unicast_servers[i].qos_reconfigure && playing_state) {
+			ret = k_msgq_put(&cap_start_msgq, &i, K_NO_WAIT);
+			if (ret) {
+				LOG_ERR("Failed to put device_index %d on the queue: %d", i, ret);
+			}
+			k_work_submit(&cap_start_work);
+		}
+	}
+}
+
+static struct bt_cap_initiator_cb cap_cbs = {
+	.unicast_discovery_complete = unicast_discovery_complete_cb,
+	.unicast_start_complete = unicast_start_complete_cb,
+	.unicast_update_complete = unicast_update_complete_cb,
+	.unicast_stop_complete = unicast_stop_complete_cb,
+};
 
 int unicast_client_config_get(struct bt_conn *conn, enum bt_audio_dir dir, uint32_t *bitrate,
 			      uint32_t *sampling_rate_hz)
 {
 	int ret;
-	uint8_t headset_idx;
+	uint8_t device_idx;
 
 	if (conn == NULL) {
 		LOG_ERR("No valid connection pointer received");
@@ -1335,22 +1307,23 @@ int unicast_client_config_get(struct bt_conn *conn, enum bt_audio_dir dir, uint3
 		return -ENXIO;
 	}
 
-	ret = channel_index_get(conn, &headset_idx);
+	ret = device_index_get(conn, &device_idx);
 	if (ret) {
 		LOG_WRN("No configured streams found");
 		return ret;
 	}
 
 	if (dir == BT_AUDIO_DIR_SINK) {
-		if (headsets[headset_idx].sink_stream.codec_cfg == NULL) {
+		if (unicast_servers[device_idx].cap_sink_stream.bap_stream.codec_cfg == NULL) {
 			LOG_ERR("No codec found for the stream");
 
 			return -ENXIO;
 		}
 
 		if (sampling_rate_hz != NULL) {
-			ret = le_audio_freq_hz_get(headsets[headset_idx].sink_stream.codec_cfg,
-						   sampling_rate_hz);
+			ret = le_audio_freq_hz_get(
+				unicast_servers[device_idx].cap_sink_stream.bap_stream.codec_cfg,
+				sampling_rate_hz);
 			if (ret) {
 				LOG_ERR("Invalid sampling frequency: %d", ret);
 				return -ENXIO;
@@ -1358,22 +1331,24 @@ int unicast_client_config_get(struct bt_conn *conn, enum bt_audio_dir dir, uint3
 		}
 
 		if (bitrate != NULL) {
-			ret = le_audio_bitrate_get(headsets[headset_idx].sink_stream.codec_cfg,
-						   bitrate);
+			ret = le_audio_bitrate_get(
+				unicast_servers[device_idx].cap_sink_stream.bap_stream.codec_cfg,
+				bitrate);
 			if (ret) {
 				LOG_ERR("Unable to calculate bitrate: %d", ret);
 				return -ENXIO;
 			}
 		}
 	} else if (dir == BT_AUDIO_DIR_SOURCE) {
-		if (headsets[headset_idx].source_stream.codec_cfg == NULL) {
+		if (unicast_servers[device_idx].cap_source_stream.bap_stream.codec_cfg == NULL) {
 			LOG_ERR("No codec found for the stream");
 			return -ENXIO;
 		}
 
 		if (sampling_rate_hz != NULL) {
-			ret = le_audio_freq_hz_get(headsets[headset_idx].source_stream.codec_cfg,
-						   sampling_rate_hz);
+			ret = le_audio_freq_hz_get(
+				unicast_servers[device_idx].cap_source_stream.bap_stream.codec_cfg,
+				sampling_rate_hz);
 			if (ret) {
 				LOG_ERR("Invalid sampling frequency: %d", ret);
 				return -ENXIO;
@@ -1381,8 +1356,9 @@ int unicast_client_config_get(struct bt_conn *conn, enum bt_audio_dir dir, uint3
 		}
 
 		if (bitrate != NULL) {
-			ret = le_audio_bitrate_get(headsets[headset_idx].source_stream.codec_cfg,
-						   bitrate);
+			ret = le_audio_bitrate_get(
+				unicast_servers[device_idx].cap_source_stream.bap_stream.codec_cfg,
+				bitrate);
 			if (ret) {
 				LOG_ERR("Unable to calculate bitrate: %d", ret);
 				return -ENXIO;
@@ -1396,13 +1372,13 @@ int unicast_client_config_get(struct bt_conn *conn, enum bt_audio_dir dir, uint3
 void unicast_client_conn_disconnected(struct bt_conn *conn)
 {
 	int ret;
-	uint8_t channel_index;
+	uint8_t device_index;
 
-	ret = channel_index_get(conn, &channel_index);
+	ret = device_index_get(conn, &device_index);
 	if (ret) {
 		LOG_WRN("Unknown connection disconnected");
 	} else {
-		disconnected_headset_cleanup(channel_index);
+		disconnected_cleanup(device_index);
 	}
 }
 
@@ -1411,19 +1387,25 @@ int unicast_client_discover(struct bt_conn *conn, enum unicast_discover_dir dir)
 	int ret;
 	uint8_t index;
 
-	ret = channel_index_vacant_get(conn, &index);
+	ret = bt_cap_initiator_unicast_discover(conn);
+	if (ret) {
+		LOG_WRN("Failed to start cap discover: %d", ret);
+		return ret;
+	}
+
+	ret = device_index_vacant_get(conn, &index);
 	if (ret) {
 		return ret;
 	}
 
-	headsets[index].headset_conn = conn;
+	unicast_servers[index].device_conn = conn;
 
 	if (dir & BT_AUDIO_DIR_SOURCE) {
-		headsets[index].waiting_for_source_disc = true;
+		unicast_servers[index].waiting_for_source_disc = true;
 	}
 
 	if (dir & BT_AUDIO_DIR_SINK) {
-		headsets[index].waiting_for_sink_disc = true;
+		unicast_servers[index].waiting_for_sink_disc = true;
 	}
 
 	if (dir == UNICAST_SERVER_BIDIR) {
@@ -1436,86 +1418,132 @@ int unicast_client_discover(struct bt_conn *conn, enum unicast_discover_dir dir)
 	return ret;
 }
 
-int unicast_client_start(enum bt_audio_dir dir)
+int unicast_client_start(void)
 {
 	int ret;
-	bool any_errors = false;
+	struct bt_cap_unicast_audio_start_stream_param
+		cap_stream_params[CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT +
+				  CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT];
+	static struct bt_cap_unicast_audio_start_param param;
 
-	for (int i = 0; i < ARRAY_SIZE(headsets); i++) {
-		if (dir == BT_AUDIO_DIR_SINK &&
-		    le_audio_ep_state_check(headsets[i].sink_stream.ep,
-					    BT_BAP_EP_STATE_QOS_CONFIGURED)) {
+	param.stream_params = cap_stream_params;
+	param.count = 0;
+	param.type = BT_CAP_SET_TYPE_AD_HOC;
+
+	for (int i = 0; i < ARRAY_SIZE(unicast_servers); i++) {
+		uint8_t state;
+
+		ret = le_audio_ep_state_get(unicast_servers[i].sink_ep, &state);
+		if (ret) {
+			continue;
+		}
+
+		if (state == BT_BAP_EP_STATE_IDLE) {
 			/* Start all streams in the configured state */
-			ret = bt_bap_stream_enable(&headsets[i].sink_stream,
-						   lc3_preset_sink.codec_cfg.meta,
-						   lc3_preset_sink.codec_cfg.meta_len);
+			cap_stream_params[param.count].member.member =
+				unicast_servers[i].device_conn;
+			cap_stream_params[param.count].stream = &unicast_servers[i].cap_sink_stream;
+			cap_stream_params[param.count].ep = unicast_servers[i].sink_ep;
+			cap_stream_params[param.count].codec_cfg = &lc3_preset_sink.codec_cfg;
+			param.count++;
+		} else {
+			LOG_WRN("Found unicast_server[%d] with an endpoint not in IDLE state: %d",
+				i, state);
+		}
 
-			if (ret) {
-				LOG_WRN("Failed to enable stream %d: %d", i, ret);
-				any_errors = true;
-			}
+		ret = le_audio_ep_state_get(unicast_servers[i].source_ep, &state);
+		if (ret) {
+			continue;
+		}
 
-		} else if (dir == BT_AUDIO_DIR_SOURCE &&
-			   le_audio_ep_state_check(headsets[i].source_stream.ep,
-						   BT_BAP_EP_STATE_QOS_CONFIGURED)) {
+		if (state == BT_BAP_EP_STATE_IDLE) {
 			/* Start all streams in the configured state */
-			ret = bt_bap_stream_enable(&headsets[i].source_stream,
-						   lc3_preset_source.codec_cfg.meta,
-						   lc3_preset_source.codec_cfg.meta_len);
-
-			if (ret) {
-				LOG_WRN("Failed to enable stream %d: %d", i, ret);
-				any_errors = true;
-			}
+			cap_stream_params[param.count].member.member =
+				unicast_servers[i].device_conn;
+			cap_stream_params[param.count].stream =
+				&unicast_servers[i].cap_source_stream;
+			cap_stream_params[param.count].ep = unicast_servers[i].source_ep;
+			cap_stream_params[param.count].codec_cfg = &lc3_preset_source.codec_cfg;
+			param.count++;
+		} else {
+			LOG_WRN("Found unicast_server[%d] with an endpoint not in IDLE state: %d",
+				i, state);
 		}
 	}
 
-	if (any_errors) {
+	if (param.count > 0) {
+		ret = bt_cap_initiator_unicast_audio_start(&param);
+		if (ret) {
+			LOG_ERR("Failed to start unicast audio: %d", ret);
+			return ret;
+		}
+
+		playing_state = true;
+	} else {
 		return -EIO;
 	}
-
-	playing_state = true;
 
 	return 0;
 }
 
-int unicast_client_stop(enum bt_audio_dir dir)
+int unicast_client_stop(void)
 {
 	int ret;
-	bool any_errors = false;
+	struct bt_cap_stream *streams[CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT +
+				      CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT];
+	static struct bt_cap_unicast_audio_stop_param param;
+
+	param.streams = streams;
+	param.count = 0;
+	param.type = BT_CAP_SET_TYPE_AD_HOC;
 
 	le_audio_event_publish(LE_AUDIO_EVT_NOT_STREAMING, NULL, 0);
 
-	for (int i = 0; i < ARRAY_SIZE(headsets); i++) {
-		if (dir == BT_AUDIO_DIR_SINK &&
-		    le_audio_ep_state_check(headsets[i].sink_stream.ep,
-					    BT_BAP_EP_STATE_STREAMING)) {
-			/* Stop all streams currently in a streaming state */
-			ret = bt_bap_stream_disable(&headsets[i].sink_stream);
+	for (int i = 0; i < ARRAY_SIZE(unicast_servers); i++) {
+		uint8_t state;
 
-			if (ret) {
-				LOG_WRN("Failed to disable stream %d: %d", i, ret);
-				any_errors = true;
-			}
+		ret = le_audio_ep_state_get(unicast_servers[i].sink_ep, &state);
+		if (ret) {
+			continue;
+		}
 
-		} else if (dir == BT_AUDIO_DIR_SOURCE &&
-			   le_audio_ep_state_check(headsets[i].source_stream.ep,
-						   BT_BAP_EP_STATE_STREAMING)) {
-			/* Stop all streams currently in a streaming state */
-			ret = bt_bap_stream_disable(&headsets[i].source_stream);
+		if (state == BT_BAP_EP_STATE_STREAMING) {
+			/* Stop all sink streams currently in a streaming state */
+			streams[param.count] = &unicast_servers[i].cap_sink_stream;
+			param.count++;
+		} else {
+			LOG_WRN("Found unicast_server[%d] with an endpoint not in STREAMING state: "
+				"%d",
+				i, state);
+		}
 
-			if (ret) {
-				LOG_WRN("Failed to disable stream %d: %d", i, ret);
-				any_errors = true;
-			}
+		ret = le_audio_ep_state_get(unicast_servers[i].source_ep, &state);
+		if (ret) {
+			continue;
+		}
+
+		if (state == BT_BAP_EP_STATE_STREAMING) {
+			/* Stop all source streams currently in a streaming state */
+			streams[param.count] = &unicast_servers[i].cap_source_stream;
+			param.count++;
+		} else {
+			LOG_WRN("Found unicast_server[%d] with an endpoint not in STREAMING state: "
+				"%d",
+				i, state);
 		}
 	}
 
-	if (any_errors) {
+	if (param.count > 0) {
+		ret = bt_cap_initiator_unicast_audio_stop(&param);
+		if (ret) {
+			LOG_ERR("Failed to stop unicast audio: %d", ret);
+			return ret;
+		}
+
+		playing_state = false;
+	} else {
 		return -EIO;
 	}
-
-	playing_state = false;
 
 	return 0;
 }
@@ -1528,11 +1556,11 @@ int unicast_client_send(struct le_audio_encoded_audio enc_audio)
 	uint8_t audio_mapping_mask[CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT] = {UINT8_MAX};
 
 	for (int i = 0; i < CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT; i++) {
-		bap_tx_streams[i] = &headsets[i].sink_stream;
-		if (headsets[i].location == BT_AUDIO_LOCATION_FRONT_RIGHT) {
+		bap_tx_streams[i] = &unicast_servers[i].cap_sink_stream.bap_stream;
+		if (unicast_servers[i].location == BT_AUDIO_LOCATION_FRONT_RIGHT) {
 			audio_mapping_mask[i] = AUDIO_CH_R;
 		} else {
-			/* Both mono and left devices will receive left channel */
+			/* Both mono and left unicast_servers will receive left channel */
 			audio_mapping_mask[i] = AUDIO_CH_L;
 		}
 	}
@@ -1556,11 +1584,12 @@ int unicast_client_enable(le_audio_receive_cb recv_cb)
 {
 	int ret;
 	static bool initialized;
-	int headset_iterator = 0;
+	int device_iterator = 0;
 	int stream_iterator = 0;
-	struct bt_bap_unicast_group_stream_pair_param pair_params[ARRAY_SIZE(headsets)];
-	/* 2 streams (one sink and one source stream) for each headset */
-	struct bt_bap_unicast_group_stream_param group_stream_params[(ARRAY_SIZE(headsets) * 2)];
+	struct bt_bap_unicast_group_stream_pair_param pair_params[ARRAY_SIZE(unicast_servers)];
+	/* 2 streams (one sink and one source stream) for each unicast_server */
+	struct bt_bap_unicast_group_stream_param
+		group_stream_params[(ARRAY_SIZE(unicast_servers) * 2)];
 	struct bt_bap_unicast_group_param group_param;
 
 	if (initialized) {
@@ -1575,18 +1604,20 @@ int unicast_client_enable(le_audio_receive_cb recv_cb)
 
 	receive_cb = recv_cb;
 
-	LOG_DBG("Start workers");
-
-	for (int i = 0; i < ARRAY_SIZE(headsets); i++) {
-		headsets[i].source_stream.ops = &stream_ops;
-		headsets[i].sink_stream.ops = &stream_ops;
-		k_work_init_delayable(&headsets[i].stream_start_sink_work, work_stream_start);
-		k_work_init_delayable(&headsets[i].stream_start_source_work, work_stream_start);
+	for (int i = 0; i < ARRAY_SIZE(unicast_servers); i++) {
+		bt_cap_stream_ops_register(&unicast_servers[i].cap_sink_stream, &stream_ops);
+		bt_cap_stream_ops_register(&unicast_servers[i].cap_source_stream, &stream_ops);
 	}
 
 	ret = bt_bap_unicast_client_register_cb(&unicast_client_cbs);
-	if (ret != 0) {
+	if (ret) {
 		LOG_ERR("Failed to register client callbacks: %d", ret);
+		return ret;
+	}
+
+	ret = bt_cap_initiator_register_cb(&cap_cbs);
+	if (ret) {
+		LOG_ERR("Failed to register cap callbacks: %d", ret);
 		return ret;
 	}
 
@@ -1601,11 +1632,13 @@ int unicast_client_enable(le_audio_receive_cb recv_cb)
 		/* Every other stream should be sink or source */
 		if ((i % 2) == 0) {
 			group_stream_params[i].qos = &lc3_preset_max.qos;
-			group_stream_params[i].stream = &headsets[headset_iterator].sink_stream;
+			group_stream_params[i].stream =
+				&unicast_servers[device_iterator].cap_sink_stream.bap_stream;
 		} else {
 			group_stream_params[i].qos = &lc3_preset_max.qos;
-			group_stream_params[i].stream = &headsets[headset_iterator].source_stream;
-			headset_iterator++;
+			group_stream_params[i].stream =
+				&unicast_servers[device_iterator].cap_source_stream.bap_stream;
+			device_iterator++;
 		}
 	}
 

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_client.h
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_client.h
@@ -85,20 +85,20 @@ void unicast_client_conn_disconnected(struct bt_conn *conn);
 /**
  * @brief	Start the Bluetooth LE Audio unicast (CIS) client.
  *
- * @param[in]	dir	Direction of the stream to start.
+ * @note	Will start both sink and source if present.
  *
  * @return	0 for success, error otherwise.
  */
-int unicast_client_start(enum bt_audio_dir dir);
+int unicast_client_start(void);
 
 /**
  * @brief	Stop the Bluetooth LE Audio unicast (CIS) client.
  *
- * @param[in]	dir	Direction of the stream to stop.
+ * @note	Will stop both sink and source if present.
  *
  * @return	0 for success, error otherwise.
  */
-int unicast_client_stop(enum bt_audio_dir dir);
+int unicast_client_stop(void);
 
 /**
  * @brief	Send encoded audio using the Bluetooth LE Audio unicast.

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_server.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_server.c
@@ -669,18 +669,6 @@ int unicast_server_enable(le_audio_receive_cb recv_cb, enum bt_audio_location lo
 	}
 
 	if (IS_ENABLED(CONFIG_BT_AUDIO_RX)) {
-		ret = bt_pacs_set_supported_contexts(BT_AUDIO_DIR_SINK, AVAILABLE_SINK_CONTEXT);
-
-		if (ret) {
-			LOG_ERR("Supported context set failed. Err: %d", ret);
-			return ret;
-		}
-
-		ret = bt_pacs_set_available_contexts(BT_AUDIO_DIR_SINK, AVAILABLE_SINK_CONTEXT);
-		if (ret) {
-			LOG_ERR("Available context set failed. Err: %d", ret);
-			return ret;
-		}
 		if (location == BT_AUDIO_LOCATION_FRONT_LEFT) {
 			csip_param.rank = CSIP_HL_RANK;
 		} else if (location == BT_AUDIO_LOCATION_FRONT_RIGHT) {
@@ -703,24 +691,37 @@ int unicast_server_enable(le_audio_receive_cb recv_cb, enum bt_audio_location lo
 			return ret;
 		}
 
-		ret = bt_pacs_set_supported_contexts(BT_AUDIO_DIR_SOURCE, AVAILABLE_SOURCE_CONTEXT);
-
-		if (ret) {
-			LOG_ERR("Supported context set failed. Err: %d", ret);
-			return ret;
-		}
-
-		ret = bt_pacs_set_available_contexts(BT_AUDIO_DIR_SOURCE, AVAILABLE_SOURCE_CONTEXT);
-		if (ret) {
-			LOG_ERR("Available context set failed. Err: %d", ret);
-			return ret;
-		}
-
 		ret = bt_pacs_set_location(BT_AUDIO_DIR_SOURCE, location);
 		if (ret) {
 			LOG_ERR("Location set failed. Err: %d", ret);
 			return ret;
 		}
+	}
+
+	ret = bt_pacs_set_supported_contexts(BT_AUDIO_DIR_SINK, AVAILABLE_SINK_CONTEXT);
+
+	if (ret) {
+		LOG_ERR("Supported context set failed. Err: %d", ret);
+		return ret;
+	}
+
+	ret = bt_pacs_set_available_contexts(BT_AUDIO_DIR_SINK, AVAILABLE_SINK_CONTEXT);
+	if (ret) {
+		LOG_ERR("Available context set failed. Err: %d", ret);
+		return ret;
+	}
+
+	ret = bt_pacs_set_supported_contexts(BT_AUDIO_DIR_SOURCE, AVAILABLE_SOURCE_CONTEXT);
+
+	if (ret) {
+		LOG_ERR("Supported context set failed. Err: %d", ret);
+		return ret;
+	}
+
+	ret = bt_pacs_set_available_contexts(BT_AUDIO_DIR_SOURCE, AVAILABLE_SOURCE_CONTEXT);
+	if (ret) {
+		LOG_ERR("Available context set failed. Err: %d", ret);
+		return ret;
 	}
 
 	for (int i = 0; i < ARRAY_SIZE(audio_streams); i++) {

--- a/applications/nrf5340_audio/unicast_client/Kconfig.defaults
+++ b/applications/nrf5340_audio/unicast_client/Kconfig.defaults
@@ -29,6 +29,12 @@ config BT_ISO_MAX_CHAN
 config BT_BAP_UNICAST_CLIENT
 	default y
 
+config BT_CAP_INITIATOR
+	default y
+
+config BT_CSIP_SET_COORDINATOR
+	default y
+
 config BT_ISO_TX_BUF_COUNT
 	default 2
 

--- a/applications/nrf5340_audio/unicast_client/main.c
+++ b/applications/nrf5340_audio/unicast_client/main.c
@@ -75,11 +75,11 @@ static void content_control_msg_sub_thread(void)
 
 		switch (msg.event) {
 		case MEDIA_START:
-			unicast_client_start(BT_AUDIO_DIR_SINK);
+			unicast_client_start();
 			break;
 
 		case MEDIA_STOP:
-			unicast_client_stop(BT_AUDIO_DIR_SINK);
+			unicast_client_stop();
 			break;
 
 		default:

--- a/applications/nrf5340_audio/unicast_server/Kconfig.defaults
+++ b/applications/nrf5340_audio/unicast_server/Kconfig.defaults
@@ -58,6 +58,12 @@ config BT_MCC_SET_MEDIA_CONTROL_POINT
 config BT_PAC_SNK_NOTIFIABLE
 	default y
 
+config BT_PAC_SRC
+	default y
+
+config BT_PAC_SNK
+	default y
+
 config BT_CSIP_SET_MEMBER
 	default y
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -216,6 +216,8 @@ Serial LTE modem
 nRF5340 Audio
 -------------
 
+* Added CAP initiator for the Bluetooth LE Audio unicast (CIS) client.
+
 * Removed:
 
   * The LE Audio controller for nRF5340 library.


### PR DESCRIPTION
- Use CAP procedure for starting and stopping streams
- Play/pause enabled for both sink and source in bidirectional mode
- OCT-2542