### PR TITLE
applications: nrf_desktop: Fix sample.yaml

### DIFF
--- a/applications/nrf_desktop/sample.yaml
+++ b/applications/nrf_desktop/sample.yaml
@@ -236,6 +236,8 @@ tests:
                 SB_CONFIG_MCUBOOT_MODE_DIRECT_XIP=y
                 SB_CONFIG_BT_FAST_PAIR=y
                 SB_CONFIG_PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY=n
+                SB_CONFIG_SECURE_BOOT_APPCORE=n
+                SB_CONFIG_SECURE_BOOT=n
   applications.nrf_desktop.zrelease_4llpmconn:
     sysbuild: true
     build_only: true


### PR DESCRIPTION
Change fixes release Fast Pair configuration for nrf52840gmouse. The configuration must explicitly disable B0 bootloader.

Jira: NCSDK-27571