### PR TITLE
scripts: sbom: only process package if its name and version are not None

### DIFF
--- a/scripts/west_commands/sbom/output_pre_process.py
+++ b/scripts/west_commands/sbom/output_pre_process.py
@@ -101,12 +101,14 @@ def pre_process(data: Data):
             package.name = package.url[offs:]
             if package.name.endswith('.git'):
                 package.name = package.name[:-4]
-        if package.name in package_name_map:
-            existing = package_name_map[package.name]
-            del package_name_map[package.name]
-            package.name += '-' + package.version
-            existing.name += '-' + existing.version
-            package_name_map[existing.name] = existing
-        package_name_map[package.name] = package
+        if package.name is not None:
+            package_name = package.name
+            if package_name in package_name_map:
+                existing = package_name_map[package_name]
+                del package_name_map[package_name]
+                existing_new_name = f"{existing.name}-{existing.version}"
+                package_name_map[existing_new_name] = existing
+                package_name = f"{package_name}-{package.version}"
+            package_name_map[package_name] = package
         if (package.browser_url is None) and (package.url.startswith('http')):
             package.browser_url = package.url


### PR DESCRIPTION
When running `west ncs-sbom -d build` on my firmware build folder I received the following error that prevented the output HTML SBOM from being generated.

```
WARNING: Fetching input files from a build directory is experimental for now.
WARNING: Command "git" reported errors:
fatal: not a git repository (or any of the parent directories): .git

WARNING: Command "git" reported errors:
fatal: not a git repository (or any of the parent directories): .git

WARNING: Directory "../../../ncs/toolchains/2be090971e/opt/zephyr-sdk/arm-zephyr-eabi/picolibc/include/sys" does not provide valid git remote information.
WARNING: Command "git" reported errors:
fatal: not a git repository (or any of the parent directories): .git

WARNING: Command "git" reported errors:
fatal: not a git repository (or any of the parent directories): .git

WARNING: Directory "../../../ncs/toolchains/2be090971e/opt/zephyr-sdk/arm-zephyr-eabi/picolibc/include/machine" does not provide valid git remote information.
WARNING: Command "git" reported errors:
fatal: not a git repository (or any of the parent directories): .git

WARNING: Command "git" reported errors:
fatal: not a git repository (or any of the parent directories): .git

WARNING: Directory "../../../ncs/toolchains/2be090971e/opt/zephyr-sdk/arm-zephyr-eabi/lib/gcc/arm-zephyr-eabi/12.2.0/thumb/v7e-m/nofp" does not provide valid git remote information.
WARNING: Command "git" reported errors:
fatal: not a git repository (or any of the parent directories): .git

WARNING: Command "git" reported errors:
fatal: not a git repository (or any of the parent directories): .git

WARNING: Directory "../../../ncs/toolchains/2be090971e/opt/zephyr-sdk/arm-zephyr-eabi/picolibc/include" does not provide valid git remote information.
WARNING: Command "git" reported errors:
fatal: not a git repository (or any of the parent directories): .git

WARNING: Command "git" reported errors:
fatal: not a git repository (or any of the parent directories): .git

WARNING: Directory "../../../ncs/toolchains/2be090971e/opt/zephyr-sdk/arm-zephyr-eabi/picolibc/include/ssp" does not provide valid git remote information.
WARNING: Command "git" reported errors:
fatal: not a git repository (or any of the parent directories): .git

WARNING: Command "git" reported errors:
fatal: not a git repository (or any of the parent directories): .git

WARNING: Directory "../../../ncs/toolchains/2be090971e/opt/zephyr-sdk/arm-zephyr-eabi/lib/gcc/arm-zephyr-eabi/12.2.0/include" does not provide valid git remote information.
WARNING: Command "git" reported errors:
fatal: not a git repository (or any of the parent directories): .git

WARNING: Command "git" reported errors:
fatal: not a git repository (or any of the parent directories): .git

WARNING: Directory "../../../ncs/toolchains/2be090971e/opt/zephyr-sdk/arm-zephyr-eabi/lib/gcc/arm-zephyr-eabi/12.2.0/include-fixed" does not provide valid git remote information.
WARNING: Command "git" reported errors:
fatal: not a git repository (or any of the parent directories): .git

WARNING: Command "git" reported errors:
fatal: not a git repository (or any of the parent directories): .git

WARNING: Directory "../../../ncs/toolchains/2be090971e/opt/zephyr-sdk/arm-zephyr-eabi/picolibc/arm-zephyr-eabi/lib/thumb/v7e-m/nofp" does not provide valid git remote information.
Traceback (most recent call last):
  File "/home/david/ncs/toolchains/2be090971e/usr/local/bin/west", line 8, in <module>
    sys.exit(main())
  File "/home/david/ncs/toolchains/2be090971e/usr/local/lib/python3.9/site-packages/west/app/main.py", line 1085, in main
    app.run(argv or sys.argv[1:])
  File "/home/david/ncs/toolchains/2be090971e/usr/local/lib/python3.9/site-packages/west/app/main.py", line 244, in run
    self.run_command(argv, early_args)
  File "/home/david/ncs/toolchains/2be090971e/usr/local/lib/python3.9/site-packages/west/app/main.py", line 505, in run_command
    self.run_extension(args.command, argv)
  File "/home/david/ncs/toolchains/2be090971e/usr/local/lib/python3.9/site-packages/west/app/main.py", line 654, in run_extension
    self.cmd.run(args, unknown, self.topdir, manifest=self.manifest,
  File "/home/david/ncs/toolchains/2be090971e/usr/local/lib/python3.9/site-packages/west/commands.py", line 194, in run
    self.do_run(args, unknown)
  File "/home/david/ws/ms3/ms3-firmware-workspace/nrf/scripts/west_commands/sbom/ncs_sbom_command.py", line 31, in do_run
    main.main()
  File "/home/david/ws/ms3/ms3-firmware-workspace/nrf/scripts/west_commands/sbom/main.py", line 70, in main
    output_pre_process.pre_process(data)
  File "/home/david/ws/ms3/ms3-firmware-workspace/nrf/scripts/west_commands/sbom/output_pre_process.py", line 107, in pre_process
    package.name += '-' + package.version
TypeError: unsupported operand type(s) for +=: 'NoneType' and 'str'
```

With the PR changes we make sure to only process the package if its name and version aren't None.