### PR TITLE
net: openthread: rpc: otCoAP API serialization p.2

### DIFF
--- a/subsys/net/openthread/rpc/Kconfig
+++ b/subsys/net/openthread/rpc/Kconfig
@@ -39,6 +39,18 @@ config OPENTHREAD_RPC_SERVER
 
 endchoice
 
+menu "OpenThread over RPC client configuration"
+	depends on OPENTHREAD_RPC_CLIENT
+
+config OPENTHREAD_RPC_CLIENT_NUM_SENT_COAP_REQUESTS
+	int "Maximum number of ongoing sent CoAP messages"
+	default 8
+	help
+	  Defines the number of slots for storing a callback along with its context
+	  for ongoing CoAP requests awaiting a response.
+
+endmenu # "OpenThread over RPC client configuration"
+
 config OPENTHREAD_RPC_INITIALIZE_NRF_RPC
 	bool "Automatically initialize nRF RPC library"
 	default n

--- a/subsys/net/openthread/rpc/common/ot_rpc_common.c
+++ b/subsys/net/openthread/rpc/common/ot_rpc_common.c
@@ -148,14 +148,26 @@ void ot_rpc_decode_dataset(const struct nrf_rpc_group *group, struct nrf_rpc_cbo
 	dataset->mComponents.mIsChannelMaskPresent = nrf_rpc_decode_bool(ctx);
 }
 
-void ot_rpc_decode_message_settings(struct nrf_rpc_cbor_ctx *ctx, otMessageSettings *settings)
+otMessageSettings *ot_rpc_decode_message_settings(struct nrf_rpc_cbor_ctx *ctx,
+						  otMessageSettings *settings)
 {
+	if (nrf_rpc_decode_is_null(ctx)) {
+		return NULL;
+	}
+
 	settings->mLinkSecurityEnabled = nrf_rpc_decode_bool(ctx);
 	settings->mPriority = nrf_rpc_decode_uint(ctx);
+
+	return settings;
 }
 
 void ot_rpc_encode_message_settings(struct nrf_rpc_cbor_ctx *ctx, const otMessageSettings *settings)
 {
+	if (!settings) {
+		nrf_rpc_encode_null(ctx);
+		return;
+	}
+
 	nrf_rpc_encode_bool(ctx, settings->mLinkSecurityEnabled);
 	nrf_rpc_encode_uint(ctx, settings->mPriority);
 }

