### PR TITLE
applications/samples/test: Use DEFAULT_IMAGE in sysbuild

### DIFF
--- a/applications/machine_learning/sysbuild.cmake
+++ b/applications/machine_learning/sysbuild.cmake
@@ -12,17 +12,17 @@ if(SB_CONFIG_ML_APP_INCLUDE_REMOTE_IMAGE AND DEFINED SB_CONFIG_ML_APP_REMOTE_BOA
     BOARD ${SB_CONFIG_ML_APP_REMOTE_BOARD}
   )
 
-if(SB_CONFIG_PARTITION_MANAGER)
-  set_property(GLOBAL APPEND PROPERTY PM_DOMAINS CPUNET)
-  set_property(GLOBAL APPEND PROPERTY PM_CPUNET_IMAGES remote)
-  set_property(GLOBAL PROPERTY DOMAIN_APP_CPUNET remote)
-  set(CPUNET_PM_DOMAIN_DYNAMIC_PARTITION remote CACHE INTERNAL "")
-endif()
+  if(SB_CONFIG_PARTITION_MANAGER)
+    set_property(GLOBAL APPEND PROPERTY PM_DOMAINS CPUNET)
+    set_property(GLOBAL APPEND PROPERTY PM_CPUNET_IMAGES remote)
+    set_property(GLOBAL PROPERTY DOMAIN_APP_CPUNET remote)
+    set(CPUNET_PM_DOMAIN_DYNAMIC_PARTITION remote CACHE INTERNAL "")
+  endif()
 
-# Add a dependency so that the remote image will be built first.
-sysbuild_add_dependencies(CONFIGURE machine_learning remote)
-# Add dependency so that the remote image is flashed first.
-sysbuild_add_dependencies(FLASH machine_learning remote)
-sysbuild_add_dependencies(FLASH remote ipc_radio)
+  # Add a dependency so that the remote image will be built first.
+  sysbuild_add_dependencies(CONFIGURE ${DEFAULT_IMAGE} remote)
 
+  # Add dependency so that the remote image is flashed first.
+  sysbuild_add_dependencies(FLASH ${DEFAULT_IMAGE} remote)
+  sysbuild_add_dependencies(FLASH remote ${SB_CONFIG_NETCORE_IMAGE_NAME})
 endif()

--- a/samples/caf_sensor_manager/sysbuild.cmake
+++ b/samples/caf_sensor_manager/sysbuild.cmake
@@ -25,6 +25,6 @@ if(SB_CONFIG_PARTITION_MANAGER)
 endif()
 
 # Add a dependency so that the remote sample will be built and flashed first
-add_dependencies(caf_sensor_manager remote)
+add_dependencies(${DEFAULT_IMAGE} remote)
 # Add dependency so that the remote image is flashed first.
-sysbuild_add_dependencies(FLASH caf_sensor_manager remote)
+sysbuild_add_dependencies(FLASH ${DEFAULT_IMAGE} remote)

--- a/samples/event_manager_proxy/sysbuild.cmake
+++ b/samples/event_manager_proxy/sysbuild.cmake
@@ -23,6 +23,6 @@ set_property(GLOBAL PROPERTY DOMAIN_APP_CPUNET remote)
 set(CPUNET_PM_DOMAIN_DYNAMIC_PARTITION remote CACHE INTERNAL "")
 
 # Add a dependency so that the remote sample will be built and flashed first
-sysbuild_add_dependencies(CONFIGURE event_manager_proxy remote)
+sysbuild_add_dependencies(CONFIGURE ${DEFAULT_IMAGE} remote)
 # Add dependency so that the remote image is flashed first.
-sysbuild_add_dependencies(FLASH event_manager_proxy remote)
+sysbuild_add_dependencies(FLASH ${DEFAULT_IMAGE} remote)

--- a/samples/ipc/ipc_service/sysbuild.cmake
+++ b/samples/ipc/ipc_service/sysbuild.cmake
@@ -20,6 +20,6 @@ set_property(GLOBAL PROPERTY DOMAIN_APP_CPUNET remote)
 set(CPUNET_PM_DOMAIN_DYNAMIC_PARTITION remote CACHE INTERNAL "")
 
 # Add a dependency so that the remote sample will be built and flashed first
-sysbuild_add_dependencies(CONFIGURE ipc_service remote)
+sysbuild_add_dependencies(CONFIGURE ${DEFAULT_IMAGE} remote)
 # Add dependency so that the remote image is flashed first.
-sysbuild_add_dependencies(FLASH ipc_service remote)
+sysbuild_add_dependencies(FLASH ${DEFAULT_IMAGE} remote)

--- a/tests/benchmarks/multicore/idle/sysbuild.cmake
+++ b/tests/benchmarks/multicore/idle/sysbuild.cmake
@@ -20,6 +20,6 @@ set_property(GLOBAL PROPERTY DOMAIN_APP_CPUNET remote)
 set(CPUNET_PM_DOMAIN_DYNAMIC_PARTITION remote CACHE INTERNAL "")
 
 # Add a dependency so that the remote image will be built and flashed first
-add_dependencies(idle remote)
+add_dependencies(${DEFAULT_IMAGE} remote)
 # Add dependency so that the remote image is flashed first.
-sysbuild_add_dependencies(FLASH idle remote)
+sysbuild_add_dependencies(FLASH ${DEFAULT_IMAGE} remote)

--- a/tests/subsys/event_manager_proxy/sysbuild.cmake
+++ b/tests/subsys/event_manager_proxy/sysbuild.cmake
@@ -20,6 +20,6 @@ set_property(GLOBAL PROPERTY DOMAIN_APP_CPUNET remote)
 set(CPUNET_PM_DOMAIN_DYNAMIC_PARTITION remote CACHE INTERNAL "")
 
 # Add a dependency so that the remote sample will be built and flashed first
-add_dependencies(event_manager_proxy remote)
+add_dependencies(${DEFAULT_IMAGE} remote)
 # Add dependency so that the remote image is flashed first.
-sysbuild_add_dependencies(FLASH event_manager_proxy remote)
+sysbuild_add_dependencies(FLASH ${DEFAULT_IMAGE} remote)

--- a/tests/subsys/pcd/sysbuild.cmake
+++ b/tests/subsys/pcd/sysbuild.cmake
@@ -20,6 +20,6 @@ set_property(GLOBAL PROPERTY DOMAIN_APP_CPUNET hello_world)
 set(CPUNET_PM_DOMAIN_DYNAMIC_PARTITION hello_world CACHE INTERNAL "")
 
 # Add a dependency so that the remote sample will be built and flashed first
-add_dependencies(pcd hello_world)
+add_dependencies(${DEFAULT_IMAGE} hello_world)
 # Add dependency so that the remote image is flashed first.
-sysbuild_add_dependencies(FLASH pcd hello_world)
+sysbuild_add_dependencies(FLASH ${DEFAULT_IMAGE} hello_world)


### PR DESCRIPTION
Switches to use the DEFAULT_IMAGE variable when adding dependencies in sysbuild configuration to allow for applications to be copied out of tree

Fixes: NCSDK-28028