### PR TITLE
mpsl: cx: Add a generic coex variant using a single GPIO

### DIFF
--- a/doc/nrf/app_dev/device_guides/wifi_coex.rst
+++ b/doc/nrf/app_dev/device_guides/wifi_coex.rst
@@ -242,6 +242,77 @@ To enable the generic three-wire coexistence, do the following:
    * :kconfig:option:`CONFIG_MPSL_CX`
    * :kconfig:option:`CONFIG_MPSL_CX_3WIRE`
 
+.. _ug_radio_mpsl_cx_generic_1wire:
+
+Generic one wire coexistence
+============================
+
+Refer to :ref:`ug_radio_coex_mpsl_cx_based` for the general requirements of this implementation.
+
+An example use-case of the generic one wire coexistence interface is to allow a protocol implementation to coexist alongside an LTE device on a separate chip, such as the nRF91 Series SiP.
+
+Hardware description
+--------------------
+
+The generic one wire interface consists of the signals listed in the table below.
+The *Pin* is a generic pin name of a PTA, identified rather by its function.
+The *Direction* is from the point of view of the SoC running the coexistence protocol.
+The *DT property* is the name of the devicetree node property that configures the connection between the SoC running the coexistence protocol and the other device.
+
+.. table:: Generic one wire coexistence protocol pins
+
+   ============  =========  =================================  ==============
+   Pin           Direction  Description                        DT property
+   ============  =========  =================================  ==============
+   GRANT         In         Grant signal                       grant-gpios
+   ============  =========  =================================  ==============
+
+In cases where the GPIO is asserted after the radio activity has begun, the ``GRANT`` signal triggers a software interrupt, which in turn disables the radio.
+No guarantee is made on the latency of this interrupt, but the ISR priority is configurable.
+
+Enabling generic one wire coexistence
+-------------------------------------
+
+To enable the generic one wire coexistence, do the following:
+
+
+1. Add the following node to the devicetree source file:
+
+   .. code-block::
+
+      / {
+            nrf_radio_coex: radio_coex_one_wire {
+               status = "okay";
+               compatible = "generic-radio-coex-one-wire";
+               grant-gpios =   <&gpio0 25 GPIO_ACTIVE_LOW>;
+               concurrency-mode = <0>;
+         };
+      };
+
+   The ``concurrency-mode`` property is optional and can be removed.
+   By default, or when set to 0, the ``GRANT`` signal will prevent both TX and RX.
+   When set to 1, it will only prevent TX.
+
+#. Optionally, if not using the nRF91 Series SiP, the ``GRANT`` signal may be configured active-high using ``GPIO_ACTIVE_HIGH``
+#. Optionally, replace the node name ``radio_coex_one_wire`` with a custom one.
+#. If not already present in the device tree, the GPIOTE interrupt may additionally be configured as follows (the first element is the IRQn, and the second is the priority):
+
+   .. code-block::
+
+      &gpiote {
+        interrupts = < 6 3 >;
+      };
+
+#. Replace the pin number provided for the ``grant-gpios`` property:
+   This is the GPIO characteristic of the device that interfaces with the ``GRANT`` signal of the PTA (RF medium access granted).
+
+   The first element ``&gpio0`` indicates the GPIO port (``port 0`` has been selected in the example shown).
+   The second element is the pin number on that port.
+
+#. Enable the following Kconfig options:
+
+   * :kconfig:option:`CONFIG_MPSL_CX`
+   * :kconfig:option:`CONFIG_MPSL_CX_1WIRE`
 
 .. _ug_radio_mpsl_cx_custom:
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -579,6 +579,9 @@ Multiprotocol Service Layer libraries
 -------------------------------------
 
 * The Kconfig option ``CONFIG_MPSL_CX_THREAD`` has been renamed to :kconfig:option:`CONFIG_MPSL_CX_3WIRE` to better indicate multiprotocol compatibility.
+* Added:
+
+  * A 1-wire coexistence implementation which can be enabled using the Kconfig option :kconfig:option:`CONFIG_MPSL_CX_1WIRE`.
 
 Libraries for networking
 ------------------------

--- a/dts/bindings/radio_coex/generic-radio-coex-one-wire.yaml
+++ b/dts/bindings/radio_coex/generic-radio-coex-one-wire.yaml
@@ -2,16 +2,27 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 
 description: |
-    This is a representation of an external radio coexistence setup that has a
-    one-pin control interface (GRANT).
+  This is a representation of an external radio coexistence setup that has a
+  one-pin control interface (GRANT).
 
 compatible: "generic-radio-coex-one-wire"
 
 include: base.yaml
 
 properties:
-    grant-gpios:
-        type: phandle-array
-        required: true
-        description: |
-            GPIO of the SOC connected to the PTA's GRANT pin.
+  concurrency-mode:
+    type: int
+    required: true
+    description: |
+      Concurrency mode with the external modem supported by 1-wire coexistence.
+      The possible values are:
+      0: 1-wire configuration to allow no concurrency with the external modem
+        when the grant line is asserted.
+      1: 1-wire configuration to allow RX mode concurrency
+        with the external modem when the grant line is asserted.
+
+  grant-gpios:
+    type: phandle-array
+    required: true
+    description: |
+      GPIO of the SOC connected to the PTA's GRANT pin.

