### PR TITLE
Bluetooth: Mesh: add metadata to lighting models

### DIFF
--- a/include/bluetooth/mesh/light_hsl_srv.h
+++ b/include/bluetooth/mesh/light_hsl_srv.h
@@ -34,9 +34,9 @@ struct bt_mesh_light_hsl_srv;
  *  @param[in] _hue_handlers Hue Server model handlers.
  *  @param[in] _sat_handlers Saturation Server model handlers.
  */
-#define BT_MESH_LIGHT_HSL_SRV_INIT(_lightness_srv, _hue_handlers, _sat_handlers)                 \
+#define BT_MESH_LIGHT_HSL_SRV_INIT(_lightness_srv, _hue_handlers, _sat_handlers)                   \
 	{                                                                                          \
-		.lightness = _lightness_srv,                          \
+		.lightness = _lightness_srv,                                                       \
 		.hue = BT_MESH_LIGHT_HUE_SRV_INIT(_hue_handlers),                                  \
 		.sat = BT_MESH_LIGHT_SAT_SRV_INIT(_sat_handlers),                                  \
 	}
@@ -46,18 +46,50 @@ struct bt_mesh_light_hsl_srv;
  *  @brief Light HSL Server model composition data entry.
  *
  *  @param[in] _srv Pointer to a @ref bt_mesh_light_hsl_srv instance.
+ *  @param ...	    Optional Light HSL Server metadata if application is
+ *		    compiled with Large Composition Data Server support,
+ *		    otherwise this parameter is ignored.
  */
-#define BT_MESH_MODEL_LIGHT_HSL_SRV(_srv)                                      \
-	BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_LIGHT_HSL_SRV,                       \
+#define BT_MESH_MODEL_LIGHT_HSL_SRV(_srv, ...)                                 \
+	BT_MESH_MODEL_METADATA_CB(BT_MESH_MODEL_ID_LIGHT_HSL_SRV,              \
 			 _bt_mesh_light_hsl_srv_op, &(_srv)->pub,              \
 			 BT_MESH_MODEL_USER_DATA(struct bt_mesh_light_hsl_srv, \
 						 _srv),                        \
-			 &_bt_mesh_light_hsl_srv_cb),                          \
+			 &_bt_mesh_light_hsl_srv_cb, __VA_ARGS__),             \
 	BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_LIGHT_HSL_SETUP_SRV,                 \
 			 _bt_mesh_light_hsl_setup_srv_op, NULL,                \
 			 BT_MESH_MODEL_USER_DATA(struct bt_mesh_light_hsl_srv, \
 						 _srv),                        \
 			 &_bt_mesh_light_hsl_setup_srv_cb)
+
+
+#ifdef CONFIG_BT_MESH_LARGE_COMP_DATA_SRV
+/** Light HSL Hue Range Metadata ID. */
+#define BT_MESH_LIGHT_HSL_HUE_RANGE_METADATA_ID 0x0005
+
+/** Light HSL Saturation Range Metadata ID. */
+#define BT_MESH_LIGHT_HSL_SAT_RANGE_METADATA_ID 0x0006
+
+/**
+ *  Light HSL Hue Range Metadata entry.
+ *
+ *  @param range_min Minimum boundary of range (16-bit)
+ *  @param range_max Maximum boundary of range (16-bit)
+ */
+#define BT_MESH_LIGHT_HSL_HUE_RANGE_METADATA(range_min, range_max)                                 \
+	BT_MESH_MODELS_METADATA_ENTRY(4, BT_MESH_LIGHT_HSL_HUE_RANGE_METADATA_ID,                  \
+				      ((uint16_t[]){(range_min), (range_max)}))
+
+/**
+ *  Light HSL Saturation Range Metadata entry.
+ *
+ *  @param range_min Minimum boundary of range (16-bit)
+ *  @param range_max Maximum boundary of range (16-bit)
+ */
+#define BT_MESH_LIGHT_HSL_SAT_RANGE_METADATA(range_min, range_max)                                 \
+	BT_MESH_MODELS_METADATA_ENTRY(4, BT_MESH_LIGHT_HSL_SAT_RANGE_METADATA_ID,                  \
+				      ((uint16_t[]){(range_min), (range_max)}))
+#endif
 
 /**
  * Light HSL Server instance.

--- a/include/bluetooth/mesh/light_temp_srv.h
+++ b/include/bluetooth/mesh/light_temp_srv.h
@@ -49,14 +49,32 @@ struct bt_mesh_light_temp_srv;
  * @brief Light CTL Temperature Server model composition data entry.
  *
  * @param[in] _srv Pointer to a @ref bt_mesh_light_temp_srv instance.
+ * @param ...	   Optional Light Temperature Server metadata if application is
+ *		   compiled with Large Composition Data Server support,
+ *		   otherwise this parameter is ignored.
  */
-#define BT_MESH_MODEL_LIGHT_TEMP_SRV(_srv)                                     \
+#define BT_MESH_MODEL_LIGHT_TEMP_SRV(_srv, ...)                                \
 	BT_MESH_MODEL_LVL_SRV(&(_srv)->lvl),                                   \
