### PR TITLE
bluetooth: fast_pair: fp_gatt_service: Allow compiler to opt-out not used code

### DIFF
--- a/subsys/bluetooth/services/fast_pair/fp_gatt_service.c
+++ b/subsys/bluetooth/services/fast_pair/fp_gatt_service.c
@@ -208,6 +208,11 @@ static int notify_personalized_name(struct bt_conn *conn)
 	uint8_t nonce[FP_CRYPTO_ADDITIONAL_DATA_NONCE_LEN];
 	static struct bt_gatt_attr *additional_data_attr;
 
+	if (!IS_ENABLED(CONFIG_BT_FAST_PAIR_PN)) {
+		__ASSERT_NO_MSG(false);
+		return -ENOTSUP;
+	}
+
 	err = fp_storage_pn_get(pn);
 	if (err) {
 		LOG_ERR("Failed to get Personalized Name from storage: err=%d", err);


### PR DESCRIPTION
Allows compiler to opt-out Personalized Name notify function in case the extension is disabled. It caused build errors on some compilers if not opted-out.