### PR TITLE
lib: lte_lc: add a new option to control PLMN selection optimization

### DIFF
--- a/lib/lte_link_control/Kconfig
+++ b/lib/lte_link_control/Kconfig
@@ -31,6 +31,14 @@ config LTE_LOCK_BAND_MASK
 	  can be omitted. The maximum length is 88 characters.
 endif # LTE_LOCK_BANDS
 
+config LTE_PLMN_SELECTION_OPTIMIZATION
+	bool "PLMN selection optimization"
+	default y
+	help
+	  Enable PLMN selection optimization during initial search.
+	  This optimization typically makes PLMN selection faster, especially for stationary devices.
+	  Refer to the AT%FEACONF command in the AT command manual for more details.
+
 config LTE_LOCK_PLMN
 	bool "Enable LTE PLMN lock"
 	help

--- a/lib/lte_link_control/lte_lc_modem_hooks.c
+++ b/lib/lte_link_control/lte_lc_modem_hooks.c
@@ -76,6 +76,14 @@ static void on_modem_init(int err, void *ctx)
 		(void)lte_lc_proprietary_psm_req(false);
 	}
 
+	/* Only supported in mfw 2.0.1 and newer.
+	 * Ignore the return value; an error likely means that the feature
+	 * is not supported. This optimization was enabled by default in firmware v2.0.0,
+	 * so that should not be a problem.
+	 */
+	(void)nrf_modem_at_printf("AT%%FEACONF=0,3,%d",
+		IS_ENABLED(CONFIG_LTE_PLMN_SELECTION_OPTIMIZATION));
+
 	err = lte_lc_edrx_req(IS_ENABLED(CONFIG_LTE_EDRX_REQ));
 	if (err) {
 		LOG_ERR("Failed to configure eDRX, err %d", err);


### PR DESCRIPTION
The PLMN selection optimization is disabled by default in the modem firmware from version v2.0.1.
A new `AT%FEACONF` parameter is added to control the feature.

Enabling PLMN selection optimization typically makes the initial search faster, and thus use less power.
There are no known adverse effects.

Introduce a KConfig in `lte_lc` to enable this feature upon modem firmware initialization.
Let this Kconfig be enabled by default.