### PR TITLE
net: lib: nrf_cloud: allow sec tag to be set at runtime

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -423,7 +423,10 @@ Libraries for networking
 
 * :ref:`lib_nrf_cloud` library:
 
-  * Added the :c:func:`nrf_cloud_client_id_runtime_set` function to set the device ID string if the :kconfig:option:`CONFIG_NRF_CLOUD_CLIENT_ID_SRC_RUNTIME` Kconfig option is enabled.
+  * Added:
+
+    * The function :c:func:`nrf_cloud_client_id_runtime_set` to set the device ID string if the :kconfig:option:`CONFIG_NRF_CLOUD_CLIENT_ID_SRC_RUNTIME` Kconfig option is enabled.
+    * The functions :c:func:`nrf_cloud_sec_tag_set` and :c:func:`nrf_cloud_sec_tag_get` to set and get the sec tag used for nRF Cloud credentials.
 
   * Updated the :kconfig:option:`CONFIG_NRF_CLOUD_CLIENT_ID_SRC_RUNTIME` Kconfig option to be available with CoAP and REST.
 

--- a/include/net/nrf_cloud.h
+++ b/include/net/nrf_cloud.h
@@ -1039,6 +1039,27 @@ int nrf_cloud_credentials_check(struct nrf_cloud_credentials_status *const cs);
  */
 int nrf_cloud_credentials_configured_check(void);
 
+/**
+ * @brief Set the sec tag used for nRF Cloud credentials.
+ *        The default sec tag value is @kconfig{CONFIG_NRF_CLOUD_COAP_SEC_TAG} or
+ *        @kconfig{CONFIG_NRF_CLOUD_COAP_SEC_TAG} for CoAP.
+ *
+ * @note This API only needs to be called if the default configured sec tag value is no
+ *       longer applicable. This function does not perform any management of the
+ *       device's connection to nRF Cloud.
+ *
+ * @param sec_tag The sec tag.
+ *
+ */
+void nrf_cloud_sec_tag_set(const sec_tag_t sec_tag);
+
+/**
+ * @brief Get the sec tag used for nRF Cloud credentials.
+ *
+ * @return The sec tag.
+ */
+sec_tag_t nrf_cloud_sec_tag_get(void);
+
 /** @} */
 
 #ifdef __cplusplus

--- a/subsys/net/lib/nrf_cloud/CMakeLists.txt
+++ b/subsys/net/lib/nrf_cloud/CMakeLists.txt
@@ -9,7 +9,8 @@ zephyr_library_sources(
 	src/nrf_cloud_log.c
 	src/nrf_cloud_codec.c
 	src/nrf_cloud_mem.c
-	src/nrf_cloud_client_id.c)
+	src/nrf_cloud_client_id.c
+	src/nrf_cloud_sec_tag.c)
 zephyr_library_sources_ifdef(
 	CONFIG_NRF_CLOUD_ALERT
 	src/nrf_cloud_alert.c)

--- a/subsys/net/lib/nrf_cloud/Kconfig
+++ b/subsys/net/lib/nrf_cloud/Kconfig
@@ -33,6 +33,10 @@ config NRF_CLOUD_GATEWAY
 	  Enables functionality in this device to be compatible with
 	  nRF Cloud LTE gateway support.
 
+config NRF_CLOUD_SEC_TAG
+	int "Security tag to use for nRF Cloud connection"
+	default 16842753
+
 if NRF_CLOUD_MQTT || NRF_CLOUD_REST || NRF_CLOUD_PGPS || MODEM_JWT || NRF_CLOUD_COAP
 
 config NRF_CLOUD_HOST_NAME
@@ -40,10 +44,6 @@ config NRF_CLOUD_HOST_NAME
 	default "mqtt.nrfcloud.com"
 	help
 	  Used for MQTT and JITP performed with REST
