### PR TITLE
GHA: zoomin documentation publish

### DIFF
--- a/.github/workflows/docpublish.yml
+++ b/.github/workflows/docpublish.yml
@@ -46,18 +46,18 @@ jobs:
 
           # trust server
           mkdir -p ~/.ssh
-          ssh-keyscan upload-v1.zoominsoftware.io >> ~/.ssh/known_hosts
+          ssh-keyscan ${{ vars.NCS_ZOOMIN_SERVER }} >> ~/.ssh/known_hosts
 
           # prepare key
-          echo "${{ secrets.NCS_ZOOMIN_KEY }}" | base64 -d > zoomin_key
+          echo "${{ secrets.NCS_ZOOMIN_KEY }}" > zoomin_key
           chmod 600 zoomin_key
 
           # upload files
           for file in docs/*.zip; do
-            sftp -v -i zoomin_key nordic@upload-v1.zoominsoftware.io <<EOF
-            cd docs-be.nordicsemi.com/sphinx-html/incoming
+          sftp -v -i zoomin_key ${{vars.NCS_ZOOMIN_USER}}@${{ vars.NCS_ZOOMIN_SERVER }} <<EOF
+            cd ${{ vars.NCS_ZOOMIN_DEPLOY_PROD_PATH}}
             put ${file}
-            cd ../../../nordic-be-dev.zoominsoftware.io/sphinx-html/incoming
+            cd ${{ vars.NCS_ZOOMIN_DEPLOY_DEV_PATH}}
             put ${file}
             quit
           EOF


### PR DESCRIPTION
Extract common connection parameters to GitHub variables use secret from the organization

NOTE:
Please move variables created in repository for this change to organization and remove the NCS_ZOOMIN_KEY to use the one from organization.

NOTE2:
The variables are now part of the organization, They were tested on Sidewalk, and work as expected.

The NCS_ZOOMIN_KEY from organization has been tested on Sidewalk repository -- see example run: https://github.com/nrfconnect/sdk-sidewalk/actions/runs/9284202801 and its workflow file for comparison https://github.com/nrfconnect/sdk-sidewalk/actions/runs/9284202801/workflow