### PR TITLE
manifest: Add PSA ed25519 image encryption/verification to MCUboot

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -140,7 +140,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 7aaeb636812f7e5b0b901a1894916dbfd5334f3a
+      revision: 5f95fecfa27e5b9924a91c69bca023e605fe751e
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR


### PR DESCRIPTION
Update MCUboot version to birng in PSA encryption support.

Note that at this point MCUboot partition > 76k is needed.
To build MCUboot only:
```
west build --no-sysbuild -d builds/mcuboot_x25519_54_encrypt -b nrf54l15pdk/nrf54l15/cpuapp bootloader/mcuboot/boot/zephyr/ -DDTC_OVERLAY_FILE=app.overlay -DCONFIG_BOOT_SIGNATURE_TYPE_ED25519=y -DCONFIG_BOOT_ENCRYPT_IMAGE=y -DCONFIG_BOOT_ED25519_PSA=y  -DCONFIG_MBEDTLS=n -DCONFIG_MULTITHREADING=y -DCONFIG_NRF_SECURITY=y  -DCONFIG_NRF_OBERON=y
```
or for nrf52840
```
west build --no-sysbuild -d builds/mcuboot_x25519_52_encrypt -b nrf52840dk/nrf52840 bootloader/mcuboot/boot/zephyr/ -DDTC_OVERLAY_FILE=app.overlay -DCONFIG_BOOT_SIGNATURE_TYPE_ED25519=y -DCONFIG_BOOT_ENCRYPT_IMAGE=y -DCONFIG_BOOT_ED25519_PSA=y  -DCONFIG_MBEDTLS=n -DCONFIG_MULTITHREADING=y -DCONFIG_NRF_SECURITY=y  -DCONFIG_NRF_OBERON=y
```

Above gives both encryption and verification.
The --no-sysbuild has been added to make life easier and note that you have to modify the partition layout to allow MCUboot to fit.