### PR TITLE
doc: building: mention -v for verbose builds

### DIFF
--- a/doc/nrf/config_and_build/configuring_app/building.rst
+++ b/doc/nrf/config_and_build/configuring_app/building.rst
@@ -108,6 +108,8 @@ Here are some of the possible options you can use:
 * You can provide :ref:`custom CMake options <cmake_options>` to the build command.
 * You can pass ``--no-sysbuild`` to ``west build`` to build without :ref:`configuration_system_overview_sysbuild`.
   (In the |NCS|, :ref:`building with sysbuild is enabled by default <sysbuild_enabled_ncs>`.)
+* You can pass ``-v`` to ``west build`` to enable :ref:`zephyr:west-building-verbose`.
+  Pass ``-vvv`` for a more detailed build log, which includes the full commands used by the build system to generate the :ref:`app_build_output_files`.
 * You can include the *directory_name* parameter to build from a directory other than the current directory.
 * You can specify a *destination_directory_name* parameter to choose where the build files are generated.
   If not specified, the build files are automatically generated in :file:`build/zephyr/`.

--- a/doc/nrf/config_and_build/configuring_app/output_build_files.rst
+++ b/doc/nrf/config_and_build/configuring_app/output_build_files.rst
@@ -20,6 +20,9 @@ Depending on the application and the SoC, you can use one or several images.
 
 The |NCS| build system places output images in the :file:`<build folder>` folder when using sysbuild.
 
+.. note::
+    Pass the :ref:`optional parameter <optional_build_parameters>` ``-vvv`` to ``west build`` to enable a more detailed :ref:`zephyr:west-building-verbose` log, which includes the full commands used by the build system to generate the output build files.
+
 .. _app_build_output_files_common:
 
 Common output build files


### PR DESCRIPTION
Added mention of the `-vvv` option to the optional build params list. Also propagated as a tip to the output build files page. NCSDK-27695.