### PR TITLE
doc: improve FEM user guide

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-2.6.0.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-2.6.0.rst
@@ -221,7 +221,7 @@ Working with nRF53 Series
 Working with RF front-end modules
 =================================
 
-* Added a clarification that the Simple GPIO implementation is intended for multiple front-end modules (not just one specific device) in the :ref:`ug_radio_fem_sw_support_mpsl` section of the :ref:`ug_radio_fem` guide.
+* Added a clarification that the Simple GPIO implementation is intended for multiple front-end modules (not just one specific device) in the :ref:`ug_radio_fem_sw_support` section of the :ref:`ug_radio_fem` guide.
 
 Protocols
 =========

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -945,6 +945,7 @@ Documentation
   * The trusted storage support table in the :ref:`trusted_storage_in_ncs` section by adding nRF52833 and replacing nRF9160 with nRF91 Series.
 
   * Reworked the :ref:`ble_rpc` page to be more informative and aligned with the library template.
+  * Improved the :ref:`ug_radio_fem` user guide to be up-to-date and more informative.
 
 * Fixed:
 


### PR DESCRIPTION
The Front-end module user guide contains misleading information and has several incomplete sections. This commit fixes that by restructuring, clarifying and completing the documentation.