### PR TITLE
samples: bluetooth: Link to nRF Desktop from samples using BLE HID

### DIFF
--- a/samples/bluetooth/central_hids/README.rst
+++ b/samples/bluetooth/central_hids/README.rst
@@ -10,6 +10,12 @@ Bluetooth: Central HIDS
 The Central HIDS sample demonstrates how to use the :ref:`hogp_readme` to interact with a HIDS server.
 Basically, the sample simulates a computer that connects to a mouse or a keyboard.
 
+.. note::
+   Apart from HID samples, the |NCS| provides a complete reference application design of :term:`Human Interface Device (HID)`.
+   Depending on the configuration, the application can work as a desktop mouse, gaming mouse, keyboard, or connection dongle.
+   It supports connection over Bluetooth® LE, USB, or both.
+   For details, see the :ref:`nrf_desktop` documentation.
+
 Requirements
 ************
 

--- a/samples/bluetooth/fast_pair/input_device/README.rst
+++ b/samples/bluetooth/fast_pair/input_device/README.rst
@@ -12,9 +12,11 @@ This sample demonstrates :ref:`how to use Google Fast Pair with the nRF Connect 
 Google Fast Pair Service (GFPS) is a standard for pairing Bluetooth® and Bluetooth LE devices with as little user interaction required as possible.
 Google also provides additional features built upon the Fast Pair standard.
 For detailed information about supported functionalities, see the official `Fast Pair`_ documentation.
+The software maturity level for the input device use case is outlined in the :ref:`software_maturity_fast_pair_use_case` table.
 
 .. note::
-   The software maturity level for the input device use case is listed in the :ref:`software_maturity_fast_pair_use_case` table.
+   Support for Fast Pair input device use case is also integrated into :ref:`nrf_desktop`.
+   The nRF Desktop is a complete reference application design of :term:`Human Interface Device (HID)`.
 
 Requirements
 ************

--- a/samples/bluetooth/fast_pair/locator_tag/README.rst
+++ b/samples/bluetooth/fast_pair/locator_tag/README.rst
@@ -14,10 +14,8 @@ Google Fast Pair Service (GFPS) is a standard for pairing Bluetooth® and Blueto
 Google Fast Pair standard also supports the Find My Device Network (FMDN) extension that is the main focus of this sample demonstration.
 For detailed information, see the official `Fast Pair Find My Device Network extension`_ documentation.
 
-.. note::
-   The software maturity level for the locator tag use case is listed in the :ref:`software_maturity_fast_pair_use_case` table.
-
 This sample follows the `Fast Pair Device Feature Requirements for Locator Tags`_ documentation and uses the Fast Pair configuration for the locator tag use case.
+The software maturity level for the locator tag use case is outlined in the :ref:`software_maturity_fast_pair_use_case` table.
 
 Requirements
 ************

--- a/samples/bluetooth/peripheral_hids_keyboard/README.rst
+++ b/samples/bluetooth/peripheral_hids_keyboard/README.rst
@@ -11,6 +11,12 @@ The Peripheral HIDS keyboard sample demonstrates how to use the :ref:`hids_readm
 
 The sample also shows how to perform LE Secure Connections Out-of-Band pairing using NFC.
 
+.. note::
+   Apart from HID samples, the |NCS| provides a complete reference application design of :term:`Human Interface Device (HID)`.
+   Depending on the configuration, the application can work as a desktop mouse, gaming mouse, keyboard, or connection dongle.
+   It supports connection over Bluetooth® LE, USB, or both.
+   For details, see the :ref:`nrf_desktop` documentation.
+
 Requirements
 ************
 

--- a/samples/bluetooth/peripheral_hids_mouse/README.rst
+++ b/samples/bluetooth/peripheral_hids_mouse/README.rst
@@ -10,6 +10,12 @@ Bluetooth: Peripheral HIDS mouse
 The Peripheral HIDS mouse sample demonstrates how to use the :ref:`hids_readme` to implement a mouse input device that you can connect to your computer.
 This sample also shows how to perform directed advertising.
 
+.. note::
+   Apart from HID samples, the |NCS| provides a complete reference application design of :term:`Human Interface Device (HID)`.
+   Depending on the configuration, the application can work as a desktop mouse, gaming mouse, keyboard, or connection dongle.
+   It supports connection over Bluetooth® LE, USB, or both.
+   For details, see the :ref:`nrf_desktop` documentation.
+
 Requirements
 ************
 


### PR DESCRIPTION
Change adds note referring to nRF Desktop to BLE HID samples. Change also adds reference to nRF Desktop from Fast Pair input device sample.

Jira: NCSDK-28448