### PR TITLE
boards: thingy91x: fix external_flash static partition

### DIFF
--- a/boards/nordic/thingy91x/thingy91x_nrf9151_pm_static.yml
+++ b/boards/nordic/thingy91x/thingy91x_nrf9151_pm_static.yml
@@ -80,18 +80,18 @@ app:
   region: flash_primary
 
 mcuboot_secondary:
-  device: GD25LB256E
+  device: DT_CHOSEN(nordic_pm_ext_flash)
   address: 0x0
   size: 0xD0000
   share_size: [mcuboot_primary]
   region: external_flash
 fmfu_storage:
   address: 0xD0000
-  device: GD25LB256E
+  device: DT_CHOSEN(nordic_pm_ext_flash)
   region: external_flash
   size: 0x400000
 settings_storage:
-  device: GD25LB256E
+  device: DT_CHOSEN(nordic_pm_ext_flash)
   address: 0x4D0000
   size: 0x2000
   region: external_flash

--- a/boards/nordic/thingy91x/thingy91x_nrf9151_pm_static.yml
+++ b/boards/nordic/thingy91x/thingy91x_nrf9151_pm_static.yml
@@ -79,12 +79,6 @@ app:
   size: 0xc8000
   region: flash_primary
 
-external_flash:
-  device: GD25LB256E
-  address: 0x0
-  size: 0x2000000
-  span: [mcuboot_secondary]
-  region: external_flash
 mcuboot_secondary:
   device: GD25LB256E
   address: 0x0


### PR DESCRIPTION
When using the start-to-end placement strategy in the external_flash region, it will automatically create a partition named external_flash that fills the remainder of the external flash's address space.

The external_flash we had defined in the Thingy:91 X static partitions was covering the total space in the external flash. Which caused dynamic partitions, like modem_trace, to be placed outside of the external flash address space instead of after the last static partition.

With this fix, the modem_trace partition will be placed after the last statically defined partition in the external_flash region. Then a partition named external_flash will be placed after the modem_trace partition to fill the remaining space.

The hardcoded device name referred to an old prototype revision of the thingy91x. Instead of updating to the new device name, use the `nordic,pm-ext-flash` property from the device tree's `chosen` node. This avoids hardcoding device names and improves compatibility.