### PR TITLE
lib: location: Hide LOCATION_METHOD_WIFI_NET_MGMT when Wi-Fi is disabled

### DIFF
--- a/lib/location/Kconfig
+++ b/lib/location/Kconfig
@@ -31,6 +31,7 @@ config LOCATION_METHOD_WIFI
 
 config LOCATION_METHOD_WIFI_NET_MGMT
 	bool
+	depends on LOCATION_METHOD_WIFI
 	default y
 	help
 	  Use the Network Management APIs for Wi-Fi functionality. This is


### PR DESCRIPTION
Made `CONFIG_LOCATION_METHOD_WIFI_NET_MGMT` depend on `CONFIG_LOCATION_METHOD_WIFI` to hide it when Wi-Fi location method is disabled.