### PR TITLE
doc: New button and LED numbering adjustments

### DIFF
--- a/samples/benchmarks/coremark/README.rst
+++ b/samples/benchmarks/coremark/README.rst
@@ -35,23 +35,47 @@ User interface
 
 Each target CPU has an assigned button responsible for starting the benchmark and LED that indicates the ``test in progress`` state:
 
-Button 1:
-   Start the benchmark run on the application core.
+.. tabs::
 
-Button 2:
-   Start the benchmark run on the network or radio core.
+   .. group-tab:: nRF52 and nRF53 DKs
 
-Button 3:
-   Start the benchmark run on the PPR core.
+      Button 1:
+         Start the benchmark run on the application core.
 
-LED 1:
-   Indicates ``test in progress`` on the application core.
+      Button 2:
+         Start the benchmark run on the network or radio core.
 
-LED 2:
-   Indicates ``test in progress`` on the network or radio core.
+      Button 3:
+         Start the benchmark run on the PPR core.
 
-LED 3:
-   Indicates ``test in progress`` on the PPR core.
+      LED 1:
+         Indicates ``test in progress`` on the application core.
+
+      LED 2:
+         Indicates ``test in progress`` on the network or radio core.
+
+      LED 3:
+         Indicates ``test in progress`` on the PPR core.
+
+   .. group-tab:: nRF54 DKs
+
+      Button 0:
+         Start the benchmark run on the application core.
+
+      Button 1:
+         Start the benchmark run on the network or radio core.
+
+      Button 2:
+         Start the benchmark run on the PPR core.
+
+      LED 0:
+         Indicates ``test in progress`` on the application core.
+
+      LED 1:
+         Indicates ``test in progress`` on the network or radio core.
+
+      LED 2:
+         Indicates ``test in progress`` on the PPR core.
 
 .. _coremark_configuration:
 

--- a/samples/bluetooth/central_and_peripheral_hr/README.rst
+++ b/samples/bluetooth/central_and_peripheral_hr/README.rst
@@ -54,14 +54,29 @@ It collects data from a remote device with Heart Rate Service that is sending no
 User interface
 **************
 
-LED 1:
-   Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
+.. tabs::
 
-LED 2:
-   Lit when the development kit is connected as central.
+   .. group-tab:: nRF52 and nRF53 DKs
 
-LED 3:
-  Lit when the development kit is connected as peripheral.
+      LED 1:
+         Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
+
+      LED 2:
+         Lit when the development kit is connected as central.
+
+      LED 3:
+         Lit when the development kit is connected as peripheral.
+
+   .. group-tab:: nRF54 DKs
+
+      LED 0:
+         Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
+
+      LED 1:
+         Lit when the development kit is connected as central.
+
+      LED 2:
+         Lit when the development kit is connected as peripheral.
 
 Building and running
 ********************
@@ -80,80 +95,164 @@ After programming the sample to your development kit, test it either by connecti
 Testing with other development kits
 -----------------------------------
 
-1. |connect_terminal_specific|
-#. Program the other development kit with the :ref:`zephyr:peripheral_hr` sample and reset it.
-#. Wait until the HRS is detected by the central.
-   Observe that **LED 2** is on.
-#. In the terminal window, check for information similar to the following::
+.. tabs::
 
-        Heart Rate Sensor body location: Chest
-        Heart Rate Measurement notification received:
+   .. group-tab:: nRF52 and nRF53 DKs
 
-            Heart Rate Measurement Value Format: 8 - bit
-            Sensor Contact detected: 1
-            Sensor Contact supported: 1
-            Energy Expended present: 0
-            RR-Intervals present: 0
+      1. |connect_terminal_specific|
+      #. Program the other development kit with the :ref:`zephyr:peripheral_hr` sample and reset it.
+      #. Wait until the HRS is detected by the central.
+         Observe that **LED 2** is on.
+      #. In the terminal window, check for information similar to the following::
 
-            Heart Rate Measurement Value: 134 bpm
+            Heart Rate Sensor body location: Chest
+            Heart Rate Measurement notification received:
 
-   Notifications will be displayed periodically with a frequency determined by the HR server.
+                  Heart Rate Measurement Value Format: 8 - bit
+                  Sensor Contact detected: 1
+                  Sensor Contact supported: 1
+                  Energy Expended present: 0
+                  RR-Intervals present: 0
 
-#. Program another development kit with the :ref:`zephyr:bluetooth_central_hr` sample and reset it.
-#. Wait until central is connected to your development kit.
-   Observe that **LED 3** is lit.
-#. In terminal windows connected to device with the :ref:`zephyr:bluetooth_central_hr` sample, check for information similar to following::
+                  Heart Rate Measurement Value: 134 bpm
 
-        [NOTIFICATION] data 0x20006779 length 2
+         Notifications will be displayed periodically with a frequency determined by the HR server.
 
-The sample works now as relay for the Heart Rate Service.
+      #. Program another development kit with the :ref:`zephyr:bluetooth_central_hr` sample and reset it.
+      #. Wait until central is connected to your development kit.
+         Observe that **LED 3** is lit.
+      #. In terminal windows connected to device with the :ref:`zephyr:bluetooth_central_hr` sample, check for information similar to following::
+
+            [NOTIFICATION] data 0x20006779 length 2
+
+      The sample works now as relay for the Heart Rate Service.
+
+   .. group-tab:: nRF54 DKs
+
+      1. |connect_terminal_specific|
+      #. Program the other development kit with the :ref:`zephyr:peripheral_hr` sample and reset it.
+      #. Wait until the HRS is detected by the central.
+         Observe that **LED 1** is on.
+      #. In the terminal window, check for information similar to the following::
+
+            Heart Rate Sensor body location: Chest
+            Heart Rate Measurement notification received:
+
+                  Heart Rate Measurement Value Format: 8 - bit
+                  Sensor Contact detected: 1
+                  Sensor Contact supported: 1
+                  Energy Expended present: 0
+                  RR-Intervals present: 0
+
+                  Heart Rate Measurement Value: 134 bpm
+
+         Notifications will be displayed periodically with a frequency determined by the HR server.
+
+      #. Program another development kit with the :ref:`zephyr:bluetooth_central_hr` sample and reset it.
+      #. Wait until central is connected to your development kit.
+         Observe that **LED 2** is lit.
+      #. In terminal windows connected to device with the :ref:`zephyr:bluetooth_central_hr` sample, check for information similar to following::
+
+            [NOTIFICATION] data 0x20006779 length 2
+
+      The sample works now as relay for the Heart Rate Service.
 
 Testing with nRF Connect for Desktop
 ------------------------------------
-1. |connect_terminal_specific|
-#. Reset the development kit.
-#. Start `nRF Connect for Desktop`_.
-#. Open the Bluetooth Low Energy app and select the connected dongle that is used for communication.
-#. Open the **SERVER SETUP** tab.
-#. Click the dongle configuration and select :guilabel:`Load setup`.
-#. Load the :file:`hr_service.ncs` file that is located under :file:`samples/bluetooth/central_and_peripheral_hr` in the |NCS| folder structure.
-#. Click :guilabel:`Apply to device`.
-#. Open the **CONNECTION MAP** tab.
-#. Click the dongle configuration (gear icon) and select :guilabel:`Advertising setup`.
 
-   The current version of nRF Connect can store the advertising setup.
+.. tabs::
 
-#. Click :guilabel:`Load setup`.
-   Load the :file:`hrs_adv_setup.ncs` file that is located under :file:`samples/bluetooth/central_and_peripheral_hr` in the |NCS| folder structure.
-#. Click :guilabel:`Apply` and :guilabel:`Close`.
+   .. group-tab:: nRF52 and nRF53 DKs
 
-#. Click the gear icon to open the Adapter settings and select :guilabel:`Start advertising`.
-#. Wait until the development kit running the Central and Peripheral HRS connects.
-   Observe that **LED 2** is lit.
-#. To explore the Heart Rate Measurement characteristic, complete the following steps:
+      1. |connect_terminal_specific|
+      #. Reset the development kit.
+      #. Start `nRF Connect for Desktop`_.
+      #. Open the Bluetooth Low Energy app and select the connected dongle that is used for communication.
+      #. Open the **SERVER SETUP** tab.
+      #. Click the dongle configuration and select :guilabel:`Load setup`.
+      #. Load the :file:`hr_service.ncs` file that is located under :file:`samples/bluetooth/central_and_peripheral_hr` in the |NCS| folder structure.
+      #. Click :guilabel:`Apply to device`.
+      #. Open the **CONNECTION MAP** tab.
+      #. Click the dongle configuration (gear icon) and select :guilabel:`Advertising setup`.
 
-   a. Write value ``06 80`` and click the :guilabel:`Play` button to send a notification.
-      In the terminal window, check for information similar to the following::
+         The current version of nRF Connect can store the advertising setup.
 
-        Heart Rate Sensor body location: Chest
-        Heart Rate Measurement notification received:
+      #. Click :guilabel:`Load setup`.
+         Load the :file:`hrs_adv_setup.ncs` file that is located under :file:`samples/bluetooth/central_and_peripheral_hr` in the |NCS| folder structure.
+      #. Click :guilabel:`Apply` and :guilabel:`Close`.
+      #. Click the gear icon to open the Adapter settings and select :guilabel:`Start advertising`.
+      #. Wait until the development kit running the Central and Peripheral HRS connects.
+         Observe that **LED 2** is lit.
+      #. To explore the Heart Rate Measurement characteristic, complete the following steps:
 
-            Heart Rate Measurement Value Format: 8 - bit
-            Sensor Contact detected: 1
-            Sensor Contact supported: 1
-            Energy Expended present: 0
-            RR-Intervals present: 0
+         a. Write value ``06 80`` and click the :guilabel:`Play` button to send a notification.
+            In the terminal window, check for information similar to the following::
 
-            Heart Rate Measurement Value: 128 bpm
+               Heart Rate Sensor body location: Chest
+               Heart Rate Measurement notification received:
 
-      The Bluetooth Low Energy app also detects the Central and Peripheral HRS sample Heart Rate Service.
+                     Heart Rate Measurement Value Format: 8 - bit
+                     Sensor Contact detected: 1
+                     Sensor Contact supported: 1
+                     Energy Expended present: 0
+                     RR-Intervals present: 0
 
-   #. Enable the notification for the Heart Rate Measurement characteristic.
-   #. Write again value ``06 80`` and click the :guilabel:`Play` button to send a notification.
+                     Heart Rate Measurement Value: 128 bpm
 
-      The same value appears for the Heart Rate Measurement characteristic.
+            The Bluetooth Low Energy app also detects the Central and Peripheral HRS sample Heart Rate Service.
 
-The sample works now as relay for the Heart Rate Service.
+         #. Enable the notification for the Heart Rate Measurement characteristic.
+         #. Write again value ``06 80`` and click the :guilabel:`Play` button to send a notification.
+
+            The same value appears for the Heart Rate Measurement characteristic.
+
+      The sample works now as relay for the Heart Rate Service.
+
+   .. group-tab:: nRF54 DKs
+
+      1. |connect_terminal_specific|
+      #. Reset the development kit.
+      #. Start `nRF Connect for Desktop`_.
+      #. Open the Bluetooth Low Energy app and select the connected dongle that is used for communication.
+      #. Open the **SERVER SETUP** tab.
+      #. Click the dongle configuration and select :guilabel:`Load setup`.
+      #. Load the :file:`hr_service.ncs` file that is located under :file:`samples/bluetooth/central_and_peripheral_hr` in the |NCS| folder structure.
+      #. Click :guilabel:`Apply to device`.
+      #. Open the **CONNECTION MAP** tab.
+      #. Click the dongle configuration (gear icon) and select :guilabel:`Advertising setup`.
+
+         The current version of nRF Connect can store the advertising setup.
+
+      #. Click :guilabel:`Load setup`.
+         Load the :file:`hrs_adv_setup.ncs` file that is located under :file:`samples/bluetooth/central_and_peripheral_hr` in the |NCS| folder structure.
+      #. Click :guilabel:`Apply` and :guilabel:`Close`.
+      #. Click the gear icon to open the Adapter settings and select :guilabel:`Start advertising`.
+      #. Wait until the development kit running the Central and Peripheral HRS connects.
+         Observe that **LED 1** is lit.
+      #. To explore the Heart Rate Measurement characteristic, complete the following steps:
+
+         a. Write value ``06 80`` and click the :guilabel:`Play` button to send a notification.
+            In the terminal window, check for information similar to the following::
+
+               Heart Rate Sensor body location: Chest
+               Heart Rate Measurement notification received:
+
+                     Heart Rate Measurement Value Format: 8 - bit
+                     Sensor Contact detected: 1
+                     Sensor Contact supported: 1
+                     Energy Expended present: 0
+                     RR-Intervals present: 0
+
+                     Heart Rate Measurement Value: 128 bpm
+
+            The Bluetooth Low Energy app also detects the Central and Peripheral HRS sample Heart Rate Service.
+
+         #. Enable the notification for the Heart Rate Measurement characteristic.
+         #. Write again value ``06 80`` and click the :guilabel:`Play` button to send a notification.
+
+            The same value appears for the Heart Rate Measurement characteristic.
+
+      The sample works now as relay for the Heart Rate Service.
 
 Dependencies
 ************

--- a/samples/bluetooth/central_bas/README.rst
+++ b/samples/bluetooth/central_bas/README.rst
@@ -26,13 +26,31 @@ Overview
 
 When connected, the sample subscribes to battery level notifications.
 Every notification that is received is printed to the terminal.
-If the device does not support notifications for the Battery Level Characteristic, press **Button 1** to request for reading the battery level.
+
+.. tabs::
+
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      If the device does not support notifications for the Battery Level Characteristic, press **Button 1** to request for reading the battery level.
+
+   .. group-tab:: nRF54 DKs
+
+      If the device does not support notifications for the Battery Level Characteristic, press **Button 0** to request for reading the battery level.
 
 User interface
 **************
 
-Button 1:
-   Send read request for the battery level value.
+.. tabs::
+
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      Button 1:
+         Send read request for the battery level value.
+
+   .. group-tab:: nRF54 DKs
+
+      Button 0:
+         Send read request for the battery level value.
 
 Building and running
 ********************
@@ -53,76 +71,153 @@ After programming the sample to your development kit, you can test it either by 
 Testing with another kit
 ------------------------
 
-1. |connect_terminal_specific|
-#. Reset the kit.
-#. Program the other development kit with the :ref:`peripheral_hids_keyboard` or :ref:`peripheral_hids_mouse` sample and reset it.
-#. Wait until the BAS Server is detected by the central.
-   In the terminal window, check for information similar to the following::
+.. tabs::
 
-      The discovery procedure succeeded
+   .. group-tab:: nRF52 and nRF53 DKs
 
-#. Observe that the received notifications are output in the terminal window::
+      1. |connect_terminal_specific|
+      #. Reset the kit.
+      #. Program the other development kit with the :ref:`peripheral_hids_keyboard` or :ref:`peripheral_hids_mouse` sample and reset it.
+      #. Wait until the BAS Server is detected by the central.
+         In the terminal window, check for information similar to the following::
 
-      [xx.xx.xx.xx.xx.xx (random)]: Battery notification: 99%
-      [xx.xx.xx.xx.xx.xx (random)]: Battery notification: 98%
-      [xx.xx.xx.xx.xx.xx (random)]: Battery notification: 97%
+            The discovery procedure succeeded
 
-#. Press **Button 1** to send a read request and process the response::
+      #. Observe that the received notifications are output in the terminal window::
 
-      Reading BAS value:
-      [xx.xx.xx.xx.xx.xx (random)]: Battery read: 97%
+            [xx.xx.xx.xx.xx.xx (random)]: Battery notification: 99%
+            [xx.xx.xx.xx.xx.xx (random)]: Battery notification: 98%
+            [xx.xx.xx.xx.xx.xx (random)]: Battery notification: 97%
+
+      #. Press **Button 1** to send a read request and process the response::
+
+            Reading BAS value:
+            [xx.xx.xx.xx.xx.xx (random)]: Battery read: 97%
+
+   .. group-tab:: nRF54 DKs
+
+      1. |connect_terminal_specific|
+      #. Reset the kit.
+      #. Program the other development kit with the :ref:`peripheral_hids_keyboard` or :ref:`peripheral_hids_mouse` sample and reset it.
+      #. Wait until the BAS Server is detected by the central.
+         In the terminal window, check for information similar to the following::
+
+            The discovery procedure succeeded
+
+      #. Observe that the received notifications are output in the terminal window::
+
+            [xx.xx.xx.xx.xx.xx (random)]: Battery notification: 99%
+            [xx.xx.xx.xx.xx.xx (random)]: Battery notification: 98%
+            [xx.xx.xx.xx.xx.xx (random)]: Battery notification: 97%
+
+      #. Press **Button 0** to send a read request and process the response::
+
+            Reading BAS value:
+            [xx.xx.xx.xx.xx.xx (random)]: Battery read: 97%
 
 
 Testing with nRF Connect for Desktop
 ------------------------------------
 
-1. |connect_terminal_specific|
-#. Reset the kit.
-#. Start `nRF Connect for Desktop`_.
-#. Open the Bluetooth Low Energy app and select the connected dongle that is used for communication.
-#. Open the :guilabel:`SERVER SETUP` tab.
-   Click the dongle configuration and select :guilabel:`Load setup`.
-   Load the :file:`hids_keyboard.ncs` file that is located under :file:`samples/bluetooth/central_bas` in the |NCS| folder structure.
-#. Click :guilabel:`Apply to device`.
-#. Open the :guilabel:`CONNECTION MAP` tab.
-   Click the dongle configuration and select :guilabel:`Advertising setup`.
+.. tabs::
 
-   The current version of the Bluetooth Low Energy app cannot store the advertising setup, so it must be configured manually.
-   See the following image for the required target configuration:
+   .. group-tab:: nRF52 and nRF53 DKs
 
-   .. figure:: /images/bt_central_hids_nrfc_ad.png
-      :alt: Advertising setup for HIDS keyboard simulator
+      1. |connect_terminal_specific|
+      #. Reset the kit.
+      #. Start `nRF Connect for Desktop`_.
+      #. Open the Bluetooth Low Energy app and select the connected dongle that is used for communication.
+      #. Open the :guilabel:`SERVER SETUP` tab.
+         Click the dongle configuration and select :guilabel:`Load setup`.
+         Load the :file:`hids_keyboard.ncs` file that is located under :file:`samples/bluetooth/central_bas` in the |NCS| folder structure.
+      #. Click :guilabel:`Apply to device`.
+      #. Open the :guilabel:`CONNECTION MAP` tab.
+         Click the dongle configuration and select :guilabel:`Advertising setup`.
 
-      Advertising setup for HIDS keyboard simulator
+         The current version of the Bluetooth Low Energy app cannot store the advertising setup, so it must be configured manually.
+         See the following image for the required target configuration:
 
-   Complete the following steps to configure the advertising setup:
+         .. figure:: /images/bt_central_hids_nrfc_ad.png
+            :alt: Advertising setup for HIDS keyboard simulator
 
-   a. Delete the default **Complete local name** from **Advertising data**.
-   #. Add a **Custom AD type** with **AD type value** set to ``19`` and **Value** set to ``03c1``.
-      This is the GAP Appearance advertising data.
-   #. Add a **Custom AD type** with **AD type value** set to ``01`` and **Value** set to ``06``.
-      This is the AD data with "General Discoverable" and "BR/EDR not supported" flags set.
-   #. Add a **UUID 16 bit complete list** with two comma-separated values: ``1812`` and ``180F``.
-      These are the values for HIDS and BAS.
-   #. Add a **Complete local name** of your choice to the **Scan response data**.
-   #. Click :guilabel:`Apply` and :guilabel:`Close`.
+            Advertising setup for HIDS keyboard simulator
 
-#. In the **Adapter settings**, select :guilabel:`Start advertising`.
-#. Wait until the kit that runs the Central BAS sample connects.
-   In the terminal window, check for information similar to the following::
+         Complete the following steps to configure the advertising setup:
 
-      The discovery procedure succeeded
+         a. Delete the default **Complete local name** from **Advertising data**.
+         #. Add a **Custom AD type** with **AD type value** set to ``19`` and **Value** set to ``03c1``.
+            This is the GAP Appearance advertising data.
+         #. Add a **Custom AD type** with **AD type value** set to ``01`` and **Value** set to ``06``.
+            This is the AD data with "General Discoverable" and "BR/EDR not supported" flags set.
+         #. Add a **UUID 16 bit complete list** with two comma-separated values: ``1812`` and ``180F``.
+            These are the values for HIDS and BAS.
+         #. Add a **Complete local name** of your choice to the **Scan response data**.
+         #. Click :guilabel:`Apply` and :guilabel:`Close`.
 
-#. Press **Button 1** to send read request and process the response::
+      #. In the **Adapter settings**, select :guilabel:`Start advertising`.
+      #. Wait until the kit that runs the Central BAS sample connects.
+         In the terminal window, check for information similar to the following::
 
-      Reading BAS value:
-      [xx.xx.xx.xx.xx.xx (random)]: Battery read: 100%
+            The discovery procedure succeeded
 
-#. Change the value in :guilabel:`Battery Service` > :guilabel:`Battery Level` to generate notifications.
-#. Observe that the notification information is displayed::
+      #. Press **Button 1** to send read request and process the response::
 
-      [xx.xx.xx.xx.xx.xx (random)]: Battery notification: 99%
+            Reading BAS value:
+            [xx.xx.xx.xx.xx.xx (random)]: Battery read: 100%
 
+      #. Change the value in :guilabel:`Battery Service` > :guilabel:`Battery Level` to generate notifications.
+      #. Observe that the notification information is displayed::
+
+            [xx.xx.xx.xx.xx.xx (random)]: Battery notification: 99%
+
+   .. group-tab:: nRF54 DKs
+
+      1. |connect_terminal_specific|
+      #. Reset the kit.
+      #. Start `nRF Connect for Desktop`_.
+      #. Open the Bluetooth Low Energy app and select the connected dongle that is used for communication.
+      #. Open the :guilabel:`SERVER SETUP` tab.
+         Click the dongle configuration and select :guilabel:`Load setup`.
+         Load the :file:`hids_keyboard.ncs` file that is located under :file:`samples/bluetooth/central_bas` in the |NCS| folder structure.
+      #. Click :guilabel:`Apply to device`.
+      #. Open the :guilabel:`CONNECTION MAP` tab.
+         Click the dongle configuration and select :guilabel:`Advertising setup`.
+
+         The current version of the Bluetooth Low Energy app cannot store the advertising setup, so it must be configured manually.
+         See the following image for the required target configuration:
+
+         .. figure:: /images/bt_central_hids_nrfc_ad.png
+            :alt: Advertising setup for HIDS keyboard simulator
+
+            Advertising setup for HIDS keyboard simulator
+
+         Complete the following steps to configure the advertising setup:
+
+         a. Delete the default **Complete local name** from **Advertising data**.
+         #. Add a **Custom AD type** with **AD type value** set to ``19`` and **Value** set to ``03c1``.
+            This is the GAP Appearance advertising data.
+         #. Add a **Custom AD type** with **AD type value** set to ``01`` and **Value** set to ``06``.
+            This is the AD data with "General Discoverable" and "BR/EDR not supported" flags set.
+         #. Add a **UUID 16 bit complete list** with two comma-separated values: ``1812`` and ``180F``.
+            These are the values for HIDS and BAS.
+         #. Add a **Complete local name** of your choice to the **Scan response data**.
+         #. Click :guilabel:`Apply` and :guilabel:`Close`.
+
+      #. In the **Adapter settings**, select :guilabel:`Start advertising`.
+      #. Wait until the kit that runs the Central BAS sample connects.
+         In the terminal window, check for information similar to the following::
+
+            The discovery procedure succeeded
+
+      #. Press **Button 0** to send read request and process the response::
+
+            Reading BAS value:
+            [xx.xx.xx.xx.xx.xx (random)]: Battery read: 100%
+
+      #. Change the value in :guilabel:`Battery Service` > :guilabel:`Battery Level` to generate notifications.
+      #. Observe that the notification information is displayed::
+
+            [xx.xx.xx.xx.xx.xx (random)]: Battery notification: 99%
 
 Dependencies
 ************

--- a/samples/bluetooth/central_hids/README.rst
+++ b/samples/bluetooth/central_hids/README.rst
@@ -30,29 +30,60 @@ If a HIDS server is found, the sample connects to it and discovers all character
 If any input reports are detected, the sample subscribes to them to receive notifications.
 If any boot reports are detected, the behavior depends on if they are boot mouse reports or boot keyboard reports:
 
-* If a boot mouse report is detected, the sample subscribes to it.
-* If a boot keyboard report is detected, the sample subscribes to its input report, and the sample functionality of changing the CAPSLOCK LED is enabled (**Button 1** and **3**).
+.. tabs::
+
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      * If a boot mouse report is detected, the sample subscribes to it.
+      * If a boot keyboard report is detected, the sample subscribes to its input report, and the sample functionality of changing the CAPSLOCK LED is enabled (**Button 1** and **Button 3**).
+
+   .. group-tab:: nRF54 DKs
+
+      * If a boot mouse report is detected, the sample subscribes to it.
+      * If a boot keyboard report is detected, the sample subscribes to its input report, and the sample functionality of changing the CAPSLOCK LED is enabled (**Button 0** and **Button 2**).
 
 User interface
 **************
 
-Button 1:
-   Toggle the CAPSLOCK LED on the connected keyboard using Write without response.
-   This function is available only if the connected keyboard is set to work in Boot Protocol Mode.
+.. tabs::
 
-   When pairing, press this button to confirm the passkey value that is printed on the COM listener to pair with the other device.
+   .. group-tab:: nRF52 and nRF53 DKs
 
-Button 2:
-   Switch between Boot Protocol Mode and Report Protocol Mode.
-   This function is available only if the connected peer supports the Protocol Mode Characteristic.
+      Button 1:
+         Toggle the CAPSLOCK LED on the connected keyboard using Write without response.
+         This function is available only if the connected keyboard is set to work in Boot Protocol Mode.
 
-   When pairing, press this button to reject the passkey value that is printed on the COM listener to prevent pairing with the other device.
+         When pairing, press this button to confirm the passkey value that is printed on the COM listener to pair with the other device.
 
-Button 3:
-   Toggle the CAPSLOCK LED on the connected keyboard using Write with response.
-   This function is available only if the connected HID has boot keyboard reports.
-   It always writes CAPSLOCK information to the boot report, even if Report Protocol Mode is selected.
+      Button 2:
+         Switch between Boot Protocol Mode and Report Protocol Mode.
+         This function is available only if the connected peer supports the Protocol Mode Characteristic.
 
+         When pairing, press this button to reject the passkey value that is printed on the COM listener to prevent pairing with the other device.
+
+      Button 3:
+         Toggle the CAPSLOCK LED on the connected keyboard using Write with response.
+         This function is available only if the connected HID has boot keyboard reports.
+         It always writes CAPSLOCK information to the boot report, even if Report Protocol Mode is selected.
+
+   .. group-tab:: nRF54 DKs
+
+      Button 0:
+         Toggle the CAPSLOCK LED on the connected keyboard using Write without response.
+         This function is available only if the connected keyboard is set to work in Boot Protocol Mode.
+
+         When pairing, press this button to confirm the passkey value that is printed on the COM listener to pair with the other device.
+
+      Button 1:
+         Switch between Boot Protocol Mode and Report Protocol Mode.
+         This function is available only if the connected peer supports the Protocol Mode Characteristic.
+
+         When pairing, press this button to reject the passkey value that is printed on the COM listener to prevent pairing with the other device.
+
+      Button 2:
+         Toggle the CAPSLOCK LED on the connected keyboard using Write with response.
+         This function is available only if the connected HID has boot keyboard reports.
+         It always writes CAPSLOCK information to the boot report, even if Report Protocol Mode is selected.
 
 Building and Running
 ********************
@@ -70,96 +101,193 @@ After programming the sample to your development kit, you can test it either by 
 Testing with another development kit
 ------------------------------------
 
-1. |connect_terminal_specific|
-#. Reset the kit.
-#. Program the other kit with the :ref:`peripheral_hids_keyboard` sample and reset it.
-#. When connected, press **Button 1** on both devices to confirm the passkey value used for bonding, or press **Button 2** to reject it.
-#. Wait until the HIDS keyboard is detected by the central.
-   All detected descriptors are listed.
-   In the terminal window, check for information similar to the following::
+.. tabs::
 
-      HIDS is ready to work
-      Subscribe to report id: 1
-      Subscribe to boot keyboard report
+   .. group-tab:: nRF52 and nRF53 DKs
 
-#. Press **Button 1** and **Button 2** one after another on the kit that runs the keyboard sample and observe the notification values in the terminal window.
-   See :ref:`peripheral_hids_keyboard` for the expected values::
+      1. |connect_terminal_specific|
+      #. Reset the kit.
+      #. Program the other kit with the :ref:`peripheral_hids_keyboard` sample and reset it.
+      #. When connected, press **Button 1** on both devices to confirm the passkey value used for bonding, or press **Button 2** to reject it.
+      #. Wait until the HIDS keyboard is detected by the central.
+         All detected descriptors are listed.
+         In the terminal window, check for information similar to the following::
 
-      Notification, id: 0, size: 8, data: 0x0 0x0 0xb 0x0 0x0 0x0 0x0 0x0
-      Notification, id: 0, size: 8, data: 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0
+            HIDS is ready to work
+            Subscribe to report id: 1
+            Subscribe to boot keyboard report
 
-#. Press **Button 2** on the kit that runs the Central HIDS sample and observe that the protocol mode is updated into boot mode::
+      #. Press **Button 1** and **Button 2** one after another on the kit that runs the keyboard sample and observe the notification values in the terminal window.
+         See :ref:`peripheral_hids_keyboard` for the expected values::
 
-      Setting protocol mode: BOOT
+            Notification, id: 0, size: 8, data: 0x0 0x0 0xb 0x0 0x0 0x0 0x0 0x0
+            Notification, id: 0, size: 8, data: 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0
 
-#. Press **Button 1** and **Button 2** one after another on the kit that runs the keyboard sample and observe the notification of the boot report values::
+      #. Press **Button 2** on the kit that runs the Central HIDS sample and observe that the protocol mode is updated into boot mode::
 
-      Notification, keyboard boot, size: 8, data: 0x0 0x0 0xf 0x0 0x0 0x0 0x0 0x0
-      Notification, keyboard boot, size: 8, data: 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0
+            Setting protocol mode: BOOT
 
+      #. Press **Button 1** and **Button 2** one after another on the kit that runs the keyboard sample and observe the notification of the boot report values::
 
-#. Press **Button 1** and **Button 3** one after another on the Central HIDS kit and observe that **LED 1** on the keyboard kit changes its state.
-   The following information is also displayed in the terminal window.
+            Notification, keyboard boot, size: 8, data: 0x0 0x0 0xf 0x0 0x0 0x0 0x0 0x0
+            Notification, keyboard boot, size: 8, data: 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0
 
-   If **Button 1** was pressed::
+      #. Press **Button 1** and **Button 3** one after another on the Central HIDS kit and observe that **LED 1** on the keyboard kit changes its state.
+         The following information is also displayed in the terminal window.
 
-      Caps lock send (val: 0x2)
-      Caps lock sent
+         If **Button 1** was pressed::
 
-   If **Button 3** was pressed::
+            Caps lock send (val: 0x2)
+            Caps lock sent
 
