### PR TITLE
Samples: Bluetooth: fix iso_time_sync sample

### DIFF
--- a/samples/bluetooth/iso_time_sync/sysbuild/hci_ipc/prj.conf
+++ b/samples/bluetooth/iso_time_sync/sysbuild/hci_ipc/prj.conf
@@ -21,7 +21,7 @@ CONFIG_BT_CTLR_ADV_ISO_STREAM_COUNT=4
 CONFIG_BT_CTLR_SYNC_ISO_STREAM_COUNT=4
 CONFIG_BT_CTLR_CONN_ISO_STREAMS=4
 
-CONFIG_BT_ISO_TX_MTU=5
+CONFIG_BT_ISO_TX_MTU=6
 
 # To present the audio at the right point in time, we need the controller and
 # audio clock to be synchronized


### PR DESCRIPTION
Add temporary workaround to fix iso_time_sync sample while we are waiting for bug fix upstream.

The fix upstream was merged here in
https://github.com/zephyrproject-rtos/zephyr/pull/76688