### PR TITLE
drivers: wifi: SAP is now production quality

### DIFF
--- a/drivers/wifi/nrf700x/Kconfig
+++ b/drivers/wifi/nrf700x/Kconfig
@@ -68,7 +68,6 @@ config NRF700X_STA_MODE
 
 config NRF700X_AP_MODE
 	bool "Enable Access point mode"
-	select EXPERIMENTAL
 	depends on WPA_SUPP_AP
 
 config NRF700X_P2P_MODE


### PR DESCRIPTION
SAP is now production quality for Wi-Fi provisioning (not general usage), this has been proven with "samples/wifi/provisioning/wifi" sample.

Implements SHEL-2859.