--- a/subsys/net/openthread/rpc/common/ot_rpc_common.h
+++ b/subsys/net/openthread/rpc/common/ot_rpc_common.h
@@ -71,7 +71,8 @@ void ot_rpc_decode_dataset_tlvs(const struct nrf_rpc_group *group, struct nrf_rp
 void ot_rpc_decode_dataset(const struct nrf_rpc_group *group, struct nrf_rpc_cbor_ctx *ctx,
 			   void *handler_data);
 void ot_rpc_encode_dataset(struct nrf_rpc_cbor_ctx *ctx, const otOperationalDataset *dataset);
-void ot_rpc_decode_message_settings(struct nrf_rpc_cbor_ctx *ctx, otMessageSettings *settings);
+otMessageSettings *ot_rpc_decode_message_settings(struct nrf_rpc_cbor_ctx *ctx,
+						  otMessageSettings *settings);
 void ot_rpc_encode_message_settings(struct nrf_rpc_cbor_ctx *ctx,
 				    const otMessageSettings *settings);
 /* The function reports about command decoding error (not responses). */

--- a/subsys/net/openthread/rpc/common/ot_rpc_ids.h
+++ b/subsys/net/openthread/rpc/common/ot_rpc_ids.h
@@ -17,6 +17,7 @@ enum ot_rpc_cmd_client {
 	OT_RPC_CMD_UDP_RECEIVE_CB,
 	OT_RPC_CMD_COAP_RESOURCE_HANDLER,
 	OT_RPC_CMD_COAP_DEFAULT_HANDLER,
+	OT_RPC_CMD_COAP_RESPONSE_HANDLER,
 };
 
 /** @brief Command IDs accepted by the OpenThread over RPC server.

--- a/subsys/net/openthread/rpc/common/ot_rpc_types.h
+++ b/subsys/net/openthread/rpc/common/ot_rpc_types.h
@@ -38,4 +38,8 @@ typedef uint32_t ot_msg_key;
  */
 typedef uint32_t ot_socket_key;
 
+/** @brief Key type for internal CoAP request registry.
+ */
+typedef uint32_t ot_rpc_coap_request_key;
+
 #endif /* OT_RPC_TYPES_H_ */

--- a/subsys/net/openthread/rpc/server/ot_rpc_coap_server.c
+++ b/subsys/net/openthread/rpc/server/ot_rpc_coap_server.c
@@ -18,14 +18,51 @@
 
 #include <openthread/coap.h>
 
+struct ot_rpc_coap_resource_buf {
+	struct ot_rpc_coap_resource_buf *next;
+	otCoapResource resource;
+	char uri[OT_RPC_COAP_MAX_URI_LENGTH + 1];
+};
+
+static struct ot_rpc_coap_resource_buf *resources;
+
+static struct ot_rpc_coap_resource_buf *find_coap_resource_by_uri(const char *uri)
+{
+	for (struct ot_rpc_coap_resource_buf *r = resources; r != NULL; r = r->next) {
+		if (strcmp(r->resource.mUriPath, uri) == 0) {
+			return r;
+		}
+	}
+
+	return NULL;
+}
+
+static struct ot_rpc_coap_resource_buf *pop_coap_resource_by_uri(const char *uri)
+{
+	struct ot_rpc_coap_resource_buf **prev_next = &resources;
+
+	for (struct ot_rpc_coap_resource_buf *r = resources; r != NULL;
+	     prev_next = &r->next, r = r->next) {
+		if (strcmp(r->resource.mUriPath, uri) == 0) {
+			*prev_next = r->next;
+			r->next = NULL;
+
+			return r;
+		}
+	}
+
+	return NULL;
+}
+
 static void ot_rpc_cmd_coap_new_message(const struct nrf_rpc_group *group,
 					struct nrf_rpc_cbor_ctx *ctx, void *handler_data)
 {
-	otMessageSettings settings;
+	otMessageSettings settings_buf;
+	otMessageSettings *settings;
 	otMessage *message;
 	ot_msg_key message_rep = 0;
 
-	ot_rpc_decode_message_settings(ctx, &settings);
+	settings = ot_rpc_decode_message_settings(ctx, &settings_buf);
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
 		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_NEW_MESSAGE);
@@ -33,7 +70,7 @@ static void ot_rpc_cmd_coap_new_message(const struct nrf_rpc_group *group,
 	}
 
 	openthread_api_mutex_lock(openthread_get_default_context());
-	message = otCoapNewMessage(NULL, &settings);
+	message = otCoapNewMessage(openthread_get_default_instance(), settings);
 	openthread_api_mutex_unlock(openthread_get_default_context());
 
 	if (!message) {
@@ -378,7 +415,7 @@ static void ot_rpc_cmd_coap_start(const struct nrf_rpc_group *group, struct nrf_
 	}
 
 	openthread_api_mutex_lock(openthread_get_default_context());
-	error = otCoapStart(NULL, port);
+	error = otCoapStart(openthread_get_default_instance(), port);
 	openthread_api_mutex_unlock(openthread_get_default_context());
 
 	nrf_rpc_rsp_send_uint(group, error);
@@ -398,7 +435,7 @@ static void ot_rpc_cmd_coap_stop(const struct nrf_rpc_group *group, struct nrf_r
 	}
 
 	openthread_api_mutex_lock(openthread_get_default_context());
-	error = otCoapStop(NULL);
+	error = otCoapStop(openthread_get_default_instance());
 	openthread_api_mutex_unlock(openthread_get_default_context());
 
 	nrf_rpc_rsp_send_uint(group, error);
@@ -406,6 +443,111 @@ static void ot_rpc_cmd_coap_stop(const struct nrf_rpc_group *group, struct nrf_r
 
 NRF_RPC_CBOR_CMD_DECODER(ot_group, ot_rpc_cmd_coap_stop, OT_RPC_CMD_COAP_STOP, ot_rpc_cmd_coap_stop,
 			 NULL);
+
+static void ot_rpc_coap_resource_handler(void *aContext, otMessage *aMessage,
+					 const otMessageInfo *aMessageInfo)
+{
+	ot_msg_key message_rep;
+	const char *uri = aContext;
+	struct nrf_rpc_cbor_ctx ctx;
+	size_t cbor_buffer_size = 0;
+
+	message_rep = ot_reg_msg_alloc(aMessage);
+
+	if (!message_rep) {
+		return;
+	}
+
+	cbor_buffer_size += 2 + strlen(uri);
+	cbor_buffer_size += 1 + sizeof(ot_msg_key);		      /* aMessage */
+	cbor_buffer_size += OT_RPC_MESSAGE_INFO_LENGTH(aMessageInfo); /* aMessageInfo */
+
+	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, cbor_buffer_size);
+	nrf_rpc_encode_str(&ctx, uri, -1);
+	nrf_rpc_encode_uint(&ctx, message_rep);
+	ot_rpc_encode_message_info(&ctx, aMessageInfo);
+	nrf_rpc_cbor_cmd_no_err(&ot_group, OT_RPC_CMD_COAP_RESOURCE_HANDLER, &ctx,
+				nrf_rpc_rsp_decode_void, NULL);
+
+	ot_msg_free(message_rep);
+}
+
+static void ot_rpc_cmd_coap_add_resource(const struct nrf_rpc_group *group,
+					 struct nrf_rpc_cbor_ctx *ctx, void *handler_data)
+{
+	char uri[OT_RPC_COAP_MAX_URI_LENGTH + 1];
+	struct ot_rpc_coap_resource_buf *res_buf;
+
+	nrf_rpc_decode_str(ctx, uri, sizeof(uri));
+
+	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
+		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_ADD_RESOURCE);
+		return;
+	}
+
+	openthread_api_mutex_lock(openthread_get_default_context());
+
+	if (find_coap_resource_by_uri(uri)) {
+		goto out;
+	}
+
+	res_buf = malloc(sizeof(*res_buf));
+
+	if (!res_buf) {
+		nrf_rpc_err(-ENOMEM, NRF_RPC_ERR_SRC_RECV, &ot_group, OT_RPC_CMD_COAP_ADD_RESOURCE,
+			    NRF_RPC_PACKET_TYPE_CMD);
+		goto out;
+	}
+
+	res_buf->resource.mUriPath = res_buf->uri;
+	res_buf->resource.mHandler = ot_rpc_coap_resource_handler;
+	res_buf->resource.mContext = res_buf->uri;
+	res_buf->resource.mNext = NULL;
+	strcpy(res_buf->uri, uri);
+	res_buf->next = resources;
+	resources = res_buf;
+
+	otCoapAddResource(openthread_get_default_instance(), &res_buf->resource);
+
+out:
+	openthread_api_mutex_unlock(openthread_get_default_context());
+	nrf_rpc_rsp_send_void(group);
+}
+
+NRF_RPC_CBOR_CMD_DECODER(ot_group, ot_rpc_cmd_coap_add_resource, OT_RPC_CMD_COAP_ADD_RESOURCE,
+			 ot_rpc_cmd_coap_add_resource, NULL);
+
+static void ot_rpc_cmd_coap_remove_resource(const struct nrf_rpc_group *group,
+					    struct nrf_rpc_cbor_ctx *ctx, void *handler_data)
+{
+	char uri[OT_RPC_COAP_MAX_URI_LENGTH + 1];
+	struct ot_rpc_coap_resource_buf *res_buf;
+
+	nrf_rpc_decode_str(ctx, uri, sizeof(uri));
+
+	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
+		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_REMOVE_RESOURCE);
+		return;
+	}
+
+	openthread_api_mutex_lock(openthread_get_default_context());
+
+	res_buf = pop_coap_resource_by_uri(uri);
+
+	if (!res_buf) {
+		goto out;
+	}
+
+	otCoapRemoveResource(openthread_get_default_instance(), &res_buf->resource);
+	free(res_buf);
+
+out:
+	openthread_api_mutex_unlock(openthread_get_default_context());
+	nrf_rpc_rsp_send_void(group);
+}
+
+NRF_RPC_CBOR_CMD_DECODER(ot_group, ot_rpc_cmd_coap_remove_resource, OT_RPC_CMD_COAP_REMOVE_RESOURCE,
+			 ot_rpc_cmd_coap_remove_resource, NULL);
 
 static void ot_rpc_coap_default_handler(void *aContext, otMessage *aMessage,
 					const otMessageInfo *aMessageInfo)
