### PR TITLE
doc-improvement: applications: nrf_desktop: Document USB next support

### DIFF
--- a/applications/nrf_desktop/doc/usb_state.rst
+++ b/applications/nrf_desktop/doc/usb_state.rst
@@ -8,7 +8,7 @@ USB state module
    :depth: 2
 
 The |usb_state| is responsible for tracking the USB connection.
-It is also responsible for transmitting data through USB on the application's device.
+It is also responsible for transmitting HID data through USB on the application's device.
 
 Module events
 *************
@@ -23,61 +23,69 @@ Module events
 Configuration
 *************
 
-The module is enabled by selecting :ref:`CONFIG_DESKTOP_USB_ENABLE <config_desktop_app_options>` option.
-The option selects :kconfig:option:`CONFIG_USB_DEVICE_STACK` and :kconfig:option:`CONFIG_USB_DEVICE_HID` Kconfig options.
+The module is enabled by selecting the :ref:`CONFIG_DESKTOP_USB_ENABLE <config_desktop_app_options>` option.
 
 The :ref:`CONFIG_DESKTOP_USB_ENABLE <config_desktop_app_options>` option is implied by the :ref:`CONFIG_DESKTOP_ROLE_HID_DONGLE <config_desktop_app_options>` option.
 The module is enabled by default for the nRF Desktop dongles because the dongles forward the HID data to the host connected over USB.
 See the :ref:`nrf_desktop_hid_configuration` documentation for details.
 
-Additionally, you can also configure the options described in the following sections.
+The module can be used with either the USB legacy stack or the USB next stack.
+The USB stack is selected by enabling one of the following Kconfig choice options:
+
+* :ref:`CONFIG_DESKTOP_USB_STACK_LEGACY <config_desktop_app_options>`
+  The option enables USB legacy stack (:kconfig:option:`CONFIG_USB_DEVICE_STACK`).
+  The USB legacy stack is used by default.
+* :ref:`CONFIG_DESKTOP_USB_STACK_NEXT <config_desktop_app_options>`
+  The option enables USB next stack (:kconfig:option:`CONFIG_USB_DEVICE_STACK_NEXT`).
+
+.. note::
+  The USB next stack integration is :ref:`experimental <software_maturity>`.
+  The HID boot protocol integration is not yet fully tested and may not work properly.
+  The secondary image slot background erase in :ref:`nrf_desktop_dfu` may cause missing USB HID subscriptions after a USB cable is attached.
+
+Some of the properties are configured in the same way for both stacks, but part of the configuration is specific to the selected USB stack.
+See the following sections for details.
 
 .. _nrf_desktop_usb_state_identifiers:
 
 USB device identifiers
 ======================
 
-When the USB support is enabled for the device, the following options are by default set to common :ref:`nrf_desktop_hid_device_identifiers` defined for the nRF Desktop application:
+USB device identifiers are defined in the same way for both USB stacks.
+The module relies on common :ref:`nrf_desktop_hid_device_identifiers` defined for the nRF Desktop application.
+
+For the USB legacy stack, this results in updating defaults for the following Kconfig options:
 
 * :kconfig:option:`CONFIG_USB_DEVICE_MANUFACTURER` - Manufacturer's name.
 * :kconfig:option:`CONFIG_USB_DEVICE_PRODUCT` - Product name.
 * :kconfig:option:`CONFIG_USB_DEVICE_VID` - Vendor ID (VID) number.
 * :kconfig:option:`CONFIG_USB_DEVICE_PID` - Product ID (PID) number.
 
-Low latency device configuration
-================================
+For the USB next stack, the module uses dedicated APIs to set the USB device identifiers during initialization.
 
-The module sets default value of :kconfig:option:`CONFIG_USB_HID_POLL_INTERVAL_MS` to ``1``.
-For low latency of HID reports, the device requests a polling rate of 1 ms.
+.. _nrf_desktop_usb_state_hid_class_instance:
 
-Boot protocol configuration
-===========================
+USB HID class instance configuration
+====================================
 
-The :ref:`CONFIG_DESKTOP_HID_BOOT_INTERFACE_MOUSE <config_desktop_app_options>` and :ref:`CONFIG_DESKTOP_HID_BOOT_INTERFACE_KEYBOARD <config_desktop_app_options>` Kconfig options are used to control support of HID boot reports in the nRF Desktop application.
-The module aligns the USB HID boot protocol configuration with the application configuration.
-The module sets the default value of the :kconfig:option:`CONFIG_USB_HID_BOOT_PROTOCOL` Kconfig option and calls the :c:func:`usb_hid_set_proto_code` function during initialization to set the USB HID Boot Interface protocol code.
-
-USB device instance configuration
-=================================
-
-The nRF Desktop device can provide multiple instances of a HID-class USB device.
-The number of instances is controlled by :kconfig:option:`CONFIG_USB_HID_DEVICE_COUNT`.
-By default, the option is set to:
+The nRF Desktop device can provide multiple instances of HID-class USB.
+By default, the number of the HID-class USB instances should be set to:
 
 * ``1`` for HID peripherals (:ref:`CONFIG_DESKTOP_ROLE_HID_PERIPHERAL <config_desktop_app_options>`).
