### PR TITLE
subsys: dfu: fmfu_dev: depend on FLASH

### DIFF
--- a/subsys/dfu/fmfu_fdev/Kconfig
+++ b/subsys/dfu/fmfu_fdev/Kconfig
@@ -6,6 +6,7 @@
 
 menuconfig FMFU_FDEV
 	bool "Full Modem Firmware Upgrade from flash device"
+	depends on FLASH
 	depends on ZCBOR
 	depends on NRF_MODEM_LIB
 	depends on MBEDTLS_SHA256_C


### PR DESCRIPTION
This library depends on `FLASH`, so express this dependency.