### PR TITLE
nRF Desktop: SUIT semantic support 

### DIFF
--- a/applications/nrf_desktop/bootloader_dfu.rst
+++ b/applications/nrf_desktop/bootloader_dfu.rst
@@ -347,7 +347,7 @@ To perform DFU using the `nRF Connect Device Manager`_ mobile app, complete the 
          #. In the mobile app, scan and select the device to update.
          #. Switch to the :guilabel:`Image` tab and tap on :guilabel:`ADVANCED` in the upper right corner of the app.
          #. In the **Firmware Upload** section, tap the :guilabel:`SELECT FILE` button and select the :file:`root.suit` envelope.
-         #. Tap the :guilabel:`START` button.
+         #. Tap the :guilabel:`UPLOAD` button.
          #. Wait for the DFU to finish and then verify that the application works properly.
 
       .. note::

--- a/applications/nrf_desktop/doc/dfu.rst
+++ b/applications/nrf_desktop/doc/dfu.rst
@@ -139,10 +139,15 @@ fwinfo
    * Version and length of the image.
    * Partition ID of the currently booted image, used to specify the image placement.
 
-   For the nRF54H Series:
+   Additionally, for the nRF54H Series, the following applies:
 
-   * Reported image size is set to zero.
-   * Root manifest sequence number is reported as the booted image version.
+   * The reported image size is set to zero.
+   * The booted image version is indicated by:
+
+     * Root manifest sequence number that is encoded in the build number field.
+     * Manifest semantic version, if supported by the SDFW (requires v0.6.2 or higher).
+       The semantic version is encoded in the major, minor and patch fields.
+       If semantic versioning is not supported, these fields are set to zero.
 
 .. _dfu_devinfo:
 

--- a/applications/nrf_desktop/src/modules/dfu.c
+++ b/applications/nrf_desktop/src/modules/dfu.c
@@ -809,17 +809,50 @@ static void handle_image_info_request(uint8_t *data, size_t *size)
 	}
 }
 #elif CONFIG_SUIT
+static const char *suit_release_type_str_get(suit_version_release_type_t type)
+{
+	switch (type) {
+	case SUIT_VERSION_RELEASE_NORMAL:
+		return NULL;
+	case SUIT_VERSION_RELEASE_RC:
+		return "rc";
+	case SUIT_VERSION_RELEASE_BETA:
+		return "beta";
+	case SUIT_VERSION_RELEASE_ALPHA:
+		return "alpha";
+	default:
+		__ASSERT(0, "Unknown release type");
+		return NULL;
+	}
+};
+
 static void handle_image_info_request(uint8_t *data, size_t *size)
 {
 	unsigned int seq_num = 0;
 	suit_ssf_manifest_class_info_t class_info;
+	suit_semver_raw_t version_raw;
+	suit_version_t version;
+	bool is_semver_supported;
 
 	int err = suit_get_supported_manifest_info(SUIT_MANIFEST_APP_ROOT, &class_info);
 
 	if (!err) {
 		err = suit_get_installed_manifest_info(&(class_info.class_id),
-				&seq_num, NULL, NULL, NULL, NULL);
+				&seq_num, &version_raw, NULL, NULL, NULL);
 	}
