### PR TITLE
applications: nrf5340_audio: Implement parts of CSIP

### DIFF
--- a/applications/nrf5340_audio/include/nrf5340_audio_common.h
+++ b/applications/nrf5340_audio/include/nrf5340_audio_common.h
@@ -30,6 +30,7 @@ enum le_audio_evt_type {
 	LE_AUDIO_EVT_NOT_STREAMING,
 	LE_AUDIO_EVT_SYNC_LOST,
 	LE_AUDIO_EVT_NO_VALID_CFG,
+	LE_AUDIO_EVT_COORD_SET_DISCOVERED,
 };
 
 struct le_audio_msg {
@@ -37,6 +38,8 @@ struct le_audio_msg {
 	struct bt_conn *conn;
 	struct bt_le_per_adv_sync *pa_sync;
 	enum bt_audio_dir dir;
+	uint8_t set_size;
+	uint8_t const *sirk;
 };
 
 /**

--- a/applications/nrf5340_audio/src/bluetooth/bt_management/bt_mgmt.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/bt_mgmt.c
@@ -35,12 +35,6 @@ ZBUS_CHAN_DEFINE(bt_mgmt_chan, struct bt_mgmt_msg, NULL, NULL, ZBUS_OBSERVERS_EM
  */
 #define BT_ENABLE_TIMEOUT_MS 100
 
-#ifndef CONFIG_BT_MAX_CONN
-#define MAX_CONN_NUM 0
-#else
-#define MAX_CONN_NUM CONFIG_BT_MAX_CONN
-#endif
-
 K_SEM_DEFINE(sem_bt_enabled, 0, 1);
 
 /**
@@ -72,7 +66,6 @@ static void connected_cb(struct bt_conn *conn, uint8_t err)
 {
 	int ret;
 	char addr[BT_ADDR_LE_STR_LEN] = {0};
-	uint8_t num_conn = 0;
 	struct bt_mgmt_msg msg;
 
 	if (err == BT_HCI_ERR_ADV_TIMEOUT && IS_ENABLED(CONFIG_BT_PERIPHERAL)) {
@@ -114,19 +107,9 @@ static void connected_cb(struct bt_conn *conn, uint8_t err)
 		return;
 	}
 
-	bt_conn_foreach(BT_CONN_TYPE_LE, conn_state_connected_check, (void *)&num_conn);
-
 	/* ACL connection established */
 	/* NOTE: The string below is used by the Nordic CI system */
 	LOG_INF("Connected: %s", addr);
-
-	if (IS_ENABLED(CONFIG_BT_CENTRAL) && (num_conn < MAX_CONN_NUM)) {
-		/* Room for more connections, start scanning again */
-		ret = bt_mgmt_scan_start(0, 0, BT_MGMT_SCAN_TYPE_CONN, NULL, BRDCAST_ID_NOT_USED);
-		if (ret) {
-			LOG_ERR("Failed to resume scanning: %d", ret);
-		}
-	}
 
 	msg.event = BT_MGMT_CONNECTED;
 	msg.conn = conn;
@@ -325,6 +308,11 @@ static int local_identity_addr_print(void)
 	}
 
 	return 0;
+}
+
+void bt_mgmt_num_conn_get(uint8_t *num_conn)
+{
+	bt_conn_foreach(BT_CONN_TYPE_LE, conn_state_connected_check, (void *)num_conn);
 }
 
 int bt_mgmt_bonding_clear(void)

