### PR TITLE
lwm2m: Fixes for push mode FOTA

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -517,6 +517,11 @@ Libraries for networking
 
   * Updated to use a shorter resource string for the ``d2c/bulk`` resource.
 
+* :ref:`lib_lwm2m_client_utils` library:
+
+  * Fixed an issue where a failed delta update for the modem would not clear the state and blocks future delta updates.
+    This only occurred when an LwM2M Firmware object was used in push mode.
+
 Libraries for NFC
 -----------------
 

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
@@ -845,6 +845,24 @@ cleanup:
 		if (dfu_target_reset() < 0) {
 			LOG_ERR("Failed to reset DFU target");
 		}
+		/* We must return only known values for LwM2M firmware handler. */
+		switch (ret) {
+		case -ENOMEM:
+		case -ENOSPC:
+		case -EFAULT:
+		case -ENOMSG:
+			break;
+		case -EFBIG:
+		case -E2BIG:
+			ret = -ENOSPC;
+			break;
+		case -EINVAL:
+			ret = -ENOMSG;
+			break;
+		default:
+			ret = -EFAULT;
+			break;
+		}
 	}
 
 	return ret;

--- a/tests/subsys/net/lib/lwm2m_fota_utils/src/firmware.c
+++ b/tests/subsys/net/lib/lwm2m_fota_utils/src/firmware.c
@@ -250,6 +250,7 @@ int fota_download_util_image_schedule_stub(enum dfu_target_image_type dfu_target
 static int fota_download_util_image_reset_stub(enum dfu_target_image_type dfu_target_type)
 {
 	target_reset_done = true;
+	target_offset = 0;
 	return 0;
 }
 


### PR DESCRIPTION
This PR contains 3 separate fixes for push-mode FOTA.

## net: lwm2m_client_utils: Don't return unknown FOTA errors

We should take care to not return any other error than
what lwm2m_obj_firmware.c handles. If we for example return
-EACCESS, then LwM2M content format writer ignores that as
it is supposed to skip over write requests to read-only
resources. So we now default to -EFAULT, so we don't
cause any undefined behaviour.

## net: lwm2m_client_utils: Handle erase properly

Push mode handler should follow what fota_download.c does.
When FOTA fails, we should call dfu_target_done(false), so it also
tells modem to reset FOTA process in case of delta package.
dfu_target_reset() does not seem to be enough, it only erases the area.

Handle erasing when a new FOTA process starts, but only if offset is
showing that we need it.

## net: lwm2m_client_utils: Handle retried FOTA writes

When Block N=0 is retransmitted, our FOTA handler might see that
as a completely new FOTA process, if previous one failed.
We should instead return failure if the FOTA is retried as
we already know that we failed the previous time.

If we instead accept the first block, then retries are just
skipped and handled normally.
