### PR TITLE
zigbee: name some unnamed Kconfig options

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -37,7 +37,7 @@
 /applications/sdp/                        @masz-nordic
 /applications/serial_lte_modem/           @nrfconnect/ncs-co-networking @nrfconnect/ncs-iot-oulu
 /applications/serial_lte_modem/src/lwm2m_carrier/ @nrfconnect/ncs-carrier
-/applications/zigbee_weather_station/     @milewr
+/applications/zigbee_weather_station/     @nrfconnect/ncs-zigbee
 /applications/**/*.rst                    @nrfconnect/ncs-doc-owners
 
 # Boards
@@ -209,7 +209,7 @@
 /samples/peripheral/802154_phy_test/      @nrfconnect/ncs-radio-sw
 /samples/peripheral/802154_sniffer/       @e-rk
 /samples/tfm/                             @nrfconnect/ncs-aegir
-/samples/zigbee/                          @milewr
+/samples/zigbee/                          @nrfconnect/ncs-zigbee
 /samples/nrf5340/netboot/                 @nrfconnect/ncs-pluto
 /samples/nrf5340/multiprotocol_rpmsg/     @hubertmis
 /samples/sdfw/                            @nrfconnect/ncs-aurora
@@ -329,7 +329,7 @@
 /subsys/trusted_storage/                  @nrfconnect/ncs-aegir
 /subsys/uart_async_adapter/               @nrfconnect/ncs-si-muffin
 /subsys/net_core_monitor/                 @nrfconnect/ncs-si-muffin
-/subsys/zigbee/                           @milewr
+/subsys/zigbee/                           @nrfconnect/ncs-zigbee
 
 # Sysbuild
 /sysbuild/                                @nrfconnect/ncs-co-build-system
@@ -417,7 +417,7 @@
 /tests/subsys/pcd/                        @nrfconnect/ncs-pluto
 /tests/subsys/nrf_profiler/               @nrfconnect/ncs-si-bluebagel
 /tests/subsys/sdfw_services/              @nrfconnect/ncs-aurora
-/tests/subsys/zigbee/                     @milewr
+/tests/subsys/zigbee/                     @nrfconnect/ncs-zigbee
 /tests/subsys/suit/                       @nrfconnect/ncs-charon
 /tests/tfm/                               @nrfconnect/ncs-aegir @stephen-nordic @magnev
 /tests/unity/                             @nordic-krch

--- a/subsys/zigbee/Kconfig
+++ b/subsys/zigbee/Kconfig
@@ -77,7 +77,7 @@ config ZIGBEE_CHANNEL_MASK
 	   - bits 26..11: bit n enables its corresponding channel
 	   - bits 10..0: UNUSED, should be cleared
 
-choice
+choice ZIGBEE_ROLE
 	prompt "Select Zigbee device role"
 
 config ZIGBEE_ROLE_END_DEVICE
@@ -117,7 +117,7 @@ config ZIGBEE_DEBUG_FUNCTIONS
 	  It may be helpful when debugging but using this functions can cause instability of the device.
 
 # Configure default behavior of zb_osif_abort() function called as ZBOSS assert handler
-choice
+choice ZBOSS_ASSERT_HANDLER
 	prompt "Default behavior for ZBOSS stack internal assert handler"
 	default ZBOSS_RESET_ON_ASSERT
 
@@ -146,7 +146,7 @@ config ZIGBEE_ERROR_TO_STRING_ENABLED
 	  Include functions for mapping ZBOSS errors to string.
 
 # Configure ZBOSS_TRACE_LOG_LEVEL
-choice
+choice ZBOSS_TRACE_LOG_LEVEL_CHOICE
 	prompt "Max compiled-in log level for ZBOSS trace"
 	default ZBOSS_TRACE_LOG_LEVEL_OFF
 
@@ -229,7 +229,7 @@ config ZBOSS_TRAF_DUMP
 
 if ZIGBEE_HAVE_SERIAL
 
-choice
+choice ZBOSS_TRACE_LOGGING_METHOD
 	prompt "Select ZBOSS trace logging method: hexdump, binary, NCP transport"
 	default ZBOSS_TRACE_HEXDUMP_LOGGING
 
@@ -260,7 +260,7 @@ endif # (ZBOSS_TRACE_HEXDUMP_LOGGING || ZBOSS_TRACE_BINARY_LOGGING)
 
 if ZBOSS_TRACE_BINARY_LOGGING
 
-choice
+choice ZBOSS_TRACE_LOGGING_BACKEND
 	prompt "Backend used to log ZBOSS Traces"
 	default ZBOSS_TRACE_UART_LOGGING
 
@@ -368,7 +368,7 @@ config ZIGBEE_TC_REJOIN_ENABLED
 
 DT_CHOSEN_NCS_ZIGBEE_TIMER := ncs,zigbee-timer
 
-choice
+choice ZIGBEE_TIME_SOURCE
 	prompt "ZBOSS time source"
 	default ZIGBEE_TIME_COUNTER if ZIGBEE_LIBRARY_PRODUCTION && \
 		$(dt_chosen_enabled,$(DT_CHOSEN_NCS_ZIGBEE_TIMER))


### PR DESCRIPTION
Make sure all choices under `ZIGBEE` have a name.