### PR TITLE
samples: bluetooth: peripheral_uart: Fix RPC build docs

### DIFF
--- a/samples/bluetooth/peripheral_uart/README.rst
+++ b/samples/bluetooth/peripheral_uart/README.rst
@@ -187,7 +187,7 @@ To build the sample with a :ref:`ble_rpc` interface, use the following command:
 
 .. code-block:: console
 
-   west build samples/bluetooth/peripheral_uart -b board_name --sysbuild -S nordic-rpc-host -- -DFILE_SUFFIX=bt_rpc
+   west build samples/bluetooth/peripheral_uart -b board_name --sysbuild -S nordic-bt-rpc -- -DFILE_SUFFIX=bt_rpc
 
 Activating sample extensions
 ============================


### PR DESCRIPTION
The documentation was referring to the wrong snippet. Now it matches what is found in the sample.yaml.