### PR TITLE
samples: fix prohibited usage of BLE in sample names

### DIFF
--- a/applications/nrf_desktop/sample.yaml
+++ b/applications/nrf_desktop/sample.yaml
@@ -12,7 +12,7 @@ common:
       - "app_event_manager: e:module_state_event module:main state:READY"
       - "ble_state: Bluetooth initialized"
       - "settings_loader: Settings loaded"
-      - "ble_bond: Selected BLE peers"
+      - "ble_bond: Selected Bluetooth LE peers"
       - "(ble_adv: Advertising started)|(ble_scan: Scan started)"
       - "dfu: Secondary image slot is clean"
 tests:

--- a/applications/nrf_desktop/src/modules/ble_bond.c
+++ b/applications/nrf_desktop/src/modules/ble_bond.c
@@ -552,7 +552,7 @@ static void select_dongle_peer(void)
 
 static void select_ble_peers(void)
 {
-	LOG_INF("Selected BLE peers");
+	LOG_INF("Selected Bluetooth LE peers");
 	if (state == STATE_DONGLE) {
 		state = STATE_IDLE;
 	} else if (state == STATE_DONGLE_STANDBY) {

--- a/doc/_scripts/software_maturity/software_maturity_features.yaml
+++ b/doc/_scripts/software_maturity/software_maturity_features.yaml
@@ -24,7 +24,7 @@ top_table:
       - BOARD_NRF7002DK_NRF5340_CPUAPP_NRF7001
 features:
   sidewalk:
-    Sidewalk over BLE: SIDEWALK && SIDEWALK_LINK_MASK_BLE
+    Sidewalk over Bluetooth LE: SIDEWALK && SIDEWALK_LINK_MASK_BLE
     Sidewalk over FSK: SIDEWALK && CONFIG_SIDEWALK_SUBGHZ_SUPPORT
     Sidewalk over LORA: SIDEWALK && CONFIG_SIDEWALK_SUBGHZ_SUPPORT
     Sidewalk - OTA DFU over Bluetooth LE: SIDEWALK && SIDEWALK_DFU_SERVICE_BLE

--- a/samples/bluetooth/central_and_peripheral_hr/sample.yaml
+++ b/samples/bluetooth/central_and_peripheral_hr/sample.yaml
@@ -1,6 +1,6 @@
 sample:
   description: Bluetooth Low Energy central and peripheral heart rate relay sample
-  name: BLE Central and Peripheral HRS
+  name: Bluetooth LE Central and Peripheral HRS
 tests:
   sample.bluetooth.central_and_peripheral_hr.build:
     sysbuild: true

--- a/samples/bluetooth/central_bas/sample.yaml
+++ b/samples/bluetooth/central_bas/sample.yaml
@@ -1,6 +1,6 @@
 sample:
   description: Bluetooth Low Energy central battery service sample
-  name: BLE Central BAS
+  name: Bluetooth LE Central BAS
 tests:
   sample.bluetooth.central_bas:
     sysbuild: true

--- a/samples/bluetooth/central_hids/sample.yaml
+++ b/samples/bluetooth/central_hids/sample.yaml
@@ -1,6 +1,6 @@
 sample:
   description: Bluetooth Low Energy central Human Interface Device sample
-  name: BLE Central HIDS
+  name: Bluetooth LE Central HIDS
 tests:
   sample.bluetooth.central_hids:
     sysbuild: true

--- a/samples/bluetooth/central_smp_client/sample.yaml
+++ b/samples/bluetooth/central_smp_client/sample.yaml
@@ -1,6 +1,6 @@
 sample:
   description: Bluetooth Low Energy Central Device Firmware Update sample
-  name: BLE Central DFU SMP
+  name: Bluetooth LE Central DFU SMP
 tests:
   sample.bluetooth.central_dfu_smp:
     sysbuild: true

--- a/samples/bluetooth/central_uart/sample.yaml
+++ b/samples/bluetooth/central_uart/sample.yaml
@@ -1,6 +1,6 @@
 sample:
   description: Bluetooth Low Energy central UART sample
-  name: BLE Central UART
+  name: Bluetooth LE Central UART
 tests:
   sample.bluetooth.central_uart:
     sysbuild: true

--- a/samples/bluetooth/event_trigger/sample.yaml
+++ b/samples/bluetooth/event_trigger/sample.yaml
@@ -1,6 +1,6 @@
 sample:
   description: Buetooth Low Energy Event Trigger sample
-  name: BLE Event Trigger
+  name: Bluetooth LE Event Trigger
 tests:
   sample.bluetooth.event_trigger:
     sysbuild: true

--- a/samples/bluetooth/iso_combined_bis_and_cis/sample.yaml
+++ b/samples/bluetooth/iso_combined_bis_and_cis/sample.yaml
@@ -1,6 +1,6 @@
 sample:
   description: Bluetooth Low Energy combined BIS and CIS sample
-  name: BLE combined BIS and CIS
+  name: Bluetooth LE combined BIS and CIS
 tests:
   sample.bluetooth.iso_bis_cis:
     sysbuild: true

--- a/samples/bluetooth/llpm/sample.yaml
+++ b/samples/bluetooth/llpm/sample.yaml
@@ -1,6 +1,6 @@
 sample:
   description: Buetooth Low Energy LLPM sample
-  name: BLE LLPM
+  name: Bluetooth LE LLPM
 tests:
   sample.bluetooth.llpm:
     sysbuild: true

--- a/samples/bluetooth/multiple_adv_sets/sample.yaml
+++ b/samples/bluetooth/multiple_adv_sets/sample.yaml
@@ -1,6 +1,6 @@
 sample:
   description: Bluetooth Low Energy multiple advertising sets sample
-  name: BLE multiple advertising sets sample
+  name: Bluetooth LE multiple advertising sets
 tests:
   sample.bluetooth.multiple_adv_sets.build:
     sysbuild: true

--- a/samples/bluetooth/peripheral_ams_client/sample.yaml
+++ b/samples/bluetooth/peripheral_ams_client/sample.yaml
@@ -1,6 +1,6 @@
 sample:
   description: Bluetooth Low Energy AMS client sample
-  name: BLE AMS client sample
+  name: Bluetooth LE AMS client
 tests:
   sample.bluetooth.peripheral_ams_client.build:
     sysbuild: true

--- a/samples/bluetooth/peripheral_ancs_client/sample.yaml
+++ b/samples/bluetooth/peripheral_ancs_client/sample.yaml
@@ -1,6 +1,6 @@
 sample:
   description: Bluetooth Low Energy ANCS client sample
-  name: BLE ANCS client sample
+  name: Bluetooth LE ANCS client
 tests:
   sample.bluetooth.peripheral_ancs_client.build:
     sysbuild: true

--- a/samples/bluetooth/peripheral_bms/sample.yaml
+++ b/samples/bluetooth/peripheral_bms/sample.yaml
@@ -1,6 +1,6 @@
 sample:
   description: Bluetooth Low Energy Bond Management service sample
-  name: BLE Bond Management service
+  name: Bluetooth LE Bond Management service
 tests:
   sample.bluetooth.peripheral_bms:
     sysbuild: true

--- a/samples/bluetooth/peripheral_cts_client/sample.yaml
+++ b/samples/bluetooth/peripheral_cts_client/sample.yaml
@@ -1,6 +1,6 @@
 sample:
   description: Bluetooth Low Energy CTS client sample
-  name: BLE CTS client sample
+  name: Bluetooth LE CTS client
 tests:
   sample.bluetooth.peripheral_cts_client.build:
     sysbuild: true

--- a/samples/bluetooth/peripheral_gatt_dm/sample.yaml
+++ b/samples/bluetooth/peripheral_gatt_dm/sample.yaml
@@ -1,6 +1,6 @@
 sample:
   description: Bluetooth Low Energy Gatt client discovery manager sample
-  name: BLE Gatt Discovery
+  name: Bluetooth LE Gatt Discovery
 tests:
   sample.bluetooth.peripheral_gatt_dm:
     sysbuild: true

--- a/samples/bluetooth/peripheral_hids_keyboard/sample.yaml
+++ b/samples/bluetooth/peripheral_hids_keyboard/sample.yaml
@@ -1,6 +1,6 @@
 sample:
   description: Bluetooth Low Energy Human Interface Device keyboard sample
-  name: BLE HIDS keyboard sample
+  name: Bluetooth LE HIDS keyboard
 tests:
   sample.bluetooth.peripheral_hids_keyboard:
     sysbuild: true

--- a/samples/bluetooth/peripheral_hids_mouse/sample.yaml
+++ b/samples/bluetooth/peripheral_hids_mouse/sample.yaml
@@ -1,6 +1,6 @@
 sample:
   description: Bluetooth Low Energy Human Interface Device mouse sample
-  name: BLE HIDS mouse sample
+  name: Bluetooth LE HIDS mouse
 tests:
   sample.bluetooth.peripheral_hids_mouse:
     sysbuild: true

--- a/samples/bluetooth/peripheral_lbs/sample.yaml
+++ b/samples/bluetooth/peripheral_lbs/sample.yaml
@@ -1,6 +1,6 @@
 sample:
   description: Bluetooth Low Energy LED Button service sample
-  name: BLE LED Button service
+  name: Bluetooth LE LED Button service
 tests:
   sample.bluetooth.peripheral_lbs:
     sysbuild: true

--- a/samples/bluetooth/peripheral_mds/sample.yaml
+++ b/samples/bluetooth/peripheral_mds/sample.yaml
@@ -1,6 +1,6 @@
 sample:
   description: Bluetooth Low Energy Memfault Diagnostic service sample
-  name: BLE MDS service
+  name: Bluetooth LE MDS service
 tests:
   sample.bluetooth.peripheral_mds:
     sysbuild: true

--- a/samples/bluetooth/peripheral_power_profiling/sample.yaml
+++ b/samples/bluetooth/peripheral_power_profiling/sample.yaml
@@ -1,6 +1,6 @@
 sample:
   description: Bluetooth Low Energy Power Profiling sample
-  name: BLE Power Profiling
+  name: Bluetooth LE Power Profiling
 tests:
   sample.bluetooth.peripheral_power_profiling:
     sysbuild: true

--- a/samples/bluetooth/peripheral_status/sample.yaml
+++ b/samples/bluetooth/peripheral_status/sample.yaml
@@ -1,6 +1,6 @@
 sample:
   description: Bluetooth Nordic Status Message service sample
-  name: BLE Nordic Status Message service
+  name: Bluetooth LE Nordic Status Message service
 tests:
   sample.bluetooth.peripheral_nsms:
     sysbuild: true

--- a/samples/bluetooth/peripheral_uart/sample.yaml
+++ b/samples/bluetooth/peripheral_uart/sample.yaml
@@ -1,6 +1,6 @@
 sample:
   description: Bluetooth Low Energy UART service sample
-  name: BLE UART service
+  name: Bluetooth LE UART service
 tests:
   sample.bluetooth.peripheral_uart:
     sysbuild: true

--- a/samples/bluetooth/rpc_host/sample.yaml
+++ b/samples/bluetooth/rpc_host/sample.yaml
@@ -1,6 +1,6 @@
 sample:
-  description: nRF RPC host providing BLE API access
-  name: nRF RPC host for BLE API
+  description: nRF RPC host providing Bluetooth Low Energy API access
+  name: nRF RPC host for Bluetooth LE API
 tests:
   sample.bluetooth.rpc_host:
     sysbuild: true

--- a/samples/bluetooth/subrating/sample.yaml
+++ b/samples/bluetooth/subrating/sample.yaml
@@ -1,6 +1,6 @@
 sample:
   description: Bluetooth Low Energy Connection Subrating sample
-  name: BLE Connection Subrating
+  name: Bluetooth LE Connection Subrating
 tests:
   sample.bluetooth.subrating.build:
     sysbuild: true

--- a/samples/bluetooth/throughput/sample.yaml
+++ b/samples/bluetooth/throughput/sample.yaml
@@ -1,6 +1,6 @@
 sample:
   description: Bluetooth Low Energy throughput sample
-  name: BLE throughput
+  name: Bluetooth LE throughput
 tests:
   sample.bluetooth.throughput:
     sysbuild: true

--- a/samples/cellular/lte_ble_gateway/sample.yaml
+++ b/samples/cellular/lte_ble_gateway/sample.yaml
@@ -1,5 +1,5 @@
 sample:
-  name: LTE-BLE gateway sample
+  name: LTE-Bluetooth LE gateway sample
 tests:
   sample.cellular.lte_ble_gateway:
     sysbuild: true

--- a/samples/nrf_rpc/protocols_serialization/client/sample.yaml
+++ b/samples/nrf_rpc/protocols_serialization/client/sample.yaml
@@ -1,6 +1,6 @@
 sample:
   name: Protocols serialization client sample
-  description: Demonstrates serialization of BLE and OpenThread API using nRF RPC
+  description: Demonstrates serialization of Bluetooth LE and OpenThread API using nRF RPC
 tests:
   samples.nrf_rpc.protocols_serialization.client.rpc_ble:
     build_only: true

--- a/samples/nrf_rpc/protocols_serialization/server/sample.yaml
+++ b/samples/nrf_rpc/protocols_serialization/server/sample.yaml
@@ -1,6 +1,6 @@
 sample:
   name: Protocols serialization server sample
-  description: Demonstrates serialization of BLE and OpenThread API using nRF RPC
+  description: Demonstrates serialization of Bluetooth LE and OpenThread API using nRF RPC
 tests:
   samples.nrf_rpc.protocols_serialization.server.rpc_ble:
     build_only: true

--- a/samples/wifi/ble_coex/sample.yaml
+++ b/samples/wifi/ble_coex/sample.yaml
@@ -1,7 +1,6 @@
 sample:
-  description: Wi-Fi BLE coex sample
-    application
-  name: Wi-Fi BLE coex
+  description: Wi-Fi Bluetooth Low Energy coex sample
+  name: Wi-Fi Bluetooth LE coex
 tests:
   sample.nrf7002.ble_coex_sep_ant:
     sysbuild: true

--- a/samples/wifi/provisioning/ble/sample.yaml
+++ b/samples/wifi/provisioning/ble/sample.yaml
@@ -1,7 +1,6 @@
 sample:
-  description: BLE Wi-Fi provision sample
-    application
-  name: BLE Wi-Fi provision
+  description: Bluetooth Low Energy Wi-Fi provision sample
+  name: Bluetooth LE Wi-Fi provision
 tests:
   sample.nrf7002.ble-wifi-provision:
     sysbuild: true


### PR DESCRIPTION
Edited sample.yaml files to remove the prohibited usage of BLE. Correct term: Bluetooth LE. Source: Bluetooth Brand Guidelines, August 2023, p. 10. VSC-2646.
