### PR TITLE
lib: nrf_modem: wait for coredump before shutting down modem

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -847,8 +847,12 @@ Modem libraries
     * The :kconfig:option:`CONFIG_NRF_MODEM_LIB_ON_FAULT_LTE_NET_IF` Kconfig option for sending modem faults to the :ref:`nrf_modem_lib_lte_net_if` when it is enabled.
     * The :kconfig:option:`CONFIG_NRF_MODEM_LIB_FAULT_THREAD_STACK_SIZE` Kconfig option to allow the application to set the modem fault thread stack size.
 
+  * Fixed:
+
+    * An issue with the CFUN hooks when the Modem library is initialized during ``SYS_INIT`` at kernel level and makes calls to the :ref:`nrf_modem_at` interface before the application level initialization is done.
+    * A potential issue where the Modem library would not wait for the modem to complete the coredump before shutting it down after a modem fault.
+
   * Deprecated the Kconfig option :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_UART_ZEPHYR`.
-  * Fixed an issue with the CFUN hooks when the Modem library is initialized during ``SYS_INIT`` at kernel level and makes calls to the :ref:`nrf_modem_at` interface before the application level initialization is done.
   * Removed the deprecated options ``CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_UART_ASYNC`` and ``CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_UART_SYNC``.
 
   * :ref:`nrf_modem_lib_lte_net_if`:

--- a/lib/nrf_modem_lib/nrf_modem_lib_trace.c
+++ b/lib/nrf_modem_lib/nrf_modem_lib_trace.c
@@ -299,7 +299,10 @@ trace_reset:
 			LOG_INF("Modem was turned off, no more traces");
 			goto deinit;
 		case -NRF_ENODATA:
-			LOG_INF("No more trace data");
+			LOG_INF("Coredump complete, no more traces");
+			goto deinit;
+		case -NRF_ENOTSUP:
+			LOG_INF("Tracing not supported");
 			goto deinit;
 		case -NRF_EINPROGRESS:
 			__ASSERT(0, "Error in transport backend");


### PR DESCRIPTION
Wait for the modem coredump to complete before shutting down the modem. This is required if the modem fault is receivedbefore the coredump is complete.