### PR TITLE
lib: lte_link_control: deprecate factory reset

### DIFF
--- a/doc/nrf/releases_and_maturity/migration/migration_guide_2.8.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_guide_2.8.rst
@@ -137,6 +137,23 @@ LTE link control library
      * Remove the use of the ``CONFIG_LTE_NETWORK_USE_FALLBACK`` Kconfig option.
        Use the :kconfig:option:`CONFIG_LTE_NETWORK_MODE_LTE_M_NBIOT` or :kconfig:option:`CONFIG_LTE_NETWORK_MODE_LTE_M_NBIOT_GPS` Kconfig option instead.
        In addition, you can control the priority between LTE-M and NB-IoT using the :kconfig:option:`CONFIG_LTE_MODE_PREFERENCE` Kconfig option.
+     * Replace the use of the :c:func:`lte_lc_factory_reset` function with the following:
+
+      * If the :c:enumerator:`LTE_LC_FACTORY_RESET_ALL` value is used with the :c:func:`lte_lc_factory_reset` function:
+
+         .. code-block:: C
+
+            #include <nrf_modem_at.h>
+
+            err = nrf_modem_at_printf("AT%%XFACTORYRESET=0");
+
+      * If the :c:enumerator:`LTE_LC_FACTORY_RESET_USER` value is used with the :c:func:`lte_lc_factory_reset` function:
+
+         .. code-block:: C
+
+            #include <nrf_modem_at.h>
+
+            err = nrf_modem_at_printf("AT%%XFACTORYRESET=1");
 
 AT command parser
 -----------------

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -749,6 +749,11 @@ Modem libraries
 
     * To use the :ref:`at_parser_readme` library instead of the :ref:`at_cmd_parser_readme` library.
     * The :c:func:`lte_lc_neighbor_cell_measurement` function to return an error for invalid GCI count.
+    * The :c:func:`lte_lc_factory_reset` function has been deprecated.
+      Use the ``AT%XFACTORYRESET`` AT command instead.
+      Refer to the :ref:`migration guide <migration_2.8>` for more details.
+    * The :c:enum:`lte_lc_factory_reset_type` type has been deprecated.
+      Refer to the :ref:`migration guide <migration_2.8>` for more details.
 
 * :ref:`lib_location` library:
 

--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -742,7 +742,11 @@ enum lte_lc_modem_evt {
 	LTE_LC_MODEM_EVT_CE_LEVEL_3,
 };
 
