### PR TITLE
samples: bluetooth: fast_pair: locator_tag: Rework fp_adv module

### DIFF
--- a/samples/bluetooth/fast_pair/locator_tag/CMakeLists.txt
+++ b/samples/bluetooth/fast_pair/locator_tag/CMakeLists.txt
@@ -30,6 +30,8 @@ target_sources(app PRIVATE
 
 zephyr_linker_sources(SECTIONS src/factory_reset_callbacks.ld)
 
+zephyr_linker_sources(DATA_SECTIONS src/fp_adv_trigger.ld)
+
 if (NOT CONFIG_BT_FAST_PAIR_FMDN_RING_COMP_NONE)
   target_sources(app PRIVATE src/ring.c)
 endif()

--- a/samples/bluetooth/fast_pair/locator_tag/CMakeLists.txt
+++ b/samples/bluetooth/fast_pair/locator_tag/CMakeLists.txt
@@ -28,6 +28,8 @@ target_sources(app PRIVATE
   src/fp_adv.c
 )
 
+zephyr_linker_sources(SECTIONS src/factory_reset_callbacks.ld)
+
 if (NOT CONFIG_BT_FAST_PAIR_FMDN_RING_COMP_NONE)
   target_sources(app PRIVATE src/ring.c)
 endif()

--- a/samples/bluetooth/fast_pair/locator_tag/include/app_factory_reset.h
+++ b/samples/bluetooth/fast_pair/locator_tag/include/app_factory_reset.h
@@ -20,16 +20,32 @@
 extern "C" {
 #endif
 
-/** Callback type used to notify the user that the factory reset has been executed. */
-typedef void (*app_factory_reset_executed_cb)(void);
+/** Factory reset callback descriptor. */
+struct app_factory_reset_callbacks {
+	/** Callback used to allow the user to prepare for the factory reset. */
+	void (*prepare)(void);
+
+	/** Callback used to notify the user that the factory reset has been executed. */
+	void (*executed)(void);
+};
+
+/** Register a factory reset callback descriptor.
+ *
+ *  @param _name Factory reset callbacks descriptor name.
+ *  @param _prepare Callback to define actions before the factory reset.
+ *  @param _executed Callback to define actions after the factory reset.
+ */
+#define APP_FACTORY_RESET_CALLBACKS_REGISTER(_name, _prepare, _executed)		\
+	static const STRUCT_SECTION_ITERABLE(app_factory_reset_callbacks, _name) = {	\
+		.prepare = _prepare,							\
+		.executed = _executed,							\
+	}
 
 /** Schedule the factory reset action.
  *
  * @param delay Time to wait before the factory reset action is performed.
- * @param cb    Callback to define the prepare action before the factory reset.
  */
-void app_factory_reset_schedule(k_timeout_t delay,
-				app_factory_reset_executed_cb cb);
+void app_factory_reset_schedule(k_timeout_t delay);
 
 /** Cancel the scheduled factory reset action. */
 void app_factory_reset_cancel(void);

--- a/samples/bluetooth/fast_pair/locator_tag/include/app_fp_adv.h
+++ b/samples/bluetooth/fast_pair/locator_tag/include/app_fp_adv.h
@@ -32,11 +32,54 @@ enum app_fp_adv_mode {
 	APP_FP_ADV_MODE_NOT_DISCOVERABLE,
 };
 
-/** Set the Fast Pair advertising mode.
+/** Fast Pair advertising trigger. */
+struct app_fp_adv_trigger {
+	/* Identifier. */
+	const char *id;
+};
+
+/** Register a trigger for Fast Pair advertising.
  *
- * @param adv_mode Fast Pair advertising mode.
+ *  @param _name Trigger structure name.
+ *  @param _id Trigger identifier.
  */
-void app_fp_adv_mode_set(enum app_fp_adv_mode adv_mode);
+#define APP_FP_ADV_TRIGGER_REGISTER(_name, _id)				\
+	BUILD_ASSERT(_id != NULL);					\
+	static STRUCT_SECTION_ITERABLE(app_fp_adv_trigger, _name) = {	\
+		.id = _id,						\
+	}
+
+/** Request turning on the Fast Pair advertising.
+ *
+ *  The Fast Pair advertising will be turned off only when no
+ *  trigger has requested to keep the Fast Pair advertising on.
+ *
+ *  If the current Fast Pair advertising mode is the same as the requested mode,
+ *  the Fast Pair advertising payload will not be refreshed.
+ *  Use the @ref app_fp_adv_payload_refresh function to manually refresh
+ *  the Fast Pair advertising payload.
+ *
+ *  @param trigger Trigger identifier.
+ *  @param enable true to request to turn on the Fast Pair advertising.
+ *		  false to remove request to turn on the Fast Pair advertising.
+ */
+void app_fp_adv_request(struct app_fp_adv_trigger *trigger, bool enable);
+
+/** Refresh the Fast Pair advertising payload.
+ *
+ *  This function is used to manually trigger the refreshing of the Fast Pair
+ *  advertising data to ensure that the advertising data is up to date.
+ *
+ *  Use with caution, as it updates the Fast Pair advertising payload asynchronously
+ *  to the RPA address rotation and to the update of the FMDN advertising payload.
+ */
+void app_fp_adv_payload_refresh(void);
+
+/** Get the current Fast Pair advertising mode.
+ *
+ *  @return Current Fast Pair advertising mode.
+ */
+enum app_fp_adv_mode app_fp_adv_mode_get(void);
 
 /** Set the suspension mode for the RPA rotations of the Fast Pair advertising set.
  *
@@ -65,23 +108,39 @@ int app_fp_adv_id_set(uint8_t id);
  */
 uint8_t app_fp_adv_id_get(void);
 
-/** Uninitialize the Fast Pair advertising module.
- *
- * @return 0 if the operation was successful. Otherwise, a (negative) error code is returned.
- */
-int app_fp_adv_uninit(void);
-
 /** Initialize the Fast Pair advertising module.
  *
  * @return 0 if the operation was successful. Otherwise, a (negative) error code is returned.
  */
 int app_fp_adv_init(void);
 
-/** Check if the Fast Pair advertising module is initialized.
+/** Enable the Fast Pair advertising module.
  *
- *  @return true when the module is initialized, false otherwise.
+ *  Can be called after the Fast Pair advertising module has been initialized using the
+ *  @ref app_fp_adv_init function.
+ *  Must be called after enabling the Fast Pair subsystem using the @ref bt_fast_pair_enable
+ *  function.
+ *
+ *  @return 0 if the operation was successful. Otherwise, a (negative) error code is returned.
  */
-bool app_fp_adv_is_init(void);
+int app_fp_adv_enable(void);
+
+/** Disable the Fast Pair advertising module.
+ *
+ *  Can be called after the Fast Pair advertising module has been initialized using the
+ *  @ref app_fp_adv_init function.
+ *  Should be called before disabling the Fast Pair subsystem using the @ref bt_fast_pair_disable
+ *  function.
+ *
+ *  @return 0 if the operation was successful. Otherwise, a (negative) error code is returned.
+ */
+int app_fp_adv_disable(void);
+
+/** Check if the Fast Pair advertising module is ready.
+ *
+ *  @return true when the module is ready, false otherwise.
+ */
+bool app_fp_adv_is_ready(void);
 
 #ifdef __cplusplus
 }

--- a/samples/bluetooth/fast_pair/locator_tag/src/factory_reset.c
+++ b/samples/bluetooth/fast_pair/locator_tag/src/factory_reset.c
@@ -36,10 +36,8 @@ static bool factory_reset_ui_requested;
 
 int bt_fast_pair_factory_reset_user_action_perform(void)
 {
-	int err;
 	int id;
 	size_t id_count;
-	bool fp_adv_is_init = app_fp_adv_is_init();
 	uint8_t bt_id;
 
 	/* Please be extra careful while implementing this hook function, as it can be
@@ -49,15 +47,6 @@ int bt_fast_pair_factory_reset_user_action_perform(void)
 	 * will be propagated as a return value of the bt_fast_pair_enable API.
 	 */
 	LOG_INF("Factory Reset: resetting Bluetooth identity within the factory reset");
-
-	/* Uninitialize the Fast Pair advertising module if it is active. */
-	if (fp_adv_is_init) {
-		err = app_fp_adv_uninit();
-		if (err) {
-			LOG_ERR("Factory Reset: app_fp_adv_uninit failed (err %d)", err);
-			return err;
-		}
-	}
 
 	/* Check if FP identity exists. */
 	bt_id = app_fp_adv_id_get();
@@ -73,15 +62,6 @@ int bt_fast_pair_factory_reset_user_action_perform(void)
 		}
 	} else {
 		LOG_INF("Factory Reset: identity for factory reset does not exist");
-	}
-
-	/* Initialize the Fast Pair advertising module if it was active before the reset. */
-	if (fp_adv_is_init) {
-		err = app_fp_adv_init();
-		if (err) {
-			LOG_ERR("Factory Reset: app_fp_adv_init failed (err %d)", err);
-			return err;
-		}
 	}
 
 	return 0;
