### PR TITLE
doc: sysbuild: link consistency and capitalization

### DIFF
--- a/doc/nrf/config_and_build/bootloaders/bootloader_adding_sysbuild.rst
+++ b/doc/nrf/config_and_build/bootloaders/bootloader_adding_sysbuild.rst
@@ -47,7 +47,7 @@ To build |NSIB| with a Zephyr or |NCS| sample, enable the ``SB_CONFIG_SECURE_BOO
 |how_to_configure|
 
 Like other images, you can assign image-specific configurations at build time to further customize the bootloader's functionality.
-For details, see :ref:`zephyr:sysbuild` documentation.
+For details, see :ref:`zephyr:sysbuild` documentation in Zephyr.
 
 To ensure that the immutable bootloader occupies as little flash memory as possible, you can also apply the :file:`prj_minimal.conf` configuration:
 
@@ -232,7 +232,7 @@ To build :doc:`MCUboot <mcuboot:index-ncs>` with a Zephyr or |NCS| sample, enabl
 
 |how_to_configure|
 Like other images, you can assign image-specific configurations at build time to further customize the bootloader's functionality.
-For details, see :ref:`zephyr:sysbuild` documentation.
+For details, see :ref:`zephyr:sysbuild` documentation in Zephyr.
 
 Configuring MCUboot as an immutable bootloader
 ----------------------------------------------

--- a/doc/nrf/config_and_build/bootloaders/bootloader_downgrade_protection.rst
+++ b/doc/nrf/config_and_build/bootloaders/bootloader_downgrade_protection.rst
@@ -93,11 +93,11 @@ To enable anti-rollback protection with monotonic counter for |NSIB|, set the fo
 
 Special handling is needed when updating the S1 variant of an image when :ref:`ug_bootloader_adding_upgradable`.
 See :ref:`ug_bootloader_adding_presigned_variants` for details.
-See :ref:`zephyr:sysbuild_kconfig_namespacing` for information on how to set options for built images in Sysbuild.
+See :ref:`zephyr:sysbuild_kconfig_namespacing` in the Zephyr documentation for information on how to set options for built images in sysbuild.
 
 .. bootloader_monotonic_counter_nsib_end
 
-To set options for other images, see :ref:`zephyr:sysbuild_kconfig_namespacing`.
+To set options for other images, see :ref:`zephyr:sysbuild_kconfig_namespacing` in the Zephyr documentation.
 
 .. _ug_fw_update_hw_downgrade_mcuboot:
 

--- a/doc/nrf/config_and_build/configuring_app/sysbuild_images.rst
+++ b/doc/nrf/config_and_build/configuring_app/sysbuild_images.rst
@@ -3,7 +3,7 @@
 Sysbuild images
 ###############
 
-Sysbuild allows you to add additional images to your builds.
+:ref:`configuration_system_overview_sysbuild` allows you to add additional images to your builds.
 
 Enabling images
 ===============
@@ -242,4 +242,4 @@ Kconfig.sysbuild:
 Next steps
 ==========
 
-For more information on sysbuild, see :ref:`zephyr:sysbuild`, :ref:`zephyr_samples_sysbuild`, and :ref:`sysbuild_forced_options`.
+For more information on sysbuild, see :ref:`sysbuild_forced_options` and :ref:`zephyr_samples_sysbuild` in the |NCS| documentation and :ref:`zephyr:sysbuild` in the Zephyr documentation.

--- a/doc/nrf/releases_and_maturity/migration/migration_hwmv2.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_hwmv2.rst
@@ -19,7 +19,7 @@ The current hardware model adds support for the following features:
 * Support for multi-core, multi-architecture Asymmetrical Multi Processing (AMP) SoCs.
 * Support for multi-SoC boards.
 * Support for reusing the SoC and board Kconfig trees outside of the Zephyr and |NCS| build system.
-* Support for advanced use cases with :ref:`zephyr:sysbuild`.
+* Support for advanced use cases with :ref:`configuration_system_overview_sysbuild`.
 * Removal of all existing arbitrary and inconsistent uses of Kconfig and folder names.
 
 For more information about the rationale, development, and concepts behind the new model, see the following links:

--- a/doc/nrf/releases_and_maturity/migration/migration_sysbuild.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_sysbuild.rst
@@ -20,7 +20,7 @@ This results in the CMake configuration step running more than once, as this inf
 * Sysbuild output files have different names and locations (they are namespaced).
 * Sysbuild introduces support for file suffixes, replacing the deprecated build type used by child/parent images.
 
-The changes needed to convert a child/parent image project to a Sysbuild project depend on the features used.
+The changes needed to convert a child/parent image project to a sysbuild project depend on the features used.
 Review how :ref:`sysbuild` works to understand the basic usage and configuration methods, and how these differ from a child image build, before proceeding with project migration according to the guidelines listed in the following sections.
 
 .. _child_parent_to_sysbuild_migration_sysbuild_configuration_file:


### PR DESCRIPTION
Edited capitalization of sysbuild for consistency with Zephyr docs. Added reference to doc placement next to links.