### PR TITLE
samples: openthread: increase baudrate for nRF54L in RCP

### DIFF
--- a/samples/openthread/coprocessor/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
+++ b/samples/openthread/coprocessor/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
@@ -4,7 +4,7 @@
  */
 
 &uart20 {
-    current-speed = <115200>;
+    current-speed = <1000000>;
     status = "okay";
     hw-flow-control;
 };


### PR DESCRIPTION
increase the baudrate to 1000000 for nRF54L in RCP sample

test_thread: PR-1186