### PR TITLE
samples: matter: Fix diagnostic logs snippet

### DIFF
--- a/doc/nrf/protocols/matter/getting_started/advanced_kconfigs.rst
+++ b/doc/nrf/protocols/matter/getting_started/advanced_kconfigs.rst
@@ -232,7 +232,7 @@ The controller obtains the logs from the connected Matter devices according to t
 To use the diagnostic logs module, add the ``Diagnostic Logs`` cluster as ``server`` in the ZAP configuration.
 To learn how to add a new cluster to the ZAP configuration, see the :ref:`ug_matter_gs_adding_cluster` page.
 
-To enable diagnostic logs support, set the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS` Kconfig option to ``y``.
+To enable diagnostic log support, you must use the :ref:`diagnostic logs snippet <ug_matter_diagnostic_logs_snippet>`, which contains required devicetree overlays.
 
 Currently, the following intents are defined within the ``IntentEnum`` enumerator in the Matter stack:
 
@@ -270,6 +270,11 @@ The snippet sets the following kconfig options:
   * :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_REMOVE_CRASH_AFTER_READ` to ``y``.
   * :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_END_USER_LOGS` to ``y``.
   * :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_NETWORK_LOGS` to ``y``.
+
+.. note::
+
+  You cannot set the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS` Kconfig option separately without adding the devicetree overlays contained in the snippet.
+  Instead, if you want to use just some of the diagnostic logs functionality, use the snippet and set the Kconfig options for the other functionalities to ``n``.
 
 To use the snippet when building a sample, add ``-D<project_name>_SNIPPET=diagnostic-logs`` to the west arguments list.
 

--- a/snippets/matter-diagnostic-logs/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
+++ b/snippets/matter-diagnostic-logs/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
@@ -4,7 +4,7 @@
  */
 
 / {
-	sram@2003EB40 {
+	cpuapp_sram@2003EB40 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x2003EB40 0x14C0>;
 		zephyr,memory-region = "DiagnosticLogMem";
@@ -44,7 +44,7 @@
 	};
 };
 
-/* Reduce SRAM0 usage by 5312 B to account for non-init area */
-&sram0 {
+/* Reduce cpuapp_sram usage by 5312 B to account for non-init area */
+&cpuapp_sram {
 	reg = <0x20000000 0x3EB40>;
 };

--- a/snippets/matter-diagnostic-logs/snippet.yml
+++ b/snippets/matter-diagnostic-logs/snippet.yml
@@ -6,7 +6,7 @@ boards:
   nrf52840dk/nrf52840:
     append:
       EXTRA_DTC_OVERLAY_FILE: boards/nrf52840dk_nrf52840.overlay
-  nrf5340dk/nrf5340_cpuapp:
+  nrf5340dk/nrf5340/cpuapp:
     append:
       EXTRA_DTC_OVERLAY_FILE: boards/nrf5340dk_nrf5340_cpuapp.overlay
   nrf7002dk/nrf5340/cpuapp:


### PR DESCRIPTION
Several issues were found in the matter diagnostic logs snippet. Added an important note to the documentation about using snippets.

JIRA: KRKNWK-19076