### PR TITLE
lib: at_shell: Add optional multiline support

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -738,6 +738,11 @@ Modem libraries
     * To use the ``AT+CMMS`` AT command when sending concatenated SMS message.
     * To set "7" as a fallback SMS service center address for type approval SIM cards which do not have it set.
 
+* :ref:`lib_at_shell` library:
+
+  * Added the :kconfig:option:`CONFIG_AT_SHELL_UNESCAPE_LF` Kconfig option to enable reception of multiline AT commands.
+  * Updated the :c:func:`at_shell` function to replace ``\n`` with ``<CR><LF>`` if :kconfig:option:`CONFIG_AT_SHELL_UNESCAPE_LF` is enabled.
+
 Multiprotocol Service Layer libraries
 -------------------------------------
 

--- a/lib/at_shell/Kconfig
+++ b/lib/at_shell/Kconfig
@@ -20,4 +20,12 @@ config AT_SHELL_CMD_RESPONSE_MAX_LEN
 	int "Maximum AT command response length"
 	default 2700
 
+config AT_SHELL_UNESCAPE_LF
+	bool "Unescape linefeed"
+	help
+	  Replaces \n with <CR><LF>. This enables commands such as AT%CMNG=0 to
+	  properly receive certificates that ordinarily have multiple lines.
+	  The certificate must have been preprocessed to replace EOL sequences
+	  with a literal \ character followed by an n character.
+
 endif # AT_SHELL

--- a/subsys/net/lib/nrf_cloud/Kconfig
+++ b/subsys/net/lib/nrf_cloud/Kconfig
@@ -127,6 +127,7 @@ choice NRF_CLOUD_CREDENTIALS_MGMT
 config NRF_CLOUD_CREDENTIALS_MGMT_MODEM
 	depends on NRF_MODEM_LIB
 	select MODEM_KEY_MGMT
+	imply AT_SHELL_UNESCAPE_LF if AT_SHELL
 	bool "Credentials are managed by the modem"
 
 config NRF_CLOUD_CREDENTIALS_MGMT_TLS_CRED


### PR DESCRIPTION
Added CONFIG_AT_SHELL_UNESCAPE_LF to enable reception of multiline AT commands.

Updated the at_shell() function to replace the 2 character sequence "\n" with <CR><LF>
if CONFIG_AT_SHELL_UNESCAPE_LF is enabled.

Jira: IRIS-6919