### PR TITLE
cracen: Remove dependency on MbedTLS ASN.1

### DIFF
--- a/subsys/nrf_security/configs/nrf-config.h.template
+++ b/subsys/nrf_security/configs/nrf-config.h.template
@@ -26,11 +26,6 @@ extern "C" {
  * MBEDTLS crypto definitions.
  */
 /****************************************************************/
-#if defined(CONFIG_PSA_CRYPTO_DRIVER_CRACEN)
-/* TODO: NCSDK-26258: Improve, or get rid of this code */
-#define MBEDTLS_ASN1_PARSE_C
-#endif
-
 #if defined(CONFIG_PSA_NEED_CRACEN_KEY_MANAGEMENT_DRIVER)
 #define MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS
 #endif

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/common.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/common.c
@@ -10,7 +10,6 @@
 #include <cracen/mem_helpers.h>
 #include <cracen/statuscodes.h>
 #include <hal/nrf_cracen.h>
-#include <mbedtls/asn1.h>
 #include <nrfx.h>
 #include <sicrypto/rsa_keys.h>
 #include <sicrypto/sicrypto.h>
@@ -424,9 +423,96 @@ void cracen_xorbytes(char *a, const char *b, size_t sz)
 	}
 }
 
-/*
- * This function is based mbedtls ASN1 API.
- */
+static int cracen_asn1_get_len(unsigned char **p, const unsigned char *end, size_t *len)
+{
+	if ((end - *p) < 1) {
+		return SX_ERR_INVALID_PARAM;
+	}
+
+	if ((**p & 0x80) == 0) {
+		*len = *(*p)++;
+	} else {
+		int n = (**p) & 0x7F;
+
+		if (n == 0 || n > 4) {
+			return SX_ERR_INVALID_PARAM;
+		}
+		if ((end - *p) <= n) {
+			return SX_ERR_INVALID_PARAM;
+		}
+		*len = 0;
+		(*p)++;
+		while (n--) {
+			*len = (*len << 8) | **p;
+			(*p)++;
+		}
+	}
+
+	if (*len > (size_t)(end - *p)) {
+		return SX_ERR_INVALID_PARAM;
+	}
+
+	return 0;
+}
+
+static int cracen_asn1_get_tag(unsigned char **p, const unsigned char *end, size_t *len, int tag)
+{
+	if ((end - *p) < 1) {
+		return SX_ERR_INVALID_PARAM;
+	}
+
+	if (**p != tag) {
+		return SX_ERR_INVALID_PARAM;
+	}
+
+	(*p)++;
+
+	return cracen_asn1_get_len(p, end, len);
+}
+
+static int cracen_asn1_get_int(unsigned char **p, const unsigned char *end, int *val)
+{
+	int ret = SX_ERR_INVALID_PARAM;
+	size_t len;
+
+	ret = cracen_asn1_get_tag(p, end, &len, ASN1_INTEGER);
+	if (ret != 0) {
+		return ret;
+	}
+
+	if (len == 0) {
+		return SX_ERR_INVALID_PARAM;
+	}
+	/* Reject negative integers. */
+	if ((**p & 0x80) != 0) {
+		return SX_ERR_INVALID_PARAM;
+	}
+
+	/* Skip leading zeros. */
+	while (len > 0 && **p == 0) {
+		++(*p);
+		--len;
+	}
+
+	/* Reject integers that don't fit in an int. This code assumes that
+	 * the int type has no padding bit.
+	 */
+	if (len > sizeof(int)) {
+		return SX_ERR_INVALID_PARAM;
+	}
+	if (len == sizeof(int) && (**p & 0x80) != 0) {
+		return SX_ERR_INVALID_PARAM;
+	}
+
+	*val = 0;
+	while (len-- > 0) {
+		*val = (*val << 8) | **p;
+		(*p)++;
+	}
+
+	return 0;
+}
+
 int cracen_signature_asn1_get_operand(unsigned char **p, const unsigned char *end,
 				      struct sx_buf *op)
 {
@@ -434,7 +520,7 @@ int cracen_signature_asn1_get_operand(unsigned char **p, const unsigned char *en
 	size_t len = 0;
 	size_t i = 0;
 
-	ret = mbedtls_asn1_get_tag(p, end, &len, MBEDTLS_ASN1_INTEGER);
+	ret = cracen_asn1_get_tag(p, end, &len, ASN1_INTEGER);
 	if (ret) {
 		return SX_ERR_INVALID_PARAM;
 	}
@@ -502,7 +588,7 @@ int cracen_signature_get_rsa_key(struct si_rsa_key *rsa, bool extract_pubkey, bo
 	 *  OpenSSL wraps public keys with an RSA algorithm identifier that we skip
 	 *  if it is present.
 	 */
-	ret = mbedtls_asn1_get_tag(&p, end, &len, MBEDTLS_ASN1_CONSTRUCTED | MBEDTLS_ASN1_SEQUENCE);
+	ret = cracen_asn1_get_tag(&p, end, &len, ASN1_CONSTRUCTED | ASN1_SEQUENCE);
 	if (ret) {
 		return SX_ERR_INVALID_KEYREF;
 	}
@@ -510,7 +596,7 @@ int cracen_signature_get_rsa_key(struct si_rsa_key *rsa, bool extract_pubkey, bo
 	end = p + len;
 
 	if (is_key_pair) {
-		ret = mbedtls_asn1_get_int(&p, end, &version);
+		ret = cracen_asn1_get_int(&p, end, &version);
 		if (ret) {
 			return SX_ERR_INVALID_KEYREF;
 		}
@@ -521,8 +607,7 @@ int cracen_signature_get_rsa_key(struct si_rsa_key *rsa, bool extract_pubkey, bo
 		/* Skip algorithm identifier prefix. */
 		unsigned char *id_seq = p;
 
-		ret = mbedtls_asn1_get_tag(&id_seq, end, &len,
-					   MBEDTLS_ASN1_CONSTRUCTED | MBEDTLS_ASN1_SEQUENCE);
+		ret = cracen_asn1_get_tag(&id_seq, end, &len, ASN1_CONSTRUCTED | ASN1_SEQUENCE);
 		if (ret == 0) {
 			if (len != sizeof(RSA_ALGORITHM_IDENTIFIER)) {
 				return SX_ERR_INVALID_KEYREF;
@@ -534,15 +619,14 @@ int cracen_signature_get_rsa_key(struct si_rsa_key *rsa, bool extract_pubkey, bo
 
 			id_seq += len;
 
-			ret = mbedtls_asn1_get_tag(&id_seq, end, &len, MBEDTLS_ASN1_BIT_STRING);
+			ret = cracen_asn1_get_tag(&id_seq, end, &len, ASN1_BIT_STRING);
 			if (ret != 0 || *id_seq != 0) {
 				return SX_ERR_INVALID_KEYREF;
 			}
 
 			p = id_seq + 1;
 
-			ret = mbedtls_asn1_get_tag(
-				&p, end, &len, MBEDTLS_ASN1_CONSTRUCTED | MBEDTLS_ASN1_SEQUENCE);
+			ret = cracen_asn1_get_tag(&p, end, &len, ASN1_CONSTRUCTED | ASN1_SEQUENCE);
 			if (ret) {
 				return SX_ERR_INVALID_KEYREF;
 			}

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/common.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/common.h
@@ -38,6 +38,13 @@ __attribute__((warn_unused_result)) psa_status_t silex_statuscodes_to_psa(int re
 __attribute__((warn_unused_result)) psa_status_t
 hash_get_algo(psa_algorithm_t alg, const struct sxhashalg **sx_hash_algo);
 
+enum asn1_tags {
+	ASN1_SEQUENCE = 0x10,
+	ASN1_INTEGER = 0x2,
+	ASN1_CONSTRUCTED = 0x20,
+	ASN1_BIT_STRING = 0x3
+};
+
 /*!
  * \brief Get Cracen curve object based on the PSA attributes.
  *

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/key_management.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/key_management.c
@@ -28,12 +28,6 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/byteorder.h>
 
-enum asn1_tags {
-	ASN1_SEQUENCE = 0x10,
-	ASN1_INTEGER = 0x2,
-	ASN1_CONSTRUCTED = 0x20
-};
-
 extern const uint8_t cracen_N3072[384];
 
 extern nrf_security_mutex_t cracen_mutex_symmetric;

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/sign.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/sign.c
@@ -8,7 +8,6 @@
 
 #include <cracen/mem_helpers.h>
 #include <cracen/statuscodes.h>
-#include <mbedtls/asn1.h>
 #include <psa/crypto.h>
 #include <psa/crypto_values.h>
 #include <sicrypto/drbghash.h>


### PR DESCRIPTION
Adds full ASN.1 parsing of RSA keys so we don't have to rely on external libraries.