### PR TITLE
doc: Matter: new button and LED numbering

### DIFF
--- a/applications/matter_bridge/doc/matter_bridge_description.rst
+++ b/applications/matter_bridge/doc/matter_bridge_description.rst
@@ -125,7 +125,7 @@ Remote testing in a network
 By default, the Matter accessory device has no IPv6 network configured.
 To use the device within a Wi-Fi network, you must pair it with the Matter controller over Bluetooth® LE to get the configuration from the controller.
 
-The Bluetooth LE advertising starts automatically upon device startup, but only for a predefined period of time (15 minutes by default).
+The Bluetooth LE advertising starts automatically upon device startup, but only for a predefined period of time (1 hour by default).
 If the Bluetooth LE advertising times out, you can re-enable it manually by pressing **Button (SW1)**.
 
 Additionally, the controller must get the `Onboarding information`_ from the Matter accessory device and provision the device into the network.
@@ -134,30 +134,11 @@ For details, see the `Testing`_ section.
 User interface
 **************
 
-.. include:: ../../../samples/matter/lock/README.rst
-    :start-after: matter_door_lock_sample_led1_start
-    :end-before: matter_door_lock_sample_led1_end
-
 Button 1:
-    Depending on how long you press the button:
+   .. include:: /includes/matter_sample_button.txt
 
-    * If pressed for less than three seconds:
-
-      * If the device is not provisioned to the Matter network, it initiates the SMP server (Simple Management Protocol) and Bluetooth LE advertising for Matter commissioning.
-        After that, the Device Firmware Update (DFU) over Bluetooth Low Energy can be started.
-        (See `Updating the device firmware`_.)
-        Bluetooth LE advertising makes the device discoverable over Bluetooth LE for the predefined period of time (15 minutes by default).
-
-      * If the device is already provisioned to the Matter network it re-enables the SMP server.
-        After that, the DFU over Bluetooth Low Energy can be started.
-        (See `Updating the device firmware`_.)
-
-    * If pressed for more than three seconds, it initiates the factory reset of the device.
-      Releasing the button within a 3-second window of the initiation cancels the factory reset procedure.
-
-.. include:: ../../../samples/matter/lock/README.rst
-    :start-after: matter_door_lock_sample_led1_start
-    :end-before: matter_door_lock_sample_led1_end
+LED 1:
+   .. include:: /includes/matter_sample_state_led.txt
 
 LED 2:
    If the :ref:`CONFIG_BRIDGED_DEVICE_BT <CONFIG_BRIDGED_DEVICE_BT>` Kconfig option is set to ``y``, shows the current state of Bridge's Bluetooth LE connectivity.
@@ -169,9 +150,7 @@ LED 2:
    * Even Flashing (300 ms on / 300 ms off) - The scan for Bluetooth LE devices is in progress.
    * Fast Even Flashing (100 ms on / 100 ms off) - The Bridge device is connecting to the Bluetooth LE device and waiting for the Bluetooth LE authentication PIN code.
 
-.. include:: ../../../samples/matter/lock/README.rst
-    :start-after: matter_door_lock_sample_jlink_start
-    :end-before: matter_door_lock_sample_jlink_end
+.. include:: /includes/matter_segger_usb.txt
 
 .. _matter_bridge_cli:
 
@@ -968,8 +947,8 @@ For this application, you can use one of the following :ref:`onboarding informat
 
 .. _matter_bridge_app_dfu:
 
-Updating the device firmware
-============================
+Upgrading the device firmware
+=============================
 
 To update the device firmware, complete the steps listed for the selected method in the :doc:`matter:nrfconnect_examples_software_update` tutorial in the Matter documentation.
 

--- a/doc/nrf/includes/matter_sample_button.txt
+++ b/doc/nrf/includes/matter_sample_button.txt
@@ -1,0 +1,15 @@
+Depending on how long you press the button:
+
+* If pressed for less than three seconds:
+
+  * If the device is not provisioned to the Matter network, it initiates the SMP server (Simple Management Protocol) and Bluetooth LE advertising for Matter commissioning.
+    After that, the Device Firmware Update (DFU) over Bluetooth Low Energy can be started.
+    (See `Upgrading the device firmware`_.)
+    Bluetooth LE advertising makes the device discoverable over Bluetooth LE for the predefined period of time (1 hour by default).
+
+  * If the device is already provisioned to the Matter network, it re-enables the SMP server.
+    After that, the DFU over Bluetooth Low Energy can be started.
+    (See `Upgrading the device firmware`_.)
+
+* If pressed for more than three seconds, it initiates the factory reset of the device.
+  Releasing the button within a 3-second window of the initiation cancels the factory reset procedure.

--- a/doc/nrf/includes/matter_sample_state_led.txt
+++ b/doc/nrf/includes/matter_sample_state_led.txt
@@ -1,0 +1,6 @@
+Shows the overall state of the device and its connectivity.
+The following states are possible:
+
+* Short Flash On (50 ms on/950 ms off) - The device is in the unprovisioned (unpaired) state and is waiting for a commissioning application to connect.
+* Rapid Even Flashing (100 ms on/100 ms off) - The device is in the unprovisioned state and a commissioning application is connected over Bluetooth LE.
+* Solid On - The device is fully provisioned.

--- a/doc/nrf/includes/matter_segger_usb.txt
+++ b/doc/nrf/includes/matter_segger_usb.txt
@@ -1,0 +1,2 @@
+SEGGER J-Link USB Port:
+   Used for getting logs from the device or for communicating with it through the command-line interface.

--- a/doc/nrf/protocols/matter/getting_started/adding_clusters.rst
+++ b/doc/nrf/protocols/matter/getting_started/adding_clusters.rst
@@ -349,10 +349,19 @@ Testing the new sensor application
 
 To check if the sensor device is working, complete the following steps:
 
-.. include:: ../../../../../samples/matter/template/README.rst
-   :start-after: matter_template_sample_testing_start
-   :end-before: #. Keep the **Button 1**
+1. |connect_kit|
+#. |connect_terminal_ANSI|
+#. Commission the device into a Matter network by following the guides linked on the :ref:`ug_matter_configuring` page for the Matter controller you want to use.
+   The guides walk you through the following steps:
 
+   * Only if you are configuring Matter over Thread: Configure the Thread Border Router.
+   * Build and install the Matter controller.
+   * Commission the device.
+     You can use the :ref:`matter_template_network_mode_onboarding` listed earlier on this page.
+   * Send Matter commands.
+
+   At the end of this procedure, the LED indicating the state of the Matter device programmed with the sample starts flashing in the Short Flash Off state.
+   This indicates that the device is fully provisioned, but does not yet have full IPv6 network connectivity.
 #. Activate the sensor by running the following command on the On/off cluster with the correct *node_ID* assigned during commissioning:
 
    .. parsed-literal::

--- a/samples/matter/light_bulb/README.rst
+++ b/samples/matter/light_bulb/README.rst
@@ -49,7 +49,7 @@ The sample uses buttons to test changing the light bulb and device states, and L
 You can test it in the following ways:
 
 * Standalone, by using a single DK that runs the light bulb application.
-* Remotely over the Thread or Wi-Fi, which requires more devices.
+* Remotely over Thread or Wi-Fi, which requires more devices.
 
 The remote control testing requires a Matter controller that you can configure either on a PC or a mobile device (for remote testing in a network).
 You can enable both methods after :ref:`building and running the sample <matter_light_bulb_sample_remote_control>`.
@@ -196,34 +196,53 @@ To set up an AWS IoT instance and configure the sample, complete the following s
 User interface
 **************
 
-.. include:: ../template/README.rst
-   :start-after: matter_template_nrf54l15_0_3_0_interface_start
-   :end-before: matter_template_nrf54l15_0_3_0_interface_end
+.. tabs::
 
-.. include:: ../lock/README.rst
-    :start-after: matter_door_lock_sample_led1_start
-    :end-before: matter_door_lock_sample_led1_end
+   .. group-tab:: nRF52, nRF53 and nRF70 DKs
 
-LED 2:
-    Shows the state of the light bulb.
-    The following states are possible:
+      LED 1:
+         .. include:: /includes/matter_sample_state_led.txt
 
-    * Solid On - The light bulb is on.
-    * Off - The light bulb is off.
+      LED 2:
+         Shows the state of the light bulb.
+         The following states are possible:
 
-    Additionally, the LED starts blinking evenly (500 ms on/500 ms off) when the Identify command of the Identify cluster is received on the endpoint ``1``.
-    The command's argument can be used to specify the duration of the effect.
+         * Solid On - The light bulb is on.
+         * Off - The light bulb is off.
 
-.. include:: ../lock/README.rst
-    :start-after: matter_door_lock_sample_button1_start
-    :end-before: matter_door_lock_sample_button1_end
+         Additionally, the LED starts blinking evenly (500 ms on/500 ms off) when the Identify command of the Identify cluster is received on the endpoint ``1``.
+         The command's argument can be used to specify the duration of the effect.
 
-Button 2:
-    * Changes the light bulb state to the opposite one.
+      Button 1:
+         .. include:: /includes/matter_sample_button.txt
 
-.. include:: ../lock/README.rst
-    :start-after: matter_door_lock_sample_jlink_start
-    :end-before: matter_door_lock_sample_jlink_end
+      Button 2:
+         Changes the light bulb state to the opposite one.
+
+      .. include:: /includes/matter_segger_usb.txt
+
+   .. group-tab:: nRF54 DKs
+
+      LED 0:
+         .. include:: /includes/matter_sample_state_led.txt
+
+      LED 1:
+         Shows the state of the light bulb.
+         The following states are possible:
+
+         * Solid On - The light bulb is on.
+         * Off - The light bulb is off.
+
+         Additionally, the LED starts blinking evenly (500 ms on/500 ms off) when the Identify command of the Identify cluster is received on the endpoint ``1``.
+         The command's argument can be used to specify the duration of the effect.
+
+      Button 0:
+         .. include:: /includes/matter_sample_button.txt
+
+      Button 1:
+         Changes the light bulb state to the opposite one.
+
+      .. include:: /includes/matter_segger_usb.txt
 
 NFC port with antenna attached:
     Optionally used for obtaining the `Onboarding information`_ from the Matter accessory device to start the :ref:`commissioning procedure <matter_light_bulb_sample_remote_control_commissioning>`.
@@ -257,26 +276,57 @@ Testing basic features
 
 After building the sample and programming it to your development kit, complete the following steps to test its basic features:
 
-#. |connect_kit|
-#. |connect_terminal_ANSI|
-#. Observe that **LED 2** is off.
-#. Press **Button 2** on the light bulb device.
-   The **LED 2** turns on and the following messages appear on the console:
+.. tabs::
 
-   .. code-block:: console
+   .. group-tab:: nRF52, nRF53 and nRF70 DKs
 
-      I: Turn On Action has been initiated
-      I: Turn On Action has been completed
+      #. |connect_kit|
+      #. |connect_terminal_ANSI|
+      #. Observe that **LED 2** is off.
+      #. Press **Button 2** on the light bulb device.
+         The **LED 2** turns on and the following messages appear on the console:
 
-#. Press **Button 2** again.
-   The **LED 2** turns off and the following messages appear on the console:
+         .. code-block:: console
 
-   .. code-block:: console
+            I: Turn On Action has been initiated
+            I: Turn On Action has been completed
 
-      I: Turn Off Action has been initiated
-      I: Turn Off Action has been completed
+      #. Press **Button 2** again.
+         The **LED 2** turns off and the following messages appear on the console:
 
-#. Keep the **Button 1** pressed for more than six seconds to initiate factory reset of the device.
+         .. code-block:: console
+
+            I: Turn Off Action has been initiated
+            I: Turn Off Action has been completed
+
+      #. Keep the **Button 1** pressed for more than six seconds to initiate factory reset of the device.
+
+         The device reboots after all its settings are erased.
+
+   .. group-tab:: nRF54 DKs
+
+      #. |connect_kit|
+      #. |connect_terminal_ANSI|
+      #. Observe that **LED 1** is off.
+      #. Press **Button 1** on the light bulb device.
+         The **LED 1** turns on and the following messages appear on the console:
+
+         .. code-block:: console
+
+            I: Turn On Action has been initiated
+            I: Turn On Action has been completed
+
+      #. Press **Button 1** again.
+         The **LED 1** turns off and the following messages appear on the console:
+
+         .. code-block:: console
+
+            I: Turn Off Action has been initiated
+            I: Turn Off Action has been completed
+
+      #. Keep the **Button 0** pressed for more than six seconds to initiate factory reset of the device.
+
+         The device reboots after all its settings are erased.
 
 .. _matter_light_bulb_sample_light_switch_tests:
 
@@ -333,7 +383,7 @@ If you are new to Matter, the recommended approach is to use :ref:`CHIP Tool for
 
 Before starting the commissioning procedure, the device must be made discoverable over Bluetooth LE.
 The device becomes discoverable automatically upon the device startup, but only for a predefined period of time (1 hour by default).
