### PR TITLE
samples: matter: Switch VCOM to the default UART20 on nRF54L15 PDK

### DIFF
--- a/samples/matter/light_bulb/boards/nrf54l15pdk_nrf54l15_cpuapp_0_2_1.overlay
+++ b/samples/matter/light_bulb/boards/nrf54l15pdk_nrf54l15_cpuapp_0_2_1.overlay
@@ -5,11 +5,6 @@
  */
 
 / {
-	chosen {
-		zephyr,console = &uart30;
-		zephyr,shell-uart = &uart30;
-	};
-
 	aliases {
 		factory-data = &factory_data;
 		factory-data-memory-region = &rram0;
@@ -54,10 +49,6 @@
 			};
 		};
 	};
-};
-
-&uart30 {
-	status = "okay";
 };
 
 &pwm20 {

--- a/samples/matter/light_bulb/boards/nrf54l15pdk_nrf54l15_cpuapp_0_3_0.overlay
+++ b/samples/matter/light_bulb/boards/nrf54l15pdk_nrf54l15_cpuapp_0_3_0.overlay
@@ -6,11 +6,6 @@
 
 
 / {
-	chosen {
-		zephyr,console = &uart30;
-		zephyr,shell-uart = &uart30;
-	};
-
 	aliases {
 		factory-data = &factory_data;
 		factory-data-memory-region = &rram0;
@@ -55,10 +50,6 @@
 			};
 		};
 	};
-};
-
-&uart30 {
-	status = "okay";
 };
 
 &pwm20 {

--- a/samples/matter/light_switch/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
+++ b/samples/matter/light_switch/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
@@ -5,11 +5,6 @@
  */
 
 / {
-	chosen {
-		zephyr,console = &uart30;
-		zephyr,shell-uart = &uart30;
-	};
-
 	aliases {
 		factory-data = &factory_data;
 		factory-data-memory-region = &rram0;
@@ -44,10 +39,6 @@
 			};
 		};
 	};
-};
-
-&uart30 {
-	status = "okay";
 };
 
 &wdt30 {

--- a/samples/matter/template/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
+++ b/samples/matter/template/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
@@ -5,11 +5,6 @@
  */
 
 / {
-	chosen {
-		zephyr,console = &uart30;
-		zephyr,shell-uart = &uart30;
-	};
-
 	aliases {
 		factory-data = &factory_data;
 		factory-data-memory-region = &rram0;
@@ -44,10 +39,6 @@
 			};
 		};
 	};
-};
-
-&uart30 {
-	status = "okay";
 };
 
 &wdt30 {

--- a/samples/matter/thermostat/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
+++ b/samples/matter/thermostat/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
@@ -5,11 +5,6 @@
  */
 
 / {
-	chosen {
-		zephyr,console = &uart30;
-		zephyr,shell-uart = &uart30;
-	};
-
 	aliases {
 		factory-data = &factory_data;
 		factory-data-memory-region = &rram0;
@@ -44,10 +39,6 @@
 			};
 		};
 	};
-};
-
-&uart30 {
-	status = "okay";
 };
 
 &wdt30 {

--- a/samples/matter/window_covering/boards/nrf54l15pdk_nrf54l15_cpuapp_0_2_1.overlay
+++ b/samples/matter/window_covering/boards/nrf54l15pdk_nrf54l15_cpuapp_0_2_1.overlay
@@ -5,11 +5,6 @@
  */
 
 / {
-	chosen {
-		zephyr,console = &uart30;
-		zephyr,shell-uart = &uart30;
-	};
-
 	aliases {
 		factory-data = &factory_data;
 		factory-data-memory-region = &rram0;
@@ -58,10 +53,6 @@
 			};
 		};
 	};
-};
-
-&uart30 {
-	status = "okay";
 };
 
 &pwm20 {

--- a/samples/matter/window_covering/boards/nrf54l15pdk_nrf54l15_cpuapp_0_3_0.overlay
+++ b/samples/matter/window_covering/boards/nrf54l15pdk_nrf54l15_cpuapp_0_3_0.overlay
@@ -5,11 +5,6 @@
  */
 
 / {
-	chosen {
-		zephyr,console = &uart30;
-		zephyr,shell-uart = &uart30;
-	};
-
 	aliases {
 		factory-data = &factory_data;
 		factory-data-memory-region = &rram0;
@@ -58,10 +53,6 @@
 			};
 		};
 	};
-};
-
-&uart30 {
-	status = "okay";
 };
 
 &pwm20 {


### PR DESCRIPTION
Disable previously used UART30 and switch to the default UART20. It means that from now the second port of the PDK's VCOM will be in use.