### PR TITLE
bluetooth: Always build hci_vs_sdc if CONFIG_BT is selected

### DIFF
--- a/subsys/bluetooth/CMakeLists.txt
+++ b/subsys/bluetooth/CMakeLists.txt
@@ -9,7 +9,7 @@ zephyr_sources_ifdef(CONFIG_BT_GATT_DM gatt_dm.c)
 zephyr_sources_ifdef(CONFIG_BT_SCAN scan.c)
 zephyr_sources_ifdef(CONFIG_BT_CONN_CTX conn_ctx.c)
 zephyr_sources_ifdef(CONFIG_BT_ENOCEAN enocean.c)
-zephyr_sources_ifdef(CONFIG_BT_LL_SOFTDEVICE hci_vs_sdc.c)
+zephyr_sources_ifdef(CONFIG_BT_LL_SOFTDEVICE_HEADERS_INCLUDE hci_vs_sdc.c)
 
 add_subdirectory_ifdef(CONFIG_BT_ADV_PROV adv_prov)
 add_subdirectory_ifdef(CONFIG_BT_LL_SOFTDEVICE controller)

--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -31,6 +31,7 @@ config BT_MAX_CONN
 
 config BT_LL_SOFTDEVICE_HEADERS_INCLUDE
 	bool
+	depends on (SOC_SERIES_BSIM_NRFXX || SOC_FAMILY_NORDIC_NRF)
 	default y if !BT_CTLR
 	help
 	  Include SoftDevice header files provided with the library.


### PR DESCRIPTION
When using a remote HCI image, the LL KConfig is not available. Match the approach used by host_extensions and always build the VS command wrappers if CONFIG_BT is set.
The remote LL can return unsupported BTLE command if it's not SDC.