### PR TITLE
applications: nrf_desktop: Use smaller write buffer size for RRAM

### DIFF
--- a/applications/nrf_desktop/configuration/nrf54l15pdk_nrf54l15_cpuapp/prj.conf
+++ b/applications/nrf_desktop/configuration/nrf54l15pdk_nrf54l15_cpuapp/prj.conf
@@ -90,6 +90,11 @@ CONFIG_STREAM_FLASH=y
 CONFIG_IMG_MANAGER=y
 CONFIG_MCUBOOT_IMG_MANAGER=y
 
+# Assign RRAM write buffer size to ensure short write slots. Trying to allocate long write slots
+# while maintaining a BLE connection with short interval and no connection latency may lead to
+# timeouts in flash_sync_mpsl.
+CONFIG_NRF_RRAM_WRITE_BUFFER_SIZE=8
+
 ################################################################################
 
 CONFIG_ASSERT=y

--- a/applications/nrf_desktop/configuration/nrf54l15pdk_nrf54l15_cpuapp/prj_fast_pair.conf
+++ b/applications/nrf_desktop/configuration/nrf54l15pdk_nrf54l15_cpuapp/prj_fast_pair.conf
@@ -125,6 +125,11 @@ CONFIG_BT_FAST_PAIR=y
 CONFIG_BT_FAST_PAIR_LOG_LEVEL_DBG=y
 CONFIG_BT_PRIVACY=y
 
+# Assign RRAM write buffer size to ensure short write slots. Trying to allocate long write slots
+# while maintaining a BLE connection with short interval and no connection latency may lead to
+# timeouts in flash_sync_mpsl.
+CONFIG_NRF_RRAM_WRITE_BUFFER_SIZE=8
+
 ################################################################################
 
 CONFIG_ASSERT=y

--- a/applications/nrf_desktop/configuration/nrf54l15pdk_nrf54l15_cpuapp/prj_keyboard.conf
+++ b/applications/nrf_desktop/configuration/nrf54l15pdk_nrf54l15_cpuapp/prj_keyboard.conf
@@ -95,6 +95,11 @@ CONFIG_STREAM_FLASH=y
 CONFIG_IMG_MANAGER=y
 CONFIG_MCUBOOT_IMG_MANAGER=y
 
+# Assign RRAM write buffer size to ensure short write slots. Trying to allocate long write slots
+# while maintaining a BLE connection with short interval and no connection latency may lead to
+# timeouts in flash_sync_mpsl.
+CONFIG_NRF_RRAM_WRITE_BUFFER_SIZE=8
+
 ################################################################################
 
 CONFIG_ASSERT=y

--- a/applications/nrf_desktop/configuration/nrf54l15pdk_nrf54l15_cpuapp/prj_release.conf
+++ b/applications/nrf_desktop/configuration/nrf54l15pdk_nrf54l15_cpuapp/prj_release.conf
@@ -39,6 +39,11 @@ CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE=y
 CONFIG_DESKTOP_CONFIG_CHANNEL_OUT_REPORT=y
 CONFIG_DESKTOP_CONFIG_CHANNEL_DFU_ENABLE=y
 
+# Assign RRAM write buffer size to ensure short write slots. Trying to allocate long write slots
+# while maintaining a BLE connection with short interval and no connection latency may lead to
+# timeouts in flash_sync_mpsl.
+CONFIG_NRF_RRAM_WRITE_BUFFER_SIZE=8
+
 ################################################################################
 # Zephyr Configuration
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -204,8 +204,13 @@ nRF Desktop
 
 * Added a debug configuration enabling the `Fast Pair`_ feature on the nRF54L15 PDK with the ``nrf54l15pdk/nrf54l15/cpuapp`` board target.
 
-* Updated the :kconfig:option:`CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL` Kconfig option value in configurations with the Fast Pair support.
-  The value is now aligned with the Fast Pair requirements.
+* Updated:
+
+  * The :kconfig:option:`CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL` Kconfig option value in configurations with the Fast Pair support.
+    The value is now aligned with the Fast Pair requirements.
+  * The :kconfig:option:`CONFIG_NRF_RRAM_WRITE_BUFFER_SIZE` Kconfig option value in the nRF54L15 PDK configurations to ensure short write slots.
+    It prevents timeouts in the MPSL flash synchronization caused by allocating long write slots while maintaining a Bluetooth LE connection with short intervals and no connection latency.
+
 
 nRF Machine Learning (Edge Impulse)
 -----------------------------------


### PR DESCRIPTION
Assign RRAM write buffer size to ensure short write slots. Trying to allocate long write slots while maintaining a BLE connection with short interval and no connection latency may lead to timeouts in flash_sync_mpsl.

Jira: NCSDK-28416