### PR TITLE
doc: Bluetooth: Mesh: Add note about cancel after successful dist

### DIFF
--- a/doc/nrf/protocols/bt/bt_mesh/dfu_over_bt_mesh.rst
+++ b/doc/nrf/protocols/bt/bt_mesh/dfu_over_bt_mesh.rst
@@ -96,6 +96,9 @@ To avoid applying the image immediately and only verify it, set the 4th argument
 
   mesh models dfd start 0 0 0 0
 
+.. note::
+   After a successful firmware distribution, the Firmware Distribution Server has to be set to idle state by issuing the ``mesh models dfd cancel`` shell command, before a new firmware distribution can be initiated.
+
 Firmware distribution
 =====================
 


### PR DESCRIPTION
Add a note about the need to cancel the Distribution Server after a successful firmware distribution.