### PR TITLE
nrf_security: Added cache handling using DMM in PSA Crypto service

### DIFF
--- a/include/sdfw/sdfw_services/crypto_service.h
+++ b/include/sdfw/sdfw_services/crypto_service.h
@@ -481,35 +481,6 @@ psa_status_t ssf_psa_generate_random(uint8_t *output, size_t output_size);
 psa_status_t ssf_psa_generate_key(const psa_key_attributes_t *attributes,
 				  mbedtls_svc_key_id_t *key);
 
-/** @brief Execute psa_sign_hash_start over SSF.
- *
- * See psa_sign_hash_start for details.
- */
-psa_status_t ssf_psa_sign_hash_start(psa_sign_hash_interruptible_operation_t *operation,
-				     mbedtls_svc_key_id_t key, psa_algorithm_t alg,
-				     const uint8_t *hash, size_t hash_length);
-
-/** @brief Execute psa_sign_hash_abort over SSF.
- *
- * See psa_sign_hash_abort for details.
- */
-psa_status_t ssf_psa_sign_hash_abort(psa_sign_hash_interruptible_operation_t *operation);
-
-/** @brief Execute psa_verify_hash_start over SSF.
- *
- * See psa_verify_hash_start for details.
- */
-psa_status_t ssf_psa_verify_hash_start(psa_verify_hash_interruptible_operation_t *operation,
-				       mbedtls_svc_key_id_t key, psa_algorithm_t alg,
-				       const uint8_t *hash, size_t hash_length,
-				       const uint8_t *signature, size_t signature_length);
-
-/** @brief Execute psa_verify_hash_abort over SSF.
- *
- * See psa_verify_hash_abort for details.
- */
-psa_status_t ssf_psa_verify_hash_abort(psa_verify_hash_interruptible_operation_t *operation);
-
 /** @brief Execute psa_pake_setup over SSF.
  *
  * See psa_pake_setup for details.

--- a/subsys/nrf_security/src/ssf_secdom/ssf_crypto.c
+++ b/subsys/nrf_security/src/ssf_secdom/ssf_crypto.c
@@ -423,32 +423,6 @@ psa_status_t psa_generate_key(const psa_key_attributes_t *attributes, mbedtls_sv
 	return ssf_psa_generate_key(attributes, key);
 }
 
-psa_status_t psa_sign_hash_start(psa_sign_hash_interruptible_operation_t *operation,
-				 mbedtls_svc_key_id_t key, psa_algorithm_t alg, const uint8_t *hash,
-				 size_t hash_length)
-{
-	return ssf_psa_sign_hash_start(operation, key, alg, hash, hash_length);
-}
-
-psa_status_t psa_sign_hash_abort(psa_sign_hash_interruptible_operation_t *operation)
-{
-	return ssf_psa_sign_hash_abort(operation);
-}
-
-psa_status_t psa_verify_hash_start(psa_verify_hash_interruptible_operation_t *operation,
-				   mbedtls_svc_key_id_t key, psa_algorithm_t alg,
-				   const uint8_t *hash, size_t hash_length,
-				   const uint8_t *signature, size_t signature_length)
-{
-	return ssf_psa_verify_hash_start(operation, key, alg, hash, hash_length, signature,
-					 signature_length);
-}
-
-psa_status_t psa_verify_hash_abort(psa_verify_hash_interruptible_operation_t *operation)
-{
-	return ssf_psa_verify_hash_abort(operation);
-}
-
 psa_status_t psa_pake_setup(psa_pake_operation_t *operation, mbedtls_svc_key_id_t password_key,
 			    const psa_pake_cipher_suite_t *cipher_suite)
 {

--- a/subsys/sdfw_services/services/psa_crypto/Kconfig
+++ b/subsys/sdfw_services/services/psa_crypto/Kconfig
@@ -8,6 +8,6 @@ service_name = PSA_CRYPTO
 service_default_enabled = n
 service_id = 0x71
 service_version = 1
-service_buffer_size = 64
+service_buffer_size = 128
 service_name_str = PSA Crypto
 rsource "../Kconfig.template.service"

--- a/subsys/sdfw_services/services/psa_crypto/psa_crypto_service.c
+++ b/subsys/sdfw_services/services/psa_crypto/psa_crypto_service.c
@@ -4,8 +4,10 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include <zephyr/device.h>
 #include "psa_crypto_service_encode.h"
 #include "psa_crypto_service_decode.h"
+#include "dmm.h"
 
 #include <sdfw/sdfw_services/ssf_client.h>
 #include <sdfw/sdfw_services/crypto_service.h>
@@ -15,6 +17,12 @@ LOG_MODULE_REGISTER(psa_crypto_srvc, CONFIG_SSF_PSA_CRYPTO_SERVICE_LOG_LEVEL);
 
 SSF_CLIENT_SERVICE_DEFINE(psa_crypto_srvc, PSA_CRYPTO, cbor_encode_psa_crypto_req,
 			  cbor_decode_psa_crypto_rsp);
+
+#if CONFIG_SOC_NRF54H20_CPUAPP
+static void *mem_region = (void *)DT_REG_ADDR(DT_NODELABEL(cpuapp_dma_region));
+#else
+static void *mem_region = (void *)DT_REG_ADDR(DT_NODELABEL(cpurad_dma_region));
+#endif
 
 psa_status_t ssf_psa_crypto_init(void)
 {
@@ -32,54 +40,68 @@ psa_status_t ssf_psa_crypto_init(void)
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_get_key_attributes(
-
-	mbedtls_svc_key_id_t key, psa_key_attributes_t *attributes)
+psa_status_t ssf_psa_get_key_attributes(mbedtls_svc_key_id_t key, psa_key_attributes_t *attributes)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_get_key_attributes_req *req_data;
+	void *attributes_buffer = NULL;
+
+	err = dmm_buffer_in_prepare(mem_region, attributes, sizeof(psa_key_attributes_t),
+				    &attributes_buffer);
+	if (err != 0) {
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_get_key_attributes_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_get_key_attributes_req_m;
 
 	req_data->psa_get_key_attributes_req_key = key;
-	req_data->psa_get_key_attributes_req_p_attributes = (uint32_t)attributes;
+	req_data->psa_get_key_attributes_req_p_attributes = (uint32_t)attributes_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, attributes, sizeof(psa_key_attributes_t),
+			      attributes_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_reset_key_attributes(
-
-	psa_key_attributes_t *attributes)
+psa_status_t ssf_psa_reset_key_attributes(psa_key_attributes_t *attributes)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_reset_key_attributes_req *req_data;
+	void *attributes_buffer = NULL;
+
+	err = dmm_buffer_in_prepare(mem_region, attributes, sizeof(psa_key_attributes_t),
+				    &attributes_buffer);
+	if (err != 0) {
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_reset_key_attributes_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_reset_key_attributes_req_m;
 
-	req_data->psa_reset_key_attributes_req_p_attributes = (uint32_t)attributes;
+	req_data->psa_reset_key_attributes_req_p_attributes = (uint32_t)attributes_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, attributes, sizeof(psa_key_attributes_t),
+			      attributes_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_purge_key(
-
-	mbedtls_svc_key_id_t key)
+psa_status_t ssf_psa_purge_key(mbedtls_svc_key_id_t key)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
@@ -99,34 +121,49 @@ psa_status_t ssf_psa_purge_key(
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_copy_key(
-
-	mbedtls_svc_key_id_t source_key, const psa_key_attributes_t *attributes,
-	mbedtls_svc_key_id_t *target_key)
+psa_status_t ssf_psa_copy_key(mbedtls_svc_key_id_t source_key,
+			      const psa_key_attributes_t *attributes,
+			      mbedtls_svc_key_id_t *target_key)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_copy_key_req *req_data;
+	void *attributes_buffer = NULL;
+	void *target_key_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, attributes, sizeof(psa_key_attributes_t),
+				     &attributes_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, target_key, sizeof(mbedtls_svc_key_id_t),
+				    &target_key_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, attributes_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_copy_key_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_copy_key_req_m;
 
 	req_data->psa_copy_key_req_source_key = source_key;
-	req_data->psa_copy_key_req_p_attributes = (uint32_t)attributes;
-	req_data->psa_copy_key_req_p_target_key = (uint32_t)target_key;
+	req_data->psa_copy_key_req_p_attributes = (uint32_t)attributes_buffer;
+	req_data->psa_copy_key_req_p_target_key = (uint32_t)target_key_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_out_release(mem_region, attributes_buffer);
+	dmm_buffer_in_release(mem_region, target_key, sizeof(mbedtls_svc_key_id_t),
+			      target_key_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_destroy_key(
-
-	mbedtls_svc_key_id_t key)
+psa_status_t ssf_psa_destroy_key(mbedtls_svc_key_id_t key)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
@@ -146,127 +183,208 @@ psa_status_t ssf_psa_destroy_key(
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_import_key(
-
-	const psa_key_attributes_t *attributes, const uint8_t *data, size_t data_length,
-	mbedtls_svc_key_id_t *key)
+psa_status_t ssf_psa_import_key(const psa_key_attributes_t *attributes, const uint8_t *data,
+				size_t data_length, mbedtls_svc_key_id_t *key)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_import_key_req *req_data;
+	void *attributes_buffer = NULL;
+	void *data_buffer = NULL;
+	void *key_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, attributes, sizeof(psa_key_attributes_t),
+				     &attributes_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_out_prepare(mem_region, data, data_length, &data_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, attributes_buffer);
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, key, sizeof(mbedtls_svc_key_id_t), &key_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, attributes_buffer);
+		dmm_buffer_out_release(mem_region, data_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_import_key_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_import_key_req_m;
 
-	req_data->psa_import_key_req_p_attributes = (uint32_t)attributes;
-	req_data->psa_import_key_req_p_data = (uint32_t)data;
+	req_data->psa_import_key_req_p_attributes = (uint32_t)attributes_buffer;
+	req_data->psa_import_key_req_p_data = (uint32_t)data_buffer;
 	req_data->psa_import_key_req_data_length = data_length;
-	req_data->psa_import_key_req_p_key = (uint32_t)key;
+	req_data->psa_import_key_req_p_key = (uint32_t)key_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_out_release(mem_region, attributes_buffer);
+	dmm_buffer_out_release(mem_region, data_buffer);
+	dmm_buffer_in_release(mem_region, key, sizeof(mbedtls_svc_key_id_t), key_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_export_key(
-
-	mbedtls_svc_key_id_t key, uint8_t *data, size_t data_size, size_t *data_length)
+psa_status_t ssf_psa_export_key(mbedtls_svc_key_id_t key, uint8_t *data, size_t data_size,
+				size_t *data_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_export_key_req *req_data;
+	void *data_buffer = NULL;
+	void *data_length_buffer = NULL;
+
+	err = dmm_buffer_in_prepare(mem_region, data, data_size, &data_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, data_length, sizeof(size_t), &data_length_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, data, data_size, data_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_export_key_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_export_key_req_m;
 
 	req_data->psa_export_key_req_key = key;
-	req_data->psa_export_key_req_p_data = (uint32_t)data;
+	req_data->psa_export_key_req_p_data = (uint32_t)data_buffer;
 	req_data->psa_export_key_req_data_size = data_size;
-	req_data->psa_export_key_req_p_data_length = (uint32_t)data_length;
+	req_data->psa_export_key_req_p_data_length = (uint32_t)data_length_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, data, data_size, data_buffer);
+	dmm_buffer_in_release(mem_region, data_length, sizeof(size_t), data_length_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_export_public_key(
-
-	mbedtls_svc_key_id_t key, uint8_t *data, size_t data_size, size_t *data_length)
+psa_status_t ssf_psa_export_public_key(mbedtls_svc_key_id_t key, uint8_t *data, size_t data_size,
+				       size_t *data_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_export_public_key_req *req_data;
+	void *data_buffer = NULL;
+	void *data_length_buffer = NULL;
+
+	err = dmm_buffer_in_prepare(mem_region, data, data_size, &data_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, data_length, sizeof(size_t), &data_length_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, data, data_size, data_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_export_public_key_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_export_public_key_req_m;
 
 	req_data->psa_export_public_key_req_key = key;
-	req_data->psa_export_public_key_req_p_data = (uint32_t)data;
+	req_data->psa_export_public_key_req_p_data = (uint32_t)data_buffer;
 	req_data->psa_export_public_key_req_data_size = data_size;
-	req_data->psa_export_public_key_req_p_data_length = (uint32_t)data_length;
+	req_data->psa_export_public_key_req_p_data_length = (uint32_t)data_length_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, data, data_size, data_buffer);
+	dmm_buffer_in_release(mem_region, data_length, sizeof(size_t), data_length_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_hash_compute(
-
-	psa_algorithm_t alg, const uint8_t *input, size_t input_length, uint8_t *hash,
-	size_t hash_size, size_t *hash_length)
+psa_status_t ssf_psa_hash_compute(psa_algorithm_t alg, const uint8_t *input, size_t input_length,
+				  uint8_t *hash, size_t hash_size, size_t *hash_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_hash_compute_req *req_data;
+	void *input_buffer = NULL;
+	void *hash_buffer = NULL;
+	void *hash_length_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, input, input_length, &input_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, hash, hash_size, &hash_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, input_buffer);
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, hash_length, sizeof(size_t), &hash_length_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, input_buffer);
+		dmm_buffer_in_release(mem_region, hash, hash_size, hash_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_hash_compute_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_hash_compute_req_m;
 
 	req_data->psa_hash_compute_req_alg = alg;
-	req_data->psa_hash_compute_req_p_input = (uint32_t)input;
+	req_data->psa_hash_compute_req_p_input = (uint32_t)input_buffer;
 	req_data->psa_hash_compute_req_input_length = input_length;
-	req_data->psa_hash_compute_req_p_hash = (uint32_t)hash;
+	req_data->psa_hash_compute_req_p_hash = (uint32_t)hash_buffer;
 	req_data->psa_hash_compute_req_hash_size = hash_size;
-	req_data->psa_hash_compute_req_p_hash_length = (uint32_t)hash_length;
+	req_data->psa_hash_compute_req_p_hash_length = (uint32_t)hash_length_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_out_release(mem_region, input_buffer);
+	dmm_buffer_in_release(mem_region, hash, hash_size, hash_buffer);
+	dmm_buffer_in_release(mem_region, hash_length, sizeof(size_t), hash_length_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_hash_compare(
-
-	psa_algorithm_t alg, const uint8_t *input, size_t input_length, const uint8_t *hash,
-	size_t hash_length)
+psa_status_t ssf_psa_hash_compare(psa_algorithm_t alg, const uint8_t *input, size_t input_length,
+				  const uint8_t *hash, size_t hash_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_hash_compare_req *req_data;
+	void *input_buffer = NULL;
+	void *hash_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, input, input_length, &input_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_out_prepare(mem_region, hash, hash_length, &hash_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, input_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_hash_compare_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_hash_compare_req_m;
 
 	req_data->psa_hash_compare_req_alg = alg;
-	req_data->psa_hash_compare_req_p_input = (uint32_t)input;
+	req_data->psa_hash_compare_req_p_input = (uint32_t)input_buffer;
 	req_data->psa_hash_compare_req_input_length = input_length;
-	req_data->psa_hash_compare_req_p_hash = (uint32_t)hash;
+	req_data->psa_hash_compare_req_p_hash = (uint32_t)hash_buffer;
 	req_data->psa_hash_compare_req_hash_length = hash_length;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
@@ -274,22 +392,30 @@ psa_status_t ssf_psa_hash_compare(
 		return err;
 	}
 
+	dmm_buffer_out_release(mem_region, input_buffer);
+	dmm_buffer_out_release(mem_region, hash_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_hash_setup(
-
-	mbedtls_psa_client_handle_t *p_handle, psa_algorithm_t alg)
+psa_status_t ssf_psa_hash_setup(mbedtls_psa_client_handle_t *p_handle, psa_algorithm_t alg)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_hash_setup_req *req_data;
+	void *handle_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_hash_setup_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_hash_setup_req_m;
 
-	req_data->psa_hash_setup_req_p_handle = (uint32_t)p_handle;
+	req_data->psa_hash_setup_req_p_handle = (uint32_t)handle_buffer;
 	req_data->psa_hash_setup_req_alg = alg;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
@@ -297,23 +423,39 @@ psa_status_t ssf_psa_hash_setup(
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_hash_update(
-
-	mbedtls_psa_client_handle_t *p_handle, const uint8_t *input, size_t input_length)
+psa_status_t ssf_psa_hash_update(mbedtls_psa_client_handle_t *p_handle, const uint8_t *input,
+				 size_t input_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_hash_update_req *req_data;
+	void *handle_buffer = NULL;
+	void *input_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_out_prepare(mem_region, input, input_length, &input_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_hash_update_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_hash_update_req_m;
 
-	req_data->psa_hash_update_req_p_handle = (uint32_t)p_handle;
-	req_data->psa_hash_update_req_p_input = (uint32_t)input;
+	req_data->psa_hash_update_req_p_handle = (uint32_t)handle_buffer;
+	req_data->psa_hash_update_req_p_input = (uint32_t)input_buffer;
 	req_data->psa_hash_update_req_input_length = input_length;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
@@ -321,48 +463,91 @@ psa_status_t ssf_psa_hash_update(
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+	dmm_buffer_out_release(mem_region, input_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_hash_finish(
-
-	mbedtls_psa_client_handle_t *p_handle, uint8_t *hash, size_t hash_size, size_t *hash_length)
+psa_status_t ssf_psa_hash_finish(mbedtls_psa_client_handle_t *p_handle, uint8_t *hash,
+				 size_t hash_size, size_t *hash_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_hash_finish_req *req_data;
+	void *handle_buffer = NULL;
+	void *hash_buffer = NULL;
+	void *hash_length_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, hash, hash_size, &hash_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, hash_length, sizeof(size_t), &hash_length_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		dmm_buffer_in_release(mem_region, hash, hash_size, hash_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_hash_finish_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_hash_finish_req_m;
 
-	req_data->psa_hash_finish_req_p_handle = (uint32_t)p_handle;
-	req_data->psa_hash_finish_req_p_hash = (uint32_t)hash;
+	req_data->psa_hash_finish_req_p_handle = (uint32_t)handle_buffer;
+	req_data->psa_hash_finish_req_p_hash = (uint32_t)hash_buffer;
 	req_data->psa_hash_finish_req_hash_size = hash_size;
-	req_data->psa_hash_finish_req_p_hash_length = (uint32_t)hash_length;
+	req_data->psa_hash_finish_req_p_hash_length = (uint32_t)hash_length_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+	dmm_buffer_in_release(mem_region, hash, hash_size, hash_buffer);
+	dmm_buffer_in_release(mem_region, hash_length, sizeof(size_t), hash_length_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_hash_verify(
-
-	mbedtls_psa_client_handle_t *p_handle, const uint8_t *hash, size_t hash_length)
+psa_status_t ssf_psa_hash_verify(mbedtls_psa_client_handle_t *p_handle, const uint8_t *hash,
+				 size_t hash_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_hash_verify_req *req_data;
+	void *handle_buffer = NULL;
+	void *hash_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_out_prepare(mem_region, hash, hash_length, &hash_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_hash_verify_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_hash_verify_req_m;
 
-	req_data->psa_hash_verify_req_p_handle = (uint32_t)p_handle;
-	req_data->psa_hash_verify_req_p_hash = (uint32_t)hash;
+	req_data->psa_hash_verify_req_p_handle = (uint32_t)handle_buffer;
+	req_data->psa_hash_verify_req_p_hash = (uint32_t)hash_buffer;
 	req_data->psa_hash_verify_req_hash_length = hash_length;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
@@ -370,101 +555,154 @@ psa_status_t ssf_psa_hash_verify(
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+	dmm_buffer_out_release(mem_region, hash_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_hash_abort(
-
-	mbedtls_psa_client_handle_t *p_handle)
+psa_status_t ssf_psa_hash_abort(mbedtls_psa_client_handle_t *p_handle)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_hash_abort_req *req_data;
+	void *handle_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_hash_abort_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_hash_abort_req_m;
 
-	req_data->psa_hash_abort_req_p_handle = (uint32_t)p_handle;
+	req_data->psa_hash_abort_req_p_handle = (uint32_t)handle_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_hash_clone(
-
-	mbedtls_psa_client_handle_t handle, mbedtls_psa_client_handle_t *p_handle)
+psa_status_t ssf_psa_hash_clone(mbedtls_psa_client_handle_t handle,
+				mbedtls_psa_client_handle_t *p_handle)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_hash_clone_req *req_data;
+	void *handle_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_hash_clone_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_hash_clone_req_m;
 
 	req_data->psa_hash_clone_req_handle = (uint32_t)handle;
-	req_data->psa_hash_clone_req_p_handle = (uint32_t)p_handle;
+	req_data->psa_hash_clone_req_p_handle = (uint32_t)handle_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_mac_compute(
-
-	mbedtls_svc_key_id_t key, psa_algorithm_t alg, const uint8_t *input, size_t input_length,
-	uint8_t *mac, size_t mac_size, size_t *mac_length)
+psa_status_t ssf_psa_mac_compute(mbedtls_svc_key_id_t key, psa_algorithm_t alg,
+				 const uint8_t *input, size_t input_length, uint8_t *mac,
+				 size_t mac_size, size_t *mac_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_mac_compute_req *req_data;
+	void *input_buffer = NULL;
+	void *mac_buffer = NULL;
+	void *mac_length_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, input, input_length, &input_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, mac, mac_size, &mac_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, input_buffer);
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, mac_length, sizeof(size_t), &mac_length_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, input_buffer);
+		dmm_buffer_in_release(mem_region, mac, mac_size, mac_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_mac_compute_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_mac_compute_req_m;
 
 	req_data->psa_mac_compute_req_key = key;
 	req_data->psa_mac_compute_req_alg = alg;
-	req_data->psa_mac_compute_req_p_input = (uint32_t)input;
+	req_data->psa_mac_compute_req_p_input = (uint32_t)input_buffer;
 	req_data->psa_mac_compute_req_input_length = input_length;
-	req_data->psa_mac_compute_req_p_mac = (uint32_t)mac;
+	req_data->psa_mac_compute_req_p_mac = (uint32_t)mac_buffer;
 	req_data->psa_mac_compute_req_mac_size = mac_size;
-	req_data->psa_mac_compute_req_p_mac_length = (uint32_t)mac_length;
+	req_data->psa_mac_compute_req_p_mac_length = (uint32_t)mac_length_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_out_release(mem_region, input_buffer);
+	dmm_buffer_in_release(mem_region, mac, mac_size, mac_buffer);
+	dmm_buffer_in_release(mem_region, mac_length, sizeof(size_t), mac_length_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_mac_verify(
-
-	mbedtls_svc_key_id_t key, psa_algorithm_t alg, const uint8_t *input, size_t input_length,
-	const uint8_t *mac, size_t mac_length)
+psa_status_t ssf_psa_mac_verify(mbedtls_svc_key_id_t key, psa_algorithm_t alg, const uint8_t *input,
+				size_t input_length, const uint8_t *mac, size_t mac_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_mac_verify_req *req_data;
+	void *input_buffer = NULL;
+	void *mac_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, input, input_length, &input_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_out_prepare(mem_region, mac, mac_length, &mac_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, input_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_mac_verify_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_mac_verify_req_m;
 
 	req_data->psa_mac_verify_req_key = key;
 	req_data->psa_mac_verify_req_alg = alg;
-	req_data->psa_mac_verify_req_p_input = (uint32_t)input;
+	req_data->psa_mac_verify_req_p_input = (uint32_t)input_buffer;
 	req_data->psa_mac_verify_req_input_length = input_length;
-	req_data->psa_mac_verify_req_p_mac = (uint32_t)mac;
+	req_data->psa_mac_verify_req_p_mac = (uint32_t)mac_buffer;
 	req_data->psa_mac_verify_req_mac_length = mac_length;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
@@ -472,22 +710,31 @@ psa_status_t ssf_psa_mac_verify(
 		return err;
 	}
 
+	dmm_buffer_out_release(mem_region, input_buffer);
+	dmm_buffer_out_release(mem_region, mac_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_mac_sign_setup(
-
-	mbedtls_psa_client_handle_t *p_handle, mbedtls_svc_key_id_t key, psa_algorithm_t alg)
+psa_status_t ssf_psa_mac_sign_setup(mbedtls_psa_client_handle_t *p_handle, mbedtls_svc_key_id_t key,
+				    psa_algorithm_t alg)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_mac_sign_setup_req *req_data;
+	void *handle_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_mac_sign_setup_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_mac_sign_setup_req_m;
 
-	req_data->psa_mac_sign_setup_req_p_handle = (uint32_t)p_handle;
+	req_data->psa_mac_sign_setup_req_p_handle = (uint32_t)handle_buffer;
 	req_data->psa_mac_sign_setup_req_key = key;
 	req_data->psa_mac_sign_setup_req_alg = alg;
 
@@ -496,22 +743,31 @@ psa_status_t ssf_psa_mac_sign_setup(
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_mac_verify_setup(
-
-	mbedtls_psa_client_handle_t *p_handle, mbedtls_svc_key_id_t key, psa_algorithm_t alg)
+psa_status_t ssf_psa_mac_verify_setup(mbedtls_psa_client_handle_t *p_handle,
+				      mbedtls_svc_key_id_t key, psa_algorithm_t alg)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_mac_verify_setup_req *req_data;
+	void *handle_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_mac_verify_setup_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_mac_verify_setup_req_m;
 
-	req_data->psa_mac_verify_setup_req_p_handle = (uint32_t)p_handle;
+	req_data->psa_mac_verify_setup_req_p_handle = (uint32_t)handle_buffer;
 	req_data->psa_mac_verify_setup_req_key = key;
 	req_data->psa_mac_verify_setup_req_alg = alg;
 
@@ -520,23 +776,39 @@ psa_status_t ssf_psa_mac_verify_setup(
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_mac_update(
-
-	mbedtls_psa_client_handle_t *p_handle, const uint8_t *input, size_t input_length)
+psa_status_t ssf_psa_mac_update(mbedtls_psa_client_handle_t *p_handle, const uint8_t *input,
+				size_t input_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_mac_update_req *req_data;
+	void *handle_buffer = NULL;
+	void *input_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_out_prepare(mem_region, input, input_length, &input_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_mac_update_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_mac_update_req_m;
 
-	req_data->psa_mac_update_req_p_handle = (uint32_t)p_handle;
-	req_data->psa_mac_update_req_p_input = (uint32_t)input;
+	req_data->psa_mac_update_req_p_handle = (uint32_t)handle_buffer;
+	req_data->psa_mac_update_req_p_input = (uint32_t)input_buffer;
 	req_data->psa_mac_update_req_input_length = input_length;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
@@ -544,48 +816,91 @@ psa_status_t ssf_psa_mac_update(
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+	dmm_buffer_out_release(mem_region, input_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_mac_sign_finish(
-
-	mbedtls_psa_client_handle_t *p_handle, uint8_t *mac, size_t mac_size, size_t *mac_length)
+psa_status_t ssf_psa_mac_sign_finish(mbedtls_psa_client_handle_t *p_handle, uint8_t *mac,
+				     size_t mac_size, size_t *mac_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_mac_sign_finish_req *req_data;
+	void *handle_buffer = NULL;
+	void *mac_buffer = NULL;
+	void *mac_length_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, mac, mac_size, &mac_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, mac_length, sizeof(size_t), &mac_length_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		dmm_buffer_in_release(mem_region, mac, mac_size, mac_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_mac_sign_finish_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_mac_sign_finish_req_m;
 
-	req_data->psa_mac_sign_finish_req_p_handle = (uint32_t)p_handle;
-	req_data->psa_mac_sign_finish_req_p_mac = (uint32_t)mac;
+	req_data->psa_mac_sign_finish_req_p_handle = (uint32_t)handle_buffer;
+	req_data->psa_mac_sign_finish_req_p_mac = (uint32_t)mac_buffer;
 	req_data->psa_mac_sign_finish_req_mac_size = mac_size;
-	req_data->psa_mac_sign_finish_req_p_mac_length = (uint32_t)mac_length;
+	req_data->psa_mac_sign_finish_req_p_mac_length = (uint32_t)mac_length_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+	dmm_buffer_in_release(mem_region, mac, mac_size, mac_buffer);
+	dmm_buffer_in_release(mem_region, mac_length, sizeof(size_t), mac_length_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_mac_verify_finish(
-
-	mbedtls_psa_client_handle_t *p_handle, const uint8_t *mac, size_t mac_length)
+psa_status_t ssf_psa_mac_verify_finish(mbedtls_psa_client_handle_t *p_handle, const uint8_t *mac,
+				       size_t mac_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_mac_verify_finish_req *req_data;
+	void *handle_buffer = NULL;
+	void *mac_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_out_prepare(mem_region, mac, mac_length, &mac_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_mac_verify_finish_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_mac_verify_finish_req_m;
 
-	req_data->psa_mac_verify_finish_req_p_handle = (uint32_t)p_handle;
-	req_data->psa_mac_verify_finish_req_p_mac = (uint32_t)mac;
+	req_data->psa_mac_verify_finish_req_p_handle = (uint32_t)handle_buffer;
+	req_data->psa_mac_verify_finish_req_p_mac = (uint32_t)mac_buffer;
 	req_data->psa_mac_verify_finish_req_mac_length = mac_length;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
@@ -593,102 +908,166 @@ psa_status_t ssf_psa_mac_verify_finish(
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+	dmm_buffer_out_release(mem_region, mac_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_mac_abort(
-
-	mbedtls_psa_client_handle_t *p_handle)
+psa_status_t ssf_psa_mac_abort(mbedtls_psa_client_handle_t *p_handle)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_mac_abort_req *req_data;
+	void *handle_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_mac_abort_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_mac_abort_req_m;
 
-	req_data->psa_mac_abort_req_p_handle = (uint32_t)p_handle;
+	req_data->psa_mac_abort_req_p_handle = (uint32_t)handle_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_cipher_encrypt(
-
-	mbedtls_svc_key_id_t key, psa_algorithm_t alg, const uint8_t *input, size_t input_length,
-	uint8_t *output, size_t output_size, size_t *output_length)
+psa_status_t ssf_psa_cipher_encrypt(mbedtls_svc_key_id_t key, psa_algorithm_t alg,
+				    const uint8_t *input, size_t input_length, uint8_t *output,
+				    size_t output_size, size_t *output_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_cipher_encrypt_req *req_data;
+	void *input_buffer = NULL;
+	void *output_buffer = NULL;
+	void *output_length_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, input, input_length, &input_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, output, output_size, &output_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, input_buffer);
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, output_length, sizeof(size_t),
+				    &output_length_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, input_buffer);
+		dmm_buffer_in_release(mem_region, output, output_size, output_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_cipher_encrypt_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_cipher_encrypt_req_m;
 
 	req_data->psa_cipher_encrypt_req_key = key;
 	req_data->psa_cipher_encrypt_req_alg = alg;
-	req_data->psa_cipher_encrypt_req_p_input = (uint32_t)input;
+	req_data->psa_cipher_encrypt_req_p_input = (uint32_t)input_buffer;
 	req_data->psa_cipher_encrypt_req_input_length = input_length;
-	req_data->psa_cipher_encrypt_req_p_output = (uint32_t)output;
+	req_data->psa_cipher_encrypt_req_p_output = (uint32_t)output_buffer;
 	req_data->psa_cipher_encrypt_req_output_size = output_size;
-	req_data->psa_cipher_encrypt_req_p_output_length = (uint32_t)output_length;
+	req_data->psa_cipher_encrypt_req_p_output_length = (uint32_t)output_length_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_out_release(mem_region, input_buffer);
+	dmm_buffer_in_release(mem_region, output, output_size, output_buffer);
+	dmm_buffer_in_release(mem_region, output_length, sizeof(size_t), output_length_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_cipher_decrypt(
-
-	mbedtls_svc_key_id_t key, psa_algorithm_t alg, const uint8_t *input, size_t input_length,
-	uint8_t *output, size_t output_size, size_t *output_length)
+psa_status_t ssf_psa_cipher_decrypt(mbedtls_svc_key_id_t key, psa_algorithm_t alg,
+				    const uint8_t *input, size_t input_length, uint8_t *output,
+				    size_t output_size, size_t *output_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_cipher_decrypt_req *req_data;
+	void *input_buffer = NULL;
+	void *output_buffer = NULL;
+	void *output_length_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, input, input_length, &input_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, output, output_size, &output_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, input_buffer);
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, output_length, sizeof(size_t),
+				    &output_length_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, input_buffer);
+		dmm_buffer_in_release(mem_region, output, output_size, output_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_cipher_decrypt_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_cipher_decrypt_req_m;
 
 	req_data->psa_cipher_decrypt_req_key = key;
 	req_data->psa_cipher_decrypt_req_alg = alg;
-	req_data->psa_cipher_decrypt_req_p_input = (uint32_t)input;
+	req_data->psa_cipher_decrypt_req_p_input = (uint32_t)input_buffer;
 	req_data->psa_cipher_decrypt_req_input_length = input_length;
-	req_data->psa_cipher_decrypt_req_p_output = (uint32_t)output;
+	req_data->psa_cipher_decrypt_req_p_output = (uint32_t)output_buffer;
 	req_data->psa_cipher_decrypt_req_output_size = output_size;
-	req_data->psa_cipher_decrypt_req_p_output_length = (uint32_t)output_length;
+	req_data->psa_cipher_decrypt_req_p_output_length = (uint32_t)output_length_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_out_release(mem_region, input_buffer);
+	dmm_buffer_in_release(mem_region, output, output_size, output_buffer);
+	dmm_buffer_in_release(mem_region, output_length, sizeof(size_t), output_length_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_cipher_encrypt_setup(
-
-	mbedtls_psa_client_handle_t *p_handle, mbedtls_svc_key_id_t key, psa_algorithm_t alg)
+psa_status_t ssf_psa_cipher_encrypt_setup(mbedtls_psa_client_handle_t *p_handle,
+					  mbedtls_svc_key_id_t key, psa_algorithm_t alg)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_cipher_encrypt_setup_req *req_data;
+	void *handle_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_cipher_encrypt_setup_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_cipher_encrypt_setup_req_m;
 
-	req_data->psa_cipher_encrypt_setup_req_p_handle = (uint32_t)p_handle;
+	req_data->psa_cipher_encrypt_setup_req_p_handle = (uint32_t)handle_buffer;
 	req_data->psa_cipher_encrypt_setup_req_key = key;
 	req_data->psa_cipher_encrypt_setup_req_alg = alg;
 
@@ -697,22 +1076,31 @@ psa_status_t ssf_psa_cipher_encrypt_setup(
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_cipher_decrypt_setup(
-
-	mbedtls_psa_client_handle_t *p_handle, mbedtls_svc_key_id_t key, psa_algorithm_t alg)
+psa_status_t ssf_psa_cipher_decrypt_setup(mbedtls_psa_client_handle_t *p_handle,
+					  mbedtls_svc_key_id_t key, psa_algorithm_t alg)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_cipher_decrypt_setup_req *req_data;
+	void *handle_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_cipher_decrypt_setup_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_cipher_decrypt_setup_req_m;
 
-	req_data->psa_cipher_decrypt_setup_req_p_handle = (uint32_t)p_handle;
+	req_data->psa_cipher_decrypt_setup_req_p_handle = (uint32_t)handle_buffer;
 	req_data->psa_cipher_decrypt_setup_req_key = key;
 	req_data->psa_cipher_decrypt_setup_req_alg = alg;
 
@@ -721,48 +1109,90 @@ psa_status_t ssf_psa_cipher_decrypt_setup(
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_cipher_generate_iv(
-
-	mbedtls_psa_client_handle_t *p_handle, uint8_t *iv, size_t iv_size, size_t *iv_length)
+psa_status_t ssf_psa_cipher_generate_iv(mbedtls_psa_client_handle_t *p_handle, uint8_t *iv,
+					size_t iv_size, size_t *iv_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_cipher_generate_iv_req *req_data;
+	void *handle_buffer = NULL;
+	void *iv_buffer = NULL;
+	void *iv_length_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, iv, iv_size, &iv_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, iv_length, sizeof(size_t), &iv_length_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		dmm_buffer_in_release(mem_region, iv, iv_size, iv_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_cipher_generate_iv_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_cipher_generate_iv_req_m;
 
-	req_data->psa_cipher_generate_iv_req_p_handle = (uint32_t)p_handle;
-	req_data->psa_cipher_generate_iv_req_p_iv = (uint32_t)iv;
+	req_data->psa_cipher_generate_iv_req_p_handle = (uint32_t)handle_buffer;
+	req_data->psa_cipher_generate_iv_req_p_iv = (uint32_t)iv_buffer;
 	req_data->psa_cipher_generate_iv_req_iv_size = iv_size;
-	req_data->psa_cipher_generate_iv_req_p_iv_length = (uint32_t)iv_length;
+	req_data->psa_cipher_generate_iv_req_p_iv_length = (uint32_t)iv_length_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+	dmm_buffer_in_release(mem_region, iv, iv_size, iv_buffer);
+	dmm_buffer_in_release(mem_region, iv_length, sizeof(size_t), iv_length_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_cipher_set_iv(
-
-	mbedtls_psa_client_handle_t *p_handle, const uint8_t *iv, size_t iv_length)
+psa_status_t ssf_psa_cipher_set_iv(mbedtls_psa_client_handle_t *p_handle, const uint8_t *iv,
+				   size_t iv_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_cipher_set_iv_req *req_data;
+	void *handle_buffer = NULL;
+	void *iv_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_out_prepare(mem_region, iv, iv_length, &iv_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_cipher_set_iv_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_cipher_set_iv_req_m;
 
-	req_data->psa_cipher_set_iv_req_p_handle = (uint32_t)p_handle;
-	req_data->psa_cipher_set_iv_req_p_iv = (uint32_t)iv;
+	req_data->psa_cipher_set_iv_req_p_handle = (uint32_t)handle_buffer;
+	req_data->psa_cipher_set_iv_req_p_iv = (uint32_t)iv_buffer;
 	req_data->psa_cipher_set_iv_req_iv_length = iv_length;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
@@ -770,168 +1200,339 @@ psa_status_t ssf_psa_cipher_set_iv(
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+	dmm_buffer_out_release(mem_region, iv_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_cipher_update(
-
-	mbedtls_psa_client_handle_t *p_handle, const uint8_t *input, size_t input_length,
-	uint8_t *output, size_t output_size, size_t *output_length)
+psa_status_t ssf_psa_cipher_update(mbedtls_psa_client_handle_t *p_handle, const uint8_t *input,
+				   size_t input_length, uint8_t *output, size_t output_size,
+				   size_t *output_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_cipher_update_req *req_data;
+	void *handle_buffer = NULL;
+	void *input_buffer = NULL;
+	void *output_buffer = NULL;
+	void *output_length_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_out_prepare(mem_region, input, input_length, &input_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, output, output_size, &output_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		dmm_buffer_out_release(mem_region, input_buffer);
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, output_length, sizeof(size_t),
+				    &output_length_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		dmm_buffer_out_release(mem_region, input_buffer);
+		dmm_buffer_in_release(mem_region, output, output_size, output_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_cipher_update_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_cipher_update_req_m;
 
-	req_data->psa_cipher_update_req_p_handle = (uint32_t)p_handle;
-	req_data->psa_cipher_update_req_p_input = (uint32_t)input;
+	req_data->psa_cipher_update_req_p_handle = (uint32_t)handle_buffer;
+	req_data->psa_cipher_update_req_p_input = (uint32_t)input_buffer;
 	req_data->psa_cipher_update_req_input_length = input_length;
-	req_data->psa_cipher_update_req_p_output = (uint32_t)output;
+	req_data->psa_cipher_update_req_p_output = (uint32_t)output_buffer;
 	req_data->psa_cipher_update_req_output_size = output_size;
-	req_data->psa_cipher_update_req_p_output_length = (uint32_t)output_length;
+	req_data->psa_cipher_update_req_p_output_length = (uint32_t)output_length_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+	dmm_buffer_out_release(mem_region, input_buffer);
+	dmm_buffer_in_release(mem_region, output, output_size, output_buffer);
+	dmm_buffer_in_release(mem_region, output_length, sizeof(size_t), output_length_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_cipher_finish(
-
-	mbedtls_psa_client_handle_t *p_handle, uint8_t *output, size_t output_size,
-	size_t *output_length)
+psa_status_t ssf_psa_cipher_finish(mbedtls_psa_client_handle_t *p_handle, uint8_t *output,
+				   size_t output_size, size_t *output_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_cipher_finish_req *req_data;
+	void *handle_buffer = NULL;
+	void *output_buffer = NULL;
+	void *output_length_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, output, output_size, &output_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, output_length, sizeof(size_t),
+				    &output_length_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		dmm_buffer_in_release(mem_region, output, output_size, output_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_cipher_finish_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_cipher_finish_req_m;
 
-	req_data->psa_cipher_finish_req_p_handle = (uint32_t)p_handle;
-	req_data->psa_cipher_finish_req_p_output = (uint32_t)output;
+	req_data->psa_cipher_finish_req_p_handle = (uint32_t)handle_buffer;
+	req_data->psa_cipher_finish_req_p_output = (uint32_t)output_buffer;
 	req_data->psa_cipher_finish_req_output_size = output_size;
-	req_data->psa_cipher_finish_req_p_output_length = (uint32_t)output_length;
+	req_data->psa_cipher_finish_req_p_output_length = (uint32_t)output_length_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+	dmm_buffer_in_release(mem_region, output, output_size, output_buffer);
+	dmm_buffer_in_release(mem_region, output_length, sizeof(size_t), output_length_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_cipher_abort(
-
-	mbedtls_psa_client_handle_t *p_handle)
+psa_status_t ssf_psa_cipher_abort(mbedtls_psa_client_handle_t *p_handle)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_cipher_abort_req *req_data;
+	void *handle_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_cipher_abort_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_cipher_abort_req_m;
 
-	req_data->psa_cipher_abort_req_p_handle = (uint32_t)p_handle;
+	req_data->psa_cipher_abort_req_p_handle = (uint32_t)handle_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_aead_encrypt(
-
-	mbedtls_svc_key_id_t key, psa_algorithm_t alg, const uint8_t *nonce, size_t nonce_length,
-	const uint8_t *additional_data, size_t additional_data_length, const uint8_t *plaintext,
-	size_t plaintext_length, uint8_t *ciphertext, size_t ciphertext_size,
-	size_t *ciphertext_length)
+psa_status_t ssf_psa_aead_encrypt(mbedtls_svc_key_id_t key, psa_algorithm_t alg,
+				  const uint8_t *nonce, size_t nonce_length,
+				  const uint8_t *additional_data, size_t additional_data_length,
+				  const uint8_t *plaintext, size_t plaintext_length,
+				  uint8_t *ciphertext, size_t ciphertext_size,
+				  size_t *ciphertext_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_aead_encrypt_req *req_data;
+	void *nonce_buffer = NULL;
+	void *additional_data_buffer = NULL;
+	void *plaintext_buffer = NULL;
+	void *ciphertext_buffer = NULL;
+	void *ciphertext_length_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, nonce, nonce_length, &nonce_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_out_prepare(mem_region, additional_data, additional_data_length,
+				     &additional_data_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, nonce_buffer);
+		return err;
+	}
+	err = dmm_buffer_out_prepare(mem_region, plaintext, plaintext_length, &plaintext_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, nonce_buffer);
+		dmm_buffer_out_release(mem_region, additional_data_buffer);
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, ciphertext, ciphertext_size, &ciphertext_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, nonce_buffer);
+		dmm_buffer_out_release(mem_region, additional_data_buffer);
+		dmm_buffer_out_release(mem_region, plaintext_buffer);
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, ciphertext_length, sizeof(size_t),
+				    &ciphertext_length_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, nonce_buffer);
+		dmm_buffer_out_release(mem_region, additional_data_buffer);
+		dmm_buffer_out_release(mem_region, plaintext_buffer);
+		dmm_buffer_in_release(mem_region, ciphertext, ciphertext_size, ciphertext_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_aead_encrypt_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_aead_encrypt_req_m;
 
 	req_data->psa_aead_encrypt_req_key = key;
 	req_data->psa_aead_encrypt_req_alg = alg;
-	req_data->psa_aead_encrypt_req_p_nonce = (uint32_t)nonce;
+	req_data->psa_aead_encrypt_req_p_nonce = (uint32_t)nonce_buffer;
 	req_data->psa_aead_encrypt_req_nonce_length = nonce_length;
-	req_data->psa_aead_encrypt_req_p_additional_data = (uint32_t)additional_data;
+	req_data->psa_aead_encrypt_req_p_additional_data = (uint32_t)additional_data_buffer;
 	req_data->psa_aead_encrypt_req_additional_data_length = additional_data_length;
-	req_data->psa_aead_encrypt_req_p_plaintext = (uint32_t)plaintext;
+	req_data->psa_aead_encrypt_req_p_plaintext = (uint32_t)plaintext_buffer;
 	req_data->psa_aead_encrypt_req_plaintext_length = plaintext_length;
-	req_data->psa_aead_encrypt_req_p_ciphertext = (uint32_t)ciphertext;
+	req_data->psa_aead_encrypt_req_p_ciphertext = (uint32_t)ciphertext_buffer;
 	req_data->psa_aead_encrypt_req_ciphertext_size = ciphertext_size;
-	req_data->psa_aead_encrypt_req_p_ciphertext_length = (uint32_t)ciphertext_length;
+	req_data->psa_aead_encrypt_req_p_ciphertext_length = (uint32_t)ciphertext_length_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_out_release(mem_region, nonce_buffer);
+	dmm_buffer_out_release(mem_region, additional_data_buffer);
+	dmm_buffer_out_release(mem_region, plaintext_buffer);
+	dmm_buffer_in_release(mem_region, ciphertext, ciphertext_size, ciphertext_buffer);
+	dmm_buffer_in_release(mem_region, ciphertext_length, sizeof(size_t),
+			      ciphertext_length_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_aead_decrypt(
-
-	mbedtls_svc_key_id_t key, psa_algorithm_t alg, const uint8_t *nonce, size_t nonce_length,
-	const uint8_t *additional_data, size_t additional_data_length, const uint8_t *ciphertext,
-	size_t ciphertext_length, uint8_t *plaintext, size_t plaintext_size,
-	size_t *plaintext_length)
+psa_status_t ssf_psa_aead_decrypt(mbedtls_svc_key_id_t key, psa_algorithm_t alg,
+				  const uint8_t *nonce, size_t nonce_length,
+				  const uint8_t *additional_data, size_t additional_data_length,
+				  const uint8_t *ciphertext, size_t ciphertext_length,
+				  uint8_t *plaintext, size_t plaintext_size,
+				  size_t *plaintext_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_aead_decrypt_req *req_data;
+	void *nonce_buffer = NULL;
+	void *additional_data_buffer = NULL;
+	void *ciphertext_buffer = NULL;
+	void *plaintext_buffer = NULL;
+	void *plaintext_length_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, nonce, nonce_length, &nonce_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_out_prepare(mem_region, additional_data, additional_data_length,
+				     &additional_data_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, nonce_buffer);
+		return err;
+	}
+	err = dmm_buffer_out_prepare(mem_region, ciphertext, ciphertext_length, &ciphertext_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, nonce_buffer);
+		dmm_buffer_out_release(mem_region, additional_data_buffer);
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, plaintext, plaintext_size, &plaintext_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, nonce_buffer);
+		dmm_buffer_out_release(mem_region, additional_data_buffer);
+		dmm_buffer_out_release(mem_region, ciphertext_buffer);
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, plaintext_length, sizeof(size_t),
+				    &plaintext_length_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, nonce_buffer);
+		dmm_buffer_out_release(mem_region, additional_data_buffer);
+		dmm_buffer_out_release(mem_region, ciphertext_buffer);
+		dmm_buffer_in_release(mem_region, plaintext, plaintext_size, plaintext_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_aead_decrypt_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_aead_decrypt_req_m;
 
 	req_data->psa_aead_decrypt_req_key = key;
 	req_data->psa_aead_decrypt_req_alg = alg;
-	req_data->psa_aead_decrypt_req_p_nonce = (uint32_t)nonce;
+	req_data->psa_aead_decrypt_req_p_nonce = (uint32_t)nonce_buffer;
 	req_data->psa_aead_decrypt_req_nonce_length = nonce_length;
-	req_data->psa_aead_decrypt_req_p_additional_data = (uint32_t)additional_data;
+	req_data->psa_aead_decrypt_req_p_additional_data = (uint32_t)additional_data_buffer;
 	req_data->psa_aead_decrypt_req_additional_data_length = additional_data_length;
-	req_data->psa_aead_decrypt_req_p_ciphertext = (uint32_t)ciphertext;
+	req_data->psa_aead_decrypt_req_p_ciphertext = (uint32_t)ciphertext_buffer;
 	req_data->psa_aead_decrypt_req_ciphertext_length = ciphertext_length;
-	req_data->psa_aead_decrypt_req_p_plaintext = (uint32_t)plaintext;
+	req_data->psa_aead_decrypt_req_p_plaintext = (uint32_t)plaintext_buffer;
 	req_data->psa_aead_decrypt_req_plaintext_size = plaintext_size;
-	req_data->psa_aead_decrypt_req_p_plaintext_length = (uint32_t)plaintext_length;
+	req_data->psa_aead_decrypt_req_p_plaintext_length = (uint32_t)plaintext_length_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_out_release(mem_region, nonce_buffer);
+	dmm_buffer_out_release(mem_region, additional_data_buffer);
+	dmm_buffer_out_release(mem_region, ciphertext_buffer);
+	dmm_buffer_in_release(mem_region, plaintext, plaintext_size, plaintext_buffer);
+	dmm_buffer_in_release(mem_region, plaintext_length, sizeof(size_t),
+			      plaintext_length_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_aead_encrypt_setup(
-
-	mbedtls_psa_client_handle_t *p_handle, mbedtls_svc_key_id_t key, psa_algorithm_t alg)
+psa_status_t ssf_psa_aead_encrypt_setup(mbedtls_psa_client_handle_t *p_handle,
+					mbedtls_svc_key_id_t key, psa_algorithm_t alg)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_aead_encrypt_setup_req *req_data;
+	void *handle_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_aead_encrypt_setup_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_aead_encrypt_setup_req_m;
 
-	req_data->psa_aead_encrypt_setup_req_p_handle = (uint32_t)p_handle;
+	req_data->psa_aead_encrypt_setup_req_p_handle = (uint32_t)handle_buffer;
 	req_data->psa_aead_encrypt_setup_req_key = key;
 	req_data->psa_aead_encrypt_setup_req_alg = alg;
 
@@ -940,22 +1541,31 @@ psa_status_t ssf_psa_aead_encrypt_setup(
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_aead_decrypt_setup(
-
-	mbedtls_psa_client_handle_t *p_handle, mbedtls_svc_key_id_t key, psa_algorithm_t alg)
+psa_status_t ssf_psa_aead_decrypt_setup(mbedtls_psa_client_handle_t *p_handle,
+					mbedtls_svc_key_id_t key, psa_algorithm_t alg)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_aead_decrypt_setup_req *req_data;
+	void *handle_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_aead_decrypt_setup_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_aead_decrypt_setup_req_m;
 
-	req_data->psa_aead_decrypt_setup_req_p_handle = (uint32_t)p_handle;
+	req_data->psa_aead_decrypt_setup_req_p_handle = (uint32_t)handle_buffer;
 	req_data->psa_aead_decrypt_setup_req_key = key;
 	req_data->psa_aead_decrypt_setup_req_alg = alg;
 
@@ -964,49 +1574,90 @@ psa_status_t ssf_psa_aead_decrypt_setup(
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_aead_generate_nonce(
-
-	mbedtls_psa_client_handle_t *p_handle, uint8_t *nonce, size_t nonce_size,
-	size_t *nonce_length)
+psa_status_t ssf_psa_aead_generate_nonce(mbedtls_psa_client_handle_t *p_handle, uint8_t *nonce,
+					 size_t nonce_size, size_t *nonce_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_aead_generate_nonce_req *req_data;
+	void *handle_buffer = NULL;
+	void *nonce_buffer = NULL;
+	void *nonce_length_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, nonce, nonce_size, &nonce_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, nonce_length, sizeof(size_t), &nonce_length_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		dmm_buffer_in_release(mem_region, nonce, nonce_size, nonce_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_aead_generate_nonce_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_aead_generate_nonce_req_m;
 
-	req_data->psa_aead_generate_nonce_req_p_handle = (uint32_t)p_handle;
-	req_data->psa_aead_generate_nonce_req_p_nonce = (uint32_t)nonce;
+	req_data->psa_aead_generate_nonce_req_p_handle = (uint32_t)handle_buffer;
+	req_data->psa_aead_generate_nonce_req_p_nonce = (uint32_t)nonce_buffer;
 	req_data->psa_aead_generate_nonce_req_nonce_size = nonce_size;
-	req_data->psa_aead_generate_nonce_req_p_nonce_length = (uint32_t)nonce_length;
+	req_data->psa_aead_generate_nonce_req_p_nonce_length = (uint32_t)nonce_length_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+	dmm_buffer_in_release(mem_region, nonce, nonce_size, nonce_buffer);
+	dmm_buffer_in_release(mem_region, nonce_length, sizeof(size_t), nonce_length_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_aead_set_nonce(
-
-	mbedtls_psa_client_handle_t *p_handle, const uint8_t *nonce, size_t nonce_length)
+psa_status_t ssf_psa_aead_set_nonce(mbedtls_psa_client_handle_t *p_handle, const uint8_t *nonce,
+				    size_t nonce_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_aead_set_nonce_req *req_data;
+	void *handle_buffer = NULL;
+	void *nonce_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_out_prepare(mem_region, nonce, nonce_length, &nonce_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_aead_set_nonce_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_aead_set_nonce_req_m;
 
-	req_data->psa_aead_set_nonce_req_p_handle = (uint32_t)p_handle;
-	req_data->psa_aead_set_nonce_req_p_nonce = (uint32_t)nonce;
+	req_data->psa_aead_set_nonce_req_p_handle = (uint32_t)handle_buffer;
+	req_data->psa_aead_set_nonce_req_p_nonce = (uint32_t)nonce_buffer;
 	req_data->psa_aead_set_nonce_req_nonce_length = nonce_length;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
@@ -1014,22 +1665,32 @@ psa_status_t ssf_psa_aead_set_nonce(
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+	dmm_buffer_out_release(mem_region, nonce_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_aead_set_lengths(
-
-	mbedtls_psa_client_handle_t *p_handle, size_t ad_length, size_t plaintext_length)
+psa_status_t ssf_psa_aead_set_lengths(mbedtls_psa_client_handle_t *p_handle, size_t ad_length,
+				      size_t plaintext_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_aead_set_lengths_req *req_data;
+	void *handle_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_aead_set_lengths_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_aead_set_lengths_req_m;
 
-	req_data->psa_aead_set_lengths_req_p_handle = (uint32_t)p_handle;
+	req_data->psa_aead_set_lengths_req_p_handle = (uint32_t)handle_buffer;
 	req_data->psa_aead_set_lengths_req_ad_length = ad_length;
 	req_data->psa_aead_set_lengths_req_plaintext_length = plaintext_length;
 
@@ -1038,23 +1699,39 @@ psa_status_t ssf_psa_aead_set_lengths(
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_aead_update_ad(
-
-	mbedtls_psa_client_handle_t *p_handle, const uint8_t *input, size_t input_length)
+psa_status_t ssf_psa_aead_update_ad(mbedtls_psa_client_handle_t *p_handle, const uint8_t *input,
+				    size_t input_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_aead_update_ad_req *req_data;
+	void *handle_buffer = NULL;
+	void *input_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_out_prepare(mem_region, input, input_length, &input_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_aead_update_ad_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_aead_update_ad_req_m;
 
-	req_data->psa_aead_update_ad_req_p_handle = (uint32_t)p_handle;
-	req_data->psa_aead_update_ad_req_p_input = (uint32_t)input;
+	req_data->psa_aead_update_ad_req_p_handle = (uint32_t)handle_buffer;
+	req_data->psa_aead_update_ad_req_p_input = (uint32_t)input_buffer;
 	req_data->psa_aead_update_ad_req_input_length = input_length;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
@@ -1062,84 +1739,208 @@ psa_status_t ssf_psa_aead_update_ad(
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+	dmm_buffer_out_release(mem_region, input_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_aead_update(
-
-	mbedtls_psa_client_handle_t *p_handle, const uint8_t *input, size_t input_length,
-	uint8_t *output, size_t output_size, size_t *output_length)
+psa_status_t ssf_psa_aead_update(mbedtls_psa_client_handle_t *p_handle, const uint8_t *input,
+				 size_t input_length, uint8_t *output, size_t output_size,
+				 size_t *output_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_aead_update_req *req_data;
+	void *handle_buffer = NULL;
+	void *input_buffer = NULL;
+	void *output_buffer = NULL;
+	void *output_length_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_out_prepare(mem_region, input, input_length, &input_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, output, output_size, &output_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		dmm_buffer_out_release(mem_region, input_buffer);
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, output_length, sizeof(size_t),
+				    &output_length_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		dmm_buffer_out_release(mem_region, input_buffer);
+		dmm_buffer_in_release(mem_region, output, output_size, output_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_aead_update_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_aead_update_req_m;
 
-	req_data->psa_aead_update_req_p_handle = (uint32_t)p_handle;
-	req_data->psa_aead_update_req_p_input = (uint32_t)input;
+	req_data->psa_aead_update_req_p_handle = (uint32_t)handle_buffer;
+	req_data->psa_aead_update_req_p_input = (uint32_t)input_buffer;
 	req_data->psa_aead_update_req_input_length = input_length;
-	req_data->psa_aead_update_req_p_output = (uint32_t)output;
+	req_data->psa_aead_update_req_p_output = (uint32_t)output_buffer;
 	req_data->psa_aead_update_req_output_size = output_size;
-	req_data->psa_aead_update_req_p_output_length = (uint32_t)output_length;
+	req_data->psa_aead_update_req_p_output_length = (uint32_t)output_length_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+	dmm_buffer_out_release(mem_region, input_buffer);
+	dmm_buffer_in_release(mem_region, output, output_size, output_buffer);
+	dmm_buffer_in_release(mem_region, output_length, sizeof(size_t), output_length_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_aead_finish(
-
-	mbedtls_psa_client_handle_t *p_handle, uint8_t *ciphertext, size_t ciphertext_size,
-	size_t *ciphertext_length, uint8_t *tag, size_t tag_size, size_t *tag_length)
+psa_status_t ssf_psa_aead_finish(mbedtls_psa_client_handle_t *p_handle, uint8_t *ciphertext,
+				 size_t ciphertext_size, size_t *ciphertext_length, uint8_t *tag,
+				 size_t tag_size, size_t *tag_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_aead_finish_req *req_data;
+	void *handle_buffer = NULL;
+	void *ciphertext_buffer = NULL;
+	void *ciphertext_length_buffer = NULL;
+	void *tag_buffer = NULL;
+	void *tag_length_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, ciphertext, ciphertext_size, &ciphertext_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, ciphertext_length, sizeof(size_t),
+				    &ciphertext_length_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		dmm_buffer_in_release(mem_region, ciphertext, ciphertext_size, ciphertext_buffer);
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, tag, tag_size, &tag_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		dmm_buffer_in_release(mem_region, ciphertext, ciphertext_size, ciphertext_buffer);
+		dmm_buffer_in_release(mem_region, ciphertext_length, sizeof(size_t),
+				      ciphertext_length_buffer);
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, tag_length, sizeof(size_t), &tag_length_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		dmm_buffer_in_release(mem_region, ciphertext, ciphertext_size, ciphertext_buffer);
+		dmm_buffer_in_release(mem_region, ciphertext_length, sizeof(size_t),
+				      ciphertext_length_buffer);
+		dmm_buffer_in_release(mem_region, tag, tag_size, tag_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_aead_finish_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_aead_finish_req_m;
 
-	req_data->psa_aead_finish_req_p_handle = (uint32_t)p_handle;
-	req_data->psa_aead_finish_req_p_ciphertext = (uint32_t)ciphertext;
+	req_data->psa_aead_finish_req_p_handle = (uint32_t)handle_buffer;
+	req_data->psa_aead_finish_req_p_ciphertext = (uint32_t)ciphertext_buffer;
 	req_data->psa_aead_finish_req_ciphertext_size = ciphertext_size;
-	req_data->psa_aead_finish_req_p_ciphertext_length = (uint32_t)ciphertext_length;
-	req_data->psa_aead_finish_req_p_tag = (uint32_t)tag;
+	req_data->psa_aead_finish_req_p_ciphertext_length = (uint32_t)ciphertext_length_buffer;
+	req_data->psa_aead_finish_req_p_tag = (uint32_t)tag_buffer;
 	req_data->psa_aead_finish_req_tag_size = tag_size;
-	req_data->psa_aead_finish_req_p_tag_length = (uint32_t)tag_length;
+	req_data->psa_aead_finish_req_p_tag_length = (uint32_t)tag_length_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+	dmm_buffer_in_release(mem_region, ciphertext, ciphertext_size, ciphertext_buffer);
+	dmm_buffer_in_release(mem_region, ciphertext_length, sizeof(size_t),
+			      ciphertext_length_buffer);
+	dmm_buffer_in_release(mem_region, tag, tag_size, tag_buffer);
+	dmm_buffer_in_release(mem_region, tag_length, sizeof(size_t), tag_length_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_aead_verify(
-
-	mbedtls_psa_client_handle_t *p_handle, uint8_t *plaintext, size_t plaintext_size,
-	size_t *plaintext_length, const uint8_t *tag, size_t tag_length)
+psa_status_t ssf_psa_aead_verify(mbedtls_psa_client_handle_t *p_handle, uint8_t *plaintext,
+				 size_t plaintext_size, size_t *plaintext_length,
+				 const uint8_t *tag, size_t tag_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_aead_verify_req *req_data;
+	void *handle_buffer = NULL;
+	void *plaintext_buffer = NULL;
+	void *plaintext_length_buffer = NULL;
+	void *tag_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, plaintext, plaintext_size, &plaintext_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, plaintext_length, sizeof(size_t),
+				    &plaintext_length_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		dmm_buffer_in_release(mem_region, plaintext, plaintext_size, plaintext_buffer);
+		return err;
+	}
+	err = dmm_buffer_out_prepare(mem_region, tag, tag_length, &tag_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		dmm_buffer_in_release(mem_region, plaintext, plaintext_size, plaintext_buffer);
+		dmm_buffer_in_release(mem_region, plaintext_length, sizeof(size_t),
+				      plaintext_length_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_aead_verify_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_aead_verify_req_m;
 
-	req_data->psa_aead_verify_req_p_handle = (uint32_t)p_handle;
-	req_data->psa_aead_verify_req_p_plaintext = (uint32_t)plaintext;
+	req_data->psa_aead_verify_req_p_handle = (uint32_t)handle_buffer;
+	req_data->psa_aead_verify_req_p_plaintext = (uint32_t)plaintext_buffer;
 	req_data->psa_aead_verify_req_plaintext_size = plaintext_size;
-	req_data->psa_aead_verify_req_p_plaintext_length = (uint32_t)plaintext_length;
-	req_data->psa_aead_verify_req_p_tag = (uint32_t)tag;
+	req_data->psa_aead_verify_req_p_plaintext_length = (uint32_t)plaintext_length_buffer;
+	req_data->psa_aead_verify_req_p_tag = (uint32_t)tag_buffer;
 	req_data->psa_aead_verify_req_tag_length = tag_length;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
@@ -1147,78 +1948,128 @@ psa_status_t ssf_psa_aead_verify(
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+	dmm_buffer_in_release(mem_region, plaintext, plaintext_size, plaintext_buffer);
+	dmm_buffer_in_release(mem_region, plaintext_length, sizeof(size_t),
+			      plaintext_length_buffer);
+	dmm_buffer_out_release(mem_region, tag_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_aead_abort(
-
-	mbedtls_psa_client_handle_t *p_handle)
+psa_status_t ssf_psa_aead_abort(mbedtls_psa_client_handle_t *p_handle)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_aead_abort_req *req_data;
+	void *handle_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_aead_abort_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_aead_abort_req_m;
 
-	req_data->psa_aead_abort_req_p_handle = (uint32_t)p_handle;
+	req_data->psa_aead_abort_req_p_handle = (uint32_t)handle_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_sign_message(
-
-	mbedtls_svc_key_id_t key, psa_algorithm_t alg, const uint8_t *input, size_t input_length,
-	uint8_t *signature, size_t signature_size, size_t *signature_length)
+psa_status_t ssf_psa_sign_message(mbedtls_svc_key_id_t key, psa_algorithm_t alg,
+				  const uint8_t *input, size_t input_length, uint8_t *signature,
+				  size_t signature_size, size_t *signature_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_sign_message_req *req_data;
+	void *input_buffer = NULL;
+	void *signature_buffer = NULL;
+	void *signature_length_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, input, input_length, &input_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, signature, signature_size, &signature_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, input_buffer);
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, signature_length, sizeof(size_t),
+				    &signature_length_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, input_buffer);
+		dmm_buffer_in_release(mem_region, signature, signature_size, signature_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_sign_message_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_sign_message_req_m;
 
 	req_data->psa_sign_message_req_key = key;
 	req_data->psa_sign_message_req_alg = alg;
-	req_data->psa_sign_message_req_p_input = (uint32_t)input;
+	req_data->psa_sign_message_req_p_input = (uint32_t)input_buffer;
 	req_data->psa_sign_message_req_input_length = input_length;
-	req_data->psa_sign_message_req_p_signature = (uint32_t)signature;
+	req_data->psa_sign_message_req_p_signature = (uint32_t)signature_buffer;
 	req_data->psa_sign_message_req_signature_size = signature_size;
-	req_data->psa_sign_message_req_p_signature_length = (uint32_t)signature_length;
+	req_data->psa_sign_message_req_p_signature_length = (uint32_t)signature_length_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_out_release(mem_region, input_buffer);
+	dmm_buffer_in_release(mem_region, signature, signature_size, signature_buffer);
+	dmm_buffer_in_release(mem_region, signature_length, sizeof(size_t),
+			      signature_length_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_verify_message(
-
-	mbedtls_svc_key_id_t key, psa_algorithm_t alg, const uint8_t *input, size_t input_length,
-	const uint8_t *signature, size_t signature_length)
+psa_status_t ssf_psa_verify_message(mbedtls_svc_key_id_t key, psa_algorithm_t alg,
+				    const uint8_t *input, size_t input_length,
+				    const uint8_t *signature, size_t signature_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_verify_message_req *req_data;
+	void *input_buffer = NULL;
+	void *signature_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, input, input_length, &input_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_out_prepare(mem_region, signature, signature_length, &signature_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, input_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_verify_message_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_verify_message_req_m;
 
 	req_data->psa_verify_message_req_key = key;
 	req_data->psa_verify_message_req_alg = alg;
-	req_data->psa_verify_message_req_p_input = (uint32_t)input;
+	req_data->psa_verify_message_req_p_input = (uint32_t)input_buffer;
 	req_data->psa_verify_message_req_input_length = input_length;
-	req_data->psa_verify_message_req_p_signature = (uint32_t)signature;
+	req_data->psa_verify_message_req_p_signature = (uint32_t)signature_buffer;
 	req_data->psa_verify_message_req_signature_length = signature_length;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
@@ -1226,56 +2077,94 @@ psa_status_t ssf_psa_verify_message(
 		return err;
 	}
 
+	dmm_buffer_out_release(mem_region, input_buffer);
+	dmm_buffer_out_release(mem_region, signature_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_sign_hash(
-
-	mbedtls_svc_key_id_t key, psa_algorithm_t alg, const uint8_t *hash, size_t hash_length,
-	uint8_t *signature, size_t signature_size, size_t *signature_length)
+psa_status_t ssf_psa_sign_hash(mbedtls_svc_key_id_t key, psa_algorithm_t alg, const uint8_t *hash,
+			       size_t hash_length, uint8_t *signature, size_t signature_size,
+			       size_t *signature_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_sign_hash_req *req_data;
+	void *hash_buffer = NULL;
+	void *signature_buffer = NULL;
+	void *signature_length_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, hash, hash_length, &hash_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, signature, signature_size, &signature_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, hash_buffer);
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, signature_length, sizeof(size_t),
+				    &signature_length_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, hash_buffer);
+		dmm_buffer_in_release(mem_region, signature, signature_size, signature_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_sign_hash_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_sign_hash_req_m;
 
 	req_data->psa_sign_hash_req_key = key;
 	req_data->psa_sign_hash_req_alg = alg;
-	req_data->psa_sign_hash_req_p_hash = (uint32_t)hash;
+	req_data->psa_sign_hash_req_p_hash = (uint32_t)hash_buffer;
 	req_data->psa_sign_hash_req_hash_length = hash_length;
-	req_data->psa_sign_hash_req_p_signature = (uint32_t)signature;
+	req_data->psa_sign_hash_req_p_signature = (uint32_t)signature_buffer;
 	req_data->psa_sign_hash_req_signature_size = signature_size;
-	req_data->psa_sign_hash_req_p_signature_length = (uint32_t)signature_length;
+	req_data->psa_sign_hash_req_p_signature_length = (uint32_t)signature_length_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_out_release(mem_region, hash_buffer);
+	dmm_buffer_in_release(mem_region, signature, signature_size, signature_buffer);
+	dmm_buffer_in_release(mem_region, signature_length, sizeof(size_t),
+			      signature_length_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_verify_hash(
-
-	mbedtls_svc_key_id_t key, psa_algorithm_t alg, const uint8_t *hash, size_t hash_length,
-	const uint8_t *signature, size_t signature_length)
+psa_status_t ssf_psa_verify_hash(mbedtls_svc_key_id_t key, psa_algorithm_t alg, const uint8_t *hash,
+				 size_t hash_length, const uint8_t *signature,
+				 size_t signature_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_verify_hash_req *req_data;
+	void *hash_buffer = NULL;
+	void *signature_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, hash, hash_length, &hash_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_out_prepare(mem_region, signature, signature_length, &signature_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, hash_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_verify_hash_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_verify_hash_req_m;
 
 	req_data->psa_verify_hash_req_key = key;
 	req_data->psa_verify_hash_req_alg = alg;
-	req_data->psa_verify_hash_req_p_hash = (uint32_t)hash;
+	req_data->psa_verify_hash_req_p_hash = (uint32_t)hash_buffer;
 	req_data->psa_verify_hash_req_hash_length = hash_length;
-	req_data->psa_verify_hash_req_p_signature = (uint32_t)signature;
+	req_data->psa_verify_hash_req_p_signature = (uint32_t)signature_buffer;
 	req_data->psa_verify_hash_req_signature_length = signature_length;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
@@ -1283,86 +2172,159 @@ psa_status_t ssf_psa_verify_hash(
 		return err;
 	}
 
+	dmm_buffer_out_release(mem_region, hash_buffer);
+	dmm_buffer_out_release(mem_region, signature_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_asymmetric_encrypt(
-
-	mbedtls_svc_key_id_t key, psa_algorithm_t alg, const uint8_t *input, size_t input_length,
-	const uint8_t *salt, size_t salt_length, uint8_t *output, size_t output_size,
-	size_t *output_length)
+psa_status_t ssf_psa_asymmetric_encrypt(mbedtls_svc_key_id_t key, psa_algorithm_t alg,
+					const uint8_t *input, size_t input_length,
+					const uint8_t *salt, size_t salt_length, uint8_t *output,
+					size_t output_size, size_t *output_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_asymmetric_encrypt_req *req_data;
+	void *input_buffer = NULL;
+	void *salt_buffer = NULL;
+	void *output_buffer = NULL;
+	void *output_length_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, input, input_length, &input_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_out_prepare(mem_region, salt, salt_length, &salt_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, input_buffer);
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, output, output_size, &output_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, input_buffer);
+		dmm_buffer_out_release(mem_region, salt_buffer);
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, output_length, sizeof(size_t),
+				    &output_length_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, input_buffer);
+		dmm_buffer_out_release(mem_region, salt_buffer);
+		dmm_buffer_in_release(mem_region, output, output_size, output_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_asymmetric_encrypt_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_asymmetric_encrypt_req_m;
 
 	req_data->psa_asymmetric_encrypt_req_key = key;
 	req_data->psa_asymmetric_encrypt_req_alg = alg;
-	req_data->psa_asymmetric_encrypt_req_p_input = (uint32_t)input;
+	req_data->psa_asymmetric_encrypt_req_p_input = (uint32_t)input_buffer;
 	req_data->psa_asymmetric_encrypt_req_input_length = input_length;
-	req_data->psa_asymmetric_encrypt_req_p_salt = (uint32_t)salt;
+	req_data->psa_asymmetric_encrypt_req_p_salt = (uint32_t)salt_buffer;
 	req_data->psa_asymmetric_encrypt_req_salt_length = salt_length;
-	req_data->psa_asymmetric_encrypt_req_p_output = (uint32_t)output;
+	req_data->psa_asymmetric_encrypt_req_p_output = (uint32_t)output_buffer;
 	req_data->psa_asymmetric_encrypt_req_output_size = output_size;
-	req_data->psa_asymmetric_encrypt_req_p_output_length = (uint32_t)output_length;
+	req_data->psa_asymmetric_encrypt_req_p_output_length = (uint32_t)output_length_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_out_release(mem_region, input_buffer);
+	dmm_buffer_out_release(mem_region, salt_buffer);
+	dmm_buffer_in_release(mem_region, output, output_size, output_buffer);
+	dmm_buffer_in_release(mem_region, output_length, sizeof(size_t), output_length_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_asymmetric_decrypt(
-
-	mbedtls_svc_key_id_t key, psa_algorithm_t alg, const uint8_t *input, size_t input_length,
-	const uint8_t *salt, size_t salt_length, uint8_t *output, size_t output_size,
-	size_t *output_length)
+psa_status_t ssf_psa_asymmetric_decrypt(mbedtls_svc_key_id_t key, psa_algorithm_t alg,
+					const uint8_t *input, size_t input_length,
+					const uint8_t *salt, size_t salt_length, uint8_t *output,
+					size_t output_size, size_t *output_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_asymmetric_decrypt_req *req_data;
+	void *input_buffer = NULL;
+	void *salt_buffer = NULL;
+	void *output_buffer = NULL;
+	void *output_length_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, input, input_length, &input_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_out_prepare(mem_region, salt, salt_length, &salt_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, input_buffer);
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, output, output_size, &output_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, input_buffer);
+		dmm_buffer_out_release(mem_region, salt_buffer);
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, output_length, sizeof(size_t),
+				    &output_length_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, input_buffer);
+		dmm_buffer_out_release(mem_region, salt_buffer);
+		dmm_buffer_in_release(mem_region, output, output_size, output_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_asymmetric_decrypt_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_asymmetric_decrypt_req_m;
 
 	req_data->psa_asymmetric_decrypt_req_key = key;
 	req_data->psa_asymmetric_decrypt_req_alg = alg;
-	req_data->psa_asymmetric_decrypt_req_p_input = (uint32_t)input;
+	req_data->psa_asymmetric_decrypt_req_p_input = (uint32_t)input_buffer;
 	req_data->psa_asymmetric_decrypt_req_input_length = input_length;
-	req_data->psa_asymmetric_decrypt_req_p_salt = (uint32_t)salt;
+	req_data->psa_asymmetric_decrypt_req_p_salt = (uint32_t)salt_buffer;
 	req_data->psa_asymmetric_decrypt_req_salt_length = salt_length;
-	req_data->psa_asymmetric_decrypt_req_p_output = (uint32_t)output;
+	req_data->psa_asymmetric_decrypt_req_p_output = (uint32_t)output_buffer;
 	req_data->psa_asymmetric_decrypt_req_output_size = output_size;
-	req_data->psa_asymmetric_decrypt_req_p_output_length = (uint32_t)output_length;
+	req_data->psa_asymmetric_decrypt_req_p_output_length = (uint32_t)output_length_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_out_release(mem_region, input_buffer);
+	dmm_buffer_out_release(mem_region, salt_buffer);
+	dmm_buffer_in_release(mem_region, output, output_size, output_buffer);
+	dmm_buffer_in_release(mem_region, output_length, sizeof(size_t), output_length_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_key_derivation_setup(
-
-	mbedtls_psa_client_handle_t *p_handle, psa_algorithm_t alg)
+psa_status_t ssf_psa_key_derivation_setup(mbedtls_psa_client_handle_t *p_handle,
+					  psa_algorithm_t alg)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_key_derivation_setup_req *req_data;
+	void *handle_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_key_derivation_setup_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_key_derivation_setup_req_m;
 
-	req_data->psa_key_derivation_setup_req_p_handle = (uint32_t)p_handle;
+	req_data->psa_key_derivation_setup_req_p_handle = (uint32_t)handle_buffer;
 	req_data->psa_key_derivation_setup_req_alg = alg;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
@@ -1370,45 +2332,61 @@ psa_status_t ssf_psa_key_derivation_setup(
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_key_derivation_get_capacity(
-
-	mbedtls_psa_client_handle_t handle, size_t *capacity)
+psa_status_t ssf_psa_key_derivation_get_capacity(mbedtls_psa_client_handle_t handle,
+						 size_t *capacity)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_key_derivation_get_capacity_req *req_data;
+	void *capacity_buffer = NULL;
+
+	err = dmm_buffer_in_prepare(mem_region, capacity, sizeof(size_t), &capacity_buffer);
+	if (err != 0) {
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_key_derivation_get_capacity_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_key_derivation_get_capacity_req_m;
 
 	req_data->psa_key_derivation_get_capacity_req_handle = (uint32_t)handle;
-	req_data->psa_key_derivation_get_capacity_req_p_capacity = (uint32_t)capacity;
+	req_data->psa_key_derivation_get_capacity_req_p_capacity = (uint32_t)capacity_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, capacity, sizeof(size_t), capacity_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_key_derivation_set_capacity(
-
-	mbedtls_psa_client_handle_t *p_handle, size_t capacity)
+psa_status_t ssf_psa_key_derivation_set_capacity(mbedtls_psa_client_handle_t *p_handle,
+						 size_t capacity)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_key_derivation_set_capacity_req *req_data;
+	void *handle_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_key_derivation_set_capacity_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_key_derivation_set_capacity_req_m;
 
-	req_data->psa_key_derivation_set_capacity_req_p_handle = (uint32_t)p_handle;
+	req_data->psa_key_derivation_set_capacity_req_p_handle = (uint32_t)handle_buffer;
 	req_data->psa_key_derivation_set_capacity_req_capacity = capacity;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
@@ -1416,25 +2394,41 @@ psa_status_t ssf_psa_key_derivation_set_capacity(
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_key_derivation_input_bytes(
-
-	mbedtls_psa_client_handle_t *p_handle, psa_key_derivation_step_t step, const uint8_t *data,
-	size_t data_length)
+psa_status_t ssf_psa_key_derivation_input_bytes(mbedtls_psa_client_handle_t *p_handle,
+						psa_key_derivation_step_t step, const uint8_t *data,
+						size_t data_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_key_derivation_input_bytes_req *req_data;
+	void *handle_buffer = NULL;
+	void *data_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_out_prepare(mem_region, data, data_length, &data_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_key_derivation_input_bytes_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_key_derivation_input_bytes_req_m;
 
-	req_data->psa_key_derivation_input_bytes_req_p_handle = (uint32_t)p_handle;
+	req_data->psa_key_derivation_input_bytes_req_p_handle = (uint32_t)handle_buffer;
 	req_data->psa_key_derivation_input_bytes_req_step = step;
-	req_data->psa_key_derivation_input_bytes_req_p_data = (uint32_t)data;
+	req_data->psa_key_derivation_input_bytes_req_p_data = (uint32_t)data_buffer;
 	req_data->psa_key_derivation_input_bytes_req_data_length = data_length;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
@@ -1442,22 +2436,32 @@ psa_status_t ssf_psa_key_derivation_input_bytes(
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+	dmm_buffer_out_release(mem_region, data_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_key_derivation_input_integer(
-
-	mbedtls_psa_client_handle_t *p_handle, psa_key_derivation_step_t step, uint64_t value)
+psa_status_t ssf_psa_key_derivation_input_integer(mbedtls_psa_client_handle_t *p_handle,
+						  psa_key_derivation_step_t step, uint64_t value)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_key_derivation_input_integer_req *req_data;
+	void *handle_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_key_derivation_input_integer_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_key_derivation_input_integer_req_m;
 
-	req_data->psa_key_derivation_input_integer_req_p_handle = (uint32_t)p_handle;
+	req_data->psa_key_derivation_input_integer_req_p_handle = (uint32_t)handle_buffer;
 	req_data->psa_key_derivation_input_integer_req_step = step;
 	req_data->psa_key_derivation_input_integer_req_value = value;
 
@@ -1466,23 +2470,32 @@ psa_status_t ssf_psa_key_derivation_input_integer(
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_key_derivation_input_key(
-
-	mbedtls_psa_client_handle_t *p_handle, psa_key_derivation_step_t step,
-	mbedtls_svc_key_id_t key)
+psa_status_t ssf_psa_key_derivation_input_key(mbedtls_psa_client_handle_t *p_handle,
+					      psa_key_derivation_step_t step,
+					      mbedtls_svc_key_id_t key)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_key_derivation_input_key_req *req_data;
+	void *handle_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_key_derivation_input_key_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_key_derivation_input_key_req_m;
 
-	req_data->psa_key_derivation_input_key_req_p_handle = (uint32_t)p_handle;
+	req_data->psa_key_derivation_input_key_req_p_handle = (uint32_t)handle_buffer;
 	req_data->psa_key_derivation_input_key_req_step = step;
 	req_data->psa_key_derivation_input_key_req_key = key;
 
@@ -1491,26 +2504,43 @@ psa_status_t ssf_psa_key_derivation_input_key(
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_key_derivation_key_agreement(
-
-	mbedtls_psa_client_handle_t *p_handle, psa_key_derivation_step_t step,
-	mbedtls_svc_key_id_t private_key, const uint8_t *peer_key, size_t peer_key_length)
+psa_status_t ssf_psa_key_derivation_key_agreement(mbedtls_psa_client_handle_t *p_handle,
+						  psa_key_derivation_step_t step,
+						  mbedtls_svc_key_id_t private_key,
+						  const uint8_t *peer_key, size_t peer_key_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_key_derivation_key_agreement_req *req_data;
+	void *handle_buffer = NULL;
+	void *peer_key_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_out_prepare(mem_region, peer_key, peer_key_length, &peer_key_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_key_derivation_key_agreement_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_key_derivation_key_agreement_req_m;
 
-	req_data->psa_key_derivation_key_agreement_req_p_handle = (uint32_t)p_handle;
+	req_data->psa_key_derivation_key_agreement_req_p_handle = (uint32_t)handle_buffer;
 	req_data->psa_key_derivation_key_agreement_req_step = step;
 	req_data->psa_key_derivation_key_agreement_req_private_key = private_key;
-	req_data->psa_key_derivation_key_agreement_req_p_peer_key = (uint32_t)peer_key;
+	req_data->psa_key_derivation_key_agreement_req_p_peer_key = (uint32_t)peer_key_buffer;
 	req_data->psa_key_derivation_key_agreement_req_peer_key_length = peer_key_length;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
@@ -1518,23 +2548,40 @@ psa_status_t ssf_psa_key_derivation_key_agreement(
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+	dmm_buffer_out_release(mem_region, peer_key_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_key_derivation_output_bytes(
-
-	mbedtls_psa_client_handle_t *p_handle, uint8_t *output, size_t output_length)
+psa_status_t ssf_psa_key_derivation_output_bytes(mbedtls_psa_client_handle_t *p_handle,
+						 uint8_t *output, size_t output_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_key_derivation_output_bytes_req *req_data;
+	void *handle_buffer = NULL;
+	void *output_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, output, output_length, &output_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_key_derivation_output_bytes_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_key_derivation_output_bytes_req_m;
 
-	req_data->psa_key_derivation_output_bytes_req_p_handle = (uint32_t)p_handle;
-	req_data->psa_key_derivation_output_bytes_req_p_output = (uint32_t)output;
+	req_data->psa_key_derivation_output_bytes_req_p_handle = (uint32_t)handle_buffer;
+	req_data->psa_key_derivation_output_bytes_req_p_output = (uint32_t)output_buffer;
 	req_data->psa_key_derivation_output_bytes_req_output_length = output_length;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
@@ -1542,98 +2589,163 @@ psa_status_t ssf_psa_key_derivation_output_bytes(
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+	dmm_buffer_in_release(mem_region, output, output_length, output_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_key_derivation_output_key(
-
-	const psa_key_attributes_t *attributes, mbedtls_psa_client_handle_t *p_handle,
-	mbedtls_svc_key_id_t *key)
+psa_status_t ssf_psa_key_derivation_output_key(const psa_key_attributes_t *attributes,
+					       mbedtls_psa_client_handle_t *p_handle,
+					       mbedtls_svc_key_id_t *key)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_key_derivation_output_key_req *req_data;
+	void *attributes_buffer = NULL;
+	void *handle_buffer = NULL;
+	void *key_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, attributes, sizeof(psa_key_attributes_t),
+				     &attributes_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, attributes_buffer);
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, key, sizeof(mbedtls_svc_key_id_t), &key_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, attributes_buffer);
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_key_derivation_output_key_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_key_derivation_output_key_req_m;
 
-	req_data->psa_key_derivation_output_key_req_p_attributes = (uint32_t)attributes;
-	req_data->psa_key_derivation_output_key_req_p_handle = (uint32_t)p_handle;
-	req_data->psa_key_derivation_output_key_req_p_key = (uint32_t)key;
+	req_data->psa_key_derivation_output_key_req_p_attributes = (uint32_t)attributes_buffer;
+	req_data->psa_key_derivation_output_key_req_p_handle = (uint32_t)handle_buffer;
+	req_data->psa_key_derivation_output_key_req_p_key = (uint32_t)key_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_out_release(mem_region, attributes_buffer);
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+	dmm_buffer_in_release(mem_region, key, sizeof(mbedtls_svc_key_id_t), key_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_key_derivation_abort(
-
-	mbedtls_psa_client_handle_t *p_handle)
+psa_status_t ssf_psa_key_derivation_abort(mbedtls_psa_client_handle_t *p_handle)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_key_derivation_abort_req *req_data;
+	void *handle_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_key_derivation_abort_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_key_derivation_abort_req_m;
 
-	req_data->psa_key_derivation_abort_req_p_handle = (uint32_t)p_handle;
+	req_data->psa_key_derivation_abort_req_p_handle = (uint32_t)handle_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_raw_key_agreement(
-
-	psa_algorithm_t alg, mbedtls_svc_key_id_t private_key, const uint8_t *peer_key,
-	size_t peer_key_length, uint8_t *output, size_t output_size, size_t *output_length)
+psa_status_t ssf_psa_raw_key_agreement(psa_algorithm_t alg, mbedtls_svc_key_id_t private_key,
+				       const uint8_t *peer_key, size_t peer_key_length,
+				       uint8_t *output, size_t output_size, size_t *output_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_raw_key_agreement_req *req_data;
+	void *peer_key_buffer = NULL;
+	void *output_buffer = NULL;
+	void *output_length_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, peer_key, peer_key_length, &peer_key_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, output, output_size, &output_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, peer_key_buffer);
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, output_length, sizeof(size_t),
+				    &output_length_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, peer_key_buffer);
+		dmm_buffer_in_release(mem_region, output, output_size, output_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_raw_key_agreement_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_raw_key_agreement_req_m;
 
 	req_data->psa_raw_key_agreement_req_alg = alg;
 	req_data->psa_raw_key_agreement_req_private_key = private_key;
-	req_data->psa_raw_key_agreement_req_p_peer_key = (uint32_t)peer_key;
+	req_data->psa_raw_key_agreement_req_p_peer_key = (uint32_t)peer_key_buffer;
 	req_data->psa_raw_key_agreement_req_peer_key_length = peer_key_length;
-	req_data->psa_raw_key_agreement_req_p_output = (uint32_t)output;
+	req_data->psa_raw_key_agreement_req_p_output = (uint32_t)output_buffer;
 	req_data->psa_raw_key_agreement_req_output_size = output_size;
-	req_data->psa_raw_key_agreement_req_p_output_length = (uint32_t)output_length;
+	req_data->psa_raw_key_agreement_req_p_output_length = (uint32_t)output_length_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_out_release(mem_region, peer_key_buffer);
+	dmm_buffer_in_release(mem_region, output, output_size, output_buffer);
+	dmm_buffer_in_release(mem_region, output_length, sizeof(size_t), output_length_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_generate_random(
-
-	uint8_t *output, size_t output_size)
+psa_status_t ssf_psa_generate_random(uint8_t *output, size_t output_size)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_generate_random_req *req_data;
+	void *output_buffer = NULL;
+
+	err = dmm_buffer_in_prepare(mem_region, output, output_size, &output_buffer);
+	if (err != 0) {
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_generate_random_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_generate_random_req_m;
 
-	req_data->psa_generate_random_req_p_output = (uint32_t)output;
+	req_data->psa_generate_random_req_p_output = (uint32_t)output_buffer;
 	req_data->psa_generate_random_req_output_size = output_size;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
@@ -1641,171 +2753,109 @@ psa_status_t ssf_psa_generate_random(
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, output, output_size, output_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_generate_key(
-
-	const psa_key_attributes_t *attributes, mbedtls_svc_key_id_t *key)
+psa_status_t ssf_psa_generate_key(const psa_key_attributes_t *attributes, mbedtls_svc_key_id_t *key)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_generate_key_req *req_data;
+	void *attributes_buffer = NULL;
+	void *key_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, attributes, sizeof(psa_key_attributes_t),
+				     &attributes_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, key, sizeof(mbedtls_svc_key_id_t), &key_buffer);
+	if (err != 0) {
+		dmm_buffer_out_release(mem_region, attributes_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_generate_key_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_generate_key_req_m;
 
-	req_data->psa_generate_key_req_p_attributes = (uint32_t)attributes;
-	req_data->psa_generate_key_req_p_key = (uint32_t)key;
+	req_data->psa_generate_key_req_p_attributes = (uint32_t)attributes_buffer;
+	req_data->psa_generate_key_req_p_key = (uint32_t)key_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
-	return rsp.psa_crypto_rsp_status;
-}
-
-psa_status_t ssf_psa_sign_hash_start(
-
-	psa_sign_hash_interruptible_operation_t *operation, mbedtls_svc_key_id_t key,
-	psa_algorithm_t alg, const uint8_t *hash, size_t hash_length)
-{
-	int err;
-	struct psa_crypto_req req = { 0 };
-	struct psa_crypto_rsp rsp = { 0 };
-	struct psa_sign_hash_start_req *req_data;
-
-	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_sign_hash_start_req_m_c;
-	req_data = &req.psa_crypto_req_msg_psa_sign_hash_start_req_m;
-
-	req_data->psa_sign_hash_start_req_p_operation = (uint32_t)operation;
-	req_data->psa_sign_hash_start_req_key = key;
-	req_data->psa_sign_hash_start_req_alg = alg;
-	req_data->psa_sign_hash_start_req_p_hash = (uint32_t)hash;
-	req_data->psa_sign_hash_start_req_hash_length = hash_length;
-
-	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
-	if (err != 0) {
-		return err;
-	}
+	dmm_buffer_out_release(mem_region, attributes_buffer);
+	dmm_buffer_in_release(mem_region, key, sizeof(mbedtls_svc_key_id_t), key_buffer);
 
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_sign_hash_abort(
-
-	psa_sign_hash_interruptible_operation_t *operation)
-{
-	int err;
-	struct psa_crypto_req req = { 0 };
-	struct psa_crypto_rsp rsp = { 0 };
-	struct psa_sign_hash_abort_req *req_data;
-
-	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_sign_hash_abort_req_m_c;
-	req_data = &req.psa_crypto_req_msg_psa_sign_hash_abort_req_m;
-
-	req_data->psa_sign_hash_abort_req_p_operation = (uint32_t)operation;
-
-	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
-	if (err != 0) {
-		return err;
-	}
-
-	return rsp.psa_crypto_rsp_status;
-}
-
-psa_status_t ssf_psa_verify_hash_start(
-
-	psa_verify_hash_interruptible_operation_t *operation, mbedtls_svc_key_id_t key,
-	psa_algorithm_t alg, const uint8_t *hash, size_t hash_length, const uint8_t *signature,
-	size_t signature_length)
-{
-	int err;
-	struct psa_crypto_req req = { 0 };
-	struct psa_crypto_rsp rsp = { 0 };
-	struct psa_verify_hash_start_req *req_data;
-
-	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_verify_hash_start_req_m_c;
-	req_data = &req.psa_crypto_req_msg_psa_verify_hash_start_req_m;
-
-	req_data->psa_verify_hash_start_req_p_operation = (uint32_t)operation;
-	req_data->psa_verify_hash_start_req_key = key;
-	req_data->psa_verify_hash_start_req_alg = alg;
-	req_data->psa_verify_hash_start_req_p_hash = (uint32_t)hash;
-	req_data->psa_verify_hash_start_req_hash_length = hash_length;
-	req_data->psa_verify_hash_start_req_p_signature = (uint32_t)signature;
-	req_data->psa_verify_hash_start_req_signature_length = signature_length;
-
-	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
-	if (err != 0) {
-		return err;
-	}
-
-	return rsp.psa_crypto_rsp_status;
-}
-
-psa_status_t ssf_psa_verify_hash_abort(
-
-	psa_verify_hash_interruptible_operation_t *operation)
-{
-	int err;
-	struct psa_crypto_req req = { 0 };
-	struct psa_crypto_rsp rsp = { 0 };
-	struct psa_verify_hash_abort_req *req_data;
-
-	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_verify_hash_abort_req_m_c;
-	req_data = &req.psa_crypto_req_msg_psa_verify_hash_abort_req_m;
-
-	req_data->psa_verify_hash_abort_req_p_operation = (uint32_t)operation;
-
-	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
-	if (err != 0) {
-		return err;
-	}
-
-	return rsp.psa_crypto_rsp_status;
-}
-
-psa_status_t ssf_psa_pake_setup(
-
-	mbedtls_psa_client_handle_t *p_handle, mbedtls_svc_key_id_t password_key,
-	const psa_pake_cipher_suite_t *cipher_suite)
+psa_status_t ssf_psa_pake_setup(mbedtls_psa_client_handle_t *p_handle,
+				mbedtls_svc_key_id_t password_key,
+				const psa_pake_cipher_suite_t *cipher_suite)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_pake_setup_req *req_data;
+	void *handle_buffer = NULL;
+	void *cipher_suite_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_out_prepare(mem_region, cipher_suite, sizeof(psa_pake_cipher_suite_t),
+				     &cipher_suite_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_pake_setup_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_pake_setup_req_m;
 
-	req_data->psa_pake_setup_req_p_handle = (uint32_t)p_handle;
+	req_data->psa_pake_setup_req_p_handle = (uint32_t)handle_buffer;
 	req_data->psa_pake_setup_req_password_key = password_key;
-	req_data->psa_pake_setup_req_p_cipher_suite = (uint32_t)cipher_suite;
+	req_data->psa_pake_setup_req_p_cipher_suite = (uint32_t)cipher_suite_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+	dmm_buffer_out_release(mem_region, cipher_suite_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_pake_set_role(
-
-	mbedtls_psa_client_handle_t *p_handle, psa_pake_role_t role)
+psa_status_t ssf_psa_pake_set_role(mbedtls_psa_client_handle_t *p_handle, psa_pake_role_t role)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_pake_set_role_req *req_data;
+	void *handle_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_pake_set_role_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_pake_set_role_req_m;
 
-	req_data->psa_pake_set_role_req_p_handle = (uint32_t)p_handle;
+	req_data->psa_pake_set_role_req_p_handle = (uint32_t)handle_buffer;
 	req_data->psa_pake_set_role_req_role = role;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
@@ -1813,23 +2863,39 @@ psa_status_t ssf_psa_pake_set_role(
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_pake_set_user(
-
-	mbedtls_psa_client_handle_t *p_handle, const uint8_t *user_id, size_t user_id_len)
+psa_status_t ssf_psa_pake_set_user(mbedtls_psa_client_handle_t *p_handle, const uint8_t *user_id,
+				   size_t user_id_len)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_pake_set_user_req *req_data;
+	void *handle_buffer = NULL;
+	void *user_id_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_out_prepare(mem_region, user_id, user_id_len, &user_id_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_pake_set_user_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_pake_set_user_req_m;
 
-	req_data->psa_pake_set_user_req_p_handle = (uint32_t)p_handle;
-	req_data->psa_pake_set_user_req_p_user_id = (uint32_t)user_id;
+	req_data->psa_pake_set_user_req_p_handle = (uint32_t)handle_buffer;
+	req_data->psa_pake_set_user_req_p_user_id = (uint32_t)user_id_buffer;
 	req_data->psa_pake_set_user_req_user_id_len = user_id_len;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
@@ -1837,23 +2903,40 @@ psa_status_t ssf_psa_pake_set_user(
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+	dmm_buffer_out_release(mem_region, user_id_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_pake_set_peer(
-
-	mbedtls_psa_client_handle_t *p_handle, const uint8_t *peer_id, size_t peer_id_len)
+psa_status_t ssf_psa_pake_set_peer(mbedtls_psa_client_handle_t *p_handle, const uint8_t *peer_id,
+				   size_t peer_id_len)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_pake_set_peer_req *req_data;
+	void *handle_buffer = NULL;
+	void *peer_id_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_out_prepare(mem_region, peer_id, peer_id_len, &peer_id_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_pake_set_peer_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_pake_set_peer_req_m;
 
-	req_data->psa_pake_set_peer_req_p_handle = (uint32_t)p_handle;
-	req_data->psa_pake_set_peer_req_p_peer_id = (uint32_t)peer_id;
+	req_data->psa_pake_set_peer_req_p_handle = (uint32_t)handle_buffer;
+	req_data->psa_pake_set_peer_req_p_peer_id = (uint32_t)peer_id_buffer;
 	req_data->psa_pake_set_peer_req_peer_id_len = peer_id_len;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
@@ -1861,23 +2944,40 @@ psa_status_t ssf_psa_pake_set_peer(
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+	dmm_buffer_out_release(mem_region, peer_id_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_pake_set_context(
-
-	mbedtls_psa_client_handle_t *p_handle, const uint8_t *context, size_t context_len)
+psa_status_t ssf_psa_pake_set_context(mbedtls_psa_client_handle_t *p_handle, const uint8_t *context,
+				      size_t context_len)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_pake_set_context_req *req_data;
+	void *handle_buffer = NULL;
+	void *context_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_out_prepare(mem_region, context, context_len, &context_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_pake_set_context_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_pake_set_context_req_m;
 
-	req_data->psa_pake_set_context_req_p_handle = (uint32_t)p_handle;
-	req_data->psa_pake_set_context_req_p_context = (uint32_t)context;
+	req_data->psa_pake_set_context_req_p_handle = (uint32_t)handle_buffer;
+	req_data->psa_pake_set_context_req_p_context = (uint32_t)context_buffer;
 	req_data->psa_pake_set_context_req_context_len = context_len;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
@@ -1885,52 +2985,94 @@ psa_status_t ssf_psa_pake_set_context(
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+	dmm_buffer_out_release(mem_region, context_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_pake_output(
-
-	mbedtls_psa_client_handle_t *p_handle, psa_pake_step_t step, uint8_t *output,
-	size_t output_size, size_t *output_length)
+psa_status_t ssf_psa_pake_output(mbedtls_psa_client_handle_t *p_handle, psa_pake_step_t step,
+				 uint8_t *output, size_t output_size, size_t *output_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_pake_output_req *req_data;
+	void *handle_buffer = NULL;
+	void *output_buffer = NULL;
+	void *output_length_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, output, output_size, &output_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, output_length, sizeof(size_t),
+				    &output_length_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		dmm_buffer_in_release(mem_region, output, output_size, output_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_pake_output_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_pake_output_req_m;
 
-	req_data->psa_pake_output_req_p_handle = (uint32_t)p_handle;
+	req_data->psa_pake_output_req_p_handle = (uint32_t)handle_buffer;
 	req_data->psa_pake_output_req_step = step;
-	req_data->psa_pake_output_req_p_output = (uint32_t)output;
+	req_data->psa_pake_output_req_p_output = (uint32_t)output_buffer;
 	req_data->psa_pake_output_req_output_size = output_size;
-	req_data->psa_pake_output_req_p_output_length = (uint32_t)output_length;
+	req_data->psa_pake_output_req_p_output_length = (uint32_t)output_length_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+	dmm_buffer_in_release(mem_region, output, output_size, output_buffer);
+	dmm_buffer_in_release(mem_region, output_length, sizeof(size_t), output_length_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_pake_input(
-
-	mbedtls_psa_client_handle_t *p_handle, psa_pake_step_t step, const uint8_t *input,
-	size_t input_length)
+psa_status_t ssf_psa_pake_input(mbedtls_psa_client_handle_t *p_handle, psa_pake_step_t step,
+				const uint8_t *input, size_t input_length)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_pake_input_req *req_data;
+	void *handle_buffer = NULL;
+	void *input_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_out_prepare(mem_region, input, input_length, &input_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_pake_input_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_pake_input_req_m;
 
-	req_data->psa_pake_input_req_p_handle = (uint32_t)p_handle;
+	req_data->psa_pake_input_req_p_handle = (uint32_t)handle_buffer;
 	req_data->psa_pake_input_req_step = step;
-	req_data->psa_pake_input_req_p_input = (uint32_t)input;
+	req_data->psa_pake_input_req_p_input = (uint32_t)input_buffer;
 	req_data->psa_pake_input_req_input_length = input_length;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
@@ -1938,52 +3080,91 @@ psa_status_t ssf_psa_pake_input(
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+	dmm_buffer_out_release(mem_region, input_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_pake_get_shared_key(
-
-	mbedtls_psa_client_handle_t *p_handle, const psa_key_attributes_t *attributes,
-	mbedtls_svc_key_id_t *key)
+psa_status_t ssf_psa_pake_get_shared_key(mbedtls_psa_client_handle_t *p_handle,
+					 const psa_key_attributes_t *attributes,
+					 mbedtls_svc_key_id_t *key)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_pake_get_shared_key_req *req_data;
+	void *handle_buffer = NULL;
+	void *attributes_buffer = NULL;
+	void *key_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
+	err = dmm_buffer_out_prepare(mem_region, attributes, sizeof(psa_key_attributes_t),
+				     &attributes_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		return err;
+	}
+	err = dmm_buffer_in_prepare(mem_region, key, sizeof(mbedtls_svc_key_id_t), &key_buffer);
+	if (err != 0) {
+		dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				      handle_buffer);
+		dmm_buffer_out_release(mem_region, attributes_buffer);
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_pake_get_shared_key_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_pake_get_shared_key_req_m;
 
-	req_data->psa_pake_get_shared_key_req_p_handle = (uint32_t)p_handle;
-	req_data->psa_pake_get_shared_key_req_p_attributes = (uint32_t)attributes;
-	req_data->psa_pake_get_shared_key_req_p_key = (uint32_t)key;
+	req_data->psa_pake_get_shared_key_req_p_handle = (uint32_t)handle_buffer;
+	req_data->psa_pake_get_shared_key_req_p_attributes = (uint32_t)attributes_buffer;
+	req_data->psa_pake_get_shared_key_req_p_key = (uint32_t)key_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
 
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
+	dmm_buffer_out_release(mem_region, attributes_buffer);
+	dmm_buffer_in_release(mem_region, key, sizeof(mbedtls_svc_key_id_t), key_buffer);
+
 	return rsp.psa_crypto_rsp_status;
 }
 
-psa_status_t ssf_psa_pake_abort(
-
-	mbedtls_psa_client_handle_t *p_handle)
+psa_status_t ssf_psa_pake_abort(mbedtls_psa_client_handle_t *p_handle)
 {
 	int err;
 	struct psa_crypto_req req = { 0 };
 	struct psa_crypto_rsp rsp = { 0 };
 	struct psa_pake_abort_req *req_data;
+	void *handle_buffer = NULL;
+
+	err = dmm_buffer_out_prepare(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+				     &handle_buffer);
+	if (err != 0) {
+		return err;
+	}
 
 	req.psa_crypto_req_msg_choice = psa_crypto_req_msg_psa_pake_abort_req_m_c;
 	req_data = &req.psa_crypto_req_msg_psa_pake_abort_req_m;
 
-	req_data->psa_pake_abort_req_p_handle = (uint32_t)p_handle;
+	req_data->psa_pake_abort_req_p_handle = (uint32_t)handle_buffer;
 
 	err = ssf_client_send_request(&psa_crypto_srvc, &req, &rsp, NULL);
 	if (err != 0) {
 		return err;
 	}
+
+	dmm_buffer_in_release(mem_region, p_handle, sizeof(mbedtls_psa_client_handle_t),
+			      handle_buffer);
 
 	return rsp.psa_crypto_rsp_status;
 }

--- a/subsys/sdfw_services/services/psa_crypto/psa_crypto_service.cddl
+++ b/subsys/sdfw_services/services/psa_crypto/psa_crypto_service.cddl
@@ -3,695 +3,592 @@
 ;
 ; SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 ;
-
-
+ptr_buf = #6.32770(uint)
+buf_len = #6.32771(uint)
+ptr_attr = #6.32772(uint)
+ptr_key = #6.32773(uint)
+ptr_uint = #6.32774(uint)
+ptr_cipher = #6.32775(uint)
 
 psa_crypto_init_req = (
     10,
 )
 
-
 psa_get_key_attributes_req = (
     11,
     key: uint,
-    p_attributes: uint,
+    p_attributes: ptr_attr,
 )
-
 
 psa_reset_key_attributes_req = (
     12,
-    p_attributes: uint,
+    p_attributes: ptr_attr,
 )
-
 
 psa_purge_key_req = (
     13,
     key: uint,
 )
 
-
 psa_copy_key_req = (
     14,
     source_key: uint,
-    p_attributes: uint,
-    p_target_key: uint,
+    p_attributes: ptr_attr,
+    p_target_key: ptr_key,
 )
-
 
 psa_destroy_key_req = (
     15,
     key: uint,
 )
 
-
 psa_import_key_req = (
     16,
-    p_attributes: uint,
-    p_data: uint,
-    data_length: uint,
-    p_key: uint,
+    p_attributes: ptr_attr,
+    p_data: ptr_buf,
+    data_length: buf_len,
+    p_key: ptr_key,
 )
-
 
 psa_export_key_req = (
     17,
     key: uint,
-    p_data: uint,
-    data_size: uint,
-    p_data_length: uint,
+    p_data: ptr_buf,
+    data_size: buf_len,
+    p_data_length: ptr_uint,
 )
-
 
 psa_export_public_key_req = (
     18,
     key: uint,
-    p_data: uint,
-    data_size: uint,
-    p_data_length: uint,
+    p_data: ptr_buf,
+    data_size: buf_len,
+    p_data_length: ptr_uint,
 )
-
 
 psa_hash_compute_req = (
     19,
     alg: uint,
-    p_input: uint,
-    input_length: uint,
-    p_hash: uint,
-    hash_size: uint,
-    p_hash_length: uint,
+    p_input: ptr_buf,
+    input_length: buf_len,
+    p_hash: ptr_buf,
+    hash_size: buf_len,
+    p_hash_length: ptr_uint,
 )
-
 
 psa_hash_compare_req = (
     20,
     alg: uint,
-    p_input: uint,
-    input_length: uint,
-    p_hash: uint,
-    hash_length: uint,
+    p_input: ptr_buf,
+    input_length: buf_len,
+    p_hash: ptr_buf,
+    hash_length: buf_len,
 )
-
 
 psa_hash_setup_req = (
     21,
-    p_handle: uint,
+    p_handle: ptr_uint,
     alg: uint,
 )
 
-
 psa_hash_update_req = (
     22,
-    p_handle: uint,
-    p_input: uint,
-    input_length: uint,
+    p_handle: ptr_uint,
+    p_input: ptr_buf,
+    input_length: buf_len,
 )
-
 
 psa_hash_finish_req = (
     23,
-    p_handle: uint,
-    p_hash: uint,
-    hash_size: uint,
-    p_hash_length: uint,
+    p_handle: ptr_uint,
+    p_hash: ptr_buf,
+    hash_size: buf_len,
+    p_hash_length: ptr_uint,
 )
-
 
 psa_hash_verify_req = (
     24,
-    p_handle: uint,
-    p_hash: uint,
-    hash_length: uint,
+    p_handle: ptr_uint,
+    p_hash: ptr_buf,
+    hash_length: buf_len,
 )
-
 
 psa_hash_abort_req = (
     25,
-    p_handle: uint,
+    p_handle: ptr_uint,
 )
-
 
 psa_hash_clone_req = (
     26,
     handle: uint,
-    p_handle: uint,
+    p_handle: ptr_uint,
 )
-
 
 psa_mac_compute_req = (
     27,
     key: uint,
     alg: uint,
-    p_input: uint,
-    input_length: uint,
-    p_mac: uint,
-    mac_size: uint,
-    p_mac_length: uint,
+    p_input: ptr_buf,
+    input_length: buf_len,
+    p_mac: ptr_buf,
+    mac_size: buf_len,
+    p_mac_length: ptr_uint,
 )
-
 
 psa_mac_verify_req = (
     28,
     key: uint,
     alg: uint,
-    p_input: uint,
-    input_length: uint,
-    p_mac: uint,
-    mac_length: uint,
+    p_input: ptr_buf,
+    input_length: buf_len,
+    p_mac: ptr_buf,
+    mac_length: buf_len,
 )
-
 
 psa_mac_sign_setup_req = (
     29,
-    p_handle: uint,
+    p_handle: ptr_uint,
     key: uint,
     alg: uint,
 )
-
 
 psa_mac_verify_setup_req = (
     30,
-    p_handle: uint,
+    p_handle: ptr_uint,
     key: uint,
     alg: uint,
 )
 
-
 psa_mac_update_req = (
     31,
-    p_handle: uint,
-    p_input: uint,
-    input_length: uint,
+    p_handle: ptr_uint,
+    p_input: ptr_buf,
+    input_length: buf_len,
 )
-
 
 psa_mac_sign_finish_req = (
     32,
-    p_handle: uint,
-    p_mac: uint,
-    mac_size: uint,
-    p_mac_length: uint,
+    p_handle: ptr_uint,
+    p_mac: ptr_buf,
+    mac_size: buf_len,
+    p_mac_length: ptr_uint,
 )
-
 
 psa_mac_verify_finish_req = (
     33,
-    p_handle: uint,
-    p_mac: uint,
-    mac_length: uint,
+    p_handle: ptr_uint,
+    p_mac: ptr_buf,
+    mac_length: buf_len,
 )
-
 
 psa_mac_abort_req = (
     34,
-    p_handle: uint,
+    p_handle: ptr_uint,
 )
-
 
 psa_cipher_encrypt_req = (
     35,
     key: uint,
     alg: uint,
-    p_input: uint,
-    input_length: uint,
-    p_output: uint,
-    output_size: uint,
-    p_output_length: uint,
+    p_input: ptr_buf,
+    input_length: buf_len,
+    p_output: ptr_buf,
+    output_size: buf_len,
+    p_output_length: ptr_uint,
 )
-
 
 psa_cipher_decrypt_req = (
     36,
     key: uint,
     alg: uint,
-    p_input: uint,
-    input_length: uint,
-    p_output: uint,
-    output_size: uint,
-    p_output_length: uint,
+    p_input: ptr_buf,
+    input_length: buf_len,
+    p_output: ptr_buf,
+    output_size: buf_len,
+    p_output_length: ptr_uint,
 )
-
 
 psa_cipher_encrypt_setup_req = (
     37,
-    p_handle: uint,
+    p_handle: ptr_uint,
     key: uint,
     alg: uint,
 )
-
 
 psa_cipher_decrypt_setup_req = (
     38,
-    p_handle: uint,
+    p_handle: ptr_uint,
     key: uint,
     alg: uint,
 )
 
-
 psa_cipher_generate_iv_req = (
     39,
-    p_handle: uint,
-    p_iv: uint,
-    iv_size: uint,
-    p_iv_length: uint,
+    p_handle: ptr_uint,
+    p_iv: ptr_buf,
+    iv_size: buf_len,
+    p_iv_length: ptr_uint,
 )
-
 
 psa_cipher_set_iv_req = (
     40,
-    p_handle: uint,
-    p_iv: uint,
-    iv_length: uint,
+    p_handle: ptr_uint,
+    p_iv: ptr_buf,
+    iv_length: buf_len,
 )
-
 
 psa_cipher_update_req = (
     41,
-    p_handle: uint,
-    p_input: uint,
-    input_length: uint,
-    p_output: uint,
-    output_size: uint,
-    p_output_length: uint,
+    p_handle: ptr_uint,
+    p_input: ptr_buf,
+    input_length: buf_len,
+    p_output: ptr_buf,
+    output_size: buf_len,
+    p_output_length: ptr_uint,
 )
-
 
 psa_cipher_finish_req = (
     42,
-    p_handle: uint,
-    p_output: uint,
-    output_size: uint,
-    p_output_length: uint,
+    p_handle: ptr_uint,
+    p_output: ptr_buf,
+    output_size: buf_len,
+    p_output_length: ptr_uint,
 )
-
 
 psa_cipher_abort_req = (
     43,
-    p_handle: uint,
+    p_handle: ptr_uint,
 )
-
 
 psa_aead_encrypt_req = (
     44,
     key: uint,
     alg: uint,
-    p_nonce: uint,
-    nonce_length: uint,
-    p_additional_data: uint,
-    additional_data_length: uint,
-    p_plaintext: uint,
-    plaintext_length: uint,
-    p_ciphertext: uint,
-    ciphertext_size: uint,
-    p_ciphertext_length: uint,
+    p_nonce: ptr_buf,
+    nonce_length: buf_len,
+    p_additional_data: ptr_buf,
+    additional_data_length: buf_len,
+    p_plaintext: ptr_buf,
+    plaintext_length: buf_len,
+    p_ciphertext: ptr_buf,
+    ciphertext_size: buf_len,
+    p_ciphertext_length: ptr_uint,
 )
-
 
 psa_aead_decrypt_req = (
     45,
     key: uint,
     alg: uint,
-    p_nonce: uint,
-    nonce_length: uint,
-    p_additional_data: uint,
-    additional_data_length: uint,
-    p_ciphertext: uint,
-    ciphertext_length: uint,
-    p_plaintext: uint,
-    plaintext_size: uint,
-    p_plaintext_length: uint,
+    p_nonce: ptr_buf,
+    nonce_length: buf_len,
+    p_additional_data: ptr_buf,
+    additional_data_length: buf_len,
+    p_ciphertext: ptr_buf,
+    ciphertext_length: buf_len,
+    p_plaintext: ptr_buf,
+    plaintext_size: buf_len,
+    p_plaintext_length: ptr_uint,
 )
-
 
 psa_aead_encrypt_setup_req = (
     46,
-    p_handle: uint,
+    p_handle: ptr_uint,
     key: uint,
     alg: uint,
 )
-
 
 psa_aead_decrypt_setup_req = (
     47,
-    p_handle: uint,
+    p_handle: ptr_uint,
     key: uint,
     alg: uint,
 )
 
-
 psa_aead_generate_nonce_req = (
     48,
-    p_handle: uint,
-    p_nonce: uint,
-    nonce_size: uint,
-    p_nonce_length: uint,
+    p_handle: ptr_uint,
+    p_nonce: ptr_buf,
+    nonce_size: buf_len,
+    p_nonce_length: ptr_uint,
 )
-
 
 psa_aead_set_nonce_req = (
     49,
-    p_handle: uint,
-    p_nonce: uint,
-    nonce_length: uint,
+    p_handle: ptr_uint,
+    p_nonce: ptr_buf,
+    nonce_length: buf_len,
 )
-
 
 psa_aead_set_lengths_req = (
     50,
-    p_handle: uint,
-    ad_length: uint,
-    plaintext_length: uint,
+    p_handle: ptr_uint,
+    ad_length: buf_len,
+    plaintext_length: buf_len,
 )
-
 
 psa_aead_update_ad_req = (
     51,
-    p_handle: uint,
-    p_input: uint,
-    input_length: uint,
+    p_handle: ptr_uint,
+    p_input: ptr_buf,
+    input_length: buf_len,
 )
-
 
 psa_aead_update_req = (
     52,
-    p_handle: uint,
-    p_input: uint,
-    input_length: uint,
-    p_output: uint,
-    output_size: uint,
-    p_output_length: uint,
+    p_handle: ptr_uint,
+    p_input: ptr_buf,
+    input_length: buf_len,
+    p_output: ptr_buf,
+    output_size: buf_len,
+    p_output_length: ptr_uint,
 )
-
 
 psa_aead_finish_req = (
     53,
-    p_handle: uint,
-    p_ciphertext: uint,
-    ciphertext_size: uint,
-    p_ciphertext_length: uint,
-    p_tag: uint,
-    tag_size: uint,
-    p_tag_length: uint,
+    p_handle: ptr_uint,
+    p_ciphertext: ptr_buf,
+    ciphertext_size: buf_len,
+    p_ciphertext_length: ptr_uint,
+    p_tag: ptr_buf,
+    tag_size: buf_len,
+    p_tag_length: ptr_uint,
 )
-
 
 psa_aead_verify_req = (
     54,
-    p_handle: uint,
-    p_plaintext: uint,
-    plaintext_size: uint,
-    p_plaintext_length: uint,
-    p_tag: uint,
-    tag_length: uint,
+    p_handle: ptr_uint,
+    p_plaintext: ptr_buf,
+    plaintext_size: buf_len,
+    p_plaintext_length: ptr_uint,
+    p_tag: ptr_buf,
+    tag_length: buf_len,
 )
-
 
 psa_aead_abort_req = (
     55,
-    p_handle: uint,
+    p_handle: ptr_uint,
 )
-
 
 psa_sign_message_req = (
     56,
     key: uint,
     alg: uint,
-    p_input: uint,
-    input_length: uint,
-    p_signature: uint,
-    signature_size: uint,
-    p_signature_length: uint,
+    p_input: ptr_buf,
+    input_length: buf_len,
+    p_signature: ptr_buf,
+    signature_size: buf_len,
+    p_signature_length: ptr_uint,
 )
-
 
 psa_verify_message_req = (
     57,
     key: uint,
     alg: uint,
-    p_input: uint,
-    input_length: uint,
-    p_signature: uint,
-    signature_length: uint,
+    p_input: ptr_buf,
+    input_length: buf_len,
+    p_signature: ptr_buf,
+    signature_length: buf_len,
 )
-
 
 psa_sign_hash_req = (
     58,
     key: uint,
     alg: uint,
-    p_hash: uint,
-    hash_length: uint,
-    p_signature: uint,
-    signature_size: uint,
-    p_signature_length: uint,
+    p_hash: ptr_buf,
+    hash_length: buf_len,
+    p_signature: ptr_buf,
+    signature_size: buf_len,
+    p_signature_length: ptr_uint,
 )
-
 
 psa_verify_hash_req = (
     59,
     key: uint,
     alg: uint,
-    p_hash: uint,
-    hash_length: uint,
-    p_signature: uint,
-    signature_length: uint,
+    p_hash: ptr_buf,
+    hash_length: buf_len,
+    p_signature: ptr_buf,
+    signature_length: buf_len,
 )
-
 
 psa_asymmetric_encrypt_req = (
     60,
     key: uint,
     alg: uint,
-    p_input: uint,
-    input_length: uint,
-    p_salt: uint,
-    salt_length: uint,
-    p_output: uint,
-    output_size: uint,
-    p_output_length: uint,
+    p_input: ptr_buf,
+    input_length: buf_len,
+    p_salt: ptr_buf,
+    salt_length: buf_len,
+    p_output: ptr_buf,
+    output_size: buf_len,
+    p_output_length: ptr_uint,
 )
-
 
 psa_asymmetric_decrypt_req = (
     61,
     key: uint,
     alg: uint,
-    p_input: uint,
-    input_length: uint,
-    p_salt: uint,
-    salt_length: uint,
-    p_output: uint,
-    output_size: uint,
-    p_output_length: uint,
+    p_input: ptr_buf,
+    input_length: buf_len,
+    p_salt: ptr_buf,
+    salt_length: buf_len,
+    p_output: ptr_buf,
+    output_size: buf_len,
+    p_output_length: ptr_uint,
 )
-
 
 psa_key_derivation_setup_req = (
     62,
-    p_handle: uint,
+    p_handle: ptr_uint,
     alg: uint,
 )
-
 
 psa_key_derivation_get_capacity_req = (
     63,
     handle: uint,
-    p_capacity: uint,
+    p_capacity: ptr_uint,
 )
-
 
 psa_key_derivation_set_capacity_req = (
     64,
-    p_handle: uint,
+    p_handle: ptr_uint,
     capacity: uint,
 )
 
-
 psa_key_derivation_input_bytes_req = (
     65,
-    p_handle: uint,
+    p_handle: ptr_uint,
     step: uint,
-    p_data: uint,
-    data_length: uint,
+    p_data: ptr_buf,
+    data_length: buf_len,
 )
-
 
 psa_key_derivation_input_integer_req = (
     66,
-    p_handle: uint,
+    p_handle: ptr_uint,
     step: uint,
     value: uint,
 )
 
-
 psa_key_derivation_input_key_req = (
     67,
-    p_handle: uint,
+    p_handle: ptr_uint,
     step: uint,
     key: uint,
 )
 
-
 psa_key_derivation_key_agreement_req = (
     68,
-    p_handle: uint,
+    p_handle: ptr_uint,
     step: uint,
     private_key: uint,
-    p_peer_key: uint,
-    peer_key_length: uint,
+    p_peer_key: ptr_buf,
+    peer_key_length: buf_len,
 )
-
 
 psa_key_derivation_output_bytes_req = (
     69,
-    p_handle: uint,
-    p_output: uint,
-    output_length: uint,
+    p_handle: ptr_uint,
+    p_output: ptr_buf,
+    output_length: buf_len,
 )
-
 
 psa_key_derivation_output_key_req = (
     70,
-    p_attributes: uint,
-    p_handle: uint,
-    p_key: uint,
+    p_attributes: ptr_attr,
+    p_handle: ptr_uint,
+    p_key: ptr_key,
 )
-
 
 psa_key_derivation_abort_req = (
     71,
-    p_handle: uint,
+    p_handle: ptr_uint,
 )
-
 
 psa_raw_key_agreement_req = (
     72,
     alg: uint,
     private_key: uint,
-    p_peer_key: uint,
-    peer_key_length: uint,
-    p_output: uint,
-    output_size: uint,
-    p_output_length: uint,
+    p_peer_key: ptr_buf,
+    peer_key_length: buf_len,
+    p_output: ptr_buf,
+    output_size: buf_len,
+    p_output_length: ptr_uint,
 )
-
 
 psa_generate_random_req = (
     73,
-    p_output: uint,
-    output_size: uint,
+    p_output: ptr_buf,
+    output_size: buf_len,
 )
-
 
 psa_generate_key_req = (
     74,
-    p_attributes: uint,
-    p_key: uint,
+    p_attributes: ptr_attr,
+    p_key: ptr_key,
 )
-
-
-psa_sign_hash_start_req = (
-    75,
-    p_operation: uint,
-    key: uint,
-    alg: uint,
-    p_hash: uint,
-    hash_length: uint,
-)
-
-
-psa_sign_hash_abort_req = (
-    76,
-    p_operation: uint,
-)
-
-
-psa_verify_hash_start_req = (
-    77,
-    p_operation: uint,
-    key: uint,
-    alg: uint,
-    p_hash: uint,
-    hash_length: uint,
-    p_signature: uint,
-    signature_length: uint,
-)
-
-
-psa_verify_hash_abort_req = (
-    78,
-    p_operation: uint,
-)
-
 
 psa_pake_setup_req = (
-    79,
-    p_handle: uint,
+    75,
+    p_handle: ptr_uint,
     password_key: uint,
-    p_cipher_suite: uint,
+    p_cipher_suite: ptr_cipher,
 )
 
-
 psa_pake_set_role_req = (
-    80,
-    p_handle: uint,
+    76,
+    p_handle: ptr_uint,
     role: uint,
 )
 
-
 psa_pake_set_user_req = (
-    81,
-    p_handle: uint,
-    p_user_id: uint,
-    user_id_len: uint,
+    77,
+    p_handle: ptr_uint,
+    p_user_id: ptr_buf,
+    user_id_len: buf_len,
 )
-
 
 psa_pake_set_peer_req = (
-    82,
-    p_handle: uint,
-    p_peer_id: uint,
-    peer_id_len: uint,
+    78,
+    p_handle: ptr_uint,
+    p_peer_id: ptr_buf,
+    peer_id_len: buf_len,
 )
-
 
 psa_pake_set_context_req = (
-    83,
-    p_handle: uint,
-    p_context: uint,
-    context_len: uint,
+    79,
+    p_handle: ptr_uint,
+    p_context: ptr_buf,
+    context_len: buf_len,
 )
-
 
 psa_pake_output_req = (
-    84,
-    p_handle: uint,
+    80,
+    p_handle: ptr_uint,
     step: uint,
-    p_output: uint,
-    output_size: uint,
-    p_output_length: uint,
+    p_output: ptr_buf,
+    output_size: buf_len,
+    p_output_length: ptr_uint,
 )
-
 
 psa_pake_input_req = (
-    85,
-    p_handle: uint,
+    81,
+    p_handle: ptr_uint,
     step: uint,
-    p_input: uint,
-    input_length: uint,
+    p_input: ptr_buf,
+    input_length: buf_len,
 )
-
 
 psa_pake_get_shared_key_req = (
-    86,
-    p_handle: uint,
-    p_attributes: uint,
-    p_key: uint,
+    82,
+    p_handle: ptr_uint,
+    p_attributes: ptr_attr,
+    p_key: ptr_key,
 )
 
-
 psa_pake_abort_req = (
-    87,
-    p_handle: uint,
+    83,
+    p_handle: ptr_uint,
 )
 
 
@@ -763,10 +660,6 @@ psa_crypto_req = [
         psa_raw_key_agreement_req /
         psa_generate_random_req /
         psa_generate_key_req /
-        psa_sign_hash_start_req /
-        psa_sign_hash_abort_req /
-        psa_verify_hash_start_req /
-        psa_verify_hash_abort_req /
         psa_pake_setup_req /
         psa_pake_set_role_req /
         psa_pake_set_user_req /

--- a/subsys/sdfw_services/services/psa_crypto/zcbor_generated/psa_crypto_service_decode.c
+++ b/subsys/sdfw_services/services/psa_crypto/zcbor_generated/psa_crypto_service_decode.c
@@ -5,7 +5,7 @@
  */
 
 /*
- * Generated using zcbor version 0.8.1
+ * Generated using zcbor version 0.8.99
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */
@@ -22,14 +22,19 @@
 #error "The type file was generated with a different default_max_qty than this file"
 #endif
 
