### PR TITLE
doc: snippets: move info from VSC extension docs

### DIFF
--- a/doc/nrf/config_and_build/config_and_build_system.rst
+++ b/doc/nrf/config_and_build/config_and_build_system.rst
@@ -177,6 +177,18 @@ See the Configuration section of the given application or sample's documentation
 
 For information about how to provide file suffixes when building an application, see :ref:`cmake_options`.
 
+.. _app_build_snippets:
+
+Snippets
+--------
+
+Snippets are a Zephyr mechanism for defining portable build system overrides that could be applied to any application.
+Read Zephyr's :ref:`zephyr:snippets` documentation for more information.
+
+You can set snippets for use with your application when you :ref:`set up your build configuration <building>` by :ref:`providing them as CMake options <cmake_options>`.
+
+Usage of snippets is optional.
+
 .. _configuration_system_overview_build:
 
 Building phase

--- a/doc/nrf/device_guides/working_with_nrf/nrf70/developing/fw_patches_ext_flash.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf70/developing/fw_patches_ext_flash.rst
@@ -80,7 +80,7 @@ In this case the upload of the firmware patch from the external memory to the nR
 1. The firmware patch is loaded from the external memory onto internal RAM.
 #. The firmware patch is uploaded to the nRF70 device.
 
-This feature can be enabled using DTS or :ref:`snippets` feature or by using :ref:`partition_manager`.
+This feature can be enabled using DTS or the :ref:`app_build_snippets` feature, or by using :ref:`partition_manager`.
 
 Configuration
 -------------

--- a/doc/nrf/device_guides/working_with_nrf/nrf91/nrf91_snippet.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf91/nrf91_snippet.rst
@@ -8,7 +8,7 @@ Snippets for an nRF91 Series device
    :depth: 2
 
 
-:ref:`snippets` are tailored for tracing on the nRF91 Series devices but can work with other boards as well.
+nRF91 Series' :ref:`app_build_snippets` are tailored for tracing on the nRF91 Series devices but can work with other boards as well.
 On nRF91 Series devices, snippets are used for the following functionalities:
 
 * Modem tracing with the flash backend

--- a/doc/nrf/protocols/thread/certification.rst
+++ b/doc/nrf/protocols/thread/certification.rst
@@ -66,7 +66,7 @@ Complete the following steps to prepare for the certification tests:
 
 #. Build the certification image.
 
-   Use the :ref:`ot_cli_sample` sample as a base and apply the ``ci`` and ``multiprotocol`` snippets.
+   Use the :ref:`ot_cli_sample` sample as a base and apply the ``ci`` and ``multiprotocol`` :ref:`app_build_snippets`.
    If you are building for the ``nrf5340dk/nrf5340/cpuapp`` target, also set the :kconfig:option:`SB_CONFIG_NETCORE_MULTIPROTOCOL_RPMSG` Kconfig option to ``y``.
 
    * If building on the command line, use the following command:

--- a/doc/nrf/protocols/wifi/debugging.rst
+++ b/doc/nrf/protocols/wifi/debugging.rst
@@ -19,7 +19,7 @@ Enable debug features
 
 The nRF Wi-Fi driver, WPA supplicant, and networking stack have debug features that can be enabled to help debug issues.
 
-You can enable debug features by using Zephyr's configuration :ref:`snippets` feature.
+You can enable debug features by using the :ref:`app_build_snippets` feature.
 
 For example, to build the :ref:`wifi_shell_sample` sample for the nRF7002 DK with debugging enabled, run the following commands:
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -38,7 +38,10 @@ IDE and tool support
 Build and configuration system
 ==============================
 
-* Added documentation about the :ref:`file suffix feature from Zephyr <app_build_file_suffixes>` with a related information in the :ref:`migration guide <migration_2.7_recommended>`.
+* Added:
+
+  * Documentation section about the :ref:`file suffix feature from Zephyr <app_build_file_suffixes>` with a related information in the :ref:`migration guide <migration_2.7_recommended>`.
+  * Documentation section about :ref:`app_build_snippets`.
 
 Working with nRF91 Series
 =========================


### PR DESCRIPTION
Moved info about snippets from VSC extension docs to where it should belong.