### PR TITLE
kconfig: ssf: select zcbor canonical

### DIFF
--- a/subsys/sdfw_services/Kconfig
+++ b/subsys/sdfw_services/Kconfig
@@ -15,6 +15,7 @@ config SDFW_SERVICES_ENABLED
 	default y
 	depends on SSF_CLIENT
 	imply ZCBOR
+	select ZCBOR_CANONICAL
 	help
 	  Enable SDFW Service Framework (SSF)
 


### PR DESCRIPTION
Ensure that ZCBOR_CANONICAL is set for SSF clients.

This is required since SDFW uses ZCBOR_CANONICAL.

This is a sub-optimal solution, see PR-15776 for proper one.

Ref: NCSDK-27818