### PR TITLE
boards: shields: add support for PCA63566

### DIFF
--- a/boards/shields/pca63566/Kconfig.shield
+++ b/boards/shields/pca63566/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+config SHIELD_PCA63566
+	def_bool $(shields_list_contains,pca63566)

--- a/boards/shields/pca63566/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/boards/shields/pca63566/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,87 @@
+/ {
+	aliases {
+		sensor-bme688 = &i2c130;
+		accel0 = &adxl362;
+		accel-gyro = &bmi270;
+	};
+};
+
+&cpuapp_dma_region {
+	status="okay";
+};
+
+&pinctrl {
+	i2c130_default: i2c130_default {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 2, 8)>,
+				<NRF_PSEL(TWIM_SCL, 2, 3)>;
+				bias-pull-up;
+		};
+	};
+
+	i2c130_sleep: i2c130_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 2, 8)>,
+				<NRF_PSEL(TWIM_SCL, 2, 3)>;
+			low-power-enable;
+			bias-pull-up;
+		};
+	};
+
+	spi130_default: spi130_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_MISO, 1, 6)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 5)>,
+				<NRF_PSEL(SPIM_SCK, 1, 1)>;
+		};
+	};
+
+	spi130_sleep: spi130_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_MISO, 1, 6)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 5)>,
+				<NRF_PSEL(SPIM_SCK, 1, 1)>;
+				low-power-enable;
+		};
+	};
+};
+
+&i2c130 {
+	compatible = "nordic,nrf-twim";
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	pinctrl-0 = <&i2c130_default>;
+	pinctrl-1 = <&i2c130_sleep>;
+	pinctrl-names = "default", "sleep";
+	memory-regions = <&cpuapp_dma_region>;
+	bme688: bme688@76 {
+		compatible = "bosch,bme680";
+		status = "okay";
+		reg = <0x76>;
+	};
+};
+
+&spi130 {
+	status = "okay";
+	pinctrl-0 = <&spi130_default>;
+	pinctrl-1 = <&spi130_sleep>;
+	pinctrl-names = "default", "sleep";
+	cs-gpios = <&gpio0 4 GPIO_ACTIVE_LOW>,
+				<&gpio1 2 GPIO_ACTIVE_LOW>;
+
+
+	bmi270: bmi270@0 {
+		compatible = "bosch,bmi270";
+		status = "okay";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(8)>;
+	};
+
+	adxl362: adxl362@1 {
+		compatible = "adi,adxl362";
+		status = "okay";
+		reg = <1>;
+		int1-gpios = <&gpio1 8 (GPIO_ACTIVE_HIGH)>;
+		spi-max-frequency = <DT_FREQ_M(8)>;
+	};
+};

--- a/boards/shields/pca63566/doc/index.rst
+++ b/boards/shields/pca63566/doc/index.rst
@@ -1,0 +1,25 @@
+.. _pca63566:
+
+PCA63566 shield
+###############
+
+Overview
+********
+
+PCA63566 is a testing shield with sensors and transceivers:
+- temperature,
+- humidity,
+- pressure,
+- accelerometer,
+- CAN transceiver
+It is targeted for testing I2C, I3C, SPI and CAN protocols drivers.
+
+Requirements
+************
+
+This shield is pin compatible with nrf54h20dk.
+
+Usage
+*****
+
+The shield can be used in any application by setting ``SHIELD`` to ``pca63566``.

--- a/boards/shields/pca63566/pca63566.overlay
+++ b/boards/shields/pca63566/pca63566.overlay
@@ -1,0 +1,4 @@
+/*
+ * Copyright (C) 2024 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */


### PR DESCRIPTION
Add PCA63566 teting shield with env. sensors and CAN transceiver