### PR TITLE
applications: serial_lte_modem: add missing integration_platforms

### DIFF
--- a/applications/serial_lte_modem/sample.yaml
+++ b/applications/serial_lte_modem/sample.yaml
@@ -14,6 +14,8 @@ tests:
     integration_platforms:
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
+      - nrf9151dk/nrf9151/ns
+      - nrf9131ek/nrf9131/ns
       - thingy91/nrf9160/ns
       - thingy91x/nrf9151/ns
     tags: ci_build sysbuild


### PR DESCRIPTION
List all the supported platforms under integration_platforms so that they are all built with the default configuration in CI.