### PR TITLE
Revert "lib: lte_link_control: Rewrite XMONITOR to use nrf_modem_at_scanf"

### DIFF
--- a/tests/lib/location/src/location_test.c
+++ b/tests/lib/location/src/location_test.c
@@ -87,6 +87,19 @@ static int location_cb_expected_2;
 K_SEM_DEFINE(event_handler_called_sem, 0, 1);
 K_SEM_DEFINE(event_handler_called_sem_2, 0, 1);
 
+/* Strings for GNSS positioning */
+#if !defined(CONFIG_LOCATION_TEST_AGNSS)
+static const char xmonitor_resp[] =
+	"%XMONITOR: 1,\"Operator\",\"OP\",\"20065\",\"0140\",7,20,\"001F8414\","
+	"334,6200,66,44,\"\","
+	"\"11100000\",\"00010011\",\"01001001\"";
+
+static const char xmonitor_resp_psm_on[] =
+	"%XMONITOR: 1,\"Operator\",\"OP\",\"20065\",\"0140\",7,20,\"001F8414\","
+	"334,6200,66,44,\"\","
+	"\"00100001\",\"00101001\",\"01001001\"";
+#endif
+
 #if !defined(CONFIG_LOCATION_SERVICE_EXTERNAL)
 /* PDN active response */
 static const char cgact_resp_active[] = "+CGACT: 0,1";
@@ -743,13 +756,11 @@ void test_location_gnss(void)
 
 #else
 	/* PSM is configured */
-	__mock_nrf_modem_at_scanf_ExpectAndReturn(
-		"AT%XMONITOR",
-		"%%XMONITOR: %*u,%*[^,],%*[^,],%*[^,],%*[^,],%*u,%*u,%*[^,],%*u,%*u,%*u,%*u,%*[^,],\"%8[^\"]\",\"%8[^\"]\",\"%8[^\"]\"",
-		3);
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("00100001");
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("00101001");
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("01001001");
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
+		(char *)xmonitor_resp_psm_on, sizeof(xmonitor_resp_psm_on));
 
 	err = location_request(&config);
 	TEST_ASSERT_EQUAL(0, err);
@@ -849,13 +860,11 @@ void test_location_gnss_location_request_timeout(void)
 #endif
 
 #if !defined(CONFIG_LOCATION_TEST_AGNSS)
-	__mock_nrf_modem_at_scanf_ExpectAndReturn(
-		"AT%XMONITOR",
-		"%%XMONITOR: %*u,%*[^,],%*[^,],%*[^,],%*[^,],%*u,%*u,%*[^,],%*u,%*u,%*u,%*u,%*[^,],\"%8[^\"]\",\"%8[^\"]\",\"%8[^\"]\"",
-		3);
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("11100000");
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("00010011");
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("01001001");
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
+		(char *)xmonitor_resp, sizeof(xmonitor_resp));
 #endif
 	__cmock_nrf_modem_gnss_stop_ExpectAndReturn(0);
 
@@ -1459,13 +1468,11 @@ void test_location_request_default(void)
 #endif
 
 #if !defined(CONFIG_LOCATION_TEST_AGNSS)
-	__mock_nrf_modem_at_scanf_ExpectAndReturn(
-		"AT%XMONITOR",
-		"%%XMONITOR: %*u,%*[^,],%*[^,],%*[^,],%*[^,],%*u,%*u,%*[^,],%*u,%*u,%*u,%*u,%*[^,],\"%8[^\"]\",\"%8[^\"]\",\"%8[^\"]\"",
-		3);
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("11100000");
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("00010011");
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("01001001");
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
+		(char *)xmonitor_resp, sizeof(xmonitor_resp));
 #endif
 	at_monitor_dispatch("+CSCON: 0");
 	k_sleep(K_MSEC(1));
@@ -1684,13 +1691,11 @@ void test_location_request_mode_all_cellular_gnss(void)
 	__mock_nrf_modem_at_scanf_ReturnVarg_int(0); /* LTE preference */
 
 #if !defined(CONFIG_LOCATION_TEST_AGNSS)
-	__mock_nrf_modem_at_scanf_ExpectAndReturn(
-		"AT%XMONITOR",
-		"%%XMONITOR: %*u,%*[^,],%*[^,],%*[^,],%*[^,],%*u,%*u,%*[^,],%*u,%*u,%*u,%*u,%*[^,],\"%8[^\"]\",\"%8[^\"]\",\"%8[^\"]\"",
-		3);
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("11100000");
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("00010011");
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("01001001");
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
+		(char *)xmonitor_resp, sizeof(xmonitor_resp));
 #endif
 	at_monitor_dispatch("+CSCON: 0");
 	k_sleep(K_MSEC(1));
