### PR TITLE
samples: cellular: modem_shell: add printing of more modem info

### DIFF
--- a/samples/cellular/modem_shell/src/link/link_api.c
+++ b/samples/cellular/modem_shell/src/link/link_api.c
@@ -662,16 +662,24 @@ void link_api_modem_info_get_for_shell(bool connected)
 	enum lte_lc_lte_mode currently_active_mode;
 	char info_str[MODEM_INFO_MAX_RESPONSE_SIZE + 1];
 	char device_id[NRF_CLOUD_CLIENT_ID_MAX_LEN + 1];
+	int value;
 	int ret;
 
 	(void)link_shell_get_and_print_current_system_modes(
 		&sys_mode_current, &sys_mode_preferred, &currently_active_mode);
 
-	ret = modem_info_string_get(MODEM_INFO_FW_VERSION, info_str, sizeof(info_str));
-	if (ret >= 0) {
-		mosh_print("Modem FW version:      %s", info_str);
+	ret = modem_info_get_batt_voltage(&value);
+	if (ret == 0) {
+		mosh_print("Battery voltage:       %d mV", value);
 	} else {
-		mosh_error("Unable to obtain modem FW version (%d)", ret);
+		mosh_error("Unable to obtain battery voltage (%d)", ret);
+	}
+
+	ret = modem_info_get_temperature(&value);
+	if (ret == 0) {
+		mosh_print("Modem temperature:     %d C", value);
+	} else {
+		mosh_error("Unable to obtain modem temperature (%d)", ret);
 	}
 
 	/* Get the device id used with nRF Cloud */

--- a/samples/cellular/modem_shell/src/main.c
+++ b/samples/cellular/modem_shell/src/main.c
@@ -257,8 +257,6 @@ int main(void)
 		mosh_print_reset_reason();
 	}
 
-	mosh_print_version_info();
-
 #if defined(CONFIG_NRF_CLOUD_REST) || defined(CONFIG_NRF_CLOUD_MQTT) || \
 	defined(CONFIG_NRF_CLOUD_COAP)
 #if defined(CONFIG_MOSH_IPERF3)
@@ -322,10 +320,15 @@ int main(void)
 #if defined(CONFIG_MODEM_INFO)
 	err = modem_info_init();
 	if (err) {
-		printk("Modem info could not be established: %d\n", err);
+		printk("Modem info could not be initialized: %d\n", err);
 		return 0;
 	}
 #endif
+
+	/* Version information printing uses the Modem information library, so it can not be done
+	 * before the library has been initialized.
+	 */
+	mosh_print_version_info();
 
 #if defined(CONFIG_DK_LIBRARY)
 	err = dk_buttons_init(button_handler);

--- a/samples/cellular/modem_shell/src/utils/mosh_print.c
+++ b/samples/cellular/modem_shell/src/utils/mosh_print.c
@@ -13,6 +13,7 @@
 #include <zephyr/posix/time.h>
 #include <zephyr/sys/cbprintf.h>
 #include <zephyr/shell/shell.h>
+#include <modem/modem_info.h>
 #include <net/nrf_cloud.h>
 
 #include "mosh_print.h"
@@ -173,28 +174,52 @@ int mosh_print_help_shell(const struct shell *shell, size_t argc, char **argv)
 
 void mosh_print_version_info(void)
 {
+	int ret;
+	char info_str[MODEM_INFO_MAX_RESPONSE_SIZE + 1];
+
 	/* shell_print() is not used here, because this function is called early during
 	 * application startup and the shell might not be ready yet.
 	 */
 #if defined(APP_VERSION)
-	printk("\nMOSH version:       %s", STRINGIFY(APP_VERSION));
+	printk("\nMOSH version:       %s\n", STRINGIFY(APP_VERSION));
 #else
-	printk("\nMOSH version:       unknown");
+	printk("\nMOSH version:       unknown\n");
 #endif
 
 #if defined(BUILD_ID)
-	printk("\nMOSH build id:      v%s", STRINGIFY(BUILD_ID));
+	printk("MOSH build id:      v%s\n", STRINGIFY(BUILD_ID));
 #else
-	printk("\nMOSH build id:      custom");
+	printk("MOSH build id:      custom\n");
 #endif
 
 #if defined(BUILD_VARIANT)
 #if defined(BRANCH_NAME)
-	printk("\nMOSH build variant: %s/%s\n\n", STRINGIFY(BRANCH_NAME), STRINGIFY(BUILD_VARIANT));
+	printk("MOSH build variant: %s/%s\n", STRINGIFY(BRANCH_NAME), STRINGIFY(BUILD_VARIANT));
 #else
-	printk("\nMOSH build variant: %s\n\n", STRINGIFY(BUILD_VARIANT));
+	printk("MOSH build variant: %s\n", STRINGIFY(BUILD_VARIANT));
 #endif
 #else
-	printk("\nMOSH build variant: dev\n\n");
+	printk("MOSH build variant: dev\n");
 #endif
+
+	ret = modem_info_get_hw_version(info_str, sizeof(info_str));
+	if (ret == 0) {
+		printk("HW version:         %s\n", info_str);
+	} else {
+		printk("Unable to obtain HW version, error: %d\n", ret);
+	}
+
+	ret = modem_info_string_get(MODEM_INFO_FW_VERSION, info_str, sizeof(info_str));
+	if (ret >= 0) {
+		printk("Modem FW version:   %s\n", info_str);
+	} else {
+		printk("Unable to obtain modem FW version, error: %d\n", ret);
+	}
+
+	ret = modem_info_get_fw_uuid(info_str, sizeof(info_str));
+	if (ret == 0) {
+		printk("Modem FW UUID:      %s\n\n", info_str);
+	} else {
+		printk("Unable to obtain modem FW UUID, error: %d\n\n", ret);
+	}
 }


### PR DESCRIPTION
Added battery voltage and temperature to `link status` command, and HW version, MFW version and MFW UUID to `version` command.

MOSH-336