### PR TITLE
suit: Fixed missing Kconfig in push-to-cache configuration

### DIFF
--- a/subsys/suit/Kconfig
+++ b/subsys/suit/Kconfig
@@ -100,6 +100,7 @@ config SUIT_DFU_CANDIDATE_PROCESSING_PUSH_TO_CACHE
 	select SUIT_CACHE_RW
 	select SUIT_MEMPTR_STORAGE
 	select SUIT_STREAM_SINK_FLASH
+	select SUIT_STREAM_SOURCE_MEMPTR
 
 config SUIT_DFU_CANDIDATE_PROCESSING_NONE
 	bool "Disable any processing of the SUIT candidate envelope"


### PR DESCRIPTION
This was not found out until suit_dfu_cleanup was used.