### PR TITLE
doc: move a misplaced changelog entry

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -519,9 +519,7 @@ Matter samples
 Multicore samples
 -----------------
 
-* :ref:`ipc_service_sample` sample:
-
-  * Removed support for the `OpenAMP`_ library backend on the :ref:`zephyr:nrf54h20dk_nrf54h20` board.
+|no_changes_yet_note|
 
 Networking samples
 ------------------
@@ -643,6 +641,10 @@ Other samples
 
 * Added the :ref:`coremark_sample` sample that demonstrates how to easily measure a performance of the supported SoCs by running the Embedded Microprocessor Benchmark Consortium (EEMBC) CoreMark benchmark.
   Included support for the nRF52840 DK, nRF5340 DK, and nRF54L15 PDK.
+
+* :ref:`ipc_service_sample` sample:
+
+  * Removed support for the `OpenAMP`_ library backend on the :ref:`zephyr:nrf54h20dk_nrf54h20` board.
 
 Drivers
 =======


### PR DESCRIPTION
The changelog entry related to IPC service sample
was misplaced under Multicore samples.
Moved it to the proper location under Other samples.