### PR TITLE
manifest: Update zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: b2701cf40d055f9bb24293d3b0b6cd22520d0a12
+      revision: fa10fde5897372cdf44cc69caf9bf119fa4e1ce6
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull in changes that:
- adjust the LFXO CLOAD value in nrf54h20dk_bicr
- configure run once in flash for nrf54l15 and nrf54h20.