### PR TITLE
samples: Fix warnings in smp_transfer sample

### DIFF
--- a/samples/suit/smp_transfer/prj.conf
+++ b/samples/suit/smp_transfer/prj.conf
@@ -14,15 +14,6 @@ CONFIG_ZCBOR_CANONICAL=y
 CONFIG_MCUMGR=y
 CONFIG_MCUMGR_SMP_LEGACY_RC_BEHAVIOUR=y
 CONFIG_CRC=y
-CONFIG_MCUMGR_TRANSPORT_NETBUF_SIZE=1040
-
-# Enable the serial mcumgr transport
-CONFIG_SERIAL=y
-CONFIG_CONSOLE=y
-CONFIG_BASE64=y
-CONFIG_MCUMGR_TRANSPORT_UART=y
-CONFIG_UART_MCUMGR_RX_BUF_SIZE=1040
-CONFIG_MCUMGR_TRANSPORT_UART_MTU=1024
 
 # Enable SUIT services
 CONFIG_SUIT=y
@@ -32,7 +23,5 @@ CONFIG_FLASH=y
 # Extended SUIT commands over USER group
 CONFIG_MGMT_SUITFU_GRP_SUIT=y
 
-# Disable boot banners and printk
-CONFIG_NCS_BOOT_BANNER=n
-CONFIG_BOOT_BANNER=n
-CONFIG_PRINTK=n
+# For UART transport settings see: sysbuild/smp_transfer.conf
+# For BLE transport settings see: sysbuild/smp_transfer_bt.conf

--- a/samples/suit/smp_transfer/sysbuild/smp_transfer.conf
+++ b/samples/suit/smp_transfer/sysbuild/smp_transfer.conf
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Enable the serial mcumgr transport
+CONFIG_SERIAL=y
+CONFIG_CONSOLE=y
+CONFIG_BASE64=y
+CONFIG_MCUMGR_TRANSPORT_UART=y
+
+# Optimize buffer sizes for transport speed
+CONFIG_MCUMGR_TRANSPORT_NETBUF_SIZE=1040
+CONFIG_UART_MCUMGR_RX_BUF_SIZE=1040
+CONFIG_MCUMGR_TRANSPORT_UART_MTU=1024
+
+# Disable boot banners and printk
+CONFIG_NCS_BOOT_BANNER=n
+CONFIG_BOOT_BANNER=n
+CONFIG_PRINTK=n

--- a/samples/suit/smp_transfer/sysbuild/smp_transfer_bt.conf
+++ b/samples/suit/smp_transfer/sysbuild/smp_transfer_bt.conf
@@ -17,12 +17,8 @@ CONFIG_MCUMGR_TRANSPORT_BT=y
 CONFIG_MCUMGR_TRANSPORT_BT_AUTHEN=n
 CONFIG_MCUMGR_TRANSPORT_BT_CONN_PARAM_CONTROL=y
 
-# Disable SMP over UART
-CONFIG_MCUMGR_TRANSPORT_UART=n
 # Enable logs over UART
 CONFIG_LOG=y
-CONFIG_LOG_PRINTK=y
-CONFIG_UART_CONSOLE=y
 
 # Enable the mcumgr Packet Reassembly feature over Bluetooth and its configuration dependencies.
 # MCUmgr buffer size is optimized to fit one SMP packet divided into five Bluetooth Write Commands,
@@ -32,8 +28,3 @@ CONFIG_MCUMGR_TRANSPORT_NETBUF_SIZE=2475
 CONFIG_MCUMGR_TRANSPORT_WORKQUEUE_STACK_SIZE=4096
 
 CONFIG_BT_DEVICE_NAME="SUIT SMP Sample"
-
-# Enable boot banners
-CONFIG_NCS_BOOT_BANNER=y
-CONFIG_BOOT_BANNER=y
-CONFIG_PRINTK=y


### PR DESCRIPTION
Adjust Kconfigs, so they do not produce build-time warnings.

Ref: NCSDK-NONE