### PR TITLE
editorconfig: Add editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,92 @@
+# EditorConfig: https://editorconfig.org/
+
+# top-most EditorConfig file
+root = true
+
+# All (Defaults)
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+max_line_length = 100
+
+# Assembly
+[*.S]
+indent_style = tab
+indent_size = 8
+
+# C
+[*.{c,h}]
+indent_style = tab
+indent_size = 8
+
+# C++
+[*.{cpp,hpp}]
+indent_style = tab
+indent_size = 8
+
+# Linker Script
+[*.ld]
+indent_style = tab
+indent_size = 8
+
+# Python
+[*.py]
+indent_style = space
+indent_size = 4
+
+# Perl
+[*.pl]
+indent_style = tab
+indent_size = 8
+
+# reStructuredText
+[*.rst]
+indent_style = space
+indent_size = 3
+
+# YAML
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+# Shell Script
+[*.sh]
+indent_style = space
+indent_size = 4
+
+# Windows Command Script
+[*.cmd]
+end_of_line = crlf
+indent_style = tab
+indent_size = 8
+
+# Valgrind Suppression File
+[*.supp]
+indent_style = space
+indent_size = 3
+
+# CMake
+[{CMakeLists.txt,*.cmake}]
+indent_style = space
+indent_size = 2
+
+# Makefile
+[Makefile]
+indent_style = tab
+indent_size = 8
+
+# Device tree
+[*.{dts,dtsi,overlay}]
+indent_style = tab
+indent_size = 8
+
+# Git commit messages
+[COMMIT_EDITMSG]
+max_line_length = 75
+
+# Kconfig
+[Kconfig*]
+indent_style = tab
+indent_size = 8


### PR DESCRIPTION
Adding an editor config file to improve developer experience. Especially nice for editors that default to a tab-size of 4 instead of 8.

The file added in this commit is an exact copy of the one found in zephyr.

EditorConfig (https://editorconfig.org) is a widely supported configuration tool that helps to ensure better consistency amongst developers by auto-configuring an editor to match the original/intended style i.e. tab-width etc

Lots of editors support this natively and those that do not probably have a plugin or extension.