### PR TITLE
partition_manager: TrustZone HW model 1 workaround

### DIFF
--- a/subsys/partition_manager/Kconfig
+++ b/subsys/partition_manager/Kconfig
@@ -32,6 +32,23 @@ config SRAM_BASE_ADDRESS
 	hex
 	depends on !PARTITION_MANAGER_ENABLED
 
+# Workaround for the hardware model v1 which is not aware of the new
+# TrustZone definitions. Since nRF54L15 is not supported with the
+# hardware model v1, the values are set to the SPU values
+# since both nRF53 and nRF9X series are using the SPU for configuring
+# secure/non-secure regions.
+# TODO: Remove this when support for hardware model v1 is removed.
+# Tracked by NCSDK-28541
+if "$(HWM_SCHEME)" = "v1"
+config NRF_TRUSTZONE_FLASH_REGION_SIZE
+	hex
+	default NRF_SPU_FLASH_REGION_SIZE
+
+config NRF_TRUSTZONE_RAM_REGION_SIZE
+	hex
+	default NRF_SPU_RAM_REGION_SIZE
+endif
+
 menu "Zephyr subsystem configurations"
 
 DT_CHOSEN_Z_IPC_SHM := zephyr,ipc_shm


### PR DESCRIPTION
The configurations: NRF_TRUSTZONE_FLASH_REGION_SIZE and NRF_TRUSTZONE_RAM_REGION_SIZE are added after the release and they are not included in the hardware
model 1. This is a workaround for this use case,
since we don't expect to support the nRF54L15 devices with this model this workaround should work for the older generation of devices.

Ref: NCSDK-28479