### PR TITLE
samples: cellular: modem_shell: Add Thingy:91 X Wi-Fi scanning support

### DIFF
--- a/doc/nrf/includes/sample_board_rows.txt
+++ b/doc/nrf/includes/sample_board_rows.txt
@@ -92,6 +92,14 @@
 
 | :ref:`Thingy:91 <ug_thingy91>` | PCA20035 | thingy91 | ``thingy91/nrf9160/ns`` |
 
+.. thingy91x_nrf9151
+
+| Thingy:91 X | PCA20065 | thingy91x | ``thingy91x/nrf9151`` |
+
+.. thingy91x_nrf9151_ns
+
+| Thingy:91 X | PCA20065 | thingy91x | ``thingy91x/nrf9151/ns`` |
+
 .. thingy91x_nrf5340_cpuapp
 
 | Thingy:91 x | PCA20065 | thingy91x | ``thingy91x/nrf5340/cpuapp`` |

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -503,7 +503,11 @@ Cellular samples
 
 * :ref:`modem_shell_application` sample:
 
-  * Added support for sending location data details into nRF Cloud with ``--cloud_details`` command-line option in the ``location`` command.
+  * Added:
+
+    * Support for sending location data details into nRF Cloud with ``--cloud_details`` command-line option in the ``location`` command.
+    * Support for Thingy:91 X Wi-Fi scanning.
+
   * Removed ESP8266 Wi-Fi DTC and Kconfig overlay files.
 
 * :ref:`nrf_cloud_rest_cell_pos_sample` sample:

--- a/samples/cellular/location/overlay-nrf700x-wifi-scan-only.conf
+++ b/samples/cellular/location/overlay-nrf700x-wifi-scan-only.conf
@@ -4,10 +4,9 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# Overlay to use Wi-Fi scanning
-# with one of the following configurations:
-# * a nRF7002 EK on top of nrf9160 DK
-# * a Thingy:91 X
+# Overlay to use Wi-Fi scanning with one of the following configurations:
+# * nRF7002 EK on top of nRF91 Series DK
+# * Thingy:91 X
 
 # Disable modem traces as UART1 is disabled
 CONFIG_NRF_MODEM_LIB_TRACE=n

--- a/samples/cellular/modem_shell/README.rst
+++ b/samples/cellular/modem_shell/README.rst
@@ -1003,8 +1003,8 @@ To program the certificates and connect to nRF Cloud, complete the following ste
 .. parsed-literal::
    :class: highlight
 
-   west build -p -b *board_target* -d build
-   west flash -d build
+   west build -p -b *board_target*
+   west flash
 
 |board_target|
 
@@ -1066,15 +1066,27 @@ To program the certificates and connect to nRF Cloud, complete the following ste
 nRF91 Series DK with nRF7002 EK Wi-Fi support
 =============================================
 
-To build the MoSh sample for an nRF91 Series DK with nRF7002 EK Wi-Fi support, use the ``-DSHIELD=nrf7002ek`` and  ``-DEXTRA_CONF_FILE=overlay-nrf7002ek-wifi-scan-only.conf`` options.
+To build the MoSh sample for an nRF91 Series DK with nRF7002 EK Wi-Fi support, use the ``-DSHIELD=nrf7002ek``, ``-DEXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf``, ``-DSB_CONFIG_WIFI_NRF700X=y`` and ``-DSB_CONFIG_WIFI_NRF700X_SCAN_ONLY=y`` options.
 For example:
 
 .. parsed-literal::
    :class: highlight
 
-   west build -p -b *board_target* -- -DSHIELD=nrf7002ek -DEXTRA_CONF_FILE=overlay-nrf7002ek-wifi-scan-only.conf
+   west build -p -b *board_target* -- -DSHIELD=nrf7002ek -DEXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf -DSB_CONFIG_WIFI_NRF700X=y -DSB_CONFIG_WIFI_NRF700X_SCAN_ONLY=y
 
 |board_target|
