### PR TITLE
 CPP14 and CPP17 usage in Edge Impulse applications.

### DIFF
--- a/lib/edge_impulse/Kconfig
+++ b/lib/edge_impulse/Kconfig
@@ -7,7 +7,7 @@
 menuconfig EDGE_IMPULSE
 	bool "Enable Edge Impulse"
 	depends on CPP
-	depends on STD_CPP11
+	depends on STD_CPP11 || STD_CPP14 || STD_CPP17
 	depends on !FP16
 	select REQUIRES_FULL_LIBCPP
 	imply FPU


### PR DESCRIPTION
Currently there is a conflict, Matter examples require CPP17 and Edge Impulse CPP11.