### PR TITLE
manifest: update zephyr to pull in ipc workaround

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 4e6070dbdc332a17ae439649e5e6af01a6365290
+      revision: 5c19b37dd82cb25c02da195af2666e75369b7fad
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Updated the Zephyr revision to pull in a workaround for the IPC service module.