### PR TITLE
doc: migration: sysbuild: Add clarifications

### DIFF
--- a/doc/nrf/config_and_build/config_and_build_system.rst
+++ b/doc/nrf/config_and_build/config_and_build_system.rst
@@ -276,12 +276,49 @@ To disable these warnings, disable the :kconfig:option:`CONFIG_WARN_EXPERIMENTAL
 Sysbuild enabled by default
 ===========================
 
-When building :ref:`workspace applications <create_application_types_workspace>` copied from :ref:`nRF repositories <dm_repo_types>`, using the :ref:`standard building procedure <building>` automatically includes :ref:`configuration_system_overview_sysbuild` (the ``--sysbuild`` parameter).
-For this reason, unlike in Zephyr, ``--sysbuild`` does not have to be explicitly mentioned in the command prompt when building the application.
+The |NCS| `modifies the default behavior <sdk-zephyr west build patch_>`_ of ``west build``, so that the :ref:`standard building procedure <building>` will use sysbuild by default for :ref:`repository applications <create_application_types_repository>` in the :ref:`SDK repositories <dm_repo_types>`.
+For this reason, unlike in Zephyr, ``--sysbuild`` does not have to be explicitly mentioned in the command prompt when building a repository application.
+This setting only applies to repositories delivered with the |NCS|, to maintain compatibility with child/parent images.
 
-This rule does not apply if you work with out-of-tree :ref:`freestanding applications <create_application_types_freestanding>`, for which you need to manually pass ``--sysbuild`` to build commands in every case.
+This setting does not apply to out-of-tree applications, such as :ref:`workspace <create_application_types_workspace>` or :ref:`freestanding applications <create_application_types_freestanding>`.
+In such cases, once you ported your application to sysbuild, it is up to you to either use the ``--sysbuild`` parameter on the command line every time you build or to :ref:`configure west to always use it <sysbuild_enabled_ncs_configuring>`.
 
-You can disable building with sysbuild by using the ``--no-sysbuild`` parameter in the build command.
+Moreover, this |NCS| setting does not apply to the following areas:
+
+* :ref:`Twister <running_unit_tests>` will not use sysbuild unless tests are updated.
+* CMake will not configure projects using sysbuild unless the invocation command is updated.
+
+.. _sysbuild_enabled_ncs_configuring:
+
+Configuring sysbuild usage in west
+----------------------------------
+
+You can configure your project to use sysbuild by default whenever invoking ``west build``.
+You can do this either per-workspace, using the local configuration option, or for all your workspaces, using the global configuration option:
+
+.. tabs::
+
+   .. group-tab:: Local sysbuild configuration
+
+      Use the following command to configure west to use sysbuild by default for building all projects in the current workspace (including any freestanding applications that are built against it):
+
+      .. parsed-literal::
+         :class: highlight
+
+         west config --local build.sysbuild True
+
+   .. group-tab:: Global sysbuild configuration
+
+      Use the following command to configure west to use sysbuild by default for building all projects in all workspaces:
+
+      .. parsed-literal::
+         :class: highlight
+
+         west config --global build.sysbuild True
+
+.. note::
+    |parameters_override_west_config|
+    This means that you can pass ``--no-sysbuild`` to the build command to disable using sysbuild for a given build even if you configured west to always use sysbuild by default.
 
 .. _app_build_additions_build_types:
 .. _gs_modifying_build_types:

--- a/doc/nrf/config_and_build/configuring_app/advanced_building.rst
+++ b/doc/nrf/config_and_build/configuring_app/advanced_building.rst
@@ -36,6 +36,8 @@ To learn more about how to use the :kconfig:option:`CONFIG_NCS_SAMPLE_MCUMGR_BT_
 Optional build parameters
 *************************
 
+|parameters_override_west_config|
+
 Here are some of the possible options you can use:
 
 * You can provide :ref:`custom CMake options <cmake_options>` to the build command.

