### PR TITLE
cmake: sysbuild: Align b0_packaging.cmake with new manifest format

### DIFF
--- a/cmake/sysbuild/b0_packaging.cmake
+++ b/cmake/sysbuild/b0_packaging.cmake
@@ -6,7 +6,7 @@ include(${ZEPHYR_NRF_MODULE_DIR}/cmake/fw_zip.cmake)
 
 sysbuild_get(app_fw_info_firmware_version IMAGE ${DEFAULT_IMAGE} VAR CONFIG_FW_INFO_FIRMWARE_VERSION KCONFIG)
 
-set(s0_name signed_by_b0_s0_image.bin)
+set(s0_name "signed_by_b0_${DEFAULT_IMAGE}.bin")
 set(s1_name signed_by_b0_s1_image.bin)
 
 generate_dfu_zip(
@@ -17,8 +17,13 @@ generate_dfu_zip(
   IMAGE ${DEFAULT_IMAGE}
   SCRIPT_PARAMS
   "${s0_name}load_address=$<TARGET_PROPERTY:partition_manager,PM_S0_ADDRESS>"
-  "${s1_image}load_address=$<TARGET_PROPERTY:partition_manager,PM_S1_ADDRESS>"
-  "version_B0=${app_fw_info_firmware_version}"
+  "${s0_name}image_index=0"
+  "${s0_name}slot=0"
+  "${s0_name}version_B0=${app_fw_info_firmware_version}"
+  "${s1_name}load_address=$<TARGET_PROPERTY:partition_manager,PM_S1_ADDRESS>"
+  "${s1_name}image_index=0"
+  "${s1_name}slot=1"
+  "${s1_name}version_B0=${app_fw_info_firmware_version}"
   DEPENDS
   ${DEFAULT_IMAGE}_extra_byproducts
   ${DEFAULT_IMAGE}_signed_kernel_hex_target


### PR DESCRIPTION
Change ensures that manifest.json included in the dfu_application.zip follows the agreed format.

Jira: NCSDK-27569