### PR TITLE
samples: openthread: Add missing `FILE_SUFFIX` to OT cli.

### DIFF
--- a/samples/openthread/cli/README.rst
+++ b/samples/openthread/cli/README.rst
@@ -109,6 +109,11 @@ The following snippets are available:
     See :ref:`app_build_file_suffixes` and :ref:`cmake_options` for more information.
 
 * ``tcat`` - Enables support for Thread commissioning over authenticated TLS.
+
+  .. note::
+    When building with the ``tcat`` snippet for the ``nrf5340dk/nrf5340/cpuapp`` board target, set the :makevar:`FILE_SUFFIX` CMake option to ``ble``.
+    See :ref:`app_build_file_suffixes` and :ref:`cmake_options` for more information.
+
   Not compatible with the ``multiprotocol`` snippet.
   For using TCAT, refer to the :ref:`thread_tcat` page.
 * ``tcp`` - Enables experimental TCP support in this sample.

--- a/samples/openthread/cli/sample.yaml
+++ b/samples/openthread/cli/sample.yaml
@@ -101,6 +101,7 @@ tests:
       nrf54l15pdk/nrf54l15/cpuapp
     extra_args: >
       cli_SNIPPET="ci;tcat;tcp"
+      FILE_SUFFIX=ble
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf21540dk/nrf52840


### PR DESCRIPTION
Commit adds missing `FILE_SUFFIX=ble` to sample yml for TCAT feaure.