### PR TITLE
tests: subsys: dfu: add tags for dfu tests

### DIFF
--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -669,3 +669,10 @@ ci_tests_modules_mcuboot:
     - nrf/subsys/bootloader/
     - nrf/tests/modules/mcuboot/
     - zephyr/drivers/flash/
+
+ci_tests_subsys_dfu:
+  files:
+    - nrf/subsys/dfu/
+    - nrf/tests/subsys/dfu/
+    - zephyr/drivers/flash/
+    - zephyr/subsys/mgmt/

--- a/tests/subsys/dfu/dfu_multi_image/testcase.yaml
+++ b/tests/subsys/dfu/dfu_multi_image/testcase.yaml
@@ -4,4 +4,4 @@ tests:
     platform_allow: native_posix
     integration_platforms:
       - native_posix
-    tags: dfu sysbuild
+    tags: dfu sysbuild ci_tests_subsys_dfu

--- a/tests/subsys/dfu/dfu_target/mcuboot_bootloader/testcase.yaml
+++ b/tests/subsys/dfu/dfu_target/mcuboot_bootloader/testcase.yaml
@@ -13,4 +13,4 @@ tests:
       - nrf9160dk/nrf9160
       - native_posix
       - qemu_cortex_m3
-    tags: dfu mcuboot sysbuild
+    tags: dfu mcuboot sysbuild ci_tests_subsys_dfu

--- a/tests/subsys/dfu/dfu_target/smp/testcase.yaml
+++ b/tests/subsys/dfu/dfu_target/smp/testcase.yaml
@@ -4,4 +4,4 @@ tests:
     platform_allow: native_posix
     integration_platforms:
       - native_posix
-    tags: dfu smp sysbuild
+    tags: dfu smp sysbuild ci_tests_subsys_dfu

--- a/tests/subsys/dfu/dfu_target_stream/testcase.yaml
+++ b/tests/subsys/dfu/dfu_target_stream/testcase.yaml
@@ -2,7 +2,7 @@
 tests:
   dfu.target_stream:
     sysbuild: true
-    tags: target_stream sysbuild
+    tags: target_stream sysbuild ci_tests_subsys_dfu
     platform_allow: nrf52840dk/nrf52840 nrf9160dk/nrf9160 nrf5340dk/nrf5340/cpuapp native_posix
     integration_platforms:
       - nrf52840dk/nrf52840
@@ -11,7 +11,7 @@ tests:
       - native_posix
   dfu.target_stream.store_progress:
     sysbuild: true
-    tags: target_stream sysbuild
+    tags: target_stream sysbuild ci_tests_subsys_dfu
     extra_args: OVERLAY_CONFIG=overlay-store-progress.conf
     # Since we need the storage partition (and hence PM) allow some nRF devices
     # only.


### PR DESCRIPTION
Extend tags for CI test scope selection.