### PR TITLE
snippets: add hw-flow-control snippet

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -244,6 +244,7 @@ Kconfig*                                  @tejlmand
 /share/zephyrbuild-package/               @tejlmand
 /share/ncs-package/                       @tejlmand
 /snippets/emulated*/                      @masz-nordic
+/snippets/hw-flow-control/                @nrfconnect/ncs-low-level-test @miha-nordic
 /snippets/matter-diagnostic-logs/         @nrfconnect/ncs-matter
 /snippets/nrf91-modem-trace-ext-flash/    @nrfconnect/ncs-cia
 /snippets/nrf91-modem-trace-uart/         @eivindj-nordic

--- a/snippets/hw-flow-control/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/snippets/hw-flow-control/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&uart0 {
+	hw-flow-control;
+};

--- a/snippets/hw-flow-control/snippet.yml
+++ b/snippets/hw-flow-control/snippet.yml
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+name: hw-flow-control
+
+boards:
+  nrf5340dk/nrf5340/cpuapp:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/nrf5340dk_nrf5340_cpuapp.overlay


### PR DESCRIPTION
To be applied for tests which require HWFC
but board does not have it by default.