### PR TITLE
samples: cellular: MSS: Thingy91X support

### DIFF
--- a/samples/cellular/nrf_cloud_multi_service/sample.yaml
+++ b/samples/cellular/nrf_cloud_multi_service/sample.yaml
@@ -15,6 +15,7 @@ tests:
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
       - thingy91/nrf9160/ns
+      - thingy91x/nrf9151/ns
     tags: ci_build sysbuild
   sample.cellular.nrf_cloud_multi_service.mqtt.full:
     sysbuild: true
@@ -41,11 +42,13 @@ tests:
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
       - thingy91/nrf9160/ns
+      - thingy91x/nrf9151/ns
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
       - thingy91/nrf9160/ns
+      - thingy91x/nrf9151/ns
     extra_args: EXTRA_CONF_FILE="overlay_coap.conf"
     tags: ci_build sysbuild
   sample.cellular.nrf_cloud_multi_service.coap.min:


### PR DESCRIPTION
Add the Thingy91:x as an integration platform
and an allowed platform for both MQTT and CoAP.

Jira: IRIS-9259