### PR TITLE
bluetooth: rpc: fix assert condition

### DIFF
--- a/subsys/bluetooth/rpc/host/bt_rpc_gatt_host.c
+++ b/subsys/bluetooth/rpc/host/bt_rpc_gatt_host.c
@@ -98,7 +98,7 @@ void bt_rpc_encode_gatt_attr(struct nrf_rpc_cbor_ctx *encoder, const struct bt_g
 	int err;
 
 	err = bt_rpc_gatt_attr_to_index(attr, &attr_index);
-	__ASSERT(err = 0, "Service attribute not found. Service database might be out of sync");
+	__ASSERT(err == 0, "Service attribute not found. Service database might be out of sync");
 
 	nrf_rpc_encode_uint(encoder, attr_index);
 }


### PR DESCRIPTION
The __ASSERT() instruction used assignment instead of comparison operator, causing a failure when receiving a Write Request/Write Command.