### PR TITLE
nrf_security: Increase range of PSA key slots

### DIFF
--- a/subsys/nrf_security/Kconfig.psa
+++ b/subsys/nrf_security/Kconfig.psa
@@ -67,7 +67,7 @@ config MBEDTLS_USE_PSA_CRYPTO
 config MBEDTLS_PSA_KEY_SLOT_COUNT
 	int "Number of PSA key slots available"
 	default 32
-	range 1 64
+	range 1 65535
 	help
 	  Describes the number of available PSA key slots. A key slot is used in PSA
 	  for each transparent key in use. So this number defines the sum of volatile and


### PR DESCRIPTION
Increase the range of the available PSA slots because some use cases require more than 64. The maximum number is an educated guess, I don't expect that any application will need more than 65K keys in our devices.