### PR TITLE
lib: nrf_modem: net_if: Kconfig changes and IPv4 only support

### DIFF
--- a/doc/nrf/libraries/modem/nrf_modem_lib/index.rst
+++ b/doc/nrf/libraries/modem/nrf_modem_lib/index.rst
@@ -11,11 +11,12 @@ The integration layer is constituted by the library wrapper and functionalities 
    :glob:
    :caption: Subpages:
 
-   nrf_modem_lib_wrapper.rst
-   nrf_modem_lib_socket_offloading.rst
-   nrf_modem_lib_os_abstraction.rst
-   nrf_modem_lib_pm_integration.rst
-   nrf_modem_lib_trace.rst
-   nrf_modem_lib_fault.rst
+   nrf_modem_lib_wrapper
+   nrf_modem_lib_socket_offloading
+   nrf_modem_lib_os_abstraction
+   nrf_modem_lib_pm_integration
+   nrf_modem_lib_lte_net_if
+   nrf_modem_lib_trace
+   nrf_modem_lib_fault
    nrf_modem_lib_diagnostic
-   nrf_modem_lib_api.rst
+   nrf_modem_lib_api

--- a/doc/nrf/libraries/modem/nrf_modem_lib/nrf_modem_lib_fault.rst
+++ b/doc/nrf/libraries/modem/nrf_modem_lib/nrf_modem_lib_fault.rst
@@ -16,6 +16,8 @@ The behavior of the :c:func:`nrf_modem_fault_handler` function is controlled wit
 * :kconfig:option:`CONFIG_NRF_MODEM_LIB_ON_FAULT_DO_NOTHING` - This option lets the fault handler log the Modem fault and return (default).
 * :kconfig:option:`CONFIG_NRF_MODEM_LIB_ON_FAULT_RESET_MODEM` - This option lets the fault handler schedule a workqueue task to reinitialize the modem and Modem library.
 * :kconfig:option:`CONFIG_NRF_MODEM_LIB_ON_FAULT_APPLICATION_SPECIFIC` - This option lets the fault handler function :c:func:`nrf_modem_fault_handler` be defined by the application, outside of the Modem library integration layer.
+* :kconfig:option:`CONFIG_NRF_MODEM_LIB_ON_FAULT_LTE_NET_IF` - This is the only option available when the :kconfig:option:`CONFIG_NRF_MODEM_LIB_NET_IF` Kconfig option is selected.
+  With this option, modem faults are signaled to the application as fatal network events (``NET_EVENT_CONN_IF_FATAL_ERROR``), to which the application subscribes by calling the :c:func:`net_mgmt_init_event_callback` function.
 
 Implementing a custom fault handler
 ***********************************

--- a/doc/nrf/libraries/modem/nrf_modem_lib/nrf_modem_lib_lte_net_if.rst
+++ b/doc/nrf/libraries/modem/nrf_modem_lib/nrf_modem_lib_lte_net_if.rst
@@ -1,0 +1,14 @@
+.. _nrf_modem_lib_lte_net_if:
+
+Network interface driver
+########################
+
+The LTE network interface in the :ref:`nrfxlib:nrf_modem` is a Zephyr network interface driver for the nRF91 Series cellular firmware.
+
+The driver is enabled using the :kconfig:option:`CONFIG_NRF_MODEM_LIB_NET_IF` Kconfig option.
+By enabling the LTE network interface in the :ref:`nrfxlib:nrf_modem`, you can control the nRF91 series modem as a Zephyr network interface, for example, :c:func:`net_if_up`, :c:func:`conn_mgr_if_connect`, and :c:func:`net_if_down`.
+
+.. note::
+
+   The LTE network interface supports both IPv4 and IPv6.
+   The support is enabled automatically for whichever IP stack version is enabled in Zephyr.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -850,16 +850,23 @@ Modem libraries
 
 * :ref:`nrf_modem_lib_readme`:
 
+  * Added:
 
-  * Added
-
-    * The Kconfig option  :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_UART_CHUNK_SZ` to process traces in chunks.
+    * The :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_UART_CHUNK_SZ` Kconfig option to process traces in chunks.
       This can improve the availability of trace memory, and thus reduce the chances of losing traces.
