### PR TITLE
applications: serial_lte_modem: carrier app data hex string format

### DIFF
--- a/applications/serial_lte_modem/src/lwm2m_carrier/Kconfig
+++ b/applications/serial_lte_modem/src/lwm2m_carrier/Kconfig
@@ -12,8 +12,8 @@ if SLM_CARRIER
 
 config SLM_CARRIER_APP_DATA_BUFFER_LEN
 	int "Size of the buffer for setting application data"
-	default 768
-	range 128 768
+	default 1016
+	range 120 1016
 	help
 	  Specifies maximum application data size to be set in the App Data Container,
 	  the Binary App Data Container or the Event Log objects.


### PR DESCRIPTION
The AT#XCARRIER="app_data_set" is modified to accept hexadecimal string input, as it is more adequate than plain-text in terms of application data. Similarly, the AT#XCARRIEREVT notification will log application data in such format. Changed app data buffer size so that only up to 508 bytes may be sent to the library. This is to conform with an updated requirement from one of the operators.