### PR TITLE
samples: bluetooth: fix peripheral hr coded

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -325,6 +325,10 @@ Bluetooth samples
 
   * Moved to the :file:`samples/bluetooth/event_trigger` folder.
 
+* :ref:`peripheral_hr_coded` sample:
+
+   * Fixed an issue where the HCI LE Set Extended Advertising Enable command was called with a NULL pointer.
+
 Bluetooth Fast Pair samples
 ---------------------------
 

--- a/samples/bluetooth/peripheral_hr_coded/src/main.c
+++ b/samples/bluetooth/peripheral_hr_coded/src/main.c
@@ -122,7 +122,7 @@ static void start_advertising_coded(struct k_work *work)
 {
 	int err;
 
-	err = bt_le_ext_adv_start(adv, NULL);
+	err = bt_le_ext_adv_start(adv, BT_LE_EXT_ADV_START_DEFAULT);
 	if (err) {
 		printk("Failed to start advertising set (err %d)\n", err);
 		return;


### PR DESCRIPTION
Pass default params to bt_le_ext_adv_start
instead of NULL. The NULL was deferenced and used
to set parameters for starting extended advertising in the sample.