### PR TITLE
ci: doc: align Zoomin zip names with bundle names

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -89,7 +89,7 @@ jobs:
 
           # Create documentation upload files
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            ARCHIVE="doc_build_pr_${{ github.event.number }}_legacy.zip"
+            ARCHIVE="legacy-ncs-pr-${{ github.event.number }}.zip"
             echo "publish2 dev PR-${{ github.event.number }} ${ARCHIVE}" > "${MONITOR}"
             echo "${{ github.event.number }}" > pr.txt
           else
@@ -98,7 +98,7 @@ jobs:
               exit 0
             fi
 
-            ARCHIVE="doc_build_${VERSION}_legacy.zip"
+            ARCHIVE="legacy-ncs-${VERSION}.zip"
             echo "publish2 main ${VERSION} ${ARCHIVE}" > "${MONITOR}"
           fi
 
@@ -136,12 +136,12 @@ jobs:
           cd doc/_build/
 
           cd html-doxygen/zephyr-apis
-          ARCHIVE="doc_build_${VERSION}_zoomin_doxygen_zephyr_apis.zip"
+          ARCHIVE="zephyr-apis-${VERSION}.zip"
           zip -rq "${ARCHIVE}" .
           mv "${ARCHIVE}" ../../../../
           cd ../../
 
-          ARCHIVE="doc_build_${VERSION}_zoomin_sphinx_ncs.zip"
+          ARCHIVE="ncs-${VERSION}.zip"
           cd html
           zip -rq "${ARCHIVE}" .
           mv "${ARCHIVE}" ../../../

--- a/.github/workflows/docpublish.yml
+++ b/.github/workflows/docpublish.yml
@@ -30,7 +30,7 @@ jobs:
           mkdir -p ~/.ssh && \
             ssh-keyscan -p 2222 transfer.nordicsemi.no >> ~/.ssh/known_hosts
           # upload files
-          for file in docs/*legacy.zip docs/monitor*.txt; do
+          for file in docs/legacy*.zip docs/monitor*.txt; do
             echo "put ${file}" | \
               sshpass -e sftp -P 2222 -o BatchMode=no -b - $SSHUSER@transfer.nordicsemi.no
           done
@@ -53,7 +53,7 @@ jobs:
           chmod 600 zoomin_key
 
           # upload files
-          for file in docs/*zoomin_doxygen*.zip; do
+          for file in docs/*-apis-*.zip; do
             sftp -v -i zoomin_key nordic@upload-v1.zoominsoftware.io <<EOF
             cd docs-be.nordicsemi.com/doxygen/incoming
             put ${file}
@@ -63,7 +63,7 @@ jobs:
           EOF
           done
 
-          for file in docs/*zoomin_sphinx*.zip; do
+          for file in docs/ncs-*.zip; do
             sftp -v -i zoomin_key nordic@upload-v1.zoominsoftware.io <<EOF
             cd docs-be.nordicsemi.com/sphinx-html/incoming
             put ${file}


### PR DESCRIPTION
Apparently some Zoomin plugins ignore the content of `custom.properties` and use the Zip file name as the uploaded bundle name. Until fixed, align Zip file names with their expected bundle name.