### PR TITLE
Clang-format: Sync Clang rules to CI rules.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -78,6 +78,7 @@ IncludeCategories:
   - Regex: '.*'
     Priority: 3
 IndentCaseLabels: false
+IndentGotoLabels: false
 IndentWidth: 8
 InsertBraces: true
 SpaceBeforeParens: ControlStatementsExceptControlMacros


### PR DESCRIPTION
Added flag: IndentGotoLabels: false