### PR TITLE
net: lib: nrf_cloud_coap: expose CoAP transport functions

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -808,7 +808,10 @@ Libraries for networking
 
   * Updated to request proprietary PSM mode for ``SOC_NRF9151_LACA`` and ``SOC_NRF9131_LACA`` in addition to ``SOC_NRF9161_LACA``.
 
-  * Added the :c:func:`nrf_cloud_coap_shadow_desired_update` function to allow devices to reject invalid shadow deltas.
+  * Added:
+
+    * The :c:func:`nrf_cloud_coap_shadow_desired_update` function to allow devices to reject invalid shadow deltas.
+    * Support for IPv6 connections.
 
 * :ref:`lib_lwm2m_client_utils` library:
 

--- a/include/net/nrf_cloud_coap.h
+++ b/include/net/nrf_cloud_coap.h
@@ -59,6 +59,7 @@ int nrf_cloud_coap_init(void);
  *           Negative values are device-side errors defined in errno.h.
  *           Positive values are cloud-side errors (CoAP result codes)
  *           defined in zephyr/net/coap.h.
+ * @retval -EACCES if @ref nrf_cloud_coap_init has not been called.
  */
 int nrf_cloud_coap_connect(const char * const app_ver);
 

--- a/samples/cellular/nrf_cloud_multi_service/src/shadow_support_coap.c
+++ b/samples/cellular/nrf_cloud_multi_service/src/shadow_support_coap.c
@@ -23,6 +23,10 @@ LOG_MODULE_REGISTER(shadow_support_coap, CONFIG_MULTI_SERVICE_LOG_LEVEL);
 
 static int process_delta(struct nrf_cloud_data *const delta)
 {
+	if (delta->len == 0) {
+		return -ENODATA;
+	}
+
 	int err;
 	bool update_desired = false;
 	struct nrf_cloud_obj delta_obj = {0};
@@ -86,14 +90,13 @@ static int check_shadow(void)
 	}
 
 	in_data.len = strlen(buf);
-	if (in_data.len) {
-		err = process_delta(&in_data);
-		if (err == -ENODATA) {
-			/* There was no application specific delta data to process.
-			 * Return -EAGAIN so the thread sleeps for a longer duration.
-			 */
-			err = -EAGAIN;
-		}
+
+	err = process_delta(&in_data);
+	if (err == -ENODATA) {
+		/* There was no application specific delta data to process.
+		 * Return -EAGAIN so the thread sleeps for a longer duration.
+		 */
+		err = -EAGAIN;
 	}
 
 	if (!config_sent) {

--- a/subsys/net/lib/nrf_cloud/coap/include/nrf_cloud_coap_transport.h
+++ b/subsys/net/lib/nrf_cloud/coap/include/nrf_cloud_coap_transport.h
@@ -58,7 +58,8 @@ int nrf_cloud_coap_transport_init(struct nrf_cloud_coap_client *const client);
 /**@brief Connect to the cloud.
  *
  * @param client Client to connect.
- *
+
+ * @retval 1 Socket is already open.
  * @return 0 if successful, otherwise a negative error code.
  */
 int nrf_cloud_coap_transport_connect(struct nrf_cloud_coap_client *const client);

--- a/subsys/net/lib/nrf_cloud/coap/include/nrf_cloud_coap_transport.h
+++ b/subsys/net/lib/nrf_cloud/coap/include/nrf_cloud_coap_transport.h
@@ -32,10 +32,82 @@ enum coap_content_format {
 };
 #endif
 
+struct nrf_cloud_coap_client {
+	struct coap_client cc;
+	int sock;
+	bool initialized;
+	bool authenticated;
+	bool cid_saved;
+};
+
+#define NRF_CLOUD_COAP_PROXY_RSC "proxy"
+
 /**
  * @defgroup nrf_cloud_coap_transport nRF CoAP API
  * @{
  */
+
+/**@brief Initialize the provided nrf_cloud_coap_client.
+ *
+ * @param client Client to initialize.
+ *
+ * @return 0 if successful, otherwise a negative error code.
+ */
+int nrf_cloud_coap_transport_init(struct nrf_cloud_coap_client *const client);
+
+/**@brief Connect to the cloud.
+ *
+ * @param client Client to connect.
+ *
+ * @return 0 if successful, otherwise a negative error code.
+ */
+int nrf_cloud_coap_transport_connect(struct nrf_cloud_coap_client *const client);
+
+/**@brief Disconnect from the cloud.
+ *
+ * @param client Client to disconnect.
+ *
+ * @return 0 if successful, otherwise a negative error code.
+ */
+int nrf_cloud_coap_transport_disconnect(struct nrf_cloud_coap_client *const client);
+
+/**@brief Perform authentication with the cloud.
+ *
+ * @param client Client to authenticate.
+ *
+ * @retval -ENOTCONN Client is not connected.
+ * @return 0 if successful, otherwise a negative error code.
+ */
+int nrf_cloud_coap_transport_authenticate(struct nrf_cloud_coap_client *const client);
+
+/**@brief Pause the CoAP connection.
+ *
+ * @param client Client to pause.
+ *
+ * @return 0 if successful, otherwise a negative error code.
+ */
+int nrf_cloud_coap_transport_pause(struct nrf_cloud_coap_client *const client);
+
+/**@brief Resume a paused CoAP connection.
+ *
+ * @param client Client to resume.
+ *
+ * @return 0 if successful, otherwise a negative error code.
+ */
+int nrf_cloud_coap_transport_resume(struct nrf_cloud_coap_client *const client);
+
+/**@brief Get the CoAP options required to perform a proxy download.
+ *
+ * @param opt_accept	Option to be populated with COAP_OPTION_ACCEPT details.
+ * @param opt_proxy_uri	Option to be populated with COAP_OPTION_PROXY_URI details.
+ * @param host		Download host.
+ * @param path		Download file path.
+ *
+ * @return 0 if successful, otherwise a negative error code.
+ */
+int nrf_cloud_coap_transport_proxy_dl_opts_get(struct coap_client_option *const opt_accept,
+					       struct coap_client_option *const opt_proxy_uri,
+					       char const *const host, char const *const path);
 
 /**@brief Check if device is connected and authorized to use nRF Cloud CoAP.
  *


### PR DESCRIPTION
Expose transport functions so that external coap_client instances can be used with nRF Cloud.
IRIS-8806