### PR TITLE
samples: matter: add record to light bulb matter sample

### DIFF
--- a/samples/matter/light_bulb/sample.yaml
+++ b/samples/matter/light_bulb/sample.yaml
@@ -75,13 +75,22 @@ tests:
     build_only: true
     extra_args: CONFIG_CHIP_PERSISTENT_SUBSCRIPTIONS=y
       CONFIG_CHIP_MEMORY_PROFILING=y CONFIG_SHELL_MINIMAL=y
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf7002dk/nrf5340/cpuapp
+    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
       nrf54l15pdk/nrf54l15/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
-      - nrf7002dk/nrf5340/cpuapp
       - nrf54l15pdk/nrf54l15/cpuapp
+    tags: sysbuild ci_samples_matter
+  sample.matter.light_bulb.lto.memory_profiling.persistent_subscriptions:
+    sysbuild: true
+    build_only: true
+    extra_args: CONFIG_CHIP_PERSISTENT_SUBSCRIPTIONS=y
+      CONFIG_CHIP_MEMORY_PROFILING=y CONFIG_SHELL_MINIMAL=y CONFIG_LTO=y
+      CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+    platform_allow: nrf7002dk/nrf5340/cpuapp
+    integration_platforms:
+      - nrf7002dk/nrf5340/cpuapp
     tags: sysbuild ci_samples_matter
   sample.matter.light_bulb.aws:
     sysbuild: true


### PR DESCRIPTION
Sample configuration enable testing memory load on nRF7002. The default configuration does not fit into the SoC size, thus the LTO needs to be enabled.