### PR TITLE
Samples: Bluetooth: Mesh: add nRF54L15 support to light_ctrl

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -454,7 +454,10 @@ Bluetooth Mesh samples
 
 * :ref:`bluetooth_mesh_light_lc` sample:
 
-  * Added a section about the :ref:`occupancy mode <bluetooth_mesh_light_lc_occupancy_mode>`.
+  * Added
+
+    * A section about the :ref:`occupancy mode <bluetooth_mesh_light_lc_occupancy_mode>`.
+    * Support for the :ref:`nRF54L15 PDK <ug_nrf54l15_gs>` board.
 
 * :ref:`ble_mesh_dfu_distributor` sample:
 

--- a/samples/bluetooth/mesh/light_ctrl/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/bluetooth/mesh/light_ctrl/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+################################################################################
+# Application overlay - nrf54l15
+
+CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE=n

--- a/samples/bluetooth/mesh/light_ctrl/sample.yaml
+++ b/samples/bluetooth/mesh/light_ctrl/sample.yaml
@@ -14,9 +14,11 @@ tests:
       - thingy53/nrf5340/cpuapp
       - nrf21540dk/nrf52840
       - nrf52840dongle/nrf52840
+      - nrf54l15pdk/nrf54l15/cpuapp
     platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
       nrf5340dk/nrf5340/cpuapp/ns thingy53/nrf5340/cpuapp
       nrf21540dk/nrf52840 nrf52833dk/nrf52833 nrf52840dongle/nrf52840
+      nrf54l15pdk/nrf54l15/cpuapp
     tags: bluetooth ci_build sysbuild
   sample.bluetooth.mesh.light_ctrl.emds:
     sysbuild: true
@@ -30,7 +32,8 @@ tests:
       - nrf5340dk/nrf5340/cpuapp/ns
       - thingy53/nrf5340/cpuapp
       - nrf21540dk/nrf52840
+      - nrf54l15pdk/nrf54l15/cpuapp
     platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
       nrf5340dk/nrf5340/cpuapp/ns thingy53/nrf5340/cpuapp
-      nrf21540dk/nrf52840 nrf52833dk/nrf52833
+      nrf21540dk/nrf52840 nrf52833dk/nrf52833 nrf54l15pdk/nrf54l15/cpuapp
     tags: bluetooth ci_build sysbuild

--- a/samples/bluetooth/mesh/light_ctrl/src/main.c
+++ b/samples/bluetooth/mesh/light_ctrl/src/main.c
@@ -21,7 +21,14 @@
 #include <mpsl/mpsl_lib.h>
 #endif
 
-#define EMDS_DEV_IRQ 26
+#if defined(CONFIG_SOC_SERIES_NRF52X)
+	#define EMDS_DEV_IRQ SWI1_EGU1_IRQn
+#elif defined(CONFIG_SOC_SERIES_NRF53X)
+	#define EMDS_DEV_IRQ EGU1_IRQn
+#elif defined(CONFIG_SOC_SERIES_NRF54LX)
+	#define EMDS_DEV_IRQ SWI01_IRQn
+#endif
+
 #define EMDS_DEV_PRIO 0
 #define EMDS_ISR_ARG 0
 #define EMDS_IRQ_FLAGS 0


### PR DESCRIPTION
This adds support for the nRF54L15 PDK to the light_ctrl sample. It changes the interrupt line used, as the one that was there was not available on the nRF54L15.

Note: Currently, there is an issue with PWM LEDs on the nRF54L15 PDK where the LED dims inverted. I have not handled this here, since the same incorrect behavior shows up in other samples and I expect it to be fixed in Zephyr.