### PR TITLE
samples: matter: Fixed FinitMap Insert implementation

### DIFF
--- a/samples/matter/common/src/util/finite_map.h
+++ b/samples/matter/common/src/util/finite_map.h
@@ -62,6 +62,8 @@ template <typename T1, typename T2, uint16_t N> struct FiniteMap {
 			mMap[slot].key = key;
 			mMap[slot].value = std::move(value);
 			mElementsCount++;
+		} else {
+			return false;
 		}
 		return true;
 	}


### PR DESCRIPTION
Insert method returns true in case there is no place to put new object, what is counterintuitive.