-/** Type of factory reset to perform. */
+/**
+ * Type of factory reset to perform.
+ *
+ * @deprecated since v2.8.0.
+ */
 enum lte_lc_factory_reset_type {
 	/** Reset all modem data to factory settings. */
 	LTE_LC_FACTORY_RESET_ALL = 0,
@@ -1789,6 +1793,8 @@ int lte_lc_reduced_mobility_set(enum lte_lc_reduced_mobility_mode mode);
  *
  * @retval 0 if factory reset was performed successfully.
  * @retval -EFAULT if an AT command failed.
+ *
+ * @deprecated since v2.8.0.
  */
 int lte_lc_factory_reset(enum lte_lc_factory_reset_type type);
 

--- a/samples/cellular/modem_shell/src/link/link.h
+++ b/samples/cellular/modem_shell/src/link/link.h
@@ -19,7 +19,18 @@ enum link_ncellmeas_modes {
 #define LINK_FUNMODE_NONE 99
 #define LINK_SYSMODE_NONE 99
 #define LINK_REDMOB_NONE 99
-#define LTE_LC_FACTORY_RESET_INVALID 99
+
+/** Type of factory reset to perform. */
+enum link_factory_reset_type {
+	/** Reset all modem data to factory settings. */
+	LINK_FACTORY_RESET_ALL = 0,
+
+	/** Reset user-configurable data to factory settings. */
+	LINK_FACTORY_RESET_USER = 1,
+
+	/** Invalid type. */
+	LINK_FACTORY_RESET_INVALID = 99
+};
 
 void link_init(void);
 void link_ind_handler(const struct lte_lc_evt *const evt);

--- a/samples/cellular/modem_shell/src/link/link_settings.c
+++ b/samples/cellular/modem_shell/src/link/link_settings.c
@@ -801,12 +801,12 @@ void link_sett_defaults_set(void)
 	mosh_print("link settings reseted");
 }
 
-void link_sett_modem_factory_reset(enum lte_lc_factory_reset_type type)
+void link_sett_modem_factory_reset(enum link_factory_reset_type type)
 {
 	int err;
 
 	/* Reset modem factory settings by type */
-	err = lte_lc_factory_reset(type);
+	err = nrf_modem_at_printf("AT%%XFACTORYRESET=%d", type);
 	if (err) {
 		mosh_error("Resetting modem factory settings failed, err %d", err);
 	} else {

--- a/samples/cellular/modem_shell/src/link/link_settings.h
+++ b/samples/cellular/modem_shell/src/link/link_settings.h
@@ -7,6 +7,8 @@
 #ifndef MOSH_LINK_SETTINGS_H
 #define MOSH_LINK_SETTINGS_H
 
+#include "link.h"
+
 int link_sett_init(void);
 
 void link_sett_defaults_set(void);
@@ -56,6 +58,6 @@ bool link_sett_is_normal_mode_autoconn_enabled(void);
 bool link_sett_is_normal_mode_autoconn_rel14_used(void);
 void link_sett_normal_mode_autoconn_shell_print(void);
 
-void link_sett_modem_factory_reset(enum lte_lc_factory_reset_type type);
+void link_sett_modem_factory_reset(enum link_factory_reset_type type);
 
 #endif /* MOSH_LINK_SETTINGS_H */

--- a/samples/cellular/modem_shell/src/link/link_shell.c
+++ b/samples/cellular/modem_shell/src/link/link_shell.c
@@ -2354,7 +2354,7 @@ show_usage:
 static int link_shell_settings(const struct shell *shell, size_t argc, char **argv)
 {
 	enum link_shell_operation operation = LINK_OPERATION_NONE;
-	enum lte_lc_factory_reset_type mreset_type = LTE_LC_FACTORY_RESET_INVALID;
+	enum link_factory_reset_type mreset_type = LINK_FACTORY_RESET_INVALID;
 
 	optreset = 1;
 	optind = 1;
@@ -2372,10 +2372,10 @@ static int link_shell_settings(const struct shell *shell, size_t argc, char **ar
 			break;
 
 		case LINK_SHELL_OPT_MRESET_ALL:
-			mreset_type = LTE_LC_FACTORY_RESET_ALL;
+			mreset_type = LINK_FACTORY_RESET_ALL;
 			break;
 		case LINK_SHELL_OPT_MRESET_USER:
-			mreset_type = LTE_LC_FACTORY_RESET_USER;
+			mreset_type = LINK_FACTORY_RESET_USER;
 			break;
 
 		case 'h':
@@ -2395,7 +2395,7 @@ static int link_shell_settings(const struct shell *shell, size_t argc, char **ar
 	if (operation == LINK_OPERATION_READ) {
 		link_sett_all_print();
 	} else if (operation == LINK_OPERATION_RESET ||
-		   mreset_type != LTE_LC_FACTORY_RESET_INVALID) {
+		   mreset_type != LINK_FACTORY_RESET_INVALID) {
 		if (operation == LINK_OPERATION_RESET) {
 			link_sett_defaults_set();
 			if (SYS_MODE_PREFERRED != LINK_SYSMODE_NONE) {
@@ -2403,10 +2403,10 @@ static int link_shell_settings(const struct shell *shell, size_t argc, char **ar
 						       CONFIG_LTE_MODE_PREFERENCE_VALUE);
 			}
 		}
-		if (mreset_type == LTE_LC_FACTORY_RESET_ALL) {
-			link_sett_modem_factory_reset(LTE_LC_FACTORY_RESET_ALL);
-		} else if (mreset_type == LTE_LC_FACTORY_RESET_USER) {
-			link_sett_modem_factory_reset(LTE_LC_FACTORY_RESET_USER);
+		if (mreset_type == LINK_FACTORY_RESET_ALL) {
+			link_sett_modem_factory_reset(mreset_type);
+		} else if (mreset_type == LINK_FACTORY_RESET_USER) {
+			link_sett_modem_factory_reset(mreset_type);
 		}
 	} else {
 		goto show_usage;


### PR DESCRIPTION
Deprecate factory reset API. This functionality is trivial to implement and doesn't need a whole API within the Link Controller.