### PR TITLE
applications: nrf5340_audio: Enable RTC timer in audio sync module

### DIFF
--- a/applications/nrf5340_audio/src/modules/audio_sync_timer_rtc.c
+++ b/applications/nrf5340_audio/src/modules/audio_sync_timer_rtc.c
@@ -215,7 +215,7 @@ static int audio_sync_timer_init(void)
 		return -ENOMEM;
 	}
 
-	nrf_rtc_subscribe_set(audio_sync_lf_timer_instance.p_reg, NRF_RTC_TASK_START,
+	nrf_rtc_subscribe_set(audio_sync_lf_timer_instance.p_reg, NRF_RTC_TASK_CLEAR,
 			      dppi_channel_rtc_start);
 	nrf_timer_subscribe_set(audio_sync_hf_timer_instance.p_reg, NRF_TIMER_TASK_START,
 				dppi_channel_rtc_start);
@@ -249,6 +249,8 @@ static int audio_sync_timer_init(void)
 		LOG_ERR("nrfx DPPI channel enable error (timer clear): %d", ret);
 		return -EIO;
 	}
+
+	nrfx_rtc_enable(&audio_sync_lf_timer_instance);
 
 	LOG_DBG("Audio sync timer initialized");
 


### PR DESCRIPTION
After manifest commit 17b4dc7 Zephyr drivers enables the network core twice for bluetooth applications: once by board cpunet reset file, once by HCI driver (nrf53_support.c). The HCI driver uses the cpunet management module which assumes multiple calls to enable function will enable cpunet only once, but as the board cpunet reset doesn't use the management module the network core is started twice which causes application and SDC to have different time references. This change ensures both cores have the sme time reference, and is a workaround while issue is being handled upstream.

OCT-3026