### PR TITLE
tfm: 54l: Stop encrypting ITS by default

### DIFF
--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -200,7 +200,6 @@ config TFM_ITS_STACK_SIZE
 config TFM_ITS_ENCRYPTED
 	bool
 	prompt "PSA Internal Trusted Storage with encryption"
-	default y if SOC_SERIES_NRF54LX
 	select PSA_ITS_ENCRYPTED
 	help
 	  Enables authenticated encryption for PSA Internal Trusted Storage files


### PR DESCRIPTION
Encryption of ITS on 54L is broken so we stop enabling it by default.

Allowing ITS to be used on 54L while we debug encryption of ITS.