### PR TITLE
applications: serial_lte_modem: HWFC for Thingy91 X

### DIFF
--- a/applications/serial_lte_modem/boards/thingy91x_nrf9151_ns.conf
+++ b/applications/serial_lte_modem/boards/thingy91x_nrf9151_ns.conf
@@ -13,5 +13,5 @@ CONFIG_UART_0_NRF_HW_ASYNC_TIMER=2
 CONFIG_UART_0_NRF_HW_ASYNC=y
 CONFIG_SLM_POWER_PIN=26
 
-# Increase buffer space as hardware flow control is not used with Thingy:91.
+# Increase buffer space as hardware flow control is not necessarily used with Thingy:91 X.
 CONFIG_SLM_UART_RX_BUF_SIZE=2048

--- a/applications/serial_lte_modem/boards/thingy91x_nrf9151_ns.overlay
+++ b/applications/serial_lte_modem/boards/thingy91x_nrf9151_ns.overlay
@@ -10,6 +10,11 @@
 	};
 };
 
+&uart0 {
+	status = "okay";
+	hw-flow-control;
+};
+
 &button0 {
 	status = "disabled";
 };


### PR DESCRIPTION
Enable hardware flow control for Thingy91 X.