### PR TITLE
aplications: protocols_serializations: Add config for nrf54l.

### DIFF
--- a/applications/protocols_serialization/sample.yaml
+++ b/applications/protocols_serialization/sample.yaml
@@ -35,3 +35,14 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf54l15pdk/nrf54l15/cpuapp
+  applications.protocols_serialization.all:
+    build_only: true
+    platform_allow: >
+      nrf52840dk/nrf52840
+      nrf54l15pdk/nrf54l15/cpuapp
+    tags: ci_build
+    extra_args: >
+      SNIPPET="ble;openthread;debug;coex;log_rpc"
+    integration_platforms:
+      - nrf52840dk/nrf52840
+      - nrf54l15pdk/nrf54l15/cpuapp

--- a/applications/protocols_serialization/snippets/log_rpc/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
+++ b/applications/protocols_serialization/snippets/log_rpc/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,35 @@
+/* Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+ / {
+	sram@2003FC00 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0x2002EC00 DT_SIZE_K(1)>;
+		zephyr,memory-region = "RetainedMem";
+		status = "okay";
+
+		retainedmem {
+			compatible = "zephyr,retained-ram";
+			status = "okay";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			/* This creates a 1kB partition for crash log */
+			crash_log: retention@0 {
+				compatible = "zephyr,retention";
+				status = "okay";
+				reg = <0x0 DT_SIZE_K(1)>;
+
+				/* This is the prefix which must appear at the front of the data */
+				prefix = [ 01 00 00 00  ];
+			};
+		};
+	};
+};
+
+/* Reduce SRAM_CPUAPP usage by 1KB to account for non-init area */
+&cpuapp_sram {
+	reg = <0x20000000 DT_SIZE_K(187)>;
+};

--- a/applications/protocols_serialization/snippets/log_rpc/snippet.yml
+++ b/applications/protocols_serialization/snippets/log_rpc/snippet.yml
@@ -12,3 +12,6 @@ boards:
   nrf52840dk/nrf52840:
     append:
       EXTRA_DTC_OVERLAY_FILE: boards/nrf52840dk_nrf52840.overlay
+  nrf54l15pdk/nrf54l15/cpuapp:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/nrf54l15pdk_nrf54l15_cpuapp.overlay

--- a/samples/nrf_rpc/ps_client/sample.yaml
+++ b/samples/nrf_rpc/ps_client/sample.yaml
@@ -35,3 +35,14 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf54l15pdk/nrf54l15/cpuapp
+  applications.ps_client.client.all:
+    build_only: true
+    platform_allow: >
+      nrf52840dk/nrf52840
+      nrf54l15pdk/nrf54l15/cpuapp
+    tags: ci_build
+    extra_args: >
+      SNIPPET="ble;openthread;debug;coex;log_rpc"
+    integration_platforms:
+      - nrf52840dk/nrf52840
+      - nrf54l15pdk/nrf54l15/cpuapp

--- a/subsys/logging/log_rpc_group.h
+++ b/subsys/logging/log_rpc_group.h
@@ -23,7 +23,7 @@ extern "C" {
 #ifdef CONFIG_NRF_RPC_IPC_SERVICE
 NRF_RPC_IPC_TRANSPORT(log_rpc_tr, DEVICE_DT_GET(DT_NODELABEL(ipc0)), "log_rpc_ept");
 #elif defined(CONFIG_NRF_RPC_UART_TRANSPORT)
-#define log_rpc_tr NRF_RPC_UART_TRANSPORT(DT_NODELABEL(uart1))
+#define log_rpc_tr NRF_RPC_UART_TRANSPORT(DT_CHOSEN(nordic_rpc_uart))
 #endif
 NRF_RPC_GROUP_DEFINE(log_rpc_group, "log", &log_rpc_tr, NULL, NULL, NULL);
 

--- a/subsys/mpsl/cx/software/mpsl_cx_software_rpc.c
+++ b/subsys/mpsl/cx/software/mpsl_cx_software_rpc.c
@@ -20,7 +20,7 @@
 #ifdef CONFIG_NRF_RPC_IPC_SERVICE
 NRF_RPC_IPC_TRANSPORT(mpsl_cx_rpc_tr, DEVICE_DT_GET(DT_NODELABEL(ipc0)), "mpsl_cx_rpc_ept");
 #elif defined(CONFIG_NRF_RPC_UART_TRANSPORT)
-#define mpsl_cx_rpc_tr NRF_RPC_UART_TRANSPORT(DT_NODELABEL(uart1))
+#define mpsl_cx_rpc_tr NRF_RPC_UART_TRANSPORT(DT_CHOSEN(nordic_rpc_uart))
 #endif
 NRF_RPC_GROUP_DEFINE(mpsl_cx_rpc_group, "mpsl_cx", &mpsl_cx_rpc_tr, NULL, NULL, NULL);
 


### PR DESCRIPTION
Commit adds config nesessary to compile nrf54l with `coex` and `log_rpc` snippets. Also adds former to sample.yml for twister build.