### PR TITLE
samples: cellular: modem_shell: sock: Fix 'packet' socket connect

### DIFF
--- a/samples/cellular/modem_shell/src/sock/sock.c
+++ b/samples/cellular/modem_shell/src/sock/sock.c
@@ -566,12 +566,16 @@ int sock_open_and_connect(
 	}
 
 	/* Set port to address info */
-	if (family == AF_INET) {
-		((struct sockaddr_in *)socket_info->addrinfo->ai_addr)->sin_port = htons(port);
-	} else if (family == AF_INET6) {
-		((struct sockaddr_in6 *)socket_info->addrinfo->ai_addr)->sin6_port = htons(port);
-	} else {
-		assert(0);
+	if ((address != NULL) && (strlen(address) != 0)) {
+		if (family == AF_INET) {
+			((struct sockaddr_in *)socket_info->addrinfo->ai_addr)->sin_port =
+				htons(port);
+		} else if (family == AF_INET6) {
+			((struct sockaddr_in6 *)socket_info->addrinfo->ai_addr)->sin6_port =
+				htons(port);
+		} else {
+			assert(0);
+		}
 	}
 
 	/* Create socket */


### PR DESCRIPTION
PR #13772 added an assert requiring family to be 'inet' or 'inet6' when port is set into address structure.
This must be removed for 'packet' (raw) sockets to work.

Jira: MOSH-588