### PR TITLE
tests: benchmarks: multicore: idle: add ppk_power_measure tag

### DIFF
--- a/tests/benchmarks/multicore/idle/testcase.yaml
+++ b/tests/benchmarks/multicore/idle/testcase.yaml
@@ -83,6 +83,7 @@ tests:
       fixture: ppk_power_measure
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption"
+    tags: ppk_power_measure
 
   benchmarks.multicore.idle.nrf54h20dk_cpuapp_cpurad.ram_retention_high_usage:
     platform_allow:
@@ -105,6 +106,7 @@ tests:
       fixture: ppk_power_measure
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_ram_retention_high_usage"
+    tags: ppk_power_measure
 
   benchmarks.multicore.idle.nrf54h20dk_cpuapp_cpurad.ram_retention_low_usage:
     platform_allow:
@@ -127,3 +129,4 @@ tests:
       fixture: ppk_power_measure
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_ram_retention_low_usage"
+    tags: ppk_power_measure


### PR DESCRIPTION
Will be used to filter tests for execution with power measurements.