### PR TITLE
suit: Handle duplicate MPIs as icorrect MPI value

### DIFF
--- a/subsys/suit/orchestrator/src/suit_orchestrator_sdfw.c
+++ b/subsys/suit/orchestrator/src/suit_orchestrator_sdfw.c
@@ -384,6 +384,10 @@ int suit_orchestrator_init(void)
 			LOG_ERR("Failed to load MPI: invalid MPI format (i.e. version, values)");
 			plat_err = suit_execution_mode_set(EXECUTION_MODE_FAIL_MPI_INVALID);
 			break;
+		case SUIT_PLAT_ERR_EXISTS:
+			LOG_ERR("Failed to load MPI: duplicate class IDs found");
+			plat_err = suit_execution_mode_set(EXECUTION_MODE_FAIL_MPI_INVALID);
+			break;
 		case SUIT_PLAT_ERR_UNSUPPORTED:
 			LOG_ERR("Failed to load MPI: unsupported configuration");
 			plat_err = suit_execution_mode_set(EXECUTION_MODE_FAIL_MPI_UNSUPPORTED);

--- a/subsys/suit/storage/include/suit_storage.h
+++ b/subsys/suit/storage/include/suit_storage.h
@@ -29,8 +29,21 @@ extern "C" {
 /**
  * @brief Initialize the SUIT storage.
  *
- * @retval SUIT_PLAT_SUCCESS           if module is successfully initialized.
- * @retval SUIT_PLAT_ERR_HW_NOT_READY  if NVM controller is unavailable.
+ * @retval SUIT_PLAT_SUCCESS             if module is successfully initialized.
+ * @retval SUIT_PLAT_ERR_AUTHENTICATION  if application MPI digest does not match.
+ * @retval SUIT_PLAT_ERR_NOT_FOUND       if MPIs for essential roles (Nordic, root) are not
+ *                                       configured.
+ * @retval SUIT_PLAT_ERR_OUT_OF_BOUNDS   if one of MPI structures has invalid format.
+ * @retval SUIT_PLAT_ERR_EXISTS          if MPI area contains two regions for the same class IDs.
+ * @retval SUIT_PLAT_ERR_UNSUPPORTED     if one of MPI structures contains unsupported
+ *                                       configuration, (i.e. root class ID cannot be used inside
+ *                                       update candidate).
+ * @retval SUIT_PLAT_ERR_CRASH           if unable to initialize empty NVV erea.
+ * @retval SUIT_PLAT_ERR_HW_NOT_READY    if NVM controller is unavailable.
+ * @retval SUIT_PLAT_ERR_IO              if unable to modify NVM contents.
+ * @retval SUIT_PLAT_ERR_NOMEM           if storage partition is too small.
+ * @retval SUIT_PLAT_ERR_SIZE            if internal buffers are too small.
+ * @retval SUIT_PLAT_ERR_INVAL           in case of internal error.
  */
 suit_plat_err_t suit_storage_init(void);
 
@@ -75,7 +88,7 @@ suit_plat_err_t suit_storage_update_cand_set(suit_plat_mreg_t *regions, size_t l
  * @retval SUIT_PLAT_ERR_CBOR_DECODING  if failed to decode envelope.
  */
 suit_plat_err_t suit_storage_installed_envelope_get(const suit_manifest_class_id_t *id,
-						   const uint8_t **addr, size_t *size);
+						    const uint8_t **addr, size_t *size);
 
 /**
  * @brief Install the authentication block and manifest of the envelope inside the SUIT storage.

--- a/tests/subsys/suit/orchestrator/orchestrator_sdfw_nrf54h20/src/test_init.c
+++ b/tests/subsys/suit/orchestrator/orchestrator_sdfw_nrf54h20/src/test_init.c
@@ -189,6 +189,53 @@ static void write_mpi_area_app_unsupported_version(void)
 	zassert_equal(0, err, "Unable to store application MPI digest before test execution");
 }
 
+static void write_mpi_area_app_duplicate_class_ids(void)
+{
+	uint8_t mpi_root[] = {
+		0x01, /* version */
+		0x01, /* downgrade prevention disabled */
+		0x02, /* Independent update allowed */
+		0x01, /* signature check disabled */
+		/* reserved (12) */
+		0xFF, 0xFF, 0xFF, 0xFF,
+		0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+		/* RFC4122 uuid5(uuid.NAMESPACE_DNS, 'nordicsemi.com') */
+		0x76, 0x17, 0xda, 0xa5, 0x71, 0xfd, 0x5a, 0x85,
+		0x8f, 0x94, 0xe2, 0x8d, 0x73, 0x5c, 0xe9, 0xf4,
+		/* RFC4122 uuid5(nordic_vid, 'test_sample_root') */
+		0x97, 0x05, 0x48, 0x23, 0x4c, 0x3d, 0x59, 0xa1,
+		0x89, 0x86, 0xa5, 0x46, 0x60, 0xa1, 0x4b, 0x0a,
+	};
+	/* Digest of the content defined in assert_valid_mpi_area_app(). */
+	uint8_t app_digest[] = {
+		0x1a, 0x81, 0x80, 0xb6, 0x43, 0x8e, 0xe0, 0x59,
+		0xd0, 0xce, 0x9a, 0xf9, 0x51, 0x46, 0xa5, 0x58,
+		0x9d, 0x72, 0xb6, 0x71, 0x98, 0xc1, 0x8a, 0x0f,
+		0xf5, 0xf3, 0x6e, 0x92, 0xac, 0xc3, 0x7d, 0x58,
+	};
+
+	/* Write the sample application area (root and local MPI) and corresponding digest */
+	const struct device *fdev = SUIT_PLAT_INTERNAL_NVM_DEV;
+
+	zassert_not_null(fdev, "Unable to find a driver to modify MPI area");
+
+	int err = flash_write(fdev, SUIT_STORAGE_OFFSET, mpi_root, sizeof(mpi_root));
+
+	zassert_equal(0, err,
+		      "Unable to store application root MPI contents before test execution");
+
+	err = flash_write(fdev, SUIT_STORAGE_OFFSET + sizeof(mpi_root) * 2, mpi_root,
+			  sizeof(mpi_root));
+
+	zassert_equal(
+		0, err,
+		"Unable to store application application local MPI contents before test execution");
+
+	err = flash_write(fdev, SUIT_STORAGE_OFFSET + SUIT_STORAGE_APP_MPI_SIZE, app_digest,
+			  sizeof(app_digest));
+	zassert_equal(0, err, "Unable to store application MPI digest before test execution");
+}
+
 ZTEST_SUITE(orchestrator_nrf54h20_init_tests, NULL, NULL, setup_erased_flash, NULL, NULL);
 
 ZTEST(orchestrator_nrf54h20_init_tests, test_no_mpi)
