### PR TITLE
lib: lte_link_control: Fix null pointer access

### DIFF
--- a/lib/lte_link_control/lte_lc_helpers.c
+++ b/lib/lte_link_control/lte_lc_helpers.c
@@ -823,8 +823,8 @@ int parse_cereg(const char *at_response,
 	}
 
 	/* Check PSM parameters only if we are connected */
-	if ((*reg_status != LTE_LC_NW_REG_REGISTERED_HOME) &&
-	    (*reg_status != LTE_LC_NW_REG_REGISTERED_ROAMING)) {
+	if ((status != LTE_LC_NW_REG_REGISTERED_HOME) &&
+	    (status != LTE_LC_NW_REG_REGISTERED_ROAMING)) {
 		goto clean_exit;
 	}
 

--- a/tests/lib/lte_lc/src/main.c
+++ b/tests/lib/lte_lc/src/main.c
@@ -96,6 +96,10 @@ void test_parse_cereg(void)
 	char *at_notif_90 = "+CEREG: 90,,\"FFFFFFFF\",,,,,";
 	char *at_notif_wrong = "+CEREG: 10,,\"FFFFFFFF\",,,,,";
 
+	/* Pass NULL parameter to reg_status param and expect the API to succeed. */
+	err = parse_cereg(at_response_0, false, NULL, NULL, NULL, NULL);
+	TEST_ASSERT_EQUAL(0, err);
+
 	/* For CEREG reads, we only check the network status, as that's the only
 	 * functionality that is exposed.
 	 */


### PR DESCRIPTION
The reg_status param is allowed to be set to NULL by the call. So we should not derefence it without a NULL check. This patch uses the status variable instead of dereferencing the reg_status parameter.

Added unit test to cover this scenario. The unit test fails with a segmentation fault without this fix.

Found as violation of CWE-476 by SonarCloud.
https://sonarcloud.io/project/issues?open=AY8xkfuQ-1NVyxUQu2Ht&id=balaji-nordic_sdk-nrf 