### PR TITLE
applications: nrf5340_audio: Add a deinitialise function

### DIFF
--- a/include/data_fifo.h
+++ b/include/data_fifo.h
@@ -43,14 +43,14 @@ struct data_fifo {
 
 #define DATA_FIFO_DEFINE(name, elements_max_in, block_size_max_in)                                 \
 	char __aligned(WB_UP(1))                                                                   \
-		_msgq_buffer_##name[(elements_max_in) * sizeof(struct data_fifo_msgq)] = { 0 };    \
+		_msgq_buffer_##name[(elements_max_in) * sizeof(struct data_fifo_msgq)] = {0};      \
 	char __aligned(WB_UP(1))                                                                   \
-		_slab_buffer_##name[(elements_max_in) * (block_size_max_in)] = { 0 };              \
-	struct data_fifo name = { .msgq_buffer = _msgq_buffer_##name,                              \
-				  .slab_buffer = _slab_buffer_##name,                              \
-				  .block_size_max = block_size_max_in,                             \
-				  .elements_max = elements_max_in,                                 \
-				  .initialized = false }
+		_slab_buffer_##name[(elements_max_in) * (block_size_max_in)] = {0};                \
+	struct data_fifo name = {.msgq_buffer = _msgq_buffer_##name,                               \
+				 .slab_buffer = _slab_buffer_##name,                               \
+				 .block_size_max = block_size_max_in,                              \
+				 .elements_max = elements_max_in,                                  \
+				 .initialized = false}
 
 /**
  * @brief Get pointer to the first vacant block in slab.
@@ -149,6 +149,18 @@ int data_fifo_num_used_get(struct data_fifo *data_fifo, uint32_t *alloced_num,
  * @return 0 if success, error otherwise.
  */
 int data_fifo_empty(struct data_fifo *data_fifo);
+
+/**
+ * @brief Deinitialize data_fifo.
+ *
+ * @note data_fifo is emptied first, so it is the user's responsibility to release any data items it
+ *       has queued. The internal slab and message buffer are not released.
+ *
+ * @param data_fifo Pointer to the data_fifo structure.
+ *
+ * @retval 0 if success, error otherwise.
+ */
+int data_fifo_uninit(struct data_fifo *data_fifo);
 
 /**
  * @brief Initialise the data_fifo.

--- a/lib/data_fifo/data_fifo.c
+++ b/lib/data_fifo/data_fifo.c
@@ -167,6 +167,22 @@ int data_fifo_empty(struct data_fifo *data_fifo)
 	return 0;
 }
 
+int data_fifo_uninit(struct data_fifo *data_fifo)
+{
+	__ASSERT_NO_MSG(data_fifo != NULL);
+	__ASSERT_NO_MSG(data_fifo->initialized);
+	int ret;
+
+	ret = data_fifo_empty(data_fifo);
+	if (ret) {
+		return ret;
+	}
+
+	data_fifo->initialized = false;
+
+	return 0;
+}
+
 int data_fifo_init(struct data_fifo *data_fifo)
 {
 	__ASSERT_NO_MSG(data_fifo != NULL);


### PR DESCRIPTION
The data FIFO module did not have a deinitialise function, so added one, with a twister test.