### PR TITLE
samples: cellular: nrf_cloud_rest_device_message: update logging

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -264,6 +264,11 @@ Cellular samples
 
   * Updated Wi-Fi overlays from newlibc to picolib.
 
+* :ref:`nrf_cloud_rest_device_message` sample:
+
+  * Removed the dictionary-based comments in the :file:`overlay_nrfcloud_logging.conf` file.
+    Dictionary-based logging is not available for the REST protocol at the moment.
+
 Cryptography samples
 --------------------
 

--- a/samples/cellular/nrf_cloud_rest_device_message/overlay_nrfcloud_logging.conf
+++ b/samples/cellular/nrf_cloud_rest_device_message/overlay_nrfcloud_logging.conf
@@ -14,10 +14,7 @@ CONFIG_LOG_RUNTIME_FILTERING=n
 
 CONFIG_LOG_BUFFER_SIZE=4096
 
-# Select which format to generate. Dictionary logs are compact but require
-# decoding on the server or user PC.  Text logs are verbose but immediately
-# visible in the nRF Cloud web portal.
-# CONFIG_LOG_BACKEND_NRF_CLOUD_OUTPUT_DICTIONARY=y
+# Text logs are verbose and immediately visible in the nRF Cloud web portal.
 CONFIG_LOG_BACKEND_NRF_CLOUD_OUTPUT_TEXT=y
 
 CONFIG_LOG_PROCESS_THREAD_STACK_SIZE=4096


### PR DESCRIPTION
Updated the overlay_nrfcloud_logging.conf to remove the comments for dictionary-based logging which is not available for the REST protocol.