### PR TITLE
lib: sms: Add support for Service Center Address

### DIFF
--- a/doc/nrf/libraries/modem/gcf_sms_lib.rst
+++ b/doc/nrf/libraries/modem/gcf_sms_lib.rst
@@ -13,6 +13,25 @@ The library implements the following AT commands:
 * ``AT+CPMS``
 * ``AT+CSMS``
 * ``AT+CSCA``
+
+  * Set command: ``+CSCA=<sca>[,<tosca>]``
+
+    * ``<sca>``: string
+    * ``<tosca>``: Type-of-Address octet in integer format, default ``145``.
+
+   .. code-block:: console
+
+      AT+CSCA=""+358501234567""
+      OK"
+
+  * Read command: ``+CSCA?``
+
+    .. code-block:: console
+
+       AT+CSCA?
+       +CSCA: ""+358501234567"",145"
+       OK
+
 * ``AT+CSCS``
 * ``AT+CMGD``
 * ``AT+CMSS``

--- a/doc/nrf/libraries/modem/sms.rst
+++ b/doc/nrf/libraries/modem/sms.rst
@@ -23,13 +23,21 @@ In addition, AT commands are also used to send SMS messages.
 SMS notifications are received using AT commands, but those are not visible for the users of this module.
 The module automatically acknowledges the SMS messages received on behalf of each listener.
 
+The SMS module reads the SMS service center number using the ``AT+CSCA?`` AT command.
+Most applications do not need to set a custom SMS service center number because the default value is enough.
+However, if your application requires a custom SMS service center number, you can set it using the ``AT+CSCA`` AT command.
+Because ``AT+CSCA`` AT command is not supported by the modem firmware, you can use the :ref:`lib_gcf_sms_readme` library.
+
 Configuration
 *************
 
-Configure the following Kconfig options when using this library:
+Configure the following mandatory Kconfig options when using this library:
 
-* :kconfig:option:`CONFIG_SMS` - Enables the SMS subscriber library.
+* :kconfig:option:`CONFIG_SMS` - Enables the SMS library.
 * :kconfig:option:`CONFIG_SMS_SUBSCRIBERS_MAX_CNT` - Sets the maximum number of SMS subscribers.
+
+Check and configure the optional :kconfig:option:`CONFIG_GCF_SMS` Kconfig option when using this library.
+It enables the :ref:`lib_gcf_sms_readme` library for the ``AT+CSCA`` AT command support to allow a custom SMS service center number.
 
 Limitations
 ***********

--- a/doc/nrf/libraries/modem/sms.rst
+++ b/doc/nrf/libraries/modem/sms.rst
@@ -23,9 +23,9 @@ In addition, AT commands are also used to send SMS messages.
 SMS notifications are received using AT commands, but those are not visible for the users of this module.
 The module automatically acknowledges the SMS messages received on behalf of each listener.
 
-The SMS module reads the SMS service center number using the ``AT+CSCA?`` AT command.
-Most applications do not need to set a custom SMS service center number because the default value is enough.
-However, if your application requires a custom SMS service center number, you can set it using the ``AT+CSCA`` AT command.
+The SMS module reads the SMS service center address, that is, phone number of the SMS service center, using the ``AT+CSCA?`` AT command.
+Most applications do not need to set a custom SMS service center address because the default value is enough.
+However, if your application requires a custom SMS service center address, you can set it using the ``AT+CSCA`` AT command.
 Because ``AT+CSCA`` AT command is not supported by the modem firmware, you can use the :ref:`lib_gcf_sms_readme` library.
 
 Configuration
@@ -37,7 +37,7 @@ Configure the following mandatory Kconfig options when using this library:
 * :kconfig:option:`CONFIG_SMS_SUBSCRIBERS_MAX_CNT` - Sets the maximum number of SMS subscribers.
 
 Check and configure the optional :kconfig:option:`CONFIG_GCF_SMS` Kconfig option when using this library.
-It enables the :ref:`lib_gcf_sms_readme` library for the ``AT+CSCA`` AT command support to allow a custom SMS service center number.
+It enables the :ref:`lib_gcf_sms_readme` library for the ``AT+CSCA`` AT command support to allow a custom SMS service center address.
 
 Limitations
 ***********

