### PR TITLE
samples: mpsl: timeslot: Fix missing empty_app_core in build

### DIFF
--- a/samples/bluetooth/connection_event_trigger/sysbuild.cmake
+++ b/samples/bluetooth/connection_event_trigger/sysbuild.cmake
@@ -2,12 +2,31 @@
 # Copyright (c) 2024 Nordic Semiconductor
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
-#
 
-if (${SB_CONFIG_BOARD_NRF5340DK_NRF5340_CPUNET})
+get_property(PM_DOMAINS GLOBAL PROPERTY PM_DOMAINS)
+
+# Include app core image if enabled
+if(SB_CONFIG_SOC_NRF5340_CPUNET)
+  # Get application core board target
+  string(REPLACE "/" ";" split_board_qualifiers "${BOARD_QUALIFIERS}")
+  list(GET split_board_qualifiers 1 target_soc)
+  set(board_target_appcore "${BOARD}/${target_soc}/cpuapp")
+  set(target_soc)
+
   ExternalZephyrProject_Add(
-      APPLICATION empty_app_core
-      SOURCE_DIR  ${ZEPHYR_NRF_MODULE_DIR}/samples/nrf5340/empty_app_core
-      BOARD nrf5340dk/nrf5340/cpuapp
-    )
+    APPLICATION empty_app_core
+    SOURCE_DIR ${ZEPHYR_NRF_MODULE_DIR}/samples/nrf5340/empty_app_core
+    BOARD ${board_target_appcore}
+    BOARD_REVISION ${BOARD_REVISION}
+  )
+
+  if(NOT "CPUAPP" IN_LIST PM_DOMAINS)
+    list(APPEND PM_DOMAINS CPUAPP)
+  endif()
+
+  set_property(GLOBAL APPEND PROPERTY PM_CPUAPP_IMAGES "empty_app_core")
+  set_property(GLOBAL PROPERTY DOMAIN_APP_CPUAPP "empty_app_core")
+  set(CPUAPP_PM_DOMAIN_DYNAMIC_PARTITION empty_app_core CACHE INTERNAL "")
 endif()
+
+set_property(GLOBAL PROPERTY PM_DOMAINS ${PM_DOMAINS})

--- a/samples/bluetooth/direct_test_mode/Kconfig.sysbuild
+++ b/samples/bluetooth/direct_test_mode/Kconfig.sysbuild
@@ -8,15 +8,11 @@ source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
 
 config SUPPORT_APPCORE
 	bool
-	default y if BOARD_NRF5340DK_NRF5340_CPUNET
-
-config APPCORE_REMOTE_BOARD_NAME
-	string
-	default "nrf5340dk/nrf5340/cpuapp" if BOARD_NRF5340DK_NRF5340_CPUNET
+	default y if SOC_NRF5340_CPUNET
 
 choice APPCORE
 	prompt "Appcore image"
-	default APPCORE_REMOTE_HCI if DTM_TRANSPORT_HCI && APPCORE_REMOTE_BOARD_NAME != ""
+	default APPCORE_REMOTE_HCI if DTM_TRANSPORT_HCI
 	default APPCORE_REMOTE_SHELL
 	depends on SUPPORT_APPCORE
 

--- a/samples/bluetooth/direct_test_mode/sysbuild.cmake
+++ b/samples/bluetooth/direct_test_mode/sysbuild.cmake
@@ -6,11 +6,18 @@
 get_property(PM_DOMAINS GLOBAL PROPERTY PM_DOMAINS)
 
 # Include app core image if enabled
-if(SB_CONFIG_SUPPORT_APPCORE AND DEFINED SB_CONFIG_APPCORE_IMAGE_NAME)
+if(SB_CONFIG_SOC_NRF5340_CPUNET AND DEFINED SB_CONFIG_APPCORE_IMAGE_NAME)
+  # Get application core board target
+  string(REPLACE "/" ";" split_board_qualifiers "${BOARD_QUALIFIERS}")
+  list(GET split_board_qualifiers 1 target_soc)
+  set(board_target_appcore "${BOARD}/${target_soc}/cpuapp")
+  set(target_soc)
+
   ExternalZephyrProject_Add(
     APPLICATION ${SB_CONFIG_APPCORE_IMAGE_NAME}
     SOURCE_DIR ${SB_CONFIG_APPCORE_IMAGE_PATH}
-    BOARD ${SB_CONFIG_APPCORE_REMOTE_BOARD_NAME}
+    BOARD ${board_target_appcore}
+    BOARD_REVISION ${BOARD_REVISION}
   )
 
   if(NOT "CPUAPP" IN_LIST PM_DOMAINS)

