### PR TITLE
doc: add clustering tags for Zoomin

### DIFF
--- a/doc/_zoomin/nrf.apis.tags.yml
+++ b/doc/_zoomin/nrf.apis.tags.yml
@@ -4,6 +4,7 @@
 mapping_global:
   - nrf-apis
   - nrf-apis-__VERSION__
+  - cluster-nrf-apis-__VERSION__
 
 # Tags for individual topics:
 mapping_topics: []

--- a/doc/_zoomin/nrfx.apis.tags.yml
+++ b/doc/_zoomin/nrfx.apis.tags.yml
@@ -4,6 +4,7 @@
 mapping_global:
   - nrfx-apis
   - nrfx-apis-__VERSION__
+  - cluster-nrfx-apis-__VERSION__
 
 # Tags for individual topics:
 mapping_topics: []

--- a/doc/_zoomin/nrfxlib.apis.tags.yml
+++ b/doc/_zoomin/nrfxlib.apis.tags.yml
@@ -4,6 +4,7 @@
 mapping_global:
   - nrfxlib-apis
   - nrfxlib-apis-__VERSION__
+  - cluster-nrfxlib-apis-__VERSION__
 
 # Tags for individual topics:
 mapping_topics: []

--- a/doc/_zoomin/zephyr.apis.tags.yml
+++ b/doc/_zoomin/zephyr.apis.tags.yml
@@ -4,6 +4,7 @@
 mapping_global:
   - zephyr-apis
   - zephyr-apis-__VERSION__
+  - cluster-zephyr-apis-__VERSION__
 
 # Tags for individual topics:
 mapping_topics: []


### PR DESCRIPTION
These tags will allow to change between different versions of API doc in the doc portal.