### PR TITLE
samples: matter: Enable Fprotect to secure factory data.

### DIFF
--- a/samples/matter/light_bulb/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/light_bulb/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -9,17 +9,6 @@ CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 
 CONFIG_FPU=n
 CONFIG_PM=n
-CONFIG_HWINFO_NRF=n
-
-# TODO: Workaround to be removed once Zephyr's CONFIG_FPROTECT is supported on nRF54L
-CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT=n
-
-# Currently, without tickless kernel, the SYSCOUNTER value after the software
-# reset is not set properly and due to that the first system interrupt is not called
-# in the proper time - the SYSCOUNTER value is set to the value from before
-# reset + 1. Hence, the reboot time increases more and more.
-# To avoid it enable tickles kernel for mcuboot.
-CONFIG_TICKLESS_KERNEL=y
 
 # nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
 CONFIG_CHIP_MALLOC_SYS_HEAP_SIZE=10240

--- a/samples/matter/light_bulb/boards/nrf54l15pdk_nrf54l15_cpuapp_ns.conf
+++ b/samples/matter/light_bulb/boards/nrf54l15pdk_nrf54l15_cpuapp_ns.conf
@@ -9,9 +9,8 @@ CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 
 CONFIG_FPU=n
 CONFIG_PM=n
-CONFIG_HWINFO_NRF=n
 
-# TODO: Workaround to be removed once Zephyr's CONFIG_FPROTECT is supported on nRF54L
+# TODO: Workaround to be removed once Zephyr's CONFIG_FPROTECT is supported on nRF54L_ns
 CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT=n
 
 # TODO: KRKNWK-19382: Disable NFC commissioning due to an issue with definitions for ns build.

--- a/samples/matter/light_bulb/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/light_bulb/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# TODO: Workaround Fprotect is not supported on nRF54l15 yet.
-CONFIG_FPROTECT=n
 # TODO: Workaround, disable memory guard to avoid false faults in application after boot
 CONFIG_HW_STACK_PROTECTION=n
 
@@ -18,6 +16,11 @@ CONFIG_SPI_NOR=y
 CONFIG_SPI_NOR_SFDP_DEVICETREE=y
 CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
 
+# TODO: NCSDK-28931: Cannot use fprotect twice, so disable it in MCUboot to
+# test protecting Matter factory data. It can be enabled while there is a support
+# for protection more than one region.
+CONFIG_FPROTECT=n
+
 # required by SPI driver
 CONFIG_MULTITHREADING=y
 
@@ -25,3 +28,10 @@ CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y
 
 # Adjust the maximum sectors to the app image size of ~1.4MB
 CONFIG_BOOT_MAX_IMG_SECTORS=512
+
+# Currently, without tickless kernel, the SYSCOUNTER value after the software
+# reset is not set properly and due to that the first system interrupt is not called
+# in the proper time - the SYSCOUNTER value is set to the value from before
+# reset + 1. Hence, the reboot time increases more and more.
+# To avoid it enable tickles kernel for mcuboot.
+CONFIG_TICKLESS_KERNEL=y

--- a/samples/matter/light_switch/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/light_switch/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -9,10 +9,6 @@ CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 
 CONFIG_FPU=n
 CONFIG_PM=n
-CONFIG_HWINFO_NRF=n
-
-# TODO: Workaround to be removed once Zephyr's CONFIG_FPROTECT is supported on nRF54L
-CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT=n
 
 # nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
 CONFIG_CHIP_MALLOC_SYS_HEAP_SIZE=10240

--- a/samples/matter/light_switch/boards/nrf54l15pdk_nrf54l15_cpuapp_ns.conf
+++ b/samples/matter/light_switch/boards/nrf54l15pdk_nrf54l15_cpuapp_ns.conf
@@ -11,7 +11,7 @@ CONFIG_FPU=n
 CONFIG_PM=n
 CONFIG_HWINFO_NRF=n
 
-# TODO: Workaround to be removed once Zephyr's CONFIG_FPROTECT is supported on nRF54L
+# TODO: Workaround to be removed once Zephyr's CONFIG_FPROTECT is supported on nRF54L_ns
 CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT=n
 
 # TODO: KRKNWK-19382: Disable NFC commissioning due to an issue with definitions for ns build.

--- a/samples/matter/light_switch/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/light_switch/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# TODO: Workaround Fprotect is not supported on nRF54l15 yet.
-CONFIG_FPROTECT=n
 # TODO: Workaround, disable memory guard to avoid false faults in application after boot
 CONFIG_HW_STACK_PROTECTION=n
 
