### PR TITLE
samples: cellular: modem_shell: Make cJSON use system heap with CoAP

### DIFF
--- a/samples/cellular/modem_shell/src/main.c
+++ b/samples/cellular/modem_shell/src/main.c
@@ -259,7 +259,8 @@ int main(void)
 
 	mosh_print_version_info();
 
-#if defined(CONFIG_NRF_CLOUD_REST) || defined(CONFIG_NRF_CLOUD_MQTT)
+#if defined(CONFIG_NRF_CLOUD_REST) || defined(CONFIG_NRF_CLOUD_MQTT) || \
+	defined(CONFIG_NRF_CLOUD_COAP)
 #if defined(CONFIG_MOSH_IPERF3)
 	/* Due to iperf3, we cannot let nrf cloud lib to initialize cJSON lib to be
 	 * using kernel heap allocations (i.e. k_ prepending functions).

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps.c
@@ -24,6 +24,7 @@
 
 LOG_MODULE_REGISTER(nrf_cloud_pgps, CONFIG_NRF_CLOUD_GPS_LOG_LEVEL);
 
+#include "nrf_cloud_mem.h"
 #include "nrf_cloud_transport.h"
 #include "nrf_cloud_fsm.h"
 #include "nrf_cloud_pgps_schema_v1.h"
@@ -1732,8 +1733,9 @@ int nrf_cloud_pgps_init(struct nrf_cloud_pgps_init_param *param)
 	state = PGPS_NONE;
 
 	if (!write_buf) {
-		write_buf = k_malloc(flash_page_size);
+		write_buf = nrf_cloud_malloc(flash_page_size);
 		if (!write_buf) {
+			LOG_ERR("Failed to allocate write buffer");
 			return -ENOMEM;
 		}
 #if PGPS_DEBUG


### PR DESCRIPTION
Make nRF Cloud and cJSON libraries use system heap instead of kernel heap in `modem_shell` also with CoAP transport. This is needed to avoid running out of memory in some use cases.

The P-GPS implementation used `k_malloc()` to allocate memory, while all other allocations in the nRF Cloud library were done using nrf_cloud_mem hooks. Updated also P-GPS to use the mem hooks.