### PR TITLE
manifest: zephyr: Add Bluetooth cherry-picks

### DIFF
--- a/subsys/bluetooth/rpc/client/bt_rpc_gap_client.c
+++ b/subsys/bluetooth/rpc/client/bt_rpc_gap_client.c
@@ -1252,17 +1252,23 @@ void bt_le_per_adv_sync_cb_register_on_remote(void)
 				&ctx, ser_rsp_decode_void, NULL);
 }
 
-void bt_le_per_adv_sync_cb_register(struct bt_le_per_adv_sync_cb *cb)
+int bt_le_per_adv_sync_cb_register(struct bt_le_per_adv_sync_cb *cb)
 {
 	bool register_on_remote;
 
 	register_on_remote = sys_slist_is_empty(&pa_sync_cbs);
+
+	if (sys_slist_find(&pa_sync_cbs, &cb->node, NULL)) {
+		return -EEXIST;
+	}
 
 	sys_slist_append(&pa_sync_cbs, &cb->node);
 
 	if (register_on_remote) {
 		bt_le_per_adv_sync_cb_register_on_remote();
 	}
+
+	return 0;
 }
 
 int bt_le_per_adv_sync_recv_enable(struct bt_le_per_adv_sync *per_adv_sync)
@@ -1752,17 +1758,23 @@ static void bt_le_scan_cb_register_on_remote(void)
 				&ctx, ser_rsp_decode_void, NULL);
 }
 
-void bt_le_scan_cb_register(struct bt_le_scan_cb *cb)
+int bt_le_scan_cb_register(struct bt_le_scan_cb *cb)
 {
 	bool register_on_remote;
 
 	register_on_remote = sys_slist_is_empty(&scan_cbs);
+
+	if (sys_slist_find(&scan_cbs, &cb->node, NULL)) {
+		return -EEXIST;
+	}
 
 	sys_slist_append(&scan_cbs, &cb->node);
 
 	if (register_on_remote) {
 		bt_le_scan_cb_register_on_remote();
 	}
+
+	return 0;
 }
 #endif /* defined(CONFIG_BT_OBSERVER) */
 

--- a/tests/subsys/bluetooth/enocean/src/main.c
+++ b/tests/subsys/bluetooth/enocean/src/main.c
@@ -45,9 +45,10 @@ static uint16_t exp_light_sensor = 0x018D;
  * we can use it for testing the module.
  */
 static struct bt_le_scan_cb *scancb;
-void bt_le_scan_cb_register(struct bt_le_scan_cb *cb)
+int bt_le_scan_cb_register(struct bt_le_scan_cb *cb)
 {
 	scancb = cb;
+	return 0;
 }
 
 int settings_save_one(const char *name, const void *value, size_t val_len)

--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 36fbc3ffc636fae0291b5d83ae6c59b8a814958d
+      revision: 00266aa3b56f75168d14892728a7525e55d6b2ee
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This PR contains a selection of cherry-picks to
support concurrent scanning and initiating.
In addition, this PR adds the following commits:

* Commits that fixes bugs related to concurrent scanning and initiating or bugfixes required to verify this feature.
* Commits that ensure the other commits can be applied without merge conflicts.
* Simple useability improvements.