### PR TITLE
cracen: Update to new IKG personalization strings

### DIFF
--- a/subsys/nrf_security/include/psa/nrf_platform_key_ids.h
+++ b/subsys/nrf_security/include/psa/nrf_platform_key_ids.h
@@ -45,7 +45,6 @@ extern "C" {
 #define USAGE_AUTHOP	   0x14
 #define USAGE_FWENC	   0x20
 #define USAGE_PUBKEY	   0x21
-#define USAGE_AUTHDEBUG	   0x23
 #define USAGE_STMTRACE	   0x25
 #define USAGE_COREDUMP	   0x26
 #define USAGE_RMNORDIC	   0xAA

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/common.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/common.c
@@ -23,21 +23,13 @@
 #include <sxsymcrypt/sha2.h>
 #include <sxsymcrypt/sha3.h>
 #include <zephyr/sys/util.h>
+#include <psa/nrf_platform_key_ids.h>
 
 #define NOT_ENABLED_CURVE    (0)
 #define NOT_ENABLED_HASH_ALG (0)
 
 #ifdef NRF54H_SERIES
-/* NCSDK-27273: These defines will come from an external header file. */
-#define DOMAIN_NONE	   0x00
-#define DOMAIN_SECURE	   0x01
-#define DOMAIN_APPLICATION 0x02
-#define DOMAIN_RADIO	   0x03
-#define DOMAIN_CELL	   0x04
-#define DOMAIN_ISIM	   0x05
-#define DOMAIN_WIFI	   0x06
-#define DOMAIN_SYSCTRL	   0x08
-
+/* Address from the IPS. May come from the MDK in the future. */
 #define DEVICE_SECRET_LENGTH 4
 #define DEVICE_SECRET_ADDRESS ((uint32_t *)0x0E001620)
 #endif
@@ -694,28 +686,28 @@ int cracen_prepare_ik_key(const uint8_t *user_data)
 		cfg.key_bundle_sz = sizeof(lstr_##x) / sizeof(uint32_t);                           \
 	}
 	case DOMAIN_NONE:
-		SET_STR(NONE);
+		SET_STR(NONE0);
 		break;
 	case DOMAIN_SECURE:
-		SET_STR(SECURE);
+		SET_STR(SECURE0);
 		break;
 	case DOMAIN_APPLICATION:
-		SET_STR(APPLICATION);
+		SET_STR(APPLICATION0);
 		break;
 	case DOMAIN_RADIO:
-		SET_STR(RADIO);
+		SET_STR(RADIOCORE0);
 		break;
 	case DOMAIN_CELL:
-		SET_STR(CELL);
+		SET_STR(CELL0);
 		break;
 	case DOMAIN_ISIM:
-		SET_STR(ISIM);
+		SET_STR(ISIM0);
 		break;
 	case DOMAIN_WIFI:
-		SET_STR(WIFI);
+		SET_STR(WIFI0);
 		break;
 	case DOMAIN_SYSCTRL:
-		SET_STR(SYSCTRL);
+		SET_STR(SYSCTRL0);
 		break;
 
 	default:

--- a/subsys/nrf_security/src/drivers/cracen/silexpk/target/hw/ik/ikhardware.c
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/target/hw/ik/ikhardware.c
@@ -74,18 +74,6 @@ int sx_pk_list_ik_inslots(sx_pk_req *req, unsigned int key, struct sx_pk_slot *i
 	int i = 0;
 	const struct sx_pk_capabilities *caps;
 
-	caps = sx_pk_fetch_capabilities();
-
-	if (!caps->ik_opsz) {
-		sx_pk_release_req(req);
-		return SX_ERR_IK_NOT_READY;
-	}
-
-	int max_opsz = caps->max_gfp_opsz;
-
-	req->op_size = caps->ik_opsz;
-	uint32_t rval = req->cmd->cmdcode & 0x301;
-
 	if (req->cmd->cmdcode == PK_OP_IK_EXIT) {
 		req->ik_mode = 0;
 	} else {
@@ -100,6 +88,18 @@ int sx_pk_list_ik_inslots(sx_pk_req *req, unsigned int key, struct sx_pk_slot *i
 			req->ik_mode = 1;
 		}
 	}
+
+	caps = sx_pk_fetch_capabilities();
+
+	if (!caps->ik_opsz) {
+		sx_pk_release_req(req);
+		return SX_ERR_IK_NOT_READY;
+	}
+
+	int max_opsz = caps->max_gfp_opsz;
+
+	req->op_size = caps->ik_opsz;
+	uint32_t rval = req->cmd->cmdcode & 0x301;
 
 	/* Write IK cmd register */
 	sx_pk_wrreg(&req->regs, IK_REG_PK_COMMAND, rval);


### PR DESCRIPTION
Updates IKG loader to the new strings and make use of the platform key ids header file for the domain defines.