### PR TITLE
lib: wifi_credentials: Add passphrase length check

### DIFF
--- a/subsys/net/lib/wifi_credentials/wifi_credentials_shell.c
+++ b/subsys/net/lib/wifi_credentials/wifi_credentials_shell.c
@@ -163,6 +163,11 @@ static int cmd_add_network(const struct shell *shell, size_t argc, char *argv[])
 			goto help;
 		}
 		creds.password_len = strlen(argv[3]);
+		if (creds.password_len < WIFI_PSK_MIN_LEN) {
+			shell_error(shell, "Passphrase should be minimum %d characters",
+				    WIFI_PSK_MIN_LEN);
+			goto help;
+		}
 		if (
 			(creds.password_len > CONFIG_WIFI_CREDENTIALS_SAE_PASSWORD_LENGTH &&
 			 creds.header.type == WIFI_SECURITY_TYPE_SAE) ||


### PR DESCRIPTION
Passphrase minimum length should be WIFI_PSK_MIN_LEN. Adding check for WPA3-SAE and other security modes.