### PR TITLE
manifest: sdk-zephyr: wdt without irq

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 64796d7323b1ae58b29542c48a7bf9a0f8d241c1
+      revision: 766b306bcbe819053d52717857d3228febe8ae43
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull update to WDT driver to use it without IRQs.