### PR TITLE
samples: cellular: smp_svr: add sysbuild files

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -441,6 +441,10 @@ Cellular samples
 
   * Removed redundant logging now done by the :ref:`lib_nrf_cloud` library.
 
+* :ref:`smp_svr` sample:
+
+  * Added sysbuild configuration files.
+
 Cryptography samples
 --------------------
 

--- a/samples/cellular/smp_svr/sysbuild.conf
+++ b/samples/cellular/smp_svr/sysbuild.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+SB_CONFIG_BOOTLOADER_MCUBOOT=y
+SB_CONFIG_PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY=n

--- a/samples/cellular/smp_svr/sysbuild/mcuboot/prj.conf
+++ b/samples/cellular/smp_svr/sysbuild/mcuboot/prj.conf
@@ -1,0 +1,37 @@
+CONFIG_MAIN_STACK_SIZE=10240
+CONFIG_MBEDTLS_CFG_FILE="mcuboot-mbedtls-cfg.h"
+
+CONFIG_BOOT_SWAP_SAVE_ENCTLV=n
+CONFIG_BOOT_ENCRYPT_IMAGE=n
+
+CONFIG_BOOT_UPGRADE_ONLY=n
+CONFIG_BOOT_BOOTSTRAP=n
+
+### mbedTLS has its own heap
+# CONFIG_HEAP_MEM_POOL_SIZE is not set
+
+### We never want Zephyr's copy of tinycrypt.  If tinycrypt is needed,
+### MCUboot has its own copy in tree.
+# CONFIG_TINYCRYPT is not set
+# CONFIG_TINYCRYPT_ECC_DSA is not set
+# CONFIG_TINYCRYPT_SHA256 is not set
+
+CONFIG_FLASH=y
+CONFIG_FPROTECT=y
+
+### Various Zephyr boards enable features that we don't want.
+# CONFIG_BT is not set
+# CONFIG_BT_CTLR is not set
+# CONFIG_I2C is not set
+
+CONFIG_LOG=y
+CONFIG_LOG_MODE_MINIMAL=y # former CONFIG_MODE_MINIMAL
+### Ensure Zephyr logging changes don't use more resources
+CONFIG_LOG_DEFAULT_LEVEL=0
+### Use info log level by default
+CONFIG_MCUBOOT_LOG_LEVEL_INF=y
+### Decrease footprint by ~4 KB in comparison to CBPRINTF_COMPLETE=y
+CONFIG_CBPRINTF_NANO=y
+CONFIG_NRF_RTC_TIMER_USER_CHAN_COUNT=0
+### Use the minimal C library to reduce flash usage
+CONFIG_MINIMAL_LIBC=y


### PR DESCRIPTION
Add sysbuild configuration files.
This enables the sample to be properly built with overlay-serial.conf and nrf9160dk_nrf52840_mcumgr_srv.overlay.

IRIS-9783