### PR TITLE
bluetooth: samples: add iso_rx disconnect cb.

### DIFF
--- a/samples/bluetooth/iso_time_sync/include/iso_time_sync.h
+++ b/samples/bluetooth/iso_time_sync/include/iso_time_sync.h
@@ -59,8 +59,10 @@ void iso_tx_init(uint8_t retransmission_number, void (*iso_connected_cb)(void));
 /** Initialize RX path channel.
  *
  * @param retransmission_number Requested retransmission number (if central).
+ * @param Callback that is triggered when an ISO RX channel disconnects.
+ *                 This can be set to NULL.
  */
-void iso_rx_init(uint8_t retransmission_number);
+void iso_rx_init(uint8_t retransmission_number, void (*iso_disconnected_cb)(void));
 
 /** Obtain pointer to TX channels.
  *

--- a/samples/bluetooth/iso_time_sync/src/bis_receiver.c
+++ b/samples/bluetooth/iso_time_sync/src/bis_receiver.c
@@ -118,7 +118,7 @@ void bis_receiver_start(uint8_t bis_index_to_sync_to)
 
 	uint8_t unused_rtn = 0;
 
-	iso_rx_init(unused_rtn);
+	iso_rx_init(unused_rtn, NULL);
 
 	bt_le_scan_cb_register(&scan_callbacks);
 	bt_le_per_adv_sync_cb_register(&sync_callbacks);

--- a/samples/bluetooth/iso_time_sync/src/cis_peripheral.c
+++ b/samples/bluetooth/iso_time_sync/src/cis_peripheral.c
@@ -82,7 +82,7 @@ void cis_peripheral_start(bool do_tx)
 	if (do_tx) {
 		iso_tx_init(unused_rtn, NULL);
 	} else {
-		iso_rx_init(unused_rtn);
+		iso_rx_init(unused_rtn, NULL);
 	}
 
 	bt_conn_cb_register(&conn_callbacks);

--- a/samples/bluetooth/iso_time_sync/src/iso_rx.c
+++ b/samples/bluetooth/iso_time_sync/src/iso_rx.c
@@ -24,6 +24,8 @@ static void iso_recv(struct bt_iso_chan *chan, const struct bt_iso_recv_info *in
 static void iso_connected(struct bt_iso_chan *chan);
 static void iso_disconnected(struct bt_iso_chan *chan, uint8_t reason);
 
+static void (*iso_chan_disconnected_cb)(void);
+
 static struct gpio_dt_spec led_sdu_received = GPIO_DT_SPEC_GET_OR(DT_ALIAS(led1), gpios, {0});
 
 static struct bt_iso_chan_ops iso_ops = {
@@ -114,11 +116,17 @@ static void iso_connected(struct bt_iso_chan *chan)
 static void iso_disconnected(struct bt_iso_chan *chan, uint8_t reason)
 {
 	printk("ISO Channel disconnected with reason 0x%02x\n", reason);
+
+	if (iso_chan_disconnected_cb) {
+		iso_chan_disconnected_cb();
+	}
 }
 
-void iso_rx_init(uint8_t retransmission_number)
+void iso_rx_init(uint8_t retransmission_number, void (*iso_disconnected_cb)(void))
 {
 	int err;
+
+	iso_chan_disconnected_cb = iso_disconnected_cb;
 
 	iso_rx_qos.rtn = retransmission_number;
 


### PR DESCRIPTION
Add callback that is triggered when an RX ISO channel disconnects. The usecase is to start scanning for a new connection. Scanning for a new connection is also done in the ACL disconnection callback in this sample, but the ISO channel might disconnect after the ACL, which will prevent the central from starting to scan for a new ISO connection.