### PR TITLE
net: lib: nrf_cloud_coap: use shorter rsc

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -470,6 +470,10 @@ Libraries for networking
 
   * Fixed a hard fault that occurred when encoding AGNSS request data and the ``net_info`` field of the :c:struct:`nrf_cloud_rest_agnss_request` structure is NULL.
 
+* :ref:`lib_nrf_cloud_coap` library:
+
+  * Updated to use a shorter resource string for the ``d2c/bulk`` resource.
+
 Libraries for NFC
 -----------------
 


### PR DESCRIPTION
We can use /d2c/bulk now instead of the older verbose form that included the device_id.

Jira: IRIS-8337