### PR TITLE
manifest: improve west debug support for nRF54H20

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: bf1bd22933927d0444bede472f363cd029262d11
+      revision: 93dfa43722e70c28b40cad3861baa5ce49fd8c99
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Some extra quirks have been added so that we can e.g. add a breakpoint to main.