### PR TITLE
requirements: Update nrf-regtool

### DIFF
--- a/scripts/requirements-build.txt
+++ b/scripts/requirements-build.txt
@@ -6,4 +6,4 @@ imagesize>=1.2.0
 intelhex
 pylint
 zcbor~=0.8.0
-nrf-regtool~=5.4.0
+nrf-regtool~=5.5.1

--- a/scripts/requirements-fixed.txt
+++ b/scripts/requirements-fixed.txt
@@ -16,7 +16,7 @@ canopen==2.1.0            # via -r zephyr/scripts/requirements-base.txt
 capstone==4.0.2           # via pyocd
 cbor==1.0.0               # via -r zephyr/scripts/requirements-run-test.txt
 cbor2==5.4.6              # via -r bootloader/mcuboot/scripts/requirements.txt, -r nrf/scripts/requirements-build.txt, imgtool, zcbor
-certifi==2023.7.22        # via requests
+certifi==2024.7.4         # via requests
 cffi==1.15.1              # via cmsis-pack-manager, cryptography, milksnake, pygit2, pynacl
 chardet==5.2.0            # via -r nrf/scripts/requirements-ci.txt
 charset-normalizer==3.2.0  # via requests

--- a/scripts/requirements-fixed.txt
+++ b/scripts/requirements-fixed.txt
@@ -70,7 +70,7 @@ msgpack==1.0.5            # via python-can
 mypy==1.5.1               # via -r zephyr/scripts/requirements-build-test.txt
 mypy-extensions==1.0.0    # via mypy
 natsort==8.4.0            # via pyocd
-nrf-regtool==5.4.0        # via -r nrf/scripts/requirements-build.txt
+nrf-regtool==5.5.1        # via -r nrf/scripts/requirements-build.txt
 nrfcredstore==1.0.0       # via -r nrf/scripts/requirements-extra.txt
 numpy==1.26.4             # via svada
 packaging==24.0           # via -r zephyr/scripts/requirements-base.txt, pkg-about, pytest, python-can, setuptools-scm, west


### PR DESCRIPTION
In order to fix the communication between application and SDFW, it is required to update compatible key matching in nrf-regtool.

Ref: NCSDK-28471

test-sdk-dfu: PR-293