### PR TITLE
lib: at_cmd_parser: Support digits in AT notifications

### DIFF
--- a/lib/at_cmd_parser/at_utils.h
+++ b/lib/at_cmd_parser/at_utils.h
@@ -74,7 +74,7 @@ static inline bool is_valid_command_char(char chr)
 /**
  * @brief Verify that the character is a valid character
  *
- * Notification ID strings can only contain upper case letters 'A' through 'Z' and '_'
+ * Notification ID strings can only contain upper case letters 'A' through 'Z', digits and '_'
  *
  * @param[in] chr Character that should be examined
  *
@@ -85,7 +85,7 @@ static inline bool is_valid_notification_char(char chr)
 {
 	chr = toupper((int)chr);
 
-	if (((chr >= 'A') && (chr <= 'Z')) || (chr == '_')) {
+	if (((chr >= 'A') && (chr <= 'Z')) || ((chr >= '0') && (chr <= '9')) || (chr == '_')) {
 		return true;
 	}
 


### PR DESCRIPTION
Add digits as valid characters in AT notifications.