### PR TITLE
applications: serial_lte_modem: Fix AT#XCMNG=1

### DIFF
--- a/applications/serial_lte_modem/src/nativetls/slm_native_tls.c
+++ b/applications/serial_lte_modem/src/nativetls/slm_native_tls.c
@@ -133,7 +133,7 @@ static int list_credentials_cb(const char *key, size_t len, settings_read_cb rea
 		ptr++;
 	}
 
-	slm_at_send_str(buf);
+	err = slm_at_send_str(buf);
 	if (err) {
 		LOG_ERR("Failed slm_at_send: %d", err);
 	}


### PR DESCRIPTION
Fix listing credentials with AT#XCMNG=1.