### PR TITLE
tests: bluetooth: fast_pair: crypto: fix stack overflow for PSA config

### DIFF
--- a/tests/subsys/bluetooth/fast_pair/crypto/prj_psa.conf
+++ b/tests/subsys/bluetooth/fast_pair/crypto/prj_psa.conf
@@ -8,5 +8,9 @@ CONFIG_ZTEST=y
 CONFIG_ZTEST_SHUFFLE=y
 CONFIG_ZTEST_SHUFFLE_SUITE_REPEAT_COUNT=1
 CONFIG_ZTEST_SHUFFLE_TEST_REPEAT_COUNT=2
+
+# Increase stack size for tests to avoid stack overflow.
+CONFIG_ZTEST_STACK_SIZE=4096
+
 # Set crypto backend through a helper option to enable dependencies too.
 CONFIG_TEST_BT_FAST_PAIR_CRYPTO_PSA=y


### PR DESCRIPTION
Fixed the stack overflow issue for the nRF54L15 PDK and the PSA configuration in the Fast Pair Crypto test. Increased the stack size globally for all platforms to avoid potential issues with other board targets.

Ref: NCSDK-28342