### PR TITLE
scripts: add integration quarantine part 14

### DIFF
--- a/scripts/quarantine_integration.yaml
+++ b/scripts/quarantine_integration.yaml
@@ -1295,3 +1295,69 @@
     - nrf52840dk/nrf52840
     - nrf5340dk/nrf5340/cpuapp
   comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - sample.bootloader
+  platforms:
+    - nrf21540dk/nrf52840
+    - nrf52833dk/nrf52833
+    - nrf52dk/nrf52832
+    - nrf5340dk/nrf5340/cpuapp
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - bootloader.bl_validation
+    - bootloader.bl_crypto
+  platforms:
+    - nrf52833dk/nrf52833
+    - nrf52dk/nrf52832
+    - nrf5340dk/nrf5340/cpuapp
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - bootloader.bl_validation.ff_key
+  platforms:
+    - nrf52840dk/nrf52840
+    - nrf52dk/nrf52832
+    - nrf5340dk/nrf5340/cpuapp
+    - nrf9160dk/nrf9160
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - bootloader.bl_validation.negative
+  platforms:
+    - nrf9160dk/nrf9160
+    - nrf5340dk/nrf5340/cpuapp
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - bootloader.bl_validation.negative.nrf52
+  platforms:
+    - nrf52840dk/nrf52840
+    - nrf52dk/nrf52832
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - bootloader.bl_storage
+  platforms:
+    - nrf5340dk/nrf5340/cpuapp
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - sample.event_manager_proxy
+  platforms:
+    - nrf5340dk/nrf5340/cpuapp
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - applications.machine_learning.zdebug_rtt
+  platforms:
+    - thingy53/nrf5340/cpuapp
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
+- scenarios:
+    - applications.machine_learning.zdebug
+    - applications.machine_learning.zrelease
+  platforms:
+    - thingy53/nrf5340/cpuapp/ns
+  comment: "Configurations excluded to limit resources usage in integration builds"


### PR DESCRIPTION
To limit integration scope.
For:
nrf/tests/subsys/bootloader
nrf/samples/bootloader
nrf/samples/event_manager_proxy
nrf/applications/machine_learning