### PR TITLE
tools: Python 3.12 - Mac & Windows

### DIFF
--- a/scripts/requirements-ci.txt
+++ b/scripts/requirements-ci.txt
@@ -12,6 +12,5 @@ pytz
 pyusb
 qrcode
 stringcase==1.2.0
-typed-ast
 toml
 wget

--- a/scripts/requirements-fixed.txt
+++ b/scripts/requirements-fixed.txt
@@ -10,7 +10,7 @@ appdirs==1.4.4            # via cmsis-pack-manager
 arrow==1.2.1              # via gitlint-core
 astroid==3.0.1            # via pylint
 attrs==23.1.0             # via jsonschema, referencing
-bitarray==2.8.1           # via -r nrf/scripts/requirements-ci.txt
+bitarray==2.9.2           # via -r nrf/scripts/requirements-ci.txt
 bz==1.0                   # via -r zephyr/scripts/requirements-run-test.txt
 canopen==2.1.0            # via -r zephyr/scripts/requirements-base.txt
 capstone==4.0.2           # via pyocd
@@ -25,7 +25,7 @@ click==8.0.3              # via -r bootloader/mcuboot/scripts/requirements.txt, 
 cmsis-pack-manager==0.5.2  # via pyocd
 colorama==0.4.6           # via -r zephyr/scripts/requirements-build-test.txt, pyocd, west
 coverage==7.3.1           # via -r zephyr/scripts/requirements-build-test.txt
-cryptography==42.0.5      # via -r bootloader/mcuboot/scripts/requirements.txt, -r nrf/scripts/requirements-build.txt, imgtool, pyjwt
+cryptography==43.0.1      # via -r bootloader/mcuboot/scripts/requirements.txt, -r nrf/scripts/requirements-build.txt, imgtool, pyjwt
 deprecated==1.2.14        # via pygithub
 devicetree==0.0.2         # via nrf-regtool
 dill==0.3.7               # via pylint
@@ -108,9 +108,9 @@ pyusb==1.2.1              # via -r nrf/scripts/requirements-ci.txt, pyocd
 pyyaml==6.0.1             # via -r bootloader/mcuboot/scripts/requirements.txt, -r zephyr/scripts/requirements-base.txt, cmsis-pack-manager, devicetree, pyocd, west, yamllint, zcbor
 qrcode==7.4.2             # via -r nrf/scripts/requirements-ci.txt
 referencing==0.30.2       # via jsonschema, jsonschema-specifications
-regex==2023.8.8           # via zcbor
+regex==2024.7.24          # via zcbor
 requests==2.32.0          # via -r zephyr/scripts/requirements-base.txt, pygithub
-rpds-py==0.10.3           # via jsonschema, referencing
+rpds-py==0.20.0           # via jsonschema, referencing
 ruamel-yaml==0.17.32      # via pykwalify
 setuptools-scm==8.0.4     # via svada
 sh==1.14.2                # via gitlint-core
@@ -123,7 +123,6 @@ tabulate==0.9.0           # via -r zephyr/scripts/requirements-run-test.txt
 toml==0.10.2              # via -r nrf/scripts/requirements-ci.txt
 tomli==2.0.1              # via nrf-regtool
 tomlkit==0.12.1           # via pylint
-typed-ast==1.5.5          # via -r nrf/scripts/requirements-ci.txt
 typing-extensions==4.8.0  # via mypy, pyocd, python-can, qrcode, setuptools-scm, svada
 urllib3==2.2.2            # via requests
 wcwidth==0.2.6            # via prettytable
@@ -135,4 +134,4 @@ zcbor==0.8.1              # via -r nrf/scripts/requirements-build.txt, -r nrf/sc
 zipp==3.17.0              # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==70.1.0        # via grpcio-tools, libusb, pkg-about, python-can, setuptools-scm, west
+setuptools==74.1.1        # via grpcio-tools, libusb, pkg-about, python-can, setuptools-scm, west

--- a/scripts/tools-versions-darwin.yml
+++ b/scripts/tools-versions-darwin.yml
@@ -1,6 +1,6 @@
 # Requirement file for native tools on Darwin 86 and aarch64
 python:
-  version: 3.9.6
+  version: 3.12.4
 git:
   version: 2.37.3
 cmake:
@@ -24,3 +24,5 @@ zephyr-sdk:
     - riscv64-zephyr-elf
 doxygen:
   version: 1.9.2
+pip:
+  version: 24.2

--- a/scripts/tools-versions-linux.yml
+++ b/scripts/tools-versions-linux.yml
@@ -29,3 +29,5 @@ dfu_util:
   version: 0.9-1
 doxygen:
   version: 1.9.6
+pip:
+  version: 24.2

--- a/scripts/tools-versions-win10.yml
+++ b/scripts/tools-versions-win10.yml
@@ -1,5 +1,5 @@
 python:
-  version: 3.9.13
+  version: 3.12.4
 git:
   version: 2.37.3.windows.1
 cmake:
@@ -23,3 +23,5 @@ zephyr-sdk:
     - riscv64-zephyr-elf
 doxygen:
   version: 1.9.2
+pip:
+  version: 24.2


### PR DESCRIPTION
Bump Python to version 3.12 on Mac and Windows