@@ -109,7 +89,7 @@ static void factory_reset_perform(void)
 {
 	int err;
 	bool fast_pair_is_ready = bt_fast_pair_is_ready();
-	bool fp_adv_is_init = app_fp_adv_is_init();
+	bool fp_adv_is_ready = app_fp_adv_is_ready();
 
 	LOG_INF("Performing reset to factory settings...");
 
@@ -122,20 +102,20 @@ static void factory_reset_perform(void)
 
 	factory_reset_prepare();
 
+	/* Disable the Fast Pair advertising module if it is active. */
+	if (fp_adv_is_ready) {
+		err = app_fp_adv_disable();
+		if (err) {
+			LOG_ERR("Factory Reset: app_fp_adv_disable failed (err %d)", err);
+			goto finish;
+		}
+	}
+
 	/* Disable the Fast Pair subsystem if it is active. */
 	if (fast_pair_is_ready) {
 		err = bt_fast_pair_disable();
 		if (err) {
 			LOG_ERR("Factory Reset: bt_fast_pair_disable failed: %d", err);
-			goto finish;
-		}
-	}
-
-	/* Uninitialize the Fast Pair advertising module if it is active. */
-	if (fp_adv_is_init) {
-		err = app_fp_adv_uninit();
-		if (err) {
-			LOG_ERR("Factory Reset: app_fp_adv_uninit failed (err %d)", err);
 			goto finish;
 		}
 	}
@@ -149,20 +129,20 @@ static void factory_reset_perform(void)
 		goto finish;
 	}
 
