### PR TITLE
boards: shield: Add defconfigs for nRF54 shields.

### DIFF
--- a/boards/shields/nrf700x_nrf54h20dk/Kconfig.defconfig
+++ b/boards/shields/nrf700x_nrf54h20dk/Kconfig.defconfig
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+if SHIELD_NRF700X_NRF54H20DK
+
+config NETWORKING
+	default y
+
+config WIFI
+	default y
+
+config WIFI_NRF700X
+	default y
+
+config NRFX_GPIOTE
+	default y
+
+endif #SHIELD_NRF700X_NRF54H20DK

--- a/boards/shields/nrf700x_nrf54l15pdk/Kconfig.defconfig
+++ b/boards/shields/nrf700x_nrf54l15pdk/Kconfig.defconfig
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+if SHIELD_NRF700X_NRF54L15PDK
+
+config NETWORKING
+	default y
+
+config WIFI
+	default y
+
+config WIFI_NRF700X
+	default y
+
+config NRFX_GPIOTE
+	default y
+
+endif #SHIELD_NRF700X_NRF54L15PDK


### PR DESCRIPTION
Problem statement:
Sample or standalone application has no `WIFI` config set by default and build fails due to missing Kconfig dependencies:
```
warning: NRF_WIFI_COMBINED_BUCKEN_IOVDD_GPIO (defined at /home/maga/WorkingDirectory/workspace/nrf/drivers/wifi/nrf700x/Kconfig:717) has direct dependencies WIFI with value n, but is currently being y-selected by the following symbols:
 - SHIELD_NRF700X_NRF54H20DK (defined at /home/maga/WorkingDirectory/workspace/nrf/boards/shields/nrf700x_nrf54h20dk/Kconfig.shield:9, /home/maga/WorkingDirectory/workspace/nrf/boards/shields/nrf700x_nrf54h20dk/Kconfig.shield:9), with value y, direct dependencies y (value: y)
 - SHIELD_NRF700X_NRF54H20DK (defined at /home/maga/WorkingDirectory/workspace/nrf/boards/shields/nrf700x_nrf54h20dk/Kconfig.shield:9, /home/maga/WorkingDirectory/workspace/nrf/boards/shields/nrf700x_nrf54h20dk/Kconfig.shield:9), with value y, direct dependencies y (value: y)

error: Aborting due to Kconfig warnings
```

This PR allows add `nRF700x_nrf54XXX` shields to any application without warnings or errors. Additionally it allows to improve user experience with the shield attaching to project.
