### PR TITLE
lib: nrf_modem: let application set modem fault thread stack size

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -807,8 +807,13 @@ Modem libraries
 
 * :ref:`nrf_modem_lib_readme`:
 
-  * Added the Kconfig option  :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_UART_CHUNK_SZ` to process traces in chunks.
-    This can improve the availability of trace memory, and thus reduce the chances of losing traces.
+
+  * Added
+
+    * The Kconfig option  :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_UART_CHUNK_SZ` to process traces in chunks.
+      This can improve the availability of trace memory, and thus reduce the chances of losing traces.
+    * The :kconfig:option:`CONFIG_NRF_MODEM_LIB_FAULT_THREAD_STACK_SIZE` Kconfig option to allow the application to set the modem fault thread stack size.
+
   * Deprecated the Kconfig option :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_UART_ZEPHYR`.
   * Fixed an issue with the CFUN hooks when the Modem library is initialized during ``SYS_INIT`` at kernel level and makes calls to the :ref:`nrf_modem_at` interface before the application level initialization is done.
   * Removed the deprecated options ``CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_UART_ASYNC`` and ``CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_UART_SYNC``.

--- a/lib/nrf_modem_lib/Kconfig.modemlib
+++ b/lib/nrf_modem_lib/Kconfig.modemlib
@@ -217,6 +217,15 @@ config NRF_MODEM_LIB_ON_FAULT_APPLICATION_SPECIFIC
 
 endchoice # NRF_MODEM_LIB_ON_FAULT
 
+if NRF_MODEM_LIB_ON_FAULT_RESET_MODEM
+
+config NRF_MODEM_LIB_FAULT_THREAD_STACK_SIZE
+	int "Modem fault thread stack size"
+	default 768 if SIZE_OPTIMIZATIONS
+	default 2048
+
+endif
+
 config NRF_MODEM_LIB_CFUN_HOOKS
 	bool "Modem CFUN hooks"
 	default y

--- a/lib/nrf_modem_lib/fault.c
+++ b/lib/nrf_modem_lib/fault.c
@@ -85,17 +85,11 @@ static void restart_on_fault(void *p1, void *p2, void *p3)
 	}
 }
 
-#if CONFIG_SIZE_OPTIMIZATIONS
-#define STACK_SIZE 768
-#else
-#define STACK_SIZE 1024
-#endif
-
 /* The thread that re-initializes the Modem library should have a lower priority
  * than any other application thread that wants to see the NRF_ESHUTDOWN error
  * when the Modem library is shutdown or the modem has faulted.
  */
-K_THREAD_DEFINE(nrf_modem_lib_fault, STACK_SIZE, restart_on_fault, NULL, NULL, NULL,
-		K_LOWEST_APPLICATION_THREAD_PRIO, 0, 0);
+K_THREAD_DEFINE(nrf_modem_lib_fault, CONFIG_NRF_MODEM_LIB_FAULT_THREAD_STACK_SIZE,
+		restart_on_fault, NULL, NULL, NULL, K_LOWEST_APPLICATION_THREAD_PRIO, 0, 0);
 
 #endif /* CONFIG_NRF_MODEM_LIB_ON_FAULT_RESET_MODEM */


### PR DESCRIPTION
Let the application set the modem fault thread stack size using the CONFIG_NRF_MODEM_LIB_FAULT_THREAD_STACK_SIZE Kconfig option.

This is useful as the application can have modem init and shutdown hooks that are called when the modem is reset.