### PR TITLE
applications: Fixed writing the bridged device node label

### DIFF
--- a/applications/matter_bridge/src/ble_providers/ble_environmental_data_provider.cpp
+++ b/applications/matter_bridge/src/ble_providers/ble_environmental_data_provider.cpp
@@ -96,7 +96,20 @@ void BleEnvironmentalDataProvider::NotifyUpdateState(chip::ClusterId clusterId, 
 CHIP_ERROR BleEnvironmentalDataProvider::UpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId,
 						     uint8_t *)
 {
-	return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+	if (clusterId != Clusters::BridgedDeviceBasicInformation::Id) {
+		return CHIP_ERROR_INVALID_ARGUMENT;
+	}
+
+	switch (attributeId) {
+	case Clusters::BridgedDeviceBasicInformation::Attributes::NodeLabel::Id:
+		/* Node label is just updated locally and there is no need to propagate the information to the end
+		 * device. */
+		break;
+	default:
+		return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+	}
+
+	return CHIP_NO_ERROR;
 }
 
 int BleEnvironmentalDataProvider::ParseDiscoveredData(bt_gatt_dm *discoveredData)

--- a/applications/matter_bridge/src/ble_providers/ble_lbs_data_provider.cpp
+++ b/applications/matter_bridge/src/ble_providers/ble_lbs_data_provider.cpp
@@ -28,7 +28,8 @@ static const bt_uuid *sUuidButton = BT_UUID_LBS_BUTTON;
 static const bt_uuid *sUuidCcc = BT_UUID_GATT_CCC;
 
 #ifdef CONFIG_BRIDGE_ONOFF_LIGHT_SWITCH_BRIDGED_DEVICE
