### PR TITLE
Samples: Bluetooth: Mesh: Fix sysbuild thingy53 cfg on light

### DIFF
--- a/samples/bluetooth/mesh/light/sysbuild/hci_ipc/prj.conf
+++ b/samples/bluetooth/mesh/light/sysbuild/hci_ipc/prj.conf
@@ -33,4 +33,12 @@ CONFIG_BT_CTLR_PRIVACY=n
 # Enables the extended advertising API support and the necessary amount of advertising sets
 # in the Bluetooth controller on the network core required by the Bluetooth Mesh.
 CONFIG_BT_EXT_ADV=y
-CONFIG_BT_EXT_ADV_MAX_ADV_SET=5
+CONFIG_BT_EXT_ADV_MAX_ADV_SET=6
+
+# One extra connection for mesh GATT/proxy and one for SMP BT.
+CONFIG_BT_MAX_CONN=3
+CONFIG_BT_CTLR_SDC_PERIPHERAL_COUNT=3
+
+# Ensure that BT_CENTRAL role is disabled, while still keeping the BT_OBSERVER role
+CONFIG_BT_CENTRAL=n
+CONFIG_BT_OBSERVER=y


### PR DESCRIPTION
Updates the light sample hci_ipc sysbuild configuration to account for the extra resources needed for p2p DFU.

Also, rectify some misconfiguration where BT_CENTRAL role was wrongly choosen.