### PR TITLE
wifi: Add kconfig option to disable wmm mode

### DIFF
--- a/drivers/wifi/nrf700x/Kconfig
+++ b/drivers/wifi/nrf700x/Kconfig
@@ -720,3 +720,9 @@ config NRF_WIFI_COMBINED_BUCKEN_IOVDD_GPIO
 	  Enable this option to use a single GPIO to control both buck enable and IOVDD enable,
 	  there will be a internal hardware switch to add delay between the two operations. This
 	  is typically 4ms delay for nRF70.
+
+config NRF_WIFI_FEAT_WMM
+	bool "Enable/Disable WMM mode"
+	default y
+	help
+	  This option controls disable/enable of the WMM(Wireless Multi-Media) feature.

--- a/drivers/wifi/nrf700x/src/fmac_main.c
+++ b/drivers/wifi/nrf700x/src/fmac_main.c
@@ -71,7 +71,6 @@ BUILD_ASSERT(CONFIG_NRF700X_TX_MAX_DATA_SIZE >= MAX_TX_FRAME_SIZE,
 	"TX buffer size must be at least as big as the MTU and headroom");
 
 static const unsigned char aggregation = 1;
-static const unsigned char wmm = 1;
 static const unsigned char max_num_tx_agg_sessions = 4;
 static const unsigned char max_num_rx_agg_sessions = 8;
 static const unsigned char reorder_buf_size = 16;
@@ -718,7 +717,7 @@ static int nrf_wifi_drv_main_zep(const struct device *dev)
 
 #ifdef CONFIG_NRF700X_DATA_TX
 	data_config.aggregation = aggregation;
-	data_config.wmm = wmm;
+	data_config.wmm = IS_ENABLED(CONFIG_NRF_WIFI_FEAT_WMM);
 	data_config.max_num_tx_agg_sessions = max_num_tx_agg_sessions;
 	data_config.max_num_rx_agg_sessions = max_num_rx_agg_sessions;
 	data_config.max_tx_aggregation = max_tx_aggregation;


### PR DESCRIPTION
[SHEL-2054] A wmm was by default set to 1. Adding a kconfig option for WMM. By default it will be enabled. If user needs to disable it, set it as the n.

[SHEL-2054]: https://nordicsemi.atlassian.net/browse/SHEL-2054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