### PR TITLE
samples: nrf5340: extxip_smp_svr: Add in accidentally removed files

### DIFF
--- a/samples/nrf5340/extxip_smp_svr/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/nrf5340/extxip_smp_svr/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,5 @@
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/nrf5340/extxip_smp_svr/child_image/mcuboot/boards/thingy53_nrf5340_cpuapp.overlay
+++ b/samples/nrf5340/extxip_smp_svr/child_image/mcuboot/boards/thingy53_nrf5340_cpuapp.overlay
@@ -1,0 +1,5 @@
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};


### PR DESCRIPTION
Adds back files that were removed in the child/parent image cleanup for a sample that has not been converted