-If the Bluetooth LE advertising times out, press **Button 1** to enable it again.
+If the Bluetooth LE advertising times out, enable it again.
 
 Onboarding information
 ++++++++++++++++++++++

--- a/samples/matter/light_switch/README.rst
+++ b/samples/matter/light_switch/README.rst
@@ -49,7 +49,7 @@ The development kits for this sample offer the following IPv6 network support fo
 Overview
 ********
 
-The sample controls the state of the **LED 2** on connected light bulbs devices.
+The sample controls the state of the state-indication LED on connected light bulbs devices.
 After configuring the light switch sample, the lighting devices get proper `Access Control List`_ from the Matter controller to start receiving commands sent from the light switch.
 Then, the light switch device prepares a new binding table to be able to discover light bulb devices and perform :ref:`matter_light_switch_sample_binding`.
 
@@ -139,39 +139,63 @@ Factory data support
 User interface
 **************
 
-.. include:: ../template/README.rst
-   :start-after: matter_template_nrf54l15_0_3_0_interface_start
-   :end-before: matter_template_nrf54l15_0_3_0_interface_end
+.. tabs::
 
-.. include:: ../lock/README.rst
-    :start-after: matter_door_lock_sample_led1_start
-    :end-before: matter_door_lock_sample_led1_end
+   .. group-tab:: nRF52, nRF53 and nRF70 DKs
 
-LED 2:
-   The LED starts blinking evenly (500 ms on/500 ms off) when the Identify command of the Identify cluster is received on the endpoint ``1``.
-   The command's argument can be used to specify the duration of the effect.
+      LED 1:
+         .. include:: /includes/matter_sample_state_led.txt
 
-All LEDs:
-   Blink in unison when the factory reset procedure is initiated.
+      LED 2:
+         The LED starts blinking evenly (500 ms on/500 ms off) when the Identify command of the Identify cluster is received on the endpoint ``1``.
+         The command's argument can be used to specify the duration of the effect.
 
-.. include:: ../lock/README.rst
-   :start-after: matter_door_lock_sample_button1_start
-   :end-before: matter_door_lock_sample_button1_end
+      All LEDs:
+         Blink in unison when the factory reset procedure is initiated.
 
-Button 2:
-   * Controls the light on the bound lighting device.
-     Depending on how long you press the button:
+      Button 1:
+         .. include:: /includes/matter_sample_button.txt
 
-      * If pressed for less than 0.5 seconds, it changes the light state to the opposite one on the bound lighting device (:ref:`light bulb <matter_light_bulb_sample>`).
-      * If pressed for more than 0.5 seconds, it changes the brightness of the light on the bound lighting bulb device (:ref:`light bulb <matter_light_bulb_sample>`).
-        The brightness is changing from 0% to 100% with 1% increments every 300 milliseconds as long as **Button 2** is pressed.
+      Button 2:
+         Controls the light on the bound lighting device.
+         Depending on how long you press the button:
 
-.. include:: ../lock/README.rst
-    :start-after: matter_door_lock_sample_jlink_start
-    :end-before: matter_door_lock_sample_jlink_end
+         * If pressed for less than 0.5 seconds, it changes the light state to the opposite one on the bound lighting device (:ref:`light bulb <matter_light_bulb_sample>`).
+         * If pressed for more than 0.5 seconds, it changes the brightness of the light on the bound lighting bulb device (:ref:`light bulb <matter_light_bulb_sample>`).
+           The brightness is changing from 0% to 100% with 1% increments every 300 milliseconds as long as **Button 2** is pressed.
 
-NFC port with antenna attached:
-   Optionally used for obtaining the `Onboarding information`_ from the Matter accessory device to start the :ref:`commissioning procedure <matter_light_switch_sample_remote_control_commissioning>`.
+      .. include:: /includes/matter_segger_usb.txt
+
+      NFC port with antenna attached:
+         Optionally used for obtaining the `Onboarding information`_ from the Matter accessory device to start the :ref:`commissioning procedure <matter_light_switch_sample_remote_control_commissioning>`.
+
+   .. group-tab:: nRF54 DKs
+
+      LED 0:
+         .. include:: /includes/matter_sample_state_led.txt
+
+      LED 1:
+         The LED starts blinking evenly (500 ms on/500 ms off) when the Identify command of the Identify cluster is received on the endpoint ``1``.
+         The command's argument can be used to specify the duration of the effect.
+
+      All LEDs:
+         Blink in unison when the factory reset procedure is initiated.
+
+      Button 0:
+         .. include:: /includes/matter_sample_button.txt
+
+      Button 1:
+         Controls the light on the bound lighting device.
+         Depending on how long you press the button:
+
+         * If pressed for less than 0.5 seconds, it changes the light state to the opposite one on the bound lighting device (:ref:`light bulb <matter_light_bulb_sample>`).
+         * If pressed for more than 0.5 seconds, it changes the brightness of the light on the bound lighting bulb device (:ref:`light bulb <matter_light_bulb_sample>`).
+           The brightness is changing from 0% to 100% with 1% increments every 300 milliseconds as long as **Button 1** is pressed.
+
+      .. include:: /includes/matter_segger_usb.txt
+
+      NFC port with antenna attached:
+         Optionally used for obtaining the `Onboarding information`_ from the Matter accessory device to start the :ref:`commissioning procedure <matter_light_switch_sample_remote_control_commissioning>`.
 
 .. _matter_light_switch_sample_ui_matter_cli:
 
