### PR TITLE
applications: nrf5340_audio: Add sysbuild config in buildprog.py

### DIFF
--- a/applications/nrf5340_audio/tools/buildprog/buildprog.py
+++ b/applications/nrf5340_audio/tools/buildprog/buildprog.py
@@ -88,7 +88,8 @@ def __build_cmd_get(core: Core, device: AudioDevice, build: BuildType,
                     pristine, child_image, options):
     if core == Core.app:
         build_cmd = (f"west build {TARGET_CORE_APP_FOLDER} "
-                     f"-b {TARGET_BOARD_NRF5340_AUDIO_DK_APP_NAME}")
+                     f"-b {TARGET_BOARD_NRF5340_AUDIO_DK_APP_NAME} "
+                     f"--sysbuild")
         if device == AudioDevice.headset:
             device_flag = "-DCONFIG_AUDIO_DEV=1"
             dest_folder = TARGET_DEV_HEADSET_FOLDER


### PR DESCRIPTION
Add --sysbuild in buildprog.py for handling the build out of default path.
OCT-NONE
Signed-off-by: Jui-Chou Chung <jui-chou.chung@nordicsemi.no>