### PR TITLE
manifest: Pull in sdk-zephyr with new i2c tests

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 987b5d17c3db527e91eb7d7677b021b47fda6980
+      revision: pull/1715/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull in - Extend coverage for the i2c master mode driver This test suite uses external sensor BME688