### PR TITLE
samples: matter: Fixed NVS sectors count in samples configurations

### DIFF
--- a/applications/matter_weather_station/prj.conf
+++ b/applications/matter_weather_station/prj.conf
@@ -86,3 +86,6 @@ CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_NETWORK_LOGS=y
 
 # Enable test event triggers for diagnostic logs testing purposes.
 CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_TEST=y
+
+# Set the NVS sector count to match the settings partition size that is 64 kB for this application.
+CONFIG_SETTINGS_NVS_SECTOR_COUNT=16

--- a/applications/matter_weather_station/prj_release.conf
+++ b/applications/matter_weather_station/prj_release.conf
@@ -81,3 +81,6 @@ CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_NETWORK_LOGS=y
 
 # Enable test event triggers for diagnostic logs testing purposes.
 CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_TEST=y
+
+# Set the NVS sector count to match the settings partition size that is 64 kB for this application.
+CONFIG_SETTINGS_NVS_SECTOR_COUNT=16

--- a/doc/nrf/protocols/matter/end_product/bootloader.rst
+++ b/doc/nrf/protocols/matter/end_product/bootloader.rst
@@ -64,6 +64,11 @@ The nRF Connect platform in Matter uses Zephyr's :ref:`zephyr:settings_api` API 
 This requires that you define the ``settings_storage`` partition in the flash.
 The recommended minimum size of the partition is 32 kB, but you can reserve even more space if your application uses the storage extensively.
 
+The Zephyr settings storage is implemented by the Zephyr NVS (Non-Volatile Storage) module.
+The NVS uses multiple sectors of 4 kB each and it has to use the appropriate number of sectors to cover all settings partition area.
+To configure the number of sectors used by the NVS, set the :kconfig:option:`CONFIG_SETTINGS_NVS_SECTOR_COUNT` Kconfig option to the desired value.
+For example, to cover a settings partition of 32 kB in size, you require 8 sectors.
+
 As you can see in :ref:`ug_matter_hw_requirements_layouts`, Matter samples in the |NCS| reserve exactly 32 kB for the ``settings_storage`` partition.
 
 Factory data partition

--- a/doc/nrf/releases_and_maturity/known_issues.rst
+++ b/doc/nrf/releases_and_maturity/known_issues.rst
@@ -373,6 +373,21 @@ Matter
 
 The issues in this section are related to the :ref:`ug_matter` protocol.
 
+.. rst-class:: v2-7-0 v2-6-1 v2-6-0 v2-5-3 v2-5-2 v2-5-1 v2-5-0 v2-4-3 v2-4-2 v2-4-1 v2-4-0 v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0
+
+KRKNWK-19300: The Matter weather station application has NVS size inconsistent with the settings partition size.
+  The settings partition size for Matter weather station is configured to the value of 64 kB.
+  However, the application cannot use all 64 kB of the settings space, because it depends on the NVS size that is limited by the :kconfig:option:`CONFIG_SETTINGS_NVS_SECTOR_COUNT` Kconfig option to 32 kB.
+
+  **Affected platforms:** Thingy53
+
+  **Workaround:** Set the :kconfig:option:`CONFIG_SETTINGS_NVS_SECTOR_COUNT` Kconfig option to ``16`` in the application :file:`prj.conf` file.
+
+  .. caution::
+
+     The workaround can be applied only to a newly programmed or factory reset device.
+     Changing the NVS sectors count for a device that is in-field and already has some data stored in settings may lead to the data corruption and undefined behavior.
+
 .. rst-class:: v2-7-0
 
 KRKNWK-19199: Matter Lock and Matter Template samples cannot be built in the release configuration for the nRF54H20 platform.

--- a/samples/matter/light_bulb/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/light_bulb/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -26,3 +26,7 @@ CONFIG_TICKLESS_KERNEL=y
 # nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
 CONFIG_CHIP_MALLOC_SYS_HEAP_SIZE=10240
 CONFIG_MPSL_WORK_STACK_SIZE=2048
+CONFIG_CHIP_TASK_STACK_SIZE=7168
+
+# Set the NVS sector count to match the settings partition size that is 40 kB for this application.
+CONFIG_SETTINGS_NVS_SECTOR_COUNT=10

--- a/samples/matter/light_switch/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/light_switch/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -19,3 +19,7 @@ CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT=n
 # nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
 CONFIG_CHIP_MALLOC_SYS_HEAP_SIZE=10240
 CONFIG_MPSL_WORK_STACK_SIZE=2048
+CONFIG_CHIP_TASK_STACK_SIZE=7168
+
+# Set the NVS sector count to match the settings partition size that is 40 kB for this application.
+CONFIG_SETTINGS_NVS_SECTOR_COUNT=10

--- a/samples/matter/lock/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/lock/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -19,3 +19,7 @@ CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT=n
 # nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
 CONFIG_CHIP_MALLOC_SYS_HEAP_SIZE=10240
 CONFIG_MPSL_WORK_STACK_SIZE=2048
+CONFIG_CHIP_TASK_STACK_SIZE=7168
+
+# Set the NVS sector count to match the settings partition size that is 40 kB for this application.
+CONFIG_SETTINGS_NVS_SECTOR_COUNT=10

--- a/samples/matter/template/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/template/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -19,3 +19,7 @@ CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT=n
 # nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
 CONFIG_CHIP_MALLOC_SYS_HEAP_SIZE=10240
 CONFIG_MPSL_WORK_STACK_SIZE=2048
+CONFIG_CHIP_TASK_STACK_SIZE=7168
+
+# Set the NVS sector count to match the settings partition size that is 40 kB for this application.
+CONFIG_SETTINGS_NVS_SECTOR_COUNT=10

--- a/samples/matter/thermostat/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/thermostat/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -19,3 +19,7 @@ CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT=n
 # nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
 CONFIG_CHIP_MALLOC_SYS_HEAP_SIZE=10240
 CONFIG_MPSL_WORK_STACK_SIZE=2048
+CONFIG_CHIP_TASK_STACK_SIZE=7168
+
+# Set the NVS sector count to match the settings partition size that is 40 kB for this application.
+CONFIG_SETTINGS_NVS_SECTOR_COUNT=10

--- a/samples/matter/window_covering/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/window_covering/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -19,3 +19,7 @@ CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT=n
 # nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
 CONFIG_CHIP_MALLOC_SYS_HEAP_SIZE=10240
 CONFIG_MPSL_WORK_STACK_SIZE=2048
+CONFIG_CHIP_TASK_STACK_SIZE=7168
+
+# Set the NVS sector count to match the settings partition size that is 40 kB for this application.
+CONFIG_SETTINGS_NVS_SECTOR_COUNT=10

--- a/west.yml
+++ b/west.yml
@@ -160,7 +160,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: a16456f1557cbc0d12a42639b5f858b0e2b71840
+      revision: b6d6e9a8885ce8390e1847e7a986ecbbdcbc277d
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
Several configurations contain settings partition of a size inconsistent with the default NVS sectors count, which results in using smaller NVS size than expected.