### PR TITLE
doc: Bluetooth: Document HCI driver moved to DTS

### DIFF
--- a/doc/nrf/protocols/bt/bt_stack_arch.rst
+++ b/doc/nrf/protocols/bt/bt_stack_arch.rst
@@ -51,7 +51,10 @@ For this controller the support includes:
 
 The Zephyr Project has a community support :ref:`ug_ble_controller`.
 This Bluetooth controller will be the default when using Zephyr RTOS stand-alone.
-It is possible to configure projects in the |NCS| to use the Zephyr Controller, but Nordic Semiconductor does not support this configuration for production.
+
+.. note::
+   It is possible to configure projects in the |NCS| to use the Zephyr Controller.
+   Nordic Semiconductor does not support the Zephyr Bluetooth LE Controller for production.
 
 .. _ug_ble_controller_softdevice:
 

--- a/doc/nrf/protocols/bt/bt_stack_arch.rst
+++ b/doc/nrf/protocols/bt/bt_stack_arch.rst
@@ -87,7 +87,7 @@ Most :ref:`Bluetooth LE samples <ble_samples>` in the |NCS|, including the :ref:
 Exceptions are the :ref:`ble_llpm` sample, which requires the SoftDevice Controller that supports LLPM, and the :ref:`nrf53_audio_app`, which require the SoftDevice Controller that supports :ref:`LE Isochronous Channels <nrfxlib:softdevice_controller_iso>`.
 
 By default, all samples are currently configured to use SoftDevice Controller.
-To use the Zephyr Bluetooth LE Controller instead, set :kconfig:option:`CONFIG_BT_LL_SW_SPLIT` to ``y`` in the :file:`prj.conf` file (see :ref:`configure_application`) and make sure to build from a clean build directory.
+To use the Zephyr Bluetooth LE Controller instead, use the :ref:`bt-ll-sw-split <zephyr:snippet-bt-ll-sw-split>` snippet (see :ref:`app_build_snippets`) and make sure to build from a clean build directory.
 
 .. note::
    If your Bluetooth application requires the LE Secure Connections pairing and you want to use the Zephyr Bluetooth LE Controller, make sure to enable the :kconfig:option:`CONFIG_BT_TINYCRYPT_ECC` Kconfig option as the ECDH cryptography is not supported by this Bluetooth LE Controller.

--- a/doc/nrf/releases_and_maturity/migration/migration_guide_2.8.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_guide_2.8.rst
@@ -350,3 +350,13 @@ This section describes the changes related to snippets.
    * ``nrf70-driver-verbose-logs`` - To enable the nRF70 driver, firmware interface, and BUS interface debug logs.
 
    * ``wpa-supplicant-debug`` - To enable supplicant logs.
+
+Protocols
+=========
+
+This section provides detailed lists of changes by :ref:`protocol <protocols>`.
+
+Bluetooth® LE
+-------------
+
+*  To use the Zephyr Bluetooth LE Controller, use the :ref:`bt-ll-sw-split <zephyr:snippet-bt-ll-sw-split>` snippet (see :ref:`app_build_snippets`).

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -117,6 +117,10 @@ Bluetooth® LE
 * Added the APIs :c:func:`bt_hci_err_to_str` and :c:func:`bt_security_err_to_str` to allow printing error codes as strings.
   Each API returns string representations of the error codes when the corresponding Kconfig option, :kconfig:option:`CONFIG_BT_HCI_ERR_TO_STR` or :kconfig:option:`CONFIG_BT_SECURITY_ERR_TO_STR`, is enabled.
   The :ref:`ble_samples` and :ref:`nrf53_audio_app` are updated to utilize these new APIs.
+* The Bluetooth HCI driver is now present as a devicetree node in the device tree.
+  The SoftDevice Controller driver uses a devicetree node named ``bt_hci_sdc`` with a devicetree binding compatible with ``nordic,bt-hci-sdc``.
+  The Zephyr Bluetooth LE Controller uses a devicetree node named ``bt_hci_controller`` with a devicetree binding compatible with ``zephyr,bt-hci-ll-sw-split``.
+  Applications using the Zephyr Bluetooth Controller need to be updated (see the :ref:`migration guide <migration_2.8>`).
 
 Bluetooth Mesh
 --------------


### PR DESCRIPTION
Documents that the HCI driver has now been moved to device tree and that action is needed for applications using the Zephyr Bluetooth LE Controller.