### PR TITLE
samples: peripheral: radio_test: make cpurad_dma reg bigger

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -204,6 +204,7 @@
 
 "CI-ble-samples-test":
   - "samples/bluetooth/**/*"
+  - "samples/peripheral/radio_test/**/*"
   - "subsys/nrf_rpc/**/*"
   - "subsys/mpsl/**/*"
   - "drivers/mpsl/**/*"

--- a/samples/peripheral/radio_test/boards/nrf54h20dk_nrf54h20_cpurad.overlay
+++ b/samples/peripheral/radio_test/boards/nrf54h20dk_nrf54h20_cpurad.overlay
@@ -20,6 +20,14 @@
 	memory-regions = <&cpurad_dma_region>;
 };
 
+&cpuapp_dma_region {
+	reg = <0xe80 0x80>;
+};
+
+&cpurad_dma_region {
+	reg = <0xf00 DT_SIZE_K(4)>;
+};
+
 &dppic020 {
 	status = "okay";
 	source-channels = < 0 1 >;


### PR DESCRIPTION
Sample needs more space for buffer at heap.