### PR TITLE
lib: date_time: Retry improvements

### DIFF
--- a/doc/nrf/libraries/others/date_time.rst
+++ b/doc/nrf/libraries/others/date_time.rst
@@ -30,6 +30,10 @@ When this library retrieves the date-time information, it is fetched in the foll
 #. If the time information obtained from the nRF91 Series modem is not valid and the :kconfig:option:`CONFIG_DATE_TIME_NTP` option is set, the library requests time from an NTP server.
 #. If the NTP time request does not succeed, the library tries to request time information from a different NTP server, before it fails.
 
+If all time requests fail and the :kconfig:option:`CONFIG_DATE_TIME_RETRY_COUNT` Kconfig option is greater than zero, the entire process listed above will be retried.
+The interval before each retry is defined by the :kconfig:option:`CONFIG_DATE_TIME_RETRY_INTERVAL_SECONDS` Kconfig option, and the :kconfig:option:`CONFIG_DATE_TIME_RETRY_COUNT` Kconfig option sets how many consecutive retries are attempted before giving up.
+If the :kconfig:option:`CONFIG_DATE_TIME_UPDATE_INTERVAL_SECONDS` Kconfig option is greater than zero, periodic updates at the defined interval resume after all retries have been attempted.
+
 The current date-time information is stored as Zephyr time when it has been retrieved and hence, applications can also get the time using the POSIX function ``clock_gettime``.
 It is also stored as modem time if the modem does not have valid time.
 
@@ -67,6 +71,8 @@ Configure the following options to fine-tune the behavior of the library:
 
 * :kconfig:option:`CONFIG_DATE_TIME_UPDATE_INTERVAL_SECONDS` - Control the frequency with which the library fetches the time information.
 * :kconfig:option:`CONFIG_DATE_TIME_TOO_OLD_SECONDS` - Control the time when date-time update is applied if previous update was done earlier.
+* :kconfig:option:`CONFIG_DATE_TIME_RETRY_COUNT` - Configure whether date-time update retries should be attempted, and how many before giving up.
+* :kconfig:option:`CONFIG_DATE_TIME_RETRY_INTERVAL_SECONDS` - Control the frequency with which the library performs date-time update retries.
 * :kconfig:option:`CONFIG_DATE_TIME_NTP_QUERY_TIME_SECONDS` - Timeout for a single NTP query.
 * :kconfig:option:`CONFIG_DATE_TIME_THREAD_STACK_SIZE` - Configure the stack size of the date-time update thread.
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -798,6 +798,14 @@ Other libraries
 ---------------
 
 * Added a compression/decompression library with support for the LZMA decompression.
+* :ref:`lib_date_time` library:
+
+  * Fixed a bug that caused date-time updates to not be rescheduled under certain circumstances.
+
+  * Added:
+
+    * A retry feature that reattempts failed date-time updates up to a certain number of consecutive times.
+    * The Kconfig options :kconfig:option:`CONFIG_DATE_TIME_RETRY_COUNT` to control whether and how many consecutive date-time update retries may be performed, and :kconfig:option:`CONFIG_DATE_TIME_RETRY_INTERVAL_SECONDS` to control how quickly date-time update retries occur.
 
 Security libraries
 ------------------

--- a/lib/date_time/Kconfig
+++ b/lib/date_time/Kconfig
@@ -32,6 +32,19 @@ config DATE_TIME_TOO_OLD_SECONDS
 	  done earlier than given number of seconds ago.
 	  This must be smaller than or equal to DATE_TIME_UPDATE_INTERVAL_SECONDS.
 
+config DATE_TIME_RETRY_COUNT
+	int "Reattempt date-time updates at a reduced interval, up to this many times in a row"
+	default 0
+	help
+	  If this value is nonzero, failed date-time updates will be retried at a reduced interval,
+	  up to the number of times specified.
+
+config DATE_TIME_RETRY_INTERVAL_SECONDS
+	int "Time between date-time update retries, in seconds"
+	default 60
+	help
+	  The number of seconds to wait between date-time update retries.
+
 config DATE_TIME_MODEM
 	bool "Get date time from the nRF9160 onboard modem"
 	depends on NRF_MODEM_LIB

--- a/samples/cellular/nrf_cloud_multi_service/overlay_nrf700x_wifi_coap_no_lte.conf
+++ b/samples/cellular/nrf_cloud_multi_service/overlay_nrf700x_wifi_coap_no_lte.conf
@@ -76,6 +76,16 @@ CONFIG_DATE_TIME_MODEM=n
 CONFIG_DATE_TIME_NTP=y
 CONFIG_DATE_TIME_LOG_LEVEL_DBG=y
 
+## Enable date_time retries for Wi-Fi
+## This prevents occasional DNS lookup flukes from
+## rendering the device unable to connect until the next
+## CONFIG_DATE_TIME_UPDATE_INTERVAL_SECONDS elapses (default 4 hours)
+CONFIG_DATE_TIME_RETRY_COUNT=5
+# Use a really short retry interval for demo purposes
+# 60 seconds to 15 minutes is probably more appropriate for
+# real-world applications
+CONFIG_DATE_TIME_RETRY_INTERVAL_SECONDS=20
+
 ## Disable LED patterns since the WiFi shield is not compatible
 CONFIG_LED_INDICATION_DISABLED=y
 

--- a/samples/cellular/nrf_cloud_multi_service/overlay_nrf700x_wifi_mqtt_no_lte.conf
+++ b/samples/cellular/nrf_cloud_multi_service/overlay_nrf700x_wifi_mqtt_no_lte.conf
@@ -72,6 +72,16 @@ CONFIG_BASE64=y
 ## are enabled)
 CONFIG_DATE_TIME_AUTO_UPDATE=n
 
+## Enable date_time retries for Wi-Fi
+## This prevents occasional DNS lookup flukes from
+## rendering the device unable to connect until the next
+## CONFIG_DATE_TIME_UPDATE_INTERVAL_SECONDS elapses (default 4 hours)
+CONFIG_DATE_TIME_RETRY_COUNT=5
+# Use a really short retry interval for demo purposes
+# 60 seconds to 15 minutes is probably more appropriate for
+# real-world applications
+CONFIG_DATE_TIME_RETRY_INTERVAL_SECONDS=20
+
 ## Disable LED patterns since the WiFi shield is not compatible
 CONFIG_LED_INDICATION_DISABLED=y
 


### PR DESCRIPTION
Remove pending-update checks that caused date_time to be unable to schedule retries on failure. See commit log for detailed justification of change.

Also added fast retry option for NTP, so that transient DNS errors can be recovered from without waiting the full refresh period