### PR TITLE
manifest: Pull in sdk-zephyr with uart_elementary update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 987b5d17c3db527e91eb7d7677b021b47fda6980
+      revision: aa69cb93da07e9402e551bd912ded090581e7700
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull in updates of the 'tests/drivers/uart_elementary' suite