### PR TITLE
nrf_rpc: protocol_serialization: Increase stack size for nrfrpc.

### DIFF
--- a/applications/protocols_serialization/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/applications/protocols_serialization/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -4,3 +4,4 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 CONFIG_MAIN_STACK_SIZE=4196
+CONFIG_NRF_RPC_THREAD_STACK_SIZE=6144

--- a/applications/protocols_serialization/snippets/ble/ble.conf
+++ b/applications/protocols_serialization/snippets/ble/ble.conf
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2144
-
 # Enable and configure Bluetooth LE
 CONFIG_BT=y
 CONFIG_BT_RPC=y


### PR DESCRIPTION
Increase stack size for nRF54l in protocol serialization server. Currently crypto operations take over 5KiB to compleate.