### PR TITLE
Bluetooth: Expose API to obtain connection event anchor point

### DIFF
--- a/include/bluetooth/hci_vs_sdc.h
+++ b/include/bluetooth/hci_vs_sdc.h
@@ -392,6 +392,16 @@ int hci_vs_sdc_scan_accept_ext_adv_packets_set(
  */
 int hci_vs_sdc_set_role_priority(const sdc_hci_cmd_vs_set_role_priority_t *params);
 
+/** @brief Set Event Start Task.
+ *
+ * For the complete API description, see sdc_hci_cmd_vs_set_event_start_task().
+ *
+ * @param[in]  params Input parameters.
+ *
+ * @return 0 on success or negative error value on failure.
+ */
+int hci_vs_sdc_set_event_start_task(const sdc_hci_cmd_vs_set_event_start_task_t *params);
+
 /** @brief Connection Anchor_Point Update Event Reports enable.
  *
  * For the complete API description,

--- a/include/bluetooth/hci_vs_sdc.h
+++ b/include/bluetooth/hci_vs_sdc.h
@@ -392,6 +392,18 @@ int hci_vs_sdc_scan_accept_ext_adv_packets_set(
  */
 int hci_vs_sdc_set_role_priority(const sdc_hci_cmd_vs_set_role_priority_t *params);
 
+/** @brief Connection Anchor_Point Update Event Reports enable.
+ *
+ * For the complete API description,
+ * see sdc_hci_cmd_vs_conn_anchor_point_update_event_report_enable().
+ *
+ * @param[in]  params Input parameters.
+ *
+ * @return 0 on success or negative error value on failure.
+ */
+int hci_vs_sdc_conn_anchor_point_update_event_report_enable(
+	const sdc_hci_cmd_vs_conn_anchor_point_update_event_report_enable_t *params);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -394,6 +394,17 @@ config BT_CTLR_SDC_EVENT_TRIGGER
 	  When used for connections, the connection event trigger can be configured to trigger
 	  every N connection events starting from a given connection event counter.
 
+config BT_CTLR_SDC_CONN_ANCHOR_POINT_REPORT
+	bool "Connection event anchor point reports"
+	depends on BT_CONN
+	help
+	  Enable support for obtaining connection anchor point reports.
+	  This is a proprietary SDC feature which allows the controller
+	  to produce timestamps for ACL connection anchor points.
+	  A new timestamp is generated whenever a connection's anchor point changes.
+	  The reporting is enabled through an HCI command.
+	  See Core_v5.4, Vol 6, Part B, Section 4.5.1.
+
 config BT_CTLR_SDC_ISO_RX_PDU_BUFFER_PER_STREAM_COUNT
 	int "BT_CTLR_SDC_ISO_RX_PDU_BUFFER_PER_STREAM_COUNT"
 	depends on BT_CTLR_SYNC_ISO || BT_CTLR_CONN_ISO

--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -1695,9 +1695,14 @@ static uint8_t vs_cmd_put(uint8_t const *const cmd, uint8_t *const raw_event_out
 		return sdc_hci_cmd_vs_scan_accept_ext_adv_packets_set(
 			(sdc_hci_cmd_vs_scan_accept_ext_adv_packets_set_t const *)cmd_params);
 #endif
-		case SDC_HCI_OPCODE_CMD_VS_SET_ROLE_PRIORITY:
-			return sdc_hci_cmd_vs_set_role_priority(
-				(sdc_hci_cmd_vs_set_role_priority_t const *) cmd_params);
+	case SDC_HCI_OPCODE_CMD_VS_SET_ROLE_PRIORITY:
+		return sdc_hci_cmd_vs_set_role_priority(
+			(sdc_hci_cmd_vs_set_role_priority_t const *) cmd_params);
+#if defined(CONFIG_BT_CTLR_SDC_CONN_ANCHOR_POINT_REPORT)
+	case SDC_HCI_OPCODE_CMD_VS_CONN_ANCHOR_POINT_UPDATE_EVENT_REPORT_ENABLE:
+		return sdc_hci_cmd_vs_conn_anchor_point_update_event_report_enable(
+		(sdc_hci_cmd_vs_conn_anchor_point_update_event_report_enable_t const *)cmd_params);
+#endif
 	default:
 		return BT_HCI_ERR_UNKNOWN_CMD;
 	}

--- a/subsys/bluetooth/hci_vs_sdc.c
+++ b/subsys/bluetooth/hci_vs_sdc.c
@@ -325,3 +325,11 @@ int hci_vs_sdc_set_role_priority(const sdc_hci_cmd_vs_set_role_priority_t *param
 				 params,
 				 sizeof(*params));
 }
+
+int hci_vs_sdc_conn_anchor_point_update_event_report_enable(
+	const sdc_hci_cmd_vs_conn_anchor_point_update_event_report_enable_t *params)
+{
+	return hci_vs_cmd_no_rsp(SDC_HCI_OPCODE_CMD_VS_CONN_ANCHOR_POINT_UPDATE_EVENT_REPORT_ENABLE,
+				 params,
+				 sizeof(*params));
+}

--- a/subsys/bluetooth/hci_vs_sdc.c
+++ b/subsys/bluetooth/hci_vs_sdc.c
@@ -326,6 +326,13 @@ int hci_vs_sdc_set_role_priority(const sdc_hci_cmd_vs_set_role_priority_t *param
 				 sizeof(*params));
 }
 
+int hci_vs_sdc_set_event_start_task(const sdc_hci_cmd_vs_set_event_start_task_t *params)
+{
+	return hci_vs_cmd_no_rsp(SDC_HCI_OPCODE_CMD_VS_SET_EVENT_START_TASK,
+				 params,
+				 sizeof(*params));
+}
+
 int hci_vs_sdc_conn_anchor_point_update_event_report_enable(
 	const sdc_hci_cmd_vs_conn_anchor_point_update_event_report_enable_t *params)
 {


### PR DESCRIPTION
This is a proprietary SDC feature which allows the controller to produce reports for all ACL connections whenever	  a connection anchor point is updated. The reporting is enabled through a HCI command.

This information can be utilized for time synchronization between a central and peripheral.