### PR TITLE
TF-M and Crypto samples: add 9161 support

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -536,7 +536,8 @@ Cryptography samples
 * Added:
 
     * :ref:`crypto_spake2p` sample.
-    *  Support for the :ref:`zephyr:nrf9151dk_nrf9151` board for all crypto samples.
+    * Support for the :ref:`zephyr:nrf9151dk_nrf9151` board for all crypto samples.
+    * Support for the :ref:`nRF9161 DK <ug_nrf9161>` board for the :ref:`crypto_test` sample.
 
 Debug samples
 -------------
@@ -701,7 +702,7 @@ Sensor samples
 Trusted Firmware-M (TF-M) samples
 ---------------------------------
 
-* Added support for the :ref:`zephyr:nrf9151dk_nrf9151` board for all TF-M samples.
+* Added support for the :ref:`zephyr:nrf9151dk_nrf9151` and the :ref:`nRF9161 DK <ug_nrf9161>` boards for all TF-M samples (except for the :ref:`provisioning_image_net_core` sample).
 
 Thread samples
 --------------

--- a/samples/crypto/ecjpake/boards/nrf9161dk_nrf9161.conf
+++ b/samples/crypto/ecjpake/boards/nrf9161dk_nrf9161.conf
@@ -3,8 +3,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
-CONFIG_SRAM_SIZE=256
 
-# Using Oberon software crypto
+# Using software crypto
 CONFIG_PSA_CRYPTO_DRIVER_OBERON=y
 CONFIG_PSA_CRYPTO_DRIVER_CC3XX=n

--- a/samples/crypto/ecjpake/boards/nrf9161dk_nrf9161_ns.conf
+++ b/samples/crypto/ecjpake/boards/nrf9161dk_nrf9161_ns.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_TFM_PROFILE_TYPE_NOT_SET=y

--- a/samples/crypto/rng/prj.conf
+++ b/samples/crypto/rng/prj.conf
@@ -12,6 +12,7 @@ CONFIG_HEAP_MEM_POOL_SIZE=4096
 # Enable logging
 CONFIG_CONSOLE=y
 CONFIG_LOG=y
+CONFIG_LOG_MODE_IMMEDIATE=y
 
 # Enable nordic security backend and PSA APIs
 CONFIG_NRF_SECURITY=y

--- a/samples/crypto/rsa/prj.conf
+++ b/samples/crypto/rsa/prj.conf
@@ -9,6 +9,7 @@ CONFIG_HEAP_MEM_POOL_SIZE=16384
 # Enable logging
 CONFIG_CONSOLE=y
 CONFIG_LOG=y
+CONFIG_LOG_MODE_IMMEDIATE=y
 
 # Enable nordic security backend and PSA APIs
 CONFIG_NRF_SECURITY=y

--- a/samples/crypto/spake2p/boards/nrf9161dk_nrf9161_ns.conf
+++ b/samples/crypto/spake2p/boards/nrf9161dk_nrf9161_ns.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_TFM_PROFILE_TYPE_NOT_SET=y

--- a/samples/tfm/provisioning_image/sample.yaml
+++ b/samples/tfm/provisioning_image/sample.yaml
@@ -3,11 +3,16 @@ sample:
   name: Provisioning Image
 common:
   tags: keys
-  platform_allow: nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160 nrf9151dk/nrf9151
+  platform_allow:
+    - nrf5340dk/nrf5340/cpuapp
+    - nrf9151dk/nrf9151
+    - nrf9160dk/nrf9160
+    - nrf9161dk/nrf9161
   integration_platforms:
     - nrf5340dk/nrf5340/cpuapp
-    - nrf9160dk/nrf9160
     - nrf9151dk/nrf9151
+    - nrf9160dk/nrf9160
+    - nrf9161dk/nrf9161
   harness: console
   harness_config:
     type: multi_line

--- a/samples/tfm/tfm_hello_world/boards/nrf9161dk_nrf9161_ns.conf
+++ b/samples/tfm/tfm_hello_world/boards/nrf9161dk_nrf9161_ns.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_FPU=y

--- a/samples/tfm/tfm_hello_world/sample.yaml
+++ b/samples/tfm/tfm_hello_world/sample.yaml
@@ -6,13 +6,15 @@ common:
   tags: tfm
   platform_allow:
     - nrf5340dk/nrf5340/cpuapp/ns
-    - nrf9160dk/nrf9160/ns
-    - nrf9151dk/nrf9151/ns
     - nrf54l15pdk/nrf54l15/cpuapp/ns