--- a/include/modem/sms.h
+++ b/include/modem/sms.h
@@ -52,7 +52,7 @@ enum sms_data_type {
 
 /**
  * @brief Maximum length of SMS address, i.e., phone number, in characters
- * as specified in 3GPP TS 23.040 Section 9.1.2.3.
+ * as specified in 3GPP TS 23.040 Section 9.1.2.5.
  */
 #define SMS_MAX_ADDRESS_LEN_CHARS 20
 

--- a/include/modem/sms.h
+++ b/include/modem/sms.h
@@ -233,8 +233,6 @@ int sms_send_text(const char *number, const char *text);
  *
  * This function does not support sending of 8 bit binary data messages or UCS2 encoded text.
  *
- * Concatenated messages are not supported in this function.
- *
  * @param[in] number Recipient number in international format.
  * @param[in] data Data to be sent.
  * @param[in] data_len Data length.

--- a/lib/sms/sms_submit.c
+++ b/lib/sms/sms_submit.c
@@ -63,7 +63,7 @@ static int sms_submit_encode_number(
 	__ASSERT_NO_MSG(number != NULL);
 
 	if (*number_size == 0) {
-		LOG_ERR("Number not given but zero length");
+		LOG_ERR("Number given but zero length");
 		return -EINVAL;
 	}
 

--- a/samples/cellular/sms/Kconfig
+++ b/samples/cellular/sms/Kconfig
@@ -7,8 +7,18 @@
 menu "SMS Sample Settings"
 
 config SMS_SEND_PHONE_NUMBER
-	string "Phone number, including country code, where the SMS message is sent"
+	string "Phone number to which the SMS message is sent, including the country code."
 	default ""
+	help
+	  Phone number to which the SMS message is sent, including the country code.
+	  If empty, SMS will not be sent at all but the sample waits for received messages.
+
+config SMS_SERVICE_CENTER_NUMBER
+	string "Phone number of the SMS service center, including the country code."
+	default ""
+	help
+	  If empty, SMS will not add the service center number into the SMS PDU,
+	  and the modem/network will use the default values.
 
 endmenu
 

--- a/samples/cellular/sms/README.rst
+++ b/samples/cellular/sms/README.rst
@@ -27,6 +27,8 @@ The sample requires an LTE connection.
 When the sample starts, it sends an SMS if a recipient phone number is set in the configuration.
 The sample then receives all the SMS messages and displays the information about the messages including the text that is sent.
 
+If you need a custom SMS service center number, you can set it through the configuration.
+
 Configuration
 *************
 
@@ -42,6 +44,11 @@ Check and configure the following configuration option for the sample:
 CONFIG_SMS_SEND_PHONE_NUMBER - Configuration for recipient phone number in international format
    The sample configuration is used to set the recipient phone number in international format if you need to send an SMS.
 
+.. _CONFIG_SMS_SERVICE_CENTER_NUMBER:
+
+CONFIG_SMS_SERVICE_CENTER_NUMBER - Configuration for SMS service center number in international format
+   The sample configuration is used to set the SMS service center number in international format if you need to use custom service center number.
+
 Additional configuration
 ========================
 
@@ -53,6 +60,7 @@ Check and configure the following mandatory library options that are used by the
 Check and configure the following optional library options that are used by the sample:
 
 * :kconfig:option:`CONFIG_SMS_SUBSCRIBERS_MAX_CNT`
+* :kconfig:option:`CONFIG_GCF_SMS`
 * :kconfig:option:`CONFIG_LOG`
 * :kconfig:option:`CONFIG_ASSERT`
 * :kconfig:option:`CONFIG_ASSERT_VERBOSE`

--- a/samples/cellular/sms/sample.yaml
+++ b/samples/cellular/sms/sample.yaml
@@ -13,3 +13,19 @@ tests:
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
     tags: ci_build sysbuild ci_samples_cellular
+  sample.cellular.sms.sca:
+    sysbuild: true
+    build_only: true
+    integration_platforms:
+      - nrf9151dk/nrf9151/ns
+      - nrf9160dk/nrf9160/ns
+      - nrf9161dk/nrf9161/ns
+    platform_allow:
+      - nrf9151dk/nrf9151/ns
+      - nrf9160dk/nrf9160/ns
+      - nrf9161dk/nrf9161/ns
+    extra_configs:
+      - CONFIG_GCF_SMS=y
+      - CONFIG_SMS_SEND_PHONE_NUMBER=\"123456789\"
+      - CONFIG_SMS_SERVICE_CENTER_NUMBER=\"9876543210\"
+    tags: ci_build sysbuild ci_samples_cellular

--- a/tests/lib/gcf_sms/src/main.c
+++ b/tests/lib/gcf_sms/src/main.c
@@ -41,7 +41,7 @@ static char response[64];
 #define CMD_CSCA_E "AT+CSCA=\"+358501234567\""
 
 #define CMD_CSCA_Q "AT+CSCA?"
-#define RES_CSCA_Q "+CSMS: \"+358501234567\""
+#define RES_CSCA_Q "+CSCA: \"+358501234567\""
 
 #define CMD_CMGD_E_0 "AT+CMGD=0"
 #define CMD_CMGD_E_1 "AT+CMGD=1"

--- a/tests/lib/gcf_sms/testcase.yaml
+++ b/tests/lib/gcf_sms/testcase.yaml
@@ -1,7 +1,9 @@
 tests:
   gcf_sms.functionality_test:
     sysbuild: true
-    platform_allow: nrf9160dk/nrf9160/ns
+    platform_allow: nrf9151dk/nrf9151/ns nrf9160dk/nrf9160/ns nrf9161dk/nrf9161/ns
     integration_platforms:
+      - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
+      - nrf9161dk/nrf9161/ns
     tags: gcf_sms sysbuild ci_tests_lib_gcf_sms

--- a/tests/lib/sms/src/sms_test.c
+++ b/tests/lib/sms/src/sms_test.c
@@ -651,6 +651,26 @@ void test_send_fail_number_null(void)
 	TEST_ASSERT_EQUAL(-EINVAL, ret);
 }
 
+/**
+ * Phone number is too long with 21 characters.
+ */
+void test_send_fail_number21(void)
+{
+	int ret = sms_send_text("123456789012345678901", "1");
+
+	TEST_ASSERT_EQUAL(-E2BIG, ret);
+}
+
+/**
+ * Phone number is too long with 21 characters and preceded by '+' sign.
+ */
+void test_send_fail_number21plus(void)
+{
+	int ret = sms_send_text("+123456789012345678901", "1");
+
+	TEST_ASSERT_EQUAL(-E2BIG, ret);
+}
+
 /** Text is NULL. */
 void test_send_fail_text_null(void)
 {

--- a/tests/lib/sms/src/sms_test.c
+++ b/tests/lib/sms/src/sms_test.c
@@ -419,6 +419,9 @@ void test_send_len3_number10plus(void)
 {
 	sms_reg_helper();
 
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 48, "AT+CSCA?", 65536);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+
 	__mock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=15\r0021000A912143658709000003CD771A\x1A", 0);
 
@@ -446,6 +449,9 @@ void test_send_len1_number20plus(void)
 {
 	sms_reg_helper();
 
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 48, "AT+CSCA?", 65536);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+
 	__mock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=18\r00210014912143658709214365870900000131\x1A", 0);
 
@@ -472,6 +478,9 @@ void test_send_len1_number20plus(void)
  */
 void test_send_len7_number11(void)
 {
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 48, "AT+CSCA?", 65536);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+
 	__mock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=20\r0021000B912143658709F100000731D98C56B3DD00\x1A", 0);
 
@@ -487,6 +496,9 @@ void test_send_len7_number11(void)
  */
 void test_send_len8_number1(void)
 {
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 48, "AT+CSCA?", 65536);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+
 	__mock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=15\r0021000191F100000831D98C56B3DD70\x1A", 0);
 
@@ -501,6 +513,9 @@ void test_send_len8_number1(void)
  */
 void test_send_len9_number5(void)
 {
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 48, "AT+CSCA?", 65536);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+
 	__mock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=18\r00210005912143F500000931D98C56B3DD7039\x1A", 0);
 
@@ -515,6 +530,9 @@ void test_send_len9_number5(void)
  */
 void test_send_concat_220chars_2msgs(void)
 {
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 48, "AT+CSCA?", 65536);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+
 	__mock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=153\r0061010C912143658709210000A005000301020162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966\x1A",
 		0);
@@ -535,6 +553,9 @@ void test_send_concat_220chars_2msgs(void)
  */
 void test_send_concat_291chars_2msgs(void)
 {
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 48, "AT+CSCA?", 65536);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+
 	__mock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=153\r0061030C912143658709210000A005000302020162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966\x1A",
 		0);
