### PR TITLE
Bluetooth: Controller: Fix reading uninitialized memory

### DIFF
--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -1849,7 +1849,7 @@ int hci_internal_msg_get(uint8_t *msg_out, sdc_hci_msg_type_t *msg_type_out)
 	const int retval = sdc_hci_get(msg_out, msg_type_out);
 
 #if defined(CONFIG_BT_CTLR_SDC_PAWR_SYNC)
-	if (*msg_type_out == SDC_HCI_MSG_TYPE_EVT
+	if (retval == 0 && *msg_type_out == SDC_HCI_MSG_TYPE_EVT
 		&& msg_out[0] == BT_HCI_EVT_CMD_COMPLETE) {
 		padv_response_data_cmd_pending = false;
 	}


### PR DESCRIPTION
If sdc_hci_get did not have an event we were reading uninitialized memory.