### PR TITLE
tests: drivers: Run i2c bme688 test with all supported i2c speeds

### DIFF
--- a/scripts/twister/alt/zephyr/tests/drivers/i2c/i2c_bme688/testcase.yaml
+++ b/scripts/twister/alt/zephyr/tests/drivers/i2c/i2c_bme688/testcase.yaml
@@ -12,8 +12,34 @@ tests:
       - SB_CONFIG_VPR_LAUNCHER=y
       - vpr_launcher_DTC_OVERLAY_FILE="../../../../nrf/boards/shields/pca63565/boards/nrf54l15pdk_nrf54l15_vpr_launcher.overlay"
     platform_allow:
-      - nrf54l15pdk/nrf54l15/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuflpr
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuflpr
+
+  drivers.i2c.bme688_nrf54l_fast_speed:
+    filter: not CONFIG_COVERAGE
+    harness_config:
+      fixture: pca63565
+    extra_args:
+      - SHIELD=pca63565
+      - SB_CONFIG_VPR_LAUNCHER=y
+      - vpr_launcher_DTC_OVERLAY_FILE="../../../../nrf/boards/shields/pca63565/boards/nrf54l15pdk_nrf54l15_vpr_launcher.overlay"
+      - CONFIG_TEST_I2C_SPEED=2
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuflpr
+
+  drivers.i2c.bme688_nrf54l_fast_plus_speed:
+    filter: not CONFIG_COVERAGE
+    harness_config:
+      fixture: pca63565
+    extra_args:
+      - SHIELD=pca63565
+      - SB_CONFIG_VPR_LAUNCHER=y
+      - vpr_launcher_DTC_OVERLAY_FILE="../../../../nrf/boards/shields/pca63565/boards/nrf54l15pdk_nrf54l15_vpr_launcher.overlay"
+      - CONFIG_TEST_I2C_SPEED=3
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuflpr
 
   drivers.i2c.bme688_nrf54l_coverage:
     filter: CONFIG_COVERAGE
@@ -22,7 +48,27 @@ tests:
     extra_args:
       - SHIELD=pca63565;coverage_support
     platform_allow:
-      - nrf54l15pdk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+
+  drivers.i2c.bme688_nrf54l_coverage_fast_speed:
+    filter: CONFIG_COVERAGE
+    harness_config:
+      fixture: pca63565
+    extra_args:
+      - SHIELD=pca63565;coverage_support
+      - CONFIG_TEST_I2C_SPEED=2
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+
+  drivers.i2c.bme688_nrf54l_coverage_fast_plus_speed:
+    filter: CONFIG_COVERAGE
+    harness_config:
+      fixture: pca63565
+    extra_args:
+      - SHIELD=pca63565;coverage_support
+      - CONFIG_TEST_I2C_SPEED=3
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
 
   drivers.i2c.bme688_nrf54h:
     filter: not CONFIG_COVERAGE
@@ -36,11 +82,57 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54h20dk/nrf54h20/cpuppr
 
+  drivers.i2c.bme688_nrf54h_fast_speed:
+    filter: not CONFIG_COVERAGE
+    harness_config:
+      fixture: pca63566
+    extra_args:
+      - i2c_bme688_SHIELD=pca63566
+      - SB_CONFIG_VPR_LAUNCHER=y
+      - vpr_launcher_SHIELD=pca63566_fwd
+      - CONFIG_TEST_I2C_SPEED=2
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54h20dk/nrf54h20/cpuppr
+
+  drivers.i2c.bme688_nrf54h_fast_plus_speed:
+    filter: not CONFIG_COVERAGE
+    harness_config:
+      fixture: pca63566
+    extra_args:
+      - i2c_bme688_SHIELD=pca63566
+      - SB_CONFIG_VPR_LAUNCHER=y
+      - vpr_launcher_SHIELD=pca63566_fwd
+      - CONFIG_TEST_I2C_SPEED=3
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54h20dk/nrf54h20/cpuppr
+
   drivers.i2c.bme688_nrf54h_coverage:
     filter: CONFIG_COVERAGE
     harness_config:
       fixture: pca63566
     extra_args:
       - SHIELD=pca63566;coverage_support
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+
+  drivers.i2c.bme688_nrf54h_coverage_fast_speed:
+    filter: CONFIG_COVERAGE
+    harness_config:
+      fixture: pca63566
+    extra_args:
+      - SHIELD=pca63566;coverage_support
+      - CONFIG_TEST_I2C_SPEED=2
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+
+  drivers.i2c.bme688_nrf54h_coverage_fast_plus_speed:
+    filter: CONFIG_COVERAGE
+    harness_config:
+      fixture: pca63566
+    extra_args:
+      - SHIELD=pca63566;coverage_support
+      - CONFIG_TEST_I2C_SPEED=3
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp


### PR DESCRIPTION
Adapt the alternative configuration of the i2c/bme688 test to run on all supported I2C speeds.