### PR TITLE
tests: benchmarks: peripheral_load: Remove test run in coverage mode

### DIFF
--- a/tests/benchmarks/peripheral_load/sample.yaml
+++ b/tests/benchmarks/peripheral_load/sample.yaml
@@ -33,32 +33,6 @@ tests:
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
 
-  sample.benchmarks.peripheral_stress_test.nrf54h_coverage:
-    filter: CONFIG_COVERAGE
-    harness_config:
-      fixture: pca63566
-      type: multi_line
-      ordered: false
-      regex:
-        - ".*Accelerometer thread has completed"
-        - ".*ADC thread has completed"
-        - ".*BME680 thread has completed"
-        - ".*CAN thread has completed"
-        - ".*Counter thread has completed"
-        - ".*Flash thread has completed"
-        - ".*GPIO thread has completed"
-        - ".*PWM thread has completed"
-        - ".*TEMP thread has completed"
-        - ".*Timer thread has completed"
-        - ".*WDT thread has completed"
-        - ".*CPU load thread has completed"
-        - ".*all \\d{1,} threads have completed"
-    extra_args:
-      - SHIELD=pca63566;coverage_support
-    platform_allow: nrf54h20dk/nrf54h20/cpuapp
-    integration_platforms:
-      - nrf54h20dk/nrf54h20/cpuapp
-
   sample.benchmarks.peripheral_stress_test.nrf54l:
     filter: not CONFIG_COVERAGE
     harness_config:
@@ -81,32 +55,6 @@ tests:
         - ".*all \\d{1,} threads have completed"
     extra_args:
       - SHIELD=pca63565
-    platform_allow: nrf54l15dk/nrf54l15/cpuapp
-    integration_platforms:
-      - nrf54l15dk/nrf54l15/cpuapp
-
-  sample.benchmarks.peripheral_stress_test.nrf54l_coverage:
-    filter: CONFIG_COVERAGE
-    harness_config:
-      fixture: pca63565
-      type: multi_line
-      ordered: false
-      regex:
-        - ".*Accelerometer thread has completed"
-        - ".*ADC thread has completed"
-        - ".*BME680 thread has completed"
-        - ".*Counter thread has completed"
-        - ".*Flash thread has completed"
-        - ".*GPIO thread has completed"
-        - ".*I2S thread has completed"
-        - ".*PWM thread has completed"
-        - ".*TEMP thread has completed"
-        - ".*Timer thread has completed"
-        - ".*WDT thread has completed"
-        - ".*CPU load thread has completed"
-        - ".*all \\d{1,} threads have completed"
-    extra_args:
-      - SHIELD=pca63565;coverage_support
     platform_allow: nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp


### PR DESCRIPTION
In coverage mode:
- RAM is overflown by ~30 kB on nRF54L15.
- ROM is overflown by ~30 kB on nRF54H20.

Remove from sample.yaml tests dedicated to be run in a coverage mode as they don't fit into available memory.