### PR TITLE
suit: generate DFU ZIP artifact

### DIFF
--- a/cmake/sysbuild/suit.cmake
+++ b/cmake/sysbuild/suit.cmake
@@ -149,6 +149,28 @@ function(suit_register_post_build_commands)
   )
 endfunction()
 
+function(suit_generate_dfu_zip)
+  get_property(
+    dfu_artifacts
+    GLOBAL PROPERTY
+    SUIT_DFU_ARTIFACTS
+  )
+
+  set(root_name "${SB_CONFIG_SUIT_ENVELOPE_ROOT_ARTIFACT_NAME}.suit")
+  set(script_params "${root_name}type=suit-envelope")
+
+  include(${ZEPHYR_NRF_MODULE_DIR}/cmake/fw_zip.cmake)
+
+  generate_dfu_zip(
+    OUTPUT ${PROJECT_BINARY_DIR}/dfu_suit.zip
+    BIN_FILES ${dfu_artifacts}
+    TYPE bin
+    IMAGE ${DEFAULT_IMAGE}
+    DEPENDS ${create_suit_artifacts}
+    SCRIPT_PARAMS "${script_params}"
+  )
+endfunction()
+
 # Create DFU package/main envelope.
 #
 # Usage:
@@ -402,4 +424,5 @@ endif()
 
 if(SB_CONFIG_SUIT_ENVELOPE)
   suit_create_package()
+  suit_generate_dfu_zip()
 endif()

--- a/cmake/sysbuild/suit_utilities.cmake
+++ b/cmake/sysbuild/suit_utilities.cmake
@@ -27,7 +27,10 @@ function(suit_copy_artifact_to_output_directory target artifact)
   set_property(
     GLOBAL APPEND PROPERTY SUIT_POST_BUILD_COMMANDS
     COMMAND ${CMAKE_COMMAND} -E copy ${artifact} ${SUIT_ROOT_DIRECTORY}${target}.bin
+    BYPRODUCTS ${SUIT_ROOT_DIRECTORY}${target}.bin
   )
+
+  set_property(GLOBAL APPEND PROPERTY SUIT_DFU_ARTIFACTS ${SUIT_ROOT_DIRECTORY}${target}.bin)
 endfunction()
 
 # Render jinja templates using passed arguments.
@@ -55,6 +58,7 @@ function(suit_render_template input_file output_file core_arguments)
     COMMAND ${PYTHON_EXECUTABLE} ${SUIT_GENERATOR_BUILD_SCRIPT}
     template
     ${TEMPLATE_ARGS}
+    BYPRODUCTS ${output_file}
   )
 endfunction()
 
@@ -74,7 +78,11 @@ function(suit_create_envelope input_file output_file create_signature)
     create
     --input-file ${input_file}
     --output-file ${output_file}
+    BYPRODUCTS ${output_file}
   )
+
+  set_property(GLOBAL APPEND PROPERTY SUIT_DFU_ARTIFACTS ${output_file})
+
   if (create_signature AND SB_CONFIG_SUIT_ENVELOPE_SIGN_SCRIPT)
     suit_sign_envelope(${output_file} ${output_file})
   endif()


### PR DESCRIPTION
The build system now generates a ZIP file containing all necessary artifacts necessary to perform SUIT DFU.