### PR TITLE
Application: nrf5340_audio: Allow opening multiple files on SD card

### DIFF
--- a/applications/nrf5340_audio/src/modules/sd_card.c
+++ b/applications/nrf5340_audio/src/modules/sd_card.c
@@ -18,12 +18,9 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(sd_card, CONFIG_MODULE_SD_CARD_LOG_LEVEL);
 
-#define SD_ROOT_PATH	      "/SD:/"
+#define SD_ROOT_PATH "/SD:/"
 /* Maximum length for path support by Windows file system */
-#define PATH_MAX_LEN	      260
-#define K_SEM_OPER_TIMEOUT_MS 100
-
-K_SEM_DEFINE(m_sem_sd_oper_ongoing, 1, 1);
+#define PATH_MAX_LEN 260
 
 static const char *sd_root_path = "/SD:";
 static FATFS fat_fs;
@@ -42,14 +39,7 @@ int sd_card_list_files(char const *const path, char *buf, size_t *buf_size)
 	char abs_path_name[PATH_MAX_LEN + 1] = SD_ROOT_PATH;
 	size_t used_buf_size = 0;
 
-	ret = k_sem_take(&m_sem_sd_oper_ongoing, K_MSEC(K_SEM_OPER_TIMEOUT_MS));
-	if (ret) {
-		LOG_ERR("Sem take failed. Ret: %d", ret);
-		return ret;
-	}
-
 	if (!sd_init_success) {
-		k_sem_give(&m_sem_sd_oper_ongoing);
 		return -ENODEV;
 	}
 
@@ -59,13 +49,11 @@ int sd_card_list_files(char const *const path, char *buf, size_t *buf_size)
 		ret = fs_opendir(&dirp, sd_root_path);
 		if (ret) {
 			LOG_ERR("Open SD card root dir failed");
-			k_sem_give(&m_sem_sd_oper_ongoing);
 			return ret;
 		}
 	} else {
 		if (strlen(path) > CONFIG_FS_FATFS_MAX_LFN) {
 			LOG_ERR("Path is too long");
-			k_sem_give(&m_sem_sd_oper_ongoing);
 			return -FR_INVALID_NAME;
 		}
 
@@ -74,7 +62,6 @@ int sd_card_list_files(char const *const path, char *buf, size_t *buf_size)
 		ret = fs_opendir(&dirp, abs_path_name);
 		if (ret) {
 			LOG_ERR("Open assigned path failed");
-			k_sem_give(&m_sem_sd_oper_ongoing);
 			return ret;
 		}
 	}
@@ -82,7 +69,6 @@ int sd_card_list_files(char const *const path, char *buf, size_t *buf_size)
 	while (1) {
 		ret = fs_readdir(&dirp, &entry);
 		if (ret) {
-			k_sem_give(&m_sem_sd_oper_ongoing);
 			return ret;
 		}
 
@@ -98,7 +84,6 @@ int sd_card_list_files(char const *const path, char *buf, size_t *buf_size)
 
 			if (len >= remaining_buf_size) {
 				LOG_ERR("Failed to append to buffer, error: %d", len);
-				k_sem_give(&m_sem_sd_oper_ongoing);
 				return -EINVAL;
 			}
 
@@ -111,12 +96,10 @@ int sd_card_list_files(char const *const path, char *buf, size_t *buf_size)
 	ret = fs_closedir(&dirp);
 	if (ret) {
 		LOG_ERR("Close SD card root dir failed");
-		k_sem_give(&m_sem_sd_oper_ongoing);
 		return ret;
 	}
 
 	*buf_size = used_buf_size;
-	k_sem_give(&m_sem_sd_oper_ongoing);
 	return 0;
 }
 
