### PR TITLE
samples: nrf_rpc: protocol_serialization: add nfc

### DIFF
--- a/samples/nrf_rpc/protocols_serialization/client/CMakeLists.txt
+++ b/samples/nrf_rpc/protocols_serialization/client/CMakeLists.txt
@@ -17,4 +17,5 @@ target_sources(app PRIVATE
 zephyr_library_sources_ifdef(CONFIG_OPENTHREAD_RPC src/ot_shell.c)
 zephyr_library_sources_ifdef(CONFIG_MPSL_CX_SOFTWARE src/coex_shell.c)
 zephyr_library_sources_ifdef(CONFIG_LOG_FORWARDER_RPC src/log_rpc_shell.c)
+zephyr_library_sources_ifdef(CONFIG_NFC_RPC src/nfc_shell.c)
 # NORDIC SDK APP START

--- a/samples/nrf_rpc/protocols_serialization/client/README.rst
+++ b/samples/nrf_rpc/protocols_serialization/client/README.rst
@@ -8,7 +8,7 @@ nRF RPC: Protocols serialization client
    :depth: 2
 
 The Protocols serialization client sample demonstrates how to send remote procedure calls (RPC) to a protocols serialization server device, such as one running the :ref:`Protocols serialization server <nrf_rpc_protocols_serialization_server>` sample.
-The RPCs are used to control Bluetooth® LE and :ref:`OpenThread <ug_thread_intro>` stacks running on the server device.
+The RPCs are used to control Bluetooth® LE, :ref:`NFC <ug_nfc>` and :ref:`OpenThread <ug_thread_intro>` stacks running on the server device.
 The client and server devices use the :ref:`nrfxlib:nrf_rpc` and the :ref:`nrf_rpc_uart` to communicate with each other.
 
 Requirements
@@ -20,13 +20,15 @@ The sample supports the following development kit:
 
 To test the sample, you also need another device running the :ref:`Protocols serialization server <nrf_rpc_protocols_serialization_server>` sample.
 
-For testing the Bluetooth LE API serialization, you also need to have the `nRF Connect for Mobile`_ app installed on your smartphone or tablet.
+For testing the Bluetooth LE API serialization, you need to have the `nRF Connect for Mobile`_ app installed on your smartphone or tablet.
+
+For testing the NFC API serialization, you also need a smartphone or tablet that can read NFC tags.
 
 Overview
 ********
 
-The Protocols serialization client sample is a thin client that neither includes OpenThread nor Bluetooth LE stacks.
-Instead, it provides implementations of selected OpenThread and Bluetooth LE functions that forward the function calls over UART to the Protocols serialization server.
+The Protocols serialization client sample is a thin client that does not include OpenThread, Bluetooth LE or NFC stacks.
+Instead, it provides implementations of selected OpenThread, Bluetooth LE and NFC functions that forward the function calls over UART to the Protocols serialization server.
 The client also includes a shell for testing the serialization.
 
 Configuration
@@ -47,6 +49,7 @@ The following snippets are available:
 * ``debug`` - Enables debugging the sample by enabling :c:func:`__ASSERT()` statements globally and verbose logging.
 * ``log_rpc`` - Enables logging over RPC.
 * ``openthread`` - Enables the client part of the OpenThread RPC.
+* ``nfc`` - Enables the client part of the NFC RPC.
 
 Building and running
 ********************
@@ -64,6 +67,10 @@ To test the client sample, follow the instructions in the :ref:`protocols_serial
 
 Dependencies
 ************
+
+This sample uses the following |NCS| libraries:
+
+* :ref:`nfc_ndef_msg`
 
 This sample uses the following `sdk-nrfxlib`_ library:
 

--- a/samples/nrf_rpc/protocols_serialization/client/snippets/nfc/nfc.conf
+++ b/samples/nrf_rpc/protocols_serialization/client/snippets/nfc/nfc.conf
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Enable and configure Bluetooth LE
+CONFIG_NFC_RPC=y
+CONFIG_NFC_RPC_CLIENT=y
+
+CONFIG_NFC_NDEF=y
+CONFIG_NFC_NDEF_MSG=y
+CONFIG_NFC_NDEF_RECORD=y
+CONFIG_NFC_NDEF_TEXT_RECORD=y

--- a/samples/nrf_rpc/protocols_serialization/client/snippets/nfc/snippet.yml
+++ b/samples/nrf_rpc/protocols_serialization/client/snippets/nfc/snippet.yml
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+name: nfc
+append:
+  EXTRA_CONF_FILE: nfc.conf

--- a/samples/nrf_rpc/protocols_serialization/client/src/nfc_shell.c
+++ b/samples/nrf_rpc/protocols_serialization/client/src/nfc_shell.c
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <nfc_t2t_lib.h>
+#include <nfc/ndef/msg.h>
+#include <nfc/ndef/text_rec.h>
+
+#include <zephyr/shell/shell.h>
+#include <zephyr/sys/__assert.h>
+
+#define NFC_MESSAGE_BUFFER 128
+
+static uint8_t *default_message = "Hello World!";
+static uint8_t *default_code = "en";
+
+/* Buffer used to hold an NFC NDEF message. */
+static uint8_t ndef_msg_buf[NFC_MESSAGE_BUFFER];
+
+NFC_NDEF_MSG_DEF(msg_descr, 1);
+
+static int message_encode(char *msg, uint32_t *length)
+{
+	int err;
+
+	/* Create NFC NDEF text record description */
+	NFC_NDEF_TEXT_RECORD_DESC_DEF(record, UTF_8, default_code, strlen(default_code), msg,
+				      strlen(msg));
+
+	/* Clear the message description. */
+	nfc_ndef_msg_clear(&NFC_NDEF_MSG(msg_descr));
+
+	/* Add text records to NDEF text message */
+	err = nfc_ndef_msg_record_add(&NFC_NDEF_MSG(msg_descr), &NFC_NDEF_TEXT_RECORD_DESC(record));
+	if (err < 0) {
+		return err;
+	}
+
+	err = nfc_ndef_msg_encode(&NFC_NDEF_MSG(msg_descr), ndef_msg_buf, length);
+	__ASSERT(*length <= NFC_MESSAGE_BUFFER, "message too long");
+
+	return err;
+}
+
+static void nfc_callback(void *context, nfc_t2t_event_t event, const uint8_t *data,
+			 size_t data_length)
+{
+	static const char *const event_str[] = {"none", "field_on", "field_off", "data_read",
+						"stopped"};
+	const struct shell *sh = (const struct shell *)context;
+
+	switch (event) {
+	case NFC_T2T_EVENT_NONE:
+	case NFC_T2T_EVENT_FIELD_ON:
+	case NFC_T2T_EVENT_FIELD_OFF:
+	case NFC_T2T_EVENT_DATA_READ:
+	case NFC_T2T_EVENT_STOPPED:
+		shell_print(sh, "NFC T2T event: %s", event_str[event]);
+		break;
+	default:
+		shell_print(sh, "Unknown NFC event");
+	}
+}
+
+static int nfc_init_cmd(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err = nfc_t2t_setup(nfc_callback, (void *)sh);
+	uint32_t length = sizeof(ndef_msg_buf);
+
+	if (err) {
+		shell_print(sh, "Cannot setup NFC T2T library. err: %u", err);
+		return -ENOEXEC;
+	}
+
+	if (message_encode(default_message, &length) < 0) {
+		shell_print(sh, "Cannot encode message.");
+		return -ENOEXEC;
+	}
+
+	/* Set created message as the NFC payload */
+	if (nfc_t2t_payload_set(ndef_msg_buf, length) < 0) {
+		shell_print(sh, "Cannot set payload.");
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
+
+static int nfc_release_cmd(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err = nfc_t2t_done();
+
+	if (err) {
+		shell_print(sh, "Cannot release NFC. err: %u", err);
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
+
+static int nfc_start_cmd(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err = nfc_t2t_emulation_start();
+
+	if (err) {
+		shell_print(sh, "Cannot activate NFC frontend. err: %u", err);
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
+
+static int nfc_stop_cmd(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err = nfc_t2t_emulation_stop();
+
+	if (err) {
+		shell_print(sh, "Cannot deactivate NFC frontend. err: %u", err);
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
+
+static int nfc_set_msg_cmd(const struct shell *sh, size_t argc, char *argv[])
+{
+	uint32_t length = sizeof(ndef_msg_buf);
+
+	if (message_encode(argv[1], &length) < 0) {
+		shell_print(sh, "Cannot encode message.");
+		return -ENOEXEC;
+	}
+
+	/* Set created message as the NFC payload */
+	if (nfc_t2t_payload_set(ndef_msg_buf, length) < 0) {
+		shell_print(sh, "Cannot set payload.");
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	nfc_cmds, SHELL_CMD_ARG(init, NULL, "Initialize NFC", nfc_init_cmd, 1, 0),
+	SHELL_CMD_ARG(release, NULL, "Release NFC", nfc_release_cmd, 1, 0),
+	SHELL_CMD_ARG(start, NULL, "Activate the NFC frontend", nfc_start_cmd, 1, 0),
+	SHELL_CMD_ARG(stop, NULL, "Deactivate the NFC frontend", nfc_stop_cmd, 1, 0),
+	SHELL_CMD_ARG(set_new_msg, NULL, "Set the new message to NFC payload", nfc_set_msg_cmd, 2,
+		      0),
+	SHELL_SUBCMD_SET_END);
+
+SHELL_CMD_ARG_REGISTER(nfc, &nfc_cmds, "NFC demonstration commands", NULL, 1, 0);

--- a/samples/nrf_rpc/protocols_serialization/server/README.rst
+++ b/samples/nrf_rpc/protocols_serialization/server/README.rst
@@ -7,7 +7,7 @@ nRF RPC: Protocols serialization server
    :local:
    :depth: 2
 
-The Protocols serialization server sample runs full Bluetooth® LE and OpenThread stacks, and it exposes selected functions from these stacks over UART.
+The Protocols serialization server sample runs full Bluetooth® LE, OpenThread or NFC stacks, and it exposes selected functions from these stacks over UART.
 
 Requirements
 ************
@@ -18,12 +18,14 @@ The sample supports the following development kits for testing the network statu
 
 To test the sample, you also need another device running the :ref:`Protocols serialization client <nrf_rpc_protocols_serialization_client>` sample.
 
-For testing the Bluetooth LE API serialization, you also need to have the `nRF Connect for Mobile`_ app installed on your smartphone or tablet.
+For testing the Bluetooth LE API serialization, you need to have the `nRF Connect for Mobile`_ app installed on your smartphone or tablet.
+
+For testing the NFC API serialization, you also need a smartphone or tablet that can read NFC tags.
 
 Overview
 ********
 
-The Protocols serialization server sample implements the server part of the serialization of OpenThread and Bluetooth LE API calls between two devices that communicate with each other using the UART interface.
+The Protocols serialization server sample implements the server part of the serialization of OpenThread, Bluetooth LE API and NFC calls between two devices that communicate with each other using the UART interface.
 The sample uses the :ref:`nrfxlib:nrf_rpc` and CBOR encoding to serialize function calls.
 
 Configuration
@@ -44,6 +46,7 @@ The following snippets are available:
 * ``debug`` - Enables debugging the sample by enabling :c:func:`__ASSERT()` statements globally and verbose logging.
 * ``log_rpc`` - Enables logging over RPC.
 * ``openthread`` - Enables the server part of the OpenThread RPC.
+* ``nfc`` - Enables the server part of the NFC RPC.
 
 User interface
 **************
@@ -76,7 +79,7 @@ You can modify the list of enabled features, which by default includes Bluetooth
 Testing
 *******
 
-After building the Protocols serialization server sample and programming it to your development kit, connect it to a second device running the :ref:`Protocol serialization client <nrf_rpc_protocols_serialization_client>` sample to test either the Bluetooth LE or OpenThread functionality.
+After building the Protocols serialization server sample and programming it to your development kit, connect it to a second device running the :ref:`Protocol serialization client <nrf_rpc_protocols_serialization_client>` sample to test either the Bluetooth LE, OpenThread or NFC functionality.
 
 .. _protocols_serialization_server_app_connection:
 
@@ -84,7 +87,7 @@ Connecting the client and server samples
 ========================================
 
 The client and server devices are connected using two UART peripherals.
-In the protocols serialization samples, one peripheral is used for shell and logging purposes, similarly to other applications and samples, while the other peripheral is used for sending OpenThread and Bluetooth LE remote procedure calls (RPCs).
+In the protocols serialization samples, one peripheral is used for shell and logging purposes, similarly to other applications and samples, while the other peripheral is used for sending OpenThread, Bluetooth LE and NFC remote procedure calls (RPCs).
 
 .. tabs::
 
@@ -161,7 +164,7 @@ Testing Bluetooth LE API serialization
 
 Complete the following steps to test Bluetooth LE API serialization:
 
-1. |connect_terminal_both|
+#. |connect_terminal_both|
 
 #. Reboot both devices at the same time by pressing the **RESET** button on each DK.
 
@@ -312,9 +315,54 @@ Complete the following steps to test OpenThread API serialization:
 
 Note that all IPv6 addresses shown here are just examples and will be replaced with the actual IPv6 addresses of the peer devices.
 
+Testing NFC API serialization
+====================================
+
+#. |connect_terminal_both|
+
+#. Reboot both devices at the same time by pressing the **RESET** button on each DK.
+
+#. Wait a few seconds until you see a message similar to the following on both terminal emulators:
+
+   .. code-block:: console
+
+      [00:00:00.842,862] <inf> nrf_rpc_host: RPC client ready
+
+
+   This indicates that the communication between the devices has been initialized properly.
+
+#. Run the following commands on the client's terminal emulator to bring up NFC interface on the server device:
+
+   .. code-block:: console
+
+      uart:~$ nfc init
+      uart:~$ nfc start
+
+#. Start any application on smartphone or tablet that is able to read NFC tags.
+
+#. Touch the NFC antenna with the smartphone or tablet and observe it displays the encoded text "Hello world!".
+
+#. Run the following commands on the client's terminal emulator to set and encode a custom message on the server device:
+
+   .. code-block:: console
+
+      uart:~$ nfc stop
+      uart:~$ nfc set_new_msg "https://www.nordicsemi.com/Products/Development-software/nRF-Connect-SDK"
+      uart:~$ nfc start
+
+#. Touch the NFC antenna with the smartphone or tablet and observe it displays the custom message as the encoded text.
+
+#. Run the following commands on the client's terminal emulator to stop and to release NFC frontend on the server device:
+
+   .. code-block:: console
+
+      uart:~$ nfc stop
+      uart:~$ nfc release
+
 Dependencies
 ************
 
 This sample uses the following `sdk-nrfxlib`_ library:
 
 * :ref:`nrfxlib:nrf_rpc`
+* :ref:`nrfxlib:nfc_api_type2`

--- a/samples/nrf_rpc/protocols_serialization/server/snippets/nfc/nfc.conf
+++ b/samples/nrf_rpc/protocols_serialization/server/snippets/nfc/nfc.conf
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Enable and configure Bluetooth LE
+CONFIG_NFC_RPC=y
+CONFIG_NFC_RPC_SERVER=y
+
+CONFIG_NFC_T2T_NRFXLIB=y
+CONFIG_NFC_T4T_NRFXLIB=y

--- a/samples/nrf_rpc/protocols_serialization/server/snippets/nfc/snippet.yml
+++ b/samples/nrf_rpc/protocols_serialization/server/snippets/nfc/snippet.yml
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+name: nfc
+append:
+  EXTRA_CONF_FILE: nfc.conf

--- a/subsys/nfc/rpc/Kconfig
+++ b/subsys/nfc/rpc/Kconfig
@@ -46,6 +46,7 @@ config NFC_RPC_T2T
 config NFC_RPC_T4T
 	bool "NFC T4T over RPC"
 	select NFC_NDEF
+	select NFC_NDEF_MSG
 	default y
 	help
 	  Enables serialization NFC T4T API over RPC.

--- a/subsys/nfc/rpc/client/CMakeLists.txt
+++ b/subsys/nfc/rpc/client/CMakeLists.txt
@@ -9,6 +9,8 @@ zephyr_library()
 zephyr_library_sources_ifdef(CONFIG_NFC_RPC_T2T nfc_rpc_t2t_client.c)
 zephyr_library_sources_ifdef(CONFIG_NFC_RPC_T4T nfc_rpc_t4t_client.c)
 
+zephyr_include_directories(${ZEPHYR_NRFXLIB_MODULE_DIR}/nfc/include/)
+
 zephyr_library_include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/../common
 )

--- a/subsys/nfc/rpc/client/nfc_rpc_t2t_client.c
+++ b/subsys/nfc/rpc/client/nfc_rpc_t2t_client.c
@@ -22,12 +22,12 @@ static void nfc_rpc_t2t_cb_rpc_handler(const struct nrf_rpc_group *group,
 	void *context;
 	nfc_t2t_callback_t callback;
 
+	context = (void *)nrf_rpc_decode_uint(ctx);
 	event = nrf_rpc_decode_uint(ctx);
 	data = nrf_rpc_decode_buffer_ptr_and_size(ctx, &data_length);
-	context = (void *)nrf_rpc_decode_uint(ctx);
 	callback = (nfc_t2t_callback_t)nrf_rpc_decode_callback_call(ctx);
 
-	if (data && data_length && callback) {
+	if (data && data_length) {
 		container = k_malloc(data_length);
 	}
 
@@ -41,10 +41,10 @@ static void nfc_rpc_t2t_cb_rpc_handler(const struct nrf_rpc_group *group,
 		return;
 	}
 
-	if (container) {
-		callback(context, event, container, data_length);
-		k_free(container);
+	if (callback) {
+		callback(context, event, data ? container : NULL, data ? data_length : 0);
 	}
+	k_free(container);
 
 	nrf_rpc_rsp_send_void(group);
 }

--- a/subsys/nfc/rpc/client/nfc_rpc_t4t_client.c
+++ b/subsys/nfc/rpc/client/nfc_rpc_t4t_client.c
@@ -23,13 +23,13 @@ static void nfc_rpc_t4t_cb_rpc_handler(const struct nrf_rpc_group *group,
 	void *context;
 	nfc_t4t_callback_t callback;
 
+	context = (void *)nrf_rpc_decode_uint(ctx);
 	event = nrf_rpc_decode_uint(ctx);
 	data = nrf_rpc_decode_buffer_ptr_and_size(ctx, &data_length);
 	flags = nrf_rpc_decode_uint(ctx);
-	context = (void *)nrf_rpc_decode_uint(ctx);
 	callback = (nfc_t4t_callback_t)nrf_rpc_decode_callback_call(ctx);
 
-	if (data && data_length && callback) {
+	if (data && data_length) {
 		container = k_malloc(data_length);
 	}
 
@@ -43,10 +43,10 @@ static void nfc_rpc_t4t_cb_rpc_handler(const struct nrf_rpc_group *group,
 		return;
 	}
 
-	if (container) {
-		callback(context, event, container, data_length, flags);
-		k_free(container);
+	if (callback) {
+		callback(context, event, data ? container : NULL, data ? data_length : 0, flags);
 	}
+	k_free(container);
 
 	nrf_rpc_rsp_send_void(group);
 }

--- a/tests/subsys/nfc/rpc/client/CMakeLists.txt
+++ b/tests/subsys/nfc/rpc/client/CMakeLists.txt
@@ -21,8 +21,6 @@ target_sources(app PRIVATE
   ../common/nrf_rpc_single_thread.c
 )
 
-zephyr_include_directories(${ZEPHYR_NRFXLIB_MODULE_DIR}/nfc/include/)
-
 # Enforce single-threaded nRF RPC command processing.
 target_link_options(app PUBLIC
   -Wl,--wrap=nrf_rpc_os_init,--wrap=nrf_rpc_os_thread_pool_send

--- a/tests/subsys/nfc/rpc/client/src/t2t_suite.c
+++ b/tests/subsys/nfc/rpc/client/src/t2t_suite.c
@@ -258,8 +258,8 @@ ZTEST(nfc_rpc_t2t_cli, test_t2t_cb_handler)
 	slot_cnt++;
 	cb_called = false;
 	mock_nrf_rpc_tr_expect_add(RPC_RSP(), NO_RSP);
-	mock_nrf_rpc_tr_receive(RPC_CMD(NFC_RPC_CMD_T2T_CB, NFC_T2T_EVENT_DATA_READ, NFC_DATA,
-					CBOR_UINT32(0xdeadbeef), in_slot));
+	mock_nrf_rpc_tr_receive(RPC_CMD(NFC_RPC_CMD_T2T_CB, CBOR_UINT32(0xdeadbeef),
+					NFC_T2T_EVENT_DATA_READ, NFC_DATA, in_slot));
 	mock_nrf_rpc_tr_expect_done();
 
 	zassert_true(cb_called);

--- a/tests/subsys/nfc/rpc/client/src/t4t_suite.c
+++ b/tests/subsys/nfc/rpc/client/src/t4t_suite.c
@@ -212,8 +212,9 @@ ZTEST(nfc_rpc_t4t_cli, test_t4t_cb_handler)
 	slot_cnt++;
 	cb_called = false;
 	mock_nrf_rpc_tr_expect_add(RPC_RSP(), NO_RSP);
-	mock_nrf_rpc_tr_receive(RPC_CMD(NFC_RPC_CMD_T4T_CB, NFC_T4T_EVENT_DATA_IND, NFC_DATA,
-					CBOR_UINT32(0xcafebabe), CBOR_UINT32(0xdeadbeef), in_slot));
+	mock_nrf_rpc_tr_receive(RPC_CMD(NFC_RPC_CMD_T4T_CB, CBOR_UINT32(0xdeadbeef),
+					NFC_T4T_EVENT_DATA_IND, NFC_DATA, CBOR_UINT32(0xcafebabe),
+					in_slot));
 	mock_nrf_rpc_tr_expect_done();
 
 	zassert_true(cb_called);


### PR DESCRIPTION
PR fixes the sequence of the serialized parameters in event callback serializer to make compatible client and server parts.
PR adds NFC API usage in the protocol serialization samples (both client and server) as well as extends samples documentation.