### PR TITLE
samples: 802154_sniffer: reduce chances of missed frames

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -336,7 +336,9 @@ nRF5340 samples
 Peripheral samples
 ------------------
 
-|no_changes_yet_note|
+* :ref:`802154_sniffer` sample:
+
+  * Increased the number of RX buffers to reduce the chances of frame drops during high traffic periods.
 
 PMIC samples
 ------------

--- a/samples/peripheral/802154_sniffer/prj.conf
+++ b/samples/peripheral/802154_sniffer/prj.conf
@@ -7,6 +7,11 @@ CONFIG_NET_PKT_TIMESTAMP=y
 # Allow sharing the RTC between IEEE 802.15.4 and Zephyr
 CONFIG_NRF_RTC_TIMER_USER_CHAN_COUNT=3
 
+# Increase the number of RX buffers to minimize the chances of frame drops.
+# The value must not be higher than 127 - X, where X is the number of notification
+# slots reserved by the radio driver (see NTF_PRIMARY_POOL_SIZE macro definition).
+CONFIG_NRF_802154_RX_BUFFERS=120
+
 # Shell configuration
 CONFIG_SHELL=y
 CONFIG_SHELL_PROMPT_UART=""


### PR DESCRIPTION
I observed that with the default number of RX buffers, 16, the sniffer starts dropping frames when sending 40 frames of size 115B, with the gap of 1ms (tested with "ltx 40 1" PHY test sample's command).

Increase the number of RX buffers to reduce the frame drops. With the new setting, I am able to run "ltx 250 1" without a drop.