### PR TITLE
samples: bluetooth: peripheral_uart: Add nrf54h20 cpurad to sample.yaml

### DIFF
--- a/samples/bluetooth/peripheral_uart/sample.yaml
+++ b/samples/bluetooth/peripheral_uart/sample.yaml
@@ -8,7 +8,7 @@ tests:
     platform_allow: nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840
       nrf5340dk/nrf5340/cpuapp nrf5340dk/nrf5340/cpuapp/ns thingy53/nrf5340/cpuapp
       thingy53/nrf5340/cpuapp/ns nrf21540dk/nrf52840 nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15pdk/nrf54l15/cpuapp nrf54h20dk/nrf54h20/cpuapp
+      nrf54l15pdk/nrf54l15/cpuapp nrf54h20dk/nrf54h20/cpuapp nrf54h20dk/nrf54h20/cpurad
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52833dk/nrf52833
@@ -21,6 +21,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15pdk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54h20dk/nrf54h20/cpurad
     tags: bluetooth ci_build sysbuild
   sample.bluetooth.peripheral_uart_cdc:
     sysbuild: true


### PR DESCRIPTION
This commit adds build for nrf54h20 radio core to sample.yaml