### PR TITLE
scripts: ci: tags: add suit samples path

### DIFF
--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -290,6 +290,7 @@ suit:
     - nrf/subsys/sdfw_services/
     - nrf/subsys/mgmt/suitfu/
     - nrf/tests/subsys/suit/
+    - nrf/samples/suit/
     - modules/lib/suit-processor/
     - modules/lib/suit-generator/
 


### PR DESCRIPTION
Missing path to sample in dependencies.