### PR TITLE
applications: asset_tracker_v2: add tag for asset_tracker

### DIFF
--- a/applications/asset_tracker_v2/sample.yaml
+++ b/applications/asset_tracker_v2/sample.yaml
@@ -17,7 +17,7 @@ tests:
       - thingy91/nrf9160/ns
       - thingy91x/nrf9151/ns
       - native_sim
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild applications_asset_tracker_v2
   applications.asset_tracker_v2.nrf_cloud-pgps:
     sysbuild: true
     build_only: true
@@ -31,7 +31,7 @@ tests:
       - nrf9160dk/nrf9160/ns
       - thingy91/nrf9160/ns
     extra_args: EXTRA_CONF_FILE=overlay-pgps.conf
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild applications_asset_tracker_v2
   applications.asset_tracker_v2.nrf_cloud-no-agnss:
     sysbuild: true
     build_only: true
@@ -46,7 +46,7 @@ tests:
       - nrf9160dk/nrf9160/ns
       - thingy91/nrf9160/ns
     extra_args: CONFIG_NRF_CLOUD_AGNSS=n
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild applications_asset_tracker_v2
   applications.asset_tracker_v2.aws:
     sysbuild: true
     build_only: true
@@ -65,7 +65,7 @@ tests:
     extra_configs:
       - CONFIG_AWS_IOT_BROKER_HOST_NAME="example-hostname.aws.com"
     extra_args: EXTRA_CONF_FILE="overlay-aws.conf"
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild applications_asset_tracker_v2
   applications.asset_tracker_v2.aws-pgps:
     sysbuild: true
     build_only: true
@@ -82,7 +82,7 @@ tests:
     extra_configs:
       - CONFIG_AWS_IOT_BROKER_HOST_NAME="example-hostname.aws.com"
     extra_args: EXTRA_CONF_FILE="overlay-aws.conf;overlay-pgps.conf"
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild applications_asset_tracker_v2
   applications.asset_tracker_v2.aws-all:
     sysbuild: true
     build_only: true
@@ -100,7 +100,7 @@ tests:
       - CONFIG_MEMFAULT_NCS_PROJECT_KEY="PROJECTKEY"
     extra_args: >
       EXTRA_CONF_FILE="overlay-aws.conf;overlay-pgps.conf;overlay-debug.conf;overlay-memfault.conf"
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild applications_asset_tracker_v2
   applications.asset_tracker_v2.azure:
     sysbuild: true
     build_only: true
@@ -120,7 +120,7 @@ tests:
       - CONFIG_AZURE_IOT_HUB_DPS_HOSTNAME="global.azure-devices-provisioning.net"
       - CONFIG_AZURE_IOT_HUB_DPS_ID_SCOPE="IDSCOPE"
     extra_args: EXTRA_CONF_FILE="overlay-azure.conf"
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild applications_asset_tracker_v2
   applications.asset_tracker_v2.debug:
     sysbuild: true
     build_only: true
@@ -137,7 +137,7 @@ tests:
       - thingy91/nrf9160/ns
       - native_sim
     extra_args: EXTRA_CONF_FILE=overlay-debug.conf
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild applications_asset_tracker_v2
   applications.asset_tracker_v2.debug-memfault:
     sysbuild: true
     build_only: true
@@ -154,7 +154,7 @@ tests:
     extra_configs:
       - CONFIG_MEMFAULT_NCS_PROJECT_KEY="PROJECTKEY"
     extra_args: EXTRA_CONF_FILE="overlay-debug.conf;overlay-memfault.conf"
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild applications_asset_tracker_v2
   applications.asset_tracker_v2.memfault:
     sysbuild: true
     build_only: true
@@ -171,7 +171,7 @@ tests:
     extra_configs:
       - CONFIG_MEMFAULT_NCS_PROJECT_KEY="PROJECTKEY"
     extra_args: EXTRA_CONF_FILE=overlay-memfault.conf
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild applications_asset_tracker_v2
   applications.asset_tracker_v2.low-power:
     sysbuild: true
     build_only: true
@@ -186,7 +186,7 @@ tests:
       - nrf9160dk/nrf9160/ns
       - thingy91/nrf9160/ns
     extra_args: EXTRA_CONF_FILE=overlay-low-power.conf
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild applications_asset_tracker_v2
   applications.asset_tracker_v2.carrier.nrf9160dk:
     sysbuild: true
     build_only: true
