### PR TITLE
suit: allow usage of custom vid/cid

### DIFF
--- a/cmake/sysbuild/suit.cmake
+++ b/cmake/sysbuild/suit.cmake
@@ -237,7 +237,13 @@ function(suit_create_package)
 
   sysbuild_get(DEFAULT_BINARY_DIR IMAGE ${DEFAULT_IMAGE} VAR APPLICATION_BINARY_DIR CACHE)
   # create all storages in the DEFAULT_IMAGE output directory
-  list(APPEND STORAGE_BOOT_ARGS --storage-output-directory "${DEFAULT_BINARY_DIR}/zephyr" --zephyr-base ${ZEPHYR_BASE} ${CORE_ARGS})
+  list(APPEND STORAGE_BOOT_ARGS
+    --storage-output-directory
+    "${DEFAULT_BINARY_DIR}/zephyr"
+    --zephyr-base ${ZEPHYR_BASE}
+    --config-file "${DEFAULT_BINARY_DIR}/zephyr/.config"
+    ${CORE_ARGS}
+  )
   set_property(
     GLOBAL APPEND PROPERTY SUIT_POST_BUILD_COMMANDS
     COMMAND ${PYTHON_EXECUTABLE}

--- a/west.yml
+++ b/west.yml
@@ -239,7 +239,7 @@ manifest:
           upstream-sha: c6eaeda5a1c1c5dbb24dce7e027340cb8893a77b
           compare-by-default: false
     - name: suit-generator
-      revision: 1dfb3fa1676c255c9d19a5c159249b5a7e53c476
+      revision: d49015bfe31d348656f68a3a633321fcb3384f66
       path: modules/lib/suit-generator
     - name: suit-processor
       revision: 5603911b75f037dc3822fd95542c3435c0bf812d


### PR DESCRIPTION
Allow usage of custom vid/cid defined using SUIT MPI settings.

```
west build -b nrf54h20dk/nrf54h20/cpuapp --sysbuild -p -- -DFILE_SUFFIX=bt -DCONFIG_SUIT_MPI_APP_LOCAL_1_CLASS_NAME=\"test_acme_application\" -DCONFIG_SUIT_MPI_RAD_LOCAL_1_CLASS_NAME=\"test_acme_radio\" -DCONFIG_SUIT_MPI_APP_LOCAL_1_VENDOR_NAME=\"acme.com\" -DCONFIG_SUIT_MPI_RAD_LOCAL_1_VENDOR_NAME=\"acme_radio.com\"
```

Ref: NCSDK-27373

Signed-off-by: Robert Stypa <robert.stypa@nordicsemi.no>