-      Caps lock send using write with response (val: 0x2)
-      Capslock write result: 0
-      Received data (size: 1, data[0]: 0x2)
+         If **Button 3** was pressed::
+
+            Caps lock send using write with response (val: 0x2)
+            Capslock write result: 0
+            Received data (size: 1, data[0]: 0x2)
+
+   .. group-tab:: nRF54 DKs
+
+      1. |connect_terminal_specific|
+      #. Reset the kit.
+      #. Program the other kit with the :ref:`peripheral_hids_keyboard` sample and reset it.
+      #. When connected, press **Button 0** on both devices to confirm the passkey value used for bonding, or press **Button 1** to reject it.
+      #. Wait until the HIDS keyboard is detected by the central.
+         All detected descriptors are listed.
+         In the terminal window, check for information similar to the following::
+
+            HIDS is ready to work
+            Subscribe to report id: 1
+            Subscribe to boot keyboard report
+
+      #. Press **Button 0** and **Button 1** one after another on the kit that runs the keyboard sample and observe the notification values in the terminal window.
+         See :ref:`peripheral_hids_keyboard` for the expected values::
+
+            Notification, id: 0, size: 8, data: 0x0 0x0 0xb 0x0 0x0 0x0 0x0 0x0
+            Notification, id: 0, size: 8, data: 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0
+
+      #. Press **Button 1** on the kit that runs the Central HIDS sample and observe that the protocol mode is updated into boot mode::
+
+            Setting protocol mode: BOOT
+
+      #. Press **Button 0** and **Button 1** one after another on the kit that runs the keyboard sample and observe the notification of the boot report values::
+
+            Notification, keyboard boot, size: 8, data: 0x0 0x0 0xf 0x0 0x0 0x0 0x0 0x0
+            Notification, keyboard boot, size: 8, data: 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0
+
+      #. Press **Button 0** and **Button 2** one after another on the Central HIDS kit and observe that **LED 0** on the keyboard kit changes its state.
+         The following information is also displayed in the terminal window.
+
+         If **Button 0** was pressed::
+
+            Caps lock send (val: 0x2)
+            Caps lock sent
+
+         If **Button 2** was pressed::
+
+            Caps lock send using write with response (val: 0x2)
+            Capslock write result: 0
+            Received data (size: 1, data[0]: 0x2)
 
 
 Testing with nRF Connect for Desktop
 ------------------------------------
 
-1. |connect_terminal_specific|
-#. Reset the kit.
-#. Start `nRF Connect for Desktop`_.
-#. Open the Bluetooth Low Energy app and select the connected dongle that is used for communication.
-#. Open the :guilabel:`SERVER SETUP` tab.
-   Click the dongle configuration and select :guilabel:`Load setup`.
-   Load the :file:`hids_keyboard.ncs` file that is located under :file:`samples/bluetooth/central_hids` in the |NCS| folder structure.
-#. Click :guilabel:`Apply to device`.
-#. Open the :guilabel:`CONNECTION MAP` tab.
-   Click the dongle configuration and select :guilabel:`Advertising setup`.
+.. tabs::
 
-   The current version of nRF Connect cannot store the advertising setup, so it must be configured manually.
-   See the following image for the required target configuration:
+   .. group-tab:: nRF52 and nRF53 DKs
 
-   .. figure:: /images/bt_central_hids_nrfc_ad.png
-      :alt: Advertising setup for HIDS keyboard simulator
+      1. |connect_terminal_specific|
+      #. Reset the kit.
+      #. Start `nRF Connect for Desktop`_.
+      #. Open the Bluetooth Low Energy app and select the connected dongle that is used for communication.
+      #. Open the :guilabel:`SERVER SETUP` tab.
+         Click the dongle configuration and select :guilabel:`Load setup`.
+         Load the :file:`hids_keyboard.ncs` file that is located under :file:`samples/bluetooth/central_hids` in the |NCS| folder structure.
+      #. Click :guilabel:`Apply to device`.
+      #. Open the :guilabel:`CONNECTION MAP` tab.
+         Click the dongle configuration and select :guilabel:`Advertising setup`.
 
-      Advertising setup for HIDS keyboard simulator
+         The current version of nRF Connect cannot store the advertising setup, so it must be configured manually.
+         See the following image for the required target configuration:
 
-   Complete the following steps to configure the advertising setup:
+         .. figure:: /images/bt_central_hids_nrfc_ad.png
+            :alt: Advertising setup for HIDS keyboard simulator
 
-   a. Delete the default **Complete local name** from **Advertising data**.
-   #. Add a **Custom AD type** with **AD type value** set to ``19`` and **Value** set to ``03c1``.
-      This is the GAP Appearance advertising data.
-   #. Add a **Custom AD type** with **AD type value** set to ``01`` and **Value** set to ``06``.
-      This is the AD data with "General Discoverable" and "BR/EDR not supported" flags set.
-   #. Add a **UUID 16 bit complete list** with two comma-separated values: ``1812`` and ``180F``.
-      These are the values for HIDS and BAS.
-   #. Add a **Complete local name** of your choice to the **Scan response data**.
-   #. Click :guilabel:`Apply` and :guilabel:`Close`.
+            Advertising setup for HIDS keyboard simulator
 
-#. In the **Adapter settings**, select :guilabel:`Start advertising`.
-#. Wait until the kit that runs the Central HIDS sample connects.
-   All detected descriptors are listed.
-   Check for information similar to the following::
+         Complete the following steps to configure the advertising setup:
 
-      HIDS is ready to work
-      Subscribe in report id: 1
-      Subscribe in boot keyboard report
+         a. Delete the default **Complete local name** from **Advertising data**.
+         #. Add a **Custom AD type** with **AD type value** set to ``19`` and **Value** set to ``03c1``.
+            This is the GAP Appearance advertising data.
+         #. Add a **Custom AD type** with **AD type value** set to ``01`` and **Value** set to ``06``.
+            This is the AD data with "General Discoverable" and "BR/EDR not supported" flags set.
+         #. Add a **UUID 16 bit complete list** with two comma-separated values: ``1812`` and ``180F``.
+            These are the values for HIDS and BAS.
+         #. Add a **Complete local name** of your choice to the **Scan response data**.
+         #. Click :guilabel:`Apply` and :guilabel:`Close`.
 
-#. Explore the first report inside Human Interface Device (the one with eight values).
-   Change any of the values and note that the kit logs the change.
-#. Press **Button 2** on the kit and observe that the **Protocol Mode** value changes from ``01`` to ``00``.
-#. Press **Button 1** and **Button 3** one after another and observe that the **Boot Keyboard Output Report** value toggles between ``00`` and ``02``.
+      #. In the **Adapter settings**, select :guilabel:`Start advertising`.
+      #. Wait until the kit that runs the Central HIDS sample connects.
+         All detected descriptors are listed.
+         Check for information similar to the following::
+
+            HIDS is ready to work
+            Subscribe in report id: 1
+            Subscribe in boot keyboard report
+
+      #. Explore the first report inside Human Interface Device (the one with eight values).
+         Change any of the values and note that the kit logs the change.
+      #. Press **Button 2** on the kit and observe that the **Protocol Mode** value changes from ``01`` to ``00``.
+      #. Press **Button 1** and **Button 3** one after another and observe that the **Boot Keyboard Output Report** value toggles between ``00`` and ``02``.
+
+   .. group-tab:: nRF54 DKs
+
+      1. |connect_terminal_specific|
+      #. Reset the kit.
+      #. Start `nRF Connect for Desktop`_.
+      #. Open the Bluetooth Low Energy app and select the connected dongle that is used for communication.
+      #. Open the :guilabel:`SERVER SETUP` tab.
+         Click the dongle configuration and select :guilabel:`Load setup`.
+         Load the :file:`hids_keyboard.ncs` file that is located under :file:`samples/bluetooth/central_hids` in the |NCS| folder structure.
+      #. Click :guilabel:`Apply to device`.
+      #. Open the :guilabel:`CONNECTION MAP` tab.
+         Click the dongle configuration and select :guilabel:`Advertising setup`.
+
+         The current version of nRF Connect cannot store the advertising setup, so it must be configured manually.
+         See the following image for the required target configuration:
+
+         .. figure:: /images/bt_central_hids_nrfc_ad.png
+            :alt: Advertising setup for HIDS keyboard simulator
+
+            Advertising setup for HIDS keyboard simulator
+
+         Complete the following steps to configure the advertising setup:
+
+         a. Delete the default **Complete local name** from **Advertising data**.
+         #. Add a **Custom AD type** with **AD type value** set to ``19`` and **Value** set to ``03c1``.
+            This is the GAP Appearance advertising data.
+         #. Add a **Custom AD type** with **AD type value** set to ``01`` and **Value** set to ``06``.
+            This is the AD data with "General Discoverable" and "BR/EDR not supported" flags set.
+         #. Add a **UUID 16 bit complete list** with two comma-separated values: ``1812`` and ``180F``.
+            These are the values for HIDS and BAS.
+         #. Add a **Complete local name** of your choice to the **Scan response data**.
+         #. Click :guilabel:`Apply` and :guilabel:`Close`.
+
+      #. In the **Adapter settings**, select :guilabel:`Start advertising`.
+      #. Wait until the kit that runs the Central HIDS sample connects.
+         All detected descriptors are listed.
+         Check for information similar to the following::
+
+            HIDS is ready to work
+            Subscribe in report id: 1
+            Subscribe in boot keyboard report
+
+      #. Explore the first report inside Human Interface Device (the one with eight values).
+         Change any of the values and note that the kit logs the change.
+      #. Press **Button 1** on the kit and observe that the **Protocol Mode** value changes from ``01`` to ``00``.
+      #. Press **Button 0** and **Button 2** one after another and observe that the **Boot Keyboard Output Report** value toggles between ``00`` and ``02``.
 
 Dependencies
 *************

--- a/samples/bluetooth/fast_pair/input_device/README.rst
+++ b/samples/bluetooth/fast_pair/input_device/README.rst
@@ -112,55 +112,115 @@ You can control the sample using predefined buttons, while LEDs are used to disp
 Buttons
 =======
 
-Button 1:
-   Toggles between three Fast Pair advertising modes:
+.. tabs::
 
-   * Fast Pair discoverable advertising.
-   * Fast Pair not discoverable advertising (with the show UI indication).
-   * Fast Pair not discoverable advertising (with the hide UI indication).
+   .. group-tab:: nRF52 and nRF53 DKs
 
-   The advertising pairing mode (:c:member:`bt_le_adv_prov_adv_state.pairing_mode`) is enabled only if the Fast Pair discoverable advertising mode is selected.
+      Button 1:
+         Toggles between three Fast Pair advertising modes:
 
-   .. note::
-       The Bluetooth advertising is active only until the Fast Pair Provider connects to a Bluetooth Central.
-       After the connection, you can still switch the advertising modes, but the switch will come into effect only after disconnection.
-       The discoverable advertising is automatically switched to the not discoverable advertising with the show UI indication mode in the following cases:
+         * Fast Pair discoverable advertising.
+         * Fast Pair not discoverable advertising (with the show UI indication).
+         * Fast Pair not discoverable advertising (with the hide UI indication).
 
-       * After 10 minutes of active advertising.
-       * After a Bluetooth Central successfully pairs.
+         The advertising pairing mode (:c:member:`bt_le_adv_prov_adv_state.pairing_mode`) is enabled only if the Fast Pair discoverable advertising mode is selected.
 
-       After the device reaches the maximum number of paired devices (:kconfig:option:`CONFIG_BT_MAX_PAIRED`), the device stops looking for new peers.
-       Therefore, the device no longer advertises in the pairing mode (:c:member:`bt_le_adv_prov_adv_state.pairing_mode`), and the Fast Pair advertising mode is automatically set to the Fast Pair not discoverable advertising with the hide UI indication on every advertising start.
+         .. note::
+            The Bluetooth advertising is active only until the Fast Pair Provider connects to a Bluetooth Central.
+            After the connection, you can still switch the advertising modes, but the switch will come into effect only after disconnection.
+            The discoverable advertising is automatically switched to the not discoverable advertising with the show UI indication mode in the following cases:
 
-Button 2:
-   Increases audio volume of the connected Bluetooth Central.
+            * After 10 minutes of active advertising.
+            * After a Bluetooth Central successfully pairs.
 
-Button 3:
-   Removes the Bluetooth bonds.
-   This operation does not clear Fast Pair storage data.
-   The stored Account Keys are not removed.
+            After the device reaches the maximum number of paired devices (:kconfig:option:`CONFIG_BT_MAX_PAIRED`), the device stops looking for new peers.
+            Therefore, the device no longer advertises in the pairing mode (:c:member:`bt_le_adv_prov_adv_state.pairing_mode`), and the Fast Pair advertising mode is automatically set to the Fast Pair not discoverable advertising with the hide UI indication on every advertising start.
 
-Button 4:
-   Decreases audio volume of the connected Bluetooth Central.
+      Button 2:
+         Increases audio volume of the connected Bluetooth Central.
+
+      Button 3:
+         Removes the Bluetooth bonds.
+         This operation does not clear Fast Pair storage data.
+         The stored Account Keys are not removed.
+
+      Button 4:
+         Decreases audio volume of the connected Bluetooth Central.
+
+   .. group-tab:: nRF54 DKs
+
+      Button 0:
+         Toggles between three Fast Pair advertising modes:
+
+         * Fast Pair discoverable advertising.
+         * Fast Pair not discoverable advertising (with the show UI indication).
+         * Fast Pair not discoverable advertising (with the hide UI indication).
+
+         The advertising pairing mode (:c:member:`bt_le_adv_prov_adv_state.pairing_mode`) is enabled only if the Fast Pair discoverable advertising mode is selected.
+
+         .. note::
+            The Bluetooth advertising is active only until the Fast Pair Provider connects to a Bluetooth Central.
+            After the connection, you can still switch the advertising modes, but the switch will come into effect only after disconnection.
+            The discoverable advertising is automatically switched to the not discoverable advertising with the show UI indication mode in the following cases:
+
+            * After 10 minutes of active advertising.
+            * After a Bluetooth Central successfully pairs.
+
+            After the device reaches the maximum number of paired devices (:kconfig:option:`CONFIG_BT_MAX_PAIRED`), the device stops looking for new peers.
+            Therefore, the device no longer advertises in the pairing mode (:c:member:`bt_le_adv_prov_adv_state.pairing_mode`), and the Fast Pair advertising mode is automatically set to the Fast Pair not discoverable advertising with the hide UI indication on every advertising start.
+
+      Button 1:
+         Increases audio volume of the connected Bluetooth Central.
+
+      Button 2:
+         Removes the Bluetooth bonds.
+         This operation does not clear Fast Pair storage data.
+         The stored Account Keys are not removed.
+
+      Button 3:
+         Decreases audio volume of the connected Bluetooth Central.
 
 LEDs
 ====
 
-LED 1:
-   Keeps blinking with constant interval to indicate that firmware is running.
+.. tabs::
 
-LED 2:
-   Depending on the Bluetooth Central connection status:
+   .. group-tab:: nRF52 and nRF53 DKs
 
-   * On if the Central is connected over Bluetooth.
-   * Off if there is no Central connected.
+      LED 1:
+         Keeps blinking with constant interval to indicate that firmware is running.
 
-LED 3:
-   Depending on the Fast Pair advertising mode setting:
+      LED 2:
+         Depending on the Bluetooth Central connection status:
 
-   * On if the device is Fast Pair discoverable.
-   * Blinks with 0.5 secs interval if the selected mode is the Fast Pair not discoverable advertising with the show UI indication.
-   * Blinks with 1.5 secs interval if the selected mode is the Fast Pair not discoverable advertising with the hide UI indication.
+         * On if the Central is connected over Bluetooth.
+         * Off if there is no Central connected.
+
+      LED 3:
+         Depending on the Fast Pair advertising mode setting:
+
+         * On if the device is Fast Pair discoverable.
+         * Blinks with 0.5 secs interval if the selected mode is the Fast Pair not discoverable advertising with the show UI indication.
+         * Blinks with 1.5 secs interval if the selected mode is the Fast Pair not discoverable advertising with the hide UI indication.
+
+   .. group-tab:: nRF54 DKs
+
+      LED 0:
+         Keeps blinking with constant interval to indicate that firmware is running.
+
+      LED 1:
+         Depending on the Bluetooth Central connection status:
+
+         * On if the Central is connected over Bluetooth.
+         * Off if there is no Central connected.
+
+      LED 2:
+         Depending on the Fast Pair advertising mode setting:
+
+         * On if the device is Fast Pair discoverable.
+         * Blinks with 0.5 secs interval if the selected mode is the Fast Pair not discoverable advertising with the show UI indication.
+         * Blinks with 1.5 secs interval if the selected mode is the Fast Pair not discoverable advertising with the hide UI indication.
+
 
 Configuration
 *************
@@ -187,40 +247,81 @@ Testing
 
 |test_sample|
 
-1. |connect_terminal_specific|
-   The sample provides Fast Pair debug logs to inform about state of the Fast Pair procedure.
-#. Reset the kit.
-#. Observe that **LED 1** is blinking (firmware is running) and **LED 3** is lit (device is Fast Pair discoverable).
-   This means that the device is now working as Fast Pair Provider and is advertising.
-#. On the Android device, go to :guilabel:`Settings` > :guilabel:`Google` > :guilabel:`Devices & sharing` (or :guilabel:`Device connections`, depending on your Android device configuration) > :guilabel:`Devices`.
-#. Move the Android device close to the Fast Pair Provider that is advertising.
-#. Wait for Android device's notification about the detected Fast Pair Provider.
-   If you use the Model ID certified by Google, the notification is similar to the following:
+.. tabs::
 
-   .. figure:: /images/bt_fast_pair_discoverable_notification.png
-      :scale: 33 %
-      :alt: Fast Pair discoverable advertising Android notification
+   .. group-tab:: nRF52 and nRF53 DKs
 
-   The device model name and displayed logo depend on the data provided during the device model registration.
+      1. |connect_terminal_specific|
+         The sample provides Fast Pair debug logs to inform about state of the Fast Pair procedure.
+      #. Reset the kit.
+      #. Observe that **LED 1** is blinking (firmware is running) and **LED 3** is lit (device is Fast Pair discoverable).
+         This means that the device is now working as Fast Pair Provider and is advertising.
+      #. On the Android device, go to :guilabel:`Settings` > :guilabel:`Google` > :guilabel:`Devices & sharing` (or :guilabel:`Device connections`, depending on your Android device configuration) > :guilabel:`Devices`.
+      #. Move the Android device close to the Fast Pair Provider that is advertising.
+      #. Wait for Android device's notification about the detected Fast Pair Provider.
+         If you use the Model ID certified by Google, the notification is similar to the following:
 
-   If you use the debug Model ID (for example, the default is *NCS input device*), the notification is similar to the following:
+         .. figure:: /images/bt_fast_pair_discoverable_notification.png
+            :scale: 33 %
+            :alt: Fast Pair discoverable advertising Android notification
 
-   .. figure:: /images/bt_fast_pair_discoverable_notification_debug.png
-      :scale: 50 %
-      :alt: Fast Pair discoverable advertising Android notification for debug Model ID.
+         The device model name and displayed logo depend on the data provided during the device model registration.
 
-   The device model name is covered by asterisks and the default Fast Pair logo is displayed instead of the one specified during the device model registration.
-#. Tap the :guilabel:`Connect` button to initiate the connection and trigger the Fast Pair procedure.
-   After the procedure has completed, the pop-up is updated to inform about successfully completed Fast Pair procedure.
-   **LED 2** is lit to indicate that the device is connected with the Bluetooth Central.
+         If you use the debug Model ID (for example, the default is *NCS input device*), the notification is similar to the following:
 
-   .. note::
-      Some Android devices might disconnect right after the Fast Pair procedure has completed.
-      Go to :guilabel:`Settings` > :guilabel:`Bluetooth` and tap on the bonded Fast Pair Provider to reconnect.
+         .. figure:: /images/bt_fast_pair_discoverable_notification_debug.png
+            :scale: 50 %
+            :alt: Fast Pair discoverable advertising Android notification for debug Model ID.
 
-   You can now use the connected Fast Pair Provider to control audio volume of the Bluetooth Central.
-#. Press **Button 2** to increase the audio volume.
-#. Press **Button 4** to decrease the audio volume.
+         The device model name is covered by asterisks and the default Fast Pair logo is displayed instead of the one specified during the device model registration.
+      #. Tap the :guilabel:`Connect` button to initiate the connection and trigger the Fast Pair procedure.
+         After the procedure has completed, the pop-up is updated to inform about successfully completed Fast Pair procedure.
+         **LED 2** is lit to indicate that the device is connected with the Bluetooth Central.
+
+         .. note::
+            Some Android devices might disconnect right after the Fast Pair procedure has completed.
+            Go to :guilabel:`Settings` > :guilabel:`Bluetooth` and tap on the bonded Fast Pair Provider to reconnect.
+
+         You can now use the connected Fast Pair Provider to control audio volume of the Bluetooth Central.
+      #. Press **Button 2** to increase the audio volume.
+      #. Press **Button 4** to decrease the audio volume.
+
+   .. group-tab:: nRF54 DKs
+
+      1. |connect_terminal_specific|
+         The sample provides Fast Pair debug logs to inform about state of the Fast Pair procedure.
+      #. Reset the kit.
+      #. Observe that **LED 0** is blinking (firmware is running) and **LED 2** is lit (device is Fast Pair discoverable).
+         This means that the device is now working as Fast Pair Provider and is advertising.
+      #. On the Android device, go to :guilabel:`Settings` > :guilabel:`Google` > :guilabel:`Devices & sharing` (or :guilabel:`Device connections`, depending on your Android device configuration) > :guilabel:`Devices`.
+      #. Move the Android device close to the Fast Pair Provider that is advertising.
+      #. Wait for Android device's notification about the detected Fast Pair Provider.
+         If you use the Model ID certified by Google, the notification is similar to the following:
+
+         .. figure:: /images/bt_fast_pair_discoverable_notification.png
+            :scale: 33 %
+            :alt: Fast Pair discoverable advertising Android notification
+
+         The device model name and displayed logo depend on the data provided during the device model registration.
+
+         If you use the debug Model ID (for example, the default is *NCS input device*), the notification is similar to the following:
+
+         .. figure:: /images/bt_fast_pair_discoverable_notification_debug.png
+            :scale: 50 %
+            :alt: Fast Pair discoverable advertising Android notification for debug Model ID.
+
+         The device model name is covered by asterisks and the default Fast Pair logo is displayed instead of the one specified during the device model registration.
+      #. Tap the :guilabel:`Connect` button to initiate the connection and trigger the Fast Pair procedure.
+         After the procedure has completed, the pop-up is updated to inform about successfully completed Fast Pair procedure.
+         **LED 1** is lit to indicate that the device is connected with the Bluetooth Central.
+
+         .. note::
+            Some Android devices might disconnect right after the Fast Pair procedure has completed.
+            Go to :guilabel:`Settings` > :guilabel:`Bluetooth` and tap on the bonded Fast Pair Provider to reconnect.
+
+         You can now use the connected Fast Pair Provider to control audio volume of the Bluetooth Central.
+      #. Press **Button 1** to increase the audio volume.
+      #. Press **Button 3** to decrease the audio volume.
 
 Not discoverable advertising
 ----------------------------
@@ -229,61 +330,123 @@ Testing not discoverable advertising requires using a second Android device that
 
 Test not discoverable advertising by completing `Testing`_ and the following additional steps:
 
-#. Disconnect the Android device that was used during the default `Testing`_:
+.. tabs::
 
-   a. Go to :guilabel:`Settings` > :guilabel:`Bluetooth`.
-   #. Tap on the connected device name to disconnect it.
+   .. group-tab:: nRF52 and nRF53 DKs
 
-      .. note::
-         Do not remove Bluetooth bond information related to the Fast Pair Provider.
+      #. Disconnect the Android device that was used during the default `Testing`_:
 
-      After disconnection, the provider automatically switches from the discoverable advertising to the not discoverable advertising with the show UI indication mode.
-      **LED 3** is blinking rapidly.
+         a. Go to :guilabel:`Settings` > :guilabel:`Bluetooth`.
+         #. Tap on the connected device name to disconnect it.
 
-#. Make sure that the Fast Pair Provider is added to :guilabel:`Saved devices` on the Android device that was used for `Testing`_:
+            .. note::
+               Do not remove Bluetooth bond information related to the Fast Pair Provider.
 
-   a. Go to :guilabel:`Settings` > :guilabel:`Google` > :guilabel:`Devices & sharing` (or :guilabel:`Device connections`) > :guilabel:`Devices` > :guilabel:`Saved devices`.
-   #. Verify that the paired device is appearing on the list.
+            After disconnection, the provider automatically switches from the discoverable advertising to the not discoverable advertising with the show UI indication mode.
+            **LED 3** is blinking rapidly.
 
-#. If you want to test the Fast Pair not discoverable advertising with the hide UI indication mode, press **Button 1**.
-   **LED 3** starts blinking slowly.
+      #. Make sure that the Fast Pair Provider is added to :guilabel:`Saved devices` on the Android device that was used for `Testing`_:
 
-#. Wait until the Fast Pair Provider is added to :guilabel:`Saved devices` on the second Android device:
+         a. Go to :guilabel:`Settings` > :guilabel:`Google` > :guilabel:`Devices & sharing` (or :guilabel:`Device connections`) > :guilabel:`Devices` > :guilabel:`Saved devices`.
+         #. Verify that the paired device is appearing on the list.
 
-   a. Go to :guilabel:`Settings` > :guilabel:`Google` > :guilabel:`Devices & sharing` (or :guilabel:`Device connections`) > :guilabel:`Devices` > :guilabel:`Saved devices`.
-      The paired device appears on the list.
-   #. If the device does not appear on the list, wait until the data is synced between phones.
+      #. If you want to test the Fast Pair not discoverable advertising with the hide UI indication mode, press **Button 1**.
+         **LED 3** starts blinking slowly.
 
-#. Move the second Android device close to the Fast Pair Provider.
-   If you use the Model ID certified by Google and the device is in the show UI indication advertising mode, a notification similar to the following one appears:
+      #. Wait until the Fast Pair Provider is added to :guilabel:`Saved devices` on the second Android device:
 
-   .. figure:: /images/bt_fast_pair_not_discoverable_notification.png
-      :scale: 50 %
-      :alt: Fast Pair not discoverable advertising Android notification
+         a. Go to :guilabel:`Settings` > :guilabel:`Google` > :guilabel:`Devices & sharing` (or :guilabel:`Device connections`) > :guilabel:`Devices` > :guilabel:`Saved devices`.
+            The paired device appears on the list.
+         #. If the device does not appear on the list, wait until the data is synced between phones.
 
-   If you use the debug Model ID (for example, the default is *NCS input device*) and the device is in the show UI indication advertising mode, a notification similar to the following one appears:
+      #. Move the second Android device close to the Fast Pair Provider.
+         If you use the Model ID certified by Google and the device is in the show UI indication advertising mode, a notification similar to the following one appears:
 
-   .. figure:: /images/bt_fast_pair_not_discoverable_notification_debug.png
-      :scale: 50 %
-      :alt: Fast Pair not discoverable advertising Android notification for debug Model ID
+         .. figure:: /images/bt_fast_pair_not_discoverable_notification.png
+            :scale: 50 %
+            :alt: Fast Pair not discoverable advertising Android notification
 
-   The *Nordic* name is replaced by your own Google account name as this is a default name created by the Fast Pair Seeker during the initial pairing.
+         If you use the debug Model ID (for example, the default is *NCS input device*) and the device is in the show UI indication advertising mode, a notification similar to the following one appears:
 
-   If the device is in the hide UI indication advertising mode, no notification appears.
-   This is because the device advertises, but does not want to be paired with.
-   You can verify that the device is advertising using the `nRF Connect for Mobile`_ application.
+         .. figure:: /images/bt_fast_pair_not_discoverable_notification_debug.png
+            :scale: 50 %
+            :alt: Fast Pair not discoverable advertising Android notification for debug Model ID
 
-#. In the show UI indication mode, when the notification appears, tap on it to trigger the Fast Pair procedure.
-#. Wait for the notification about successful Fast Pair procedure.
-   **LED 2** is lit to inform that the device is connected with the Bluetooth Central.
+         The *Nordic* name is replaced by your own Google account name as this is a default name created by the Fast Pair Seeker during the initial pairing.
 
-   .. note::
-      Some Android devices might disconnect right after Fast Pair procedure is finished.
-      Go to :guilabel:`Settings` > :guilabel:`Bluetooth` and tap on the bonded Fast Pair Provider to reconnect.
+         If the device is in the hide UI indication advertising mode, no notification appears.
+         This is because the device advertises, but does not want to be paired with.
+         You can verify that the device is advertising using the `nRF Connect for Mobile`_ application.
 
-   You can now use the connected Fast Pair Provider to control the audio volume of the Bluetooth Central.
-#. Press **Button 2** to increase the audio volume.
-#. Press **Button 4** to decrease the audio volume.
+      #. In the show UI indication mode, when the notification appears, tap on it to trigger the Fast Pair procedure.
+      #. Wait for the notification about successful Fast Pair procedure.
+         **LED 2** is lit to inform that the device is connected with the Bluetooth Central.
+
+         .. note::
+            Some Android devices might disconnect right after Fast Pair procedure is finished.
+            Go to :guilabel:`Settings` > :guilabel:`Bluetooth` and tap on the bonded Fast Pair Provider to reconnect.
+
+         You can now use the connected Fast Pair Provider to control the audio volume of the Bluetooth Central.
+      #. Press **Button 2** to increase the audio volume.
+      #. Press **Button 4** to decrease the audio volume.
+
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      #. Disconnect the Android device that was used during the default `Testing`_:
+
+         a. Go to :guilabel:`Settings` > :guilabel:`Bluetooth`.
+         #. Tap on the connected device name to disconnect it.
+
+            .. note::
+               Do not remove Bluetooth bond information related to the Fast Pair Provider.
+
+            After disconnection, the provider automatically switches from the discoverable advertising to the not discoverable advertising with the show UI indication mode.
+            **LED 2** is blinking rapidly.
+
+      #. Make sure that the Fast Pair Provider is added to :guilabel:`Saved devices` on the Android device that was used for `Testing`_:
+
+         a. Go to :guilabel:`Settings` > :guilabel:`Google` > :guilabel:`Devices & sharing` (or :guilabel:`Device connections`) > :guilabel:`Devices` > :guilabel:`Saved devices`.
+         #. Verify that the paired device is appearing on the list.
+
+      #. If you want to test the Fast Pair not discoverable advertising with the hide UI indication mode, press **Button 0**.
+         **LED 2** starts blinking slowly.
+
+      #. Wait until the Fast Pair Provider is added to :guilabel:`Saved devices` on the second Android device:
+
+         a. Go to :guilabel:`Settings` > :guilabel:`Google` > :guilabel:`Devices & sharing` (or :guilabel:`Device connections`) > :guilabel:`Devices` > :guilabel:`Saved devices`.
+            The paired device appears on the list.
+         #. If the device does not appear on the list, wait until the data is synced between phones.
+
+      #. Move the second Android device close to the Fast Pair Provider.
+         If you use the Model ID certified by Google and the device is in the show UI indication advertising mode, a notification similar to the following one appears:
+
+         .. figure:: /images/bt_fast_pair_not_discoverable_notification.png
+            :scale: 50 %
+            :alt: Fast Pair not discoverable advertising Android notification
+
+         If you use the debug Model ID (for example, the default is *NCS input device*) and the device is in the show UI indication advertising mode, a notification similar to the following one appears:
+
+         .. figure:: /images/bt_fast_pair_not_discoverable_notification_debug.png
+            :scale: 50 %
+            :alt: Fast Pair not discoverable advertising Android notification for debug Model ID
+
+         The *Nordic* name is replaced by your own Google account name as this is a default name created by the Fast Pair Seeker during the initial pairing.
+
+         If the device is in the hide UI indication advertising mode, no notification appears.
+         This is because the device advertises, but does not want to be paired with.
+         You can verify that the device is advertising using the `nRF Connect for Mobile`_ application.
+
+      #. In the show UI indication mode, when the notification appears, tap on it to trigger the Fast Pair procedure.
+      #. Wait for the notification about successful Fast Pair procedure.
+         **LED 1** is lit to inform that the device is connected with the Bluetooth Central.
+
+         .. note::
+            Some Android devices might disconnect right after Fast Pair procedure is finished.
+            Go to :guilabel:`Settings` > :guilabel:`Bluetooth` and tap on the bonded Fast Pair Provider to reconnect.
+
+         You can now use the connected Fast Pair Provider to control the audio volume of the Bluetooth Central.
+      #. Press **Button 1** to increase the audio volume.
+      #. Press **Button 3** to decrease the audio volume.
 
 Personalized Name extension
 ----------------------------

--- a/samples/bluetooth/fast_pair/locator_tag/README.rst
+++ b/samples/bluetooth/fast_pair/locator_tag/README.rst
@@ -136,91 +136,188 @@ The user interface of the sample depends on the hardware platform you are using.
 Development kits
 ================
 
-LED 1:
-   Keeps blinking at constant intervals to indicate that firmware is running.
+.. tabs::
 
