### PR TITLE
doc: build: conf_file and dtc_overlay_file edits

### DIFF
--- a/doc/nrf/config_and_build/config_and_build_system.rst
+++ b/doc/nrf/config_and_build/config_and_build_system.rst
@@ -101,7 +101,10 @@ The :file:`zephyr.dts` file contains the entire hardware-related configuration o
 The header file contains the same kind of information, but with defines usable by source code.
 
 For more information, see :ref:`configuring_devicetree` and Zephyr's :ref:`zephyr:dt-guide`.
-In particular, :ref:`zephyr:set-devicetree-overlays` explains how to use devicetree and its overlays to customize an application's devicetree.
+In particular, :ref:`zephyr:set-devicetree-overlays` explains how the base devicetree files are selected.
+
+In the |NCS|, you can use the |nRFVSC| to `create the devicetree files <How to create devicetree files_>`_ and work with them using the dedicated `Devicetree Visual Editor <How to work with Devicetree Visual Editor_>`_.
+You can also select the devicetree files when :ref:`cmake_options`.
 
 .. _configure_application_sw:
 
@@ -119,7 +122,12 @@ Information from devicetree is available to Kconfig, through the functions defin
 The :file:`.config` file in the :file:`<build_dir>/zephyr/` directory describes most of the software configuration of the constructed binary.
 Some subsystems can use their own configuration files.
 
-For more information, see :ref:`configure_application` and Zephyr's :ref:`zephyr:application-kconfig`.
+For more information, see Zephyr's :ref:`zephyr:application-kconfig`.
+In particular, :ref:`zephyr:initial-conf` explains how the base configuration files are selected.
+
+In the |NCS|, just as in Zephyr, you can :ref:`configure Kconfig temporarily or permanently <configuring_kconfig>`.
+You can also select the Kconfig options and files when :ref:`cmake_options`.
+
 The :ref:`Kconfig Reference <configuration_options>` provides the documentation for each configuration option in the |NCS|.
 
 Memory layout configuration
@@ -221,7 +229,7 @@ The |NCS| supports Zephyr's System Build (Sysbuild).
    :start-after: #######################
    :end-before: Definitions
 
-To distinguish CMake variables and Kconfig options specific to the underlying build systems, sysbuild uses namespacing.
+To distinguish CMake variables and Kconfig options specific to the underlying build systems, :ref:`sysbuild uses namespacing <zephyr:sysbuild_kconfig_namespacing>`.
 For example, sysbuild-specific Kconfig options are preceded by `SB_` before `CONFIG` and application-specific CMake options are preceded by the application name.
 
 Sysbuild is integrated with west.

--- a/doc/nrf/config_and_build/configuring_app/cmake/index.rst
+++ b/doc/nrf/config_and_build/configuring_app/cmake/index.rst
@@ -57,20 +57,33 @@ The |NCS| uses the same CMake build variables as Zephyr and they are compatible 
 For the complete list of build variables in Zephyr and more information about them, see :ref:`zephyr:important-build-vars` in the Zephyr documentation.
 The following table lists the most common ones used in the |NCS|:
 
-.. list-table:: Build system variables in the |NCS|
+.. list-table:: Common build system variables in the |NCS|
    :header-rows: 1
 
    * - Variable
      - Purpose
      - CMake argument to use
    * - Name of the Kconfig option
-     - Set the given Kconfig option to a specific value :ref:`for a single build <configuration_temporary_change_single_build>`.
+     - | Set the given Kconfig option to a specific value :ref:`for a single build <configuration_temporary_change_single_build>`.
+       | The Kconfig option name can be subject to :ref:`variable namespacing <zephyr:sysbuild_kconfig_namespacing>` and :ref:`sysbuild Kconfig namespacing <zephyr:sysbuild_kconfig_namespacing>`.
      - ``-D<name_of_Kconfig_option>=<value>``
