### PR TITLE
manifest: sdk-zephyr: Pull fix for filter settings

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: c0e08266a73496e70a6b44331b79e03bc55507b6
+      revision: bf1bd22933927d0444bede472f363cd029262d11
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
The filter settings for control and data are set incorrectly. The change pulls in that fix for setting data and control filter settings properly for sniffer operation

Resolves SHEL-2790