### PR TITLE
manifest: sdk-zephyr: update sdk-zephyr revision for mesh fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: fa10fde5897372cdf44cc69caf9bf119fa4e1ce6
+      revision: 40bba7637eb2854d22aa4403baa431d3c16f72fb
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pulls in the fixes for mesh friendship timing corrections and advertiser device name for PB-GATT server.