### PR TITLE
lib: modem_info: scanf fixes

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -452,6 +452,10 @@ Modem libraries
 
   * Added a log warning suggesting a SIM card to be installed if a UICC error is detected by the modem.
 
+* :ref:`modem_info_readme` library:
+
+  * Fixed a potential issue with scanf in the :c:func:`modem_info_get_current_band` function, which could lead to memory corruption.
+
 Multiprotocol Service Layer libraries
 -------------------------------------
 

--- a/tests/lib/modem_info/src/main.c
+++ b/tests/lib/modem_info/src/main.c
@@ -145,7 +145,7 @@ static int nrf_modem_at_scanf_custom_xcband(const char *cmd, const char *fmt, va
 	TEST_ASSERT_EQUAL_STRING("AT%XCBAND", cmd);
 	TEST_ASSERT_EQUAL_STRING("%%XCBAND: %u", fmt);
 
-	uint8_t *val = va_arg(args, uint8_t *);
+	unsigned int *val = va_arg(args, unsigned int *);
 	*val = EXAMPLE_BAND;
 
 	return 1;
@@ -156,7 +156,7 @@ static int nrf_modem_at_scanf_custom_xcband_max_val(const char *cmd, const char 
 	TEST_ASSERT_EQUAL_STRING("AT%XCBAND", cmd);
 	TEST_ASSERT_EQUAL_STRING("%%XCBAND: %u", fmt);
 
-	uint8_t *val = va_arg(args, uint8_t *);
+	unsigned int *val = va_arg(args, unsigned int *);
 	*val = EXAMPLE_BAND_MAX_VAL;
 
 	return 1;
@@ -168,7 +168,7 @@ static int nrf_modem_at_scanf_custom_xcband_unavailable(const char *cmd, const c
 	TEST_ASSERT_EQUAL_STRING("AT%XCBAND", cmd);
 	TEST_ASSERT_EQUAL_STRING("%%XCBAND: %u", fmt);
 
-	uint8_t *val = va_arg(args, uint8_t *);
+	unsigned int *val = va_arg(args, unsigned int *);
 	*val = BAND_UNAVAILABLE;
 
 	return 1;


### PR DESCRIPTION
This commit fixes potential issues with scanf in the modem info library.