### PR TITLE
lib: modem_key_mgmt: Handle generic CME errors

### DIFF
--- a/include/modem/modem_key_mgmt.h
+++ b/include/modem/modem_key_mgmt.h
@@ -111,6 +111,7 @@ int modem_key_mgmt_clear(nrf_sec_tag_t sec_tag);
  * @retval -ENOENT	No credential associated with the given
  *			@p sec_tag and @p cred_type.
  * @retval -EACCES	Access to credential not allowed.
+ * @retval -E2BIG	Memory failure.
  */
 int modem_key_mgmt_read(nrf_sec_tag_t sec_tag,
 			enum modem_key_mgmt_cred_type cred_type,

--- a/lib/modem_key_mgmt/modem_key_mgmt.c
+++ b/lib/modem_key_mgmt/modem_key_mgmt.c
@@ -66,6 +66,18 @@ static int translate_error(int err)
 
 	/* In case of CME error translate to an errno value */
 	switch (nrf_modem_at_err(err)) {
+	case 0: /* phone failure. invalid command, parameter, or other unexpected error */
+		LOG_WRN("Phone failure");
+		return -EIO;
+	case 23: /* memory failure. unexpected error in memory handling */
+		LOG_WRN("Memory failure");
+		return -E2BIG;
+	case 50: /* incorrect parameters in a command */
+		LOG_WRN("Incorrect parameters in command");
+		return -EINVAL;
+	case 60: /* system error */
+		LOG_WRN("System error");
+		return -ENOEXEC;
 	case 513: /* not found */
 		LOG_WRN("Key not found");
 		return -ENOENT;


### PR DESCRIPTION
Handle generic CME errors from all AT%CMNG commands.
For reference, see 3GPP 27.007 Ch. 9.1.