### PR TITLE
partition_manager: HW model 1 fix for non TF-M socs

### DIFF
--- a/subsys/partition_manager/Kconfig
+++ b/subsys/partition_manager/Kconfig
@@ -42,11 +42,13 @@ config SRAM_BASE_ADDRESS
 if "$(HWM_SCHEME)" = "v1"
 config NRF_TRUSTZONE_FLASH_REGION_SIZE
 	hex
-	default NRF_SPU_FLASH_REGION_SIZE
+	default 0x0 if !BUILD_WITH_TFM
+	default NRF_SPU_FLASH_REGION_SIZE if BUILD_WITH_TFM
 
 config NRF_TRUSTZONE_RAM_REGION_SIZE
 	hex
-	default NRF_SPU_RAM_REGION_SIZE
+	default 0x0 if !BUILD_WITH_TFM
+	default NRF_SPU_RAM_REGION_SIZE if BUILD_WITH_TFM
 endif
 
 menu "Zephyr subsystem configurations"


### PR DESCRIPTION
The workaround that we have for the hardware model v1 with TF-M seems to cause build issues with non TF-M devices because of the missing NRF_SPU_* Kconfigs. Set a default 0x0 to the non TF-M devices to avoid the build issue. This configuration is not used for non TF-M devices, so it doesn't have any negative sideffects.