### PR TITLE
partition_manager: Add support for nrf54l15_cpuflpr with vpr_launcher

### DIFF
--- a/Kconfig.nrf
+++ b/Kconfig.nrf
@@ -109,6 +109,17 @@ config NORDIC_QSPI_NOR_FLASH_LAYOUT_PAGE_SIZE
 config GETOPT
 	default n
 
+# Temporary hack to be able to build samples and tests on the nRF51L15 FLPR core
+if SOC_NRF54L15_ENGA_CPUFLPR && PARTITION_MANAGER_ENABLED
+config FLASH_BASE_ADDRESS
+	hex
+	default 0x0
+config FLASH_SIZE
+	int
+	default 1524
+endif
+
+
 rsource "samples/Kconfig"
 rsource "subsys/Kconfig"
 rsource "modules/Kconfig"

--- a/subsys/partition_manager/CMakeLists.txt
+++ b/subsys/partition_manager/CMakeLists.txt
@@ -130,6 +130,10 @@ if (CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_FLASH)
   ncs_add_partition_manager_config(pm.yml.modem_trace)
 endif()
 
+if (CONFIG_SOC_NRF54L15_ENGA_CPUFLPR)
+  ncs_add_partition_manager_config(pm.yml.vpr_launcher)
+endif()
+
 # We are using partition manager if we are a child image or if we are
 # the root image and the 'partition_manager' target exists.
 if (SYSBUILD)

--- a/subsys/partition_manager/Kconfig
+++ b/subsys/partition_manager/Kconfig
@@ -120,6 +120,16 @@ rsource "Kconfig.template.partition_config"
 rsource "Kconfig.template.partition_region"
 endif
 
+if SOC_NRF54L15_ENGA_CPUFLPR
+config PM_PARTITION_SIZE_VPR_LAUNCHER
+	hex
+	default $(dt_node_reg_addr_hex,/soc/rram-controller@5004b000/rram@165000)
+	help
+	  Memory set aside for the vpr_launcher partition.
+	  Must match the size of the cpuapp_rram partition which is deleted.
+	  This to place the flpr app's code at the address found in the devicetree.
+endif
+
 endmenu # Zephyr subsystem configurations
 menu "NCS subsystem configurations"
 
@@ -205,11 +215,13 @@ config PM_OVERRIDE_EXTERNAL_DRIVER_CHECK
 config PM_SRAM_BASE
 	hex
 	default $(dt_node_reg_addr_hex,/soc/memory@21000000) if SOC_NRF5340_CPUNET
+	default 0x20000000 if SOC_NRF54L15_ENGA_CPUFLPR  # Because the cpuapp_sram DT node is deleted in nrf54l15_cpuflpr.dtsi
 	default $(dt_node_reg_addr_hex,/soc/memory@20000000)
 
 config PM_SRAM_SIZE
 	hex
 	default $(dt_node_reg_size_hex,/soc/memory@21000000) if SOC_NRF5340_CPUNET
+	default 0x40000 if SOC_NRF54L15_ENGA_CPUFLPR  # Because the cpuapp_rram DT node is deleted in nrf54l15_cpuflpr.dtsi
 	default $(dt_node_reg_size_hex,/soc/memory@20000000)
 
 endmenu # Partition Manager

--- a/subsys/partition_manager/pm.yml.vpr_launcher
+++ b/subsys/partition_manager/pm.yml.vpr_launcher
@@ -1,0 +1,10 @@
+#include <autoconf.h>
+
+vpr_launcher:
+  placement: {before: app}
+  size: CONFIG_PM_PARTITION_SIZE_VPR_LAUNCHER
+
+vpr_launcher_sram:
+  region: sram_primary
+  placement: {before: app}
+  size: 0x28000


### PR DESCRIPTION
Add case for cpuflpr_sram in PM_SRAM_(BASE|SIZE)

Add pm.yml.vpr_launcher file

Include a noup patch in Zephyr that overwrites FLASH_BASE_ADDRESS and
FLASH_SIZE to allow Partition Manager to use the whole RRAM instead of
trying to put both the flpr firmware and the vpr_launcher into the flpr
RRAM partition.