### PR TITLE
samples: suit: Fixed dts overlays - incorrect UICR generation

### DIFF
--- a/samples/suit/smp_transfer/sysbuild/hci_ipc.overlay
+++ b/samples/suit/smp_transfer/sysbuild/hci_ipc.overlay
@@ -9,3 +9,7 @@
 &uart135 {
 	status = "disabled";
 };
+
+&cpurad_rx_partitions {
+	status = "okay";
+};

--- a/samples/suit/smp_transfer/sysbuild/nrf54h20dk_nrf54h20_memory_map.dtsi
+++ b/samples/suit/smp_transfer/sysbuild/nrf54h20dk_nrf54h20_memory_map.dtsi
@@ -16,7 +16,6 @@
 };
 &cpurad_rx_partitions {
 	compatible = "nordic,owned-partitions", "fixed-partitions";
-	status = "okay";
 	perm-read;
 	perm-execute;
 	perm-secure;

--- a/samples/suit/smp_transfer/sysbuild/recovery_hci_ipc.overlay
+++ b/samples/suit/smp_transfer/sysbuild/recovery_hci_ipc.overlay
@@ -9,3 +9,7 @@
 &uart135 {
 	status = "disabled";
 };
+
+&cpurad_rx_partitions {
+	status = "okay";
+};


### PR DESCRIPTION
The application core dts enabled was enabling the radio core partition, which led to the radio core area being added to the application core UICR.

This in turn led to not rejecting a manifest in which the application core image was placed in the radio core area.