### PR TITLE
samples: bluetooth: fast_pair: align sample name with new doc location

### DIFF
--- a/doc/nrf/samples.rst
+++ b/doc/nrf/samples.rst
@@ -28,6 +28,7 @@ If you want to list samples available for one or more specific boards, `use the 
 
    samples/amazon_sidewalk
    samples/bl
+   samples/fast_pair
    samples/mesh
    samples/cellular
    samples/crypto
@@ -35,7 +36,6 @@ If you want to list samples available for one or more specific boards, `use the 
    samples/dect
    samples/edge
    samples/esb
-   samples/fast_pair
    samples/gazell
    samples/keys
    samples/matter

--- a/doc/nrf/samples/fast_pair.rst
+++ b/doc/nrf/samples/fast_pair.rst
@@ -1,7 +1,7 @@
-.. _fast_pair_samples:
+.. _bt_fast_pair_samples:
 
-Fast Pair samples
-#################
+Bluetooth Fast Pair samples
+###########################
 
 .. toctree::
    :maxdepth: 1

--- a/samples/bluetooth/fast_pair/input_device/README.rst
+++ b/samples/bluetooth/fast_pair/input_device/README.rst
@@ -1,13 +1,13 @@
 .. _fast_pair_input_device:
 
-Bluetooth: Fast Pair input device
+Bluetooth Fast Pair: Input device
 #################################
 
 .. contents::
    :local:
    :depth: 2
 
-The Fast Pair input device sample demonstrates :ref:`how to use Google Fast Pair with the nRF Connect SDK <ug_bt_fast_pair>`.
+This sample demonstrates :ref:`how to use Google Fast Pair with the nRF Connect SDK <ug_bt_fast_pair>`.
 
 Google Fast Pair Service (GFPS) is a standard for pairing Bluetooth® and Bluetooth LE devices with as little user interaction required as possible.
 Google also provides additional features built upon the Fast Pair standard.

--- a/samples/bluetooth/fast_pair/locator_tag/README.rst
+++ b/samples/bluetooth/fast_pair/locator_tag/README.rst
@@ -1,13 +1,13 @@
 .. _fast_pair_locator_tag:
 
-Bluetooth: Fast Pair locator tag
+Bluetooth Fast Pair: Locator tag
 ################################
 
 .. contents::
    :local:
    :depth: 2
 
-The Fast Pair locator tag demonstrates :ref:`how to use Google Fast Pair with the nRF Connect SDK <ug_bt_fast_pair>` to create a locator tag device that is compatible with the Android `Find My Device app`_.
+This sample demonstrates :ref:`how to use Google Fast Pair with the nRF Connect SDK <ug_bt_fast_pair>` to create a locator tag device that is compatible with the Android `Find My Device app`_.
 Locator tag is a small electronic device that can be attached to an object or a person, and is designed to help locate them in case they are missing.
 
 Google Fast Pair Service (GFPS) is a standard for pairing Bluetooth® and Bluetooth LE devices with as little user interaction required as possible.


### PR DESCRIPTION
Aligned names of Fast Pair samples with their new documentation location.