### PR TITLE
samples: matter: Fixed DFU using internal flash for nRF54L15

### DIFF
--- a/doc/nrf/protocols/matter/end_product/bootloader.rst
+++ b/doc/nrf/protocols/matter/end_product/bootloader.rst
@@ -56,6 +56,8 @@ Consider the following when defining partitions for your end product:
   This means that performing DFU from one firmware version to another using different partition sizes may not be possible, and you will not be able to change the partition sizes without reprogramming the device.
   Trying to perform DFU between applications that use incompatible partition sizes can result in unwanted application behavior, depending on which partitions are overlapping.
   In some cases, this may corrupt some partitions; in others, this can lead to a DFU failure.
+* The MCUboot requires its `mcuboot_primary` and `mcuboot_secondary` partitions to be located under offsets being aligned to the 4 kB flash page size.
+  Selecting offset values that are not aligned to 4 kB for these partititions will lead to erase failures, and result in a DFU failure.
 
 Settings partition
 ==================

--- a/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp_internal.conf
+++ b/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp_internal.conf
@@ -12,8 +12,8 @@ CONFIG_CHIP_MALLOC_SYS_HEAP_SIZE=10240
 CONFIG_MPSL_WORK_STACK_SIZE=2048
 CONFIG_CHIP_TASK_STACK_SIZE=7168
 
-# Set the NVS sector count to match the settings partition size that is 40 kB for this application.
-CONFIG_SETTINGS_NVS_SECTOR_COUNT=10
+# Set the NVS sector count to match the settings partition size that is 44 kB for this application.
+CONFIG_SETTINGS_NVS_SECTOR_COUNT=11
 
 # Disable SPI
 CONFIG_CHIP_SPI_NOR=n

--- a/samples/matter/template/pm_static_nrf54l15dk_nrf54l15_cpuapp_internal.yml
+++ b/samples/matter/template/pm_static_nrf54l15dk_nrf54l15_cpuapp_internal.yml
@@ -9,43 +9,43 @@ mcuboot_pad:
 app:
   address: 0x7800
   region: flash_primary
-  size: 0xb5000
+  size: 0xb4800
 mcuboot_primary:
   address: 0x7000
   orig_span: &id001
   - app
   - mcuboot_pad
   region: flash_primary
-  size: 0xb5800
+  size: 0xb5000
   span: *id001
 mcuboot_primary_app:
   address: 0x7800
   orig_span: &id002
   - app
   region: flash_primary
-  size: 0xb5000
+  size: 0xb4800
   span: *id002
 mcuboot_secondary:
-  address: 0xbc800
+  address: 0xbc000
   orig_span: &id003
   - mcuboot_secondary_pad
   - mcuboot_secondary_app
   region: flash_primary
-  size: 0xb5800
+  size: 0xb5000
   span: *id003
 mcuboot_secondary_pad:
   region: flash_primary
-  address: 0xbc800
+  address: 0xbc000
   size: 0x800
 mcuboot_secondary_app:
   region: flash_primary
-  address: 0xbd000
-  size: 0xb5000
+  address: 0xbc800
+  size: 0xb4800
 factory_data:
-  address: 0x172000
+  address: 0x171000
   region: flash_primary
   size: 0x1000
 settings_storage:
-  address: 0x173000
+  address: 0x172000
   region: flash_primary
-  size: 0xa000
+  size: 0xb000


### PR DESCRIPTION
The DFU using internal flash for nRF54L15DK does not work properly, because the mcuboot secondary partition offset is not aligned to the 4k. Due to that mcuboot erase operation is not performed properly and trailer information are not removed, what leads to swapping back the old image.

The problems was solved by increasing the settings size, to move all partitions and in result achieve aligned mcuboot partitions offset.