### PR TITLE
nrf_security: cracen: Remove redundant aes_countermeasures field.

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/include/sxsymcrypt/internal.h
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/include/sxsymcrypt/internal.h
@@ -29,9 +29,6 @@ extern "C" {
 /** Mode Register value for context saving */
 #define BA417_MODEID_CTX_SAVE (1u << 6)
 
-#define BA411_AES_COUNTERMEASURES_ENABLE  (true)
-#define BA411_AES_COUNTERMEASURES_DISABLE (false)
-
 struct sx_blkcipher_cmdma_cfg;
 struct sx_aead_cmdma_cfg;
 struct sxhashalg;
@@ -98,7 +95,6 @@ struct sxaead {
 	uint8_t tagsz;
 	bool is_in_ctx;
 	uint8_t ctxsz;
-	bool aes_countermeasures;
 	const struct sxkeyref *key;
 	struct sx_dmactl dma;
 	struct sxdesc allindescs[7];
@@ -117,7 +113,6 @@ struct sxblkcipher {
 	size_t inminsz;
 	size_t granularity;
 	uint32_t mode;
-	bool aes_countermeasures;
 	struct sxkeyref key;
 	struct sx_dmactl dma;
 	struct sxdesc allindescs[5];

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/aead.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/aead.c
@@ -106,20 +106,16 @@ static int sx_aead_hw_reserve(struct sxaead *c)
 	int err = SX_OK;
 	uint32_t prng_value;
 
-	if (c->aes_countermeasures == BA411_AES_COUNTERMEASURES_ENABLE) {
-		err = cracen_prng_value_from_pool(&prng_value);
-		if (err != SX_OK) {
-			return err;
-		}
+	err = cracen_prng_value_from_pool(&prng_value);
+	if (err != SX_OK) {
+		return err;
 	}
 
 	sx_hw_reserve(&c->dma);
 
-	if (c->aes_countermeasures == BA411_AES_COUNTERMEASURES_ENABLE) {
-		err = sx_cm_load_mask(prng_value);
-		if (err != SX_OK) {
-			goto exit;
-		}
+	err = sx_cm_load_mask(prng_value);
+	if (err != SX_OK) {
+		goto exit;
 	}
 
 	if (c->key->prepare_key) {
@@ -186,7 +182,6 @@ int sx_aead_create_aesgcm_enc(struct sxaead *c, const struct sxkeyref *key, cons
 {
 	int r;
 
-	c->aes_countermeasures = BA411_AES_COUNTERMEASURES_ENABLE;
 	r = sx_aead_create_aesgcm(c, key, iv, tagsz);
 	if (r) {
 		return r;
@@ -202,7 +197,6 @@ int sx_aead_create_aesgcm_dec(struct sxaead *c, const struct sxkeyref *key, cons
 {
 	int r;
 
-	c->aes_countermeasures = BA411_AES_COUNTERMEASURES_ENABLE;
 	r = sx_aead_create_aesgcm(c, key, iv, tagsz);
 	if (r) {
 		return r;
@@ -280,7 +274,6 @@ static int sx_aead_create_aesccm(struct sxaead *c, const struct sxkeyref *key, c
 int sx_aead_create_aesccm_enc(struct sxaead *c, const struct sxkeyref *key, const char *nonce,
 			      size_t noncesz, size_t tagsz, size_t aadsz, size_t datasz)
 {
-	c->aes_countermeasures = BA411_AES_COUNTERMEASURES_ENABLE;
 	return sx_aead_create_aesccm(c, key, nonce, noncesz, tagsz, aadsz, datasz,
 				     ba411ccmcfg.encr);
 }
@@ -288,7 +281,6 @@ int sx_aead_create_aesccm_enc(struct sxaead *c, const struct sxkeyref *key, cons
 int sx_aead_create_aesccm_dec(struct sxaead *c, const struct sxkeyref *key, const char *nonce,
 			      size_t noncesz, size_t tagsz, size_t aadsz, size_t datasz)
 {
-	c->aes_countermeasures = BA411_AES_COUNTERMEASURES_ENABLE;
 	return sx_aead_create_aesccm(c, key, nonce, noncesz, tagsz, aadsz, datasz,
 				     ba411ccmcfg.decr);
 }

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/blkcipher.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/blkcipher.c
@@ -67,20 +67,16 @@ static int sx_blkcipher_hw_reserve(struct sxblkcipher *c)
 
 	uint32_t prng_value;
 
-	if (c->aes_countermeasures == BA411_AES_COUNTERMEASURES_ENABLE) {
-		err = cracen_prng_value_from_pool(&prng_value);
-		if (err != SX_OK) {
-			return err;
-		}
+	err = cracen_prng_value_from_pool(&prng_value);
+	if (err != SX_OK) {
+		return err;
 	}
 
 	sx_hw_reserve(&c->dma);
 
-	if (c->aes_countermeasures == BA411_AES_COUNTERMEASURES_ENABLE) {
-		err = sx_cm_load_mask(prng_value);
-		if (err != SX_OK) {
-			goto exit;
-		}
+	err = sx_cm_load_mask(prng_value);
+	if (err != SX_OK) {
+		goto exit;
 	}
 
 	if (c->key.prepare_key) {
@@ -214,7 +210,6 @@ int sx_blkcipher_create_aesctr_enc(struct sxblkcipher *c, const struct sxkeyref 
 {
 	c->inminsz = 1;
 	c->granularity = 1;
-	c->aes_countermeasures = BA411_AES_COUNTERMEASURES_ENABLE;
 	return sx_blkcipher_create_aes_ba411(c, key, iv, BLKCIPHER_MODEID_CTR, ba411cfg.encr);
 }
 
@@ -223,7 +218,6 @@ int sx_blkcipher_create_aesctr_dec(struct sxblkcipher *c, const struct sxkeyref 
 {
 	c->inminsz = 1;
 	c->granularity = 1;
-	c->aes_countermeasures = BA411_AES_COUNTERMEASURES_ENABLE;
 	return sx_blkcipher_create_aes_ba411(c, key, iv, BLKCIPHER_MODEID_CTR, ba411cfg.decr);
 }
 
@@ -232,7 +226,6 @@ int sx_blkcipher_create_aesecb_enc(struct sxblkcipher *c, const struct sxkeyref 
 {
 	c->inminsz = 16;
 	c->granularity = 16;
-	c->aes_countermeasures = BA411_AES_COUNTERMEASURES_ENABLE;
 	return sx_blkcipher_create_aes_ba411(c, key, NULL, BLKCIPHER_MODEID_ECB, ba411cfg.encr);
 }
 
@@ -240,7 +233,6 @@ int sx_blkcipher_create_aesecb_dec(struct sxblkcipher *c, const struct sxkeyref 
 {
 	c->inminsz = 16;
 	c->granularity = 16;
-	c->aes_countermeasures = BA411_AES_COUNTERMEASURES_ENABLE;
 	return sx_blkcipher_create_aes_ba411(c, key, NULL, BLKCIPHER_MODEID_ECB, ba411cfg.decr);
 }
 
@@ -249,7 +241,6 @@ int sx_blkcipher_create_aescbc_enc(struct sxblkcipher *c, const struct sxkeyref 
 {
 	c->inminsz = 16;
 	c->granularity = 16;
-	c->aes_countermeasures = BA411_AES_COUNTERMEASURES_ENABLE;
 	return sx_blkcipher_create_aes_ba411(c, key, iv, BLKCIPHER_MODEID_CBC, ba411cfg.encr);
 }
 
@@ -258,7 +249,6 @@ int sx_blkcipher_create_aescbc_dec(struct sxblkcipher *c, const struct sxkeyref 
 {
 	c->inminsz = 16;
 	c->granularity = 16;
-	c->aes_countermeasures = BA411_AES_COUNTERMEASURES_ENABLE;
 	return sx_blkcipher_create_aes_ba411(c, key, iv, BLKCIPHER_MODEID_CBC, ba411cfg.decr);
 }
 
@@ -267,7 +257,6 @@ int sx_blkcipher_create_aescfb_enc(struct sxblkcipher *c, const struct sxkeyref 
 {
 	c->inminsz = 16;
 	c->granularity = 16;
-	c->aes_countermeasures = BA411_AES_COUNTERMEASURES_ENABLE;
 	return sx_blkcipher_create_aes_ba411(c, key, iv, BLKCIPHER_MODEID_CFB, ba411cfg.encr);
 }
 
@@ -276,7 +265,6 @@ int sx_blkcipher_create_aescfb_dec(struct sxblkcipher *c, const struct sxkeyref 
 {
 	c->inminsz = 16;
 	c->granularity = 16;
-	c->aes_countermeasures = BA411_AES_COUNTERMEASURES_ENABLE;
 	return sx_blkcipher_create_aes_ba411(c, key, iv, BLKCIPHER_MODEID_CFB, ba411cfg.decr);
 }
 
@@ -285,7 +273,6 @@ int sx_blkcipher_create_aesofb_enc(struct sxblkcipher *c, const struct sxkeyref 
 {
 	c->inminsz = 1;
 	c->granularity = 1;
-	c->aes_countermeasures = BA411_AES_COUNTERMEASURES_ENABLE;
 	return sx_blkcipher_create_aes_ba411(c, key, iv, BLKCIPHER_MODEID_OFB, ba411cfg.encr);
 }
 
@@ -294,7 +281,6 @@ int sx_blkcipher_create_aesofb_dec(struct sxblkcipher *c, const struct sxkeyref 
 {
 	c->inminsz = 1;
 	c->granularity = 1;
-	c->aes_countermeasures = BA411_AES_COUNTERMEASURES_ENABLE;
 	return sx_blkcipher_create_aes_ba411(c, key, iv, BLKCIPHER_MODEID_OFB, ba411cfg.decr);
 }
 

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/chachapoly.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/chachapoly.c
@@ -160,27 +160,23 @@ static int sx_blkcipher_create_chacha20(struct sxblkcipher *c, const struct sxke
 int sx_aead_create_chacha20poly1305_enc(struct sxaead *c, const struct sxkeyref *key,
 					const char *nonce, size_t tagsz)
 {
-	c->aes_countermeasures = BA411_AES_COUNTERMEASURES_DISABLE;
 	return sx_aead_create_chacha20poly1305(c, key, nonce, ba417chachapolycfg.encr, tagsz);
 }
 
 int sx_aead_create_chacha20poly1305_dec(struct sxaead *c, const struct sxkeyref *key,
 					const char *nonce, size_t tagsz)
 {
-	c->aes_countermeasures = BA411_AES_COUNTERMEASURES_DISABLE;
 	return sx_aead_create_chacha20poly1305(c, key, nonce, ba417chachapolycfg.decr, tagsz);
 }
 
 int sx_blkcipher_create_chacha20_enc(struct sxblkcipher *c, const struct sxkeyref *key,
 				     const char *counter, const char *nonce)
 {
-	c->aes_countermeasures = BA411_AES_COUNTERMEASURES_DISABLE;
 	return sx_blkcipher_create_chacha20(c, key, nonce, counter, ba417chacha20cfg.encr);
 }
 
 int sx_blkcipher_create_chacha20_dec(struct sxblkcipher *c, const struct sxkeyref *key,
 				     const char *counter, const char *nonce)
 {
-	c->aes_countermeasures = BA411_AES_COUNTERMEASURES_DISABLE;
 	return sx_blkcipher_create_chacha20(c, key, nonce, counter, ba417chacha20cfg.decr);
 }


### PR DESCRIPTION
Remove the aes_countermeasures field as it is no longer needed.