### PR TITLE
samples: wifi: twt: Fix build with default configuration

### DIFF
--- a/samples/wifi/twt/README.rst
+++ b/samples/wifi/twt/README.rst
@@ -95,6 +95,10 @@ The following is an example of the CLI command:
 
    west build -b nrf7002dk/nrf5340/cpuapp
 
+.. important::
+
+   It is mandatory to set the :kconfig:option:`CONFIG_TRAFFIC_GEN_REMOTE_IPV4_ADDR` Kconfig option to the IPv4 address of the host running the traffic generator server. If this is set incorrectly, the sample may fail to work as expected.
+
 Testing
 =======
 

--- a/samples/wifi/twt/prj.conf
+++ b/samples/wifi/twt/prj.conf
@@ -90,5 +90,7 @@ CONFIG_NET_CONFIG_MY_IPV4_GW="192.168.1.1"
 CONFIG_NET_MGMT_EVENT_QUEUE_TIMEOUT=5000
 
 CONFIG_TRAFFIC_GEN=y
+# IPv4 address of the host running the traffic generator server
+CONFIG_TRAFFIC_GEN_REMOTE_IPV4_ADDR="192.168.0.1"
 # Needed because traffic gen uses more sockets, so, keeping an upper limit
 CONFIG_POSIX_MAX_FDS=16


### PR DESCRIPTION
TWT sample fails without extra `TRAFFIC_GEN_REMOTE_IPV4_ADDR` config, so added it as a default configuration in prj.conf.