### PR TITLE
lib: pdn: destroy context on CFUN 0

### DIFF
--- a/applications/asset_tracker_v2/src/modules/modem_module.c
+++ b/applications/asset_tracker_v2/src/modules/modem_module.c
@@ -290,6 +290,8 @@ void pdn_event_handler(uint8_t cid, enum pdn_event event, int reason)
 	case PDN_EVENT_NETWORK_DETACH:
 		LOG_DBG("PDN_EVENT_NETWORK_DETACH");
 		break;
+	case PDN_EVENT_CTX_DESTROYED:
+		LOG_DBG("PDN_EVENT_CTX_DESTROYED");
 	default:
 		LOG_WRN("Unexpected PDN event!");
 		break;

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -671,16 +671,18 @@ Modem libraries
 
 * :ref:`nrf_modem_lib_readme`:
 
+  * Updated the RTT trace backend to allocate the RTT channel at boot, instead of when the modem is activated.
   * Rename the nRF91 socket offload layer from ``nrf91_sockets`` to ``nrf9x_sockets`` to reflect that the offload layer is not exclusive to the nRF91 Series SiPs.
+  * Removed support for deprecated RAI socket options ``SO_RAI_LAST``, ``SO_RAI_NO_DATA``, ``SO_RAI_ONE_RESP``, ``SO_RAI_ONGOING``, and ``SO_RAI_WAIT_MORE``.
 
 * :ref:`modem_info_readme` library:
 
   * Fixed a potential issue with scanf in the :c:func:`modem_info_get_current_band` function, which could lead to memory corruption.
 
-* :ref:`nrf_modem_lib_readme` library:
+* :ref:`pdn_readme` library:
 
-  * Updated the RTT trace backend to allocate the RTT channel at boot, instead of when the modem is activated.
-  * Removed support for deprecated RAI socket options ``SO_RAI_LAST``, ``SO_RAI_NO_DATA``, ``SO_RAI_ONE_RESP``, ``SO_RAI_ONGOING``, and ``SO_RAI_WAIT_MORE``.
+  * Added the event ``PDN_EVENT_CTX_DESTROYED`` to indicate when a PDP context is destroyed.
+    This happens when the modem is switched to minimum functionality mode (``CFUN=0``).
 
 Multiprotocol Service Layer libraries
 -------------------------------------

