### PR TITLE
doc: Matter: update from build type to suffix description

### DIFF
--- a/applications/matter_bridge/doc/matter_bridge_description.rst
+++ b/applications/matter_bridge/doc/matter_bridge_description.rst
@@ -526,35 +526,43 @@ If the bridged device supports also levels higher than the selected minimum, the
 In case the bridged device does not support the minimum required level, the connection will be terminated.
 To select the minimum security level, set the :ref:`CONFIG_BRIDGE_BT_MINIMUM_SECURITY_LEVEL <CONFIG_BRIDGE_BT_MINIMUM_SECURITY_LEVEL>` Kconfig option to ``2``, ``3`` or ``4``.
 
-.. _matter_bridge_app_build_types:
+.. _matter_bridge_app_custom_configs:
 
-Matter bridge build types
-=========================
+Matter bridge custom configurations
+===================================
 
-The Matter bridge application does not use a single :file:`prj.conf` file.
-Before you start testing the application, you can select one of the build types supported by the application.
-Not every board supports both mentioned build types.
+The Matter bridge application uses a :file:`prj.conf` configuration file located in the application root directory for the default configuration.
+It also provides additional files for different custom configurations.
+When you build the application, you can select one of these configurations using the :makevar:`FILE_SUFFIX` variable.
 
-See :ref:`app_build_additions_build_types` and :ref:`modifying_build_types` for more information about this feature of the |NCS|.
+See :ref:`app_build_file_suffixes` and :ref:`cmake_options` for more information.
 
-The application supports the following build types:
 
-.. list-table:: Matter bridge build types
+The application supports the following configurations:
+
+.. list-table:: Matter bridge configurations
    :widths: auto
    :header-rows: 1
 
-   * - Build type
+   * - Configuration
      - File name
+     - :makevar:`FILE_SUFFIX`
      - Supported board
      - Description
    * - Debug (default)
      - :file:`prj.conf`
+     - No suffix
      - All from `Requirements`_
-     - Debug version of the application; can be used to enable additional features for verifying the application behavior, such as logs.
+     - Debug version of the application.
+
+       Enables additional features for verifying the application behavior, such as logs.
    * - Release
      - :file:`prj_release.conf`
+     - ``release``
      - All from `Requirements`_
-     - Release version of the application; can be used to enable only the necessary application functionalities to optimize its performance.
+     - Release version of the application.
+
+       Enables only the necessary application functionalities to optimize its performance.
 
 Building and running
 ********************
@@ -573,11 +581,11 @@ For example:
 
       west build -b nrf5340dk/nrf5340/cpuapp -p -- -Dmatter_bridge_SHIELD=nrf7002ek -DSB_CONFIG_WIFI_PATCHES_EXT_FLASH_STORE=y -DSB_CONFIG_DFU_MULTI_IMAGE_PACKAGE_WIFI_FW_PATCH=y -DSB_CONFIG_WIFI_NRF700X=y -Dmcuboot_CONFIG_UPDATEABLE_IMAGE_NUMBER=3
 
-Selecting a build type
-======================
+Selecting a configuration
+=========================
 
-Before you start testing the application, you can select one of the :ref:`matter_bridge_app_build_types`.
-See :ref:`modifying_build_types` for detailed steps how to select a build type.
+Before you start testing the application, you can select one of the :ref:`matter_bridge_app_custom_configs`.
+See :ref:`app_build_file_suffixes` and :ref:`cmake_options` for more information how to select a configuration.
 
 .. _matter_bridge_testing:
 

--- a/applications/matter_weather_station/README.rst
+++ b/applications/matter_weather_station/README.rst
@@ -47,7 +47,7 @@ IPv6 network support
 The development kits for this sample offer the following IPv6 network support for Matter:
 
 * Matter over Thread is supported for ``thingy53/nrf5340/cpuapp``.
-* Matter over Wi-Fi is supported for ``thingy53/nrf5340/cpuapp`` with the ``nrf7002`` expansion board attached, for the :file:`prj_release.conf` build type only.
+* Matter over Wi-Fi is supported for ``thingy53/nrf5340/cpuapp`` with the ``nrf7002`` expansion board attached, for the :ref:`release configuration <matter_weather_station_custom_configs>` only.
   See `Building for the nRF7002 Wi-Fi expansion board`_ for more information.
 
 Overview
