### PR TITLE
Add nRF Cloud CoAP download support

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -942,6 +942,7 @@ Libraries for networking
     * The :c:func:`nrf_cloud_coap_shadow_desired_update` function to allow devices to reject invalid shadow deltas.
     * Support for IPv6 connections.
     * The ``SO_KEEPOPEN`` socket option to keep the socket open even during PDN disconnect and reconnect.
+    * The experimental Kconfig option :kconfig:option:`CONFIG_NRF_CLOUD_COAP_DOWNLOADS` that enables downloading FOTA and P-GPS data using CoAP instead of HTTP.
 
 * :ref:`lib_lwm2m_client_utils` library:
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -964,6 +964,13 @@ Libraries for networking
 
   * Removed the deprecated ``download_client_connect`` function.
 
+* :ref:`lib_fota_download` library:
+
+  * Added:
+
+    * The function :c:func:`fota_download_b1_file_parse` to parse a bootloader update file path.
+    * Experimental support for performing FOTA updates using an external download client with the Kconfig option :kconfig:option:`CONFIG_FOTA_DOWNLOAD_EXTERNAL_DL` and functions :c:func:`fota_download_external_start` and Function :c:func:`fota_download_external_evt_handle`.
+
 Libraries for NFC
 -----------------
 

--- a/subsys/net/lib/fota_download/Kconfig
+++ b/subsys/net/lib/fota_download/Kconfig
@@ -62,6 +62,10 @@ config FOTA_DOWNLOAD_SEC_TAG_LIST_SIZE_MAX
 	help
 	  Maximum size of the list of security tags used to store TLS credentials.
 
+config FOTA_DOWNLOAD_EXTERNAL_DL
+	bool "Use external download events to perform FOTA updates"
+	select EXPERIMENTAL
+
 module=FOTA_DOWNLOAD
 module-dep=LOG
 module-str=Firmware Over the Air Download

--- a/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_coap
+++ b/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_coap
@@ -48,6 +48,15 @@ config NRF_CLOUD_COAP_SEND_SSIDS
 
 endif # WIFI
 
+config NRF_CLOUD_COAP_DOWNLOADS
+	bool "Download files using CoAP instead of HTTP"
+	depends on NRF_CLOUD_COAP
+	select EXPERIMENTAL
+	help
+	  Use nRF Cloud CoAP's proxy download resource to download files for FOTA and P-GPS.
+	  When enabled, the Kconfig option COAP_EXTENDED_OPTIONS_LEN_VALUE must be increased
+	  from the default value. Safe values are 80 for P-GPS and 192 for FOTA.
+
 module = NRF_CLOUD_COAP
 module-str = nRF Cloud COAP
 source "subsys/logging/Kconfig.template.log_config"

--- a/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_fota
+++ b/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_fota
@@ -147,6 +147,8 @@ config NRF_CLOUD_FOTA_TYPE_MODEM_FULL_SUPPORTED
 
 config NRF_CLOUD_FOTA_POLL
 	bool "Enable FOTA job polling helpers"
