### PR TITLE
boards: thingy91x: resolve build warnings

### DIFF
--- a/boards/nordic/thingy91x/CMakeLists.txt
+++ b/boards/nordic/thingy91x/CMakeLists.txt
@@ -3,9 +3,11 @@
 # Copyright (c) 2024 Nordic Semiconductor
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 
-if(CONFIG_BOARD_THINGY91X_NRF9151 OR CONFIG_BOARD_THINGY91X_NRF9151_NS)
-  zephyr_library()
-  zephyr_library_sources_ifdef(CONFIG_WIFI_NRF700X nrf70_support.c)
+if(CONFIG_WIFI_NRF700X)
+  if(CONFIG_BOARD_THINGY91X_NRF9151 OR CONFIG_BOARD_THINGY91X_NRF9151_NS)
+    zephyr_library()
+    zephyr_library_sources(nrf70_support.c)
+  endif()
 endif()
 
 if(CONFIG_BOARD_THINGY91X_NRF9151_NS)
@@ -16,7 +18,9 @@ if(CONFIG_BOARD_THINGY91X_NRF9151_NS)
 endif()
 
 if(CONFIG_BOARD_THINGY91X_NRF5340_CPUAPP OR CONFIG_BOARD_THINGY91X_NRF5340_CPUAPP_NS)
-  zephyr_library()
-  zephyr_library_sources_ifdef(CONFIG_BOARD_ENABLE_CPUNET nrf5340_cpunet_reset.c)
+  if(CONFIG_BOARD_ENABLE_CPUNET)
+    zephyr_library()
+    zephyr_library_sources(nrf5340_cpunet_reset.c)
+  endif()
   set(PM_STATIC_YML_FILE ${CMAKE_CURRENT_LIST_DIR}/thingy91x_nrf5340_pm_static.yml CACHE INTERNAL "")
 endif()


### PR DESCRIPTION
This patch resolves warnings about empty libraries from the thingy91x board files.