@@ -17,6 +15,11 @@ CONFIG_SPI=y
 CONFIG_SPI_NOR=y
 CONFIG_SPI_NOR_SFDP_DEVICETREE=y
 CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
+
+# TODO: NCSDK-28931: Cannot use fprotect twice, so disable it in MCUboot to
+# test protecting Matter factory data. It can be enabled while there is a support
+# for protection more than one region.
+CONFIG_FPROTECT=n
 
 # required by SPI driver
 CONFIG_MULTITHREADING=y

--- a/samples/matter/lock/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/lock/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -9,10 +9,6 @@ CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 
 CONFIG_FPU=n
 CONFIG_PM=n
-CONFIG_HWINFO_NRF=n
-
-# TODO: Workaround to be removed once Zephyr's CONFIG_FPROTECT is supported on nRF54L
-CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT=n
 
 # nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
 CONFIG_CHIP_MALLOC_SYS_HEAP_SIZE=10240

--- a/samples/matter/lock/boards/nrf54l15pdk_nrf54l15_cpuapp_ns.conf
+++ b/samples/matter/lock/boards/nrf54l15pdk_nrf54l15_cpuapp_ns.conf
@@ -11,7 +11,7 @@ CONFIG_FPU=n
 CONFIG_PM=n
 CONFIG_HWINFO_NRF=n
 
-# TODO: Workaround to be removed once Zephyr's CONFIG_FPROTECT is supported on nRF54L
+# TODO: Workaround to be removed once Zephyr's CONFIG_FPROTECT is supported on nRF54L_ns
 CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT=n
 
 # TODO: KRKNWK-19382: Disable NFC commissioning due to an issue with definitions for ns build.

--- a/samples/matter/lock/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/lock/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# TODO: Workaround Fprotect is not supported on nRF54l15 yet.
-CONFIG_FPROTECT=n
 # TODO: Workaround, disable memory guard to avoid false faults in application after boot
 CONFIG_HW_STACK_PROTECTION=n
 
@@ -17,6 +15,11 @@ CONFIG_SPI=y
 CONFIG_SPI_NOR=y
 CONFIG_SPI_NOR_SFDP_DEVICETREE=y
 CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
+
+# TODO: NCSDK-28931: Cannot use fprotect twice, so disable it in MCUboot to
+# test protecting Matter factory data. It can be enabled while there is a support
+# for protection more than one region.
+CONFIG_FPROTECT=n
 
 # required by SPI driver
 CONFIG_MULTITHREADING=y

--- a/samples/matter/template/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/template/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -9,10 +9,6 @@ CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 
 CONFIG_FPU=n
 CONFIG_PM=n
-CONFIG_HWINFO_NRF=n
-
-# TODO: Workaround to be removed once Zephyr's CONFIG_FPROTECT is supported on nRF54L
-CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT=n
 
 # nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
 CONFIG_CHIP_MALLOC_SYS_HEAP_SIZE=10240

--- a/samples/matter/template/boards/nrf54l15pdk_nrf54l15_cpuapp_ns.conf
+++ b/samples/matter/template/boards/nrf54l15pdk_nrf54l15_cpuapp_ns.conf
@@ -11,7 +11,7 @@ CONFIG_FPU=n
 CONFIG_PM=n
 CONFIG_HWINFO_NRF=n
 
-# TODO: Workaround to be removed once Zephyr's CONFIG_FPROTECT is supported on nRF54L
+# TODO: Workaround to be removed once Zephyr's CONFIG_FPROTECT is supported on nRF54L_ns
 CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT=n
 
 # nRF54L15 requires bigger stack sizes than nRF52/nRF53 families

--- a/samples/matter/template/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/template/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# TODO: Workaround Fprotect is not supported on nRF54l15 yet.
-CONFIG_FPROTECT=n
 # TODO: Workaround, disable memory guard to avoid false faults in application after boot
 CONFIG_HW_STACK_PROTECTION=n
 
@@ -17,6 +15,11 @@ CONFIG_SPI=y
 CONFIG_SPI_NOR=y
 CONFIG_SPI_NOR_SFDP_DEVICETREE=y
 CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
+
+# TODO: NCSDK-28931: Cannot use fprotect twice, so disable it in MCUboot to
+# test protecting Matter factory data. It can be enabled while there is a support
+# for protection more than one region.
+CONFIG_FPROTECT=n
 
 # required by SPI driver
 CONFIG_MULTITHREADING=y

