### PR TITLE
samples: suit: Update mobile app versions

### DIFF
--- a/applications/nrf_desktop/bootloader_dfu.rst
+++ b/applications/nrf_desktop/bootloader_dfu.rst
@@ -326,8 +326,8 @@ To perform DFU using the `nRF Connect Device Manager`_ mobile app, complete the 
       .. note::
          Support for SUIT updates is available starting from the following versions of the `nRF Connect Device Manager`_ mobile app:
 
-         * Version ``1.10`` on Android.
-         * Version ``1.6`` on iOS.
+         * Version ``2.0`` on Android.
+         * Version ``1.7`` on iOS.
 
 Update image verification and application image update
 ======================================================

--- a/samples/suit/smp_transfer/README.rst
+++ b/samples/suit/smp_transfer/README.rst
@@ -22,10 +22,10 @@ The sample supports the following development kit:
 You need the nRF Device Manager app for SUIT update over Bluetooth Low Energy:
 
 * `nRF Device Manager mobile app for Android`_
-  (The minimum required version is v1.9.)
+  (The minimum required version is v2.0.)
 
 * `nRF Device Manager mobile app for iOS`_
-  (The minimum required version is v1.5.)
+  (The minimum required version is v1.7.)
 
 For a SUIT update over UART, you need to install :ref:`zephyr:mcu_mgr`, a tool that can be used to upload SUIT envelopes through the SMP protocol.
 


### PR DESCRIPTION
It is required to use the newest mobile app to perform SUIT-based DFU.

Ref: NCSDK-NONE