### PR TITLE
applications: serial_lte_modem: data mode support for object /19

### DIFF
--- a/applications/serial_lte_modem/doc/CARRIER_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/CARRIER_AT_commands.rst
@@ -79,17 +79,15 @@ Syntax
 
 The ``<cmd>`` command is a string, and can be used as follows:
 
-* ``AT#XCARRIER="app_data_set"[,<data>][,<obj_inst_id>,<res_inst_id>]``
+* ``AT#XCARRIER="app_data_set",<uri_path>[,<data>]``
 
   Put the value in ``<data>`` into the indicated path.
-  ``<data>`` must be an opaque string in double quotes, unless ``slm_data_mode`` is enabled.
+  ``<uri_path>`` is a string in double quotes indicating the target URI path. This command currently support two possible URI paths:
 
-  * If ``<obj_inst_id>`` and ``<res_inst_id>`` are specified, the data is set in an instance of the Data resource (ID: 0) of the Binary App Data Container object (ID: 19).
-    The URI path of the resource instance is indicated as ``/19/<obj_inst_id>/0/<res_inst_id>``.
-  * If ``<obj_inst_id>`` and ``<res_inst_id>`` are not present, the data is set in the Uplink Data resource (ID: 0) of the App Data Container object (ID: 10250).
-    The URI path of the resource instance is indicated as ``/10250/0/0``.
-  * If ``<data>`` is not present, SLM enters ``slm_data_mode`` and the data is set in the Uplink Data resource (ID: 0) of the App Data Container object (ID: 10250).
-    The URI path of the resource instance is indicated as ``/10250/0/0``.
+  * ``"/10250/0/0"``, in which case the data is set in the Uplink Data resource (ID: 0) of the App Data Container object (ID: 10250).
+  * ``"/19/<obj_inst_id>/0/<res_inst_id>"``, the data is set in an instance of the Data resource (ID: 0) of the Binary App Data Container object (ID: 19).
+
+  ``<data>`` must be a hexadecimal string in double quotes, unless ``slm_data_mode`` is enabled. If ``<data>`` is not present, SLM enters ``slm_data_mode``
 
 * ``AT#XCARRIER="battery_level",<battery_level>``
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -237,6 +237,7 @@ Serial LTE modem
   * New behavior for when a connection is closed unexpectedly while SLM is in data mode.
     SLM now sends the :ref:`CONFIG_SLM_DATAMODE_TERMINATOR <CONFIG_SLM_DATAMODE_TERMINATOR>` string when this happens.
   * Sending of GNSS data to carrier library when the library is enabled.
+  * Full data mode support in the ``AT#XCARRIER="app_data_set"`` command.
 
 * Removed:
 
@@ -248,6 +249,7 @@ Serial LTE modem
 
   * AT command parsing to utilize the :ref:`at_cmd_custom_readme` library.
   * The format of the ``#XCARRIEREVT: 12`` unsolicited notification.
+  * The format of the ``AT#XCARRIER="app_data_set"`` command.
 
 Connectivity Bridge
 -------------------


### PR DESCRIPTION
The test specification of a certain carrier requires to test the upper limit of data set through the AT#XCARRIER="app_data_set". This cannot be set through a single command and so must be done via data mode. Change the format of the command to accept the target URI path as a string to be tokenized.