### PR TITLE
applications: nrf5340_audio: Fix CIS bidir mic return issue

### DIFF
--- a/applications/nrf5340_audio/src/audio/audio_datapath.c
+++ b/applications/nrf5340_audio/src/audio/audio_datapath.c
@@ -1041,6 +1041,16 @@ int audio_datapath_init(void)
 	ctrl_blk.drift_comp.enabled = true;
 	ctrl_blk.pres_comp.enabled = true;
 
+	if (IS_ENABLED(CONFIG_STREAM_BIDIRECTIONAL) && (CONFIG_AUDIO_DEV == GATEWAY)) {
+		/* Disable presentation compensation feature for microphone return on gateway,
+		 * since there's only one stream output from gateway for now, so no need to
+		 * qhave presentation compensation.
+		 */
+		ctrl_blk.pres_comp.enabled = false;
+	} else {
+		ctrl_blk.pres_comp.enabled = true;
+	}
+
 	ctrl_blk.pres_comp.pres_delay_us = CONFIG_BT_AUDIO_PRESENTATION_DELAY_US;
 
 	return 0;


### PR DESCRIPTION
Disable pres-comp in CIS bidir gateway since there's only one mic stream in CIS gateway, and also pres-comp only defined in unicast server side.
OCT-3040
Signed-off-by: Jui-Chou Chung <jui-chou.chung@nordicsemi.no>