### PR TITLE
samples: cellular: modem_shell: Coverity - Remove unused includes

### DIFF
--- a/samples/cellular/modem_shell/src/at/at_cmd_mode.c
+++ b/samples/cellular/modem_shell/src/at/at_cmd_mode.c
@@ -11,9 +11,6 @@
 #include <modem/at_monitor.h>
 #include <nrf_modem_at.h>
 
-#include "mosh_defines.h"
-#include "mosh_print.h"
-
 #include "at_cmd_mode.h"
 
 extern struct k_work_q mosh_common_work_q;

--- a/samples/cellular/modem_shell/src/cloud/cloud_lwm2m.c
+++ b/samples/cellular/modem_shell/src/cloud/cloud_lwm2m.c
@@ -10,7 +10,6 @@
 #include <modem/modem_info.h>
 #include <lwm2m_object.h>
 #include <net/lwm2m_client_utils.h>
-#include <net/lwm2m_client_utils_location.h>
 
 #include "mosh_print.h"
 #include "cloud_lwm2m.h"

--- a/samples/cellular/modem_shell/src/location/location_srv_ext_lwm2m.c
+++ b/samples/cellular/modem_shell/src/location/location_srv_ext_lwm2m.c
@@ -9,7 +9,6 @@
 
 #include "cloud_lwm2m.h"
 #include "mosh_print.h"
-#include "mosh_defines.h"
 #include "location_srv_ext.h"
 
 /* Location Assistance resource IDs */

--- a/samples/cellular/modem_shell/src/location/location_srv_ext_nrf_cloud.c
+++ b/samples/cellular/modem_shell/src/location/location_srv_ext_nrf_cloud.c
@@ -13,7 +13,6 @@
 #include <modem/location.h>
 
 #include "mosh_print.h"
-#include "mosh_defines.h"
 #include "location_srv_ext.h"
 
 static struct location_data nrf_cloud_location;

--- a/samples/cellular/modem_shell/src/main.c
+++ b/samples/cellular/modem_shell/src/main.c
@@ -26,7 +26,6 @@
 
 #include <modem/nrf_modem_lib.h>
 #include <modem/nrf_modem_lib_trace.h>
-#include <modem/at_monitor.h>
 #include <modem/modem_info.h>
 #include <modem/lte_lc.h>
 

--- a/samples/cellular/modem_shell/src/ppp/ppp_ctrl.c
+++ b/samples/cellular/modem_shell/src/ppp/ppp_ctrl.c
@@ -27,8 +27,6 @@
 #include <zephyr/posix/sys/socket.h>
 #include <zephyr/shell/shell.h>
 
-#include <zephyr/settings/settings.h>
-
 #include "link_api.h"
 #include "mosh_print.h"
 

--- a/samples/cellular/modem_shell/src/ppp/ppp_mdm_data_rcv.c
+++ b/samples/cellular/modem_shell/src/ppp/ppp_mdm_data_rcv.c
@@ -18,7 +18,6 @@
 
 #include <zephyr/posix/poll.h>
 #include <zephyr/posix/sys/socket.h>
-#include <zephyr/shell/shell.h>
 
 #include "mosh_print.h"
 #include "ppp_ctrl.h"

--- a/samples/cellular/modem_shell/src/ppp/ppp_settings.c
+++ b/samples/cellular/modem_shell/src/ppp/ppp_settings.c
@@ -13,7 +13,6 @@
 #include <zephyr/settings/settings.h>
 
 #include "mosh_print.h"
-#include "ppp_ctrl.h"
 #include "ppp_settings.h"
 
 #define PPP_SETT_KEY "ppp_settings"

--- a/samples/cellular/modem_shell/src/shell.c
+++ b/samples/cellular/modem_shell/src/shell.c
@@ -33,7 +33,6 @@
 #if defined(CONFIG_MOSH_CURL)
 #include <nrf_curl.h>
 #endif
-#include "uart_shell.h"
 #include "mosh_print.h"
 
 extern struct k_poll_signal mosh_signal;

--- a/samples/cellular/modem_shell/src/sms/sms.c
+++ b/samples/cellular/modem_shell/src/sms/sms.c
@@ -12,7 +12,6 @@
 #include <modem/sms.h>
 
 #include "sms.h"
-#include "mosh_defines.h"
 #include "mosh_print.h"
 #include "str_utils.h"
 

--- a/samples/cellular/modem_shell/src/sms/sms_shell.c
+++ b/samples/cellular/modem_shell/src/sms/sms_shell.c
@@ -15,7 +15,6 @@
 #include <modem/sms.h>
 
 #include "sms.h"
-#include "mosh_defines.h"
 #include "mosh_print.h"
 
 /* Maximum length of the message data that can be specified with -m option */

--- a/samples/cellular/modem_shell/src/sock/sock_shell.c
+++ b/samples/cellular/modem_shell/src/sock/sock_shell.c
@@ -22,7 +22,6 @@
 #include "mosh_defines.h"
 #include "mosh_print.h"
 #include "link_api.h"
-#include "net_utils.h"
 
 /* Maximum length of the address */
 #define SOCK_MAX_ADDR_LEN 100


### PR DESCRIPTION
Removing Low-category Coverity warnings about unused includes.