### PR TITLE
doc: sysbuild: add related deprecation notes

### DIFF
--- a/doc/nrf/config_and_build/config_and_build_system.rst
+++ b/doc/nrf/config_and_build/config_and_build_system.rst
@@ -144,6 +144,9 @@ This process also creates a set of header files that provides defines, which can
 Child images
 ------------
 
+.. important::
+    |sysbuild_related_deprecation_note|
+
 The |NCS| build system allows the application project to become a root for the sub-applications known in the |NCS| as child images.
 Examples of child images are bootloader images, network core images, or security-related images.
 Each child image is a separate application.
@@ -170,10 +173,8 @@ See the Configuration section of the given application or sample's documentation
 
 .. important::
     The file suffixes feature is replacing the :ref:`app_build_additions_build_types` that used the :makevar:`CONF_FILE` variable.
-    File suffixes are backward compatible with this variable, but the following software components are not compatible with file suffixes:
-
-    * :ref:`Child image Kconfig configuration <ug_multi_image_permanent_changes>`.
-      Use the :makevar:`CONF_FILE` variable during the deprecation period of the build types.
+    File suffixes are backward compatible with this variable.
+    Some applications might still require using the :makevar:`CONF_FILE` variable during the deprecation period of the build types.
 
 For information about how to provide file suffixes when building an application, see :ref:`cmake_options`.
 
@@ -204,6 +205,26 @@ See :ref:`output build files <app_build_output_files>` for details.
 
 The build phase can be broken down, conceptually, into four stages: the pre-build, first-pass binary, final binary, and post-processing.
 To read about each of these stages, see :ref:`zephyr:cmake-details` in the Zephyr documentation.
+
+.. _configuration_system_overview_sysbuild:
+
+Sysbuild
+========
+
+The |NCS| supports Zephyr's System Build (Sysbuild).
+
+.. ncs-include:: build/sysbuild/index.rst
+   :docset: zephyr
+   :start-after: #######################
+   :end-before: Definitions
+
+To distinguish CMake variables and Kconfig options specific to the underlying build systems, sysbuild uses namespacing.
+For example, sysbuild-specific Kconfig options are preceded by `SB_` before `CONFIG` and application-specific CMake options are preceded by the application name.
+
+Sysbuild is integrated with west.
+The sysbuild build configuration is generated using the sysbuild's :file:`CMakeLists.txt` file (which provides information about each underlying build system and CMake variables) and the sysbuild's Kconfig options (which are gathered in the :file:`sysbuild.conf` file).
+
+For more information about sysbuild, see the :ref:`documentation in Zephyr <zephyr:sysbuild>`.
 
 .. _app_build_additions:
 
@@ -239,9 +260,8 @@ Custom build types
 ==================
 
 .. important::
-    The build types are deprecated and are being replaced by :ref:`suffix-based configurations <app_build_additions_build_types>` and Zephyr's :ref:`zephyr:sysbuild`.
-    You can continue to use the build types feature until the transition is complete in the |NCS|.
-    It is still required for applications that use build types with :ref:`multiple images <ug_multi_image>`.
+    |file_suffix_related_deprecation_note|
+    It is still required for some applications that use build types with :ref:`multiple images <ug_multi_image>`.
     Check the application and sample documentation pages for which variable to use.
 
 A build type is a feature that defines the way in which the configuration files are to be handled.
@@ -275,6 +295,9 @@ For more information about how to invoke build types, see :ref:`cmake_options`.
 
 Multi-image builds
 ==================
+
+.. important::
+    |sysbuild_related_deprecation_note|
 
 The |NCS| build system extends Zephyr's with support for multi-image builds.
 You can find out more about these in the :ref:`ug_multi_image` section.

--- a/doc/nrf/config_and_build/configuring_app/cmake/index.rst
+++ b/doc/nrf/config_and_build/configuring_app/cmake/index.rst
@@ -74,12 +74,12 @@ The following table lists the most common ones used in the |NCS|:
      - ``-DEXTRA_DTC_OVERLAY_FILE=<file_name>.overlay``
    * - :makevar:`SHIELD`
      - Select one of the supported :ref:`shields <shield_names_nrf>` for building the firmware.
-     - ``-DSHIELD=<shield>``
+     - ``-DSHIELD=<shield>`` (``-Dimage-name_SHIELD`` for images)
    * - :makevar:`FILE_SUFFIX`
      - | Select one of the available :ref:`suffixed configurations <zephyr:application-file-suffixes>`, if the application or sample supports any.
        | See :ref:`app_build_file_suffixes` for more information about their usage and limitations in the |NCS|.
        | This variable is gradually replacing :makevar:`CONF_FILE`.
