### PR TITLE
applications: nrf5340_audio: Using low latency setting as default

### DIFF
--- a/applications/nrf5340_audio/src/audio/Kconfig
+++ b/applications/nrf5340_audio/src/audio/Kconfig
@@ -32,7 +32,7 @@ config AUDIO_FRAME_DURATION_US
 
 config AUDIO_MIN_PRES_DLY_US
 	int "The minimum presentation delay"
-	default 4000
+	default 3000
 	help
 	  The minimum presentation delay in micro seconds determined by
 	  the audio system processing and the minimum buffering.

--- a/applications/nrf5340_audio/src/bluetooth/Kconfig
+++ b/applications/nrf5340_audio/src/bluetooth/Kconfig
@@ -70,7 +70,7 @@ menu "QoS"
 config BT_AUDIO_PRESENTATION_DELAY_US
 	int "Presentation delay"
 	range AUDIO_MIN_PRES_DLY_US AUDIO_MAX_PRES_DLY_US
-	default 10000
+	default 3000
 	help
 	  The audio source/client defined presentation delay if within
 	  AUDIO_MIN_PRES_DLY_US and AUDIO_MAX_PRES_DLY_US range. This will
@@ -82,7 +82,7 @@ config BT_AUDIO_PRESENTATION_DELAY_US
 config BT_AUDIO_MAX_TRANSPORT_LATENCY_MS
 	int "Max transport latency"
 	range 5 4000
-	default 20
+	default 10
 	help
 	  Max transport latency for the ISO link.
 

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/Kconfig
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/Kconfig
@@ -97,7 +97,7 @@ config CODEC_CAP_COUNT_MAX
 config BT_AUDIO_PREFERRED_MIN_PRES_DLY_US
 	int "The preferred minimum presentation delay"
 	range AUDIO_MIN_PRES_DLY_US AUDIO_MAX_PRES_DLY_US
-	default 10000
+	default 3000
 	help
 	  The preferred minimum presentation delay in microseconds. This can not
 	  be less than the absolute minimum presentation delay.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -192,11 +192,15 @@ Serial LTE modem
 nRF5340 Audio
 -------------
 
-* Updated:
+* Removed:
 
-  * Removed the LE Audio controller for nRF5340 library.
+  * The LE Audio controller for nRF5340 library.
     The only supported controller for LE Audio is :ref:`ug_ble_controller_softdevice`.
     This enables use of standard tools for building, configuring, and DFU.
+
+* Updated:
+
+  * Low latency configuration to be used as default setting for the nRF5340 Audio application.
 
 nRF Machine Learning (Edge Impulse)
 -----------------------------------


### PR DESCRIPTION
Using low latency configuration as default.
* Set transport latency to 5ms
* Set minimal presentation delay to 3ms
* Set prefer minimal presentation delay to 3ms 
OCT-2995
Signed-off-by: Jui-Chou Chung <jui-chou.chung@nordicsemi.no>