### PR TITLE
manifest: sdk-zephyr: pull nrfs ipc send fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 20ab87f134cfd57a64747e101f4a5693b14c6a67
+      revision: pull/1886/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull fix to nrfs ipc service send function,
where wrong buffer was used.

Issue
https://nordicsemi.atlassian.net/browse/NRFX-6104