### PR TITLE
samples: cellular: modem_shell: Show errno on setsockopt error

### DIFF
--- a/samples/cellular/modem_shell/src/utils/net_utils.c
+++ b/samples/cellular/modem_shell/src/utils/net_utils.c
@@ -17,13 +17,10 @@
 
 int net_utils_socket_pdn_id_set(int fd, uint32_t pdn_id)
 {
-	int ret;
+	int err = setsockopt(fd, SOL_SOCKET, SO_BINDTOPDN, &pdn_id, sizeof(pdn_id));
 
-	ret = setsockopt(fd, SOL_SOCKET, SO_BINDTOPDN, &pdn_id, sizeof(pdn_id));
-	if (ret < 0) {
-		mosh_error(
-			"Failed to bind socket with PDN ID %d, error: %d, %s",
-			pdn_id, ret, strerror(ret));
+	if (err) {
+		mosh_error("Failed to bind socket with PDN ID %d, errno %d", pdn_id, errno);
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
When setsockopt() fails to bind socket with PDN ID it return -1. Change the error message to show errno.