### PR TITLE
tests: benchmarks: multicore: idle_gpio: add wakeups from uart rx pin

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -314,6 +314,7 @@ Kconfig*                                  @tejlmand
 /tests/                                   @PerMac @katgiadla
 /tests/benchmarks/multicore/              @carlescufi
 /tests/benchmarks/multicore/idle/         @adamkondraciuk @nrfconnect/ncs-low-level-test
+/tests/benchmarks/multicore/idle_gpio/    @adamkondraciuk @nrfconnect/ncs-low-level-test
 /tests/benchmarks/i2c_endless/            @nrfconnect/ncs-low-level-test
 /tests/benchmarks/spi_endless/            @nrfconnect/ncs-low-level-test
 /tests/bluetooth/tester/                  @carlescufi @nrfconnect/ncs-paladin

--- a/tests/benchmarks/multicore/idle_gpio/boards/nrf54h20dk_nrf54h20_cpuapp_s2ram.overlay
+++ b/tests/benchmarks/multicore/idle_gpio/boards/nrf54h20dk_nrf54h20_cpuapp_s2ram.overlay
@@ -5,22 +5,22 @@
  */
 
 / {
-        power-states {
-                idle: idle {
-                        compatible = "zephyr,power-state";
-                        power-state-name = "suspend-to-idle";
-                        min-residency-us = <100000>;
-                };
+	power-states {
+		idle: idle {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-idle";
+			min-residency-us = <100000>;
+		};
 
-                s2ram: s2ram {
-                        compatible = "zephyr,power-state";
-                        power-state-name = "suspend-to-ram";
-                        min-residency-us = <800000>;
-                };
-        };
-        aliases {
+		s2ram: s2ram {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-ram";
+			min-residency-us = <800000>;
+		};
+	};
+	aliases {
 		/delete-property/ sw1;
-        };
+	};
 };
 
 /delete-node/ &button1;

--- a/tests/benchmarks/multicore/idle_gpio/boards/wakeup_from_uart_pins.overlay
+++ b/tests/benchmarks/multicore/idle_gpio/boards/wakeup_from_uart_pins.overlay
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+
+/ {
+	/*
+	 * Redefine sw0/button0 to use RXD0 - P2.04
+	 * Thus, when sending character from host, there will be gpio interrupt,
+	 * the same as originally triggered by sw0 button.
+	 */
+	buttons {
+		compatible = "gpio-keys";
+		button0: button_0 {
+			gpios = <&gpio2 4 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button 0";
+			zephyr,code = <INPUT_KEY_0>;
+		};
+	};
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+/*
+ * Redefine RX -> P2.03 (not used)
+ */
+&pinctrl {
+	/omit-if-no-ref/ uart136_default: uart136_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 2, 6)>,
+				<NRF_PSEL(UART_RTS, 2, 7)>;
+		};
+
+		group2 {
+			bias-pull-up;
+			psels = <NRF_PSEL(UART_RX, 2, 3)>,
+				<NRF_PSEL(UART_CTS, 2, 5)>;
+		};
+	};
+
+	/omit-if-no-ref/ uart136_sleep: uart136_sleep {
+		group1 {
+			low-power-enable;
+			psels = <NRF_PSEL(UART_TX, 2, 6)>,
+				<NRF_PSEL(UART_RX, 2, 3)>,
+				<NRF_PSEL(UART_RTS, 2, 7)>,
+				<NRF_PSEL(UART_CTS, 2, 5)>;
+		};
+	};
+};

--- a/tests/benchmarks/multicore/idle_gpio/remote/boards/nrf54h20dk_nrf54h20_cpurad_s2ram.overlay
+++ b/tests/benchmarks/multicore/idle_gpio/remote/boards/nrf54h20dk_nrf54h20_cpurad_s2ram.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-   / {
+/ {
 	aliases {
 		sw1 = &button1;
 	};
@@ -16,7 +16,7 @@
 			zephyr,code = <INPUT_KEY_1>;
 		};
 	};
