### PR TITLE
sdc: handle opcode for VS Set Event Start Task

### DIFF
--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -663,6 +663,7 @@ static void vs_supported_commands(sdc_hci_vs_supported_vs_commands_t *cmds)
 
 #if defined(CONFIG_BT_CTLR_SDC_EVENT_TRIGGER)
 	cmds->set_conn_event_trigger = 1;
+	cmds->set_event_start_task = 1;
 #endif
 
 #if defined(CONFIG_BT_CONN)
@@ -1648,6 +1649,8 @@ static uint8_t vs_cmd_put(uint8_t const *const cmd, uint8_t *const raw_event_out
 #if defined(CONFIG_BT_CTLR_SDC_EVENT_TRIGGER)
 	case SDC_HCI_OPCODE_CMD_VS_SET_CONN_EVENT_TRIGGER:
 		return sdc_hci_cmd_vs_set_conn_event_trigger((void *)cmd_params);
+	case SDC_HCI_OPCODE_CMD_VS_SET_EVENT_START_TASK:
+		return sdc_hci_cmd_vs_set_event_start_task((void *)cmd_params);
 #endif
 #if defined(CONFIG_BT_CONN)
 	case SDC_HCI_OPCODE_CMD_VS_GET_NEXT_CONN_EVENT_COUNTER:


### PR DESCRIPTION
Add new VS command VS Set Event Start Task to the hci driver.