### PR TITLE
doc: nrf: update nrf91 snippets documentation after sysbuild

### DIFF
--- a/doc/nrf/config_and_build/config_and_build_system.rst
+++ b/doc/nrf/config_and_build/config_and_build_system.rst
@@ -186,6 +186,9 @@ Snippets
 Snippets are a Zephyr mechanism for defining portable build system overrides that could be applied to any application.
 Read Zephyr's :ref:`zephyr:snippets` documentation for more information.
 
+.. important::
+  When using :ref:`configuration_system_overview_sysbuild`, the snippet is applied to all images, unless the image is specified explicitly (``-D<image_name>_SNIPPET="<your_snippet>"``).
+
 You can set snippets for use with your application when you :ref:`set up your build configuration <building>` by :ref:`providing them as CMake options <cmake_options>`.
 
 Usage of snippets is optional.

--- a/doc/nrf/config_and_build/configuring_app/cmake/index.rst
+++ b/doc/nrf/config_and_build/configuring_app/cmake/index.rst
@@ -74,21 +74,20 @@ The following table lists the most common ones used in the |NCS|:
      - ``-DEXTRA_DTC_OVERLAY_FILE=<file_name>.overlay``
    * - :makevar:`SHIELD`
      - Select one of the supported :ref:`shields <shield_names_nrf>` for building the firmware.
-     - ``-DSHIELD=<shield>`` (``-Dimage-name_SHIELD`` for images)
+     - ``-DSHIELD=<shield>`` (``-D<image_name>_SHIELD`` for images)
    * - :makevar:`FILE_SUFFIX`
      - | Select one of the available :ref:`suffixed configurations <zephyr:application-file-suffixes>`, if the application or sample supports any.
        | See :ref:`app_build_file_suffixes` for more information about their usage and limitations in the |NCS|.
        | This variable is gradually replacing :makevar:`CONF_FILE`.
-     - ``-DFILE_SUFFIX=<configuration_suffix>`` (``-Dimage-name_FILE_SUFFIX`` for images)
+     - ``-DFILE_SUFFIX=<configuration_suffix>`` (``-D<image_name>_FILE_SUFFIX`` for images)
    * - :makevar:`CONF_FILE`
      - | Select one of the available :ref:`build types <modifying_build_types>`, if the application or sample supports any.
        | This variable is deprecated and is being gradually replaced by :makevar:`FILE_SUFFIX`, but :ref:`still required for some applications <modifying_build_types>`.
      - ``-DCONF_FILE=prj_<build_type_name>.conf``
    * - ``-S`` (west) or :makevar:`SNIPPET` (CMake)
-     - | Select one of the :ref:`zephyr:snippets` to add to the application firmware during the build.
-       | The west argument ``-S`` is more commonly used.
-     - | ``-S <name_of_snippet>``
-       | ``-DSNIPPET=<name_of_snippet>`` (``-Dimage-name_SNIPPET`` for images)
+     - Select one of the :ref:`zephyr:snippets` to add to the application firmware during the build.
+     - | ``-S <name_of_snippet>`` (applies the snippet to all images)
+       | ``-DSNIPPET=<name_of_snippet>`` (``-D<image_name>_SNIPPET=<name_of_snippet>`` for images)
    * - :makevar:`PM_STATIC_YML_FILE`
      - | Select a :ref:`static configuration file <ug_pm_static>` for the Partition Manager script.
        | For applications that *do not* use multiple images, the static configuration can be selected with :makevar:`FILE_SUFFIX` (see above).

--- a/doc/nrf/device_guides/nrf70/fw_patches_ext_flash.rst
+++ b/doc/nrf/device_guides/nrf70/fw_patches_ext_flash.rst
@@ -135,14 +135,14 @@ With west
 
 .. code-block:: console
 
