### PR TITLE
doc: Minor updates to Bluetooth samples

### DIFF
--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -140,6 +140,10 @@
 .. |smp| replace:: simple management protocol module
 .. |usb_state| replace:: USB state module
 .. |usb_state_pm| replace:: USB state power manager module
+.. |nrf_desktop_HID_ref| replace:: Apart from HID samples, the |NCS| provides a complete reference application design of :term:`Human Interface Device (HID)`.
+   Depending on the configuration, the application can work as a desktop mouse, gaming mouse, keyboard, or connection dongle.
+   It supports connection over Bluetooth® LE, USB, or both.
+   For details, see the :ref:`nrf_desktop` documentation.
 
 .. ### Matter shortcuts
 

--- a/samples/bluetooth/central_hids/README.rst
+++ b/samples/bluetooth/central_hids/README.rst
@@ -11,10 +11,7 @@ The Central HIDS sample demonstrates how to use the :ref:`hogp_readme` to intera
 Basically, the sample simulates a computer that connects to a mouse or a keyboard.
 
 .. note::
-   Apart from HID samples, the |NCS| provides a complete reference application design of :term:`Human Interface Device (HID)`.
-   Depending on the configuration, the application can work as a desktop mouse, gaming mouse, keyboard, or connection dongle.
-   It supports connection over Bluetooth® LE, USB, or both.
-   For details, see the :ref:`nrf_desktop` documentation.
+   |nrf_desktop_HID_ref|
 
 Requirements
 ************
@@ -25,7 +22,7 @@ The sample supports the following development kits:
 
 .. include:: /includes/tfm.txt
 
-The sample also requires a HIDS device to connect with (for example, another development kit running the :ref:`peripheral_hids_mouse` sample or :ref:`peripheral_hids_keyboard` sample, or a computer with a Bluetooth® Low Energy dongle and `nRF Connect for Desktop`_).
+The sample also requires a HIDS device to connect with (for example, another development kit running the :ref:`peripheral_hids_mouse` sample or :ref:`peripheral_hids_keyboard` sample, or a computer with a Bluetooth Low Energy dongle and `nRF Connect for Desktop`_).
 
 Overview
 ********

