### PR TITLE
nfc: platform: Fix NULL pointer check and potential dereference

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -701,6 +701,7 @@ Libraries for NFC
 -----------------
 
 * Added an experimental serialization of NFC tag 2 and tag 4 APIs.
+* Fixed a potential issue with handling data pointers in the function ``ring_buf_get_data`` in the :file:`platform_internal_thread` file.
 
 nRF RPC libraries
 -----------------

--- a/subsys/nfc/lib/platform_internal_thread.c
+++ b/subsys/nfc/lib/platform_internal_thread.c
@@ -64,6 +64,10 @@ static int ring_buf_get_data(struct ring_buf *buf, uint8_t **data, uint32_t size
 	uint32_t tmp;
 	int err;
 
+	if (!buf || !data || !is_alloc) {
+		return -EINVAL;
+	}
+
 	*is_alloc = false;
 
 	/* Try to access data without copying.
@@ -79,7 +83,7 @@ static int ring_buf_get_data(struct ring_buf *buf, uint8_t **data, uint32_t size
 		}
 
 		*data = k_malloc(size);
-		if (data == NULL) {
+		if (*data == NULL) {
 			LOG_DBG("Could not allocate %d bytes.", size);
 			return -ENOMEM;
 		}


### PR DESCRIPTION
Fix potential NULL pointer dereferencing in ring_buf_get_data function.

Jira: NCSDK-27132