### PR TITLE
suit: build recovery image from main application

### DIFF
--- a/cmake/sysbuild/suit.cmake
+++ b/cmake/sysbuild/suit.cmake
@@ -134,6 +134,10 @@ function(suit_register_post_build_commands)
     list(APPEND dependencies "${BINARY_DIR}/zephyr/${BINARY_FILE}.bin")
   endforeach()
 
+  if (SB_CONFIG_SUIT_BUILD_RECOVERY)
+    list(APPEND dependencies recovery)
+  endif()
+
   add_custom_target(
     create_suit_artifacts
     ALL
@@ -318,6 +322,16 @@ function(suit_setup_merge)
       list(APPEND ARTIFACTS_TO_MERGE ${IMAGE_BINARY_DIR}/zephyr/uicr.hex)
     endif()
 
+    if(SB_CONFIG_SUIT_BUILD_RECOVERY)
+      get_property(
+        recovery_artifacts
+        GLOBAL PROPERTY
+        SUIT_RECOVERY_ARTIFACTS_TO_MERGE_${IMAGE_TARGET_NAME}
+      )
+
+      list(APPEND ARTIFACTS_TO_MERGE ${recovery_artifacts})
+    endif()
+
     set_property(
       GLOBAL APPEND PROPERTY SUIT_POST_BUILD_COMMANDS
       COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/mergehex.py
@@ -331,6 +345,61 @@ function(suit_setup_merge)
     )
   endforeach()
 endfunction()
+
+# Build recovery image.
+#
+# Usage:
+#   suit_build_recovery()
+#
+function(suit_build_recovery)
+  include(ExternalProject)
+
+  set(sysbuild_root_path "${ZEPHYR_NRF_MODULE_DIR}/../zephyr/share/sysbuild")
+  set(board_target "${SB_CONFIG_BOARD}/${target_soc}/cpuapp")
+
+  # Get class and vendor ID-s to pass to recovery application
+  sysbuild_get(APP_RECOVERY_VENDOR_NAME IMAGE ${DEFAULT_IMAGE} VAR CONFIG_SUIT_MPI_APP_RECOVERY_VENDOR_NAME KCONFIG)
+  sysbuild_get(APP_RECOVERY_CLASS_NAME IMAGE ${DEFAULT_IMAGE} VAR CONFIG_SUIT_MPI_APP_RECOVERY_CLASS_NAME KCONFIG)
+  sysbuild_get(RAD_RECOVERY_VENDOR_NAME IMAGE ${DEFAULT_IMAGE} VAR CONFIG_SUIT_MPI_RAD_RECOVERY_VENDOR_NAME KCONFIG)
+  sysbuild_get(RAD_RECOVERY_CLASS_NAME IMAGE ${DEFAULT_IMAGE} VAR CONFIG_SUIT_MPI_RAD_RECOVERY_CLASS_NAME KCONFIG)
+
+  ExternalProject_Add(
+    recovery
+    SOURCE_DIR ${sysbuild_root_path}
+    PREFIX ${CMAKE_BINARY_DIR}/recovery
+    INSTALL_COMMAND ""
+    CMAKE_CACHE_ARGS
+      "-DAPP_DIR:PATH=${ZEPHYR_NRF_MODULE_DIR}/samples/suit/recovery"
+      "-DBOARD:STRING=${board_target}"
+      "-DEXTRA_DTC_OVERLAY_FILE:STRING=${APP_DIR}/sysbuild/recovery.overlay"
+      "-Dhci_ipc_EXTRA_DTC_OVERLAY_FILE:STRING=${APP_DIR}/sysbuild/recovery_hci_ipc.overlay"
+      "-DSB_CONFIG_SUIT_ENVELOPE_ROOT_TEMPLATE:STRING=\\\"${ZEPHYR_NRF_MODULE_DIR}/samples/suit/recovery/app_recovery_envelope.yaml.jinja2\\\""
+      "-Dhci_ipc_CONFIG_SUIT_ENVELOPE_TEMPLATE:STRING=\\\"${ZEPHYR_NRF_MODULE_DIR}/samples/suit/recovery/rad_recovery_envelope.yaml.jinja2\\\""
+      "-DCONFIG_SUIT_MPI_APP_RECOVERY_VENDOR_NAME:STRING=\\\"${APP_RECOVERY_VENDOR_NAME}\\\""
+      "-DCONFIG_SUIT_MPI_APP_RECOVERY_CLASS_NAME:STRING=\\\"${APP_RECOVERY_CLASS_NAME}\\\""
+      "-DCONFIG_SUIT_MPI_RAD_RECOVERY_VENDOR_NAME:STRING=\\\"${RAD_RECOVERY_VENDOR_NAME}\\\""
+      "-DCONFIG_SUIT_MPI_RAD_RECOVERY_CLASS_NAME:STRING=\\\"${RAD_RECOVERY_CLASS_NAME}\\\""
+    BUILD_ALWAYS True
+)
+  ExternalProject_Get_property(recovery BINARY_DIR)
+
+  set_property(
+    GLOBAL APPEND PROPERTY SUIT_RECOVERY_ARTIFACTS_TO_MERGE_application
+    ${BINARY_DIR}/recovery/zephyr/suit_installed_envelopes_application_merged.hex)
+  set_property(
+    GLOBAL APPEND PROPERTY SUIT_RECOVERY_ARTIFACTS_TO_MERGE_application ${BINARY_DIR}/recovery/zephyr/zephyr.hex)
+
+  set_property(
+    GLOBAL APPEND PROPERTY SUIT_RECOVERY_ARTIFACTS_TO_MERGE_radio
+    ${BINARY_DIR}/recovery/zephyr/suit_installed_envelopes_radio_merged.hex)
+  set_property(
+    GLOBAL APPEND PROPERTY SUIT_RECOVERY_ARTIFACTS_TO_MERGE_radio ${BINARY_DIR}/hci_ipc/zephyr/zephyr.hex)
+
+endfunction()
+
+if(SB_CONFIG_SUIT_BUILD_RECOVERY)
+  suit_build_recovery()
+endif()
 
 if(SB_CONFIG_SUIT_ENVELOPE)
   suit_create_package()

--- a/samples/suit/recovery/Kconfig
+++ b/samples/suit/recovery/Kconfig
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config SUIT_MPI_APP_RECOVERY_VENDOR_NAME
+	string "Vendor name to generate vendor UUID"
+	default "nordicsemi.com"
+
+config SUIT_MPI_APP_RECOVERY_CLASS_NAME
+	string "Vendor name to generate class UUID"
+	default "nRF54H20_app_recovery"
+
+config SUIT_MPI_RAD_RECOVERY_VENDOR_NAME
+	string "Vendor name to generate vendor UUID"
+	default "nordicsemi.com"
+
+config SUIT_MPI_RAD_RECOVERY_CLASS_NAME
+	string "Vendor name to generate class UUID"
+	default "nRF54H20_rad_recovery"
+
+source "Kconfig.zephyr"

--- a/samples/suit/recovery/app_recovery_envelope.yaml.jinja2
+++ b/samples/suit/recovery/app_recovery_envelope.yaml.jinja2
@@ -2,9 +2,9 @@
 {%- set component_list = [] %}
 {%- set dependencies_list = [] %}
 {%- set mpi_app_recovery_vendor_name = application['config']['CONFIG_SUIT_MPI_APP_RECOVERY_VENDOR_NAME']|default('nordicsemi.com') %}
-{%- set mpi_app_recovery_class_name = application['config']['CONFIG_SUIT_MPI_APP_RECOVERY_CLASS_NAME']|default('nRF54H20_sample_app_recovery') %}
+{%- set mpi_app_recovery_class_name = application['config']['CONFIG_SUIT_MPI_APP_RECOVERY_CLASS_NAME']|default('nRF54H20_app_recovery') %}
 {%- set mpi_rad_recovery_vendor_name = application['config']['CONFIG_SUIT_MPI_RAD_RECOVERY_VENDOR_NAME']|default('nordicsemi.com') %}
-{%- set mpi_rad_recovery_class_name = application['config']['CONFIG_SUIT_MPI_RAD_RECOVERY_CLASS_NAME']|default('nRF54H20_sample_rad_recovery') %}
+{%- set mpi_rad_recovery_class_name = application['config']['CONFIG_SUIT_MPI_RAD_RECOVERY_CLASS_NAME']|default('nRF54H20_rad_recovery') %}
 {%- set sequence_number = sysbuild['config']['SB_CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM'] %}
 SUIT_Envelope_Tagged:
   suit-authentication-wrapper:

--- a/samples/suit/smp_transfer/sample.yaml
+++ b/samples/suit/smp_transfer/sample.yaml
@@ -76,3 +76,21 @@ tests:
       - FILE_SUFFIX=extflash
       - SB_CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM=2
     tags: suit
+
+  subsys.suit.smp_transfer.recovery.v1:
+    extra_args:
+      - FILE_SUFFIX=bt
+      - SB_CONFIG_SUIT_BUILD_RECOVERY=y
+    extra_configs:
+      - CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM=1
+      - CONFIG_SUIT_DFU_CANDIDATE_PROCESSING_FULL=y
+    tags: suit bluetooth
+
+  subsys.suit.smp_transfer.recovery.v2:
+    extra_args:
+      - FILE_SUFFIX=bt
+      - SB_CONFIG_SUIT_BUILD_RECOVERY=y
+    extra_configs:
+      - CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM=2
+      - CONFIG_SUIT_DFU_CANDIDATE_PROCESSING_FULL=y
+    tags: suit bluetooth

--- a/subsys/suit/provisioning/soc/Kconfig.nrf54h20
+++ b/subsys/suit/provisioning/soc/Kconfig.nrf54h20
@@ -39,7 +39,7 @@ rsource "Kconfig.template.manifest_config"
 endmenu
 
 manifest=APP_RECOVERY
-manifest-class=nRF54H20_sample_app_recovery
+manifest-class=nRF54H20_app_recovery
 manifest-downgrade-prevention-enabled=n
 manifest-independent-updates=y
 manifest-signature-check=DISABLED
@@ -105,7 +105,7 @@ config SUIT_MPI_APP_AREA_SIZE
 	  Size of the application domain MPI configurations
 
 manifest=RAD_RECOVERY
-manifest-class=nRF54H20_sample_rad_recovery
+manifest-class=nRF54H20_rad_recovery
 manifest-downgrade-prevention-enabled=n
 manifest-independent-updates=n
 manifest-signature-check=DISABLED

--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -401,6 +401,11 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
   else()
     set_config_bool(${DEFAULT_IMAGE} CONFIG_CHIP n)
   endif()
+
+  if(SB_CONFIG_SUIT_BUILD_RECOVERY)
+    set_config_bool(${DEFAULT_IMAGE} CONFIG_SUIT_MPI_APP_RECOVERY y)
+    set_config_bool(${DEFAULT_IMAGE} CONFIG_SUIT_MPI_RAD_RECOVERY y)
+  endif()
 endfunction(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
 
 # Sysbuild function hooks used by nRF Connect SDK

--- a/sysbuild/Kconfig.suit
+++ b/sysbuild/Kconfig.suit
@@ -69,6 +69,13 @@ config SUIT_ENVELOPE_NORDIC_TOP_DIRECTORY
 
 endif # SUIT_ENVELOPE
 
+config SUIT_BUILD_RECOVERY
+	bool "Build SUIT recovery firmware"
+	depends on NETCORE_HCI_IPC
+	help
+	  Build the recovery firmware, which allows to recover the main application
+	  if the image on the board was damaged.
+
 config SUIT_BUILD_FLASH_COMPANION
 	bool "Build SUIT flash companion firmware"
 	help


### PR DESCRIPTION
This PR allows to build the recovery image as a child image of a main application by using the SB_CONFIG_SUIT_BUILD_RECOVERY option.