### PR TITLE
applications: nrf5340_audio: Fix CIS bidir unicast client noise issue

### DIFF
--- a/applications/nrf5340_audio/unicast_client/Kconfig.defaults
+++ b/applications/nrf5340_audio/unicast_client/Kconfig.defaults
@@ -68,6 +68,8 @@ config MCTL_LOCAL_PLAYER_CONTROL
 config MCTL_LOCAL_PLAYER_REMOTE_CONTROL
 	default y
 
+config BT_AUDIO_PRESENTATION_DELAY_US
+	default 10000
 
 ## LC3 related configs ##
 config LC3_BITRATE


### PR DESCRIPTION
For CIS gateway in bidirectional mode, the default pres_comp time is too short for CIS gateway to handle, which triggering pres_comp very frequently causing noise. Set the presentation delay back to 10ms for unicast client for fixing this issue.
OCT-3040
Signed-off-by: Jui-Chou Chung <jui-chou.chung@nordicsemi.no>