### PR TITLE
applications: serial_lte_modem: fix the format of Carrier app data

### DIFF
--- a/applications/serial_lte_modem/src/lwm2m_carrier/slm_at_carrier.c
+++ b/applications/serial_lte_modem/src/lwm2m_carrier/slm_at_carrier.c
@@ -124,9 +124,10 @@ static void on_event_app_data(const lwm2m_carrier_event_t *event)
 			return;
 		}
 
-		rsp_send("\r\n#XCARRIEREVT: %u,%hhu,\"%s\",%d\r\n", event->type, app_data->type,
+		rsp_send("\r\n#XCARRIEREVT: %u,%hhu,\"%s\",%d\r\n\"", event->type, app_data->type,
 			 uri_path, ret);
 		data_send(slm_data_buf, ret);
+		rsp_send("\"");
 	} else {
 		rsp_send("\r\n#XCARRIEREVT: %u,%hhu,\"%s\"\r\n", event->type, app_data->type,
 			 uri_path);

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -247,6 +247,7 @@ Serial LTE modem
 * Updated:
 
   * AT command parsing to utilize the :ref:`at_cmd_custom_readme` library.
+  * The format of the ``#XCARRIEREVT: 12`` unsolicited notification.
 
 Connectivity Bridge
 -------------------


### PR DESCRIPTION
The data sent in the #XCARRIER: 12 unsolicited notification is a string and so should be enclosed in double quotes.
Print the data on the same line.