### PR TITLE
sysbuild: Allow empty netcore to be in DFU package

### DIFF
--- a/sysbuild/Kconfig.dfu
+++ b/sysbuild/Kconfig.dfu
@@ -20,7 +20,6 @@ config DFU_MULTI_IMAGE_PACKAGE_NET
 	bool "Network core update"
 	depends on SUPPORT_NETCORE
 	depends on !NETCORE_NONE
-	depends on !NETCORE_EMPTY
 	depends on SECURE_BOOT_NETCORE
 
 config DFU_MULTI_IMAGE_PACKAGE_MCUBOOT

--- a/sysbuild/Kconfig.zip
+++ b/sysbuild/Kconfig.zip
@@ -22,7 +22,6 @@ config DFU_ZIP_NET
 	bool "Network core update"
 	depends on SUPPORT_NETCORE
 	depends on !NETCORE_NONE
-	depends on !NETCORE_EMPTY
 	depends on SECURE_BOOT_NETCORE
 	depends on NETCORE_APP_UPDATE
 	default y


### PR DESCRIPTION
Empty netcore is a normal app that can be used
for testing. Do not block adding empty netcore
to DFU package or zip.