### PR TITLE
samples: wifi: provisioning: softap: increase stack size

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -450,6 +450,10 @@ Wi-Fi samples
 
   * Added capture timeout as a parameter for packet capture.
 
+* :ref:`softap_wifi_provision_sample` sample:
+
+  * Increased the value of the :kconfig:option:`CONFIG_SOFTAP_WIFI_PROVISION_THREAD_STACK_SIZE` Kconfig option to 8192 bytes to avoid stack overflow.
+
 Other samples
 -------------
 

--- a/samples/wifi/provisioning/softap/prj.conf
+++ b/samples/wifi/provisioning/softap/prj.conf
@@ -68,6 +68,7 @@ CONFIG_L2_WIFI_CONNECTIVITY_AUTO_DOWN=n
 
 # SoftAP Wi-Fi Provision library
 CONFIG_SOFTAP_WIFI_PROVISION=y
+CONFIG_SOFTAP_WIFI_PROVISION_THREAD_STACK_SIZE=8192
 # Disable socket close on completed provisioning to keep mDNS SD running.
 # SD depends on the socket being open for a specified port.
 CONFIG_SOFTAP_WIFI_PROVISION_SOCKET_CLOSE_ON_COMPLETION=n


### PR DESCRIPTION
Increase CONFIG_SOFTAP_WIFI_PROVISION_THREAD_STACK_SIZE to 8192 to avoid stack overflow usage fault.
Default was 4096.