### PR TITLE
sysbuild: Remove non-functional environmental key support

### DIFF
--- a/cmake/sysbuild/debug_keys.cmake
+++ b/cmake/sysbuild/debug_keys.cmake
@@ -16,23 +16,7 @@ set(PUB_CMD
   ${ZEPHYR_NRF_MODULE_DIR}/scripts/bootloader/keygen.py --public
   )
 
-# Check if PEM file is specified by user, if not, create one.
-
-# First, check environment variables. Only use if not specified in command line.
-if(DEFINED ENV{SB_SIGNING_KEY_FILE} AND NOT SB_SIGNING_KEY_FILE)
-  if(NOT EXISTS "$ENV{SB_SIGNING_KEY_FILE}")
-    message(FATAL_ERROR "ENV points to non-existing PEM file '$ENV{SB_SIGNING_KEY_FILE}'")
-  else()
-    set(SIGNATURE_PRIVATE_KEY_FILE $ENV{SB_SIGNING_KEY_FILE})
-  endif()
-endif()
-
-# Next, check command line arguments
-if(DEFINED SB_SIGNING_KEY_FILE)
-  set(SIGNATURE_PRIVATE_KEY_FILE ${SB_SIGNING_KEY_FILE})
-endif()
-
-# Check if debug sign key should be generated.
+# Check if PEM file is specified by user, if not, create one a debug key
 if(NOT SB_CONFIG_SECURE_BOOT_SIGNING_CUSTOM AND "${SB_CONFIG_SECURE_BOOT_SIGNING_KEY_FILE}" STREQUAL "")
   message(WARNING "
     --------------------------------------------------------------


### PR DESCRIPTION
Removes using the environmental or command line parameters for specifying a key as the underlying functionality in child/parent has never worked so does not need reimplementation in sysbuild