### PR TITLE
bluetooth: rpc: rpc clean up and optimization

### DIFF
--- a/subsys/bluetooth/rpc/client/bt_rpc_conn_client.c
+++ b/subsys/bluetooth/rpc/client/bt_rpc_conn_client.c
@@ -253,7 +253,7 @@ uint8_t bt_conn_index(const struct bt_conn *conn)
 }
 
 #if defined(CONFIG_BT_USER_PHY_UPDATE)
-void bt_conn_le_phy_info_dec(struct nrf_rpc_cbor_ctx *ctx, struct bt_conn_le_phy_info *data)
+static void bt_conn_le_phy_info_dec(struct nrf_rpc_cbor_ctx *ctx, struct bt_conn_le_phy_info *data)
 {
 	data->tx_phy = ser_decode_uint(ctx);
 	data->rx_phy = ser_decode_uint(ctx);
@@ -261,8 +261,8 @@ void bt_conn_le_phy_info_dec(struct nrf_rpc_cbor_ctx *ctx, struct bt_conn_le_phy
 #endif /* defined(CONFIG_BT_USER_PHY_UPDATE) */
 
 #if defined(CONFIG_BT_USER_DATA_LEN_UPDATE)
-void bt_conn_le_data_len_info_dec(struct nrf_rpc_cbor_ctx *ctx,
-				  struct bt_conn_le_data_len_info *data)
+static void bt_conn_le_data_len_info_dec(struct nrf_rpc_cbor_ctx *ctx,
+					 struct bt_conn_le_data_len_info *data)
 {
 	data->tx_max_len = ser_decode_uint(ctx);
 	data->tx_max_time = ser_decode_uint(ctx);
@@ -271,8 +271,8 @@ void bt_conn_le_data_len_info_dec(struct nrf_rpc_cbor_ctx *ctx,
 }
 #endif /* defined(CONFIG_BT_USER_DATA_LEN_UPDATE) */
 
-void bt_conn_info_dec(struct nrf_rpc_cbor_ctx *ctx, struct bt_conn *conn,
-		      struct bt_conn_info *info)
+static void bt_conn_info_dec(struct nrf_rpc_cbor_ctx *ctx, struct bt_conn *conn,
+			     struct bt_conn_info *info)
 {
 	info->type = ser_decode_uint(ctx);
 	info->role = ser_decode_uint(ctx);
@@ -355,8 +355,8 @@ int bt_conn_get_info(const struct bt_conn *conn, struct bt_conn_info *info)
 	return result.result;
 }
 
-void bt_conn_remote_info_dec(struct nrf_rpc_cbor_ctx *ctx, struct bt_conn *conn,
-			     struct bt_conn_remote_info *remote_info)
+static void bt_conn_remote_info_dec(struct nrf_rpc_cbor_ctx *ctx, struct bt_conn *conn,
+				    struct bt_conn_remote_info *remote_info)
 {
 	remote_info->type = ser_decode_uint(ctx);
 	remote_info->version = ser_decode_uint(ctx);
@@ -365,8 +365,8 @@ void bt_conn_remote_info_dec(struct nrf_rpc_cbor_ctx *ctx, struct bt_conn *conn,
 
 	if (remote_info->type == BT_CONN_TYPE_LE && conn != NULL) {
 		LOCK_CONN_INFO();
-		remote_info->le.features = ser_decode_buffer(ctx, &conn->features,
-							     sizeof(conn->features));
+		remote_info->le.features =
+			ser_decode_buffer(ctx, &conn->features, sizeof(conn->features));
 		UNLOCK_CONN_INFO();
 	} else {
 		/* non-LE connection types are not supported. */
@@ -412,7 +412,8 @@ int bt_conn_get_remote_info(struct bt_conn *conn,
 	return result.result;
 }
 
-void bt_le_conn_param_enc(struct nrf_rpc_cbor_ctx *encoder, const struct bt_le_conn_param *data)
+static void bt_le_conn_param_enc(struct nrf_rpc_cbor_ctx *encoder,
+				 const struct bt_le_conn_param *data)
 {
 	ser_encode_uint(encoder, data->interval_min);
 	ser_encode_uint(encoder, data->interval_max);
@@ -420,7 +421,7 @@ void bt_le_conn_param_enc(struct nrf_rpc_cbor_ctx *encoder, const struct bt_le_c
 	ser_encode_uint(encoder, data->timeout);
 }
 
-void bt_le_conn_param_dec(struct nrf_rpc_cbor_ctx *ctx, struct bt_le_conn_param *data)
+static void bt_le_conn_param_dec(struct nrf_rpc_cbor_ctx *ctx, struct bt_le_conn_param *data)
 {
 	data->interval_min = ser_decode_uint(ctx);
 	data->interval_max = ser_decode_uint(ctx);
@@ -447,8 +448,8 @@ int bt_conn_le_param_update(struct bt_conn *conn,
 }
 
 #if defined(CONFIG_BT_USER_DATA_LEN_UPDATE)
-void bt_conn_le_data_len_param_enc(struct nrf_rpc_cbor_ctx *encoder,
-				   const struct bt_conn_le_data_len_param *data)
+static void bt_conn_le_data_len_param_enc(struct nrf_rpc_cbor_ctx *encoder,
+					  const struct bt_conn_le_data_len_param *data)
 {
 	ser_encode_uint(encoder, data->tx_max_len);
 	ser_encode_uint(encoder, data->tx_max_time);
@@ -474,8 +475,8 @@ int bt_conn_le_data_len_update(struct bt_conn *conn,
 #endif /* defined(CONFIG_BT_USER_DATA_LEN_UPDATE) */
 
 #if defined(CONFIG_BT_USER_PHY_UPDATE)
-void bt_conn_le_phy_param_enc(struct nrf_rpc_cbor_ctx *encoder,
-	const struct bt_conn_le_phy_param *data)
+static void bt_conn_le_phy_param_enc(struct nrf_rpc_cbor_ctx *encoder,
+				     const struct bt_conn_le_phy_param *data)
 {
 	ser_encode_uint(encoder, data->options);
 	ser_encode_uint(encoder, data->pref_tx_phy);
@@ -520,8 +521,8 @@ int bt_conn_disconnect(struct bt_conn *conn, uint8_t reason)
 }
 
 #if defined(CONFIG_BT_CENTRAL)
-void bt_conn_le_create_param_enc(struct nrf_rpc_cbor_ctx *encoder,
-				 const struct bt_conn_le_create_param *data)
+static void bt_conn_le_create_param_enc(struct nrf_rpc_cbor_ctx *encoder,
+					const struct bt_conn_le_create_param *data)
 {
 	ser_encode_uint(encoder, data->options);
 	ser_encode_uint(encoder, data->interval);
@@ -1239,14 +1240,14 @@ size_t bt_le_oob_sc_data_buf_size(const struct bt_le_oob_sc_data *data)
 	return buffer_size_max;
 }
 
-void bt_le_oob_sc_data_enc(struct nrf_rpc_cbor_ctx *encoder,
-	const struct bt_le_oob_sc_data *data)
+static void bt_le_oob_sc_data_enc(struct nrf_rpc_cbor_ctx *encoder,
+				  const struct bt_le_oob_sc_data *data)
 {
 	ser_encode_buffer(encoder, data->r, 16 * sizeof(uint8_t));
 	ser_encode_buffer(encoder, data->c, 16 * sizeof(uint8_t));
 }
 
-void bt_le_oob_sc_data_dec(struct nrf_rpc_cbor_ctx *ctx, struct bt_le_oob_sc_data *data)
+static void bt_le_oob_sc_data_dec(struct nrf_rpc_cbor_ctx *ctx, struct bt_le_oob_sc_data *data)
 {
 	ser_decode_buffer(ctx, data->r, 16 * sizeof(uint8_t));
 	ser_decode_buffer(ctx, data->c, 16 * sizeof(uint8_t));
@@ -1357,7 +1358,8 @@ int bt_passkey_set(unsigned int passkey)
 static const struct bt_conn_auth_cb *auth_cb;
 
 #if defined(CONFIG_BT_SMP_APP_PAIRING_ACCEPT)
-void bt_conn_pairing_feat_dec(struct nrf_rpc_cbor_ctx *ctx, struct bt_conn_pairing_feat *data)
+static void bt_conn_pairing_feat_dec(struct nrf_rpc_cbor_ctx *ctx,
+				     struct bt_conn_pairing_feat *data)
 {
 	data->io_capability = ser_decode_uint(ctx);
 	data->oob_data_flag = ser_decode_uint(ctx);
@@ -1576,7 +1578,7 @@ NRF_RPC_CBOR_CMD_DECODER(bt_rpc_grp, bt_rpc_auth_cb_pairing_confirm,
 			 BT_RPC_AUTH_CB_PAIRING_CONFIRM_RPC_CMD,
 			 bt_rpc_auth_cb_pairing_confirm_rpc_handler, NULL);
 
-int bt_conn_auth_cb_register_on_remote(uint16_t flags)
+static int bt_conn_auth_cb_register_on_remote(uint16_t flags)
 {
 	struct nrf_rpc_cbor_ctx ctx;
 	int result;
@@ -1586,8 +1588,8 @@ int bt_conn_auth_cb_register_on_remote(uint16_t flags)
 
 	ser_encode_uint(&ctx, flags);
 
-	nrf_rpc_cbor_cmd_no_err(&bt_rpc_grp, BT_CONN_AUTH_CB_REGISTER_ON_REMOTE_RPC_CMD,
-				&ctx, ser_rsp_decode_i32, &result);
+	nrf_rpc_cbor_cmd_no_err(&bt_rpc_grp, BT_CONN_AUTH_CB_REGISTER_ON_REMOTE_RPC_CMD, &ctx,
+				ser_rsp_decode_i32, &result);
 
 	return result;
 }
@@ -1622,8 +1624,9 @@ int bt_conn_auth_cb_register(const struct bt_conn_auth_cb *cb)
 
 sys_slist_t bt_auth_info_cbs = SYS_SLIST_STATIC_INIT(&bt_auth_info_cbs);
 
-void bt_rpc_auth_info_cb_bond_deleted_rpc_handler(const struct nrf_rpc_group *group,
-						  struct nrf_rpc_cbor_ctx *ctx, void *handler_data)
+static void bt_rpc_auth_info_cb_bond_deleted_rpc_handler(const struct nrf_rpc_group *group,
+							 struct nrf_rpc_cbor_ctx *ctx,
+							 void *handler_data)
 {
 	uint8_t id;
 	bt_addr_le_t peer_data;
@@ -1717,7 +1720,7 @@ NRF_RPC_CBOR_CMD_DECODER(bt_rpc_grp, bt_rpc_auth_info_cb_pairing_failed,
 			 BT_RPC_AUTH_INFO_CB_PAIRING_FAILED_RPC_CMD,
 			 bt_rpc_auth_info_cb_pairing_failed_rpc_handler, NULL);
 
-int bt_conn_auth_info_cb_register_on_remote(uint16_t flags)
+static int bt_conn_auth_info_cb_register_on_remote(uint16_t flags)
 {
 	struct nrf_rpc_cbor_ctx ctx;
 	int result;
@@ -1727,8 +1730,8 @@ int bt_conn_auth_info_cb_register_on_remote(uint16_t flags)
 
 	ser_encode_uint(&ctx, flags);
 
-	nrf_rpc_cbor_cmd_no_err(&bt_rpc_grp, BT_CONN_AUTH_INFO_CB_REGISTER_ON_REMOTE_RPC_CMD,
-				&ctx, ser_rsp_decode_i32, &result);
+	nrf_rpc_cbor_cmd_no_err(&bt_rpc_grp, BT_CONN_AUTH_INFO_CB_REGISTER_ON_REMOTE_RPC_CMD, &ctx,
+				ser_rsp_decode_i32, &result);
 
 	return result;
 }
@@ -1766,7 +1769,7 @@ int bt_conn_auth_info_cb_register(struct bt_conn_auth_info_cb *cb)
 	return res;
 }
 
-int bt_conn_auth_info_cb_unregister_on_remote(void)
+static int bt_conn_auth_info_cb_unregister_on_remote(void)
 {
 	struct nrf_rpc_cbor_ctx ctx;
 	int result;

--- a/subsys/bluetooth/rpc/client/bt_rpc_gap_client.c
+++ b/subsys/bluetooth/rpc/client/bt_rpc_gap_client.c
@@ -448,7 +448,6 @@ int bt_id_delete(uint8_t id)
 	return result;
 }
 
-
 size_t bt_data_buf_size(const struct bt_data *data)
 {
 	size_t buffer_size_max = 9;
@@ -467,14 +466,16 @@ size_t bt_data_sp_size(const struct bt_data *data)
 	return scratchpad_size;
 }
 
-void bt_data_enc(struct nrf_rpc_cbor_ctx *encoder, const struct bt_data *data)
+static void bt_data_enc(struct nrf_rpc_cbor_ctx *encoder, const struct bt_data *data)
 {
 	ser_encode_uint(encoder, data->type);
 	ser_encode_uint(encoder, data->data_len);
 	ser_encode_buffer(encoder, data->data, sizeof(uint8_t) * data->data_len);
 }
 
-void bt_le_scan_param_enc(struct nrf_rpc_cbor_ctx *encoder, const struct bt_le_scan_param *data)
+#if defined(CONFIG_BT_OBSERVER)
+static void bt_le_scan_param_enc(struct nrf_rpc_cbor_ctx *encoder,
+				 const struct bt_le_scan_param *data)
 {
 	ser_encode_uint(encoder, data->type);
 	ser_encode_uint(encoder, data->options);
@@ -484,8 +485,9 @@ void bt_le_scan_param_enc(struct nrf_rpc_cbor_ctx *encoder, const struct bt_le_s
 	ser_encode_uint(encoder, data->interval_coded);
 	ser_encode_uint(encoder, data->window_coded);
 }
+#endif /* defined(CONFIG_BT_OBSERVER) */
 
-void net_buf_simple_dec(struct ser_scratchpad *scratchpad, struct net_buf_simple *data)
+static void net_buf_simple_dec(struct ser_scratchpad *scratchpad, struct net_buf_simple *data)
 {
 	size_t len;
 
@@ -494,7 +496,6 @@ void net_buf_simple_dec(struct ser_scratchpad *scratchpad, struct net_buf_simple
 	data->size = data->len;
 	data->__buf = data->data;
 }
-
 
 static void bt_le_scan_cb_t_callback_rpc_handler(const struct nrf_rpc_group *group,
 						 struct nrf_rpc_cbor_ctx *ctx, void *handler_data)
@@ -531,7 +532,7 @@ decoding_error:
 NRF_RPC_CBOR_CMD_DECODER(bt_rpc_grp, bt_le_scan_cb_t_callback, BT_LE_SCAN_CB_T_CALLBACK_RPC_CMD,
 			 bt_le_scan_cb_t_callback_rpc_handler, NULL);
 
-size_t bt_le_adv_param_sp_size(const struct bt_le_adv_param *data)
+static size_t bt_le_adv_param_sp_size(const struct bt_le_adv_param *data)
 {
 	size_t scratchpad_size = 0;
 
@@ -540,7 +541,7 @@ size_t bt_le_adv_param_sp_size(const struct bt_le_adv_param *data)
 	return scratchpad_size;
 }
 
-size_t bt_le_adv_param_buf_size(const struct bt_le_adv_param *data)
+static size_t bt_le_adv_param_buf_size(const struct bt_le_adv_param *data)
 {
 	size_t buffer_size_max = 22;
 
@@ -549,7 +550,8 @@ size_t bt_le_adv_param_buf_size(const struct bt_le_adv_param *data)
 	return buffer_size_max;
 }
 
-void bt_le_adv_param_enc(struct nrf_rpc_cbor_ctx *encoder, const struct bt_le_adv_param *data)
+static void bt_le_adv_param_enc(struct nrf_rpc_cbor_ctx *encoder,
+				const struct bt_le_adv_param *data)
 {
 	ser_encode_uint(encoder, data->id);
 	ser_encode_uint(encoder, data->sid);
@@ -661,7 +663,7 @@ int bt_le_adv_stop(void)
 	return result;
 }
 
-void bt_le_oob_dec(struct nrf_rpc_cbor_ctx *ctx, struct bt_le_oob *data)
+static void bt_le_oob_dec(struct nrf_rpc_cbor_ctx *ctx, struct bt_le_oob *data)
 {
 	ser_decode_buffer(ctx, &data->addr, sizeof(bt_addr_le_t));
 	ser_decode_buffer(ctx, data->le_sc_data.r, 16 * sizeof(uint8_t));
@@ -669,18 +671,17 @@ void bt_le_oob_dec(struct nrf_rpc_cbor_ctx *ctx, struct bt_le_oob *data)
 }
 
 #if defined(CONFIG_BT_EXT_ADV)
-void bt_le_ext_adv_sent_info_dec(struct nrf_rpc_cbor_ctx *ctx,
-	struct bt_le_ext_adv_sent_info *data)
+static void bt_le_ext_adv_sent_info_dec(struct nrf_rpc_cbor_ctx *ctx,
+					struct bt_le_ext_adv_sent_info *data)
 {
 	data->num_sent = ser_decode_uint(ctx);
 }
 
-void bt_le_ext_adv_scanned_info_dec(struct ser_scratchpad *scratchpad,
-				    struct bt_le_ext_adv_scanned_info *data)
+static void bt_le_ext_adv_scanned_info_dec(struct ser_scratchpad *scratchpad,
+					   struct bt_le_ext_adv_scanned_info *data)
 {
 	data->addr = ser_decode_buffer_into_scratchpad(scratchpad, NULL);
 }
-
 
 static void bt_le_ext_adv_cb_sent_callback_rpc_handler(const struct nrf_rpc_group *group,
 						       struct nrf_rpc_cbor_ctx *ctx,
@@ -712,8 +713,8 @@ NRF_RPC_CBOR_CMD_DECODER(bt_rpc_grp, bt_le_ext_adv_cb_sent_callback,
 			 bt_le_ext_adv_cb_sent_callback_rpc_handler, NULL);
 
 #if defined(CONFIG_BT_CONN)
-void bt_le_ext_adv_connected_info_dec(struct nrf_rpc_cbor_ctx *ctx,
-	struct bt_le_ext_adv_connected_info *data)
+static void bt_le_ext_adv_connected_info_dec(struct nrf_rpc_cbor_ctx *ctx,
+					     struct bt_le_ext_adv_connected_info *data)
 {
 	data->conn = bt_rpc_decode_bt_conn(ctx);
 }
@@ -782,7 +783,8 @@ NRF_RPC_CBOR_CMD_DECODER(bt_rpc_grp, bt_le_ext_adv_cb_scanned_callback,
 
 static const size_t bt_le_ext_adv_cb_buf_size = 15;
 
-void bt_le_ext_adv_cb_enc(struct nrf_rpc_cbor_ctx *encoder, const struct bt_le_ext_adv_cb *data)
+static void bt_le_ext_adv_cb_enc(struct nrf_rpc_cbor_ctx *encoder,
+				 const struct bt_le_ext_adv_cb *data)
 {
 	ser_encode_callback(encoder, data->sent);
 	ser_encode_callback(encoder, data->connected);
@@ -838,8 +840,8 @@ int bt_le_ext_adv_create(const struct bt_le_adv_param *param,
 	return result.result;
 }
 
-void bt_le_ext_adv_start_param_enc(struct nrf_rpc_cbor_ctx *encoder,
-				   const struct bt_le_ext_adv_start_param *data)
+static void bt_le_ext_adv_start_param_enc(struct nrf_rpc_cbor_ctx *encoder,
+					  const struct bt_le_ext_adv_start_param *data)
 {
 	ser_encode_uint(encoder, data->timeout);
 	ser_encode_uint(encoder, data->num_events);
@@ -863,7 +865,6 @@ int bt_le_ext_adv_start(struct bt_le_ext_adv *adv,
 	return result;
 }
 
-
 int bt_le_ext_adv_stop(struct bt_le_ext_adv *adv)
 {
 	struct nrf_rpc_cbor_ctx ctx;
@@ -879,7 +880,6 @@ int bt_le_ext_adv_stop(struct bt_le_ext_adv *adv)
 
 	return result;
 }
-
 
 int bt_le_ext_adv_set_data(struct bt_le_ext_adv *adv,
 			   const struct bt_data *ad, size_t ad_len,
@@ -979,12 +979,12 @@ uint8_t bt_le_ext_adv_get_index(struct bt_le_ext_adv *adv)
 	return result;
 }
 
-void bt_le_ext_adv_info_enc(struct nrf_rpc_cbor_ctx *encoder, const struct bt_le_ext_adv_info *data)
+static void bt_le_ext_adv_info_enc(struct nrf_rpc_cbor_ctx *encoder,
+				   const struct bt_le_ext_adv_info *data)
 {
 	ser_encode_uint(encoder, data->id);
 	ser_encode_int(encoder, data->tx_power);
 }
-
 
 int bt_le_ext_adv_get_info(const struct bt_le_ext_adv *adv,
 			   struct bt_le_ext_adv_info *info)
@@ -1040,14 +1040,13 @@ int bt_le_ext_adv_oob_get_local(struct bt_le_ext_adv *adv,
 #endif /* defined(CONFIG_BT_EXT_ADV) */
 
 #if defined(CONFIG_BT_PER_ADV)
-void bt_le_per_adv_param_enc(struct nrf_rpc_cbor_ctx *encoder,
-			     const struct bt_le_per_adv_param *data)
+static void bt_le_per_adv_param_enc(struct nrf_rpc_cbor_ctx *encoder,
+				    const struct bt_le_per_adv_param *data)
 {
 	ser_encode_uint(encoder, data->interval_min);
 	ser_encode_uint(encoder, data->interval_max);
 	ser_encode_uint(encoder, data->options);
 }
-
 
 int bt_le_per_adv_set_param(struct bt_le_ext_adv *adv,
 			    const struct bt_le_per_adv_param *param)
@@ -1241,15 +1240,15 @@ int bt_le_per_adv_sync_delete(struct bt_le_per_adv_sync *per_adv_sync)
 
 static sys_slist_t pa_sync_cbs = SYS_SLIST_STATIC_INIT(&pa_sync_cbs);
 
-void bt_le_per_adv_sync_cb_register_on_remote(void)
+static void bt_le_per_adv_sync_cb_register_on_remote(void)
 {
 	struct nrf_rpc_cbor_ctx ctx;
 	size_t buffer_size_max = 0;
 
 	NRF_RPC_CBOR_ALLOC(&bt_rpc_grp, ctx, buffer_size_max);
 
-	nrf_rpc_cbor_cmd_no_err(&bt_rpc_grp, BT_LE_PER_ADV_SYNC_CB_REGISTER_ON_REMOTE_RPC_CMD,
-				&ctx, ser_rsp_decode_void, NULL);
+	nrf_rpc_cbor_cmd_no_err(&bt_rpc_grp, BT_LE_PER_ADV_SYNC_CB_REGISTER_ON_REMOTE_RPC_CMD, &ctx,
+				ser_rsp_decode_void, NULL);
 }
 
 void bt_le_per_adv_sync_cb_register(struct bt_le_per_adv_sync_cb *cb)
@@ -1318,8 +1317,9 @@ int bt_le_per_adv_sync_transfer(const struct bt_le_per_adv_sync *per_adv_sync,
 	return result;
 }
 
-void bt_le_per_adv_sync_transfer_param_enc(struct nrf_rpc_cbor_ctx *encoder,
-					   const struct bt_le_per_adv_sync_transfer_param *data)
+static void
+bt_le_per_adv_sync_transfer_param_enc(struct nrf_rpc_cbor_ctx *encoder,
+				      const struct bt_le_per_adv_sync_transfer_param *data)
 {
 	ser_encode_uint(encoder, data->skip);
 	ser_encode_uint(encoder, data->timeout);
@@ -1414,8 +1414,8 @@ int bt_le_per_adv_list_clear(void)
 	return result;
 }
 
-void bt_le_per_adv_sync_synced_info_dec(struct ser_scratchpad *scratchpad,
-					struct bt_le_per_adv_sync_synced_info *data)
+static void bt_le_per_adv_sync_synced_info_dec(struct ser_scratchpad *scratchpad,
+					       struct bt_le_per_adv_sync_synced_info *data)
 {
 	struct nrf_rpc_cbor_ctx *ctx = scratchpad->ctx;
 
@@ -1472,8 +1472,8 @@ decoding_error:
 NRF_RPC_CBOR_CMD_DECODER(bt_rpc_grp, per_adv_sync_cb_synced, PER_ADV_SYNC_CB_SYNCED_RPC_CMD,
 			 per_adv_sync_cb_synced_rpc_handler, NULL);
 
-void bt_le_per_adv_sync_term_info_dec(struct ser_scratchpad *scratchpad,
-				      struct bt_le_per_adv_sync_term_info *data)
+static void bt_le_per_adv_sync_term_info_dec(struct ser_scratchpad *scratchpad,
+					     struct bt_le_per_adv_sync_term_info *data)
 {
 	struct nrf_rpc_cbor_ctx *ctx = scratchpad->ctx;
 
@@ -1481,8 +1481,8 @@ void bt_le_per_adv_sync_term_info_dec(struct ser_scratchpad *scratchpad,
 	data->sid = ser_decode_uint(ctx);
 }
 
-void bt_le_per_adv_sync_recv_info_dec(struct ser_scratchpad *scratchpad,
-				      struct bt_le_per_adv_sync_recv_info *data)
+static void bt_le_per_adv_sync_recv_info_dec(struct ser_scratchpad *scratchpad,
+					     struct bt_le_per_adv_sync_recv_info *data)
 {
 	struct nrf_rpc_cbor_ctx *ctx = scratchpad->ctx;
 
@@ -1493,14 +1493,14 @@ void bt_le_per_adv_sync_recv_info_dec(struct ser_scratchpad *scratchpad,
 	data->cte_type = ser_decode_uint(ctx);
 }
 
-void bt_le_per_adv_sync_state_info_dec(struct nrf_rpc_cbor_ctx *ctx,
-				       struct bt_le_per_adv_sync_state_info *data)
+static void bt_le_per_adv_sync_state_info_dec(struct nrf_rpc_cbor_ctx *ctx,
+					      struct bt_le_per_adv_sync_state_info *data)
 {
 	data->recv_enabled = ser_decode_bool(ctx);
 }
 
-void per_adv_sync_cb_term(struct bt_le_per_adv_sync *sync,
-			  const struct bt_le_per_adv_sync_term_info *info)
+static void per_adv_sync_cb_term(struct bt_le_per_adv_sync *sync,
+				 const struct bt_le_per_adv_sync_term_info *info)
 {
 	struct bt_le_per_adv_sync_cb *listener;
 
@@ -1539,9 +1539,9 @@ decoding_error:
 NRF_RPC_CBOR_CMD_DECODER(bt_rpc_grp, per_adv_sync_cb_term, PER_ADV_SYNC_CB_TERM_RPC_CMD,
 			 per_adv_sync_cb_term_rpc_handler, NULL);
 
-void per_adv_sync_cb_recv(struct bt_le_per_adv_sync *sync,
-			  const struct bt_le_per_adv_sync_recv_info *info,
-			  struct net_buf_simple *buf)
+static void per_adv_sync_cb_recv(struct bt_le_per_adv_sync *sync,
+				 const struct bt_le_per_adv_sync_recv_info *info,
+				 struct net_buf_simple *buf)
 {
 	struct net_buf_simple_state state;
 	struct bt_le_per_adv_sync_cb *listener;
@@ -1585,8 +1585,8 @@ decoding_error:
 NRF_RPC_CBOR_CMD_DECODER(bt_rpc_grp, per_adv_sync_cb_recv, PER_ADV_SYNC_CB_RECV_RPC_CMD,
 			 per_adv_sync_cb_recv_rpc_handler, NULL);
 
-void per_adv_sync_cb_state_changed(struct bt_le_per_adv_sync *sync,
-				   const struct bt_le_per_adv_sync_state_info *info)
+static void per_adv_sync_cb_state_changed(struct bt_le_per_adv_sync *sync,
+					  const struct bt_le_per_adv_sync_state_info *info)
 {
 	struct bt_le_per_adv_sync_cb *listener;
 
@@ -1659,8 +1659,8 @@ int bt_le_scan_stop(void)
 	return result;
 }
 
-void bt_le_scan_recv_info_dec(struct ser_scratchpad *scratchpad,
-			      struct bt_le_scan_recv_info *data)
+static void bt_le_scan_recv_info_dec(struct ser_scratchpad *scratchpad,
+				     struct bt_le_scan_recv_info *data)
 {
 	struct nrf_rpc_cbor_ctx *ctx = scratchpad->ctx;
 
@@ -1674,7 +1674,6 @@ void bt_le_scan_recv_info_dec(struct ser_scratchpad *scratchpad,
 	data->primary_phy = ser_decode_uint(ctx);
 	data->secondary_phy = ser_decode_uint(ctx);
 }
-
 
 static sys_slist_t scan_cbs = SYS_SLIST_STATIC_INIT(&scan_cbs);
 
@@ -1983,7 +1982,7 @@ int bt_unpair(uint8_t id, const bt_addr_le_t *addr)
 #endif /* defined(CONFIG_BT_CONN) */
 
 #if (defined(CONFIG_BT_CONN) && defined(CONFIG_BT_SMP))
-void bt_bond_info_dec(struct nrf_rpc_cbor_ctx *ctx, struct bt_bond_info *data)
+static void bt_bond_info_dec(struct nrf_rpc_cbor_ctx *ctx, struct bt_bond_info *data)
 {
 	ser_decode_buffer(ctx, &data->addr, sizeof(bt_addr_le_t));
 }

--- a/subsys/bluetooth/rpc/client/bt_rpc_gatt_client.c
+++ b/subsys/bluetooth/rpc/client/bt_rpc_gatt_client.c
@@ -1434,11 +1434,11 @@ static const size_t bt_gatt_subscribe_params_buf_size =
 	1 + BT_RPC_SIZE_OF_FIELD(struct bt_gatt_subscribe_params, value_handle) +
 	1 + BT_RPC_SIZE_OF_FIELD(struct bt_gatt_subscribe_params, ccc_handle) +
 	1 + BT_RPC_SIZE_OF_FIELD(struct bt_gatt_subscribe_params, value) +
-	/* Placeholder for the flags field */
-	2 +
 #if defined(CONFIG_BT_SMP)
-	1 + BT_RPC_SIZE_OF_FIELD(struct bt_gatt_subscribe_params, min_security);
-#endif /* defined(CONFIG_BT_SMP) */
+	1 + BT_RPC_SIZE_OF_FIELD(struct bt_gatt_subscribe_params, min_security) +
+#endif
+	/* Placeholder for the flags field */
+	2;
 
 void bt_gatt_subscribe_params_enc(struct nrf_rpc_cbor_ctx *encoder,
 				  const struct bt_gatt_subscribe_params *data)

--- a/subsys/bluetooth/rpc/client/bt_rpc_gatt_client.c
+++ b/subsys/bluetooth/rpc/client/bt_rpc_gatt_client.c
@@ -716,7 +716,7 @@ int bt_gatt_service_unregister(struct bt_gatt_service *svc)
 }
 #endif /* defined(CONFIG_BT_GATT_DYNAMIC_DB) */
 
-size_t bt_gatt_notify_params_buf_size(const struct bt_gatt_notify_params *data)
+static size_t bt_gatt_notify_params_buf_size(const struct bt_gatt_notify_params *data)
 {
 	size_t buffer_size_max = 23;
 
@@ -727,7 +727,7 @@ size_t bt_gatt_notify_params_buf_size(const struct bt_gatt_notify_params *data)
 	return buffer_size_max;
 }
 
-size_t bt_gatt_notify_params_sp_size(const struct bt_gatt_notify_params *data)
+static size_t bt_gatt_notify_params_sp_size(const struct bt_gatt_notify_params *data)
 {
 	size_t scratchpad_size = 0;
 
@@ -738,8 +738,8 @@ size_t bt_gatt_notify_params_sp_size(const struct bt_gatt_notify_params *data)
 	return scratchpad_size;
 }
 
-void bt_gatt_notify_params_enc(struct nrf_rpc_cbor_ctx *encoder,
-		const struct bt_gatt_notify_params *data)
+static void bt_gatt_notify_params_enc(struct nrf_rpc_cbor_ctx *encoder,
+				      const struct bt_gatt_notify_params *data)
 {
 	bt_rpc_encode_gatt_attr(encoder, data->attr);
 	ser_encode_uint(encoder, data->len);
@@ -799,7 +799,7 @@ int bt_gatt_notify_multiple(struct bt_conn *conn, uint16_t num_params,
 }
 #endif /* CONFIG_BT_GATT_NOTIFY_MULTIPLE */
 
-size_t bt_gatt_indicate_params_sp_size(const struct bt_gatt_indicate_params *data)
+static size_t bt_gatt_indicate_params_sp_size(const struct bt_gatt_indicate_params *data)
 {
 	size_t scratchpad_size = 0;
 
@@ -810,7 +810,7 @@ size_t bt_gatt_indicate_params_sp_size(const struct bt_gatt_indicate_params *dat
 	return scratchpad_size;
 }
 
-size_t bt_gatt_indicate_params_buf_size(const struct bt_gatt_indicate_params *data)
+static size_t bt_gatt_indicate_params_buf_size(const struct bt_gatt_indicate_params *data)
 {
 	size_t buffer_size_max = 15;
 
@@ -820,8 +820,8 @@ size_t bt_gatt_indicate_params_buf_size(const struct bt_gatt_indicate_params *da
 	return buffer_size_max;
 }
 
-void bt_gatt_indicate_params_enc(struct nrf_rpc_cbor_ctx *encoder,
-				 const struct bt_gatt_indicate_params *data)
+static void bt_gatt_indicate_params_enc(struct nrf_rpc_cbor_ctx *encoder,
+					const struct bt_gatt_indicate_params *data)
 {
 	bt_rpc_encode_gatt_attr(encoder, data->attr);
 	ser_encode_uint(encoder, data->len);
@@ -1440,8 +1440,8 @@ static const size_t bt_gatt_subscribe_params_buf_size =
 	/* Placeholder for the flags field */
 	2;
 
-void bt_gatt_subscribe_params_enc(struct nrf_rpc_cbor_ctx *encoder,
-				  const struct bt_gatt_subscribe_params *data)
+static void bt_gatt_subscribe_params_enc(struct nrf_rpc_cbor_ctx *encoder,
+					 const struct bt_gatt_subscribe_params *data)
 {
 	ser_encode_bool(encoder, data->notify != NULL);
 	ser_encode_callback(encoder, data->write);

--- a/subsys/bluetooth/rpc/host/bt_rpc_conn_host.c
+++ b/subsys/bluetooth/rpc/host/bt_rpc_conn_host.c
@@ -217,8 +217,8 @@ static const size_t bt_conn_le_phy_info_buf_size =
 	1 + BT_RPC_SIZE_OF_FIELD(struct bt_conn_le_phy_info, tx_phy) +
 	1 + BT_RPC_SIZE_OF_FIELD(struct bt_conn_le_phy_info, rx_phy);
 
-void bt_conn_le_phy_info_enc(struct nrf_rpc_cbor_ctx *encoder,
-			     const struct bt_conn_le_phy_info *data)
+static bt_conn_le_phy_info_enc(struct nrf_rpc_cbor_ctx *encoder,
+			       const struct bt_conn_le_phy_info *data)
 {
 	ser_encode_uint(encoder, data->tx_phy);
 	ser_encode_uint(encoder, data->rx_phy);
@@ -232,8 +232,8 @@ static const size_t bt_conn_le_data_len_info_buf_size =
 	1 + BT_RPC_SIZE_OF_FIELD(struct bt_conn_le_data_len_info, rx_max_len) +
 	1 + BT_RPC_SIZE_OF_FIELD(struct bt_conn_le_data_len_info, rx_max_time);
 
-void bt_conn_le_data_len_info_enc(struct nrf_rpc_cbor_ctx *encoder,
-				  const struct bt_conn_le_data_len_info *data)
+static void bt_conn_le_data_len_info_enc(struct nrf_rpc_cbor_ctx *encoder,
+					 const struct bt_conn_le_data_len_info *data)
 {
 	ser_encode_uint(encoder, data->tx_max_len);
 	ser_encode_uint(encoder, data->tx_max_time);
@@ -262,7 +262,7 @@ static const size_t bt_conn_info_buf_size =
 #endif
 	1 + BT_RPC_SIZE_OF_FIELD(struct bt_conn_info, state);
 
-void bt_conn_info_enc(struct nrf_rpc_cbor_ctx *encoder, struct bt_conn_info *info)
+static void bt_conn_info_enc(struct nrf_rpc_cbor_ctx *encoder, struct bt_conn_info *info)
 {
 	ser_encode_uint(encoder, info->type);
 	ser_encode_uint(encoder, info->role);
@@ -340,8 +340,8 @@ static const size_t bt_conn_remote_info_buf_size =
 	1 + BT_RPC_SIZE_OF_FIELD(struct bt_conn_remote_info, subversion) +
 	1 + 8 * sizeof(uint8_t);
 
-void bt_conn_remote_info_enc(struct nrf_rpc_cbor_ctx *encoder,
-	struct bt_conn_remote_info *remote_info)
+static void bt_conn_remote_info_enc(struct nrf_rpc_cbor_ctx *encoder,
+				    struct bt_conn_remote_info *remote_info)
 {
 	ser_encode_uint(encoder, remote_info->type);
 	ser_encode_uint(encoder, remote_info->version);
@@ -395,8 +395,8 @@ decoding_error:
 NRF_RPC_CBOR_CMD_DECODER(bt_rpc_grp, bt_conn_get_remote_info, BT_CONN_GET_REMOTE_INFO_RPC_CMD,
 			 bt_conn_get_remote_info_rpc_handler, NULL);
 
-void bt_le_conn_param_enc(struct nrf_rpc_cbor_ctx *encoder,
-	const struct bt_le_conn_param *data)
+static void bt_le_conn_param_enc(struct nrf_rpc_cbor_ctx *encoder,
+				 const struct bt_le_conn_param *data)
 {
 	ser_encode_uint(encoder, data->interval_min);
 	ser_encode_uint(encoder, data->interval_max);
@@ -404,8 +404,7 @@ void bt_le_conn_param_enc(struct nrf_rpc_cbor_ctx *encoder,
 	ser_encode_uint(encoder, data->timeout);
 }
 
-
-void bt_le_conn_param_dec(struct nrf_rpc_cbor_ctx *ctx, struct bt_le_conn_param *data)
+static void bt_le_conn_param_dec(struct nrf_rpc_cbor_ctx *ctx, struct bt_le_conn_param *data)
 {
 	data->interval_min = ser_decode_uint(ctx);
 	data->interval_max = ser_decode_uint(ctx);
@@ -440,8 +439,8 @@ NRF_RPC_CBOR_CMD_DECODER(bt_rpc_grp, bt_conn_le_param_update, BT_CONN_LE_PARAM_U
 			 bt_conn_le_param_update_rpc_handler, NULL);
 
 #if defined(CONFIG_BT_USER_DATA_LEN_UPDATE)
-void bt_conn_le_data_len_param_dec(struct nrf_rpc_cbor_ctx *ctx,
-				   struct bt_conn_le_data_len_param *data)
+static void bt_conn_le_data_len_param_dec(struct nrf_rpc_cbor_ctx *ctx,
+					  struct bt_conn_le_data_len_param *data)
 {
 	data->tx_max_len = ser_decode_uint(ctx);
 	data->tx_max_time = ser_decode_uint(ctx);
@@ -475,7 +474,8 @@ NRF_RPC_CBOR_CMD_DECODER(bt_rpc_grp, bt_conn_le_data_len_update, BT_CONN_LE_DATA
 #endif /* defined(CONFIG_BT_USER_DATA_LEN_UPDATE) */
 
 #if defined(CONFIG_BT_USER_PHY_UPDATE)
-void bt_conn_le_phy_param_dec(struct nrf_rpc_cbor_ctx *ctx, struct bt_conn_le_phy_param *data)
+static void bt_conn_le_phy_param_dec(struct nrf_rpc_cbor_ctx *ctx,
+				     struct bt_conn_le_phy_param *data)
 {
 	data->options = ser_decode_uint(ctx);
 	data->pref_tx_phy = ser_decode_uint(ctx);
@@ -536,7 +536,8 @@ NRF_RPC_CBOR_CMD_DECODER(bt_rpc_grp, bt_conn_disconnect, BT_CONN_DISCONNECT_RPC_
 			 bt_conn_disconnect_rpc_handler, NULL);
 
 #if defined(CONFIG_BT_CENTRAL)
-void bt_conn_le_create_param_dec(struct nrf_rpc_cbor_ctx *ctx, struct bt_conn_le_create_param *data)
+static void bt_conn_le_create_param_dec(struct nrf_rpc_cbor_ctx *ctx,
+					struct bt_conn_le_create_param *data)
 {
 	data->options = ser_decode_uint(ctx);
 	data->interval = ser_decode_uint(ctx);
@@ -1044,7 +1045,7 @@ NRF_RPC_CBOR_CMD_DECODER(bt_rpc_grp, bt_le_oob_set_legacy_tk, BT_LE_OOB_SET_LEGA
 #endif /* !defined(CONFIG_BT_SMP_SC_PAIR_ONLY) */
 
 #if !defined(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)
-size_t bt_le_oob_sc_data_buf_size(const struct bt_le_oob_sc_data *data)
+static size_t bt_le_oob_sc_data_buf_size(const struct bt_le_oob_sc_data *data)
 {
 	size_t buffer_size_max = 10;
 
@@ -1054,13 +1055,14 @@ size_t bt_le_oob_sc_data_buf_size(const struct bt_le_oob_sc_data *data)
 	return buffer_size_max;
 }
 
-void bt_le_oob_sc_data_enc(struct nrf_rpc_cbor_ctx *encoder, const struct bt_le_oob_sc_data *data)
+static void bt_le_oob_sc_data_enc(struct nrf_rpc_cbor_ctx *encoder,
+				  const struct bt_le_oob_sc_data *data)
 {
 	ser_encode_buffer(encoder, data->r, 16 * sizeof(uint8_t));
 	ser_encode_buffer(encoder, data->c, 16 * sizeof(uint8_t));
 }
 
-void bt_le_oob_sc_data_dec(struct nrf_rpc_cbor_ctx *ctx, struct bt_le_oob_sc_data *data)
+static void bt_le_oob_sc_data_dec(struct nrf_rpc_cbor_ctx *ctx, struct bt_le_oob_sc_data *data)
 {
 	ser_decode_buffer(ctx, data->r, 16 * sizeof(uint8_t));
 	ser_decode_buffer(ctx, data->c, 16 * sizeof(uint8_t));
@@ -1215,8 +1217,8 @@ static void bt_rpc_auth_cb_pairing_accept_rpc_rsp(const struct nrf_rpc_group *gr
 	res->result = (enum bt_security_err)ser_decode_uint(ctx);
 }
 
-enum bt_security_err bt_rpc_auth_cb_pairing_accept(struct bt_conn *conn,
-						   const struct bt_conn_pairing_feat *const feat)
+static enum bt_security_err
+bt_rpc_auth_cb_pairing_accept(struct bt_conn *conn, const struct bt_conn_pairing_feat *const feat)
 {
 	struct nrf_rpc_cbor_ctx ctx;
 	struct bt_rpc_auth_cb_pairing_accept_rpc_res result;
@@ -1229,14 +1231,14 @@ enum bt_security_err bt_rpc_auth_cb_pairing_accept(struct bt_conn *conn,
 	bt_rpc_encode_bt_conn(&ctx, conn);
 	bt_conn_pairing_feat_enc(&ctx, feat);
 
-	nrf_rpc_cbor_cmd_no_err(&bt_rpc_grp, BT_RPC_AUTH_CB_PAIRING_ACCEPT_RPC_CMD,
-				&ctx, bt_rpc_auth_cb_pairing_accept_rpc_rsp, &result);
+	nrf_rpc_cbor_cmd_no_err(&bt_rpc_grp, BT_RPC_AUTH_CB_PAIRING_ACCEPT_RPC_CMD, &ctx,
+				bt_rpc_auth_cb_pairing_accept_rpc_rsp, &result);
 
 	return result.result;
 }
 #endif /* CONFIG_BT_SMP_APP_PAIRING_ACCEPT */
 
-void bt_rpc_auth_cb_passkey_display(struct bt_conn *conn, unsigned int passkey)
+static void bt_rpc_auth_cb_passkey_display(struct bt_conn *conn, unsigned int passkey)
 {
 	struct nrf_rpc_cbor_ctx ctx;
 	size_t buffer_size_max = 8;
@@ -1246,11 +1248,11 @@ void bt_rpc_auth_cb_passkey_display(struct bt_conn *conn, unsigned int passkey)
 	bt_rpc_encode_bt_conn(&ctx, conn);
 	ser_encode_uint(&ctx, passkey);
 
-	nrf_rpc_cbor_cmd_no_err(&bt_rpc_grp, BT_RPC_AUTH_CB_PASSKEY_DISPLAY_RPC_CMD,
-				&ctx, ser_rsp_decode_void, NULL);
+	nrf_rpc_cbor_cmd_no_err(&bt_rpc_grp, BT_RPC_AUTH_CB_PASSKEY_DISPLAY_RPC_CMD, &ctx,
+				ser_rsp_decode_void, NULL);
 }
 
-void bt_rpc_auth_cb_passkey_entry(struct bt_conn *conn)
+static void bt_rpc_auth_cb_passkey_entry(struct bt_conn *conn)
 {
 	struct nrf_rpc_cbor_ctx ctx;
 	size_t buffer_size_max = 3;
@@ -1259,11 +1261,11 @@ void bt_rpc_auth_cb_passkey_entry(struct bt_conn *conn)
 
 	bt_rpc_encode_bt_conn(&ctx, conn);
 
-	nrf_rpc_cbor_cmd_no_err(&bt_rpc_grp, BT_RPC_AUTH_CB_PASSKEY_ENTRY_RPC_CMD,
-				&ctx, ser_rsp_decode_void, NULL);
+	nrf_rpc_cbor_cmd_no_err(&bt_rpc_grp, BT_RPC_AUTH_CB_PASSKEY_ENTRY_RPC_CMD, &ctx,
+				ser_rsp_decode_void, NULL);
 }
 
-void bt_rpc_auth_cb_passkey_confirm(struct bt_conn *conn, unsigned int passkey)
+static void bt_rpc_auth_cb_passkey_confirm(struct bt_conn *conn, unsigned int passkey)
 {
 	struct nrf_rpc_cbor_ctx ctx;
 	size_t buffer_size_max = 8;
@@ -1273,11 +1275,11 @@ void bt_rpc_auth_cb_passkey_confirm(struct bt_conn *conn, unsigned int passkey)
 	bt_rpc_encode_bt_conn(&ctx, conn);
 	ser_encode_uint(&ctx, passkey);
 
-	nrf_rpc_cbor_cmd_no_err(&bt_rpc_grp, BT_RPC_AUTH_CB_PASSKEY_CONFIRM_RPC_CMD,
-				&ctx, ser_rsp_decode_void, NULL);
+	nrf_rpc_cbor_cmd_no_err(&bt_rpc_grp, BT_RPC_AUTH_CB_PASSKEY_CONFIRM_RPC_CMD, &ctx,
+				ser_rsp_decode_void, NULL);
 }
 
-void bt_rpc_auth_cb_oob_data_request(struct bt_conn *conn, struct bt_conn_oob_info *info)
+static void bt_rpc_auth_cb_oob_data_request(struct bt_conn *conn, struct bt_conn_oob_info *info)
 {
 	struct nrf_rpc_cbor_ctx ctx;
 	size_t buffer_size_max = 6;
@@ -1289,11 +1291,11 @@ void bt_rpc_auth_cb_oob_data_request(struct bt_conn *conn, struct bt_conn_oob_in
 	bt_rpc_encode_bt_conn(&ctx, conn);
 	ser_encode_buffer(&ctx, info, sizeof(struct bt_conn_oob_info));
 
-	nrf_rpc_cbor_cmd_no_err(&bt_rpc_grp, BT_RPC_AUTH_CB_OOB_DATA_REQUEST_RPC_CMD,
-				&ctx, ser_rsp_decode_void, NULL);
+	nrf_rpc_cbor_cmd_no_err(&bt_rpc_grp, BT_RPC_AUTH_CB_OOB_DATA_REQUEST_RPC_CMD, &ctx,
+				ser_rsp_decode_void, NULL);
 }
 
-void bt_rpc_auth_cb_cancel(struct bt_conn *conn)
+static void bt_rpc_auth_cb_cancel(struct bt_conn *conn)
 {
 	struct nrf_rpc_cbor_ctx ctx;
 	size_t buffer_size_max = 3;
@@ -1302,11 +1304,11 @@ void bt_rpc_auth_cb_cancel(struct bt_conn *conn)
 
 	bt_rpc_encode_bt_conn(&ctx, conn);
 
-	nrf_rpc_cbor_cmd_no_err(&bt_rpc_grp, BT_RPC_AUTH_CB_CANCEL_RPC_CMD,
-				&ctx, ser_rsp_decode_void, NULL);
+	nrf_rpc_cbor_cmd_no_err(&bt_rpc_grp, BT_RPC_AUTH_CB_CANCEL_RPC_CMD, &ctx,
+				ser_rsp_decode_void, NULL);
 }
 
-void bt_rpc_auth_cb_pairing_confirm(struct bt_conn *conn)
+static void bt_rpc_auth_cb_pairing_confirm(struct bt_conn *conn)
 {
 	struct nrf_rpc_cbor_ctx ctx;
 	size_t buffer_size_max = 3;
@@ -1315,8 +1317,8 @@ void bt_rpc_auth_cb_pairing_confirm(struct bt_conn *conn)
 
 	bt_rpc_encode_bt_conn(&ctx, conn);
 
-	nrf_rpc_cbor_cmd_no_err(&bt_rpc_grp, BT_RPC_AUTH_CB_PAIRING_CONFIRM_RPC_CMD,
-				&ctx, ser_rsp_decode_void, NULL);
+	nrf_rpc_cbor_cmd_no_err(&bt_rpc_grp, BT_RPC_AUTH_CB_PAIRING_CONFIRM_RPC_CMD, &ctx,
+				ser_rsp_decode_void, NULL);
 }
 
 static int bt_conn_auth_cb_register_on_remote(uint16_t flags)
@@ -1372,7 +1374,7 @@ NRF_RPC_CBOR_CMD_DECODER(bt_rpc_grp, bt_conn_auth_cb_register_on_remote,
 
 static struct bt_conn_auth_info_cb remote_auth_info_cb;
 
-void bt_rpc_auth_info_cb_pairing_complete(struct bt_conn *conn, bool bonded)
+static void bt_rpc_auth_info_cb_pairing_complete(struct bt_conn *conn, bool bonded)
 {
 	struct nrf_rpc_cbor_ctx ctx;
 	size_t buffer_size_max = 4;
@@ -1382,11 +1384,11 @@ void bt_rpc_auth_info_cb_pairing_complete(struct bt_conn *conn, bool bonded)
 	bt_rpc_encode_bt_conn(&ctx, conn);
 	ser_encode_bool(&ctx, bonded);
 
-	nrf_rpc_cbor_cmd_no_err(&bt_rpc_grp, BT_RPC_AUTH_INFO_CB_PAIRING_COMPLETE_RPC_CMD,
-				&ctx, ser_rsp_decode_void, NULL);
+	nrf_rpc_cbor_cmd_no_err(&bt_rpc_grp, BT_RPC_AUTH_INFO_CB_PAIRING_COMPLETE_RPC_CMD, &ctx,
+				ser_rsp_decode_void, NULL);
 }
 
-void bt_rpc_auth_info_cb_pairing_failed(struct bt_conn *conn, enum bt_security_err reason)
+static void bt_rpc_auth_info_cb_pairing_failed(struct bt_conn *conn, enum bt_security_err reason)
 {
 	struct nrf_rpc_cbor_ctx ctx;
 	size_t buffer_size_max = 8;
@@ -1396,11 +1398,11 @@ void bt_rpc_auth_info_cb_pairing_failed(struct bt_conn *conn, enum bt_security_e
 	bt_rpc_encode_bt_conn(&ctx, conn);
 	ser_encode_uint(&ctx, (uint32_t)reason);
 
-	nrf_rpc_cbor_cmd_no_err(&bt_rpc_grp, BT_RPC_AUTH_INFO_CB_PAIRING_FAILED_RPC_CMD,
-				&ctx, ser_rsp_decode_void, NULL);
+	nrf_rpc_cbor_cmd_no_err(&bt_rpc_grp, BT_RPC_AUTH_INFO_CB_PAIRING_FAILED_RPC_CMD, &ctx,
+				ser_rsp_decode_void, NULL);
 }
 
-void bt_rpc_auth_info_cb_bond_deleted(uint8_t id, const bt_addr_le_t *peer)
+static void bt_rpc_auth_info_cb_bond_deleted(uint8_t id, const bt_addr_le_t *peer)
 {
 	struct nrf_rpc_cbor_ctx ctx;
 	size_t buffer_size_max = 3;
@@ -1412,8 +1414,8 @@ void bt_rpc_auth_info_cb_bond_deleted(uint8_t id, const bt_addr_le_t *peer)
 	ser_encode_uint(&ctx, id);
 	ser_encode_buffer(&ctx, peer, sizeof(bt_addr_le_t));
 
-	nrf_rpc_cbor_cmd_no_err(&bt_rpc_grp, BT_RPC_AUTH_INFO_CB_BOND_DELETED_RPC_CMD,
-				&ctx, ser_rsp_decode_void, NULL);
+	nrf_rpc_cbor_cmd_no_err(&bt_rpc_grp, BT_RPC_AUTH_INFO_CB_BOND_DELETED_RPC_CMD, &ctx,
+				ser_rsp_decode_void, NULL);
 }
 
 static int bt_conn_auth_info_cb_register_on_remote(uint16_t flags)


### PR DESCRIPTION
PR fixes minor bug with RPC GATT implementation without SMP. Also, `static` keyword was added to all local functions to improve compiler optimization ability. 