### PR TITLE
samples: cellular: nrf_cloud_multi_service: add cfg handling

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -432,7 +432,13 @@ Cellular samples
 
 * :ref:`nrf_cloud_multi_service` sample:
 
-  * Fixed issue that prevented network connectivity when using Wi-Fi scanning with the nRF91xx.
+  * Fixed:
+
+    * An issue that prevented network connectivity when using Wi-Fi scanning with the nRF91xx.
+
+  * Added:
+
+    * The ability to control the state of the test counter using the config section in the device shadow.
 
 Cryptography samples
 --------------------

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -711,6 +711,7 @@ Libraries for networking
     * The :kconfig:option:`CONFIG_NRF_CLOUD_LOCATION_ANCHOR_LIST` Kconfig option to enable including Wi-Fi anchor names in the location callback.
     * The :kconfig:option:`CONFIG_NRF_CLOUD_LOCATION_ANCHOR_LIST_BUFFER_SIZE` Kconfig option to control the buffer size used for the anchor names.
     * The :kconfig:option:`CONFIG_NRF_CLOUD_LOCATION_PARSE_ANCHORS` Kconfig option to control if anchor names are parsed.
+    * The :c:func:`nrf_cloud_obj_bool_get` function to get a boolean value from an object.
 
   * Updated:
 

--- a/include/net/nrf_cloud_codec.h
+++ b/include/net/nrf_cloud_codec.h
@@ -261,6 +261,23 @@ int nrf_cloud_obj_str_get(const struct nrf_cloud_obj *const obj, const char *con
 			  char **str);
 
 /**
+ * @brief Get the boolean value associated with the provided key.
+ *
+ * @param[in] obj Object containing the key and value.
+ * @param[in] key Key.
+ * @param[out] val Boolean value associated with the provided key.
+ *
+ * @retval -EINVAL Invalid parameter.
+ * @retval -ENODEV Object does not contain the provided key.
+ * @retval -ENOENT Object is not initialized.
+ * @retval -ENOTSUP Action not supported for the object's type.
+ * @retval -ENOMSG Value associated with the key is not a boolean.
+ * @retval 0 Success; boolean found.
+ */
+int nrf_cloud_obj_bool_get(const struct nrf_cloud_obj *const obj, const char *const key,
+			   bool *val);
+
+/**
  * @brief Get and detach the object associated with the provided key.
  *
  * @details If successful, the object data specified by the given key is removed from obj

--- a/samples/cellular/nrf_cloud_multi_service/CMakeLists.txt
+++ b/samples/cellular/nrf_cloud_multi_service/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(app PRIVATE src/temperature.c)
 target_sources(app PRIVATE src/fota_support.c)
 target_sources(app PRIVATE src/led_control.c)
 target_sources(app PRIVATE src/sample_reboot.c)
+target_sources(app PRIVATE src/shadow_config.c)
 
 if(CONFIG_LOCATION_TRACKING)
 target_sources(app PRIVATE src/location_tracking.c)

--- a/samples/cellular/nrf_cloud_multi_service/Kconfig
+++ b/samples/cellular/nrf_cloud_multi_service/Kconfig
@@ -215,6 +215,8 @@ config GNSS_FIX_TIMEOUT_SECONDS
 
 config TEST_COUNTER
 	bool "Sets whether the test counter is enabled"
+	help
+	  When enabled, the test counter configuration setting in the shadow is ignored.
 
 config AT_CMD_REQUESTS
 	depends on !NRF_CLOUD_COAP

--- a/samples/cellular/nrf_cloud_multi_service/README.rst
+++ b/samples/cellular/nrf_cloud_multi_service/README.rst
@@ -318,11 +318,23 @@ See :ref:`nrf_cloud_multi_service_led_third_party` for details on configuring LE
 Test counter
 ============
 
-You can enable a test counter by enabling the :ref:`CONFIG_TEST_COUNTER <CONFIG_TEST_COUNTER>` option.
 Every time a sensor sample is sent, this counter is incremented by one, and its current value is sent to `nRF Cloud`_.
 A plot of the value of the counter over time is automatically shown in the nRF Cloud portal.
 This plot is useful for tracking, visualizing, and debugging connection loss, resets, and re-establishment behavior.
 
+You can enable or disable the test counter using the device shadow.
+In the desired config section, set ``"counterEnable"`` to ``true`` to enable or ``false`` to disable the test counter.
+
+.. code-block:: json
+
+   "desired": {
+      "config": {
+         "counterEnable": true
+      }
+   }
+
+You can perform the shadow update by clicking the :guilabel:`View Config` button on the **Device** page in the nRF Cloud portal or through the ``UpdateDeviceState`` endpoint in the `nRF Cloud Rest API`_.
+To ignore the shadow setting so that the test counter is always active, enable the :ref:`CONFIG_TEST_COUNTER <CONFIG_TEST_COUNTER>` Kconfig option.
 
 .. _nrf_cloud_multi_service_device_message_formatting:
 
@@ -619,7 +631,8 @@ CONFIG_LED_CONTINUOUS_INDICATION - Continuous LED status indication
 .. _CONFIG_TEST_COUNTER:
 
 CONFIG_TEST_COUNTER - Enable test counter
-   Enables the test counter.
+   Enable the test counter.
+   When enabled, the test counter configuration setting in the shadow is ignored.
 
 .. _CONFIG_AT_CMD_REQUESTS:
 

--- a/samples/cellular/nrf_cloud_multi_service/src/application.h
+++ b/samples/cellular/nrf_cloud_multi_service/src/application.h
@@ -20,4 +20,7 @@
  */
 void main_application_thread_fn(void);
 
