### PR TITLE
applications: connectivity_bridge: patch usb_serial_str desc buffer size

### DIFF
--- a/applications/connectivity_bridge/src/main.c
+++ b/applications/connectivity_bridge/src/main.c
@@ -15,7 +15,11 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(MODULE);
 
-static uint8_t usb_serial_str[] = "THINGY91_12PLACEHLDRS";
+#if defined(CONFIG_SOC_SERIES_NRF52X)
+static uint8_t usb_serial_str[sizeof("THINGY91_XXXXXXXXXXXX")];
+#else
+static uint8_t usb_serial_str[sizeof("THINGY91X_") + HW_ID_LEN];
+#endif
 
 /* Overriding weak function to set iSerialNumber at runtime. */
 uint8_t *usb_update_sn_string_descriptor(void)


### PR DESCRIPTION
If CONFIG_SPEED_OPTIMIZATIONS=n, the compiler catches a buffer truncation in usb_update_sn_string_descriptor() where the destination usb_serial_str is too small for the full descriptor.

This commit updates the size of the usb_serial_str buffer to match adapt to the size of HW_ID_LEN or the custom descriptor used for the NRF52X SOC (which doesn't support hw_id_get()).

Note that this patch presumes there is no hard limit to the size of the USB descriptor string. If there is such limitation, the size of `buf` should be adjusted to be smaller instead.