### PR TITLE
doc: quick_start: edits from testing

### DIFF
--- a/doc/nrf/app_dev/device_guides/fem/index.rst
+++ b/doc/nrf/app_dev/device_guides/fem/index.rst
@@ -3,6 +3,10 @@
 Developing with Front-End Modules
 #################################
 
+.. |nrf_series| replace:: Front-End Module devices
+
+.. include:: /includes/guides_complementary_to_app_dev.txt
+
 Zephyr and the |NCS| provides support for developing applications with the following :term:`Front-End Module (FEM)` devices:
 
 .. list-table::

--- a/doc/nrf/app_dev/device_guides/nrf52/index.rst
+++ b/doc/nrf/app_dev/device_guides/nrf52/index.rst
@@ -7,6 +7,10 @@
 Developing with nRF52 Series
 ############################
 
+.. |nrf_series| replace:: devices of the nRF52 Series
+
+.. include:: /includes/guides_complementary_to_app_dev.txt
+
 Zephyr and the |NCS| provide support and contain board definitions for developing on the following nRF52 Series devices:
 
 .. list-table::

--- a/doc/nrf/app_dev/device_guides/nrf53/index.rst
+++ b/doc/nrf/app_dev/device_guides/nrf53/index.rst
@@ -6,6 +6,10 @@
 Developing with nRF53 Series
 ############################
 
+.. |nrf_series| replace:: devices of the nRF53 Series
+
+.. include:: /includes/guides_complementary_to_app_dev.txt
+
 Zephyr and the |NCS| provide support and contain board definitions for developing on the following nRF53 Series devices:
 
 .. list-table::

--- a/doc/nrf/app_dev/device_guides/nrf54h.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54h.rst
@@ -7,6 +7,10 @@ Working with nRF54H Series
 
    All software for the nRF54H20 SoC is experimental, and hardware availability is restricted to the participants in the customer sampling program.
 
+.. |nrf_series| replace:: devices of the nRF54H Series
+
+.. include:: /includes/guides_complementary_to_app_dev.txt
+
 Zephyr and the |NCS| provide support and contain board definitions for developing on the following nRF54H Series device:
 
 .. list-table::

--- a/doc/nrf/app_dev/device_guides/nrf54l/index.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54l/index.rst
@@ -8,6 +8,10 @@ Developing with nRF54L Series
 
   All software for the nRF54L15 SoC is experimental and hardware availability is restricted to the participants in the limited sampling program.
 
+.. |nrf_series| replace:: devices of the nRF54L Series
+
+.. include:: /includes/guides_complementary_to_app_dev.txt
+
 Zephyr and the |NCS| provide support and contain board definitions for developing on the following nRF54L Series device:
 
 .. list-table::

--- a/doc/nrf/app_dev/device_guides/nrf70/index.rst
+++ b/doc/nrf/app_dev/device_guides/nrf70/index.rst
@@ -4,6 +4,10 @@
 Developing with nRF70 Series
 ############################
 
+.. |nrf_series| replace:: devices of the nRF70 Series
+
+.. include:: /includes/guides_complementary_to_app_dev.txt
+
 Zephyr and the |NCS| provide support for developing networking applications with Wi-Fi® connectivity using the following nRF70 Series companion IC devices:
 
 .. list-table::

--- a/doc/nrf/app_dev/device_guides/nrf91/index.rst
+++ b/doc/nrf/app_dev/device_guides/nrf91/index.rst
@@ -4,9 +4,12 @@
 .. _ug_thingy91:
 .. _thingy91_ug_intro:
 
-
 Developing with nRF91 Series
 ############################
+
+.. |nrf_series| replace:: devices of the nRF91 Series
+
+.. include:: /includes/guides_complementary_to_app_dev.txt
 
 Zephyr and the |NCS| provide support for developing cellular applications using the following nRF91 Series devices:
 

--- a/doc/nrf/app_dev/device_guides/pmic/index.rst
+++ b/doc/nrf/app_dev/device_guides/pmic/index.rst
@@ -3,6 +3,10 @@
 Developing with PMICs
 #####################
 
+.. |nrf_series| replace:: Power Management IC devices
+
+.. include:: /includes/guides_complementary_to_app_dev.txt
+
 Zephyr and the |NCS| provides support for developing applications with the following Power Management IC devices:
 
 .. list-table::

--- a/doc/nrf/includes/guides_complementary_to_app_dev.txt
+++ b/doc/nrf/includes/guides_complementary_to_app_dev.txt
@@ -1,0 +1,1 @@
+Information in this section complements the general :ref:`ug_app_dev` guides (such as :ref:`configuration_and_build` or :ref:`programming`) with information specific to |nrf_series|.

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -232,3 +232,6 @@
 
 .. |migration_contact_devzone| replace:: While we strive to document all breaking changes, the migration guides might not include the detailed migration steps for your use case.
    If you need assistance, contact Nordic Semiconductor's technical support on `DevZone`_.
