### PR TITLE
tests: lib: lte_lc_api: Add coverage for edrx

### DIFF
--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -1023,6 +1023,19 @@ int lte_lc_edrx_req(bool enable)
 	int err = 0;
 	int actt[] = {AT_CEDRXS_ACTT_WB, AT_CEDRXS_ACTT_NB};
 
+	LOG_DBG("enable=%d, "
+		"requested_edrx_value_ltem=%s, edrx_value_ltem=%s, "
+		"requested_ptw_value_ltem=%s, ptw_value_ltem=%s, ",
+		enable,
+		requested_edrx_value_ltem, edrx_value_ltem,
+		requested_ptw_value_ltem, ptw_value_ltem);
+	LOG_DBG("enable=%d, "
+		"requested_edrx_value_nbiot=%s, edrx_value_nbiot=%s, "
+		"requested_ptw_value_nbiot=%s, ptw_value_nbiot=%s",
+		enable,
+		requested_edrx_value_nbiot, edrx_value_nbiot,
+		requested_ptw_value_nbiot, ptw_value_nbiot);
+
 	requested_edrx_enable = enable;
 
 	if (!enable) {

--- a/tests/lib/lte_lc_api/src/lte_lc_api_test.c
+++ b/tests/lib/lte_lc_api/src/lte_lc_api_test.c
@@ -1194,7 +1194,7 @@ void test_lte_lc_edrx_get_ltem2_success(void)
 {
 	int ret;
 	struct lte_lc_edrx_cfg edrx_cfg;
-	static const char cedrxrdp_resp[] = "+CEDRXRDP: 4,\"1000\",\"0010\",\"1110\"";
+	static const char cedrxrdp_resp[] = "+CEDRXRDP: 4,\"1000\",\"0000\",\"1110\"";
 
 	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT+CEDRXRDP", 0);
 	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
@@ -1205,7 +1205,7 @@ void test_lte_lc_edrx_get_ltem2_success(void)
 	ret = lte_lc_edrx_get(&edrx_cfg);
 	TEST_ASSERT_EQUAL(EXIT_SUCCESS, ret);
 	TEST_ASSERT_EQUAL(LTE_LC_LTE_MODE_LTEM, edrx_cfg.mode);
-	TEST_ASSERT_EQUAL_FLOAT(20.48, edrx_cfg.edrx);
+	TEST_ASSERT_EQUAL_FLOAT(5.12, edrx_cfg.edrx);
 	TEST_ASSERT_EQUAL_FLOAT(19.2, edrx_cfg.ptw);
 }
 
@@ -1252,6 +1252,73 @@ void test_lte_lc_edrx_get_invalid_mode_fail(void)
 	int ret;
 	struct lte_lc_edrx_cfg edrx_cfg;
 	static const char cedrxrdp_resp[] = "+CEDRXRDP: 1,\"1000\",\"0101\",\"1011\"";
+
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT+CEDRXRDP", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
+		(char *)cedrxrdp_resp, sizeof(cedrxrdp_resp));
+
+	ret = lte_lc_edrx_get(&edrx_cfg);
+	TEST_ASSERT_EQUAL(-EBADMSG, ret);
+}
+
+void test_lte_lc_edrx_get_invalid_nw_edrx_value_fail(void)
+{
+	int ret;
+	struct lte_lc_edrx_cfg edrx_cfg;
+	static const char cedrxrdp_resp[] = "+CEDRXRDP: 4,\"1000\",0101,\"1011\"";
+
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT+CEDRXRDP", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
+		(char *)cedrxrdp_resp, sizeof(cedrxrdp_resp));
+
+	ret = lte_lc_edrx_get(&edrx_cfg);
+	TEST_ASSERT_EQUAL(-EBADMSG, ret);
+}
+
+void test_lte_lc_edrx_get_invalid_nw_edrx_value_empty(void)
+{
+	int ret;
+	struct lte_lc_edrx_cfg edrx_cfg;
+	static const char cedrxrdp_resp[] = "+CEDRXRDP: 4,\"1000\",\"\",\"1011\"";
+
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT+CEDRXRDP", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
+		(char *)cedrxrdp_resp, sizeof(cedrxrdp_resp));
+
+	ret = lte_lc_edrx_get(&edrx_cfg);
+	TEST_ASSERT_EQUAL(0, ret);
+	TEST_ASSERT_EQUAL(LTE_LC_LTE_MODE_NONE, edrx_cfg.mode);
+	TEST_ASSERT_EQUAL_FLOAT(0, edrx_cfg.edrx);
+	TEST_ASSERT_EQUAL_FLOAT(0, edrx_cfg.ptw);
+}
+
+void test_lte_lc_edrx_get_missing_nw_edrx_value(void)
+{
+	int ret;
+	struct lte_lc_edrx_cfg edrx_cfg;
+	static const char cedrxrdp_resp[] = "+CEDRXRDP: 4,\"1000\"";
+
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT+CEDRXRDP", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
+		(char *)cedrxrdp_resp, sizeof(cedrxrdp_resp));
+
+	ret = lte_lc_edrx_get(&edrx_cfg);
+	TEST_ASSERT_EQUAL(-EBADMSG, ret);
+}
+
+void test_lte_lc_edrx_get_missing_ptw_value_fail(void)
+{
+	int ret;
+	struct lte_lc_edrx_cfg edrx_cfg;
+	static const char cedrxrdp_resp[] = "+CEDRXRDP: 4,\"1000\",\"0101\"";
 
 	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT+CEDRXRDP", 0);
 	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();


### PR DESCRIPTION
Adding test coverage for edrx related tests.
Also cleaning up dead code, i.e., conditions that cannot be met, have been changed from if-statements to asserts.