### PR TITLE
wifi: Fix de-initialization sequence

### DIFF
--- a/drivers/wifi/nrf700x/src/qspi/inc/spi_if.h
+++ b/drivers/wifi/nrf700x/src/qspi/inc/spi_if.h
@@ -13,6 +13,8 @@
 
 int spim_init(struct qspi_config *config);
 
+int spim_deinit(void);
+
 int spim_write(unsigned int addr, const void *data, int len);
 
 int spim_read(unsigned int addr, void *data, int len);

--- a/drivers/wifi/nrf700x/src/qspi/src/device.c
+++ b/drivers/wifi/nrf700x/src/qspi/src/device.c
@@ -21,15 +21,19 @@
 static struct qspi_config config;
 
 #if defined(CONFIG_NRF700X_ON_QSPI)
-static struct qspi_dev qspi = { .init = qspi_init,
-			 .read = qspi_read,
-			 .write = qspi_write,
-			 .hl_read = qspi_hl_read};
+static struct qspi_dev qspi = {
+	.init = qspi_init,
+	.read = qspi_read,
+	.write = qspi_write,
+	.hl_read = qspi_hl_read
+};
 #else
-static struct qspi_dev spim = { .init = spim_init,
-			 .read = spim_read,
-			 .write = spim_write,
-			 .hl_read = spim_hl_read};
+static struct qspi_dev spim = {
+	.init = spim_init,
+	.read = spim_read,
+	.write = spim_write,
+	.hl_read = spim_hl_read
+};
 #endif
 
 struct qspi_config *qspi_defconfig(void)

--- a/drivers/wifi/nrf700x/src/qspi/src/device.c
+++ b/drivers/wifi/nrf700x/src/qspi/src/device.c
@@ -23,6 +23,7 @@ static struct qspi_config config;
 #if defined(CONFIG_NRF700X_ON_QSPI)
 static struct qspi_dev qspi = {
 	.init = qspi_init,
+	.deinit = qspi_deinit,
 	.read = qspi_read,
 	.write = qspi_write,
 	.hl_read = qspi_hl_read
@@ -30,6 +31,7 @@ static struct qspi_dev qspi = {
 #else
 static struct qspi_dev spim = {
 	.init = spim_init,
+	.deinit = spim_deinit,
 	.read = spim_read,
 	.write = spim_write,
 	.hl_read = spim_hl_read

--- a/drivers/wifi/nrf700x/src/qspi/src/spi_if.c
+++ b/drivers/wifi/nrf700x/src/qspi/src/spi_if.c
@@ -243,6 +243,13 @@ int spim_init(struct qspi_config *config)
 	return 0;
 }
 
+int spim_deinit(void)
+{
+	LOG_DBG("TODO : %s", __func__);
+
+	return 0;
+}
+
 static void spim_addr_check(unsigned int addr, const void *data, unsigned int len)
 {
 	if ((addr % 4 != 0) || (((unsigned int)data) % 4 != 0) || (len % 4 != 0)) {

--- a/drivers/wifi/nrf700x/src/shim.c
+++ b/drivers/wifi/nrf700x/src/shim.c
@@ -633,11 +633,10 @@ static enum nrf_wifi_status zep_shim_bus_qspi_dev_init(void *os_qspi_dev_ctx)
 	return NRF_WIFI_STATUS_SUCCESS;
 }
 
-static void zep_shim_bus_qspi_dev_deinit(void *os_qspi_dev_ctx)
+static void zep_shim_bus_qspi_dev_deinit(void *priv)
 {
-	struct qspi_dev *dev = NULL;
-
-	dev = os_qspi_dev_ctx;
+	struct zep_shim_bus_qspi_priv *qspi_priv = priv;
+	volatile struct qspi_dev *dev = qspi_priv->qspi_dev;
 
 	dev->deinit();
 }
@@ -645,7 +644,7 @@ static void zep_shim_bus_qspi_dev_deinit(void *os_qspi_dev_ctx)
 static void *zep_shim_bus_qspi_dev_add(void *os_qspi_priv, void *osal_qspi_dev_ctx)
 {
 	struct zep_shim_bus_qspi_priv *zep_qspi_priv = os_qspi_priv;
-	struct qspi_dev *qdev = qspi_dev();
+	struct qspi_dev *dev = qspi_dev();
 	int ret;
 	enum nrf_wifi_status status;
 
@@ -655,7 +654,7 @@ static void *zep_shim_bus_qspi_dev_add(void *os_qspi_priv, void *osal_qspi_dev_c
 		return NULL;
 	}
 
-	status = qdev->init(qspi_defconfig());
+	status = dev->init(qspi_defconfig());
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		LOG_ERR("%s: QSPI device init failed", __func__);
 		return NULL;
@@ -666,17 +665,18 @@ static void *zep_shim_bus_qspi_dev_add(void *os_qspi_priv, void *osal_qspi_dev_c
 		LOG_ERR("%s: RPU enable failed with error %d", __func__, ret);
 		return NULL;
 	}
-	zep_qspi_priv->qspi_dev = qdev;
+	zep_qspi_priv->qspi_dev = dev;
 	zep_qspi_priv->dev_added = true;
 
 	return zep_qspi_priv;
 }
 
-static void zep_shim_bus_qspi_dev_rem(void *os_qspi_dev_ctx)
+static void zep_shim_bus_qspi_dev_rem(void *priv)
 {
-	struct qspi_dev *dev = NULL;
+	struct zep_shim_bus_qspi_priv *qspi_priv = priv;
+	struct qspi_dev *dev = qspi_priv->qspi_dev;
 
-	dev = os_qspi_dev_ctx;
+	ARG_UNUSED(dev);
 
 	/* TODO: Make qspi_dev a dynamic instance and remove it here */
 	rpu_disable();

--- a/drivers/wifi/nrf700x/src/shim.c
+++ b/drivers/wifi/nrf700x/src/shim.c
@@ -796,11 +796,18 @@ out:
 
 static void zep_shim_bus_qspi_intr_unreg(void *os_qspi_dev_ctx)
 {
+	struct k_work_sync sync;
+	int ret;
+
 	ARG_UNUSED(os_qspi_dev_ctx);
 
-	k_work_cancel_delayable(&intr_priv->work);
+	ret = rpu_irq_remove(&intr_priv->gpio_cb_data);
+	if (ret) {
+		LOG_ERR("%s: rpu_irq_remove failed", __func__);
+		return;
+	}
 
-	rpu_irq_remove(&intr_priv->gpio_cb_data);
+	k_work_cancel_delayable_sync(&intr_priv->work, &sync);
 
 	k_free(intr_priv);
 	intr_priv = NULL;

--- a/west.yml
+++ b/west.yml
@@ -148,7 +148,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 9837d3bfacabf06d888ac12765c3868c251a58c2
+      revision: 589238f61085c510a603245428d136b36110cfb4
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
De-initialization sequence in nRF70 driver was not properly implemented and has never been tested (init + reboot was the usecase), but we need this to work properly in order to put RPU in lowest power state, recover RPU etc.

This PR fills the gaps, fixes race conditions etc to solve numerous crashes.

Note: needs to be rebase once https://github.com/nrfconnect/sdk-nrf/pull/15599 is merged (top two commits are taken from this PR to enable tests/build).