### PR TITLE
doc: fixes for building with nrf54l15

### DIFF
--- a/doc/nrf/device_guides/nrf54l.rst
+++ b/doc/nrf/device_guides/nrf54l.rst
@@ -18,8 +18,8 @@ Zephyr and the |NCS| provide support and contain board definitions for developin
      - Documentation
    * - :ref:`zephyr:nrf54l15pdk_nrf54l15`
      - PCA10156
-     - | ``nrf54l15pdk/nrf54l15/cpuapp`` for the PDK revision v0.2.1, AB0-ES7 (Engineering A).
-       | ``nrf54l15pdk@0.3.0/nrf54l15/cpuapp`` for the PDK revisions v0.3.0 and v0.7.0 (Engineering A).
+     - | ``nrf54l15pdk@0.2.1/nrf54l15/cpuapp`` for the PDK revision v0.2.1, AB0-ES7 (Engineering A).
+       | ``nrf54l15pdk/nrf54l15/cpuapp`` for the PDK revisions v0.3.0 and v0.7.0 (Engineering A).
      - --
 
 .. note::

--- a/doc/nrf/device_guides/working_with_nrf/nrf54l/features.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf54l/features.rst
@@ -121,8 +121,8 @@ To compile the SMP server sample for testing secondary image slots on external S
 
    Make sure to use the correct board target depending on your PDK version:
 
-   * For the PDK revision v0.2.1, AB0-ES7, use the ``nrf54l15pdk/nrf54l15/cpuapp`` board target.
-   * For the PDK revisions v0.3.0 and v0.7.0, use the ``nrf54l15pdk@0.3.0/nrf54l15/cpuapp`` board target.
+   * For the PDK revision v0.2.1, AB0-ES7, use the ``nrf54l15pdk@0.2.1/nrf54l15/cpuapp`` board target.
+   * For the PDK revisions v0.3.0 and v0.7.0, use the ``nrf54l15pdk/nrf54l15/cpuapp`` board target.
 
 This configuration sets up the secondary image slot on the serial flash memory installed on the nRF54L15 PDK.
 It also enables the relevant SPI and the SPI NOR flash drivers.

--- a/doc/nrf/device_guides/working_with_nrf/nrf54l/ug_nrf54l15_gs.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf54l/ug_nrf54l15_gs.rst
@@ -28,8 +28,8 @@ Hardware
 
       For commands, use the correct board target depending on your PDK version:
 
-      * For the PDK revision v0.2.1, AB0-ES7 (Engineering A), use the ``nrf54l15pdk/nrf54l15/cpuapp`` board target.
-      * For the PDK revisions v0.3.0 and v0.7.0 (Engineering A), use the ``nrf54l15pdk@0.3.0/nrf54l15/cpuapp`` board target.
+      * For the PDK revision v0.2.1, AB0-ES7 (Engineering A), use the ``nrf54l15pdk@0.2.1/nrf54l15/cpuapp`` board target.
+      * For the PDK revisions v0.3.0 and v0.7.0 (Engineering A), use the ``nrf54l15pdk/nrf54l15/cpuapp`` board target.
 
 * USB-C cable
 
@@ -57,7 +57,7 @@ Go to the :file:`ncs/v2.6.0/nrf` folder and run the following commands:
    :class: highlight
 
    git fetch
-   git checkout 2.6.99-cs1
+   git checkout v2.6.99-cs1
    west update
 
 .. _ug_nrf54l15_gs_test_sample:


### PR DESCRIPTION
Correct the default board revision for the nrf54l15.
Fix wrong tag in git command