### PR TITLE
scripts: requirements-base.txt update certifi because of CVE

### DIFF
--- a/scripts/requirements-base.txt
+++ b/scripts/requirements-base.txt
@@ -1,1 +1,2 @@
 west>=1.0.0
+certifi >=2024.7.4 # from requests above;  https://nvd.nist.gov/vuln/detail/CVE-2024-39689

--- a/scripts/requirements-fixed.txt
+++ b/scripts/requirements-fixed.txt
@@ -16,7 +16,7 @@ canopen==2.1.0            # via -r zephyr/scripts/requirements-base.txt
 capstone==4.0.2           # via pyocd
 cbor==1.0.0               # via -r zephyr/scripts/requirements-run-test.txt
 cbor2==5.4.6              # via -r bootloader/mcuboot/scripts/requirements.txt, -r nrf/scripts/requirements-build.txt, imgtool, zcbor
-certifi==2023.7.22        # via requests
+certifi==2024.7.4         # via -r nrf/scripts/requirements-base.txt, requests
 cffi==1.15.1              # via cmsis-pack-manager, cryptography, milksnake, pygit2, pynacl
 chardet==5.2.0            # via -r nrf/scripts/requirements-ci.txt
 charset-normalizer==3.2.0  # via requests


### PR DESCRIPTION
certifi >=2024.7.4 # from requests above;  https://nvd.nist.gov/vuln/detail/CVE-2024-39689

Signed-off-by: Thomas Stilwell <Thomas.Stilwell@nordicsemi.no>
