### PR TITLE
board: thingy91x_nrf9151: Power optimization

### DIFF
--- a/boards/nordic/thingy91x/dts/thingy91x_wifi.dtsi
+++ b/boards/nordic/thingy91x/dts/thingy91x_wifi.dtsi
@@ -11,6 +11,7 @@
 
 /* set pmic_wifi enable signal  */
 &ldsw_nPM60_en {
+	/delete-property/ regulator-boot-off;
 	regulator-boot-on;
 };
 

--- a/boards/nordic/thingy91x/thingy91x_nrf9151_common.dts
+++ b/boards/nordic/thingy91x/thingy91x_nrf9151_common.dts
@@ -88,8 +88,12 @@
 
 &gpio0 {
 	status = "okay";
-	exp-board-power-enable {
+	/* Use PORT event rather than GPIOTE IN event, to save power */
+	sense-edge-mask = <0xffffffff>;
+	/* Load switch controlling 3.3V supply and I/O voltage for external boards */
+	exp_board_enable: exp_board_enable {
 		gpio-hog;
+		output-low;
 		gpios = <3 GPIO_ACTIVE_HIGH>;
 	};
 };
@@ -160,6 +164,7 @@
 			ldsw_nPM60_en: LDO1 {
 				regulator-initial-mode = <NPM1300_LDSW_MODE_LDSW>;
 				regulator-allowed-modes = <NPM1300_LDSW_MODE_LDSW>;
+				regulator-boot-off;
 			};
 			/* LDO2 is used as a load switch for sensor power supply */
 			ldsw_sensors: LDO2 {


### PR DESCRIPTION
Change the board configuration to use PORT event rather than GPIOTE IN event for GPIO interrupts, to save power.

Add a label to expansion board node and initialize it to low output.

Turn off WiFi PMIC by default