### PR TITLE
samples: wifi: ble_coex: Add missing tag

### DIFF
--- a/samples/wifi/ble_coex/sample.yaml
+++ b/samples/wifi/ble_coex/sample.yaml
@@ -50,7 +50,7 @@ tests:
                 CONFIG_MPSL_CX=y ipc_radio_CONFIG_MPSL_CX=y
                 CONFIG_COEX_SEP_ANTENNAS=y
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: sysbuild ci_samples_wifi
+    tags: ci_build sysbuild ci_samples_wifi
   sample.nrf7002_eb.thingy53.ble_coex:
     sysbuild: true
     build_only: true


### PR DESCRIPTION
Add mising ci_build tag for nRF7001 EK.