### PR TITLE
applications: serial_lte_modem: Separate 9151 overlay

### DIFF
--- a/applications/serial_lte_modem/boards/nrf9151dk_nrf9151_ns.overlay
+++ b/applications/serial_lte_modem/boards/nrf9151dk_nrf9151_ns.overlay
@@ -4,4 +4,57 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
- #include "nrf9161dk_nrf9161_ns.overlay"
+ / {
+	chosen {
+		ncs,slm-uart = &uart0;
+	};
+};
+
+&uart0 {
+	status = "okay";
+	hw-flow-control;
+};
+
+&uart2 {
+	compatible = "nordic,nrf-uarte";
+	current-speed = <115200>;
+	status = "disabled";
+	hw-flow-control;
+
+	pinctrl-0 = <&uart2_default_alt>;
+	pinctrl-1 = <&uart2_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+};
+
+&i2c2 {
+	status = "disabled";
+};
+
+&pinctrl {
+	uart2_default_alt: uart2_default_alt {
+		group1 {
+			psels = <NRF_PSEL(UART_RX, 0, 11)>;
+			bias-pull-up;
+		};
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 0, 10)>,
+				<NRF_PSEL(UART_RTS, 0, 12)>,
+				<NRF_PSEL(UART_CTS, 0, 13)>;
+		};
+	};
+
+	uart2_sleep_alt: uart2_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 10)>,
+				<NRF_PSEL(UART_RX, 0, 11)>,
+				<NRF_PSEL(UART_RTS, 0, 12)>,
+				<NRF_PSEL(UART_CTS, 0, 13)>;
+			low-power-enable;
+		};
+	};
+};
+
+/* Enable external flash */
+&gd25wb256 {
+	status = "okay";
+};


### PR DESCRIPTION
Duplicate 9161 overlay file information to 9151. This makes it easier for customers to modify the overlay file according to our documentation.

See: https://github.com/nrfconnect/sdk-nrf/pull/16217#discussion_r1722716449