### PR TITLE
manifest: sdk-zephyr: add support for fast SPIM12x instances

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: c0e08266a73496e70a6b44331b79e03bc55507b6
+      revision: 0741603bf0c4d571b9fa22ef1fc9c95a8d4c104b
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Updated sdk-zephyr revision contains support for nRF54H20 fast SPIM12x instances.