### PR TITLE
boards: nrf54h20dk: Fix settings partition

### DIFF
--- a/boards/shields/nrf700x_nrf54h20dk/nrf700x_nrf54h20dk.overlay
+++ b/boards/shields/nrf700x_nrf54h20dk/nrf700x_nrf54h20dk.overlay
@@ -87,11 +87,11 @@
 		#size-cells = <1>;
 
 		dfu_partition: partition@136000 {
-			reg = < 0x136000 DT_SIZE_K(676) >;
+			reg = < 0x136000 DT_SIZE_K(692) >;
 		};
 
-		storage_partition: partition@1df000 {
-			reg = < 0x1df000 DT_SIZE_K(24) >;
+		storage_partition: partition@1e3000 {
+			reg = < 0x1e3000 DT_SIZE_K(24) >;
 		};
 	};
 };

--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 78f654738d488e96e4d2107cec538347c3f0fce0
+      revision: d3a967f7b8696e5e05a1ff64be49561a58e9e13d
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Align settings and DFU partition definition with the values, specified by the design documentation.

Ref: NCSDK-NONE