--- a/include/modem/pdn.h
+++ b/include/modem/pdn.h
@@ -56,14 +56,26 @@ struct pdn_pdp_opt {
 
 /** @brief PDN library event */
 enum pdn_event {
-	PDN_EVENT_CNEC_ESM,		/**< +CNEC ESM error code */
-	PDN_EVENT_ACTIVATED,		/**< PDN connection activated */
-	PDN_EVENT_DEACTIVATED,		/**< PDN connection deactivated */
-	PDN_EVENT_IPV6_UP,		/**< PDN has IPv6 connectivity */
-	PDN_EVENT_IPV6_DOWN,		/**< PDN has lost IPv6 connectivity */
-	PDN_EVENT_NETWORK_DETACH,	/**< Network detached */
-	PDN_EVENT_APN_RATE_CONTROL_ON,	/**< APN rate control is ON for given PDN */
-	PDN_EVENT_APN_RATE_CONTROL_OFF, /**< APN rate control is OFF for given PDN */
+	/** +CNEC ESM error code */
+	PDN_EVENT_CNEC_ESM,
+	/** PDN connection activated */
+	PDN_EVENT_ACTIVATED,
+	/** PDN connection deactivated */
+	PDN_EVENT_DEACTIVATED,
+	/** PDN has IPv6 connectivity */
+	PDN_EVENT_IPV6_UP,
+	/** PDN has lost IPv6 connectivity */
+	PDN_EVENT_IPV6_DOWN,
+	/** Network detached */
+	PDN_EVENT_NETWORK_DETACH,
+	/** APN rate control is ON for given PDN */
+	PDN_EVENT_APN_RATE_CONTROL_ON,
+	/** APN rate control is OFF for given PDN */
+	PDN_EVENT_APN_RATE_CONTROL_OFF,
+	/** PDP context is destroyed for given PDN.
+	 *  This happens if modem is switched to minimum functionality mode.
+	 */
+	PDN_EVENT_CTX_DESTROYED,
 };
 
 /** @brief PDN authentication method */

--- a/lib/nrf_modem_lib/lte_net_if/lte_net_if.c
+++ b/lib/nrf_modem_lib/lte_net_if/lte_net_if.c
@@ -295,6 +295,9 @@ static void pdn_event_handler(uint8_t cid, enum pdn_event event, int reason)
 		on_pdn_ipv6_down();
 		break;
 #endif /* CONFIG_NET_IPV6 */
+	case PDN_EVENT_CTX_DESTROYED:
+		LOG_DBG("PDN context destroyed");
+		break;
 	default:
 		LOG_ERR("Unexpected PDN event: %d", event);
 		break;

--- a/lib/pdn/pdn.c
+++ b/lib/pdn/pdn.c
@@ -300,10 +300,20 @@ static void on_modem_init(int ret, void *ctx)
 int pdn_default_ctx_cb_reg(pdn_event_handler_t cb)
 {
 	struct pdn *pdn;
+	struct pdn *tmp;
 
 	if (!cb) {
 		return -EFAULT;
 	}
+
+	k_mutex_lock(&list_mutex, K_FOREVER);
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&pdn_contexts, pdn, tmp, node) {
+		if (pdn->context_id == 0 && pdn->callback == cb) {
+			/* Already registered */
+			return 0;
+		}
+	}
+	k_mutex_unlock(&list_mutex);
 
 	pdn = pdn_ctx_new();
 	if (!pdn) {
@@ -318,12 +328,12 @@ int pdn_default_ctx_cb_reg(pdn_event_handler_t cb)
 	return 0;
 }
 
-static void pdn_ctx_free(struct pdn *pdn)
+static bool pdn_ctx_free(struct pdn *pdn)
 {
 	bool removed;
 
 	if (!pdn) {
-		return;
+		return false;
 	}
 
 	k_mutex_lock(&list_mutex, K_FOREVER);
@@ -331,10 +341,12 @@ static void pdn_ctx_free(struct pdn *pdn)
 	k_mutex_unlock(&list_mutex);
 
 	if (!removed) {
-		return;
+		return false;
 	}
 
 	k_free(pdn);
+
+	return true;
 }
 
 int pdn_default_ctx_cb_dereg(pdn_event_handler_t cb)
@@ -351,7 +363,7 @@ int pdn_default_ctx_cb_dereg(pdn_event_handler_t cb)
 	k_mutex_lock(&list_mutex, K_FOREVER);
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&pdn_contexts, pdn, tmp, node) {
 		if (pdn->callback == cb) {
-			removed = sys_slist_find_and_remove(&pdn_contexts, &pdn->node);
+			removed = pdn_ctx_free(pdn);
 			break;
 		}
 	}
@@ -362,7 +374,6 @@ int pdn_default_ctx_cb_dereg(pdn_event_handler_t cb)
 	}
 
 	LOG_DBG("Default PDP ctx callback %p unregistered", pdn->callback);
-	k_free(pdn);
 
 	return 0;
 }
@@ -384,17 +395,17 @@ int pdn_ctx_create(uint8_t *cid, pdn_event_handler_t cb)
 
 	err = nrf_modem_at_scanf("AT%XNEWCID?", "%%XNEWCID: %d", &ctx_id_tmp);
 	if (err < 0) {
-		pdn_ctx_free(pdn);
+		(void)pdn_ctx_free(pdn);
 		return err;
 	} else if (err == 0) {
 		/* no argument matched */
-		pdn_ctx_free(pdn);
+		(void)pdn_ctx_free(pdn);
 		return -EBADMSG;
 	}
 
 	if (ctx_id_tmp > SCHAR_MAX || ctx_id_tmp < SCHAR_MIN) {
 		LOG_ERR("Context ID (%d) out of bounds", ctx_id_tmp);
-		pdn_ctx_free(pdn);
+		(void)pdn_ctx_free(pdn);
 		return -EFAULT;
 	}
 
@@ -512,7 +523,7 @@ int pdn_ctx_destroy(uint8_t cid)
 		/* cleanup regardless */
 	}
 
-	pdn_ctx_free(pdn);
+	(void)pdn_ctx_free(pdn);
 
 	return err;
 }
@@ -672,11 +683,17 @@ int pdn_default_apn_get(char *buf, size_t len)
 	return 0;
 }
 
-NRF_MODEM_LIB_ON_CFUN(pdn_cfun_hook, on_cfun, NULL);
+#if defined(CONFIG_UNITY)
+void pdn_on_modem_cfun(int mode, void *ctx)
+#else
+NRF_MODEM_LIB_ON_CFUN(pdn_cfun_hook, pdn_on_modem_cfun, NULL);
 
