### PR TITLE
doc improvement: board_target: align formatting

### DIFF
--- a/doc/nrf/config_and_build/bootloaders/bootloader_downgrade_protection.rst
+++ b/doc/nrf/config_and_build/bootloaders/bootloader_downgrade_protection.rst
@@ -40,7 +40,7 @@ You can compile your application with this feature as follows:
 .. parsed-literal::
    :class: highlight
 
-   west build -b *board* *application* -- \\
+   west build -b *board_target* *application* -- \\
    -DCONFIG_BOOTLOADER_MCUBOOT=y \\
    -DCONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION=\\"0.1.2\\+3\\" \\
    -Dmcuboot_CONFIG_MCUBOOT_DOWNGRADE_PREVENTION=y \\

--- a/doc/nrf/device_guides/nrf91/nrf91_snippet.rst
+++ b/doc/nrf/device_guides/nrf91/nrf91_snippet.rst
@@ -30,12 +30,12 @@ The following board targets have support for this snippet:
 * ``nrf9160dk/nrf9160/ns``
 * ``nrf9131ek/nrf9131/ns``
 
-To enable modem traces with the flash backend, use the following command:
+To enable modem traces with the flash backend, use the following command, where *board_target* corresponds to your development kit board target and `<image_name>` to your application image name:
 
 .. parsed-literal::
    :class: highlight
 
-   west build --board *board target* -- -D<image_name>_SNIPPET="nrf91-modem-trace-ext-flash"
+   west build --board *board_target* -- -D<image_name>_SNIPPET="nrf91-modem-trace-ext-flash"
 
 .. _nrf91_modem_trace_uart_snippet:
 
@@ -51,11 +51,12 @@ This can be done in one of the following ways:
 With west
 =========
 
-To add the modem trace UART snippet when building an application with west, use the following command:
+To add the modem trace UART snippet when building an application with west, use the following command, where *board_target* corresponds to your development kit board target and `<image_name>` to your application image name:
 
-.. code-block:: console
+.. parsed-literal::
+   :class: highlight
 
-   west build --board <your_board> -- -D<image_name>_SNIPPET="nrf91-modem-trace-uart"
+   west build --board *board_target* -- -D<image_name>_SNIPPET="nrf91-modem-trace-uart"
 
 .. note::
    With Sysbuild, using the ``west build -S`` option applies the snippet to all images.
@@ -85,4 +86,4 @@ To activate both modem traces and TF-M logs, use the following command:
 .. parsed-literal::
    :class: highlight
 
-   west build --board *board target* -S nrf91-modem-trace-uart -S tfm-enable-share-uart
+   west build --board *board_target* -S nrf91-modem-trace-uart -S tfm-enable-share-uart

--- a/doc/nrf/libraries/bluetooth_services/rpc.rst
+++ b/doc/nrf/libraries/bluetooth_services/rpc.rst
@@ -89,7 +89,7 @@ Then, you can invoke build command like this:
 .. parsed-literal::
    :class: highlight
 
-   west build -b *board* -- -DEXTRA_CONF_FILE=my_overlay_file.conf
+   west build -b *board_target* -- -DEXTRA_CONF_FILE=my_overlay_file.conf
 
 Configuration
 *************

--- a/doc/nrf/protocols/matter/getting_started/hw_requirements.rst
+++ b/doc/nrf/protocols/matter/getting_started/hw_requirements.rst
@@ -589,11 +589,12 @@ For more information about configuration of memory layouts in Matter, see :ref:`
 
 ..
 
-You can generate :ref:`Partition Manager's ASCII representation <pm_partition_reports>` of these tables by running the following command for your respective *<board_target>*:
+You can generate :ref:`Partition Manager's ASCII representation <pm_partition_reports>` of these tables by running the following command for your respective *board_target*:
 
-.. code-block:: console
+.. parsed-literal::
+   :class: highlight
 
-   west build -b <board_target> -t partition_manager_report
+   west build -b *board_target* -t partition_manager_report
 
 For example, for the ``nrf7002dk/nrf5340/cpuapp`` board target, the command is as follows:
 

--- a/doc/nrf/test_and_optimize/test_framework/running_unit_tests.rst
+++ b/doc/nrf/test_and_optimize/test_framework/running_unit_tests.rst
@@ -28,7 +28,7 @@ To generate the test project and run the unit tests, locate the directory with t
          <Zephyr_path>/scripts/twister -T .
 
       This command will generate the test project and run it for :ref:`zephyr:native_sim` and ``qemu_cortex_m3`` boards.
-      If you want to specify a board target, use the ``-p <board_target>`` parameter.
+      If you want to specify a board target, use the ``-p`` parameter and specify the *board_target*.
       For example, to run the unit test on ``qemu_cortex_m3``, use the following command:
 
       .. code-block:: console
@@ -42,7 +42,7 @@ To generate the test project and run the unit tests, locate the directory with t
          <Zephyr_path>/scripts/twister -T .
 
       This command will generate the test project and run it for :ref:`zephyr:native_sim` and ``qemu_cortex_m3`` boards.
