### PR TITLE
cracen: Fix KMU encryption key derivation

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/key_management.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/key_management.c
@@ -1326,9 +1326,12 @@ psa_status_t cracen_export_key(const psa_key_attributes_t *attributes, const uin
 		/* The keys will already be in the key buffer as they got loaded their by a previous
 		 * call to cracen_get_builtin_key or cached in the memory.
 		 */
-		if (PSA_KEY_TYPE_ECC_GET_FAMILY(psa_get_key_type(attributes)) ==
-		    PSA_ECC_FAMILY_TWISTED_EDWARDS) {
+		psa_ecc_family_t ecc_fam =
+			PSA_KEY_TYPE_ECC_GET_FAMILY(psa_get_key_type(attributes));
+		if (ecc_fam == PSA_ECC_FAMILY_TWISTED_EDWARDS ||
+		    ecc_fam == PSA_ECC_FAMILY_SECP_R1) {
 			memcpy(data, key_buffer, key_buffer_size);
+			*data_length = key_buffer_size;
 			return PSA_SUCCESS;
 		}
 


### PR DESCRIPTION
Wrong input type used for CMAC kdf.