### PR TITLE
samples: wifi: add wifi tag for samples

### DIFF
--- a/samples/wifi/ble_coex/sample.yaml
+++ b/samples/wifi/ble_coex/sample.yaml
@@ -11,7 +11,7 @@ tests:
     extra_args: CONFIG_MPSL_CX=y ipc_radio_CONFIG_MPSL_CX=y
                 CONFIG_COEX_SEP_ANTENNAS=y
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7002.ble_coex_sha_ant:
     sysbuild: true
     build_only: true
@@ -20,7 +20,7 @@ tests:
     extra_args: CONFIG_MPSL_CX=y ipc_radio_CONFIG_MPSL_CX=y
                 CONFIG_COEX_SEP_ANTENNAS=n
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7001.ble_coex:
     sysbuild: true
     build_only: true
@@ -29,7 +29,7 @@ tests:
     extra_args: CONFIG_MPSL_CX=y ipc_radio_CONFIG_MPSL_CX=y
                 CONFIG_COEX_SEP_ANTENNAS=y
     platform_allow: nrf7002dk/nrf5340/cpuapp/nrf7001
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   # Daughter boards (EK's/EB's) do not have a shared antenna
   sample.nrf7002ek.ble_coex:
     sysbuild: true
@@ -40,7 +40,7 @@ tests:
                 CONFIG_MPSL_CX=y ipc_radio_CONFIG_MPSL_CX=y
                 CONFIG_COEX_SEP_ANTENNAS=y
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7001ek.ble_coex:
     sysbuild: true
     build_only: true
@@ -50,7 +50,7 @@ tests:
                 CONFIG_MPSL_CX=y ipc_radio_CONFIG_MPSL_CX=y
                 CONFIG_COEX_SEP_ANTENNAS=y
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: sysbuild
+    tags: sysbuild wifi
   sample.nrf7002_eb.thingy53.ble_coex:
     sysbuild: true
     build_only: true
@@ -60,4 +60,4 @@ tests:
     integration_platforms:
       - thingy53/nrf5340/cpuapp
     platform_allow: thingy53/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi

--- a/samples/wifi/monitor/sample.yaml
+++ b/samples/wifi/monitor/sample.yaml
@@ -9,7 +9,7 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7002_eks.monitor:
     sysbuild: true
     build_only: true
@@ -17,7 +17,7 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7000.monitor:
     sysbuild: true
     build_only: true
@@ -26,11 +26,11 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7001.monitor:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp/nrf7001
     platform_allow: nrf7002dk/nrf5340/cpuapp/nrf7001
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi

--- a/samples/wifi/promiscuous/sample.yaml
+++ b/samples/wifi/promiscuous/sample.yaml
@@ -9,7 +9,7 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7002_eks.promiscuous:
     sysbuild: true
     build_only: true
@@ -17,12 +17,12 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7001.promiscuous:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp/nrf7001
     platform_allow: nrf7002dk/nrf5340/cpuapp/nrf7001
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
     skip: true

--- a/samples/wifi/provisioning/ble/sample.yaml
+++ b/samples/wifi/provisioning/ble/sample.yaml
@@ -9,14 +9,14 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7001.ble-wifi-provision:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp/nrf7001
     platform_allow: nrf7002dk/nrf5340/cpuapp/nrf7001
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
     skip: true
   sample.nrf7002_eks.ble-wifi-provision:
     sysbuild: true
@@ -25,7 +25,7 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7001_eks.ble-wifi-provision:
     sysbuild: true
     build_only: true
@@ -33,7 +33,7 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7002_eb.thingy53.ble-wifi-provision:
     sysbuild: true
     build_only: true
@@ -41,4 +41,4 @@ tests:
     integration_platforms:
       - thingy53/nrf5340/cpuapp
     platform_allow: thingy53/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi

--- a/samples/wifi/provisioning/softap/sample.yaml
+++ b/samples/wifi/provisioning/softap/sample.yaml
@@ -7,4 +7,4 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp/ns
     platform_allow: nrf7002dk/nrf5340/cpuapp/ns
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi

--- a/samples/wifi/radio_test/sample.yaml
+++ b/samples/wifi/radio_test/sample.yaml
@@ -9,14 +9,14 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7001.radio_test:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp/nrf7001
     platform_allow: nrf7002dk/nrf5340/cpuapp/nrf7001
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
     skip: true
   sample.nrf7002.radio_test_combo:
     sysbuild: true
@@ -25,7 +25,7 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7002_eks.radio_test:
     sysbuild: true
     build_only: true
@@ -34,7 +34,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf52840dk/nrf52840
     platform_allow: nrf5340dk/nrf5340/cpuapp nrf52840dk/nrf52840
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7001_eks.radio_test:
     sysbuild: true
     build_only: true
