### PR TITLE
scripts: sdfw: add scripts for communicating with SDFW

### DIFF
--- a/scripts/sdfw/README.rst
+++ b/scripts/sdfw/README.rst
@@ -1,0 +1,68 @@
+.. _sdfw_ctrlap_script:
+
+Secure Domain Firmware (SDFW) scripts
+#####################################
+
+.. contents::
+   :local:
+   :depth: 2
+
+These scripts enables communication with the SDFW using the CTRL-AP.
+
+Overview
+********
+
+Several types of requests can be issued to the SDFW over the CTRL-AP interface.
+These requests are based on the ADAC protocol.
+
+There are two types of requests: ADAC commands and SSF services.
+
+ADAC commands
+-------------
+
+ADAC commands are invoked through :file:`scripts/sdfw/main.py`.
+These are vendor specific extensions to the ADAC protocol.
+
+SSF Services
+------------
+SSF services are invoked by calling their respective script file directly.
+For instance :file:`sdfw_update_service.py`.
+
+Requirements
+************
+
+The script source files are located in the :file:`scripts/sdfw` directory.
+There are no extra dependencies in addition to the ones in sdk-nrf.
+These scripts also requires an the nRF54H Series development kit to run the SDFW.
+
+Using the script
+****************
+
+To list all supported ADAC commands run the following command:
+
+.. code-block:: console
+
+   python3 main.py --help
+
+For detailed information about a specific command (for instance ``version``) run the following command:
+
+.. code-block:: console
+
+   python3 main.py version --help
+
+
+Reading the SDFW version with an ADAC command
+---------------------------------------------
+
+.. code-block:: console
+
+   python3 main.py version --type 1 # Read the Firmware version
+   python3 main.py version --type 0 # Read the ADAC protocol version
+
+Purging a domain
+----------------
+
+.. code-block:: console
+
+   python3 main.py purge --domain-id 2 # Purge the application domain
+   python3 main.py purge --domain-id 3 # Purge the radio domain

--- a/scripts/sdfw/ctrlap.py
+++ b/scripts/sdfw/ctrlap.py
@@ -1,0 +1,126 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+"""
+Module exposing CTRLAP functionality
+"""
+
+from argparse import ArgumentParser
+from enum import IntEnum
+from time import sleep, time
+
+from jlink_connector import JLinkConnector
+
+
+class CtrlApReg(IntEnum):
+    """Access Port register enumerations."""
+
+    READY = 0x4
+    TXDATA = 0x10
+    RXDATA = 0x18
+    RXSTATUS = 0x1C
+    TXSTATUS = 0x14
+
+
+class ReadyStatus(IntEnum):
+    """Enum for READY status CTRLAP register"""
+
+    READY = 0
+    NOT_READY = 1
+
+
+class MailboxStatus(IntEnum):
+    """Enum for mailbox Rx/Tx status CTRLAP register"""
+
+    NO_DATA_PENDING = 0
+    DATA_PENDING = 1
+
+
+class Ctrlap:
+    """Class for performing CTRLAP operations"""
+
+    def __init__(self, **kwargs) -> None:
+        """
+        :param kwargs: dict with wait_time and timeout.
+        Use 'add_arguments(...)' function from this class to add required arguments to
+        the argument parser.
+        """
+        self.connector = JLinkConnector(**kwargs)
+        self.wait_time = kwargs["wait_time"]
+        self.timeout = kwargs["timeout"]
+
+    def wait_for_ready(self) -> None:
+        """Wait until the CTRLAP READY register is ready.
+
+        :raises Exception: If waiting times out.
+        """
+
+        self._block_on_ctrlap_status(CtrlApReg.READY, ReadyStatus.NOT_READY)
+
+    def read(self) -> bytes:
+        """
+        Receive a word from CTRLAP by reading the RX register. Will block until there is
+        data pending.
+
+        :return: The value of CTRLAP.RX
+        """
+
+        self._block_on_ctrlap_status(CtrlApReg.RXSTATUS, MailboxStatus.NO_DATA_PENDING)
+        word = self.connector.access_port_read(CtrlApReg.RXDATA)
+
+        return word.to_bytes(4, "little")
+
+    def write(self, word: bytes) -> None:
+        """
+        Write a word to CTRLAP, block until the data has been read.
+
+        :param word: Word to write
+        """
+
+        val = int.from_bytes(word, byteorder="little")
+        self.connector.access_port_write(CtrlApReg.TXDATA, val)
+        self._block_on_ctrlap_status(CtrlApReg.TXSTATUS, MailboxStatus.DATA_PENDING)
+
+    def _block_on_ctrlap_status(self, reg: CtrlApReg, status: IntEnum) -> None:
+        """
+        Block while waiting for another status
+
+        :param reg: Access port register to check status of
+        :param status: Block while the value of the register equals this value.
+        :raises RuntimeError: if operation times out.
+        """
+
+        start = time()
+        while (self.connector.access_port_read(reg)) == status:
+            if (time() - start) >= self.timeout:
+                raise RuntimeError("Timed out when waiting for CTRLAP status")
+            sleep(self.wait_time)
+
+    @classmethod
+    def add_arguments(cls, parser: ArgumentParser) -> None:
+        """
+        Append command line options needed by this class.
+        """
+
+        group = parser.add_argument_group(
+            title="CTRL-AP connection parameters",
+            description="Use these parameters for communicating with CTRL-AP",
+        )
+        group.add_argument(
+            "--timeout",
+            type=float,
+            default=100,
+            help="Number of seconds to wait for a CTRL-AP register value before timing out",
+        )
+
+        group.add_argument(
+            "--wait-time",
+            type=float,
+            default=0.1,
+            help="Number of seconds to wait between reading the CTRL-AP registers while waiting for a given status",
+        )
+
+        JLinkConnector.add_arguments(parser)

