### PR TITLE
samples: nfc: add nfc tag for samples

### DIFF
--- a/samples/nfc/record_launch_app/sample.yaml
+++ b/samples/nfc/record_launch_app/sample.yaml
@@ -19,4 +19,4 @@ tests:
       nrf5340dk/nrf5340/cpuapp/ns
       nrf54h20dk/nrf54h20/cpuapp
       nrf54l15pdk/nrf54l15/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild nfc

--- a/samples/nfc/record_text/sample.yaml
+++ b/samples/nfc/record_text/sample.yaml
@@ -19,4 +19,4 @@ tests:
       nrf5340dk/nrf5340/cpuapp/ns
       nrf54h20dk/nrf54h20/cpuapp
       nrf54l15pdk/nrf54l15/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild nfc

--- a/samples/nfc/shell/sample.yaml
+++ b/samples/nfc/shell/sample.yaml
@@ -19,4 +19,4 @@ tests:
       nrf5340dk/nrf5340/cpuapp/ns
       nrf54h20dk/nrf54h20/cpuapp
       nrf54l15pdk/nrf54l15/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild nfc

--- a/samples/nfc/system_off/sample.yaml
+++ b/samples/nfc/system_off/sample.yaml
@@ -17,4 +17,4 @@ tests:
       nrf5340dk/nrf5340/cpuapp
       nrf5340dk/nrf5340/cpuapp/ns
       nrf54l15pdk/nrf54l15/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild nfc

--- a/samples/nfc/tag_reader/sample.yaml
+++ b/samples/nfc/tag_reader/sample.yaml
@@ -10,4 +10,4 @@ tests:
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf52840dk/nrf52840 nrf52dk/nrf52832 nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild nfc

--- a/samples/nfc/tnep_poller/sample.yaml
+++ b/samples/nfc/tnep_poller/sample.yaml
@@ -10,4 +10,4 @@ tests:
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf52840dk/nrf52840 nrf52dk/nrf52832 nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild nfc

--- a/samples/nfc/tnep_tag/sample.yaml
+++ b/samples/nfc/tnep_tag/sample.yaml
@@ -19,4 +19,4 @@ tests:
       nrf5340dk/nrf5340/cpuapp/ns
       nrf54h20dk/nrf54h20/cpuapp
       nrf54l15pdk/nrf54l15/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild nfc

--- a/samples/nfc/writable_ndef_msg/sample.yaml
+++ b/samples/nfc/writable_ndef_msg/sample.yaml
@@ -19,4 +19,4 @@ tests:
       nrf5340dk/nrf5340/cpuapp/ns
       nrf54h20dk/nrf54h20/cpuapp
       nrf54l15pdk/nrf54l15/cpuapp
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild nfc

--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -249,3 +249,14 @@ suit:
     - nrf/tests/subsys/suit/
     - modules/lib/suit-processor/
     - modules/lib/suit-generator/
+
+nfc:
+  files:
+    - nrf/subsys/nfc/
+    - nrf/include/nfc/
+    - nrf/lib/st25r3911b/
+    - nrf/samples/nfc/
+    - nrf/samples/bluetooth/peripheral_nfc_pairing/
+    - nrf/samples/bluetooth/central_nfc_pairing/
+    - nrf/samples/bluetooth/peripheral_hids_keyboard/
+    - nrfxlib/nfc/


### PR DESCRIPTION
Extend list of paths used to check if nfc
samples should be executed.