### PR TITLE
Cracen: Fix import/export/generate key implementations

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/common/include/cracen/mem_helpers.h
+++ b/subsys/nrf_security/src/drivers/cracen/common/include/cracen/mem_helpers.h
@@ -43,10 +43,22 @@ bool constant_memcmp_is_zero(const void *s1, size_t n);
 void safe_memset(void *dest, const size_t dest_size, const uint8_t ch, const size_t n);
 
 /*!
- * \brief A meset to zero function that is not optimized out by the compiler.
+ * \brief A memset to zero function that is not optimized out by the compiler.
  *
  * \param[in] dest		Pointer to the memory to set to zero.
  * \param[in] dest_size Size of the memory in bytes.
  *
  */
 void safe_memzero(void *dest, const size_t dest_size);
+
+/*!
+ * \brief Will copy memory, verifying that the source buffer is non-zero.
+ *
+ * \param[in] dest      Pointer to destination memory.
+ * \param[in] dest_size Size of the memory in bytes.
+ * \param[in] src       Pointer to source memory.
+ * \param[in] src_size  Size of the memory in bytes.
+ *
+ * \return true if src buffer is non-zero and fits into the destination.
+ */
+bool memcpy_check_non_zero(void *dest, size_t dest_size, const void *src, size_t src_size);

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/mem_helpers.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/mem_helpers.c
@@ -32,6 +32,26 @@ bool constant_memcmp_is_zero(const void *s1, size_t n)
 	return (x == 0);
 }
 
+bool memcpy_check_non_zero(void *dest, size_t dest_size, const void *src, size_t src_size)
+{
+	uint8_t *byte_ptr_dest = dest;
+	const uint8_t *byte_ptr_src = src;
+	uint8_t x = 0;
+
+	if (src_size > dest_size) {
+		return false;
+	}
+
+	for (size_t i = 0; i < src_size; i++) {
+		uint8_t byte = byte_ptr_src[i];
+
+		byte_ptr_dest[i] = byte;
+		x |= byte;
+	}
+
+	return (x != 0);
+}
+
 void safe_memset(void *dest, const size_t dest_size, const uint8_t ch, const size_t n)
 {
 	size_t bytes_to_set = MIN(dest_size, n);


### PR DESCRIPTION
Fixes some double read inconsitiencies and key validation in Cracen key management implementation.