### PR TITLE
Mitigate risk of pin security misconfiguration

### DIFF
--- a/modules/trusted-firmware-m/Kconfig.peripheral_secure
+++ b/modules/trusted-firmware-m/Kconfig.peripheral_secure
@@ -295,6 +295,7 @@ config NRF_GPIOTE0_SECURE
 
 config NRF_GPIO0_PIN_MASK_SECURE
 	hex "Set GPIO0 PERM mask for Secure"
+	default 0x00000003 if TFM_SECURE_UART30 # P0.0 and P0.1 are used by default when TFM_SECURE_UART30
 	default 0x00000000
 	depends on $(dt_nodelabel_has_compat,gpio0,$(DT_COMPAT_NORDIC_NRF_GPIO)) && !NRF_GPIO0_SECURE
 	help
@@ -306,6 +307,7 @@ config NRF_GPIO0_PIN_MASK_SECURE
 
 config NRF_GPIO1_PIN_MASK_SECURE
 	hex "Set GPIO1 PERM mask for Secure"
+	default 0x00000003 if TFM_SECURE_UART1 # P1.0 and P1.1 are used by default when TFM_SECURE_UART1
 	default 0x00000000
 	depends on $(dt_nodelabel_has_compat,gpio1,$(DT_COMPAT_NORDIC_NRF_GPIO)) && !NRF_GPIO1_SECURE
 	help

--- a/modules/trusted-firmware-m/tfm_boards/common/tfm_hal_platform.c
+++ b/modules/trusted-firmware-m/tfm_boards/common/tfm_hal_platform.c
@@ -4,14 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#if defined(TFM_PARTITION_CRYPTO)
 #include <autoconf.h>
 
-#ifdef CONFIG_HAS_HW_NRF_CC3XX
+#if defined(TFM_PARTITION_CRYPTO) && defined(CONFIG_HAS_HW_NRF_CC3XX)
 #include <nrf_cc3xx_platform.h>
 #include <nrf_cc3xx_platform_ctr_drbg.h>
-#endif
-
 #endif
 
 #if defined(NRF_PROVISIONING)
@@ -91,6 +88,33 @@ static void allow_nonsecure_reset(void)
 	SCB->AIRCR = reg_value;
 }
 
+static void maybe_log_for_gpio_port(uint32_t gpio_port, uint32_t secure_pin_mask)
+{
+	if (secure_pin_mask == 0) {
+		return;
+	}
+
+	SPMLOG_INFMSG("Pins have been configured as secure.\r\n");
+	SPMLOG_INFMSGVAL("GPIO port: ", gpio_port);
+
+	for (int i = 0; i < 32; i++) {
+		if (secure_pin_mask & (1 << i)) {
+			SPMLOG_INFMSGVAL("Pin: ", i);
+		}
+	}
+}
+
+static void log_pin_security_configuration(void)
+{
+#if CONFIG_NRF_GPIO0_PIN_MASK_SECURE || CONFIG_NRF_GPIO1_PIN_MASK_SECURE
+
+	maybe_log_for_gpio_port(0, CONFIG_NRF_GPIO0_PIN_MASK_SECURE);
+	maybe_log_for_gpio_port(1, CONFIG_NRF_GPIO1_PIN_MASK_SECURE);
+#else
+	SPMLOG_INFMSG("All pins have been configured as non-secure\r\n");
+#endif
+}
+
 enum tfm_hal_status_t tfm_hal_platform_init(void)
 {
 	enum tfm_hal_status_t status;
@@ -122,6 +146,8 @@ enum tfm_hal_status_t tfm_hal_platform_init(void)
 		return TFM_HAL_ERROR_BAD_STATE;
 	}
 #endif /* defined(NRF_PROVISIONING) */
+
+	log_pin_security_configuration();
 
 	return TFM_HAL_SUCCESS;
 }


### PR DESCRIPTION
Mitigate the risk of pin security misconfiguration by giving more reasonable default values and by logging which pins are configured as secure.