### PR TITLE
extmem: remote improvements

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -276,6 +276,7 @@ Kconfig*                                  @tejlmand
 /subsys/nrf_profiler/                     @pdunaj
 /subsys/shell/                            @nordic-krch
 /subsys/sdfw_services/                    @anhmolt @hakonfam @jonathannilsen
+/subsys/sdfw_services/services/extmem/    @e-rk @tomchy
 /subsys/suit/                             @tomchy @ahasztag
 /subsys/nrf_security/                     @frkv @Vge0rge @vili-nordic @SebastianBoe @mswarowsky
 /subsys/trusted_storage/                  @frkv @Vge0rge @vili-nordic @SebastianBoe @mswarowsky

--- a/subsys/suit/stream/address_streamer_selector/src/suit_address_streamer_selector.c
+++ b/subsys/suit/stream/address_streamer_selector/src/suit_address_streamer_selector.c
@@ -38,12 +38,6 @@ struct stream_iface {
 };
 
 const struct stream_iface ifaces[] = {
-#if IS_ENABLED(CONFIG_SUIT_STREAM_SOURCE_EXTMEM)
-	{
-		.stream = suit_extmem_streamer_stream,
-		.address_check = suit_extmem_streamer_address_in_range
-	},
-#endif
 #if IS_ENABLED(CONFIG_SUIT_STREAM_SOURCE_FLASH)
 	{
 		.stream = suit_flash_streamer_stream,
@@ -54,6 +48,12 @@ const struct stream_iface ifaces[] = {
 	{
 		.stream = suit_memptr_streamer_stream,
 		.address_check = suit_memptr_streamer_address_in_range
+	},
+#endif
+#if IS_ENABLED(CONFIG_SUIT_STREAM_SOURCE_EXTMEM)
+	{
+		.stream = suit_extmem_streamer_stream,
+		.address_check = suit_extmem_streamer_address_in_range
 	},
 #endif
 };


### PR DESCRIPTION
Added cache operations to the extmem service to ensure no loss or out-of-date data.
Re-ordered stream sources to ensure that the extmem, which has the highest overhead and lowest probability of being used compared to other sources, is the last source checked.