--- a/scripts/sdfw/jlink_connector.py
+++ b/scripts/sdfw/jlink_connector.py
@@ -1,0 +1,107 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+"""
+Module exposing a JLink connection
+"""
+from argparse import ArgumentParser
+
+import pylink
+
+AP_ID_CTRLAP = 4
+AP_BANK_1 = 1
+# Ref ARM ADIv5 B2.2.9 "SELECT, AP Select register"
+DP_SELECT_APSEL_OFFSET = 24
+DP_SELECT_APBANKSEL_OFFSET = 4
+DP_SELECT_CTRLAP_BANK_1 = (AP_ID_CTRLAP << DP_SELECT_APSEL_OFFSET) | (
+    AP_BANK_1 << DP_SELECT_APBANKSEL_OFFSET
+)
+DP_SELECT_ADDR = 0x8
+
+
+class JLinkConnector:
+    """Connect and maintain a JLink connection"""
+
+    def __init__(self, **kwargs) -> None:
+        """
+        :param kwargs: dict with serial, hostname and port
+        Use the `add_arguments(...)` function from this class to add those to
+        your CLI's argument list.
+        """
+
+        self.params = kwargs
+        self._jlink = pylink.JLink()
+
+    def connect(self) -> None:
+        """
+        Open the JLink DLL, configure coresight operations and select the CTRL-AP.
+        """
+        opts = dict()
+
+        if self.params["hostname"]:
+            opts["ip_addr"] = f'{self.params["hostname"]}:{self.params["port"]}'
+        if self.params["serial"]:
+            opts["serial_no"] = self.params["serial"]
+
+        self._jlink.open(**opts)
+        self._jlink.set_tif(pylink.enums.JLinkInterfaces.SWD)
+        self._jlink.coresight_configure()
+
+        # Select CTRL-AP bank 1 with the Debug Port
+        self._jlink.coresight_write(
+            reg=self._get_index_from_address(DP_SELECT_ADDR),
+            data=DP_SELECT_CTRLAP_BANK_1,
+            ap=False,
+        )
+
+    def disconnect(self) -> None:
+        """
+        Disconnect from JLink and close the API.
+        """
+        self._jlink.close()
+
+    def access_port_read(self, register_address: int) -> int:
+        """
+        Read the value of an access port register.
+
+        :return: The value read from the given register index.
+        """
+
+        val = self._jlink.coresight_read(
+            reg=self._get_index_from_address(register_address)
+        )
+        return val
+
+    def access_port_write(self, register_address: int, value: int) -> None:
+        self._jlink.coresight_write(
+            reg=self._get_index_from_address(register_address), data=value
+        )
+
+    @staticmethod
+    def add_arguments(parser: ArgumentParser) -> None:
+        """
+        Append command line options needed by this class.
+        """
+
+        group = parser.add_argument_group(
+            title="JLink connection parameters",
+            description="Use these parameters for connecting to JLink",
+        )
+
+        group.add_argument(
+            "--port",
+            type=int,
+            default=19020,
+            help="Port to use when connecting to J-Link emulator host",
+        )
+
+        group.add_argument("--hostname", type=str, help="J-Link emulator hostname IP")
+
+        group.add_argument("--serial", type=int, help="J-Link emulator serial number")
+
+    @staticmethod
+    def _get_index_from_address(register_address: int) -> int:
+        return register_address // 4

