### PR TITLE
manifest: Update zephyr to fix boot banner

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: b5cf3040298410845311ff7397374540d3451528
+      revision: pull/1683/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Jira: NCSDK-27345

Update zephyr to include upstream change making boot banner weak. This ensures that linker will only pick the strong implementation of boot banner when llext is used.