-      If you want to specify a board target, use the ``-p <board_target>`` parameter.
+      If you want to specify a board target, use the ``-p`` parameter and specify the *board_target*.
       For example, to run the unit test on ``qemu_cortex_m3``, use the following command:
 
       .. code-block:: console
@@ -51,9 +51,10 @@ To generate the test project and run the unit tests, locate the directory with t
 
    .. group-tab:: west
 
-      .. code-block:: console
+      .. parsed-literal::
+         :class: highlight
 
-         west build -b <board_target> -t run
+         west build -b *board_target* -t run
 
       The ``-t run`` parameter tells west to run the default test target.
       For example, to run the unit test on :ref:`zephyr:native_sim` board, use the following command:

--- a/samples/bluetooth/fast_pair/locator_tag/README.rst
+++ b/samples/bluetooth/fast_pair/locator_tag/README.rst
@@ -457,9 +457,10 @@ LTO is an advanced compilation technique that optimizes across all compiled unit
 See :ref:`cmake_options` for detailed instructions on how to add the ``FILE_SUFFIX=release`` option to your build.
 For example, when building from the command line, you can add it as follows:
 
-.. code-block:: console
+.. parsed-literal::
+   :class: highlight
 
-   west build -b <board_name> -- -DFILE_SUFFIX=release
+   west build -b *board_target* -- -DFILE_SUFFIX=release
 
 .. _fast_pair_locator_tag_testing:
 

--- a/samples/bluetooth/mesh/light/README.rst
+++ b/samples/bluetooth/mesh/light/README.rst
@@ -137,11 +137,12 @@ DFU configuration
    .. tab:: nRF52840 DK and nRF54L15 PDK
 
       To enable the DFU feature for the nRF52840 and nRF54L15 development kits, set :makevar:`SB_CONF_FILE` to :file:`sysbuild-dfu.conf` and :makevar:`EXTRA_CONF_FILE` to :file:`overlay-dfu.conf` when building the sample.
-      For example, when building from the command line, use the following command:
+      For example, when building from the command line, use the following command, where *board_target* is the target for the development kit for which you are building:
 
-      .. code-block:: console
+      .. parsed-literal::
+         :class: highlight
 
-         west build -b <BOARD> -p -- -DSB_CONF_FILE="sysbuild-dfu.conf" -DEXTRA_CONF_FILE="overlay-dfu.conf"
+         west build -b *board_target* -p -- -DSB_CONF_FILE="sysbuild-dfu.conf" -DEXTRA_CONF_FILE="overlay-dfu.conf"
 
       The configuration overlay file :file:`overlay-dfu.conf` and the sysbuild configuration file :file:`sysbuild-dfu.conf` enable the DFU feature.
       To review the required configuration alterations, open and inspect the two files.
@@ -151,11 +152,12 @@ DFU configuration
       To enable the DFU feature for the nRF5340 development kit, set :makevar:`SB_CONF_FILE` to :file:`sysbuild-dfu.conf` and :makevar:`EXTRA_CONF_FILE` to :file:`overlay-dfu.conf` when building the sample.
       Additionally, you need to set the :makevar:`EXTRA_CONF_FILE` for the ipc_radio network image to :file:`overlay-dfu.conf` as well.
       This is an additional network image specific configuration overlay file, which allocates the necessary resources to enable the DFU feature.
-      For example, when building from the command line, use the following command:
+      For example, when building from the command line, use the following command, where *board_target* is the target for the development kit for which you are building:
 
-      .. code-block:: console
+      .. parsed-literal::
+         :class: highlight
 
-         west build -b <BOARD> -p -- -DSB_CONF_FILE="sysbuild-dfu.conf" -DEXTRA_CONF_FILE="overlay-dfu.conf" -Dipc_radio_EXTRA_CONF_FILE="overlay-dfu.conf"
+         west build -b *board_target* -p -- -DSB_CONF_FILE="sysbuild-dfu.conf" -DEXTRA_CONF_FILE="overlay-dfu.conf" -Dipc_radio_EXTRA_CONF_FILE="overlay-dfu.conf"
 
       .. note::
          Currently, the nRF5340 development kit only supports DFU for the application core.

--- a/samples/bluetooth/mesh/light_switch/README.rst
+++ b/samples/bluetooth/mesh/light_switch/README.rst
@@ -229,11 +229,12 @@ LPN configuration
 =================
 
 To make the light switch run as an LPN, set :makevar:`EXTRA_CONF_FILE` to :file:`overlay-lpn.conf` when building the sample.
-For example, when building from the command line, use the following command:
+For example, when building from the command line, use the following command, where *board_target* is the target for the development kit for which you are building:
 
-  .. code-block:: console
+.. parsed-literal::
+   :class: highlight
 
-     west build -b <BOARD> -p -- -DEXTRA_CONF_FILE="overlay-lpn.conf"
+   west build -b *board_target* -p -- -DEXTRA_CONF_FILE="overlay-lpn.conf"
 
 The configuration overlay :file:`overlay-lpn.conf` enables the LPN feature, and alters certain configuration options to further lower the power consumption.
 To review the specific alterations, open and inspect the :file:`overlay-lpn.conf` file.

