### PR TITLE
manifest: Pull DHCPv4 Renew/Rebind fix to sdk-zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 297b00dade9f72873f9dd9147008e4a90516a3ff
+      revision: pull/1844/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull fixes for DHCPv4 Renew/Rebind states logic.

NCSIDB-1270