### PR TITLE
applications: nrf5340_audio: Rewrite adv population for broadcast_source

### DIFF
--- a/applications/nrf5340_audio/broadcast_source/Kconfig.defaults
+++ b/applications/nrf5340_audio/broadcast_source/Kconfig.defaults
@@ -30,6 +30,9 @@ config BT_BAP_BROADCAST_SRC_STREAM_COUNT
 config BT_ISO_MAX_CHAN
 	default 2
 
+config BT_ISO_MAX_BIG
+	default 2
+
 config BT_AUDIO_TX
 	default y
 

--- a/applications/nrf5340_audio/broadcast_source/main.c
+++ b/applications/nrf5340_audio/broadcast_source/main.c
@@ -48,6 +48,61 @@ K_THREAD_STACK_DEFINE(le_audio_msg_sub_thread_stack, CONFIG_LE_AUDIO_MSG_SUB_STA
 
 static enum stream_state strm_state = STATE_PAUSED;
 
+/* Buffer for the UUIDs. */
+#define EXT_ADV_UUID_BUF_SIZE (128)
+NET_BUF_SIMPLE_DEFINE_STATIC(uuid_data, EXT_ADV_UUID_BUF_SIZE);
+NET_BUF_SIMPLE_DEFINE_STATIC(uuid_data2, EXT_ADV_UUID_BUF_SIZE);
+
+/* Buffer for periodic advertising BASE data. */
+NET_BUF_SIMPLE_DEFINE_STATIC(base_data, 128);
+NET_BUF_SIMPLE_DEFINE_STATIC(base_data2, 128);
+
+/* Extended advertising buffer. */
+static struct bt_data ext_adv_buf[CONFIG_BT_ISO_MAX_BIG][CONFIG_EXT_ADV_BUF_MAX];
+
+/* Periodic advertising buffer. */
+static struct bt_data per_adv_buf[CONFIG_BT_ISO_MAX_BIG];
+
+#if (CONFIG_AURACAST)
+/* Total size of the PBA buffer includes the 16-bit UUID, 8-bit features and the
+ * meta data size.
+ */
+#define BROADCAST_SRC_PBA_BUF_SIZE                                                                 \
+	(BROADCAST_SOURCE_PBA_HEADER_SIZE + CONFIG_BT_AUDIO_BROADCAST_PBA_METADATA_SIZE)
+
+/* Number of metadata items that can be assigned. */
+#define BROADCAST_SOURCE_PBA_METADATA_VACANT                                                       \
+	(CONFIG_BT_AUDIO_BROADCAST_PBA_METADATA_SIZE / (sizeof(struct bt_data)))
+
+/* Make sure pba_buf is large enough for a 16bit UUID and meta data
+ * (any addition to pba_buf requires an increase of this value)
+ */
+uint8_t pba_data[CONFIG_BT_ISO_MAX_BIG][BROADCAST_SRC_PBA_BUF_SIZE];
+
+/**
+ * @brief	Broadcast source static extended advertising data.
+ */
+static struct broadcast_source_ext_adv_data ext_adv_data[] = {
+	{.uuid_buf = &uuid_data,
+	 .pba_metadata_vacant_cnt = BROADCAST_SOURCE_PBA_METADATA_VACANT,
+	 .pba_buf = pba_data[0]},
+	{.uuid_buf = &uuid_data2,
+	 .pba_metadata_vacant_cnt = BROADCAST_SOURCE_PBA_METADATA_VACANT,
+	 .pba_buf = pba_data[1]}};
+#else
+/**
+ * @brief	Broadcast source static extended advertising data.
+ */
+static struct broadcast_source_ext_adv_data ext_adv_data[] = {{.uuid_buf = &uuid_data},
+							      {.uuid_buf = &uuid_data2}};
+#endif /* (CONFIG_AURACAST) */
+
+/**
+ * @brief	Broadcast source static periodic advertising data.
+ */
+static struct broadcast_source_per_adv_data per_adv_data[] = {{.base_buf = &base_data},
+							      {.base_buf = &base_data2}};
+
 /* Function for handling all stream state changes */
 static void stream_state_set(enum stream_state stream_state_new)
 {
@@ -291,6 +346,97 @@ static int zbus_link_producers_observers(void)
 	return 0;
 }
 
+/*
+ * @brief  The following configures the data for the extended advertising.
+ *         This includes the Broadcast Audio Announcements [BAP 3.7.2.1] and Broadcast_ID
+ *         [BAP 3.7.2.1.1] in the AUX_ADV_IND Extended Announcements.
+ *
+ * @param  big_index         Index of the Broadcast Isochronous Group (BIG) to get
+ *                           advertising data for.
+ * @param  ext_adv_data      Pointer to the extended advertising buffers.
+ * @param  ext_adv_buf       Pointer to the bt_data used for extended advertising.
+ * @param  ext_adv_buf_size  Size of @p ext_adv_buf.
+ * @param  ext_adv_count     Pointer to the number of elements added to @p adv_buf.
+ *
+ * @return  0 for success, error otherwise.
+ */
+static int ext_adv_populate(uint8_t big_index, struct broadcast_source_ext_adv_data *ext_adv_data,
+			    struct bt_data *ext_adv_buf, size_t ext_adv_buf_size,
+			    size_t *ext_adv_count)
+{
+	int ret;
+	size_t ext_adv_buf_cnt = 0;
+
+	ext_adv_buf[ext_adv_buf_cnt].type = BT_DATA_UUID16_SOME;
+	ext_adv_buf[ext_adv_buf_cnt].data = ext_adv_data->uuid_buf->data;
+	ext_adv_buf_cnt++;
+
+	ret = bt_mgmt_manufacturer_uuid_populate(ext_adv_data->uuid_buf,
+						 CONFIG_BT_DEVICE_MANUFACTURER_ID);
+	if (ret) {
+		LOG_ERR("Failed to add adv data with manufacturer ID: %d", ret);
+		return ret;
+	}
+
+	ret = broadcast_source_ext_adv_populate(big_index, ext_adv_data,
+						&ext_adv_buf[ext_adv_buf_cnt],
+						ext_adv_buf_size - ext_adv_buf_cnt);
+	if (ret < 0) {
+		LOG_ERR("Failed to add ext adv data for broadcast source: %d", ret);
+		return ret;
+	}
+
+	ext_adv_buf_cnt += ret;
+
+	/* Add the number of UUIDs */
+	ext_adv_buf[0].data_len = ext_adv_data->uuid_buf->len;
+
+	LOG_DBG("Size of adv data: %d, num_elements: %d", sizeof(struct bt_data) * ext_adv_buf_cnt,
+		ext_adv_buf_cnt);
+
+	*ext_adv_count = ext_adv_buf_cnt;
+
+	return 0;
+}
+
+/*
+ * @brief  The following configures the data for the periodic advertising.
+ *         This includes the Basic Audio Announcement, including the
+ *         BASE [BAP 3.7.2.2] and BIGInfo.
+ *
+ * @param  big_index         Index of the Broadcast Isochronous Group (BIG) to get
+ *                           advertising data for.
+ * @param  pre_adv_data      Pointer to the periodic advertising buffers.
+ * @param  per_adv_buf       Pointer to the bt_data used for periodic advertising.
+ * @param  per_adv_buf_size  Size of @p ext_adv_buf.
+ * @param  per_adv_count     Pointer to the number of elements added to @p adv_buf.
+ *
+ * @return  0 for success, error otherwise.
+ */
+static int per_adv_populate(uint8_t big_index, struct broadcast_source_per_adv_data *pre_adv_data,
+			    struct bt_data *per_adv_buf, size_t per_adv_buf_size,
+			    size_t *per_adv_count)
+{
+	int ret;
+	size_t per_adv_buf_cnt = 0;
+
+	ret = broadcast_source_per_adv_populate(big_index, pre_adv_data, per_adv_buf,
+						per_adv_buf_size - per_adv_buf_cnt);
+	if (ret < 0) {
+		LOG_ERR("Failed to add per adv data for broadcast source: %d", ret);
+		return ret;
+	}
+
+	per_adv_buf_cnt += ret;
+
+	LOG_DBG("Size of per adv data: %d, num_elements: %d",
+		sizeof(struct bt_data) * per_adv_buf_cnt, per_adv_buf_cnt);
+
+	*per_adv_count = per_adv_buf_cnt;
+
+	return 0;
+}
+
 uint8_t stream_state_get(void)
 {
 	return strm_state;
@@ -373,14 +519,12 @@ static void broadcast_create(struct broadcast_source_big *broadcast_param)
 int main(void)
 {
 	int ret;
-
 	static struct broadcast_source_big broadcast_param;
-	static const struct bt_data *ext_ad;
-	static const struct bt_data *per_ad;
-	size_t ext_ad_size = 0;
-	size_t per_ad_size = 0;
 
 	LOG_DBG("Main started");
+
+	size_t ext_adv_buf_cnt = 0;
+	size_t per_adv_buf_cnt = 0;
 
 	ret = nrf5340_audio_dk_init();
 	ERR_CHK(ret);
@@ -412,10 +556,16 @@ int main(void)
 	ERR_CHK_MSG(ret, "Failed to set sample- and bitrate");
 
 	/* Get advertising set for BIG0 */
-	broadcast_source_adv_get(0, &ext_ad, &ext_ad_size, &per_ad, &per_ad_size);
+	ret = ext_adv_populate(0, &ext_adv_data[0], ext_adv_buf[0], ARRAY_SIZE(ext_adv_buf[0]),
+			       &ext_adv_buf_cnt);
+	ERR_CHK(ret);
+
+	ret = per_adv_populate(0, &per_adv_data[0], &per_adv_buf[0], 1, &per_adv_buf_cnt);
+	ERR_CHK(ret);
 
 	/* Start broadcaster */
-	ret = bt_mgmt_adv_start(0, ext_ad, ext_ad_size, per_ad, per_ad_size, false);
+	ret = bt_mgmt_adv_start(0, ext_adv_buf[0], ext_adv_buf_cnt, &per_adv_buf[0],
+				per_adv_buf_cnt, false);
 	ERR_CHK_MSG(ret, "Failed to start first advertiser");
 
 	return 0;

--- a/applications/nrf5340_audio/src/bluetooth/bt_management/advertising/Kconfig
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/advertising/Kconfig
@@ -52,7 +52,7 @@ config EXT_ADV_BUF_MAX
 
 config EXT_ADV_UUID_BUF_MAX
 	int "Maximum number of UUIDs to add to extended advertisements"
-	default 20
+	default 40
 
 config BT_DEVICE_MANUFACTURER_ID
 	hex "Manufacturer ID"

--- a/applications/nrf5340_audio/src/bluetooth/bt_management/bt_mgmt.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/bt_mgmt.c
@@ -306,6 +306,25 @@ void bt_mgmt_num_conn_get(uint8_t *num_conn)
 	bt_conn_foreach(BT_CONN_TYPE_LE, conn_state_connected_check, (void *)num_conn);
 }
 
+int bt_mgmt_adv_buffer_put(struct bt_data *const adv_buf, int *index, size_t adv_buf_vacant,
+			   size_t data_len, uint8_t type, void *data)
+{
+	if (adv_buf == NULL || index == NULL || data_len == 0) {
+		return -EINVAL;
+	}
+
+	if ((adv_buf_vacant - *index) <= 0) {
+		return -ENOMEM;
+	}
+
+	adv_buf[*index].type = type;
+	adv_buf[*index].data_len = data_len;
+	adv_buf[*index].data = data;
+	(*index)++;
+
+	return 0;
+}
+
 int bt_mgmt_bonding_clear(void)
 {
 	int ret;

--- a/applications/nrf5340_audio/src/bluetooth/bt_management/bt_mgmt.h
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/bt_mgmt.h
@@ -72,6 +72,21 @@ void bt_mgmt_set_size_filled_get(uint8_t *num_filled);
 void bt_mgmt_scan_sirk_set(uint8_t const *const sirk);
 
 /**
+ * @brief	Load advertising data into an advertising buffer.
+ *
+ * @param[out]     adv_buf         Pointer to the advertising  buffer to load.
+ * @param[in,out]  index           Next free index in the advertising buffer.
+ * @param[in]      adv_buf_vacant  Number of free advertising buffers.
+ * @param[in]      data_len        Length of the data.
+ * @param[in]      type            Type of the data.
+ * @param[in]      data            Data to store in the buffer, can be a pointer or value.
+ *
+ * @return	0 if success, error otherwise.
+ */
+int bt_mgmt_adv_buffer_put(struct bt_data *const adv_buf, int *index, size_t adv_buf_vacant,
+			   size_t data_len, uint8_t type, void *data);
+
+/**
  * @brief	Start scanning for advertisements.
  *
  * @param[in]	scan_intvl	Scan interval in units of 0.625ms.

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/Kconfig
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/Kconfig
@@ -147,6 +147,16 @@ config BT_AUDIO_BROADCAST_ID_FIXED
 	  Fixed broadcast ID; 3 octets. Will only be used if BT_AUDIO_USE_BROADCAST_ID_RANDOM=n.
 	  Only use for debugging.
 
+config BT_AUDIO_BROADCAST_PBA_METADATA_SIZE
+	int "Configure PBA meta data buffer size"
+	depends on TRANSPORT_BIS && AURACAST
+	default 16
+	help
+	  Configure the maximum size of the Public Broadcast Announcement meata data buffer in octets.
+	  This is the number of meta data LVT records, or the number of meta data items multiplied by
+	  the size of the LTV (sizeof(bt_data)). Configurable option that doesn't follow any preset.
+	  Allows for more flexibility.
+
 config BT_AUDIO_BROADCAST_PARENTAL_RATING
 	hex "Parental rating"
 	depends on TRANSPORT_BIS

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/broadcast_source.h
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/broadcast_source.h
@@ -94,76 +94,135 @@ struct broadcast_source_big {
 #error Unsupported LC3 codec preset for broadcast
 #endif /* CONFIG_BT_AUDIO_BROADCAST_CONFIGURABLE */
 
-/**
- * @brief	Get the data to advertise.
- *
- * @param[in]	big_index	Index of the Broadcast Isochronous Group (BIG) to get advertising
- *				data for.
- * @param[out]	ext_adv		Pointer to the pointer of bt_data used for extended advertising.
- * @param[out]	ext_adv_size	Pointer to size of @p ext_adv.
- * @param[out]	per_adv		Pointer to the pointer of bt_data used for periodic advertising.
- * @param[out]	per_adv_size	Pointer to size of @p per_adv.
+/* Size of the Public Broadcast Announcement header, 2-octet Service UUID followed by
+ * an octet for the features and an octet for the length of the meta data feild.
  */
-void broadcast_source_adv_get(uint8_t big_index, const struct bt_data **ext_adv,
-			      size_t *ext_adv_size, const struct bt_data **per_adv,
-			      size_t *per_adv_size);
+#define BROADCAST_SOURCE_PBA_HEADER_SIZE (BT_UUID_SIZE_16 + (sizeof(uint8_t) * 2))
+
+#define BROADCAST_SOURCE_ADV_NAME_MAX (32)
+#define BROADCAST_SOURCE_ADV_ID_START (BT_UUID_SIZE_16)
 
 /**
- * @brief	Start the Bluetooth LE Audio broadcast (BIS) source.
+ * @brief  Advertising data for broadcast source.
+ */
+struct broadcast_source_ext_adv_data {
+	/* Broadcast Audio Streaming UUIDs. */
+	struct net_buf_simple *uuid_buf;
+
+	/* Broadcast Audio Streaming Endpoint advertising data. */
+	uint8_t brdcst_id_buf[BT_UUID_SIZE_16 + BT_AUDIO_BROADCAST_ID_SIZE];
+
+	/* Buffer for Appearance. */
+	uint8_t brdcst_appearance_buf[(sizeof(uint8_t) * 2)];
+
+	/* Broadcast name, must be between 4 and 32 UTF-8 encoded characters in length. */
+	uint8_t brdcst_name_buf[BROADCAST_SOURCE_ADV_NAME_MAX];
+
+#if (CONFIG_AURACAST)
+	/* Number of free metadata items */
+	uint8_t pba_metadata_vacant_cnt;
+
+	/* Public Broadcast Announcement buffer. */
+	uint8_t *pba_buf;
+#endif /* (CONFIG_AURACAST) */
+};
+
+/**
+ * @brief  Periodic advertising data for broadcast source.
+ */
+struct broadcast_source_per_adv_data {
+	/* Buffer for periodic advertising data */
+	struct net_buf_simple *base_buf;
+};
+
+/**
+ * @brief  Populate the extended advertising data buffer.
  *
- * @param[in]	big_index	Index of the Broadcast Isochronous Group (BIG) to start.
- * @param[in]	ext_adv		Pointer to the extended advertising set; can be NULL if a stream
- *				is restarted.
+ * @param[in]	big_index           Index of the Broadcast Isochronous Group (BIG) to get
+ *                                  advertising data for.
+ * @param[in]   ext_adv_data        Pointer to the extended advertising buffers.
+ * @param[out]  ext_adv_buf         Pointer to the bt_data used for extended advertising.
+ * @param[out]  ext_adv_buf_vacant  Pointer to unused size of @p ext_adv_buf.
  *
- * @return	0 for success, error otherwise.
+ * @return  Negative values for errors or number of elements added to @p ext_adv_buf.
+ */
+int broadcast_source_ext_adv_populate(uint8_t big_index,
+				      struct broadcast_source_ext_adv_data *ext_adv_data,
+				      struct bt_data *ext_adv_buf, size_t ext_adv_buf_vacant);
+
+/**
+ * @brief  Populate the periodic advertising data buffer.
+ *
+ * @param[in]	big_index           Index of the Broadcast Isochronous Group (BIG) to get
+ *                                  advertising data for.
+ * @param[in]   per_adv_data        Pointer to a structure of periodic advertising buffers.
+ * @param[out]  per_adv_buf         Pointer to the bt_data used for periodic advertising.
+ * @param[out]  per_adv_buf_vacant  Pointer to unused size of @p per_adv_buf.
+ *
+ * @return  Negative values for errors or number of elements added to @p per_adv_buf.
+ */
+int broadcast_source_per_adv_populate(uint8_t big_index,
+				      struct broadcast_source_per_adv_data *per_adv_data,
+				      struct bt_data *per_adv_buf, size_t per_adv_buf_vacant);
+
+/**
+ * @brief  Start the Bluetooth LE Audio broadcast (BIS) source.
+ *
+ * @param[in]  big_index  Index of the Broadcast Isochronous Group (BIG) to start.
+ * @param[in]  ext_adv    Pointer to the extended advertising set; can be NULL if a stream
+ *                        is restarted.
+ *
+ * @return  0 for success, error otherwise.
  */
 int broadcast_source_start(uint8_t big_index, struct bt_le_ext_adv *ext_adv);
 
 /**
- * @brief	Stop the Bluetooth LE Audio broadcast (BIS) source.
+ * @brief  Stop the Bluetooth LE Audio broadcast (BIS) source.
  *
- * @param[in]	big_index	Index of the Broadcast Isochronous Group (BIG) to stop.
- * @return	0 for success, error otherwise.
+ * @param[in]  big_index  Index of the Broadcast Isochronous Group (BIG) to stop.
+ *
+ * @return  0 for success, error otherwise.
  */
 int broadcast_source_stop(uint8_t big_index);
 
 /**
- * @brief	Broadcast the Bluetooth LE Audio data.
+ * @brief  Broadcast the Bluetooth LE Audio data.
  *
- * @param[in]	big_index	Index of the Broadcast Isochronous Group (BIG) to broadcast.
- * @param[in]	enc_audio	Encoded audio struct.
+ * @param[in]  big_index  Index of the Broadcast Isochronous Group (BIG) to broadcast.
+ * @param[in]  enc_audio  Encoded audio struct.
  *
- * @return	0 for success, error otherwise.
+ * @return  0 for success, error otherwise.
  */
 int broadcast_source_send(uint8_t big_index, struct le_audio_encoded_audio enc_audio);
 
 /**
- * @brief	Disable the LE Audio broadcast (BIS) source.
+ * @brief  Disable the LE Audio broadcast (BIS) source.
  *
- * @param[in]	big_index	Index of the Broadcast Isochronous Group (BIG) to disable.
- * @return	0 for success, error otherwise.
+ * @param[in]  big_index  Index of the Broadcast Isochronous Group (BIG) to disable.
+ *
+ * @return  0 for success, error otherwise.
  */
 int broadcast_source_disable(uint8_t big_index);
 
 /**
- * @brief	Create a set up for a default broadcaster.
+ * @brief  Create a set up for a default broadcaster.
  *
- * @note	This will create the parameters for a simple broadcaster with 1 Broadcast
- *		Isochronous Group (BIG), 1 subgroup, and 2 BISes.
- *		The BISes will be front_left and front_right and language will be set to 'eng'.
+ * @note  This will create the parameters for a simple broadcaster with 1 Broadcast
+ *        Isochronous Group (BIG), 1 subgroup, and 2 BISes.
+ *        The BISes will be front_left and front_right and language will be set to 'eng'.
  *
- * @param[out]	broadcast_param	Pointer to populate with parameters for setting up the broadcaster.
+ * @param[out] broadcast_param  Pointer to populate with parameters for setting up the broadcaster.
  */
 void broadcast_source_default_create(struct broadcast_source_big *broadcast_param);
 
 /**
- * @brief	Enable the LE Audio broadcast (BIS) source.
+ * @brief  Enable the LE Audio broadcast (BIS) source.
  *
- * @param[in]	broadcast_param	Array of create parameters for creating a Broadcast
- *				Isochronous Group (BIG).
- * @param[in]	num_bigs	Number of BIGs to set up.
+ * @param[in]  broadcast_param  Array of create parameters for creating a Broadcast Isochronous
+ *                              Group (BIG).
+ * @param[in] num_bigs          Number of BIGs to set up.
  *
- * @return	0 for success, error otherwise.
+ * @return  0 for success, error otherwise.
  */
 int broadcast_source_enable(struct broadcast_source_big const *const broadcast_param,
 			    uint8_t num_bigs);

--- a/applications/nrf5340_audio/unicast_server/main.c
+++ b/applications/nrf5340_audio/unicast_server/main.c
@@ -411,6 +411,18 @@ static int zbus_link_producers_observers(void)
 	return 0;
 }
 
+/*
+ * @brief  The following configures the data for the extended advertising. This includes the
+ *         Audio Stream Control Service requirements [BAP 3.7.2.1.1] in the AUX_ADV_IND Extended
+ *         Announcements.
+ *
+ * @param  ext_adv_buf       Pointer to the bt_data used for extended advertising.
+ * @param  ext_adv_buf_size  Size of @p ext_adv_buf.
+ * @param  ext_adv_count     Pointer to the number of elements added to @p adv_buf.
+ *
+ * @return  0 for success, error otherwise.
+ */
+
 static int ext_adv_populate(struct bt_data *ext_adv_buf, size_t ext_adv_buf_size,
 			    size_t *ext_adv_count)
 {
@@ -420,7 +432,6 @@ static int ext_adv_populate(struct bt_data *ext_adv_buf, size_t ext_adv_buf_size
 	NET_BUF_SIMPLE_DEFINE_STATIC(uuid_buf, CONFIG_EXT_ADV_UUID_BUF_MAX);
 
 	ext_adv_buf[ext_adv_buf_cnt].type = BT_DATA_UUID16_SOME;
-	ext_adv_buf[ext_adv_buf_cnt].data_len = 0;
 	ext_adv_buf[ext_adv_buf_cnt].data = uuid_buf.data;
 	ext_adv_buf_cnt++;
 


### PR DESCRIPTION
OCT-2949

While adding the manufacturer ID in the advertisement packet it was noticed that the adv packet for unicast_client and broadcast_source are done in completely different ways. This rewrites both to make them closer and with a view to setting these later with a shell.

The implementation has moved any Kconfig CONFIG_* into the populate routine in preparation for driving externally.