### PR TITLE
lib: lte_link_control: Avoid unnecessary eDRX enable

### DIFF
--- a/lib/lte_link_control/lte_lc_helpers.c
+++ b/lib/lte_link_control/lte_lc_helpers.c
@@ -295,7 +295,7 @@ int string_to_int(const char *str_buf, int base, int *output)
 }
 
 /* Parses eDRX parameters from a +CEDRXS notification or a +CEDRXRDP response. */
-int parse_edrx(const char *at_response, struct lte_lc_edrx_cfg *cfg)
+int parse_edrx(const char *at_response, struct lte_lc_edrx_cfg *cfg, char *edrx_str, char *ptw_str)
 {
 	int err, tmp_int;
 	uint8_t idx;
@@ -373,6 +373,8 @@ int parse_edrx(const char *at_response, struct lte_lc_edrx_cfg *cfg)
 	}
 
 	tmp_buf[len] = '\0';
+	__ASSERT_NO_MSG(edrx_str != NULL);
+	strcpy(edrx_str, tmp_buf);
 
 	/* The eDRX value is a multiple of 10.24 seconds, except for the
 	 * special case of idx == 0 for LTE-M, where the value is 5.12 seconds.
@@ -404,6 +406,8 @@ int parse_edrx(const char *at_response, struct lte_lc_edrx_cfg *cfg)
 	}
 
 	tmp_buf[len] = '\0';
+	__ASSERT_NO_MSG(ptw_str != NULL);
+	strcpy(ptw_str, tmp_buf);
 
 	/* Value can be a maximum of 15, as there are 16 entries in the table
 	 * for paging time window (both for LTE-M and NB1).

--- a/lib/lte_link_control/lte_lc_helpers.h
+++ b/lib/lte_link_control/lte_lc_helpers.h
@@ -185,12 +185,14 @@ int parse_rrc_mode(const char *at_response,
  * @note It is assumed that the network only reports valid eDRX values when
  *	 in each mode (LTE-M and NB1). There is no sanity check of these values.
  *
- * @param at_response Pointer to buffer with AT response.
- * @param cfg Pointer to where the eDRX configuration is stored.
+ * @param[in] at_response Pointer to buffer with AT response.
+ * @param[in] cfg Pointer to where the eDRX configuration is stored.
+ * @param[out] edrx_str eDRX value as a string. Must be 5 characters long buffer.
+ * @param[out] ptw_str PTW as a string. Must be 5 characters long buffer.
  *
  * @return Zero on success or (negative) error code otherwise.
  */
