### PR TITLE
doc: nRF54L15 getting started small fix

### DIFF
--- a/doc/nrf/device_guides/working_with_nrf/nrf54l/nrf54l15_gs.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf54l/nrf54l15_gs.rst
@@ -108,7 +108,7 @@ To build and program the sample to the nRF54L15 PDK, complete the following step
 
    .. code-block:: console
 
-      west flash --erase
+      west flash
 
    If you have multiple Nordic Semiconductor devices, make sure that only the nRF54L15 PDK is connected.
 


### PR DESCRIPTION
removed the --erase argument from west flash command.
VS code runs it by default.