### PR TITLE
scripts: ci: test_plan: Align tags and ignores for NCS

### DIFF
--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -39,53 +39,65 @@
 # 1. Avoid putting include/ in entries as any include/ change we want
 #    to get test coverage as broad as possible.
 # 2. Keep tag entries sorted alphabetically
+# 3. The root folder for listed paths here is NCS,
+#    thus files from sdk-nrf starts from nrf, from sdk-zephyr: zephyr,
+#    from sdk-mcuboot: bootloader/mcuboot etc.
+#    Paths should match location after checking out sdk-nrf (+ west update)
 
 bluetooth:
   files:
-    - drivers/bluetooth/
-    - subsys/bluetooth/
-    - subsys/net/l2/bluetooth/
+    - zephyr/drivers/bluetooth/
+    - zephyr/subsys/bluetooth/
+    - zephyr/subsys/net/l2/bluetooth/
+#    Examples:
+#    - nrf/drivers/bluetooth/
+#    - nrf/subsys/bluetooth/
 
 net:
   files:
-    - subsys/net/
-    - include/zephyr/net/
-    - drivers/wifi/
-    - drivers/net/
-    - drivers/ethernet/
-    - drivers/ieee802154/
-    - drivers/ptp_clock/
+    - zephyr/subsys/net/
+    - zephyr/include/zephyr/net/
+    - zephyr/drivers/wifi/
+    - zephyr/drivers/net/
+    - zephyr/drivers/ethernet/
+    - zephyr/drivers/ieee802154/
+    - zephyr/drivers/ptp_clock/
+#    Examples:
+#    - nrf/subsys/net/
+#    - nrf/include/net/
+#    - nrf/drivers/wifi/
+#    - nrf/drivers/net/
 
 test_framework:
   files:
-    - subsys/testsuite/
-    - samples/subsys/testsuite/
-    - tests/subsys/testsuite/
-    - tests/ztest/
+    - zephyr/subsys/testsuite/
+    - zephyr/samples/subsys/testsuite/
+    - zephyr/tests/subsys/testsuite/
+    - zephyr/tests/ztest/
 
 cmsis_dsp:
   files:
-    - modules/Kconfig.cmsis_dsp
+    - zephyr/modules/Kconfig.cmsis_dsp
     # we have no means of telling file changes in a module, so for assume any
     # change to west.yml is updating something we need to re-test for.
-    - west.yml
+    - zephyr/west.yml
 
 mcumgr:
   files:
-    - subsys/mgmt/mcumgr/
-    - tests/subsys/mgmt/mcumgr/
-    - samples/subsys/mgmt/mcumgr/
-    - include/zephyr/mgmt/mcumgr/
+    - zephyr/subsys/mgmt/mcumgr/
+    - zephyr/tests/subsys/mgmt/mcumgr/
+    - zephyr/samples/subsys/mgmt/mcumgr/
+    - zephyr/include/zephyr/mgmt/mcumgr/
 kernel:
   files:
-    - kernel/
-    - arch/
+    - zephyr/kernel/
+    - zephyr/arch/
 
 posix:
   files:
-    - lib/posix/
+    - zephyr/lib/posix/
 
 # cbprintf:
 #    files:
-#        - lib/os/cbprintf*
-#        - lib/posix
+#        - zephyr/lib/os/cbprintf*
+#        - zephyr/lib/posix

--- a/scripts/ci/twister_ignore.txt
+++ b/scripts/ci/twister_ignore.txt
@@ -5,44 +5,17 @@
 # are matched, then twister will not do a full run and optionally will only
 # run on changed tests or boards.
 #
-.gitlint
-.checkpatch.conf
-.clang-format
-.codecov.yml
-.editorconfig
-.gitattributes
-.gitignore
-.mailmap
-.github/workflows/codecov.yaml
-.github/workflows/issue_count.yml
-.github/workflows/stats_merged_prs.yml
-.github/workflows/assigner.yml
-.github/workflows/daily_test_version.yml
-.github/workflows/do_not_merge.yml
-.github/workflows/stale_issue.yml
-.github/workflows/stale-workflow-queue-cleanup.yml
-.github/workflows/greet_first_time_contributor.yml
-.github/workflows/issues-report-config.json
-CODEOWNERS
-MAINTAINERS.yml
-LICENSE
-Makefile
-doc/*
+nrf/.gitlint
+nrf/.checkpatch.conf
+nrf/.clang-format
+nrf/.gitignore
 # GH action have no impact on code
-.github/*
+nrf/.github/*
+nrf/CODEOWNERS
+nrf/LICENSE
+nrf/doc/*
 *.rst
 *.md
-# if we change this file or associated script, it should not trigger a full
-# twister.
-scripts/ci/test_plan.py
-scripts/ci/twister_ignore.txt
-scripts/ci/what_changed.py
-scripts/ci/version_mgr.py
-scripts/ci/stats/*
-scripts/requirements*
-scripts/checkpatch/*
-scripts/checkpatch.pl
-scripts/ci/pylintrc
-scripts/footprint/*
-scripts/set_assignees.py
-scripts/gitlint/zephyr_commit_rules.py
+nrf/scripts/ci/test_plan.py
+nrf/scripts/ci/twister_ignore.txt
+nrf/scripts/checkpatch/*


### PR DESCRIPTION
Tags and ignores are paths with root at NCS,
thus add specific path for nrf or zephyr.