-int parse_edrx(const char *at_response, struct lte_lc_edrx_cfg *cfg);
+int parse_edrx(const char *at_response, struct lte_lc_edrx_cfg *cfg, char *edrx_str, char *ptw_str);
 
 /* @brief Parses PSM configuration from periodic TAU timer and active time strings.
  *

--- a/lib/lte_link_control/lte_lc_modem_hooks.c
+++ b/lib/lte_link_control/lte_lc_modem_hooks.c
@@ -128,7 +128,7 @@ static void on_modem_shutdown(void *ctx)
 	}
 }
 
-#if CONFIG_UNITY
+#if defined(CONFIG_UNITY)
 void lte_lc_on_modem_cfun(int mode, void *ctx)
 #else
 NRF_MODEM_LIB_ON_CFUN(lte_lc_cfun_hook, lte_lc_on_modem_cfun, NULL);

--- a/tests/lib/lte_lc/src/main.c
+++ b/tests/lib/lte_lc/src/main.c
@@ -22,6 +22,8 @@ void test_parse_edrx(void)
 {
 	int err;
 	struct lte_lc_edrx_cfg cfg;
+	char edrx_str[5];
+	char ptw_str[5];
 	char *at_response_none = "+CEDRXP: 0";
 	char *at_response_fail = "+CEDRXP: 1,\"1000\",\"0101\",\"1011\"";
 	char *at_response_ltem = "+CEDRXP: 4,\"1000\",\"0101\",\"1011\"";
@@ -29,38 +31,46 @@ void test_parse_edrx(void)
 	char *at_response_nbiot = "+CEDRXP: 5,\"1000\",\"1101\",\"0111\"";
 	char *at_response_nbiot_2 = "+CEDRXP: 5,\"1000\",\"1101\",\"0101\"";
 
-	err = parse_edrx(at_response_none, &cfg);
+	err = parse_edrx(at_response_none, &cfg, edrx_str, ptw_str);
 	TEST_ASSERT_EQUAL(0, err);
 	TEST_ASSERT_EQUAL(0, cfg.edrx);
 	TEST_ASSERT_EQUAL(0, cfg.ptw);
 	TEST_ASSERT_EQUAL(LTE_LC_LTE_MODE_NONE, cfg.mode);
 
-	err = parse_edrx(at_response_fail, &cfg);
+	err = parse_edrx(at_response_fail, &cfg, edrx_str, ptw_str);
 	TEST_ASSERT_NOT_EQUAL_MESSAGE(0, err, "parse_edrx should have failed");
 
-	err = parse_edrx(at_response_ltem, &cfg);
+	err = parse_edrx(at_response_ltem, &cfg, edrx_str, ptw_str);
 	TEST_ASSERT_EQUAL(0, err);
 	TEST_ASSERT_FLOAT_WITHIN(0.1, 81.92, cfg.edrx);
 	TEST_ASSERT_FLOAT_WITHIN(0.1, 15.36, cfg.ptw);
 	TEST_ASSERT_EQUAL(LTE_LC_LTE_MODE_LTEM, cfg.mode);
+	TEST_ASSERT_EQUAL_STRING("0101", edrx_str);
+	TEST_ASSERT_EQUAL_STRING("1011", ptw_str);
 
-	err = parse_edrx(at_response_ltem_2, &cfg);
+	err = parse_edrx(at_response_ltem_2, &cfg, edrx_str, ptw_str);
 	TEST_ASSERT_EQUAL(0, err);
 	TEST_ASSERT_FLOAT_WITHIN(0.1, 20.48, cfg.edrx);
 	TEST_ASSERT_FLOAT_WITHIN(0.1, 19.2, cfg.ptw);
 	TEST_ASSERT_EQUAL(LTE_LC_LTE_MODE_LTEM, cfg.mode);
+	TEST_ASSERT_EQUAL_STRING("0010", edrx_str);
+	TEST_ASSERT_EQUAL_STRING("1110", ptw_str);
 
-	err = parse_edrx(at_response_nbiot, &cfg);
+	err = parse_edrx(at_response_nbiot, &cfg, edrx_str, ptw_str);
 	TEST_ASSERT_EQUAL(0, err);
 	TEST_ASSERT_FLOAT_WITHIN(0.1, 2621.44, cfg.edrx);
 	TEST_ASSERT_FLOAT_WITHIN(0.1, 20.48, cfg.ptw);
 	TEST_ASSERT_EQUAL(LTE_LC_LTE_MODE_NBIOT, cfg.mode);
+	TEST_ASSERT_EQUAL_STRING("1101", edrx_str);
+	TEST_ASSERT_EQUAL_STRING("0111", ptw_str);
 
-	err = parse_edrx(at_response_nbiot_2, &cfg);
+	err = parse_edrx(at_response_nbiot_2, &cfg, edrx_str, ptw_str);
 	TEST_ASSERT_EQUAL(0, err);
 	TEST_ASSERT_FLOAT_WITHIN(0.1, 2621.44, cfg.edrx);
 	TEST_ASSERT_FLOAT_WITHIN(0.1, 15.36, cfg.ptw);
 	TEST_ASSERT_EQUAL(LTE_LC_LTE_MODE_NBIOT, cfg.mode);
+	TEST_ASSERT_EQUAL_STRING("1101", edrx_str);
+	TEST_ASSERT_EQUAL_STRING("0101", ptw_str);
 }
 
 void test_parse_cereg(void)


### PR DESCRIPTION
lte_lc used to enable eDRX with AT+CEDRXS and send AT%XPTW immediately after. This causes an unnecessary TAU when PTW is set same value that network reported.
Now AT%XPTW is not sent if PTW value given by the network is the one we are supposed to request.

Jira: NRF91-2041

TODO:

- [x] Update lte_lc tests
- [x] Add new tests to cover the new logic in lte_lc_api tests
- [x] Test scenarios where eDRX parameters are set in offline mode and then eDRX enabled and that parameters are applied