### PR TITLE
manifest: update sdk-zephyr

### DIFF
--- a/scripts/quarantine_zephyr.yaml
+++ b/scripts/quarantine_zephyr.yaml
@@ -420,6 +420,7 @@
     - kernel.context
     - shell.min_cmds_all
     - shell.min_colors
+    - drivers.gpio.build
   platforms:
     - nrf54h20dk/nrf54h20/cpuppr
   comment: "region RAM/FLASH overflowed"

--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 58284ff0e1b85f24d1be928860e9e6eb0e86b4e5
+      revision: pull/1843/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
boards: nordic: nrf54h20dk: Counter and i2c are supported by cpuppr
https://github.com/nrfconnect/sdk-zephyr/pull/1843
https://github.com/zephyrproject-rtos/zephyr/pull/74644