### PR TITLE
doc: remove redundant bootloader links

### DIFF
--- a/doc/nrf/app_dev/bootloaders_dfu/mcuboot_nsib/bootloader_quick_start.rst
+++ b/doc/nrf/app_dev/bootloaders_dfu/mcuboot_nsib/bootloader_quick_start.rst
@@ -61,8 +61,6 @@ This setup supports both UART and Bluetooth® LE connections.
 The following samples are supported:
 
 * :zephyr:code-sample:`smp-svr`
-* :ref:`smp_svr_ext_xip`
-* :ref:`bootloader`
 * :ref:`zephyr:with_mcuboot`
 
 .. rst-class:: numbered-step


### PR DESCRIPTION
Removes redundant links.
These shouldn't be listed for quick start under samples