### PR TITLE
manifest: Update sdk-zephyr wieh nRF54L20 support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 631b9a25d5ab2951bacbdf33576a529c7aeb87a2
+      revision: pull/1917/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Includes new SoC and board definitions.