### PR TITLE
samples: nrf_rpc: ps_client: update snippet

### DIFF
--- a/samples/nrf_rpc/ps_client/snippets/log_rpc/log_rpc.conf
+++ b/samples/nrf_rpc/ps_client/snippets/log_rpc/log_rpc.conf
@@ -4,4 +4,5 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+CONFIG_LOG=y
 CONFIG_LOG_FORWARDER_RPC=y


### PR DESCRIPTION
CONFIG_LOG_FORWARDER_RPC requires CONFIG_LOG,
currently we can't build use log_rpc withoud building with
debug snippet.

Signed-off-by: Tomasz Kobylarz <tomasz.kobylarz@nordicsemi.no>
