### PR TITLE
bluetooth: adv_prov: Add adv_handle parameter

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -431,6 +431,10 @@ Bluetooth libraries and services
 * :ref:`bt_le_adv_prov_readme`:
 
   * Updated the :kconfig:option:`CONFIG_BT_ADV_PROV_FAST_PAIR_SHOW_UI_PAIRING` Kconfig option and the :c:func:`bt_le_adv_prov_fast_pair_show_ui_pairing` function to require the enabling of the :kconfig:option:`CONFIG_BT_FAST_PAIR_SUBSEQUENT_PAIRING` Kconfig option.
+  * Added the :c:member:`bt_le_adv_prov_adv_state.adv_handle` field to the :c:struct:`bt_le_adv_prov_adv_state` structure to store the advertising handle.
+    If the :kconfig:option:`CONFIG_BT_EXT_ADV` Kconfig option is enabled, you can use the :c:func:`bt_hci_get_adv_handle` function to obtain the advertising handle for the advertising set that employs :ref:`bt_le_adv_prov_readme`.
+    If the Kconfig option is disabled, the :c:member:`bt_le_adv_prov_adv_state.adv_handle` field must be set to ``0``.
+    This field is currently used by the TX Power provider (:kconfig:option:`CONFIG_BT_ADV_PROV_TX_POWER`).
 
 Common Application Framework
 ----------------------------

--- a/include/bluetooth/adv_prov.h
+++ b/include/bluetooth/adv_prov.h
@@ -46,6 +46,13 @@ struct bt_le_adv_prov_adv_state {
 	 * previously started advertising session is continued.
 	 */
 	bool new_adv_session;
+
+	/** Information about the advertising set for which the advertising data is prepared.
+	 *  If @kconfig{CONFIG_BT_EXT_ADV} is used, the advertising handle can be acquired using
+	 *  the bt_hci_get_adv_handle function.
+	 *  Otherwise, the advertising handle must be set to 0.
+	 */
+	uint8_t adv_handle;
 };
 
 /** Structure describing feedback reported by advertising providers. */

--- a/samples/bluetooth/fast_pair/input_device/src/bt_adv_helper.c
+++ b/samples/bluetooth/fast_pair/input_device/src/bt_adv_helper.c
@@ -79,6 +79,7 @@ static int adv_start_internal(void)
 	state.in_grace_period = false;
 	state.rpa_rotated = true;
 	state.new_adv_session = adv_helper_new_adv_session;
+	state.adv_handle = 0;
 
 	adv_helper_new_adv_session = false;
 

--- a/samples/bluetooth/fast_pair/locator_tag/src/fp_adv.c
+++ b/samples/bluetooth/fast_pair/locator_tag/src/fp_adv.c
@@ -138,20 +138,16 @@ static int fp_adv_payload_set(bool rpa_rotated, bool new_session)
 	/* Set advertising mode of Fast Pair advertising data provider. */
 	fp_adv_prov_configure(fp_adv_mode);
 
-	state.pairing_mode = fp_adv_is_pairing_mode(fp_adv_mode);
-	state.rpa_rotated = rpa_rotated;
-	state.new_adv_session = new_session;
-
 	err = bt_hci_get_adv_handle(fp_adv_set, &adv_handle);
 	if (err) {
 		LOG_ERR("Fast Pair: cannot get advertising handle (err: %d)", err);
 		return err;
 	}
-	/* The TX power advertising provider reads the power for the first advertising set.
-	 * This logic verifies that the Fast Pair advertising set has the correct index
-	 * and has been created as a first one with the bt_le_ext_adv_create() API.
-	 */
-	__ASSERT(adv_handle == 0, "Fast Pair: invalid advertising handle: 0x%02X", adv_handle);
+
+	state.pairing_mode = fp_adv_is_pairing_mode(fp_adv_mode);
+	state.rpa_rotated = rpa_rotated;
+	state.new_adv_session = new_session;
+	state.adv_handle = adv_handle;
 
 	err = bt_le_adv_prov_get_ad(ad, &ad_len, &state, &fb);
 	if (err) {

--- a/subsys/bluetooth/adv_prov/providers/tx_power.c
+++ b/subsys/bluetooth/adv_prov/providers/tx_power.c
@@ -19,7 +19,6 @@ LOG_MODULE_DECLARE(bt_le_adv_prov, CONFIG_BT_ADV_PROV_LOG_LEVEL);
 static int get_data(struct bt_data *ad, const struct bt_le_adv_prov_adv_state *state,
 		    struct bt_le_adv_prov_feedback *fb)
 {
-	ARG_UNUSED(state);
 	ARG_UNUSED(fb);
 
 	static uint8_t tx_power;
@@ -35,7 +34,7 @@ static int get_data(struct bt_data *ad, const struct bt_le_adv_prov_adv_state *s
 
 	cp = net_buf_add(cmd_buf, sizeof(*cp));
 	cp->handle_type = BT_HCI_VS_LL_HANDLE_TYPE_ADV;
-	cp->handle = sys_cpu_to_le16(0);
+	cp->handle = sys_cpu_to_le16(state->adv_handle);
 
 	int err = bt_hci_cmd_send_sync(BT_HCI_OP_VS_READ_TX_POWER_LEVEL, cmd_buf, &rsp);
 

--- a/subsys/caf/modules/ble_adv.c
+++ b/subsys/caf/modules/ble_adv.c
@@ -273,6 +273,7 @@ static int update_undirected_advertising(struct bt_le_adv_param *adv_param)
 	adv_state.in_grace_period = (state == STATE_GRACE_PERIOD);
 	adv_state.new_adv_session = req_new_adv_session;
 	adv_state.rpa_rotated = rpa_rotated;
+	adv_state.adv_handle = 0;
 	req_grace_period_s = 0;
 
 	int err = bt_le_adv_prov_get_ad(ad, &ad_len, &adv_state, &fb);


### PR DESCRIPTION
The tx_power advertising provider used advertising handle hardcoded to 0.
Added adv_handle parameter to the struct bt_le_adv_prov_adv_state so it can be configurable.
Aligned all users of the adv_prov to properly initialize the structure.

Jira: NCSDK-28077