### PR TITLE
doc: companion components: add generic user guide

### DIFF
--- a/applications/ipc_radio/README.rst
+++ b/applications/ipc_radio/README.rst
@@ -9,6 +9,8 @@ IPC radio firmware
 
 The IPC radio firmware allows to use the radio peripheral from another core in a multicore device.
 
+.. _ipc_radio_overview:
+
 Application overview
 ********************
 
@@ -40,6 +42,8 @@ IEEE 802.15.4
 
 The firmware exposes radio driver support to another core using the IPC subsystem.
 
+.. _ipc_radio_reqs:
+
 Requirements
 ************
 
@@ -48,6 +52,8 @@ The firmware supports the following development kits:
 .. table-from-sample-yaml::
 
 To automatically attach the firmware image, you need to use :ref:`configuration_system_overview_sysbuild`.
+
+.. _ipc_radio_config:
 
 Configuration
 *************
@@ -104,6 +110,8 @@ The following files are available:
    The selection of specific configuration files is determined by the sysbuild Kconfig.
 
    For instance, the ``SB_CONFIG_NETCORE_IPC_RADIO_IEEE802154`` Kconfig option enables the :file:`overlay-802154.conf` configuration file to be used with the IPC radio firmware.
+
+.. _ipc_radio_build_run:
 
 Building and running as a single image
 **************************************

--- a/doc/nrf/config_and_build.rst
+++ b/doc/nrf/config_and_build.rst
@@ -39,6 +39,7 @@ Make sure to consider :ref:`app_bootloaders` and :ref:`app_dfu` already at this 
    config_and_build/config_and_build_system
    config_and_build/board_support/index
    config_and_build/configuring_app/index
+   config_and_build/companion_components
    config_and_build/programming
    config_and_build/multi_image
    config_and_build/bootloaders/index

--- a/doc/nrf/config_and_build/companion_components.rst
+++ b/doc/nrf/config_and_build/companion_components.rst
@@ -1,0 +1,61 @@
+.. _companion_components:
+
+Using companion components
+##########################
+
+.. contents::
+   :local:
+   :depth: 2
+
+The |NCS| provides several companion components.
+Typically, a companion component is independent from the application and is included in your project as a separate firmware image.
+
+Companion components are intended to be used as-is, but integrating them with your application can require minimal modifications of both the component and your application.
+Refer to the component documentation for tested and supported integration instructions (see the links in the table).
+
+While you can also significantly modify these components, they are only tested for the default configuration set provided in the |NCS|.
+
+Depending on its function, a companion component image can either run on the same core as the application, as in the case of :ref:`bootloader` and :ref:`ug_tfm`, or run on a separate core, as in the case of :ref:`ipc_radio`.
+
+You can add some of the components, such as :ref:`ipc_radio`, using :ref:`configuration_system_overview_sysbuild`.
+
+The following table lists the available companion components:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Component
+     - Purpose
+     - Supported platforms
+     - Location
+     - Integration instructions
+   * - :ref:`ipc_radio`
+     - Companion component that allows to use the radio peripheral from another core in a multicore device.
+     - :ref:`nRF54H20 DK <ug_nrf54h20_gs>`, :ref:`nRF5340 DK <ug_nrf5340>`, :ref:`Thingy:53 <ug_thingy53>`
+     - :file:`applications/ipc_radio`
+     - :ref:`Application's configuration section <ipc_radio_config>`
+   * - :ref:`MCUboot <mcuboot:mcuboot_wrapper>`
+     - Secure bootloader for 32-bit microcontrollers.
+     - :ref:`All supported boards <app_boards_names>` **except** the nRF54H20 DK
+     - :file:`ncs/bootloader/mcuboot` (external module), :file:`ncs/nrf/modules/mcuboot` (integration files)
+     - :ref:`mcuboot:mcuboot_ncs`
+   * - `Trusted Firmware-M (TF-M) <TF-M documentation_>`_
+     - Platform security architecture reference implementation aligning with PSA Certified guidelines, enabling chips, Real Time Operating Systems and devices to become PSA Certified.
+     - :ref:`nRF91 Series devices <ug_nrf91>`, :ref:`nRF54L15 PDK <ug_nrf54l>`, :ref:`nRF54H20 DK <ug_nrf54h20_gs>`, :ref:`nRF5340 DK <ug_nrf5340>`, :ref:`Thingy:53 <ug_thingy53>`
+     - :file:`ncs/modules/tee/tf-m` (external module), :file:`ncs/nrf/modules/trusted-firmware-m` (integration files)
+     - :ref:`ug_tfm`
+   * - :ref:`bootloader`
+     - Bootloader tailored for the :ref:`two-stage bootloader <immutable_bootloader>`.
+     - :ref:`Bootloader requirements <bootloader_rot>`
+     - :file:`samples/bootloader`
+     - :ref:`ug_bootloader_adding_immutable_b0`
+   * - :ref:`SUIT flash companion <suit_flash_companion>`
+     - Companion image that allows the Secure Domain Firmware to access the external memory during the :ref:`Software Updates for Internet of Things (SUIT) <ug_nrf54h20_suit_dfu>` firmware upgrade.
+     - :ref:`Sample requirements <suit_flash_companion_reqs>`
+     - :file:`samples/suit/flash_companion`
+     - :ref:`Sample's configuration section <suit_flash_companion_config>`
+   * - :ref:`SUIT flash recovery image <suit_recovery>`
+     - Companion image that allows recovering the device firmware if the original firmware is damaged during the :ref:`Software Updates for Internet of Things (SUIT) <ug_nrf54h20_suit_dfu>` firmware upgrade.
+     - :ref:`Sample requirements <suit_recovery_reqs>`
+     - :file:`samples/suit/recovery`
+     - :ref:`Sample's building and running section <suit_recovery_build_run>`

