### PR TITLE
samples: matter: fix CredentialsManager credentials clearing

### DIFF
--- a/samples/matter/lock/src/access/access_manager_credentials.cpp
+++ b/samples/matter/lock/src/access/access_manager_credentials.cpp
@@ -151,8 +151,9 @@ template <CredentialsBits CRED_BIT_MASK> bool AccessManager<CRED_BIT_MASK>::Clea
 	return mCredentials.ForEach([](DoorLockData::Credential &credential, uint8_t credIdx) {
 		/* At this point the door-lock-server already invalidated both mCreatedBy and mLastModifiedBy
 		    of all credentials assigned to the fabric which is currently being removed */
-		if (credential.mInfo.mFields.mCreatedBy == kUndefinedFabricIndex ||
-		    credential.mInfo.mFields.mLastModifiedBy == kUndefinedFabricIndex) {
+		if (credential.mInfo.mFields.mCreatedBy == kUndefinedFabricIndex &&
+		    credential.mInfo.mFields.mLastModifiedBy == kUndefinedFabricIndex &&
+		    credential.mSecret.mDataLength != 0) {
 			return Instance().ClearCredential(credential, credIdx);
 		}
 		return true;


### PR DESCRIPTION
... on fabric removal. This patch makes sure that we don't overwrite the credentials that are not supposed to be cleared when the given fabric is removed.