### PR TITLE
samples: suit: Remove unnecessary ICRs

### DIFF
--- a/samples/suit/flash_companion/prj.conf
+++ b/samples/suit/flash_companion/prj.conf
@@ -59,6 +59,7 @@ CONFIG_USE_DT_CODE_PARTITION=y
 CONFIG_SUIT_LOCAL_ENVELOPE_GENERATE=n
 CONFIG_SUIT_ENVELOPE_TARGET=""
 CONFIG_NRF_REGTOOL_GENERATE_UICR=n
+CONFIG_NRF_REGTOOL_GENERATE_BICR=n
 
 # The MPI has to be generated from the top level application, not from
 # the flash companion application.

--- a/samples/suit/recovery/prj.conf
+++ b/samples/suit/recovery/prj.conf
@@ -20,6 +20,7 @@ CONFIG_SUIT_LOCAL_ENVELOPE_GENERATE=n
 # It is the main application which is responsible for flashing and generating the UICR
 # configuration - the recovery application should not do it.
 CONFIG_NRF_REGTOOL_GENERATE_UICR=n
+CONFIG_NRF_REGTOOL_GENERATE_BICR=n
 
 ############
 

--- a/samples/suit/recovery/sysbuild/hci_ipc.conf
+++ b/samples/suit/recovery/sysbuild/hci_ipc.conf
@@ -7,7 +7,17 @@
 # Kconfigs necessary to build the application as a recovery application
 
 CONFIG_SUIT_ENVELOPE_TEMPLATE="../rad_recovery_envelope.yaml.jinja2"
+
+# The MPI has to be generated from the top level application, not from
+# the recovery application. This is because the digests of the main application MPI
+# and the recovery application MPI is calculated together for a given domain.
+CONFIG_SUIT_MPI_GENERATE=n
 CONFIG_SUIT_ENVELOPE_OUTPUT_MPI_MERGE=n
+
+# It is the main application which is responsible for flashing and generating the UICR
+# configuration - the recovery application should not do it.
+CONFIG_NRF_REGTOOL_GENERATE_UICR=n
+CONFIG_NRF_REGTOOL_GENERATE_BICR=n
 
 ###########
 CONFIG_BT_BUF_ACL_RX_SIZE=502


### PR DESCRIPTION
The recovery application, as well as flash companion does not need to generate UICRs, BICRs, as well as MPIs.

Ref: NCSDK-NONE