--- a/doc/nrf/config_and_build/configuring_app/cmake/index.rst
+++ b/doc/nrf/config_and_build/configuring_app/cmake/index.rst
@@ -53,6 +53,7 @@ You can provide additional options for building your application to the CMake pr
 These options are specified when CMake is run, thus not during the actual build, but when configuring the build.
 
 The |NCS| uses the same CMake build variables as Zephyr and they are compatible with both CMake and west.
+|parameters_override_west_config|
 
 For the complete list of build variables in Zephyr and more information about them, see :ref:`zephyr:important-build-vars` in the Zephyr documentation.
 The following table lists the most common ones used in the |NCS|:

--- a/doc/nrf/config_and_build/configuring_app/index.rst
+++ b/doc/nrf/config_and_build/configuring_app/index.rst
@@ -56,7 +56,9 @@ Just as for creating the application, you can build the application using either
          The board targets supported for a given application are always listed in its requirements section.
 
          |sysbuild_autoenabled_ncs|
+
          The command can be expanded with :ref:`optional_build_parameters`, such as :ref:`custom CMake options <cmake_options>` or the ``--no-sysbuild`` parameter that disables building with sysbuild.
+         |parameters_override_west_config|
 
        After running the ``west build`` command, the build files can be found in the main build directory or in the application-named sub-directories in the main build directory (or both, depending on your project structure).
        |output_files_note|

--- a/doc/nrf/create_application.rst
+++ b/doc/nrf/create_application.rst
@@ -29,8 +29,44 @@ You can read more about each of these files in Zephyr's :ref:`Application Develo
 Application types
 *****************
 
-Based on where the :file:`<app>` directory is located, you will usually work with one of two types of applications in the |NCS|: workspace or freestanding.
+Based on where the :file:`<app>` directory is located, you will usually work with one of the following types of applications in the |NCS|: repository, workspace, or freestanding.
 These types are adopted from :ref:`Zephyr application types <zephyr:zephyr-app-types>`.
+
+.. _create_application_types_repository:
+
+Repository application
+======================
+
+This kind of application is located inside the |NCS| source code (:ref:`SDK repositories <dm_repo_types>`, including downstream forks of upstream projects).
+In the following example, the :ref:`Bluetooth Peripheral UART <peripheral_uart>` sample is an |NCS| repository application and its location in the source code structure serves as the :file:`<app>` directory:
+
+.. code-block:: none
+
+   <home>/
+   ├─── .west/
+   ├─── bootloader/
+   ├─── mbedtls/
+   ├─── modules/
+   ├─── nrf/
+   │    ├─── applications/
+   │    ├─── ...
+   │    └─── samples/
+   │       ├─── ...
+   │       ├─── bluetooth/
+   │       │  ├── ...
+   │       │  └── peripheral_uart/   <--- <app> directory
+   │       └─── ...
+   ├─── nrfxlib/
+   ├─── test/
+   ├─── tools/
+   └─── zephyr/
+
+This type of application uses the default |NCS| settings and configuration, which might differ from the corresponding upstream configuration.
+For example, a notable difference is that when building this type of applications, :ref:`sysbuild is enabled by default <sysbuild_enabled_ncs>`.
+
+This application type is suitable for the following development cases:
+
+* You want to test the solution provided by the |NCS| out-of-the-box.
 
 .. _create_application_types_workspace:
 

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -63,6 +63,7 @@
 .. _`Zephyr commit 8dc3f8`: https://github.com/nrfconnect/sdk-zephyr/commit/8dc3f856229ce083c956aa301c31a23e65bd8cd8
 .. _`hwmv2 conversion script`: https://github.com/nrfconnect/sdk-zephyr/blob/main/scripts/utils/board_v1_to_v2.py
 .. _`ncs-example-application commit f9f2da`: https://github.com/nrfconnect/ncs-example-application/commit/f9f2da24041a7b1923e49893cca912482c138aae