+
+.. |nrf54_buttons_leds_numbering| replace:: The nRF54 DKs use a different numbering pattern for LED and buttons.
+   See the User interface section for full overview.

--- a/samples/bluetooth/peripheral_lbs/README.rst
+++ b/samples/bluetooth/peripheral_lbs/README.rst
@@ -18,7 +18,7 @@ The sample supports the following development kits:
 
 .. include:: /includes/tfm.txt
 
-The sample also requires a smartphone or tablet running a compatible application.
+The sample also requires a smartphone or tablet running a compatible mobile application.
 The `Testing`_ instructions refer to `nRF Connect for Mobile`_, but you can also use other similar applications (for example, `nRF Blinky`_ or `nRF Toolbox`_).
 
 .. note::
@@ -134,13 +134,15 @@ For example, when building on the command line, you can add the option as follow
 Testing
 =======
 
-After programming the sample to your dongle or development kit, test it by performing the following steps:
+After programming the sample to your dongle or development kit, one of the LEDs starts blinking to indicate that the advertising loop is active (see `User interface`_ for details).
+
+To test the sample using the `nRF Connect for Mobile`_ mobile application, complete the following steps:
 
 .. tabs::
 
    .. group-tab:: nRF52 and nRF53 DKs
 
-      1. Start the `nRF Connect for Mobile`_ application on your smartphone or tablet.
+      1. Install and start the `nRF Connect for Mobile`_ application on your smartphone or tablet.
       #. Power on the development kit or insert your dongle into the USB port.
       #. Connect to the device from the application.
          The device is advertising as ``Nordic_LBS``.
@@ -155,25 +157,28 @@ After programming the sample to your dongle or development kit, test it by perfo
       #. Write the following values to the LED characteristic in the **Nordic LED Button Service**.
          Depending on the hardware platform, this produces results described in the table.
 
-      +------------------------+---------+----------------------------------------------+
-      | Hardware platform      | Value   | Effect                                       |
-      +========================+=========+==============================================+
-      | Development kit        | ``OFF`` | Switch the **LED 3** off.                    |
-      +                        +---------+----------------------------------------------+
-      |                        | ``ON``  | Switch the **LED 3** on.                     |
-      +------------------------+---------+----------------------------------------------+
-      | nRF52840 Dongle        | ``OFF`` | Switch the green channel of the RGB LED off. |
-      +                        +---------+----------------------------------------------+
-      |                        | ``ON``  | Switch the green channel of the RGB LED on.  |
-      +------------------------+---------+----------------------------------------------+
-      | Thingy:53              | ``OFF`` | Switch the blue channel of the RGB LED off.  |
-      +                        +---------+----------------------------------------------+
-      |                        | ``ON``  | Switch the blue channel of the RGB LED on.   |
-      +------------------------+---------+----------------------------------------------+
+         +------------------------+---------+----------------------------------------------+
+         | Hardware platform      | Value   | Effect                                       |
+         +========================+=========+==============================================+
+         | nRF52 and nRF53 DKs    | ``OFF`` | Switch the **LED 3** off.                    |
+         +                        +---------+----------------------------------------------+
+         |                        | ``ON``  | Switch the **LED 3** on.                     |
+         +------------------------+---------+----------------------------------------------+
+         | nRF52840 Dongle        | ``OFF`` | Switch the green channel of the RGB LED off. |
+         +                        +---------+----------------------------------------------+
+         |                        | ``ON``  | Switch the green channel of the RGB LED on.  |
+         +------------------------+---------+----------------------------------------------+
+         | Thingy:53              | ``OFF`` | Switch the blue channel of the RGB LED off.  |
+         +                        +---------+----------------------------------------------+
+         |                        | ``ON``  | Switch the blue channel of the RGB LED on.   |
+         +------------------------+---------+----------------------------------------------+
 
    .. group-tab:: nRF54 DKs
 
-      1. Start the `nRF Connect for Mobile`_ application on your smartphone or tablet.
+      .. note::
+          |nrf54_buttons_leds_numbering|
+
+      1. Install and start the `nRF Connect for Mobile`_ application on your smartphone or tablet.
       #. Power on the development kit or insert your dongle into the USB port.
       #. Connect to the device from the application.
          The device is advertising as ``Nordic_LBS``.
@@ -188,21 +193,14 @@ After programming the sample to your dongle or development kit, test it by perfo
       #. Write the following values to the LED characteristic in the **Nordic LED Button Service**.
          Depending on the hardware platform, this produces results described in the table.
 
