### PR TITLE
lib: lte_link_control: Tune lte_lc_work_q_stack size

### DIFF
--- a/lib/lte_link_control/Kconfig
+++ b/lib/lte_link_control/Kconfig
@@ -344,6 +344,11 @@ config LTE_LC_TRACE
 	  what has happened and has no associated payload.
 	  It is intended to be used for debugging purposes.
 
+config LTE_LC_WORKQUEUE_STACK_SIZE
+	int "Stack size for the library work queue"
+	default 1280 if LOG_MODE_IMMEDIATE
+	default 1024
+
 module = LTE_LINK_CONTROL
 module-dep = LOG
 module-str = LTE link control library

--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -138,7 +138,7 @@ K_WORK_DEFINE(lte_lc_edrx_ptw_send_work, lte_lc_edrx_ptw_send_work_fn);
 static void lte_lc_edrx_req_work_fn(struct k_work *work_item);
 K_WORK_DEFINE(lte_lc_edrx_req_work, lte_lc_edrx_req_work_fn);
 
-K_THREAD_STACK_DEFINE(lte_lc_work_q_stack, 1024);
+K_THREAD_STACK_DEFINE(lte_lc_work_q_stack, CONFIG_LTE_LC_WORKQUEUE_STACK_SIZE);
 
 static struct k_work_q lte_lc_work_q;
 


### PR DESCRIPTION
Stack overflow occurs if `CONFIG_LOG_MODE_IMMEDIATE` is set. Reserving more stack with immediate logging but keeping the default stack size.

Jira: NCSDK-29063