### PR TITLE
manifest: zephyr: Update PR ref with SHA

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: pull/2021/head
+      revision: 4040aa0bf581206dd68beb0758b39096342ee7e0
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Mistakenly the PR ref was merged, so, update with the SHA of the merged Zephyr PR.

FYI, original PR is https://github.com/nrfconnect/sdk-nrf/pull/17277 this should ideally have the SHA, but it was merged early before the manifest update, this PR fixes that.