### PR TITLE
manifest: update sdk-mcuboot, fix build warnings

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -131,7 +131,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 0b5810de95eb93bbd4fba8e20a2152b33880fc43
+      revision: 650d11c32368d8ddea310fcdf0d52b45d9017f15
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR


### PR DESCRIPTION
Update sdk-mcuboot to romeve warnigs with cleanup
unusable slot when direct xip mode is enabled.