### PR TITLE
drivers: wifi: Fix crash when recovery is triggered

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 090547835b50fc910abb58d4bf026203b9dbac05
+      revision: pull/2021/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
There is a race condition when recovery is in progress and in parallel Wi-Fi util commands are being executed (CTF), where the RPU context is de-initialized as part of recovery but no checks are present in the Wi-Fi util command processing causing a crash.

This needs a proper fix for all commands, but for maintenance branch fix is added only for commonly used commands.