### PR TITLE
applications: protocols_serialization: set BT_CTLR to n on client

### DIFF
--- a/applications/protocols_serialization/client/Kconfig
+++ b/applications/protocols_serialization/client/Kconfig
@@ -14,6 +14,9 @@ config RPC_CRASH_LOG_READ_BUFFER_SIZE
 	  Size of the stack buffer used for reading a single chunk of the crash
 	  log from the server device.
 
+config BT_CTLR
+	default n
+
 menu "Zephyr Kernel"
 source "Kconfig.zephyr"
 endmenu


### PR DESCRIPTION
By default BT_CTLR is set to BT on nRF52 and nRF54 DKs, but for the client application we need this to be 'n'.