### PR TITLE
net: lib: nrf_cloud_coap: Simplify headers

### DIFF
--- a/include/net/nrf_cloud_coap.h
+++ b/include/net/nrf_cloud_coap.h
@@ -23,7 +23,18 @@ extern "C" {
 #include <net/nrf_cloud_pgps.h>
 #endif
 #include <net/nrf_cloud_codec.h>
+#if defined(CONFIG_NRF_CLOUD_COAP)
 #include <zephyr/net/coap.h>
+#include <zephyr/net/coap_client.h>
+#else
+/* Work around missing Kconfigs upstream in coap_client.h */
+#define coap_client_response_cb_t void *
+enum coap_content_format {
+	dummy
+};
+struct coap_client {};
+struct coap_client_option {};
+#endif
 
 /**
  * @defgroup nrf_cloud_coap nRF CoAP API

--- a/subsys/net/lib/nrf_cloud/coap/include/nrf_cloud_coap_transport.h
+++ b/subsys/net/lib/nrf_cloud/coap/include/nrf_cloud_coap_transport.h
@@ -22,17 +22,7 @@ extern "C" {
 #if defined(CONFIG_NRF_CLOUD_PGPS)
 #include <net/nrf_cloud_pgps.h>
 #endif
-#if defined(CONFIG_NRF_CLOUD_COAP)
-#include <zephyr/net/coap_client.h>
-#else
-/* Work around missing Kconfigs upstream in coap_client.h */
-#define coap_client_response_cb_t void *
-enum coap_content_format {
-	dummy
-};
-struct coap_client {};
-struct coap_client_option {};
-#endif
+#include <net/nrf_cloud_coap.h>
 
 struct nrf_cloud_coap_client {
 	struct k_mutex mutex;


### PR DESCRIPTION
The multi service sample fails to build with the logging overlay due to a recent change to the nrf_cloud_coap.h header.

Move conflicting definitions from nrf_cloud_coap_transport.h to nrf_cloud_coap.h.

Jira: IRIS-9135