### PR TITLE
nrf_security: Update TLS in/out buffer defaults

### DIFF
--- a/subsys/nrf_security/Kconfig.tls
+++ b/subsys/nrf_security/Kconfig.tls
@@ -306,14 +306,14 @@ config MBEDTLS_SSL_OUT_CONTENT_LEN
 	prompt "Max length for TLS outgoing fragments"
 	range 0 16384
 	default 900 if OPENTHREAD_NRF_SECURITY || OPENTHREAD_NRF_SECURITY_PSA
-	default 16380
+	default 16384
 
 config MBEDTLS_SSL_IN_CONTENT_LEN
 	prompt "Max length for TLS outgoing fragments"
 	int
 	range 0 16384
 	default 900 if OPENTHREAD_NRF_SECURITY || OPENTHREAD_NRF_SECURITY_PSA
-	default 16380
+	default 16384
 
 
 config MBEDTLS_SSL_CIPHERSUITES


### PR DESCRIPTION
The currently set defaults are 4 bytes less than the actual maximum allowed fragment size. This prevents communication with TLS servers which tend to use the maximum allowed fragment size, regardless of the client configuration. Hence, update the defaults accordingly, to use the maximum fragment size instead.