-      +------------------------+---------+----------------------------------------------+
-      | Hardware platform      | Value   | Effect                                       |
-      +========================+=========+==============================================+
-      | Development kit        | ``OFF`` | Switch the **LED 2** off.                    |
-      +                        +---------+----------------------------------------------+
-      |                        | ``ON``  | Switch the **LED 2** on.                     |
-      +------------------------+---------+----------------------------------------------+
-      | nRF52840 Dongle        | ``OFF`` | Switch the green channel of the RGB LED off. |
-      +                        +---------+----------------------------------------------+
-      |                        | ``ON``  | Switch the green channel of the RGB LED on.  |
-      +------------------------+---------+----------------------------------------------+
-      | Thingy:53              | ``OFF`` | Switch the blue channel of the RGB LED off.  |
-      +                        +---------+----------------------------------------------+
-      |                        | ``ON``  | Switch the blue channel of the RGB LED on.   |
-      +------------------------+---------+----------------------------------------------+
+         +------------------------+---------+----------------------------------------------+
+         | Hardware platform      | Value   | Effect                                       |
+         +========================+=========+==============================================+
+         | nRF54 DKs              | ``OFF`` | Switch the **LED 2** off.                    |
+         +                        +---------+----------------------------------------------+
+         |                        | ``ON``  | Switch the **LED 2** on.                     |
+         +------------------------+---------+----------------------------------------------+
+
 
 Dependencies
 ************

--- a/samples/bluetooth/peripheral_uart/README.rst
+++ b/samples/bluetooth/peripheral_uart/README.rst
@@ -20,13 +20,14 @@ The sample supports the following development kits:
 .. include:: /includes/tfm.txt
 
 .. note::
-   * The boards ``nrf52dk_nrf52810``, ``nrf52840dk_nrf52811``, and ``nrf52833dk_nrf52820`` only support the `Minimal sample variant`_.
+   * The boards ``nrf52dk/nrf52810``, ``nrf52840dk/nrf52811``, and ``nrf52833dk/nrf52820`` only support the `Minimal sample variant`_.
    * When used with :ref:`zephyr:thingy53_nrf5340`, the sample supports the MCUboot bootloader with serial recovery and SMP DFU over Bluetooth.
      Thingy:53 has no built-in SEGGER chip, so the UART 0 peripheral is not gated to a USB CDC virtual serial port.
    * When used with :ref:`zephyr:nrf5340dk_nrf5340`, the sample might support the MCUboot bootloader with serial recovery of the networking core image.
 
-The sample also requires a smartphone or tablet running a compatible application.
-The `Testing`_ instructions refer to `nRF Connect for Mobile`_, but you can also use other similar applications (for example, `nRF Blinky`_ or `nRF Toolbox`_).
+The sample also requires using a compatible application for `Testing`_.
+You can use the `nRF Connect Bluetooth Low Energy`_ or `nRF Connect for Mobile`_ applications (or other similar applications, such as `nRF Blinky`_ or `nRF Toolbox`_).
+Using mobile applications for testing requires a smartphone or tablet.
 
 You can also test the application with the :ref:`central_uart` sample.
 See the documentation for that sample for detailed instructions.
@@ -34,7 +35,7 @@ See the documentation for that sample for detailed instructions.
 .. note::
    |thingy53_sample_note|
 
-   The sample also enables an additional USB CDC ACM port that is used instead of UART 0.
+   The sample also enables an additional :ref:`USB CDC ACM class serial port <thingy53_app_usb>` that is used instead of UART 0.
    Because of that, it uses a separate USB Vendor and Product ID.
 
 Overview
@@ -60,7 +61,7 @@ Instead, they are printed by the RTT logger.
 If you want to view the debug messages, follow the procedure in :ref:`testing_rtt_connect`.
 
 .. note::
-   On the Thingy:53, debug logs are provided over the USB CDC ACM class serial port, instead of using RTT.
+   On the Thingy:53, debug logs are provided over the :ref:`USB CDC ACM class serial port <thingy53_app_usb>` instead of :ref:`RTT or other logging backends <ug_logging_backends>`.
 
 For more information about debugging in the |NCS|, see :ref:`debugging`.
 