-LED 2:
-   Indicates that the ringing action is in progress.
-   Depending on the ringing state:
+   .. group-tab:: nRF52 and nRF53 DKs
 
-   * Lit if the device is ringing.
-   * Off if the device is not ringing.
+      LED 1:
+         Keeps blinking at constant intervals to indicate that firmware is running.
 
-LED 3:
-   Depending on the FMDN provisioning state:
+      LED 2:
+         Indicates that the ringing action is in progress.
+         Depending on the ringing state:
 
-   * Lit if the device is provisioned.
-   * Off if the device is not provisioned.
+         * Lit if the device is ringing.
+         * Off if the device is not ringing.
 
-LED 4:
-   Depending on the states of the recovery mode and the identification mode:
+      LED 3:
+         Depending on the FMDN provisioning state:
 
-   * Lit if both modes are active on the device.
-   * Off if both modes are inactive on the device.
-   * Blinks at a 0.5 second interval if the identification mode is active on the device and the recovery mode is inactive on the device.
-   * Blinks at a 1 second interval if the recovery mode is active on the device and the identification mode is inactive on the device.
+         * Lit if the device is provisioned.
+         * Off if the device is not provisioned.
 
-Button 1:
-   Toggles between different modes of the Fast Pair advertising set:
+      LED 4:
+         Depending on the states of the recovery mode and the identification mode:
 
-   * Without an Account Key stored on the device:
+         * Lit if both modes are active on the device.
+         * Off if both modes are inactive on the device.
+         * Blinks at a 0.5 second interval if the identification mode is active on the device and the recovery mode is inactive on the device.
+         * Blinks at a 1 second interval if the recovery mode is active on the device and the identification mode is inactive on the device.
 
-     * Fast Pair advertising disabled.
-     * Fast Pair discoverable advertising (the default after the system bootup).
+      Button 1:
+         Toggles between different modes of the Fast Pair advertising set:
 
-   * With an Account Key stored on the device:
+         * Without an Account Key stored on the device:
 
-     * Fast Pair advertising disabled.
-     * Fast Pair not discoverable advertising (the default after the system bootup).
+           * Fast Pair advertising disabled.
+           * Fast Pair discoverable advertising (the default after the system bootup).
 
-   .. note::
-      The Bluetooth advertising is active only until the Fast Pair Provider connects to a Bluetooth Central.
-      After the connection, you can still switch the advertising modes, but the switch will come into effect only after disconnection.
+         * With an Account Key stored on the device:
 
-      The sample automatically switches to the following Fast Pair advertising modes under certain conditions:
+           * Fast Pair advertising disabled.
+           * Fast Pair not discoverable advertising (the default after the system bootup).
 
-      * Fast Pair not discoverable advertising - On the Account Key write operation.
-      * Fast Pair advertising disabled:
+         .. note::
 
-        * Right before the factory reset operation.
-          Press **Button 1** to set the device to the Fast Pair discoverable advertising mode after the unprovisioning operation.
-        * After the beacon clock synchronization.
+            The Bluetooth advertising is active only until the Fast Pair Provider connects to a Bluetooth Central.
+            After the connection, you can still switch the advertising modes, but the switch will come into effect only after disconnection.
 
-Button 2:
-   Stops the ongoing ringing action.
+            The sample automatically switches to the following Fast Pair advertising modes under certain conditions:
 
-Button 3:
-   Decrements the battery level by 10% (the default value in the :ref:`CONFIG_APP_BATTERY_LEVEL_DECREMENT <CONFIG_APP_BATTERY_LEVEL_DECREMENT>` Kconfig option), starting from the full battery level of 100%.
-   In the default sample configuration, with the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_BATTERY_DULT` Kconfig option enabled, pressing the button when the battery level is lower than the decrement value transitions the device back to the starting point of 100%.
-   You can disable the default :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_BATTERY_DULT` Kconfig setting to transition through the mode in which the battery level indication is not supported (refer to the last point in the list).
-   The battery level is encoded in the FMDN advertising set according to the following rules:
+            * Fast Pair not discoverable advertising - On the Account Key write operation.
+            * Fast Pair advertising disabled:
 
-   * Normal battery level (starting point, as derived from the 100% battery level) - The battery level is higher than 40% and less than or equal to 100%.
-     The lower threshold, 40%, is controlled by the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_BATTERY_LEVEL_LOW_THR` Kconfig option.
-   * Low battery level - The battery level is higher than 10% and less than or equal to 40%.
-     The lower threshold, 10%, is controlled by the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_BATTERY_LEVEL_CRITICAL_THR` Kconfig option.
-   * Critically low battery level (battery replacement needed soon) - The battery level is higher than or equal to 0% and less than or equal to 10%.
-   * Battery level indication unsupported - Occurs when the special :c:macro:`BT_FAST_PAIR_FMDN_BATTERY_LEVEL_NONE` value is used.
-     This battery level is unavailable in the default sample configuration.
-     You can disable the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_BATTERY_DULT` Kconfig option to reach this mode when transitioning from the critically low battery level to the full battery level of 100%.
+               * Right before the factory reset operation.
+                 Press **Button 1** to set the device to the Fast Pair discoverable advertising mode after the unprovisioning operation.
 
-   In the default sample configuration, with the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_BATTERY_DULT` Kconfig option enabled, the battery level is also encoded in the Battery Level response of the Accessory Non-owner Service (ANOS), which is set according to the following rules:
+               * After the beacon clock synchronization.
 
-   * Full battery level (starting point, as derived from the 100% battery level) - The battery level is higher than 80% and less than or equal to 100%.
-     The lower threshold, 80%, is controlled by the :kconfig:option:`CONFIG_DULT_BATTERY_LEVEL_MEDIUM_THR` Kconfig option.
-   * Medium battery level - The battery level is higher than 40% and less than or equal to 80%.
-     The lower threshold, 40%, is controlled by the :kconfig:option:`CONFIG_DULT_BATTERY_LEVEL_LOW_THR` Kconfig option.
-   * Low battery level - The battery level is higher than 10% and less than or equal to 40%.
-     The lower threshold, 10%, is controlled by the :kconfig:option:`CONFIG_DULT_BATTERY_LEVEL_CRITICAL_THR` Kconfig option.
-   * Critically low battery level (battery replacement needed soon) - The battery level is higher than or equal to 0% and less than or equal to 10%.
+      Button 2:
+         Stops the ongoing ringing action.
 
-Button 4:
-   A short press requests the FMDN subsystem to enable the identification mode for five minutes.
-   This timeout value is defined by the :kconfig:option:`CONFIG_DULT_ID_READ_STATE_TIMEOUT` Kconfig option according to the DULT specification requirements.
+      Button 3:
+         Decrements the battery level by 10% (the default value in the :ref:`CONFIG_APP_BATTERY_LEVEL_DECREMENT <CONFIG_APP_BATTERY_LEVEL_DECREMENT>` Kconfig option), starting from the full battery level of 100%.
+         In the default sample configuration, with the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_BATTERY_DULT` Kconfig option enabled, pressing the button when the battery level is lower than the decrement value transitions the device back to the starting point of 100%.
+         You can disable the default :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_BATTERY_DULT` Kconfig setting to transition through the mode in which the battery level indication is not supported (refer to the last point in the list).
+         The battery level is encoded in the FMDN advertising set according to the following rules:
 
-   A long press (>3 s) enables the recovery mode for one minute as defined by the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_READ_MODE_FMDN_RECOVERY_TIMEOUT` Kconfig option.
+         * Normal battery level (starting point, as derived from the 100% battery level) - The battery level is higher than 40% and less than or equal to 100%.
+           The lower threshold, 40%, is controlled by the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_BATTERY_LEVEL_LOW_THR` Kconfig option.
+         * Low battery level - The battery level is higher than 10% and less than or equal to 40%.
+           The lower threshold, 10%, is controlled by the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_BATTERY_LEVEL_CRITICAL_THR` Kconfig option.
+         * Critically low battery level (battery replacement needed soon) - The battery level is higher than or equal to 0% and less than or equal to 10%.
+         * Battery level indication unsupported - Occurs when the special :c:macro:`BT_FAST_PAIR_FMDN_BATTERY_LEVEL_NONE` value is used.
+           This battery level is unavailable in the default sample configuration.
+           You can disable the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_BATTERY_DULT` Kconfig option to reach this mode when transitioning from the critically low battery level to the full battery level of 100%.
 
-   When pressed during the application bootup, resets the accessory to default factory settings.
+         In the default sample configuration, with the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_BATTERY_DULT` Kconfig option enabled, the battery level is also encoded in the Battery Level response of the Accessory Non-owner Service (ANOS), which is set according to the following rules:
+
+         * Full battery level (starting point, as derived from the 100% battery level) - The battery level is higher than 80% and less than or equal to 100%.
+           The lower threshold, 80%, is controlled by the :kconfig:option:`CONFIG_DULT_BATTERY_LEVEL_MEDIUM_THR` Kconfig option.
+         * Medium battery level - The battery level is higher than 40% and less than or equal to 80%.
+           The lower threshold, 40%, is controlled by the :kconfig:option:`CONFIG_DULT_BATTERY_LEVEL_LOW_THR` Kconfig option.
+         * Low battery level - The battery level is higher than 10% and less than or equal to 40%.
+           The lower threshold, 10%, is controlled by the :kconfig:option:`CONFIG_DULT_BATTERY_LEVEL_CRITICAL_THR` Kconfig option.
+         * Critically low battery level (battery replacement needed soon) - The battery level is higher than or equal to 0% and less than or equal to 10%.
+
+      Button 4:
+         A short press requests the FMDN subsystem to enable the identification mode for five minutes.
+         This timeout value is defined by the :kconfig:option:`CONFIG_DULT_ID_READ_STATE_TIMEOUT` Kconfig option according to the DULT specification requirements.
+
+         A long press (>3 s) enables the recovery mode for one minute as defined by the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_READ_MODE_FMDN_RECOVERY_TIMEOUT` Kconfig option.
+
+         When pressed during the application bootup, resets the accessory to default factory settings.
+
+
+   .. group-tab:: nRF54 DKs
+
+      LED 0:
+         Keeps blinking at constant intervals to indicate that firmware is running.
+
+      LED 1:
+         Indicates that the ringing action is in progress.
+         Depending on the ringing state:
+
+         * Lit if the device is ringing.
+         * Off if the device is not ringing.
+
+      LED 2:
+         Depending on the FMDN provisioning state:
+
+         * Lit if the device is provisioned.
+         * Off if the device is not provisioned.
+
+      LED 3:
+         Depending on the states of the recovery mode and the identification mode:
+
+         * Lit if both modes are active on the device.
+         * Off if both modes are inactive on the device.
+         * Blinks at a 0.5 second interval if the identification mode is active on the device and the recovery mode is inactive on the device.
+         * Blinks at a 1 second interval if the recovery mode is active on the device and the identification mode is inactive on the device.
+
+      Button 0:
+         Toggles between different modes of the Fast Pair advertising set:
+
+         * Without an Account Key stored on the device:
+
+           * Fast Pair advertising disabled.
+           * Fast Pair discoverable advertising (the default after the system bootup).
+
+         * With an Account Key stored on the device:
+
+           * Fast Pair advertising disabled.
+           * Fast Pair not discoverable advertising (the default after the system bootup).
+
+         .. note::
+
+            The Bluetooth advertising is active only until the Fast Pair Provider connects to a Bluetooth Central.
+            After the connection, you can still switch the advertising modes, but the switch will come into effect only after disconnection.
+
+            The sample automatically switches to the following Fast Pair advertising modes under certain conditions:
+
+            * Fast Pair not discoverable advertising - On the Account Key write operation.
+            * Fast Pair advertising disabled:
+
+              * Right before the factory reset operation.
+                Press **Button 0** to set the device to the Fast Pair discoverable advertising mode after the unprovisioning operation.
+
+              * After the beacon clock synchronization.
+
+      Button 1:
+         Stops the ongoing ringing action.
+
+      Button 2:
+         Decrements the battery level by 10% (the default value in the :ref:`CONFIG_APP_BATTERY_LEVEL_DECREMENT <CONFIG_APP_BATTERY_LEVEL_DECREMENT>` Kconfig option), starting from the full battery level of 100%.
+         In the default sample configuration, with the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_BATTERY_DULT` Kconfig option enabled, pressing the button when the battery level is lower than the decrement value transitions the device back to the starting point of 100%.
+         You can disable the default :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_BATTERY_DULT` Kconfig setting to transition through the mode in which the battery level indication is not supported (refer to the last point in the list).
+         The battery level is encoded in the FMDN advertising set according to the following rules:
+
+         * Normal battery level (starting point, as derived from the 100% battery level) - The battery level is higher than 40% and less than or equal to 100%.
+           The lower threshold, 40%, is controlled by the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_BATTERY_LEVEL_LOW_THR` Kconfig option.
+         * Low battery level - The battery level is higher than 10% and less than or equal to 40%.
+           The lower threshold, 10%, is controlled by the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_BATTERY_LEVEL_CRITICAL_THR` Kconfig option.
+         * Critically low battery level (battery replacement needed soon) - The battery level is higher than or equal to 0% and less than or equal to 10%.
+         * Battery level indication unsupported - Occurs when the special :c:macro:`BT_FAST_PAIR_FMDN_BATTERY_LEVEL_NONE` value is used.
+           This battery level is unavailable in the default sample configuration.
+           You can disable the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_BATTERY_DULT` Kconfig option to reach this mode when transitioning from the critically low battery level to the full battery level of 100%.
+
+         In the default sample configuration, with the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_BATTERY_DULT` Kconfig option enabled, the battery level is also encoded in the Battery Level response of the Accessory Non-owner Service (ANOS), which is set according to the following rules:
+
+         * Full battery level (starting point, as derived from the 100% battery level) - The battery level is higher than 80% and less than or equal to 100%.
+           The lower threshold, 80%, is controlled by the :kconfig:option:`CONFIG_DULT_BATTERY_LEVEL_MEDIUM_THR` Kconfig option.
+         * Medium battery level - The battery level is higher than 40% and less than or equal to 80%.
+           The lower threshold, 40%, is controlled by the :kconfig:option:`CONFIG_DULT_BATTERY_LEVEL_LOW_THR` Kconfig option.
+         * Low battery level - The battery level is higher than 10% and less than or equal to 40%.
+           The lower threshold, 10%, is controlled by the :kconfig:option:`CONFIG_DULT_BATTERY_LEVEL_CRITICAL_THR` Kconfig option.
+         * Critically low battery level (battery replacement needed soon) - The battery level is higher than or equal to 0% and less than or equal to 10%.
+
+      Button 3:
+         A short press requests the FMDN subsystem to enable the identification mode for five minutes.
+         This timeout value is defined by the :kconfig:option:`CONFIG_DULT_ID_READ_STATE_TIMEOUT` Kconfig option according to the DULT specification requirements.
+
+         A long press (>3 s) enables the recovery mode for one minute as defined by the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_READ_MODE_FMDN_RECOVERY_TIMEOUT` Kconfig option.
+
+         When pressed during the application bootup, resets the accessory to default factory settings.
 
 Thingy:53
 =========
@@ -375,67 +472,136 @@ Testing
 
 |test_sample|
 
-1. |connect_terminal_specific|
-#. Reset the development kit.
-#. Observe that **LED 1** is blinking to indicate that firmware is running.
-#. Observe that **LED 3** is off, which indicates that the device is not provisioned as an FMDN beacon.
-   The Fast Pair Provider is advertising in the Fast Pair discoverable mode and is ready for the FMDN provisioning.
-#. Move the Android device close to your locator tag device.
-#. Wait for the notification from your Android device about the detected Fast Pair Provider.
+.. tabs::
 
-   .. figure:: /images/bt_fast_pair_locator_tag_discoverable_notification.png
-      :scale: 80 %
-      :alt: Fast Pair discoverable notification with support for the `Find My Device app`_
+   .. group-tab:: nRF52 and nRF53 DKs
 
-#. Initiate the connection and trigger the Fast Pair procedure by tapping the :guilabel:`Connect` button.
-   After the procedure is complete, you will see a pop-up with the Acceptable Use Policy for the `Find My Device app`_.
-#. If you want to start the FMDN provisioning, accept the Acceptable Use Policy by tapping the :guilabel:`Agree and continue` button.
+      1. |connect_terminal_specific|
+      #. Reset the development kit.
+      #. Observe that **LED 1** is blinking to indicate that firmware is running.
+      #. Observe that **LED 3** is off, which indicates that the device is not provisioned as an FMDN beacon.
+         The Fast Pair Provider is advertising in the Fast Pair discoverable mode and is ready for the FMDN provisioning.
+      #. Move the Android device close to your locator tag device.
+      #. Wait for the notification from your Android device about the detected Fast Pair Provider.
 
-   .. figure:: /images/bt_fast_pair_locator_tag_acceptable_use_policy.png
-      :scale: 80 %
-      :alt: The Find My Device Acceptable Use Policy
+         .. figure:: /images/bt_fast_pair_locator_tag_discoverable_notification.png
+            :scale: 80 %
+            :alt: Fast Pair discoverable notification with support for the `Find My Device app`_
 
-#. Wait for the Android device's notification that indicates completion of the provisioning process.
+      #. Initiate the connection and trigger the Fast Pair procedure by tapping the :guilabel:`Connect` button.
+         After the procedure is complete, you will see a pop-up with the Acceptable Use Policy for the `Find My Device app`_.
+      #. If you want to start the FMDN provisioning, accept the Acceptable Use Policy by tapping the :guilabel:`Agree and continue` button.
 
-   .. figure:: /images/bt_fast_pair_locator_tag_provisioning_complete.png
-      :scale: 80 %
-      :alt: Notification about provisioning completion for the `Find My Device app`_
+         .. figure:: /images/bt_fast_pair_locator_tag_acceptable_use_policy.png
+            :scale: 80 %
+            :alt: The Find My Device Acceptable Use Policy
 
-#. Observe that **LED 3** is lit, which indicates that the device is provisioned as an FMDN beacon.
-#. Open the `Find My Device app`_ by tapping the :guilabel:`Open app` button.
-#. In your accessory view, tap the :guilabel:`Find nearby` button.
-#. Observe in the Find nearby view that the grey shape shrinks when you move your Android device further away from your locator tag device.
-   The shape also grows when you move your Android device closer to the locator tag.
-   The closest proximity level is indicated by the device logo displayed inside the grey shape.
+      #. Wait for the Android device's notification that indicates completion of the provisioning process.
 
-   .. figure:: /images/bt_fast_pair_locator_tag_fmd_app_nearby_view.png
-      :scale: 80 %
-      :alt: Find nearby view of the `Find My Device app`_
+         .. figure:: /images/bt_fast_pair_locator_tag_provisioning_complete.png
+            :scale: 80 %
+            :alt: Notification about provisioning completion for the `Find My Device app`_
 
-#. Start the ringing action on your device by tapping the :guilabel:`Play sound` button.
-#. Observe that **LED 2** is lit, which indicates that the ringing action is in progress.
-#. Stop the ringing action in one of the following ways:
+      #. Observe that **LED 3** is lit, which indicates that the device is provisioned as an FMDN beacon.
+      #. Open the `Find My Device app`_ by tapping the :guilabel:`Open app` button.
+      #. In your accessory view, tap the :guilabel:`Find nearby` button.
+      #. Observe in the Find nearby view that the grey shape shrinks when you move your Android device further away from your locator tag device.
+         The shape also grows when you move your Android device closer to the locator tag.
+         The closest proximity level is indicated by the device logo displayed inside the grey shape.
 
-   * Press **Button 2** on the locator tag device.
-   * Tap the :guilabel:`Stop sound` button in the `Find My Device app`_.
+         .. figure:: /images/bt_fast_pair_locator_tag_fmd_app_nearby_view.png
+            :scale: 80 %
+            :alt: Find nearby view of the `Find My Device app`_
 
-#. Observe that **LED 2** is off, which indicates that your accessory is no longer ringing.
-#. Press **Button 3** a few times to change the normal (default) battery level to low battery level.
-#. See that the Android notification with the **Device with low battery** label is displayed after a while.
-#. Exit the Find nearby view and return to the main accessory view.
-#. Open **Device details** by tapping the cog icon, located below the map view, next to the accessory name.
-#. Start the unprovisioning operation by tapping the :guilabel:`Remove from Find My Device` button at the bottom of the screen.
-#. Confirm the operation by tapping the :guilabel:`Remove` button in the Remove from Find My Device view.
+      #. Start the ringing action on your device by tapping the :guilabel:`Play sound` button.
+      #. Observe that **LED 2** is lit, which indicates that the ringing action is in progress.
+      #. Stop the ringing action in one of the following ways:
 
-   .. figure:: /images/bt_fast_pair_locator_tag_fmd_app_unprovision.png
-      :scale: 80 %
-      :alt: Remove from Find My Device view
+         * Press **Button 2** on the locator tag device.
+         * Tap the :guilabel:`Stop sound` button in the `Find My Device app`_.
 
-#. Reconfirm the procedure by tapping the :guilabel:`Remove` button in the Android pop-up window.
-#. Wait for the unprovisioning operation to complete.
-#. Observe that **LED 3** is off, which indicates that the device is no longer provisioned as an FMDN beacon.
-#. Observe that the Android does not display a notification about the detected Fast Pair Provider, as the locator tag device disables advertising after the unprovisioning operation.
-#. Press **Button 1** if you want to start the Fast Pair discoverable advertising and restart the FMDN provisioning process.
+      #. Observe that **LED 2** is off, which indicates that your accessory is no longer ringing.
+      #. Press **Button 3** a few times to change the normal (default) battery level to low battery level.
+      #. See that the Android notification with the **Device with low battery** label is displayed after a while.
+      #. Exit the Find nearby view and return to the main accessory view.
+      #. Open **Device details** by tapping the cog icon, located below the map view, next to the accessory name.
+      #. Start the unprovisioning operation by tapping the :guilabel:`Remove from Find My Device` button at the bottom of the screen.
+      #. Confirm the operation by tapping the :guilabel:`Remove` button in the Remove from Find My Device view.
+
+         .. figure:: /images/bt_fast_pair_locator_tag_fmd_app_unprovision.png
+            :scale: 80 %
+            :alt: Remove from Find My Device view
+
+      #. Reconfirm the procedure by tapping the :guilabel:`Remove` button in the Android pop-up window.
+      #. Wait for the unprovisioning operation to complete.
+      #. Observe that **LED 3** is off, which indicates that the device is no longer provisioned as an FMDN beacon.
+      #. Observe that the Android does not display a notification about the detected Fast Pair Provider, as the locator tag device disables advertising after the unprovisioning operation.
+      #. Press **Button 1** if you want to start the Fast Pair discoverable advertising and restart the FMDN provisioning process.
+
+   .. group-tab:: nRF54 DKs
+
+      1. |connect_terminal_specific|
+      #. Reset the development kit.
+      #. Observe that **LED 0** is blinking to indicate that firmware is running.
+      #. Observe that **LED 2** is off, which indicates that the device is not provisioned as an FMDN beacon.
+         The Fast Pair Provider is advertising in the Fast Pair discoverable mode and is ready for the FMDN provisioning.
+      #. Move the Android device close to your locator tag device.
+      #. Wait for the notification from your Android device about the detected Fast Pair Provider.
+
+         .. figure:: /images/bt_fast_pair_locator_tag_discoverable_notification.png
+            :scale: 80 %
+            :alt: Fast Pair discoverable notification with support for the `Find My Device app`_
+
+      #. Initiate the connection and trigger the Fast Pair procedure by tapping the :guilabel:`Connect` button.
+         After the procedure is complete, you will see a pop-up with the Acceptable Use Policy for the `Find My Device app`_.
+      #. If you want to start the FMDN provisioning, accept the Acceptable Use Policy by tapping the :guilabel:`Agree and continue` button.
+
+         .. figure:: /images/bt_fast_pair_locator_tag_acceptable_use_policy.png
+            :scale: 80 %
+            :alt: The Find My Device Acceptable Use Policy
+
+      #. Wait for the Android device's notification that indicates completion of the provisioning process.
+
+         .. figure:: /images/bt_fast_pair_locator_tag_provisioning_complete.png
+            :scale: 80 %
+            :alt: Notification about provisioning completion for the `Find My Device app`_
+
+      #. Observe that **LED 2** is lit, which indicates that the device is provisioned as an FMDN beacon.
+      #. Open the `Find My Device app`_ by tapping the :guilabel:`Open app` button.
+      #. In your accessory view, tap the :guilabel:`Find nearby` button.
+      #. Observe in the Find nearby view that the grey shape shrinks when you move your Android device further away from your locator tag device.
+         The shape also grows when you move your Android device closer to the locator tag.
+         The closest proximity level is indicated by the device logo displayed inside the grey shape.
+
+         .. figure:: /images/bt_fast_pair_locator_tag_fmd_app_nearby_view.png
+            :scale: 80 %
+            :alt: Find nearby view of the `Find My Device app`_
+
+      #. Start the ringing action on your device by tapping the :guilabel:`Play sound` button.
+      #. Observe that **LED 1** is lit, which indicates that the ringing action is in progress.
+      #. Stop the ringing action in one of the following ways:
+
+         * Press **Button 1** on the locator tag device.
+         * Tap the :guilabel:`Stop sound` button in the `Find My Device app`_.
+
+      #. Observe that **LED 1** is off, which indicates that your accessory is no longer ringing.
+      #. Press **Button 2** a few times to change the normal (default) battery level to low battery level.
+      #. See that the Android notification with the **Device with low battery** label is displayed after a while.
+      #. Exit the Find nearby view and return to the main accessory view.
+      #. Open **Device details** by tapping the cog icon, located below the map view, next to the accessory name.
+      #. Start the unprovisioning operation by tapping the :guilabel:`Remove from Find My Device` button at the bottom of the screen.
+      #. Confirm the operation by tapping the :guilabel:`Remove` button in the Remove from Find My Device view.
+
+         .. figure:: /images/bt_fast_pair_locator_tag_fmd_app_unprovision.png
+            :scale: 80 %
+            :alt: Remove from Find My Device view
+
+      #. Reconfirm the procedure by tapping the :guilabel:`Remove` button in the Android pop-up window.
+      #. Wait for the unprovisioning operation to complete.
+      #. Observe that **LED 2** is off, which indicates that the device is no longer provisioned as an FMDN beacon.
+      #. Observe that the Android does not display a notification about the detected Fast Pair Provider, as the locator tag device disables advertising after the unprovisioning operation.
+      #. Press **Button 0** if you want to start the Fast Pair discoverable advertising and restart the FMDN provisioning process.
+
 
 Clock synchronization
 ---------------------
@@ -445,39 +611,79 @@ The device must be registered to a **different** Google account from the first A
 
 To test this feature, complete the following steps:
 
-1. Go to the :ref:`fast_pair_locator_tag_testing` section and follow the instructions on performing the FMDN provisioning operation.
-#. Observe that **LED 3** is lit, which indicates that the device is provisioned as an FMDN beacon.
-#. Power off the development kit and wait for 24 hours.
-#. Power off the Android device that you used to perform the FMDN provisioning operation.
-#. Power on the development kit.
-#. |connect_terminal_specific|
-#. Use your second Android device configured for a **different** account, and start the `nRF Connect for Mobile`_ application.
-#. Wait for the **SCANNER** tab of the mobile application to populate the scanning list.
-#. Observe that the device advertising the Fast Pair Service UUID (*0xFE2C*) AD type with the Fast Pair Account Data payload is present in the scanning list.
-   This entry indicates that the development kit is in the clock synchronization mode, and it is advertising the Fast Pair not discoverable payload.
+.. tabs::
 
-   .. note::
-      By default, the `nRF Connect for Mobile`_ application filters advertising packets used by ecosystems like Google or Apple.
-      You need to take additional steps to see the Fast Pair advertising on the scanning list:
+   .. group-tab:: nRF52 and nRF53 DKs
 
-         1. In the **SCANNER** tab of the `nRF Connect for Mobile`_ application, tap the :guilabel:`No filter` white bar below the **SCANNER** label.
-         #. In the drop-down menu for the filtering configuration, tap the three-dot icon in the **Exclude** option.
-         #. In the exclude configuration menu, uncheck the **Google** option to remove the filtering for Google-related advertising like the Fast Pair advertising.
-         #. Close the exclude configuration menu and the filtering configuration drop-down.
-         #. Tap the :guilabel:`SCAN` button to restart the scanning activity.
+      1. Go to the :ref:`fast_pair_locator_tag_testing` section and follow the instructions on performing the FMDN provisioning operation.
+      #. Observe that **LED 3** is lit, which indicates that the device is provisioned as an FMDN beacon.
+      #. Power off the development kit and wait for 24 hours.
+      #. Power off the Android device that you used to perform the FMDN provisioning operation.
+      #. Power on the development kit.
+      #. |connect_terminal_specific|
+      #. Use your second Android device configured for a **different** account, and start the `nRF Connect for Mobile`_ application.
+      #. Wait for the **SCANNER** tab of the mobile application to populate the scanning list.
+      #. Observe that the device advertising the Fast Pair Service UUID (*0xFE2C*) AD type with the Fast Pair Account Data payload is present in the scanning list.
+         This entry indicates that the development kit is in the clock synchronization mode, and it is advertising the Fast Pair not discoverable payload.
 
-#. Power on the first Android device that you used to perform the FMDN provisioning operation.
-#. In the terminal, observe the message confirming that your first Android device connected to the development kit and synchronized the clock value::
+         .. note::
+            By default, the `nRF Connect for Mobile`_ application filters advertising packets used by ecosystems like Google or Apple.
+            You need to take additional steps to see the Fast Pair advertising on the scanning list:
 
-      FMDN: clock information synchronized with the authenticated Bluetooth peer
+               1. In the **SCANNER** tab of the `nRF Connect for Mobile`_ application, tap the :guilabel:`No filter` white bar below the **SCANNER** label.
+               #. In the drop-down menu for the filtering configuration, tap the three-dot icon in the **Exclude** option.
+               #. In the exclude configuration menu, uncheck the **Google** option to remove the filtering for Google-related advertising like the Fast Pair advertising.
+               #. Close the exclude configuration menu and the filtering configuration drop-down.
+               #. Tap the :guilabel:`SCAN` button to restart the scanning activity.
 
-#. Go back to your second Android device and refresh the scanning list in the `nRF Connect for Mobile`_ application.
-#. Observe that the entry for the device advertising the Fast Pair Service UUID AD type is no longer present in the scanning list.
-   The missing entry indicates that the development kit is no longer in the clock synchronization mode, and it is not advertising the Fast Pair not discoverable payload.
-#. In your first Android device, open the `Find My Device app`_.
-   Navigate to your accessory view, and tap the :guilabel:`Find nearby` button.
-#. Start the ringing action on your device by tapping the :guilabel:`Play sound` button.
-#. Observe that **LED 2** is lit to confirm that the Android device is able to connect to your development kit after a clock synchronization.
+      #. Power on the first Android device that you used to perform the FMDN provisioning operation.
+      #. In the terminal, observe the message confirming that your first Android device connected to the development kit and synchronized the clock value::
+
+            FMDN: clock information synchronized with the authenticated Bluetooth peer
+
+      #. Go back to your second Android device and refresh the scanning list in the `nRF Connect for Mobile`_ application.
+      #. Observe that the entry for the device advertising the Fast Pair Service UUID AD type is no longer present in the scanning list.
+         The missing entry indicates that the development kit is no longer in the clock synchronization mode, and it is not advertising the Fast Pair not discoverable payload.
+      #. In your first Android device, open the `Find My Device app`_.
+         Navigate to your accessory view, and tap the :guilabel:`Find nearby` button.
+      #. Start the ringing action on your device by tapping the :guilabel:`Play sound` button.
+      #. Observe that **LED 2** is lit to confirm that the Android device is able to connect to your development kit after a clock synchronization.
+
+   .. group-tab:: nRF54 DKs
+
+      1. Go to the :ref:`fast_pair_locator_tag_testing` section and follow the instructions on performing the FMDN provisioning operation.
+      #. Observe that **LED 2** is lit, which indicates that the device is provisioned as an FMDN beacon.
+      #. Power off the development kit and wait for 24 hours.
+      #. Power off the Android device that you used to perform the FMDN provisioning operation.
+      #. Power on the development kit.
+      #. |connect_terminal_specific|
+      #. Use your second Android device configured for a **different** account, and start the `nRF Connect for Mobile`_ application.
+      #. Wait for the **SCANNER** tab of the mobile application to populate the scanning list.
+      #. Observe that the device advertising the Fast Pair Service UUID (*0xFE2C*) AD type with the Fast Pair Account Data payload is present in the scanning list.
+         This entry indicates that the development kit is in the clock synchronization mode, and it is advertising the Fast Pair not discoverable payload.
+
+         .. note::
+            By default, the `nRF Connect for Mobile`_ application filters advertising packets used by ecosystems like Google or Apple.
+            You need to take additional steps to see the Fast Pair advertising on the scanning list:
+
+               1. In the **SCANNER** tab of the `nRF Connect for Mobile`_ application, tap the :guilabel:`No filter` white bar below the **SCANNER** label.
+               #. In the drop-down menu for the filtering configuration, tap the three-dot icon in the **Exclude** option.
+               #. In the exclude configuration menu, uncheck the **Google** option to remove the filtering for Google-related advertising like the Fast Pair advertising.
+               #. Close the exclude configuration menu and the filtering configuration drop-down.
+               #. Tap the :guilabel:`SCAN` button to restart the scanning activity.
+
+      #. Power on the first Android device that you used to perform the FMDN provisioning operation.
+      #. In the terminal, observe the message confirming that your first Android device connected to the development kit and synchronized the clock value::
+
+            FMDN: clock information synchronized with the authenticated Bluetooth peer
+
+      #. Go back to your second Android device and refresh the scanning list in the `nRF Connect for Mobile`_ application.
+      #. Observe that the entry for the device advertising the Fast Pair Service UUID AD type is no longer present in the scanning list.
+         The missing entry indicates that the development kit is no longer in the clock synchronization mode, and it is not advertising the Fast Pair not discoverable payload.
+      #. In your first Android device, open the `Find My Device app`_.
+         Navigate to your accessory view, and tap the :guilabel:`Find nearby` button.
+      #. Start the ringing action on your device by tapping the :guilabel:`Play sound` button.
+      #. Observe that **LED 1** is lit to confirm that the Android device is able to connect to your development kit after a clock synchronization.
 
 Fast Pair Validator app
 -----------------------
@@ -486,43 +692,88 @@ You can test the sample against the Eddystone test suite from the `Fast Pair Val
 
 |test_sample|
 
