### PR TITLE
scripts: quarantine_zephyr: add sample.drivers.spi.flash

### DIFF
--- a/scripts/quarantine_zephyr.yaml
+++ b/scripts/quarantine_zephyr.yaml
@@ -156,6 +156,13 @@
     - nrf54h20dk/nrf54h20/cpurad
   comment: "to be fixed in https://github.com/zephyrproject-rtos/zephyr/pull/73777"
 
+- scenarios:
+    - sample.drivers.spi.flash
+    - sample.drivers.spi.flash_dpd
+  platforms:
+    - nrf54l15dk/nrf54l15/cpuapp
+  comment: "Test not aligned for nrf54l15 but selected due to jedec,spi-nor"
+
 # ---------------------------------   Won't fix section -----------------------------------
 
 - scenarios:


### PR DESCRIPTION
Enabled during PDK->DK transfer but not aligned for nrf54l15.