### PR TITLE
doc improvement: adding link to nRF9161 guide

### DIFF
--- a/doc/nrf/device_guides/working_with_nrf/nrf91/nrf9161.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf91/nrf9161.rst
@@ -21,7 +21,7 @@ Board controller
 
 The nRF9161 DK contains an nRF5340 Interface MCU (IMCU), which acts both as an on-board debugger and board controller.
 The board controller controls signal switches on the nRF9161 DK and can be used to route the nRF9161 SiP pins to different components on the DK, such as pin headers, external memory, a SIM card or eSIM.
-For a complete list of configuration options available, see the nRF9161 DK board control section in the nRF9161 DK User Guide.
+For a complete list of configuration options available, see the `nRF9161 DK board control section in the nRF9161 DK User Guide`_.
 
 The nRF5340 IMCU comes preprogrammed with J-Link SEGGER OB and board controller firmware.
 If you want to change the default configuration of the DK, you can use the Board Configurator app in `nRF Connect for Desktop`_ .

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -603,15 +603,16 @@
 .. _`Security protocol for cellular IoT`: https://docs.nordicsemi.com/bundle/nwp_044/page/WP/nwp_044/security_protocols.html
 
 .. _`nRF9160 DK Hardware`: https://docs.nordicsemi.com/bundle/ug_nrf91_dk/page/UG/nrf91_DK/intro.html
-.. _`nRF9160 DK board control section in the nRF9160 DK User Guide`: https://docs.nordicsemi.com/bundle/ug_nrf91_dk/page/UG/nrf91_DK/board_controller.html
-.. _`External memory section in the nRF9160 DK User Guide`: https://docs.nordicsemi.com/bundle/ug_nrf91_dk/page/UG/nrf91_DK/external_memory.html
-.. _`Device programming section in the nRF9160 DK User Guide`: https://docs.nordicsemi.com/bundle/ug_nrf91_dk/page/UG/nrf91_DK/mcu_device_programming.html
-.. _`VDD supply rail section in the nRF9160 DK User Guide`: https://docs.nordicsemi.com/bundle/ug_nrf91_dk/page/UG/nrf91_DK/power_sources_vdd.html
+.. _`nRF9160 DK board control section in the nRF9160 DK User Guide`: https://docs.nordicsemi.com/bundle/ug_nrf9160_dk/page/UG/nrf91_DK/hw_description/nrf9160_board_controller.html
+.. _`External memory section in the nRF9160 DK User Guide`: https://docs.nordicsemi.com/bundle/ug_nrf9160_dk/page/UG/nrf91_DK/hw_description/external_memory.html
+.. _`Device programming section in the nRF9160 DK User Guide`: https://docs.nordicsemi.com/bundle/ug_nrf9160_dk/page/UG/nrf91_DK/operating_modes/mcu_device_programming.html
+.. _`VDD supply rail section in the nRF9160 DK User Guide`: https://docs.nordicsemi.com/bundle/ug_nrf9160_dk/page/UG/nrf91_DK/hw_description/power_sources_vdd.html
 
 .. _`nRF9161 Product Specification`: https://docs.nordicsemi.com/bundle/ps_nrf9161/page/nRF9161_html5_keyfeatures.html
 .. _`nRF9161 GPS receiver specification`: https://docs.nordicsemi.com/bundle/ps_nrf9161/page/gps.html
 
 .. _`nRF9161 DK Hardware`: https://docs.nordicsemi.com/bundle/ug_nrf9161_dk/page/UG/nrf91_DK/intro.html
+.. _`nRF9161 DK board control section in the nRF9161 DK User Guide`: https://docs.nordicsemi.com/bundle/ug_nrf9161_dk/page/UG/nrf91_DK/hw_description/nrf9161_board_controller.html
 .. _`Measuring current on nRF9161 DK`: https://docs.nordicsemi.com/bundle/ug_nrf9161_dk/page/UG/nrf91_DK/measuring_current/hw_measure_current.html
 
 .. _`AT Commands Reference Guide`:


### PR DESCRIPTION
The link to the nRF9161 board control section was missing both from the guide and the links.txt file. Added now.