### PR TITLE
manifest: update sdk-zephyr with BLE Mesh extension fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 3d2f1c7f0558d76b24afdabbaff6d36ea96db768
+      revision: pull/1851/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This updates the sdk-zephyr revision to fix a bug with model extension in Bluetooth Mesh