### PR TITLE
tests: benchmarks: multicore: idle: use exit-latency-us

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -314,6 +314,7 @@ Kconfig*                                  @tejlmand
 /subsys/zigbee/                           @milewr
 /tests/                                   @PerMac @katgiadla
 /tests/benchmarks/multicore/              @carlescufi
+/tests/benchmarks/multicore/idle/         @adamkondraciuk @nrfconnect/ncs-low-level-test
 /tests/bluetooth/tester/                  @carlescufi @nrfconnect/ncs-paladin
 /tests/bluetooth/iso/                     @nrfconnect/ncs-audio @Frodevan
 /tests/subsys/nrf_compress/               @nordicjm

--- a/tests/benchmarks/multicore/idle/boards/nrf54h20dk_nrf54h20_cpuapp_s2ram.overlay
+++ b/tests/benchmarks/multicore/idle/boards/nrf54h20dk_nrf54h20_cpuapp_s2ram.overlay
@@ -16,6 +16,8 @@
                        compatible = "zephyr,power-state";
                        power-state-name = "suspend-to-ram";
                        min-residency-us = <800000>;
+                       /* TODO: replace with a busy loop in S2RAM entering procedure; replace 1000 with real value here */
+                       exit-latency-us = <1000>;
                };
        };
 };


### PR DESCRIPTION
Set exit-latency-us for 1ms.