+
+See :ref:`cmake_options` for more instructions on how to add these options.
+
+Thingy:91 X Wi-Fi support
+=========================
+
+To build the MoSh sample with Thingy:91 X Wi-Fi support, use the ``-DDTC_OVERLAY_FILE=thingy91x_wifi.overlay``, ``-DEXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf``, ``-DSB_CONFIG_WIFI_NRF700X=y``, and ``-DSB_CONFIG_WIFI_NRF700X_SCAN_ONLY=y`` options.
+For example:
+
+.. code-block:: console
+
+   west build -p -b thingy91x/nrf9151/ns -- -DDTC_OVERLAY_FILE=thingy91x_wifi.overlay -DEXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf -DSB_CONFIG_WIFI_NRF700X=y -DSB_CONFIG_WIFI_NRF700X_SCAN_ONLY=y
 
 See :ref:`cmake_options` for more instructions on how to add these options.
 
@@ -1148,13 +1160,13 @@ After programming the development kit, test it in the Linux environment by perfo
 Application FOTA support
 ========================
 
-To build the MoSh sample with application FOTA support, use the ``-DEXTRA_CONF_FILE=overlay-app_fota.conf`` option.
+To build the MoSh sample with application FOTA support, use the ``-DEXTRA_CONF_FILE=overlay-app_fota.conf`` and ``-DSB_CONFIG_BOOTLOADER_MCUBOOT=y`` options.
 For example:
 
 .. parsed-literal::
    :class: highlight
 
-   west build -p -b *board_target* -d build -- -DEXTRA_CONF_FILE=overlay-app_fota.conf
+   west build -p -b *board_target* -- -DEXTRA_CONF_FILE=overlay-app_fota.conf -DSB_CONFIG_BOOTLOADER_MCUBOOT=y
 
 |board_target|
 
@@ -1166,7 +1178,7 @@ The following is an example for the nRF9161 DK:
 
 .. code-block:: console
 
-   west build -p -b nrf9161dk/nrf9161/ns -d build -- -DEXTRA_CONF_FILE=overlay-modem_fota_full.conf -DDTC_OVERLAY_FILE=nrf9161dk_ext_flash.overlay
+   west build -p -b nrf9161dk/nrf9161/ns -- -DEXTRA_CONF_FILE=overlay-modem_fota_full.conf -DDTC_OVERLAY_FILE=nrf9161dk_ext_flash.overlay
 
 LwM2M carrier library support
 =============================
@@ -1177,7 +1189,7 @@ For example:
 .. parsed-literal::
    :class: highlight
 
-   west build -p -b *board_target* -d build -- -DEXTRA_CONF_FILE=overlay-carrier.conf
+   west build -p -b *board_target* -- -DEXTRA_CONF_FILE=overlay-carrier.conf
 
 |board_target|
 
@@ -1190,7 +1202,7 @@ For example:
 .. parsed-literal::
    :class: highlight
 
-   west build -p -b *board_target* -d build -- -DEXTRA_CONF_FILE=overlay-pgps.conf
+   west build -p -b *board_target* -- -DEXTRA_CONF_FILE=overlay-pgps.conf
 
 |board_target|
 
@@ -1205,7 +1217,7 @@ For example:
 .. parsed-literal::
    :class: highlight
 
-   west build -p -b *board_target* -d build -- -DEXTRA_CONF_FILE=overlay-cloud_mqtt.conf
+   west build -p -b *board_target* -- -DEXTRA_CONF_FILE=overlay-cloud_mqtt.conf
 
 |board_target|
 
@@ -1218,7 +1230,7 @@ For example:
 .. parsed-literal::
    :class: highlight
 
-   west build -p -b *board_target* -d build -- -DEXTRA_CONF_FILE=overlay-cloud_coap.conf
+   west build -p -b *board_target* -- -DEXTRA_CONF_FILE=overlay-cloud_coap.conf
 
 |board_target|
 
@@ -1233,7 +1245,7 @@ For example:
 .. parsed-literal::
    :class: highlight
 
-   west build -p -b *board_target* -d build -- -DEXTRA_CONF_FILE=overlay-cloud_mqtt.conf -DCONFIG_LOCATION_SERVICE_EXTERNAL=y
+   west build -p -b *board_target* -- -DEXTRA_CONF_FILE=overlay-cloud_mqtt.conf -DCONFIG_LOCATION_SERVICE_EXTERNAL=y
 
 |board_target|
 
@@ -1243,7 +1255,7 @@ For example:
 .. parsed-literal::
    :class: highlight
 
