### PR TITLE
samples: matter: Multiple door lock's schedules refinements

### DIFF
--- a/samples/matter/common/src/persistent_storage/Kconfig
+++ b/samples/matter/common/src/persistent_storage/Kconfig
@@ -31,7 +31,7 @@ if NCS_SAMPLE_MATTER_SECURE_STORAGE_BACKEND
 
 config NCS_SAMPLE_MATTER_SECURE_STORAGE_MAX_ENTRY_NUMBER
 	int "Maximum number of entries that can be stored securely"
-	default 30
+	default 64
 
 config NCS_SAMPLE_MATTER_SECURE_STORAGE_PSA_KEY_VALUE_OFFSET
 	hex "The PSA key offset dedicated for Matter application"

--- a/samples/matter/lock/Kconfig
+++ b/samples/matter/lock/Kconfig
@@ -148,6 +148,26 @@ config NCS_SAMPLE_MATTER_SECURE_STORAGE_BACKEND
 config NCS_SAMPLE_MATTER_SETTINGS_STORAGE_BACKEND
 	default n if !CHIP_WIFI
 
+# Increase the storage capacity if the schedules are enabled with secure storage
+# This also implies increasing of the OT and Matter stacks because some operations
+# performed during commissioning seem to allocate stack buffers based on the
+# maximum possible secure asset size.
+if LOCK_SCHEDULES && NCS_SAMPLE_MATTER_SECURE_STORAGE_BACKEND
+
+config NCS_SAMPLE_MATTER_SECURE_STORAGE_MAX_ENTRY_NUMBER
+	default 128
+
+config TRUSTED_STORAGE_BACKEND_AEAD_MAX_DATA_SIZE
+	default 3072
+
+config OPENTHREAD_THREAD_STACK_SIZE
+	default 5120
+
+config CHIP_TASK_STACK_SIZE
+	default 9216
+
+endif
+
 source "${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/chip-module/Kconfig.features"
 source "${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/chip-module/Kconfig.defaults"
 source "${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common/src/Kconfig"

