### PR TITLE
samples: crypto: Remove nRF54H20 from failing crypto samples

### DIFF
--- a/samples/crypto/aes_cbc/sample.yaml
+++ b/samples/crypto/aes_cbc/sample.yaml
@@ -30,7 +30,7 @@ tests:
     sysbuild: true
     tags: introduction psa cracen sysbuild
     platform_allow: >
-      nrf54h20dk/nrf54h20/cpuapp nrf54l15pdk/nrf54l15/cpuapp nrf54l15pdk/nrf54l15/cpuapp/ns
+      nrf54l15pdk/nrf54l15/cpuapp nrf54l15pdk/nrf54l15/cpuapp/ns
     harness: console
     harness_config:
       type: multi_line
@@ -39,5 +39,3 @@ tests:
     integration_platforms:
       - nrf54l15pdk/nrf54l15/cpuapp
       - nrf54l15pdk/nrf54l15/cpuapp/ns
-      # nRF54H uses Oberon+fake entropy until crypto service is available from SDFW
-      - nrf54h20dk/nrf54h20/cpuapp

--- a/samples/crypto/aes_ccm/sample.yaml
+++ b/samples/crypto/aes_ccm/sample.yaml
@@ -30,7 +30,7 @@ tests:
     sysbuild: true
     tags: introduction psa cracen sysbuild
     platform_allow: >
-      nrf54h20dk/nrf54h20/cpuapp nrf54l15pdk/nrf54l15/cpuapp nrf54l15pdk/nrf54l15/cpuapp/ns
+      nrf54l15pdk/nrf54l15/cpuapp nrf54l15pdk/nrf54l15/cpuapp/ns
     harness: console
     harness_config:
       type: multi_line
@@ -39,5 +39,3 @@ tests:
     integration_platforms:
       - nrf54l15pdk/nrf54l15/cpuapp
       - nrf54l15pdk/nrf54l15/cpuapp/ns
-      # nRF54H uses Oberon+fake entropy until crypto service is available from SDFW
-      - nrf54h20dk/nrf54h20/cpuapp

--- a/samples/crypto/aes_ctr/sample.yaml
+++ b/samples/crypto/aes_ctr/sample.yaml
@@ -30,7 +30,7 @@ tests:
     sysbuild: true
     tags: introduction psa cracen sysbuild
     platform_allow: >
-      nrf54h20dk/nrf54h20/cpuapp nrf54l15pdk/nrf54l15/cpuapp nrf54l15pdk/nrf54l15/cpuapp/ns
+      nrf54l15pdk/nrf54l15/cpuapp nrf54l15pdk/nrf54l15/cpuapp/ns
     harness: console
     harness_config:
       type: multi_line
@@ -39,5 +39,3 @@ tests:
     integration_platforms:
       - nrf54l15pdk/nrf54l15/cpuapp
       - nrf54l15pdk/nrf54l15/cpuapp/ns
-      # nRF54H uses Oberon+fake entropy until crypto service is available from SDFW
-      - nrf54h20dk/nrf54h20/cpuapp

--- a/samples/crypto/aes_gcm/sample.yaml
+++ b/samples/crypto/aes_gcm/sample.yaml
@@ -42,7 +42,6 @@ tests:
     platform_allow: >
       nrf54l15pdk/nrf54l15/cpuapp
       nrf54l15pdk/nrf54l15/cpuapp/ns
-      nrf54h20dk/nrf54h20/cpuapp
     harness: console
     harness_config:
       type: multi_line
@@ -51,5 +50,3 @@ tests:
     integration_platforms:
       - nrf54l15pdk/nrf54l15/cpuapp
       - nrf54l15pdk/nrf54l15/cpuapp/ns
-      # nRF54H uses Oberon+fake entropy until crypto service is available from SDFW
-      - nrf54h20dk/nrf54h20/cpuapp

--- a/samples/crypto/chachapoly/sample.yaml
+++ b/samples/crypto/chachapoly/sample.yaml
@@ -30,7 +30,6 @@ tests:
     sysbuild: true
     tags: introduction psa cracen sysbuild
     platform_allow: >
