### PR TITLE
doc: Update devictree link in include file

### DIFF
--- a/doc/nrf/includes/sample_fem_support.txt
+++ b/doc/nrf/includes/sample_fem_support.txt
@@ -1,20 +1,20 @@
 You can add support for the nRF21540 front-end module to this sample by using one of the following options, depending on your hardware:
 
 * Build the sample for one board that contains the nRF21540 FEM, such as :ref:`nrf21540dk/nrf52840 <zephyr:nrf21540dk_nrf52840>`.
-* Manually create a devicetree overlay file that describes how FEM is connected to the nRF5 SoC in your device.
-  See :ref:`zephyr:set-devicetree-overlays` for different ways of adding the overlay file.
-* Provide nRF21540 FEM capabilities by using a :ref:`shield <zephyr:shields>`, for example the :ref:`ug_radio_fem_nrf21540ek` shield that is available in the |NCS|.
-  In this case, build the project for a board connected to the shield you are using with an appropriate variable included in the build command, for example ``SHIELD=nrf21540ek``.
+* Manually create a devicetree overlay file that describes how the nRF21540 FEM is connected to the SoC.
+  See :ref:`configuring_devicetree` for different ways of adding the overlay file.
+* Provide nRF21540 FEM capabilities by using a :ref:`shield <zephyr:shields>`, for example the :ref:`nRF21540 EK <ug_radio_fem_nrf21540ek>` shield that is available in the |NCS|.
+  In this case, build the project for a board connected to the shield you are using with an appropriate variable included in the build command, for example ``-DSHIELD=nrf21540ek``.
   This variable instructs the build system to append the appropriate devicetree overlay file.
 
   .. tabs::
 
      .. group-tab:: nRF Connect for VS Code
 
-        To build the sample in the nRF Connect for VS Code IDE for an nRF52840 DK with the nRF21540 EK attached, add the shield variable in the build configuration's :guilabel:`Extra CMake arguments` and rebuild the build configuration.
+        To build the sample in the |nRFVSC| for an nRF52840 DK with the nRF21540 EK attached, add the shield variable in the build configuration's :guilabel:`Extra CMake arguments` and rebuild the build configuration.
         For example: ``-DSHIELD=nrf21540ek``.
 
-        See `nRF Connect for VS Code extension pack <How to work with build configurations_>`_ documentation for more information.
+        See `How to work with build configurations`_ in the |nRFVSC| documentation for more information.
 
      .. group-tab:: Command line
 
@@ -24,7 +24,7 @@ You can add support for the nRF21540 front-end module to this sample by using on
 
            west build -b nrf52840dk/nrf52840 -- -DSHIELD=nrf21540ek
 
-  See :ref:`Programming nRF21540 EK <ug_radio_fem_nrf21540ek_programming>` for information about how to program when you are using a board with a network core, for example nRF5340 DK.
+  See :ref:`Programming nRF21540 EK <ug_radio_fem_nrf21540ek_programming>` for information about how to program when you are using a board with a network core, for example the nRF5340 DK.
 
 Each of these options adds the description of the nRF21540 FEM to the devicetree.
 See :ref:`ug_radio_fem` for more information about FEM in the |NCS|.


### PR DESCRIPTION
The `sample_fem_support.txt` include file links to Zephyr documentation for information on configuring devicetree. This updates the link to point to the Configuring devicetree page in the nRF Connect SDK documentation instead.

Also makes other small improvements to the file.