### PR TITLE
nrf_security: Enable OWNER ID for SSF server build

### DIFF
--- a/subsys/nrf_security/CMakeLists.txt
+++ b/subsys/nrf_security/CMakeLists.txt
@@ -20,11 +20,17 @@ set(mbedtls_target    mbedtls)
 # Populate ARM_MBEDTLS_PATH with the value of ZEPHYR_MBEDTLS_MODULE_DIR
 set(ARM_MBEDTLS_PATH ${ZEPHYR_MBEDTLS_MODULE_DIR})
 
+if(CONFIG_SSF_SERVER_PSA_CRYPTO_SERVICE_ENABLED)
+# Inside the SSF server, when the PSA crypto service is enabled we need to
+# use the OWNER id to give key ownership to the differrent domains.
+set(CONFIG_MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER     True)
+else()
 # MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER must be disabled for Zephyr
 # builds or when MBEDTLS_USE_PSA_CRYPTO is enabled (e.g. for TLS/DTLS
 # and x.509 support) Note: This configuration is internal and may be
 # removed with a new mbed TLS version
 set(CONFIG_MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER     False)
+endif()
 
 if(CONFIG_BUILD_WITH_TFM)
   # Execute Cmake logic to forward configurations to TF-M build


### PR DESCRIPTION
Enable MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER when we build SECDOM with the PSA crypto service enabled.