### PR TITLE
doc: Bluetooth RPC Host related documentation updates

### DIFF
--- a/applications/ipc_radio/README.rst
+++ b/applications/ipc_radio/README.rst
@@ -65,7 +65,11 @@ You can set the supported radio configurations using the following Kconfig optio
 * :kconfig:option:`CONFIG_IPC_RADIO_BT` - For the Bluetooth Low Energy serialization.
 * :kconfig:option:`CONFIG_IPC_RADIO_802154` - For the IEEE 802.15.4 serialization.
 
-You can select the Bluetooth Low Energy serialization using the :kconfig:option:`CONFIG_IPC_RADIO_BT_SER` Kconfig option.
+
+You can select the Bluetooth Low Energy serialization using the :kconfig:option:`CONFIG_IPC_RADIO_BT_SER` Kconfig option:
+
+* :kconfig:option:`CONFIG_IPC_RADIO_BT_HCI_IPC` - For the Bluetooh HCI serialization.
+* :kconfig:option:`CONFIG_IPC_RADIO_BT_RPC` - For the Bluetooh host API serialization.
 
 The Bluetooth Low Energy and IEEE 802.15.4 functionalities can operate simultaneously and are only limited by available memory.
 

--- a/doc/nrf/libraries/bluetooth_services/rpc.rst
+++ b/doc/nrf/libraries/bluetooth_services/rpc.rst
@@ -45,7 +45,7 @@ Requirements
 ************
 
 Some configuration options related to Bluetooth Low Energy must be the same on the host and client.
-Set the following options in the same way for the :ref:`ble_rpc_host` and application core:
+Set the following options in the same way for the :ref:`ble_rpc_host` or :ref:`ipc_radio`, and application core:
 
   * :kconfig:option:`CONFIG_BT_CENTRAL`
   * :kconfig:option:`CONFIG_BT_PERIPHERAL`

--- a/samples/bluetooth/peripheral_uart/README.rst
+++ b/samples/bluetooth/peripheral_uart/README.rst
@@ -160,6 +160,15 @@ Building and running
 
 .. _peripheral_uart_sample_activating_variants:
 
+Experimental Bluetooth Low Energy Remote Procedure Call interface
+=================================================================
+
+To build the sample with a :ref:`ble_rpc` interface, use the following command:
+
+.. code-block:: console
+
+   west build samples/bluetooth/peripheral_uart -b board_name --sysbuild -S nordic-rpc-host -- -DFILE_SUFFIX=bt_rpc
+
 Activating sample extensions
 ============================
 

--- a/snippets/nordic-bt-rpc/README.rst
+++ b/snippets/nordic-bt-rpc/README.rst
@@ -1,11 +1,23 @@
-.. _nordic-rpc-host:
+.. _nordic-bt-rpc:
 
-Nordic RPC Host snippet (nordic-rpc-host)
-#########################################
+Nordic Bluetooth Low Energy Remote Procedure Call snippet (nordic-bt-rpc)
+#########################################################################
 
 Overview
 ********
 
-This snippet allows users to build Bluetooth applications with Bluetooth stack running on Radio
-core. The communication between an application and Bluetooth stack is handled over the Bluetooth
-RPC subsystem.
+This snippet allows you to build Bluetooth applications with Bluetooth stack running on a core dedicated for radio communication.
+For example in the nRF54H20 SoC, it is the radio core.
+The communication between an application and the Bluetooth stack is handled by the Bluetooth RPC library.
+
+Supported SoCs
+**************
+
+Currently, the following SoCs from Nordic Semiconductor are supported for use with the snippet:
+
+* :ref:`zephyr:nrf5340dk_nrf5340`
+* :ref:`zephyr:nrf54h20dk_nrf54h20`
+
+.. note::
+   On the nRF54H20 SoC, the snippet modifies the memory map to make room for settings storage for the radio core.
+   The memory for settings storage is obtained by shrinking the application core ``cpuapp_slot0_partition`` partition.


### PR DESCRIPTION
There were updated documentation related to Bluetooth RPC host interface in following parts of SDK:
- nordic-bt-rpc snippet
- BLE RPC subsystem
- ipc_radio
- peripheral_uart

