### PR TITLE
manifest: update sdk-zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 2c2f60d1ebd959900405e448cee45c03ecdc6646
+      revision: pull/1866/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This update takes in a Zephyr bug-fix addressing the issue of not relinking Zephyr when TF-M rebuilds.

Jira: NCSDK-28131