### PR TITLE
doc improvement: Update to nRF91 table and features

### DIFF
--- a/doc/nrf/config_and_build/dfu/index.rst
+++ b/doc/nrf/config_and_build/dfu/index.rst
@@ -7,9 +7,9 @@ Device Firmware Updates
 Device Firmware Update (DFU) is the procedure of upgrading the application firmware version on a device.
 It consists of two primary steps:
 
-1. Transferring the new firmware - a new firmware image is transferred to the device's chip.
+1. Transferring the new firmware - A new firmware image is transferred to the device's chip.
 
-#. Testing and booting - the bootloader then tests and boots the new firmware.
+#. Testing and booting - The bootloader then tests and boots the new firmware.
 
 .. note::
   The choice of bootloader affects how firmware updates can be performed (except for the nRF54H20 SoC where only the Software Updates for Internet of Things (SUIT) is supported).
@@ -97,6 +97,8 @@ For device-specific guides related to DFU, see the following pages:
   * :ref:`qspi_xip` - For external execute in place (XIP) for the nRF5340 SoC.
 
 * :ref:`ug_nrf70_fw_patch_update` - For nRF70 Series devices.
+
+* :ref:`nrf91_fota` section of :ref:`ug_nrf91_config_build` - For nRF91 Series devices.
 
 .. note::
 

--- a/doc/nrf/device_guides/nrf91/index.rst
+++ b/doc/nrf/device_guides/nrf91/index.rst
@@ -33,6 +33,16 @@ Zephyr and the |NCS| provide support for developing cellular applications using 
        | `User Guide <nRF9160 DK Hardware_>`_
      - | `nRF9160 DK product page`_
        | `nRF9160 System in Package (SiP) <nRF9160 product website_>`_
+   * - :ref:`zephyr:nrf9151dk_nrf9151`
+     - PCA10171
+     - ``nrf9151dk/nrf9151``, ``nrf9151dk/nrf9151/ns``
+     - --
+     - | `nRF9151 System in Package (SiP) <nRF9151 product website_>`_
+   * - :ref:`zephyr:nrf9131ek_nrf9131`
+     - PCA10165
+     - ``nrf9131ek/nrf9131``, ``nrf9131ek/nrf9131/ns``
+     - --
+     - | `nRF9131 System in Package (SiP) <nRF9131 product website_>`_
    * - Thingy:91
      - PCA20035
      - ``thingy91/nrf9160``, ``thingy91/nrf9160/ns``
@@ -40,6 +50,11 @@ Zephyr and the |NCS| provide support for developing cellular applications using 
        | `User Guide <Nordic Thingy:91 User Guide_>`_
      - | `Thingy\:91 product page`_
        | `nRF9160 System in Package (SiP) <nRF9160 product website_>`_
+   * - Thingy:91 X
+     - PCA20065
+     - ``thingy91x/nrf9151``, ``thingy91x/nrf9151/ns``
+     - --
+     - | `nRF9151 System in Package (SiP) <nRF9151 product website_>`_
 
 The nRF Connect SDK also offers :ref:`samples <cellular_samples>` dedicated to these devices, as well as compatible :ref:`drivers` and :ref:`libraries`.
 

--- a/doc/nrf/device_guides/nrf91/nrf91_board_controllers.rst
+++ b/doc/nrf/device_guides/nrf91/nrf91_board_controllers.rst
@@ -11,12 +11,13 @@ The nRF91 Series DKs contain additional chips that act as board controllers.
 
 .. _nrf9161_ug_intro:
 
-Board controller on the nRF9161 DK
-**********************************
+Board controller on the nRF91x1 DKs
+***********************************
 
