### PR TITLE
samples: bluetooth: mesh: Add nRF54L15 support for samples with mcuboot

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -378,7 +378,19 @@ Bluetooth Fast Pair samples
 Bluetooth Mesh samples
 ----------------------
 
-|no_changes_yet_note|
+* Added support for the :ref:`zephyr:nrf54l15dk_nrf54l15` board in the following samples:
+
+  * :ref:`bluetooth_mesh_sensor_client`
+  * :ref:`bluetooth_mesh_sensor_server`
+  * :ref:`bluetooth_ble_peripheral_lbs_coex`
+  * :ref:`bt_mesh_chat`
+  * :ref:`bluetooth_mesh_light_switch`
+  * :ref:`bluetooth_mesh_silvair_enocean`
+  * :ref:`bluetooth_mesh_light_dim`
+  * :ref:`bluetooth_mesh_light`
+  * :ref:`bluetooth_mesh_light_lc`
+  * :ref:`ble_mesh_dfu_target`
+  * :ref:`ble_mesh_dfu_distributor`
 
 Cellular samples
 ----------------

--- a/samples/bluetooth/mesh/dfu/distributor/sample.yaml
+++ b/samples/bluetooth/mesh/dfu/distributor/sample.yaml
@@ -7,7 +7,8 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf54l15pdk/nrf54l15/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf54l15pdk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+    platform_allow: nrf52840dk/nrf52840 nrf54l15pdk/nrf54l15/cpuapp nrf54l15dk/nrf54l15/cpuapp
     tags: bluetooth ci_build sysbuild
   sample.bluetooth.mesh_dfu_distributor.smp_bt_auth:
     sysbuild: true
@@ -15,6 +16,7 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf54l15pdk/nrf54l15/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf54l15pdk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+    platform_allow: nrf52840dk/nrf52840 nrf54l15pdk/nrf54l15/cpuapp nrf54l15dk/nrf54l15/cpuapp
     extra_args: OVERLAY_CONFIG=overlay-smp-bt-auth.conf
     tags: bluetooth ci_build sysbuild

--- a/samples/bluetooth/mesh/dfu/target/sample.yaml
+++ b/samples/bluetooth/mesh/dfu/target/sample.yaml
@@ -8,5 +8,7 @@ tests:
       - nrf52840dk/nrf52840
       - nrf52840dongle/nrf52840
       - nrf54l15pdk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
     platform_allow: nrf52840dk/nrf52840 nrf52840dongle/nrf52840 nrf54l15pdk/nrf54l15/cpuapp
+      nrf54l15dk/nrf54l15/cpuapp
     tags: bluetooth ci_build sysbuild

--- a/samples/bluetooth/mesh/light/sample.yaml
+++ b/samples/bluetooth/mesh/light/sample.yaml
@@ -14,9 +14,11 @@ tests:
       - thingy53/nrf5340/cpuapp
       - nrf21540dk/nrf52840
       - nrf54l15pdk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
     platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
       nrf5340dk/nrf5340/cpuapp/ns thingy53/nrf5340/cpuapp
       nrf21540dk/nrf52840 nrf52833dk/nrf52833 nrf54l15pdk/nrf54l15/cpuapp
+      nrf54l15dk/nrf54l15/cpuapp
     tags: bluetooth ci_build sysbuild
   sample.bluetooth.mesh.light.dfu:
     sysbuild: true
@@ -25,7 +27,9 @@ tests:
       - nrf52840dk/nrf52840
       - nrf21540dk/nrf52840
       - nrf54l15pdk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
     platform_allow: nrf52840dk/nrf52840 nrf21540dk/nrf52840 nrf54l15pdk/nrf54l15/cpuapp
+      nrf54l15dk/nrf54l15/cpuapp
     extra_args:
       - EXTRA_CONF_FILE=overlay-dfu.conf
       - SB_CONF_FILE=sysbuild-dfu.conf


### PR DESCRIPTION
This commit adds support for nRF54L15 for mesh samples that use mcuboot.