### PR TITLE
applications: serial_lte_modem: adjust SLM_CARRIER_APP_DATA_BUFFER_LEN

### DIFF
--- a/applications/serial_lte_modem/src/lwm2m_carrier/Kconfig
+++ b/applications/serial_lte_modem/src/lwm2m_carrier/Kconfig
@@ -12,8 +12,8 @@ if SLM_CARRIER
 
 config SLM_CARRIER_APP_DATA_BUFFER_LEN
 	int "Size of the buffer for setting application data in hexadecimal string format"
-	default 1536
-	range 128 1536
+	default 1537
+	range 128 1537
 	help
 	  Specifies maximum application data size (in hexadecimal string format) to be set in the
 	  App Data Container, the Binary App Data Container or the Event Log objects.


### PR DESCRIPTION
The buffer used to set application data via AT#XCARRIER="app_data_set" is of size SLM_CARRIER_APP_DATA_BUFFER_LEN. This buffer however must also accommodate a null-terminator on top of the actual data when retrieving the string from the issued AT command. Increase the size by one byte as it is crucial to pass a test item of a certain operator, which verifies the upper limit of data that can be set.