### PR TITLE
samples: Bluetooth: Mesh: add nrf54l support for Target sample

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -411,6 +411,7 @@ Bluetooth Mesh samples
 
     * A note on how to compile the sample with new Composition Data.
     * Point-to-point DFU support with overlay file :file:`overlay-ptp_dfu.conf`.
+    * Support for the :ref:`nRF54L15 PDK <ug_nrf54l15_gs>` board.
 
 * :ref:`bluetooth_mesh_light_lc` sample:
 

--- a/samples/bluetooth/mesh/dfu/target/README.rst
+++ b/samples/bluetooth/mesh/dfu/target/README.rst
@@ -10,8 +10,6 @@ Bluetooth Mesh: Device Firmware Update (DFU) target
 The Bluetooth® Mesh DFU target sample demonstrates how to update device firmware over Bluetooth Mesh network.
 The sample implements the Target role of the :ref:`Bluetooth Mesh DFU subsystem <zephyr:bluetooth_mesh_dfu>`.
 
-The specification that the Bluetooth Mesh DFU subsystem is based on is not adopted yet, and therefore this feature should be used for experimental purposes only.
-
 Requirements
 ************
 

--- a/samples/bluetooth/mesh/dfu/target/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/bluetooth/mesh/dfu/target/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+################################################################################
+# Application overlay - nrf54l15
+
+CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE=n

--- a/samples/bluetooth/mesh/dfu/target/sample.yaml
+++ b/samples/bluetooth/mesh/dfu/target/sample.yaml
@@ -6,5 +6,6 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf52840dongle/nrf52840
-    platform_allow: nrf52840dk/nrf52840 nrf52840dongle/nrf52840
+      - nrf54l15pdk/nrf54l15/cpuapp
+    platform_allow: nrf52840dk/nrf52840 nrf52840dongle/nrf52840 nrf54l15pdk/nrf54l15/cpuapp
     tags: bluetooth ci_build


### PR DESCRIPTION
Add support for nrf54l15pdk_nrf54l15_cpuapp in Mesh DFU Target sample.

Removes statement from Target sample README which says that the DFU spec is not yet adopted.