### PR TITLE
suit: Changes in build system for extracting images to caches

### DIFF
--- a/cmake/sysbuild/suit_utilities.cmake
+++ b/cmake/sysbuild/suit_utilities.cmake
@@ -87,3 +87,13 @@ function(suit_create_envelope input_file output_file create_signature)
     suit_sign_envelope(${output_file} ${output_file})
   endif()
 endfunction()
+
+function(suit_create_cache_partition args)
+  set_property(
+    GLOBAL APPEND PROPERTY SUIT_POST_BUILD_COMMANDS
+    COMMAND ${PYTHON_EXECUTABLE} ${SUIT_GENERATOR_CLI_SCRIPT}
+    cache_create
+    ${args}
+    BYPRODUCTS ${output_file}
+  )
+endfunction()

--- a/config/suit/templates/nrf54h20/default/v1/app_envelope.yaml.jinja2
+++ b/config/suit/templates/nrf54h20/default/v1/app_envelope.yaml.jinja2
@@ -77,7 +77,11 @@ SUIT_Envelope_Tagged:
     suit-install:
     - suit-directive-set-component-index: 1
     - suit-directive-override-parameters:
+{%- if 'CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI' in application['config'] and application['config']['CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI'] != '' %}
+        suit-parameter-uri: '{{ application['config']['CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI'] }}'
+{%- else %}
         suit-parameter-uri: '#{{ application['name'] }}'
+{%- endif %}
         suit-parameter-image-digest:
           suit-digest-algorithm-id: cose-alg-sha-256
           suit-digest-bytes:
@@ -125,7 +129,11 @@ SUIT_Envelope_Tagged:
     suit-candidate-verification:
     - suit-directive-set-component-index: 1
     - suit-directive-override-parameters:
+{%- if 'CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI' in application['config'] and application['config']['CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI'] != '' %}
+        suit-parameter-uri: '{{ application['config']['CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI'] }}'
+{%- else %}
         suit-parameter-uri: '#{{ application['name'] }}'
+{%- endif %}
         suit-parameter-image-digest:
           suit-digest-algorithm-id: cose-alg-sha-256
           suit-digest-bytes:
@@ -158,5 +166,7 @@ SUIT_Envelope_Tagged:
         suit-text-model-info: The nRF54H20 application core
         suit-text-component-description: Sample application core FW
         suit-text-component-version: v1.0.0
+{%- if 'CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE' not in application['config'] or application['config']['CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE'] == '' %}
   suit-integrated-payloads:
     '#{{ application['name'] }}': {{ application['binary'] }}
+{%- endif %}

--- a/config/suit/templates/nrf54h20/default/v1/rad_envelope.yaml.jinja2
+++ b/config/suit/templates/nrf54h20/default/v1/rad_envelope.yaml.jinja2
@@ -82,7 +82,11 @@ SUIT_Envelope_Tagged:
     suit-install:
     - suit-directive-set-component-index: 1
     - suit-directive-override-parameters:
+{%- if 'CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI' in radio['config'] and radio['config']['CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI'] != '' %}
+        suit-parameter-uri: '{{ radio['config']['CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI'] }}'
+{%- else %}
         suit-parameter-uri: '#{{ radio['name'] }}'
+{%- endif %}
         suit-parameter-image-digest:
           suit-digest-algorithm-id: cose-alg-sha-256
           suit-digest-bytes:
@@ -130,7 +134,11 @@ SUIT_Envelope_Tagged:
     suit-candidate-verification:
     - suit-directive-set-component-index: 1
     - suit-directive-override-parameters:
+{%- if 'CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI' in radio['config'] and radio['config']['CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI'] != '' %}
+        suit-parameter-uri: '{{ radio['config']['CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI'] }}'
+{%- else %}
         suit-parameter-uri: '#{{ radio['name'] }}'
+{%- endif %}
         suit-parameter-image-digest:
           suit-digest-algorithm-id: cose-alg-sha-256
           suit-digest-bytes:
@@ -163,5 +171,8 @@ SUIT_Envelope_Tagged:
         suit-text-model-info: The nRF54H20 radio core
         suit-text-component-description: Sample radio core FW
         suit-text-component-version: v1.0.0
+
+{%- if 'CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE' not in radio['config'] or radio['config']['CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE'] == '' %}
   suit-integrated-payloads:
     '#{{ radio['name'] }}': {{ radio['binary'] }}
+{%- endif %}

--- a/config/suit/templates/nrf54h20/matter/v1/app_envelope.yaml.jinja2
+++ b/config/suit/templates/nrf54h20/matter/v1/app_envelope.yaml.jinja2
@@ -115,7 +115,11 @@ SUIT_Envelope_Tagged:
 {%- endif %}
     - suit-directive-set-component-index: 1
     - suit-directive-override-parameters:
+{%- if 'CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI' in application['config'] and application['config']['CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI'] != '' %}
+        suit-parameter-uri: '{{ application['config']['CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI'] }}'
+{%- else %}
         suit-parameter-uri: '#{{ application['name'] }}'
+{%- endif %}
         suit-parameter-image-digest:
           suit-digest-algorithm-id: cose-alg-sha-256
           suit-digest-bytes:
@@ -154,7 +158,9 @@ SUIT_Envelope_Tagged:
         suit-text-component-description: Sample application core FW
         suit-text-component-version: v1.0.0
   suit-integrated-payloads:
+{%- if 'CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE' not in application['config'] or application['config']['CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE'] == '' %}
     '#{{ application['name'] }}': {{ application['binary'] }}
+{%- endif %}
 {%- if flash_companion is defined %}
     '#{{ flash_companion['name'] }}': {{ flash_companion['binary'] }}
 {%- endif %}

