### PR TITLE
lib: lte_lc: deprecate LTE_LC_ON_CFUN

### DIFF
--- a/doc/nrf/libraries/modem/lte_lc.rst
+++ b/doc/nrf/libraries/modem/lte_lc.rst
@@ -184,40 +184,6 @@ To enable modem sleep and TAU pre-warning notifications, enable the following op
 
 For additional configurations related to these features, see the API documentation.
 
-Functional mode changes callback
-================================
-
-The library allows the application to define compile-time callbacks to receive the modem's functional mode changes.
-These callbacks allow any part of the application to perform certain operations when the modem enters or re-enters a certain functional mode using the library :c:func:`lte_lc_func_mode_set` API.
-For example, one kind of operation that the application or a library may need to perform and repeat, whenever the modem enters a certain functional mode is the subscription to AT notifications.
-The application can set up a callback for modem`s functional mode changes using the :c:macro:`LTE_LC_ON_CFUN` macro.
-
-.. important::
-   When the :c:macro:`LTE_LC_ON_CFUN` macro is used, the application must not call :c:func:`nrf_modem_at_cfun_handler_set` as that will override the handler set by the modem library integration layer.
-
-.. note::
-   The CFUN callback is not supported with :c:func:`nrf_modem_at_cmd_async`.
-
-The following code snippet shows how to use the :c:macro:`LTE_LC_ON_CFUN` macro:
-
-.. code-block:: c
-
-   /* Define a callback */
-   LTE_LC_ON_CFUN(cfun_hook, on_cfun, NULL);
-
-   /* Callback implementation */
-   static void on_cfun(enum lte_lc_func_mode mode, void *context)
-   {
-           printk("Functional mode changed to %d\n", mode);
-   }
-
-   int main(void)
-   {
-           /* Change functional mode using the LTE link control API */
-           lte_lc_func_mode_set(LTE_LC_FUNC_MODE_NORMAL);
-           return 0;
-   }
-
 Dependencies
 ************
 

--- a/doc/nrf/libraries/modem/nrf_modem_lib/nrf_modem_lib_wrapper.rst
+++ b/doc/nrf/libraries/modem/nrf_modem_lib/nrf_modem_lib_wrapper.rst
@@ -40,7 +40,7 @@ The result of the initialization and the callback context are provided to these 
   The callback can be used to perform modem and library configurations that require the modem to be turned on in offline mode.
   The callback cannot be used to change the modem's functional mode.
   Calls to :c:func:`lte_lc_connect` and ``CFUN`` AT calls are not allowed, and must be done after :c:func:`nrf_modem_lib_init` has returned.
-  If a library needs to perform operations after the link is up, it can use the :ref:`lte_lc_readme` and subscribe to a :c:macro:`LTE_LC_ON_CFUN` callback.
+  If a library needs to perform operations after the link is up, it can use the :c:macro:`NRF_MODEM_LIB_ON_CFUN` callback.
 
 Callbacks for the macro :c:macro:`NRF_MODEM_LIB_ON_INIT` must have the signature ``void callback_name(int ret, void *ctx)``, where ``ret`` is the result of the initialization and ``ctx`` is the context passed to the macro.
 The callbacks registered using the :c:macro:`NRF_MODEM_LIB_ON_SHUTDOWN` macro are executed before the library is shut down.

--- a/doc/nrf/releases_and_maturity/migration/migration_guide_2.8.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_guide_2.8.rst
@@ -134,6 +134,7 @@ LTE link control library
      * Replace the use of the :c:func:`lte_lc_deinit` function with the :c:func:`lte_lc_power_off` function.
      * Replace the use of the :c:func:`lte_lc_init_and_connect` function with the :c:func:`lte_lc_connect` function.
      * Replace the use of the :c:func:`lte_lc_init_and_connect_async` function with the :c:func:`lte_lc_connect_async` function.
+     * Replace the use of the :c:macro:`LTE_LC_ON_CFUN` macro with the :c:macro:`NRF_MODEM_LIB_ON_CFUN` macro.
      * Remove the use of the ``CONFIG_LTE_NETWORK_USE_FALLBACK`` Kconfig option.
        Use the :kconfig:option:`CONFIG_LTE_NETWORK_MODE_LTE_M_NBIOT` or :kconfig:option:`CONFIG_LTE_NETWORK_MODE_LTE_M_NBIOT_GPS` Kconfig option instead.
        In addition, you can control the priority between LTE-M and NB-IoT using the :kconfig:option:`CONFIG_LTE_MODE_PREFERENCE` Kconfig option.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -748,9 +748,10 @@ Modem libraries
       Use the :kconfig:option:`CONFIG_LTE_NETWORK_MODE_LTE_M_NBIOT` or :kconfig:option:`CONFIG_LTE_NETWORK_MODE_LTE_M_NBIOT_GPS` Kconfig option instead.
       In addition, you can control the priority between LTE-M and NB-IoT using the :kconfig:option:`CONFIG_LTE_MODE_PREFERENCE` Kconfig option.
 
-  * Added:
+  * Deprecated the :c:macro:`LTE_LC_ON_CFUN` macro.
+    Use the :c:macro:`NRF_MODEM_LIB_ON_CFUN` macro instead.
 
-    * A new :c:enum:`LTE_LC_EVT_RAI_UPDATE` event that is enabled with the :kconfig:option:`CONFIG_LTE_RAI_REQ` Kconfig option.
+  * Added a new :c:enum:`LTE_LC_EVT_RAI_UPDATE` event that is enabled with the :kconfig:option:`CONFIG_LTE_RAI_REQ` Kconfig option.
 
   * Updated:
 

--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -1193,6 +1193,8 @@ struct lte_lc_cfun_cb {
  * @param name Callback name.
  * @param _callback Callback function.
  * @param _context User-defined context.
+ *
+ * @deprecated since v2.8.0, use @ref NRF_MODEM_LIB_ON_CFUN instead.
  */
 #define LTE_LC_ON_CFUN(name, _callback, _context)                                                  \
 	static void _callback(enum lte_lc_func_mode, void *ctx);                                   \

--- a/include/modem/nrf_modem_lib.h
+++ b/include/modem/nrf_modem_lib.h
@@ -166,8 +166,7 @@ struct nrf_modem_lib_at_cfun_cb {
  * configurations that require the modem to be turned on in offline mode. It cannot be used to
  * change the modem functional mode. Calls to @c lte_lc_connect and CFUN AT calls are not
  * allowed, and must be done after @c nrf_modem_lib_init has returned. If a library needs to
- * perform operations after the link is up, it can use the link controller and subscribe to a
- * @c LTE_LC_ON_CFUN callback.
+ * perform operations after the link is up, it can subscribe to a @c NRF_MODEM_LIB_ON_CFUN callback.
  *
  * @param name Callback name
  * @param _callback Callback function name

--- a/lib/date_time/date_time_modem.c
+++ b/lib/date_time/date_time_modem.c
@@ -22,6 +22,9 @@ LOG_MODULE_DECLARE(date_time, CONFIG_DATE_TIME_LOG_LEVEL);
 
 extern struct k_work_q date_time_work_q;
 
+#define MODEM_CFUN_NORMAL 1
+#define MODEM_CFUN_ACTIVATE_LTE 21
+
 #if defined(CONFIG_DATE_TIME_AUTO_UPDATE)
 /* AT monitor for %XTIME notifications */
 AT_MONITOR(xtime, "%XTIME", date_time_at_xtime_handler);
@@ -241,7 +244,7 @@ static void date_time_modem_on_cfun(int mode, void *ctx)
 {
 	ARG_UNUSED(ctx);
 
-	if (mode == LTE_LC_FUNC_MODE_NORMAL || mode == LTE_LC_FUNC_MODE_ACTIVATE_LTE) {
+	if (mode == MODEM_CFUN_NORMAL || mode == MODEM_CFUN_ACTIVATE_LTE) {
 		k_work_submit_to_queue(&date_time_work_q, &date_time_modem_xtime_subscribe_work);
 	}
 }

--- a/samples/cellular/modem_callbacks/README.rst
+++ b/samples/cellular/modem_callbacks/README.rst
@@ -23,7 +23,7 @@ Overview
 
 The sample performs the following operations:
 
-1. Registers callbacks during compile time for modem initialization, functional mode changes, and shutdown using the :c:macro:`NRF_MODEM_LIB_ON_INIT`, :c:macro:`LTE_LC_ON_CFUN` and :c:macro:`NRF_MODEM_LIB_ON_SHUTDOWN` macros respectively.
+1. Registers callbacks during compile time for modem initialization, functional mode changes, and shutdown using the :c:macro:`NRF_MODEM_LIB_ON_INIT`, :c:macro:`NRF_MODEM_LIB_ON_CFUN` and :c:macro:`NRF_MODEM_LIB_ON_SHUTDOWN` macros respectively.
 #. Initializes the :ref:`nrfxlib:nrf_modem`.
 #. Changes functional mode using the :c:func:`lte_lc_func_mode_set` function in the :ref:`lte_lc_readme` library
 #. Shuts down the :ref:`nrfxlib:nrf_modem`.

--- a/samples/cellular/modem_trace_backend/src/main.c
+++ b/samples/cellular/modem_trace_backend/src/main.c
@@ -10,10 +10,10 @@
 #include <nrf_modem_at.h>
 
 /* define callback */
-LTE_LC_ON_CFUN(cfun_hook, on_cfun, NULL);
+NRF_MODEM_LIB_ON_CFUN(cfun_hook, on_cfun, NULL);
 
 /* callback implementation */
-static void on_cfun(enum lte_lc_func_mode mode, void *context)
+static void on_cfun(int mode, void *context)
 {
 	printk("LTE mode changed to %d\n", mode);
 }

--- a/samples/cellular/modem_trace_flash/src/main.c
+++ b/samples/cellular/modem_trace_flash/src/main.c
@@ -25,10 +25,10 @@ LOG_MODULE_REGISTER(modem_trace_flash_sample, CONFIG_MODEM_TRACE_FLASH_SAMPLE_LO
 
 static const struct device *const uart_dev = DEVICE_DT_GET(UART1_DT_NODE);
 
-LTE_LC_ON_CFUN(cfun_hook, on_cfun, NULL);
+NRF_MODEM_LIB_ON_CFUN(cfun_hook, on_cfun, NULL);
 
 /* Callback for when modem functional mode is changed */
-static void on_cfun(enum lte_lc_func_mode mode, void *context)
+static void on_cfun(int mode, void *context)
 {
 	LOG_INF("LTE mode changed to %d\n", mode);
 }

--- a/tests/lib/sms/src/sms_test.c
+++ b/tests/lib/sms/src/sms_test.c
@@ -32,10 +32,15 @@ static void sms_callback(struct sms_data *const data, void *context);
  */
 extern void at_monitor_dispatch(const char *at_notif);
 
-/* lte_lc_on_modem_cfun() is implemented in SMS library and
+
+#define CFUN_MODE_OFFLINE 0
+#define CFUN_MODE_NORMAL 1
+#define CFUN_MODE_ACTIVATE_LTE 21
+
+/* sms_on_cfun() is implemented in SMS library and
  * we'll call it directly to fake notification of functional modem change
  */
-extern void lte_lc_on_modem_cfun(int mode, void *ctx);
+extern void sms_on_cfun(int mode, void *ctx);
 
 /* sms_ack_resp_handler() is implemented in SMS library and
  * we'll call it directly to fake response to AT+CNMA=1.
@@ -330,7 +335,7 @@ void test_sms_lte_lc_cb_reregisteration(void)
 
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT+CFUN=4", 0);
 	lte_lc_func_mode_set(LTE_LC_FUNC_MODE_OFFLINE);
-	lte_lc_on_modem_cfun(LTE_LC_FUNC_MODE_OFFLINE, NULL);
+	sms_on_cfun(CFUN_MODE_OFFLINE, NULL);
 
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT+CEREG=5", 0);
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT+CSCON=1", 0);
@@ -348,7 +353,7 @@ void test_sms_lte_lc_cb_reregisteration(void)
 #endif
 
 	lte_lc_func_mode_set(LTE_LC_FUNC_MODE_ACTIVATE_LTE);
-	lte_lc_on_modem_cfun(LTE_LC_FUNC_MODE_ACTIVATE_LTE, NULL);
+	sms_on_cfun(CFUN_MODE_ACTIVATE_LTE, NULL);
 
 	sms_unreg_helper();
 }
@@ -375,7 +380,7 @@ void test_sms_lte_lc_cb_registration_already_exists(void)
 	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(cnmi_reg_ok, sizeof(cnmi_reg_ok));
 
 	lte_lc_func_mode_set(LTE_LC_FUNC_MODE_NORMAL);
-	lte_lc_on_modem_cfun(LTE_LC_FUNC_MODE_NORMAL, NULL);
+	sms_on_cfun(CFUN_MODE_NORMAL, NULL);
 
 	sms_unreg_helper();
 }
@@ -392,7 +397,7 @@ void test_sms_lte_lc_cb_reregisteration_fail(void)
 
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT+CFUN=4", 0);
 	lte_lc_func_mode_set(LTE_LC_FUNC_MODE_OFFLINE);
-	lte_lc_on_modem_cfun(LTE_LC_FUNC_MODE_OFFLINE, NULL);
+	sms_on_cfun(CFUN_MODE_OFFLINE, NULL);
 
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT+CEREG=5", 0);
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT+CSCON=1", 0);
@@ -403,7 +408,7 @@ void test_sms_lte_lc_cb_reregisteration_fail(void)
 	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
 
 	lte_lc_func_mode_set(LTE_LC_FUNC_MODE_NORMAL);
-	lte_lc_on_modem_cfun(LTE_LC_FUNC_MODE_NORMAL, NULL);
+	sms_on_cfun(CFUN_MODE_NORMAL, NULL);
 
 	/* Unregister listener. SMS got unregistered already above */
 	sms_unregister_listener(test_handle);
@@ -420,13 +425,13 @@ void test_sms_lte_lc_cb_registeration_not_exists(void)
 {
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT+CFUN=4", 0);
 	lte_lc_func_mode_set(LTE_LC_FUNC_MODE_OFFLINE);
-	lte_lc_on_modem_cfun(LTE_LC_FUNC_MODE_OFFLINE, NULL);
+	sms_on_cfun(CFUN_MODE_OFFLINE, NULL);
 
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT+CEREG=5", 0);
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT+CSCON=1", 0);
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT+CFUN=21", 0);
 	lte_lc_func_mode_set(LTE_LC_FUNC_MODE_ACTIVATE_LTE);
-	lte_lc_on_modem_cfun(LTE_LC_FUNC_MODE_ACTIVATE_LTE, NULL);
+	sms_on_cfun(CFUN_MODE_ACTIVATE_LTE, NULL);
 }
 
 /********* SMS SEND TEXT TESTS ***********************/


### PR DESCRIPTION
Deprecate LTE_LC_ON_CFUN. The application should instead use the NRF_MODEM_LIB_ON_CFUN macro.