### PR TITLE
manifest: Update sdk-zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 1a5d3b4a4ff98a33222856526afdf9c089b96d2b
+      revision: pull/1733/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This PR introduces the suspend to ram feature for nRF54H20 targets.