### PR TITLE
bluetooth: controller: Move LE Path Loss Monitoring to separate KConfig

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -515,6 +515,14 @@ config BT_CTLR_SDC_PERIODIC_SYNC_RSP_TX_BUFFER_COUNT
 
 endif
 
+config BT_CTLR_SDC_LE_PATH_LOSS_MONITORING
+	bool "LE Path Loss Monitoring Feature"
+	depends on BT_CTLR_LE_POWER_CONTROL
+	select EXPERIMENTAL
+	help
+	  Enable support for LE Path Loss Monitoring feature that is defined in the
+	  Bluetooth Core specification, Version 5.4 | Vol 6, Part B, Section 4.6.32.
+
 config BT_CTLR_SDC_SILENCE_UNEXPECTED_MSG_TYPE
 	bool
 	help

--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -539,12 +539,15 @@ void hci_internal_supported_commands(sdc_hci_ip_supported_commands_t *cmds)
 	cmds->hci_le_enhanced_read_transmit_power_level = 1;
 	cmds->hci_le_read_remote_transmit_power_level = 1;
 	cmds->hci_le_set_transmit_power_reporting_enable = 1;
-	cmds->hci_le_set_path_loss_reporting_parameters = 1;
-	cmds->hci_le_set_path_loss_reporting_enable = 1;
 	/* NOTE: The DTM commands are *not* supported by the SoftDevice
 	 * controller. See doc/nrf/known_issues.rst.
 	 */
 	cmds->hci_le_transmitter_test_v4 = 1;
+#endif
+
+#if defined(CONFIG_BT_CTLR_SDC_LE_PATH_LOSS_MONITORING)
+	cmds->hci_le_set_path_loss_reporting_parameters = 1;
+	cmds->hci_le_set_path_loss_reporting_enable = 1;
 #endif
 
 #if defined(CONFIG_BT_CTLR_LE_POWER_CONTROL) || defined(CONFIG_BT_CTLR_ADV_EXT)
@@ -744,6 +747,9 @@ void hci_internal_le_supported_features(
 #if defined(CONFIG_BT_CTLR_LE_POWER_CONTROL)
 	features->params.le_power_control_request = 1;
 	features->params.le_power_change_indication = 1;
+#endif
+
+#if defined(CONFIG_BT_CTLR_SDC_LE_PATH_LOSS_MONITORING)
 	features->params.le_path_loss_monitoring = 1;
 #endif
 
@@ -1304,7 +1310,9 @@ static uint8_t le_controller_cmd_put(uint8_t const * const cmd,
 			sizeof(sdc_hci_cmd_le_set_transmit_power_reporting_enable_return_t);
 		return sdc_hci_cmd_le_set_transmit_power_reporting_enable((void *)cmd_params,
 									  (void *)event_out_params);
+#endif
 
+#if defined(CONFIG_BT_CTLR_SDC_LE_PATH_LOSS_MONITORING)
 	case SDC_HCI_OPCODE_CMD_LE_SET_PATH_LOSS_REPORTING_PARAMS:
 		*param_length_out += sizeof(sdc_hci_cmd_le_set_path_loss_reporting_params_return_t);
 		return sdc_hci_cmd_le_set_path_loss_reporting_params((void *)cmd_params,


### PR DESCRIPTION
Move the feature to a temporary KConfig until it has been marked as supported by the SoftDevice Controller.