### PR TITLE
Bluetooth: Remove core spec version number from refs

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/bt_management/bt_mgmt.h
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/bt_mgmt.h
@@ -199,7 +199,7 @@ int bt_mgmt_pa_sync_delete(struct bt_le_per_adv_sync *pa_sync);
  *
  * @param[in]	conn	Connection to disconnect.
  * @param[in]	reason	Reason code for the disconnection, as specified in
- *			HCI Error Codes, BT Core Spec v5.4 [Vol 1, Part F].
+ *			HCI Error Codes, BT Core Spec [Vol 1, Part F].
  *
  * @return	0 if success, error otherwise.
  */

--- a/doc/nrf/glossary.rst
+++ b/doc/nrf/glossary.rst
@@ -51,7 +51,7 @@ Glossary
 
    Attribute Protocol (ATT)
       "[It] allows a device referred to as the server to expose a set of attributes and their associated values to a peer device referred to as the client."
-      `Bluetooth Core Specification`_, Version 5.3, Vol 3, Part F, Section 1.1.
+      `Bluetooth Core Specification`_, Vol 3, Part F, Section 1.1.
 
    AT command
       A command used to control the modem.
@@ -349,11 +349,11 @@ Glossary
    Generic Access Profile (GAP)
       A base profile that all Bluetooth devices implement.
       It defines the basic requirements of a Bluetooth device.
-      See `Bluetooth Core Specification`_, Version 5.3, Vol 1, Part A, Section 6.2.
+      See `Bluetooth Core Specification`_, Vol 1, Part A, Section 6.2.
 
    Generic Attribute Profile (GATT)
       "Generic Attribute Profile (GATT) is built on top of the Attribute Protocol (ATT) and establishes common operations and a framework for the data transported and stored by the Attribute Protocol."
-      `Bluetooth Core Specification`_, Version 5.3, Vol 1, Part A, Section 6.4.2.
+      `Bluetooth Core Specification`_, Vol 1, Part A, Section 6.4.2.
 
    Global Navigation Satellite System (GNSS)
       A satellite navigation system with global coverage.
@@ -462,14 +462,14 @@ Glossary
 
    Link Layer (LL)
       "A control protocol for the link and physical layers that is carried over logical links in addition to user data."
-      `Bluetooth Core Specification`_, Version 5.3, Vol 1, Part A, Section 1.2.
+      `Bluetooth Core Specification`_, Vol 1, Part A, Section 1.2.
       It is implemented in the Bluetooth LE Controller layer.
 
    Logical Link Control and Adaptation Protocol (L2CAP)
       A protocol used within the Bluetooth protocol stack.
       "[It] provides a channel-based abstraction to applications and services.
       It carries out segmentation and reassembly of application data and multiplexing and de-multiplexing of multiple channels over a shared logical link."
-      `Bluetooth Core Specification`_, Version 5.3, Vol 1, Part A, Section 1.1.
+      `Bluetooth Core Specification`_, Vol 1, Part A, Section 1.1.
 
    Low-density parity-check (LDPC)
       A class of error correcting codes that may be employed for providing error correction of transmission errors in communication systems.

