### PR TITLE
dts: Bluetooth: Add new DTS binding for the SoftDevice Controller

### DIFF
--- a/applications/nrf_desktop/configuration/nrf52810dmouse_nrf52810/app.overlay
+++ b/applications/nrf_desktop/configuration/nrf52810dmouse_nrf52810/app.overlay
@@ -2,3 +2,17 @@
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 };
+
+&bt_hci_controller {
+	status = "okay";
+};
+
+&bt_hci_sdc {
+	status = "disabled";
+};
+
+/ {
+	chosen {
+		zephyr,bt-hci = &bt_hci_controller;
+	};
+};

--- a/applications/nrf_desktop/configuration/nrf52820dongle_nrf52820/app.overlay
+++ b/applications/nrf_desktop/configuration/nrf52820dongle_nrf52820/app.overlay
@@ -1,4 +1,8 @@
 / {
+	chosen {
+		zephyr,bt-hci = &bt_hci_controller;
+	};
+
 	/* Configure DTS nodes used for USB next HID support. */
 	hid_dev_0: hid_dev_0 {
 		compatible = "zephyr,hid-device";
@@ -58,4 +62,12 @@
 	num-out-endpoints = <2>;
 	num-isoin-endpoints = <0>;
 	num-isoout-endpoints = <0>;
+};
+
+&bt_hci_controller {
+	status = "okay";
+};
+
+&bt_hci_sdc {
+	status = "disabled";
 };

--- a/applications/nrf_desktop/configuration/nrf52833dk_nrf52820/app.overlay
+++ b/applications/nrf_desktop/configuration/nrf52833dk_nrf52820/app.overlay
@@ -1,4 +1,8 @@
 / {
+	chosen {
+		zephyr,bt-hci = &bt_hci_controller;
+	};
+
 	/* Configure DTS nodes used for USB next HID support. */
 	hid_dev_0: hid_dev_0 {
 		compatible = "zephyr,hid-device";
@@ -50,4 +54,13 @@
 	num-out-endpoints = <2>;
 	num-isoin-endpoints = <0>;
 	num-isoout-endpoints = <0>;
+};
+
+&bt_hci_controller {
+	status = "okay";
+};
+
+
+&bt_hci_sdc {
+	status = "disabled";
 };

--- a/dts/bindings/bluetooth/nordic,bt-hci-sdc.yaml
+++ b/dts/bindings/bluetooth/nordic,bt-hci-sdc.yaml
@@ -1,0 +1,11 @@
+description: Bluetooth HCI provided by the SoftDevice Controller
+
+compatible: "nordic,bt-hci-sdc"
+
+include: bt-hci.yaml
+
+properties:
+  bt-hci-name:
+    default: "SDC"
+  bt-hci-bus:
+    default: "BT_HCI_BUS_VIRTUAL"

--- a/samples/bluetooth/direction_finding_central/sysbuild.cmake
+++ b/samples/bluetooth/direction_finding_central/sysbuild.cmake
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+if(NOT SB_CONFIG_SOC_NRF5340_CPUAPP)
+  if(NOT "bt-ll-sw-split" IN_LIST ${DEFAULT_IMAGE}_SNIPPET)
+    list(APPEND ${DEFAULT_IMAGE}_SNIPPET ${SNIPPET})
+    list(APPEND ${DEFAULT_IMAGE}_SNIPPET bt-ll-sw-split)
+    set(${DEFAULT_IMAGE}_SNIPPET ${${DEFAULT_IMAGE}_SNIPPET} CACHE STRING "" FORCE)
+  endif()
+  if(SB_CONFIG_SECURE_BOOT_BUILD_S1_VARIANT_IMAGE AND NOT "bt-ll-sw-split" IN_LIST s1_image_SNIPPET)
+    list(APPEND s1_image_SNIPPET ${SNIPPET})
+    list(APPEND s1_image_SNIPPET bt-ll-sw-split)
+    set(s1_image_SNIPPET ${s1_image_SNIPPET} CACHE STRING "" FORCE)
+  endif()
+endif()
+
+if(NOT "bt-ll-sw-split" IN_LIST ipc_radio_SNIPPET)
+  list(APPEND ipc_radio_SNIPPET ${SNIPPET})
+  list(APPEND ipc_radio_SNIPPET bt-ll-sw-split)
+  set(ipc_radio_SNIPPET ${ipc_radio_SNIPPET} CACHE STRING "" FORCE)
+endif()

--- a/samples/bluetooth/direction_finding_connectionless_rx/sysbuild.cmake
+++ b/samples/bluetooth/direction_finding_connectionless_rx/sysbuild.cmake
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+if(NOT SB_CONFIG_SOC_NRF5340_CPUAPP)
+  if(NOT "bt-ll-sw-split" IN_LIST ${DEFAULT_IMAGE}_SNIPPET)
+    list(APPEND ${DEFAULT_IMAGE}_SNIPPET ${SNIPPET})
+    list(APPEND ${DEFAULT_IMAGE}_SNIPPET bt-ll-sw-split)
+    set(${DEFAULT_IMAGE}_SNIPPET ${${DEFAULT_IMAGE}_SNIPPET} CACHE STRING "" FORCE)
+  endif()
+  if(SB_CONFIG_SECURE_BOOT_BUILD_S1_VARIANT_IMAGE AND NOT "bt-ll-sw-split" IN_LIST s1_image_SNIPPET)
+    list(APPEND s1_image_SNIPPET ${SNIPPET})
+    list(APPEND s1_image_SNIPPET bt-ll-sw-split)
+    set(s1_image_SNIPPET ${s1_image_SNIPPET} CACHE STRING "" FORCE)
+  endif()
+endif()
+
+if(NOT "bt-ll-sw-split" IN_LIST ipc_radio_SNIPPET)
+  list(APPEND ipc_radio_SNIPPET ${SNIPPET})
+  list(APPEND ipc_radio_SNIPPET bt-ll-sw-split)
+  set(ipc_radio_SNIPPET ${ipc_radio_SNIPPET} CACHE STRING "" FORCE)
+endif()

--- a/samples/bluetooth/direction_finding_connectionless_tx/sysbuild.cmake
+++ b/samples/bluetooth/direction_finding_connectionless_tx/sysbuild.cmake
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+if(NOT SB_CONFIG_SOC_NRF5340_CPUAPP)
+  if(NOT "bt-ll-sw-split" IN_LIST ${DEFAULT_IMAGE}_SNIPPET)
+    list(APPEND ${DEFAULT_IMAGE}_SNIPPET ${SNIPPET})
+    list(APPEND ${DEFAULT_IMAGE}_SNIPPET bt-ll-sw-split)
+    set(${DEFAULT_IMAGE}_SNIPPET ${${DEFAULT_IMAGE}_SNIPPET} CACHE STRING "" FORCE)
+  endif()
+  if(SB_CONFIG_SECURE_BOOT_BUILD_S1_VARIANT_IMAGE AND NOT "bt-ll-sw-split" IN_LIST s1_image_SNIPPET)
+    list(APPEND s1_image_SNIPPET ${SNIPPET})
+    list(APPEND s1_image_SNIPPET bt-ll-sw-split)
+    set(s1_image_SNIPPET ${s1_image_SNIPPET} CACHE STRING "" FORCE)
+  endif()
+endif()
+
+if(NOT "bt-ll-sw-split" IN_LIST ipc_radio_SNIPPET)
+  list(APPEND ipc_radio_SNIPPET ${SNIPPET})
+  list(APPEND ipc_radio_SNIPPET bt-ll-sw-split)
+  set(ipc_radio_SNIPPET ${ipc_radio_SNIPPET} CACHE STRING "" FORCE)
+endif()

--- a/samples/bluetooth/direction_finding_peripheral/sysbuild.cmake
+++ b/samples/bluetooth/direction_finding_peripheral/sysbuild.cmake
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+if(NOT SB_CONFIG_SOC_NRF5340_CPUAPP)
+  if(NOT "bt-ll-sw-split" IN_LIST ${DEFAULT_IMAGE}_SNIPPET)
+    list(APPEND ${DEFAULT_IMAGE}_SNIPPET ${SNIPPET})
+    list(APPEND ${DEFAULT_IMAGE}_SNIPPET bt-ll-sw-split)
+    set(${DEFAULT_IMAGE}_SNIPPET ${${DEFAULT_IMAGE}_SNIPPET} CACHE STRING "" FORCE)
+  endif()
+  if(SB_CONFIG_SECURE_BOOT_BUILD_S1_VARIANT_IMAGE AND NOT "bt-ll-sw-split" IN_LIST s1_image_SNIPPET)
+    list(APPEND s1_image_SNIPPET ${SNIPPET})
+    list(APPEND s1_image_SNIPPET bt-ll-sw-split)
+    set(s1_image_SNIPPET ${s1_image_SNIPPET} CACHE STRING "" FORCE)
+  endif()
+endif()
+
+if(NOT "bt-ll-sw-split" IN_LIST ipc_radio_SNIPPET)
+  list(APPEND ipc_radio_SNIPPET ${SNIPPET})
+  list(APPEND ipc_radio_SNIPPET bt-ll-sw-split)
+  set(ipc_radio_SNIPPET ${ipc_radio_SNIPPET} CACHE STRING "" FORCE)
+endif()

--- a/samples/debug/ppi_trace/sysbuild.cmake
+++ b/samples/debug/ppi_trace/sysbuild.cmake
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+if(SB_CONFIG_SOC_SERIES_NRF52X)
+  if(NOT "bt-ll-sw-split" IN_LIST ${DEFAULT_IMAGE}_SNIPPET)
+    list(APPEND ${DEFAULT_IMAGE}_SNIPPET ${SNIPPET})
+    list(APPEND ${DEFAULT_IMAGE}_SNIPPET bt-ll-sw-split)
+    set(${DEFAULT_IMAGE}_SNIPPET ${${DEFAULT_IMAGE}_SNIPPET} CACHE STRING "" FORCE)
+  endif()
+endif()
+
+if(NOT "bt-ll-sw-split" IN_LIST ipc_radio_SNIPPET)
+  list(APPEND ipc_radio_SNIPPET ${SNIPPET})
+  list(APPEND ipc_radio_SNIPPET bt-ll-sw-split)
+  set(ipc_radio_SNIPPET ${ipc_radio_SNIPPET} CACHE STRING "" FORCE)
+endif()

--- a/subsys/bluetooth/controller/ecdh.c
+++ b/subsys/bluetooth/controller/ecdh.c
@@ -18,7 +18,7 @@
 
 #include "ecdh.h"
 
-#define DT_DRV_COMPAT zephyr_bt_hci_ll_sw_split
+#define DT_DRV_COMPAT nordic_bt_hci_sdc
 
 #define LOG_LEVEL CONFIG_BT_HCI_DRIVER_LOG_LEVEL
 #include "zephyr/logging/log.h"

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -32,7 +32,7 @@
 #include "ecdh.h"
 #include "radio_nrf5_txp.h"
 
-#define DT_DRV_COMPAT zephyr_bt_hci_ll_sw_split
+#define DT_DRV_COMPAT nordic_bt_hci_sdc
 
 #define LOG_LEVEL CONFIG_BT_HCI_DRIVER_LOG_LEVEL
 #include "zephyr/logging/log.h"

--- a/tests/drivers/nrfx_integration_test/testcase.yaml
+++ b/tests/drivers/nrfx_integration_test/testcase.yaml
@@ -44,6 +44,7 @@ tests:
     tags: drivers ci_build sysbuild ci_tests_drivers_nrfx_integration_test
     extra_configs:
       - CONFIG_NRFX_AND_BT_LL_SW_SPLIT=y
+    extra_args: SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpunet

--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 21c97d07da26177a3d1cc000f523e3fe73569d63
+      revision: fb6ca20a06ba31a3dc1b86d6986d48ad4a5760b0
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
The SoftDevice Controller is a different controller than the open source link layer with a different set of quirks. It should therefore have its own device tree binding.

This commit converts the SoftDevice Controller driver to use this new DTS binding instead of reusing the existing one.

This commit updates or adds additional overlays for existing samples, applications and tests that were using the open source link layer.

Updating migration guide will be done in a separate commit.