### PR TITLE
samples: matter: fix the pm static for nRF54L15 in window covering

### DIFF
--- a/samples/matter/window_covering/pm_static_nrf54l15pdk_nrf54l15_cpuapp.yml
+++ b/samples/matter/window_covering/pm_static_nrf54l15pdk_nrf54l15_cpuapp.yml
@@ -11,6 +11,10 @@ app:
   region: flash_primary
   size: 0x167800
 mcuboot_primary:
+  orig_span: &id001
+  - mcuboot_pad
+  - app
+  span: *id001
   address: 0xc000
   region: flash_primary
   size: 0x168000

--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -5,7 +5,7 @@
 
 
 - scenarios:
-    - sample.matter.light_bulb.memory_profiling
+    - sample.matter.light_bulb.memory_profiling.persistent_subscriptions
   platforms:
     - nrf7002dk/nrf5340/cpuapp
   comment: "https://nordicsemi.atlassian.net/browse/KRKNWK-19027"

--- a/scripts/quarantine_windows_mac.yaml
+++ b/scripts/quarantine_windows_mac.yaml
@@ -31,9 +31,3 @@
   platforms:
     - nrf9160dk/nrf9160/ns
   comment: "https://nordicsemi.atlassian.net/browse/NCSDK-26461"
-
-- scenarios:
-    - sample.matter.light_bulb.memory_profiling
-  platforms:
-    - nrf7002dk/nrf5340/cpuapp
-  comment: "https://nordicsemi.atlassian.net/browse/KRKNWK-19027"


### PR DESCRIPTION
 * Fix nRF54L15 pm_static in window covering matter samples
 * Add matter specifc sample to quarantine due to memory overflow