### PR TITLE
manifest: Bring Zephyr with disabled Cracen RAMs 

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: b063a96d60f4b881114fb99157c7b394daaa4448
+      revision: pull/1983/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Updated soc file in Zephyr to disable Cracen RAMs
on system off.