### PR TITLE
lib: pdn: do not error in `pdn_dynamic_params_get()` when MTU is missing

### DIFF
--- a/applications/serial_lte_modem/src/slm_ppp.c
+++ b/applications/serial_lte_modem/src/slm_ppp.c
@@ -212,8 +212,14 @@ static int ppp_start_internal(void)
 		return ret;
 	}
 
-	/* Set the PPP MTU to that of the LTE link. */
-	mtu = MIN(mtu, sizeof(ppp_data_buf));
+	if (mtu) {
+		/* Set the PPP MTU to that of the LTE link. */
+		mtu = MIN(mtu, sizeof(ppp_data_buf));
+	} else {
+		LOG_DBG("Could not retrieve MTU, using default.");
+		mtu = sizeof(ppp_data_buf);
+	}
+
 	net_if_set_mtu(ppp_iface, mtu);
 	LOG_DBG("MTU set to %u.", mtu);
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -762,6 +762,11 @@ Modem libraries
     * Convenience function to get :c:struct:`location_data_details` from the :c:struct:`location_event_data`.
     * Location data details for event :c:enum:`LOCATION_EVT_RESULT_UNKNOWN`.
 
+* :ref:`pdn_readme` library:
+
+  * Updated the ``dns4_pri``, ``dns4_sec``, and ``ipv4_mtu`` parameters of the :c:func:`pdn_dynamic_params_get` function to be optional.
+    If the MTU is not reported by the SIM card, the ``ipv4_mtu`` parameter is set to zero.
+
 * :ref:`lte_lc_readme` library:
 
   * Removed ``AT%XRAI`` related deprecated functions ``lte_lc_rai_param_set()`` and ``lte_lc_rai_req()``, and Kconfig option :kconfig:option:`CONFIG_LTE_RAI_REQ_VALUE`.

--- a/include/modem/pdn.h
+++ b/include/modem/pdn.h
@@ -169,12 +169,12 @@ int pdn_deactivate(uint8_t cid);
 int pdn_id_get(uint8_t cid);
 
 /**
- * @brief Retrieves dynamic parameters of a given PDP context.
+ * @brief Retrieve dynamic parameters of a given PDP context.
  *
  * @param cid The PDP context ID.
- * @param[out] dns4_pri The address of the primary IPv4 DNS server.
- * @param[out] dns4_sec The address of the secondary IPv4 DNS server.
- * @param[out] ipv4_mtu The IPv4 MTU.
+ * @param[out] dns4_pri The address of the primary IPv4 DNS server. Optional, can be NULL.
+ * @param[out] dns4_sec The address of the secondary IPv4 DNS server. Optional, can be NULL.
+ * @param[out] ipv4_mtu The IPv4 MTU. Optional, can be NULL.
  *
  * @return Zero on success or an error code on failure.
  */


### PR DESCRIPTION
The MTU parameter is optional in `+CGCONTRDP`.

Let `pdn_dynamic_params_get()` handle this scenario without raising an error.
Additionally, make all parameters optional, that is, passing `NULL` prevents the information to be copied in the parameters.