@@ -126,20 +109,12 @@ int sd_card_open_write_close(char const *const filename, char const *const data,
 	struct fs_file_t f_entry;
 	char abs_path_name[PATH_MAX_LEN + 1] = SD_ROOT_PATH;
 
-	ret = k_sem_take(&m_sem_sd_oper_ongoing, K_MSEC(K_SEM_OPER_TIMEOUT_MS));
-	if (ret) {
-		LOG_ERR("Sem take failed. Ret: %d", ret);
-		return ret;
-	}
-
 	if (!sd_init_success) {
-		k_sem_give(&m_sem_sd_oper_ongoing);
 		return -ENODEV;
 	}
 
 	if (strlen(filename) > CONFIG_FS_FATFS_MAX_LFN) {
 		LOG_ERR("Filename is too long");
-		k_sem_give(&m_sem_sd_oper_ongoing);
 		return -ENAMETOOLONG;
 	}
 
@@ -149,7 +124,6 @@ int sd_card_open_write_close(char const *const filename, char const *const data,
 	ret = fs_open(&f_entry, abs_path_name, FS_O_CREATE | FS_O_WRITE | FS_O_APPEND);
 	if (ret) {
 		LOG_ERR("Create file failed");
-		k_sem_give(&m_sem_sd_oper_ongoing);
 		return ret;
 	}
 
@@ -157,14 +131,12 @@ int sd_card_open_write_close(char const *const filename, char const *const data,
 	ret = fs_seek(&f_entry, 0, FS_SEEK_END);
 	if (ret) {
 		LOG_ERR("Seek file pointer failed");
-		k_sem_give(&m_sem_sd_oper_ongoing);
 		return ret;
 	}
 
 	ret = fs_write(&f_entry, data, *size);
 	if (ret < 0) {
 		LOG_ERR("Write file failed");
-		k_sem_give(&m_sem_sd_oper_ongoing);
 		return ret;
 	}
 
@@ -173,11 +145,9 @@ int sd_card_open_write_close(char const *const filename, char const *const data,
 	ret = fs_close(&f_entry);
 	if (ret) {
 		LOG_ERR("Close file failed");
-		k_sem_give(&m_sem_sd_oper_ongoing);
 		return ret;
 	}
 
-	k_sem_give(&m_sem_sd_oper_ongoing);
 	return 0;
 }
 
@@ -187,20 +157,12 @@ int sd_card_open_read_close(char const *const filename, char *const buf, size_t 
 	struct fs_file_t f_entry;
 	char abs_path_name[PATH_MAX_LEN + 1] = SD_ROOT_PATH;
 
-	ret = k_sem_take(&m_sem_sd_oper_ongoing, K_MSEC(K_SEM_OPER_TIMEOUT_MS));
-	if (ret) {
-		LOG_ERR("Sem take failed. Ret: %d", ret);
-		return ret;
-	}
-
 	if (!sd_init_success) {
-		k_sem_give(&m_sem_sd_oper_ongoing);
 		return -ENODEV;
 	}
 
 	if (strlen(filename) > CONFIG_FS_FATFS_MAX_LFN) {
 		LOG_ERR("Filename is too long");
-		k_sem_give(&m_sem_sd_oper_ongoing);
 		return -FR_INVALID_NAME;
 	}
 
@@ -210,14 +172,12 @@ int sd_card_open_read_close(char const *const filename, char *const buf, size_t 
 	ret = fs_open(&f_entry, abs_path_name, FS_O_READ);
 	if (ret) {
 		LOG_ERR("Open file failed");
-		k_sem_give(&m_sem_sd_oper_ongoing);
 		return ret;
 	}
 
 	ret = fs_read(&f_entry, buf, *size);
 	if (ret < 0) {
 		LOG_ERR("Read file failed. Ret: %d", ret);
-		k_sem_give(&m_sem_sd_oper_ongoing);
 		return ret;
 	}
 
@@ -229,11 +189,9 @@ int sd_card_open_read_close(char const *const filename, char *const buf, size_t 
 	ret = fs_close(&f_entry);
 	if (ret) {
 		LOG_ERR("Close file failed");
-		k_sem_give(&m_sem_sd_oper_ongoing);
 		return ret;
 	}
 
-	k_sem_give(&m_sem_sd_oper_ongoing);
 	return 0;
 }
 
@@ -243,26 +201,17 @@ int sd_card_open(char const *const filename, struct fs_file_t *f_seg_read_entry)
 	char abs_path_name[PATH_MAX_LEN + 1] = SD_ROOT_PATH;
 	size_t avilable_path_space = PATH_MAX_LEN - strlen(SD_ROOT_PATH);
 
-	ret = k_sem_take(&m_sem_sd_oper_ongoing, K_MSEC(K_SEM_OPER_TIMEOUT_MS));
-	if (ret) {
-		LOG_ERR("Sem take failed. Ret: %d", ret);
-		return ret;
-	}
-
 	if (!sd_init_success) {
-		k_sem_give(&m_sem_sd_oper_ongoing);
 		return -ENODEV;
 	}
 
 	if (strlen(filename) > CONFIG_FS_FATFS_MAX_LFN) {
 		LOG_ERR("Filename is too long");
-		k_sem_give(&m_sem_sd_oper_ongoing);
 		return -ENAMETOOLONG;
 	}
 
 	if ((strlen(abs_path_name) + strlen(filename)) > PATH_MAX_LEN) {
 		LOG_ERR("Filepath is too long");
-		k_sem_give(&m_sem_sd_oper_ongoing);
 		return -EINVAL;
 	}
 
@@ -275,7 +224,6 @@ int sd_card_open(char const *const filename, struct fs_file_t *f_seg_read_entry)
 	ret = fs_open(f_seg_read_entry, abs_path_name, FS_O_READ);
 	if (ret) {
 		LOG_ERR("Open file failed: %d", ret);
-		k_sem_give(&m_sem_sd_oper_ongoing);
 		return ret;
 	}
 
@@ -286,15 +234,9 @@ int sd_card_read(char *buf, size_t *size, struct fs_file_t *f_seg_read_entry)
 {
 	int ret;
 
-	if (!(k_sem_count_get(&m_sem_sd_oper_ongoing) <= 0)) {
-		LOG_ERR("SD operation not ongoing");
-		return -EPERM;
-	}
-
 	ret = fs_read(f_seg_read_entry, buf, *size);
 	if (ret < 0) {
 		LOG_ERR("Read file failed. Ret: %d", ret);
-		k_sem_give(&m_sem_sd_oper_ongoing);
 		return ret;
 	}
 
@@ -307,19 +249,12 @@ int sd_card_close(struct fs_file_t *f_seg_read_entry)
 {
 	int ret;
 
-	if (k_sem_count_get(&m_sem_sd_oper_ongoing) != 0) {
-		LOG_ERR("SD operation not ongoing");
-		return -EPERM;
-	}
-
 	ret = fs_close(f_seg_read_entry);
 	if (ret) {
 		LOG_ERR("Close file failed: %d", ret);
-		k_sem_give(&m_sem_sd_oper_ongoing);
 		return ret;
 	}
 
-	k_sem_give(&m_sem_sd_oper_ongoing);
 	return 0;
 }
 


### PR DESCRIPTION
Remove semaphores in sd_card module so multiple files can be opened and read from at the same time. The Zephyr FS supports multiple open files, and there are no relevant limitiations of the SD card module to not allow multiple files.

OCT-3031