### PR TITLE
samples: matter: Enabled BLE extended announcement

### DIFF
--- a/applications/matter_bridge/prj.conf
+++ b/applications/matter_bridge/prj.conf
@@ -10,11 +10,17 @@
 
 # Enable CHIP
 CONFIG_CHIP=y
-CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y
 CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
 # 32770 == 0x8002 (example bridge)
 CONFIG_CHIP_DEVICE_PRODUCT_ID=32770
 CONFIG_STD_CPP17=y
+
+# Enable Matter pairing automatically on application start.
+CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y
+
+# Enable Matter extended announcement and increase duration to 1 hour.
+CONFIG_CHIP_BLE_EXT_ADVERTISING=y
+CONFIG_CHIP_BLE_ADVERTISING_DURATION=60
 
 # Add support for LEDs and buttons on Nordic development kits
 CONFIG_DK_LIBRARY=y

--- a/applications/matter_bridge/prj_release.conf
+++ b/applications/matter_bridge/prj_release.conf
@@ -10,11 +10,17 @@
 
 # Enable CHIP
 CONFIG_CHIP=y
-CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y
 CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
 # 32770 == 0x8002 (example bridge)
 CONFIG_CHIP_DEVICE_PRODUCT_ID=32770
 CONFIG_STD_CPP17=y
+
+# Enable Matter pairing automatically on application start.
+CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y
+
+# Enable Matter extended announcement and increase duration to 1 hour.
+CONFIG_CHIP_BLE_EXT_ADVERTISING=y
+CONFIG_CHIP_BLE_ADVERTISING_DURATION=60
 
 # Add support for LEDs and buttons on Nordic development kits
 CONFIG_DK_LIBRARY=y

--- a/applications/matter_weather_station/prj.conf
+++ b/applications/matter_weather_station/prj.conf
@@ -10,11 +10,17 @@
 
 # Enable CHIP
 CONFIG_CHIP=y
-CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y
 CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
 # 32781 == 0x800D (matter example of Temperature measurement device as NCS Weather Station)
 CONFIG_CHIP_DEVICE_PRODUCT_ID=32781
 CONFIG_STD_CPP17=y
+
+# Enable Matter pairing automatically on application start.
+CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y
+
+# Enable Matter extended announcement and increase duration to 1 hour.
+CONFIG_CHIP_BLE_EXT_ADVERTISING=y
+CONFIG_CHIP_BLE_ADVERTISING_DURATION=60
 
 # Enable Bluetooth Low Energy
 CONFIG_BT_DEVICE_NAME="MatterWeather"

--- a/applications/matter_weather_station/prj_release.conf
+++ b/applications/matter_weather_station/prj_release.conf
@@ -10,11 +10,17 @@
 
 # Enable CHIP
 CONFIG_CHIP=y
-CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y
 CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
 # 32781 == 0x800D (matter example of Temperature measurement device as NCS Weather Station)
 CONFIG_CHIP_DEVICE_PRODUCT_ID=32781
 CONFIG_STD_CPP17=y
+
+# Enable Matter pairing automatically on application start.
+CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y
+
+# Enable Matter extended announcement and increase duration to 1 hour.
+CONFIG_CHIP_BLE_EXT_ADVERTISING=y
+CONFIG_CHIP_BLE_ADVERTISING_DURATION=60
 
 # Enable Bluetooth Low Energy
 CONFIG_BT_DEVICE_NAME="MatterWeather"

