### PR TITLE
Bluetooth: Mesh: add metadata to missing models

### DIFF
--- a/include/bluetooth/mesh/light_hsl_srv.h
+++ b/include/bluetooth/mesh/light_hsl_srv.h
@@ -62,8 +62,6 @@ struct bt_mesh_light_hsl_srv;
 						 _srv),                        \
 			 &_bt_mesh_light_hsl_setup_srv_cb)
 
-
-#ifdef CONFIG_BT_MESH_LARGE_COMP_DATA_SRV
 /** Light HSL Hue Range Metadata ID. */
 #define BT_MESH_LIGHT_HSL_HUE_RANGE_METADATA_ID 0x0005
 
@@ -89,7 +87,6 @@ struct bt_mesh_light_hsl_srv;
 #define BT_MESH_LIGHT_HSL_SAT_RANGE_METADATA(range_min, range_max)                                 \
 	BT_MESH_MODELS_METADATA_ENTRY(4, BT_MESH_LIGHT_HSL_SAT_RANGE_METADATA_ID,                  \
 				      ((uint16_t[]){(range_min), (range_max)}))
-#endif
 
 /**
  * Light HSL Server instance.

--- a/include/bluetooth/mesh/light_temp_srv.h
+++ b/include/bluetooth/mesh/light_temp_srv.h
@@ -61,7 +61,6 @@ struct bt_mesh_light_temp_srv;
 		BT_MESH_MODEL_USER_DATA(struct bt_mesh_light_temp_srv, _srv),  \
 		&_bt_mesh_light_temp_srv_cb, __VA_ARGS__)
 
-#ifdef CONFIG_BT_MESH_LARGE_COMP_DATA_SRV
 /** Light CTL Temperature Range Metadata ID. */
 #define BT_MESH_LIGHT_CTL_TEMP_RANGE_METADATA_ID 0x0004
 
@@ -74,7 +73,6 @@ struct bt_mesh_light_temp_srv;
 #define BT_MESH_LIGHT_CTL_TEMP_RANGE_METADATA(range_min, range_max)                                \
 	BT_MESH_MODELS_METADATA_ENTRY(4, BT_MESH_LIGHT_CTL_TEMP_RANGE_METADATA_ID,                 \
 				      ((uint16_t[]){(range_min), (range_max)}))
-#endif
 
 /** Light CTL Temperature Server state access handlers. */
 struct bt_mesh_light_temp_srv_handlers {

--- a/include/bluetooth/mesh/lightness_srv.h
+++ b/include/bluetooth/mesh/lightness_srv.h
@@ -68,7 +68,6 @@ struct bt_mesh_lightness_srv;
 						 _srv),                        \
 			 &_bt_mesh_lightness_setup_srv_cb)
 
-#ifdef CONFIG_BT_MESH_LARGE_COMP_DATA_SRV
 /** The Light Purpose Metadata ID. */
 #define BT_MESH_LIGHT_PURPOSE_METADATA_ID 0x0002
 
@@ -93,7 +92,6 @@ struct bt_mesh_lightness_srv;
 #define BT_MESH_LIGHT_LIGHTNESS_RANGE_METADATA(range_min, range_max)                               \
 	BT_MESH_MODELS_METADATA_ENTRY(4, BT_MESH_LIGHT_LIGHTNESS_RANGE_METADATA_ID,                \
 				      ((uint16_t[]){(range_min), (range_max)}))
-#endif
 
 /** Collection of handler callbacks for the Light Lightness Server. */
 struct bt_mesh_lightness_srv_handlers {

--- a/include/bluetooth/mesh/sensor_srv.h
+++ b/include/bluetooth/mesh/sensor_srv.h
@@ -44,19 +44,35 @@ struct bt_mesh_sensor_srv;
  *  @brief Sensor Server model composition data entry.
  *
  *  @param[in] _srv Pointer to a @ref bt_mesh_sensor_srv instance.
+ *  @param ...      Optional Light Lightness Server metadata if application is
+ *                  compiled with Large Composition Data Server support,
+ *                  otherwise this parameter is ignored.
  */
-#define BT_MESH_MODEL_SENSOR_SRV(_srv)                                         \
-	BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_SENSOR_SRV, _bt_mesh_sensor_srv_op,  \
-			 &(_srv)->pub,                                         \
+#define BT_MESH_MODEL_SENSOR_SRV(_srv, ...)                                    \
+	BT_MESH_MODEL_METADATA_CB(BT_MESH_MODEL_ID_SENSOR_SRV,                 \
+			 _bt_mesh_sensor_srv_op, &(_srv)->pub,                 \
 			 BT_MESH_MODEL_USER_DATA(struct bt_mesh_sensor_srv,    \
 						 _srv),                        \
-			 &_bt_mesh_sensor_srv_cb),                             \
+			 &_bt_mesh_sensor_srv_cb, __VA_ARGS__),                \
 	BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_SENSOR_SETUP_SRV,                    \
 			 _bt_mesh_sensor_setup_srv_op,                         \
 			 &(_srv)->setup_pub,                                   \
 			 BT_MESH_MODEL_USER_DATA(struct bt_mesh_sensor_srv,    \
 					      _srv),                           \
 			 &_bt_mesh_sensor_setup_srv_cb)
