### PR TITLE
net: lib: nrf_cloud: Fix for PGPS_EVT_AVAILABLE not being sent

### DIFF
--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps.c
@@ -493,6 +493,7 @@ int nrf_cloud_pgps_notify_prediction(void)
 	 */
 	int err;
 	int pnum;
+	struct nrf_modem_gnss_agnss_data_frame processed;
 	struct nrf_cloud_pgps_prediction *prediction = NULL;
 	struct nrf_cloud_pgps_event evt = {
 		.type = PGPS_EVT_AVAILABLE,
@@ -503,7 +504,12 @@ int nrf_cloud_pgps_notify_prediction(void)
 		return -EINVAL;
 	}
 
-	if (prediction_timer_is_running()) {
+	nrf_cloud_agnss_processed(&processed);
+
+	/* If the prediction timer is running and a prediction has already been injected,
+	 * there's no need to find the next prediction yet.
+	 */
+	if (prediction_timer_is_running() && processed.system[0].sv_mask_ephe != 0) {
 		LOG_INF("Not time to find next prediction yet.");
 		return 0;
 	}


### PR DESCRIPTION
The `PGPS_EVT_AVAILABLE` event was skipped also when predictions had been downloaded during library initialization, but no prediction had been injected to GNSS. This behavior was introduced in https://github.com/nrfconnect/sdk-nrf/commit/9c58294a79467bac17103e0a0d7a5bede209906e. This broke the P-GPS support at least in the modem_shell sample, but could also affect end user applications.