### PR TITLE
cmake: sysbuild: b0/nrf700x: Fix not configuring string

### DIFF
--- a/cmake/sysbuild/b0_mcuboot_signing.cmake
+++ b/cmake/sysbuild/b0_mcuboot_signing.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 Nordic Semiconductor ASA
+# Copyright (c) 2020-2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 
 # This file includes extra build system logic that is enabled when
@@ -12,6 +12,7 @@
 
 function(ncs_secure_boot_mcuboot_sign application bin_files signed_targets prefix)
   set(keyfile "${SB_CONFIG_BOOT_SIGNATURE_KEY_FILE}")
+  string(CONFIGURE "${keyfile}" keyfile)
 
   # Find imgtool. Even though west is installed, imgtool might not be.
   # The user may also have a custom manifest which doesn't include

--- a/cmake/sysbuild/image_signing_nrf700x.cmake
+++ b/cmake/sysbuild/image_signing_nrf700x.cmake
@@ -4,6 +4,8 @@
 function(nrf7x_signing_tasks input output_hex output_bin dependencies)
   set(keyfile "${SB_CONFIG_BOOT_SIGNATURE_KEY_FILE}")
   set(keyfile_enc "${SB_CONFIG_BOOT_ENCRYPTION_KEY_FILE}")
+  string(CONFIGURE "${keyfile}" keyfile)
+  string(CONFIGURE "${keyfile_enc}" keyfile_enc)
 
   if(NOT "${SB_CONFIG_BOOT_SIGNATURE_TYPE_NONE}")
     # Check for misconfiguration.


### PR DESCRIPTION
Fixes issues with strings not being expanded