### PR TITLE
sysbuild: Flash network core image first, if enabled

### DIFF
--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -489,6 +489,11 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_post_cmake)
       get_property(PM_NRF70_WIFI_FW_OFFSET TARGET partition_manager PROPERTY PM_NRF70_WIFI_FW_OFFSET)
       get_property(PM_NRF70_WIFI_FW_SIZE TARGET partition_manager PROPERTY PM_NRF70_WIFI_FW_SIZE)
     endif()
+
+    # If the network core image is enabled on nRF53, ensure it is flashed before the main application
+    if(SB_CONFIG_SUPPORT_NETCORE AND NOT SB_CONFIG_NETCORE_NONE)
+      sysbuild_add_dependencies(FLASH ${DEFAULT_IMAGE} ${SB_CONFIG_NETCORE_IMAGE_NAME})
+    endif()
   endif()
   foreach(image ${IMAGES})
     configure_cache(IMAGE ${image})


### PR DESCRIPTION
Flashes the merged network core image first when partition manager is enabled, this prevents issues if security modes become active after the main core image is flashed first