### PR TITLE
zigbee: use proper API to get RSSI

### DIFF
--- a/doc/nrf/releases_and_maturity/known_issues.rst
+++ b/doc/nrf/releases_and_maturity/known_issues.rst
@@ -922,6 +922,14 @@ Zigbee
 
 The issues in this section are related to the :ref:`ug_zigbee` protocol.
 
+
+.. rst-class:: v2-6-1 v2-6-0 v2-5-3 v2-5-2 v2-5-1 v2-5-0
+
+KRKNWK-19026: Wrong RSSI values reported
+  The Zephyr API to get the RSSI value from the radio driver was modified and adaptation is needed in the Zigbee integration.
+
+  **Workaround:** Manually cherry-pick and apply commit with fix from ``main`` (commit hash: ``7ca42b219d1333b911d7671cf2a714bd93cbac45``).
+
 .. rst-class:: v2-6-1 v2-6-0 v2-5-3 v2-5-2 v2-5-1 v2-5-0 v2-4-3 v2-4-2 v2-4-1 v2-4-0 v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0
 
 NCSIDB-1213: Subsequent Zigbee FOTA updates fail

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -174,6 +174,7 @@ Zigbee
 ------
 
 * Fixed an issue with Zigbee FOTA updates failing after a previous attempt was interrupted.
+* Fixed the RSSI level value reported to the MAC layer in the Zigbee stack.
 
 Gazell
 ------

--- a/subsys/zigbee/osif/zb_nrf_transceiver.c
+++ b/subsys/zigbee/osif/zb_nrf_transceiver.c
@@ -495,7 +495,7 @@ zb_uint8_t zb_trans_get_next_packet(zb_bufid_t buf)
 	zb_macll_metadata_t *metadata = ZB_MACLL_GET_METADATA(buf);
 
 	metadata->lqi = net_pkt_ieee802154_lqi(pkt);
-	metadata->power = net_pkt_ieee802154_rssi(pkt);
+	metadata->power = net_pkt_ieee802154_rssi_dbm(pkt);
 
 	/* Put timestamp (usec) into the packet tail */
 	*ZB_BUF_GET_PARAM(buf, zb_time_t) =


### PR DESCRIPTION
Zephyr's net packet data handling APIs were modified.

KRKNWK-19026