### PR TITLE
applications: nrf5340_audio: Optionally include nRF5340 ADK features

### DIFF
--- a/applications/nrf5340_audio/Kconfig.defaults
+++ b/applications/nrf5340_audio/Kconfig.defaults
@@ -30,9 +30,6 @@ config RESET_ON_FATAL_ERROR
 	default n
 
 # Default Config for Debug and Release build
-config HW_CODEC_CIRRUS_LOGIC
-	default y
-
 config BT
 	default y
 

--- a/applications/nrf5340_audio/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
+++ b/applications/nrf5340_audio/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_NRF5340_AUDIO_CS47L63_DRIVER=y
+CONFIG_NRF5340_AUDIO_POWER_MEASUREMENT=y
+CONFIG_NRF5340_AUDIO_SD_CARD_MODULE=y

--- a/applications/nrf5340_audio/boards/nrf5340_audio_dk_nrf5340_cpuapp_release.conf
+++ b/applications/nrf5340_audio/boards/nrf5340_audio_dk_nrf5340_cpuapp_release.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_NRF5340_AUDIO_CS47L63_DRIVER=y
+CONFIG_NRF5340_AUDIO_SD_CARD_MODULE=y

--- a/applications/nrf5340_audio/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/applications/nrf5340_audio/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&usbd {
+	hs_0: hs_0 {
+		compatible = "usb-audio-hs";
+		mic-feature-mute;
+		mic-channel-l;
+		mic-channel-r;
+
+		hp-feature-mute;
+		hp-channel-l;
+		hp-channel-r;
+	};
+};

