### PR TITLE
boards: shields: nrf2240ek: 500mA pmic current limit on bootup

### DIFF
--- a/boards/shields/nrf2240ek/nrf2240ek.conf
+++ b/boards/shields/nrf2240ek/nrf2240ek.conf
@@ -1,3 +1,11 @@
 CONFIG_BOOT_BANNER=n
 CONFIG_EARLY_CONSOLE=n
 CONFIG_NCS_BOOT_BANNER=n
+
+# Options related to the nPM1300 regulator and the workaround
+# against voltage drops on the nRF2240 power supply pin VDDPALDO.
+CONFIG_SENSOR=y
+CONFIG_NPM1300_CHARGER=y
+# Ensure that FEM is initialized after the nPM1300 current limit on the nRF2240EK is set.
+CONFIG_SENSOR_INIT_PRIORITY=90
+CONFIG_MPSL_FEM_INIT_PRIORITY=91

--- a/boards/shields/nrf2240ek/nrf2240ek.overlay
+++ b/boards/shields/nrf2240ek/nrf2240ek.overlay
@@ -18,7 +18,7 @@
 	};
 };
 
-fem_twi: &arduino_i2c {
+&arduino_i2c {
 	status = "okay";
 	compatible = "nordic,nrf-twim";
 
@@ -26,5 +26,28 @@ fem_twi: &arduino_i2c {
 		compatible = "nordic,nrf2240-fem-twi";
 		status = "okay";
 		reg = <0x30>;
+	};
+
+	/* The nPM1300 on the nRF2240EK is used to supply power to the nRF2240 device. */
+	nrf2240ek_pmic: pmic@6b {
+		compatible = "nordic,npm1300";
+		status = "okay";
+		reg = <0x6b>;
+
+		nrf2240ek_pmic_charger: charger {
+			compatible = "nordic,npm1300-charger";
+			status = "okay";
+			/* When objects are placed close to the PCB antenna of the nRF2240EK shield
+			 * the supply voltage drops on the nRF2240 power supply pin VDDPALDO were observed.
+			 * As a workaround the current limit on VBUS of the PMIC is increased.
+			 */
+			vbus-limit-microamp = <500000>;
+			/* This PMIC does not have a battery, but the settings below are required by the driver */
+			term-microvolt = <4150000>;
+			current-microamp = <150000>;
+			dischg-limit-microamp = <1000000>;
+			thermistor-ohms = <10000>;
+			thermistor-beta = <3380>;
+		};
 	};
 };


### PR DESCRIPTION
Bringing objects close to the PCB antenna of the nRF2240EK might
cause voltage drops which could in effect reset the nRF2240 what is
invisible to the remaining application.
To counteract this phenomenon the current limit of the PMIC
present on the nRF2240EK is increased to 500mA.