### PR TITLE
samples: tfm: Fix provisioning image for 5340 sysbuild

### DIFF
--- a/samples/tfm/provisioning_image/README.rst
+++ b/samples/tfm/provisioning_image/README.rst
@@ -13,8 +13,8 @@ This sample does not include a TF-M image, it is a Zephyr image intended to be f
 After completion, the device is in the Platform Root-of-Trust (PRoT) security lifecycle state called **PRoT Provisioning**.
 For more information about the PRoT security lifecycle, see Arm's Platform Security Model 1.1 defined in the Platform Security Architecture (PSA).
 
-When built for the nrf5340dk/nrf5340/cpuapp target, this image by default also includes the :ref:`provisioning_image_net_core` sample as a child image for the network core (``nrf5340dk/nrf5340/cpunet`` target).
-The child image demonstrates how to disable the debugging access on the network core by writing to the UICR.APPROTECT register.
+When built for the nrf5340dk/nrf5340/cpuapp target, this image by default also includes the :ref:`provisioning_image_net_core` sample as an additional image for the network core (``nrf5340dk/nrf5340/cpunet`` target).
+The network core image demonstrates how to disable the debugging access on the network core by writing to the UICR.APPROTECT register.
 
 Requirements
 ************

--- a/samples/tfm/provisioning_image/sysbuild.cmake
+++ b/samples/tfm/provisioning_image/sysbuild.cmake
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+get_property(PM_DOMAINS GLOBAL PROPERTY PM_DOMAINS)
+
+# Include net core provision image for 5340
+if(SB_CONFIG_SOC_NRF5340_CPUAPP)
+  # Get network core board target
+  string(REPLACE "/" ";" split_board_qualifiers "${BOARD_QUALIFIERS}")
+  list(GET split_board_qualifiers 1 target_soc)
+  set(board_target_netcore "${BOARD}/${target_soc}/cpunet")
+  set(target_soc)
+
+  ExternalZephyrProject_Add(
+    APPLICATION provisioning_image_net_core
+    SOURCE_DIR ${ZEPHYR_NRF_MODULE_DIR}/samples/tfm/provisioning_image_net_core
+    BOARD ${board_target_netcore}
+    BOARD_REVISION ${BOARD_REVISION}
+  )
+
+  if(NOT "CPUNET" IN_LIST PM_DOMAINS)
+    list(APPEND PM_DOMAINS CPUNET)
+  endif()
+
+  set_property(GLOBAL APPEND PROPERTY PM_CPUNET_IMAGES "provisioning_image_net_core")
+  set_property(GLOBAL PROPERTY DOMAIN_APP_CPUNET "provisioning_image_net_core")
+  set(CPUNET_PM_DOMAIN_DYNAMIC_PARTITION provisioning_image_net_core CACHE INTERNAL "")
+endif()
+
+set_property(GLOBAL PROPERTY PM_DOMAINS ${PM_DOMAINS})

--- a/samples/tfm/provisioning_image_net_core/README.rst
+++ b/samples/tfm/provisioning_image_net_core/README.rst
@@ -10,7 +10,7 @@ TF-M: Provisioning image for network core
 
 Running this provisioning image in the network core will disable the debugging access, as required by the Trusted Firmware-M (TF-M) provisioning process.
 The debugging is disabled by enabling the APPROTECT in the UICR register.
-This sample is included by default as a child image of the :ref:`provisioning image<provisioning_image>` sample which runs on the application core.
+This sample is included by default as an additional image for the :ref:`provisioning image<provisioning_image>` sample which runs on the application core.
 
 The provisioning images initialize the provisioning process of a device in a manner compatible with TF-M.
 The APPROTECT feature is explained in detail in :ref:`app_approtect`.


### PR DESCRIPTION
Add TF-M Provisioning image for network core sample as an additional image when building nRF5340 with sysbuild.

Edit: To be fixed to 2.7 as well.