### PR TITLE
samples: edge_impulse: data_forwarder: Enable picolib float support

### DIFF
--- a/samples/edge_impulse/data_forwarder/prj.conf
+++ b/samples/edge_impulse/data_forwarder/prj.conf
@@ -14,3 +14,6 @@ CONFIG_UART_ASYNC_API=y
 
 # Enable simulated sensor
 CONFIG_SENSOR=y
+
+# LibC
+CONFIG_PICOLIBC_IO_FLOAT=y


### PR DESCRIPTION
Include floating point support in printk/snprintf functions.