### PR TITLE
sysbuild: Fix nRF5340 network core updates

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -43,6 +43,8 @@ Build and configuration system
   .. note::
      This has security implications and may allow secrets to be leaked to the non-secure application in RAM.
 
+* Added the ``SB_CONFIG_MCUBOOT_NRF53_MULTI_IMAGE_UPDATE`` sysbuild Kconfig option that enables updating the network core on the nRF5340 SoC from external flash.
+
 Bootloaders and DFU
 ===================
 

--- a/modules/mcuboot/Kconfig
+++ b/modules/mcuboot/Kconfig
@@ -91,7 +91,7 @@ config MCUBOOT_USB_SUPPORT
 	default y if "$(dt_nodelabel_enabled,zephyr_udc0)"
 
 config USE_NRF53_MULTI_IMAGE_WITHOUT_UPGRADE_ONLY
-	bool
+	bool "Allow nRF53 multi-image update support [dangerous]"
 	help
 	  Enabling this option allows you to use NRF53_MULTI_IMAGE update
 	  without having BOOT_UPGRADE_ONLY enabled, allowing you to use

--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -321,6 +321,18 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
       # MCUboot must run in secure mode on the nRF9160/nRF5340
       set_target_properties(mcuboot PROPERTIES BOARD ${board_target_secure})
     endif()
+
+    if(SB_CONFIG_MCUBOOT_NRF53_MULTI_IMAGE_UPDATE)
+      set_config_bool(mcuboot CONFIG_NRF53_MULTI_IMAGE_UPDATE y)
+      set_config_bool(mcuboot CONFIG_BOOT_IMAGE_ACCESS_HOOKS y)
+      set_config_bool(mcuboot CONFIG_FLASH_SIMULATOR y)
+      set_config_bool(mcuboot CONFIG_FLASH_SIMULATOR_DOUBLE_WRITES y)
+      set_config_bool(mcuboot CONFIG_FLASH_SIMULATOR_STATS n)
+
+      if(NOT SB_CONFIG_MCUBOOT_MODE_OVERWRITE_ONLY)
+        set_config_bool(mcuboot CONFIG_USE_NRF53_MULTI_IMAGE_WITHOUT_UPGRADE_ONLY y)
+      endif()
+    endif()
   endif()
 
   if(SB_CONFIG_SECURE_BOOT_APPCORE)

--- a/sysbuild/Kconfig.mcuboot
+++ b/sysbuild/Kconfig.mcuboot
@@ -192,4 +192,14 @@ config MCUBOOT_USE_ALL_AVAILABLE_RAM
 	  may allow secrets to be leaked to non-secure through the non-secure
 	  RAM partition.
 
+config MCUBOOT_NRF53_MULTI_IMAGE_UPDATE
+	bool "Network core multi-image update (in single operation)"
+	depends on NETCORE_APP_UPDATE
+	help
+	  If selected, network core image updates can be applied in a single operation. This is
+	  required if the secondary partition resides in off-chip memory.
+
+	  Note: if not using overwrite only mode for MCUboot, this can result in a bricked device
+	  upon firmware reverts.
+
 endmenu

--- a/sysbuild/Kconfig.sysbuild
+++ b/sysbuild/Kconfig.sysbuild
@@ -28,6 +28,7 @@ config PM_MCUBOOT_PAD
 config PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY
 	bool "Place MCUboot secondary in external flash"
 	depends on BOOTLOADER_MCUBOOT
+	select MCUBOOT_NRF53_MULTI_IMAGE_UPDATE if NETCORE_APP_UPDATE
 	help
 	  Place the secondary partition of MCUboot in the external flash instead
 	  of the internal flash. This option should only be enabled by the user


### PR DESCRIPTION
Adds a new Kconfig option that will enable setting Kconfig options in MCUboot to enable network core updates to work if device is storing update images in external flash

NCSDK-28955