### PR TITLE
Bluetooth: Get rid of HCI boilerplate code for vendor specific commands

### DIFF
--- a/applications/nrf_desktop/src/modules/ble_qos.c
+++ b/applications/nrf_desktop/src/modules/ble_qos.c
@@ -16,8 +16,7 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/hci.h>
-
-#include "sdc_hci_vs.h"
+#include <bluetooth/hci_vs_sdc.h>
 
 #include "chmap_filter.h"
 
@@ -432,7 +431,7 @@ static bool on_vs_evt(struct net_buf_simple *buf)
 static void enable_qos_reporting(void)
 {
 	int err;
-	struct net_buf *buf;
+	sdc_hci_cmd_vs_qos_conn_event_report_enable_t cmd_enable;
 
 	err = bt_hci_register_vnd_evt_cb(on_vs_evt);
 	if (err) {
@@ -440,23 +439,11 @@ static void enable_qos_reporting(void)
 		return;
 	}
 
-	sdc_hci_cmd_vs_qos_conn_event_report_enable_t *cmd_enable;
+	cmd_enable.enable = 1;
 
-	buf = bt_hci_cmd_create(SDC_HCI_OPCODE_CMD_VS_QOS_CONN_EVENT_REPORT_ENABLE,
-				sizeof(*cmd_enable));
-	if (!buf) {
-		LOG_ERR("Failed to enable HCI VS QoS");
-		return;
-	}
-
-	cmd_enable = net_buf_add(buf, sizeof(*cmd_enable));
-	cmd_enable->enable = 1;
-
-	err = bt_hci_cmd_send_sync(
-		SDC_HCI_OPCODE_CMD_VS_QOS_CONN_EVENT_REPORT_ENABLE, buf, NULL);
+	err = hci_vs_sdc_qos_conn_event_report_enable(&cmd_enable);
 	if (err) {
 		LOG_ERR("Failed to enable HCI VS QoS");
-		return;
 	}
 }
 

--- a/samples/bluetooth/iso_time_sync/src/iso_tx.c
+++ b/samples/bluetooth/iso_time_sync/src/iso_tx.c
@@ -24,7 +24,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/bluetooth/iso.h>
-#include <sdc_hci_vs.h>
+#include <bluetooth/hci_vs_sdc.h>
 #include <sdc_hci.h>
 
 #include "iso_time_sync.h"
@@ -141,10 +141,8 @@ static int iso_tx_time_stamp_get(struct bt_conn *conn, uint32_t *time_stamp)
 {
 	int err;
 	uint16_t conn_handle = 0;
-	struct net_buf *buf;
-	struct net_buf *rsp_buf;
-	sdc_hci_cmd_vs_iso_read_tx_timestamp_t *params;
-	sdc_hci_cmd_vs_iso_read_tx_timestamp_return_t *rsp;
+	sdc_hci_cmd_vs_iso_read_tx_timestamp_t params;
+	sdc_hci_cmd_vs_iso_read_tx_timestamp_return_t rsp;
 
 	err = bt_hci_get_conn_handle(conn, &conn_handle);
 	if (err) {
@@ -152,25 +150,14 @@ static int iso_tx_time_stamp_get(struct bt_conn *conn, uint32_t *time_stamp)
 		return err;
 	}
 
-	buf = bt_hci_cmd_create(SDC_HCI_OPCODE_CMD_VS_ISO_READ_TX_TIMESTAMP, sizeof(*params));
-	if (!buf) {
-		printk("Unable to allocate buffer\n");
-		return -ENOMEM;
-	}
+	params.conn_handle = conn_handle;
 
-	params = net_buf_add(buf, sizeof(*params));
-	params->conn_handle = conn_handle;
-
-	err = bt_hci_cmd_send_sync(SDC_HCI_OPCODE_CMD_VS_ISO_READ_TX_TIMESTAMP, buf, &rsp_buf);
+	err = hci_vs_sdc_iso_read_tx_timestamp(&params, &rsp);
 	if (err) {
-		printk("Error while getting ISO Tx timestamp %d\n", err);
 		return err;
 	}
 
-	rsp = (void *)&rsp_buf->data[1];
-	*time_stamp = rsp->tx_time_stamp;
-
-	net_buf_unref(rsp_buf);
+	*time_stamp = rsp.tx_time_stamp;
 
 	return 0;
 }

