### PR TITLE
samples: matter: add error logs to key migration process.

### DIFF
--- a/samples/matter/common/src/migration/migration_manager.cpp
+++ b/samples/matter/common/src/migration/migration_manager.cpp
@@ -11,6 +11,9 @@
 #include <crypto/OperationalKeystore.h>
 #include <crypto/PersistentStorageOperationalKeystore.h>
 
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(app, CONFIG_CHIP_APP_LOG_LEVEL);
+
 namespace Nrf::Matter
 {
 namespace Migration
@@ -32,12 +35,14 @@ namespace Migration
 		for (const chip::FabricInfo &fabric : chip::Server::GetInstance().GetFabricTable()) {
 			err = keystore->MigrateOpKeypairForFabric(fabric.GetFabricIndex(), obsoleteKeystore);
 			if (CHIP_NO_ERROR != err) {
+				LOG_ERR("Cannot migrate %d fabric to PSA crypto storage", fabric.GetFabricIndex());
 				break;
 			}
 		}
 
 #ifdef CONFIG_NCS_SAMPLE_MATTER_FACTORY_RESET_ON_KEY_MIGRATION_FAILURE
 		if (CHIP_NO_ERROR != err) {
+			LOG_ERR("Keystore migration failure due to %s. Performing Factory reset...", err.AsString());
 			GroupDataProviderImpl::Instance().WillBeFactoryReset();
 			chip::Server::GetInstance().ScheduleFactoryReset();
 			/* Return a success to not block the Matter event Loop and allow to call scheduled factory


### PR DESCRIPTION
It is expected to see some error logs if the operational keys migration fails.