### PR TITLE
applications: nrf5340_audio: Set pres_delay depends on uni/bidr mode

### DIFF
--- a/applications/nrf5340_audio/src/audio/Kconfig
+++ b/applications/nrf5340_audio/src/audio/Kconfig
@@ -32,6 +32,7 @@ config AUDIO_FRAME_DURATION_US
 
 config AUDIO_MIN_PRES_DLY_US
 	int "The minimum presentation delay"
+	default 5000 if STREAM_BIDIRECTIONAL
 	default 3000
 	help
 	  The minimum allowable presentation delay in microseconds.

--- a/applications/nrf5340_audio/src/bluetooth/Kconfig
+++ b/applications/nrf5340_audio/src/bluetooth/Kconfig
@@ -70,7 +70,7 @@ menu "QoS"
 config BT_AUDIO_PRESENTATION_DELAY_US
 	int "Presentation delay"
 	range AUDIO_MIN_PRES_DLY_US AUDIO_MAX_PRES_DLY_US
-	default 3000
+	default AUDIO_MIN_PRES_DLY_US
 	help
 	  The audio source/client defined presentation delay if within
 	  AUDIO_MIN_PRES_DLY_US and AUDIO_MAX_PRES_DLY_US range. This will

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/Kconfig
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/Kconfig
@@ -97,7 +97,7 @@ config CODEC_CAP_COUNT_MAX
 config BT_AUDIO_PREFERRED_MIN_PRES_DLY_US
 	int "The preferred minimum presentation delay"
 	range AUDIO_MIN_PRES_DLY_US AUDIO_MAX_PRES_DLY_US
-	default 3000
+	default AUDIO_MIN_PRES_DLY_US
 	help
 	  The preferred minimum presentation delay in microseconds. This can not
 	  be less than the absolute minimum presentation delay.


### PR DESCRIPTION
Set pres-delay longer in bidirectional mode.
OCT-NONE
Signed-off-by: Jui-Chou Chung <jui-chou.chung@nordicsemi.no>