### PR TITLE
sysbuild: Fix issue with re-generating provision data

### DIFF
--- a/cmake/sysbuild/provision_hex.cmake
+++ b/cmake/sysbuild/provision_hex.cmake
@@ -47,7 +47,7 @@ function(provision application prefix_name)
         --public-key-files "${PUBLIC_KEY_FILES}"
       )
 
-      set(PROVISION_DEPENDS signature_public_key_file_target ${application}_extra_byproducts ${application}/zephyr/.config)
+      set(PROVISION_DEPENDS signature_public_key_file_target ${application}_extra_byproducts ${application}/zephyr/.config ${SIGNATURE_PUBLIC_KEY_FILE} zephyr/.config)
     endif()
 
     # Adjustment to be able to load into sysbuild

--- a/cmake/sysbuild/sign.cmake
+++ b/cmake/sysbuild/sign.cmake
@@ -49,6 +49,7 @@ function(b0_gen_keys)
         ${PUB_GEN_CMD}
         DEPENDS
         ${SIGNATURE_PRIVATE_KEY_FILE}
+        zephyr/.config
         COMMENT
         "Creating public key from private key used for signing"
         WORKING_DIRECTORY


### PR DESCRIPTION
Fixes an issue with sysbuild whereby settings were changed and the provision data was not re-generated, which would then cause an unbootable image