+static bool decode_ptr_attr(zcbor_state_t *state, uint32_t *result);
 static bool decode_psa_get_key_attributes_req(zcbor_state_t *state,
 					      struct psa_get_key_attributes_req *result);
 static bool decode_psa_reset_key_attributes_req(zcbor_state_t *state,
 						struct psa_reset_key_attributes_req *result);
 static bool decode_psa_purge_key_req(zcbor_state_t *state, struct psa_purge_key_req *result);
+static bool decode_ptr_key(zcbor_state_t *state, uint32_t *result);
 static bool decode_psa_copy_key_req(zcbor_state_t *state, struct psa_copy_key_req *result);
 static bool decode_psa_destroy_key_req(zcbor_state_t *state, struct psa_destroy_key_req *result);
+static bool decode_ptr_buf(zcbor_state_t *state, uint32_t *result);
+static bool decode_buf_len(zcbor_state_t *state, uint32_t *result);
 static bool decode_psa_import_key_req(zcbor_state_t *state, struct psa_import_key_req *result);
+static bool decode_ptr_uint(zcbor_state_t *state, uint32_t *result);
 static bool decode_psa_export_key_req(zcbor_state_t *state, struct psa_export_key_req *result);
 static bool decode_psa_export_public_key_req(zcbor_state_t *state,
 					     struct psa_export_public_key_req *result);
