### PR TITLE
cracen: Fix handling of key_bits=0

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/blkcipher.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/blkcipher.c
@@ -213,19 +213,24 @@ static bool is_alg_supported(psa_algorithm_t alg, const psa_key_attributes_t *at
 		}
 		break;
 	case PSA_ALG_CBC_NO_PADDING:
-		IF_ENABLED(PSA_NEED_CRACEN_CBC_NO_PADDING_AES, (is_supported = true));
+		IF_ENABLED(PSA_NEED_CRACEN_CBC_NO_PADDING_AES,
+			   (is_supported = psa_get_key_type(attributes) == PSA_KEY_TYPE_AES));
 		break;
 	case PSA_ALG_CBC_PKCS7:
-		IF_ENABLED(PSA_NEED_CRACEN_CBC_PKCS7_AES, (is_supported = true));
+		IF_ENABLED(PSA_NEED_CRACEN_CBC_PKCS7_AES,
+			   (is_supported = psa_get_key_type(attributes) == PSA_KEY_TYPE_AES));
 		break;
 	case PSA_ALG_CTR:
-		IF_ENABLED(PSA_NEED_CRACEN_CTR_AES, (is_supported = true));
+		IF_ENABLED(PSA_NEED_CRACEN_CTR_AES,
+			   (is_supported = psa_get_key_type(attributes) == PSA_KEY_TYPE_AES));
 		break;
 	case PSA_ALG_ECB_NO_PADDING:
-		IF_ENABLED(PSA_NEED_CRACEN_ECB_NO_PADDING_AES, (is_supported = true));
+		IF_ENABLED(PSA_NEED_CRACEN_ECB_NO_PADDING_AES,
+			   (is_supported = psa_get_key_type(attributes) == PSA_KEY_TYPE_AES));
 		break;
 	case PSA_ALG_OFB:
-		IF_ENABLED(PSA_NEED_CRACEN_OFB_AES, (is_supported = true));
+		IF_ENABLED(PSA_NEED_CRACEN_OFB_AES,
+			   (is_supported = psa_get_key_type(attributes) == PSA_KEY_TYPE_AES));
 		break;
 	default:
 		is_supported = false;
@@ -565,10 +570,10 @@ psa_status_t cracen_cipher_finish(cracen_cipher_operation_t *operation, uint8_t 
 	 */
 	if (IS_ENABLED(PSA_NEED_CRACEN_ECB_NO_PADDING_AES)) {
 		if (operation->alg == PSA_ALG_ECB_NO_PADDING) {
-			return cracen_cipher_crypt_ecb(
-				&operation->keyref, operation->unprocessed_input,
-				operation->unprocessed_input_bytes, output, output_size,
-				output_length, operation->dir);
+			return cracen_cipher_crypt_ecb(&operation->keyref,
+						       operation->unprocessed_input,
+						       operation->unprocessed_input_bytes, output,
+						       output_size, output_length, operation->dir);
 		}
 	}
 

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/key_derivation.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/key_derivation.c
@@ -313,12 +313,7 @@ psa_status_t cracen_key_derivation_set_capacity(cracen_key_derivation_operation_
 	}
 
 	operation->capacity = capacity;
-	/* The capacity changes when the output bytes are derived, but L must not change, therefore
-	 * saving it separately
-	 */
-	if (operation->alg == PSA_ALG_SP800_108_COUNTER_CMAC) {
-		operation->cmac_ctr.L = uint32_to_be(PSA_BYTES_TO_BITS(operation->capacity));
-	}
+
 	return PSA_SUCCESS;
 }
 
@@ -808,6 +803,11 @@ cracen_key_derivation_cmac_ctr_generate_K_0(cracen_key_derivation_operation_t *o
 {
 	struct sxmac cmac_ctx;
 	int sx_status;
+
+	/* The capacity changes when the output bytes are derived, but L must not change, therefore
+	 * saving it separately
+	 */
+	operation->cmac_ctr.L = uint32_to_be(PSA_BYTES_TO_BITS(operation->capacity));
 
 	sx_status = sx_mac_create_aescmac(&cmac_ctx, &operation->cmac_ctr.keyref);
 	if (sx_status) {


### PR DESCRIPTION
PSA specifies that key bits should be determined from the key buffer when bits=0 is specified in attributes at import.

test_crypto: PR-646