### PR TITLE
manifest: PCB loss information from RF params

### DIFF
--- a/drivers/wifi/nrf700x/Kconfig
+++ b/drivers/wifi/nrf700x/Kconfig
@@ -266,6 +266,26 @@ config NRF700X_QSPI_LOW_POWER
 	bool "Enable low power mode in QSPI"
 	default y if NRF_WIFI_LOW_POWER
 
+config NRF700X_PCB_LOSS_2G
+	int "PCB loss for 2.4 GHz band"
+	default 0
+	range 0 4
+
+config NRF700X_PCB_LOSS_5G_BAND1
+	int "PCB loss for 5 GHz band (5150 MHz - 5350 MHz)"
+	default 0
+	range 0 4
+
+config NRF700X_PCB_LOSS_5G_BAND2
+	int "PCB loss for 5 GHz band (5470 MHz - 5730 MHz)"
+	default 0
+	range 0 4
+
+config NRF700X_PCB_LOSS_5G_BAND3
+	int "PCB loss for 5 GHz band (5730 MHz - 5895 MHz)"
+	default 0
+	range 0 4
+
 config NRF700X_ANT_GAIN_2G
 	int "Antenna gain for 2.4 GHz band"
 	default 0

--- a/drivers/wifi/nrf700x/inc/fmac_main.h
+++ b/drivers/wifi/nrf700x/inc/fmac_main.h
@@ -119,6 +119,7 @@ extern struct nrf_wifi_drv_priv_zep rpu_drv_priv_zep;
 void nrf_wifi_scan_timeout_work(struct k_work *work);
 void configure_tx_pwr_settings(struct nrf_wifi_tx_pwr_ctrl_params *tx_pwr_ctrl_params,
 				struct nrf_wifi_tx_pwr_ceil_params *tx_pwr_ceil_params);
+void configure_board_dep_params(struct nrf_wifi_board_params *board_params);
 void set_tx_pwr_ceil_default(struct nrf_wifi_tx_pwr_ceil_params *pwr_ceil_params);
 const char *nrf_wifi_get_drv_version(void);
 enum nrf_wifi_status nrf_wifi_fmac_dev_add_zep(struct nrf_wifi_drv_priv_zep *drv_priv_zep);

--- a/drivers/wifi/nrf700x/src/fmac_main.c
+++ b/drivers/wifi/nrf700x/src/fmac_main.c
@@ -567,6 +567,16 @@ void configure_tx_pwr_settings(struct nrf_wifi_tx_pwr_ctrl_params *tx_pwr_ctrl_p
 #endif /* CONFIG_NRF70_2_4G_ONLY */
 }
 
+void configure_board_dep_params(struct nrf_wifi_board_params *board_params)
+{
+	board_params->pcb_loss_2g = CONFIG_NRF700X_PCB_LOSS_2G;
+#ifndef CONFIG_NRF70_2_4G_ONLY
+	board_params->pcb_loss_5g_band1 = CONFIG_NRF700X_PCB_LOSS_5G_BAND1;
+	board_params->pcb_loss_5g_band2 = CONFIG_NRF700X_PCB_LOSS_5G_BAND2;
+	board_params->pcb_loss_5g_band3 = CONFIG_NRF700X_PCB_LOSS_5G_BAND3;
+#endif /* CONFIG_NRF70_2_4G_ONLY */
+}
+
 enum nrf_wifi_status nrf_wifi_fmac_dev_add_zep(struct nrf_wifi_drv_priv_zep *drv_priv_zep)
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
@@ -584,6 +594,7 @@ enum nrf_wifi_status nrf_wifi_fmac_dev_add_zep(struct nrf_wifi_drv_priv_zep *drv
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
 	struct nrf_wifi_tx_pwr_ctrl_params tx_pwr_ctrl_params;
 	struct nrf_wifi_tx_pwr_ceil_params tx_pwr_ceil_params;
+	struct nrf_wifi_board_params board_params;
 
 	unsigned int fw_ver = 0;
 
@@ -624,6 +635,7 @@ enum nrf_wifi_status nrf_wifi_fmac_dev_add_zep(struct nrf_wifi_drv_priv_zep *drv
 	configure_tx_pwr_settings(&tx_pwr_ctrl_params,
 				  &tx_pwr_ceil_params);
 
+	configure_board_dep_params(&board_params);
 
 #ifdef CONFIG_NRF700X_RADIO_TEST
 	status = nrf_wifi_fmac_dev_init_rt(rpu_ctx_zep->rpu_ctx,
@@ -634,7 +646,8 @@ enum nrf_wifi_status nrf_wifi_fmac_dev_add_zep(struct nrf_wifi_drv_priv_zep *drv
 					op_band,
 					IS_ENABLED(CONFIG_NRF_WIFI_BEAMFORMING),
 					&tx_pwr_ctrl_params,
-					&tx_pwr_ceil_params);
+					&tx_pwr_ceil_params,
+					&board_params);
 #else
 	status = nrf_wifi_fmac_dev_init(rpu_ctx_zep->rpu_ctx,
 #ifdef CONFIG_NRF_WIFI_LOW_POWER
@@ -644,7 +657,8 @@ enum nrf_wifi_status nrf_wifi_fmac_dev_add_zep(struct nrf_wifi_drv_priv_zep *drv
 					op_band,
 					IS_ENABLED(CONFIG_NRF_WIFI_BEAMFORMING),
 					&tx_pwr_ctrl_params,
-					&tx_pwr_ceil_params);
+					&tx_pwr_ceil_params,
+					&board_params);
 #endif /* CONFIG_NRF700X_RADIO_TEST */
 
 

--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -21,3 +21,15 @@
   platforms:
     - nrf54l15pdk/nrf54l15/cpuapp
   comment: "https://nordicsemi.atlassian.net/browse/DRGN-22129"
+
+- scenarios:
+    - applications.machine_learning.sensor_hub.zdebug.singlecore
+  platforms:
+    - nrf54h20dk/nrf54h20/cpuapp
+  comment: "Temporary to unblock RC1 PRs"
+
+- scenarios:
+    - applications.machine_learning.sensor_hub.zdebug
+  platforms:
+    - nrf54h20dk/nrf54h20/cpuapp
+  comment: "Temporary to unblock RC1 PRs"


### PR DESCRIPTION
SHEL-2800 : Support for passing frequency dependent PCB loss parameters.

test_wifi:test-sdk-wifi-PR-15630