### PR TITLE
samples: matter: enable dual-bank dfu config for template on nRF54L15

### DIFF
--- a/samples/matter/template/boards/nrf54l15pdk_nrf54l15_cpuapp_internal.conf
+++ b/samples/matter/template/boards/nrf54l15pdk_nrf54l15_cpuapp_internal.conf
@@ -1,0 +1,54 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Multirole is the only currently supported role by SoftDevice.
+CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
+
+CONFIG_FPU=n
+CONFIG_PM=n
+CONFIG_HWINFO_NRF=n
+
+# TODO: Workaround to be removed once Zephyr's CONFIG_FPROTECT is supported on nRF54L
+CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT=n
+
+# nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
+CONFIG_CHIP_MALLOC_SYS_HEAP_SIZE=10240
+CONFIG_MPSL_WORK_STACK_SIZE=2048
+CONFIG_CHIP_TASK_STACK_SIZE=7168
+
+# Set the NVS sector count to match the settings partition size that is 40 kB for this application.
+CONFIG_SETTINGS_NVS_SECTOR_COUNT=10
+
+# Release Configuration
+
+# Enable system reset on fatal error
+CONFIG_RESET_ON_FATAL_ERROR=y
+
+# Disable all debug features
+CONFIG_THREAD_NAME=n
+CONFIG_MPU_STACK_GUARD=n
+CONFIG_CHIP_LIB_SHELL=n
+CONFIG_USE_SEGGER_RTT=n
+CONFIG_SHELL=n
+CONFIG_OPENTHREAD_SHELL=n
+CONFIG_CONSOLE=n
+CONFIG_UART_CONSOLE=n
+CONFIG_SERIAL=n
+CONFIG_LOG=n
+CONFIG_LOG_MODE_MINIMAL=n
+CONFIG_ASSERT_VERBOSE=n
+CONFIG_ASSERT_NO_FILE_INFO=y
+CONFIG_PRINTK=n
+CONFIG_PRINTK_SYNC=n
+CONFIG_THREAD_NAME=n
+CONFIG_BOOT_BANNER=n
+
+# Enable Watchdog
+CONFIG_NCS_SAMPLE_MATTER_WATCHDOG=y
+
+# Enable LTO
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y

--- a/samples/matter/template/boards/nrf54l15pdk_nrf54l15_cpuapp_internal.overlay
+++ b/samples/matter/template/boards/nrf54l15pdk_nrf54l15_cpuapp_internal.overlay
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	aliases {
+		// Use watchdog wdt31 as the application watchdog
+		watchdog0 = &wdt31;
+	};
+
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};
+
+// restore full RRAM and SRAM space - by default some parts are dedicated to FLRP
+&cpuapp_rram {
+	reg = <0x0 DT_SIZE_K(1524)>;
+};
+
+&cpuapp_sram {
+	reg = <0x20000000 DT_SIZE_K(256)>;
+	ranges = <0x0 0x20000000  0x40000>;
+};
+
+// TODO: re-enable HWFC once it's fixed
+&uart20 {
+	/delete-property/ hw-flow-control;
+};
+
+&mx25r64 {
+	status = "okay";
+};
+
+&wdt31 {
+	status = "okay";
+};

--- a/samples/matter/template/pm_static_nrf54l15pdk_nrf54l15_cpuapp_internal.yml
+++ b/samples/matter/template/pm_static_nrf54l15pdk_nrf54l15_cpuapp_internal.yml
@@ -9,38 +9,38 @@ mcuboot_pad:
 app:
   address: 0x7800
   region: flash_primary
-  size: 0xb4000
+  size: 0xb5000
 mcuboot_primary:
   address: 0x7000
   orig_span: &id001
   - app
   - mcuboot_pad
   region: flash_primary
-  size: 0xb4800
+  size: 0xb5800
   span: *id001
 mcuboot_primary_app:
   address: 0x7800
   orig_span: &id002
   - app
   region: flash_primary
-  size: 0xb4000
+  size: 0xb5000
   span: *id002
 mcuboot_secondary:
-  address: 0xbb800
+  address: 0xbc800
   orig_span: &id003
   - mcuboot_secondary_pad
   - mcuboot_secondary_app
   region: flash_primary
-  size: 0xb4800
+  size: 0xb5800
   span: *id003
 mcuboot_secondary_pad:
   region: flash_primary
-  address: 0xbb800
+  address: 0xbc800
   size: 0x800
 mcuboot_secondary_app:
   region: flash_primary
-  address: 0xbc000
-  size: 0xb4000
+  address: 0xbd000
+  size: 0xb5000
 factory_data:
   address: 0x172000
   region: flash_primary

--- a/samples/matter/template/sample.yaml
+++ b/samples/matter/template/sample.yaml
@@ -93,3 +93,12 @@ tests:
     platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf7002dk/nrf5340/cpuapp
       nrf54l15pdk/nrf54l15/cpuapp nrf54h20dk/nrf54h20/cpuapp
     tags: sysbuild ci_samples_matter
+  sample.matter.template.release.internal.smp_dfu:
+    sysbuild: true
+    build_only: true
+    extra_args: FILE_SUFFIX=internal CONFIG_CHIP_DFU_OVER_BT_SMP=y
+      CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS=y
+    integration_platforms:
+      - nrf54l15pdk/nrf54l15/cpuapp
+    platform_allow: nrf54l15pdk/nrf54l15/cpuapp
+    tags: sysbuild ci_samples_matter


### PR DESCRIPTION
Internal DFU (dual bank) configuration has not been defined in sample.yaml, thus additional configuration has been defined. Internal configuration is an release configuration with enabled LTO to reduce size as much as possibile.
Additionaly aligned the pm_static for internal configuration.