### PR TITLE
samples: cellular: modem_shell: Add commands for modem init and shutdown

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -367,6 +367,7 @@ Cellular samples
 
 * :ref:`modem_shell_application` sample:
 
+  * Added ``link modem`` command for initializing and shutting down the modem.
   * Updated to use the :ref:`at_parser_readme` library instead of the :ref:`at_cmd_parser_readme` library.
 
 * :ref:`nrf_cloud_rest_fota` sample:


### PR DESCRIPTION
Adding 'link modem' command for initializing and shutting down the modem  through nrf_modem_lib_init()/nrf_modem_lib_shutdown(). There is also an option to do AT+CFUN=0 and nrf_modem_lib_shutdown() so that we can test the timings of this scenario.
Manually doing AT+CFUN=0 and shutdown is too slow to test what applications might experience.

Jira: MOSH-610