### PR TITLE
modules: hostap: Fix H2E default value

### DIFF
--- a/modules/hostap/src/supp_main.c
+++ b/modules/hostap/src/supp_main.c
@@ -188,6 +188,7 @@ static int z_wpas_add_interface(const char *ifname)
 
 	wpa_s->conf->filter_ssids = 1;
 	wpa_s->conf->ap_scan = 1;
+	wpa_s->conf->sae_pwe = 2;
 
 	/* Default interface, kick start wpa_supplicant */
 	if (z_wpas_get_iface_count() == 1) {


### PR DESCRIPTION
As Zephyr still doesn't have a way to convey the choice of algo for WPA3 (HaP or H2E), set the default method to allow both, else if AP sets H2E only then association will fail.

Fixes SHEL-2930.