### PR TITLE
shields: nrf54h20dk_nrf700x: Fix DFU partition offsets

### DIFF
--- a/boards/shields/nrf700x_nrf54h20dk/nrf700x_nrf54h20dk.overlay
+++ b/boards/shields/nrf700x_nrf54h20dk/nrf700x_nrf54h20dk.overlay
@@ -52,6 +52,7 @@
 
 /* Wi-Fi needs more flash, so, minimize Radio memory to make room for Wi-Fi */
 /delete-node/ &cpuapp_rx_partitions;
+/delete-node/ &cpuapp_rw_partitions;
 
 /* For MPC, min. granularity is 4K*/
 &cpurad_slot0_partition {
@@ -74,6 +75,23 @@
 
 		cpuppr_code_partition: partition@126000 {
 			reg = <0x126000 DT_SIZE_K(64)>;
+		};
+	};
+	cpuapp_rw_partitions: cpuapp-rw-partitions {
+		compatible = "nordic,owned-partitions", "fixed-partitions";
+		status = "okay";
+		perm-read;
+		perm-write;
+		perm-secure;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		dfu_partition: partition@136000 {
+			reg = < 0x136000 DT_SIZE_K(676) >;
+		};
+
+		storage_partition: partition@1df000 {
+			reg = < 0x1df000 DT_SIZE_K(24) >;
 		};
 	};
 };


### PR DESCRIPTION
Due to recent DFU additions, adjust the offsets to account for increased Flash.

Fixes SHEL-2858.