### PR TITLE
Add custom device update

### DIFF
--- a/include/dfu/dfu_target.h
+++ b/include/dfu/dfu_target.h
@@ -36,6 +36,8 @@ enum dfu_target_image_type {
 	DFU_TARGET_IMAGE_TYPE_FULL_MODEM = 4,
 	/** SMP external MCU */
 	DFU_TARGET_IMAGE_TYPE_SMP = 8,
+	/** Custom update implementation, e.g. for external MCU */
+	DFU_TARGET_IMAGE_TYPE_CUSTOM = 16,
 	/** Any application image type */
 	DFU_TARGET_IMAGE_TYPE_ANY_APPLICATION = DFU_TARGET_IMAGE_TYPE_MCUBOOT,
 	/** Any modem image */
@@ -44,7 +46,7 @@ enum dfu_target_image_type {
 	/** Any DFU image type */
 	DFU_TARGET_IMAGE_TYPE_ANY =
 		(DFU_TARGET_IMAGE_TYPE_MCUBOOT | DFU_TARGET_IMAGE_TYPE_MODEM_DELTA |
-		 DFU_TARGET_IMAGE_TYPE_FULL_MODEM),
+		 DFU_TARGET_IMAGE_TYPE_FULL_MODEM | DFU_TARGET_IMAGE_TYPE_CUSTOM),
 };
 
 enum dfu_target_evt_id {

--- a/include/dfu/dfu_target_custom.h
+++ b/include/dfu/dfu_target_custom.h
@@ -1,0 +1,24 @@
+
+#ifndef DFU_TARGET_CUSTOM_H__
+#define DFU_TARGET_CUSTOM_H__
+
+#include <dfu/dfu_target.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+bool dfu_target_custom_identify(const void *const buf);
+int dfu_target_custom_init(size_t file_size, dfu_target_callback_t cb);
+int dfu_target_custom_offset_get(size_t *offset);
+int dfu_target_custom_write(const void *const buf, size_t len);
+int dfu_target_custom_done(bool successful);
+int dfu_target_custom_schedule_update(int img_num);
+int dfu_target_custom_reset(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DFU_TARGET_SUIT_H__ */

--- a/subsys/dfu/dfu_target/Kconfig
+++ b/subsys/dfu/dfu_target/Kconfig
@@ -125,6 +125,9 @@ config DFU_TARGET_SUIT
 	help
 	  Enable support for updates using DFU target based on SUIT
 
+config DFU_TARGET_CUSTOM
+	bool "Custom application controlled update support"
+
 module=DFU_TARGET
 module-dep=LOG
 module-str=Device Firmware Upgrade

--- a/subsys/dfu/dfu_target/src/dfu_target.c
+++ b/subsys/dfu/dfu_target/src/dfu_target.c
@@ -38,6 +38,10 @@ DEF_DFU_TARGET(smp);
 #include "dfu/dfu_target_suit.h"
 DEF_DFU_TARGET(suit);
 #endif
+#ifdef CONFIG_DFU_TARGET_CUSTOM
+#include "dfu/dfu_target_custom.h"
+DEF_DFU_TARGET(custom);
+#endif
 
 #define MIN_SIZE_IDENTIFY_BUF 32
 
@@ -64,6 +68,11 @@ enum dfu_target_image_type dfu_target_img_type(const void *const buf, size_t len
 #ifdef CONFIG_DFU_TARGET_FULL_MODEM
 	if (dfu_target_full_modem_identify(buf)) {
 		return DFU_TARGET_IMAGE_TYPE_FULL_MODEM;
+	}
+#endif
+#ifdef CONFIG_DFU_TARGET_CUSTOM
+	if (dfu_target_custom_identify(buf)) {
+		return DFU_TARGET_IMAGE_TYPE_CUSTOM;
 	}
 #endif
 	LOG_ERR("No supported image type found");
@@ -111,6 +120,11 @@ int dfu_target_init(int img_type, int img_num, size_t file_size, dfu_target_call
 #ifdef CONFIG_DFU_TARGET_SUIT
 	if (img_type == DFU_TARGET_IMAGE_TYPE_SUIT) {
 		new_target = &dfu_target_suit;
+	}
+#endif
+#ifdef CONFIG_DFU_TARGET_CUSTOM
+	if (img_type == DFU_TARGET_IMAGE_TYPE_CUSTOM) {
+		new_target = &dfu_target_custom;
 	}
 #endif
 


### PR DESCRIPTION
This pull request introduces support for custom application-controlled updates in the Device Firmware Upgrade (DFU) subsystem. The most important changes include adding a new image type for custom updates, defining the necessary functions for custom DFU targets, and updating the configuration and core DFU logic to support this new functionality.

### Support for Custom DFU Targets:

* [`include/dfu/dfu_target.h`](diffhunk://#diff-8857e847743854e08dd616843f7fa8327e20c35a1c1e3a40307c529da49c56c4R39-R40): Added a new image type `DFU_TARGET_IMAGE_TYPE_CUSTOM` for custom updates. [[1]](diffhunk://#diff-8857e847743854e08dd616843f7fa8327e20c35a1c1e3a40307c529da49c56c4R39-R40) [[2]](diffhunk://#diff-8857e847743854e08dd616843f7fa8327e20c35a1c1e3a40307c529da49c56c4L47-R49)
* [`include/dfu/dfu_target_custom.h`](diffhunk://#diff-023b5e3f2a94df25ac3299e88c7e8068a547e7b6f5a2b74a7dc4a24c4de8815aR1-R24): Created a new header file defining the interface for custom DFU targets, including functions for identification, initialization, writing, and completion of updates.

### Configuration Updates:

* [`subsys/dfu/dfu_target/Kconfig`](diffhunk://#diff-9fa7108dc767c7dcebe797118db25c274c06f74ff4d9dd860a6c8b87dc5ce2b1R128-R130): Added a new configuration option `CONFIG_DFU_TARGET_CUSTOM` to enable support for custom application-controlled updates.

### Core DFU Logic Updates:

* [`subsys/dfu/dfu_target/src/dfu_target.c`](diffhunk://#diff-5ec84e4daa033f549562bdfebb2d50facf28417764dc9a747d73902f648cfde7R41-R44): Updated the DFU target initialization and identification logic to include support for the custom DFU target. [[1]](diffhunk://#diff-5ec84e4daa033f549562bdfebb2d50facf28417764dc9a747d73902f648cfde7R41-R44) [[2]](diffhunk://#diff-5ec84e4daa033f549562bdfebb2d50facf28417764dc9a747d73902f648cfde7R72-R76) [[3]](diffhunk://#diff-5ec84e4daa033f549562bdfebb2d50facf28417764dc9a747d73902f648cfde7R125-R129)