### PR TITLE
mpsl: Use soc compatible definition to include bsim

### DIFF
--- a/subsys/mpsl/cx/Kconfig
+++ b/subsys/mpsl/cx/Kconfig
@@ -71,7 +71,7 @@ config MPSL_CX_THREAD
 	  implementation for co-located 2.4 GHz radios.
 
 config MPSL_CX_BT_1WIRE
-	depends on SOC_SERIES_NRF52X
+	depends on SOC_COMPATIBLE_NRF52X
 	select NRFX_GPIOTE
 	select GPIO
 	select NRFX_TIMER1

--- a/subsys/mpsl/cx/bluetooth/mpsl_cx_1w_bluetooth.c
+++ b/subsys/mpsl/cx/bluetooth/mpsl_cx_1w_bluetooth.c
@@ -35,7 +35,7 @@
 #error Selected coex node is not compatible with sdc-radio-coex-one-wire.
 #endif
 
-#if !IS_ENABLED(CONFIG_SOC_SERIES_NRF52X)
+#if !IS_ENABLED(CONFIG_SOC_COMPATIBLE_NRF52X)
 #error Bluetooth coex is only supported on the nRF52 series
 #endif
 


### PR DESCRIPTION
To support Coex 1W with nrf52_bsim, SOC_COMPATIBLE_NRF52X is used instead of SOC_SERIES_NRF52X.