### PR TITLE
lib: lte_link_control: add %UICCPOWERSAVE

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -368,6 +368,7 @@ Cellular samples
 * :ref:`modem_shell_application` sample:
 
   * Updated to use the :ref:`at_parser_readme` library instead of the :ref:`at_cmd_parser_readme` library.
+  * Added the ``uiccpowersave`` link command for reading/setting UICC power saving mode. This feature is supported by Modem Firmware 2.0.2 or higher.
 
 * :ref:`nrf_cloud_rest_fota` sample:
 
@@ -685,6 +686,12 @@ Modem libraries
 
     * To use the :ref:`at_parser_readme` library instead of the :ref:`at_cmd_parser_readme` library.
     * The :c:func:`lte_lc_neighbor_cell_measurement` function to return an error for invalid GCI count.
+
+  * Added:
+
+    * The :c:func:`lte_lc_uiccpowersave_get` function for reading the current UICC power saving mode, and the :c:func:`lte_lc_uiccpowersave_set` function for setting the UICC power saving mode. These functions are supported by Modem Firmware 2.0.2 or higher. Please refer to the :ref:`lte_lc_readme` documentation for more information.
+    * The :c:enum:`LTE_LC_UICCPOWERSAVE_DEFAULT`, :c:enum:`LTE_LC_UICCPOWERSAVE_POLLING`, :c:enum:`LTE_LC_UICCPOWERSAVE_BYPASS`, and :c:enum:`LTE_LC_UICCPOWERSAVE_RRC` UICC power saving modes. These modes are supported by Modem Firmware 2.0.2 or higher. Please refer to the :ref:`lte_lc_readme` documentation for more information.
+    * The :kconfig:option:`CONFIG_LTE_UICCPOWERSAVE_DEFAULT`, :kconfig:option:`CONFIG_LTE_UICCPOWERSAVE_POLLING`, :kconfig:option:`CONFIG_LTE_UICCPOWERSAVE_BYPASS`, and :kconfig:option:`CONFIG_LTE_UICCPOWERSAVE_RRC` Kconfig options for setting the respective UICC power saving modes during initialization. These Kconfig options are supported by Modem Firmware 2.0.2 or higher.
 
 * :ref:`lib_location` library:
 

--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -651,6 +651,47 @@ enum lte_lc_reduced_mobility_mode {
 	LTE_LC_REDUCED_MOBILITY_DISABLED = 2,
 };
 
