### PR TITLE
manifest: sdk-zephyr: Pull fix for IPv6 MLD

### DIFF
--- a/scripts/quarantine_integration.yaml
+++ b/scripts/quarantine_integration.yaml
@@ -1189,3 +1189,9 @@
     - nrf5340dk/nrf5340/cpuapp
     - nrf9160dk/nrf9160
   comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - applications.matter_bridge.smp_dfu.br_ble
+  platforms:
+    - nrf7002dk/nrf5340/cpuapp
+  comment: "Flash overflow, disable till a proper solution is available"

--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 987b5d17c3db527e91eb7d7677b021b47fda6980
+      revision: 26f4b1bee18ab7851676fd836a4e7348ed0470ca
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This was found during Matter CI failures in upmerge PR.