### PR TITLE
codeowners: Fix board location for thingy91* boards

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -40,7 +40,7 @@
 /applications/zigbee_weather_station/     @milewr
 # Boards
 /boards/                                  @anangl
-/boards/arm/thingy91*                     @anangl @nrfconnect/ncs-cia
+/boards/nordic/thingy91*                  @anangl @nrfconnect/ncs-cia
 # All cmake related files
 /cmake/                                   @tejlmand
 /CMakeLists.txt                           @tejlmand


### PR DESCRIPTION
The codeowners entry was added in parallel to HWMv2 transition, the CI was not rerun after the upmerge so this was missed and CODEOWNERS check is now failing.