### PR TITLE
applications: nrf5340_audio: lc3_streamer: Use correct filename buf

### DIFF
--- a/applications/nrf5340_audio/src/modules/lc3_streamer.c
+++ b/applications/nrf5340_audio/src/modules/lc3_streamer.c
@@ -296,7 +296,7 @@ int lc3_streamer_stream_register(const char *const filename, uint8_t *const stre
 		return -EAGAIN;
 	}
 
-	ret = lc3_file_open(&streams[*streamer_idx].file, streams[*streamer_idx].filename);
+	ret = lc3_file_open(&streams[*streamer_idx].file, filename);
 	if (ret) {
 		LOG_ERR("Failed to open file %d", ret);
 		return ret;

--- a/tests/nrf5340_audio/lc3_streamer/src/main.c
+++ b/tests/nrf5340_audio/lc3_streamer/src/main.c
@@ -52,9 +52,13 @@ ZTEST(lc3_streamer, test_lc3_streamer_stream_register_valid)
 	int ret;
 	uint8_t streamer_idx;
 
-	ret = lc3_streamer_stream_register("test", &streamer_idx, false);
+	static const char test_filename[] = "test";
+
+	ret = lc3_streamer_stream_register(test_filename, &streamer_idx, false);
 	zassert_equal(0, ret, "lc3_streamer_stream_register should return success");
 	zassert_equal(0, streamer_idx, "lc3_streamer_stream_register should return index 0");
+	zassert_mem_equal(test_filename, lc3_file_open_fake.arg1_val, sizeof(test_filename),
+			  "lc3_file_open called with wrong filename");
 
 	int num_active = lc3_streamer_num_active_streams();
 


### PR DESCRIPTION
Fixes a bug in the lc3_streamer where the stored filename variable would be used instead of the argument variable, but before the argument buffer has been copied to the stored variable. Updated tests to catch the error.

OCT-NONE