@@ -111,7 +111,6 @@ Button (SW3):
 USB port:
     Used for getting logs from the device or communicating with it through the command-line interface.
     It is enabled only for the debug configuration of an application.
-    See the `Selecting a build type`_ section to learn how to select the debug configuration.
 
 NFC port with antenna attached:
     Used for obtaining the `Onboarding information`_ from the Matter accessory device to start the commissioning procedure.
@@ -121,37 +120,44 @@ Configuration
 
 |config|
 
-.. _matter_weather_station_app_build_types:
+.. _matter_weather_station_custom_configs:
 
-Matter weather station build types
-==================================
+Matter weather station custom configurations
+============================================
 
-The Matter weather station application does not use a single :file:`prj.conf` file.
-Configuration files are provided for different build types, and they are located in the :file:`configuration/thingy53_nrf5340_cpuapp` directory.
-Before you start testing the application, you can select one of the build types supported by the application.
+The Matter weather station application uses a :file:`prj.conf` configuration file located in the root directory for the default configuration.
+It also provides additional files for different custom configurations.
+When you build the application, you can select one of these configurations using the :makevar:`FILE_SUFFIX` variable.
 
-See :ref:`app_build_additions_build_types` and :ref:`cmake_options` for more information.
+See :ref:`app_build_file_suffixes` and :ref:`cmake_options` for more information.
 
-The application supports the following build types:
+The application supports the following configurations:
 
-.. list-table:: Matter weather station build types
+.. list-table:: Matter weather station configurations
    :widths: auto
    :header-rows: 1
 
-   * - Build type
+   * - Configuration
      - File name
+     - :makevar:`FILE_SUFFIX`
      - Supported board
      - Description
    * - Debug (default)
      - :file:`prj.conf`
+     - No suffix
      - All from `Requirements`_
-     - Debug version of the application; can be used to enable additional features for verifying the application behavior, such as logs or command-line shell.
+     - Debug version of the application.
+
+       Enables additional features for verifying the application behavior, such as logs.
    * - Release
      - :file:`prj_release.conf`
+     - ``release``
      - All from `Requirements`_
-     - | Release version of the application; can be used to enable only the necessary application functionalities to optimize its performance.
-       |
-       | Currently, this application supports only the release build type when `Building for the nRF7002 Wi-Fi expansion board`_.
+     - Release version of the application.
+
+       Enables only the necessary application functionalities to optimize its performance.
+
+       Currently, only the release configuration is supported when `Building for the nRF7002 Wi-Fi expansion board`_.
 
 .. _matter_weather_station_app_build_configuration_overlays:
 
@@ -185,11 +191,11 @@ Building and running
 
 .. include:: /includes/build_and_run.txt
 
-Selecting a build type
-======================
+Selecting a configuration
+=========================
 
-Before you start testing the application, you can select one of the :ref:`matter_weather_station_app_build_types`.
-See :ref:`cmake_options` for information about how to select a build type.
+Before you start testing the application, you can select one of the :ref:`matter_weather_station_custom_configs`.
+See :ref:`app_build_file_suffixes` and :ref:`cmake_options` for more information how to select a configuration.
 
 Building for the nRF7002 Wi-Fi expansion board
 ==============================================
@@ -203,7 +209,7 @@ To build this application to work with the nRF7002 Wi-Fi expansion board:
 
       .. group-tab:: nRF Connect for VS Code
 
-         To build the application in the nRF Connect for VS Code IDE for Thingy:53 with the nRF7002 EB attached, add the expansion board and the build type variables in the build configuration's :guilabel:`Extra CMake arguments` and rebuild the build configuration.
+         To build the application in the nRF Connect for VS Code IDE for Thingy:53 with the nRF7002 EB attached, add the expansion board and the file suffix variables in the build configuration's :guilabel:`Extra CMake arguments` and rebuild the build configuration.
          For example: ``-- -Dmatter_weather_station_SHIELD=nrf7002eb -DFILE_SUFFIX=release -DSB_CONFIG_WIFI_NRF700X=y``.
 
       .. group-tab:: Command line
@@ -318,11 +324,11 @@ The onboarding information representation depends on your commissioner setup.
 For this application, the data payload, which includes the device discriminator and setup PIN code, is encoded and shared using an NFC tag.
 When using the debug configuration, you can also get this type of information from the USB interface logs.
 
