### PR TITLE
suit: add option to erase cache on init

### DIFF
--- a/subsys/suit/cache/Kconfig
+++ b/subsys/suit/cache/Kconfig
@@ -52,6 +52,12 @@ config SUIT_CACHE0_ERASE_ON_ENVELOPE_STORED
 	depends on SUIT_CACHE_RW
 	default y
 
+config SUIT_CACHEX_ERASE_ON_INIT
+	bool "Always erase the DFU cache partition 1 .. n on initialization"
+	help
+	  If this option is set the SUIT caches with ID 1 .. n will be erased
+	  during cache initialization, if the cache partition is not already erased.
+
 config SUIT_CACHEX_ERASE_BLOCK_SIZE
 	int "Erase block size"
 	default 4096


### PR DESCRIPTION
The SUIT cache partitions 1..n may contain left-over data after the last update. To ensure that the cache does not contain left-over data, the partition is erased if it were not empty already.
This can be enabled or disabled with SUIT_CACHEX_ERASE_ON_INIT Kconfig.