### PR TITLE
nrf_security: cracen: Add helper functions for common bit manipulation

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/common/include/cracen/ec_helpers.h
+++ b/subsys/nrf_security/src/drivers/cracen/common/include/cracen/ec_helpers.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+/**
+ * @brief Decode a byte array containing a coordinate in place.
+ *
+ * @note Corresponds to the decodeUCoordinate function in RFC 7748 for Curve25519.
+ *
+ * @param[in,out] u Byte array containing a coordinate of size 32 bytes.
+ */
+void decode_u_coordinate_25519(uint8_t *u);
+
+/**
+ * @brief Decode a byte array containing a scalar in place.
+ *
+ * @note Corresponds to the decodeScalar25519 function in RFC 7748.
+ *
+ * @param[in,out] k Byte array containing a scalar of size 32.
+ */
+void decode_scalar_25519(uint8_t *k);
+
+/**
+ * @brief Decode a byte array containing a scalar in place.
+ *
+ * @note Corresponds to the decodeScalar448 function in RFC 7748.
+ *
+ * @param[in,out] k Byte array containing a scalar of size 56.
+ */
+void decode_scalar_448(uint8_t *k);

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/cracenpsa.cmake
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/cracenpsa.cmake
@@ -14,6 +14,7 @@ list(APPEND cracen_driver_sources
   ${CMAKE_CURRENT_LIST_DIR}/src/cracen.c
   ${CMAKE_CURRENT_LIST_DIR}/src/common.c
   ${CMAKE_CURRENT_LIST_DIR}/src/mem_helpers.c
+  ${CMAKE_CURRENT_LIST_DIR}/src/ec_helpers.c
 
   # Note: We always need to have blkcipher.c and ctr_drbg.c since it
   # is used directly by many Cracen drivers.

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/ec_helpers.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/ec_helpers.c
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <stdint.h>
+
+void decode_u_coordinate_25519(uint8_t *u)
+{
+	u[31] &= ~0x80; /* Clear the last bit. */
+}
+
+void decode_scalar_25519(uint8_t *k)
+{
+	k[0] &= ~0x07; /* Clear bits 0, 1 and 2. */
+	k[31] &= ~0x80; /* Clear bit 255. */
+	k[31] |= 0x40; /* Set bit 254. */
+}
+
+void decode_scalar_448(uint8_t *k)
+{
+	k[0] &= ~0x03; /* Clear bits 0 and 1. */
+	k[55] |= 0x80; /* Set bit 447. */
+}

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/key_management.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/key_management.c
@@ -5,6 +5,7 @@
  */
 
 #include "common.h"
+#include <cracen/ec_helpers.h>
 #include <cracen/mem_helpers.h>
 #include "cracen_psa.h"
 #include "platform_keys/platform_keys.h"
@@ -541,13 +542,10 @@ static psa_status_t generate_ecc_private_key(const psa_key_attributes_t *attribu
 			 */
 			if (key_size_bytes == 32) {
 				/* X25519 */
-				workmem[0] &= 248;
-				workmem[31] &= 127;
-				workmem[31] |= 64;
+				decode_scalar_25519(&workmem[0]);
 			} else if (key_size_bytes == 56) {
 				/* X448 */
-				workmem[0] &= 252;  /* clear bits 0 and 1 */
-				workmem[55] |= 128; /* set bit 447 */
+				decode_scalar_448(&workmem[0]);
 			}
 		}
 

--- a/subsys/nrf_security/src/drivers/cracen/sicrypto/src/ed25519.c
+++ b/subsys/nrf_security/src/drivers/cracen/sicrypto/src/ed25519.c
@@ -38,6 +38,7 @@
 #include <silexpk/ed25519.h>
 #include <sicrypto/sicrypto.h>
 #include <cracen/statuscodes.h>
+#include <cracen/ec_helpers.h>
 #include <cracen/mem_helpers.h>
 #include <sicrypto/ed25519.h>
 #include <sicrypto/hash.h>
@@ -183,9 +184,7 @@ static int ed25519_compute_pubkey(struct sitask *t)
 	/* The secret scalar s is computed in place from the first half of the
 	 * private key digest.
 	 */
-	t->workmem[0] &= ~0x07;			/* clear bits 0, 1 and 2 */
-	t->workmem[SX_ED25519_SZ - 1] &= ~0x80; /* clear bit 255 */
-	t->workmem[SX_ED25519_SZ - 1] |= 0x40;	/* set bit 254 */
+	decode_scalar_25519(t->workmem);
 
 	/* Clear second half of private key digest: sx_async_ed25519_ptmult_go()
 	 * works on an input of SX_ED25519_DGST_SZ bytes.

--- a/subsys/nrf_security/src/drivers/cracen/sicrypto/src/ed448.c
+++ b/subsys/nrf_security/src/drivers/cracen/sicrypto/src/ed448.c
@@ -46,6 +46,7 @@
 #include <silexpk/ed448.h>
 #include <sicrypto/sicrypto.h>
 #include <cracen/statuscodes.h>
+#include <cracen/ec_helpers.h>
 #include <cracen/mem_helpers.h>
 #include <sicrypto/ed448.h>
 #include <sicrypto/hash.h>
@@ -143,9 +144,7 @@ static int ed448_compute_pubkey(struct sitask *t)
 	/* The secret scalar s is computed in place from the first half of the
 	 * private key digest.
 	 */
-	t->workmem[0] &= ~0x03;		     /* clear bits 0 and 1 */
-	t->workmem[SX_ED448_SZ - 1] = 0;     /* clear last octet */
-	t->workmem[SX_ED448_SZ - 2] |= 0x80; /* set bit 447 */
+	decode_scalar_448(t->workmem);
 
 	/* Clear second half of private key digest: sx_async_ed448_ptmult_go()
 	 * works on an input of SX_ED448_DGST_SZ bytes.


### PR DESCRIPTION
Add helper functions for the common bit manipulation operations described in RFC 7748.