### PR TITLE
crypto service: change cddl to enable memory checking on server side

### DIFF
--- a/subsys/sdfw_services/services/psa_crypto/psa_crypto_service.cddl
+++ b/subsys/sdfw_services/services/psa_crypto/psa_crypto_service.cddl
@@ -3,667 +3,598 @@
 ;
 ; SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 ;
-
+ptr_buf = #6.32770(uint)
+buf_len = #6.32771(uint)
+ptr_attr = #6.32772(uint)
+ptr_key = #6.32773(uint)
+ptr_uint = #6.32774(uint)
+ptr_cipher = #6.32775(uint)
 
 
 psa_crypto_init_req = (
     10,
 )
 
-
 psa_get_key_attributes_req = (
     11,
     key: uint,
-    p_attributes: uint,
+    p_attributes: ptr_attr,
 )
-
 
 psa_reset_key_attributes_req = (
     12,
-    p_attributes: uint,
+    p_attributes: ptr_attr,
 )
-
 
 psa_purge_key_req = (
     13,
     key: uint,
 )
 
-
 psa_copy_key_req = (
     14,
     source_key: uint,
-    p_attributes: uint,
-    p_target_key: uint,
+    p_attributes: ptr_attr,
+    p_target_key: ptr_key,
 )
-
 
 psa_destroy_key_req = (
     15,
     key: uint,
 )
 
-
 psa_import_key_req = (
     16,
-    p_attributes: uint,
-    p_data: uint,
-    data_length: uint,
-    p_key: uint,
+    p_attributes: ptr_attr,
+    p_data: ptr_buf,
+    data_length: buf_len,
+    p_key: ptr_key,
 )
-
 
 psa_export_key_req = (
     17,
     key: uint,
-    p_data: uint,
-    data_size: uint,
-    p_data_length: uint,
+    p_data: ptr_buf,
+    data_size: buf_len,
+    p_data_length: ptr_uint,
 )
-
 
 psa_export_public_key_req = (
     18,
     key: uint,
-    p_data: uint,
-    data_size: uint,
-    p_data_length: uint,
+    p_data: ptr_buf,
+    data_size: buf_len,
+    p_data_length: ptr_uint,
 )
-
 
 psa_hash_compute_req = (
     19,
     alg: uint,
-    p_input: uint,
-    input_length: uint,
-    p_hash: uint,
-    hash_size: uint,
-    p_hash_length: uint,
+    p_input: ptr_buf,
+    input_length: buf_len,
+    p_hash: ptr_buf,
+    hash_size: buf_len,
+    p_hash_length: ptr_uint,
 )
-
 
 psa_hash_compare_req = (
     20,
     alg: uint,
-    p_input: uint,
-    input_length: uint,
-    p_hash: uint,
-    hash_length: uint,
+    p_input: ptr_buf,
+    input_length: buf_len,
+    p_hash: ptr_buf,
+    hash_length: buf_len,
 )
-
 
 psa_hash_setup_req = (
     21,
-    p_handle: uint,
+    p_handle: ptr_uint,
     alg: uint,
 )
 
-
 psa_hash_update_req = (
     22,
-    p_handle: uint,
-    p_input: uint,
-    input_length: uint,
+    p_handle: ptr_uint,
+    p_input: ptr_buf,
+    input_length: buf_len,
 )
-
 
 psa_hash_finish_req = (
     23,
-    p_handle: uint,
-    p_hash: uint,
-    hash_size: uint,
-    p_hash_length: uint,
+    p_handle: ptr_uint,
+    p_hash: ptr_buf,
+    hash_size: buf_len,
+    p_hash_length: ptr_uint,
 )
-
 
 psa_hash_verify_req = (
     24,
-    p_handle: uint,
-    p_hash: uint,
-    hash_length: uint,
+    p_handle: ptr_uint,
+    p_hash: ptr_buf,
+    hash_length: buf_len,
 )
-
 
 psa_hash_abort_req = (
     25,
-    p_handle: uint,
+    p_handle: ptr_uint,
 )
-
 
 psa_hash_clone_req = (
     26,
     handle: uint,
-    p_handle: uint,
+    p_handle: ptr_uint,
 )
-
 
 psa_mac_compute_req = (
     27,
     key: uint,
     alg: uint,
-    p_input: uint,
-    input_length: uint,
-    p_mac: uint,
-    mac_size: uint,
-    p_mac_length: uint,
+    p_input: ptr_buf,
+    input_length: buf_len,
+    p_mac: ptr_buf,
+    mac_size: buf_len,
+    p_mac_length: ptr_uint,
 )
-
 
 psa_mac_verify_req = (
     28,
     key: uint,
     alg: uint,
-    p_input: uint,
-    input_length: uint,
-    p_mac: uint,
-    mac_length: uint,
+    p_input: ptr_buf,
+    input_length: buf_len,
+    p_mac: ptr_buf,
+    mac_length: buf_len,
 )
-
 
 psa_mac_sign_setup_req = (
     29,
-    p_handle: uint,
+    p_handle: ptr_uint,
     key: uint,
     alg: uint,
 )
-
 
 psa_mac_verify_setup_req = (
     30,
-    p_handle: uint,
+    p_handle: ptr_uint,
     key: uint,
     alg: uint,
 )
 
-
 psa_mac_update_req = (
     31,
-    p_handle: uint,
-    p_input: uint,
-    input_length: uint,
+    p_handle: ptr_uint,
+    p_input: ptr_buf,
+    input_length: buf_len,
 )
-
 
 psa_mac_sign_finish_req = (
     32,
-    p_handle: uint,
-    p_mac: uint,
-    mac_size: uint,
-    p_mac_length: uint,
+    p_handle: ptr_uint,
+    p_mac: ptr_buf,
+    mac_size: buf_len,
+    p_mac_length: ptr_uint,
 )
-
 
 psa_mac_verify_finish_req = (
     33,
-    p_handle: uint,
-    p_mac: uint,
-    mac_length: uint,
+    p_handle: ptr_uint,
+    p_mac: ptr_buf,
+    mac_length: buf_len,
 )
-
 
 psa_mac_abort_req = (
     34,
-    p_handle: uint,
+    p_handle: ptr_uint,
 )
-
 
 psa_cipher_encrypt_req = (
     35,
     key: uint,
     alg: uint,
-    p_input: uint,
-    input_length: uint,
-    p_output: uint,
-    output_size: uint,
-    p_output_length: uint,
+    p_input: ptr_buf,
+    input_length: buf_len,
+    p_output: ptr_buf,
+    output_size: buf_len,
+    p_output_length: ptr_uint,
 )
-
 
 psa_cipher_decrypt_req = (
     36,
     key: uint,
     alg: uint,
-    p_input: uint,
-    input_length: uint,
-    p_output: uint,
-    output_size: uint,
-    p_output_length: uint,
+    p_input: ptr_buf,
+    input_length: buf_len,
+    p_output: ptr_buf,
+    output_size: buf_len,
+    p_output_length: ptr_uint,
 )
-
 
 psa_cipher_encrypt_setup_req = (
     37,
-    p_handle: uint,
+    p_handle: ptr_uint,
     key: uint,
     alg: uint,
 )
-
 
 psa_cipher_decrypt_setup_req = (
     38,
-    p_handle: uint,
+    p_handle: ptr_uint,
     key: uint,
     alg: uint,
 )
 
-
 psa_cipher_generate_iv_req = (
     39,
-    p_handle: uint,
-    p_iv: uint,
-    iv_size: uint,
-    p_iv_length: uint,
+    p_handle: ptr_uint,
+    p_iv: ptr_buf,
+    iv_size: buf_len,
+    p_iv_length: ptr_uint,
 )
-
 
 psa_cipher_set_iv_req = (
     40,
-    p_handle: uint,
-    p_iv: uint,
-    iv_length: uint,
+    p_handle: ptr_uint,
+    p_iv: ptr_buf,
+    iv_length: buf_len,
 )
-
 
 psa_cipher_update_req = (
     41,
-    p_handle: uint,
-    p_input: uint,
-    input_length: uint,
-    p_output: uint,
-    output_size: uint,
-    p_output_length: uint,
+    p_handle: ptr_uint,
+    p_input: ptr_buf,
+    input_length: buf_len,
+    p_output: ptr_buf,
+    output_size: buf_len,
+    p_output_length: ptr_uint,
 )
-
 
 psa_cipher_finish_req = (
     42,
-    p_handle: uint,
-    p_output: uint,
-    output_size: uint,
-    p_output_length: uint,
+    p_handle: ptr_uint,
+    p_output: ptr_buf,
+    output_size: buf_len,
+    p_output_length: ptr_uint,
 )
-
 
 psa_cipher_abort_req = (
     43,
-    p_handle: uint,
+    p_handle: ptr_uint,
 )
-
 
 psa_aead_encrypt_req = (
     44,
     key: uint,
     alg: uint,
-    p_nonce: uint,
-    nonce_length: uint,
-    p_additional_data: uint,
-    additional_data_length: uint,
-    p_plaintext: uint,
-    plaintext_length: uint,
-    p_ciphertext: uint,
-    ciphertext_size: uint,
-    p_ciphertext_length: uint,
+    p_nonce: ptr_buf,
+    nonce_length: buf_len,
+    p_additional_data: ptr_buf,
+    additional_data_length: buf_len,
+    p_plaintext: ptr_buf,
+    plaintext_length: buf_len,
+    p_ciphertext: ptr_buf,
+    ciphertext_size: buf_len,
+    p_ciphertext_length: ptr_uint,
 )
-
 
 psa_aead_decrypt_req = (
     45,
     key: uint,
     alg: uint,
-    p_nonce: uint,
-    nonce_length: uint,
-    p_additional_data: uint,
-    additional_data_length: uint,
-    p_ciphertext: uint,
-    ciphertext_length: uint,
-    p_plaintext: uint,
-    plaintext_size: uint,
-    p_plaintext_length: uint,
+    p_nonce: ptr_buf,
+    nonce_length: buf_len,
+    p_additional_data: ptr_buf,
+    additional_data_length: buf_len,
+    p_ciphertext: ptr_buf,
+    ciphertext_length: buf_len,
+    p_plaintext: ptr_buf,
+    plaintext_size: buf_len,
+    p_plaintext_length: ptr_uint,
 )
-
 
 psa_aead_encrypt_setup_req = (
     46,
-    p_handle: uint,
+    p_handle: ptr_uint,
     key: uint,
     alg: uint,
 )
-
 
 psa_aead_decrypt_setup_req = (
     47,
-    p_handle: uint,
+    p_handle: ptr_uint,
     key: uint,
     alg: uint,
 )
 
-
 psa_aead_generate_nonce_req = (
     48,
-    p_handle: uint,
-    p_nonce: uint,
-    nonce_size: uint,
-    p_nonce_length: uint,
+    p_handle: ptr_uint,
+    p_nonce: ptr_buf,
+    nonce_size: buf_len,
+    p_nonce_length: ptr_uint,
 )
-
 
 psa_aead_set_nonce_req = (
     49,
-    p_handle: uint,
-    p_nonce: uint,
-    nonce_length: uint,
+    p_handle: ptr_uint,
+    p_nonce: ptr_buf,
+    nonce_length: buf_len,
 )
-
 
 psa_aead_set_lengths_req = (
     50,
-    p_handle: uint,
-    ad_length: uint,
-    plaintext_length: uint,
+    p_handle: ptr_uint,
+    ad_length: buf_len,
+    plaintext_length: buf_len,
 )
-
 
 psa_aead_update_ad_req = (
     51,
-    p_handle: uint,
-    p_input: uint,
-    input_length: uint,
+    p_handle: ptr_uint,
+    p_input: ptr_buf,
+    input_length: buf_len,
 )
-
 
 psa_aead_update_req = (
     52,
-    p_handle: uint,
-    p_input: uint,
-    input_length: uint,
-    p_output: uint,
-    output_size: uint,
-    p_output_length: uint,
+    p_handle: ptr_uint,
+    p_input: ptr_buf,
+    input_length: buf_len,
+    p_output: ptr_buf,
+    output_size: buf_len,
+    p_output_length: ptr_uint,
 )
-
 
 psa_aead_finish_req = (
     53,
-    p_handle: uint,
-    p_ciphertext: uint,
-    ciphertext_size: uint,
-    p_ciphertext_length: uint,
-    p_tag: uint,
-    tag_size: uint,
-    p_tag_length: uint,
+    p_handle: ptr_uint,
+    p_ciphertext: ptr_buf,
+    ciphertext_size: buf_len,
+    p_ciphertext_length: ptr_uint,
+    p_tag: ptr_buf,
+    tag_size: buf_len,
+    p_tag_length: ptr_uint,
 )
-
 
 psa_aead_verify_req = (
     54,
-    p_handle: uint,
-    p_plaintext: uint,
-    plaintext_size: uint,
-    p_plaintext_length: uint,
-    p_tag: uint,
-    tag_length: uint,
+    p_handle: ptr_uint,
+    p_plaintext: ptr_buf,
+    plaintext_size: buf_len,
+    p_plaintext_length: ptr_uint,
+    p_tag: ptr_buf,
+    tag_length: buf_len,
 )
-
 
 psa_aead_abort_req = (
     55,
-    p_handle: uint,
+    p_handle: ptr_uint,
 )
-
 
 psa_sign_message_req = (
     56,
     key: uint,
     alg: uint,
-    p_input: uint,
-    input_length: uint,
-    p_signature: uint,
-    signature_size: uint,
-    p_signature_length: uint,
+    p_input: ptr_buf,
+    input_length: buf_len,
+    p_signature: ptr_buf,
+    signature_size: buf_len,
+    p_signature_length: ptr_uint,
 )
-
 
 psa_verify_message_req = (
     57,
     key: uint,
     alg: uint,
-    p_input: uint,
-    input_length: uint,
-    p_signature: uint,
-    signature_length: uint,
+    p_input: ptr_buf,
+    input_length: buf_len,
+    p_signature: ptr_buf,
+    signature_length: buf_len,
 )
-
 
 psa_sign_hash_req = (
     58,
     key: uint,
     alg: uint,
-    p_hash: uint,
-    hash_length: uint,
-    p_signature: uint,
-    signature_size: uint,
-    p_signature_length: uint,
+    p_hash: ptr_buf,
+    hash_length: buf_len,
+    p_signature: ptr_buf,
+    signature_size: buf_len,
+    p_signature_length: ptr_uint,
 )
-
 
 psa_verify_hash_req = (
     59,
     key: uint,
     alg: uint,
-    p_hash: uint,
-    hash_length: uint,
-    p_signature: uint,
-    signature_length: uint,
+    p_hash: ptr_buf,
+    hash_length: buf_len,
+    p_signature: ptr_buf,
+    signature_length: buf_len,
 )
