### PR TITLE
bluetooth: controller: Add SDC feature enabler for Path Loss Monitoring

### DIFF
--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -774,6 +774,13 @@ static int configure_supported_features(void)
 				return -ENOTSUP;
 			}
 		}
+
+		if (IS_ENABLED(CONFIG_BT_CTLR_LE_PATH_LOSS_MONITORING)) {
+			err = sdc_support_le_path_loss_monitoring();
+			if (err) {
+				return -ENOTSUP;
+			}
+		}
 	}
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_SCA_UPDATE)) {


### PR DESCRIPTION
This enables support for LE Path Loss Monitoring in the SoftDevice controller when the corresponding Kconfig is selected.