+    - nrf9151dk/nrf9151/ns
+    - nrf9160dk/nrf9160/ns
+    - nrf9161dk/nrf9161/ns
   integration_platforms:
     - nrf5340dk/nrf5340/cpuapp/ns
-    - nrf9160dk/nrf9160/ns
     - nrf9151dk/nrf9151/ns
+    - nrf9160dk/nrf9160/ns
+    - nrf9161dk/nrf9161/ns
   harness: console
   harness_config:
     type: multi_line

--- a/samples/tfm/tfm_psa_template/boards/nrf9161dk_nrf9161_ns.conf
+++ b/samples/tfm/tfm_psa_template/boards/nrf9161dk_nrf9161_ns.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_FPU=y

--- a/samples/tfm/tfm_psa_template/sample.yaml
+++ b/samples/tfm/tfm_psa_template/sample.yaml
@@ -3,11 +3,16 @@ sample:
   name: TF-M PSA Template
 common:
   tags: tfm
-  platform_allow: nrf5340dk/nrf5340/cpuapp/ns nrf9160dk/nrf9160/ns nrf9151dk/nrf9151/ns
+  platform_allow:
+    - nrf5340dk/nrf5340/cpuapp/ns
+    - nrf9151dk/nrf9151/ns
+    - nrf9160dk/nrf9160/ns
+    - nrf9161dk/nrf9161/ns
   integration_platforms:
     - nrf5340dk/nrf5340/cpuapp/ns
-    - nrf9160dk/nrf9160/ns
     - nrf9151dk/nrf9151/ns
+    - nrf9160dk/nrf9160/ns
+    - nrf9161dk/nrf9161/ns
 tests:
   sample.tfm.psa_template:
     sysbuild: true

--- a/samples/tfm/tfm_secure_peripheral/boards/nrf9161dk_nrf9161_ns.conf
+++ b/samples/tfm/tfm_secure_peripheral/boards/nrf9161dk_nrf9161_ns.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+CONFIG_FPU=y
+# P0: 8 (button0), 11 (SPIM_MOSI), 13 (SPIM_SCK)
+CONFIG_NRF_GPIO0_PIN_MASK_SECURE=0x00002900

--- a/samples/tfm/tfm_secure_peripheral/boards/nrf9161dk_nrf9161_ns.overlay
+++ b/samples/tfm/tfm_secure_peripheral/boards/nrf9161dk_nrf9161_ns.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+ #include "nrf9160dk_nrf9160_ns.overlay"

--- a/samples/tfm/tfm_secure_peripheral/sample.yaml
+++ b/samples/tfm/tfm_secure_peripheral/sample.yaml
@@ -4,11 +4,16 @@ sample:
     TF-M sample demonstrating use of secure peripherals in a secure partition
 common:
   tags: tfm
-  platform_allow: nrf5340dk/nrf5340/cpuapp/ns nrf9160dk/nrf9160/ns nrf9151dk/nrf9151/ns
+  platform_allow:
+    - nrf5340dk/nrf5340/cpuapp/ns
+    - nrf9151dk/nrf9151/ns
+    - nrf9160dk/nrf9160/ns
+    - nrf9161dk/nrf9161/ns
   integration_platforms:
     - nrf5340dk/nrf5340/cpuapp/ns
-    - nrf9160dk/nrf9160/ns
     - nrf9151dk/nrf9151/ns
+    - nrf9160dk/nrf9160/ns
+    - nrf9161dk/nrf9161/ns
   harness: console
   harness_config:
     type: multi_line

--- a/tests/crypto/README.rst
+++ b/tests/crypto/README.rst
@@ -16,7 +16,7 @@ The tests support the following development kits:
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp, nrf9160dk_nrf9160, nrf9151dk_nrf9151, nrf52840dk_nrf52840
+   :rows: nrf52840dk_nrf52840, nrf5340dk_nrf5340_cpuapp, nrf9151dk_nrf9151, nrf9160dk_nrf9160, nrf9161dk_nrf9161
 
 .. note::
    Nordic Semiconductor devices for nRF51 Series, nRF52810, or nRF52811 cannot run the full test suite because of limited flash capacity.

--- a/tests/crypto/testcase.yaml
+++ b/tests/crypto/testcase.yaml
@@ -2,12 +2,18 @@ tests:
   crypto.cc3xx:
     sysbuild: true
     extra_args: OVERLAY_CONFIG=overlay-cc3xx.conf
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160 nrf9151dk/nrf9151
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9151dk/nrf9151
+      - nrf9160dk/nrf9160
+      - nrf9161dk/nrf9161
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
-      - nrf9160dk/nrf9160
       - nrf9151dk/nrf9151