-The nRF9161 DK contains an nRF5340 Interface MCU (IMCU) that acts both as an on-board debugger and board controller.
-The board controller controls signal switches on the nRF9161 DK and can be used to route the nRF9161 SiP pins to different components on the DK, such as pin headers, external memory, a SIM card or eSIM.
-For a complete list of configuration options available, see the `nRF9161 DK board control section in the nRF9161 DK User Guide`_.
+The nRF91x1 DKs (nRF9161 and nRF9151 DKs) contain an nRF5340 Interface MCU (IMCU) that acts both as an on-board debugger and board controller.
+The board controller controls signal switches on the nRF91x1 DKs and can be used to route the nRF91x1 SiPs pins to different components on the DK, such as pin headers, external memory, a SIM card, or eSIM.
+
+The `Board control section in the nRF9161 DK User Guide <nRF9161 DK board control section in the nRF9161 DK User Guide_>`_ has a complete list of configuration options available for the nRF9161 DK.
 
 The nRF5340 IMCU comes preprogrammed with J-Link SEGGER OB and board controller firmware.
 If you want to change the default configuration of the DK, you can use the `nRF Connect Board Configurator`_ app in `nRF Connect for Desktop`_ .

--- a/doc/nrf/device_guides/nrf91/nrf91_features.rst
+++ b/doc/nrf/device_guides/nrf91/nrf91_features.rst
@@ -7,13 +7,24 @@ Features of nRF91 Series
    :local:
    :depth: 2
 
-The nRF91 Series SiPs integrate an application MCU, a full LTE modem, an RF front end, and power management.
+The nRF91 Series SiPs integrate an application MCU, a full LTE modem, an RF front end, and power management capabilities.
+These SiPs are designed to support a wide range of cellular IoT applications and DECT NR+ applications.
 
-* The nRF9160 DK is a hardware development platform used to design and develop application firmware on the nRF9160 LTE Cat-M1 and Cat-NB1 :term:`System in Package (SiP)`.
-* The nRF9161 DK is a hardware development platform used to design and develop application firmware on the nRF9161 :term:`System in Package (SiP)`.
-  The nRF9161 SiP is a low power SiP with integrated DECT NR+ modem and 3GPP Release 14 LTE-M/NB-IoT with GNSS.
-* Nordic Thingy:91 is a battery-operated prototyping platform for cellular IoT systems, designed especially for asset tracking applications and environmental monitoring.
-  Thingy:91 integrates an nRF9160 SiP that supports LTE-M, NB-IoT, and Global Navigation Satellite System (GNSS) and an nRF52840 SoC that supports Bluetooth® Low Energy, Near Field Communication (NFC) and USB.
+Development Kits and Evaluation Kits
+  * nRF9160 DK: A development kit for designing and developing application firmware on the nRF9160 :term:`System in Package (SiP)`, supporting LTE Cat-M1 and Cat-NB1 and GNSS with 3GPP 13 support.
+  * nRF9161 DK: A development kit for designing and developing application firmware on the nRF9161 SiP, supporting LTE Cat-M1 and Cat-NB1 and GNSS with 3GPP 14 support and DECT NR+.
+  * nRF9151 DK: A development kit for designing and developing application firmware on the nRF9151 SiP, supporting LTE Cat-M1 and Cat-NB1 and GNSS with 3GPP 14 support and DECT NR+.
+  * nRF9131 EK: A single-board evaluation kit for the nRF9131 SiP, designed for DECT NR+ applications.
+
+Prototyping Platforms
+  * Nordic Thingy:91: A battery-operated prototyping platform for cellular IoT systems, suitable for prototyping asset tracking, environmental monitoring and more.
+    Thingy:91 integrates an nRF9160 SiP that supports LTE-M, NB-IoT, and Global Navigation Satellite System (GNSS) and an nRF52840 SoC that supports Bluetooth® Low Energy, Near Field Communication (NFC) and USB.
+  * Nordic Thingy:91 X: An advanced version of the Thingy:91.
+    Thingy:91 X integrates the following components:
+
+    * An nRF9151 SiP with LTE-M, NB-IoT, and Global Navigation Satellite System (GNSS) support.
+    * The nRF7002 companion IC that adds support for low power Wi-Fi®.
+    * An nRF5340 SoC that supports Bluetooth Low Energy, 802.15.4 protocols, and USB.
 
 With built-in GNSS support, these devices are a great choice for asset tracking applications.
 

--- a/doc/nrf/includes/sample_board_rows.txt
+++ b/doc/nrf/includes/sample_board_rows.txt
@@ -42,19 +42,19 @@
 
 .. nrf9131ek_nrf9131
 
