### PR TITLE
snippets: Add snippet for nRF54H20 PSA rng

### DIFF
--- a/snippets/nrf54h20-psa-rng/README.rst
+++ b/snippets/nrf54h20-psa-rng/README.rst
@@ -1,0 +1,15 @@
+.. _nrf54h20-psa-rng:
+
+nRF54H20 PSA RNG snippet (nrf54h20-psa-rng)
+###############################
+
+Overview
+********
+
+This snippet allows using the PSA RNG with nRF54H20. This will
+allow using the random number generator in CRACEN through
+the Zephyr random APIS. In the future this snippet will be removed
+and PSA RNG will be the default option that does't require any
+special configuration but we need to wait until the Secure domain
+firmware with the PSA SSF server enabled is released and used
+by everyone.

--- a/snippets/nrf54h20-psa-rng/nrf54h20_psa_rng.conf
+++ b/snippets/nrf54h20-psa-rng/nrf54h20_psa_rng.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_ENTROPY_GENERATOR=y
+CONFIG_ZCBOR=y
+# Data cache not support by the SSF PSA service yet
+CONFIG_DCACHE=n
+
+CONFIG_NRF_SECURITY=y
+CONFIG_PSA_SSF_CRYPTO_CLIENT=y
+CONFIG_SSF_PSA_CRYPTO_SERVICE_ENABLED=y
+

--- a/snippets/nrf54h20-psa-rng/nrf54h20_psa_rng.overlay
+++ b/snippets/nrf54h20-psa-rng/nrf54h20_psa_rng.overlay
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,entropy = &psa_rng;
+	};
+
+	psa_rng: psa-rng {
+		compatible = "zephyr,psa-crypto-rng";
+		status = "okay";
+	};
+};
+
+	&cpusec_cpuapp_ipc {
+		status = "okay";
+	};
+
+	&cpusec_bellboard {
+		status = "okay";
+	};
+
+	&prng {
+		status = "disabled";
+	};

--- a/snippets/nrf54h20-psa-rng/snippet.yml
+++ b/snippets/nrf54h20-psa-rng/snippet.yml
@@ -1,0 +1,7 @@
+name: nrf54h20-psa-rng
+
+boards:
+  nrf54h20dk/nrf54h20/cpuapp:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: nrf54h20_psa_rng.overlay
+      EXTRA_CONF_FILE: nrf54h20_psa_rng.conf

--- a/subsys/nrf_security/src/CMakeLists.txt
+++ b/subsys/nrf_security/src/CMakeLists.txt
@@ -65,7 +65,7 @@ file(REMOVE_RECURSE ${generated_include_path})
 include(${NRF_SECURITY_ROOT}/cmake/psa_crypto_want_config.cmake)
 
 # Generate mbed TLS configurations
-if(CONFIG_MBEDTLS_LEGACY_CRYPTO_C OR NOT COMPILE_PSA_APIS)
+if(CONFIG_MBEDTLS_LEGACY_CRYPTO_C OR NOT COMPILE_PSA_APIS AND NOT CONFIG_PSA_SSF_CRYPTO_CLIENT)
   include(${NRF_SECURITY_ROOT}/cmake/legacy_crypto_config.cmake)
 else()
   include(${NRF_SECURITY_ROOT}/cmake/psa_crypto_config.cmake)

--- a/subsys/nrf_security/src/drivers/Kconfig
+++ b/subsys/nrf_security/src/drivers/Kconfig
@@ -11,6 +11,7 @@ config PSA_CRYPTO_DRIVER_OBERON
 	prompt "Oberon PSA driver" if !(TFM_PARTITION_PROTECTED_STORAGE || TFM_CRYPTO_BUILTIN_KEYS)
 	bool
 	default y if ! CRACEN_HW_PRESENT
+	depends on PSA_CORE_OBERON
 	help
 	  This configuration enables the usage of the Oberon PSA driver.
 
@@ -18,6 +19,7 @@ config PSA_CRYPTO_DRIVER_CC3XX
 	prompt "CryptoCell PSA driver"
 	bool
 	depends on HAS_HW_NRF_CC3XX
+	depends on PSA_CORE_OBERON
 	help
 	  This configuration enables the usage of CryptoCell for the supported operations.
 	  Disabling this option will result in all crypto operations being handled by
@@ -30,6 +32,7 @@ config PSA_CRYPTO_DRIVER_CRACEN
 	bool "Enable the Cracen PSA driver" if !NRF_SECURITY_LEGACY_AND_PSA
 	depends on MBEDTLS_PSA_CRYPTO_C
 	depends on CRACEN_HW_PRESENT
+	depends on PSA_CORE_OBERON
 	# CRACEN uses the k_event_ API
 	select EVENTS if MULTITHREADING
 	default y if !NRF_SECURITY_LEGACY_AND_PSA


### PR DESCRIPTION
    Add a snippet for enabling the PSA RNG as the
    Zephyr chosen entropy for nRF54H20. This is meant
    for users who use a Secure domain firmware version
    with the SSF server enabled.