+.. _`sdk-zephyr west build patch`: https://github.com/nrfconnect/sdk-zephyr/blob/1a5d3b4a4ff98a33222856526afdf9c089b96d2b/scripts/west_commands/build.py#L585-L598
 
 .. |ncs_nrfxlib_repo| replace:: https://github.com/nrfconnect/sdk-nrfxlib
 .. _`sdk-nrfxlib`: https://github.com/nrfconnect/sdk-nrfxlib

--- a/doc/nrf/releases_and_maturity/migration/migration_sysbuild.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_sysbuild.rst
@@ -570,19 +570,16 @@ They function the same in both systems:
 Building with sysbuild
 ======================
 
-With |NCS| 2.7, building with ``west`` will use sysbuild by default in |NCS| repositories.
-To maintain compatibility with child/parent images, out-of-tree applications will not use sysbuild by default.
-Twister does not inherit this change and will not use sysbuild unless tests are updated.
-Similarly, CMake will not configure projects using sysbuild unless the invocation command is updated.
+Sysbuild needs to be enabled from the command-line when building with ``west build``.
+You can pass the ``--sysbuild`` parameter to the build command or :ref:`configure west to use sysbuild whenever you build <sysbuild_enabled_ncs_configuring>`.
+
+Similarly, you can pass the ``--no-sysbuild`` parameter to the build command to disable sysbuild.
+With these two parameters, which always take precedence over the west configuration, the usage of sysbuild can always be selected from the command line.
 
 .. note::
+    The |NCS| v2.7.0 :ref:`modifies the default behavior <sysbuild_enabled_ncs>` of ``west build``, so that building with west uses sysbuild for :ref:`repository applications <create_application_types_repository>` in the :ref:`SDK repositories <dm_repo_types>`.
 
-    Sysbuild can optionally be set as the default when using west.
-    This means that unless west is ran with ``--no-sysbuild`` then it will always use sysbuild
-
-    .. code-block:: shell
-
-        west config build.sysbuild True
+See the following command patterns for building with sysbuild for different use cases:
 
 .. tabs::
 

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -214,8 +214,10 @@
    You can continue to use it until the transition is complete in the |NCS| and the feature is removed in one of the upcoming |NCS| releases.
    For more information, see :ref:`zephyr:sysbuild`, :ref:`sysbuild_images`, :ref:`zephyr_samples_sysbuild`, and :ref:`sysbuild_forced_options`.
 
-.. |sysbuild_autoenabled_ncs| replace:: When building :ref:`workspace applications <create_application_types_workspace>` copied from :ref:`nRF repositories <dm_repo_types>`, building with sysbuild is :ref:`enabled by default <sysbuild_enabled_ncs>`.
-   If you work with out-of-tree :ref:`freestanding applications <create_application_types_freestanding>`, you need to manually pass ``--sysbuild`` to build commands.
+.. |sysbuild_autoenabled_ncs| replace:: When building :ref:`repository applications <create_application_types_repository>` in the :ref:`SDK repositories <dm_repo_types>`, building with sysbuild is :ref:`enabled by default <sysbuild_enabled_ncs>`.
+   If you work with out-of-tree :ref:`freestanding applications <create_application_types_freestanding>`, you need to manually pass the ``--sysbuild`` parameter to every build command or :ref:`configure west to always use it <sysbuild_enabled_ncs_configuring>`.
+
+.. |parameters_override_west_config| replace:: The parameters and options passed in the command line always take precedence over ``west config`` settings.
 
 .. |file_suffix_related_deprecation_note| replace:: This feature is deprecated and is being replaced by :ref:`suffix-based configurations <app_build_file_suffixes>`.
     You can continue to use it until the transition is complete in the |NCS| and the feature is removed in one of the upcoming |NCS| releases.


### PR DESCRIPTION
Try to clarify the behaviour of west with the command-line ``--sysbuild`` option and the configuration options.