### PR TITLE
Samples: Bluetooth: Mesh: fix common mesh adv data

### DIFF
--- a/samples/bluetooth/mesh/common/smp_bt.c
+++ b/samples/bluetooth/mesh/common/smp_bt.c
@@ -34,12 +34,12 @@ static struct bt_le_adv_param adv_params = {
 
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
+	BT_DATA_BYTES(BT_DATA_UUID128_ALL, 0x84, 0xaa, 0x60, 0x74, 0x52, 0x8a, 0x8b, 0x86, 0xd3,
+		      0x4c, 0xb7, 0x1d, 0x1d, 0xdc, 0x53, 0x8d),
 	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
 };
 
 static const struct bt_data sd[] = {
-	BT_DATA_BYTES(BT_DATA_UUID128_ALL, 0x84, 0xaa, 0x60, 0x74, 0x52, 0x8a, 0x8b, 0x86, 0xd3,
-		      0x4c, 0xb7, 0x1d, 0x1d, 0xdc, 0x53, 0x8d),
 	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
 };
 


### PR DESCRIPTION
SMP service UUID must be presented in adv data.