### PR TITLE
net: nrf_provisioning: Add support for socket option SO_KEEPOPEN

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -777,11 +777,15 @@ Libraries for networking
 
 * :ref:`lib_nrf_cloud_fota` library:
 
-* Updated:
+  * Updated:
 
-  * The :kconfig:option:`CONFIG_NRF_CLOUD_FOTA_DOWNLOAD_FRAGMENT_SIZE` Kconfig option is made available and used also when the :kconfig:option:`CONFIG_NRF_CLOUD_FOTA_POLL` Kconfig option is enabled.
-    The range of the option is now from 128 to 1900 bytes, and the default value is 1700 bytes.
-  * The function :c:func:`nrf_cloud_fota_poll_process` can now be used asynchrounously if a callback to handle errors is provided.
+    * The :kconfig:option:`CONFIG_NRF_CLOUD_FOTA_DOWNLOAD_FRAGMENT_SIZE` Kconfig option to be available and used also when the :kconfig:option:`CONFIG_NRF_CLOUD_FOTA_POLL` Kconfig option is enabled.
+      The range of the option is now from 128 to 1900 bytes, and the default value is 1700 bytes.
+    * The function :c:func:`nrf_cloud_fota_poll_process` to be used asynchrounously if a callback to handle errors is provided.
+
+* :ref:`lib_nrf_provisioning` library:
+
+  * Added support for the ``SO_KEEPOPEN`` socket option to keep the socket open even during PDN disconnect and reconnect.
 
 Libraries for NFC
 -----------------

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning.c
@@ -625,6 +625,8 @@ int nrf_provisioning_req(void)
 			LOG_ERR("Invalid exchange");
 		} else if (ret == -ECONNREFUSED) {
 			LOG_ERR("Connection refused, client exits");
+			LOG_WRN("Please check the CA certificate stored in sectag "
+				STRINGIFY(CONFIG_NRF_PROVISIONING_ROOT_CA_SEC_TAG)"");
 			k_mutex_lock(&np_mtx, K_FOREVER);
 			initialized = false;
 			k_mutex_unlock(&np_mtx);


### PR DESCRIPTION
Enable socket option SO_KEEPOPEN for nRF91x1 devices. This allows keeping the socket open while PDN is down, or modem is in flight mode.

Print a message to check the CA certificate if connection is refused.