@@ -130,14 +135,7 @@ static bool decode_psa_raw_key_agreement_req(zcbor_state_t *state,
 static bool decode_psa_generate_random_req(zcbor_state_t *state,
 					   struct psa_generate_random_req *result);
 static bool decode_psa_generate_key_req(zcbor_state_t *state, struct psa_generate_key_req *result);
-static bool decode_psa_sign_hash_start_req(zcbor_state_t *state,
-					   struct psa_sign_hash_start_req *result);
-static bool decode_psa_sign_hash_abort_req(zcbor_state_t *state,
-					   struct psa_sign_hash_abort_req *result);
-static bool decode_psa_verify_hash_start_req(zcbor_state_t *state,
-					     struct psa_verify_hash_start_req *result);
-static bool decode_psa_verify_hash_abort_req(zcbor_state_t *state,
-					     struct psa_verify_hash_abort_req *result);
+static bool decode_ptr_cipher(zcbor_state_t *state, uint32_t *result);
 static bool decode_psa_pake_setup_req(zcbor_state_t *state, struct psa_pake_setup_req *result);
 static bool decode_psa_pake_set_role_req(zcbor_state_t *state,
 					 struct psa_pake_set_role_req *result);
@@ -155,16 +153,32 @@ static bool decode_psa_pake_abort_req(zcbor_state_t *state, struct psa_pake_abor
 static bool decode_psa_crypto_rsp(zcbor_state_t *state, struct psa_crypto_rsp *result);
 static bool decode_psa_crypto_req(zcbor_state_t *state, struct psa_crypto_req *result);
 
+static bool decode_ptr_attr(zcbor_state_t *state, uint32_t *result)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool tmp_result =
+		((zcbor_tag_expect(state, 32772) && (zcbor_uint32_decode(state, (&(*result))))));
+
+	if (!tmp_result) {
+		zcbor_trace_file(state);
+		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
+	} else {
+		zcbor_log("%s success\r\n", __func__);
+	}
+
+	return tmp_result;
+}
+
 static bool decode_psa_get_key_attributes_req(zcbor_state_t *state,
 					      struct psa_get_key_attributes_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (11)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_get_key_attributes_req_key)))) &&