--- a/samples/matter/template/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp_internal.conf
+++ b/samples/matter/template/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp_internal.conf
@@ -4,7 +4,9 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# TODO: Workaround Fprotect is not supported on nRF54l15 yet.
+# TODO: NCSDK-28931: Cannot use fprotect twice, so disable it in MCUboot to
+# test protecting Matter factory data. It can be enabled while there is a support
+# for protection more than one region.
 CONFIG_FPROTECT=n
 # TODO: Workaround, disable memory guard to avoid false faults in application after boot
 CONFIG_HW_STACK_PROTECTION=n

--- a/samples/matter/thermostat/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/thermostat/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -9,10 +9,6 @@ CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 
 CONFIG_FPU=n
 CONFIG_PM=n
-CONFIG_HWINFO_NRF=n
-
-# TODO: Workaround to be removed once Zephyr's CONFIG_FPROTECT is supported on nRF54L
-CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT=n
 
 # nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
 CONFIG_CHIP_MALLOC_SYS_HEAP_SIZE=10240

--- a/samples/matter/thermostat/boards/nrf54l15pdk_nrf54l15_cpuapp_ns.conf
+++ b/samples/matter/thermostat/boards/nrf54l15pdk_nrf54l15_cpuapp_ns.conf
@@ -11,7 +11,7 @@ CONFIG_FPU=n
 CONFIG_PM=n
 CONFIG_HWINFO_NRF=n
 
-# TODO: Workaround to be removed once Zephyr's CONFIG_FPROTECT is supported on nRF54L
+# TODO: Workaround to be removed once Zephyr's CONFIG_FPROTECT is supported on nRF54L_ns
 CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT=n
 
 # TODO: KRKNWK-19382: Disable NFC commissioning due to an issue with definitions for ns build.

--- a/samples/matter/thermostat/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/thermostat/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# TODO: Workaround Fprotect is not supported on nRF54l15 yet.
-CONFIG_FPROTECT=n
 # TODO: Workaround, disable memory guard to avoid false faults in application after boot
 CONFIG_HW_STACK_PROTECTION=n
 
@@ -17,6 +15,11 @@ CONFIG_SPI=y
 CONFIG_SPI_NOR=y
 CONFIG_SPI_NOR_SFDP_DEVICETREE=y
 CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
+
+# TODO: NCSDK-28931: Cannot use fprotect twice, so disable it in MCUboot to
+# test protecting Matter factory data. It can be enabled while there is a support
+# for protection more than one region.
+CONFIG_FPROTECT=n
 
 # required by SPI driver
 CONFIG_MULTITHREADING=y

--- a/samples/matter/window_covering/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/window_covering/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -9,10 +9,6 @@ CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 
 CONFIG_FPU=n
 CONFIG_PM=n
-CONFIG_HWINFO_NRF=n
-
-# TODO: Workaround to be removed once Zephyr's CONFIG_FPROTECT is supported on nRF54L
-CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT=n
 
 # nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
 CONFIG_CHIP_MALLOC_SYS_HEAP_SIZE=10240

--- a/samples/matter/window_covering/boards/nrf54l15pdk_nrf54l15_cpuapp_ns.conf
+++ b/samples/matter/window_covering/boards/nrf54l15pdk_nrf54l15_cpuapp_ns.conf
@@ -11,7 +11,7 @@ CONFIG_FPU=n
 CONFIG_PM=n
 CONFIG_HWINFO_NRF=n
 
-# TODO: Workaround to be removed once Zephyr's CONFIG_FPROTECT is supported on nRF54L
+# TODO: Workaround to be removed once Zephyr's CONFIG_FPROTECT is supported on nRF54L_ns
 CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT=n
 
 # TODO: KRKNWK-19382: Disable NFC commissioning due to an issue with definitions for ns build.

--- a/samples/matter/window_covering/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/window_covering/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# TODO: Workaround Fprotect is not supported on nRF54l15 yet.
-CONFIG_FPROTECT=n
 # TODO: Workaround, disable memory guard to avoid false faults in application after boot
 CONFIG_HW_STACK_PROTECTION=n
 
@@ -17,6 +15,11 @@ CONFIG_SPI=y
 CONFIG_SPI_NOR=y
 CONFIG_SPI_NOR_SFDP_DEVICETREE=y
 CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
+
+# TODO: NCSDK-28931: Cannot use fprotect twice, so disable it in MCUboot to
+# test protecting Matter factory data. It can be enabled while there is a support
+# for protection more than one region.
+CONFIG_FPROTECT=n
 
 # required by SPI driver
 CONFIG_MULTITHREADING=y


### PR DESCRIPTION
Enabled FPROTECT in the Matter samples working on nRF54L15 to protect Matter Factory Data.