### PR TITLE
drivers: wifi: add random MAC

### DIFF
--- a/drivers/wifi/nrf700x/Kconfig
+++ b/drivers/wifi/nrf700x/Kconfig
@@ -516,7 +516,33 @@ endif
 config WIFI_FIXED_MAC_ADDRESS
 	string "WiFi Fixed MAC address in format XX:XX:XX:XX:XX:XX"
 	help
-		This overrides the MAC address read from OTP. Strictly for testing purposes only.
+	  This overrides the MAC address read from OTP. Strictly for testing purposes only.
+
+choice
+	prompt "Wi-Fi MAC address type"
+	default WIFI_OTP_MAC_ADDRESS if WIFI_FIXED_MAC_ADDRESS = ""
+	default WIFI_FIXED_MAC_ADDRESS_ENABLED if WIFI_FIXED_MAC_ADDRESS != ""
+	help
+	  Select the type of MAC address to be used by the Wi-Fi driver
+
+config WIFI_OTP_MAC_ADDRESS
+	bool "Use MAC address from OTP"
+	help
+	  This option uses the MAC address stored in the OTP memory of the nRF700x.
+
+config WIFI_FIXED_MAC_ADDRESS_ENABLED
+	bool "Enable fixed MAC address"
+	help
+	  Enable fixed MAC address
+
+config WIFI_RANDOM_MAC_ADDRESS
+	bool "Enable random MAC address generation at runtime"
+	depends on ENTROPY_GENERATOR
+	help
+	  This option enables random MAC address generation at runtime.
+	  The random MAC address is generated using the entropy device random generator.
+
+endchoice
 
 config NRF700X_RSSI_STALE_TIMEOUT_MS
 	int "RSSI stale timeout in milliseconds"

--- a/drivers/wifi/nrf700x/inc/net_if.h
+++ b/drivers/wifi/nrf700x/inc/net_if.h
@@ -18,6 +18,9 @@
 #include <fmac_structs.h>
 #include <zephyr/net/wifi_mgmt.h>
 
+#define UNICAST_MASK GENMASK(7, 1)
+#define LOCAL_BIT BIT(1)
+
 void nrf_wifi_if_init_zep(struct net_if *iface);
 
 int nrf_wifi_if_start_zep(const struct device *dev);


### PR DESCRIPTION
Adds random run-time generated MAC address as a Kconfig

Also adds build asserts to; ensure that a fixed MAC address
is of the correct length, ensure that fixed and random MAC
addresses are not enabled at the same time.

Signed-off-by: Helmut Lord <kellyhlord@gmail.com>
