### PR TITLE
ci: pip-requirements: do not persist Git credentials

### DIFF
--- a/.github/workflows/pip-requirements.yml
+++ b/.github/workflows/pip-requirements.yml
@@ -22,6 +22,7 @@ jobs:
           token: ${{ secrets.NCS_GITHUB_TOKEN }}
           path: ncs/nrf
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Switch to PR source branch
         working-directory: ncs/nrf


### PR DESCRIPTION
They are not needed after clone, so delete them.