### PR TITLE
samples: matter: light_bulb: enable mandatory resposne command in zap

### DIFF
--- a/samples/matter/light_bulb/src/light_bulb.zap
+++ b/samples/matter/light_bulb/src/light_bulb.zap
@@ -19,17 +19,17 @@
   "package": [
     {
       "pathRelativity": "relativeToZap",
-      "path": "../../../../../modules/lib/matter/src/app/zap-templates/app-templates.json",
-      "type": "gen-templates-json",
-      "version": "chip-v1"
-    },
-    {
-      "pathRelativity": "relativeToZap",
       "path": "../../../../../modules/lib/matter/src/app/zap-templates/zcl/zcl.json",
       "type": "zcl-properties",
       "category": "matter",
       "version": 1,
       "description": "Matter SDK ZCL data"
+    },
+    {
+      "pathRelativity": "relativeToZap",
+      "path": "../../../../../modules/lib/matter/src/app/zap-templates/app-templates.json",
+      "type": "gen-templates-json",
+      "version": "chip-v1"
     }
   ],
   "endpointTypes": [
@@ -5126,6 +5126,14 @@
               "mfgCode": null,
               "source": "client",
               "isIncoming": 1,
+              "isEnabled": 1
+            },
+            {
+              "name": "CopySceneResponse",
+              "code": 64,
+              "mfgCode": null,
+              "source": "server",
+              "isIncoming": 0,
               "isEnabled": 1
             }
           ],

--- a/samples/matter/light_bulb/src/zap-generated/IMClusterCommandHandler.cpp
+++ b/samples/matter/light_bulb/src/zap-generated/IMClusterCommandHandler.cpp
@@ -34,15 +34,12 @@ namespace chip
 {
 namespace app
 {
-
 	// Cluster specific command parsing
 
 	namespace Clusters
 	{
-
 		namespace AdministratorCommissioning
 		{
-
 			void DispatchServerCommand(CommandHandler *apCommandObj,
 						   const ConcreteCommandPath &aCommandPath, TLV::TLVReader &aDataTlv)
 			{
@@ -107,7 +104,6 @@ namespace app
 
 		namespace GeneralCommissioning
 		{
-
 			void DispatchServerCommand(CommandHandler *apCommandObj,
 						   const ConcreteCommandPath &aCommandPath, TLV::TLVReader &aDataTlv)
 			{
@@ -172,7 +168,6 @@ namespace app
 
 		namespace GeneralDiagnostics
 		{
-
 			void DispatchServerCommand(CommandHandler *apCommandObj,
 						   const ConcreteCommandPath &aCommandPath, TLV::TLVReader &aDataTlv)
 			{
@@ -227,7 +222,6 @@ namespace app
 
 		namespace GroupKeyManagement
 		{
-
 			void DispatchServerCommand(CommandHandler *apCommandObj,
 						   const ConcreteCommandPath &aCommandPath, TLV::TLVReader &aDataTlv)
 			{
@@ -301,7 +295,6 @@ namespace app
 
 		namespace Groups
 		{
-
 			void DispatchServerCommand(CommandHandler *apCommandObj,
 						   const ConcreteCommandPath &aCommandPath, TLV::TLVReader &aDataTlv)
 			{
@@ -390,7 +383,6 @@ namespace app
 
 		namespace Identify
 		{
-
 			void DispatchServerCommand(CommandHandler *apCommandObj,
 						   const ConcreteCommandPath &aCommandPath, TLV::TLVReader &aDataTlv)
 			{
@@ -443,7 +435,6 @@ namespace app
 
 		namespace LevelControl
 		{
-
 			void DispatchServerCommand(CommandHandler *apCommandObj,
 						   const ConcreteCommandPath &aCommandPath, TLV::TLVReader &aDataTlv)
 			{
@@ -551,7 +542,6 @@ namespace app
 
 		namespace OtaSoftwareUpdateRequestor
 		{
-
 			void DispatchServerCommand(CommandHandler *apCommandObj,
 						   const ConcreteCommandPath &aCommandPath, TLV::TLVReader &aDataTlv)
 			{
@@ -596,7 +586,6 @@ namespace app
 
 		namespace OnOff
 		{
-
 			void DispatchServerCommand(CommandHandler *apCommandObj,
 						   const ConcreteCommandPath &aCommandPath, TLV::TLVReader &aDataTlv)
 			{
@@ -685,7 +674,6 @@ namespace app
 
 		namespace OperationalCredentials
 		{
-
 			void DispatchServerCommand(CommandHandler *apCommandObj,
 						   const ConcreteCommandPath &aCommandPath, TLV::TLVReader &aDataTlv)
 			{
@@ -799,7 +787,6 @@ namespace app
 
 		namespace ThreadNetworkDiagnostics
 		{
-
 			void DispatchServerCommand(CommandHandler *apCommandObj,
 						   const ConcreteCommandPath &aCommandPath, TLV::TLVReader &aDataTlv)
 			{

--- a/samples/matter/light_bulb/src/zap-generated/endpoint_config.h
+++ b/samples/matter/light_bulb/src/zap-generated/endpoint_config.h
@@ -997,10 +997,7 @@ static_assert(ATTRIBUTE_LARGEST <= CHIP_CONFIG_MAX_ATTRIBUTE_STORE_ELEMENT_SIZE,
 // Array of device types
 #define FIXED_DEVICE_TYPES                                                                                             \
 	{                                                                                                              \
-		{ 0x00000016, 2 },                                                                                     \
-		{                                                                                                      \
-			0x00000101, 2                                                                                  \
-		}                                                                                                      \
+		{ 0x00000016, 2 }, { 0x00000101, 2 }                                                                   \
 	}
 
 // Array of device type offsets


### PR DESCRIPTION
Enable mandatory CopySceneResponse command in Scene Management Cluster in light bulb sample.