### PR TITLE
tests: lib: lte_lc: correct platforms

### DIFF
--- a/tests/lib/lte_lc/testcase.yaml
+++ b/tests/lib/lte_lc/testcase.yaml
@@ -1,9 +1,7 @@
 tests:
   lte_lc.functionality_test:
     sysbuild: true
-    platform_allow: nrf9160dk/nrf9160 qemu_x86 native_posix qemu_cortex_m3
+    platform_allow: native_sim
     integration_platforms:
-      - nrf9160dk/nrf9160
-      - native_posix
-      - qemu_cortex_m3
+      - native_sim
     tags: lte_lc sysbuild


### PR DESCRIPTION
This is a unit tests, it shouldn't run on target.
There is no point in running it in `qemu_cortex_m3` and `qemu_x86` either.

Change from `native_posix` to `native_sim`.