### PR TITLE
net: download_client: remove deprecated function

### DIFF
--- a/doc/nrf/libraries/networking/download_client.rst
+++ b/doc/nrf/libraries/networking/download_client.rst
@@ -48,7 +48,7 @@ Configuring HTTP and HTTPS (TLS 1.2)
 
 Set the :kconfig:option:`CONFIG_DOWNLOAD_CLIENT_BUF_SIZE` and :kconfig:option:`CONFIG_DOWNLOAD_CLIENT_HTTP_FRAG_SIZE` Kconfig options, so that the buffer is large enough to accommodate the entire HTTP header of the request and the response.
 
-Moreover, the application must provision the TLS credentials and pass the security tag to the library when using HTTPS and calling the :c:func:`download_client_connect` function.
+Moreover, the application must provision the TLS credentials and pass the security tag to the library when using HTTPS and calling the :c:func:`download_client_set_host` function.
 To provision a TLS certificate to the modem, use :c:func:`modem_key_mgmt_write` and other :ref:`modem_key_mgmt` APIs.
 
 Configuring CoAP and CoAPS (DTLS 1.2)
@@ -56,7 +56,7 @@ Configuring CoAP and CoAPS (DTLS 1.2)
 
 Make sure to configure the :kconfig:option:`CONFIG_DOWNLOAD_CLIENT_BUF_SIZE` and :kconfig:option:`CONFIG_DOWNLOAD_CLIENT_COAP_BLOCK_SIZE` Kconfig options, so that the buffer is large enough to accommodate the entire CoAP header and the CoAP block.
 
-The application must provision the TLS credentials and pass the security tag to the library when using CoAPS and calling :c:func:`download_client_connect`.
+The application must provision the TLS credentials and pass the security tag to the library when using CoAPS and calling :c:func:`download_client_set_host`.
 
 When you have modem firmware v1.3.5 or newer, you can use the :kconfig:option:`CONFIG_DOWNLOAD_CLIENT_CID` Kconfig option to enable the DTLS Connection Identifier feature in this library.
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-2.4.0.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-2.4.0.rst
@@ -818,7 +818,7 @@ Libraries for networking
 
   * Updated:
 
-    * The :c:func:`download_client_connect` function has been refactored to :c:func:`download_client_set_host` and made it non-blocking.
+    * The ``download_client_connect`` function has been refactored to :c:func:`download_client_set_host` and made it non-blocking.
     * The configuration from one security tag to a list of security tags.
     * The library reports error ``ERANGE`` when HTTP range is requested but not supported by server.
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -774,6 +774,10 @@ Libraries for networking
 
   * Fixed a NULL pointer issue that could occur when there are some valid predictions in flash but not the one required at the current time.
 
+* :ref:`lib_download_client` library:
+
+  * Removed the deprecated ``download_client_connect`` function.
+
 Libraries for NFC
 -----------------
 

--- a/include/net/download_client.h
+++ b/include/net/download_client.h
@@ -258,22 +258,6 @@ int download_client_set_host(struct download_client *client, const char *host,
 			    const struct download_client_cfg *config);
 
 /**
- * @brief Set a target hostname.
- *
- * @deprecated Use download_client_set_host() instead.
- *
- * @param[in] client	Client instance.
- * @param[in] host	Name of the host to connect to, null-terminated.
- *			Can include scheme and port number, defaults to
- *			HTTP or HTTPS if no scheme is provided.
- * @param[in] config	Configuration options.
- *
- * @retval int Zero on success, a negative error code otherwise.
- */
-__deprecated int download_client_connect(struct download_client *client, const char *host,
-			    const struct download_client_cfg *config);
-
-/**
  * @brief Download a file.
  *
  * The download is carried out in fragments of up to

--- a/subsys/net/lib/download_client/src/download_client.c
+++ b/subsys/net/lib/download_client/src/download_client.c
@@ -957,12 +957,6 @@ int download_client_set_host(struct download_client *client, const char *host,
 	return 0;
 }
 
-int download_client_connect(struct download_client *client, const char *host,
-			    const struct download_client_cfg *config)
-{
-	return download_client_set_host(client, host, config);
-}
-
 int download_client_disconnect(struct download_client *const client)
 {
 	if (client == NULL || is_idle(client)) {


### PR DESCRIPTION
Remove deprecated `download_client_connect()` function.