### PR TITLE
Revert "manifest: tf-m: add fix for build with nrfx v3.6.0"

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -161,7 +161,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: dc309f687d4ad579013a6022db12794a69e47bdd
+      revision: ac5004232f9b5ae7209b5b1b77eb30ae89309abe
     - name: psa-arch-tests
       repo-path: sdk-psa-arch-tests
       path: modules/tee/tf-m/psa-arch-tests


### PR DESCRIPTION
This reverts commit 17a4653340de82322273ad66ff2d59f9316fdc01.

This caused unittest failures in sdk-nrf/main. 
Build: 3937

