### PR TITLE
lib: lte_link_control: deprecate reduced mobility

### DIFF
--- a/doc/nrf/releases_and_maturity/migration/migration_guide_2.8.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_guide_2.8.rst
@@ -155,6 +155,47 @@ LTE link control library
 
             err = nrf_modem_at_printf("AT%%XFACTORYRESET=1");
 
+     * Replace the use of the :c:func:`lte_lc_reduced_mobility_get` function with the following:
+
+      .. code-block:: C
+
+         #include <nrf_modem_at.h>
+
+         uint16_t mode;
+
+         ret = nrf_modem_at_scanf("AT%REDMOB?", "%%REDMOB: %hu", &mode);
+         if (ret != 1) {
+            /* Handle failure. */
+         } else {
+            /* Handle success. */
+         }
+
+     * Replace the use of the :c:func:`lte_lc_reduced_mobility_set` function with the following:
+
+      * If the :c:enumerator:`LTE_LC_REDUCED_MOBILITY_DEFAULT` value is used with the :c:func:`lte_lc_reduced_mobility_set` function:
+
+         .. code-block:: C
+
+            #include <nrf_modem_at.h>
+
+            err = nrf_modem_at_printf("AT%%REDMOB=0");
+
+      * If the :c:enumerator:`LTE_LC_REDUCED_MOBILITY_NORDIC` value is used with the :c:func:`lte_lc_reduced_mobility_set` function:
+
+         .. code-block:: C
+
+            #include <nrf_modem_at.h>
+
+            err = nrf_modem_at_printf("AT%%REDMOB=1");
+
+      * If the :c:enumerator:`LTE_LC_REDUCED_MOBILITY_DISABLED` value is used with the :c:func:`lte_lc_reduced_mobility_set` function:
+
+         .. code-block:: C
+
+            #include <nrf_modem_at.h>
+
+            err = nrf_modem_at_printf("AT%%REDMOB=2");
+
 AT command parser
 -----------------
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -753,6 +753,9 @@ Modem libraries
       Use the ``AT%XFACTORYRESET`` AT command instead.
       Refer to the :ref:`migration guide <migration_2.8>` for more details.
     * The :c:enum:`lte_lc_factory_reset_type` type has been deprecated.
+    * The :c:func:`lte_lc_reduced_mobility_get` and :c:func:`lte_lc_reduced_mobility_set` functions have been deprecated.
+      Refer to the :ref:`migration guide <migration_2.8>` for more details.
+    * The :c:enum:`lte_lc_reduced_mobility_mode` type has been deprecated.
       Refer to the :ref:`migration guide <migration_2.8>` for more details.
 
 * :ref:`lib_location` library:

--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -652,7 +652,10 @@ enum lte_lc_ce_level {
 	LTE_LC_CE_LEVEL_UNKNOWN	= UINT8_MAX,
 };
 