+    * The :kconfig:option:`CONFIG_NRF_MODEM_LIB_ON_FAULT_LTE_NET_IF` Kconfig option for sending modem faults to the :ref:`nrf_modem_lib_lte_net_if` when it is enabled.
     * The :kconfig:option:`CONFIG_NRF_MODEM_LIB_FAULT_THREAD_STACK_SIZE` Kconfig option to allow the application to set the modem fault thread stack size.
 
   * Deprecated the Kconfig option :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_UART_ZEPHYR`.
   * Fixed an issue with the CFUN hooks when the Modem library is initialized during ``SYS_INIT`` at kernel level and makes calls to the :ref:`nrf_modem_at` interface before the application level initialization is done.
   * Removed the deprecated options ``CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_UART_ASYNC`` and ``CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_UART_SYNC``.
+
+  * :ref:`nrf_modem_lib_lte_net_if`:
+
+    * Added the dependency to the :kconfig:option:`CONFIG_NET_CONNECTION_MANAGER` Kconfig option.
+    * Removed the requirement of IPv4 and IPv6 support for all applications.
+      IPv4 and IPv6 support can be enabled using the :kconfig:option:`CONFIG_NET_IPV4` and :kconfig:option:`CONFIG_NET_IPV6` Kconfig options, respectively.
+    * Increased the required stack size of the :kconfig:option:`NET_CONNECTION_MANAGER_MONITOR_STACK_SIZE` Kconfig option to ``1024``.
 
 * :ref:`lib_location` library:
 

--- a/lib/nrf_modem_lib/Kconfig.modemlib
+++ b/lib/nrf_modem_lib/Kconfig.modemlib
@@ -198,20 +198,30 @@ endif # NRF_MODEM_LIB_TRACE
 
 choice NRF_MODEM_LIB_ON_FAULT
 	prompt "Action on modem fault"
+	default NRF_MODEM_LIB_ON_FAULT_LTE_NET_IF if NRF_MODEM_LIB_NET_IF
 	default NRF_MODEM_LIB_ON_FAULT_DO_NOTHING
 
 config NRF_MODEM_LIB_ON_FAULT_DO_NOTHING
 	bool "Do nothing"
+	depends on !NRF_MODEM_LIB_NET_IF
 	help
 	  Let the fault handler log the fault and return.
 
 config NRF_MODEM_LIB_ON_FAULT_RESET_MODEM
 	bool "Reset modem"
+	depends on !NRF_MODEM_LIB_NET_IF
 	help
 	  Let the fault handler reset the modem.
 
 config NRF_MODEM_LIB_ON_FAULT_APPLICATION_SPECIFIC
 	bool "Application defined"
+	depends on !NRF_MODEM_LIB_NET_IF
+	help
+	  Let the application define the fault handler function.
+
+config NRF_MODEM_LIB_ON_FAULT_LTE_NET_IF
+	bool "Application defined"
+	depends on NRF_MODEM_LIB_NET_IF
 	help
 	  Let the application define the fault handler function.
 

--- a/lib/nrf_modem_lib/fault.c
+++ b/lib/nrf_modem_lib/fault.c
@@ -60,8 +60,12 @@ void nrf_modem_fault_handler(struct nrf_modem_fault_info *fault)
 	LOG_ERR("Modem has crashed, reason 0x%x, PC: 0x%x",
 		fault->reason, fault->program_counter);
 #endif
+
 #if CONFIG_NRF_MODEM_LIB_ON_FAULT_RESET_MODEM
 	k_sem_give(&fault_sem);
+#elif CONFIG_NRF_MODEM_LIB_ON_FAULT_LTE_NET_IF
+	extern void lte_net_if_modem_fault_handler(void);
+	lte_net_if_modem_fault_handler();
 #endif
 }
 #endif /* not CONFIG_NRF_MODEM_LIB_ON_FAULT_APPLICATION_SPECIFIC */

--- a/lib/nrf_modem_lib/lte_net_if/Kconfig
+++ b/lib/nrf_modem_lib/lte_net_if/Kconfig
@@ -8,10 +8,11 @@ menuconfig NRF_MODEM_LIB_NET_IF
 	select PDN
 	select PDN_ESM_STRERROR
 	select LTE_LINK_CONTROL
-	depends on NET_SOCKETS_OFFLOAD
+	depends on NRF_MODEM_LIB
+	depends on NET_CONNECTION_MANAGER
+	depends on NET_IPV4 || NET_IPV6
 	depends on !NET_IPV6_NBR_CACHE
 	depends on !NET_IPV6_MLD
-	depends on NRF_MODEM_LIB_ON_FAULT_APPLICATION_SPECIFIC
 	help
 	  Add support for controlling the nRF91 modem using Zephyr networking API.
 
@@ -71,6 +72,10 @@ config NRF_MODEM_LIB_NET_IF_DOWN_DEFAULT_LTE_DISCONNECT
 	help
 	 If this option is set, the LTE iface will disconnect LTE instead of shutting down the
 	 modem when being brought down.
+
+# LTE_NET_IF require a bigger stack than the default
+config NET_CONNECTION_MANAGER_MONITOR_STACK_SIZE
+	default 1024
 
 module = NRF_MODEM_LIB_NET_IF
 module-str = Modem network interface

--- a/lib/nrf_modem_lib/lte_net_if/lte_ip_addr_helper.c
+++ b/lib/nrf_modem_lib/lte_net_if/lte_ip_addr_helper.c
@@ -24,10 +24,14 @@ LOG_MODULE_REGISTER(ip_addr_helper, CONFIG_NRF_MODEM_LIB_NET_IF_LOG_LEVEL);
 
 /* Structure that keeps track of the current IP addresses in use. */
 static struct ip_addr_helper_data {
+#if CONFIG_NET_IPV4
 	struct in_addr ipv4_addr_current;
-	struct in6_addr ipv6_addr_current;
 	bool ipv4_added;
+#endif
+#if CONFIG_NET_IPV6
+	struct in6_addr ipv6_addr_current;
 	bool ipv6_added;
+#endif
 } ctx;
 
 /* @brief Function that obtains either the IPv4 or IPv6 address associated with
@@ -49,25 +53,54 @@ static int ip_addr_get(char *addr4, char *addr6)
 	int ret;
 	char tmp[sizeof(struct in6_addr)];
 	char addr1[NET_IPV6_ADDR_LEN] = { 0 };
+#if CONFIG_NET_IPV6
 	char addr2[NET_IPV6_ADDR_LEN] = { 0 };
+#endif
+
+	if ((!addr4 && !addr6) || (addr4 && addr6)) {
+		return -EINVAL;
+	}
+
+#if !CONFIG_NET_IPV4
+	if (addr4) {
+		LOG_ERR("IPv4 address requested when IPv4 is not enabled");
+		return -EINVAL;
+	}
+#endif /* !CONFIG_NET_IPV4 */
+
+#if !CONFIG_NET_IPV6
+	if (addr6) {
+		LOG_ERR("IPv6 address requested when IPv6 is not enabled");
+		return -EINVAL;
+	}
+#endif /* !CONFIG_NET_IPV6 */
+
 
 	/* Parse +CGPADDR: <cid>,<PDP_addr_1>,<PDP_addr_2>
 	 * PDN type "IP": PDP_addr_1 is <IPv4>, max 16(INET_ADDRSTRLEN), '.' and digits
 	 * PDN type "IPV6": PDP_addr_1 is <IPv6>, max 46(INET6_ADDRSTRLEN),':', digits, 'A'~'F'
 	 * PDN type "IPV4V6": <IPv4>,<IPv6> or <IPV4> or <IPv6>
 	 */
+#if CONFIG_NET_IPV6
 	ret = nrf_modem_at_scanf("AT+CGPADDR=0", "+CGPADDR: %*d,\"%46[.:0-9A-F]\",\"%46[:0-9A-F]\"",
 				 addr1, addr2);
+#else
+	ret = nrf_modem_at_scanf("AT+CGPADDR=0", "+CGPADDR: %*d,\"%46[.:0-9A-F]\"",
+				 addr1);
+#endif
 	if (ret <= 0) {
 		return -EFAULT;
 	}
 
+#if CONFIG_NET_IPV4
 	/* inet_pton() is used to check the type of returned address(es). */
 	if ((addr4 != NULL) && (zsock_inet_pton(AF_INET, addr1, tmp) == 1)) {
 		strcpy(addr4, addr1);
 		return strlen(addr4);
 	}
+#endif
 
+#if CONFIG_NET_IPV6
 	if ((addr6 != NULL) && (zsock_inet_pton(AF_INET6, addr1, tmp) == 1)) {
 		strcpy(addr6, addr1);
 		return strlen(addr6);
@@ -78,10 +111,12 @@ static int ip_addr_get(char *addr4, char *addr6)
 		strcpy(addr6, addr2);
 		return strlen(addr6);
 	}
+#endif
 
 	return -ENODATA;
 }
 
+#if CONFIG_NET_IPV4
 int lte_ipv4_addr_add(const struct net_if *iface)
 {
 	int len;
@@ -116,6 +151,28 @@ int lte_ipv4_addr_add(const struct net_if *iface)
 	return 0;
 }
 
+int lte_ipv4_addr_remove(const struct net_if *iface)
+{
+	if (iface == NULL) {
+		return -EINVAL;
+	}
+
+	if (!ctx.ipv4_added) {
+		LOG_DBG("No IPv4 address to remove");
+		return 0;
+	}
+
+	if (!net_if_ipv4_addr_rm((struct net_if *)iface, &ctx.ipv4_addr_current)) {
+		return -EFAULT;
+	}
+
+	ctx.ipv4_added = false;
+
+	return 0;
+}
+#endif
+
+#if CONFIG_NET_IPV6
 int lte_ipv6_addr_add(const struct net_if *iface)
 {
 	int len;
@@ -150,26 +207,6 @@ int lte_ipv6_addr_add(const struct net_if *iface)
 	return 0;
 }
 
-int lte_ipv4_addr_remove(const struct net_if *iface)
-{
-	if (iface == NULL) {
-		return -EINVAL;
-	}
-
-	if (!ctx.ipv4_added) {
-		LOG_DBG("No IPv4 address to remove");
-		return 0;
-	}
-
-	if (!net_if_ipv4_addr_rm((struct net_if *)iface, &ctx.ipv4_addr_current)) {
-		return -EFAULT;
-	}
-
-	ctx.ipv4_added = false;
-
-	return 0;
-}
-
 int lte_ipv6_addr_remove(const struct net_if *iface)
 {
 	if (iface == NULL) {
@@ -189,3 +226,4 @@ int lte_ipv6_addr_remove(const struct net_if *iface)
 
 	return 0;
 }
+#endif /* #if CONFIG_NET_IPV6 */


### PR DESCRIPTION
* Replace build asserts with Kconfig dependencies.
* Allow supporting IPv4 only, without IPv6. It is up to the application to make sure this is acceptable to their use. IPv6 is enabled by default.