### PR TITLE
childimage/NSIB: Remove non-functional environmental key support

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -45,6 +45,13 @@ Build and configuration system
 
 * Added the ``SB_CONFIG_MCUBOOT_NRF53_MULTI_IMAGE_UPDATE`` sysbuild Kconfig option that enables updating the network core on the nRF5340 SoC from external flash.
 
+* Removed the non-working support for configuring the NSIB signing key through the environmental or command line variable (``SB_SIGNING_KEY_FILE``) along with child image.
+
+  .. note::
+     This feature has never been functional.
+     To configure the signing key, use any available Kconfig method.
+
+
 Bootloaders and DFU
 ===================
 

--- a/subsys/bootloader/Kconfig
+++ b/subsys/bootloader/Kconfig
@@ -75,9 +75,6 @@ config SB_SIGNING_KEY_FILE
 	  Specifies the private key used for signing the firmware image.
 	  The hash of the corresponding public key is stored as the first
 	  entry in the list of public key hashes in the provision hex file.
-	  This value can also be set by exporting an environment variable
-	  named 'SB_SIGNING_KEY_FILE' or passing
-	  '-DSB_SIGNING_KEY_FILE=/path/to/my/pem' when running cmake.
 	  See also SB_PUBLIC_KEY_FILES.
 
 config SB_SIGNING_COMMAND

--- a/subsys/bootloader/cmake/debug_keys.cmake
+++ b/subsys/bootloader/cmake/debug_keys.cmake
@@ -16,22 +16,6 @@ set(PUB_CMD
   )
 
 # Check if PEM file is specified by user, if not, create one.
-
-# First, check environment variables. Only use if not specified in command line.
-if (DEFINED ENV{SB_SIGNING_KEY_FILE} AND NOT SB_SIGNING_KEY_FILE)
-  if (NOT EXISTS "$ENV{SB_SIGNING_KEY_FILE}")
-    message(FATAL_ERROR "ENV points to non-existing PEM file '$ENV{SB_SIGNING_KEY_FILE}'")
-  else()
-    set(SIGNATURE_PRIVATE_KEY_FILE $ENV{SB_SIGNING_KEY_FILE})
-  endif()
-endif()
-
-# Next, check command line arguments
-if (DEFINED SB_SIGNING_KEY_FILE)
-  set(SIGNATURE_PRIVATE_KEY_FILE ${SB_SIGNING_KEY_FILE})
-endif()
-
-# Check if debug sign key should be generated.
 if( "${CONFIG_SB_SIGNING_KEY_FILE}" STREQUAL "")
   message(WARNING "
     --------------------------------------------------------------


### PR DESCRIPTION
Removes non-workable possibility for configuring signing key using
either environmental or command-line variable (SB_SIGNING_KEY_FILE).
This has never worked.

ref.: NCSDK-28124

similar change was done for the sysbuild (#16154)