### PR TITLE
Reserve memory for the KMU push aread

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/kmu.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/kmu.c
@@ -18,8 +18,12 @@
 #include "common.h"
 #include "kmu.h"
 
-/* NCSDK-25121: Ensure address of this array is at a fixed address. */
-uint8_t kmu_push_area[64] __aligned(16);
+/* The section .nrf_kmu_reserved_push_area is placed at the top RAM address
+ * by the linker scripts. We do that for both the secure and non-secure builds.
+ * Since this buffer is placed on the top of RAM we don't need to have the alignment
+ * attribute anymore.
+ */
+uint8_t kmu_push_area[64] __attribute__((section(".nrf_kmu_reserved_push_area")));
 
 typedef struct kmu_metadata {
 	uint32_t metadata_version: 4;

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/kmu.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/kmu.h
@@ -48,7 +48,6 @@ enum kmu_metadata_key_usage_scheme {
 	KMU_METADATA_SCHEME_RAW
 };
 
-/* NCSDK-25121: Ensure address of this array is at a fixed address. */
 extern uint8_t kmu_push_area[64];
 
 /**

--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 58284ff0e1b85f24d1be928860e9e6eb0e86b4e5
+      revision: pull/1853/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -152,7 +152,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: 553c47a6a4c490bc799f2b455dfd0ebe3a49b0d0
+      revision: pull/159/head
     - name: psa-arch-tests
       repo-path: sdk-psa-arch-tests
       path: modules/tee/tf-m/psa-arch-tests


### PR DESCRIPTION
This reserves 64 bytes on the top RAM address for the KMU to push keys into.  Since the KMU sets it's push address when we provision the device we need to do to allow using it across different images/dfus.