-void ProcessCommand(const EmberBindingTableEntry &aBinding, OperationalDeviceProxy *aDevice, Nrf::Matter::BindingHandler::BindingData &aData)
+void ProcessCommand(const EmberBindingTableEntry &aBinding, OperationalDeviceProxy *aDevice,
+		    Nrf::Matter::BindingHandler::BindingData &aData)
 {
 	CHIP_ERROR ret = CHIP_NO_ERROR;
 
@@ -142,7 +143,7 @@ void BleLBSDataProvider::GattWriteCallback(bt_conn *conn, uint8_t err, bt_gatt_w
 
 CHIP_ERROR BleLBSDataProvider::UpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer)
 {
-	if (clusterId != Clusters::OnOff::Id) {
+	if (clusterId != Clusters::OnOff::Id && clusterId != Clusters::BridgedDeviceBasicInformation::Id) {
 		return CHIP_ERROR_INVALID_ARGUMENT;
 	}
 
@@ -170,6 +171,10 @@ CHIP_ERROR BleLBSDataProvider::UpdateState(chip::ClusterId clusterId, chip::Attr
 
 		return CHIP_NO_ERROR;
 	}
+	case Clusters::BridgedDeviceBasicInformation::Attributes::NodeLabel::Id:
+		/* Node label is just updated locally and there is no need to propagate the information to the end
+		 * device. */
+		break;
 	default:
 		return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 	}

--- a/applications/matter_bridge/src/bridged_device_types/generic_switch.h
+++ b/applications/matter_bridge/src/bridged_device_types/generic_switch.h
@@ -12,17 +12,25 @@ class GenericSwitchDevice : public Nrf::MatterBridgedDevice {
 public:
 	GenericSwitchDevice(const char *nodeLabel);
 
-	uint16_t GetDeviceType() const override
-	{
-		return Nrf::MatterBridgedDevice::DeviceType::GenericSwitch;
-	}
+	uint16_t GetDeviceType() const override { return Nrf::MatterBridgedDevice::DeviceType::GenericSwitch; }
 	CHIP_ERROR HandleRead(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer,
 			      uint16_t maxReadLength) override;
 	CHIP_ERROR HandleAttributeChange(chip::ClusterId clusterId, chip::AttributeId attributeId, void *data,
 					 size_t dataSize) override;
-	CHIP_ERROR HandleWrite(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer) override
+	CHIP_ERROR HandleWrite(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer,
+			       size_t size) override
 	{
-		return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+		if (clusterId != chip::app::Clusters::BridgedDeviceBasicInformation::Id) {
+			return CHIP_ERROR_INVALID_ARGUMENT;
+		}
+
+		switch (attributeId) {
+		case chip::app::Clusters::BridgedDeviceBasicInformation::Attributes::NodeLabel::Id:
+			return HandleWriteDeviceBasicInformation(clusterId, attributeId, buffer, size);
+		default:
+			return CHIP_ERROR_INVALID_ARGUMENT;
+		}
+		return CHIP_NO_ERROR;
 	};
 
 private:

--- a/applications/matter_bridge/src/bridged_device_types/humidity_sensor.h
+++ b/applications/matter_bridge/src/bridged_device_types/humidity_sensor.h
@@ -21,9 +21,20 @@ public:
 			      uint16_t maxReadLength) override;
 	CHIP_ERROR HandleReadRelativeHumidityMeasurement(chip::AttributeId attributeId, uint8_t *buffer,
 							 uint16_t maxReadLength);
-	CHIP_ERROR HandleWrite(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer) override
+	CHIP_ERROR HandleWrite(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer,
+			       size_t size) override
 	{
-		return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+		if (clusterId != chip::app::Clusters::BridgedDeviceBasicInformation::Id) {
+			return CHIP_ERROR_INVALID_ARGUMENT;
+		}
+
+		switch (attributeId) {
+		case chip::app::Clusters::BridgedDeviceBasicInformation::Attributes::NodeLabel::Id:
+			return HandleWriteDeviceBasicInformation(clusterId, attributeId, buffer, size);
+		default:
+			return CHIP_ERROR_INVALID_ARGUMENT;
+		}
+		return CHIP_NO_ERROR;
 	}
 	CHIP_ERROR HandleAttributeChange(chip::ClusterId clusterId, chip::AttributeId attributeId, void *data,
 					 size_t dataSize) override;

--- a/applications/matter_bridge/src/bridged_device_types/onoff_light.cpp
+++ b/applications/matter_bridge/src/bridged_device_types/onoff_light.cpp
@@ -34,8 +34,10 @@ DECLARE_DYNAMIC_ATTRIBUTE(Clusters::OnOff::Attributes::OnOff::Id, BOOLEAN, 1, 0)
 	DECLARE_DYNAMIC_ATTRIBUTE(Clusters::OnOff::Attributes::FeatureMap::Id, BITMAP32, 4, 0),
 	DECLARE_DYNAMIC_ATTRIBUTE(Clusters::OnOff::Attributes::GlobalSceneControl::Id, BOOLEAN, 1, 0),
 	DECLARE_DYNAMIC_ATTRIBUTE(Clusters::OnOff::Attributes::OnTime::Id, INT16U, 2, ZAP_ATTRIBUTE_MASK(WRITABLE)),
-	DECLARE_DYNAMIC_ATTRIBUTE(Clusters::OnOff::Attributes::OffWaitTime::Id, INT16U, 2, ZAP_ATTRIBUTE_MASK(WRITABLE)),
-	DECLARE_DYNAMIC_ATTRIBUTE(Clusters::OnOff::Attributes::StartUpOnOff::Id, ENUM8, 1, ZAP_ATTRIBUTE_MASK(WRITABLE)),
+	DECLARE_DYNAMIC_ATTRIBUTE(Clusters::OnOff::Attributes::OffWaitTime::Id, INT16U, 2,
+				  ZAP_ATTRIBUTE_MASK(WRITABLE)),
+	DECLARE_DYNAMIC_ATTRIBUTE(Clusters::OnOff::Attributes::StartUpOnOff::Id, ENUM8, 1,
+				  ZAP_ATTRIBUTE_MASK(WRITABLE)),
 	DECLARE_DYNAMIC_ATTRIBUTE_LIST_END();
 
 constexpr CommandId onOffIncomingCommands[] = {
@@ -167,9 +169,9 @@ CHIP_ERROR OnOffLightDevice::HandleReadGroups(AttributeId attributeId, uint8_t *
 	}
 }
 
-CHIP_ERROR OnOffLightDevice::HandleWrite(ClusterId clusterId, AttributeId attributeId, uint8_t *buffer)
+CHIP_ERROR OnOffLightDevice::HandleWrite(ClusterId clusterId, AttributeId attributeId, uint8_t *buffer, size_t size)
 {
-	if (clusterId != Clusters::OnOff::Id) {
+	if (clusterId != Clusters::OnOff::Id && clusterId != Clusters::BridgedDeviceBasicInformation::Id) {
 		return CHIP_ERROR_INVALID_ARGUMENT;
 	}
 
@@ -186,6 +188,8 @@ CHIP_ERROR OnOffLightDevice::HandleWrite(ClusterId clusterId, AttributeId attrib
 	case Clusters::OnOff::Attributes::StartUpOnOff::Id:
 		mStartUpOnOff = static_cast<Clusters::OnOff::StartUpOnOffEnum>(*buffer);
 		break;
+	case Clusters::BridgedDeviceBasicInformation::Attributes::NodeLabel::Id:
+		return HandleWriteDeviceBasicInformation(clusterId, attributeId, buffer, size);
 	default:
 		return CHIP_ERROR_INVALID_ARGUMENT;
 	}

--- a/applications/matter_bridge/src/bridged_device_types/onoff_light.h
+++ b/applications/matter_bridge/src/bridged_device_types/onoff_light.h
@@ -20,7 +20,7 @@ public:
 			      uint16_t maxReadLength) override;
 	CHIP_ERROR HandleReadOnOff(chip::AttributeId attributeId, uint8_t *buffer, uint16_t maxReadLength);
 	CHIP_ERROR HandleReadGroups(chip::AttributeId attributeId, uint8_t *buffer, uint16_t maxReadLength);
-	CHIP_ERROR HandleWrite(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer) override;
+	CHIP_ERROR HandleWrite(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer, size_t size) override;
 	CHIP_ERROR HandleAttributeChange(chip::ClusterId clusterId, chip::AttributeId attributeId, void *data,
 					 size_t dataSize) override;
 

--- a/applications/matter_bridge/src/bridged_device_types/onoff_light_switch.h
+++ b/applications/matter_bridge/src/bridged_device_types/onoff_light_switch.h
@@ -17,9 +17,20 @@ public:
 			      uint16_t maxReadLength) override;
 	CHIP_ERROR HandleReadOnOff(chip::AttributeId attributeId, uint8_t *buffer, uint16_t maxReadLength);
 	CHIP_ERROR HandleReadBinding(chip::AttributeId attributeId, uint8_t *buffer, uint16_t maxReadLength);
-	CHIP_ERROR HandleWrite(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer) override
+	CHIP_ERROR HandleWrite(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer,
+			       size_t size) override
 	{
-		return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+		if (clusterId != chip::app::Clusters::BridgedDeviceBasicInformation::Id) {
+			return CHIP_ERROR_INVALID_ARGUMENT;
+		}
+
+		switch (attributeId) {
+		case chip::app::Clusters::BridgedDeviceBasicInformation::Attributes::NodeLabel::Id:
+			return HandleWriteDeviceBasicInformation(clusterId, attributeId, buffer, size);
+		default:
+			return CHIP_ERROR_INVALID_ARGUMENT;
+		}
+		return CHIP_NO_ERROR;
 	}
 	CHIP_ERROR HandleAttributeChange(chip::ClusterId clusterId, chip::AttributeId attributeId, void *data,
 					 size_t dataSize) override

--- a/applications/matter_bridge/src/bridged_device_types/temperature_sensor.h
+++ b/applications/matter_bridge/src/bridged_device_types/temperature_sensor.h
@@ -21,9 +21,20 @@ public:
 			      uint16_t maxReadLength) override;
 	CHIP_ERROR HandleReadTemperatureMeasurement(chip::AttributeId attributeId, uint8_t *buffer,
 						    uint16_t maxReadLength);
-	CHIP_ERROR HandleWrite(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer) override
+	CHIP_ERROR HandleWrite(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer,
+			       size_t size) override
 	{
-		return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+		if (clusterId != chip::app::Clusters::BridgedDeviceBasicInformation::Id) {
+			return CHIP_ERROR_INVALID_ARGUMENT;
+		}
+
+		switch (attributeId) {
+		case chip::app::Clusters::BridgedDeviceBasicInformation::Attributes::NodeLabel::Id:
+			return HandleWriteDeviceBasicInformation(clusterId, attributeId, buffer, size);
+		default:
+			return CHIP_ERROR_INVALID_ARGUMENT;
+		}
+		return CHIP_NO_ERROR;
 	}
 	CHIP_ERROR HandleAttributeChange(chip::ClusterId clusterId, chip::AttributeId attributeId, void *data,
 					 size_t dataSize) override;

--- a/applications/matter_bridge/src/simulated_providers/simulated_generic_switch_data_provider.cpp
+++ b/applications/matter_bridge/src/simulated_providers/simulated_generic_switch_data_provider.cpp
@@ -33,7 +33,7 @@ void SimulatedGenericSwitchDataProvider::NotifyUpdateState(chip::ClusterId clust
 CHIP_ERROR SimulatedGenericSwitchDataProvider::UpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId,
 							   uint8_t *buffer)
 {
-	if (clusterId != Clusters::Switch::Id) {
+	if (clusterId != Clusters::Switch::Id && clusterId != Clusters::BridgedDeviceBasicInformation::Id) {
 		return CHIP_ERROR_INVALID_ARGUMENT;
 	}
 
@@ -46,6 +46,10 @@ CHIP_ERROR SimulatedGenericSwitchDataProvider::UpdateState(chip::ClusterId clust
 		NotifyUpdateState(clusterId, attributeId, &mCurrentSwitchPosition, sizeof(mCurrentSwitchPosition));
 		return CHIP_NO_ERROR;
 	}
+	case Clusters::BridgedDeviceBasicInformation::Attributes::NodeLabel::Id:
+		/* Node label is just updated locally and there is no need to propagate the information to the end
+		 * device. */
+		break;
 	default:
 		return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 	}

--- a/applications/matter_bridge/src/simulated_providers/simulated_humidity_sensor_data_provider.cpp
+++ b/applications/matter_bridge/src/simulated_providers/simulated_humidity_sensor_data_provider.cpp
@@ -34,7 +34,20 @@ void SimulatedHumiditySensorDataProvider::NotifyUpdateState(chip::ClusterId clus
 CHIP_ERROR SimulatedHumiditySensorDataProvider::UpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId,
 							    uint8_t *buffer)
 {
-	return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+	if (clusterId != Clusters::BridgedDeviceBasicInformation::Id) {
+		return CHIP_ERROR_INVALID_ARGUMENT;
+	}
+
+	switch (attributeId) {
+	case Clusters::BridgedDeviceBasicInformation::Attributes::NodeLabel::Id:
+		/* Node label is just updated locally and there is no need to propagate the information to the end
+		 * device. */
+		break;
+	default:
+		return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+	}
+
+	return CHIP_NO_ERROR;
 }
 
 void SimulatedHumiditySensorDataProvider::TimerTimeoutCallback(k_timer *timer)

--- a/applications/matter_bridge/src/simulated_providers/simulated_onoff_light_data_provider.cpp
+++ b/applications/matter_bridge/src/simulated_providers/simulated_onoff_light_data_provider.cpp
@@ -35,7 +35,7 @@ void SimulatedOnOffLightDataProvider::NotifyUpdateState(chip::ClusterId clusterI
 CHIP_ERROR SimulatedOnOffLightDataProvider::UpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId,
 							uint8_t *buffer)
 {
-	if (clusterId != Clusters::OnOff::Id) {
+	if (clusterId != Clusters::OnOff::Id && clusterId != Clusters::BridgedDeviceBasicInformation::Id) {
 		return CHIP_ERROR_INVALID_ARGUMENT;
 	}
 
@@ -48,6 +48,10 @@ CHIP_ERROR SimulatedOnOffLightDataProvider::UpdateState(chip::ClusterId clusterI
 		NotifyUpdateState(clusterId, attributeId, &mOnOff, sizeof(mOnOff));
 		return CHIP_NO_ERROR;
 	}
+	case Clusters::BridgedDeviceBasicInformation::Attributes::NodeLabel::Id:
+		/* Node label is just updated locally and there is no need to propagate the information to the end
+		 * device. */
+		break;
 	default:
 		return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 	}

--- a/applications/matter_bridge/src/simulated_providers/simulated_temperature_sensor_data_provider.cpp
+++ b/applications/matter_bridge/src/simulated_providers/simulated_temperature_sensor_data_provider.cpp
@@ -34,7 +34,20 @@ void SimulatedTemperatureSensorDataProvider::NotifyUpdateState(chip::ClusterId c
 CHIP_ERROR SimulatedTemperatureSensorDataProvider::UpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId,
 							       uint8_t *buffer)
 {
-	return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+	if (clusterId != Clusters::BridgedDeviceBasicInformation::Id) {
+		return CHIP_ERROR_INVALID_ARGUMENT;
+	}
+
+	switch (attributeId) {
+	case Clusters::BridgedDeviceBasicInformation::Attributes::NodeLabel::Id:
+		/* Node label is just updated locally and there is no need to propagate the information to the end
+		 * device. */
+		break;
+	default:
+		return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+	}
+
+	return CHIP_NO_ERROR;
 }
 
 void SimulatedTemperatureSensorDataProvider::TimerTimeoutCallback(k_timer *timer)

--- a/samples/matter/common/src/bridge/matter_bridged_device.cpp
+++ b/samples/matter/common/src/bridge/matter_bridged_device.cpp
@@ -11,7 +11,8 @@
 using namespace ::chip;
 using namespace ::chip::app;
 
-namespace Nrf {
+namespace Nrf
+{
 
 CHIP_ERROR MatterBridgedDevice::CopyAttribute(const void *attribute, size_t attributeSize, void *buffer,
 					      uint16_t maxBufferSize)
@@ -25,6 +26,13 @@ CHIP_ERROR MatterBridgedDevice::CopyAttribute(const void *attribute, size_t attr
 	return CHIP_NO_ERROR;
 }
 
+void MatterBridgedDevice::SetNodeLabel(void *data, size_t size)
+{
+	/* Clean the buffer and fill it with the new data. */
+	memset(mNodeLabel, 0, sizeof(mNodeLabel));
+	memcpy(mNodeLabel, data, size);
+}
+
 CHIP_ERROR MatterBridgedDevice::HandleWriteDeviceBasicInformation(chip::ClusterId clusterId,
 								  chip::AttributeId attributeId, void *data,
 								  size_t dataSize)
@@ -35,6 +43,10 @@ CHIP_ERROR MatterBridgedDevice::HandleWriteDeviceBasicInformation(chip::ClusterI
 			SetIsReachable(*reinterpret_cast<bool *>(data));
 			return CHIP_NO_ERROR;
 		}
+	case Clusters::BridgedDeviceBasicInformation::Attributes::NodeLabel::Id:
+		SetNodeLabel(data, dataSize);
+		return CHIP_NO_ERROR;
+
 	default:
 		return CHIP_ERROR_INVALID_ARGUMENT;
 	}

--- a/samples/matter/common/src/bridge/matter_bridged_device.h
+++ b/samples/matter/common/src/bridge/matter_bridged_device.h
@@ -11,7 +11,8 @@
 #include <app/clusters/identify-server/identify-server.h>
 #include <app/util/attribute-storage.h>
 
-namespace Nrf {
+namespace Nrf
+{
 
 /* Definitions of  helper macros that are used across all bridged device types to create common mandatory clusters in a
  * consistent way. */
@@ -19,13 +20,16 @@ namespace Nrf {
 #define DESCRIPTOR_CLUSTER_ATTRIBUTES(descriptorAttrs)                                                                 \
 	DECLARE_DYNAMIC_ATTRIBUTE_LIST_BEGIN(descriptorAttrs)                                                          \
 	DECLARE_DYNAMIC_ATTRIBUTE(chip::app::Clusters::Descriptor::Attributes::DeviceTypeList::Id, ARRAY,              \
-				  Nrf::MatterBridgedDevice::kDescriptorAttributeArraySize, 0), /* device list */            \
+				  Nrf::MatterBridgedDevice::kDescriptorAttributeArraySize, 0), /* device list */       \
 		DECLARE_DYNAMIC_ATTRIBUTE(chip::app::Clusters::Descriptor::Attributes::ServerList::Id, ARRAY,          \
-					  Nrf::MatterBridgedDevice::kDescriptorAttributeArraySize, 0), /* server list */    \
+					  Nrf::MatterBridgedDevice::kDescriptorAttributeArraySize, 0), /* server list  \
+													*/             \
 		DECLARE_DYNAMIC_ATTRIBUTE(chip::app::Clusters::Descriptor::Attributes::ClientList::Id, ARRAY,          \
-					  Nrf::MatterBridgedDevice::kDescriptorAttributeArraySize, 0), /* client list */    \
+					  Nrf::MatterBridgedDevice::kDescriptorAttributeArraySize, 0), /* client list  \
+													*/             \
 		DECLARE_DYNAMIC_ATTRIBUTE(chip::app::Clusters::Descriptor::Attributes::PartsList::Id, ARRAY,           \
-					  Nrf::MatterBridgedDevice::kDescriptorAttributeArraySize, 0), /* parts list */     \
+					  Nrf::MatterBridgedDevice::kDescriptorAttributeArraySize, 0), /* parts list   \
+													*/             \
 		DECLARE_DYNAMIC_ATTRIBUTE(chip::app::Clusters::Descriptor::Attributes::FeatureMap::Id, BITMAP32, 4,    \
 					  0), /* feature map */                                                        \
 		DECLARE_DYNAMIC_ATTRIBUTE_LIST_END();
@@ -34,7 +38,8 @@ namespace Nrf {
 #define BRIDGED_DEVICE_BASIC_INFORMATION_CLUSTER_ATTRIBUTES(bridgedDeviceBasicAttrs)                                   \
 	DECLARE_DYNAMIC_ATTRIBUTE_LIST_BEGIN(bridgedDeviceBasicAttrs)                                                  \
 	DECLARE_DYNAMIC_ATTRIBUTE(chip::app::Clusters::BridgedDeviceBasicInformation::Attributes::NodeLabel::Id,       \
-				  CHAR_STRING, Nrf::MatterBridgedDevice::kNodeLabelSize, 0), /* NodeLabel */                \
+				  CHAR_STRING, Nrf::MatterBridgedDevice::kNodeLabelSize,                               \
+				  ZAP_ATTRIBUTE_MASK(WRITABLE)), /* NodeLabel */                                       \
 		DECLARE_DYNAMIC_ATTRIBUTE(                                                                             \
 			chip::app::Clusters::BridgedDeviceBasicInformation::Attributes::Reachable::Id, BOOLEAN, 1,     \
 			0), /* Reachable */                                                                            \
@@ -108,11 +113,12 @@ public:
 	virtual uint16_t GetDeviceType() const = 0;
 	virtual CHIP_ERROR HandleRead(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer,
 				      uint16_t maxReadLength) = 0;
-	virtual CHIP_ERROR HandleWrite(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer) = 0;
+	virtual CHIP_ERROR HandleWrite(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer,
+				       size_t size) = 0;
 	virtual CHIP_ERROR HandleAttributeChange(chip::ClusterId clusterId, chip::AttributeId attributeId, void *data,
 						 size_t dataSize) = 0;
 
-	virtual void ConfigureIdentifyServer(Identify *identifyServer){};
+	virtual void ConfigureIdentifyServer(Identify *identifyServer) {};
 	CHIP_ERROR CopyAttribute(const void *attribute, size_t attributeSize, void *buffer, uint16_t maxBufferSize);
 	CHIP_ERROR HandleWriteDeviceBasicInformation(chip::ClusterId clusterId, chip::AttributeId attributeId,
 						     void *data, size_t dataSize);
@@ -139,6 +145,7 @@ public:
 
 protected:
 	void SetIsReachable(bool isReachable) { mIsReachable = isReachable; }
+	void SetNodeLabel(void *data, size_t size);
 
 	chip::EndpointId mEndpointId{};
 


### PR DESCRIPTION
It is not possible to modify the bridged device node label e.g. using controller commands, despite the spec says this is R/W attribute.

Changed attribute type to writable and exteded implementation to allow handling write requests for it. Additionally added parsing the write requests with string type, as it turned out to not work properly.