### PR TITLE
samples: ipc: ipc_service: disable hw_flow_control for cpurad nRF54H20

### DIFF
--- a/samples/ipc/ipc_service/remote/boards/nrf54h20dk_nrf54h20_cpurad.overlay
+++ b/samples/ipc/ipc_service/remote/boards/nrf54h20dk_nrf54h20_cpurad.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&uart135 {
+	/delete-property/ hw-flow-control;
+};


### PR DESCRIPTION
hw-flow-control disabled to prevent sample blocking during UART data transmission when the terminal is not connected.
