### PR TITLE
nrf_modem_lib: trace_backends: rtt: early alloc buf

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -606,6 +606,7 @@ Modem libraries
 
 * :ref:`nrf_modem_lib_readme` library:
 
+  * Updated the RTT trace backend to allocate the RTT channel at boot, instead of when the modem is activated.
   * Removed support for deprecated RAI socket options ``SO_RAI_LAST``, ``SO_RAI_NO_DATA``, ``SO_RAI_ONE_RESP``, ``SO_RAI_ONGOING``, and ``SO_RAI_WAIT_MORE``.
 
 Multiprotocol Service Layer libraries

--- a/tests/lib/nrf_modem_lib/trace_backends/rtt/src/main.c
+++ b/tests/lib/nrf_modem_lib/trace_backends/rtt/src/main.c
@@ -10,6 +10,9 @@
 
 #include "trace_backend.h"
 
+/* SYS_INIT function */
+int nrf_modem_lib_trace_rtt_channel_alloc(void);
+
 extern struct nrf_modem_lib_trace_backend trace_backend;
 
 #include "cmock_SEGGER_RTT.h"
@@ -51,8 +54,10 @@ void test_trace_backend_init_rtt(void)
 	__cmock_SEGGER_RTT_AllocUpBuffer_ExpectAnyArgsAndReturn(trace_rtt_channel);
 	__cmock_SEGGER_RTT_AllocUpBuffer_AddCallback(&rtt_allocupbuffer_callback);
 
-	ret = trace_backend.init(callback);
+	ret = nrf_modem_lib_trace_rtt_channel_alloc();
+	TEST_ASSERT_EQUAL(0, ret);
 
+	ret = trace_backend.init(callback);
 	TEST_ASSERT_EQUAL(0, ret);
 }
 
@@ -62,6 +67,9 @@ void test_trace_backend_init_rtt_ebusy(void)
 
 	/* Simulate failure by returning negative RTT channel. */
 	__cmock_SEGGER_RTT_AllocUpBuffer_ExpectAnyArgsAndReturn(-1);
+
+	ret = nrf_modem_lib_trace_rtt_channel_alloc();
+	TEST_ASSERT_EQUAL(-EBUSY, ret);
 
 	ret = trace_backend.init(callback);
 	TEST_ASSERT_EQUAL(-EBUSY, ret);


### PR DESCRIPTION
Allocate the modem trace buffer for the RTT backend on boot, instead of when `nrf_modem_lib_init` is called. This allows the user to delay the call to `nrf_modem_lib_init`, giving them a chance to attach to the RTT channel before the modem starts.

Without this change the start of trace logs from the RTT backend are invariably lost, as the user cannot attach until after data generation has started.