### PR TITLE
boards: thingy91x: use nrfutil runner

### DIFF
--- a/boards/nordic/thingy91x/board.cmake
+++ b/boards/nordic/thingy91x/board.cmake
@@ -2,19 +2,19 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 
 if(CONFIG_BOARD_THINGY91X_NRF9151 OR CONFIG_BOARD_THINGY91X_NRF9151_NS)
-  board_runner_args(nrfjprog "--nrf-family=NRF91")
+  board_runner_args(nrfjprog)
   board_runner_args(nrfutil "--nrf-family=NRF91")
   board_runner_args(jlink "--device=nRF9160_xxAA" "--speed=4000")
 elseif(BOARD_THINGY91X_NRF5340_CPUAPP OR BOARD_THINGY91X_NRF5340_CPUAPP_NS)
-  board_runner_args(nrfjprog "--nrf-family=NRF53")
+  board_runner_args(nrfjprog)
   board_runner_args(nrfutil "--nrf-family=NRF53")
   board_runner_args(jlink "--device=nrf5340_xxaa_app" "--speed=4000")
 elseif(BOARD_THINGY91X_NRF5340_CPUNET)
-  board_runner_args(nrfjprog "--nrf-family=NRF53")
+  board_runner_args(nrfjprog)
   board_runner_args(nrfutil "--nrf-family=NRF53")
   board_runner_args(jlink "--device=nrf5340_xxaa_net" "--speed=4000")
 endif()
 
-include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/nrfutil.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
This patch uses the nrfutil runner by default for the Thingy:91x board. Also, the device family option was removed for the nrfjprog runner. The device family option is dangerous to use and should be avoided. For nrfutil-device, a safeguard is being put in place to remedy that problem, but nrfjprog will not be updated in that way.