--- a/config/suit/templates/nrf54h20/matter/v1/rad_envelope.yaml.jinja2
+++ b/config/suit/templates/nrf54h20/matter/v1/rad_envelope.yaml.jinja2
@@ -78,7 +78,11 @@ SUIT_Envelope_Tagged:
     suit-install:
     - suit-directive-set-component-index: 1
     - suit-directive-override-parameters:
+{%- if 'CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI' in radio['config'] and radio['config']['CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI'] != '' %}
+        suit-parameter-uri: '{{ radio['config']['CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI'] }}'
+{%- else %}
         suit-parameter-uri: '#{{ radio['name'] }}'
+{%- endif %}
     - suit-directive-fetch:
       - suit-send-record-failure
     - suit-condition-image-match:
@@ -112,5 +116,7 @@ SUIT_Envelope_Tagged:
         suit-text-model-info: The nRF54H20 radio core
         suit-text-component-description: Sample radio core FW
         suit-text-component-version: v1.0.0
+{%- if 'CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE' not in radio['config'] or radio['config']['CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE'] == '' %}
   suit-integrated-payloads:
     '#{{ radio['name'] }}': {{ radio['binary'] }}
+{%- endif %}

--- a/samples/suit/smp_transfer/sample.yaml
+++ b/samples/suit/smp_transfer/sample.yaml
@@ -52,3 +52,22 @@ tests:
       - OVERLAY_CONFIG="sysbuild/smp_transfer_bt.conf"
       - SB_OVERLAY_CONFIG="sysbuild_bt.conf"
     tags: suit bluetooth ci_samples_suit
+
+  sample.suit.smp_transfer.full.extflash.extracted_cache:
+    extra_args:
+      - FILE_SUFFIX=extflash
+      - SUIT_DFU_CACHE_PARTITION_1_EB_SIZE=4096
+    extra_configs:
+      - CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE=y
+    tags: suit ci_samples_suit
+
+  sample.suit.smp_transfer.full.extflash.bt.extracted_cache:
+    extra_args:
+      - FILE_SUFFIX=extflash
+      - OVERLAY_CONFIG="sysbuild/smp_transfer_bt.conf"
+      - SB_OVERLAY_CONFIG="sysbuild_bt.conf"
+      - SUIT_DFU_CACHE_PARTITION_1_EB_SIZE=4096
+      - hci_ipc_CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE=y
+    extra_configs:
+      - CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE=y
+    tags: suit bluetooth ci_samples_suit

--- a/samples/suit/smp_transfer/suit/nrf54h20/app_envelope_extflash.yaml.jinja2
+++ b/samples/suit/smp_transfer/suit/nrf54h20/app_envelope_extflash.yaml.jinja2
@@ -86,12 +86,14 @@ SUIT_Envelope_Tagged:
     suit-current-version: {{ DEFAULT_VERSION }}
 {%- endif %}
 
+{%- if 'CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE' not in application['config'] or application['config']['CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE'] == '' %}
     suit-payload-fetch:
     - suit-directive-set-component-index: 2
     - suit-directive-override-parameters:
         suit-parameter-uri: 'file://{{ application['filename'] }}'
     - suit-directive-fetch:
       - suit-send-record-failure
+{%- endif %}
     suit-install:
 {%- if flash_companion is defined %}
     - suit-directive-set-component-index: 1
@@ -123,7 +125,11 @@ SUIT_Envelope_Tagged:
 {%- endif %}
     - suit-directive-set-component-index: 1
     - suit-directive-override-parameters:
+{%- if 'CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI' in application['config'] and application['config']['CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI'] != '' %}
+        suit-parameter-uri: '{{ application['config']['CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI'] }}'
+{%- else %}
         suit-parameter-uri: 'file://{{ application['filename'] }}'
+{%- endif %}
         suit-parameter-image-digest:
           suit-digest-algorithm-id: cose-alg-sha-256
           suit-digest-bytes:

--- a/samples/suit/smp_transfer/suit/nrf54h20/rad_envelope_extflash.yaml.jinja2
+++ b/samples/suit/smp_transfer/suit/nrf54h20/rad_envelope_extflash.yaml.jinja2
@@ -77,16 +77,22 @@ SUIT_Envelope_Tagged:
     suit-current-version: {{ DEFAULT_VERSION }}
 {%- endif %}
 
+{%- if 'CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE' not in radio['config'] or radio['config']['CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE'] == '' %}
     suit-payload-fetch:
     - suit-directive-set-component-index: 2
     - suit-directive-override-parameters:
         suit-parameter-uri: 'file://{{ radio['filename'] }}'
     - suit-directive-fetch:
       - suit-send-record-failure
+{%- endif %}
     suit-install:
     - suit-directive-set-component-index: 1
     - suit-directive-override-parameters:
+{%- if 'CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI' in radio['config'] and radio['config']['CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI'] != '' %}
+        suit-parameter-uri: '{{ radio['config']['CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI'] }}'
+{%- else %}
         suit-parameter-uri: 'file://{{ radio['filename'] }}'
+{%- endif %}
     - suit-directive-fetch:
       - suit-send-record-failure
     - suit-condition-image-match:

--- a/west.yml
+++ b/west.yml
@@ -254,7 +254,7 @@ manifest:
           upstream-sha: c6eaeda5a1c1c5dbb24dce7e027340cb8893a77b
           compare-by-default: false
     - name: suit-generator
-      revision: 97ef5bdd41716aa7fa21a0f0c149a66d1f91ab8d
+      revision: 4372d27e940798cb596d18d90affa9d62d9d2564
       path: modules/lib/suit-generator
     - name: suit-processor
       revision: ee58d543994256d545c692e14badf3efa9830237


### PR DESCRIPTION
This commit introduces several changes which allow to severe firmware images from SUIT envelopes and extract them to raw cache files, which can then be flashed separately to the device.