### PR TITLE
net: lib: nrf_cloud_coap: binary log support

### DIFF
--- a/doc/nrf/libraries/networking/nrf_cloud_log.rst
+++ b/doc/nrf/libraries/networking/nrf_cloud_log.rst
@@ -56,7 +56,7 @@ Supported backends
 ==================
 
 When so configured, this library includes a Zephyr logging backend that can transport log messages to nRF Cloud using REST, MQTT, or CoAP.
-The logging backend can also use either JSON messages or dictionary-based compact binary messages (binary messages are only supported with MQTT and REST).
+The logging backend can also use either JSON messages or dictionary-based compact binary messages.
 
 Multiple JSON log messages are sent together as a JSON array to the `d2c/bulk device message topic <nRF Cloud MQTT Topics_>`_.
 The nRF Cloud backend splits the array into individual JSON messages for display.
@@ -100,7 +100,7 @@ Configure one of the following Kconfig options to select the data transport meth
 
 Configure the message encoding:
 
-* :kconfig:option:`CONFIG_LOG_BACKEND_NRF_CLOUD_OUTPUT_TEXT` or :kconfig:option:`CONFIG_LOG_BACKEND_NRF_CLOUD_OUTPUT_DICTIONARY` (MQTT or REST only)
+* :kconfig:option:`CONFIG_LOG_BACKEND_NRF_CLOUD_OUTPUT_TEXT` or :kconfig:option:`CONFIG_LOG_BACKEND_NRF_CLOUD_OUTPUT_DICTIONARY`
 
 See `Dictionary-based Logging`_ to learn how dictionary-based logging works, how the dictionary is built, and how to decode the binary log output.
 Dictionary logs are compact binary log messages that require decoding using an offline script.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -718,6 +718,7 @@ Libraries for networking
 * :ref:`lib_nrf_cloud_log` library:
 
   * Added support for dictionary logs using REST.
+  * Added support for dictionary (binary) logs when connected to nRF Cloud using CoAP.
 
 Libraries for NFC
 -----------------

--- a/include/net/nrf_cloud_coap.h
+++ b/include/net/nrf_cloud_coap.h
@@ -409,7 +409,8 @@ int nrf_cloud_coap_shadow_delta_process(const struct nrf_cloud_data *in_data,
 					struct nrf_cloud_obj *const delta_out);
 
 /**
- * @brief Send raw bytes to nRF Cloud.
+ * @brief Send raw bytes to nRF Cloud on the /msg/d2c/raw topic. The data sent can be for any
+ * purpose.
  *
  * @param[in]     buf buffer with binary string.
  * @param[in]     buf_len  length of buf in bytes.

--- a/subsys/net/lib/nrf_cloud/coap/include/nrf_cloud_coap_transport.h
+++ b/subsys/net/lib/nrf_cloud/coap/include/nrf_cloud_coap_transport.h
@@ -246,6 +246,21 @@ int nrf_cloud_coap_patch(const char *resource, const char *query,
 			 enum coap_content_format fmt, bool reliable,
 			 coap_client_response_cb_t cb, void *user);
 
+/**
+ * @brief Send binary log data to nRF Cloud on the /msg/d2c/bin topic. The data sent should
+ * come from the nrf_cloud_log_backend. It will be assembled in sequential order and made
+ * available for download by the nRF Cloud REST API or website.
+ *
+ * @param[in]     buf buffer with binary string.
+ * @param[in]     buf_len  length of buf in bytes.
+ * @param[in]     confirmable Select whether to use a CON or NON CoAP transfer.
+ * @return 0 If successful, nonzero if failed.
+ *           Negative values are device-side errors defined in errno.h.
+ *           Positive values are cloud-side errors (CoAP result codes)
+ *           defined in zephyr/net/coap.h.
+ */
+int nrf_cloud_coap_bin_log_send(const uint8_t * const buf, size_t buf_len, bool confirmable);
+
 /** @} */
 
 #ifdef __cplusplus

--- a/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap.c
+++ b/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap.c
@@ -246,6 +246,22 @@ int nrf_cloud_coap_bytes_send(uint8_t *buf, size_t buf_len, bool confirmable)
 	return err;
 }
 
+int nrf_cloud_coap_bin_log_send(const uint8_t * const buf, size_t buf_len, bool confirmable)
+{
+	int err = 0;
+
+	if (!nrf_cloud_coap_is_connected()) {
+		return -EACCES;
+	}
+
+	err = nrf_cloud_coap_post(COAP_D2C_BIN_RSC, NULL, buf, buf_len,
+				  COAP_CONTENT_FORMAT_APP_OCTET_STREAM, confirmable, NULL, NULL);
+	if (err) {
+		LOG_ERR("Failed to send POST request: %d", err);
+	}
+	return err;
+}
+
 int nrf_cloud_coap_obj_send(struct nrf_cloud_obj *const obj, bool confirmable)
 {
 	if (!nrf_cloud_coap_is_connected()) {


### PR DESCRIPTION
Send binary (dictionary) logs over CoAP to d2c/bin.

Jira: IRIS-9388