### PR TITLE
mpsl: cx: Remove TIMER1 from the 1-wire coex implementation

### DIFF
--- a/subsys/mpsl/cx/Kconfig
+++ b/subsys/mpsl/cx/Kconfig
@@ -80,7 +80,6 @@ config MPSL_CX_BT_1WIRE
 	depends on SOC_COMPATIBLE_NRF52X
 	select NRFX_GPIOTE
 	select GPIO
-	select NRFX_TIMER1
 	bool "Bluetooth Radio 1-Wire Coexistence"
 	help
 	  Radio Coexistence interface implementation using a simple 1-wire PTA

--- a/subsys/mpsl/cx/bluetooth/mpsl_cx_1w_bluetooth.c
+++ b/subsys/mpsl/cx/bluetooth/mpsl_cx_1w_bluetooth.c
@@ -22,8 +22,6 @@
 #include <nrfx_gpiote.h>
 #include <mpsl_coex.h>
 
-#define COEX_TIMER NRF_TIMER1
-
 #if DT_NODE_HAS_STATUS(DT_PHANDLE(DT_NODELABEL(radio), coex), okay)
 #define COEX_NODE DT_PHANDLE(DT_NODELABEL(radio), coex)
 #else


### PR DESCRIPTION
Nowhere in this implementation is this timer actuall used.