### PR TITLE
samples: cellular: mss: Add test counter multiplier

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -263,6 +263,7 @@ Cellular samples
 * :ref:`nrf_cloud_multi_service` sample:
 
   * Updated Wi-Fi overlays from newlibc to picolib.
+  * Added the :kconfig:option:`CONFIG_TEST_COUNTER_MULTIPLIER` Kconfig option to multiply the number of test counter messages sent, for testing purposes.
 
 * :ref:`nrf_cloud_rest_device_message` sample:
 

--- a/samples/cellular/nrf_cloud_multi_service/Kconfig
+++ b/samples/cellular/nrf_cloud_multi_service/Kconfig
@@ -218,6 +218,14 @@ config TEST_COUNTER
 	help
 	  When enabled, the test counter configuration setting in the shadow is ignored.
 
+config TEST_COUNTER_MULTIPLIER
+	int "The number of test counter messages sent on each update"
+	default 1
+	range 1 1000
+	help
+	  This is a way to increase the number of device messages sent by the sample.
+	  It is useful for load testing.
+
 config AT_CMD_REQUESTS
 	depends on !NRF_CLOUD_COAP
 	bool "Enables remote execution of AT commands using device messages"

--- a/samples/cellular/nrf_cloud_multi_service/src/application.c
+++ b/samples/cellular/nrf_cloud_multi_service/src/application.c
@@ -307,6 +307,20 @@ static void monitor_temperature(double temp)
 	}
 }
 
+/** @brief Send an incrementing test counter message to nRF Cloud.
+ * If CONFIG_TEST_COUNTER_MULTIPLIER is greater than 1, the counter will be incremented
+ * that many times in a row, and a separate test counter message will be sent for each increment.
+ */
+static void test_counter_send(void)
+{
+	static int counter;
+
+	for (int i = 0; i < CONFIG_TEST_COUNTER_MULTIPLIER; i++) {
+		LOG_INF("Sent test counter = %d", counter);
+		(void)send_sensor_sample("COUNT", counter++);
+	}
+}
+
 void main_application_thread_fn(void)
 {
 	if (IS_ENABLED(CONFIG_AT_CMD_REQUESTS)) {
@@ -351,7 +365,6 @@ void main_application_thread_fn(void)
 	(void)start_location_tracking(on_location_update,
 					CONFIG_LOCATION_TRACKING_SAMPLE_INTERVAL_SECONDS);
 #endif
-	int counter = 0;
 
 	/* Begin sampling sensors. */
 	while (true) {
@@ -376,8 +389,7 @@ void main_application_thread_fn(void)
 		}
 
 		if (test_counter_enable_get()) {
-			LOG_INF("Sent test counter = %d", counter);
-			(void)send_sensor_sample("COUNT", counter++);
+			test_counter_send();
 		}
 
 		/* Wait out any remaining time on the sample interval timer. */


### PR DESCRIPTION
Add the CONFIG_TEST_COUNTER_MULTIPLIER KConfig option, which multiplies the number of test counter messages sent every time the test counter updates.

IRIS-9198