### PR TITLE
bluetooth: controller: Select SDC multirole variant if subrating

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -308,6 +308,7 @@ choice BT_LL_SOFTDEVICE_VARIANT
 						     MPSL_CX || \
 						     BT_CTLR_SYNC_PERIODIC || \
 						     BT_CTLR_SCA_UPDATE || \
+						     BT_CTLR_SUBRATING || \
 						     BT_CTLR_SDC_PAWR_ADV || \
 						     BT_CTLR_SDC_PAWR_SYNC || \
 						     BT_ISO || \


### PR DESCRIPTION
LE Subrating support requires the SDC multirole library. 
Update the Kconfig dependencies so this is done automatically.