### PR TITLE
nrf_rpc: Add header guard to OT nrfrpc headers.

### DIFF
--- a/subsys/net/openthread/rpc/common/ot_rpc_ids.h
+++ b/subsys/net/openthread/rpc/common/ot_rpc_ids.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#ifndef OT_RPC_IDS_H_
+#define OT_RPC_IDS_H_
+
 /** @brief Command IDs accepted by the OpenThread over RPC client.
  */
 enum ot_rpc_cmd_client {
@@ -64,3 +67,5 @@ enum ot_rpc_cmd_server {
 	OT_RPC_CMD_MESSAGE_GET_OFFSET,
 	OT_RPC_CMD_MESSAGE_READ,
 };
+
+#endif /* OT_RPC_IDS_H_ */

--- a/subsys/net/openthread/rpc/common/ot_rpc_types.h
+++ b/subsys/net/openthread/rpc/common/ot_rpc_types.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#ifndef OT_RPC_TYPES_H_
+#define OT_RPC_TYPES_H_
+
 #include <stdint.h>
 #include <openthread/thread.h>
 
@@ -28,3 +31,5 @@ enum ot_rpc_link_mode_offsets {
 };
 
 typedef uint32_t ot_msg_key;
+
+#endif /* OT_RPC_TYPES_H_ */


### PR DESCRIPTION
Adding header `ifdef` to:
- ot_rpc_ids.h
- ot_rpc_types.h