### PR TITLE
lib: lte_link_control: Rewrite XMONITOR to use nrf_modem_at_scanf

### DIFF
--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -137,7 +137,7 @@ K_WORK_DEFINE(lte_lc_edrx_ptw_send_work, lte_lc_edrx_ptw_send_work_fn);
 static void lte_lc_edrx_req_work_fn(struct k_work *work_item);
 K_WORK_DEFINE(lte_lc_edrx_req_work, lte_lc_edrx_req_work_fn);
 
-K_THREAD_STACK_DEFINE(lte_lc_work_q_stack, 1024);
+K_THREAD_STACK_DEFINE(lte_lc_work_q_stack, 1280);
 
 static struct k_work_q lte_lc_work_q;
 
@@ -864,9 +864,6 @@ int lte_lc_psm_get(int *tau, int *active_time)
 	char active_time_str[9] = {0};
 	char tau_ext_str[9] = {0};
 	char tau_legacy_str[9] = {0};
-	static char response[160] = { 0 };
-	const char ch = ',';
-	char *comma_ptr;
 
 	if ((tau == NULL) || (active_time == NULL)) {
 		return -EINVAL;
@@ -880,67 +877,41 @@ int lte_lc_psm_get(int *tau, int *active_time)
 	 * Periodic-TAU.
 	 */
 
-	response[0] = '\0';
+	err = nrf_modem_at_scanf(
+		"AT%XMONITOR",
+		"%%XMONITOR: "
+		"%*u,"          /* <reg_status> */
+		"%*[^,],"       /* <full_name> */
+		"%*[^,],"       /* <short_name> */
+		"%*[^,],"       /* <plmn> */
+		"%*[^,],"       /* <tac> */
+		"%*u,"          /* <AcT> */
+		"%*u,"          /* <band> */
+		"%*[^,],"       /* <cell_id> */
+		"%*u,"          /* <phys_cell_id> */
+		"%*u,"          /* <EARFCN> */
+		"%*u,"          /* <rsrp> */
+		"%*u,"          /* <snr> */
+		"%*[^,],"       /* <NW-Provided_eDRX_value> */
+		"\"%8[^\"]\","  /* <Active-Time> */
+		"\"%8[^\"]\","  /* <Periodic-TAU-ext> */
+		"\"%8[^\"]\"",  /* <Periodic-TAU> */
+		active_time_str,
+		tau_ext_str,
+		tau_legacy_str);
 
-	err = nrf_modem_at_cmd(response, sizeof(response), "AT%%XMONITOR");
-	if (err) {
+	if (err < 0) {
 		LOG_ERR("AT command failed, error: %d", err);
 		return -EFAULT;
-	}
-
-	comma_ptr = strchr(response, ch);
-	if (!comma_ptr) {
-		/* Not an AT error, thus must be that just a <reg_status> received:
-		 * optional part is included in a response only when <reg_status> is 1 or 5.
-		 */
-		LOG_DBG("Not registered: cannot get current PSM configuration");
-		return -EBADMSG;
-	}
-
-	/* Skip over first 13 fields in AT cmd response by counting delimiters (commas). */
-	for (int i = 0; i < 12; i++) {
-		if (comma_ptr) {
-			comma_ptr = strchr(comma_ptr + 1, ch);
-		} else {
-			LOG_ERR("AT command parsing failed");
-			return -EBADMSG;
-		}
-	}
-
-	/* The last three fields of AT response looks something like this:
-	 * ,"00011110","00000111","01001001"
-	 * comma_ptr now points the comma before Active-Time. Discard the comma and the quote mark,
-	 * hence + 2, and copy Active-Time into active_time_str. Find the next comma and repeat for
-	 * Periodic-TAU-ext and so forth.
-	 */
-
-	if (comma_ptr) {
-		strncpy(active_time_str, comma_ptr + 2, 8);
-	} else {
-		LOG_ERR("AT command parsing failed");
-		return -EBADMSG;
-	}
-
-	comma_ptr = strchr(comma_ptr + 1, ch);
-	if (comma_ptr) {
-		strncpy(tau_ext_str, comma_ptr + 2, 8);
-	} else {
-		LOG_ERR("AT command parsing failed");
-		return -EBADMSG;
-	}
-
-	comma_ptr = strchr(comma_ptr + 1, ch);
-	if (comma_ptr) {
-		strncpy(tau_legacy_str, comma_ptr + 2, 8);
-	} else {
-		LOG_ERR("AT command parsing failed");
+	} else if (err != 3) {
+		LOG_ERR("XMONITOR parsing failed, error: %d", err);
 		return -EBADMSG;
 	}
 
 	err = parse_psm(active_time_str, tau_ext_str, tau_legacy_str, &psm_cfg);
 	if (err) {
 		LOG_ERR("Failed to parse PSM configuration, error: %d", err);
-		return err;
+		return -EBADMSG;
 	}
 
 	*tau = psm_cfg.tau;

--- a/tests/lib/location/src/location_test.c
+++ b/tests/lib/location/src/location_test.c
@@ -87,19 +87,6 @@ static int location_cb_expected_2;
 K_SEM_DEFINE(event_handler_called_sem, 0, 1);
 K_SEM_DEFINE(event_handler_called_sem_2, 0, 1);
 
-/* Strings for GNSS positioning */
-#if !defined(CONFIG_LOCATION_TEST_AGNSS)
-static const char xmonitor_resp[] =
-	"%XMONITOR: 1,\"Operator\",\"OP\",\"20065\",\"0140\",7,20,\"001F8414\","
-	"334,6200,66,44,\"\","
-	"\"11100000\",\"00010011\",\"01001001\"";
-
-static const char xmonitor_resp_psm_on[] =
-	"%XMONITOR: 1,\"Operator\",\"OP\",\"20065\",\"0140\",7,20,\"001F8414\","
-	"334,6200,66,44,\"\","
-	"\"00100001\",\"00101001\",\"01001001\"";
-#endif
-
 #if !defined(CONFIG_LOCATION_SERVICE_EXTERNAL)
 /* PDN active response */
 static const char cgact_resp_active[] = "+CGACT: 0,1";
@@ -756,11 +743,13 @@ void test_location_gnss(void)
 
 #else
 	/* PSM is configured */
-	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
-	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
-	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
-	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
-		(char *)xmonitor_resp_psm_on, sizeof(xmonitor_resp_psm_on));
+	__mock_nrf_modem_at_scanf_ExpectAndReturn(
+		"AT%XMONITOR",
+		"%%XMONITOR: %*u,%*[^,],%*[^,],%*[^,],%*[^,],%*u,%*u,%*[^,],%*u,%*u,%*u,%*u,%*[^,],\"%8[^\"]\",\"%8[^\"]\",\"%8[^\"]\"",
+		3);
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("00100001");
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("00101001");
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("01001001");
 
 	err = location_request(&config);
 	TEST_ASSERT_EQUAL(0, err);
@@ -860,11 +849,13 @@ void test_location_gnss_location_request_timeout(void)
 #endif
 
 #if !defined(CONFIG_LOCATION_TEST_AGNSS)
-	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
-	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
-	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
-	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
-		(char *)xmonitor_resp, sizeof(xmonitor_resp));
+	__mock_nrf_modem_at_scanf_ExpectAndReturn(
+		"AT%XMONITOR",
+		"%%XMONITOR: %*u,%*[^,],%*[^,],%*[^,],%*[^,],%*u,%*u,%*[^,],%*u,%*u,%*u,%*u,%*[^,],\"%8[^\"]\",\"%8[^\"]\",\"%8[^\"]\"",
+		3);
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("11100000");
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("00010011");
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("01001001");
 #endif
 	__cmock_nrf_modem_gnss_stop_ExpectAndReturn(0);
 
