### PR TITLE
net: lwm2m_client_utils: Fix Push FOTA

### DIFF
--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
@@ -685,7 +685,7 @@ static int firmware_block_received_cb(uint16_t obj_inst_id, uint16_t res_id, uin
 		return -EINVAL;
 	}
 
-	if (bytes_downloaded == 0) {
+	if (bytes_downloaded == 0 && offset == 0) {
 		if (ongoing_obj_id != UNUSED_OBJ_ID) {
 			LOG_INF("DFU is allocated already");
 			return -EAGAIN;
@@ -718,6 +718,11 @@ static int firmware_block_received_cb(uint16_t obj_inst_id, uint16_t res_id, uin
 					image_type == DFU_TARGET_IMAGE_TYPE_FULL_MODEM ?
 				"Modem" :
 				"Application");
+	}
+
+	if (offset < bytes_downloaded) {
+		LOG_DBG("Skipping already downloaded bytes");
+		return 0;
 	}
 
 	ret = dfu_target_offset_get(&target_offset);
@@ -947,8 +952,7 @@ static int write_dl_uri(uint16_t obj_inst_id, uint16_t res_id, uint16_t res_inst
 	uint8_t state;
 	char *package_uri = (char *)data;
 
-
-	LOG_DBG("write URI: %s", package_uri);
+	LOG_DBG("write URI: %s", package_uri ? package_uri : "NULL");
 	state = get_state(obj_inst_id);
 	bool empty_uri = data_len == 0 || strnlen(data, data_len) == 0;
 


### PR DESCRIPTION
When FOTA push starts by modem erasing,
the block 0 is retryed, which causes FOTA to restart unless we actively skip the already downloaded block.