+   * - :makevar:`CONF_FILE`
+     - | Select the base Kconfig configuration file to be used for your application and override the :ref:`autoselection process <zephyr:initial-conf>`.
+       | This variable has also been used to select one of the available :ref:`build types <modifying_build_types>`, if the application or sample supports any.
+       | Using this variable for build type selection is deprecated and is being gradually replaced by :makevar:`FILE_SUFFIX`, but :ref:`still required for some applications <modifying_build_types>`.
+     - | ``-DCONF_FILE=<file_name>.conf``
+       | ``-DCONF_FILE=prj_<build_type_name>.conf``
+   * - :makevar:`SB_CONF_FILE`
+     - Select the base :ref:`sysbuild <configuration_system_overview_sysbuild>` Kconfig configuration file to be used for your application and override the :ref:`autoselection process <zephyr:initial-conf>`.
+     - ``-DSB_CONF_FILE=<file_name>.conf``
    * - :makevar:`EXTRA_CONF_FILE`
-     - Provide additional :ref:`Kconfig fragment files <configuration_permanent_change>`.
+     - Provide additional :ref:`Kconfig fragment files <configuration_permanent_change>` to be "mixed in" with the base configuration file.
      - ``-DEXTRA_CONF_FILE=<file_name>.conf``
+   * - :makevar:`DTC_OVERLAY_FILE`
+     - Select the base :ref:`devicetree overlay files <configuring_devicetree>` to be used for your application and override the :ref:`autoselection process <zephyr:set-devicetree-overlays>`.
+     - ``-DDTC_OVERLAY_FILE=<file_name>.overlay``
    * - :makevar:`EXTRA_DTC_OVERLAY_FILE`
-     - Provide additional, custom :ref:`devicetree overlay files <configuring_devicetree>`.
+     - Provide additional, custom :ref:`devicetree overlay files <configuring_devicetree>` to be "mixed in" with the base devicetree overlay file.
      - ``-DEXTRA_DTC_OVERLAY_FILE=<file_name>.overlay``
    * - :makevar:`SHIELD`
      - Select one of the supported :ref:`shields <shield_names_nrf>` for building the firmware.
@@ -78,12 +91,8 @@ The following table lists the most common ones used in the |NCS|:
    * - :makevar:`FILE_SUFFIX`
      - | Select one of the available :ref:`suffixed configurations <zephyr:application-file-suffixes>`, if the application or sample supports any.
        | See :ref:`app_build_file_suffixes` for more information about their usage and limitations in the |NCS|.
-       | This variable is gradually replacing :makevar:`CONF_FILE`.
+       | This variable is gradually replacing :makevar:`CONF_FILE` for selecting build types.
      - ``-DFILE_SUFFIX=<configuration_suffix>`` (``-D<image_name>_FILE_SUFFIX`` for images)
-   * - :makevar:`CONF_FILE`
-     - | Select one of the available :ref:`build types <modifying_build_types>`, if the application or sample supports any.
-       | This variable is deprecated and is being gradually replaced by :makevar:`FILE_SUFFIX`, but :ref:`still required for some applications <modifying_build_types>`.
-     - ``-DCONF_FILE=prj_<build_type_name>.conf``
    * - ``-S`` (west) or :makevar:`SNIPPET` (CMake)
      - Select one of the :ref:`zephyr:snippets` to add to the application firmware during the build.
      - | ``-S <name_of_snippet>`` (applies the snippet to all images)

--- a/doc/nrf/config_and_build/configuring_app/hardware/index.rst
+++ b/doc/nrf/config_and_build/configuring_app/hardware/index.rst
@@ -17,6 +17,7 @@ To select them manually, see :ref:`cmake_options`.
 
 The following guides provide information about configuring specific aspects of hardware support related to devicetree.
 Read them together with Zephyr's :ref:`zephyr:hardware_support` and :ref:`zephyr:dt-guide` guides, and the official `Devicetree Specification`_.
+In particular, :ref:`zephyr:set-devicetree-overlays` explains how the base devicetree files are selected.
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Aligned information about conf_file and dtc_overlay_file usage in the NCS with documentation in Zephyr.
Added cross-links.
VSC-2598.

----

- [x] Mention SB_CONF_FILE