### PR TITLE
doc: Support for PBKDF2 algorithms with TF-M

### DIFF
--- a/doc/nrf/libraries/security/nrf_security/doc/driver_config.rst
+++ b/doc/nrf/libraries/security/nrf_security/doc/driver_config.rst
@@ -229,8 +229,6 @@ To enable key derivation function (KDF) support, set one or more of the Kconfig 
 | TLS 1.2 EC J-PAKE to PMS | :kconfig:option:`CONFIG_PSA_WANT_ALG_TLS12_ECJPAKE_TO_PMS`    |
 +--------------------------+---------------------------------------------------------------+
 
-.. note::
-   PBKDF2 algorithms are not supported with TF-M.
 
 Key derivation function support
 ===============================

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -819,11 +819,6 @@ Bluetooth libraries and services
 
   * Added experimental support for a new cryptographical backend that relies on the PSA crypto APIs (:kconfig:option:`CONFIG_BT_FAST_PAIR_CRYPTO_PSA`).
 
-Bootloader libraries
---------------------
-
-|no_changes_yet_note|
-
 Debug libraries
 ---------------
 
@@ -1035,7 +1030,10 @@ zcbor
 Trusted Firmware-M
 ==================
 
-* Support PSA PAKE APIs from the PSA Crypto API specification 1.2.
+* Added:
+
+  * Support for PSA PAKE APIs from the PSA Crypto API specification 1.2.
+  * Support for PBKDF2 algorithms as of |NCS| v2.6.0.
 
 cJSON
 =====


### PR DESCRIPTION
PBKDF2 algorithms are supported with TF-M
Removed note in nrf_security lib stating the opposite Added an entry in changelog for TF-M