### PR TITLE
lib: location: Send GNSS coordinates to nRF Cloud

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -815,6 +815,7 @@ Modem libraries
 
     * Convenience function to get :c:struct:`location_data_details` from the :c:struct:`location_event_data`.
     * Location data details for event :c:enum:`LOCATION_EVT_RESULT_UNKNOWN`.
+    * Sending GNSS coordinates to nRF Cloud when the :kconfig:option:`CONFIG_LOCATION_SERVICE_NRF_CLOUD_GNSS_POS_SEND` Kconfig option is set.
 
 * :ref:`pdn_readme` library:
 

--- a/lib/location/Kconfig
+++ b/lib/location/Kconfig
@@ -86,6 +86,13 @@ config LOCATION_METHOD_GNSS_PRIORITIZE_QZSS_ASSISTANCE
 	  needed at the same time. Enabling this option allows A-GNSS data request to be sent also
 	  when only QZSS assistance data (usually ephemerides) is needed.
 
+config LOCATION_SERVICE_NRF_CLOUD_GNSS_POS_SEND
+	bool "Send GNSS coordinates to nRF Cloud"
+	depends on !LOCATION_SERVICE_EXTERNAL
+	depends on NRF_CLOUD_REST || NRF_CLOUD_MQTT || NRF_CLOUD_COAP
+	help
+	  Send GNSS coordinates to nRF Cloud.
+
 endif # LOCATION_METHOD_GNSS
 
 if LOCATION_METHOD_WIFI

--- a/samples/cellular/modem_shell/sample.yaml
+++ b/samples/cellular/modem_shell/sample.yaml
@@ -37,6 +37,8 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
+    extra_configs:
+      - CONFIG_LOCATION_SERVICE_NRF_CLOUD_GNSS_POS_SEND=y
     extra_args: OVERLAY_CONFIG=overlay-cloud_mqtt.conf
     tags: ci_build sysbuild
   sample.cellular.modem_shell.cloud_mqtt_rest:
@@ -65,6 +67,8 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
+    extra_configs:
+      - CONFIG_LOCATION_SERVICE_NRF_CLOUD_GNSS_POS_SEND=y
     extra_args: OVERLAY_CONFIG=overlay-cloud_coap.conf
     tags: ci_build sysbuild
   sample.cellular.modem_shell.non_offloading_ip:


### PR DESCRIPTION
Added support for sending GNSS coordinates to nRF Cloud. This is only supported with nRF Cloud and is configured with a Kconfig option.

Jira: NCSDK-24322