### PR TITLE
manifest: sdk-zephyr: [fromlist] Bluetooth: Mesh: Fix uninitialized field when cancelling transfer blob

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 468d06db5542594fe9e6420fd2e1fe30d9209699
+      revision: 5f4236e29cb8b90ed9ddd4bbc8a1d91ef6c5227e
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
zephyr manifest update