### PR TITLE
manifest: mcuboot

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -131,7 +131,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: f1e1675630561a745d28107144e9a863860204cf
+      revision: 1d023039111774334a3bcf85f9d876286ed6cb74
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR


### PR DESCRIPTION
Remove force enabled CONFIG_EXT_API_PROVIDE_EXT_API_ATLEAST_OPTIONAL
for MCUboot subimage with external-crypto enabled.

Ref.: NCSDK-27718