-1. Open the Fast Pair Validator app on your Android device.
-#. In the app list, tap on the target device model that matches your flashed firmware.
-#. Select the correct test category by tapping the :guilabel:`EDDYSTONE` button.
+.. tabs::
 
-   .. figure:: /images/bt_fast_pair_fpv_app_test_category.png
-      :scale: 80 %
-      :alt: Test category selection in the Fast Pair Validator app
+   .. group-tab:: nRF52 and nRF53 DKs
 
-#. In the Eddystone test view, choose a test case by tapping the :guilabel:`START` button next to it.
+      1. Open the Fast Pair Validator app on your Android device.
+      #. In the app list, tap on the target device model that matches your flashed firmware.
+      #. Select the correct test category by tapping the :guilabel:`EDDYSTONE` button.
 
-   .. figure:: /images/bt_fast_pair_fpv_app_eddystone_category.png
-      :scale: 80 %
-      :alt: Eddystone test suite in the Fast Pair Validator app
+         .. figure:: /images/bt_fast_pair_fpv_app_test_category.png
+            :scale: 80 %
+            :alt: Test category selection in the Fast Pair Validator app
 
-#. In the chosen test view, run the test case by tapping the :guilabel:`TEST` button.
-#. Follow the pop-up instructions during the test execution.
+      #. In the Eddystone test view, choose a test case by tapping the :guilabel:`START` button next to it.
 
-   .. important::
-      Use your locator tag device button interface to comply with the instructions during the test execution:
+         .. figure:: /images/bt_fast_pair_fpv_app_eddystone_category.png
+            :scale: 80 %
+            :alt: Eddystone test suite in the Fast Pair Validator app
 
-      * *Please put the headset into pairing mode* - Ensure that your device advertises in the Fast Pair discoverable mode or switch to this mode by pressing **Button 1**.
-      * *After you close this dialog, as soon as you hear device ringing, press a button on the device to stop ringing* - Stop the ringing action by pressing **Button 2** once the **LED 2** is lit.
-      * *Before you close this dialog, press the button on the device to allow reading its identifier* - Enter the identification mode by shortly pressing **Button 4**.
-        The **LED 4** should start blinking at half-second intervals after the button press.
+      #. In the chosen test view, run the test case by tapping the :guilabel:`TEST` button.
+      #. Follow the pop-up instructions during the test execution.
 
-#. Wait until the test case execution completes.
+         .. important::
+            Use your locator tag device button interface to comply with the instructions during the test execution:
 
-   .. figure:: /images/bt_fast_pair_fpv_app_eddystone_provisioning_test.png
-      :scale: 80 %
-      :alt: Successful execution of the provisioning test case in the Fast Pair Validator app
+            * *Please put the headset into pairing mode* - Ensure that your device advertises in the Fast Pair discoverable mode or switch to this mode by pressing **Button 1**.
+            * *After you close this dialog, as soon as you hear device ringing, press a button on the device to stop ringing* - Stop the ringing action by pressing **Button 2** once the **LED 2** is lit.
+            * *Before you close this dialog, press the button on the device to allow reading its identifier* - Enter the identification mode by shortly pressing **Button 4**.
+              The **LED 4** should start blinking at half-second intervals after the button press.
 
-#. Exit the test case view by tapping on the cross icon in the upper left corner.
-#. Start another test case or exit the Fast Pair Validator app.
+      #. Wait until the test case execution completes.
 
-   .. note::
-      Each test case is concluded with the unprovisioning operation that disables the Fast Pair advertising in the discoverable mode.
-      To set your locator tag device back into the pairing mode, press **Button 1**.
+         .. figure:: /images/bt_fast_pair_fpv_app_eddystone_provisioning_test.png
+            :scale: 80 %
+            :alt: Successful execution of the provisioning test case in the Fast Pair Validator app
+
+      #. Exit the test case view by tapping on the cross icon in the upper left corner.
+      #. Start another test case or exit the Fast Pair Validator app.
+
+         .. note::
+            Each test case is concluded with the unprovisioning operation that disables the Fast Pair advertising in the discoverable mode.
+            To set your locator tag device back into the pairing mode, press **Button 1**.
+
+   .. group-tab:: nRF54 DKs
+
+      1. Open the Fast Pair Validator app on your Android device.
+      #. In the app list, tap on the target device model that matches your flashed firmware.
+      #. Select the correct test category by tapping the :guilabel:`EDDYSTONE` button.
+
+         .. figure:: /images/bt_fast_pair_fpv_app_test_category.png
+            :scale: 80 %
+            :alt: Test category selection in the Fast Pair Validator app
+
+      #. In the Eddystone test view, choose a test case by tapping the :guilabel:`START` button next to it.
+
+         .. figure:: /images/bt_fast_pair_fpv_app_eddystone_category.png
+            :scale: 80 %
+            :alt: Eddystone test suite in the Fast Pair Validator app
+
+      #. In the chosen test view, run the test case by tapping the :guilabel:`TEST` button.
+      #. Follow the pop-up instructions during the test execution.
+
+         .. important::
+            Use your locator tag device button interface to comply with the instructions during the test execution:
+
+            * *Please put the headset into pairing mode* - Ensure that your device advertises in the Fast Pair discoverable mode or switch to this mode by pressing **Button 0**.
+            * *After you close this dialog, as soon as you hear device ringing, press a button on the device to stop ringing* - Stop the ringing action by pressing **Button 1** once the **LED 1** is lit.
+            * *Before you close this dialog, press the button on the device to allow reading its identifier* - Enter the identification mode by shortly pressing **Button 3**.
+              The **LED 3** should start blinking at half-second intervals after the button press.
+
+      #. Wait until the test case execution completes.
+
+         .. figure:: /images/bt_fast_pair_fpv_app_eddystone_provisioning_test.png
+            :scale: 80 %
+            :alt: Successful execution of the provisioning test case in the Fast Pair Validator app
+
+      #. Exit the test case view by tapping on the cross icon in the upper left corner.
+      #. Start another test case or exit the Fast Pair Validator app.
+
+         .. note::
+            Each test case is concluded with the unprovisioning operation that disables the Fast Pair advertising in the discoverable mode.
+            To set your locator tag device back into the pairing mode, press **Button 0**.
+
 
 Dependencies
 ************

--- a/samples/bluetooth/iso_time_sync/README.rst
+++ b/samples/bluetooth/iso_time_sync/README.rst
@@ -35,10 +35,21 @@ The sample demonstrates the following features:
  * How to provide the isochronous data to the controller right before it is sent on-air.
  * How to achieve this for either broadcast (BIS) or over connections (CIS).
 
-This sample configures a single device as a transmitter of its **BUTTON1** state.
-The transmitting and receiving devices toggle **LED1** synchronously with the accuracy of a few microseconds.
-When the :ref:`CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE <CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE>` Kconfig option is enabled, **LED2** is toggled upon sending or receiving data.
-This allows you to measure the minimal end-to-end latency.
+.. tabs::
+
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      This sample configures a single device as a transmitter of its **Button 1** state.
+      The transmitting and receiving devices toggle **LED 1** synchronously with the accuracy of a few microseconds.
+      When the :ref:`CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE <CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE>` Kconfig option is enabled, **LED 2** is toggled upon sending or receiving data.
+      This allows you to measure the minimal end-to-end latency.
+
+   .. group-tab:: nRF54 DKs
+
+      This sample configures a single device as a transmitter of its **Button 0** state.
+      The transmitting and receiving devices toggle **LED 0** synchronously with the accuracy of a few microseconds.
+      When the :ref:`CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE <CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE>` Kconfig option is enabled, **LED 1** is toggled upon sending or receiving data.
+      This allows you to measure the minimal end-to-end latency.
 
 .. note::
    This sample requires less hardware resources when it is run on an nRF54L Series device compared to the nRF52 or nRF53 Series devices.
@@ -58,7 +69,7 @@ Check and configure the following Kconfig options:
 .. _CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE:
 
 CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE
-   This configuration option enables immediate toggling of **LED2** when isochronous data is sent or received.
+   This configuration option enables immediate toggling of **LED 2** (nRF52 and nRF53 DKs) or **LED 1** (nRF54 DKs) when isochronous data is sent or received.
    It allows for measurement of the minimum end-to-end latency.
 
 .. _CONFIG_SDU_INTERVAL_US:
@@ -165,36 +176,74 @@ The sample code is divided into multiple source files, which makes it easier to 
 
   When a valid SDU is received, the following operations are performed:
 
-  * If the :ref:`CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE <CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE>` Kconfig option is enabled, **LED2** is toggled immediately.
-    You can use this to observe that different receivers may receive the SDU at different points in time.
-  * A timer trigger is configured to toggle **LED1** :ref:`CONFIG_TIMED_LED_PRESENTATION_DELAY_US <CONFIG_TIMED_LED_PRESENTATION_DELAY_US>` after the received timestamp.
-    This ensures that all receivers and the transmitter toggle it at the same time.
+.. tabs::
 
-``iso_tx.c``
-  This file handles time-synchronized transmitting of isochronous data on all established streams.
-  Each SDU contains a counter and the current value of **BUTTON1**.
-  The implementation ensures the following:
+   .. group-tab:: nRF52 and nRF53 DKs
 
-  * The SDU is transmitted right before it is supposed to be sent on air.
-    This is achieved by setting up a timer to trigger right before the next TX timestamp.
-  * The SDU is transmitted on all the established isochronous channels with the same timestamp.
-    This ensures that all the receivers can toggle their corresponding LEDs at the same time.
-    The very first SDU is provided without a timestamp, because the timestamp is not known at this point in time.
-  * **LED1** is configured to toggle synchronously with the **LED1** on all the receivers.
-    The toggle time is determined by the TX timestamp and defined relative to the synchronization reference on the receiver.
-  * If the :ref:`CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE <CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE>` Kconfig option is enabled, **LED2** is toggled right before sending the SDU.
-    You can use this to observe the end-to-end latency.
+      * If the :ref:`CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE <CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE>` Kconfig option is enabled, **LED 2** is toggled immediately.
+        You can use this to observe that different receivers may receive the SDU at different points in time.
+      * A timer trigger is configured to toggle **LED 1** :ref:`CONFIG_TIMED_LED_PRESENTATION_DELAY_US <CONFIG_TIMED_LED_PRESENTATION_DELAY_US>` after the received timestamp.
+        This ensures that all receivers and the transmitter toggle it at the same time.
 
-``timed_led_toggle.c``
-  This file implements timed toggling a LED.
-  The ``GPIOTE`` peripheral is used together with ``PPI`` to achieve accurate timing.
+    ``iso_tx.c``
+      This file handles time-synchronized transmitting of isochronous data on all established streams.
+      Each SDU contains a counter and the current value of **Button 1**.
+      The implementation ensures the following:
 
-``controller_time_<device>.c``
-  The SDU timestamps sent to and received from the controller are based upon the controller clock.
-  These files allow the application to read the current timestamp and set up a PPI trigger at a given point in time.
+      * The SDU is transmitted right before it is supposed to be sent on air.
+        This is achieved by setting up a timer to trigger right before the next TX timestamp.
+      * The SDU is transmitted on all the established isochronous channels with the same timestamp.
+        This ensures that all the receivers can toggle their corresponding LEDs at the same time.
+        The very first SDU is provided without a timestamp, because the timestamp is not known at this point in time.
+      * **LED 1** is configured to toggle synchronously with the **LED 1** on all the receivers.
+        The toggle time is determined by the TX timestamp and defined relative to the synchronization reference on the receiver.
+      * If the :ref:`CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE <CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE>` Kconfig option is enabled, **LED 2** is toggled right before sending the SDU.
+        You can use this to observe the end-to-end latency.
 
-  The implementation for nRF52 and nRF53 Series devices is implemented by shadowing an RTC peripheral combined with a timer peripheral.
-  The implementation for nRF54L Series devices uses the GRTC and is simpler to use.
+    ``timed_led_toggle.c``
+      This file implements timed toggling a LED.
+      The ``GPIOTE`` peripheral is used together with ``PPI`` to achieve accurate timing.
+
+    ``controller_time_<device>.c``
+      The SDU timestamps sent to and received from the controller are based upon the controller clock.
+      These files allow the application to read the current timestamp and set up a PPI trigger at a given point in time.
+
+      The implementation for nRF52 and nRF53 Series devices is implemented by shadowing an RTC peripheral combined with a timer peripheral.
+      The implementation for nRF54L Series devices uses the GRTC and is simpler to use.
+
+   .. group-tab:: nRF54 DKs
+
+      * If the :ref:`CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE <CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE>` Kconfig option is enabled, **LED 1** is toggled immediately.
+        You can use this to observe that different receivers may receive the SDU at different points in time.
+      * A timer trigger is configured to toggle **LED 0** :ref:`CONFIG_TIMED_LED_PRESENTATION_DELAY_US <CONFIG_TIMED_LED_PRESENTATION_DELAY_US>` after the received timestamp.
+        This ensures that all receivers and the transmitter toggle it at the same time.
+
+    ``iso_tx.c``
+      This file handles time-synchronized transmitting of isochronous data on all established streams.
+      Each SDU contains a counter and the current value of **Button 0**.
+      The implementation ensures the following:
+
+      * The SDU is transmitted right before it is supposed to be sent on air.
+        This is achieved by setting up a timer to trigger right before the next TX timestamp.
+      * The SDU is transmitted on all the established isochronous channels with the same timestamp.
+        This ensures that all the receivers can toggle their corresponding LEDs at the same time.
+        The very first SDU is provided without a timestamp, because the timestamp is not known at this point in time.
+      * **LED 0** is configured to toggle synchronously with the **LED 0** on all the receivers.
+        The toggle time is determined by the TX timestamp and defined relative to the synchronization reference on the receiver.
+      * If the :ref:`CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE <CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE>` Kconfig option is enabled, **LED 1** is toggled right before sending the SDU.
+        You can use this to observe the end-to-end latency.
+
+    ``timed_led_toggle.c``
+      This file implements timed toggling a LED.
+      The ``GPIOTE`` peripheral is used together with ``PPI`` to achieve accurate timing.
+
+    ``controller_time_<device>.c``
+      The SDU timestamps sent to and received from the controller are based upon the controller clock.
+      These files allow the application to read the current timestamp and set up a PPI trigger at a given point in time.
+
+      The implementation for nRF52 and nRF53 Series devices is implemented by shadowing an RTC peripheral combined with a timer peripheral.
+      The implementation for nRF54L Series devices uses the GRTC and is simpler to use.
+
 
 Building and running
 ********************
@@ -213,39 +262,86 @@ Testing broadcast isochronous streams
 
 After programming the sample to the development kits, perform the following steps to test it:
 
-1. |connect_terminal_specific|
-#. Reset the kits.
-#. Configure one of the devices as an isochronous broadcaster by typing either ``b`` or ``c`` in the terminal emulator.
-#. Configure the number of retransmissions and maximum transport latency.
-#. Observe that the broadcaster starts and begins to transmit SDUs.
-#. On the other terminal(s), type ``r`` to configure the device(s) as receivers of the broadcast isochronous stream.
-#. Select which BIS the receiver should synchronize to.
-#. Observe that the device(s) synchronize to the broadcaster and start receiving isochronous data.
-#. Press **BUTTON1** on the broadcaster.
-#. Observe that **LED1** toggles on both the broadcaster and the receivers.
+.. tabs::
+
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      1. |connect_terminal_specific|
+      #. Reset the kits.
+      #. Configure one of the devices as an isochronous broadcaster by typing either ``b`` or ``c`` in the terminal emulator.
+      #. Configure the number of retransmissions and maximum transport latency.
+      #. Observe that the broadcaster starts and begins to transmit SDUs.
+      #. On the other terminal(s), type ``r`` to configure the device(s) as receivers of the broadcast isochronous stream.
+      #. Select which BIS the receiver should synchronize to.
+      #. Observe that the device(s) synchronize to the broadcaster and start receiving isochronous data.
+      #. Press **Button 1** on the broadcaster.
+      #. Observe that **LED 1** toggles on both the broadcaster and the receivers.
+
+   .. group-tab:: nRF54 DKs
+
+      1. |connect_terminal_specific|
+      #. Reset the kits.
+      #. Configure one of the devices as an isochronous broadcaster by typing either ``b`` or ``c`` in the terminal emulator.
+      #. Configure the number of retransmissions and maximum transport latency.
+      #. Observe that the broadcaster starts and begins to transmit SDUs.
+      #. On the other terminal(s), type ``r`` to configure the device(s) as receivers of the broadcast isochronous stream.
+      #. Select which BIS the receiver should synchronize to.
+      #. Observe that the device(s) synchronize to the broadcaster and start receiving isochronous data.
+      #. Press **Button 0** on the broadcaster.
+      #. Observe that **LED 0** toggles on both the broadcaster and the receivers.
 
 Testing connected isochronous streams
 =====================================
 
 After programming the sample to the development kits, perform the following steps to test it:
 
-1. |connect_terminal_specific|
-#. Reset the kits.
-#. Configure one of the devices as a connected isochronous stream central by typing ``c`` in the terminal emulator.
-#. Configure the number of retransmissions and the maximum transport latency.
-#. Select data direction.
-   If the central is configured for transmission, it connects to multiple peripherals.
-#. On the other terminal(s), type ``p`` to configure the device(s) as connected isochronous stream peripheral(s).
-#. Select data direction.
-#. Observe that the peripheral(s) connect to the central and start receiving isochronous data.
-#. Press **BUTTON1** on the central device.
-#. Observe that **LED1** toggles on both the central and peripheral devices.
+.. tabs::
+
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      1. |connect_terminal_specific|
+      #. Reset the kits.
+      #. Configure one of the devices as a connected isochronous stream central by typing ``c`` in the terminal emulator.
+      #. Configure the number of retransmissions and the maximum transport latency.
+      #. Select data direction.
+         If the central is configured for transmission, it connects to multiple peripherals.
+
+      #. On the other terminal(s), type ``p`` to configure the device(s) as connected isochronous stream peripheral(s).
+      #. Select data direction.
+      #. Observe that the peripheral(s) connect to the central and start receiving isochronous data.
+      #. Press **Button 1** on the central device.
+      #. Observe that **LED 1** toggles on both the central and peripheral devices.
+
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      1. |connect_terminal_specific|
+      #. Reset the kits.
+      #. Configure one of the devices as a connected isochronous stream central by typing ``c`` in the terminal emulator.
+      #. Configure the number of retransmissions and the maximum transport latency.
+      #. Select data direction.
+         If the central is configured for transmission, it connects to multiple peripherals.
+
+      #. On the other terminal(s), type ``p`` to configure the device(s) as connected isochronous stream peripheral(s).
+      #. Select data direction.
+      #. Observe that the peripheral(s) connect to the central and start receiving isochronous data.
+      #. Press **Button 0** on the central device.
+      #. Observe that **LED 0** toggles on both the central and peripheral devices.
+
 
 Observe time-synchronized ISO data processing
 =============================================
 
-When you press **BUTTON1** on the transmitting device, you can observe that **LED1** toggles simultaneously on all devices.
-To observe the accurate toggling, use a logic analyzer or an oscilloscope.
+.. tabs::
+
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      When you press **Button 1** on the transmitting device, you can observe that **LED 1** toggles simultaneously on all devices.
+      To observe the accurate toggling, use a logic analyzer or an oscilloscope.
+
+   .. group-tab:: nRF54 DKs
+
+      When you press **Button 0** on the transmitting device, you can observe that **LED 0** toggles simultaneously on all devices.
+      To observe the accurate toggling, use a logic analyzer or an oscilloscope.
 
 Sample output
 *************

--- a/samples/bluetooth/mesh/light_ctrl/README.rst
+++ b/samples/bluetooth/mesh/light_ctrl/README.rst
@@ -129,22 +129,38 @@ The model handling is implemented in :file:`src/model_handler.c`, which uses the
 User interface
 **************
 
-Buttons:
-   Can be used to input the out-of-band (OOB) authentication value during provisioning.
-   All buttons have the same functionality during this procedure.
-   If the :ref:`emds_readme` feature is enabled and the provisioning and configuration are complete, **Button 4** can be used to trigger storing for data with emergency data storage and halt the system.
+.. tabs::
 
-LEDs:
-   Show the OOB authentication value during provisioning if the "Push button" OOB method is used.
-   First LED outputs the current light level of the Light Lightness Server in the first element.
-   If the :ref:`emds_readme` feature is enabled and **Button 4** is pressed LEDs 2 to 4 will light up to show that the board is halted.
+   .. group-tab:: nRF21, nRF52 and nRF53 DKs
 
-.. note::
-   :ref:`zephyr:thingy53_nrf5340` supports only one RGB LED.
-   Each RGB LED channel is used as separate LED.
+      Buttons:
+        Can be used to input the out-of-band (OOB) authentication value during provisioning.
+        All buttons have the same functionality during this procedure.
+        If the :ref:`emds_readme` feature is enabled and the provisioning and configuration are complete, **Button 4** can be used to trigger storing for data with emergency data storage and halt the system.
 
-.. note::
-   :ref:`zephyr:thingy53_nrf5340` and the :ref:`zephyr:nrf52840dongle_nrf52840` do not support emergency data storage.
+      LEDs:
+        Show the OOB authentication value during provisioning if the "Push button" OOB method is used.
+        First LED outputs the current light level of the Light Lightness Server in the first element.
+        If the :ref:`emds_readme` feature is enabled and **Button 4** is pressed **LEDs 2** to **LED 4** will light up to show that the board is halted.
+
+      .. note::
+        :ref:`zephyr:thingy53_nrf5340` supports only one RGB LED.
+        Each RGB LED channel is used as separate LED.
+
+      .. note::
+        :ref:`zephyr:thingy53_nrf5340` and the :ref:`zephyr:nrf52840dongle_nrf52840` do not support emergency data storage.
+
+   .. group-tab:: nRF54 DKs
+
+      Buttons:
+        Can be used to input the out-of-band (OOB) authentication value during provisioning.
+        All buttons have the same functionality during this procedure.
+        If the :ref:`emds_readme` feature is enabled and the provisioning and configuration are complete, **Button 3** can be used to trigger storing for data with emergency data storage and halt the system.
+
+      LEDs:
+        Show the OOB authentication value during provisioning if the "Push button" OOB method is used.
+        First LED outputs the current light level of the Light Lightness Server in the first element.
+        If the :ref:`emds_readme` feature is enabled and **Button 3** is pressed **LEDs 1** to **LED 3** will light up to show that the board is halted.
 
 Configuration
 *************
@@ -197,8 +213,17 @@ Testing
 After programming the sample to your development kit, you can test it by using a smartphone with `nRF Mesh mobile app`_ installed.
 Testing consists of provisioning the device and configuring it for communication with the mesh models.
 
-When the development kit is started, it will keep its previous Light state as the ``BT_MESH_ON_POWER_UP_RESTORE`` is set for the :ref:`bt_mesh_lightness_srv_readme`.
-When :ref:`emds_readme` is enabled it is important that the **Button 4** is used to store the data before the development kit is halted and then restarted.
+.. tabs::
+
+   .. group-tab:: nRF21, nRF52 and nRF53 DKs
+
+      When the development kit is started, it will keep its previous Light state as the ``BT_MESH_ON_POWER_UP_RESTORE`` is set for the :ref:`bt_mesh_lightness_srv_readme`.
+      When :ref:`emds_readme` is enabled it is important that the **Button 4** is used to store the data before the development kit is halted and then restarted.
+
+   .. group-tab:: nRF54 DKs
+
+      When the development kit is started, it will keep its previous Light state as the ``BT_MESH_ON_POWER_UP_RESTORE`` is set for the :ref:`bt_mesh_lightness_srv_readme`.
+      When :ref:`emds_readme` is enabled it is important that the **Button 3** is used to store the data before the development kit is halted and then restarted.
 
 Provisioning the device
 -----------------------

--- a/samples/bluetooth/mesh/light_dimmer/README.rst
+++ b/samples/bluetooth/mesh/light_dimmer/README.rst
@@ -51,11 +51,24 @@ The sample instantiates the following models:
 Devices are nodes with a provisionee role in a mesh network.
 Provisioning is performed using the `nRF Mesh mobile app`_.
 This mobile application is also used to configure key bindings, and publication and subscription settings of the Bluetooth Mesh model instances in the sample.
-After provisioning and configuring the mesh models supported by the sample in the `nRF Mesh mobile app`_, **Button 1** on the Mesh Light Dimmer device can be used to control the configured network nodes' LEDs, while **Button 2** can be used to store and restore scenes on the network nodes.
 
-.. note::
-  When running this sample on the :ref:`zephyr:nrf52840dongle_nrf52840`, the scene selection functionality will not be available as the device only has one button.
-  The single button of the dongle will be used for dimming and the on/off functionality as described for **Button 1** in this documentation.
+.. tabs::
+
+   .. group-tab:: nRF21, nRF52 and nRF53 DKs
+
+      After provisioning and configuring the mesh models supported by the sample in the `nRF Mesh mobile app`_, **Button 1** on the Mesh Light Dimmer device can be used to control the configured network nodes' LEDs, while **Button 2** can be used to store and restore scenes on the network nodes.
+
+      .. note::
+        When running this sample on the :ref:`zephyr:nrf52840dongle_nrf52840`, the scene selection functionality will not be available as the device only has one button.
+        The single button of the dongle will be used for dimming and the on/off functionality as described for **Button 1** in this documentation.
+
+   .. group-tab:: nRF54 DKs
+
+      After provisioning and configuring the mesh models supported by the sample in the `nRF Mesh mobile app`_, **Button 0** on the Mesh Light Dimmer device can be used to control the configured network nodes' LEDs, while **Button 1** can be used to store and restore scenes on the network nodes.
+
+      .. note::
+        When running this sample on the :ref:`zephyr:nrf52840dongle_nrf52840`, the scene selection functionality will not be available as the device only has one button.
+        The single button of the dongle will be used for dimming and the on/off functionality as described for **Button 0** in this documentation.
 
 Provisioning
 ============
@@ -102,32 +115,57 @@ The model handling is implemented in :file:`src/model_handler.c`, which uses the
 User interface
 **************
 
-Buttons:
-   Can be used to input the out-of-band (OOB) authentication value during provisioning. All buttons have the same functionality during this procedure.
+.. tabs::
 
-Button 1:
-   On press and release, **Button 1** will publish a Generic OnOff Set message using the configured publication parameters of its model instance, and toggle the LED on/off on a :ref:`mesh light fixture <bluetooth_mesh_light_lc>` device.
+   .. group-tab:: nRF21, nRF52 and nRF53 DKs
 
-   On press and hold, **Button 1** will publish a Generic Level move set message using the configured publication parameters of its model instance and will continuously dim the LED lightness state on a :ref:`mesh light fixture <bluetooth_mesh_light_lc>` device. On release, the button publishes another Generic Level move set message with the ``delta`` parameter set to 0 and stops the continuous level change from the previous message.
+      Buttons:
+        Can be used to input the out-of-band (OOB) authentication value during provisioning. All buttons have the same functionality during this procedure.
 
-Button 2:
-   On short press and release, **Button 2** will publish a Scene Restore message using the configured publication parameters of its model instance, and restore the LED state of all the targets to the values stored under the current scene number.
-   Each press of the button will recall the next scene, meaning, the first press will recall scene 2, the next press will recall scene 3, and so on, before wrapping around back to scene 1.
+      Button 1:
+        On press and release, **Button 1** will publish a Generic OnOff Set message using the configured publication parameters of its model instance, and toggle the LED on/off on a :ref:`mesh light fixture <bluetooth_mesh_light_lc>` device.
 
-   On long press and release, **Button 2** will publish a Scene Store message using the configured publication parameters of its model instance, and store the current LED state of all the targets under the scene with the most recently recalled scene number.
+        On press and hold, **Button 1** will publish a Generic Level move set message using the configured publication parameters of its model instance and will continuously dim the LED lightness state on a :ref:`mesh light fixture <bluetooth_mesh_light_lc>` device.
+        On release, the button publishes another Generic Level move set message with the ``delta`` parameter set to 0 and stops the continuous level change from the previous message.
 
-  .. note::
-    On the :ref:`zephyr:nrf52840dongle_nrf52840`, the scene selection functionality will not be available as the device only has one button.
+      Button 2:
+        On short press and release, **Button 2** will publish a Scene Restore message using the configured publication parameters of its model instance, and restore the LED state of all the targets to the values stored under the current scene number.
+        Each press of the button will recall the next scene, meaning, the first press will recall scene 2, the next press will recall scene 3, and so on, before wrapping around back to scene 1.
 
-  .. tip::
-    On Thingy:53, **Button 2** can be accessed by removing the top part of the casing.
+        On long press and release, **Button 2** will publish a Scene Store message using the configured publication parameters of its model instance, and store the current LED state of all the targets under the scene with the most recently recalled scene number.
 
-LEDs:
-   Show the OOB authentication value during provisioning if the "Push button" OOB method is used.
+        .. note::
+          On the :ref:`zephyr:nrf52840dongle_nrf52840`, the scene selection functionality will not be available as the device only has one button.
 
-  .. note::
-    :ref:`zephyr:thingy53_nrf5340` supports only one RGB LED.
-    Each RGB LED channel is used as separate LED.
+        .. tip::
+          On Thingy:53, **Button 2** can be accessed by removing the top part of the casing.
+
+      LEDs:
+        Show the OOB authentication value during provisioning if the "Push button" OOB method is used.
+
+        .. note::
+          :ref:`zephyr:thingy53_nrf5340` supports only one RGB LED.
+          Each RGB LED channel is used as separate LED.
+
+   .. group-tab:: nRF54 DKs
+
+      Buttons:
+        Can be used to input the out-of-band (OOB) authentication value during provisioning. All buttons have the same functionality during this procedure.
+
+      Button 1:
+        On press and release, **Button 0** will publish a Generic OnOff Set message using the configured publication parameters of its model instance, and toggle the LED on/off on a :ref:`mesh light fixture <bluetooth_mesh_light_lc>` device.
+
+        On press and hold, **Button 0** will publish a Generic Level move set message using the configured publication parameters of its model instance and will continuously dim the LED lightness state on a :ref:`mesh light fixture <bluetooth_mesh_light_lc>` device.
+        On release, the button publishes another Generic Level move set message with the ``delta`` parameter set to 0 and stops the continuous level change from the previous message.
+
+      Button 2:
+        On short press and release, **Button 1** will publish a Scene Restore message using the configured publication parameters of its model instance, and restore the LED state of all the targets to the values stored under the current scene number.
+        Each press of the button will recall the next scene, meaning, the first press will recall scene 2, the next press will recall scene 3, and so on, before wrapping around back to scene 1.
+
+        On long press and release, **Button 1** will publish a Scene Store message using the configured publication parameters of its model instance, and store the current LED state of all the targets under the scene with the most recently recalled scene number.
+
+      LEDs:
+        Show the OOB authentication value during provisioning if the "Push button" OOB method is used.
 
 Configuration
 *************
