### PR TITLE
samples: matter: Enable Memory profiling test case for ns build.

### DIFF
--- a/samples/matter/light_bulb/sample.yaml
+++ b/samples/matter/light_bulb/sample.yaml
@@ -76,12 +76,13 @@ tests:
     extra_args: CONFIG_CHIP_PERSISTENT_SUBSCRIPTIONS=y
       CONFIG_CHIP_MEMORY_PROFILING=y CONFIG_SHELL_MINIMAL=y
     platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf7002dk/nrf5340/cpuapp
-      nrf54l15pdk/nrf54l15/cpuapp
+      nrf54l15pdk/nrf54l15/cpuapp nrf54l15pdk/nrf54l15/cpuapp/ns
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf7002dk/nrf5340/cpuapp
       - nrf54l15pdk/nrf54l15/cpuapp
+      - nrf54l15pdk/nrf54l15/cpuapp/ns
     tags: sysbuild ci_samples_matter
   sample.matter.light_bulb.aws:
     sysbuild: true


### PR DESCRIPTION
Enabled memory profiling test case for nRF54L15 NS build.