### PR TITLE
boards: nrf53: config EXTDOMAIN in soc to reduce code duplication

### DIFF
--- a/boards/nordic/nrf7002dk/nrf5340_cpunet_nrf7001_reset.c
+++ b/boards/nordic/nrf7002dk/nrf5340_cpunet_nrf7001_reset.c
@@ -24,13 +24,6 @@ static void remoteproc_mgr_config(void)
 	/* Route Bluetooth Controller Debug Pins */
 	DEBUG_SETUP();
 #endif /* !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) || defined(CONFIG_BUILD_WITH_TFM) */
-
-#if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
-	/* Retain nRF5340 Network MCU in Secure domain (bus
-	 * accesses by Network MCU will have Secure attribute set).
-	 */
-	NRF_SPU->EXTDOMAIN[0].PERM = BIT(4);
-#endif /* !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) */
 }
 
 static int remoteproc_mgr_boot(void)

--- a/boards/nordic/nrf7002dk/nrf5340_cpunet_reset.c
+++ b/boards/nordic/nrf7002dk/nrf5340_cpunet_reset.c
@@ -24,13 +24,6 @@ static void remoteproc_mgr_config(void)
 	/* Route Bluetooth Controller Debug Pins */
 	DEBUG_SETUP();
 #endif /* !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) || defined(CONFIG_BUILD_WITH_TFM) */
-
-#if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
-	/* Retain nRF5340 Network MCU in Secure domain (bus
-	 * accesses by Network MCU will have Secure attribute set).
-	 */
-	NRF_SPU->EXTDOMAIN[0].PERM = BIT(4);
-#endif /* !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) */
 }
 
 static int remoteproc_mgr_boot(void)

--- a/boards/nordic/thingy91x/nrf5340_cpunet_reset.c
+++ b/boards/nordic/thingy91x/nrf5340_cpunet_reset.c
@@ -24,13 +24,6 @@ static void remoteproc_mgr_config(void)
 	/* Route Bluetooth Controller Debug Pins */
 	DEBUG_SETUP();
 #endif /* !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) || defined(CONFIG_BUILD_WITH_TFM) */
-
-#if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
-	/* Retain nRF5340 Network MCU in Secure domain (bus
-	 * accesses by Network MCU will have Secure attribute set).
-	 */
-	NRF_SPU->EXTDOMAIN[0].PERM = BIT(4);
-#endif /* !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) */
 }
 
 static int remoteproc_mgr_boot(void)

--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: a1769aba631b078769d182eaaea13aafc09039bc
+      revision: pull/1749/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Configure the "cpunet" to be secure from the soc system initialization to avoid code duplication across all the boards.

cpunet is now configured to be secure earlier in the boot process, from POST_KERNEL to PRE_KERNEL, but AFAIK this is not a problem.