@@ -1468,11 +1459,13 @@ void test_location_request_default(void)
 #endif
 
 #if !defined(CONFIG_LOCATION_TEST_AGNSS)
-	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
-	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
-	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
-	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
-		(char *)xmonitor_resp, sizeof(xmonitor_resp));
+	__mock_nrf_modem_at_scanf_ExpectAndReturn(
+		"AT%XMONITOR",
+		"%%XMONITOR: %*u,%*[^,],%*[^,],%*[^,],%*[^,],%*u,%*u,%*[^,],%*u,%*u,%*u,%*u,%*[^,],\"%8[^\"]\",\"%8[^\"]\",\"%8[^\"]\"",
+		3);
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("11100000");
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("00010011");
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("01001001");
 #endif
 	at_monitor_dispatch("+CSCON: 0");
 	k_sleep(K_MSEC(1));
@@ -1691,11 +1684,13 @@ void test_location_request_mode_all_cellular_gnss(void)
 	__mock_nrf_modem_at_scanf_ReturnVarg_int(0); /* LTE preference */
 
 #if !defined(CONFIG_LOCATION_TEST_AGNSS)
-	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
-	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
-	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
-	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
-		(char *)xmonitor_resp, sizeof(xmonitor_resp));
+	__mock_nrf_modem_at_scanf_ExpectAndReturn(
+		"AT%XMONITOR",
+		"%%XMONITOR: %*u,%*[^,],%*[^,],%*[^,],%*[^,],%*u,%*u,%*[^,],%*u,%*u,%*u,%*u,%*[^,],\"%8[^\"]\",\"%8[^\"]\",\"%8[^\"]\"",
+		3);
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("11100000");
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("00010011");
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("01001001");
 #endif
 	at_monitor_dispatch("+CSCON: 0");
 	k_sleep(K_MSEC(1));
