### PR TITLE
Bluetooth: Mesh: p2p DFU for all Light sample boards

### DIFF
--- a/samples/bluetooth/mesh/light/CMakeLists.txt
+++ b/samples/bluetooth/mesh/light/CMakeLists.txt
@@ -21,10 +21,8 @@ target_include_directories(app PRIVATE
 	${ZEPHYR_NRF_MODULE_DIR}/samples/bluetooth/mesh/common
 )
 
-# Preinitialization related to DFU over SMP for nRF52 series
-if(CONFIG_SOC_SERIES_NRF52X)
-  target_sources_ifdef(CONFIG_MCUMGR_TRANSPORT_BT app PRIVATE
+# Preinitialization related to DFU over SMP
+target_sources_ifdef(CONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU app PRIVATE
     ${ZEPHYR_NRF_MODULE_DIR}/samples/bluetooth/mesh/common/smp_bt.c)
-endif()
 
 # NORDIC SDK APP END

--- a/samples/bluetooth/mesh/light/Kconfig
+++ b/samples/bluetooth/mesh/light/Kconfig
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Set lower default sizes for TF-M partition when using the TF-M Profile Small.
+# This is done using defaults instead of in a conf file in order to set the
+# correctly aligned size depending on the presence of the bootloader or not.
+
+# Declared before sourcing "Kconfig.zephyr" in order to give precedence
+# to these application-specific defaults instead of the unconditional default
+# in the Zephyr Kconfig tree.
+configdefault PM_PARTITION_SIZE_TFM
+	default 0x17e00 if TFM_PROFILE_TYPE_SMALL && BOOTLOADER_MCUBOOT
+	default 0x18000 if TFM_PROFILE_TYPE_SMALL
+
+source "Kconfig.zephyr"

--- a/samples/bluetooth/mesh/light/README.rst
+++ b/samples/bluetooth/mesh/light/README.rst
@@ -47,8 +47,9 @@ Take the flash size into consideration when using DFU over Bluetooth LE on other
 For example, both nRF52832 and nRF52833 have limited flash size.
 
 .. note::
-   Point-to-point DFU over Bluetooth Low Energy for :ref:`zephyr:thingy53_nrf5340` is supported by default.
+   Point-to-point DFU over Bluetooth Low Energy for :ref:`zephyr:thingy53_nrf5340` and :ref:`zephyr:nrf5340dk_nrf5340` is supported by default.
    See :ref:`thingy53_app_update` for more information about updating firmware image on :ref:`zephyr:thingy53_nrf5340`.
+   Updating firmware image on :ref:`zephyr:nrf5340dk_nrf5340` works similarly to :ref:`zephyr:thingy53_nrf5340`.
 
 The DFU feature also requires a smartphone with Nordic Semiconductor's nRF Device Manager mobile app installed in one of the following versions:
 

--- a/samples/bluetooth/mesh/light/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/samples/bluetooth/mesh/light/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -1,23 +1,22 @@
 #
-# Copyright (c) 2021 Nordic Semiconductor ASA
+# Copyright (c) 2024 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 ################################################################################
-# Application overlay - Thingy:53 DFU
+# Application overlay - nrf5340dk secure image
 
+CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE=n
+
+# Enable point to point DFU over SMP
+CONFIG_BOOTLOADER_MCUBOOT=y
 CONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU=y
 CONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU_SPEEDUP=y
 
-CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
-
-# Use deferred logging
-CONFIG_NCS_SAMPLES_DEFAULTS=n
-CONFIG_LOG=y
-CONFIG_ASSERT=y
-CONFIG_ASSERT_NO_COND_INFO=y
-CONFIG_ASSERT_NO_MSG_INFO=y
-CONFIG_HW_STACK_PROTECTION=y
+# Enable updates for the network core
+CONFIG_NRF53_UPGRADE_NETWORK_CORE=y
+CONFIG_UPDATEABLE_IMAGE_NUMBER=2
+CONFIG_MCUBOOT_USE_ALL_AVAILABLE_RAM=y
 
 # Enable Extended Advertiser to advertise BT SMP service
 CONFIG_BT_EXT_ADV=y

--- a/samples/bluetooth/mesh/light/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/bluetooth/mesh/light/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Enable external flash */
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/bluetooth/mesh/light/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
+++ b/samples/bluetooth/mesh/light/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
@@ -12,3 +12,26 @@ CONFIG_BT_HOST_CRYPTO=n
 CONFIG_BT_GATT_CACHING=n
 
 CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE=n
+
+# Enable point to point DFU over SMP
+CONFIG_BOOTLOADER_MCUBOOT=y
+CONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU=y
+CONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU_SPEEDUP=y
+
+# Enable updates for the network core
+CONFIG_NRF53_UPGRADE_NETWORK_CORE=y
+CONFIG_UPDATEABLE_IMAGE_NUMBER=2
+CONFIG_MCUBOOT_USE_ALL_AVAILABLE_RAM=y
+
+# Enable Extended Advertiser to advertise BT SMP service
+CONFIG_BT_EXT_ADV=y
+CONFIG_BT_EXT_ADV_MAX_ADV_SET=6
+
+# One extra connection for mesh GATT/proxy and one for SMP BT.
+CONFIG_BT_MAX_CONN=3
+
+# One extra identity for SMP service
+CONFIG_BT_ID_MAX=2
+
+# Use the TF-M Profile Small to save ROM and be able to fit when using bootloader
+CONFIG_TFM_PROFILE_TYPE_SMALL=y

--- a/samples/bluetooth/mesh/light/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/mesh/light/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Enable external flash */
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/bluetooth/mesh/light/child_image/hci_ipc.conf
+++ b/samples/bluetooth/mesh/light/child_image/hci_ipc.conf
@@ -1,6 +1,26 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
 # Copy controller configuration from prj.conf
 CONFIG_BT_CTLR_DUP_FILTER_LEN=0
 CONFIG_BT_CTLR_LE_ENC=n
 CONFIG_BT_CTLR_CHAN_SEL_2=n
 CONFIG_BT_CTLR_MIN_USED_CHAN=n
 CONFIG_BT_CTLR_PRIVACY=n
+
+# One extra connection for mesh GATT/proxy and one for SMP BT.
+CONFIG_BT_MAX_CONN=3
+CONFIG_BT_CTLR_SDC_PERIPHERAL_COUNT=3
+
+# Enable extended advertising
+CONFIG_BT_EXT_ADV=y
+CONFIG_BT_EXT_ADV_MAX_ADV_SET=6
+CONFIG_BT_CTLR_ADV_EXT=y
+CONFIG_BT_CTLR_ADV_SET=6
+
+# Ensure that BT_CENTRAL role is disabled, while still keeping the BT_OBSERVER role
+CONFIG_BT_CENTRAL=n
+CONFIG_BT_OBSERVER=y

--- a/samples/bluetooth/mesh/light/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/samples/bluetooth/mesh/light/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -1,0 +1,47 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# MCUboot config to enable multi core update with secondary slot in external flash
+CONFIG_PM=n
+
+CONFIG_MAIN_STACK_SIZE=10240
+CONFIG_MBEDTLS_CFG_FILE="mcuboot-mbedtls-cfg.h"
+
+CONFIG_BOOT_SWAP_SAVE_ENCTLV=n
+CONFIG_BOOT_ENCRYPT_IMAGE=n
+
+CONFIG_BOOT_UPGRADE_ONLY=n
+CONFIG_BOOT_BOOTSTRAP=n
+
+# Enable QSPI drivers for external flash
+CONFIG_NORDIC_QSPI_NOR=y
+CONFIG_BOOT_MAX_IMG_SECTORS=256
+
+# Logging
+CONFIG_LOG=y
+CONFIG_MCUBOOT_LOG_LEVEL_INF=y
+CONFIG_LOG_MODE_MINIMAL=y
+
+# Enable simultaenous multi-core updates
+CONFIG_NRF53_MULTI_IMAGE_UPDATE=y
+CONFIG_UPDATEABLE_IMAGE_NUMBER=2
+CONFIG_BOOT_UPGRADE_ONLY=y
+CONFIG_PCD_APP=y
+
+# Dependencies for CONFIG_NRF53_MULTI_IMAGE_UPDATE
+CONFIG_FLASH=y
+CONFIG_FPROTECT=y
+CONFIG_FLASH_SIMULATOR=y
+CONFIG_FLASH_SIMULATOR_DOUBLE_WRITES=y
+CONFIG_FLASH_SIMULATOR_STATS=n
+
+# Ensure Zephyr logging changes don't use more resources
+CONFIG_LOG_DEFAULT_LEVEL=0
+# Decrease footprint by ~4 KB in comparison to CBPRINTF_COMPLETE=y
+CONFIG_CBPRINTF_NANO=y
+# Use the minimal C library to reduce flash usage
+CONFIG_MINIMAL_LIBC=y
+CONFIG_NRF_RTC_TIMER_USER_CHAN_COUNT=0

--- a/samples/bluetooth/mesh/light/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/bluetooth/mesh/light/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Enable external flash for MCUBOOT*/
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+		zephyr,code-partition = &boot_partition;
+	};
+};

--- a/samples/bluetooth/mesh/light/src/main.c
+++ b/samples/bluetooth/mesh/light/src/main.c
@@ -50,7 +50,7 @@ static void bt_ready(int err)
 
 	printk("Mesh initialized\n");
 
-	if (IS_ENABLED(CONFIG_SOC_SERIES_NRF52X) && IS_ENABLED(CONFIG_MCUMGR_TRANSPORT_BT)) {
+	if (IS_ENABLED(CONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU)) {
 		err = smp_dfu_init();
 		if (err) {
 			printk("Unable to initialize DFU (err %d)\n", err);


### PR DESCRIPTION
This commit adds the following to the Mesh Light sample:

- Multi image p2p DFU support for nrf5340DK secure platform.
- Multi image p2p DFU support for nrf5340DK non-secure platform.
- Fixes/adds separate SMP adv for all supported nRF5340 platforms.
- Enables use of external flash for all supported nRF5340 platforms.
- Updates network core cfg for all supported nRF5340 platforms to fully support p2p DFU.
- Updates sample documentation.