### PR TITLE
net: lib: nrf_cloud_coap: Enable ground fix conf

### DIFF
--- a/doc/nrf/libraries/networking/nrf_cloud_coap.rst
+++ b/doc/nrf/libraries/networking/nrf_cloud_coap.rst
@@ -68,7 +68,6 @@ Additionally, the following Kconfig options are available:
 
 * :kconfig:option:`CONFIG_NRF_CLOUD_COAP_SERVER_HOSTNAME`
 * :kconfig:option:`CONFIG_NRF_CLOUD_COAP_SEC_TAG`
-* :kconfig:option:`CONFIG_NRF_CLOUD_COAP_GF_CONF`
 * :kconfig:option:`CONFIG_NRF_CLOUD_COAP_SEND_SSIDS`
 * :kconfig:option:`CONFIG_NRF_CLOUD_SEND_DEVICE_STATUS`
 * :kconfig:option:`CONFIG_NRF_CLOUD_SEND_DEVICE_STATUS_NETWORK`

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -917,6 +917,7 @@ Libraries for networking
 * :ref:`lib_nrf_cloud_coap` library:
 
   * Updated to request proprietary PSM mode for ``SOC_NRF9151_LACA`` and ``SOC_NRF9131_LACA`` in addition to ``SOC_NRF9161_LACA``.
+  * Removed the :kconfig:option:`CONFIG_NRF_CLOUD_COAP_GF_CONF` Kconfig option.
 
   * Added:
 

--- a/include/net/nrf_cloud_coap.h
+++ b/include/net/nrf_cloud_coap.h
@@ -94,6 +94,15 @@ int nrf_cloud_coap_pause(void);
  */
 int nrf_cloud_coap_resume(void);
 
+/**@brief Check if you can pause and resume safely.
+ *
+ * Check if the device can avoid performing a full handshake after a temporary network outage ends.
+ *
+ * @retval false if SO_KEEPOPEN is not supported.
+ * @retval true if it is supported.
+ */
+bool nrf_cloud_coap_keepopen_is_supported(void);
+
 /**
  * @brief Disconnect the nRF Cloud CoAP connection.
  *

--- a/lib/location/cloud_service/cloud_service_nrf.c
+++ b/lib/location/cloud_service/cloud_service_nrf.c
@@ -115,7 +115,8 @@ int cloud_service_nrf_pos_get(
 #endif
 	const struct nrf_cloud_rest_location_request loc_req = {
 		.cell_info = params->cell_data,
-		.wifi_info = params->wifi_data
+		.wifi_info = params->wifi_data,
+		.config = NULL
 	};
 	struct nrf_cloud_location_result result;
 

--- a/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_coap
+++ b/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_coap
@@ -27,15 +27,6 @@ config NRF_CLOUD_COAP_SERVER_PORT
 	int "CoAP server port"
 	default 5684
 
-config NRF_CLOUD_COAP_GF_CONF
-	bool "Enable configuration options for ground-fix requests"
-	help
-	  The initial release of CoAP for nRF Cloud did not provide a way to
-	  configure the response; it defaulted to always returning the location
-	  and method used to acquire the location. The cloud will soon support
-	  configuration values do_reply, fallback, and hi_conf. When the cloud
-	  support is ready, NRF_CLOUD_COAP_GF_CONF can be set true.
-
 config NRF_CLOUD_COAP_KEEPOPEN
 	bool "Enable SO_KEEPOPEN to prevent unnecessary socket closures"
 	default y

--- a/subsys/net/lib/nrf_cloud/coap/include/nrf_cloud_coap_transport.h
+++ b/subsys/net/lib/nrf_cloud/coap/include/nrf_cloud_coap_transport.h
@@ -89,6 +89,9 @@ int nrf_cloud_coap_transport_authenticate(struct nrf_cloud_coap_client *const cl
  *
  * @param client Client to pause.
  *
+ * @retval -EINVAL Client cannot be NULL.
+ * @retval -EBADF Device is disconnected.
+ * @retval -EACCES Unable to pause; device was not using CID or not authenticated.
  * @return 0 if successful, otherwise a negative error code.
  */
 int nrf_cloud_coap_transport_pause(struct nrf_cloud_coap_client *const client);
@@ -97,6 +100,9 @@ int nrf_cloud_coap_transport_pause(struct nrf_cloud_coap_client *const client);
  *
  * @param client Client to resume.
  *
+ * @retval -EINVAL Client cannot be NULL or DTLS CID not supported with current mfw.
+ * @retval -EAGAIN Failed to load DTLS CID session.
+ * @retval -EACCES Unable to resume because DTLS CID was not previously saved.
  * @return 0 if successful, otherwise a negative error code.
  */
 int nrf_cloud_coap_transport_resume(struct nrf_cloud_coap_client *const client);

--- a/subsys/net/lib/nrf_cloud/coap/include/nrfc_dtls.h
+++ b/subsys/net/lib/nrf_cloud/coap/include/nrfc_dtls.h
@@ -54,4 +54,13 @@ int nrfc_dtls_session_save(int sock);
  */
 int nrfc_dtls_session_load(int sock);
 