-      nrf54h20dk/nrf54h20/cpuapp
       nrf54l15pdk/nrf54l15/cpuapp
       nrf54l15pdk/nrf54l15/cpuapp/ns
     harness: console
@@ -41,5 +40,3 @@ tests:
     integration_platforms:
       - nrf54l15pdk/nrf54l15/cpuapp
       - nrf54l15pdk/nrf54l15/cpuapp/ns
-      # nRF54H uses Oberon+fake entropy until crypto service is available from SDFW
-      - nrf54h20dk/nrf54h20/cpuapp

--- a/samples/crypto/ecdh/sample.yaml
+++ b/samples/crypto/ecdh/sample.yaml
@@ -30,7 +30,7 @@ tests:
     sysbuild: true
     tags: introduction psa cracen sysbuild
     platform_allow: >
-      nrf54h20dk/nrf54h20/cpuapp nrf54l15pdk/nrf54l15/cpuapp nrf54l15pdk/nrf54l15/cpuapp/ns
+      nrf54l15pdk/nrf54l15/cpuapp nrf54l15pdk/nrf54l15/cpuapp/ns
     harness: console
     harness_config:
       type: multi_line
@@ -39,5 +39,3 @@ tests:
     integration_platforms:
       - nrf54l15pdk/nrf54l15/cpuapp
       - nrf54l15pdk/nrf54l15/cpuapp/ns
-      # nRF54H uses Oberon+fake entropy until crypto service is available from SDFW
-      - nrf54h20dk/nrf54h20/cpuapp

--- a/samples/crypto/ecdsa/sample.yaml
+++ b/samples/crypto/ecdsa/sample.yaml
@@ -29,7 +29,6 @@ tests:
     sysbuild: true
     tags: introduction psa cracen sysbuild
     platform_allow: >
-      nrf54h20dk/nrf54h20/cpuapp
       nrf54l15pdk/nrf54l15/cpuapp
       nrf54l15pdk/nrf54l15/cpuapp/ns
     harness: console
@@ -40,5 +39,3 @@ tests:
     integration_platforms:
       - nrf54l15pdk/nrf54l15/cpuapp
       - nrf54l15pdk/nrf54l15/cpuapp/ns
-      # nRF54H uses Oberon+fake entropy until crypto service is available from SDFW
-      - nrf54h20dk/nrf54h20/cpuapp

--- a/samples/crypto/ecjpake/sample.yaml
+++ b/samples/crypto/ecjpake/sample.yaml
@@ -37,7 +37,6 @@ tests:
     platform_allow: >
       nrf54l15pdk/nrf54l15/cpuapp
       nrf54l15pdk/nrf54l15/cpuapp/ns
-      nrf54h20dk/nrf54h20/cpuapp
     harness: console
     harness_config:
       type: multi_line
@@ -46,5 +45,3 @@ tests:
     integration_platforms:
       - nrf54l15pdk/nrf54l15/cpuapp
       - nrf54l15pdk/nrf54l15/cpuapp/ns
-      # nRF54H uses Oberon+fake entropy until crypto service is available from SDFW
-      - nrf54h20dk/nrf54h20/cpuapp

--- a/samples/crypto/eddsa/sample.yaml
+++ b/samples/crypto/eddsa/sample.yaml
@@ -29,7 +29,7 @@ tests:
     sysbuild: true
     tags: introduction psa cracen sysbuild
     platform_allow: >
-      nrf54l15pdk/nrf54l15/cpuapp nrf54l15pdk/nrf54l15/cpuapp/ns nrf54h20dk/nrf54h20/cpuapp
+      nrf54l15pdk/nrf54l15/cpuapp nrf54l15pdk/nrf54l15/cpuapp/ns
     harness: console
     harness_config:
       type: multi_line
@@ -38,5 +38,3 @@ tests:
     integration_platforms:
       - nrf54l15pdk/nrf54l15/cpuapp
       - nrf54l15pdk/nrf54l15/cpuapp/ns
