### PR TITLE
net: lwm2m_client_utils: Enable SO_KEEPOPEN

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -916,6 +916,7 @@ Libraries for networking
 
   * :c:func:`lwm2m_init_firmware` is deprecated in favour of :c:func:`lwm2m_init_firmware_cb` that allows application to set a callback to receive FOTA events.
   * Fixed an issue where the Location Area Code was not updated when the Connection Monitor object version 1.3 was enabled.
+  * Added support for the ``SO_KEEPOPEN`` socket option to keep the socket open even during PDN disconnect and reconnect.
 
 * :ref:`lib_nrf_cloud_pgps` library:
 

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_security.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_security.c
@@ -711,6 +711,17 @@ static int set_socketoptions(struct lwm2m_ctx *ctx)
 		purge_sessions = false;
 	}
 
+	if (IS_ENABLED(CONFIG_SOC_NRF9120)) {
+		/* Modem FW 2.0.1 allows keeping the socket open while PDN is down, or modem
+		 * is in flight mode.
+		 */
+		ret = zsock_setsockopt(ctx->sock_fd, SOL_SOCKET, SO_KEEPOPEN, &(int){1},
+				       sizeof(int));
+		if (ret) {
+			LOG_ERR("Failed to set SO_KEEPOPEN: %d", errno);
+		}
+	}
+
 	return lwm2m_set_default_sockopt(ctx);
 }
 


### PR DESCRIPTION
Enable socket option SO_KEEPOPEN for hardware that supports modem FW 2.0.1.

This allows LwM2M engine to resume DTLS CID connection even after network have been lost for a while.