### PR TITLE
scripts: hid_configurator: Add support in Windows for dll folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ ext/lib/bin/libsupl.zip
 ext/BSEC_*
 
 applications/nrf5340_audio/src/fw_info_app.c
+scripts/hid_configurator/hidapi.dll

--- a/scripts/hid_configurator/README.rst
+++ b/scripts/hid_configurator/README.rst
@@ -54,10 +54,7 @@ Complete the following steps:
    Use the bundled DLL or build it according to instructions in `HIDAPI library`_.
 
 #. Select the appropriate HIDADPI library version for the used Windows system (either ``x86`` or ``x64``).
-   Copy the :file:`hidapi.dll` file and paste it into either of the following directory:
-
-   * The directory where used Python executable is located.
-   * The :file:`Windows\\System32` directory, for example :file:`C:\\Windows\\System32`.
+   Copy the :file:`hidapi.dll` file and paste it into the directory where the :file:`configurator_cli.py` script is located.
 
 #. Install `pyhidapi Python wrapper`_ and other required libraries with the following command:
 

--- a/scripts/hid_configurator/configurator_cli.py
+++ b/scripts/hid_configurator/configurator_cli.py
@@ -8,6 +8,15 @@ import logging
 import os
 import pprint
 
+if os.name == "nt":
+    try:
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        os.add_dll_directory(script_dir)
+    except AttributeError:
+        print('Cannot add directory containing configurator_cli.py script to DLL search path. \
+               Please update to Python 3.8 or newer to allow placing hidapi.dll in the directory \
+               containing configurator_cli.py script')
+
 from NrfHidManager import NrfHidManager
 
 from modules.module_config import MODULE_CONFIG
@@ -186,12 +195,7 @@ def perform_led_stream(dev, args):
 
 
 def parse_arguments():
-    try:
-        parser = argparse.ArgumentParser(allow_abbrev=False)
-    except TypeError:
-        # The allow_abbrev argument was added in Python 3.5.
-        # Skip setting the value if used Python version does not support it.
-        parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
 
     parser.add_argument(dest='device', default=None, nargs='?',
                         help='Device specified by type, board name or HW ID '


### PR DESCRIPTION
Adding the path to find a .dll to PATH
environment variable has been removed in Python 3.8. Now os.add_dll_directory is recommended solution for adding dll. This commit adds an optional argument to script with path to dll folder.

Jira: NCSDK-27863