### PR TITLE
samples: event_manager_proxy: Add default configuration

### DIFF
--- a/samples/event_manager_proxy/README.rst
+++ b/samples/event_manager_proxy/README.rst
@@ -83,9 +83,11 @@ Complete the following steps to program the sample:
 
    **nRF54H20 DK**
 
+   A snippet for running the PPR core is added automatically to build configuration.
+
    .. code-block:: console
 
-      west build -b nrf54h20dk/nrf54h20/cpuapp -- -Devent_manager_proxy_SNIPPET=nordic-ppr
+      west build -b nrf54h20dk/nrf54h20/cpuapp
 
    or use twister test case:
 

--- a/samples/event_manager_proxy/sample.yaml
+++ b/samples/event_manager_proxy/sample.yaml
@@ -38,5 +38,3 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
-    extra_args:
-      event_manager_proxy_SNIPPET=nordic-ppr

--- a/samples/event_manager_proxy/sysbuild.cmake
+++ b/samples/event_manager_proxy/sysbuild.cmake
@@ -4,6 +4,13 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+# This sample always requires PPR snippet for nRF54h20.
+if (${NORMALIZED_BOARD_TARGET} STREQUAL "nrf54h20dk_nrf54h20_cpuapp")
+  if(NOT nordic-ppr IN_LIST event_manager_proxy_SNIPPET)
+    set(event_manager_proxy_SNIPPET nordic-ppr CACHE STRING "" FORCE)
+  endif()
+endif()
+
 # Add remote project
 ExternalZephyrProject_Add(
   APPLICATION remote


### PR DESCRIPTION
This commit allows to build Event Manager Proxy
sample for all target in default configuration
without a need for passing additional parameters
to the build command.