### PR TITLE
net: openthread: Introduce OpenThread build report for NCS

### DIFF
--- a/doc/nrf/protocols/thread/certification.rst
+++ b/doc/nrf/protocols/thread/certification.rst
@@ -23,6 +23,9 @@ You can find the certification information for the SoC or the SiP you are using 
 
 Depending on your development approach, you have several certification options when using Nordic Semiconductor devices.
 
+You will need to analyze the :ref:`ug_thread_build_report` to check that there is a proper Thread version and library used for the certification process and that there are no changes that may affect the certification by inheritance.
+Additionally, you may be asked to include the build report during the certification process.
+
 .. _ug_thread_cert_inheritance_without_modifications:
 
 Certification by inheritance without modifications to binaries
@@ -177,3 +180,87 @@ This is valid only for Nordic Semiconductor development kits with a J-Link virtu
 
 To add an nRF52840 DK, drag the nRF52840 DK and drop it on the test bed configuration page.
 After that, the device is configured and the :ref:`proper baud rate (115200) <test_and_optimize>` and COM port are set.
+
+.. _ug_thread_build_report:
+
+OpenThread build report
+***********************
+
+The OpenThread build report contains information about:
+
+   * The current |NCS| and OpenThread revisions.
+   * The Thread feature set and Thread library path.
+   * Changes in the :ref:`nrfxlib:nrfxlib` repository in comparison to the latest |NCS| release.
+
+The report is generated to the output console log, and stored as an additional build artefact in the application build directory.
+
+Generating the OpenThread report is enabled by default if the :kconfig:option:`CONFIG_NET_L2_OPENTHREAD` Kconfig option is set to ``y``.
+This means that it is enabled for all samples that use the Thread stack.
+To disable the generation, set the :kconfig:option:`CONFIG_OPENTHREAD_REPORT` kconfig option to ``n``.
+
+By default, the build artefact name is set as :file:`ot_report.txt`, but you can specify a different name by setting the :kconfig:option:`CONFIG_OPENTHREAD_REPORT_BUILD_ARTEFACT_NAME` kconfig value to the new one.
+
+Depending on if you build the application using the :ref:`nrfxlib:ot_libs` or if you build the application and Thread stack from the source files, you will see the following logs in your build console:
+
+.. tabs::
+
+   .. group-tab:: Using pre-built libraries
+
+      .. code-block::
+
+         ################### OPENTHREAD REPORT ###################
+         + Target device: nrf52840
+         + Thread version: v1.3
+         + OpenThread library feature set: Minimal Thread Device (MTD)
+         + Thread device type: Sleepy End Device (SED)
+         + OpenThread Library: openthread/lib/cortex-m4/soft-float/v1.3/mtd/
+         + OpenThread NCS revision: thread-reference-20230706-819-gd60aaab22
+         + OpenThread NCS SHA: d60aaab22
+         + NCS revision: v2.7.99-cs1-41-g26ef793b91-dirty
+         + NCS SHA: 26ef793b91
+         + No differences in the used Thread library in comparison to the NCS v2.7.0 release.
+         ###################        END        ###################
+
+      The generated build artefact will also include the list of the :ref:`nrfxlib:nrfxlib` repository changes between the current revision and the latest |NCS| release.
+      If there are no changes related to the used Thread library, you can use :ref:`ug_thread_cert_inheritance_without_modifications`.
+      If the report shows any changes detected in the used Thread library, you will need to contact the Thread Group to check if certification by inheritance is still possible.
+
+      An example of the changes detected in the Thread library:
+
+      .. code-block::
+
+         ################### OPENTHREAD REPORT ###################
+         + Target device: nrf52840
+         + Thread version: v1.3
+         + OpenThread library feature set: Minimal Thread Device (MTD)
+         + Thread device type: Sleepy End Device (SED)
+         + OpenThread Library: openthread/lib/cortex-m4/soft-float/v1.3/mtd/
+         + OpenThread NCS revision: thread-reference-20230706-819-gd60aaab22
+         + OpenThread NCS SHA: d60aaab22
+         + NCS revision: v2.7.99-cs1-41-g26ef793b91-dirty
+         + NCS SHA: 26ef793b91
+         + Found differences in the nrfxlib repository in comparison to the NCS v2.7.0 release. See the ot_report.txt report file to learn more.
+         ###################        END        ###################
+
+      You can look at the report file located in the application build directory to see the full list of changes.
+      For example, for the :ref:`ot_cli_sample` sample, you can find a report file in the default location: :file:`cli/build/cli/ot_report.txt`.
+
+   .. group-tab:: From source files
+
+      .. code-block::
+
+         ################### OPENTHREAD REPORT ###################
+         + Target device: nrf52840
+         + Thread version: v1.3
+         + OpenThread library feature set: Minimal Thread Device (MTD)
+         + Thread device type: Sleepy End Device (SED)
+         + OpenThread library has been built from sources
+         + OpenThread NCS revision: thread-reference-20230706-819-gd60aaab22
+         + OpenThread NCS SHA: d60aaab22
+         + NCS revision: v2.7.99-cs1-41-g26ef793b91-dirty
+         + NCS SHA: 26ef793b91
+         ###################        END        ###################
+
+      The information shows that the Thread library has been build from sources, so it cannot be used for :ref:`ug_thread_cert_inheritance_without_modifications`.
+
+..

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -173,7 +173,7 @@ nRF IEEE 802.15.4 radio driver
 Thread
 ------
 
