### PR TITLE
suit: rename output artifact in case of suit boot

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,4 +1,6 @@
 build:
+  depends:
+    - hal_nordic
   cmake: .
   kconfig: Kconfig.nrf
   sysbuild-cmake: sysbuild


### PR DESCRIPTION
WIP/PoC

Use merged.hex instead of uicr_merged.hex in case suit used to boot the system.

[Discussion about that solution](https://github.com/nrfconnect/sdk-nrf/pull/14689#pullrequestreview-2022346303)

Ref: NCSDK-27357