### PR TITLE
samples: wifi: Fix duplicate twister names

### DIFF
--- a/samples/wifi/ble_coex/src/main.c
+++ b/samples/wifi/ble_coex/src/main.c
@@ -16,7 +16,7 @@
 LOG_MODULE_REGISTER(coex, CONFIG_LOG_DEFAULT_LEVEL);
 
 #include <zephyr/kernel.h>
-#if defined(CLOCK_FEATURE_HFCLK_DIVIDE_PRESENT) || NRF_CLOCK_HAS_HFCLK192M
+#if NRFX_CLOCK_ENABLED && (defined(CLOCK_FEATURE_HFCLK_DIVIDE_PRESENT) || NRF_CLOCK_HAS_HFCLK192M)
 #include <nrfx_clock.h>
 #endif
 #include <zephyr/init.h>
@@ -358,7 +358,7 @@ int main(void)
 
 	net_mgmt_add_event_callback(&net_addr_mgmt_cb);
 
-#if defined(CLOCK_FEATURE_HFCLK_DIVIDE_PRESENT) || NRF_CLOCK_HAS_HFCLK192M
+#if NRFX_CLOCK_ENABLED && (defined(CLOCK_FEATURE_HFCLK_DIVIDE_PRESENT) || NRF_CLOCK_HAS_HFCLK192M)
 	nrfx_clock_divider_set(NRF_CLOCK_DOMAIN_HFCLK, NRF_CLOCK_HFCLK_DIV_1);
 #endif
 

--- a/samples/wifi/scan/sample.yaml
+++ b/samples/wifi/scan/sample.yaml
@@ -76,7 +76,7 @@ tests:
     build_only: true
     platform_allow: thingy91x/nrf9151/ns
     tags: ci_build sysbuild ci_samples_wifi
-  sample.nrf7002eb.nrf54l15dk.shell:
+  sample.scan.nrf7002eb.nrf54l15dk.shell:
     sysbuild: true
     build_only: true
     extra_args: SHIELD=nrf700x_nrf54l15pdk
@@ -84,7 +84,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
     platform_allow: nrf54l15dk/nrf54l15/cpuapp
     tags: ci_build sysbuild ci_samples_wifi
-  sample.nrf54h20dk_nrf7002ek.shell:
+  sample.scan.nrf54h20dk_nrf7002ek.shell:
     sysbuild: true
     build_only: true
     extra_args: SHIELD=nrf700x_nrf54h20dk

--- a/samples/wifi/scan/src/main.c
+++ b/samples/wifi/scan/src/main.c
@@ -12,9 +12,6 @@
 LOG_MODULE_REGISTER(scan, CONFIG_LOG_DEFAULT_LEVEL);
 
 #include <zephyr/kernel.h>
-#if defined(CLOCK_FEATURE_HFCLK_DIVIDE_PRESENT) || NRF_CLOCK_HAS_HFCLK192M
-#include <nrfx_clock.h>
-#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <zephyr/shell/shell.h>

--- a/samples/wifi/shutdown/src/main.c
+++ b/samples/wifi/shutdown/src/main.c
@@ -11,7 +11,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(shutdown, CONFIG_LOG_DEFAULT_LEVEL);
 
-#include <nrfx_clock.h>
 #include <zephyr/kernel.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/samples/wifi/sta/sample.yaml
+++ b/samples/wifi/sta/sample.yaml
@@ -58,7 +58,7 @@ tests:
       - thingy53/nrf5340/cpuapp
     platform_allow: thingy53/nrf5340/cpuapp
     tags: ci_build sysbuild ci_samples_wifi
-  sample.nrf7002eb.nrf54l15dk.shell:
+  sample.sta.nrf7002eb.nrf54l15dk.shell:
     sysbuild: true
     build_only: true
     extra_args: SHIELD=nrf700x_nrf54l15pdk
@@ -66,7 +66,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
     platform_allow: nrf54l15dk/nrf54l15/cpuapp
     tags: ci_build sysbuild ci_samples_wifi
-  sample.nrf54h20dk_nrf7002ek.shell:
+  sample.sta.nrf54h20dk_nrf7002ek.shell:
     sysbuild: true
     build_only: true
     extra_args: SHIELD=nrf700x_nrf54h20dk

--- a/samples/wifi/sta/src/main.c
+++ b/samples/wifi/sta/src/main.c
@@ -11,7 +11,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(sta, CONFIG_LOG_DEFAULT_LEVEL);
 
-#include <nrfx_clock.h>
 #include <zephyr/kernel.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/samples/wifi/thread_coex/src/main.h
+++ b/samples/wifi/thread_coex/src/main.h
@@ -15,8 +15,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main, CONFIG_LOG_DEFAULT_LEVEL);
 
-#include <nrfx_clock.h>
-
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
 #include <zephyr/device.h>

--- a/samples/wifi/thread_coex/src/ot_coex_functions.c
+++ b/samples/wifi/thread_coex/src/ot_coex_functions.c
@@ -6,6 +6,10 @@
 
 #include "ot_coex_functions.h"
 
