### PR TITLE
lib: at_monitor: use dedicated workqueue

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -751,6 +751,10 @@ DFU libraries
 Modem libraries
 ---------------
 
+* :ref:`at_monitor_readme`:
+
+  * Added the :kconfig:option:`CONFIG_AT_MONITOR_USE_DEDICATED_WORKQUEUE` to dispatch AT notifications from a dedicated workqueue, instead of the system workqueue. This is option enabled by default.
+
 * :ref:`nrf_modem_lib_readme`:
 
   * Fixed an issue with the CFUN hooks when the Modem library is initialized during ``SYS_INIT`` at kernel level and makes calls to the :ref:`nrf_modem_at` interface before the application level initialization is done.

--- a/lib/at_monitor/Kconfig
+++ b/lib/at_monitor/Kconfig
@@ -14,8 +14,24 @@ config AT_MONITOR_HEAP_SIZE
 	range 64 4096
 	default 256
 
-config SYSTEM_WORKQUEUE_STACK_SIZE
-	default 1152 if (LTE_LINK_CONTROL && LOG)
+config AT_MONITOR_USE_DEDICATED_WORKQUEUE
+	bool "Use dedicated workqueue to dispatch notifications"
+	default y
+
+if AT_MONITOR_USE_DEDICATED_WORKQUEUE
+
+config AT_MONITOR_WORKQ_STACK_SIZE
+	int "Workqueue stack size"
+	default 768
+
+config AT_MONITOR_WORKQ_PRIO_OVERRIDE
+	bool "Override default workqueue priority"
+
+config AT_MONITOR_WORKQ_PRIO
+	int "Workqueue priority" if AT_MONITOR_WORKQ_PRIO_OVERRIDE
+	default -1
+
+endif # AT_MONITOR_USE_DEDICATED_WORKQUEUE
 
 module=AT_MONITOR
 module-dep=LOG


### PR DESCRIPTION
This patch adds a dedicated workqueue to dispatch AT notifications.

Earlier, AT notifications were dispatched from the system workqueue. This was RAM-efficient but led to problems because of the system workqueue "popularity" that made it used for many tasks, including blocking operations. Blocking the system workqueue would halt the dispatching of AT notifications, causing `at_monitor` to assert after running out of heap.

Dispatching from a dedicated workqueue mitigates this problem, which fundamentally lies in the application performing blocking operations in the system workqueue, at the cost of some RAM.

This is K-configurable, so the old behavior can be retained, if desired.