+      - nrf9160dk/nrf9160
+      - nrf9161dk/nrf9161
     tags: crypto ci_build legacy cc3xx_legacy sysbuild
     harness_config:
       type: multi_line
@@ -17,12 +23,18 @@ tests:
   crypto.oberon:
     sysbuild: true
     extra_args: OVERLAY_CONFIG=overlay-oberon.conf
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160 nrf9151dk/nrf9151
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9151dk/nrf9151
+      - nrf9160dk/nrf9160
+      - nrf9161dk/nrf9161
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
-      - nrf9160dk/nrf9160
       - nrf9151dk/nrf9151
+      - nrf9160dk/nrf9160
+      - nrf9161dk/nrf9161
     tags: crypto ci_build legacy oberon_legacy sysbuild
     harness_config:
       type: multi_line

--- a/tests/tfm/secure_services/testcase.yaml
+++ b/tests/tfm/secure_services/testcase.yaml
@@ -1,9 +1,14 @@
 tests:
   tfm.secure_services:
     sysbuild: true
-    platform_allow: nrf9160dk/nrf9160/ns nrf9151dk/nrf9151/ns nrf5340dk/nrf5340/cpuapp/ns
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf9151dk/nrf9151/ns
+      - nrf9160dk/nrf9160/ns
+      - nrf9161dk/nrf9161/ns
     tags: tfm secure_services sysbuild
     integration_platforms:
-      - nrf9160dk/nrf9160/ns
-      - nrf9151dk/nrf9151/ns
       - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf9151dk/nrf9151/ns
+      - nrf9160dk/nrf9160/ns
+      - nrf9161dk/nrf9161/ns

--- a/tests/tfm/tfm_psa_test/README.rst
+++ b/tests/tfm/tfm_psa_test/README.rst
@@ -16,7 +16,7 @@ The test supports the following development kits:
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_ns, nrf9160dk_nrf9160_ns, nrf9151dk_nrf9151_ns
+   :rows: nrf5340dk_nrf5340_cpuapp_ns, nrf9151dk_nrf9151_ns, nrf9160dk_nrf9160_ns, nrf9161dk_nrf9161_ns
 
 Overview
 ********

--- a/tests/tfm/tfm_psa_test/testcase.yaml
+++ b/tests/tfm/tfm_psa_test/testcase.yaml
@@ -17,14 +17,16 @@ tests:
     timeout: 130
     platform_allow: >
       nrf5340dk/nrf5340/cpuapp/ns
-      nrf9160dk/nrf9160/ns
-      nrf9151dk/nrf9151/ns
       nrf54l15pdk/nrf54l15/cpuapp/ns
+      nrf9151dk/nrf9151/ns
+      nrf9160dk/nrf9160/ns
+      nrf9161dk/nrf9161/ns
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp/ns
-      - nrf9160dk/nrf9160/ns
-      - nrf9151dk/nrf9151/ns
       - nrf54l15pdk/nrf54l15/cpuapp/ns
+      - nrf9151dk/nrf9151/ns
+      - nrf9160dk/nrf9160/ns
+      - nrf9161dk/nrf9161/ns
   tfm.psa_test_storage_lvl2:
     sysbuild: true
     tags: tfm_lvl2 sysbuild
@@ -33,14 +35,16 @@ tests:
     timeout: 130
     platform_allow: >
       nrf5340dk/nrf5340/cpuapp/ns
-      nrf9160dk/nrf9160/ns
-      nrf9151dk/nrf9151/ns
       nrf54l15pdk/nrf54l15/cpuapp/ns
+      nrf9151dk/nrf9151/ns
+      nrf9160dk/nrf9160/ns
+      nrf9161dk/nrf9161/ns
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp/ns
-      - nrf9160dk/nrf9160/ns
-      - nrf9151dk/nrf9151/ns
       - nrf54l15pdk/nrf54l15/cpuapp/ns
+      - nrf9151dk/nrf9151/ns
+      - nrf9160dk/nrf9160/ns
+      - nrf9161dk/nrf9161/ns
   tfm.psa_test_crypto_lvl1:
     sysbuild: true
     tags: tfm_lvl1 sysbuild
