### PR TITLE
manifest: add haltium tracing

### DIFF
--- a/scripts/requirements-build.txt
+++ b/scripts/requirements-build.txt
@@ -6,4 +6,4 @@ imagesize>=1.2.0
 intelhex
 pylint
 zcbor~=0.8.0
-nrf-regtool~=5.6.0
+nrf-regtool~=6.0.0

--- a/scripts/requirements-fixed.txt
+++ b/scripts/requirements-fixed.txt
@@ -69,7 +69,7 @@ msgpack==1.0.5            # via python-can
 mypy==1.5.1               # via -r zephyr/scripts/requirements-build-test.txt
 mypy-extensions==1.0.0    # via mypy
 natsort==8.4.0            # via pyocd
-nrf-regtool==5.6.0        # via -r nrf/scripts/requirements-build.txt
+nrf-regtool==6.0.0        # via -r nrf/scripts/requirements-build.txt
 nrfcredstore==1.0.0       # via -r nrf/scripts/requirements-extra.txt
 numpy==1.26.4             # via svada
 packaging==24.0           # via -r zephyr/scripts/requirements-base.txt, pkg-about, pytest, python-can, setuptools-scm, west

--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: f869e11484287622d9a3b63fd50151371966dd0e
+      revision: 3d01dcc251bf3aa2a675941e8ac2b244f776724d
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull in newest sdk-zephyr to support new fields in UICR TRACE that allow tracing via ETM and changes the format of the tddconf binding.