### PR TITLE
net: lib: nrf_cloud_log: Fix crash with dictionary fmt

### DIFF
--- a/samples/cellular/nrf_cloud_multi_service/overlay_nrfcloud_logging.conf
+++ b/samples/cellular/nrf_cloud_multi_service/overlay_nrfcloud_logging.conf
@@ -16,10 +16,14 @@ CONFIG_LOG_RUNTIME_FILTERING=n
 CONFIG_LOG_BUFFER_SIZE=4096
 
 # Select which format to generate. Dictionary logs are compact but require
-# decoding on the server or user PC.  Text logs are verbose but immediately
-# visible in the nRF Cloud web portal.
-#CONFIG_LOG_BACKEND_NRF_CLOUD_OUTPUT_DICTIONARY=y
+# decoding on the server or user PC. Text logs are verbose but immediately
+# visible in the nRF Cloud web portal. Unless you disable UART text logging,
+# you must set CONFIG_LOG_FMT_SECTION_STRIP=n when
+# CONFIG_LOG_BACKEND_NRF_CLOUD_OUTPUT_DICTIONARY=y, or else you will get a
+# build assert warning you to do so. This is to prevent a hard crash at runtime.
 CONFIG_LOG_BACKEND_NRF_CLOUD_OUTPUT_TEXT=y
+#CONFIG_LOG_BACKEND_NRF_CLOUD_OUTPUT_DICTIONARY=y
+#CONFIG_LOG_FMT_SECTION_STRIP=n
 
 CONFIG_LOG_PROCESS_THREAD_STACK_SIZE=4096
 CONFIG_LOG_PROCESS_THREAD_SLEEP_MS=30000


### PR DESCRIPTION
Due to an upstream Zephyr change, CONFIG_LOG_FMT_SECTION_STRIP was being enabled when CONFIG_LOG_BACKEND_NRF_CLOUD_OUTPUT_DICTIONARY was enabled, which causes a hard crash when text logging to the UART (because the strings the UART logger needs are missing from the image).

Add documentation to the overlay_nrf_cloud_logging.conf and a build assert to detect this.

Jira: IRIS-9177