### PR TITLE
samples: suit: propagate SB_CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM

### DIFF
--- a/samples/suit/smp_transfer/sample.yaml
+++ b/samples/suit/smp_transfer/sample.yaml
@@ -13,49 +13,53 @@ common:
   sysbuild: true
 tests:
   subsys.suit.smp_transfer.v1:
-    extra_configs:
-      - CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM=1
+    extra_args:
+      - SB_CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM=1
     tags: suit
 
   subsys.suit.smp_transfer.bt.v1:
-    extra_args: FILE_SUFFIX=bt
-    extra_configs:
-      - CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM=1
+    extra_args:
+      - FILE_SUFFIX=bt
+      - SB_CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM=1
     tags: suit bluetooth
 
   subsys.suit.smp_transfer.v2:
-    extra_configs:
-      - CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM=2
+    extra_args:
+      - SB_CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM=2
     tags: suit
 
   subsys.suit.smp_transfer.bt.v2:
-    extra_args: FILE_SUFFIX=bt
-    extra_configs:
-      - CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM=2
+    extra_args:
+      - FILE_SUFFIX=bt
+      - SB_CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM=2
     tags: suit bluetooth
 
   subsys.suit.smp_transfer.full.v1:
+    extra_args:
+      - SB_CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM=1
     extra_configs:
-      - CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM=1
       - CONFIG_SUIT_DFU_CANDIDATE_PROCESSING_FULL=y
     tags: suit
 
   subsys.suit.smp_transfer.full.v2:
+    extra_args:
+      - SB_CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM=2
     extra_configs:
-      - CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM=2
       - CONFIG_SUIT_DFU_CANDIDATE_PROCESSING_FULL=y
     tags: suit
 
   subsys.suit.smp_transfer.full.bt.v1:
-    extra_args: FILE_SUFFIX=bt
+    extra_args:
+      - FILE_SUFFIX=bt
+      - SB_CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM=1
     extra_configs:
-      - CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM=1
       - CONFIG_SUIT_DFU_CANDIDATE_PROCESSING_FULL=y
     tags: suit bluetooth
 
   subsys.suit.smp_transfer.full.bt.v2:
-    extra_args: FILE_SUFFIX=bt
+    extra_args:
+      - FILE_SUFFIX=bt
+      - SB_CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM=2
     extra_configs:
-      - CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM=2
       - CONFIG_SUIT_DFU_CANDIDATE_PROCESSING_FULL=y
     tags: suit bluetooth

--- a/samples/suit/smp_transfer/sysbuild.cmake
+++ b/samples/suit/smp_transfer/sysbuild.cmake
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Set the CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM defined in smp_transfer/Kconfig
+# to be equal to SB_CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM
+set_property(TARGET smp_transfer APPEND_STRING PROPERTY CONFIG "CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM=${SB_CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM}\n")


### PR DESCRIPTION
The smp_transfer needs to be able to access the value of SB_CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM inside the source code for demonstration purposes.

The value of SB_CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM is propagated into CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM, which is defined locally for the sample.