### PR TITLE
manifest: connectedhomeip: Update revision

### DIFF
--- a/samples/matter/light_switch/snippets/lit_icd/lit_icd.conf
+++ b/samples/matter/light_switch/snippets/lit_icd/lit_icd.conf
@@ -4,9 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# Increase system workqueue stack size
-CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=1536
-
 # Enable LIT ICD configuration
 CONFIG_CHIP_ICD_LIT_SUPPORT=y
 CONFIG_NCS_SAMPLE_MATTER_ZAP_FILES_PATH="snippets/lit_icd"

--- a/west.yml
+++ b/west.yml
@@ -169,7 +169,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: be30c50987d7bf02815b376785fc6f6256fabc67
+      revision: 3c8919e9869641167b8bf4403353726392d808a0
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
Move increasing `SYSTEM_WORKQUEUE_STACK_SIZE` for
`CHIP_ICD_LIT_SUPPORT` to Kconfig instead of manually increasing in snippets.