### PR TITLE
tools: Add windows-curses to reequirements

### DIFF
--- a/scripts/requirements-build.txt
+++ b/scripts/requirements-build.txt
@@ -7,3 +7,4 @@ intelhex
 pylint
 zcbor~=0.8.0
 nrf-regtool~=5.5.1
+windows-curses; sys_platform == 'win32'


### PR DESCRIPTION
windows-curses package is available only on Windows.