### PR TITLE
doc/nrf/bootloaders: clarify MCUboot as second-stage boot setup

### DIFF
--- a/doc/nrf/config_and_build/bootloaders/index.rst
+++ b/doc/nrf/config_and_build/bootloaders/index.rst
@@ -48,7 +48,7 @@ You can find an overview of currently supported bootloaders in the table below:
      - Dual-slot direct-xip
    * - :doc:`MCUboot <mcuboot:index-ncs>`
      - Yes
-     - Yes
+     - Yes (only with :ref:`NSIB <bootloader>` as first-stage)
      - :doc:`See imgtool <mcuboot:imgtool>`
      - No
      - Yes


### PR DESCRIPTION
Clarified that MCUboot can only by use as second-stage bootloader if NSIB is the first-stage.