### PR TITLE
boards: thingy91x: replace bmm150 with bmm350

### DIFF
--- a/boards/nordic/thingy91x/thingy91x_common.dtsi
+++ b/boards/nordic/thingy91x/thingy91x_common.dtsi
@@ -130,10 +130,10 @@
 		reg = <0x1d>;
 	};
 
-	magnetometer: bmm150@10 {
+	magnetometer: bmm350@14 {
 		status = "disabled";
-		compatible = "bosch,bmm150";
-		reg = <0x10>;
+		compatible = "bosch,bmm350";
+		reg = <0x14>;
 	};
 };
 


### PR DESCRIPTION
This patch updates the Thingy:91 X board files to match the latest hardware revision 0.9.1. The BMM150 magnetometer has been replaced with the BMM350 magnetometer.