### PR TITLE
net: lib: nrf_cloud: send obj data for all topics

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -653,6 +653,8 @@ Libraries for networking
     * The JSON string representing longitude in ``PVT`` reports from ``lng`` to ``lon`` to align with nRF Cloud.
       nRF Cloud still accepts ``lng`` for backward compatibility.
 
+  * Fixed an issue in the :c:func:`nrf_cloud_send` function that prevented data in the provided :c:struct:`nrf_cloud_obj` structure from being sent to the bulk and bin topics.
+
 * :ref:`lib_nrf_cloud_coap` library:
 
   * Fixed a hard fault that occurred when encoding AGNSS request data and the ``net_info`` field of the :c:struct:`nrf_cloud_rest_agnss_request` structure is NULL.

--- a/tests/subsys/net/lib/nrf_cloud/cloud/src/main.c
+++ b/tests/subsys/net/lib/nrf_cloud/cloud/src/main.c
@@ -1467,6 +1467,15 @@ ZTEST(nrf_cloud_test, test_cloud_send_invalid_topic_type)
 	zassert_equal(STATE_IDLE, nfsm_get_current_state(),
 		"nrf_cloud lib should be in the idle state (uninitialized) at the start of test");
 
+	/* Init the cloud successfully */
+	init_cloud_success();
+
+	/* NRF_CLOUD_TOPIC_STATE requires state STATE_CC_CONNECTED
+	 * and all other topics require STATE_DC_CONNECTED.
+	 * Connect to the cloud successfully with dc_connect.
+	 */
+	connect_cloud_dc_success();
+
 	/* Message data */
 	struct nrf_cloud_tx_data tx_wrong_type = {
 		.topic_type = 0,
@@ -1486,9 +1495,17 @@ ZTEST(nrf_cloud_test, test_cloud_send_obj_encode_fail)
 
 	NRF_CLOUD_OBJ_JSON_DEFINE(tx_obj);
 
+	/* Init the cloud successfully */
+	init_cloud_success();
+
+	/* Topic type NRF_CLOUD_TOPIC_MESSAGE requires state STATE_DC_CONNECTED.
+	 * Connect to the cloud successfully with dc_connect.
+	 */
+	connect_cloud_dc_success();
+
 	/* Message data */
 	struct nrf_cloud_tx_data tx = {
-		.topic_type = 0,
+		.topic_type = NRF_CLOUD_TOPIC_MESSAGE,
 		.qos = MQTT_QOS_0_AT_MOST_ONCE,
 		.obj = &tx_obj
 	};


### PR DESCRIPTION
Fixed an issue in nrf_cloud_send() that prevented data in the provided nrf_cloud_obj structure from being sent to the bulk and bin topics.
IRIS-9540