### PR TITLE
Bluetooth: Mesh: Fix status pub for move set in gen_lvl_srv

### DIFF
--- a/subsys/bluetooth/mesh/gen_lvl_srv.c
+++ b/subsys/bluetooth/mesh/gen_lvl_srv.c
@@ -152,7 +152,7 @@ static int move_set(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *c
 		rsp_status(model, ctx, &status);
 	}
 
-	(void)bt_mesh_lvl_srv_pub(srv, ctx, &status);
+	(void)bt_mesh_lvl_srv_pub(srv, NULL, &status);
 
 	return 0;
 }


### PR DESCRIPTION
Fixes issue in publishing of generic level status message in response to a move set action. It should use the publishing parameters of the model, not the sender context it received the original message on.