### PR TITLE
Codeowners: Migrate to ncs-audio

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -148,7 +148,7 @@ Kconfig*                                  @tejlmand
 /lib/data_fifo/                           @nrfconnect/ncs-audio
 /lib/pcm_mix/                             @nrfconnect/ncs-audio
 /lib/pcm_stream_channel_modifier/         @nrfconnect/ncs-audio
-/lib/sample_rate_converter/               @andvib @gWacey
+/lib/sample_rate_converter/               @nrfconnect/ncs-audio
 /lib/tone/                                @nrfconnect/ncs-audio
 /modules/                                 @tejlmand
 /modules/hostap/                          @krish2718 @jukkar @rado17 @sachinthegreen @rlubos
@@ -337,7 +337,7 @@ Kconfig*                                  @tejlmand
 /tests/lib/data_fifo/                     @nrfconnect/ncs-audio
 /tests/lib/pcm_mix/                       @nrfconnect/ncs-audio
 /tests/lib/pcm_stream_channel_modifier/   @nrfconnect/ncs-audio
-/tests/lib/sample_rate_converter/         @andvib @gWacey
+/tests/lib/sample_rate_converter/         @nrfconnect/ncs-audio
 /tests/lib/tone/                          @nrfconnect/ncs-audio
 /tests/mocks/nrf_rpc/                     @nrfconnect/ncs-protocols-serialization
 /tests/modules/lib/zcbor/                 @oyvindronningstad


### PR DESCRIPTION
OCT-2935
ncs-audio now used for all relevant areas.