### PR TITLE
lib: lte_link_control: Reduce workqueue stack size

### DIFF
--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -139,7 +139,7 @@ K_WORK_DEFINE(lte_lc_edrx_ptw_send_work, lte_lc_edrx_ptw_send_work_fn);
 static void lte_lc_edrx_req_work_fn(struct k_work *work_item);
 K_WORK_DEFINE(lte_lc_edrx_req_work, lte_lc_edrx_req_work_fn);
 
-K_THREAD_STACK_DEFINE(lte_lc_work_q_stack, 1024);
+K_THREAD_STACK_DEFINE(lte_lc_work_q_stack, 768);
 
 static struct k_work_q lte_lc_work_q;
 


### PR DESCRIPTION
PR #14108 introduced lte_lc dedicated workqueue which sent AT%XMONITOR. The stack size was not optimized. Dropping it from 1024 -> 768 now. PR #15203 introduced more use for the workqueue (and renamed it) but it's lighter in terms of stack usage.

Measured usage for lte_lc_work_q_stack was 744 and this should not get bigger. So there is 24 bytes room which is not that much.