@@ -426,7 +568,7 @@ static void ot_rpc_coap_default_handler(void *aContext, otMessage *aMessage,
 	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, cbor_buffer_size);
 	nrf_rpc_encode_uint(&ctx, message_rep);
 	ot_rpc_encode_message_info(&ctx, aMessageInfo);
-	nrf_rpc_cbor_cmd_no_err(&ot_group, OT_RPC_CMD_COAP_RESOURCE_HANDLER, &ctx,
+	nrf_rpc_cbor_cmd_no_err(&ot_group, OT_RPC_CMD_COAP_DEFAULT_HANDLER, &ctx,
 				nrf_rpc_rsp_decode_void, NULL);
 
 	ot_msg_free(message_rep);
@@ -445,7 +587,8 @@ static void ot_rpc_cmd_coap_set_default_handler(const struct nrf_rpc_group *grou
 	}
 
 	openthread_api_mutex_lock(openthread_get_default_context());
-	otCoapSetDefaultHandler(NULL, enabled ? ot_rpc_coap_default_handler : NULL, NULL);
+	otCoapSetDefaultHandler(openthread_get_default_instance(),
+				enabled ? ot_rpc_coap_default_handler : NULL, NULL);
 	openthread_api_mutex_unlock(openthread_get_default_context());
 
 	nrf_rpc_rsp_send_void(group);
@@ -454,3 +597,107 @@ static void ot_rpc_cmd_coap_set_default_handler(const struct nrf_rpc_group *grou
 NRF_RPC_CBOR_CMD_DECODER(ot_group, ot_rpc_cmd_coap_set_default_handler,
 			 OT_RPC_CMD_COAP_SET_DEFAULT_HANDLER, ot_rpc_cmd_coap_set_default_handler,
 			 NULL);
+
+static void ot_rpc_coap_response_handler(void *context, otMessage *message,
+					 const otMessageInfo *message_info, otError error)
+{
+	ot_rpc_coap_request_key request_rep = (ot_rpc_coap_request_key)context;
+	ot_msg_key message_rep = 0;
+	struct nrf_rpc_cbor_ctx ctx;
+	size_t cbor_buffer_size = 0;
+
+	if (message) {
+		message_rep = ot_reg_msg_alloc(message);
+
+		if (!message_rep) {
+			return;
+		}
+	}
+
+	cbor_buffer_size += 1 + sizeof(ot_rpc_coap_request_key);
+	cbor_buffer_size += 1 + sizeof(ot_msg_key);
+	cbor_buffer_size += OT_RPC_MESSAGE_INFO_LENGTH(message_info);
+
+	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, cbor_buffer_size);
+	nrf_rpc_encode_uint(&ctx, request_rep);
+	nrf_rpc_encode_uint(&ctx, message_rep);
+	ot_rpc_encode_message_info(&ctx, message_info);
+	nrf_rpc_encode_uint(&ctx, error);
+	nrf_rpc_cbor_cmd_no_err(&ot_group, OT_RPC_CMD_COAP_RESPONSE_HANDLER, &ctx,
+				nrf_rpc_rsp_decode_void, NULL);
+
+	ot_msg_free(message_rep);
+}
+
+static void ot_rpc_cmd_coap_send_request(const struct nrf_rpc_group *group,
+					 struct nrf_rpc_cbor_ctx *ctx, void *handler_data)
+{
+	ot_msg_key message_rep;
+	otMessageInfo message_info;
+	ot_rpc_coap_request_key request_rep;
+	otMessage *message;
+	otError error;
+
+	message_rep = nrf_rpc_decode_uint(ctx);
+	ot_rpc_decode_message_info(ctx, &message_info);
+	request_rep = nrf_rpc_decode_uint(ctx);
+
+	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
+		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_SEND_REQUEST);
+		return;
+	}
+
+	message = ot_msg_get(message_rep);
+
+	if (!message) {
+		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_SEND_REQUEST);
+		return;
+	}
+
+	openthread_api_mutex_lock(openthread_get_default_context());
+	error = otCoapSendRequest(openthread_get_default_instance(), message, &message_info,
+				  ot_rpc_coap_response_handler, (void *)request_rep);
+	openthread_api_mutex_unlock(openthread_get_default_context());
+
+	if (error == OT_ERROR_NONE) {
+		ot_msg_free(message_rep);
+	}
+
+	nrf_rpc_rsp_send_uint(group, error);
+}
+
+NRF_RPC_CBOR_CMD_DECODER(ot_group, ot_rpc_cmd_coap_send_request, OT_RPC_CMD_COAP_SEND_REQUEST,
+			 ot_rpc_cmd_coap_send_request, NULL);
+
+static void ot_rpc_cmd_coap_send_response(const struct nrf_rpc_group *group,
+					  struct nrf_rpc_cbor_ctx *ctx, void *handler_data)
+{
+	ot_msg_key message_rep;
+	otMessageInfo message_info;
+	otMessage *message;
+	otError error;
+
+	message_rep = nrf_rpc_decode_uint(ctx);
+	ot_rpc_decode_message_info(ctx, &message_info);
+
+	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
+		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_SEND_RESPONSE);
+		return;
+	}
+
+	message = ot_msg_get(message_rep);
+
+	if (!message) {
+		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_SEND_RESPONSE);
+		return;
+	}
+
+	openthread_api_mutex_lock(openthread_get_default_context());
+	error = otCoapSendResponse(openthread_get_default_instance(), message, &message_info);
+	openthread_api_mutex_unlock(openthread_get_default_context());
+
+	nrf_rpc_rsp_send_uint(group, error);
+}
+
+NRF_RPC_CBOR_CMD_DECODER(ot_group, ot_rpc_cmd_coap_send_response, OT_RPC_CMD_COAP_SEND_RESPONSE,
+			 ot_rpc_cmd_coap_send_response, NULL);

