### PR TITLE
manifest: update sdk-zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: c0e08266a73496e70a6b44331b79e03bc55507b6
+      revision: pull/1728/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Enable sysbuild for nrf54
https://github.com/nrfconnect/sdk-zephyr/pull/1728 https://github.com/zephyrproject-rtos/zephyr/pull/73076 https://github.com/zephyrproject-rtos/zephyr/pull/72942