### PR TITLE
applications: nrf_desktop: doc: align Fast Pair demo model for mouse

### DIFF
--- a/applications/nrf_desktop/description.rst
+++ b/applications/nrf_desktop/description.rst
@@ -925,7 +925,7 @@ See :ref:`app_build_file_suffixes` and :ref:`cmake_options` for information abou
       * Device Name: NCS gaming mouse
       * Model ID: ``0x8E717D``
       * Anti-Spoofing Private Key (base64, uncompressed): ``dZxFzP7X9CcfLPC0apyRkmgsh3n2EbWo9NFNXfVuxAM=``
-      * Device Type: Input Device
+      * Device Type: Mouse
       * Notification Type: Fast Pair
       * Data-Only connection: true
       * No Personalized Name: false


### PR DESCRIPTION
Aligned the Fast Pair model for mouse in the  nRF Desktop application with the Google Nearby Console configuration.