### PR TITLE
doc: audio: various fixes

### DIFF
--- a/applications/nrf5340_audio/doc/configuration.rst
+++ b/applications/nrf5340_audio/doc/configuration.rst
@@ -38,10 +38,10 @@ The walkie-talkie demo uses one or two bidirectional streams from the gateway to
 The PDM microphone is used as input on both the gateway and headset device.
 To switch to using the walkie-talkie, set the ``CONFIG_WALKIE_TALKIE_DEMO`` Kconfig option to ``y``  in the :file:`applications/nrf5340_audio/prj.conf` file (for the debug version) or in the :file:`applications/nrf5340_audio/prj_release.conf` file (for the release version).
 
-Enabling the Auracast/Broadcast mode
-====================================
+Enabling the Auracast™ (broadcast) mode
+=======================================
 
-If you want to work with Auracast/broadcast sources and sinks, set the :kconfig:option:`CONFIG_TRANSPORT_BIS` Kconfig option to ``y`` in the :file:`applications/nrf5340_audio/prj.conf` file.
+If you want to work with `Auracast™`_ (broadcast) sources and sinks, set the :kconfig:option:`CONFIG_TRANSPORT_BIS` Kconfig option to ``y`` in the :file:`applications/nrf5340_audio/prj.conf` file.
 
 .. _nrf53_audio_app_configuration_select_bis_two_gateways:
 

--- a/applications/nrf5340_audio/doc/firmware_architecture.rst
+++ b/applications/nrf5340_audio/doc/firmware_architecture.rst
@@ -22,7 +22,7 @@ See the testing steps for each of the application for more information.
 Gateway and headset roles
 *************************
 
-The gateway is a common term for a base device, such as the unicast client or an Auracast/broadast source, often used with USB or analog jack input.
+The gateway is a common term for a base device, such as the unicast client or an `Auracast™`_ (broadcast) source, often used with USB or analog jack input.
 Often, but not always, the gateway is the largest or most stationary device, and is commonly the Bluetooth Central (if applicable).
 
 The headset is a common term for a receiver device that plays back the audio it gets from the gateway.
@@ -62,7 +62,7 @@ Connected Isochronous Stream (CIS)
 Broadcast Isochronous Stream (BIS)
   BIS is a unidirectional communication protocol that allows for broadcasting one or more audio streams from a source device to an unlimited number of receivers that are not connected to the source.
 
-  This is the mode available for the broadcast applications (:ref:`broadcast source<nrf53_audio_broadcast_source_app>` for headset and :ref:`broadcast sink<nrf53_audio_broadcast_sink_app>` for gateway).
+  This is the mode available for the broadcast applications (:ref:`broadcast source<nrf53_audio_broadcast_source_app>` for gateway and :ref:`broadcast sink<nrf53_audio_broadcast_sink_app>` for headset).
   In this mode, you can use the nRF5340 Audio development kit in the role of the gateway or as one of the headsets.
   Use multiple nRF5340 Audio development kits to test BIS having multiple receiving headsets.
 

--- a/doc/nrf/protocols/bt/bt_solutions.rst
+++ b/doc/nrf/protocols/bt/bt_solutions.rst
@@ -6,7 +6,7 @@ Bluetooth® technology provides full stack support for a wide and expanding rang
 Audio streaming
 ***************
 
-The |NCS| supports the Bluetooth LE Audio standard, including Auracast broadcast audio.
+The |NCS| supports the Bluetooth LE Audio standard, including `Auracast™`_ (broadcast) audio.
 See :ref:`nrf53_audio_app` to get started.
 
 Note that Nordic Semiconductor SoCs do not support Bluetooth Classic Audio, which is based on the Bluetooth BR/EDR radio.

--- a/samples/bluetooth/broadcast_config_tool/README.rst
+++ b/samples/bluetooth/broadcast_config_tool/README.rst
@@ -1,13 +1,13 @@
 .. _broadcast_configuration_tool:
 
-Broadcast Configuration Tool
-############################
+Auracast: Broadcast Configuration Tool
+######################################
 
 .. contents::
    :local:
    :depth: 2
 
-The Broadcast Configuration Tool sample implements the :ref:`BIS gateway mode <nrf53_audio_app_overview>` and may act as an Auracast broadcaster if you are using a preset compatible with Auracast.
+The Broadcast Configuration Tool sample implements the :ref:`BIS gateway mode <nrf53_audio_app_overview>` and may act as an `Auracast™`_ broadcaster if you are using a preset compatible with Auracast.
 The sample features a shell interface that allows you to configure the broadcast source in many different ways.
 
 In the BIS gateway mode, transmitting audio from the broadcast source happens using Broadcast Isochronous Stream (BIS) and Broadcast Isochronous Group (BIG).


### PR DESCRIPTION
Fixed inverted, incorrect info on the architecture page.
Added TMs and link to Auracast where needed.
Added Auracast to the name of the BCT to categorize it on the list of BT samples.
NCSDK-29427.