### PR TITLE
samples: broadcast_config_tool: Clear pba_data on stop

### DIFF
--- a/samples/bluetooth/broadcast_config_tool/src/main.c
+++ b/samples/bluetooth/broadcast_config_tool/src/main.c
@@ -1035,6 +1035,8 @@ static int broadcaster_stop(const struct shell *shell, uint8_t big_index)
 	per_adv_buf[big_index].data_len = 0;
 	per_adv_buf[big_index].type = 0;
 
+	memset(pba_data[big_index], 0, sizeof(pba_data[big_index]));
+
 	for (size_t j = 0; j < ARRAY_SIZE(ext_adv_buf[big_index]); j++) {
 		ext_adv_buf[big_index][j].data_len = 0;
 		ext_adv_buf[big_index][j].type = 0;


### PR DESCRIPTION
- Fixes bug where pba_data was not cleared on bct stop.
- OCT-3151