--- a/samples/esb/esb_prx/sysbuild.cmake
+++ b/samples/esb/esb_prx/sysbuild.cmake
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+get_property(PM_DOMAINS GLOBAL PROPERTY PM_DOMAINS)
+
+# Include app core image if enabled
+if(SB_CONFIG_SOC_NRF5340_CPUNET)
+  # Get application core board target
+  string(REPLACE "/" ";" split_board_qualifiers "${BOARD_QUALIFIERS}")
+  list(GET split_board_qualifiers 1 target_soc)
+  set(board_target_appcore "${BOARD}/${target_soc}/cpuapp")
+  set(target_soc)
+
+  ExternalZephyrProject_Add(
+    APPLICATION empty_app_core
+    SOURCE_DIR ${ZEPHYR_NRF_MODULE_DIR}/samples/nrf5340/empty_app_core
+    BOARD ${board_target_appcore}
+    BOARD_REVISION ${BOARD_REVISION}
+  )
+
+  if(NOT "CPUAPP" IN_LIST PM_DOMAINS)
+    list(APPEND PM_DOMAINS CPUAPP)
+  endif()
+
+  set_property(GLOBAL APPEND PROPERTY PM_CPUAPP_IMAGES "empty_app_core")
+  set_property(GLOBAL PROPERTY DOMAIN_APP_CPUAPP "empty_app_core")
+  set(CPUAPP_PM_DOMAIN_DYNAMIC_PARTITION empty_app_core CACHE INTERNAL "")
+endif()
+
+set_property(GLOBAL PROPERTY PM_DOMAINS ${PM_DOMAINS})

--- a/samples/esb/esb_ptx/sysbuild.cmake
+++ b/samples/esb/esb_ptx/sysbuild.cmake
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+get_property(PM_DOMAINS GLOBAL PROPERTY PM_DOMAINS)
+
+# Include app core image if enabled
+if(SB_CONFIG_SOC_NRF5340_CPUNET)
+  # Get application core board target
+  string(REPLACE "/" ";" split_board_qualifiers "${BOARD_QUALIFIERS}")
+  list(GET split_board_qualifiers 1 target_soc)
+  set(board_target_appcore "${BOARD}/${target_soc}/cpuapp")
+  set(target_soc)
+
+  ExternalZephyrProject_Add(
+    APPLICATION empty_app_core
+    SOURCE_DIR ${ZEPHYR_NRF_MODULE_DIR}/samples/nrf5340/empty_app_core
+    BOARD ${board_target_appcore}
+    BOARD_REVISION ${BOARD_REVISION}
+  )
+
+  if(NOT "CPUAPP" IN_LIST PM_DOMAINS)
+    list(APPEND PM_DOMAINS CPUAPP)
+  endif()
+
+  set_property(GLOBAL APPEND PROPERTY PM_CPUAPP_IMAGES "empty_app_core")
+  set_property(GLOBAL PROPERTY DOMAIN_APP_CPUAPP "empty_app_core")
+  set(CPUAPP_PM_DOMAIN_DYNAMIC_PARTITION empty_app_core CACHE INTERNAL "")
+endif()
+
+set_property(GLOBAL PROPERTY PM_DOMAINS ${PM_DOMAINS})

