### PR TITLE
doc: nrf54: Fix typo on board target

### DIFF
--- a/doc/nrf/app_dev/device_guides/nrf54l/features.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54l/features.rst
@@ -94,7 +94,7 @@ The nRF54L15 DK supports MCUboot as its bootloader, in the experimental phase.
 This means the following:
 
   * Only software cryptography is supported.
-  * Single image pair is supported for dual-bank Device Firmware Update (DFU) targeted at the CPU application (the ``nrf54l15dk/nrf54l51/cpuapp`` board target).
+  * Single image pair is supported for dual-bank Device Firmware Update (DFU) targeted at the CPU application (the ``nrf54l15dk/nrf54l15/cpuapp`` board target).
   * MCUboot can be configured as a first-stage bootloader (second-stage bootloader functionality is not yet available).
   * Serial recovery mode is also not yet supported.
 

--- a/doc/nrf/app_dev/device_guides/nrf54l/index.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54l/index.rst
@@ -24,7 +24,7 @@ Zephyr and the |NCS| provide support and contain board definitions for developin
      - Product pages
    * - :ref:`zephyr:nrf54l15dk_nrf54l15`
      - PCA10156
-     - ``nrf54l15dk/nrf54l51/cpuapp``
+     - ``nrf54l15dk/nrf54l15/cpuapp``
      - :ref:`Getting started <gsg_other>`
      - `nRF54L15 System-on-Chip`_
 

--- a/doc/nrf/app_dev/device_guides/nrf54l/testing_dfu.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54l/testing_dfu.rst
@@ -3,7 +3,7 @@
 Testing the DFU solution
 ########################
 
-You can evaluate the DFU functionality by running the :zephyr:code-sample:`smp-svr` sample for the ``nrf54l15dk/nrf54l51/cpuapp`` board target, which is available for both Bluetooth® LE and serial channels.
+You can evaluate the DFU functionality by running the :zephyr:code-sample:`smp-svr` sample for the ``nrf54l15dk/nrf54l15/cpuapp`` board target, which is available for both Bluetooth® LE and serial channels.
 This allows you to build and test the DFU solutions that are facilitated through integration with child images and the partition manager.
 
 To compile the SMP server sample for testing secondary image slots on external SPI NOR flash, make sure you are in the :file:`ncs` directory and run the command based on the selected partitioning method.


### PR DESCRIPTION
`nrf54l15pdk/nrf54l51/cpuapp` to `nrf54l15pdk/nrf54l15/cpuapp`.