-
 
 psa_asymmetric_encrypt_req = (
     60,
     key: uint,
     alg: uint,
-    p_input: uint,
-    input_length: uint,
-    p_salt: uint,
-    salt_length: uint,
-    p_output: uint,
-    output_size: uint,
-    p_output_length: uint,
+    p_input: ptr_buf,
+    input_length: buf_len,
+    p_salt: ptr_buf,
+    salt_length: buf_len,
+    p_output: ptr_buf,
+    output_size: buf_len,
+    p_output_length: ptr_uint,
 )
-
 
 psa_asymmetric_decrypt_req = (
     61,
     key: uint,
     alg: uint,
-    p_input: uint,
-    input_length: uint,
-    p_salt: uint,
-    salt_length: uint,
-    p_output: uint,
-    output_size: uint,
-    p_output_length: uint,
+    p_input: ptr_buf,
+    input_length: buf_len,
+    p_salt: ptr_buf,
+    salt_length: buf_len,
+    p_output: ptr_buf,
+    output_size: buf_len,
+    p_output_length: ptr_uint,
 )
-
 
 psa_key_derivation_setup_req = (
     62,
-    p_handle: uint,
+    p_handle: ptr_uint,
     alg: uint,
 )
-
 
 psa_key_derivation_get_capacity_req = (
     63,
     handle: uint,
-    p_capacity: uint,
+    p_capacity: ptr_uint,
 )
-
 
 psa_key_derivation_set_capacity_req = (
     64,
-    p_handle: uint,
+    p_handle: ptr_uint,
     capacity: uint,
 )
 
-
 psa_key_derivation_input_bytes_req = (
     65,
-    p_handle: uint,
+    p_handle: ptr_uint,
     step: uint,
-    p_data: uint,
-    data_length: uint,
+    p_data: ptr_buf,
+    data_length: buf_len,
 )
-
 
 psa_key_derivation_input_integer_req = (
     66,
-    p_handle: uint,
+    p_handle: ptr_uint,
     step: uint,
     value: uint,
 )
 
-
 psa_key_derivation_input_key_req = (
     67,
-    p_handle: uint,
+    p_handle: ptr_uint,
     step: uint,
     key: uint,
 )
 
-
 psa_key_derivation_key_agreement_req = (
     68,
-    p_handle: uint,
+    p_handle: ptr_uint,
     step: uint,
     private_key: uint,
-    p_peer_key: uint,
-    peer_key_length: uint,
+    p_peer_key: ptr_buf,
+    peer_key_length: buf_len,
 )
-
 
 psa_key_derivation_output_bytes_req = (
     69,
-    p_handle: uint,
-    p_output: uint,
-    output_length: uint,
+    p_handle: ptr_uint,
+    p_output: ptr_buf,
+    output_length: buf_len,
 )
-
 
 psa_key_derivation_output_key_req = (
     70,
-    p_attributes: uint,
-    p_handle: uint,
-    p_key: uint,
+    p_attributes: ptr_attr,
+    p_handle: ptr_uint,
+    p_key: ptr_key,
 )
-
 
 psa_key_derivation_abort_req = (
     71,
-    p_handle: uint,
+    p_handle: ptr_uint,
 )
-
 
 psa_raw_key_agreement_req = (
     72,
     alg: uint,
     private_key: uint,
-    p_peer_key: uint,
-    peer_key_length: uint,
-    p_output: uint,
-    output_size: uint,
-    p_output_length: uint,
+    p_peer_key: ptr_buf,
+    peer_key_length: buf_len,
+    p_output: ptr_buf,
+    output_size: buf_len,
+    p_output_length: ptr_uint,
 )
-
 
 psa_generate_random_req = (
     73,
-    p_output: uint,
-    output_size: uint,
+    p_output: ptr_buf,
+    output_size: buf_len,
 )
-
 
 psa_generate_key_req = (
     74,
-    p_attributes: uint,
-    p_key: uint,
+    p_attributes: ptr_attr,
+    p_key: ptr_key,
 )
-
 
 psa_pake_setup_req = (
     79,
-    p_handle: uint,
+    p_handle: ptr_uint,
     password_key: uint,
-    p_cipher_suite: uint,
+    p_cipher_suite: ptr_cipher,
 )
-
 
 psa_pake_set_role_req = (
     80,
-    p_handle: uint,
+    p_handle: ptr_uint,
     role: uint,
 )
 
-
 psa_pake_set_user_req = (
     81,
-    p_handle: uint,
-    p_user_id: uint,
-    user_id_len: uint,
+    p_handle: ptr_uint,
+    p_user_id: ptr_buf,
+    user_id_len: buf_len,
 )
-
 
 psa_pake_set_peer_req = (
     82,
-    p_handle: uint,
-    p_peer_id: uint,
-    peer_id_len: uint,
+    p_handle: ptr_uint,
+    p_peer_id: ptr_buf,
+    peer_id_len: buf_len,
 )
-
 
 psa_pake_set_context_req = (
     83,
-    p_handle: uint,
-    p_context: uint,
-    context_len: uint,
+    p_handle: ptr_uint,
+    p_context: ptr_buf,
+    context_len: buf_len,
 )
-
 
 psa_pake_output_req = (
     84,
-    p_handle: uint,
+    p_handle: ptr_uint,
     step: uint,
-    p_output: uint,
-    output_size: uint,
-    p_output_length: uint,
+    p_output: ptr_buf,
+    output_size: buf_len,
+    p_output_length: ptr_uint,
 )
-
 
 psa_pake_input_req = (
     85,
-    p_handle: uint,
+    p_handle: ptr_uint,
     step: uint,
-    p_input: uint,
-    input_length: uint,
+    p_input: ptr_buf,
+    input_length: buf_len,
 )
-
 
 psa_pake_get_shared_key_req = (
     86,
-    p_handle: uint,
-    p_attributes: uint,
-    p_key: uint,
+    p_handle: ptr_uint,
+    p_attributes: ptr_attr,
+    p_key: ptr_key,
 )
-
 
 psa_pake_abort_req = (
     87,
-    p_handle: uint,
+    p_handle: ptr_uint,
 )
 
-
 psa_crypto_req = [
-	; Union of different requests
-	msg: (
+    ; Union of different requests
+    msg: (
         psa_crypto_init_req /
         psa_get_key_attributes_req /
         psa_reset_key_attributes_req /
@@ -738,7 +669,7 @@ psa_crypto_req = [
         psa_pake_input_req /
         psa_pake_get_shared_key_req /
         psa_pake_abort_req
-	),
+    ),
 ]
 
 psa_crypto_rsp = [

--- a/subsys/sdfw_services/services/psa_crypto/zcbor_generated/psa_crypto_service_decode.c
+++ b/subsys/sdfw_services/services/psa_crypto/zcbor_generated/psa_crypto_service_decode.c
@@ -22,14 +22,19 @@
 #error "The type file was generated with a different default_max_qty than this file"
 #endif
 
+static bool decode_ptr_attr(zcbor_state_t *state, uint32_t *result);
 static bool decode_psa_get_key_attributes_req(zcbor_state_t *state,
 					      struct psa_get_key_attributes_req *result);
 static bool decode_psa_reset_key_attributes_req(zcbor_state_t *state,
 						struct psa_reset_key_attributes_req *result);
 static bool decode_psa_purge_key_req(zcbor_state_t *state, struct psa_purge_key_req *result);
+static bool decode_ptr_key(zcbor_state_t *state, uint32_t *result);
 static bool decode_psa_copy_key_req(zcbor_state_t *state, struct psa_copy_key_req *result);
 static bool decode_psa_destroy_key_req(zcbor_state_t *state, struct psa_destroy_key_req *result);
+static bool decode_ptr_buf(zcbor_state_t *state, uint32_t *result);
+static bool decode_buf_len(zcbor_state_t *state, uint32_t *result);
 static bool decode_psa_import_key_req(zcbor_state_t *state, struct psa_import_key_req *result);
+static bool decode_ptr_uint(zcbor_state_t *state, uint32_t *result);
 static bool decode_psa_export_key_req(zcbor_state_t *state, struct psa_export_key_req *result);
 static bool decode_psa_export_public_key_req(zcbor_state_t *state,
 					     struct psa_export_public_key_req *result);
@@ -130,6 +135,7 @@ static bool decode_psa_raw_key_agreement_req(zcbor_state_t *state,
 static bool decode_psa_generate_random_req(zcbor_state_t *state,
 					   struct psa_generate_random_req *result);
 static bool decode_psa_generate_key_req(zcbor_state_t *state, struct psa_generate_key_req *result);
+static bool decode_ptr_cipher(zcbor_state_t *state, uint32_t *result);
 static bool decode_psa_pake_setup_req(zcbor_state_t *state, struct psa_pake_setup_req *result);
 static bool decode_psa_pake_set_role_req(zcbor_state_t *state,
 					 struct psa_pake_set_role_req *result);
@@ -147,16 +153,32 @@ static bool decode_psa_pake_abort_req(zcbor_state_t *state, struct psa_pake_abor
 static bool decode_psa_crypto_rsp(zcbor_state_t *state, struct psa_crypto_rsp *result);
 static bool decode_psa_crypto_req(zcbor_state_t *state, struct psa_crypto_req *result);
 
+static bool decode_ptr_attr(zcbor_state_t *state, uint32_t *result)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool tmp_result =
+		((zcbor_tag_expect(state, 32772) && (zcbor_uint32_decode(state, (&(*result))))));
+
+	if (!tmp_result) {
+		zcbor_trace_file(state);
+		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
+	} else {
+		zcbor_log("%s success\r\n", __func__);
+	}
+
+	return tmp_result;
+}
+
 static bool decode_psa_get_key_attributes_req(zcbor_state_t *state,
 					      struct psa_get_key_attributes_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (11)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_get_key_attributes_req_key)))) &&
-		   ((zcbor_uint32_decode(state,
-					 (&(*result).psa_get_key_attributes_req_p_attributes)))))));
+	bool tmp_result = (((
+		((zcbor_uint32_expect(state, (11)))) &&
+		((zcbor_uint32_decode(state, (&(*result).psa_get_key_attributes_req_key)))) &&
+		((decode_ptr_attr(state, (&(*result).psa_get_key_attributes_req_p_attributes)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -175,8 +197,8 @@ static bool decode_psa_reset_key_attributes_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (12)))) &&
-		   ((zcbor_uint32_decode(
-			   state, (&(*result).psa_reset_key_attributes_req_p_attributes)))))));
+		   ((decode_ptr_attr(state,
+				     (&(*result).psa_reset_key_attributes_req_p_attributes)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -205,6 +227,23 @@ static bool decode_psa_purge_key_req(zcbor_state_t *state, struct psa_purge_key_
 	return tmp_result;
 }
 
+static bool decode_ptr_key(zcbor_state_t *state, uint32_t *result)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool tmp_result =
+		((zcbor_tag_expect(state, 32773) && (zcbor_uint32_decode(state, (&(*result))))));
+
+	if (!tmp_result) {
+		zcbor_trace_file(state);
+		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
+	} else {
+		zcbor_log("%s success\r\n", __func__);
+	}
+
+	return tmp_result;
+}
+
 static bool decode_psa_copy_key_req(zcbor_state_t *state, struct psa_copy_key_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
@@ -212,8 +251,8 @@ static bool decode_psa_copy_key_req(zcbor_state_t *state, struct psa_copy_key_re
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (14)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_copy_key_req_source_key)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_copy_key_req_p_attributes)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_copy_key_req_p_target_key)))))));
+		   ((decode_ptr_attr(state, (&(*result).psa_copy_key_req_p_attributes)))) &&
+		   ((decode_ptr_key(state, (&(*result).psa_copy_key_req_p_target_key)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -243,16 +282,67 @@ static bool decode_psa_destroy_key_req(zcbor_state_t *state, struct psa_destroy_
 	return tmp_result;
 }
 
+static bool decode_ptr_buf(zcbor_state_t *state, uint32_t *result)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool tmp_result =
+		((zcbor_tag_expect(state, 32770) && (zcbor_uint32_decode(state, (&(*result))))));
+
+	if (!tmp_result) {
+		zcbor_trace_file(state);
+		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
+	} else {
+		zcbor_log("%s success\r\n", __func__);
+	}
+
+	return tmp_result;
+}
+
+static bool decode_buf_len(zcbor_state_t *state, uint32_t *result)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool tmp_result =
+		((zcbor_tag_expect(state, 32771) && (zcbor_uint32_decode(state, (&(*result))))));
+
+	if (!tmp_result) {
+		zcbor_trace_file(state);
+		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
+	} else {
+		zcbor_log("%s success\r\n", __func__);
+	}
+
+	return tmp_result;
+}
+
 static bool decode_psa_import_key_req(zcbor_state_t *state, struct psa_import_key_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (16)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_import_key_req_p_attributes)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_import_key_req_p_data)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_import_key_req_data_length)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_import_key_req_p_key)))))));
