### PR TITLE
manifest: update sdk-zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 987b5d17c3db527e91eb7d7677b021b47fda6980
+      revision: 7f128a1027b50b69f5a69cfd8f01c093302f1a50
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Add missing WDT instances on nrf54h20.
Enable execution of tests/drivers/watchdog/wdt_error_cases on nrf54h20 Application and Radio cores.

Include changes from
https://github.com/nrfconnect/sdk-zephyr/pull/1695