### PR TITLE
nrf_security: add MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH option

### DIFF
--- a/subsys/nrf_security/Kconfig.legacy
+++ b/subsys/nrf_security/Kconfig.legacy
@@ -421,6 +421,12 @@ config MBEDTLS_AES_ROM_TABLES
 
 endmenu # CBC cipher padding modes
 
+config MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
+	bool
+	prompt "Enable MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH"
+	help
+	   Enable AES operations to support only 128-bit keys to reduce ROM usage.
+
 config MBEDTLS_CIPHER_MODE_CTR
 	bool "AES-CTR - AES Counter Block Cipher mode"
 	default y

--- a/subsys/nrf_security/cmake/legacy_crypto_config.cmake
+++ b/subsys/nrf_security/cmake/legacy_crypto_config.cmake
@@ -29,6 +29,7 @@ kconfig_check_and_set_base(MBEDTLS_CIPHER_PADDING_ZEROS)
 
 kconfig_check_and_set_base(MBEDTLS_AES_FEWER_TABLES)
 kconfig_check_and_set_base(MBEDTLS_AES_ROM_TABLES)
+kconfig_check_and_set_base(MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH)
 
 kconfig_check_and_set_base(MBEDTLS_CIPHER_MODE_CTR)
 kconfig_check_and_set_base(MBEDTLS_CIPHER_MODE_CFB)

--- a/subsys/nrf_security/configs/legacy_crypto_config.h.template
+++ b/subsys/nrf_security/configs/legacy_crypto_config.h.template
@@ -505,6 +505,23 @@
 #cmakedefine MBEDTLS_AES_FEWER_TABLES
 
 /**
+ * \def MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
+ *
+ * Use only 128-bit keys in AES operations to save ROM.
+ *
+ * Uncomment this macro to remove support for AES operations that use 192-
+ * or 256-bit keys.
+ *
+ * Uncommenting this macro reduces the size of AES code by ~300 bytes
+ * on v8-M/Thumb2.
+ *
+ * Module:  library/aes.c
+ *
+ * Requires: MBEDTLS_AES_C
+ */
+#cmakedefine MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
+
+/**
  * \def MBEDTLS_CAMELLIA_SMALL_MEMORY
  *
  * Use less ROM for the Camellia implementation (saves about 768 bytes).

--- a/west.yml
+++ b/west.yml
@@ -160,7 +160,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 579d8eebc3352ec1cc342ade2570897daa5ccdab
+      revision: 2540dfe3ecfb10890e2046646965456c4784121d
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
This commit allows application to set mbedTLS option that allow to remove support for AES operations that use 192- or 256-bit keys.

It also enables it by default for Matter over Wi-Fi applications.