### PR TITLE
modules: TF-M: Allow RRAMC configuration from the non-secure app

### DIFF
--- a/modules/trusted-firmware-m/tfm_boards/services/include/tfm_platform_user_memory_ranges.h
+++ b/modules/trusted-firmware-m/tfm_boards/services/include/tfm_platform_user_memory_ranges.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#ifndef TFM_READ_RANGES_H__
-#define TFM_READ_RANGES_H__
+#ifndef TFM_PLATFORM_USER_MEMORY_RANGES_H__
+#define TFM_PLATFORM_USER_MEMORY_RANGES_H__
 
 #include <pm_config.h>
 
@@ -76,4 +76,9 @@ static const struct tfm_read_service_range ranges[] = {
 #endif
 };
 
-#endif /* TFM_READ_RANGES_H__ */
+static const struct tfm_write32_service_address tfm_write32_service_addresses[] = {
+	/* This is a dummy value because this table cannot be empty */
+	{.addr = 0xFFFFFFFF, .mask = 0x0, .allowed_values = NULL, .allowed_values_array_size = 0},
+};
+
+#endif /* TFM_PLATFORM_USER_MEMORY_RANGES_H__ */

--- a/modules/trusted-firmware-m/tfm_boards/services/include/tfm_platform_user_memory_ranges.h
+++ b/modules/trusted-firmware-m/tfm_boards/services/include/tfm_platform_user_memory_ranges.h
@@ -76,9 +76,27 @@ static const struct tfm_read_service_range ranges[] = {
 #endif
 };
 
+#if defined(NRF_RRAMC_S)
+/**
+ * 0x518 is the offset for the low power configuration, currently not in MDK,
+ * the first two bits control the lower power mode of RRAMC.
+ */
+#define NRF_RRAMC_LOWPOWER_CONFIG_ADDR (NRF_RRAMC_S_BASE + 0x518)
+
+/* Values: 0x0 = Power down mode, 0x1 = Standby mode */
+static const uint32_t rramc_lowpower_config_allowed[] = {0x0, 0x1};
+#endif /* NRF_RRAMC_S */
+
 static const struct tfm_write32_service_address tfm_write32_service_addresses[] = {
+#if defined(NRF_RRAMC_S)
+	{.addr = NRF_RRAMC_LOWPOWER_CONFIG_ADDR,
+	 .mask = 0x3,
+	 .allowed_values = rramc_lowpower_config_allowed,
+	 .allowed_values_array_size = 2 },
+#else
 	/* This is a dummy value because this table cannot be empty */
 	{.addr = 0xFFFFFFFF, .mask = 0x0, .allowed_values = NULL, .allowed_values_array_size = 0},
+#endif
 };
 
 #endif /* TFM_PLATFORM_USER_MEMORY_RANGES_H__ */

--- a/modules/trusted-firmware-m/tfm_boards/src/tfm_platform_system.c
+++ b/modules/trusted-firmware-m/tfm_boards/src/tfm_platform_system.c
@@ -128,6 +128,8 @@ enum tfm_platform_err_t tfm_platform_hal_ioctl(tfm_platform_ioctl_req_t request,
 	switch (request) {
 	case TFM_PLATFORM_IOCTL_READ_SERVICE:
 		return tfm_platform_hal_read_service(in_vec, out_vec);
+	case TFM_PLATFORM_IOCTL_WRITE32_SERVICE:
+		return tfm_platform_hal_write32_service(in_vec, out_vec);
 #if defined(GPIO_PIN_CNF_MCUSEL_Msk)
 	case TFM_PLATFORM_IOCTL_GPIO_SERVICE:
 		return tfm_platform_hal_gpio_service(in_vec, out_vec);

--- a/west.yml
+++ b/west.yml
@@ -152,7 +152,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: f334e66e3d38aa99f4fbf08ebf17c16697bda4ed
+      revision: e7ecf59761197975b86c0c7077950ca3c9159681
     - name: psa-arch-tests
       repo-path: sdk-psa-arch-tests
       path: modules/tee/tf-m/psa-arch-tests


### PR DESCRIPTION
Adds a service which allows writing to secure memory from the non-secure application for specific memory locations.

Adds an option to configure the RRAMC controller to low power mode from the non-secure application.

Ref: NCSDK-27159