### PR TITLE
manifest: Update zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: c0e08266a73496e70a6b44331b79e03bc55507b6
+      revision: pull/1776/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Upgrade twister to work with nrf54h and nrf54l (always use sysbuild)