### PR TITLE
manifest: bring CAN support to nRF54H20

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 18285a0ea4b93e0e37dacebfc715cd39c7640994
+      revision: de7a6f83556d3f316ffa7407efb499041b87349c
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull Zephyr changes that bring CAN support to nRF54H20.