### PR TITLE
applications: serial_lte_modem: check for uninitialized send callback

### DIFF
--- a/applications/serial_lte_modem/src/slm_at_host.c
+++ b/applications/serial_lte_modem/src/slm_at_host.c
@@ -484,6 +484,9 @@ static int slm_at_send_indicate(const uint8_t *data, size_t len,
 	if (k_is_in_isr()) {
 		LOG_ERR("FIXME: Attempt to send AT response (of size %u) in ISR.", len);
 		return -EINTR;
+	} else if (at_backend.send == NULL) {
+		LOG_ERR("Attempt to send via an uninitialized AT backend");
+		return -EFAULT;
 	}
 
 	if (indicate) {


### PR DESCRIPTION
Calling slm_at_send_indicate() before the AT backend is initialized will dereference a NULL pointer, which may happen as several modules can dispatch custom notifications at any point.