### PR TITLE
esb, nfc: fix Doxygen issues

### DIFF
--- a/include/esb.h
+++ b/include/esb.h
@@ -22,7 +22,6 @@ extern "C" {
 
 /** @defgroup esb Enhanced ShockBurst
  * @{
- * @ingroup proprietary_api
  *
  * @brief Enhanced ShockBurst (ESB) is a basic protocol that supports two-way
  *        data packet communication including packet buffering, packet

--- a/include/nfc/ndef/ch_msg.h
+++ b/include/nfc/ndef/ch_msg.h
@@ -11,7 +11,6 @@
  *
  * @defgroup nfc_ndef_ch_msg NFC Connection Hanover messages
  * @{
- * @ingroup nfc_ndef_messages
  *
  * @brief Generation of The Connection Handover NDEF messages.
  *

--- a/include/nfc/ndef/le_oob_rec.h
+++ b/include/nfc/ndef/le_oob_rec.h
@@ -11,7 +11,6 @@
  *
  * @defgroup nfc_ndef_le_oob_rec LE OOB records
  * @{
- * @ingroup  nfc_ndef_messages
  *
  * @brief    Generation of NFC NDEF LE OOB records for NDEF messages.
  *

--- a/include/nfc/ndef/msg.h
+++ b/include/nfc/ndef/msg.h
@@ -18,7 +18,6 @@ extern "C" {
  *
  * @defgroup nfc_ndef_msg Custom NDEF messages
  * @{
- * @ingroup  nfc_modules
  *
  * @brief    Generation of NFC NDEF messages for the NFC tag.
  *

--- a/include/nfc/ndef/text_rec.h
+++ b/include/nfc/ndef/text_rec.h
@@ -11,7 +11,6 @@
  *
  * @defgroup nfc_text_rec Text records
  * @{
- * @ingroup  nfc_ndef_messages
  *
  * @brief    Generation of NFC NDEF Text record descriptions.
  *

--- a/include/nfc/ndef/uri_msg.h
+++ b/include/nfc/ndef/uri_msg.h
@@ -11,7 +11,6 @@
  *
  * @defgroup nfc_uri_msg URI messages
  * @{
- * @ingroup  nfc_ndef_messages
  *
  * @brief    Generation of NFC NDEF messages with a URI record.
  *


### PR DESCRIPTION
Remove references to non-existing groups. These are reported on new Doxygen versions (e.g. 1.12).