### PR TITLE
applications: nrf_desktop: Add harness to sample.yaml

### DIFF
--- a/applications/nrf_desktop/sample.yaml
+++ b/applications/nrf_desktop/sample.yaml
@@ -201,3 +201,12 @@ tests:
     extra_args: FILE_SUFFIX=keyboard
     extra_configs:
       - CONFIG_DESKTOP_USB_STACK_NEXT=y
+  applications.nrf_desktop.zrelease.usb_next:
+    build_only: true
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52840dongle/nrf52840
+    integration_platforms:
+      - nrf52840dk/nrf52840
+      - nrf52840dongle/nrf52840
+    extra_args: FILE_SUFFIX=release

--- a/applications/nrf_desktop/sample.yaml
+++ b/applications/nrf_desktop/sample.yaml
@@ -1,15 +1,34 @@
 sample:
   name: nRF Desktop
   description: HID device reference design
+common:
+  sysbuild: true
+  tags: bluetooth ci_build sysbuild
+  harness: console
+  harness_config:
+    type: multi_line
+    ordered: false
+    regex:
+      - "app_event_manager: e:module_state_event module:main state:READY"
+      - "ble_state: Bluetooth initialized"
+      - "settings_loader: Settings loaded"
+      - "ble_bond: Selected BLE peers"
+      - "(ble_adv: Advertising started)|(ble_scan: Scan started)"
+      - "dfu: Secondary image slot is clean"
 tests:
+  applications.nrf_desktop.zdebug.uart:
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54l15pdk/nrf54l15/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54l15pdk/nrf54l15/cpuapp
   applications.nrf_desktop.zdebug:
-    sysbuild: true
     build_only: true
     platform_allow: >
       nrf52dmouse/nrf52832 nrf52kbd/nrf52832 nrf52810dmouse/nrf52810 nrf52820dongle/nrf52820
       nrf52833dk/nrf52820 nrf52833dk/nrf52833 nrf52833dongle/nrf52833 nrf52840dk/nrf52840
       nrf52840dongle/nrf52840 nrf52840gmouse/nrf52840 nrf5340dk/nrf5340/cpuapp
-      nrf54h20dk/nrf54h20/cpuapp nrf54l15pdk/nrf54l15/cpuapp
     integration_platforms:
       - nrf52dmouse/nrf52832
       - nrf52kbd/nrf52832
@@ -22,47 +41,35 @@ tests:
       - nrf52840dongle/nrf52840
       - nrf52840gmouse/nrf52840
       - nrf5340dk/nrf5340/cpuapp
-      - nrf54h20dk/nrf54h20/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuapp
-    tags: bluetooth ci_build sysbuild
   applications.nrf_desktop.zdebug_wwcb:
-    sysbuild: true
     build_only: true
     platform_allow: nrf52840dk/nrf52840
     integration_platforms:
       - nrf52840dk/nrf52840
-    tags: bluetooth ci_build sysbuild
     extra_args: FILE_SUFFIX=wwcb
   applications.nrf_desktop.zdebug_fast_pair.gmouse:
-    sysbuild: true
     build_only: true
     platform_allow: nrf52840dk/nrf52840 nrf52840gmouse/nrf52840
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf52840gmouse/nrf52840
-    tags: bluetooth ci_build sysbuild
     extra_args: FILE_SUFFIX=fast_pair
                 FP_MODEL_ID=0x8E717D
                 FP_ANTI_SPOOFING_KEY=dZxFzP7X9CcfLPC0apyRkmgsh3n2EbWo9NFNXfVuxAM=
   applications.nrf_desktop.zdebug_mcuboot_qspi:
-    sysbuild: true
     build_only: true
     platform_allow: nrf52840dk/nrf52840
     integration_platforms:
       - nrf52840dk/nrf52840
-    tags: bluetooth ci_build sysbuild
     extra_args: FILE_SUFFIX=mcuboot_qspi
   applications.nrf_desktop.zdebug_mcuboot_smp:
-    sysbuild: true
     build_only: true
     platform_allow: nrf52840dk/nrf52840 nrf52840gmouse/nrf52840
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf52840gmouse/nrf52840
-    tags: bluetooth ci_build sysbuild
     extra_args: FILE_SUFFIX=mcuboot_smp
   applications.nrf_desktop.zdebugwithshell:
-    sysbuild: true
     build_only: true
     platform_allow: >
       nrf52kbd/nrf52832 nrf52833dk/nrf52833 nrf52833dongle/nrf52833 nrf52840dk/nrf52840
@@ -74,67 +81,57 @@ tests:
       - nrf52840dk/nrf52840
       - nrf52840dongle/nrf52840
       - nrf52840gmouse/nrf52840
-    tags: bluetooth ci_build sysbuild
     extra_configs:
       - CONFIG_DESKTOP_SHELL=y
   applications.nrf_desktop.zdebug_3bleconn:
-    sysbuild: true
     build_only: true
     platform_allow: nrf52840dongle/nrf52840
     integration_platforms:
       - nrf52840dongle/nrf52840
-    tags: bluetooth ci_build sysbuild
     extra_args: FILE_SUFFIX=3bleconn
   applications.nrf_desktop.zdebug_4llpmconn:
-    sysbuild: true
     build_only: true
     platform_allow: nrf52840dongle/nrf52840
     integration_platforms:
       - nrf52840dongle/nrf52840
-    tags: bluetooth ci_build sysbuild
     extra_args: FILE_SUFFIX=4llpmconn
   applications.nrf_desktop.zdebug_dongle:
-    sysbuild: true
     build_only: true
     platform_allow: nrf52840dk/nrf52840
     integration_platforms:
       - nrf52840dk/nrf52840
