### PR TITLE
Revert "Bluetooth: Host: Remove useless internal include"

### DIFF
--- a/subsys/bluetooth/host_extensions/host_extensions.c
+++ b/subsys/bluetooth/host_extensions/host_extensions.c
@@ -14,6 +14,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/hci.h>
+#include <../subsys/bluetooth/host/conn_internal.h>
 
 #if defined(CONFIG_BT_LL_SOFTDEVICE_HEADERS_INCLUDE)
 #include <bluetooth/hci_vs_sdc.h>


### PR DESCRIPTION
This reverts commit 2678a8233c6e73526a66da07ea7081663eb7020b.