### PR TITLE
Nrfx-6038 run samples sensor bme and accel_polling on nrf54l15/cpuflpr and nrf54h20/cpuppr

### DIFF
--- a/boards/shields/pca63565/boards/nrf54l15pdk_nrf54l15_cpuflpr.overlay
+++ b/boards/shields/pca63565/boards/nrf54l15pdk_nrf54l15_cpuflpr.overlay
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2024 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	aliases {
+		sensor-bme688 = &i2c22;
+		accel0 = &adxl362;
+		accel-gyro = &bmi270;
+		/delete-property/ led2;
+		/delete-property/ led3;
+		/delete-property/ sw3;
+	};
+};
+
+/delete-node/ &led2;	// P1.13 is bmi270 chip select signal
+/delete-node/ &led3;	// P1.14 is adxl362 interrupt signal
+/delete-node/ &button3; // P2.10 is adxl362 chip select signal
+
+&pinctrl {
+	i2c22_default: i2c22_default {
+		group1  {
+			psels = <NRF_PSEL(TWIM_SCL, 1, 11)>,
+					<NRF_PSEL(TWIM_SDA, 1, 12)>;
+		};
+	};
+
+	i2c22_sleep: i2c22_sleep {
+		group1  {
+			psels = <NRF_PSEL(TWIM_SCL, 1, 11)>,
+					<NRF_PSEL(TWIM_SDA, 1, 12)>;
+			low-power-enable;
+		};
+	};
+
+	spi00_default: spi00_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 2, 6)>,
+					<NRF_PSEL(SPIM_MISO, 2, 9)>,
+					<NRF_PSEL(SPIM_MOSI, 2, 8)>;
+		};
+	};
+
+	spi00_sleep: spi00_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 2, 6)>,
+					<NRF_PSEL(SPIM_MISO, 2, 9)>,
+					<NRF_PSEL(SPIM_MOSI, 2, 8)>;
+			low-power-enable;
+		};
+	};
+};
+
+&i2c22 {
+	status = "okay";
+	zephyr,concat-buf-size = <512>;
+	pinctrl-0 = <&i2c22_default>;
+	pinctrl-1 = <&i2c22_sleep>;
+	pinctrl-names = "default", "sleep";
+
+	bme688: bme688@76 {
+		compatible = "bosch,bme680";
+		status = "okay";
+		reg = <0x76>;
+	};
+};
+
+&spi00 {
+	status = "okay";
+	pinctrl-0 = <&spi00_default>;
+	pinctrl-1 = <&spi00_sleep>;
+	pinctrl-names = "default", "sleep";
+	cs-gpios = <&gpio1 13 GPIO_ACTIVE_LOW>,
+			   <&gpio2 10 GPIO_ACTIVE_LOW>;
+
+	bmi270: bmi270@0 {
+		compatible = "bosch,bmi270";
+		status = "okay";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(8)>;
+	};
+
+	adxl362: adxl362@1 {
+		compatible = "adi,adxl362";
+		status = "okay";
+		reg = <1>;
+		int1-gpios = <&gpio1 14 (GPIO_ACTIVE_HIGH)>;
+		spi-max-frequency = <DT_FREQ_M(8)>;
+	};
+};

--- a/boards/shields/pca63565/boards/nrf54l15pdk_nrf54l15_vpr_launcher.overlay
+++ b/boards/shields/pca63565/boards/nrf54l15pdk_nrf54l15_vpr_launcher.overlay
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2024 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/*
+ * SHIELD is applied to both FLPR and Application cores.
+ * Disable sensors on Application core because:
+ *   - vpr_launcher is not using them;
+ *   - prevent collision when both cores try to initialize same resource;
+ */
+
+&i2c22 {
+    status = "disabled";
+};
+
+&bme688 {
+    status = "disabled";
+};
+
+&spi00 {
+    status = "disabled";
+};
+
+&bmi270 {
+    status = "disabled";
+};
+
+&adxl362 {
+    status = "disabled";
+};

