### PR TITLE
boards: shields: pca63565: Update sensor board overlay

### DIFF
--- a/boards/shields/pca63565/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/boards/shields/pca63565/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -34,7 +34,7 @@
 		};
 	};
 
-	spi00_default: spi00_default {
+	spi21_default: spi21_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 2, 6)>,
 					<NRF_PSEL(SPIM_MISO, 2, 9)>,
@@ -42,7 +42,7 @@
 		};
 	};
 
-	spi00_sleep: spi00_sleep {
+	spi21_sleep: spi21_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 2, 6)>,
 					<NRF_PSEL(SPIM_MISO, 2, 9)>,
@@ -66,10 +66,10 @@
 	};
 };
 
-&spi00 {
+&spi21 {
 	status = "okay";
-	pinctrl-0 = <&spi00_default>;
-	pinctrl-1 = <&spi00_sleep>;
+	pinctrl-0 = <&spi21_default>;
+	pinctrl-1 = <&spi21_sleep>;
 	pinctrl-names = "default", "sleep";
 	cs-gpios = <&gpio1 13 GPIO_ACTIVE_LOW>,
 			   <&gpio2 10 GPIO_ACTIVE_LOW>;

--- a/boards/shields/pca63565/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/boards/shields/pca63565/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -8,15 +8,15 @@
 		sensor-bme688 = &i2c22;
 		accel0 = &adxl362;
 		accel-gyro = &bmi270;
-		/delete-property/ led2;
+		/delete-property/ led0;
 		/delete-property/ led3;
-		/delete-property/ sw3;
+		/delete-property/ sw0;
 	};
 };
 
-/delete-node/ &led2;	// P1.13 is bmi270 chip select signal
+/delete-node/ &led0;	// P2.09 is adxl362 SPIM_MISO
 /delete-node/ &led3;	// P1.14 is adxl362 interrupt signal
-/delete-node/ &button3; // P2.10 is adxl362 chip select signal
+/delete-node/ &button0; // P1.13 is bmi270 chip select signal
 
 &pinctrl {
 	i2c22_default: i2c22_default {

--- a/boards/shields/pca63565/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
+++ b/boards/shields/pca63565/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
@@ -34,7 +34,7 @@
 		};
 	};
 
-	spi00_default: spi00_default {
+	spi21_default: spi21_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 2, 6)>,
 					<NRF_PSEL(SPIM_MISO, 2, 9)>,
@@ -42,7 +42,7 @@
 		};
 	};
 
-	spi00_sleep: spi00_sleep {
+	spi21_sleep: spi21_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 2, 6)>,
 					<NRF_PSEL(SPIM_MISO, 2, 9)>,
@@ -66,10 +66,10 @@
 	};
 };
 
-&spi00 {
+&spi21 {
 	status = "okay";
-	pinctrl-0 = <&spi00_default>;
-	pinctrl-1 = <&spi00_sleep>;
+	pinctrl-0 = <&spi21_default>;
+	pinctrl-1 = <&spi21_sleep>;
 	pinctrl-names = "default", "sleep";
 	cs-gpios = <&gpio1 13 GPIO_ACTIVE_LOW>,
 			   <&gpio2 10 GPIO_ACTIVE_LOW>;

--- a/boards/shields/pca63565/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
+++ b/boards/shields/pca63565/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
@@ -8,15 +8,15 @@
 		sensor-bme688 = &i2c22;
 		accel0 = &adxl362;
 		accel-gyro = &bmi270;
-		/delete-property/ led2;
+		/delete-property/ led0;
 		/delete-property/ led3;
-		/delete-property/ sw3;
+		/delete-property/ sw0;
 	};
 };
 
-/delete-node/ &led2;	// P1.13 is bmi270 chip select signal
+/delete-node/ &led0;	// P2.09 is adxl362 SPIM_MISO
 /delete-node/ &led3;	// P1.14 is adxl362 interrupt signal
-/delete-node/ &button3; // P2.10 is adxl362 chip select signal
+/delete-node/ &button0; // P1.13 is bmi270 chip select signal
 
 &pinctrl {
 	i2c22_default: i2c22_default {

--- a/boards/shields/pca63565/boards/nrf54l15dk_nrf54l15_vpr_launcher.overlay
+++ b/boards/shields/pca63565/boards/nrf54l15dk_nrf54l15_vpr_launcher.overlay
@@ -18,7 +18,7 @@
     status = "disabled";
 };
 
-&spi00 {
+&spi21 {
     status = "disabled";
 };
 

--- a/boards/shields/pca63565/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
+++ b/boards/shields/pca63565/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
@@ -34,7 +34,7 @@
 		};
 	};
 
-	spi00_default: spi00_default {
+	spi21_default: spi21_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 2, 6)>,
 					<NRF_PSEL(SPIM_MISO, 2, 9)>,