@@ -555,6 +576,9 @@ void test_send_concat_291chars_2msgs(void)
  */
 void test_send_concat_700chars_5msgs(void)
 {
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 48, "AT+CSCA?", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+
 	__mock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=153\r0061050C912143658709210000A005000303050162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966\x1A",
 		0);
@@ -586,6 +610,9 @@ void test_send_concat_700chars_5msgs(void)
  */
 void test_send_special_characters(void)
 {
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 48, "AT+CSCA?", 65536);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+
 	__mock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=49\r00210005912143F500002C5378799C0EB3416374581E1ED3CBF2B90EB4A1803628D02605DAF0401B1F68F3026D7AA00DD005\x1A",
 		0);
@@ -608,6 +635,9 @@ void test_send_special_characters(void)
  */
 void test_send_concat_special_character_split(void)
 {
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 48, "AT+CSCA?", 65536);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+
 	__mock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=150\r00610A05912143F500009F05000304020162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC900\x1A",
 		0);
@@ -625,6 +655,9 @@ void test_send_concat_special_character_split(void)
 /** Text is empty. Message will be sent successfully. */
 void test_send_text_empty(void)
 {
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 48, "AT+CSCA?", 65536);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+
 	__mock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=12\r002100099121436587F9000000\x1A", 0);
 
