### PR TITLE
doc improvement: Minor updates on nRF91 Series and LwM2M carrier

### DIFF
--- a/doc/nrf/device_guides/nrf91/index.rst
+++ b/doc/nrf/device_guides/nrf91/index.rst
@@ -22,6 +22,7 @@ Zephyr and the |NCS| provide support for developing cellular applications using 
      - PCA10153
      - ``nrf9161dk/nrf9161``, ``nrf9161dk/nrf9161/ns``
      - | `Product Specification <nRF9161 Product Specification_>`_
+       | :ref:`Getting started <gsg_guides>`
        | `User Guide <nRF9161 DK Hardware_>`_
      - | `nRF9161 DK product page`_
        | `nRF9161 System in Package (SiP) <nRF9161 product website_>`_
@@ -36,7 +37,7 @@ Zephyr and the |NCS| provide support for developing cellular applications using 
    * - :ref:`zephyr:nrf9151dk_nrf9151`
      - PCA10171
      - ``nrf9151dk/nrf9151``, ``nrf9151dk/nrf9151/ns``
-     - --
+     - | :ref:`Getting started <gsg_guides>`
      - | `nRF9151 System in Package (SiP) <nRF9151 product website_>`_
    * - :ref:`zephyr:nrf9131ek_nrf9131`
      - PCA10165

--- a/doc/nrf/device_guides/nrf91/nrf91_board_controllers.rst
+++ b/doc/nrf/device_guides/nrf91/nrf91_board_controllers.rst
@@ -22,6 +22,9 @@ The `Board control section in the nRF9161 DK User Guide <nRF9161 DK board contro
 The nRF5340 IMCU comes preprogrammed with J-Link SEGGER OB and board controller firmware.
 If you want to change the default configuration of the DK, you can use the `nRF Connect Board Configurator`_ app in `nRF Connect for Desktop`_ .
 
+To update board controller firmware on the nRF9161 DK, download the `nRF9161 DK board controller firmware`_ from the nRF9161 DK downloads page.
+To program the HEX file, use `nRF Util`_.
+
 .. _nrf9160_ug_intro:
 
 Board controller on the nRF9160 DK
@@ -32,7 +35,7 @@ For a complete list of all the routing options available, see the `nRF9160 DK bo
 Make sure to select the correct controller before you program the application to your development kit.
 
 The nRF52840 SoC on the DK comes preprogrammed with a firmware.
-If you need to restore the original firmware at some point, download the nRF9160 DK board controller firmware from the `nRF9160 DK downloads`_ page.
+If you need to restore the original firmware at some point, download the `nRF9160 DK board controller firmware`_ from the nRF9160 DK downloads page.
 To program the HEX file, use nrfjprog (which is part of the `nRF Command Line Tools`_).
 
 If you want to route some pins differently from what is done in the preprogrammed firmware, program the :ref:`zephyr:hello_world` sample instead of the preprogrammed firmware.

--- a/doc/nrf/device_guides/nrf91/nrf91_dk_updating_fw_programmer.rst
+++ b/doc/nrf/device_guides/nrf91/nrf91_dk_updating_fw_programmer.rst
@@ -8,7 +8,7 @@ Updating the DK firmware using Programmer
    :local:
    :depth: 2
 
-Before you begin to update the firmware, download and extract the latest application and modem firmware from the `nRF9160 DK Downloads`_ page.
+Before you begin to update the firmware, download and extract the latest application and modem firmware from the `nRF9161 DK Downloads`_ or `nRF9160 DK Downloads`_ page, depending on the DK you are using.
 
 The downloaded ZIP archive contains the following firmware:
 

--- a/doc/nrf/device_guides/nrf91/nrf91_features.rst
+++ b/doc/nrf/device_guides/nrf91/nrf91_features.rst
@@ -93,7 +93,7 @@ A delta patch can only update the modem firmware from one specific version to an
 If you need to perform a major version update (for example, v1.2.x to v1.3.x), you need an external flash with a minimum size of 4 MB.
 
 Different versions of the LTE modem firmware are available, and these versions are certified for the mobile network operators having their own certification programs.
-See the `Mobile network operator certifications`_ for more information.
+For more information, see the `nRF9161 Mobile network operator certifications`_ or `nRF9160 Mobile network operator certifications`_, depending on the SiP you are using.
 
 .. note::
 

--- a/doc/nrf/libraries/bin/lwm2m_carrier/CHANGELOG.rst
+++ b/doc/nrf/libraries/bin/lwm2m_carrier/CHANGELOG.rst
@@ -12,7 +12,7 @@ All notable changes to this project are documented in this file.
 Certification status
 ====================
 
