### PR TITLE
samples: openthread: Do not use Partition Manager on nRF52 dongle

### DIFF
--- a/samples/openthread/cli/Kconfig.sysbuild
+++ b/samples/openthread/cli/Kconfig.sysbuild
@@ -4,7 +4,11 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+# Do not use partition manager on nRF52840 dongle.
+config PARTITION_MANAGER
+	default n if BOARD_NRF52840DONGLE_NRF52840
 
 config NRF_DEFAULT_IPC_RADIO
 	default y
+
+source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"

--- a/samples/openthread/cli/src/main.c
+++ b/samples/openthread/cli/src/main.c
@@ -38,7 +38,7 @@ int main(void)
 	uint32_t dtr = 0U;
 
 	ret = usb_enable(NULL);
-	if (ret != 0) {
+	if (ret != 0 && ret != -EALREADY) {
 		LOG_ERR("Failed to enable USB");
 		return 0;
 	}


### PR DESCRIPTION
Partition Manager is redundant on the nRF52840 dongle while sysbuild is in use.

DNM until it is verified.