### PR TITLE
lib: nrf_modem_lib: Turn off CONFIG_COAP_CLIENT_TRUNCATE_MSGS

### DIFF
--- a/lib/nrf_modem_lib/Kconfig.modemlib
+++ b/lib/nrf_modem_lib/Kconfig.modemlib
@@ -10,6 +10,12 @@ config HEAP_MEM_POOL_SIZE
 	int
 	default 512
 
+# Redefine this symbol as Zephyr defines this as y by
+# default, but the offloading layer does not support it.
+config COAP_CLIENT_TRUNCATE_MSGS
+	bool
+	default n if NRF_MODEM_LIB
+
 menu "Memory configuration"
 
 config NRF_MODEM_LIB_HEAP_SIZE


### PR DESCRIPTION
This is to prepare for eventual upmerge of https://github.com/zephyrproject-rtos/zephyr/pull/79155. An earlier version of that is included in the pre-NCS 2.8.0 upmerge already, but that earlier version had the new Kconfig defaulting to n.

This upstream Zephyr PR will default it to y, but is not compatible with the modem's socket implementation, so turn it off here.
