### PR TITLE
west: Update sdk-zephyr to fix CI tests of nRF Desktop

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 3b6c6e00baa6acd7a01753d7d6d0a31dca7f8920
+      revision: 4f64a3afb9fd9a350ce471efbc029a3769a7d5b6
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Change updates sdk-zephyr to bring in fix for assertion failure in nRF Desktop application.

Jira: NCSDK-28624