### PR TITLE
cracen: Fix for EC J-PAKE to PMS KDF

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_primitives.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_primitives.h
@@ -112,6 +112,10 @@ enum cracen_kd_state {
 	/* TLS12 PSK TO MS states: */
 	CRACEN_KD_STATE_TLS12_PSK_TO_MS_INIT = 0x100,
 	CRACEN_KD_STATE_TLS12_PSK_TO_MS_OUTPUT,
+
+	/* TLS12 EC J-PAKE to PMS state: */
+	CRACEN_KD_STATE_TLS12_ECJPAKE_TO_PMS_INIT = 0x200,
+	CRACEN_KD_STATE_TLS12_ECJPAKE_TO_PMS_OUTPUT
 };
 
 /* States to keep track of when the AEAD sxsymcrypt context has been initialized with xxx_create and

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/key_derivation.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/key_derivation.c
@@ -263,6 +263,8 @@ psa_status_t cracen_key_derivation_setup(cracen_key_derivation_operation_t *oper
 
 	if (IS_ENABLED(PSA_NEED_CRACEN_TLS12_ECJPAKE_TO_PMS)) {
 		if (operation->alg == PSA_ALG_TLS12_ECJPAKE_TO_PMS) {
+			operation->capacity = PSA_TLS12_ECJPAKE_TO_PMS_DATA_SIZE;
+			operation->state = CRACEN_KD_STATE_TLS12_ECJPAKE_TO_PMS_INIT;
 			return PSA_SUCCESS;
 		}
 	}
@@ -617,6 +619,10 @@ psa_status_t cracen_key_derivation_input_bytes(cracen_key_derivation_operation_t
 
 	if (IS_ENABLED(PSA_NEED_CRACEN_TLS12_ECJPAKE_TO_PMS) &&
 	    operation->alg == PSA_ALG_TLS12_ECJPAKE_TO_PMS) {
+		if (operation->state != CRACEN_KD_STATE_TLS12_ECJPAKE_TO_PMS_INIT) {
+			return PSA_ERROR_BAD_STATE;
+		}
+		operation->state = CRACEN_KD_STATE_TLS12_ECJPAKE_TO_PMS_OUTPUT;
 		if (data_length != 65 || data[0] != 0x04) {
 			return PSA_ERROR_INVALID_ARGUMENT;
 		}


### PR DESCRIPTION
Add states for PSA_ALG_TLS12_ECJPAKE_TO_PMS so
functions like set_capacity works as expected.