### PR TITLE
manifest: update sdk-zephyr revision.

### DIFF
--- a/scripts/quarantine_zephyr.yaml
+++ b/scripts/quarantine_zephyr.yaml
@@ -160,6 +160,8 @@
   platforms:
     - nrf54l15pdk/nrf54l15/cpuapp
     - nrf54h20dk/nrf54h20/cpuapp
+    - nrf54h20dk/nrf54h20/cpurad
+    - nrf54h20dk/nrf54h20/cpuppr
   comment: "https://nordicsemi.atlassian.net/browse/NCSDK-27853"
 
 - scenarios:

--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v3.6.99-ncs2-rc2
+      revision: 7cdba410507f1edd6af13aa723628f7f95a465d9
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull in changes enabling coverage calculation in adc samples.

Extend quarantine to make CI green.