### PR TITLE
drivers: mpsl: flash: Add uspport for nRF54L15DK to the driver

### DIFF
--- a/drivers/mpsl/flash_sync/flash_sync_mpsl.c
+++ b/drivers/mpsl/flash_sync/flash_sync_mpsl.c
@@ -56,13 +56,13 @@ static struct mpsl_context _context;
  */
 static uint32_t get_timeslot_time_us(void)
 {
-#ifdef CONFIG_SOC_NRF54L15_ENGA_CPUAPP
+#ifdef CONFIG_SOC_SERIES_NRF54LX
 	nrf_timer_task_trigger(NRF_TIMER10, NRF_TIMER_TASK_CAPTURE0);
 	return nrf_timer_cc_get(NRF_TIMER10, NRF_TIMER_CC_CHANNEL0);
 #else
 	nrf_timer_task_trigger(NRF_TIMER0, NRF_TIMER_TASK_CAPTURE0);
 	return nrf_timer_cc_get(NRF_TIMER0, NRF_TIMER_CC_CHANNEL0);
-#endif
+#endif /* SOC_SERIES_NRF54LX */
 }
 
 static void reschedule_next_timeslot(void)
@@ -229,7 +229,7 @@ void nrf_flash_sync_get_timestamp_begin(void)
 
 bool nrf_flash_sync_check_time_limit(uint32_t iteration)
 {
-#ifdef CONFIG_SOC_NRF54L15_ENGA_CPUAPP
+#ifdef CONFIG_SOC_SERIES_NRF54LX
 	/* The time taken in a previous write is not a predictor of the time taken
 	 * for the next write. Writing the same value as is already stored is much
 	 * faster than writing a different value. If the first few writes are fast
@@ -237,11 +237,11 @@ bool nrf_flash_sync_check_time_limit(uint32_t iteration)
 	 * event length is only guaranteed to fit one write block.
 	 */
 
-	(void)get_timeslot_time_us;
+	(void)get_timeslot_time_us; /* Needed to avoid build time warning: unused static function*/
 	return true;
 #else
 	uint32_t now_us = get_timeslot_time_us();
 	uint32_t time_per_iteration_us = now_us / iteration;
 	return now_us + time_per_iteration_us >= _context.request_length_us;
-#endif
+#endif /* SOC_SERIES_NRF54LX */
 }


### PR DESCRIPTION
The driver had two places where it was dependent on CONFIG_SOC_NRF54L15_ENGA_CPUAPP Kconfig. Change the code to make  it build for all nRF54L15 versions.