@@ -188,10 +226,21 @@ Configure the first element on the target **Mesh Light Fixture** node:
 
 You should now be able to perform the following actions:
 
-* Press and release **Button 1** to see the LED on the target Mesh Light Fixture device toggle on and off.
-* Press and hold **Button 1** to see the light level of the LED on the target Mesh Light Fixture device slowly decrease or increase.
-* Short press and release **Button 2** to rotate through scenes, recalling each of them in turn.
-* Long press and release **Button 2** to store the current LED states as a scene with the current scene number.
+.. tabs::
+
+   .. group-tab:: nRF21, nRF52 and nRF53 DKs
+
+      * Press and release **Button 1** to see the LED on the target Mesh Light Fixture device toggle on and off.
+      * Press and hold **Button 1** to see the light level of the LED on the target Mesh Light Fixture device slowly decrease or increase.
+      * Short press and release **Button 2** to rotate through scenes, recalling each of them in turn.
+      * Long press and release **Button 2** to store the current LED states as a scene with the current scene number.
+
+   .. group-tab:: nRF54 DKs
+
+      * Press and release **Button 0** to see the LED on the target Mesh Light Fixture device toggle on and off.
+      * Press and hold **Button 0** to see the light level of the LED on the target Mesh Light Fixture device slowly decrease or increase.
+      * Short press and release **Button 1** to rotate through scenes, recalling each of them in turn.
+      * Long press and release **Button 1** to store the current LED states as a scene with the current scene number.
 
 .. note::
   When controlling a Mesh Light Fixture device using the Mesh Light Dimmer device, the Light LC Server control will be temporarily disabled for the Mesh Light Fixture device.

--- a/samples/bluetooth/mesh/light_switch/README.rst
+++ b/samples/bluetooth/mesh/light_switch/README.rst
@@ -112,12 +112,25 @@ Low Power node support
 
 The mesh light switch sample can also be run as a Low Power node (LPN), giving the possibility of lowering the power consumption.
 
-While running the sample with the LPN configuration, the fourth :ref:`bt_mesh_onoff_cli_readme` instance will be omitted.
-Instead, button 4 will be used to temporarily enable Node ID advertisement on the LPN device.
+.. tabs::
 
-Running continuous proxy advertisement with Network ID consumes considerable power, and is therefore disabled in the configuration.
-Instead, the user can manually enable the Node ID advertisement for a period of 30 seconds by pressing **Button 4** on the device.
-This will give the user a short period of time to connect directly to the LPN, and thus perform necessary configuration of the device.
+   .. group-tab:: nRF21, nRF52 and nRF53 DKs
+
+      While running the sample with the LPN configuration, the fourth :ref:`bt_mesh_onoff_cli_readme` instance will be omitted.
+      Instead, **Button 4** will be used to temporarily enable Node ID advertisement on the LPN device.
+
+      Running continuous proxy advertisement with Network ID consumes considerable power, and is therefore disabled in the configuration.
+      Instead, the user can manually enable the Node ID advertisement for a period of 30 seconds by pressing **Button 4** on the device.
+      This will give the user a short period of time to connect directly to the LPN, and thus perform necessary configuration of the device.
+
+   .. group-tab:: nRF21, nRF52 and nRF53 DKs
+
+      While running the sample with the LPN configuration, the fourth :ref:`bt_mesh_onoff_cli_readme` instance will be omitted.
+      Instead, **Button 3** will be used to temporarily enable Node ID advertisement on the LPN device.
+
+      Running continuous proxy advertisement with Network ID consumes considerable power, and is therefore disabled in the configuration.
+      Instead, the user can manually enable the Node ID advertisement for a period of 30 seconds by pressing **Button 3** on the device.
+      This will give the user a short period of time to connect directly to the LPN, and thus perform necessary configuration of the device.
 
 After the connection to the LPN is terminated, and the Node ID advertisement has stopped, the LPN will return to its previous state.
 
@@ -185,8 +198,17 @@ LEDs:
 The LPN assignments
 ===================
 
-Button 4:
-	When pressed, enables the Node ID advertisement for a short period of time.
+.. tabs::
+
+   .. group-tab:: nRF21, nRF52 and nRF53 DKs
+
+      Button 4:
+         When pressed, enables the Node ID advertisement for a short period of time.
+
+   .. group-tab:: nRF54 DKs
+
+      Button 3:
+         When pressed, enables the Node ID advertisement for a short period of time.
 
 Configuration
 *************

--- a/samples/bluetooth/mesh/sensor_client/README.rst
+++ b/samples/bluetooth/mesh/sensor_client/README.rst
@@ -95,17 +95,35 @@ Buttons:
 
 Once the provisioning procedure has completed, the buttons will have the following functionality:
 
-Button 1:
-   Sends a get message for the :c:var:`bt_mesh_sensor_dev_op_temp_range_spec` setting of the :c:var:`bt_mesh_sensor_present_dev_op_temp` sensor.
+.. tabs::
 
-Button 2:
-   Sends a set message for the :c:var:`bt_mesh_sensor_dev_op_temp_range_spec` setting of the :c:var:`bt_mesh_sensor_present_dev_op_temp` sensor, switching between the ranges specified in the :c:var:`temp_ranges` variable.
+   .. group-tab:: nRF21 and nRF52 DKs
 
-Button 3:
-   Sends a get message for a descriptor, requesting information about the :c:var:`bt_mesh_sensor_present_dev_op_temp` sensor.
+      Button 1:
+         Sends a get message for the :c:var:`bt_mesh_sensor_dev_op_temp_range_spec` setting of the :c:var:`bt_mesh_sensor_present_dev_op_temp` sensor.
 
-Button 4:
-   Sends a set message for the :c:var:`bt_mesh_sensor_motion_threshold` setting of the :c:var:`bt_mesh_sensor_presence_detected` sensor, switching between the ranges specified in the :c:var:`presence_motion_threshold` variable.
+      Button 2:
+         Sends a set message for the :c:var:`bt_mesh_sensor_dev_op_temp_range_spec` setting of the :c:var:`bt_mesh_sensor_present_dev_op_temp` sensor, switching between the ranges specified in the :c:var:`temp_ranges` variable.
+
+      Button 3:
+         Sends a get message for a descriptor, requesting information about the :c:var:`bt_mesh_sensor_present_dev_op_temp` sensor.
+
+      Button 4:
+         Sends a set message for the :c:var:`bt_mesh_sensor_motion_threshold` setting of the :c:var:`bt_mesh_sensor_presence_detected` sensor, switching between the ranges specified in the :c:var:`presence_motion_threshold` variable.
+
+   .. group-tab:: nRF54 DKs
+
+      Button 0:
+         Sends a get message for the :c:var:`bt_mesh_sensor_dev_op_temp_range_spec` setting of the :c:var:`bt_mesh_sensor_present_dev_op_temp` sensor.
+
+      Button 1:
+         Sends a set message for the :c:var:`bt_mesh_sensor_dev_op_temp_range_spec` setting of the :c:var:`bt_mesh_sensor_present_dev_op_temp` sensor, switching between the ranges specified in the :c:var:`temp_ranges` variable.
+
+      Button 2:
+         Sends a get message for a descriptor, requesting information about the :c:var:`bt_mesh_sensor_present_dev_op_temp` sensor.
+
+      Button 3:
+         Sends a set message for the :c:var:`bt_mesh_sensor_motion_threshold` setting of the :c:var:`bt_mesh_sensor_presence_detected` sensor, switching between the ranges specified in the :c:var:`presence_motion_threshold` variable.
 
 Terminal:
    All sensor values gathered from the server are printed over UART.

--- a/samples/bluetooth/mesh/sensor_server/README.rst
+++ b/samples/bluetooth/mesh/sensor_server/README.rst
@@ -143,21 +143,43 @@ Buttons:
 
 Once the provisioning procedure has completed, the buttons will have the following functionality:
 
-Button 1:
-   Simulates different ambient light sensor values.
-   These dummy values represent raw values coming from an ambient light sensor.
+.. tabs::
 
-Button 2:
-   Simulates presence detected.
-   For how long the button has to be pressed before the presence is detected depends on the motion threshold.
-   The motion threshold has five steps from 0 % (representing 0 seconds) to 100 % (representing 10 seconds) separated by 25 %-steps.
+   .. group-tab:: nRF21 and nRF52 DKs
 
-Button 3:
-   Simulates motion sensed.
+      Button 1:
+        Simulates different ambient light sensor values.
+        These dummy values represent raw values coming from an ambient light sensor.
 
-Button 4:
-   Simulates different people count sensor values.
-   These dummy values represent raw values coming from a people count sensor.
+      Button 2:
+        Simulates presence detected.
+        For how long the button has to be pressed before the presence is detected depends on the motion threshold.
+        The motion threshold has five steps from 0 % (representing 0 seconds) to 100 % (representing 10 seconds) separated by 25 %-steps.
+
+      Button 3:
+        Simulates motion sensed.
+
+      Button 4:
+        Simulates different people count sensor values.
+        These dummy values represent raw values coming from a people count sensor.
+
+   .. group-tab:: nRF54 DKs
+
+      Button 0:
+        Simulates different ambient light sensor values.
+        These dummy values represent raw values coming from an ambient light sensor.
+
+      Button 1:
+        Simulates presence detected.
+        For how long the button has to be pressed before the presence is detected depends on the motion threshold.
+        The motion threshold has five steps from 0 % (representing 0 seconds) to 100 % (representing 10 seconds) separated by 25 %-steps.
+
+      Button 2:
+        Simulates motion sensed.
+
+      Button 3:
+        Simulates different people count sensor values.
+        These dummy values represent raw values coming from a people count sensor.
 
 Configuration
 *************

--- a/samples/bluetooth/mesh/silvair_enocean/README.rst
+++ b/samples/bluetooth/mesh/silvair_enocean/README.rst
@@ -95,7 +95,7 @@ User interface
 **************
 
 Development kit buttons:
-      During the provisioning process, the buttons (1 to 4) can be used for OOB input.
+      During the provisioning process, all buttons can be used for OOB input.
       Once the provisioning and configuration are completed, the buttons are not used.
 
 EnOcean buttons:
@@ -103,7 +103,7 @@ EnOcean buttons:
       Pressing and holding the button on the EnOcean switch publishes a Level message using the configured publication parameters of its model instance, and changes the emitted LED light level on the :ref:`mesh light <bluetooth_mesh_light_lc>` device.
 
 LEDs:
-   During the provisioning process, the LEDs (1 to 4) are used to output the OOB actions.
+   During the provisioning process, all LEDs are used to output the OOB actions.
    Once the provisioning and configuration are completed, the LEDs are used to reflect the status of actions, and they show the last known OnOff/Level state of the corresponding button.
    It will not change its emitted LED light level, it will only be on or off.
 

--- a/samples/bluetooth/multiple_adv_sets/README.rst
+++ b/samples/bluetooth/multiple_adv_sets/README.rst
@@ -43,11 +43,23 @@ After disconnection, the connectable advertising starts again.
 User interface
 **************
 
-LED 1:
-   Blinks with a period of two seconds with the duty cycle set to 50% when the main loop is running and the device is advertising.
+.. tabs::
 
-LED 2:
-   Lit when the development kit is connected.
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      LED 1:
+         Blinks with a period of two seconds with the duty cycle set to 50% when the main loop is running and the device is advertising.
+
+      LED 2:
+         Lit when the development kit is connected.
+
+   .. group-tab:: nRF54 DKs
+
+      LED 0:
+         Blinks with a period of two seconds with the duty cycle set to 50% when the main loop is running and the device is advertising.
+
+      LED 1:
+         Lit when the development kit is connected.
 
 Building and running
 ********************

--- a/samples/bluetooth/peripheral_ams_client/README.rst
+++ b/samples/bluetooth/peripheral_ams_client/README.rst
@@ -32,25 +32,51 @@ It can request the MS to perform certain actions, such as starting playback and 
 User interface
 **************
 
-LED 1:
-   Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
+.. tabs::
 
-LED 2:
-   Lit when connected.
+   .. group-tab:: nRF52 and nRF53 DKs
 
-Button 1:
-   Enable and disable MS track attributes notification.
+      LED 1:
+         Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
 
-Button 2:
-   Request MS to start or pause playback.
+      LED 2:
+         Lit when connected.
 
-Button 3:
-   Request MS to jump to the next track if it is supported.
-   Otherwise, request MS to turn up the volume.
+      Button 1:
+         Enable and disable MS track attributes notification.
 
-Button 4:
-   Request MS to jump to the previous track if it is supported.
-   Otherwise, request MS to turn down the volume.
+      Button 2:
+         Request MS to start or pause playback.
+
+      Button 3:
+         Request MS to jump to the next track if it is supported.
+         Otherwise, request MS to turn up the volume.
+
+      Button 4:
+         Request MS to jump to the previous track if it is supported.
+         Otherwise, request MS to turn down the volume.
+
+   .. group-tab:: nRF54 DKs
+
+      LED 0:
+         Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
+
+      LED 1:
+         Lit when connected.
+
+      Button 0:
+         Enable and disable MS track attributes notification.
+
+      Button 1:
+         Request MS to start or pause playback.
+
+      Button 2:
+         Request MS to jump to the next track if it is supported.
+         Otherwise, request MS to turn up the volume.
+
+      Button 3:
+         Request MS to jump to the previous track if it is supported.
+         Otherwise, request MS to turn down the volume.
 
 Building and running
 ********************
@@ -69,16 +95,33 @@ After programming the sample to your development kit, you can test it either by 
 Testing with an iOS device
 --------------------------
 
-#. |connect_terminal_specific|
-#. Reset the kit.
-#. Select the device in the iOS :guilabel:`Settings` > :guilabel:`Bluetooth` menu > :guilabel:`Connect`.
-   When requested, proceed with pairing.
-#. Open the :guilabel:`Apple Music` app and bring up a playlist with some songs.
-#. Press **Button 1** to enable song detail updates.
-#. Press **Button 2** to play a song.
-   Press again to pause playback.
-#. Press **Button 3** to jump to the next song.
-#. Press **Button 4** to jump to the previous song.
+.. tabs::
+
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      #. |connect_terminal_specific|
+      #. Reset the kit.
+      #. Select the device in the iOS :guilabel:`Settings` > :guilabel:`Bluetooth` menu > :guilabel:`Connect`.
+         When requested, proceed with pairing.
+      #. Open the :guilabel:`Apple Music` app and bring up a playlist with some songs.
+      #. Press **Button 1** to enable song detail updates.
+      #. Press **Button 2** to play a song.
+         Press again to pause playback.
+      #. Press **Button 3** to jump to the next song.
+      #. Press **Button 4** to jump to the previous song.
+
+   .. group-tab:: nRF54 DKs
+
+      #. |connect_terminal_specific|
+      #. Reset the kit.
+      #. Select the device in the iOS :guilabel:`Settings` > :guilabel:`Bluetooth` menu > :guilabel:`Connect`.
+         When requested, proceed with pairing.
+      #. Open the :guilabel:`Apple Music` app and bring up a playlist with some songs.
+      #. Press **Button 0** to enable song detail updates.
+      #. Press **Button 1** to play a song.
+         Press again to pause playback.
+      #. Press **Button 2** to jump to the next song.
+      #. Press **Button 3** to jump to the previous song.
 
 Testing with nRF Connect for Desktop
 ------------------------------------
@@ -108,151 +151,307 @@ Testing with nRF Connect for Desktop
 Music setup
 ^^^^^^^^^^^
 
-Complete the following steps to initiate a music player setup:
+.. tabs::
 
-#. In the Bluetooth Low Energy app, verify that the **Apple Entity Update** is initiated to ``00 00 01 02``.
-   The following table lists the attributes requested by the MR.
+   .. group-tab:: nRF52 and nRF53 DKs
 
-   +--------------+-------+----------------+
-   | Field        | Value | Interpretation |
-   +==============+=======+================+
-   | Entity ID    | 00    | Player         |
-   +--------------+-------+----------------+
-   | Attribute ID | 00    | Name           |
-   +--------------+-------+----------------+
-   | Attribute ID | 01    | Playback Info  |
-   +--------------+-------+----------------+
-   | Attribute ID | 02    | Volume         |
-   +--------------+-------+----------------+
+      Complete the following steps to initiate a music player setup:
 
-#. Press **Button 1** to enable track attributes notification.
-#. In the Bluetooth Low Energy app, verify that the **Apple Entity Update** is updated to ``02 00 01 02 03``.
-   The following table lists the attributes requested by the MR.
+      #. In the Bluetooth Low Energy app, verify that the **Apple Entity Update** is initiated to ``00 00 01 02``.
+         The following table lists the attributes requested by the MR.
 
-   +--------------+-------+----------------+
-   | Field        | Value | Interpretation |
-   +==============+=======+================+
-   | Entity ID    | 02    | Track          |
-   +--------------+-------+----------------+
-   | Attribute ID | 00    | Artist         |
-   +--------------+-------+----------------+
-   | Attribute ID | 01    | Album          |
-   +--------------+-------+----------------+
-   | Attribute ID | 02    | Title          |
-   +--------------+-------+----------------+
-   | Attribute ID | 03    | Duration       |
-   +--------------+-------+----------------+
+         +--------------+-------+----------------+
+         | Field        | Value | Interpretation |
+         +==============+=======+================+
+         | Entity ID    | 00    | Player         |
+         +--------------+-------+----------------+
+         | Attribute ID | 00    | Name           |
+         +--------------+-------+----------------+
+         | Attribute ID | 01    | Playback Info  |
+         +--------------+-------+----------------+
+         | Attribute ID | 02    | Volume         |
+         +--------------+-------+----------------+
 
-#. Set the **Apple Remote Command** value to ``00 01 02 03 04 05 06 07 08 09 0A 0B 0C``.
-   It tells the MR the list of commands supported by the MS.
-#. Verify that the UART output is as follows::
+      #. Press **Button 1** to enable track attributes notification.
+      #. In the Bluetooth Low Energy app, verify that the **Apple Entity Update** is updated to ``02 00 01 02 03``.
+         The following table lists the attributes requested by the MR.
 
-      AMS RC: 00,01,02,03,04,05,06,07,08,09,0A,0B,0C
+         +--------------+-------+----------------+
+         | Field        | Value | Interpretation |
+         +==============+=======+================+
+         | Entity ID    | 02    | Track          |
+         +--------------+-------+----------------+
+         | Attribute ID | 00    | Artist         |
+         +--------------+-------+----------------+
+         | Attribute ID | 01    | Album          |
+         +--------------+-------+----------------+
+         | Attribute ID | 02    | Title          |
+         +--------------+-------+----------------+
+         | Attribute ID | 03    | Duration       |
+         +--------------+-------+----------------+
 
-#. Set the **Apple Entity Update** value to ``00 01 00 30 2C 30 2E 30 2C 30 2E 30 30 30``.
-#. Verify that the UART output is as follows::
+      #. Set the **Apple Remote Command** value to ``00 01 02 03 04 05 06 07 08 09 0A 0B 0C``.
+         It tells the MR the list of commands supported by the MS.
+      #. Verify that the UART output is as follows::
 
-      AMS EU: 00,01,00 0,0.0,0.000
+            AMS RC: 00,01,02,03,04,05,06,07,08,09,0A,0B,0C
 
-   The following table explains the notification.
+      #. Set the **Apple Entity Update** value to ``00 01 00 30 2C 30 2E 30 2C 30 2E 30 30 30``.
+      #. Verify that the UART output is as follows::
 
-   +--------------+-------------+----------------+
-   | Field        | Value       | Interpretation |
-   +==============+=============+================+
-   | Entity ID    | 00          | Player         |
-   +--------------+-------------+----------------+
-   | Attribute ID | 01          | Playback Info  |
-   +--------------+-------------+----------------+
-   | Flags        | 00          |                |
-   +--------------+-------------+----------------+
-   | Value        | 0,0.0,0.000 | Paused         |
-   +--------------+-------------+----------------+
+            AMS EU: 00,01,00 0,0.0,0.000
 
-#. Set the **Apple Entity Update** value to ``02 03 00 31 32 30 2E 30 30 30``.
-#. Verify that the UART output is as follows::
+         The following table explains the notification.
 
-      AMS EU: 02,03,00 120.000
+         +--------------+-------------+----------------+
+         | Field        | Value       | Interpretation |
+         +==============+=============+================+
+         | Entity ID    | 00          | Player         |
+         +--------------+-------------+----------------+
+         | Attribute ID | 01          | Playback Info  |
+         +--------------+-------------+----------------+
+         | Flags        | 00          |                |
+         +--------------+-------------+----------------+
+         | Value        | 0,0.0,0.000 | Paused         |
+         +--------------+-------------+----------------+
 
-   The following table explains the notification.
+      #. Set the **Apple Entity Update** value to ``02 03 00 31 32 30 2E 30 30 30``.
+      #. Verify that the UART output is as follows::
 
-   +--------------+---------+----------------+
-   | Field        | Value   | Interpretation |
-   +==============+=========+================+
-   | Entity ID    | 02      | Track          |
-   +--------------+---------+----------------+
-   | Attribute ID | 03      | Duration       |
-   +--------------+---------+----------------+
-   | Flags        | 00      |                |
-   +--------------+---------+----------------+
-   | Value        | 120.000 | 120 seconds    |
-   +--------------+---------+----------------+
+            AMS EU: 02,03,00 120.000
 
-#. Set the **Apple Entity Update** value to ``02 02 00 6E 52 46 35 32 20 53 65 72 69 65 73 20 73 6F 6E 67``.
-#. Verify that the UART output is as follows::
+         The following table explains the notification.
 
-      AMS EU: 02,02,00 nRF52 Series song
+         +--------------+---------+----------------+
+         | Field        | Value   | Interpretation |
+         +==============+=========+================+
+         | Entity ID    | 02      | Track          |
+         +--------------+---------+----------------+
+         | Attribute ID | 03      | Duration       |
+         +--------------+---------+----------------+
+         | Flags        | 00      |                |
+         +--------------+---------+----------------+
+         | Value        | 120.000 | 120 seconds    |
+         +--------------+---------+----------------+
 
-   The following table explains the notification.
+      #. Set the **Apple Entity Update** value to ``02 02 00 6E 52 46 35 32 20 53 65 72 69 65 73 20 73 6F 6E 67``.
+      #. Verify that the UART output is as follows::
 
-   +--------------+-------------------+--------------------+
-   | Field        | Value             | Interpretation     |
-   +==============+===================+====================+
-   | Entity ID    | 02                | Track              |
-   +--------------+-------------------+--------------------+
-   | Attribute ID | 02                | Title              |
-   +--------------+-------------------+--------------------+
-   | Flags        | 00                |                    |
-   +--------------+-------------------+--------------------+
-   | Value        | nRF52 Series song | Current song title |
-   +--------------+-------------------+--------------------+
+            AMS EU: 02,02,00 nRF52 Series song
+
+         The following table explains the notification.
+
+         +--------------+-------------------+--------------------+
+         | Field        | Value             | Interpretation     |
+         +==============+===================+====================+
+         | Entity ID    | 02                | Track              |
+         +--------------+-------------------+--------------------+
+         | Attribute ID | 02                | Title              |
+         +--------------+-------------------+--------------------+
+         | Flags        | 00                |                    |
+         +--------------+-------------------+--------------------+
+         | Value        | nRF52 Series song | Current song title |
+         +--------------+-------------------+--------------------+
+
+   .. group-tab:: nRF54 DKs
+
+      Complete the following steps to initiate a music player setup:
+
+      #. In the Bluetooth Low Energy app, verify that the **Apple Entity Update** is initiated to ``00 00 01 02``.
+         The following table lists the attributes requested by the MR.
+
+         +--------------+-------+----------------+
+         | Field        | Value | Interpretation |
+         +==============+=======+================+
+         | Entity ID    | 00    | Player         |
+         +--------------+-------+----------------+
+         | Attribute ID | 00    | Name           |
+         +--------------+-------+----------------+
+         | Attribute ID | 01    | Playback Info  |
+         +--------------+-------+----------------+
+         | Attribute ID | 02    | Volume         |
+         +--------------+-------+----------------+
+
+      #. Press **Button 0** to enable track attributes notification.
+      #. In the Bluetooth Low Energy app, verify that the **Apple Entity Update** is updated to ``02 00 01 02 03``.
+         The following table lists the attributes requested by the MR.
+
+         +--------------+-------+----------------+
+         | Field        | Value | Interpretation |
+         +==============+=======+================+
+         | Entity ID    | 02    | Track          |
+         +--------------+-------+----------------+
+         | Attribute ID | 00    | Artist         |
+         +--------------+-------+----------------+
+         | Attribute ID | 01    | Album          |
+         +--------------+-------+----------------+
+         | Attribute ID | 02    | Title          |
+         +--------------+-------+----------------+
+         | Attribute ID | 03    | Duration       |
+         +--------------+-------+----------------+
+
+      #. Set the **Apple Remote Command** value to ``00 01 02 03 04 05 06 07 08 09 0A 0B 0C``.
+         It tells the MR the list of commands supported by the MS.
+      #. Verify that the UART output is as follows::
+
+            AMS RC: 00,01,02,03,04,05,06,07,08,09,0A,0B,0C
+
+      #. Set the **Apple Entity Update** value to ``00 01 00 30 2C 30 2E 30 2C 30 2E 30 30 30``.
+      #. Verify that the UART output is as follows::
+
+            AMS EU: 00,01,00 0,0.0,0.000
+
+         The following table explains the notification.
+
+         +--------------+-------------+----------------+
+         | Field        | Value       | Interpretation |
+         +==============+=============+================+
+         | Entity ID    | 00          | Player         |
+         +--------------+-------------+----------------+
+         | Attribute ID | 01          | Playback Info  |
+         +--------------+-------------+----------------+
+         | Flags        | 00          |                |
+         +--------------+-------------+----------------+
+         | Value        | 0,0.0,0.000 | Paused         |
+         +--------------+-------------+----------------+
+
+      #. Set the **Apple Entity Update** value to ``02 03 00 31 32 30 2E 30 30 30``.
+      #. Verify that the UART output is as follows::
+
+            AMS EU: 02,03,00 120.000
+
+         The following table explains the notification.
+
+         +--------------+---------+----------------+
+         | Field        | Value   | Interpretation |
+         +==============+=========+================+
+         | Entity ID    | 02      | Track          |
+         +--------------+---------+----------------+
+         | Attribute ID | 03      | Duration       |
+         +--------------+---------+----------------+
+         | Flags        | 00      |                |
+         +--------------+---------+----------------+
+         | Value        | 120.000 | 120 seconds    |
+         +--------------+---------+----------------+
+
+      #. Set the **Apple Entity Update** value to ``02 02 00 6E 52 46 35 32 20 53 65 72 69 65 73 20 73 6F 6E 67``.
+      #. Verify that the UART output is as follows::
+
+            AMS EU: 02,02,00 nRF52 Series song
+
+         The following table explains the notification.
+
+         +--------------+-------------------+--------------------+
+         | Field        | Value             | Interpretation     |
+         +==============+===================+====================+
+         | Entity ID    | 02                | Track              |
+         +--------------+-------------------+--------------------+
+         | Attribute ID | 02                | Title              |
+         +--------------+-------------------+--------------------+
+         | Flags        | 00                |                    |
+         +--------------+-------------------+--------------------+
+         | Value        | nRF52 Series song | Current song title |
+         +--------------+-------------------+--------------------+
 
 Playback
 ^^^^^^^^
 
 To test an audio playback, complete the following steps:
 
-#. Press **Button 2** to start audio playback.
-#. In the Bluetooth Low Energy app, verify that the **Apple Remote Command** is updated to ``02``.
-#. Set the **Apple Entity Update** value to ``00 01 00 31 2C 31 2E 30 2C 30 2E 30 31 34``.
-#. Verify that the UART output is as follows::
+.. tabs::
 
-      AMS EU: 00,01,00 1,1.0,0.014
+   .. group-tab:: nRF52 and nRF53 DKs
 
-   The following table explains the notification.
+      #. Press **Button 2** to start audio playback.
+      #. In the Bluetooth Low Energy app, verify that the **Apple Remote Command** is updated to ``02``.
+      #. Set the **Apple Entity Update** value to ``00 01 00 31 2C 31 2E 30 2C 30 2E 30 31 34``.
+      #. Verify that the UART output is as follows::
 
-   +--------------+-------------+------------------------+
-   | Field        | Value       | Interpretation         |
-   +==============+=============+========================+
-   | Entity ID    | 00          | Player                 |
-   +--------------+-------------+------------------------+
-   | Attribute ID | 01          | Playback Info          |
-   +--------------+-------------+------------------------+
-   | Flags        | 00          |                        |
-   +--------------+-------------+------------------------+
-   | Value        | 1,1.0,0.014 | Playing at rate 1.0.   |
-   |              |             | Elapsed 0.014 seconds. |
-   +--------------+-------------+------------------------+
+            AMS EU: 00,01,00 1,1.0,0.014
+
+         The following table explains the notification.
+
+         +--------------+-------------+------------------------+
+         | Field        | Value       | Interpretation         |
+         +==============+=============+========================+
+         | Entity ID    | 00          | Player                 |
+         +--------------+-------------+------------------------+
+         | Attribute ID | 01          | Playback Info          |
+         +--------------+-------------+------------------------+
+         | Flags        | 00          |                        |
+         +--------------+-------------+------------------------+
+         | Value        | 1,1.0,0.014 | Playing at rate 1.0.   |
+         |              |             | Elapsed 0.014 seconds. |
+         +--------------+-------------+------------------------+
+
+   .. group-tab:: nRF54 DKs
+
+      #. Press **Button 1** to start audio playback.
+      #. In the Bluetooth Low Energy app, verify that the **Apple Remote Command** is updated to ``02``.
+      #. Set the **Apple Entity Update** value to ``00 01 00 31 2C 31 2E 30 2C 30 2E 30 31 34``.
+      #. Verify that the UART output is as follows::
+
+            AMS EU: 00,01,00 1,1.0,0.014
+
+         The following table explains the notification.
+
+         +--------------+-------------+------------------------+
+         | Field        | Value       | Interpretation         |
+         +==============+=============+========================+
+         | Entity ID    | 00          | Player                 |
+         +--------------+-------------+------------------------+
+         | Attribute ID | 01          | Playback Info          |
+         +--------------+-------------+------------------------+
+         | Flags        | 00          |                        |
+         +--------------+-------------+------------------------+
+         | Value        | 1,1.0,0.014 | Playing at rate 1.0.   |
+         |              |             | Elapsed 0.014 seconds. |
+         +--------------+-------------+------------------------+
 
 Next track
 ^^^^^^^^^^
 
-To test the next track feature, complete the following steps:
+.. tabs::
 
-#. Press **Button 3** to jump to next song.
-#. In the Bluetooth Low Energy app, verify that the **Apple Remote Command** is updated to ``03``.
-#. Set the **Apple Entity Update** value to ``02 03 00 31 38 30 2E 30 30 30``.
-#. Verify that the UART output is as follows::
+   .. group-tab:: nRF52 and nRF53 DKs
 
-      AMS EU: 02,03,00 180.000
+      To test the next track feature, complete the following steps:
 
-   The notification shows the updated song duration.
+      #. Press **Button 3** to jump to next song.
+      #. In the Bluetooth Low Energy app, verify that the **Apple Remote Command** is updated to ``03``.
+      #. Set the **Apple Entity Update** value to ``02 03 00 31 38 30 2E 30 30 30``.
+      #. Verify that the UART output is as follows::
 