+	depends on FOTA_DOWNLOAD
+	select FOTA_DOWNLOAD_EXTERNAL_DL if NRF_CLOUD_COAP_DOWNLOADS
 	help
 	  When enabled, nRF Cloud FOTA job polling helpers will be built.  These
 	  functions make it easy to request, download, and handle modem, boot,

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_download.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_download.h
@@ -28,6 +28,7 @@ enum nrf_cloud_download_type {
 struct nrf_cloud_download_fota {
 	/* FOTA update type */
 	enum dfu_target_image_type expected_type;
+	int img_sz;
 };
 
 struct nrf_cloud_download_data {

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_download.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_download.c
@@ -9,18 +9,298 @@
 #if defined(CONFIG_FOTA_DOWNLOAD)
 #include <net/fota_download.h>
 #endif
+#if defined(CONFIG_NRF_CLOUD_COAP)
+#include "../coap/include/nrf_cloud_coap_transport.h"
+#endif
 #include "nrf_cloud_download.h"
+
 LOG_MODULE_REGISTER(nrf_cloud_download, CONFIG_NRF_CLOUD_LOG_LEVEL);
+
+#if defined(CONFIG_NRF_CLOUD_COAP_DOWNLOADS) && defined(CONFIG_NRF_CLOUD_PGPS)
+BUILD_ASSERT(CONFIG_COAP_EXTENDED_OPTIONS_LEN_VALUE >= 80,
+	"CONFIG_COAP_EXTENDED_OPTIONS_LEN_VALUE should be at least 80 for CoAP P-GPS downloads");
+#endif
+
+#if defined(CONFIG_NRF_CLOUD_COAP_DOWNLOADS) && defined(CONFIG_NRF_CLOUD_FOTA_POLL)
+BUILD_ASSERT(CONFIG_COAP_EXTENDED_OPTIONS_LEN_VALUE >= 192,
+	"CONFIG_COAP_EXTENDED_OPTIONS_LEN_VALUE should be at least 192 for CoAP FOTA downloads");
+#endif
 
 static K_MUTEX_DEFINE(active_dl_mutex);
 static struct nrf_cloud_download_data active_dl = { .type = NRF_CLOUD_DL_TYPE_NONE };
 
-void nrf_cloud_download_end(void)
+#if defined(CONFIG_NRF_CLOUD_COAP_DOWNLOADS)
+#define ACPT_IDX 0
+#define PRXY_IDX 1
+#define OPT_CNT  2
+/* CoAP option array */
+static struct coap_client_option cc_opts[OPT_CNT] = {0};
+/* CoAP client to be used for file downloads */
+static struct nrf_cloud_coap_client coap_client;
+
+static int coap_dl_init(void)
 {
-	k_mutex_lock(&active_dl_mutex, K_FOREVER);
+	return nrf_cloud_coap_transport_init(&coap_client);
+}
+
+static int coap_dl_connect_and_auth(struct nrf_cloud_download_data *const dl)
+{
+	int ret = nrf_cloud_coap_transport_connect(&coap_client);
+
+	if (ret) {
+		LOG_ERR("CoAP connect failed, error; %d", ret);
+		return -EIO;
+	}
+
+	ret = nrf_cloud_coap_transport_authenticate(&coap_client);
+	if (ret) {
+		LOG_ERR("CoAP authentication failed, error; %d", ret);
+		return -EACCES;
+	}
+
+	return 0;
+}
+
+static int fota_dl_evt_send(const struct download_client_evt *evt)
+{
+#if defined(CONFIG_FOTA_DOWNLOAD)
+	return fota_download_external_evt_handle(evt);
+#endif
+	return -ENOTSUP;
+}
+
+static int coap_dl_event_send(struct nrf_cloud_download_data const *const dl,
+			      const struct download_client_evt *const evt)
+{
+	if (dl->type == NRF_CLOUD_DL_TYPE_FOTA) {
+		return fota_dl_evt_send(evt);
+	} else if (dl->type == NRF_CLOUD_DL_TYPE_DL_CLIENT) {
+		return dl->dlc->callback(evt);
+	}
+
+	return -EINVAL;
+}
+
+static int coap_dl_disconnect(void)
+{
+	return nrf_cloud_coap_transport_disconnect(&coap_client);
+}
+
+static void coap_dl_cb(int16_t result_code, size_t offset, const uint8_t *payload, size_t len,
+		       bool last_block, void *user_data)
+{
+	int ret;
+	bool send_closed_evt = false;
+	bool error = false;
+	struct nrf_cloud_download_data *dl = (struct nrf_cloud_download_data *)user_data;
+	struct download_client_evt evt = {0};
+
+	LOG_DBG("CoAP result: %d, offset: 0x%X, len: 0x%X, last_block: %d",
+		result_code, offset, len, last_block);
+
+	if (result_code == COAP_RESPONSE_CODE_CONTENT) {
+		evt.id = DOWNLOAD_CLIENT_EVT_FRAGMENT;
+		evt.fragment.buf = payload;
+		evt.fragment.len = len;
+	} else if (result_code != COAP_RESPONSE_CODE_OK) {
+		LOG_ERR("Unexpected CoAP result: %d", result_code);
+		LOG_DBG("CoAP response: %*s", len, payload);
+		evt.id = DOWNLOAD_CLIENT_EVT_ERROR;
+		evt.error = ETIMEDOUT;
+		error = true;
+	}
+
+	ret = coap_dl_event_send(dl, &evt);
+	if (ret || error) {
+		send_closed_evt = true;
+		error = true;
+	} else if (last_block) {
+		LOG_INF("Download complete");
+
+		memset(&evt, 0, sizeof(evt));
+		evt.id = DOWNLOAD_CLIENT_EVT_DONE;
+
+		ret = coap_dl_event_send(dl, &evt);
+		if (ret) {
+			/* Send a closed event on error */
+			send_closed_evt = true;
+			error = true;
+		}
+
+		ret = coap_dl_disconnect();
+		if (ret && (ret != -ENOTCONN)) {
+			LOG_WRN("Failed to disconnect CoAP transport, error: %d", ret);
+		}
+
+		if (dl->type == NRF_CLOUD_DL_TYPE_FOTA) {
+			/* fota_download expects a closed event when the download is done */
+			send_closed_evt = true;
+		}
+	}
+
+	if (send_closed_evt) {
+		memset(&evt, 0, sizeof(evt));
+		evt.id = DOWNLOAD_CLIENT_EVT_CLOSED;
+
+		(void)coap_dl_event_send(dl, &evt);
+	}
+
+	if (error) {
+		LOG_ERR("CoAP download error, stopping download");
+		nrf_cloud_download_end();
+	}
+}
+
+#define MAX_RETRIES 5
+static int coap_dl_start(struct nrf_cloud_download_data *const dl)
+{
+	int err;
+	int retry = 0;
+	struct coap_client *cc = &coap_client.cc;
+
+	struct coap_client_request request = {
+		.method = COAP_METHOD_GET,
+		.confirmable = true,
+		.path = NRF_CLOUD_COAP_PROXY_RSC,
+		.fmt = COAP_CONTENT_FORMAT_APP_OCTET_STREAM,
+		.payload = NULL,
+		.len = 0,
+		.cb = coap_dl_cb,
+		.user_data = dl,
+		.options = cc_opts,
+		.num_options = OPT_CNT
+	};
+
+	while ((err = coap_client_req(cc, cc->fd, NULL, &request, NULL)) == -EAGAIN) {
+		if (retry++ > MAX_RETRIES) {
+			LOG_ERR("Timeout waiting for CoAP client to be available");
+			return -ETIMEDOUT;
+		}
+		LOG_DBG("CoAP client busy");
+		k_sleep(K_MSEC(500));
+	}
+
+	if (err == 0) {
+		LOG_DBG("Sent CoAP download request");
+	} else {
+		LOG_ERR("Error sending CoAP request: %d", err);
+	}
+
+	return err;
+}
+
+static int coap_dl(struct nrf_cloud_download_data *const dl)
+{
+#if defined(CONFIG_FOTA_DOWNLOAD) && defined(CONFIG_NRF_CLOUD_FOTA_TYPE_BOOT_SUPPORTED)
+	static char buf[CONFIG_FOTA_DOWNLOAD_RESOURCE_LOCATOR_LENGTH];
+#endif
+	const char *file_path = dl->path;
+	int ret = coap_dl_init();
+
+	if (ret) {
+		LOG_ERR("Failed to initialize CoAP download, error: %d", ret);
+		return ret;
+	}
+
+	ret = coap_dl_connect_and_auth(dl);
+	if (ret) {
+		return ret;
+	}
+
+#if defined(CONFIG_FOTA_DOWNLOAD) && defined(CONFIG_NRF_CLOUD_FOTA_TYPE_BOOT_SUPPORTED)
+	if (dl->type == NRF_CLOUD_DL_TYPE_FOTA) {
+		/* Copy file path to modifiable buffer and check for a bootloader file */
+		memcpy(buf, dl->path, strlen(dl->path) + 1);
+		ret = fota_download_b1_file_parse(buf);
+
+		if (ret == 0) {
+			/* A bootload file has been found */
+			file_path = buf;
+		}
+	}
+#endif
+
+	/* Get the options for the proxy download */
+	ret = nrf_cloud_coap_transport_proxy_dl_opts_get(&cc_opts[ACPT_IDX],
+							 &cc_opts[PRXY_IDX],
+							 dl->host, file_path);
+	if (ret) {
+		LOG_ERR("Failed to set CoAP options, error: %d", ret);
+		return ret;
+	}
+
+	if (dl->type == NRF_CLOUD_DL_TYPE_FOTA) {
+		ret = fota_download_external_start(dl->host, file_path, dl->fota.expected_type,
+						  (size_t)dl->fota.img_sz);
+		if (ret) {
+			LOG_ERR("Failed to start FOTA download, error: %d", ret);
+			return ret;
+		}
+	}
+
+	return coap_dl_start(dl);
+}
+#endif /* NRF_CLOUD_COAP_DOWNLOADS */
+
+static int fota_start(struct nrf_cloud_download_data *const dl)
+{
+#if defined(CONFIG_FOTA_DOWNLOAD)
+#if defined(CONFIG_NRF_CLOUD_COAP_DOWNLOADS)
+	return coap_dl(dl);
+#else
+	return fota_download_start_with_image_type(dl->host, dl->path,
+		dl->dl_cfg.sec_tag_count ? dl->dl_cfg.sec_tag_list[0] : -1,
+		dl->dl_cfg.pdn_id, dl->dl_cfg.frag_size_override, dl->fota.expected_type);
+#endif /* CONFIG_NRF_CLOUD_COAP_DOWNLOADS */
+#endif /* CONFIG_FOTA_DOWNLOAD */
+	return -ENOTSUP;
+}
+
+static int dlc_start(struct nrf_cloud_download_data *const dl)
+{
+	__ASSERT(dl->dlc != NULL, "Download client is NULL");
+	__ASSERT(dl->dlc->callback != NULL, "Download client callback is NULL");
+
+#if defined(CONFIG_NRF_CLOUD_COAP_DOWNLOADS)
+	return coap_dl(dl);
+#endif /* CONFIG_NRF_CLOUD_COAP_DOWNLOADS */
+
+	return download_client_get(dl->dlc, dl->host, &dl->dl_cfg, dl->path, 0);
+}
+
+static int dlc_disconnect(struct nrf_cloud_download_data *const dl)
+{
+#if defined(CONFIG_NRF_CLOUD_COAP_DOWNLOADS)
+	return coap_dl_disconnect();
+#endif /* CONFIG_NRF_CLOUD_COAP_DOWNLOADS */
+
+	return download_client_disconnect(dl->dlc);
+}
+
+static void active_dl_reset(void)
+{
 	memset(&active_dl, 0, sizeof(active_dl));
 	active_dl.type = NRF_CLOUD_DL_TYPE_NONE;
+}
+
+void nrf_cloud_download_end(void)
+{
+#if defined(CONFIG_NRF_CLOUD_COAP_DOWNLOADS)
+	coap_dl_disconnect();
+#endif
+
+	k_mutex_lock(&active_dl_mutex, K_FOREVER);
+	active_dl_reset();
 	k_mutex_unlock(&active_dl_mutex);
+}
+
+static bool check_fota_file_path_len(char const *const file_path)
+{
+#if defined(CONFIG_FOTA_DOWNLOAD)
+	/* Check that the null-terminator is found in the allowable buffer length */
+	return memchr(file_path, '\0', CONFIG_FOTA_DOWNLOAD_RESOURCE_LOCATOR_LENGTH) != NULL;
+#endif
+	return true;
 }
 
 int nrf_cloud_download_start(struct nrf_cloud_download_data *const dl)
@@ -32,6 +312,11 @@ int nrf_cloud_download_start(struct nrf_cloud_download_data *const dl)
 
 	if (!IS_ENABLED(CONFIG_FOTA_DOWNLOAD) && (dl->type == NRF_CLOUD_DL_TYPE_FOTA)) {
 		return -ENOTSUP;
+	}
+
+	if (!check_fota_file_path_len(dl->path)) {
+		LOG_ERR("FOTA download file path is too long");
+		return -E2BIG;
 	}
 
 	int ret = 0;
@@ -52,33 +337,31 @@ int nrf_cloud_download_start(struct nrf_cloud_download_data *const dl)
 	 */
 	if (active_dl.type == NRF_CLOUD_DL_TYPE_DL_CLIENT) {
 		LOG_INF("Stopping active download, incoming FOTA update download has priority");
-		ret = download_client_disconnect(active_dl.dlc);
+		ret = dlc_disconnect(&active_dl);
 
 		if (ret) {
 			LOG_ERR("download_client_disconnect() failed, error %d", ret);
 		}
 	}
 
-	if (dl->type == NRF_CLOUD_DL_TYPE_FOTA) {
-#if defined(CONFIG_FOTA_DOWNLOAD)
-		ret = fota_download_start_with_image_type(dl->host, dl->path,
-			dl->dl_cfg.sec_tag_count ? dl->dl_cfg.sec_tag_list[0] : -1,
-			dl->dl_cfg.pdn_id, dl->dl_cfg.frag_size_override, dl->fota.expected_type);
-#endif
-	} else if (dl->type == NRF_CLOUD_DL_TYPE_DL_CLIENT) {
-		ret = download_client_get(dl->dlc, dl->host, &dl->dl_cfg,
-					  dl->path, 0);
+	active_dl = *dl;
+
+	if (active_dl.type == NRF_CLOUD_DL_TYPE_FOTA) {
+		ret = fota_start(&active_dl);
+	} else if (active_dl.type == NRF_CLOUD_DL_TYPE_DL_CLIENT) {
+		ret = dlc_start(&active_dl);
 		if (ret) {
-			(void)download_client_disconnect(dl->dlc);
+			(void)dlc_disconnect(&active_dl);
 		}
 	} else {
-		LOG_WRN("Unhandled download type: %d", dl->type);
+		LOG_WRN("Unhandled download type: %d", active_dl.type);
 		ret = -EFTYPE;
 	}
 
-	if (ret == 0) {
-		active_dl = *dl;
+	if (ret != 0) {
+		active_dl_reset();
 	}
+
 	k_mutex_unlock(&active_dl_mutex);
 
 	return ret;

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota_poll.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota_poll.c
@@ -156,6 +156,15 @@ static void http_fota_dl_handler(const struct fota_download_evt *evt)
 	case FOTA_DOWNLOAD_EVT_PROGRESS:
 		LOG_DBG("FOTA download percent: %d%%", evt->progress);
 		break;
+	case FOTA_DOWNLOAD_EVT_RESUME_OFFSET:
+		/* TODO: for now, just fail the download.
+		 * Unable to resume with CoAP until NRFCDP-423 is complete.
+		 */
+		nrf_cloud_download_end();
+		fota_status = NRF_CLOUD_FOTA_FAILED;
+		fota_status_details = FOTA_STATUS_DETAILS_DL_ERR;
+		k_sem_give(&fota_download_sem);
+		break;
 	default:
 		break;
 	}
@@ -360,7 +369,10 @@ static int start_download(void)
 			.pdn_id = 0,
 			.frag_size_override = FOTA_DL_FRAGMENT_SZ,
 		},
-		.fota = { .expected_type = img_type }
+		.fota = {
+			.expected_type = img_type,
+			.img_sz = job.file_size
+		}
 	};
 
 	ret = nrf_cloud_download_start(&dl);

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps_utils.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps_utils.c
@@ -565,11 +565,14 @@ static int download_client_callback(const struct download_client_evt *event)
 		return 0;
 	}
 
+	/* CoAP downloads do not need to disconnect since they don't directly use download_client */
+#if !defined(CONFIG_NRF_CLOUD_COAP_DOWNLOADS)
 	int ret = download_client_disconnect(&dlc);
 
 	if (ret) {
 		LOG_ERR("Error disconnecting from download client:%d", ret);
 	}
+#endif
 
 	nrf_cloud_download_end();
 


### PR DESCRIPTION
Update `fota_download` to allow for FOTA updates to be performed using an external download source.
Update `nrf_cloud` library to enable downloading FOTA and P-GPS data using nRF Cloud's CoAP proxy download resource.