### PR TITLE
tests: bluetooth: extend bluetooth tag for tests

### DIFF
--- a/samples/bluetooth/peripheral_hids_mouse/sample.yaml
+++ b/samples/bluetooth/peripheral_hids_mouse/sample.yaml
@@ -48,4 +48,4 @@ tests:
     platform_allow: nrf5340dk/nrf5340/cpuapp
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
-    tags: sysbuild
+    tags: bluetooth sysbuild

--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -48,10 +48,16 @@ bluetooth:
   files:
     - zephyr/drivers/bluetooth/
     - zephyr/subsys/bluetooth/
-    - zephyr/subsys/net/l2/bluetooth/
-#    Examples:
-#    - nrf/drivers/bluetooth/
-#    - nrf/subsys/bluetooth/
+    - zephyr/include/zephyr/bluetooth/
+    - nrfxlib/softdevice_controller/include/
+    - nrfxlib/softdevice_controller/lib/
+    - nrfxlib/mpsl/include/
+    - nrfxlib/mpsl/lib/
+    - nrf/subsys/bluetooth/
+    - nrf/include/bluetooth/
+    - nrf/subsys/nrf_rpc/
+    - nrf/subsys/mpsl/
+    - nrf/drivers/mpsl/
 
 net:
   files:

--- a/tests/bluetooth/iso/testcase.yaml
+++ b/tests/bluetooth/iso/testcase.yaml
@@ -6,5 +6,5 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340_audio_dk/nrf5340/cpuapp
-    tags: bis_and_acl sysbuild
+    tags: bis_and_acl sysbuild bluetooth
     timeout: 20

--- a/tests/subsys/bluetooth/gatt_dm/testcase.yaml
+++ b/tests/subsys/bluetooth/gatt_dm/testcase.yaml
@@ -5,4 +5,4 @@ tests:
     integration_platforms:
       - native_posix
       - nrf52840dk/nrf52840
-    tags: discovery_manager sysbuild
+    tags: discovery_manager sysbuild bluetooth


### PR DESCRIPTION
Extend list of paths used to check if bluetooth tests/samples should be executed.