### PR TITLE
bluetooth: rpc: include shell Kconfig

### DIFF
--- a/subsys/bluetooth/rpc/Kconfig
+++ b/subsys/bluetooth/rpc/Kconfig
@@ -183,5 +183,6 @@ source "$(ZEPHYR_BASE)/subsys/bluetooth/services/Kconfig"
 source "$(ZEPHYR_BASE)/subsys/bluetooth/common/Kconfig"
 source "$(ZEPHYR_BASE)/subsys/bluetooth/host/Kconfig"
 source "$(ZEPHYR_BASE)/subsys/bluetooth/crypto/Kconfig"
+source "$(ZEPHYR_BASE)/subsys/bluetooth/shell/Kconfig"
 
 endif # BT_RPC_STACK

--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: protocols_serialization_2
+      revision: a56fee6870e152b71a7baf5b85bfa0b9746286a0
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Include Bluetooth shell Kconfig when Bluetooth RPC stack is built.