### PR TITLE
Align to support nRF2 clock control API

### DIFF
--- a/drivers/mpsl/clock_control/Kconfig
+++ b/drivers/mpsl/clock_control/Kconfig
@@ -8,5 +8,6 @@ config CLOCK_CONTROL_MPSL
 	bool
 	depends on MPSL
 	depends on CLOCK_CONTROL
+	depends on !SOC_SERIES_NRF54HX
 	default y
 	select CLOCK_CONTROL_NRF_FORCE_ALT

--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: a415e2d702d5192ffdf7ddf67fa73f8fab70a277
+      revision: 28b6861211d2d9f54411ff60357a42d84a253600
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
The new nRF2 clock control API is enabled by default for the nRF54H20 CPUAPP as it is used to initialize the HSFLL clock. This requires two changes to sdk-nrf:
* Don't enable MPSL clock control driver for nRF54HX as it is not supported for this platform. It was previously enabled if CLOCK_CONTROL and MPSL was enabled.
* The CPUAPP base image is a bit larger now with the addition of the API, which results in it not fitting the recovery partition set aside in the SUIT smp_transfer sample (overrun by 1200 bytes), so the partitions have been adjusted to fit the app.