### PR TITLE
cmake: pass root cache variables to child images

### DIFF
--- a/cmake/multi_image.cmake
+++ b/cmake/multi_image.cmake
@@ -400,6 +400,17 @@ function(add_child_image_from_source)
       WEST_PYTHON
       )
 
+    # Construct a list of cache variables that, when present in the root
+    # image, should be passed on to all child images as well.
+    list(APPEND
+      SHARED_CACHED_MULTI_IMAGE_VARIABLES
+      ARCH_ROOT
+      BOARD_ROOT
+      SOC_ROOT
+      MODULE_EXT_ROOT
+      SCA_ROOT
+    )
+
     foreach(kconfig_target ${EXTRA_KCONFIG_TARGETS})
       list(APPEND
         SHARED_MULTI_IMAGE_VARIABLES
@@ -418,6 +429,17 @@ function(add_child_image_from_source)
           APPEND
           ${preload_file}
           "set(${shared_var} \"${${shared_var}}\" CACHE INTERNAL \"NCS child image controlled\")\n"
+          )
+      endif()
+    endforeach()
+
+    list(REMOVE_DUPLICATES SHARED_CACHED_MULTI_IMAGE_VARIABLES)
+    foreach(shared_var ${SHARED_CACHED_MULTI_IMAGE_VARIABLES})
+      if(DEFINED CACHE{${shared_var}} AND NOT DEFINED ${ACI_NAME}_${shared_var})
+        file(
+          APPEND
+          ${preload_file}
+          "set(${shared_var} \"$CACHE{${shared_var}}\" CACHE INTERNAL \"NCS child image controlled\")\n"
           )
       endif()
     endforeach()


### PR DESCRIPTION
When a ROOT cache variable is set by the user in the parent image then those cache variables should be passed to child images so that the child images will use the same root folders.

Jira: NCSDK-28257