### PR TITLE
tests: benchmarks: multicore: idle: add harness explicit

### DIFF
--- a/tests/benchmarks/multicore/idle/testcase.yaml
+++ b/tests/benchmarks/multicore/idle/testcase.yaml
@@ -1,7 +1,6 @@
 common:
   sysbuild: true
   tags: ci_build
-  harness: console
   harness_config:
     type: multi_line
     ordered: true
@@ -12,6 +11,7 @@ common:
 
 tests:
   benchmarks.multicore.idle.nrf5340dk_cpuapp_cpunet:
+    harness: console
     platform_allow:
       - nrf5340dk/nrf5340/cpuapp
     integration_platforms:
@@ -20,6 +20,7 @@ tests:
       SB_CONF_FILE=sysbuild/nrf5340dk_nrf5340_cpunet.conf
 
   benchmarks.multicore.idle.nrf5340dk_cpuapp_cpunet_mcuboot:
+    harness: console
     platform_allow:
       - nrf5340dk/nrf5340/cpuapp
     integration_platforms:
@@ -30,6 +31,7 @@ tests:
       SB_CONF_FILE=sysbuild/nrf5340dk_nrf5340_cpunet.conf
 
   benchmarks.multicore.idle.nrf54h20dk_cpuapp_cpuppr:
+    harness: console
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
@@ -39,6 +41,7 @@ tests:
       idle_SNIPPET=nordic-ppr
 
   benchmarks.multicore.idle.nrf54h20dk_cpuapp_cpuppr_xip:
+    harness: console
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
@@ -48,6 +51,7 @@ tests:
       idle_SNIPPET=nordic-ppr-xip
 
   benchmarks.multicore.idle.nrf54h20dk_cpuapp_cpurad:
+    harness: console
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:


### PR DESCRIPTION
Common harness is appended not replaced by specific testcase. harness_config is replaced by specific testcase.