### PR TITLE
tests: drivers: migrate flash_rpc to sysbuild

### DIFF
--- a/tests/drivers/flash/flash_rpc/CMakeLists.txt
+++ b/tests/drivers/flash/flash_rpc/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-set(ZEPHYR_EXTRA_MODULES ${CMAKE_CURRENT_LIST_DIR})
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(flash_rpc)
 

--- a/tests/drivers/flash/flash_rpc/Kconfig
+++ b/tests/drivers/flash/flash_rpc/Kconfig
@@ -15,4 +15,5 @@ config APP_INCLUDE_REMOTE_IMAGE
 
 config APP_REMOTE_BOARD
 	string "The name of the CORE to be used by remote image"
+	default "nrf5340dk/nrf5340/cpunet"
 	depends on APP_INCLUDE_REMOTE_IMAGE

--- a/tests/drivers/flash/flash_rpc/Kconfig.sysbuild
+++ b/tests/drivers/flash/flash_rpc/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+
+config REMOTE_BOARD
+	string "The board used for remote target"

--- a/tests/drivers/flash/flash_rpc/sysbuild.cmake
+++ b/tests/drivers/flash/flash_rpc/sysbuild.cmake
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+if("${SB_CONFIG_REMOTE_BOARD}" STREQUAL "")
+  message(FATAL_ERROR "REMOTE_BOARD must be set to a valid board name")
+endif()
+
+# Add remote project
+ExternalZephyrProject_Add(
+  APPLICATION remote
+  SOURCE_DIR ${APP_DIR}/remote
+  BOARD ${SB_CONFIG_REMOTE_BOARD}
+)
+set_property(GLOBAL APPEND PROPERTY PM_DOMAINS CPUNET)
+set_property(GLOBAL APPEND PROPERTY PM_CPUNET_IMAGES remote)
+set_property(GLOBAL PROPERTY DOMAIN_APP_CPUNET remote)
+set(CPUNET_PM_DOMAIN_DYNAMIC_PARTITION remote CACHE INTERNAL "")
+
+# Add a dependency so that the remote sample will be built and flashed first
+add_dependencies(flash_rpc remote)
+# Add dependency so that the remote image is flashed first.
+sysbuild_add_dependencies(FLASH flash_rpc remote)

--- a/tests/drivers/flash/flash_rpc/sysbuild/nrf5340dk_nrf5340_cpunet.conf
+++ b/tests/drivers/flash/flash_rpc/sysbuild/nrf5340dk_nrf5340_cpunet.conf
@@ -1,0 +1,1 @@
+SB_CONFIG_REMOTE_BOARD="nrf5340dk/nrf5340/cpunet"

--- a/tests/drivers/flash/flash_rpc/testcase.yaml
+++ b/tests/drivers/flash/flash_rpc/testcase.yaml
@@ -1,4 +1,5 @@
 common:
+  sysbuild: true
   tags:
     - drivers
     - flash
@@ -7,3 +8,5 @@ tests:
     platform_allow: nrf5340dk/nrf5340/cpuapp
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
+    extra_args:
+      SB_CONF_FILE=sysbuild/nrf5340dk_nrf5340_cpunet.conf


### PR DESCRIPTION
Migrate the flash rpc driver test to use sysbuild.