### PR TITLE
manifest: pull removal of zephyr domain patches

### DIFF
--- a/doc/nrfxlib/conf.py
+++ b/doc/nrfxlib/conf.py
@@ -36,11 +36,11 @@ extensions = [
     "sphinxcontrib.mscgen",
     "inventory_builder",
     "warnings_filter",
-    "zephyr.domain",
     "zephyr.kconfig",
     "zephyr.external_content",
     "zephyr.doxyrunner",
     "zephyr.doxybridge",
+    "zephyr.domain",
 ]
 master_doc = "README"
 

--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 6f6b0e4ac941540618a5933449538408acc85c7b
+      revision: ae75e9ebc34cafdcd5b68946026f15d030c5c798
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
They are no longer needed as breathe has gone away.