### PR TITLE
doc: Bluetooth: Fix typo in the header

### DIFF
--- a/doc/nrf/protocols/bt/bt_stack_arch.rst
+++ b/doc/nrf/protocols/bt/bt_stack_arch.rst
@@ -1,5 +1,5 @@
-Blutooth stack architecture
-###########################
+Bluetooth stack architecture
+############################
 
 .. contents::
    :local:


### PR DESCRIPTION
This was missed in an earlier PR.