### PR TITLE
net: lib: nrf_cloud_coap_transport: Update error handling

### DIFF
--- a/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap_transport.c
+++ b/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap_transport.c
@@ -406,7 +406,7 @@ static int client_transfer(enum coap_method method,
 		k_sem_take(&serial_sem, K_FOREVER);
 	}
 
-	int err;
+	int err = 0;
 	int retry;
 	char path[MAX_COAP_PATH + 1];
 	struct coap_client_option options[1] = {{
@@ -454,7 +454,8 @@ static int client_transfer(enum coap_method method,
 
 	retry = 0;
 	k_sem_reset(xfer->sem);
-	while ((err = coap_client_req(cc, xfer->nrfc_cc->sock, NULL, &request, NULL)) == -EAGAIN) {
+	while ((xfer->nrfc_cc->sock >= 0) &&
+	       (err = coap_client_req(cc, xfer->nrfc_cc->sock, NULL, &request, NULL)) == -EAGAIN) {
 		if (!nrf_cloud_coap_is_connected()) {
 			err = -EACCES;
 			break;
@@ -474,6 +475,13 @@ static int client_transfer(enum coap_method method,
 	if (err < 0) {
 		LOG_ERR("Error sending CoAP request: %d", err);
 	} else {
+
+		if (xfer->nrfc_cc->sock < 0) {
+			LOG_ERR("Socket closed during CoAP request");
+			err = -ESHUTDOWN;
+			goto transfer_end;
+		}
+
 		if (buf_len) {
 			LOG_HEXDUMP_DBG(buf, MIN(64, buf_len), "Sent");
 		}


### PR DESCRIPTION
Return ESHUTDOWN if the socket is closed during
a coap request.