### PR TITLE
nrf_security: Don't configure RRAMC for TFM builds

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/Kconfig
+++ b/subsys/nrf_security/src/drivers/cracen/Kconfig
@@ -26,6 +26,7 @@ config CRACEN_LOAD_MICROCODE
 config CRACEN_LIB_KMU
 	bool
 	depends on SOC_SERIES_NRF54LX
+	select NRFX_RRAMC if !BUILD_WITH_TFM
 	default y
 	help
 	  The CRACEN KMU library.

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/lib_kmu.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/lib_kmu.c
@@ -11,41 +11,13 @@
 #include <zephyr/kernel.h>
 
 #include <nrf.h>
+
+#if !defined(__NRF_TFM__)
 #include <hal/nrf_rramc.h>
+#include <nrfx_rramc.h>
+#endif
 
 #include <cracen/lib_kmu.h>
-
-/*
- * Enable writes and set the write buffer size to 0
- * bytes. IPS states that this is invalid but the IPS is
- * wrong. Setting it to 0 will prevent buffering and therefore
- * prevent writes from being discarded on soft reset.
- */
-static void rramc_enable_writes(void)
-{
-	nrf_rramc_config_t const config = {
-		.mode_write = true, .write_buff_size = 0 /* Unbuffered */
-	};
-	nrf_rramc_config_set(NRF_RRAMC_S, &config);
-
-	while (!nrf_rramc_ready_check(NRF_RRAMC_S)) {
-		;
-	}
-}
-
-/*
- * Reset the CONFIG register back to having writes disabled. Also set
- * buffer size to 1.
- */
-static void rramc_disable_writes(void)
-{
-	nrf_rramc_config_t const config = {.mode_write = false, .write_buff_size = 1};
-
-	nrf_rramc_config_set(NRF_RRAMC_S, &config);
-	while (!nrf_rramc_ready_check(NRF_RRAMC_S)) {
-		;
-	}
-}
 
 void lib_kmu_clear_all_events(void)
 {
@@ -103,7 +75,9 @@ int lib_kmu_provision_slot(int slot_id, struct kmu_src_t *kmu_src)
 
 	int result = 1;
 
-	rramc_enable_writes();
+#if !defined(__NRF_TFM__)
+	nrfx_rramc_write_enable_set(true, 0);
+#endif
 
 	NRF_KMU_S->KEYSLOT = slot_id;
 	NRF_KMU_S->SRC = (uint32_t)kmu_src;
@@ -111,7 +85,9 @@ int lib_kmu_provision_slot(int slot_id, struct kmu_src_t *kmu_src)
 	result = trigger_task_and_wait_for_event_or_error(&(NRF_KMU_S->TASKS_PROVISION),
 							  &(NRF_KMU_S->EVENTS_PROVISIONED));
 
-	rramc_disable_writes();
+#if !defined(__NRF_TFM__)
+	nrfx_rramc_write_enable_set(false, 0);
+#endif
 
 	return result;
 }
@@ -126,14 +102,18 @@ int lib_kmu_push_slot(int slot_id)
 
 int lib_kmu_revoke_slot(int slot_id)
 {
-	rramc_enable_writes();
+#if !defined(__NRF_TFM__)
+	nrfx_rramc_write_enable_set(true, 0);
+#endif
 
 	NRF_KMU_S->KEYSLOT = slot_id;
 
 	int result = trigger_task_and_wait_for_event_or_error(&(NRF_KMU_S->TASKS_REVOKE),
 							      &(NRF_KMU_S->EVENTS_REVOKED));
 
-	rramc_disable_writes();
+#if !defined(__NRF_TFM__)
+	nrfx_rramc_write_enable_set(false, 0);
+#endif
 
 	return result;
 }


### PR DESCRIPTION
When the lib kmu is included inside the TFM image it should not update the RRAMC write mode since we
configure it to have the write mode enabled during the initialization of TFM and expect it to be enabled all the time.