--- a/samples/cellular/nrf_cloud_multi_service/README.rst
+++ b/samples/cellular/nrf_cloud_multi_service/README.rst
@@ -922,14 +922,14 @@ If you are certain you understand the inherent security risks, you can use this 
          .. parsed-literal::
             :class: highlight
 
-            west build --board *your_board* -p always -- -DCONFIG_NRF_CLOUD_PROVISION_CERTIFICATES=y -DCONFIG_NRF_CLOUD_CLIENT_ID_SRC_COMPILE_TIME=y -DCONFIG_NRF_CLOUD_CLIENT_ID=\"698d4c11-0ccc-4f04-89cd-6882724e3f6f\"
+            west build --board *board_target* -p always -- -DCONFIG_NRF_CLOUD_PROVISION_CERTIFICATES=y -DCONFIG_NRF_CLOUD_CLIENT_ID_SRC_COMPILE_TIME=y -DCONFIG_NRF_CLOUD_CLIENT_ID=\"698d4c11-0ccc-4f04-89cd-6882724e3f6f\"
 
       .. group-tab:: PowerShell
 
          .. parsed-literal::
             :class: highlight
 
-            west build --board *your_board* -p always -- -DCONFIG_NRF_CLOUD_PROVISION_CERTIFICATES=y -DCONFIG_NRF_CLOUD_CLIENT_ID_SRC_COMPILE_TIME=y  "-DCONFIG_NRF_CLOUD_CLIENT_ID=\`"698d4c11-0ccc-4f04-89cd-6882724e3f6f\`""
+            west build --board *board_target* -p always -- -DCONFIG_NRF_CLOUD_PROVISION_CERTIFICATES=y -DCONFIG_NRF_CLOUD_CLIENT_ID_SRC_COMPILE_TIME=y  "-DCONFIG_NRF_CLOUD_CLIENT_ID=\`"698d4c11-0ccc-4f04-89cd-6882724e3f6f\`""
 
 
 .. _nrf_cloud_multi_service_setup_wifi_cred:

--- a/samples/suit/flash_companion/README.rst
+++ b/samples/suit/flash_companion/README.rst
@@ -97,8 +97,8 @@ Perform the following steps in the main application directory:
 
    .. code-block:: console
 
-      $ west build -b nrf54h20dk/nrf54h20/cpuapp --sysbuild
-      $ west flash
+      west build -b nrf54h20dk/nrf54h20/cpuapp --sysbuild
+      west flash
 
 The flash companion sample will be built flashed automatically by Sysbuild.
 

--- a/tests/tfm/tfm_psa_test/README.rst
+++ b/tests/tfm/tfm_psa_test/README.rst
@@ -50,19 +50,21 @@ Building and running
     For programming, use the :ref:`programming command without --erase <programming_params_no_erase>`.
     Programming with ``--erase`` or ``--recover`` (or similar parameters) will erase the PSA platform security parameters.
 
-You can indicate the desired test suite by using a configuration flag when building (replace ``<board_target>`` with your board name, for example ``nrf5340dk/nrf5340/cpuapp/ns``):
+You can indicate the desired test suite by using a configuration flag when building (replace *board_target* with your board target name, for example ``nrf5340dk/nrf5340/cpuapp/ns``):
 
-.. code-block:: console
+.. parsed-literal::
+   :class: highlight
 
-    west build -b <board_target> nrf/tests/tfm/tfm_psa_test -- -DCONFIG_TFM_PSA_TEST_STORAGE=y
+    west build -b *board_target* nrf/tests/tfm/tfm_psa_test -- -DCONFIG_TFM_PSA_TEST_STORAGE=y
 
 When the test suite :kconfig:option:`CONFIG_TFM_PSA_TEST_INITIAL_ATTESTATION` is selected, it is required that the device is provisioned with the PSA root-of-trust security parameters using the :ref:`provisioning image <provisioning_image>` sample.
 To provision the device, build and flash the provisioning image sample.
-Then run the PSA test suite with the following command:
+Then run the PSA test suite with the following command, where *board_target* is your board target name:
 
-.. code-block:: console
+.. parsed-literal::
+   :class: highlight
 
-    west build -b <build_target> nrf/tests/tfm/tfm_psa_test -- -DCONFIG_TFM_PSA_TEST_INITIAL_ATTESTATION=y -DCONFIG_TFM_PARTITION_INITIAL_ATTESTATION=y -DCONFIG_TFM_NRF_PROVISIONING=y
+    west build -b *board_target* nrf/tests/tfm/tfm_psa_test -- -DCONFIG_TFM_PSA_TEST_INITIAL_ATTESTATION=y -DCONFIG_TFM_PARTITION_INITIAL_ATTESTATION=y -DCONFIG_TFM_NRF_PROVISIONING=y
 
 Not all test suites are valid on all boards.
 See the :file:`testcase.yaml` file for the list of valid test suites for each board.


### PR DESCRIPTION
Applied consistent formatting to west build commands that mention board_targets.