### PR TITLE
shields: nrf54l15pdk: Fix RAM overflow

### DIFF
--- a/boards/shields/nrf700x_nrf54l15pdk/nrf700x_nrf54l15pdk.overlay
+++ b/boards/shields/nrf700x_nrf54l15pdk/nrf700x_nrf54l15pdk.overlay
@@ -6,6 +6,8 @@
 #include <freq.h>
 
 / {
+	/* Wi-Fi doesn't needs this and it frees up 68K RAM */
+	/delete-node/ cpuflpr_sram;
 	nordic_wlan0: nordic_wlan0 {
 			compatible = "nordic,wlan0";
 			status = "okay";
@@ -28,6 +30,11 @@
 		max-pwr-5g-high-mcs0 = <0x30>;
 		max-pwr-5g-high-mcs7 = <0x30>;
 	};
+};
+
+&cpuapp_sram {
+	reg = <0x20000000 DT_SIZE_K(256)>;
+	ranges = <0x0 0x20000000 0x20040000>;
 };
 
 &pinctrl {

--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -11,12 +11,6 @@
   comment: "https://nordicsemi.atlassian.net/browse/KRKNWK-19027"
 
 - scenarios:
-    - sample.nrf7002eb.nrf54l15pdk.shell
-  platforms:
-    - nrf54l15pdk/nrf54l15/cpuapp
-  comment: "Till Wi-Fi RAM optimizations are merged"
-
-- scenarios:
     - sample.nrf54h20dk_nrf7002ek.shell
   platforms:
     - nrf54h20dk/nrf54h20/cpuapp


### PR DESCRIPTION
Remove FLPR RAM partition as Wi-Fi doesn't use to fix the RAM overflow.

Fixes SHEL-2832.