### PR TITLE
doc: installation: J-Link explicit mention

### DIFF
--- a/doc/nrf/app_dev/device_guides/working_with_nrf/nrf54h/ug_nrf54h20_gs.rst
+++ b/doc/nrf/app_dev/device_guides/working_with_nrf/nrf54h/ug_nrf54h20_gs.rst
@@ -50,10 +50,10 @@ You also need the following:
      Before running the initial J-Link installation from the `nRF Command Line Tools`_ package, ensure not to have any other J-Link executables on your system.
      If you have other J-Link installations, uninstall them before proceeding.
 
-* On Windows, SEGGER USB Driver for J-Link from SEGGER `J-Link version 7.94e`_.
+* On Windows, SEGGER USB Driver for J-Link from `SEGGER J-Link`_ |jlink_ver|.
 
    .. note::
-      To install the SEGGER USB Driver for J-Link on Windows, you must manually reinstall J-Link v7.94e from the command line using the ``-InstUSBDriver=1`` parameter, updating the installation previously run by the `nRF Command Line Tools`_:
+      To install the SEGGER USB Driver for J-Link on Windows, you must manually reinstall J-Link |jlink_ver| from the command line using the ``-InstUSBDriver=1`` parameter, updating the installation previously run by the `nRF Command Line Tools`_:
 
       1. Navigate to the download location of the J-Link executable and run one of the following commands:
 

--- a/doc/nrf/installation/install_ncs.rst
+++ b/doc/nrf/installation/install_ncs.rst
@@ -48,6 +48,8 @@ Depending on your preferred development environment, install the following requi
 
       * The latest version of the :ref:`requirements_clt` package.
         Download it from the `nRF Command Line Tools`_ page.
+      * The |jlink_ver| of :ref:`SEGGER J-Link <requirements_jlink>`.
+        Download it from the `J-Link Software and Documentation Pack`_ page.
       * The latest version of |VSC| for your operating system from the `Visual Studio Code download page`_.
       * In |VSC|, the latest version of the `nRF Connect for VS Code Extension Pack`_.
       * Linux users: `nrf-udev`_ module with udev rules required to access USB ports on Nordic Semiconductor devices and program the firmware.
@@ -66,6 +68,8 @@ Depending on your preferred development environment, install the following requi
         .. note::
             After downloading and installing the tools, add nrfjprog to the system :envvar:`PATH` in the environment variables.
 
+      * The latest version of :ref:`SEGGER J-Link <requirements_jlink>`.
+        Download it from the `J-Link Software and Documentation Pack`_ page.
       * Linux users: `nrf-udev`_ module with udev rules required to access USB ports on Nordic Semiconductor devices and program the firmware.
 
 .. _gs_installing_toolchain:

--- a/doc/nrf/installation/recommended_versions.rst
+++ b/doc/nrf/installation/recommended_versions.rst
@@ -332,14 +332,21 @@ They can all be installed using the ``doc/requirements.txt`` file using ``pip``.
 nRF Command Line Tools
 **********************
 
-`nRF Command Line Tools`_ is a package of tools used for development, programming, and debugging of Nordic Semiconductor's nRF51, nRF52, nRF53 and nRF91 Series devices.
-Among others, this package includes the following prerequisites for the |NCS|:
-
-* The universal version of SEGGER J-Link, which is required for SEGGER J-Link to work correctly with both Intel and ARM assemblies.
-* nrfjprog executable and library, which the west command uses by default to program the development kits.
-  For more information on nrfjprog, see `Programming SoCs with nrfjprog`_.
+`nRF Command Line Tools`_ is a package of tools used for development, programming, and debugging of Nordic Semiconductor's nRF51, nRF52, nRF53, nRF54H, and nRF91 Series devices.
+Among others, this package includes the nrfjprog executable and library, which the west command uses by default to program the development kits.
+For more information on nrfjprog, see `Programming SoCs with nrfjprog`_.
 
 It is recommended to use the latest version of the package when you :ref:`installing_vsc`.
+
+.. _requirements_jlink:
+
+J-Link Software and Documentation Pack
+**************************************
+
+SEGGER's `J-Link Software and Documentation Pack`_ is a package of tools that is required for SEGGER J-Link to work correctly with both Intel and ARM assemblies.
+Among others, this package includes the J-Link RTT Viewer, which can be used for :ref:`test_and_optimize`.
+
+It is recommended to use the |jlink_ver| of the package when you :ref:`installing_vsc`.
 
 .. _toolchain_management_tools:
 

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -927,6 +927,7 @@
 
 .. ### Source: www.segger.com
 
+.. _`SEGGER J-Link`:
 .. _`J-Link Software and Documentation Pack`: https://www.segger.com/downloads/jlink
 
 .. _`SEGGER SystemView`: https://www.segger.com/products/development-tools/systemview/
@@ -1688,10 +1689,6 @@
 
 .. _`BICR binary file`: https://files.nordicsemi.com/artifactory/SDSC/external/bicr_ext_loadcap.hex
 .. _`BICR new binary file`: https://files.nordicsemi.com/artifactory/SDSC/external/bicr/bicr.hex
