### PR TITLE
samples: cellular: modem_shell: Reconfigure location status LEDs for DKs

### DIFF
--- a/samples/cellular/modem_shell/README.rst
+++ b/samples/cellular/modem_shell/README.rst
@@ -929,12 +929,23 @@ LED indications
 
 The LEDs have the following functions:
 
-LED 1 (nRF91 Series DKs)/Purple LED (Thingy:91):
-   Lit for five seconds when the current location has been successfully retrieved by using the ``location get`` command.
-LED 2 (nRF91 Series DKs):
-   Indicates the state of the GPIO pin when pulse counting has been enabled using the ``gpio_count enable`` command.
-LED 3 (nRF91 Series DKs)/Blue LED (Thingy:91):
-   Indicates the LTE registration status.
+nRF91 Series DKs:
+
+* **LED 2** indicates the state of the GPIO pin when pulse counting has been enabled using the ``gpio_count enable`` command.
+* **LED 3** indicates the LTE registration status.
+* **LED 4** is lit for five seconds when the current location has been successfully retrieved by using the ``location get`` command.
+
+Thingy:91 and Thingy:91 X RGB LED:
+
+* LTE connected:
+
+  * Default state constant blue.
+  * Lit purple for five seconds when the current location has been successfully retrieved by using the ``location get`` command.
+
+* LTE disconnected:
+
+  * Default state OFF.
+  * Lit red for five seconds when the current location has been successfully retrieved by using the ``location get`` command.
 
 Power measurements
 ==================

--- a/samples/cellular/modem_shell/src/mosh_defines.h
+++ b/samples/cellular/modem_shell/src/mosh_defines.h
@@ -21,7 +21,15 @@ enum mosh_signals {
 	MOSH_SIGNAL_KILL,
 };
 
+/* For location status indication, use LED1 for Thingy:91 or Thingy:91 X, and LED4 for DKs.
+ * Connecting an nRF7002 EK to nRF9151 or nRF9161 DK causes GPIO conflict with LED1 and Button 1.
+ */
+#if defined(CONFIG_BOARD_THINGY91_NRF9160_NS) || defined(CONFIG_BOARD_THINGY91X_NRF9151_NS)
 #define LOCATION_STATUS_LED            DK_LED1
+#else
+#define LOCATION_STATUS_LED            DK_LED4
+#endif
+
 #define GPIO_STATUS_LED                DK_LED2
 #define REGISTERED_STATUS_LED          DK_LED3
 


### PR DESCRIPTION
Connecting an nRF7002 EK to nRF9151/nRF9161 DK causes GPIO conflict between LED1 and Button 1. To indicate location status on a DK, use LED4 instead.