### PR TITLE
applications: ipc_radio: align net_buf to new API

### DIFF
--- a/applications/ipc_radio/src/bt_hci_ipc.c
+++ b/applications/ipc_radio/src/bt_hci_ipc.c
@@ -88,7 +88,7 @@ static void recv_cmd(const uint8_t *data, size_t len)
 						sys_le16_to_cpu(hdr->opcode), hdr->param_len);
 
 	net_buf_add_mem(buf, data, len);
-	net_buf_put(&tx_queue, buf);
+	k_fifo_put(&tx_queue, buf);
 }
 
 static void recv_acl(const uint8_t *data, size_t len)
@@ -125,7 +125,7 @@ static void recv_acl(const uint8_t *data, size_t len)
 					sys_le16_to_cpu(hdr->handle), sys_le16_to_cpu(hdr->len));
 
 	net_buf_add_mem(buf, data, len);
-	net_buf_put(&tx_queue, buf);
+	k_fifo_put(&tx_queue, buf);
 }
 
 static void recv_iso(const uint8_t *data, size_t len)
@@ -162,7 +162,7 @@ static void recv_iso(const uint8_t *data, size_t len)
 					sys_le16_to_cpu(hdr->handle), sys_le16_to_cpu(hdr->len));
 
 	net_buf_add_mem(buf, data, len);
-	net_buf_put(&tx_queue, buf);
+	k_fifo_put(&tx_queue, buf);
 }
 
 static void send(struct net_buf *buf, bool is_fatal_err)
@@ -260,7 +260,7 @@ static void tx_thread(void)
 	int err;
 
 	while (1) {
-		buf = net_buf_get(&tx_queue, K_FOREVER);
+		buf = k_fifo_get(&tx_queue, K_FOREVER);
 		err = bt_send(buf);
 		if (err) {
 			LOG_ERR("bt_send failed err: %d.", err);
@@ -374,7 +374,7 @@ int ipc_bt_process(void)
 	k_sem_take(&ipc_bound_sem, K_FOREVER);
 
 	while (1) {
-		buf = net_buf_get(&rx_queue, K_FOREVER);
+		buf = k_fifo_get(&rx_queue, K_FOREVER);
 		send(buf, HCI_REGULAR_MSG);
 	}
 

--- a/samples/bluetooth/direct_test_mode/remote_hci/src/main.c
+++ b/samples/bluetooth/direct_test_mode/remote_hci/src/main.c
@@ -124,7 +124,7 @@ NRF_RPC_CBOR_CMD_DECODER(hci_group, hci_uart_init, RPC_HCI_UART_INIT_CMD,
 
 static void dtm_hci_put_wrapper(struct net_buf *buf)
 {
-	net_buf_put(&dtm_put_queue, buf);
+	k_fifo_put(&dtm_put_queue, buf);
 }
 
 static void dtm_put_thread(void)
@@ -132,7 +132,7 @@ static void dtm_put_thread(void)
 	struct net_buf *buf;
 
 	for (;;) {
-		buf = net_buf_get(&dtm_put_queue, K_FOREVER);
+		buf = k_fifo_get(&dtm_put_queue, K_FOREVER);
 
 		__ASSERT_NO_MSG(buf != NULL);
 

--- a/samples/bluetooth/direct_test_mode/src/transport/dtm_hci.c
+++ b/samples/bluetooth/direct_test_mode/src/transport/dtm_hci.c
@@ -712,7 +712,7 @@ static int hci_cmd(const struct bt_hci_cmd_hdr *hdr, const uint8_t *data)
 
 static void dtm_hci_put(struct net_buf *buf)
 {
-	net_buf_put(&hci_rx_queue, buf);
+	k_fifo_put(&hci_rx_queue, buf);
 }
 
 int dtm_tr_init(void)
@@ -738,7 +738,7 @@ union dtm_tr_packet dtm_tr_get(void)
 {
 	union dtm_tr_packet tmp;
 
-	tmp.hci = net_buf_get(&hci_rx_queue, K_FOREVER);
+	tmp.hci = k_fifo_get(&hci_rx_queue, K_FOREVER);
 	return tmp;
 }
 

--- a/samples/bluetooth/direct_test_mode/src/transport/hci_uart.c
+++ b/samples/bluetooth/direct_test_mode/src/transport/hci_uart.c
@@ -249,7 +249,7 @@ static void tx_thread(void)
 		 * and it's not supposed to be sent over uart.
 		 * The pointer is an address to the associated net_buf.
 		 */
-		buf = net_buf_get(&hci_tx_queue, K_FOREVER);
+		buf = k_fifo_get(&hci_tx_queue, K_FOREVER);
 		uart_tx(hci_uart_dev, &buf->data[sizeof(buf)],
 			buf->len - sizeof(buf), SYS_FOREVER_US);
 	}
@@ -304,6 +304,6 @@ int hci_uart_write(uint8_t type, const uint8_t *hdr, size_t hdr_len, const uint8
 	net_buf_add_mem(buf, hdr, hdr_len);
 	net_buf_add_mem(buf, pld, len);
 
-	net_buf_put(&hci_tx_queue, buf);
+	k_fifo_put(&hci_tx_queue, buf);
 	return 0;
 }

--- a/samples/nrf5340/multiprotocol_rpmsg/src/main.c
+++ b/samples/nrf5340/multiprotocol_rpmsg/src/main.c
@@ -131,7 +131,7 @@ static void hci_rpmsg_rx(uint8_t *data, size_t len)
 	}
 
 	if (buf) {
-		net_buf_put(&tx_queue, buf);
+		k_fifo_put(&tx_queue, buf);
 
 		LOG_HEXDUMP_DBG(buf->data, buf->len, "Final net buffer:");
 	}
@@ -144,7 +144,7 @@ static void tx_thread(void *p1, void *p2, void *p3)
 		int err;
 
 		/* Wait until a buffer is available */
-		buf = net_buf_get(&tx_queue, K_FOREVER);
+		buf = k_fifo_get(&tx_queue, K_FOREVER);
 		/* Pass buffer to the stack */
 		err = bt_send(buf);
 		if (err) {
@@ -253,7 +253,7 @@ int main(void)
 	while (1) {
 		struct net_buf *buf;
 
-		buf = net_buf_get(&rx_queue, K_FOREVER);
+		buf = k_fifo_get(&rx_queue, K_FOREVER);
 		err = hci_rpmsg_send(buf);
 		if (err) {
 			LOG_ERR("Failed to send (err %d)", err);


### PR DESCRIPTION
The net_buf_put/get is deprecated, align to recommended API.