### PR TITLE
sample: wifi_privisioning: add missing sysbuild file

### DIFF
--- a/samples/wifi/provisioning/ble/Kconfig.sysbuild
+++ b/samples/wifi/provisioning/ble/Kconfig.sysbuild
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+
+config NRF_DEFAULT_IPC_RADIO
+	default y
+
+config NETCORE_IPC_RADIO_BT_HCI_IPC
+	default y


### PR DESCRIPTION
The sample is not included in recent effort to convert to sysbuild manner. Add the missing kconfig file to enable hci_ipc for net core.
The kconfig file is copied from https://github.com/nrfconnect/sdk-nrf/pull/15435