### PR TITLE
bluetooth: fast_pair: separate subsequent pairing feature into Kconfig

### DIFF
--- a/doc/nrf/external_comp/bt_fast_pair.rst
+++ b/doc/nrf/external_comp/bt_fast_pair.rst
@@ -362,7 +362,7 @@ The Fast Pair service implementation provides API to generate the advertising da
   Account Keys are used to generate not discoverable advertising data.
 
 :c:func:`bt_fast_pair_set_pairing_mode`
-  This function is to be used to set pairing mode before the advertising is started.
+  This function is used to set the pairing mode before the advertising is started.
 
 Since you control the advertising, make sure to use advertising parameters consistent with the specification.
 The Bluetooth privacy is selected by the Fast Pair service, but you must make sure that the following requirements are met:

--- a/doc/nrf/external_comp/bt_fast_pair.rst
+++ b/doc/nrf/external_comp/bt_fast_pair.rst
@@ -364,6 +364,11 @@ The Fast Pair service implementation provides API to generate the advertising da
 :c:func:`bt_fast_pair_set_pairing_mode`
   This function is used to set the pairing mode before the advertising is started.
 
+.. note::
+   When the :kconfig:option:`CONFIG_BT_FAST_PAIR_SUBSEQUENT_PAIRING` Kconfig option is disabled, you cannot use the Fast Pair not discoverable advertising with UI indications (:c:enum:`BT_FAST_PAIR_NOT_DISC_ADV_TYPE_SHOW_UI_IND`).
+   This type of advertising is required for triggering the subsequent pairing.
+   For more details, see the :ref:`ug_bt_fast_pair_gatt_service_subsequent_pairing` section.
+
 Since you control the advertising, make sure to use advertising parameters consistent with the specification.
 The Bluetooth privacy is selected by the Fast Pair service, but you must make sure that the following requirements are met:
 
@@ -588,6 +593,18 @@ In the Fast Pair subsystem disabled state, GATT operations on the Fast Pair serv
 The Fast Pair GATT service modifies default values of related Kconfig options to follow Fast Pair requirements.
 The service also enables the needed functionalities using Kconfig select statement.
 For details, see the :ref:`bt_fast_pair_readme` Bluetooth service documentation in the |NCS|.
+
+.. _ug_bt_fast_pair_gatt_service_subsequent_pairing:
+
+Subsequent pairing
+==================
+
+The Fast Pair specification supports the subsequent pairing feature.
+Subsequent pairing refers to the procedure between a Fast Pair Provider, initially paired with your Google account, and another Fast Pair Seeker logged into the same account.
+
+To support the subsequent pairing feature in the `Fast Pair Procedure`_, enable the :kconfig:option:`CONFIG_BT_FAST_PAIR_SUBSEQUENT_PAIRING` Kconfig option.
+
+Consequently, the Fast Pair not discoverable advertising with UI indications, which is used to trigger the subsequent pairing UI flow, is only available when the subsequent pairing feature is supported.
 
 .. _ug_bt_fast_pair_gatt_service_no_ble_pairing:
 

--- a/doc/nrf/libraries/bluetooth_services/services/fast_pair.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/fast_pair.rst
@@ -44,6 +44,9 @@ With the :kconfig:option:`CONFIG_BT_FAST_PAIR` Kconfig option enabled, the follo
 * :kconfig:option:`CONFIG_BT_FAST_PAIR_REQ_PAIRING` - The option enforces the requirement for Bluetooth pairing and bonding during the `Fast Pair Procedure`_.
   This option is enabled by default.
   See the :ref:`ug_bt_fast_pair_gatt_service_no_ble_pairing` for more details.
