### PR TITLE
cmake: multi_image: Fix handling of HWMv1 boards with revisions

### DIFF
--- a/cmake/multi_image.cmake
+++ b/cmake/multi_image.cmake
@@ -234,11 +234,7 @@ function(add_child_image_from_source)
   elseif (NOT ACI_BOARD)
     # No BOARD is given as argument, this triggers automatic conversion of
     # *.ns board from parent image.
-    if(DEFINED BOARD_REVISION)
-      get_board_without_ns_suffix(${BOARD}@${BOARD_REVISION}${BOARD_QUALIFIERS} ACI_BOARD)
-    else()
-      get_board_without_ns_suffix(${BOARD}${BOARD_QUALIFIERS} ACI_BOARD)
-    endif()
+    get_board_without_ns_suffix(${BOARD}${BOARD_QUALIFIERS} ACI_BOARD)
   endif()
 
   if (NOT ACI_DOMAIN AND DOMAIN)


### PR DESCRIPTION
Function `get_board_without_ns_suffix` cannot recognize the non-secure suffix if the board revision is placed after it, as is the case in the old hardware model. Example: `nrf9160dk_nrf9160_ns@0.14.0`

Before d7a19af4fe5b5d944befb66b6d9d1de3df67e275, board revisions were not passed to `get_board_without_ns_suffix`, because they are handled independently in the `ncs_file` call further down. Undo this change.