### PR TITLE
doc: nrf: app_dev: bootloaders_dfu: Fix QSPI nRF91 mention

### DIFF
--- a/doc/nrf/app_dev/bootloaders_dfu/qspi_xip_split_image.rst
+++ b/doc/nrf/app_dev/bootloaders_dfu/qspi_xip_split_image.rst
@@ -12,7 +12,7 @@ The QSPI XIP split image feature lets you gain more flash storage space for appl
 * Code that runs on the internal flash memory.
 * Code that runs on supported external flash memory over the Quad Serial Peripheral Interface (QSPI) using Execute in Place (XIP).
 
-This feature is supported on nRF52840, nRF5340, and the SoCs of the nRF91 Series.
+This feature is supported on nRF52840 and nRF5340.
 
 .. warning::
     On the nRF52840, do not relocate interrupts to the QSPI XIP flash.
@@ -27,7 +27,7 @@ Requirements
 
 To use this feature, meet the following requirements:
 
-* Board based on nRF52840, nRF5340, or nRF91 Series SoCs, with file structure compatible with :ref:`Hardware model v2 (HWMv2) <hwmv1_to_v2_migration>`
+* Board based on nRF52840 or nRF5340, with file structure compatible with :ref:`Hardware model v2 (HWMv2) <hwmv1_to_v2_migration>`
 * External QSPI flash chip with supported commands connected to QSPI pins
 * QSPI flash chip in always-on mode (meaning, no DPM or low-power modes)
 * :doc:`MCUboot configuration <mcuboot:design>` in the Swap using move mode (``MCUBOOT_SWAP_USING_MOVE``), the Upgrade only mode (``MCUBOOT_OVERWRITE_ONLY``), or in the direct-XIP mode


### PR DESCRIPTION
Removes a reference to nRF91 as this does not support QSPI