### PR TITLE
doc: programming: expand --recover info

### DIFF
--- a/applications/nrf5340_audio/doc/building.rst
+++ b/applications/nrf5340_audio/doc/building.rst
@@ -111,7 +111,7 @@ Programming with the script
    This command builds the headset and the gateway applications with ``debug`` version of both the application core binary and the network core binary - and programs each to its respective core.
 
    .. note::
-      If the programming command fails because of :ref:`readback_protection_error`, run :file:`buildprog.py` with the ``--recover_on_fail`` or ``-f`` parameter to recover and re-program automatically when programming fails.
+      If the programming command fails because of a :ref:`readback protection error <readback_protection_error>`, run :file:`buildprog.py` with the ``--recover_on_fail`` or ``-f`` parameter to recover and re-program automatically when programming fails.
       For example, using the programming command example above:
 
       .. code-block:: console

--- a/doc/nrf/app_dev/device_guides/nrf53/building_nrf53.rst
+++ b/doc/nrf/app_dev/device_guides/nrf53/building_nrf53.rst
@@ -146,46 +146,6 @@ To program the nRF5340 DK from the command line, use either west (which uses nrf
             .. note::
                  The ``--verify`` command confirms that the writing operation has succeeded.
 
-.. _readback_protection_error:
-
-Readback protection
-===================
-
-When programming the device, you might get an error similar to the following message::
-
-    ERROR: The operation attempted is unavailable due to readback protection in
-    ERROR: your device. Please use --recover to unlock the device.
-
-This error occurs when readback protection is enabled.
-To disable the readback protection, you must *recover* your device.
-See the following instructions.
-
-.. tabs::
-
-   .. group-tab:: west
-
-      Use the ``--recover`` parameter with ``west flash``, as described in :ref:`programming_params`.
-
-   .. group-tab:: nRF Util
-
-      Enter the following commands to recover first the network core and then the application core:
-
-      .. code-block:: console
-
-         nrfutil device recover --core Network
-         nrfutil device recover
-
-      .. note::
-           Make sure to recover the network core before you recover the application core.
-
-           The ``nrfutil device recover`` command erases the flash memory and then writes a small binary into the recovered flash memory.
-           This binary prevents the readback protection from enabling itself again after a pin reset or power cycle.
-
-           Recovering the network core erases the flash memory of both cores.
-           Recovering the application core erases only the flash memory of the application core.
-           Therefore, you must recover the network core first.
-           Otherwise, if you recover the application core first and the network core last, the binary written to the application core is deleted and readback protection is enabled again after a reset.
-
 .. _thingy53_building_pgming:
 
 Building and programming with Thingy:53

--- a/doc/nrf/app_dev/programming.rst
+++ b/doc/nrf/app_dev/programming.rst
@@ -56,16 +56,35 @@ Programming without ``--erase``
 
      west flash
 
-Programming with ``--recover``
-  Several Nordic Semiconductor SoCs or SiPs supported in the |NCS| offer an implementation of the :term:`Access port protection mechanism (AP-Protect)`, a form of readback protection.
-  To disable the AP-Protect, you must recover your device.
-  This is particularly important for multi-core devices.
+  ..
 
-  Use the following command:
+.. _readback_protection_error:
+
+Programming with ``--recover``
+  Recovering a device typically refers to the process of resetting it to a known, working state, often by erasing and reprogramming its memory.
+  This is usually done in the following cases:
+
+  * The device is not functioning correctly.
+  * The device is using a readback protection, such as the :term:`Access port protection mechanism (AP-Protect)`, offered by several Nordic Semiconductor SoCs or SiPs supported in the |NCS|.
+    In such a case, you might get an error similar to the following message:
+
+    .. code-block:: console
+
+       ERROR: The operation attempted is unavailable due to readback protection in
+       ERROR: your device. Please use --recover to unlock the device.
+
+  Use the following command to recover your device:
 
   .. code-block:: console
 
      west flash --recover
 
-  This command uses ``nrfjprog --recover`` command in the background.
-  It erases all user available non-volatile memory and disables the readback protection mechanism if enabled.
+  This command erases all user-available non-volatile memory and disables the readback protection mechanism, if enabled.
+
+  .. toggle:: Background recovery commands
+
+     The ``west flash --recover`` command uses one of the following background commands:
+
+     * ``nrfjprog --recover`` for devices from nRF52, nRF53, and nRF91 Series.
+     * ``nrfutil device recover`` for devices from nRF54H and nRF54L Series.
+       For more information about how ``nrfutil device recover`` works, see the `nRF Util documentation <Recovering the device_>`_.

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -796,6 +796,7 @@
 .. _`Generating DFU packages`: https://docs.nordicsemi.com/bundle/nrfutil/page/guides-nrf5sdk/dfu_generating_packages.html
 .. _`DFU over a serial USB connection`: https://docs.nordicsemi.com/bundle/nrfutil/page/guides-nrf5sdk/dfu_performing.html#dfu-over-a-serial-usb-connection
 .. _`Toolchain Manager command`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-toolchain-manager/nrfutil-toolchain-manager_0.14.1.html#available-subcommands
+.. _`Recovering the device`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-device/guides/programming_recovery.html
 
 .. _`anomaly 19`: https://docs.nordicsemi.com/bundle/errata_nRF5340_EngA/page/ERR/nRF5340/EngineeringA/latest/anomaly_340_19.html
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -954,3 +954,4 @@ Documentation
 * Updated:
 
   * The :ref:`ug_nrf70_developing_debugging` page with the new snippets added for the nRF70 driver debug and WPA supplicant debug logs.
+  * The :ref:`programming_params` section on the :ref:`programming` page with information about readback protection moved from the :ref:`ug_nrf5340_building` page.


### PR DESCRIPTION
Moved information from building_nrf53.rst to programming.rst and nRF Util docs, given that it applies to more than one device series. Expanded information to include information about nRF54H and nRF54L. Linked to nRF Util docs. NCSDK-28527.