--- a/tests/subsys/net/openthread/rpc/common/test_rpc_env.h
+++ b/tests/subsys/net/openthread/rpc/common/test_rpc_env.h
@@ -8,17 +8,17 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util_macro.h>
 
-/* CBOR constants */
+/* Macros for constructing CBOR data items. */
 
 #define CBOR_FALSE 0xf4
 #define CBOR_TRUE  0xf5
 #define CBOR_NULL  0xf6
 
-#define LSFY_IDENTITY(n, _) n + 1
-#define INT_SEQUENCE(length) LISTIFY(length, LSFY_IDENTITY, (,))
-
-#define LSFY_CHAR(n, _) 'a'
-#define STR_SEQUENCE(length) LISTIFY(length, LSFY_CHAR, (,))
+#define CBOR_UINT64(value) 0x1B, BT_BYTES_LIST_LE64(BSWAP_64(value))
+#define CBOR_UINT32(value) 0x1A, BT_BYTES_LIST_LE32(BSWAP_32(value))
+#define CBOR_UINT16(value) 0x19, BT_BYTES_LIST_LE16(BSWAP_16(value))
+/* for value bigger than 0x17 */
+#define CBOR_UINT8(value)  0x18, (value)
 
 /* Macros for constructing nRF RPC packets for the OpenThread command group. */
 
