### PR TITLE
doc: nrf: add entries for nRF54L15DK

### DIFF
--- a/doc/nrf/includes/sample_board_rows.txt
+++ b/doc/nrf/includes/sample_board_rows.txt
@@ -233,3 +233,7 @@
 .. nrf54l15pdk@0.3.0_nrf54l15_cpuapp
 
 | :ref:`nRF54L15 PDK <ug_nrf54l15_gs>` | PCA10156 | :ref:`nrf54l15pdk <zephyr:nrf54l15pdk_nrf54l15>` | ``nrf54l15pdk@0.3.0/nrf54l15/cpuapp`` |
+
+.. nrf54l15dk_nrf54l15_cpuapp
+
+| nRF54L15 DK | PCA10156 | :ref:`nrf54l15dk <zephyr:nrf54l15dk_nrf54l15>` | ``nrf54l15dk/nrf54l15/cpuapp`` |


### PR DESCRIPTION
The documentation can render sample tables from the sample.yaml file.