### PR TITLE
samples: matter: Fixed secure backend remove condition

### DIFF
--- a/samples/matter/common/src/persistent_storage/backends/persistent_storage_secure.cpp
+++ b/samples/matter/common/src/persistent_storage/backends/persistent_storage_secure.cpp
@@ -72,7 +72,7 @@ PSErrorCode PersistentStorageSecure::_SecureRemove(PersistentStorageNode *node)
 	if (node->GetKey(key)) {
 		bool alreadyInTheMap{ false };
 		psa_storage_uid_t uid = UIDFromString(key, &alreadyInTheMap);
-		if (!alreadyInTheMap) {
+		if (alreadyInTheMap) {
 			psa_status_t status = psa_ps_remove(uid);
 
 			if (status == PSA_SUCCESS) {


### PR DESCRIPTION
The SecureRemove method removes object only if it is NOT present in the map, what seems to be a broken condition.