-Alternatively, depending on your build type and selected overlay, you can also use one of the following :ref:`onboarding information formats <ug_matter_network_topologies_commissioning_onboarding_formats>` to provide the commissioner with the data required:
+Alternatively, depending on your configuration and selected overlay, you can also use one of the following :ref:`onboarding information formats <ug_matter_network_topologies_commissioning_onboarding_formats>` to provide the commissioner with the data required:
 
-* For the debug and release build types:
+* For the debug and release configurations:
 
-  .. list-table:: Weather station application onboarding information for the debug build type
+  .. list-table:: Weather station application onboarding information for the debug or release configurations
      :header-rows: 1
 
      * - QR Code
@@ -332,7 +338,7 @@ Alternatively, depending on your build type and selected overlay, you can also u
 
          .. figure:: /images/matter_qr_code_weather_station_default.png
             :width: 200px
-            :alt: QR code for commissioning the weather station device (debug build type)
+            :alt: QR code for commissioning the weather station device (debug or release configuration)
 
        - MT:M1TJ342C00KA0648G00
        - 34970112332

--- a/doc/nrf/includes/sample_custom_config_intro.txt
+++ b/doc/nrf/includes/sample_custom_config_intro.txt
@@ -1,0 +1,5 @@
+The sample uses a :file:`prj.conf` configuration file located in the sample root directory for the default configuration.
+It also provides additional files for different custom configurations.
+When you build the sample, you can select one of these configurations using the :makevar:`FILE_SUFFIX` variable.
+
+See :ref:`app_build_file_suffixes` and :ref:`cmake_options` for more information.

--- a/samples/matter/light_bulb/README.rst
+++ b/samples/matter/light_bulb/README.rst
@@ -73,38 +73,40 @@ Configuration
 
 |config|
 
+.. _matter_light_bulb_custom_configs:
 
-.. _matter_light_bulb_build_types:
-
-Matter light bulb build types
-=============================
+Matter light bulb custom configurations
+=======================================
 
 .. matter_light_bulb_sample_configuration_file_types_start
 
-The sample does not use a single :file:`prj.conf` file.
-Configuration files are provided for different build types, and they are located in the sample root directory.
-Before you start testing the application, you can select one of the build types supported by the application.
+.. include:: /includes/sample_custom_config_intro.txt
 
-See :ref:`app_build_additions_build_types` and :ref:`cmake_options` for more information.
+The sample supports the following configurations:
 
-The sample supports the following build types:
-
-.. list-table:: Sample build types
+.. list-table:: Sample configurations
    :widths: auto
    :header-rows: 1
 
-   * - Build type
+   * - Configuration
      - File name
+     - :makevar:`FILE_SUFFIX`
      - Supported board
      - Description
    * - Debug (default)
      - :file:`prj.conf`
+     - No suffix
      - All from `Requirements`_
-     - Debug version of the application; can be used to enable additional features for verifying the application behavior, such as logs or command-line shell.
+     - Debug version of the application.
+
+       Enables additional features for verifying the application behavior, such as logs.
    * - Release
      - :file:`prj_release.conf`
+     - ``release``
      - All from `Requirements`_
-     - Release version of the application; can be used to enable only the necessary application functionalities to optimize its performance.
+     - Release version of the application.
+
+       Enables only the necessary application functionalities to optimize its performance.
 
 .. matter_light_bulb_sample_configuration_file_types_end
 
@@ -256,11 +258,11 @@ Building and running
 
 See `Configuration`_ for information about building the sample with the DFU support.
 
-Selecting a build type
-======================
+Selecting a custom configuration
+================================
 
-Before you start testing the application, you can select one of the :ref:`matter_light_bulb_build_types`.
-See :ref:`cmake_options` for information about how to select a build type.
+Before you start testing the application, you can select one of the :ref:`matter_light_bulb_custom_configs`.
+See :ref:`app_build_file_suffixes` and :ref:`cmake_options` for more information how to select a configuration.
 
 Testing
 =======

--- a/samples/matter/light_switch/README.rst
+++ b/samples/matter/light_switch/README.rst
@@ -108,8 +108,10 @@ Configuration
 
 |config|
 
-Matter light switch build types
-===============================
+.. _matter_light_switch_custom_configs:
+
+Matter light switch custom configurations
+=========================================
 
 .. include:: ../light_bulb/README.rst
     :start-after: matter_light_bulb_sample_configuration_file_types_start
