### PR TITLE
lib: location: Fix GNSS obstructed visibility detection

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -642,6 +642,11 @@ Modem libraries
 
 * :ref:`lib_location` library:
 
+  * Fixed:
+
+    * A bug causing the GNSS obstructed visibility detection to sometimes count only part of the tracked satellites.
+    * A bug causing the GNSS obstructed visibility detection to be sometimes performed twice.
+
   * Removed the unused :ref:`at_cmd_parser_readme` library.
 
 * :ref:`lib_zzhc` library:


### PR DESCRIPTION
Fixed a bug which caused only part of the satellites to be iterated when counting the number of tracked satellites. This was caused by a problem in the satellite C/N0 level check. The check has now been removed, because it is no longer relevant.

Fixed a bug which caused visiblity detection to be sometimes performed twice.