--- a/applications/nrf5340_audio/src/bluetooth/bt_management/bt_mgmt.h
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/bt_mgmt.h
@@ -56,6 +56,22 @@ enum bt_mgmt_scan_type {
 #define BRDCAST_ID_NOT_USED (BT_AUDIO_BROADCAST_ID_MAX + 1)
 
 /**
+ * @brief	Get the numbers of connected members of a given 'Set Identity Resolving Key' (SIRK).
+ *		The SIRK shall be set through bt_mgmt_scan_sirk_set() before calling this function.
+ *
+ * @param[out]	num_filled	The number of connected set members.
+ */
+void bt_mgmt_set_size_filled_get(uint8_t *num_filled);
+
+/**
+ * @brief	Set 'Set Identity Resolving Key' (SIRK).
+ *		Used for searching for other member of the same set.
+ *
+ * @param[in]	sirk	Pointer to the Set Identity Resolving Key to store.
+ */
+void bt_mgmt_scan_sirk_set(uint8_t const *const sirk);
+
+/**
  * @brief	Start scanning for advertisements.
  *
  * @param[in]	scan_intvl	Scan interval in units of 0.625ms.
@@ -108,6 +124,13 @@ int bt_mgmt_manufacturer_uuid_populate(struct net_buf_simple *uuid_buf, uint16_t
  */
 int bt_mgmt_adv_start(const struct bt_data *ext_adv, size_t ext_adv_size,
 		      const struct bt_data *per_adv, size_t per_adv_size, bool connectable);
+
+/**
+ * @brief	Get the number of active connections.
+ *
+ * @param[out]	num_conn	The number of active connections.
+ */
+void bt_mgmt_num_conn_get(uint8_t *num_conn);
 
 /**
  * @brief	Clear all bonded devices.

--- a/applications/nrf5340_audio/src/bluetooth/bt_management/scanning/bt_mgmt_scan_for_conn.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/scanning/bt_mgmt_scan_for_conn.c
@@ -8,6 +8,11 @@
 
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/gatt.h>
+#include <zephyr/bluetooth/audio/csip.h>
+
+/* Will become public when https://github.com/zephyrproject-rtos/zephyr/pull/73445 is merged */
+#include <../subsys/bluetooth/audio/csip_internal.h>
 
 #include "bt_mgmt.h"
 
@@ -22,6 +27,7 @@ static uint8_t bonded_num;
 static struct bt_le_scan_cb scan_callback;
 static bool cb_registered;
 static char const *srch_name;
+static uint8_t const *server_sirk;
 
 static void bond_check(const struct bt_bond_info *info, void *user_data)
 {
@@ -87,10 +93,42 @@ static void bond_connect(const struct bt_bond_info *bond_info, void *user_data)
 }
 
 /**
+ * @brief	Check if the address belongs to an already connected device.
+ *
+ * @param[in]	addr	Address to check.
+ *
+ * @retval	false	No device in connected state with that address.
+ * @retval	true	Device found.
+ */
+static bool conn_exist_check(bt_addr_le_t *addr)
+{
+	int ret;
+	struct bt_conn_info info;
+	struct bt_conn *existing_conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, addr);
+
+	if (existing_conn != NULL) {
+		ret = bt_conn_get_info(existing_conn, &info);
+		if (ret == 0 && info.state == BT_CONN_STATE_CONNECTED) {
+			LOG_DBG("Trying to connect to an already connected conn");
+			bt_conn_unref(existing_conn);
+			return true;
+		} else if (ret) {
+			LOG_WRN("Failed to get info from conn: %d", ret);
+		}
+
+		/* Unref is needed due to bt_conn_lookup */
+		bt_conn_unref(existing_conn);
+	}
+
+	/* No existing connection found with that address */
+	return false;
+}
+
+/**
  * @brief	Check the advertising data for the matching device name.
  *
  * @param[in]	data		The advertising data to be checked.
- * @param[in]	user_data	The user data that contains the pointer to the address.
+ * @param[in]	user_data	Pointer to the address.
  *
  * @retval	false	Stop going through adv data.
  * @retval	true	Continue checking the data.
@@ -105,24 +143,14 @@ static bool device_name_check(struct bt_data *data, void *user_data)
 	/* We only care about LTVs with name */
 	if (data->type == BT_DATA_NAME_COMPLETE || data->type == BT_DATA_NAME_SHORTENED) {
 		size_t srch_name_size = strlen(srch_name);
-
 		if ((data->data_len == srch_name_size) &&
 		    (strncmp(srch_name, data->data, srch_name_size) == 0)) {
 			/* Check if the device is still connected due to waiting for ACL timeout */
-			struct bt_conn_info info;
-			struct bt_conn *existing_conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, addr);
-
-			if (existing_conn != NULL) {
-				ret = bt_conn_get_info(existing_conn, &info);
-				if (ret == 0 && info.state == BT_CONN_STATE_CONNECTED) {
-					LOG_DBG("Trying to connect to an already connected conn");
-					bt_conn_unref(existing_conn);
-					return false;
-				}
-
-				/* Unref is needed due to bt_conn_lookup */
-				bt_conn_unref(existing_conn);
+			if (conn_exist_check(addr)) {
+				/* Device is already connected, stop parsing the adv data */
+				return false;
 			}
+
 			LOG_DBG("Device found: %s", srch_name);
 
 			bt_le_scan_cb_unregister(&scan_callback);
@@ -157,6 +185,62 @@ static bool device_name_check(struct bt_data *data, void *user_data)
 }
 
 /**
+ * @brief	Check the advertising data for the matching 'Set Identity Resolving Key' (SIRK).
+ *
+ * @param[in]	data		The advertising data to be checked.
+ * @param[in]	user_data	Pointer to the address.
+ *
+ * @retval	false	Stop going through adv data.
+ * @retval	true	Continue checking the data.
+ */
+static bool csip_found(struct bt_data *data, void *user_data)
+{
+	int ret;
+	bt_addr_le_t *addr = user_data;
+	struct bt_conn *conn;
+	char addr_string[BT_ADDR_LE_STR_LEN];
+
+	if (!bt_csip_set_coordinator_is_set_member(server_sirk, data)) {
+		/* This part of the data doesn't contain matching SIRK, continue parsing */
+		return true;
+	}
+
+	/* Check if the device is still connected due to waiting for ACL timeout */
+	if (conn_exist_check(addr)) {
+		/* Device is already connected, stop parsing the adv data */
+		return false;
+	}
+
+	LOG_DBG("Coordinated set device found");
+	server_sirk = NULL;
+
+	bt_le_scan_cb_unregister(&scan_callback);
+	cb_registered = false;
+
+	ret = bt_le_scan_stop();
+	if (ret) {
+		LOG_ERR("Stop scan failed: %d", ret);
+	}
+
+	bt_addr_le_to_str(addr, addr_string, BT_ADDR_LE_STR_LEN);
+
+	LOG_INF("Creating connection to device in coordinated set: %s", addr_string);
+
+	ret = bt_conn_le_create(addr, BT_CONN_LE_CREATE_CONN, CONNECTION_PARAMETERS, &conn);
+	if (ret) {
+		LOG_ERR("Could not init connection: %d", ret);
+
+		ret = bt_mgmt_scan_start(0, 0, BT_MGMT_SCAN_TYPE_CONN, NULL, BRDCAST_ID_NOT_USED);
+		if (ret) {
+			LOG_ERR("Failed to restart scanning: %d", ret);
+		}
+	}
+
+	/* Set member found and connected, stop parsing */
+	return false;
+}
+
+/**
  * @brief	Callback handler for scan receive when scanning for connections.
  *
  * @param[in]	info	Advertiser packet and scan response information.
@@ -182,7 +266,11 @@ static void scan_recv_cb(const struct bt_le_scan_recv_info *info, struct net_buf
 	case BT_GAP_ADV_TYPE_SCAN_RSP:
 		/* Note: May lead to connection creation */
 		if (bonded_num < CONFIG_BT_MAX_PAIRED) {
-			bt_data_parse(ad, device_name_check, (void *)info->addr);
+			if (server_sirk == NULL) {
+				bt_data_parse(ad, device_name_check, (void *)info->addr);
+			} else {
+				bt_data_parse(ad, csip_found, (void *)info->addr);
+			}
 		} else {
 			/* All bonded slots are taken, so we will only
 			 * accept previously bonded devices
@@ -193,6 +281,48 @@ static void scan_recv_cb(const struct bt_le_scan_recv_info *info, struct net_buf
 	default:
 		break;
 	}
+}
+
+static void conn_in_coord_set_check(struct bt_conn *conn, void *data)
+{
+	int ret;
+	struct bt_conn_info info;
+	const struct bt_csip_set_coordinator_set_member *member;
+
+	if (data == NULL) {
+		LOG_ERR("Got NULL pointer");
+		return;
+	}
+
+	uint8_t *num_filled = (uint8_t *)data;
+
+	ret = bt_conn_get_info(conn, &info);
+	if (ret) {
+		LOG_ERR("Failed to get conn info for %p: %d", (void *)conn, ret);
+		return;
+	}
+
+	/* Don't care about connection not in a connected state */
+	if (info.state != BT_CONN_STATE_CONNECTED) {
+		return;
+	}
+
+	member = bt_csip_set_coordinator_csis_member_by_conn(conn);
+
+	if (memcmp((void *)server_sirk, (void *)member->insts[0].info.set_sirk,
+		   BT_CSIP_SET_SIRK_SIZE) == 0) {
+		(*num_filled)++;
+	}
+}
+
+void bt_mgmt_set_size_filled_get(uint8_t *num_filled)
+{
+	bt_conn_foreach(BT_CONN_TYPE_LE, conn_in_coord_set_check, (void *)num_filled);
+}
+
+void bt_mgmt_scan_sirk_set(uint8_t const *const sirk)
+{
+	server_sirk = sirk;
 }
 
 int bt_mgmt_scan_for_conn_start(struct bt_le_scan_param *scan_param, char const *const name)


### PR DESCRIPTION
- Use SIRK to discover and connect to other members of the same set.
- If device is not part of set, scan by device name as normal.
- Move restart of scanning after connected to one device to main.
- OCT-3024