### PR TITLE
applications: serial_lte_modem: Remove thingy91 nativetls

### DIFF
--- a/applications/serial_lte_modem/sample.yaml
+++ b/applications/serial_lte_modem/sample.yaml
@@ -28,12 +28,10 @@ tests:
       - nrf9161dk/nrf9161/ns
       - nrf9151dk/nrf9151/ns
       - nrf9131ek/nrf9131/ns
-      - thingy91/nrf9160/ns
       - thingy91x/nrf9151/ns
     integration_platforms:
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-      - thingy91/nrf9160/ns
     tags: ci_build sysbuild
   applications.serial_lte_modem.lwm2m_carrier:
     sysbuild: true


### PR DESCRIPTION
Native TLS overlay no longer fits to thingy91 flash. Remove it from sample.yaml. The combination was already marked as not supported in documentation.