@@ -187,7 +211,7 @@ Unicast commands
 You can use the following commands for direct communication with the single lighting device:
 
 switch onoff on
-   This command turns on **LED 2** on the bound lighting device.
+   This command turns on the state-indication LED on the bound lighting device.
    For example:
 
    .. parsed-literal::
@@ -196,7 +220,7 @@ switch onoff on
       uart:~$ matter switch onoff on
 
 switch onoff off
-   This command turns off **LED 2** on the bound lighting device.
+   This command turns off the state-indication LED on the bound lighting device.
    For example:
 
    .. parsed-literal::
@@ -205,7 +229,7 @@ switch onoff off
       uart:~$ matter switch onoff off
 
 switch onoff toggle
-   This command changes the **LED 2** state to the opposite one on the bound lighting device.
+   This command changes the state of the state-indication LED to the opposite state on the bound lighting device.
    For example:
 
    .. parsed-literal::
@@ -219,7 +243,7 @@ Groupcast commands
 You can use the following commands a group of devices that are programmed with the Light Switch Example application by using the Matter CLI:
 
 switch groups onoff on
-   This command turns on **LED 2** on each bound lighting device connected to the same group.
+   This command turns on the state-indication LED on each bound lighting device connected to the same group.
    For example:
 
    .. parsed-literal::
@@ -228,7 +252,7 @@ switch groups onoff on
       uart:~$ matter switch groups onoff on
 
 switch groups onoff off
-   This command turns off **LED 2** on each bound lighting device connected to the same group.
+   This command turns off the state-indication LED on each bound lighting device connected to the same group.
    For example:
 
    .. parsed-literal::
@@ -237,7 +261,7 @@ switch groups onoff off
       uart:~$ matter switch groups onoff off
 
 switch groups onoff toggle
-   This command changes the **LED 2** state to the opposite one on each bound lighting device connected to the same group.
+   This command changes the state of the state-indication LED to the opposite state on each bound lighting device connected to the same group.
    For example:
 
    .. parsed-literal::
@@ -277,53 +301,105 @@ After building this and the :ref:`Matter Light Bulb <matter_light_bulb_sample>` 
    This means that only one uncommissioned device can be powered up before commissioning.
    If both are powered up at the same time, the CHIP Tool can commission a random device and the node ID assignment is also random.
    When one device is commissioned, power up the next device and perform the commissioning.
-   To avoid this unclear situation, you can set up your unique discriminator in :file:`src/chip_project_config.h` file by changing :kconfig:option:`CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR` value.
+
+   To avoid this unclear situation, you can set up your unique discriminator in the :file:`src/chip_project_config.h` file by changing the :kconfig:option:`CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR` value.
    Then build an example and commission with your unique discriminator.
 
 .. matter_light_switch_sample_prepare_to_testing_start
 
-1. |connect_kit|
-#. |connect_terminal_ANSI|
-#. If devices were not erased during the programming, press and hold **Button 1** on each device until the factory reset takes place.
-#. On each device, press **Button 1** to start the Bluetooth LE advertising.
-#. Commission devices to the Matter network.
-   See `Commissioning the device`_ for more information.
-   During the commissioning process, write down the values for the light switch node ID and the light bulb node ID (or IDs, if you are using more than one light bulb).
-   These IDs are going to be used in the next steps (*<light_switch_node_ID>* and *<light_bulb_node_ID>*, respectively).
-#. Use the :doc:`CHIP Tool <matter:chip_tool_guide>` ("Writing ACL to the ``accesscontrol`` cluster" section) to add proper ACL for the light bulb device.
-   Depending on the number of the light bulb devices you are using, use one of the following commands, with *<light_switch_node_ID>* and *<light_bulb_node_ID>* values from the previous step about commissioning:
+.. tabs::
 
-   * If you are using only one light bulb device, run the following command for the light bulb device:
+   .. group-tab:: nRF52, nRF53 and nRF70 DKs
 
-     .. parsed-literal::
-        :class: highlight
+      1. |connect_kit|
+      #. |connect_terminal_ANSI|
+      #. If the devices were not erased during the programming, press and hold **Button 1** on each device until the factory reset takes place.
+      #. On each device, press **Button 1** to start the Bluetooth LE advertising.
+      #. Commission devices to the Matter network.
+         See `Commissioning the device`_ for more information.
 
-        chip-tool accesscontrol write acl '[{"fabricIndex": 1, "privilege": 5, "authMode": 2, "subjects": [112233], "targets": null}, {"fabricIndex": 1, "privilege": 3, "authMode": 2, "subjects": [<light_switch_node_ID>], "targets": [{"cluster": 6, "endpoint": 1, "deviceType": null}, {"cluster": 8, "endpoint": 1, "deviceType": null}]}]' <light_bulb_node_ID> 0
+         During the commissioning process, write down the values for the light switch node ID and the light bulb node ID (or IDs, if you are using more than one light bulb).
+         These IDs are going to be used in the next steps (*<light_switch_node_ID>* and *<light_bulb_node_ID>*, respectively).
+      #. Use the :doc:`CHIP Tool <matter:chip_tool_guide>` ("Writing ACL to the ``accesscontrol`` cluster" section) to add proper ACL for the light bulb device.
+         Depending on the number of the light bulb devices you are using, use one of the following commands, with *<light_switch_node_ID>* and *<light_bulb_node_ID>* values from the previous step about commissioning:
 
-   * If you are using more than one light bulb device, connect all devices to the multicast group by running the following command for each device, including the light switch:
+         * If you are using only one light bulb device, run the following command for the light bulb device:
 
-     .. parsed-literal::
-        :class: highlight
+           .. parsed-literal::
+              :class: highlight
 
-        chip-tool tests TestGroupDemoConfig --nodeId <node_ID>
+              chip-tool accesscontrol write acl '[{"fabricIndex": 1, "privilege": 5, "authMode": 2, "subjects": [112233], "targets": null}, {"fabricIndex": 1, "privilege": 3, "authMode": 2, "subjects": [<light_switch_node_ID>], "targets": [{"cluster": 6, "endpoint": 1, "deviceType": null}, {"cluster": 8, "endpoint": 1, "deviceType": null}]}]' <light_bulb_node_ID> 0
 
-     Use the *<node_ID>* values from the commissioning step.
+         * If you are using more than one light bulb device, connect all devices to the multicast group by running the following command for each device, including the light switch:
 
-#. Write a binding table to the light switch to inform the device about all endpoints by running this command (only for light switch):
+           .. parsed-literal::
+              :class: highlight
 
-   * For unicast binding to bind the light switch with only one light Bulb:
+              chip-tool tests TestGroupDemoConfig --nodeId <node_ID>
 
-      .. parsed-literal::
-         :class: highlight
+           Use the *<node_ID>* values from the commissioning step.
 
-         chip-tool binding write binding '[{"fabricIndex": 1, "node": <light bulb node id>, "endpoint": 1, "cluster": 6}, {"fabricIndex": 1, "node": <light bulb node id>, "endpoint": 1, "cluster": 8}]' <light switch node id> 1
+      #. Write a binding table to the light switch to inform the device about all endpoints by running this command (only for light switch):
 
-   * For groupcast binding to bind the light switch with multiple light bulbs:
+         * For unicast binding to bind the light switch with only one light Bulb:
 
-      .. parsed-literal::
-         :class: highlight
+            .. parsed-literal::
+               :class: highlight
 
