### PR TITLE
west.yml: Update sdk-zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 3611f46f85c0980c19b60bb842033cbaba35e023
+      revision: pull/1835/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update sdk-zephyr to bring in fix for a build warning when building nRF Desktop with BLE QoS stats printout enabled.

Jira: NCSDK-27883