-		   ((zcbor_uint32_decode(state,
-					 (&(*result).psa_get_key_attributes_req_p_attributes)))))));
+	bool tmp_result = (((
+		((zcbor_uint32_expect(state, (11)))) &&
+		((zcbor_uint32_decode(state, (&(*result).psa_get_key_attributes_req_key)))) &&
+		((decode_ptr_attr(state, (&(*result).psa_get_key_attributes_req_p_attributes)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -183,8 +197,8 @@ static bool decode_psa_reset_key_attributes_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (12)))) &&
-		   ((zcbor_uint32_decode(
-			   state, (&(*result).psa_reset_key_attributes_req_p_attributes)))))));
+		   ((decode_ptr_attr(state,
+				     (&(*result).psa_reset_key_attributes_req_p_attributes)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -213,6 +227,23 @@ static bool decode_psa_purge_key_req(zcbor_state_t *state, struct psa_purge_key_
 	return tmp_result;
 }
 
+static bool decode_ptr_key(zcbor_state_t *state, uint32_t *result)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool tmp_result =
+		((zcbor_tag_expect(state, 32773) && (zcbor_uint32_decode(state, (&(*result))))));
+
+	if (!tmp_result) {
+		zcbor_trace_file(state);
+		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
+	} else {
+		zcbor_log("%s success\r\n", __func__);
+	}
+
+	return tmp_result;
+}
+
 static bool decode_psa_copy_key_req(zcbor_state_t *state, struct psa_copy_key_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
@@ -220,8 +251,8 @@ static bool decode_psa_copy_key_req(zcbor_state_t *state, struct psa_copy_key_re
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (14)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_copy_key_req_source_key)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_copy_key_req_p_attributes)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_copy_key_req_p_target_key)))))));
+		   ((decode_ptr_attr(state, (&(*result).psa_copy_key_req_p_attributes)))) &&
+		   ((decode_ptr_key(state, (&(*result).psa_copy_key_req_p_target_key)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -251,16 +282,67 @@ static bool decode_psa_destroy_key_req(zcbor_state_t *state, struct psa_destroy_
 	return tmp_result;
 }
 
+static bool decode_ptr_buf(zcbor_state_t *state, uint32_t *result)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool tmp_result =
+		((zcbor_tag_expect(state, 32770) && (zcbor_uint32_decode(state, (&(*result))))));
+
+	if (!tmp_result) {
+		zcbor_trace_file(state);
+		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
+	} else {
+		zcbor_log("%s success\r\n", __func__);
+	}
+
+	return tmp_result;
+}
+
+static bool decode_buf_len(zcbor_state_t *state, uint32_t *result)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool tmp_result =
+		((zcbor_tag_expect(state, 32771) && (zcbor_uint32_decode(state, (&(*result))))));
+
+	if (!tmp_result) {
+		zcbor_trace_file(state);
+		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
+	} else {
+		zcbor_log("%s success\r\n", __func__);
+	}
+
+	return tmp_result;
+}
+
 static bool decode_psa_import_key_req(zcbor_state_t *state, struct psa_import_key_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (16)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_import_key_req_p_attributes)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_import_key_req_p_data)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_import_key_req_data_length)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_import_key_req_p_key)))))));
