### PR TITLE
samples: add nrf54l15pdk and nrf54h20dk to platform_allow

### DIFF
--- a/samples/bluetooth/peripheral_power_profiling/sample.yaml
+++ b/samples/bluetooth/peripheral_power_profiling/sample.yaml
@@ -13,4 +13,5 @@ tests:
       - nrf5340dk/nrf5340/cpuapp/ns
     platform_allow: nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840
       nrf5340dk/nrf5340/cpuapp nrf5340dk/nrf5340/cpuapp/ns
+      nrf54l15pdk/nrf54l15/cpuapp nrf54h20dk/nrf54h20/cpuapp
     tags: bluetooth ci_build sysbuild


### PR DESCRIPTION
samples: power_profiler: add `nrf54l15pdk/nrf54l15/cpuapp` and `nrf54h20dk/nrf54h20/cpuapp` to platform_allow
   
Requested by ~keer for the Quick Start Guide


Signed-off-by: Thomas Stilwell <thomas.stilwell@nordicsemi.no>
