### PR TITLE
applications: matter-ble bridge over thread

### DIFF
--- a/applications/matter_bridge/Kconfig
+++ b/applications/matter_bridge/Kconfig
@@ -163,6 +163,19 @@ config BRIDGE_SMART_PLUG_SUPPORT
 	bool "Enables additional endpoint implementing Matter smart plug functionality"
 	default n
 
+# Sample configuration used for Thread networking
+if NET_L2_OPENTHREAD
+
+choice OPENTHREAD_NORDIC_LIBRARY_CONFIGURATION
+	default OPENTHREAD_NORDIC_LIBRARY_FTD
+endchoice
+
+choice OPENTHREAD_DEVICE_TYPE
+	default OPENTHREAD_FTD
+endchoice
+
+endif # NET_L2_OPENTHREAD
+
 source "${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/chip-module/Kconfig.features"
 source "${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/chip-module/Kconfig.defaults"
 source "${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common/src/bridge/Kconfig"

--- a/applications/matter_bridge/Kconfig.sysbuild
+++ b/applications/matter_bridge/Kconfig.sysbuild
@@ -17,6 +17,11 @@ choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT if !SOC_SERIES_NRF54HX
 endchoice
 
+# Enable IEEE802.15.4 serialization to network core
+# This config automatically pulls in the `overlay-802154.conf` in the ipc_radio image
+config NETCORE_IPC_RADIO_IEEE802154
+	default y if (SOC_SERIES_NRF53X || SOC_SERIES_NRF54HX) && !WIFI_NRF700X
+
 if BOOTLOADER_MCUBOOT
 
 #### DFU multi-image support
@@ -33,7 +38,7 @@ config PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY
 if SOC_SERIES_NRF53X
 
 config MCUBOOT_UPDATEABLE_IMAGES
-	default 3 if BOARD_NRF5340DK_NRF5340_CPUAPP #### Support for WiFi patch on external flash memory.
+	default 3 if (BOARD_NRF5340DK_NRF5340_CPUAPP && WIFI_NRF700X) #### Support for WiFi patch on external flash memory.
 	default 2
 
 choice MCUBOOT_MODE