--- a/doc/nrf/glossary.rst
+++ b/doc/nrf/glossary.rst
@@ -161,6 +161,10 @@ Glossary
    Commit tag
       A tag prepended to the first line of the commit message to ease filtering and identification of particular :term:`commit <Commit>` types.
 
+   Companion component
+      A firmware component that is independent from the application and is included in your project as a separate firmware image.
+      The |NCS| provides several :ref:`companion components <companion_components>` tailored for different purposes.
+
    Connected Isochronous Stream (CIS)
       A configuration of the :term:`Isochronous channels (ISO)` feature of the :term:`LE Audio` standard.
       In this configuration, one audio source sends the audio data using both the left and the right ISO channels at the same time, allowing for stereophonic sound reproduction with synchronized playback.

--- a/samples/suit/flash_companion/README.rst
+++ b/samples/suit/flash_companion/README.rst
@@ -9,6 +9,8 @@ SUIT: Flash companion
 
 The SUIT flash companion sample allows the Secure Domain Firmware to access the external memory during the :ref:`Software Updates for Internet of Things (SUIT) <ug_nrf54h20_suit_dfu>` firmware upgrade.
 
+.. _suit_flash_companion_reqs:
+
 Requirements
 ************
 
@@ -17,6 +19,8 @@ The sample supports the following development kit:
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
    :rows: nrf54h20dk_nrf54h20_cpuapp
+
+.. _suit_flash_companion_overview:
 
 Overview
 ********
@@ -27,6 +31,8 @@ The Secure Domain Firmware uses the IPC service to read, erase, or write data to
 The sample is meant to be booted by the Secure Domain while performing the firmware update process using the :ref:`SUIT <ug_nrf54h20_suit_dfu>` firmware upgrade.
 
 The flash companion sample is not a stand-alone firmware, it is intended to be used with the ``nrf54h_suit_sample`` to complete a firmware transfer with external flash.
+
+.. _suit_flash_companion_config:
 
 Configuration
 *************
@@ -53,6 +59,8 @@ Check and configure the following configuration option:
 
 SB_CONFIG_SUIT_BUILD_FLASH_COMPANION - Configuration for the firmware
    This option enables the sample and builds it during the sysbuild.
+
+.. _suit_flash_companion_build_run:
 
 Building and running
 ********************

--- a/samples/suit/recovery/README.rst
+++ b/samples/suit/recovery/README.rst
@@ -10,6 +10,8 @@ SUIT: Recovery application
 The SUIT recovery application is a minimal application that allows recovering the device firmware if the original firmware is damaged.
 It is to be used as a companion firmware to the main application that is using :ref:`Software Update for Internet of Things (SUIT) <ug_nrf54h20_suit_intro>` procedure, rather than a stand-alone application.
 
+.. _suit_recovery_reqs:
+
 Requirements
 ************
 
@@ -18,6 +20,8 @@ The sample supports the following development kit:
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
    :rows: nrf54h20dk_nrf54h20_cpuapp
+
+.. _suit_recovery_overview:
 
 Overview
 ********
@@ -28,6 +32,8 @@ It is optimized for memory usage and only contains the basic necessary functiona
 .. caution::
 
     This firmware is only able to recover from a situation where the application or radio core are damaged. It does not recover from Nordic Semiconductor-controlled firmware failures.
+
+.. _suit_recovery_config:
 
 Configuration
 *************
@@ -41,6 +47,8 @@ To do this, add the :file:`recovery.overlay` and :file:`recovery_hci_ipc.ovelay`
 The former file will be passed automatically to the recovery application image and the latter to the recovery radio image.
 These devicetree files must define the ``cpuapp_recovery_partition`` and ``cpurad_recovery_partition`` nodes respectively.`
 For an example, see the files in the ``samples/suit/smp_transfer`` sample.
+
+.. _suit_recovery_build_run:
 
 Building and running
 ********************


### PR DESCRIPTION
Added a generic user guide about the FW companion components in the NCS. NCSDK-10551.

----

- [x] Request changelog entry in #15961 when this PR is ready for merge.