### PR TITLE
lib: nrf_modem: net_if: Include SIM help message

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -407,7 +407,9 @@ Gazell libraries
 Modem libraries
 ---------------
 
-|no_changes_yet_note|
+* :ref:`nrf_modem_lib_lte_net_if` library:
+
+  * Added a log warning suggesting a SIM card to be installed if a UICC error is detected by the modem.
 
 Multiprotocol Service Layer libraries
 -------------------------------------

--- a/lib/nrf_modem_lib/lte_net_if/lte_net_if.c
+++ b/lib/nrf_modem_lib/lte_net_if/lte_net_if.c
@@ -325,6 +325,9 @@ static void lte_reg_handler(const struct lte_lc_evt *const evt)
 			 * an unregistered status).
 			 */
 			break;
+		case LTE_LC_NW_REG_UICC_FAIL:
+			LOG_WRN("The modem reports a UICC failure. Is SIM installed?");
+			__fallthrough;
 		default:
 			LOG_DBG("Not registered to serving cell");
 			/* Mark the serving cell as lost. */


### PR DESCRIPTION
Print log warning instructing user to install
SIM card if UICC error is detected.

IRIS-7432