### PR TITLE
doc: cmake: change ref link to build system

### DIFF
--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -294,8 +294,8 @@ See :ref:`app_build_system`: for more information on the |NCS| configuration sys
 
 .. important::
 
-  When adding Kconfig fragments and devicetree overlays, make sure to use the ``-DEXTRA_CONF_FILE`` and ``-DEXTRA_DTC_OVERLAY_FILE`` CMake parameters, respectively.
-  Otherwise, if ``-DCONF_FILE`` or ``-DDTC_OVERLAY_FILE`` is used, all the configuration files that normally get picked up automatically will have to be included explicitly.
+  When adding Kconfig fragments and devicetree overlays, make sure to use the :makevar:`EXTRA_CONF_FILE` and :makevar:`EXTRA_DTC_OVERLAY_FILE` :ref:`CMake options <cmake_options>`, respectively.
+  Otherwise, if :makevar:`CONF_FILE` or :makevar:`DTC_OVERLAY_FILE` is used, all the configuration files that normally get picked up automatically will have to be included explicitly.
 
 The following configuration files are provided:
 

--- a/doc/nrf/protocols/wifi/stack_configuration.rst
+++ b/doc/nrf/protocols/wifi/stack_configuration.rst
@@ -294,5 +294,4 @@ The nRF Wi-Fi driver can be used in the following profiles (not an exhaustive li
    The measured throughputs, as shown in the table above, are based on tests conducted using the nRF7002 DK.
    The results represent the best throughput, averaged over three iterations, and were obtained with a good RSSI signal in a clean environment.
 
-   The above configuration values can be passed using standard ways such as CMake arguments to west build (`Zephyr One Time Arguments`_ or `Zephyr Permanent Arguments`_), or by adding them in an :file:`overlay` file and passing to west build as CMake argument ``EXTRA_CONF_FILE``.
-   See `Zephyr Application Configuration`_ for more details.
+   The above configuration values can be passed when :ref:`configuring Kconfig options <configuring_kconfig>` before a build or by adding them in an :file:`overlay` file and passing to west build as CMake argument :makevar:`EXTRA_CONF_FILE` using the respective :ref:`CMake option <cmake_options>`.

--- a/doc/nrf/releases_and_maturity/migration/migration_sysbuild.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_sysbuild.rst
@@ -560,7 +560,7 @@ Without doing this, projects with multiple images (for example, those with MCUbo
 | ``-D<image>_SHIELD=...``      | Applies only to <image>          |Applies only to <image>|
 +-------------------------------+----------------------------------+-----------------------+
 
-Configuration values that specify Kconfig fragment or overlay files (for example, ``EXTRA_CONF_FILE`` and ``EXTRA_DTC_OVERLAY_FILE``) cannot be applied globally using either child/parent image or sysbuild.
+Configuration values that specify Kconfig fragment or overlay files (for example, :makevar:`EXTRA_CONF_FILE` and :makevar:`EXTRA_DTC_OVERLAY_FILE`) cannot be applied globally using either child/parent image or sysbuild.
 They function the same in both systems:
 
 * Without a prefix, they will be applied to the main application only.

--- a/samples/bluetooth/direction_finding_central/README.rst
+++ b/samples/bluetooth/direction_finding_central/README.rst
@@ -72,10 +72,9 @@ The following additional configuration files are available for the :ref:`nRF5340
 Angle of departure mode
 =======================
 
-To build this sample with AoD mode only, set ``EXTRA_CONF_FILE`` to the :file:`overlay-aod.conf` file.
+To build this sample with AoD mode only, set :makevar:`EXTRA_CONF_FILE` to the :file:`overlay-aod.conf` file using the respective :ref:`CMake option <cmake_options>`.
 
-See :ref:`cmake_options` for instructions on how to add this option.
-For more information about using configuration overlay files, see :ref:`zephyr:important-build-vars` in the Zephyr documentation.
+For more information about configuration files in the |NCS|, see :ref:`app_build_system`.
 
 To build this sample for :ref:`nRF5340 DK <ug_nrf5340>`, with AoD mode only, add content of :file:`overlay-aod.conf` file to :file:`child_image/hci_ipc.conf` file.
 

--- a/samples/bluetooth/direction_finding_connectionless_tx/README.rst
+++ b/samples/bluetooth/direction_finding_connectionless_tx/README.rst
@@ -48,10 +48,9 @@ Configuration
 Angle of arrival mode
 =====================
 
-To build this sample with AoA mode only, set ``EXTRA_CONF_FILE`` to the :file:`overlay-aoa.conf` file.
+To build this sample with AoA mode only, set :makevar:`EXTRA_CONF_FILE` to the :file:`overlay-aoa.conf` file using the respective :ref:`CMake option <cmake_options>`.
 
-See :ref:`cmake_options` for instructions on how to add this option.
-For more information about using configuration overlay files, see :ref:`zephyr:important-build-vars` in the Zephyr documentation.
+For more information about configuration files in the |NCS|, see :ref:`app_build_system`.
 
 To build this sample for :ref:`nRF5340 DK <ug_nrf5340>`, with AoA mode only, add content of :file:`overlay-aoa.conf` file to :file:`child_image/hci_ipc.conf` file.
 

--- a/samples/bluetooth/mesh/light/README.rst
+++ b/samples/bluetooth/mesh/light/README.rst
@@ -163,8 +163,7 @@ DFU configuration
          Currently, the nRF5340 development kit only supports DFU for the application core.
          This implies that all application DFU images must be compatible with the network core image running on the device.
 
-For more information about using configuration overlay files, see :ref:`zephyr:important-build-vars` in the Zephyr documentation.
-For more information about selecting a sysbuild configuration file, see the sysbuild Kconfig file section on the :ref:`zephyr:sysbuild` page in the Zephyr documentation.
+For more information about configuration files in the |NCS|, see :ref:`app_build_system`.
 
 FEM support
 ===========

--- a/samples/bluetooth/mesh/light_ctrl/README.rst
+++ b/samples/bluetooth/mesh/light_ctrl/README.rst
@@ -190,13 +190,12 @@ FEM support
 Emergency data storage
 ======================
 
-To build this sample with support for emergency data storage (EMDS), set ``EXTRA_CONF_FILE`` to :file:`overlay-emds.conf`.
+To build this sample with support for emergency data storage (EMDS), set :makevar:`EXTRA_CONF_FILE` to :file:`overlay-emds.conf` using the respective :ref:`CMake option <cmake_options>`.
 This will save replay protection list (RPL) data and some of the :ref:`bt_mesh_lightness_srv_readme` data to the emergency data storage instead of to the :ref:`settings_api`.
 When using EMDS, certain considerations need to be taken regarding hardware choices in your application design.
 See :ref:`emds_readme_application_integration` in the EMDS documentation for more information.
 
-See :ref:`cmake_options` for instructions on how to add this option.
-For more information about using configuration overlay files, see :ref:`zephyr:important-build-vars` in the Zephyr documentation.
+For more information about configuration files in the |NCS|, see :ref:`app_build_system`.
 
 Building and running
 ********************

--- a/samples/bluetooth/mesh/light_switch/README.rst
+++ b/samples/bluetooth/mesh/light_switch/README.rst
@@ -228,7 +228,7 @@ The light switch sample is split into the following source files:
 LPN configuration
 =================
 
-To make the light switch run as an LPN, set :makevar:`EXTRA_CONF_FILE` to :file:`overlay-lpn.conf` when building the sample.
+To make the light switch run as an LPN, set :makevar:`EXTRA_CONF_FILE` to :file:`overlay-lpn.conf` when building the sample using the respective :ref:`CMake option <cmake_options>`.
 For example, when building from the command line, use the following command, where *board_target* is the target for the development kit for which you are building:
 
 .. parsed-literal::
@@ -238,7 +238,8 @@ For example, when building from the command line, use the following command, whe
 
 The configuration overlay :file:`overlay-lpn.conf` enables the LPN feature, and alters certain configuration options to further lower the power consumption.
 To review the specific alterations, open and inspect the :file:`overlay-lpn.conf` file.
-For more information about using configuration overlay files, see :ref:`zephyr:important-build-vars` in the Zephyr documentation.
+
+For more information about configuration files in the |NCS|, see :ref:`app_build_system`.
 
 FEM support
 ===========

--- a/samples/bluetooth/peripheral_uart/README.rst
+++ b/samples/bluetooth/peripheral_uart/README.rst
@@ -192,16 +192,15 @@ To build the sample with a :ref:`ble_rpc` interface, use the following command:
 Activating sample extensions
 ============================
 
-To activate the optional extensions supported by this sample, modify :makevar:`EXTRA_CONF_FILE` in the following manner:
+To activate the optional extensions supported by this sample, set :makevar:`EXTRA_CONF_FILE` using the respective :ref:`CMake option <cmake_options>` in the following manner:
 
-* For the minimal build variant, set :file:`prj_minimal.conf`.
-* For the USB CDC ACM extension, set :file:`prj_cdc.conf`.
+* For the minimal build variant, set it to :file:`prj_minimal.conf`.
+* For the USB CDC ACM extension, set it to :file:`prj_cdc.conf`.
   Additionally, you need to set :makevar:`DTC_OVERLAY_FILE` to the :file:`usb.overlay` file.
-* For the MCUboot with serial recovery of the networking core image feature, set the :file:`nrf5340dk_app_sr_net.conf` file.
+* For the MCUboot with serial recovery of the networking core image feature, set it to :file:`nrf5340dk_app_sr_net.conf`.
   You also need to set the :makevar:`mcuboot_EXTRA_CONF_FILE` variant to the :file:`nrf5340dk_mcuboot_sr_net.conf` file.
 
-See :ref:`cmake_options` for instructions on how to add this option.
-For more information about using configuration overlay files, see :ref:`zephyr:important-build-vars` in the Zephyr documentation.
+For more information about configuration files in the |NCS|, see :ref:`app_build_system`.
 
 .. _peripheral_uart_testing:
 

--- a/samples/cellular/lwm2m_carrier/sample_description.rst
+++ b/samples/cellular/lwm2m_carrier/sample_description.rst
@@ -120,7 +120,7 @@ Building and running
 Building with overlay
 =====================
 
-To build with a Kconfig overlay, pass it to the build system using the ``EXTRA_CONF_FILE`` CMake variable, as shown in the following example:
+To build with a Kconfig overlay, set :makevar:`EXTRA_CONF_FILE` to the :file:`overlay-shell.conf` file using the respective :ref:`CMake option <cmake_options>`, as shown in the following example:
 
 .. parsed-literal::
    :class: highlight
@@ -131,6 +131,8 @@ To build with a Kconfig overlay, pass it to the build system using the ``EXTRA_C
 
 This command builds for your nRF91 Series DK using the configurations found in the :file:`overlay-shell.conf` file, in addition to the configurations found in the :file:`prj.conf` file.
 If some options are defined in both files, the options set in the overlay take precedence.
+
+For more information about configuration files in the |NCS|, see :ref:`app_build_system`.
 
 Testing
 =======

--- a/samples/zigbee/light_switch/README.rst
+++ b/samples/zigbee/light_switch/README.rst
@@ -128,7 +128,7 @@ For example, when building from the command line, use the following command:
 For the board name to use instead of the ``nrf52840dk/nrf52840``, see :ref:`programming_board_names`.
 
 See :ref:`cmake_options` for instructions on how to add flags to your build.
-For more information about using configuration overlay files, see :ref:`zephyr:important-build-vars` in the Zephyr documentation.
+For more information about configuration files in the |NCS|, see :ref:`app_build_system`.
 
 FEM support
 ===========

--- a/samples/zigbee/ncp/README.rst
+++ b/samples/zigbee/ncp/README.rst
@@ -190,7 +190,7 @@ To use the same MCUboot configuration as in `Communication through USB`_, you ne
 See :ref:`ug_multi_image_variables` to learn how to set the required options.
 
 MCUboot with the USB DFU requires a larger partition.
-To increase the partition, define the ``PM_STATIC_YML_FILE`` variable that provides the path to the :file:`pm_static_<board>_<suffix>.yml` static configuration file for the board target of your choice.
+To increase the partition, define the :makevar:`PM_STATIC_YML_FILE` variable that provides the path to the :file:`pm_static_<board>_<suffix>.yml` static configuration file for the board target of your choice.
 This is done automatically when building the sample with the ``-DFILE_SUFFIX=<suffix>`` flag.
 
 For instructions on how to set these additional options and configuration at build time, see :ref:`cmake_options` and :ref:`configure_application`.

--- a/scripts/partition_manager/partition_manager.rst
+++ b/scripts/partition_manager/partition_manager.rst
@@ -770,9 +770,9 @@ Configuring static partitions
 Static partitions are defined through a YAML-formatted configuration file in the root application's source directory.
 This file is similar to the regular :file:`pm.yml` configuration files, except that it also defines the start address for all partitions.
 
-You can set ``PM_STATIC_YML_FILE`` to contain exactly the static configuration you want to use.
+You can set :makevar:`PM_STATIC_YML_FILE` to contain exactly the static configuration you want to use.
 
-If you do not set ``PM_STATIC_YML_FILE``, the build system will use the following order to look for files in your application source directory to use as a static configuration layout:
+If you do not set :makevar:`PM_STATIC_YML_FILE`, the build system will use the following order to look for files in your application source directory to use as a static configuration layout:
 
 * If a :ref:`file suffix <app_build_file_suffixes>` is used, the following order applies:
 


### PR DESCRIPTION
Changed the link pointing incorrectly to Zephyr's build system vars so that it points to the nRF Connect SDK's build system overview. Aligned formatting of EXTRA_CONF_FILE and _FILE variables (:makevar:). NCSDK-27178.