### PR TITLE
Samples: Bluetooth: ISO time sync fixes

### DIFF
--- a/samples/bluetooth/iso_time_sync/README.rst
+++ b/samples/bluetooth/iso_time_sync/README.rst
@@ -40,15 +40,15 @@ The sample demonstrates the following features:
    .. group-tab:: nRF52 and nRF53 DKs
 
       This sample configures a single device as a transmitter of its **Button 1** state.
-      The transmitting and receiving devices toggle **LED 1** synchronously with the accuracy of a few microseconds.
-      When the :ref:`CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE <CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE>` Kconfig option is enabled, **LED 2** is toggled upon sending or receiving data.
+      The transmitting and receiving devices toggle **LED 2** synchronously with the accuracy of a few microseconds.
+      When the :ref:`CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE <CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE>` Kconfig option is enabled, **LED 1** is toggled upon sending or receiving data.
       This allows you to measure the minimal end-to-end latency.
 
    .. group-tab:: nRF54 DKs
 
       This sample configures a single device as a transmitter of its **Button 0** state.
-      The transmitting and receiving devices toggle **LED 0** synchronously with the accuracy of a few microseconds.
-      When the :ref:`CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE <CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE>` Kconfig option is enabled, **LED 1** is toggled upon sending or receiving data.
+      The transmitting and receiving devices toggle **LED 1** synchronously with the accuracy of a few microseconds.
+      When the :ref:`CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE <CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE>` Kconfig option is enabled, **LED 0** is toggled upon sending or receiving data.
       This allows you to measure the minimal end-to-end latency.
 
 .. note::
@@ -69,7 +69,7 @@ Check and configure the following Kconfig options:
 .. _CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE:
 
 CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE
-   This configuration option enables immediate toggling of **LED 2** (nRF52 and nRF53 DKs) or **LED 1** (nRF54 DKs) when isochronous data is sent or received.
+   This configuration option enables immediate toggling of **LED 1** (nRF52 and nRF53 DKs) or **LED 0** (nRF54 DKs) when isochronous data is sent or received.
    It allows for measurement of the minimum end-to-end latency.
 
 .. _CONFIG_SDU_INTERVAL_US:
@@ -180,9 +180,9 @@ The sample code is divided into multiple source files, which makes it easier to 
 
       When a valid SDU is received, the following operations are performed:
 
-      * If the :ref:`CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE <CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE>` Kconfig option is enabled, **LED 2** is toggled immediately.
+      * If the :ref:`CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE <CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE>` Kconfig option is enabled, **LED 1** is toggled immediately.
         You can use this to observe that different receivers may receive the SDU at different points in time.
-      * A timer trigger is configured to toggle **LED 1** :ref:`CONFIG_TIMED_LED_PRESENTATION_DELAY_US <CONFIG_TIMED_LED_PRESENTATION_DELAY_US>` after the received timestamp.
+      * A timer trigger is configured to toggle **LED 2** :ref:`CONFIG_TIMED_LED_PRESENTATION_DELAY_US <CONFIG_TIMED_LED_PRESENTATION_DELAY_US>` after the received timestamp.
         This ensures that all receivers and the transmitter toggle it at the same time.
 
     ``iso_tx.c``
@@ -195,9 +195,9 @@ The sample code is divided into multiple source files, which makes it easier to 
       * The SDU is transmitted on all the established isochronous channels with the same timestamp.
         This ensures that all the receivers can toggle their corresponding LEDs at the same time.
         The very first SDU is provided without a timestamp, because the timestamp is not known at this point in time.
-      * **LED 1** is configured to toggle synchronously with the **LED 1** on all the receivers.
+      * **LED 2** is configured to toggle synchronously with the **LED 2** on all the receivers.
         The toggle time is determined by the TX timestamp and defined relative to the synchronization reference on the receiver.
-      * If the :ref:`CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE <CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE>` Kconfig option is enabled, **LED 2** is toggled right before sending the SDU.
+      * If the :ref:`CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE <CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE>` Kconfig option is enabled, **LED 1** is toggled right before sending the SDU.
         You can use this to observe the end-to-end latency.
 
     ``timed_led_toggle.c``
