### PR TITLE
tests: benchmarks: multicore: idle: disable CLOCK_CONTROL for s2ram

### DIFF
--- a/tests/benchmarks/multicore/idle/testcase.yaml
+++ b/tests/benchmarks/multicore/idle/testcase.yaml
@@ -68,10 +68,11 @@ tests:
       SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
       CONFIG_PM=y CONFIG_PM_S2RAM=y CONFIG_POWEROFF=y CONFIG_PM_S2RAM_CUSTOM_MARKING=y
       CONFIG_CONSOLE=n CONFIG_UART_CONSOLE=n CONFIG_SERIAL=n CONFIG_GPIO=n CONFIG_BOOT_BANNER=n
-      CONFIG_NRFS_MRAM_SERVICE_ENABLED=n
+      CONFIG_NRFS_MRAM_SERVICE_ENABLED=n CONFIG_CLOCK_CONTROL=n
       remote_CONFIG_PM=y remote_CONFIG_POWEROFF=y remote_CONFIG_CONSOLE=n
       remote_CONFIG_UART_CONSOLE=n remote_CONFIG_SERIAL=n remote_CONFIG_GPIO=n
       remote_CONFIG_BOOT_BANNER=n remote_CONFIG_NRFS_MRAM_SERVICE_ENABLED=n
+      remote_CONFIG_CLOCK_CONTROL=n
       DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_s2ram.overlay"
     harness: pytest
     harness_config:
@@ -88,10 +89,11 @@ tests:
       SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
       CONFIG_PM=y CONFIG_PM_S2RAM=y CONFIG_POWEROFF=y CONFIG_PM_S2RAM_CUSTOM_MARKING=y
       CONFIG_CONSOLE=n CONFIG_UART_CONSOLE=n CONFIG_SERIAL=n CONFIG_GPIO=n CONFIG_BOOT_BANNER=n
-      CONFIG_NRFS_MRAM_SERVICE_ENABLED=n
+      CONFIG_NRFS_MRAM_SERVICE_ENABLED=n CONFIG_CLOCK_CONTROL=n
       remote_CONFIG_PM=y remote_CONFIG_POWEROFF=y remote_CONFIG_CONSOLE=n
       remote_CONFIG_UART_CONSOLE=n remote_CONFIG_SERIAL=n remote_CONFIG_GPIO=n
       remote_CONFIG_BOOT_BANNER=n remote_CONFIG_NRFS_MRAM_SERVICE_ENABLED=n
+      remote_CONFIG_CLOCK_CONTROL=n
       DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_s2ram.overlay;boards/nrf54h20dk_nrf54h20_cpuapp_ram_high_usage.overlay"
     harness: pytest
     harness_config:
@@ -108,10 +110,11 @@ tests:
       SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
       CONFIG_PM=y CONFIG_PM_S2RAM=y CONFIG_POWEROFF=y CONFIG_PM_S2RAM_CUSTOM_MARKING=y
       CONFIG_CONSOLE=n CONFIG_UART_CONSOLE=n CONFIG_SERIAL=n CONFIG_GPIO=n CONFIG_BOOT_BANNER=n
-      CONFIG_NRFS_MRAM_SERVICE_ENABLED=n
+      CONFIG_NRFS_MRAM_SERVICE_ENABLED=n CONFIG_CLOCK_CONTROL=n
       remote_CONFIG_PM=y remote_CONFIG_POWEROFF=y remote_CONFIG_CONSOLE=n
       remote_CONFIG_UART_CONSOLE=n remote_CONFIG_SERIAL=n remote_CONFIG_GPIO=n
       remote_CONFIG_BOOT_BANNER=n remote_CONFIG_NRFS_MRAM_SERVICE_ENABLED=n
+      remote_CONFIG_CLOCK_CONTROL=n
       DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_s2ram.overlay;boards/nrf54h20dk_nrf54h20_cpuapp_ram_low_usage.overlay"
     harness: pytest
     harness_config:


### PR DESCRIPTION
To prevent bad idle current.