### PR TITLE
Bluetooth: hci_driver: Mark Anchor point update report as discardable

### DIFF
--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -512,6 +512,8 @@ static bool event_packet_is_discardable(const uint8_t *hci_buf)
 		switch (subevent) {
 		case SDC_HCI_SUBEVENT_VS_QOS_CONN_EVENT_REPORT:
 			return true;
+		case SDC_HCI_SUBEVENT_VS_CONN_ANCHOR_POINT_UPDATE_REPORT:
+			return true;
 		default:
 			return false;
 		}


### PR DESCRIPTION
This avoids that the all event buffers get full making the system deadlock.

Jira: DRGN-23279