### PR TITLE
suit: Log class IDs for manifests

### DIFF
--- a/subsys/suit/metadata/include/suit_metadata.h
+++ b/subsys/suit/metadata/include/suit_metadata.h
@@ -20,6 +20,18 @@ typedef int suit_metadata_err_t;
 /**< Content of compared suit_uuid_t structures differs */
 #define METADATA_ERR_COMPARISON_FAILED 1
 
+/**< Format string to print manifest class ID */
+#define SUIT_MANIFEST_CLASS_ID_LOG_FORMAT                                                          \
+	"%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x%s"
+
+/**< List of arguments to log manifest class ID */
+#define SUIT_MANIFEST_CLASS_ID_LOG_ARGS(class_id)                                                  \
+	(class_id)->raw[0], (class_id)->raw[1], (class_id)->raw[2], (class_id)->raw[3],            \
+		(class_id)->raw[4], (class_id)->raw[5], (class_id)->raw[6], (class_id)->raw[7],    \
+		(class_id)->raw[8], (class_id)->raw[9], (class_id)->raw[10], (class_id)->raw[11],  \
+		(class_id)->raw[12], (class_id)->raw[13], (class_id)->raw[14],                     \
+		(class_id)->raw[15], suit_manifest_class_name_get(class_id)
+
 /* Define constant values for backward compatibility purposes. */
 typedef enum {
 	/** Digest status value uninitialized (invalid). */
@@ -178,6 +190,22 @@ suit_metadata_err_t suit_metadata_uuid_compare(const suit_uuid_t *uuid1, const s
  */
 suit_metadata_err_t suit_metadata_version_from_array(suit_version_t *version, int32_t *array,
 						     size_t array_len);
+
+/** @brief Get a pointer to the constant string, that describes the manifest role.
+ *
+ * @param[in]  role  Integer value of a manifest role to describe.
+ *
+ * @returns Pointer to the constant string, describing role or empty string for unknown values.
+ */
+const char *suit_role_name_get(suit_manifest_role_t role);
+
+/** @brief Get a pointer to the constant string, that describes the known manifest class ID.
+ *
+ * @param[in]  class_id  Pointer to the manifest class ID value.
+ *
+ * @returns Pointer to the constant string, describing class ID or empty string for unknown classes.
+ */
+const char *suit_manifest_class_name_get(const suit_manifest_class_id_t *class_id);
 
 #ifdef __cplusplus
 }

--- a/subsys/suit/metadata/src/suit_metadata.c
+++ b/subsys/suit/metadata/src/suit_metadata.c
@@ -71,3 +71,117 @@ suit_metadata_err_t suit_metadata_version_from_array(suit_version_t *version, in
 
 	return SUIT_PLAT_SUCCESS;
 }
+
+const char *suit_role_name_get(suit_manifest_role_t role)
+{
+#ifdef CONFIG_LOG
+	switch (role) {
+	case SUIT_MANIFEST_UNKNOWN:
+		return " (Unknown)";
+	case SUIT_MANIFEST_SEC_TOP:
+		return " (Nordic: Top manifest)";
+	case SUIT_MANIFEST_SEC_SDFW:
+		return " (Nordic: SDFW & Recovery)";
+	case SUIT_MANIFEST_SEC_SYSCTRL:
+		return " (Nordic: SCFW)";
+	case SUIT_MANIFEST_APP_ROOT:
+		return " (Application: Root)";
+	case SUIT_MANIFEST_APP_RECOVERY:
+		return " (Application: Recovery)";
+	case SUIT_MANIFEST_APP_LOCAL_1:
+		return " (Application: Local 1)";
+	case SUIT_MANIFEST_APP_LOCAL_2:
+		return " (Application: Local 2)";
+	case SUIT_MANIFEST_APP_LOCAL_3:
+		return " (Application: Local 3)";
+	case SUIT_MANIFEST_RAD_RECOVERY:
+		return " (Radio: Recovery)";
+	case SUIT_MANIFEST_RAD_LOCAL_1:
+		return " (Radio: Local 1)";
+	case SUIT_MANIFEST_RAD_LOCAL_2:
+		return " (Radio: Local 2)";
+	default:
+		break;
+	}
+#endif /* CONFIG_LOG */
+
+	return "";
+}
+
+const char *suit_manifest_class_name_get(const suit_manifest_class_id_t *class_id)
+{
+#ifdef CONFIG_LOG
+	const uint8_t nRF54H20_nordic_top[] = {0xf0, 0x3d, 0x38, 0x5e, 0xa7, 0x31, 0x56, 0x05,
+					       0xb1, 0x5d, 0x03, 0x7f, 0x6d, 0xa6, 0x09, 0x7f};
+	const uint8_t nRF54H20_sec[] = {0xd9, 0x6b, 0x40, 0xb7, 0x09, 0x2b, 0x5c, 0xd1,
+					0xa5, 0x9f, 0x9a, 0xf8, 0x0c, 0x33, 0x7e, 0xba};
+	const uint8_t nRF54H20_sys[] = {0xc0, 0x8a, 0x25, 0xd7, 0x35, 0xe6, 0x59, 0x2c,
+					0xb7, 0xad, 0x43, 0xac, 0xc8, 0xd1, 0xd1, 0xc8};
+	const uint8_t test_sample_root[] = {0x97, 0x05, 0x48, 0x23, 0x4c, 0x3d, 0x59, 0xa1,
+					    0x89, 0x86, 0xa5, 0x46, 0x60, 0xa1, 0x4b, 0x0a};
+	const uint8_t test_sample_app[] = {0x5b, 0x46, 0x9f, 0xd1, 0x90, 0xee, 0x53, 0x9c,
+					   0xa3, 0x18, 0x68, 0x1b, 0x03, 0x69, 0x5e, 0x36};
+	const uint8_t test_sample_recovery[] = {0x74, 0xa0, 0xc6, 0xe7, 0xa9, 0x2a, 0x56, 0x00,
+						0x9c, 0x5d, 0x30, 0xee, 0x87, 0x8b, 0x06, 0xba};
+	const uint8_t nRF54H20_sample_root[] = {0x3f, 0x6a, 0x3a, 0x4d, 0xcd, 0xfa, 0x58, 0xc5,
+						0xac, 0xce, 0xf9, 0xf5, 0x84, 0xc4, 0x11, 0x24};
+	const uint8_t nRF54H20_app_recovery[] = {0xa3, 0x7b, 0x77, 0xb0, 0x87, 0x0e, 0x57, 0x49,
+						 0xa8, 0x64, 0xf1, 0x44, 0x4a, 0xaf, 0xf5, 0x47};
+	const uint8_t nRF54H20_sample_app[] = {0x08, 0xc1, 0xb5, 0x99, 0x55, 0xe8, 0x5f, 0xbc,
+					       0x9e, 0x76, 0x7b, 0xc2, 0x9c, 0xe1, 0xb0, 0x4d};
+	const uint8_t nRF54H20_sample_app_local_2[] = {0x51, 0xde, 0x10, 0xb8, 0xee, 0x2e,
+						       0x5b, 0x4b, 0x80, 0xee, 0x53, 0x4a,
+						       0x4a, 0x3c, 0x04, 0xfc};
+	const uint8_t nRF54H20_sample_app_local_3[] = {0x2d, 0xca, 0x15, 0xa5, 0xa3, 0x2e,
+						       0x5a, 0x71, 0xbe, 0x54, 0xba, 0x07,
+						       0xbb, 0xaf, 0xae, 0x27};
+	const uint8_t nRF54H20_rad_recovery[] = {0x58, 0x00, 0x98, 0xae, 0xb2, 0x40, 0x50, 0x66,
+						 0xaf, 0x45, 0x57, 0x33, 0x25, 0xfc, 0x39, 0xf6};
+	const uint8_t nRF54H20_sample_rad[] = {0x81, 0x6a, 0xa0, 0xa0, 0xaf, 0x11, 0x5e, 0xf2,
+					       0x85, 0x8a, 0xfe, 0xb6, 0x68, 0xb2, 0xe9, 0xc9};
+	const uint8_t nRF54H20_sample_rad_local_2[] = {0x0a, 0xa4, 0xbe, 0x57, 0xb3, 0x1e,
+						       0x57, 0x9c, 0xab, 0x81, 0x13, 0xbd,
+						       0x90, 0xe1, 0x6e, 0xf7};
+
+	if (class_id == NULL) {
+		return "";
+	}
+
+	if (memcmp(class_id->raw, nRF54H20_nordic_top, sizeof(nRF54H20_nordic_top)) == 0) {
+		return " (nRF54H20_nordic_top)";
+	} else if (memcmp(class_id->raw, nRF54H20_sec, sizeof(nRF54H20_sec)) == 0) {
+		return " (nRF54H20_sec)";
+	} else if (memcmp(class_id->raw, nRF54H20_sys, sizeof(nRF54H20_sys)) == 0) {
+		return " (nRF54H20_sys)";
+	} else if (memcmp(class_id->raw, test_sample_root, sizeof(test_sample_root)) == 0) {
+		return " (test_sample_root)";
+	} else if (memcmp(class_id->raw, test_sample_app, sizeof(test_sample_app)) == 0) {
+		return " (test_sample_app)";
+	} else if (memcmp(class_id->raw, test_sample_recovery, sizeof(test_sample_recovery)) == 0) {
+		return " (test_sample_recovery)";
+	} else if (memcmp(class_id->raw, nRF54H20_sample_root, sizeof(nRF54H20_sample_root)) == 0) {
+		return " (nRF54H20_sample_root)";
+	} else if (memcmp(class_id->raw, nRF54H20_app_recovery, sizeof(nRF54H20_app_recovery)) ==
+		   0) {
+		return " (nRF54H20_app_recovery)";
+	} else if (memcmp(class_id->raw, nRF54H20_sample_app, sizeof(nRF54H20_sample_app)) == 0) {
+		return " (nRF54H20_sample_app)";
+	} else if (memcmp(class_id->raw, nRF54H20_sample_app_local_2,
+			  sizeof(nRF54H20_sample_app_local_2)) == 0) {
+		return " (nRF54H20_sample_app_local_2)";
+	} else if (memcmp(class_id->raw, nRF54H20_sample_app_local_3,
+			  sizeof(nRF54H20_sample_app_local_3)) == 0) {
+		return " (nRF54H20_sample_app_local_3)";
+	} else if (memcmp(class_id->raw, nRF54H20_rad_recovery, sizeof(nRF54H20_rad_recovery)) ==
+		   0) {
+		return " (nRF54H20_rad_recovery)";
+	} else if (memcmp(class_id->raw, nRF54H20_sample_rad, sizeof(nRF54H20_sample_rad)) == 0) {
+		return " (nRF54H20_sample_rad)";
+	} else if (memcmp(class_id->raw, nRF54H20_sample_rad_local_2,
+			  sizeof(nRF54H20_sample_rad_local_2)) == 0) {
+		return " (nRF54H20_sample_rad_local_2)";
+	}
+#endif /* CONFIG_LOG */
+
+	return "";
+}

--- a/subsys/suit/orchestrator/src/suit_orchestrator_sdfw.c
+++ b/subsys/suit/orchestrator/src/suit_orchestrator_sdfw.c
@@ -352,15 +352,10 @@ static int boot_path(bool emergency)
 
 		ret = boot_envelope(class_id);
 		if (ret != 0) {
-			LOG_ERR("Booting %d manifest failed (%d):", i, ret);
-			LOG_ERR("\t%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%"
-				"02x%02x",
-				class_id->raw[0], class_id->raw[1], class_id->raw[2],
-				class_id->raw[3], class_id->raw[4], class_id->raw[5],
-				class_id->raw[6], class_id->raw[7], class_id->raw[8],
-				class_id->raw[9], class_id->raw[10], class_id->raw[11],
-				class_id->raw[12], class_id->raw[13], class_id->raw[14],
-				class_id->raw[15]);
+			LOG_ERR("Booting manifest %d/%d failed (%d):", i + 1, class_ids_to_boot_len,
+				ret);
+			LOG_ERR("\t" SUIT_MANIFEST_CLASS_ID_LOG_FORMAT,
+				SUIT_MANIFEST_CLASS_ID_LOG_ARGS(class_id));
 			if (emergency) {
 				/* Conditionally continue booting other envelopes.
 				 * Recovery FW shall discover which parts of the system
@@ -371,12 +366,9 @@ static int boot_path(bool emergency)
 			return ret;
 		}
 
-		LOG_DBG("Manifest %d booted", i);
-		LOG_DBG("\t%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
-			class_id->raw[0], class_id->raw[1], class_id->raw[2], class_id->raw[3],
-			class_id->raw[4], class_id->raw[5], class_id->raw[6], class_id->raw[7],
-			class_id->raw[8], class_id->raw[9], class_id->raw[10], class_id->raw[11],
-			class_id->raw[12], class_id->raw[13], class_id->raw[14], class_id->raw[15]);
+		LOG_INF("Manifest %d/%d booted", i + 1, class_ids_to_boot_len);
+		LOG_INF("\t" SUIT_MANIFEST_CLASS_ID_LOG_FORMAT,
+			SUIT_MANIFEST_CLASS_ID_LOG_ARGS(class_id));
 	}
 
 	return ret;
@@ -400,7 +392,7 @@ int suit_orchestrator_init(void)
 	if (plat_err != SUIT_PLAT_SUCCESS) {
 		switch (plat_err) {
 		case SUIT_PLAT_ERR_AUTHENTICATION:
-			LOG_ERR("Failed to load MPI: invalid digest");
+			LOG_ERR("Failed to load MPI: application MPI missing (invalid digest)");
 			plat_err = suit_execution_mode_set(EXECUTION_MODE_FAIL_NO_MPI);
 			break;
 		case SUIT_PLAT_ERR_NOT_FOUND:

--- a/subsys/suit/storage/src/suit_storage_nrf54h20.c
+++ b/subsys/suit/storage/src/suit_storage_nrf54h20.c
@@ -728,18 +728,20 @@ static suit_plat_err_t configure_manifests(suit_manifest_role_t *roles, size_t n
 	for (size_t i = 0; i < num_roles; i++) {
 		ret = find_mpi_area(roles[i], &mpi_addr, &mpi_size);
 		if (ret != SUIT_PLAT_SUCCESS) {
-			LOG_ERR("Failed to locate MPI area for role 0x%x: %d", roles[i], ret);
+			LOG_ERR("Failed to locate MPI area for role 0x%x%s: %d", roles[i],
+				suit_role_name_get(roles[i]), ret);
 			return ret;
 		}
 
 		ret = suit_storage_mpi_configuration_load(roles[i], mpi_addr, mpi_size);
 		if (ret != SUIT_PLAT_SUCCESS) {
 			if ((ret == SUIT_PLAT_ERR_NOT_FOUND) && (ignore_missing)) {
-				LOG_INF("Skip MPI area for role 0x%x. Area load failed.", roles[i]);
+				LOG_INF("Skip MPI area for role 0x%x%s. Area load failed.",
+					roles[i], suit_role_name_get(roles[i]));
 				continue;
 			} else {
-				LOG_WRN("Failed to load MPI configuration for role 0x%x: %d",
-					roles[i], ret);
+				LOG_WRN("Failed to load MPI configuration for role 0x%x%s: %d",
+					roles[i], suit_role_name_get(roles[i]), ret);
 				return ret;
 			}
 		}
@@ -915,25 +917,29 @@ suit_plat_err_t suit_storage_installed_envelope_get(const suit_manifest_class_id
 	suit_plat_err_t err = suit_storage_mpi_role_get(id, &role);
 
 	if (err != SUIT_PLAT_SUCCESS) {
-		LOG_INF("Unable to find role for given class ID.");
+		LOG_WRN("Unable to find role for given class ID.");
 		return err;
 	}
 
 	err = find_manifest_area(role, addr, size);
 	if (err != SUIT_PLAT_SUCCESS) {
-		LOG_INF("Unable to find area for envelope with role 0x%x.", role);
+		LOG_ERR("Unable to find area for envelope with role 0x%x%s.", role,
+			suit_role_name_get(role));
 		return err;
 	}
 
-	LOG_DBG("Decode envelope with role: 0x%x address: 0x%lx", role, (intptr_t)(*addr));
+	LOG_DBG("Decode envelope with role: 0x%x%s address: 0x%lx", role, suit_role_name_get(role),
+		(intptr_t)(*addr));
 
 	err = suit_storage_envelope_get(*addr, *size, id, addr, size);
 	if (err != SUIT_PLAT_SUCCESS) {
-		LOG_WRN("Unable to parse envelope with role 0x%x", role);
+		LOG_WRN("Unable to parse envelope with role 0x%x%s", role,
+			suit_role_name_get(role));
 		return err;
 	}
 
-	LOG_DBG("Valid envelope with given class ID and role 0x%x found", role);
+	LOG_DBG("Valid envelope with given class ID and role 0x%x%s found", role,
+		suit_role_name_get(role));
 
 	return err;
 }
@@ -948,7 +954,7 @@ suit_plat_err_t suit_storage_install_envelope(const suit_manifest_class_id_t *id
 
 	err = suit_storage_mpi_role_get(id, &role);
 	if (err != SUIT_PLAT_SUCCESS) {
-		LOG_INF("Unable to find role for given class ID.");
+		LOG_WRN("Unable to find role for given class ID.");
 		return err;
 	}
 
@@ -958,17 +964,19 @@ suit_plat_err_t suit_storage_install_envelope(const suit_manifest_class_id_t *id
 
 	err = find_manifest_area(role, (const uint8_t **)&area_addr, &area_size);
 	if (err != SUIT_PLAT_SUCCESS) {
-		LOG_INF("Unable to find area for envelope with role 0x%x.", role);
+		LOG_ERR("Unable to find area for envelope with role 0x%x%s.", role,
+			suit_role_name_get(role));
 		return err;
 	}
 
 	err = suit_storage_envelope_install(area_addr, area_size, id, addr, size);
 	if (err != SUIT_PLAT_SUCCESS) {
-		LOG_INF("Failed to install envelope with role 0x%x.", role);
+		LOG_ERR("Failed to install envelope with role 0x%x%s.", role,
+			suit_role_name_get(role));
 		return err;
 	}
 
-	LOG_INF("Envelope with role 0x%x saved.", role);
+	LOG_INF("Envelope with role 0x%x%s saved.", role, suit_role_name_get(role));
 
 	return err;
 }
@@ -1001,7 +1009,7 @@ suit_plat_err_t suit_storage_var_set(size_t index, uint32_t value)
 	suit_plat_err_t err = suit_storage_nvv_set(area_addr, area_size, index, value);
 
 	if (err != SUIT_PLAT_SUCCESS) {
-		LOG_INF("Failed to update NVV at index %d", index);
+		LOG_ERR("Failed to update NVV at index %d", index);
 		return err;
 	}
 
@@ -1017,7 +1025,7 @@ suit_plat_err_t suit_storage_report_clear(size_t index)
 
 	err = find_report_area(index, &area_addr, &area_size);
 	if (err != SUIT_PLAT_SUCCESS) {
-		LOG_INF("Unable to find report area at index %d.", index);
+		LOG_WRN("Unable to find report area at index %d.", index);
 		return err;
 	}
 
@@ -1032,7 +1040,7 @@ suit_plat_err_t suit_storage_report_save(size_t index, const uint8_t *buf, size_
 
 	err = find_report_area(index, &area_addr, &area_size);
 	if (err != SUIT_PLAT_SUCCESS) {
-		LOG_INF("Unable to find area for report at index %d.", index);
+		LOG_WRN("Unable to find area for report at index %d.", index);
 		return err;
 	}
 
@@ -1047,7 +1055,7 @@ suit_plat_err_t suit_storage_report_read(size_t index, const uint8_t **buf, size
 
 	err = find_report_area(index, &area_addr, &area_size);
 	if (err != SUIT_PLAT_SUCCESS) {
-		LOG_INF("Unable to find area with report at index %d.", index);
+		LOG_WRN("Unable to find area with report at index %d.", index);
 		return err;
 	}
 

--- a/subsys/suit/storage/src/suit_storage_test.c
+++ b/subsys/suit/storage/src/suit_storage_test.c
@@ -275,25 +275,29 @@ suit_plat_err_t suit_storage_installed_envelope_get(const suit_manifest_class_id
 	suit_plat_err_t err = suit_storage_mpi_role_get(id, &role);
 
 	if (err != SUIT_PLAT_SUCCESS) {
-		LOG_INF("Unable to find role for given class ID.");
+		LOG_WRN("Unable to find role for given class ID.");
 		return err;
 	}
 
 	err = find_manifest_area(role, addr, size);
 	if (err != SUIT_PLAT_SUCCESS) {
-		LOG_INF("Unable to find area for envelope with role 0x%x.", role);
+		LOG_ERR("Unable to find area for envelope with role 0x%x%s.", role,
+			suit_role_name_get(role));
 		return err;
 	}
 
-	LOG_DBG("Decode envelope with role: 0x%x address: 0x%lx", role, (intptr_t)(*addr));
+	LOG_DBG("Decode envelope with role: 0x%x%s address: 0x%lx", role, suit_role_name_get(role),
+		(intptr_t)(*addr));
 
 	err = suit_storage_envelope_get(*addr, *size, id, addr, size);
 	if (err != SUIT_PLAT_SUCCESS) {
-		LOG_WRN("Unable to parse envelope with role 0x%x", role);
+		LOG_WRN("Unable to parse envelope with role 0x%x%s", role,
+			suit_role_name_get(role));
 		return err;
 	}
 
-	LOG_DBG("Valid envelope with given class ID and role 0x%x found", role);
+	LOG_DBG("Valid envelope with given class ID and role 0x%x%s found", role,
+		suit_role_name_get(role));
 
 	return err;
 }
@@ -308,7 +312,7 @@ suit_plat_err_t suit_storage_install_envelope(const suit_manifest_class_id_t *id
 
 	err = suit_storage_mpi_role_get(id, &role);
 	if (err != SUIT_PLAT_SUCCESS) {
-		LOG_INF("Unable to find role for given class ID.");
+		LOG_WRN("Unable to find role for given class ID.");
 		return err;
 	}
 
@@ -318,17 +322,19 @@ suit_plat_err_t suit_storage_install_envelope(const suit_manifest_class_id_t *id
 
 	err = find_manifest_area(role, (const uint8_t **)&area_addr, &area_size);
 	if (err != SUIT_PLAT_SUCCESS) {
-		LOG_INF("Unable to find area for envelope with role 0x%x.", role);
+		LOG_ERR("Unable to find area for envelope with role 0x%x%s.", role,
+			suit_role_name_get(role));
 		return err;
 	}
 
 	err = suit_storage_envelope_install(area_addr, area_size, id, addr, size);
 	if (err != SUIT_PLAT_SUCCESS) {
-		LOG_INF("Failed to install envelope with role 0x%x.", role);
+		LOG_ERR("Failed to install envelope with role 0x%x%s.", role,
+			suit_role_name_get(role));
 		return err;
 	}
 
-	LOG_INF("Envelope with role 0x%x saved.", role);
+	LOG_INF("Envelope with role 0x%x%s saved.", role, suit_role_name_get(role));
 
 	return err;
 }
@@ -341,7 +347,7 @@ suit_plat_err_t suit_storage_report_clear(size_t index)
 
 	err = find_report_area(index, &area_addr, &area_size);
 	if (err != SUIT_PLAT_SUCCESS) {
-		LOG_INF("Unable to find report area at index %d.", index);
+		LOG_WRN("Unable to find report area at index %d.", index);
 		return err;
 	}
 
@@ -356,7 +362,7 @@ suit_plat_err_t suit_storage_report_save(size_t index, const uint8_t *buf, size_
 
 	err = find_report_area(index, &area_addr, &area_size);
 	if (err != SUIT_PLAT_SUCCESS) {
-		LOG_INF("Unable to find area for report at index %d.", index);
+		LOG_WRN("Unable to find area for report at index %d.", index);
 		return err;
 	}
 
@@ -371,7 +377,7 @@ suit_plat_err_t suit_storage_report_read(size_t index, const uint8_t **buf, size
 
 	err = find_report_area(index, &area_addr, &area_size);
 	if (err != SUIT_PLAT_SUCCESS) {
-		LOG_INF("Unable to find area with report at index %d.", index);
+		LOG_WRN("Unable to find area with report at index %d.", index);
 		return err;
 	}
 


### PR DESCRIPTION
Remove the false indication that the root manifest was processed. Log manifest class ID for each manifest that is booted.

Ref: NCSDK-NONE