### PR TITLE
manifest: update sdk-zephyr to have functional support for nRF54H20 PWM - v2.6.99

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: bdda11bdb687157e55b44e3053bb0966ecf75d4f
+      revision: bd660a463f3fd9ae9f5e74a33435eba30d19b929
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update sdk-zephyr so functional changes aligning PWM driver to nRF54H20 are available.