### PR TITLE
ci: Use pipeline from v2.6.99-cs2-branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library("CI_LIB") _
+@Library("CI_LIB@v2.6.99-cs2-branch") _
 
 def pipeline = new ncs.sdk_nrf.Main()
 


### PR DESCRIPTION
On v2.6.99-cs2-branch sdk-zephyr's test suite is disabled.