### PR TITLE
applications: nrf5340_audio: Expand broadcast_source_enable

### DIFF
--- a/applications/nrf5340_audio/Kconfig
+++ b/applications/nrf5340_audio/Kconfig
@@ -10,6 +10,12 @@ menuconfig NRF5340_AUDIO
 
 if NRF5340_AUDIO
 
+config CUSTOM_BROADCASTER
+	bool "Allow custom broadcasters"
+	default n
+	help
+	  Incomplete feature for now, but will introduce support for multiple BIGs and subgroups.
+
 config AUDIO_DEV
 	int "Select which device type to compile for. 1=HEADSET or 2=GATEWAY"
 	range 1 2

--- a/applications/nrf5340_audio/include/nrf5340_audio_common.h
+++ b/applications/nrf5340_audio/include/nrf5340_audio_common.h
@@ -61,6 +61,7 @@ enum bt_mgmt_evt_type {
 struct bt_mgmt_msg {
 	enum bt_mgmt_evt_type event;
 	struct bt_conn *conn;
+	uint8_t index;
 	struct bt_le_ext_adv *ext_adv;
 	struct bt_le_per_adv_sync *pa_sync;
 	uint32_t broadcast_id;

--- a/applications/nrf5340_audio/src/bluetooth/bt_management/advertising/bt_mgmt_adv_internal.h
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/advertising/bt_mgmt_adv_internal.h
@@ -19,7 +19,9 @@ void bt_mgmt_adv_init(void);
  *
  *		This function deletes the old ext_adv and creates a new one.
  *		It also sets the dir_adv_timed_out flag and restarts advertisement.
+ *
+ * @param[in]	ext_adv_index	Index of the ext_adv to restart.
  */
-void bt_mgmt_dir_adv_timed_out(void);
+void bt_mgmt_dir_adv_timed_out(uint8_t ext_adv_index);
 
 #endif /* _BT_MGMT_ADV_INTERNAL_H_ */

--- a/applications/nrf5340_audio/src/bluetooth/bt_management/bt_mgmt.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/bt_mgmt.c
@@ -78,9 +78,9 @@ static void connected_cb(struct bt_conn *conn, uint8_t err)
 	if (err == BT_HCI_ERR_ADV_TIMEOUT && IS_ENABLED(CONFIG_BT_PERIPHERAL)) {
 		LOG_INF("Directed adv timed out with no connection, reverting to normal adv");
 
-		bt_mgmt_dir_adv_timed_out();
+		bt_mgmt_dir_adv_timed_out(0);
 
-		ret = bt_mgmt_adv_start(NULL, 0, NULL, 0, true);
+		ret = bt_mgmt_adv_start(0, NULL, 0, NULL, 0, true);
 		if (ret) {
 			LOG_ERR("Failed to restart advertising: %d", ret);
 		}
@@ -105,7 +105,7 @@ static void connected_cb(struct bt_conn *conn, uint8_t err)
 		}
 
 		if (IS_ENABLED(CONFIG_BT_PERIPHERAL)) {
-			ret = bt_mgmt_adv_start(NULL, 0, NULL, 0, true);
+			ret = bt_mgmt_adv_start(0, NULL, 0, NULL, 0, true);
 			if (ret) {
 				LOG_ERR("Failed to restart advertising: %d", ret);
 			}
@@ -167,7 +167,7 @@ static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 	ERR_CHK(ret);
 
 	if (IS_ENABLED(CONFIG_BT_PERIPHERAL)) {
-		ret = bt_mgmt_adv_start(NULL, 0, NULL, 0, true);
+		ret = bt_mgmt_adv_start(0, NULL, 0, NULL, 0, true);
 		ERR_CHK(ret);
 	}
 

--- a/applications/nrf5340_audio/src/bluetooth/bt_management/bt_mgmt.h
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/bt_mgmt.h
@@ -94,6 +94,7 @@ int bt_mgmt_manufacturer_uuid_populate(struct net_buf_simple *uuid_buf, uint16_t
 /**
  * @brief	Create and start advertising for ACL connection.
  *
+ * @param[in]	ext_adv_index	Index of the advertising set to start.
  * @param[in]	ext_adv		The data to be put in the extended advertisement.
  * @param[in]	ext_adv_size	Size of @p ext_adv.
  * @param[in]	per_adv		The data for the periodic advertisement; can be NULL.
@@ -106,7 +107,7 @@ int bt_mgmt_manufacturer_uuid_populate(struct net_buf_simple *uuid_buf, uint16_t
  *
  * @return	0 if success, error otherwise.
  */
-int bt_mgmt_adv_start(const struct bt_data *ext_adv, size_t ext_adv_size,
+int bt_mgmt_adv_start(uint8_t ext_adv_index, const struct bt_data *ext_adv, size_t ext_adv_size,
 		      const struct bt_data *per_adv, size_t per_adv_size, bool connectable);
 
 /**

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/broadcast_source.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/broadcast_source.c
@@ -28,32 +28,33 @@ LOG_MODULE_REGISTER(broadcast_source, CONFIG_BROADCAST_SOURCE_LOG_LEVEL);
 /* Length-type-value size for channel allocation */
 #define LTV_CHAN_ALLOC_SIZE 6
 
-BUILD_ASSERT(CONFIG_BT_BAP_BROADCAST_SRC_STREAM_COUNT <= 2,
-	     "A maximum of two audio streams are currently supported");
-
 ZBUS_CHAN_DEFINE(le_audio_chan, struct le_audio_msg, NULL, NULL, ZBUS_OBSERVERS_EMPTY,
 		 ZBUS_MSG_INIT(0));
 
-static struct bt_cap_broadcast_source *broadcast_source;
-static struct bt_cap_stream cap_streams[CONFIG_BT_BAP_BROADCAST_SRC_STREAM_COUNT];
-static struct bt_bap_lc3_preset lc3_preset = BT_BAP_LC3_BROADCAST_PRESET_NRF5340_AUDIO;
-static struct bt_le_ext_adv *adv;
-static bool initialized;
-static bool delete_broadcast_src;
+static struct bt_cap_broadcast_source *broadcast_source[CONFIG_BT_ISO_MAX_BIG];
+/* Make sure we have statically allocated streams for all potential BISes */
+static struct bt_cap_stream cap_streams[CONFIG_BT_ISO_MAX_BIG]
+				       [CONFIG_BT_BAP_BROADCAST_SRC_SUBGROUP_COUNT]
+				       [CONFIG_BT_BAP_BROADCAST_SRC_STREAM_COUNT /
+					CONFIG_BT_BAP_BROADCAST_SRC_SUBGROUP_COUNT];
 
-uint8_t audio_mapping_mask[CONFIG_BT_BAP_BROADCAST_SRC_STREAM_COUNT] = {UINT8_MAX};
+static struct bt_bap_lc3_preset lc3_preset = BT_BAP_LC3_BROADCAST_PRESET_NRF5340_AUDIO;
+
+static bool initialized;
+static bool delete_broadcast_src[CONFIG_BT_ISO_MAX_BIG];
 
 #if (CONFIG_AURACAST)
 /* Make sure pba_buf is large enough for a 16bit UUID and meta data
  * (any addition to pba_buf requires an increase of this value)
  */
 NET_BUF_SIMPLE_DEFINE(pba_buf, BT_UUID_SIZE_16 + 8);
-static struct bt_data ext_ad[5];
+NET_BUF_SIMPLE_DEFINE(pba_buf2, BT_UUID_SIZE_16 + 8);
+static struct bt_data ext_ad[CONFIG_BT_ISO_MAX_BIG][5];
 #else
-static struct bt_data ext_ad[4];
+static struct bt_data ext_ad[CONFIG_BT_ISO_MAX_BIG][4];
 #endif /* (CONFIG_AURACAST) */
 
-static struct bt_data per_ad[1];
+static struct bt_data per_ad[CONFIG_BT_ISO_MAX_BIG][1];
 
 static void le_audio_event_publish(enum le_audio_evt_type event)
 {
@@ -66,12 +67,23 @@ static void le_audio_event_publish(enum le_audio_evt_type event)
 	ERR_CHK(ret);
 }
 
-static int get_stream_index(struct bt_bap_stream *stream, uint8_t *index)
+static int get_stream_index(struct bt_bap_stream *stream, struct stream_index *index,
+			    uint8_t *flattened_index)
 {
-	for (int i = 0; i < ARRAY_SIZE(cap_streams); i++) {
-		if (&cap_streams[i].bap_stream == stream) {
-			*index = i;
-			return 0;
+	uint8_t flat_index = 0;
+
+	for (int i = 0; i < CONFIG_BT_ISO_MAX_BIG; i++) {
+		for (int j = 0; i < CONFIG_BT_BAP_BROADCAST_SRC_SUBGROUP_COUNT; j++) {
+			for (int k = 0; k < ARRAY_SIZE(cap_streams[i][j]); k++) {
+				if (&cap_streams[i][j][k].bap_stream == stream) {
+					index->level1_idx = i;
+					index->level2_idx = j;
+					index->level3_idx = k;
+					*flattened_index = flat_index;
+					return 0;
+				}
+				flat_index++;
+			}
 		}
 	}
 
@@ -82,18 +94,30 @@ static int get_stream_index(struct bt_bap_stream *stream, uint8_t *index)
 
 static void stream_sent_cb(struct bt_bap_stream *stream)
 {
-	uint8_t index = 0;
+	int ret;
+	struct stream_index index;
+	uint8_t flattened_index;
 
-	get_stream_index(stream, &index);
-	ERR_CHK(bt_le_audio_tx_stream_sent(index));
+	ret = get_stream_index(stream, &index, &flattened_index);
+	if (ret) {
+		return;
+	}
+
+	ERR_CHK(bt_le_audio_tx_stream_sent(flattened_index));
 }
 
 static void stream_started_cb(struct bt_bap_stream *stream)
 {
-	uint8_t index = 0;
+	int ret;
+	struct stream_index index;
+	uint8_t flattened_index;
 
-	get_stream_index(stream, &index);
-	ERR_CHK(bt_le_audio_tx_stream_started(index));
+	ret = get_stream_index(stream, &index, &flattened_index);
+	if (ret) {
+		return;
+	}
+
+	ERR_CHK(bt_le_audio_tx_stream_started(flattened_index));
 
 	le_audio_event_publish(LE_AUDIO_EVT_STREAMING);
 
@@ -106,29 +130,33 @@ static void stream_started_cb(struct bt_bap_stream *stream)
 static void stream_stopped_cb(struct bt_bap_stream *stream, uint8_t reason)
 {
 	int ret;
-	uint8_t index = 0;
+	struct stream_index index;
+	uint8_t flattened_index;
 
-	get_stream_index(stream, &index);
+	ret = get_stream_index(stream, &index, &flattened_index);
+	if (ret) {
+		return;
+	}
 
 	le_audio_event_publish(LE_AUDIO_EVT_NOT_STREAMING);
 
-	ERR_CHK(bt_le_audio_tx_stream_stopped(index));
+	ERR_CHK(bt_le_audio_tx_stream_stopped(flattened_index));
 
 	LOG_INF("Broadcast source %p stopped. Reason: %d", (void *)stream, reason);
 
-	if (delete_broadcast_src && broadcast_source != NULL) {
-		ret = bt_cap_initiator_broadcast_audio_delete(broadcast_source);
+	if (delete_broadcast_src[index.level1_idx] && broadcast_source[index.level1_idx] != NULL) {
+		ret = bt_cap_initiator_broadcast_audio_delete(broadcast_source[index.level1_idx]);
 		if (ret) {
 			LOG_ERR("Unable to delete broadcast source %p", (void *)stream);
-			delete_broadcast_src = false;
+			delete_broadcast_src[index.level1_idx] = false;
 			return;
 		}
 
-		broadcast_source = NULL;
+		broadcast_source[index.level1_idx] = NULL;
 
 		LOG_INF("Broadcast source %p deleted", (void *)stream);
 
-		delete_broadcast_src = false;
+		delete_broadcast_src[index.level1_idx] = false;
 	}
 }
 
@@ -163,28 +191,44 @@ static void public_broadcast_features_set(uint8_t *features)
 }
 #endif /* (CONFIG_AURACAST) */
 
-static int adv_create(void)
+/* Broadcast Audio Streaming Endpoint advertising data */
+NET_BUF_SIMPLE_DEFINE_STATIC(brdcst_id_buf, BT_UUID_SIZE_16 + BT_AUDIO_BROADCAST_ID_SIZE);
+/* Buffer for Appearance */
+NET_BUF_SIMPLE_DEFINE_STATIC(brdcst_appearance_buf, BT_UUID_SIZE_16);
+/* Buffer for manufacturer ID */
+NET_BUF_SIMPLE_DEFINE_STATIC(manufacturer_id_buf, BT_UUID_SIZE_16);
+/* Buffer for Public Broadcast Announcement */
+NET_BUF_SIMPLE_DEFINE_STATIC(base_buf, 128);
+
+/* Broadcast Audio Streaming Endpoint advertising data */
+NET_BUF_SIMPLE_DEFINE_STATIC(brdcst_id_buf2, BT_UUID_SIZE_16 + BT_AUDIO_BROADCAST_ID_SIZE);
+/* Buffer for Appearance */
+NET_BUF_SIMPLE_DEFINE_STATIC(brdcst_appearance_buf2, BT_UUID_SIZE_16);
+/* Buffer for manufacturer ID */
+NET_BUF_SIMPLE_DEFINE_STATIC(manufacturer_id_buf2, BT_UUID_SIZE_16);
+/* Buffer for Public Broadcast Announcement */
+NET_BUF_SIMPLE_DEFINE_STATIC(base_buf2, 128);
+
+static int adv_create(uint8_t big_index)
 {
 	int ret;
 	uint32_t broadcast_id = 0;
 
-	/* Broadcast Audio Streaming Endpoint advertising data */
-	NET_BUF_SIMPLE_DEFINE_STATIC(brdcst_id_buf, BT_UUID_SIZE_16 + BT_AUDIO_BROADCAST_ID_SIZE);
-	/* Buffer for Appearance */
-	NET_BUF_SIMPLE_DEFINE_STATIC(brdcst_appearance_buf, BT_UUID_SIZE_16);
-	/* Buffer for manufacturer ID */
-	NET_BUF_SIMPLE_DEFINE_STATIC(manufacturer_id_buf, BT_UUID_SIZE_16);
-	/* Buffer for Public Broadcast Announcement */
-	NET_BUF_SIMPLE_DEFINE_STATIC(base_buf, 128);
+	if (big_index == 0) {
+		net_buf_simple_add_le16(&manufacturer_id_buf, CONFIG_BT_DEVICE_MANUFACTURER_ID);
 
-	net_buf_simple_add_le16(&manufacturer_id_buf, CONFIG_BT_DEVICE_MANUFACTURER_ID);
-
-	ext_ad[0].data_len = manufacturer_id_buf.len;
-	ext_ad[0].type = BT_DATA_UUID16_SOME;
-	ext_ad[0].data = manufacturer_id_buf.data;
+		ext_ad[big_index][0].data_len = manufacturer_id_buf.len;
+		ext_ad[big_index][0].type = BT_DATA_UUID16_SOME;
+		ext_ad[big_index][0].data = manufacturer_id_buf.data;
+	} else {
+		net_buf_simple_add_le16(&manufacturer_id_buf2, CONFIG_BT_DEVICE_MANUFACTURER_ID);
+		ext_ad[big_index][0].data_len = manufacturer_id_buf2.len;
+		ext_ad[big_index][0].type = BT_DATA_UUID16_SOME;
+		ext_ad[big_index][0].data = manufacturer_id_buf2.data;
+	}
 
 	if (IS_ENABLED(CONFIG_BT_AUDIO_USE_BROADCAST_ID_RANDOM)) {
-		ret = bt_cap_initiator_broadcast_get_id(broadcast_source, &broadcast_id);
+		ret = bt_cap_initiator_broadcast_get_id(broadcast_source[big_index], &broadcast_id);
 		if (ret) {
 			LOG_ERR("Unable to get broadcast ID: %d", ret);
 			return ret;
@@ -194,73 +238,124 @@ static int adv_create(void)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_AUDIO_USE_BROADCAST_NAME_ALT)) {
-		ext_ad[1] = (struct bt_data)BT_DATA(BT_DATA_BROADCAST_NAME,
-						    CONFIG_BT_AUDIO_BROADCAST_NAME_ALT,
-						    sizeof(CONFIG_BT_AUDIO_BROADCAST_NAME_ALT) - 1);
+		ext_ad[big_index][1] = (struct bt_data)BT_DATA(
+			BT_DATA_BROADCAST_NAME, CONFIG_BT_AUDIO_BROADCAST_NAME_ALT,
+			sizeof(CONFIG_BT_AUDIO_BROADCAST_NAME_ALT) - 1);
 	} else {
-		ext_ad[1] = (struct bt_data)BT_DATA(BT_DATA_BROADCAST_NAME,
-						    CONFIG_BT_AUDIO_BROADCAST_NAME,
-						    sizeof(CONFIG_BT_AUDIO_BROADCAST_NAME) - 1);
+		ext_ad[big_index][1] = (struct bt_data)BT_DATA(
+			BT_DATA_BROADCAST_NAME, CONFIG_BT_AUDIO_BROADCAST_NAME,
+			sizeof(CONFIG_BT_AUDIO_BROADCAST_NAME) - 1);
 	}
 
 	/* Setup extended advertising data */
-	net_buf_simple_add_le16(&brdcst_id_buf, BT_UUID_BROADCAST_AUDIO_VAL);
-	net_buf_simple_add_le24(&brdcst_id_buf, broadcast_id);
+	if (big_index == 0) {
+		net_buf_simple_add_le16(&brdcst_id_buf, BT_UUID_BROADCAST_AUDIO_VAL);
+		net_buf_simple_add_le24(&brdcst_id_buf, broadcast_id);
+		ext_ad[big_index][2].data_len = brdcst_id_buf.len;
+		ext_ad[big_index][2].type = BT_DATA_SVC_DATA16;
+		ext_ad[big_index][2].data = brdcst_id_buf.data;
+	} else {
+		net_buf_simple_add_le16(&brdcst_id_buf2, BT_UUID_BROADCAST_AUDIO_VAL);
+		net_buf_simple_add_le24(&brdcst_id_buf2, broadcast_id);
+		ext_ad[big_index][2].data_len = brdcst_id_buf2.len;
+		ext_ad[big_index][2].type = BT_DATA_SVC_DATA16;
+		ext_ad[big_index][2].data = brdcst_id_buf2.data;
+	}
 
-	ext_ad[2].data_len = brdcst_id_buf.len;
-	ext_ad[2].type = BT_DATA_SVC_DATA16;
-	ext_ad[2].data = brdcst_id_buf.data;
-
-	net_buf_simple_add_le16(&brdcst_appearance_buf, CONFIG_BT_DEVICE_APPEARANCE);
-
-	ext_ad[3].data_len = brdcst_appearance_buf.len;
-	ext_ad[3].type = BT_DATA_GAP_APPEARANCE;
-	ext_ad[3].data = brdcst_appearance_buf.data;
+	if (big_index == 0) {
+		net_buf_simple_add_le16(&brdcst_appearance_buf, CONFIG_BT_DEVICE_APPEARANCE);
+		ext_ad[big_index][3].data_len = brdcst_appearance_buf.len;
+		ext_ad[big_index][3].type = BT_DATA_GAP_APPEARANCE;
+		ext_ad[big_index][3].data = brdcst_appearance_buf.data;
+	} else {
+		net_buf_simple_add_le16(&brdcst_appearance_buf2, CONFIG_BT_DEVICE_APPEARANCE);
+		ext_ad[big_index][3].data_len = brdcst_appearance_buf2.len;
+		ext_ad[big_index][3].type = BT_DATA_GAP_APPEARANCE;
+		ext_ad[big_index][3].data = brdcst_appearance_buf2.data;
+	}
 
 #if (CONFIG_AURACAST)
 	uint8_t pba_features = 0;
 	public_broadcast_features_set(&pba_features);
 
-	net_buf_simple_add_le16(&pba_buf, 0x1856);
-	net_buf_simple_add_u8(&pba_buf, pba_features);
+	if (big_index == 0) {
+		net_buf_simple_add_le16(&pba_buf, 0x1856);
+		net_buf_simple_add_u8(&pba_buf, pba_features);
 
-	/* Metadata */
-	/* 3 bytes for parental_rating and 3 bytes for active_flag LTVs */
-	net_buf_simple_add_u8(&pba_buf, 0x06);
+		/* Metadata */
+		/* 3 bytes for parental_rating and 3 bytes for active_flag LTVs */
+		net_buf_simple_add_u8(&pba_buf, 0x06);
 
-	/* Parental rating*/
-	/* Length */
-	net_buf_simple_add_u8(&pba_buf, 0x02);
-	/* Type */
-	net_buf_simple_add_u8(&pba_buf, BT_AUDIO_METADATA_TYPE_PARENTAL_RATING);
-	/* Value */
-	net_buf_simple_add_u8(&pba_buf, CONFIG_BT_AUDIO_BROADCAST_PARENTAL_RATING);
+		/* Parental rating*/
+		/* Length */
+		net_buf_simple_add_u8(&pba_buf, 0x02);
+		/* Type */
+		net_buf_simple_add_u8(&pba_buf, BT_AUDIO_METADATA_TYPE_PARENTAL_RATING);
+		/* Value */
+		net_buf_simple_add_u8(&pba_buf, CONFIG_BT_AUDIO_BROADCAST_PARENTAL_RATING);
 
-	/* Active flag */
-	/* Length */
-	net_buf_simple_add_u8(&pba_buf, 0x02);
-	/* Type */
-	net_buf_simple_add_u8(&pba_buf, BT_AUDIO_METADATA_TYPE_AUDIO_STATE);
-	/* Value */
-	net_buf_simple_add_u8(&pba_buf, BT_AUDIO_ACTIVE_STATE_ENABLED);
+		/* Active flag */
+		/* Length */
+		net_buf_simple_add_u8(&pba_buf, 0x02);
+		/* Type */
+		net_buf_simple_add_u8(&pba_buf, BT_AUDIO_METADATA_TYPE_AUDIO_STATE);
+		/* Value */
+		net_buf_simple_add_u8(&pba_buf, BT_AUDIO_ACTIVE_STATE_ENABLED);
+		ext_ad[big_index][4].data_len = pba_buf.len;
+		ext_ad[big_index][4].type = BT_DATA_SVC_DATA16;
+		ext_ad[big_index][4].data = pba_buf.data;
+	} else {
+		net_buf_simple_add_le16(&pba_buf2, 0x1856);
+		net_buf_simple_add_u8(&pba_buf2, pba_features);
 
+		/* Metadata */
+		/* 3 bytes for parental_rating and 3 bytes for active_flag LTVs */
+		net_buf_simple_add_u8(&pba_buf2, 0x06);
+
+		/* Parental rating*/
+		/* Length */
+		net_buf_simple_add_u8(&pba_buf2, 0x02);
+		/* Type */
+		net_buf_simple_add_u8(&pba_buf2, BT_AUDIO_METADATA_TYPE_PARENTAL_RATING);
+		/* Value */
+		net_buf_simple_add_u8(&pba_buf2, CONFIG_BT_AUDIO_BROADCAST_PARENTAL_RATING);
+
+		/* Active flag */
+		/* Length */
+		net_buf_simple_add_u8(&pba_buf2, 0x02);
+		/* Type */
+		net_buf_simple_add_u8(&pba_buf2, BT_AUDIO_METADATA_TYPE_AUDIO_STATE);
+		/* Value */
+		net_buf_simple_add_u8(&pba_buf2, BT_AUDIO_ACTIVE_STATE_ENABLED);
+		ext_ad[big_index][4].data_len = pba_buf2.len;
+		ext_ad[big_index][4].type = BT_DATA_SVC_DATA16;
+		ext_ad[big_index][4].data = pba_buf2.data;
+	}
 	/* If any additional data is to be added, remember to increase NET_BUF size */
 
-	ext_ad[4].data_len = pba_buf.len;
-	ext_ad[4].type = BT_DATA_SVC_DATA16;
-	ext_ad[4].data = pba_buf.data;
 #endif /* (CONFIG_AURACAST) */
 
 	/* Setup periodic advertising data */
-	ret = bt_cap_initiator_broadcast_get_base(broadcast_source, &base_buf);
-	if (ret) {
-		LOG_ERR("Failed to get encoded BASE: %d", ret);
-		return ret;
-	}
 
-	per_ad[0].data_len = base_buf.len;
-	per_ad[0].type = BT_DATA_SVC_DATA16;
-	per_ad[0].data = base_buf.data;
+	if (big_index == 0) {
+		ret = bt_cap_initiator_broadcast_get_base(broadcast_source[big_index], &base_buf);
+		if (ret) {
+			LOG_ERR("Failed to get encoded BASE: %d", ret);
+			return ret;
+		}
+		per_ad[big_index][0].data_len = base_buf.len;
+		per_ad[big_index][0].type = BT_DATA_SVC_DATA16;
+		per_ad[big_index][0].data = base_buf.data;
+	} else {
+		ret = bt_cap_initiator_broadcast_get_base(broadcast_source[big_index], &base_buf2);
+		if (ret) {
+			LOG_ERR("Failed to get encoded BASE: %d", ret);
+			return ret;
+		}
+		per_ad[big_index][0].data_len = base_buf2.len;
+		per_ad[big_index][0].type = BT_DATA_SVC_DATA16;
+		per_ad[big_index][0].data = base_buf2.data;
+	}
 
 	return 0;
 }
@@ -280,24 +375,110 @@ static void bt_audio_codec_allocation_set(uint8_t *data, uint8_t data_len,
 	sys_put_le32((const uint32_t)loc, &data[2]);
 }
 
-void broadcast_source_adv_get(const struct bt_data **ext_adv, size_t *ext_adv_size,
-			      const struct bt_data **per_adv, size_t *per_adv_size)
-{
-	*ext_adv = ext_ad;
-	*ext_adv_size = ARRAY_SIZE(ext_ad);
-	*per_adv = per_ad;
-	*per_adv_size = ARRAY_SIZE(per_ad);
-}
-
-int broadcast_source_start(struct bt_le_ext_adv *ext_adv)
+static int create_param_produce(uint8_t big_index,
+				struct broadcast_source_big const *const ext_create_param,
+				struct bt_cap_initiator_broadcast_create_param *create_param)
 {
 	int ret;
 
-	if (ext_adv != NULL) {
-		adv = ext_adv;
+	if (ext_create_param->num_subgroups > CONFIG_BT_BAP_BROADCAST_SRC_SUBGROUP_COUNT) {
+		LOG_ERR("Trying to create %d subgroups, but only allocated memory for %d",
+			ext_create_param->num_subgroups,
+			CONFIG_BT_BAP_BROADCAST_SRC_SUBGROUP_COUNT);
+		return -EINVAL;
 	}
 
-	if (adv == NULL) {
+	uint8_t total_num_bis = 0;
+
+	for (size_t i = 0U; i < ext_create_param->num_subgroups; i++) {
+		for (size_t j = 0; j < ext_create_param->subgroups[i].num_bises; j++) {
+			total_num_bis++;
+		}
+	}
+
+	if (total_num_bis > CONFIG_BT_BAP_BROADCAST_SRC_STREAM_COUNT) {
+		LOG_ERR("Trying to set up %d BISes in total, but only allocated memory for %d",
+			total_num_bis, CONFIG_BT_BAP_BROADCAST_SRC_STREAM_COUNT);
+		return -EINVAL;
+	}
+
+	static struct bt_cap_initiator_broadcast_stream_param
+		stream_params[CONFIG_BT_BAP_BROADCAST_SRC_SUBGROUP_COUNT][2];
+	static uint8_t bis_codec_data[CONFIG_BT_BAP_BROADCAST_SRC_SUBGROUP_COUNT][2]
+				     [LTV_CHAN_ALLOC_SIZE];
+	static struct bt_cap_initiator_broadcast_subgroup_param
+		subgroup_params[CONFIG_BT_BAP_BROADCAST_SRC_SUBGROUP_COUNT];
+
+	(void)memset(cap_streams[big_index], 0, sizeof(cap_streams[big_index]));
+
+	for (size_t i = 0U; i < ext_create_param->num_subgroups; i++) {
+		enum bt_audio_location subgroup_loc = 0;
+
+		for (size_t j = 0; j < ext_create_param->subgroups[i].num_bises; j++) {
+			stream_params[i][j].stream = &cap_streams[big_index][i][j];
+
+			stream_params[i][j].data_len = ARRAY_SIZE(bis_codec_data[i][j]);
+			stream_params[i][j].data = bis_codec_data[i][j];
+
+			enum bt_audio_location loc = ext_create_param->subgroups[i].location[j];
+
+			subgroup_loc |= loc;
+			bt_audio_codec_allocation_set(stream_params[i][j].data,
+						      stream_params[i][j].data_len, loc);
+		}
+
+		subgroup_params[i].stream_count = ARRAY_SIZE(stream_params[i]);
+		subgroup_params[i].stream_params = stream_params[i];
+		subgroup_params[i].codec_cfg =
+			&ext_create_param->subgroups[i].group_lc3_preset.codec_cfg;
+		ret = bt_audio_codec_cfg_set_chan_allocation(subgroup_params[i].codec_cfg,
+							     subgroup_loc);
+		if (ret < 0) {
+			LOG_WRN("Failed to set location: %d", ret);
+			return -EINVAL;
+		}
+
+		ret = bt_audio_codec_cfg_meta_set_stream_context(
+			subgroup_params[i].codec_cfg, ext_create_param->subgroups[i].context);
+		if (ret < 0) {
+			LOG_WRN("Failed to set context: %d", ret);
+			return -EINVAL;
+		}
+	}
+
+	/* Create broadcast_source */
+	create_param->subgroup_count = ext_create_param->num_subgroups;
+	create_param->subgroup_params = subgroup_params;
+	/* All QoS within the BIG will be the same, so we get the one from the first subgroup */
+	create_param->qos = &ext_create_param->subgroups[0].group_lc3_preset.qos;
+
+	create_param->packing = ext_create_param->packing;
+
+	create_param->encryption = ext_create_param->encryption;
+	if (ext_create_param->encryption) {
+		memset(create_param->broadcast_code, 0, sizeof(create_param->broadcast_code));
+		memcpy(create_param->broadcast_code, ext_create_param->broadcast_code,
+		       sizeof(ext_create_param->broadcast_code));
+	}
+
+	return 0;
+}
+
+void broadcast_source_adv_get(uint8_t big_index, const struct bt_data **ext_adv,
+			      size_t *ext_adv_size, const struct bt_data **per_adv,
+			      size_t *per_adv_size)
+{
+	*ext_adv = ext_ad[big_index];
+	*ext_adv_size = ARRAY_SIZE(ext_ad[big_index]);
+	*per_adv = per_ad[big_index];
+	*per_adv_size = ARRAY_SIZE(per_ad[big_index]);
+}
+
+int broadcast_source_start(uint8_t big_index, struct bt_le_ext_adv *ext_adv)
+{
+	int ret;
+
+	if (ext_adv == NULL) {
 		LOG_ERR("No advertising set available");
 		return -EINVAL;
 	}
@@ -307,17 +488,17 @@ int broadcast_source_start(struct bt_le_ext_adv *ext_adv)
 	/* All streams in a broadcast source is in the same state,
 	 * so we can just check the first stream
 	 */
-	if (cap_streams[0].bap_stream.ep == NULL) {
+	if (cap_streams[big_index][0][0].bap_stream.ep == NULL) {
 		LOG_ERR("stream->ep is NULL");
 		return -ECANCELED;
 	}
 
-	if (cap_streams[0].bap_stream.ep->status.state == BT_BAP_EP_STATE_STREAMING) {
+	if (cap_streams[big_index][0][0].bap_stream.ep->status.state == BT_BAP_EP_STATE_STREAMING) {
 		LOG_WRN("Already streaming");
 		return -EALREADY;
 	}
 
-	ret = bt_cap_initiator_broadcast_audio_start(broadcast_source, adv);
+	ret = bt_cap_initiator_broadcast_audio_start(broadcast_source[big_index], ext_adv);
 	if (ret) {
 		LOG_WRN("Failed to start broadcast, ret: %d", ret);
 		return ret;
@@ -326,20 +507,20 @@ int broadcast_source_start(struct bt_le_ext_adv *ext_adv)
 	return 0;
 }
 
-int broadcast_source_stop(void)
+int broadcast_source_stop(uint8_t big_index)
 {
 	int ret;
 
 	/* All streams in a broadcast source is in the same state,
 	 * so we can just check the first stream
 	 */
-	if (cap_streams[0].bap_stream.ep == NULL) {
+	if (cap_streams[big_index][0][0].bap_stream.ep == NULL) {
 		LOG_ERR("stream->ep is NULL");
 		return -ECANCELED;
 	}
 
-	if (cap_streams[0].bap_stream.ep->status.state == BT_BAP_EP_STATE_STREAMING) {
-		ret = bt_cap_initiator_broadcast_audio_stop(broadcast_source);
+	if (cap_streams[big_index][0][0].bap_stream.ep->status.state == BT_BAP_EP_STATE_STREAMING) {
+		ret = bt_cap_initiator_broadcast_audio_stop(broadcast_source[big_index]);
 		if (ret) {
 			LOG_WRN("Failed to stop broadcast, ret: %d", ret);
 			return ret;
@@ -352,17 +533,62 @@ int broadcast_source_stop(void)
 	return 0;
 }
 
-int broadcast_source_send(struct le_audio_encoded_audio enc_audio)
+/* TODO: Use the function below once
+ * https://github.com/zephyrproject-rtos/zephyr/pull/72908 is merged
+ */
+#if CONFIG_CUSTOM_BROADCASTER
+static uint8_t audio_map_location_get(struct bt_bap_stream *bap_stream)
 {
 	int ret;
-	struct bt_bap_stream *bap_tx_streams[CONFIG_BT_BAP_BROADCAST_SRC_STREAM_COUNT];
+	enum bt_audio_location loc;
 
-	for (int i = 0; i < ARRAY_SIZE(cap_streams); i++) {
-		bap_tx_streams[i] = &cap_streams[i].bap_stream;
+	ret = bt_audio_codec_cfg_get_chan_allocation(bap_stream->codec_cfg, &loc);
+	if (ret) {
+		LOG_WRN("Unable to find location, defaulting to left");
+		return AUDIO_CH_L;
 	}
 
-	ret = bt_le_audio_tx_send(bap_tx_streams, audio_mapping_mask, enc_audio,
-				  ARRAY_SIZE(cap_streams));
+	/* For now, only front_left and front_right are supported,
+	 * left is default for everything else.
+	 */
+
+	if (loc == BT_AUDIO_LOCATION_FRONT_RIGHT) {
+		LOG_WRN("Setting right");
+		return AUDIO_CH_R;
+	}
+
+	return AUDIO_CH_L;
+}
+#endif
+
+int broadcast_source_send(uint8_t big_index, struct le_audio_encoded_audio enc_audio)
+{
+	int ret;
+	struct bt_bap_stream *bap_tx_streams[CONFIG_BT_ISO_MAX_CHAN];
+	uint8_t audio_mapping_mask[CONFIG_BT_ISO_MAX_CHAN] = {UINT8_MAX};
+	uint8_t flat_index = 0;
+
+	for (int i = 0; i < CONFIG_BT_BAP_BROADCAST_SRC_SUBGROUP_COUNT; i++) {
+		for (int j = 0; j < ARRAY_SIZE(cap_streams[big_index][i]); j++) {
+			struct bt_bap_stream *stream = &cap_streams[big_index][i][j].bap_stream;
+
+			/* TODO: Use the function below once
+			 * https://github.com/zephyrproject-rtos/zephyr/pull/72908 is merged
+			 */
+			/* audio_mapping_mask[flat_index] = audio_map_location_get(stream); */
+
+			audio_mapping_mask[flat_index] = j;
+			bap_tx_streams[flat_index] = stream;
+			flat_index++;
+		}
+	}
+
+	if (!flat_index) {
+		LOG_WRN("No active streams");
+		return -ECANCELED;
+	}
+
+	ret = bt_le_audio_tx_send(bap_tx_streams, audio_mapping_mask, enc_audio, flat_index);
 	if (ret) {
 		return ret;
 	}
@@ -370,25 +596,25 @@ int broadcast_source_send(struct le_audio_encoded_audio enc_audio)
 	return 0;
 }
 
-int broadcast_source_disable(void)
+int broadcast_source_disable(uint8_t big_index)
 {
 	int ret;
 
-	if (cap_streams[0].bap_stream.ep->status.state == BT_BAP_EP_STATE_STREAMING) {
+	if (cap_streams[big_index][0][0].bap_stream.ep->status.state == BT_BAP_EP_STATE_STREAMING) {
 		/* Deleting broadcast source in stream_stopped_cb() */
-		delete_broadcast_src = true;
+		delete_broadcast_src[big_index] = true;
 
-		ret = bt_cap_initiator_broadcast_audio_stop(broadcast_source);
+		ret = bt_cap_initiator_broadcast_audio_stop(broadcast_source[big_index]);
 		if (ret) {
 			return ret;
 		}
-	} else if (broadcast_source != NULL) {
-		ret = bt_cap_initiator_broadcast_audio_delete(broadcast_source);
+	} else if (broadcast_source[big_index] != NULL) {
+		ret = bt_cap_initiator_broadcast_audio_delete(broadcast_source[big_index]);
 		if (ret) {
 			return ret;
 		}
 
-		broadcast_source = NULL;
+		broadcast_source[big_index] = NULL;
 	}
 
 	initialized = false;
@@ -398,15 +624,68 @@ int broadcast_source_disable(void)
 	return 0;
 }
 
-int broadcast_source_enable(void)
+/* Will set up one BIG, one subgroup and two BISes */
+void broadcast_source_default_create(struct broadcast_source_big *broadcast_param)
+{
+	static enum bt_audio_location location[2] = {BT_AUDIO_LOCATION_FRONT_LEFT,
+						     BT_AUDIO_LOCATION_FRONT_RIGHT};
+	static struct subgroup_config subgroups;
+
+	subgroups.group_lc3_preset = lc3_preset;
+
+	subgroups.num_bises = 2;
+	subgroups.context = BT_AUDIO_CONTEXT_TYPE_MEDIA;
+
+	subgroups.location = location;
+
+	broadcast_param->subgroups = &subgroups;
+	broadcast_param->num_subgroups = 1;
+
+	if (IS_ENABLED(CONFIG_BT_AUDIO_PACKING_INTERLEAVED)) {
+		broadcast_param->packing = BT_ISO_PACKING_INTERLEAVED;
+	} else {
+		broadcast_param->packing = BT_ISO_PACKING_SEQUENTIAL;
+	}
+
+	if (IS_ENABLED(CONFIG_BT_AUDIO_BROADCAST_ENCRYPTED)) {
+		broadcast_param->encryption = true;
+		memset(broadcast_param->broadcast_code, 0, sizeof(broadcast_param->broadcast_code));
+		memcpy(broadcast_param->broadcast_code, CONFIG_BT_AUDIO_BROADCAST_ENCRYPTION_KEY,
+		       MIN(sizeof(CONFIG_BT_AUDIO_BROADCAST_ENCRYPTION_KEY),
+			   sizeof(broadcast_param->broadcast_code)));
+	} else {
+		broadcast_param->encryption = false;
+	}
+
+	if (IS_ENABLED(CONFIG_BT_AUDIO_BROADCAST_IMMEDIATE_FLAG)) {
+		bt_audio_codec_cfg_meta_set_bcast_audio_immediate_rend_flag(
+			&subgroups.group_lc3_preset.codec_cfg);
+	}
+
+	uint8_t src[3] = "eng";
+
+	bt_audio_codec_cfg_meta_set_stream_lang(&subgroups.group_lc3_preset.codec_cfg,
+						(uint32_t)sys_get_le24(src));
+}
+
+int broadcast_source_enable(struct broadcast_source_big const *const broadcast_param,
+			    uint8_t num_bigs)
 {
 	int ret;
 
-	struct bt_cap_initiator_broadcast_stream_param stream_params[ARRAY_SIZE(cap_streams)];
-	uint8_t bis_codec_data[ARRAY_SIZE(stream_params)][LTV_CHAN_ALLOC_SIZE];
-	struct bt_cap_initiator_broadcast_subgroup_param
-		subgroup_params[CONFIG_BT_BAP_BROADCAST_SRC_SUBGROUP_COUNT];
-	struct bt_cap_initiator_broadcast_create_param create_param;
+	struct bt_cap_initiator_broadcast_create_param create_param[CONFIG_BT_ISO_MAX_BIG];
+
+	/* TODO: Remove once multiple BIGs are supported in all parts of the code */
+	if (num_bigs > 1) {
+		LOG_ERR("Only one BIG is supported at the moment");
+		return -EINVAL;
+	}
+
+	if (num_bigs > CONFIG_BT_ISO_MAX_BIG) {
+		LOG_ERR("Trying to set up %d BIGS, but only allocated memory for %d", num_bigs,
+			CONFIG_BT_ISO_MAX_BIG);
+		return -EINVAL;
+	}
 
 	if (initialized) {
 		LOG_WRN("Already initialized");
@@ -420,68 +699,36 @@ int broadcast_source_enable(void)
 
 	LOG_INF("Enabling broadcast_source %s", CONFIG_BT_AUDIO_BROADCAST_NAME);
 
-	(void)memset(cap_streams, 0, sizeof(cap_streams));
+	for (int i = 0; i < num_bigs; i++) {
+		ret = create_param_produce(i, &broadcast_param[i], &create_param[i]);
+		if (ret) {
+			LOG_ERR("Failed to create the create_param: %d", ret);
+			return ret;
+		}
 
-	/* Populate BISes */
-	for (size_t i = 0; i < ARRAY_SIZE(stream_params); i++) {
-		stream_params[i].stream = &cap_streams[i];
+		/* Register callbacks per stream */
+		for (size_t j = 0U; j < create_param[i].subgroup_count; j++) {
+			for (size_t k = 0; k < create_param[i].subgroup_params[j].stream_count;
+			     k++) {
+				bt_cap_stream_ops_register(
+					create_param[i].subgroup_params[j].stream_params[k].stream,
+					&stream_ops);
+			}
+		}
 
-		bt_cap_stream_ops_register(stream_params[i].stream, &stream_ops);
+		ret = bt_cap_initiator_broadcast_audio_create(&create_param[i],
+							      &broadcast_source[i]);
+		if (ret) {
+			LOG_ERR("Failed to create broadcast source, ret: %d", ret);
+			return ret;
+		}
 
-		stream_params[i].data_len = ARRAY_SIZE(bis_codec_data[i]);
-		stream_params[i].data = bis_codec_data[i];
-
-		/* The channel allocation is set incrementally */
-		bt_audio_codec_allocation_set(stream_params[i].data, stream_params[i].data_len,
-					      BIT(i));
-		audio_mapping_mask[i] = i;
-	}
-
-	/* Create BIGs */
-	for (size_t i = 0U; i < ARRAY_SIZE(subgroup_params); i++) {
-		subgroup_params[i].stream_count = ARRAY_SIZE(stream_params);
-		subgroup_params[i].stream_params = &stream_params[i];
-		subgroup_params[i].codec_cfg = &lc3_preset.codec_cfg;
-#if (CONFIG_BT_AUDIO_BROADCAST_IMMEDIATE_FLAG)
-		bt_audio_codec_cfg_meta_set_bcast_audio_immediate_rend_flag(
-			subgroup_params[i].codec_cfg);
-#endif /* (CONFIG_BT_AUDIO_BROADCAST_IMMEDIATE_FLAG) */
-	}
-
-	/* Create broadcast_source */
-	create_param.subgroup_count = ARRAY_SIZE(subgroup_params);
-	create_param.subgroup_params = subgroup_params;
-	create_param.qos = &lc3_preset.qos;
-
-	if (IS_ENABLED(CONFIG_BT_AUDIO_PACKING_INTERLEAVED)) {
-		create_param.packing = BT_ISO_PACKING_INTERLEAVED;
-	} else {
-		create_param.packing = BT_ISO_PACKING_SEQUENTIAL;
-	}
-
-	if (IS_ENABLED(CONFIG_BT_AUDIO_BROADCAST_ENCRYPTED)) {
-		create_param.encryption = true;
-		memset(create_param.broadcast_code, 0, sizeof(create_param.broadcast_code));
-		memcpy(create_param.broadcast_code, CONFIG_BT_AUDIO_BROADCAST_ENCRYPTION_KEY,
-		       MIN(sizeof(CONFIG_BT_AUDIO_BROADCAST_ENCRYPTION_KEY),
-			   sizeof(create_param.broadcast_code)));
-	} else {
-		create_param.encryption = false;
-	}
-
-	LOG_DBG("Creating broadcast source");
-
-	ret = bt_cap_initiator_broadcast_audio_create(&create_param, &broadcast_source);
-	if (ret) {
-		LOG_ERR("Failed to create broadcast source, ret: %d", ret);
-		return ret;
-	}
-
-	/* Create advertising set */
-	ret = adv_create();
-	if (ret) {
-		LOG_ERR("Failed to create advertising set");
-		return ret;
+		/* Create advertising set */
+		ret = adv_create(i);
+		if (ret) {
+			LOG_ERR("Failed to create advertising set");
+			return ret;
+		}
 	}
 
 	initialized = true;

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/broadcast_source.h
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/broadcast_source.h
@@ -7,7 +7,24 @@
 #ifndef _BROADCAST_SOURCE_H_
 #define _BROADCAST_SOURCE_H_
 
+#include <zephyr/bluetooth/audio/cap.h>
+#include <zephyr/bluetooth/audio/bap_lc3_preset.h>
 #include "bt_le_audio_tx.h"
+
+struct subgroup_config {
+	enum bt_audio_location *location;
+	uint8_t num_bises;
+	enum bt_audio_context context;
+	struct bt_bap_lc3_preset group_lc3_preset;
+};
+
+struct broadcast_source_big {
+	struct subgroup_config *subgroups;
+	uint8_t num_subgroups;
+	uint8_t packing;
+	bool encryption;
+	uint8_t broadcast_code[BT_AUDIO_BROADCAST_CODE_SIZE];
+};
 
 #if CONFIG_BT_AUDIO_BROADCAST_CONFIGURABLE
 #define BT_BAP_LC3_BROADCAST_PRESET_NRF5340_AUDIO                                                  \
@@ -80,52 +97,75 @@
 /**
  * @brief	Get the data to advertise.
  *
+ * @param[in]	big_index	Index of the Broadcast Isochronous Group (BIG) to get advertising
+ *				data for.
  * @param[out]	ext_adv		Pointer to the pointer of bt_data used for extended advertising.
  * @param[out]	ext_adv_size	Pointer to size of @p ext_adv.
  * @param[out]	per_adv		Pointer to the pointer of bt_data used for periodic advertising.
  * @param[out]	per_adv_size	Pointer to size of @p per_adv.
  */
-void broadcast_source_adv_get(const struct bt_data **ext_adv, size_t *ext_adv_size,
-			      const struct bt_data **per_adv, size_t *per_adv_size);
+void broadcast_source_adv_get(uint8_t big_index, const struct bt_data **ext_adv,
+			      size_t *ext_adv_size, const struct bt_data **per_adv,
+			      size_t *per_adv_size);
 
 /**
  * @brief	Start the Bluetooth LE Audio broadcast (BIS) source.
  *
+ * @param[in]	big_index	Index of the Broadcast Isochronous Group (BIG) to start.
  * @param[in]	ext_adv		Pointer to the extended advertising set; can be NULL if a stream
  *				is restarted.
  *
  * @return	0 for success, error otherwise.
  */
-int broadcast_source_start(struct bt_le_ext_adv *ext_adv);
+int broadcast_source_start(uint8_t big_index, struct bt_le_ext_adv *ext_adv);
 
 /**
  * @brief	Stop the Bluetooth LE Audio broadcast (BIS) source.
  *
+ * @param[in]	big_index	Index of the Broadcast Isochronous Group (BIG) to stop.
  * @return	0 for success, error otherwise.
  */
-int broadcast_source_stop(void);
+int broadcast_source_stop(uint8_t big_index);
 
 /**
  * @brief	Broadcast the Bluetooth LE Audio data.
  *
+ * @param[in]	big_index	Index of the Broadcast Isochronous Group (BIG) to broadcast.
  * @param[in]	enc_audio	Encoded audio struct.
  *
  * @return	0 for success, error otherwise.
  */
-int broadcast_source_send(struct le_audio_encoded_audio enc_audio);
+int broadcast_source_send(uint8_t big_index, struct le_audio_encoded_audio enc_audio);
 
 /**
  * @brief	Disable the LE Audio broadcast (BIS) source.
  *
+ * @param[in]	big_index	Index of the Broadcast Isochronous Group (BIG) to disable.
  * @return	0 for success, error otherwise.
  */
-int broadcast_source_disable(void);
+int broadcast_source_disable(uint8_t big_index);
+
+/**
+ * @brief	Create a set up for a default broadcaster.
+ *
+ * @note	This will create the parameters for a simple broadcaster with 1 Broadcast
+ *		Isochronous Group (BIG), 1 subgroup, and 2 BISes.
+ *		The BISes will be front_left and front_right and language will be set to 'eng'.
+ *
+ * @param[out]	broadcast_param	Pointer to populate with parameters for setting up the broadcaster.
+ */
+void broadcast_source_default_create(struct broadcast_source_big *broadcast_param);
 
 /**
  * @brief	Enable the LE Audio broadcast (BIS) source.
  *
+ * @param[in]	broadcast_param	Array of create parameters for creating a Broadcast
+ *				Isochronous Group (BIG).
+ * @param[in]	num_bigs	Number of BIGs to set up.
+ *
  * @return	0 for success, error otherwise.
  */
-int broadcast_source_enable(void);
+int broadcast_source_enable(struct broadcast_source_big const *const broadcast_param,
+			    uint8_t num_bigs);
 
 #endif /* _BROADCAST_SOURCE_H_ */

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/bt_le_audio_tx/bt_le_audio_tx.h
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/bt_le_audio_tx/bt_le_audio_tx.h
@@ -13,19 +13,19 @@
 #include "le_audio.h"
 
 /**
- * @brief Allocates buffers and sends data to the controller.
+ * @brief	Allocates buffers and sends data to the controller.
  *
  * @note	Send all available channels in a single call.
  *		Do not call this for each channel.
  *
- * @param bap_streams	Pointer to an array of BAP streams.
- * @param channel_mask	Pointer to an array of channel masks.
- * @param enc_audio	Encoded audio data.
- * @param streams_to_tx	Number of streams to send.
+ * @param	bap_streams		Pointer to an array of BAP streams.
+ * @param	audio_mapping_mask	Pointer to an array of channel masks.
+ * @param	enc_audio		Encoded audio data.
+ * @param	streams_to_tx		Number of streams to send.
  *
  * @return 0 if successful, error otherwise.
  */
-int bt_le_audio_tx_send(struct bt_bap_stream **bap_streams, uint8_t *channel_mask,
+int bt_le_audio_tx_send(struct bt_bap_stream **bap_streams, uint8_t *audio_mapping_mask,
 			struct le_audio_encoded_audio enc_audio, uint8_t streams_to_tx);
 
 /**

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.h
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.h
@@ -66,6 +66,12 @@ struct le_audio_encoded_audio {
 	uint8_t num_ch;
 };
 
+struct stream_index {
+	uint8_t level1_idx; /* BIG / CIG */
+	uint8_t level2_idx; /* Subgroups if applicable */
+	uint8_t level3_idx; /* BIS / CIS */
+};
+
 /**
  * @brief	Get the current state of an endpoint.
  *

--- a/applications/nrf5340_audio/unicast_server/main.c
+++ b/applications/nrf5340_audio/unicast_server/main.c
@@ -537,7 +537,7 @@ int main(void)
 	ret = ext_adv_populate(ext_adv_buf, ARRAY_SIZE(ext_adv_buf), &ext_adv_buf_cnt);
 	ERR_CHK(ret);
 
-	ret = bt_mgmt_adv_start(ext_adv_buf, ext_adv_buf_cnt, NULL, 0, true);
+	ret = bt_mgmt_adv_start(0, ext_adv_buf, ext_adv_buf_cnt, NULL, 0, true);
 	ERR_CHK(ret);
 
 	return 0;


### PR DESCRIPTION
- Allow user to input their own create_param
- Create helper function to produce create_param
- Alter the API of broadcast_source_enable to take in a struct.
- Struct will determine the number of subgroups, BISes and their info.
- OCT-3016