### PR TITLE
samples: matter: optimize the factory reset time

### DIFF
--- a/samples/matter/common/src/app/fabric_table_delegate.h
+++ b/samples/matter/common/src/app/fabric_table_delegate.h
@@ -10,6 +10,8 @@
 #include <app/util/attribute-storage.h>
 #include <lib/support/logging/CHIPLogging.h>
 
+#include "app/group_data_provider.h"
+
 #ifdef CONFIG_CHIP_WIFI
 #include <platform/nrfconnect/wifi/WiFiManager.h>
 #endif
@@ -48,6 +50,7 @@ private:
 		if (chip::Server::GetInstance().GetFabricTable().FabricCount() == 0) {
 			chip::DeviceLayer::PlatformMgr().ScheduleWork([](intptr_t) {
 #ifdef CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_REBOOT
+				GroupDataProviderImpl::Instance().WillBeFactoryReset();
 				chip::Server::GetInstance().ScheduleFactoryReset();
 #elif defined(CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_ONLY) ||                                                           \
 	defined(CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_PAIRING_START)

--- a/samples/matter/common/src/app/group_data_provider.h
+++ b/samples/matter/common/src/app/group_data_provider.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#pragma once
+
+#include <credentials/GroupDataProviderImpl.h>
+
+namespace Nrf::Matter
+{
+class GroupDataProviderImpl : public chip::Credentials::GroupDataProviderImpl {
+public:
+	/**
+	 * @brief Return the static GroupDataProviderImpl instance.
+	 */
+	static GroupDataProviderImpl &Instance()
+	{
+		static GroupDataProviderImpl sGroupDataProviderImpl;
+		return sGroupDataProviderImpl;
+	}
+
+	/**
+	 * @brief Inform that the factory reset will happen.
+	 *
+	 * This function informs the GroupDataProviderImpl that the factory
+	 * reset will happen, therefore we can skip the time-consuming default
+	 * RemoveFabric's operations that heavily use persistent storage.
+	 *
+	 * It should be called before scheduling the factory reset with
+	 * chip::Server::ScheduleFactoryReset().
+	 *
+	 */
+	void WillBeFactoryReset() { mClearStorage = false; }
+
+	CHIP_ERROR RemoveFabric(chip::FabricIndex fabricIdx) override
+	{
+		if (mClearStorage) {
+			return chip::Credentials::GroupDataProviderImpl::RemoveFabric(fabricIdx);
+		} else {
+			/* The storage will be erased and the device will be rebooted anyway,
+			   so to optimize the time needed for the factory reset we can simply
+			   do nothing. */
+			return CHIP_NO_ERROR;
+		}
+	}
+
+	/* No copy, nor move. */
+	GroupDataProviderImpl(const GroupDataProviderImpl &) = delete;
+	GroupDataProviderImpl &operator=(const GroupDataProviderImpl &) = delete;
+	GroupDataProviderImpl(GroupDataProviderImpl &&) = delete;
+	GroupDataProviderImpl &operator=(GroupDataProviderImpl &&) = delete;
+
+private:
+	GroupDataProviderImpl() = default;
+	~GroupDataProviderImpl() = default;
+
+	bool mClearStorage{ true };
+};
+
+} // namespace Nrf::Matter

--- a/samples/matter/common/src/board/board.cpp
+++ b/samples/matter/common/src/board/board.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "board.h"
+#include "app/group_data_provider.h"
 #include "app/task_executor.h"
 
 #include <app/server/Server.h>
@@ -210,6 +211,7 @@ void Board::FunctionTimerEventHandler()
 	} else if (sInstance.mFunction == BoardFunctions::FactoryReset) {
 		/* Actually trigger Factory Reset */
 		sInstance.mFunction = BoardFunctions::None;
+		Matter::GroupDataProviderImpl::Instance().WillBeFactoryReset();
 		chip::Server::GetInstance().ScheduleFactoryReset();
 	}
 }

--- a/samples/matter/common/src/event_triggers/default_event_triggers.cpp
+++ b/samples/matter/common/src/event_triggers/default_event_triggers.cpp
@@ -7,10 +7,11 @@
 #include <app/server/Server.h>
 #include <platform/nrfconnect/Reboot.h>
 
+#include "app/group_data_provider.h"
 #include "app/task_executor.h"
 #include "default_event_triggers.h"
-
 #include "event_triggers.h"
+
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/reboot.h>
 
@@ -60,6 +61,7 @@ void DelayTimerCallback(k_timer *timer)
 
 		switch (ctx->action) {
 		case DelayedAction::FactoryReset:
+			GroupDataProviderImpl::Instance().WillBeFactoryReset();
 			Server::GetInstance().ScheduleFactoryReset();
 			break;
 #ifdef CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_EVENT_TRIGGERS

--- a/samples/matter/common/src/migration/migration_manager.cpp
+++ b/samples/matter/common/src/migration/migration_manager.cpp
@@ -6,6 +6,8 @@
 
 #include "migration_manager.h"
 
+#include "app/group_data_provider.h"
+
 #include <crypto/OperationalKeystore.h>
 #include <crypto/PersistentStorageOperationalKeystore.h>
 
@@ -36,6 +38,7 @@ namespace Migration
 
 #ifdef CONFIG_NCS_SAMPLE_MATTER_FACTORY_RESET_ON_KEY_MIGRATION_FAILURE
 		if (CHIP_NO_ERROR != err) {
+			GroupDataProviderImpl::Instance().WillBeFactoryReset();
 			chip::Server::GetInstance().ScheduleFactoryReset();
 			/* Return a success to not block the Matter event Loop and allow to call scheduled factory
 			 * reset. */


### PR DESCRIPTION
Currently the Matter core uses generic implementation of GroupDataProvider that performs multiple operations on persistent storage (including erasing of the related keys) even though the KVS is erased at the end and the device is rebooted. Implemented custom GroupDataProvider that can be configured at runtime to avoid redundant and time-consuming tasks.

It decreases the factory reset time on nRF52 by ~40%.