-         chip-tool binding write binding '[{"fabricIndex": 1, "group": 257}]' <light_switch_node_ID> 1
+               chip-tool binding write binding '[{"fabricIndex": 1, "node": <light bulb node id>, "endpoint": 1, "cluster": 6}, {"fabricIndex": 1, "node": <light bulb node id>, "endpoint": 1, "cluster": 8}]' <light switch node id> 1
+
+         * For groupcast binding to bind the light switch with multiple light bulbs:
+
+            .. parsed-literal::
+               :class: highlight
+
+               chip-tool binding write binding '[{"fabricIndex": 1, "group": 257}]' <light_switch_node_ID> 1
+
+   .. group-tab:: nRF54 DKs
+
+      1. |connect_kit|
+      #. |connect_terminal_ANSI|
+      #. If the devices were not erased during the programming, press and hold **Button 0** on each device until the factory reset takes place.
+      #. On each device, press **Button 0** to start the Bluetooth LE advertising.
+      #. Commission devices to the Matter network.
+         See `Commissioning the device`_ for more information.
+
+         During the commissioning process, write down the values for the light switch node ID and the light bulb node ID (or IDs, if you are using more than one light bulb).
+         These IDs are going to be used in the next steps (*<light_switch_node_ID>* and *<light_bulb_node_ID>*, respectively).
+      #. Use the :doc:`CHIP Tool <matter:chip_tool_guide>` ("Writing ACL to the ``accesscontrol`` cluster" section) to add proper ACL for the light bulb device.
+         Depending on the number of the light bulb devices you are using, use one of the following commands, with *<light_switch_node_ID>* and *<light_bulb_node_ID>* values from the previous step about commissioning:
+
+         * If you are using only one light bulb device, run the following command for the light bulb device:
+
+           .. parsed-literal::
+              :class: highlight
+
+              chip-tool accesscontrol write acl '[{"fabricIndex": 1, "privilege": 5, "authMode": 2, "subjects": [112233], "targets": null}, {"fabricIndex": 1, "privilege": 3, "authMode": 2, "subjects": [<light_switch_node_ID>], "targets": [{"cluster": 6, "endpoint": 1, "deviceType": null}, {"cluster": 8, "endpoint": 1, "deviceType": null}]}]' <light_bulb_node_ID> 0
+
+         * If you are using more than one light bulb device, connect all devices to the multicast group by running the following command for each device, including the light switch:
+
+           .. parsed-literal::
+              :class: highlight
+
+              chip-tool tests TestGroupDemoConfig --nodeId <node_ID>
+
+           Use the *<node_ID>* values from the commissioning step.
+
+      #. Write a binding table to the light switch to inform the device about all endpoints by running this command (only for light switch):
+
+         * For unicast binding to bind the light switch with only one light Bulb:
+
+            .. parsed-literal::
+               :class: highlight
+
+               chip-tool binding write binding '[{"fabricIndex": 1, "node": <light bulb node id>, "endpoint": 1, "cluster": 6}, {"fabricIndex": 1, "node": <light bulb node id>, "endpoint": 1, "cluster": 8}]' <light switch node id> 1
+
+         * For groupcast binding to bind the light switch with multiple light bulbs:
+
+            .. parsed-literal::
+               :class: highlight
+
+               chip-tool binding write binding '[{"fabricIndex": 1, "group": 257}]' <light_switch_node_ID> 1
 
 .. matter_light_switch_sample_prepare_to_testing_end
 
@@ -338,52 +414,99 @@ Testing with bound light bulbs devices
 
 .. matter_light_switch_sample_testing_start
 
-After preparing devices for testing, you can test the communication either of a single light bulb or of a group of light bulbs with the light switch (but not both a single device and a group at the same time).
+After preparing devices for testing, you can test the communication of either a single light bulb or of a group of light bulbs with the light switch (but not both a single device and a group at the same time).
 
-Complete the following steps:
+Complete the following steps using the light switch device:
 
-1. On the light switch device, use :ref:`buttons <matter_light_switch_sample_ui>` to control the bound light bulbs:
+.. tabs::
 
-   #. On the light switch device, press **Button 2** to turn off the **LED 2** located on the bound light bulb device.
-   #. On the light switch device, press **Button 2** to turn on the light again.
-      **LED 2** on the light bulb device turns back on.
-   #. Press **Button 2** and hold it for more than 0.5 seconds to test the dimmer functionality.
-      **LED 2** on the bound light bulb device changes its brightness from 0% to 100% with 1% increments every 300 milliseconds as long as **Button 2** is pressed.
+   .. group-tab:: nRF52, nRF53 and nRF70 DKs
 
-#. Using the terminal emulator connected to the light switch, run the following :ref:`Matter CLI commands <matter_light_switch_sample_ui_matter_cli>`:
+      1. On the light switch device, use the :ref:`buttons <matter_light_switch_sample_ui>` to control the bound light bulbs:
 
-   a. Write the following command to turn on **LED 2** located on the bound light bulb devices:
+         a. Press **Button 2** to turn off the state-indication LED located on the bound light bulb device.
+         #. Press **Button 2** to turn the LED on again.
+         #. Press **Button 2** and hold it for more than 0.5 seconds to test the dimmer functionality.
 
-      * For a single bound light bulb:
+            The state-indication LED on the bound light bulb device changes its brightness from 0% to 100% with 1% increments every 300 milliseconds as long as **Button 2** is pressed.
 
-        .. parsed-literal::
-           :class: highlight
+      #. Using the terminal emulator connected to the light switch, run the following :ref:`Matter CLI commands <matter_light_switch_sample_ui_matter_cli>`:
 
-           matter switch onoff on
+         a. Write the following command to turn on state-indication LED located on the bound light bulb device:
 
-      * For a group of light bulbs:
+            * For a single bound light bulb:
 
-        .. parsed-literal::
-           :class: highlight
+              .. parsed-literal::
+                 :class: highlight
 
-           matter switch groups onoff on
+                 matter switch onoff on
 
-   #. Write the following command to turn on **LED 2** located on the bound light bulb device:
+            * For a group of light bulbs:
 
-      * For a single bound light bulb:
+              .. parsed-literal::
+                 :class: highlight
 
-        .. parsed-literal::
-           :class: highlight
+                 matter switch groups onoff on
 
-           matter switch onoff off
+         #. Write the following command to turn off the state-indication LED located on the bound light bulb device:
 
-      * For a group of light bulbs:
+            * For a single bound light bulb:
 
-        .. parsed-literal::
-           :class: highlight
+              .. parsed-literal::
+                 :class: highlight
 
-           matter switch groups onoff off
+                 matter switch onoff off
 
+            * For a group of light bulbs:
+
+              .. parsed-literal::
+                 :class: highlight
+
+                 matter switch groups onoff off
+
+   .. group-tab:: nRF54 DKs
+
+      1. On the light switch device, use the :ref:`buttons <matter_light_switch_sample_ui>` to control the bound light bulbs:
+
+         #. Press **Button 1** to turn off the state-indication LED located on the bound light bulb device.
+         #. Press **Button 1** to turn the LED on again.
+         #. Press **Button 1** and hold it for more than 0.5 seconds to test the dimmer functionality.
+
+            The state-indication LED on the bound light bulb device changes its brightness from 0% to 100% with 1% increments every 300 milliseconds as long as **Button 1** is pressed.
+
+      #. Using the terminal emulator connected to the light switch, run the following :ref:`Matter CLI commands <matter_light_switch_sample_ui_matter_cli>`:
+
+         a. Write the following command to turn on the state-indication LED located on the bound light bulb device:
+
+            * For a single bound light bulb:
+
+              .. parsed-literal::
+                 :class: highlight
+
+                 matter switch onoff on
+
+            * For a group of light bulbs:
+
+              .. parsed-literal::
+                 :class: highlight
+
+                 matter switch groups onoff on
+
+         #. Write the following command to turn off the state-indication LED located on the bound light bulb device:
+
+            * For a single bound light bulb:
+
+              .. parsed-literal::
+                 :class: highlight
+
+                 matter switch onoff off
+
+            * For a group of light bulbs:
+
+              .. parsed-literal::
+                 :class: highlight
+
+                 matter switch groups onoff off
 
 .. matter_light_switch_sample_testing_end
 
@@ -398,7 +521,7 @@ Commissioning the device
 
 Before starting the commissioning procedure, the device must be made discoverable over Bluetooth LE.
 The device becomes discoverable automatically upon the device startup, but only for a predefined period of time (1 hour by default).
-If the Bluetooth LE advertising times out, press **Button 1** to enable it again.
+If the Bluetooth LE advertising times out, enable it again.
 
 Onboarding information
 ----------------------

--- a/samples/matter/lock/README.rst
+++ b/samples/matter/lock/README.rst
@@ -162,6 +162,40 @@ However, you can use the Bluetooth LE service extension regardless of whether th
 
 See `Enabling Matter Bluetooth LE with Nordic UART Service`_ and `Testing door lock using Bluetooth LE with Nordic UART Service`_ for more information about how to configure and test this feature with this sample.
 
+.. _matter_lock_scheduled_timed_access:
+
+Scheduled timed access
+======================
+
+The scheduled timed access feature is an optional Matter lock feature that can be applicable to all available lock users.
+You can use the scheduled timed access feature to allow guest users of the home to access the lock at the specific scheduled times.
+To use this feature, you need to create at least one user on the lock device, and assign credentials.
+For more information about setting user credentials, see the Saving users and credentials on door lock devices section of the :doc:`matter:chip_tool_guide` page in the :doc:`Matter documentation set <matter:index>`, and the :ref:`matter_lock_sample_remote_access_with_pin` section of this sample.
+
+You can schedule the following types of timed access:
+
+   - ``Week-day`` - Restricts access to a specified time window on certain days of the week for a specific user.
+     This schedule grants repeated access each week.
+     When the schedule is cleared, the user is granted unrestricted access.
+
+   - ``Year-day`` - Restricts access to a specified time window on a specific date window.
+     This schedule grants access only once, and does not repeat.
+     When the schedule is cleared, the user is granted unrestricted access.
+
+   - ``Holiday`` - Sets up a holiday operating mode in the lock device.
+     You can choose one of the following operating modes:
+
+     - ``Normal`` - The lock operates normally.
+     - ``Vacation`` - Only remote operations are enabled.
+     - ``Privacy`` - All external interactions with the lock are disabled.
+       Can only be used if the lock is in the locked state.
+       Manually unlocking the lock changes the mode to ``Normal``.
+     - ``NoRemoteLockUnlock`` - All remote operations with the lock are disabled.
+     - ``Passage`` - The lock can be operated without providing a PIN.
+       This option can be used, for example, for employees during working hours.
+
+See the :ref:`matter_lock_enabling_scheduled_timed_access` and :ref:`matter_lock_sample_schedule_testing` sections of this sample for more information.
+
 .. _matter_lock_sample_configuration:
 
 Configuration
