### PR TITLE
modules: TF-M: Allow reading UICR.OTP areas

### DIFF
--- a/doc/nrf/libraries/security/tfm/tfm_ioctl_api.rst
+++ b/doc/nrf/libraries/security/tfm/tfm_ioctl_api.rst
@@ -29,6 +29,32 @@ The supported platform services are defined by :c:struct:`tfm_platform_ioctl_cor
 
 Set the :kconfig:option:`CONFIG_TFM_PARTITION_PLATFORM` Kconfig option to enable the services.
 
+Read service
+============
+
+The TF-M IOTCL read service allows the NSPE to access memory areas within the SPE that would otherwise be inaccessible to it.
+The allowed memory areas are defined by the :file:`tfm_platform_user_memory_ranges.h` file.
+
+The service is used by the :c:func:`tfm_platform_mem_read` function.
+For example, you can use the service to read the OTP value from UICR registers:
+
+.. code-block:: c
+
+    #include <tfm_ioctl_api.h>
+
+    void read_otp_value(void) {
+        uint32_t otp_value;
+        int err;
+        enum tfm_platform_err_t plt_err;
+
+        plt_err = tfm_platform_mem_read(buf, (intptr_t)&NRF_UICR_S->OTP[0], sizeof(otp_value), &err);
+        if (plt_err != TFM_PLATFORM_ERR_SUCCESS || err != 0) {
+            /* Handle error */
+        }
+
+        printk("OTP[0]: %u\n", otp_value);
+    }
+
 See the :ref:`tfm_hello_world` sample for example usage.
 
 Prerequisites

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -768,7 +768,7 @@ zcbor
 Trusted Firmware-M
 ==================
 
-|no_changes_yet_note|
+* Added possibility to read UICR.OTP registers through platform services.
 
 cJSON
 =====

--- a/modules/trusted-firmware-m/tfm_boards/services/include/tfm_platform_user_memory_ranges.h
+++ b/modules/trusted-firmware-m/tfm_boards/services/include/tfm_platform_user_memory_ranges.h
@@ -51,6 +51,11 @@
 #define CPUC_CPUID_SIZE (sizeof(uint32_t))
 #endif /* NRF_APPLICATION_CPUC_S_BASE */
 
+#if defined(NRF91_SERIES) || defined(NRF53_SERIES)
+#define UICR_OTP_ADDR (NRF_UICR_S_BASE + offsetof(NRF_UICR_Type, OTP))
+#define UICR_OTP_SIZE (sizeof(NRF_UICR_S->OTP))
+#endif
+
 static const struct tfm_read_service_range ranges[] = {
 #ifdef PM_MCUBOOT_ADDRESS
 	/* Allow reads of mcuboot metadata */
@@ -74,6 +79,11 @@ static const struct tfm_read_service_range ranges[] = {
 #if defined(NRF_APPLICATION_CPUC_S)
 	{.start = CPUC_CPUID_ADDR, .size = CPUC_CPUID_SIZE},
 #endif
+
+#if defined(UICR_OTP_ADDR)
+	{.start = UICR_OTP_ADDR, .size = UICR_OTP_SIZE},
+#endif
+
 };
 
 #if defined(NRF_RRAMC_S)


### PR DESCRIPTION
Some applications might use OTP areas for information, so they need access to read those, without exposing all UICR registers.