--- a/samples/bluetooth/peripheral_hids_keyboard/README.rst
+++ b/samples/bluetooth/peripheral_hids_keyboard/README.rst
@@ -12,10 +12,7 @@ The Peripheral HIDS keyboard sample demonstrates how to use the :ref:`hids_readm
 The sample also shows how to perform LE Secure Connections Out-of-Band pairing using NFC.
 
 .. note::
-   Apart from HID samples, the |NCS| provides a complete reference application design of :term:`Human Interface Device (HID)`.
-   Depending on the configuration, the application can work as a desktop mouse, gaming mouse, keyboard, or connection dongle.
-   It supports connection over Bluetooth® LE, USB, or both.
-   For details, see the :ref:`nrf_desktop` documentation.
+   |nrf_desktop_HID_ref|
 
 Requirements
 ************
@@ -156,7 +153,7 @@ After programming the sample to your development kit, you can test it either by 
 Testing with a Microsoft Windows computer
 -----------------------------------------
 
-To test with a Microsoft Windows computer that has a Bluetooth® radio, complete the following steps:
+To test with a Microsoft Windows computer that has a Bluetooth radio, complete the following steps:
 
 .. tabs::
 

--- a/samples/bluetooth/peripheral_hids_mouse/README.rst
+++ b/samples/bluetooth/peripheral_hids_mouse/README.rst
@@ -11,10 +11,7 @@ The Peripheral HIDS mouse sample demonstrates how to use the :ref:`hids_readme` 
 This sample also shows how to perform directed advertising.
 
 .. note::
-   Apart from HID samples, the |NCS| provides a complete reference application design of :term:`Human Interface Device (HID)`.
-   Depending on the configuration, the application can work as a desktop mouse, gaming mouse, keyboard, or connection dongle.
-   It supports connection over Bluetooth® LE, USB, or both.
-   For details, see the :ref:`nrf_desktop` documentation.
+   |nrf_desktop_HID_ref|
 
 Requirements
 ************
@@ -38,7 +35,7 @@ This sample exposes the HID GATT Service.
 It uses a report map for a generic mouse.
 
 You can also disable the directed advertising feature by clearing the ``BT_DIRECTED_ADVERTISING`` flag in the application configuration.
-This feature is enabled by default and it changes the way how advertising works in comparison to the other Bluetooth® Low Energy samples.
+This feature is enabled by default and it changes the way how advertising works in comparison to the other Bluetooth Low Energy samples.
 When the device wants to advertise, it starts with high duty cycle directed advertising provided that it has bonding information.
 If the timeout occurs, the device starts directed advertising to the next bonded peer.
 If all bonding information is used and there is still no connection, the regular advertising starts.

--- a/samples/bluetooth/peripheral_lbs/README.rst
+++ b/samples/bluetooth/peripheral_lbs/README.rst
@@ -48,41 +48,6 @@ User interface
 
 The user interface of the sample depends on the hardware platform you are using.
 
-nRF52840 Dongle
-===============
-
-Green LED:
-   Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
-
-RGB LED:
-   The RGB LED channels are used independently to display the following information:
-
-   * Red - If Dongle is connected.
-   * Green - If user set the LED using Nordic LED Button Service.
-
-Button 1:
-   Send a notification with the button state: "pressed" or "released".
-
-Thingy:53
-=========
-
-RGB LED:
-   The RGB LED channels are used independently to display the following information:
-
-   * Red - If the main loop is running (that is, the device is advertising).
-     The LED blinks with a period of two seconds, duty cycle 50%.
-   * Green - If the device is connected.
-   * Blue - If user set the LED using Nordic LED Button Service.
-
-   For example, if Thingy:53 is connected over Bluetooth, the LED color toggles between green and yellow.
-   The green LED channel is kept on and the red LED channel is blinking.
-
-Button 1:
-   Send a notification with the button state: "pressed" or "released".
-
-Development kits
-================
-
 .. tabs::
 
    .. group-tab:: nRF52 and nRF53 DKs
@@ -113,8 +78,39 @@ Development kits
       Button 0:
          Send a notification with the button state: "pressed" or "released".
 
+   .. group-tab:: Thingy:53
+
+      RGB LED:
+         The RGB LED channels are used independently to display the following information:
+
+         * Red - If the main loop is running (that is, the device is advertising).
+           The LED blinks with a period of two seconds, duty cycle 50%.
+         * Green - If the device is connected.
+         * Blue - If user set the LED using Nordic LED Button Service.
+
+         For example, if Thingy:53 is connected over Bluetooth, the LED color toggles between green and yellow.
+         The green LED channel is kept on and the red LED channel is blinking.
+
+      Button 1:
+         Send a notification with the button state: "pressed" or "released".
+
+   .. group-tab:: nRF52840 Dongle
+
+      Green LED:
+         Blinks, toggling on/off every second, when the main loop is running and the device is advertising.
+
+      RGB LED:
+         The RGB LED channels are used independently to display the following information:
+
+         * Red - If Dongle is connected.
+         * Green - If user set the LED using Nordic LED Button Service.
+
+      Button 1:
+         Send a notification with the button state: "pressed" or "released".
+
 Building and running
 ********************
+
 .. |sample path| replace:: :file:`samples/bluetooth/peripheral_lbs`
 
 .. include:: /includes/build_and_run_ns.txt

--- a/samples/bluetooth/peripheral_status/README.rst
+++ b/samples/bluetooth/peripheral_status/README.rst
@@ -48,31 +48,6 @@ User interface
 
 The user interface of the sample depends on the hardware platform you are using.
 
-Thingy:53
-=========
-
-RGB LED:
-   The RGB LED channels are used independently to display the following information:
-
-   * Red - If the main loop is running (that is, the device is advertising).
-     Blinks with a period of two seconds with the duty cycle set to 50% when the main loop is running and the device is advertising.
-   * Green - If the device is connected.
-
-   For example, if Thingy:53 is connected over Bluetooth, the LED color toggles between green and yellow.
-   The green LED channel is kept on, and the red LED channel is blinking.
-
-Button 1:
-   Set **Button 1** NSMS Status Characteristic to: "Pressed" or "Released".
-   Notify the client if notification is enabled.
-
-Button 2 (the one hidden under the cover):
-   Set **Button 2** NSMS Status Characteristic to: "Pressed" or "Released".
-   Notify the client if notification is enabled.
-   By default, this service requires the connection to be secured to read or notify.
-
-Development kits
-================
-
 .. tabs::
 
    .. group-tab:: nRF52 and nRF53 DKs
@@ -106,6 +81,27 @@ Development kits
 
       Button 1 (the one hidden under the cover):
          Set **Button 1** NSMS Status Characteristic to: "Pressed" or "Released".
+         Notify the client if notification is enabled.
+         By default, this service requires the connection to be secured to read or notify.
+
+   .. group-tab:: Thingy:53
+
+      RGB LED:
+         The RGB LED channels are used independently to display the following information:
+
+         * Red - If the main loop is running (that is, the device is advertising).
+           Blinks with a period of two seconds with the duty cycle set to 50% when the main loop is running and the device is advertising.
+         * Green - If the device is connected.
+
+         For example, if Thingy:53 is connected over Bluetooth, the LED color toggles between green and yellow.
+         The green LED channel is kept on, and the red LED channel is blinking.
+
+      Button 1:
+         Set **Button 1** NSMS Status Characteristic to: "Pressed" or "Released".
+         Notify the client if notification is enabled.
+
+      Button 2 (the one hidden under the cover):
+         Set **Button 2** NSMS Status Characteristic to: "Pressed" or "Released".
          Notify the client if notification is enabled.
          By default, this service requires the connection to be secured to read or notify.
 

--- a/samples/bluetooth/peripheral_uart/README.rst
+++ b/samples/bluetooth/peripheral_uart/README.rst
@@ -141,18 +141,17 @@ Development kits
       Button 1:
          Reject the passkey value that is printed in the debug logs to prevent pairing/bonding with the other device.
 
-Thingy:53
-=========
+   .. group-tab:: Thingy:53
 
-RGB LED:
-   The RGB LED channels are used independently to display the following information:
+      RGB LED:
+         The RGB LED channels are used independently to display the following information:
 
-   * Red channel blinks with a period of two seconds, duty cycle 50%, when the main loop is running (device is advertising).
-   * Green channel displays if device is connected.
+         * Red channel blinks with a period of two seconds, duty cycle 50%, when the main loop is running (device is advertising).
+         * Green channel displays if device is connected.
 
-Button:
-   Confirm the passkey value that is printed in the debug logs to pair/bond with the other device.
-   Thingy:53 has only one button, therefore the passkey value cannot be rejected by pressing a button.
+      Button:
+         Confirm the passkey value that is printed in the debug logs to pair/bond with the other device.
+         Thingy:53 has only one button, therefore the passkey value cannot be rejected by pressing a button.
 
 Configuration
 *************


### PR DESCRIPTION
Made following changes to some of the Bluetooth
samples:
* Mentioned Thingy:53 also as tabs in the user-interface section.
* Moved a note to shortcuts.txt, which was mentioned in different Bluetooth samples.
* Removed trademark symbol apart from the 1st instance.