### PR TITLE
doc: update links to nPM PowerUP and RSSI Viewer

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -573,8 +573,9 @@
 .. _`nRF Sniffer for Bluetooth LE`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-ble-sniffer/guides/overview.html
 .. _`nRF Connect Bluetooth Low Energy`: https://docs.nordicsemi.com/bundle/nrf-connect-ble/page/index.html
 .. _`Cellular Monitor`: https://docs.nordicsemi.com/bundle/nrf-connect-cellularmonitor/page/index.html
-.. _`nPM PowerUP`: https://docs.nordicsemi.com/bundle/nan_045/page/APP/nan_045/profiling_npm_powerup.html
+.. _`nPM PowerUP`: https://docs.nordicsemi.com/bundle/nrf-connect-npm/page/index.html
 .. _`Quick Start`: https://docs.nordicsemi.com/bundle/nrf-connect-quickstart/page/index.html
+.. _`RSSI Viewer`: https://docs.nordicsemi.com/bundle/nrf-connect-rssi-viewer/page/index.html
 
 .. _`Managing credentials`: https://docs.nordicsemi.com/bundle/nrf-connect-cellularmonitor/page/managing_credentials.html
 

--- a/doc/nrf/test_and_optimize/debugging.rst
+++ b/doc/nrf/test_and_optimize/debugging.rst
@@ -162,11 +162,14 @@ The following debugging tools are most commonly used in different areas of the |
    * - `nRF Connect Bluetooth Low Energy`_
      - Configure and test Bluetooth Low Energy devices. Available from `nRF Connect for Desktop`_.
      - :ref:`ug_bt`
-   * - `Cellular Monitor`_
+   * - `nRF Connect Cellular Monitor <Cellular Monitor_>`_
      - Capture and analyze modem traces to evaluate communication and view network parameters. Available from `nRF Connect for Desktop`_.
      - :ref:`ug_lte`
    * - `nRF Connect Direct Test Mode`_
      - Perform RF PHY checks of Bluetooth Low Energy devices using a GUI for the Bluetooth-specified Direct Test Mode. Available from `nRF Connect for Desktop`_.
+     - :ref:`ug_bt`
+   * - `nRF Connect RSSI Viewer <RSSI Viewer_>`_
+     - Visualize RSSI and frequency in the 2.4-GHz band in real time. Available from `nRF Connect for Desktop`_.
      - :ref:`ug_bt`
    * - `nRF Connect Power Profiler`_
      - Measure the real-time power consumption of your designs. Available from `nRF Connect for Desktop`_.

--- a/samples/peripheral/radio_test/README.rst
+++ b/samples/peripheral/radio_test/README.rst
@@ -31,7 +31,7 @@ The sample also requires one of the following testing devices:
 
   * Another development kit with the same sample.
     See :ref:`radio_test_testing_board`.
-  * Another development kit connected to a PC with RSSI Viewer application (available in the `nRF Connect for Desktop`_).
+  * Another development kit connected to a PC with the `RSSI Viewer`_ application (available in the `nRF Connect for Desktop`_).
     See :ref:`radio_test_testing_rssi`.
 
 .. note::
@@ -235,6 +235,8 @@ After programming the sample to your development kit, complete the following ste
 Testing with another development kit
 ------------------------------------
 
+Complete the following steps:
+
 1. Connect both development kits to the computer using a USB cable.
    The kits are assigned a COM port (Windows) or ttyACM device (Linux), which is visible in the Device Manager.
 #. |connect_terminal_both_ANSI|
@@ -255,6 +257,8 @@ Testing with another development kit
 Testing with RSSI Viewer
 ------------------------
 
+Complete the following steps:
+
 1. Connect the kit to the computer using a USB cable.
    The kit is assigned a COM port (Windows) or ttyACM device (Linux), which is visible in the Device Manager.
 #. |connect_terminal_ANSI|
@@ -262,7 +266,7 @@ Testing with RSSI Viewer
 #. Set the end channel with the ``end_channel`` command to 60.
 #. Set the time on channel with the ``time_on_channel`` command to 50 ms.
 #. Set the kit in the TX sweep mode using the ``start_tx_sweep`` command.
-#. Start the RSSI Viewer application and select the kit to communicate with.
+#. Start the `RSSI Viewer`_ application and select the kit to communicate with.
 #. On the application chart, observe the TX sweep in the form of a wave that starts at 2420 MHz frequency and ends with 2480 MHz.
 
 Dependencies


### PR DESCRIPTION
Updated links pointing to the documentation for the nPM PowerUP and RSSI Viewer apps in nRF Connect for Desktop. NCD-684 and NCD-686.

----

- [x] Update https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/test_and_optimize/debugging.html#debugging_tools ?