### PR TITLE
manifest: Test updated Memfault SDK to 1.11.3-rc.1

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -274,7 +274,7 @@ manifest:
       remote: throwtheswitch
     - name: memfault-firmware-sdk
       path: modules/lib/memfault-firmware-sdk
-      revision: 1.6.0
+      revision: 1.11.3
       remote: memfault
     - name: ant
       repo-path: sdk-ant


### PR DESCRIPTION
Update the Memmfault SDK version to 1.11.3-rc.1

Signed-off-by: Noah Pendleton <noah.pendleton@gmail.com>