### PR TITLE
bl_crypto: cc310: Do not initialize cc310 from EXT_ABI

### DIFF
--- a/subsys/bootloader/bl_crypto/bl_crypto_cc310_common.c
+++ b/subsys/bootloader/bl_crypto/bl_crypto_cc310_common.c
@@ -33,8 +33,11 @@ int cc310_bl_init(void)
 #if (defined(CONFIG_BL_ROT_VERIFY_EXT_API_ENABLED) || defined(CONFIG_BL_SHA256_EXT_API_ENABLED) \
 	|| defined(CONFIG_BL_SECP256R1_EXT_API_ENABLED)) && defined(PM_B0_END_ADDRESS)
 	uint32_t msp = __get_MSP();
+	uint32_t psp = __get_PSP();
+	bool psp_selected = (__get_CONTROL() & CONTROL_SPSEL_Msk);
+	bool called_from_b0 = psp_selected ? (psp < PM_B0_END_ADDRESS) : (msp < PM_B0_END_ADDRESS);
 
-	if (msp < PM_B0_END_ADDRESS) {
+	if (called_from_b0) {
 #endif
 		static bool initialized;
 


### PR DESCRIPTION
Fix-up for 723194f47bfdc3572c3e5cb27eeab74df23522b9 to add handling for a case where you call this function when you are running from PSP and have modified MSP so that you would still initialize the cc310.

Ref. NCSDK-23962