### PR TITLE
samples: npm1300_one_button: Fix irq allocation for nRF52840 DK.

### DIFF
--- a/samples/pmic/native/npm1300_one_button/README.rst
+++ b/samples/pmic/native/npm1300_one_button/README.rst
@@ -66,7 +66,7 @@ To connect your DK to the nPM1300 EK, complete the following steps:
         - P0.31
       * - GPIO3
         - P0.22
-        - P0.22
+        - P1.12
         - P1.12
         - P0.10
       * - VDDIO

--- a/samples/pmic/native/npm1300_one_button/nrf52840dk_nrf52840.overlay
+++ b/samples/pmic/native/npm1300_one_button/nrf52840dk_nrf52840.overlay
@@ -17,6 +17,6 @@
 };
 
 &npm1300_ek_pmic {
-	host-int-gpios = <&gpio0 22 0>;
+	host-int-gpios = <&gpio1 12 0>;
 	pmic-int-pin = <3>;
 };


### PR DESCRIPTION
Pin allocation for PMIC interrupt output on nRF52840 DK has been fixed.  It was previously allocated to a pin that is not available on a pin header.