-|no_changes_yet_note|
+* Added the :ref:`ug_thread_build_report` and described how to use it.
 
 Zigbee
 ------
@@ -449,6 +449,8 @@ Matter samples
 
     * Added :ref:`Matter Lock schedule snippet <matter_lock_snippets>`, and updated the documentation to use the snippet.
 
+* Enabled the :ref:`ug_thread_build_report` generation in all samples.
+
 Networking samples
 ------------------
 
@@ -518,7 +520,7 @@ Trusted Firmware-M (TF-M) samples
 Thread samples
 --------------
 
-|no_changes_yet_note|
+* Enabled the :ref:`ug_thread_build_report` generation in all samples.
 
 Zigbee samples
 --------------

--- a/subsys/net/CMakeLists.txt
+++ b/subsys/net/CMakeLists.txt
@@ -7,3 +7,4 @@
 add_subdirectory(lib)
 add_subdirectory_ifdef(CONFIG_OPENTHREAD_RPC openthread/rpc)
 add_subdirectory_ifdef(CONFIG_L2_WIFI_CONNECTIVITY l2_wifi_if_conn)
+add_subdirectory_ifdef(CONFIG_OPENTHREAD_REPORT openthread/report)

--- a/subsys/net/openthread/Kconfig
+++ b/subsys/net/openthread/Kconfig
@@ -150,3 +150,4 @@ endmenu # "OpenThread"
 endif # NET_L2_OPENTHREAD
 
 rsource "rpc/Kconfig"
+rsource "report/Kconfig"

