### PR TITLE
boards: nordic: nrf7002dk: align nRF7001 shared SRAM

### DIFF
--- a/boards/nordic/nrf7002dk/nrf5340_nrf7001_shared_sram_planning_conf.dtsi
+++ b/boards/nordic/nrf7002dk/nrf5340_nrf7001_shared_sram_planning_conf.dtsi
@@ -22,9 +22,9 @@
 		#size-cells = <1>;
 		ranges;
 
-		sram0_shared: memory@20070010 {
+		sram0_shared: memory@20070000 {
 			/* SRAM allocated to shared memory */
-			reg = <0x20070010 0x10000>;
+			reg = <0x20070000 0x10000>;
 		};
 	};
 };


### PR DESCRIPTION
Align nRF7001 shared SRAM to fix crashes that occur immediately when running samples/wifi/shell with OpenThread overlay applied.