### PR TITLE
samples: matter: Add TF-M build to nRF54L15 Matter samples

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -399,6 +399,10 @@ Matter samples
 
     * Added :ref:`Matter Lock schedule snippet <matter_lock_snippets>`, and updated the documentation to use the snippet.
 
+* :ref:`matter_template_sample` sample:
+
+  * Added support for :ref:`Trusted Firmware-M <ug_tfm>` on the nRF54L15 PDK.
+
 Networking samples
 ------------------
 

--- a/samples/matter/common/src/persistent_storage/Kconfig
+++ b/samples/matter/common/src/persistent_storage/Kconfig
@@ -13,8 +13,15 @@ config NCS_SAMPLE_MATTER_SETTINGS_STORAGE_BACKEND
 
 config NCS_SAMPLE_MATTER_SECURE_STORAGE_BACKEND
 	bool "Secure storage implementation for Matter samples"
-	select TRUSTED_STORAGE
-	select PSA_PROTECTED_STORAGE
+	select TRUSTED_STORAGE if !BUILD_WITH_TFM
+	select PSA_PROTECTED_STORAGE if !BUILD_WITH_TFM
+	help
+	  Enables secure persistent storage wrapper API, that
+	  imitates Zephyr Settings key-value data format.
+	  If building with CMSE enabled (*/ns), the TF-M
+	  PS implementation is leveraged by default.
+	  If building with CMSE disabled (cpuapp target),
+	  the Trusted Storage library must be used.
 
 config NCS_SAMPLE_MATTER_STORAGE_MAX_KEY_LEN
 	int "Maximum length (bytes) of the key under which the asset can be stored"

--- a/samples/matter/template/Kconfig.sysbuild
+++ b/samples/matter/template/Kconfig.sysbuild
@@ -59,6 +59,19 @@ config DFU_MULTI_IMAGE_PACKAGE_NET
 	default y
 
 endif # SOC_SERIES_NRF53X
+
+if BOARD_NRF54L15PDK_NRF54L15_CPUAPP_NS
+
+# Disable checking the external drivers for NS build.
+config PM_OVERRIDE_EXTERNAL_DRIVER_CHECK
+	default y
+
+# override the mcuboot pad size, because it is not set globally for NS build.
+config PM_MCUBOOT_PAD
+	default 0x800
+
+endif #BOARD_NRF54L15PDK_NRF54L15_CPUAPP_NS
+
 endif # BOOTLOADER_MCUBOOT
 
 #### Enable generating factory data

--- a/samples/matter/template/README.rst
+++ b/samples/matter/template/README.rst
@@ -108,6 +108,24 @@ Matter template custom configurations
     :start-after: matter_light_bulb_sample_configuration_file_types_start
     :end-before: matter_light_bulb_sample_configuration_file_types_end
 
+Matter template with Trusted Firmware-M
+=======================================
+
+.. matter_template_build_with_tfm_start
+
+The sample supports using :ref:`Trusted Firmware-M <ug_tfm>` on the nRF54L15 PDK.
+The memory map of the sample has been aligned to meet the :ref:`ug_tfm_partition_alignment_requirements`.
+
+You can build the sample with Trusted Firmware-M support by adding the ``ns`` suffix to the build target.
+
+For example:
+
+.. code-block:: console
+
+    west build -p -b nrf54l15pdk/nrf54l15/cpuapp/ns
+
+.. matter_template_build_with_tfm_end
+
 Device Firmware Upgrade support
 ===============================
 

--- a/samples/matter/template/boards/nrf54l15pdk_nrf54l15_cpuapp_ns.conf
+++ b/samples/matter/template/boards/nrf54l15pdk_nrf54l15_cpuapp_ns.conf
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Multirole is the only currently supported role by SoftDevice.
+CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
+
+CONFIG_FPU=n
+CONFIG_PM=n
+CONFIG_HWINFO_NRF=n
+
+CONFIG_NRF_802154_TEMPERATURE_UPDATE=n
+
+# TODO: Workaround to be removed once Zephyr's CONFIG_FPROTECT is supported on nRF54L
+CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT=n
+
+# nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
+CONFIG_CHIP_MALLOC_SYS_HEAP_SIZE=10240
+CONFIG_MPSL_WORK_STACK_SIZE=2048

--- a/samples/matter/template/boards/nrf54l15pdk_nrf54l15_cpuapp_ns.overlay
+++ b/samples/matter/template/boards/nrf54l15pdk_nrf54l15_cpuapp_ns.overlay
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	aliases {
+		// Use watchdog wdt31 as the application watchdog
+		watchdog0 = &wdt31;
+	};
+
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};
+
+// restore full RRAM and SRAM space - by default some parts are dedicated to FLRP
+&cpuapp_rram {
+	reg = <0x0 DT_SIZE_K(1524)>;
+};
+
+&cpuapp_sram {
+	reg = <0x20000000 DT_SIZE_K(256)>;
+	ranges = <0x0 0x20000000  0x40000>;
+};
+
+// TODO: re-enable HWFC once it's fixed
+&uart20 {
+	/delete-property/ hw-flow-control;
+};
+
+&mx25r64 {
+	status = "okay";
+};
+
+&wdt31 {
+	status = "okay";
+};

