### PR TITLE
samples: cellular: gnss: Build integration CI images with twister

### DIFF
--- a/applications/asset_tracker_v2/sample.yaml
+++ b/applications/asset_tracker_v2/sample.yaml
@@ -364,3 +364,18 @@ tests:
                 EXTRA_CONF_FILE="overlay-nrf7002ek-wifi-scan-only.conf;overlay-debug.conf"
                 SB_CONFIG_WIFI_NRF700X=y SB_CONFIG_WIFI_NRF700X_SCAN_ONLY=y
     tags: ci_build sysbuild
+
+  # Configuration which will be used by the positioning CI integration job to verify PRs
+  applications.asset_tracker_v2.integration_config_positioning:
+    sysbuild: true
+    build_only: true
+    extra_configs:
+      - CONFIG_MODEM_ANTENNA_GNSS_EXTERNAL=y
+      - CONFIG_LOCATION_LOG_LEVEL_DBG=y
+      - CONFIG_LOG_BUFFER_SIZE=2048
+    extra_args: asset_tracker_v2_SNIPPET="nrf91-modem-trace-uart"
+    integration_platforms:
+      - nrf9151dk/nrf9151/ns
+    platform_allow:
+      - nrf9151dk/nrf9151/ns
+    tags: ci_build sysbuild

--- a/samples/cellular/gnss/sample.yaml
+++ b/samples/cellular/gnss/sample.yaml
@@ -13,3 +13,99 @@ tests:
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
     tags: ci_build sysbuild
+
+  # Following configurations will be used by the positioning CI integration job to verify PRs
+  sample.cellular.gnss.integration_config_positioning_agnss_nrfcloud_ltem_pvt:
+    sysbuild: true
+    build_only: true
+    extra_configs:
+      - CONFIG_LTE_NETWORK_MODE_LTE_M_GPS=y
+      - CONFIG_LTE_NETWORK_MODE_NBIOT_GPS=n
+      - CONFIG_GNSS_SAMPLE_LTE_ON_DEMAND=y
+      - CONFIG_GNSS_SAMPLE_ASSISTANCE_NRF_CLOUD=y
+      - CONFIG_GNSS_SAMPLE_NMEA_ONLY=n
+      - CONFIG_GNSS_SAMPLE_MODE_PERIODIC=n
+      - CONFIG_GNSS_SAMPLE_ASSISTANCE_MINIMAL=n
+      - CONFIG_LTE_EDRX_REQ=y
+      - CONFIG_FPU=y
+      - CONFIG_GNSS_SAMPLE_REFERENCE_LATITUDE="61.49375330"
+      - CONFIG_GNSS_SAMPLE_REFERENCE_LONGITUDE="23.77588976"
+      - CONFIG_MODEM_ANTENNA_GNSS_EXTERNAL=y
+      - CONFIG_LOG_BUFFER_SIZE=2048
+    extra_args: gnss_SNIPPET="nrf91-modem-trace-uart"
+    integration_platforms:
+      - nrf9151dk/nrf9151/ns
+    platform_allow:
+      - nrf9151dk/nrf9151/ns
+    tags: ci_build sysbuild
+  sample.cellular.gnss.integration_config_positioning_agnss_nrfcloud_nbiot_nmea_lte_on:
+    sysbuild: true
+    build_only: true
+    extra_configs:
+      - CONFIG_LTE_NETWORK_MODE_LTE_M_GPS=n
+      - CONFIG_LTE_NETWORK_MODE_NBIOT_GPS=y
+      - CONFIG_GNSS_SAMPLE_LTE_ON_DEMAND=n
+      - CONFIG_GNSS_SAMPLE_ASSISTANCE_NRF_CLOUD=y
+      - CONFIG_GNSS_SAMPLE_NMEA_ONLY=y
+      - CONFIG_GNSS_SAMPLE_MODE_PERIODIC=n
+      - CONFIG_GNSS_SAMPLE_ASSISTANCE_MINIMAL=n
+      - CONFIG_LTE_EDRX_REQ=y
+      - CONFIG_FPU=y
+      - CONFIG_GNSS_SAMPLE_REFERENCE_LATITUDE="61.49375330"
+      - CONFIG_GNSS_SAMPLE_REFERENCE_LONGITUDE="23.77588976"
+      - CONFIG_MODEM_ANTENNA_GNSS_EXTERNAL=y
+      - CONFIG_LOG_BUFFER_SIZE=2048
+    extra_args: gnss_SNIPPET="nrf91-modem-trace-uart"
+    integration_platforms:
+      - nrf9151dk/nrf9151/ns
+    platform_allow:
+      - nrf9151dk/nrf9151/ns
+    tags: ci_build sysbuild
+  sample.cellular.gnss.integration_config_positioning_pgps_nrfcloud_ltem_nmea:
+    sysbuild: true
+    build_only: true
+    extra_configs:
+      - CONFIG_LTE_NETWORK_MODE_LTE_M_GPS=y
+      - CONFIG_LTE_NETWORK_MODE_NBIOT_GPS=n
+      - CONFIG_GNSS_SAMPLE_LTE_ON_DEMAND=n
+      - CONFIG_GNSS_SAMPLE_ASSISTANCE_NRF_CLOUD=n
+      - CONFIG_GNSS_SAMPLE_NMEA_ONLY=y
+      - CONFIG_GNSS_SAMPLE_MODE_PERIODIC=n
+      - CONFIG_GNSS_SAMPLE_ASSISTANCE_MINIMAL=n
+      - CONFIG_LTE_EDRX_REQ=n
+      - CONFIG_FPU=y
+      - CONFIG_GNSS_SAMPLE_REFERENCE_LATITUDE="61.49375330"
+      - CONFIG_GNSS_SAMPLE_REFERENCE_LONGITUDE="23.77588976"
+      - CONFIG_MODEM_ANTENNA_GNSS_EXTERNAL=y
+      - CONFIG_LOG_BUFFER_SIZE=2048
+    extra_args:
+      - OVERLAY_CONFIG=overlay-pgps.conf
+      - gnss_SNIPPET="nrf91-modem-trace-uart"
+    integration_platforms:
+      - nrf9151dk/nrf9151/ns
+    platform_allow:
+      - nrf9151dk/nrf9151/ns
+    tags: ci_build sysbuild
+  sample.cellular.gnss.integration_config_positioning_gnss_ltem_pvt:
+    sysbuild: true
+    build_only: true
+    extra_configs:
+      - CONFIG_LTE_NETWORK_MODE_LTE_M_GPS=y
+      - CONFIG_LTE_NETWORK_MODE_NBIOT_GPS=n
+      - CONFIG_GNSS_SAMPLE_LTE_ON_DEMAND=n
+      - CONFIG_GNSS_SAMPLE_ASSISTANCE_NRF_CLOUD=n
+      - CONFIG_GNSS_SAMPLE_NMEA_ONLY=n
+      - CONFIG_GNSS_SAMPLE_MODE_PERIODIC=n
+      - CONFIG_GNSS_SAMPLE_ASSISTANCE_MINIMAL=n
+      - CONFIG_LTE_EDRX_REQ=y
+      - CONFIG_FPU=y
+      - CONFIG_GNSS_SAMPLE_REFERENCE_LATITUDE="61.49375330"
+      - CONFIG_GNSS_SAMPLE_REFERENCE_LONGITUDE="23.77588976"
+      - CONFIG_MODEM_ANTENNA_GNSS_EXTERNAL=y
+      - CONFIG_LOG_BUFFER_SIZE=2048
+    extra_args: gnss_SNIPPET="nrf91-modem-trace-uart"
+    integration_platforms:
+      - nrf9151dk/nrf9151/ns
+    platform_allow:
+      - nrf9151dk/nrf9151/ns
+    tags: ci_build sysbuild

