### PR TITLE
sysbuild: Add b0 zip update output generation without MCUboot

### DIFF
--- a/cmake/sysbuild/b0_packaging.cmake
+++ b/cmake/sysbuild/b0_packaging.cmake
@@ -6,13 +6,18 @@ include(${ZEPHYR_NRF_MODULE_DIR}/cmake/fw_zip.cmake)
 
 sysbuild_get(app_fw_info_firmware_version IMAGE ${DEFAULT_IMAGE} VAR CONFIG_FW_INFO_FIRMWARE_VERSION KCONFIG)
 
+set(s0_name signed_by_b0_s0_image.bin)
+set(s1_name signed_by_b0_s1_image.bin)
+
 generate_dfu_zip(
   OUTPUT ${PROJECT_BINARY_DIR}/dfu_application.zip
   BIN_FILES ${PROJECT_BINARY_DIR}/signed_by_b0_${DEFAULT_IMAGE}.bin ${PROJECT_BINARY_DIR}/signed_by_b0_s1_image.bin
+  ZIP_NAMES ${s0_name} ${s1_name}
   TYPE application
+  IMAGE ${DEFAULT_IMAGE}
   SCRIPT_PARAMS
-  "signed_by_b0_${DEFAULT_IMAGE}.binload_address=$<TARGET_PROPERTY:partition_manager,PM_S0_ADDRESS>"
-  "signed_by_b0_s1_image.binload_address=$<TARGET_PROPERTY:partition_manager,PM_S1_ADDRESS>"
+  "${s0_name}load_address=$<TARGET_PROPERTY:partition_manager,PM_S0_ADDRESS>"
+  "${s1_image}load_address=$<TARGET_PROPERTY:partition_manager,PM_S1_ADDRESS>"
   "version_B0=${app_fw_info_firmware_version}"
   DEPENDS
   ${DEFAULT_IMAGE}_extra_byproducts

--- a/cmake/sysbuild/b0_packaging.cmake
+++ b/cmake/sysbuild/b0_packaging.cmake
@@ -1,0 +1,22 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+# B0 will boot the app directly, create the DFU zip with both update candidates
+include(${ZEPHYR_NRF_MODULE_DIR}/cmake/fw_zip.cmake)
+
+sysbuild_get(app_fw_info_firmware_version IMAGE ${DEFAULT_IMAGE} VAR CONFIG_FW_INFO_FIRMWARE_VERSION KCONFIG)
+
+generate_dfu_zip(
+  OUTPUT ${PROJECT_BINARY_DIR}/dfu_application.zip
+  BIN_FILES ${PROJECT_BINARY_DIR}/signed_by_b0_${DEFAULT_IMAGE}.bin ${PROJECT_BINARY_DIR}/signed_by_b0_s1_image.bin
+  TYPE application
+  SCRIPT_PARAMS
+  "signed_by_b0_${DEFAULT_IMAGE}.binload_address=$<TARGET_PROPERTY:partition_manager,PM_S0_ADDRESS>"
+  "signed_by_b0_s1_image.binload_address=$<TARGET_PROPERTY:partition_manager,PM_S1_ADDRESS>"
+  "version_B0=${app_fw_info_firmware_version}"
+  DEPENDS
+  ${DEFAULT_IMAGE}_extra_byproducts
+  ${DEFAULT_IMAGE}_signed_kernel_hex_target
+  s1_image_extra_byproducts
+  s1_image_signed_kernel_hex_target
+  )

--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -94,6 +94,10 @@ function(include_fw_zip)
   include(${ZEPHYR_NRF_MODULE_DIR}/cmake/sysbuild/zip.cmake)
 endfunction()
 
+function(include_b0_packaging)
+  include(${ZEPHYR_NRF_MODULE_DIR}/cmake/sysbuild/b0_packaging.cmake)
+endfunction()
+
 function(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
   cmake_parse_arguments(PRE_CMAKE "" "" "IMAGES" ${ARGN})
   restore_ncs_vars()
@@ -311,6 +315,11 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
           mcuboot
           ${ZEPHYR_MCUBOOT_MODULE_DIR}/boot/zephyr/external_crypto.conf
           )
+      else()
+        add_overlay_config(
+          ${DEFAULT_IMAGE}
+          ${ZEPHYR_NRF_MODULE_DIR}/sysbuild/mcuboot_enable_secure_bootloader.overlay
+          )
       endif()
     endif()
 
@@ -398,6 +407,10 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_post_cmake)
 
   if(SB_CONFIG_SECURE_BOOT OR SB_CONFIG_MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION)
     include_provision_hex()
+
+    if(NOT SB_CONFIG_BOOTLOADER_MCUBOOT AND SB_CONFIG_SECURE_BOOT_APPCORE AND SB_CONFIG_SECURE_BOOT_BUILD_S1_VARIANT_IMAGE)
+      include_b0_packaging()
+    endif()
   endif()
 
   if(SB_CONFIG_MATTER_FACTORY_DATA AND SB_CONFIG_PARTITION_MANAGER)


### PR DESCRIPTION
Adds a dfu_application.zip output file which contains the update bin files when secure boot is used without MCUboot being enabled