### PR TITLE
doc: extensions: table_from_rows: fix shield list not displaying

### DIFF
--- a/doc/_extensions/table_from_rows.py
+++ b/doc/_extensions/table_from_rows.py
@@ -106,6 +106,7 @@ class TableFromRows(SphinxDirective):
         if shields:
             header_lines[0] += ' Shields |'
             for i, target in enumerate(rows_sections):
+                target = target.replace("_", "/")
                 if target in shields:
                     rows[i][0] += f'``{"`` ``".join(shields[target])}``'
                 rows[i][0] += ' |'


### PR DESCRIPTION
Targets in row sections still use `_`, so set lookup failed as shields set uses `/` (from HWMv2).