### PR TITLE
manifest: update sdk-zephyr pull/1870

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v3.6.99-ncs2-rc3
+      revision: pull/1870/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pick up https://github.com/nrfconnect/sdk-zephyr/pull/1870

Bluetooth: test: privacy/legacy: Scan continuously

Some controllers, like the SoftDevice Controller can miss the first few advertisements after the host tells it to start scanning. The DUT would assumes the first RPA advertisements report it gets is the first that was sent, but it was actually not the first. This would skew the tester's judgement about the timing of RPA rotations.

To remedy this, the tester will scan continuously and switch between expecting the identity address and the RPA without stopping the scanner.

The tester will tell the DUT to switch to RPA after it has received the identity address advertisement. This ensures that the tester will not miss the first RPA advertisement.