### PR TITLE
sysbuild: update image specific names to use DEFAULT_IMAGE

### DIFF
--- a/applications/machine_learning/sysbuild.cmake
+++ b/applications/machine_learning/sysbuild.cmake
@@ -31,8 +31,8 @@ if(SB_CONFIG_PARTITION_MANAGER)
 endif()
 
 # Add a dependency so that the remote image will be built first.
-sysbuild_add_dependencies(CONFIGURE machine_learning ipc_radio remote)
+sysbuild_add_dependencies(CONFIGURE ${DEFAULT_IMAGE} ipc_radio remote)
 # Add dependency so that the remote image is flashed first.
-sysbuild_add_dependencies(FLASH machine_learning ipc_radio remote)
+sysbuild_add_dependencies(FLASH ${DEFAULT_IMAGE} ipc_radio remote)
 
 endif()

--- a/samples/caf_sensor_manager/sysbuild.cmake
+++ b/samples/caf_sensor_manager/sysbuild.cmake
@@ -33,6 +33,6 @@ if(SB_CONFIG_PARTITION_MANAGER)
 endif()
 
 # Add a dependency so that the remote sample will be built and flashed first
-sysbuild_add_dependencies(CONFIGURE caf_sensor_manager remote)
+sysbuild_add_dependencies(CONFIGURE ${DEFAULT_IMAGE} remote)
 # Add dependency so that the remote image is flashed first.
-sysbuild_add_dependencies(FLASH caf_sensor_manager remote)
+sysbuild_add_dependencies(FLASH ${DEFAULT_IMAGE} remote)

--- a/samples/event_manager_proxy/sysbuild.cmake
+++ b/samples/event_manager_proxy/sysbuild.cmake
@@ -24,6 +24,6 @@ set_property(GLOBAL PROPERTY DOMAIN_APP_CPUNET remote)
 set(CPUNET_PM_DOMAIN_DYNAMIC_PARTITION remote CACHE INTERNAL "")
 
 # Add a dependency so that the remote sample will be built and flashed first
-sysbuild_add_dependencies(CONFIGURE event_manager_proxy remote)
+sysbuild_add_dependencies(CONFIGURE ${DEFAULT_IMAGE} remote)
 # Add dependency so that the remote image is flashed first.
-sysbuild_add_dependencies(FLASH event_manager_proxy remote)
+sysbuild_add_dependencies(FLASH ${DEFAULT_IMAGE} remote)

--- a/samples/ipc/ipc_service/sysbuild.cmake
+++ b/samples/ipc/ipc_service/sysbuild.cmake
@@ -21,6 +21,6 @@ set_property(GLOBAL PROPERTY DOMAIN_APP_CPUNET remote)
 set(CPUNET_PM_DOMAIN_DYNAMIC_PARTITION remote CACHE INTERNAL "")
 
 # Add a dependency so that the remote sample will be built and flashed first
-sysbuild_add_dependencies(CONFIGURE ipc_service remote)
+sysbuild_add_dependencies(CONFIGURE ${DEFAULT_IMAGE} remote)
 # Add dependency so that the remote image is flashed first.
-sysbuild_add_dependencies(FLASH ipc_service remote)
+sysbuild_add_dependencies(FLASH ${DEFAULT_IMAGE} remote)

--- a/tests/benchmarks/multicore/idle/sysbuild.cmake
+++ b/tests/benchmarks/multicore/idle/sysbuild.cmake
@@ -21,6 +21,6 @@ set_property(GLOBAL PROPERTY DOMAIN_APP_CPUNET remote)
 set(CPUNET_PM_DOMAIN_DYNAMIC_PARTITION remote CACHE INTERNAL "")
 
 # Add a dependency so that the remote image will be built and flashed first
-add_dependencies(idle remote)
+add_dependencies(${DEFAULT_IMAGE} remote)
 # Add dependency so that the remote image is flashed first.
-sysbuild_add_dependencies(FLASH idle remote)
+sysbuild_add_dependencies(FLASH ${DEFAULT_IMAGE} remote)

--- a/tests/subsys/event_manager_proxy/sysbuild.cmake
+++ b/tests/subsys/event_manager_proxy/sysbuild.cmake
@@ -21,6 +21,6 @@ set_property(GLOBAL PROPERTY DOMAIN_APP_CPUNET remote)
 set(CPUNET_PM_DOMAIN_DYNAMIC_PARTITION remote CACHE INTERNAL "")
 
 # Add a dependency so that the remote sample will be built and flashed first
-add_dependencies(event_manager_proxy remote)
+add_dependencies(${DEFAULT_IMAGE} remote)
 # Add dependency so that the remote image is flashed first.
-sysbuild_add_dependencies(FLASH event_manager_proxy remote)
+sysbuild_add_dependencies(FLASH ${DEFAULT_IMAGE} remote)

--- a/tests/subsys/pcd/sysbuild.cmake
+++ b/tests/subsys/pcd/sysbuild.cmake
@@ -21,6 +21,6 @@ set_property(GLOBAL PROPERTY DOMAIN_APP_CPUNET hello_world)
 set(CPUNET_PM_DOMAIN_DYNAMIC_PARTITION hello_world CACHE INTERNAL "")
 
 # Add a dependency so that the remote sample will be built and flashed first
-add_dependencies(pcd hello_world)
+add_dependencies(${DEFAULT_IMAGE} hello_world)
 # Add dependency so that the remote image is flashed first.
-sysbuild_add_dependencies(FLASH pcd hello_world)
+sysbuild_add_dependencies(FLASH ${DEFAULT_IMAGE} hello_world)


### PR DESCRIPTION
The image name is hard coded for dependency configuration, but when using sysbuild the image name of the default image is based on the name of the folder. This means that if sample is copied elsewhere for local modification the hard coded name may no longer match the default image name.

Improve this by using DEFAULT_IMAGE variable instead of hard coded name.

Jira: NCSDK-28028