### PR TITLE
lib: modem: lte_net_if: Fix handling of missing IPv4

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -558,6 +558,7 @@ Modem libraries
 * :ref:`nrf_modem_lib_lte_net_if` library:
 
   * Added a log warning suggesting a SIM card to be installed if a UICC error is detected by the modem.
+  * Fixed a bug causing the cell network to be treated as offline if IPv4 is not assigned.
 
 * :ref:`modem_info_readme` library:
 

--- a/lib/nrf_modem_lib/lte_net_if/lte_net_if.c
+++ b/lib/nrf_modem_lib/lte_net_if/lte_net_if.c
@@ -195,21 +195,22 @@ static void on_pdn_activated(void)
 #if CONFIG_NET_IPV4
 	int ret;
 
+	/* If IPv4 is enabled, check whether modem has been assigned an IPv4. */
 	ret = lte_ipv4_addr_add(iface_bound);
+
 	if (ret == -ENODATA) {
 		LOG_WRN("No IPv4 address given by the network");
-		return;
 	} else if (ret) {
 		LOG_ERR("ipv4_addr_add, error: %d", ret);
 		fatal_error_notify_and_disconnect();
 		return;
 	}
 
-	update_has_pdn(true);
-
 #endif /* CONFIG_NET_IPV4 */
 
 	/* IPv6 is updated on a aseparate event */
+
+	update_has_pdn(true);
 }
 
 static void on_pdn_deactivated(void)
@@ -248,8 +249,6 @@ static void on_pdn_ipv6_up(void)
 		fatal_error_notify_and_disconnect();
 		return;
 	}
-
-	update_has_pdn(true);
 }
 
 static void on_pdn_ipv6_down(void)


### PR DESCRIPTION
Currently, if IPv4 is disabled or was not assigned, the cellular network is incorrectly treated as
offline, even if an IPv6 gets assigned.

This patch fixes this behavior.