@@ -1793,11 +1788,13 @@ void test_location_request_mode_all_cellular_error_gnss_timeout(void)
 	__mock_nrf_modem_at_scanf_ReturnVarg_int(0); /* LTE preference */
 
 #if !defined(CONFIG_LOCATION_TEST_AGNSS)
-	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
-	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
-	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
-	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
-		(char *)xmonitor_resp, sizeof(xmonitor_resp));
+	__mock_nrf_modem_at_scanf_ExpectAndReturn(
+		"AT%XMONITOR",
+		"%%XMONITOR: %*u,%*[^,],%*[^,],%*[^,],%*[^,],%*u,%*u,%*[^,],%*u,%*u,%*u,%*u,%*[^,],\"%8[^\"]\",\"%8[^\"]\",\"%8[^\"]\"",
+		3);
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("11100000");
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("00010011");
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("01001001");
 #endif
 	__cmock_nrf_modem_gnss_stop_ExpectAndReturn(0);
 
@@ -1895,11 +1892,13 @@ void test_location_gnss_periodic(void)
 	TEST_ASSERT_EQUAL(0, err);
 
 #if !defined(CONFIG_LOCATION_TEST_AGNSS)
-	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
-	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
-	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
-	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
-		(char *)xmonitor_resp, sizeof(xmonitor_resp));
+	__mock_nrf_modem_at_scanf_ExpectAndReturn(
+		"AT%XMONITOR",
+		"%%XMONITOR: %*u,%*[^,],%*[^,],%*[^,],%*[^,],%*u,%*u,%*[^,],%*u,%*u,%*u,%*u,%*[^,],\"%8[^\"]\",\"%8[^\"]\",\"%8[^\"]\"",
+		3);
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("11100000");
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("00010011");
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("01001001");
 #endif
 	at_monitor_dispatch("+CSCON: 0");
 	k_sleep(K_MSEC(1));
@@ -1954,11 +1953,13 @@ void test_location_gnss_periodic(void)
 	__mock_nrf_modem_at_scanf_ReturnVarg_int(0); /* LTE preference */
 
 #if !defined(CONFIG_LOCATION_TEST_AGNSS)
