### PR TITLE
manifest: Update sdk-zephyr for LRCCONF manager

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: b83478a230e79d24d69592274f2a93c9c83958a9
+      revision: ed625337f3e5b79221d6185f90287e94843728fe
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Due to the possibility of simultaneous accesess to LRCCONF registers, additional management is required.