### PR TITLE
samples: wifi: radio_test: Add BLE combo

### DIFF
--- a/samples/wifi/radio_test/sample.yaml
+++ b/samples/wifi/radio_test/sample.yaml
@@ -25,6 +25,14 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
+    tags: ci_build sysbuild
+  sample.nrf5340.radio_test_combo:
+    sysbuild: true
+    build_only: true
+    extra_args: SHIELD=nrf7002ek CONFIG_NRF700X_RADIO_TEST_COMBO=y
+    integration_platforms:
+      - nrf5340dk/nrf5340/cpuapp
+    platform_allow: nrf5340dk/nrf5340/cpuapp
     tags: ci_build sysbuild wifi
   sample.nrf7002_eks.radio_test:
     sysbuild: true


### PR DESCRIPTION
With sysbuild the issue NCSDK-22755 is fixed, so, add a combo build for radio test.