### PR TITLE
manifest: sdk-hostap: Pull fix for time

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -114,7 +114,7 @@ manifest:
     - name: hostap
       repo-path: sdk-hostap
       path: modules/lib/hostap
-      revision: 3ac5008029de16f83d585d2735768ada53c5b05e
+      revision: c947dc6e4a0f5ef24a84922112ad2c0fac4b0864
       userdata:
         ncs:
           upstream-url: https://w1.fi/cgit/hostap/


### PR DESCRIPTION
Fixes data type for time.

Fixes SHEL-2731.