--- a/samples/matter/lock/src/access/access_data_types.cpp
+++ b/samples/matter/lock/src/access/access_data_types.cpp
@@ -180,8 +180,6 @@ CHIP_ERROR User::Deserialize(const void *buff, size_t buffSize)
 
 CHIP_ERROR WeekDaySchedule::FillFromPlugin(EmberAfPluginDoorLockWeekDaySchedule &plugin)
 {
-	static_assert(sizeof(EmberAfPluginDoorLockWeekDaySchedule) == RequiredBufferSize());
-
 	mData.mFields.mDaysMask = static_cast<uint8_t>(plugin.daysMask);
 	mData.mFields.mStartHour = plugin.startHour;
 	mData.mFields.mStartMinute = plugin.startMinute;
@@ -193,8 +191,6 @@ CHIP_ERROR WeekDaySchedule::FillFromPlugin(EmberAfPluginDoorLockWeekDaySchedule 
 
 CHIP_ERROR YearDaySchedule::FillFromPlugin(EmberAfPluginDoorLockYearDaySchedule &plugin)
 {
-	static_assert(sizeof(EmberAfPluginDoorLockYearDaySchedule) == RequiredBufferSize());
-
 	mData.mFields.mLocalStartTime = plugin.localStartTime;
 	mData.mFields.mLocalEndTime = plugin.localEndTime;
 
@@ -203,8 +199,6 @@ CHIP_ERROR YearDaySchedule::FillFromPlugin(EmberAfPluginDoorLockYearDaySchedule 
 
 CHIP_ERROR HolidaySchedule::FillFromPlugin(EmberAfPluginDoorLockHolidaySchedule &plugin)
 {
-	static_assert(sizeof(EmberAfPluginDoorLockHolidaySchedule) == RequiredBufferSize());
-
 	mData.mFields.mLocalStartTime = plugin.localStartTime;
 	mData.mFields.mLocalEndTime = plugin.localEndTime;
 	mData.mFields.mOperatingMode = static_cast<uint8_t>(plugin.operatingMode);
@@ -214,8 +208,6 @@ CHIP_ERROR HolidaySchedule::FillFromPlugin(EmberAfPluginDoorLockHolidaySchedule 
 
 CHIP_ERROR WeekDaySchedule::ConvertToPlugin(EmberAfPluginDoorLockWeekDaySchedule &plugin) const
 {
-	static_assert(sizeof(EmberAfPluginDoorLockWeekDaySchedule) == RequiredBufferSize());
-
 	plugin.daysMask = static_cast<DaysMaskMap>(mData.mFields.mDaysMask);
 	plugin.startHour = mData.mFields.mStartHour;
 	plugin.startMinute = mData.mFields.mStartMinute;
@@ -227,8 +219,6 @@ CHIP_ERROR WeekDaySchedule::ConvertToPlugin(EmberAfPluginDoorLockWeekDaySchedule
 
 CHIP_ERROR YearDaySchedule::ConvertToPlugin(EmberAfPluginDoorLockYearDaySchedule &plugin) const
 {
-	static_assert(sizeof(EmberAfPluginDoorLockYearDaySchedule) == RequiredBufferSize());
-
 	plugin.localStartTime = mData.mFields.mLocalStartTime;
 	plugin.localEndTime = mData.mFields.mLocalEndTime;
 
@@ -237,89 +227,9 @@ CHIP_ERROR YearDaySchedule::ConvertToPlugin(EmberAfPluginDoorLockYearDaySchedule
 
 CHIP_ERROR HolidaySchedule::ConvertToPlugin(EmberAfPluginDoorLockHolidaySchedule &plugin) const
 {
-	static_assert(sizeof(EmberAfPluginDoorLockHolidaySchedule) == RequiredBufferSize());
-
 	plugin.localStartTime = mData.mFields.mLocalStartTime;
 	plugin.localEndTime = mData.mFields.mLocalEndTime;
 	plugin.operatingMode = static_cast<OperatingModeEnum>(mData.mFields.mOperatingMode);
-
-	return CHIP_NO_ERROR;
-}
-
-size_t WeekDaySchedule::Serialize(void *buff, size_t buffSize)
-{
-	if (!buff || buffSize < RequiredBufferSize()) {
-		return 0;
-	}
-
-	memcpy(buff, mData.mRaw, sizeof(mData.mRaw));
-
-	return sizeof(mData.mRaw);
-}
-
-size_t YearDaySchedule::Serialize(void *buff, size_t buffSize)
-{
-	if (!buff || buffSize < RequiredBufferSize()) {
-		return 0;
-	}
-
-	memcpy(buff, mData.mRaw, sizeof(mData.mRaw));
-
-	return sizeof(mData.mRaw);
-}
-
-size_t HolidaySchedule::Serialize(void *buff, size_t buffSize)
-{
-	if (!buff || buffSize < RequiredBufferSize()) {
-		return 0;
-	}
-
-	memcpy(buff, mData.mRaw, sizeof(mData.mRaw));
-
-	return sizeof(mData.mRaw);
-}
-
-CHIP_ERROR WeekDaySchedule::Deserialize(const void *buff, size_t buffSize)
-{
-	if (!buff) {
-		return CHIP_ERROR_INVALID_ARGUMENT;
-	}
-
-	if (buffSize > RequiredBufferSize()) {
-		return CHIP_ERROR_BUFFER_TOO_SMALL;
-	}
-
-	memcpy(mData.mRaw, buff, sizeof(mData.mRaw));
-
-	return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR YearDaySchedule::Deserialize(const void *buff, size_t buffSize)
-{
-	if (!buff) {
-		return CHIP_ERROR_INVALID_ARGUMENT;
-	}
-
-	if (buffSize > RequiredBufferSize()) {
-		return CHIP_ERROR_BUFFER_TOO_SMALL;
-	}
-
-	memcpy(mData.mRaw, buff, sizeof(mData.mRaw));
-
-	return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR HolidaySchedule::Deserialize(const void *buff, size_t buffSize)
-{
-	if (!buff) {
-		return CHIP_ERROR_INVALID_ARGUMENT;
-	}
-
-	if (buffSize > RequiredBufferSize()) {
-		return CHIP_ERROR_BUFFER_TOO_SMALL;
-	}
-
-	memcpy(mData.mRaw, buff, sizeof(mData.mRaw));
 
 	return CHIP_NO_ERROR;
 }

--- a/samples/matter/lock/src/access/access_manager_schedules.cpp
+++ b/samples/matter/lock/src/access/access_manager_schedules.cpp
@@ -24,9 +24,12 @@ DlStatus AccessManager<CRED_BIT_MASK>::GetWeekDaySchedule(uint8_t weekdayIndex, 
 	VerifyOrReturnError(userIndex > 0 && userIndex <= CONFIG_LOCK_MAX_NUM_USERS, DlStatus::kFailure);
 	VerifyOrReturnError(weekdayIndex > 0 && weekdayIndex <= CONFIG_LOCK_MAX_WEEKDAY_SCHEDULES_PER_USER,
 			    DlStatus::kFailure);
-	VerifyOrReturnError(!mWeekDaySchedule[userIndex - 1][weekdayIndex - 1].mAvailable, DlStatus::kNotFound);
 
-	if (CHIP_NO_ERROR != mWeekDaySchedule[userIndex - 1][weekdayIndex - 1].ConvertToPlugin(schedule)) {
+	auto &sch = mWeekDaySchedule[userIndex - 1][weekdayIndex - 1];
+
+	VerifyOrReturnError(!sch.mAvailable, DlStatus::kNotFound);
+
+	if (CHIP_NO_ERROR != sch.ConvertToPlugin(schedule)) {
 		return DlStatus::kNotFound;
 	}
 
@@ -47,15 +50,15 @@ DlStatus AccessManager<CRED_BIT_MASK>::SetWeekDaySchedule(uint8_t weekdayIndex, 
 
 	if (DlScheduleStatus::kAvailable == status && !schedule.mAvailable) {
 		schedule.mAvailable = true;
-		memset(schedule.mData.mRaw, 0, DoorLockData::WeekDaySchedule::RequiredBufferSize());
+		memset(schedule.mData.mRaw, 0, sizeof(schedule.mData.mRaw));
 		if (!AccessStorage::Instance().Remove(AccessStorage::Type::WeekDaySchedule, userIndex, weekdayIndex)) {
 			LOG_ERR("Cannot remove the WeekDay schedule");
 			return DlStatus::kFailure;
 		}
 		return DlStatus::kSuccess;
+	} else if (DlScheduleStatus::kOccupied == status && !schedule.mAvailable) {
+		LOG_DBG("Modifying week day schedule of index: %d for user %d", weekdayIndex, userIndex);
 	}
-
-	VerifyOrReturnError(schedule.mAvailable, DlStatus::kOccupied);
 
 	schedule.mData.mFields.mDaysMask = static_cast<uint8_t>(daysMask);
 	schedule.mData.mFields.mStartHour = startHour;
@@ -104,9 +107,12 @@ DlStatus AccessManager<CRED_BIT_MASK>::GetYearDaySchedule(uint8_t yearDayIndex, 
 	VerifyOrReturnError(userIndex > 0 && userIndex <= CONFIG_LOCK_MAX_NUM_USERS, DlStatus::kFailure);
 	VerifyOrReturnError(yearDayIndex > 0 && yearDayIndex <= CONFIG_LOCK_MAX_YEARDAY_SCHEDULES_PER_USER,
 			    DlStatus::kFailure);
-	VerifyOrReturnError(!mYearDaySchedule[userIndex - 1][yearDayIndex - 1].mAvailable, DlStatus::kNotFound);
 
-	if (CHIP_NO_ERROR != mYearDaySchedule[userIndex - 1][yearDayIndex - 1].ConvertToPlugin(schedule)) {
+	auto &sch = mYearDaySchedule[userIndex - 1][yearDayIndex - 1];
+
+	VerifyOrReturnError(!sch.mAvailable, DlStatus::kNotFound);
+
+	if (CHIP_NO_ERROR != sch.ConvertToPlugin(schedule)) {
 		return DlStatus::kNotFound;
 	}
 
@@ -126,15 +132,15 @@ DlStatus AccessManager<CRED_BIT_MASK>::SetYearDaySchedule(uint8_t yeardayIndex, 
 
 	if (DlScheduleStatus::kAvailable == status && !schedule.mAvailable) {
 		schedule.mAvailable = true;
-		memset(schedule.mData.mRaw, 0, DoorLockData::YearDaySchedule::RequiredBufferSize());
+		memset(schedule.mData.mRaw, 0, sizeof(schedule.mData.mRaw));
 		if (!AccessStorage::Instance().Remove(AccessStorage::Type::YearDaySchedule, userIndex, yeardayIndex)) {
 			LOG_ERR("Cannot remove the YearDay schedule");
 			return DlStatus::kFailure;
 		}
 		return DlStatus::kSuccess;
+	} else if (DlScheduleStatus::kOccupied == status && !schedule.mAvailable) {
+		LOG_DBG("Modifying year day schedule of index: %d for user %d", yeardayIndex, userIndex);
 	}
-
-	VerifyOrReturnError(schedule.mAvailable, DlStatus::kOccupied);
 
 	schedule.mData.mFields.mLocalStartTime = localStartTime;
 	schedule.mData.mFields.mLocalEndTime = localEndTime;
@@ -178,9 +184,12 @@ DlStatus AccessManager<CRED_BIT_MASK>::GetHolidaySchedule(uint8_t holidayIndex,
 							  EmberAfPluginDoorLockHolidaySchedule &schedule)
 {
 	VerifyOrReturnError(holidayIndex > 0 && holidayIndex <= CONFIG_LOCK_MAX_HOLIDAY_SCHEDULES, DlStatus::kFailure);
-	VerifyOrReturnError(!mHolidaySchedule[holidayIndex - 1].mAvailable, DlStatus::kNotFound);
 
-	if (CHIP_NO_ERROR != mHolidaySchedule[holidayIndex - 1].ConvertToPlugin(schedule)) {
+	auto &sch = mHolidaySchedule[holidayIndex - 1];
+
+	VerifyOrReturnError(!sch.mAvailable, DlStatus::kNotFound);
+
+	if (CHIP_NO_ERROR != sch.ConvertToPlugin(schedule)) {
 		return DlStatus::kNotFound;
 	}
 
@@ -198,15 +207,15 @@ DlStatus AccessManager<CRED_BIT_MASK>::SetHolidaySchedule(uint8_t holidayIndex, 
 
 	if (DlScheduleStatus::kAvailable == status && !schedule.mAvailable) {
 		schedule.mAvailable = true;
-		memset(schedule.mData.mRaw, 0, DoorLockData::HolidaySchedule::RequiredBufferSize());
+		memset(schedule.mData.mRaw, 0, sizeof(schedule.mData.mRaw));
 		if (!AccessStorage::Instance().Remove(AccessStorage::Type::HolidaySchedule, holidayIndex)) {
 			LOG_ERR("Cannot remove the Holiday schedule");
 			return DlStatus::kFailure;
 		}
 		return DlStatus::kSuccess;
+	} else if (DlScheduleStatus::kOccupied == status && !schedule.mAvailable) {
+		LOG_DBG("Modifying holiday schedule of index: %d", holidayIndex);
 	}
-
-	VerifyOrReturnError(schedule.mAvailable, DlStatus::kOccupied);
 
 	schedule.mData.mFields.mLocalStartTime = localStartTime;
 	schedule.mData.mFields.mLocalEndTime = localEndTime;
@@ -369,7 +378,7 @@ void AccessManager<CRED_BIT_MASK>::PrintSchedule(ScheduleType scheduleType, uint
 	case ScheduleType::WeekDay: {
 		auto *schedule = &mWeekDaySchedule[userIndex - 1][scheduleIndex - 1];
 		if (schedule) {
-			LOG_INF("-- WeekDay Schedule %d for user %d, days %08u, start %d:%d, end %d:%d", scheduleIndex,
+			LOG_DBG("-- WeekDay Schedule %d for user %d, days %08u, start %d:%d, end %d:%d", scheduleIndex,
 				userIndex, static_cast<uint8_t>(schedule->mData.mFields.mDaysMask),
 				schedule->mData.mFields.mStartHour, schedule->mData.mFields.mStartMinute,
 				schedule->mData.mFields.mEndHour, schedule->mData.mFields.mEndMinute);
@@ -378,7 +387,7 @@ void AccessManager<CRED_BIT_MASK>::PrintSchedule(ScheduleType scheduleType, uint
 	case ScheduleType::YearDay: {
 		auto *schedule = &mYearDaySchedule[userIndex - 1][scheduleIndex - 1];
 		if (schedule) {
-			LOG_INF("-- YearDay Schedule %d for user %d, starting time: %u, ending time: %u", scheduleIndex,
+			LOG_DBG("-- YearDay Schedule %d for user %d, starting time: %u, ending time: %u", scheduleIndex,
 				userIndex, schedule->mData.mFields.mLocalStartTime,
 				schedule->mData.mFields.mLocalEndTime);
 		}
@@ -386,7 +395,7 @@ void AccessManager<CRED_BIT_MASK>::PrintSchedule(ScheduleType scheduleType, uint
 	case ScheduleType::Holiday: {
 		auto *schedule = &mHolidaySchedule[scheduleIndex - 1];
 		if (schedule) {
-			LOG_INF("-- Holiday Schedule %d, Local start time: %u, Local end time: %u, Operating mode: %d",
+			LOG_DBG("-- Holiday Schedule %d, Local start time: %u, Local end time: %u, Operating mode: %d",
 				scheduleIndex, schedule->mData.mFields.mLocalStartTime,
 				schedule->mData.mFields.mLocalEndTime,
 				static_cast<uint8_t>(schedule->mData.mFields.mOperatingMode));


### PR DESCRIPTION
* increase maximum number of secure entries that can be stored
* align the maximum asset size for scheduled access feature
* align the OT and Matter stack sizes
* allow for re-setting of the same schedule with different data
* added missing serialization of mAvailable flag - it was not stored because of that
* refactor the *Schedule structs to avoid boiler plate code
* decrease the log level for schedule prints