### PR TITLE
tests:Bluetooth:Enocean: Missing linker file

### DIFF
--- a/tests/subsys/bluetooth/enocean/CMakeLists.txt
+++ b/tests/subsys/bluetooth/enocean/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(app PRIVATE ${app_sources})
 target_sources(app
     PRIVATE
     ${ZEPHYR_BASE}/subsys/bluetooth/common/addr.c
+    ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
     ${ZEPHYR_NRF_MODULE_DIR}/subsys/bluetooth/enocean.c
     )
 


### PR DESCRIPTION
Fixed an issue when optimization is turned off
the linking of the twister test failed. Default
optimization is turned on and the log functions
will be optimized away, and the twister test will
compile without any issues.