### PR TITLE
bluetooth: fast_pair: Remove the factory reset prepare user action

### DIFF
--- a/doc/nrf/external_comp/bt_fast_pair.rst
+++ b/doc/nrf/external_comp/bt_fast_pair.rst
@@ -850,8 +850,7 @@ Custom user reset action
 
 Use the :kconfig:option:`CONFIG_BT_FAST_PAIR_STORAGE_USER_RESET_ACTION` Kconfig option to enable a custom user reset action that executes together with the factory reset operation.
 To define the custom user reset action, you need to implement the ``bt_fast_pair_factory_reset_user_action_perform`` function in your application code.
-Optionally, you can also define the ``bt_fast_pair_factory_reset_user_action_prepare`` function if you want an earlier notification that the reset operation is due to begin.
-Both functions are defined as weak no-op functions.
+The function is defined as a weak, no-op function.
 Ensure that your reset action implementation executes correctly in the following execution contexts:
 
 * In the :c:func:`bt_fast_pair_factory_reset` function context - The factory reset action is triggered by calling the :c:func:`bt_fast_pair_factory_reset` function.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -653,6 +653,8 @@ Bluetooth libraries and services
       This configuration is now selected only by the Fast Pair use cases that require the Device Information Service (DIS).
     * The default override for the :kconfig:option:`CONFIG_BT_DIS_FW_REV_STR` Kconfig option that was set to :kconfig:option:`CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION` if :kconfig:option:`CONFIG_BOOTLOADER_MCUBOOT` was enabled.
       The default override is now handled in the Kconfig of the Zephyr Device Information Service (DIS) module and is based on Zephyr's :ref:`zephyr:app-version-details` that uses the :file:`VERSION` file.
+    * The :c:func:`bt_fast_pair_factory_reset_user_action_prepare` weak function definition, which could previously be overridden to prepare for the incoming Fast Pair factory reset.
+      You can still override the :c:func:`bt_fast_pair_factory_reset_user_action_perform` weak function to perform custom actions during the Fast Pair factory reset.
 
   * Updated the default values of the following Fast Pair Kconfig options:
 

--- a/subsys/bluetooth/services/fast_pair/fp_storage/Kconfig.fp_storage
+++ b/subsys/bluetooth/services/fast_pair/fp_storage/Kconfig.fp_storage
@@ -25,9 +25,7 @@ config BT_FAST_PAIR_STORAGE_USER_RESET_ACTION
 	  Enable user reset action that executes together with the Fast Pair factory reset
 	  operation within the bt_fast_pair_factory_reset API function. To define the user reset
 	  action, you need to override the weak function definition of the
-	  bt_fast_pair_factory_reset_user_action_perform symbol. Optionally, you can override the
-	  bt_fast_pair_factory_reset_user_action_prepare symbol if you want an earlier notification
-	  that the reset operation is due to begin.
+	  bt_fast_pair_factory_reset_user_action_perform symbol.
 
 config BT_FAST_PAIR_STORAGE_OWNER_ACCOUNT_KEY
 	bool

--- a/subsys/bluetooth/services/fast_pair/fp_storage/fp_storage_ak.c
+++ b/subsys/bluetooth/services/fast_pair/fp_storage/fp_storage_ak.c
@@ -504,13 +504,8 @@ static int fp_storage_ak_reset(void)
 	return 0;
 }
 
-static void reset_prepare(void)
-{
-	/* intentionally left empty */
-}
-
 SETTINGS_STATIC_HANDLER_DEFINE(fp_storage_ak, SETTINGS_AK_SUBTREE_NAME, NULL, fp_settings_set,
 			       NULL, NULL);
 
-FP_STORAGE_MANAGER_MODULE_REGISTER(fp_storage_ak, fp_storage_ak_reset, reset_prepare,
+FP_STORAGE_MANAGER_MODULE_REGISTER(fp_storage_ak, fp_storage_ak_reset,
 				   fp_storage_ak_init, fp_storage_ak_uninit);

--- a/subsys/bluetooth/services/fast_pair/fp_storage/fp_storage_ak_minimal.c
+++ b/subsys/bluetooth/services/fast_pair/fp_storage/fp_storage_ak_minimal.c
@@ -255,11 +255,6 @@ static int fp_storage_ak_reset(void)
 	return 0;
 }
 
