### PR TITLE
[v2.6.99-cs2] update nrf-regtool to v5.3.0

### DIFF
--- a/scripts/requirements-build.txt
+++ b/scripts/requirements-build.txt
@@ -6,4 +6,4 @@ imagesize>=1.2.0
 intelhex
 pylint
 zcbor~=0.8.0
-nrf-regtool~=5.1.0
+nrf-regtool~=5.3.0

--- a/scripts/requirements-fixed.txt
+++ b/scripts/requirements-fixed.txt
@@ -43,7 +43,7 @@ grpcio==1.58.0            # via grpcio-tools
 grpcio-tools==1.58.0      # via -r zephyr/scripts/requirements-extras.txt
 idna==3.4                 # via requests
 imagesize==1.4.1          # via -r nrf/scripts/requirements-build.txt
-imgtool==1.10.0           # via -r zephyr/scripts/requirements-extras.txt
+imgtool==2.1.0            # via -r zephyr/scripts/requirements-extras.txt
 importlib-metadata==6.8.0  # via pyocd
 importlib-resources==6.1.0  # via libusb-package, pyocd
 iniconfig==2.0.0          # via pytest
@@ -69,7 +69,7 @@ msgpack==1.0.5            # via python-can
 mypy==1.5.1               # via -r zephyr/scripts/requirements-build-test.txt
 mypy-extensions==1.0.0    # via mypy
 natsort==8.4.0            # via pyocd
-nrf-regtool==5.1.0        # via -r nrf/scripts/requirements-build.txt
+nrf-regtool==5.3.0        # via -r nrf/scripts/requirements-build.txt
 nrfcredstore==1.0.0       # via -r nrf/scripts/requirements-extra.txt
 numpy==1.26.4             # via svada
 packaging==23.1           # via -r zephyr/scripts/requirements-base.txt, pytest, python-can, setuptools-scm, west
@@ -104,7 +104,7 @@ python-magic==0.4.27      # via -r zephyr/scripts/requirements-compliance.txt
 python-stdnum==1.19       # via -r nrf/scripts/requirements-ci.txt
 pytz==2023.3.post1        # via -r nrf/scripts/requirements-ci.txt
 pyusb==1.2.1              # via -r nrf/scripts/requirements-ci.txt, pyocd
-pyyaml==6.0.1             # via -r zephyr/scripts/requirements-base.txt, cmsis-pack-manager, devicetree, pyocd, west, yamllint, zcbor
+pyyaml==6.0.1             # via -r bootloader/mcuboot/scripts/requirements.txt, -r zephyr/scripts/requirements-base.txt, cmsis-pack-manager, devicetree, pyocd, west, yamllint, zcbor
 qrcode==7.4.2             # via -r nrf/scripts/requirements-ci.txt
 referencing==0.30.2       # via jsonschema, jsonschema-specifications
 regex==2023.8.8           # via zcbor

--- a/scripts/requirements-fixed.txt
+++ b/scripts/requirements-fixed.txt
@@ -41,7 +41,7 @@ gitpython==3.1.41         # via -r nrf/scripts/requirements-ci.txt
 graphviz==0.20.1          # via -r zephyr/scripts/requirements-extras.txt
 grpcio==1.58.0            # via grpcio-tools
 grpcio-tools==1.58.0      # via -r zephyr/scripts/requirements-extras.txt
-idna==3.4                 # via requests
+idna==3.7                 # via requests
 imagesize==1.4.1          # via -r nrf/scripts/requirements-build.txt
 imgtool==2.1.0            # via -r zephyr/scripts/requirements-extras.txt
 importlib-metadata==6.8.0  # via pyocd
@@ -50,7 +50,7 @@ iniconfig==2.0.0          # via pytest
 intelhex==2.3.0           # via -r bootloader/mcuboot/scripts/requirements.txt, -r nrf/scripts/requirements-build.txt, -r zephyr/scripts/requirements-base.txt, imgtool, lpc-checksum, nrf-regtool, pyocd
 intervaltree==3.1.0       # via pyocd
 isort==5.12.0             # via pylint
-jinja2==3.1.3             # via -r nrf/scripts/requirements-extra.txt, gcovr, junit2html
+jinja2==3.1.4             # via -r nrf/scripts/requirements-extra.txt, gcovr, junit2html
 jsonschema==4.19.1        # via -r nrf/scripts/requirements-ci.txt
 jsonschema-specifications==2023.7.1  # via jsonschema
 junit2html==30.1.3        # via -r zephyr/scripts/requirements-extras.txt
@@ -74,7 +74,7 @@ nrfcredstore==1.0.0       # via -r nrf/scripts/requirements-extra.txt
 numpy==1.26.4             # via svada
 packaging==23.1           # via -r zephyr/scripts/requirements-base.txt, pytest, python-can, setuptools-scm, west
 pathspec==0.11.2          # via yamllint
-pillow==10.2.0            # via -r nrf/scripts/requirements-extra.txt, -r zephyr/scripts/requirements-extras.txt
+pillow==10.3.0            # via -r nrf/scripts/requirements-extra.txt, -r zephyr/scripts/requirements-extras.txt
 platformdirs==3.10.0      # via pylint
 pluggy==1.3.0             # via pytest
 ply==3.11                 # via -r zephyr/scripts/requirements-build-test.txt
@@ -108,7 +108,7 @@ pyyaml==6.0.1             # via -r bootloader/mcuboot/scripts/requirements.txt, 
 qrcode==7.4.2             # via -r nrf/scripts/requirements-ci.txt
 referencing==0.30.2       # via jsonschema, jsonschema-specifications
 regex==2023.8.8           # via zcbor
-requests==2.31.0          # via -r zephyr/scripts/requirements-base.txt, pygithub
+requests==2.32.0          # via -r zephyr/scripts/requirements-base.txt, pygithub
 rpds-py==0.10.3           # via jsonschema, referencing
 ruamel-yaml==0.17.32      # via pykwalify
 ruamel-yaml-clib==0.2.7   # via ruamel-yaml

--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 5938faf9379a2be34f1f115a1d159db1ba1fee13
+      revision: 7a22da43c1d46758f827adcba3c96b94effd6ee4
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update nrf-regtool to v5.3.0 which is able to set CTRLSEL for most peripherals automatically.

Update sdk-zephyr to pull in a change that increases the number of ports supported by the NRF_PSEL macro, which is required alongside the nrf-regtool version.