### PR TITLE
samples: cellular: modem_shell: link: Coverity - Buffer overflow

### DIFF
--- a/samples/cellular/modem_shell/src/link/link_settings.c
+++ b/samples/cellular/modem_shell/src/link/link_settings.c
@@ -278,7 +278,7 @@ int link_sett_save_defcont_pdn_family(enum pdn_fam family)
 {
 	int err;
 	const char *key = LINK_SETT_KEY "/" LINK_SETT_DEFCONT_IP_FAMILY_KEY;
-	char tmp_str[8];
+	char tmp_str[16];
 
 	err = settings_save_one(key, &family, sizeof(enum pdn_fam));
 

--- a/samples/cellular/modem_shell/src/link/link_shell_print.c
+++ b/samples/cellular/modem_shell/src/link/link_shell_print.c
@@ -243,8 +243,8 @@ link_shell_map_to_string(struct mapping_tbl_item const *mapping_table,
 	}
 
 	if (!found) {
-		sprintf(out_str_buff,
-			"%d (unknown value, not converted to string)", mode);
+		mosh_error("%d (unknown value, not converted to string)", mode);
+		sprintf(out_str_buff, "%d", mode);
 	} else {
 		strcpy(out_str_buff, mapping_table[i].value_str);
 	}


### PR DESCRIPTION
link_shell_map_to_string() wrote failure string of 42 bytes while many callers had room for 8 or 16 bytes.