### PR TITLE
samples: wifi: radio_test: Correct command output and order

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -520,6 +520,7 @@ Wi-Fi samples
 * :ref:`wifi_radio_test` sample:
 
   * Added capture timeout as a parameter for packet capture.
+  * Expanded the scope of ``wifi_radio_test show_config`` subcommand and rectified the behavior of ``wifi_radio_test tx_pkt_preamble`` subcommand.
 
 * :ref:`softap_wifi_provision_sample` sample:
 

--- a/samples/wifi/radio_test/sample_description.rst
+++ b/samples/wifi/radio_test/sample_description.rst
@@ -100,7 +100,7 @@ Testing
 
               tx_pkt_tput_mode = 0
               tx_pkt_sgi = 0
-              tx_pkt_preamble = 1
+              tx_pkt_preamble = 0
               tx_pkt_mcs = 0
               tx_pkt_rate = 6
               tx_pkt_gap = 0
@@ -111,7 +111,7 @@ Testing
               phy_calib_txiq = 1
               tx_pkt_num = -1
               tx_pkt_len = 1400
-              tx_power = 0
+              tx_power = 30
               he_ltf = 2
               he_gi = 2
               xo_val = 42
@@ -120,12 +120,14 @@ Testing
               rx = 0
               tx_tone_freq = 0
               rx_lna_gain = 0
-              rx_lna_gain = 0
+              rx_bb_gain = 0
               rx_capture_length = 0
               wlan_ant_switch_ctrl = 0
               tx_pkt_cw = 15
               reg_domain = 00
-              bypass_reg_domian = 0
+              bypass_reg_domain = 0
+              ru_tone = 26
+              ru_index = 1
 
          * To run a continuous Orthogonal frequency-division multiplexing (OFDM) TX traffic sequence with the following configuration:
 
@@ -185,7 +187,7 @@ Testing
            .. code-block:: console
 
               wifi_radio_test init 14
-              wifi_radio_test tx_pkt_preamble 1
+              wifi_radio_test tx_pkt_preamble 0
               wifi_radio_test tx_pkt_rate 1
               wifi_radio_test tx_pkt_len 1024
               wifi_radio_test tx_power 10

--- a/samples/wifi/radio_test/src/nrf_wifi_radio_test_shell.c
+++ b/samples/wifi/radio_test/src/nrf_wifi_radio_test_shell.c
@@ -2423,8 +2423,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD_ARG(rx_cap,
 		      NULL,
 		      "0 = ADC capture\n"
-		      "1 = Static packet capture\n"
-		      "2 = Dynamic packet captur              ",
+		      "1 = Filtered ADC capture\n"
+		      "2 = Dynamic packet capture              ",
 		      nrf_wifi_radio_test_rx_cap,
 		      2,
 		      0),


### PR DESCRIPTION
[SHEL-3047]: Update command output, subcommand order and argument.

[SHEL-3047]: https://nordicsemi.atlassian.net/browse/SHEL-3047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