### PR TITLE
samples: ipc: ipc_service: align test config when rad/net is sending

### DIFF
--- a/samples/ipc/ipc_service/sample.yaml
+++ b/samples/ipc/ipc_service/sample.yaml
@@ -39,6 +39,15 @@ tests:
       - CONFIG_APP_IPC_SERVICE_SEND_INTERVAL=200000000
     extra_args: >
       remote_CONFIG_APP_IPC_SERVICE_SEND_INTERVAL=1
+    harness_config:
+      type: multi_line
+      ordered: true
+      regex:
+        - "IPC-service .* demo started"
+        # there will be only single tranfser from this core
+        - "Δpkt: (?!0)\\d+ ((?!0)\\d+ B/pkt) | throughput: (?!0)\\d+ bit/s"
+        - "Δpkt: \\d+ (\\d+ B/pkt) | throughput: \\d+ bit/s"
+        - "Δpkt: \\d+ (\\d+ B/pkt) | throughput: \\d+ bit/s"
   sample.ipc.ipc_service.nrf5340dk_icmsg_default:
     platform_allow:
       - nrf5340dk/nrf5340/cpuapp
@@ -66,6 +75,15 @@ tests:
     extra_args: >
       FILE_SUFFIX=icmsg
       remote_CONFIG_APP_IPC_SERVICE_SEND_INTERVAL=1
+    harness_config:
+      type: multi_line
+      ordered: true
+      regex:
+        - "IPC-service .* demo started"
+        # there will be only single tranfser from this core
+        - "Δpkt: (?!0)\\d+ ((?!0)\\d+ B/pkt) | throughput: (?!0)\\d+ bit/s"
+        - "Δpkt: \\d+ (\\d+ B/pkt) | throughput: \\d+ bit/s"
+        - "Δpkt: \\d+ (\\d+ B/pkt) | throughput: \\d+ bit/s"
   sample.ipc.ipc_service.nrf54h20dk_cpuapp_cpurad_icmsg:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp


### PR DESCRIPTION
When rad/net is sending, there will be only single tranfser from app core.