### PR TITLE
application: serial_lte_modem: Automation of LwM2M requests

### DIFF
--- a/applications/serial_lte_modem/doc/CARRIER_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/CARRIER_AT_commands.rst
@@ -31,27 +31,27 @@ These may be the following:
 
 * ``#XCARRIEREVT: 1,<status>``
 
-  Request to set the modem to full functional mode.
+  Request to use the ``AT+CFUN=1`` AT command to set the modem to full functional mode.
   ``<status>`` returns two possible values:
 
-  * ``0`` - Request handled successfully.
-  * ``-1`` - Request handling was deferred and must be performed by the application at its earliest convenience.
+  * ``0`` - Request handling is fulfilled automatically.
+  * ``-1`` - Request handling is deferred and must be fulfilled by the application at its earliest convenience.
 
 * ``#XCARRIEREVT: 2,<status>``
 
-  Request to set the modem to flight functional mode.
+  Request to use the ``AT+CFUN=4`` AT command to set the modem to flight functional mode.
   ``<status>`` returns two possible values:
 
-  * ``0`` - Request handled successfully.
-  * ``-1`` - Request handling was deferred and must be performed by the application at its earliest convenience.
+  * ``0`` - Request handling is fulfilled automatically.
+  * ``-1`` - Request handling is deferred and must be fulfilled by the application at its earliest convenience.
 
 * ``#XCARRIEREVT: 3,<status>``
 
-  Request to set the modem to minimum functional mode.
+  Request to use the ``AT+CFUN=0`` AT command to set the modem to minimum functional mode.
   ``<status>`` returns two possible values:
 
-  * ``0`` - Request handled successfully.
-  * ``-1`` - Request handling was deferred and must be performed by the application at its earliest convenience.
+  * ``0`` - Request handling is fulfilled automatically.
+  * ``-1`` - Request handling is deferred and must be fulfilled by the application at its earliest convenience.
 
 * ``#XCARRIEREVT: 4,0``
 
@@ -94,12 +94,12 @@ These may be the following:
 
 * ``#XCARRIEREVT: 10,<status>``
 
-  Request to perform an application reboot.
+  Request to perform an application reboot, for example using the ``AT#XRESET`` AT command.
 
   ``<status>`` returns two possible values:
 
-  * ``0`` - Request handled successfully.
-  * ``-1`` - Request handling was deferred and must be performed by the application at its earliest convenience.
+  * ``0`` - Request handling is fulfilled automatically.
+  * ``-1`` - Request handling is deferred and must be fulfilled by the application at its earliest convenience.
 
 * ``#XCARRIEREVT: 11,0``
 

--- a/applications/serial_lte_modem/src/lwm2m_carrier/Kconfig
+++ b/applications/serial_lte_modem/src/lwm2m_carrier/Kconfig
@@ -25,4 +25,13 @@ config SLM_CARRIER_AUTO_STARTUP
 	  Enable automatic startup of the library on device boot. If this configuration is
 	  disabled, automatic startup is controlled through a dedicated AT command.
 
+config SLM_CARRIER_AUTO_CONTROL
+	bool "Automatic handling of LwM2M requests"
+	depends on SLM_AUTO_CONNECT
+	default y
+	help
+	  Enable automatic power off, reboot, link up or link down when requested by the LwM2M
+	  stack. If this is disabled, the host MCU must perform these operations via AT commands
+	  when requested.
+
 endif # SLM_CARRIER


### PR DESCRIPTION
 Add `CONFIG_SLM_CARRIER_AUTO_CONTROL` to control automatical handling of below requests from LwM2M in SLM, instead of by host MCU:
 - Link down/up
 - Power off modem
 - Reboot

By default this CONFIG is enabled.

JIRA-ticket: NCSDK-28267
JIRA-ticket: NCSDK-28431