### PR TITLE
Bluetooth: Host: Add missing include

### DIFF
--- a/subsys/bluetooth/host_extensions/host_extensions.c
+++ b/subsys/bluetooth/host_extensions/host_extensions.c
@@ -20,6 +20,7 @@
 #include <sdc_hci_vs.h>
 #endif /* CONFIG_BT_LL_SOFTDEVICE */
 
+#include "hci_types_host_extensions.h"
 #include <bluetooth/nrf/host_extensions.h>
 
 #if defined(CONFIG_BT_TRANSMIT_POWER_CONTROL)


### PR DESCRIPTION
The include of hci_types_host_extensions.h was removed by mistake. Adding it back.