### PR TITLE
net: lib: nrf_cloud: Log connection info from lib

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -406,10 +406,8 @@ Cellular samples
 
 * :ref:`nrf_cloud_rest_fota` sample:
 
-  * Added:
-
-    * Support for setting the FOTA update check interval using the config section in the shadow.
-    * A call to the :c:func:`nrf_cloud_print_details` function and removed redundant logging.
+  * Added support for setting the FOTA update check interval using the config section in the shadow.
+  * Removed redundant logging now done by the :ref:`lib_nrf_cloud` library.
 
 * :ref:`nrf_cloud_multi_service` sample:
 
@@ -417,7 +415,6 @@ Cellular samples
 
     * The :kconfig:option:`CONFIG_TEST_COUNTER_MULTIPLIER` Kconfig option to multiply the number of test counter messages sent, for testing purposes.
     * A handler for new nRF Cloud event type ``NRF_CLOUD_EVT_RX_DATA_DISCON`` to stop sensors and location services.
-    * A call to the :c:func:`nrf_cloud_print_details` function and removed redundant logging.
     * Board support files to enable Wi-Fi scanning for the Thingy:91 X.
     * The :kconfig:option:`CONFIG_SEND_ONLINE_ALERT` Kconfig option to enable calling the :c:func:`nrf_cloud_alert` function on startup.
     * Logging of the `reset reason code <nRF9160 RESETREAS_>`_.
@@ -430,19 +427,21 @@ Cellular samples
     * Renamed the :file:`overlay_nrf7002ek_wifi_coap_no_lte.conf` overlay to :file:`overlay_nrf700x_wifi_coap_no_lte.conf`.
 
   * Fixed an issue where the accepted shadow was not marked as received because the config section did not yet exist in the shadow.
+  * Removed redundant logging now done by the :ref:`lib_nrf_cloud` library.
 
 * :ref:`nrf_cloud_rest_device_message` sample:
 
   * Added:
 
     * Support for dictionary logs using REST.
-    * A call to the :c:func:`nrf_cloud_print_details` function and removed redundant logging.
     * The :kconfig:option:`CONFIG_SEND_ONLINE_ALERT` Kconfig option to enable calling the :c:func:`nrf_cloud_alert` function on startup.
     * Logging of the `reset reason code <nRF9160 RESETREAS_>`_.
 
+  * Removed redundant logging now done by the :ref:`lib_nrf_cloud` library.
+
 * :ref:`nrf_cloud_rest_cell_pos_sample` sample:
 
-    * Added a call to the :c:func:`nrf_cloud_print_details` function and removed redundant logging.
+  * Removed redundant logging now done by the :ref:`lib_nrf_cloud` library.
 
 Cryptography samples
 --------------------
@@ -819,8 +818,9 @@ Libraries for networking
     * The function :c:func:`nrf_cloud_client_id_runtime_set` to set the device ID string if the :kconfig:option:`CONFIG_NRF_CLOUD_CLIENT_ID_SRC_RUNTIME` Kconfig option is enabled.
     * The functions :c:func:`nrf_cloud_sec_tag_set` and :c:func:`nrf_cloud_sec_tag_get` to set and get the sec tag used for nRF Cloud credentials.
     * A new nRF Cloud event type ``NRF_CLOUD_EVT_RX_DATA_DISCON`` which is generated when a device is deleted from nRF Cloud.
-    * The function :c:func:`nrf_cloud_print_details` to log common nRF Cloud connection information in a uniform way.
-    * The :kconfig:option:`CONFIG_NRF_CLOUD_VERBOSE_DETAILS` Kconfig option to enable the :c:func:`nrf_cloud_print_details` function to print all details instead of only the device ID.
+    * The functions :c:func:`nrf_cloud_print_details` and :c:func:`nrf_cloud_print_cloud_details` to log common nRF Cloud connection information in a uniform way.
+    * The :kconfig:option:`CONFIG_NRF_CLOUD_PRINT_DETAILS` Kconfig option to enable the above functions.
+    * The :kconfig:option:`CONFIG_NRF_CLOUD_VERBOSE_DETAILS` Kconfig option to print all details instead of only the device ID.
 
   * Updated:
 

