### PR TITLE
applications: nrf_desktop: Update BLE QoS stats printout

### DIFF
--- a/applications/nrf_desktop/configuration/nrf52840dongle_nrf52840/app.overlay
+++ b/applications/nrf_desktop/configuration/nrf52840dongle_nrf52840/app.overlay
@@ -8,6 +8,7 @@
 		 * the RNG node for entropy exclusively.
 		 */
 		zephyr,entropy = &rng;
+		ncs,ble-qos-uart = &cdc_acm_uart;
 	};
 
 	/* Configure DTS nodes used for USB next HID support. */
@@ -58,6 +59,10 @@
 	num-out-endpoints = <2>;
 	num-isoin-endpoints = <0>;
 	num-isoout-endpoints = <0>;
+};
+
+&cdc_acm_uart {
+		status = "okay";
 };
 
 &pwm0 {

--- a/applications/nrf_desktop/doc/ble_qos.rst
+++ b/applications/nrf_desktop/doc/ble_qos.rst
@@ -32,10 +32,16 @@ The library is linked if :ref:`CONFIG_DESKTOP_BLE_QOS_ENABLE <config_desktop_app
 Enable the module using the :ref:`CONFIG_DESKTOP_BLE_QOS_ENABLE <config_desktop_app_options>` Kconfig option.
 The option selects :kconfig:option:`CONFIG_BT_HCI_VS_EVT_USER`, because the module uses vendor-specific HCI events.
 
-You can use the :ref:`CONFIG_DESKTOP_BLE_QOS_STATS_PRINTOUT_ENABLE <config_desktop_app_options>` option to enable real-time QoS information printouts through a UART (e.g. a virtual COM port).
-The chosen UART needs to be specified in devicetree using ``ncs,ble-qos-uart``.
-This option also enables and configures the COM port (USB CDC ACM).
-For this reason, the :kconfig:option:`CONFIG_USB_DEVICE_STACK` must be enabled.
+You can use the :ref:`CONFIG_DESKTOP_BLE_QOS_STATS_PRINTOUT_ENABLE <config_desktop_app_options>` Kconfig option to enable real-time QoS information printouts through the USB CDC ACM port.
+The :ref:`CONFIG_DESKTOP_USB_STACK_LEGACY <config_desktop_app_options>` Kconfig option must be enabled and the selected USB CDC ACM instance must be enabled, and specified in devicetree using ``ncs,ble-qos-uart`` DT chosen.
+For an example of configuration that specifies the ``ncs,ble-qos-uart`` DT chosen, see the :file:`configuration/nrf52840dongle_nrf52840/app.overlay` file.
+This option automatically selects other Kconfig options needed to handle stats printouts over the USB CDC ACM port:
+
+* :kconfig:option:`CONFIG_USB_COMPOSITE_DEVICE`
+* :kconfig:option:`CONFIG_USB_CDC_ACM`
+* :kconfig:option:`CONFIG_SERIAL`
+* :kconfig:option:`CONFIG_UART_LINE_CTRL`
+* :kconfig:option:`CONFIG_UART_INTERRUPT_DRIVEN`
 
 The QoS module creates additional thread for processing the QoS algorithm.
 You can define the following options:

--- a/applications/nrf_desktop/src/modules/Kconfig.ble_qos
+++ b/applications/nrf_desktop/src/modules/Kconfig.ble_qos
@@ -28,9 +28,14 @@ config DESKTOP_BLE_QOS_STACK_SIZE
 	help
 	  Configure base stack size for QoS processing thread.
 
+DT_CHOSEN_NCS_BLE_QOS_UART := ncs,ble-qos-uart
+DT_COMP_ZEPHYR_CDC_ACM_UART := zephyr,cdc-acm-uart
+
 config DESKTOP_BLE_QOS_STATS_PRINTOUT_ENABLE
 	bool "Enable BLE QoS statistics printout"
-	depends on USB_DEVICE_STACK
+	depends on DESKTOP_USB_STACK_LEGACY
+	depends on $(dt_chosen_enabled,$(DT_CHOSEN_NCS_BLE_QOS_UART)) && \
+		$(dt_chosen_has_compat,$(DT_CHOSEN_NCS_BLE_QOS_UART),$(DT_COMP_ZEPHYR_CDC_ACM_UART))
 	select USB_COMPOSITE_DEVICE
 	select USB_CDC_ACM
 	select SERIAL

--- a/applications/nrf_desktop/src/modules/ble_qos.c
+++ b/applications/nrf_desktop/src/modules/ble_qos.c
@@ -100,8 +100,7 @@ BUILD_ASSERT(THREAD_PRIORITY >= CONFIG_BT_HCI_TX_PRIO);
 
 static void ble_qos_thread_fn(void);
 
-static const struct device *const cdc_dev =
-	DEVICE_DT_GET_OR_NULL(DT_CHOSEN(ncs_ble_qos_uart));
+static const struct device *const cdc_dev = DEVICE_DT_GET_OR_NULL(DT_CHOSEN(ncs_ble_qos_uart));
 static uint32_t cdc_dtr;
 
 enum ble_qos_opt {


### PR DESCRIPTION
Change updates dependencies and documentation of the CONFIG_DESKTOP_BLE_QOS_STATS_PRINTOUT_ENABLE Kconfig option.

Jira: NCSDK-27883