### PR TITLE
nrf_wifi: Remove dependency on OSAL layer handle

### DIFF
--- a/drivers/wifi/nrf700x/src/fmac_main.c
+++ b/drivers/wifi/nrf700x/src/fmac_main.c
@@ -43,6 +43,7 @@
 LOG_MODULE_DECLARE(wifi_nrf, CONFIG_WIFI_NRF700X_LOG_LEVEL);
 
 struct nrf_wifi_drv_priv_zep rpu_drv_priv_zep;
+extern const struct nrf_wifi_osal_ops nrf_wifi_os_zep_ops;
 
 /* 3 bytes for addreess, 3 bytes for length */
 #define MAX_PKT_RAM_TX_ALIGN_OVERHEAD 6
@@ -258,7 +259,7 @@ static void nrf_wifi_process_rssi_from_rx(void *vif_ctx,
 
 	vif_ctx_zep->rssi = MBM_TO_DBM(signal);
 	vif_ctx_zep->rssi_record_timestamp_us =
-		nrf_wifi_osal_time_get_curr_us(fmac_dev_ctx->fpriv->opriv);
+		nrf_wifi_osal_time_get_curr_us();
 }
 #endif /* CONFIG_NRF700X_STA_MODE */
 
@@ -774,11 +775,21 @@ static int nrf_wifi_drv_main_zep(const struct device *dev)
 	callbk_fns.get_conn_info_callbk_fn = nrf_wifi_supp_event_proc_get_conn_info;
 #endif /* CONFIG_NRF700X_STA_MODE */
 
+	/* The OSAL layer needs to be initialized before any other initialization
+	 * so that other layers (like FW IF,HW IF etc) have access to OS ops
+	 */
+	nrf_wifi_osal_init(&nrf_wifi_os_zep_ops);
+
 	rpu_drv_priv_zep.fmac_priv = nrf_wifi_fmac_init(&data_config,
 							rx_buf_pools,
 							&callbk_fns);
 #else /* !CONFIG_NRF700X_RADIO_TEST */
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
+
+	/* The OSAL layer needs to be initialized before any other initialization
+	 * so that other layers (like FW IF,HW IF etc) have access to OS ops
+	 */
+	nrf_wifi_osal_init(&nrf_wifi_os_zep_ops);
 
 	rpu_drv_priv_zep.fmac_priv = nrf_wifi_fmac_init_rt();
 #endif /* CONFIG_NRF700X_RADIO_TEST */
@@ -820,6 +831,7 @@ static int nrf_wifi_drv_main_zep(const struct device *dev)
 #ifdef CONFIG_NRF700X_RADIO_TEST
 fmac_deinit:
 	nrf_wifi_fmac_deinit_rt(rpu_drv_priv_zep.fmac_priv);
+	nrf_wifi_osal_deinit();
 #endif /* CONFIG_NRF700X_RADIO_TEST */
 err:
 	return -1;

--- a/drivers/wifi/nrf700x/src/net_if.c
+++ b/drivers/wifi/nrf700x/src/net_if.c
@@ -513,8 +513,7 @@ enum nrf_wifi_status nrf_wifi_get_mac_addr(struct nrf_wifi_vif_ctx_zep *vif_ctx_
 	}
 #endif
 
