### PR TITLE
ci: docbuild: move Doxygen content out of html dir

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -143,7 +143,8 @@ jobs:
           declare -a DOXYGEN=("nrfx")
 
           for docset in "${DOXYGEN[@]}"; do
-            OUTDIR=doc/_build/html/$docset
+            OUTDIR=doc/_build/html-doxygen/$docset-apis
+            mv doc/_build/html/$docset "$OUTDIR"
 
             # Populate custom.properties, tags.yml
             cp doc/_zoomin/$docset.apis.custom.properties "$OUTDIR/custom.properties"


### PR DESCRIPTION
Otherwise it gets mixed with Sphinx content when uploading to Zoomin.