--- a/doc/nrf/protocols/matter/getting_started/low_power_configuration.rst
+++ b/doc/nrf/protocols/matter/getting_started/low_power_configuration.rst
@@ -161,6 +161,20 @@ For more information about the Wi-Fi power save mechanism, see the :ref:`Wi-Fi M
 
 To enable the Wi-Fi power save mode, set the :kconfig:option:`CONFIG_NRF_WIFI_LOW_POWER` Kconfig option to ``y``.
 
+Configure Bluetooth LE advertising duration
+*******************************************
+
+A Matter device uses Bluetooth® Low Energy (LE) to advertise its service for device commissioning purposes.
+The duration of this advertising is configurable and can last up to 15 minutes in the standard mode and up to 48 hours in the Extended Announcement mode.
+An extended advertising duration may improve the user experience, as it gives more time for the user to setup the device, but it also increases the energy consumption.
+
+Selecting the optimal advertising duration is a compromise and depends on the specific application use case.
+Use the following Kconfig options to configure the advertising and reduce the consumed energy:
+
+* :kconfig:option:`CONFIG_CHIP_BLE_EXT_ADVERTISING` -  Set to ``n`` to disable Extended Announcement (also called Extended Beaconing).
+  When disabled, the device is not allowed to advertise for a duration of more than 15 minutes.
+* :kconfig:option:`CONFIG_CHIP_BLE_ADVERTISING_DURATION` - Set how long the device advertises (in minutes).
+
 Disable serial logging
 **********************
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -549,6 +549,8 @@ Matter samples
 
     DFU support for the nRF54L15 PDK is available only for the ``release`` build target.
 
+* Enabled the Bluetooth® LE Extended Announcement feature for all samples, and increased advertising timeout from 15 minutes to 1 hour.
+
 * :ref:`matter_lock_sample` sample:
 
   * Added support for emulation of the nRF7001 Wi-Fi companion IC on the nRF7002 DK.

--- a/samples/matter/light_bulb/README.rst
+++ b/samples/matter/light_bulb/README.rst
@@ -336,7 +336,7 @@ If you are new to Matter, the recommended approach is to use :ref:`CHIP Tool for
 .. matter_light_bulb_sample_commissioning_end
 
 Before starting the commissioning procedure, the device must be made discoverable over Bluetooth LE.
-The device becomes discoverable automatically upon the device startup, but only for a predefined period of time (15 minutes by default).
+The device becomes discoverable automatically upon the device startup, but only for a predefined period of time (1 hour by default).
 If the Bluetooth LE advertising times out, press **Button 1** to enable it again.
 
 Onboarding information

--- a/samples/matter/light_bulb/prj.conf
+++ b/samples/matter/light_bulb/prj.conf
@@ -11,8 +11,12 @@ CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
 CONFIG_CHIP_DEVICE_PRODUCT_ID=32773
 CONFIG_STD_CPP17=y
 
-# Enable CHIP pairing automatically on application start.
+# Enable Matter pairing automatically on application start.
 CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y
+
+# Enable Matter extended announcement and increase duration to 1 hour.
+CONFIG_CHIP_BLE_EXT_ADVERTISING=y
+CONFIG_CHIP_BLE_ADVERTISING_DURATION=60
 
 # Add support for LEDs and buttons on Nordic development kits
 CONFIG_DK_LIBRARY=y

--- a/samples/matter/light_bulb/prj_release.conf
+++ b/samples/matter/light_bulb/prj_release.conf
@@ -11,8 +11,12 @@ CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
 CONFIG_CHIP_DEVICE_PRODUCT_ID=32773
 CONFIG_STD_CPP17=y
 
-# Enable CHIP pairing automatically on application start.
+# Enable Matter pairing automatically on application start.
 CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y
+
+# Enable Matter extended announcement and increase duration to 1 hour.
+CONFIG_CHIP_BLE_EXT_ADVERTISING=y
+CONFIG_CHIP_BLE_ADVERTISING_DURATION=60
 
 # Add support for LEDs and buttons on Nordic development kits
 CONFIG_DK_LIBRARY=y

--- a/samples/matter/light_switch/README.rst
+++ b/samples/matter/light_switch/README.rst
@@ -401,8 +401,8 @@ Commissioning the device
     :end-before: matter_door_lock_sample_commissioning_end
 
 Before starting the commissioning procedure, the device must be made discoverable over Bluetooth LE.
-By default, the device is not discoverable automatically upon startup.
-Press **Button 1** to enable the Bluetooth LE advertising.
+The device becomes discoverable automatically upon the device startup, but only for a predefined period of time (1 hour by default).
+If the Bluetooth LE advertising times out, press **Button 1** to enable it again.
 
 Onboarding information
 ----------------------

--- a/samples/matter/light_switch/prj.conf
+++ b/samples/matter/light_switch/prj.conf
@@ -11,6 +11,13 @@ CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
 CONFIG_CHIP_DEVICE_PRODUCT_ID=32772
 CONFIG_STD_CPP17=y
 
+# Enable Matter pairing automatically on application start.
+CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y
+
+# Enable Matter extended announcement and increase duration to 1 hour.
+CONFIG_CHIP_BLE_EXT_ADVERTISING=y
+CONFIG_CHIP_BLE_ADVERTISING_DURATION=60
+
 # Add support for LEDs and buttons on Nordic development kits
 CONFIG_DK_LIBRARY=y
 

--- a/samples/matter/light_switch/prj_release.conf
+++ b/samples/matter/light_switch/prj_release.conf
@@ -11,6 +11,13 @@ CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
 CONFIG_CHIP_DEVICE_PRODUCT_ID=32772
 CONFIG_STD_CPP17=y
 
