### PR TITLE
partition_manager: Move ns storage partitions for nRF54L15

### DIFF
--- a/subsys/partition_manager/pm.yml.nvs
+++ b/subsys/partition_manager/pm.yml.nvs
@@ -1,5 +1,22 @@
 #include <autoconf.h>
 
+# In nRF54L15 we place the TF-M non-secure storage partitions after the
+# TF-M non-secure application to avoid splitting the secure/non-secure
+# partitions more than necessary.
+#ifdef CONFIG_SOC_NRF54L15_ENGA_CPUAPP
+nvs_storage:
+  placement:
+    after: [app]
+    before: [end]
+#ifdef CONFIG_PM_PARTITION_REGION_NVS_STORAGE_EXTERNAL
+  region: external_flash
+#else
+  inside: [nonsecure_storage]
+#endif
+  size: CONFIG_PM_PARTITION_SIZE_NVS_STORAGE
+
+
+#else
 nvs_storage:
   placement:
     before: [tfm_storage, end]
@@ -12,3 +29,5 @@ nvs_storage:
   inside: [nonsecure_storage]
 #endif
   size: CONFIG_PM_PARTITION_SIZE_NVS_STORAGE
+
+#endif /* CONFIG_SOC_NRF54L15_ENGA_CPUAPP */

--- a/subsys/partition_manager/pm.yml.settings
+++ b/subsys/partition_manager/pm.yml.settings
@@ -1,5 +1,21 @@
 #include <autoconf.h>
 
+# In nRF54L15 we place the TF-M non-secure storage partitions after the
+# TF-M non-secure application to avoid splitting the secure/non-secure
+# partitions more than necessary.
+#ifdef CONFIG_SOC_NRF54L15_ENGA_CPUAPP
+settings_storage:
+  placement:
+    after: [app]
+    before: [end]
+#ifdef CONFIG_PM_PARTITION_REGION_SETTINGS_STORAGE_EXTERNAL
+  region: external_flash
+#else
+  inside: [nonsecure_storage]
+#endif
+  size: CONFIG_PM_PARTITION_SIZE_SETTINGS_STORAGE
+
+#else
 settings_storage:
   placement:
     before: [tfm_storage, end]
@@ -10,3 +26,5 @@ settings_storage:
   inside: [nonsecure_storage]
 #endif
   size: CONFIG_PM_PARTITION_SIZE_SETTINGS_STORAGE
+
+#endif /* CONFIG_SOC_NRF54L15_ENGA_CPUAPP */


### PR DESCRIPTION
When we have TF-M enabled with the nRF54L15 we want to minimize how many secure/non-secure regions we use, so in TF-M we make the assumption that there is one secure and one non-secure region.

This updates the non-secure storage partitions (settings/nvs) in nRF54L15 so that they are placed after the non-secure application.