@@ -202,7 +204,7 @@ User interface
 Matter CLI commands
 ===================
 
-If you build the application using the ``debug`` build type, you can use a series of commands to control the light switch device.
+If you build the application with the :ref:`debug configuration <matter_light_switch_custom_configs>`, you can use a series of commands to control the light switch device.
 These commands can be sent to one device (unicast) or a group of devices (groupcast).
 
 Unicast commands
@@ -278,11 +280,11 @@ Building and running
 
 See `Configuration`_ for information about building the sample with the DFU support.
 
-Selecting a build type
-======================
+Selecting a configuration
+=========================
 
-Before you start testing the application, you can select one of the `Matter light switch build types`_.
-See :ref:`cmake_options` for information about how to select a build type.
+Before you start testing the application, you can select one of the :ref:`matter_light_switch_custom_configs`.
+See :ref:`app_build_file_suffixes` and :ref:`cmake_options` for more information how to select a configuration.
 
 Testing
 *******

--- a/samples/matter/lock/README.rst
+++ b/samples/matter/lock/README.rst
@@ -45,7 +45,7 @@ The development kits for this sample offer the following IPv6 network support fo
 
 * Matter over Thread is supported for ``nrf52840dk/nrf52840``, ``nrf5340dk/nrf5340/cpuapp``, ``nrf21540dk/nrf52840``, and ``nrf54h20dk/nrf54h20/cpuapp``.
 * Matter over Wi-Fi is supported for ``nrf5340dk/nrf5340/cpuapp`` with the ``nrf7002ek`` shield attached (2.4 GHz and 5 GHz), for ``nrf7002dk/nrf5340/cpuapp`` (2.4 GHz and 5 GHz), or for ``nrf7002dk/nrf5340/cpuapp/nrf7001`` (2.4 GHz only).
-* :ref:`Switching between Matter over Thread and Matter over Wi-Fi <matter_lock_sample_wifi_thread_switching>` is supported for ``nrf5340dk/nrf5340/cpuapp`` with the ``nrf7002ek`` shield attached, using the ``thread_wifi_switched`` build type.
+* :ref:`Switching between Matter over Thread and Matter over Wi-Fi <matter_lock_sample_wifi_thread_switching>` is supported for ``nrf5340dk/nrf5340/cpuapp`` with the ``nrf7002ek`` shield attached, using the :ref:`switched Thread and Wi-Fi configuration <matter_lock_sample_custom_configs>`.
 
 Overview
 ********
@@ -99,7 +99,7 @@ The following Kconfig options control the limits of the users and credentials th
 Thread and Wi-Fi switching
 ==========================
 
-When built using the ``thread_wifi_switched`` build type and programmed to the nRF5340 DK with the nRF7002 EK shield attached, the door lock sample supports a feature that allows you to :ref:`switch between Matter over Thread and Matter over Wi-Fi <ug_matter_overview_architecture_integration_designs_switchable>` at runtime.
+When built using the :ref:`switched Thread and Wi-Fi configuration <matter_lock_sample_custom_configs>` and programmed to the nRF5340 DK with the nRF7002 EK shield attached, the door lock sample supports a feature that allows you to :ref:`switch between Matter over Thread and Matter over Wi-Fi <ug_matter_overview_architecture_integration_designs_switchable>` at runtime.
 Due to Matter protocol limitations, a single Matter node can only use one transport protocol at a time.
 
 .. matter_door_lock_sample_thread_wifi_switch_desc_start
@@ -108,14 +108,14 @@ The application is built with support for both Matter over Thread and Matter ove
 The device activates either Thread or Wi-Fi transport protocol on boot, based on a flag stored in the non-volatile memory on the device.
 By default, Matter over Wi-Fi is activated.
 
-You can trigger the switch from one transport protocol to the other using the **Button 3** on the nRF5340 DK.
+You can trigger the switch from one transport protocol to the other using **Button 3** on the nRF5340 DK.
 This toggles the flag stored in the non-volatile memory, and then the device is factory reset and rebooted.
 Because the flag is toggled, the factory reset does not switch the device back to the default transport protocol (Wi-Fi).
 Instead, the factory reset and recommissioning to a Matter fabric allows the device to be provisioned with network credentials for the transport protocol that it was switched to, and to start operating in the selected network.
 
 .. matter_door_lock_sample_thread_wifi_switch_desc_end
 
