### PR TITLE
applications: nrf_desktop: Disable USB remote wakeup on nRF54H20

### DIFF
--- a/applications/nrf_desktop/src/modules/Kconfig.usb_state
+++ b/applications/nrf_desktop/src/modules/Kconfig.usb_state
@@ -16,9 +16,14 @@ config DESKTOP_USB_REMOTE_WAKEUP
 	bool "Enable USB remote wakeup"
 	default y
 	depends on DESKTOP_USB_PM_ENABLE
+	depends on !UDC_DWC2
 	help
 	  Enable USB remote wakeup functionality. The USB wakeup request is
 	  triggered on wake_up_event.
+
+	  The DWC2 USB device controller driver used by the nRF54H20 SoC does
+	  not support the remote wakeup capability. Because of that, the feature
+	  is disabled in the configuration.
 
 config DESKTOP_USB_SUBSCRIBER_REPORT_PRIORITY
 	int "USB HID reports subscriber priority"

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -244,6 +244,8 @@ nRF Desktop
     For details, see :ref:`nrf_desktop_usb_state_sof_synchronization`.
   * Local HID report buffering in :ref:`nrf_desktop_usb_state`.
     This ensures that the memory buffer passed to the USB next stack is valid until a HID report is sent and allows to enqueue up to two HID input reports for a USB HID instance (used only when :ref:`CONFIG_DESKTOP_USB_HID_REPORT_SENT_ON_SOF <config_desktop_app_options>` Kconfig option is enabled).
+  * Kconfig dependency that prevents enabling USB remote wakeup (:ref:`CONFIG_DESKTOP_USB_REMOTE_WAKEUP <config_desktop_app_options>`) for the nRF54H20 SoC.
+    The DWC2 USB device controller driver used by the nRF54H20 SoC does not support the remote wakeup capability.
 
 * Updated:
 


### PR DESCRIPTION
The USB remote wakeup is not yet supported by DWC2 USB device controller driver. Disable the feature in application configuration.

Jira: NCSDK-28559