--- a/subsys/bluetooth/host_extensions/host_extensions.c
+++ b/subsys/bluetooth/host_extensions/host_extensions.c
@@ -16,6 +16,10 @@
 #include <zephyr/bluetooth/hci.h>
 #include <../subsys/bluetooth/host/conn_internal.h>
 
+#if defined(CONFIG_BT_LL_SOFTDEVICE_HEADERS_INCLUDE)
+#include <bluetooth/hci_vs_sdc.h>
+#endif
+
 #if defined(CONFIG_BT_LL_SOFTDEVICE)
 #include <sdc_hci_vs.h>
 #endif /* CONFIG_BT_LL_SOFTDEVICE */
@@ -83,22 +87,13 @@ int bt_conn_set_power_control_request_params(struct bt_conn_set_pcr_params *para
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 int bt_nrf_host_extension_reduce_initator_aux_channel_priority(bool reduce)
 {
-	sdc_hci_cmd_vs_set_role_priority_t *cmd;
-	struct net_buf *buf;
+	sdc_hci_cmd_vs_set_role_priority_t cmd;
 
-	buf = bt_hci_cmd_create(SDC_HCI_OPCODE_CMD_VS_SET_ROLE_PRIORITY, sizeof(*cmd));
-	if (!buf) {
-		return -ENOBUFS;
-	}
+	cmd.handle_type = SDC_HCI_VS_SET_ROLE_PRIORITY_HANDLE_TYPE_INITIATOR_SECONDARY_CHANNEL;
+	cmd.handle = 0x0;
+	cmd.priority = reduce ? 5 : 0xff;
 
-	cmd = net_buf_add(buf, sizeof(*cmd));
-	*cmd = (sdc_hci_cmd_vs_set_role_priority_t) {
-	  .handle_type = SDC_HCI_VS_SET_ROLE_PRIORITY_HANDLE_TYPE_INITIATOR_SECONDARY_CHANNEL,
-	  .handle = 0x0,
-	  .priority = reduce ? 5 : 0xff
-	};
-
-	return bt_hci_cmd_send_sync(SDC_HCI_OPCODE_CMD_VS_SET_ROLE_PRIORITY, buf, NULL);
+	return hci_vs_sdc_set_role_priority(&cmd);
 }
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
 #endif /* CONFIG_BT_LL_SOFTDEVICE */

--- a/subsys/caf/modules/ble_state.c
+++ b/subsys/caf/modules/ble_state.c
@@ -14,9 +14,8 @@
 #include <zephyr/bluetooth/hci.h>
 
 #include <caf/events/ble_common_event.h>
-
 #ifdef CONFIG_CAF_BLE_USE_LLPM
-#include "sdc_hci_vs.h"
+#include <bluetooth/hci_vs_sdc.h>
 #endif /* CONFIG_CAF_BLE_USE_LLPM */
 
 #define MODULE ble_state
@@ -313,15 +312,11 @@ static void bt_ready(int err)
 	LOG_INF("Bluetooth initialized");
 
 #ifdef CONFIG_CAF_BLE_USE_LLPM
-	sdc_hci_cmd_vs_llpm_mode_set_t *p_cmd_enable;
+	sdc_hci_cmd_vs_llpm_mode_set_t cmd_enable;
 
-	struct net_buf *buf = bt_hci_cmd_create(SDC_HCI_OPCODE_CMD_VS_LLPM_MODE_SET,
-						sizeof(*p_cmd_enable));
+	cmd_enable.enable = 1;
 
-	p_cmd_enable = net_buf_add(buf, sizeof(*p_cmd_enable));
-	p_cmd_enable->enable = 1;
-
-	err = bt_hci_cmd_send_sync(SDC_HCI_OPCODE_CMD_VS_LLPM_MODE_SET, buf, NULL);
+	err = hci_vs_sdc_llpm_mode_set(&cmd_enable);
 	if (err) {
 		LOG_ERR("Error enabling LLPM (err: %d)", err);
 	} else {


### PR DESCRIPTION
The new header `hci_vs_sdc.h` provides APIs that wraps handling of HCI commands creating code that is simpler to understand and maintain. This PR updates some existing code to use these APIs.