### PR TITLE
Bluetooth: Remove inclusion of conn_internal.h

### DIFF
--- a/samples/bluetooth/conn_time_sync/src/central.c
+++ b/samples/bluetooth/conn_time_sync/src/central.c
@@ -9,7 +9,6 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/hci.h>
 #include <bluetooth/services/nus.h>
-#include <../subsys/bluetooth/host/conn_internal.h>
 #include "conn_time_sync.h"
 #include <bluetooth/hci_vs_sdc.h>
 
@@ -280,7 +279,7 @@ static bool on_vs_evt(struct net_buf_simple *buf)
 		return false;
 	}
 
-	conn = bt_conn_lookup_handle(evt->conn_handle, BT_CONN_TYPE_LE);
+	conn = bt_hci_conn_lookup_handle(evt->conn_handle);
 	if (!conn) {
 		return true;
 	}

--- a/samples/bluetooth/conn_time_sync/src/peripheral.c
+++ b/samples/bluetooth/conn_time_sync/src/peripheral.c
@@ -10,7 +10,6 @@
 #include <zephyr/bluetooth/hci.h>
 #include <bluetooth/services/nus.h>
 #include <bluetooth/services/nus_client.h>
-#include <../subsys/bluetooth/host/conn_internal.h>
 #include <bluetooth/hci_vs_sdc.h>
 
 #include "conn_time_sync.h"
@@ -148,7 +147,7 @@ static bool on_vs_evt(struct net_buf_simple *buf)
 		return false;
 	}
 
-	conn = bt_conn_lookup_handle(evt->conn_handle, BT_CONN_TYPE_LE);
+	conn = bt_hci_conn_lookup_handle(evt->conn_handle);
 	if (!conn) {
 		return true;
 	}

--- a/subsys/bluetooth/host_extensions/host_extensions.c
+++ b/subsys/bluetooth/host_extensions/host_extensions.c
@@ -14,7 +14,6 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/hci.h>
-#include <../subsys/bluetooth/host/conn_internal.h>
 
 #if defined(CONFIG_BT_LL_SOFTDEVICE_HEADERS_INCLUDE)
 #include <bluetooth/hci_vs_sdc.h>


### PR DESCRIPTION
This file was temporary included until the needed APIs were exposed.
Now we no longer need to include it.