### PR TITLE
manifest: sdk-hostap: Pull CSRNG fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -114,7 +114,7 @@ manifest:
     - name: hostap
       repo-path: sdk-hostap
       path: modules/lib/hostap
-      revision: 6311fde66f87ac8c8838a2d5fcfe55a498a8682a
+      revision: 3b64b3bf9957f3b1515d58429b89589d234dcaaf
       userdata:
         ncs:
           upstream-url: https://w1.fi/cgit/hostap/


### PR DESCRIPTION
This fixes an issue in case a platform has no CSRNG drivers (e.g., nRF53 in Zephyr upstream).

Workaround for bug NCSIDB-1303.