### PR TITLE
 DNM:Testing CI-test-all flag

### DIFF
--- a/samples/wifi/thread_coex/overlay-logging.conf
+++ b/samples/wifi/thread_coex/overlay-logging.conf
@@ -45,3 +45,4 @@ CONFIG_LOG_BACKEND_RTT=y
 # Disable UART logging backend
 # CONFIG_LOG_BACKEND_UART=n
 CONFIG_SHELL_LOG_BACKEND=n
+# Testing Twister test scope with flag CI-all-test


### PR DESCRIPTION
Dummy PR to test new behavior of CI-test-all all flag in CI_LIB It should force twister to run with full scope.