### PR TITLE
bluetooth: fast_pair: fmdn: improve fmdn adv set lifetime management

### DIFF
--- a/include/bluetooth/services/fast_pair/fmdn.h
+++ b/include/bluetooth/services/fast_pair/fmdn.h
@@ -373,6 +373,10 @@ struct bt_fast_pair_fmdn_adv_param {
  *  Fast Pair with the @ref bt_fast_pair_enable API. Otherwise, the default
  *  value @ref BT_FAST_PAIR_FMDN_ADV_PARAM_DEFAULT is used for advertising.
  *
+ *  In the Fast Pair disabled state, advertising parameters are accepted
+ *  without any validation but are subsequently validated during the
+ *  @ref bt_fast_pair_enable API call.
+ *
  *  You can use this function to dynamically update advertising parameters
  *  during an ongoing FMDN advertising.
  *


### PR DESCRIPTION
Improved management of the FMDN advertising set lifetime in the FMDN extension of the Fast Pair library. The advertising set is now allocated during the bt_fast_pair_enable operation and released during the bt_fast_pair_disable operation.

Ref: NCSDK-22229