### PR TITLE
manifest: Update sdk-zephyr to bring nRF54L LFXO, HFXO fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 297b00dade9f72873f9dd9147008e4a90516a3ff
+      revision: pull/1847/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update the manifest to bring fixes related to nRF54L LFXO and HFXO INTCAP codes calculations. Those fixes make accuracy of both crystals in nRF54L to be better.