+  You can use more HID-class USB instances if the selective HID report subscription feature is enabled (:ref:`CONFIG_DESKTOP_USB_SELECTIVE_REPORT_SUBSCRIPTION <config_desktop_app_options>`).
 * :ref:`CONFIG_DESKTOP_HID_DONGLE_BOND_COUNT <config_desktop_app_options>` for HID dongles (:ref:`CONFIG_DESKTOP_ROLE_HID_DONGLE <config_desktop_app_options>`).
 
 See the subsections below for details.
 
-nRF Desktop Peripheral
+nRF Desktop peripheral
 ----------------------
 
-The nRF Desktop Peripheral devices by default use only a single HID-class USB instance.
+The nRF Desktop peripheral devices by default use only a single HID-class USB instance.
 In that case, this instance is used for all the HID reports.
 
-Enable :ref:`CONFIG_DESKTOP_USB_SELECTIVE_REPORT_SUBSCRIPTION <config_desktop_app_options>` to use more than one HID-class USB instance on nRF Desktop Peripheral.
-Make sure to set a greater value in the :kconfig:option:`CONFIG_USB_HID_DEVICE_COUNT` option and create an additional :file:`usb_state_def.h` header in the configuration.
-The header assigns HID reports to the HID-class USB instances.
+Enable :ref:`CONFIG_DESKTOP_USB_SELECTIVE_REPORT_SUBSCRIPTION <config_desktop_app_options>` to use more than one USB HID-class instance on the nRF Desktop peripheral.
+Make sure to configure additional HID-class USB instances and create an additional :file:`usb_state_def.h` header in the configuration.
+The header assigns HID input reports to the HID-class USB instances.
 A given HID report can be handled only by a single HID-class USB instance.
 For example, the file contents can look as follows:
 
@@ -102,23 +110,57 @@ For example, the file contents can look as follows:
 The ``usb_hid_report_bm`` defines HID reports handled by a HID-class USB instance, in a bitmask format.
 In this example, the HID mouse input report is handled by the first HID-class USB instance and the HID keyboard input report is handled by the second HID-class USB instance.
 
-nRF Desktop Central
--------------------
+nRF Desktop dongle
+------------------
 
-The nRF Desktop Central device can use either a single HID-class USB instance or a number of instances equal to that specified in the :ref:`CONFIG_DESKTOP_HID_DONGLE_BOND_COUNT <config_desktop_app_options>` option.
-If only one instance is used, reports from all Peripherals connected to the Central are forwarded to the same instance.
+The nRF Desktop dongle device can use either a single HID-class USB instance or a number of instances equal to that specified in the :ref:`CONFIG_DESKTOP_HID_DONGLE_BOND_COUNT <config_desktop_app_options>` option.
+If only one instance is used, reports from all peripherals connected to the dongle are forwarded to the same instance.
 In other cases, reports from each of the bonded peripherals are forwarded to a dedicated HID-class USB instance.
 The same instance is used after reconnection.
+
+USB HID configuration in USB legacy stack
+-----------------------------------------
+
+For the USB legacy stack, the :ref:`CONFIG_DESKTOP_USB_STACK_LEGACY <config_desktop_app_options>` selects the required dependencies: :kconfig:option:`CONFIG_USB_DEVICE_STACK` and :kconfig:option:`CONFIG_USB_DEVICE_HID` Kconfig options.
+The number of HID-class USB instances in the USB legacy stack is specified by :kconfig:option:`CONFIG_USB_HID_DEVICE_COUNT`.
+The default value of this option is updated to match requirements for either an nRF Desktop peripheral or a dongle.
+
+Low latency device configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The module sets the default value of :kconfig:option:`CONFIG_USB_HID_POLL_INTERVAL_MS` to ``1``.
+For low latency of HID reports, the device requests a polling rate of 1 ms.
+
+Boot protocol configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The :ref:`CONFIG_DESKTOP_HID_BOOT_INTERFACE_MOUSE <config_desktop_app_options>` and :ref:`CONFIG_DESKTOP_HID_BOOT_INTERFACE_KEYBOARD <config_desktop_app_options>` Kconfig options are used to control support of HID boot reports in the nRF Desktop application.
+The module aligns the USB HID boot protocol configuration with the application configuration.
+The module sets the default value of the :kconfig:option:`CONFIG_USB_HID_BOOT_PROTOCOL` Kconfig option and calls the :c:func:`usb_hid_set_proto_code` function during initialization to set the USB HID boot interface protocol code.
+Common HID boot protocol code is used for all of the HID-class USB instances.
+
+USB HID configuration in USB next stack
+---------------------------------------
+
+For the USB next stack, the :ref:`CONFIG_DESKTOP_USB_STACK_NEXT <config_desktop_app_options>` selects the :kconfig:option:`CONFIG_USB_DEVICE_STACK_NEXT` Kconfig option.
+Every USB HID-class instance is configured through a separate DTS node compatible with ``zephyr,hid-device``.
+The DTS node configures, among others, the used HID boot protocol, the size of the longest HID input report, and the HID polling rate.
+Make sure to update the DTS configuration to match requirements of your application.
+nRF Desktop application defines the USB HID-class instances used by the USB next stack for all of the supported boards and file suffixes.
+See the existing configurations for reference.
+
+Defining USB HID-class instances in the DTS, by default, enables the :kconfig:option:`CONFIG_USBD_HID_SUPPORT` Kconfig option.
 
 USB wakeup configuration
 ========================
 
 The nRF Desktop device can work as a source of wakeup events for the host device if connected through the USB.
 To use the feature, enable the :ref:`CONFIG_DESKTOP_USB_REMOTE_WAKEUP <config_desktop_app_options>` option.
