### PR TITLE
samples/nrf5340/extxip_smp_svr: no sysbuild for twister

### DIFF
--- a/samples/nrf5340/extxip_smp_svr/sample.yaml
+++ b/samples/nrf5340/extxip_smp_svr/sample.yaml
@@ -10,6 +10,7 @@ common:
       - "<inf> smp_sample: build time:"
 tests:
   sample.mcumgr.smp_svr.ext_xip:
+    sysbuild: false
     platform_allow:
       - nrf5340dk/nrf5340/cpuapp
       - thingy53/nrf5340/cpuapp


### PR DESCRIPTION
Added sysbuild: false to the testcase in sample.yaml as the sample is expected to build using childimage.