### PR TITLE
samples: wifi: thread_coex: Remove child image folder

### DIFF
--- a/samples/wifi/thread_coex/child_image/802154_rpmsg.conf
+++ b/samples/wifi/thread_coex/child_image/802154_rpmsg.conf
@@ -1,7 +1,0 @@
-#
-# Copyright (c) 2024 Nordic Semiconductor
-#
-# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
-#
-
-CONFIG_NRF_802154_ENCRYPTION=y


### PR DESCRIPTION
This folder should never have been added