### PR TITLE
Bluetooth: Remove VS HCI wrappers for coex

### DIFF
--- a/include/bluetooth/hci_vs_sdc.h
+++ b/include/bluetooth/hci_vs_sdc.h
@@ -187,26 +187,6 @@ int hci_vs_sdc_event_length_set(const sdc_hci_cmd_vs_event_length_set_t *params)
 int hci_vs_sdc_periodic_adv_event_length_set(
 	const sdc_hci_cmd_vs_periodic_adv_event_length_set_t *params);
 
-/** @brief Configure Coexistence Scan Request Mode.
- *
- * For the complete API description, see sdc_hci_cmd_vs_coex_scan_mode_config().
- *
- * @param[in]  params Input parameters.
- *
- * @return 0 on success or negative error value on failure.
- */
-int hci_vs_sdc_coex_scan_mode_config(const sdc_hci_cmd_vs_coex_scan_mode_config_t *params);
-
-/** @brief Configure Coexistence Per-Role Priority.
- *
- * For the complete API description, see sdc_hci_cmd_vs_coex_priority_config().
- *
- * @param[in]  params Input parameters.
- *
- * @return 0 on success or negative error value on failure.
- */
-int hci_vs_sdc_coex_priority_config(const sdc_hci_cmd_vs_coex_priority_config_t *params);
-
 /** @brief Set peripheral latency mode.
  *
  * For the complete API description, see sdc_hci_cmd_vs_peripheral_latency_mode_set().

--- a/subsys/bluetooth/hci_vs_sdc.c
+++ b/subsys/bluetooth/hci_vs_sdc.c
@@ -181,20 +181,6 @@ int hci_vs_sdc_periodic_adv_event_length_set(
 				 sizeof(*params));
 }
 
-int hci_vs_sdc_coex_scan_mode_config(const sdc_hci_cmd_vs_coex_scan_mode_config_t *params)
-{
-	return hci_vs_cmd_no_rsp(SDC_HCI_OPCODE_CMD_VS_COEX_SCAN_MODE_CONFIG,
-				 params,
-				 sizeof(*params));
-}
-
-int hci_vs_sdc_coex_priority_config(const sdc_hci_cmd_vs_coex_priority_config_t *params)
-{
-	return hci_vs_cmd_no_rsp(SDC_HCI_OPCODE_CMD_VS_COEX_PRIORITY_CONFIG,
-				 params,
-				 sizeof(*params));
-}
-
 int hci_vs_sdc_peripheral_latency_mode_set(
 	const sdc_hci_cmd_vs_peripheral_latency_mode_set_t *params)
 {


### PR DESCRIPTION
Those were removed in pull request sdk-nrf #16323, [nrfxlib PR #1403.](https://github.com/nrfconnect/sdk-nrfxlib/pull/1403)