### PR TITLE
applications: nrf5340_audio: Improve PACS contents for BIS/CIS

### DIFF
--- a/applications/nrf5340_audio/broadcast_sink/Kconfig.defaults
+++ b/applications/nrf5340_audio/broadcast_sink/Kconfig.defaults
@@ -61,6 +61,19 @@ config NVS_LOG_LEVEL
 config BT_DEVICE_NAME
 	default "NRF5340_BIS_HEADSET"
 
+## PACS related configs ##
+config BT_PAC_SNK_NOTIFIABLE
+	default y
+
+config BT_PAC_SNK
+	default y
+
+config BT_PAC_SRC_NOTIFIABLE
+	default y
+
+config BT_PAC_SRC
+	default y
+
 ## Audio related configs ##
 config AUDIO_MUTE
 	default n

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/broadcast_sink.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/broadcast_sink.c
@@ -73,6 +73,8 @@ static struct bt_pacs_cap capabilities = {
 	.codec_cap = &codec_cap,
 };
 
+#define AVAILABLE_SINK_CONTEXT (BT_AUDIO_CONTEXT_TYPE_ANY)
+
 static le_audio_receive_cb receive_cb;
 
 static bool init_routine_completed;
@@ -657,6 +659,18 @@ int broadcast_sink_enable(le_audio_receive_cb recv_cb)
 		ret = bt_pacs_set_location(BT_AUDIO_DIR_SINK, BT_AUDIO_LOCATION_FRONT_LEFT);
 	} else {
 		ret = bt_pacs_set_location(BT_AUDIO_DIR_SINK, BT_AUDIO_LOCATION_FRONT_RIGHT);
+	}
+
+	ret = bt_pacs_set_supported_contexts(BT_AUDIO_DIR_SINK, AVAILABLE_SINK_CONTEXT);
+	if (ret) {
+		LOG_ERR("Supported context set failed. Err: %d", ret);
+		return ret;
+	}
+
+	ret = bt_pacs_set_available_contexts(BT_AUDIO_DIR_SINK, AVAILABLE_SINK_CONTEXT);
+	if (ret) {
+		LOG_ERR("Available context set failed. Err: %d", ret);
+		return ret;
 	}
 
 	if (ret) {

--- a/applications/nrf5340_audio/unicast_server/Kconfig.defaults
+++ b/applications/nrf5340_audio/unicast_server/Kconfig.defaults
@@ -64,13 +64,16 @@ config BT_MCC_SET_MEDIA_CONTROL_POINT
 	default y
 
 # For fixing compatibility issue with Android 14
+config BT_PAC_SNK
+	default y
+
 config BT_PAC_SNK_NOTIFIABLE
 	default y
 
 config BT_PAC_SRC
 	default y
 
-config BT_PAC_SNK
+config BT_PAC_SRC_NOTIFIABLE
 	default y
 
 config BT_CSIP_SET_MEMBER


### PR DESCRIPTION
Add available/support context type to PACS in broadcast sink. Enable BT_PAC_SRC_NOTIFIABLE for unicast client.
OCT-3089
Signed-off-by: Jui-Chou Chung <jui-chou.chung@nordicsemi.no>