### PR TITLE
Samples: Bluetooth: Fix use of local obtained conn refs

### DIFF
--- a/samples/bluetooth/iso_combined_bis_and_cis/src/combined_bis_cis.c
+++ b/samples/bluetooth/iso_combined_bis_and_cis/src/combined_bis_cis.c
@@ -105,6 +105,8 @@ static void scan_recv(const struct bt_le_scan_recv_info *info, struct net_buf_si
 
 	if (err) {
 		LOG_ERR("Create conn to %s failed (%d)", name_str, err);
+	} else {
+		bt_conn_unref(conn);
 	}
 }
 
@@ -226,8 +228,6 @@ static void connected(struct bt_conn *conn, uint8_t err)
 	if (err) {
 		LOG_INF("Failed to connect to %s (%u)", addr, err);
 
-		bt_conn_unref(conn);
-
 		scan_start();
 		return;
 	}
@@ -264,8 +264,6 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	LOG_INF("Disconnected: %s (reason 0x%02x)", addr, reason);
-
-	bt_conn_unref(conn);
 
 	scan_start();
 }

--- a/samples/bluetooth/iso_time_sync/src/cis_central.c
+++ b/samples/bluetooth/iso_time_sync/src/cis_central.c
@@ -87,6 +87,8 @@ static void scan_recv(const struct bt_le_scan_recv_info *info, struct net_buf_si
 				    &conn);
 	if (err) {
 		printk("Create conn to %s failed (%d)\n", name_str, err);
+	} else {
+		bt_conn_unref(conn);
 	}
 }
 
@@ -127,8 +129,6 @@ static void connected(struct bt_conn *conn, uint8_t err)
 	if (err) {
 		printk("Failed to connect to %s (%u)\n", addr, err);
 
-		bt_conn_unref(conn);
-
 		scan_start();
 		return;
 	}
@@ -163,8 +163,6 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s (reason 0x%02x)\n", addr, reason);
-
-	bt_conn_unref(conn);
 
 	scan_start();
 }


### PR DESCRIPTION
The returned reference is unused.

Found using the semantic patch file:
```
@@
local idexpression conn;
identifier e;
statement S1;
@@
* e = bt_conn_le_create(..., &conn);
... when != bt_conn_unref(conn)
    when != if (e == 0) { <+... bt_conn_unref(conn) ...+> } else S1
```