+		   ((decode_ptr_attr(state, (&(*result).psa_import_key_req_p_attributes)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_import_key_req_p_data)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_import_key_req_data_length)))) &&
+		   ((decode_ptr_key(state, (&(*result).psa_import_key_req_p_key)))))));
+
+	if (!tmp_result) {
+		zcbor_trace_file(state);
+		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
+	} else {
+		zcbor_log("%s success\r\n", __func__);
+	}
+
+	return tmp_result;
+}
+
+static bool decode_ptr_uint(zcbor_state_t *state, uint32_t *result)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool tmp_result =
+		((zcbor_tag_expect(state, 32774) && (zcbor_uint32_decode(state, (&(*result))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -271,9 +361,9 @@ static bool decode_psa_export_key_req(zcbor_state_t *state, struct psa_export_ke
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (17)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_export_key_req_key)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_export_key_req_p_data)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_export_key_req_data_size)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_export_key_req_p_data_length)))))));
+		   ((decode_ptr_buf(state, (&(*result).psa_export_key_req_p_data)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_export_key_req_data_size)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_export_key_req_p_data_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -290,13 +380,12 @@ static bool decode_psa_export_public_key_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_expect(state, (18)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_export_public_key_req_key)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_export_public_key_req_p_data)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_export_public_key_req_data_size)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_export_public_key_req_p_data_length)))))));
+	bool tmp_result = (((
+		((zcbor_uint32_expect(state, (18)))) &&
+		((zcbor_uint32_decode(state, (&(*result).psa_export_public_key_req_key)))) &&
+		((decode_ptr_buf(state, (&(*result).psa_export_public_key_req_p_data)))) &&
+		((decode_buf_len(state, (&(*result).psa_export_public_key_req_data_size)))) &&
+		((decode_ptr_uint(state, (&(*result).psa_export_public_key_req_p_data_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -312,14 +401,14 @@ static bool decode_psa_hash_compute_req(zcbor_state_t *state, struct psa_hash_co
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_expect(state, (19)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_hash_compute_req_alg)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_hash_compute_req_p_input)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_hash_compute_req_input_length)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_hash_compute_req_p_hash)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_hash_compute_req_hash_size)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_hash_compute_req_p_hash_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_expect(state, (19)))) &&
+		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_compute_req_alg)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_hash_compute_req_p_input)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_hash_compute_req_input_length)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_hash_compute_req_p_hash)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_hash_compute_req_hash_size)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_hash_compute_req_p_hash_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -338,10 +427,10 @@ static bool decode_psa_hash_compare_req(zcbor_state_t *state, struct psa_hash_co
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (20)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_compare_req_alg)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_compare_req_p_input)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_compare_req_input_length)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_compare_req_p_hash)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_compare_req_hash_length)))))));
+		   ((decode_ptr_buf(state, (&(*result).psa_hash_compare_req_p_input)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_hash_compare_req_input_length)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_hash_compare_req_p_hash)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_hash_compare_req_hash_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -357,10 +446,9 @@ static bool decode_psa_hash_setup_req(zcbor_state_t *state, struct psa_hash_setu
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (21)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_setup_req_p_handle)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_setup_req_alg)))))));
+	bool tmp_result = (((((zcbor_uint32_expect(state, (21)))) &&
+			     ((decode_ptr_uint(state, (&(*result).psa_hash_setup_req_p_handle)))) &&
+			     ((zcbor_uint32_decode(state, (&(*result).psa_hash_setup_req_alg)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -378,9 +466,9 @@ static bool decode_psa_hash_update_req(zcbor_state_t *state, struct psa_hash_upd
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (22)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_update_req_p_handle)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_update_req_p_input)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_update_req_input_length)))))));
+		   ((decode_ptr_uint(state, (&(*result).psa_hash_update_req_p_handle)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_hash_update_req_p_input)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_hash_update_req_input_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -396,12 +484,12 @@ static bool decode_psa_hash_finish_req(zcbor_state_t *state, struct psa_hash_fin
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_expect(state, (23)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_hash_finish_req_p_handle)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_hash_finish_req_p_hash)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_hash_finish_req_hash_size)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_hash_finish_req_p_hash_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_expect(state, (23)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_hash_finish_req_p_handle)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_hash_finish_req_p_hash)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_hash_finish_req_hash_size)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_hash_finish_req_p_hash_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -419,9 +507,9 @@ static bool decode_psa_hash_verify_req(zcbor_state_t *state, struct psa_hash_ver
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (24)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_verify_req_p_handle)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_verify_req_p_hash)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_verify_req_hash_length)))))));
+		   ((decode_ptr_uint(state, (&(*result).psa_hash_verify_req_p_handle)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_hash_verify_req_p_hash)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_hash_verify_req_hash_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -439,7 +527,7 @@ static bool decode_psa_hash_abort_req(zcbor_state_t *state, struct psa_hash_abor
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (25)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_abort_req_p_handle)))))));
+		   ((decode_ptr_uint(state, (&(*result).psa_hash_abort_req_p_handle)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -458,7 +546,7 @@ static bool decode_psa_hash_clone_req(zcbor_state_t *state, struct psa_hash_clon
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (26)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_clone_req_handle)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_clone_req_p_handle)))))));
+		   ((decode_ptr_uint(state, (&(*result).psa_hash_clone_req_p_handle)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -478,11 +566,11 @@ static bool decode_psa_mac_compute_req(zcbor_state_t *state, struct psa_mac_comp
 		(((((zcbor_uint32_expect(state, (27)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_compute_req_key)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_compute_req_alg)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_compute_req_p_input)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_compute_req_input_length)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_compute_req_p_mac)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_compute_req_mac_size)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_compute_req_p_mac_length)))))));
+		   ((decode_ptr_buf(state, (&(*result).psa_mac_compute_req_p_input)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_mac_compute_req_input_length)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_mac_compute_req_p_mac)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_mac_compute_req_mac_size)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_mac_compute_req_p_mac_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -502,10 +590,10 @@ static bool decode_psa_mac_verify_req(zcbor_state_t *state, struct psa_mac_verif
 		(((((zcbor_uint32_expect(state, (28)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_verify_req_key)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_verify_req_alg)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_verify_req_p_input)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_verify_req_input_length)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_verify_req_p_mac)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_verify_req_mac_length)))))));
+		   ((decode_ptr_buf(state, (&(*result).psa_mac_verify_req_p_input)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_mac_verify_req_input_length)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_mac_verify_req_p_mac)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_mac_verify_req_mac_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -524,7 +612,7 @@ static bool decode_psa_mac_sign_setup_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (29)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_sign_setup_req_p_handle)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_mac_sign_setup_req_p_handle)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_sign_setup_req_key)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_sign_setup_req_alg)))))));
 
@@ -545,7 +633,7 @@ static bool decode_psa_mac_verify_setup_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (30)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_verify_setup_req_p_handle)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_mac_verify_setup_req_p_handle)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_verify_setup_req_key)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_verify_setup_req_alg)))))));
 
@@ -565,9 +653,9 @@ static bool decode_psa_mac_update_req(zcbor_state_t *state, struct psa_mac_updat
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (31)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_update_req_p_handle)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_update_req_p_input)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_update_req_input_length)))))));
+		   ((decode_ptr_uint(state, (&(*result).psa_mac_update_req_p_handle)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_mac_update_req_p_input)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_mac_update_req_input_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -586,11 +674,10 @@ static bool decode_psa_mac_sign_finish_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (32)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_sign_finish_req_p_handle)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_sign_finish_req_p_mac)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_sign_finish_req_mac_size)))) &&
-		   ((zcbor_uint32_decode(state,
-					 (&(*result).psa_mac_sign_finish_req_p_mac_length)))))));
+		   ((decode_ptr_uint(state, (&(*result).psa_mac_sign_finish_req_p_handle)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_mac_sign_finish_req_p_mac)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_mac_sign_finish_req_mac_size)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_mac_sign_finish_req_p_mac_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -607,12 +694,11 @@ static bool decode_psa_mac_verify_finish_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_expect(state, (33)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_mac_verify_finish_req_p_handle)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_mac_verify_finish_req_p_mac)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_mac_verify_finish_req_mac_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_expect(state, (33)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_mac_verify_finish_req_p_handle)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_mac_verify_finish_req_p_mac)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_mac_verify_finish_req_mac_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -628,9 +714,8 @@ static bool decode_psa_mac_abort_req(zcbor_state_t *state, struct psa_mac_abort_
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (34)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_abort_req_p_handle)))))));
+	bool tmp_result = (((((zcbor_uint32_expect(state, (34)))) &&
+			     ((decode_ptr_uint(state, (&(*result).psa_mac_abort_req_p_handle)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -651,12 +736,11 @@ static bool decode_psa_cipher_encrypt_req(zcbor_state_t *state,
 		(((zcbor_uint32_expect(state, (35)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_encrypt_req_key)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_encrypt_req_alg)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_encrypt_req_p_input)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_encrypt_req_input_length)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_encrypt_req_p_output)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_encrypt_req_output_size)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_cipher_encrypt_req_p_output_length)))))));
+		 ((decode_ptr_buf(state, (&(*result).psa_cipher_encrypt_req_p_input)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_cipher_encrypt_req_input_length)))) &&
+		 ((decode_ptr_buf(state, (&(*result).psa_cipher_encrypt_req_p_output)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_cipher_encrypt_req_output_size)))) &&
+		 ((decode_ptr_uint(state, (&(*result).psa_cipher_encrypt_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -677,12 +761,11 @@ static bool decode_psa_cipher_decrypt_req(zcbor_state_t *state,
 		(((zcbor_uint32_expect(state, (36)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_decrypt_req_key)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_decrypt_req_alg)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_decrypt_req_p_input)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_decrypt_req_input_length)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_decrypt_req_p_output)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_decrypt_req_output_size)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_cipher_decrypt_req_p_output_length)))))));
+		 ((decode_ptr_buf(state, (&(*result).psa_cipher_decrypt_req_p_input)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_cipher_decrypt_req_input_length)))) &&
+		 ((decode_ptr_buf(state, (&(*result).psa_cipher_decrypt_req_p_output)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_cipher_decrypt_req_output_size)))) &&
+		 ((decode_ptr_uint(state, (&(*result).psa_cipher_decrypt_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -701,8 +784,7 @@ static bool decode_psa_cipher_encrypt_setup_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (37)))) &&
-		   ((zcbor_uint32_decode(state,
-					 (&(*result).psa_cipher_encrypt_setup_req_p_handle)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_cipher_encrypt_setup_req_p_handle)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_cipher_encrypt_setup_req_key)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_cipher_encrypt_setup_req_alg)))))));
 
@@ -723,8 +805,7 @@ static bool decode_psa_cipher_decrypt_setup_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (38)))) &&
-		   ((zcbor_uint32_decode(state,
-					 (&(*result).psa_cipher_decrypt_setup_req_p_handle)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_cipher_decrypt_setup_req_p_handle)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_cipher_decrypt_setup_req_key)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_cipher_decrypt_setup_req_alg)))))));
 
@@ -745,11 +826,10 @@ static bool decode_psa_cipher_generate_iv_req(zcbor_state_t *state,
 
 	bool tmp_result = ((
 		(((zcbor_uint32_expect(state, (39)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_generate_iv_req_p_handle)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_generate_iv_req_p_iv)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_generate_iv_req_iv_size)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_cipher_generate_iv_req_p_iv_length)))))));
+		 ((decode_ptr_uint(state, (&(*result).psa_cipher_generate_iv_req_p_handle)))) &&
+		 ((decode_ptr_buf(state, (&(*result).psa_cipher_generate_iv_req_p_iv)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_cipher_generate_iv_req_iv_size)))) &&
+		 ((decode_ptr_uint(state, (&(*result).psa_cipher_generate_iv_req_p_iv_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -767,9 +847,9 @@ static bool decode_psa_cipher_set_iv_req(zcbor_state_t *state, struct psa_cipher
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (40)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_cipher_set_iv_req_p_handle)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_cipher_set_iv_req_p_iv)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_cipher_set_iv_req_iv_length)))))));
+		   ((decode_ptr_uint(state, (&(*result).psa_cipher_set_iv_req_p_handle)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_cipher_set_iv_req_p_iv)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_cipher_set_iv_req_iv_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -787,13 +867,12 @@ static bool decode_psa_cipher_update_req(zcbor_state_t *state, struct psa_cipher
 
 	bool tmp_result = ((
 		(((zcbor_uint32_expect(state, (41)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_update_req_p_handle)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_update_req_p_input)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_update_req_input_length)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_update_req_p_output)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_update_req_output_size)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_cipher_update_req_p_output_length)))))));
