### PR TITLE
lib: lte_link_control: Add logging for LTE registration reject

### DIFF
--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -256,17 +256,14 @@ static void at_handler_cereg(const char *response)
 
 	static enum lte_lc_nw_reg_status prev_reg_status = LTE_LC_NW_REG_NOT_REGISTERED;
 	static struct lte_lc_cell prev_cell;
-	enum lte_lc_nw_reg_status reg_status = 0;
-	struct lte_lc_cell cell = {0};
+	enum lte_lc_nw_reg_status reg_status;
+	struct lte_lc_cell cell;
 	enum lte_lc_lte_mode lte_mode;
-	struct lte_lc_psm_cfg psm_cfg = {
-		.active_time = -1,
-		.tau = -1
-	};
+	struct lte_lc_psm_cfg psm_cfg;
 
 	LOG_DBG("+CEREG notification: %.*s", strlen(response) - strlen("\r\n"), response);
 
-	err = parse_cereg(response, true, &reg_status, &cell, &lte_mode, &psm_cfg);
+	err = parse_cereg(response, &reg_status, &cell, &lte_mode, &psm_cfg);
 	if (err) {
 		LOG_ERR("Failed to parse notification (error %d): %s",
 			err, response);

--- a/lib/lte_link_control/lte_lc_helpers.h
+++ b/lib/lte_link_control/lte_lc_helpers.h
@@ -21,24 +21,18 @@
 #define AT_CFUN_RESPONSE_PREFIX			"+CFUN"
 #define AT_CFUN_MODE_INDEX			1
 #define AT_CFUN_PARAMS_COUNT			2
-#define AT_CFUN_RESPONSE_MAX_LEN		20
 #define AT_CEREG_5				"AT+CEREG=5"
 #define AT_CEREG_READ				"AT+CEREG?"
 #define AT_CEREG_RESPONSE_PREFIX		"+CEREG"
 #define AT_CEREG_PARAMS_COUNT_MAX		11
 #define AT_CEREG_REG_STATUS_INDEX		1
-#define AT_CEREG_READ_REG_STATUS_INDEX		2
 #define AT_CEREG_TAC_INDEX			2
-#define AT_CEREG_READ_TAC_INDEX			3
 #define AT_CEREG_CELL_ID_INDEX			3
-#define AT_CEREG_READ_CELL_ID_INDEX		4
 #define AT_CEREG_ACT_INDEX			4
-#define AT_CEREG_READ_ACT_INDEX			5
+#define AT_CEREG_CAUSE_TYPE_INDEX		5
+#define AT_CEREG_REJECT_CAUSE_INDEX		6
 #define AT_CEREG_ACTIVE_TIME_INDEX		7
-#define AT_CEREG_READ_ACTIVE_TIME_INDEX		8
 #define AT_CEREG_TAU_INDEX			8
-#define AT_CEREG_READ_TAU_INDEX			9
-#define AT_CEREG_RESPONSE_MAX_LEN		80
 #define AT_XSYSTEMMODE_READ			"AT%XSYSTEMMODE?"
 #define AT_XSYSTEMMODE_RESPONSE_PREFIX		"%XSYSTEMMODE"
 #define AT_XSYSTEMMODE_PROTO			"AT%%XSYSTEMMODE=%d,%d,%d,%d"
@@ -49,7 +43,6 @@
 #define AT_XSYSTEMMODE_READ_GPS_INDEX		3
 #define AT_XSYSTEMMODE_READ_PREFERENCE_INDEX	4
 #define AT_XSYSTEMMODE_PARAMS_COUNT		5
-#define AT_XSYSTEMMODE_RESPONSE_MAX_LEN		30
 
 /* CEDRXS command parameters */
 #define AT_CEDRXS_MODE_INDEX
@@ -120,7 +113,6 @@
 #define AT_CONEVAL_READ				"AT%CONEVAL"
 #define AT_CONEVAL_RESPONSE_PREFIX		"%CONEVAL"
 #define AT_CONEVAL_PREFIX_INDEX			0
-#define AT_CONEVAL_RESPONSE_MAX_LEN		110
 #define AT_CONEVAL_PARAMS_MAX			19
 #define AT_CONEVAL_RESULT_INDEX			1
 #define AT_CONEVAL_RRC_STATE_INDEX		2
@@ -220,21 +212,19 @@ int parse_psm(const char *active_time_str, const char *tau_ext_str,
  */
 int encode_psm(char *tau_ext_str, char *active_time_str, int rptau, int rat);
 
-/* @brief Parses an CEREG response and returns network registration status,
- *	  cell information, LTE mode and pSM configuration.
+/* @brief Parses a +CEREG notification and returns network registration status,
+ *	  cell information, LTE mode and PSM configuration. The function always
+ *	  initializes the return values. The destination pointers must be non-NULL.
  *
- * @param at_response Pointer to buffer with AT response.
- * @param is_notif The buffer in at_response is a notification.
- * @param reg_status Pointer to where the registration status is stored.
- *		     Can be NULL.
- * @param cell Pointer to cell information struct. Can be NULL.
- * @param lte_mode Pointer to LTE mode struct. Can be NULL.
- * @param psm_cfg Pointer to PSM configuration struct. Can be NULL.
+ * @param[in] at_response AT notification.
+ * @param[out] reg_status Registration status.
+ * @param[out] cell Cell information.
+ * @param[out] lte_mode LTE mode.
+ * @param[out] psm_cfg PSM configuration.
  *
  * @return Zero on success or (negative) error code otherwise.
  */
 int parse_cereg(const char *at_response,
-		bool is_notif,
 		enum lte_lc_nw_reg_status *reg_status,
 		struct lte_lc_cell *cell,
 		enum lte_lc_lte_mode *lte_mode,


### PR DESCRIPTION
Added a warning log for registration reject EMM cause from the network. Cleaned up `+CEREG` notification parsing.