### PR TITLE
doc: installation: add section about terminal env

### DIFF
--- a/doc/nrf/installation/updating.rst
+++ b/doc/nrf/installation/updating.rst
@@ -16,6 +16,52 @@ You might also want to switch to a newer release or check out the latest state o
 However, if you work with a specific release of the |NCS|, you do not need to update your repositories, because the release will not change.
 For an overview of changes in the latest releases, see :ref:`release_notes`.
 
+.. _using_toolchain_environment:
+
+Using the correct command line environment
+******************************************
+
+Whenever you update repositories and tools, make sure that you use the command line environment that is configured to work with west and the rest of the nRF Connect Toolchain and nRF Connect SDK environment.
+
+Depending on your preferred development method, you can start the correct CLI toolchain environment the following way:
+
+.. tabs::
+
+   .. group-tab:: nRF Connect for Visual Studio Code
+
+      Start the nRF Connect terminal profile from the :guilabel:`Panel View`.
+      See `the extension documentation <nRF Terminal documentation_>`_ for more information.
+
+      .. note::
+          Repositories and tools can be updated in the |nRFVSC| using GUI.
+          See :ref:`updating_repos` below for details.
+
+   .. group-tab:: Command line
+
+      Use the command for your operating system:
+
+      .. tabs::
+
+         .. tab:: Windows
+
+            .. code-block:: console
+
+               nrfutil toolchain-manager launch --terminal
+
+         .. tab:: Linux
+
+            .. code-block:: console
+
+               nrfutil toolchain-manager launch --shell
+
+         .. tab:: macOS
+
+            .. code-block:: console
+
+               nrfutil toolchain-manager launch --shell
+
+      ..
+
 .. _gs_updating_repos:
 .. _gs_updating_repos_examples:
 .. _updating_repos_examples:

--- a/doc/nrf/releases_and_maturity/migration/migration_hwmv2.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_hwmv2.rst
@@ -55,7 +55,9 @@ Conversion script
 
 There is a `conversion script <hwmv2 conversion script_>`_ to help you in the migration process.
 It has built-in help text documenting all the parameters it takes.
+
 The following example shows an invocation of the script converting a hypothetical out-of-tree board ``plank`` based on the nRF52840 and having ``acme`` as vendor.
+The command must be run from the :ref:`toolchain environment <using_toolchain_environment>`.
 
 .. code-block::
    :class: highlight

--- a/doc/nrf/releases_and_maturity/migration/migration_hwmv2.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_hwmv2.rst
@@ -62,8 +62,8 @@ The command must be run from the :ref:`toolchain environment <using_toolchain_en
 .. code-block::
    :class: highlight
 
-   $ cd my-repo
-   $ python ../zephyr/scripts/utils/board_v1_to_v2.py --board-root boards/ -b plank -s nrf52840 -v acme
+   cd my-repo
+   python ../zephyr/scripts/utils/board_v1_to_v2.py --board-root . -b plank -s nrf52840 -g acme -v acme
 
 
 After running this command, the script converts the board from the previous hardware model to the current one, creating a board in the new format in :file:`my-repo/boards/acme/plank`.


### PR DESCRIPTION
Added a section about using terminal environment, as a target for different references in docs.
Requested by @carlescufi.