@@ -216,7 +217,7 @@ For more information about configuration files in the |NCS|, see :ref:`app_build
 Testing
 =======
 
-After programming the sample to your development kit, complete the following steps to test it:
+After programming the sample to your development kit, complete the following steps to test the basic functionality:
 
 .. tabs::
 
@@ -226,10 +227,44 @@ After programming the sample to your development kit, complete the following ste
          If you use a development kit, UART 0 is forwarded as a COM port (Windows) or ttyACM device (Linux) after you connect the development kit over USB.
          If you use Thingy:53, you must attach the debug board and connect an external USB to UART converter to it.
       #. |connect_terminal|
-      #. Optionally, you can display debug messages. See :ref:`peripheral_uart_debug` for details.
       #. Reset the kit.
       #. Observe that **LED 1** is blinking and that the device is advertising with the device name that is configured in :kconfig:option:`CONFIG_BT_DEVICE_NAME`.
       #. Observe that the text "Starting Nordic UART service example" is printed on the COM listener running on the computer.
+
+   .. group-tab:: nRF54 DKs
+
+      .. note::
+          |nrf54_buttons_leds_numbering|
+
+      1. Connect the device to the computer to access UART 0.
+         If you use a development kit, UART 0 is forwarded as a COM port (Windows) or ttyACM device (Linux) after you connect the development kit over USB.
+         If you use Thingy:53, you must attach the debug board and connect an external USB to UART converter.
+      #. |connect_terminal|
+      #. Reset the kit.
+      #. Observe that **LED 0** is blinking and that the device is advertising with the device name that is configured in :kconfig:option:`CONFIG_BT_DEVICE_NAME`.
+      #. Observe that the text "Starting Nordic UART service example" is printed on the COM listener running on the computer.
+
+.. _peripheral_uart_testing_mobile:
+
+Testing with nRF Connect for Mobile
+-----------------------------------
+
+You can test the sample pairing with a mobile device.
+For this purpose, use `nRF Connect for Mobile`_ (or other similar applications, such as `nRF Blinky`_ or `nRF Toolbox`_).
+
+To perform the test, complete the following steps:
+
+.. tabs::
+
+   .. group-tab:: nRF21, nRF52 and nRF53 DKs
+
+      1. Connect the device to the computer to access UART 0.
+         If you use a development kit, UART 0 is forwarded as a COM port (Windows) or ttyACM device (Linux) after you connect the development kit over USB.
+         If you use Thingy:53, you must attach the debug board and connect an external USB to UART converter.
+      #. |connect_terminal|
+      #. Optionally, you can display debug messages.
+         See :ref:`peripheral_uart_debug` for details.
+      #. Install and start the `nRF Connect for Mobile`_ application on your smartphone or tablet.
       #. Connect to the device using nRF Connect for Mobile.
          Observe that **LED 2** is lit.
       #. Optionally, pair or bond with the device with MITM protection.
@@ -248,14 +283,16 @@ After programming the sample to your development kit, complete the following ste
 
    .. group-tab:: nRF54 DKs
 
+      .. note::
+          |nrf54_buttons_leds_numbering|
+
       1. Connect the device to the computer to access UART 0.
          If you use a development kit, UART 0 is forwarded as a COM port (Windows) or ttyACM device (Linux) after you connect the development kit over USB.
          If you use Thingy:53, you must attach the debug board and connect an external USB to UART converter to it.
       #. |connect_terminal|
-      #. Optionally, you can display debug messages. See :ref:`peripheral_uart_debug` for details.
-      #. Reset the kit.
-      #. Observe that **LED 0** is blinking and that the device is advertising with the device name that is configured in :kconfig:option:`CONFIG_BT_DEVICE_NAME`.
-      #. Observe that the text "Starting Nordic UART service example" is printed on the COM listener running on the computer.
+      #. Optionally, you can display debug messages.
+         See :ref:`peripheral_uart_debug` for details.
+      #. Install and start the `nRF Connect for Mobile`_ application on your smartphone or tablet.
       #. Connect to the device using nRF Connect for Mobile.
          Observe that **LED 1** is lit.
       #. Optionally, pair or bond with the device with MITM protection.
@@ -273,16 +310,18 @@ After programming the sample to your development kit, complete the following ste
          Observe that **LED 1** turns off.
 
 .. _nrf52_computer_testing:
+.. _peripheral_uart_testing_ble:
 
-Testing with nRF Connect for Desktop
-------------------------------------
+Testing with Bluetooth Low Energy app
+-------------------------------------
 
 If you have an nRF52 Series DK with the Peripheral UART sample and either a dongle or second Nordic Semiconductor development kit that supports Bluetooth Low Energy, you can test the sample on your computer.
-Use the Bluetooth Low Energy app in `nRF Connect for Desktop`_ for testing.
+Use the `nRF Connect Bluetooth Low Energy`_ app in `nRF Connect for Desktop`_ for testing.
 
 To perform the test, complete the following steps:
 
-1. Connect to your nRF52 Series DK.
+1. Install the nRF Connect Bluetooth Low Energy app in `nRF Connect for Desktop`_.
+#. Connect to your nRF52 Series DK.
 #. Connect the dongle or second development kit to a USB port of your computer.
 #. Open the Bluetooth Low Energy app.
 #. Select the serial port that corresponds to the dongle or the second development kit.


### PR DESCRIPTION
Applied edits from testing the Quick Start app with @ketile.
Added information about how Developing with pages relate to other guides
in Application development.
Broke down testing steps for samples supported in Quick Start into
passive behavior that can be observed after programming using the app
and steps that require additional applications.