### PR TITLE
applications: nrf5340_audio: Handle known disconnect reason

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/bt_management/bt_mgmt.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/bt_mgmt.c
@@ -75,8 +75,12 @@ static void connected_cb(struct bt_conn *conn, uint8_t err)
 	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err) {
-		LOG_ERR("ACL connection to addr: %s, conn: %p, failed, error %d", addr,
-			(void *)conn, err);
+		if (err == BT_HCI_ERR_UNKNOWN_CONN_ID) {
+			LOG_WRN("ACL connection to addr: %s timed out, will try again", addr);
+		} else {
+			LOG_ERR("ACL connection to addr: %s, conn: %p, failed, error %d", addr,
+				(void *)conn, err);
+		}
 
 		bt_conn_unref(conn);
 


### PR DESCRIPTION
- Due to high ACL traffic we might get a cancelled ACL creation.
- Change error print for these cases to a warning.
- OCT-NONE