### PR TITLE
samples: matter: Repair reaction to last fabric removal

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -111,6 +111,8 @@ Matter
   * Support for merging the generated factory data HEX file with the firmware HEX file by using the devicetree configuration, when Partition Manager is not enabled in the project.
   * Support for the unified Persistent Storage API, including the implementation of the PSA Persistent Storage.
   * Watchdog timer implementation for creating multiple :ref:`ug_matter_device_watchdog` sources and monitoring the time of executing specific parts of the code.
+  * Clearing SRP host services on factory reset.
+    This resolves the known issue related to the :kconfig:option:`CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_PAIRING_START` (KRKNWK-18916).
 
 * Updated default MRP retry intervals for Thread devices to two seconds to reduce the number of spurious retransmissions in Thread networks.
 * Increased the number of available packet buffers in the Matter stack to avoid packet allocation issues.

--- a/samples/matter/common/src/app/fabric_table_delegate.h
+++ b/samples/matter/common/src/app/fabric_table_delegate.h
@@ -14,7 +14,8 @@
 #include <platform/nrfconnect/wifi/WiFiManager.h>
 #endif
 
-namespace Nrf::Matter {
+namespace Nrf::Matter
+{
 
 class AppFabricTableDelegate : public chip::FabricTable::Delegate {
 public:
@@ -50,6 +51,9 @@ private:
 				chip::Server::GetInstance().ScheduleFactoryReset();
 #elif defined(CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_ONLY) ||                                                           \
 	defined(CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_PAIRING_START)
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+				chip::DeviceLayer::ThreadStackMgr().ClearAllSrpHostAndServices();
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
 				/* Erase Matter data */
 				chip::DeviceLayer::PersistedStorage::KeyValueStoreMgrImpl().DoFactoryReset();
 				/* Erase Network credentials and disconnect */

--- a/west.yml
+++ b/west.yml
@@ -160,7 +160,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: a497f79deea945a73b8a632166b26dad6e9dc10d
+      revision: cf7eda28d1ce686d883d42ea6e15838df1837ea1
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
- Repaired a reaction on the last fabric removal when the CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_PAIRING_START option is selected.
- Cherry-picked a commit from Matter upstream to disable the IPv6 interface after the factory reset.
- Enabled clearing SRP host services on factory reset.

This repairs a known issue: KRKNWK-18916