### PR TITLE
samples: radio_test: Fix shortcut configuration for nRF52 and nRF53

### DIFF
--- a/samples/peripheral/radio_test/src/radio_test.c
+++ b/samples/peripheral/radio_test/src/radio_test.c
@@ -699,7 +699,7 @@ static void radio_modulated_tx_carrier(uint8_t mode, int8_t txpower, uint8_t cha
 	case NRF_RADIO_MODE_BLE_LR500KBIT:
 		nrf_radio_shorts_enable(NRF_RADIO,
 					NRF_RADIO_SHORT_READY_START_MASK |
-					RADIO_TEST_SHORT_END_START_MASK);
+					NRF_RADIO_SHORT_PHYEND_START_MASK);
 		break;
 
 #endif /* CONFIG_HAS_HW_NRF_RADIO_IEEE802154 || CONFIG_HAS_HW_NRF_RADIO_BLE_CODED */
@@ -752,7 +752,7 @@ static void radio_rx(uint8_t mode, uint8_t channel, enum transmit_pattern patter
 
 	nrf_radio_shorts_enable(NRF_RADIO,
 				NRF_RADIO_SHORT_READY_START_MASK |
-				RADIO_TEST_SHORT_END_START_MASK);
+				NRF_RADIO_SHORT_END_START_MASK);
 	nrf_radio_packetptr_set(NRF_RADIO, rx_packet);
 
 	radio_config(mode, pattern);


### PR DESCRIPTION
Fixed the radio shortcut settings for nRF52 and nRF53 devices to use the PHYEND_START 
shortcut when operating in 802.15.4 or BLE Coded PHY modes.