### PR TITLE
manifest: nrfxlib update to nrf_oberon 3.0.15

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -148,7 +148,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 1e3850de8b28809feb730b805f3033d3c0bcd164
+      revision: 7bf4f9b7fab245d2e430de9a005ed5af615056dc
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Updates to the new nrf_oberon library.

Ref: NCSDK-26596