### PR TITLE
Revert "lib: at_host: use CRLF termination as default"

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -810,10 +810,6 @@ DFU libraries
 Modem libraries
 ---------------
 
-* :ref:`lib_at_host`:
-
-   * Updated to set the default termination mode to the :kconfig:option:`CONFIG_CR_LF_TERMINATION` Kconfig option instead of the :kconfig:option:`CONFIG_CR_TERMINATION` Kconfig option.
-
 * :ref:`nrf_modem_lib_readme`:
 
   * Added the Kconfig option  :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_UART_CHUNK_SZ` to process traces in chunks.

--- a/lib/at_host/Kconfig
+++ b/lib/at_host/Kconfig
@@ -21,7 +21,7 @@ config AT_HOST_UART_INIT_TIMEOUT
 
 choice
 	prompt "Termination Mode"
-	default CR_LF_TERMINATION
+	default CR_TERMINATION
 	depends on AT_HOST_LIBRARY
 	help
 		Sets the termination ending from the serial terminal


### PR DESCRIPTION
This reverts commit 1318fd7ca595d3c68937972ea185b2dc8a3f80fb (#15535). The changes should be done in the nRF Connect tools instead.
