### PR TITLE
sysbuild: Split variant image logic

### DIFF
--- a/cmake/sysbuild/modules/ncs_sysbuild_extensions.cmake
+++ b/cmake/sysbuild/modules/ncs_sysbuild_extensions.cmake
@@ -33,4 +33,7 @@ function(ExternalNcsVariantProject_Add)
     -DCONFIG_NCS_IS_VARIANT_IMAGE=y
     -DPRELOAD_BINARY_DIR=${${VBUILD_APPLICATION}_BINARY_DIR}
   )
+
+  # Configure variant image after application so that the configuration is present
+  sysbuild_add_dependencies(CONFIGURE ${VBUILD_VARIANT} ${VBUILD_APPLICATION})
 endfunction()

--- a/cmake/sysbuild/modules/ncs_sysbuild_extensions.cmake
+++ b/cmake/sysbuild/modules/ncs_sysbuild_extensions.cmake
@@ -28,16 +28,7 @@ function(ExternalNcsVariantProject_Add)
     BUILD_ONLY true
   )
 
-  get_cmake_property(sysbuild_cache CACHE_VARIABLES)
-  foreach(var_name ${sysbuild_cache})
-    if("${var_name}" MATCHES "^(${VBUILD_APPLICATION}_.*)$")
-      string(LENGTH "${VBUILD_APPLICATION}" tmplen)
-      string(SUBSTRING "${var_name}" ${tmplen} -1 tmp)
-      set(${VBUILD_VARIANT}${tmp} "${${var_name}}" CACHE UNINITIALIZED "" FORCE)
-    endif()
-  endforeach()
-
-  ExternalProject_Get_Property(${VBUILD_VARIANT} BINARY_DIR)
+  set_property(TARGET ${VBUILD_VARIANT} PROPERTY NCS_VARIANT_APPLICATION ${VBUILD_APPLICATION})
   set_property(TARGET ${VBUILD_VARIANT} APPEND PROPERTY _EP_CMAKE_ARGS
     -DCONFIG_NCS_IS_VARIANT_IMAGE=y
     -DPRELOAD_BINARY_DIR=${${VBUILD_APPLICATION}_BINARY_DIR}

--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -406,6 +406,22 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
   endif()
 endfunction(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
 
+function(${SYSBUILD_CURRENT_MODULE_NAME}_pre_image_cmake)
+  cmake_parse_arguments(PRE_IMAGE_CMAKE "" "IMAGE" "" ${ARGN})
+
+  get_property(variant_app TARGET ${PRE_IMAGE_CMAKE_IMAGE} PROPERTY NCS_VARIANT_APPLICATION)
+  if(NOT "${variant_app}" STREQUAL "")
+    set(variant_image ${PRE_IMAGE_CMAKE_IMAGE})
+
+    get_cmake_property(sysbuild_cache CACHE_VARIABLES)
+    foreach(var_name ${sysbuild_cache})
+      if("${var_name}" MATCHES "^${variant_app}_(.*)$")
+        set(${variant_image}_${CMAKE_MATCH_1} "${${var_name}}" CACHE UNINITIALIZED "" FORCE)
+      endif()
+    endforeach()
+  endif()
+endfunction(${SYSBUILD_CURRENT_MODULE_NAME}_pre_image_cmake)
+
 # Sysbuild function hooks used by nRF Connect SDK
 function(${SYSBUILD_CURRENT_MODULE_NAME}_post_cmake)
   cmake_parse_arguments(POST_CMAKE "" "" "IMAGES" ${ARGN})

--- a/sysbuild/mcuboot.cmake
+++ b/sysbuild/mcuboot.cmake
@@ -7,9 +7,6 @@ if(SB_CONFIG_MCUBOOT_BUILD_DIRECT_XIP_VARIANT)
   set(image mcuboot_secondary_app)
   ExternalNcsVariantProject_Add(APPLICATION ${DEFAULT_IMAGE} VARIANT ${image})
 
-  # Configure variant image after application so that the configuration is present
-  sysbuild_add_dependencies(CONFIGURE mcuboot_secondary_app ${DEFAULT_IMAGE})
-
   set_property(GLOBAL APPEND PROPERTY
       PM_APP_IMAGES
       "${image}"


### PR DESCRIPTION
A variant image copies several properties of the original image. This includes cache variables, which should be copied as late as possible, because more of these variables can be set during sysbuild processing - for example, through the original image's `sysbuild.cmake`, which may be sourced after `ExternalNcsVariantProject_Add()` was already called.

The latest possible point in sysbuild would be a PRE_IMAGE_CMAKE hook before the variant image is configured. Create this hook in NCS and move the relevant logic there.

Ref: NCSDK-28495