### PR TITLE
bluetooth: rpc: minor fixes

### DIFF
--- a/subsys/bluetooth/rpc/client/bt_rpc_gatt_client.c
+++ b/subsys/bluetooth/rpc/client/bt_rpc_gatt_client.c
@@ -1434,11 +1434,11 @@ static const size_t bt_gatt_subscribe_params_buf_size =
 	1 + BT_RPC_SIZE_OF_FIELD(struct bt_gatt_subscribe_params, value_handle) +
 	1 + BT_RPC_SIZE_OF_FIELD(struct bt_gatt_subscribe_params, ccc_handle) +
 	1 + BT_RPC_SIZE_OF_FIELD(struct bt_gatt_subscribe_params, value) +
-	/* Placeholder for the flags field */
-	2 +
 #if defined(CONFIG_BT_SMP)
-	1 + BT_RPC_SIZE_OF_FIELD(struct bt_gatt_subscribe_params, min_security);
-#endif /* defined(CONFIG_BT_SMP) */
+	1 + BT_RPC_SIZE_OF_FIELD(struct bt_gatt_subscribe_params, min_security) +
+#endif
+	/* Placeholder for the flags field */
+	2;
 
 void bt_gatt_subscribe_params_enc(struct nrf_rpc_cbor_ctx *encoder,
 				  const struct bt_gatt_subscribe_params *data)

--- a/subsys/bluetooth/rpc/common/bt_rpc_common.c
+++ b/subsys/bluetooth/rpc/common/bt_rpc_common.c
@@ -29,6 +29,34 @@ NRF_RPC_IPC_TRANSPORT(bt_rpc_tr, DEVICE_DT_GET(DT_NODELABEL(ipc0)), "bt_rpc_ept"
 #endif
 NRF_RPC_GROUP_DEFINE(bt_rpc_grp, "bt_rpc", &bt_rpc_tr, NULL, NULL, NULL);
 
+#if CONFIG_BT_RPC_INITIALIZE_NRF_RPC
+static void err_handler(const struct nrf_rpc_err_report *report)
+{
+	LOG_ERR("nRF RPC error %d ocurred. See nRF RPC logs for more details.",
+		report->code);
+	k_oops();
+}
+
+static int serialization_init(void)
+{
+
+	int err;
+
+	LOG_DBG("Init begin");
+
+	err = nrf_rpc_init(err_handler);
+	if (err) {
+		return -EINVAL;
+	}
+
+	LOG_DBG("Init done\n");
+
+	return 0;
+}
+
+SYS_INIT(serialization_init, POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY);
+#endif /* CONFIG_BT_RPC_INITIALIZE_NRF_RPC */
+
 enum {
 	CHECK_ENTRY_FLAGS,
 	CHECK_ENTRY_UINT,


### PR DESCRIPTION
1. Fix bug with not correct subscription parameters length for bt client without smp service
2. Move initialization back for backward compatibility