### PR TITLE
applications: Aligned retained RAM partitions for diagnostic logs

### DIFF
--- a/applications/matter_weather_station/app.overlay
+++ b/applications/matter_weather_station/app.overlay
@@ -25,9 +25,9 @@
 		buzzer-pwm = &buzzer;
 	};
 
-	sram@2007EB40 {
+	sram@2007E340 {
 		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x2007EB40 0x14C0>;
+		reg = <0x2007E340 0x1CC0>;
 		zephyr,memory-region = "DiagnosticLogMem";
 		status = "okay";
 		retainedmem {
@@ -44,20 +44,20 @@
 					checksum = <2>;
 			};
 
-			/* Reserve 4 kB for the end user logs. */
-			end_user_logs_retention: retention@c0 {
+			/* Reserve 6 kB for the network logs. */
+			network_logs_retention: retention@c0 {
 					compatible = "zephyr,retention";
 					status = "okay";
-					reg = <0xC0 0x1000>;
+					reg = <0xC0 0x1800>;
 					prefix = [06 03];
 					checksum = <2>;
 			};
 
-			/* Reserve 1 kB for the network logs. */
-			network_logs_retention: retention@10c0 {
+			/* Reserve 1 kB for the end user logs. */
+			end_user_logs_retention: retention@18c0 {
 					compatible = "zephyr,retention";
 					status = "okay";
-					reg = <0x10C0 0x400>;
+					reg = <0x18C0 0x400>;
 					prefix = [05 02];
 					checksum = <2>;
 			};
@@ -100,7 +100,7 @@
 	status = "disabled";
 };
 
-/* Reduce SRAM0 usage by 5312B to account for non-init area */
+/* Reduce SRAM0 usage by 7360 B to account for non-init area */
 &sram0 {
-	reg = <0x20000000 0x7EB40>;
+	reg = <0x20000000 0x7E340>;
 };


### PR DESCRIPTION
The retained RAM partitions for diagnostic logs were changed in all other samples, but Matter weather station was accidentally missed.