### PR TITLE
mpsl: Stop calibration work on mpsl uninit

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -588,6 +588,10 @@ Multiprotocol Service Layer libraries
 
   * A 1-wire coexistence implementation which can be enabled using the Kconfig option :kconfig:option:`CONFIG_MPSL_CX_1WIRE`.
 
+* Fixed:
+
+  * An issue where the HFXO would be left on after uninitializing MPSL when the RC oscillator was used as the Low Frequency clock source (DRGN-22809).
+
 Libraries for networking
 ------------------------
 


### PR DESCRIPTION
The mpsl api shall not be used after mpsl is uninitialized.

MPSL requests the HFXO when doing LFRC calibration. However, when MPSL is uninitialized it does not handle the CLOCK DONE event and does not release the HFXO, leaving the HFXO running and consuming power.

---

There may be a nicer way to stop the work handler from running, but the zephyr plug api does not prevent the work item to resubmit itself, which is the case here.