### PR TITLE
applications: nrf_desktop: Fix emitting error logs in HIDS module and HID state module

### DIFF
--- a/applications/nrf_desktop/src/modules/hid_state.c
+++ b/applications/nrf_desktop/src/modules/hid_state.c
@@ -961,7 +961,7 @@ static void report_issued(const void *subscriber_id, uint8_t report_id, bool err
 			/* To maintain the sanity of HID state, clear
 			 * all recorded events and items.
 			 */
-			LOG_ERR("Error while sending report");
+			LOG_WRN("Error while sending report");
 
 			clear_report_data(rs->linked_rd);
 

--- a/applications/nrf_desktop/src/modules/hids.c
+++ b/applications/nrf_desktop/src/modules/hids.c
@@ -479,6 +479,8 @@ static void send_hid_report(const struct hid_report_event *event)
 			LOG_WRN("Cannot send report: device disconnected");
 		} else if (err == -EBADF) {
 			LOG_WRN("Cannot send report: incompatible mode");
+		} else if (err == -EACCES) {
+			LOG_WRN("Cannot send report: peer unsubscribed");
 		} else {
 			LOG_ERR("Cannot send report (%d)", err);
 		}

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -243,6 +243,9 @@ nRF Desktop
   * The ``nrfdesktop-wheel-qdec`` DT alias support to :ref:`nrf_desktop_wheel`.
     You must use the alias to specify the QDEC instance used for scroll wheel, if your board supports multiple QDEC instances (for example ``nrf54l15pdk_nrf54l15_cpuapp``).
     You do not need to define the alias if your board supports only one QDEC instance, because in that case, the wheel module can rely on the ``qdec`` DT label provided by the board.
+  * A warning log for handling ``-EACCES`` error code returned by functions that send GATT notification with HID report in :ref:`nrf_desktop_hids`.
+    The error code might be returned if an HID report is sent right after a remote peer unsubscribes.
+    The warning log prevents displaying an error log in a use case that does not indicate an error.
 
 * Updated:
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -257,6 +257,9 @@ nRF Desktop
     The module relies only on the HID report queue of a HID subscriber.
     This is done to simplify implementation, reduce memory consumption and speed up retrieving enqueued HID reports.
     You can modify the enqueued HID report limit through the :ref:`CONFIG_DESKTOP_HID_FORWARD_MAX_ENQUEUED_REPORTS <config_desktop_app_options>` Kconfig option.
+  * ``Error while sending report`` log level in :ref:`nrf_desktop_hid_state` from error to warning.
+    The log might appear, for example, during the disconnection of a HID transport.
+    In that case, it does not denote an actual error.
 
 Thingy:53: Matter weather station
 ---------------------------------


### PR DESCRIPTION
PR fixes emitting error logs:

* in `hid_state` module:

The "Error while sending report" log should not use error log level. It may appear for example during disconnection of a HID transport.

*  in `hids` module:

Functions that send GATT notification with HID report may return `-EACCES` if HID report is sent right after remote peer unsubscribes. HIDS library uses an asynchronous callback to indicate subscription state changes. `hid_notification_event` is used to synchronize handling of the subscription state changes. Processing of the event introduces a delay which may lead to trying to send a GATT notification by HIDS application module after the asynchronous callback was called.

Change adds a warning log to avoid displaying an error log under the circumstances described above.

Jira: NCSDK-26947