### PR TITLE
samples: bluetooth: event_trigger: Add support for nRF54H20 (cpurad) and nRF54L15

### DIFF
--- a/samples/bluetooth/event_trigger/Kconfig.sysbuild
+++ b/samples/bluetooth/event_trigger/Kconfig.sysbuild
@@ -5,6 +5,6 @@
 #
 
 config NRF_DEFAULT_EMPTY
-	default y
+	default y if SOC_SERIES_NRF53X
 
 source "share/sysbuild/Kconfig"

--- a/samples/bluetooth/event_trigger/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/bluetooth/event_trigger/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	aliases {
+		egu = &egu0;
+	};
+};

--- a/samples/bluetooth/event_trigger/boards/nrf52dk_nrf52832.overlay
+++ b/samples/bluetooth/event_trigger/boards/nrf52dk_nrf52832.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	aliases {
+		egu = &egu0;
+	};
+};

--- a/samples/bluetooth/event_trigger/boards/nrf5340dk_nrf5340_cpunet.overlay
+++ b/samples/bluetooth/event_trigger/boards/nrf5340dk_nrf5340_cpunet.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	aliases {
+		egu = &egu0;
+	};
+};

--- a/samples/bluetooth/event_trigger/boards/nrf54h20dk_nrf54h20_cpurad.overlay
+++ b/samples/bluetooth/event_trigger/boards/nrf54h20dk_nrf54h20_cpurad.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	aliases {
+		egu = &egu020;
+	};
+};

--- a/samples/bluetooth/event_trigger/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/bluetooth/event_trigger/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	aliases {
+		egu = &egu10;
+	};
+};

--- a/samples/bluetooth/event_trigger/sample.yaml
+++ b/samples/bluetooth/event_trigger/sample.yaml
@@ -9,5 +9,8 @@ tests:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpunet
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpurad
     platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpunet
+      nrf54l15dk/nrf54l15/cpuapp nrf54h20dk/nrf54h20/cpurad
     tags: bluetooth ci_build sysbuild


### PR DESCRIPTION
This PR adds support for nRF54H20 built for radio core and nRF54L15 in event_trigger sample.