### PR TITLE
sysbuild: Add warning if variables are set too late to be used

### DIFF
--- a/cmake/sysbuild/modules/ncs_sysbuild_extensions.cmake
+++ b/cmake/sysbuild/modules/ncs_sysbuild_extensions.cmake
@@ -28,12 +28,23 @@ function(ExternalNcsVariantProject_Add)
     BUILD_ONLY true
   )
 
+  # Add duplicate image names for checking if variables have been set too late
+  list(APPEND SYSBUILD_NCS_VARIANT_IMAGE_NAMES "${VBUILD_VARIANT};${VBUILD_APPLICATION}")
+  set(SYSBUILD_NCS_VARIANT_IMAGE_NAMES ${SYSBUILD_NCS_VARIANT_IMAGE_NAMES} PARENT_SCOPE)
+
   get_cmake_property(sysbuild_cache CACHE_VARIABLES)
   foreach(var_name ${sysbuild_cache})
     if("${var_name}" MATCHES "^(${VBUILD_APPLICATION}_.*)$")
       string(LENGTH "${VBUILD_APPLICATION}" tmplen)
       string(SUBSTRING "${var_name}" ${tmplen} -1 tmp)
       set(${VBUILD_VARIANT}${tmp} "${${var_name}}" CACHE UNINITIALIZED "" FORCE)
+
+      # Add duplicate variables so that these can be checked to see if they have been changed
+      # after having been used
+      list(APPEND SYSBUILD_NCS_VARIANT_IMAGE_VAR_${VBUILD_APPLICATION}_${var_name} "${${var_name}}")
+      set(SYSBUILD_NCS_VARIANT_IMAGE_VAR_${VBUILD_APPLICATION}_${var_name} ${SYSBUILD_NCS_VARIANT_IMAGE_VAR_${VBUILD_APPLICATION}_${var_name}} PARENT_SCOPE)
+      list(APPEND SYSBUILD_NCS_VARIANT_IMAGE_VAR_${VBUILD_VARIANT}_${VBUILD_VARIANT}${tmp} "${${var_name}}")
+      set(SYSBUILD_NCS_VARIANT_IMAGE_VAR_${VBUILD_VARIANT}_${VBUILD_VARIANT}${tmp} ${SYSBUILD_NCS_VARIANT_IMAGE_VAR_${VBUILD_VARIANT}${tmp}} PARENT_SCOPE)
     endif()
   endforeach()
 

--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -518,6 +518,23 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_post_cmake)
       set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${BINARY_DIR}/zephyr/.config)
     endif()
   endif()
+
+  # Check if variant image variables have been set too late
+  foreach(check_images ${SYSBUILD_NCS_VARIANT_IMAGE_NAMES})
+    get_cmake_property(sysbuild_cache CACHE_VARIABLES)
+    foreach(var_name ${sysbuild_cache})
+      if("${var_name}" MATCHES "^(${check_images}_.*)$")
+        if(NOT "${${var_name}}" STREQUAL "${SYSBUILD_NCS_VARIANT_IMAGE_VAR_${check_images}_${var_name}}")
+          message(WARNING "
+    WARNING: Variable ${var_name} has been set too late.
+    Original used value: ${SYSBUILD_NCS_VARIANT_IMAGE_VAR_${check_images}_${var_name}}
+    Current value: ${${var_name}}
+    This is likely to cause issues with variant image configuration diverging from the base image.
+   ")
+        endif()
+      endif()
+    endforeach()
+  endforeach()
 endfunction(${SYSBUILD_CURRENT_MODULE_NAME}_post_cmake)
 
 # Enable use of partition manager with sysbuild.


### PR DESCRIPTION
Adds a warning to notify users about NCSDK-28495 whereby configuration might be set for one image too late and not used when variant images are configured, this can cause variant images to have diverging, and incompatible configuration