### PR TITLE
samples: bluetooth: fast_pair: locator_tag: Update docs

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -321,7 +321,19 @@ Bluetooth Fast Pair samples
 
 * :ref:`fast_pair_locator_tag` sample:
 
-  * Updated the :ref:`ipc_radio` image configuration by splitting it into the debug and release configurations.
+  * Added:
+
+    * LED indication on development kits for the Fast Pair advertising state.
+    * An application versioning using the :file:`VERSION` file.
+    * The DFU support which can be enabled using the ``SB_CONFIG_APP_DFU`` sysbuild Kconfig option.
+      DFU is available for all supported targets except the ``debug`` configurations of :ref:`zephyr:nrf52dk_nrf52832` and :ref:`zephyr:nrf52833dk_nrf52833` due to size constraints.
+
+  * Updated:
+
+    * The :ref:`ipc_radio` image configuration by splitting it into the debug and release configurations.
+    * The location of the sample configuration.
+      It has been moved from the root sample directory to the dedicated folder (:file:`locator_tag/configuration`).
+    * The ``fp_adv`` module to use the trigger requests for the Fast Pair advertising state instead of setting the Fast Pair advertising mode directly.
 
 Bluetooth Mesh samples
 ----------------------


### PR DESCRIPTION
Updated locator_tag sample README and added release notes due to the recent changes:
* Moving the sample configuration into dedicated directory
* Rework of fp_adv module
* Addition of FP advertising state LED indication
* Addition of DFU mode

Jira: NCSDK-28293

This PR documents changes introduced in the following PR and its list of dependent PRs:
https://github.com/nrfconnect/sdk-nrf/pull/16311