### PR TITLE
applications: samples: add handling for LWM2M_CARRIER_ERROR_CONNECT

### DIFF
--- a/applications/asset_tracker_v2/src/modules/modem_module.c
+++ b/applications/asset_tracker_v2/src/modules/modem_module.c
@@ -338,6 +338,8 @@ static void print_carrier_error(const lwm2m_carrier_event_t *evt)
 			"Initialization failure",
 		[LWM2M_CARRIER_ERROR_RUN] =
 			"Configuration failure",
+		[LWM2M_CARRIER_ERROR_CONNECT] =
+			"Connection failure",
 	};
 
 	__ASSERT(PART_OF_ARRAY(strerr, &strerr[err->type]), "Unhandled carrier library error");

--- a/samples/cellular/http_update/application_update/src/main.c
+++ b/samples/cellular/http_update/application_update/src/main.c
@@ -401,6 +401,8 @@ static void print_err(const lwm2m_carrier_event_t *evt)
 			"Initialization failure",
 		[LWM2M_CARRIER_ERROR_RUN] =
 			"Configuration failure",
+		[LWM2M_CARRIER_ERROR_CONNECT] =
+			"Connection failure",
 	};
 
 	printk("%s, reason %d\n", strerr[err->type], err->value);

--- a/samples/cellular/lwm2m_carrier/src/main.c
+++ b/samples/cellular/lwm2m_carrier/src/main.c
@@ -79,6 +79,8 @@ void print_err(const lwm2m_carrier_event_t *evt)
 			"Initialization failure",
 		[LWM2M_CARRIER_ERROR_RUN] =
 			"Configuration failure",
+		[LWM2M_CARRIER_ERROR_CONNECT] =
+			"Connection failure",
 	};
 
 	__ASSERT(PART_OF_ARRAY(strerr[err->type]),

--- a/samples/cellular/modem_shell/src/shell.c
+++ b/samples/cellular/modem_shell/src/shell.c
@@ -60,6 +60,8 @@ void lwm2m_handle_error(const lwm2m_carrier_event_t *evt)
 			"Initialization failure",
 		[LWM2M_CARRIER_ERROR_RUN] =
 			"Configuration failure",
+		[LWM2M_CARRIER_ERROR_CONNECT] =
+			"Connection failure",
 	};
 
 	mosh_error("%s, reason %d\n", strerr[err->type], err->value);


### PR DESCRIPTION
This new error type was introduced in the latest release of the LwM2M Carrier library but not all the existing integrations have been updated to handle it.