### PR TITLE
doc: Matter Bridge documentation enhancement

### DIFF
--- a/applications/matter_bridge/doc/matter_bridge_description.rst
+++ b/applications/matter_bridge/doc/matter_bridge_description.rst
@@ -733,21 +733,12 @@ See :ref:`app_build_file_suffixes` and :ref:`cmake_options` for more information
 Configure the functionality of the Matter-Bridge device
 -------------------------------------------------------
 
-To enable the Matter smart plug functionality, run the following command:
+To enable the Matter smart plugin functionality, run the following command with *board_target* replaced with the board target name:
 
-.. tabs::
+.. parsed-literal::
+   :class: highlight
 
-   .. group-tab:: nRF54 DKs
-
-      .. code-block:: console
-
-         west build -b nrf54h20dk/nrf54h20/cpuapp -p -- -DSB_CONFIG_WIFI_NRF700X=y -DCONFIG_CHIP_WIFI=y -Dmatter_bridge_SHIELD=nrf700x_nrf54h20dk -DCONFIG_BRIDGED_DEVICE_BT=y -Dmatter_bridge_SNIPPET=onoff_plug
-
-   .. group-tab:: nRF70 DKs
-
-      .. code-block:: console
-
-         west build -b nrf7002dk/nrf5340/cpuapp -p -- -DCONFIG_BRIDGED_DEVICE_BT=y -Dmatter_bridge_SNIPPET=onoff_plug
+   west build -b *board_target* -p -- -Dmatter_bridge_SNIPPET=onoff_plug
 
 .. _matter_bridge_testing:
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -225,9 +225,9 @@ Matter Bridge
 
   * The :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_ZAP_FILES_PATH` Kconfig option, which specifies ZAP files location for the application.
     By default, the option points to the :file:`src/default_zap` directory and can be changed to any path relative to application's location that contains the ZAP file and :file:`zap-generated` directory.
-  * Support for the :ref:`zephyr:nrf54h20dk_nrf54h20`.
+  * Experimental support for the :ref:`zephyr:nrf54h20dk_nrf54h20`.
   * Optional smart plug device functionality.
-  * Support for the Thread protocol.
+  * Experimental support for the Thread protocol.
   * Added :ref:`multiprotocol_bt_thread` page.
 
 nRF5340 Audio


### PR DESCRIPTION
- Support for Thread protocol and nRF54H20 is experimental
- There is to many unnecesary buildings commands in smart-plug section