### PR TITLE
samples: matter: Used DFUsync module in the DFU over SMP

### DIFF
--- a/samples/matter/common/src/dfu/smp/dfu_over_smp.h
+++ b/samples/matter/common/src/dfu/smp/dfu_over_smp.h
@@ -50,6 +50,8 @@ public:
 	 */
 	void StartServer();
 
+	static void Disconnected(bt_conn *conn, uint8_t reason);
+
 private:
 	bool mIsStarted = false;
 	chip::DeviceLayer::BLEAdvertisingArbiter::Request mAdvertisingRequest = {};

--- a/west.yml
+++ b/west.yml
@@ -160,7 +160,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: fd8e621006950f56c6cb54f670872d709d95b64f
+      revision: 4d8e75cf312083c39be9523f2ff92bc8359bbf02
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
Updated Matter repository to pull the change introducing DFUSync module and use in the DFU over SMP implementation in Matter.