### PR TITLE
samples: net: https_client: Fix client cert match

### DIFF
--- a/lib/modem_key_mgmt/modem_key_mgmt.c
+++ b/lib/modem_key_mgmt/modem_key_mgmt.c
@@ -225,6 +225,14 @@ int modem_key_mgmt_cmp(nrf_sec_tag_t sec_tag,
 		goto out;
 	}
 
+	if (*(end - 1) == '\n') {
+		end--;
+	}
+
+	if (((char *)buf)[len - 1] == '\n') {
+		len--;
+	}
+
 	if (end - begin != len) {
 		LOG_DBG("Credential length mismatch");
 		err = 1;

--- a/samples/net/https_client/README.rst
+++ b/samples/net/https_client/README.rst
@@ -99,63 +99,126 @@ After programming the sample to your development kit, test it by performing the 
 Sample output
 =============
 
-Output for the default configuration (dual stack, IPV4V6) where the carrier does not support IPv6:
+.. tabs::
 
-.. code-block:: console
+   .. group-tab:: Wi-Fi
 
-   HTTPS client sample started
-   Certificate match
-   Waiting for network.. PDP context 0 activated
-   OK
-   Waiting for IPv6..
-   IPv6 not available
-   Looking up example.com
-   Resolved 93.184.216.34 (AF_INET)
-   Connecting to example.com:443
-   Sent 61 bytes
-   Received 370 bytes
+      Output for the default configuration (dual stack, IPV4V6) where the network does not support IPv6:
 
-   >        HTTP/1.1 200 OK
+      .. code-block:: console
 
-   Finished, closing socket.
-   PDP context 0 deactivated
+         HTTPS client sample started
+         Bringing network interface up
+         Provisioning certificate
+         Connecting to the network
+         <add your wifi configuration using shell here if not pre-provisioned>
+         <inf> wifi_mgmt_ext: Connection requested
+         Network connectivity established and IP address assigned
+         Looking up example.com
+         Resolved 93.184.215.14 (AF_INET)
+         Connecting to example.com:443
+         Sent 61 bytes
+         Received 377 bytes
 
-Output for the default configuration, where the carrier does support IPv6:
+         >        HTTP/1.1 200 OK
 
-.. code-block:: console
+         Finished, closing socket.
+         Network connectivity lost
+         Disconnected from the network
 
-   HTTPS client sample started
-   Bringing network interface up
-   Provisioning certificate
-   Certificate match
-   Connecting to the network
-   Looking up example.com
-   Resolved 2606:2800:220:1:248:1893:25c8:1946 (AF_INET6)
-   Connecting to example.com:443
-   Sent 61 bytes
-   Received 370 bytes
+   .. group-tab:: Cellular
 
-   >        HTTP/1.1 200 OK
+      Output for the default configuration (dual stack, IPV4V6) where the carrier does not support IPv6:
 
-   Finished, closing socket.
-   PDP context 0 deactivated
+      .. code-block:: console
 
-Output where you override the default packet data network (PDN) configuration to IPv4 only, using the ``overlay-pdn-nrf91-ipv4.conf`` overlay:
+         HTTPS client sample started
+         Bringing network interface up
+         Provisioning certificate
+         Certificate mismatch
+         Provisioning certificate to the modem
+         Connecting to the network
+         +CGEV: EXCE STATUS 0
+         +CEREG: 2,"8169","0149FB00",7
+         +CSCON: 1
+         +CGEV: ME PDN ACT 0
+         +CEREG: 1,"8169","0149FB00",7,,,"11100000","11100000"
+         Network connectivity established and IP address assigned
+         Looking up example.com
+         Resolved 93.184.215.14 (AF_INET)
+         Connecting to example.com:443
+         Sent 61 bytes
+         Received 377 bytes
 
-.. code-block:: console
+         >        HTTP/1.1 200 OK
 
-   HTTPS client sample started
-   Bringing network interface up
-   Provisioning certificate
-   Looking up example.com
-   Resolved 93.184.216.34 (AF_INET)
-   Connecting to example.com:443
-   Sent 61 bytes
-   Received 370 bytes
+         Finished, closing socket.
+         +CEREG: 0
+         +CGEV: ME DETACH
+         +CSCON: 0
+         Network connectivity lost
+         Disconnected from the network
 
-   >        HTTP/1.1 200 OK
+      Output for the default configuration, where the carrier does support IPv6:
 
-   Finished, closing socket.
+      .. code-block:: console
+
+         HTTPS client sample started
+         Bringing network interface up
+         Provisioning certificate
+         Certificate match
+         Connecting to the network
+         +CGEV: EXCE STATUS 0
+         +CEREG: 2,"8169","0149FB00",7
+         +CSCON: 1
+         +CGEV: ME PDN ACT 0
+         +CEREG: 1,"8169","0149FB00",7,,,"11100000","11100000"
+         Network connectivity established and IP address assigned
+         Looking up example.com
+         +CGEV: IPV6 0
+         Resolved 2606:2800:21f:cb07:6820:80da:af6b:8b2c (AF_INET6)
+         Connecting to example.com:443
+         Sent 61 bytes
+         Received 377 bytes
+
+         >        HTTP/1.1 200 OK
+
+         Finished, closing socket.
+         +CEREG: 0
+         +CGEV: ME DETACH
+         +CSCON: 0
+         Network connectivity lost
+         Disconnected from the net
+
+      Output where you override the default packet data network (PDN) configuration to IPv4 only, using the ``overlay-pdn-nrf91-ipv4.conf`` overlay:
+
+      .. code-block:: console
+
+         HTTPS client sample started
+         Bringing network interface up
+         Provisioning certificate
+         Certificate match
+         Connecting to the network
+         +CGEV: EXCE STATUS 0
+         +CEREG: 2,"8169","0149FB00",7
+         +CSCON: 1
+         +CGEV: ME PDN ACT 0
+         +CEREG: 1,"8169","0149FB00",7,,,"11100000","11100000"
+         Network connectivity established and IP address assigned
+         Looking up example.com
+         Resolved 93.184.215.14 (AF_INET)
+         Connecting to example.com:443
+         Sent 61 bytes
+         Received 377 bytes
+
+         >        HTTP/1.1 200 OK
+
+         Finished, closing socket.
+         +CEREG: 0
+         +CGEV: ME DETACH
+         +CSCON: 0
+         Network connectivity lost
+         Disconnected from the network
 
 Dependencies
 ************

--- a/samples/net/https_client/src/main.c
+++ b/samples/net/https_client/src/main.c
@@ -95,11 +95,11 @@ int cert_provision(void)
 		}
 	}
 
-	printk("Provisioning certificate\n");
+	printk("Provisioning certificate to the modem\n");
 
 	/*  Provision certificate to the modem */
 	err = modem_key_mgmt_write(TLS_SEC_TAG, MODEM_KEY_MGMT_CRED_TYPE_CA_CHAIN, cert,
-				   sizeof(cert) - 1);
+				   sizeof(cert));
 	if (err) {
 		printk("Failed to provision certificate, err %d\n", err);
 		return err;


### PR DESCRIPTION
Allow compare to not be strict about ending newline when comparing
the given certificate with the one in the modem.