### PR TITLE
applications: serial_lte_modem: Add GNSS data to carrier library

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -225,6 +225,7 @@ Serial LTE modem
 
   * New behavior for when a connection is closed unexpectedly while SLM is in data mode.
     SLM now sends the :ref:`CONFIG_SLM_DATAMODE_TERMINATOR <CONFIG_SLM_DATAMODE_TERMINATOR>` string when this happens.
+  * Sending of GNSS data to carrier library when the library is enabled.
 
 * Removed:
 


### PR DESCRIPTION
When carrier library is enabled the GNSS data will be provided using the lwm2m_carrier_location_set() and lwm2m_carrier_velocity_set() API.