-    west build -p -b nrf5340dk/nrf5340/cpuapp -S nrf70-fw-patch-ext-flash samples/wifi/shell -- -DSHIELD=nrf7002ek
+    west build -p -b nrf5340dk/nrf5340/cpuapp samples/wifi/shell -- -Dnrf_wifi_shell_SHIELD=nrf7002ek -Dnrf_wifi_shell_SNIPPET="nrf70-fw-patch-ext-flash"
 
 With CMake
 ^^^^^^^^^^
 
 .. code-block:: console
 
-    cmake -GNinja -Bbuild -DBOARD=nrf5340dk/nrf5340/cpuapp -DSHIELD=nrf7002ek -DSNIPPET=nrf70-fw-patch-ext-flash samples/wifi/shell
+    cmake -GNinja -Bbuild -DBOARD=nrf5340dk/nrf5340/cpuapp -Dnrf_wifi_shell_SHIELD=nrf7002ek -Dnrf_wifi_shell_SNIPPET="nrf70-fw-patch-ext-flash" samples/wifi/shell
     ninja -C build
 
 For example, to build the :ref:`wifi_shell_sample` sample for the nRF5340 DK with the :kconfig:option:`CONFIG_PARTITION_MANAGER_ENABLED` option enabled, run the following commands:
@@ -152,14 +152,14 @@ With west
 
 .. code-block:: console
 
-    west build -p -b nrf5340dk/nrf5340/cpuapp samples/wifi/shell -- -DSHIELD=nrf7002ek -DCONFIG_PARTITION_MANAGER_ENABLED=y -DCONFIG_NRF_WIFI_PATCHES_EXT_FLASH_STORE=y
+    west build -p -b nrf5340dk/nrf5340/cpuapp samples/wifi/shell -- -Dnrf_wifi_shell_SHIELD=nrf7002ek -DCONFIG_PARTITION_MANAGER_ENABLED=y -DCONFIG_NRF_WIFI_PATCHES_EXT_FLASH_STORE=y
 
 With CMake
 ^^^^^^^^^^
 
 .. code-block:: console
 
-    cmake -GNinja -Bbuild -DBOARD=nrf5340dk/nrf5340/cpuapp -DSHIELD=nrf7002ek -DCONFIG_PARTITION_MANAGER_ENABLED=y -DCONFIG_NRF_WIFI_PATCHES_EXT_FLASH_STORE=y samples/wifi/shell
+    cmake -GNinja -Bbuild -DBOARD=nrf5340dk/nrf5340/cpuapp -Dnrf_wifi_shell_SHIELD=nrf7002ek -DCONFIG_PARTITION_MANAGER_ENABLED=y -DCONFIG_NRF_WIFI_PATCHES_EXT_FLASH_STORE=y samples/wifi/shell
     ninja -C build
 
 Programming

--- a/doc/nrf/device_guides/nrf91/nrf91_snippet.rst
+++ b/doc/nrf/device_guides/nrf91/nrf91_snippet.rst
@@ -35,7 +35,7 @@ To enable modem traces with the flash backend, use the following command:
 .. parsed-literal::
    :class: highlight
 
-   west build --board *board target* -S nrf91-modem-trace-ext-flash
+   west build --board *board target* -- -D<image_name>_SNIPPET="nrf91-modem-trace-ext-flash"
 
 .. _nrf91_modem_trace_uart_snippet:
 
@@ -55,7 +55,11 @@ To add the modem trace UART snippet when building an application with west, use 
 
 .. code-block:: console
 
-   west build --board <your_board> -S nrf91-modem-trace-uart
+   west build --board <your_board> -- -D<image_name>_SNIPPET="nrf91-modem-trace-uart"
+
+.. note::
+   With Sysbuild, using the ``west build -S`` option applies the snippet to all images.
+   Therefore, use the CMake argument instead, specifying the application image.
 
 With CMake
 ==========
@@ -64,9 +68,9 @@ To add the modem trace UART snippet when building an application with CMake, add
 
 .. code-block:: console
 
