### PR TITLE
doc: Remove infocenter mentions

### DIFF
--- a/applications/nrf5340_audio/doc/requirements.rst
+++ b/applications/nrf5340_audio/doc/requirements.rst
@@ -40,7 +40,7 @@ nRF5340 Audio development kit
 *****************************
 
 The nRF5340 Audio development kit is a hardware development platform that demonstrates the nRF5340 Audio applications.
-Read the `nRF5340 Audio DK Hardware`_ documentation on Nordic Semiconductor Infocenter for more information about this development kit.
+Read the `nRF5340 Audio DK Hardware`_ documentation for more information about this development kit.
 
 You can :ref:`test the DK out of the box <nrf53_audio_app_dk_testing_out_of_the_box>` before you program it.
 

--- a/doc/nrf/libraries/others/emds.rst
+++ b/doc/nrf/libraries/others/emds.rst
@@ -35,7 +35,9 @@ If the remaining empty flash area is smaller than the required data size, the fl
 
 The storage is done in deterministic time, so it is possible to know how long it takes to store all registered entries.
 However, this is chip-dependent, so it is important to measure the time.
-The `Nordic Semiconductor Infocenter`_ contains chip information and datasheet, and timing values can be found under the "Electrical specification" for the Non-volatile memory controller.
+Find timing values under the "Electrical specification" section for the non-volatile memory controller in the Product Specification for the relevant SoC or the SiP you are using.
+For example, for the nRF9160 SiP, see the `Electrical specification of nRF9160`_ page.
+
 The following Kconfig options can be configured:
 
 * :kconfig:option:`CONFIG_EMDS_FLASH_TIME_WRITE_ONE_WORD_US`

--- a/doc/nrf/protocols/bt/bt_qualification/index.rst
+++ b/doc/nrf/protocols/bt/bt_qualification/index.rst
@@ -90,11 +90,9 @@ Switching to another SDK version
 
 If you want to switch to another |NCS| version for an existing product, complete the following steps:
 
-1. Go to the `Nordic Semiconductor Infocenter`_ and search for the SoC or SiP model you use.
+1. Go to the Compatibility Matrix relevant for the SoC or SiP model you use.
 
-#. Navigate to the relevant Compatibility Matrix directory.
-
-#. Open the Bluetooth QDIDs article and, based on the table, confirm the following:
+#. Open the Bluetooth QDIDs section and, based on the table, confirm the following:
 
    * The version you want to use must be compatible with versions of other Subsystems you want to keep for your product.
    * Relevant Host and SoftDevice Controller Subsystems implemented in the |NCS| version you want to use must be pre-qualified.

--- a/doc/nrf/protocols/thread/certification.rst
+++ b/doc/nrf/protocols/thread/certification.rst
@@ -19,8 +19,7 @@ Thread certification options
 
 The :ref:`nrfxlib:ot_libs`, which are available in the :ref:`nrfxlib:nrfxlib` repository, are certified by Thread Group for various Nordic Semiconductor devices.
 
-You can find the certification information for the chip that you are using in the `Nordic Semiconductor Infocenter`_.
-Navigate to the compatibility matrix for your chip and select *Thread CIDs*.
+You can find the certification information for the SoC or the SiP you are using in the relevant Compatibility Matrix's "Thread CIDs" section.
 
 Depending on your development approach, you have several certification options when using Nordic Semiconductor devices.
 

--- a/doc/nrf/test_and_optimize/optimizing/power_general.rst
+++ b/doc/nrf/test_and_optimize/optimizing/power_general.rst
@@ -85,7 +85,7 @@ Peripherals other than the serial ports can also cause elevated currents.
 The power management of the Nordic SoCs automatically switches in and out the resources that are needed by the active peripherals.
 Peripherals that need a high frequency clock like UART, PWM, PDM or high frequency timers will show similar currents if enabled.
 
-You can check the current consumption in peripherals for the SoC you are using in the "Power and clock management" section of the Product Specification for your SoC on `Nordic Semiconductor Infocenter`_.
+You can check the current consumption in peripherals for the SoC or the SiP you are using in the relevant Product Specification's "Power and clock management" section.
 For example, for the nRF9160 SiP, see the `Electrical specification of nRF9160`_ page.
 
 .. note::


### PR DESCRIPTION
Several places Infocenter is mentioned as the source of documentation for e.g. product specification and comp matrices.
Rewriting to remove its mentions.