### PR TITLE
nrf_rpc: add documentation page for the UART transport 

### DIFF
--- a/doc/nrf/libraries/nrf_rpc/nrf_rpc_uart.rst
+++ b/doc/nrf/libraries/nrf_rpc/nrf_rpc_uart.rst
@@ -1,0 +1,77 @@
+.. _nrf_rpc_uart:
+
+nRF RPC UART transport
+######################
+
+.. contents::
+   :local:
+   :depth: 2
+
+The nRF RPC UART transport allows you to use the :ref:`nrf_rpc` library to execute procedures on a remote processor that is connected with the local processor using the UART interface.
+
+Frame encoding
+**************
+
+.. note::
+
+   The current frame format is experimental and is a subject to change.
+
+An nRF RPC packet that is sent using the nRF RPC UART transport is encoded within a frame whose format resembles the one used by the HDLC protocol.
+
+Each frame shall start and end with the **delimiter** octet (``0b01111110`` = ``0x7e``).
+Each two subsequent frames may be separated by more than one delimiter octet.
+
+Each byte of the nRF RPC packet shall be encoded according to the following rules:
+
+* If the byte matches one of the :ref:`special octets <nrf_rpc_uart_special_octets>`, it shall be encoded as the following two octets:
+
+  * the **escape** octet (``0x7d``),
+  * the input byte XORed with ``0x20``.
+
+* Otherwise, the byte shall be encoded into a frame’s octet without changes.
+
+The last two bytes of the frame contain the nRF RPC packet checksum, in little-endian byte order.
+The checksum is calculated using the CRC16_CCITT function with the initial value ``0xffff``.
+
+.. _nrf_rpc_uart_special_octets:
+
+Special octets
+==============
+
+The following octets transmitted over the UART interface have a special meaning:
+
+.. table::
+   :align: center
+
+   +-----------+-----------+
+   | Value     | Meaning   |
+   +===========+===========+
+   | ``0x7d``  | escape    |
+   +-----------+-----------+
+   | ``0x7e``  | delimiter |
+   +-----------+-----------+
+
+Encoding example
+================
+
+If the following nRF RPC packet is sent using the nRF RPC UART transport:
+
+.. code-block:: none
+
+   80 01 ff 00 00 61 7e f6
+
+Then the following octets are transmitted over the UART interface:
+
+.. code-block:: none
+
+   7e 80 01 ff 00 00 61 7d 5e f6 6d 72 7e
+
+API documentation
+*****************
+
+| Header file: :file:`include/nrf_rpc/nrf_rpc_uart.h`
+| Source file: :file:`subsys/nrf_rpc/nrf_rpc_uart.c`
+
+.. doxygengroup:: nrf_rpc_uart
+   :project: nrf
+   :members:

--- a/include/nrf_rpc/nrf_rpc_uart.h
+++ b/include/nrf_rpc/nrf_rpc_uart.h
@@ -34,7 +34,7 @@ typedef enum {
 	hdlc_state_escape,
 } hdlc_state_t;
 
-typedef struct nrf_rpc_uart {
+struct nrf_rpc_uart {
 	const struct device *uart;
 	nrf_rpc_tr_receive_handler_t receive_callback;
 	void *receive_ctx;
@@ -57,7 +57,7 @@ typedef struct nrf_rpc_uart {
 
 	/* Workqueue for rx*/
 	struct k_work_q rx_workq;
-} nrf_rpc_uart;
+};
 
 /**
  * @brief Returns nRF RPC UART transport object name for the given devicetree node.
@@ -66,14 +66,14 @@ typedef struct nrf_rpc_uart {
  */
 #define NRF_RPC_UART_TRANSPORT(node_id) _CONCAT(nrf_rpc_tr_, DT_DEP_ORD(node_id))
 
+/**
+ * @}
+ */
+
 #define _NRF_RPC_UART_TRANSPORT_DECLARE(node_id)                                                   \
 	extern const struct nrf_rpc_tr NRF_RPC_UART_TRANSPORT(node_id);
 
 DT_FOREACH_STATUS_OKAY(nordic_nrf_uarte, _NRF_RPC_UART_TRANSPORT_DECLARE);
-
-/**
- * @}
- */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Add a documentation page that describes the nRF RPC UART
transport frame encoding and API.