### PR TITLE
samples: matter: Fix ipc_radio image configuration

### DIFF
--- a/samples/matter/light_bulb/sysbuild/ipc_radio/prj.conf
+++ b/samples/matter/light_bulb/sysbuild/ipc_radio/prj.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_SERIAL=n
+CONFIG_UART_CONSOLE=n
+CONFIG_LOG=n

--- a/samples/matter/light_switch/sysbuild/ipc_radio/prj.conf
+++ b/samples/matter/light_switch/sysbuild/ipc_radio/prj.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_SERIAL=n
+CONFIG_UART_CONSOLE=n
+CONFIG_LOG=n

--- a/samples/matter/lock/sysbuild/ipc_radio/prj.conf
+++ b/samples/matter/lock/sysbuild/ipc_radio/prj.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_SERIAL=n
+CONFIG_UART_CONSOLE=n
+CONFIG_LOG=n

--- a/samples/matter/template/sysbuild/ipc_radio/prj.conf
+++ b/samples/matter/template/sysbuild/ipc_radio/prj.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_SERIAL=n
+CONFIG_UART_CONSOLE=n
+CONFIG_LOG=n

--- a/samples/matter/thermostat/sysbuild/ipc_radio/prj.conf
+++ b/samples/matter/thermostat/sysbuild/ipc_radio/prj.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_SERIAL=n
+CONFIG_UART_CONSOLE=n
+CONFIG_LOG=n

--- a/samples/matter/window_covering/sysbuild/ipc_radio/prj.conf
+++ b/samples/matter/window_covering/sysbuild/ipc_radio/prj.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_SERIAL=n
+CONFIG_UART_CONSOLE=n
+CONFIG_LOG=n


### PR DESCRIPTION
This adds missing prj.conf file for matter samples ipc radio network core image.