### PR TITLE
wifi: Fixes for recovery stress tests

### DIFF
--- a/drivers/wifi/nrf700x/src/fmac_main.c
+++ b/drivers/wifi/nrf700x/src/fmac_main.c
@@ -632,8 +632,6 @@ enum nrf_wifi_status nrf_wifi_fmac_dev_add_zep(struct nrf_wifi_drv_priv_zep *drv
 		goto err;
 	}
 
-	k_mutex_init(&rpu_ctx_zep->rpu_lock);
-
 	return status;
 err:
 	if (rpu_ctx) {
@@ -782,6 +780,7 @@ static int nrf_wifi_drv_main_zep(const struct device *dev)
 			      nrf_wifi_scan_timeout_work);
 #endif /* CONFIG_NRF700X_RADIO_TEST */
 
+	k_mutex_init(&rpu_drv_priv_zep.rpu_ctx_zep.rpu_lock);
 	return 0;
 #ifdef CONFIG_NRF700X_RADIO_TEST
 fmac_deinit:

--- a/drivers/wifi/nrf700x/src/wifi_util.c
+++ b/drivers/wifi/nrf700x/src/wifi_util.c
@@ -909,6 +909,7 @@ static int nrf_wifi_util_dump_rpu_stats(const struct shell *shell,
 
 	ret = 0;
 unlock:
+	k_mutex_unlock(&ctx->rpu_lock);
 	return ret;
 }
 #endif /* CONFIG_NRF700X_RADIO_TEST */

--- a/west.yml
+++ b/west.yml
@@ -142,7 +142,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 0d57997cfc6fabd9c2ddec8cbe68cdcc228ae74d
+      revision: 10f7478f83bcbbddd4213431b3dbe48efff88db5
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
* The RPU context lock is not unlocked this is causing recovery to be stuck waiting for the lock.
* Fix the improper re-initialization of RPU context lock
* FW: Fix recovery reset for every TX command