### PR TITLE
cmake: sysbuild: Align zip.cmake for MCUboot with new manifest format

### DIFF
--- a/cmake/sysbuild/zip.cmake
+++ b/cmake/sysbuild/zip.cmake
@@ -13,35 +13,38 @@ function(dfu_app_zip_package)
   sysbuild_get(CONFIG_KERNEL_BIN_NAME IMAGE ${DEFAULT_IMAGE} VAR CONFIG_KERNEL_BIN_NAME KCONFIG)
 
   if(SB_CONFIG_DFU_ZIP_APP)
+    set(app_update_name "${DEFAULT_IMAGE}.bin")
+    set(secondary_app_update_name mcuboot_secondary_app.bin)
+
     if(NOT SB_CONFIG_MCUBOOT_BUILD_DIRECT_XIP_VARIANT)
       # Application
       set(generate_script_app_params
-          "${DEFAULT_IMAGE}.binload_address=$<TARGET_PROPERTY:partition_manager,PM_APP_ADDRESS>"
-          "${DEFAULT_IMAGE}.binimage_index=0"
-          "${DEFAULT_IMAGE}.binslot_index_primary=1"
-          "${DEFAULT_IMAGE}.binslot_index_secondary=2"
-          "${DEFAULT_IMAGE}.binversion_MCUBOOT=${CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION}"
+          "${app_update_name}load_address=$<TARGET_PROPERTY:partition_manager,PM_APP_ADDRESS>"
+          "${app_update_name}image_index=0"
+          "${app_update_name}slot_index_primary=1"
+          "${app_update_name}slot_index_secondary=2"
+          "${app_update_name}version_MCUBOOT=${CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION}"
          )
       list(APPEND bin_files "${DEFAULT_IMAGE}/zephyr/${CONFIG_KERNEL_BIN_NAME}.signed.bin")
-      list(APPEND zip_names "${DEFAULT_IMAGE}.bin")
+      list(APPEND zip_names ${app_update_name})
       list(APPEND signed_targets ${DEFAULT_IMAGE}_extra_byproducts)
       set(exclude_files EXCLUDE ${DEFAULT_IMAGE}/zephyr/${CONFIG_KERNEL_BIN_NAME}.signed.bin)
       set(include_files INCLUDE ${DEFAULT_IMAGE}/zephyr/${CONFIG_KERNEL_BIN_NAME}.bin)
     else()
       # Application in DirectXIP mode
       set(generate_script_app_params
-          "${DEFAULT_IMAGE}load_address=$<TARGET_PROPERTY:partition_manager,PM_MCUBOOT_PRIMARY_APP_ADDRESS>"
-          "${DEFAULT_IMAGE}version_MCUBOOT+XIP=${CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION}"
-          "${DEFAULT_IMAGE}slot=0"
-          "mcuboot_secondary_app.binload_address=$<TARGET_PROPERTY:partition_manager,PM_MCUBOOT_SECONDARY_APP_ADDRESS>"
-          "mcuboot_secondary_app.binslot=1"
-          "mcuboot_secondary_app.binversion_MCUBOOT+XIP=${CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION}"
-          "load_address=$<TARGET_PROPERTY:partition_manager,PM_APP_ADDRESS>"
-          "version_MCUBOOT=${CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION}"
+          "${app_update_name}load_address=$<TARGET_PROPERTY:partition_manager,PM_MCUBOOT_PRIMARY_APP_ADDRESS>"
+          "${app_update_name}version_MCUBOOT+XIP=${CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION}"
+          "${app_update_name}image_index=0"
+          "${app_update_name}slot=0"
+          "${secondary_app_update_name}load_address=$<TARGET_PROPERTY:partition_manager,PM_MCUBOOT_SECONDARY_APP_ADDRESS>"
+          "${secondary_app_update_name}image_index=0"
+          "${secondary_app_update_name}slot=1"
+          "${secondary_app_update_name}version_MCUBOOT+XIP=${CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION}"
          )
 
       list(APPEND bin_files "${DEFAULT_IMAGE}/zephyr/${CONFIG_KERNEL_BIN_NAME}.signed.bin;mcuboot_secondary_app/zephyr/${CONFIG_KERNEL_BIN_NAME}.signed.bin")
-      list(APPEND zip_names "${DEFAULT_IMAGE}.bin;mcuboot_secondary_app.bin")
+      list(APPEND zip_names "${app_update_name};${secondary_app_update_name}")
       list(APPEND signed_targets ${DEFAULT_IMAGE}_extra_byproducts mcuboot_secondary_app_extra_byproducts)
       set(exclude_files EXCLUDE ${DEFAULT_IMAGE}/zephyr/${CONFIG_KERNEL_BIN_NAME}.signed.bin;mcuboot_secondary_app/zephyr/${CONFIG_KERNEL_BIN_NAME}.signed.bin)
       set(include_files INCLUDE ${DEFAULT_IMAGE}/zephyr/${CONFIG_KERNEL_BIN_NAME}.bin;mcuboot_secondary_app/zephyr/${CONFIG_KERNEL_BIN_NAME}.bin)
@@ -51,19 +54,21 @@ function(dfu_app_zip_package)
   if(SB_CONFIG_DFU_ZIP_NET)
     # Network core
     get_property(image_name GLOBAL PROPERTY DOMAIN_APP_CPUNET)
+    set(net_update_name "${image_name}.bin")
     sysbuild_get(net_core_board IMAGE ${image_name} VAR BOARD CACHE)
+    sysbuild_get(net_update_version IMAGE ${image_name} VAR CONFIG_FW_INFO_FIRMWARE_VERSION KCONFIG)
     set(generate_script_app_params
         ${generate_script_app_params}
-        "${image_name}.binimage_index=1"
-        "${image_name}.binslot_index_primary=3"
-        "${image_name}.binslot_index_secondary=4"
-        "${image_name}.binload_address=$<TARGET_PROPERTY:partition_manager,CPUNET_PM_APP_ADDRESS>"
-        "${image_name}.binboard=${net_core_board}"
-#        "${image_name}.binversion=${net_core_version}"
-        "${image_name}.binsoc=${SB_CONFIG_SOC}"
+        "${net_update_name}image_index=1"
+        "${net_update_name}slot_index_primary=3"
+        "${net_update_name}slot_index_secondary=4"
+        "${net_update_name}load_address=$<TARGET_PROPERTY:partition_manager,CPUNET_PM_APP_ADDRESS>"
+        "${net_update_name}version=${net_update_version}"
+        "${net_update_name}board=${net_core_board}"
+        "${net_update_name}soc=${SB_CONFIG_SOC}"
        )
     list(APPEND bin_files "signed_by_mcuboot_and_b0_${image_name}.bin")
-    list(APPEND zip_names "${image_name}.bin")
+    list(APPEND zip_names "${net_update_name}")
     list(APPEND signed_targets ${image_name}_extra_byproducts ${image_name}_signed_packaged_target)
   endif()
 


### PR DESCRIPTION
Change ensures that manifest.json included in the dfu_application.zip follows the agreed format.

Jira: NCSDK-27569