### PR TITLE
applications: nrf_desktop: Add missing dependency to USB remote wakeup

### DIFF
--- a/applications/nrf_desktop/src/modules/Kconfig.usb_state
+++ b/applications/nrf_desktop/src/modules/Kconfig.usb_state
@@ -15,7 +15,7 @@ if DESKTOP_USB_ENABLE
 config DESKTOP_USB_REMOTE_WAKEUP
 	bool "Enable USB remote wakeup"
 	default y
-	depends on CAF_PM_EVENTS
+	depends on DESKTOP_USB_PM_ENABLE
 	help
 	  Enable USB remote wakeup functionality. The USB wakeup request is
 	  triggered on wake_up_event.


### PR DESCRIPTION
Change adds missing dependency to CONFIG_DESKTOP_USB_REMOTE_WAKEUP. Enabling USB remote wakeup without CONFIG_DESKTOP_USB_PM_ENABLE results in missing force_power_down_event on USB suspend. Because of this, CAF Power Manager does not suspend application and there is no related wake_up_event on user activity. The wake_up_event is needed to trigger USB remote wakeup.

Jira: NCSDK-27912