### PR TITLE
doc: links: migration and environment

### DIFF
--- a/doc/nrf/app_dev/config_and_build/building.rst
+++ b/doc/nrf/app_dev/config_and_build/building.rst
@@ -34,7 +34,7 @@ Just as for creating the application, you can build the application using either
 
       Complete the following steps to build on the command line:
 
-      1. Open a terminal window.
+      1. |open_terminal_window_with_environment|
       #. Go to the specific application directory.
 
          For example, if you want to build the :ref:`at_client_sample` sample, run the following command to navigate to its directory:

--- a/doc/nrf/app_dev/create_application.rst
+++ b/doc/nrf/app_dev/create_application.rst
@@ -232,7 +232,7 @@ Use the following steps depending on the application type:
       #. Click the :guilabel:`Use this template` button on the GitHub web user interface.
          This creates your own copy of the template repository.
          In the copy of the repository, the :file:`app` directory contains the template application that you can start modifying.
-      #. Open a command line terminal.
+      #. |open_terminal_window_with_environment|
       #. Initialize the repository with the repository name and path you have chosen for your manifest repository (*your-name/your-application* and *your-app-workspace*, respectively).
          *your-app-workspace* corresponds to :file:`ncs/` in the :ref:`workspace application structure <create_application_types_workspace>`.
          Use the following command pattern:

--- a/doc/nrf/app_dev/device_guides/nrf53/building_nrf53.rst
+++ b/doc/nrf/app_dev/device_guides/nrf53/building_nrf53.rst
@@ -69,22 +69,28 @@ To program the nRF5340 DK from the command line, use either west (which uses nrf
          .. group-tab:: west
 
             1. |open_terminal_window_with_environment|
-            #. Run the following command to erase the flash memory of the network core and program the network sample::
+            #. Run the following command to erase the flash memory of the network core and program the network sample:
 
-                west flash --erase
+               .. code-block:: console
 
-            #. Navigate to the build folder of the application sample and run the same command to erase the flash memory of the application core and program the application sample::
+                  west flash --erase
 
-                west flash --erase
+            #. Navigate to the build folder of the application sample and run the same command to erase the flash memory of the application core and program the application sample:
+
+               .. code-block:: console
+
+                  west flash --erase
 
          .. group-tab:: nRF Util
 
             1. |open_terminal_window_with_environment|
-            #. Run the following command to erase the flash memory of the network core and program the network sample::
+            #. Run the following command to erase the flash memory of the network core and program the network sample:
 
-                nrfutil device program --firmware zephyr.hex --options chip_erase_mode=ERASE_ALL --core Network
+               .. code-block:: console
 
-                .. note::
+                  nrfutil device program --firmware zephyr.hex --options chip_erase_mode=ERASE_ALL --core Network
+
+               .. note::
                     If you cannot locate the build folder of the network sample, look for a folder with one of these names inside the build folder of the application sample:
 
                     * :file:`rpc_host`
@@ -92,16 +98,20 @@ To program the nRF5340 DK from the command line, use either west (which uses nrf
                     * :file:`802154_rpmsg`
                     * :file:`multiprotocol_rpmsg`
 
-            #. Navigate to the build folder of the application sample and run the following command to erase the flash memory of the application core and program the application sample::
+            #. Navigate to the build folder of the application sample and run the following command to erase the flash memory of the application core and program the application sample:
 
-                nrfutil device program --firmware zephyr.hex  --options chip_erase_mode=ERASE_ALL
+               .. code-block:: console
 
-            .. note::
-               The application build folder will be in a sub-directory which is the name of the folder of the application
+                  nrfutil device program --firmware zephyr.hex  --options chip_erase_mode=ERASE_ALL
 
-            #. Reset the development kit::
+               .. note::
+                    The application build folder will be in a sub-directory which is the name of the folder of the application
 
-                nrfutil device reset --reset-kind=RESET_PIN
+            #. Reset the development kit:
+
+               .. code-block:: console
+
+                  nrfutil device reset --reset-kind=RESET_PIN
 
       See :ref:`readback_protection_error` if you encounter an error.
 
@@ -115,22 +125,26 @@ To program the nRF5340 DK from the command line, use either west (which uses nrf
 
          .. group-tab:: west
 
-            Enter the following command to program multi-image builds for different cores::
+            Enter the following command to program multi-image builds for different cores:
 
-             west flash
+            .. code-block:: console
 
-			   .. note::
-               The minimum supported version of nrfjprog for multi-image builds for different cores is 10.21.0.
+               west flash
+
+            .. note::
+                 The minimum supported version of nrfjprog for multi-image builds for different cores is 10.21.0.
 
          .. group-tab:: nRF Util
 
-            Enter the following commands to program multiple image builds for different cores::
+            Enter the following commands to program multiple image builds for different cores:
 
-             nrfutil device program --firmware merged_CPUNET.hex --options verify=VERIFY_READ,chip_erase_mode=ERASE_CTRL_AP
-             nrfutil device program --firmware merged.hex --options verify=VERIFY_READ,chip_erase_mode=ERASE_CTRL_AP
+            .. code-block:: console
+
+               nrfutil device program --firmware merged_CPUNET.hex --options verify=VERIFY_READ,chip_erase_mode=ERASE_CTRL_AP
+               nrfutil device program --firmware merged.hex --options verify=VERIFY_READ,chip_erase_mode=ERASE_CTRL_AP
 
             .. note::
-               The ``--verify`` command confirms that the writing operation has succeeded.
+                 The ``--verify`` command confirms that the writing operation has succeeded.
 
 .. _readback_protection_error:
 
@@ -154,21 +168,23 @@ See the following instructions.
 
    .. group-tab:: nRF Util
 
-      Enter the following commands to recover first the network core and then the application core::
+      Enter the following commands to recover first the network core and then the application core:
 
-        nrfutil device recover --core Network
-        nrfutil device recover
+      .. code-block:: console
+
+         nrfutil device recover --core Network
+         nrfutil device recover
 
       .. note::
-         Make sure to recover the network core before you recover the application core.
+           Make sure to recover the network core before you recover the application core.
 
-         The ``nrfutil device recover`` command erases the flash memory and then writes a small binary into the recovered flash memory.
-         This binary prevents the readback protection from enabling itself again after a pin reset or power cycle.
+           The ``nrfutil device recover`` command erases the flash memory and then writes a small binary into the recovered flash memory.
+           This binary prevents the readback protection from enabling itself again after a pin reset or power cycle.
 
-         Recovering the network core erases the flash memory of both cores.
-         Recovering the application core erases only the flash memory of the application core.
-         Therefore, you must recover the network core first.
-         Otherwise, if you recover the application core first and the network core last, the binary written to the application core is deleted and readback protection is enabled again after a reset.
+           Recovering the network core erases the flash memory of both cores.
+           Recovering the application core erases only the flash memory of the application core.
+           Therefore, you must recover the network core first.
+           Otherwise, if you recover the application core first and the network core last, the binary written to the application core is deleted and readback protection is enabled again after a reset.
 
 .. _thingy53_building_pgming:
 
@@ -271,7 +287,9 @@ To build and program the source code from the command line, complete the followi
    For example, the directory path is :file:`ncs/nrf/applications/machine_learning` when building the source code for the :ref:`nrf_machine_learning_app` application.
 
 #. Make sure that you have the required version of the |NCS| repository by pulling the ``sdk-nrf`` repository on GitHub as described in :ref:`dm-wf-get-ncs` and :ref:`dm-wf-update-ncs` sections.
-#. Get the rest of the dependencies using west::
+#. Get the rest of the dependencies using west:
+
+   .. code-block:: console
 
       west update
 
@@ -291,7 +309,9 @@ To build and program the source code from the command line, complete the followi
    a. Connect the Nordic Thingy:53 to the debug out port on a 10-pin external debug probe, for example nRF5340 DK, using a 10-pin JTAG cable.
    #. Connect the external debug probe to the PC using a USB cable.
    #. Make sure that the Nordic Thingy:53 and the external debug probe are powered on.
-   #. Use the following command to program the sample or application to the device::
+   #. Use the following command to program the sample or application to the device:
+
+      .. code-block:: console
 
          west flash
 

--- a/doc/nrf/app_dev/device_guides/nrf53/building_nrf53.rst
+++ b/doc/nrf/app_dev/device_guides/nrf53/building_nrf53.rst
@@ -68,36 +68,38 @@ To program the nRF5340 DK from the command line, use either west (which uses nrf
 
          .. group-tab:: west
 
-            1. Open a command prompt in the build folder of the network sample and enter the following command to erase the flash memory of the network core and program the network sample::
+            1. |open_terminal_window_with_environment|
+            #. Run the following command to erase the flash memory of the network core and program the network sample::
 
                 west flash --erase
 
-            2. Navigate to the build folder of the application sample and enter the same command to erase the flash memory of the application core and program the application sample::
+            #. Navigate to the build folder of the application sample and run the same command to erase the flash memory of the application core and program the application sample::
 
                 west flash --erase
 
          .. group-tab:: nRF Util
 
-            1. Open a command prompt in the build folder of the network sample and enter the following command to erase the flash memory of the network core and program the network sample::
+            1. |open_terminal_window_with_environment|
+            #. Run the following command to erase the flash memory of the network core and program the network sample::
 
                 nrfutil device program --firmware zephyr.hex --options chip_erase_mode=ERASE_ALL --core Network
 
-            .. note::
-               If you cannot locate the build folder of the network sample, look for a folder with one of these names inside the build folder of the application sample:
+                .. note::
+                    If you cannot locate the build folder of the network sample, look for a folder with one of these names inside the build folder of the application sample:
 
-               * :file:`rpc_host`
-               * :file:`hci_rpsmg`
-               * :file:`802154_rpmsg`
-               * :file:`multiprotocol_rpmsg`
+                    * :file:`rpc_host`
+                    * :file:`hci_rpsmg`
+                    * :file:`802154_rpmsg`
+                    * :file:`multiprotocol_rpmsg`
 
-            2. Navigate to the build folder of the application sample and enter the following command to erase the flash memory of the application core and program the application sample::
+            #. Navigate to the build folder of the application sample and run the following command to erase the flash memory of the application core and program the application sample::
 
                 nrfutil device program --firmware zephyr.hex  --options chip_erase_mode=ERASE_ALL
 
             .. note::
                The application build folder will be in a sub-directory which is the name of the folder of the application
 
-            3. Reset the development kit::
+            #. Reset the development kit::
 
                 nrfutil device reset --reset-kind=RESET_PIN
 
@@ -263,7 +265,7 @@ You must :ref:`build_environment_cli` before you start building an |NCS| project
 
 To build and program the source code from the command line, complete the following steps:
 
-1. Open a command line or terminal window.
+1. |open_terminal_window_with_environment|
 #. Go to the specific directory for the sample or application.
 
    For example, the directory path is :file:`ncs/nrf/applications/machine_learning` when building the source code for the :ref:`nrf_machine_learning_app` application.

--- a/doc/nrf/app_dev/device_guides/nrf91/nrf91_programming.rst
+++ b/doc/nrf/app_dev/device_guides/nrf91/nrf91_programming.rst
@@ -105,7 +105,8 @@ Complete the following steps to program firmware onto Thingy:91:
 
    .. group-tab:: Command line
 
-      5. Program the sample or application to the device using the following command::
+      5. |open_terminal_window_with_environment|
+      6. Program the sample or application to the device using the following command::
 
            west flash
 

--- a/doc/nrf/app_dev/device_guides/working_with_nrf/nrf54h/ug_nrf54h20_custom_pcb.rst
+++ b/doc/nrf/app_dev/device_guides/working_with_nrf/nrf54h/ug_nrf54h20_custom_pcb.rst
@@ -125,7 +125,9 @@ After programming the BICR, the nRF54H20 SoC requires the provisioning of a bund
 To program the Secure Domain Firmware (SDFW, also known as ``urot``) and the System Controller Firmware (SCFW) from the firmware bundle to the nRF54H20 DK, do the following:
 
 1. Download the `nRF54H20 firmware bundle`_.
-#. Move the :file:`ZIP` bundle to a folder of your choice, then run nRF Util to program the binaries using the following command::
+#. Move the :file:`ZIP` bundle to a folder of your choice.
+#. |open_terminal_window_with_environment|
+#. Run nRF Util to program the binaries using the following command::
 
       nrfutil device x-provision-nrf54h --firmware <path-to_bundle_zip_file> --serial-number <serial_number>
 
@@ -135,7 +137,7 @@ Updating the FICR
 After programming the SDFW and SCFW from the firmware bundle, you must update the Factory Information Configuration Registers (FICR) to correctly configure some trims of the nRF54H20 SoC.
 To update the FICR, you must run a J-Link script:
 
-1. Get the Jlink script that updates the FICR::
+1. Get the J-Link script that updates the FICR::
 
       curl -LO https://files.nordicsemi.com/artifactory/swtools/external/scripts/nrf54h20es_trim_adjust.jlink
 
@@ -155,7 +157,8 @@ If the LCS is set to ``EMPTY``, you must transition it to ``RoT``.
 
 To transition the LCS to ``RoT``, do the following:
 
-1. Verify the current lifecycle state of the nRF54H20::
+1. |open_terminal_window_with_environment|
+#. Verify the current lifecycle state of the nRF54H20::
 
       nrfutil device x-adac-discovery --serial-number <serial_number>
 

--- a/doc/nrf/app_dev/device_guides/working_with_nrf/nrf54h/ug_nrf54h20_gs.rst
+++ b/doc/nrf/app_dev/device_guides/working_with_nrf/nrf54h/ug_nrf54h20_gs.rst
@@ -152,6 +152,7 @@ Installing the Terminal application
 
 On your computer, install `nRF Connect for Desktop`_.
 You must also install a terminal emulator, such as `nRF Connect Serial Terminal`_ (from the nRF Connect for Desktop application) or the nRF Terminal (part of the `nRF Connect for Visual Studio Code`_ extension).
+Both of these terminal emulators start the required :ref:`toolchain environment <using_toolchain_environment>`.
 
 Installing nRF Util and its commands
 ************************************

--- a/doc/nrf/app_dev/device_guides/working_with_nrf/nrf54h/ug_nrf54h20_suit_external_memory.rst
+++ b/doc/nrf/app_dev/device_guides/working_with_nrf/nrf54h/ug_nrf54h20_suit_external_memory.rst
@@ -122,6 +122,7 @@ To enable the external memory, you must add the ``-DFILE_SUFFIX="extflash"`` arg
 
       The companion image can be optionally upgraded and have its integrity checked.
 
+#. |open_terminal_window_with_environment|
 #. Build and flash the application by completing the following commands:
 
    .. code-block:: console

--- a/doc/nrf/app_dev/device_guides/working_with_nrf/nrf54l/nrf54l15_gs.rst
+++ b/doc/nrf/app_dev/device_guides/working_with_nrf/nrf54l/nrf54l15_gs.rst
@@ -84,6 +84,7 @@ To build and program the sample to the nRF54L15 PDK, complete the following step
 
 1. Connect the nRF54L15 PDK to your computer using the IMCU USB port on the PDK.
 #. Navigate to the :file:`zephyr/samples/hello_world` folder containing the sample.
+#. |open_terminal_window_with_environment|
 #. Build the sample by running the following command:
 
    .. code-block:: console

--- a/doc/nrf/dev_model_and_contributions/documentation/build.rst
+++ b/doc/nrf/dev_model_and_contributions/documentation/build.rst
@@ -53,7 +53,8 @@ Since there are links from the |NCS| documentation set into other documentation 
 
 Complete the following steps to build the documentation output:
 
-1. Open a command-line window and enter the doc folder :file:`ncs/nrf/doc`.
+1. |open_terminal_window_with_environment|
+#. Enter the doc folder :file:`ncs/nrf/doc`.
 #. Generate the Ninja build files by entering the following command:
 
    .. code-block:: console

--- a/doc/nrf/includes/vsc_build_and_run_series.txt
+++ b/doc/nrf/includes/vsc_build_and_run_series.txt
@@ -25,6 +25,7 @@
       1. Connect the development kit to your PC using a USB cable.
       #. Power on the development kit.
       #. |exceptions_step|
+      #. |open_terminal_window_with_environment|
       #. Program the application to the kit using the following command:
 
          .. code-block:: console

--- a/doc/nrf/installation/updating.rst
+++ b/doc/nrf/installation/updating.rst
@@ -142,6 +142,16 @@ Use the method corresponding to the way you installed the |NCS|, as described in
                git checkout origin/main
                west update
 
+.. _migrating_project:
+
+Migrating your project to a new SDK version
+===========================================
+
+After you updated the |NCS| repositories to the new version and you need to migrate your |NCS| project to the new version, check the available :ref:`migration_guides` for information about which components received major breaking changes and what you have to do to keep using them.
+
+.. note::
+    |migration_contact_devzone|
+
 .. _vsc_update:
 
 Updating |nRFVSC|

--- a/doc/nrf/installation/updating.rst
+++ b/doc/nrf/installation/updating.rst
@@ -22,6 +22,11 @@ Using the correct command line environment
 ******************************************
 
 Whenever you update repositories and tools, make sure that you use the command line environment that is configured to work with west and the rest of the nRF Connect Toolchain and nRF Connect SDK environment.
+This is also valid for commands that must be executed in the |NCS| toolchain environment or when you get the following error:
+
+.. code-block:: console
+
+   west is not recognized as an internal or external command
 
 Depending on your preferred development method, you can start the correct CLI toolchain environment the following way:
 

--- a/doc/nrf/protocols/matter/getting_started/adding_clusters.rst
+++ b/doc/nrf/protocols/matter/getting_started/adding_clusters.rst
@@ -100,7 +100,8 @@ This guide uses the :ref:`ug_matter_gs_tools_matter_west_commands_zap_tool` to i
 
 To edit clusters using the ZAP tool, complete the following steps:
 
-1. Navigate to your sample directory and run the following command:
+1. |open_terminal_window_with_environment|
+#. Navigate to your sample directory and run the following command:
 
    .. code-block::
 

--- a/doc/nrf/protocols/thread/tools.rst
+++ b/doc/nrf/protocols/thread/tools.rst
@@ -79,6 +79,7 @@ As neither the Linux-based PC nor the Raspberry Pi have such radio capability, y
 
 To program the nRF device with the RCP application, complete the following steps:
 
+#. |open_terminal_window_with_environment|
 #. Build the :ref:`ot_coprocessor_sample` sample for the hardware platform and the transport of your choice:
 
    .. tabs::

--- a/doc/nrf/releases_and_maturity/migration/nRF54H20_migration_2.7/transition_guide_2.4.99-cs3_to_2.7_environment.rst
+++ b/doc/nrf/releases_and_maturity/migration/nRF54H20_migration_2.7/transition_guide_2.4.99-cs3_to_2.7_environment.rst
@@ -221,6 +221,7 @@ To prepare the nRF54H20 DK for first use, you must manually program the values o
    On MacOS, connecting the DK might cause a popup containing the message ``“Disk Not Ejected Properly`` to repeatedly appear on screen.
    To disable this, run ``JLinkExe``, then run ``MSDDisable`` in the J-Link Commander interface.
 
+#. |open_terminal_window_with_environment|
 #. List all the connected development kits to see their serial number (matching the one on the DK's sticker)::
 
       nrfutil device list
@@ -242,7 +243,9 @@ To program the Secure Domain Firmware (SDFW, also known as ``urot``) and the Sys
    .. note::
       On MacOS, ensure that the ZIP file is not unpacked automatically upon download.
 
-#. Move the :file:`.zip` bundle to a folder of your choice, then run nRF Util to program the binaries using the following command::
+#. Move the :file:`.zip` bundle to a folder of your choice.
+#. |open_terminal_window_with_environment|
+#. Run nRF Util to program the binaries using the following command::
 
       nrfutil device x-provision-nrf54h --firmware <path-to_bundle_zip_file> --serial-number <serial_number>
 
@@ -258,7 +261,7 @@ Updating the FICR
 After programming the SDFW and SCFW from the firmware bundle, you must update the Factory Information Configuration Registers (FICR) to correctly configure some trims of the nRF54H20 SoC.
 To update the FICR, you must run a J-Link script:
 
-1. Get the Jlink script that updates the FICR::
+1. Get the J-Link script that updates the FICR::
 
       curl -LO https://files.nordicsemi.com/artifactory/swtools/external/scripts/nrf54h20es_trim_adjust.jlink
 

--- a/doc/nrf/releases_and_maturity/migration_guides.rst
+++ b/doc/nrf/releases_and_maturity/migration_guides.rst
@@ -6,6 +6,9 @@ Migration guides
 The |NCS| provides migration guides for all :ref:`major and minor releases <dm-revisions>` to assist user's transition from the previous release.
 Migration guides are also provided for major functionality updates.
 
+.. note::
+    |migration_contact_devzone|
+
 .. toctree::
    :maxdepth: 1
    :glob:

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -225,3 +225,6 @@
     You can continue to use it until the transition is complete in the |NCS| and the feature is removed in one of the upcoming |NCS| releases.
 
 .. |multi_image| replace:: These samples are built for the application core and, by default, include the network core application as child image in a multi-image build (see :ref:`ug_nrf5340_multi_image`).
+
+.. |migration_contact_devzone| replace:: While we strive to document all breaking changes, the migration guides might not include the detailed migration steps for your use case.
+   If you need assistance, contact Nordic Semiconductor's technical support on `DevZone`_.

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -43,6 +43,8 @@
 
 .. |ANSI| replace:: that supports VT100/ANSI escape characters
 
+.. |open_terminal_window_with_environment| replace:: Start the :ref:`toolchain environment <using_toolchain_environment>` in a terminal window.
+
 .. ### Board shortcuts
 
 .. |nRF5340DKnoref| replace:: nRF5340 DK board (PCA10095)

--- a/samples/bluetooth/rpc_host/README.rst
+++ b/samples/bluetooth/rpc_host/README.rst
@@ -66,7 +66,8 @@ You also need to use the ``nordic-bt-rpc`` snippet, see :file:`snippets/nordic-b
 
 See :ref:`configure_application` for information about how to configure a sample.
 
-1. Build the sample with the same Bluetooth configuration as the application core sample.
+1. |open_terminal_window_with_environment|
+#. Build the sample with the same Bluetooth configuration as the application core sample.
    For more details, see: :ref:`ble_rpc`.
 
 #. Build the :ref:`peripheral_uart` on the application core.

--- a/samples/caf_sensor_manager/README.rst
+++ b/samples/caf_sensor_manager/README.rst
@@ -63,7 +63,7 @@ You can build and flash all the required images by completing the following step
 Complete the following steps to program the sample:
 
       1. Go to the sample directory.
-      #. Open the command line terminal.
+      #. |open_terminal_window_with_environment|
       #. Run the following command to build the application code for the host and the remote:
 
          .. code-block:: console

--- a/samples/event_manager_proxy/README.rst
+++ b/samples/event_manager_proxy/README.rst
@@ -71,7 +71,7 @@ Building and running
 Complete the following steps to program the sample:
 
 1. Go to the sample directory.
-#. Open the command line terminal.
+#. |open_terminal_window_with_environment|
 #. Run the following command to build the application code for the host and the remote:
 
 

--- a/samples/matter/light_bulb/README.rst
+++ b/samples/matter/light_bulb/README.rst
@@ -165,6 +165,7 @@ To set up an AWS IoT instance and configure the sample, complete the following s
 
    The certificates will vary in size depending on the method you chose when generating the certificates.
    Due to this, you might need to increase the value of the :kconfig:option:`CONFIG_MBEDTLS_SSL_OUT_CONTENT_LEN` option to be able to establish a connection.
+#. |open_terminal_window_with_environment|
 #. Build the sample using the following command:
 
    .. code-block:: console

--- a/samples/suit/smp_transfer/README.rst
+++ b/samples/suit/smp_transfer/README.rst
@@ -147,7 +147,8 @@ To build and program the sample to the nRF54H20 DK, complete the following steps
 
    .. group-tab:: Over Bluetooth Low Energy
 
-      1. Open a terminal window in |sample path|.
+      1. |open_terminal_window_with_environment|
+      #. Navigate to |sample path|.
       #. Build the sample using the following command, with the following Kconfig options set:
 
          .. code-block:: console
@@ -173,7 +174,8 @@ To build and program the sample to the nRF54H20 DK, complete the following steps
 
    .. group-tab:: Over UART
 
-      1. Open a terminal window in |sample path|.
+      1. |open_terminal_window_with_environment|
+      #. Navigate to |sample path|.
       #. Build the sample:
 
          .. code-block:: console

--- a/samples/wifi/ble_coex/README.rst
+++ b/samples/wifi/ble_coex/README.rst
@@ -219,7 +219,7 @@ Programming DKs
 
 To program the nRF5340 DK:
 
-1. Open a new terminal in the test PC.
+1. |open_terminal_window_with_environment|
 #. Navigate to :file:`<ncs code>/nrf/samples/bluetooth/throughput/`.
 #. Run the following command:
 
@@ -229,7 +229,7 @@ To program the nRF5340 DK:
 
 To program the nRF7002 DK:
 
-1. Open a new terminal in the test PC.
+1. |open_terminal_window_with_environment|
 #. Navigate to :file:`<ncs code>/nrf/samples/wifi/ble_coex/`.
 #. Run the following command:
 

--- a/samples/wifi/thread_coex/README.rst
+++ b/samples/wifi/thread_coex/README.rst
@@ -229,7 +229,7 @@ Testing
 
 #. Program the nRF7002 DK by completing the following steps:
 
-	1. Open a new terminal in the test PC.
+	1. |open_terminal_window_with_environment|
 	#. Navigate to the :file:`<ncs code>/nrf/samples/wifi/thread_coex/` folder.
 	#. Run the following command:
 


### PR DESCRIPTION
Added cross-links to migration guides from Updating tools and repositories page. Added links to using toolchain environment from command line to different pages.
NCSDK-28530 and NCSDK-28568.