### PR TITLE
v2.6: drivers: wifi: Fix shell hang

### DIFF
--- a/drivers/wifi/nrf700x/src/shim.c
+++ b/drivers/wifi/nrf700x/src/shim.c
@@ -120,7 +120,7 @@ static void zep_shim_qspi_cpy_to(void *priv, unsigned long addr, const void *src
 
 static void *zep_shim_spinlock_alloc(void)
 {
-	struct k_sem *lock = NULL;
+	struct k_mutex *lock = NULL;
 
 	lock = k_malloc(sizeof(*lock));
 
@@ -138,27 +138,29 @@ static void zep_shim_spinlock_free(void *lock)
 
 static void zep_shim_spinlock_init(void *lock)
 {
-	k_sem_init(lock, 1, 1);
+	k_mutex_init(lock);
 }
 
 static void zep_shim_spinlock_take(void *lock)
 {
-	k_sem_take(lock, K_FOREVER);
+	k_mutex_lock(lock, K_FOREVER);
 }
 
 static void zep_shim_spinlock_rel(void *lock)
 {
-	k_sem_give(lock);
+	k_mutex_unlock(lock);
 }
 
 static void zep_shim_spinlock_irq_take(void *lock, unsigned long *flags)
 {
-	k_sem_take(lock, K_FOREVER);
+	ARG_UNUSED(flags);
+	k_mutex_lock(lock, K_FOREVER);
 }
 
 static void zep_shim_spinlock_irq_rel(void *lock, unsigned long *flags)
 {
-	k_sem_give(lock);
+	ARG_UNUSED(flags);
+	k_mutex_unlock(lock);
 }
 
 static int zep_shim_pr_dbg(const char *fmt, va_list args)

--- a/drivers/wifi/nrf700x/src/shim.c
+++ b/drivers/wifi/nrf700x/src/shim.c
@@ -754,6 +754,11 @@ static void irq_work_handler(struct k_work *work)
 {
 	int ret = 0;
 
+	if (!intr_priv || !intr_priv->callbk_fn || !intr_priv->callbk_data) {
+		LOG_ERR("%s: Invalid intr_priv handler", __func__);
+		return;
+	}
+
 	ret = intr_priv->callbk_fn(intr_priv->callbk_data);
 
 	if (ret) {
@@ -768,6 +773,11 @@ static void zep_shim_irq_handler(const struct device *dev, struct gpio_callback 
 {
 	ARG_UNUSED(cb);
 	ARG_UNUSED(pins);
+
+	if (!intr_priv || !intr_priv->callbk_fn || !intr_priv->callbk_data) {
+		LOG_ERR("%s: Invalid intr_priv", __func__);
+		return;
+	}
 
 	k_work_schedule_for_queue(&zep_wifi_intr_q, &intr_priv->work, K_NO_WAIT);
 }


### PR DESCRIPTION
Add a null check for HAL context in the interrupt handler, this was causing locking issue operating on null. The root cause of null is not known, but this solves the locking issue when data and control paths are excited in parallel.