+		 ((decode_ptr_uint(state, (&(*result).psa_cipher_update_req_p_handle)))) &&
+		 ((decode_ptr_buf(state, (&(*result).psa_cipher_update_req_p_input)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_cipher_update_req_input_length)))) &&
+		 ((decode_ptr_buf(state, (&(*result).psa_cipher_update_req_p_output)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_cipher_update_req_output_size)))) &&
+		 ((decode_ptr_uint(state, (&(*result).psa_cipher_update_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -809,13 +888,12 @@ static bool decode_psa_cipher_finish_req(zcbor_state_t *state, struct psa_cipher
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (42)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_cipher_finish_req_p_handle)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_cipher_finish_req_p_output)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_cipher_finish_req_output_size)))) &&
-		   ((zcbor_uint32_decode(state,
-					 (&(*result).psa_cipher_finish_req_p_output_length)))))));
+	bool tmp_result = ((
+		(((zcbor_uint32_expect(state, (42)))) &&
+		 ((decode_ptr_uint(state, (&(*result).psa_cipher_finish_req_p_handle)))) &&
+		 ((decode_ptr_buf(state, (&(*result).psa_cipher_finish_req_p_output)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_cipher_finish_req_output_size)))) &&
+		 ((decode_ptr_uint(state, (&(*result).psa_cipher_finish_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -833,7 +911,7 @@ static bool decode_psa_cipher_abort_req(zcbor_state_t *state, struct psa_cipher_
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (43)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_cipher_abort_req_p_handle)))))));
+		   ((decode_ptr_uint(state, (&(*result).psa_cipher_abort_req_p_handle)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -849,23 +927,21 @@ static bool decode_psa_aead_encrypt_req(zcbor_state_t *state, struct psa_aead_en
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
-		((zcbor_uint32_expect(state, (44)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_encrypt_req_key)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_encrypt_req_alg)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_encrypt_req_p_nonce)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_encrypt_req_nonce_length)))) &&
-		((zcbor_uint32_decode(state,
-				      (&(*result).psa_aead_encrypt_req_p_additional_data)))) &&
-		((zcbor_uint32_decode(state,
-				      (&(*result).psa_aead_encrypt_req_additional_data_length)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_encrypt_req_p_plaintext)))) &&
-		((zcbor_uint32_decode(state,
-				      (&(*result).psa_aead_encrypt_req_plaintext_length)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_encrypt_req_p_ciphertext)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_encrypt_req_ciphertext_size)))) &&
-		((zcbor_uint32_decode(state,
-				      (&(*result).psa_aead_encrypt_req_p_ciphertext_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_expect(state, (44)))) &&
+		   ((zcbor_uint32_decode(state, (&(*result).psa_aead_encrypt_req_key)))) &&
+		   ((zcbor_uint32_decode(state, (&(*result).psa_aead_encrypt_req_alg)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_aead_encrypt_req_p_nonce)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_aead_encrypt_req_nonce_length)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_aead_encrypt_req_p_additional_data)))) &&
+		   ((decode_buf_len(state,
+				    (&(*result).psa_aead_encrypt_req_additional_data_length)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_aead_encrypt_req_p_plaintext)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_aead_encrypt_req_plaintext_length)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_aead_encrypt_req_p_ciphertext)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_aead_encrypt_req_ciphertext_size)))) &&
+		   ((decode_ptr_uint(state,
+				     (&(*result).psa_aead_encrypt_req_p_ciphertext_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -881,23 +957,20 @@ static bool decode_psa_aead_decrypt_req(zcbor_state_t *state, struct psa_aead_de
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_expect(state, (45)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_decrypt_req_key)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_decrypt_req_alg)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_decrypt_req_p_nonce)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_decrypt_req_nonce_length)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_aead_decrypt_req_p_additional_data)))) &&
-		 ((zcbor_uint32_decode(
-			 state, (&(*result).psa_aead_decrypt_req_additional_data_length)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_decrypt_req_p_ciphertext)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_aead_decrypt_req_ciphertext_length)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_decrypt_req_p_plaintext)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_decrypt_req_plaintext_size)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_aead_decrypt_req_p_plaintext_length)))))));
+	bool tmp_result = (((
+		((zcbor_uint32_expect(state, (45)))) &&
+		((zcbor_uint32_decode(state, (&(*result).psa_aead_decrypt_req_key)))) &&
+		((zcbor_uint32_decode(state, (&(*result).psa_aead_decrypt_req_alg)))) &&
+		((decode_ptr_buf(state, (&(*result).psa_aead_decrypt_req_p_nonce)))) &&
+		((decode_buf_len(state, (&(*result).psa_aead_decrypt_req_nonce_length)))) &&
+		((decode_ptr_buf(state, (&(*result).psa_aead_decrypt_req_p_additional_data)))) &&
+		((decode_buf_len(state,
+				 (&(*result).psa_aead_decrypt_req_additional_data_length)))) &&
+		((decode_ptr_buf(state, (&(*result).psa_aead_decrypt_req_p_ciphertext)))) &&
+		((decode_buf_len(state, (&(*result).psa_aead_decrypt_req_ciphertext_length)))) &&
+		((decode_ptr_buf(state, (&(*result).psa_aead_decrypt_req_p_plaintext)))) &&
+		((decode_buf_len(state, (&(*result).psa_aead_decrypt_req_plaintext_size)))) &&
+		((decode_ptr_uint(state, (&(*result).psa_aead_decrypt_req_p_plaintext_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -914,11 +987,11 @@ static bool decode_psa_aead_encrypt_setup_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_expect(state, (46)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_encrypt_setup_req_p_handle)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_encrypt_setup_req_key)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_encrypt_setup_req_alg)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_expect(state, (46)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_aead_encrypt_setup_req_p_handle)))) &&
+		   ((zcbor_uint32_decode(state, (&(*result).psa_aead_encrypt_setup_req_key)))) &&
+		   ((zcbor_uint32_decode(state, (&(*result).psa_aead_encrypt_setup_req_alg)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -935,11 +1008,11 @@ static bool decode_psa_aead_decrypt_setup_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_expect(state, (47)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_decrypt_setup_req_p_handle)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_decrypt_setup_req_key)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_decrypt_setup_req_alg)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_expect(state, (47)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_aead_decrypt_setup_req_p_handle)))) &&
+		   ((zcbor_uint32_decode(state, (&(*result).psa_aead_decrypt_setup_req_key)))) &&
+		   ((zcbor_uint32_decode(state, (&(*result).psa_aead_decrypt_setup_req_alg)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -956,14 +1029,13 @@ static bool decode_psa_aead_generate_nonce_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
-		((zcbor_uint32_expect(state, (48)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_generate_nonce_req_p_handle)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_generate_nonce_req_p_nonce)))) &&
-		((zcbor_uint32_decode(state,
-				      (&(*result).psa_aead_generate_nonce_req_nonce_size)))) &&
-		((zcbor_uint32_decode(state,
-				      (&(*result).psa_aead_generate_nonce_req_p_nonce_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_expect(state, (48)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_aead_generate_nonce_req_p_handle)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_aead_generate_nonce_req_p_nonce)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_aead_generate_nonce_req_nonce_size)))) &&
+		   ((decode_ptr_uint(state,
+				     (&(*result).psa_aead_generate_nonce_req_p_nonce_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -980,11 +1052,11 @@ static bool decode_psa_aead_set_nonce_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
-		((zcbor_uint32_expect(state, (49)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_set_nonce_req_p_handle)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_set_nonce_req_p_nonce)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_set_nonce_req_nonce_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_expect(state, (49)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_aead_set_nonce_req_p_handle)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_aead_set_nonce_req_p_nonce)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_aead_set_nonce_req_nonce_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1001,12 +1073,12 @@ static bool decode_psa_aead_set_lengths_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_expect(state, (50)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_set_lengths_req_p_handle)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_set_lengths_req_ad_length)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_aead_set_lengths_req_plaintext_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_expect(state, (50)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_aead_set_lengths_req_p_handle)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_aead_set_lengths_req_ad_length)))) &&
+		   ((decode_buf_len(state,
+				    (&(*result).psa_aead_set_lengths_req_plaintext_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1023,11 +1095,11 @@ static bool decode_psa_aead_update_ad_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
-		((zcbor_uint32_expect(state, (51)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_update_ad_req_p_handle)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_update_ad_req_p_input)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_update_ad_req_input_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_expect(state, (51)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_aead_update_ad_req_p_handle)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_aead_update_ad_req_p_input)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_aead_update_ad_req_input_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1043,14 +1115,14 @@ static bool decode_psa_aead_update_req(zcbor_state_t *state, struct psa_aead_upd
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
-		((zcbor_uint32_expect(state, (52)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_update_req_p_handle)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_update_req_p_input)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_update_req_input_length)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_update_req_p_output)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_update_req_output_size)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_aead_update_req_p_output_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_expect(state, (52)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_aead_update_req_p_handle)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_aead_update_req_p_input)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_aead_update_req_input_length)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_aead_update_req_p_output)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_aead_update_req_output_size)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_aead_update_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1068,14 +1140,13 @@ static bool decode_psa_aead_finish_req(zcbor_state_t *state, struct psa_aead_fin
 
 	bool tmp_result = ((
 		(((zcbor_uint32_expect(state, (53)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_finish_req_p_handle)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_finish_req_p_ciphertext)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_finish_req_ciphertext_size)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_aead_finish_req_p_ciphertext_length)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_finish_req_p_tag)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_finish_req_tag_size)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_finish_req_p_tag_length)))))));
+		 ((decode_ptr_uint(state, (&(*result).psa_aead_finish_req_p_handle)))) &&
+		 ((decode_ptr_buf(state, (&(*result).psa_aead_finish_req_p_ciphertext)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_aead_finish_req_ciphertext_size)))) &&
+		 ((decode_ptr_uint(state, (&(*result).psa_aead_finish_req_p_ciphertext_length)))) &&
+		 ((decode_ptr_buf(state, (&(*result).psa_aead_finish_req_p_tag)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_aead_finish_req_tag_size)))) &&
+		 ((decode_ptr_uint(state, (&(*result).psa_aead_finish_req_p_tag_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1093,13 +1164,12 @@ static bool decode_psa_aead_verify_req(zcbor_state_t *state, struct psa_aead_ver
 
 	bool tmp_result = ((
 		(((zcbor_uint32_expect(state, (54)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_verify_req_p_handle)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_verify_req_p_plaintext)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_verify_req_plaintext_size)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_aead_verify_req_p_plaintext_length)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_verify_req_p_tag)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_verify_req_tag_length)))))));
+		 ((decode_ptr_uint(state, (&(*result).psa_aead_verify_req_p_handle)))) &&
+		 ((decode_ptr_buf(state, (&(*result).psa_aead_verify_req_p_plaintext)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_aead_verify_req_plaintext_size)))) &&
+		 ((decode_ptr_uint(state, (&(*result).psa_aead_verify_req_p_plaintext_length)))) &&
+		 ((decode_ptr_buf(state, (&(*result).psa_aead_verify_req_p_tag)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_aead_verify_req_tag_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1117,7 +1187,7 @@ static bool decode_psa_aead_abort_req(zcbor_state_t *state, struct psa_aead_abor
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (55)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_aead_abort_req_p_handle)))))));
+		   ((decode_ptr_uint(state, (&(*result).psa_aead_abort_req_p_handle)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1133,16 +1203,15 @@ static bool decode_psa_sign_message_req(zcbor_state_t *state, struct psa_sign_me
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_expect(state, (56)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_sign_message_req_key)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_sign_message_req_alg)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_sign_message_req_p_input)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_sign_message_req_input_length)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_sign_message_req_p_signature)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_sign_message_req_signature_size)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_sign_message_req_p_signature_length)))))));
+	bool tmp_result = (((
+		((zcbor_uint32_expect(state, (56)))) &&
+		((zcbor_uint32_decode(state, (&(*result).psa_sign_message_req_key)))) &&
+		((zcbor_uint32_decode(state, (&(*result).psa_sign_message_req_alg)))) &&
+		((decode_ptr_buf(state, (&(*result).psa_sign_message_req_p_input)))) &&
+		((decode_buf_len(state, (&(*result).psa_sign_message_req_input_length)))) &&
+		((decode_ptr_buf(state, (&(*result).psa_sign_message_req_p_signature)))) &&
+		((decode_buf_len(state, (&(*result).psa_sign_message_req_signature_size)))) &&
+		((decode_ptr_uint(state, (&(*result).psa_sign_message_req_p_signature_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1163,11 +1232,10 @@ static bool decode_psa_verify_message_req(zcbor_state_t *state,
 		(((zcbor_uint32_expect(state, (57)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_verify_message_req_key)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_verify_message_req_alg)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_verify_message_req_p_input)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_verify_message_req_input_length)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_verify_message_req_p_signature)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_verify_message_req_signature_length)))))));
+		 ((decode_ptr_buf(state, (&(*result).psa_verify_message_req_p_input)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_verify_message_req_input_length)))) &&
+		 ((decode_ptr_buf(state, (&(*result).psa_verify_message_req_p_signature)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_verify_message_req_signature_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1187,12 +1255,11 @@ static bool decode_psa_sign_hash_req(zcbor_state_t *state, struct psa_sign_hash_
 		(((((zcbor_uint32_expect(state, (58)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_sign_hash_req_key)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_sign_hash_req_alg)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_sign_hash_req_p_hash)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_sign_hash_req_hash_length)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_sign_hash_req_p_signature)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_sign_hash_req_signature_size)))) &&
-		   ((zcbor_uint32_decode(state,
-					 (&(*result).psa_sign_hash_req_p_signature_length)))))));
+		   ((decode_ptr_buf(state, (&(*result).psa_sign_hash_req_p_hash)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_sign_hash_req_hash_length)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_sign_hash_req_p_signature)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_sign_hash_req_signature_size)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_sign_hash_req_p_signature_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1212,11 +1279,10 @@ static bool decode_psa_verify_hash_req(zcbor_state_t *state, struct psa_verify_h
 		(((((zcbor_uint32_expect(state, (59)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_verify_hash_req_key)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_verify_hash_req_alg)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_verify_hash_req_p_hash)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_verify_hash_req_hash_length)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_verify_hash_req_p_signature)))) &&
-		   ((zcbor_uint32_decode(state,
-					 (&(*result).psa_verify_hash_req_signature_length)))))));
+		   ((decode_ptr_buf(state, (&(*result).psa_verify_hash_req_p_hash)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_verify_hash_req_hash_length)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_verify_hash_req_p_signature)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_verify_hash_req_signature_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1237,17 +1303,14 @@ static bool decode_psa_asymmetric_encrypt_req(zcbor_state_t *state,
 		(((zcbor_uint32_expect(state, (60)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_asymmetric_encrypt_req_key)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_asymmetric_encrypt_req_alg)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_asymmetric_encrypt_req_p_input)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_asymmetric_encrypt_req_input_length)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_asymmetric_encrypt_req_p_salt)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_asymmetric_encrypt_req_salt_length)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_asymmetric_encrypt_req_p_output)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_asymmetric_encrypt_req_output_size)))) &&
-		 ((zcbor_uint32_decode(
-			 state, (&(*result).psa_asymmetric_encrypt_req_p_output_length)))))));
+		 ((decode_ptr_buf(state, (&(*result).psa_asymmetric_encrypt_req_p_input)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_asymmetric_encrypt_req_input_length)))) &&
+		 ((decode_ptr_buf(state, (&(*result).psa_asymmetric_encrypt_req_p_salt)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_asymmetric_encrypt_req_salt_length)))) &&
+		 ((decode_ptr_buf(state, (&(*result).psa_asymmetric_encrypt_req_p_output)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_asymmetric_encrypt_req_output_size)))) &&
+		 ((decode_ptr_uint(state,
+				   (&(*result).psa_asymmetric_encrypt_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1268,17 +1331,14 @@ static bool decode_psa_asymmetric_decrypt_req(zcbor_state_t *state,
 		(((zcbor_uint32_expect(state, (61)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_asymmetric_decrypt_req_key)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_asymmetric_decrypt_req_alg)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_asymmetric_decrypt_req_p_input)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_asymmetric_decrypt_req_input_length)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_asymmetric_decrypt_req_p_salt)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_asymmetric_decrypt_req_salt_length)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_asymmetric_decrypt_req_p_output)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_asymmetric_decrypt_req_output_size)))) &&
-		 ((zcbor_uint32_decode(
-			 state, (&(*result).psa_asymmetric_decrypt_req_p_output_length)))))));
+		 ((decode_ptr_buf(state, (&(*result).psa_asymmetric_decrypt_req_p_input)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_asymmetric_decrypt_req_input_length)))) &&
+		 ((decode_ptr_buf(state, (&(*result).psa_asymmetric_decrypt_req_p_salt)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_asymmetric_decrypt_req_salt_length)))) &&
+		 ((decode_ptr_buf(state, (&(*result).psa_asymmetric_decrypt_req_p_output)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_asymmetric_decrypt_req_output_size)))) &&
+		 ((decode_ptr_uint(state,
+				   (&(*result).psa_asymmetric_decrypt_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1297,8 +1357,7 @@ static bool decode_psa_key_derivation_setup_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (62)))) &&
-		   ((zcbor_uint32_decode(state,
-					 (&(*result).psa_key_derivation_setup_req_p_handle)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_key_derivation_setup_req_p_handle)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_key_derivation_setup_req_alg)))))));
 
 	if (!tmp_result) {
@@ -1321,7 +1380,7 @@ decode_psa_key_derivation_get_capacity_req(zcbor_state_t *state,
 		(((((zcbor_uint32_expect(state, (63)))) &&
 		   ((zcbor_uint32_decode(
 			   state, (&(*result).psa_key_derivation_get_capacity_req_handle)))) &&
-		   ((zcbor_uint32_decode(
+		   ((decode_ptr_uint(
 			   state, (&(*result).psa_key_derivation_get_capacity_req_p_capacity)))))));
 
 	if (!tmp_result) {
@@ -1342,8 +1401,8 @@ decode_psa_key_derivation_set_capacity_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (64)))) &&
-		   ((zcbor_uint32_decode(
-			   state, (&(*result).psa_key_derivation_set_capacity_req_p_handle)))) &&
+		   ((decode_ptr_uint(state,
+				     (&(*result).psa_key_derivation_set_capacity_req_p_handle)))) &&
 		   ((zcbor_uint32_decode(
 			   state, (&(*result).psa_key_derivation_set_capacity_req_capacity)))))));
 