--- a/applications/matter_bridge/README.rst
+++ b/applications/matter_bridge/README.rst
@@ -7,7 +7,8 @@ The Matter bridge application can be used to build a :ref:`bridge <ug_matter_ove
 The bridge device allows the use of non-Matter devices in a :ref:`Matter fabric <ug_matter_network_topologies_structure>` by exposing them as Matter endpoints.
 The devices on the non-Matter side of the Matter bridge are called *bridged devices*.
 
-The Matter bridge device works as a Matter accessory device, meaning it can be paired and controlled remotely over a Matter network built on top of a low-power 802.11ax (Wi-Fi 6) network.
+The Matter bridge device functions as a Matter accessory, allowing it to be paired with and controlled through a Matter network.
+This network can be constructed using either a low-power 802.11ax (Wi-Fi 6) or 802.15.4 (Thread) protocol.
 
 Currently the Matter bridge application supports the following types of *bridged devices*:
 

--- a/applications/matter_bridge/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/applications/matter_bridge/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Set 10 BLE connections, as it is an upper limit supported caused by RAM usage due to using Thread and BLE at same time.
+CONFIG_BT_MAX_CONN=10
+
+# Set buffer sizes in a consistent way with the ones used by the network core.
+#id if oncomment it there is an error that rx buffer is out of range (minimal value is 69)
+CONFIG_BT_BUF_ACL_RX_SIZE=69
+CONFIG_BT_BUF_ACL_TX_SIZE=69
+
+# Set MTU size to fit in the single buffer and avoid fragmentation (BUF_SIZE = MTU_SIZE + 4 B of L2CAP header).
+CONFIG_BT_L2CAP_TX_MTU=65
+
+# Set max number of bridged BLE devices, which is CONFIG_BT_MAX_CONN-1, as 1 connection is reserved for Matter.
+CONFIG_BRIDGE_MAX_BRIDGED_DEVICES_NUMBER=9
+CONFIG_BT_MAX_PAIRED=9
+
+# Assume that every bridged device uses 2 endpoints, however it can be increased if specific use case requires it.
+CONFIG_BRIDGE_MAX_DYNAMIC_ENDPOINTS_NUMBER=18
+# 15.4 RX buffers were decreased to save RAM
+CONFIG_NRF_802154_RX_BUFFERS=14

--- a/applications/matter_bridge/doc/matter_bridge_description.rst
+++ b/applications/matter_bridge/doc/matter_bridge_description.rst
@@ -532,18 +532,79 @@ Since the Matter stack uses one Bluetooth LE connection for commissioning, the m
 
 Increasing the number of Bluetooth LE connections affects the RAM usage on both the application and network cores.
 The current maximum number of Bluetooth LE connections that can be selected using the default configuration is ``10``.
-You can increase the number of Bluetooth LE connections if you decrease the size of the Bluetooth LE TX/RX buffers used by the Bluetooth controller, but this will decrease the communication throughput.
-Build the target using the following command in the project directory to enable a configuration that increases the number of Bluetooth LE connections to ``20`` by decreasing the sizes of Bluetooth LE TX/RX buffers:
 
-.. parsed-literal::
-   :class: highlight
+.. tabs::
 
-   west build -b nrf7002dk/nrf5340/cpuapp -- -DCONFIG_BRIDGED_DEVICE_BT=y -DEXTRA_CONF_FILE="overlay-bt_max_connections_app.conf" -Dipc_radio_EXTRA_CONF_FILE="overlay-bt_max_connections_net.conf"
+   You can configure the number of Bluetooth LE bridged devices depending on your device and configuration:
 
-.. parsed-literal::
-   :class: highlight
+   .. group-tab:: nRF53 DKs
 
-   west build -b nrf54h20dk/nrf54h20/cpuapp -- -DSB_CONFIG_WIFI_NRF700X=y -DCONFIG_CHIP_WIFI=y -Dmatter_bridge_SHIELD=nrf700x_nrf54h20dk -DCONFIG_BRIDGED_DEVICE_BT=y -DEXTRA_CONF_FILE="overlay-bt_max_connections_app.conf" -Dipc_radio_EXTRA_CONF_FILE="overlay-bt_max_connections_net.conf"
+      The nRF53 Series supports the Matter bridge over Wi-Fi and Matter bridge over Thread configurations.
+
+      .. tabs::
+
+         .. group-tab:: Matter bridge over Wi-Fi
+
+            You can increase the number of Bluetooth LE connections if you decrease the size of the Bluetooth LE TX/RX buffers used by the Bluetooth controller, but this will decrease the communication throughput.
+
+            Build the target using the following command in the project directory to enable a configuration that increases the number of Bluetooth LE connections to ``20`` by decreasing the size of Bluetooth LE TX/RX buffers:
+
+            .. parsed-literal::
+               :class: highlight
+
+               west build -b nrf5340dk/nrf5340/cpuapp -p -- -Dmatter_bridge_SHIELD=nrf7002ek -DSB_CONFIG_WIFI_PATCHES_EXT_FLASH_STORE=y -DSB_CONFIG_DFU_MULTI_IMAGE_PACKAGE_WIFI_FW_PATCH=y -DSB_CONFIG_WIFI_NRF700X=y -Dmcuboot_CONFIG_UPDATEABLE_IMAGE_NUMBER=3 -DCONFIG_BRIDGED_DEVICE_BT=y -DEXTRA_CONF_FILE="overlay-bt_max_connections_app.conf" -Dipc_radio_EXTRA_CONF_FILE="overlay-bt_max_connections_net.conf" -DFILE_SUFFIX=nrf70ek
+
+         .. group-tab:: Matter bridge over Thread
+
+            You can not increase the default number of Bluetooth LE connections in this configuration using overlays.
+            This is because the configuration uses both Thread and Bluetooth LE protocols, and limited RAM memory.
+            You can still increase the number of connections by modifying the board files and decreasing the buffer sizes.
+            The default number of connections is nine.
+
+   .. group-tab:: nRF54 DKs
+
+      The nRF54 Series supports the Matter bridge over Wi-Fi and Matter bridge over Thread configurations.
+
+      .. tabs::
+
+         .. group-tab:: Matter bridge over Wi-Fi
+
+            You can increase the number of Bluetooth LE connections if you decrease the size of the Bluetooth LE TX/RX buffers used by the Bluetooth controller, but this will decrease the communication throughput.
+
+            Build the target using the following command in the project directory to enable a configuration that increases the number of Bluetooth LE connections to ``20`` by decreasing the sizes of Bluetooth LE TX/RX buffers:
+
+             .. parsed-literal::
+               :class: highlight
+
+               west build -b nrf54h20dk/nrf54h20/cpuapp -p -- -DSB_CONFIG_WIFI_NRF700X=y -DCONFIG_CHIP_WIFI=y -Dmatter_bridge_SHIELD=nrf700x_nrf54h20dk -DCONFIG_BRIDGED_DEVICE_BT=y -DEXTRA_CONF_FILE="overlay-bt_max_connections_app.conf" -Dipc_radio_EXTRA_CONF_FILE="overlay-bt_max_connections_net.conf"
+
+         .. group-tab:: Matter bridge over Thread
+
+            You can increase the number of Bluetooth LE connections if you decrease the size of the Bluetooth LE TX/RX buffers used by the Bluetooth controller, but this will decrease the communication throughput.
+
+            Build the target using the following command in the project directory to enable a configuration that increases the number of Bluetooth LE connections to ``20`` by decreasing the sizes of Bluetooth LE TX/RX buffers:
+
+             .. parsed-literal::
+               :class: highlight
+
+               west build -b nrf54h20dk/nrf54h20/cpuapp -p -- -DCONFIG_BRIDGED_DEVICE_BT=y -DEXTRA_CONF_FILE="overlay-bt_max_connections_app.conf" -Dipc_radio_EXTRA_CONF_FILE="overlay-bt_max_connections_net.conf"
+
+   .. group-tab:: nRF70 DKs
+
+      The nRF70 Series supports the Matter bridge over Wi-Fi configuration.
+
+      .. tabs::
+
+         .. group-tab:: Matter-Bridge over Wi-Fi
+
+            You can increase the number of Bluetooth LE connections if you decrease the size of the Bluetooth LE TX/RX buffers used by the Bluetooth controller, but this will decrease the communication throughput.
+
+            Build the target using the following command in the project directory to enable a configuration that increases the number of Bluetooth LE connections to ``20`` by decreasing the sizes of Bluetooth LE TX/RX buffers:
+
+             .. parsed-literal::
+               :class: highlight
+
+               west build -b nrf7002dk/nrf5340/cpuapp -- -DCONFIG_BRIDGED_DEVICE_BT=y -DEXTRA_CONF_FILE="overlay-bt_max_connections_app.conf" -Dipc_radio_EXTRA_CONF_FILE="overlay-bt_max_connections_net.conf"
 
 .. _matter_bridge_app_bt_security:
 
@@ -611,6 +672,13 @@ The application supports the following configurations:
      - Release version of the application.
 
        Enables only the necessary application functionalities to optimize its performance.
+   * - Matter bridge over Wi-Fi with nRF5340 DK and nRF7002 EK
+     - :file:`---`
+     - ``nrf70ek``
+     - nRF5340 DK with the nRF7002 EK shield attached
+     - Debug version of the application with Matter over Wi-Fi enabled.
+
+       Enables the Matter Bridge to work with Wi-Fi on nRF5340 DK.
 
 Building and running
 ********************
@@ -627,7 +695,7 @@ For example:
 
    .. code-block:: console
 
-      west build -b nrf5340dk/nrf5340/cpuapp -p -- -Dmatter_bridge_SHIELD=nrf7002ek -DSB_CONFIG_WIFI_PATCHES_EXT_FLASH_STORE=y -DSB_CONFIG_DFU_MULTI_IMAGE_PACKAGE_WIFI_FW_PATCH=y -DSB_CONFIG_WIFI_NRF700X=y -Dmcuboot_CONFIG_UPDATEABLE_IMAGE_NUMBER=3
+      west build -b nrf5340dk/nrf5340/cpuapp -p -- -Dmatter_bridge_SHIELD=nrf7002ek -DSB_CONFIG_WIFI_PATCHES_EXT_FLASH_STORE=y -DSB_CONFIG_DFU_MULTI_IMAGE_PACKAGE_WIFI_FW_PATCH=y -DSB_CONFIG_WIFI_NRF700X=y -Dmcuboot_CONFIG_UPDATEABLE_IMAGE_NUMBER=3 -DFILE_SUFFIX=nrf70ek
 
 
 To use the nRF54H20 DK with the ``nrf7002ek`` shield (2.4 GHz or 5 GHz), follow the :ref:`ug_nrf7002eb_nrf54h20dk_gs` user guide to connect all required pins.

--- a/applications/matter_bridge/pm_static_nrf5340dk_nrf5340_cpuapp_nrf70ek.yml
+++ b/applications/matter_bridge/pm_static_nrf5340dk_nrf5340_cpuapp_nrf70ek.yml
@@ -45,9 +45,33 @@ mcuboot_secondary_1:
   size: 0x40000
   device: MX25R64
   region: external_flash
-external_flash:
+nrf70_wifi_fw_mcuboot_pad:
   address: 0x12F000
-  size: 0x6D1000
+  size: 0x200
+  device: MX25R64
+  region: external_flash
+nrf70_wifi_fw:
+  address: 0x12F200
+  size: 0x20000
+  device: MX25R64
+  region: external_flash
+mcuboot_primary_2:
+  orig_span: &id003
+  - nrf70_wifi_fw_mcuboot_pad
+  - nrf70_wifi_fw
+  span: *id003
+  address: 0x12F000
+  size: 0x21000
+  device: MX25R64
+  region: external_flash
+mcuboot_secondary_2:
+  address: 0x150000
+  size: 0x21000
+  device: MX25R64
+  region: external_flash
+external_flash:
+  address: 0x171000
+  size: 0x68F000
   device: MX25R64
   region: external_flash
 pcd_sram:

--- a/applications/matter_bridge/sample.yaml
+++ b/applications/matter_bridge/sample.yaml
@@ -58,6 +58,7 @@ tests:
       mcuboot_CONFIG_UPDATEABLE_IMAGE_NUMBER=3 SB_CONFIG_WIFI_NRF700X=y
       SB_CONFIG_DFU_MULTI_IMAGE_PACKAGE_WIFI_FW_PATCH=y
       CONFIG_CHIP_DFU_OVER_BT_SMP=y
+      FILE_SUFFIX=nrf70ek
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
@@ -72,67 +73,12 @@ tests:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
     tags: sysbuild ci_applications_matter
-  applications.matter_bridge.nrf54h20.br_ble:
-    sysbuild: true
-    build_only: true
-    extra_args: SB_CONFIG_WIFI_NRF700X=y
-      CONFIG_CHIP_WIFI=y
-      matter_bridge_SHIELD=nrf700x_nrf54h20dk
-      CONFIG_BRIDGED_DEVICE_BT=y
-    integration_platforms:
-      - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf54h20dk/nrf54h20/cpuapp
-    tags: sysbuild ci_applications_matter
-  applications.matter_bridge.nrf54h20:
-    sysbuild: true
-    build_only: true
-    extra_args: SB_CONFIG_WIFI_NRF700X=y
-      CONFIG_CHIP_WIFI=y
-      matter_bridge_SHIELD=nrf700x_nrf54h20dk
-      CONFIG_BRIDGED_DEVICE_SIMULATED=y
-    integration_platforms:
-      - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf54h20dk/nrf54h20/cpuapp
-    tags: sysbuild ci_applications_matter
-  applications.matter_bridge.nrf54h20.br_ble.smart_plug:
-    sysbuild: true
-    build_only: true
-    extra_args: SB_CONFIG_WIFI_NRF700X=y
-      CONFIG_CHIP_WIFI=y
-      matter_bridge_SHIELD=nrf700x_nrf54h20dk
-      CONFIG_BRIDGED_DEVICE_BT=y
-      matter_bridge_SNIPPET=onoff_plug
-    integration_platforms:
-      - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf54h20dk/nrf54h20/cpuapp
-    tags: sysbuild ci_applications_matter
-  applications.matter_bridge.nrf54h20.smart_plug:
-    sysbuild: true
-    build_only: true
-    extra_args: SB_CONFIG_WIFI_NRF700X=y
-      CONFIG_CHIP_WIFI=y
-      matter_bridge_SHIELD=nrf700x_nrf54h20dk
-      CONFIG_BRIDGED_DEVICE_SIMULATED=y
-      matter_bridge_SNIPPET=onoff_plug
-    integration_platforms:
-      - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf54h20dk/nrf54h20/cpuapp
-    tags: sysbuild ci_applications_matter
-  applications.matter_bridge.br_ble.smart_plug:
+  applications.matter_bridge.nrf5340.br_ble.smart_plug.thread:
     sysbuild: true
     build_only: true
     extra_args: CONFIG_BRIDGED_DEVICE_BT=y
       matter_bridge_SNIPPET=onoff_plug
     integration_platforms:
-      - nrf7002dk/nrf5340/cpuapp
-    platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: sysbuild ci_applications_matter
-  applications.matter_bridge.smart_plug:
-    sysbuild: true
-    build_only: true
-    extra_args: CONFIG_BRIDGED_DEVICE_SIMULATED=y
-      matter_bridge_SNIPPET=onoff_plug
-    integration_platforms:
-      - nrf7002dk/nrf5340/cpuapp
-    platform_allow: nrf7002dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp
+    platform_allow: nrf5340dk/nrf5340/cpuapp
     tags: sysbuild ci_applications_matter

--- a/applications/matter_bridge/sysbuild/ipc_radio/boards/nrf5340dk_nrf5340_cpunet.conf
+++ b/applications/matter_bridge/sysbuild/ipc_radio/boards/nrf5340dk_nrf5340_cpunet.conf
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Set 10 BLE connections, as it is an upper limit supported caused by RAM usage due to using Thread and BLE at same time.
+CONFIG_BT_MAX_CONN=10
+
+# Decrease stack and buffer sizes to free some RAM and support 10 BLE connections
+CONFIG_MAIN_STACK_SIZE=512
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=512
+CONFIG_BT_BUF_ACL_RX_SIZE=69
+CONFIG_BT_BUF_ACL_TX_SIZE=69
+CONFIG_BT_CTLR_DATA_LENGTH_MAX=69
+# 15.4 RX buffers were decreased to save RAM
+CONFIG_NRF_802154_RX_BUFFERS=14
+
+# NRF_802154_ENCRYPTION is not enabled by default in the `overlay-802154.conf` file
+# that is pulled in by NETCORE_IPC_RADIO_IEEE802154 in application's Kconfig.sysbuild.
+# For Wi-Fi builds, this option will not get applied anyway.
+CONFIG_NRF_802154_ENCRYPTION=y

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -219,6 +219,7 @@ Matter Bridge
     By default, the option points to the :file:`src/default_zap` directory and can be changed to any path relative to application's location that contains the ZAP file and :file:`zap-generated` directory.
   * Support for the :ref:`zephyr:nrf54h20dk_nrf54h20`.
   * Optional smart plug device functionality.
+  * Support for the Thread protocol.
 
 nRF5340 Audio
 -------------

--- a/samples/matter/common/src/bridge/Kconfig
+++ b/samples/matter/common/src/bridge/Kconfig
@@ -48,4 +48,32 @@ config BRIDGE_BT_MINIMUM_SECURITY_LEVEL
 	   allowed to connect to the bridge. The level cannot be set to a value smaller than 2, as it would mean that
 	   the communication with the connected devices will not be encrypted, what is not considered to be secure.
 
+config BRIDGE_BT_SCAN_WINDOW
+	int "Time duration of a central actively scanning for devices within scan interval, it is equal BRIDGE_BT_SCAN_WINDOW*0.625 ms"
+	default 40  if NET_L2_OPENTHREAD # It is necessary to decrease Bluetooth LE activity to leave some radio time to Thread
+	default 48
+
+config BRIDGE_BT_SCAN_INTERVAL
+	int "Time between consecutive Bluetooth scan windows, it is equal BRIDGE_BT_SCAN_INTERVAL*0.625 ms"
+	default 160 if NET_L2_OPENTHREAD # It is necessary to decrease Bluetooth LE activity to leave some radio time to Thread
+	default 96
+
+config BRIDGE_BT_CONNECTION_INTERVAL_MIN
+	int "It is the minimum duration of time requested by central after the peripheral device should wake up to communicate, it is equal BRIDGE_BT_CONNECTION_INTERVAL_MIN*1.25 ms"
+	default 80 if NET_L2_OPENTHREAD # It is necessary to decrease Bluetooth LE activity to leave some radio time to Thread
+	default 24
+
+config BRIDGE_BT_CONNECTION_INTERVAL_MAX
+	int "It is the maximum duration of time requested by central after the peripheral device should wake up to communicate, it is equal BRIDGE_BT_CONNECTION_INTERVAL_MAX*1.25 ms"
+	default 80 if NET_L2_OPENTHREAD # It is necessary to decrease Bluetooth LE activity to leave some radio time to Thread
+	default 40
+
+config BRIDGE_BT_CONNECTION_TIMEOUT
+	int "The time since the last packet was successfully received until the devices consider the connection lost, it is equal BRIDGE_BT_CONNECTION_TIMEOUT cs"
+	default 400
+
+config BRIDGE_BT_CONNECTION_LATENCY
+	int "It allows the peripheral to skip waking up for a certain number of connection events if it does not have any data to send"
+	default 0
+
 endif

--- a/samples/matter/common/src/bridge/ble_connectivity_manager.cpp
+++ b/samples/matter/common/src/bridge/ble_connectivity_manager.cpp
@@ -433,15 +433,31 @@ CHIP_ERROR BLEConnectivityManager::Init(const bt_uuid **serviceUuids, uint8_t se
 	}
 #endif /* CONFIG_BT_SMP */
 
+	struct bt_le_scan_param scan_param = {
+		.type = BT_LE_SCAN_TYPE_PASSIVE,
+		.options = BT_LE_SCAN_OPT_FILTER_DUPLICATE,
+		.interval = CONFIG_BRIDGE_BT_SCAN_INTERVAL,
+		.window = CONFIG_BRIDGE_BT_SCAN_WINDOW,
+	};
+
+	struct bt_le_conn_param conn_param = {
+		.interval_min = CONFIG_BRIDGE_BT_CONNECTION_INTERVAL_MIN,
+		.interval_max = CONFIG_BRIDGE_BT_CONNECTION_INTERVAL_MAX,
+		.latency = CONFIG_BRIDGE_BT_CONNECTION_LATENCY,
+		.timeout = CONFIG_BRIDGE_BT_CONNECTION_TIMEOUT,
+	};
+
 	bt_scan_init_param scan_init = {
+		.scan_param = &scan_param,
 		.connect_if_match = 0,
+		.conn_param = &conn_param,
 	};
 
 	bt_scan_init(&scan_init);
 	bt_scan_cb_register(&scan_cb);
 
 	return PrepareFilterForUuid();
-}
+} // namespace Nrf
 
 CHIP_ERROR BLEConnectivityManager::PrepareFilterForUuid()
 {


### PR DESCRIPTION
- modyfiy application configuration files, and  board files, to create support for nrf5340, in matter-bridge application.
- create support for nrf54h20.
- create .conf files to maximize BLE connections
- update sample.yaml
- update documentation