### PR TITLE
manifest: Update sdk-zephyr witm PWM support in samples for nRF54

### DIFF
--- a/applications/nrf_desktop/configuration/nrf54l15pdk_nrf54l15_cpuapp/boards/nrf54l15pdk_nrf54l15_cpuapp_0_2_0.overlay
+++ b/applications/nrf_desktop/configuration/nrf54l15pdk_nrf54l15_cpuapp/boards/nrf54l15pdk_nrf54l15_cpuapp_0_2_0.overlay
@@ -10,6 +10,11 @@
 };
 
 / {
+	/* Disable pwmleds and redefine them to align configuration with CAF LEDs requirements.
+	 * The configuration needs to match the used board revision (v0.2.0).
+	 */
+	/delete-node/ pwmleds;
+
 	pwmleds0 {
 		compatible = "pwm-leds";
 		status = "okay";

--- a/applications/nrf_desktop/configuration/nrf54l15pdk_nrf54l15_cpuapp/boards/nrf54l15pdk_nrf54l15_cpuapp_0_3_0.overlay
+++ b/applications/nrf_desktop/configuration/nrf54l15pdk_nrf54l15_cpuapp/boards/nrf54l15pdk_nrf54l15_cpuapp_0_3_0.overlay
@@ -12,6 +12,11 @@
 };
 
 / {
+	/* Disable pwmleds and redefine them to align configuration with CAF LEDs requirements.
+	 * The configuration needs to match the used board revision (v0.3.0).
+	 */
+	/delete-node/ pwmleds;
+
 	pwmleds0 {
 		compatible = "pwm-leds";
 		status = "okay";

--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 634bfae60938f9b005f6a14aa15e88798458fbd3
+      revision: bdda11bdb687157e55b44e3053bb0966ecf75d4f
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Add support for PWM LEDs configuratoin to run PWM samples on nRF54 DKs.