### PR TITLE
manifest: icbmsg: Allow deregistration of the endpoints

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: b37d8914af3b4bef91540f33094f5cb56c2f6c1c
+      revision: 297b00dade9f72873f9dd9147008e4a90516a3ff
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This is implementation of ICBMsg endpoint deregistration. The underlying ICMsg instance and blocks are not affected by deregistration, so it is possible to reuse the same address during the re-registration of the same endpoint.