--- a/subsys/net/openthread/report/CMakeLists.txt
+++ b/subsys/net/openthread/report/CMakeLists.txt
@@ -1,0 +1,104 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+include(report_generation_utils.cmake)
+include(${ZEPHYR_NRFXLIB_MODULE_DIR}/openthread/cmake/extensions.cmake)
+
+# Remove the existing file before the next report generation
+set(ARTEFACT ${CMAKE_BINARY_DIR}/${CONFIG_OPENTHREAD_REPORT_BUILD_ARTEFACT_NAME})
+if(EXISTS ${ARTEFACT})
+    file(REMOVE ${ARTEFACT})
+endif()
+
+ot_report_add_message("################### OPENTHREAD REPORT ###################" TRUE)
+
+# Add basic information
+ot_report_add_message("+ Target device: ${CONFIG_SOC}" TRUE)
+ot_report_add_message("+ Thread version: v${CONFIG_OPENTHREAD_THREAD_VERSION}" TRUE)
+
+# Add feature set
+if(DEFINED CONFIG_OPENTHREAD_NORDIC_LIBRARY_MASTER)
+    set(FEATURE_SET "Master")
+elseif(DEFINED CONFIG_OPENTHREAD_NORDIC_LIBRARY_FTD)
+    set(FEATURE_SET "Full Thread Device (FTD)")
+elseif(DEFINED CONFIG_OPENTHREAD_NORDIC_LIBRARY_MTD)
+    set(FEATURE_SET "Minimal Thread Device (MTD)")
+elseif(DEFINED CONFIG_OPENTHREAD_NORDIC_LIBRARY_RCP)
+    set(FEATURE_SET "Radio Coprocessor (RCP)")
+else()
+    set(FEATURE_SET "Custom")
+endif()
+ot_report_add_message("+ OpenThread library feature set: ${FEATURE_SET}" TRUE)
+
+if(DEFINED CONFIG_OPENTHREAD_MTD_SED)
+    set(DEVICE_TYPE "Sleepy End Device (SED)")
+elseif(DEFINED CONFIG_OPENTHREAD_NORDIC_LIBRARY_MTD)
+    set(DEVICE_TYPE "Minimal End Device (MED)")
+elseif(DEFINED CONFIG_OPENTHREAD_NORDIC_LIBRARY_FTD)
+    set(DEVICE_TYPE "Full End Device (FED)")
+else()
+    set(DEVICE_TYPE "Unknown")
+endif()
+ot_report_add_message("+ Thread device type: ${DEVICE_TYPE}" TRUE)
+
+# Check whether OpenThread is built from library or from sources
+if(CONFIG_OPENTHREAD_SOURCES)
+    ot_report_add_message("+ OpenThread library has been built from sources" TRUE)
+else()
+    openthread_calculate_lib_path("v${CONFIG_OPENTHREAD_THREAD_VERSION}" LIB_PATH)
+    cmake_path(RELATIVE_PATH LIB_PATH BASE_DIRECTORY ${ZEPHYR_NRFXLIB_MODULE_DIR} OUTPUT_VARIABLE LIB_PATH_REL)
+    ot_report_add_message("+ OpenThread Library: ${LIB_PATH_REL}" TRUE)
+endif()
+
+# Get OpenThread revision
+set(OPENTHREAD_VERSION "" CACHE STRING "OpenThread revision")
+if(OPENTHREAD_VERSION STREQUAL "")
+    ot_report_git_version(OPENTHREAD_VERSION ${ZEPHYR_OPENTHREAD_MODULE_DIR})
+    ot_report_add_message("+ OpenThread NCS revision: ${OPENTHREAD_VERSION}" TRUE)
+endif()
+set(OPENTHREAD_SHA "" CACHE STRING "OpenThread revision")
+if(OPENTHREAD_SHA STREQUAL "")
+    ot_report_git_head_sha(OPENTHREAD_SHA ${ZEPHYR_OPENTHREAD_MODULE_DIR})
+    ot_report_add_message("+ OpenThread NCS SHA: ${OPENTHREAD_SHA}" TRUE)
+endif()
+
+# Get NCS revision
+set(NCS_VERSION "" CACHE STRING "NCS revision")
+if(NCS_VERSION STREQUAL "")
+    ot_report_git_version(NCS_VERSION ${ZEPHYR_NRF_MODULE_DIR})
+    ot_report_add_message("+ NCS revision: ${NCS_VERSION}" TRUE)
+endif()
+set(NCS_SHA "" CACHE STRING "NCS revision")
+if(NCS_SHA STREQUAL "")
+    ot_report_git_head_sha(NCS_SHA ${ZEPHYR_NRF_MODULE_DIR})
+    ot_report_add_message("+ NCS SHA: ${NCS_SHA}" TRUE)
+endif()
+
+# Diff of nrfxlib directory between the current and the latest NCS release revisions.
+if(NOT DEFINED CONFIG_OPENTHREAD_SOURCES)
+    # Get NCS version from openthread lib configuration file.
+    file(READ "${LIB_PATH}/openthread_lib_configuration.txt" INSTANCE_FILE_CONTENT)
+    string(REGEX MATCH "NRFXLIB_RELEASE_TAG=([^ \n]+)" MACRO_DEF "${INSTANCE_FILE_CONTENT}")
+    if(NOT ${CMAKE_MATCH_1} STREQUAL "")
+        set(LATEST_NCS_RELEASE ${CMAKE_MATCH_1})
+    else()
+        # Read NRFXLIB commit version if NCS_VERSION is not available - backward compatibility for NCS 2.7.0
+        string(REGEX MATCH "NRFXLIB_commit=([^ -]+)" MACRO_DEF "${INSTANCE_FILE_CONTENT}")
+        set(LATEST_NCS_RELEASE ${CMAKE_MATCH_1})
+    endif()
+
+    set(NRFXLIB_DIFF "" CACHE STRING "nrfxlib diff to the recent revision")
+    ot_report_git_diff(NRFXLIB_DIFF ${LATEST_NCS_RELEASE} ${ZEPHYR_NRFXLIB_MODULE_DIR} "openthread")
+
+    if(NOT NRFXLIB_DIFF STREQUAL "")
+        ot_report_add_message("+ Found differences in the nrfxlib repository in comparison to the NCS ${LATEST_NCS_RELEASE} release. See the ${CONFIG_OPENTHREAD_REPORT_BUILD_ARTEFACT_NAME} report file to learn more." TRUE)
+        ot_report_add_message(${NRFXLIB_DIFF} FALSE)
+    else()
+        ot_report_add_message("+ No differences in the used Thread library in comparison to the NCS ${LATEST_NCS_RELEASE} release." TRUE)
+    endif()
+endif()
+
+ot_report_add_message("###################        END        ###################" TRUE)

--- a/subsys/net/openthread/report/Kconfig
+++ b/subsys/net/openthread/report/Kconfig
@@ -1,0 +1,23 @@
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+menuconfig OPENTHREAD_REPORT
+	bool "OpenThread report generation"
+	default y
+	depends on NET_L2_OPENTHREAD
+	help
+	  Enables report generation that contains the OpenThread version,
+	  NCS revision, OpenThread library build information, List of enabled
+	  Thread features, the diff of nrfxlib directory between the NCS release
+	  version (TAG) and the version that is used by a customer.
+	  The report will be stored as a build artefact (separate .txt file),
+	  or printed to console.
+
+config OPENTHREAD_REPORT_BUILD_ARTEFACT_NAME
+	string "Name of the report .txt file build artefact"
+	depends on OPENTHREAD_REPORT
+	default "ot_report.txt"
+	help
+	  Set the name of the report .txt build artefact.

