### PR TITLE
samples: wifi: radio_test: Fix combo build config

### DIFF
--- a/samples/wifi/radio_test/sample.yaml
+++ b/samples/wifi/radio_test/sample.yaml
@@ -21,6 +21,7 @@ tests:
   sample.nrf7002.radio_test_combo:
     sysbuild: true
     build_only: true
+    extra_args: CONFIG_NRF700X_RADIO_TEST_COMBO=y
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp


### PR DESCRIPTION
Add CONFIG_NRF700X_RADIO_TEST_COMBO option to CI build.