@@ -1363,16 +1422,15 @@ decode_psa_key_derivation_input_bytes_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (65)))) &&
-		   ((zcbor_uint32_decode(
-			   state, (&(*result).psa_key_derivation_input_bytes_req_p_handle)))) &&
-		   ((zcbor_uint32_decode(state,
-					 (&(*result).psa_key_derivation_input_bytes_req_step)))) &&
-		   ((zcbor_uint32_decode(
-			   state, (&(*result).psa_key_derivation_input_bytes_req_p_data)))) &&
-		   ((zcbor_uint32_decode(
-			   state, (&(*result).psa_key_derivation_input_bytes_req_data_length)))))));
+	bool tmp_result = (((
+		((zcbor_uint32_expect(state, (65)))) &&
+		((decode_ptr_uint(state,
+				  (&(*result).psa_key_derivation_input_bytes_req_p_handle)))) &&
+		((zcbor_uint32_decode(state,
+				      (&(*result).psa_key_derivation_input_bytes_req_step)))) &&
+		((decode_ptr_buf(state, (&(*result).psa_key_derivation_input_bytes_req_p_data)))) &&
+		((decode_buf_len(state,
+				 (&(*result).psa_key_derivation_input_bytes_req_data_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1392,7 +1450,7 @@ decode_psa_key_derivation_input_integer_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (66)))) &&
-		   ((zcbor_uint32_decode(
+		   ((decode_ptr_uint(
 			   state, (&(*result).psa_key_derivation_input_integer_req_p_handle)))) &&
 		   ((zcbor_uint32_decode(
 			   state, (&(*result).psa_key_derivation_input_integer_req_step)))) &&
@@ -1416,8 +1474,8 @@ static bool decode_psa_key_derivation_input_key_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (67)))) &&
-		   ((zcbor_uint32_decode(
-			   state, (&(*result).psa_key_derivation_input_key_req_p_handle)))) &&
+		   ((decode_ptr_uint(state,
+				     (&(*result).psa_key_derivation_input_key_req_p_handle)))) &&
 		   ((zcbor_uint32_decode(state,
 					 (&(*result).psa_key_derivation_input_key_req_step)))) &&
 		   ((zcbor_uint32_decode(state,
@@ -1441,15 +1499,15 @@ decode_psa_key_derivation_key_agreement_req(zcbor_state_t *state,
 
 	bool tmp_result = ((
 		(((zcbor_uint32_expect(state, (68)))) &&
-		 ((zcbor_uint32_decode(
-			 state, (&(*result).psa_key_derivation_key_agreement_req_p_handle)))) &&
+		 ((decode_ptr_uint(state,
+				   (&(*result).psa_key_derivation_key_agreement_req_p_handle)))) &&
 		 ((zcbor_uint32_decode(state,
 				       (&(*result).psa_key_derivation_key_agreement_req_step)))) &&
 		 ((zcbor_uint32_decode(
 			 state, (&(*result).psa_key_derivation_key_agreement_req_private_key)))) &&
-		 ((zcbor_uint32_decode(
-			 state, (&(*result).psa_key_derivation_key_agreement_req_p_peer_key)))) &&
-		 ((zcbor_uint32_decode(
+		 ((decode_ptr_buf(state,
+				  (&(*result).psa_key_derivation_key_agreement_req_p_peer_key)))) &&
+		 ((decode_buf_len(
 			 state,
 			 (&(*result).psa_key_derivation_key_agreement_req_peer_key_length)))))));
 
@@ -1471,11 +1529,11 @@ decode_psa_key_derivation_output_bytes_req(zcbor_state_t *state,
 
 	bool tmp_result = (((
 		((zcbor_uint32_expect(state, (69)))) &&
-		((zcbor_uint32_decode(
-			state, (&(*result).psa_key_derivation_output_bytes_req_p_handle)))) &&
-		((zcbor_uint32_decode(
-			state, (&(*result).psa_key_derivation_output_bytes_req_p_output)))) &&
-		((zcbor_uint32_decode(
+		((decode_ptr_uint(state,
+				  (&(*result).psa_key_derivation_output_bytes_req_p_handle)))) &&
+		((decode_ptr_buf(state,
+				 (&(*result).psa_key_derivation_output_bytes_req_p_output)))) &&
+		((decode_buf_len(
 			state, (&(*result).psa_key_derivation_output_bytes_req_output_length)))))));
 
 	if (!tmp_result) {
@@ -1494,14 +1552,13 @@ decode_psa_key_derivation_output_key_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (70)))) &&
-		   ((zcbor_uint32_decode(
-			   state, (&(*result).psa_key_derivation_output_key_req_p_attributes)))) &&
-		   ((zcbor_uint32_decode(
-			   state, (&(*result).psa_key_derivation_output_key_req_p_handle)))) &&
-		   ((zcbor_uint32_decode(state,
-					 (&(*result).psa_key_derivation_output_key_req_p_key)))))));
+	bool tmp_result = ((
+		(((zcbor_uint32_expect(state, (70)))) &&
+		 ((decode_ptr_attr(state,
+				   (&(*result).psa_key_derivation_output_key_req_p_attributes)))) &&
+		 ((decode_ptr_uint(state,
+				   (&(*result).psa_key_derivation_output_key_req_p_handle)))) &&
+		 ((decode_ptr_key(state, (&(*result).psa_key_derivation_output_key_req_p_key)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1518,10 +1575,9 @@ static bool decode_psa_key_derivation_abort_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (71)))) &&
-		   ((zcbor_uint32_decode(state,
-					 (&(*result).psa_key_derivation_abort_req_p_handle)))))));
+	bool tmp_result = ((
+		(((zcbor_uint32_expect(state, (71)))) &&
+		 ((decode_ptr_uint(state, (&(*result).psa_key_derivation_abort_req_p_handle)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1543,14 +1599,12 @@ static bool decode_psa_raw_key_agreement_req(zcbor_state_t *state,
 		((zcbor_uint32_decode(state, (&(*result).psa_raw_key_agreement_req_alg)))) &&
 		((zcbor_uint32_decode(state,
 				      (&(*result).psa_raw_key_agreement_req_private_key)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_raw_key_agreement_req_p_peer_key)))) &&
-		((zcbor_uint32_decode(state,
-				      (&(*result).psa_raw_key_agreement_req_peer_key_length)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_raw_key_agreement_req_p_output)))) &&
-		((zcbor_uint32_decode(state,
-				      (&(*result).psa_raw_key_agreement_req_output_size)))) &&
-		((zcbor_uint32_decode(state,
-				      (&(*result).psa_raw_key_agreement_req_p_output_length)))))));
+		((decode_ptr_buf(state, (&(*result).psa_raw_key_agreement_req_p_peer_key)))) &&
+		((decode_buf_len(state, (&(*result).psa_raw_key_agreement_req_peer_key_length)))) &&
+		((decode_ptr_buf(state, (&(*result).psa_raw_key_agreement_req_p_output)))) &&
+		((decode_buf_len(state, (&(*result).psa_raw_key_agreement_req_output_size)))) &&
+		((decode_ptr_uint(state,
+				  (&(*result).psa_raw_key_agreement_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1567,10 +1621,10 @@ static bool decode_psa_generate_random_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
-		((zcbor_uint32_expect(state, (73)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_generate_random_req_p_output)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_generate_random_req_output_size)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_expect(state, (73)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_generate_random_req_p_output)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_generate_random_req_output_size)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1588,8 +1642,25 @@ static bool decode_psa_generate_key_req(zcbor_state_t *state, struct psa_generat
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (74)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_generate_key_req_p_attributes)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_generate_key_req_p_key)))))));
+		   ((decode_ptr_attr(state, (&(*result).psa_generate_key_req_p_attributes)))) &&
+		   ((decode_ptr_key(state, (&(*result).psa_generate_key_req_p_key)))))));
+
+	if (!tmp_result) {
+		zcbor_trace_file(state);
+		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
+	} else {
+		zcbor_log("%s success\r\n", __func__);
+	}
+
+	return tmp_result;
+}
+
+static bool decode_ptr_cipher(zcbor_state_t *state, uint32_t *result)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool tmp_result =
+		((zcbor_tag_expect(state, 32775) && (zcbor_uint32_decode(state, (&(*result))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1605,11 +1676,11 @@ static bool decode_psa_pake_setup_req(zcbor_state_t *state, struct psa_pake_setu
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_expect(state, (79)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_pake_setup_req_p_handle)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_pake_setup_req_password_key)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_pake_setup_req_p_cipher_suite)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_expect(state, (79)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_pake_setup_req_p_handle)))) &&
+		   ((zcbor_uint32_decode(state, (&(*result).psa_pake_setup_req_password_key)))) &&
+		   ((decode_ptr_cipher(state, (&(*result).psa_pake_setup_req_p_cipher_suite)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1627,7 +1698,7 @@ static bool decode_psa_pake_set_role_req(zcbor_state_t *state, struct psa_pake_s
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (80)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_pake_set_role_req_p_handle)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_pake_set_role_req_p_handle)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_pake_set_role_req_role)))))));
 
 	if (!tmp_result) {
@@ -1644,11 +1715,11 @@ static bool decode_psa_pake_set_user_req(zcbor_state_t *state, struct psa_pake_s
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_expect(state, (81)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_pake_set_user_req_p_handle)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_pake_set_user_req_p_user_id)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_pake_set_user_req_user_id_len)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_expect(state, (81)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_pake_set_user_req_p_handle)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_pake_set_user_req_p_user_id)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_pake_set_user_req_user_id_len)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1664,11 +1735,11 @@ static bool decode_psa_pake_set_peer_req(zcbor_state_t *state, struct psa_pake_s
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_expect(state, (82)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_pake_set_peer_req_p_handle)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_pake_set_peer_req_p_peer_id)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_pake_set_peer_req_peer_id_len)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_expect(state, (82)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_pake_set_peer_req_p_handle)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_pake_set_peer_req_p_peer_id)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_pake_set_peer_req_peer_id_len)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1685,12 +1756,11 @@ static bool decode_psa_pake_set_context_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_expect(state, (83)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_pake_set_context_req_p_handle)))) &&
-		 ((zcbor_uint32_decode(state, (&(*result).psa_pake_set_context_req_p_context)))) &&
-		 ((zcbor_uint32_decode(state,
-				       (&(*result).psa_pake_set_context_req_context_len)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_expect(state, (83)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_pake_set_context_req_p_handle)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_pake_set_context_req_p_context)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_pake_set_context_req_context_len)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1706,13 +1776,13 @@ static bool decode_psa_pake_output_req(zcbor_state_t *state, struct psa_pake_out
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
-		((zcbor_uint32_expect(state, (84)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_pake_output_req_p_handle)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_pake_output_req_step)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_pake_output_req_p_output)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_pake_output_req_output_size)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_pake_output_req_p_output_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_expect(state, (84)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_pake_output_req_p_handle)))) &&
+		   ((zcbor_uint32_decode(state, (&(*result).psa_pake_output_req_step)))) &&
+		   ((decode_ptr_buf(state, (&(*result).psa_pake_output_req_p_output)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_pake_output_req_output_size)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_pake_output_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1730,10 +1800,10 @@ static bool decode_psa_pake_input_req(zcbor_state_t *state, struct psa_pake_inpu
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (85)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_pake_input_req_p_handle)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_pake_input_req_p_handle)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_pake_input_req_step)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_pake_input_req_p_input)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_pake_input_req_input_length)))))));
+		   ((decode_ptr_buf(state, (&(*result).psa_pake_input_req_p_input)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_pake_input_req_input_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1752,10 +1822,9 @@ static bool decode_psa_pake_get_shared_key_req(zcbor_state_t *state,
 
 	bool tmp_result = (((
 		((zcbor_uint32_expect(state, (86)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_pake_get_shared_key_req_p_handle)))) &&
-		((zcbor_uint32_decode(state,
-				      (&(*result).psa_pake_get_shared_key_req_p_attributes)))) &&
-		((zcbor_uint32_decode(state, (&(*result).psa_pake_get_shared_key_req_p_key)))))));
+		((decode_ptr_uint(state, (&(*result).psa_pake_get_shared_key_req_p_handle)))) &&
+		((decode_ptr_attr(state, (&(*result).psa_pake_get_shared_key_req_p_attributes)))) &&
+		((decode_ptr_key(state, (&(*result).psa_pake_get_shared_key_req_p_key)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1773,7 +1842,7 @@ static bool decode_psa_pake_abort_req(zcbor_state_t *state, struct psa_pake_abor
 
 	bool tmp_result =
 		(((((zcbor_uint32_expect(state, (87)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_pake_abort_req_p_handle)))))));
+		   ((decode_ptr_uint(state, (&(*result).psa_pake_abort_req_p_handle)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);

--- a/subsys/sdfw_services/services/psa_crypto/zcbor_generated/psa_crypto_service_encode.c
+++ b/subsys/sdfw_services/services/psa_crypto/zcbor_generated/psa_crypto_service_encode.c
@@ -22,15 +22,20 @@
 #error "The type file was generated with a different default_max_qty than this file"
 #endif
 
+static bool encode_ptr_attr(zcbor_state_t *state, const uint32_t *input);
 static bool encode_psa_get_key_attributes_req(zcbor_state_t *state,
 					      const struct psa_get_key_attributes_req *input);
 static bool encode_psa_reset_key_attributes_req(zcbor_state_t *state,
 						const struct psa_reset_key_attributes_req *input);
 static bool encode_psa_purge_key_req(zcbor_state_t *state, const struct psa_purge_key_req *input);
+static bool encode_ptr_key(zcbor_state_t *state, const uint32_t *input);
 static bool encode_psa_copy_key_req(zcbor_state_t *state, const struct psa_copy_key_req *input);
 static bool encode_psa_destroy_key_req(zcbor_state_t *state,
 				       const struct psa_destroy_key_req *input);
+static bool encode_ptr_buf(zcbor_state_t *state, const uint32_t *input);
+static bool encode_buf_len(zcbor_state_t *state, const uint32_t *input);
 static bool encode_psa_import_key_req(zcbor_state_t *state, const struct psa_import_key_req *input);
+static bool encode_ptr_uint(zcbor_state_t *state, const uint32_t *input);
 static bool encode_psa_export_key_req(zcbor_state_t *state, const struct psa_export_key_req *input);
 static bool encode_psa_export_public_key_req(zcbor_state_t *state,
 					     const struct psa_export_public_key_req *input);
@@ -144,6 +149,7 @@ static bool encode_psa_generate_random_req(zcbor_state_t *state,
 					   const struct psa_generate_random_req *input);
 static bool encode_psa_generate_key_req(zcbor_state_t *state,
 					const struct psa_generate_key_req *input);
+static bool encode_ptr_cipher(zcbor_state_t *state, const uint32_t *input);
 static bool encode_psa_pake_setup_req(zcbor_state_t *state, const struct psa_pake_setup_req *input);
 static bool encode_psa_pake_set_role_req(zcbor_state_t *state,
 					 const struct psa_pake_set_role_req *input);
@@ -162,16 +168,32 @@ static bool encode_psa_pake_abort_req(zcbor_state_t *state, const struct psa_pak
 static bool encode_psa_crypto_rsp(zcbor_state_t *state, const struct psa_crypto_rsp *input);
 static bool encode_psa_crypto_req(zcbor_state_t *state, const struct psa_crypto_req *input);
 
+static bool encode_ptr_attr(zcbor_state_t *state, const uint32_t *input)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool tmp_result =
+		((zcbor_tag_put(state, 32772) && (zcbor_uint32_encode(state, (&(*input))))));
+
+	if (!tmp_result) {
+		zcbor_trace_file(state);
+		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
+	} else {
+		zcbor_log("%s success\r\n", __func__);
+	}
+
+	return tmp_result;
+}
+
 static bool encode_psa_get_key_attributes_req(zcbor_state_t *state,
 					      const struct psa_get_key_attributes_req *input)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (11)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_get_key_attributes_req_key)))) &&
-		   ((zcbor_uint32_encode(state,
-					 (&(*input).psa_get_key_attributes_req_p_attributes)))))));
+	bool tmp_result = ((
+		(((zcbor_uint32_put(state, (11)))) &&
+		 ((zcbor_uint32_encode(state, (&(*input).psa_get_key_attributes_req_key)))) &&
+		 ((encode_ptr_attr(state, (&(*input).psa_get_key_attributes_req_p_attributes)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -190,8 +212,8 @@ static bool encode_psa_reset_key_attributes_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (12)))) &&
-		   ((zcbor_uint32_encode(
-			   state, (&(*input).psa_reset_key_attributes_req_p_attributes)))))));
+		   ((encode_ptr_attr(state,
+				     (&(*input).psa_reset_key_attributes_req_p_attributes)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -220,6 +242,23 @@ static bool encode_psa_purge_key_req(zcbor_state_t *state, const struct psa_purg
 	return tmp_result;
 }
 
+static bool encode_ptr_key(zcbor_state_t *state, const uint32_t *input)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool tmp_result =
+		((zcbor_tag_put(state, 32773) && (zcbor_uint32_encode(state, (&(*input))))));
+
+	if (!tmp_result) {
+		zcbor_trace_file(state);
+		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
+	} else {
+		zcbor_log("%s success\r\n", __func__);
+	}
+
+	return tmp_result;
+}
+
 static bool encode_psa_copy_key_req(zcbor_state_t *state, const struct psa_copy_key_req *input)
 {
 	zcbor_log("%s\r\n", __func__);
@@ -227,8 +266,8 @@ static bool encode_psa_copy_key_req(zcbor_state_t *state, const struct psa_copy_
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (14)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_copy_key_req_source_key)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_copy_key_req_p_attributes)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_copy_key_req_p_target_key)))))));
+		   ((encode_ptr_attr(state, (&(*input).psa_copy_key_req_p_attributes)))) &&
+		   ((encode_ptr_key(state, (&(*input).psa_copy_key_req_p_target_key)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -258,16 +297,67 @@ static bool encode_psa_destroy_key_req(zcbor_state_t *state,
 	return tmp_result;
 }
 
+static bool encode_ptr_buf(zcbor_state_t *state, const uint32_t *input)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool tmp_result =
+		((zcbor_tag_put(state, 32770) && (zcbor_uint32_encode(state, (&(*input))))));
+
+	if (!tmp_result) {
+		zcbor_trace_file(state);
+		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
+	} else {
+		zcbor_log("%s success\r\n", __func__);
+	}
+
+	return tmp_result;
+}
+
+static bool encode_buf_len(zcbor_state_t *state, const uint32_t *input)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool tmp_result =
+		((zcbor_tag_put(state, 32771) && (zcbor_uint32_encode(state, (&(*input))))));
+
+	if (!tmp_result) {
+		zcbor_trace_file(state);
+		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
+	} else {
+		zcbor_log("%s success\r\n", __func__);
+	}
+
+	return tmp_result;
+}
+
 static bool encode_psa_import_key_req(zcbor_state_t *state, const struct psa_import_key_req *input)
 {
 	zcbor_log("%s\r\n", __func__);
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (16)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_import_key_req_p_attributes)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_import_key_req_p_data)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_import_key_req_data_length)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_import_key_req_p_key)))))));
+		   ((encode_ptr_attr(state, (&(*input).psa_import_key_req_p_attributes)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_import_key_req_p_data)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_import_key_req_data_length)))) &&
+		   ((encode_ptr_key(state, (&(*input).psa_import_key_req_p_key)))))));
+
+	if (!tmp_result) {
+		zcbor_trace_file(state);
+		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
+	} else {
+		zcbor_log("%s success\r\n", __func__);
+	}
+
+	return tmp_result;
+}
+
+static bool encode_ptr_uint(zcbor_state_t *state, const uint32_t *input)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool tmp_result =
+		((zcbor_tag_put(state, 32774) && (zcbor_uint32_encode(state, (&(*input))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -286,9 +376,9 @@ static bool encode_psa_export_key_req(zcbor_state_t *state, const struct psa_exp
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (17)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_export_key_req_key)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_export_key_req_p_data)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_export_key_req_data_size)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_export_key_req_p_data_length)))))));
+		   ((encode_ptr_buf(state, (&(*input).psa_export_key_req_p_data)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_export_key_req_data_size)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_export_key_req_p_data_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -308,10 +398,9 @@ static bool encode_psa_export_public_key_req(zcbor_state_t *state,
 	bool tmp_result = ((
 		(((zcbor_uint32_put(state, (18)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_export_public_key_req_key)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_export_public_key_req_p_data)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_export_public_key_req_data_size)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_export_public_key_req_p_data_length)))))));
