### PR TITLE
manifest: west.yml updated to reflect zephyr module name change

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -83,7 +83,7 @@ manifest:
         #
         # Please keep this list sorted alphabetically.
         name-allowlist:
-          - TraceRecorderSource
+          - percepio
           - canopennode
           - chre
           - cmsis


### PR DESCRIPTION
manifest: west.yml updated to reflect zephyr TraceRecorderSource module name change to percepio.
Change occurred on Sep 12, 2023 via this PR: https://github.com/zephyrproject-rtos/zephyr/pull/62377

Signed-off-by: Erik Tamlin <erik.tamlin@percepio.com>