### PR TITLE
bluetooth: fast_pair: improve doc for enable and factory reset APIs

### DIFF
--- a/include/bluetooth/services/fast_pair/fast_pair.h
+++ b/include/bluetooth/services/fast_pair/fast_pair.h
@@ -156,6 +156,19 @@ struct bt_fast_pair_info_cb {
  * functions. The Fast Pair operations require the enabled Bluetooth subsystem
  * (see the bt_is_ready function) and the load operation of the settings subsystem.
  *
+ * Mandatory callbacks must be registered before the user enables the Fast Pair module with
+ * this API. The mandatory callback set may depend on the chosen Fast Pair extension set
+ * that is selected in the application Kconfig configuration. The enable API fails with
+ * an error if mandatory callbacks are not registered. An example of a mandatory callback
+ * is the @ref bt_fast_pair_fmdn_ring_cb structure defined in the API header of the Find My
+ * Device Network extension when this extension is configured to support ringing operations.
+ * The Fast Pair module configuration without any extensions does not require any mandatory
+ * callbacks.
+ *
+ * If the application uses non-mandatory callbacks, like the @ref bt_fast_pair_fmdn_ring_cb
+ * structure, these callbacks must also be registered before the @ref bt_fast_pair_enable
+ * API call.
+ *
  * This function must be called in the cooperative thread context.
  *
  * @return 0 if the operation was successful. Otherwise, a (negative) error code is returned.
@@ -281,6 +294,9 @@ int bt_fast_pair_info_cb_register(const struct bt_fast_pair_info_cb *cb);
  * unwanted state after the reset interruption.
  *
  * This function must be called in the cooperative thread context.
+ *
+ * If the Find My Network Device extension is enabled, this function can only be called in the
+ * disabled state of the Fast Pair module (see the @ref bt_fast_pair_is_ready function).
  *
  * @return 0 if the operation was successful. Otherwise, a (negative) error code is returned.
  */


### PR DESCRIPTION
Improved the documentation for the bt_fast_pair_enable and the bt_fast_pair_factory_reset API functions in the Fast Pair header file to describe additional requirements for the FMDN extension.

Ref: NCSDK-25234