### PR TITLE
manifest: Update sdk-zephyr to have device PM enabled for SPIM

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 66628acfb7a88e71fe06124649168a02c94996d9
+      revision: a19a7285a58f631c3507c2886e3d9cb1a758c07f
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Enable the device runtime power management on the SPIM shim.