### PR TITLE
doc: libraries: modem: correct source file paths for various libraries

### DIFF
--- a/doc/nrf/libraries/modem/at_cmd_custom.rst
+++ b/doc/nrf/libraries/modem/at_cmd_custom.rst
@@ -96,7 +96,7 @@ API documentation
 *****************
 
 | Header file: :file:`include/modem/at_cmd_custom.h`
-| Source file: :file:`lib/at_cmd_custom/src/at_cmd_custom.c`
+| Source file: :file:`lib/at_cmd_custom/at_cmd_custom.c`
 
 .. doxygengroup:: at_cmd_custom
    :project: nrf

--- a/doc/nrf/libraries/modem/at_cmd_parser.rst
+++ b/doc/nrf/libraries/modem/at_cmd_parser.rst
@@ -30,7 +30,7 @@ API documentation
 *****************
 
 | Header file: :file:`include/modem/at_cmd_parser.h`
-| Source file: :file:`lib/at_cmd_parser/src/at_cmd_parser.c`
+| Source file: :file:`lib/at_cmd_parser/at_cmd_parser.c`
 
 .. doxygengroup:: at_cmd_parser
    :project: nrf

--- a/doc/nrf/libraries/modem/at_params.rst
+++ b/doc/nrf/libraries/modem/at_params.rst
@@ -25,7 +25,7 @@ API documentation
 *****************
 
 | Header file: :file:`include/modem/at_params.h`
-| Source file: :file:`lib/at_cmd_parser/src/at_params.c`
+| Source file: :file:`lib/at_cmd_parser/at_params.c`
 
 .. doxygengroup:: at_params
    :project: nrf

--- a/doc/nrf/libraries/modem/gcf_sms_lib.rst
+++ b/doc/nrf/libraries/modem/gcf_sms_lib.rst
@@ -30,4 +30,4 @@ API documentation
 
 The library does not expose any API of its own.
 
-| Source files: :file:`lib/gcf_sms/gcf_sms.c`
+| Source file: :file:`lib/gcf_sms/gcf_sms.c`

--- a/doc/nrf/libraries/modem/location.rst
+++ b/doc/nrf/libraries/modem/location.rst
@@ -408,7 +408,7 @@ API documentation
 *****************
 
 | Header file: :file:`include/modem/location.h`
-| Source files: :file:`lib/location`
+| Source files: :file:`lib/location/`
 
 .. doxygengroup:: location
    :project: nrf

--- a/doc/nrf/libraries/modem/modem_attest_token.rst
+++ b/doc/nrf/libraries/modem/modem_attest_token.rst
@@ -39,7 +39,7 @@ API documentation
 *****************
 
 | Header file: :file:`include/modem/modem_attest_token.h`
-| Source file: :file:`lib/modem/modem_attest_token.c`
+| Source file: :file:`lib/modem_attest_token/modem_attest_token.c`
 
 .. doxygengroup:: modem_attest_token
    :project: nrf

--- a/doc/nrf/libraries/modem/modem_jwt.rst
+++ b/doc/nrf/libraries/modem/modem_jwt.rst
@@ -55,7 +55,7 @@ API documentation
 *****************
 
 | Header file: :file:`include/modem/modem_jwt.h`
-| Source file: :file:`lib/modem/modem_jwt.c`
+| Source file: :file:`lib/modem_jwt/modem_jwt.c`
 
 .. doxygengroup:: modem_jwt
    :project: nrf

--- a/doc/nrf/libraries/modem/modem_slm.rst
+++ b/doc/nrf/libraries/modem/modem_slm.rst
@@ -98,8 +98,8 @@ API documentation
 *****************
 
 | Header file: :file:`include/modem/modem_slm.h`
-| Source file: :file:`lib/modem/modem_slm.c`
-| Source file: :file:`lib/modem/modem_slm_monitor.c`
+| Source file: :file:`lib/modem_slm/modem_slm.c`
+| Source file: :file:`lib/modem_slm/modem_slm_monitor.c`
 
 .. doxygengroup:: modem_slm
    :project: nrf


### PR DESCRIPTION
Fix incorrect source file paths in the documentation.