### PR TITLE
samples: conn_time_sync: Fix typo in diagram

### DIFF
--- a/doc/nrf/images/conn_time_sync_diagram.svg
+++ b/doc/nrf/images/conn_time_sync_diagram.svg
@@ -175,9 +175,9 @@
 			<text x="5.14" y="317.79" class="st9">79998</text>		</g>
 		<g id="shape301-113" transform="translate(452.408,-47.9999)">
 			<title>Sheet.301</title>
-			<desc>80002</desc>
+			<desc>90002</desc>
 			<rect x="0" y="307.239" width="35.3041" height="15.7058" class="st8"/>
-			<text x="5.14" y="317.79" class="st9">80002</text>		</g>
+			<text x="5.14" y="317.79" class="st9">90002</text>		</g>
 		<g id="shape302-116" transform="translate(493.292,-43.7057)">
 			<title>Sheet.302</title>
 			<desc>Peripheral clock</desc>


### PR DESCRIPTION
The timestamp mistyped, it should have been 90002 instead of 80002 as we expect the timestamp to be close to 10000 away from the previous one.