### PR TITLE
samples: matter: set External Flash to sleep at init

### DIFF
--- a/samples/matter/common/src/app/matter_init.cpp
+++ b/samples/matter/common/src/app/matter_init.cpp
@@ -46,6 +46,7 @@
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/server/OnboardingCodesUtil.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
+#include <platform/nrfconnect/ExternalFlashManager.h>
 
 LOG_MODULE_DECLARE(app, CONFIG_CHIP_APP_LOG_LEVEL);
 
@@ -224,6 +225,9 @@ void DoInitChipServer(intptr_t /* unused */)
 	Nrf::GetDFUOverSMP().Init();
 	Nrf::GetDFUOverSMP().ConfirmNewImage();
 #endif
+
+	/* Set External Flash into sleep mode */
+	ExternalFlashManager::GetInstance().DoAction(ExternalFlashManager::Action::SLEEP);
 
 	/* Initialize CHIP server */
 #ifdef CONFIG_CHIP_FACTORY_DATA

--- a/samples/matter/common/src/dfu/ota/ota_util.cpp
+++ b/samples/matter/common/src/dfu/ota/ota_util.cpp
@@ -39,7 +39,7 @@ namespace Nrf::Matter
 OTAImageProcessorImpl &GetOTAImageProcessor()
 {
 #if CONFIG_PM_DEVICE && CONFIG_NORDIC_QSPI_NOR
-	static OTAImageProcessorBaseImpl sOTAImageProcessor(&GetFlashHandler());
+	static OTAImageProcessorBaseImpl sOTAImageProcessor(&ExternalFlashManager::GetInstance());
 #else
 	static OTAImageProcessorBaseImpl sOTAImageProcessor;
 #endif
@@ -57,7 +57,6 @@ void InitBasicOTARequestor()
 	sOTARequestor.Init(Server::GetInstance(), sOTARequestorStorage, sOTARequestorDriver, sBDXDownloader);
 	chip::SetRequestorInstance(&sOTARequestor);
 	sOTARequestorDriver.Init(&sOTARequestor, &imageProcessor);
-	imageProcessor.TriggerFlashAction(ExternalFlashManager::Action::SLEEP);
 }
 
 void OtaConfirmNewImage()
@@ -86,11 +85,5 @@ void OtaConfirmNewImage()
 }
 
 #endif
-
-ExternalFlashManager &GetFlashHandler()
-{
-	static ExternalFlashManager sFlashHandler;
-	return sFlashHandler;
-}
 
 } /* namespace Nrf::Matter */

--- a/samples/matter/common/src/dfu/ota/ota_util.h
+++ b/samples/matter/common/src/dfu/ota/ota_util.h
@@ -47,12 +47,4 @@ void OtaConfirmNewImage();
 
 #endif /* CONFIG_CHIP_OTA_REQUESTOR */
 
-/**
- * Get FlashHandler static instance.
- *
- * Returned object can be used to control the QSPI external flash,
- * which can be introduced into sleep mode and woken up on demand.
- */
-chip::DeviceLayer::ExternalFlashManager &GetFlashHandler();
-
 } /* namespace Nrf::Matter */

--- a/samples/matter/common/src/dfu/smp/dfu_over_smp.cpp
+++ b/samples/matter/common/src/dfu/smp/dfu_over_smp.cpp
@@ -72,9 +72,9 @@ enum mgmt_cb_return CommandHandler(uint32_t event, enum mgmt_cb_return, int32_t 
 				   bool *, void *, size_t)
 {
 	if (event == MGMT_EVT_OP_CMD_RECV) {
-		Nrf::Matter::GetFlashHandler().DoAction(ExternalFlashManager::Action::WAKE_UP);
+		ExternalFlashManager::GetInstance().DoAction(ExternalFlashManager::Action::WAKE_UP);
 	} else if (event == MGMT_EVT_OP_CMD_DONE) {
-		Nrf::Matter::GetFlashHandler().DoAction(ExternalFlashManager::Action::SLEEP);
+		ExternalFlashManager::GetInstance().DoAction(ExternalFlashManager::Action::SLEEP);
 	}
 
 	return MGMT_CB_OK;

--- a/west.yml
+++ b/west.yml
@@ -169,7 +169,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: acb371d0899282622dd6ff0252b48409201bd85a
+      revision: be30c50987d7bf02815b376785fc6f6256fabc67
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
set External Flash to sleep always during initialization. This ensures that if External Flash is available, it will be put into deep sleep mode and consume less energy.

Additionaly align with `ExternalFlashManager` refactor.