### PR TITLE
sysbuild: pass the dynamic partition to partition manager

### DIFF
--- a/cmake/sysbuild/partition_manager.cmake
+++ b/cmake/sysbuild/partition_manager.cmake
@@ -99,8 +99,7 @@ function(partition_manager)
     )
   endif()
 
-# We must set this when running for the domain, so how is the domain name partition handled in settings ?
-  if("${PM_DOMAIN}" STREQUAL "CPUNET")
+  if(NOT "${PM_DOMAIN}" STREQUAL "")
     set(dynamic_partition ${${PM_DOMAIN}_PM_DOMAIN_DYNAMIC_PARTITION})
     set(
       dynamic_partition_argument


### PR DESCRIPTION
Pass the dynamic partition to partition manager when a DOMAIN is passed to CMake partition_manager() function.

Remove the CPUNET domain restriction as the use of any domain should be handled. Domain is only passed to the function when it's not the domain of the main application.

This fixes the issues like:
```
Traceback (most recent call last):
  File "/<path>/partition_manager_output.py", line 251, in <module>
    main()
  File "/<path>/partition_manager_output.py", line 247, in main
    write_gpm_config(gpm_config, greg_config, name, header_file)
  File "/<path>/partition_manager_output.py", line 142, in
                                                      write_gpm_config
    if any('span' in x for x in gpm_config[domain][image]):
                                ~~~~~~~~~~~~~~~~~~^^^^^^^
KeyError: 'empty_app_core'
```

as the dynamic partition is now passed to the partition manager script in all cases where domain is specified.

Jira: NCSDK-23805