@@ -300,66 +334,65 @@ To learn more about factory data, read the :doc:`matter:nrfconnect_factory_data_
 User interface
 **************
 
-.. matter_door_lock_sample_led1_start
+.. tabs::
 
-LED 1:
-    Shows the overall state of the device and its connectivity.
-    The following states are possible:
+   .. group-tab:: nRF52, nRF53, nRF21 and nRF70 DKs
 
-    * Short Flash On (50 ms on/950 ms off) - The device is in the unprovisioned (unpaired) state and is waiting for a commissioning application to connect.
-    * Rapid Even Flashing (100 ms on/100 ms off) - The device is in the unprovisioned state and a commissioning application is connected over Bluetooth LE.
-    * Solid On - The device is fully provisioned.
+      LED 1:
+         .. include:: /includes/matter_sample_state_led.txt
 
-.. matter_door_lock_sample_led1_end
+      LED 2:
+         Shows the state of the lock.
+         The following states are possible:
 
-LED 2:
-    Shows the state of the lock.
-    The following states are possible:
+         * Solid On - The bolt is extended and the door is locked.
+         * Off - The bolt is retracted and the door is unlocked.
+         * Rapid Even Flashing (50 ms on/50 ms off during 2 s) - The simulated bolt is in motion from one position to another.
 
-    * Solid On - The bolt is extended and the door is locked.
-    * Off - The bolt is retracted and the door is unlocked.
-    * Rapid Even Flashing (50 ms on/50 ms off during 2 s) - The simulated bolt is in motion from one position to another.
+         Additionally, the LED starts blinking evenly (500 ms on/500 ms off) when the Identify command of the Identify cluster is received on the endpoint ``1``.
+         The command's argument can be used to specify the duration of the effect.
 
-    Additionally, the LED starts blinking evenly (500 ms on/500 ms off) when the Identify command of the Identify cluster is received on the endpoint ``1``.
-    The command's argument can be used to specify the duration of the effect.
+      Button 1:
+         .. include:: /includes/matter_sample_button.txt
 
-.. matter_door_lock_sample_button1_start
+      Button 2:
+         * Changes the lock state to the opposite one.
 
-Button 1:
-    Depending on how long you press the button:
+      Button 3:
+         * On the nRF5340 DK when using the ``thread_wifi_switched`` build type: If pressed for more than ten seconds, it switches the Matter transport protocol from Thread or Wi-Fi to the other and factory resets the device.
+         * On other platform or build type: Not available.
 
-    * If pressed for less than three seconds:
+      .. include:: /includes/matter_segger_usb.txt
 
-      * If the device is not provisioned to the Matter network, it initiates the SMP server (Simple Management Protocol) and Bluetooth LE advertising for Matter commissioning.
-        After that, the Device Firmware Update (DFU) over Bluetooth Low Energy can be started.
-        (See `Upgrading the device firmware`_.)
-        Bluetooth LE advertising makes the device discoverable over Bluetooth LE for the predefined period of time (1 hour by default).
+      NFC port with antenna attached:
+         Optionally used for obtaining the `Onboarding information`_ from the Matter accessory device to start the :ref:`commissioning procedure <matter_lock_sample_remote_control>`.
 
-      * If the device is already provisioned to the Matter network it re-enables the SMP server.
-        After that, the DFU over Bluetooth Low Energy can be started.
-        (See `Upgrading the device firmware`_.)
+   .. group-tab:: nRF54 DKs
 
-    * If pressed for more than three seconds, it initiates the factory reset of the device.
-      Releasing the button within a 3-second window of the initiation cancels the factory reset procedure.
+      LED 0:
+         .. include:: /includes/matter_sample_state_led.txt
 
-.. matter_door_lock_sample_button1_end
+      LED 1:
+         Shows the state of the lock.
+         The following states are possible:
 
-Button 2:
-    * Changes the lock state to the opposite one.
+         * Solid On - The bolt is extended and the door is locked.
+         * Off - The bolt is retracted and the door is unlocked.
+         * Rapid Even Flashing (50 ms on/50 ms off during 2 s) - The simulated bolt is in motion from one position to another.
 
-Button 3:
-    * On the nRF5340 DK when using the ``thread_wifi_switched`` build type: If pressed for more than ten seconds, it switches the Matter transport protocol from Thread or Wi-Fi to the other and factory resets the device.
-    * On other platform or build type: Not available.
+         Additionally, the LED starts blinking evenly (500 ms on/500 ms off) when the Identify command of the Identify cluster is received on the endpoint ``1``.
+         The command's argument can be used to specify the duration of the effect.
 
-.. matter_door_lock_sample_jlink_start
+      Button 0:
+         .. include:: /includes/matter_sample_button.txt
 
-SEGGER J-Link USB port:
-    Used for getting logs from the device or for communicating with it through the command-line interface.
+      Button 1:
+         * Changes the lock state to the opposite one.
 
-.. matter_door_lock_sample_jlink_end
+      .. include:: /includes/matter_segger_usb.txt
 
-NFC port with antenna attached:
-    Optionally used for obtaining the `Onboarding information`_ from the Matter accessory device to start the :ref:`commissioning procedure <matter_lock_sample_remote_control>`.
+      NFC port with antenna attached:
+         Optionally used for obtaining the `Onboarding information`_ from the Matter accessory device to start the :ref:`commissioning procedure <matter_lock_sample_remote_control>`.
 
 Building and running
 ********************
@@ -381,31 +414,65 @@ Testing
 
 After building the sample and programming it to your development kit, complete the following steps to test its basic features:
 
-#. |connect_kit|
-#. |connect_terminal_ANSI|
-#. Observe that **LED 2** is lit, which means that the door lock is closed.
-#. Press **Button 2** to unlock the door.
-   **LED 2** is blinking while the lock is opening.
-   After approximately two seconds, **LED 2** turns off permanently.
-   The following messages appear on the console:
+.. tabs::
 
-   .. code-block:: console
+   .. group-tab:: nRF52, nRF53, nRF21 and nRF70 DKs
 
-      I: Unlock Action has been initiated
-      I: Unlock Action has been completed
+      #. |connect_kit|
+      #. |connect_terminal_ANSI|
+      #. Observe that **LED 2** is lit, which means that the door lock is closed.
+      #. Press **Button 2** to unlock the door.
+         **LED 2** is blinking while the lock is opening.
 
-#. Press **Button 2** one more time to lock the door again.
-   **LED 2** starts blinking and remains turned on.
-   The following messages appear on the console:
+         After approximately two seconds, **LED 2** turns off permanently.
+         The following messages appear on the console:
 
-   .. code-block:: console
+         .. code-block:: console
 
-      I: Lock Action has been initiated
-      I: Lock Action has been completed
+            I: Unlock Action has been initiated
+            I: Unlock Action has been completed
 
-#. Keep the **Button 1** pressed for more than six seconds to initiate factory reset of the device.
+      #. Press **Button 2** one more time to lock the door again.
+         **LED 2** starts blinking and remains turned on.
+         The following messages appear on the console:
 
-The device reboots after all its settings are erased.
+         .. code-block:: console
+
+            I: Lock Action has been initiated
+            I: Lock Action has been completed
+
+      #. Keep the **Button 1** pressed for more than six seconds to initiate factory reset of the device.
+
+         The device reboots after all its settings are erased.
+
+   .. group-tab:: nRF54 DKs
+
+      #. |connect_kit|
+      #. |connect_terminal_ANSI|
+      #. Observe that **LED 1** is lit, which means that the door lock is closed.
+      #. Press **Button 1** to unlock the door.
+         **LED 1** is blinking while the lock is opening.
+
+         After approximately two seconds, **LED 1** turns off permanently.
+         The following messages appear on the console:
+
+         .. code-block:: console
+
+            I: Unlock Action has been initiated
+            I: Unlock Action has been completed
+
+      #. Press **Button 1** one more time to lock the door again.
+         **LED 1** starts blinking and remains turned on.
+         The following messages appear on the console:
+
+         .. code-block:: console
+
+            I: Lock Action has been initiated
+            I: Lock Action has been completed
+
+      #. Keep the **Button 0** pressed for more than six seconds to initiate factory reset of the device.
+
+         The device reboots after all its settings are erased.
 
 .. _matter_lock_sample_remote_control:
 
@@ -481,37 +548,10 @@ Upgrading the device firmware
 
 To upgrade the device firmware, complete the steps listed for the selected method in the :doc:`matter:nrfconnect_examples_software_update` tutorial of the Matter documentation.
 
-.. _matter_lock_scheduled_timed_access:
+.. _matter_lock_enabling_scheduled_timed_access:
 
-Scheduled timed access
-======================
-
-The scheduled timed access feature is an optional Matter lock feature that can be applicable to all available lock users.
-You can use the scheduled timed access feature to allow guest users of the home to access the lock at the specific scheduled times.
-To use this feature, you need to create at least one user on the lock device, and assign credentials.
-For more information about setting user credentials, see the Saving users and credentials on door lock devices section of the :doc:`matter:chip_tool_guide` page in the :doc:`Matter documentation set <matter:index>`, and the :ref:`matter_lock_sample_remote_access_with_pin` section of this sample.
-
-You can schedule the following types of timed access:
-
-   - ``Week-day`` - Restricts access to a specified time window on certain days of the week for a specific user.
-     This schedule grants repeated access each week.
-     When the schedule is cleared, the user is granted unrestricted access.
-
-   - ``Year-day`` - Restricts access to a specified time window on a specific date window.
-     This schedule grants access only once, and does not repeat.
-     When the schedule is cleared, the user is granted unrestricted access.
-
-   - ``Holiday`` - Sets up a holiday operating mode in the lock device.
-     You can choose one of the following operating modes:
-
-     - ``Normal`` - The lock operates normally.
-     - ``Vacation`` - Only remote operations are enabled.
-     - ``Privacy`` - All external interactions with the lock are disabled.
-       Can only be used if the lock is in the locked state.
-       Manually unlocking the lock changes the mode to ``Normal``.
-     - ``NoRemoteLockUnlock`` - All remote operations with the lock are disabled.
-     - ``Passage`` - The lock can be operated without providing a PIN.
-       This option can be used, for example, for employees during working hours.
+Enabling scheduled timed access
+===============================
 
 To enable the scheduled timed access feature, complete the following steps:
 
@@ -836,7 +876,7 @@ Testing door lock using Bluetooth LE with Nordic UART Service
 
 To test the :ref:`matter_lock_sample_ble_nus` feature, complete the following steps:
 
-#. Install `nRF Toolbox`_ on your Android (Android 11 or newer) or iOS smartphone (iOS 16.1 or newer).
+#. Install `nRF Toolbox`_ on your Android (Android 11 or newer) or iOS (iOS 16.1 or newer) smartphone.
 #. Build the door lock application for Matter over Thread with the :kconfig:option:`CONFIG_CHIP_NUS` set to ``y``.
    For example, if you build from command line for the ``nrf52840dk/nrf52840``, use the following command:
 
@@ -872,7 +912,7 @@ To test the :ref:`matter_lock_sample_ble_nus` feature, complete the following st
    * ``Lock`` as the Command value type ``Text`` and any image.
    * ``Unlock`` as the Command value type ``Text`` and any image.
 
-#. Tap on the generated macros and observe the **LED 2** on the DK.
+#. Tap on the generated macros and to change the lock state.
 
 The Bluetooth LE connection between a phone and the DK will be suspended when the commissioning to the Matter network is in progress or there is an active session of SMP DFU.
 

--- a/samples/matter/template/README.rst
+++ b/samples/matter/template/README.rst
@@ -140,29 +140,28 @@ Factory data support
 User interface
 **************
 
-.. matter_template_nrf54l15_0_3_0_interface_start
+.. tabs::
 
-.. note::
+   .. group-tab:: nRF52, nRF53 and nRF70 DKs
 
-    The nRF54L15 PDK revision v0.3.0 uses a different numbering system for buttons and LEDs compared to previous boards.
-    All numbers start from 0 instead of 1, as was the case previously.
-    This means that **LED1** in this documentation refers to **LED0** on the nRF54L15 PDK board, **LED2** refers to **LED1**, **Button 1** refers to **Button 0**, and so on.
+      LED 1:
+         .. include:: /includes/matter_sample_state_led.txt
 
-    For the nRF54L15 PDK revision v0.2.1, the numbering of buttons and LEDs is the same as on the nRF52840 DK and nRF5340 DK boards.
+      Button 1:
+         .. include:: /includes/matter_sample_button.txt
 
-.. matter_template_nrf54l15_0_3_0_interface_end
+      .. include:: /includes/matter_segger_usb.txt
 
-.. include:: ../lock/README.rst
-    :start-after: matter_door_lock_sample_led1_start
-    :end-before: matter_door_lock_sample_led1_end
+   .. group-tab:: nRF54 DKs
 
-.. include:: ../lock/README.rst
-    :start-after: matter_door_lock_sample_button1_start
-    :end-before: matter_door_lock_sample_button1_end
+      LED 0:
+         .. include:: /includes/matter_sample_state_led.txt
 
-.. include:: ../lock/README.rst
-    :start-after: matter_door_lock_sample_jlink_start
-    :end-before: matter_door_lock_sample_jlink_end
+      Button 0:
+         .. include:: /includes/matter_sample_button.txt
+
+      .. include:: /includes/matter_segger_usb.txt
+
 
 Building and running
 ********************
@@ -180,8 +179,17 @@ See :ref:`cmake_options` for information about how to select a build type.
 Testing
 =======
 
-When you have built the sample and programmed it to your development kit, it automatically starts the Bluetooth LE advertising and the **LED1** starts flashing (Short Flash On).
-At this point, you can press **Button 1** for six seconds to initiate the factory reset of the device.
+.. tabs::
+
+   .. group-tab:: nRF52, nRF53 and nRF70 DKs
+
+      When you have built the sample and programmed it to your development kit, it automatically starts the Bluetooth LE advertising and the **LED 1** starts flashing (Short Flash On).
+      At this point, you can press **Button 1** for six seconds to initiate the factory reset of the device.
+
+   .. group-tab:: nRF54 DKs
+
+      When you have built the sample and programmed it to your development kit, it automatically starts the Bluetooth LE advertising and the **LED 0** starts flashing (Short Flash On).
+      At this point, you can press **Button 0** for six seconds to initiate the factory reset of the device.
 
 .. _matter_template_network_testing:
 
@@ -190,22 +198,45 @@ Testing in a network
 
 To test the sample in a Matter-enabled Thread network, complete the following steps:
 
-.. matter_template_sample_testing_start
+.. tabs::
 
-1. |connect_kit|
-#. |connect_terminal_ANSI|
-#. Commission the device into a Matter network by following the guides linked on the :ref:`ug_matter_configuring` page for the Matter controller you want to use.
-   The guides walk you through the following steps:
+   .. group-tab:: nRF52, nRF53 and nRF70 DKs
 
-   * Only if you are configuring Matter over Thread: Configure the Thread Border Router.
-   * Build and install the Matter controller.
-   * Commission the device.
-     You can use the :ref:`matter_template_network_mode_onboarding` listed earlier on this page.
-   * Send Matter commands.
+      1. |connect_kit|
+      #. |connect_terminal_ANSI|
+      #. Commission the device into a Matter network by following the guides linked on the :ref:`ug_matter_configuring` page for the Matter controller you want to use.
+         The guides walk you through the following steps:
 
-   At the end of this procedure, **LED 1** of the Matter device programmed with the sample starts flashing in the Short Flash Off state.
-   This indicates that the device is fully provisioned, but does not yet have full IPv6 network connectivity.
-#. Keep the **Button 1** pressed for more than six seconds to initiate factory reset of the device.
+         * Only if you are configuring Matter over Thread: Configure the Thread Border Router.
+         * Build and install the Matter controller.
+         * Commission the device.
+           You can use the :ref:`matter_template_network_mode_onboarding` listed earlier on this page.
+         * Send Matter commands.
+
+         At the end of this procedure, **LED 1** of the Matter device programmed with the sample starts flashing in the Short Flash Off state.
+         This indicates that the device is fully provisioned, but does not yet have full IPv6 network connectivity.
+      #. Keep the **Button 1** pressed for more than six seconds to initiate factory reset of the device.
+
+         The device reboots after all its settings are erased.
+
+   .. group-tab:: nRF54 DKs
+
+      1. |connect_kit|
+      #. |connect_terminal_ANSI|
+      #. Commission the device into a Matter network by following the guides linked on the :ref:`ug_matter_configuring` page for the Matter controller you want to use.
+         The guides walk you through the following steps:
+
+         * Only if you are configuring Matter over Thread: Configure the Thread Border Router.
+         * Build and install the Matter controller.
+         * Commission the device.
+           You can use the :ref:`matter_template_network_mode_onboarding` listed earlier on this page.
+         * Send Matter commands.
+
+         At the end of this procedure, **LED 0** of the Matter device programmed with the sample starts flashing in the Short Flash Off state.
+         This indicates that the device is fully provisioned, but does not yet have full IPv6 network connectivity.
+      #. Keep the **Button 0** pressed for more than six seconds to initiate factory reset of the device.
+
+         The device reboots after all its settings are erased.
 
 The device reboots after all its settings are erased.
 

--- a/samples/matter/thermostat/README.rst
+++ b/samples/matter/thermostat/README.rst
@@ -157,27 +157,39 @@ Factory data support
 User interface
 **************
 
-.. include:: ../template/README.rst
-   :start-after: matter_template_nrf54l15_0_3_0_interface_start
-   :end-before: matter_template_nrf54l15_0_3_0_interface_end
+.. tabs::
 
-.. include:: ../lock/README.rst
-    :start-after: matter_door_lock_sample_led1_start
-    :end-before: matter_door_lock_sample_led1_end
+   .. group-tab:: nRF52, nRF53 and nRF70 DKs
 
-.. include:: ../lock/README.rst
-    :start-after: matter_door_lock_sample_button1_start
-    :end-before: matter_door_lock_sample_button1_end
+      LED 1:
+         .. include:: /includes/matter_sample_state_led.txt
 
-Button 2:
-    * Prints the most recent thermostat data to terminal.
+      Button 1:
+         .. include:: /includes/matter_sample_button.txt
 
-.. include:: ../lock/README.rst
-    :start-after: matter_door_lock_sample_jlink_start
-    :end-before: matter_door_lock_sample_jlink_end
+      Button 2:
+         Prints the most recent thermostat data to terminal.
 
-NFC port with antenna attached:
-    Optionally used for obtaining the `Onboarding information`_ from the Matter accessory device to start the :ref:`commissioning procedure <matter_thermostat_sample_remote_control>`.
+      .. include:: /includes/matter_segger_usb.txt
+
+      NFC port with antenna attached:
+          Optionally used for obtaining the `Onboarding information`_ from the Matter accessory device to start the :ref:`commissioning procedure <matter_thermostat_sample_remote_control>`.
+
+   .. group-tab:: nRF54 DKs
+
+      LED 0:
+         .. include:: /includes/matter_sample_state_led.txt
+
+      Button 0:
+         .. include:: /includes/matter_sample_button.txt
+
+      Button 1:
+         Prints the most recent thermostat data to terminal.
+
+      .. include:: /includes/matter_segger_usb.txt
+
+      NFC port with antenna attached:
+          Optionally used for obtaining the `Onboarding information`_ from the Matter accessory device to start the :ref:`commissioning procedure <matter_thermostat_sample_remote_control>`.
 
 Building and running
 ********************
@@ -206,16 +218,33 @@ Testing basic features
 
 After building the sample and programming it to your development kit, complete the following steps to test its basic features:
 
-1. |connect_kit|
-#. |connect_terminal_ANSI|
-#. Observe that the **LED1** starts flashing (short flash on).
-   This means that the sample has automatically started the Bluetooth LE advertising.
-#. Observe the UART terminal.
-   The sample starts automatically printing the simulated temperature data to the terminal with 30-second intervals.
-#. Press **Button 2** to print the most recent temperature data to the terminal.
-#. Keep the **Button 1** pressed for more than six seconds to initiate factory reset of the device.
+.. tabs::
 
-The device reboots after all its settings are erased.
+   .. group-tab:: nRF52, nRF53 and nRF70 DKs
+
+      1. |connect_kit|
+      #. |connect_terminal_ANSI|
+      #. Observe that **LED 1** starts flashing (short flash on).
+         This means that the sample has automatically started the Bluetooth LE advertising.
+      #. Observe the UART terminal.
+         The sample starts automatically printing the simulated temperature data to the terminal with 30-second intervals.
+      #. Press **Button 2** to print the most recent temperature data to the terminal.
+      #. Keep **Button 1** pressed for more than six seconds to initiate factory reset of the device.
+
+         The device reboots after all its settings are erased.
+
+   .. group-tab:: nRF52, nRF53 and nRF70 DKs
+
+      1. |connect_kit|
+      #. |connect_terminal_ANSI|
+      #. Observe that **LED 0** starts flashing (short flash on).
+         This means that the sample has automatically started the Bluetooth LE advertising.
+      #. Observe the UART terminal.
+         The sample starts automatically printing the simulated temperature data to the terminal with 30-second intervals.
+      #. Press **Button 1** to print the most recent temperature data to the terminal.
+      #. Keep **Button 0** pressed for more than six seconds to initiate factory reset of the device.
+
+         The device reboots after all its settings are erased.
 
 .. _matter_thermostat_sensor_testing:
 
@@ -230,6 +259,7 @@ After building this sample and the :ref:`Matter weather station <matter_weather_
 #. On each device, press the button that starts the Bluetooth LE advertising.
 #. Commission devices to the Matter network.
    See `Commissioning the device`_ for more information.
