### PR TITLE
lib: lte_link_control: Remove deprecated (de)init functions

### DIFF
--- a/doc/nrf/releases_and_maturity/migration/migration_guide_2.8.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_guide_2.8.rst
@@ -40,7 +40,17 @@ Libraries
 
 This section describes the changes related to libraries.
 
-|no_changes_yet_note|
+LTE link control library
+------------------------
+
+.. toggle::
+
+   * For applications using :ref:`lte_lc_readme`:
+
+     * Remove all instances of the :c:func:`lte_lc_init` function.
+     * Replace the use of the :c:func:`lte_lc_deinit` function with the :c:func:`lte_lc_power_off` function.
+     * Replace the use of the :c:func:`lte_lc_init_and_connect` function with the :c:func:`lte_lc_connect` function.
+     * Replace the use of the :c:func:`lte_lc_init_and_connect_async` function with the :c:func:`lte_lc_connect_async` function.
 
 .. _migration_2.8_recommended:
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -448,6 +448,19 @@ Gazell libraries
 Modem libraries
 ---------------
 
+* :ref:`lte_lc_readme` library:
+
+  * Removed:
+
+    * The :c:func:`lte_lc_init` function.
+      All instances of this function can be removed without any additional actions.
+    * The :c:func:`lte_lc_deinit` function.
+      Use the :c:func:`lte_lc_power_off` function instead.
+    * The :c:func:`lte_lc_init_and_connect` function.
+      Use the :c:func:`lte_lc_connect` function instead.
+    * The :c:func:`lte_lc_init_and_connect_async` function.
+      Use the :c:func:`lte_lc_connect_async` function instead.
+
 * :ref:`nrf_modem_lib_lte_net_if` library:
 
   * Added a log warning suggesting a SIM card to be installed if a UICC error is detected by the modem.

--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -1230,19 +1230,6 @@ void lte_lc_register_handler(lte_lc_evt_handler_t handler);
 int lte_lc_deregister_handler(lte_lc_evt_handler_t handler);
 
 /**
- * Initialize the library and configure the modem.
- *
- * @deprecated There is no need to call this function anymore.
- *
- * @note A follow-up call to lte_lc_connect() or lte_lc_connect_async() must be made to establish
- *       an LTE connection. The library can be initialized only once, and subsequent calls will
- *       return @c 0.
- *
- * @retval 0 if successful.
- */
-__deprecated int lte_lc_init(void);
-
-/**
  * Connect to LTE network.
  *
  *
@@ -1256,24 +1243,6 @@ __deprecated int lte_lc_init(void);
  * @retval -EINPROGRESS if a connection establishment attempt is already in progress.
  */
 int lte_lc_connect(void);
-
-/**
- * Initialize the library, configure the modem and connect to LTE network.
- *
- * @deprecated Use @ref lte_lc_connect instead.
- *
- * The function blocks until connection is established, or the connection attempt times out.
- *
- * @note The library can be initialized only once, and repeated calls will return @c 0.
- *       lte_lc_connect_async() should be used on subsequent calls.
- *
- * @retval 0 if successful.
- * @retval -EFAULT if an AT command failed.
- * @retval -ETIMEDOUT if a connection attempt timed out before the device was
- *	   registered to a network.
- * @retval -EINPROGRESS if a connection establishment attempt is already in progress.
- */
-__deprecated int lte_lc_init_and_connect(void);
 
 /**
  * Connect to LTE network.
@@ -1290,35 +1259,6 @@ __deprecated int lte_lc_init_and_connect(void);
  * @retval -EFAULT if an AT command failed.
  */
 int lte_lc_connect_async(lte_lc_evt_handler_t handler);
-
-/**
- * Initialize the library, configure the modem and connect to LTE network.
- *
- * @deprecated Use @ref lte_lc_connect_async instead.
- *
- * The function returns immediately.
- *
- * @note The library can be initialized only once, and repeated calls will return @c 0.
- *       lte_lc_connect() should be used on subsequent calls.
- *
- * @param[in] handler Event handler for receiving LTE events. The parameter can be @c NULL if an
- *                    event handler is already registered.
- *
- * @retval 0 if successful.
- * @retval -EFAULT if an AT command failed.
- * @retval -EINVAL if no event handler was registered.
- */
-__deprecated int lte_lc_init_and_connect_async(lte_lc_evt_handler_t handler);
-
-/**
- * Deinitialize the library and power off the modem.
- *
- * @deprecated Use @ref lte_lc_power_off instead.
- *
- * @retval 0 if successful.
- * @retval -EFAULT if an AT command failed.
- */
-__deprecated int lte_lc_deinit(void);
 
 /**
  * Set the modem to offline mode.

--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -822,11 +822,6 @@ static int feaconf_write(enum feaconf_feat feat, bool state)
 
 /* Public API */
 
-int lte_lc_init(void)
-{
-	return 0;
-}
-
 void lte_lc_register_handler(lte_lc_evt_handler_t handler)
 {
 	if (handler == NULL) {
@@ -853,11 +848,6 @@ int lte_lc_connect(void)
 	return connect_lte(true);
 }
 
-int lte_lc_init_and_connect(void)
-{
-	return connect_lte(true);
-}
-
 int lte_lc_connect_async(lte_lc_evt_handler_t handler)
 {
 	if (handler) {
@@ -868,16 +858,6 @@ int lte_lc_connect_async(lte_lc_evt_handler_t handler)
 	}
 
 	return connect_lte(false);
-}
-
-int lte_lc_init_and_connect_async(lte_lc_evt_handler_t handler)
-{
-	return lte_lc_connect_async(handler);
-}
-
-int lte_lc_deinit(void)
-{
-	return lte_lc_power_off();
 }
 
 int lte_lc_normal(void)


### PR DESCRIPTION
Removing the following functions that have been deprecated by PR #13057:

- lte_lc_init()
- lte_lc_init_and_connect()
- lte_lc_init_and_connect_async()
- lte_lc_deinit()