### PR TITLE
applications: nrf5340_audio: SYS_INIT channel assignment module

### DIFF
--- a/applications/nrf5340_audio/src/nrf5340_audio_common.c
+++ b/applications/nrf5340_audio/src/nrf5340_audio_common.c
@@ -19,8 +19,6 @@ int nrf5340_audio_common_init(void)
 {
 	int ret;
 
-	channel_assignment_init();
-
 	/* Use this to turn on 128 MHz clock for cpu_app */
 	ret = nrfx_clock_divider_set(NRF_CLOCK_DOMAIN_HFCLK, NRF_CLOCK_HFCLK_DIV_1);
 	ret -= NRFX_ERROR_BASE_NUM;

--- a/applications/nrf5340_audio/src/utils/channel_assignment.c
+++ b/applications/nrf5340_audio/src/utils/channel_assignment.c
@@ -35,7 +35,7 @@ void channel_assignment_set(enum audio_channel channel)
 }
 #endif /* CONFIG_AUDIO_HEADSET_CHANNEL_RUNTIME */
 
-void channel_assignment_init(void)
+static int channel_assignment_init(void)
 {
 #if CONFIG_AUDIO_HEADSET_CHANNEL_RUNTIME
 	channel_value = uicr_channel_get();
@@ -47,4 +47,8 @@ void channel_assignment_init(void)
 #else
 	channel_value = CONFIG_AUDIO_HEADSET_CHANNEL;
 #endif /* CONFIG_AUDIO_HEADSET_CHANNEL_RUNTIME */
+
+	return 0;
 }
+
+SYS_INIT(channel_assignment_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);

--- a/applications/nrf5340_audio/src/utils/channel_assignment.h
+++ b/applications/nrf5340_audio/src/utils/channel_assignment.h
@@ -40,9 +40,4 @@ void channel_assignment_get(enum audio_channel *channel);
 void channel_assignment_set(enum audio_channel channel);
 #endif /* AUDIO_HEADSET_CHANNEL_RUNTIME */
 
-/**
- * @brief Initialize the channel assignment
- */
-void channel_assignment_init(void);
-
 #endif /* _CHANNEL_ASSIGNMENT_H_ */


### PR DESCRIPTION
Move initialization of the channel assignment module to APPLICATION level of SYS_INIT. This ensures that the module is initialized correctly before any code references it - regardless if app is running on audio DK or not.

OCT-3029