-	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
-	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
-	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
-	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
-		(char *)xmonitor_resp, sizeof(xmonitor_resp));
+	__mock_nrf_modem_at_scanf_ExpectAndReturn(
+		"AT%XMONITOR",
+		"%%XMONITOR: %*u,%*[^,],%*[^,],%*[^,],%*[^,],%*u,%*u,%*[^,],%*u,%*u,%*u,%*u,%*[^,],\"%8[^\"]\",\"%8[^\"]\",\"%8[^\"]\"",
+		3);
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("11100000");
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("00010011");
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("01001001");
 #endif
 	k_sleep(K_MSEC(1500));
 	at_monitor_dispatch("+CSCON: 0");

--- a/tests/lib/lte_lc_api/src/lte_lc_api_test.c
+++ b/tests/lib/lte_lc_api/src/lte_lc_api_test.c
@@ -774,117 +774,56 @@ void test_lte_lc_psm_get_null_fail(void)
 	TEST_ASSERT_EQUAL(-EINVAL, ret);
 }
 
-void test_lte_lc_psm_get_badmsg_no_comma_fail(void)
-{
-	int ret;
-	int tau;
-	int active_time;
-
-	static const char xmonitor_resp[] =
-		"%XMONITOR: 1";
-	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
-	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
-	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
-	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
-		(char *)xmonitor_resp, sizeof(xmonitor_resp));
-
-	ret = lte_lc_psm_get(&tau, &active_time);
-	TEST_ASSERT_EQUAL(-EBADMSG, ret);
-}
-
-void test_lte_lc_psm_get_badmsg_no_edrx_value_fail(void)
-{
-	int ret;
-	int tau;
-	int active_time;
-
-	static const char xmonitor_resp[] =
-		"%XMONITOR: 1,\"Operator\",\"OP\",\"20065\",\"002F\",7,20,\"0012BEEF\","
-		"334,6200,66,44";
-	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
-	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
-	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
-	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
-		(char *)xmonitor_resp, sizeof(xmonitor_resp));
-
-	ret = lte_lc_psm_get(&tau, &active_time);
-	TEST_ASSERT_EQUAL(-EBADMSG, ret);
-}
-
-void test_lte_lc_psm_get_badmsg_no_active_time_fail(void)
-{
-	int ret;
-	int tau;
-	int active_time;
-
-	static const char xmonitor_resp[] =
-		"%XMONITOR: 1,\"Operator\",\"OP\",\"20065\",\"002F\",7,20,\"0012BEEF\","
-		"334,6200,66,44,\"\"";
-	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
-	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
-	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
-	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
-		(char *)xmonitor_resp, sizeof(xmonitor_resp));
-
-	ret = lte_lc_psm_get(&tau, &active_time);
-	TEST_ASSERT_EQUAL(-EBADMSG, ret);
-}
-
 void test_lte_lc_psm_get_badmsg_no_tau_ext_fail(void)
 {
 	int ret;
 	int tau;
 	int active_time;
 
-	static const char xmonitor_resp[] =
-		"%XMONITOR: 1,\"Operator\",\"OP\",\"20065\",\"002F\",7,20,\"0012BEEF\","
-		"334,6200,66,44,\"\",\"00000101\"";
-	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
-	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
-	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
-	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
-		(char *)xmonitor_resp, sizeof(xmonitor_resp));
+	__mock_nrf_modem_at_scanf_ExpectAndReturn(
+		"AT%XMONITOR",
+		"%%XMONITOR: %*u,%*[^,],%*[^,],%*[^,],%*[^,],%*u,%*u,%*[^,],%*u,%*u,%*u,%*u,%*[^,],\"%8[^\"]\",\"%8[^\"]\",\"%8[^\"]\"",
+		1);
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("11100000");
 
 	ret = lte_lc_psm_get(&tau, &active_time);
 	TEST_ASSERT_EQUAL(-EBADMSG, ret);
 }
 
