### PR TITLE
manifest: Update sdk-zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: b37d8914af3b4bef91540f33094f5cb56c2f6c1c
+      revision: pull/1840/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update sdk-zephyr to pull in fix for hash_map testing.

Jira: NCSDK-27925
Jira: NCSDK-28096