### PR TITLE
modules: TF-m: nrf54l15_cpuapp: hardcode CPU frequency

### DIFF
--- a/modules/trusted-firmware-m/tfm_boards/nrf54l15_cpuapp/ns/cpuarch_ns.cmake
+++ b/modules/trusted-firmware-m/tfm_boards/nrf54l15_cpuapp/ns/cpuarch_ns.cmake
@@ -7,4 +7,6 @@
 set(PLATFORM_DIR  ${CMAKE_CURRENT_LIST_DIR})
 set(PLATFORM_PATH ${CMAKE_CURRENT_LIST_DIR})
 
+add_compile_definitions(NRF_CONFIG_CPU_FREQ_MHZ=128)
+
 include(${CMAKE_CURRENT_LIST_DIR}/common/nrf54l15/cpuarch.cmake)


### PR DESCRIPTION
Hardcoded 128 MHz frequency in the TF-m build for the nRF54L15 target as the frequency setting with the NRF_CONFIG_CPU_FREQ_MHZ symbol is mandatory for this board target in nrfx v3.6.0.