### PR TITLE
doc: cmake: fix Python check

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -29,7 +29,7 @@ separate_arguments(SPHINXOPTS_EXTRA)
 #-------------------------------------------------------------------------------
 # Dependencies
 
-find_package(PythonInterp 3.4)
+find_package(Python 3.8)
 set(DOXYGEN_SKIP_DOT True)
 find_package(Doxygen 1.8.18 REQUIRED)
 


### PR DESCRIPTION
CMake policy CMP0148 deprecates usage of PythonInterp/Libs in favor of Python/2/3 starting from CMake 3.12. Let's update our CMake, and require the same version Zephyr sets as its minimum.