@@ -50,14 +54,16 @@ tests:
     timeout: 120
     platform_allow: >
       nrf5340dk/nrf5340/cpuapp/ns
-      nrf9160dk/nrf9160/ns
-      nrf9151dk/nrf9151/ns
       nrf54l15pdk/nrf54l15/cpuapp/ns
+      nrf9151dk/nrf9151/ns
+      nrf9160dk/nrf9160/ns
+      nrf9161dk/nrf9161/ns
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp/ns
-      - nrf9160dk/nrf9160/ns
-      - nrf9151dk/nrf9151/ns
       - nrf54l15pdk/nrf54l15/cpuapp/ns
+      - nrf9151dk/nrf9151/ns
+      - nrf9160dk/nrf9160/ns
+      - nrf9161dk/nrf9161/ns
   tfm.psa_test_crypto_lvl2:
     sysbuild: true
     tags: tfm_lvl2 sysbuild
@@ -66,12 +72,14 @@ tests:
     timeout: 120
     platform_allow: >
       nrf5340dk/nrf5340/cpuapp/ns
-      nrf9160dk/nrf9160/ns
       nrf9151dk/nrf9151/ns
+      nrf9160dk/nrf9160/ns
+      nrf9161dk/nrf9161/ns
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp/ns
-      - nrf9160dk/nrf9160/ns
       - nrf9151dk/nrf9151/ns
+      - nrf9160dk/nrf9160/ns
+      - nrf9161dk/nrf9161/ns
   tfm.psa_test_initial_attestation_lvl1:
     sysbuild: true
     tags: tfm_lvl1 sysbuild
@@ -82,12 +90,14 @@ tests:
       - CONFIG_TFM_NRF_PROVISIONING=y
     platform_allow: >
       nrf5340dk/nrf5340/cpuapp/ns
-      nrf9160dk/nrf9160/ns
       nrf9151dk/nrf9151/ns
+      nrf9160dk/nrf9160/ns
+      nrf9161dk/nrf9161/ns
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp/ns
-      - nrf9160dk/nrf9160/ns
       - nrf9151dk/nrf9151/ns
+      - nrf9160dk/nrf9160/ns
+      - nrf9161dk/nrf9161/ns
   tfm.psa_test_initial_attestation_lvl2:
     sysbuild: true
     tags: tfm_lvl2 sysbuild
@@ -97,9 +107,11 @@ tests:
       - CONFIG_TFM_NRF_PROVISIONING=y
     platform_allow: >
       nrf5340dk/nrf5340/cpuapp/ns
-      nrf9160dk/nrf9160/ns
       nrf9151dk/nrf9151/ns
+      nrf9160dk/nrf9160/ns
+      nrf9161dk/nrf9161/ns
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp/ns
-      - nrf9160dk/nrf9160/ns
       - nrf9151dk/nrf9151/ns
+      - nrf9160dk/nrf9160/ns
+      - nrf9161dk/nrf9161/ns

--- a/tests/tfm/tfm_regression_test/README.rst
+++ b/tests/tfm/tfm_regression_test/README.rst
@@ -19,7 +19,7 @@ The tests support the following development kits:
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_ns, nrf9160dk_nrf9160_ns, nrf9151dk_nrf9151_ns
+   :rows: nrf5340dk_nrf5340_cpuapp_ns, nrf9151dk_nrf9151_ns, nrf9160dk_nrf9160_ns, nrf9161dk_nrf9161_ns
 
 Overview
 ********

--- a/tests/tfm/tfm_regression_test/testcase.yaml
+++ b/tests/tfm/tfm_regression_test/testcase.yaml
@@ -1,11 +1,16 @@
 common:
   tags: tfm
   build_only: true
-  platform_allow: nrf5340dk/nrf5340/cpuapp/ns nrf9160dk/nrf9160/ns nrf9151dk/nrf9151/ns
+  platform_allow:
+    - nrf5340dk/nrf5340/cpuapp/ns
+    - nrf9151dk/nrf9151/ns
+    - nrf9160dk/nrf9160/ns
+    - nrf9161dk/nrf9161/ns
   integration_platforms:
     - nrf5340dk/nrf5340/cpuapp/ns
-    - nrf9160dk/nrf9160/ns
     - nrf9151dk/nrf9151/ns
+    - nrf9160dk/nrf9160/ns
+    - nrf9161dk/nrf9161/ns
   harness: console
   harness_config:
     type: multi_line


### PR DESCRIPTION
* Add 9161 support to t-fm samples and tests
* Add 9161 support to crypto tests and samples