### PR TITLE
doc: Add changelog entry for BT APIs converting err to string

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -103,6 +103,9 @@ Bluetooth® LE
 -------------
 
 * The correct SoftDevice Controller library :kconfig:option:`CONFIG_BT_LL_SOFTDEVICE_MULTIROLE` will now be selected automatically when using coexistence based on :kconfig:option:`CONFIG_MPSL_CX` for nRF52-series devices.
+* Added the APIs :c:func:`bt_hci_err_to_str` and :c:func:`bt_security_err_to_str` to allow printing error codes as strings.
+  Each API returns string representations of the error codes when the corresponding Kconfig option, :kconfig:option:`CONFIG_BT_HCI_ERR_TO_STR` or :kconfig:option:`CONFIG_BT_SECURITY_ERR_TO_STR`, is enabled.
+  The :ref:`ble_samples` and :ref:`nrf53_audio_app` are updated to utilize these new APIs.
 
 Bluetooth Mesh
 --------------
@@ -212,7 +215,10 @@ Matter Bridge
 nRF5340 Audio
 -------------
 
-|no_changes_yet_note|
+* Added:
+
+  * The APIs :c:func:`bt_hci_err_to_str` and :c:func:`bt_security_err_to_str` that are used to allow printing error codes as strings.
+    Each API returns string representations of the error codes when the corresponding Kconfig option, :kconfig:option:`CONFIG_BT_HCI_ERR_TO_STR` or :kconfig:option:`CONFIG_BT_SECURITY_ERR_TO_STR`, is enabled.
 
 nRF Desktop
 -----------


### PR DESCRIPTION
The new APIs will simplify debugging issues.
The APIs are used in samples and audio app, see
https://github.com/nrfconnect/sdk-nrf/pull/16729
and
https://github.com/nrfconnect/sdk-nrf/pull/16733