-     - ``-DFILE_SUFFIX=<configuration_suffix>``
+     - ``-DFILE_SUFFIX=<configuration_suffix>`` (``-Dimage-name_FILE_SUFFIX`` for images)
    * - :makevar:`CONF_FILE`
      - | Select one of the available :ref:`build types <modifying_build_types>`, if the application or sample supports any.
        | This variable is deprecated and is being gradually replaced by :makevar:`FILE_SUFFIX`, but :ref:`still required for some applications <modifying_build_types>`.
@@ -88,7 +88,7 @@ The following table lists the most common ones used in the |NCS|:
      - | Select one of the :ref:`zephyr:snippets` to add to the application firmware during the build.
        | The west argument ``-S`` is more commonly used.
      - | ``-S <name_of_snippet>``
-       | ``-DSNIPPET=<name_of_snippet>``
+       | ``-DSNIPPET=<name_of_snippet>`` (``-Dimage-name_SNIPPET`` for images)
    * - :makevar:`PM_STATIC_YML_FILE`
      - | Select a :ref:`static configuration file <ug_pm_static>` for the Partition Manager script.
        | For applications that *do not* use multiple images, the static configuration can be selected with :makevar:`FILE_SUFFIX` (see above).

--- a/doc/nrf/config_and_build/multi_image.rst
+++ b/doc/nrf/config_and_build/multi_image.rst
@@ -7,6 +7,9 @@ Multi-image builds
    :local:
    :depth: 2
 
+.. important::
+    |sysbuild_related_deprecation_note|
+
 The firmware programmed to a device can be composed of either one application or several separate images.
 In the latter case, the *parent* :term:`image file` requires one or more other images (the *child images*) to be present.
 The child image then *chain-loads*, or *boots*, the parent image, which could also be a child image to another parent image, and boots that one.

--- a/doc/nrf/releases_and_maturity/migration/migration_guide_2.7.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_guide_2.7.rst
@@ -95,16 +95,19 @@ The following changes are recommended for your application to work optimally aft
 Samples and applications
 ========================
 
-* For applications using build types (without child images):
+* For applications using build types:
 
   * The :makevar:`CONF_FILE` used for :ref:`app_build_additions_build_types` is now deprecated and is being replaced with the :makevar:`FILE_SUFFIX` variable, inherited from Zephyr.
     You can read more about it in :ref:`app_build_file_suffixes`, :ref:`cmake_options`, and the :ref:`related Zephyr documentation <zephyr:application-file-suffixes>`.
 
     If your application uses build types, it is recommended to update the :file:`sample.yaml` to use the new variable instead of :makevar:`CONF_FILE`.
 
-    .. note::
-        The :ref:`child image Kconfig configuration <ug_multi_image_permanent_changes>` are not yet compatible with :makevar:`FILE_SUFFIX`.
-        Read more about this in the note in :ref:`app_build_file_suffixes`.
+* For applications using child images:
+
+  * With the inheritance of Zephyr's :ref:`zephyr:sysbuild` in the |NCS|, the :ref:`ug_multi_image` are deprecated.
+
+    If your application uses parent and child images, it is recommended to migrate your application to :ref:`zephyr:sysbuild` before the multi-image builds are removed in one of the upcoming |NCS| releases.
+    See the documentation in Zephyr for more information.
 
 Matter
 ------

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -205,3 +205,9 @@
 .. |board_target| replace:: Replace the *board_target* with the board target of the nRF91 Series device you are using (see the Requirements section).
 
 .. |thingy52_not_supported_note| replace:: Despite being supported in :ref:`Zephyr <zephyr:thingy52_nrf52832>`, the |NCS| does not support `Nordic Thingy:52`_.
+
+.. |sysbuild_related_deprecation_note| replace:: This feature is deprecated and is being replaced by Zephyr's :ref:`zephyr:sysbuild`.
+   You can continue to use it until the transition is complete in the |NCS| and the feature is removed in one of the upcoming |NCS| releases.
+
+.. |file_suffix_related_deprecation_note| replace:: This feature is deprecated and is being replaced by :ref:`suffix-based configurations <app_build_additions_build_types>`.
+    You can continue to use it until the transition is complete in the |NCS| and the feature is removed in one of the upcoming |NCS| releases.


### PR DESCRIPTION
Added or updated deprecation notes for features that will be replaced by sysbuild.
Updated CMake option list with image-related variables. Updated the migration guide with generic notice.