+		   ((decode_ptr_attr(state, (&(*result).psa_import_key_req_p_attributes)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_import_key_req_p_data)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_import_key_req_data_length)))) &&
+		   ((decode_ptr_key(state, (&(*result).psa_import_key_req_p_key)))))));
+
+	if (!tmp_result) {
+		zcbor_trace_file(state);
+		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
+	} else {
+		zcbor_log("%s success\r\n", __func__);
+	}
+
+	return tmp_result;
+}
+
+static bool decode_ptr_uint(zcbor_state_t *state, uint32_t *result)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool tmp_result =
+		((zcbor_tag_expect(state, 32774) && (zcbor_uint32_decode(state, (&(*result))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -279,9 +361,9 @@ static bool decode_psa_export_key_req(zcbor_state_t *state, struct psa_export_ke
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (17)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_export_key_req_key)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_export_key_req_p_data)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_export_key_req_data_size)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_export_key_req_p_data_length)))))));
+		   ((decode_ptr_buf(state, (&(*result).psa_export_key_req_p_data)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_export_key_req_data_size)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_export_key_req_p_data_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -298,13 +380,12 @@ static bool decode_psa_export_public_key_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_expect(state, (18)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_export_public_key_req_key)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_export_public_key_req_p_data)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_export_public_key_req_data_size)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_export_public_key_req_p_data_length)))))));
+	bool tmp_result = (((
+		((zcbor_uint32_expect(state, (18)))) &&
+		((zcbor_uint32_decode(state, (&(*result).psa_export_public_key_req_key)))) &&
+		((decode_ptr_buf(state, (&(*result).psa_export_public_key_req_p_data)))) &&
+		((decode_buf_len(state, (&(*result).psa_export_public_key_req_data_size)))) &&
+		((decode_ptr_uint(state, (&(*result).psa_export_public_key_req_p_data_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -320,14 +401,14 @@ static bool decode_psa_hash_compute_req(zcbor_state_t *state, struct psa_hash_co
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_expect(state, (19)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_hash_compute_req_alg)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_hash_compute_req_p_input)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_hash_compute_req_input_length)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_hash_compute_req_p_hash)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_hash_compute_req_hash_size)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_hash_compute_req_p_hash_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_expect(state, (19)))) &&
+		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_compute_req_alg)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_hash_compute_req_p_input)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_hash_compute_req_input_length)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_hash_compute_req_p_hash)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_hash_compute_req_hash_size)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_hash_compute_req_p_hash_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -346,10 +427,10 @@ static bool decode_psa_hash_compare_req(zcbor_state_t *state, struct psa_hash_co
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (20)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_compare_req_alg)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_compare_req_p_input)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_compare_req_input_length)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_compare_req_p_hash)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_compare_req_hash_length)))))));
+		   ((decode_ptr_buf(state, (&(*result).psa_hash_compare_req_p_input)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_hash_compare_req_input_length)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_hash_compare_req_p_hash)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_hash_compare_req_hash_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -365,10 +446,9 @@ static bool decode_psa_hash_setup_req(zcbor_state_t *state, struct psa_hash_setu
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (21)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_setup_req_p_handle)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_setup_req_alg)))))));
+	bool tmp_result = (((((zcbor_uint32_expect(state, (21)))) &&
+			     ((decode_ptr_uint(state, (&(*result).psa_hash_setup_req_p_handle)))) &&
+			     ((zcbor_uint32_decode(state, (&(*result).psa_hash_setup_req_alg)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -386,9 +466,9 @@ static bool decode_psa_hash_update_req(zcbor_state_t *state, struct psa_hash_upd
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (22)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_update_req_p_handle)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_update_req_p_input)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_update_req_input_length)))))));
+		   ((decode_ptr_uint(state, (&(*result).psa_hash_update_req_p_handle)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_hash_update_req_p_input)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_hash_update_req_input_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -404,12 +484,12 @@ static bool decode_psa_hash_finish_req(zcbor_state_t *state, struct psa_hash_fin
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_expect(state, (23)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_hash_finish_req_p_handle)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_hash_finish_req_p_hash)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_hash_finish_req_hash_size)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_hash_finish_req_p_hash_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_expect(state, (23)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_hash_finish_req_p_handle)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_hash_finish_req_p_hash)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_hash_finish_req_hash_size)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_hash_finish_req_p_hash_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -427,9 +507,9 @@ static bool decode_psa_hash_verify_req(zcbor_state_t *state, struct psa_hash_ver
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (24)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_verify_req_p_handle)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_verify_req_p_hash)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_verify_req_hash_length)))))));
+		   ((decode_ptr_uint(state, (&(*result).psa_hash_verify_req_p_handle)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_hash_verify_req_p_hash)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_hash_verify_req_hash_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -447,7 +527,7 @@ static bool decode_psa_hash_abort_req(zcbor_state_t *state, struct psa_hash_abor
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (25)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_abort_req_p_handle)))))));
+		   ((decode_ptr_uint(state, (&(*result).psa_hash_abort_req_p_handle)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -466,7 +546,7 @@ static bool decode_psa_hash_clone_req(zcbor_state_t *state, struct psa_hash_clon
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (26)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_clone_req_handle)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_clone_req_p_handle)))))));
+		   ((decode_ptr_uint(state, (&(*result).psa_hash_clone_req_p_handle)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -486,11 +566,11 @@ static bool decode_psa_mac_compute_req(zcbor_state_t *state, struct psa_mac_comp
 		(((((zcbor_uint32_expect(state, (27)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_compute_req_key)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_compute_req_alg)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_compute_req_p_input)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_compute_req_input_length)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_compute_req_p_mac)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_compute_req_mac_size)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_compute_req_p_mac_length)))))));
+		   ((decode_ptr_buf(state, (&(*result).psa_mac_compute_req_p_input)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_mac_compute_req_input_length)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_mac_compute_req_p_mac)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_mac_compute_req_mac_size)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_mac_compute_req_p_mac_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -510,10 +590,10 @@ static bool decode_psa_mac_verify_req(zcbor_state_t *state, struct psa_mac_verif
 		(((((zcbor_uint32_expect(state, (28)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_verify_req_key)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_verify_req_alg)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_verify_req_p_input)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_verify_req_input_length)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_verify_req_p_mac)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_verify_req_mac_length)))))));
+		   ((decode_ptr_buf(state, (&(*result).psa_mac_verify_req_p_input)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_mac_verify_req_input_length)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_mac_verify_req_p_mac)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_mac_verify_req_mac_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -532,7 +612,7 @@ static bool decode_psa_mac_sign_setup_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (29)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_sign_setup_req_p_handle)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_mac_sign_setup_req_p_handle)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_sign_setup_req_key)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_sign_setup_req_alg)))))));
 
@@ -553,7 +633,7 @@ static bool decode_psa_mac_verify_setup_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (30)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_verify_setup_req_p_handle)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_mac_verify_setup_req_p_handle)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_verify_setup_req_key)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_verify_setup_req_alg)))))));
 
@@ -573,9 +653,9 @@ static bool decode_psa_mac_update_req(zcbor_state_t *state, struct psa_mac_updat
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (31)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_update_req_p_handle)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_update_req_p_input)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_update_req_input_length)))))));
+		   ((decode_ptr_uint(state, (&(*result).psa_mac_update_req_p_handle)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_mac_update_req_p_input)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_mac_update_req_input_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -594,11 +674,10 @@ static bool decode_psa_mac_sign_finish_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (32)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_sign_finish_req_p_handle)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_sign_finish_req_p_mac)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_sign_finish_req_mac_size)))) &&
-		   ((zcbor_uint32_decode(state,
-					 (&(*result).psa_mac_sign_finish_req_p_mac_length)))))));
+		   ((decode_ptr_uint(state, (&(*result).psa_mac_sign_finish_req_p_handle)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_mac_sign_finish_req_p_mac)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_mac_sign_finish_req_mac_size)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_mac_sign_finish_req_p_mac_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -615,12 +694,11 @@ static bool decode_psa_mac_verify_finish_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_expect(state, (33)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_mac_verify_finish_req_p_handle)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_mac_verify_finish_req_p_mac)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_mac_verify_finish_req_mac_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_expect(state, (33)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_mac_verify_finish_req_p_handle)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_mac_verify_finish_req_p_mac)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_mac_verify_finish_req_mac_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -636,9 +714,8 @@ static bool decode_psa_mac_abort_req(zcbor_state_t *state, struct psa_mac_abort_
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (34)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_abort_req_p_handle)))))));
+	bool tmp_result = (((((zcbor_uint32_expect(state, (34)))) &&
+			     ((decode_ptr_uint(state, (&(*result).psa_mac_abort_req_p_handle)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -659,12 +736,11 @@ static bool decode_psa_cipher_encrypt_req(zcbor_state_t *state,
 		(((zcbor_uint32_expect(state, (35)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_encrypt_req_key)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_encrypt_req_alg)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_encrypt_req_p_input)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_encrypt_req_input_length)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_encrypt_req_p_output)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_encrypt_req_output_size)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_cipher_encrypt_req_p_output_length)))))));
+		 ((decode_ptr_buf(state, (&(*result).psa_cipher_encrypt_req_p_input)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_cipher_encrypt_req_input_length)))) &&
+		 ((decode_ptr_buf(state, (&(*result).psa_cipher_encrypt_req_p_output)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_cipher_encrypt_req_output_size)))) &&
+		 ((decode_ptr_uint(state, (&(*result).psa_cipher_encrypt_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -685,12 +761,11 @@ static bool decode_psa_cipher_decrypt_req(zcbor_state_t *state,
 		(((zcbor_uint32_expect(state, (36)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_decrypt_req_key)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_decrypt_req_alg)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_decrypt_req_p_input)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_decrypt_req_input_length)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_decrypt_req_p_output)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_decrypt_req_output_size)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_cipher_decrypt_req_p_output_length)))))));
+		 ((decode_ptr_buf(state, (&(*result).psa_cipher_decrypt_req_p_input)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_cipher_decrypt_req_input_length)))) &&
+		 ((decode_ptr_buf(state, (&(*result).psa_cipher_decrypt_req_p_output)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_cipher_decrypt_req_output_size)))) &&
+		 ((decode_ptr_uint(state, (&(*result).psa_cipher_decrypt_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -709,8 +784,7 @@ static bool decode_psa_cipher_encrypt_setup_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (37)))) &&
-		   ((zcbor_uint32_decode(state,
-					 (&(*result).psa_cipher_encrypt_setup_req_p_handle)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_cipher_encrypt_setup_req_p_handle)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_cipher_encrypt_setup_req_key)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_cipher_encrypt_setup_req_alg)))))));
 
@@ -731,8 +805,7 @@ static bool decode_psa_cipher_decrypt_setup_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (38)))) &&
-		   ((zcbor_uint32_decode(state,
-					 (&(*result).psa_cipher_decrypt_setup_req_p_handle)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_cipher_decrypt_setup_req_p_handle)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_cipher_decrypt_setup_req_key)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_cipher_decrypt_setup_req_alg)))))));
 
@@ -753,11 +826,10 @@ static bool decode_psa_cipher_generate_iv_req(zcbor_state_t *state,
 
 	bool tmp_result = ((
 		(((zcbor_uint32_expect(state, (39)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_generate_iv_req_p_handle)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_generate_iv_req_p_iv)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_generate_iv_req_iv_size)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_cipher_generate_iv_req_p_iv_length)))))));
+		 ((decode_ptr_uint(state, (&(*result).psa_cipher_generate_iv_req_p_handle)))) &&
+		 ((decode_ptr_buf(state, (&(*result).psa_cipher_generate_iv_req_p_iv)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_cipher_generate_iv_req_iv_size)))) &&
+		 ((decode_ptr_uint(state, (&(*result).psa_cipher_generate_iv_req_p_iv_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -775,9 +847,9 @@ static bool decode_psa_cipher_set_iv_req(zcbor_state_t *state, struct psa_cipher
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (40)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_cipher_set_iv_req_p_handle)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_cipher_set_iv_req_p_iv)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_cipher_set_iv_req_iv_length)))))));
+		   ((decode_ptr_uint(state, (&(*result).psa_cipher_set_iv_req_p_handle)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_cipher_set_iv_req_p_iv)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_cipher_set_iv_req_iv_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -795,13 +867,12 @@ static bool decode_psa_cipher_update_req(zcbor_state_t *state, struct psa_cipher
 
 	bool tmp_result = ((
 		(((zcbor_uint32_expect(state, (41)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_update_req_p_handle)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_update_req_p_input)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_update_req_input_length)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_update_req_p_output)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_update_req_output_size)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_cipher_update_req_p_output_length)))))));