-For certification status of the released versions, see `Mobile network operator certifications`_.
+For certification status of the released versions, see the `nRF9161 Mobile network operator certifications`_ or `nRF9160 Mobile network operator certifications`_, depending on the SiP you are using.
 
 liblwm2m_carrier 3.5.1
 **********************

--- a/doc/nrf/libraries/bin/lwm2m_carrier/certification.rst
+++ b/doc/nrf/libraries/bin/lwm2m_carrier/certification.rst
@@ -10,7 +10,7 @@ Certification and version dependencies
 Every released version of the LwM2M carrier library is considered for certification with applicable carriers.
 The LwM2M carrier library is certified together with specific versions of the modem firmware and the |NCS|.
 
-For a list of all the carrier certifications (including those certifications with no dependency on the LwM2M carrier library), see the `Mobile network operator certifications`_.
+For a list of all the carrier certifications (including those certifications with no dependency on the LwM2M carrier library), see the `nRF9161 Mobile network operator certifications`_ or `nRF9160 Mobile network operator certifications`_, depending on the SiP you are using.
 
 The LwM2M carrier library is used by Nordic during *module certification*.
 Including the library in your application is one way to fulfill the device management requirements of your carrier.

--- a/doc/nrf/libraries/bin/lwm2m_carrier/index.rst
+++ b/doc/nrf/libraries/bin/lwm2m_carrier/index.rst
@@ -9,7 +9,11 @@ LwM2M carrier
 
 Several mobile network carriers specify their own LwM2M device management.
 The LwM2M carrier library facilitates an nRF91 device to connect to the device management servers, regardless of the other actions of the user application.
-For more information, see the list of `applicable carriers <Mobile network operator certifications_>`_, and the :ref:`lwm2m_certification` subpage.
+For more information, see the following pages:
+
+* `nRF9161 Mobile network operator certifications`_
+* `nRF9160 Mobile network operator certifications`_
+* :ref:`lwm2m_certification`
 
 .. important::
 

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -412,10 +412,12 @@
 .. _`Nordic nRF9161 DK`:
 .. _`nRF9161 DK product page`: https://www.nordicsemi.com/Products/Development-hardware/nRF9161-DK
 .. _`nRF9161 DK Downloads`: https://www.nordicsemi.com/Products/Development-hardware/nRF9161-DK/Download?lang=en#infotabs
+.. _`nRF9161 DK board controller firmware`: https://www.nordicsemi.com/Products/Development-hardware/nRF9161-DK/Download?lang=en#B73EF1B2F2A34F50A40DC90199A1DAE2
 
 .. _`Nordic nRF9160 DK`:
 .. _`nRF9160 DK product page`: https://www.nordicsemi.com/Products/Development-hardware/nrf9160-dk/
 .. _`nRF9160 DK Downloads`: https://www.nordicsemi.com/Products/Development-hardware/nRF9160-DK/Download#infotabs
+.. _`nRF9160 DK board controller firmware`: https://www.nordicsemi.com/Products/Development-hardware/nRF9160-DK/Download?lang=en#B460A4E1F91A40B99C6432AD8CEC767C
 .. _`SUPL client download`: https://www.nordicsemi.com/Software-and-tools/Development-Kits/nRF9160-DK/Download#supl-c
 
 .. _`nRF9151 product website`: https://www.nordicsemi.com/Products/nRF9151
@@ -713,7 +715,8 @@
 .. _`AP-Protect for nRF52810`: https://docs.nordicsemi.com/bundle/ps_nrf52810/page/dif.html#ariaid-title3
 .. _`AP-Protect for nRF52805`: https://docs.nordicsemi.com/bundle/ps_nrf52805/page/dif.html#ariaid-title3
 
-.. _`Mobile network operator certifications`: https://docs.nordicsemi.com/bundle/comp_matrix_nrf9160/page/COMP/nrf9160/nrf9160_operator_certifications.html
+.. _`nRF9160 Mobile network operator certifications`: https://docs.nordicsemi.com/bundle/comp_matrix_nrf9160/page/COMP/nrf9160/nrf9160_operator_certifications.html
+.. _`nRF9161 Mobile network operator certifications`: https://docs.nordicsemi.com/bundle/comp_matrix_nrf9161/page/COMP/nrf9161/nrf9161_operator_certifications.html
 .. _`Modem firmware compatibility matrix`: https://docs.nordicsemi.com/bundle/comp_matrix_nrf9160/page/COMP/nrf9160/nrf9160_modem_fw.html
 
 .. _`Electrical specification of nRF9160`: https://docs.nordicsemi.com/bundle/ps_nrf9160/page/_tmp/alta.nRF9160/autodita/APPLICATION.CURRENT/parameters.frontpage.html


### PR DESCRIPTION
* Added nRF9161 comp matrix ref links to the NCS docs.
* Updated the nRF91 Series table to add GSG link.
NCSDK-25959