### PR TITLE
tests: modules: mcuboot: add tags for mcuboot tests

### DIFF
--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -659,3 +659,13 @@ ci_applications_ipc_radio:
     - zephyr/subsys/bluetooth/
     - zephyr/subsys/ipc/
     - zephyr/subsys/net/
+
+ci_tests_modules_mcuboot:
+  files:
+    - bootloader/mcuboot/
+    - nrf/modules/mcuboot/
+    - nrf/samples/nrf5340/empty_net_core/
+    - nrf/samples/nrf5340/netboot/
+    - nrf/subsys/bootloader/
+    - nrf/tests/modules/mcuboot/
+    - zephyr/drivers/flash/

--- a/tests/modules/mcuboot/direct_xip/testcase.yaml
+++ b/tests/modules/mcuboot/direct_xip/testcase.yaml
@@ -1,7 +1,7 @@
 tests:
   mcuboot.direct_xip:
     sysbuild: true
-    tags: mcuboot direct_xip sysbuild
+    tags: mcuboot direct_xip sysbuild ci_tests_modules_mcuboot
     platform_allow: nrf9160dk/nrf9160 nrf52840dk/nrf52840 nrf52dk/nrf52832
       nrf5340dk/nrf5340/cpuapp
     integration_platforms:
@@ -12,7 +12,7 @@ tests:
   # Deprecated child and parent build to ensure feature does not break until it is removed
   mcuboot.direct_xip.child_parent:
     sysbuild: false
-    tags: mcuboot direct_xip child_parent deprecated
+    tags: mcuboot direct_xip child_parent deprecated ci_tests_modules_mcuboot
     platform_allow: nrf9160dk/nrf9160 nrf52840dk/nrf52840 nrf52dk/nrf52832
       nrf5340dk/nrf5340/cpuapp
     integration_platforms:

--- a/tests/modules/mcuboot/external_flash/testcase.yaml
+++ b/tests/modules/mcuboot/external_flash/testcase.yaml
@@ -2,7 +2,7 @@ tests:
   mcuboot.external_flash:
     sysbuild: true
     platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp thingy53/nrf5340/cpuapp
-    tags: mcuboot external_flash sysbuild
+    tags: mcuboot external_flash sysbuild ci_tests_modules_mcuboot
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
@@ -11,7 +11,7 @@ tests:
   mcuboot.external_flash.child_parent:
     sysbuild: false
     platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp thingy53/nrf5340/cpuapp
-    tags: mcuboot external_flash child_parent deprecated
+    tags: mcuboot external_flash child_parent deprecated ci_tests_modules_mcuboot
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp


### PR DESCRIPTION
Extend tags for CI test scope selection.