### PR TITLE
ESB, Radio Test: Add support for new 4Mbit mode configurations 

### DIFF
--- a/include/esb.h
+++ b/include/esb.h
@@ -127,6 +127,11 @@ enum esb_bitrate {
 	/** 4 Mb radio mode. */
 	ESB_BITRATE_4MBPS = NRF_RADIO_MODE_NRF_4MBIT_H_0_5,
 #endif /* defined(RADIO_MODE_MODE_Nrf_4Mbit0_5) */
+
+#if defined(RADIO_MODE_MODE_Nrf_4Mbit_0BT6)
+	/** 4 Mb radio mode. */
+	ESB_BITRATE_4MBPS = RADIO_MODE_MODE_Nrf_4Mbit_0BT6,
+#endif /* defined(RADIO_MODE_MODE_Nrf_4Mbit_0BT6) */
 };
 
 /** @brief Enhanced ShockBurst CRC modes. */

--- a/samples/peripheral/radio_test/src/radio_cmd.c
+++ b/samples/peripheral/radio_test/src/radio_cmd.c
@@ -476,6 +476,22 @@ static int cmd_print(const struct shell *shell, size_t argc, char **argv)
 		break;
 #endif /* defined(RADIO_MODE_MODE_Nrf_4Mbit0_25) */
 
