### PR TITLE
mpsl: fem: fix initial values to happify static analysis

### DIFF
--- a/subsys/mpsl/fem/simple_gpio/mpsl_fem_simple_gpio.c
+++ b/subsys/mpsl/fem/simple_gpio/mpsl_fem_simple_gpio.c
@@ -30,7 +30,7 @@ static int fem_simple_gpio_configure(void)
 	int err;
 
 #if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), ctx_gpios)
-	uint8_t ctx_gpiote_channel;
+	uint8_t ctx_gpiote_channel = MPSL_FEM_GPIOTE_INVALID_CHANNEL;
 	const nrfx_gpiote_t ctx_gpiote = NRFX_GPIOTE_INSTANCE(
 		NRF_DT_GPIOTE_INST(DT_NODELABEL(nrf_radio_fem), ctx_gpios));
 
@@ -40,7 +40,7 @@ static int fem_simple_gpio_configure(void)
 #endif
 
 #if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), crx_gpios)
-	uint8_t crx_gpiote_channel;
+	uint8_t crx_gpiote_channel = MPSL_FEM_GPIOTE_INVALID_CHANNEL;
 	const nrfx_gpiote_t crx_gpiote = NRFX_GPIOTE_INSTANCE(
 		NRF_DT_GPIOTE_INST(DT_NODELABEL(nrf_radio_fem), crx_gpios));
 


### PR DESCRIPTION
The vaiables `ctx_gpiote_channel` and `crx_gpiote_channel` were marked as uninitialized by static analysis tool.
There is no bug, because these values are set by successful call to `nrfx_gpiote_channel_alloc`. In case of failure the variables are not used.
This commit just makes static analysis happy.

Ticket: KRKNWK-19242