-    tags: bluetooth ci_build sysbuild
     extra_args: FILE_SUFFIX=dongle
+  applications.nrf_desktop.zdebug_keyboard.uart:
+    platform_allow:
+      - nrf54l15pdk/nrf54l15/cpuapp
+    integration_platforms:
+      - nrf54l15pdk/nrf54l15/cpuapp
+    extra_args: FILE_SUFFIX=keyboard
   applications.nrf_desktop.zdebug_keyboard:
-    sysbuild: true
     build_only: true
     platform_allow:
       - nrf52840dk/nrf52840
-      - nrf54l15pdk/nrf54l15/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
-      - nrf54l15pdk/nrf54l15/cpuapp
-    tags: bluetooth ci_build sysbuild
     extra_args: FILE_SUFFIX=keyboard
   applications.nrf_desktop.zdebug_nrf21540ek:
-    sysbuild: true
     build_only: true
     platform_allow: nrf52840dk/nrf52840
     integration_platforms:
       - nrf52840dk/nrf52840
-    tags: bluetooth ci_build sysbuild
     extra_args: SHIELD=nrf21540ek
     extra_configs:
       - CONFIG_CAF_BLE_USE_LLPM=n
   applications.nrf_desktop.zdebug_nrf21540ek_multicore:
-    sysbuild: true
     build_only: true
     platform_allow: nrf5340dk/nrf5340/cpuapp
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
-    tags: bluetooth ci_build sysbuild
     extra_args: SHIELD=nrf21540ek_fwd
                 ipc_radio_SHIELD=nrf21540ek
     extra_configs:
       - CONFIG_CAF_BLE_USE_LLPM=n
   applications.nrf_desktop.zrelease:
-    sysbuild: true
     build_only: true
     platform_allow: >
       nrf52dmouse/nrf52832 nrf52kbd/nrf52832 nrf52810dmouse/nrf52810 nrf52820dongle/nrf52820
@@ -155,38 +152,30 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15pdk/nrf54l15/cpuapp
-    tags: bluetooth ci_build sysbuild
     extra_args: FILE_SUFFIX=release
   applications.nrf_desktop.zrelease_fast_pair.keyboard:
-    sysbuild: true
     build_only: true
     platform_allow: nrf52kbd/nrf52832
     integration_platforms:
       - nrf52kbd/nrf52832
-    tags: bluetooth ci_build sysbuild
     extra_args: FILE_SUFFIX=release_fast_pair
                 FP_MODEL_ID=0x52FF02
                 FP_ANTI_SPOOFING_KEY=8E8ulwhSIp/skZeg27xmWv2SxRxTOagypHrf2OdrhGY=
   applications.nrf_desktop.zrelease_fast_pair.gmouse:
-    sysbuild: true
     build_only: true
     platform_allow: nrf52840gmouse/nrf52840
     integration_platforms:
       - nrf52840gmouse/nrf52840
-    tags: bluetooth ci_build sysbuild
     extra_args: FILE_SUFFIX=release_fast_pair
                 FP_MODEL_ID=0x8E717D
                 FP_ANTI_SPOOFING_KEY=dZxFzP7X9CcfLPC0apyRkmgsh3n2EbWo9NFNXfVuxAM=
   applications.nrf_desktop.zrelease_4llpmconn:
-    sysbuild: true
     build_only: true
     platform_allow: nrf52840dongle/nrf52840
     integration_platforms:
       - nrf52840dongle/nrf52840
-    tags: bluetooth ci_build sysbuild
     extra_args: FILE_SUFFIX=release_4llpmconn
   applications.nrf_desktop.zdebug.usb_next:
-    sysbuild: true
     build_only: true
     platform_allow: >
       nrf52840dk/nrf52840 nrf52840gmouse/nrf52840 nrf52840dongle/nrf52840
@@ -194,26 +183,21 @@ tests:
       - nrf52840dk/nrf52840
       - nrf52840gmouse/nrf52840
       - nrf52840dongle/nrf52840
-    tags: bluetooth ci_build sysbuild
     extra_configs:
       - CONFIG_DESKTOP_USB_STACK_NEXT=y
   applications.nrf_desktop.zdebug_dongle.usb_next:
-    sysbuild: true
     build_only: true
     platform_allow: nrf52840dk/nrf52840
     integration_platforms:
       - nrf52840dk/nrf52840
-    tags: bluetooth ci_build sysbuild
     extra_args: FILE_SUFFIX=dongle
     extra_configs:
       - CONFIG_DESKTOP_USB_STACK_NEXT=y
   applications.nrf_desktop.zdebug_keyboard.usb_next:
-    sysbuild: true
     build_only: true
     platform_allow: nrf52840dk/nrf52840
     integration_platforms:
       - nrf52840dk/nrf52840
-    tags: bluetooth ci_build sysbuild
     extra_args: FILE_SUFFIX=keyboard
     extra_configs:
       - CONFIG_DESKTOP_USB_STACK_NEXT=y

--- a/scripts/quarantine_integration.yaml
+++ b/scripts/quarantine_integration.yaml
@@ -474,6 +474,7 @@
 - scenarios:
     - applications.nrf_desktop.zdebug_3bleconn
     - applications.nrf_desktop.zrelease_4llpmconn
+    - applications.nrf_desktop.zrelease.usb_next
   platforms:
     - nrf52840dongle/nrf52840
   comment: "Configurations excluded to limit resources usage in integration builds"


### PR DESCRIPTION
PR adds harness to sample.yaml to introduce a simple validation. The harness is used only by configurations that provide logs over UART. PR also moves part of test configuration under common to avoid duplication.

PR also adds USB next release configuration to sample.yaml to ensure that the configuration builds without problems.

Jira: NCSDK-26996