### PR TITLE
tests: bootloader: Add 9151 and 9161 support

### DIFF
--- a/tests/subsys/bootloader/bl_crypto/testcase.yaml
+++ b/tests/subsys/bootloader/bl_crypto/testcase.yaml
@@ -1,24 +1,40 @@
 tests:
   bootloader.bl_crypto:
     sysbuild: true
-    platform_allow: nrf52840dk/nrf52840 nrf52dk/nrf52832 nrf9160dk/nrf9160
-      nrf5340dk/nrf5340/cpuapp nrf52833dk/nrf52833
-    integration_platforms:
+    platform_allow:
+      - nrf52833dk/nrf52833
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
-      - nrf9160dk/nrf9160
       - nrf5340dk/nrf5340/cpuapp
+      - nrf9151dk/nrf9151
+      - nrf9160dk/nrf9160
+      - nrf9161dk/nrf9161
+    integration_platforms:
       - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf52dk/nrf52832
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9151dk/nrf9151
+      - nrf9160dk/nrf9160
+      - nrf9161dk/nrf9161
     tags: b0 sysbuild
   # Deprecated child and parent build to ensure feature does not break until it is removed
   bootloader.bl_crypto.child_parent:
     sysbuild: false
-    platform_allow: nrf52840dk/nrf52840 nrf52dk/nrf52832 nrf9160dk/nrf9160
-      nrf5340dk/nrf5340/cpuapp nrf52833dk/nrf52833
-    integration_platforms:
+    platform_allow:
+      - nrf52833dk/nrf52833
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
-      - nrf9160dk/nrf9160
       - nrf5340dk/nrf5340/cpuapp
+      - nrf9151dk/nrf9151
+      - nrf9160dk/nrf9160
+      - nrf9161dk/nrf9161
+    integration_platforms:
       - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf52dk/nrf52832
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9151dk/nrf9151
+      - nrf9160dk/nrf9160
+      - nrf9161dk/nrf9161
     tags: b0 child_parent deprecated

--- a/tests/subsys/bootloader/bl_storage/testcase.yaml
+++ b/tests/subsys/bootloader/bl_storage/testcase.yaml
@@ -1,10 +1,16 @@
 tests:
   bootloader.bl_storage:
     sysbuild: true
-    platform_allow: nrf9160dk/nrf9160 nrf5340dk/nrf5340/cpuapp
-    integration_platforms:
-      - nrf9160dk/nrf9160
+    platform_allow:
       - nrf5340dk/nrf5340/cpuapp
+      - nrf9151dk/nrf9151
+      - nrf9160dk/nrf9160
+      - nrf9161dk/nrf9161
+    integration_platforms:
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9151dk/nrf9151
+      - nrf9160dk/nrf9160
+      - nrf9161dk/nrf9161
     tags: b0 sysbuild
     harness: console
     harness_config:

--- a/tests/subsys/bootloader/bl_validation/testcase.yaml
+++ b/tests/subsys/bootloader/bl_validation/testcase.yaml
@@ -1,12 +1,20 @@
 tests:
   bootloader.bl_validation:
     sysbuild: true
-    platform_allow: nrf9160dk/nrf9160 nrf52840dk/nrf52840 nrf52dk/nrf52832
-      nrf5340dk/nrf5340/cpuapp nrf52833dk/nrf52833
-    integration_platforms:
-      - nrf9160dk/nrf9160
+    platform_allow:
+      - nrf52833dk/nrf52833
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
+      - nrf9151dk/nrf9151
+      - nrf9160dk/nrf9160
+      - nrf9161dk/nrf9161
+    integration_platforms:
       - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf52dk/nrf52832
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9151dk/nrf9151
+      - nrf9160dk/nrf9160
+      - nrf9161dk/nrf9161
     tags: b0 bl_validation sysbuild

--- a/tests/subsys/bootloader/bl_validation_ff_key/testcase.yaml
+++ b/tests/subsys/bootloader/bl_validation_ff_key/testcase.yaml
@@ -1,13 +1,20 @@
 tests:
   bootloader.bl_validation.ff_key:
     sysbuild: true
-    platform_allow: nrf9160dk/nrf9160 nrf52840dk/nrf52840 nrf52dk/nrf52832
-      nrf5340dk/nrf5340/cpuapp
-    integration_platforms:
-      - nrf9160dk/nrf9160
+    platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
+      - nrf9151dk/nrf9151
+      - nrf9160dk/nrf9160
+      - nrf9161dk/nrf9161
+    integration_platforms:
+      - nrf52840dk/nrf52840
+      - nrf52dk/nrf52832
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9151dk/nrf9151
+      - nrf9160dk/nrf9160
+      - nrf9161dk/nrf9161
     tags: b0 bl_validation ff_key sysbuild
     harness: console
     harness_config:

--- a/tests/subsys/bootloader/bl_validation_neg/testcase.yaml
+++ b/tests/subsys/bootloader/bl_validation_neg/testcase.yaml
@@ -1,11 +1,16 @@
 tests:
   bootloader.bl_validation.negative:
     sysbuild: true
-    platform_allow: nrf9160dk/nrf9160
-      nrf5340dk/nrf5340/cpuapp
-    integration_platforms:
-      - nrf9160dk/nrf9160
+    platform_allow:
       - nrf5340dk/nrf5340/cpuapp
+      - nrf9151dk/nrf9151
+      - nrf9160dk/nrf9160
+      - nrf9161dk/nrf9161
+    integration_platforms:
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9151dk/nrf9151
+      - nrf9160dk/nrf9160
+      - nrf9161dk/nrf9161
     tags: b0 bl_validation negative bl_validation_negative sysbuild
     harness: console
     harness_config:
@@ -29,7 +34,9 @@ tests:
         - "No bootable image found. Aborting boot."
   bootloader.bl_validation.negative.nrf52:
     sysbuild: true
-    platform_allow: nrf52840dk/nrf52840 nrf52dk/nrf52832
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52dk/nrf52832
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832

--- a/tests/subsys/bootloader/bl_validation_unittest/testcase.yaml
+++ b/tests/subsys/bootloader/bl_validation_unittest/testcase.yaml
@@ -1,7 +1,10 @@
 tests:
   bootloader.bl_validation.unittest:
     sysbuild: true
-    platform_allow: native_posix
+    platform_allow:
+      - native_posix
+      - native_sim
     integration_platforms:
       - native_posix
+      - native_sim
     tags: b0 bl_validation unittest sysbuild

--- a/tests/subsys/bootloader/boot_chains/testcase.yaml
+++ b/tests/subsys/bootloader/boot_chains/testcase.yaml
@@ -22,7 +22,9 @@ tests:
       SB_CONFIG_BOOTLOADER_MCUBOOT=y
     platform_allow:
       nrf5340dk/nrf5340/cpuapp/ns
+      nrf9151dk/nrf9151/ns
       nrf9160dk/nrf9160/ns
+      nrf9161dk/nrf9161/ns
     tags: sysbuild
   boot_chains.secure_boot_and_bootloader_mcuboot:
     sysbuild: true
@@ -32,7 +34,9 @@ tests:
       SB_CONFIG_BOOTLOADER_MCUBOOT=y
     platform_allow:
       nrf5340dk/nrf5340/cpuapp/ns
+      nrf9151dk/nrf9151/ns
       nrf9160dk/nrf9160/ns
+      nrf9161dk/nrf9161/ns
     tags: sysbuild
   boot_chains.bootloader_mcuboot_and_nv_counters.sysbuild:
     sysbuild: true


### PR DESCRIPTION
- Add support for nRF9151 and nRF9161.
- Add native_sim support to bl_validation_unittest.