### PR TITLE
Samples: Bluetooth: Checking return value of functions

### DIFF
--- a/samples/bluetooth/central_uart/src/main.c
+++ b/samples/bluetooth/central_uart/src/main.c
@@ -289,14 +289,25 @@ static int uart_init(void)
 static void discovery_complete(struct bt_gatt_dm *dm,
 			       void *context)
 {
+	int err;
 	struct bt_nus_client *nus = context;
 	LOG_INF("Service discovery completed");
 
 	bt_gatt_dm_data_print(dm);
 
-	bt_nus_handles_assign(dm, nus);
-	bt_nus_subscribe_receive(nus);
+	err = bt_nus_handles_assign(dm, nus);
+	if (err) {
+		LOG_INF("bt_nus_handles_assign failed (err %d)", err);
+		goto cleanup;
+	}
 
+	err = bt_nus_subscribe_receive(nus);
+	if (err) {
+		LOG_INF("bt_nus_subscribe_receive failed (err %d)", err);
+		goto cleanup;
+	}
+
+cleanup:
 	bt_gatt_dm_data_release(dm);
 }
 


### PR DESCRIPTION
Without this, an assert in [gatt.c:5350](https://github.com/nrfconnect/sdk-zephyr/blob/5708d4e344b853572de6dad5cbdd26335ac3ed35/subsys/bluetooth/host/gatt.c#L5350) could happen, when bt_nus_subscribe_receive called  bt_gatt_subscribe. It happened when the link got disconnected during
service discovery procedure.

I was debugging something else, and I simulated very bad rf-conditions to trigger this assert.

Callstack when assert triggered
![image](https://github.com/user-attachments/assets/87bad9f7-c745-414b-a5dc-ffe5e500b074)
