### PR TITLE
samples: cellular: nrf_cloud: Control online alert

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -648,6 +648,7 @@
 .. _`External memory section in the nRF9160 DK User Guide`: https://docs.nordicsemi.com/bundle/ug_nrf9160_dk/page/UG/nrf91_DK/hw_description/external_memory.html
 .. _`Device programming section in the nRF9160 DK User Guide`: https://docs.nordicsemi.com/bundle/ug_nrf9160_dk/page/UG/nrf91_DK/operating_modes/mcu_device_programming.html
 .. _`VDD supply rail section in the nRF9160 DK User Guide`: https://docs.nordicsemi.com/bundle/ug_nrf9160_dk/page/UG/nrf91_DK/hw_description/power_sources_vdd.html
+.. _`nRF9160 RESETREAS`: https://docs.nordicsemi.com/bundle/ps_nrf9160/page/power.html#ariaid-title16
 
 .. _`nRF9161 Product Specification`: https://docs.nordicsemi.com/bundle/ps_nrf9161/page/nRF9161_html5_keyfeatures.html
 .. _`nRF9161 GPS receiver specification`: https://docs.nordicsemi.com/bundle/ps_nrf9161/page/gps.html

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -392,6 +392,8 @@ Cellular samples
     * A handler for new nRF Cloud event type ``NRF_CLOUD_EVT_RX_DATA_DISCON`` to stop sensors and location services.
     * A call to the :c:func:`nrf_cloud_print_details` function and removed redundant logging.
     * Board support files to enable Wi-Fi scanning for the Thingy:91 X.
+    * The :kconfig:option:`CONFIG_SEND_ONLINE_ALERT` Kconfig option to enable calling the :c:func:`nrf_cloud_alert` function on startup.
+    * Logging of the `reset reason code <nRF9160 RESETREAS_>`_.
 
   * Updated:
 
@@ -408,6 +410,8 @@ Cellular samples
 
     * Support for dictionary logs using REST.
     * A call to the :c:func:`nrf_cloud_print_details` function and removed redundant logging.
+    * The :kconfig:option:`CONFIG_SEND_ONLINE_ALERT` Kconfig option to enable calling the :c:func:`nrf_cloud_alert` function on startup.
+    * Logging of the `reset reason code <nRF9160 RESETREAS_>`_.
 
 * :ref:`nrf_cloud_rest_cell_pos_sample` sample:
 

--- a/samples/cellular/nrf_cloud_multi_service/Kconfig
+++ b/samples/cellular/nrf_cloud_multi_service/Kconfig
@@ -239,6 +239,12 @@ config AT_CMD_REQUEST_RESPONSE_BUFFER_LENGTH
 	  error code sent in its place (-NRF_E2BIG). Cannot be less than 40 bytes.
 	default 200
 
+config SEND_ONLINE_ALERT
+	bool "Sends a routine ALERT_TYPE_DEVICE_NOW_ONLINE on startup"
+	help
+	  Enable this to demonstrate the alert feature of nRF Cloud. Reception of this alert
+	  indicates the device has rebooted.
+
 if NRF_CLOUD_COAP
 
 menuconfig COAP_FOTA

--- a/samples/cellular/nrf_cloud_multi_service/README.rst
+++ b/samples/cellular/nrf_cloud_multi_service/README.rst
@@ -122,8 +122,11 @@ Application thread and main application loop
 ============================================
 
 The application thread is implemented in the :file:`src/application.c` file, and is responsible for the high-level behavior of this sample.
-It performs the following major tasks:
 
+When it starts, it logs the `reset reason code <nRF9160 RESETREAS_>`_.
+If the :kconfig:option:`CONFIG_SEND_ONLINE_ALERT` Kconfig option is enabled, it sends an alert to nRF Cloud containing the reset reason as the value field.
+
+It performs the following major tasks:
 * Establishes periodic position tracking (which the :ref:`lib_location` library performs).
 * Periodically samples temperature data (using the :file:`src/temperature.c` file).
 * Constructs timestamped sensor sample and location `device messages <nRF Cloud Device Messages_>`_.

--- a/samples/cellular/nrf_cloud_multi_service/prj.conf
+++ b/samples/cellular/nrf_cloud_multi_service/prj.conf
@@ -14,6 +14,7 @@ CONFIG_EVENTS=y
 CONFIG_PICOLIBC_IO_FLOAT=y
 CONFIG_RESET_ON_FATAL_ERROR=y
 CONFIG_NCS_SAMPLES_DEFAULTS=y
+CONFIG_DK_LIBRARY=y
 
 # LED indication
 # Uncomment these to minimize LED state indication when power savings are necessary

--- a/samples/cellular/nrf_cloud_multi_service/src/application.c
+++ b/samples/cellular/nrf_cloud_multi_service/src/application.c
@@ -20,6 +20,7 @@
 #include <modem/location.h>
 #include "location_tracking.h"
 #endif
+#include <dk_buttons_and_leds.h>
 #include "application.h"
 #include "temperature.h"
 #include "cloud_connection.h"
