### PR TITLE
samples: bootloader: Add 9151 and 9161 support

### DIFF
--- a/doc/nrf/libraries/security/bootloader/bl_storage.rst
+++ b/doc/nrf/libraries/security/bootloader/bl_storage.rst
@@ -22,7 +22,7 @@ The library has the following functions for either reading or writing, or in som
 * Invalidation tokens, used to revoke public keys.
 * Additional public key metadata.
 
-The library uses either the OTP region of the User information configuration registers (UICR), when present on SoCs like the nRF9160 or nRF5340, or the internal flash memory.
+The library uses either the OTP region of the user information configuration registers (UICR), when present on nRF91 Series or nRF5340 devices, or the internal flash memory.
 When the library uses the internal flash memory, the bootloader blocks the write access before booting the next image.
 
 See :ref:`bootloader_provisioning` for more information about the provisioned data and how the bootloader uses it.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -741,6 +741,10 @@ Other samples
 * Added the :ref:`coremark_sample` sample that demonstrates how to easily measure a performance of the supported SoCs by running the Embedded Microprocessor Benchmark Consortium (EEMBC) CoreMark benchmark.
   Included support for the nRF52840 DK, nRF5340 DK, and nRF54L15 PDK.
 
+* :ref:`bootloader` sample:
+
+  * Added support for the :ref:`zephyr:nrf9151dk_nrf9151` and the :ref:`nRF9161 DK <ug_nrf9161>` boards.
+
 * :ref:`ipc_service_sample` sample:
 
   * Removed support for the `OpenAMP`_ library backend on the :ref:`zephyr:nrf54h20dk_nrf54h20` board.

--- a/samples/bootloader/README.rst
+++ b/samples/bootloader/README.rst
@@ -72,7 +72,7 @@ OTP regions
 
 The one-time programmable (OTP) region is a special region of the *User Information Configuration Registers* (UICR) that only allows flash memory writes in half-word lengths, and *only* when the target half-word has the value of ``0xFFFF``.
 
-On the SoCs that support an OTP region, such as the nRF9160 and nRF5340, the provisioned data is held in the OTP region instead of the internal flash memory.
+On products that support an OTP region, such as the nRF91 Series and nRF5340, the provisioned data is held in the OTP region instead of the internal flash memory.
 
 Because of these design constraints, the following limitations apply:
 
@@ -84,7 +84,7 @@ Because of these design constraints, the following limitations apply:
   When programming images that contain flash memory content in the UICR region, such as the NSIB image, the UICR must first be erased.
 
 .. note::
-   On the nRF9160 and nRF5340, the UICR can only be erased by erasing the entire flash memory.
+   On the nRF91 Series and nRF5340 devices, the UICR can only be erased by erasing the entire flash memory.
 
 For information how to erase the entire flash memory when flashing, see :ref:`programming`.
 

--- a/samples/bootloader/sample.yaml
+++ b/samples/bootloader/sample.yaml
@@ -7,12 +7,21 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
       - nrf9160dk/nrf9160
+      - nrf9161dk/nrf9161
+      - nrf9151dk/nrf9151
       - nrf52833dk/nrf52833
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
       - nrf21540dk/nrf52840
-    platform_allow: nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160 nrf52840dk/nrf52840
-      nrf52833dk/nrf52833 nrf52dk/nrf52832 nrf21540dk/nrf52840
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160
+      - nrf9161dk/nrf9161
+      - nrf9151dk/nrf9151
+      - nrf52840dk/nrf52840
+      - nrf52833dk/nrf52833
+      - nrf52dk/nrf52832
+      - nrf21540dk/nrf52840
     extra_args:
       - SB_CONFIG_PARTITION_MANAGER=n
     tags: ci_build sysbuild


### PR DESCRIPTION
nrf9151 and nrf9161 to tests and documentation.

This stems from adding nrf9151 and nrf9161 support for crypto and security samples. 