### PR TITLE
scripts: tools-versions-*.yml: update zephyr-sdk==0.16.8

### DIFF
--- a/scripts/tools-versions-darwin.yml
+++ b/scripts/tools-versions-darwin.yml
@@ -16,8 +16,8 @@ west:
 nanopb:
   version: 0.4.6
 zephyr-sdk:
-  version: 0.16.5-1
-  architectures: # https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.16.5-1
+  version: 0.16.8
+  architectures: # https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.16.8
     - aarch64-zephyr-elf
     - x86_64-zephyr-elf
     - arm-zephyr-eabi

--- a/scripts/tools-versions-linux.yml
+++ b/scripts/tools-versions-linux.yml
@@ -17,8 +17,8 @@ gn:
 nanopb:
   version: 0.4.6
 zephyr-sdk:
-  version: 0.16.5-1
-  architectures: # https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.16.5-1
+  version: 0.16.8
+  architectures: # https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.16.8
     - aarch64-zephyr-elf
     - x86_64-zephyr-elf
     - arm-zephyr-eabi

--- a/scripts/tools-versions-win10.yml
+++ b/scripts/tools-versions-win10.yml
@@ -15,8 +15,8 @@ west:
 nanopb:
   version: 0.4.6
 zephyr-sdk:
-  version: 0.16.5-1
-  architectures: # https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.16.5-1
+  version: 0.16.8
+  architectures: # https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.16.8
     - aarch64-zephyr-elf
     - x86_64-zephyr-elf
     - arm-zephyr-eabi


### PR DESCRIPTION
scripts: tools-versions-*.yml: update zephyr-sdk==0.16.8
Release Notes:
      Removed experimental ISO C11 <threads.h>-based gthread implementation
