### PR TITLE
net: lib: nrf_cloud: fix non-coap logging build

### DIFF
--- a/subsys/net/lib/nrf_cloud/coap/include/nrf_cloud_coap_transport.h
+++ b/subsys/net/lib/nrf_cloud/coap/include/nrf_cloud_coap_transport.h
@@ -30,6 +30,8 @@ extern "C" {
 enum coap_content_format {
 	dummy
 };
+struct coap_client {};
+struct coap_client_option {};
 #endif
 
 struct nrf_cloud_coap_client {


### PR DESCRIPTION
Fix non-CoAP builds with NRF_CLOUD_LOG_BACKEND enabled.