### PR TITLE
samples: dtm: nrf5340_cpunet do not redefine uart0 as ipc_uart

### DIFF
--- a/doc/nrf/drivers/uart_ipc.rst
+++ b/doc/nrf/drivers/uart_ipc.rst
@@ -23,11 +23,13 @@ A configuration example:
 
 .. code-block:: devicetree
 
-	&uart0 {
-		status = "okay";
-		compatible = "nordic,nrf-ipc-uart";
-		ipc = <&ipc0>;
-		ept-name = "remote shell";
+	/ {
+			uart_ipc: uart_ipc {
+				status = "okay";
+				compatible = "nordic,nrf-ipc-uart";
+				ipc = <&ipc0>;
+				ept-name = "remote shell";
+			};
 	};
 
 The following configuration options are available for this driver:

--- a/samples/bluetooth/direct_test_mode/boards/nrf5340dk_nrf5340_cpunet.overlay
+++ b/samples/bluetooth/direct_test_mode/boards/nrf5340dk_nrf5340_cpunet.overlay
@@ -6,16 +6,16 @@
 
 / {
 	chosen {
-		ncs,dtm-uart = &uart0;
+		ncs,dtm-uart = &uart_ipc;
 	};
-};
 
-&uart0 {
-	status = "okay";
-	compatible = "nordic,nrf-ipc-uart";
-	ipc = <&ipc0>;
-	ept-name = "remote shell";
-	current-speed = <19200>;
+	uart_ipc: uart_ipc {
+		status = "okay";
+		compatible = "nordic,nrf-ipc-uart";
+		ipc = <&ipc0>;
+		ept-name = "remote shell";
+		current-speed = <19200>;
+	};
 };
 
 &radio {


### PR DESCRIPTION
Making the `uart0` a `compatible = "nordic,nrf-ipc-uart";` does
not release the `uart0` for other purposes. On nrf5340_cpunet when
when an overlay that uses TWIM0 is used the fact that `uart0` node
is still used (regardless that redefined to use ipc uart not the
hardware uart driver) leads to compilation error.

To overcome this issue the `uart0` is no more redefined but a new
device tree node `uart_ipc` is provided. From application's point
of view this is an additional uart that is used by dtm. The
`uart0` present in device tree can be used for other purpose or
disabled.

The doc regarding the uart_ipc driver is also updated to not endorse use case
that leads to this issue.

The main goal of this PR is to enable use of nrf2220ek and nrf2240ek shields
with direct_test_mode application. This PR makes possible to build the dtm app with:
```
west build -p -b nrf5340dk/nrf5340/cpunet -- -Ddirect_test_mode_SHIELD=nrf2240ek -Dremote_shell_SHIELD=nrf2240ek_fwd
```