### PR TITLE
 lib: lte_link_control: eDRX request not in workqueue in power off

### DIFF
--- a/lib/lte_link_control/lte_lc_modem_hooks.c
+++ b/lib/lte_link_control/lte_lc_modem_hooks.c
@@ -132,20 +132,6 @@ static void on_modem_init(int err, void *ctx)
 }
 
 #if defined(CONFIG_UNITY)
-void on_modem_shutdown(void *ctx)
-#else
-NRF_MODEM_LIB_ON_SHUTDOWN(lte_lc_shutdown_hook, on_modem_shutdown, NULL);
-
-static void on_modem_shutdown(void *ctx)
-#endif
-{
-	/* Make sure the Modem library was in normal mode and not in bootloader mode. */
-	if (nrf_modem_is_initialized()) {
-		(void)lte_lc_power_off();
-	}
-}
-
-#if defined(CONFIG_UNITY)
 void lte_lc_on_modem_cfun(int mode, void *ctx)
 #else
 NRF_MODEM_LIB_ON_CFUN(lte_lc_cfun_hook, lte_lc_on_modem_cfun, NULL);

--- a/tests/lib/lte_lc_api/src/lte_lc_api_test.c
+++ b/tests/lib/lte_lc_api/src/lte_lc_api_test.c
@@ -266,7 +266,6 @@ static int sys_init_helper(void)
 }
 
 extern void on_modem_init(int err, void *ctx);
-extern void on_modem_shutdown(void *ctx);
 extern void lte_lc_on_modem_cfun(int mode, void *ctx);
 
 void test_lte_lc_on_modem_init_success(void)
@@ -342,21 +341,6 @@ void test_lte_lc_on_modem_init_rai_fail(void)
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT%RAI=0", -NRF_EFAULT);
 
 	on_modem_init(0, NULL);
-}
-
-void test_lte_lc_on_modem_shutdown(void)
-{
-	__cmock_nrf_modem_is_initialized_ExpectAndReturn(true);
-	__mock_nrf_modem_at_printf_ExpectAndReturn("AT+CFUN=0", EXIT_SUCCESS);
-
-	on_modem_shutdown(NULL);
-}
-
-void test_lte_lc_on_modem_shutdown_not_initialized(void)
-{
-	__cmock_nrf_modem_is_initialized_ExpectAndReturn(false);
-
-	on_modem_shutdown(NULL);
 }
 
 static int lte_lc_on_modem_cfun_callback_count;


### PR DESCRIPTION
There are two small changes that make `lte_lc` function a little better:

1)
`lte_lc_edrx_req()` will be run directly in `lte_lc_edrx_on_modem_cfun()` when power off is issued. Earlier it was submitted to a work queue and run in `lte_lc_work_q`. Work queue was originally added because we wanted to avoid sending AT commands in the callback. However, when modem is powered off, we are not expecting AT notifications that could cause an assertion or
missing notification.
This was added in PR #15203.
Jira: NCSIDB-1347

2)
Remove power off from modem shutdown. `nrf_modem_lib` uses 'AT+CFUN=0' in `nrf_modem_lib_shutdown()` if the mode is not already '0'. So doing this also in `lte_lc` is unnecessary.