### PR TITLE
Samples: Bluetooth: Mesh: add nrf54l15 back to dfu integration test

### DIFF
--- a/samples/bluetooth/mesh/dfu/distributor/sample.yaml
+++ b/samples/bluetooth/mesh/dfu/distributor/sample.yaml
@@ -6,6 +6,7 @@ tests:
     build_only: true
     integration_platforms:
       - nrf52840dk/nrf52840
+      - nrf54l15pdk/nrf54l15/cpuapp
     platform_allow: nrf52840dk/nrf52840 nrf54l15pdk/nrf54l15/cpuapp
     tags: bluetooth ci_build sysbuild
   sample.bluetooth.mesh_dfu_distributor.smp_bt_auth:


### PR DESCRIPTION
Adding nrf54l15 target for integration platforms for twister tests.