### PR TITLE
ci: docpublish: temporarily ignore old server publish failures

### DIFF
--- a/.github/workflows/docpublish.yml
+++ b/.github/workflows/docpublish.yml
@@ -32,7 +32,7 @@ jobs:
           # upload files
           for file in docs/*.zip docs/monitor*.txt; do
             echo "put ${file}" | \
-              sshpass -e sftp -P 2222 -o BatchMode=no -b - $SSHUSER@transfer.nordicsemi.no
+              sshpass -e sftp -P 2222 -o BatchMode=no -b - $SSHUSER@transfer.nordicsemi.no || true
           done
 
       - name: Upload Zoomin documentation


### PR DESCRIPTION
Until server is fixed, let's ignore failures during the upload process. Zoomin is still published, so it should not be critical.