### PR TITLE
manifets: Update sdk-zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v3.6.99-ncs2-rc1
+      revision: 5964d41c681f4d2b4f5dd322cb6b9e5395911bc0
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull-in changes, required to program nRF54H20 radio core if the application core is not built.

Ref: NCSDK-27790, NCSDK-27874