@@ -43,7 +43,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf52840dk/nrf52840
     platform_allow: nrf5340dk/nrf5340/cpuapp nrf52840dk/nrf52840
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7000_eks.radio_test:
     sysbuild: true
     build_only: true
@@ -51,7 +51,7 @@ tests:
     integration_platforms:
       - nrf9160dk/nrf9160/ns
     platform_allow: nrf9160dk/nrf9160/ns
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7002_eb.thingy53.radio_test:
     sysbuild: true
     build_only: true
@@ -59,9 +59,9 @@ tests:
     integration_platforms:
       - thingy53/nrf5340/cpuapp
     platform_allow: thingy53/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.thingy91x_nrf7002.radio_test:
     sysbuild: true
     build_only: true
     platform_allow: thingy91x/nrf9151/ns
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi

--- a/samples/wifi/raw_tx_packet/sample.yaml
+++ b/samples/wifi/raw_tx_packet/sample.yaml
@@ -9,7 +9,7 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7002_eks.raw_tx_packet:
     sysbuild: true
     build_only: true
@@ -17,7 +17,7 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7000.raw_tx_packet:
     sysbuild: true
     build_only: true
@@ -26,11 +26,11 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7001.raw_tx_packet:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp/nrf7001
     platform_allow: nrf7002dk/nrf5340/cpuapp/nrf7001
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi

--- a/samples/wifi/scan/sample.yaml
+++ b/samples/wifi/scan/sample.yaml
@@ -9,14 +9,14 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7001.scan:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp/nrf7001
     platform_allow: nrf7002dk/nrf5340/cpuapp/nrf7001
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
     skip: true
   sample.nrf7002_eks.scan:
     sysbuild: true
@@ -32,7 +32,7 @@ tests:
       - nrf52840dk/nrf52840
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7002_eks.raw_scan:
     sysbuild: true
     build_only: true
@@ -44,7 +44,7 @@ tests:
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
       - nrf9151dk/nrf9151/ns
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7000_eks.scan:
     sysbuild: true
     build_only: true
@@ -52,7 +52,7 @@ tests:
     integration_platforms:
       - nrf9160dk/nrf9160/ns
     platform_allow: nrf9160dk/nrf9160/ns
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7001_eks.scan:
     sysbuild: true
     build_only: true
@@ -62,7 +62,7 @@ tests:
       - nrf52840dk/nrf52840
       - nrf9160dk/nrf9160/ns
     platform_allow: nrf5340dk/nrf5340/cpuapp nrf52840dk/nrf52840 nrf9160dk/nrf9160/ns
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7002_eb.thingy53.scan:
     sysbuild: true
     build_only: true
@@ -70,9 +70,9 @@ tests:
     integration_platforms:
       - thingy53/nrf5340/cpuapp
     platform_allow: thingy53/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.thingy91x_nrf7002.scan:
     sysbuild: true
     build_only: true
     platform_allow: thingy91x/nrf9151/ns
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi

--- a/samples/wifi/shell/sample.yaml
+++ b/samples/wifi/shell/sample.yaml
@@ -9,7 +9,7 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   # Disable optional features to reduce memory usage
   sample.nrf7002.shell.disable_adv_features:
     sysbuild: true
@@ -18,14 +18,14 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7001.shell:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp/nrf7001
     platform_allow: nrf7002dk/nrf5340/cpuapp/nrf7001
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7002_eks.shell:
     sysbuild: true
     build_only: true
@@ -34,7 +34,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf52840dk/nrf52840
     platform_allow: nrf5340dk/nrf5340/cpuapp nrf52840dk/nrf52840
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7000_eks.shell:
     sysbuild: true
     build_only: true
@@ -43,7 +43,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf52840dk/nrf52840
     platform_allow: nrf5340dk/nrf5340/cpuapp nrf52840dk/nrf52840
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7001_eks.shell:
     sysbuild: true
     build_only: true
@@ -52,7 +52,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf52840dk/nrf52840
     platform_allow: nrf5340dk/nrf5340/cpuapp nrf52840dk/nrf52840
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7002_eks_cpunet.shell:
     sysbuild: true
     build_only: true
@@ -60,7 +60,7 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7000_eks_cpunet.shell:
     sysbuild: true
     build_only: true
@@ -68,7 +68,7 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7001_eks_cpunet.shell:
     sysbuild: true
     build_only: true
@@ -76,7 +76,7 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7002.shell.zperf:
     sysbuild: true
     build_only: true
@@ -84,7 +84,7 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7001.shell.zperf:
     sysbuild: true
     build_only: true