@@ -682,6 +715,9 @@ void test_send_fail_text_null(void)
 /** Failing AT command response to CMGS command. */
 void test_send_fail_atcmd(void)
 {
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 48, "AT+CSCA?", 65536);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+
 	__mock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=15\r0021000A912143658709000003CD771A\x1A", -ENOMEM);
 
@@ -693,6 +729,9 @@ void test_send_fail_atcmd(void)
 /** Failing AT command response to CMGS command when sending concatenated message. */
 void test_send_fail_atcmd_concat(void)
 {
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 48, "AT+CSCA?", 65536);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+
 	__mock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=153\r00610C0C912143658709210000A005000305020162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966\x1A",
 		304);
@@ -708,6 +747,9 @@ void test_send_fail_atcmd_concat(void)
 /** Data has special characters. */
 void test_send_gsm7bit_special_characters(void)
 {
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 48, "AT+CSCA?", 65536);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+
 	uint8_t data[] = {
 		0x00, 0x01, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
 		0x09, 0x0E, 0x0F, 0x10, 0x12, 0x13, 0x14, 0x15,
@@ -765,6 +807,172 @@ void test_send_gsm7bit_fail_data_null(void)
 	int ret = sms_send("123456789", NULL, 0, SMS_DATA_TYPE_GSM7BIT);
 
 	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/********* SMS SEND SMS CENTER ADDRESS (SCA) TESTS ******************/
+
+/** Test that SCA is included. */
+void test_send_sca_included_tosca(void)
+{
+	char csca_resp[] = "+CSCA: \"987654321\",145\r\nOK\r\n";
+
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 48, "AT+CSCA?", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(csca_resp, sizeof(csca_resp));
+
+	__mock_nrf_modem_at_printf_ExpectAndReturn(
+		"AT+CMGS=18\r069189674523F1210005912143F500000931D98C56B3DD7039\x1A", 0);
+
+	int ret = sms_send_text("12345", "123456789");
+
+	TEST_ASSERT_EQUAL(0, ret);
+}
+
+/** Test that SCA is included with maximum length and without tosca. */
+void test_send_sca_included_max_len(void)
+{
+	char csca_resp[] = "+CSCA: \"+98765432109876543210\"\r\n";
+
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 48, "AT+CSCA?", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(csca_resp, sizeof(csca_resp));
+
+	__mock_nrf_modem_at_printf_ExpectAndReturn(
+		"AT+CMGS=18\r0B9189674523018967452301210005912143F500000931D98C56B3DD7039\x1A", 0);
+
+	int ret = sms_send_text("12345", "123456789");
+
+	TEST_ASSERT_EQUAL(0, ret);
+}
+
+/**
+ * Test that:
+ * - SCA is included for both parts of concatenated message
+ * - AT+CSCA? is requested just ones
+ * - Non-default tosca value
+ */
+void test_send_sca_included_concat_msg(void)
+{
+	char csca_resp[] = "+CSCA: \"987654321\",100\r\nOK\r\n";
+
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 48, "AT+CSCA?", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(csca_resp, sizeof(csca_resp));
+
+	__mock_nrf_modem_at_printf_ExpectAndReturn(
+		"AT+CMGS=153\r066489674523F1610C0C912143658709210000A005000306020162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966\x1A",
+		0);
+
+	__mock_nrf_modem_at_printf_ExpectAndReturn(
+		"AT+CMGS=78\r066489674523F1610D0C9121436587092100004A0500030602026835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD703918\x1A",
+		0);
+
+	int ret = sms_send_text("+123456789012",
+		"1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890");
+
+	TEST_ASSERT_EQUAL(0, ret);
+}
+
+/** Test that SCA is not included when it is too long but does not have plus sign. */
+void test_send_sca_excluded_too_long_without_plus(void)
+{
+	char csca_resp[] = "+CSCA: \"987654321098765432109\"\r\nOK\r\n";
+
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 48, "AT+CSCA?", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(csca_resp, sizeof(csca_resp));
+
+	__mock_nrf_modem_at_printf_ExpectAndReturn(
+		"AT+CMGS=18\r00210005912143F500000931D98C56B3DD7039\x1A", 0);
+
+	int ret = sms_send_text("12345", "123456789");
+
+	TEST_ASSERT_EQUAL(0, ret);
+}
+
+/** Test that SCA is not included when it is too long and has plus sign. */
+void test_send_sca_excluded_too_long_with_plus(void)
+{
+	char csca_resp[] = "+CSCA: \"+987654321098765432109\",100\r\nOK\r\n";
+
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 48, "AT+CSCA?", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(csca_resp, sizeof(csca_resp));
+
+	__mock_nrf_modem_at_printf_ExpectAndReturn(
+		"AT+CMGS=18\r00210005912143F500000931D98C56B3DD7039\x1A", 0);
+
+	int ret = sms_send_text("12345", "123456789");
+
+	TEST_ASSERT_EQUAL(0, ret);
+}
+
+/** Test that SCA is not included when it has non-number characters. */
+void test_send_sca_excluded_non_numbers(void)
+{
+	char csca_resp[] = "+CSCA: \"12nonnumbers34\"\r\nOK\r\n";
+
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 48, "AT+CSCA?", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(csca_resp, sizeof(csca_resp));
+
+	__mock_nrf_modem_at_printf_ExpectAndReturn(
+		"AT+CMGS=18\r00210005912143F500000931D98C56B3DD7039\x1A", 0);
+
+	int ret = sms_send_text("12345", "123456789");
+
+	TEST_ASSERT_EQUAL(0, ret);
+}
+
+/** Test that SCA is not included when it does not have double quote. */
+void test_send_sca_excluded_no_double_quotes(void)
+{
+	char csca_resp[] = "+CSCA: 9876543210";
+
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 48, "AT+CSCA?", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(csca_resp, sizeof(csca_resp));
+
+	__mock_nrf_modem_at_printf_ExpectAndReturn(
+		"AT+CMGS=18\r00210005912143F500000931D98C56B3DD7039\x1A", 0);
+
+	int ret = sms_send_text("12345", "123456789");
+
+	TEST_ASSERT_EQUAL(0, ret);
+}
+
+/** Test that SCA is not included when it does not have closing double quote. */
+void test_send_sca_excluded_no_closing_double_quote(void)
+{
+	char csca_resp[] = "+CSCA: \"9876543210";
+
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 48, "AT+CSCA?", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(csca_resp, sizeof(csca_resp));
+
+	__mock_nrf_modem_at_printf_ExpectAndReturn(
+		"AT+CMGS=18\r00210005912143F500000931D98C56B3DD7039\x1A", 0);
+
+	int ret = sms_send_text("12345", "123456789");
+
+	TEST_ASSERT_EQUAL(0, ret);
+}
+
+/** Test that SCA is not included when it is empty. */
+void test_send_sca_excluded_empty(void)
+{
+	char csca_resp[] = "+CSCA: \"\"\r\nOK\r\n";
+
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 48, "AT+CSCA?", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(csca_resp, sizeof(csca_resp));
+
+	__mock_nrf_modem_at_printf_ExpectAndReturn(
+		"AT+CMGS=18\r00210005912143F500000931D98C56B3DD7039\x1A", 0);
+
+	int ret = sms_send_text("12345", "123456789");
+
+	TEST_ASSERT_EQUAL(0, ret);
 }
 
 /********* SMS RECV TESTS ***********************/
@@ -1935,6 +2143,9 @@ void test_recv_large_negative_time_zone_offset(void)
 void send_basic(void)
 {
 	helper_sms_data_clear();
+
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 48, "AT+CSCA?", 65536);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
 
 	__mock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=15\r0021000A912143658709000003CD771A\x1A", 0);


### PR DESCRIPTION
Added support for reading SMS Service Center Address (number) with AT+CSCA? and include it into the SMS PDU sent with AT+CMGS.
SMS sample made to use it.
Fixing gcf_sms library also related to AT+CSCA which responded with +CSMS due to a typo.

TODO list:

- [x] Add SMS library tests
- [x] Check gcf_sms library tests
- [x] Add gcf_sms configuration into sample.yaml
- [x] Add `AT+CSCA` documentation
- [x] Add mention of `AT+CSCA` or CONFIG_GCF_SMS into SMS sample and library documentation
- [ ] Add release note

Jira: NCSDK-27729

NOTE 27th Jun: This PR is kind of ready but will be finalized only after summer holidays in the end of July.
