### PR TITLE
CODEOWNERS: Add the carrier team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -37,6 +37,7 @@
 /applications/nrf_desktop/                @MarekPieta
 /applications/nrf5340_audio/              @nrfconnect/ncs-audio
 /applications/serial_lte_modem/           @SeppoTakalo @MarkusLassila @rlubos @tomi-font
+/applications/serial_lte_modem/src/lwm2m_carrier/ @ncs-carrier
 /applications/zigbee_weather_station/     @milewr
 # Boards
 /boards/                                  @anangl
@@ -105,6 +106,7 @@ Kconfig*                                  @tejlmand
 /include/shell/                           @nordic-krch
 /kernel/                                  @nordicjm
 /lib/bin/                                 @rlubos @lemrey
+/lib/bin/lwm2m_carrier/                   @ncs-carrier
 /lib/adp536x/                             @nrfconnect/ncs-cia
 /lib/at_cmd_parser/                       @rlubos
 /lib/at_cmd_custom/                       @eivindj-nordic
@@ -180,6 +182,7 @@ Kconfig*                                  @tejlmand
 /samples/cellular/                        @rlubos @lemrey
 /samples/cellular/battery/                @MirkoCovizzi
 /samples/cellular/location/               @trantanen @jhirsi @tokangas
+/samples/cellular/lwm2m_carrier/          @ncs-carrier
 /samples/cellular/lwm2m_client/           @rlubos @SeppoTakalo @juhaylinen
 /samples/cellular/modem_shell/            @trantanen @jhirsi @tokangas
 /samples/cellular/nidd/                   @stig-bjorlykke


### PR DESCRIPTION
- Add the Carrier team to serial lte modem files.
- Add the Carrier team to the LwM2M carrier library files.