### PR TITLE
[NCSDK-28174] docker: Install JLink in sdk-nrf-toolchain image

### DIFF
--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:22.04
 ARG VERSION
 ENV HOME=/opt
 RUN apt-get update && apt-get install -y wget ca-certificates qemu-system-arm libffi7 git \
+    libxcb-render-util0 libxcb-shape0 libxcb-icccm4  libxcb-keysyms1 libxcb-image0 libxkbcommon-x11-0 libsm6 libice6 udev \
     && rm -rf /var/lib/apt/lists/*
 RUN wget https://developer.nordicsemi.com/.pc-tools/nrfutil/x64-linux/nrfutil -q -O /usr/local/bin/nrfutil  \
     && chmod +x /usr/local/bin/nrfutil \
@@ -12,19 +13,25 @@ RUN nrfutil toolchain-manager install --toolchain-bundle-id $VERSION \
     && nrfutil toolchain-manager env --as-script > /opt/toolchain-env.sh \
     && rm -rf /opt/ncs/downloads
 
+# Prepare JLink to be installed when user accepts license agreement
+COPY --chmod=0555 jlink/ /jlink
+RUN wget --post-data="accept_license_agreement=accepted&submit=Download+software" -O /jlink/JLink_Linux.deb \
+    https://www.segger.com/downloads/jlink/JLink_Linux_V794e_x86_64.deb
+
+# Add interactive-setup.sh which is called at the beginning of bash session, only if session is interactive
+# interactive-setup.sh is saved as bashrc file in root's home folder (/opt)
+COPY --chmod=0555 interactive-setup.sh /opt/.bashrc
+
+# Add non-interactive-setup.sh which is called at the beginning of bash session, even is session is non-interactive
+# It is called at the beginning of /etc/bash.bashrc, before /etc/bash.bashrc exits due to non-interactive session
+COPY non-interactive-setup.sh /opt/non-interactive-setup.sh
+ENV BASH_ENV=/opt/non-interactive-setup.sh
+
 # Link to repo (https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images)
 LABEL org.opencontainers.image.source=https://github.com/nrfconnect/sdk-nrf
 # Set metadata for an image
 LABEL org.opencontainers.image.description="This image contains toolchain for sdk-nrf."
 
-## Add entrypoint which calls toolchain-env.sh
-COPY entrypoint.sh /opt/entrypoint.sh
-ENTRYPOINT ["/opt/entrypoint.sh"]
-
-RUN cat /opt/entrypoint.sh >> /tmp.sh
-RUN cat /etc/bash.bashrc >> /tmp.sh
-RUN cat /tmp.sh > /etc/bash.bashrc
-ENV BASH_ENV=/etc/bash.bashrc
-
+ENTRYPOINT ["/bin/bash", "-c"]
 SHELL ["/bin/bash", "-c"]
 CMD ["bin/bash"]

--- a/scripts/docker/README.md
+++ b/scripts/docker/README.md
@@ -1,0 +1,103 @@
+# sdk-nrf-toolchain docker image
+
+## Content
+
+The image is based on ubuntu:22.04 docker image with additional tools:
+
+* git
+* nrfutil with following commands:
+    * toolchain-manager
+    * device
+* ncs toolchain-bundle
+* JLink (installation requires accepting SEGGER License)
+
+## Building image
+
+To build docker image you have to provide `VERSION` argument containing ID of Linux toolchain bundle you want to
+install.
+You can use [print_toolchain_checksum.sh](../print_toolchain_checksum.sh) to get ID proper for your sdk-nrf revision.
+
+```shell
+TOOLCHAIN_ID=$(../print_toolchain_checksum.sh)
+docker build --build-arg VERSION=$TOOLCHAIN_ID .
+```
+
+## Accepting JLink License
+
+To install and use JLink software you have to accept [JLink License Agreement](./jlink/license.txt).
+
+```
+By accessing and using Software and Materials provided by SEGGER as free download, you acknowledge and agree to the following Terms of Use. If you do not agree to these Terms, do not download or use any Software or Material.
+
+1) You agree that you will not use the Software or Material for any purpose that is unlawful or illegal.
+2) You agree to use the Software only in accordance with the license regulations included in the Software.
+3) You acknowledge that the Software and Material is provided by SEGGER on "as is" basis without any express or implied warranty of any kind.
+4) You confirm that you are not a person, entity or organization designated by the European Community as a terrorist, terror organization or entity pursuant to the applicable European Council Regulations.
+5) You confirm that you are not located in a prohibited or embargoed country and confirm that you will not ship, distribute, transfer and/or export our Software or Material to any prohibited or embargoed country as mentioned in any such European Union law or regulation.
+
+Further information with regard to the listed persons, entities and organizations can be obtained from the official EU website. If there is any doubt if you are on this list it is strongly recommended to review such lists or get in touch with SEGGER prior download of any Software or Material.
+
+Copyright (c) SEGGER Microcontroller GmbH
+```
+
+If container is run in interactive mode, you will be asked for accepting license on the start of container.
+
+You can also start container with `ACCEPT_JLINK_LICENSE=1` environment variable which and JLink will be installed
+without prompting.
+
+During post installation steps, JLink configures `udev` roles. That operation requires running container with
+`--privileged` flag to grant container needed permissions.
+
+## Running container
+
+Toolchain environment variables are set only in bash session. Outside bash session, these variables are not set and
+tools delivered in toolchain bundle cannot be found on path.
+`sdk-nrf-toolchain` image uses `bash` command as entrypoint. If entrypoint is not overwritten, you can start your docker
+container in both interactive and non-interactive mode.
+
+### Locally
+
+To run `sdk-nrf-toolchain` container to build and flash hexes, please run following command.
+
+```docker run -ti ghcr.io/nrfconnect/sdk-nrf-toolchain:<TAG> -v /dev:/dev --privileged -e ACCEPT_JLINK_LICENSE=1 bash```
+
+> [!TIP]
+> You can also add `-v <PATH-TO-NCS-PROJECT-ON-DOCKER-HOST>:/ncs` argument to `docker run` command to mount NCS project
+> to container.
+> In such case, you might encounter issues with repositories ownership and west project configuration. To resolve them,
+> please:
+> * Run `git config --global --add safe.directory '*'` command to mark mounted git repositories as trusted.
+> * Run `west update` to import west commands delivered in NCS project (for example `west build`)
+> * Add `--pristine` argument to `west build` command - to avoid path mismatch issues.
+
+### In CI
+
+CI systems usually run docker container in detached mode and can override default entrypoint and command.
+However, it is still possible to use `sdk-nrf-toolchain` image in pipelines.
+
+#### GitHub Actions
+
+GitHub action starts container with overwritten default entrypoint. That means you have to set `bash` as a default shell
+to load all required environment variables.
+
+If container is started with `ACCEPT_JLINK_LICENSE` env variable set to 1, JLink will be installed just before first
+bash command is executed.
+
+Example job configuration:
+
+```yaml
+jobs:
+  build-in-docker:
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/nrfconnect/sdk-nrf-toolchain:<TAG>  # steps in this job are executed inside sdk-nrf-toolchain container
+      env:
+        ACCEPT_JLINK_LICENSE: 1 # set if you want to install JLink
+    defaults:
+      run:
+        shell: bash  # It is required to set `bash` as default shell
+    steps:
+      - name: Run command in NCS toolchain environment
+        run: "west --version"  # This command is executed in bash shell `docker exec <container> bash -c west --version`)
+        # It will also install JLink if ACCEPT_JLINK_LICENSE is set to 1
+```

--- a/scripts/docker/entrypoint.sh
+++ b/scripts/docker/entrypoint.sh
@@ -1,6 +1,0 @@
-#! /bin/bash
-
-if [ -z "${ZEPHYR_SDK_INSTALL_DIR}" ]; then
-  source /opt/toolchain-env.sh
-fi
-exec "$@"

--- a/scripts/docker/interactive-setup.sh
+++ b/scripts/docker/interactive-setup.sh
@@ -1,0 +1,22 @@
+# Run this only once
+if [ ! -f /jlink/license_processed ] && [ ! -f /usr/bin/JLinkExe ] ; then
+  # Do not ask if shell is not interactive
+  if [ ! -z "$PS1" ] ; then
+    echo "To install JLink you have to accept following license"
+    printf '\n'
+    cat '/jlink/license.txt'
+    printf '\n'
+    while true; do
+      read -p "Do you accept these Terms of Use (y/n)? " yn
+      case $yn in
+          [Yy]* ) export ACCEPT_JLINK_LICENSE=1; break;;
+          [Nn]* ) export ACCEPT_JLINK_LICENSE=0; break;;
+          * ) echo "Invalid input. Please use y/n";;
+      esac
+    done
+  fi
+  if [[ "${ACCEPT_JLINK_LICENSE}" == "1" ]]; then
+    /jlink/install.sh
+  fi
+  touch /jlink/license_processed
+fi

--- a/scripts/docker/jlink/install.sh
+++ b/scripts/docker/jlink/install.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Install JLink if license was accepted and JLink does not exist
+if [ "${ACCEPT_JLINK_LICENSE}" = "1" ] ; then
+  echo "License accepted, Jlink will be installed"
+  dpkg -i /jlink/JLink_Linux.deb
+fi

--- a/scripts/docker/jlink/license.txt
+++ b/scripts/docker/jlink/license.txt
@@ -1,0 +1,11 @@
+By accessing and using Software and Materials provided by SEGGER as free download, you acknowledge and agree to the following Terms of Use. If you do not agree to these Terms, do not download or use any Software or Material.
+
+1) You agree that you will not use the Software or Material for any purpose that is unlawful or illegal.
+2) You agree to use the Software only in accordance with the license regulations included in the Software.
+3) You acknowledge that the Software and Material is provided by SEGGER on "as is" basis without any express or implied warranty of any kind.
+4) You confirm that you are not a person, entity or organization designated by the European Community as a terrorist, terror organization or entity pursuant to the applicable European Council Regulations.
+5) You confirm that you are not located in a prohibited or embargoed country and confirm that you will not ship, distribute, transfer and/or export our Software or Material to any prohibited or embargoed country as mentioned in any such European Union law or regulation.
+
+Further information with regard to the listed persons, entities and organizations can be obtained from the official EU website. If there is any doubt if you are on this list it is strongly recommended to review such lists or get in touch with SEGGER prior download of any Software or Material.
+
+Copyright (c) SEGGER Microcontroller GmbH

--- a/scripts/docker/non-interactive-setup.sh
+++ b/scripts/docker/non-interactive-setup.sh
@@ -1,0 +1,11 @@
+#! /bin/bash
+
+# Set toolchain environemnt
+if [ -z "${ZEPHYR_SDK_INSTALL_DIR}" ]; then
+  source /opt/toolchain-env.sh
+fi
+
+# Install JLink if it is not installed and license was accepted
+if [[ "${ACCEPT_JLINK_LICENSE}" == "1" ]] && [ ! -f /usr/bin/JLinkExe ] ; then
+  /jlink/install.sh
+fi


### PR DESCRIPTION
Add possibility to install JLink tools if user accepts license terms.

If you want to test image, it can be pull from Nordic Docker Registry
`docker-dtr.nordicsemi.no/jag1/public-with-nrfutil:ask_for_jlink`

You can also test publicly available docker:
`ghcr.io/nrfconnect/sdk-nrf-toolchain:pr-16290`