### PR TITLE
tools: rebuild v2.7.0-rc2 darwin tool bundle

### DIFF
--- a/scripts/tools-versions-darwin.yml
+++ b/scripts/tools-versions-darwin.yml
@@ -1,3 +1,4 @@
+# Requirement file for native tools on Darwin 86 and aarch64
 python:
   version: 3.9.6
 git:


### PR DESCRIPTION
There was a pypi environment issue (4 missing packages) that is now fixed

This comment will change the input file hash, and rebuild the bundle. 

Signed-off-by: Thomas Stilwell <thomas.stilwell@nordicsemi.no>