+		 ((encode_ptr_buf(state, (&(*input).psa_export_public_key_req_p_data)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_export_public_key_req_data_size)))) &&
+		 ((encode_ptr_uint(state, (&(*input).psa_export_public_key_req_p_data_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -328,14 +417,14 @@ static bool encode_psa_hash_compute_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_put(state, (19)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_hash_compute_req_alg)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_hash_compute_req_p_input)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_hash_compute_req_input_length)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_hash_compute_req_p_hash)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_hash_compute_req_hash_size)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_hash_compute_req_p_hash_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (19)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_compute_req_alg)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_hash_compute_req_p_input)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_hash_compute_req_input_length)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_hash_compute_req_p_hash)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_hash_compute_req_hash_size)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_hash_compute_req_p_hash_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -355,10 +444,10 @@ static bool encode_psa_hash_compare_req(zcbor_state_t *state,
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (20)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_compare_req_alg)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_compare_req_p_input)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_compare_req_input_length)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_compare_req_p_hash)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_compare_req_hash_length)))))));
+		   ((encode_ptr_buf(state, (&(*input).psa_hash_compare_req_p_input)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_hash_compare_req_input_length)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_hash_compare_req_p_hash)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_hash_compare_req_hash_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -374,10 +463,9 @@ static bool encode_psa_hash_setup_req(zcbor_state_t *state, const struct psa_has
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (21)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_setup_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_setup_req_alg)))))));
+	bool tmp_result = (((((zcbor_uint32_put(state, (21)))) &&
+			     ((encode_ptr_uint(state, (&(*input).psa_hash_setup_req_p_handle)))) &&
+			     ((zcbor_uint32_encode(state, (&(*input).psa_hash_setup_req_alg)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -396,9 +484,9 @@ static bool encode_psa_hash_update_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (22)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_update_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_update_req_p_input)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_update_req_input_length)))))));
+		   ((encode_ptr_uint(state, (&(*input).psa_hash_update_req_p_handle)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_hash_update_req_p_input)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_hash_update_req_input_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -417,10 +505,10 @@ static bool encode_psa_hash_finish_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (23)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_finish_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_finish_req_p_hash)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_finish_req_hash_size)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_finish_req_p_hash_length)))))));
+		   ((encode_ptr_uint(state, (&(*input).psa_hash_finish_req_p_handle)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_hash_finish_req_p_hash)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_hash_finish_req_hash_size)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_hash_finish_req_p_hash_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -439,9 +527,9 @@ static bool encode_psa_hash_verify_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (24)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_verify_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_verify_req_p_hash)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_verify_req_hash_length)))))));
+		   ((encode_ptr_uint(state, (&(*input).psa_hash_verify_req_p_handle)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_hash_verify_req_p_hash)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_hash_verify_req_hash_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -457,9 +545,8 @@ static bool encode_psa_hash_abort_req(zcbor_state_t *state, const struct psa_has
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (25)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_abort_req_p_handle)))))));
+	bool tmp_result = (((((zcbor_uint32_put(state, (25)))) &&
+			     ((encode_ptr_uint(state, (&(*input).psa_hash_abort_req_p_handle)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -478,7 +565,7 @@ static bool encode_psa_hash_clone_req(zcbor_state_t *state, const struct psa_has
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (26)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_clone_req_handle)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_clone_req_p_handle)))))));
+		   ((encode_ptr_uint(state, (&(*input).psa_hash_clone_req_p_handle)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -499,11 +586,11 @@ static bool encode_psa_mac_compute_req(zcbor_state_t *state,
 		(((((zcbor_uint32_put(state, (27)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_compute_req_key)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_compute_req_alg)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_compute_req_p_input)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_compute_req_input_length)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_compute_req_p_mac)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_compute_req_mac_size)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_compute_req_p_mac_length)))))));
+		   ((encode_ptr_buf(state, (&(*input).psa_mac_compute_req_p_input)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_mac_compute_req_input_length)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_mac_compute_req_p_mac)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_mac_compute_req_mac_size)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_mac_compute_req_p_mac_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -523,10 +610,10 @@ static bool encode_psa_mac_verify_req(zcbor_state_t *state, const struct psa_mac
 		(((((zcbor_uint32_put(state, (28)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_verify_req_key)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_verify_req_alg)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_verify_req_p_input)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_verify_req_input_length)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_verify_req_p_mac)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_verify_req_mac_length)))))));
+		   ((encode_ptr_buf(state, (&(*input).psa_mac_verify_req_p_input)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_mac_verify_req_input_length)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_mac_verify_req_p_mac)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_mac_verify_req_mac_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -545,7 +632,7 @@ static bool encode_psa_mac_sign_setup_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (29)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_sign_setup_req_p_handle)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_mac_sign_setup_req_p_handle)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_sign_setup_req_key)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_sign_setup_req_alg)))))));
 
@@ -566,7 +653,7 @@ static bool encode_psa_mac_verify_setup_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (30)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_verify_setup_req_p_handle)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_mac_verify_setup_req_p_handle)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_verify_setup_req_key)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_verify_setup_req_alg)))))));
 
@@ -586,9 +673,9 @@ static bool encode_psa_mac_update_req(zcbor_state_t *state, const struct psa_mac
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (31)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_update_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_update_req_p_input)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_update_req_input_length)))))));
+		   ((encode_ptr_uint(state, (&(*input).psa_mac_update_req_p_handle)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_mac_update_req_p_input)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_mac_update_req_input_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -605,12 +692,12 @@ static bool encode_psa_mac_sign_finish_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
-		((zcbor_uint32_put(state, (32)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_mac_sign_finish_req_p_handle)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_mac_sign_finish_req_p_mac)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_mac_sign_finish_req_mac_size)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_mac_sign_finish_req_p_mac_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (32)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_mac_sign_finish_req_p_handle)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_mac_sign_finish_req_p_mac)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_mac_sign_finish_req_mac_size)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_mac_sign_finish_req_p_mac_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -627,11 +714,11 @@ static bool encode_psa_mac_verify_finish_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
-		((zcbor_uint32_put(state, (33)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_mac_verify_finish_req_p_handle)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_mac_verify_finish_req_p_mac)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_mac_verify_finish_req_mac_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (33)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_mac_verify_finish_req_p_handle)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_mac_verify_finish_req_p_mac)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_mac_verify_finish_req_mac_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -647,9 +734,8 @@ static bool encode_psa_mac_abort_req(zcbor_state_t *state, const struct psa_mac_
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (34)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_abort_req_p_handle)))))));
+	bool tmp_result = (((((zcbor_uint32_put(state, (34)))) &&
+			     ((encode_ptr_uint(state, (&(*input).psa_mac_abort_req_p_handle)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -670,12 +756,11 @@ static bool encode_psa_cipher_encrypt_req(zcbor_state_t *state,
 		(((zcbor_uint32_put(state, (35)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_encrypt_req_key)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_encrypt_req_alg)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_encrypt_req_p_input)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_encrypt_req_input_length)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_encrypt_req_p_output)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_encrypt_req_output_size)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_cipher_encrypt_req_p_output_length)))))));
+		 ((encode_ptr_buf(state, (&(*input).psa_cipher_encrypt_req_p_input)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_cipher_encrypt_req_input_length)))) &&
+		 ((encode_ptr_buf(state, (&(*input).psa_cipher_encrypt_req_p_output)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_cipher_encrypt_req_output_size)))) &&
+		 ((encode_ptr_uint(state, (&(*input).psa_cipher_encrypt_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -696,12 +781,11 @@ static bool encode_psa_cipher_decrypt_req(zcbor_state_t *state,
 		(((zcbor_uint32_put(state, (36)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_decrypt_req_key)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_decrypt_req_alg)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_decrypt_req_p_input)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_decrypt_req_input_length)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_decrypt_req_p_output)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_decrypt_req_output_size)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_cipher_decrypt_req_p_output_length)))))));
+		 ((encode_ptr_buf(state, (&(*input).psa_cipher_decrypt_req_p_input)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_cipher_decrypt_req_input_length)))) &&
+		 ((encode_ptr_buf(state, (&(*input).psa_cipher_decrypt_req_p_output)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_cipher_decrypt_req_output_size)))) &&
+		 ((encode_ptr_uint(state, (&(*input).psa_cipher_decrypt_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -718,11 +802,11 @@ static bool encode_psa_cipher_encrypt_setup_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
-		((zcbor_uint32_put(state, (37)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_cipher_encrypt_setup_req_p_handle)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_cipher_encrypt_setup_req_key)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_cipher_encrypt_setup_req_alg)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (37)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_cipher_encrypt_setup_req_p_handle)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_encrypt_setup_req_key)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_encrypt_setup_req_alg)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -739,11 +823,11 @@ static bool encode_psa_cipher_decrypt_setup_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
-		((zcbor_uint32_put(state, (38)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_cipher_decrypt_setup_req_p_handle)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_cipher_decrypt_setup_req_key)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_cipher_decrypt_setup_req_alg)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (38)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_cipher_decrypt_setup_req_p_handle)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_decrypt_setup_req_key)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_decrypt_setup_req_alg)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -762,11 +846,10 @@ static bool encode_psa_cipher_generate_iv_req(zcbor_state_t *state,
 
 	bool tmp_result = ((
 		(((zcbor_uint32_put(state, (39)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_generate_iv_req_p_handle)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_generate_iv_req_p_iv)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_generate_iv_req_iv_size)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_cipher_generate_iv_req_p_iv_length)))))));