-static void reset_prepare_set(void)
-{
-	/* intentionally left empty */
-}
-
 SETTINGS_STATIC_HANDLER_DEFINE(fp_storage_ak_minimal,
 			       SETTINGS_AK_SUBTREE_NAME,
 			       NULL,
@@ -269,6 +264,5 @@ SETTINGS_STATIC_HANDLER_DEFINE(fp_storage_ak_minimal,
 
 FP_STORAGE_MANAGER_MODULE_REGISTER(fp_storage_ak_minimal,
 				   fp_storage_ak_reset,
-				   reset_prepare_set,
 				   fp_storage_ak_init,
 				   fp_storage_ak_uninit);

--- a/subsys/bluetooth/services/fast_pair/fp_storage/fp_storage_clock.c
+++ b/subsys/bluetooth/services/fast_pair/fp_storage/fp_storage_clock.c
@@ -184,11 +184,6 @@ static int fp_storage_clock_reset_perform(void)
 	return 0;
 }
 
-static void fp_storage_clock_reset_prepare(void)
-{
-	/* intentionally left empty */
-}
-
 SETTINGS_STATIC_HANDLER_DEFINE(fp_storage_clock,
 			       SETTINGS_CLOCK_SUBTREE_NAME,
 			       NULL,
@@ -198,6 +193,5 @@ SETTINGS_STATIC_HANDLER_DEFINE(fp_storage_clock,
 
 FP_STORAGE_MANAGER_MODULE_REGISTER(fp_storage_clock,
 				   fp_storage_clock_reset_perform,
-				   fp_storage_clock_reset_prepare,
 				   fp_storage_clock_init,
 				   fp_storage_clock_uninit);

--- a/subsys/bluetooth/services/fast_pair/fp_storage/fp_storage_eik.c
+++ b/subsys/bluetooth/services/fast_pair/fp_storage/fp_storage_eik.c
@@ -193,11 +193,6 @@ static int fp_storage_eik_reset_perform(void)
 	return 0;
 }
 
-static void fp_storage_eik_reset_prepare(void)
-{
-	/* intentionally left empty */
-}
-
 SETTINGS_STATIC_HANDLER_DEFINE(fp_storage_eik,
 			       SETTINGS_EIK_SUBTREE_NAME,
 			       NULL,
@@ -207,6 +202,5 @@ SETTINGS_STATIC_HANDLER_DEFINE(fp_storage_eik,
 
 FP_STORAGE_MANAGER_MODULE_REGISTER(fp_storage_eik,
 				   fp_storage_eik_reset_perform,
-				   fp_storage_eik_reset_prepare,
 				   fp_storage_eik_init,
 				   fp_storage_eik_uninit);

--- a/subsys/bluetooth/services/fast_pair/fp_storage/fp_storage_manager.c
+++ b/subsys/bluetooth/services/fast_pair/fp_storage/fp_storage_manager.c
@@ -42,13 +42,6 @@ static int fp_settings_load_reset_in_progress(size_t len, settings_read_cb read_
 	return 0;
 }
 
-static void modules_reset_prepare(void)
-{
-	STRUCT_SECTION_FOREACH(fp_storage_manager_module, module) {
-		module->module_reset_prepare();
-	}
-}
-
 static int fp_settings_set(const char *name, size_t len, settings_read_cb read_cb, void *cb_arg)
 {
 	int err = 0;
@@ -123,8 +116,6 @@ int fp_storage_factory_reset(void)
 	if (err) {
 		return err;
 	}
-
-	modules_reset_prepare();
 
 	err = modules_reset();
 	if (err) {

--- a/subsys/bluetooth/services/fast_pair/fp_storage/fp_storage_pn.c
+++ b/subsys/bluetooth/services/fast_pair/fp_storage/fp_storage_pn.c
@@ -160,13 +160,8 @@ static int fp_storage_pn_reset(void)
 	return 0;
 }
 
-static void reset_prepare(void)
-{
-	/* intentionally left empty */
-}
-
 SETTINGS_STATIC_HANDLER_DEFINE(fp_storage_pn, SETTINGS_PN_SUBTREE_NAME, NULL, fp_settings_set,
 			       NULL, NULL);
 
-FP_STORAGE_MANAGER_MODULE_REGISTER(fp_storage_pn, fp_storage_pn_reset, reset_prepare,
+FP_STORAGE_MANAGER_MODULE_REGISTER(fp_storage_pn, fp_storage_pn_reset,
 				   fp_storage_pn_init, fp_storage_pn_uninit);

--- a/subsys/bluetooth/services/fast_pair/fp_storage/fp_storage_user_reset_action.c
+++ b/subsys/bluetooth/services/fast_pair/fp_storage/fp_storage_user_reset_action.c
@@ -14,12 +14,6 @@ __weak int bt_fast_pair_factory_reset_user_action_perform(void)
 	return 0;
 }
 
-__weak void bt_fast_pair_factory_reset_user_action_prepare(void)
-{
-	/* intentionally left empty */
-}
-
 FP_STORAGE_MANAGER_MODULE_REGISTER(bt_fast_pair_factory_reset_user_action,
 				   bt_fast_pair_factory_reset_user_action_perform,
-				   bt_fast_pair_factory_reset_user_action_prepare,
 				   NULL, NULL);

--- a/subsys/bluetooth/services/fast_pair/fp_storage/include_priv/fp_storage_manager.h
+++ b/subsys/bluetooth/services/fast_pair/fp_storage/include_priv/fp_storage_manager.h
@@ -31,12 +31,6 @@ extern "C" {
 typedef int (*fp_storage_manager_module_reset_perform)(void);
 
 /**
- * @typedef fp_storage_manager_module_reset_prepare
- * Callback used to inform the Fast Pair storage module that the reset operation is due to begin.
- */
-typedef void (*fp_storage_manager_module_reset_prepare)(void);
-
-/**
  * @typedef fp_storage_manager_module_init
  * Callback used to initialize the Fast Pair storage module.
  *
@@ -57,11 +51,6 @@ struct fp_storage_manager_module {
 	/** Function used to perform a reset of the Fast Pair storage module. */
 	fp_storage_manager_module_reset_perform module_reset_perform;
 
-	/** Function used to inform the Fast Pair storage module that the reset operation is due to
-	 * begin. This function is always called before @ref module_reset_perform.
-	 */
-	fp_storage_manager_module_reset_prepare module_reset_prepare;
-
 	/** Function used to initialize Fast Pair storage module. */
 	fp_storage_manager_module_init module_init;
 
@@ -78,22 +67,17 @@ struct fp_storage_manager_module {
  *
  * @param _name				Storage module name.
  * @param _module_reset_perform_fn	Function used to perform a reset of the storage module.
- * @param _module_reset_prepare_fn	Function used to inform the storage module that the reset
- *					operation is due to begin.
  * @param _module_init_fn		Function used to initialize the storage module
  *					(can be NULL).
  * @param _module_uninit_fn		Function used to uninitialize the storage module
  *					(can be NULL).
  */
 #define FP_STORAGE_MANAGER_MODULE_REGISTER(_name, _module_reset_perform_fn,			\
-					   _module_reset_prepare_fn, _module_init_fn,		\
-					   _module_uninit_fn)					\
+					   _module_init_fn, _module_uninit_fn)			\
 	BUILD_ASSERT(_module_reset_perform_fn != NULL);						\
-	BUILD_ASSERT(_module_reset_prepare_fn != NULL);						\
 	BUILD_ASSERT((_module_init_fn == NULL) == (_module_uninit_fn == NULL));			\
 	static const STRUCT_SECTION_ITERABLE(fp_storage_manager_module, _name) = {		\
 		.module_reset_perform = _module_reset_perform_fn,				\
-		.module_reset_prepare = _module_reset_prepare_fn,				\
 		.module_init = _module_init_fn,							\
 		.module_uninit = _module_uninit_fn,						\
 	}

--- a/tests/subsys/bluetooth/fast_pair/storage/factory_reset/src/main.c
+++ b/tests/subsys/bluetooth/fast_pair/storage/factory_reset/src/main.c
@@ -127,13 +127,10 @@ static int test_fp_storage_reset_perform(void)
 	return 0;
 }
 
-static void test_fp_storage_reset_prepare(void) {}
-
 /* The name starts with '_0_' so that this module's struct would be first in section (linker sorts
  * entries by name) and its callbacks would be call before other's modules callbacks.
  */
-FP_STORAGE_MANAGER_MODULE_REGISTER(_0_test_reset, test_fp_storage_reset_perform,
-				   test_fp_storage_reset_prepare, NULL, NULL);
+FP_STORAGE_MANAGER_MODULE_REGISTER(_0_test_reset, test_fp_storage_reset_perform, NULL, NULL);
 
 static void *setup_fn(void)
 {
@@ -142,8 +139,6 @@ static void *setup_fn(void)
 	STRUCT_SECTION_GET(fp_storage_manager_module, 0, &module);
 
 	zassert_equal_ptr(test_fp_storage_reset_perform, module->module_reset_perform,
-			  "Invalid order of elements in section");
-	zassert_equal_ptr(test_fp_storage_reset_prepare, module->module_reset_prepare,
 			  "Invalid order of elements in section");
 
 	return NULL;


### PR DESCRIPTION
Removes bt_fast_pair_factory_reset_user_action_prepare weak function definition that could earlier be overriden to prepare for the oncoming Fast Pair factory reset.

Jira: NCSDK-25394