### PR TITLE
labeler: Remove some files from "changelog-entry-required"

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -21,7 +21,11 @@
 "changelog-entry-required":
 - all:
   - changed-files:
-    - all-globs-to-all-files: ["!doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst"]
+    - all-globs-to-all-files:
+      - "!doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst"
+      - "!.github/*"
+      - "!CODEOWNERS"
+      - "!.*"
 
 "ble mesh":
 - changed-files:


### PR DESCRIPTION
For certain files we know that we do not want to add a changelog entry.

The list has now been extended to include more such files.