### PR TITLE
nrf_rpc: pull protocol specification

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -148,7 +148,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 1e3850de8b28809feb730b805f3033d3c0bcd164
+      revision: d7d48b6cd217a1806ef31fb7d00e0dcb9e9e1fb0
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Pull documentation page that contains the initial nRF RPC protocol specification.