@@ -196,7 +196,7 @@ tests:
     integration_platforms:
       - nrf9160dk/nrf9160/ns
     extra_args: EXTRA_CONF_FILE=overlay-carrier.conf
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild applications_asset_tracker_v2
   applications.asset_tracker_v2.carrier.thingy91:
     sysbuild: true
     build_only: true
@@ -205,7 +205,7 @@ tests:
       - thingy91/nrf9160/ns
     extra_args: EXTRA_CONF_FILE=overlay-carrier.conf
       SB_CONFIG_THINGY91_STATIC_PARTITIONS_LWM2M_CARRIER=y
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild applications_asset_tracker_v2
   applications.asset_tracker_v2.carrier.nrf9161dk:
     sysbuild: true
     build_only: true
@@ -214,7 +214,7 @@ tests:
     integration_platforms:
       - nrf9161dk/nrf9161/ns
     extra_args: EXTRA_CONF_FILE=overlay-carrier.conf
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild applications_asset_tracker_v2
   applications.asset_tracker_v2.carrier.nrf9151dk:
     sysbuild: true
     build_only: true
@@ -223,7 +223,7 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
     extra_args: EXTRA_CONF_FILE=overlay-carrier.conf
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild applications_asset_tracker_v2
   applications.asset_tracker_v2.lwm2m.bootstrap-low_power:
     sysbuild: true
     build_only: true
@@ -240,7 +240,7 @@ tests:
     extra_configs:
       - CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP=y
     extra_args: EXTRA_CONF_FILE="overlay-lwm2m.conf;overlay-low-power.conf"
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild applications_asset_tracker_v2
   applications.asset_tracker_v2.lwm2m.debug:
     sysbuild: true
     build_only: true
@@ -254,7 +254,7 @@ tests:
       - nrf9160dk/nrf9160/ns
       - thingy91/nrf9160/ns
     extra_args: EXTRA_CONF_FILE="overlay-lwm2m.conf;overlay-debug.conf"
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild applications_asset_tracker_v2
   applications.asset_tracker_v2.lwm2m.debug-modem_trace:
     sysbuild: true
     build_only: true
@@ -268,7 +268,7 @@ tests:
     extra_args:
       EXTRA_CONF_FILE="overlay-lwm2m.conf;overlay-debug.conf"
       asset_tracker_v2_SNIPPET="nrf91-modem-trace-uart;tfm-enable-share-uart"
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild applications_asset_tracker_v2
   applications.asset_tracker_v2.lwm2m.modem_trace:
     sysbuild: true
     build_only: true
@@ -284,7 +284,7 @@ tests:
     extra_args:
       EXTRA_CONF_FILE="overlay-lwm2m.conf"
       asset_tracker_v2_SNIPPET="nrf91-modem-trace-uart;tfm-enable-share-uart"
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild applications_asset_tracker_v2
   applications.asset_tracker_v2.lwm2m.memfault:
     sysbuild: true
     build_only: true
@@ -302,7 +302,7 @@ tests:
     extra_configs:
       - CONFIG_MEMFAULT_NCS_PROJECT_KEY="PROJECTKEY"
     extra_args: EXTRA_CONF_FILE="overlay-lwm2m.conf;overlay-memfault.conf"
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild applications_asset_tracker_v2
   applications.asset_tracker_v2.memfault-low-power:
     sysbuild: true
     build_only: true
@@ -321,7 +321,7 @@ tests:
     extra_configs:
       - CONFIG_MEMFAULT_NCS_PROJECT_KEY="PROJECTKEY"
     extra_args: EXTRA_CONF_FILE="overlay-low-power.conf;overlay-memfault.conf"
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild applications_asset_tracker_v2
   applications.asset_tracker_v2.nrf7002ek_wifi.nrf9160dk:
     sysbuild: true
     build_only: true
@@ -330,7 +330,7 @@ tests:
     platform_allow: nrf9160dk/nrf9160/ns
     extra_args: SHIELD=nrf7002ek EXTRA_CONF_FILE=overlay-nrf7002ek-wifi-scan-only.conf
                 SB_CONFIG_WIFI_NRF700X=y SB_CONFIG_WIFI_NRF700X_SCAN_ONLY=y
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild applications_asset_tracker_v2
   applications.asset_tracker_v2.nrf7002ek_wifi.nrf9161dk:
     sysbuild: true
     build_only: true