-      # nRF54H uses Oberon+fake entropy until crypto service is available from SDFW
-      - nrf54h20dk/nrf54h20/cpuapp

--- a/samples/crypto/hmac/sample.yaml
+++ b/samples/crypto/hmac/sample.yaml
@@ -30,7 +30,7 @@ tests:
     sysbuild: true
     tags: introduction psa cracen sysbuild
     platform_allow: >
-      nrf54h20dk/nrf54h20/cpuapp nrf54l15pdk/nrf54l15/cpuapp nrf54l15pdk/nrf54l15/cpuapp/ns
+      nrf54l15pdk/nrf54l15/cpuapp nrf54l15pdk/nrf54l15/cpuapp/ns
     harness: console
     harness_config:
       type: multi_line
@@ -39,5 +39,3 @@ tests:
     integration_platforms:
       - nrf54l15pdk/nrf54l15/cpuapp
       - nrf54l15pdk/nrf54l15/cpuapp/ns
-      # nRF54H uses Oberon+fake entropy until crypto service is available from SDFW
-      - nrf54h20dk/nrf54h20/cpuapp

--- a/samples/crypto/rng/sample.yaml
+++ b/samples/crypto/rng/sample.yaml
@@ -28,7 +28,7 @@ tests:
     sysbuild: true
     tags: introduction psa cracen sysbuild
     platform_allow: >
-      nrf54h20dk/nrf54h20/cpuapp nrf54l15pdk/nrf54l15/cpuapp nrf54l15pdk/nrf54l15/cpuapp/ns
+      nrf54l15pdk/nrf54l15/cpuapp nrf54l15pdk/nrf54l15/cpuapp/ns
     harness: console
     harness_config:
       type: multi_line
@@ -37,5 +37,3 @@ tests:
     integration_platforms:
       - nrf54l15pdk/nrf54l15/cpuapp
       - nrf54l15pdk/nrf54l15/cpuapp/ns
-      # nRF54H uses Oberon+fake entropy until crypto service is available from SDFW
-      - nrf54h20dk/nrf54h20/cpuapp

--- a/samples/crypto/rsa/sample.yaml
+++ b/samples/crypto/rsa/sample.yaml
@@ -29,7 +29,7 @@ tests:
     sysbuild: true
     tags: introduction psa cracen sysbuild
     platform_allow: >
-      nrf54l15pdk/nrf54l15/cpuapp nrf54l15pdk/nrf54l15/cpuapp/ns nrf54h20dk/nrf54h20/cpuapp
+      nrf54l15pdk/nrf54l15/cpuapp nrf54l15pdk/nrf54l15/cpuapp/ns
     harness: console
     harness_config:
       type: multi_line
@@ -38,5 +38,3 @@ tests:
     integration_platforms:
       - nrf54l15pdk/nrf54l15/cpuapp
       - nrf54l15pdk/nrf54l15/cpuapp/ns
-      # nRF54H uses Oberon+fake entropy until crypto service is available from SDFW
-      - nrf54h20dk/nrf54h20/cpuapp

--- a/samples/crypto/spake2p/sample.yaml
+++ b/samples/crypto/spake2p/sample.yaml
@@ -31,7 +31,6 @@ tests:
     platform_allow: >
       nrf54l15pdk/nrf54l15/cpuapp
       nrf54l15pdk/nrf54l15/cpuapp/ns
-      nrf54h20dk/nrf54h20/cpuapp
     harness: console
     harness_config:
       type: multi_line
@@ -40,5 +39,3 @@ tests:
     integration_platforms:
       - nrf54l15pdk/nrf54l15/cpuapp
       - nrf54l15pdk/nrf54l15/cpuapp/ns
-      # nRF54H uses Oberon+fake entropy until crypto service is available from SDFW
-      - nrf54h20dk/nrf54h20/cpuapp


### PR DESCRIPTION
nRF54H20 app core doesn't yet have access to CRACEN entropy from secure domain. Remove nRF54H20 from sample.yaml until crypto service is available from secure domain firmware.