### PR TITLE
Bluetooth: radio_notification_callback: Refactor to not use EGUs

### DIFF
--- a/subsys/bluetooth/host_extensions/Kconfig
+++ b/subsys/bluetooth/host_extensions/Kconfig
@@ -4,77 +4,16 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-menuconfig BT_RADIO_NOTIFICATION_CONN_CB
+config BT_RADIO_NOTIFICATION_CONN_CB
 	bool "Radio Notification connection callback [EXPERIMENTAL]"
-	depends on BT_LL_SOFTDEVICE
-	select BT_CTLR_SDC_EVENT_TRIGGER
-	select NRFX_PPI if HAS_HW_NRF_PPI
-	select NRFX_DPPI if HAS_HW_NRF_DPPIC
+	depends on BT_LL_SOFTDEVICE || \
+		   (BT_LL_SOFTDEVICE_HEADERS_INCLUDE && !SOC_COMPATIBLE_NRF5340_CPUAPP)
 	select EXPERIMENTAL
+	select BT_HCI_VS_EVT_USER
+	select BT_CTLR_SDC_CONN_ANCHOR_POINT_REPORT
 	help
 	  Enables the support for setting up a radio notification
 	  callback to trigger a configurable amount of time before the
 	  connection event starts.
 	  This feature can be used to synchronize data sampling
 	  with on-air data transmission.
-
-if BT_RADIO_NOTIFICATION_CONN_CB
-
-choice BT_RADIO_NOTIFICATION_CONN_CB_EGU_INST
-	bool "Radio Notification connection callback EGU instance"
-	help
-	  Radio Notification connection callback implementation uses
-	  an EGU instance. This config selects which instance to be
-	  used.
-
-config BT_RADIO_NOTIFICATION_CONN_CB_EGU_INST_EGU0
-	bool "Use EGU0"
-	depends on $(dt_nodelabel_has_compat,egu0,$(DT_COMPAT_NORDIC_NRF_EGU))
-	select NRFX_EGU0
-
-config BT_RADIO_NOTIFICATION_CONN_CB_EGU_INST_EGU1
-	bool "Use EGU1"
-	depends on $(dt_nodelabel_has_compat,egu1,$(DT_COMPAT_NORDIC_NRF_EGU))
-	select NRFX_EGU1
-
-config BT_RADIO_NOTIFICATION_CONN_CB_EGU_INST_EGU2
-	bool "Use EGU2"
-	depends on $(dt_nodelabel_has_compat,egu2,$(DT_COMPAT_NORDIC_NRF_EGU))
-	select NRFX_EGU2
-
-config BT_RADIO_NOTIFICATION_CONN_CB_EGU_INST_EGU3
-	bool "Use EGU3"
-	depends on $(dt_nodelabel_has_compat,egu3,$(DT_COMPAT_NORDIC_NRF_EGU))
-	select NRFX_EGU3
-
-config BT_RADIO_NOTIFICATION_CONN_CB_EGU_INST_EGU4
-	bool "Use EGU3"
-	depends on $(dt_nodelabel_has_compat,egu4,$(DT_COMPAT_NORDIC_NRF_EGU))
-	select NRFX_EGU4
-
-config BT_RADIO_NOTIFICATION_CONN_CB_EGU_INST_EGU5
-	bool "Use EGU5"
-	depends on $(dt_nodelabel_has_compat,egu5,$(DT_COMPAT_NORDIC_NRF_EGU))
-	select NRFX_EGU5
-
-config BT_RADIO_NOTIFICATION_CONN_CB_EGU_INST_EGU10
-	bool "Use EGU10"
-	depends on $(dt_nodelabel_has_compat,egu10,$(DT_COMPAT_NORDIC_NRF_EGU))
-	select NRFX_EGU10
-
-config BT_RADIO_NOTIFICATION_CONN_CB_EGU_INST_EGU020
-	bool "Use EGU020"
-	depends on $(dt_nodelabel_has_compat,egu020,$(DT_COMPAT_NORDIC_NRF_EGU))
-	select NRFX_EGU020
-
-endchoice
-
-config BT_RADIO_NOTIFICATION_CONN_CB_EGU_TRIGGER_ISR_PRIO
-	int
-	depends on BT_RADIO_NOTIFICATION_CONN_CB
-	default 2
-	help
-	  The ISR priority of the connection event trigger
-	  used to setup the timer for the callback.
-
-endif


### PR DESCRIPTION
By using the the connection anchor point events instead of the connection connection event trigger functionality the implementation can be refactored to not use an EGU instance.
This approach will also scale better to multicore architectures.

This approach also uses less FLASH.
For the radio_notification_cb sample on 53, the FLASH usage is reduced with almost 400 bytes.

For multicore devices that have different time domains on different cores, a translation mechanism is needed. This is currently not present. That is, we don't support this feauture on 53 app core, but it works nicely on 54 as that uses the global GRTC.