### PR TITLE
boards: thingy91x: Fix external flash issue with mcuboot

### DIFF
--- a/boards/nordic/thingy91x/Kconfig.sysbuild
+++ b/boards/nordic/thingy91x/Kconfig.sysbuild
@@ -39,6 +39,9 @@ config SECURE_BOOT_APPCORE
 config PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY
 	default y if BOOTLOADER_MCUBOOT
 
+config PM_OVERRIDE_EXTERNAL_DRIVER_CHECK
+	default y if BOOTLOADER_MCUBOOT
+
 config SECURE_BOOT_SIGNING_KEY_FILE
 	default "$(ZEPHYR_NRF_MODULE_DIR)/boards/nordic/thingy91x/nsib_signing_key.pem"
 


### PR DESCRIPTION
This patch fixes the issue that prevented MCUboot
to work at all on the Thingy:91 X.