### PR TITLE
manifest: update sdk-zephyr version

### DIFF
--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -21,4 +21,9 @@ rsource "sensor/Kconfig"
 rsource "serial/Kconfig"
 rsource "wifi/Kconfig"
 
+config NRFE
+	bool
+	default y if GPIO_NRFE
+	# Temporary kconfig to include DPPI channel allocation for NRFE
+
 endmenu

--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 6debbaf8115c13f31fca0d6acdadfad153e413b4
+      revision: 6249458d4927bb67e0085ec43549d0e980385d9e
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update sdk-zephyr with DPPI channel allocation for SW-defined IO devices on nRF54L15.