### PR TITLE
doc: utils: drop announcement message

### DIFF
--- a/doc/_utils/utils.py
+++ b/doc/_utils/utils.py
@@ -149,9 +149,7 @@ def add_announcement_banner(options: dict) -> None:
         options: html theme options.
     """
 
-    msg = "<b>Important: </b>This website will be taken offline by 2024-06-18 and replaced " \
-           "with <a href=\"https://docs.nordicsemi.com/\">docs.nordicsemi.com</a>, " \
-           "where all Nordic technical documentation is already accessible. " \
+    msg = ""
 
-    options["set_default_announcement"] = True
+    options["set_default_announcement"] = False
     options["default_announcement_message"] = msg


### PR DESCRIPTION
Now that legacy docs are no longer _officially_ visible, let's drop the banner.