### PR TITLE
CODEOWNERS: Overhaul in order to enable required reviews

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -20,7 +20,7 @@ Kconfig*                                  @nrfconnect/ncs-co-build-system
 /README.rst                               @carlescufi
 /VERSION                                  @nrfconnect/ncs-code-owners
 /west.yml                                 @nrfconnect/ncs-code-owners
-/west-test.yml                            @thst-nordic
+
 
 # Dot folders
 /.github/                                 @nrfconnect/ncs-ci
@@ -221,16 +221,18 @@ Kconfig*                                  @nrfconnect/ncs-co-build-system
 
 # Scripts
 /scripts/                                 @nrfconnect/ncs-code-owners
-/scripts/quarantine*.yaml                 @nrfconnect/ncs-test-leads
-/scripts/hid_configurator/                @MarekPieta
-/scripts/tools-versions-*.txt             @nrfconnect/ncs-co-build-system @grho @shanthanordic @ihansse
-/scripts/requirements-*.txt               @nrfconnect/ncs-co-build-system @grho @shanthanordic @ihansse
-/scripts/west_commands/sbom/              @doki-nordic @maje-emb
-/scripts/west_commands/thingy91x_dfu.py   @nrfconnect/ncs-cia
 /scripts/bootloader/                      @hakonfam @sigvartmh
+/scripts/docker/                          @nrfconnect/ncs-ci
+/scripts/hid_configurator/                @MarekPieta
 /scripts/ncs-docker-version.txt           @nrfconnect/ncs-ci
 /scripts/print_docker_image.sh            @nrfconnect/ncs-ci
 /scripts/print_toolchain_checksum.sh      @nrfconnect/ncs-ci
+/scripts/quarantine*.yaml                 @nrfconnect/ncs-test-leads
+/scripts/ncs-toolchain-version-minimum.txt @nrfconnect/ncs-co-build-system @nrfconnect/ncs-ci 
+/scripts/requirements-*.txt               @nrfconnect/ncs-co-build-system @nrfconnect/ncs-ci
+/scripts/tools-versions-*.txt             @nrfconnect/ncs-co-build-system @nrfconnect/ncs-ci
+/scripts/west_commands/sbom/              @doki-nordic @maje-emb
+/scripts/west_commands/thingy91x_dfu.py   @nrfconnect/ncs-cia
 
 # Share
 /share/			                  @nrfconnect/ncs-co-build-system
@@ -382,7 +384,8 @@ Kconfig*                                  @nrfconnect/ncs-co-build-system
 /tests/unity/                             @nordic-krch
 
 # CI specific west
-/test-manifests/99-default-test-nrf.yml   @thst-nordic
+/test-manifests/99-default-test-nrf.yml   @nrfconnect/ncs-ci
+/west-test.yml                            @nrfconnect/ncs-ci
 
 # Zephyr module
 /zephyr/                                  @nrfconnect/ncs-co-build-system

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,90 +4,79 @@
 # Order is important; the last matching pattern takes the most
 # precedence.
 
+# General default
+*					  @nrfconnect/ncs-code-owners
+
+# Global file patterns
+Kconfig*                                  @nrfconnect/ncs-co-build-system
+
 # Root folder
-/VERSION                                  @carlescufi @tejlmand
-/ncs_version.h.in                         @carlescufi @tejlmand
-/CODEOWNERS                               @carlescufi
+/.*					  @nrfconnect/ncs-code-owners
+/CMakeLists.txt                           @nrfconnect/ncs-co-build-system
+/CODEOWNERS                               @nrfconnect/ncs-code-owners
+/Jenkinsfile                              @nrfconnect/ncs-ci
+/ncs_version.h.in                         @nrfconnect/ncs-code-owners
 /LICENSE                                  @carlescufi
 /README.rst                               @carlescufi
-/Jenkinsfile                              @thst-nordic
-/west.yml                                 @carlescufi @tejlmand
+/VERSION                                  @nrfconnect/ncs-code-owners
+/west.yml                                 @nrfconnect/ncs-code-owners
 /west-test.yml                            @thst-nordic
 
-# CI specific west
-/test-manifests/99-default-test-nrf.yml     @thst-nordic
-
-# Github Actions
+# Dot folders
 /.github/                                 @nrfconnect/ncs-ci
 /.github/test-spec.yml                    @nrfconnect/ncs-test-leads
-
-# Quarantine for the CI and Twister
-/scripts/quarantine.yaml                  @nrfconnect/ncs-test-leads
-
-# VS Code Configuration files
 /.vscode/                                 @FilipZajdel
 
 # Applications
