### PR TITLE
samples: wifi: shell: Fix HF CPU frequency configuration

### DIFF
--- a/samples/wifi/shell/src/main.c
+++ b/samples/wifi/shell/src/main.c
@@ -10,7 +10,7 @@
 
 #include <zephyr/sys/printk.h>
 #include <zephyr/kernel.h>
-#if NRFX_CLOCK_ENABLED && defined(CLOCK_FEATURE_HFCLK_DIVIDE_PRESENT) && NRF_CLOCK_HAS_HFCLK192M
+#if NRFX_CLOCK_ENABLED && (defined(CLOCK_FEATURE_HFCLK_DIVIDE_PRESENT) || NRF_CLOCK_HAS_HFCLK192M)
 #include <nrfx_clock.h>
 #endif
 #include <zephyr/device.h>
@@ -42,7 +42,7 @@ int init_usb(void)
 
 int main(void)
 {
-#if NRFX_CLOCK_ENABLED && defined(CLOCK_FEATURE_HFCLK_DIVIDE_PRESENT) && NRF_CLOCK_HAS_HFCLK192M
+#if NRFX_CLOCK_ENABLED && (defined(CLOCK_FEATURE_HFCLK_DIVIDE_PRESENT) || NRF_CLOCK_HAS_HFCLK192M)
 	/* For now hardcode to 128MHz */
 	nrfx_clock_divider_set(NRF_CLOCK_DOMAIN_HFCLK,
 			       NRF_CLOCK_HFCLK_DIV_1);


### PR DESCRIPTION
In order to add support for nRF54H20DK commit 5a20cee36f3 ("samples: wifi: shell: Fix nRFx clock configuration) introduced a regression where instead of choosing one of the clock sources HF or HF192M, it enforced both to be available, this causes the CPU to be stuck at lower frequency impacting peak performance.

Fixes SHEL-2771.