### PR TITLE
Quarantine TFM failures from PR-17084

### DIFF
--- a/scripts/quarantine_integration.yaml
+++ b/scripts/quarantine_integration.yaml
@@ -2,6 +2,22 @@
 # To use with "quarantine-list" twister argument.
 
 - scenarios:
+    - tfm.psa_test_crypto_lvl1
+    - tfm.psa_test_storage_lvl1
+    - tfm.psa_test_storage_lvl2
+    - tfm.regression_fp_hardabi
+    - tfm.regression_ipc_lvl1
+    - tfm.regression_ipc_lvl2
+    - tfm.regression_ipc_lvl2.oberon
+    - tfm.regression_ipc_lvl2.cc3xx_oberon
+    - tfm.regression_ipc_lvl2.cc3xx
+    - tfm.regression_sfn_lvl1
+  platforms:
+    - nrf54l15pdk/nrf54l15/cpuapp
+    - nrf54l15pdk/nrf54l15/cpuapp/ns
+  comment: "Regression from PR-17084 being worked on."
+
+- scenarios:
     - sample.matter.lock.release
     - sample.matter.lock.debug
     - sample.matter.lock.lto


### PR DESCRIPTION
PR-17084 caused tfm unittest failures in sdk-nrf/main
Build: 3937

- Revert "Revert "applications: nrf_desktop: Add BLE addr derived HWINFO for HW ID module""
- Revert "manifest: tf-m: add fix for build with nrfx v3.6.0"
- Revert "manifest: Update sdk-zephyr revision (auto-manifest PR)"
