### PR TITLE
codeowners: add CIA team to Thingy91 boards

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -40,6 +40,7 @@
 /applications/zigbee_weather_station/     @milewr
 # Boards
 /boards/                                  @anangl
+/boards/arm/thingy91*                     @anangl @nrfconnect/ncs-cia
 # All cmake related files
 /cmake/                                   @tejlmand
 /CMakeLists.txt                           @tejlmand


### PR DESCRIPTION
Both of the Thingy:91 boards are the responsibility of the CIA team.