--- a/subsys/net/openthread/report/report_generation_utils.cmake
+++ b/subsys/net/openthread/report/report_generation_utils.cmake
@@ -1,0 +1,104 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Usage:
+#   ot_report_git_version(<output> <directory>)
+#
+# This function uses the git describe command to read the current revision
+# of the <directory> directory and saves the result in the <output> variable
+#
+#
+# directory: Directory that contains checked out the git repository of which
+#            you want to read the revision.
+# output: Output variable that will contain the read revision.
+#
+function(ot_report_git_version output directory)
+    execute_process(
+        COMMAND git describe --dirty --always
+        WORKING_DIRECTORY ${directory}
+        OUTPUT_VARIABLE GIT_REV OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+    )
+    set(${output} "${GIT_REV}" PARENT_SCOPE)
+endfunction()
+
+# Usage:
+#   ot_report_git_head_sha(<output> <directory>)
+#
+# This function uses the git rev-parse command to read the current revision SHA
+# of the <directory> directory and saves the result in the <output> variable
+#
+#
+# directory: Directory that contains checked out the git repository of which
+#            you want to read the revision SHA.
+# output: Output variable that will contain the read revision SHA.
+#
+function(ot_report_git_head_sha output directory)
+    execute_process(
+        COMMAND git rev-parse --short HEAD
+        WORKING_DIRECTORY ${directory}
+        OUTPUT_VARIABLE GIT_REV OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+    )
+    set(${output} "${GIT_REV}" PARENT_SCOPE)
+endfunction()
+
+# Usage:
+#   ot_report_add_message(<message> <to_stdout>)
+#
+# This function writes the <message> text to the file which is defined by
+# the CONFIG_OPENTHREAD_REPORT_BUILD_ARTEFACT_NAME kconfig value located in the
+# application build directory.
+#
+#
+# If the <to_stdout> argument is set to TRUE then the message will be printed
+# to the stdout console.
+#
+#
+# message: Text message to be written
+# to_stdout: Boolean to decide whether the text message should be shown in the
+#            std console.
+#
+function(ot_report_add_message message to_stdout)
+    if(NOT ${message} STREQUAL "")
+        set(ARTEFACT ${CMAKE_BINARY_DIR}/${CONFIG_OPENTHREAD_REPORT_BUILD_ARTEFACT_NAME})
+        file(APPEND ${ARTEFACT} ${message}\n)
+        if(${to_stdout})
+            message(${message})
+        endif()
+    endif()
+endfunction()
+
+# Usage:
+#   ot_report_git_diff(<output> <base_revision> <base_directory> <subdirectory>)
+#
+# This function generates git difference between the <base_revision> and the current
+# revision that is checked out within the <base_directory>.
+# You can provide the <subdirectory> argument to narrow down the scope of the diff
+# function.
+#
+# For example to compare the current revision of the nrfxlib to the state from
+# NCS 2.7.0 release and take into account only the openthread directory use the following
+# invocation:
+#
+# ot_report_git_diff(MY_VARIABLE v2.7.0 ${ZEPHYR_NRFXLIB_MODULE_DIR} "openthread")
+#
+# OUTPUT: Output variable that contains the git diff.
+# base_revision: The revision to be compared with the current one.
+# base_directory: Directory that contains the git repository of which
+#                 you want to read the revision.
+# subdirectory: A subdirectory within the base_directory to be checked by the git
+#               diff command.
+#
+function(ot_report_git_diff output base_revision base_directory subdirectory)
+    execute_process(
+        COMMAND git diff ${base_revision} -- ":${subdirectory}/*.a" ":${subdirectory}/*.h"
+        WORKING_DIRECTORY ${base_directory}
+        OUTPUT_VARIABLE GIT_REV OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+    )
+    set(${output} "${GIT_REV}" PARENT_SCOPE)
+endfunction()

--- a/west.yml
+++ b/west.yml
@@ -157,7 +157,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 82c2271901d054da32217c5a9622c7ab66639b41
+      revision: a21499e8ac4bbf00e41879ade74dc95a26f7edb9
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
The OpenThread report contains information about the current NCS and OpenThread revisions, Thread feature set, and the
difference between the current and the latest nrfxlib OpenThread directory to detect the potential changes that may impact the Thread work.
The report is shown as a build console log and as a .txt file build artefact.

Described the OpenThread build report and how to use it in the certification process.
Updated release notes.