### PR TITLE
manifest: update sdk-zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: bd660a463f3fd9ae9f5e74a33435eba30d19b929
+      revision: 07150bdfdb9edccf052d1aa16b34ec4c88691e4f
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull in support for watchdog on nrf54h20.
https://github.com/nrfconnect/sdk-zephyr/pull/1712