### PR TITLE
Samples: Bluetooth: add overlays to iso_time_sync

### DIFF
--- a/samples/bluetooth/iso_time_sync/boards/nrf52_bsim.conf
+++ b/samples/bluetooth/iso_time_sync/boards/nrf52_bsim.conf
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_NRFX_TIMER1=y
+CONFIG_NRFX_RTC2=y
+CONFIG_NRFX_PPI=y
+CONFIG_GPIO=y
+CONFIG_UART_CONSOLE=y
+CONFIG_UART_NATIVE_POSIX=y
+CONFIG_SERIAL=y

--- a/samples/bluetooth/iso_time_sync/boards/nrf52_bsim.overlay
+++ b/samples/bluetooth/iso_time_sync/boards/nrf52_bsim.overlay
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+
+/ {
+	uart2: uart {
+		status = "okay";
+		compatible = "zephyr,native-posix-uart";
+		/* Dummy current-speed entry to comply with serial
+		 * DTS binding
+		 */
+		 current-speed = <0>;
+	};
+
+	chosen {
+		zephyr,console = &uart2;
+		zephyr,shell-uart = &uart2;
+	};
+	leds {
+		compatible = "gpio-leds";
+		led1: led_1 {
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+			label = "Green LED 1";
+		};
+	};
+
+	buttons {
+		compatible = "gpio-keys";
+		button0: button_0 {
+			gpios = <&gpio0 11 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button switch 0";
+			zephyr,code = <INPUT_KEY_0>;
+		};
+	};
+
+	aliases {
+		led1 = &led1;
+		sw0 = &button0;
+	};
+};

--- a/samples/bluetooth/iso_time_sync/src/controller_time_nrf52.c
+++ b/samples/bluetooth/iso_time_sync/src/controller_time_nrf52.c
@@ -61,7 +61,7 @@ static int rtc_config(void)
 		return -ENODEV;
 	}
 
-#ifndef BT_CTLR_SDC_BSIM_BUILD
+#ifndef CONFIG_BT_CTLR_SDC_BSIM_BUILD
 	IRQ_CONNECT(NRFX_IRQ_NUMBER_GET(NRF_RTC_INST_GET(2)), IRQ_PRIO_LOWEST,
 		    NRFX_RTC_INST_HANDLER_GET(2), NULL, 0);
 #else


### PR DESCRIPTION
Add overlays required to run the sample for the
bsim target.