+	if (!err) {
+		/* Semantic versioning support has been added to the SDFW in the v0.6.2
+		 * public release. Older SDFW versions return empty array in the version
+		 * variable.
+		 */
+		is_semver_supported = (version_raw.len != 0);
+		if (is_semver_supported) {
+			err = suit_metadata_version_from_array(&version,
+							       version_raw.raw,
+							       version_raw.len);
+		}
+	}
+
 	if (!err) {
 		uint8_t flash_area_id = 0;
 		/* SUIT supports multiple images, return zero as a special image size value. */
@@ -828,6 +861,31 @@ static void handle_image_info_request(uint8_t *data, size_t *size)
 		uint8_t major = 0;
 		uint8_t minor = 0;
 		uint16_t revision = 0;
+
+		if (is_semver_supported) {
+			const char *release_type;
+
+			release_type = suit_release_type_str_get(version.type);
+			if (release_type) {
+				LOG_INF("Booted application version: %d.%d.%d-%s%d",
+					version.major, version.minor, version.patch,
+					release_type, version.pre_release_number);
+			} else {
+				LOG_INF("Booted application version: %d.%d.%d",
+					version.major, version.minor, version.patch);
+			}
+
+			__ASSERT_NO_MSG((version.major >= 0) && (version.major <= UINT8_MAX));
+			__ASSERT_NO_MSG((version.minor >= 0) && (version.minor <= UINT8_MAX));
+			__ASSERT_NO_MSG((version.patch >= 0) && (version.patch <= UINT16_MAX));
+
+			major = version.major;
+			minor = version.minor;
+			revision = version.patch;
+			/* The Release type and the pre-release number are not included
+			 * in the image info response.
+			 */
+		}
 
 		LOG_INF("Booted application sequence number: %" PRIu32, seq_num);
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -250,6 +250,7 @@ nRF Desktop
     This ensures that the memory buffer passed to the USB next stack is valid until a HID report is sent and allows to enqueue up to two HID input reports for a USB HID instance (used only when :ref:`CONFIG_DESKTOP_USB_HID_REPORT_SENT_ON_SOF <config_desktop_app_options>` Kconfig option is enabled).
   * Kconfig dependency that prevents enabling USB remote wakeup (:ref:`CONFIG_DESKTOP_USB_REMOTE_WAKEUP <config_desktop_app_options>`) for the nRF54H20 SoC.
     The DWC2 USB device controller driver used by the nRF54H20 SoC does not support the remote wakeup capability.
+  * Bootup logs with the manifest semantic version information to :ref:`nrf_desktop_dfu_mcumgr` when the module is used for SUIT DFU and the SDFW supports semantic versioning (requires v0.6.2 and higher).
 
 * Updated:
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -251,6 +251,7 @@ nRF Desktop
   * Kconfig dependency that prevents enabling USB remote wakeup (:ref:`CONFIG_DESKTOP_USB_REMOTE_WAKEUP <config_desktop_app_options>`) for the nRF54H20 SoC.
     The DWC2 USB device controller driver used by the nRF54H20 SoC does not support the remote wakeup capability.
   * Bootup logs with the manifest semantic version information to :ref:`nrf_desktop_dfu_mcumgr` when the module is used for SUIT DFU and the SDFW supports semantic versioning (requires v0.6.2 and higher).
+  * Manifest semantic version information to the firmware information response in :ref:`nrf_desktop_dfu` when the module is used for SUIT DFU and the SDFW supports semantic versioning (requires v0.6.2 and higher).
 
 * Updated:
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -846,7 +846,7 @@ Scripts
 
 This section provides detailed lists of changes by :ref:`script <scripts>`.
 
-|no_changes_yet_note|
+* Added semantic version support to :ref:`nrf_desktop_config_channel_script` Python script for devices that use the SUIT DFU.
 
 Integrations
 ============

--- a/scripts/hid_configurator/modules/dfu.py
+++ b/scripts/hid_configurator/modules/dfu.py
@@ -293,7 +293,7 @@ class DfuImage:
             self._initialize_from_zip_file(dfu_package, dev_fwinfo, dev_board_name,
                                            dev_bootloader_variant)
         elif dfu_package.endswith('.suit'):
-            self._initialize_from_suit_file(dfu_package)
+            self._initialize_from_suit_file(dfu_package, dev_fwinfo)
         else:
             print('Invalid DFU package format')
             return
@@ -322,24 +322,55 @@ class DfuImage:
         except Exception:
             print("Parsing zip file failed")
 
-    def _initialize_from_suit_file(self, dfu_package):
+    def _initialize_from_suit_file(self, dfu_package, dev_fwinfo):
         try:
             envelope = SuitEnvelope()
             envelope.load(dfu_package)
-            version = envelope.sequence_number
+            sequence_number = envelope.sequence_number
         except Exception as e:
             print("Exception during retrieving manifest sequence number")
             print(e)
             return
 
-        if not isinstance(version, int):
+        if not isinstance(sequence_number, int):
             print("Invalid sequence number type. \
-                   Is of type: {} and should be: int".format(type(version)))
+                   Is of type: {} and should be: int".format(type(sequence_number)))
             return
+
+        if not hasattr(envelope, 'current_version'):
+            print("The current_version field is not found in the SuitEnvelope class. \
+                   Upgrade suit-generator package to the newer version")
+            return
+
+        current_version = envelope.current_version
+        if current_version is not None and not isinstance(current_version, list):
+            print("Invalid current_version type. \
+                   Is of type: {} and should be: list or None".format(type(current_version)))
+            return
+
+        booted_fw_version = dev_fwinfo.get_fw_version()
+        assert len(booted_fw_version) == 4
+        if booted_fw_version[:3] == (0, 0, 0):
+            # Semantic versioning is not supported in the booted firmware:
+            # fallback to sequence number versioning
+            image_bin_version = (0, 0, 0, sequence_number)
+        else:
+            if current_version is None:
+                print("The semantic version is not defined in the SUIT envelope. \
+                       Generate the SUIT package with the semantic version")
+                return
+
+            # It is assumed that the version list uses the following order of elements:
+            # (major, minor, patch, type, pre_release_number)
+            # Field names are documented in the suit_version_t structure from:
+            # nrf/subsys/suit/metadata/include/suit_metadata.h
+            assert len(current_version) >= 3
+            major, minor, patch = current_version[:3]
+            image_bin_version = (major, minor, patch, sequence_number)
 
         self.image_bin_path = dfu_package
         self.bootloader_variant = "SUIT"
-        self.image_bin_version = (0, 0, 0, version)
+        self.image_bin_version = image_bin_version
 
     @staticmethod
     def _is_dfu_file_correct(dfu_bin):


### PR DESCRIPTION
- [x] Test the code with the SDFW that supports semantic versioning