### PR TITLE
samples: matter: Provide a fix for unacceptable booting time

### DIFF
--- a/samples/matter/light_bulb/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/light_bulb/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -15,3 +15,10 @@ CONFIG_NRF_802154_TEMPERATURE_UPDATE=n
 
 # TODO: Workaround to be removed once Zephyr's CONFIG_FPROTECT is supported on nRF54L
 CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT=n
+
+# Currently, without tickless kernel, the SYSCOUNTER value after the software
+# reset is not set properly and due to that the first system interrupt is not called
+# in the proper time - the SYSCOUNTER value is set to the value from before
+# reset + 1. Hence, the reboot time increases more and more.
+# To avoid it enable tickles kernel for mcuboot.
+CONFIG_TICKLESS_KERNEL=y

--- a/samples/matter/light_switch/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/light_switch/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -25,3 +25,10 @@ CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y
 
 # Adjust the maximum sectors to the app image size of ~1.4MB
 CONFIG_BOOT_MAX_IMG_SECTORS=512
+
+# Currently, without tickless kernel, the SYSCOUNTER value after the software
+# reset is not set properly and due to that the first system interrupt is not called
+# in the proper time - the SYSCOUNTER value is set to the value from before
+# reset + 1. Hence, the reboot time increases more and more.
+# To avoid it enable tickles kernel for mcuboot.
+CONFIG_TICKLESS_KERNEL=y

--- a/samples/matter/lock/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/lock/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -25,3 +25,10 @@ CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y
 
 # Adjust the maximum sectors to the app image size of ~1.4MB
 CONFIG_BOOT_MAX_IMG_SECTORS=512
+
+# Currently, without tickless kernel, the SYSCOUNTER value after the software
+# reset is not set properly and due to that the first system interrupt is not called
+# in the proper time - the SYSCOUNTER value is set to the value from before
+# reset + 1. Hence, the reboot time increases more and more.
+# To avoid it enable tickles kernel for mcuboot.
+CONFIG_TICKLESS_KERNEL=y

--- a/samples/matter/template/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/template/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -25,3 +25,10 @@ CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y
 
 # Adjust the maximum sectors to the app image size of ~1.4MB
 CONFIG_BOOT_MAX_IMG_SECTORS=512
+
+# Currently, without tickless kernel, the SYSCOUNTER value after the software
+# reset is not set properly and due to that the first system interrupt is not called
+# in the proper time - the SYSCOUNTER value is set to the value from before
+# reset + 1. Hence, the reboot time increases more and more.
+# To avoid it enable tickles kernel for mcuboot.
+CONFIG_TICKLESS_KERNEL=y

--- a/samples/matter/template/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp_internal.conf
+++ b/samples/matter/template/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp_internal.conf
@@ -36,3 +36,10 @@ CONFIG_SPI_NOR=n
 CONFIG_SPI=n
 CONFIG_MULTITHREADING=n
 CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=n
+
+# Currently, without tickless kernel, the SYSCOUNTER value after the software
+# reset is not set properly and due to that the first system interrupt is not called
+# in the proper time - the SYSCOUNTER value is set to the value from before
+# reset + 1. Hence, the reboot time increases more and more.
+# To avoid it enable tickles kernel for mcuboot.
+CONFIG_TICKLESS_KERNEL=y

--- a/samples/matter/thermostat/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/thermostat/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -25,3 +25,10 @@ CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y
 
 # Adjust the maximum sectors to the app image size of ~1.4MB
 CONFIG_BOOT_MAX_IMG_SECTORS=512
+
+# Currently, without tickless kernel, the SYSCOUNTER value after the software
+# reset is not set properly and due to that the first system interrupt is not called
+# in the proper time - the SYSCOUNTER value is set to the value from before
+# reset + 1. Hence, the reboot time increases more and more.
+# To avoid it enable tickles kernel for mcuboot.
+CONFIG_TICKLESS_KERNEL=y

--- a/samples/matter/window_covering/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/window_covering/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -25,3 +25,10 @@ CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y
 
 # Adjust the maximum sectors to the app image size of ~1.4MB
 CONFIG_BOOT_MAX_IMG_SECTORS=512
+
+# Currently, without tickless kernel, the SYSCOUNTER value after the software
+# reset is not set properly and due to that the first system interrupt is not called
+# in the proper time - the SYSCOUNTER value is set to the value from before
+# reset + 1. Hence, the reboot time increases more and more.
+# To avoid it enable tickles kernel for mcuboot.
+CONFIG_TICKLESS_KERNEL=y


### PR DESCRIPTION
Currently, without tickless kernel, the SYSCOUNTER value after the software reset is not set properly and due to that the first system interrupt is not called in the proper time, the SYSCOUNTER value is set to the value from before reset + 1. Hence, the reboot time increases more and more.

To avoid it enable tickles kernel for mcuboot.