-
-.. _`J-Link version 7.94e`: https://www.segger.com/downloads/jlink/
-
-.. _`J-Link version 7.88j`: https://www.segger.com/downloads/jlink/
 
 .. _`Zephyr's nRF clock control API extensions`: https://github.com/nrfconnect/sdk-zephyr/blob/main/include/zephyr/drivers/clock_control/nrf_clock_control.h
 .. _`clocks devicetree macro API`: https://github.com/nrfconnect/sdk-zephyr/blob/main/include/zephyr/devicetree/clocks.h

--- a/doc/nrf/releases_and_maturity/migration/2.4.99-cs3_to_2.6.99-cs2/migration_guide_2.4.99-cs3_to_2.6.99-cs2_environment.rst
+++ b/doc/nrf/releases_and_maturity/migration/2.4.99-cs3_to_2.6.99-cs2/migration_guide_2.4.99-cs3_to_2.6.99-cs2_environment.rst
@@ -50,7 +50,7 @@ You also need the following:
 * `Git`_ or `Git for Windows`_ (on Linux and Mac, or Windows, respectively)
 * `curl`_
 * On Windows, SEGGER USB Driver for J-Link
-* SEGGER `J-Link version 7.94e`_
+* `SEGGER J-Link` (v7.94e)
 
 .. note::
    The SEGGER USB Driver for J-Link was included, on Windows, in the nRF Command Line Tools bundle required by the |NCS| v2.4.99-cs3.

--- a/doc/nrf/releases_and_maturity/migration/nRF54H20_migration_2.7/migration_guide_2.6.99-cs2_to_2_7_environment.rst
+++ b/doc/nrf/releases_and_maturity/migration/nRF54H20_migration_2.7/migration_guide_2.6.99-cs2_to_2_7_environment.rst
@@ -56,9 +56,9 @@ You also need the following:
 * The latest version of the `nRF Command Line Tools`_ package.
   After downloading and installing the tools, add the nrfjprog executable to the system path, on Linux and MacOS, or to the environment variables, on Windows, to run it from anywhere on the system.
 
-  The CLI tools installation will also trigger the installation of J-Link.
+  The CLI tools installation will also trigger the installation of `SEGGER J-Link`_ (v7.94e).
   During that installation, in the :guilabel:`Choose optional components` window, select :guilabel:`update existing installation`.
-* On Windows, SEGGER USB Driver for J-Link from SEGGER `J-Link version 7.94e`_.
+* On Windows, SEGGER USB Driver for J-Link from `SEGGER J-Link`_ v7.94e.
 
    .. note::
       To install the SEGGER USB Driver for J-Link on Windows, you must manually reinstall J-Link v7.94e from the command line using the ``-InstUSBDriver=1`` parameter, updating the installation previously run by the `nRF Command Line Tools`_:

--- a/doc/nrf/releases_and_maturity/migration/nRF54H20_migration_2.7/transition_guide_2.4.99-cs3_to_2.7_environment.rst
+++ b/doc/nrf/releases_and_maturity/migration/nRF54H20_migration_2.7/transition_guide_2.4.99-cs3_to_2.7_environment.rst
@@ -56,9 +56,9 @@ You also need the following:
 * The latest version of the `nRF Command Line Tools`_ package.
   After downloading and installing the tools, add the nrfjprog executable to the system path, on Linux and MacOS, or to the environment variables, on Windows, to run it from anywhere on the system.
 
-  The CLI tools installation will also trigger the installation of J-Link.
+  The CLI tools installation will also trigger the installation of `SEGGER J-Link`_ (v7.94e).
   During that installation, in the :guilabel:`Choose optional components` window, select :guilabel:`update existing installation`.
-* On Windows, SEGGER USB Driver for J-Link from SEGGER `J-Link version 7.94e`_.
+* On Windows, SEGGER USB Driver for J-Link from `SEGGER J-Link`_ v7.94e.
 
    .. note::
       To install the SEGGER USB Driver for J-Link on Windows, you must manually reinstall J-Link v7.94e from the command line using the ``-InstUSBDriver=1`` parameter, updating the installation previously run by the `nRF Command Line Tools`_:

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -33,7 +33,8 @@ The following sections provide detailed lists of changes by component.
 IDE, and tool support
 =====================
 
-|no_changes_yet_note|
+* Added explicit mention of the :ref:`requirements_jlink` being required in the :ref:`installing_vsc` section of the installation page.
+* Updated the required `SEGGER J-Link`_ version to v7.94i.
 
 Build and configuration system
 ==============================

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -1,8 +1,12 @@
 .. |NCS| replace:: nRF Connect SDK
 
+.. ### Versions
+
 .. |release| replace:: v2.7.0
 .. |release_tt| replace:: ``v2.7.0``
 .. |release_number_tt| replace:: ``2.7.0``
+
+.. |jlink_ver| replace:: v7.94i
 
 .. ### Config shortcuts
 


### PR DESCRIPTION
Added explicit mention of the J-Link being required. Added mention of nRF54H Series working with nRF Command Line Tools. NRFU-1160.