### PR TITLE
manifest: update sdk-zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 41095df79d11e081ea96d150fbe3dbd93f73af6c
+      revision: pull/1719/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
drivers: watchdog: wdt_nrfx.c: Unistall timeouts in wdt_disable()
https://github.com/nrfconnect/sdk-zephyr/pull/1719
based on
https://github.com/zephyrproject-rtos/zephyr/pull/70220