### PR TITLE
applications: nrf_desktop: Use build type specific DTS overlays

### DIFF
--- a/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/app_mcuboot_qspi.overlay
+++ b/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/app_mcuboot_qspi.overlay
@@ -1,5 +1,11 @@
 / {
 	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};
+
+/ {
+	chosen {
 		/*
 		 * In some default configurations within the nRF Connect SDK,
 		 * e.g. on nRF52840 and nRF9160, the chosen zephyr,entropy node
@@ -76,6 +82,10 @@
 	status = "okay";
 	pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 	label = "LED System State";
+};
+
+&qspi {
+	status = "okay";
 };
 
 &pinctrl {


### PR DESCRIPTION
Use build type specific DTS overlays for nRF52840DK to clean up configuration and avoid enabling unnecessary features.

Jira: NCSDK-27014