### PR TITLE
samples: matter: Fixed logging on a door lock

### DIFF
--- a/samples/matter/lock/src/access/access_manager.cpp
+++ b/samples/matter/lock/src/access/access_manager.cpp
@@ -11,7 +11,7 @@
 
 #include <zephyr/logging/log.h>
 
-LOG_MODULE_DECLARE(cr_manager, CONFIG_CHIP_APP_LOG_LEVEL);
+LOG_MODULE_REGISTER(cr_manager, CONFIG_CHIP_APP_LOG_LEVEL);
 
 using namespace chip;
 using namespace DoorLockData;


### PR DESCRIPTION
Door lock sample uses LOG_MODULE_DECLARE(cr_manager, ...) in several files, but there is no LOG_MODULE_REGISTER anywhere, so the compilation ends with linker error.