-void test_lte_lc_psm_get_badmsg_no_legacy_tau_fail(void)
+void test_lte_lc_psm_get_badmsg_legacy_tau_len_not_8_fail(void)
 {
 	int ret;
 	int tau;
 	int active_time;
 
-	static const char xmonitor_resp[] =
-		"%XMONITOR: 1,\"Operator\",\"OP\",\"20065\",\"002F\",7,20,\"0012BEEF\","
-		"334,6200,66,44,\"\",\"00000101\",\"00010011\"";
-	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
-	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
-	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
-	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
-		(char *)xmonitor_resp, sizeof(xmonitor_resp));
+	__mock_nrf_modem_at_scanf_ExpectAndReturn(
+		"AT%XMONITOR",
+		"%%XMONITOR: %*u,%*[^,],%*[^,],%*[^,],%*[^,],%*u,%*u,%*[^,],%*u,%*u,%*u,%*u,%*[^,],\"%8[^\"]\",\"%8[^\"]\",\"%8[^\"]\"",
+		3);
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("11100000");
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("00010011");
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("001001");
 
 	ret = lte_lc_psm_get(&tau, &active_time);
 	TEST_ASSERT_EQUAL(-EBADMSG, ret);
 }
 
-void test_lte_lc_psm_get_inval_legacy_tau_len_not_8_fail(void)
+void test_lte_lc_psm_get_badmsg_tau_ext_len_not_8_fail(void)
 {
 	int ret;
 	int tau;
 	int active_time;
 
-	static const char xmonitor_resp[] =
-		"%XMONITOR: 1,\"Operator\",\"OP\",\"20065\",\"002F\",7,20,\"0012BEEF\","
-		"334,6200,66,44,\"\",\"00000101\",\"00010011\",\"001001\"";
-	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
-	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
-	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
-	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
-		(char *)xmonitor_resp, sizeof(xmonitor_resp));
+	__mock_nrf_modem_at_scanf_ExpectAndReturn(
+		"AT%XMONITOR",
+		"%%XMONITOR: %*u,%*[^,],%*[^,],%*[^,],%*[^,],%*u,%*u,%*[^,],%*u,%*u,%*u,%*u,%*[^,],\"%8[^\"]\",\"%8[^\"]\",\"%8[^\"]\"",
+		3);
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("11100000");
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("000100");
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("00010010");
 
 	ret = lte_lc_psm_get(&tau, &active_time);
-	TEST_ASSERT_EQUAL(-EINVAL, ret);
+	TEST_ASSERT_EQUAL(-EBADMSG, ret);
 }
 
 void test_lte_lc_proprietary_psm_req_enable_success(void)
@@ -1669,11 +1608,6 @@ void test_lte_lc_cereg_with_xmonitor(void)
 {
 	strcpy(at_notif, "+CEREG: 5,\"4321\",\"87654321\",9,,,\"11100000\",\"11100000\"\r\n");
 
-	static const char xmonitor_resp[] =
-		"%XMONITOR: 1,\"Operator\",\"OP\",\"20065\",\"4321\",9,20,\"12345678\","
-		"334,6200,66,44,\"\","
-		"\"11100000\",\"11100000\",\"01001001\"";
-
 	lte_lc_callback_count_expected = 4;
 
 	test_event_data[0].type = LTE_LC_EVT_NW_REG_STATUS;
@@ -1699,11 +1633,13 @@ void test_lte_lc_cereg_with_xmonitor(void)
 	test_event_data[3].psm_cfg.tau = 3240;
 	test_event_data[3].psm_cfg.active_time = -1;
 
-	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
-	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
-	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
-	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
-		(char *)xmonitor_resp, sizeof(xmonitor_resp));
+	__mock_nrf_modem_at_scanf_ExpectAndReturn(
+		"AT%XMONITOR",
+		"%%XMONITOR: %*u,%*[^,],%*[^,],%*[^,],%*[^,],%*u,%*u,%*[^,],%*u,%*u,%*u,%*u,%*[^,],\"%8[^\"]\",\"%8[^\"]\",\"%8[^\"]\"",
+		3);
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("11100000");
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("11100000");
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("01001001");
 
 	at_monitor_dispatch(at_notif);
 	k_sleep(K_MSEC(1));
