### PR TITLE
manifest: sdk-connectedhomeip: Update revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -160,7 +160,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 4d8e75cf312083c39be9523f2ff92bc8359bbf02
+      revision: c0df90bc9f48360bdcd3d5d2aedde020648ef6b6
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
Pull fixes for ICD LIT config and `zap-generate` `-o` path.