@@ -92,7 +92,7 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp/nrf7001
     platform_allow: nrf7002dk/nrf5340/cpuapp/nrf7001
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7002.shell.wpa_cli:
     sysbuild: true
     build_only: true
@@ -100,7 +100,7 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7001.shell.wpa_cli:
     sysbuild: true
     build_only: true
@@ -108,7 +108,7 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp/nrf7001
     platform_allow: nrf7002dk/nrf5340/cpuapp/nrf7001
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7002.shell.scan_only_7002:
     sysbuild: true
     build_only: true
@@ -116,7 +116,7 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7000.shell.scan_only_91:
     sysbuild: true
     build_only: true
@@ -128,14 +128,14 @@ tests:
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
       - nrf9151dk/nrf9151/ns
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7002.shell.scan_only_thingy91x:
     sysbuild: true
     build_only: true
     extra_args: OVERLAY_CONFIG=overlay-scan-only.conf CONFIG_WPA_SUPP=n
     platform_allow:
       - thingy91x/nrf9151/ns
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7002.shell.otbr:
     sysbuild: true
     build_only: true
@@ -143,7 +143,7 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7002.shell.posix_names:
     sysbuild: true
     build_only: true
@@ -151,7 +151,7 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7002_ns.shell:
     sysbuild: true
     build_only: true
@@ -166,7 +166,7 @@ tests:
     integration_platforms:
       - thingy53/nrf5340/cpuapp
     platform_allow: thingy53/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.qspi.ext_flash_xip:
     sysbuild: true
     build_only: true
@@ -178,7 +178,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf52840dk/nrf52840
     platform_allow: nrf5340dk/nrf5340/cpuapp nrf52840dk/nrf52840
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.qspi.ext_flash_store:
     sysbuild: true
     build_only: true
@@ -191,7 +191,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf52840dk/nrf52840
     platform_allow: nrf5340dk/nrf5340/cpuapp nrf52840dk/nrf52840
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf54h20dk_nrf7002ek.shell:
     sysbuild: true
     build_only: true
@@ -199,7 +199,7 @@ tests:
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     platform_allow: nrf54h20dk/nrf54h20/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   # Used by QA and also acts as a memory stress test
   sample.nrf7001.superset:
     sysbuild: true
@@ -279,7 +279,7 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7002.with_overlay_raw_tx_packet:
     sysbuild: true
     build_only: true
@@ -289,7 +289,7 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7002.with_overlay_monitor:
     sysbuild: true
     build_only: true
@@ -299,7 +299,7 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7002.promiscuous_mode:
     sysbuild: true
     build_only: true
@@ -309,7 +309,7 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7001.promiscuous_mode_7001:
     sysbuild: true
     build_only: true
@@ -319,7 +319,7 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp/nrf7001
     platform_allow: nrf7002dk/nrf5340/cpuapp/nrf7001
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7002eb.nrf54l15pdk.shell:
     sysbuild: true
     build_only: true
@@ -327,11 +327,11 @@ tests:
     integration_platforms:
       - nrf54l15pdk/nrf54l15/cpuapp
     platform_allow: nrf54l15pdk/nrf54l15/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7002.shell.psa:
     build_only: true
     extra_args: CONFIG_WPA_SUPP_CRYPTO_PSA=y
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi

--- a/samples/wifi/shutdown/sample.yaml
+++ b/samples/wifi/shutdown/sample.yaml
@@ -9,14 +9,14 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7001.shutdown:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp/nrf7001
     platform_allow: nrf7002dk/nrf5340/cpuapp/nrf7001
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
     skip: true
   sample.nrf7002_eks.shutdown:
     sysbuild: true
@@ -26,7 +26,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf52840dk/nrf52840
     platform_allow: nrf5340dk/nrf5340/cpuapp nrf52840dk/nrf52840
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7000_location.shutdown:
     sysbuild: true
     build_only: true
@@ -38,4 +38,4 @@ tests:
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
       - nrf9151dk/nrf9151/ns
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi

--- a/samples/wifi/softap/sample.yaml
+++ b/samples/wifi/softap/sample.yaml
@@ -9,7 +9,7 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7002_eks.softap:
     sysbuild: true
     build_only: true
@@ -17,14 +17,14 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7001.softap:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp/nrf7001
     platform_allow: nrf7002dk/nrf5340/cpuapp/nrf7001
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7001_eks.softap:
     sysbuild: true
     build_only: true
@@ -32,4 +32,4 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi

--- a/samples/wifi/sta/sample.yaml
+++ b/samples/wifi/sta/sample.yaml
@@ -9,7 +9,7 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7002.sta.no_wifi_ready:
     sysbuild: true
     build_only: true
