### PR TITLE
samples: nrfcloud_multi_service: Decrease heap usage

### DIFF
--- a/samples/cellular/nrf_cloud_multi_service/Kconfig
+++ b/samples/cellular/nrf_cloud_multi_service/Kconfig
@@ -60,7 +60,7 @@ config LED_THREAD_STACK_SIZE
 
 config MAX_OUTGOING_MESSAGES
 	int "Outgoing message maximum"
-	default 50
+	default 25
 	help
 	  Sets the maximum number of device messages which may be enqueued
 	  before further messages are dropped.

--- a/samples/cellular/nrf_cloud_multi_service/prj.conf
+++ b/samples/cellular/nrf_cloud_multi_service/prj.conf
@@ -37,7 +37,7 @@ CONFIG_LOG_BUFFER_SIZE=4096
 CONFIG_AT_MONITOR_HEAP_SIZE=2048
 CONFIG_AT_HOST_STACK_SIZE=2048
 # Extended memory heap size needed both for PGPS and for encoding JSON-based nRF Cloud Device Messages.
-CONFIG_HEAP_MEM_POOL_SIZE=24576
+CONFIG_HEAP_MEM_POOL_SIZE=19000
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
 
 # Enable Networking and Connection Manager.

--- a/samples/cellular/nrf_cloud_multi_service/sample.yaml
+++ b/samples/cellular/nrf_cloud_multi_service/sample.yaml
@@ -56,6 +56,20 @@ tests:
       - nrf9160dk/nrf9160/ns
     extra_args: EXTRA_CONF_FILE="overlay_coap.conf;overlay_min_coap.conf"
     tags: ci_build sysbuild
+  sample.cellular.nrf_cloud_multi_service.coap.trace:
+    sysbuild: true
+    build_only: true
+    platform_allow:
+      - nrf9151dk/nrf9151/ns
+      - nrf9160dk/nrf9160/ns
+      - nrf9161dk/nrf9161/ns
+    integration_platforms:
+      - nrf9151dk/nrf9151/ns
+      - nrf9160dk/nrf9160/ns
+      - nrf9161dk/nrf9161/ns
+    extra_args: EXTRA_CONF_FILE="overlay_coap.conf;overlay-coap_nrf_provisioning.conf"
+      nrf_cloud_multi_service_SNIPPET=nrf91-modem-trace-uart
+    tags: ci_build sysbuild
   sample.cellular.nrf7002ek_wifi.scan:
     sysbuild: true
     build_only: true


### PR DESCRIPTION
Not enough RAM to build the coap + nrf_provisioning + modem_trace combination. Lowering heap usage to make space.