### PR TITLE
lib: at_host: use CRLF termination as default

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -767,6 +767,10 @@ DFU libraries
 Modem libraries
 ---------------
 
+* :ref:`lib_at_host`:
+
+   * Updated to set the default termination mode to the :kconfig:option:`CONFIG_CR_LF_TERMINATION` Kconfig option instead of the :kconfig:option:`CONFIG_CR_TERMINATION` Kconfig option.
+
 * :ref:`nrf_modem_lib_readme`:
 
   * Fixed an issue with the CFUN hooks when the Modem library is initialized during ``SYS_INIT`` at kernel level and makes calls to the :ref:`nrf_modem_at` interface before the application level initialization is done.

--- a/lib/at_host/Kconfig
+++ b/lib/at_host/Kconfig
@@ -21,7 +21,7 @@ config AT_HOST_UART_INIT_TIMEOUT
 
 choice
 	prompt "Termination Mode"
-	default CR_TERMINATION
+	default CR_LF_TERMINATION
 	depends on AT_HOST_LIBRARY
 	help
 		Sets the termination ending from the serial terminal


### PR DESCRIPTION
Use CRLF termination as default as that is the standard AT termination characters and also used by the Serial Terminal in nRF Connect for Desktop.