-   west build -p -b *board_target* -d build -- -DEXTRA_CONF_FILE="overlay-cloud_mqtt.conf;overlay-pgps.conf" -DCONFIG_LOCATION_SERVICE_EXTERNAL=y -DCONFIG_NRF_CLOUD_PGPS_TRANSPORT_NONE=y
+   west build -p -b *board_target* -- -DEXTRA_CONF_FILE="overlay-cloud_mqtt.conf;overlay-pgps.conf" -DCONFIG_LOCATION_SERVICE_EXTERNAL=y -DCONFIG_NRF_CLOUD_PGPS_TRANSPORT_NONE=y
 
 |board_target|
 

--- a/samples/cellular/modem_shell/overlay-nrf700x-wifi-scan-only.conf
+++ b/samples/cellular/modem_shell/overlay-nrf700x-wifi-scan-only.conf
@@ -4,7 +4,9 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# Overlay to use nRF7002 EK on top of nrf9160 DK for Wi-Fi scanning
+# Overlay to use Wi-Fi scanning with one of the following configurations:
+# * nRF7002 EK on top of nRF91 Series DK
+# * Thingy:91 X
 
 # Disable modem traces as UART1 is disabled
 CONFIG_NRF_MODEM_LIB_TRACE=n

--- a/samples/cellular/modem_shell/sample.yaml
+++ b/samples/cellular/modem_shell/sample.yaml
@@ -91,7 +91,7 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    extra_args: SHIELD=nrf7002ek OVERLAY_CONFIG=overlay-nrf7002ek-wifi-scan-only.conf
+    extra_args: SHIELD=nrf7002ek OVERLAY_CONFIG=overlay-nrf700x-wifi-scan-only.conf
                 SB_CONFIG_WIFI_NRF700X=y SB_CONFIG_WIFI_NRF700X_SCAN_ONLY=y
     tags: ci_build sysbuild
   sample.cellular.modem_shell.nrf7000ek_wifi:
@@ -105,7 +105,7 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    extra_args: SHIELD=nrf7002ek_nrf7000 OVERLAY_CONFIG=overlay-nrf7002ek-wifi-scan-only.conf
+    extra_args: SHIELD=nrf7002ek_nrf7000 OVERLAY_CONFIG=overlay-nrf700x-wifi-scan-only.conf
                 CONFIG_WPA_SUPP=n SB_CONFIG_WIFI_NRF700X=y
                 SB_CONFIG_WIFI_NRF700X_SCAN_ONLY=y
     tags: ci_build sysbuild
@@ -120,7 +120,7 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    extra_args: SHIELD=nrf7002ek_nrf7001 OVERLAY_CONFIG=overlay-nrf7002ek-wifi-scan-only.conf
+    extra_args: SHIELD=nrf7002ek_nrf7001 OVERLAY_CONFIG=overlay-nrf700x-wifi-scan-only.conf
                 SB_CONFIG_WIFI_NRF700X=y SB_CONFIG_WIFI_NRF700X_SCAN_ONLY=y
     tags: ci_build sysbuild
   sample.cellular.modem_shell.nrf7002ek_wifi-debug:
@@ -135,7 +135,7 @@ tests:
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
     extra_args: SHIELD=nrf7002ek
-                OVERLAY_CONFIG="overlay-nrf7002ek-wifi-scan-only.conf;overlay-debug.conf"
+                OVERLAY_CONFIG="overlay-nrf700x-wifi-scan-only.conf;overlay-debug.conf"
                 SB_CONFIG_WIFI_NRF700X=y SB_CONFIG_WIFI_NRF700X_SCAN_ONLY=y
     tags: ci_build sysbuild
   sample.cellular.modem_shell.app_fota:
@@ -157,7 +157,6 @@ tests:
     build_only: true
     extra_args: OVERLAY_CONFIG=overlay-modem_fota_full.conf
                 DTC_OVERLAY_FILE="nrf9160dk_ext_flash.overlay"
-                SB_CONFIG_PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY=y
     integration_platforms:
       - nrf9160dk/nrf9160/ns
     platform_allow: nrf9160dk/nrf9160/ns
@@ -167,7 +166,6 @@ tests:
     build_only: true
     extra_args: OVERLAY_CONFIG=overlay-modem_fota_full.conf
                 DTC_OVERLAY_FILE="nrf9161dk_ext_flash.overlay"
