### PR TITLE
modules: memfault: Avoid resetting connectivity stats when sampling

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -806,7 +806,11 @@ Bootloader libraries
 Debug libraries
 ---------------
 
-|no_changes_yet_note|
+* :ref:`mod_memfault` library:
+
+  * Fixed an issue where the library resets the LTE connectivity statistics after each read.
+    This could lead to an accumulated error over time because of the byte counter resolution.
+    The connectivity statistics are now only reset when the library is initialized and will be cumulative after that.
 
 DFU libraries
 -------------

--- a/modules/memfault-firmware-sdk/memfault_lte_metrics.c
+++ b/modules/memfault-firmware-sdk/memfault_lte_metrics.c
@@ -233,11 +233,5 @@ void memfault_lte_metrics_update(void)
 			LOG_ERR("Failed to set ncs_lte_operator");
 		}
 	}
-
-	/* Reset stats */
-	err = modem_info_connectivity_stats_init();
-	if (err) {
-		LOG_ERR("Failed to reset connectivity stats, err: %d", err);
-	}
 #endif
 }


### PR DESCRIPTION
The connectivity stats should not be reset when samplet, as that may result in an accumulated rounding error over time due to the kilobyte resolution of the counters.