### PR TITLE
Memfault LTE metrics improvements

### DIFF
--- a/modules/memfault-firmware-sdk/config/memfault_metrics_heartbeat_extra.def
+++ b/modules/memfault-firmware-sdk/config/memfault_metrics_heartbeat_extra.def
@@ -31,6 +31,8 @@ MEMFAULT_METRICS_KEY_DEFINE(ncs_lte_edrx_ptw_ms, kMemfaultMetricType_Unsigned)
 MEMFAULT_METRICS_KEY_DEFINE(ncs_lte_mode, kMemfaultMetricType_Unsigned)
 MEMFAULT_METRICS_KEY_DEFINE(ncs_lte_on_time_ms, kMemfaultMetricType_Timer)
 MEMFAULT_METRICS_KEY_DEFINE(ncs_lte_reset_loop_detected_count, kMemfaultMetricType_Unsigned)
+MEMFAULT_METRICS_KEY_DEFINE(ncs_lte_cell_id, kMemfaultMetricType_Signed)
+MEMFAULT_METRICS_KEY_DEFINE(ncs_lte_tracking_area_code, kMemfaultMetricType_Signed)
 #endif /* CONFIG_MEMFAULT_NCS_LTE_METRICS */
 
 #ifdef CONFIG_MEMFAULT_NCS_BT_METRICS

--- a/modules/memfault-firmware-sdk/memfault_lte_metrics.c
+++ b/modules/memfault-firmware-sdk/memfault_lte_metrics.c
@@ -99,7 +99,7 @@ static void modem_params_get(void)
 
 	err = modem_info_get_snr(&snr);
 	if (err) {
-		LOG_DBG("Failed to get SNR")
+		LOG_DBG("Failed to get SNR");
 		return;
 	}
 
@@ -120,6 +120,17 @@ static void lte_handler(const struct lte_lc_evt *const evt)
 	}
 
 	switch (evt->type) {
+	case LTE_LC_EVT_CELL_UPDATE:
+		err = MEMFAULT_METRIC_SET_SIGNED(ncs_lte_cell_id, evt->cell.id);
+		if (err) {
+			LOG_ERR("Failed to set ncs_lte_cell_id");
+		}
+
+		err = MEMFAULT_METRIC_SET_SIGNED(ncs_lte_tracking_area_code, evt->cell.tac);
+		if (err) {
+			LOG_ERR("Failed to set ncs_lte_tracking_area_code");
+		}
+		break;
 	case LTE_LC_EVT_NW_REG_STATUS:
 		switch (evt->nw_reg_status) {
 

--- a/modules/memfault-firmware-sdk/memfault_lte_metrics.c
+++ b/modules/memfault-firmware-sdk/memfault_lte_metrics.c
@@ -75,6 +75,7 @@ static void modem_params_get(void)
 
 	err = modem_info_get_rsrp(&rsrp);
 	if (err) {
+		LOG_DBG("Failed to get RSRP");
 		return;
 	}
 
@@ -86,6 +87,7 @@ static void modem_params_get(void)
 
 	err = modem_info_get_current_band(&band);
 	if (err) {
+		LOG_DBG("Failed to get band");
 		return;
 	}
 
@@ -97,6 +99,7 @@ static void modem_params_get(void)
 
 	err = modem_info_get_snr(&snr);
 	if (err) {
+		LOG_DBG("Failed to get SNR")
 		return;
 	}
 


### PR DESCRIPTION
* Add debug level logging when modem_info calls fail.
* Add collection of cell ID and tracking area code metrics when a cell update event is received.