### PR TITLE
ci: stale: allow DNM

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,5 +16,5 @@ jobs:
         days-before-close: 14
         stale-issue-label: 'Stale'
         stale-pr-label: 'Stale'
-        exempt-pr-labels: 'DNM,In progress,RFC'
+        exempt-pr-labels: 'In progress,RFC'
         exempt-issue-labels: 'In progress,Enhancement,Feature,Feature Request,RFC,Meta'


### PR DESCRIPTION
There are tons of stale PRs with the 'DNM' tag due to stale manifest changes, so allow closing stale PRs with the 'DNM' label.