### PR TITLE
samples: Bluetooth: Mesh: Fix documentation for Light Dimmer sample

### DIFF
--- a/samples/bluetooth/mesh/light_dimmer/README.rst
+++ b/samples/bluetooth/mesh/light_dimmer/README.rst
@@ -54,8 +54,8 @@ This mobile application is also used to configure key bindings, and publication 
 After provisioning and configuring the mesh models supported by the sample in the `nRF Mesh mobile app`_, **Button 1** on the Mesh Light Dimmer device can be used to control the configured network nodes' LEDs, while **Button 2** can be used to store and restore scenes on the network nodes.
 
 .. note::
-  When running this sample on Thingy:53 or the :ref:`zephyr:nrf52840dongle_nrf52840`, the scene selection functionality will not be available as the device only has one button.
-  The single button of Thingy:53 and the dongle will be used for dimming and the on/off functionality as described for **Button 1** in this documentation.
+  When running this sample on the :ref:`zephyr:nrf52840dongle_nrf52840`, the scene selection functionality will not be available as the device only has one button.
+  The single button of the dongle will be used for dimming and the on/off functionality as described for **Button 1** in this documentation.
 
 Provisioning
 ============
@@ -116,15 +116,18 @@ Button 2:
 
    On long press and release, **Button 2** will publish a Scene Store message using the configured publication parameters of its model instance, and store the current LED state of all the targets under the scene with the most recently recalled scene number.
 
-.. note::
-   :ref:`zephyr:thingy53_nrf5340` and the :ref:`zephyr:nrf52840dongle_nrf52840` only support dimming and the on/off functionality, not the scene selection functionality.
+  .. note::
+    On the :ref:`zephyr:nrf52840dongle_nrf52840`, the scene selection functionality will not be available as the device only has one button.
+
+  .. tip::
+    On Thingy:53, **Button 2** can be accessed by removing the top part of the casing.
 
 LEDs:
    Show the OOB authentication value during provisioning if the "Push button" OOB method is used.
 
-.. note::
-   :ref:`zephyr:thingy53_nrf5340` supports only one RGB LED.
-   Each RGB LED channel is used as separate LED.
+  .. note::
+    :ref:`zephyr:thingy53_nrf5340` supports only one RGB LED.
+    Each RGB LED channel is used as separate LED.
 
 Configuration
 *************


### PR DESCRIPTION
The Light Dimmer sample documentation falsely stated that Thingy:53 only has one button and that therefore some functionality would not work on Thingy:53