+#if NRFX_CLOCK_ENABLED && (defined(CLOCK_FEATURE_HFCLK_DIVIDE_PRESENT) || NRF_CLOCK_HAS_HFCLK192M)
+#include <nrfx_clock.h>
+#endif
+
 bool is_ot_device_role_client;
 
 uint8_t ot_wait4_ping_reply_from_peer;

--- a/samples/wifi/thread_coex/src/ot_coex_functions.h
+++ b/samples/wifi/thread_coex/src/ot_coex_functions.h
@@ -14,8 +14,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(ot_coex_functions, CONFIG_LOG_DEFAULT_LEVEL);
 
-#include <nrfx_clock.h>
-
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
 #include <zephyr/device.h>

--- a/samples/wifi/throughput/src/main.c
+++ b/samples/wifi/throughput/src/main.c
@@ -10,14 +10,14 @@
 
 #include <zephyr/sys/printk.h>
 #include <zephyr/kernel.h>
-#if defined(CLOCK_FEATURE_HFCLK_DIVIDE_PRESENT) || NRF_CLOCK_HAS_HFCLK192M
+#if NRFX_CLOCK_ENABLED && (defined(CLOCK_FEATURE_HFCLK_DIVIDE_PRESENT) || NRF_CLOCK_HAS_HFCLK192M)
 #include <nrfx_clock.h>
 #endif
 #include <stdio.h>
 
 int main(void)
 {
-#if defined(CLOCK_FEATURE_HFCLK_DIVIDE_PRESENT) || NRF_CLOCK_HAS_HFCLK192M
+#if NRFX_CLOCK_ENABLED && (defined(CLOCK_FEATURE_HFCLK_DIVIDE_PRESENT) || NRF_CLOCK_HAS_HFCLK192M)
 	/* For now hardcode to 128MHz */
 	nrfx_clock_divider_set(NRF_CLOCK_DOMAIN_HFCLK,
 			       NRF_CLOCK_HFCLK_DIV_1);

--- a/samples/wifi/twt/modules/traffic_gen/src/main.c
+++ b/samples/wifi/twt/modules/traffic_gen/src/main.c
@@ -18,7 +18,6 @@ LOG_MODULE_REGISTER(traffic_gen, CONFIG_TRAFFIC_GEN_LOG_LEVEL);
 #include <zephyr/posix/sys/socket.h>
 #endif
 
-#include <nrfx_clock.h>
 #include <zephyr/kernel.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/samples/wifi/twt/modules/traffic_gen/src/tcp.c
+++ b/samples/wifi/twt/modules/traffic_gen/src/tcp.c
@@ -18,7 +18,6 @@ LOG_MODULE_DECLARE(traffic_gen, CONFIG_TRAFFIC_GEN_LOG_LEVEL);
 #include <zephyr/posix/sys/socket.h>
 #endif
 
-#include <nrfx_clock.h>
 #include <zephyr/kernel.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/samples/wifi/twt/src/main.c
+++ b/samples/wifi/twt/src/main.c
@@ -18,7 +18,6 @@ LOG_MODULE_REGISTER(twt, CONFIG_LOG_DEFAULT_LEVEL);
 #include <zephyr/posix/sys/socket.h>
 #endif
 
-#include <nrfx_clock.h>
 #include <zephyr/kernel.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/samples/wifi/wfa_qt_app/src/qt_app_main.c
+++ b/samples/wifi/wfa_qt_app/src/qt_app_main.c
@@ -10,7 +10,7 @@
 
 #include <zephyr/sys/printk.h>
 #include <zephyr/kernel.h>
-#if defined(CLOCK_FEATURE_HFCLK_DIVIDE_PRESENT) || NRF_CLOCK_HAS_HFCLK192M
+#if NRFX_CLOCK_ENABLED && (defined(CLOCK_FEATURE_HFCLK_DIVIDE_PRESENT) || NRF_CLOCK_HAS_HFCLK192M)
 #include <nrfx_clock.h>
 #endif
 #include <zephyr/device.h>
@@ -38,7 +38,7 @@ int main(void)
 	struct in_addr addr = {0};
 	struct in_addr mask;
 
-#if defined(CLOCK_FEATURE_HFCLK_DIVIDE_PRESENT) || NRF_CLOCK_HAS_HFCLK192M
+#if NRFX_CLOCK_ENABLED && (defined(CLOCK_FEATURE_HFCLK_DIVIDE_PRESENT) || NRF_CLOCK_HAS_HFCLK192M)
 	/* For now hardcode to 128MHz */
 	nrfx_clock_divider_set(NRF_CLOCK_DOMAIN_HFCLK,
 			       NRF_CLOCK_HFCLK_DIV_1);


### PR DESCRIPTION
Fix duplicates name by using sample name prefix.

Note: For some reason CI didn't catch this in the original PR.