--- a/include/net/nrf_cloud.h
+++ b/include/net/nrf_cloud.h
@@ -714,13 +714,25 @@ int nrf_cloud_uninit(void);
 /**
  * @brief Print details about cloud connection.
  *
- * if @kconfig{CONFIG_NRF_CLOUD_VERBOSE_DETAILS} is not enabled,
+ * If @kconfig{CONFIG_NRF_CLOUD_VERBOSE_DETAILS} is not enabled,
  * only print the device id. If enabled, also print the protocol,
- * sec tag, host name, stage, and team id.
+ * sec tag, and host name.
  *
  * @return A negative value indicates an error.
  */
 int nrf_cloud_print_details(void);
+
+/**
+ * @brief Print details about cloud connection after connected.
+ *
+ * Some information is only available after the device is connected.
+ * When using MQTT, the tenant will be printed.
+ *
+ * When using CoAP and REST, there is no further information to print.
+ *
+ * @return A negative value indicates an error.
+ */
+int nrf_cloud_print_cloud_details(void);
 
 /**
  * @brief Retrieve the IMEI.

--- a/samples/cellular/nrf_cloud_multi_service/src/cloud_connection.c
+++ b/samples/cellular/nrf_cloud_multi_service/src/cloud_connection.c
@@ -255,8 +255,6 @@ static bool connect_cloud(void)
 	/* Clear the disconnected flag, no longer accurate. */
 	k_event_clear(&cloud_events, CLOUD_DISCONNECTED);
 
-	nrf_cloud_print_details();
-
 #if defined(CONFIG_NRF_CLOUD_MQTT)
 	/* Connect to nRF Cloud -- Non-blocking. State updates are handled in callbacks. */
 	err = nrf_cloud_connect();
@@ -467,7 +465,6 @@ static void cloud_event_handler(const struct nrf_cloud_evt *nrf_cloud_evt)
 		 * device's shadow based on the build configuration.
 		 * See config NRF_CLOUD_SEND_SHADOW_INFO for details.
 		 */
-
 		break;
 	case NRF_CLOUD_EVT_SENSOR_DATA_ACK:
 		LOG_DBG("NRF_CLOUD_EVT_SENSOR_DATA_ACK");

--- a/samples/cellular/nrf_cloud_rest_cell_location/src/main.c
+++ b/samples/cellular/nrf_cloud_rest_cell_location/src/main.c
@@ -442,11 +442,7 @@ int init(void)
 		LOG_ERR("Failed to get device ID, error: %d", err);
 		return err;
 	}
-
-	err = nrf_cloud_print_details();
-	if (err) {
-		LOG_ERR("Error printing cloud information: %d", err);
-	}
+	LOG_INF("Device ID: %s", device_id);
 
 	/* Check modem FW version */
 	check_modem_fw_version();

--- a/samples/cellular/nrf_cloud_rest_device_message/src/main.c
+++ b/samples/cellular/nrf_cloud_rest_device_message/src/main.c
@@ -527,11 +527,6 @@ static int init(void)
 		return -EFAULT;
 	}
 
-	err = nrf_cloud_print_details();
-	if (err) {
-		LOG_ERR("Error printing cloud information: %d", err);
-	}
-
 	/* If provisioning library is disabled, ensure device has credentials installed
 	 * before proceeding
 	 */

--- a/samples/cellular/nrf_cloud_rest_fota/src/main.c
+++ b/samples/cellular/nrf_cloud_rest_fota/src/main.c
@@ -347,11 +347,6 @@ int init(void)
 		return -EFAULT;
 	}
 