-See `Matter door lock build types`_, `Selecting a build type`_, and :ref:`matter_lock_sample_switching_thread_wifi` for more information about how to configure and test this feature with this sample.
+See :ref:`matter_lock_sample_custom_configs` and :ref:`matter_lock_sample_switching_thread_wifi` for more information about how to configure and test this feature with this sample.
 
 Wi-Fi firmware on external memory
 ---------------------------------
@@ -203,39 +203,43 @@ Configuration
 
 |config|
 
-.. _matter_lock_sample_configuration_build_types:
+.. _matter_lock_sample_custom_configs:
 
-Matter door lock build types
-============================
+Matter door lock custom configurations
+======================================
 
 .. matter_door_lock_sample_configuration_file_types_start
 
-The sample does not use a single :file:`prj.conf` file.
-Configuration files are provided for different build types, and they are located in the sample root directory.
-Before you start testing the application, you can select one of the build types supported by the application.
+.. include:: /includes/sample_custom_config_intro.txt
 
-See :ref:`app_build_additions_build_types` and :ref:`cmake_options` for more information.
+The sample supports the following configurations:
 
-The sample supports the following build types:
-
-.. list-table:: Sample build types
+.. list-table:: Sample configurations
    :widths: auto
    :header-rows: 1
 
-   * - Build type
+   * - Configuration
      - File name
+     - :makevar:`FILE_SUFFIX`
      - Supported board
      - Description
    * - Debug (default)
      - :file:`prj.conf`
+     - No suffix
      - All from `Requirements`_
-     - Debug version of the application; can be used to enable additional features for verifying the application behavior, such as logs or command-line shell.
+     - Debug version of the application.
+
+       Enables additional features for verifying the application behavior, such as logs.
    * - Release
      - :file:`prj_release.conf`
+     - ``release``
      - All from `Requirements`_
-     - Release version of the application; can be used to enable only the necessary application functionalities to optimize its performance.
+     - Release version of the application.
+
+       Enables only the necessary application functionalities to optimize its performance.
    * - Switched Thread and Wi-Fi
      - :file:`prj_thread_wifi_switched.conf`
+     - ``thread_wifi_switched``
      - nRF5340 DK with the nRF7002 EK shield attached
      - Debug version of the application with the ability to :ref:`switch between Thread and Wi-Fi network support <matter_lock_sample_wifi_thread_switching>` in the field.
 
@@ -302,15 +306,15 @@ You can enable the :ref:`matter_lock_sample_ble_nus` feature by setting the :kco
    Matter commissioning, DFU, and NUS over Bluetooth LE must be run separately.
 
 The door lock's Bluetooth LE service extension with NUS requires a secure connection with a smartphone, which is established using a security PIN code.
-The PIN code is different depending on the build type:
+The PIN code is different depending on the :ref:`configuration <matter_lock_sample_custom_configs>` the sample was built with:
 
-* In the ``debug`` build type, the secure PIN code is generated randomly and printed in the log console in the following way:
+* In the debug configuration, the secure PIN code is generated randomly and printed in the log console in the following way:
 
   .. code-block:: console
 
      PROVIDE THE FOLLOWING CODE IN YOUR MOBILE APP: 165768
 
-* In the ``release`` build type, the secure PIN is set to ``123456`` due to lack of a different way of showing it on nRF boards other than in the log console.
+* In the release configuration, the secure PIN is set to ``123456`` due to lack of a different way of showing it on nRF boards other than in the log console.
 
 See `Testing door lock using Bluetooth LE with Nordic UART Service`_ for more information about how to test this feature.
 
@@ -319,7 +323,7 @@ Factory data support
 
 .. matter_door_lock_sample_factory_data_start
 
-In this sample, the factory data support is enabled by default for all build types except for the target board nRF21540 DK.
+In this sample, the factory data support is enabled by default for all configurations except for the target board nRF21540 DK.
 This means that a new factory data set will be automatically generated when building for the target board.
 
 To disable factory data support, set the following Kconfig options to ``n``:
@@ -359,8 +363,8 @@ User interface
          * Changes the lock state to the opposite one.
 
       Button 3:
