### PR TITLE
manifest: sdk-zephyr: Pull fix for socket filtering

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: fa10fde5897372cdf44cc69caf9bf119fa4e1ce6
+      revision: pull/1784/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This should solve issues where supplicant gets a frame that bypasses EAPoL check and parsing fails with error.

Fixes SHEL-2873.