### PR TITLE
manifest: Update Zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 66628acfb7a88e71fe06124649168a02c94996d9
+      revision: pull/1727/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update Zephyr revision to have fixed kernel/timer tests when custom k_busy_wait implementation is chosen.