-| nRF9131 EK | PCA10165 | :ref:`nrf9131ek <zephyr:nrf9131ek_nrf9131>` | ``nrf9131ek/nrf9131``  |
+| :ref:`nRF9131 EK <ug_nrf91>` | PCA10165 | :ref:`nrf9131ek <zephyr:nrf9131ek_nrf9131>` | ``nrf9131ek/nrf9131``  |
 
 .. nrf9131ek_nrf9131_ns
 
-| nRF9131 EK | PCA10165 | :ref:`nrf9131ek <zephyr:nrf9131ek_nrf9131>` | ``nrf9131ek/nrf9131/ns`` |
+| :ref:`nRF9131 EK <ug_nrf91>` | PCA10165 | :ref:`nrf9131ek <zephyr:nrf9131ek_nrf9131>` | ``nrf9131ek/nrf9131/ns`` |
 
 .. nrf9151dk_nrf9151
 
-| nRF9151 DK | PCA10171 | :ref:`nrf9151dk <zephyr:nrf9151dk_nrf9151>` | ``nrf9151dk/nrf9151`` |
+| :ref:`nRF9151 DK <ug_nrf91>` | PCA10171 | :ref:`nrf9151dk <zephyr:nrf9151dk_nrf9151>` | ``nrf9151dk/nrf9151`` |
 
 .. nrf9151dk_nrf9151_ns
 
-| nRF9151 DK | PCA10171 | :ref:`nrf9151dk <zephyr:nrf9151dk_nrf9151>` | ``nrf9151dk/nrf9151/ns`` |
+| :ref:`nRF9151 DK <ug_nrf91>` | PCA10171 | :ref:`nrf9151dk <zephyr:nrf9151dk_nrf9151>` | ``nrf9151dk/nrf9151/ns`` |
 
 .. nrf5340dk_nrf5340_cpuapp
 
@@ -94,15 +94,15 @@
 
 .. thingy91x_nrf9151
 
-| Thingy:91 X | PCA20065 | thingy91x | ``thingy91x/nrf9151`` |
+| :ref:`Thingy:91 X <ug_nrf91>` | PCA20065 | thingy91x | ``thingy91x/nrf9151`` |
 
 .. thingy91x_nrf9151_ns
 
-| Thingy:91 X | PCA20065 | thingy91x | ``thingy91x/nrf9151/ns`` |
+| :ref:`Thingy:91 X <ug_nrf91>` | PCA20065 | thingy91x | ``thingy91x/nrf9151/ns`` |
 
 .. thingy91x_nrf5340_cpuapp
 
-| Thingy:91 X | PCA20065 | thingy91x | ``thingy91x/nrf5340/cpuapp`` |
+| :ref:`Thingy:91 X <ug_nrf91>` | PCA20065 | thingy91x | ``thingy91x/nrf5340/cpuapp`` |
 
 .. nrf52dk_nrf52810
 

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -418,8 +418,10 @@
 .. _`nRF9160 DK Downloads`: https://www.nordicsemi.com/Products/Development-hardware/nRF9160-DK/Download#infotabs
 .. _`SUPL client download`: https://www.nordicsemi.com/Software-and-tools/Development-Kits/nRF9160-DK/Download#supl-c
 
+.. _`nRF9151 product website`: https://www.nordicsemi.com/Products/nRF9151
 .. _`nRF9161 product website`: https://www.nordicsemi.com/Products/nRF9161
 .. _`nRF9160 product website`: https://www.nordicsemi.com/Products/Low-power-cellular-IoT/nRF9160
+.. _`nRF9131 product website`: https://www.nordicsemi.com/Products/nRF9131
 
 .. _`nRF9160 product website (compatible downloads)`: https://www.nordicsemi.com/Products/Low-power-cellular-IoT/nRF9160/Download#infotabs
 .. _`nRF9161 product website (compatible downloads)`: https://www.nordicsemi.com/Products/nRF9161/Download#infotabs


### PR DESCRIPTION
Updated the following:
* nRf91 Series table with nRF9151, nRF9131, and Thingy:91 X details.
* provided a ref link on DFU page for nRF91 Series FOTA updates
* Feature page with nRF9151, nRF9131, and Thingy:91 X details.
* Board controller page for the nRF9151.
