### PR TITLE
doc: redistributing: use latest tag for Golioth

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -74,9 +74,9 @@
 .. _`ANT entry in the manifest`: https://github.com/nrfconnect/sdk-nrf/blob/20f40501f69bc9bfd2b321704917da1769411936/west.yml#L182-L187
 
 .. _`Golioth Firmware SDK`: https://github.com/golioth/golioth-firmware-sdk
-.. _`Golioth module.yml`: https://github.com/golioth/golioth-firmware-sdk/blob/v0.10.0/zephyr/module.yml
-.. _`Golioth west-ncs.yml`: https://github.com/golioth/golioth-firmware-sdk/blob/v0.10.0/west-ncs.yml
-.. _`Golioth Firmware SDK NCS doc`: https://github.com/golioth/golioth-firmware-sdk/tree/main/examples/zephyr#using-with-nordics-nrf-connect-sdk
+.. _`Golioth module.yml`: https://github.com/golioth/golioth-firmware-sdk/blob/v0.13.1/zephyr/module.yml
+.. _`Golioth west-ncs.yml`: https://github.com/golioth/golioth-firmware-sdk/blob/v0.13.1/west-ncs.yml
+.. _`Golioth Firmware SDK NCS doc`: https://github.com/golioth/golioth-firmware-sdk/tree/v0.13.1/examples/zephyr#using-with-nordics-nrf-connect-sdk
 
 .. _`nrfx`: https://github.com/NordicSemiconductor/nrfx/
 .. _`Changelog for nrfx 2.2.0`: https://github.com/NordicSemiconductor/nrfx/blob/master/CHANGELOG.md#user-content-220---2020-04-28


### PR DESCRIPTION
Updated the links to the Golioth Zephyr SDK to use the latest v0.13.1 release.

This is a new PR that implements the same changes that were approved in #12551 (the difference is the version numbers have been updated to latest).

That PR was approved more than once but never merged. If there is anything I can do to help get this across the finish line, please let me know.

Approvers of the previous PR:
- @gregersrygg 
- @nordicjm 
- @peknis 
- @wiba-nordic