--- a/boards/shields/pca63566/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
+++ b/boards/shields/pca63566/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2024 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	aliases {
+		sensor-bme688 = &i2c130;
+		accel0 = &adxl362;
+		accel-gyro = &bmi270;
+	};
+};
+
+&pinctrl {
+	i2c130_default: i2c130_default {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 2, 8)>,
+				<NRF_PSEL(TWIM_SCL, 2, 3)>;
+				bias-pull-up;
+		};
+	};
+
+	i2c130_sleep: i2c130_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 2, 8)>,
+				<NRF_PSEL(TWIM_SCL, 2, 3)>;
+			low-power-enable;
+			bias-pull-up;
+		};
+	};
+
+	spi131_default: spi131_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_MISO, 1, 6)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 5)>,
+				<NRF_PSEL(SPIM_SCK, 1, 1)>;
+		};
+	};
+
+	spi131_sleep: spi131_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_MISO, 1, 6)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 5)>,
+				<NRF_PSEL(SPIM_SCK, 1, 1)>;
+				low-power-enable;
+		};
+	};
+};
+
+&i2c130 {
+	compatible = "nordic,nrf-twim";
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	pinctrl-0 = <&i2c130_default>;
+	pinctrl-1 = <&i2c130_sleep>;
+	pinctrl-names = "default", "sleep";
+	memory-regions = <&cpuapp_dma_region>;
+	bme688: bme688@76 {
+		compatible = "bosch,bme680";
+		status = "okay";
+		reg = <0x76>;
+	};
+	zephyr,concat-buf-size = <255>;
+};
+
+&cpuapp_dma_region {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpiote130 {
+	status = "okay";
+	owned-channels = <7>;
+};
+
+&spi131 {
+	compatible = "nordic,nrf-spim";
+/* Disabled to enable I2C sensor test.
+ * SPI driver is not yet enabled on PPR.
+ */
+	status = "disabled";
+	pinctrl-0 = <&spi131_default>;
+	pinctrl-1 = <&spi131_sleep>;
+	pinctrl-names = "default", "sleep";
+	overrun-character = <0x00>;
+	cs-gpios = <&gpio0 4 GPIO_ACTIVE_LOW>,
+				<&gpio1 2 GPIO_ACTIVE_LOW>;
+	memory-regions = <&cpuapp_dma_region>;
+
+	bmi270: bmi270@0 {
+		compatible = "bosch,bmi270";
+/* Disabled to enable I2C sensor test.
+ * SPI driver is not yet enabled on PPR.
+ */
+		status = "disabled";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(8)>;
+	};
+
+	adxl362: adxl362@1 {
+		compatible = "adi,adxl362";
+/* Disabled to enable I2C sensor test.
+ * SPI driver is not yet enabled on PPR.
+ */
+		status = "disabled";
+		reg = <1>;
+		int1-gpios = <&gpio1 8 (GPIO_ACTIVE_HIGH)>;
+		spi-max-frequency = <DT_FREQ_M(8)>;
+	};
+};

--- a/boards/shields/pca63566/boards/nrf54h20dk_nrf54h20_vpr_launcher.overlay
+++ b/boards/shields/pca63566/boards/nrf54h20dk_nrf54h20_vpr_launcher.overlay
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2024 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&pinctrl {
+    i2c130_default: i2c130_default {
+        group1 {
+            psels = <NRF_PSEL(TWIM_SDA, 2, 8)>,
+                <NRF_PSEL(TWIM_SCL, 2, 3)>;
+                bias-pull-up;
+        };
+    };
+
+    i2c130_sleep: i2c130_sleep {
+        group1 {
+            psels = <NRF_PSEL(TWIM_SDA, 2, 8)>,
+                <NRF_PSEL(TWIM_SCL, 2, 3)>;
+            low-power-enable;
+            bias-pull-up;
+        };
+    };
+
+    spi131_default: spi131_default {
+        group1 {
+            psels = <NRF_PSEL(SPIM_MISO, 1, 6)>,
+                <NRF_PSEL(SPIM_MOSI, 1, 5)>,
+                <NRF_PSEL(SPIM_SCK, 1, 1)>;
+        };
+    };
+
+    spi131_sleep: spi131_sleep {
+        group1 {
+            psels = <NRF_PSEL(SPIM_MISO, 1, 6)>,
+                <NRF_PSEL(SPIM_MOSI, 1, 5)>,
+                <NRF_PSEL(SPIM_SCK, 1, 1)>;
+                low-power-enable;
+        };
+    };
+};
+
+&i2c130 {
+    compatible = "nordic,nrf-twim";
+    status = "reserved";
+    interrupt-parent = <&cpuppr_clic>;
+    clock-frequency = <I2C_BITRATE_STANDARD>;
+    pinctrl-0 = <&i2c130_default>;
+    pinctrl-1 = <&i2c130_sleep>;
+    pinctrl-names = "default", "sleep";
+    memory-regions = <&cpuapp_dma_region>;
+    bme688: bme688@76 {
+        compatible = "bosch,bme680";
+        status = "disabled";
+        reg = <0x76>;
+    };
+    zephyr,concat-buf-size = <255>;
+};
+
+&cpuapp_dma_region {
+    status = "okay";
+};
+
+&gpio1 {
+    status = "okay";
+};
+
+&gpiote130 {
+    owned-channels = < 7 >;
+    nonsecure-channels = < 7 >;
+    child-owned-channels = < 7 >;
+};
+
+&spi131 {
+    compatible = "nordic,nrf-spim";
+    status = "reserved";
+    interrupt-parent = <&cpuppr_clic>;
+    pinctrl-0 = <&spi131_default>;
+    pinctrl-1 = <&spi131_sleep>;
+    pinctrl-names = "default", "sleep";
+    overrun-character = <0x00>;
+    cs-gpios = <&gpio0 4 GPIO_ACTIVE_LOW>,
+                <&gpio1 2 GPIO_ACTIVE_LOW>;
+    memory-regions = <&cpuapp_dma_region>;
+
+    bmi270: bmi270@0 {
+        compatible = "bosch,bmi270";
+        status = "disabled";
+        reg = <0>;
+        spi-max-frequency = <DT_FREQ_M(8)>;
+    };
+
+    adxl362: adxl362@1 {
+        compatible = "adi,adxl362";
+        status = "disabled";
+        reg = <1>;
+        int1-gpios = <&gpio1 8 (GPIO_ACTIVE_HIGH)>;
+        spi-max-frequency = <DT_FREQ_M(8)>;
+    };
+};

--- a/scripts/twister/alt/zephyr/samples/sensor/accel_polling/sample.yaml
+++ b/scripts/twister/alt/zephyr/samples/sensor/accel_polling/sample.yaml
@@ -18,6 +18,20 @@ tests:
       - SHIELD=pca63566
     platform_allow: nrf54h20dk/nrf54h20/cpuapp
 
+  sample.sensor.accel_polling.nrf54h_cpuppr:
+    filter: not CONFIG_COVERAGE
+    sysbuild: true
+    harness_config:
+      fixture: pca63566
+      type: one_line
+      regex:
+        - "^\\s*[0-9A-Za-z_,+-.]*@[0-9A-Fa-f]* \\[m\/s\\^2\\]:    \
+           \\(\\s*-?[0-9\\.]*,\\s*-?[0-9\\.]*,\\s*-?[0-9\\.]*\\)$"
+    extra_args:
+      - SHIELD=pca63566
+      - vpr_launcher_DTC_OVERLAY_FILE="../../../../nrf/boards/shields/pca63566/boards/nrf54h20dk_nrf54h20_vpr_launcher.overlay"
+    platform_allow: nrf54h20dk/nrf54h20/cpuppr
+
   sample.sensor.accel_polling.nrf54h_coverage:
     filter: CONFIG_COVERAGE
     harness_config:
@@ -53,3 +67,17 @@ tests:
     extra_args:
       - SHIELD=pca63565;coverage_support
     platform_allow: nrf54l15pdk/nrf54l15/cpuapp
+
+  sample.sensor.accel_polling.nrf54l_cpuflpr:
+    filter: not CONFIG_COVERAGE
+    sysbuild: true
+    harness_config:
+      fixture: pca63565
+      type: one_line
+      regex:
+        - "^\\s*[0-9A-Za-z_,+-.]*@[0-9A-Fa-f]* \\[m\/s\\^2\\]:    \
+           \\(\\s*-?[0-9\\.]*,\\s*-?[0-9\\.]*,\\s*-?[0-9\\.]*\\)$"
+    extra_args:
+      - SHIELD=pca63565
+      - vpr_launcher_DTC_OVERLAY_FILE="../../../../nrf/boards/shields/pca63565/boards/nrf54l15pdk_nrf54l15_vpr_launcher.overlay"
+    platform_allow: nrf54l15pdk/nrf54l15/cpuflpr

--- a/scripts/twister/alt/zephyr/samples/sensor/bme680/sample.yaml
+++ b/scripts/twister/alt/zephyr/samples/sensor/bme680/sample.yaml
@@ -17,6 +17,19 @@ tests:
       - SHIELD=pca63566
     platform_allow: nrf54h20dk/nrf54h20/cpuapp
 
+  sample.sensor.bme680.nrf54h_cpuppr:
+    filter: not CONFIG_COVERAGE
+    sysbuild: true
+    harness_config:
+      fixture: pca63566
+      type: one_line
+      regex:
+        - "^\\s*T:\\s*-?[0-9\\.]*; P:\\s*-?[0-9\\.]*; H: \\s*-?[0-9\\.]*; G:\\s*-?[0-9\\.]*$"
+    extra_args:
+      - SHIELD=pca63566
+      - vpr_launcher_DTC_OVERLAY_FILE="../../../../nrf/boards/shields/pca63566/boards/nrf54h20dk_nrf54h20_vpr_launcher.overlay"
+    platform_allow: nrf54h20dk/nrf54h20/cpuppr
+
   sample.sensor.bme680.nrf54h_coverage:
     filter: CONFIG_COVERAGE
     harness_config:
@@ -49,3 +62,16 @@ tests:
     extra_args:
       - SHIELD=pca63565;coverage_support
     platform_allow: nrf54l15pdk/nrf54l15/cpuapp
+
+  sample.sensor.bme680.nrf54l_cpuflpr:
+    filter: not CONFIG_COVERAGE
+    sysbuild: true
+    harness_config:
+      fixture: pca63565
+      type: one_line
+      regex:
+        - "^\\s*T:\\s*-?[0-9\\.]*; P:\\s*-?[0-9\\.]*; H: \\s*-?[0-9\\.]*; G:\\s*-?[0-9\\.]*$"
+    extra_args:
+      - SHIELD=pca63565
+      - vpr_launcher_DTC_OVERLAY_FILE="../../../../nrf/boards/shields/pca63565/boards/nrf54l15pdk_nrf54l15_vpr_launcher.overlay"
+    platform_allow: nrf54l15pdk/nrf54l15/cpuflpr


### PR DESCRIPTION
samples/sensor/bme680 was manually tested and confirmed to work on both FLPR and PPR (missing i2c on supported list).

samples/sensor/accel_polling was manually tested and confirmed to work on FLPR. It doesn't compile on PPR due to missing SPI support.