### PR TITLE
doc: extensions: table_from_rows: handle extra_args as list

### DIFF
--- a/doc/_extensions/table_from_rows.py
+++ b/doc/_extensions/table_from_rows.py
@@ -175,10 +175,16 @@ class TableFromSampleYaml(TableFromRows):
         """Associate all integration platforms for a sample with any shield used.
         """
 
-        if 'extra_args' not in sample_data:
+        extra_args_raw = sample_data.get('extra_args')
+        if not extra_args_raw:
             return
 
-        shield_args = re.findall(r'SHIELD=(\S*)', sample_data['extra_args'])
+        if isinstance(extra_args_raw, list):
+            extra_args = " ".join(extra_args_raw)
+        else:
+            extra_args = extra_args_raw
+
+        shield_args = re.findall(r'SHIELD=(\S*)', extra_args)
         if not shield_args:
             return
 


### PR DESCRIPTION
Twister files support giving extra_args as string or list. Until now, lists haven't been used, but when used they'll cause the extension to crash producing cryptic Sphinx errors.