### PR TITLE
ci: docbuild: run Sphinx in quiet mode

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -69,7 +69,7 @@ jobs:
             BUILD_CONF="-DNO_DTS_BINDINGS=ON"
           fi
 
-          cmake -GNinja -Bdoc/_build -Sdoc ${BUILD_CONF}
+          cmake -GNinja -Bdoc/_build -Sdoc -DSPHINXOPTS_EXTRA="-q" ${BUILD_CONF}
           ninja -C doc/_build
 
       - name: Check version


### PR DESCRIPTION
This option will make CI less verbose, showing only warnings/errors.
