### PR TITLE
samples: broadcast_config_tool: Verify lc3 header file

### DIFF
--- a/applications/nrf5340_audio/src/modules/lc3_file.c
+++ b/applications/nrf5340_audio/src/modules/lc3_file.c
@@ -12,6 +12,34 @@ LOG_MODULE_REGISTER(sd_card_lc3_file, CONFIG_MODULE_SD_CARD_LC3_FILE_LOG_LEVEL);
 
 #define LC3_FILE_ID 0xCC1C
 
+static void lc3_header_print(struct lc3_file_header *header)
+{
+	if (header == NULL) {
+		LOG_ERR("Nullptr received");
+		return;
+	}
+
+	LOG_DBG("File ID: 0x%04x", header->file_id);
+	LOG_DBG("Header size: %d", header->hdr_size);
+	LOG_DBG("Sample rate: %d Hz", header->sample_rate * 100);
+	LOG_DBG("Bit rate: %d bps", header->bit_rate * 100);
+	LOG_DBG("Channels: %d", header->channels);
+	LOG_DBG("Frame duration: %d us", header->frame_duration * 10);
+	LOG_DBG("Num samples: %d", header->signal_len_lsb | (header->signal_len_msb << 16));
+}
+
+int lc3_header_get(struct lc3_file_ctx *file, struct lc3_file_header *header)
+{
+	if ((file == NULL) || (header == NULL)) {
+		LOG_ERR("Nullptr received");
+		return -EINVAL;
+	}
+
+	*header = file->lc3_header;
+
+	return 0;
+}
+
 int lc3_file_frame_get(struct lc3_file_ctx *file, uint8_t *buffer, size_t buffer_size)
 {
 	int ret;
@@ -82,6 +110,9 @@ int lc3_file_open(struct lc3_file_ctx *file, const char *file_name)
 		LOG_ERR("Failed to read the LC3 header: %d", ret);
 		return ret;
 	}
+
+	/* Debug: Print header */
+	lc3_header_print(&file->lc3_header);
 
 	if (file->lc3_header.file_id != LC3_FILE_ID) {
 		LOG_ERR("Invalid file ID: 0x%04x", file->lc3_header.file_id);

--- a/applications/nrf5340_audio/src/modules/lc3_file.h
+++ b/applications/nrf5340_audio/src/modules/lc3_file.h
@@ -32,6 +32,17 @@ struct lc3_file_ctx {
 };
 
 /**
+ * @brief Get the LC3 header from the file.
+ *
+ * @param[in]	file	Pointer to the file context.
+ * @param[out]	header	Pointer to the header structure to store the header.
+ *
+ * @retval -EINVAL	Invalid file context.
+ * @retval 0		Success.
+ */
+int lc3_header_get(struct lc3_file_ctx *file, struct lc3_file_header *header);
+
+/**
  * @brief Get the next LC3 frame from the file.
  *
  * @param[in]	file		Pointer to the file context.

--- a/applications/nrf5340_audio/src/modules/lc3_streamer.h
+++ b/applications/nrf5340_audio/src/modules/lc3_streamer.h
@@ -12,14 +12,20 @@
 #include <stdbool.h>
 #include <sys/types.h>
 
+struct lc3_stream_cfg {
+	uint32_t sample_rate_hz;
+	uint32_t bit_rate_bps;
+	uint32_t frame_duration_us;
+};
+
 /**
  * @brief Get the next frame for the stream.
  *
- * @details Populates a pointer to the buffer holding the next frame. This buffer is valid until
- *          the next call to this function. or stream is closed.
+ * @details	Populates a pointer to the buffer holding the next frame. This buffer is valid until
+ *		the next call to this function. or stream is closed.
  *
- * @param[in]   streamer_idx    Index of the streamer to get the next frame from.
- * @param[out]  frame_buffer    Pointer to the buffer holding the next frame.
+ * @param[in]	streamer_idx	Index of the streamer to get the next frame from.
+ * @param[out]	frame_buffer	Pointer to the buffer holding the next frame.
  *
  * @retval 0		Success.
  * @retval -EINVAL	Invalid streamer index.
@@ -29,6 +35,22 @@
  *			streaming. Call lc3_streamer_end_stream to clean context.
  */
 int lc3_streamer_next_frame_get(const uint8_t streamer_idx, const uint8_t **const frame_buffer);
+
+/**
+ * @brief Verify that the LC3 header matches the stream configuration.
+ *
+ * @details	Verifies that the file is valid and can be used by the LC3 streamer.
+ *		Since there is no standard header for LC3 files, the header might be different than
+ *		what is defined in the struct lc3_file_header.
+ *
+ * @param[in]	filename	Name of the file to verify.
+ * @param[in]	cfg		Stream configuration to compare against.
+ *
+ * @retval	true	Success.
+ * @retval	false	Header is not matching the configuration.
+ */
+bool lc3_streamer_file_header_verify(const char *const filename,
+				     const struct lc3_stream_cfg *const cfg);
 
 /**
  * @brief Register a new stream that will be played by the LC3 streamer.
@@ -63,10 +85,10 @@ uint8_t lc3_streamer_num_active_streams(void);
  *          truncated.
  *
  * @param[in]	streamer_idx	Index of the streamer.
- * @param[out]	path		Pointer for string to store filepath in.
+ * @param[out]	path		Pointer for string to store file path in.
  * @param[in]	path_len	Length of string buffer.
  *
- * @retval	-EINVAL		Nullpointers or invalid index given.
+ * @retval	-EINVAL		Null pointers or invalid index given.
  * @retval	0		Success.
  */
 int lc3_streamer_file_path_get(const uint8_t streamer_idx, char *const path, const size_t path_len);


### PR DESCRIPTION
- Compare the header file of a LC3 file with the configuration of a stream.
- Print a warning if there is a mismatch, but do not halt process
- OCT-3120