### PR TITLE
manifest: sdk-zephyr: Pull fix for sockets services

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 18285a0ea4b93e0e37dacebfc715cd39c7640994
+      revision: pull/1754/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This fixes issue with sockets services register hang. E.g., DHCPv4 server start shell command with fewer sockets.

Fixes SHEL-2802.