### PR TITLE
samples: bluetooth: peripehral_uart: All to run complete sample on nRF54H20 radio core

### DIFF
--- a/samples/bluetooth/peripheral_uart/README.rst
+++ b/samples/bluetooth/peripheral_uart/README.rst
@@ -177,6 +177,16 @@ Building and running
 
 .. include:: /includes/nRF54H20_erase_UICR.txt
 
+Experimental nRF54H20 SoC radio core only build
+===============================================
+
+The sample can also be built in a configuration that allows it to run on the nRF54H20 SoC radio core only.
+To build the sample with this configuration, use the following command:
+
+.. code-block:: console
+
+   west build -b nrf54h20dk/nrf54h20/cpurad
+
 Experimental Bluetooth Low Energy Remote Procedure Call interface
 =================================================================
 

--- a/samples/bluetooth/peripheral_uart/boards/nrf54h20dk_nrf54h20_cpurad.conf
+++ b/samples/bluetooth/peripheral_uart/boards/nrf54h20dk_nrf54h20_cpurad.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable the unspupported UART0 driver
+CONFIG_NRFX_UARTE0=n

--- a/samples/bluetooth/peripheral_uart/boards/nrf54h20dk_nrf54h20_cpurad.overlay
+++ b/samples/bluetooth/peripheral_uart/boards/nrf54h20dk_nrf54h20_cpurad.overlay
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,nus-uart = &uart135;
+		zephyr,settings_partition = &cpurad_storage_partition;
+	};
+
+	/* LEDs and buttons definitions are required for the DK Buttons and
+	 * LEDs module.
+	 */
+
+	aliases {
+		led0 = &led0;
+		led1 = &led1;
+		led2 = &led2;
+		led3 = &led3;
+
+		sw0 = &button0;
+		sw1 = &button1;
+		sw2 = &button2;
+		sw3 = &button3;
+	};
+
+	buttons {
+		compatible = "gpio-keys";
+
+		button0: button_0 {
+			gpios = <&gpio0 8 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button 0";
+			zephyr,code = <INPUT_KEY_0>;
+		};
+
+		button1: button_1 {
+			gpios = <&gpio0 9 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button 1";
+			zephyr,code = <INPUT_KEY_1>;
+		};
+
+		button2: button_2 {
+			gpios = <&gpio0 10 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button 2";
+			zephyr,code = <INPUT_KEY_2>;
+		};
+
+		button3: button_3 {
+			gpios = <&gpio0 11 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button 3";
+			zephyr,code = <INPUT_KEY_3>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led0: led_0 {
+			gpios = <&gpio9 0 GPIO_ACTIVE_HIGH>;
+			label = "Green LED 0";
+		};
+
+		led1: led_1 {
+			gpios = <&gpio9 1 GPIO_ACTIVE_HIGH>;
+			label = "Green LED 1";
+		};
+
+		led2: led_2 {
+			gpios = <&gpio9 2 GPIO_ACTIVE_HIGH>;
+			label = "Green LED 2";
+		};
+
+		led3: led_3 {
+			gpios = <&gpio9 3 GPIO_ACTIVE_HIGH>;
+			label = "Green LED 3";
+		};
+	};
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&gpio9 {
+	status = "okay";
+};
+
+&gpiote130 {
+	status = "okay";
+	owned-channels = <4 5 6 7>;
+};
+
+/* Change to memory map to make room for read write partition for settings
+ * module.
+ *
+ * @note In case of use of the settings sotrage when running firmware on the
+ *       application core, the same memory map change must be applied to the
+*        application core DTS.
+ */
+/delete-node/ &dfu_partition;
+/delete-node/ &storage_partition;
+
+&cpuapp_rw_partitions {
+	dfu_partition: partition@100000 {
+		reg = < 0x100000 DT_SIZE_K(884) >;
+	};
+
+	storage_partition: partition@1dd000 {
+		reg = < 0x1dd000 DT_SIZE_K(24) >;
+	};
+};
+
+&mram1x {
+	cpurad_rw_partitions: cpurad-rw-partitions {
+		compatible = "nordic,owned-partitions", "fixed-partitions";
+		perm-read;
+		perm-write;
+		perm-secure;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		cpurad_storage_partition: partition@1e3000 {
+			reg = <0x1e3000 DT_SIZE_K(24)>;
+		};
+	};
+};
+
+&cpurad_rw_partitions {
+	status = "okay";
+};


### PR DESCRIPTION
Add configuration that allows to build the sample application the nRF54H20 radio core. 
That presents possibility to run BLE firmware and use the nRF54h20 application core for other purposes.

All changes are related with nRF54H20 SoC only.