### PR TITLE
suit: stream: extmem: Remove unused variable

### DIFF
--- a/subsys/suit/stream/stream_sinks/src/suit_extmem_sink.c
+++ b/subsys/suit/stream/stream_sinks/src/suit_extmem_sink.c
@@ -67,7 +67,6 @@ static bool is_address_supported(uintptr_t address, struct extmem_capabilities *
 {
 	uintptr_t extmem_area_start = capabilities->base_addr;
 	size_t extmem_area_size = capabilities->capacity;
-	uintptr_t extmem_area_end = extmem_area_start + extmem_area_size;
 
 	return suit_memory_global_address_range_is_in_external_memory(extmem_area_start,
 								      extmem_area_size);


### PR DESCRIPTION
Drop `extmem_area_end` from `is_address_supported()`.