### PR TITLE
scripts: update quarantine for zephyr samples.

### DIFF
--- a/scripts/quarantine_zephyr.yaml
+++ b/scripts/quarantine_zephyr.yaml
@@ -239,10 +239,3 @@
   platforms:
     - nrf54l15pdk/nrf54l15/cpuapp
   comment: "to be fixed in https://github.com/zephyrproject-rtos/zephyr/pull/73777"
-
-- scenarios:
-    - sample.mcumgr.smp_svr.bt.nrf54l15pdk.ext_flash
-    - sample.mcumgr.smp_svr.bt.nrf54l15pdk.ext_flash.pure_dts
-  platforms:
-    - nrf54l15pdk/nrf54l15/cpuapp
-  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-27817"


### PR DESCRIPTION
Tests were fixed in https://github.com/nrfconnect/sdk-zephyr/pull/1777 and https://github.com/nrfconnect/sdk-mcuboot/pull/316.