-	if (!nrf_wifi_utils_is_mac_addr_valid(fmac_dev_ctx->fpriv->opriv,
-	    vif_ctx_zep->mac_addr.addr)) {
+	if (!nrf_wifi_utils_is_mac_addr_valid(vif_ctx_zep->mac_addr.addr)) {
 		LOG_ERR("%s: Invalid MAC address: %s",
 			__func__,
 			net_sprint_ll_addr(vif_ctx_zep->mac_addr.addr,
@@ -718,8 +717,7 @@ int nrf_wifi_if_start_zep(const struct device *dev)
 	mac_addr = net_if_get_link_addr(vif_ctx_zep->zep_net_if_ctx)->addr;
 	mac_addr_len = net_if_get_link_addr(vif_ctx_zep->zep_net_if_ctx)->len;
 
-	if (!nrf_wifi_utils_is_mac_addr_valid(fmac_dev_ctx->fpriv->opriv,
-					      mac_addr)) {
+	if (!nrf_wifi_utils_is_mac_addr_valid(mac_addr)) {
 		status = nrf_wifi_get_mac_addr(vif_ctx_zep);
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			LOG_ERR("%s: Failed to get MAC address",

--- a/drivers/wifi/nrf700x/src/shim.c
+++ b/drivers/wifi/nrf700x/src/shim.c
@@ -881,7 +881,7 @@ static unsigned int zep_shim_strlen(const void *str)
 	return strlen(str);
 }
 
-static const struct nrf_wifi_osal_ops nrf_wifi_os_zep_ops = {
+const struct nrf_wifi_osal_ops nrf_wifi_os_zep_ops = {
 	.mem_alloc = zep_shim_mem_alloc,
 	.mem_zalloc = zep_shim_mem_zalloc,
 	.mem_free = k_free,
@@ -971,8 +971,3 @@ static const struct nrf_wifi_osal_ops nrf_wifi_os_zep_ops = {
 	.assert = zep_shim_assert,
 	.strlen = zep_shim_strlen,
 };
-
-const struct nrf_wifi_osal_ops *get_os_ops(void)
-{
-	return &nrf_wifi_os_zep_ops;
-}

--- a/drivers/wifi/nrf700x/src/wifi_mgmt.c
+++ b/drivers/wifi/nrf700x/src/wifi_mgmt.c
@@ -203,15 +203,13 @@ int nrf_wifi_get_power_save_config(const struct device *dev,
 	}
 
 	do {
-		nrf_wifi_osal_sleep_ms(fmac_dev_ctx->fpriv->opriv,
-					1);
+		nrf_wifi_osal_sleep_ms(1);
 		 count++;
 	} while ((vif_ctx_zep->ps_config_info_evnt == false) &&
 		 (count < NRF_WIFI_FMAC_PS_CONF_EVNT_RECV_TIMEOUT));
 
 	if (count == NRF_WIFI_FMAC_PS_CONF_EVNT_RECV_TIMEOUT) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Timed out",
+		nrf_wifi_osal_log_err("%s: Timed out",
 				      __func__);
 		goto out;
 	}
@@ -697,19 +695,16 @@ void nrf_wifi_event_proc_twt_sleep_zep(void *vif_ctx,
 
 	switch (sleep_evnt->info.type) {
 	case TWT_BLOCK_TX:
-		nrf_wifi_osal_spinlock_take(fmac_dev_ctx->fpriv->opriv,
-					    def_dev_ctx->tx_config.tx_lock);
+		nrf_wifi_osal_spinlock_take(def_dev_ctx->tx_config.tx_lock);
 
 		def_dev_ctx->twt_sleep_status = NRF_WIFI_FMAC_TWT_STATE_SLEEP;
 
 		wifi_mgmt_raise_twt_sleep_state(vif_ctx_zep->zep_net_if_ctx,
 						WIFI_TWT_STATE_SLEEP);
-		nrf_wifi_osal_spinlock_rel(fmac_dev_ctx->fpriv->opriv,
-					    def_dev_ctx->tx_config.tx_lock);
+		nrf_wifi_osal_spinlock_rel(def_dev_ctx->tx_config.tx_lock);
 	break;
 	case TWT_UNBLOCK_TX:
-		nrf_wifi_osal_spinlock_take(fmac_dev_ctx->fpriv->opriv,
-					    def_dev_ctx->tx_config.tx_lock);
+		nrf_wifi_osal_spinlock_take(def_dev_ctx->tx_config.tx_lock);
 		def_dev_ctx->twt_sleep_status = NRF_WIFI_FMAC_TWT_STATE_AWAKE;
 		wifi_mgmt_raise_twt_sleep_state(vif_ctx_zep->zep_net_if_ctx,
 						WIFI_TWT_STATE_AWAKE);
@@ -722,8 +717,7 @@ void nrf_wifi_event_proc_twt_sleep_zep(void *vif_ctx,
 			}
 		}
 #endif
-		nrf_wifi_osal_spinlock_rel(fmac_dev_ctx->fpriv->opriv,
-				def_dev_ctx->tx_config.tx_lock);
+		nrf_wifi_osal_spinlock_rel(def_dev_ctx->tx_config.tx_lock);
 	break;
 	default:
 	break;

--- a/drivers/wifi/nrf700x/src/wifi_mgmt_scan.c
+++ b/drivers/wifi/nrf700x/src/wifi_mgmt_scan.c
@@ -192,7 +192,7 @@ int nrf_wifi_disp_scan_zep(const struct device *dev, struct wifi_scan_params *pa
 			}
 
 			scan_info->scan_params.center_frequency[k++] = nrf_wifi_utils_chan_to_freq(
-				fmac_dev_ctx->fpriv->opriv, band, params->band_chan[i].channel);
+				band, params->band_chan[i].channel);
 
 			if (scan_info->scan_params.center_frequency[k - 1] == -1) {
 				LOG_ERR("%s: Invalid channel %d", __func__,
@@ -414,23 +414,16 @@ void nrf_wifi_rx_bcn_prb_resp_frm(void *vif_ctx,
 
 	fmac_dev_ctx = rpu_ctx_zep->rpu_ctx;
 
-	frame_length = nrf_wifi_osal_nbuf_data_size(fmac_dev_ctx->fpriv->opriv,
-						    nwb);
+	frame_length = nrf_wifi_osal_nbuf_data_size(nwb);
 
 	if (frame_length > CONFIG_WIFI_MGMT_RAW_SCAN_RESULT_LENGTH) {
-		nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-				      &bcn_prb_resp_info.data,
-				      nrf_wifi_osal_nbuf_data_get(
-						fmac_dev_ctx->fpriv->opriv,
-						nwb),
+		nrf_wifi_osal_mem_cpy(&bcn_prb_resp_info.data,
+				      nrf_wifi_osal_nbuf_data_get(nwb),
 				      CONFIG_WIFI_MGMT_RAW_SCAN_RESULT_LENGTH);
 
 	} else {
-		nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-				      &bcn_prb_resp_info.data,
-				      nrf_wifi_osal_nbuf_data_get(
-					      fmac_dev_ctx->fpriv->opriv,
-					      nwb),
+		nrf_wifi_osal_mem_cpy(&bcn_prb_resp_info.data,
+				      nrf_wifi_osal_nbuf_data_get(nwb),
 				      frame_length);
 	}
 

--- a/drivers/wifi/nrf700x/src/wifi_util.c
+++ b/drivers/wifi/nrf700x/src/wifi_util.c
@@ -295,7 +295,7 @@ static int nrf_wifi_util_tx_stats(const struct shell *shell,
 
 	for (int i = 0; i < NRF_WIFI_FMAC_AC_MAX ; i++) {
 		queue = def_dev_ctx->tx_config.data_pending_txq[peer_index][i];
-		tx_pending_pkts = nrf_wifi_utils_q_len(fmac_dev_ctx->fpriv->opriv, queue);
+		tx_pending_pkts = nrf_wifi_utils_q_len(queue);
 
 		shell_fprintf(
 			shell,

--- a/drivers/wifi/nrf700x/src/wpa_supp_if.c
+++ b/drivers/wifi/nrf700x/src/wpa_supp_if.c
@@ -1172,8 +1172,8 @@ int nrf_wifi_wpa_supp_signal_poll(void *if_priv, struct wpa_signal_info *si, uns
 
 	vif_ctx_zep->signal_info = si;
 
-	rssi_record_elapsed_time_ms = nrf_wifi_osal_time_elapsed_us(fmac_dev_ctx->fpriv->opriv,
-						    vif_ctx_zep->rssi_record_timestamp_us) / 1000;
+	rssi_record_elapsed_time_ms =
+		nrf_wifi_osal_time_elapsed_us(vif_ctx_zep->rssi_record_timestamp_us) / 1000;
 
 	if (rssi_record_elapsed_time_ms > CONFIG_NRF700X_RSSI_STALE_TIMEOUT_MS) {
 		ret = nrf_wifi_fmac_get_station(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx, bssid);

--- a/samples/wifi/radio_test/src/nrf_wifi_radio_ficr_shell.c
+++ b/samples/wifi/radio_test/src/nrf_wifi_radio_ficr_shell.c
@@ -305,8 +305,7 @@ static int nrf_wifi_radio_test_otp_write_params(const struct shell *shell,
 		write_val[0] = strtoul(argv[2], NULL, 0);
 		write_val[1] = strtoul(argv[3], NULL, 0) & 0xFFFF;
 
-		if (!nrf_wifi_utils_is_mac_addr_valid(fmac_dev_ctx->fpriv->opriv,
-				(const char *)&write_val[0])) {
+		if (!nrf_wifi_utils_is_mac_addr_valid((const char *)&write_val[0])) {
 			shell_fprintf(shell,
 				      SHELL_ERROR,
 				      "Invalid MAC address. MAC address cannot be all 0's, broadcast or multicast address\n");

--- a/west.yml
+++ b/west.yml
@@ -148,7 +148,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 6bc32b5a8d7fb82317350dad8323b35fbe03c666
+      revision: 153b5817280e5b127a6563ec1357c7af64de49b4
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Removes the requirement for the different layers in the OS agnostic parts of the driver having to maintain a handle to the OS interface layer in order to call the OS interface calls. The OS interface layer now maitains the handle to OS-specific ops internally and invokes the appropriate functions.

Fixes SHEL-2639