### PR TITLE
doc: small cleanup for nrf54l15 docs

### DIFF
--- a/doc/nrf/app_dev/device_guides/nrf54l/features.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54l/features.rst
@@ -1,23 +1,23 @@
 .. _nrf54l_features:
 
-Features of the nRF54L15 PDK
-############################
+Features of the nRF54L Series
+#############################
 
 .. contents::
    :local:
    :depth: 2
 
-The nRF54L15 PDK embeds an Arm® Cortex®-M33 processor with multiprotocol 2.4 GHz transceiver and supports Bluetooth® 5.4.
+The nRF54L15 DK embeds an Arm® Cortex®-M33 processor with multiprotocol 2.4 GHz transceiver and supports Bluetooth® 5.4.
 
 For additional information, see the following documentation:
 
-* Zephyr page on the :ref:`zephyr:nrf54l15pdk_nrf54l15`
+* Zephyr page on the :ref:`zephyr:nrf54l15dk_nrf54l15`
 * :ref:`installation` and :ref:`configuration_and_build` documentation to install the |NCS| and learn more about its development environment.
 
 Supported protocols
 *******************
 
-The nRF54L15 PDK supports Bluetooth Low Energy (LE), proprietary protocols (including Enhanced ShockBurst), Matter, and Thread.
+The nRF54L15 DK supports Bluetooth Low Energy (LE), proprietary protocols (including Enhanced ShockBurst), Matter, and Thread.
 
 Amazon Sidewalk
 ===============
@@ -37,7 +37,7 @@ This stack is split into two core components: the Bluetooth Host and the Bluetoo
 The :ref:`ug_ble_controller` user guide contains more information about the two available Bluetooth LE Controllers, and instructions for switching between them.
 
 See the :ref:`zephyr:bluetooth` section of the Zephyr documentation for information on the Bluetooth Host and open source Bluetooth LE Controller.
-The |NCS| contains :ref:`ble_samples` that can be run on the nRF54L15 PDK device.
+The |NCS| contains :ref:`ble_samples` that can be run on the nRF54L15 DK device.
 In addition, you can run the :ref:`zephyr:bluetooth-samples` that are included from Zephyr.
 
 For available libraries, see :ref:`lib_bluetooth_services` (|NCS|) and :ref:`zephyr:bluetooth_api` (Zephyr).
@@ -90,18 +90,18 @@ See the :ref:`nfc_samples` and :ref:`lib_nfc` for the samples and libraries that
 MCUboot bootloader support
 **************************
 
-The nRF54L15 PDK supports MCUboot as its bootloader, in the experimental phase.
+The nRF54L15 DK supports MCUboot as its bootloader, in the experimental phase.
 This means the following:
 
   * Only software cryptography is supported.
-  * Single image pair is supported for dual-bank Device Firmware Update (DFU) targeted at the CPU application (the ``nrf54l15pdk/nrf54l51/cpuapp`` board target).
+  * Single image pair is supported for dual-bank Device Firmware Update (DFU) targeted at the CPU application (the ``nrf54l15dk/nrf54l51/cpuapp`` board target).
   * MCUboot can be configured as a first-stage bootloader (second-stage bootloader functionality is not yet available).
   * Serial recovery mode is also not yet supported.
 
 Supported DFU protocols
 =======================
 
-The DFU process in the nRF54L15 PDK uses the MCUmgr protocol.
+The DFU process in the nRF54L15 DK uses the MCUmgr protocol.
 It can be used for performing updates over Bluetooth® Low Energy (LE) and serial connections.
 
 For instructions on testing, see :ref:`nrf54l_testing_dfu`.

--- a/doc/nrf/app_dev/device_guides/nrf54l/index.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54l/index.rst
@@ -22,17 +22,11 @@ Zephyr and the |NCS| provide support and contain board definitions for developin
      - Board target
      - Documentation
      - Product pages
-   * - :ref:`zephyr:nrf54l15pdk_nrf54l15`
+   * - :ref:`zephyr:nrf54l15dk_nrf54l15`
      - PCA10156