-	err = nrf_cloud_print_details();
-	if (err) {
-		LOG_ERR("Error printing cloud information: %d", err);
-	}
-
 	err = nrf_cloud_fota_poll_init(&fota_ctx);
 	if (err) {
 		LOG_ERR("FOTA support init failed: %d", err);

--- a/subsys/net/lib/nrf_cloud/Kconfig
+++ b/subsys/net/lib/nrf_cloud/Kconfig
@@ -121,12 +121,19 @@ rsource "Kconfig.nrf_cloud_log"
 
 rsource "Kconfig.nrf_cloud_shadow_info"
 
-config NRF_CLOUD_VERBOSE_DETAILS
-	bool "Log more info about cloud connection"
+config NRF_CLOUD_PRINT_DETAILS
+	bool "Log info about cloud connection"
 	default y
 	help
-	  Log at INF level the stage, protocol, sec tag, host name, and team ID,
-	  in addition to device id.
+	  Log at the INF level the device ID.
+
+config NRF_CLOUD_VERBOSE_DETAILS
+	bool "Log more info about cloud connection"
+	depends on NRF_CLOUD_PRINT_DETAILS
+	default y if NRF_CLOUD_PRINT_DETAILS
+	help
+	  Log at INF level the protocol, sec tag, host name, and team ID,
+	  in addition to device ID.
 
 config NRF_CLOUD_GATEWAY
 	bool "nRF Cloud Gateway"

--- a/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap_transport.c
+++ b/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap_transport.c
@@ -190,6 +190,8 @@ int nrf_cloud_coap_init(void)
 {
 	int err;
 
+	(void)nrf_cloud_print_details();
+
 	internal_cc.authenticated = false;
 
 	if (!internal_cc.initialized) {

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
@@ -133,6 +133,7 @@ int nrf_cloud_init(const struct nrf_cloud_init_param *param)
 	if (err) {
 		return err;
 	}
+	(void)nrf_cloud_print_details();
 
 	app_event_handler = param->event_handler;
 

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fsm.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fsm.c
@@ -627,6 +627,7 @@ static int dc_connection_handler(const struct nct_evt *nct_evt)
 		nfsm_set_current_state_and_notify(STATE_DC_CONNECTED, &evt);
 	}
 
+	(void)nrf_cloud_print_cloud_details();
 	return 0;
 }
 

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_rest.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_rest.c
@@ -172,6 +172,13 @@ static void close_connection(struct nrf_cloud_rest_context *const rest_ctx)
 static void init_rest_client_request(struct nrf_cloud_rest_context const *const rest_ctx,
 	struct rest_client_req_context *const req, const enum http_method meth)
 {
+	static bool printed;
+
+	if (!printed) {
+		printed = true;
+		(void)nrf_cloud_print_details();
+	}
+
 	memset(req, 0, sizeof(*req));
 
 	req->connect_socket	= rest_ctx->connect_socket;

--- a/tests/subsys/net/lib/nrf_cloud/cloud/CMakeLists.txt
+++ b/tests/subsys/net/lib/nrf_cloud/cloud/CMakeLists.txt
@@ -46,6 +46,7 @@ if (CONFIG_NRF_CLOUD_MQTT OR CONFIG_NRF_CLOUD_FOTA OR CONFIG_NRF_MODEM_LIB)
 			${ZEPHYR_NRF_MODULE_DIR}/subsys/net/lib/nrf_cloud/src/nrf_cloud_fsm.c
 			${ZEPHYR_NRF_MODULE_DIR}/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
 			${ZEPHYR_NRF_MODULE_DIR}/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec.c
+			${ZEPHYR_NRF_MODULE_DIR}/subsys/net/lib/nrf_cloud/src/nrf_cloud_info.c
 			DIRECTORY ${ZEPHYR_NRF_MODULE_DIR}/subsys/net/lib/nrf_cloud/
 			PROPERTIES HEADER_FILE_ONLY ON
 		)

--- a/tests/subsys/net/lib/nrf_cloud/cloud/src/fakes.h
+++ b/tests/subsys/net/lib/nrf_cloud/cloud/src/fakes.h
@@ -45,6 +45,7 @@ FAKE_VOID_FUNC(nrf_cloud_free, void *);
 FAKE_VALUE_FUNC(int, poll, struct zsock_pollfd *, int, int);
 FAKE_VALUE_FUNC(int, nrf_cloud_obj_cloud_encode, struct nrf_cloud_obj *const);
 FAKE_VALUE_FUNC(int, nrf_cloud_obj_cloud_encoded_free, struct nrf_cloud_obj *const);
+FAKE_VALUE_FUNC(int, nrf_cloud_print_details);
 
 /* Custom fakes implementation */
 int fake_nct_initialize__succeeds(const struct nrf_cloud_init_param *param)
@@ -345,4 +346,9 @@ int fake_nrf_cloud_obj_cloud_encode__fails(struct nrf_cloud_obj *const obj)
 {
 	ARG_UNUSED(obj);
 	return -ENOMEM;
+}
+
+int fake_nrf_cloud_print_details__succeeds(void)
+{
+	return 0;
 }


### PR DESCRIPTION
Some nRF Cloud connection information is available regardless of whether the device has successfully connected, whereas other information is only available post-connection.

Separate out the post-connection info into a new function, and call both at the appropriate times in the nrf_cloud_libraries.

Remove previous requirement to call these functions from the application.

Jira: IRIS-9653