-         * On the nRF5340 DK when using the ``thread_wifi_switched`` build type: If pressed for more than ten seconds, it switches the Matter transport protocol from Thread or Wi-Fi to the other and factory resets the device.
-         * On other platform or build type: Not available.
+         * On the nRF5340 DK when using the :ref:`switched Thread and Wi-Fi configuration <matter_lock_sample_custom_configs>`: If pressed for more than ten seconds, it switches the Matter transport protocol from Thread or Wi-Fi to the other and factory resets the device.
+         * On other platform or configuration: Not available.
 
       .. include:: /includes/matter_segger_usb.txt
 
@@ -403,11 +407,11 @@ Building and running
 
 See `Configuration`_ for information about building the sample with the DFU support.
 
-Selecting a build type
-======================
+Selecting a configuration
+=========================
 
-Before you start testing the application, you can select one of the :ref:`matter_lock_sample_configuration_build_types`.
-See :ref:`cmake_options` for information about how to select a build type.
+Before you start testing the application, you can select one of the :ref:`matter_lock_sample_custom_configs`.
+See :ref:`app_build_file_suffixes` and :ref:`cmake_options` for more information how to select a configuration.
 
 Testing
 =======
@@ -839,11 +843,11 @@ Testing switching between Thread and Wi-Fi
 ==========================================
 
 .. note::
-   You can only test :ref:`matter_lock_sample_wifi_thread_switching` on the nRF5340 DK with the nRF7002 EK shield attached, using the ``thread_wifi_switched`` build type.
+   You can only test :ref:`matter_lock_sample_wifi_thread_switching` on the nRF5340 DK with the nRF7002 EK shield attached, using the :ref:`switched Thread and Wi-Fi configuration <matter_lock_sample_custom_configs>`.
 
 To test this feature, complete the following steps:
 
-#. Build the door lock application using the ``thread_wifi_switched`` build type:
+#. Build the door lock application using the switched Thread and Wi-Fi configuration:
 
    .. code-block:: console
 
@@ -876,6 +880,9 @@ Testing door lock using Bluetooth LE with Nordic UART Service
 
 To test the :ref:`matter_lock_sample_ble_nus` feature, complete the following steps:
 
+.. note::
+   Some of the steps depend on which :ref:`configuration <matter_lock_sample_custom_configs>` the sample was built with.
+
 #. Install `nRF Toolbox`_ on your Android (Android 11 or newer) or iOS (iOS 16.1 or newer) smartphone.
 #. Build the door lock application for Matter over Thread with the :kconfig:option:`CONFIG_CHIP_NUS` set to ``y``.
    For example, if you build from command line for the ``nrf52840dk/nrf52840``, use the following command:
@@ -890,17 +897,17 @@ To test the :ref:`matter_lock_sample_ble_nus` feature, complete the following st
 
       west flash --erase
 
-#. If you built the sample with the ``debug`` build type, connect the board to an UART console to see the log entries from the device.
+#. If you built the sample with the debug configuration, connect the board to an UART console to see the log entries from the device.
 #. Open the nRF Toolbox application on your smartphone.
 #. Select :guilabel:`Universal Asynchronous Receiver/Transmitter UART` from the list in the nRF Toolbox application.
 #. Tap on :guilabel:`Connect`.
    The application connects to the devices connected through UART.
 #. Select :guilabel:`MatterLock_NUS` from the list of available devices.
    The Bluetooth Pairing Request with an input field for passkey appears as a notification (Android) or on the screen (iOS).
-#. Depending on the build type you are using:
+#. Depending on the configuration you are using:
 
-   * For the ``release`` build type: Enter the passkey ``123456``.
-   * For the ``debug`` build type, complete the following steps:
+   * For the release configuration: Enter the passkey ``123456``.
+   * For the debug configuration, complete the following steps:
 
      a. Search the device's logs to find ``PROVIDE THE FOLLOWING CODE IN YOUR MOBILE APP:`` phrase.
      #. Read the randomly generated passkey from the console logs.

--- a/samples/matter/template/README.rst
+++ b/samples/matter/template/README.rst
@@ -99,8 +99,10 @@ Configuration
 
 |config|
 
-Matter template build types
-===========================
+.. _matter_template_custom_configs:
+
+Matter template custom configurations
+=====================================
 
 .. include:: ../light_bulb/README.rst
     :start-after: matter_light_bulb_sample_configuration_file_types_start
@@ -115,7 +117,7 @@ Device Firmware Upgrade support
 
 Alternatively, for the nRF54L15 PDK, the DFU can be configured to only use the internal MRAM for storage.
 This means that both the currently running firmware and the new firmware to be updated will be stored within the device's internal flash memory.
