### PR TITLE
Bluetooth: Tester: Disable partition manager

### DIFF
--- a/tests/bluetooth/tester/sysbuild.conf
+++ b/tests/bluetooth/tester/sysbuild.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+SB_CONFIG_PARTITION_MANAGER=n


### PR DESCRIPTION
Disables partition manager for the BT tester. After migration to sysbuild, the partition manager was enabled by default.