-	/* Initialize the Fast Pair advertising module if it was active before the reset. */
-	if (fp_adv_is_init) {
-		err = app_fp_adv_init();
-		if (err) {
-			LOG_ERR("Factory Reset: app_fp_adv_init failed (err %d)", err);
-			goto finish;
-		}
-	}
-
 	/* Reenable the Fast Pair subsystem. */
 	if (fast_pair_is_ready) {
 		err = bt_fast_pair_enable();
 		if (err) {
 			LOG_ERR("Factory Reset: bt_fast_pair_enable failed: %d", err);
+			goto finish;
+		}
+	}
+
+	/* Reenable the Fast Pair advertising module if it was active before the reset. */
+	if (fp_adv_is_ready) {
+		err = app_fp_adv_enable();
+		if (err) {
+			LOG_ERR("Factory Reset: app_fp_adv_enable failed (err %d)", err);
 			goto finish;
 		}
 	}

--- a/samples/bluetooth/fast_pair/locator_tag/src/factory_reset_callbacks.ld
+++ b/samples/bluetooth/fast_pair/locator_tag/src/factory_reset_callbacks.ld
@@ -1,0 +1,1 @@
+ITERABLE_SECTION_ROM(app_factory_reset_callbacks, 4)

--- a/samples/bluetooth/fast_pair/locator_tag/src/fp_adv.c
+++ b/samples/bluetooth/fast_pair/locator_tag/src/fp_adv.c
@@ -30,12 +30,18 @@ LOG_MODULE_DECLARE(fp_fmdn, LOG_LEVEL_INF);
 #define FP_RPA_TIMEOUT			(13 * FP_RPA_SEC_PER_MIN)
 #define FP_RPA_TIMEOUT_OFFSET_MAX	(2 * FP_RPA_SEC_PER_MIN)
 
+#define BITS_PER_VAR(_var)	(__CHAR_BIT__ * sizeof(_var))
+
+static bool is_initialized;
+static bool is_enabled;
+
 static bool fmdn_provisioned;
 
 static struct bt_conn *fp_conn;
 static struct bt_le_ext_adv *fp_adv_set;
 static bool fp_adv_rpa_rotation_suspended;
 static enum app_fp_adv_mode fp_adv_mode = APP_FP_ADV_MODE_OFF;
+static uint32_t fp_adv_request_bm;
 static const char * const fp_adv_mode_description[] = {
 	[APP_FP_ADV_MODE_OFF] = "disabled",
 	[APP_FP_ADV_MODE_DISCOVERABLE] = "discoverable",
@@ -170,7 +176,7 @@ static int fp_adv_payload_set(bool rpa_rotated, bool new_session)
 	return 0;
 }
 
