### PR TITLE
lib: nrf_modem: add semaphore to flash trace backend

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -797,7 +797,11 @@ Modem libraries
 
 * :ref:`nrf_modem_lib_readme`:
 
-  * Updated the RTT trace backend to allocate the RTT channel at boot, instead of when the modem is activated.
+  * Updated:
+
+    * The RTT trace backend to allocate the RTT channel at boot, instead of when the modem is activated.
+    * The flash trace backend to solve concurrency issues when reading traces while writing, and when reinitializing the application (warm start).
+
   * Rename the nRF91 socket offload layer from ``nrf91_sockets`` to ``nrf9x_sockets`` to reflect that the offload layer is not exclusive to the nRF91 Series SiPs.
   * Removed support for deprecated RAI socket options ``SO_RAI_LAST``, ``SO_RAI_NO_DATA``, ``SO_RAI_ONE_RESP``, ``SO_RAI_ONGOING``, and ``SO_RAI_WAIT_MORE``.
 

--- a/lib/nrf_modem_lib/trace_backends/flash/flash.c
+++ b/lib/nrf_modem_lib/trace_backends/flash/flash.c
@@ -42,13 +42,13 @@ static __noinit size_t read_offset;
 static __noinit struct fcb_entry loc;
 static __noinit struct flash_sector *sector;
 
-static size_t trace_bytes_unread;
-static size_t flash_buf_written;
-static uint8_t flash_buf[BUF_SIZE];
+static __noinit size_t trace_bytes_unread;
+static __noinit size_t flash_buf_written;
+static __noinit uint8_t flash_buf[BUF_SIZE];
 
 static bool is_initialized;
 
-static int trace_backend_clear(void);
+static struct k_sem fcb_sem;
 
 static size_t buffer_append(const void *data, size_t len)
 {
@@ -87,6 +87,8 @@ static int buffer_flush_to_flash(void)
 		return -ENODATA;
 	}
 
+	k_sem_take(&fcb_sem, K_FOREVER);
+
 	err = fcb_append(&trace_fcb, flash_buf_written, &loc_flush);
 	if (err) {
 		if (IS_ENABLED(CONFIG_NRF_MODEM_TRACE_FLASH_NOSPACE_ERASE_OLDEST)) {
@@ -101,21 +103,22 @@ static int buffer_flush_to_flash(void)
 			err = fcb_walk(&trace_fcb, loc_flush.fe_sector, fcb_walk_callback, NULL);
 			if (err) {
 				LOG_ERR("fcb_walk failed, err %d", err);
-				return err;
+				goto out;
 			}
 
 			/* Erase the oldest sector and append again. */
 			err = fcb_rotate(&trace_fcb);
 			if (err) {
 				LOG_ERR("fcb_rotate failed, err %d", err);
-				return err;
+				goto out;
 			}
 			err = fcb_append(&trace_fcb, flash_buf_written, &loc_flush);
 		}
 
 		if (err) {
 			LOG_ERR("fcb_append failed, err %d", err);
-			return -ENOSPC;
+			err = -ENOSPC;
+			goto out;
 		}
 	}
 
@@ -123,18 +126,20 @@ static int buffer_flush_to_flash(void)
 		trace_fcb.fap, FCB_ENTRY_FA_DATA_OFF(loc_flush), flash_buf, flash_buf_written);
 	if (err) {
 		LOG_ERR("flash_area_write failed, err %d", err);
-		return err;
+		goto out;
 	}
 
 	err = fcb_append_finish(&trace_fcb, &loc_flush);
 	if (err) {
 		LOG_ERR("fcb_append_finish failed, err %d", err);
-		return err;
+		goto out;
 	}
 
 	flash_buf_written = 0;
 
-	return 0;
+out:
+	k_sem_give(&fcb_sem);
+	return err;
 }
 
 static int trace_flash_erase(void)
@@ -160,6 +165,8 @@ int trace_backend_init(trace_backend_processed_cb trace_processed_cb)
 		return -EFAULT;
 	}
 
+	k_sem_init(&fcb_sem, 0, 1);
+
 	trace_processed_callback = trace_processed_cb;
 
 	err = flash_area_open(FIXED_PARTITION_ID(MODEM_TRACE), &modem_trace_area);
