### PR TITLE
application: serial_lte_modem: DNS query enhancement

### DIFF
--- a/applications/serial_lte_modem/doc/SOCKET_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/SOCKET_AT_commands.rst
@@ -1276,9 +1276,15 @@ Syntax
 
 ::
 
-   #XGETADDRINFO=<hostname>
+   #XGETADDRINFO=<hostname>[,<address_family>]
 
 * The ``<hostname>`` parameter is a string.
+* The ``<address_family>`` parameter is an integer that gives a hint for DNS query on address family.
+  * ``0`` means unspecified address family.
+  * ``1`` means IPv4 address family.
+  * ``2`` means IPv6 address family.
+
+  If ``<address_family>`` is not specified, there will be no hint given for DNS query.
 
 Response syntax
 ~~~~~~~~~~~~~~~
@@ -1295,8 +1301,17 @@ Example
 
 ::
 
-   AT#XGETADDRINFO="nordicsemi.com"
-   #XGETADDRINFO: "104.20.251.111"
+   AT#XGETADDRINFO="google.com"
+   #XGETADDRINFO: "142.251.42.142"
+   OK
+   AT#XGETADDRINFO="google.com",0
+   #XGETADDRINFO: "172.217.31.142"
+   OK
+   AT#XGETADDRINFO="google.com",1
+   #XGETADDRINFO: "142.251.42.142"
+   OK
+   AT#XGETADDRINFO="ipv6.google.com",2
+   #XGETADDRINFO: "2404:6800:4004:824::200e"
    OK
 
 Read command


### PR DESCRIPTION
Allow to specify address_family in DNS query request. Support 4 configurations
 No hint (default)
 With hint, but address_family is unspecified
 With hint, address_family is IPv4
 With hint, address_family is IPv6
This is further combined with PDN types for test of all DNS query behavior by modem firmware in specific network.

JIRA ticket TNSW-61994