### PR TITLE
samples: suit: use binary filename when fetching

### DIFF
--- a/samples/suit/smp_transfer/templates/extflash/app_envelope.yaml.jinja2
+++ b/samples/suit/smp_transfer/templates/extflash/app_envelope.yaml.jinja2
@@ -77,7 +77,7 @@ SUIT_Envelope_Tagged:
     suit-payload-fetch:
     - suit-directive-set-component-index: 2
     - suit-directive-override-parameters:
-        suit-parameter-uri: 'file://{{ application['binary'] }}'
+        suit-parameter-uri: 'file://{{ application['filename'] }}'
     - suit-directive-fetch:
       - suit-send-record-failure
     suit-install:
@@ -111,7 +111,7 @@ SUIT_Envelope_Tagged:
 {%- endif %}
     - suit-directive-set-component-index: 1
     - suit-directive-override-parameters:
-        suit-parameter-uri: 'file://{{ application['binary'] }}'
+        suit-parameter-uri: 'file://{{ application['filename'] }}'
         suit-parameter-image-digest:
           suit-digest-algorithm-id: cose-alg-sha-256
           suit-digest-bytes:

--- a/samples/suit/smp_transfer/templates/extflash/rad_envelope.yaml.jinja2
+++ b/samples/suit/smp_transfer/templates/extflash/rad_envelope.yaml.jinja2
@@ -63,13 +63,13 @@ SUIT_Envelope_Tagged:
     suit-payload-fetch:
     - suit-directive-set-component-index: 2
     - suit-directive-override-parameters:
-        suit-parameter-uri: 'file://{{ radio['binary'] }}'
+        suit-parameter-uri: 'file://{{ radio['filename'] }}'
     - suit-directive-fetch:
       - suit-send-record-failure
     suit-install:
     - suit-directive-set-component-index: 1
     - suit-directive-override-parameters:
-        suit-parameter-uri: 'file://{{ radio['binary'] }}'
+        suit-parameter-uri: 'file://{{ radio['filename'] }}'
     - suit-directive-fetch:
       - suit-send-record-failure
     - suit-condition-image-match:

--- a/west.yml
+++ b/west.yml
@@ -239,7 +239,7 @@ manifest:
           upstream-sha: c6eaeda5a1c1c5dbb24dce7e027340cb8893a77b
           compare-by-default: false
     - name: suit-generator
-      revision: 0b06da29af3d4e60e0eb0781f0e2a85ed964f0ee
+      revision: 34583134444365cbf35a591c7f8c5c497a10feef
       path: modules/lib/suit-generator
     - name: suit-processor
       revision: dcb84006795fe99b497e044f3435988d206ac177


### PR DESCRIPTION
The manifest URI now contains only the binary filename instead of full path from the file system. This is made to match the structure of the generated dfu_suit.zip file.

Additional context:
The Device Manager mobile application will expect that payloads are specified by filename alone. Therefore this is a bugfix.