### PR TITLE
crypto service: Increase SSF buffer size to 128 bytes

### DIFF
--- a/subsys/sdfw_services/services/psa_crypto/Kconfig
+++ b/subsys/sdfw_services/services/psa_crypto/Kconfig
@@ -8,6 +8,6 @@ service_name = PSA_CRYPTO
 service_default_enabled = n
 service_id = 0x71
 service_version = 1
-service_buffer_size = 64
+service_buffer_size = 128
 service_name_str = PSA Crypto
 rsource "../Kconfig.template.service"


### PR DESCRIPTION
Increase the SSF buffer size of the crypto service to 128 bytes

Ref: NCSDK-NONE