### PR TITLE
toolchain: Bump minimum toolchain veresion

### DIFF
--- a/scripts/ncs-toolchain-version-minimum.txt
+++ b/scripts/ncs-toolchain-version-minimum.txt
@@ -1,3 +1,3 @@
 # This file specifies the minimum nRF Connect SDK Toolchain that will be
 # working with this release.
-nrf-connect-sdk-toolchain=2.6.20240605
+nrf-connect-sdk-toolchain=2.7.20240919


### PR DESCRIPTION
2.7.20240919 contains Python 3.12
Required to enforce cmake to pick proper toolchain bundle