### PR TITLE
applications: nrf5340_audio: Audio lost when other headset disconnects

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_client.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_client.c
@@ -1171,7 +1171,9 @@ static void stream_released_cb(struct bt_bap_stream *stream)
 
 	/* Check if the other streams are streaming, send event if not */
 	for (int i = 0; i < ARRAY_SIZE(headsets); i++) {
-		if (le_audio_ep_state_check(headsets[i].source_stream.ep,
+		if (le_audio_ep_state_check(headsets[i].sink_stream.ep,
+					    BT_BAP_EP_STATE_STREAMING) ||
+		    le_audio_ep_state_check(headsets[i].source_stream.ep,
 					    BT_BAP_EP_STATE_STREAMING)) {
 			return;
 		}


### PR DESCRIPTION
OCT-3008

For the stereo disconnection stress test, the headset which does not disconnect looses audio when the disconnecting headset disconnects, and never resumes audio. This was due to not testing if any of the other sinks were still streaming in the stream_released_cb().