### PR TITLE
manifest: zephyr: Turn off MRAM suspend for NRF54H20 DK

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 3d2f1c7f0558d76b24afdabbaff6d36ea96db768
+      revision: 58284ff0e1b85f24d1be928860e9e6eb0e86b4e5
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Turn off suspending MRAM for NRF54H20 DK
This change is required so sections of code
depending on critical timings will not have unacceptable latency.

Jira: NCSDK-27870