### PR TITLE
net: lib: nrf_cloud: Add option to specify content format

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -924,6 +924,7 @@ Libraries for networking
     * Deprecated :kconfig:option:`CONFIG_NRF_CLOUD_SEND_SERVICE_INFO_UI` and its related UI Kconfig options.
     * Deprecated the :c:struct:`nrf_cloud_svc_info_ui` structure contained in the :c:struct:`nrf_cloud_svc_info` structure.
       nRF Cloud no longer uses the UI section in the shadow.
+    * The :c:func:`nrf_cloud_coap_shadow_get` function to include a parameter to specify the content format of the returned payload.
 
 * :ref:`lib_mqtt_helper` library:
 

--- a/include/net/nrf_cloud_coap.h
+++ b/include/net/nrf_cloud_coap.h
@@ -23,6 +23,7 @@ extern "C" {
 #include <net/nrf_cloud_pgps.h>
 #endif
 #include <net/nrf_cloud_codec.h>
+#include <zephyr/net/coap.h>
 
 /**
  * @defgroup nrf_cloud_coap nRF CoAP API
@@ -295,16 +296,20 @@ int nrf_cloud_coap_fota_job_update(const char *const job_id,
  * in buf will be 0.
  *
  * @param[in,out] buf     Pointer to memory in which to receive the delta.
- * @param[in]     buf_len Size of buffer.
+ * @param[in,out] buf_len Size of buffer, will be set to the incoming length.
  * @param[in]     delta   True to request only changes in the shadow, if any; otherwise,
  *                        all of desired part.
+ * @param[in]     format  Content format of the returned data. Supported values are
+ *			  COAP_CONTENT_FORMAT_APP_OCTET_STREAM, COAP_CONTENT_FORMAT_APP_JSON,
+ *			  and COAP_CONTENT_FORMAT_APP_CBOR.
  *
  * @return 0 If successful, nonzero if failed.
  *           Negative values are device-side errors defined in errno.h.
  *           Positive values are cloud-side errors (CoAP result codes)
  *           defined in zephyr/net/coap.h.
  */
-int nrf_cloud_coap_shadow_get(char *buf, size_t buf_len, bool delta);
+int nrf_cloud_coap_shadow_get(char *buf, size_t *buf_len, bool delta,
+			      enum coap_content_format format);
 
 /**
  * @brief Update the device's "reported state" in the shadow through the state/update CoAP resource.

--- a/samples/cellular/nrf_cloud_multi_service/src/shadow_support_coap.c
+++ b/samples/cellular/nrf_cloud_multi_service/src/shadow_support_coap.c
@@ -74,13 +74,14 @@ static int check_shadow(void)
 
 	int err;
 	char buf[COAP_SHADOW_MAX_SIZE] = {0};
+	size_t length = sizeof(buf);
 	struct nrf_cloud_data in_data = {
 		.ptr = buf
 	};
 
 	LOG_INF("Checking for shadow delta...");
 
-	err = nrf_cloud_coap_shadow_get(buf, sizeof(buf), true);
+	err = nrf_cloud_coap_shadow_get(buf, &length, true, COAP_CONTENT_FORMAT_APP_JSON);
 	if (err == -EACCES) {
 		LOG_DBG("Not connected yet.");
 		return err;
@@ -89,7 +90,7 @@ static int check_shadow(void)
 		return err;
 	}
 
-	in_data.len = strlen(buf);
+	in_data.len = length;
 
 	err = process_delta(&in_data);
 	if (err == -ENODATA) {


### PR DESCRIPTION
Add option to specify content format in nrf_cloud_coap_shadow_get(). Also, make the length argument a pointer to an integer, so that the function can return the actual length of the payload.