### PR TITLE
doc: BLE peripheral_uart - fix linking to sample extensions section

### DIFF
--- a/samples/bluetooth/peripheral_uart/README.rst
+++ b/samples/bluetooth/peripheral_uart/README.rst
@@ -178,8 +178,6 @@ Building and running
 
 .. include:: /includes/nRF54H20_erase_UICR.txt
 
-.. _peripheral_uart_sample_activating_variants:
-
 Experimental Bluetooth Low Energy Remote Procedure Call interface
 =================================================================
 
@@ -188,6 +186,8 @@ To build the sample with a :ref:`ble_rpc` interface, use the following command:
 .. code-block:: console
 
    west build samples/bluetooth/peripheral_uart -b board_name --sysbuild -S nordic-bt-rpc -- -DFILE_SUFFIX=bt_rpc
+
+.. _peripheral_uart_sample_activating_variants:
 
 Activating sample extensions
 ============================


### PR DESCRIPTION
Several subsections in the sample README.txt used to link to "Activating sample extensions" section that discribe how to build this sample in different configuration variants. The addition of a specific BLE RPC subsection made the links point to the new section instead of the correct one ("Activating...")