### PR TITLE
applications: nrf_desktop: Fix USB next HID configuration

### DIFF
--- a/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/app_mcuboot_qspi.overlay
+++ b/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/app_mcuboot_qspi.overlay
@@ -16,6 +16,15 @@
 		zephyr,entropy = &rng;
 	};
 
+	/* Configure DTS nodes used for USB next HID support. */
+	hid_dev_0: hid_dev_0 {
+		compatible = "zephyr,hid-device";
+		interface-name = "HID0";
+		protocol-code = "mouse";
+		in-polling-rate = <1000>;
+		in-report-size = <64>;
+	};
+
 	pwmleds1 {
 		compatible = "pwm-leds";
 		status = "okay";


### PR DESCRIPTION
Change adds missing USB HID DTS node for nRF52840DK in MCUboot QSPI configuration. This is necessary to support HID over USB when USB next stack is selected.

Jira: NCSDK-27740