### PR TITLE
partition_manager_output.py: Convert affiliation string to list

### DIFF
--- a/scripts/partition_manager_output.py
+++ b/scripts/partition_manager_output.py
@@ -68,11 +68,13 @@ def get_config_lines(gpm_config, greg_config, head, split, dest, current_domain=
             add_line(f'{name_upper}_NAME', name)
 
             try:
-                for paf in partition['affiliation']:
-                    ptd = affiliations.get(paf)
-                    if not ptd:
-                        affiliations[paf] = list()
+                # To support single item string for affiliation we convert the string into a list.
+                pafs = partition['affiliation']
+                if isinstance(pafs, str):
+                    pafs = [pafs]
 
+                for paf in pafs:
+                    ptd = affiliations.setdefault(paf, list())
                     if ptd not in affiliations[paf]:
                         affiliations[paf].append(name)
 


### PR DESCRIPTION
In the documentation we have to following example:

```yaml
      fatfs_storage:
          affiliation: disk
          extra_params: {
              disk_name: "SD",
              disk_cache_size: 4096,
              disk_sector_size: 512,
              disk_read_only: 0
          }
          placement:
              before: [end]
              align: {start: 4096}
          inside: [nonsecure_storage]
          size: 65536
```

Unfortunately this does not compile in NCS this is due to the affiliation parameter is assumed to be a list in the python code. Resulting in the parsed parameter to be `['d', 'i', 's', 'k']` instead of `['disk']`.

To generate the correct parameter the correct example would be:

```yaml
      fatfs_storage:
          affiliation:
            - disk
          extra_params: {
              disk_name: "SD",
              disk_cache_size: 4096,
              disk_sector_size: 512,
              disk_read_only: 0
          }
          placement:
              before: [end]
              align: {start: 4096}
          inside: [nonsecure_storage]
          size: 65536
```

However since I think it should be supported to just provide 1 affiliation as a string I've added support code in python to convert the affiliation parameter into a single item list if it's provided as a string.

Ref. NCSIDB-1228