+		 ((encode_ptr_uint(state, (&(*input).psa_cipher_generate_iv_req_p_handle)))) &&
+		 ((encode_ptr_buf(state, (&(*input).psa_cipher_generate_iv_req_p_iv)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_cipher_generate_iv_req_iv_size)))) &&
+		 ((encode_ptr_uint(state, (&(*input).psa_cipher_generate_iv_req_p_iv_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -785,9 +868,9 @@ static bool encode_psa_cipher_set_iv_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (40)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_set_iv_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_set_iv_req_p_iv)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_set_iv_req_iv_length)))))));
+		   ((encode_ptr_uint(state, (&(*input).psa_cipher_set_iv_req_p_handle)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_cipher_set_iv_req_p_iv)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_cipher_set_iv_req_iv_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -806,13 +889,12 @@ static bool encode_psa_cipher_update_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (41)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_update_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_update_req_p_input)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_update_req_input_length)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_update_req_p_output)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_update_req_output_size)))) &&
-		   ((zcbor_uint32_encode(state,
-					 (&(*input).psa_cipher_update_req_p_output_length)))))));
+		   ((encode_ptr_uint(state, (&(*input).psa_cipher_update_req_p_handle)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_cipher_update_req_p_input)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_cipher_update_req_input_length)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_cipher_update_req_p_output)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_cipher_update_req_output_size)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_cipher_update_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -831,11 +913,10 @@ static bool encode_psa_cipher_finish_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (42)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_finish_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_finish_req_p_output)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_finish_req_output_size)))) &&
-		   ((zcbor_uint32_encode(state,
-					 (&(*input).psa_cipher_finish_req_p_output_length)))))));
+		   ((encode_ptr_uint(state, (&(*input).psa_cipher_finish_req_p_handle)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_cipher_finish_req_p_output)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_cipher_finish_req_output_size)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_cipher_finish_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -854,7 +935,7 @@ static bool encode_psa_cipher_abort_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (43)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_abort_req_p_handle)))))));
+		   ((encode_ptr_uint(state, (&(*input).psa_cipher_abort_req_p_handle)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -875,18 +956,16 @@ static bool encode_psa_aead_encrypt_req(zcbor_state_t *state,
 		((zcbor_uint32_put(state, (44)))) &&
 		((zcbor_uint32_encode(state, (&(*input).psa_aead_encrypt_req_key)))) &&
 		((zcbor_uint32_encode(state, (&(*input).psa_aead_encrypt_req_alg)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_aead_encrypt_req_p_nonce)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_aead_encrypt_req_nonce_length)))) &&
-		((zcbor_uint32_encode(state,
-				      (&(*input).psa_aead_encrypt_req_p_additional_data)))) &&
-		((zcbor_uint32_encode(state,
-				      (&(*input).psa_aead_encrypt_req_additional_data_length)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_aead_encrypt_req_p_plaintext)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_aead_encrypt_req_plaintext_length)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_aead_encrypt_req_p_ciphertext)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_aead_encrypt_req_ciphertext_size)))) &&
-		((zcbor_uint32_encode(state,
-				      (&(*input).psa_aead_encrypt_req_p_ciphertext_length)))))));
+		((encode_ptr_buf(state, (&(*input).psa_aead_encrypt_req_p_nonce)))) &&
+		((encode_buf_len(state, (&(*input).psa_aead_encrypt_req_nonce_length)))) &&
+		((encode_ptr_buf(state, (&(*input).psa_aead_encrypt_req_p_additional_data)))) &&
+		((encode_buf_len(state,
+				 (&(*input).psa_aead_encrypt_req_additional_data_length)))) &&
+		((encode_ptr_buf(state, (&(*input).psa_aead_encrypt_req_p_plaintext)))) &&
+		((encode_buf_len(state, (&(*input).psa_aead_encrypt_req_plaintext_length)))) &&
+		((encode_ptr_buf(state, (&(*input).psa_aead_encrypt_req_p_ciphertext)))) &&
+		((encode_buf_len(state, (&(*input).psa_aead_encrypt_req_ciphertext_size)))) &&
+		((encode_ptr_uint(state, (&(*input).psa_aead_encrypt_req_p_ciphertext_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -907,19 +986,16 @@ static bool encode_psa_aead_decrypt_req(zcbor_state_t *state,
 		(((zcbor_uint32_put(state, (45)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_decrypt_req_key)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_decrypt_req_alg)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_decrypt_req_p_nonce)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_decrypt_req_nonce_length)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_aead_decrypt_req_p_additional_data)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_aead_decrypt_req_additional_data_length)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_decrypt_req_p_ciphertext)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_aead_decrypt_req_ciphertext_length)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_decrypt_req_p_plaintext)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_decrypt_req_plaintext_size)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_aead_decrypt_req_p_plaintext_length)))))));
+		 ((encode_ptr_buf(state, (&(*input).psa_aead_decrypt_req_p_nonce)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_aead_decrypt_req_nonce_length)))) &&
+		 ((encode_ptr_buf(state, (&(*input).psa_aead_decrypt_req_p_additional_data)))) &&
+		 ((encode_buf_len(state,
+				  (&(*input).psa_aead_decrypt_req_additional_data_length)))) &&
+		 ((encode_ptr_buf(state, (&(*input).psa_aead_decrypt_req_p_ciphertext)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_aead_decrypt_req_ciphertext_length)))) &&
+		 ((encode_ptr_buf(state, (&(*input).psa_aead_decrypt_req_p_plaintext)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_aead_decrypt_req_plaintext_size)))) &&
+		 ((encode_ptr_uint(state, (&(*input).psa_aead_decrypt_req_p_plaintext_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -936,11 +1012,11 @@ static bool encode_psa_aead_encrypt_setup_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_put(state, (46)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_encrypt_setup_req_p_handle)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_encrypt_setup_req_key)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_encrypt_setup_req_alg)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (46)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_aead_encrypt_setup_req_p_handle)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_aead_encrypt_setup_req_key)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_aead_encrypt_setup_req_alg)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -957,11 +1033,11 @@ static bool encode_psa_aead_decrypt_setup_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_put(state, (47)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_decrypt_setup_req_p_handle)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_decrypt_setup_req_key)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_decrypt_setup_req_alg)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (47)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_aead_decrypt_setup_req_p_handle)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_aead_decrypt_setup_req_key)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_aead_decrypt_setup_req_alg)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -978,14 +1054,13 @@ static bool encode_psa_aead_generate_nonce_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_put(state, (48)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_generate_nonce_req_p_handle)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_generate_nonce_req_p_nonce)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_aead_generate_nonce_req_nonce_size)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_aead_generate_nonce_req_p_nonce_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (48)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_aead_generate_nonce_req_p_handle)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_aead_generate_nonce_req_p_nonce)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_aead_generate_nonce_req_nonce_size)))) &&
+		   ((encode_ptr_uint(state,
+				     (&(*input).psa_aead_generate_nonce_req_p_nonce_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1002,11 +1077,11 @@ static bool encode_psa_aead_set_nonce_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_put(state, (49)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_set_nonce_req_p_handle)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_set_nonce_req_p_nonce)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_set_nonce_req_nonce_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (49)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_aead_set_nonce_req_p_handle)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_aead_set_nonce_req_p_nonce)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_aead_set_nonce_req_nonce_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1023,12 +1098,11 @@ static bool encode_psa_aead_set_lengths_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (50)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_aead_set_lengths_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_aead_set_lengths_req_ad_length)))) &&
-		   ((zcbor_uint32_encode(
-			   state, (&(*input).psa_aead_set_lengths_req_plaintext_length)))))));
+	bool tmp_result = (((
+		((zcbor_uint32_put(state, (50)))) &&
+		((encode_ptr_uint(state, (&(*input).psa_aead_set_lengths_req_p_handle)))) &&
+		((encode_buf_len(state, (&(*input).psa_aead_set_lengths_req_ad_length)))) &&
+		((encode_buf_len(state, (&(*input).psa_aead_set_lengths_req_plaintext_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1045,11 +1119,11 @@ static bool encode_psa_aead_update_ad_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_put(state, (51)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_update_ad_req_p_handle)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_update_ad_req_p_input)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_update_ad_req_input_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (51)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_aead_update_ad_req_p_handle)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_aead_update_ad_req_p_input)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_aead_update_ad_req_input_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1066,14 +1140,14 @@ static bool encode_psa_aead_update_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_put(state, (52)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_update_req_p_handle)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_update_req_p_input)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_update_req_input_length)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_update_req_p_output)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_update_req_output_size)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_update_req_p_output_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (52)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_aead_update_req_p_handle)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_aead_update_req_p_input)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_aead_update_req_input_length)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_aead_update_req_p_output)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_aead_update_req_output_size)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_aead_update_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1092,14 +1166,13 @@ static bool encode_psa_aead_finish_req(zcbor_state_t *state,
 
 	bool tmp_result = ((
 		(((zcbor_uint32_put(state, (53)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_finish_req_p_handle)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_finish_req_p_ciphertext)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_finish_req_ciphertext_size)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_aead_finish_req_p_ciphertext_length)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_finish_req_p_tag)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_finish_req_tag_size)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_finish_req_p_tag_length)))))));
+		 ((encode_ptr_uint(state, (&(*input).psa_aead_finish_req_p_handle)))) &&
+		 ((encode_ptr_buf(state, (&(*input).psa_aead_finish_req_p_ciphertext)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_aead_finish_req_ciphertext_size)))) &&
+		 ((encode_ptr_uint(state, (&(*input).psa_aead_finish_req_p_ciphertext_length)))) &&
+		 ((encode_ptr_buf(state, (&(*input).psa_aead_finish_req_p_tag)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_aead_finish_req_tag_size)))) &&
+		 ((encode_ptr_uint(state, (&(*input).psa_aead_finish_req_p_tag_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1118,13 +1191,12 @@ static bool encode_psa_aead_verify_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (54)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_aead_verify_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_aead_verify_req_p_plaintext)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_aead_verify_req_plaintext_size)))) &&
-		   ((zcbor_uint32_encode(state,
-					 (&(*input).psa_aead_verify_req_p_plaintext_length)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_aead_verify_req_p_tag)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_aead_verify_req_tag_length)))))));
+		   ((encode_ptr_uint(state, (&(*input).psa_aead_verify_req_p_handle)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_aead_verify_req_p_plaintext)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_aead_verify_req_plaintext_size)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_aead_verify_req_p_plaintext_length)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_aead_verify_req_p_tag)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_aead_verify_req_tag_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1140,9 +1212,8 @@ static bool encode_psa_aead_abort_req(zcbor_state_t *state, const struct psa_aea
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (55)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_aead_abort_req_p_handle)))))));
+	bool tmp_result = (((((zcbor_uint32_put(state, (55)))) &&
+			     ((encode_ptr_uint(state, (&(*input).psa_aead_abort_req_p_handle)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1163,12 +1234,11 @@ static bool encode_psa_sign_message_req(zcbor_state_t *state,
 		(((zcbor_uint32_put(state, (56)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_sign_message_req_key)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_sign_message_req_alg)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_sign_message_req_p_input)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_sign_message_req_input_length)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_sign_message_req_p_signature)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_sign_message_req_signature_size)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_sign_message_req_p_signature_length)))))));
+		 ((encode_ptr_buf(state, (&(*input).psa_sign_message_req_p_input)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_sign_message_req_input_length)))) &&
+		 ((encode_ptr_buf(state, (&(*input).psa_sign_message_req_p_signature)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_sign_message_req_signature_size)))) &&
+		 ((encode_ptr_uint(state, (&(*input).psa_sign_message_req_p_signature_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1189,11 +1259,10 @@ static bool encode_psa_verify_message_req(zcbor_state_t *state,
 		(((zcbor_uint32_put(state, (57)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_verify_message_req_key)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_verify_message_req_alg)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_verify_message_req_p_input)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_verify_message_req_input_length)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_verify_message_req_p_signature)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_verify_message_req_signature_length)))))));
