### PR TITLE
nfc:ndef: Fix memory allocation check to prevent NULL dereference

### DIFF
--- a/subsys/nfc/ndef/ch_rec_parser.c
+++ b/subsys/nfc/ndef/ch_rec_parser.c
@@ -213,7 +213,7 @@ static int ac_rec_payload_parse(struct nfc_ndef_bin_payload_desc *payload_desc,
 
 	ac_rec->aux_data_ref = (struct nfc_ndef_ch_ac_rec_ref *)
 		memory_allocate(&buf, ac_rec->aux_data_ref_cnt * sizeof(*ac_rec->aux_data_ref));
-	if (ac_rec->aux_data_ref) {
+	if (!ac_rec->aux_data_ref) {
 		return -ENOMEM;
 	}
 


### PR DESCRIPTION
Fixes coverity issue 112949