### PR TITLE
wifi: hostap: Fix user disconnection request

### DIFF
--- a/modules/hostap/src/supp_events.c
+++ b/modules/hostap/src/supp_events.c
@@ -70,6 +70,8 @@ static enum wifi_conn_status wpas_to_wifi_mgmt_conn_status(int status)
 static enum wifi_disconn_reason wpas_to_wifi_mgmt_diconn_status(int status)
 {
 	switch (status) {
+	case WLAN_STATUS_SUCCESS:
+		return WIFI_REASON_DISCONN_SUCCESS;
 	case WLAN_REASON_DEAUTH_LEAVING:
 		return WIFI_REASON_DISCONN_AP_LEAVING;
 	case WLAN_REASON_DISASSOC_DUE_TO_INACTIVITY:


### PR DESCRIPTION
[SHEL-2326] When user tries to disconnect the shell, it's always printing "Disconnection request failed". Here setting status as 0 when disconnection is requested by user. (wifi disconnect command). If disconnection happens due to any other reason, it will take reason code.

[SHEL-2326]: https://nordicsemi.atlassian.net/browse/SHEL-2326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