### PR TITLE
applications: Reworked sample.yaml configuration for Matter bridge

### DIFF
--- a/applications/matter_bridge/sample.yaml
+++ b/applications/matter_bridge/sample.yaml
@@ -10,7 +10,10 @@ tests:
       CONFIG_BRIDGE_ONOFF_LIGHT_SWITCH_BRIDGED_DEVICE=y
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
-    platform_allow: nrf7002dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+    platform_allow: nrf7002dk/nrf5340/cpuapp nrf5340dk/nrf5340/cpuapp
+      nrf54h20dk/nrf54h20/cpuapp
     tags: sysbuild ci_applications_matter
   applications.matter_bridge.lto:
     sysbuild: true
@@ -19,17 +22,10 @@ tests:
       CONFIG_BRIDGE_ONOFF_LIGHT_SWITCH_BRIDGED_DEVICE=y
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
-    platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: sysbuild ci_applications_matter
-  applications.matter_bridge.lto.smp_dfu:
-    sysbuild: true
-    build_only: true
-    extra_args: CONFIG_CHIP_DFU_OVER_BT_SMP=y
-      CONFIG_BRIDGE_GENERIC_SWITCH_BRIDGED_DEVICE=n
-      CONFIG_BRIDGE_ONOFF_LIGHT_SWITCH_BRIDGED_DEVICE=y
-    integration_platforms:
-      - nrf7002dk/nrf5340/cpuapp
-    platform_allow: nrf7002dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+    platform_allow: nrf7002dk/nrf5340/cpuapp nrf5340dk/nrf5340/cpuapp
+      nrf54h20dk/nrf54h20/cpuapp
     tags: sysbuild ci_applications_matter
   applications.matter_bridge.lto.br_ble:
     sysbuild: true
@@ -39,7 +35,10 @@ tests:
       CONFIG_BRIDGE_ONOFF_LIGHT_SWITCH_BRIDGED_DEVICE=y
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
-    platform_allow: nrf7002dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+    platform_allow: nrf7002dk/nrf5340/cpuapp nrf5340dk/nrf5340/cpuapp
+      nrf54h20dk/nrf54h20/cpuapp
     tags: sysbuild ci_applications_matter
   applications.matter_bridge.release.br_ble:
     sysbuild: true
@@ -49,9 +48,22 @@ tests:
       CONFIG_BRIDGE_ONOFF_LIGHT_SWITCH_BRIDGED_DEVICE=y
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+    platform_allow: nrf7002dk/nrf5340/cpuapp nrf5340dk/nrf5340/cpuapp
+      nrf54h20dk/nrf54h20/cpuapp
+    tags: sysbuild ci_applications_matter
+  applications.matter_bridge.lto.br_ble.smp_dfu:
+    sysbuild: true
+    build_only: true
+    extra_args: CONFIG_CHIP_DFU_OVER_BT_SMP=y CONFIG_BRIDGED_DEVICE_BT=y
+      CONFIG_BRIDGE_GENERIC_SWITCH_BRIDGED_DEVICE=n
+      CONFIG_BRIDGE_ONOFF_LIGHT_SWITCH_BRIDGED_DEVICE=y
+    integration_platforms:
+      - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
     tags: sysbuild ci_applications_matter
-  applications.matter_bridge.lto.nrf70ek:
+  applications.matter_bridge.lto.nrf5340.wifi:
     sysbuild: true
     build_only: true
     extra_args: matter_bridge_SHIELD=nrf7002ek SB_CONFIG_WIFI_PATCHES_EXT_FLASH_STORE=y
@@ -63,21 +75,41 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
     tags: sysbuild ci_applications_matter
