### PR TITLE
scripts: add integration quarantine part 11

### DIFF
--- a/scripts/quarantine_integration.yaml
+++ b/scripts/quarantine_integration.yaml
@@ -1175,3 +1175,11 @@
   platforms:
     - nrf5340dk/nrf5340/cpuapp
   comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - dfu.target_stream
+    - dfu.target_stream.store_progress
+  platforms:
+    - nrf5340dk/nrf5340/cpuapp
+    - nrf9160dk/nrf9160
+  comment: "Configurations excluded to limit resources usage in integration builds"

--- a/scripts/quarantine_zephyr_integration.yaml
+++ b/scripts/quarantine_zephyr_integration.yaml
@@ -164,3 +164,80 @@
 - scenarios:
     - libraries.cmsis_dsp.*
   comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - mgmt.mcumgr.os.info
+    - mgmt.mcumgr.os.info.build_date
+    - mgmt.mcumgr.os.info.limited_size
+    - mgmt.mcumgr.os.info.no_hooks
+  platforms:
+    - nrf52dk/nrf52832
+    - nrf5340dk/nrf5340/cpunet
+    - nrf9160dk/nrf9160
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - mgmt.mcumgr.os.info
+    - mgmt.mcumgr.os.info.build_date
+    - mgmt.mcumgr.os.info.limited_size
+    - mgmt.mcumgr.os.info.net
+    - mgmt.mcumgr.os.info.no_hooks
+  platforms:
+    - nrf5340dk/nrf5340/cpuapp
+    - nrf5340dk/nrf5340/cpuapp/ns
+    - nrf9160dk/nrf9160/ns
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - mgmt.mcumgr.fs.mgmt.hash.supported.all
+    - mgmt.mcumgr.fs.mgmt.hash.supported.crc32
+    - mgmt.mcumgr.fs.mgmt.hash.supported.sha256
+  platforms:
+    - mps2_an521
+    - nrf52dk/nrf52832
+    - nrf5340dk/nrf5340/cpuapp
+    - nrf5340dk/nrf5340/cpuapp/ns
+    - nrf5340dk/nrf5340/cpunet
+    - nrf9160dk/nrf9160
+    - nrf9160dk/nrf9160/ns
+    - qemu_cortex_m3
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - mgmt.mcumgr.smp.version
+    - mgmt.mcumgr.smp.version_no_legacy
+  platforms:
+    - mps2_an521
+    - nrf52dk/nrf52832
+    - nrf5340dk/nrf5340/cpuapp
+    - nrf5340dk/nrf5340/cpuapp/ns
+    - nrf5340dk/nrf5340/cpunet
+    - nrf9160dk/nrf9160
+    - nrf9160dk/nrf9160/ns
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - mgmt.mcumgr.os.echo
+  platforms:
+    - mps2_an521
+    - nrf52dk/nrf52832
+    - nrf5340dk/nrf5340/cpuapp
+    - nrf5340dk/nrf5340/cpuapp/ns
+    - nrf5340dk/nrf5340/cpunet
+    - nrf9160dk/nrf9160
+    - nrf9160dk/nrf9160/ns
+    - qemu_cortex_m3
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - sample.usb.dfu
+    - sample.usb.dfu.permanent.download
+  platforms:
+    - nrf5340dk/nrf5340/cpuapp
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - sample.mcumgr.smp_svr.bt
+  platforms:
+    - nrf52dk/nrf52832
+  comment: "Configurations excluded to limit resources usage in integration builds"


### PR DESCRIPTION
To limit integration scope.
For:
zephyr/tests/subsys/mgmt/mcumgr/os_mgmt_info
zephyr/tests/subsys/mgmt/mcumgr/fs_mgmt_hash_supported
zephyr/tests/subsys/mgmt/mcumgr/smp_version
zephyr/tests/subsys/mgmt/mcumgr/os_mgmt_echo
zephyr/samples/subsys/mgmt/mcumgr/smp_svr
nrf/tests/subsys/dfu/dfu_target_stream