+/applications/				  @nrfconnect/ncs-code-owners
 /applications/asset_tracker_v2/           @nrfconnect/ncs-cia @coderbyheart
 /applications/connectivity_bridge/        @nrfconnect/ncs-cia @nordic-auko
 /applications/ipc_radio/                  @dchat-nordic
 /applications/machine_learning/           @pdunaj
 /applications/matter_bridge/              @nrfconnect/ncs-matter
 /applications/matter_weather_station/     @nrfconnect/ncs-matter
-/applications/nrf_desktop/                @MarekPieta
 /applications/nrf5340_audio/              @nrfconnect/ncs-audio
-/applications/serial_lte_modem/           @SeppoTakalo @MarkusLassila @rlubos @tomi-font
+/applications/nrf_desktop/                @MarekPieta
+/applications/serial_lte_modem/           @nrfconnect/ncs-co-networking @SeppoTakalo @MarkusLassila @tomi-font
 /applications/zigbee_weather_station/     @milewr
+/applications/**/*.rst                    @nrfconnect/ncs-doc-owners
+
 # Boards
-/boards/                                  @anangl
-/boards/nordic/thingy91*                  @anangl @nrfconnect/ncs-cia
+/boards/                                  @nrfconnect/ncs-co-boards
+/boards/nordic/thingy91*                  @nrfconnect/ncs-co-boards @nrfconnect/ncs-cia
+
 # All cmake related files
-/cmake/                                   @tejlmand
-/CMakeLists.txt                           @tejlmand
-# All Kconfig related files
-Kconfig*                                  @tejlmand
-# Sysbuild related files
-/sysbuild/                                @tejlmand @nordicjm
-/cmake/sysbuild/                          @tejlmand @nordicjm
+/cmake/                                   @nrfconnect/ncs-co-build-system
+/cmake/sysbuild/suit.cmake                @nrfconnect/ncs-charon
+/cmake/sysbuild/suit_utilities.cmake      @nrfconnect/ncs-charon
+
 # All doc related files