-This configuration is only available for the ``release`` build variant.
+This configuration is only available for the :ref:`release configuration <matter_template_custom_configs>`.
 
 The following is an example command to build the sample on the nRF54L15 PDK with support for Matter OTA DFU and DFU over Bluetooth® SMP, and using internal MRAM only:
 
@@ -170,11 +172,11 @@ Building and running
 
 .. include:: /includes/build_and_run.txt
 
-Selecting a build type
-======================
+Selecting a configuration
+=========================
 
-Before you start testing the application, you can select one of the `Matter template build types`_.
-See :ref:`cmake_options` for information about how to select a build type.
+Before you start testing the application, you can select one of the :ref:`matter_template_custom_configs`.
+See :ref:`app_build_file_suffixes` and :ref:`cmake_options` for more information how to select a configuration.
 
 Testing
 =======

--- a/samples/matter/thermostat/README.rst
+++ b/samples/matter/thermostat/README.rst
@@ -103,33 +103,14 @@ Binding
 In this sample, the thermostat device prints simulated temperature data by default and it does not know the remote endpoints of the temperature sensors (on remote nodes).
 Using binding, the thermostat device updates its Binding cluster with all relevant information about the temperature sensor devices, such as their IPv6 address, node ID, and the IDs of the remote endpoints that contain the temperature measurement cluster.
 
-Matter thermostat build types
-=============================
+.. _matter_thermostat_custom_configs:
 
-The sample does not use a single :file:`prj.conf` file.
-Configuration files are provided for different build types, and they are located in the sample root directory.
-Before you start testing the application, you can select one of the build types supported by the application.
+Matter thermostat custom configurations
+=======================================
 
-See :ref:`app_build_additions_build_types` and :ref:`cmake_options` for more information.
-
-The sample supports the following build types:
-
-.. list-table:: Sample build types
-   :widths: auto
-   :header-rows: 1
-
-   * - Build type
-     - File name
-     - Supported board
-     - Description
-   * - Debug (default)
-     - :file:`prj.conf`
-     - All from `Requirements`_
-     - Debug version of the application; can be used to enable additional features for verifying the application behavior, such as logs or command-line shell.
-   * - Release
-     - :file:`prj_release.conf`
-     - All from `Requirements`_
-     - Release version of the application; can be used to enable only the necessary application functionalities to optimize its performance.
+.. include:: ../light_bulb/README.rst
+    :start-after: matter_light_bulb_sample_configuration_file_types_start
+    :end-before: matter_light_bulb_sample_configuration_file_types_end
 
 Device Firmware Upgrade support
 ===============================
@@ -201,8 +182,8 @@ Building and running
 Selecting a build type
 ======================
 
-Before you start testing the application, you can select one of the `Matter thermostat build types`_, depending on your building method.
-See :ref:`cmake_options` for information about how to select a build type.
+Before you start testing the application, you can select one of the :ref:`matter_thermostat_custom_configs`, depending on your building method.
+See :ref:`app_build_file_suffixes` and :ref:`cmake_options` for more information how to select a configuration.
 
 .. _matter_thermostat_testing:
 

--- a/samples/matter/window_covering/README.rst
+++ b/samples/matter/window_covering/README.rst
@@ -84,8 +84,10 @@ Configuration
 
 |config|
 
-Matter window covering build types
-==================================
+.. _matter_window_cover_custom_configs:
+
+Matter window covering custom configurations
+============================================
 
 .. include:: ../light_bulb/README.rst
     :start-after: matter_light_bulb_sample_configuration_file_types_start
@@ -201,11 +203,11 @@ Building and running
 
 .. include:: /includes/build_and_run.txt
 
-Selecting a build type
-======================
+Selecting a configuration
+=========================
 
-Before you start testing the application, you can select one of the `Matter window covering build types`_.
-See :ref:`cmake_options` for information about how to select a build type.
+Before you start testing the application, you can select one of the :ref:`matter_window_cover_custom_configs`.
+See :ref:`app_build_file_suffixes` and :ref:`cmake_options` for more information how to select a configuration.
 
 Testing
 =======


### PR DESCRIPTION
Sample documentation still refers to build types, which are deprecated. This updates the wording to match the use of the FILE_SUFFIX variable.