### PR TITLE
treewide: do not select NRF_MODEM_LIB

### DIFF
--- a/lib/modem_info/Kconfig
+++ b/lib/modem_info/Kconfig
@@ -6,7 +6,7 @@
 
 menuconfig MODEM_INFO
 	bool "nRF91 modem information library"
-	select NRF_MODEM_LIB
+	depends on NRF_MODEM_LIB
 	select AT_PARSER
 	select AT_MONITOR
 

--- a/lib/modem_jwt/Kconfig
+++ b/lib/modem_jwt/Kconfig
@@ -6,7 +6,7 @@
 
 menuconfig MODEM_JWT
 	bool "Modem JWT Library"
-	select NRF_MODEM_LIB
+	depends on NRF_MODEM_LIB
 	select BASE64
 	help
 	  Functionality requires modem firmware version 1.3 or greater.

--- a/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_fota
+++ b/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_fota
@@ -91,7 +91,7 @@ endif # NRF_CLOUD_REST
 
 menuconfig NRF_CLOUD_FOTA_FULL_MODEM_UPDATE
 	bool "Enable full modem FOTA updates"
-	select NRF_MODEM_LIB
+	depends on NRF_MODEM_LIB
 	select ZCBOR
 	select DFU_TARGET
 	select DFU_TARGET_FULL_MODEM

--- a/subsys/net/lib/nrf_provisioning/Kconfig
+++ b/subsys/net/lib/nrf_provisioning/Kconfig
@@ -7,7 +7,7 @@
 menuconfig NRF_PROVISIONING
 	bool "nRF Provisioning"
 	select EXPERIMENTAL
-	imply NRF_MODEM_LIB
+	depends on NRF_MODEM_LIB
 	depends on SETTINGS
 	imply FCB
 

--- a/subsys/net/lib/nrf_provisioning/Kconfig.nrf_provisioning_codec
+++ b/subsys/net/lib/nrf_provisioning/Kconfig.nrf_provisioning_codec
@@ -6,7 +6,7 @@
 menuconfig NRF_PROVISIONING_CODEC
 	bool "nRF Provisioning codec"
 	select EXPERIMENTAL
-	imply NRF_MODEM_LIB
+	depends on NRF_MODEM_LIB
 
 if NRF_PROVISIONING_CODEC
 


### PR DESCRIPTION
libmodem is enabled automatically for all nRF9 projects.
Using `select` to express a dependency is bad practice, and should be avoided in favour of `depends on`.

I will add more commits-- just checking what changes I need in each to keep things building.
edit: I may need one commit to change lots of stuff to untangle dependency loops.