### PR TITLE
manifest: update sdk-zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 78d3dec9f93725fd453e1a3a960a1a4a6a12c483
+      revision: 60fce5e378ba89f71a2eec86de1c159cc448aad7
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
[nrf fromlist] tests: Bluetooth: Mesh: Default to ext adv
[nrf noup] Bluetooth: Mesh: remove legacy adv support 
https://github.com/nrfconnect/sdk-zephyr/pull/1725