### PR TITLE
tests: lib: lte_lc_api: Add tests for modem hooks

### DIFF
--- a/lib/lte_link_control/lte_lc_modem_hooks.c
+++ b/lib/lte_link_control/lte_lc_modem_hooks.c
@@ -11,10 +11,13 @@
 
 LOG_MODULE_DECLARE(lte_lc, CONFIG_LTE_LINK_CONTROL_LOG_LEVEL);
 
+#if defined(CONFIG_UNITY)
+void on_modem_init(int err, void *ctx)
+#else
 NRF_MODEM_LIB_ON_INIT(lte_lc_init_hook, on_modem_init, NULL);
-NRF_MODEM_LIB_ON_SHUTDOWN(lte_lc_shutdown_hook, on_modem_shutdown, NULL);
 
 static void on_modem_init(int err, void *ctx)
+#endif
 {
 	extern const enum lte_lc_system_mode lte_lc_sys_mode;
 	extern const enum lte_lc_system_mode_preference lte_lc_sys_mode_pref;
@@ -128,7 +131,13 @@ static void on_modem_init(int err, void *ctx)
 	}
 }
 
+#if defined(CONFIG_UNITY)
+void on_modem_shutdown(void *ctx)
+#else
+NRF_MODEM_LIB_ON_SHUTDOWN(lte_lc_shutdown_hook, on_modem_shutdown, NULL);
+
 static void on_modem_shutdown(void *ctx)
+#endif
 {
 	/* Make sure the Modem library was in normal mode and not in bootloader mode. */
 	if (nrf_modem_is_initialized()) {

--- a/tests/lib/lte_lc_api/CMakeLists.txt
+++ b/tests/lib/lte_lc_api/CMakeLists.txt
@@ -16,6 +16,8 @@ cmock_handle(${ZEPHYR_NRFXLIB_MODULE_DIR}/nrf_modem/include/nrf_modem_at.h
 	     FUNC_EXCLUDE ".*nrf_modem_at_scanf"
 	     FUNC_EXCLUDE ".*nrf_modem_at_printf")
 
+cmock_handle(${ZEPHYR_NRFXLIB_MODULE_DIR}/nrf_modem/include/nrf_modem.h)
+
 # When mocking nrf_modem_at then nrf_modem/include must manually be added
 # because CONFIG_NRF_MODEM_LINK_BINARY=n
 zephyr_include_directories(${ZEPHYR_NRFXLIB_MODULE_DIR}/nrf_modem/include/)


### PR DESCRIPTION
Adding tests to cover on_modem_init, on_modem_shutdown and lte_lc_on_modem_cfun.