### PR TITLE
manifest: Update zephyr with uart legacy shim for nrf54h20

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 41b063f31e3be53d79f5838fb3a5b41a0bfcd157
+      revision: 4ad051ddc4127dab34585763ed60b4b884c6691b
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Allow to use legacy uart shim for nrf54h20 (in particular PPR).