### PR TITLE
tfm: Remove dead CMake code

### DIFF
--- a/modules/trusted-firmware-m/tfm_boards/CMakeLists.txt
+++ b/modules/trusted-firmware-m/tfm_boards/CMakeLists.txt
@@ -145,16 +145,6 @@ if (CONFIG_NRF_TRACE_PORT)
   target_compile_definitions(platform_s PUBLIC ENABLE_TRACE)
 endif()
 
-if (CRYPTO_STORAGE_DISABLED AND TFM_PARTITION_CRYPTO AND NOT TFM_PARTITION_INTERNAL_TRUSTED_STORAGE)
-  # Added here to satisfy the following requirement from tfm_crypto.yaml:
-  #
-  # "dependencies": [
-  #   "TFM_INTERNAL_TRUSTED_STORAGE_SERVICE"
-  # ]
-  target_compile_definitions(platform_s PUBLIC
-    TFM_INTERNAL_TRUSTED_STORAGE_SERVICE_SID=0x00000070)
-endif()
-
 if(BL2)
   message(FATAL_ERROR "BL2 is not supported")
 endif()

--- a/modules/trusted-firmware-m/tfm_boards/board/common_config_tfm_target.h
+++ b/modules/trusted-firmware-m/tfm_boards/board/common_config_tfm_target.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#pragma once
+
+#if defined(TFM_PARTITION_INTERNAL_TRUSTED_STORAGE)
+/* The ITS partition is enabled so
+ * TFM_INTERNAL_TRUSTED_STORAGE_SERVICE_SID will be defined by
+ * psa_manifest/sid.h and we don't need to define it here.
+ */
+#else
+/* The ITS partition is not enabled, but the crypto partition is
+ * definitely enabled as it is mandatory.
+ *
+ * The manifest states that the crypto partition depends on the ITS
+ * partition, but this is not true for all configurations of the
+ * crypto partition.
+ *
+ * The crypto partition unfortunately does not build without
+ * TFM_INTERNAL_TRUSTED_STORAGE_SERVICE_SID defined, so we define it
+ * here to pretend like it's dependency is satisfied and support this
+ * configuration.
+ */
+
+#define TFM_INTERNAL_TRUSTED_STORAGE_SERVICE_SID 0x00000070
+
+#endif

--- a/modules/trusted-firmware-m/tfm_boards/nrf5340_cpuapp/config_tfm_target.h
+++ b/modules/trusted-firmware-m/tfm_boards/nrf5340_cpuapp/config_tfm_target.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#pragma once
+
+#ifndef DOMAIN_NS
+#include <common_config_tfm_target.h>
+#endif

--- a/modules/trusted-firmware-m/tfm_boards/nrf54l15_cpuapp/config_tfm_target.h
+++ b/modules/trusted-firmware-m/tfm_boards/nrf54l15_cpuapp/config_tfm_target.h
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#pragma once
+
+#include <common_config_tfm_target.h>

--- a/modules/trusted-firmware-m/tfm_boards/nrf9120/config_tfm_target.h
+++ b/modules/trusted-firmware-m/tfm_boards/nrf9120/config_tfm_target.h
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#pragma once
+
+#include <common_config_tfm_target.h>

--- a/modules/trusted-firmware-m/tfm_boards/nrf9160/config_tfm_target.h
+++ b/modules/trusted-firmware-m/tfm_boards/nrf9160/config_tfm_target.h
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#pragma once
+
+#include <common_config_tfm_target.h>


### PR DESCRIPTION
I am unable to find any C code that uses this definition as it appears that it is being redundantly provided by

build/*/tfm/generated/interface/include/psa_manifest/sid.h