### PR TITLE
net: lib: nrf_cloud: allow runtime client id for coap

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -408,6 +408,12 @@ Libraries for networking
 
   * Added the function :c:func:`nrf_cloud_rest_shadow_transform_request` to request shadow data using a JSONata expression.
 
+* :ref:`lib_nrf_cloud` library:
+
+  * Added the :c:func:`nrf_cloud_client_id_runtime_set` function to set the device ID string if the :kconfig:option:`CONFIG_NRF_CLOUD_CLIENT_ID_SRC_RUNTIME` Kconfig option is enabled.
+
+  * Updated the :kconfig:option:`CONFIG_NRF_CLOUD_CLIENT_ID_SRC_RUNTIME` Kconfig option to be available with CoAP and REST.
+
 Libraries for NFC
 -----------------
 

--- a/include/net/nrf_cloud.h
+++ b/include/net/nrf_cloud.h
@@ -575,7 +575,7 @@ struct nrf_cloud_credentials_status {
 #endif
 /** @brief NMEA data */
 struct nrf_cloud_gnss_nmea {
-	/** NULL-terminated NMEA sentence. Supported types are GPGGA, GPGLL, GPRMC.
+	/** Null-terminated NMEA sentence. Supported types are GPGGA, GPGLL, GPRMC.
 	 * Max string length is NRF_MODEM_GNSS_NMEA_MAX_LEN - 1
 	 */
 	const char *sentence;
@@ -640,7 +640,7 @@ typedef void (*nrf_cloud_event_handler_t)(const struct nrf_cloud_evt *evt);
 struct nrf_cloud_init_param {
 	/** Event handler that is registered with the module. */
 	nrf_cloud_event_handler_t event_handler;
-	/** NULL-terminated MQTT client ID string.
+	/** Null-terminated MQTT client ID string.
 	 * Must not exceed NRF_CLOUD_CLIENT_ID_MAX_LEN.
 	 * Must be set if NRF_CLOUD_CLIENT_ID_SRC_RUNTIME
 	 * is enabled; otherwise, NULL.
@@ -822,13 +822,32 @@ int nrf_cloud_modem_fota_completed(const bool fota_success);
 /**
  * @brief Retrieve the current device ID.
  *
- * @param[in,out] id_buf Buffer to receive the device ID.
- * @param[in] id_len     Size of buffer (NRF_CLOUD_CLIENT_ID_MAX_LEN).
+ * @param[in,out] id_buf Buffer to receive the device ID as a null-terminated string.
+ * @param[in] id_buf_sz  Size of buffer, maximum size is NRF_CLOUD_CLIENT_ID_MAX_LEN + 1.
+ *
+ * @retval 0         If successful.
+ * @retval -EMSGSIZE The provided buffer is too small.
+ * @retval -EIO      The client ID could not be initialized.
+ * @retval -ENXIO    The Kconfig option @kconfig{CONFIG_NRF_CLOUD_CLIENT_ID_SRC_RUNTIME} is enabled
+ *                   but the runtime client ID has not been set.
+ *                   See @ref nrf_cloud_client_id_runtime_set.
+ * @return A negative value indicates an error.
+ */
+int nrf_cloud_client_id_get(char *id_buf, size_t id_buf_sz);
+
+/**
+ * @brief Set the device ID at runtime.
+ *        Requires @kconfig{CONFIG_NRF_CLOUD_CLIENT_ID_SRC_RUNTIME} to be enabled.
+ *
+ * @note This function does not perform any management of the device's connection to nRF Cloud.
+ *
+ * @param[in] client_id Null-terminated device ID string.
+ *                      Max string length is NRF_CLOUD_CLIENT_ID_MAX_LEN.
  *
  * @retval 0 If successful.
  * @return A negative value indicates an error.
  */
-int nrf_cloud_client_id_get(char *id_buf, size_t id_len);
+int nrf_cloud_client_id_runtime_set(const char *const client_id);
 
 /**
  * @brief Retrieve the current customer tenant ID.

--- a/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_client_id
+++ b/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_client_id
@@ -27,10 +27,9 @@ config NRF_CLOUD_CLIENT_ID_SRC_HW_ID
 
 config NRF_CLOUD_CLIENT_ID_SRC_RUNTIME
 	bool "Runtime value"
-	depends on NRF_CLOUD_MQTT
 	help
-		NULL-terminated client ID string must be passed to this library's
-		initialization function.
+		NULL-terminated client ID string must be set using the provided library function.
+		For MQTT, this can also be set with library initialization function.
 endchoice
 
 if NRF_CLOUD_CLIENT_ID_SRC_IMEI

--- a/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap_transport.c
+++ b/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap_transport.c
@@ -438,8 +438,8 @@ static int client_transfer(enum coap_method method,
 		strncpy(path, resource, MAX_COAP_PATH);
 		path[MAX_COAP_PATH] = '\0';
 	} else {
-		err = snprintf(path, MAX_COAP_PATH, "%s?%s", resource, query);
-		if ((err < 0) || (err >= MAX_COAP_PATH)) {
+		err = snprintf(path, sizeof(path), "%s?%s", resource, query);
+		if ((err <= 0) || (err >= sizeof(path))) {
 			LOG_ERR("Could not format string");
 			err = -ETXTBSY;
 			goto transfer_end;

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_client_id.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_client_id.h
@@ -13,11 +13,8 @@
 extern "C" {
 #endif
 
-/** @brief Gets the length of the Kconfig configured client id string. */
-size_t nrf_cloud_configured_client_id_length_get(void);
-
-/** @brief Copies the Kconfig configured client id string to the provided buffer */
-int nrf_cloud_configured_client_id_get(char * const buf, size_t buf_sz);
+/** @brief Get the pointer to the device ID string. */
+int nrf_cloud_client_id_ptr_get(const char **client_id);
 
 #ifdef __cplusplus
 }

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_jwt.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_jwt.c
@@ -11,8 +11,13 @@
 #if defined(CONFIG_MODEM_JWT)
 #include <nrf_modem_at.h>
 #endif
+#include "nrf_cloud_client_id.h"
 
-#define GET_TIME_CMD "AT%%CCLK?"
+#define GET_TIME_CMD		"AT%%CCLK?"
+/* Example CCLK response */
+#define GET_TIME_RSP_STR	"%CCLK: \"24/07/03,21:29:34-28\",1\r\nOK\r\n"
+/* Expected size of the response, plus some extra padding */
+#define GET_TIME_RSP_SZ		(sizeof(GET_TIME_RSP_STR) + 5)
 
 LOG_MODULE_REGISTER(nrf_cloud_jwt, CONFIG_NRF_CLOUD_LOG_LEVEL);
 
@@ -462,7 +467,7 @@ int nrf_cloud_jwt_generate(uint32_t time_valid_s, char *const jwt_buf, size_t jw
 	}
 
 	int err;
-	char buf[NRF_CLOUD_CLIENT_ID_MAX_LEN + 1];
+	const char *id_ptr;
 	struct jwt_data jwt = {
 		.audience = NULL,
 #if defined(CONFIG_NRF_CLOUD_COAP)
@@ -478,6 +483,8 @@ int nrf_cloud_jwt_generate(uint32_t time_valid_s, char *const jwt_buf, size_t jw
 
 #if defined(CONFIG_MODEM_JWT)
 	/* Check if modem time is valid */
+	char buf[GET_TIME_RSP_SZ];
+
 	err = nrf_modem_at_cmd(buf, sizeof(buf), GET_TIME_CMD);
 	if (err != 0) {
 		LOG_ERR("Modem does not have valid date/time, JWT not generated");
@@ -498,12 +505,12 @@ int nrf_cloud_jwt_generate(uint32_t time_valid_s, char *const jwt_buf, size_t jw
 		 */
 		jwt.subject = NULL;
 	} else {
-		err = nrf_cloud_client_id_get(buf, sizeof(buf));
+		err = nrf_cloud_client_id_ptr_get(&id_ptr);
 		if (err) {
-			LOG_ERR("Failed to obtain client id, error: %d", err);
+			LOG_ERR("Failed to obtain client ID, error: %d", err);
 			return err;
 		}
-		jwt.subject = buf;
+		jwt.subject = id_ptr;
 	}
 
 #if defined(CONFIG_NRF_CLOUD_JWT_SOURCE_CUSTOM)


### PR DESCRIPTION
Add function nrf_cloud_client_id_runtime_set.
Allow runtime client ID for CoAP and REST.

IRIS-9081