### PR TITLE
Fixed bug in response to direct method

### DIFF
--- a/samples/net/azure_iot_hub/src/main.c
+++ b/samples/net/azure_iot_hub/src/main.c
@@ -323,7 +323,7 @@ static void direct_method_handler(struct k_work *work)
 		},
 		.status = 200,
 		.payload.ptr = response,
-		.payload.size = sizeof(response) - 1,
+		.payload.size = strlen(response),
 	};
 	bool led_state = strncmp(method_data.payload, "0", 1) ? 1 : 0;
 


### PR DESCRIPTION
The response payload size was not set correctly resulting in an invalid json response. The size set was the size of the pointer (4) not the string content.