### PR TITLE
NCSDK-28174: Add nrfutil device to sdk-nrf-toolchain

### DIFF
--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -1,29 +1,21 @@
-FROM ubuntu:22.04 as nrfutil-builder
+FROM ubuntu:22.04
 
 ARG VERSION
 ENV HOME=/opt
-RUN apt-get update && apt-get install -y \
-    wget \
+RUN apt-get update && apt-get install -y wget ca-certificates qemu-system-arm libffi7 git \
     && rm -rf /var/lib/apt/lists/*
-RUN wget https://developer.nordicsemi.com/.pc-tools/nrfutil/x64-linux/nrfutil && chmod +x nrfutil \
-    && ./nrfutil install toolchain-manager && ./nrfutil toolchain-manager install --toolchain-bundle-id $VERSION
-RUN  ./nrfutil toolchain-manager env --as-script > /opt/toolchain-env.sh
-
-
-FROM ubuntu:22.04
+RUN wget https://developer.nordicsemi.com/.pc-tools/nrfutil/x64-linux/nrfutil -q -O /usr/local/bin/nrfutil  \
+    && chmod +x /usr/local/bin/nrfutil \
+    && nrfutil install device=2.4.0 \
+    && nrfutil install toolchain-manager=0.15.0
+RUN nrfutil toolchain-manager install --toolchain-bundle-id $VERSION \
+    && nrfutil toolchain-manager env --as-script > /opt/toolchain-env.sh \
+    && rm -rf /opt/ncs/downloads
 
 # Link to repo (https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images)
 LABEL org.opencontainers.image.source=https://github.com/nrfconnect/sdk-nrf
 # Set metadata for an image
 LABEL org.opencontainers.image.description="This image contains toolchain for sdk-nrf."
-
-RUN apt-get update && apt-get install -y \
-    ca-certificates qemu-system-arm libffi7 git \
-    && rm -rf /var/lib/apt/lists/*
-
-# Copy toolchain
-COPY --from=nrfutil-builder /opt/ncs/toolchains /opt/ncs/toolchains
-COPY --from=nrfutil-builder /opt/toolchain-env.sh /opt/toolchain-env.sh
 
 ## Add entrypoint which calls toolchain-env.sh
 COPY entrypoint.sh /opt/entrypoint.sh


### PR DESCRIPTION
Using sdk-nrf-toolchain image you are able to flash hexes on boards

Jira: NCSDK-28174