+		 ((encode_ptr_buf(state, (&(*input).psa_verify_message_req_p_input)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_verify_message_req_input_length)))) &&
+		 ((encode_ptr_buf(state, (&(*input).psa_verify_message_req_p_signature)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_verify_message_req_signature_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1209,15 +1278,15 @@ static bool encode_psa_sign_hash_req(zcbor_state_t *state, const struct psa_sign
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
-		((zcbor_uint32_put(state, (58)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_sign_hash_req_key)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_sign_hash_req_alg)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_sign_hash_req_p_hash)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_sign_hash_req_hash_length)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_sign_hash_req_p_signature)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_sign_hash_req_signature_size)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_sign_hash_req_p_signature_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (58)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_sign_hash_req_key)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_sign_hash_req_alg)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_sign_hash_req_p_hash)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_sign_hash_req_hash_length)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_sign_hash_req_p_signature)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_sign_hash_req_signature_size)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_sign_hash_req_p_signature_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1234,14 +1303,14 @@ static bool encode_psa_verify_hash_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
-		((zcbor_uint32_put(state, (59)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_verify_hash_req_key)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_verify_hash_req_alg)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_verify_hash_req_p_hash)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_verify_hash_req_hash_length)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_verify_hash_req_p_signature)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_verify_hash_req_signature_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (59)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_verify_hash_req_key)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_verify_hash_req_alg)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_verify_hash_req_p_hash)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_verify_hash_req_hash_length)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_verify_hash_req_p_signature)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_verify_hash_req_signature_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1258,21 +1327,18 @@ static bool encode_psa_asymmetric_encrypt_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_put(state, (60)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_encrypt_req_key)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_encrypt_req_alg)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_encrypt_req_p_input)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_asymmetric_encrypt_req_input_length)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_encrypt_req_p_salt)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_asymmetric_encrypt_req_salt_length)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_encrypt_req_p_output)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_asymmetric_encrypt_req_output_size)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_asymmetric_encrypt_req_p_output_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (60)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_encrypt_req_key)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_encrypt_req_alg)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_asymmetric_encrypt_req_p_input)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_asymmetric_encrypt_req_input_length)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_asymmetric_encrypt_req_p_salt)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_asymmetric_encrypt_req_salt_length)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_asymmetric_encrypt_req_p_output)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_asymmetric_encrypt_req_output_size)))) &&
+		   ((encode_ptr_uint(state,
+				     (&(*input).psa_asymmetric_encrypt_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1289,21 +1355,18 @@ static bool encode_psa_asymmetric_decrypt_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_put(state, (61)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_decrypt_req_key)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_decrypt_req_alg)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_decrypt_req_p_input)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_asymmetric_decrypt_req_input_length)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_decrypt_req_p_salt)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_asymmetric_decrypt_req_salt_length)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_decrypt_req_p_output)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_asymmetric_decrypt_req_output_size)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_asymmetric_decrypt_req_p_output_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (61)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_decrypt_req_key)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_decrypt_req_alg)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_asymmetric_decrypt_req_p_input)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_asymmetric_decrypt_req_input_length)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_asymmetric_decrypt_req_p_salt)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_asymmetric_decrypt_req_salt_length)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_asymmetric_decrypt_req_p_output)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_asymmetric_decrypt_req_output_size)))) &&
+		   ((encode_ptr_uint(state,
+				     (&(*input).psa_asymmetric_decrypt_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1320,10 +1383,10 @@ static bool encode_psa_key_derivation_setup_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
-		((zcbor_uint32_put(state, (62)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_key_derivation_setup_req_p_handle)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_key_derivation_setup_req_alg)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (62)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_key_derivation_setup_req_p_handle)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_key_derivation_setup_req_alg)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1345,7 +1408,7 @@ encode_psa_key_derivation_get_capacity_req(zcbor_state_t *state,
 		(((((zcbor_uint32_put(state, (63)))) &&
 		   ((zcbor_uint32_encode(
 			   state, (&(*input).psa_key_derivation_get_capacity_req_handle)))) &&
-		   ((zcbor_uint32_encode(
+		   ((encode_ptr_uint(
 			   state, (&(*input).psa_key_derivation_get_capacity_req_p_capacity)))))));
 
 	if (!tmp_result) {
@@ -1366,8 +1429,8 @@ encode_psa_key_derivation_set_capacity_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (64)))) &&
-		   ((zcbor_uint32_encode(
-			   state, (&(*input).psa_key_derivation_set_capacity_req_p_handle)))) &&
+		   ((encode_ptr_uint(state,
+				     (&(*input).psa_key_derivation_set_capacity_req_p_handle)))) &&
 		   ((zcbor_uint32_encode(
 			   state, (&(*input).psa_key_derivation_set_capacity_req_capacity)))))));
 
@@ -1387,16 +1450,15 @@ encode_psa_key_derivation_input_bytes_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (65)))) &&
-		   ((zcbor_uint32_encode(
-			   state, (&(*input).psa_key_derivation_input_bytes_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state,
-					 (&(*input).psa_key_derivation_input_bytes_req_step)))) &&
-		   ((zcbor_uint32_encode(state,
-					 (&(*input).psa_key_derivation_input_bytes_req_p_data)))) &&
-		   ((zcbor_uint32_encode(
-			   state, (&(*input).psa_key_derivation_input_bytes_req_data_length)))))));
+	bool tmp_result = ((
+		(((zcbor_uint32_put(state, (65)))) &&
+		 ((encode_ptr_uint(state,
+				   (&(*input).psa_key_derivation_input_bytes_req_p_handle)))) &&
+		 ((zcbor_uint32_encode(state,
+				       (&(*input).psa_key_derivation_input_bytes_req_step)))) &&
+		 ((encode_ptr_buf(state, (&(*input).psa_key_derivation_input_bytes_req_p_data)))) &&
+		 ((encode_buf_len(state,
+				  (&(*input).psa_key_derivation_input_bytes_req_data_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1415,8 +1477,8 @@ static bool encode_psa_key_derivation_input_integer_req(
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (66)))) &&
-		   ((zcbor_uint32_encode(
-			   state, (&(*input).psa_key_derivation_input_integer_req_p_handle)))) &&
+		   ((encode_ptr_uint(state,
+				     (&(*input).psa_key_derivation_input_integer_req_p_handle)))) &&
 		   ((zcbor_uint32_encode(state,
 					 (&(*input).psa_key_derivation_input_integer_req_step)))) &&
 		   ((zcbor_uint32_encode(
@@ -1440,8 +1502,7 @@ encode_psa_key_derivation_input_key_req(zcbor_state_t *state,
 
 	bool tmp_result = (((
 		((zcbor_uint32_put(state, (67)))) &&
-		((zcbor_uint32_encode(state,
-				      (&(*input).psa_key_derivation_input_key_req_p_handle)))) &&
+		((encode_ptr_uint(state, (&(*input).psa_key_derivation_input_key_req_p_handle)))) &&
 		((zcbor_uint32_encode(state, (&(*input).psa_key_derivation_input_key_req_step)))) &&
 		((zcbor_uint32_encode(state, (&(*input).psa_key_derivation_input_key_req_key)))))));
 
@@ -1462,15 +1523,15 @@ static bool encode_psa_key_derivation_key_agreement_req(
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (68)))) &&
-		   ((zcbor_uint32_encode(
-			   state, (&(*input).psa_key_derivation_key_agreement_req_p_handle)))) &&
+		   ((encode_ptr_uint(state,
+				     (&(*input).psa_key_derivation_key_agreement_req_p_handle)))) &&
 		   ((zcbor_uint32_encode(state,
 					 (&(*input).psa_key_derivation_key_agreement_req_step)))) &&
 		   ((zcbor_uint32_encode(
 			   state, (&(*input).psa_key_derivation_key_agreement_req_private_key)))) &&
-		   ((zcbor_uint32_encode(
+		   ((encode_ptr_buf(
 			   state, (&(*input).psa_key_derivation_key_agreement_req_p_peer_key)))) &&
-		   ((zcbor_uint32_encode(
+		   ((encode_buf_len(
 			   state,
 			   (&(*input).psa_key_derivation_key_agreement_req_peer_key_length)))))));
 
@@ -1490,14 +1551,14 @@ encode_psa_key_derivation_output_bytes_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
-		((zcbor_uint32_put(state, (69)))) &&
-		((zcbor_uint32_encode(state,
-				      (&(*input).psa_key_derivation_output_bytes_req_p_handle)))) &&
-		((zcbor_uint32_encode(state,
-				      (&(*input).psa_key_derivation_output_bytes_req_p_output)))) &&
-		((zcbor_uint32_encode(
-			state, (&(*input).psa_key_derivation_output_bytes_req_output_length)))))));
+	bool tmp_result = ((
+		(((zcbor_uint32_put(state, (69)))) &&
+		 ((encode_ptr_uint(state,
+				   (&(*input).psa_key_derivation_output_bytes_req_p_handle)))) &&
+		 ((encode_ptr_buf(state,
+				  (&(*input).psa_key_derivation_output_bytes_req_p_output)))) &&
+		 ((encode_buf_len(
+			 state, (&(*input).psa_key_derivation_output_bytes_req_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1515,14 +1576,13 @@ encode_psa_key_derivation_output_key_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (70)))) &&
-		   ((zcbor_uint32_encode(
-			   state, (&(*input).psa_key_derivation_output_key_req_p_attributes)))) &&
-		   ((zcbor_uint32_encode(
-			   state, (&(*input).psa_key_derivation_output_key_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state,
-					 (&(*input).psa_key_derivation_output_key_req_p_key)))))));
+	bool tmp_result = ((
+		(((zcbor_uint32_put(state, (70)))) &&
+		 ((encode_ptr_attr(state,
+				   (&(*input).psa_key_derivation_output_key_req_p_attributes)))) &&
+		 ((encode_ptr_uint(state,
+				   (&(*input).psa_key_derivation_output_key_req_p_handle)))) &&
+		 ((encode_ptr_key(state, (&(*input).psa_key_derivation_output_key_req_p_key)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1539,9 +1599,9 @@ static bool encode_psa_key_derivation_abort_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((((zcbor_uint32_put(state, (71)))) &&
-			     ((zcbor_uint32_encode(
-				     state, (&(*input).psa_key_derivation_abort_req_p_handle)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (71)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_key_derivation_abort_req_p_handle)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1562,13 +1622,12 @@ static bool encode_psa_raw_key_agreement_req(zcbor_state_t *state,
 		((zcbor_uint32_put(state, (72)))) &&
 		((zcbor_uint32_encode(state, (&(*input).psa_raw_key_agreement_req_alg)))) &&
 		((zcbor_uint32_encode(state, (&(*input).psa_raw_key_agreement_req_private_key)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_raw_key_agreement_req_p_peer_key)))) &&
-		((zcbor_uint32_encode(state,
-				      (&(*input).psa_raw_key_agreement_req_peer_key_length)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_raw_key_agreement_req_p_output)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_raw_key_agreement_req_output_size)))) &&
-		((zcbor_uint32_encode(state,
-				      (&(*input).psa_raw_key_agreement_req_p_output_length)))))));
+		((encode_ptr_buf(state, (&(*input).psa_raw_key_agreement_req_p_peer_key)))) &&
+		((encode_buf_len(state, (&(*input).psa_raw_key_agreement_req_peer_key_length)))) &&
+		((encode_ptr_buf(state, (&(*input).psa_raw_key_agreement_req_p_output)))) &&
+		((encode_buf_len(state, (&(*input).psa_raw_key_agreement_req_output_size)))) &&
+		((encode_ptr_uint(state,
+				  (&(*input).psa_raw_key_agreement_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1585,10 +1644,10 @@ static bool encode_psa_generate_random_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_put(state, (73)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_generate_random_req_p_output)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_generate_random_req_output_size)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (73)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_generate_random_req_p_output)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_generate_random_req_output_size)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1607,8 +1666,25 @@ static bool encode_psa_generate_key_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (74)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_generate_key_req_p_attributes)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_generate_key_req_p_key)))))));
+		   ((encode_ptr_attr(state, (&(*input).psa_generate_key_req_p_attributes)))) &&
+		   ((encode_ptr_key(state, (&(*input).psa_generate_key_req_p_key)))))));
+
+	if (!tmp_result) {
+		zcbor_trace_file(state);
+		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
+	} else {
+		zcbor_log("%s success\r\n", __func__);
+	}
+
+	return tmp_result;
+}
+
+static bool encode_ptr_cipher(zcbor_state_t *state, const uint32_t *input)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool tmp_result =
+		((zcbor_tag_put(state, 32775) && (zcbor_uint32_encode(state, (&(*input))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1626,9 +1702,9 @@ static bool encode_psa_pake_setup_req(zcbor_state_t *state, const struct psa_pak
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (79)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_setup_req_p_handle)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_pake_setup_req_p_handle)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_setup_req_password_key)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_setup_req_p_cipher_suite)))))));
+		   ((encode_ptr_cipher(state, (&(*input).psa_pake_setup_req_p_cipher_suite)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1647,7 +1723,7 @@ static bool encode_psa_pake_set_role_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (80)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_set_role_req_p_handle)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_pake_set_role_req_p_handle)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_set_role_req_role)))))));
 
 	if (!tmp_result) {
@@ -1667,9 +1743,9 @@ static bool encode_psa_pake_set_user_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (81)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_set_user_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_set_user_req_p_user_id)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_set_user_req_user_id_len)))))));
+		   ((encode_ptr_uint(state, (&(*input).psa_pake_set_user_req_p_handle)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_pake_set_user_req_p_user_id)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_pake_set_user_req_user_id_len)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1688,9 +1764,9 @@ static bool encode_psa_pake_set_peer_req(zcbor_state_t *state,
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (82)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_set_peer_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_set_peer_req_p_peer_id)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_set_peer_req_peer_id_len)))))));
+		   ((encode_ptr_uint(state, (&(*input).psa_pake_set_peer_req_p_handle)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_pake_set_peer_req_p_peer_id)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_pake_set_peer_req_peer_id_len)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1707,11 +1783,11 @@ static bool encode_psa_pake_set_context_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
-		((zcbor_uint32_put(state, (83)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_pake_set_context_req_p_handle)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_pake_set_context_req_p_context)))) &&
-		((zcbor_uint32_encode(state, (&(*input).psa_pake_set_context_req_context_len)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (83)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_pake_set_context_req_p_handle)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_pake_set_context_req_p_context)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_pake_set_context_req_context_len)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1728,13 +1804,13 @@ static bool encode_psa_pake_output_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
-		(((zcbor_uint32_put(state, (84)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_pake_output_req_p_handle)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_pake_output_req_step)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_pake_output_req_p_output)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_pake_output_req_output_size)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_pake_output_req_p_output_length)))))));
+	bool tmp_result =
+		(((((zcbor_uint32_put(state, (84)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_pake_output_req_p_handle)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_output_req_step)))) &&
+		   ((encode_ptr_buf(state, (&(*input).psa_pake_output_req_p_output)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_pake_output_req_output_size)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_pake_output_req_p_output_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1752,10 +1828,10 @@ static bool encode_psa_pake_input_req(zcbor_state_t *state, const struct psa_pak
 
 	bool tmp_result =
 		(((((zcbor_uint32_put(state, (85)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_input_req_p_handle)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_pake_input_req_p_handle)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_input_req_step)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_input_req_p_input)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_input_req_input_length)))))));
+		   ((encode_ptr_buf(state, (&(*input).psa_pake_input_req_p_input)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_pake_input_req_input_length)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1774,10 +1850,9 @@ static bool encode_psa_pake_get_shared_key_req(zcbor_state_t *state,
 
 	bool tmp_result = ((
 		(((zcbor_uint32_put(state, (86)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_pake_get_shared_key_req_p_handle)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_pake_get_shared_key_req_p_attributes)))) &&
-		 ((zcbor_uint32_encode(state, (&(*input).psa_pake_get_shared_key_req_p_key)))))));
+		 ((encode_ptr_uint(state, (&(*input).psa_pake_get_shared_key_req_p_handle)))) &&
+		 ((encode_ptr_attr(state, (&(*input).psa_pake_get_shared_key_req_p_attributes)))) &&
+		 ((encode_ptr_key(state, (&(*input).psa_pake_get_shared_key_req_p_key)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);
@@ -1793,9 +1868,8 @@ static bool encode_psa_pake_abort_req(zcbor_state_t *state, const struct psa_pak
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (87)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_abort_req_p_handle)))))));
+	bool tmp_result = (((((zcbor_uint32_put(state, (87)))) &&
+			     ((encode_ptr_uint(state, (&(*input).psa_pake_abort_req_p_handle)))))));
 
 	if (!tmp_result) {
 		zcbor_trace_file(state);


### PR DESCRIPTION
Tags are added to all pointers to enable memory checking on the server side of the service. The cbor tags are registered here: https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml

Ref: NCSDK-NONE