### PR TITLE
applications: connectivity_bridge: Enable BLE on thingy91x

### DIFF
--- a/applications/connectivity_bridge/boards/thingy91x_nrf5340_cpuapp.overlay
+++ b/applications/connectivity_bridge/boards/thingy91x_nrf5340_cpuapp.overlay
@@ -11,7 +11,6 @@
 		status = "okay";
 		clk-gpios = <&gpio0 25 GPIO_ACTIVE_HIGH>;
 		dio-gpios = <&gpio0 27 GPIO_ACTIVE_HIGH>;
-		noe-gpios = <&gpio0 18 GPIO_ACTIVE_HIGH>;
 		reset-gpios = <&gpio1 7 GPIO_ACTIVE_HIGH>;
 		port-write-cycles = <2>;
 	};

--- a/applications/connectivity_bridge/sample.yaml
+++ b/applications/connectivity_bridge/sample.yaml
@@ -10,4 +10,5 @@ tests:
       - thingy91x/nrf5340/cpuapp
     integration_platforms:
       - thingy91/nrf52840
+      - thingy91x/nrf5340/cpuapp
     tags: ci_build sysbuild

--- a/boards/nordic/thingy91x/thingy91x_nrf5340_cpuapp_common.dts
+++ b/boards/nordic/thingy91x/thingy91x_nrf5340_cpuapp_common.dts
@@ -44,6 +44,7 @@
 
 	zephyr,user {
 		button1-gpios = <&gpio1 15 (GPIO_PULL_UP | GPIO_OPEN_DRAIN)>;
+		short-range-rf-fe-enable-gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
 	};
 
 	/* These aliases are provided for compatibility with samples */

--- a/doc/nrf/includes/sample_board_rows.txt
+++ b/doc/nrf/includes/sample_board_rows.txt
@@ -92,6 +92,10 @@
 
 | :ref:`Thingy:91 <ug_thingy91>` | PCA20035 | thingy91 | ``thingy91/nrf9160/ns`` |
 
+.. thingy91x_nrf5340_cpuapp
+
+| Thingy:91 x | PCA20065 | thingy91x | ``thingy91x/nrf5340/cpuapp`` |
+
 .. nrf52dk_nrf52810
 
 | :ref:`nRF52 DK (emulating nRF52810) <ug_nrf52>` | PCA10040 | :ref:`nrf52dk <nrf52dk_nrf52810>` | ``nrf52dk/nrf52810`` |

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -226,6 +226,11 @@ Serial LTE modem
 
   * AT command parsing to utilize the :ref:`at_cmd_custom_readme` library.
 
+Connectivity Bridge
+-------------------
+
+* Updated to make the Bluetooth LE feature work for Thingy:91 X by using the load switch.
+
 nRF5340 Audio
 -------------
 


### PR DESCRIPTION
For enabling BLE on the thingy91x, the short range RF Front end module needs to be enabled. This patch enables it when BLE is needed and disables it otherwise. It does so only for the boards that have the short range rf froend end module in device tree. The zephyr,user node is used for this purpose.