### PR TITLE
scripts: add integration quarantine part 10

### DIFF
--- a/scripts/quarantine_integration.yaml
+++ b/scripts/quarantine_integration.yaml
@@ -1109,3 +1109,69 @@
   platforms:
     - nrf9160dk/nrf9160
   comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - sample.nrf7001_eks.shell
+    - sample.nrf7001_eks_cpunet.shell
+    - sample.nrf7002_eks.shell
+    - sample.nrf7002_eks_cpunet.shell
+  platforms:
+    - nrf5340dk/nrf5340/cpuapp
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - sample.nrf7002.shell
+    - sample.nrf7002.shell.disable_adv_features
+    - sample.nrf7002.shell.otbr
+    - sample.nrf7002.shell.posix_names
+    - sample.nrf7002.shell.scan_only_7002
+    - sample.nrf7002.shell.wpa_cli
+    - sample.nrf7002.shell.zperf
+  platforms:
+    - nrf7002dk/nrf5340/cpuapp
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - sample.nrf7001.shell
+    - sample.nrf7001.shell.wpa_cli
+    - sample.nrf7001.shell.zperf
+  platforms:
+    - nrf7002dk/nrf7001/nrf5340/cpuapp
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - sample.nrf7002_ns.shell
+  platforms:
+    - nrf7002dk/nrf5340/cpuapp/ns
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - sample.nrf7001_eks.scan
+    - sample.nrf7002_eks.raw_scan
+    - sample.nrf7002_eks.scan
+  platforms:
+    - nrf9160dk/nrf9160/ns
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - sample.nrf7002_eks.raw_scan
+  platforms:
+    - nrf9161dk/nrf9161/ns
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - sample.nrf7002_eks.radio_test
+    - sample.nrf7002_eks.sta
+    - sample.nrf7002_eks.scan
+  platforms:
+    - nrf52840dk/nrf52840
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - sample.nrf7001_eks.radio_test
+    - sample.nrf7001_eks.sta
+    - sample.nrf7001_eks.scan
+    - sample.nrf7001_eks.provisioning
+  platforms:
+    - nrf5340dk/nrf5340/cpuapp
+  comment: "Configurations excluded to limit resources usage in integration builds"


### PR DESCRIPTION
To limit integration scope.
For:
nrf/samples/wifi/shell
nrf/samples/wifi/scan
nrf/samples/wifi/radio_test
nrf/samples/wifi/sta
nrf/samples/wifi/provisioning
