### PR TITLE
Add nRF54L15DK to lib ram_pwrdn and OT CLI low power snippet

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -531,6 +531,10 @@ Thread samples
 
 * Enabled the :ref:`ug_thread_build_report` generation in all samples.
 
+* :ref:`ot_cli_sample` sample:
+
+  * Added the :ref:`zephyr:nrf54l15dk_nrf54l15` board support in the low-power snippet.
+
 Zigbee samples
 --------------
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -533,7 +533,7 @@ Thread samples
 
 * :ref:`ot_cli_sample` sample:
 
-  * Added the :ref:`zephyr:nrf54l15dk_nrf54l15` board support in the low-power snippet.
+  * Added support for the :ref:`zephyr:nrf54l15dk_nrf54l15` in the low-power snippet.
 
 Zigbee samples
 --------------
@@ -837,6 +837,10 @@ Other libraries
 
     * A retry feature that reattempts failed date-time updates up to a certain number of consecutive times.
     * The Kconfig options :kconfig:option:`CONFIG_DATE_TIME_RETRY_COUNT` to control whether and how many consecutive date-time update retries may be performed, and :kconfig:option:`CONFIG_DATE_TIME_RETRY_INTERVAL_SECONDS` to control how quickly date-time update retries occur.
+
+* :ref:`lib_ram_pwrdn` library:
+
+  * Added support for the nRF54L15 SoC.
 
 Security libraries
 ------------------

--- a/lib/ram_pwrdn/Kconfig
+++ b/lib/ram_pwrdn/Kconfig
@@ -6,7 +6,7 @@
 
 menuconfig RAM_POWER_DOWN_LIBRARY
 	bool "Enable API for turning off unused RAM segments"
-	depends on SOC_NRF52840 || SOC_NRF52833 || SOC_NRF5340_CPUAPP
+	depends on SOC_NRF52840 || SOC_NRF52833 || SOC_NRF5340_CPUAPP || SOC_NRF54L15_CPUAPP
 	# Powering down RAM blocks can only be done from the secure domain
 	# for security reasons. If necessary, this limitation could be
 	# addressed by a secure service in the future.

--- a/samples/openthread/cli/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/openthread/cli/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+
+// restore full RRAM and SRAM space - by default some parts are dedicated to FLRP
+&cpuapp_rram {
+	reg = <0x0 DT_SIZE_K(1524)>;
+};
+
+&cpuapp_sram {
+	reg = <0x20000000 DT_SIZE_K(256)>;
+	ranges = <0x0 0x20000000  0x40000>;
+};

--- a/samples/openthread/cli/snippets/low_power/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/openthread/cli/snippets/low_power/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -4,6 +4,4 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-CONFIG_GPIO_SHELL=n
-
-CONFIG_NRF_802154_TEMPERATURE_UPDATE=n
+CONFIG_POWEROFF=y

--- a/samples/openthread/cli/snippets/low_power/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/openthread/cli/snippets/low_power/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,32 @@
+/* Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&adc {
+	status = "disabled";
+};
+&uart21 {
+	status = "disabled";
+};
+&pwm20 {
+	status = "disabled";
+};
+&i2c20 {
+	status = "disabled";
+};
+&spi00 {
+	status = "disabled";
+};
+&spi20 {
+	status = "disabled";
+};
+&spi21 {
+	status = "disabled";
+};
+&spi22 {
+	status = "disabled";
+};
+&mx25r64 {
+	status = "disabled";
+};

--- a/samples/openthread/cli/snippets/low_power/snippet.yml
+++ b/samples/openthread/cli/snippets/low_power/snippet.yml
@@ -7,4 +7,15 @@
 name: low_power
 append:
   EXTRA_CONF_FILE: low_power.conf
-  EXTRA_DTC_OVERLAY_FILE: low_power.overlay
+
+boards:
+  nrf54l15dk/nrf54l15/cpuapp:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+      EXTRA_CONF_FILE: boards/nrf54l15dk_nrf54l15_cpuapp.conf
+  nrf5340dk/nrf5340/cpuapp:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: low_power.overlay
+  nrf52840dk/nrf52840:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: low_power.overlay

--- a/samples/openthread/cli/src/low_power.c
+++ b/samples/openthread/cli/src/low_power.c
@@ -8,7 +8,9 @@
 #include <zephyr/net/openthread.h>
 #include <zephyr/device.h>
 #include <zephyr/pm/device.h>
+#if defined(CONFIG_RAM_POWER_DOWN_LIBRARY)
 #include <ram_pwrdn.h>
+#endif
 
 #include "low_power.h"
 
@@ -24,7 +26,9 @@ static void on_thread_state_changed(otChangedFlags flags, struct openthread_cont
 			}
 
 			pm_device_action_run(cons, PM_DEVICE_ACTION_SUSPEND);
+#if defined(CONFIG_RAM_POWER_DOWN_LIBRARY)
 			power_down_unused_ram();
+#endif
 		}
 	}
 }


### PR DESCRIPTION
Updated the low power snippet by nRF54L15 DK target, configs and a dts overlay file.