### PR TITLE
samples: common: mcumgr_bt_ota_dfu: Remove speedup deps on child image

### DIFF
--- a/samples/common/mcumgr_bt_ota_dfu/Kconfig
+++ b/samples/common/mcumgr_bt_ota_dfu/Kconfig
@@ -106,7 +106,7 @@ endif # NCS_SAMPLE_MCUMGR_BT_OTA_DFU
 
 config NCS_SAMPLE_MCUMGR_BT_OTA_DFU_SPEEDUP
 	bool "MCUmgr OTA DFU speedup"
-	depends on BT_CTLR || (NCS_SAMPLE_HCI_IPC_CHILD_IMAGE || NCS_SAMPLE_MULTIPROTOCOL_RPMSG_CHILD_IMAGE)
+	depends on BT_CTLR || BT_HCI_HOST
 	help
 	  Enable this option to speed up the OTA DFU transfer over Bluetooth.
 	  This option extends the Bluetooth buffers to extend Bluetooth MTU


### PR DESCRIPTION
Removed dependency in the common MCUmgr BT OTA DFU speedup Kconfig option which is used only in child/parent build system. Now it will possible to use this option with the sysbuild.

Jira: NCSDK-28077