@@ -257,9 +257,9 @@ The sample code is divided into multiple source files, which makes it easier to 
 
       When a valid SDU is received, the following operations are performed:
 
-      * If the :ref:`CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE <CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE>` Kconfig option is enabled, **LED 1** is toggled immediately.
+      * If the :ref:`CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE <CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE>` Kconfig option is enabled, **LED 0** is toggled immediately.
         You can use this to observe that different receivers may receive the SDU at different points in time.
-      * A timer trigger is configured to toggle **LED 0** :ref:`CONFIG_TIMED_LED_PRESENTATION_DELAY_US <CONFIG_TIMED_LED_PRESENTATION_DELAY_US>` after the received timestamp.
+      * A timer trigger is configured to toggle **LED 1** :ref:`CONFIG_TIMED_LED_PRESENTATION_DELAY_US <CONFIG_TIMED_LED_PRESENTATION_DELAY_US>` after the received timestamp.
         This ensures that all receivers and the transmitter toggle it at the same time.
 
     ``iso_tx.c``
@@ -272,9 +272,9 @@ The sample code is divided into multiple source files, which makes it easier to 
       * The SDU is transmitted on all the established isochronous channels with the same timestamp.
         This ensures that all the receivers can toggle their corresponding LEDs at the same time.
         The very first SDU is provided without a timestamp, because the timestamp is not known at this point in time.
-      * **LED 0** is configured to toggle synchronously with the **LED 0** on all the receivers.
+      * **LED 1** is configured to toggle synchronously with the **LED 1** on all the receivers.
         The toggle time is determined by the TX timestamp and defined relative to the synchronization reference on the receiver.
-      * If the :ref:`CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE <CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE>` Kconfig option is enabled, **LED 1** is toggled right before sending the SDU.
+      * If the :ref:`CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE <CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE>` Kconfig option is enabled, **LED 0** is toggled right before sending the SDU.
         You can use this to observe the end-to-end latency.
 
     ``timed_led_toggle.c``
@@ -318,7 +318,7 @@ After programming the sample to the development kits, perform the following step
       #. Select which BIS the receiver should synchronize to.
       #. Observe that the device(s) synchronize to the broadcaster and start receiving isochronous data.
       #. Press **Button 1** on the broadcaster.
-      #. Observe that **LED 1** toggles on both the broadcaster and the receivers.
+      #. Observe that **LED 2** toggles on both the broadcaster and the receivers.
 
    .. group-tab:: nRF54 DKs
 
@@ -331,7 +331,7 @@ After programming the sample to the development kits, perform the following step
       #. Select which BIS the receiver should synchronize to.
       #. Observe that the device(s) synchronize to the broadcaster and start receiving isochronous data.
       #. Press **Button 0** on the broadcaster.
-      #. Observe that **LED 0** toggles on both the broadcaster and the receivers.
+      #. Observe that **LED 1** toggles on both the broadcaster and the receivers.
 
 Testing connected isochronous streams
 =====================================
@@ -353,7 +353,7 @@ After programming the sample to the development kits, perform the following step
       #. Select data direction.
       #. Observe that the peripheral(s) connect to the central and start receiving isochronous data.
       #. Press **Button 1** on the central device.
-      #. Observe that **LED 1** toggles on both the central and peripheral devices.
+      #. Observe that **LED 2** toggles on both the central and peripheral devices.
 
    .. group-tab:: nRF54 DKs
 
@@ -368,7 +368,7 @@ After programming the sample to the development kits, perform the following step
       #. Select data direction.
       #. Observe that the peripheral(s) connect to the central and start receiving isochronous data.
       #. Press **Button 0** on the central device.
-      #. Observe that **LED 0** toggles on both the central and peripheral devices.
+      #. Observe that **LED 1** toggles on both the central and peripheral devices.
 
 
 Observe time-synchronized ISO data processing
@@ -378,12 +378,12 @@ Observe time-synchronized ISO data processing
 
    .. group-tab:: nRF52 and nRF53 DKs
 
