### PR TITLE
manifest: update zephyr to pull in bluetooth dis change

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 65acb953582beb2ceaba8e4e458df019c245f74f
+      revision: pull/1931/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update the Zephyr revision to pull in the Kconfig change for Bluetooth DIS module.