-/doc/_extensions/                         @gmarull
-/doc/_scripts/                            @carlescufi
-/doc/_static/                             @carlescufi
-/doc/_utils/                              @gmarull
-/doc/cache.yml                            @gmarull
-/doc/CMakeLists.txt                       @carlescufi
-/doc/**/conf.py                           @carlescufi
-/doc/kconfig/                             @gmarull
-/doc/nrf/                                 @carlescufi
+/doc/					  @nrfconnect/ncs-co-doc
+/doc/tags.yml                             @nrfconnect/ncs-co-doc @umapraseeda @b-gent
+/doc/**/*.rst				  @nrfconnect/ncs-doc-owners
+/doc/**/*.svg				  @nrfconnect/ncs-doc-owners
+/doc/**/*.png				  @nrfconnect/ncs-doc-owners
+/doc/nrf/protocols/thread/*.rst           @wiba-nordic
 /doc/nrf/device_guides/working_with_nrf/nrf54h/  @FrancescoSer
 /doc/nrf/device_guides/working_with_nrf/nrf54l/ @annwoj
-/doc/nrfx/                                @gmarull
-/doc/matter/                              @gmarull
-/doc/mcuboot/                             @carlescufi
-/doc/nrfxlib/                             @gmarull
-/doc/versions.json                        @carlescufi
-/doc/custom.properties                    @gmarull
-/doc/tags.yml                             @gmarull @umapraseeda @b-gent
-/doc/requirements.txt                     @gmarull
-# General top-level docs
-/doc/nrf/config_and_build/                @greg-fer
-/doc/nrf/installation/                    @greg-fer
-/doc/nrf/security/                        @greg-fer
-/doc/nrf/test_and_optimize/               @greg-fer
-/doc/nrf/*.rst                            @greg-fer
-# Protocols related docs
-/doc/nrf/protocols/thread/*.rst           @wiba-nordic
-# All subfolders
-/drivers/                                 @anangl
-/drivers/serial/                          @nordic-krch @anangl
-/drivers/sensor/bh1749/                   @nrfconnect/ncs-cia
-/drivers/sensor/bme68x_iaq/               @nrfconnect/ncs-cia
-/drivers/sensor/paw3212/                  @anangl @pdunaj @MarekPieta
-/drivers/sensor/pmw3360/                  @anangl @pdunaj @MarekPieta
-/drivers/wifi/nrf700x/                    @krish2718 @sachinthegreen @rado17 @rlubos
-/dts/                                     @anangl
+
+# Drivers
+/drivers/                                 @nrfconnect/ncs-co-drivers
+/drivers/serial/                          @nrfconnect/ncs-co-drivers @nordic-krch
+/drivers/sensor/bh1749/                   @nrfconnect/ncs-co-drivers @nrfconnect/ncs-cia
+/drivers/sensor/bme68x_iaq/               @nrfconnect/ncs-co-drivers @nrfconnect/ncs-cia
+/drivers/sensor/paw3212/                  @nrfconnect/ncs-co-drivers @pdunaj @MarekPieta
+/drivers/sensor/pmw3360/                  @nrfconnect/ncs-co-drivers @pdunaj @MarekPieta
+/drivers/wifi/nrf700x/                    @nrfconnect/ncs-co-networking @krish2718 @sachinthegreen @rado17
+
+# Devicetree
+/dts/                                     @nrfconnect/ncs-co-drivers
+
+# External
 /ext/                                     @carlescufi
-/include/                                 @anangl @rlubos
+
+# Include
+/include/                                 @nrfconnect/ncs-code-owners
 /include/net/azure_*                      @nrfconnect/ncs-cia @coderbyheart
 /include/net/wifi_credentials.h           @nrfconnect/ncs-cia
 /include/net/nrf_cloud_*                  @plskeggs @jayteemo @glarsennordic
@@ -96,24 +85,32 @@ Kconfig*                                  @tejlmand
 /include/bluetooth/adv_prov.h             @MarekPieta @kapi-no @KAGA164
 /include/bluetooth/mesh/                  @ludvigsj
 /include/caf/                             @pdunaj
-/include/debug/ppi_trace.h                @nordic-krch @anangl
-/include/drivers/                         @anangl
+/include/debug/ppi_trace.h                @nrfconnect/ncs-co-drivers @nordic-krch
+/include/dfu/dfu_target_suit.h            @nrfconnect/ncs-charon
+/include/dfu/suit_dfu_fetch_source.h      @nrfconnect/ncs-charon
+/include/dfu/suit_dfu.h                   @nrfconnect/ncs-charon
+/include/drivers/                         @nrfconnect/ncs-co-drivers
 /include/dult.h                           @alstrzebonski @kapi-no
 /include/mpsl/                            @nrfconnect/ncs-dragoon
-/include/net/                             @rlubos
-/include/nfc/                             @anangl @grochu
+/include/net/                             @nrfconnect/ncs-co-networking
+/include/nfc/                             @nrfconnect/ncs-co-drivers @grochu
 /include/sdfw/                            @anhmolt @hakonfam @jonathannilsen
+/include/sdfw/sdfw_services/extmem_remote.h @nrfconnect/ncs-charon
+/include/sdfw/sdfw_services/suit_service.h @nrfconnect/ncs-charon
 /include/shell/                           @nordic-krch
-/lib/bin/                                 @rlubos @lemrey
+
+# Libraries
+/lib/					  @nrfconnect/ncs-code-owners
+/lib/bin/                                 @nrfconnect/ncs-co-networking @lemrey
 /lib/boot_banner/                         @nordicjm
 /lib/adp536x/                             @nrfconnect/ncs-cia
-/lib/at_cmd_parser/                       @rlubos
+/lib/at_cmd_parser/                       @nrfconnect/ncs-co-networking
 /lib/at_cmd_custom/                       @eivindj-nordic
-/lib/at_host/                             @rlubos
-/lib/at_monitor/                          @lemrey @rlubos
+/lib/at_host/                             @nrfconnect/ncs-co-networking
+/lib/at_monitor/                          @nrfconnect/ncs-co-networking @lemrey
 /lib/at_shell/                            @nrfconnect/ncs-cia
 /lib/gcf_sms/                             @eivindj-nordic
-/lib/nrf_modem_lib/                       @rlubos @lemrey
+/lib/nrf_modem_lib/                       @nrfconnect/ncs-co-networking @lemrey
 /lib/edge_impulse/                        @pdunaj
 /lib/fem_al/                              @KAGA164
 /lib/fprotect/                            @hakonfam
@@ -122,16 +119,16 @@ Kconfig*                                  @tejlmand
 /lib/lte_link_control/                    @tokangas @trantanen @jhirsi
 /lib/modem_antenna/                       @tokangas
 /lib/modem_battery/                       @MirkoCovizzi
-/lib/modem_info/                          @rlubos
-/lib/modem_key_mgmt/                      @rlubos
+/lib/modem_info/                          @nrfconnect/ncs-co-networking
+/lib/modem_key_mgmt/                      @nrfconnect/ncs-co-networking
 /lib/multithreading_lock/                 @nrfconnect/ncs-dragoon
-/lib/pdn/                                 @lemrey @rlubos
+/lib/pdn/                                 @nrfconnect/ncs-co-networking @lemrey
 /lib/ram_pwrdn/                           @MarekPorwisz
 /lib/fatal_error/                         @KAGA164 @nordic-krch
 /lib/sfloat/                              @kapi-no @maje-emb
 /lib/sms/                                 @trantanen @tokangas
 /lib/st25r3911b/                          @grochu
-/lib/supl/                                @rlubos @tokangas
+/lib/supl/                                @nrfconnect/ncs-co-networking @tokangas
 /lib/date_time/                           @trantanen @tokangas
 /lib/hw_id/                               @nrfconnect/ncs-cia
 /lib/wave_gen/                            @MarekPieta
@@ -147,13 +144,18 @@ Kconfig*                                  @tejlmand
 /lib/pcm_stream_channel_modifier/         @nrfconnect/ncs-audio
 /lib/sample_rate_converter/               @andvib @gWacey
 /lib/tone/                                @nrfconnect/ncs-audio
-/modules/                                 @tejlmand
-/modules/hostap/                          @krish2718 @jukkar @rado17 @sachinthegreen @rlubos
-/modules/mcuboot/                         @de-nordic @nordicjm
+
+# Modules
+/modules/                                 @nrfconnect/ncs-co-build-system
+/modules/hostap/                          @nrfconnect/ncs-co-networking @krish2718 @rado17 @sachinthegreen
+/modules/mcuboot/                         @nordicjm @de-nordic
 /modules/cjson/                           @nrfconnect/ncs-cia @plskeggs @sigvartmh
 /modules/trusted-firmware-m/              @frkv @Vge0rge @vili-nordic @mswarowsky
 /modules/coremark/                        @zycz
-/samples/                                 @nrfconnect/ncs-test-leads
+
+# Samples
+/samples/                                 @nrfconnect/ncs-code-owners
+/samples/CMakeLists.txt                   @nrfconnect/ncs-co-build-system
 /samples/net/                             @nrfconnect/ncs-cia @lemrey
 /samples/sensor/bh1749/                   @nrfconnect/ncs-cia
 /samples/sensor/bme68x_iaq/               @nrfconnect/ncs-cia
@@ -166,7 +168,7 @@ Kconfig*                                  @tejlmand
 /samples/matter/                          @nrfconnect/ncs-matter
 /samples/crypto/                          @frkv @Vge0rge @vili-nordic @mswarowsky
 /samples/debug/memfault/                  @nrfconnect/ncs-cia
-/samples/debug/ppi_trace/                 @nordic-krch @anangl
+/samples/debug/ppi_trace/                 @nordic-krch
 /samples/hw_id/                           @nrfconnect/ncs-cia
 /samples/edge_impulse/                    @pdunaj
 /samples/esb/                             @lemrey
@@ -178,10 +180,10 @@ Kconfig*                                  @tejlmand
 /samples/nfc/                             @grochu
 /samples/nrf_rpc/                         @doki-nordic @KAGA164
 /samples/nrf5340/empty_app_core/          @doki-nordic
-/samples/cellular/                        @rlubos @lemrey
+/samples/cellular/                        @nrfconnect/ncs-co-networking @lemrey
 /samples/cellular/battery/                @MirkoCovizzi
 /samples/cellular/location/               @trantanen @jhirsi @tokangas
-/samples/cellular/lwm2m_client/           @rlubos @SeppoTakalo @juhaylinen
+/samples/cellular/lwm2m_client/           @nrfconnect/ncs-co-networking @SeppoTakalo @juhaylinen
 /samples/cellular/modem_shell/            @trantanen @jhirsi @tokangas
 /samples/cellular/nidd/                   @stig-bjorlykke
 /samples/cellular/nrf_cloud_*             @plskeggs @jayteemo @glarsennordic
@@ -189,7 +191,7 @@ Kconfig*                                  @tejlmand
 /samples/cellular/modem_trace_flash/      @eivindj-nordic
 /samples/cellular/slm_shell/              @MarkusLassila @tomi-font
 /samples/cellular/sms/                    @trantanen @tokangas
-/samples/openthread/                      @rlubos @edmont @canisLupus1313 @maciejbaczmanski
+/samples/openthread/                      @nrfconnect/ncs-co-networking @edmont @canisLupus1313 @maciejbaczmanski
 /samples/nrf_profiler/                    @pdunaj
 /samples/peripheral/radio_test/           @KAGA164 @maje-emb
 /samples/peripheral/lpuart/               @nordic-krch
@@ -197,18 +199,16 @@ Kconfig*                                  @tejlmand
 /samples/peripheral/802154_sniffer/       @e-rk
 /samples/tfm/                             @frkv @Vge0rge @vili-nordic @mswarowsky
 /samples/zigbee/                          @milewr
-/samples/CMakeLists.txt                   @tejlmand
 /samples/nrf5340/netboot/                 @hakonfam
 /samples/nrf5340/multiprotocol_rpmsg/     @hubertmis
 /samples/sdfw/                            @hakonfam @jonathannilsen
 /samples/sdfw/ssf_client/                 @anhmolt
-/samples/suit/                            @tomchy @ahasztag
-/samples/suit/flash_companion/            @e-rk @tomchy
+/samples/suit/                            @nrfconnect/ncs-charon
 /samples/wifi/provisioning/ble/           @wentong-li @bama-nordic
 /samples/wifi/provisioning/softap/        @nrfconnect/ncs-cia
 /samples/wifi/radio_test/                 @bama-nordic @sachinthegreen
 /samples/wifi/scan/                       @D-Triveni @bama-nordic
-/samples/wifi/shell/                      @krish2718 @sachinthegreen @rado17 @rlubos
+/samples/wifi/shell/                      @nrfconnect/ncs-co-networking @krish2718 @sachinthegreen @rado17
 /samples/wifi/sta/                        @D-Triveni @bama-nordic
 /samples/wifi/ble_coex/                   @muraliThokala @bama-nordic
 /samples/wifi/shutdown/                   @krish2718 @sachinthegreen
@@ -219,25 +219,35 @@ Kconfig*                                  @tejlmand
 /samples/wifi/monitor/                    @D-Triveni
 /samples/wifi/promiscuous/                @D-Triveni
 /samples/benchmarks/coremark/             @zycz
-/scripts/                                 @tejlmand @nrfconnect/ncs-test-leads
+
+# Scripts
+/scripts/                                 @nrfconnect/ncs-code-owners
+/scripts/quarantine*.yaml                 @nrfconnect/ncs-test-leads
 /scripts/hid_configurator/                @MarekPieta
-/scripts/tools-versions-*.txt             @tejlmand @grho @shanthanordic @ihansse
-/scripts/requirements-*.txt               @tejlmand @grho @shanthanordic @ihansse
+/scripts/tools-versions-*.txt             @nrfconnect/ncs-co-build-system @grho @shanthanordic @ihansse
+/scripts/requirements-*.txt               @nrfconnect/ncs-co-build-system @grho @shanthanordic @ihansse
 /scripts/west_commands/sbom/              @doki-nordic @maje-emb
 /scripts/west_commands/thingy91x_dfu.py   @nrfconnect/ncs-cia
 /scripts/bootloader/                      @hakonfam @sigvartmh
 /scripts/ncs-docker-version.txt           @nrfconnect/ncs-ci
 /scripts/print_docker_image.sh            @nrfconnect/ncs-ci
 /scripts/print_toolchain_checksum.sh      @nrfconnect/ncs-ci
-/share/zephyrbuild-package/               @tejlmand
-/share/ncs-package/                       @tejlmand
-/snippets/matter-diagnostic-logs/         @nrfconnect/ncs-matter
+
+# Share
+/share/			                  @nrfconnect/ncs-co-build-system
+
+# Snippets
+/snippets/                                @nrfconnect/ncs-co-boards
 /snippets/nrf91-modem-trace-ext-flash/    @nrfconnect/ncs-cia
 /snippets/nrf91-modem-trace-uart/         @eivindj-nordic
 /snippets/tfm-enable-share-uart/          @nrfconnect/ncs-cia
 /snippets/nrf70-debug/                    @krish2718 @sachinthegreen
 /snippets/nrf70-fw-patch-ext-flash/       @krish2718 @sachinthegreen
 /snippets/nordic-bt-rpc/                  @ppryga-nordic
+/snippets/matter-diagnostic-logs/         @nrfconnect/ncs-matter
+
+# Subsystems
+/subsys/                                  @nrfconnect/ncs-code-owners
 /subsys/audio_module/                     @nrfconnect/ncs-audio
 /subsys/bluetooth/                        @alwa-nordic @jori-nordic @carlescufi @KAGA164
 /subsys/bluetooth/mesh/                   @ludvigsj
@@ -247,14 +257,14 @@ Kconfig*                                  @tejlmand
 /subsys/bluetooth/services/wifi_prov/     @wentong-li @bama-nordic
 /subsys/bootloader/                       @hakonfam @sigvartmh
 /subsys/caf/                              @pdunaj
-/subsys/debug/                            @nordic-krch @anangl
+/subsys/debug/                            @nordic-krch
 /subsys/dfu/                              @hakonfam @sigvartmh
 /subsys/dfu/dfu_multi_image/              @Damian-Nordic
 /subsys/dm/                               @maje-emb
 /subsys/dult/                             @alstrzebonski @kapi-no
-/subsys/ieee802154/                       @rlubos @ankuns @piotrkoziar
+/subsys/ieee802154/                       @nrfconnect/ncs-co-networking @ankuns @piotrkoziar
 /subsys/mgmt/                             @hakonfam @sigvartmh
-/subsys/mgmt/suitfu/                      @tomchy @ahasztag
+/subsys/mgmt/suitfu/                      @nrfconnect/ncs-charon
 /subsys/emds/                             @balaklaka
 /subsys/esb/                              @lemrey
 /subsys/app_event_manager/                @pdunaj
@@ -265,34 +275,42 @@ Kconfig*                                  @tejlmand
 /subsys/mpsl/                             @nrfconnect/ncs-dragoon
 /subsys/mpsl/cx/                          @ankuns @martintv
 /subsys/mpsl/fem/                         @ankuns @martintv
-/subsys/net/                              @rlubos
+/subsys/net/                              @nrfconnect/ncs-co-networking
 /subsys/net/lib/mqtt_helper/              @nrfconnect/ncs-cia
 /subsys/net/lib/azure_*                   @nrfconnect/ncs-cia @coderbyheart
 /subsys/net/lib/aws_*                     @nrfconnect/ncs-cia @coderbyheart
 /subsys/net/lib/ftp_client/               @MarkusLassila @tomi-font
 /subsys/net/lib/icalendar_parser/         @lats1980
-/subsys/net/lib/lwm2m_client_utils/       @rlubos @SeppoTakalo @juhaylinen
+/subsys/net/lib/lwm2m_client_utils/       @nrfconnect/ncs-co-networking @SeppoTakalo @juhaylinen
 /subsys/net/lib/nrf_cloud/                @plskeggs @jayteemo @glarsennordic
 /subsys/net/lib/nrf_provisioning/         @SeppoTakalo @juhaylinen
 /subsys/net/lib/zzhc/                     @junqingzou
 /subsys/net/lib/wifi_credentials/         @nrfconnect/ncs-cia
 /subsys/net/lib/softap_wifi_provision/    @nrfconnect/ncs-cia
-/subsys/net/openthread/                   @rlubos @edmont @canisLupus1313 @maciejbaczmanski
-/subsys/nfc/                              @grochu @anangl
+/subsys/net/openthread/                   @nrfconnect/ncs-co-networking @edmont @canisLupus1313 @maciejbaczmanski
+/subsys/nfc/                              @grochu
 /subsys/nrf_rpc/                          @doki-nordic @KAGA164
 /subsys/partition_manager/                @hakonfam
 /subsys/pcd/                              @hakonfam
 /subsys/nrf_profiler/                     @pdunaj
 /subsys/shell/                            @nordic-krch
 /subsys/sdfw_services/                    @anhmolt @hakonfam @jonathannilsen
-/subsys/sdfw_services/services/extmem/    @e-rk @tomchy
-/subsys/suit/                             @tomchy @ahasztag
+/subsys/sdfw_services/services/extmem/    @nrfconnect/ncs-charon
+/subsys/sdfw_services/services/suit_service/ @nrfconnect/ncs-charon
+/subsys/suit/                             @nrfconnect/ncs-charon
 /subsys/nrf_security/                     @frkv @Vge0rge @vili-nordic @mswarowsky
 /subsys/trusted_storage/                  @frkv @Vge0rge @vili-nordic @mswarowsky
 /subsys/uart_async_adapter/               @rakons
 /subsys/net_core_monitor/                 @maje-emb
 /subsys/zigbee/                           @milewr
-/tests/                                   @PerMac @katgiadla
+
+# Sysbuild
+/sysbuild/                                @nrfconnect/ncs-co-build-system
+/sysbuild/Kconfig.suit                    @nrfconnect/ncs-charon
+/sysbuild/suit.cmake                      @nrfconnect/ncs-charon
+
+# Tests
+/tests/                                   @nrfconnect/ncs-co-verification @katgiadla
 /tests/bluetooth/tester/                  @carlescufi @ludvigsj
 /tests/bluetooth/iso/                     @nrfconnect/ncs-audio @Frodevan
 /tests/crypto/                            @stephen-nordic @magnev
@@ -300,8 +318,8 @@ Kconfig*                                  @tejlmand
 /tests/drivers/flash/flash_rpc/           @sigvartmh
 /tests/drivers/fprotect/                  @oyvindronningstad
 /tests/drivers/lpuart/                    @nordic-krch
-/tests/drivers/nrfx_integration_test/     @anangl
-/tests/lib/at_cmd_parser/                 @rlubos
+/tests/drivers/nrfx_integration_test/     @nrfconnect/ncs-co-drivers
+/tests/lib/at_cmd_parser/                 @lemrey
 /tests/lib/at_cmd_custom/                 @eivindj-nordic
 /tests/lib/date_time/                     @trantanen @tokangas
 /tests/lib/edge_impulse/                  @pdunaj @MarekPieta
@@ -360,7 +378,12 @@ Kconfig*                                  @tejlmand
 /tests/subsys/nrf_profiler/               @pdunaj @MarekPieta
 /tests/subsys/sdfw_services/              @anhmolt @hakonfam @jonathannilsen
 /tests/subsys/zigbee/                     @milewr
-/tests/subsys/suit/                       @tomchy @ahasztag @robertstypa
+/tests/subsys/suit/                       @nrfconnect/ncs-charon
 /tests/tfm/                               @frkv @Vge0rge @vili-nordic @mswarowsky @stephen-nordic @magnev
 /tests/unity/                             @nordic-krch
-/zephyr/                                  @carlescufi
+
+# CI specific west
+/test-manifests/99-default-test-nrf.yml   @thst-nordic
+
+# Zephyr module
+/zephyr/                                  @nrfconnect/ncs-co-build-system

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -104,25 +104,25 @@ Kconfig*                                  @nrfconnect/ncs-co-build-system
 /lib/bin/                                 @nrfconnect/ncs-co-networking @lemrey
 /lib/boot_banner/                         @nordicjm
 /lib/adp536x/                             @nrfconnect/ncs-cia
-/lib/at_cmd_parser/                       @nrfconnect/ncs-co-networking
-/lib/at_cmd_custom/                       @eivindj-nordic
-/lib/at_host/                             @nrfconnect/ncs-co-networking
-/lib/at_monitor/                          @nrfconnect/ncs-co-networking @lemrey
+/lib/at_cmd_parser/                       @nrfconnect/ncs-co-networking @nrfconnect/ncs-modem
+/lib/at_cmd_custom/                       @nrfconnect/ncs-modem
+/lib/at_host/                             @nrfconnect/ncs-co-networking @nrfconnect/ncs-modem
+/lib/at_monitor/                          @nrfconnect/ncs-co-networking @nrfconnect/ncs-modem
 /lib/at_shell/                            @nrfconnect/ncs-cia
-/lib/gcf_sms/                             @eivindj-nordic
-/lib/nrf_modem_lib/                       @nrfconnect/ncs-co-networking @lemrey
+/lib/gcf_sms/                             @nrfconnect/ncs-modem
+/lib/nrf_modem_lib/                       @nrfconnect/ncs-co-networking @nrfconnect/ncs-modem
 /lib/edge_impulse/                        @pdunaj
 /lib/fem_al/                              @KAGA164
 /lib/fprotect/                            @hakonfam
 /lib/flash_patch/                         @hakonfam
 /lib/location/                            @trantanen @jhirsi @tokangas
-/lib/lte_link_control/                    @tokangas @trantanen @jhirsi
-/lib/modem_antenna/                       @tokangas
-/lib/modem_battery/                       @MirkoCovizzi
-/lib/modem_info/                          @nrfconnect/ncs-co-networking
-/lib/modem_key_mgmt/                      @nrfconnect/ncs-co-networking
+/lib/lte_link_control/                    @tokangas @trantanen @jhirsi @nrfconnect/ncs-modem
+/lib/modem_antenna/                       @tokangas @nrfconnect/ncs-modem
+/lib/modem_battery/                       @nrfconnect/ncs-modem
+/lib/modem_info/                          @nrfconnect/ncs-co-networking @nrfconnect/ncs-modem
+/lib/modem_key_mgmt/                      @nrfconnect/ncs-co-networking @nrfconnect/ncs-modem
 /lib/multithreading_lock/                 @nrfconnect/ncs-dragoon
-/lib/pdn/                                 @nrfconnect/ncs-co-networking @lemrey
+/lib/pdn/                                 @nrfconnect/ncs-co-networking @nrfconnect/ncs-modem
 /lib/ram_pwrdn/                           @MarekPorwisz
 /lib/fatal_error/                         @KAGA164 @nordic-krch
 /lib/sfloat/                              @kapi-no @maje-emb
@@ -156,7 +156,7 @@ Kconfig*                                  @nrfconnect/ncs-co-build-system
 # Samples
 /samples/                                 @nrfconnect/ncs-code-owners
 /samples/CMakeLists.txt                   @nrfconnect/ncs-co-build-system
-/samples/net/                             @nrfconnect/ncs-cia @lemrey
+/samples/net/                             @nrfconnect/ncs-cia @nrfconnect/ncs-modem
 /samples/sensor/bh1749/                   @nrfconnect/ncs-cia
 /samples/sensor/bme68x_iaq/               @nrfconnect/ncs-cia
 /samples/bluetooth/                       @alwa-nordic @jori-nordic @carlescufi @KAGA164
@@ -180,15 +180,14 @@ Kconfig*                                  @nrfconnect/ncs-co-build-system
 /samples/nfc/                             @grochu
 /samples/nrf_rpc/                         @doki-nordic @KAGA164
 /samples/nrf5340/empty_app_core/          @doki-nordic
-/samples/cellular/                        @nrfconnect/ncs-co-networking @lemrey
-/samples/cellular/battery/                @MirkoCovizzi
+/samples/cellular/                        @nrfconnect/ncs-co-networking @nrfconnect/ncs-modem
 /samples/cellular/location/               @trantanen @jhirsi @tokangas
 /samples/cellular/lwm2m_client/           @nrfconnect/ncs-co-networking @SeppoTakalo @juhaylinen
 /samples/cellular/modem_shell/            @trantanen @jhirsi @tokangas
 /samples/cellular/nidd/                   @stig-bjorlykke
 /samples/cellular/nrf_cloud_*             @plskeggs @jayteemo @glarsennordic
 /samples/cellular/nrf_provisioning/       @SeppoTakalo @juhaylinen
-/samples/cellular/modem_trace_flash/      @eivindj-nordic
+/samples/cellular/modem_trace_flash/      @nrfconnect/ncs-modem
 /samples/cellular/slm_shell/              @MarkusLassila @tomi-font
 /samples/cellular/sms/                    @trantanen @tokangas
 /samples/openthread/                      @nrfconnect/ncs-co-networking @edmont @canisLupus1313 @maciejbaczmanski
@@ -239,7 +238,7 @@ Kconfig*                                  @nrfconnect/ncs-co-build-system
 # Snippets
 /snippets/                                @nrfconnect/ncs-co-boards
 /snippets/nrf91-modem-trace-ext-flash/    @nrfconnect/ncs-cia
-/snippets/nrf91-modem-trace-uart/         @eivindj-nordic
+/snippets/nrf91-modem-trace-uart/         @nrfconnect/ncs-modem
 /snippets/tfm-enable-share-uart/          @nrfconnect/ncs-cia
 /snippets/nrf70-debug/                    @krish2718 @sachinthegreen
 /snippets/nrf70-fw-patch-ext-flash/       @krish2718 @sachinthegreen
@@ -319,26 +318,26 @@ Kconfig*                                  @nrfconnect/ncs-co-build-system
 /tests/drivers/fprotect/                  @oyvindronningstad
 /tests/drivers/lpuart/                    @nordic-krch
 /tests/drivers/nrfx_integration_test/     @nrfconnect/ncs-co-drivers
-/tests/lib/at_cmd_parser/                 @lemrey
-/tests/lib/at_cmd_custom/                 @eivindj-nordic
+/tests/lib/at_cmd_parser/                 @nrfconnect/ncs-modem
+/tests/lib/at_cmd_custom/                 @nrfconnect/ncs-modem
 /tests/lib/date_time/                     @trantanen @tokangas
 /tests/lib/edge_impulse/                  @pdunaj @MarekPieta
 /tests/lib/nrf_fuel_gauge/                @nordic-auko @aasinclair
-/tests/lib/gcf_sms/                       @eivindj-nordic
+/tests/lib/gcf_sms/                       @nrfconnect/ncs-modem
 /tests/lib/hw_unique_key*/                @frkv @Vge0rge @vili-nordic @mswarowsky
 /tests/lib/hw_id/                         @nrfconnect/ncs-cia
 /tests/lib/location/                      @trantanen @tokangas
 /tests/lib/lte_lc/                        @trantanen @tokangas
 /tests/lib/lte_lc_api/                    @trantanen @tokangas
 /tests/lib/modem_jwt/                     @SeppoTakalo
