### PR TITLE
applications: nrf_desktop: Fix USB next release config in sample.yaml

### DIFF
--- a/applications/nrf_desktop/sample.yaml
+++ b/applications/nrf_desktop/sample.yaml
@@ -217,3 +217,5 @@ tests:
       - nrf52840dk/nrf52840
       - nrf52840dongle/nrf52840
     extra_args: FILE_SUFFIX=release
+    extra_configs:
+      - CONFIG_DESKTOP_USB_STACK_NEXT=y


### PR DESCRIPTION
Change adds missing CONFIG_DESKTOP_USB_STACK_NEXT=y to make sure that the application is built with USB next stack.