+void test_counter_enable_set(const bool enable);
+bool test_counter_enable_get(void);
+
 #endif /* _APPLICATION_H_ */

--- a/samples/cellular/nrf_cloud_multi_service/src/shadow_config.c
+++ b/samples/cellular/nrf_cloud_multi_service/src/shadow_config.c
@@ -1,0 +1,201 @@
+/* Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/logging/log_ctrl.h>
+#include <net/nrf_cloud_defs.h>
+
+#include "shadow_config.h"
+#if defined(CONFIG_NRF_CLOUD_COAP)
+#include "shadow_support_coap.h"
+#endif
+#include "application.h"
+
+LOG_MODULE_REGISTER(shadow_config, CONFIG_MULTI_SERVICE_LOG_LEVEL);
+
+#define TEST_COUNTER_EN	"counterEnable"
+
+/* Flag to indicate that the accepted shadow data has been received (MQTT only) */
+static bool accepted_rcvd;
+
+static int add_cfg_data(struct nrf_cloud_obj *const cfg_obj)
+{
+	/* Add the test counter state */
+	return nrf_cloud_obj_bool_add(cfg_obj, TEST_COUNTER_EN, test_counter_enable_get(), false);
+}
+
+static int process_cfg(struct nrf_cloud_obj *const cfg_obj)
+{
+	bool val;
+	int err = nrf_cloud_obj_bool_get(cfg_obj, TEST_COUNTER_EN, &val);
+
+	if (err == 0) {
+		/* The expected key/value was found, set the test counter enable state */
+		test_counter_enable_set(val);
+	} else if (err == -ENOMSG) {
+		/* The key was found, but the value was not a boolean */
+		LOG_WRN("Invalid configuration value");
+		/* Reject the config */
+		err = -EBADF;
+	} else {
+		LOG_DBG("Expected data not found in config object");
+		err = -ENOMSG;
+	}
+
+	return err;
+}
+
+static int send_config(void)
+{
+	int err;
+
+	NRF_CLOUD_OBJ_JSON_DEFINE(root_obj);
+	NRF_CLOUD_OBJ_JSON_DEFINE(state_obj);
+	NRF_CLOUD_OBJ_JSON_DEFINE(reported_obj);
+	NRF_CLOUD_OBJ_JSON_DEFINE(cfg_obj);
+
+	if (nrf_cloud_obj_init(&cfg_obj) || nrf_cloud_obj_init(&reported_obj) ||
+	    nrf_cloud_obj_init(&state_obj) || nrf_cloud_obj_init(&root_obj)) {
+		err = -ENOMEM;
+		goto cleanup;
+	}
+
+	/* Add the supported configuration data */
+	err = add_cfg_data(&cfg_obj);
+	if (err) {
+		goto cleanup;
+	}
+
+#if defined(CONFIG_NRF_CLOUD_MQTT)
+
+	/* Add config to reported */
+	err = nrf_cloud_obj_object_add(&reported_obj, NRF_CLOUD_JSON_KEY_CFG, &cfg_obj, false);
+	if (err) {
+		goto cleanup;
+	}
+
+	/* Add reported to state */
+	err = nrf_cloud_obj_object_add(&state_obj, NRF_CLOUD_JSON_KEY_REP, &reported_obj, false);
+	if (err) {
+		goto cleanup;
+	}
+
+	/* Add state to the root object */
+	err = nrf_cloud_obj_object_add(&root_obj, NRF_CLOUD_JSON_KEY_STATE, &state_obj, false);
+	if (err) {
+		goto cleanup;
+	}
+
+	/* Send to the cloud */
+	err = nrf_cloud_obj_shadow_update(&root_obj);
+#else  /* CONFIG_NRF_CLOUD_COAP */
+
+	/* Add config to root */
+	err = nrf_cloud_obj_object_add(&root_obj, NRF_CLOUD_JSON_KEY_CFG, &cfg_obj, false);
+	if (err) {
+		goto cleanup;
+	}
+
+	err = shadow_support_coap_obj_send(&root_obj, false);
+#endif
+
+cleanup:
+	nrf_cloud_obj_free(&root_obj);
+	nrf_cloud_obj_free(&state_obj);
+	nrf_cloud_obj_free(&reported_obj);
+	nrf_cloud_obj_free(&cfg_obj);
+	return err;
+}
+
+void shadow_config_cloud_connected(void)
+{
+	accepted_rcvd = false;
+}
+
+int shadow_config_reported_send(void)
+{
+	LOG_INF("Sending reported configuration");
+
+	int err = send_config();
+
+	if (err) {
+		LOG_ERR("Failed to send configuration, error: %d", err);
+	}
+
+	return err;
+}
+
+int shadow_config_delta_process(struct nrf_cloud_obj *const delta_obj)
+{
+	if (!delta_obj) {
+		return -EINVAL;
+	}
+
+	if ((delta_obj->type != NRF_CLOUD_OBJ_TYPE_JSON) || !delta_obj->json) {
+		/* No state JSON */
+		return -ENOMSG;
+	}
+
+	/* If there is a pending delta event when the device establishes a cloud connection
+	 * it is possible that it will be received before the accepted shadow data.
+	 * Do not process a delta event until the accepted shadow data has been received.
+	 * This is only a concern for MQTT.
+	 */
+	if (!accepted_rcvd && IS_ENABLED(CONFIG_NRF_CLOUD_MQTT)) {
+		return -EAGAIN;
+	}
+
+	int err;
+
+	NRF_CLOUD_OBJ_JSON_DEFINE(cfg_obj);
+
+	/* Get the config object */
+	err = nrf_cloud_obj_object_detach(delta_obj, NRF_CLOUD_JSON_KEY_CFG, &cfg_obj);
+	if (err == -ENODEV) {
+		/* No config in the delta */
+		return -ENOMSG;
+	}
+
+	/* Process the configuration */
+	err = process_cfg(&cfg_obj);
+
+	if (err == -EBADF) {
+		/* Clear incoming config and replace it with a good one */
+		nrf_cloud_obj_free(&cfg_obj);
+		nrf_cloud_obj_init(&cfg_obj);
+		if (add_cfg_data(&cfg_obj)) {
+			LOG_ERR("Failed to create delta response");
+		}
+	}
+
+	/* Add the config object back into the state so the response can be sent */
+	if (nrf_cloud_obj_object_add(delta_obj, NRF_CLOUD_JSON_KEY_CFG, &cfg_obj, false)) {
+		nrf_cloud_obj_free(&cfg_obj);
+		return -ENOMEM;
+	}
+
+	return err;
+}
+
+int shadow_config_accepted_process(struct nrf_cloud_obj *const accepted_obj)
+{
+	if (!accepted_obj) {
+		return -EINVAL;
+	}
+
+	if ((accepted_obj->type != NRF_CLOUD_OBJ_TYPE_JSON) || !accepted_obj->json) {
+		/* No config JSON */
+		return -ENOMSG;
+	}
+
+	int err = process_cfg(accepted_obj);
+
+	if (err == 0) {
+		accepted_rcvd = true;
+	}
+
+	return err;
+}