-/tests/lib/modem_battery/                 @MirkoCovizzi
+/tests/lib/modem_battery/                 @nrfconnect/ncs-modem
 /tests/lib/modem_info/                    @nrfconnect/ncs-cia
 /tests/lib/qos/                           @nrfconnect/ncs-cia
 /tests/lib/sfloat/                        @kapi-no @maje-emb
 /tests/lib/sms/                           @trantanen @tokangas
-/tests/lib/nrf_modem_lib/                 @lemrey @MirkoCovizzi
-/tests/lib/nrf_modem_lib/nrf91_sockets/   @MirkoCovizzi
-/tests/lib/pdn/                           @lemrey @eivindj-nordic
+/tests/lib/nrf_modem_lib/                 @nrfconnect/ncs-modem
+/tests/lib/nrf_modem_lib/nrf91_sockets/   @nrfconnect/ncs-modem
+/tests/lib/pdn/                           @nrfconnect/ncs-modem
 /tests/lib/ram_pwrdn/                     @Damian-Nordic
 /tests/lib/contin_array/                  @nrfconnect/ncs-audio
 /tests/lib/data_fifo/                     @nrfconnect/ncs-audio


### PR DESCRIPTION
In preparation for the enabling of the GitHub "Require reviews from Code Owners" branch protection setting, reorganize the Codeowners file so that Vestavind is aware of changes in the files it needs to oversee.

See also: https://nordicsemi.atlassian.net/wiki/spaces/SPG/pages/635604878/CODEOWNERS+file