@@ -17,14 +17,14 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7001.sta:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp/nrf7001
     platform_allow: nrf7002dk/nrf5340/cpuapp/nrf7001
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
     skip: true
   sample.nrf7002_eks.sta:
     sysbuild: true
@@ -37,7 +37,7 @@ tests:
     extra_configs:
       - CONFIG_NET_TX_STACK_SIZE=3700
       - CONFIG_NET_RX_STACK_SIZE=3700
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7001_eks.sta:
     sysbuild: true
     build_only: true
@@ -49,7 +49,7 @@ tests:
     extra_configs:
       - CONFIG_NET_TX_STACK_SIZE=3700
       - CONFIG_NET_RX_STACK_SIZE=3700
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7002_eb.thingy53.sta:
     sysbuild: true
     build_only: true
@@ -57,4 +57,4 @@ tests:
     integration_platforms:
       - thingy53/nrf5340/cpuapp
     platform_allow: thingy53/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi

--- a/samples/wifi/thread_coex/sample.yaml
+++ b/samples/wifi/thread_coex/sample.yaml
@@ -12,7 +12,7 @@ tests:
                 CONFIG_COEX_SEP_ANTENNAS=y
                 EXTRA_CONF_FILE="overlay-ot.conf;overlay-wifi-udp-client-thread-udp-client.conf"
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7001.thread_coex:
     sysbuild: true
     build_only: true
@@ -22,7 +22,7 @@ tests:
                 CONFIG_COEX_SEP_ANTENNAS=y
                 EXTRA_CONF_FILE="overlay-ot.conf;overlay-wifi-udp-client-thread-udp-client.conf"
     platform_allow: nrf7002dk/nrf5340/cpuapp/nrf7001
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7002ek.thread_coex:
     sysbuild: true
     build_only: true
@@ -33,7 +33,7 @@ tests:
                 CONFIG_COEX_SEP_ANTENNAS=y
                 EXTRA_CONF_FILE="overlay-ot.conf;overlay-wifi-udp-client-thread-udp-client.conf"
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7001ek.thread_coex:
     sysbuild: true
     build_only: true
@@ -44,7 +44,7 @@ tests:
                 CONFIG_COEX_SEP_ANTENNAS=y
                 EXTRA_CONF_FILE="overlay-ot.conf;overlay-wifi-udp-client-thread-udp-client.conf"
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7002_eb.thingy53.thread_coex:
     sysbuild: true
     build_only: true
@@ -55,4 +55,4 @@ tests:
     integration_platforms:
       - thingy53/nrf5340/cpuapp
     platform_allow: thingy53/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi

--- a/samples/wifi/throughput/sample.yaml
+++ b/samples/wifi/throughput/sample.yaml
@@ -9,7 +9,7 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
 
   # Used by QA to measure memory footprints
   sample.nrf7002.iot_devices:
@@ -19,7 +19,7 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7002.high_performance:
     sysbuild: true
     build_only: true
@@ -27,7 +27,7 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7002.memory_optimized:
     sysbuild: true
     build_only: true
@@ -35,7 +35,7 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7002.rx_prioritized:
     sysbuild: true
     build_only: true
@@ -43,7 +43,7 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7002.tx_prioritized:
     sysbuild: true
     build_only: true
@@ -51,4 +51,4 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi

--- a/samples/wifi/twt/sample.yaml
+++ b/samples/wifi/twt/sample.yaml
@@ -11,4 +11,4 @@ tests:
     platform_allow: nrf7002dk/nrf5340/cpuapp
     # Dummy IP address for building the sample
     extra_args: CONFIG_TRAFFIC_GEN_REMOTE_IPV4_ADDR="1.2.3.4"
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi

--- a/samples/wifi/wfa_qt_app/sample.yaml
+++ b/samples/wifi/wfa_qt_app/sample.yaml
@@ -8,7 +8,7 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi
   sample.nrf7002_eks.wfa_qt_app:
     sysbuild: true
     build_only: true
@@ -16,4 +16,4 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild wifi

--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -97,7 +97,12 @@ posix:
   files:
     - zephyr/lib/posix/
 
-# cbprintf:
-#    files:
-#        - zephyr/lib/os/cbprintf*
-#        - zephyr/lib/posix
+wifi:
+  files:
+    - nrf/drivers/wifi/
+    - nrf/modules/hostap/
+    - modules/lib/hostap/
+    - zephyr/subsys/net/l2/wifi/
+    - zephyr/subsys/net/l2/ethernet/
+    - nrfxlib/nrf_wifi/
+    - nrfxlib/crypto/


### PR DESCRIPTION
Extend list of paths used to check if wifi
samples should be executed.