-#. Set the **Apple Entity Update** value to ``02 02 00 6E 52 46 35 33 20 53 65 72 69 65 73 20 73 6F 6E 67``.
-#. Verify that the UART output is as follows::
+            AMS EU: 02,03,00 180.000
 
-      AMS EU: 02,02,00 nRF53 Series song
+         The notification shows the updated song duration.
 
-   The notification shows the updated song title.
+      #. Set the **Apple Entity Update** value to ``02 02 00 6E 52 46 35 33 20 53 65 72 69 65 73 20 73 6F 6E 67``.
+      #. Verify that the UART output is as follows::
+
+            AMS EU: 02,02,00 nRF53 Series song
+
+         The notification shows the updated song title.
+
+   .. group-tab:: nRF54 DKs
+
+      To test the next track feature, complete the following steps:
+
+      #. Press **Button 2** to jump to next song.
+      #. In the Bluetooth Low Energy app, verify that the **Apple Remote Command** is updated to ``03``.
+      #. Set the **Apple Entity Update** value to ``02 03 00 31 38 30 2E 30 30 30``.
+      #. Verify that the UART output is as follows::
+
+            AMS EU: 02,03,00 180.000
+
+         The notification shows the updated song duration.
+
+      #. Set the **Apple Entity Update** value to ``02 02 00 6E 52 46 35 33 20 53 65 72 69 65 73 20 73 6F 6E 67``.
+      #. Verify that the UART output is as follows::
+
+            AMS EU: 02,02,00 nRF53 Series song
+
+         The notification shows the updated song title.
 
 Disconnect
 ^^^^^^^^^^

