### PR TITLE
tools: update requirements for nrf-regtool

### DIFF
--- a/scripts/requirements-build.txt
+++ b/scripts/requirements-build.txt
@@ -6,4 +6,4 @@ imagesize>=1.2.0
 intelhex
 pylint
 zcbor~=0.8.0
-nrf-regtool~=5.5.1
+nrf-regtool~=5.6.0

--- a/scripts/requirements-fixed.txt
+++ b/scripts/requirements-fixed.txt
@@ -70,7 +70,7 @@ msgpack==1.0.5            # via python-can
 mypy==1.5.1               # via -r zephyr/scripts/requirements-build-test.txt
 mypy-extensions==1.0.0    # via mypy
 natsort==8.4.0            # via pyocd
-nrf-regtool==5.5.1        # via -r nrf/scripts/requirements-build.txt
+nrf-regtool==5.6.0        # via -r nrf/scripts/requirements-build.txt
 nrfcredstore==1.0.0       # via -r nrf/scripts/requirements-extra.txt
 numpy==1.26.4             # via svada
 packaging==24.0           # via -r zephyr/scripts/requirements-base.txt, pkg-about, pytest, python-can, setuptools-scm, west


### PR DESCRIPTION
5.6.0 is required by
https://github.com/zephyrproject-rtos/zephyr/
blob/main/modules/hal_nordic/CMakeLists.txt#L15.