-static int fp_adv_start_internal(void)
+static int bt_stack_advertising_update(void)
 {
 	int err;
 	struct bt_le_ext_adv_start_param ext_adv_start_param = {0};
@@ -200,7 +206,7 @@ static int fp_adv_start_internal(void)
 	return 0;
 }
 
-static void fp_advertising_start(void)
+static void fp_advertising_update(void)
 {
 	int err;
 
@@ -214,7 +220,7 @@ static void fp_advertising_start(void)
 		return;
 	}
 
-	err = fp_adv_start_internal();
+	err = bt_stack_advertising_update();
 	if (!err) {
 		app_ui_state_change_indicate(APP_UI_STATE_FP_ADV,
 					     (fp_adv_mode != APP_FP_ADV_MODE_OFF));
@@ -249,6 +255,8 @@ static bool fp_adv_rpa_expired(struct bt_le_ext_adv *adv)
 	 */
 	__ASSERT_NO_MSG(!k_is_preempt_thread());
 	__ASSERT_NO_MSG(!k_is_in_isr());
+
+	__ASSERT_NO_MSG(is_enabled);
 
 	LOG_INF("Fast Pair: RPA expired");
 
@@ -288,6 +296,7 @@ static bool fp_adv_rpa_expired(struct bt_le_ext_adv *adv)
 	}
 
 	if (fp_adv_mode != APP_FP_ADV_MODE_OFF) {
+		/* Update the advertising payload. */
 		err = fp_adv_payload_set(expire_rpa, false);
 		if (err) {
 			LOG_ERR("Fast Pair: cannot set advertising payload (err: %d)", err);
@@ -300,7 +309,6 @@ static bool fp_adv_rpa_expired(struct bt_le_ext_adv *adv)
 static int fp_adv_set_setup(void)
 {
 	int err;
-	struct bt_le_oob oob;
 	static const struct bt_le_ext_adv_cb fp_adv_set_cb = {
 		.connected = fp_adv_connected,
 		.rpa_expired = fp_adv_rpa_expired,
@@ -312,15 +320,6 @@ static int fp_adv_set_setup(void)
 	err = bt_le_ext_adv_create(&fp_adv_param, &fp_adv_set_cb, &fp_adv_set);
 	if (err) {
 		LOG_ERR("Fast Pair: bt_le_ext_adv_create returned error: %d", err);
-		return err;
-	}
-
-	/* Force the RPA rotation to synchronize the Fast Pair advertising
-	 * payload with its RPA address using rpa_expired callback.
-	 */
-	err = bt_le_oob_get_local(fp_adv_param.id, &oob);
-	if (err) {
-		LOG_ERR("Fast Pair: bt_le_oob_get_local failed: %d", err);
 		return err;
 	}
 
@@ -348,7 +347,7 @@ static int fp_adv_set_teardown(void)
 
 static void fp_adv_restart_work_handle(struct k_work *w)
 {
-	fp_advertising_start();
+	fp_advertising_update();
 }
 
 static void fp_adv_conn_clear(void)
@@ -405,24 +404,103 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 
 static void fp_adv_provisioning_state_changed(bool provisioned)
 {
+	struct bt_le_oob oob;
+	int err;
+
 	fmdn_provisioned = provisioned;
+
+	if (!provisioned) {
+		/* Force the RPA rotation to synchronize the Fast Pair advertising
+		 * payload with its RPA address using rpa_expired callback.
+		 */
+		err = bt_le_oob_get_local(fp_adv_param.id, &oob);
+		if (err) {
+			LOG_ERR("Fast Pair: bt_le_oob_get_local failed: %d", err);
+		}
+	}
 }
 
 static struct bt_fast_pair_fmdn_info_cb fmdn_info_cb = {
 	.provisioning_state_changed = fp_adv_provisioning_state_changed,
 };
 
-void app_fp_adv_mode_set(enum app_fp_adv_mode adv_mode)
+enum app_fp_adv_mode app_fp_adv_mode_get(void)
+{
+	return fp_adv_mode;
+}
+
+static uint8_t fp_adv_trigger_idx_get(struct app_fp_adv_trigger *trigger)
+{
+	__ASSERT_NO_MSG(trigger);
+
+	STRUCT_SECTION_START_EXTERN(app_fp_adv_trigger);
+	STRUCT_SECTION_END_EXTERN(app_fp_adv_trigger);
+
+	__ASSERT_NO_MSG((trigger >= STRUCT_SECTION_START(app_fp_adv_trigger)) &&
+			(trigger < STRUCT_SECTION_END(app_fp_adv_trigger)));
+	ARG_UNUSED(STRUCT_SECTION_END(app_fp_adv_trigger));
+
+	return (trigger - STRUCT_SECTION_START(app_fp_adv_trigger));
+}
+
+static void fp_adv_mode_set(enum app_fp_adv_mode adv_mode)
 {
 	fp_adv_mode = adv_mode;
 
 	if (!fp_conn) {
 		/* Support only one connection for the Fast Pair advertising set. */
-		fp_advertising_start();
+		fp_advertising_update();
 	} else {
 		LOG_INF("Fast Pair: automatically switched to %s advertising mode",
 			fp_adv_mode_description[fp_adv_mode]);
 		LOG_INF("Fast Pair: advertising inactive due to an active connection");
+	}
+}
+
+static void fp_adv_mode_update(void)
+{
+	bool has_account_key = bt_fast_pair_has_account_key();
+	bool is_any_request_enabled = (fp_adv_request_bm != 0);
+	enum app_fp_adv_mode requested_mode;
+
+	if (is_any_request_enabled) {
+		requested_mode = has_account_key ?
+				 APP_FP_ADV_MODE_NOT_DISCOVERABLE :
+				 APP_FP_ADV_MODE_DISCOVERABLE;
+	} else {
+		requested_mode = APP_FP_ADV_MODE_OFF;
+	}
+
+	/* Switch the advertising mode only on change. */
+	if (requested_mode != fp_adv_mode) {
+		LOG_INF("Fast Pair: advertising: %sabling", is_any_request_enabled ? "en" : "dis");
+		fp_adv_mode_set(requested_mode);
+	}
+}
+
+void app_fp_adv_request(struct app_fp_adv_trigger *trigger, bool enable)
+{
+	uint8_t idx = fp_adv_trigger_idx_get(trigger);
+	bool trigger_enabled = fp_adv_request_bm & BIT(idx);
+
+	if (trigger_enabled == enable) {
+		return;
+	}
+
+	WRITE_BIT(fp_adv_request_bm, idx, enable);
+
+	LOG_INF("Fast Pair: advertising request from trigger \"%s\": %sable",
+		trigger->id, enable ? "en" : "dis");
+
+	if (is_enabled) {
+		fp_adv_mode_update();
+	}
+}
+
+void app_fp_adv_payload_refresh(void)
+{
+	if (fp_adv_mode != APP_FP_ADV_MODE_OFF) {
+		fp_adv_mode_set(fp_adv_mode);
 	}
 }
 
@@ -431,52 +509,9 @@ void app_fp_adv_rpa_rotation_suspend(bool suspended)
 	fp_adv_rpa_rotation_suspended = suspended;
 }
 
-static void fp_adv_request_handle(enum app_ui_request request)
-{
-	/* It is assumed that the callback executes in the cooperative
-	 * thread context as it interacts with the FMDN API.
-	 */
-	__ASSERT_NO_MSG(!k_is_preempt_thread());
-	__ASSERT_NO_MSG(!k_is_in_isr());
-
-	if (!app_fp_adv_is_init()) {
-		return;
-	}
-
-	if (request == APP_UI_REQUEST_FP_ADV_MODE_CHANGE) {
-		bool has_account_key = bt_fast_pair_has_account_key();
-
-		if (has_account_key) {
-			switch (fp_adv_mode) {
-			case APP_FP_ADV_MODE_OFF:
-				fp_adv_mode = APP_FP_ADV_MODE_NOT_DISCOVERABLE;
-				break;
-			case APP_FP_ADV_MODE_NOT_DISCOVERABLE:
-				fp_adv_mode = APP_FP_ADV_MODE_OFF;
-				break;
-			default:
-				__ASSERT_NO_MSG(0);
-			}
-		} else {
-			switch (fp_adv_mode) {
-			case APP_FP_ADV_MODE_OFF:
-				fp_adv_mode = APP_FP_ADV_MODE_DISCOVERABLE;
-				break;
-			case APP_FP_ADV_MODE_DISCOVERABLE:
-				fp_adv_mode = APP_FP_ADV_MODE_OFF;
-				break;
-			default:
-				__ASSERT_NO_MSG(0);
-			}
-		}
-
-		fp_advertising_start();
-	}
-}
-
 int app_fp_adv_id_set(uint8_t id)
 {
-	if (app_fp_adv_is_init()) {
+	if (app_fp_adv_is_ready()) {
 		/* It is not possible to switch the Bluetooth identity
 		 * if Fast Pair advertising module is operational.
 		 */
@@ -493,12 +528,67 @@ uint8_t app_fp_adv_id_get(void)
 	return fp_adv_param.id;
 }
 
-int app_fp_adv_uninit(void)
+int app_fp_adv_init(void)
+{
+	int err;
+	int trigger_cnt;
+
+	err = bt_fast_pair_fmdn_info_cb_register(&fmdn_info_cb);
+	if (err) {
+		LOG_ERR("Fast Pair: bt_fast_pair_fmdn_info_cb_register returned error: %d", err);
+		return err;
+	}
+
+	STRUCT_SECTION_COUNT(app_fp_adv_trigger, &trigger_cnt);
+	__ASSERT_NO_MSG(trigger_cnt <= BITS_PER_VAR(fp_adv_request_bm));
+
+	is_initialized = true;
+
+	return 0;
+}
+
+int app_fp_adv_enable(void)
 {
 	int err;
 
-	app_fp_adv_mode_set(APP_FP_ADV_MODE_OFF);
-	app_fp_adv_rpa_rotation_suspend(false);
+	__ASSERT_NO_MSG(bt_fast_pair_is_ready());
+	__ASSERT_NO_MSG(is_initialized);
+
+	if (is_enabled) {
+		LOG_ERR("Fast Pair: fp_adv module already enabled");
+		return 0;
+	}
+
+	err = fp_adv_set_setup();
+	if (err) {
+		LOG_ERR("Fast Pair: fp_adv_set_setup failed (err %d)", err);
+		return err;
+	}
+
+	fp_adv_mode_update();
+
+	is_enabled = true;
+
+	LOG_INF("Fast Pair: fp_adv module enabled");
+
+	return 0;
+}
+
+int app_fp_adv_disable(void)
+{
+	int err;
+
+	__ASSERT_NO_MSG(is_initialized);
+
+	if (!is_enabled) {
+		LOG_ERR("Fast Pair: fp_adv module already disabled");
+		return 0;
+	}
+
+	is_enabled = false;
+
+	/* Suspend the requested advertising until the fp_adv module reinitializes. */
+	fp_adv_mode_set(APP_FP_ADV_MODE_OFF);
 
 	fp_adv_conn_clear();
 
@@ -508,31 +598,12 @@ int app_fp_adv_uninit(void)
 		return err;
 	}
 
-	return 0;
-}
-
-int app_fp_adv_init(void)
-{
-	int err;
-
-	err = bt_fast_pair_fmdn_info_cb_register(&fmdn_info_cb);
-	if (err) {
-		LOG_ERR("Fast Pair: bt_fast_pair_fmdn_info_cb_register returned error: %d", err);
-		return err;
-	}
-
-	err = fp_adv_set_setup();
-	if (err) {
-		LOG_ERR("Fast Pair: fp_adv_set_setup failed (err %d)", err);
-		return err;
-	}
+	LOG_INF("Fast Pair: fp_adv module disabled");
 
 	return 0;
 }
 
-bool app_fp_adv_is_init(void)
+bool app_fp_adv_is_ready(void)
 {
-	return (fp_adv_set != NULL);
+	return is_enabled;
 }
-
-APP_UI_REQUEST_LISTENER_REGISTER(fp_adv_request_handler, fp_adv_request_handle);

--- a/samples/bluetooth/fast_pair/locator_tag/src/fp_adv_trigger.ld
+++ b/samples/bluetooth/fast_pair/locator_tag/src/fp_adv_trigger.ld
@@ -1,0 +1,1 @@
+ITERABLE_SECTION_RAM(app_fp_adv_trigger, 4)

--- a/samples/bluetooth/fast_pair/locator_tag/src/main.c
+++ b/samples/bluetooth/fast_pair/locator_tag/src/main.c
@@ -74,9 +74,12 @@ static void fmdn_factory_reset_executed(void)
 	factory_reset_executed = true;
 }
 
+APP_FACTORY_RESET_CALLBACKS_REGISTER(factory_reset_cbs, NULL,
+				    fmdn_factory_reset_executed);
+
 static void fmdn_factory_reset_schedule(enum factory_reset_trigger trigger, k_timeout_t delay)
 {
-	app_factory_reset_schedule(delay, fmdn_factory_reset_executed);
+	app_factory_reset_schedule(delay);
 	factory_reset_trigger = trigger;
 }
 

--- a/samples/bluetooth/fast_pair/locator_tag/src/main.c
+++ b/samples/bluetooth/fast_pair/locator_tag/src/main.c
@@ -58,6 +58,18 @@ static bool fmdn_provisioned;
 static bool fmdn_recovery_mode;
 static bool fmdn_id_mode;
 static bool fp_account_key_present;
+static bool fp_adv_ui_request;
+
+/* Used to trigger the clock synchronization after the bootup if provisioned. */
+APP_FP_ADV_TRIGGER_REGISTER(fp_adv_trigger_clock_sync, "clock_sync");
+
+/* Used to wait for the FMDN provisioning procedure after the Account Key write. */
+APP_FP_ADV_TRIGGER_REGISTER(fp_adv_trigger_fmdn_provisioning, "fmdn_provisioning");
+
+/* Used to manually request the FP advertising by the user.
+ * Enabled by default on bootup if not provisioned.
+ */
+APP_FP_ADV_TRIGGER_REGISTER(fp_adv_trigger_ui, "ui");
 
 static bool factory_reset_executed;
 static enum factory_reset_trigger factory_reset_trigger;
@@ -67,6 +79,19 @@ static void init_work_handle(struct k_work *w);
 static K_SEM_DEFINE(init_work_sem, 0, 1);
 static K_WORK_DEFINE(init_work, init_work_handle);
 
+static void fmdn_factory_reset_prepare(void)
+{
+	/* Disable advertising requests related to the FMDN. */
+	app_fp_adv_request(&fp_adv_trigger_fmdn_provisioning, false);
+	app_fp_adv_request(&fp_adv_trigger_clock_sync, false);
+
+	/* Disable advertising request from the UI. */
+	fp_adv_ui_request = false;
+	app_fp_adv_request(&fp_adv_trigger_ui, fp_adv_ui_request);
+
+	app_fp_adv_rpa_rotation_suspend(false);
+}
+
 static void fmdn_factory_reset_executed(void)
 {
 	/* Clear the trigger state for the scheduled factory reset operations. */
@@ -74,7 +99,7 @@ static void fmdn_factory_reset_executed(void)
 	factory_reset_executed = true;
 }
 
-APP_FACTORY_RESET_CALLBACKS_REGISTER(factory_reset_cbs, NULL,
+APP_FACTORY_RESET_CALLBACKS_REGISTER(factory_reset_cbs, fmdn_factory_reset_prepare,
 				    fmdn_factory_reset_executed);
 
 static void fmdn_factory_reset_schedule(enum factory_reset_trigger trigger, k_timeout_t delay)
@@ -154,13 +179,14 @@ static void fp_account_key_written(struct bt_conn *conn)
 {
 	LOG_INF("Fast Pair: Account Key write");
 
-	app_fp_adv_mode_set(APP_FP_ADV_MODE_NOT_DISCOVERABLE);
-
-	/* Fast Pair Implementation Guidelines for the locator tag use case:
-	 * trigger the reset to factory settings if there is no FMDN
-	 * provisioning operation within 5 minutes.
-	 */
+	/* The first and only Account Key write starts the FMDN provisioning. */
 	if (!fp_account_key_present) {
+		app_fp_adv_request(&fp_adv_trigger_fmdn_provisioning, true);
+
+		/* Fast Pair Implementation Guidelines for the locator tag use case:
+		 * trigger the reset to factory settings if there is no FMDN
+		 * provisioning operation within 5 minutes.
+		 */
 		fmdn_factory_reset_schedule(
 			FACTORY_RESET_TRIGGER_PROVISIONING_TIMEOUT,
 			K_MINUTES(FMDN_PROVISIONING_TIMEOUT));
@@ -290,6 +316,9 @@ static void fmdn_mode_request_handle(enum app_ui_request request)
 		fmdn_recovery_mode_action_handle();
 	} else if (request == APP_UI_REQUEST_ID_MODE_ENTER) {
 		fmdn_id_mode_action_handle();
+	} else if (request == APP_UI_REQUEST_FP_ADV_MODE_CHANGE) {
+		fp_adv_ui_request = !fp_adv_ui_request;
+		app_fp_adv_request(&fp_adv_trigger_ui, fp_adv_ui_request);
 	}
 }
 
@@ -304,15 +333,24 @@ static void fmdn_clock_synced(void)
 		 * This lets the Seeker detect the device and synchronize the clock even
 		 * if a significant clock drift occurred.
 		 */
-		app_fp_adv_mode_set(APP_FP_ADV_MODE_OFF);
+		app_fp_adv_request(&fp_adv_trigger_clock_sync, false);
 	}
+}
+
+static bool fmdn_provisioning_state_is_first_cb_after_bootup(void)
+{
+	static bool first_cb_after_bootup = true;
+	bool is_first_cb_after_bootup = first_cb_after_bootup;
+
+	first_cb_after_bootup = false;
+
+	return is_first_cb_after_bootup;
 }
 
 static void fmdn_provisioning_state_changed(bool provisioned)
 {
-	static bool is_first_state_changed_cb = true;
-
-	enum app_fp_adv_mode fp_adv_mode;
+	bool clock_sync_required = fmdn_provisioning_state_is_first_cb_after_bootup() &&
+				   provisioned;
 
 	LOG_INF("FMDN: state changed to %s",
 		provisioned ? "provisioned" : "unprovisioned");
@@ -335,8 +373,6 @@ static void fmdn_provisioning_state_changed(bool provisioned)
 	 */
 	fp_account_key_present = bt_fast_pair_has_account_key();
 	if (fp_account_key_present != provisioned) {
-		app_fp_adv_mode_set(APP_FP_ADV_MODE_OFF);
-
 		/* Delay the factory reset operation to allow the local device
 		 * to send a response to the unprovisioning command and give
 		 * the connected peer necessary time to finalize its operations
@@ -345,32 +381,24 @@ static void fmdn_provisioning_state_changed(bool provisioned)
 		fmdn_factory_reset_schedule(
 			FACTORY_RESET_TRIGGER_KEY_STATE_MISMATCH,
 			K_SECONDS(FACTORY_RESET_DELAY));
-
 		return;
 	}
 
 	/* Triggered on the unprovisioning operation. */
 	if (factory_reset_executed) {
+		LOG_INF("The device has been reset to factory settings");
 		LOG_INF("Please press a button to put the device in the Fast Pair discoverable "
-			"advertising mode after a reset to factory settings");
-		factory_reset_executed = false;
+			"advertising mode");
 
+		factory_reset_executed = false;
 		return;
 	}
 
-	/* Select the Fast Pair advertising mode according to the FMDN provisioning state. */
-	if (provisioned) {
-		if (is_first_state_changed_cb) {
-			fp_adv_mode = APP_FP_ADV_MODE_NOT_DISCOVERABLE;
-		} else {
-			fp_adv_mode = APP_FP_ADV_MODE_OFF;
-		}
-	} else {
-		fp_adv_mode = APP_FP_ADV_MODE_DISCOVERABLE;
-	}
-	app_fp_adv_mode_set(fp_adv_mode);
+	app_fp_adv_request(&fp_adv_trigger_clock_sync, clock_sync_required);
+	app_fp_adv_request(&fp_adv_trigger_fmdn_provisioning, false);
 
-	is_first_state_changed_cb = false;
+	fp_adv_ui_request = !provisioned;
+	app_fp_adv_request(&fp_adv_trigger_ui, fp_adv_ui_request);
 }
 
 static struct bt_fast_pair_fmdn_info_cb fmdn_info_cb = {
@@ -382,15 +410,15 @@ static int fast_pair_prepare(void)
 {
 	int err;
 
-	err = app_fp_adv_id_set(APP_BT_ID);
-	if (err) {
-		LOG_ERR("Fast Pair: app_fp_adv_id_set failed (err %d)", err);
-		return err;
-	}
-
 	err = app_fp_adv_init();
 	if (err) {
 		LOG_ERR("Fast Pair: app_fp_adv_init failed (err %d)", err);
+		return err;
+	}
+
+	err = app_fp_adv_id_set(APP_BT_ID);
+	if (err) {
+		LOG_ERR("Fast Pair: app_fp_adv_id_set failed (err %d)", err);
 		return err;
 	}
 
@@ -542,6 +570,12 @@ static void init_work_handle(struct k_work *w)
 	err = bt_fast_pair_enable();
 	if (err) {
 		LOG_ERR("FMDN: bt_fast_pair_enable failed (err %d)", err);
+		return;
+	}
+
+	err = app_fp_adv_enable();
+	if (err) {
+		LOG_ERR("FMDN: app_fp_adv_enable failed (err %d)", err);
 		return;
 	}
 


### PR DESCRIPTION
Reworked fp_adv module so the triggers request the state of the advertising instead of setting it directly (works as a mediator).

Jira: NCSDK-28077

Depends on: 
+ https://github.com/nrfconnect/sdk-nrf/pull/16626