### PR TITLE
doc/nrf/../fota: documented auto confirmation of direct-XIP image

### DIFF
--- a/doc/nrf/app_dev/device_guides/nrf52/fota_update.rst
+++ b/doc/nrf/app_dev/device_guides/nrf52/fota_update.rst
@@ -106,9 +106,8 @@ See how to build the :ref:`peripheral_lbs` sample with MCUboot in direct-xip mod
     west build -b *board_target* -- -DSB_CONFIG_BOOTLOADER_MCUBOOT=y -DSB_CONFIG_MCUBOOT_MODE_DIRECT_XIP_WITH_REVERT=y -DCONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU=y
 
 .. note::
-   When building the application for the first time with MCUboot in direct-xip mode and the revert mechanism support, use an additional option ``-DCONFIG_MCUBOOT_EXTRA_IMGTOOL_ARGS=\"--confirm\"``.
-   This option will mark the application as ``confirmed`` during the image signing process.
-   If the application is built without this option, it will fail to boot.
+   When building the application with MCUboot in direct-XIP mode with revert mechanism support, the signed image intended for flashing is automatically marked as confirmed.
+   Without this configuration, the application will fail to boot.
    It must, however, be disabled when building update images.
 
 Both the ``SB_CONFIG_MCUBOOT_MODE_DIRECT_XIP`` and ``SB_CONFIG_MCUBOOT_MODE_DIRECT_XIP_WITH_REVERT`` Kconfig options automatically build application update images for both slots.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -48,8 +48,14 @@ Build and configuration system
 Bootloaders and DFU
 ===================
 
-* Added documentation for :ref:`qspi_xip_split_image` functionality.
-* Added a section in the sysbuild-related migration guide about the migration of :ref:`child_parent_to_sysbuild_migration_qspi_xip` from child/parent image to sysbuild.
+* Added:
+
+  * Documentation for :ref:`qspi_xip_split_image` functionality.
+  * A section in the sysbuild-related migration guide about the migration of :ref:`child_parent_to_sysbuild_migration_qspi_xip` from child/parent image to sysbuild.
+
+* Updated the procedure for signing the application image built for booting by MCUboot in direct-XIP mode with revert support.
+  Now, the Intel-Hex file of the application image automatically receives a confirmation flag.
+
 * Removed secure bootloader Kconfig ``CONFIG_SECURE_BOOT_DEBUG`` and replaced with usage of logging subsystem.
 
 See also the `MCUboot`_ section.


### PR DESCRIPTION
Documented this feature for applcation image intel-hex file built along with MCUBoot in diret-XPI with revert mode.



goes once  #17390 gets merged.