### PR TITLE
tests: drivers: Remove unsupported i2c speed for bme688 with nrf54l15dk

### DIFF
--- a/scripts/twister/alt/zephyr/tests/drivers/i2c/i2c_bme688/testcase.yaml
+++ b/scripts/twister/alt/zephyr/tests/drivers/i2c/i2c_bme688/testcase.yaml
@@ -28,19 +28,6 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuflpr
 
-  drivers.i2c.bme688_nrf54l_fast_plus_speed:
-    filter: not CONFIG_COVERAGE
-    harness_config:
-      fixture: pca63565
-    extra_args:
-      - SHIELD=pca63565
-      - SB_CONFIG_VPR_LAUNCHER=y
-      - vpr_launcher_DTC_OVERLAY_FILE="../../../../nrf/boards/shields/pca63565/boards/nrf54l15dk_nrf54l15_vpr_launcher.overlay"
-      - CONFIG_TEST_I2C_SPEED=3
-    platform_allow:
-      - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15dk/nrf54l15/cpuflpr
-
   drivers.i2c.bme688_nrf54l_coverage:
     filter: CONFIG_COVERAGE
     harness_config:
@@ -57,16 +44,6 @@ tests:
     extra_args:
       - SHIELD=pca63565;coverage_support
       - CONFIG_TEST_I2C_SPEED=2
-    platform_allow:
-      - nrf54l15dk/nrf54l15/cpuapp
-
-  drivers.i2c.bme688_nrf54l_coverage_fast_plus_speed:
-    filter: CONFIG_COVERAGE
-    harness_config:
-      fixture: pca63565
-    extra_args:
-      - SHIELD=pca63565;coverage_support
-      - CONFIG_TEST_I2C_SPEED=3
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
 


### PR DESCRIPTION
…est case for nrf54l15dk

Fixes: https://nordicsemi.atlassian.net/browse/NCSDK-29132