### PR TITLE
cmake: Update format-version of generated dfu_application.zip

### DIFF
--- a/cmake/fw_zip.cmake
+++ b/cmake/fw_zip.cmake
@@ -68,6 +68,7 @@ function(generate_dfu_zip)
     ${GENZIP_ZIP_NAMES}
     --output ${GENZIP_OUTPUT}
     --name "${APPNAME}"
+    --format-version 1
     ${meta_argument}
     ${GENZIP_SCRIPT_PARAMS}
     "type=${GENZIP_TYPE}"

--- a/scripts/bootloader/generate_zip.py
+++ b/scripts/bootloader/generate_zip.py
@@ -36,6 +36,8 @@ def parse_args():
                         file.''')
     parser.add_argument('--name', required=False, help='Optional name to display to the user to help identify the '
                         'purpose of this update')
+    parser.add_argument('--format-version', required=False, type=int, default=1,
+                        help='The format-version field is used to determine manifest.json format')
     return parser.parse_known_args()
 
 
@@ -47,7 +49,7 @@ if __name__ == '__main__':
     args, info = parse_args()
 
     manifest = {
-        'format-version': 0,
+        'format-version': args.format_version,
         'time': int(time.time()),
         'files': list()
     }


### PR DESCRIPTION
Change updates `format-version` in `manifest.json` of generated `dfu_application.zip` files. The new `format-version` is necessary
because changes introduced by HW model v2 and sysbuild break backwards compatibility.

PR also updates `generate_zip.py` to allow specifying `format-version`.

Jira: NCSDK-27569