@@ -1712,11 +1648,6 @@ void test_lte_lc_cereg_with_xmonitor(void)
 void test_lte_lc_cereg_with_xmonitor_badmsg(void)
 {
 	strcpy(at_notif, "+CEREG: 1,\"5678\",\"87654321\",9,,,\"11100000\",\"11100000\"\r\n");
-
-	static const char xmonitor_resp[] =
-		"%XMONITOR: 1,\"Operator\",\"OP\",\"20065\",\"4321\",9,20,\"12345678\","
-		"334,6200,66,44,\"\","
-		"\"11100000\",\"11100000\"";
 
 	lte_lc_callback_count_expected = 2;
 
@@ -1739,11 +1670,12 @@ void test_lte_lc_cereg_with_xmonitor_badmsg(void)
 	/* No LTE_LC_EVT_LTE_MODE_UPDATE because same values */
 	/* No LTE_LC_EVT_PSM_UPDATE because XMONITOR doesn't have legacy TAU timer */
 
-	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
-	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
-	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
-	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
-		(char *)xmonitor_resp, sizeof(xmonitor_resp));
+	__mock_nrf_modem_at_scanf_ExpectAndReturn(
+		"AT%XMONITOR",
+		"%%XMONITOR: %*u,%*[^,],%*[^,],%*[^,],%*[^,],%*u,%*u,%*[^,],%*u,%*u,%*u,%*u,%*[^,],\"%8[^\"]\",\"%8[^\"]\",\"%8[^\"]\"",
+		2);
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("11100000");
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("11100000");
 
 	at_monitor_dispatch(at_notif);
 	k_sleep(K_MSEC(1));
@@ -1762,9 +1694,35 @@ void test_lte_lc_cereg_with_xmonitor_fail(void)
 	/* No LTE_LC_EVT_LTE_MODE_UPDATE because same values */
 	/* No LTE_LC_EVT_PSM_UPDATE because XMONITOR fails */
 
-	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", -NRF_E2BIG);
-	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
-	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
+	__mock_nrf_modem_at_scanf_ExpectAndReturn(
+		"AT%XMONITOR",
+		"%%XMONITOR: %*u,%*[^,],%*[^,],%*[^,],%*[^,],%*u,%*u,%*[^,],%*u,%*u,%*u,%*u,%*[^,],\"%8[^\"]\",\"%8[^\"]\",\"%8[^\"]\"",
+		-NRF_E2BIG);
+
+	at_monitor_dispatch(at_notif);
+	k_sleep(K_MSEC(1));
+}
+
+void test_lte_lc_cereg_with_xmonitor_tau_ext_not_8_fail(void)
+{
+	strcpy(at_notif, "+CEREG: 1,\"5678\",\"87654321\",9,,,\"11100000\",\"111000\"\r\n");
+
+	lte_lc_callback_count_expected = 1;
+
+	test_event_data[0].type = LTE_LC_EVT_NW_REG_STATUS;
+	test_event_data[0].nw_reg_status = LTE_LC_NW_REG_REGISTERED_HOME;
+
+	/* No LTE_LC_EVT_CELL_UPDATE because same values */
+	/* No LTE_LC_EVT_LTE_MODE_UPDATE because same values */
+	/* No LTE_LC_EVT_PSM_UPDATE because XMONITOR parsing fails */
+
+	__mock_nrf_modem_at_scanf_ExpectAndReturn(
+		"AT%XMONITOR",
+		"%%XMONITOR: %*u,%*[^,],%*[^,],%*[^,],%*[^,],%*u,%*u,%*[^,],%*u,%*u,%*u,%*u,%*[^,],\"%8[^\"]\",\"%8[^\"]\",\"%8[^\"]\"",
+		3);
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("11100000");
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("11100000");
+	__mock_nrf_modem_at_scanf_ReturnVarg_string("001001");
 
 	at_monitor_dispatch(at_notif);
 	k_sleep(K_MSEC(1));


### PR DESCRIPTION
XMONITOR is used in lte_lc_psm_get() and it's been using nrf_modem_at_cmd() and the response has been "manually" parsed by searching for specific commas and copying 8 characters after those. This approach had bugs if some of the interested fields were not 8 character long.
So, lte_lc_psm_get() has been changed to use nrf_modem_at_scanf().