### PR TITLE
manifest: Updated Matter revision to pull new Kconfigs

### DIFF
--- a/doc/nrf/protocols/matter/getting_started/advanced_kconfigs.rst
+++ b/doc/nrf/protocols/matter/getting_started/advanced_kconfigs.rst
@@ -52,6 +52,18 @@ This is a much faster way than waiting for the subscriber node to notice that th
 
 To enable persistent subscriptions, set the :kconfig:option:`CONFIG_CHIP_PERSISTENT_SUBSCRIPTIONS` Kconfig option.
 
+The time that it takes to re-establish all subscriptions and CASE sessions depends on the number of sessions that can be recovered simultaneously.
+If the number of sessions and subscriptions to recover is greater than the maximum, the device will re-establish as many as possible and schedule re-establishment of the rest after a specified time interval.
+Since the wait interval between the following re-establishment attempts impacts the overall time to recover all device connections, decreasing it can be beneficial for the user experience.
+However, a small interval value will increase device power consumption.
+
+You can configure how many sessions will be re-established concurrently and what will be the subscription resumption retry interval using the following Kconfig options:
+
+* :kconfig:option:`CONFIG_CHIP_MAX_ACTIVE_CASE_CLIENTS` - Sets the maximum number of CASE sessions that can be simultaneously re-established by the end device.
+* :kconfig:option:`CONFIG_CHIP_MAX_ACTIVE_DEVICES` - Sets the maximum number of subscriptions that can be simultaneously re-established by the end device.
+* :kconfig:option:`CONFIG_CHIP_SUBSCRIPTION_RESUMPTION_MIN_RETRY_INTERVAL` - Sets the minimum wait time in seconds before the first resumption retry.
+* :kconfig:option:`CONFIG_CHIP_SUBSCRIPTION_RESUMPTION_RETRY_MULTIPLIER` - Sets the multiplier in seconds that is used to calculate the wait time for the following resumption retries.
+
 .. _ug_matter_configuring_optional_log:
 
 Logging configuration

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -124,7 +124,14 @@ Gazell
 Matter
 ------
 
-|no_changes_yet_note|
+* Added:
+
+  * The Kconfig options to configure parameters impacting persistent subscriptions re-establishment:
+
+    * :kconfig:option:`CONFIG_CHIP_MAX_ACTIVE_CASE_CLIENTS`
+    * :kconfig:option:`CONFIG_CHIP_MAX_ACTIVE_DEVICES`
+    * :kconfig:option:`CONFIG_CHIP_SUBSCRIPTION_RESUMPTION_MIN_RETRY_INTERVAL`
+    * :kconfig:option:`CONFIG_CHIP_SUBSCRIPTION_RESUMPTION_RETRY_MULTIPLIER`
 
 Matter fork
 +++++++++++

--- a/west.yml
+++ b/west.yml
@@ -160,7 +160,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: v2.7.0
+      revision: 2b9dc09add5f112e9f6a57deec6c4b7f093b2b88
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
Updated Matter revision to pull new Kconfigs that allow configure parameters impacting the persistence subscriptions re-establishment procedure.