+
+/** Sensor Properties Metadata ID. */
+#define BT_MESH_SENSOR_PROP_METADATA_ID 0x0001
+
+/**
+ *  Sensor Properties Metadata entry.
+ *
+ *  @param[in] ... list of 16-bit sensor property IDs split by comma.
+ */
+#define BT_MESH_SENSOR_PROP_METADATA(...)                                                          \
+	BT_MESH_MODELS_METADATA_ENTRY(2 * ARRAY_SIZE(((uint16_t[]){__VA_ARGS__})),                 \
+				      BT_MESH_SENSOR_PROP_METADATA_ID,                             \
+				      ((uint16_t[]){__VA_ARGS__}))
 
 /** Sensor server instance. */
 struct bt_mesh_sensor_srv {

--- a/include/bluetooth/mesh/time_srv.h
+++ b/include/bluetooth/mesh/time_srv.h
@@ -46,18 +46,45 @@ struct tm;
  * @brief Time Server model composition data entry.
  *
  * @param[in] _srv Pointer to a @ref bt_mesh_time_srv instance.
+ * @param ...	   Optional Time Server metadata if application is
+ *		   compiled with Large Composition Data Server support,
+ *		   otherwise this parameter is ignored.
  */
-#define BT_MESH_MODEL_TIME_SRV(_srv)                                           \
-	BT_MESH_MODEL_CB(                                                      \
+#define BT_MESH_MODEL_TIME_SRV(_srv, ...)                                      \
+	BT_MESH_MODEL_METADATA_CB(                                             \
 		BT_MESH_MODEL_ID_TIME_SRV, _bt_mesh_time_srv_op, &(_srv)->pub, \
 		BT_MESH_MODEL_USER_DATA(struct bt_mesh_time_srv, _srv),        \
-		&_bt_mesh_time_srv_cb),                                        \
+		&_bt_mesh_time_srv_cb, __VA_ARGS__),                           \
 	BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_TIME_SETUP_SRV,                      \
 		_bt_mesh_time_setup_srv_op,                                    \
 		&(_srv)->setup_pub,                                            \
 		BT_MESH_MODEL_USER_DATA(                                       \
 		struct bt_mesh_time_srv, _srv),                                \
 		&_bt_mesh_time_setup_srv_cb)
+
+/** Clock Accuracy Metadata ID. */
+#define BT_MESH_CLOCK_ACCURACY_METADATA_ID 0x0007
+
+/** Timekeeping Reserve Metadata ID. */
+#define BT_MESH_TIMEKEEPING_RESERVE_METADATA_ID 0x0008
+
+/**
+ *  Clock Accuracy Metadata entry.
+ *
+ *  @param clock_accuracy 24-bit clock accuracy value.
+ */
+#define BT_MESH_CLOCK_ACCURACY_METADATA(clock_accuracy)                                            \
+	BT_MESH_MODELS_METADATA_ENTRY(3, BT_MESH_CLOCK_ACCURACY_METADATA_ID,                       \
+				      ((uint8_t[]){BT_BYTES_LIST_LE24(clock_accuracy)}))
+
+/**
+ *  Timekeeping Reserve Metadata entry.
+ *
+ *  @param timekeeping_reserve 24-bit timekeeping reserve value.
+ */
+#define BT_MESH_TIMEKEEPING_RESERVE_METADATA(timekeeping_reserve)                                  \
+	BT_MESH_MODELS_METADATA_ENTRY(3, BT_MESH_TIMEKEEPING_RESERVE_METADATA_ID,                  \
+				      ((uint8_t[]){BT_BYTES_LIST_LE24(timekeeping_reserve)}))
 
 /** Time srv update types */
 enum bt_mesh_time_update_types {


### PR DESCRIPTION
This commit adds metadata to the Sensor Server, and Time Server models in form of an optional parameter.

Note: Metadata is only supported if the Large Composition Data Server model is supported.