-
-config NRF_CLOUD_SEC_TAG
-	int "Security tag to use for nRF Cloud connection"
-	default 16842753
 
 config NRF_CLOUD_DEVICE_STATUS_ENCODE_VOLTAGE
 	bool "Include the (battery) voltage when encoding device status"

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_credentials.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_credentials.c
@@ -71,11 +71,7 @@ static int add_cred(uint32_t sec_tag, int type, const void *cred, const size_t c
 int nrf_cloud_credentials_provision(void)
 {
 	int err = 0;
-	uint32_t sec_tag = CONFIG_NRF_CLOUD_SEC_TAG;
-
-#if defined(CONFIG_NRF_CLOUD_COAP)
-	sec_tag = CONFIG_NRF_CLOUD_COAP_SEC_TAG;
-#endif
+	const uint32_t sec_tag = nrf_cloud_sec_tag_get();
 
 	LOG_WRN("CONFIG_NRF_CLOUD_PROVISION_CERTIFICATES is not secure and should be used only for "
 		"testing purposes");
@@ -192,11 +188,7 @@ int nrf_cloud_credentials_check(struct nrf_cloud_credentials_status *const cs)
 
 	memset(cs, 0, sizeof(*cs));
 
-	cs->sec_tag = CONFIG_NRF_CLOUD_SEC_TAG;
-
-#if defined(CONFIG_NRF_CLOUD_COAP)
-	cs->sec_tag = CONFIG_NRF_CLOUD_COAP_SEC_TAG;
-#endif
+	cs->sec_tag = nrf_cloud_sec_tag_get();
 
 	ret = cred_exists(cs->sec_tag, CA_CERT, &exists);
 	if (ret < 0) {

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota.c
@@ -795,7 +795,7 @@ int nrf_cloud_fota_job_start(void)
 static int start_job(struct nrf_cloud_fota_job *const job, const bool send_evt)
 {
 	__ASSERT_NO_MSG(job != NULL);
-	static const int sec_tag = CONFIG_NRF_CLOUD_SEC_TAG;
+	static int sec_tag;
 	int ret = 0;
 
 	enum dfu_target_image_type img_type;
@@ -826,6 +826,8 @@ static int start_job(struct nrf_cloud_fota_job *const job, const bool send_evt)
 		job->error = NRF_CLOUD_FOTA_ERROR_BAD_TYPE;
 		return ret;
 	}
+
+	sec_tag = nrf_cloud_sec_tag_get();
 
 	struct nrf_cloud_download_data dl = {
 		.type = NRF_CLOUD_DL_TYPE_FOTA,

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota_poll.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota_poll.c
@@ -326,7 +326,7 @@ static int update_job_status(struct nrf_cloud_fota_poll_ctx *ctx)
 static int start_download(void)
 {
 	enum dfu_target_image_type img_type;
-	static const int sec_tag = CONFIG_NRF_CLOUD_SEC_TAG;
+	static int sec_tag;
 	int ret = 0;
 
 	/* Start the FOTA download, specifying the job/image type */
@@ -358,6 +358,8 @@ static int start_download(void)
 	}
 
 	LOG_INF("Starting FOTA download of %s/%s", job.host, job.path);
+
+	sec_tag = nrf_cloud_sec_tag_get();
 
 	struct nrf_cloud_download_data dl = {
 		.type = NRF_CLOUD_DL_TYPE_FOTA,

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_jwt.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_jwt.c
@@ -470,11 +470,7 @@ int nrf_cloud_jwt_generate(uint32_t time_valid_s, char *const jwt_buf, size_t jw
 	const char *id_ptr;
 	struct jwt_data jwt = {
 		.audience = NULL,
-#if defined(CONFIG_NRF_CLOUD_COAP)
-		.sec_tag = CONFIG_NRF_CLOUD_COAP_SEC_TAG,
-#else
-		.sec_tag = CONFIG_NRF_CLOUD_SEC_TAG,
-#endif
+		.sec_tag = nrf_cloud_sec_tag_get(),
 		.key = JWT_KEY_TYPE_CLIENT_PRIV,
 		.alg = JWT_ALG_TYPE_ES256,
 		.jwt_buf = jwt_buf,

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps.c
@@ -39,7 +39,6 @@ LOG_MODULE_REGISTER(nrf_cloud_pgps, CONFIG_NRF_CLOUD_GPS_LOG_LEVEL);
 #define PREDICTION_PERIOD		240
 #endif
 #define REPLACEMENT_THRESHOLD		CONFIG_NRF_CLOUD_PGPS_REPLACEMENT_THRESHOLD
-#define SEC_TAG				CONFIG_NRF_CLOUD_SEC_TAG
 #define FRAGMENT_SIZE			CONFIG_NRF_CLOUD_PGPS_DOWNLOAD_FRAGMENT_SIZE
 #define PREDICTION_MIDPOINT_SHIFT_SEC	(120 * SEC_PER_MIN)
 #define LOCATION_UNC_SEMIMAJOR_K	89U
@@ -915,7 +914,7 @@ int nrf_cloud_pgps_update(struct nrf_cloud_pgps_result *file_location)
 		return err;
 	}
 
-	int sec_tag = SEC_TAG;
+	int sec_tag = nrf_cloud_sec_tag_get();
 
 	if (FORCE_HTTP_DL && (strncmp(file_location->host, "https", 5) == 0)) {
 		memmove(&file_location->host[4],

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_rest.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_rest.c
@@ -180,7 +180,7 @@ static void init_rest_client_request(struct nrf_cloud_rest_context const *const 
 	req->resp_buff		= rest_ctx->rx_buf;
 	req->resp_buff_len	= rest_ctx->rx_buf_len;
 
-	req->sec_tag		= CONFIG_NRF_CLOUD_SEC_TAG;
+	req->sec_tag		= nrf_cloud_sec_tag_get();
 	req->port		= HTTPS_PORT;
 	req->host		= CONFIG_NRF_CLOUD_REST_HOST_NAME;
 	req->tls_peer_verify	= TLS_PEER_VERIFY_REQUIRED;

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_sec_tag.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_sec_tag.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <net/nrf_cloud.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(nrf_cloud_sec_tag, CONFIG_NRF_CLOUD_LOG_LEVEL);
+
+static sec_tag_t nrf_cloud_sec_tag =
+#if defined(CONFIG_NRF_CLOUD_COAP)
+	CONFIG_NRF_CLOUD_COAP_SEC_TAG;
+#else
+	CONFIG_NRF_CLOUD_SEC_TAG;
+#endif
+
+void nrf_cloud_sec_tag_set(const sec_tag_t sec_tag)
+{
+	nrf_cloud_sec_tag = sec_tag;
+	LOG_DBG("Sec tag updated: %d", nrf_cloud_sec_tag);
+}
+
+sec_tag_t nrf_cloud_sec_tag_get(void)
+{
+	return nrf_cloud_sec_tag;
+}

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -458,14 +458,16 @@ err_cleanup:
 /* Provisions root CA certificate using modem_key_mgmt API */
 static int nct_provision(void)
 {
-	static sec_tag_t sec_tag_list[] = { CONFIG_NRF_CLOUD_SEC_TAG };
+	static sec_tag_t sec_tag;
 	int err = 0;
+
+	sec_tag = nrf_cloud_sec_tag_get();
 
 	nct.tls_config.peer_verify = 2;
 	nct.tls_config.cipher_count = 0;
 	nct.tls_config.cipher_list = NULL;
-	nct.tls_config.sec_tag_count = ARRAY_SIZE(sec_tag_list);
-	nct.tls_config.sec_tag_list = sec_tag_list;
+	nct.tls_config.sec_tag_count = 1;
+	nct.tls_config.sec_tag_list = &sec_tag;
 	nct.tls_config.hostname = NRF_CLOUD_HOSTNAME;
 
 #if defined(CONFIG_NRF_CLOUD_PROVISION_CERTIFICATES)


### PR DESCRIPTION
Added functions nrf_cloud_sec_tag_set() and nrf_cloud_sec_tag_get() to set and get the sec tag used for nRF Cloud credentials.
IRIS-9080