### PR TITLE
NCS 2.7.0 rebase

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 1a5d3b4a4ff98a33222856526afdf9c089b96d2b
+      revision: v3.6.99-ncs2-snapshot1
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above

--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v3.6.99-ncs2-snapshot1
+      revision: 10c0de0d0cc5dd0ac71466aef69cc7e6188c8b4c
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -131,7 +131,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: v2.1.0-ncs1-rc3
+      revision: daf2946a0f07a14b57bd69d29ac4cdde6f810fb7
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR


### PR DESCRIPTION
Update zephyr revision with a snapshot tag. There is no need for a new tag in sdk-mcuboot as that -rc3 one will preserve the history. Other OSS repositories do not need to be rebased.

Update zephyr and mcuboot revisions after they were rebased.