### PR TITLE
samples: bluetooth: fast_pair: add note about device type in readme

### DIFF
--- a/doc/nrf/external_comp/bt_fast_pair.rst
+++ b/doc/nrf/external_comp/bt_fast_pair.rst
@@ -116,7 +116,7 @@ See the following samples and applications for details about the debug Fast Pair
 Device type
 -----------
 
-When registering the device in the Google Nearby Devices console, go to the **Fast Pair** protocol configuration panel, and in the **Device Type** field select an option that matches your application's use case.
+When registering the device in the Google Nearby Devices console, go to the **Fast Pair** protocol configuration panel, and in the **Device Type** list select an option that matches your application's use case.
 The chosen device type also determines the optional feature set that you can support in your use case.
 You declare support for each feature by selecting the **true** option.
 

--- a/samples/bluetooth/fast_pair/input_device/README.rst
+++ b/samples/bluetooth/fast_pair/input_device/README.rst
@@ -60,6 +60,10 @@ Fast Pair device registration
 Before you can use your device as a Fast Pair Provider, the device model must be registered with Google.
 This is required to obtain Model ID and Anti-Spoofing Private Key.
 You can register your own device or use the debug Model ID and Anti-Spoofing Public/Private Key pair obtained by Nordic for development purposes.
+
+.. note::
+   To support the input device use case, you must select :guilabel:`Input Device` option in the **Device Type** list when registering your device model.
+
 By default, if Model ID and Anti-Spoofing Private Key are not specified, the following debug Fast Pair provider is used:
 
 * NCS input device - The input device Fast Pair provider:


### PR DESCRIPTION
Added a note about selecting the input device option in the Device Type field during device model registration in the Google Nearby console.