@@ -339,7 +339,7 @@ tests:
     platform_allow: nrf9161dk/nrf9161/ns
     extra_args: SHIELD=nrf7002ek EXTRA_CONF_FILE=overlay-nrf7002ek-wifi-scan-only.conf
                 SB_CONFIG_WIFI_NRF700X=y SB_CONFIG_WIFI_NRF700X_SCAN_ONLY=y
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild applications_asset_tracker_v2
   applications.asset_tracker_v2.nrf7002ek_wifi.nrf9151dk:
     sysbuild: true
     build_only: true
@@ -348,7 +348,7 @@ tests:
     platform_allow: nrf9151dk/nrf9151/ns
     extra_args: SHIELD=nrf7002ek EXTRA_CONF_FILE=overlay-nrf7002ek-wifi-scan-only.conf
                 SB_CONFIG_WIFI_NRF700X=y SB_CONFIG_WIFI_NRF700X_SCAN_ONLY=y
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild applications_asset_tracker_v2
   applications.asset_tracker_v2.nrf7002ek_wifi-debug:
     sysbuild: true
     build_only: true
@@ -363,7 +363,7 @@ tests:
     extra_args: SHIELD=nrf7002ek
                 EXTRA_CONF_FILE="overlay-nrf7002ek-wifi-scan-only.conf;overlay-debug.conf"
                 SB_CONFIG_WIFI_NRF700X=y SB_CONFIG_WIFI_NRF700X_SCAN_ONLY=y
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild applications_asset_tracker_v2
 
   # Configuration which will be used by the positioning CI integration job to verify PRs
   applications.asset_tracker_v2.integration_config_positioning:
@@ -378,4 +378,4 @@ tests:
       - nrf9151dk/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
-    tags: ci_build sysbuild
+    tags: ci_build sysbuild applications_asset_tracker_v2

--- a/applications/asset_tracker_v2/tests/debug_module/testcase.yaml
+++ b/applications/asset_tracker_v2/tests/debug_module/testcase.yaml
@@ -6,4 +6,4 @@ tests:
       - native_sim
       - qemu_cortex_m3
       - nrf9160dk/nrf9160/ns
-    tags: debug_module sysbuild
+    tags: debug_module sysbuild applications_asset_tracker_v2

--- a/applications/asset_tracker_v2/tests/json_common/testcase.yaml
+++ b/applications/asset_tracker_v2/tests/json_common/testcase.yaml
@@ -6,7 +6,7 @@ tests:
       - nrf9160dk/nrf9160
       - native_sim
       - qemu_cortex_m3
-    tags: json_common_test-aws sysbuild
+    tags: json_common_test-aws sysbuild applications_asset_tracker_v2
     extra_configs:
       - CONFIG_CLOUD_CODEC_AWS_IOT=y
   applications.asset_tracker_v2.cloud.cloud_codec.json_common.azure:
@@ -16,6 +16,6 @@ tests:
       - nrf9160dk/nrf9160
       - native_sim
       - qemu_cortex_m3
-    tags: json_common_test-azure sysbuild
+    tags: json_common_test-azure sysbuild applications_asset_tracker_v2
     extra_configs:
       - CONFIG_CLOUD_CODEC_AZURE_IOT_HUB=y

--- a/applications/asset_tracker_v2/tests/location_module/testcase.yaml
+++ b/applications/asset_tracker_v2/tests/location_module/testcase.yaml
@@ -6,4 +6,4 @@ tests:
       - native_sim
       - qemu_cortex_m3
       - nrf9160dk/nrf9160/ns
-    tags: location_module sysbuild
+    tags: location_module sysbuild applications_asset_tracker_v2

--- a/applications/asset_tracker_v2/tests/lwm2m_codec_helpers/testcase.yaml
+++ b/applications/asset_tracker_v2/tests/lwm2m_codec_helpers/testcase.yaml
@@ -6,4 +6,4 @@ tests:
       - native_sim
       - qemu_cortex_m3
       - nrf9160dk/nrf9160/ns
-    tags: lwm2m_codec sysbuild
+    tags: lwm2m_codec sysbuild applications_asset_tracker_v2

