### PR TITLE
applications: nrf5340_audio: Speed up discovery process

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/bt_management/scanning/Kconfig
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/scanning/Kconfig
@@ -25,11 +25,18 @@ menu "Connection"
 
 config BLE_ACL_CONN_INTERVAL
 	int "Bluetooth LE ACL Connection Interval (x*1.25ms)"
-	default 32
+	default 8
 	help
-	  When the LE Audio Controller Subsystem for nRF53 is used, this
-	  interval should be a multiple of the ISO interval and maximum 4x
-	  larger than the lowest interval.
+	  This interval should be a multiple of the ISO interval used. The recommendation is to
+	  increase the interval to something like BLE_ACL_CONN_INTERVAL_SLOW after the discovery
+	  process is done, to free up time on air.
+
+config BLE_ACL_CONN_INTERVAL_SLOW
+	int "Bluetooth LE ACL Connection Interval (x*1.25ms)"
+	default 72
+	help
+	  This interval should be a multiple of the ISO interval used. 72*1.25=90 which will
+	  suit both 7.5ms and 10ms.
 
 config BLE_ACL_SLAVE_LATENCY
 	int "Bluetooth LE Slave Latency"

--- a/applications/nrf5340_audio/unicast_client/main.c
+++ b/applications/nrf5340_audio/unicast_client/main.c
@@ -269,6 +269,19 @@ static void le_audio_msg_sub_thread(void)
 			break;
 
 		case LE_AUDIO_EVT_CONFIG_RECEIVED:
+			struct bt_le_conn_param param;
+
+			/* Set the ACL interval up to allow more time for ISO packets */
+			param.interval_min = CONFIG_BLE_ACL_CONN_INTERVAL_SLOW;
+			param.interval_max = CONFIG_BLE_ACL_CONN_INTERVAL_SLOW;
+			param.latency = CONFIG_BLE_ACL_SLAVE_LATENCY;
+			param.timeout = CONFIG_BLE_ACL_SUP_TIMEOUT;
+
+			ret = bt_conn_le_param_update(msg.conn, &param);
+			if (ret) {
+				LOG_WRN("Failed to update conn parameters: %d", ret);
+			}
+
 			LOG_DBG("LE audio config received");
 
 			ret = unicast_client_config_get(msg.conn, msg.dir, &bitrate_bps,
@@ -354,6 +367,7 @@ static void bt_mgmt_evt_handler(const struct zbus_channel *chan)
 	case BT_MGMT_CONNECTED:
 		/* NOTE: The string below is used by the Nordic CI system */
 		LOG_INF("Connection event. Num connections: %u", num_conn);
+
 		break;
 
 	case BT_MGMT_SECURITY_CHANGED:


### PR DESCRIPTION
- Set ACL interval to 10ms during discovery and configuration
- Set ACL back to 80ms before ISO starts streaming to free up air time
- Fixes bug where set up time is too long
- OCT-3035