### PR TITLE
lib: nrf_modem_lib: lte_net_if: Enable modem events

### DIFF
--- a/lib/nrf_modem_lib/lte_net_if/lte_net_if.c
+++ b/lib/nrf_modem_lib/lte_net_if/lte_net_if.c
@@ -415,6 +415,11 @@ static int lte_net_if_connect(struct conn_mgr_conn_binding *const if_conn)
 		return ret;
 	}
 
+	ret = lte_lc_modem_events_enable();
+	if (ret) {
+		LOG_WRN("lte_lc_modem_events_enable, error: %d", ret);
+	}
+
 	connection_timeout_schedule();
 
 	return 0;

--- a/tests/lib/nrf_modem_lib/lte_net_if/src/main.c
+++ b/tests/lib/nrf_modem_lib/lte_net_if/src/main.c
@@ -250,6 +250,7 @@ void test_connect_should_set_functional_mode(void)
 	bring_network_interface_up();
 
 	__cmock_lte_lc_func_mode_set_ExpectAndReturn(LTE_LC_FUNC_MODE_ACTIVATE_LTE, 0);
+	__cmock_lte_lc_modem_events_enable_ExpectAndReturn(0);
 
 	TEST_ASSERT_EQUAL(0, conn_mgr_if_connect(net_if_get_default()));
 }


### PR DESCRIPTION
Enable modem events when using Zephyr Connection Manager. When the events are enabled, a warning will be printed when the modem detects a reset loop.