-static void on_cfun(int mode, void *ctx)
+static void pdn_on_modem_cfun(int mode, void *ctx)
+#endif
 {
 	int err;
+	struct pdn *pdn;
+	struct pdn *tmp;
 
 	if (mode == MODEM_CFUN_NORMAL ||
 	    mode == MODEM_CFUN_ACTIVATE_LTE) {
@@ -692,6 +709,21 @@ static void on_cfun(int mode, void *ctx)
 	}
 
 	if (mode == MODEM_CFUN_POWER_OFF) {
+		k_mutex_lock(&list_mutex, K_FOREVER);
+		SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&pdn_contexts, pdn, tmp, node) {
+			if (pdn->context_id == 0) {
+				/* Default context is not destroyed */
+				continue;
+			}
+
+			if (pdn->callback) {
+				pdn->callback(pdn->context_id, PDN_EVENT_CTX_DESTROYED, 0);
+			}
+
+			(void)pdn_ctx_free(pdn);
+		}
+		k_mutex_unlock(&list_mutex);
+
 #if defined(CONFIG_PDN_DEFAULTS_OVERRIDE)
 		pdn_defaults_override();
 #endif

--- a/lib/pdn/pdn.c
+++ b/lib/pdn/pdn.c
@@ -318,6 +318,25 @@ int pdn_default_ctx_cb_reg(pdn_event_handler_t cb)
 	return 0;
 }
 
+static void pdn_ctx_free(struct pdn *pdn)
+{
+	bool removed;
+
+	if (!pdn) {
+		return;
+	}
+
+	k_mutex_lock(&list_mutex, K_FOREVER);
+	removed = sys_slist_find_and_remove(&pdn_contexts, &pdn->node);
+	k_mutex_unlock(&list_mutex);
+
+	if (!removed) {
+		return;
+	}
+
+	k_free(pdn);
+}
+
 int pdn_default_ctx_cb_dereg(pdn_event_handler_t cb)
 {
 	bool removed;
@@ -346,25 +365,6 @@ int pdn_default_ctx_cb_dereg(pdn_event_handler_t cb)
 	k_free(pdn);
 
 	return 0;
-}
-
-static void pdn_ctx_free(struct pdn *pdn)
-{
-	bool removed;
-
-	if (!pdn) {
-		return;
-	}
-
-	k_mutex_lock(&list_mutex, K_FOREVER);
-	removed = sys_slist_find_and_remove(&pdn_contexts, &pdn->node);
-	k_mutex_unlock(&list_mutex);
-
-	if (!removed) {
-		return;
-	}
-
-	k_free(pdn);
 }
 
 int pdn_ctx_create(uint8_t *cid, pdn_event_handler_t cb)

--- a/samples/cellular/modem_shell/src/link/link_shell_pdn.c
+++ b/samples/cellular/modem_shell/src/link/link_shell_pdn.c
@@ -40,6 +40,7 @@ static const char *const event_str[] = {
 	[PDN_EVENT_IPV6_UP] = "IPv6 up",
 	[PDN_EVENT_IPV6_DOWN] = "IPv6 down",
 	[PDN_EVENT_NETWORK_DETACH] = "network detach",
+	[PDN_EVENT_CTX_DESTROYED] = "context destroyed",
 };
 
 void link_pdn_event_handler(uint8_t cid, enum pdn_event event, int reason)

--- a/samples/cellular/pdn/src/main.c
+++ b/samples/cellular/pdn/src/main.c
@@ -30,6 +30,7 @@ static const char * const event_str[] = {
 	[PDN_EVENT_IPV6_UP] = "IPv6 up",
 	[PDN_EVENT_IPV6_DOWN] = "IPv6 down",
 	[PDN_EVENT_NETWORK_DETACH] = "network detach",
+	[PDN_EVENT_CTX_DESTROYED] = "context destroyed",
 };
 
 static void snprintaddr(char *str, size_t size, struct nrf_sockaddr *addr)

--- a/tests/lib/pdn/CMakeLists.txt
+++ b/tests/lib/pdn/CMakeLists.txt
@@ -25,3 +25,6 @@ zephyr_include_directories(${ZEPHYR_NRF_MODULE_DIR}/include/modem/)
 zephyr_include_directories(${ZEPHYR_BASE}/subsys/testsuite/include)
 
 add_compile_definitions(CONFIG_PDN_ESM_TIMEOUT=1000)
+add_compile_definitions(CONFIG_PDN_DEFAULTS_OVERRIDE)
+add_compile_definitions(CONFIG_PDN_DEFAULT_APN="apn0")
+add_compile_definitions(CONFIG_PDN_DEFAULT_FAM=2)


### PR DESCRIPTION
Destroy context on CFUN 0 as that is done in the modem.

PR requires changes to the carrier library, which will not go in for NCS 2.7.0.

TODOs: 

- [x]  Check if `pdn_ctx_destroy()` can be removed from some samples.