### PR TITLE
net: lib: nrf_cloud: add log source

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -849,8 +849,13 @@ Libraries for networking
 
 * :ref:`lib_nrf_cloud_log` library:
 
-  * Added support for dictionary logs using REST.
-  * Added support for dictionary (binary) logs when connected to nRF Cloud using CoAP.
+  * Added:
+
+    * Support for dictionary logs using REST.
+    * Support for dictionary (binary) logs when connected to nRF Cloud using CoAP.
+
+  * Fixed the missing log source when passing a direct log call to the nRF Cloud logging backend.
+    This caused the log parser to incorrectly use the first declared log source with direct logs when using dictionary mode.
 
 * :ref:`lib_nrf_cloud_fota` library:
 

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_log.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_log.c
@@ -90,8 +90,20 @@ static void log_inject(int log_level, const char *fmt, va_list ap)
 	/* Idempotent so is OK to call every time. */
 	nrf_cloud_log_init();
 
+	const void *source;
+
+	/* There is no logging API call to retrieve a pointer to the current source.
+	 * Instead, access it using the local variable name declared by the
+	 * LOG_MODULE_REGISTER macro.
+	 */
+#if defined(CONFIG_LOG_RUNTIME_FILTERING)
+	source = __log_current_dynamic_data;
+#else
+	source = __log_current_const_data;
+#endif
+
 	/* Cloud logging is enabled, so send it through the main logging system. */
-	z_log_msg_runtime_vcreate(Z_LOG_LOCAL_DOMAIN_ID, NULL, log_level,
+	z_log_msg_runtime_vcreate(Z_LOG_LOCAL_DOMAIN_ID, source, log_level,
 				  NULL, 0, Z_LOG_MSG_CBPRINTF_FLAGS(0), fmt, ap);
 }
 

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_log_backend.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_log_backend.c
@@ -24,7 +24,7 @@
 #include <net/nrf_cloud_coap.h>
 #include <net/nrf_cloud_log.h>
 
-LOG_MODULE_DECLARE(nrf_cloud_log, CONFIG_NRF_CLOUD_LOG_LOG_LEVEL);
+LOG_MODULE_REGISTER(nrf_cloud_log_backend, CONFIG_NRF_CLOUD_LOG_LOG_LEVEL);
 
 #define RING_BUF_SIZE CONFIG_NRF_CLOUD_LOG_RING_BUF_SIZE
 
@@ -112,7 +112,7 @@ static const char * const filtered_modules[] = {
 	"net_ipv4",
 	"net_ipv6",
 	"nrf_cloud",
-	"nrf_cloud_log",
+	"nrf_cloud_log_backend",
 	"nrf_cloud_codec",
 	"nrf_cloud_codec_internal"
 };


### PR DESCRIPTION
When using direct log calls with the logging backend enabled, associate a valid log source with the
injected log entry.

Jira: IRIS-9302