-   -DSNIPPET="nrf91-modem-trace-uart" [...]
+   -D<image_name>_SNIPPET="nrf91-modem-trace-uart" [...]
 
-To build with the |nRFVSC|, specify ``-DSNIPPET="nrf91-modem-trace-uart" [...]`` in the **Extra CMake arguments** field.
+To build with the |nRFVSC|, specify ``-D<image_name>_SNIPPET="nrf91-modem-trace-uart" [...]`` in the **Extra CMake arguments** field.
 
 See :ref:`cmake_options` for more details.
 

--- a/doc/nrf/protocols/wifi/debugging.rst
+++ b/doc/nrf/protocols/wifi/debugging.rst
@@ -28,14 +28,14 @@ With west
 
 .. code-block:: console
 
-    west build -p -b nrf7002dk/nrf5340/cpuapp -S nrf70-debug samples/wifi/shell
+    west build -p -b nrf7002dk/nrf5340/cpuapp samples/wifi/shell -- -Dnrf_wifi_shell_SNIPPET="nrf70-debug"
 
 With CMake
 ----------
 
 .. code-block:: console
 
-    cmake -GNinja -Bbuild -DBOARD=nrf7002dk/nrf5340/cpuapp -DSNIPPET=nrf70-debug samples/wifi/shell
+    cmake -GNinja -Bbuild -DBOARD=nrf7002dk/nrf5340/cpuapp -Dnrf_wifi_shell_SNIPPET="nrf70-debug" samples/wifi/shell
     ninja -C build
 
 Statistics

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -43,7 +43,11 @@ Build and configuration system
   * Documentation section about the :ref:`file suffix feature from Zephyr <app_build_file_suffixes>` with a related information in the :ref:`migration guide <migration_2.7_recommended>`.
   * Documentation section about :ref:`app_build_snippets`.
 
-* Updated all board targets for Zephyr's :ref:`Hardware Model v2 <zephyr:hw_model_v2>`, with additional information added on the :ref:`app_boards_names` page.
+* Updated:
+
+  * All board targets for Zephyr's :ref:`Hardware Model v2 <zephyr:hw_model_v2>`, with additional information added on the :ref:`app_boards_names` page.
+  * The use of :ref:`cmake_options` to specify the image when building with :ref:`configuration_system_overview_sysbuild`.
+    If not specified, the option will be added to all images.
 
 Working with nRF91 Series
 =========================

--- a/samples/cellular/modem_shell/README.rst
+++ b/samples/cellular/modem_shell/README.rst
@@ -1420,7 +1420,7 @@ For example:
 .. parsed-literal::
    :class: highlight
 
-   west build -p -b *board_target* -S nrf91-modem-trace-ext-flash
+   west build -p -b *board_target* -- -Dmodem_shell_SNIPPET="nrf91-modem-trace-ext-flash"
 
 |board_target|
 

--- a/samples/net/http_server/README.rst
+++ b/samples/net/http_server/README.rst
@@ -328,11 +328,11 @@ Troubleshooting
 ***************
 
 If you have issues with connectivity on nRF91 Series devices, see the `Cellular Monitor`_ documentation to learn how to capture modem traces to debug network traffic in Wireshark.
-Modem traces can be enabled by providing a snippet with the west build command using the ``-S`` argument as shown in the following example for nRF9161 DK:
+Modem traces can be enabled by providing a snippet with the west build command as shown in the following example for nRF9161 DK:
 
 .. code-block:: console
 
-   west build -p -b nrf9161dk/nrf9161/ns -S nrf91-modem-trace-uart
+   west build -p -b nrf9161dk/nrf9161/ns -- -Dhttp_server_SNIPPET="nrf91-modem-trace-uart"
 
 Dependencies
 ************


### PR DESCRIPTION
With SysBuild, using the ``west build -S`` option applies the snippet to all images. We therefore use the CMake argument instead, specifying the application image.

There are probably more places this needs an update in user guides etc. @divipillai Do you have an overview?