@@ -322,6 +323,16 @@ static void test_counter_send(void)
 	}
 }
 
+static void button_handler(uint32_t button_state, uint32_t has_changed)
+{
+	if (has_changed & DK_BTN1_MSK) {
+		if ((button_state & DK_BTN1_MSK) == DK_BTN1_MSK) {
+			LOG_INF("Button pressed");
+			(void)nrf_cloud_alert_send(ALERT_TYPE_MSG, 0, "Button pressed");
+		}
+	}
+}
+
 static void print_reset_reason(void)
 {
 	uint32_t reset_reason;
@@ -351,6 +362,8 @@ void main_application_thread_fn(void)
 		 */
 		register_general_dev_msg_handler(handle_at_cmd_requests);
 	}
+
+	dk_buttons_init(button_handler);
 
 	/* Wait for first connection before starting the application. */
 	(void)await_cloud_ready(K_FOREVER);

--- a/samples/cellular/nrf_cloud_rest_device_message/Kconfig
+++ b/samples/cellular/nrf_cloud_rest_device_message/Kconfig
@@ -33,6 +33,12 @@ config REST_DEVICE_MESSAGE_KEEP_ALIVE
 	  direct logging message can reuse it. This reduces data and power
 	  consumption, but is not compatible with the cloud logging backend.
 
+config SEND_ONLINE_ALERT
+	bool "Sends a routine ALERT_TYPE_DEVICE_NOW_ONLINE on startup"
+	help
+	  Enable this to demonstrate the alert feature of nRF Cloud. Reception of this alert
+	  indicates the device has rebooted.
+
 endmenu
 
 menu "Zephyr Kernel"

--- a/samples/cellular/nrf_cloud_rest_device_message/src/main.c
+++ b/samples/cellular/nrf_cloud_rest_device_message/src/main.c
@@ -9,6 +9,7 @@
 #include <nrf_modem_at.h>
 #include <modem/modem_info.h>
 #include <zephyr/settings/settings.h>
+#include <helpers/nrfx_reset_reason.h>
 #include <net/nrf_cloud.h>
 #include <net/nrf_cloud_rest.h>
 #include <net/nrf_cloud_log.h>
@@ -551,9 +552,51 @@ static int init(void)
 	return 0;
 }
 
+static void print_reset_reason(void)
+{
+	uint32_t reset_reason;
+
+	reset_reason = nrfx_reset_reason_get();
+	LOG_INF("Reset reason: 0x%x", reset_reason);
+}
+
+static void report_startup(void)
+{
+	int err;
+
+	/* Set the keep alive flag to true;
+	 * connection will remain open to allow for multiple REST calls
+	 */
+	rest_ctx.keep_alive = true;
+
+	if (IS_ENABLED(CONFIG_SEND_ONLINE_ALERT)) {
+		uint32_t reset_reason;
+
+		reset_reason = nrfx_reset_reason_get();
+		nrfx_reset_reason_clear(reset_reason);
+
+		err = nrf_cloud_rest_alert_send(&rest_ctx, device_id,
+						ALERT_TYPE_DEVICE_NOW_ONLINE,
+						reset_reason, NULL);
+		if (err) {
+			LOG_ERR("Error sending alert to cloud: %d", err);
+		}
+	}
+
+	err = nrf_cloud_rest_log_send(&rest_ctx, device_id, LOG_LEVEL_INF,
+				      SAMPLE_SIGNON_FMT,
+				      CONFIG_REST_DEVICE_MESSAGE_SAMPLE_VERSION);
+
+	if (err) {
+		LOG_ERR("Error sending direct log to cloud: %d", err);
+	}
+}
+
 static int setup(void)
 {
 	int err;
+
+	print_reset_reason();
 
 	/* Initialize libraries and hardware */
 	err = init();
@@ -622,24 +665,8 @@ int main(void)
 		return 0;
 	}
 
-	/* Set the keep alive flag to true;
-	 * connection will remain open to allow for multiple REST calls
-	 */
-	rest_ctx.keep_alive = true;
-	err = nrf_cloud_rest_alert_send(&rest_ctx, device_id,
-					ALERT_TYPE_DEVICE_NOW_ONLINE, 0, NULL);
-
-	if (err) {
-		LOG_ERR("Error sending alert to cloud: %d", err);
-	}
-
-	err = nrf_cloud_rest_log_send(&rest_ctx, device_id, LOG_LEVEL_INF,
-				      SAMPLE_SIGNON_FMT,
-				      CONFIG_REST_DEVICE_MESSAGE_SAMPLE_VERSION);
-
-	if (err) {
-		LOG_ERR("Error sending direct log to cloud: %d", err);
-	}
+	/* Send alert (if enabled) and log message to the cloud. */
+	report_startup();
 
 	/* Set the keep alive flag to false; connection will be closed after the next REST call */
 	rest_ctx.keep_alive = false;


### PR DESCRIPTION
By default, no longer send an alert on startup.

Add logging of the reset reason, and if the online alert is enabled, include that in the value.

IRIS-9688