--- a/samples/cellular/nrf_cloud_multi_service/src/shadow_config.h
+++ b/samples/cellular/nrf_cloud_multi_service/src/shadow_config.h
@@ -1,0 +1,50 @@
+/* Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef _SHADOW_CONFIG_H_
+#define _SHADOW_CONFIG_H_
+
+#include <zephyr/kernel.h>
+#include <net/nrf_cloud_codec.h>
+
+
+/**
+ * @brief For MQTT, this function should be called when the NRF_CLOUD_EVT_TRANSPORT_CONNECTED
+ *        event is received.
+ */
+void shadow_config_cloud_connected(void);
+
+/**
+ * @brief Send the reported device configuration.
+ *
+ * @return 0 on success, otherwise negative on error.
+ */
+int shadow_config_reported_send(void);
+
+/**
+ * @brief Process an incoming delta event.
+ *
+ * @retval 0	   Success, accept the delta.
+ * @retval -EBADF  Invalid config data, reject the delta.
+ * @retval -ENOMSG The provided data did not contain JSON or a config section.
+ * @retval -EAGAIN Ignore delta event until the accepted shadow is received. MQTT only.
+ * @retval -EINVAL Error; Invalid parameter.
+ * @retval -ENOMEM Error; out of memory.
+ */
+int shadow_config_delta_process(struct nrf_cloud_obj *const delta_obj);
+
+/**
+ * @brief Process an incoming accepted shadow event.
+ *
+ * @retval 0	   Success.
+ * @retval -EBADF  Invalid config data.
+ * @retval -ENOMSG The provided data did not contain JSON or the expected config data.
+ * @retval -EINVAL Error; Invalid parameter.
+ * @return A negative value indicates an error, the device should send its current config to
+ *         the reported section of the shadow.
+ */
+int shadow_config_accepted_process(struct nrf_cloud_obj *const accepted_obj);
+
+#endif /* _SHADOW_CONFIG_H_ */

