### PR TITLE
net: lib: nrf_cloud: Add RSRP reporting

### DIFF
--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec_internal.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec_internal.c
@@ -1307,6 +1307,11 @@ static int encode_modem_info_network(struct network_param *network, cJSON *json_
 		return ret;
 	}
 
+	ret = add_modem_info_data(&network->rsrp, json_obj);
+	if (ret < 0) {
+		return ret;
+	}
+
 	ret = modem_info_name_get(network->cellid_hex.type, data_name);
 	if (ret < 0) {
 		return ret;


### PR DESCRIPTION
Add RSRP (Reference Signal Received Power) to the modem information reported to the cloud.