### PR TITLE
manifest: Pull in sdk-zephyr with updated i2c test

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 20ab87f134cfd57a64747e101f4a5693b14c6a67
+      revision: 855520b00d080f9a321b4cd97874d815e0bbe1c1
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull in new I2C BME688 test cases
Signed-off-by: Bartosz Miller <bartosz.miller@nordicsemi.no>