### PR TITLE
manifest: zephyr: Turn on NRFS for NRF54H20 DK

### DIFF
--- a/samples/suit/flash_companion/prj.conf
+++ b/samples/suit/flash_companion/prj.conf
@@ -20,6 +20,9 @@ CONFIG_FLASH=y
 # Disable power management
 CONFIG_PM=n
 
+# Disable NRFS
+CONFIG_NRFS=n
+
 # Disable unneeded interrupt features
 CONFIG_DYNAMIC_INTERRUPTS=n
 CONFIG_IRQ_OFFLOAD=n

--- a/scripts/quarantine_zephyr.yaml
+++ b/scripts/quarantine_zephyr.yaml
@@ -420,6 +420,7 @@
     - kernel.context
     - shell.min_cmds_all
     - shell.min_colors
+    - drivers.gpio.build
   platforms:
     - nrf54h20dk/nrf54h20/cpuppr
   comment: "region RAM/FLASH overflowed"

--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 58284ff0e1b85f24d1be928860e9e6eb0e86b4e5
+      revision: 2c2f60d1ebd959900405e448cee45c03ecdc6646
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Turn on NRFS globally so turning off
suspending MRAM for NRF54H20 DK will work.

Jira: NCSDK-27870