### PR TITLE
drivers: mpsl: Simplify flash operations logging

### DIFF
--- a/drivers/mpsl/flash_sync/flash_sync_mpsl.c
+++ b/drivers/mpsl/flash_sync/flash_sync_mpsl.c
@@ -141,7 +141,6 @@ int nrf_flash_sync_init(void)
 
 void nrf_flash_sync_set_context(uint32_t duration)
 {
-	LOG_DBG("duration: %u", duration);
 	_context.request_length_us = duration;
 }
 
@@ -168,7 +167,7 @@ bool nrf_flash_sync_is_required(void)
 
 int nrf_flash_sync_exe(struct flash_op_desc *op_desc)
 {
-	LOG_DBG("");
+	LOG_DBG("duration: %u", _context.request_length_us);
 
 	int errcode = MULTITHREADING_LOCK_ACQUIRE();
 	__ASSERT_NO_MSG(errcode == 0);


### PR DESCRIPTION
Reduce the number of log messages per flash operation from 2 to 1, making it easier to analyze complex logs that include debug information from the flash driver as well.