@@ -34,13 +34,23 @@
 #define RPC_RSP(...)      RPC_PKT(0x01, 0xff, 0x00, 0x00, 0x00 __VA_OPT__(,) __VA_ARGS__, 0xf6)
 #define NO_RSP            RPC_PKT()
 
-/* Other test data */
+/* Dummy test data */
 
-#define CBOR_UINT64(value) 0x1B, BT_BYTES_LIST_LE64(BSWAP_64(value))
-#define CBOR_UINT32(value) 0x1A, BT_BYTES_LIST_LE32(BSWAP_32(value))
-#define CBOR_UINT16(value) 0x19, BT_BYTES_LIST_LE16(BSWAP_16(value))
-/* for value bigger than 0x17 */
-#define CBOR_UINT8(value)  0x18, (value)
+#define LSFY_IDENTITY(n, _)  n + 1
+#define INT_SEQUENCE(length) LISTIFY(length, LSFY_IDENTITY, (,))
+
+#define LSFY_CHAR(n, _)	     'a'
+#define STR_SEQUENCE(length) LISTIFY(length, LSFY_CHAR, (,))
+
+#define ADDR_1                                                                                     \
+	0xfe, 0x80, 0xaa, 0xbb, 0xaa, 0xbb, 0xaa, 0xbb, 0xaa, 0xbb, 0xaa, 0xbb, 0xaa, 0xbb, 0xaa,  \
+		0x01
+#define ADDR_2                                                                                     \
+	0xfe, 0x80, 0xaa, 0xbb, 0xaa, 0xbb, 0xaa, 0xbb, 0xaa, 0xbb, 0xaa, 0xbb, 0xaa, 0xbb, 0xaa,  \
+		0x02
+#define PORT_1	  0xff01
+#define PORT_2	  0xff02
+#define HOP_LIMIT 64
 
 #define MADDR_FF02_1  0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01
 #define EXT_ADDR      0x48, INT_SEQUENCE(OT_EXT_ADDRESS_SIZE)
@@ -62,3 +72,6 @@
 	TIMESTAMP, TIMESTAMP, NWK_KEY, NWK_NAME, EXT_PAN_ID, LOCAL_PREFIX,                         \
 		CBOR_UINT32(0x12345678), CBOR_UINT16(0xabcd), CBOR_UINT16(0xef67), PSKC,           \
 		SECURITY_POLICY, CBOR_UINT32(0xfedcba98), DATASET_COMPONENTS
+#define CBOR_MSG_INFO                                                                              \
+	0x50, ADDR_1, 0x50, ADDR_2, CBOR_UINT16(PORT_1), CBOR_UINT16(PORT_2), CBOR_UINT8(64), 3,   \
+		CBOR_TRUE, CBOR_TRUE, CBOR_TRUE


### PR DESCRIPTION
Complete the serialization of the following APIs:
- otCoapAddResource
- otCoapRemoveResource
- otSetDefaultResource

Implement serialization of the following APIs:
- otCoapSendRequest
- otCoapSendResponse