+# Enable Matter pairing automatically on application start.
+CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y
+
+# Enable Matter extended announcement and increase duration to 1 hour.
+CONFIG_CHIP_BLE_EXT_ADVERTISING=y
+CONFIG_CHIP_BLE_ADVERTISING_DURATION=60
+
 # Add support for LEDs and buttons on Nordic development kits
 CONFIG_DK_LIBRARY=y
 

--- a/samples/matter/lock/README.rst
+++ b/samples/matter/lock/README.rst
@@ -333,7 +333,7 @@ Button 1:
       * If the device is not provisioned to the Matter network, it initiates the SMP server (Simple Management Protocol) and Bluetooth LE advertising for Matter commissioning.
         After that, the Device Firmware Update (DFU) over Bluetooth Low Energy can be started.
         (See `Upgrading the device firmware`_.)
-        Bluetooth LE advertising makes the device discoverable over Bluetooth LE for the predefined period of time (15 minutes by default).
+        Bluetooth LE advertising makes the device discoverable over Bluetooth LE for the predefined period of time (1 hour by default).
 
       * If the device is already provisioned to the Matter network it re-enables the SMP server.
         After that, the DFU over Bluetooth Low Energy can be started.

--- a/samples/matter/lock/prj.conf
+++ b/samples/matter/lock/prj.conf
@@ -15,6 +15,10 @@ CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
 CONFIG_CHIP_DEVICE_PRODUCT_ID=32774
 CONFIG_STD_CPP17=y
 
+# Enable Matter extended announcement and increase duration to 1 hour.
+CONFIG_CHIP_BLE_EXT_ADVERTISING=y
+CONFIG_CHIP_BLE_ADVERTISING_DURATION=60
+
 # Add support for LEDs and buttons on Nordic development kits
 CONFIG_DK_LIBRARY=y
 

--- a/samples/matter/lock/prj_release.conf
+++ b/samples/matter/lock/prj_release.conf
@@ -15,6 +15,10 @@ CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
 CONFIG_CHIP_DEVICE_PRODUCT_ID=32774
 CONFIG_STD_CPP17=y
 
+# Enable Matter extended announcement and increase duration to 1 hour.
+CONFIG_CHIP_BLE_EXT_ADVERTISING=y
+CONFIG_CHIP_BLE_ADVERTISING_DURATION=60
+
 # Add support for LEDs and buttons on Nordic development kits
 CONFIG_DK_LIBRARY=y
 

--- a/samples/matter/lock/prj_thread_wifi_switched.conf
+++ b/samples/matter/lock/prj_thread_wifi_switched.conf
@@ -15,6 +15,10 @@ CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
 CONFIG_CHIP_DEVICE_PRODUCT_ID=32774
 CONFIG_STD_CPP17=y
 
+# Enable Matter extended announcement and increase duration to 1 hour.
+CONFIG_CHIP_BLE_EXT_ADVERTISING=y
+CONFIG_CHIP_BLE_ADVERTISING_DURATION=60
+
 # Add support for LEDs and buttons on Nordic development kits
 CONFIG_DK_LIBRARY=y
 

--- a/samples/matter/template/prj.conf
+++ b/samples/matter/template/prj.conf
@@ -10,13 +10,19 @@
 
 # Enable CHIP
 CONFIG_CHIP=y
-CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y
 CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
 # 32768 == 0x8000 (example Product ID added temporaly,
 # but it must be changed with proper PID from the list:
 # https://github.com/project-chip/connectedhomeip/blob/482e6fd03196a6de45465a90003947ef4b86e0b1/docs/examples/discussion/PID_allocation_for_example_apps.md)
 CONFIG_CHIP_DEVICE_PRODUCT_ID=32768
 CONFIG_STD_CPP17=y
+
+# Enable Matter pairing automatically on application start.
+CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y
+
+# Enable Matter extended announcement and increase duration to 1 hour.
+CONFIG_CHIP_BLE_EXT_ADVERTISING=y
+CONFIG_CHIP_BLE_ADVERTISING_DURATION=60
 
 # Add support for LEDs and buttons on Nordic development kits
 CONFIG_DK_LIBRARY=y

--- a/samples/matter/template/prj_release.conf
+++ b/samples/matter/template/prj_release.conf
@@ -10,13 +10,19 @@
 
 # Enable CHIP
 CONFIG_CHIP=y
-CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y
 CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
 # 32768 == 0x8000 (example Product ID added temporaly,
 # but it must be changed with proper PID from the list:
 # https://github.com/project-chip/connectedhomeip/blob/482e6fd03196a6de45465a90003947ef4b86e0b1/docs/examples/discussion/PID_allocation_for_example_apps.md)
 CONFIG_CHIP_DEVICE_PRODUCT_ID=32768
 CONFIG_STD_CPP17=y
+
+# Enable Matter pairing automatically on application start.
+CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y
+
+# Enable Matter extended announcement and increase duration to 1 hour.
+CONFIG_CHIP_BLE_EXT_ADVERTISING=y
+CONFIG_CHIP_BLE_ADVERTISING_DURATION=60
 
 # Add support for LEDs and buttons on Nordic development kits
 CONFIG_DK_LIBRARY=y

--- a/samples/matter/thermostat/prj.conf
+++ b/samples/matter/thermostat/prj.conf
@@ -10,11 +10,17 @@
 
 # Enable CHIP
 CONFIG_CHIP=y
-CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y
 CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
 # 32782 == 0x800e (example thermostat product)
 CONFIG_CHIP_DEVICE_PRODUCT_ID=32782
 CONFIG_STD_CPP17=y
+
+# Enable Matter pairing automatically on application start.
+CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y
+
+# Enable Matter extended announcement and increase duration to 1 hour.
+CONFIG_CHIP_BLE_EXT_ADVERTISING=y
+CONFIG_CHIP_BLE_ADVERTISING_DURATION=60
 
 # Add support for LEDs and buttons on Nordic development kits
 CONFIG_DK_LIBRARY=y

--- a/samples/matter/thermostat/prj_release.conf
+++ b/samples/matter/thermostat/prj_release.conf
@@ -10,11 +10,17 @@
 
 # Enable CHIP
 CONFIG_CHIP=y
-CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y
 CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
 # 32782 == 0x800e (example thermostat product)
 CONFIG_CHIP_DEVICE_PRODUCT_ID=32782
 CONFIG_STD_CPP17=y
+
+# Enable Matter pairing automatically on application start.
+CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y
+
+# Enable Matter extended announcement and increase duration to 1 hour.
+CONFIG_CHIP_BLE_EXT_ADVERTISING=y
+CONFIG_CHIP_BLE_ADVERTISING_DURATION=60
 
 # Add support for LEDs and buttons on Nordic development kits
 CONFIG_DK_LIBRARY=y

--- a/samples/matter/window_covering/README.rst
+++ b/samples/matter/window_covering/README.rst
@@ -226,7 +226,8 @@ Commissioning the device
     :end-before: matter_light_bulb_sample_commissioning_end
 
 Before starting the commissioning procedure, the device must be made discoverable over Bluetooth LE.
-Press **Button 1** to enable the Bluetooth LE advertising.
+The device becomes discoverable automatically upon the device startup, but only for a predefined period of time (1 hour by default).
+If the Bluetooth LE advertising times out, press **Button 1** to enable it again.
 
 Onboarding information
 ++++++++++++++++++++++

--- a/samples/matter/window_covering/prj.conf
+++ b/samples/matter/window_covering/prj.conf
@@ -15,6 +15,13 @@ CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
 CONFIG_CHIP_DEVICE_PRODUCT_ID=32784
 CONFIG_STD_CPP17=y
 
+# Enable Matter pairing automatically on application start.
+CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y
+
+# Enable Matter extended announcement and increase duration to 1 hour.
+CONFIG_CHIP_BLE_EXT_ADVERTISING=y
+CONFIG_CHIP_BLE_ADVERTISING_DURATION=60
+
 # Add support for LEDs and buttons on Nordic development kits
 CONFIG_DK_LIBRARY=y
 

--- a/samples/matter/window_covering/prj_release.conf
+++ b/samples/matter/window_covering/prj_release.conf
@@ -15,6 +15,13 @@ CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
 CONFIG_CHIP_DEVICE_PRODUCT_ID=32784
 CONFIG_STD_CPP17=y
 
+# Enable Matter pairing automatically on application start.
+CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y
+
+# Enable Matter extended announcement and increase duration to 1 hour.
+CONFIG_CHIP_BLE_EXT_ADVERTISING=y
+CONFIG_CHIP_BLE_ADVERTISING_DURATION=60
+
 # Add support for LEDs and buttons on Nordic development kits
 CONFIG_DK_LIBRARY=y
 


### PR DESCRIPTION
Enabled by default BLE extended announcement in all Matter samples. Also, enabled pairing autostart in Window Covering and Light Switch samples (according to spec all devices shall use it besides door lock, or define custom commissioning flow).