### PR TITLE
mspl: Treat simulated nrf54l15 like real one

### DIFF
--- a/drivers/mpsl/flash_sync/flash_sync_mpsl.c
+++ b/drivers/mpsl/flash_sync/flash_sync_mpsl.c
@@ -56,7 +56,7 @@ static struct mpsl_context _context;
  */
 static uint32_t get_timeslot_time_us(void)
 {
-#ifdef CONFIG_SOC_SERIES_NRF54LX
+#ifdef CONFIG_SOC_COMPATIBLE_NRF54LX
 	nrf_timer_task_trigger(NRF_TIMER10, NRF_TIMER_TASK_CAPTURE0);
 	return nrf_timer_cc_get(NRF_TIMER10, NRF_TIMER_CC_CHANNEL0);
 #else
@@ -229,7 +229,7 @@ void nrf_flash_sync_get_timestamp_begin(void)
 
 bool nrf_flash_sync_check_time_limit(uint32_t iteration)
 {
-#ifdef CONFIG_SOC_SERIES_NRF54LX
+#ifdef CONFIG_SOC_COMPATIBLE_NRF54LX
 	/* The time taken in a previous write is not a predictor of the time taken
 	 * for the next write. Writing the same value as is already stored is much
 	 * faster than writing a different value. If the first few writes are fast

--- a/subsys/mpsl/init/Kconfig
+++ b/subsys/mpsl/init/Kconfig
@@ -69,7 +69,7 @@ config MPSL_LOW_PRIO_IRQN
 	default 25 if SOC_COMPATIBLE_NRF52X # SWI5
 	default 26 if SOC_COMPATIBLE_NRF53X # SWI0
 	default 404 if SOC_SERIES_NRF54HX # QDEC130
-	default 28 if SOC_SERIES_NRF54LX # SWI00
+	default 28 if SOC_COMPATIBLE_NRF54LX # SWI00
 	help
 	  This option sets the low priority interrupt that MPSL will use.
 	  Check the interrupt number in the MDK

--- a/subsys/mpsl/init/mpsl_init.c
+++ b/subsys/mpsl/init/mpsl_init.c
@@ -42,11 +42,11 @@ extern void rtc_pretick_rtc0_isr_hook(void);
 	#endif
 #endif
 
-#if !defined(CONFIG_SOC_SERIES_NRF54HX) && !defined(CONFIG_SOC_SERIES_NRF54LX)
+#if !defined(CONFIG_SOC_SERIES_NRF54HX) && !defined(CONFIG_SOC_COMPATIBLE_NRF54LX)
 #define MPSL_TIMER_IRQn TIMER0_IRQn
 #define MPSL_RTC_IRQn RTC0_IRQn
 #define MPSL_RADIO_IRQn RADIO_IRQn
-#elif defined(CONFIG_SOC_SERIES_NRF54LX)
+#elif defined(CONFIG_SOC_COMPATIBLE_NRF54LX)
 #define MPSL_TIMER_IRQn TIMER10_IRQn
 #define MPSL_RTC_IRQn GRTC_3_IRQn
 #define MPSL_RADIO_IRQn RADIO_0_IRQn
@@ -59,11 +59,11 @@ extern void rtc_pretick_rtc0_isr_hook(void);
 #if defined(CONFIG_SOC_SERIES_NRF54HX)
 /* Basic build time sanity checking */
 #define MPSL_RESERVED_GRTC_CHANNELS ((1U << 8) | (1U << 9) | (1U << 10) | (1U << 11) | (1U << 12))
-#elif defined(CONFIG_SOC_SERIES_NRF54LX)
+#elif defined(CONFIG_SOC_COMPATIBLE_NRF54LX)
 #define MPSL_RESERVED_GRTC_CHANNELS ((1U << 7) | (1U << 8) | (1U << 9) | (1U << 10) | (1U << 11))
 #endif
 
-#if defined(CONFIG_SOC_SERIES_NRF54HX) || defined(CONFIG_SOC_SERIES_NRF54LX)
+#if defined(CONFIG_SOC_SERIES_NRF54HX) || defined(CONFIG_SOC_COMPATIBLE_NRF54LX)
 
 BUILD_ASSERT(MPSL_RTC_IRQn != DT_IRQN(DT_NODELABEL(grtc)), "MPSL requires a dedicated GRTC IRQ");
 


### PR DESCRIPTION
Let's use the SOC_COMPATIBLE_NRF54LX kconfig option instead of SOC_SERIES_NRF54LX so we treat both the real and simulated targets equally.

Requires (merged)
* https://github.com/nrfconnect/sdk-zephyr/pull/1993 