-	BT_MESH_MODEL_CB(                                                      \
+	BT_MESH_MODEL_METADATA_CB(                                             \
 		BT_MESH_MODEL_ID_LIGHT_CTL_TEMP_SRV,                           \
 		_bt_mesh_light_temp_srv_op, &(_srv)->pub,                      \
 		BT_MESH_MODEL_USER_DATA(struct bt_mesh_light_temp_srv, _srv),  \
-		&_bt_mesh_light_temp_srv_cb)
+		&_bt_mesh_light_temp_srv_cb, __VA_ARGS__)
+
+#ifdef CONFIG_BT_MESH_LARGE_COMP_DATA_SRV
+/** Light CTL Temperature Range Metadata ID. */
+#define BT_MESH_LIGHT_CTL_TEMP_RANGE_METADATA_ID 0x0004
+
+/**
+ *  Light CTL Temperature Range Metadata entry.
+ *
+ *  @param range_min Minimum boundary of range (16-bit)
+ *  @param range_max Maximum boundary of range (16-bit)
+ */
+#define BT_MESH_LIGHT_CTL_TEMP_RANGE_METADATA(range_min, range_max)                                \
+	BT_MESH_MODELS_METADATA_ENTRY(4, BT_MESH_LIGHT_CTL_TEMP_RANGE_METADATA_ID,                 \
+				      ((uint16_t[]){(range_min), (range_max)}))
+#endif
 
 /** Light CTL Temperature Server state access handlers. */
 struct bt_mesh_light_temp_srv_handlers {

--- a/include/bluetooth/mesh/lightness_srv.h
+++ b/include/bluetooth/mesh/lightness_srv.h
@@ -50,20 +50,50 @@ struct bt_mesh_lightness_srv;
  * @brief Light Lightness model entry.
  *
  * @param[in] _srv Pointer to a @ref bt_mesh_lightness_srv instance.
+ * @param ...	   Optional Light Lightness Server metadata if application is
+ *		   compiled with Large Composition Data Server support,
+ *		   otherwise this parameter is ignored.
  */
-#define BT_MESH_MODEL_LIGHTNESS_SRV(_srv)                                      \
+#define BT_MESH_MODEL_LIGHTNESS_SRV(_srv, ...)                                 \
 	BT_MESH_MODEL_LVL_SRV(&(_srv)->lvl),                                   \
 	BT_MESH_MODEL_PONOFF_SRV(&(_srv)->ponoff),                             \
-	BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_LIGHT_LIGHTNESS_SRV,                 \
+	BT_MESH_MODEL_METADATA_CB(BT_MESH_MODEL_ID_LIGHT_LIGHTNESS_SRV,        \
 			 _bt_mesh_lightness_srv_op, &(_srv)->pub,              \
 			 BT_MESH_MODEL_USER_DATA(struct bt_mesh_lightness_srv, \
 						 _srv),                        \
-			 &_bt_mesh_lightness_srv_cb),                          \
+			 &_bt_mesh_lightness_srv_cb, __VA_ARGS__),             \
 	BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_LIGHT_LIGHTNESS_SETUP_SRV,           \
 			 _bt_mesh_lightness_setup_srv_op, NULL,                \
 			 BT_MESH_MODEL_USER_DATA(struct bt_mesh_lightness_srv, \
 						 _srv),                        \
 			 &_bt_mesh_lightness_setup_srv_cb)
+
+#ifdef CONFIG_BT_MESH_LARGE_COMP_DATA_SRV
+/** The Light Purpose Metadata ID. */
+#define BT_MESH_LIGHT_PURPOSE_METADATA_ID 0x0002
+
+/** Light Lightness Range Metadata ID. */
+#define BT_MESH_LIGHT_LIGHTNESS_RANGE_METADATA_ID 0x0003
+
+/**
+ *  Define the Light Purpose Metadata entry.
+ *
+ *  @param light_purpose 16-bit light purpose value.
+ */
+#define BT_MESH_LIGHT_PURPOSE_METADATA(light_purpose)                                              \
+	BT_MESH_MODELS_METADATA_ENTRY(2, BT_MESH_LIGHT_PURPOSE_METADATA_ID,                        \
+				      ((uint16_t[]){(light_purpose)}))
+
+/**
+ *  Light Lightness Range Metadata entry.
+ *
+ *  @param range_min Minimum boundary of range (16-bit)
+ *  @param range_max Maximum boundary of range (16-bit)
+ */
+#define BT_MESH_LIGHT_LIGHTNESS_RANGE_METADATA(range_min, range_max)                               \
+	BT_MESH_MODELS_METADATA_ENTRY(4, BT_MESH_LIGHT_LIGHTNESS_RANGE_METADATA_ID,                \
+				      ((uint16_t[]){(range_min), (range_max)}))
+#endif
 
 /** Collection of handler callbacks for the Light Lightness Server. */
 struct bt_mesh_lightness_srv_handlers {


### PR DESCRIPTION
This commit adds metadata to the Light Lightness Server, Light HSL
Server, Light CTL Temperature Server models in form of an optional parameter.

Note: Metadata is only supported if the Large Composition Data Server model is supported.