### PR TITLE
manifest: Update sdk-nrf to fix unused function warning

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -131,7 +131,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 0b5810de95eb93bbd4fba8e20a2152b33880fc43
+      revision: pull/314/head
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR


### PR DESCRIPTION
Fixes warning for unused sec_slot_cleanup_if_unusable in XIP configuration.