### PR TITLE
[DNM] manifest: update sdk-zephyr revision for normal voltage mode fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v3.6.99-ncs2
+      revision: pull/2031/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Normal voltage mode fix is part of MDK 8.67.0.