### PR TITLE
manifest: update sdk-zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 100befc70c74f7ec83dd8ac3171ee18eeddb4dbd
+      revision: pull/1799/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Nrfx none adc support on nrf54h20
https://github.com/nrfconnect/sdk-zephyr/pull/1799
https://github.com/zephyrproject-rtos/zephyr/pull/74146