+#if defined(RADIO_MODE_MODE_Nrf_4Mbit_0BT6)
+	case NRF_RADIO_MODE_NRF_4MBIT_BT_0_6:
+		shell_print(shell,
+			    "Data rate: %s",
+			    STRINGIFY(NRF_RADIO_MODE_NRF_4MBIT_BT_0_6));
+		break;
+#endif /* defined(RADIO_MODE_MODE_Nrf_4Mbit_0BT6) */
+
+#if defined(RADIO_MODE_MODE_Nrf_4Mbit_0BT4)
+	case NRF_RADIO_MODE_NRF_4MBIT_BT_0_4:
+		shell_print(shell,
+			    "Data rate: %s",
+			    STRINGIFY(NRF_RADIO_MODE_NRF_4MBIT_BT_0_4));
+		break;
+#endif /* defined(RADIO_MODE_MODE_Nrf_4Mbit_0BT4) */
+
 	case NRF_RADIO_MODE_NRF_1MBIT:
 		shell_print(shell,
 			    "Data rate: %s",
@@ -935,6 +951,30 @@ static int cmd_nrf_4mbit_h_0_25(const struct shell *shell, size_t argc,
 }
 #endif /* defined(RADIO_MODE_MODE_Nrf_4Mbit0_25) */
 
+#if defined(RADIO_MODE_MODE_Nrf_4Mbit_0BT6)
+static int cmd_nrf_4mbit_bt_0_6(const struct shell *shell, size_t argc,
+				char **argv)
+{
+	config.mode = NRF_RADIO_MODE_NRF_4MBIT_BT_0_6;
+	shell_print(shell, "Data rate: %s",
+		    STRINGIFY(NRF_RADIO_MODE_NRF_4MBIT_BT_0_6));
+
+	return 0;
+}
+#endif /* defined(RADIO_MODE_MODE_Nrf_4Mbit_0BT6) */
+
+#if defined(RADIO_MODE_MODE_Nrf_4Mbit_0BT4)
+static int cmd_nrf_4mbit_bt_0_4(const struct shell *shell, size_t argc,
+				char **argv)
+{
+	config.mode = NRF_RADIO_MODE_NRF_4MBIT_BT_0_4;
+	shell_print(shell, "Data rate: %s",
+		    STRINGIFY(NRF_RADIO_MODE_NRF_4MBIT_BT_0_4));
+
+	return 0;
+}
+#endif /* defined(RADIO_MODE_MODE_Nrf_4Mbit_0BT4) */
+
 static int cmd_ble_1mbit(const struct shell *shell, size_t argc, char **argv)
 {
 	config.mode = NRF_RADIO_MODE_BLE_1MBIT;
@@ -1042,6 +1082,18 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_data_rate,
 		  "4 Mbit/s Nordic proprietary radio mode (BT=0.5/h=0.25)",
 		  cmd_nrf_4mbit_h_0_25),
 #endif /* defined(RADIO_MODE_MODE_Nrf_4Mbit0_25) */
+
+#if defined(RADIO_MODE_MODE_Nrf_4Mbit_0BT6)
+	SHELL_CMD(nrf_4Mbit_BT06, NULL,
+		  "4 Mbps Nordic proprietary radio mode (BT=0.6/h=0.5)",
+		  cmd_nrf_4mbit_bt_0_6),
+#endif /* defined(RADIO_MODE_MODE_Nrf_4Mbit_0BT6) */
+
+#if defined(RADIO_MODE_MODE_Nrf_4Mbit_0BT4)
+	SHELL_CMD(nrf_4Mbit_BT04, NULL,
+		  "4 Mbps Nordic proprietary radio mode (BT=0.4/h=0.5)",
+		  cmd_nrf_4mbit_bt_0_4),
+#endif /* defined(RADIO_MODE_MODE_Nrf_4Mbit_0BT4) */
 
 	SHELL_CMD(ble_1Mbit, NULL, "1 Mbit/s Bluetooth Low Energy",
 		  cmd_ble_1mbit),

--- a/samples/peripheral/radio_test/src/radio_test.c
+++ b/samples/peripheral/radio_test/src/radio_test.c
@@ -718,6 +718,12 @@ static void radio_modulated_tx_carrier(uint8_t mode, int8_t txpower, uint8_t cha
 #if defined(RADIO_MODE_MODE_Nrf_4Mbit0_25)
 	case NRF_RADIO_MODE_NRF_4MBIT_H_0_25:
 #endif /* defined(RADIO_MODE_MODE_Nrf_4Mbit0_25) */
+#if defined(RADIO_MODE_MODE_Nrf_4Mbit_0BT6)
+	case NRF_RADIO_MODE_NRF_4MBIT_BT_0_6:
+#endif /* defined(RADIO_MODE_MODE_Nrf_4Mbit_0BT6) */
+#if defined(RADIO_MODE_MODE_Nrf_4Mbit_0BT4)
+	case NRF_RADIO_MODE_NRF_4MBIT_BT_0_4:
+#endif /* defined(RADIO_MODE_MODE_Nrf_4Mbit_0BT4) */
 		nrf_radio_shorts_enable(NRF_RADIO,
 					NRF_RADIO_SHORT_READY_START_MASK |
 					RADIO_TEST_SHORT_END_START_MASK);

--- a/subsys/esb/esb.c
+++ b/subsys/esb/esb.c
@@ -774,11 +774,11 @@ static bool update_radio_bitrate(void)
 
 	switch (esb_cfg.bitrate) {
 
-#if defined(RADIO_MODE_MODE_Nrf_4Mbit0_5)
+#if defined(RADIO_MODE_MODE_Nrf_4Mbit0_5) || defined(RADIO_MODE_MODE_Nrf_4Mbit_0BT6)
 	case ESB_BITRATE_4MBPS:
 		wait_for_ack_timeout_us = RX_ACK_TIMEOUT_US_4MBPS;
 		break;
-#endif /* defined(RADIO_MODE_MODE_Nrf_4Mbit0_5) */
+#endif /* defined(RADIO_MODE_MODE_Nrf_4Mbit0_5) || define(RADIO_MODE_MODE_Nrf_4Mbit_0BT6) */
 
 	case ESB_BITRATE_2MBPS:
 


### PR DESCRIPTION
Adds support for new 4Mbit PHY configurations including
`RADIO_MODE_MODE_Nrf_4Mbit_0BT6` and `RADIO_MODE_MODE_Nrf_4Mbit_0BT4`.