### PR TITLE
mgmt: prevent unbound printing of URI string

### DIFF
--- a/subsys/mgmt/suitfu/src/suitfu_mgmt_suit_image_fetch.c
+++ b/subsys/mgmt/suitfu/src/suitfu_mgmt_suit_image_fetch.c
@@ -61,7 +61,7 @@ static suit_plat_err_t suitfu_mgmt_suit_missing_image_request(const uint8_t *uri
 	stream_session_t *session = &stream_session;
 	int64_t current_ts = k_uptime_get();
 
-	LOG_INF("Request for image: %s", uri);
+	LOG_HEXDUMP_INF(uri, uri_length, "Request for image");
 
 	if (strncmp(uri, "file://", strlen("file://"))) {
 		return SUIT_PLAT_ERR_NOT_FOUND;


### PR DESCRIPTION
The URI string is not null-terminated, which results in non-printable characters being transmitted over UART. Use the hexdump log function to print the URI instead.