--- a/samples/bluetooth/peripheral_ancs_client/README.rst
+++ b/samples/bluetooth/peripheral_ancs_client/README.rst
@@ -23,23 +23,47 @@ The sample also requires a device running an ANCS Server to connect with (for ex
 User interface
 **************
 
-LED 1:
-   Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
+.. tabs::
 
-LED 2:
-   Lit when connected.
+   .. group-tab:: nRF52 and nRF53 DKs
 
-Button 1:
-   Request iOS notification attributes (content) on UART.
+      LED 1:
+         Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
 
-Button 2:
-   Request iOS app attributes on UART.
+      LED 2:
+         Lit when connected.
 
-Button 3:
-   Perform a positive action as a response to the last received notification.
+      Button 1:
+         Request iOS notification attributes (content) on UART.
 
-Button 4:
-   Perform a negative action as a response to the last received notification.
+      Button 2:
+         Request iOS app attributes on UART.
+
+      Button 3:
+         Perform a positive action as a response to the last received notification.
+
+      Button 4:
+         Perform a negative action as a response to the last received notification.
+
+   .. group-tab:: nRF54 DKs
+
+      LED 0:
+         Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
+
+      LED 1:
+         Lit when connected.
+
+      Button 0:
+         Request iOS notification attributes (content) on UART.
+
+      Button 1:
+         Request iOS app attributes on UART.
+
+      Button 2:
+         Perform a positive action as a response to the last received notification.
+
+      Button 3:
+         Perform a negative action as a response to the last received notification.
 
 Building and running
 ********************
@@ -58,15 +82,31 @@ After programming the sample to your development kit, you can test it either by 
 Testing with an iOS device
 --------------------------
 
-#. |connect_terminal_specific|
-#. Reset the kit.
-#. Select the device in the iOS settings Bluetooth menu and connect.
-#. Observe that notifications that are displayed in the iOS notification tab also show up on the UART from the sample.
-#. Press **Button 1** to retrieve the notification attributes and observe that you receive, among other information, the app identifier for the last received notification.
-   For example, if you got a notification from the Calendar app and request the app identifier, it is "com.apple.mobilecal".
-#. Press **Button 2** to retrieve the app attributes and observe that you receive the display name for the app identifier from the previous step.
-   For example, requesting the app attributes for "com.apple.mobilecal" yields "Calendar".
-#. If the notification has a flag for a positive or negative action, perform the notification action with **Button 3** or **Button 4**, respectively.
+.. tabs::
+
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      #. |connect_terminal_specific|
+      #. Reset the kit.
+      #. Select the device in the iOS settings Bluetooth menu and connect.
+      #. Observe that notifications that are displayed in the iOS notification tab also show up on the UART from the sample.
+      #. Press **Button 1** to retrieve the notification attributes and observe that you receive, among other information, the app identifier for the last received notification.
+         For example, if you got a notification from the Calendar app and request the app identifier, it is "com.apple.mobilecal".
+      #. Press **Button 2** to retrieve the app attributes and observe that you receive the display name for the app identifier from the previous step.
+         For example, requesting the app attributes for "com.apple.mobilecal" yields "Calendar".
+      #. If the notification has a flag for a positive or negative action, perform the notification action with **Button 3** or **Button 4**, respectively.
+
+   .. group-tab:: nRF54 DKs
+
+      #. |connect_terminal_specific|
+      #. Reset the kit.
+      #. Select the device in the iOS settings Bluetooth menu and connect.
+      #. Observe that notifications that are displayed in the iOS notification tab also show up on the UART from the sample.
+      #. Press **Button 0** to retrieve the notification attributes and observe that you receive, among other information, the app identifier for the last received notification.
+         For example, if you got a notification from the Calendar app and request the app identifier, it is "com.apple.mobilecal".
+      #. Press **Button 1** to retrieve the app attributes and observe that you receive the display name for the app identifier from the previous step.
+         For example, requesting the app attributes for "com.apple.mobilecal" yields "Calendar".
+      #. If the notification has a flag for a positive or negative action, perform the notification action with **Button 2** or **Button 3**, respectively.
 
 Testing with nRF Connect for Desktop
 ------------------------------------
@@ -144,8 +184,17 @@ The following table shows the format of the message that the application must se
    |                  | 01            | Negative                    |
    +------------------+---------------+-----------------------------+
 
-* Press **Button 3** to perform a positive action and verify that the **Apple Control Point** value is updated to ``02 01 02 03 04 00``.
-* You can also press **Button 4** and observe that the server receives a negative action ``02 01 02 03 04 01``.
+.. tabs::
+
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      * Press **Button 3** to perform a positive action and verify that the **Apple Control Point** value is updated to ``02 01 02 03 04 00``.
+      * You can also press **Button 4** and observe that the server receives a negative action ``02 01 02 03 04 01``.
+
+   .. group-tab:: nRF54 DKs
+
+      * Press **Button 2** to perform a positive action and verify that the **Apple Control Point** value is updated to ``02 01 02 03 04 00``.
+      * You can also press **Button 3** and observe that the server receives a negative action ``02 01 02 03 04 01``.
 
 Retrieve notification attributes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -200,20 +249,42 @@ The following table shows the format of a response that contains some of the req
    | Data             | 63 6F 6D      | "com"                       |
    +------------------+---------------+-----------------------------+
 
-#. Press **Button 1** to request notification attributes for the iOS notification that was received.
-#. In the Bluetooth Low Energy app, verify that the **Apple Control Point** is updated to ``00 01 02 03 04 00 01 20 00 02 20 00 03 20 00 04 05 06 07``.
-#. Respond to the request by sending two notification attributes: the title and the message.
-   Set the **Apple Data Source** value in the Server to ``00 01 02 03 04 01 03 00 6E 52 46 03 02 00 35 32``.
-#. The application will print the received data on UART.
-   Verify that the UART output is as follows::
 
-      Title: nRF
-      Message: 52
+.. tabs::
 
-#. Update the **Apple Data Source** value again with the app identifier ``00 03 00 63 6F 6D``.
-#. Verify that the notification is received and the UART output is as follows::
+   .. group-tab:: nRF52 and nRF53 DKs
 
-      App Identifier: com
+      #. Press **Button 1** to request notification attributes for the iOS notification that was received.
+      #. In the Bluetooth Low Energy app, verify that the **Apple Control Point** is updated to ``00 01 02 03 04 00 01 20 00 02 20 00 03 20 00 04 05 06 07``.
+      #. Respond to the request by sending two notification attributes: the title and the message.
+         Set the **Apple Data Source** value in the Server to ``00 01 02 03 04 01 03 00 6E 52 46 03 02 00 35 32``.
+      #. The application will print the received data on UART.
+         Verify that the UART output is as follows::
+
+            Title: nRF
+            Message: 52
+
+      #. Update the **Apple Data Source** value again with the app identifier ``00 03 00 63 6F 6D``.
+      #. Verify that the notification is received and the UART output is as follows::
+
+            App Identifier: com'
+
+   .. group-tab:: nRF54 DKs
+
+      #. Press **Button 0** to request notification attributes for the iOS notification that was received.
+      #. In the Bluetooth Low Energy app, verify that the **Apple Control Point** is updated to ``00 01 02 03 04 00 01 20 00 02 20 00 03 20 00 04 05 06 07``.
+      #. Respond to the request by sending two notification attributes: the title and the message.
+         Set the **Apple Data Source** value in the Server to ``00 01 02 03 04 01 03 00 6E 52 46 03 02 00 35 32``.
+      #. The application will print the received data on UART.
+         Verify that the UART output is as follows::
+
+            Title: nRF
+            Message: 52
+
+      #. Update the **Apple Data Source** value again with the app identifier ``00 03 00 63 6F 6D``.
+      #. Verify that the notification is received and the UART output is as follows::
+
+            App Identifier: com
 
 Retrieve app attributes
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -248,13 +319,28 @@ The following table shows the format of a response that contains the requested a
    | Data             | 4D 61 69 6C   | "Mail"             |
    +------------------+---------------+--------------------+
 
-#. Press **Button 2** to request app attributes for the app with the app identifier "com" (the last received app identifier).
-#. In the Bluetooth Low Energy app, verify that the **Apple Control Point** is updated to ``01 63 6F 6D 00 00``.
-#. Respond to the request by sending the app attribute.
-   Set the **Apple Data Source** value in the Server to ``01 63 6F 6D 00 00 04 00 4D 61 69 6C``.
-#. The application will print the received data on UART. Verify that the UART output is as follows::
 
-      Display Name: Mail
+.. tabs::
+
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      #. Press **Button 2** to request app attributes for the app with the app identifier "com" (the last received app identifier).
+      #. In the Bluetooth Low Energy app, verify that the **Apple Control Point** is updated to ``01 63 6F 6D 00 00``.
+      #. Respond to the request by sending the app attribute.
+         Set the **Apple Data Source** value in the Server to ``01 63 6F 6D 00 00 04 00 4D 61 69 6C``.
+      #. The application will print the received data on UART. Verify that the UART output is as follows::
+
+            Display Name: Mail
+
+   .. group-tab:: nRF54 DKs
+
+      #. Press **Button 1** to request app attributes for the app with the app identifier "com" (the last received app identifier).
+      #. In the Bluetooth Low Energy app, verify that the **Apple Control Point** is updated to ``01 63 6F 6D 00 00``.
+      #. Respond to the request by sending the app attribute.
+         Set the **Apple Data Source** value in the Server to ``01 63 6F 6D 00 00 04 00 4D 61 69 6C``.
+      #. The application will print the received data on UART. Verify that the UART output is as follows::
+
+            Display Name: Mail
 
 Disconnect
 ^^^^^^^^^^

--- a/samples/bluetooth/peripheral_bms/README.rst
+++ b/samples/bluetooth/peripheral_bms/README.rst
@@ -28,11 +28,23 @@ It supports up to two simultaneous client connections.
 User interface
 **************
 
-LED 1:
-   Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
+.. tabs::
 
-LED 2:
-   Lit when connected.
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      LED 1:
+         Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
+
+      LED 2:
+         Lit when connected.
+
+   .. group-tab:: nRF54 DKs
+
+      LED 0:
+         Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
+
+      LED 1:
+         Lit when connected.
 
 Building and running
 ********************

--- a/samples/bluetooth/peripheral_cts_client/README.rst
+++ b/samples/bluetooth/peripheral_cts_client/README.rst
@@ -31,14 +31,29 @@ The time received is printed on the UART.
 User interface
 **************
 
-LED 1:
-   Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
+.. tabs::
 
-LED 2:
-   Lit when connected.
+   .. group-tab:: nRF52 and nRF53 DKs
 
-Button 1:
-   Read the current time.
+      LED 1:
+         Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
+
+      LED 2:
+         Lit when connected.
+
+      Button 1:
+         Read the current time.
+
+   .. group-tab:: nRF54 DKs
+
+      LED 0:
+         Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
+
+      LED 1:
+         Lit when connected.
+
+      Button 0:
+         Read the current time.
 
 Building and running
 ********************
@@ -53,73 +68,147 @@ Testing
 
 After programming the sample to your development kit, you can test it with `nRF Connect for Desktop`_ by performing the following steps.
 
-1. |connect_terminal_specific|
-#. Reset the kit.
-#. Start `nRF Connect for Desktop`_
-#. Open the Bluetooth Low Energy app and select the connected dongle that is used for communication.
-#. Open the :guilabel:`SERVER SETUP` tab.
-   Click the dongle configuration and select **Load setup**.
-   Load the :file:`cts_central.ncs` file that is located under :file:`samples/bluetooth/peripheral_cts_client` in the |NCS| folder structure.
-#. Click :guilabel:`Apply to device`.
-#. Open the :guilabel:`CONNECTION MAP` tab.
-   Click the dongle configuration and select **Security parameters**.
-   Check :guilabel:`Perform Bonding`, and click :guilabel:`Apply`.
-#. Set the value of **Current Time Service** > **Current Time** to ``C2 07 0B 0F 0C 22 38 06 80 02`` and click :guilabel:`Write`.
-#. Connect to the device from the app. The device is advertising as "Nordic_CTS".
-#. Wait until the bond is established. Verify that the UART data is received as follows::
+.. tabs::
 
-      Connected xx:xx:xx:xx:xx:xx (random)
-      The discovery procedure succeeded
-      Security changed: xx:xx:xx:xx:xx:xx (random) level 2
-      Pairing completed: xx:xx:xx:xx:xx:xx (random), bonded: 1
+   .. group-tab:: nRF52 and nRF53 DKs
 
-#. Press **Button 1** on the kit.
-   Verify that the current time printed on the UART matches the time that was input in the Current Time characteristic (UUID 0x2A2B)::
+      1. |connect_terminal_specific|
+      #. Reset the kit.
+      #. Start `nRF Connect for Desktop`_
+      #. Open the Bluetooth Low Energy app and select the connected dongle that is used for communication.
+      #. Open the :guilabel:`SERVER SETUP` tab.
+         Click the dongle configuration and select **Load setup**.
+         Load the :file:`cts_central.ncs` file that is located under :file:`samples/bluetooth/peripheral_cts_client` in the |NCS| folder structure.
+      #. Click :guilabel:`Apply to device`.
+      #. Open the :guilabel:`CONNECTION MAP` tab.
+         Click the dongle configuration and select **Security parameters**.
+         Check :guilabel:`Perform Bonding`, and click :guilabel:`Apply`.
+      #. Set the value of **Current Time Service** > **Current Time** to ``C2 07 0B 0F 0C 22 38 06 80 02`` and click :guilabel:`Write`.
+      #. Connect to the device from the app. The device is advertising as "Nordic_CTS".
+      #. Wait until the bond is established. Verify that the UART data is received as follows::
 
-      Current Time:
+            Connected xx:xx:xx:xx:xx:xx (random)
+            The discovery procedure succeeded
+            Security changed: xx:xx:xx:xx:xx:xx (random) level 2
+            Pairing completed: xx:xx:xx:xx:xx:xx (random), bonded: 1
 
-      Date:
-          Day of week   Saturday
-          Day of month  15
-          Month of year November
-          Year          1986
+      #. Press **Button 1** on the kit.
+         Verify that the current time printed on the UART matches the time that was input in the Current Time characteristic (UUID 0x2A2B)::
 
-      Time:
-          Hours     12
-          Minutes   34
-          Seconds   56
-          Fractions 128/256 of a second
+            Current Time:
 
-      Adjust Reason:
-          Daylight savings 0
-          Time zone        0
-          External update  1
-          Manual update    0
+            Date:
+               Day of week   Saturday
+               Day of month  15
+               Month of year November
+               Year          1986
 
-#. Change the value of :guilabel:`Current Time Service` > :guilabel:`Current Time` to ``C2 07 0B 0F 0D 25 2A 06 FE 08``. It generates a notification. Verify that the current time printed on the UART matches the time that was input::
+            Time:
+               Hours     12
+               Minutes   34
+               Seconds   56
+               Fractions 128/256 of a second
 
-      Current Time:
+            Adjust Reason:
+               Daylight savings 0
+               Time zone        0
+               External update  1
+               Manual update    0
 
-      Date:
-          Day of week   Saturday
-          Day of month  15
-          Month of year November
-          Year          1986
+      #. Change the value of :guilabel:`Current Time Service` > :guilabel:`Current Time` to ``C2 07 0B 0F 0D 25 2A 06 FE 08``. It generates a notification. Verify that the current time printed on the UART matches the time that was input::
 
-      Time:
-          Hours     13
-          Minutes   37
-          Seconds   42
-          Fractions 254/256 of a second
+            Current Time:
 
-      Adjust Reason:
-          Daylight savings 1
-          Time zone        0
-          External update  0
-          Manual update    0
+            Date:
+               Day of week   Saturday
+               Day of month  15
+               Month of year November
+               Year          1986
 
-#. Disconnect the device in the Bluetooth Low Energy app.
-#. As bond information is preserved by the Bluetooth Low Energy app, you can immediately reconnect to the device by clicking the :guilabel:`Connect` button again.
+            Time:
+               Hours     13
+               Minutes   37
+               Seconds   42
+               Fractions 254/256 of a second
+
+            Adjust Reason:
+               Daylight savings 1
+               Time zone        0
+               External update  0
+               Manual update    0
+
+      #. Disconnect the device in the Bluetooth Low Energy app.
+      #. As bond information is preserved by the Bluetooth Low Energy app, you can immediately reconnect to the device by clicking the :guilabel:`Connect` button again.
+
+   .. group-tab:: nRF54 DKs
+
+      1. |connect_terminal_specific|
+      #. Reset the kit.
+      #. Start `nRF Connect for Desktop`_
+      #. Open the Bluetooth Low Energy app and select the connected dongle that is used for communication.
+      #. Open the :guilabel:`SERVER SETUP` tab.
+         Click the dongle configuration and select **Load setup**.
+         Load the :file:`cts_central.ncs` file that is located under :file:`samples/bluetooth/peripheral_cts_client` in the |NCS| folder structure.
+      #. Click :guilabel:`Apply to device`.
+      #. Open the :guilabel:`CONNECTION MAP` tab.
+         Click the dongle configuration and select **Security parameters**.
+         Check :guilabel:`Perform Bonding`, and click :guilabel:`Apply`.
+      #. Set the value of **Current Time Service** > **Current Time** to ``C2 07 0B 0F 0C 22 38 06 80 02`` and click :guilabel:`Write`.
+      #. Connect to the device from the app. The device is advertising as "Nordic_CTS".
+      #. Wait until the bond is established. Verify that the UART data is received as follows::
+
+            Connected xx:xx:xx:xx:xx:xx (random)
+            The discovery procedure succeeded
+            Security changed: xx:xx:xx:xx:xx:xx (random) level 2
+            Pairing completed: xx:xx:xx:xx:xx:xx (random), bonded: 1
+
+      #. Press **Button 0** on the kit.
+         Verify that the current time printed on the UART matches the time that was input in the Current Time characteristic (UUID 0x2A2B)::
+
+            Current Time:
+
+            Date:
+               Day of week   Saturday
+               Day of month  15
+               Month of year November
+               Year          1986
+
+            Time:
+               Hours     12
+               Minutes   34
+               Seconds   56
+               Fractions 128/256 of a second
+
+            Adjust Reason:
+               Daylight savings 0
+               Time zone        0
+               External update  1
+               Manual update    0
+
+      #. Change the value of :guilabel:`Current Time Service` > :guilabel:`Current Time` to ``C2 07 0B 0F 0D 25 2A 06 FE 08``. It generates a notification. Verify that the current time printed on the UART matches the time that was input::
+
+            Current Time:
+
+            Date:
+               Day of week   Saturday
+               Day of month  15
+               Month of year November
+               Year          1986
+
+            Time:
+               Hours     13
+               Minutes   37
+               Seconds   42
+               Fractions 254/256 of a second
+
+            Adjust Reason:
+               Daylight savings 1
+               Time zone        0
+               External update  0
+               Manual update    0
+
+      #. Disconnect the device in the Bluetooth Low Energy app.
+      #. As bond information is preserved by the Bluetooth Low Energy app, you can immediately reconnect to the device by clicking the :guilabel:`Connect` button again.
 
 Dependencies
 ************

--- a/samples/bluetooth/peripheral_gatt_dm/README.rst
+++ b/samples/bluetooth/peripheral_gatt_dm/README.rst
@@ -29,11 +29,23 @@ When connected to another device, the sample discovers the services of the conne
 User interface
 **************
 
-Button 1:
-   During the pairing procedure, press this button to accept the pairing.
+.. tabs::
 
-Button 2:
-   During the pairing procedure, press this button to reject the pairing.
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      Button 1:
+         During the pairing procedure, press this button to accept the pairing.
+
+      Button 2:
+         During the pairing procedure, press this button to reject the pairing.
+
+   .. group-tab:: nRF54 DKs
+
+      Button 0:
+         During the pairing procedure, press this button to accept the pairing.
+
+      Button 1:
+         During the pairing procedure, press this button to reject the pairing.
 
 Building and running
 ********************

--- a/samples/bluetooth/peripheral_hids_keyboard/README.rst
+++ b/samples/bluetooth/peripheral_hids_keyboard/README.rst
@@ -41,9 +41,20 @@ The following paragraphs describe the application behavior when NFC pairing is e
 
 When the application starts, it initializes and starts the NFCT peripheral that is used for pairing.
 The application does not start advertising immediately, but only when the NFC tag is read by an NFC polling device, for example a smartphone or a tablet with NFC support.
-To trigger advertising without NFC, press **Button 4**.
-The NDEF message that the tag sends to the NFC device contains data required to initiate pairing.
-To start the NFC data transfer, the NFC device must touch the NFC antenna that is connected to the nRF52 device.
+
+.. tabs::
+
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      To trigger advertising without NFC, press **Button 4**.
+      The NDEF message that the tag sends to the NFC device contains data required to initiate pairing.
+      To start the NFC data transfer, the NFC device must touch the NFC antenna that is connected to the nRF52 device.
+
+   .. group-tab:: nRF54 DKs
+
+      To trigger advertising without NFC, press **Button 3**.
+      The NDEF message that the tag sends to the NFC device contains data required to initiate pairing.
+      To start the NFC data transfer, the NFC device must touch the NFC antenna that is connected to the nRF52 device.
 
 After reading the tag, the device can pair with the nRF52 device which is advertising.
 After connecting, the sample application behaves in the same way as the original HID Keyboard sample.
@@ -53,32 +64,65 @@ When the connection is lost, advertising does not restart automatically.
 User interface
 **************
 
-Button 1:
-   Sends one character of the predefined input ("hello\\n") to the computer.
+.. tabs::
 
-   When pairing, press this button to confirm the passkey value that is printed on the COM listener to pair with the other device.
+   .. group-tab:: nRF52 and nRF53 DKs
 
-Button 2:
-   Simulates the Shift key.
+      Button 1:
+         Sends one character of the predefined input ("hello\\n") to the computer.
 
-   When pairing, press this button to reject the passkey value which is printed on the COM listener to prevent pairing with the other device.
+         When pairing, press this button to confirm the passkey value that is printed on the COM listener to pair with the other device.
 
-LED 1:
-   Blinks with a period of two seconds with the duty cycle set to 50% when the main loop is running and the device is advertising.
+      Button 2:
+         Simulates the Shift key.
 
-LED 2:
-   Lit when at least one device is connected.
+         When pairing, press this button to reject the passkey value which is printed on the COM listener to prevent pairing with the other device.
 
-LED 3:
-   Indicates if Caps Lock is enabled.
+      LED 1:
+         Blinks with a period of two seconds with the duty cycle set to 50% when the main loop is running and the device is advertising.
 
-If the `NFC_OOB_PAIRING` feature is enabled:
+      LED 2:
+         Lit when at least one device is connected.
 
-Button 4:
-   Starts advertising.
+      LED 3:
+         Indicates if Caps Lock is enabled.
 
-LED 4:
-   Indicates if an NFC field is present.
+      If the `NFC_OOB_PAIRING` feature is enabled:
+
+      Button 4:
+         Starts advertising.
+
+      LED 4:
+         Indicates if an NFC field is present.
+
+   .. group-tab:: nRF54 DKs
+
+      Button 0:
+         Sends one character of the predefined input ("hello\\n") to the computer.
+
+         When pairing, press this button to confirm the passkey value that is printed on the COM listener to pair with the other device.
+
+      Button 1:
+         Simulates the Shift key.
+
+         When pairing, press this button to reject the passkey value which is printed on the COM listener to prevent pairing with the other device.
+
+      LED 0:
+         Blinks with a period of two seconds with the duty cycle set to 50% when the main loop is running and the device is advertising.
+
+      LED 1:
+         Lit when at least one device is connected.
+
+      LED 2:
+         Indicates if Caps Lock is enabled.
+
+      If the `NFC_OOB_PAIRING` feature is enabled:
+
+      Button 3:
+         Starts advertising.
+
+      LED 3:
+         Indicates if an NFC field is present.
 
 Configuration
 *************
@@ -106,24 +150,49 @@ Testing with a Microsoft Windows computer
 
 To test with a Microsoft Windows computer that has a Bluetooth® radio, complete the following steps:
 
-1. Power on your development kit.
-#. Press **Button 4** on the kit if the device is not advertising.
-   A blinking **LED 1** indicates that the device is advertising.
-#. |connect_terminal|
-#. On your Windows computer, search for Bluetooth devices and connect to the device named "NCS HIDS keyboard".
-#. Observe that the connection state is indicated by **LED 2**.
-#. Open a text editor (for example, Notepad).
-#. Repeatedly press **Button 1** on the kit.
-   Every button press sends one character of the test message "hello" (the test message includes a carriage return) to the computer, and this will be displayed in the text editor.
-#. Press **Button 2** and hold it while pressing **Button 1**.
-   Observe that the next letter of the "hello" message appears as capital letter.
-   This is because **Button 2** simulates the Shift key.
-#. Turn on Caps Lock on the computer.
-   Observe that **LED 3** turns on.
-   This confirms that the output report characteristic has been written successfully on the HID device.
-#. Turn Caps Lock off on the computer.
-   Observe that **LED 3** turns off.
-#. Disconnect the computer from the device by removing the device from the computer's devices list.
+.. tabs::
+
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      1. Power on your development kit.
+      #. Press **Button 4** on the kit if the device is not advertising.
+         A blinking **LED 1** indicates that the device is advertising.
+      #. |connect_terminal|
+      #. On your Windows computer, search for Bluetooth devices and connect to the device named "NCS HIDS keyboard".
+      #. Observe that the connection state is indicated by **LED 2**.
+      #. Open a text editor (for example, Notepad).
+      #. Repeatedly press **Button 1** on the kit.
+         Every button press sends one character of the test message "hello" (the test message includes a carriage return) to the computer, and this will be displayed in the text editor.
+      #. Press **Button 2** and hold it while pressing **Button 1**.
+         Observe that the next letter of the "hello" message appears as capital letter.
+         This is because **Button 2** simulates the Shift key.
+      #. Turn on Caps Lock on the computer.
+         Observe that **LED 3** turns on.
+         This confirms that the output report characteristic has been written successfully on the HID device.
+      #. Turn Caps Lock off on the computer.
+         Observe that **LED 3** turns off.
+      #. Disconnect the computer from the device by removing the device from the computer's devices list.
+
+   .. group-tab:: nRF54 DKs
+
+      1. Power on your development kit.
+      #. Press **Button 3** on the kit if the device is not advertising.
+         A blinking **LED 0** indicates that the device is advertising.
+      #. |connect_terminal|
+      #. On your Windows computer, search for Bluetooth devices and connect to the device named "NCS HIDS keyboard".
+      #. Observe that the connection state is indicated by **LED 1**.
+      #. Open a text editor (for example, Notepad).
+      #. Repeatedly press **Button 0** on the kit.
+         Every button press sends one character of the test message "hello" (the test message includes a carriage return) to the computer, and this will be displayed in the text editor.
+      #. Press **Button 1** and hold it while pressing **Button 0**.
+         Observe that the next letter of the "hello" message appears as capital letter.
+         This is because **Button 1** simulates the Shift key.
+      #. Turn on Caps Lock on the computer.
+         Observe that **LED 2** turns on.
+         This confirms that the output report characteristic has been written successfully on the HID device.
+      #. Turn Caps Lock off on the computer.
+         Observe that **LED 2** turns off.
+      #. Disconnect the computer from the device by removing the device from the computer's devices list.
 
 
 Testing with nRF Connect for Desktop
@@ -131,55 +200,111 @@ Testing with nRF Connect for Desktop
 
 To test with `nRF Connect for Desktop`_, complete the following steps:
 
-1. Power on your development kit.
-#. Press **Button 4** on the kit if the device is not advertising.
-   A blinking **LED 1** indicates that the device is advertising.
-#. |connect_terminal|
-#. Start `nRF Connect for Desktop`_.
-#. Open the Bluetooth Low Energy app.
-#. Connect to the device from the app. The device is advertising as "NCS HIDS keyboard".
-#. Pair the devices:
+.. tabs::
 
-   a. Click the :guilabel:`Settings` button for the device in the app.
-   #. Select :guilabel:`Pair`.
-   #. Optionally, select :guilabel:`Perform Bonding`.
+   .. group-tab:: nRF52 and nRF53 DKs
 
-   Optionally, check :guilabel:`Enable MITM protection` to pair with MITM protection and use a button on the device to confirm or reject the passkey value.
+      1. Power on your development kit.
+      #. Press **Button 4** on the kit if the device is not advertising.
+         A blinking **LED 1** indicates that the device is advertising.
+      #. |connect_terminal|
+      #. Start `nRF Connect for Desktop`_.
+      #. Open the Bluetooth Low Energy app.
+      #. Connect to the device from the app. The device is advertising as "NCS HIDS keyboard".
+      #. Pair the devices:
 
-   Wait until the bond is established before you continue.
+         a. Click the :guilabel:`Settings` button for the device in the app.
+         #. Select :guilabel:`Pair`.
+         #. Optionally, select :guilabel:`Perform Bonding`.
 
-#. Observe that the connection state is indicated by **LED 2**.
-#. Observe that the services of the connected device are shown.
-#. Enable notifications for all HID characteristics.
-#. Press **Button 1** on the kit.
-   Observe that two notifications are received on one of the HID Report characteristics, denoting press and release for one character of the test message.
+         Optionally, check :guilabel:`Enable MITM protection` to pair with MITM protection and use a button on the device to confirm or reject the passkey value.
 
-   The first notification has the value ``00000B0000000000``, the second has the value ``0000000000000000``.
-   The received values correspond to press and release of character "h".
-   The format used for keyboard reports is the following byte array: ``[modifier, reserved, Key1, Key2, Key3, Key4, Key5, Key6]``.
+         Wait until the bond is established before you continue.
 
-   Similarly, further press and release events will result in press and release notifications of subsequent characters of the test string.
-   Therefore, pressing **Button 1** again will result in notification of press and release reports for character "e".
-#. Press **Button 2** and hold it while pressing **Button 1**.
-   Pressing **Button 2** changes the modifier bit to 02, which simulates pressing the Shift key on a keyboard.
+      #. Observe that the connection state is indicated by **LED 2**.
+      #. Observe that the services of the connected device are shown.
+      #. Enable notifications for all HID characteristics.
+      #. Press **Button 1** on the kit.
+         Observe that two notifications are received on one of the HID Report characteristics, denoting press and release for one character of the test message.
 
-   Observe that two notifications are received on one of the HID Report characteristics, denoting press and release for one character of the test message.
-   The first one has the value ``02000F0000000000``, the second has the value ``0200000000000000``.
-   These values correspond to press and release of character "l" with the Shift key pressed.
-#. In the Bluetooth Low Energy app, select the HID Report (which has UUID ``0x2A4D`` and the properties ``Read``, ``WriteWithoutResponse``, and ``Write``).
-   Enter ``02`` in the text box and click the :guilabel:`tick mark` button.
-   This sets the modifier bit of the Output Report to 02, which simulates turning Caps Lock ON.
+         The first notification has the value ``00000B0000000000``, the second has the value ``0000000000000000``.
+         The received values correspond to press and release of character "h".
+         The format used for keyboard reports is the following byte array: ``[modifier, reserved, Key1, Key2, Key3, Key4, Key5, Key6]``.
 
-   Observe that **LED 3** is lit.
-#. Select the same HID Report again.
-   Enter ``00`` in the text box and click :guilabel:`Write`.
-   This sets the modifier bit to 00, which simulates turning Caps Lock OFF.
+         Similarly, further press and release events will result in press and release notifications of subsequent characters of the test string.
+         Therefore, pressing **Button 1** again will result in notification of press and release reports for character "e".
+      #. Press **Button 2** and hold it while pressing **Button 1**.
+         Pressing **Button 2** changes the modifier bit to 02, which simulates pressing the Shift key on a keyboard.
 
-   Observe that **LED 3** turns off.
-#. Disconnect the device in the Bluetooth Low Energy app.
-   Observe that no new notifications are received.
-#. If the advertising did not start automatically, press **Button 4** to continue advertising.
-#. As bond information is preserved by the Bluetooth Low Energy app, you can immediately reconnect to the device by clicking the :guilabel:`Connect` button again.
+         Observe that two notifications are received on one of the HID Report characteristics, denoting press and release for one character of the test message.
+         The first one has the value ``02000F0000000000``, the second has the value ``0200000000000000``.
+         These values correspond to press and release of character "l" with the Shift key pressed.
+      #. In the Bluetooth Low Energy app, select the HID Report (which has UUID ``0x2A4D`` and the properties ``Read``, ``WriteWithoutResponse``, and ``Write``).
+         Enter ``02`` in the text box and click the :guilabel:`tick mark` button.
+         This sets the modifier bit of the Output Report to 02, which simulates turning Caps Lock ON.
+
+         Observe that **LED 3** is lit.
+      #. Select the same HID Report again.
+         Enter ``00`` in the text box and click :guilabel:`Write`.
+         This sets the modifier bit to 00, which simulates turning Caps Lock OFF.
+
+         Observe that **LED 3** turns off.
+      #. Disconnect the device in the Bluetooth Low Energy app.
+         Observe that no new notifications are received.
+      #. If the advertising did not start automatically, press **Button 4** to continue advertising.
+      #. As bond information is preserved by the Bluetooth Low Energy app, you can immediately reconnect to the device by clicking the :guilabel:`Connect` button again.
+
+   .. group-tab:: nRF54 DKs
+
+      1. Power on your development kit.
+      #. Press **Button 3** on the kit if the device is not advertising.
+         A blinking **LED 0** indicates that the device is advertising.
+      #. |connect_terminal|
+      #. Start `nRF Connect for Desktop`_.
+      #. Open the Bluetooth Low Energy app.
+      #. Connect to the device from the app. The device is advertising as "NCS HIDS keyboard".
+      #. Pair the devices:
+
+         a. Click the :guilabel:`Settings` button for the device in the app.
+         #. Select :guilabel:`Pair`.
+         #. Optionally, select :guilabel:`Perform Bonding`.
+
+         Optionally, check :guilabel:`Enable MITM protection` to pair with MITM protection and use a button on the device to confirm or reject the passkey value.
+
+         Wait until the bond is established before you continue.
+
+      #. Observe that the connection state is indicated by **LED 1**.
+      #. Observe that the services of the connected device are shown.
+      #. Enable notifications for all HID characteristics.
+      #. Press **Button 0** on the kit.
+         Observe that two notifications are received on one of the HID Report characteristics, denoting press and release for one character of the test message.
+
+         The first notification has the value ``00000B0000000000``, the second has the value ``0000000000000000``.
+         The received values correspond to press and release of character "h".
+         The format used for keyboard reports is the following byte array: ``[modifier, reserved, Key1, Key2, Key3, Key4, Key5, Key6]``.
+
+         Similarly, further press and release events will result in press and release notifications of subsequent characters of the test string.
+         Therefore, pressing **Button 0** again will result in notification of press and release reports for character "e".
+      #. Press **Button 1** and hold it while pressing **Button 0**.
+         Pressing **Button 1** changes the modifier bit to 02, which simulates pressing the Shift key on a keyboard.
+
+         Observe that two notifications are received on one of the HID Report characteristics, denoting press and release for one character of the test message.
+         The first one has the value ``02000F0000000000``, the second has the value ``0200000000000000``.
+         These values correspond to press and release of character "l" with the Shift key pressed.
+      #. In the Bluetooth Low Energy app, select the HID Report (which has UUID ``0x2A4D`` and the properties ``Read``, ``WriteWithoutResponse``, and ``Write``).
+         Enter ``02`` in the text box and click the :guilabel:`tick mark` button.
+         This sets the modifier bit of the Output Report to 02, which simulates turning Caps Lock ON.
+
+         Observe that **LED 2** is lit.
+      #. Select the same HID Report again.
+         Enter ``00`` in the text box and click :guilabel:`Write`.
+         This sets the modifier bit to 00, which simulates turning Caps Lock OFF.
+
+         Observe that **LED 2** turns off.
+      #. Disconnect the device in the Bluetooth Low Energy app.
+         Observe that no new notifications are received.
+      #. If the advertising did not start automatically, press **Button 3** to continue advertising.
+      #. As bond information is preserved by the Bluetooth Low Energy app, you can immediately reconnect to the device by clicking the :guilabel:`Connect` button again.
 
 
 Testing with Android using NFC for pairing
@@ -187,17 +312,35 @@ Testing with Android using NFC for pairing
 
 To test with an Android smartphone/tablet, complete the following steps:
 
-1. Touch the NFC antenna with the smartphone or tablet and observe that **LED 4** is lit.
-#. Observe that the device is advertising, as indicated by blinking **LED 1**.
-#. Confirm pairing with 'Nordic_HIDS_keyboard' in a pop-up window on the smartphone/tablet.
-#. Observe that the connection state is indicated by **LED 2**.
-#. Repeatedly press **Button 1** on the kit.
-   Every button press sends one character of the test message "hello" to the smartphone (the test message includes a carriage return).
-#. Press **Button 2** and hold it while pressing **Button 1**.
-   Observe that the next letter of the "hello" message appears as a capital letter.
-   This is because **Button 2** simulates the Shift key.
-#. Touch the NFC antenna with the same central device again.
-#. Observe that devices disconnect.
+.. tabs::
+
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      1. Touch the NFC antenna with the smartphone or tablet and observe that **LED 4** is lit.
+      #. Observe that the device is advertising, as indicated by blinking **LED 1**.
+      #. Confirm pairing with 'Nordic_HIDS_keyboard' in a pop-up window on the smartphone/tablet.
+      #. Observe that the connection state is indicated by **LED 2**.
+      #. Repeatedly press **Button 1** on the kit.
+         Every button press sends one character of the test message "hello" to the smartphone (the test message includes a carriage return).
+      #. Press **Button 2** and hold it while pressing **Button 1**.
+         Observe that the next letter of the "hello" message appears as a capital letter.
+         This is because **Button 2** simulates the Shift key.
+      #. Touch the NFC antenna with the same central device again.
+      #. Observe that devices disconnect.
+
+   .. group-tab:: nRF54 DKs
+
+      1. Touch the NFC antenna with the smartphone or tablet and observe that **LED 3** is lit.
+      #. Observe that the device is advertising, as indicated by blinking **LED 0**.
+      #. Confirm pairing with 'Nordic_HIDS_keyboard' in a pop-up window on the smartphone/tablet.
+      #. Observe that the connection state is indicated by **LED 1**.
+      #. Repeatedly press **Button 0** on the kit.
+         Every button press sends one character of the test message "hello" to the smartphone (the test message includes a carriage return).
+      #. Press **Button 1** and hold it while pressing **Button 0**.
+         Observe that the next letter of the "hello" message appears as a capital letter.
+         This is because **Button 1** simulates the Shift key.
+      #. Touch the NFC antenna with the same central device again.
+      #. Observe that devices disconnect.
 
 Dependencies
 ************

--- a/samples/bluetooth/peripheral_hids_mouse/README.rst
+++ b/samples/bluetooth/peripheral_hids_mouse/README.rst
@@ -40,21 +40,43 @@ If all bonding information is used and there is still no connection, the regular
 User interface
 **************
 
-Button 1:
-   Simulate moving the mouse pointer five pixels to the left.
+.. tabs::
 
-   When pairing, press this button to confirm the passkey value that is printed on the COM listener to pair with the other device.
+   .. group-tab:: nRF52 and nRF53 DKs
 
-Button 2:
-   Simulate moving the mouse pointer five pixels up.
+      Button 1:
+         Simulate moving the mouse pointer five pixels to the left.
 
-   When pairing, press this button to reject the passkey value that is printed on the COM listener to prevent pairing with the other device.
+         When pairing, press this button to confirm the passkey value that is printed on the COM listener to pair with the other device.
 
-Button 3:
-   Simulate moving the mouse pointer five pixels to the right.
+      Button 2:
+         Simulate moving the mouse pointer five pixels up.
 
-Button 4:
-   Simulate moving the mouse pointer five pixels down.
+         When pairing, press this button to reject the passkey value that is printed on the COM listener to prevent pairing with the other device.
+
+      Button 3:
+         Simulate moving the mouse pointer five pixels to the right.
+
+      Button 4:
+         Simulate moving the mouse pointer five pixels down.
+
+   .. group-tab:: nRF54 DKs
+
+      Button 0:
+         Simulate moving the mouse pointer five pixels to the left.
+
+         When pairing, press this button to confirm the passkey value that is printed on the COM listener to pair with the other device.
+
+      Button 1:
+         Simulate moving the mouse pointer five pixels up.
+
+         When pairing, press this button to reject the passkey value that is printed on the COM listener to prevent pairing with the other device.
+
+      Button 2:
+         Simulate moving the mouse pointer five pixels to the right.
+
+      Button 3:
+         Simulate moving the mouse pointer five pixels down.
 
 Configuration
 *************
@@ -92,53 +114,104 @@ Testing with a Microsoft Windows computer
 
 To test with a Microsoft Windows computer that has a Bluetooth radio, complete the following steps:
 
-1. Power on your development kit.
-#. On your Windows computer, search for Bluetooth devices and connect to the device named "NCS HIDS mouse".
-#. Push **Button 1** on the kit.
-   Observe that the mouse pointer on the computer moves to the left.
-#. Push **Button 2**.
-   Observe that the mouse pointer on the computer moves upward.
-#. Push **Button 3**.
-   Observe that the mouse pointer on the computer moves to the right.
-#. Push **Button 4**.
-   Observe that the mouse pointer on the computer moves downward.
-#. Disconnect the computer from the device by removing the device from the computer's devices list.
+.. tabs::
 
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      1. Power on your development kit.
+      #. On your Windows computer, search for Bluetooth devices and connect to the device named "NCS HIDS mouse".
+      #. Push **Button 1** on the kit.
+         Observe that the mouse pointer on the computer moves to the left.
+      #. Push **Button 2**.
+         Observe that the mouse pointer on the computer moves upward.
+      #. Push **Button 3**.
+         Observe that the mouse pointer on the computer moves to the right.
+      #. Push **Button 4**.
+         Observe that the mouse pointer on the computer moves downward.
+      #. Disconnect the computer from the device by removing the device from the computer's devices list.
+
+   .. group-tab:: nRF54 DKs
+
+      1. Power on your development kit.
+      #. On your Windows computer, search for Bluetooth devices and connect to the device named "NCS HIDS mouse".
+      #. Push **Button 0** on the kit.
+         Observe that the mouse pointer on the computer moves to the left.
+      #. Push **Button 1**.
+         Observe that the mouse pointer on the computer moves upward.
+      #. Push **Button 2**.
+         Observe that the mouse pointer on the computer moves to the right.
+      #. Push **Button 3**.
+         Observe that the mouse pointer on the computer moves downward.
+      #. Disconnect the computer from the device by removing the device from the computer's devices list.
 
 Testing with nRF Connect for Desktop
 ------------------------------------
 
 To test with `nRF Connect for Desktop`_, complete the following steps:
 
-1. Power on your development kit.
-#. Start `nRF Connect for Desktop`_.
-#. Open the Bluetooth Low Energy app.
-#. Connect to the device from the app. The device is advertising as "NCS HIDS mouse"
-#. Optionally, bond to the device.
-   Click the :guilabel:`Settings` button for the device in the app, select **Pair**, check :guilabel:`Perform Bonding`, and click :guilabel:`Pair`.
-   Optionally check :guilabel:`Enable MITM protection` to pair with MITM protection and use a button on the device to confirm or reject passkey value.
-#. Click :guilabel:`Match` in the app.
-   Wait until the bond is established before you continue.
-#. Observe that the services of the connected device are shown.
-#. Click :guilabel:`Play` for all HID Report characteristics.
-#. Push **Button 1** on the kit.
-   Observe that a notification is received on one of the HID Report characteristics, containing the value ``FB0F00``.
+.. tabs::
 
-   Mouse motion reports contain data with an X-translation and a Y-translation.
-   These are transmitted as 12-bit signed integers.
-   The format used for mouse reports is the following byte array, where LSB/MSB is the least/most significant bit: ``[8 LSB (X), 4 LSB (Y) | 4 MSB(X), 8 MSB(Y)]``.
+   .. group-tab:: nRF52 and nRF53 DKs
 
-   Therefore, ``FB0F00`` denotes an X-translation of FFB = -5 (two's complement format), which means a movement of five pixels to the left, and a Y-translation of 000 = 0.
-#. Push **Button 2**.
-   Observe that the value ``00B0FF`` is received on the same HID Report characteristic.
-#. Push **Button 3**.
-   Observe that the value ``050000`` is received on the same HID Report characteristic.
-#. Push **Button 4**.
-   Observe that the value ``005000`` is received on the same HID Report characteristic.
-#. Disconnect the device in the Bluetooth Low Energy app of nRF Connect for Desktop.
-   Observe that no new notifications are received and the device is advertising.
-#. As bond information is preserved by the Bluetooth Low Energy app, you can immediately reconnect to the device by clicking the :guilabel:`Connect` button again.
+      1. Power on your development kit.
+      #. Start `nRF Connect for Desktop`_.
+      #. Open the Bluetooth Low Energy app.
+      #. Connect to the device from the app. The device is advertising as "NCS HIDS mouse"
+      #. Optionally, bond to the device.
+         Click the :guilabel:`Settings` button for the device in the app, select **Pair**, check :guilabel:`Perform Bonding`, and click :guilabel:`Pair`.
+         Optionally check :guilabel:`Enable MITM protection` to pair with MITM protection and use a button on the device to confirm or reject passkey value.
+      #. Click :guilabel:`Match` in the app.
+         Wait until the bond is established before you continue.
+      #. Observe that the services of the connected device are shown.
+      #. Click :guilabel:`Play` for all HID Report characteristics.
+      #. Push **Button 1** on the kit.
+         Observe that a notification is received on one of the HID Report characteristics, containing the value ``FB0F00``.
 
+         Mouse motion reports contain data with an X-translation and a Y-translation.
+         These are transmitted as 12-bit signed integers.
+         The format used for mouse reports is the following byte array, where LSB/MSB is the least/most significant bit: ``[8 LSB (X), 4 LSB (Y) | 4 MSB(X), 8 MSB(Y)]``.
+
+         Therefore, ``FB0F00`` denotes an X-translation of FFB = -5 (two's complement format), which means a movement of five pixels to the left, and a Y-translation of 000 = 0.
+      #. Push **Button 2**.
+         Observe that the value ``00B0FF`` is received on the same HID Report characteristic.
+      #. Push **Button 3**.
+         Observe that the value ``050000`` is received on the same HID Report characteristic.
+      #. Push **Button 4**.
+         Observe that the value ``005000`` is received on the same HID Report characteristic.
+      #. Disconnect the device in the Bluetooth Low Energy app of nRF Connect for Desktop.
+         Observe that no new notifications are received and the device is advertising.
+      #. As bond information is preserved by the Bluetooth Low Energy app, you can immediately reconnect to the device by clicking the :guilabel:`Connect` button again.
+
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      1. Power on your development kit.
+      #. Start `nRF Connect for Desktop`_.
+      #. Open the Bluetooth Low Energy app.
+      #. Connect to the device from the app. The device is advertising as "NCS HIDS mouse"
+      #. Optionally, bond to the device.
+         Click the :guilabel:`Settings` button for the device in the app, select **Pair**, check :guilabel:`Perform Bonding`, and click :guilabel:`Pair`.
+         Optionally check :guilabel:`Enable MITM protection` to pair with MITM protection and use a button on the device to confirm or reject passkey value.
+      #. Click :guilabel:`Match` in the app.
+         Wait until the bond is established before you continue.
+      #. Observe that the services of the connected device are shown.
+      #. Click :guilabel:`Play` for all HID Report characteristics.
+      #. Push **Button 0** on the kit.
+         Observe that a notification is received on one of the HID Report characteristics, containing the value ``FB0F00``.
+
+         Mouse motion reports contain data with an X-translation and a Y-translation.
+         These are transmitted as 12-bit signed integers.
+         The format used for mouse reports is the following byte array, where LSB/MSB is the least/most significant bit: ``[8 LSB (X), 4 LSB (Y) | 4 MSB(X), 8 MSB(Y)]``.
+
+         Therefore, ``FB0F00`` denotes an X-translation of FFB = -5 (two's complement format), which means a movement of five pixels to the left, and a Y-translation of 000 = 0.
+      #. Push **Button 1**.
+         Observe that the value ``00B0FF`` is received on the same HID Report characteristic.
+      #. Push **Button 2**.
+         Observe that the value ``050000`` is received on the same HID Report characteristic.
+      #. Push **Button 3**.
+         Observe that the value ``005000`` is received on the same HID Report characteristic.
+      #. Disconnect the device in the Bluetooth Low Energy app of nRF Connect for Desktop.
+         Observe that no new notifications are received and the device is advertising.
+      #. As bond information is preserved by the Bluetooth Low Energy app, you can immediately reconnect to the device by clicking the :guilabel:`Connect` button again.
 
 Dependencies
 ************

--- a/samples/bluetooth/peripheral_hr_coded/README.rst
+++ b/samples/bluetooth/peripheral_hr_coded/README.rst
@@ -34,11 +34,23 @@ User interface
 
 The user interface of the sample depends on the hardware platform you are using.
 
-LED 1:
-   Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
+.. tabs::
 
-LED 2:
-   Lit when the development kit is connected.
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      LED 1:
+         Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
+
+      LED 2:
+         Lit when the development kit is connected.
+
+   .. group-tab:: nRF54 DKs
+
+      LED 0:
+         Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
+
+      LED 1:
+         Lit when the development kit is connected.
 
 Building and running
 ********************

--- a/samples/bluetooth/peripheral_lbs/README.rst
+++ b/samples/bluetooth/peripheral_lbs/README.rst
@@ -27,8 +27,19 @@ The `Testing`_ instructions refer to `nRF Connect for Mobile`_, but you can also
 Overview
 ********
 
-When connected, the sample sends the state of **Button 1** on the development kit to the connected device, such as a phone or tablet.
-The mobile application on the device can display the received button state and control the state of **LED 3** on the development kit.
+You can use the sample to transmit the button state from your development kit to another device.
+
+.. tabs::
+
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      When connected, the sample sends the state of **Button 1** on the development kit to the connected device, such as a phone or tablet.
+      The mobile application on the device can display the received button state and control the state of **LED 3** on the development kit.
+
+   .. group-tab:: nRF54 DKs
+
+      When connected, the sample sends the state of **Button 0** on the development kit to the connected device, such as a phone or tablet.
+      The mobile application on the device can display the received button state and control the state of **LED 2** on the development kit.
 
 You can also use this sample to control the color of the RGB LED on the nRF52840 Dongle or Thingy:53.
 
@@ -72,17 +83,35 @@ Button 1:
 Development kits
 ================
 
-LED 1:
-   Blinks when the main loop is running (that is, the device is advertising) with a period of two seconds, duty cycle 50%.
+.. tabs::
 
-LED 2:
-   Lit when the development kit is connected.
+   .. group-tab:: nRF52 and nRF53 DKs
 
-LED 3:
-   Lit when the development kit is controlled remotely from the connected device.
+      LED 1:
+         Blinks when the main loop is running (that is, the device is advertising) with a period of two seconds, duty cycle 50%.
 
-Button 1:
-   Send a notification with the button state: "pressed" or "released".
+      LED 2:
+         Lit when the development kit is connected.
+
+      LED 3:
+         Lit when the development kit is controlled remotely from the connected device.
+
+      Button 1:
+         Send a notification with the button state: "pressed" or "released".
+
+   .. group-tab:: nRF54 DKs
+
+      LED 0:
+         Blinks when the main loop is running (that is, the device is advertising) with a period of two seconds, duty cycle 50%.
+
+      LED 1:
+         Lit when the development kit is connected.
+
+      LED 2:
+         Lit when the development kit is controlled remotely from the connected device.
+
+      Button 0:
+         Send a notification with the button state: "pressed" or "released".
 
 Building and running
 ********************
@@ -109,36 +138,73 @@ Testing
 
 After programming the sample to your dongle or development kit, test it by performing the following steps:
 
-1. Start the `nRF Connect for Mobile`_ application on your smartphone or tablet.
-#. Power on the development kit or insert your dongle into the USB port.
-#. Connect to the device from the application.
-   The device is advertising as ``Nordic_LBS``.
-   The services of the connected device are shown.
-#. In **Nordic LED Button Service**, enable notifications for the **Button** characteristic.
-#. Press **Button 1** on the device.
-#. Observe that notifications with the following values are displayed:
+.. tabs::
 
-   * ``Button released`` when **Button 1** is released.
-   * ``Button pressed`` when **Button 1** is pressed.
+   .. group-tab:: nRF52 and nRF53 DKs
 
-#. Write the following values to the LED characteristic in the **Nordic LED Button Service**.
-   Depending on the hardware platform, this produces results described in the table.
+      1. Start the `nRF Connect for Mobile`_ application on your smartphone or tablet.
+      #. Power on the development kit or insert your dongle into the USB port.
+      #. Connect to the device from the application.
+         The device is advertising as ``Nordic_LBS``.
+         The services of the connected device are shown.
+      #. In **Nordic LED Button Service**, enable notifications for the **Button** characteristic.
+      #. Press **Button 1** on the device.
+      #. Observe that notifications with the following values are displayed:
 
-+------------------------+---------+----------------------------------------------+
-| Hardware platform      | Value   | Effect                                       |
-+========================+=========+==============================================+
-| Development kit        | ``OFF`` | Switch the **LED3** off.                     |
-+                        +---------+----------------------------------------------+
-|                        | ``ON``  | Switch the **LED3** on.                      |
-+------------------------+---------+----------------------------------------------+
-| nRF52840 Dongle        | ``OFF`` | Switch the green channel of the RGB LED off. |
-+                        +---------+----------------------------------------------+
-|                        | ``ON``  | Switch the green channel of the RGB LED on.  |
-+------------------------+---------+----------------------------------------------+
-| Thingy:53              | ``OFF`` | Switch the blue channel of the RGB LED off.  |
-+                        +---------+----------------------------------------------+
-|                        | ``ON``  | Switch the blue channel of the RGB LED on.   |
-+------------------------+---------+----------------------------------------------+
+         * ``Button released`` when **Button 1** is released.
+         * ``Button pressed`` when **Button 1** is pressed.
+
+      #. Write the following values to the LED characteristic in the **Nordic LED Button Service**.
+         Depending on the hardware platform, this produces results described in the table.
+
+      +------------------------+---------+----------------------------------------------+
+      | Hardware platform      | Value   | Effect                                       |
+      +========================+=========+==============================================+
+      | Development kit        | ``OFF`` | Switch the **LED 3** off.                    |
+      +                        +---------+----------------------------------------------+
+      |                        | ``ON``  | Switch the **LED 3** on.                     |
+      +------------------------+---------+----------------------------------------------+
+      | nRF52840 Dongle        | ``OFF`` | Switch the green channel of the RGB LED off. |
+      +                        +---------+----------------------------------------------+
+      |                        | ``ON``  | Switch the green channel of the RGB LED on.  |
+      +------------------------+---------+----------------------------------------------+
+      | Thingy:53              | ``OFF`` | Switch the blue channel of the RGB LED off.  |
+      +                        +---------+----------------------------------------------+
+      |                        | ``ON``  | Switch the blue channel of the RGB LED on.   |
+      +------------------------+---------+----------------------------------------------+
+
+   .. group-tab:: nRF54 DKs
+
+      1. Start the `nRF Connect for Mobile`_ application on your smartphone or tablet.
+      #. Power on the development kit or insert your dongle into the USB port.
+      #. Connect to the device from the application.
+         The device is advertising as ``Nordic_LBS``.
+         The services of the connected device are shown.
+      #. In **Nordic LED Button Service**, enable notifications for the **Button** characteristic.
+      #. Press **Button 0** on the device.
+      #. Observe that notifications with the following values are displayed:
+
+         * ``Button released`` when **Button 0** is released.
+         * ``Button pressed`` when **Button 0** is pressed.
+
+      #. Write the following values to the LED characteristic in the **Nordic LED Button Service**.
+         Depending on the hardware platform, this produces results described in the table.
+
+      +------------------------+---------+----------------------------------------------+
+      | Hardware platform      | Value   | Effect                                       |
+      +========================+=========+==============================================+
+      | Development kit        | ``OFF`` | Switch the **LED 2** off.                    |
+      +                        +---------+----------------------------------------------+
+      |                        | ``ON``  | Switch the **LED 2** on.                     |
+      +------------------------+---------+----------------------------------------------+
+      | nRF52840 Dongle        | ``OFF`` | Switch the green channel of the RGB LED off. |
+      +                        +---------+----------------------------------------------+
+      |                        | ``ON``  | Switch the green channel of the RGB LED on.  |
+      +------------------------+---------+----------------------------------------------+
+      | Thingy:53              | ``OFF`` | Switch the blue channel of the RGB LED off.  |
+      +                        +---------+----------------------------------------------+
+      |                        | ``ON``  | Switch the blue channel of the RGB LED on.   |
+      +------------------------+---------+----------------------------------------------+
 
 Dependencies
 ************

--- a/samples/bluetooth/peripheral_nfc_pairing/README.rst
+++ b/samples/bluetooth/peripheral_nfc_pairing/README.rst
@@ -77,20 +77,32 @@ You can change the default role by choosing ``CONFIG_NFC_TAG_CH_SELECTOR`` or ``
 .. figure:: images/nfc_negotiated_connection_handover.svg
    :alt: Negotiated Handover
 
-
-
-
 User interface
 **************
 
-Button 4:
-   Removes all bonded devices and terminates current connections.
+.. tabs::
 
-LED 1:
-   Indicates that a Bluetooth connection is established.
+   .. group-tab:: nRF52 and nRF53 DKs
 
-LED 2:
-   Indicates that an NFC field is present.
+      Button 4:
+         Removes all bonded devices and terminates current connections.
+
+      LED 1:
+         Indicates that a Bluetooth connection is established.
+
+      LED 2:
+         Indicates that an NFC field is present.
+
+   .. group-tab:: nRF54 DKs
+
+      Button 3:
+         Removes all bonded devices and terminates current connections.
+
+      LED 0:
+         Indicates that a Bluetooth connection is established.
+
+      LED 1:
+         Indicates that an NFC field is present.
 
 Building and running
 ********************
@@ -107,18 +119,40 @@ After programming the sample to your development kit, complete the following ste
 Testing with NFC Poller Device
 ------------------------------
 
-1. Touch the NFC antenna with the smartphone or tablet and observe that **LED 2** is lit.
-#. Confirm pairing with :guilabel:`Nordic_NFC_pairing` in a pop-up window on the smartphone or tablet and observe that **LED 1** lights up.
-#. Move the smartphone or tablet away from the NFC antenna and observe that **LED 2** turns off.
+.. tabs::
+
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      1. Touch the NFC antenna with the smartphone or tablet and observe that **LED 2** is lit.
+      #. Confirm pairing with :guilabel:`Nordic_NFC_pairing` in a pop-up window on the smartphone or tablet and observe that **LED 1** lights up.
+      #. Move the smartphone or tablet away from the NFC antenna and observe that **LED 2** turns off.
+
+   .. group-tab:: nRF54 DKs
+
+      1. Touch the NFC antenna with the smartphone or tablet and observe that **LED 1** is lit.
+      #. Confirm pairing with :guilabel:`Nordic_NFC_pairing` in a pop-up window on the smartphone or tablet and observe that **LED 0** lights up.
+      #. Move the smartphone or tablet away from the NFC antenna and observe that **LED 1** turns off.
 
 Testing with NFC TNEP Poller Device
 -----------------------------------
 
-1. Touch the NFC antenna with the NFC Poller Device, for example :ref:`central_nfc_pairing` and observe that **LED 2** is lit.
-#. Observe the output log.
-   The content of the exchanged NDEF messages is printed there.
-#. Check the security level of the paring on the terminal.
-#. Move the NFC antenna away from the NFC Poller Device.
+.. tabs::
+
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      1. Touch the NFC antenna with the NFC Poller Device, for example :ref:`central_nfc_pairing` and observe that **LED 2** is lit.
+      #. Observe the output log.
+         The content of the exchanged NDEF messages is printed there.
+      #. Check the security level of the paring on the terminal.
+      #. Move the NFC antenna away from the NFC Poller Device.
+
+   .. group-tab:: nRF54 DKs
+
+      1. Touch the NFC antenna with the NFC Poller Device, for example :ref:`central_nfc_pairing` and observe that **LED 1** is lit.
+      #. Observe the output log.
+         The content of the exchanged NDEF messages is printed there.
+      #. Check the security level of the paring on the terminal.
+      #. Move the NFC antenna away from the NFC Poller Device.
 
 Dependencies
 ************

--- a/samples/bluetooth/peripheral_rscs/README.rst
+++ b/samples/bluetooth/peripheral_rscs/README.rst
@@ -31,11 +31,23 @@ The mobile application on the device can configure sensor parameters using the S
 User interface
 **************
 
-LED 1:
-   Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
+.. tabs::
 
-LED 2:
-   Lit when connected.
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      LED 1:
+         Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
+
+      LED 2:
+         Lit when connected.
+
+   .. group-tab:: nRF54 DKs
+
+      LED 0:
+         Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
+
+      LED 1:
+         Lit when connected.
 
 Building and running
 ********************

--- a/samples/bluetooth/peripheral_status/README.rst
+++ b/samples/bluetooth/peripheral_status/README.rst
@@ -28,11 +28,20 @@ The `Testing`_ instructions refer to `nRF Connect for Mobile`_, but you can also
 Overview
 ********
 
-The sample implements two NSMS instances that result in two NSMS characteristics that describe the status of two buttons (**Button 1** and **Button 2**).
+The sample implements two NSMS instances that result in two NSMS characteristics that describe the button status.
 Each characteristic has a name set in Characteristic User Description (CUD) that corresponds to the button whose status is shown.
 
-Moreover, status related to **Button 2** has configurable security settings.
-When :ref:`CONFIG_BT_STATUS_SECURITY_ENABLED <CONFIG_BT_STATUS_SECURITY_ENABLED>` is configured, the status related to **Button 2** has security enabled, thus it can be accessed only when bonded.
+.. tabs::
+
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      Status related to **Button 2** has configurable security settings.
+      When :ref:`CONFIG_BT_STATUS_SECURITY_ENABLED <CONFIG_BT_STATUS_SECURITY_ENABLED>` is configured, the status related to **Button 2** has security enabled, thus it can be accessed only when bonded.
+
+   .. group-tab:: nRF54 DKs
+
+      Status related to **Button 1** has configurable security settings.
+      When :ref:`CONFIG_BT_STATUS_SECURITY_ENABLED <CONFIG_BT_STATUS_SECURITY_ENABLED>` is configured, the status related to **Button 1** has security enabled, thus it can be accessed only when bonded.
 
 User interface
 **************
@@ -64,20 +73,41 @@ Button 2 (the one hidden under the cover):
 Development kits
 ================
 
-LED 1:
-   Blinks with a period of two seconds with the duty cycle set to 50% when the main loop is running and the device is advertising.
+.. tabs::
 
-LED 2:
-   Lit when the development kit is connected.
+   .. group-tab:: nRF52 and nRF53 DKs
 
-Button 1:
-   Set **Button 1** NSMS Status Characteristic to: "Pressed" or "Released".
-   Notify the client if notification is enabled.
+      LED 1:
+         Blinks with a period of two seconds with the duty cycle set to 50% when the main loop is running and the device is advertising.
 
-Button 2 (the one hidden under the cover):
-   Set **Button 2** NSMS Status Characteristic to: "Pressed" or "Released".
-   Notify the client if notification is enabled.
-   By default, this service requires the connection to be secured to read or notify.
+      LED 2:
+         Lit when the development kit is connected.
+
+      Button 1:
+         Set **Button 1** NSMS Status Characteristic to: "Pressed" or "Released".
+         Notify the client if notification is enabled.
+
+      Button 2 (the one hidden under the cover):
+         Set **Button 2** NSMS Status Characteristic to: "Pressed" or "Released".
+         Notify the client if notification is enabled.
+         By default, this service requires the connection to be secured to read or notify.
+
+   .. group-tab:: nRF54 DKs
+
+      LED 0:
+         Blinks with a period of two seconds with the duty cycle set to 50% when the main loop is running and the device is advertising.
+
+      LED 1:
+         Lit when the development kit is connected.
+
+      Button 0:
+         Set **Button 0** NSMS Status Characteristic to: "Pressed" or "Released".
+         Notify the client if notification is enabled.
+
+      Button 1 (the one hidden under the cover):
+         Set **Button 1** NSMS Status Characteristic to: "Pressed" or "Released".
+         Notify the client if notification is enabled.
+         By default, this service requires the connection to be secured to read or notify.
 
 Configuration
 *************
@@ -118,8 +148,17 @@ After programming the sample to your dongle or development kit, test it by perfo
 #. Enable notification for the characteristic found.
 #. Press the related button and observe the message change between "Pressed" and "Released".
 
-.. note::
-   Performing the same for **Button 2** characteristic requires a secured connection.
+.. tabs::
+
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      .. note::
+         Performing the same for **Button 2** characteristic requires a secured connection.
+
+   .. group-tab:: nRF54 DKs
+
+      .. note::
+         Performing the same for **Button 1** characteristic requires a secured connection.
 
 Dependencies
 ************

--- a/samples/bluetooth/peripheral_uart/README.rst
+++ b/samples/bluetooth/peripheral_uart/README.rst
@@ -111,17 +111,35 @@ The user interface of the sample depends on the hardware platform you are using.
 Development kits
 ================
 
-LED 1:
-   Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
+.. tabs::
 
-LED 2:
-   Lit when connected.
+   .. group-tab:: nRF21, nRF52 and nRF53 DKs
 
-Button 1:
-   Confirm the passkey value that is printed in the debug logs to pair/bond with the other device.
+      LED 1:
+         Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
 
-Button 2:
-   Reject the passkey value that is printed in the debug logs to prevent pairing/bonding with the other device.
+      LED 2:
+         Lit when connected.
+
+      Button 1:
+         Confirm the passkey value that is printed in the debug logs to pair/bond with the other device.
+
+      Button 2:
+         Reject the passkey value that is printed in the debug logs to prevent pairing/bonding with the other device.
+
+   .. group-tab:: nRF54 DKs
+
+      LED 0:
+         Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
+
+      LED 1:
+         Lit when connected.
+
+      Button 0:
+         Confirm the passkey value that is printed in the debug logs to pair/bond with the other device.
+
+      Button 1:
+         Reject the passkey value that is printed in the debug logs to prevent pairing/bonding with the other device.
 
 Thingy:53
 =========
@@ -181,29 +199,59 @@ Testing
 
 After programming the sample to your development kit, complete the following steps to test it:
 
-1. Connect the device to the computer to access UART 0.
-   If you use a development kit, UART 0 is forwarded as a COM port (Windows) or ttyACM device (Linux) after you connect the development kit over USB.
-   If you use Thingy:53, you must attach the debug board and connect an external USB to UART converter to it.
-#. |connect_terminal|
-#. Optionally, you can display debug messages. See :ref:`peripheral_uart_debug` for details.
-#. Reset the kit.
-#. Observe that **LED 1** is blinking and that the device is advertising with the device name that is configured in :kconfig:option:`CONFIG_BT_DEVICE_NAME`.
-#. Observe that the text "Starting Nordic UART service example" is printed on the COM listener running on the computer.
-#. Connect to the device using nRF Connect for Mobile.
-   Observe that **LED 2** is lit.
-#. Optionally, pair or bond with the device with MITM protection.
-   This requires using the passkey value displayed in debug messages.
-   See :ref:`peripheral_uart_debug` for details on how to access debug messages.
-   To confirm pairing or bonding, press **Button 1** on the device and accept the passkey value on the smartphone.
-#. In the application, observe that the services are shown in the connected device.
-#. Select the UART RX characteristic value in nRF Connect for Mobile.
-   You can write to the UART RX and get the text displayed on the COM listener.
-#. Type "0123456789" and tap :guilabel:`SEND`.
-   Verify that the text "0123456789" is displayed on the COM listener.
-#. To send data from the device to your phone or tablet, enter any text, for example, "Hello", and press Enter to see it on the COM listener.
-   Observe that a notification is sent to the peer.
-#. Disconnect the device in nRF Connect for Mobile.
-   Observe that **LED 2** turns off.
+.. tabs::
+
+   .. group-tab:: nRF21, nRF52 and nRF53 DKs
+
+      1. Connect the device to the computer to access UART 0.
+         If you use a development kit, UART 0 is forwarded as a COM port (Windows) or ttyACM device (Linux) after you connect the development kit over USB.
+         If you use Thingy:53, you must attach the debug board and connect an external USB to UART converter to it.
+      #. |connect_terminal|
+      #. Optionally, you can display debug messages. See :ref:`peripheral_uart_debug` for details.
+      #. Reset the kit.
+      #. Observe that **LED 1** is blinking and that the device is advertising with the device name that is configured in :kconfig:option:`CONFIG_BT_DEVICE_NAME`.
+      #. Observe that the text "Starting Nordic UART service example" is printed on the COM listener running on the computer.
+      #. Connect to the device using nRF Connect for Mobile.
+         Observe that **LED 2** is lit.
+      #. Optionally, pair or bond with the device with MITM protection.
+         This requires using the passkey value displayed in debug messages.
+         See :ref:`peripheral_uart_debug` for details on how to access debug messages.
+         To confirm pairing or bonding, press **Button 1** on the device and accept the passkey value on the smartphone.
+      #. In the application, observe that the services are shown in the connected device.
+      #. Select the UART RX characteristic value in nRF Connect for Mobile.
+         You can write to the UART RX and get the text displayed on the COM listener.
+      #. Type "0123456789" and tap :guilabel:`SEND`.
+         Verify that the text "0123456789" is displayed on the COM listener.
+      #. To send data from the device to your phone or tablet, enter any text, for example, "Hello", and press Enter to see it on the COM listener.
+         Observe that a notification is sent to the peer.
+      #. Disconnect the device in nRF Connect for Mobile.
+         Observe that **LED 2** turns off.
+
+   .. group-tab:: nRF54 DKs
+
+      1. Connect the device to the computer to access UART 0.
+         If you use a development kit, UART 0 is forwarded as a COM port (Windows) or ttyACM device (Linux) after you connect the development kit over USB.
+         If you use Thingy:53, you must attach the debug board and connect an external USB to UART converter to it.
+      #. |connect_terminal|
+      #. Optionally, you can display debug messages. See :ref:`peripheral_uart_debug` for details.
+      #. Reset the kit.
+      #. Observe that **LED 0** is blinking and that the device is advertising with the device name that is configured in :kconfig:option:`CONFIG_BT_DEVICE_NAME`.
+      #. Observe that the text "Starting Nordic UART service example" is printed on the COM listener running on the computer.
+      #. Connect to the device using nRF Connect for Mobile.
+         Observe that **LED 1** is lit.
+      #. Optionally, pair or bond with the device with MITM protection.
+         This requires using the passkey value displayed in debug messages.
+         See :ref:`peripheral_uart_debug` for details on how to access debug messages.
+         To confirm pairing or bonding, press **Button 0** on the device and accept the passkey value on the smartphone.
+      #. In the application, observe that the services are shown in the connected device.
+      #. Select the UART RX characteristic value in nRF Connect for Mobile.
+         You can write to the UART RX and get the text displayed on the COM listener.
+      #. Type "0123456789" and tap :guilabel:`SEND`.
+         Verify that the text "0123456789" is displayed on the COM listener.
+      #. To send data from the device to your phone or tablet, enter any text, for example, "Hello", and press Enter to see it on the COM listener.
+         Observe that a notification is sent to the peer.
+      #. Disconnect the device in nRF Connect for Mobile.
+         Observe that **LED 1** turns off.
 
 Dependencies
 ************

--- a/samples/bluetooth/throughput/README.rst
+++ b/samples/bluetooth/throughput/README.rst
@@ -93,11 +93,23 @@ You can adjust the following parameters:
 User interface
 **************
 
-Button 1:
-   Set the board into a central (tester) role.
+.. tabs::
 
-Button 2:
-   Set the board into a peripheral (peer) role.
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      Button 1:
+         Set the board into a central (tester) role.
+
+      Button 2:
+         Set the board into a peripheral (peer) role.
+
+   .. group-tab:: nRF54 DKs
+
+      Button 0:
+         Set the board into a central (tester) role.
+
+      Button 1:
+         Set the board into a peripheral (peer) role.
 
 Building and running
 ********************
@@ -110,25 +122,51 @@ Testing
 
 After programming the sample to both kits, complete following steps to test it:
 
-1. |connect_terminal_both_ANSI|
-#. Reset both kits.
-#. Press **Button 1** on the first development kit or type ``central`` in the terminal connected to the first kit to set it into the central (tester) role.
-#. Press **Button 2** on the second development kit or type ``peripheral`` in the terminal connected to the second kit to set it into the peripheral (peer) role.
-#. Observe that the kits establish a connection.
-   The tester outputs the following information::
+.. tabs::
 
-      Type 'config' to change the configuration parameters.
-      You can use the Tab key to autocomplete your input.
-      Type 'run' when you are ready to run the test.
+   .. group-tab:: nRF52 and nRF53 DKs
 
-#. Type ``config print`` in the terminal to print the current configuration.
-   Type ``config`` in the terminal to configure the test parameters to your choice.
-   Use the Tab key for auto-completion and to view the options available for a parameter.
-#. Type ``run`` in the terminal to start the test.
-#. Observe the output while the tester sends data to the peer.
-   At the end of the test, both tester and peer display the results of the test.
-#. Repeat the test after changing the parameters.
-   Observe how the throughput changes for different sets of parameters.
+      1. |connect_terminal_both_ANSI|
+      #. Reset both kits.
+      #. Press **Button 1** on the first development kit or type ``central`` in the terminal connected to the first kit to set it into the central (tester) role.
+      #. Press **Button 2** on the second development kit or type ``peripheral`` in the terminal connected to the second kit to set it into the peripheral (peer) role.
+      #. Observe that the kits establish a connection.
+         The tester outputs the following information::
+
+            Type 'config' to change the configuration parameters.
+            You can use the Tab key to autocomplete your input.
+            Type 'run' when you are ready to run the test.
+
+      #. Type ``config print`` in the terminal to print the current configuration.
+         Type ``config`` in the terminal to configure the test parameters to your choice.
+         Use the Tab key for auto-completion and to view the options available for a parameter.
+      #. Type ``run`` in the terminal to start the test.
+      #. Observe the output while the tester sends data to the peer.
+         At the end of the test, both tester and peer display the results of the test.
+      #. Repeat the test after changing the parameters.
+         Observe how the throughput changes for different sets of parameters.
+
+   .. group-tab:: nRF54 DKs
+
+      1. |connect_terminal_both_ANSI|
+      #. Reset both kits.
+      #. Press **Button 0** on the first development kit or type ``central`` in the terminal connected to the first kit to set it into the central (tester) role.
+      #. Press **Button 1** on the second development kit or type ``peripheral`` in the terminal connected to the second kit to set it into the peripheral (peer) role.
+      #. Observe that the kits establish a connection.
+         The tester outputs the following information::
+
+            Type 'config' to change the configuration parameters.
+            You can use the Tab key to autocomplete your input.
+            Type 'run' when you are ready to run the test.
+
+      #. Type ``config print`` in the terminal to print the current configuration.
+         Type ``config`` in the terminal to configure the test parameters to your choice.
+         Use the Tab key for auto-completion and to view the options available for a parameter.
+      #. Type ``run`` in the terminal to start the test.
+      #. Observe the output while the tester sends data to the peer.
+         At the end of the test, both tester and peer display the results of the test.
+      #. Repeat the test after changing the parameters.
+         Observe how the throughput changes for different sets of parameters.
 
 Sample output
 ==============

--- a/samples/esb/esb_prx/README.rst
+++ b/samples/esb/esb_prx/README.rst
@@ -33,9 +33,9 @@ If packets are successfully received from the Transmitter, the LED pattern chang
 User interface
 ***************
 
-LED 1-4:
+All LEDs:
    Indicate that packets are sent or received.
-   The first four packets turn on **LED 1**, **2**, **3**, and **4**.
+   The first four packets turn on the LEDs sequentially.
    The next four packets turn them off again in the same order.
 
 Configuration

--- a/samples/esb/esb_ptx/README.rst
+++ b/samples/esb/esb_ptx/README.rst
@@ -33,9 +33,9 @@ Therefore, if packets are successfully received and acknowledged by the Receiver
 User interface
 ***************
 
-LED 1-4:
+All LEDs:
    Indicate that packets are sent or received.
-   The first four packets turn on LED 1, 2, 3, and 4.
+   The first four packets turn on the LEDs sequentially.
    The next four packets turn them off again in the same order.
 
 Configuration

--- a/samples/nfc/record_launch_app/README.rst
+++ b/samples/nfc/record_launch_app/README.rst
@@ -33,8 +33,17 @@ The only events handled by the application are the NFC events.
 User interface
 **************
 
-LED 1:
-   Indicates if an NFC field is present.
+.. tabs::
+
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      LED 1:
+         Indicates if an NFC field is present.
+
+   .. group-tab:: nRF54 DKs
+
+      LED 0:
+         Indicates if an NFC field is present.
 
 Building and running
 ********************
@@ -51,14 +60,25 @@ Testing
 
 After programming the sample to your development kit, complete the following steps to test it:
 
-1. Touch the NFC antenna with the smartphone or tablet and observe that **LED 1** is lit.
-#. Observe that the smartphone or tablet launches the `nRF Toolbox`_ application.
-#. Move the smartphone or tablet away from the NFC antenna and observe that **LED 1**
-   turns off.
+.. tabs::
 
-   .. note::
-      Devices running iOS require the nRF Toolbox app to be installed before testing the sample.
-      Devices running Android open Google Play when the application is not installed.
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      1. Touch the NFC antenna with the smartphone or tablet and observe that **LED 1** is lit.
+      #. Observe that the smartphone or tablet launches the `nRF Toolbox`_ application.
+      #. Move the smartphone or tablet away from the NFC antenna and observe that **LED 1**
+         turns off.
+
+   .. group-tab:: nRF54 DKs
+
+      1. Touch the NFC antenna with the smartphone or tablet and observe that **LED 0** is lit.
+      #. Observe that the smartphone or tablet launches the `nRF Toolbox`_ application.
+      #. Move the smartphone or tablet away from the NFC antenna and observe that **LED 0**
+         turns off.
+
+.. note::
+   Devices running iOS require the nRF Toolbox app to be installed before testing the sample.
+   Devices running Android open Google Play when the application is not installed.
 
 Dependencies
 ************

--- a/samples/nfc/record_text/README.rst
+++ b/samples/nfc/record_text/README.rst
@@ -32,8 +32,18 @@ The only events handled by the application are the NFC events.
 User interface
 **************
 
-LED 1:
-   Indicates if an NFC field is present.
+.. tabs::
+
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      LED 1:
+         Indicates if an NFC field is present.
+
+   .. group-tab:: nRF54 DKs
+
+      LED 0:
+         Indicates if an NFC field is present.
+
 
 Building and running
 ********************
@@ -50,9 +60,19 @@ Testing
 
 After programming the sample to your development kit, complete the following steps to test it:
 
-1. Touch the NFC antenna with the smartphone or tablet and observe that **LED 1** is lit.
-#. Observe that the smartphone or tablet displays the encoded text (in the most suitable language).
-#. Move the smartphone or tablet away from the NFC antenna and observe that **LED 1** turns off.
+.. tabs::
+
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      1. Touch the NFC antenna with the smartphone or tablet and observe that **LED 1** is lit.
+      #. Observe that the smartphone or tablet displays the encoded text (in the most suitable language).
+      #. Move the smartphone or tablet away from the NFC antenna and observe that **LED 1** turns off.
+
+   .. group-tab:: nRF54 DKs
+
+      1. Touch the NFC antenna with the smartphone or tablet and observe that **LED 0** is lit.
+      #. Observe that the smartphone or tablet displays the encoded text (in the most suitable language).
+      #. Move the smartphone or tablet away from the NFC antenna and observe that **LED 0** turns off.
 
 Dependencies
 ************

--- a/samples/nfc/shell/README.rst
+++ b/samples/nfc/shell/README.rst
@@ -29,21 +29,42 @@ Overview
 This sample presents one of possible ways to run shell through the NFC T4T transport layer.
 This is not a common use case for NFC as an NFC tag is a passive device.
 However, this feature can be useful, for example, for devices provisioning on the production line.
-This sample runs a shell over the NFC transport and implements two shell commands that control **LED 2**.
+This sample runs a shell over the NFC transport and implements two shell commands that control the LED.
 
 You can use the following commands:
 
-* The ``led on`` command lits **LED 2**.
-* The ``led off`` command dims **LED 2**.
+.. tabs::
+
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      * The ``led on`` command lits **LED 2**.
+      * The ``led off`` command dims **LED 2**.
+
+   .. group-tab:: nRF54 DKs
+
+      * The ``led on`` command lits **LED 1**.
+      * The ``led off`` command dims **LED 1**.
 
 User interface
 **************
 
-LED 1:
-   Blinks, toggling on/off every second, when the main loop is running.
+.. tabs::
 
-LED 2:
-   Lits or dims when user issues the shell commands that control the LED.
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      LED 1:
+         Blinks, toggling on/off every second, when the main loop is running.
+
+      LED 2:
+         Lits or dims when user issues the shell commands that control the LED.
+
+   .. group-tab:: nRF54 DKs
+
+      LED 0:
+         Blinks, toggling on/off every second, when the main loop is running.
+
+      LED 1:
+         Lits or dims when user issues the shell commands that control the LED.
 
 Building and running
 ********************
@@ -60,17 +81,35 @@ Testing
 
 After programming the sample to your development kit, complete the following steps to test it:
 
-1. |connect_terminal_ANSI|
-#. Reset your development kit.
-#. Observe that the sample starts.
-#. Touch the NFC antenna with the polling device.
-#. Observe that the shell prompt appears on the terminal.
-#. Keep the NFC antenna in the polling device field range.
-#. Issue the ``led on`` command through the terminal.
-#. Observe that the **LED 2** lits.
-#. Issue the ``led off`` command through the terminal.
-#. Observe that the **LED 2** dims.
-#. You can play with other build-in shell commands.
+.. tabs::
+
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      1. |connect_terminal_ANSI|
+      #. Reset your development kit.
+      #. Observe that the sample starts.
+      #. Touch the NFC antenna with the polling device.
+      #. Observe that the shell prompt appears on the terminal.
+      #. Keep the NFC antenna in the polling device field range.
+      #. Issue the ``led on`` command through the terminal.
+      #. Observe that the **LED 2** lits.
+      #. Issue the ``led off`` command through the terminal.
+      #. Observe that the **LED 2** dims.
+      #. You can play with other build-in shell commands.
+
+   .. group-tab:: nRF54 DKs
+
+      1. |connect_terminal_ANSI|
+      #. Reset your development kit.
+      #. Observe that the sample starts.
+      #. Touch the NFC antenna with the polling device.
+      #. Observe that the shell prompt appears on the terminal.
+      #. Keep the NFC antenna in the polling device field range.
+      #. Issue the ``led on`` command through the terminal.
+      #. Observe that the **LED 1** lits.
+      #. Issue the ``led off`` command through the terminal.
+      #. Observe that the **LED 1** dims.
+      #. You can play with other build-in shell commands.
 
 Dependencies
 ************

--- a/samples/nfc/system_off/README.rst
+++ b/samples/nfc/system_off/README.rst
@@ -58,11 +58,23 @@ See the `System OFF mode`_ page in the nRF52840 Product Specification for more i
 User interface
 **************
 
-LED 1:
-   Lit when an NFC field is present within range.
+.. tabs::
 
-LED 2:
-   Lit when the system is on.
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      LED 1:
+         Lit when an NFC field is present within range.
+
+      LED 2:
+         Lit when the system is on.
+
+   .. group-tab:: nRF54 DKs
+
+      LED 0:
+         Lit when an NFC field is present within range.
+
+      LED 1:
+         Lit when the system is on.
 
 Building and running
 ********************
@@ -79,18 +91,37 @@ Testing
 
 After programming the sample to your development kit, complete the following steps to test it:
 
-1. Observe that **LED 2** on the Tag device turns off three seconds after the programming has completed.
-   This indicates that the system is in the System OFF mode.
-#. Make sure that the NFC feature is activated on the smartphone or tablet.
-   Check the device documentation on how to enable the NFC feature.
-#. With the smartphone or tablet, touch the NFC antenna of the NFC Tag device.
-#. Observe that **LED 2** on the Tag device is lit, followed by **LED 1** shortly after that.
-   Also a "Hello World!" notification appears on the smartphone or tablet.
-   The notification text is obtained from NFC.
-#. Move the smartphone or tablet away from the NFC antenna.
-   **LED 1** turns off.
-#. Observe that **LED 2** on the Tag device turns off after three seconds.
-   This indicates that system is in the System OFF mode again.
+.. tabs::
+
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      1. Observe that **LED 2** on the Tag device turns off three seconds after the programming has completed.
+         This indicates that the system is in the System OFF mode.
+      #. Make sure that the NFC feature is activated on the smartphone or tablet.
+         Check the device documentation on how to enable the NFC feature.
+      #. With the smartphone or tablet, touch the NFC antenna of the NFC Tag device.
+      #. Observe that **LED 2** on the Tag device is lit, followed by **LED 1** shortly after that.
+         Also a "Hello World!" notification appears on the smartphone or tablet.
+         The notification text is obtained from NFC.
+      #. Move the smartphone or tablet away from the NFC antenna.
+         **LED 1** turns off.
+      #. Observe that **LED 2** on the Tag device turns off after three seconds.
+         This indicates that system is in the System OFF mode again.
+
+   .. group-tab:: nRF54 DKs
+
+      1. Observe that **LED 1** on the Tag device turns off three seconds after the programming has completed.
+         This indicates that the system is in the System OFF mode.
+      #. Make sure that the NFC feature is activated on the smartphone or tablet.
+         Check the device documentation on how to enable the NFC feature.
+      #. With the smartphone or tablet, touch the NFC antenna of the NFC Tag device.
+      #. Observe that **LED 1** on the Tag device is lit, followed by **LED 0** shortly after that.
+         Also a "Hello World!" notification appears on the smartphone or tablet.
+         The notification text is obtained from NFC.
+      #. Move the smartphone or tablet away from the NFC antenna.
+         **LED 0** turns off.
+      #. Observe that **LED 1** on the Tag device turns off after three seconds.
+         This indicates that system is in the System OFF mode again.
 
 Dependencies
 ************

--- a/samples/nfc/tnep_tag/README.rst
+++ b/samples/nfc/tnep_tag/README.rst
@@ -33,17 +33,35 @@ The sample has two TNEP services defined, each of them containing the NDEF text 
 User interface
 **************
 
-LED 1:
-   Lit when the TNEP Tag is initialized.
+.. tabs::
 
-LED 3:
-   Lit when the TNEP service one is selected.
+   .. group-tab:: nRF52 and nRF53 DKs
 
-LED 4:
-   Lit when the TNEP service two is selected.
+      LED 1:
+         Lit when the TNEP Tag is initialized.
 
-Button 1:
-   Press to provide the application data when the application service two is selected.
+      LED 3:
+         Lit when the TNEP service one is selected.
+
+      LED 4:
+         Lit when the TNEP service two is selected.
+
+      Button 1:
+         Press to provide the application data when the application service two is selected.
+
+   .. group-tab:: nRF54 DKs
+
+      LED 0:
+         Lit when the TNEP Tag is initialized.
+
+      LED 2:
+         Lit when the TNEP service one is selected.
+
+      LED 3:
+         Lit when the TNEP service two is selected.
+
+      Button 0:
+         Press to provide the application data when the application service two is selected.
 
 Building and running
 ********************
@@ -61,12 +79,25 @@ Testing
 After programming the sample to your development kit, you can test it with an NFC-A polling device that supports NFC's Tag NDEF Exchange Protocol.
 Complete the following steps:
 
-1. |connect_terminal|
-#. Reset the development kit.
-#. Touch the NFC antenna with the NFC polling device.
-#. Observe the output in the terminal.
-#. If the NFC polling device selects the service two, you have 27 seconds to press **Button 1** to provide application data.
-   If you do not do this, the NFC polling device deselects the service.
+.. tabs::
+
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      1. |connect_terminal|
+      #. Reset the development kit.
+      #. Touch the NFC antenna with the NFC polling device.
+      #. Observe the output in the terminal.
+      #. If the NFC polling device selects the service two, you have 27 seconds to press **Button 1** to provide application data.
+         If you do not do this, the NFC polling device deselects the service.
+
+   .. group-tab:: nRF54 DKs
+
+      1. |connect_terminal|
+      #. Reset the development kit.
+      #. Touch the NFC antenna with the NFC polling device.
+      #. Observe the output in the terminal.
+      #. If the NFC polling device selects the service two, you have 27 seconds to press **Button 0** to provide application data.
+         If you do not do this, the NFC polling device deselects the service.
 
 Dependencies
 ************

--- a/samples/nfc/writable_ndef_msg/README.rst
+++ b/samples/nfc/writable_ndef_msg/README.rst
@@ -36,15 +36,31 @@ Any changes to the NDEF message update the NDEF message file stored in flash mem
 User interface
 **************
 
-LED 1:
-   Indicates if an NFC field is present.
-LED 2:
-   Indicates that the NDEF message was updated.
-LED 4:
-   Indicates that the NDEF message was read.
+.. tabs::
 
-Button 1:
-   Press during startup to restore the default NDEF message.
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      LED 1:
+         Indicates if an NFC field is present.
+      LED 2:
+         Indicates that the NDEF message was updated.
+      LED 4:
+         Indicates that the NDEF message was read.
+
+      Button 1:
+         Press during startup to restore the default NDEF message.
+
+   .. group-tab:: nRF54 DKs
+
+      LED 0:
+         Indicates if an NFC field is present.
+      LED 1:
+         Indicates that the NDEF message was updated.
+      LED 3:
+         Indicates that the NDEF message was read.
+
+      Button 0:
+         Press during startup to restore the default NDEF message.
 
 Building and running
 ********************
@@ -60,11 +76,23 @@ Testing
 
 After programming the sample to your development kit, complete the following steps to test it:
 
-1. Touch the NFC antenna with the smartphone or tablet and observe that **LED 1** and **LED 4** are lit.
-#. Observe that the smartphone or tablet tries to open the URL "http\://www.nordicsemi.com" in a web browser.
-#. Use a proper application (for example, NFC Tools for Android) to overwrite the existing NDEF message with your own message.
-#. Restart your development kit and touch the antenna again.
-   Observe that the new message is displayed.
+.. tabs::
+
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      1. Touch the NFC antenna with the smartphone or tablet and observe that **LED 1** and **LED 4** are lit.
+      #. Observe that the smartphone or tablet tries to open the URL "http\://www.nordicsemi.com" in a web browser.
+      #. Use a proper application (for example, NFC Tools for Android) to overwrite the existing NDEF message with your own message.
+      #. Restart your development kit and touch the antenna again.
+         Observe that the new message is displayed.
+
+   .. group-tab:: nRF54 DKs
+
+      1. Touch the NFC antenna with the smartphone or tablet and observe that **LED 0** and **LED 3** are lit.
+      #. Observe that the smartphone or tablet tries to open the URL "http\://www.nordicsemi.com" in a web browser.
+      #. Use a proper application (for example, NFC Tools for Android) to overwrite the existing NDEF message with your own message.
+      #. Restart your development kit and touch the antenna again.
+         Observe that the new message is displayed.
 
 Dependencies
 ************

--- a/samples/peripheral/802154_phy_test/README.rst
+++ b/samples/peripheral/802154_phy_test/README.rst
@@ -944,7 +944,7 @@ After programming the sample to your development kit, complete the following ste
       custom changemode *1*
 
 #. On the bottom side of your development kit, locate the table describing the GPIO pin assignment to the LEDs.
-#. Read the numbers of the GPIO pins assigned to LED 1, 2, 3 or 4.
+#. Read the numbers of the GPIO pins assigned to all LEDs.
 
    For example, on the nRF52840DK, the LEDs are controlled by the pins ranging between P0.13 and P0.16.
    The LEDs on nRF5340DK and nRF52840DK are in the ``sink`` configuration.

--- a/samples/suit/smp_transfer/README.rst
+++ b/samples/suit/smp_transfer/README.rst
@@ -51,7 +51,7 @@ Additionally, this sample is an early version and is only meant to showcase the 
 User interface
 **************
 
-LED 1:
+LED 0:
     The number of blinks indicates the application SUIT envelope sequence number.
     The default is set to ``1`` to blink once, indicating "Version 1".
 
@@ -62,7 +62,7 @@ Configuration
 
 The default configuration uses UART with sequence number 1 (shown as Version 1 in the nRF Device Manager app).
 To change the sequence number of the application, configure the ``SB_CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM`` Sysbuild Kconfig option.
-This also changes the number of blinks on **LED 1** and sets the :ref:`sequence number <ug_suit_dfu_suit_manifest_elements>` of the :ref:`SUIT envelope <ug_suit_dfu_suit_concepts>`’s manifest.
+This also changes the number of blinks on **LED 0** and sets the :ref:`sequence number <ug_suit_dfu_suit_manifest_elements>` of the :ref:`SUIT envelope <ug_suit_dfu_suit_concepts>`’s manifest.
 
 To use this configuration, build the sample with :ref:`configuration_system_overview_sysbuild` and set the ``SB_CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM`` Sysbuild Kconfig option to ``x``, where ``x`` is the version number.
 For example:
@@ -311,7 +311,7 @@ After programming the sample to your development kit and updating the sequence n
 
          You should see that "Version: 2" is now printed in the **Images** section of the mobile app.
 
-         Additional, **LED 1** now flashes twice now to indicate "Version 2" of the firmware.
+         Additional, **LED 0** now flashes twice now to indicate "Version 2" of the firmware.
 
    .. group-tab:: Over UART
 
@@ -374,4 +374,4 @@ After programming the sample to your development kit and updating the sequence n
                hash: 707efbd3e3dfcbda1c0ce72f069a55f35c30836b79ab8132556ed92ce609f943
             Split status: N/A (0)
 
-         You should now see that **LED 1** flashes twice now to indicate "Version 2" of the firmware.
+         You should now see that **LED 0** flashes twice now to indicate "Version 2" of the firmware.


### PR DESCRIPTION
This PR aligns LEDs and buttons numbering in the documentation with the new PDK and DKs numbering for nRF54.
The changes are applied to all supported samples (based on sample.yaml).
The PR follows the agreed approach ([NCSDK-27726](https://nordicsemi.atlassian.net/browse/NCSDK-27726), [NCSDK-27724](https://nordicsemi.atlassian.net/browse/NCSDK-27724)).
For nRF54 devices a separate tab is introduced.

Please double-check the samples you're working on as it's possible I might've missed something or that there is a render issue.


[NCSDK-27726]: https://nordicsemi.atlassian.net/browse/NCSDK-27726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NCSDK-27724]: https://nordicsemi.atlassian.net/browse/NCSDK-27724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