### PR TITLE
tests: drivers: Add alt config for 'tests/drivers/i2c/i2c_bme688'

### DIFF
--- a/scripts/twister/alt/zephyr/tests/drivers/i2c/i2c_bme688/testcase.yaml
+++ b/scripts/twister/alt/zephyr/tests/drivers/i2c/i2c_bme688/testcase.yaml
@@ -1,0 +1,19 @@
+common:
+  tags: drivers i2c
+  depends_on: i2c
+  harness: ztest
+tests:
+  drivers.i2c.bme688_nrf54l:
+    harness_config:
+      fixture: pca63565
+    extra_args:
+      - SHIELD=pca63565
+    platform_allow:
+      - nrf54l15pdk/nrf54l15/cpuapp
+  drivers.i2c.bme688_nrf54h:
+    harness_config:
+      fixture: pca63566
+    extra_args:
+      - SHIELD=pca63566
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp


### PR DESCRIPTION
'i2c_bme688' is an upstream test
which requires NRF internal SHIELD.