+/** @brief Check if you can use SO_KEEPOPEN.
+ *
+ * Modem firmware < 2.0.1 does not support this.
+ *
+ * @retval true - SO_KEEPOPEN can be used.
+ * @retval false - it cannot be used.
+ */
+bool nrfc_keepopen_is_supported(void);
+
 #endif /* NRFC_DTLS_H_ */

--- a/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap.c
+++ b/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap.c
@@ -442,16 +442,12 @@ int nrf_cloud_coap_location_get(struct nrf_cloud_rest_location_request const *co
 	static uint8_t buffer[LOCATION_GET_CBOR_MAX_SIZE];
 	size_t len = sizeof(buffer);
 	int err;
-	const struct nrf_cloud_location_config *conf = IS_ENABLED(CONFIG_NRF_CLOUD_COAP_GF_CONF) ?
-						       request->config : NULL;
+	const struct nrf_cloud_location_config *conf = request->config;
 	size_t url_size = nrf_cloud_ground_fix_url_encode(NULL, 0, COAP_GND_FIX_RSC, conf);
 
 	__ASSERT_NO_MSG(url_size > 0);
 	char url[url_size + 1];
 
-	if (!IS_ENABLED(CONFIG_NRF_CLOUD_COAP_GF_CONF) && (request->config != NULL)) {
-		LOG_WRN("Use of location configuration parameters not enabled; ignored.");
-	}
 	(void)nrf_cloud_ground_fix_url_encode(url, url_size, COAP_GND_FIX_RSC, conf);
 
 	err = coap_codec_ground_fix_req_encode(request->cell_info,

--- a/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap_transport.c
+++ b/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap_transport.c
@@ -164,6 +164,11 @@ bool nrf_cloud_coap_is_connected(void)
 	return internal_cc.authenticated && !internal_cc.paused;
 }
 
+bool nrf_cloud_coap_keepopen_is_supported(void)
+{
+	return nrfc_keepopen_is_supported();
+}
+
 static inline bool is_internal(struct nrf_cloud_coap_client const *const client)
 {
 	return client == &internal_cc;
@@ -834,6 +839,13 @@ int nrf_cloud_coap_transport_pause(struct nrf_cloud_coap_client *const client)
 {
 	int err = 0;
 	int tmp;
+
+	if (!client) {
+		return -EINVAL;
+	}
+	if (client->sock == -1) {
+		return -EBADF; /* Device is disconnected. */
+	}
 
 	if (nrfc_dtls_cid_is_active(client->sock) && client->authenticated) {
 		LOG_DBG("Cancelling requests");

--- a/subsys/net/lib/nrf_cloud/coap/src/nrfc_dtls.c
+++ b/subsys/net/lib/nrf_cloud/coap/src/nrfc_dtls.c
@@ -35,6 +35,7 @@ LOG_MODULE_REGISTER(dtls, CONFIG_NRF_CLOUD_COAP_LOG_LEVEL);
 static int sectag = CONFIG_NRF_CLOUD_COAP_SEC_TAG;
 static bool dtls_cid_active;
 static bool cid_supported = true;
+static bool keepopen_supported;
 
 #if defined(CONFIG_MODEM_INFO)
 static struct modem_param_info mdm_param;
@@ -167,19 +168,24 @@ int nrfc_dtls_setup(int sock)
 
 	int session_cache = TLS_SESSION_CACHE_ENABLED;
 
+	LOG_DBG("  TLS session cache: %d", session_cache);
 	err = setsockopt(sock, SOL_TLS, TLS_SESSION_CACHE, &session_cache, sizeof(session_cache));
 	if (err) {
 		LOG_ERR("Failed to enable session cache, errno: %d", -errno);
 		err = -errno;
 	}
 
+	keepopen_supported = false;
 	if (IS_ENABLED(CONFIG_NRF_CLOUD_COAP_KEEPOPEN)) {
 		err = setsockopt(sock, SOL_SOCKET, SO_KEEPOPEN, &(int){1}, sizeof(int));
 		if (err) {
-			LOG_ERR("Failed to set SO_KEEPOPEN: %d", -errno);
-			err = -errno;
+			/* Either not supported or unusable due to unknown error. */
+			err = 0;
+		} else {
+			keepopen_supported = true;
 		}
 	}
+	LOG_DBG("  Keep open supported: %d", keepopen_supported);
 	return err;
 }
 
@@ -274,4 +280,9 @@ bool nrfc_dtls_cid_is_active(int sock)
 	}
 
 	return dtls_cid_active;
+}
+
+bool nrfc_keepopen_is_supported(void)
+{
+	return keepopen_supported;
 }


### PR DESCRIPTION
Now that cloud support is released, enable CoAP support for the ground fix configuration flags do_reply, hi_conf, and fallback.

Also set default value for .config to NULL when initializing struct nrf_cloud_rest_location_request in the location library. This structure is shared for REST and CoAP use.

Improve recent SO_KEEPOPEN support to better handle mfw_2.0.0.

Jira: IRIS-9014