### PR TITLE
doc/nrf/../nrf5340_qspi_xip: note on childimage reqirement

### DIFF
--- a/doc/nrf/device_guides/nrf53/qspi_xip_guide_nrf5340.rst
+++ b/doc/nrf/device_guides/nrf53/qspi_xip_guide_nrf5340.rst
@@ -279,6 +279,11 @@ Similarly, it is possible to relocate certain libraries, for example:
    zephyr_code_relocate(LIBRARY subsys__mgmt__mcumgr__mgmt LOCATION EXTFLASH_TEXT NOCOPY)
    zephyr_code_relocate(LIBRARY subsys__mgmt__mcumgr__mgmt LOCATION RAM_DATA)
 
+Building the project
+********************
+
+You must use child image when building your project, as XIP QSPI does not currently support sysbuild.
+
 Flashing the project
 ********************
 

--- a/samples/nrf5340/extxip_smp_svr/README.rst
+++ b/samples/nrf5340/extxip_smp_svr/README.rst
@@ -43,6 +43,12 @@ Building and running
 
 .. |sample path| replace:: :file:`samples/nrf5340/extxip_smp_svr`
 .. include:: /includes/build_and_run.txt
+Because sysbuild is currently not supported, you must add the ``--no-sysbuild`` argument when building the sample:
+
+.. parsed-literal::
+   :class: highlight
+
+   west build -b *board_target* --no-sysbuild
 
 The |NCS| build system generates all essential binaries, including the application for internal and external QSPI flash, the networking stack, and the MCUboot.
 The build process involves signing all the application binaries except for MCUboot which does not require signing in this configuration.


### PR DESCRIPTION
Clarified that childimage must be used.