+* :kconfig:option:`CONFIG_BT_FAST_PAIR_SUBSEQUENT_PAIRING` - The option adds support for the Fast Pair subsequent pairing feature.
+  It is enabled by default unless the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN` Kconfig option is enabled.
+  This aligns the default configuration with the `Fast Pair Device Feature Requirements for Locator Tags`_ documentation.
 * :kconfig:option:`CONFIG_BT_FAST_PAIR_STORAGE_USER_RESET_ACTION` - The option enables user reset action that is executed together with the Fast Pair factory reset operation.
   See the :ref:`ug_bt_fast_pair_factory_reset_custom_user_reset_action` for more details.
 * :kconfig:option:`CONFIG_BT_FAST_PAIR_STORAGE_ACCOUNT_KEY_MAX` - The option configures maximum number of stored Account Keys.

--- a/doc/nrf/libraries/bluetooth_services/services/fast_pair.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/fast_pair.rst
@@ -39,7 +39,7 @@ The Fast Pair Service is enabled with :kconfig:option:`CONFIG_BT_FAST_PAIR` Kcon
 With the :kconfig:option:`CONFIG_BT_FAST_PAIR` Kconfig option enabled, the following Kconfig options are available for this service:
 
 * :kconfig:option:`CONFIG_BT_FAST_PAIR_GATT_SERVICE_MODEL_ID` - The option adds the Model ID characteristic to the Fast Pair GATT service.
-  This option is enabled by default unless the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN` is enabled.
+  It is enabled by default unless the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN` Kconfig option is enabled.
   This is done to align default configuration with `Fast Pair Device Feature Requirements for Locator Tags`_ documentation.
 * :kconfig:option:`CONFIG_BT_FAST_PAIR_REQ_PAIRING` - The option enforces the requirement for Bluetooth pairing and bonding during the `Fast Pair Procedure`_.
   This option is enabled by default.
@@ -51,7 +51,7 @@ With the :kconfig:option:`CONFIG_BT_FAST_PAIR` Kconfig option enabled, the follo
   The Oberon backend is used by default.
   The Mbed TLS backend uses Mbed TLS crypto APIs that are now considered legacy APIs.
 * :kconfig:option:`CONFIG_BT_FAST_PAIR_PN` - The option enables the `Fast Pair Personalized Name extension`_.
-  This option is enabled by default unless the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN` is enabled.
+  It is enabled by default unless the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN` Kconfig option is enabled.
   This is done to align default configuration with `Fast Pair Device Feature Requirements for Locator Tags`_ documentation.
 
   * :kconfig:option:`CONFIG_BT_FAST_PAIR_STORAGE_PN_LEN_MAX` - The option specifies the maximum length of a stored Fast Pair Personalized Name.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -405,7 +405,13 @@ Binary libraries
 Bluetooth libraries and services
 --------------------------------
 
-|no_changes_yet_note|
+* :ref:`bt_fast_pair_readme` library:
+
+  * Added the :kconfig:option:`CONFIG_BT_FAST_PAIR_SUBSEQUENT_PAIRING` Kconfig option allowing the user to control the support for the Fast Pair subsequent pairing feature.
+
+* :ref:`bt_le_adv_prov_readme`:
+
+  * Updated the :kconfig:option:`CONFIG_BT_ADV_PROV_FAST_PAIR_SHOW_UI_PAIRING` Kconfig option and the :c:func:`bt_le_adv_prov_fast_pair_show_ui_pairing` function to require the enabling of the :kconfig:option:`CONFIG_BT_FAST_PAIR_SUBSEQUENT_PAIRING` Kconfig option.
 
 Common Application Framework
 ----------------------------

--- a/include/bluetooth/adv_prov/fast_pair.h
+++ b/include/bluetooth/adv_prov/fast_pair.h
@@ -31,6 +31,10 @@ void bt_le_adv_prov_fast_pair_enable(bool enable);
 
 /** Show/hide UI indication in Fast Pair not discoverable advertising.
  *
+ * This API is only available when the CONFIG_BT_FAST_PAIR_SUBSEQUENT_PAIRING Kconfig
+ * option is enabled. With this Kconfig option disabled, UI indications are always
+ * hidden.
+ *
  * This configuration does not affect Fast Pair discoverable advertising.
  *
  * User shall make sure that this function is not called while Fast Pair advertising data provider

--- a/include/bluetooth/services/fast_pair/fast_pair.h
+++ b/include/bluetooth/services/fast_pair/fast_pair.h
@@ -40,7 +40,9 @@ enum bt_fast_pair_adv_mode {
 
 /** @brief Fast Pair not discoverable advertising type. Used to generate advertising packet. */
 enum bt_fast_pair_not_disc_adv_type {
-	/** Show UI indication. */
+	/** Show UI indication.
+	 *  Used only when the CONFIG_BT_FAST_PAIR_SUBSEQUENT_PAIRING is enabled.
+	 */
 	BT_FAST_PAIR_NOT_DISC_ADV_TYPE_SHOW_UI_IND,
 
 	/** Hide UI indication. */

--- a/samples/bluetooth/fast_pair/locator_tag/src/fp_adv.c
+++ b/samples/bluetooth/fast_pair/locator_tag/src/fp_adv.c
@@ -115,7 +115,6 @@ static void fp_adv_prov_configure(enum app_fp_adv_mode fp_adv_mode)
 
 	case APP_FP_ADV_MODE_NOT_DISCOVERABLE:
 		bt_le_adv_prov_fast_pair_enable(true);
-		bt_le_adv_prov_fast_pair_show_ui_pairing(false);
 		break;
 
 	default:

--- a/subsys/bluetooth/adv_prov/providers/Kconfig.fast_pair
+++ b/subsys/bluetooth/adv_prov/providers/Kconfig.fast_pair
@@ -42,9 +42,12 @@ config BT_ADV_PROV_FAST_PAIR_ADV_BUF_SIZE
 config BT_ADV_PROV_FAST_PAIR_SHOW_UI_PAIRING
 	bool "Show UI indication in Fast Pair not discoverable advertising"
 	default y
+	depends on BT_FAST_PAIR_SUBSEQUENT_PAIRING
 	help
 	  The UI indication should be displayed if device is ready for pairing.
 	  The provider also exposes API to show/hide UI indication in runtime.
+	  This Kconfig option is only available when the Fast Pair Subsequent
+	  Pairing feature is supported.
 
 choice BT_ADV_PROV_FAST_PAIR_BATTERY_DATA_MODE
 	prompt "Select advertising battery data mode"

--- a/subsys/bluetooth/adv_prov/providers/fast_pair.c
+++ b/subsys/bluetooth/adv_prov/providers/fast_pair.c
@@ -29,10 +29,12 @@ void bt_le_adv_prov_fast_pair_enable(bool enable)
 	enabled = enable;
 }
 
+#if CONFIG_BT_FAST_PAIR_SUBSEQUENT_PAIRING
 void bt_le_adv_prov_fast_pair_show_ui_pairing(bool enable)
 {
 	show_ui_pairing = enable;
 }
+#endif /* CONFIG_BT_FAST_PAIR_SUBSEQUENT_PAIRING */
 
 int bt_le_adv_prov_fast_pair_set_battery_mode(enum bt_fast_pair_adv_battery_mode mode)
 {

--- a/subsys/bluetooth/services/fast_pair/Kconfig.fast_pair
+++ b/subsys/bluetooth/services/fast_pair/Kconfig.fast_pair
@@ -12,6 +12,16 @@ menuconfig BT_FAST_PAIR
 
 if BT_FAST_PAIR
 
+config BT_FAST_PAIR_SUBSEQUENT_PAIRING
+	bool "Fast Pair subsequent pairing [EXPERIMENTAL]"
+	default y if !BT_FAST_PAIR_FMDN
+	select EXPERIMENTAL
+	help
+	  Enable support for the subsequent pairing feature. Subsequent pairing
+	  refers to the procedure between a Fast Pair Provider, initially paired
+	  with your Google account, and another Fast Pair Seeker logged into the
+	  same account.
+
 config BT_FAST_PAIR_REQ_PAIRING
 	bool "Require Bluetooth Pairing during Fast Pair Procedure"
 	default y

--- a/subsys/bluetooth/services/fast_pair/fp_gatt_service.c
+++ b/subsys/bluetooth/services/fast_pair/fp_gatt_service.c
@@ -542,6 +542,11 @@ static ssize_t write_key_based_pairing(struct bt_conn *conn,
 	if (net_buf_simple_max_len(&gatt_write) == FP_CRYPTO_ECDH_PUBLIC_KEY_LEN) {
 		keygen_params.public_key = net_buf_simple_pull_mem(&gatt_write,
 								   FP_CRYPTO_ECDH_PUBLIC_KEY_LEN);
+	} else if (!IS_ENABLED(CONFIG_BT_FAST_PAIR_SUBSEQUENT_PAIRING)) {
+		LOG_WRN("This operation requires support for the subsequent pairing feature."
+			"Enable the CONFIG_BT_FAST_PAIR_SUBSEQUENT_PAIRING Kconfig to support it");
+		res = BT_GATT_ERR(BT_ATT_ERR_NOT_SUPPORTED);
+		goto finish;
 	} else {
 		keygen_params.public_key = NULL;
 	}

--- a/subsys/bluetooth/services/fast_pair/fp_keys.c
+++ b/subsys/bluetooth/services/fast_pair/fp_keys.c
@@ -310,6 +310,11 @@ int fp_keys_generate_key(const struct bt_conn *conn, struct fp_keys_keygen_param
 		/* Update state to ensure that key could be used for decryption. */
 		proc->state = FP_STATE_USE_TEMP_ACCOUNT_KEY;
 
+		/* Encryption/decryption key should not be generated from the Account Key
+		 * if the subsequent pairing feature is not enabled in Kconfig.
+		 */
+		__ASSERT_NO_MSG(IS_ENABLED(CONFIG_BT_FAST_PAIR_SUBSEQUENT_PAIRING));
+
 		err = key_gen_account_key(conn, keygen_params);
 	}
 


### PR DESCRIPTION
Added a new Kconfig option for the Fast Pair Subsequent Pairing feature. As a result, this previously supported feature is now configurable and can be disabled for the locator tag use case, which does not support subsequent pairing.

Aligned the Fast Pair Advertising Provider with the new Kconfig option for the Fast Pair service, which controls the Subsequent Pairing feature.

Removed the unavailable API call of the Fast Pair Advertising Provider from the Fast Pair Locator Tag sample.

Ref: NCSDK-27955