### PR TITLE
nrf_cloud_fota_poll: Add possibility to be non-blocking

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -719,6 +719,14 @@ Libraries for networking
 
   * Added support for dictionary logs using REST.
 
+* :ref:`lib_nrf_cloud_fota` library:
+
+* Updated:
+
+  * The :kconfig:option:`CONFIG_NRF_CLOUD_FOTA_DOWNLOAD_FRAGMENT_SIZE` Kconfig option is made available and used also when the :kconfig:option:`CONFIG_NRF_CLOUD_FOTA_POLL` Kconfig option is enabled.
+    The range of the option is now from 128 to 1900 bytes, and the default value is 1700 bytes.
+  * The function :c:func:`nrf_cloud_fota_poll_process` can now be used asynchrounously if a callback to handle errors is provided.
+
 Libraries for NFC
 -----------------
 

--- a/include/net/nrf_cloud_fota_poll.h
+++ b/include/net/nrf_cloud_fota_poll.h
@@ -55,6 +55,19 @@ struct nrf_cloud_fota_poll_ctx {
 	bool full_modem_fota_supported;
 	const char *device_id;
 
+	/* Public variables */
+
+	/** HTTP fragment size. Sets the size of the requested payload in each HTTP request when
+	 *  downloading the firmware image. Note that the header size is not included in this size.
+	 *  It is important that the total size of each fragment (HTTP headers + payload) fits in
+	 *  the buffers of the underlying network stack layers. Failing to do so, may result in
+	 *  failure to download new firmware images.
+	 *
+	 *  If this value is set to 0, the Kconfig option
+	 *  :kconfig:option:`CONFIG_NRF_CLOUD_FOTA_DOWNLOAD_FRAGMENT_SIZE` will be used.
+	 */
+	uint32_t fragment_size;
+
 	/** User-provided callback function to handle reboots */
 	fota_reboot_handler_t reboot_fn;
 

--- a/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_fota
+++ b/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_fota
@@ -44,7 +44,7 @@ config NRF_CLOUD_FOTA_DOWNLOAD_FRAGMENT_SIZE
 	int "Fragment size for FOTA downloads"
 	depends on FOTA_DOWNLOAD
 	range 128 1900
-	default 1900
+	default 1700
 
 config FOTA_USE_NRF_CLOUD_SETTINGS_AREA
 	bool "Use the same settings area as the nRF Cloud FOTA library"

--- a/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_fota
+++ b/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_fota
@@ -30,11 +30,6 @@ config NRF_CLOUD_FOTA_PROGRESS_PCT_INCREMENT
 	help
 	  0 disables progress report.
 
-config NRF_CLOUD_FOTA_DOWNLOAD_FRAGMENT_SIZE
-	int "Fragment size for FOTA downloads"
-	range 128 1700
-	default 1700
-
 config NRF_CLOUD_FOTA_BLE_DEVICES
 	bool "Enable API for FOTA of BLE devices"
 	depends on BT
@@ -44,6 +39,12 @@ module-str = nRF Cloud FOTA
 source "subsys/logging/Kconfig.template.log_config"
 
 endif # NRF_CLOUD_FOTA
+
+config NRF_CLOUD_FOTA_DOWNLOAD_FRAGMENT_SIZE
+	int "Fragment size for FOTA downloads"
+	depends on FOTA_DOWNLOAD
+	range 128 1900
+	default 1900
 
 config FOTA_USE_NRF_CLOUD_SETTINGS_AREA
 	bool "Use the same settings area as the nRF Cloud FOTA library"

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota_poll.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota_poll.c
@@ -18,7 +18,6 @@
 
 LOG_MODULE_REGISTER(nrf_cloud_fota_poll, CONFIG_NRF_CLOUD_FOTA_POLL_LOG_LEVEL);
 
-#define FOTA_DL_FRAGMENT_SZ	1400
 #define JOB_WAIT_S		30
 
 /* FOTA job status strings that provide additional details for nrf_cloud_fota_status values */
@@ -375,7 +374,7 @@ static int start_download(void)
 			.sec_tag_list = &sec_tag,
 			.sec_tag_count = (sec_tag < 0 ? 0 : 1),
 			.pdn_id = 0,
-			.frag_size_override = FOTA_DL_FRAGMENT_SZ,
+			.frag_size_override = CONFIG_NRF_CLOUD_FOTA_DOWNLOAD_FRAGMENT_SIZE,
 		},
 		.fota = {
 			.expected_type = img_type,

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota_poll.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota_poll.c
@@ -437,7 +437,8 @@ static int start_download(void)
 			.sec_tag_list = &sec_tag,
 			.sec_tag_count = (sec_tag < 0 ? 0 : 1),
 			.pdn_id = 0,
-			.frag_size_override = CONFIG_NRF_CLOUD_FOTA_DOWNLOAD_FRAGMENT_SIZE,
+			.frag_size_override = ctx_ptr->fragment_size ? ctx_ptr->fragment_size :
+					      CONFIG_NRF_CLOUD_FOTA_DOWNLOAD_FRAGMENT_SIZE,
 		},
 		.fota = {
 			.expected_type = img_type,


### PR DESCRIPTION
Add the option to use nrf_cloud_fota_poll_process() in a
non-blocking manner.
The current, blocking behavior is maintained, and the async
option is enabled by providing a callback function for error
handling.