### PR TITLE
samples: matter: lock sample on nRF54l15 added

### DIFF
--- a/samples/matter/lock/sample.yaml
+++ b/samples/matter/lock/sample.yaml
@@ -83,5 +83,6 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
+    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf54l15pdk/nrf54l15/cpuapp
     tags: sysbuild matter
+      - nrf54l15pdk/nrf54l15/cpuapp

--- a/scripts/quarantine_integration.yaml
+++ b/scripts/quarantine_integration.yaml
@@ -84,6 +84,7 @@
     - sample.matter.lock.release
     - sample.matter.lock.lto
     - sample.matter.lock.smp_dfu
+    - sample.matter.lock.nus
     - sample.matter.light_bulb.memory_profiling.persistent_subscriptions
     - sample.matter.light_switch.persistent_subscriptions
     - sample.matter.light_bulb.debug


### PR DESCRIPTION
This PR adds sample.matter.lock.nus on nrf54l15 and adds it to quarantine on integration