--- a/samples/matter/template/boards/nrf54l15pdk_nrf54l15_cpuapp_ns.overlay
+++ b/samples/matter/template/boards/nrf54l15pdk_nrf54l15_cpuapp_ns.overlay
@@ -39,7 +39,10 @@
 };
 
 // Change IRQ ids to handle button interrupts.
-// The default values for nRF54L15 are 219 and 269, but with TF-M they are reserved for the secure domain (218 and 268 are reserved for the non-secure domain).
+
+// The default values for nRF54L15 are 219 and 269,
+// but with TF-M they are reserved for the secure domain
+// (218 and 268 are reserved for the non-secure domain).
 &gpiote20 {
 	interrupts = <218 NRF_DEFAULT_IRQ_PRIORITY>;
 };

--- a/samples/matter/template/boards/nrf54l15pdk_nrf54l15_cpuapp_ns.overlay
+++ b/samples/matter/template/boards/nrf54l15pdk_nrf54l15_cpuapp_ns.overlay
@@ -37,3 +37,13 @@
 &wdt31 {
 	status = "okay";
 };
+
+// Change IRQ ids to handle button interrupts.
+// The default values for nRF54L15 are 219 and 269, but with TF-M they are reserved for the secure domain (218 and 268 are reserved for the non-secure domain).
+&gpiote20 {
+	interrupts = <218 NRF_DEFAULT_IRQ_PRIORITY>;
+};
+
+&gpiote30 {
+	interrupts = <268 NRF_DEFAULT_IRQ_PRIORITY>;
+};

--- a/samples/matter/template/pm_static_nrf54l15pdk_nrf54l15_cpuapp_ns.yml
+++ b/samples/matter/template/pm_static_nrf54l15pdk_nrf54l15_cpuapp_ns.yml
@@ -1,0 +1,113 @@
+### Partitions
+mcuboot:
+  address: 0x0
+  region: flash_primary
+  size: 0xc000
+mcuboot_pad:
+  address: 0xc000
+  region: flash_primary
+  size: 0x800
+tfm:
+  address: 0xc800
+  region: flash_primary
+  size: 0x1F800
+app:
+  address: 0x2C000
+  region: flash_primary
+  size: 0x13E000
+factory_data:
+  address: 0x16A000
+  region: flash_primary
+  size: 0x1000
+settings_storage:
+  address: 0x16B000
+  region: flash_primary
+  size: 0xa000
+tfm_storage:
+  address: 0x175000
+  orig_span: &id006
+  - tfm_ps
+  - tfm_its
+  - tfm_otp_nv_counters
+  region: flash_primary
+  size: 0x8000
+  span: *id006
+external_flash:
+  address: 0x15E000
+  size: 0x6A2000
+  device: MX25R64
+  region: external_flash
+### Bootloader configuration
+mcuboot_primary:
+  orig_span: &id001
+  - mcuboot_pad
+  - tfm
+  - app
+  span: *id001
+  address: 0xc000
+  region: flash_primary
+  size: 0x15E000
+mcuboot_primary_app:
+  orig_span: &id002
+  - app
+  - tfm
+  span: *id002
+  address: 0xc800
+  region: flash_primary
+  size: 0x15D800
+mcuboot_secondary:
+  address: 0x0
+  orig_span: &id003
+  - mcuboot_secondary_pad
+  - mcuboot_secondary_app
+  region: external_flash
+  size: 0x15E000
+  span: *id003
+mcuboot_secondary_pad:
+  region: external_flash
+  address: 0x0
+  size: 0x800
+mcuboot_secondary_app:
+  region: external_flash
+  address: 0x800
+  size: 0x15D800
+### TFM configuration
+tfm_secure:
+  address: 0xc000
+  orig_span: &id004
+  - mcuboot_pad
+  - tfm
+  region: flash_primary
+  size: 0x20000
+  span: *id004
+tfm_nonsecure:
+  address: 0x2C000
+  orig_span: &id005
+  - app
+  region: flash_primary
+  size: 0x13E000
+  span: *id005
+tfm_its:
+  address: 0x175000
+  inside:
+  - tfm_storage
+  placement:
+    before:
+    - tfm_otp_nv_counters
+  region: flash_primary
+  size: 0x2000
+tfm_otp_nv_counters:
+  address: 0x177000
+  inside:
+  - tfm_storage
+  placement:
+    before:
+    - tfm_ps
+  region: flash_primary
+  size: 0x2000
+tfm_ps:
+  address: 0x179000
+  inside:
+  - tfm_storage
+  region: flash_primary
+  size: 0x4000


### PR DESCRIPTION
- Added configuration and partitions map to the nRF54L15 target in the Matter template sample.

Issues to be resolved:
- [x] Build without RRAMC, fix in Zephyr, in progress
- [x] The new SDC & MPSL libraries are needed: https://github.com/nrfconnect/sdk-nrfxlib/pull/1421 & https://github.com/nrfconnect/sdk-nrfxlib/pull/1419
- [x] Fix for the linker: https://github.com/nrfconnect/sdk-nrf/pull/16642
- [x] The first boot after flash causes Bus fault
- [x] Coexistence of IEEE 802145 and TF-M, GRTC issue
- [x] Un-handled button interrupts
- [x] Integration with Matter PersistentStorage module