@@ -1788,13 +1793,11 @@ void test_location_request_mode_all_cellular_error_gnss_timeout(void)
 	__mock_nrf_modem_at_scanf_ReturnVarg_int(0); /* LTE preference */
 
 #if !defined(CONFIG_LOCATION_TEST_AGNSS)
-	__mock_nrf_modem_at_scanf_ExpectAndReturn(
-		"AT%XMONITOR",
-		"%%XMONITOR: %*u,%*[^,],%*[^,],%*[^,],%*[^,],%*u,%*u,%*[^,],%*u,%*u,%*u,%*u,%*[^,],\"%8[^\"]\",\"%8[^\"]\",\"%8[^\"]\"",
-		3);
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("11100000");
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("00010011");
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("01001001");
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
+		(char *)xmonitor_resp, sizeof(xmonitor_resp));
 #endif
 	__cmock_nrf_modem_gnss_stop_ExpectAndReturn(0);
 
@@ -1892,13 +1895,11 @@ void test_location_gnss_periodic(void)
 	TEST_ASSERT_EQUAL(0, err);
 
 #if !defined(CONFIG_LOCATION_TEST_AGNSS)
-	__mock_nrf_modem_at_scanf_ExpectAndReturn(
-		"AT%XMONITOR",
-		"%%XMONITOR: %*u,%*[^,],%*[^,],%*[^,],%*[^,],%*u,%*u,%*[^,],%*u,%*u,%*u,%*u,%*[^,],\"%8[^\"]\",\"%8[^\"]\",\"%8[^\"]\"",
-		3);
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("11100000");
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("00010011");
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("01001001");
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
+		(char *)xmonitor_resp, sizeof(xmonitor_resp));
 #endif
 	at_monitor_dispatch("+CSCON: 0");
 	k_sleep(K_MSEC(1));
@@ -1953,13 +1954,11 @@ void test_location_gnss_periodic(void)
 	__mock_nrf_modem_at_scanf_ReturnVarg_int(0); /* LTE preference */
 
 #if !defined(CONFIG_LOCATION_TEST_AGNSS)
-	__mock_nrf_modem_at_scanf_ExpectAndReturn(
-		"AT%XMONITOR",
-		"%%XMONITOR: %*u,%*[^,],%*[^,],%*[^,],%*[^,],%*u,%*u,%*[^,],%*u,%*u,%*u,%*u,%*[^,],\"%8[^\"]\",\"%8[^\"]\",\"%8[^\"]\"",
-		3);
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("11100000");
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("00010011");
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("01001001");
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
+		(char *)xmonitor_resp, sizeof(xmonitor_resp));
 #endif
 	k_sleep(K_MSEC(1500));
 	at_monitor_dispatch("+CSCON: 0");

--- a/tests/lib/lte_lc_api/src/lte_lc_api_test.c
+++ b/tests/lib/lte_lc_api/src/lte_lc_api_test.c
@@ -906,56 +906,117 @@ void test_lte_lc_psm_get_null_fail(void)
 	TEST_ASSERT_EQUAL(-EINVAL, ret);
 }
 
+void test_lte_lc_psm_get_badmsg_no_comma_fail(void)
+{
+	int ret;
+	int tau;
+	int active_time;
+
+	static const char xmonitor_resp[] =
+		"%XMONITOR: 1";
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
+		(char *)xmonitor_resp, sizeof(xmonitor_resp));
+
+	ret = lte_lc_psm_get(&tau, &active_time);
+	TEST_ASSERT_EQUAL(-EBADMSG, ret);
+}
+
+void test_lte_lc_psm_get_badmsg_no_edrx_value_fail(void)
+{
+	int ret;
+	int tau;
+	int active_time;
+
+	static const char xmonitor_resp[] =
+		"%XMONITOR: 1,\"Operator\",\"OP\",\"20065\",\"002F\",7,20,\"0012BEEF\","
+		"334,6200,66,44";
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
+		(char *)xmonitor_resp, sizeof(xmonitor_resp));
+
+	ret = lte_lc_psm_get(&tau, &active_time);
+	TEST_ASSERT_EQUAL(-EBADMSG, ret);
+}
+
+void test_lte_lc_psm_get_badmsg_no_active_time_fail(void)
+{
+	int ret;
+	int tau;
+	int active_time;
+
+	static const char xmonitor_resp[] =
+		"%XMONITOR: 1,\"Operator\",\"OP\",\"20065\",\"002F\",7,20,\"0012BEEF\","
+		"334,6200,66,44,\"\"";
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
+		(char *)xmonitor_resp, sizeof(xmonitor_resp));
+
+	ret = lte_lc_psm_get(&tau, &active_time);
+	TEST_ASSERT_EQUAL(-EBADMSG, ret);
+}
+
 void test_lte_lc_psm_get_badmsg_no_tau_ext_fail(void)
 {
 	int ret;
 	int tau;
 	int active_time;
 
-	__mock_nrf_modem_at_scanf_ExpectAndReturn(
-		"AT%XMONITOR",
-		"%%XMONITOR: %*u,%*[^,],%*[^,],%*[^,],%*[^,],%*u,%*u,%*[^,],%*u,%*u,%*u,%*u,%*[^,],\"%8[^\"]\",\"%8[^\"]\",\"%8[^\"]\"",
-		1);
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("11100000");
+	static const char xmonitor_resp[] =
+		"%XMONITOR: 1,\"Operator\",\"OP\",\"20065\",\"002F\",7,20,\"0012BEEF\","
+		"334,6200,66,44,\"\",\"00000101\"";
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
+		(char *)xmonitor_resp, sizeof(xmonitor_resp));
 
 	ret = lte_lc_psm_get(&tau, &active_time);
 	TEST_ASSERT_EQUAL(-EBADMSG, ret);
 }
 
