### PR TITLE
manifest: Update Zephyr version for west build fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: b42e02dfde50c7fec35eabaf69f68eaad107fa08
+      revision: 6439bfe920118e4f9eb73377d98c327358406873
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update Zephyr version for west build to correctly do incremental builds.

Jira: NCSDK-27859