--- a/applications/asset_tracker_v2/tests/lwm2m_integration/testcase.yaml
+++ b/applications/asset_tracker_v2/tests/lwm2m_integration/testcase.yaml
@@ -6,4 +6,4 @@ tests:
       - native_sim
       - qemu_cortex_m3
       - nrf9160dk/nrf9160/ns
-    tags: lwm2m_integration sysbuild
+    tags: lwm2m_integration sysbuild applications_asset_tracker_v2

--- a/applications/asset_tracker_v2/tests/nrf_cloud_codec/testcase.yaml
+++ b/applications/asset_tracker_v2/tests/nrf_cloud_codec/testcase.yaml
@@ -6,4 +6,4 @@ tests:
       - native_sim
       - qemu_cortex_m3
       - nrf9160dk/nrf9160/ns
-    tags: nrf_cloud_codec sysbuild
+    tags: nrf_cloud_codec sysbuild applications_asset_tracker_v2

--- a/applications/asset_tracker_v2/tests/nrf_cloud_codec_mocked_cjson/testcase.yaml
+++ b/applications/asset_tracker_v2/tests/nrf_cloud_codec_mocked_cjson/testcase.yaml
@@ -5,4 +5,4 @@ tests:
     integration_platforms:
       - native_sim
       - qemu_cortex_m3
-    tags: nrf_cloud_codec_mocked_cJSON sysbuild
+    tags: nrf_cloud_codec_mocked_cJSON sysbuild applications_asset_tracker_v2

--- a/applications/asset_tracker_v2/tests/ui_module/testcase.yaml
+++ b/applications/asset_tracker_v2/tests/ui_module/testcase.yaml
@@ -5,4 +5,4 @@ tests:
     integration_platforms:
       - native_sim
       - nrf9160dk/nrf9160/ns
-    tags: ui_module sysbuild
+    tags: ui_module sysbuild applications_asset_tracker_v2

--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -546,3 +546,54 @@ esb:
     - nrf/subsys/mpsl/
     - nrfxlib/crypto/
     - zephyr/soc/nordic/
+
+applications_asset_tracker_v2:
+  files:
+    - nrf/applications/asset_tracker_v2/
+    - nrf/subsys/net/lib/nrf_cloud/
+    - nrf/subsys/net/lib/aws_iot/
+    - nrf/subsys/net/lib/azure_iot_hub/
+    - nrf/subsys/caf/
+    - nrf/subsys/dfu/
+    - nrf/subsys/fw_info/
+    - nrf/subsys/net/
+    - nrf/subsys/nrf_security/
+    - nrf/modules/cjson/
+    - nrf/modules/azure-sdk-for-c/
+    - nrf/modules/memfault-firmware-sdk/
+    - nrf/modules/trusted-firmware-m/
+    - nrf/drivers/hw_cc3xx/
+    - nrf/drivers/wifi/
+    - nrf/lib/at_cmd_parser/
+    - nrf/lib/at_host/
+    - nrf/lib/at_monitor/
+    - nrf/lib/bin/lwm2m_carrier/
+    - nrf/lib/date_time/
+    - nrf/lib/dk_buttons_and_leds/
+    - nrf/lib/fprotect/
+    - nrf/lib/hw_id/
+    - nrf/lib/location/
+    - nrf/lib/lte_link_control/
+    - nrf/lib/modem*/
+    - nrf/lib/nrf_modem_lib/
+    - nrf/lib/sms/
+    - nrf/lib/pdn/
+    - nrf/lib/qos/
+    - modules/crypto/mbedtls/
+    - modules/crypto/oberon-psa-crypto/
+    - modules/lib/azure-sdk-for-c/
+    - modules/lib/cjson/
+    - modules/lib/memfault-firmware-sdk/
+    - modules/lib/zcbor/
+    - nrfxlib/crypto/
+    - nrfxlib/nrf_modem/
+    - nrfxlib/nrf_wifi/
+    - zephyr/drivers/flash/
+    - zephyr/drivers/hwinfo/
+    - zephyr/boards/nordic/nrf9160dk/
+    - zephyr/subsys/net/
+    - zephyr/subsys/settings/
+    - zephyr/subsys/storage/
+    - zephyr/subsys/tracing/
+    - zephyr/subsys/random/
+    - zephyr/subsys/fs/


### PR DESCRIPTION
Extend list of paths used to check if asset_tracker application and test should be executed.