### PR TITLE
suit: enable SUIT envelope creation for app and rad cores only

### DIFF
--- a/sysbuild/Kconfig.suit
+++ b/sysbuild/Kconfig.suit
@@ -8,7 +8,7 @@ menu "SUIT"
 
 menuconfig SUIT_ENVELOPE
 	bool "Create SUIT envelope"
-	default y if SOC_SERIES_NRF54HX
+	default y if SOC_NRF54H20_CPUAPP || SOC_NRF54H20_CPURAD
 	help
 	  Enable DFU SUIT envelope creation
 


### PR DESCRIPTION
Fix: enable generation of SUIT envelopes only in case of CPUAPP or CPURAD cores

Ref: NONE

Signed-off-by: Robert Stypa <robert.stypa@nordicsemi.no>