--- a/dts/bindings/radio_coex/sdc-radio-coex-one-wire.yaml
+++ b/dts/bindings/radio_coex/sdc-radio-coex-one-wire.yaml
@@ -3,21 +3,8 @@
 
 description: |
     This is a representation of an external radio coexistence setup that has a
-    one-pin control interface (GRANT). This extends that interface with
-    additional parameters.
+    one-pin control interface (GRANT).
 
 compatible: "sdc-radio-coex-one-wire"
 
 include: generic-radio-coex-one-wire.yaml
-
-properties:
-    concurrency-mode:
-        type: int
-        required: true
-        description: |
-            Concurrency mode with the external modem supported by 1-wire coexistence.
-            The possible values are:
-            0: 1-wire configuration to allow no concurrency with the external modem
-               when the grant line is asserted.
-            1: 1-wire configuration to allow the radio to allow RX mode concurrency
-               with the external modem when the grant line is asserted.

--- a/subsys/mpsl/cx/1wire/mpsl_cx_1wire.c
+++ b/subsys/mpsl/cx/1wire/mpsl_cx_1wire.c
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/**
+ * @file
+ *   This file implements a generic 1-wire coexistence interface.
+ */
+
+#if defined(CONFIG_MPSL_CX_PIN_FORWARDER)
+#include <string.h>
+#include <soc_secure.h>
+#else
+#include <mpsl_cx_abstract_interface.h>
+#endif
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/gpio.h>
+
+#include "hal/nrf_gpio.h"
+#include <nrfx_gpiote.h>
+
+#if DT_NODE_EXISTS(DT_NODELABEL(nrf_radio_coex))
+#define CX_NODE DT_NODELABEL(nrf_radio_coex)
+#else
+#define CX_NODE DT_INVALID_NODE
+#error No enabled coex nodes registered in DTS.
+#endif
+
+#if DT_NODE_HAS_PROP(CX_NODE, concurrency_mode)
+#define ALLOW_RX DT_PROP(CX_NODE, concurrency_mode)
+#else
+#define ALLOW_RX false
+#endif
+
+#if !(DT_NODE_HAS_COMPAT(CX_NODE, generic_radio_coex_one_wire))
+#error Selected coex node is not compatible with generic-radio-coex-one-wire.
+#endif
+
+#if !defined(CONFIG_MPSL_CX_PIN_FORWARDER)
+
+#define GRANT_PIN_PORT_NO  DT_PROP(DT_GPIO_CTLR(CX_NODE, grant_gpios), port)
+#define GRANT_PIN_PIN_NO   DT_GPIO_PIN(CX_NODE, grant_gpios)
+
+static const nrfx_gpiote_t gpiote =
+	NRFX_GPIOTE_INSTANCE(NRF_DT_GPIOTE_INST(CX_NODE, grant_gpios));
+
+static const struct gpio_dt_spec gra_spec = GPIO_DT_SPEC_GET(CX_NODE, grant_gpios);
+
+static mpsl_cx_cb_t callback;
+static struct gpio_callback grant_cb;
+static uint32_t grant_abs_pin;
+
+static bool grant_pin_is_asserted(void)
+{
+	int ret = gpio_pin_get_dt(&gra_spec);
+
+	__ASSERT(ret >= 0, "Error while reading GPIO state.");
+
+	return ret;
+}
+
+static mpsl_cx_op_map_t granted_ops_map_get(void)
+{
+#if ALLOW_RX
+	mpsl_cx_op_map_t granted_ops = MPSL_CX_OP_IDLE_LISTEN | MPSL_CX_OP_RX;
+#else
+	mpsl_cx_op_map_t granted_ops = MPSL_CX_OP_IDLE_LISTEN;
+#endif
+
+	if (grant_pin_is_asserted()) {
+		granted_ops |= MPSL_CX_OP_TX | MPSL_CX_OP_RX;
+	}
+
+	return granted_ops;
+}
+
+static int32_t granted_ops_get(mpsl_cx_op_map_t *granted_ops)
+{
+	*granted_ops = granted_ops_map_get();
+	return 0;
+}
+
+static void gpiote_irq_handler(const struct device *gpiob, struct gpio_callback *cb, uint32_t pins)
+{
+	ARG_UNUSED(gpiob);
+	ARG_UNUSED(cb);
+	ARG_UNUSED(pins);
+
+	if (callback) {
+		mpsl_cx_op_map_t granted_ops = granted_ops_map_get();
+
+		callback(granted_ops);
+	}
+}
+
+static int32_t request(const mpsl_cx_request_t *req_params)
+{
+	ARG_UNUSED(req_params);
+	return 0;
+}
+
+static int32_t release(void)
+{
+	return 0;
+}
+
+static uint32_t req_grant_delay_get(void)
+{
+	return 0;
+}
+
+static int32_t register_callback(mpsl_cx_cb_t cb)
+{
+	callback = cb;
+
+	if (cb) {
+		nrfx_gpiote_trigger_enable(&gpiote, grant_abs_pin, true);
+	} else {
+		nrfx_gpiote_trigger_disable(&gpiote, grant_abs_pin);
+	}
+
+	return 0;
+}
+
+static const mpsl_cx_interface_t m_mpsl_cx_methods = {
+	.p_request             = request,
+	.p_release             = release,
+	.p_granted_ops_get     = granted_ops_get,
+	.p_req_grant_delay_get = req_grant_delay_get,
+	.p_register_callback   = register_callback,
+};
+
+static int mpsl_cx_init(void)
+{
+	int32_t ret;
+
+	callback = NULL;
+
+	ret = mpsl_cx_interface_set(&m_mpsl_cx_methods);
+	if (ret != 0) {
+		return ret;
+	}
+
+	ret = gpio_pin_configure_dt(&gra_spec, GPIO_INPUT);
+	if (ret != 0) {
+		return ret;
+	}
+
+	ret = gpio_pin_interrupt_configure_dt(&gra_spec,
+		GPIO_INT_ENABLE | GPIO_INT_EDGE | GPIO_INT_EDGE_BOTH);
+	if (ret != 0) {
+		return ret;
+	}
+
+	grant_abs_pin = NRF_GPIO_PIN_MAP(GRANT_PIN_PORT_NO, GRANT_PIN_PIN_NO);
+	nrfx_gpiote_trigger_disable(&gpiote, grant_abs_pin);
+
+	gpio_init_callback(&grant_cb, gpiote_irq_handler, BIT(gra_spec.pin));
+	gpio_add_callback(gra_spec.port, &grant_cb);
+
+	return 0;
+}
+
+SYS_INIT(mpsl_cx_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+
+#else /* !defined(CONFIG_MPSL_CX_PIN_FORWARDER) */
+static int mpsl_cx_init(void)
+{
+#if DT_NODE_HAS_PROP(CX_NODE, grant_gpios)
+	uint8_t grant_pin = NRF_DT_GPIOS_TO_PSEL(CX_NODE, grant_gpios);
+
+	soc_secure_gpio_pin_mcu_select(grant_pin, NRF_GPIO_PIN_SEL_NETWORK);
+#endif
+
+	return 0;
+}
+
+SYS_INIT(mpsl_cx_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+
+#endif /* !defined(CONFIG_MPSL_CX_PIN_FORWARDER) */

--- a/subsys/mpsl/cx/CMakeLists.txt
+++ b/subsys/mpsl/cx/CMakeLists.txt
@@ -5,6 +5,7 @@
 #
 
 if (CONFIG_MPSL_CX_3WIRE OR
+    CONFIG_MPSL_CX_1WIRE OR
     CONFIG_MPSL_CX_BT_1WIRE OR
     CONFIG_MPSL_CX_NRF700X OR
     CONFIG_MPSL_CX_SOFTWARE)
@@ -12,6 +13,7 @@ if (CONFIG_MPSL_CX_3WIRE OR
 
     zephyr_library_sources_ifdef(CONFIG_MPSL_CX_3WIRE 3wire/mpsl_cx_3wire.c)
     zephyr_library_sources_ifdef(CONFIG_MPSL_CX_BT_1WIRE bluetooth/mpsl_cx_1w_bluetooth.c)
+    zephyr_library_sources_ifdef(CONFIG_MPSL_CX_1WIRE 1wire/mpsl_cx_1wire.c)
     zephyr_library_sources_ifdef(CONFIG_MPSL_CX_NRF700X nrf700x/mpsl_cx_nrf700x.c)
     zephyr_library_sources_ifdef(CONFIG_MPSL_CX_SOFTWARE_RPC software/mpsl_cx_software_rpc.c)
 endif()

--- a/subsys/mpsl/cx/Kconfig
+++ b/subsys/mpsl/cx/Kconfig
@@ -85,6 +85,15 @@ config MPSL_CX_BT_1WIRE
 	  Radio Coexistence interface implementation using a simple 1-wire PTA
 	  implementation for co-located radios.
 
+config MPSL_CX_1WIRE
+	select NRFX_GPIOTE if !MPSL_CX_PIN_FORWARDER
+	select GPIO if !MPSL_CX_PIN_FORWARDER
+	bool "1-Wire Radio Coexistence [EXPERIMENTAL]"
+	select EXPERIMENTAL
+	help
+	  Radio Coexistence interface implementation using a simple 1-wire PTA
+	  implementation for co-located radios.
+
 config MPSL_CX_SOFTWARE
 	bool "Software Coexistence"
 	depends on MPSL_CX_SOFTWARE_SUPPORT


### PR DESCRIPTION
This 1-wire coex variant is based on mpsl_cx_abstract_interface.h and follows the requirements/recommendations for the nrf9160 LTE modem.