@@ -184,6 +191,8 @@ int trace_backend_init(trace_backend_processed_cb trace_processed_cb)
 	if (magic != TRACE_MAGIC_INITIALIZED) {
 		LOG_DBG("Initializing");
 		read_offset = 0;
+		trace_bytes_unread = 0;
+		flash_buf_written = 0;
 		memset(&loc, 0, sizeof(loc));
 		sector = NULL;
 		magic = TRACE_MAGIC_INITIALIZED;
@@ -215,20 +224,11 @@ int trace_backend_init(trace_backend_processed_cb trace_processed_cb)
 		return err;
 	}
 
-	/* Get trace size */
-	err = fcb_getnext(&trace_fcb, &loc);
-	while (!err) {
-		trace_bytes_unread += loc.fe_data_len;
-		err = fcb_getnext(&trace_fcb, &loc);
-	}
-
-	loc.fe_sector = 0;
-	loc.fe_elem_off = 0;
-
 	is_initialized = true;
 
 	LOG_DBG("Modem trace flash storage initialized\n");
 
+	k_sem_give(&fcb_sem);
 	return 0;
 }
 
@@ -237,6 +237,9 @@ size_t trace_backend_data_size(void)
 	return trace_bytes_unread;
 }
 
+/* Read from offset
+ * FCB sem has to be taken before calling this function!
+ */
 static int read_from_offset(void *buf, size_t len)
 {
 	int err;
@@ -257,23 +260,13 @@ static int read_from_offset(void *buf, size_t len)
 		read_offset = 0;
 	}
 
-	/* Erase if done with previous sector. */
-	if (sector && (sector != loc.fe_sector)) {
-		err = fcb_rotate(&trace_fcb);
-		if (err) {
-			return to_read;
-		}
-	}
-
-	sector = loc.fe_sector;
-
 	return to_read;
 }
 
 int trace_backend_read(void *buf, size_t len)
 {
 	int err;
-	size_t to_read;
+	size_t to_read = 0;
 
 	if (!is_initialized) {
 		return -EPERM;
@@ -283,8 +276,11 @@ int trace_backend_read(void *buf, size_t len)
 		return -EINVAL;
 	}
 
-	if (read_offset != 0) {
-		return read_from_offset(buf, len);
+	k_sem_take(&fcb_sem, K_FOREVER);
+
+	if (read_offset != 0 && loc.fe_sector) {
+		err = read_from_offset(buf, len);
+		goto out;
 	}
 
 	err = fcb_getnext(&trace_fcb, &loc);
@@ -292,8 +288,10 @@ int trace_backend_read(void *buf, size_t len)
 		/* Nothing to read */
 		loc.fe_sector = 0;
 		loc.fe_elem_off = 0;
+		read_offset = 0;
 		sector = NULL;
-		return -ENODATA;
+		err = -ENODATA;
+		goto out;
 	} else if (err == -ENOTSUP && flash_buf_written) {
 		to_read = MIN(flash_buf_written, len);
 		memcpy(buf, flash_buf, to_read);
@@ -306,21 +304,29 @@ int trace_backend_read(void *buf, size_t len)
 		flash_buf_written -= to_read;
 		trace_bytes_unread -= to_read;
 
-		if (sector) {
-			err = fcb_rotate(&trace_fcb);
-			if (err) {
-				return to_read;
-			}
-			sector = NULL;
-		}
-
-		return to_read;
+		err = to_read;
+		goto out;
 
 	} else if (err) {
-		return err;
+		goto out;
 	}
 
-	return read_from_offset(buf, len);
+	err = read_from_offset(buf, len);
+
+out:
+	/* Erase if done with previous sector. */
+	if (sector && (sector != loc.fe_sector)) {
+		err = fcb_rotate(&trace_fcb);
+		if (err) {
+			k_sem_give(&fcb_sem);
+			return err;
+		}
+	}
+
+	sector = loc.fe_sector;
+
+	k_sem_give(&fcb_sem);
+	return err;
 }
 
 static int stream_write(const void *buf, size_t len)
@@ -376,6 +382,7 @@ int trace_backend_clear(void)
 		return -EPERM;
 	}
 
+	k_sem_take(&fcb_sem, K_FOREVER);
 	LOG_DBG("Clearing trace storage");
 	flash_buf_written = 0;
 	err = fcb_clear(&trace_fcb);
@@ -385,6 +392,8 @@ int trace_backend_clear(void)
 	trace_bytes_unread = 0;
 	read_offset = 0;
 	sector = NULL;
+
+	k_sem_give(&fcb_sem);
 
 	return err;
 }


### PR DESCRIPTION
Add semaphore to flash trace backend. This solves concurrency issues when reading out traces while writing.