@@ -209,7 +256,7 @@ ZTEST(orchestrator_nrf54h20_init_tests, test_no_mpi)
 
 ZTEST(orchestrator_nrf54h20_init_tests, test_no_root_mpi)
 {
-	/* GIVEN empty flash (suit storage and empty MPI area with digest)... */
+	/* GIVEN empty suit storage and empty MPI area with digest... */
 	write_empty_mpi_area_app();
 	/* ... and update candidate flag is not set... */
 	/* ... and emergency flag is not set */
@@ -226,8 +273,25 @@ ZTEST(orchestrator_nrf54h20_init_tests, test_no_root_mpi)
 
 ZTEST(orchestrator_nrf54h20_init_tests, test_invalid_mpi_version)
 {
-	/* GIVEN empty flash (suit storage and root MPI with incorrect version... */
+	/* GIVEN empty suit storage and root MPI with incorrect version... */
 	write_mpi_area_app_unsupported_version();
+	/* ... and update candidate flag is not set... */
+	/* ... and emergency flag is not set */
+
+	/* WHEN orchestrator is initialized */
+	int err = suit_orchestrator_init();
+
+	/* THEN failed state is triggered... */
+	zassert_equal(EXECUTION_MODE_FAIL_MPI_INVALID, suit_execution_mode_get(),
+		      "Malformed ROOT MPI not detected");
+	/* ... and orchestrator is initialized */
+	zassert_equal(0, err, "Orchestrator not initialized");
+}
+
+ZTEST(orchestrator_nrf54h20_init_tests, test_duplicate_class_id)
+{
+	/* GIVEN empty suit storage and root MPI with incorrect version... */
+	write_mpi_area_app_duplicate_class_ids();
 	/* ... and update candidate flag is not set... */
 	/* ... and emergency flag is not set */
 
@@ -243,7 +307,7 @@ ZTEST(orchestrator_nrf54h20_init_tests, test_invalid_mpi_version)
 
 ZTEST(orchestrator_nrf54h20_init_tests, test_unupdateable_root)
 {
-	/* GIVEN empty flash (suit storage and root MPI without updateability flag set... */
+	/* GIVEN empty suit storage and root MPI without updateability flag set... */
 	write_mpi_area_app_unupdateable_root();
 	/* ... and update candidate flag is not set... */
 	/* ... and emergency flag is not set */
@@ -260,7 +324,7 @@ ZTEST(orchestrator_nrf54h20_init_tests, test_unupdateable_root)
 
 ZTEST(orchestrator_nrf54h20_init_tests, test_valid_root)
 {
-	/* GIVEN empty flash (suit storage and valid root MPI... */
+	/* GIVEN empty suit storage and valid root MPI... */
 	write_mpi_area_app_root();
 	/* ... and update candidate flag is not set... */
 	/* ... and emergency flag is not set */
@@ -268,9 +332,9 @@ ZTEST(orchestrator_nrf54h20_init_tests, test_valid_root)
 	/* WHEN orchestrator is initialized */
 	int err = suit_orchestrator_init();
 
-	/* THEN failed state is triggered... */
+	/* THEN regular boot state is triggered... */
 	zassert_equal(EXECUTION_MODE_INVOKE, suit_execution_mode_get(),
-		      "Non-updateable ROOT MPI not detected");
+		      "Valid ROOT MPI not accepted");
 	/* ... and orchestrator is initialized */
 	zassert_equal(0, err, "Orchestrator not initialized");
 }


### PR DESCRIPTION
In case of duplicate MPIs, it is better to enter failed state than reboot the device.

Ref: NCSDK-28377