### PR TITLE
manifest: nrfxlib: pull soft float fallback for OT lib path

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -148,7 +148,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: v2.7.0
+      revision: 43090511310ba72cff82effa29d155d8b40d3b90
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Add soft float fallback to enable building from libs with softfp ABI enabled.