### PR TITLE
lib: `assert` to `__ASSERT_NO_MSG`

### DIFF
--- a/lib/lte_link_control/lte_lc_helpers.c
+++ b/lib/lte_link_control/lte_lc_helpers.c
@@ -10,7 +10,6 @@
 #include <zephyr/net/socket.h>
 #include <string.h>
 #include <stdio.h>
-#include <assert.h>
 #include <zephyr/device.h>
 #include <modem/lte_lc.h>
 #include <modem/at_parser.h>
@@ -248,7 +247,7 @@ int parse_edrx(const char *at_response, struct lte_lc_edrx_cfg *cfg, char *edrx_
 	}
 
 	err = at_parser_init(&parser, at_response);
-	assert(err == 0);
+	__ASSERT_NO_MSG(err == 0);
 
 	err = at_parser_num_get(&parser, AT_CEDRXP_ACTT_INDEX, &tmp_int);
 	if (err) {
@@ -587,7 +586,7 @@ int parse_rrc_mode(const char *at_response,
 	struct at_parser parser;
 
 	err = at_parser_init(&parser, at_response);
-	assert(err == 0);
+	__ASSERT_NO_MSG(err == 0);
 
 	/* Get the RRC mode from the response */
 	err = at_parser_num_get(&parser, mode_index, &temp_mode);
@@ -637,7 +636,7 @@ int parse_cereg(const char *at_response,
 	psm_cfg->tau = -1;
 
 	err = at_parser_init(&parser, at_response);
-	assert(err == 0);
+	__ASSERT_NO_MSG(err == 0);
 
 	/* Get network registration status */
 	err = at_parser_num_get(&parser, AT_CEREG_REG_STATUS_INDEX, &temp);
@@ -774,7 +773,7 @@ int parse_xt3412(const char *at_response, uint64_t *time)
 	}
 
 	err = at_parser_init(&parser, at_response);
-	assert(err == 0);
+	__ASSERT_NO_MSG(err == 0);
 
 	/* Get the remaining time of T3412 from the response */
 	err = at_parser_num_get(&parser, AT_XT3412_TIME_INDEX, time);
@@ -838,7 +837,7 @@ int parse_ncellmeas(const char *at_response, struct lte_lc_cells_info *cells)
 	cells->current_cell.id = LTE_LC_CELL_EUTRAN_ID_INVALID;
 
 	err = at_parser_init(&parser, at_response);
-	assert(err == 0);
+	__ASSERT_NO_MSG(err == 0);
 
 	/* Status code. */
 	err = at_parser_num_get(&parser, AT_NCELLMEAS_STATUS_INDEX, &status);
@@ -1073,7 +1072,7 @@ int parse_ncellmeas_gci(struct lte_lc_ncellmeas_params *params,
 	 */
 
 	err = at_parser_init(&parser, at_response);
-	assert(err == 0);
+	__ASSERT_NO_MSG(err == 0);
 
 	/* Status code. */
 	curr_index = AT_NCELLMEAS_STATUS_INDEX;
@@ -1338,7 +1337,7 @@ int parse_xmodemsleep(const char *at_response, struct lte_lc_modem_sleep *modem_
 	}
 
 	err = at_parser_init(&parser, at_response);
-	assert(err == 0);
+	__ASSERT_NO_MSG(err == 0);
 
 	err = at_parser_num_get(&parser, AT_XMODEMSLEEP_TYPE_INDEX, &type);
 	if (err) {

--- a/lib/modem_info/modem_info.c
+++ b/lib/modem_info/modem_info.c
@@ -20,7 +20,6 @@
 #include <zephyr/kernel.h>
 #include <zephyr/types.h>
 #include <zephyr/logging/log.h>
-#include <assert.h>
 
 LOG_MODULE_REGISTER(modem_info);
 
@@ -448,7 +447,7 @@ int modem_info_short_get(enum modem_info info, uint16_t *buf)
 	}
 
 	err = at_parser_init(&parser, recv_buf);
-	assert(err == 0);
+	__ASSERT_NO_MSG(err == 0);
 
 	err = at_parser_num_get(&parser, modem_data[info]->param_index, buf);
 	if (err) {
@@ -515,7 +514,7 @@ parse_line:
 	in_buf[++line_len + line_start_idx] = '\0';
 
 	err = at_parser_init(&parser, &in_buf[line_start_idx]);
-	assert(err == 0);
+	__ASSERT_NO_MSG(err == 0);
 
 	len = sizeof(ip_buf);
 	err = at_parser_string_get(&parser,
@@ -634,7 +633,7 @@ int modem_info_string_get(enum modem_info info, char *buf, const size_t buf_size
 	}
 
 	err = at_parser_init(&parser, recv_buf);
-	assert(err == 0);
+	__ASSERT_NO_MSG(err == 0);
 
 	if (modem_data[info]->data_type == AT_PARAM_TYPE_NUM_INT) {
 		err = at_parser_num_get(&parser,
@@ -692,7 +691,7 @@ static void modem_info_rsrp_subscribe_handler(const char *notif)
 	};
 
 	err = at_parser_init(&parser, notif);
-	assert(err == 0);
+	__ASSERT_NO_MSG(err == 0);
 
 	err = at_parser_num_get(&parser,
 				rsrp_notify_data.param_index,


### PR DESCRIPTION
Change `assert` to `__ASSERT_NO_MSG` after AT parser
initialization.
This is to make it optional via Kconfig option and to
reduce the memory footprint for this basic check.