### PR TITLE
subsys: net: lib: cloud: nrf_cloud: shutdown modem before reinit

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -840,7 +840,10 @@ Libraries for networking
       Support for statically configured nRF Cloud IP Addresses will soon be removed.
       Leave :kconfig:option:`CONFIG_NRF_CLOUD_STATIC_IPV4` disabled to instead use automatic DNS lookup.
 
-  * Fixed an issue in the :c:func:`nrf_cloud_send` function that prevented data in the provided :c:struct:`nrf_cloud_obj` structure from being sent to the bulk and bin topics.
+  * Fixed:
+
+  * An issue in the :c:func:`nrf_cloud_send` function that prevented data in the provided :c:struct:`nrf_cloud_obj` structure from being sent to the bulk and bin topics.
+  * An issue where the modem was not shut down from bootloader mode before attempting to initialize in normal mode after an unsuccessful update.
 
 * :ref:`lib_nrf_cloud_coap` library:
 

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota_common.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota_common.c
@@ -265,6 +265,7 @@ int nrf_cloud_fota_fmfu_apply(void)
 	err = fmfu_fdev_load(fmfu_buf, sizeof(fmfu_buf), fmfu_dev.dev, fmfu_dev.offset);
 	if (err != 0) {
 		LOG_ERR("Failed to apply full modem update, error: %d", err);
+		(void)nrf_modem_lib_shutdown();
 		(void)nrf_modem_lib_init();
 		return err;
 	}


### PR DESCRIPTION
Modem needs to be shut down from bootloader modem before it can be reinitialized in normal mode.