### PR TITLE
suit: fix off by one error in address range check

### DIFF
--- a/subsys/suit/memory_layout/src/suit_memory_layout.c
+++ b/subsys/suit/memory_layout/src/suit_memory_layout.c
@@ -207,8 +207,11 @@ bool suit_memory_global_address_is_in_nvm(uintptr_t address)
 
 bool suit_memory_global_address_range_is_in_nvm(uintptr_t address, size_t size)
 {
+	/* Zero-sized ranges are treated as if they were one byte in size. */
+	size = MAX(1, size);
+
 	const struct nvm_area *start = find_area(address);
-	const struct nvm_area *end = find_area(address + size);
+	const struct nvm_area *end = find_area(address + size - 1);
 
 	return start != NULL && start == end;
 }
@@ -239,12 +242,15 @@ uintptr_t suit_memory_global_address_to_ram_address(uintptr_t address)
 
 bool suit_memory_global_address_range_is_in_ram(uintptr_t address, size_t size)
 {
+	/* Zero-sized ranges are treated as if they were one byte in size. */
+	size = MAX(1, size);
+
 	if (IS_ENABLED(CONFIG_BOARD_NATIVE_POSIX)) {
 		return !suit_memory_global_address_range_is_in_nvm(address, size);
 	}
 
 	const struct ram_area *start = find_ram_area(address);
-	const struct ram_area *end = find_ram_area(address + size);
+	const struct ram_area *end = find_ram_area(address + size - 1);
 
 	return start != NULL && start == end;
 }
@@ -262,7 +268,10 @@ bool suit_memory_global_address_is_in_external_memory(uintptr_t address)
 
 bool suit_memory_global_address_range_is_in_external_memory(uintptr_t address, size_t size)
 {
-	uintptr_t end_addr = address + size;
+	/* Zero-sized ranges are treated as if they were one byte in size. */
+	size = MAX(1, size);
+
+	uintptr_t end_addr = address + size - 1;
 
 	return suit_memory_global_address_is_in_external_memory(address) &&
 	       suit_memory_global_address_is_in_external_memory(end_addr) &&


### PR DESCRIPTION
The memory range checks were off by one, which could result the following example scenario to yield a wrong result:

Memory region has 32kB and begins at address 0x0. A range check with parameters address=0x0 and size=32kB should return true. However, due to off by one error, the end address was actually calculated as 0x8000, which is outside of the memory region. The funcion would return false.

The implementation was changed to subtract one byte from end address to ensure it falls within the region.

Also zero-sized range checks are now treated as one-byte range checks.