-/** Reduced mobility mode. */
+/** Reduced mobility mode.
+ *
+ *  @deprecated since v2.8.0.
+ */
 enum lte_lc_reduced_mobility_mode {
 	/** Functionality according to the 3GPP relaxed monitoring feature. */
 	LTE_LC_REDUCED_MOBILITY_DEFAULT = 0,
@@ -1767,6 +1770,8 @@ int lte_lc_periodic_search_request(void);
  * @retval 0 if a mode was found and written to the provided pointer.
  * @retval -EINVAL if input parameter was @c NULL.
  * @retval -EFAULT if an AT command failed.
+ *
+ * @deprecated since v2.8.0.
  */
 int lte_lc_reduced_mobility_get(enum lte_lc_reduced_mobility_mode *mode);
 
@@ -1779,6 +1784,8 @@ int lte_lc_reduced_mobility_get(enum lte_lc_reduced_mobility_mode *mode);
  *
  * @retval 0 if the new reduced mobility mode was accepted by the modem.
  * @retval -EFAULT if an AT command failed.
+ *
+ * @deprecated since v2.8.0.
  */
 int lte_lc_reduced_mobility_set(enum lte_lc_reduced_mobility_mode mode);
 

--- a/samples/cellular/modem_shell/src/link/link.h
+++ b/samples/cellular/modem_shell/src/link/link.h
@@ -18,7 +18,6 @@ enum link_ncellmeas_modes {
 
 #define LINK_FUNMODE_NONE 99
 #define LINK_SYSMODE_NONE 99
-#define LINK_REDMOB_NONE 99
 
 /** Type of factory reset to perform. */
 enum link_factory_reset_type {
@@ -30,6 +29,25 @@ enum link_factory_reset_type {
 
 	/** Invalid type. */
 	LINK_FACTORY_RESET_INVALID = 99
+};
+
+/** Reduced mobility mode. */
+enum link_reduced_mobility_mode {
+	/** Functionality according to the 3GPP relaxed monitoring feature. */
+	LINK_REDUCED_MOBILITY_DEFAULT = 0,
+
+	/** Enable Nordic-proprietary reduced mobility feature. */
+	LINK_REDUCED_MOBILITY_NORDIC = 1,
+
+	/**
+	 * Full measurements for best possible mobility.
+	 *
+	 * Disable the 3GPP relaxed monitoring and Nordic-proprietary reduced mobility features.
+	 */
+	LINK_REDUCED_MOBILITY_DISABLED = 2,
+
+	/** Invalid type. */
+	LINK_REDUCED_MOBILITY_NONE = 99
 };
 
 void link_init(void);

--- a/samples/cellular/modem_shell/src/link/link_shell.c
+++ b/samples/cellular/modem_shell/src/link/link_shell.c
@@ -1998,7 +1998,7 @@ static int link_shell_redmob(const struct shell *shell, size_t argc, char **argv
 {
 	int ret;
 	enum link_shell_operation operation = LINK_OPERATION_NONE;
-	enum lte_lc_reduced_mobility_mode redmob_mode = LINK_REDMOB_NONE;
+	enum link_reduced_mobility_mode redmob_mode = LINK_REDUCED_MOBILITY_NONE;
 	char snum[10];
 
 	optreset = 1;
@@ -2017,10 +2017,10 @@ static int link_shell_redmob(const struct shell *shell, size_t argc, char **argv
 			break;
 
 		case LINK_SHELL_OPT_REDMOB_DEFAULT:
-			redmob_mode = LTE_LC_REDUCED_MOBILITY_DEFAULT;
+			redmob_mode = LINK_REDUCED_MOBILITY_DEFAULT;
 			break;
 		case LINK_SHELL_OPT_REDMOB_NORDIC:
-			redmob_mode = LTE_LC_REDUCED_MOBILITY_NORDIC;
+			redmob_mode = LINK_REDUCED_MOBILITY_NORDIC;
 			break;
 
 		case 'h':
@@ -2038,21 +2038,21 @@ static int link_shell_redmob(const struct shell *shell, size_t argc, char **argv
 	}
 
 	if (operation == LINK_OPERATION_DISABLE) {
-		redmob_mode = LTE_LC_REDUCED_MOBILITY_DISABLED;
+		redmob_mode = LINK_REDUCED_MOBILITY_DISABLED;
 	}
 	if (operation == LINK_OPERATION_READ) {
-		enum lte_lc_reduced_mobility_mode mode;
+		enum link_reduced_mobility_mode mode;
 
-		ret = lte_lc_reduced_mobility_get(&mode);
-		if (ret) {
+		ret = nrf_modem_at_scanf("AT%REDMOB?", "%%REDMOB: %hu", &mode);
+		if (ret != 1) {
 			mosh_error("Cannot get reduced mobility mode: %d", ret);
 		} else {
 			mosh_print(
 				"Reduced mobility mode read successfully: %s",
 				link_shell_redmob_mode_to_string(mode, snum));
 		}
-	} else if (redmob_mode != LINK_REDMOB_NONE) {
-		ret = lte_lc_reduced_mobility_set(redmob_mode);
+	} else if (redmob_mode != LINK_REDUCED_MOBILITY_NONE) {
+		ret = nrf_modem_at_printf("AT%%REDMOB=%d", redmob_mode);
 		if (ret) {
 			mosh_error("Cannot set reduced mobility mode: %d", ret);
 		} else {


### PR DESCRIPTION
Deprecate reduced mobility API. This functionality is trivial to implement and doesn't need a whole API within the Link Controller.