### PR TITLE
nrf_security: cracen: rename KMU_METADATA_SCHEME_*

### DIFF
--- a/lib/hw_unique_key/hw_unique_key_cracen.c
+++ b/lib/hw_unique_key/hw_unique_key_cracen.c
@@ -68,7 +68,7 @@ bool hw_unique_key_are_any_written(void)
 	mbedtls_svc_key_id_t key_id;
 
 	key_id = mbedtls_svc_key_id_make(0, PSA_KEY_HANDLE_FROM_CRACEN_KMU_SLOT(
-						KMU_METADATA_SCHEME_SEED,
+						CRACEN_KMU_KEY_USAGE_SCHEME_SEED,
 						CONFIG_CRACEN_IKG_SEED_KMU_SLOT));
 	return cracen_kmu_get_key_slot(key_id, &lifetime, &slot_number) == PSA_SUCCESS;
 }
@@ -85,7 +85,7 @@ int hw_unique_key_write(enum hw_unique_key_slot key_slot, const uint8_t *key)
 
 	psa_set_key_id(&seed_attr,
 		       mbedtls_svc_key_id_make(0, PSA_KEY_HANDLE_FROM_CRACEN_KMU_SLOT(
-							KMU_METADATA_SCHEME_SEED,
+							CRACEN_KMU_KEY_USAGE_SCHEME_SEED,
 							CONFIG_CRACEN_IKG_SEED_KMU_SLOT)));
 	psa_set_key_type(&seed_attr, PSA_KEY_TYPE_RAW_DATA);
 	psa_set_key_lifetime(&seed_attr, PSA_KEY_LIFETIME_FROM_PERSISTENCE_AND_LOCATION(

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_kmu.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_kmu.h
@@ -34,25 +34,25 @@ typedef uint64_t psa_drv_slot_number_t;
 /* Retrieve KMU slot number for PSA key id. */
 #define CRACEN_PSA_GET_KMU_SLOT(key_id) ((key_id)&0xff)
 
-enum kmu_metadata_key_usage_scheme {
+enum cracen_kmu_metadata_key_usage_scheme {
 	/**
 	 * These keys can only be pushed to CRACEN's protected RAM.
 	 * The keys are not encrypted. Only AES supported.
 	 */
-	KMU_METADATA_SCHEME_PROTECTED,
+	CRACEN_KMU_KEY_USAGE_SCHEME_PROTECTED,
 	/**
 	 * CRACEN's IKG seed uses 3 key slots. Pushed to the seed register.
 	 */
-	KMU_METADATA_SCHEME_SEED,
+	CRACEN_KMU_KEY_USAGE_SCHEME_SEED,
 	/**
 	 * These keys are stored in encrypted form. They will be decrypted
 	 * to @ref kmu_push_area for usage.
 	 */
-	KMU_METADATA_SCHEME_ENCRYPTED,
+	CRACEN_KMU_KEY_USAGE_SCHEME_ENCRYPTED,
 	/**
 	 * These keys are not encrypted. Pushed to @ref kmu_push_area.
 	 */
-	KMU_METADATA_SCHEME_RAW
+	CRACEN_KMU_KEY_USAGE_SCHEME_RAW
 };
 
 /**

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/common.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/common.c
@@ -734,20 +734,20 @@ psa_status_t cracen_load_keyref(const psa_key_attributes_t *attributes, const ui
 	if (PSA_KEY_LIFETIME_GET_LOCATION(psa_get_key_lifetime(attributes)) ==
 	    PSA_KEY_LOCATION_CRACEN_KMU) {
 		kmu_opaque_key_buffer *key = (kmu_opaque_key_buffer *)key_buffer;
-		enum kmu_metadata_key_usage_scheme key_usage_scheme = key->key_usage_scheme;
+		enum cracen_kmu_metadata_key_usage_scheme key_usage_scheme = key->key_usage_scheme;
 
 		k->clean_key = cracen_kmu_clean_key;
 		k->prepare_key = cracen_kmu_prepare_key;
 		k->user_data = key_buffer;
 
 		switch (key_usage_scheme) {
-		case KMU_METADATA_SCHEME_RAW:
-		case KMU_METADATA_SCHEME_ENCRYPTED:
+		case CRACEN_KMU_KEY_USAGE_SCHEME_RAW:
+		case CRACEN_KMU_KEY_USAGE_SCHEME_ENCRYPTED:
 			k->sz = PSA_BITS_TO_BYTES(psa_get_key_bits(attributes));
 			k->key = kmu_push_area;
 
 			return PSA_SUCCESS;
-		case KMU_METADATA_SCHEME_PROTECTED:
+		case CRACEN_KMU_KEY_USAGE_SCHEME_PROTECTED:
 			k->sz = PSA_BITS_TO_BYTES(psa_get_key_bits(attributes));
 			k->key = (uint8_t *)CRACEN_PROTECTED_RAM_AES_KEY0;
 

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/kmu.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/kmu.h
@@ -22,7 +22,7 @@ enum kmu_metadata_key_bits {
 };
 
 typedef struct {
-	uint8_t key_usage_scheme: 2; /* value of @ref kmu_metadata_key_usage_scheme. */
+	uint8_t key_usage_scheme: 2; /* value of @ref cracen_kmu_metadata_key_usage_scheme. */
 	uint8_t number_of_slots: 3;  /* Number of slots to push. */
 	uint8_t slot_id;	     /* KMU slot number. */
 } kmu_opaque_key_buffer;


### PR DESCRIPTION
To `CRACEN_KMU_KEY_USAGE_*`.
This undoes some of the changes made in
5b6a3a6354d1dd377d36b99e989c973914542836.
Keep the original naming that is also used in tests. It also makes more sense as this is a CRACEN-specific thing.