+		 ((decode_ptr_uint(state, (&(*result).psa_cipher_update_req_p_handle)))) &&
+		 ((decode_ptr_buf(state, (&(*result).psa_cipher_update_req_p_input)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_cipher_update_req_input_length)))) &&
+		 ((decode_ptr_buf(state, (&(*result).psa_cipher_update_req_p_output)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_cipher_update_req_output_size)))) &&
+		 ((decode_ptr_uint(state, (&(*result).psa_cipher_update_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -817,13 +888,12 @@ static bool decode_psa_cipher_finish_req(zcbor_state_t *state, struct psa_cipher
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (42)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_cipher_finish_req_p_handle)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_cipher_finish_req_p_output)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_cipher_finish_req_output_size)))) &&
-		   ((zcbor_uint32_decode(state,
-					 (&(*result).psa_cipher_finish_req_p_output_length)))))));
+	bool tmp_result = ((
+		(((zcbor_uint32_expect(state, (42)))) &&
+		 ((decode_ptr_uint(state, (&(*result).psa_cipher_finish_req_p_handle)))) &&
+		 ((decode_ptr_buf(state, (&(*result).psa_cipher_finish_req_p_output)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_cipher_finish_req_output_size)))) &&
+		 ((decode_ptr_uint(state, (&(*result).psa_cipher_finish_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -841,7 +911,7 @@ static bool decode_psa_cipher_abort_req(zcbor_state_t *state, struct psa_cipher_
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (43)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_cipher_abort_req_p_handle)))))));
+		   ((decode_ptr_uint(state, (&(*result).psa_cipher_abort_req_p_handle)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -857,23 +927,21 @@ static bool decode_psa_aead_encrypt_req(zcbor_state_t *state, struct psa_aead_en
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
-		((zcbor_uint32_expect(state, (44)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_encrypt_req_key)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_encrypt_req_alg)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_encrypt_req_p_nonce)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_encrypt_req_nonce_length)))) &&
-		((zcbor_uint32_decode(state,
-				      (&(*result).psa_aead_encrypt_req_p_additional_data)))) &&
-		((zcbor_uint32_decode(state,
-				      (&(*result).psa_aead_encrypt_req_additional_data_length)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_encrypt_req_p_plaintext)))) &&
-		((zcbor_uint32_decode(state,
-				      (&(*result).psa_aead_encrypt_req_plaintext_length)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_encrypt_req_p_ciphertext)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_encrypt_req_ciphertext_size)))) &&
-		((zcbor_uint32_decode(state,
-				      (&(*result).psa_aead_encrypt_req_p_ciphertext_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_expect(state, (44)))) &&
+		   ((zcbor_uint32_decode(state, (&(*result).psa_aead_encrypt_req_key)))) &&
+		   ((zcbor_uint32_decode(state, (&(*result).psa_aead_encrypt_req_alg)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_aead_encrypt_req_p_nonce)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_aead_encrypt_req_nonce_length)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_aead_encrypt_req_p_additional_data)))) &&
+		   ((decode_buf_len(state,
+				    (&(*result).psa_aead_encrypt_req_additional_data_length)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_aead_encrypt_req_p_plaintext)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_aead_encrypt_req_plaintext_length)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_aead_encrypt_req_p_ciphertext)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_aead_encrypt_req_ciphertext_size)))) &&
+		   ((decode_ptr_uint(state,
+				     (&(*result).psa_aead_encrypt_req_p_ciphertext_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -889,23 +957,20 @@ static bool decode_psa_aead_decrypt_req(zcbor_state_t *state, struct psa_aead_de
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_expect(state, (45)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_decrypt_req_key)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_decrypt_req_alg)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_decrypt_req_p_nonce)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_decrypt_req_nonce_length)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_aead_decrypt_req_p_additional_data)))) &&
-		 ((zcbor_uint32_decode(
-			 state, (&(*result).psa_aead_decrypt_req_additional_data_length)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_decrypt_req_p_ciphertext)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_aead_decrypt_req_ciphertext_length)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_decrypt_req_p_plaintext)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_decrypt_req_plaintext_size)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_aead_decrypt_req_p_plaintext_length)))))));
+	bool tmp_result = (((
+		((zcbor_uint32_expect(state, (45)))) &&
+		((zcbor_uint32_decode(state, (&(*result).psa_aead_decrypt_req_key)))) &&
+		((zcbor_uint32_decode(state, (&(*result).psa_aead_decrypt_req_alg)))) &&
+		((decode_ptr_buf(state, (&(*result).psa_aead_decrypt_req_p_nonce)))) &&
+		((decode_buf_len(state, (&(*result).psa_aead_decrypt_req_nonce_length)))) &&
+		((decode_ptr_buf(state, (&(*result).psa_aead_decrypt_req_p_additional_data)))) &&
+		((decode_buf_len(state,
+				 (&(*result).psa_aead_decrypt_req_additional_data_length)))) &&
+		((decode_ptr_buf(state, (&(*result).psa_aead_decrypt_req_p_ciphertext)))) &&
+		((decode_buf_len(state, (&(*result).psa_aead_decrypt_req_ciphertext_length)))) &&
+		((decode_ptr_buf(state, (&(*result).psa_aead_decrypt_req_p_plaintext)))) &&
+		((decode_buf_len(state, (&(*result).psa_aead_decrypt_req_plaintext_size)))) &&
+		((decode_ptr_uint(state, (&(*result).psa_aead_decrypt_req_p_plaintext_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -922,11 +987,11 @@ static bool decode_psa_aead_encrypt_setup_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_expect(state, (46)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_encrypt_setup_req_p_handle)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_encrypt_setup_req_key)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_encrypt_setup_req_alg)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_expect(state, (46)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_aead_encrypt_setup_req_p_handle)))) &&
+		   ((zcbor_uint32_decode(state, (&(*result).psa_aead_encrypt_setup_req_key)))) &&
+		   ((zcbor_uint32_decode(state, (&(*result).psa_aead_encrypt_setup_req_alg)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -943,11 +1008,11 @@ static bool decode_psa_aead_decrypt_setup_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_expect(state, (47)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_decrypt_setup_req_p_handle)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_decrypt_setup_req_key)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_decrypt_setup_req_alg)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_expect(state, (47)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_aead_decrypt_setup_req_p_handle)))) &&
+		   ((zcbor_uint32_decode(state, (&(*result).psa_aead_decrypt_setup_req_key)))) &&
+		   ((zcbor_uint32_decode(state, (&(*result).psa_aead_decrypt_setup_req_alg)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -964,14 +1029,13 @@ static bool decode_psa_aead_generate_nonce_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
-		((zcbor_uint32_expect(state, (48)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_generate_nonce_req_p_handle)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_generate_nonce_req_p_nonce)))) &&
-		((zcbor_uint32_decode(state,
-				      (&(*result).psa_aead_generate_nonce_req_nonce_size)))) &&
-		((zcbor_uint32_decode(state,
-				      (&(*result).psa_aead_generate_nonce_req_p_nonce_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_expect(state, (48)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_aead_generate_nonce_req_p_handle)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_aead_generate_nonce_req_p_nonce)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_aead_generate_nonce_req_nonce_size)))) &&
+		   ((decode_ptr_uint(state,
+				     (&(*result).psa_aead_generate_nonce_req_p_nonce_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -988,11 +1052,11 @@ static bool decode_psa_aead_set_nonce_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
-		((zcbor_uint32_expect(state, (49)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_set_nonce_req_p_handle)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_set_nonce_req_p_nonce)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_set_nonce_req_nonce_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_expect(state, (49)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_aead_set_nonce_req_p_handle)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_aead_set_nonce_req_p_nonce)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_aead_set_nonce_req_nonce_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1009,12 +1073,12 @@ static bool decode_psa_aead_set_lengths_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_expect(state, (50)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_set_lengths_req_p_handle)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_set_lengths_req_ad_length)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_aead_set_lengths_req_plaintext_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_expect(state, (50)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_aead_set_lengths_req_p_handle)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_aead_set_lengths_req_ad_length)))) &&
+		   ((decode_buf_len(state,
+				    (&(*result).psa_aead_set_lengths_req_plaintext_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1031,11 +1095,11 @@ static bool decode_psa_aead_update_ad_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
-		((zcbor_uint32_expect(state, (51)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_update_ad_req_p_handle)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_update_ad_req_p_input)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_update_ad_req_input_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_expect(state, (51)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_aead_update_ad_req_p_handle)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_aead_update_ad_req_p_input)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_aead_update_ad_req_input_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1051,14 +1115,14 @@ static bool decode_psa_aead_update_req(zcbor_state_t *state, struct psa_aead_upd
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
-		((zcbor_uint32_expect(state, (52)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_update_req_p_handle)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_update_req_p_input)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_update_req_input_length)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_update_req_p_output)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_update_req_output_size)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_update_req_p_output_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_expect(state, (52)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_aead_update_req_p_handle)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_aead_update_req_p_input)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_aead_update_req_input_length)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_aead_update_req_p_output)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_aead_update_req_output_size)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_aead_update_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1076,14 +1140,13 @@ static bool decode_psa_aead_finish_req(zcbor_state_t *state, struct psa_aead_fin
 
 	bool tmp_result = ((
 		(((zcbor_uint32_expect(state, (53)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_finish_req_p_handle)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_finish_req_p_ciphertext)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_finish_req_ciphertext_size)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_aead_finish_req_p_ciphertext_length)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_finish_req_p_tag)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_finish_req_tag_size)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_finish_req_p_tag_length)))))));
+		 ((decode_ptr_uint(state, (&(*result).psa_aead_finish_req_p_handle)))) &&
+		 ((decode_ptr_buf(state, (&(*result).psa_aead_finish_req_p_ciphertext)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_aead_finish_req_ciphertext_size)))) &&
+		 ((decode_ptr_uint(state, (&(*result).psa_aead_finish_req_p_ciphertext_length)))) &&
+		 ((decode_ptr_buf(state, (&(*result).psa_aead_finish_req_p_tag)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_aead_finish_req_tag_size)))) &&
+		 ((decode_ptr_uint(state, (&(*result).psa_aead_finish_req_p_tag_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1101,13 +1164,12 @@ static bool decode_psa_aead_verify_req(zcbor_state_t *state, struct psa_aead_ver
 
 	bool tmp_result = ((
 		(((zcbor_uint32_expect(state, (54)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_verify_req_p_handle)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_verify_req_p_plaintext)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_verify_req_plaintext_size)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_aead_verify_req_p_plaintext_length)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_verify_req_p_tag)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_verify_req_tag_length)))))));
+		 ((decode_ptr_uint(state, (&(*result).psa_aead_verify_req_p_handle)))) &&
+		 ((decode_ptr_buf(state, (&(*result).psa_aead_verify_req_p_plaintext)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_aead_verify_req_plaintext_size)))) &&
+		 ((decode_ptr_uint(state, (&(*result).psa_aead_verify_req_p_plaintext_length)))) &&
+		 ((decode_ptr_buf(state, (&(*result).psa_aead_verify_req_p_tag)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_aead_verify_req_tag_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1125,7 +1187,7 @@ static bool decode_psa_aead_abort_req(zcbor_state_t *state, struct psa_aead_abor
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (55)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_aead_abort_req_p_handle)))))));
+		   ((decode_ptr_uint(state, (&(*result).psa_aead_abort_req_p_handle)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1141,16 +1203,15 @@ static bool decode_psa_sign_message_req(zcbor_state_t *state, struct psa_sign_me
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_expect(state, (56)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_sign_message_req_key)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_sign_message_req_alg)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_sign_message_req_p_input)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_sign_message_req_input_length)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_sign_message_req_p_signature)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_sign_message_req_signature_size)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_sign_message_req_p_signature_length)))))));
+	bool tmp_result = (((
+		((zcbor_uint32_expect(state, (56)))) &&
+		((zcbor_uint32_decode(state, (&(*result).psa_sign_message_req_key)))) &&
+		((zcbor_uint32_decode(state, (&(*result).psa_sign_message_req_alg)))) &&
+		((decode_ptr_buf(state, (&(*result).psa_sign_message_req_p_input)))) &&
+		((decode_buf_len(state, (&(*result).psa_sign_message_req_input_length)))) &&
+		((decode_ptr_buf(state, (&(*result).psa_sign_message_req_p_signature)))) &&
+		((decode_buf_len(state, (&(*result).psa_sign_message_req_signature_size)))) &&
+		((decode_ptr_uint(state, (&(*result).psa_sign_message_req_p_signature_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1171,11 +1232,10 @@ static bool decode_psa_verify_message_req(zcbor_state_t *state,
 		(((zcbor_uint32_expect(state, (57)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_verify_message_req_key)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_verify_message_req_alg)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_verify_message_req_p_input)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_verify_message_req_input_length)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_verify_message_req_p_signature)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_verify_message_req_signature_length)))))));
+		 ((decode_ptr_buf(state, (&(*result).psa_verify_message_req_p_input)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_verify_message_req_input_length)))) &&
+		 ((decode_ptr_buf(state, (&(*result).psa_verify_message_req_p_signature)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_verify_message_req_signature_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1195,12 +1255,11 @@ static bool decode_psa_sign_hash_req(zcbor_state_t *state, struct psa_sign_hash_
 		(((((zcbor_uint32_expect(state, (58)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_sign_hash_req_key)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_sign_hash_req_alg)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_sign_hash_req_p_hash)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_sign_hash_req_hash_length)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_sign_hash_req_p_signature)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_sign_hash_req_signature_size)))) &&
-		   ((zcbor_uint32_decode(state,
-					 (&(*result).psa_sign_hash_req_p_signature_length)))))));
+		   ((decode_ptr_buf(state, (&(*result).psa_sign_hash_req_p_hash)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_sign_hash_req_hash_length)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_sign_hash_req_p_signature)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_sign_hash_req_signature_size)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_sign_hash_req_p_signature_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1220,11 +1279,10 @@ static bool decode_psa_verify_hash_req(zcbor_state_t *state, struct psa_verify_h
 		(((((zcbor_uint32_expect(state, (59)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_verify_hash_req_key)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_verify_hash_req_alg)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_verify_hash_req_p_hash)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_verify_hash_req_hash_length)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_verify_hash_req_p_signature)))) &&
-		   ((zcbor_uint32_decode(state,
-					 (&(*result).psa_verify_hash_req_signature_length)))))));
+		   ((decode_ptr_buf(state, (&(*result).psa_verify_hash_req_p_hash)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_verify_hash_req_hash_length)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_verify_hash_req_p_signature)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_verify_hash_req_signature_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1245,17 +1303,14 @@ static bool decode_psa_asymmetric_encrypt_req(zcbor_state_t *state,
 		(((zcbor_uint32_expect(state, (60)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_asymmetric_encrypt_req_key)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_asymmetric_encrypt_req_alg)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_asymmetric_encrypt_req_p_input)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_asymmetric_encrypt_req_input_length)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_asymmetric_encrypt_req_p_salt)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_asymmetric_encrypt_req_salt_length)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_asymmetric_encrypt_req_p_output)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_asymmetric_encrypt_req_output_size)))) &&
-		 ((zcbor_uint32_decode(
-			 state, (&(*result).psa_asymmetric_encrypt_req_p_output_length)))))));
+		 ((decode_ptr_buf(state, (&(*result).psa_asymmetric_encrypt_req_p_input)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_asymmetric_encrypt_req_input_length)))) &&
+		 ((decode_ptr_buf(state, (&(*result).psa_asymmetric_encrypt_req_p_salt)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_asymmetric_encrypt_req_salt_length)))) &&
+		 ((decode_ptr_buf(state, (&(*result).psa_asymmetric_encrypt_req_p_output)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_asymmetric_encrypt_req_output_size)))) &&
+		 ((decode_ptr_uint(state,
+				   (&(*result).psa_asymmetric_encrypt_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1276,17 +1331,14 @@ static bool decode_psa_asymmetric_decrypt_req(zcbor_state_t *state,
 		(((zcbor_uint32_expect(state, (61)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_asymmetric_decrypt_req_key)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_asymmetric_decrypt_req_alg)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_asymmetric_decrypt_req_p_input)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_asymmetric_decrypt_req_input_length)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_asymmetric_decrypt_req_p_salt)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_asymmetric_decrypt_req_salt_length)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_asymmetric_decrypt_req_p_output)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_asymmetric_decrypt_req_output_size)))) &&
-		 ((zcbor_uint32_decode(
-			 state, (&(*result).psa_asymmetric_decrypt_req_p_output_length)))))));
+		 ((decode_ptr_buf(state, (&(*result).psa_asymmetric_decrypt_req_p_input)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_asymmetric_decrypt_req_input_length)))) &&
+		 ((decode_ptr_buf(state, (&(*result).psa_asymmetric_decrypt_req_p_salt)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_asymmetric_decrypt_req_salt_length)))) &&
+		 ((decode_ptr_buf(state, (&(*result).psa_asymmetric_decrypt_req_p_output)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_asymmetric_decrypt_req_output_size)))) &&
+		 ((decode_ptr_uint(state,
+				   (&(*result).psa_asymmetric_decrypt_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1305,8 +1357,7 @@ static bool decode_psa_key_derivation_setup_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (62)))) &&
-		   ((zcbor_uint32_decode(state,
-					 (&(*result).psa_key_derivation_setup_req_p_handle)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_key_derivation_setup_req_p_handle)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_key_derivation_setup_req_alg)))))));
 
 	if (!tmp_result) {
@@ -1329,7 +1380,7 @@ decode_psa_key_derivation_get_capacity_req(zcbor_state_t *state,
 		(((((zcbor_uint32_expect(state, (63)))) &&
 		   ((zcbor_uint32_decode(
 			   state, (&(*result).psa_key_derivation_get_capacity_req_handle)))) &&
-		   ((zcbor_uint32_decode(
+		   ((decode_ptr_uint(
 			   state, (&(*result).psa_key_derivation_get_capacity_req_p_capacity)))))));
 
 	if (!tmp_result) {
@@ -1350,8 +1401,8 @@ decode_psa_key_derivation_set_capacity_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (64)))) &&
-		   ((zcbor_uint32_decode(
-			   state, (&(*result).psa_key_derivation_set_capacity_req_p_handle)))) &&
+		   ((decode_ptr_uint(state,
+				     (&(*result).psa_key_derivation_set_capacity_req_p_handle)))) &&
 		   ((zcbor_uint32_decode(
 			   state, (&(*result).psa_key_derivation_set_capacity_req_capacity)))))));
 
@@ -1371,16 +1422,15 @@ decode_psa_key_derivation_input_bytes_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (65)))) &&
-		   ((zcbor_uint32_decode(
-			   state, (&(*result).psa_key_derivation_input_bytes_req_p_handle)))) &&
-		   ((zcbor_uint32_decode(state,
-					 (&(*result).psa_key_derivation_input_bytes_req_step)))) &&
-		   ((zcbor_uint32_decode(
-			   state, (&(*result).psa_key_derivation_input_bytes_req_p_data)))) &&
-		   ((zcbor_uint32_decode(
-			   state, (&(*result).psa_key_derivation_input_bytes_req_data_length)))))));
+	bool tmp_result = (((
+		((zcbor_uint32_expect(state, (65)))) &&
+		((decode_ptr_uint(state,
+				  (&(*result).psa_key_derivation_input_bytes_req_p_handle)))) &&
+		((zcbor_uint32_decode(state,
+				      (&(*result).psa_key_derivation_input_bytes_req_step)))) &&
+		((decode_ptr_buf(state, (&(*result).psa_key_derivation_input_bytes_req_p_data)))) &&
+		((decode_buf_len(state,
+				 (&(*result).psa_key_derivation_input_bytes_req_data_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1400,7 +1450,7 @@ decode_psa_key_derivation_input_integer_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (66)))) &&
-		   ((zcbor_uint32_decode(
+		   ((decode_ptr_uint(
 			   state, (&(*result).psa_key_derivation_input_integer_req_p_handle)))) &&
 		   ((zcbor_uint32_decode(
 			   state, (&(*result).psa_key_derivation_input_integer_req_step)))) &&
@@ -1424,8 +1474,8 @@ static bool decode_psa_key_derivation_input_key_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (67)))) &&
-		   ((zcbor_uint32_decode(
-			   state, (&(*result).psa_key_derivation_input_key_req_p_handle)))) &&
+		   ((decode_ptr_uint(state,
+				     (&(*result).psa_key_derivation_input_key_req_p_handle)))) &&
 		   ((zcbor_uint32_decode(state,
 					 (&(*result).psa_key_derivation_input_key_req_step)))) &&
 		   ((zcbor_uint32_decode(state,
@@ -1449,15 +1499,15 @@ decode_psa_key_derivation_key_agreement_req(zcbor_state_t *state,
 
 	bool tmp_result = ((
 		(((zcbor_uint32_expect(state, (68)))) &&
-		 ((zcbor_uint32_decode(
-			 state, (&(*result).psa_key_derivation_key_agreement_req_p_handle)))) &&
+		 ((decode_ptr_uint(state,
+				   (&(*result).psa_key_derivation_key_agreement_req_p_handle)))) &&
 		 ((zcbor_uint32_decode(state,
 				       (&(*result).psa_key_derivation_key_agreement_req_step)))) &&
 		 ((zcbor_uint32_decode(
 			 state, (&(*result).psa_key_derivation_key_agreement_req_private_key)))) &&
-		 ((zcbor_uint32_decode(
-			 state, (&(*result).psa_key_derivation_key_agreement_req_p_peer_key)))) &&
-		 ((zcbor_uint32_decode(
+		 ((decode_ptr_buf(state,
+				  (&(*result).psa_key_derivation_key_agreement_req_p_peer_key)))) &&
+		 ((decode_buf_len(
 			 state,
 			 (&(*result).psa_key_derivation_key_agreement_req_peer_key_length)))))));
 
@@ -1479,11 +1529,11 @@ decode_psa_key_derivation_output_bytes_req(zcbor_state_t *state,
 
 	bool tmp_result = (((
 		((zcbor_uint32_expect(state, (69)))) &&
-		((zcbor_uint32_decode(
-			state, (&(*result).psa_key_derivation_output_bytes_req_p_handle)))) &&
-		((zcbor_uint32_decode(
-			state, (&(*result).psa_key_derivation_output_bytes_req_p_output)))) &&
-		((zcbor_uint32_decode(
+		((decode_ptr_uint(state,
+				  (&(*result).psa_key_derivation_output_bytes_req_p_handle)))) &&
+		((decode_ptr_buf(state,
+				 (&(*result).psa_key_derivation_output_bytes_req_p_output)))) &&
+		((decode_buf_len(
 			state, (&(*result).psa_key_derivation_output_bytes_req_output_length)))))));
 
 	if (!tmp_result) {
@@ -1502,14 +1552,13 @@ decode_psa_key_derivation_output_key_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (70)))) &&
-		   ((zcbor_uint32_decode(
-			   state, (&(*result).psa_key_derivation_output_key_req_p_attributes)))) &&
-		   ((zcbor_uint32_decode(
-			   state, (&(*result).psa_key_derivation_output_key_req_p_handle)))) &&
-		   ((zcbor_uint32_decode(state,
-					 (&(*result).psa_key_derivation_output_key_req_p_key)))))));
+	bool tmp_result = ((
+		(((zcbor_uint32_expect(state, (70)))) &&
+		 ((decode_ptr_attr(state,
+				   (&(*result).psa_key_derivation_output_key_req_p_attributes)))) &&
+		 ((decode_ptr_uint(state,
+				   (&(*result).psa_key_derivation_output_key_req_p_handle)))) &&
+		 ((decode_ptr_key(state, (&(*result).psa_key_derivation_output_key_req_p_key)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1526,10 +1575,9 @@ static bool decode_psa_key_derivation_abort_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (71)))) &&
-		   ((zcbor_uint32_decode(state,
-					 (&(*result).psa_key_derivation_abort_req_p_handle)))))));
+	bool tmp_result = ((
+		(((zcbor_uint32_expect(state, (71)))) &&
+		 ((decode_ptr_uint(state, (&(*result).psa_key_derivation_abort_req_p_handle)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1551,14 +1599,12 @@ static bool decode_psa_raw_key_agreement_req(zcbor_state_t *state,
 		((zcbor_uint32_decode(state, (&(*result).psa_raw_key_agreement_req_alg)))) &&
 		((zcbor_uint32_decode(state,
 				      (&(*result).psa_raw_key_agreement_req_private_key)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_raw_key_agreement_req_p_peer_key)))) &&
-		((zcbor_uint32_decode(state,
-				      (&(*result).psa_raw_key_agreement_req_peer_key_length)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_raw_key_agreement_req_p_output)))) &&
-		((zcbor_uint32_decode(state,
-				      (&(*result).psa_raw_key_agreement_req_output_size)))) &&
-		((zcbor_uint32_decode(state,
-				      (&(*result).psa_raw_key_agreement_req_p_output_length)))))));
+		((decode_ptr_buf(state, (&(*result).psa_raw_key_agreement_req_p_peer_key)))) &&
+		((decode_buf_len(state, (&(*result).psa_raw_key_agreement_req_peer_key_length)))) &&
+		((decode_ptr_buf(state, (&(*result).psa_raw_key_agreement_req_p_output)))) &&
+		((decode_buf_len(state, (&(*result).psa_raw_key_agreement_req_output_size)))) &&
+		((decode_ptr_uint(state,
+				  (&(*result).psa_raw_key_agreement_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1575,10 +1621,10 @@ static bool decode_psa_generate_random_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
-		((zcbor_uint32_expect(state, (73)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_generate_random_req_p_output)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_generate_random_req_output_size)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_expect(state, (73)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_generate_random_req_p_output)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_generate_random_req_output_size)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1596,8 +1642,8 @@ static bool decode_psa_generate_key_req(zcbor_state_t *state, struct psa_generat
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (74)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_generate_key_req_p_attributes)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_generate_key_req_p_key)))))));
+		   ((decode_ptr_attr(state, (&(*result).psa_generate_key_req_p_attributes)))) &&
+		   ((decode_ptr_key(state, (&(*result).psa_generate_key_req_p_key)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1609,86 +1655,12 @@ static bool decode_psa_generate_key_req(zcbor_state_t *state, struct psa_generat
 	return tmp_result;
 }
 
-static bool decode_psa_sign_hash_start_req(zcbor_state_t *state,
-					   struct psa_sign_hash_start_req *result)
-{
-	zcbor_log("%s\r\n", __func__);
-
-	bool tmp_result = (((
-		((zcbor_uint32_expect(state, (75)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_sign_hash_start_req_p_operation)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_sign_hash_start_req_key)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_sign_hash_start_req_alg)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_sign_hash_start_req_p_hash)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_sign_hash_start_req_hash_length)))))));
-
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
-}
-
-static bool decode_psa_sign_hash_abort_req(zcbor_state_t *state,
-					   struct psa_sign_hash_abort_req *result)
-{
-	zcbor_log("%s\r\n", __func__);
-
-	bool tmp_result = (((
-		((zcbor_uint32_expect(state, (76)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_sign_hash_abort_req_p_operation)))))));
-
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
-}
-
-static bool decode_psa_verify_hash_start_req(zcbor_state_t *state,
-					     struct psa_verify_hash_start_req *result)
+static bool decode_ptr_cipher(zcbor_state_t *state, uint32_t *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
 	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (77)))) &&
-		   ((zcbor_uint32_decode(state,
-					 (&(*result).psa_verify_hash_start_req_p_operation)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_verify_hash_start_req_key)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_verify_hash_start_req_alg)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_verify_hash_start_req_p_hash)))) &&
-		   ((zcbor_uint32_decode(state,
-					 (&(*result).psa_verify_hash_start_req_hash_length)))) &&
-		   ((zcbor_uint32_decode(state,
-					 (&(*result).psa_verify_hash_start_req_p_signature)))) &&
-		   ((zcbor_uint32_decode(
-			   state, (&(*result).psa_verify_hash_start_req_signature_length)))))));
-
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
-}
-
-static bool decode_psa_verify_hash_abort_req(zcbor_state_t *state,
-					     struct psa_verify_hash_abort_req *result)
-{
-	zcbor_log("%s\r\n", __func__);
-
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (78)))) &&
-		   ((zcbor_uint32_decode(state,
-					 (&(*result).psa_verify_hash_abort_req_p_operation)))))));
+		((zcbor_tag_expect(state, 32775) && (zcbor_uint32_decode(state, (&(*result))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1704,11 +1676,11 @@ static bool decode_psa_pake_setup_req(zcbor_state_t *state, struct psa_pake_setu
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_expect(state, (79)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_pake_setup_req_p_handle)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_pake_setup_req_password_key)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_pake_setup_req_p_cipher_suite)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_expect(state, (75)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_pake_setup_req_p_handle)))) &&
+		   ((zcbor_uint32_decode(state, (&(*result).psa_pake_setup_req_password_key)))) &&
+		   ((decode_ptr_cipher(state, (&(*result).psa_pake_setup_req_p_cipher_suite)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1725,8 +1697,8 @@ static bool decode_psa_pake_set_role_req(zcbor_state_t *state, struct psa_pake_s
 	zcbor_log("%s\r\n", __func__);
 
 	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (80)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_pake_set_role_req_p_handle)))) &&
+		(((((zcbor_uint32_expect(state, (76)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_pake_set_role_req_p_handle)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_pake_set_role_req_role)))))));
 
 	if (!tmp_result) {
@@ -1743,11 +1715,11 @@ static bool decode_psa_pake_set_user_req(zcbor_state_t *state, struct psa_pake_s
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_expect(state, (81)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_pake_set_user_req_p_handle)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_pake_set_user_req_p_user_id)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_pake_set_user_req_user_id_len)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_expect(state, (77)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_pake_set_user_req_p_handle)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_pake_set_user_req_p_user_id)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_pake_set_user_req_user_id_len)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1763,11 +1735,11 @@ static bool decode_psa_pake_set_peer_req(zcbor_state_t *state, struct psa_pake_s
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_expect(state, (82)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_pake_set_peer_req_p_handle)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_pake_set_peer_req_p_peer_id)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_pake_set_peer_req_peer_id_len)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_expect(state, (78)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_pake_set_peer_req_p_handle)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_pake_set_peer_req_p_peer_id)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_pake_set_peer_req_peer_id_len)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1784,12 +1756,11 @@ static bool decode_psa_pake_set_context_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_expect(state, (83)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_pake_set_context_req_p_handle)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_pake_set_context_req_p_context)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_pake_set_context_req_context_len)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_expect(state, (79)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_pake_set_context_req_p_handle)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_pake_set_context_req_p_context)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_pake_set_context_req_context_len)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1805,13 +1776,13 @@ static bool decode_psa_pake_output_req(zcbor_state_t *state, struct psa_pake_out
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
-		((zcbor_uint32_expect(state, (84)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_pake_output_req_p_handle)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_pake_output_req_step)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_pake_output_req_p_output)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_pake_output_req_output_size)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_pake_output_req_p_output_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_expect(state, (80)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_pake_output_req_p_handle)))) &&
+		   ((zcbor_uint32_decode(state, (&(*result).psa_pake_output_req_step)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_pake_output_req_p_output)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_pake_output_req_output_size)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_pake_output_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1828,11 +1799,11 @@ static bool decode_psa_pake_input_req(zcbor_state_t *state, struct psa_pake_inpu
 	zcbor_log("%s\r\n", __func__);
 
 	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (85)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_pake_input_req_p_handle)))) &&
+		(((((zcbor_uint32_expect(state, (81)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_pake_input_req_p_handle)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_pake_input_req_step)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_pake_input_req_p_input)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_pake_input_req_input_length)))))));
+		   ((decode_ptr_buf(state, (&(*result).psa_pake_input_req_p_input)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_pake_input_req_input_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1850,11 +1821,10 @@ static bool decode_psa_pake_get_shared_key_req(zcbor_state_t *state,
 	zcbor_log("%s\r\n", __func__);
 
 	bool tmp_result = (((
-		((zcbor_uint32_expect(state, (86)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_pake_get_shared_key_req_p_handle)))) &&
-		((zcbor_uint32_decode(state,
-				      (&(*result).psa_pake_get_shared_key_req_p_attributes)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_pake_get_shared_key_req_p_key)))))));
+		((zcbor_uint32_expect(state, (82)))) &&
+		((decode_ptr_uint(state, (&(*result).psa_pake_get_shared_key_req_p_handle)))) &&
+		((decode_ptr_attr(state, (&(*result).psa_pake_get_shared_key_req_p_attributes)))) &&
+		((decode_ptr_key(state, (&(*result).psa_pake_get_shared_key_req_p_key)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1871,8 +1841,8 @@ static bool decode_psa_pake_abort_req(zcbor_state_t *state, struct psa_pake_abor
 	zcbor_log("%s\r\n", __func__);
 
 	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (87)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_pake_abort_req_p_handle)))))));
