### PR TITLE
scripts: hid_configurator: Add nRF54H20 DK to NrfHidManager's list

### DIFF
--- a/scripts/hid_configurator/NrfHidManager.py
+++ b/scripts/hid_configurator/NrfHidManager.py
@@ -9,7 +9,7 @@ NORDIC_VID = 0x1915
 
 class NrfHidManager():
     TYPE2BOARDLIST = {
-        'gaming_mouse' : ['nrf52840gmouse', 'nrf52840dk', 'nrf54l15pdk'],
+        'gaming_mouse' : ['nrf52840gmouse', 'nrf52840dk', 'nrf54l15pdk', 'nrf54h20dk'],
         'dongle' : ['nrf52840dongle', 'nrf52833dongle', 'nrf52820dongle', 'nrf5340dk'],
         'keyboard' : ['nrf52kbd'],
         'desktop_mouse' : ['nrf52dmouse', 'nrf52810dmouse'],


### PR DESCRIPTION
Change adds nrf54h20dk to TYPE2BOARDLIST to ensure that the board is tagged as gaming mouse.