--- a/samples/cellular/location/sample.yaml
+++ b/samples/cellular/location/sample.yaml
@@ -84,3 +84,17 @@ tests:
                 DTC_OVERLAY_FILE=thingy91x_wifi.overlay
                 SB_CONFIG_WIFI_NRF700X=y SB_CONFIG_WIFI_NRF700X_SCAN_ONLY=y
     tags: ci_build sysbuild
+
+  # Configuration which will be used by the CI positioning integration job to verify PRs
+  sample.cellular.location.integration_config_positioning:
+    sysbuild: true
+    build_only: true
+    extra_configs:
+      - CONFIG_MODEM_ANTENNA_GNSS_EXTERNAL=y
+      - CONFIG_LOG_BUFFER_SIZE=2048
+    extra_args: location_SNIPPET="nrf91-modem-trace-uart"
+    integration_platforms:
+      - nrf9151dk/nrf9151/ns
+    platform_allow:
+      - nrf9151dk/nrf9151/ns
+    tags: ci_build sysbuild

--- a/samples/cellular/modem_shell/sample.yaml
+++ b/samples/cellular/modem_shell/sample.yaml
@@ -579,9 +579,6 @@ tests:
     extra_args: modem_shell_SNIPPET="nrf91-modem-trace-uart"
     integration_platforms:
       - nrf9151dk/nrf9151/ns
-      - nrf9160dk/nrf9160/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
-      - nrf9160dk/nrf9160/ns
-      - nrf9161dk/nrf9161/ns
     tags: ci_build sysbuild


### PR DESCRIPTION
To optimize integration CI positioning test execution times, use twister to build test images with required configurations. The images configured to be built by twister will be copied to test environment instead of re-building similar images in Jenkins jobs.

test-sdk-nrf: sdk-nrf-pr-16010