+		(((((zcbor_uint32_expect(state, (83)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_pake_abort_req_p_handle)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -2400,38 +2370,6 @@ static bool decode_psa_crypto_req(zcbor_state_t *state, struct psa_crypto_req *r
 					(&(*result).psa_crypto_req_msg_psa_generate_key_req_m)))) &&
 				(((*result).psa_crypto_req_msg_choice =
 					  psa_crypto_req_msg_psa_generate_key_req_m_c),
-				 true))) ||
-			      (zcbor_union_elem_code(state) &&
-			       (((decode_psa_sign_hash_start_req(
-					state,
-					(&(*result)
-						  .psa_crypto_req_msg_psa_sign_hash_start_req_m)))) &&
-				(((*result).psa_crypto_req_msg_choice =
-					  psa_crypto_req_msg_psa_sign_hash_start_req_m_c),
-				 true))) ||
-			      (zcbor_union_elem_code(state) &&
-			       (((decode_psa_sign_hash_abort_req(
-					state,
-					(&(*result)
-						  .psa_crypto_req_msg_psa_sign_hash_abort_req_m)))) &&
-				(((*result).psa_crypto_req_msg_choice =
-					  psa_crypto_req_msg_psa_sign_hash_abort_req_m_c),
-				 true))) ||
-			      (zcbor_union_elem_code(state) &&
-			       (((decode_psa_verify_hash_start_req(
-					state,
-					(&(*result)
-						  .psa_crypto_req_msg_psa_verify_hash_start_req_m)))) &&
-				(((*result).psa_crypto_req_msg_choice =
-					  psa_crypto_req_msg_psa_verify_hash_start_req_m_c),
-				 true))) ||
-			      (zcbor_union_elem_code(state) &&
-			       (((decode_psa_verify_hash_abort_req(
-					state,
-					(&(*result)
-						  .psa_crypto_req_msg_psa_verify_hash_abort_req_m)))) &&
-				(((*result).psa_crypto_req_msg_choice =
-					  psa_crypto_req_msg_psa_verify_hash_abort_req_m_c),
 				 true))) ||
 			      (zcbor_union_elem_code(state) &&
 			       (((decode_psa_pake_setup_req(

--- a/subsys/sdfw_services/services/psa_crypto/zcbor_generated/psa_crypto_service_decode.h
+++ b/subsys/sdfw_services/services/psa_crypto/zcbor_generated/psa_crypto_service_decode.h
@@ -5,7 +5,7 @@
  */
 
 /*
- * Generated using zcbor version 0.8.1
+ * Generated using zcbor version 0.8.99
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/subsys/sdfw_services/services/psa_crypto/zcbor_generated/psa_crypto_service_encode.c
+++ b/subsys/sdfw_services/services/psa_crypto/zcbor_generated/psa_crypto_service_encode.c
@@ -5,7 +5,7 @@
  */
 
 /*
- * Generated using zcbor version 0.8.1
+ * Generated using zcbor version 0.8.99
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */
@@ -22,15 +22,20 @@
 #error "The type file was generated with a different default_max_qty than this file"
 #endif
 
+static bool encode_ptr_attr(zcbor_state_t *state, const uint32_t *input);
 static bool encode_psa_get_key_attributes_req(zcbor_state_t *state,
 					      const struct psa_get_key_attributes_req *input);
 static bool encode_psa_reset_key_attributes_req(zcbor_state_t *state,
 						const struct psa_reset_key_attributes_req *input);
 static bool encode_psa_purge_key_req(zcbor_state_t *state, const struct psa_purge_key_req *input);
+static bool encode_ptr_key(zcbor_state_t *state, const uint32_t *input);
 static bool encode_psa_copy_key_req(zcbor_state_t *state, const struct psa_copy_key_req *input);
 static bool encode_psa_destroy_key_req(zcbor_state_t *state,
 				       const struct psa_destroy_key_req *input);
+static bool encode_ptr_buf(zcbor_state_t *state, const uint32_t *input);
+static bool encode_buf_len(zcbor_state_t *state, const uint32_t *input);
 static bool encode_psa_import_key_req(zcbor_state_t *state, const struct psa_import_key_req *input);
+static bool encode_ptr_uint(zcbor_state_t *state, const uint32_t *input);
 static bool encode_psa_export_key_req(zcbor_state_t *state, const struct psa_export_key_req *input);
 static bool encode_psa_export_public_key_req(zcbor_state_t *state,
 					     const struct psa_export_public_key_req *input);
@@ -144,14 +149,7 @@ static bool encode_psa_generate_random_req(zcbor_state_t *state,
 					   const struct psa_generate_random_req *input);
 static bool encode_psa_generate_key_req(zcbor_state_t *state,
 					const struct psa_generate_key_req *input);
-static bool encode_psa_sign_hash_start_req(zcbor_state_t *state,
-					   const struct psa_sign_hash_start_req *input);
-static bool encode_psa_sign_hash_abort_req(zcbor_state_t *state,
-					   const struct psa_sign_hash_abort_req *input);
-static bool encode_psa_verify_hash_start_req(zcbor_state_t *state,
-					     const struct psa_verify_hash_start_req *input);
-static bool encode_psa_verify_hash_abort_req(zcbor_state_t *state,
-					     const struct psa_verify_hash_abort_req *input);
+static bool encode_ptr_cipher(zcbor_state_t *state, const uint32_t *input);
 static bool encode_psa_pake_setup_req(zcbor_state_t *state, const struct psa_pake_setup_req *input);
 static bool encode_psa_pake_set_role_req(zcbor_state_t *state,
 					 const struct psa_pake_set_role_req *input);
@@ -170,16 +168,32 @@ static bool encode_psa_pake_abort_req(zcbor_state_t *state, const struct psa_pak
 static bool encode_psa_crypto_rsp(zcbor_state_t *state, const struct psa_crypto_rsp *input);
 static bool encode_psa_crypto_req(zcbor_state_t *state, const struct psa_crypto_req *input);
 
+static bool encode_ptr_attr(zcbor_state_t *state, const uint32_t *input)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool tmp_result =
+		((zcbor_tag_put(state, 32772) && (zcbor_uint32_encode(state, (&(*input))))));
+
+	if (!tmp_result) {
+		zcbor_trace_file(state);
+		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
+	} else {
+		zcbor_log("%s success\r\n", __func__);
+	}
+
+	return tmp_result;
+}
+
 static bool encode_psa_get_key_attributes_req(zcbor_state_t *state,
 					      const struct psa_get_key_attributes_req *input)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (11)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_get_key_attributes_req_key)))) &&
-		   ((zcbor_uint32_encode(state,
-					 (&(*input).psa_get_key_attributes_req_p_attributes)))))));
+	bool tmp_result = ((
+		(((zcbor_uint32_put(state, (11)))) &&
+		 ((zcbor_uint32_encode(state, (&(*input).psa_get_key_attributes_req_key)))) &&
+		 ((encode_ptr_attr(state, (&(*input).psa_get_key_attributes_req_p_attributes)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -198,8 +212,8 @@ static bool encode_psa_reset_key_attributes_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (12)))) &&
-		   ((zcbor_uint32_encode(
-			   state, (&(*input).psa_reset_key_attributes_req_p_attributes)))))));
+		   ((encode_ptr_attr(state,
+				     (&(*input).psa_reset_key_attributes_req_p_attributes)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -228,6 +242,23 @@ static bool encode_psa_purge_key_req(zcbor_state_t *state, const struct psa_purg
 	return tmp_result;
 }
 
+static bool encode_ptr_key(zcbor_state_t *state, const uint32_t *input)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool tmp_result =
+		((zcbor_tag_put(state, 32773) && (zcbor_uint32_encode(state, (&(*input))))));
+
+	if (!tmp_result) {
+		zcbor_trace_file(state);
+		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
+	} else {
+		zcbor_log("%s success\r\n", __func__);
+	}
+
+	return tmp_result;
+}
+
 static bool encode_psa_copy_key_req(zcbor_state_t *state, const struct psa_copy_key_req *input)
 {
 	zcbor_log("%s\r\n", __func__);
@@ -235,8 +266,8 @@ static bool encode_psa_copy_key_req(zcbor_state_t *state, const struct psa_copy_
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (14)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_copy_key_req_source_key)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_copy_key_req_p_attributes)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_copy_key_req_p_target_key)))))));
+		   ((encode_ptr_attr(state, (&(*input).psa_copy_key_req_p_attributes)))) &&
+		   ((encode_ptr_key(state, (&(*input).psa_copy_key_req_p_target_key)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -266,16 +297,67 @@ static bool encode_psa_destroy_key_req(zcbor_state_t *state,
 	return tmp_result;
 }
 
+static bool encode_ptr_buf(zcbor_state_t *state, const uint32_t *input)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool tmp_result =
+		((zcbor_tag_put(state, 32770) && (zcbor_uint32_encode(state, (&(*input))))));
+
+	if (!tmp_result) {
+		zcbor_trace_file(state);
+		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
+	} else {
+		zcbor_log("%s success\r\n", __func__);
+	}
+
+	return tmp_result;
+}
+
+static bool encode_buf_len(zcbor_state_t *state, const uint32_t *input)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool tmp_result =
+		((zcbor_tag_put(state, 32771) && (zcbor_uint32_encode(state, (&(*input))))));
+
+	if (!tmp_result) {
+		zcbor_trace_file(state);
+		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
+	} else {
+		zcbor_log("%s success\r\n", __func__);
+	}
+
+	return tmp_result;
+}
+
 static bool encode_psa_import_key_req(zcbor_state_t *state, const struct psa_import_key_req *input)
 {
 	zcbor_log("%s\r\n", __func__);
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (16)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_import_key_req_p_attributes)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_import_key_req_p_data)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_import_key_req_data_length)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_import_key_req_p_key)))))));
+		   ((encode_ptr_attr(state, (&(*input).psa_import_key_req_p_attributes)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_import_key_req_p_data)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_import_key_req_data_length)))) &&
+		   ((encode_ptr_key(state, (&(*input).psa_import_key_req_p_key)))))));
+
+	if (!tmp_result) {
+		zcbor_trace_file(state);
+		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
+	} else {
+		zcbor_log("%s success\r\n", __func__);
+	}
+
+	return tmp_result;
+}
+
+static bool encode_ptr_uint(zcbor_state_t *state, const uint32_t *input)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool tmp_result =
+		((zcbor_tag_put(state, 32774) && (zcbor_uint32_encode(state, (&(*input))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -294,9 +376,9 @@ static bool encode_psa_export_key_req(zcbor_state_t *state, const struct psa_exp
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (17)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_export_key_req_key)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_export_key_req_p_data)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_export_key_req_data_size)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_export_key_req_p_data_length)))))));
+		   ((encode_ptr_buf(state, (&(*input).psa_export_key_req_p_data)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_export_key_req_data_size)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_export_key_req_p_data_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -316,10 +398,9 @@ static bool encode_psa_export_public_key_req(zcbor_state_t *state,
 	bool tmp_result = ((
 		(((zcbor_uint32_put(state, (18)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_export_public_key_req_key)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_export_public_key_req_p_data)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_export_public_key_req_data_size)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_export_public_key_req_p_data_length)))))));
+		 ((encode_ptr_buf(state, (&(*input).psa_export_public_key_req_p_data)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_export_public_key_req_data_size)))) &&
+		 ((encode_ptr_uint(state, (&(*input).psa_export_public_key_req_p_data_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -336,14 +417,14 @@ static bool encode_psa_hash_compute_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_put(state, (19)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_hash_compute_req_alg)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_hash_compute_req_p_input)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_hash_compute_req_input_length)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_hash_compute_req_p_hash)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_hash_compute_req_hash_size)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_hash_compute_req_p_hash_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (19)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_compute_req_alg)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_hash_compute_req_p_input)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_hash_compute_req_input_length)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_hash_compute_req_p_hash)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_hash_compute_req_hash_size)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_hash_compute_req_p_hash_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -363,10 +444,10 @@ static bool encode_psa_hash_compare_req(zcbor_state_t *state,
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (20)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_compare_req_alg)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_compare_req_p_input)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_compare_req_input_length)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_compare_req_p_hash)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_compare_req_hash_length)))))));
+		   ((encode_ptr_buf(state, (&(*input).psa_hash_compare_req_p_input)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_hash_compare_req_input_length)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_hash_compare_req_p_hash)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_hash_compare_req_hash_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -382,10 +463,9 @@ static bool encode_psa_hash_setup_req(zcbor_state_t *state, const struct psa_has
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (21)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_setup_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_setup_req_alg)))))));
+	bool tmp_result = (((((zcbor_uint32_put(state, (21)))) &&
+			     ((encode_ptr_uint(state, (&(*input).psa_hash_setup_req_p_handle)))) &&
+			     ((zcbor_uint32_encode(state, (&(*input).psa_hash_setup_req_alg)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -404,9 +484,9 @@ static bool encode_psa_hash_update_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (22)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_update_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_update_req_p_input)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_update_req_input_length)))))));
+		   ((encode_ptr_uint(state, (&(*input).psa_hash_update_req_p_handle)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_hash_update_req_p_input)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_hash_update_req_input_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -425,10 +505,10 @@ static bool encode_psa_hash_finish_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (23)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_finish_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_finish_req_p_hash)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_finish_req_hash_size)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_finish_req_p_hash_length)))))));
+		   ((encode_ptr_uint(state, (&(*input).psa_hash_finish_req_p_handle)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_hash_finish_req_p_hash)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_hash_finish_req_hash_size)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_hash_finish_req_p_hash_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -447,9 +527,9 @@ static bool encode_psa_hash_verify_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (24)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_verify_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_verify_req_p_hash)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_verify_req_hash_length)))))));
+		   ((encode_ptr_uint(state, (&(*input).psa_hash_verify_req_p_handle)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_hash_verify_req_p_hash)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_hash_verify_req_hash_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -465,9 +545,8 @@ static bool encode_psa_hash_abort_req(zcbor_state_t *state, const struct psa_has
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (25)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_abort_req_p_handle)))))));
+	bool tmp_result = (((((zcbor_uint32_put(state, (25)))) &&
+			     ((encode_ptr_uint(state, (&(*input).psa_hash_abort_req_p_handle)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -486,7 +565,7 @@ static bool encode_psa_hash_clone_req(zcbor_state_t *state, const struct psa_has
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (26)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_clone_req_handle)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_clone_req_p_handle)))))));
+		   ((encode_ptr_uint(state, (&(*input).psa_hash_clone_req_p_handle)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -507,11 +586,11 @@ static bool encode_psa_mac_compute_req(zcbor_state_t *state,
 		(((((zcbor_uint32_put(state, (27)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_compute_req_key)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_compute_req_alg)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_compute_req_p_input)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_compute_req_input_length)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_compute_req_p_mac)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_compute_req_mac_size)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_compute_req_p_mac_length)))))));
+		   ((encode_ptr_buf(state, (&(*input).psa_mac_compute_req_p_input)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_mac_compute_req_input_length)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_mac_compute_req_p_mac)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_mac_compute_req_mac_size)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_mac_compute_req_p_mac_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -531,10 +610,10 @@ static bool encode_psa_mac_verify_req(zcbor_state_t *state, const struct psa_mac
 		(((((zcbor_uint32_put(state, (28)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_verify_req_key)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_verify_req_alg)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_verify_req_p_input)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_verify_req_input_length)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_verify_req_p_mac)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_verify_req_mac_length)))))));
+		   ((encode_ptr_buf(state, (&(*input).psa_mac_verify_req_p_input)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_mac_verify_req_input_length)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_mac_verify_req_p_mac)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_mac_verify_req_mac_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -553,7 +632,7 @@ static bool encode_psa_mac_sign_setup_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (29)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_sign_setup_req_p_handle)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_mac_sign_setup_req_p_handle)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_sign_setup_req_key)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_sign_setup_req_alg)))))));
 
@@ -574,7 +653,7 @@ static bool encode_psa_mac_verify_setup_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (30)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_verify_setup_req_p_handle)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_mac_verify_setup_req_p_handle)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_verify_setup_req_key)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_verify_setup_req_alg)))))));
 
@@ -594,9 +673,9 @@ static bool encode_psa_mac_update_req(zcbor_state_t *state, const struct psa_mac
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (31)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_update_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_update_req_p_input)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_update_req_input_length)))))));
+		   ((encode_ptr_uint(state, (&(*input).psa_mac_update_req_p_handle)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_mac_update_req_p_input)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_mac_update_req_input_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -613,12 +692,12 @@ static bool encode_psa_mac_sign_finish_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
-		((zcbor_uint32_put(state, (32)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_mac_sign_finish_req_p_handle)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_mac_sign_finish_req_p_mac)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_mac_sign_finish_req_mac_size)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_mac_sign_finish_req_p_mac_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (32)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_mac_sign_finish_req_p_handle)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_mac_sign_finish_req_p_mac)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_mac_sign_finish_req_mac_size)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_mac_sign_finish_req_p_mac_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -635,11 +714,11 @@ static bool encode_psa_mac_verify_finish_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
-		((zcbor_uint32_put(state, (33)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_mac_verify_finish_req_p_handle)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_mac_verify_finish_req_p_mac)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_mac_verify_finish_req_mac_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (33)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_mac_verify_finish_req_p_handle)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_mac_verify_finish_req_p_mac)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_mac_verify_finish_req_mac_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -655,9 +734,8 @@ static bool encode_psa_mac_abort_req(zcbor_state_t *state, const struct psa_mac_
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (34)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_abort_req_p_handle)))))));
+	bool tmp_result = (((((zcbor_uint32_put(state, (34)))) &&
+			     ((encode_ptr_uint(state, (&(*input).psa_mac_abort_req_p_handle)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -678,12 +756,11 @@ static bool encode_psa_cipher_encrypt_req(zcbor_state_t *state,
 		(((zcbor_uint32_put(state, (35)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_encrypt_req_key)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_encrypt_req_alg)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_encrypt_req_p_input)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_encrypt_req_input_length)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_encrypt_req_p_output)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_encrypt_req_output_size)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_cipher_encrypt_req_p_output_length)))))));
+		 ((encode_ptr_buf(state, (&(*input).psa_cipher_encrypt_req_p_input)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_cipher_encrypt_req_input_length)))) &&
+		 ((encode_ptr_buf(state, (&(*input).psa_cipher_encrypt_req_p_output)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_cipher_encrypt_req_output_size)))) &&
+		 ((encode_ptr_uint(state, (&(*input).psa_cipher_encrypt_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -704,12 +781,11 @@ static bool encode_psa_cipher_decrypt_req(zcbor_state_t *state,
 		(((zcbor_uint32_put(state, (36)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_decrypt_req_key)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_decrypt_req_alg)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_decrypt_req_p_input)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_decrypt_req_input_length)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_decrypt_req_p_output)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_decrypt_req_output_size)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_cipher_decrypt_req_p_output_length)))))));
+		 ((encode_ptr_buf(state, (&(*input).psa_cipher_decrypt_req_p_input)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_cipher_decrypt_req_input_length)))) &&
+		 ((encode_ptr_buf(state, (&(*input).psa_cipher_decrypt_req_p_output)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_cipher_decrypt_req_output_size)))) &&
+		 ((encode_ptr_uint(state, (&(*input).psa_cipher_decrypt_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -726,11 +802,11 @@ static bool encode_psa_cipher_encrypt_setup_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
-		((zcbor_uint32_put(state, (37)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_cipher_encrypt_setup_req_p_handle)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_cipher_encrypt_setup_req_key)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_cipher_encrypt_setup_req_alg)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (37)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_cipher_encrypt_setup_req_p_handle)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_encrypt_setup_req_key)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_encrypt_setup_req_alg)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -747,11 +823,11 @@ static bool encode_psa_cipher_decrypt_setup_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
-		((zcbor_uint32_put(state, (38)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_cipher_decrypt_setup_req_p_handle)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_cipher_decrypt_setup_req_key)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_cipher_decrypt_setup_req_alg)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (38)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_cipher_decrypt_setup_req_p_handle)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_decrypt_setup_req_key)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_decrypt_setup_req_alg)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -770,11 +846,10 @@ static bool encode_psa_cipher_generate_iv_req(zcbor_state_t *state,
 
 	bool tmp_result = ((
 		(((zcbor_uint32_put(state, (39)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_generate_iv_req_p_handle)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_generate_iv_req_p_iv)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_generate_iv_req_iv_size)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_cipher_generate_iv_req_p_iv_length)))))));
+		 ((encode_ptr_uint(state, (&(*input).psa_cipher_generate_iv_req_p_handle)))) &&
+		 ((encode_ptr_buf(state, (&(*input).psa_cipher_generate_iv_req_p_iv)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_cipher_generate_iv_req_iv_size)))) &&
+		 ((encode_ptr_uint(state, (&(*input).psa_cipher_generate_iv_req_p_iv_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -793,9 +868,9 @@ static bool encode_psa_cipher_set_iv_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (40)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_set_iv_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_set_iv_req_p_iv)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_set_iv_req_iv_length)))))));
+		   ((encode_ptr_uint(state, (&(*input).psa_cipher_set_iv_req_p_handle)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_cipher_set_iv_req_p_iv)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_cipher_set_iv_req_iv_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -814,13 +889,12 @@ static bool encode_psa_cipher_update_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (41)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_update_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_update_req_p_input)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_update_req_input_length)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_update_req_p_output)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_update_req_output_size)))) &&
-		   ((zcbor_uint32_encode(state,
-					 (&(*input).psa_cipher_update_req_p_output_length)))))));
+		   ((encode_ptr_uint(state, (&(*input).psa_cipher_update_req_p_handle)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_cipher_update_req_p_input)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_cipher_update_req_input_length)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_cipher_update_req_p_output)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_cipher_update_req_output_size)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_cipher_update_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -839,11 +913,10 @@ static bool encode_psa_cipher_finish_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (42)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_finish_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_finish_req_p_output)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_finish_req_output_size)))) &&
-		   ((zcbor_uint32_encode(state,
-					 (&(*input).psa_cipher_finish_req_p_output_length)))))));
+		   ((encode_ptr_uint(state, (&(*input).psa_cipher_finish_req_p_handle)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_cipher_finish_req_p_output)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_cipher_finish_req_output_size)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_cipher_finish_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -862,7 +935,7 @@ static bool encode_psa_cipher_abort_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (43)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_abort_req_p_handle)))))));
+		   ((encode_ptr_uint(state, (&(*input).psa_cipher_abort_req_p_handle)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -883,18 +956,16 @@ static bool encode_psa_aead_encrypt_req(zcbor_state_t *state,
 		((zcbor_uint32_put(state, (44)))) &&
 		((zcbor_uint32_encode(state, (&(*input).psa_aead_encrypt_req_key)))) &&
 		((zcbor_uint32_encode(state, (&(*input).psa_aead_encrypt_req_alg)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_aead_encrypt_req_p_nonce)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_aead_encrypt_req_nonce_length)))) &&
-		((zcbor_uint32_encode(state,
-				      (&(*input).psa_aead_encrypt_req_p_additional_data)))) &&
-		((zcbor_uint32_encode(state,
-				      (&(*input).psa_aead_encrypt_req_additional_data_length)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_aead_encrypt_req_p_plaintext)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_aead_encrypt_req_plaintext_length)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_aead_encrypt_req_p_ciphertext)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_aead_encrypt_req_ciphertext_size)))) &&
-		((zcbor_uint32_encode(state,
-				      (&(*input).psa_aead_encrypt_req_p_ciphertext_length)))))));
+		((encode_ptr_buf(state, (&(*input).psa_aead_encrypt_req_p_nonce)))) &&
+		((encode_buf_len(state, (&(*input).psa_aead_encrypt_req_nonce_length)))) &&
+		((encode_ptr_buf(state, (&(*input).psa_aead_encrypt_req_p_additional_data)))) &&
+		((encode_buf_len(state,
+				 (&(*input).psa_aead_encrypt_req_additional_data_length)))) &&
+		((encode_ptr_buf(state, (&(*input).psa_aead_encrypt_req_p_plaintext)))) &&
+		((encode_buf_len(state, (&(*input).psa_aead_encrypt_req_plaintext_length)))) &&
+		((encode_ptr_buf(state, (&(*input).psa_aead_encrypt_req_p_ciphertext)))) &&
+		((encode_buf_len(state, (&(*input).psa_aead_encrypt_req_ciphertext_size)))) &&
+		((encode_ptr_uint(state, (&(*input).psa_aead_encrypt_req_p_ciphertext_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -915,19 +986,16 @@ static bool encode_psa_aead_decrypt_req(zcbor_state_t *state,
 		(((zcbor_uint32_put(state, (45)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_decrypt_req_key)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_decrypt_req_alg)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_decrypt_req_p_nonce)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_decrypt_req_nonce_length)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_aead_decrypt_req_p_additional_data)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_aead_decrypt_req_additional_data_length)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_decrypt_req_p_ciphertext)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_aead_decrypt_req_ciphertext_length)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_decrypt_req_p_plaintext)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_decrypt_req_plaintext_size)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_aead_decrypt_req_p_plaintext_length)))))));
+		 ((encode_ptr_buf(state, (&(*input).psa_aead_decrypt_req_p_nonce)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_aead_decrypt_req_nonce_length)))) &&
+		 ((encode_ptr_buf(state, (&(*input).psa_aead_decrypt_req_p_additional_data)))) &&
+		 ((encode_buf_len(state,
+				  (&(*input).psa_aead_decrypt_req_additional_data_length)))) &&
+		 ((encode_ptr_buf(state, (&(*input).psa_aead_decrypt_req_p_ciphertext)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_aead_decrypt_req_ciphertext_length)))) &&
+		 ((encode_ptr_buf(state, (&(*input).psa_aead_decrypt_req_p_plaintext)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_aead_decrypt_req_plaintext_size)))) &&
+		 ((encode_ptr_uint(state, (&(*input).psa_aead_decrypt_req_p_plaintext_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -944,11 +1012,11 @@ static bool encode_psa_aead_encrypt_setup_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_put(state, (46)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_encrypt_setup_req_p_handle)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_encrypt_setup_req_key)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_encrypt_setup_req_alg)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (46)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_aead_encrypt_setup_req_p_handle)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_aead_encrypt_setup_req_key)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_aead_encrypt_setup_req_alg)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -965,11 +1033,11 @@ static bool encode_psa_aead_decrypt_setup_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_put(state, (47)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_decrypt_setup_req_p_handle)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_decrypt_setup_req_key)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_decrypt_setup_req_alg)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (47)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_aead_decrypt_setup_req_p_handle)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_aead_decrypt_setup_req_key)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_aead_decrypt_setup_req_alg)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -986,14 +1054,13 @@ static bool encode_psa_aead_generate_nonce_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_put(state, (48)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_generate_nonce_req_p_handle)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_generate_nonce_req_p_nonce)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_aead_generate_nonce_req_nonce_size)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_aead_generate_nonce_req_p_nonce_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (48)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_aead_generate_nonce_req_p_handle)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_aead_generate_nonce_req_p_nonce)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_aead_generate_nonce_req_nonce_size)))) &&
+		   ((encode_ptr_uint(state,
+				     (&(*input).psa_aead_generate_nonce_req_p_nonce_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1010,11 +1077,11 @@ static bool encode_psa_aead_set_nonce_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_put(state, (49)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_set_nonce_req_p_handle)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_set_nonce_req_p_nonce)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_set_nonce_req_nonce_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (49)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_aead_set_nonce_req_p_handle)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_aead_set_nonce_req_p_nonce)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_aead_set_nonce_req_nonce_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1031,12 +1098,11 @@ static bool encode_psa_aead_set_lengths_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (50)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_aead_set_lengths_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_aead_set_lengths_req_ad_length)))) &&
-		   ((zcbor_uint32_encode(
-			   state, (&(*input).psa_aead_set_lengths_req_plaintext_length)))))));
+	bool tmp_result = (((
+		((zcbor_uint32_put(state, (50)))) &&
+		((encode_ptr_uint(state, (&(*input).psa_aead_set_lengths_req_p_handle)))) &&
+		((encode_buf_len(state, (&(*input).psa_aead_set_lengths_req_ad_length)))) &&
+		((encode_buf_len(state, (&(*input).psa_aead_set_lengths_req_plaintext_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1053,11 +1119,11 @@ static bool encode_psa_aead_update_ad_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_put(state, (51)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_update_ad_req_p_handle)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_update_ad_req_p_input)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_update_ad_req_input_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (51)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_aead_update_ad_req_p_handle)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_aead_update_ad_req_p_input)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_aead_update_ad_req_input_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1074,14 +1140,14 @@ static bool encode_psa_aead_update_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_put(state, (52)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_update_req_p_handle)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_update_req_p_input)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_update_req_input_length)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_update_req_p_output)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_update_req_output_size)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_update_req_p_output_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (52)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_aead_update_req_p_handle)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_aead_update_req_p_input)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_aead_update_req_input_length)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_aead_update_req_p_output)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_aead_update_req_output_size)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_aead_update_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1100,14 +1166,13 @@ static bool encode_psa_aead_finish_req(zcbor_state_t *state,
 
 	bool tmp_result = ((
 		(((zcbor_uint32_put(state, (53)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_finish_req_p_handle)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_finish_req_p_ciphertext)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_finish_req_ciphertext_size)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_aead_finish_req_p_ciphertext_length)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_finish_req_p_tag)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_finish_req_tag_size)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_finish_req_p_tag_length)))))));
