### PR TITLE
manifest: update sdk-zephyr with LFXO for GRTC

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 96aa87c2aae419a2d04f4ee86ef12b359789a817
+      revision: pull/2010/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
GRTC needs to use direct clock source path instead of system clock path to support ELV mode for nRF54L targets.