### PR TITLE
applications: serial_lte_modem: Disable TF-M logs

### DIFF
--- a/applications/serial_lte_modem/overlay-ppp-without-cmux.conf
+++ b/applications/serial_lte_modem/overlay-ppp-without-cmux.conf
@@ -9,6 +9,3 @@
 # Ensure that HW RX byte counting is enabled for the PPP UART. This especially matters at higher baud rates.
 CONFIG_UART_1_NRF_HW_ASYNC=y
 CONFIG_UART_1_NRF_HW_ASYNC_TIMER=1
-
-# Disable TFM logging as UART1 is needed by the non-secure application.
-CONFIG_TFM_LOG_LEVEL_SILENCE=y

--- a/applications/serial_lte_modem/prj.conf
+++ b/applications/serial_lte_modem/prj.conf
@@ -108,6 +108,10 @@ CONFIG_MQTT_CLEAN_SESSION=y
 CONFIG_AT_CMD_PARSER=y
 CONFIG_AT_MONITOR=y
 
+# Disable TF-M logging.
+# TF-M log sending will block until remote end is ready, when HWFC is used on UART1.
+CONFIG_TFM_LOG_LEVEL_SILENCE=y
+
 #
 # SLM-specific configurations
 #


### PR DESCRIPTION
TF-M logs were observed to use blocking send with UART1, which together with hw-flow-control for UART1 caused the device to jam until the remote end of the UART1 was accessed.

hw-flow-control for UART1 is utilized for SLM when RTT and modem traces are needed simultaneously.