-  applications.matter_bridge.lto.memory_profiling:
+  applications.matter_bridge.lto.br_ble.nrf54h20.wifi:
+    sysbuild: true
+    build_only: true
+    extra_args: SB_CONFIG_WIFI_NRF700X=y CONFIG_CHIP_WIFI=y
+      matter_bridge_SHIELD=nrf700x_nrf54h20dk CONFIG_BRIDGED_DEVICE_BT=y
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+    platform_allow: nrf54h20dk/nrf54h20/cpuapp
+    tags: sysbuild ci_applications_matter
+  applications.matter_bridge.release.br_ble.nrf54h20.wifi:
+    sysbuild: true
+    build_only: true
+    extra_args: FILE_SUFFIX=release SB_CONFIG_WIFI_NRF700X=y CONFIG_CHIP_WIFI=y
+      matter_bridge_SHIELD=nrf700x_nrf54h20dk CONFIG_BRIDGED_DEVICE_BT=y
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+    platform_allow: nrf54h20dk/nrf54h20/cpuapp
+    tags: sysbuild ci_applications_matter
+  applications.matter_bridge.lto.br_ble.memory_profiling:
     sysbuild: true
     build_only: true
     extra_args: CONFIG_BRIDGE_GENERIC_SWITCH_BRIDGED_DEVICE=n
       CONFIG_BRIDGE_ONOFF_LIGHT_SWITCH_BRIDGED_DEVICE=y
-      CONFIG_CHIP_MEMORY_PROFILING=y
+      CONFIG_CHIP_MEMORY_PROFILING=y CONFIG_BRIDGED_DEVICE_BT=y
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
-    platform_allow: nrf7002dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+    platform_allow: nrf7002dk/nrf5340/cpuapp nrf5340dk/nrf5340/cpuapp
+      nrf54h20dk/nrf54h20/cpuapp
     tags: sysbuild ci_applications_matter
-  applications.matter_bridge.nrf5340.br_ble.smart_plug.thread:
+  applications.matter_bridge.lto.smart_plug:
     sysbuild: true
     build_only: true
-    extra_args: CONFIG_BRIDGED_DEVICE_BT=y
-      matter_bridge_SNIPPET=onoff_plug
+    extra_args: matter_bridge_SNIPPET=onoff_plug
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp

--- a/scripts/quarantine_integration.yaml
+++ b/scripts/quarantine_integration.yaml
@@ -41,6 +41,9 @@
     - sample.matter.window_cover.lto
     - sample.matter.thermostat.ext_temp
     - sample.matter.light_bulb.memory_profiling
+    - applications.matter_bridge.lto.br_ble.memory_profiling
+    - applications.matter_bridge.release
+    - applications.matter_bridge.release.br_ble
   platforms:
     - nrf5340dk/nrf5340/cpuapp
   comment: "Configurations excluded to limit resources usage in integration builds"
@@ -65,10 +68,10 @@
     - sample.matter.light_switch.lto
     - sample.matter.thermostat.release
     - sample.matter.thermostat.lto
-    - applications.matter_bridge.release
-    - applications.matter_bridge.lto
     - sample.matter.thermostat.ext_temp
-    - applications.matter_bridge.lto.memory_profiling
+    - applications.matter_bridge.lto.br_ble.memory_profiling
+    - applications.matter_bridge.release
+    - applications.matter_bridge.release.br_ble
   platforms:
     - nrf7002dk/nrf5340/cpuapp
   comment: "Configurations excluded to limit resources usage in integration builds"
@@ -112,6 +115,14 @@
   platforms:
     - nrf54l15pdk/nrf54l15/cpuapp/ns
   comment: "Configurations excluded to limit resources usage in integration Matter ns builds"
+
+- scenarios:
+    - applications.matter_bridge.lto.br_ble.memory_profiling
+    - applications.matter_bridge.release.br_ble.nrf54h20.wifi
+  platforms:
+    - nrf54h20dk/nrf54h20/cpuapp
+  comment: "Configurations excluded to limit resources usage in integration builds"
+
 
 - scenarios:
     - sample.nrf7002.iot_devices


### PR DESCRIPTION
Introduced several changes for sample.yaml in Matter bridge application:
* Added nrf54h20 platform to display it in the readme's supported platforms table.
* Added nrf5340 and nrf54h20 to the release configurations to display all supported platforms in the memory consumption table.
* Replaced several configurations run using simulated variant to the BLE one, as it is more error prone.