### PR TITLE
Bluetooth: Mesh: Fix scene recall for LLC server

### DIFF
--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -1803,7 +1803,7 @@ static void scene_recall(const struct bt_mesh_model *model, const uint8_t data[]
 			ctrl_enable(srv);
 		}
 
-		if (!!scene->light && !atomic_test_bit(&srv->flags, FLAG_ON)) {
+		if (!!scene->light) {
 			turn_on(srv, transition, true);
 		} else if (atomic_test_bit(&srv->flags, FLAG_ON)) {
 			transition_start(srv, LIGHT_CTRL_STATE_STANDBY, 0);


### PR DESCRIPTION
When recalling a scene during when the controller is not in standby, the Light Lightness Server would turn off the light even if the scene had the light turned on.

This commit fixes the issue by removing a check for whether the light is on when recalling a scene. The check was added to prevent recalling the same scene multiple times, but it is not necessary as this is checked in in `bt_mesh_scene_srv_set` (in `scene_srv.c`).