--- a/samples/cellular/nrf_cloud_multi_service/src/shadow_support_coap.c
+++ b/samples/cellular/nrf_cloud_multi_service/src/shadow_support_coap.c
@@ -15,26 +15,67 @@
 
 #include "cloud_connection.h"
 #include "shadow_support_coap.h"
+#include "shadow_config.h"
 
 LOG_MODULE_REGISTER(shadow_support_coap, CONFIG_MULTI_SERVICE_LOG_LEVEL);
 
 #define COAP_SHADOW_MAX_SIZE 512
 
-static int check_shadow(void)
+static int process_delta(struct nrf_cloud_data *const delta)
 {
 	int err;
-	char buf[COAP_SHADOW_MAX_SIZE];
+	bool update_desired = false;
+	struct nrf_cloud_obj delta_obj = {0};
+
+	LOG_DBG("Shadow delta: len:%zd, %s", delta->len, (const char *)delta->ptr);
+
+	err = nrf_cloud_coap_shadow_delta_process(delta, &delta_obj);
+	if (err < 0) {
+		LOG_ERR("Failed to process shadow delta, err: %d", err);
+		return -EIO;
+	} else if (err == 0) {
+		/* No application specific delta data */
+		return -ENODATA;
+	}
+
+	/* There is an application specific shadow delta to process.
+	 * This application only needs to deal with the configuration section.
+	 */
+	err = shadow_config_delta_process(&delta_obj);
+	if (err == -EBADF) {
+		LOG_INF("Rejecting shadow delta");
+		update_desired = true;
+	} else if (err == -ENOMEM) {
+		LOG_ERR("Error handling shadow delta");
+		return err;
+	}
+
+	/* Reject the delta by updating desired.
+	 * Accept the delta by updating reported.
+	 */
+	err = shadow_support_coap_obj_send(&delta_obj, update_desired);
+
+	if (err) {
+		LOG_ERR("Failed to send shadow delta update, err: %d", err);
+		err = -EFAULT;
+	}
+
+	return err;
+}
+
+static int check_shadow(void)
+{
+	/* Ensure the config is sent once */
+	static bool config_sent;
+
+	int err;
+	char buf[COAP_SHADOW_MAX_SIZE] = {0};
 	struct nrf_cloud_data in_data = {
 		.ptr = buf
 	};
-	struct nrf_cloud_obj delta_obj = {0};
 
-	/* Wait until we are able to communicate. */
-	LOG_DBG("Waiting for valid connection before checking shadow");
-	(void)await_cloud_ready(K_FOREVER);
-
-	buf[0] = '\0';
 	LOG_INF("Checking for shadow delta...");
+
 	err = nrf_cloud_coap_shadow_get(buf, sizeof(buf), true);
 	if (err == -EACCES) {
 		LOG_DBG("Not connected yet.");
@@ -45,48 +86,53 @@ static int check_shadow(void)
 	}
 
 	in_data.len = strlen(buf);
-	if (!in_data.len) {
-		LOG_INF("Checking again in %d seconds",
-			CONFIG_COAP_SHADOW_CHECK_RATE_SECONDS);
-		return -EAGAIN;
+	if (in_data.len) {
+		err = process_delta(&in_data);
+		if (err == -ENODATA) {
+			/* There was no application specific delta data to process.
+			 * Return -EAGAIN so the thread sleeps for a longer duration.
+			 */
+			err = -EAGAIN;
+		}
 	}
 
-	LOG_DBG("Shadow delta: len:%zd, %s", in_data.len, buf);
-
-	err = nrf_cloud_coap_shadow_delta_process(&in_data, &delta_obj);
-	if (err == 1) {
-		/* There is an application specific shadow delta to process */
-
-		/* --- Process application's delta data here --- */
-
-		/* To clear the delta, we will just accept the delta by
-		 * updating the shadow state with the received data.
-		 *
-		 * Encode the delta to send to the cloud
+	if (!config_sent) {
+		/* If the config needs to be sent, return so that the thread sleeps
+		 * for a shorter duration.
 		 */
-		err = nrf_cloud_obj_cloud_encode(&delta_obj);
-
-		/* Free the object */
-		(void)nrf_cloud_obj_free(&delta_obj);
-
-		if (!err) {
-			/* Send the encoded data */
-			err = nrf_cloud_coap_shadow_state_update(delta_obj.encoded_data.ptr);
+		if (shadow_config_reported_send() == 0) {
+			config_sent = true;
+			return 0;
 		} else {
-			LOG_ERR("Failed to encode cloud data, err: %d", err);
-			return err;
+			return -EIO;
 		}
-
-		if (err) {
-			LOG_ERR("Failed to send shadow delta update, err: %d", err);
-		}
-
-		/* Free the encoded data */
-		(void)nrf_cloud_obj_cloud_encoded_free(&delta_obj);
-
-	} else if (err < 0) {
-		LOG_ERR("Failed to process shadow delta, err: %d", err);
 	}
+
+	return err;
+}
+
+int shadow_support_coap_obj_send(struct nrf_cloud_obj *const shadow_obj, const bool desired)
+{
+	/* Encode the data for the cloud */
+	int err = nrf_cloud_obj_cloud_encode(shadow_obj);
+
+	/* Free the object */
+	(void)nrf_cloud_obj_free(shadow_obj);
+
+	if (!err) {
+		/* Send the encoded data */
+		if (desired) {
+			err = nrf_cloud_coap_shadow_desired_update(shadow_obj->encoded_data.ptr);
+		} else {
+			err = nrf_cloud_coap_shadow_state_update(shadow_obj->encoded_data.ptr);
+		}
+	} else {
+		LOG_ERR("Failed to encode cloud data, err: %d", err);
+		return err;
+	}
+
+	/* Free the encoded data */
+	(void)nrf_cloud_obj_cloud_encoded_free(shadow_obj);
 
 	return err;
 }
@@ -98,8 +144,16 @@ int coap_shadow_thread_fn(void)
 	int err;
 
 	while (1) {
+		/* Wait until we are able to communicate. */
+		if (!await_cloud_ready(K_NO_WAIT)) {
+			LOG_DBG("Waiting for valid connection before checking shadow");
+			(void)await_cloud_ready(K_FOREVER);
+		}
+
 		err = check_shadow();
 		if (err == -EAGAIN) {
+			LOG_INF("Checking shadow again in %d seconds",
+				CONFIG_COAP_SHADOW_CHECK_RATE_SECONDS);
 			k_sleep(K_SECONDS(CONFIG_COAP_SHADOW_CHECK_RATE_SECONDS));
 		} else {
 			k_sleep(K_SECONDS(SHADOW_THREAD_DELAY_S));

--- a/samples/cellular/nrf_cloud_multi_service/src/shadow_support_coap.h
+++ b/samples/cellular/nrf_cloud_multi_service/src/shadow_support_coap.h
@@ -7,6 +7,8 @@
 #ifndef SHADOW_SUPPORT_COAP_H
 #define SHADOW_SUPPORT_COAP_H
 
+int shadow_support_coap_obj_send(struct nrf_cloud_obj *const shadow_obj, const bool desired);
+
 int coap_shadow_thread_fn(void);
 
 #endif /* SHADOW_SUPPORT_COAP_H */

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec_internal.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec_internal.h
@@ -324,6 +324,10 @@ int get_string_from_obj(const cJSON * const obj, const char * const key,
 int get_num_from_obj(const cJSON *const obj, const char *const key,
 		     double *num_out);
 
+/** @brief Get the boolean value of the specified key in the cJSON object. */
+int get_bool_from_obj(const cJSON * const obj, const char * const key,
+		     bool *bool_out);
+
 /** @brief Send the cJSON object to nRF Cloud on the d2c topic */
 int json_send_to_cloud(cJSON * const request);
 

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec.c
@@ -133,6 +133,25 @@ int nrf_cloud_obj_str_get(const struct nrf_cloud_obj *const obj, const char *con
 	return -ENOTSUP;
 }
 
+int nrf_cloud_obj_bool_get(const struct nrf_cloud_obj *const obj, const char *const key,
+	bool *val)
+{
+	if (!obj || !key || !val) {
+		return -EINVAL;
+	}
+
+	switch (obj->type) {
+	case NRF_CLOUD_OBJ_TYPE_JSON:
+	{
+		return get_bool_from_obj(obj->json, key, val);
+	}
+	default:
+		break;
+	}
+
+	return -ENOTSUP;
+}
+
 int nrf_cloud_obj_object_detach(struct nrf_cloud_obj *const obj, const char *const key,
 			     struct nrf_cloud_obj *const obj_out)
 {

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec_internal.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec_internal.c
@@ -2357,6 +2357,26 @@ int get_num_from_obj(const cJSON *const obj, const char *const key,
 	return 0;
 }
 
+int get_bool_from_obj(const cJSON * const obj, const char * const key,
+		     bool *bool_out)
+{
+	__ASSERT_NO_MSG(bool_out != NULL);
+
+	if (!obj) {
+		return -ENOENT;
+	}
+
+	cJSON * item = cJSON_GetObjectItem(obj, key);
+
+	if (!cJSON_IsBool(item)) {
+		return item ? -ENOMSG : -ENODEV;
+	}
+
+	*bool_out = (bool)cJSON_IsTrue(item);
+
+	return 0;
+}
+
 static int add_ncells(cJSON * const lte_obj, const uint8_t ncells_count,
 	const struct lte_lc_ncell *const neighbor_cells)
 {


### PR DESCRIPTION
Add configuration handling.
The test counter can now be enabled/disabled by using
the device shadow.

IRIS-7709