-     - | ``nrf54l15pdk@0.2.1/nrf54l15/cpuapp`` for the PDK revision v0.2.1, AB0-ES7 (Engineering A).
-       | ``nrf54l15pdk/nrf54l15/cpuapp`` for the PDK revisions v0.3.0 and v0.7.0 (Engineering A).
+     - ``nrf54l15dk/nrf54l51/cpuapp``
      - :ref:`Getting started <gsg_other>`
      - `nRF54L15 System-on-Chip`_
-
-.. note::
-
-  The v0.2.1 revision of the nRF54L15 PDK has **Button 3** and **Button 4** connected to GPIO port 2 that do not support interrupts.
-  The workaround for this issue is enabled by default with the :kconfig:option:`CONFIG_DK_LIBRARY_BUTTON_NO_ISR` Kconfig option, but it increases the overall power consumption of the system.
 
 .. toctree::
    :maxdepth: 2

--- a/doc/nrf/app_dev/device_guides/nrf54l/testing_dfu.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54l/testing_dfu.rst
@@ -3,10 +3,10 @@
 Testing the DFU solution
 ########################
 
-You can evaluate the DFU functionality by running the :zephyr:code-sample:`smp-svr` sample for the ``nrf54l15pdk/nrf54l51/cpuapp`` board target, which is available for both Bluetooth® LE and serial channels.
+You can evaluate the DFU functionality by running the :zephyr:code-sample:`smp-svr` sample for the ``nrf54l15dk/nrf54l51/cpuapp`` board target, which is available for both Bluetooth® LE and serial channels.
 This allows you to build and test the DFU solutions that are facilitated through integration with child images and the partition manager.
 
-To compile the SMP server sample for testing secondary image slots on external SPI NOR flash, run the command based on your partitioning method.
+To compile the SMP server sample for testing secondary image slots on external SPI NOR flash, make sure you are in the :file:`ncs` directory and run the command based on the selected partitioning method.
 
 .. tabs::
 
@@ -16,7 +16,7 @@ To compile the SMP server sample for testing secondary image slots on external S
 
       .. code-block:: console
 
-         west build -b nrf54l15pdk/nrf54l15/cpuapp -d build/smp_svr_54l zephyr/samples/subsys/mgmt/mcumgr/smp_svr -T sample.mcumgr.smp_svr.bt.nrf54l15pdk.ext_flash
+         west build -b nrf54l15dk/nrf54l15/cpuapp -d build/smp_svr_54l zephyr/samples/subsys/mgmt/mcumgr/smp_svr -T sample.mcumgr.smp_svr.bt.nrf54l15pdk.ext_flash
 
    .. group-tab:: DTS partitioning
 
@@ -24,14 +24,7 @@ To compile the SMP server sample for testing secondary image slots on external S
 
       .. code-block:: console
 
-         west build -b nrf54l15pdk/nrf54l15/cpuapp -d build/smp_svr_54l_d zephyr/samples/subsys/mgmt/mcumgr/smp_svr -T sample.mcumgr.smp_svr.bt.nrf54l15pdk.ext_flash.pure_dts
+         west build -b nrf54l15dk/nrf54l15/cpuapp -d build/smp_svr_54l_d zephyr/samples/subsys/mgmt/mcumgr/smp_svr -T sample.mcumgr.smp_svr.bt.nrf54l15pdk.ext_flash.pure_dts
 
-.. note::
-
-   Make sure to use the correct board target depending on your PDK version:
-
-   * For the PDK revision v0.2.1, AB0-ES7, use the ``nrf54l15pdk@0.2.1/nrf54l15/cpuap`` board target.
-   * For the PDK revisions v0.3.0 and v0.7.0, use the ``nrf54l15pdk/nrf54l15/cpuapp`` board target.
-
-This configuration sets up the secondary image slot on the serial flash memory installed on the nRF54L15 PDK.
+This configuration sets up the secondary image slot on the serial flash memory installed on the nRF54L15 DK.
 It also enables the relevant SPI and the SPI NOR flash drivers.


### PR DESCRIPTION
Removed the PDK occurrences for the main nrf54L15 articles.
Updated references.