### PR TITLE
tfm: Change the default TF-M profile type to be NOT_SET for 54L

### DIFF
--- a/modules/trusted-firmware-m/Kconfig.tfm.defconfig
+++ b/modules/trusted-firmware-m/Kconfig.tfm.defconfig
@@ -38,8 +38,8 @@ config TFM_LOG_LEVEL_SILENCE
 		   $(dt_nodelabel_has_prop,uart1,pinctrl-names) || \
 		   SOC_SERIES_NRF54LX # TODO: NCSDK-25009: Use pin-ctrl-names for 54L
 
-
 choice TFM_PROFILE_TYPE
+	default TFM_PROFILE_TYPE_NOT_SET if SOC_SERIES_NRF54LX
 	default TFM_PROFILE_TYPE_MINIMAL
 endchoice
 


### PR DESCRIPTION
The minimal profile type actually means consuming 32kB of FLASH, and for 53/91 this is the minimal that TF-M can consume. But for 54L, with a trustzone granularity of 4kB instead of 32kB, this is no longer the minimal size that TF-M can consume.

Change the default TF-M profile type to be NOT_SET for 54L.