-This option selects the :kconfig:option:`CONFIG_USB_DEVICE_REMOTE_WAKEUP` to enable required dependencies in the USB stack.
+This option selects the :kconfig:option:`CONFIG_USB_DEVICE_REMOTE_WAKEUP` Kconfig option to enable required dependencies if USB legacy stack is used.
+The USB next stack supports remote wakeup by default, and you do not need to select any additional Kconfig dependencies.
 
 When host enters the suspended state, the USB will be suspended as well.
-With this feature enabled, this state change is used to suspend the nRF Desktop device (see :ref:`nrf_desktop_power_manager`).
+This state change is used to suspend the nRF Desktop device (see :ref:`nrf_desktop_power_manager`).
 When the nRF Desktop device wakes up from standby, the |usb_state| will issue a wakeup request on the USB.
 
 .. note::
@@ -127,7 +169,10 @@ When the nRF Desktop device wakes up from standby, the |usb_state| will issue a 
 Implementation details
 **********************
 
-The |usb_state| registers the :kconfig:option:`CONFIG_USB_HID_DEVICE_COUNT` instances of HID-class USB device and initializes the USB subsystem.
+The |usb_state| registers all of the configured instances of HID-class USB and initializes the USB subsystem.
+
+USB state tracking
+==================
 
 The necessary callbacks are connected to the module to ensure that the state of the USB connection is tracked.
 From the application's viewpoint, USB can be in the following states:
@@ -137,17 +182,23 @@ From the application's viewpoint, USB can be in the following states:
 * :c:enum:`USB_STATE_ACTIVE` - The device is ready to exchange data with the host.
 * :c:enum:`USB_STATE_SUSPENDED` - The host has requested the device to enter the suspended state.
 
-These states are broadcast by the |usb_state| with a :c:struct:`usb_state_event`.
+These states are broadcasted by the |usb_state| with a :c:struct:`usb_state_event`.
 When the device is connected to the host and configured for the communication, the module will broadcast the :c:enum:`USB_STATE_ACTIVE` state.
-The module will also subscribe to all HID reports available in the application for the selected protocol.
 
-When the device is disconnected from the host, the module will unsubscribe from receiving the HID reports.
+HID data handling
+=================
 
-When the HID report data is transmitted through :c:struct:`hid_report_event`, the module will pass it to the associated endpoint.
+The module handles USB HID input report subscriptions.
+For the USB legacy stack, all of the USB HID-class instances subscribe to all supported HID reports for the selected protocol.
+This occurs when the USB stack reports :c:enum:`USB_DC_CONFIGURED`, and the :c:enum:`USB_STATE_ACTIVE` state is broadcasted.
+When leaving the active state, the module will unsubscribe from receiving the HID reports.
+For the USB next stack, a separate callback provided by USB HID-class API is used to track HID subscription state.
+
+When the HID report data is transmitted through :c:struct:`hid_report_event`, the module will pass it to the associated USB HID-class instance.
 Upon data delivery, :c:struct:`hid_report_sent_event` is submitted by the module.
 
 .. note::
-    Only one report can be transmitted by the module to a single instance of HID-class USB device at any given time.
+    Only one HID input report is transmitted by the module to a single instance of HID-class USB device at any given time.
     Different instances can transmit reports in parallel.
 
 The |usb_state| is a transport for :ref:`nrf_desktop_config_channel` when the channel is enabled.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -297,6 +297,7 @@ nRF Desktop
   * A warning log for handling ``-EACCES`` error code returned by functions that send GATT notification with HID report in :ref:`nrf_desktop_hids`.
     The error code might be returned if an HID report is sent right after a remote peer unsubscribes.
     The warning log prevents displaying an error log in a use case that does not indicate an error.
+  * Experimental support for the USB next stack (:kconfig:option:`CONFIG_USB_DEVICE_STACK_NEXT`) to :ref:`nrf_desktop_usb_state`.
 
 * Updated:
 


### PR DESCRIPTION
Change adds USB next stack integration documentation for USB state application module.

Jir: NCSDK-27661