### PR TITLE
tests: subsys: net: lib: do not use net tag when qemu

### DIFF
--- a/tests/subsys/net/lib/aws_fota/aws_fota_json/testcase.yaml
+++ b/tests/subsys/net/lib/aws_fota/aws_fota_json/testcase.yaml
@@ -7,4 +7,4 @@ tests:
       - nrf52840dk/nrf52840
       - nrf9160dk/nrf9160
       - qemu_cortex_m3
-    tags: aws fota json sysbuild net
+    tags: aws fota json sysbuild

--- a/tests/subsys/net/lib/azure_iot_hub/iot_hub/testcase.yaml
+++ b/tests/subsys/net/lib/azure_iot_hub/iot_hub/testcase.yaml
@@ -5,4 +5,4 @@ tests:
     integration_platforms:
       - qemu_cortex_m3
       - native_posix
-    tags: azure_iot_hub sysbuild net
+    tags: azure_iot_hub sysbuild

--- a/tests/subsys/net/lib/mqtt_helper/testcase.yaml
+++ b/tests/subsys/net/lib/mqtt_helper/testcase.yaml
@@ -5,4 +5,4 @@ tests:
     integration_platforms:
       - qemu_cortex_m3
       - native_posix
-    tags: mqtt_helper sysbuild net
+    tags: mqtt_helper sysbuild


### PR DESCRIPTION
Qemu platform excludes tag net, which generates error when such platform is used as integration_platform, for test with net tag.