### PR TITLE
openthread: samples: Add nrf54h20 to twister build.

### DIFF
--- a/samples/openthread/cli/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/openthread/cli/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+
+ /delete-node/ &cpuapp_rx_partitions;
+ /delete-node/ &cpuapp_rw_partitions;
+
+&mram1x {
+	erase-block-size = < 0x1000 >;
+	write-block-size = < 0x10 >;
+
+	cpuapp_rx_partitions: cpuapp-rx-partitions {
+		compatible = "nordic,owned-partitions", "fixed-partitions";
+		status = "okay";
+		perm-read;
+		perm-execute;
+		perm-secure;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		cpuapp_slot0_partition: partition@a6000 {
+			reg = <0xa6000 DT_SIZE_K(700)>;
+		};
+
+		cpuppr_code_partition: partition@155000 {
+			reg = <0x155000 DT_SIZE_K(64)>;
+		};
+	};
+
+	cpuapp_rw_partitions: cpuapp-rw-partitions {
+		compatible = "nordic,owned-partitions", "fixed-partitions";
+		status = "okay";
+		perm-read;
+		perm-write;
+		#address-cells = < 0x1 >;
+		#size-cells = < 0x1 >;
+
+		storage_partition: partition@198000 {
+			reg = < 0x198000 DT_SIZE_K(32) >;
+		};
+	};
+};

--- a/samples/openthread/cli/sample.yaml
+++ b/samples/openthread/cli/sample.yaml
@@ -14,6 +14,7 @@ tests:
       nrf5340dk/nrf5340/cpuapp
       nrf5340dk/nrf5340/cpuapp/ns
       nrf54l15pdk/nrf54l15/cpuapp
+      nrf54h20dk/nrf54h20/cpuapp
     extra_args: >
       cli_SNIPPET="ci;logging;multiprotocol;tcp"
       FILE_SUFFIX=ble
@@ -24,6 +25,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15pdk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
   sample.openthread.cli.singleprotocol:
     sysbuild: true
     build_only: true
@@ -34,6 +36,7 @@ tests:
       nrf5340dk/nrf5340/cpuapp
       nrf5340dk/nrf5340/cpuapp/ns
       nrf54l15pdk/nrf54l15/cpuapp
+      nrf54h20dk/nrf54h20/cpuapp
     extra_args: >
       cli_SNIPPET="ci;logging;tcp"
     integration_platforms:
@@ -42,6 +45,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15pdk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
   sample.openthread.cli.usb:
     sysbuild: true
     build_only: true


### PR DESCRIPTION
Adding nrf54h20 single and multiprotocol to twister builds.