### PR TITLE
drivers: wifi: Fix initialization of extended capabilities length

### DIFF
--- a/drivers/wifi/nrf700x/src/wpa_supp_if.c
+++ b/drivers/wifi/nrf700x/src/wpa_supp_if.c
@@ -1779,6 +1779,8 @@ int nrf_wifi_supp_get_capa(void *if_priv, struct wpa_driver_capa *capa)
 		return -1;
 	}
 
+	memset(capa, 0, sizeof(*capa));
+
 	vif_ctx_zep = if_priv;
 	rpu_ctx_zep = vif_ctx_zep->rpu_ctx_zep;
 	if (!rpu_ctx_zep) {
@@ -1793,7 +1795,6 @@ int nrf_wifi_supp_get_capa(void *if_priv, struct wpa_driver_capa *capa)
 	}
 
 	/* TODO: Get these from RPU*/
-	memset(capa, 0, sizeof(*capa));
 	/* Use SME */
 	capa->flags = 0;
 	capa->flags |= WPA_DRIVER_FLAGS_SME;


### PR DESCRIPTION
In case RPU is uninitialized e.g., FW loading failure, then WPA supplicant gets uninitialized extended capabilities from the driver.

Though this doesn't affect directly, but can cause issue without boundary checks. Initialized before the error checks.

Fixes SHEL-2763.