### PR TITLE
manifest: update Zephyr to fix docs build on Python >= 3.11

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 2f78bc89c92578db48051e54f83f6820f9101909
+      revision: 8e18208ae30e172d05b69bba5908095a561c0794
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Some globbing issues on MAINTAINERS.yml, pulled by some docs extensions, are fixed.