-void test_lte_lc_psm_get_badmsg_legacy_tau_len_not_8_fail(void)
+void test_lte_lc_psm_get_badmsg_no_legacy_tau_fail(void)
 {
 	int ret;
 	int tau;
 	int active_time;
 
-	__mock_nrf_modem_at_scanf_ExpectAndReturn(
-		"AT%XMONITOR",
-		"%%XMONITOR: %*u,%*[^,],%*[^,],%*[^,],%*[^,],%*u,%*u,%*[^,],%*u,%*u,%*u,%*u,%*[^,],\"%8[^\"]\",\"%8[^\"]\",\"%8[^\"]\"",
-		3);
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("11100000");
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("00010011");
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("001001");
+	static const char xmonitor_resp[] =
+		"%XMONITOR: 1,\"Operator\",\"OP\",\"20065\",\"002F\",7,20,\"0012BEEF\","
+		"334,6200,66,44,\"\",\"00000101\",\"00010011\"";
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
+		(char *)xmonitor_resp, sizeof(xmonitor_resp));
 
 	ret = lte_lc_psm_get(&tau, &active_time);
 	TEST_ASSERT_EQUAL(-EBADMSG, ret);
 }
 
-void test_lte_lc_psm_get_badmsg_tau_ext_len_not_8_fail(void)
+void test_lte_lc_psm_get_inval_legacy_tau_len_not_8_fail(void)
 {
 	int ret;
 	int tau;
 	int active_time;
 
-	__mock_nrf_modem_at_scanf_ExpectAndReturn(
-		"AT%XMONITOR",
-		"%%XMONITOR: %*u,%*[^,],%*[^,],%*[^,],%*[^,],%*u,%*u,%*[^,],%*u,%*u,%*u,%*u,%*[^,],\"%8[^\"]\",\"%8[^\"]\",\"%8[^\"]\"",
-		3);
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("11100000");
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("000100");
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("00010010");
+	static const char xmonitor_resp[] =
+		"%XMONITOR: 1,\"Operator\",\"OP\",\"20065\",\"002F\",7,20,\"0012BEEF\","
+		"334,6200,66,44,\"\",\"00000101\",\"00010011\",\"001001\"";
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
+		(char *)xmonitor_resp, sizeof(xmonitor_resp));
 
 	ret = lte_lc_psm_get(&tau, &active_time);
-	TEST_ASSERT_EQUAL(-EBADMSG, ret);
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
 }
 
 void test_lte_lc_proprietary_psm_req_enable_success(void)
@@ -1807,6 +1868,11 @@ void test_lte_lc_cereg_with_xmonitor(void)
 {
 	strcpy(at_notif, "+CEREG: 5,\"4321\",\"87654321\",9,,,\"11100000\",\"11100000\"\r\n");
 
+	static const char xmonitor_resp[] =
+		"%XMONITOR: 1,\"Operator\",\"OP\",\"20065\",\"4321\",9,20,\"12345678\","
+		"334,6200,66,44,\"\","
+		"\"11100000\",\"11100000\",\"01001001\"";
+
 	lte_lc_callback_count_expected = 4;
 
 	test_event_data[0].type = LTE_LC_EVT_NW_REG_STATUS;
@@ -1832,13 +1898,11 @@ void test_lte_lc_cereg_with_xmonitor(void)
 	test_event_data[3].psm_cfg.tau = 3240;
 	test_event_data[3].psm_cfg.active_time = -1;
 
-	__mock_nrf_modem_at_scanf_ExpectAndReturn(
-		"AT%XMONITOR",
-		"%%XMONITOR: %*u,%*[^,],%*[^,],%*[^,],%*[^,],%*u,%*u,%*[^,],%*u,%*u,%*u,%*u,%*[^,],\"%8[^\"]\",\"%8[^\"]\",\"%8[^\"]\"",
-		3);
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("11100000");
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("11100000");
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("01001001");
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
+		(char *)xmonitor_resp, sizeof(xmonitor_resp));
 
 	at_monitor_dispatch(at_notif);
 	k_sleep(K_MSEC(1));
