### PR TITLE
Samples: Bluetooth: Mesh: Remove sensor settings ref from LC readme

### DIFF
--- a/samples/bluetooth/mesh/light_ctrl/README.rst
+++ b/samples/bluetooth/mesh/light_ctrl/README.rst
@@ -269,12 +269,6 @@ This sample can be configured to report energy usage sensor data to any device i
 
 The Sensor Server model is now configured and able to receive messages from and send data to the peer Sensor Client.
 
-Configure the Sensor Setup Server model on the **Mesh Light Fixture** node:
-
-* Bind the model to **Application Key 1**. Make sure to bind the same application key to the peer Sensor Client.
-
-The Sensor Setup Server model is now configured and able to receive sensor setting messages from the Sensor Client.
-
 .. _bluetooth_mesh_light_lc_occupancy_mode:
 
 Occupancy mode


### PR DESCRIPTION
This removes the paragraph about using the Sensor Setup Server to send and receive settings messages in the Light Fixture sample, since the Light Fixture sample has no sensor settings to set.