### PR TITLE
samples: edge_impulse: Add support for nRF54L15DK

### DIFF
--- a/samples/edge_impulse/data_forwarder/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/edge_impulse/data_forwarder/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Nordic Semiconductor ASA
+ * Copyright (c) 2024 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
@@ -11,6 +11,6 @@
 	};
 
 	chosen {
-		ncs,ei-uart = &uart0;
+		ncs,ei-uart = &uart20;
 	};
 };

--- a/samples/edge_impulse/data_forwarder/sample.yaml
+++ b/samples/edge_impulse/data_forwarder/sample.yaml
@@ -10,6 +10,7 @@ tests:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf54l15dk/nrf54l15/cpuapp
       - nrf9160dk/nrf9160/ns
       - thingy91x/nrf9151/ns
     integration_platforms:
@@ -17,6 +18,7 @@ tests:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf54l15dk/nrf54l15/cpuapp
       - nrf9160dk/nrf9160/ns
     platform_exclude: native_posix qemu_x86 qemu_cortex_m3
     tags: ci_build sysbuild ci_samples_edge_impulse

--- a/samples/edge_impulse/data_forwarder/src/main.c
+++ b/samples/edge_impulse/data_forwarder/src/main.c
@@ -20,7 +20,7 @@ const static enum sensor_channel sensor_channels[] = {
 };
 
 static const struct device *sensor_dev = DEVICE_DT_GET(DT_NODELABEL(sensor_sim));
-static const struct device *uart_dev = DEVICE_DT_GET(DT_NODELABEL(uart0));
+static const struct device *uart_dev = DEVICE_DT_GET(DT_CHOSEN(ncs_ei_uart));
 static atomic_t uart_busy;
 
 

--- a/samples/edge_impulse/wrapper/sample.yaml
+++ b/samples/edge_impulse/wrapper/sample.yaml
@@ -17,6 +17,7 @@ common:
     - nrf52840dk/nrf52840
     - nrf5340dk/nrf5340/cpuapp
     - nrf5340dk/nrf5340/cpuapp/ns
+    - nrf54l15dk/nrf54l15/cpuapp
     - nrf9160dk/nrf9160/ns
     - qemu_cortex_m3
     - thingy91x/nrf9151/ns
@@ -25,6 +26,7 @@ common:
     - nrf52840dk/nrf52840
     - nrf5340dk/nrf5340/cpuapp
     - nrf5340dk/nrf5340/cpuapp/ns
+    - nrf54l15dk/nrf54l15/cpuapp
     - nrf9160dk/nrf9160/ns
     - qemu_cortex_m3
   platform_exclude: native_posix qemu_x86


### PR DESCRIPTION
Adds support for nRF54L15DK in the data_forwarder and wrapper samples.