+		 ((encode_ptr_uint(state, (&(*input).psa_aead_finish_req_p_handle)))) &&
+		 ((encode_ptr_buf(state, (&(*input).psa_aead_finish_req_p_ciphertext)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_aead_finish_req_ciphertext_size)))) &&
+		 ((encode_ptr_uint(state, (&(*input).psa_aead_finish_req_p_ciphertext_length)))) &&
+		 ((encode_ptr_buf(state, (&(*input).psa_aead_finish_req_p_tag)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_aead_finish_req_tag_size)))) &&
+		 ((encode_ptr_uint(state, (&(*input).psa_aead_finish_req_p_tag_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1126,13 +1191,12 @@ static bool encode_psa_aead_verify_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (54)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_aead_verify_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_aead_verify_req_p_plaintext)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_aead_verify_req_plaintext_size)))) &&
-		   ((zcbor_uint32_encode(state,
-					 (&(*input).psa_aead_verify_req_p_plaintext_length)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_aead_verify_req_p_tag)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_aead_verify_req_tag_length)))))));
+		   ((encode_ptr_uint(state, (&(*input).psa_aead_verify_req_p_handle)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_aead_verify_req_p_plaintext)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_aead_verify_req_plaintext_size)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_aead_verify_req_p_plaintext_length)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_aead_verify_req_p_tag)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_aead_verify_req_tag_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1148,9 +1212,8 @@ static bool encode_psa_aead_abort_req(zcbor_state_t *state, const struct psa_aea
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (55)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_aead_abort_req_p_handle)))))));
+	bool tmp_result = (((((zcbor_uint32_put(state, (55)))) &&
+			     ((encode_ptr_uint(state, (&(*input).psa_aead_abort_req_p_handle)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1171,12 +1234,11 @@ static bool encode_psa_sign_message_req(zcbor_state_t *state,
 		(((zcbor_uint32_put(state, (56)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_sign_message_req_key)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_sign_message_req_alg)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_sign_message_req_p_input)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_sign_message_req_input_length)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_sign_message_req_p_signature)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_sign_message_req_signature_size)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_sign_message_req_p_signature_length)))))));
+		 ((encode_ptr_buf(state, (&(*input).psa_sign_message_req_p_input)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_sign_message_req_input_length)))) &&
+		 ((encode_ptr_buf(state, (&(*input).psa_sign_message_req_p_signature)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_sign_message_req_signature_size)))) &&
+		 ((encode_ptr_uint(state, (&(*input).psa_sign_message_req_p_signature_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1197,11 +1259,10 @@ static bool encode_psa_verify_message_req(zcbor_state_t *state,
 		(((zcbor_uint32_put(state, (57)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_verify_message_req_key)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_verify_message_req_alg)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_verify_message_req_p_input)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_verify_message_req_input_length)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_verify_message_req_p_signature)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_verify_message_req_signature_length)))))));
+		 ((encode_ptr_buf(state, (&(*input).psa_verify_message_req_p_input)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_verify_message_req_input_length)))) &&
+		 ((encode_ptr_buf(state, (&(*input).psa_verify_message_req_p_signature)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_verify_message_req_signature_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1217,15 +1278,15 @@ static bool encode_psa_sign_hash_req(zcbor_state_t *state, const struct psa_sign
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
-		((zcbor_uint32_put(state, (58)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_sign_hash_req_key)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_sign_hash_req_alg)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_sign_hash_req_p_hash)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_sign_hash_req_hash_length)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_sign_hash_req_p_signature)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_sign_hash_req_signature_size)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_sign_hash_req_p_signature_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (58)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_sign_hash_req_key)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_sign_hash_req_alg)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_sign_hash_req_p_hash)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_sign_hash_req_hash_length)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_sign_hash_req_p_signature)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_sign_hash_req_signature_size)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_sign_hash_req_p_signature_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1242,14 +1303,14 @@ static bool encode_psa_verify_hash_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
-		((zcbor_uint32_put(state, (59)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_verify_hash_req_key)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_verify_hash_req_alg)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_verify_hash_req_p_hash)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_verify_hash_req_hash_length)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_verify_hash_req_p_signature)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_verify_hash_req_signature_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (59)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_verify_hash_req_key)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_verify_hash_req_alg)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_verify_hash_req_p_hash)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_verify_hash_req_hash_length)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_verify_hash_req_p_signature)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_verify_hash_req_signature_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1266,21 +1327,18 @@ static bool encode_psa_asymmetric_encrypt_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_put(state, (60)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_encrypt_req_key)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_encrypt_req_alg)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_encrypt_req_p_input)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_asymmetric_encrypt_req_input_length)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_encrypt_req_p_salt)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_asymmetric_encrypt_req_salt_length)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_encrypt_req_p_output)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_asymmetric_encrypt_req_output_size)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_asymmetric_encrypt_req_p_output_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (60)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_encrypt_req_key)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_encrypt_req_alg)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_asymmetric_encrypt_req_p_input)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_asymmetric_encrypt_req_input_length)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_asymmetric_encrypt_req_p_salt)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_asymmetric_encrypt_req_salt_length)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_asymmetric_encrypt_req_p_output)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_asymmetric_encrypt_req_output_size)))) &&
+		   ((encode_ptr_uint(state,
+				     (&(*input).psa_asymmetric_encrypt_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1297,21 +1355,18 @@ static bool encode_psa_asymmetric_decrypt_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_put(state, (61)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_decrypt_req_key)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_decrypt_req_alg)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_decrypt_req_p_input)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_asymmetric_decrypt_req_input_length)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_decrypt_req_p_salt)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_asymmetric_decrypt_req_salt_length)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_decrypt_req_p_output)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_asymmetric_decrypt_req_output_size)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_asymmetric_decrypt_req_p_output_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (61)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_decrypt_req_key)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_decrypt_req_alg)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_asymmetric_decrypt_req_p_input)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_asymmetric_decrypt_req_input_length)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_asymmetric_decrypt_req_p_salt)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_asymmetric_decrypt_req_salt_length)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_asymmetric_decrypt_req_p_output)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_asymmetric_decrypt_req_output_size)))) &&
+		   ((encode_ptr_uint(state,
+				     (&(*input).psa_asymmetric_decrypt_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1328,10 +1383,10 @@ static bool encode_psa_key_derivation_setup_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
-		((zcbor_uint32_put(state, (62)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_key_derivation_setup_req_p_handle)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_key_derivation_setup_req_alg)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (62)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_key_derivation_setup_req_p_handle)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_key_derivation_setup_req_alg)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1353,7 +1408,7 @@ encode_psa_key_derivation_get_capacity_req(zcbor_state_t *state,
 		(((((zcbor_uint32_put(state, (63)))) &&
 		   ((zcbor_uint32_encode(
 			   state, (&(*input).psa_key_derivation_get_capacity_req_handle)))) &&
-		   ((zcbor_uint32_encode(
+		   ((encode_ptr_uint(
 			   state, (&(*input).psa_key_derivation_get_capacity_req_p_capacity)))))));
 
 	if (!tmp_result) {
@@ -1374,8 +1429,8 @@ encode_psa_key_derivation_set_capacity_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (64)))) &&
-		   ((zcbor_uint32_encode(
-			   state, (&(*input).psa_key_derivation_set_capacity_req_p_handle)))) &&
+		   ((encode_ptr_uint(state,
+				     (&(*input).psa_key_derivation_set_capacity_req_p_handle)))) &&
 		   ((zcbor_uint32_encode(
 			   state, (&(*input).psa_key_derivation_set_capacity_req_capacity)))))));
 
@@ -1395,16 +1450,15 @@ encode_psa_key_derivation_input_bytes_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (65)))) &&
-		   ((zcbor_uint32_encode(
-			   state, (&(*input).psa_key_derivation_input_bytes_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state,
-					 (&(*input).psa_key_derivation_input_bytes_req_step)))) &&
-		   ((zcbor_uint32_encode(state,
-					 (&(*input).psa_key_derivation_input_bytes_req_p_data)))) &&
-		   ((zcbor_uint32_encode(
-			   state, (&(*input).psa_key_derivation_input_bytes_req_data_length)))))));
+	bool tmp_result = ((
+		(((zcbor_uint32_put(state, (65)))) &&
+		 ((encode_ptr_uint(state,
+				   (&(*input).psa_key_derivation_input_bytes_req_p_handle)))) &&
+		 ((zcbor_uint32_encode(state,
+				       (&(*input).psa_key_derivation_input_bytes_req_step)))) &&
+		 ((encode_ptr_buf(state, (&(*input).psa_key_derivation_input_bytes_req_p_data)))) &&
+		 ((encode_buf_len(state,
+				  (&(*input).psa_key_derivation_input_bytes_req_data_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1423,8 +1477,8 @@ static bool encode_psa_key_derivation_input_integer_req(
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (66)))) &&
-		   ((zcbor_uint32_encode(
-			   state, (&(*input).psa_key_derivation_input_integer_req_p_handle)))) &&
+		   ((encode_ptr_uint(state,
+				     (&(*input).psa_key_derivation_input_integer_req_p_handle)))) &&
 		   ((zcbor_uint32_encode(state,
 					 (&(*input).psa_key_derivation_input_integer_req_step)))) &&
 		   ((zcbor_uint32_encode(
@@ -1448,8 +1502,7 @@ encode_psa_key_derivation_input_key_req(zcbor_state_t *state,
 
 	bool tmp_result = (((
 		((zcbor_uint32_put(state, (67)))) &&
-		((zcbor_uint32_encode(state,
-				      (&(*input).psa_key_derivation_input_key_req_p_handle)))) &&
+		((encode_ptr_uint(state, (&(*input).psa_key_derivation_input_key_req_p_handle)))) &&
 		((zcbor_uint32_encode(state, (&(*input).psa_key_derivation_input_key_req_step)))) &&
 		((zcbor_uint32_encode(state, (&(*input).psa_key_derivation_input_key_req_key)))))));
 
@@ -1470,15 +1523,15 @@ static bool encode_psa_key_derivation_key_agreement_req(
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (68)))) &&
-		   ((zcbor_uint32_encode(
-			   state, (&(*input).psa_key_derivation_key_agreement_req_p_handle)))) &&
+		   ((encode_ptr_uint(state,
+				     (&(*input).psa_key_derivation_key_agreement_req_p_handle)))) &&
 		   ((zcbor_uint32_encode(state,
 					 (&(*input).psa_key_derivation_key_agreement_req_step)))) &&
 		   ((zcbor_uint32_encode(
 			   state, (&(*input).psa_key_derivation_key_agreement_req_private_key)))) &&
-		   ((zcbor_uint32_encode(
+		   ((encode_ptr_buf(
 			   state, (&(*input).psa_key_derivation_key_agreement_req_p_peer_key)))) &&
-		   ((zcbor_uint32_encode(
+		   ((encode_buf_len(
 			   state,
 			   (&(*input).psa_key_derivation_key_agreement_req_peer_key_length)))))));
 
@@ -1498,14 +1551,14 @@ encode_psa_key_derivation_output_bytes_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
-		((zcbor_uint32_put(state, (69)))) &&
-		((zcbor_uint32_encode(state,
-				      (&(*input).psa_key_derivation_output_bytes_req_p_handle)))) &&
-		((zcbor_uint32_encode(state,
-				      (&(*input).psa_key_derivation_output_bytes_req_p_output)))) &&
-		((zcbor_uint32_encode(
-			state, (&(*input).psa_key_derivation_output_bytes_req_output_length)))))));
+	bool tmp_result = ((
+		(((zcbor_uint32_put(state, (69)))) &&
+		 ((encode_ptr_uint(state,
+				   (&(*input).psa_key_derivation_output_bytes_req_p_handle)))) &&
+		 ((encode_ptr_buf(state,
+				  (&(*input).psa_key_derivation_output_bytes_req_p_output)))) &&
+		 ((encode_buf_len(
+			 state, (&(*input).psa_key_derivation_output_bytes_req_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1523,14 +1576,13 @@ encode_psa_key_derivation_output_key_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (70)))) &&
-		   ((zcbor_uint32_encode(
-			   state, (&(*input).psa_key_derivation_output_key_req_p_attributes)))) &&
-		   ((zcbor_uint32_encode(
-			   state, (&(*input).psa_key_derivation_output_key_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state,
-					 (&(*input).psa_key_derivation_output_key_req_p_key)))))));
+	bool tmp_result = ((
+		(((zcbor_uint32_put(state, (70)))) &&
+		 ((encode_ptr_attr(state,
+				   (&(*input).psa_key_derivation_output_key_req_p_attributes)))) &&
+		 ((encode_ptr_uint(state,
+				   (&(*input).psa_key_derivation_output_key_req_p_handle)))) &&
+		 ((encode_ptr_key(state, (&(*input).psa_key_derivation_output_key_req_p_key)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1547,9 +1599,9 @@ static bool encode_psa_key_derivation_abort_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((((zcbor_uint32_put(state, (71)))) &&
-			     ((zcbor_uint32_encode(
-				     state, (&(*input).psa_key_derivation_abort_req_p_handle)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (71)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_key_derivation_abort_req_p_handle)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1570,13 +1622,12 @@ static bool encode_psa_raw_key_agreement_req(zcbor_state_t *state,
 		((zcbor_uint32_put(state, (72)))) &&
 		((zcbor_uint32_encode(state, (&(*input).psa_raw_key_agreement_req_alg)))) &&
 		((zcbor_uint32_encode(state, (&(*input).psa_raw_key_agreement_req_private_key)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_raw_key_agreement_req_p_peer_key)))) &&
-		((zcbor_uint32_encode(state,
-				      (&(*input).psa_raw_key_agreement_req_peer_key_length)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_raw_key_agreement_req_p_output)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_raw_key_agreement_req_output_size)))) &&
-		((zcbor_uint32_encode(state,
-				      (&(*input).psa_raw_key_agreement_req_p_output_length)))))));
+		((encode_ptr_buf(state, (&(*input).psa_raw_key_agreement_req_p_peer_key)))) &&
+		((encode_buf_len(state, (&(*input).psa_raw_key_agreement_req_peer_key_length)))) &&
+		((encode_ptr_buf(state, (&(*input).psa_raw_key_agreement_req_p_output)))) &&
+		((encode_buf_len(state, (&(*input).psa_raw_key_agreement_req_output_size)))) &&
+		((encode_ptr_uint(state,
+				  (&(*input).psa_raw_key_agreement_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1593,10 +1644,10 @@ static bool encode_psa_generate_random_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_put(state, (73)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_generate_random_req_p_output)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_generate_random_req_output_size)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (73)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_generate_random_req_p_output)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_generate_random_req_output_size)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1615,8 +1666,8 @@ static bool encode_psa_generate_key_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (74)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_generate_key_req_p_attributes)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_generate_key_req_p_key)))))));
+		   ((encode_ptr_attr(state, (&(*input).psa_generate_key_req_p_attributes)))) &&
+		   ((encode_ptr_key(state, (&(*input).psa_generate_key_req_p_key)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1628,82 +1679,12 @@ static bool encode_psa_generate_key_req(zcbor_state_t *state,
 	return tmp_result;
 }
 
-static bool encode_psa_sign_hash_start_req(zcbor_state_t *state,
-					   const struct psa_sign_hash_start_req *input)
+static bool encode_ptr_cipher(zcbor_state_t *state, const uint32_t *input)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_put(state, (75)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_sign_hash_start_req_p_operation)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_sign_hash_start_req_key)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_sign_hash_start_req_alg)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_sign_hash_start_req_p_hash)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_sign_hash_start_req_hash_length)))))));
-
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
-}
-
-static bool encode_psa_sign_hash_abort_req(zcbor_state_t *state,
-					   const struct psa_sign_hash_abort_req *input)
-{
-	zcbor_log("%s\r\n", __func__);
-
-	bool tmp_result = ((
-		(((zcbor_uint32_put(state, (76)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_sign_hash_abort_req_p_operation)))))));
-
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
-}
-
-static bool encode_psa_verify_hash_start_req(zcbor_state_t *state,
-					     const struct psa_verify_hash_start_req *input)
-{
-	zcbor_log("%s\r\n", __func__);
-
-	bool tmp_result = (((
-		((zcbor_uint32_put(state, (77)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_verify_hash_start_req_p_operation)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_verify_hash_start_req_key)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_verify_hash_start_req_alg)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_verify_hash_start_req_p_hash)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_verify_hash_start_req_hash_length)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_verify_hash_start_req_p_signature)))) &&
-		((zcbor_uint32_encode(state,
-				      (&(*input).psa_verify_hash_start_req_signature_length)))))));
-
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
-}
-
-static bool encode_psa_verify_hash_abort_req(zcbor_state_t *state,
-					     const struct psa_verify_hash_abort_req *input)
-{
-	zcbor_log("%s\r\n", __func__);
-
-	bool tmp_result = (((((zcbor_uint32_put(state, (78)))) &&
-			     ((zcbor_uint32_encode(
-				     state, (&(*input).psa_verify_hash_abort_req_p_operation)))))));
+	bool tmp_result =
+		((zcbor_tag_put(state, 32775) && (zcbor_uint32_encode(state, (&(*input))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1720,10 +1701,10 @@ static bool encode_psa_pake_setup_req(zcbor_state_t *state, const struct psa_pak
 	zcbor_log("%s\r\n", __func__);
 
 	bool tmp_result =
-		(((((zcbor_uint32_put(state, (79)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_setup_req_p_handle)))) &&
+		(((((zcbor_uint32_put(state, (75)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_pake_setup_req_p_handle)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_setup_req_password_key)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_setup_req_p_cipher_suite)))))));
+		   ((encode_ptr_cipher(state, (&(*input).psa_pake_setup_req_p_cipher_suite)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1741,8 +1722,8 @@ static bool encode_psa_pake_set_role_req(zcbor_state_t *state,
 	zcbor_log("%s\r\n", __func__);
 
 	bool tmp_result =
-		(((((zcbor_uint32_put(state, (80)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_set_role_req_p_handle)))) &&
+		(((((zcbor_uint32_put(state, (76)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_pake_set_role_req_p_handle)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_set_role_req_role)))))));
 
 	if (!tmp_result) {
@@ -1761,10 +1742,10 @@ static bool encode_psa_pake_set_user_req(zcbor_state_t *state,
 	zcbor_log("%s\r\n", __func__);
 
 	bool tmp_result =
-		(((((zcbor_uint32_put(state, (81)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_set_user_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_set_user_req_p_user_id)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_set_user_req_user_id_len)))))));
+		(((((zcbor_uint32_put(state, (77)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_pake_set_user_req_p_handle)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_pake_set_user_req_p_user_id)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_pake_set_user_req_user_id_len)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1782,10 +1763,10 @@ static bool encode_psa_pake_set_peer_req(zcbor_state_t *state,
 	zcbor_log("%s\r\n", __func__);
 
 	bool tmp_result =
-		(((((zcbor_uint32_put(state, (82)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_set_peer_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_set_peer_req_p_peer_id)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_set_peer_req_peer_id_len)))))));
+		(((((zcbor_uint32_put(state, (78)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_pake_set_peer_req_p_handle)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_pake_set_peer_req_p_peer_id)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_pake_set_peer_req_peer_id_len)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1802,11 +1783,11 @@ static bool encode_psa_pake_set_context_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
-		((zcbor_uint32_put(state, (83)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_pake_set_context_req_p_handle)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_pake_set_context_req_p_context)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_pake_set_context_req_context_len)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (79)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_pake_set_context_req_p_handle)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_pake_set_context_req_p_context)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_pake_set_context_req_context_len)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1823,13 +1804,13 @@ static bool encode_psa_pake_output_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_put(state, (84)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_pake_output_req_p_handle)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_pake_output_req_step)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_pake_output_req_p_output)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_pake_output_req_output_size)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_pake_output_req_p_output_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (80)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_pake_output_req_p_handle)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_output_req_step)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_pake_output_req_p_output)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_pake_output_req_output_size)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_pake_output_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1846,11 +1827,11 @@ static bool encode_psa_pake_input_req(zcbor_state_t *state, const struct psa_pak
 	zcbor_log("%s\r\n", __func__);
 
 	bool tmp_result =
-		(((((zcbor_uint32_put(state, (85)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_input_req_p_handle)))) &&
+		(((((zcbor_uint32_put(state, (81)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_pake_input_req_p_handle)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_input_req_step)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_input_req_p_input)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_input_req_input_length)))))));
+		   ((encode_ptr_buf(state, (&(*input).psa_pake_input_req_p_input)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_pake_input_req_input_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1868,11 +1849,10 @@ static bool encode_psa_pake_get_shared_key_req(zcbor_state_t *state,
 	zcbor_log("%s\r\n", __func__);
 
 	bool tmp_result = ((
-		(((zcbor_uint32_put(state, (86)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_pake_get_shared_key_req_p_handle)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_pake_get_shared_key_req_p_attributes)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_pake_get_shared_key_req_p_key)))))));
+		(((zcbor_uint32_put(state, (82)))) &&
+		 ((encode_ptr_uint(state, (&(*input).psa_pake_get_shared_key_req_p_handle)))) &&
+		 ((encode_ptr_attr(state, (&(*input).psa_pake_get_shared_key_req_p_attributes)))) &&
+		 ((encode_ptr_key(state, (&(*input).psa_pake_get_shared_key_req_p_key)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1888,9 +1868,8 @@ static bool encode_psa_pake_abort_req(zcbor_state_t *state, const struct psa_pak
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (87)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_abort_req_p_handle)))))));
+	bool tmp_result = (((((zcbor_uint32_put(state, (83)))) &&
+			     ((encode_ptr_uint(state, (&(*input).psa_pake_abort_req_p_handle)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1991,10 +1970,6 @@ static bool encode_psa_crypto_req(zcbor_state_t *state, const struct psa_crypto_
 	: (((*input).psa_crypto_req_msg_choice == psa_crypto_req_msg_psa_raw_key_agreement_req_m_c) ? ((encode_psa_raw_key_agreement_req(state, (&(*input).psa_crypto_req_msg_psa_raw_key_agreement_req_m))))
 	: (((*input).psa_crypto_req_msg_choice == psa_crypto_req_msg_psa_generate_random_req_m_c) ? ((encode_psa_generate_random_req(state, (&(*input).psa_crypto_req_msg_psa_generate_random_req_m))))
 	: (((*input).psa_crypto_req_msg_choice == psa_crypto_req_msg_psa_generate_key_req_m_c) ? ((encode_psa_generate_key_req(state, (&(*input).psa_crypto_req_msg_psa_generate_key_req_m))))
-	: (((*input).psa_crypto_req_msg_choice == psa_crypto_req_msg_psa_sign_hash_start_req_m_c) ? ((encode_psa_sign_hash_start_req(state, (&(*input).psa_crypto_req_msg_psa_sign_hash_start_req_m))))
-	: (((*input).psa_crypto_req_msg_choice == psa_crypto_req_msg_psa_sign_hash_abort_req_m_c) ? ((encode_psa_sign_hash_abort_req(state, (&(*input).psa_crypto_req_msg_psa_sign_hash_abort_req_m))))
-	: (((*input).psa_crypto_req_msg_choice == psa_crypto_req_msg_psa_verify_hash_start_req_m_c) ? ((encode_psa_verify_hash_start_req(state, (&(*input).psa_crypto_req_msg_psa_verify_hash_start_req_m))))
-	: (((*input).psa_crypto_req_msg_choice == psa_crypto_req_msg_psa_verify_hash_abort_req_m_c) ? ((encode_psa_verify_hash_abort_req(state, (&(*input).psa_crypto_req_msg_psa_verify_hash_abort_req_m))))
 	: (((*input).psa_crypto_req_msg_choice == psa_crypto_req_msg_psa_pake_setup_req_m_c) ? ((encode_psa_pake_setup_req(state, (&(*input).psa_crypto_req_msg_psa_pake_setup_req_m))))
 	: (((*input).psa_crypto_req_msg_choice == psa_crypto_req_msg_psa_pake_set_role_req_m_c) ? ((encode_psa_pake_set_role_req(state, (&(*input).psa_crypto_req_msg_psa_pake_set_role_req_m))))
 	: (((*input).psa_crypto_req_msg_choice == psa_crypto_req_msg_psa_pake_set_user_req_m_c) ? ((encode_psa_pake_set_user_req(state, (&(*input).psa_crypto_req_msg_psa_pake_set_user_req_m))))
@@ -2004,7 +1979,7 @@ static bool encode_psa_crypto_req(zcbor_state_t *state, const struct psa_crypto_
 	: (((*input).psa_crypto_req_msg_choice == psa_crypto_req_msg_psa_pake_input_req_m_c) ? ((encode_psa_pake_input_req(state, (&(*input).psa_crypto_req_msg_psa_pake_input_req_m))))
 	: (((*input).psa_crypto_req_msg_choice == psa_crypto_req_msg_psa_pake_get_shared_key_req_m_c) ? ((encode_psa_pake_get_shared_key_req(state, (&(*input).psa_crypto_req_msg_psa_pake_get_shared_key_req_m))))
 	: (((*input).psa_crypto_req_msg_choice == psa_crypto_req_msg_psa_pake_abort_req_m_c) ? ((encode_psa_pake_abort_req(state, (&(*input).psa_crypto_req_msg_psa_pake_abort_req_m))))
-	: false)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))) || (zcbor_list_map_end_force_encode(state), false)) && zcbor_list_end_encode(state, 12))));
+	: false)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))) || (zcbor_list_map_end_force_encode(state), false)) && zcbor_list_end_encode(state, 12))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);

--- a/subsys/sdfw_services/services/psa_crypto/zcbor_generated/psa_crypto_service_encode.h
+++ b/subsys/sdfw_services/services/psa_crypto/zcbor_generated/psa_crypto_service_encode.h
@@ -5,7 +5,7 @@
  */
 
 /*
- * Generated using zcbor version 0.8.1
+ * Generated using zcbor version 0.8.99
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/subsys/sdfw_services/services/psa_crypto/zcbor_generated/psa_crypto_service_types.h
+++ b/subsys/sdfw_services/services/psa_crypto/zcbor_generated/psa_crypto_service_types.h
@@ -5,7 +5,7 @@
  */
 
 /*
- * Generated using zcbor version 0.8.1
+ * Generated using zcbor version 0.8.99
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */
@@ -485,32 +485,6 @@ struct psa_generate_key_req {
 	uint32_t psa_generate_key_req_p_key;
 };
 
-struct psa_sign_hash_start_req {
-	uint32_t psa_sign_hash_start_req_p_operation;
-	uint32_t psa_sign_hash_start_req_key;
-	uint32_t psa_sign_hash_start_req_alg;
-	uint32_t psa_sign_hash_start_req_p_hash;
-	uint32_t psa_sign_hash_start_req_hash_length;
-};
-
-struct psa_sign_hash_abort_req {
-	uint32_t psa_sign_hash_abort_req_p_operation;
-};
-
-struct psa_verify_hash_start_req {
-	uint32_t psa_verify_hash_start_req_p_operation;
-	uint32_t psa_verify_hash_start_req_key;
-	uint32_t psa_verify_hash_start_req_alg;
-	uint32_t psa_verify_hash_start_req_p_hash;
-	uint32_t psa_verify_hash_start_req_hash_length;
-	uint32_t psa_verify_hash_start_req_p_signature;
-	uint32_t psa_verify_hash_start_req_signature_length;
-};
-
-struct psa_verify_hash_abort_req {
-	uint32_t psa_verify_hash_abort_req_p_operation;
-};
-
 struct psa_pake_setup_req {
 	uint32_t psa_pake_setup_req_p_handle;
 	uint32_t psa_pake_setup_req_password_key;
@@ -644,10 +618,6 @@ struct psa_crypto_req {
 		struct psa_raw_key_agreement_req psa_crypto_req_msg_psa_raw_key_agreement_req_m;
 		struct psa_generate_random_req psa_crypto_req_msg_psa_generate_random_req_m;
 		struct psa_generate_key_req psa_crypto_req_msg_psa_generate_key_req_m;
-		struct psa_sign_hash_start_req psa_crypto_req_msg_psa_sign_hash_start_req_m;
-		struct psa_sign_hash_abort_req psa_crypto_req_msg_psa_sign_hash_abort_req_m;
-		struct psa_verify_hash_start_req psa_crypto_req_msg_psa_verify_hash_start_req_m;
-		struct psa_verify_hash_abort_req psa_crypto_req_msg_psa_verify_hash_abort_req_m;
 		struct psa_pake_setup_req psa_crypto_req_msg_psa_pake_setup_req_m;
 		struct psa_pake_set_role_req psa_crypto_req_msg_psa_pake_set_role_req_m;
 		struct psa_pake_set_user_req psa_crypto_req_msg_psa_pake_set_user_req_m;
@@ -724,10 +694,6 @@ struct psa_crypto_req {
 		psa_crypto_req_msg_psa_raw_key_agreement_req_m_c,
 		psa_crypto_req_msg_psa_generate_random_req_m_c,
 		psa_crypto_req_msg_psa_generate_key_req_m_c,
-		psa_crypto_req_msg_psa_sign_hash_start_req_m_c,
-		psa_crypto_req_msg_psa_sign_hash_abort_req_m_c,
-		psa_crypto_req_msg_psa_verify_hash_start_req_m_c,
-		psa_crypto_req_msg_psa_verify_hash_abort_req_m_c,
 		psa_crypto_req_msg_psa_pake_setup_req_m_c,
 		psa_crypto_req_msg_psa_pake_set_role_req_m_c,
 		psa_crypto_req_msg_psa_pake_set_user_req_m_c,


### PR DESCRIPTION
Added dcache handling using DMM in PSA Crypto service.
Also, four unsupported PSA functions are removed.

Ref: NCSDK-NONE