### PR TITLE
logging: add RPC command to configure log level

### DIFF
--- a/include/logging/log_rpc.h
+++ b/include/logging/log_rpc.h
@@ -21,6 +21,30 @@ extern "C" {
 #endif
 
 /**
+ * nRF RPC logging level.
+ */
+enum log_rpc_level {
+	LOG_RPC_LEVEL_NONE = 0,
+	LOG_RPC_LEVEL_ERR,
+	LOG_RPC_LEVEL_WRN,
+	LOG_RPC_LEVEL_INF,
+	LOG_RPC_LEVEL_DBG,
+};
+
+/**
+ * Sets the logging stream verbosity level.
+ *
+ * Configures the remote device to only stream log messages whose level is less
+ * than or equal to the specified level.
+ *
+ * @param level		Logging level, see @c log_rpc_level.
+ *
+ * @retval 0		On success.
+ * @retval -errno	On failure.
+ */
+int log_rpc_set_stream_level(enum log_rpc_level level);
+
+/**
  * @brief Retrieves the crash log retained on the remote device.
  *
  * The function issues an nRF RPC command to obtain the last crash log retained

--- a/samples/nrf_rpc/ps_client/src/log_rpc_shell.c
+++ b/samples/nrf_rpc/ps_client/src/log_rpc_shell.c
@@ -11,7 +11,29 @@
 
 #include <stdlib.h>
 
-static int log_rpc_get_crash_log_cmd(const struct shell *sh, size_t argc, char *argv[])
+static int cmd_log_rpc_stream_level(const struct shell *sh, size_t argc, char *argv[])
+{
+	int rc = 0;
+	enum log_rpc_level level;
+
+	level = (enum log_rpc_level)shell_strtol(argv[1], 10, &rc);
+
+	if (rc) {
+		shell_error(sh, "Invalid argument: %d", rc);
+		return -EINVAL;
+	}
+
+	rc = log_rpc_set_stream_level(level);
+
+	if (rc) {
+		shell_error(sh, "Error: %d", rc);
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
+
+static int cmd_log_rpc_crash(const struct shell *sh, size_t argc, char *argv[])
 {
 	int rc;
 	char buffer[CONFIG_RPC_CRASH_LOG_READ_BUFFER_SIZE];
@@ -29,12 +51,19 @@ static int log_rpc_get_crash_log_cmd(const struct shell *sh, size_t argc, char *
 
 	shell_fprintf(sh, SHELL_NORMAL, "\n");
 
-	return rc;
+	if (rc) {
+		shell_error(sh, "Error: %d", rc);
+		return -ENOEXEC;
+	}
+
+	return 0;
 }
 
 SHELL_STATIC_SUBCMD_SET_CREATE(log_rpc_cmds,
+			       SHELL_CMD_ARG(stream_level, NULL, "Set stream logging level",
+					     cmd_log_rpc_stream_level, 2, 0),
 			       SHELL_CMD_ARG(crash, NULL, "Retrieve remote device crash log",
-					     log_rpc_get_crash_log_cmd, 1, 0),
+					     cmd_log_rpc_crash, 1, 0),
 			       SHELL_SUBCMD_SET_END);
 
 SHELL_CMD_ARG_REGISTER(log_rpc, &log_rpc_cmds, "RPC logging commands", NULL, 1, 0);

--- a/subsys/logging/log_forwarder_rpc.c
+++ b/subsys/logging/log_forwarder_rpc.c
@@ -13,17 +13,19 @@
 #include "log_rpc_group.h"
 
 #include <logging/log_rpc.h>
+#include <nrf_rpc/nrf_rpc_serialize.h>
 
 #include <nrf_rpc_cbor.h>
 
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/util.h>
 
 LOG_MODULE_REGISTER(remote);
 
 static void log_rpc_msg_handler(const struct nrf_rpc_group *group, struct nrf_rpc_cbor_ctx *ctx,
 				void *handler_data)
 {
-	uint8_t level;
+	enum log_rpc_level level;
 	struct zcbor_string message;
 	bool decoded_ok;
 
@@ -36,16 +38,16 @@ static void log_rpc_msg_handler(const struct nrf_rpc_group *group, struct nrf_rp
 	}
 
 	switch (level) {
-	case LOG_LEVEL_ERR:
+	case LOG_RPC_LEVEL_ERR:
 		LOG_ERR("%.*s", message.len, message.value);
 		break;
-	case LOG_LEVEL_WRN:
+	case LOG_RPC_LEVEL_WRN:
 		LOG_WRN("%.*s", message.len, message.value);
 		break;
-	case LOG_LEVEL_INF:
+	case LOG_RPC_LEVEL_INF:
 		LOG_INF("%.*s", message.len, message.value);
 		break;
-	case LOG_LEVEL_DBG:
+	case LOG_RPC_LEVEL_DBG:
 		LOG_DBG("%.*s", message.len, message.value);
 		break;
 	default:
@@ -55,6 +57,19 @@ static void log_rpc_msg_handler(const struct nrf_rpc_group *group, struct nrf_rp
 
 NRF_RPC_CBOR_EVT_DECODER(log_rpc_group, log_rpc_msg_handler, LOG_RPC_EVT_MSG, log_rpc_msg_handler,
 			 NULL);
+
+int log_rpc_set_stream_level(enum log_rpc_level level)
+{
+	struct nrf_rpc_cbor_ctx ctx;
+
+	NRF_RPC_CBOR_ALLOC(&log_rpc_group, ctx, 1 + sizeof(level));
+	nrf_rpc_encode_uint(&ctx, level);
+	nrf_rpc_cbor_cmd_rsp_no_err(&log_rpc_group, LOG_RPC_CMD_SET_STREAM_LEVEL, &ctx);
+
+	nrf_rpc_cbor_decoding_done(&log_rpc_group, &ctx);
+
+	return 0;
+}
 
 int log_rpc_get_crash_log(size_t offset, char *buffer, size_t buffer_length)
 {

--- a/subsys/logging/log_rpc_group.h
+++ b/subsys/logging/log_rpc_group.h
@@ -32,7 +32,8 @@ enum log_rpc_evt_forwarder {
 };
 
 enum log_rpc_cmd_backend {
-	LOG_RPC_CMD_GET_CRASH_LOG = 0,
+	LOG_RPC_CMD_SET_STREAM_LEVEL = 0,
+	LOG_RPC_CMD_GET_CRASH_LOG = 1,
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
Add RPC command to configure the maximum level of messages that are expected to be streamed to the RPC client.