--- a/scripts/sdfw/main.py
+++ b/scripts/sdfw/main.py
@@ -1,0 +1,139 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+"""
+SDFW ADAC CLI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import inspect
+import re
+import typing
+from typing import Any, Dict
+
+import sdfw_adac_cmd
+from ctrlap import Ctrlap
+from sdfw_adac import Adac
+
+
+def main() -> None:
+    args = parse_arguments()
+    do_adac_transaction(**vars(args))
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Send SDFW ADAC commands over CTRL-AP using JLink",
+        allow_abbrev=False,
+    )
+
+    Ctrlap.add_arguments(parser)
+
+    subparsers = parser.add_subparsers(
+        title="ADAC commands", description="Supported SDFW ADAC commands", required=True
+    )
+
+    for request_type in [
+        sdfw_adac_cmd.Version,
+        sdfw_adac_cmd.MemCfg,
+        sdfw_adac_cmd.Revert,
+        sdfw_adac_cmd.Reset,
+        sdfw_adac_cmd.MemErase,
+        sdfw_adac_cmd.LcsGet,
+        sdfw_adac_cmd.LcsSet,
+        sdfw_adac_cmd.Ssf,
+        sdfw_adac_cmd.Purge,
+    ]:
+        add_request_subcommand(subparsers, request_type)
+
+    return parser.parse_args()
+
+
+def add_request_subcommand(subparsers: Any, request_type: type) -> None:
+    """Add a subcommand for doing an ADAC transaction with the given request type.
+    This relies on dataclass introspection/type hints and supports simple dataclasses without
+    nesting and fields with either int, bytes, bool or string types.
+    Each subcommand automatically sets 'request_type' in the parsed arguments to the given
+    request type class.
+    """
+
+    command_name = to_kebab_case(request_type.__name__)
+    command_help = inspect.getdoc(request_type)
+
+    command_parser = subparsers.add_parser(command_name, help=command_help)
+    command_parser.set_defaults(request_type=request_type)
+
+    type_hints = typing.get_type_hints(request_type)
+
+    for field in dataclasses.fields(request_type):
+        arg_name = f"--{to_kebab_case(field.name)}"
+        default_value = (
+            field.default
+            if field.default != dataclasses.MISSING
+            else field.default_factory
+        )
+        is_required = default_value == dataclasses.MISSING
+
+        field_type = type_hints[field.name]
+        type_kwargs: Dict[str, Any] = {}
+
+        if issubclass(int, field_type):
+            type_kwargs["type"] = lambda x: int(x, 0)
+        elif issubclass(bytes, field_type):
+            type_kwargs["type"] = bytes.fromhex
+        elif issubclass(bool, field_type):
+            type_kwargs["action"] = "store_true"
+            is_required = False
+        elif not issubclass(str, field_type):
+            raise ValueError(
+                f"Unsupported field type for {request_type.__name__}.{field.name}: {field_type}"
+            )
+
+        if default_value != dataclasses.MISSING:
+            type_kwargs["default"] = default_value
+
+        command_parser.add_argument(
+            arg_name,
+            dest=field.name,
+            required=is_required,
+            **type_kwargs,
+        )
+
+
+def do_adac_transaction(request_type: type, **kwargs: Any) -> None:
+    """Perform a single ADAC transaction using the given request type."""
+
+    request_fields = {f.name for f in dataclasses.fields(request_type)}
+    request_kwargs = {k: v for k, v in kwargs.items() if k in request_fields}
+    request = request_type(**request_kwargs)
+
+    ctrlap = Ctrlap(**kwargs)
+    adac = Adac(ctrlap)
+
+    adac.ctrlap.connector.connect()
+
+    print(f"--> {request}")
+
+    response = adac.request(request.to_request())
+
+    print(f"<-- {response}")
+
+    adac.ctrlap.connector.disconnect()
+
+
+def to_kebab_case(string: str) -> str:
+    """Convert the given string to kebab case (lowercase-with-hyphens)."""
+
+    string = re.sub("([a-z0-9])([A-Z])", r"\1-\2", string)
+    string = string.replace("_", "-").lower()
+    return string
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sdfw/sdfw_adac.py
+++ b/scripts/sdfw/sdfw_adac.py
@@ -1,0 +1,80 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+"""
+Module for communicating with the SDFW using the ADAC protocol over the CTRLAP interface
+"""
+
+from __future__ import annotations
+
+import struct
+from typing import List
+
+from ctrlap import Ctrlap
+from sdfw_adac_cmd import AdacRequest, AdacResponse, AdacStatus
+
+BYTES_PER_WORD = 4
+
+
+class Adac:
+    """SDFW ADAC connector."""
+
+    def __init__(
+        self,
+        ctrlap: Ctrlap,
+    ) -> None:
+        """
+        :param ctrlap: Used for performing ctrlap operations
+        """
+        self.ctrlap = ctrlap
+
+    def request(self, req: AdacRequest) -> AdacResponse:
+        """
+        Issue an ADAC request and read the response.
+
+        :param req: The ADAC request to execute.
+        :returns: ADAC response.
+        """
+        self.ctrlap.wait_for_ready()
+        self._write_request(req)
+
+        self.ctrlap.wait_for_ready()
+        rsp = self._read_response()
+
+        return rsp
+
+    def _write_request(self, req: AdacRequest) -> None:
+        """
+        Write an ADAC request to CTRL-AP
+
+        :param req: ADAC request.
+        """
+        for word in _to_word_chunks(req.to_bytes()):
+            self.ctrlap.write(word)
+
+    def _read_response(self) -> AdacResponse:
+        """
+        Read a whole ADAC response over CTRL-AP
+
+        :return: ADAC response.
+        """
+        _reserved, status = struct.unpack("<HH", self.ctrlap.read())
+        (data_count,) = struct.unpack("<I", self.ctrlap.read())
+
+        data = bytearray()
+        for _ in range(data_count // BYTES_PER_WORD):
+            data.extend(self.ctrlap.read())
+
+        status_enum = AdacStatus(status)
+
+        return AdacResponse(status=status_enum, data=bytes(data))
+
+
+def _to_word_chunks(data: bytes) -> List[bytes]:
+    num_align_bytes = (4 - (len(data) % 4)) % 4
+    data_word_aligned = data + bytes(num_align_bytes)
+
+    return [data_word_aligned[i: i + BYTES_PER_WORD] for i in range(0, len(data_word_aligned), BYTES_PER_WORD)]

--- a/scripts/sdfw/sdfw_adac_cmd.py
+++ b/scripts/sdfw/sdfw_adac_cmd.py
@@ -1,0 +1,185 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+"""
+SDFW ADAC command structures.
+"""
+
+from __future__ import annotations
+
+import dataclasses as dc
+import struct
+from enum import IntEnum
+
+
+class SdfwAdacCmd(IntEnum):
+    """ADAC command opcodes"""
+
+    VERSION = 0xA300
+    MEM_CFG = 0xA301
+    REVERT = 0xA302
+    RESET = 0xA303
+    MEM_ERASE = 0xA304
+    LCS_GET = 0xA305
+    LCS_SET = 0xA306
+    SSF = 0xA307
+    PURGE = 0xA308
+
+
+@dc.dataclass
+class AdacRequest:
+    """Generic ADAC request"""
+
+    command: SdfwAdacCmd
+    data: bytes = b""
+
+    @property
+    def data_count(self) -> int:
+        return len(self.data)
+
+    def to_bytes(self) -> bytes:
+        header = struct.pack("<HHI", 0, self.command.value, self.data_count)
+        req = header + self.data
+        return req
+
+
+class AdacStatus(IntEnum):
+    """Enum for ADAC response statuses"""
+
+    ADAC_SUCCESS = 0
+    ADAC_FAILURE = 1
+    ADAC_NEED_MORE_DATA = 2
+    ADAC_UNSUPPORTED = 3
+    ADAC_INVALID_COMMAND = 0x7FFF
+
+
+@dc.dataclass
+class AdacResponse:
+    """Generic ADAC response"""
+
+    status: AdacStatus
+    data: bytes
+
+    @property
+    def data_count(self) -> int:
+        return len(self.data)
+
+
+@dc.dataclass
+class Version:
+    """Get version of vendor specific SDFW ADAC commands."""
+
+    type: int
+
+    def to_request(self) -> AdacRequest:
+        return AdacRequest(
+            command=SdfwAdacCmd.VERSION,
+            data=struct.pack("<I", self.type),
+        )
+
+
+@dc.dataclass
+class MemCfg:
+    """Enable memory access for a local domain to a given memory region."""
+
+    domain_id: int
+    address: int
+    length: int
+
+    def to_request(self) -> AdacRequest:
+        return AdacRequest(
+            command=SdfwAdacCmd.MEM_CFG,
+            data=struct.pack("<HHII", self.domain_id, 0, self.address, self.length),
+        )
+
+
+@dc.dataclass
+class Revert:
+    """Revert configuration applied through ADAC."""
+
+    def to_request(self) -> AdacRequest:
+        return AdacRequest(command=SdfwAdacCmd.REVERT)
+
+
+@dc.dataclass
+class Reset:
+    """Reset the whole system or a specific local domain."""
+
+    domain_id: int = 0
+    mode: int = 0
+
+    def to_request(self) -> AdacRequest:
+        return AdacRequest(
+            command=SdfwAdacCmd.RESET,
+            data=struct.pack("<HBB", 0, self.domain_id, self.mode),
+        )
+
+
+@dc.dataclass
+class MemErase:
+    """Erase a memory region. Note that the word size is 16 bytes."""
+
+    address: int
+    num_words: int
+
+    def to_request(self) -> AdacRequest:
+        return AdacRequest(
+            command=SdfwAdacCmd.MEM_ERASE,
+            data=struct.pack("<II", self.address, self.num_words),
+        )
+
+
+@dc.dataclass
+class LcsGet:
+    """Get the LifeCycle State (LCS) of a local domain."""
+
+    domain_id: int
+
+    def to_request(self) -> AdacRequest:
+        return AdacRequest(
+            command=SdfwAdacCmd.LCS_GET, data=struct.pack("<I", self.domain_id)
+        )
+
+
+@dc.dataclass
+class LcsSet:
+    """Set the LifeCycle State (LCS) of a local domain."""
+
+    domain_id: int
+    current: int
+    new: int
+
+    def to_request(self) -> AdacRequest:
+        return AdacRequest(
+            command=SdfwAdacCmd.LCS_SET,
+            data=struct.pack("<III", self.domain_id, self.current, self.new),
+        )
+
+
+@dc.dataclass
+class Ssf:
+    """Send an SSF request."""
+
+    data: bytes
+
+    def to_request(self) -> AdacRequest:
+        return AdacRequest(
+            command=SdfwAdacCmd.SSF,
+            data=self.data,
+        )
+
+
+@dc.dataclass
+class Purge:
+    """Purge a given local domain."""
+
+    domain_id: int
+
+    def to_request(self) -> AdacRequest:
+        return AdacRequest(
+            command=SdfwAdacCmd.PURGE,
+            data=struct.pack("<I", self.domain_id),
+        )

--- a/scripts/sdfw/sdfw_update_service.py
+++ b/scripts/sdfw/sdfw_update_service.py
@@ -1,0 +1,122 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+import argparse
+import enum
+from pathlib import Path
+
+import cbor2
+import zcbor
+from ctrlap import Ctrlap
+from sdfw_adac import Adac
+from ssf_ctrlap import Ssf
+
+SSF_SDFW_UPDATE_SERVICE_ID = 0x69
+SSF_SDFW_UPDATE_SERVICE_VERSION = 1
+CDDL_PATH = str(
+    Path(__file__).absolute().parents[2]
+    / "subsys/sdfw_services/services/sdfw_update/sdfw_update_service.cddl"
+)
+
+try:
+    sdfw_update_service_cddl = zcbor.DataTranslator.from_cddl(
+        open(CDDL_PATH, "r").read(), 16
+    ).my_types["sdfw_update_req"]
+except Exception as e:
+    raise RuntimeError(f"Unable to load CDDL from {CDDL_PATH}") from e
+
+
+class SdfwUpdateStatus(enum.IntEnum):
+    """Enum for SDFW Update service status"""
+
+    SUCCESS = 0
+    UPDATE_FAILED = 0x3dfc0001
+
+
+def get_arguments() -> argparse.Namespace:
+    """
+    Parse command line options.
+
+    :return: argparse arguments.
+    """
+
+    parser = argparse.ArgumentParser(
+        allow_abbrev=False,
+        description="sdfw_update_service invokes the SDFW update service over ADAC.",
+    )
+
+    Ctrlap.add_arguments(parser)
+
+    for param in sdfw_update_service_cddl.value:
+        parser.add_argument(
+            f"--{param.label.replace('_','-')}",
+            type=lambda number_string: int(number_string, 0),
+            required=True,
+            help=f"Value to pass to {param}.",
+        )
+
+    parsed_args = parser.parse_args()
+
+    return parsed_args
+
+
+def create_update_req(**kwargs) -> bytes:
+    """
+    Create an SDFW update service request
+
+    :param blob_addr:
+    :return: The CBOR formatted request
+    """
+
+    write_req_raw = (
+        kwargs["tbs_addr"],
+        kwargs["dl_max"],
+        kwargs["dl_addr_fw"],
+        kwargs["dl_addr_pk"],
+        kwargs["dl_addr_signature"],
+    )
+
+    write_req_cbor = cbor2.dumps(write_req_raw)
+
+    sdfw_update_service_cddl.validate_str(write_req_cbor)
+
+    # Verify that the request was populated as expected
+    decoded = sdfw_update_service_cddl.decode_str(write_req_cbor)
+    assert decoded.tbs_addr == kwargs["tbs_addr"]
+    assert decoded.dl_max == kwargs["dl_max"]
+    assert decoded.dl_addr_fw == kwargs["dl_addr_fw"]
+    assert decoded.dl_addr_pk == kwargs["dl_addr_pk"]
+    assert decoded.dl_addr_signature == kwargs["dl_addr_signature"]
+
+    return write_req_cbor
+
+
+def main() -> None:
+    args = get_arguments()
+
+    cbor_request = create_update_req(**vars(args))
+
+    adac = Adac(Ctrlap(**vars(args)))
+
+    adac.ctrlap.connector.connect()
+
+    ssf = Ssf(
+        adac=adac,
+        service_id=SSF_SDFW_UPDATE_SERVICE_ID,
+        service_version=SSF_SDFW_UPDATE_SERVICE_VERSION,
+    )
+
+    update_retval = ssf.request(service_request=cbor_request)
+
+    print(
+        f"sdfw_update_service: Response status code: {SdfwUpdateStatus(update_retval[0]).name}"
+    )
+
+    adac.ctrlap.connector.disconnect()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sdfw/ssf_ctrlap.py
+++ b/scripts/sdfw/ssf_ctrlap.py
@@ -1,0 +1,87 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+"""
+Module communicating with the SSF (Secure Domain Service Framework)
+using the ADAC protocol over the CTRLAP interface
+"""
+
+from enum import IntEnum
+from typing import Any
+
+import cbor2
+import sdfw_adac_cmd
+from sdfw_adac import Adac
+
+ADAC_SSF_REMOTE_ID = 165
+
+
+class SsfError(IntEnum):
+    """Enum for SSF error messages"""
+
+    SSF_SUCCESS = 0
+    SSF_EPERM = 1
+    SSF_EIO = 5
+    SSF_ENXIO = 6
+    SSF_EAGAIN = 11
+    SSF_ENOMEM = 12
+    SSF_EFAULT = 14
+    SSF_EBUSY = 16
+    SSF_EINVAL = 22
+    SSF_ENODATA = 61
+    SSF_EPROTO = 71
+    SSF_EBADMSG = 77
+    SSF_ENOBUFS = 105
+    SSF_EADDRINUSE = 112
+    SSF_ETIMEDOUT = 116
+    SSF_EALREADY = 120
+    SSF_EMSGSIZE = 122
+    SSF_EPROTONOSUPPORT = 123
+    SSF_ENOTSUP = 134
+
+
+class Ssf:
+    """Execute SSF service requests"""
+
+    def __init__(
+        self,
+        adac: Adac,
+        service_id: int,
+        service_version: int,
+    ) -> None:
+        """
+        :param adac: Used for performing ADAC operations
+        :param service_id: ID of service
+        :param service_version: Version of service.
+        """
+        self.adac = adac
+        self.service_id = service_id
+        self.service_version = service_version
+
+    def request(self, service_request: bytes) -> Any:
+        """
+        Issue an SSF service request and read its response.
+        The generic SSF header is added by this function.
+
+        :param service_request: Service specific CBOR serialized data to write.
+        """
+        ssf_header = cbor2.dumps(
+            (ADAC_SSF_REMOTE_ID, self.service_id, self.service_version)
+        )
+        full_request = ssf_header + service_request
+
+        req = sdfw_adac_cmd.Ssf(full_request).to_request()
+
+        rsp = self.adac.request(req)
+
+        if rsp.status != sdfw_adac_cmd.AdacStatus.ADAC_SUCCESS:
+            raise RuntimeError(f"Got ADAC failure: {rsp.status.name}")
+
+        decoded = cbor2.loads(rsp.data)
+        ssf_response = decoded[0]
+        if ssf_response != SsfError.SSF_SUCCESS:
+            raise RuntimeError(f"SSF operation failed: {SsfError(ssf_response)}")
+        return decoded


### PR DESCRIPTION
Opening this for exposure and discussion.

IMO we should have a single CLI entry point for communicating with SDFW (I guess main.py would suffice for that). And then we should have the option to perform either "sdfw_adac" commands (purge, mem-cfg etc) or "sdfw_ssf" commands (sdfw_update etc). Thoughts on this?

Ref: NCSDK-27391