### PR TITLE
quarantine: add specific Matter samples/app to quarantine

### DIFF
--- a/samples/matter/window_covering/pm_static_nrf54l15pdk_nrf54l15_cpuapp_release.yml
+++ b/samples/matter/window_covering/pm_static_nrf54l15pdk_nrf54l15_cpuapp_release.yml
@@ -1,4 +1,4 @@
-addmcuboot:
+mcuboot:
   address: 0x0
   region: flash_primary
   size: 0x7000

--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -2,7 +2,11 @@
 # will be skipped if quarantine is used. More details here:
 # https://docs.zephyrproject.org/latest/guides/test/twister.html#quarantine
 # To have an empty list use:
+
+
 - scenarios:
-    - None
+    - applications.matter_bridge.memory_profiling
+    - sample.matter.light_bulb.memory_profiling
   platforms:
-    - all
+    - nrf7002dk/nrf5340/cpuapp
+  comment: "https://nordicsemi.atlassian.net/browse/KRKNWK-19027"

--- a/scripts/quarantine_windows_mac.yaml
+++ b/scripts/quarantine_windows_mac.yaml
@@ -31,3 +31,10 @@
   platforms:
     - nrf9160dk/nrf9160/ns
   comment: "https://nordicsemi.atlassian.net/browse/NCSDK-26461"
+
+- scenarios:
+    - applications.matter_bridge.memory_profiling
+    - sample.matter.light_bulb.memory_profiling
+  platforms:
+    - nrf7002dk/nrf5340/cpuapp
+  comment: "https://nordicsemi.atlassian.net/browse/KRKNWK-19027"


### PR DESCRIPTION
Due to current issue with memory overflow for specific configuration on nRF7002 DK in Matter samples, these configuration are disabled to build in CI.
Additionally the commit include quick fix in pm_static definition for Matter Window Covering sample on nRF54L15.