@@ -1847,6 +1911,11 @@ void test_lte_lc_cereg_with_xmonitor(void)
 void test_lte_lc_cereg_with_xmonitor_badmsg(void)
 {
 	strcpy(at_notif, "+CEREG: 1,\"5678\",\"87654321\",9,,,\"11100000\",\"11100000\"\r\n");
+
+	static const char xmonitor_resp[] =
+		"%XMONITOR: 1,\"Operator\",\"OP\",\"20065\",\"4321\",9,20,\"12345678\","
+		"334,6200,66,44,\"\","
+		"\"11100000\",\"11100000\"";
 
 	lte_lc_callback_count_expected = 2;
 
@@ -1869,12 +1938,11 @@ void test_lte_lc_cereg_with_xmonitor_badmsg(void)
 	/* No LTE_LC_EVT_LTE_MODE_UPDATE because same values */
 	/* No LTE_LC_EVT_PSM_UPDATE because XMONITOR doesn't have legacy TAU timer */
 
-	__mock_nrf_modem_at_scanf_ExpectAndReturn(
-		"AT%XMONITOR",
-		"%%XMONITOR: %*u,%*[^,],%*[^,],%*[^,],%*[^,],%*u,%*u,%*[^,],%*u,%*u,%*u,%*u,%*[^,],\"%8[^\"]\",\"%8[^\"]\",\"%8[^\"]\"",
-		2);
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("11100000");
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("11100000");
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
+		(char *)xmonitor_resp, sizeof(xmonitor_resp));
 
 	at_monitor_dispatch(at_notif);
 	k_sleep(K_MSEC(1));
@@ -1893,35 +1961,9 @@ void test_lte_lc_cereg_with_xmonitor_fail(void)
 	/* No LTE_LC_EVT_LTE_MODE_UPDATE because same values */
 	/* No LTE_LC_EVT_PSM_UPDATE because XMONITOR fails */
 
-	__mock_nrf_modem_at_scanf_ExpectAndReturn(
-		"AT%XMONITOR",
-		"%%XMONITOR: %*u,%*[^,],%*[^,],%*[^,],%*[^,],%*u,%*u,%*[^,],%*u,%*u,%*u,%*u,%*[^,],\"%8[^\"]\",\"%8[^\"]\",\"%8[^\"]\"",
-		-NRF_E2BIG);
-
-	at_monitor_dispatch(at_notif);
-	k_sleep(K_MSEC(1));
-}
-
-void test_lte_lc_cereg_with_xmonitor_tau_ext_not_8_fail(void)
-{
-	strcpy(at_notif, "+CEREG: 1,\"5678\",\"87654321\",9,,,\"11100000\",\"111000\"\r\n");
-
-	lte_lc_callback_count_expected = 1;
-
-	test_event_data[0].type = LTE_LC_EVT_NW_REG_STATUS;
-	test_event_data[0].nw_reg_status = LTE_LC_NW_REG_REGISTERED_HOME;
-
-	/* No LTE_LC_EVT_CELL_UPDATE because same values */
-	/* No LTE_LC_EVT_LTE_MODE_UPDATE because same values */
-	/* No LTE_LC_EVT_PSM_UPDATE because XMONITOR parsing fails */
-
-	__mock_nrf_modem_at_scanf_ExpectAndReturn(
-		"AT%XMONITOR",
-		"%%XMONITOR: %*u,%*[^,],%*[^,],%*[^,],%*[^,],%*u,%*u,%*[^,],%*u,%*u,%*u,%*u,%*[^,],\"%8[^\"]\",\"%8[^\"]\",\"%8[^\"]\"",
-		3);
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("11100000");
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("11100000");
-	__mock_nrf_modem_at_scanf_ReturnVarg_string("001001");
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", -NRF_E2BIG);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
 
 	at_monitor_dispatch(at_notif);
 	k_sleep(K_MSEC(1));


### PR DESCRIPTION
XMONITOR response may not contain all fields, i.e., there are some commas one after the other so scanf parsing cannot handle it. Reverting nrf_modem_at_scanf use for AT%XMONITOR.
at_parser usage may be considered here in the future.

This reverts commit 457ff80e166bdb721bb1a511544169b5d10f6f5f.