### PR TITLE
drivers: wifi: Fix filtering support for promiscuous mode

### DIFF
--- a/drivers/wifi/nrf700x/src/fmac_main.c
+++ b/drivers/wifi/nrf700x/src/fmac_main.c
@@ -728,7 +728,7 @@ static int nrf_wifi_drv_main_zep(const struct device *dev)
 	callbk_fns.if_carr_state_chg_callbk_fn = nrf_wifi_if_carr_state_chg;
 	callbk_fns.rx_frm_callbk_fn = nrf_wifi_if_rx_frm;
 #if defined(CONFIG_NRF700X_RAW_DATA_RX) || defined(CONFIG_NRF700X_PROMISC_DATA_RX)
-	callbk_fns.rx_sniffer_frm_callbk_fn = nrf_wifi_if_sniffer_rx_frm;
+	callbk_fns.sniffer_callbk_fn = nrf_wifi_if_sniffer_rx_frm;
 #endif /* CONFIG_NRF700X_RAW_DATA_RX || CONFIG_NRF700X_PROMISC_DATA_RX */
 #endif
 	rx_buf_pools[0].num_bufs = rx1_num_bufs;

--- a/drivers/wifi/nrf700x/src/wifi_mgmt.c
+++ b/drivers/wifi/nrf700x/src/wifi_mgmt.c
@@ -919,6 +919,20 @@ int nrf_wifi_filter(const struct device *dev,
 
 	if (filter->oper == WIFI_MGMT_SET) {
 		/**
+		 * If promiscuous mode is enabled, filter settings
+		 * cannot be plumbed to the lower layers as that might
+		 * affect connectivity. Save the filter settings in the
+		 * driver and filter packet type on packet receive by
+		 * checking the 802.11 header in the packet
+		 */
+		if (((def_dev_ctx->vif_ctx[vif_ctx_zep->vif_idx]->mode) &
+		     NRF_WIFI_PROMISCUOUS_MODE) == NRF_WIFI_PROMISCUOUS_MODE) {
+			def_dev_ctx->vif_ctx[vif_ctx_zep->vif_idx]->packet_filter =
+				filter->filter;
+			goto end;
+		}
+
+		/**
 		 * In case a user sets data + management + ctrl bits
 		 * or all the filter bits. Map it to bit 0 set to
 		 * enable "all" packet filter bit setting.
@@ -949,6 +963,7 @@ int nrf_wifi_filter(const struct device *dev,
 	} else {
 		filter->filter = def_dev_ctx->vif_ctx[vif_ctx_zep->vif_idx]->packet_filter;
 	}
+end:
 	ret = 0;
 out:
 	return ret;


### PR DESCRIPTION
The filter setting for promiscuous mode needs to be handled in the driver. If the packet filtering is handled in the lower layers, it might affect station connectivity. This commit introduces code to add minimal filtering mechanism in driver.

Addresses [SHEL-2852]

[SHEL-2852]: https://nordicsemi.atlassian.net/browse/SHEL-2852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