### PR TITLE
CODEOWNERS tweaks

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,8 +4,8 @@
 # Order is important; the last matching pattern takes the most
 # precedence.
 
-# General default
-*					  @nrfconnect/ncs-code-owners
+# No general default entry with `*`. Instead the compliance workflow verifies
+# that all new files are covered by an entry in the CODEOWNERS file.
 
 # Global file patterns
 Kconfig*                                  @nrfconnect/ncs-co-build-system

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,11 +7,6 @@
 # No general default entry with `*`. Instead the compliance workflow verifies
 # that all new files are covered by an entry in the CODEOWNERS file.
 
-# Global file patterns
-Kconfig*                                  @nrfconnect/ncs-co-build-system
-CMakeLists*                               @nrfconnect/ncs-co-build-system
-*.cmake	                                  @nrfconnect/ncs-co-build-system
-
 # Root folder
 /.*					  @nrfconnect/ncs-code-owners
 /CMakeLists.txt                           @nrfconnect/ncs-co-build-system
@@ -434,3 +429,8 @@ CMakeLists*                               @nrfconnect/ncs-co-build-system
 
 # Zephyr module
 /zephyr/                                  @nrfconnect/ncs-co-build-system
+
+# Global override file patterns
+Kconfig*                                  @nrfconnect/ncs-co-build-system
+CMakeLists*                               @nrfconnect/ncs-co-build-system
+*.cmake	                                  @nrfconnect/ncs-co-build-system


### PR DESCRIPTION
```
    codeowners: Remove global default
    
    A global default prevents the codeowners check inside the compliance
    GH actions workflow to do its job of finding new files not covered by an
    entry in the CODEOWNERS file. Remove it.

```

```
    codeowners: Move build system file patterns to the end
    
    In order to ensure that build system-related files are always reviewed
    by the ncs-co-build-system team, move them to the bottom so that they
    override the default per-folder reviewers.
```