--- a/include/bluetooth/nrf/host_extensions.h
+++ b/include/bluetooth/nrf/host_extensions.h
@@ -61,7 +61,7 @@ struct bt_conn_set_pcr_params {
 	 */
 	uint16_t beta;
 	/** The lower limit of the RSSI golden range. The RSSI golden range is explained in
-	 *  Core_v5.4, Vol 6, Part B, Section 5.1.17.1.
+	 *  Bluetooth Core Specification, Vol 6, Part B, Section 5.1.17.1.
 	 *  Default value is -70 dBm.
 	 */
 	int8_t lower_limit;

--- a/include/bluetooth/radio_notification_cb.h
+++ b/include/bluetooth/radio_notification_cb.h
@@ -68,8 +68,9 @@ struct bt_radio_notification_conn_cb {
  * The Bluetooth specification allows a worst case clock accurary of 500 ppm.
  * That gives a worst case combined clock accurary of 1000 ppm.
  * This results in 1 ms drift per second.
-
- * See Bluetooth Core_v5.4, Vol 6, Part 4.2.4 for more details on clock drift.
+ *
+ * See Bluetooth Core Specification, Vol 6, Part B, Section 4.2.4
+ * for more details on clock drift.
  *
  * @param[in] cb                  The callback structure to be used.
  *                                The memory pointed to needs to be kept alive by the user.

--- a/samples/bluetooth/direct_test_mode/README.rst
+++ b/samples/bluetooth/direct_test_mode/README.rst
@@ -7,7 +7,7 @@ Bluetooth: Direct Test Mode
    :local:
    :depth: 2
 
-This sample enables the Direct Test Mode functions described in `Bluetooth® Core Specification <Bluetooth Core Specification_>`_: Version 5.2, Vol. 6, Part F.
+This sample enables the Direct Test Mode functions described in `Bluetooth® Core Specification <Bluetooth Core Specification_>`_ (Vol. 6, Part F).
 
 Requirements
 ************

--- a/samples/bluetooth/direct_test_mode/src/dtm.c
+++ b/samples/bluetooth/direct_test_mode/src/dtm.c
@@ -1744,8 +1744,8 @@ static uint32_t dtm_packet_interval_calculate(uint32_t test_payload_length,
 	uint32_t overhead_bits = 0;
 
 	/* Packet overhead
-	 * see BLE [Vol 6, Part F] page 213
-	 * 4.1 LE TEST PACKET FORMAT
+	 * see Bluetooth Core Specification [Vol 6, Part F]
+	 * Section 4.1 LE TEST PACKET FORMAT
 	 */
 	if (mode == NRF_RADIO_MODE_BLE_2MBIT) {
 		/* 16 preamble
@@ -2292,8 +2292,8 @@ int dtm_test_transmit(uint8_t channel, uint8_t length, enum dtm_packet pkt)
 	radio_prepare(TX_MODE);
 
 	/* Set the timer to the correct period. The delay between each
-	 * packet is described in the Bluetooth Core Spsification
-	 * version 4.2 Vol. 6 Part F Section 4.1.6.
+	 * packet is described in the Bluetooth Core Specification,
+	 * Vol. 6 Part F Section 4.1.6.
 	 */
 	nrfx_timer_extended_compare(&dtm_inst.timer, NRF_TIMER_CC_CHANNEL0,
 			dtm_packet_interval_calculate(dtm_inst.packet_len, dtm_inst.radio_mode),

--- a/samples/bluetooth/direction_finding_connectionless_rx/src/main.c
+++ b/samples/bluetooth/direction_finding_connectionless_rx/src/main.c
@@ -14,7 +14,8 @@
 #define DEVICE_NAME CONFIG_BT_DEVICE_NAME
 #define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
 #define PEER_NAME_LEN_MAX 30
-/* BT Core 5.3 specification allows controller to wait 6 periodic advertising events for
+/* The Bluetooth Core specification allows controller to wait 6
+ * periodic advertising events for
  * synchronization establishment, hence timeout must be longer than that.
  */
 #define SYNC_CREATE_TIMEOUT_INTERVAL_NUM 7

--- a/samples/bluetooth/iso_time_sync/src/cis_central.c
+++ b/samples/bluetooth/iso_time_sync/src/cis_central.c
@@ -188,7 +188,7 @@ void cis_central_start(bool do_tx, uint8_t retransmission_number, uint16_t max_t
 		 * connection. The CIS central starts scanning for a new connection only after a
 		 * pending CIS connection has completed. This must be done because the
 		 * LE HCI Create CIS command is disallowed while a CIS connection is
-		 * pending. See Core Specification Version 5.4, Vol 6, Part B, section 7.8.99.
+		 * pending. See Bluetooth Core Specification, Vol 6, Part B, Section 7.8.99.
 		 */
 		iso_tx_init(retransmission_number, &scan_start);
 	} else {

--- a/samples/bluetooth/iso_time_sync/src/iso_tx.c
+++ b/samples/bluetooth/iso_time_sync/src/iso_tx.c
@@ -313,7 +313,7 @@ static uint32_t trigger_time_us_get(uint32_t sdu_sync_ref, uint8_t chan_index)
 
 	/* The ISO type determines when to trigger the LED
 	 * because of how the SDU synchronization reference is defined.
-	 * See Core_v5.4, Vol 6, Part G, Section 3.2.
+	 * See Bluetooth Core Specification, Vol 6, Part G, Section 3.2.
 	 */
 
 	if (iso_infos[chan_index].type == BT_ISO_CHAN_TYPE_CONNECTED) {

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -168,7 +168,7 @@ config BT_CTLR_SDC_CONN_EVENT_EXTEND_DEFAULT
 	  When Extended Connection Events are enabled, the controller
 	  will extend the connection event as much as possible, if
 	  - Either of the peers has more data to send.
-	    See also: Core v5.6, Vol 6, Part B, Section 4.5.6.
+	    See also: Bluetooth Core Specification, Vol 6, Part B, Section 4.5.6.
 	  - There are no conflicts with other roles of equal or higher priority.
 
 config BT_CTLR_SDC_CENTRAL_ACL_EVENT_SPACING_DEFAULT
@@ -403,7 +403,7 @@ config BT_CTLR_SDC_CONN_ANCHOR_POINT_REPORT
 	  to produce timestamps for ACL connection anchor points.
 	  A new timestamp is generated whenever a connection's anchor point changes.
 	  The reporting is enabled through an HCI command.
-	  See Core_v5.4, Vol 6, Part B, Section 4.5.1.
+	  See Bluetooth Core Specification, Vol 6, Part B, Section 4.5.1.
 
 config BT_CTLR_SDC_ISO_RX_PDU_BUFFER_PER_STREAM_COUNT
 	int "BT_CTLR_SDC_ISO_RX_PDU_BUFFER_PER_STREAM_COUNT"

--- a/subsys/bluetooth/controller/ecdh.c
+++ b/subsys/bluetooth/controller/ecdh.c
@@ -38,7 +38,7 @@ enum {
 
 static atomic_t cmd;
 
-/* based on Core Specification 4.2 Vol 3. Part H 2.3.5.6.1 */
+/* Based on Bluetooth Core Specification, Vol 3. Part H, Section 2.3.5.6.1 */
 static const uint8_t debug_private_key_be[32] = {
 	0x3f, 0x49, 0xf6, 0xd4, 0xa3, 0xc5, 0x5f, 0x38,
 	0x74, 0xc9, 0xb3, 0xe3, 0xd2, 0x10, 0x3f, 0x50,

--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -120,7 +120,8 @@ static bool check_and_handle_is_host_using_legacy_and_extended_commands(uint8_t 
 	return false;
 #else
 	/* A host is not allowed to use both legacy and extended HCI commands.
-	 * See Core v5.1, Vol2, Part E, 3.1.1 Legacy and extended advertising
+	 * See Bluetooth Core Specification, Vol 2, Part E, Section 3.1.1 -
+	 * Legacy and extended advertising.
 	 */
 	static enum type_of_adv_cmd type_of_adv_cmd_used_since_reset = ADV_COMMAND_TYPE_NONE;
 	enum type_of_adv_cmd type_of_adv_cmd_needed = ADV_COMMAND_TYPE_NONE;

--- a/subsys/bluetooth/services/mds.c
+++ b/subsys/bluetooth/services/mds.c
@@ -64,7 +64,7 @@ LOG_MODULE_REGISTER(mds, CONFIG_BT_MDS_LOG_LEVEL);
 #define STREAM_ENABLED BIT(0)
 
 /* Application error code defined by the MDS.
- * According to BLE Core v5.3 Vol 3, Part F 3.4.1.
+ * According to Bluetooth Core Specification, Vol 3, Part F, Section 3.4.1.
  */
 enum mds_att_error {
 	MDS_ATT_ERROR_CLIENT_ALREADY_SUBSCRIBED = 0x80,
@@ -422,8 +422,8 @@ static size_t chunk_data_length_get(struct bt_conn *conn)
 		return 0;
 	}
 
-	/* According to BLE Core v5.3 Vol 3, Part F 3.4.7.1 maximum supported length of the
-	 * notification is (ATT_MTU - 3).
+	/* According to Bluetooth Core Specification (Vol 3, Part F, Section 3.4.7.1),
+	 * maximum supported length of the notification is (ATT_MTU - 3).
 	 */
 	length -= att_header_length;
 	length -= sizeof(struct mds_data_export_nfy);


### PR DESCRIPTION
The section numbers do not change between revisions, therefore we can safely remove them.
By removing them we also avoid having to update
code when a new spec comes out.

References were found by looking for the regex pattern `Core[_ ]v?[45]`.