-   };
+};
 
 &gpio0 {
 	status = "okay";

--- a/tests/benchmarks/multicore/idle_gpio/remote/boards/wakeup_from_uart_pins.overlay
+++ b/tests/benchmarks/multicore/idle_gpio/remote/boards/wakeup_from_uart_pins.overlay
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	/*
+	 * Redefine sw1/button1 to use RXD1 - P1.10
+	 * Thus, when sending character from host, there will be gpio interrupt,
+	 * the same as originally triggered by sw1 button.
+	 */
+	aliases {
+		sw1 = &button1;
+	};
+	buttons {
+		compatible = "gpio-keys";
+		button1: button_1 {
+			gpios = <&gpio1 10 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button 1";
+			zephyr,code = <INPUT_KEY_1>;
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+/*
+ * Redefine RX -> P1.08 (not used)
+ */
+&pinctrl {
+	/omit-if-no-ref/ uart135_default: uart135_default {
+	group1 {
+		psels = <NRF_PSEL(UART_TX, 1, 11)>,
+			<NRF_PSEL(UART_RTS, 1, 9)>;
+	};
+
+	group2 {
+		bias-pull-up;
+		psels = <NRF_PSEL(UART_RX, 1, 8)>,
+			<NRF_PSEL(UART_CTS, 1, 7)>;
+		};
+	};
+
+	/omit-if-no-ref/ uart135_sleep: uart135_sleep {
+	group1 {
+		low-power-enable;
+		psels = <NRF_PSEL(UART_TX, 1, 11)>,
+			<NRF_PSEL(UART_RX, 1, 8)>,
+			<NRF_PSEL(UART_RTS, 1, 9)>,
+			<NRF_PSEL(UART_CTS, 1, 7)>;
+		};
+	};
+};

--- a/tests/benchmarks/multicore/idle_gpio/src/main.c
+++ b/tests/benchmarks/multicore/idle_gpio/src/main.c
@@ -34,10 +34,11 @@ int main(void)
 {
 	unsigned int cnt = 0;
 	int rc;
-	const struct device *gpio_dev = DEVICE_DT_GET(DT_NODELABEL(gpio0));
 
-	if (!device_is_ready(gpio_dev)) {
-		return -ENODEV;
+	rc = gpio_is_ready_dt(&sw);
+	if (rc < 0) {
+		LOG_ERR("GPIO Device not ready (%d)\n", rc);
+		return 0;
 	}
 
 	rc = gpio_pin_configure_dt(&sw, GPIO_INPUT);
@@ -52,12 +53,12 @@ int main(void)
 		return 0;
 	}
 	gpio_init_callback(&gpio_cb, my_gpio_callback, 0xFFFF);
-	gpio_add_callback(gpio_dev, &gpio_cb);
-	LOG_INF("Multicore idle_gpio test on %s", CONFIG_BOARD_TARGET);
+	gpio_add_callback(sw.port, &gpio_cb);
+	LOG_INF("Multicore idle_gpio test on %s\n", CONFIG_BOARD_TARGET);
 	while (1) {
-		LOG_INF("Multicore idle_gpio test iteration %u", cnt++);
+		LOG_INF("Multicore idle_gpio test iteration %u\n", cnt++);
 		if (k_sem_take(&my_gpio_sem, K_FOREVER) != 0) {
-			LOG_ERR("Failed to take a semaphore");
+			LOG_ERR("Failed to take a semaphore\n");
 			return 0;
 		}
 		k_busy_wait(1000000);

--- a/tests/benchmarks/multicore/idle_gpio/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_gpio/testcase.yaml
@@ -24,3 +24,22 @@ tests:
       fixture: ppk_power_measure
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_simple"
+    tags: ppk_power_measure
+
+  benchmarks.multicore.idle_gpio.nrf54h20dk_cpuapp_cpurad.s2ram.wakeup_from_uart_pins:
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+    extra_args:
+      FILE_SUFFIX=s2ram
+      SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
+      DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_s2ram.overlay;boards/wakeup_from_uart_pins.overlay"
+      remote_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpurad_s2ram.overlay;boards/wakeup_from_uart_pins.overlay"
+    harness: pytest
+    harness_config:
+      fixture: ppk_power_measure
+      pytest_root:
+        - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_with_wakeups_two_cores"
+    timeout: 120
+    tags: ppk_power_measure


### PR DESCRIPTION
At custom configuration, redefine pins used to wakeup each core. Instead of buttons, use uart rx pin.

This will make automated testing possible without additional HW.