--- a/applications/nrf5340_audio/src/drivers/CMakeLists.txt
+++ b/applications/nrf5340_audio/src/drivers/CMakeLists.txt
@@ -4,6 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-target_sources(app PRIVATE
-	       ${CMAKE_CURRENT_SOURCE_DIR}/cs47l63_comm.c
+target_sources_ifdef(CONFIG_NRF5340_AUDIO_CS47L63_DRIVER
+		     app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/cs47l63_comm.c
 )

--- a/applications/nrf5340_audio/src/drivers/Kconfig
+++ b/applications/nrf5340_audio/src/drivers/Kconfig
@@ -6,8 +6,13 @@
 
 menu "Drivers"
 
-#----------------------------------------------------------------------------#
-menu "Thread priorities"
+menuconfig NRF5340_AUDIO_CS47L63_DRIVER
+	bool "CS47L63 HW codec driver"
+	select HW_CODEC_CIRRUS_LOGIC
+	help
+	  Include the driver for the Cirrus Logic CS47L63 hardware codec chip
+
+if NRF5340_AUDIO_CS47L63_DRIVER
 
 config CS47L63_THREAD_PRIO
 	int "Priority for CS47L63 thread"
@@ -15,23 +20,13 @@ config CS47L63_THREAD_PRIO
 	help
 	  This is a preemptible thread
 
-endmenu # Thread priorities
-
-#----------------------------------------------------------------------------#
-menu "Stack sizes"
-
 config CS47L63_STACK_SIZE
 	int "Stack size for CS47L63"
 	default 700
-
-endmenu # Stack sizes
-
-#----------------------------------------------------------------------------#
-menu "Log levels"
 
 module = CS47L63
 module-str = cs47l63
 source "subsys/logging/Kconfig.template.log_config"
 
-endmenu # Log levels
+endif # NRF5340_AUDIO_CS47L63_DRIVER
 endmenu # Drivers

--- a/applications/nrf5340_audio/src/modules/CMakeLists.txt
+++ b/applications/nrf5340_audio/src/modules/CMakeLists.txt
@@ -4,20 +4,17 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-set(SRCS
-  ${CMAKE_CURRENT_SOURCE_DIR}/audio_i2s.c
-  ${CMAKE_CURRENT_SOURCE_DIR}/audio_usb.c
-  ${CMAKE_CURRENT_SOURCE_DIR}/button_handler.c
-  ${CMAKE_CURRENT_SOURCE_DIR}/hw_codec.c
-  ${CMAKE_CURRENT_SOURCE_DIR}/led.c
-  ${CMAKE_CURRENT_SOURCE_DIR}/power_meas.c
-  ${CMAKE_CURRENT_SOURCE_DIR}/sd_card.c
-)
+target_sources(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/audio_i2s.c)
+target_sources(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/audio_usb.c)
+target_sources(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/button_handler.c)
+target_sources(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/led.c)
+target_sources(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/audio_sync_timer_rtc.c)
 
-list(APPEND SRCS ${CMAKE_CURRENT_SOURCE_DIR}/audio_sync_timer_rtc.c)
-
-if (CONFIG_SD_CARD_PLAYBACK)
-  list(APPEND SRCS ${CMAKE_CURRENT_SOURCE_DIR}/sd_card_playback.c)
-endif()
-
-target_sources(app PRIVATE ${SRCS})
+target_sources_ifdef(CONFIG_NRF5340_AUDIO_CS47L63_DRIVER app PRIVATE
+                     ${CMAKE_CURRENT_SOURCE_DIR}/hw_codec.c)
+target_sources_ifdef(CONFIG_NRF5340_AUDIO_POWER_MEASUREMENT app PRIVATE
+                     ${CMAKE_CURRENT_SOURCE_DIR}/power_meas.c)
+target_sources_ifdef(CONFIG_NRF5340_AUDIO_SD_CARD_MODULE app PRIVATE
+                     ${CMAKE_CURRENT_SOURCE_DIR}/sd_card.c)
+target_sources_ifdef(CONFIG_SD_CARD_PLAYBACK app PRIVATE
+                     ${CMAKE_CURRENT_SOURCE_DIR}/sd_card_playback.c)

--- a/applications/nrf5340_audio/src/modules/Kconfig
+++ b/applications/nrf5340_audio/src/modules/Kconfig
@@ -18,7 +18,12 @@ config AUDIO_SYNC_TIMER_USES_RTC
 	select NRFX_RTC0
 
 #----------------------------------------------------------------------------#
-menu "Power measurement"
+menuconfig NRF5340_AUDIO_POWER_MEASUREMENT
+	bool "Power measurement"
+	help
+	  Include the power measurement driver for the nRF5340 Audio DK
+
+if NRF5340_AUDIO_POWER_MEASUREMENT
 
 config POWER_MEAS_INTERVAL_MS
 	int "Power measurement interval in milliseconds"
@@ -36,7 +41,7 @@ config POWER_MEAS_START_ON_BOOT
 	  the voltage, current consumption, and power usage for the
 	  following rails: VBAT, VDD1_CODEC, VDD2_CODEC, and VDD2_NRF
 
-endmenu # Power measurement
+endif # NRF5340_AUDIO_POWER_MEASUREMENT
 
 #----------------------------------------------------------------------------#
 menu "I2S"
@@ -147,8 +152,14 @@ config VOLUME_MSG_SUB_QUEUE_SIZE
 endmenu # Zbus
 
 #----------------------------------------------------------------------------#
+config NRF5340_AUDIO_SD_CARD_MODULE
+	bool "Audio SD Card Module"
+	help
+	  Include the audio SD card module to support streaming audio files from an SD card.
+
 menuconfig SD_CARD_PLAYBACK
 	bool "Enable playback from SD card"
+	depends on NRF5340_AUDIO_SD_CARD_MODULE
 	select EXPERIMENTAL
 	default n
 	select RING_BUFFER

--- a/applications/nrf5340_audio/src/nrf5340_audio_common.c
+++ b/applications/nrf5340_audio/src/nrf5340_audio_common.c
@@ -4,8 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include <nrfx_clock.h>
+
+#include "audio_system.h"
 #include "bt_mgmt.h"
+#include "channel_assignment.h"
 #include "fw_info_app.h"
+#include "nrf5340_audio_common.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(nrf5340_audio_common, CONFIG_NRF5340_AUDIO_COMMON_LOG_LEVEL);
@@ -13,6 +18,15 @@ LOG_MODULE_REGISTER(nrf5340_audio_common, CONFIG_NRF5340_AUDIO_COMMON_LOG_LEVEL)
 int nrf5340_audio_common_init(void)
 {
 	int ret;
+
+	channel_assignment_init();
+
+	/* Use this to turn on 128 MHz clock for cpu_app */
+	ret = nrfx_clock_divider_set(NRF_CLOCK_DOMAIN_HFCLK, NRF_CLOCK_HFCLK_DIV_1);
+	ret -= NRFX_ERROR_BASE_NUM;
+	if (ret) {
+		return ret;
+	}
 
 	ret = fw_info_app_print();
 	if (ret) {
@@ -23,6 +37,12 @@ int nrf5340_audio_common_init(void)
 	ret = bt_mgmt_init();
 	if (ret) {
 		LOG_ERR("Failed to initialize bt_mgmt");
+		return ret;
+	}
+
+	ret = audio_system_init();
+	if (ret) {
+		LOG_ERR("Failed to initialize the audio system");
 		return ret;
 	}
 

--- a/applications/nrf5340_audio/src/utils/CMakeLists.txt
+++ b/applications/nrf5340_audio/src/utils/CMakeLists.txt
@@ -5,9 +5,11 @@
 #
 
 target_sources(app PRIVATE
-	       ${CMAKE_CURRENT_SOURCE_DIR}/board_version.c
 	       ${CMAKE_CURRENT_SOURCE_DIR}/channel_assignment.c
 	       ${CMAKE_CURRENT_SOURCE_DIR}/error_handler.c
 	       ${CMAKE_CURRENT_SOURCE_DIR}/uicr.c
-	       ${CMAKE_CURRENT_SOURCE_DIR}/nrf5340_audio_dk.c
 )
+
+target_sources_ifdef(CONFIG_BOARD_NRF5340_AUDIO_DK_NRF5340_CPUAPP app PRIVATE
+		${CMAKE_CURRENT_SOURCE_DIR}/nrf5340_audio_dk.c
+		${CMAKE_CURRENT_SOURCE_DIR}/board_version.c)

--- a/applications/nrf5340_audio/src/utils/nrf5340_audio_dk.c
+++ b/applications/nrf5340_audio/src/utils/nrf5340_audio_dk.c
@@ -7,7 +7,6 @@
 #include "led.h"
 #include "button_handler.h"
 #include "button_assignments.h"
-#include "nrfx_clock.h"
 #include "sd_card.h"
 #include "board_version.h"
 #include "channel_assignment.h"
@@ -19,21 +18,6 @@
 LOG_MODULE_REGISTER(nrf5340_audio_dk, CONFIG_MODULE_NRF5340_AUDIO_DK_LOG_LEVEL);
 
 static struct board_version board_rev;
-
-static int hfclock_config_and_start(void)
-{
-	int ret;
-
-	/* Use this to turn on 128 MHz clock for cpu_app */
-	ret = nrfx_clock_divider_set(NRF_CLOCK_DOMAIN_HFCLK, NRF_CLOCK_HFCLK_DIV_1);
-
-	ret -= NRFX_ERROR_BASE_NUM;
-	if (ret) {
-		return ret;
-	}
-
-	return 0;
-}
 
 static int leds_set(void)
 {
@@ -100,11 +84,6 @@ int nrf5340_audio_dk_init(void)
 {
 	int ret;
 
-	ret = hfclock_config_and_start();
-	if (ret) {
-		return ret;
-	}
-
 	ret = led_init();
 	if (ret) {
 		LOG_ERR("Failed to initialize LED module");
@@ -116,8 +95,6 @@ int nrf5340_audio_dk_init(void)
 		LOG_ERR("Failed to initialize button handler");
 		return ret;
 	}
-
-	channel_assignment_init();
 
 	ret = channel_assign_check();
 	if (ret) {
@@ -155,12 +132,6 @@ int nrf5340_audio_dk_init(void)
 			LOG_ERR("Failed to initialize SD card playback");
 			return ret;
 		}
-	}
-
-	ret = audio_system_init();
-	if (ret) {
-		LOG_ERR("Failed to initialize the audio system");
-		return ret;
 	}
 
 	return 0;


### PR DESCRIPTION
Optionally include HW codec, power measurement and SD card features as these are tied to the nRF5340 audio DK and not the audio application. Move initializations of high frequency clock, button handler and channel assignments from audio DK module and to application.