### PR TITLE
doc: coex: Bluetooth + Coex + FEM + Coded PHY now works

### DIFF
--- a/doc/nrf/device_guides/wifi_coex.rst
+++ b/doc/nrf/device_guides/wifi_coex.rst
@@ -86,9 +86,6 @@ Supported implementations
 
 The following are the implementations supported by the MPSL-provided Bluetooth-only coexistence.
 
-.. note::
-   Do not enable Wi-Fi coexistence on the nRF5340 SoC in conjunction with Coded Phy and FEM, as this can lead to undefined behavior.
-
 .. _ug_radio_mpsl_cx_nrf700x:
 
 nRF70 Series Wi-Fi coexistence


### PR DESCRIPTION
This removes a note that is no longer valid.
The bug was fixed as part of DRGN-16013 for NCS 2.6.0.