-                SB_CONFIG_PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY=y
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9161dk/nrf9161/ns
@@ -268,7 +266,7 @@ tests:
       - CONFIG_LOCATION_SERVICE_EXTERNAL=y
       - CONFIG_NRF_CLOUD_PGPS_TRANSPORT_NONE=y
     extra_args: SHIELD=nrf7002ek
-                OVERLAY_CONFIG="overlay-cloud_mqtt.conf;overlay-pgps.conf;overlay-nrf7002ek-wifi-scan-only.conf"
+                OVERLAY_CONFIG="overlay-cloud_mqtt.conf;overlay-pgps.conf;overlay-nrf700x-wifi-scan-only.conf"
                 SB_CONFIG_WIFI_NRF700X=y SB_CONFIG_WIFI_NRF700X_SCAN_ONLY=y
     integration_platforms:
       - nrf9151dk/nrf9151/ns
@@ -318,9 +316,21 @@ tests:
     build_only: true
     integration_platforms:
       - thingy91/nrf9160/ns
+      - thingy91x/nrf9151/ns
     platform_allow:
       - thingy91/nrf9160/ns
       - thingy91x/nrf9151/ns
+    tags: ci_build sysbuild
+  sample.cellular.modem_shell.thingy91x_wifi:
+    sysbuild: true
+    build_only: true
+    integration_platforms:
+      - thingy91x/nrf9151/ns
+    platform_allow:
+      - thingy91x/nrf9151/ns
+    extra_args: OVERLAY_CONFIG=overlay-nrf700x-wifi-scan-only.conf
+                DTC_OVERLAY_FILE=thingy91x_wifi.overlay
+                SB_CONFIG_WIFI_NRF700X=y SB_CONFIG_WIFI_NRF700X_SCAN_ONLY=y
     tags: ci_build sysbuild
   sample.cellular.modem_shell.modem_trace_shell_ext_flash:
     sysbuild: true
@@ -333,8 +343,7 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    extra_args: SNIPPET="nrf91-modem-trace-ext-flash"
-                SB_CONFIG_PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY=y
+    extra_args: modem_shell_SNIPPET="nrf91-modem-trace-ext-flash"
     extra_configs:
       - CONFIG_NRF_MODEM_LIB_SHELL_TRACE=y
     tags: ci_build sysbuild
@@ -368,7 +377,7 @@ tests:
       - CONFIG_LOCATION_METHOD_GNSS=y
       - CONFIG_LOCATION_METHOD_CELLULAR=n
       - CONFIG_LOCATION_METHOD_WIFI=y
-    extra_args: SHIELD=nrf7002ek OVERLAY_CONFIG=overlay-nrf7002ek-wifi-scan-only.conf
+    extra_args: SHIELD=nrf7002ek OVERLAY_CONFIG=overlay-nrf700x-wifi-scan-only.conf
                 SB_CONFIG_WIFI_NRF700X=y SB_CONFIG_WIFI_NRF700X_SCAN_ONLY=y
     tags: ci_build sysbuild
   sample.cellular.modem_shell.location_wifi_cellular_no_gnss:
@@ -386,7 +395,7 @@ tests:
       - CONFIG_LOCATION_METHOD_GNSS=n
       - CONFIG_LOCATION_METHOD_CELLULAR=y
       - CONFIG_LOCATION_METHOD_WIFI=y
-    extra_args: SHIELD=nrf7002ek OVERLAY_CONFIG=overlay-nrf7002ek-wifi-scan-only.conf
+    extra_args: SHIELD=nrf7002ek OVERLAY_CONFIG=overlay-nrf700x-wifi-scan-only.conf
                 SB_CONFIG_WIFI_NRF700X=y SB_CONFIG_WIFI_NRF700X_SCAN_ONLY=y
     tags: ci_build sysbuild
   sample.cellular.modem_shell.location_wifi_no_cellular_no_gnss:
@@ -404,7 +413,7 @@ tests:
       - CONFIG_LOCATION_METHOD_GNSS=n
       - CONFIG_LOCATION_METHOD_CELLULAR=n
       - CONFIG_LOCATION_METHOD_WIFI=y
