### PR TITLE
sysbuild: Add TF-M MCUboot option to use all nRF5340 RAM

### DIFF
--- a/doc/nrf/releases_and_maturity/migration/migration_sysbuild.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_sysbuild.rst
@@ -161,6 +161,8 @@ The following Kconfig options are available:
 +---------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------+
 |               ``SB_CONFIG_SECURE_BOOT_MCUBOOT_VERSION``                   | MCUboot version string to use when creating MCUboot update package for application secure boot mode                      |
 +---------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------+
+|               ``SB_CONFIG_MCUBOOT_USE_ALL_AVAILABLE_RAM``                 | Use all available RAM when building TF-M for nRF5340 (see Kconfig text for security implication details)                 |
++---------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------+
 
 Support for unsigned images and image encryption has been added.
 These options generate the respective output files for the main application build.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -38,7 +38,10 @@ IDE and tool support
 Build and configuration system
 ==============================
 
-|no_changes_yet_note|
+* Added the ``SB_CONFIG_MCUBOOT_USE_ALL_AVAILABLE_RAM`` sysbuild Kconfig option to system to allow utilizing all available RAM when using TF-M on an nRF5340 device.
+
+  .. note::
+     This has security implications and may allow secrets to be leaked to the non-secure application in RAM.
 
 Working with nRF91 Series
 =========================

--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -155,6 +155,18 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
       # Make mcuboot a build only target as the main application will flash this from the
       # merged hex file
       set_target_properties(mcuboot PROPERTIES BUILD_ONLY true)
+
+      if(DEFINED board_qualifiers_secure)
+        # Apply configuration for MCUboot using all available RAM or not
+        if(SB_CONFIG_MCUBOOT_USE_ALL_AVAILABLE_RAM)
+          set_config_bool(${DEFAULT_IMAGE} CONFIG_MCUBOOT_USE_ALL_AVAILABLE_RAM y)
+          set_config_bool(mcuboot CONFIG_MCUBOOT_USE_ALL_AVAILABLE_RAM y)
+          set_config_bool(mcuboot CONFIG_MCUBOOT_NRF_CLEANUP_NONSECURE_RAM y)
+        else()
+          set_config_bool(${DEFAULT_IMAGE} CONFIG_MCUBOOT_USE_ALL_AVAILABLE_RAM n)
+          set_config_bool(mcuboot CONFIG_MCUBOOT_USE_ALL_AVAILABLE_RAM n)
+        endif()
+      endif()
     endif()
 
     set_property(TARGET mcuboot APPEND_STRING PROPERTY CONFIG "CONFIG_UPDATEABLE_IMAGE_NUMBER=${SB_CONFIG_MCUBOOT_UPDATEABLE_IMAGES}\n")

--- a/sysbuild/Kconfig.mcuboot
+++ b/sysbuild/Kconfig.mcuboot
@@ -158,4 +158,12 @@ endchoice
 
 endif
 
+config MCUBOOT_USE_ALL_AVAILABLE_RAM
+	bool "Allow MCUboot to use all available RAM (security implications)"
+	depends on BOARD_IS_NON_SECURE
+	help
+	  By default MCUboot uses only the secure RAM partition. Enabling this
+	  may allow secrets to be leaked to non-secure through the non-secure
+	  RAM partition.
+
 endmenu

--- a/sysbuild/Kconfig.sysbuild
+++ b/sysbuild/Kconfig.sysbuild
@@ -58,6 +58,14 @@ config BUILD_OUTPUT_HEX
 	  The name of this file can be customized with CONFIG_KERNEL_BIN_NAME.
 	  This will be applied to all target images.
 
+# TODO: NCSDK-28330
+# This check will fail for variants
+BOARD_NS_QUALIFIER_CHECK := $(substring,$(BOARD_QUALIFIERS),-3)
+
+config BOARD_IS_NON_SECURE
+	bool
+	default y if "$(BOARD_NS_QUALIFIER_CHECK)" = "/ns"
+
 rsource "Kconfig.appcore"
 rsource "Kconfig.netcore"
 rsource "Kconfig.pprcore"

--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: e16bd76f8752ef7a77a691158019510926b53057
+      revision: 494802df911947a96e793720d865502d79c91fb2
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Adds a Kconfig option to sysbuild that will allow using all available RAM on the nRF5340 when using TF-M, will automatically select the clean up Kconfig option in MCUboot

NCSDK-28329


Note: sub-optimal solution, needs an upstream enhancement to allow sysbuild to know if it is targeting a TF-M non-secure board