-      When you press **Button 1** on the transmitting device, you can observe that **LED 1** toggles simultaneously on all devices.
+      When you press **Button 1** on the transmitting device, you can observe that **LED 2** toggles simultaneously on all devices.
       To observe the accurate toggling, use a logic analyzer or an oscilloscope.
 
    .. group-tab:: nRF54 DKs
 
-      When you press **Button 0** on the transmitting device, you can observe that **LED 0** toggles simultaneously on all devices.
+      When you press **Button 0** on the transmitting device, you can observe that **LED 1** toggles simultaneously on all devices.
       To observe the accurate toggling, use a logic analyzer or an oscilloscope.
 
 Sample output

--- a/samples/bluetooth/iso_time_sync/src/iso_rx.c
+++ b/samples/bluetooth/iso_time_sync/src/iso_rx.c
@@ -26,7 +26,7 @@ static void iso_disconnected(struct bt_iso_chan *chan, uint8_t reason);
 
 static void (*iso_chan_disconnected_cb)(void);
 
-static struct gpio_dt_spec led_sdu_received = GPIO_DT_SPEC_GET_OR(DT_ALIAS(led1), gpios, {0});
+static struct gpio_dt_spec led_sdu_received = GPIO_DT_SPEC_GET_OR(DT_ALIAS(led0), gpios, {0});
 
 static struct bt_iso_chan_ops iso_ops = {
 	.recv = iso_recv,

--- a/samples/bluetooth/iso_time_sync/src/iso_tx.c
+++ b/samples/bluetooth/iso_time_sync/src/iso_tx.c
@@ -30,7 +30,7 @@
 #include "iso_time_sync.h"
 
 static const struct gpio_dt_spec button = GPIO_DT_SPEC_GET_OR(DT_ALIAS(sw0), gpios, {0});
-static struct gpio_dt_spec led_on_sdu_send = GPIO_DT_SPEC_GET_OR(DT_ALIAS(led1), gpios, {0});
+static struct gpio_dt_spec led_on_sdu_send = GPIO_DT_SPEC_GET_OR(DT_ALIAS(led0), gpios, {0});
 
 static void iso_sent(struct bt_iso_chan *chan);
 static void iso_connected(struct bt_iso_chan *chan);

--- a/samples/bluetooth/iso_time_sync/src/timed_led_toggle.c
+++ b/samples/bluetooth/iso_time_sync/src/timed_led_toggle.c
@@ -53,8 +53,8 @@ int timed_led_toggle_init(void)
 	const nrfx_gpiote_task_config_t task_cfg_led_toggle = {
 		.task_ch = gpiote_chan_led_toggle,
 		.polarity = NRF_GPIOTE_POLARITY_TOGGLE,
-		.init_val = (led.dt_flags & GPIO_ACTIVE_HIGH) ?
-			NRF_GPIOTE_INITIAL_VALUE_LOW : NRF_GPIOTE_INITIAL_VALUE_HIGH,
+		.init_val = (led.dt_flags & GPIO_ACTIVE_LOW) ?
+			NRF_GPIOTE_INITIAL_VALUE_HIGH : NRF_GPIOTE_INITIAL_VALUE_LOW,
 	};
 
 	if (nrfx_gpiote_output_configure(&gpiote, led.pin, &gpiote_output_cfg,


### PR DESCRIPTION
This commit fixes the following:
  * ~~Sample now uses absolute pin for GPIOTE, to make the LED work on platforms where the LEDs are not on port 0 (such as nRF54L15).~~
      * This has been removed from this PR, as this is fixed in the already existing #17639 
  * Fix a bug in the initialization of `init_val` in the GPIOTE task used for the LED, where it would always be initialized to `NRF_GPIOTE_INITIAL_VALUE_HIGH` and not take the dt_flags into account. This made the LED toggle with inverted polarity on platforms where the LEDs are active high.
  * Change the LED used when `CONFIG_LED_TOGGLE_IMMEDIATELY_ON_SEND_OR_RECEIVE` is enabled to not conflict with the LED used to display synchronized toggling.
  * Update references to LED numbers in the README to match the actual sample behavior.