### PR TITLE
applications: nrf_desktop: Add USBHS init thread + nrf54H USBHS support

### DIFF
--- a/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/app.overlay
+++ b/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/app.overlay
@@ -51,6 +51,14 @@
 			label = "Green LED 3";
 		};
 	};
+
+	hid_dev_0: hid_dev_0 {
+		compatible = "zephyr,hid-device";
+		interface-name = "HID0";
+		protocol-code = "mouse";
+		in-polling-rate = <125>;
+		in-report-size = <64>;
+	};
 };
 
 &cpusec_cpuapp_ipc {

--- a/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/prj.conf
+++ b/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/prj.conf
@@ -51,6 +51,13 @@ CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE=y
 # Power management is not supported on this target.
 CONFIG_DESKTOP_POWER_MANAGER=n
 
+# Application supports 2 HID subscribers: HID over GATT (BLE) and a single USB HID instance
+CONFIG_DESKTOP_HID_STATE_SUBSCRIBER_COUNT=2
+
+CONFIG_DESKTOP_USB_ENABLE=y
+# Enable the only USB stack that supports USBHS
+CONFIG_DESKTOP_USB_STACK_NEXT=y
+
 ################################################################################
 # Zephyr Configuration
 

--- a/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/prj_release.conf
+++ b/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/prj_release.conf
@@ -42,6 +42,13 @@ CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE=y
 # Power management is not supported on this target.
 CONFIG_DESKTOP_POWER_MANAGER=n
 
+# Application supports 2 HID subscribers: HID over GATT (BLE) and a single USB HID instance
+CONFIG_DESKTOP_HID_STATE_SUBSCRIBER_COUNT=2
+
+CONFIG_DESKTOP_USB_ENABLE=y
+# Enable the only USB stack that supports USBHS
+CONFIG_DESKTOP_USB_STACK_NEXT=y
+
 ################################################################################
 # Zephyr Configuration
 

--- a/applications/nrf_desktop/src/modules/Kconfig.usb_state
+++ b/applications/nrf_desktop/src/modules/Kconfig.usb_state
@@ -47,6 +47,37 @@ config DESKTOP_USB_PM_ENABLE
 	help
 	  This enables small module that blocks power down if the USB is active.
 
+config DESKTOP_USB_INIT_THREAD
+	bool
+	default y if SOC_SERIES_NRF54HX
+	help
+	  Initialize USB stack in a separate thread instead of doing it in
+	  the context of the system workqueue.
+	  For the nRF54HX SoC use-case, the usbd_init() function blocks while
+	  waiting for a synchronization object that is received after the system
+	  controller sends the USB service event through the NRFS and IPC with
+	  the ICMSG backend to the application core.
+	  The ICMSG backend uses the system workqueue context for both
+	  initialization and on the incoming message handling, so calling the
+	  usbd_init() function from the same context causes deadlock during
+	  application boot.
+
+config DESKTOP_USB_INIT_THREAD_STACK_SIZE
+	int
+	default 2048
+
+config DESKTOP_USB_INIT_THREAD_PRIORITY
+	int
+	default 0
+
+config DESKTOP_USB_INIT_THREAD_DELAY_MS
+	int
+	default 1
+	help
+	  Due to an issue in the USB stack initialization on the nRF54HX SoC,
+	  the usbd_init() cannot be called too early. The delay is introduced
+	  to delay this call.
+
 choice DESKTOP_USB_STACK
 	prompt "USB stack"
 	default DESKTOP_USB_STACK_LEGACY


### PR DESCRIPTION
**Yet to be done:**

- [x] **Fix errors on release configuration - for some reason USB is not working there - PC doesn't see it.**

Adds nRF54H USBHS support.

Problems with USB initialization on nRF54H.
For the nRF54HX SoC use-case, the usb_init() function blocks while waiting for a synchronization object that is received after the system controller sends the USB service event through the NRFS and IPC with the ICMSG backend to the application core.
The ICMSG backend uses the system workqueue context for both, initialization and on the incoming message handling so calling the usb_init() function from the same context causes deadlock during application boot.
Workaround: Delay usb_init and execute in other thread rather than in system workqueue.

Jira: NCSDK-27010
Jira: NCSDK-22779