@@ -42,7 +42,7 @@
 		};
 	};
 
-	spi00_sleep: spi00_sleep {
+	spi21_sleep: spi21_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 2, 6)>,
 					<NRF_PSEL(SPIM_MISO, 2, 9)>,
@@ -66,10 +66,10 @@
 	};
 };
 
-&spi00 {
+&spi21 {
 	status = "okay";
-	pinctrl-0 = <&spi00_default>;
-	pinctrl-1 = <&spi00_sleep>;
+	pinctrl-0 = <&spi21_default>;
+	pinctrl-1 = <&spi21_sleep>;
 	pinctrl-names = "default", "sleep";
 	cs-gpios = <&gpio1 13 GPIO_ACTIVE_LOW>,
 			   <&gpio2 10 GPIO_ACTIVE_LOW>;

--- a/boards/shields/pca63565/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
+++ b/boards/shields/pca63565/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
@@ -8,15 +8,15 @@
 		sensor-bme688 = &i2c22;
 		accel0 = &adxl362;
 		accel-gyro = &bmi270;
-		/delete-property/ led2;
+		/delete-property/ led0;
 		/delete-property/ led3;
-		/delete-property/ sw3;
+		/delete-property/ sw0;
 	};
 };
 
-/delete-node/ &led2;	// P1.13 is bmi270 chip select signal
+/delete-node/ &led0;	// P2.09 is adxl362 SPIM_MISO
 /delete-node/ &led3;	// P1.14 is adxl362 interrupt signal
-/delete-node/ &button3; // P2.10 is adxl362 chip select signal
+/delete-node/ &button0; // P1.13 is bmi270 chip select signal
 
 &pinctrl {
 	i2c22_default: i2c22_default {

--- a/boards/shields/pca63565/boards/nrf54l15pdk_nrf54l15_cpuflpr.overlay
+++ b/boards/shields/pca63565/boards/nrf54l15pdk_nrf54l15_cpuflpr.overlay
@@ -34,7 +34,7 @@
 		};
 	};
 
-	spi00_default: spi00_default {
+	spi21_default: spi21_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 2, 6)>,
 					<NRF_PSEL(SPIM_MISO, 2, 9)>,
@@ -42,7 +42,7 @@
 		};
 	};
 
-	spi00_sleep: spi00_sleep {
+	spi21_sleep: spi21_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 2, 6)>,
 					<NRF_PSEL(SPIM_MISO, 2, 9)>,
@@ -66,10 +66,10 @@
 	};
 };
 
-&spi00 {
+&spi21 {
 	status = "okay";
-	pinctrl-0 = <&spi00_default>;
-	pinctrl-1 = <&spi00_sleep>;
+	pinctrl-0 = <&spi21_default>;
+	pinctrl-1 = <&spi21_sleep>;
 	pinctrl-names = "default", "sleep";
 	cs-gpios = <&gpio1 13 GPIO_ACTIVE_LOW>,
 			   <&gpio2 10 GPIO_ACTIVE_LOW>;

--- a/boards/shields/pca63565/boards/nrf54l15pdk_nrf54l15_cpuflpr.overlay
+++ b/boards/shields/pca63565/boards/nrf54l15pdk_nrf54l15_cpuflpr.overlay
@@ -8,15 +8,15 @@
 		sensor-bme688 = &i2c22;
 		accel0 = &adxl362;
 		accel-gyro = &bmi270;
-		/delete-property/ led2;
+		/delete-property/ led0;
 		/delete-property/ led3;
-		/delete-property/ sw3;
+		/delete-property/ sw0;
 	};
 };
 
-/delete-node/ &led2;	// P1.13 is bmi270 chip select signal
+/delete-node/ &led0;	// P2.09 is adxl362 SPIM_MISO
 /delete-node/ &led3;	// P1.14 is adxl362 interrupt signal
-/delete-node/ &button3; // P2.10 is adxl362 chip select signal
+/delete-node/ &button0; // P1.13 is bmi270 chip select signal
 
 &pinctrl {
 	i2c22_default: i2c22_default {

--- a/boards/shields/pca63565/boards/nrf54l15pdk_nrf54l15_vpr_launcher.overlay
+++ b/boards/shields/pca63565/boards/nrf54l15pdk_nrf54l15_vpr_launcher.overlay
@@ -18,7 +18,7 @@
     status = "disabled";
 };
 
-&spi00 {
+&spi21 {
     status = "disabled";
 };
 


### PR DESCRIPTION
Delete LEDs / Buttons that collide with GPIOs used by the sensor shield.
Align LEDs / Button placement to PCA10156 rev. 0.8.1.

Switch adxl362 from spi00 to spi21 because spi00 is already configured to work with external NOR flash memory.