+
    During the commissioning process, write down the values for the thermostat node ID, the temperature sensor node ID, and the temperature sensor endpoint ID.
    These IDs are going to be used in the next steps (*<thermostat_node_ID>*, *<temperature_sensor_node_ID>*, and *<temperature_sensor_endpoint_ID>*, respectively).
 #. Use the :doc:`CHIP Tool <matter:chip_tool_guide>` ("Writing ACL to the ``accesscontrol`` cluster" section) to add proper ACL for the temperature sensor device.
@@ -251,7 +281,7 @@ After building this sample and the :ref:`Matter weather station <matter_weather_
    The thermostat is now able to read the real temperature data from the temperature sensor device.
    The connection is ensured by :ref:`matter_thermostat_sample_binding` to Matter's temperature measurement cluster.
 
-#. Press **Button 2** to print the most recent temperature data from the thermostat device to the UART terminal.
+#. Press the button that prints the most recent temperature data from the thermostat device to the UART terminal.
 
 .. _matter_thermostat_sample_remote_control:
 

--- a/samples/matter/window_covering/README.rst
+++ b/samples/matter/window_covering/README.rst
@@ -113,60 +113,86 @@ Factory data support
 User interface
 **************
 
-.. include:: ../template/README.rst
-   :start-after: matter_template_nrf54l15_0_3_0_interface_start
-   :end-before: matter_template_nrf54l15_0_3_0_interface_end
+.. tabs::
 
-.. include:: ../lock/README.rst
-    :start-after: matter_door_lock_sample_led1_start
-    :end-before: matter_door_lock_sample_led1_end
+   .. group-tab:: nRF52 and nRF53 DKs
 
-LED 2
-    Indicates the lift position of the window cover, which is represented by the brightness of the LED.
-    The brightness level ranges from ``0`` to ``255``, where the brightness level set to ``0`` (switched off LED) indicates a fully opened window cover (lifted) and the brightness level set to ``255`` indicates a fully closed window cover (lowered).
+      LED 1:
+         .. include:: /includes/matter_sample_state_led.txt
 
-    Additionally, the LED starts blinking evenly (500 ms on/500 ms off) when the Identify command of the Identify cluster is received on the endpoint ``1``.
-    The command's argument can be used to specify the duration of the effect.
+      LED 2:
+         Indicates the lift position of the window cover, which is represented by the brightness of the LED.
+         The brightness level ranges from ``0`` to ``255``, where the brightness level set to ``0`` (switched off LED) indicates a fully opened window cover (lifted) and the brightness level set to ``255`` indicates a fully closed window cover (lowered).
 
-LED 3 (nRF52840 DK and nRF5340 DK)
-    Indicates the tilt position of the window cover, which is represented by the brightness of the LED.
-    The brightness level ranges from ``0`` to ``255``, where the brightness level set to ``0`` (switched off LED) indicates a fully opened window cover (tilted to a horizontal position) and the brightness level set to ``255`` indicates a fully closed window cover (tilted to a vertical position).
+         Additionally, the LED starts blinking evenly (500 ms on/500 ms off) when the Identify command of the Identify cluster is received on the endpoint ``1``.
+         The command's argument can be used to specify the duration of the effect.
 
-LED 4 (nRF54L15 PDK)
-    .. note::
-       This is **LED 3** on the board revision v0.3.0.
+      LED 3:
+         Indicates the tilt position of the window cover, which is represented by the brightness of the LED.
+         The brightness level ranges from ``0`` to ``255``, where the brightness level set to ``0`` (switched off LED) indicates a fully opened window cover (tilted to a horizontal position) and the brightness level set to ``255`` indicates a fully closed window cover (tilted to a vertical position).
 
-    Indicates the tilt position of the window cover, which is represented by the brightness of the LED.
-    The brightness level ranges from ``0`` to ``255``, where the brightness level set to ``0`` (switched off LED) indicates a fully opened window cover (tilted to a horizontal position) and the brightness level set to ``255`` indicates a fully closed window cover (tilted to a vertical position).
+      Button 1:
+         .. include:: /includes/matter_sample_button.txt
 
-.. include:: ../lock/README.rst
-    :start-after: matter_door_lock_sample_button1_start
-    :end-before: matter_door_lock_sample_button1_end
+      Button 2:
+         When pressed once and released, it moves the window cover towards the open position by one step.
+         Depending on the movement mode of the cover (see `Overview`_), the button decreases the brightness of either  **LED 2** for the lift mode or **LED 3** for the tilt mode.
 
-Button 2:
-    When pressed once and released, it moves the window cover towards the open position by one step.
-    Depending on the movement mode of the cover (see `Overview`_), the button decreases the brightness of either  **LED 2** for the lift mode or **LED 3** for the tilt mode.
+      Button 3:
+         When pressed once and released, it moves the cover towards the closed position by one step.
+         Depending on the movement mode of the cover (see `Overview`_), the button increases the brightness of either  **LED 2** for the lift mode or **LED 3** for the tilt mode.
 
-Button 3:
-    When pressed once and released, it moves the cover towards the closed position by one step.
-    Depending on the movement mode of the cover (see `Overview`_), the button increases the brightness of either  **LED 2** for the lift mode or **LED 3** for the tilt mode.
+      Button 2 and Button 3:
+         When pressed at the same time, they toggle the cover movement mode between lift and tilt.
+         After each device reset, the mode is set to lift by default.
 
-Button 2 and Button 3:
-    When pressed at the same time, they toggle the cover movement mode between lift and tilt.
-    After each device reset, the mode is set to lift by default.
+      .. include:: /includes/matter_segger_usb.txt
+
+      NFC port with antenna attached:
+         Optionally used for obtaining the `Onboarding information`_ from the Matter accessory device to start the :ref:`commissioning procedure <matter_window_cover_sample_remote_control_commissioning>`.
+
+   .. group-tab:: nRF54 DKs
+
+      LED 0:
+         .. include:: /includes/matter_sample_state_led.txt
+
+      LED 1:
+         Indicates the lift position of the window cover, which is represented by the brightness of the LED.
+         The brightness level ranges from ``0`` to ``255``, where the brightness level set to ``0`` (switched off LED) indicates a fully opened window cover (lifted) and the brightness level set to ``255`` indicates a fully closed window cover (lowered).
+
+         Additionally, the LED starts blinking evenly (500 ms on/500 ms off) when the Identify command of the Identify cluster is received on the endpoint ``1``.
+         The command's argument can be used to specify the duration of the effect.
+
+      LED 3:
+         Indicates the tilt position of the window cover, which is represented by the brightness of the LED.
+         The brightness level ranges from ``0`` to ``255``, where the brightness level set to ``0`` (switched off LED) indicates a fully opened window cover (tilted to a horizontal position) and the brightness level set to ``255`` indicates a fully closed window cover (tilted to a vertical position).
+
+      Button 0:
+         .. include:: /includes/matter_sample_button.txt
+
+      Button 1:
+         When pressed once and released, it moves the window cover towards the open position by one step.
+         Depending on the movement mode of the cover (see `Overview`_), the button decreases the brightness of either  **LED 1** for the lift mode or **LED 3** for the tilt mode.
+
+      Button 2:
+         When pressed once and released, it moves the cover towards the closed position by one step.
+         Depending on the movement mode of the cover (see `Overview`_), the button increases the brightness of either  **LED 1** for the lift mode or **LED 3** for the tilt mode.
+
+      Button 1 and Button 2:
+         When pressed at the same time, they toggle the cover movement mode between lift and tilt.
+         After each device reset, the mode is set to lift by default.
+
+      .. include:: /includes/matter_segger_usb.txt
+
+      NFC port with antenna attached:
+         Optionally used for obtaining the `Onboarding information`_ from the Matter accessory device to start the :ref:`commissioning procedure <matter_window_cover_sample_remote_control_commissioning>`.
 
 .. note::
-    Completely opening and closing the cover requires 20 button presses (steps).
-    Each step takes approximately 200 ms to simulate the real window cover movement.
-    The cover position and the LED brightness values are stored in non-volatile memory and are restored after every device reset.
-    After the firmware update or factory reset both LEDs are switched off by default, which corresponds to the cover being fully open, both lift-wise and tilt-wise.
+   Completely opening and closing the cover requires 20 button presses (steps).
+   Each step takes approximately 200 ms to simulate the real window cover movement.
 
-.. include:: ../lock/README.rst
-    :start-after: matter_door_lock_sample_jlink_start
-    :end-before: matter_door_lock_sample_jlink_end
-
-NFC port with antenna attached:
-    Optionally used for obtaining the `Onboarding information`_ from the Matter accessory device to start the :ref:`commissioning procedure <matter_window_cover_sample_remote_control_commissioning>`.
+   The cover position and the LED brightness values are stored in non-volatile memory and are restored after every device reset.
+   After the firmware update or factory reset both LEDs are switched off by default, which corresponds to the cover being fully open, both lift-wise and tilt-wise.
 
 Building and running
 ********************
@@ -186,22 +212,55 @@ Testing
 
 After building the sample and programming it to your development kit, complete the following steps to test its basic features:
 
-#. |connect_kit|
-#. |connect_terminal_ANSI|
-#. Observe that **LED 2** and **LED 3** are turned off, which means that the window cover is fully open.
-   The device starts in the lift movement mode by default.
-#. Press **Button 3** 20 times to fully close the cover in the lift movement mode.
-   **LED 2** lights up and its brightness increases with each button press until it reaches full brightness.
-#. Press **Button 2** 20 times to fully lift the cover up.
-   The brightness of **LED 2** decreases with each button press until the LED turns off.
-#. Press **Button 2** and **Button 3** together to switch into the tilt movement mode.
-#. Press **Button 3** 20 times to fully tilt the cover into the closed position.
-   **LED 3** light up and its brightness increases with each button press until it reaches full brightness.
-#. Press **Button 2** 20 times to fully tilt the cover into the open position.
-   The brightness of **LED 3** decreases with each button press until the LED turns off.
-#. Keep the **Button 1** pressed for more than six seconds to initiate factory reset of the device.
+.. tabs::
 
-The device reboots after all its settings are erased.
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      #. |connect_kit|
+      #. |connect_terminal_ANSI|
+      #. Observe that **LED 2** and **LED 3** are turned off, which means that the window cover is fully open.
+
+         The device starts in the lift movement mode by default.
+      #. Press **Button 3** 20 times to fully close the cover in the lift movement mode.
+
+         **LED 2** lights up and its brightness increases with each button press until it reaches full brightness.
+      #. Press **Button 2** 20 times to fully lift the cover up.
+
+         The brightness of **LED 2** decreases with each button press until the LED turns off.
+      #. Press **Button 2** and **Button 3** together to switch into the tilt movement mode.
+      #. Press **Button 3** 20 times to fully tilt the cover into the closed position.
+
+         **LED 3** light up and its brightness increases with each button press until it reaches full brightness.
+      #. Press **Button 2** 20 times to fully tilt the cover into the open position.
+
+         The brightness of **LED 3** decreases with each button press until the LED turns off.
+      #. Keep **Button 1** pressed for more than six seconds to initiate factory reset of the device.
+
+         The device reboots after all its settings are erased.
+
+   .. group-tab:: nRF54 DKs
+
+      #. |connect_kit|
+      #. |connect_terminal_ANSI|
+      #. Observe that **LED 1** and **LED 3** are turned off, which means that the window cover is fully open.
+
+         The device starts in the lift movement mode by default.
+      #. Press **Button 2** 20 times to fully close the cover in the lift movement mode.
+
+         **LED 1** lights up and its brightness increases with each button press until it reaches full brightness.
+      #. Press **Button 1** 20 times to fully lift the cover up.
+
+         The brightness of **LED 1** decreases with each button press until the LED turns off.
+      #. Press **Button 1** and **Button 2** together to switch into the tilt movement mode.
+      #. Press **Button 2** 20 times to fully tilt the cover into the closed position.
+
+         **LED 3** light up and its brightness increases with each button press until it reaches full brightness.
+      #. Press **Button 1** 20 times to fully tilt the cover into the open position.
+
+         The brightness of **LED 3** decreases with each button press until the LED turns off.
+      #. Keep **Button 0** pressed for more than six seconds to initiate factory reset of the device.
+
+         The device reboots after all its settings are erased.
 
 .. _matter_window_cover_sample_remote_control:
 
@@ -223,7 +282,7 @@ Commissioning the device
 
 Before starting the commissioning procedure, the device must be made discoverable over Bluetooth LE.
 The device becomes discoverable automatically upon the device startup, but only for a predefined period of time (1 hour by default).
-If the Bluetooth LE advertising times out, press **Button 1** to enable it again.
+If the Bluetooth LE advertising times out, enable it again.
 
 Onboarding information
 ++++++++++++++++++++++


### PR DESCRIPTION
The nRF54L and nRF54H series PDKs have a new numbering system. This makes the required adjustments to Matter samples that support those boards.