+/**
+ * UICC power saving mode.
+ */
+enum lte_lc_uiccpowersave_mode {
+	/**
+	 * Default functionality.
+	 * The UICC is deactivated during eDRX only when:
+	 * - \li It is allowed by the EF-AD (Elementary File - Administrative Data)
+	 * - \li Application PIN is disabled
+	 * - \li Sleep mode time is longer than the minimum time limit (1 minute in ultra
+	 *   low power mode and 5 minutes in other power modes)
+	 *
+	 * @note AT&T has a shorter minimum time of 20.48 seconds.
+	 *
+	 * Proactive polling interval can be modified during eDRX sleep only if allowed in EF-AD.
+	 */
+	LTE_LC_UICCPOWERSAVE_DEFAULT = 0,
+
+	/**
+	 * If UICC deactivation is not allowed due to some conditions mentioned in
+	 * @ref LTE_LC_UICCPOWERSAVE_DEFAULT, the proactive polling interval is increased to
+	 * match the eDRX sleep time regardless of EF-AD content.
+	 * If the interval is already longer than the sleep time, it is not affected.
+	 */
+	LTE_LC_UICCPOWERSAVE_POLLING = 1,
+
+	/**
+	 * Bypass conditions related to EF-AD, PIN state, and minimum deactivation time when
+	 * deactivating the UICC.
+	 * After deactivation on eDRX sleep, the UICC is activated only when the EMM (EPS
+	 * Mobility Management) is starting to initiate signalling to the network.
+	 */
+	LTE_LC_UICCPOWERSAVE_BYPASS = 2,
+
+	/**
+	 * In addition to @ref LTE_LC_UICCPOWERSAVE_BYPASS, this allows UICC deactivation when
+	 * entering RRC IDLE state. The UICC is activated before the next RRC connection.
+	 */
+	LTE_LC_UICCPOWERSAVE_RRC = 3
+};
+
 /** Modem domain events. */
 enum lte_lc_modem_evt {
 	/**
@@ -1739,6 +1780,35 @@ int lte_lc_reduced_mobility_get(enum lte_lc_reduced_mobility_mode *mode);
  * @retval -EFAULT if an AT command failed.
  */
 int lte_lc_reduced_mobility_set(enum lte_lc_reduced_mobility_mode mode);
+
+/**
+ * Read the current UICC power saving mode.
+ *
+ * @note This feature is only supported by modem firmware versions >= 2.0.2.
+ *
+ * @param[out] mode Pointer to a variable where the current UICC power saving mode will be stored.
+ *
+ * @retval 0 if the mode was successfully read and stored in the provided pointer.
+ * @retval -EINVAL if the input parameter is NULL.
+ * @retval -EFAULT if an AT command failed to execute.
+ *
+ * @note This function retrieves the current UICC power saving mode set on the modem.
+ */
+int lte_lc_uiccpowersave_get(enum lte_lc_uiccpowersave_mode *mode);
+
+/**
+ * Set the UICC power saving mode.
+ *
+ * @note This feature is only supported by modem firmware versions >= 2.0.2.
+ *
+ * @param[in] mode The UICC power saving mode to set.
+ *
+ * @retval 0 if the new UICC power saving mode was successfully set.
+ * @retval -EFAULT if an AT command failed to execute.
+ *
+ * @note This function configures the modem to use a specific UICC power saving mode.
+ */
+int lte_lc_uiccpowersave_set(enum lte_lc_uiccpowersave_mode mode);
 
 /**
  * Reset modem to factory settings.

--- a/lib/lte_link_control/Kconfig
+++ b/lib/lte_link_control/Kconfig
@@ -349,6 +349,57 @@ config LTE_LC_WORKQUEUE_STACK_SIZE
 	default 1280 if LOG_MODE_IMMEDIATE
 	default 1024
 
+choice LTE_UICCPOWERSAVE_MODE
+	prompt "UICC power saving mode."
+	default LTE_UICCPOWERSAVE_DEFAULT
+	help
+	  Select the UICC power saving mode.
+	  Note: This feature is supported by Modem Firmware 2.0.2 or higher.
+
+config LTE_UICCPOWERSAVE_DEFAULT
+	bool "Default functionality for UICC deactivation. UICC is deactivated in some conditions."
+	help
+	  The UICC is deactivated during eDRX only when: it is allowed by the EF-AD (Elementary
+	  File - Administrative Data); application PIN is disabled; sleep mode time is longer than
+	  the minimum time limit (1 minute in ultra low power mode and 5 minutes in
+	  other power modes). Note: AT&T has a shorter minimum time of 20.48 seconds.
+	  Proactive polling interval can be modified during eDRX sleep only if allowed in EF-AD.
+	  Note: This feature is supported by Modem Firmware 2.0.2 or higher.
+
+config LTE_UICCPOWERSAVE_POLLING
+	bool "If UICC deactivation is not allowed, increase proactive polling interval instead."
+	help
+	  If UICC deactivation is not allowed due to some conditions mentioned in
+	  LTE_UICCPOWERSAVE_DEFAULT, the proactive polling interval is increased to match the eDRX
+	  sleep time regardless of EF-AD content.
+	  If the interval is already longer than the sleep time, it is not affected.
+	  Note: This feature is supported by Modem Firmware 2.0.2 or higher.
+
+config LTE_UICCPOWERSAVE_BYPASS
+	bool "When deactivating the UICC, bypass certain conditions."
+	help
+	  Bypass conditions related to EF-AD, PIN state, and minimum deactivation time when
+	  deactivating the UICC.
+	  After deactivation on eDRX sleep, the UICC is activated only when the EMM (EPS Mobility
+	  Management) is starting to initiate signalling to the network.
+	  Note: This feature is supported by Modem Firmware 2.0.2 or higher.
+
+config LTE_UICCPOWERSAVE_RRC
+	bool "When deactivating, bypass certain conditions. Additionally, activate on RRC IDLE."
+	help
+	  In addition to LTE_UICCPOWERSAVE_BYPASS, this allows the UICC deactivation when entering
+	  RRC IDLE state. The UICC is activated before the next RRC connection.
+	  Note: This feature is supported by Modem Firmware 2.0.2 or higher.
+
+endchoice
+
+config LTE_UICCPOWERSAVE_MODE_VALUE
+	int
+	default 0 if LTE_UICCPOWERSAVE_DEFAULT
+	default 1 if LTE_UICCPOWERSAVE_POLLING
+	default 2 if LTE_UICCPOWERSAVE_BYPASS
+	default 3 if LTE_UICCPOWERSAVE_RRC
+
 module = LTE_LINK_CONTROL
 module-dep = LOG
 module-str = LTE link control library

--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -1821,6 +1821,39 @@ int lte_lc_reduced_mobility_set(enum lte_lc_reduced_mobility_mode mode)
 	return 0;
 }
 
+int lte_lc_uiccpowersave_get(enum lte_lc_uiccpowersave_mode *mode)
+{
+	int ret;
+	uint16_t mode_tmp;
+
+	if (mode == NULL) {
+		return -EINVAL;
+	}
+
+	ret = nrf_modem_at_scanf("AT%UICCPOWERSAVE?", "%%UICCPOWERSAVE: %hu", &mode_tmp);
+	if (ret != 1) {
+		LOG_ERR("AT command failed, nrf_modem_at_scanf() returned error: %d", ret);
+		return -EFAULT;
+	}
+
+	*mode = mode_tmp;
+
+	return 0;
+}
+
+int lte_lc_uiccpowersave_set(enum lte_lc_uiccpowersave_mode mode)
+{
+	int ret = nrf_modem_at_printf("AT%%UICCPOWERSAVE=%d", mode);
+
+	if (ret) {
+		/* Failure to send the AT command. */
+		LOG_ERR("AT command failed, returned error code: %d", ret);
+		return -EFAULT;
+	}
+
+	return 0;
+}
+
 int lte_lc_factory_reset(enum lte_lc_factory_reset_type type)
 {
 	return nrf_modem_at_printf("AT%%XFACTORYRESET=%d", type) ? -EFAULT : 0;

--- a/lib/lte_link_control/lte_lc_modem_hooks.c
+++ b/lib/lte_link_control/lte_lc_modem_hooks.c
@@ -87,6 +87,12 @@ static void on_modem_init(int err, void *ctx)
 	(void)nrf_modem_at_printf("AT%%FEACONF=0,3,%d",
 		IS_ENABLED(CONFIG_LTE_PLMN_SELECTION_OPTIMIZATION));
 
+	/* Only supported in mfw 2.0.2 and newer.
+	 * Ignore the return value; an error likely means that the feature
+	 * is not supported.
+	 */
+	(void)lte_lc_uiccpowersave_set(CONFIG_LTE_UICCPOWERSAVE_MODE_VALUE);
+
 	err = lte_lc_edrx_req(IS_ENABLED(CONFIG_LTE_EDRX_REQ));
 	if (err) {
 		LOG_ERR("Failed to configure eDRX, err %d", err);

--- a/samples/cellular/modem_shell/src/link/link.h
+++ b/samples/cellular/modem_shell/src/link/link.h
@@ -19,6 +19,7 @@ enum link_ncellmeas_modes {
 #define LINK_FUNMODE_NONE 99
 #define LINK_SYSMODE_NONE 99
 #define LINK_REDMOB_NONE 99
+#define LINK_UICCPOWERSAVE_NONE 99
 #define LTE_LC_FACTORY_RESET_INVALID 99
 
 void link_init(void);

--- a/samples/cellular/modem_shell/src/link/link_shell_print.c
+++ b/samples/cellular/modem_shell/src/link/link_shell_print.c
@@ -147,6 +147,19 @@ const char *link_shell_redmob_mode_to_string(int funmode, char *out_str_buff)
 	return link_shell_map_to_string(mapping_table, funmode, out_str_buff);
 }
 
+const char *link_shell_uiccpowersave_mode_to_string(int mode, char *out_str_buff)
+{
+	struct mapping_tbl_item const mapping_table[] = {
+		{ LTE_LC_UICCPOWERSAVE_DEFAULT, "default_mode" },
+		{ LTE_LC_UICCPOWERSAVE_POLLING, "polling" },
+		{ LTE_LC_UICCPOWERSAVE_BYPASS, "bypass" },
+		{ LTE_LC_UICCPOWERSAVE_RRC, "rrc" },
+		{ -1, NULL }
+	};
+
+	return link_shell_map_to_string(mapping_table, mode, out_str_buff);
+}
+
 const char *link_shell_sysmode_to_string(int sysmode, char *out_str_buff)
 {
 	struct mapping_tbl_item const mapping_table[] = {

--- a/samples/cellular/modem_shell/src/link/link_shell_print.h
+++ b/samples/cellular/modem_shell/src/link/link_shell_print.h
@@ -25,5 +25,6 @@ const char *link_shell_sysmode_currently_active_to_string(int actmode, char *out
 const char *link_shell_map_to_string(struct mapping_tbl_item const *mapping_table,
 				      int mode, char *out_str_buff);
 const char *link_shell_redmob_mode_to_string(int funmode, char *out_str_buff);
+const char *link_shell_uiccpowersave_mode_to_string(int mode, char *out_str_buff);
 
 #endif /* MOSH_LINK_SHELL_PRINT_H */

--- a/tests/lib/lte_lc_api/src/lte_lc_api_test.c
+++ b/tests/lib/lte_lc_api/src/lte_lc_api_test.c
@@ -279,6 +279,8 @@ void test_lte_lc_on_modem_init_success(void)
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT%FEACONF=0,0,0", EXIT_SUCCESS);
 	/* CONFIG_LTE_PLMN_SELECTION_OPTIMIZATION=y */
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT%FEACONF=0,3,1", EXIT_SUCCESS);
+	/* lte_lc_uiccpowersave(0) */
+	__mock_nrf_modem_at_printf_ExpectAndReturn("AT%UICCPOWERSAVE=0", EXIT_SUCCESS);
 	/* lte_lc_edrx_req(false) */
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT+CEDRXS=3", EXIT_SUCCESS);
 	/* CONFIG_LTE_RAI_REQ=n */
@@ -320,6 +322,8 @@ void test_lte_lc_on_modem_init_edrx_req_fail(void)
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT%FEACONF=0,0,0", -NRF_EFAULT);
 	/* CONFIG_LTE_PLMN_SELECTION_OPTIMIZATION=y */
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT%FEACONF=0,3,1", -NRF_EFAULT);
+	/* lte_lc_uiccpowersave(0) */
+	__mock_nrf_modem_at_printf_ExpectAndReturn("AT%UICCPOWERSAVE=0", EXIT_SUCCESS);
 	/* lte_lc_edrx_req(false) */
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT+CEDRXS=3", -NRF_EFAULT);
 
@@ -336,6 +340,8 @@ void test_lte_lc_on_modem_init_rai_fail(void)
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT%FEACONF=0,0,0", EXIT_SUCCESS);
 	/* CONFIG_LTE_PLMN_SELECTION_OPTIMIZATION=y */
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT%FEACONF=0,3,1", EXIT_SUCCESS);
+	/* lte_lc_uiccpowersave(0) */
+	__mock_nrf_modem_at_printf_ExpectAndReturn("AT%UICCPOWERSAVE=0", EXIT_SUCCESS);
 	/* lte_lc_edrx_req(false) */
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT+CEDRXS=3", EXIT_SUCCESS);
 	/* CONFIG_LTE_RAI_REQ=n */
@@ -4448,6 +4454,69 @@ void test_lte_lc_reduced_mobility_get_null(void)
 	int ret;
 
 	ret = lte_lc_reduced_mobility_get(NULL);
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+void test_lte_lc_uiccpowersave_set_success(void)
+{
+	int ret;
+
+	__mock_nrf_modem_at_printf_ExpectAndReturn("AT%UICCPOWERSAVE=0", 0);
+	ret = lte_lc_uiccpowersave_set(LTE_LC_UICCPOWERSAVE_DEFAULT);
+	TEST_ASSERT_EQUAL(EXIT_SUCCESS, ret);
+
+	__mock_nrf_modem_at_printf_ExpectAndReturn("AT%UICCPOWERSAVE=1", 0);
+	ret = lte_lc_uiccpowersave_set(LTE_LC_UICCPOWERSAVE_POLLING);
+	TEST_ASSERT_EQUAL(EXIT_SUCCESS, ret);
+
+	__mock_nrf_modem_at_printf_ExpectAndReturn("AT%UICCPOWERSAVE=2", 0);
+	ret = lte_lc_uiccpowersave_set(LTE_LC_UICCPOWERSAVE_BYPASS);
+	TEST_ASSERT_EQUAL(EXIT_SUCCESS, ret);
+
+	__mock_nrf_modem_at_printf_ExpectAndReturn("AT%UICCPOWERSAVE=3", 0);
+	ret = lte_lc_uiccpowersave_set(LTE_LC_UICCPOWERSAVE_RRC);
+	TEST_ASSERT_EQUAL(EXIT_SUCCESS, ret);
+}
+
+void test_lte_lc_uiccpowersave_set_fail(void)
+{
+	int ret;
+
+	__mock_nrf_modem_at_printf_ExpectAndReturn("AT%UICCPOWERSAVE=0", -NRF_ENOMEM);
+
+	ret = lte_lc_uiccpowersave_set(LTE_LC_UICCPOWERSAVE_DEFAULT);
+	TEST_ASSERT_EQUAL(-EFAULT, ret);
+}
+
+void test_lte_lc_uiccpowersave_get_success(void)
+{
+	int ret;
+	enum lte_lc_uiccpowersave_mode mode;
+
+	__mock_nrf_modem_at_scanf_ExpectAndReturn("AT%UICCPOWERSAVE?", "%%UICCPOWERSAVE: %hu", 1);
+	__mock_nrf_modem_at_scanf_ReturnVarg_uint16(LTE_LC_UICCPOWERSAVE_POLLING);
+
+	ret = lte_lc_uiccpowersave_get(&mode);
+	TEST_ASSERT_EQUAL(EXIT_SUCCESS, ret);
+	TEST_ASSERT_EQUAL(LTE_LC_UICCPOWERSAVE_POLLING, mode);
+}
+
+void test_lte_lc_uiccpowersave_get_fail(void)
+{
+	int ret;
+	enum lte_lc_uiccpowersave_mode mode;
+
+	__mock_nrf_modem_at_scanf_ExpectAndReturn("AT%UICCPOWERSAVE?", "%%UICCPOWERSAVE: %hu", 2);
+
+	ret = lte_lc_uiccpowersave_get(&mode);
+	TEST_ASSERT_EQUAL(-EFAULT, ret);
+}
+
+void test_lte_lc_uiccpowersave_get_null(void)
+{
+	int ret;
+
+	ret = lte_lc_uiccpowersave_get(NULL);
 	TEST_ASSERT_EQUAL(-EINVAL, ret);
 }
 


### PR DESCRIPTION
Adds support for the `UICCPOWERSAVE` AT command.