### PR TITLE
samples: radio_notification_callback: Fix building empty app core

### DIFF
--- a/samples/bluetooth/radio_notification_cb/Kconfig.sysbuild
+++ b/samples/bluetooth/radio_notification_cb/Kconfig.sysbuild
@@ -5,6 +5,6 @@
 #
 
 config NRF_DEFAULT_EMPTY
-	default y if SOC_COMPATIBLE_NRF5340_CPUNET
+	default y if SOC_SERIES_NRF53X
 
 source "share/sysbuild/Kconfig"


### PR DESCRIPTION
Fixes building for 53 network core
after 9e8d1713a8b12cc0c81356cc18bb0d00ebe2888a.
SOC_COMPATIBLE_NRF5340_CPUNET was not being set in a sysbuild context. Using SOC_SERIES_NRF53X instead.