### PR TITLE
doc: migration: hwmv2: inform about board conversion script limitations

### DIFF
--- a/doc/nrf/releases_and_maturity/migration/migration_hwmv2.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_hwmv2.rst
@@ -56,6 +56,10 @@ Conversion script
 There is a `conversion script <hwmv2 conversion script_>`_ to help you in the migration process.
 It has built-in help text documenting all the parameters it takes.
 
+.. note::
+   The script may not be able to automatically convert all boards.
+   Boards based on multicore SoCs (nRF53) or with non-secure targets (nRF53/nRF91) will need manual changes.
+
 The following example shows an invocation of the script converting a hypothetical out-of-tree board ``plank`` based on the nRF52840 and having ``acme`` as vendor.
 The command must be run from the :ref:`toolchain environment <using_toolchain_environment>`.
 


### PR DESCRIPTION
The script will not automatically convert all boards, specially those using multicore or non-secure targets. Add a note warning the users about this limitation.