-    extra_args: SHIELD=nrf7002ek OVERLAY_CONFIG=overlay-nrf7002ek-wifi-scan-only.conf
+    extra_args: SHIELD=nrf7002ek OVERLAY_CONFIG=overlay-nrf700x-wifi-scan-only.conf
                 SB_CONFIG_WIFI_NRF700X=y SB_CONFIG_WIFI_NRF700X_SCAN_ONLY=y
     tags: ci_build sysbuild
   sample.cellular.modem_shell.location_gnss_no_wifi_no_cellular:
@@ -457,7 +466,7 @@ tests:
       - CONFIG_LOCATION_METHOD_GNSS=y
       - CONFIG_LOCATION_METHOD_CELLULAR=y
       - CONFIG_LOCATION_METHOD_WIFI=y
-    extra_args: SHIELD=nrf7002ek OVERLAY_CONFIG=overlay-nrf7002ek-wifi-scan-only.conf
+    extra_args: SHIELD=nrf7002ek OVERLAY_CONFIG=overlay-nrf700x-wifi-scan-only.conf
                 SB_CONFIG_WIFI_NRF700X=y SB_CONFIG_WIFI_NRF700X_SCAN_ONLY=y
     tags: ci_build sysbuild
   sample.cellular.modem_shell.location_gnss_no_wifi_no_cellular_details:
@@ -493,7 +502,7 @@ tests:
       - CONFIG_LOCATION_METHOD_GNSS=n
       - CONFIG_LOCATION_METHOD_CELLULAR=y
       - CONFIG_LOCATION_METHOD_WIFI=y
-    extra_args: SHIELD=nrf7002ek OVERLAY_CONFIG=overlay-nrf7002ek-wifi-scan-only.conf
+    extra_args: SHIELD=nrf7002ek OVERLAY_CONFIG=overlay-nrf700x-wifi-scan-only.conf
                 SB_CONFIG_WIFI_NRF700X=y SB_CONFIG_WIFI_NRF700X_SCAN_ONLY=y
     tags: ci_build sysbuild
   sample.cellular.modem_shell.location_gnss_cellular_no_wifi_details:
@@ -519,7 +528,7 @@ tests:
   sample.cellular.modem_shell_modem_uart_trace:
     sysbuild: true
     build_only: true
-    extra_args: SNIPPET="nrf91-modem-trace-uart"
+    extra_args: modem_shell_SNIPPET="nrf91-modem-trace-uart"
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
@@ -532,7 +541,9 @@ tests:
   sample.cellular.modem_shell.non_offloading_ip_modem_uart_trace:
     sysbuild: true
     build_only: true
-    extra_args: OVERLAY_CONFIG=overlay-non-offloading.conf SNIPPET="nrf91-modem-trace-uart"
+    extra_args:
+      OVERLAY_CONFIG=overlay-non-offloading.conf
+      modem_shell_SNIPPET="nrf91-modem-trace-uart"
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
@@ -545,9 +556,10 @@ tests:
   sample.cellular.modem_shell.thingy91_modem_uart_trace:
     sysbuild: true
     build_only: true
-    extra_args: SNIPPET="nrf91-modem-trace-uart"
+    extra_args: modem_shell_SNIPPET="nrf91-modem-trace-uart"
     integration_platforms:
       - thingy91/nrf9160/ns
+      - thingy91x/nrf9151/ns
     platform_allow:
       - thingy91/nrf9160/ns
       - thingy91x/nrf9151/ns
@@ -560,7 +572,7 @@ tests:
     extra_configs:
       - CONFIG_LTE_NETWORK_MODE_LTE_M=y
       - CONFIG_MODEM_ANTENNA_GNSS_EXTERNAL=y
-    extra_args: SNIPPET="nrf91-modem-trace-uart"
+    extra_args: modem_shell_SNIPPET="nrf91-modem-trace-uart"
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns

--- a/samples/cellular/modem_shell/thingy91x_wifi.overlay
+++ b/samples/cellular/modem_shell/thingy91x_wifi.overlay
@@ -1,0 +1,6 @@
+/* Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <thingy91x_wifi.dtsi>


### PR DESCRIPTION
Added devicetree overlay for building the sample for Thingy:91 X with Wi-Fi scanning support. Renamed the nRF700x Kconfig overlay, because the same overlay can be used with nRF7002 EK and Thingy:91 X.