### PR TITLE
manifest: update zephyr with latest DVFS oppoint data

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 96aa87c2aae419a2d04f4ee86ef12b359789a817
+      revision: 2fb756ef5c417b0f3348e18c1bffb245e3d10963
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull in update in DVFS medlow oppoint trim entry index. This helps with on all idle current when switching to medlow DVFS oppoint.