--- a/samples/mpsl/timeslot/sysbuild.cmake
+++ b/samples/mpsl/timeslot/sysbuild.cmake
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+get_property(PM_DOMAINS GLOBAL PROPERTY PM_DOMAINS)
+
+# Include app core image if enabled
+if(SB_CONFIG_SOC_NRF5340_CPUNET)
+  # Get application core board target
+  string(REPLACE "/" ";" split_board_qualifiers "${BOARD_QUALIFIERS}")
+  list(GET split_board_qualifiers 1 target_soc)
+  set(board_target_appcore "${BOARD}/${target_soc}/cpuapp")
+  set(target_soc)
+
+  ExternalZephyrProject_Add(
+    APPLICATION empty_app_core
+    SOURCE_DIR ${ZEPHYR_NRF_MODULE_DIR}/samples/nrf5340/empty_app_core
+    BOARD ${board_target_appcore}
+    BOARD_REVISION ${BOARD_REVISION}
+  )
+
+  if(NOT "CPUAPP" IN_LIST PM_DOMAINS)
+    list(APPEND PM_DOMAINS CPUAPP)
+  endif()
+
+  set_property(GLOBAL APPEND PROPERTY PM_CPUAPP_IMAGES "empty_app_core")
+  set_property(GLOBAL PROPERTY DOMAIN_APP_CPUAPP "empty_app_core")
+  set(CPUAPP_PM_DOMAIN_DYNAMIC_PARTITION empty_app_core CACHE INTERNAL "")
+endif()
+
+set_property(GLOBAL PROPERTY PM_DOMAINS ${PM_DOMAINS})

--- a/samples/peripheral/802154_phy_test/sysbuild.cmake
+++ b/samples/peripheral/802154_phy_test/sysbuild.cmake
@@ -9,11 +9,18 @@ zephyr_get(EXTRA_ZEPHYR_MODULES)
 set(EXTRA_ZEPHYR_MODULES "${EXTRA_ZEPHYR_MODULES};${CMAKE_CURRENT_LIST_DIR}/modules/app_rpc" CACHE INTERNAL "extra modules directories")
 
 # Include app core image if enabled
-if(SB_CONFIG_BOARD_NRF5340DK_NRF5340_CPUNET)
+if(SB_CONFIG_SOC_NRF5340_CPUNET)
+  # Get application core board target
+  string(REPLACE "/" ";" split_board_qualifiers "${BOARD_QUALIFIERS}")
+  list(GET split_board_qualifiers 1 target_soc)
+  set(board_target_appcore "${BOARD}/${target_soc}/cpuapp")
+  set(target_soc)
+
   ExternalZephyrProject_Add(
     APPLICATION remote_shell
     SOURCE_DIR ${ZEPHYR_NRF_MODULE_DIR}/samples/nrf5340/remote_shell
-    BOARD "nrf5340dk/nrf5340/cpuapp"
+    BOARD ${board_target_appcore}
+    BOARD_REVISION ${BOARD_REVISION}
   )
 
   if(NOT "CPUAPP" IN_LIST PM_DOMAINS)

--- a/samples/peripheral/radio_test/sysbuild.cmake
+++ b/samples/peripheral/radio_test/sysbuild.cmake
@@ -6,11 +6,18 @@
 get_property(PM_DOMAINS GLOBAL PROPERTY PM_DOMAINS)
 
 # Include app core image if enabled
-if(SB_CONFIG_BOARD_NRF5340DK_NRF5340_CPUNET)
+if(SB_CONFIG_SOC_NRF5340_CPUNET AND NOT SB_CONFIG_BOARD_NRF7002DK)
+  # Get application core board target
+  string(REPLACE "/" ";" split_board_qualifiers "${BOARD_QUALIFIERS}")
+  list(GET split_board_qualifiers 1 target_soc)
+  set(board_target_appcore "${BOARD}/${target_soc}/cpuapp")
+  set(target_soc)
+
   ExternalZephyrProject_Add(
     APPLICATION remote_shell
     SOURCE_DIR ${ZEPHYR_NRF_MODULE_DIR}/samples/nrf5340/remote_shell
-    BOARD "nrf5340dk/nrf5340/cpuapp"
+    BOARD ${board_target_appcore}
+    BOARD_REVISION ${BOARD_REVISION}
   )
 
   if(NOT "CPUAPP" IN_LIST PM_DOMAINS)


### PR DESCRIPTION
Adds the empty_app_core application to the build so that it works out of the box on the nrf53 without needing a separate image built and flashed