### PR TITLE
mqtt_helper: Prevent mqtt_helper_thread hang on mqtt_live fail

### DIFF
--- a/subsys/net/lib/mqtt_helper/mqtt_helper.c
+++ b/subsys/net/lib/mqtt_helper/mqtt_helper.c
@@ -754,7 +754,6 @@ MQTT_HELPER_STATIC void mqtt_helper_poll_loop(void)
 			ret = mqtt_input(&mqtt_client);
 			if (ret) {
 				LOG_ERR("Cloud MQTT input error: %d", ret);
-				(void)mqtt_abort(&mqtt_client);
 				break;
 			}
 
@@ -782,25 +781,24 @@ MQTT_HELPER_STATIC void mqtt_helper_poll_loop(void)
 				LOG_ERR("Socket error: POLLNVAL");
 				LOG_ERR("The socket was unexpectedly closed");
 			}
-
-			(void)mqtt_abort(&mqtt_client);
-
 			break;
 		}
 
 		if ((fds[0].revents & POLLHUP) == POLLHUP) {
 			LOG_ERR("Socket error: POLLHUP");
 			LOG_ERR("Connection was unexpectedly closed");
-			(void)mqtt_abort(&mqtt_client);
 			break;
 		}
 
 		if ((fds[0].revents & POLLERR) == POLLERR) {
 			LOG_ERR("Socket error: POLLERR");
 			LOG_ERR("Connection was unexpectedly closed");
-			(void)mqtt_abort(&mqtt_client);
 			break;
 		}
+	}
+
+	if (!mqtt_state_verify(MQTT_STATE_DISCONNECTING)) {
+		(void)mqtt_abort(&mqtt_client);
 	}
 }
 

--- a/tests/subsys/net/lib/mqtt_helper/src/mqtt_helper_test.c
+++ b/tests/subsys/net/lib/mqtt_helper/src/mqtt_helper_test.c
@@ -531,10 +531,13 @@ void test_mqtt_helper_poll_loop_disconnecting(void)
 /* The test verifies that mqtt_live() is called when poll() returns 0. */
 void test_mqtt_helper_poll_loop_timeout(void)
 {
-	/* Let poll() return 0 first and then -1 on subsequent call to end the test. */
+	/* Let poll() return 0 first and then -ENOTCONN on subsequent call to end the test. */
 	__cmock_poll_ExpectAnyArgsAndReturn(0);
-	__cmock_poll_ExpectAnyArgsAndReturn(-1);
+	__cmock_poll_ExpectAnyArgsAndReturn(-ENOTCONN);
 	__cmock_mqtt_live_ExpectAndReturn(&mqtt_client, 0);
+
+	/* mqtt_abort() should be called when the connection is dropped. */
+	__cmock_mqtt_abort_ExpectAndReturn(&mqtt_client, 0);
 
 	mqtt_state = MQTT_STATE_CONNECTED;
 
@@ -550,6 +553,9 @@ void test_mqtt_helper_poll_loop_pollin(void)
 {
 	__cmock_poll_Stub(poll_stub_pollin);
 	__cmock_mqtt_input_ExpectAndReturn(&mqtt_client, 0);
+
+	/* mqtt_abort() should be called when the poll fails (after the second call). */
+	__cmock_mqtt_abort_ExpectAndReturn(&mqtt_client, 0);
 
 	mqtt_state = MQTT_STATE_CONNECTED;
 


### PR DESCRIPTION
If mqtt_live fails with an error other than -EAGAIN (for example -ENOTCONN), the poll loop exits.

connection_poll_sem is still held, and no attempt is made to abort the connection, so it is not possible for the loop to recover.

Instead, we call mqtt_abort on any occasion that we break out of the loop.

This means that a disconnect event occurs, allowing us to gracefully recover.