### PR TITLE
Add NB-IoT support for HERE positioning

### DIFF
--- a/lib/location/cloud_service/cloud_service_here_rest.c
+++ b/lib/location/cloud_service/cloud_service_here_rest.c
@@ -52,7 +52,7 @@ BUILD_ASSERT(sizeof(CONFIG_LOCATION_SERVICE_HERE_API_KEY) > 1,
 
 #define HTTP_REQUEST_BODY						\
 	"{"								\
-		"\"lte\":["						\
+		"\"lteCatM\":["						\
 			"{"						\
 				"\"mcc\":%d,"				\
 				"\"mnc\":%d,"				\
@@ -70,7 +70,7 @@ BUILD_ASSERT(sizeof(CONFIG_LOCATION_SERVICE_HERE_API_KEY) > 1,
 
 #define HTTP_REQUEST_BODY_NO_NEIGHBORS					\
 	"{"								\
-		"\"lte\":["						\
+		"\"lteCatM\":["						\
 			"{"						\
 				"\"mcc\":%d,"				\
 				"\"mnc\":%d,"				\


### PR DESCRIPTION
HERE Api v2 has added separate objects for LTE, LTE-M and NB-IoT.
[https://www.here.com/docs/bundle/network-positioning-api-developer-guide-v2/page/topics/example-nbiot.html]

Based on my tests with NB-IoT cell measurements from Finland and Germany (Elisa and Vodafone networks), the "lte" object does not work while "lteCatM" supports both LTE-M and NB-IoT cells.

Thus, the current implementation does not strictly follow the HERE Api v2 documentation, and while this PR doesn't either, it supports NB-IoT.

Better solution would be to format the payload based the current network mode, but  lte_lc_cells_info -struct does not include that information.