### PR TITLE
scripts: requirements-build: update nrf-regtool to 5.3.0

### DIFF
--- a/scripts/requirements-build.txt
+++ b/scripts/requirements-build.txt
@@ -6,4 +6,4 @@ imagesize>=1.2.0
 intelhex
 pylint
 zcbor~=0.8.0
-nrf-regtool~=5.2.0
+nrf-regtool~=5.3.0

--- a/scripts/requirements-fixed.txt
+++ b/scripts/requirements-fixed.txt
@@ -70,7 +70,7 @@ msgpack==1.0.5            # via python-can
 mypy==1.5.1               # via -r zephyr/scripts/requirements-build-test.txt
 mypy-extensions==1.0.0    # via mypy
 natsort==8.4.0            # via pyocd
-nrf-regtool==5.2.0        # via -r nrf/scripts/requirements-build.txt
+nrf-regtool==5.3.0        # via -r nrf/scripts/requirements-build.txt
 nrfcredstore==1.0.0       # via -r nrf/scripts/requirements-extra.txt
 numpy==1.26.4             # via svada
 packaging==23.1           # via -r zephyr/scripts/requirements-base.txt, pytest, python-can, setuptools-scm, west

--- a/scripts/requirements-fixed.txt
+++ b/scripts/requirements-fixed.txt
@@ -109,7 +109,7 @@ pyyaml==6.0.1             # via -r bootloader/mcuboot/scripts/requirements.txt, 
 qrcode==7.4.2             # via -r nrf/scripts/requirements-ci.txt
 referencing==0.30.2       # via jsonschema, jsonschema-specifications
 regex==2023.8.8           # via zcbor
-requests==2.31.0          # via -r zephyr/scripts/requirements-base.txt, pygithub
+requests==2.32.0          # via -r zephyr/scripts/requirements-base.txt, pygithub
 rpds-py==0.10.3           # via jsonschema, referencing
 ruamel-yaml==0.17.32      # via pykwalify
 ruamel-yaml-clib==0.2.7   # via ruamel-yaml

--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 25fbeabe900442d0568090765851aa452c4d8947
+      revision: 155bb98540633afb1c8b588397c67ea86409dbbd
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update nrf-regtool to v5.3.0 which is able to set CTRLSEL for most peripherals automatically.

Update sdk-zephyr to pull in a change that increases the number of ports supported by the NRF_PSEL macro, which is required alongside the nrf-regtool version.