### PR TITLE
samples: coremark: Add nrf52833 to integration tests in cormark

### DIFF
--- a/samples/benchmarks/coremark/sample.yaml
+++ b/samples/benchmarks/coremark/sample.yaml
@@ -10,6 +10,7 @@ tests:
     build_only: false
     platform_allow:
       - nrf52840dk/nrf52840
+      - nrf52833dk/nrf52833
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
@@ -17,6 +18,7 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
+      - nrf52833dk/nrf52833
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
@@ -48,6 +50,7 @@ tests:
     build_only: true
     platform_allow:
       - nrf52840dk/nrf52840
+      - nrf52833dk/nrf52833
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
@@ -55,6 +58,7 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
+      - nrf52833dk/nrf52833
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
@@ -67,6 +71,7 @@ tests:
     build_only: true
     platform_allow:
       - nrf52840dk/nrf52840
+      - nrf52833dk/nrf52833
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
@@ -74,6 +79,7 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
+      - nrf52833dk/nrf52833
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp

--- a/scripts/quarantine_integration.yaml
+++ b/scripts/quarantine_integration.yaml
@@ -517,6 +517,7 @@
     - sample.benchmark.coremark
   platforms:
     - nrf52dk/nrf52832
+    - nrf52833dk/nrf52833
   comment: "Configurations excluded to limit resources usage in integration builds"
 
 - scenarios:
@@ -529,6 +530,7 @@
     - sample.benchmark.coremark_static
   platforms:
     - nrf52dk/nrf52832
+    - nrf52833dk/nrf52833
     - nrf5340dk/nrf5340/cpuapp
     - nrf54l15dk/nrf54l15/cpuapp
     - nrf54l15pdk/nrf54l15/cpuapp
@@ -539,6 +541,7 @@
     - sample.benchmark.coremark_multithread
   platforms:
     - nrf52dk/nrf52832
+    - nrf52833dk/nrf52833
     - nrf5340dk/nrf5340/cpuapp
     - nrf54l15dk/nrf54l15/cpuapp
     - nrf54l15pdk/nrf54l15/cpuapp


### PR DESCRIPTION
This should make    nrf52833 visible in table:  “The sample supports the following development kits:”  in documentation.

JIRA: NCSDK-27719