### PR TITLE
applications: nrf_desktop: Fix USB stack next builds in release config

### DIFF
--- a/applications/nrf_desktop/src/modules/usb_state.c
+++ b/applications/nrf_desktop/src/modules/usb_state.c
@@ -530,9 +530,14 @@ static void usb_wakeup(void)
 {
 	int err = 0;
 
-	if (IS_ENABLED(CONFIG_DESKTOP_USB_STACK_NEXT) && usb_enabled) {
-		__ASSERT_NO_MSG(usbd_ctx);
-		err = usbd_wakeup_request(usbd_ctx);
+	if (IS_ENABLED(CONFIG_DESKTOP_USB_STACK_NEXT)) {
+		if (usb_enabled) {
+			__ASSERT_NO_MSG(usbd_ctx);
+			err = usbd_wakeup_request(usbd_ctx);
+		} else {
+			/* Skip wakeup request. */
+			return;
+		}
 	} else {
 		__ASSERT_NO_MSG(IS_ENABLED(CONFIG_DESKTOP_USB_STACK_LEGACY));
 		err = usb_wakeup_request();


### PR DESCRIPTION
Change fixes "undefined reference to `usb_wakeup_request'" build error.

Jira: NCSDK-28196