### PR TITLE
devicetree: Use the nordic,access property

### DIFF
--- a/applications/machine_learning/configuration/nrf54h20dk_nrf54h20_cpuapp/app.overlay
+++ b/applications/machine_learning/configuration/nrf54h20dk_nrf54h20_cpuapp/app.overlay
@@ -68,9 +68,7 @@ ipc1: &cpuapp_cpuppr_ipc {
        cpuapp_rx_partitions: cpuapp-rx-partitions {
 	       compatible = "nordic,owned-partitions", "fixed-partitions";
 	       status = "okay";
-	       perm-read;
-	       perm-execute;
-	       perm-secure;
+	       nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RXS>;
 	       #address-cells = <1>;
 	       #size-cells = <1>;
 
@@ -86,8 +84,7 @@ ipc1: &cpuapp_cpuppr_ipc {
        cpuapp_rw_partitions: cpuapp-rw-partitions {
 	       compatible = "nordic,owned-partitions", "fixed-partitions";
 	       status = "okay";
-	       perm-read;
-	       perm-write;
+	       nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RW>;
 	       #address-cells = < 0x1 >;
 	       #size-cells = < 0x1 >;
 

--- a/applications/machine_learning/remote/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
+++ b/applications/machine_learning/remote/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
@@ -38,9 +38,7 @@
        cpuapp_rx_partitions: cpuapp-rx-partitions {
 	       compatible = "nordic,owned-partitions", "fixed-partitions";
 	       status = "okay";
-	       perm-read;
-	       perm-execute;
-	       perm-secure;
+	       nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RXS>;
 	       #address-cells = <1>;
 	       #size-cells = <1>;
 
@@ -56,8 +54,7 @@
        cpuapp_rw_partitions: cpuapp-rw-partitions {
 	       compatible = "nordic,owned-partitions", "fixed-partitions";
 	       status = "okay";
-	       perm-read;
-	       perm-write;
+	       nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RW>;
 	       #address-cells = < 0x1 >;
 	       #size-cells = < 0x1 >;
 

--- a/applications/machine_learning/sysbuild/ipc_radio/boards/nrf54h20dk_nrf54h20_cpurad.overlay
+++ b/applications/machine_learning/sysbuild/ipc_radio/boards/nrf54h20dk_nrf54h20_cpurad.overlay
@@ -27,9 +27,7 @@
 	cpuapp_rx_partitions: cpuapp-rx-partitions {
 		compatible = "nordic,owned-partitions", "fixed-partitions";
 		status = "disabled";
-		perm-read;
-		perm-execute;
-		perm-secure;
+		nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RXS>;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
@@ -45,8 +43,7 @@
 	cpuapp_rw_partitions: cpuapp-rw-partitions {
 		compatible = "nordic,owned-partitions", "fixed-partitions";
 		status = "disabled";
-		perm-read;
-		perm-write;
+		nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RW>;
 		#address-cells = < 0x1 >;
 		#size-cells = < 0x1 >;
 

--- a/applications/matter_bridge/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/applications/matter_bridge/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -14,7 +14,7 @@
 
 /* Set IPC thread priority to the highest value to not collide with other threads. */
 &ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
+	zephyr,priority = <0 PRIO_COOP>;
 };
 
 /* Disable unused peripherals to reduce power consumption */

--- a/applications/matter_bridge/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/applications/matter_bridge/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -13,47 +13,46 @@
 /delete-node/ &cpuapp_rw_partitions;
 
 &mram1x {
-    erase-block-size = <0x1000>;
-    write-block-size = <0x10>;
+	erase-block-size = <0x1000>;
+	write-block-size = <0x10>;
 
-    cpuapp_rx_partitions: cpuapp-rx-partitions {
-        compatible = "nordic,owned-partitions", "fixed-partitions";
-        status = "okay";
-        perm-read;
-        perm-execute;
-        perm-secure;
-        #address-cells = <1>;
-        #size-cells = <1>;
+	cpuapp_rx_partitions: cpuapp-rx-partitions {
+		compatible = "nordic,owned-partitions", "fixed-partitions";
+		status = "okay";
+		perm-read;
+		perm-execute;
+		perm-secure;
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-        companion_partition: partition@98000 {
-            reg = <0x98000 DT_SIZE_K(64)>;
-        };
+		companion_partition: partition@98000 {
+			reg = <0x98000 DT_SIZE_K(64)>;
+		};
 
-        cpuapp_slot0_partition: partition@a8000 {
-            reg = <0xa8000 DT_SIZE_K(948)>;
-        };
-    };
+		cpuapp_slot0_partition: partition@a8000 {
+			reg = <0xa8000 DT_SIZE_K(948)>;
+		};
+	};
 
-    cpuapp_rw_partitions: cpuapp-rw-partitions {
-        compatible = "nordic,owned-partitions", "fixed-partitions";
-        status = "okay";
-        perm-read;
-        perm-write;
-        #address-cells = <0x1>;
-        #size-cells = <0x1>;
+	cpuapp_rw_partitions: cpuapp-rw-partitions {
+		compatible = "nordic,owned-partitions", "fixed-partitions";
+		status = "okay";
+		perm-read;
+		perm-write;
+		#address-cells = <0x1>;
+		#size-cells = <0x1>;
 
-        storage_partition: partition@195000 {
-            reg = <0x195000 DT_SIZE_K(32)>;
-        };
+		storage_partition: partition@195000 {
+			reg = <0x195000 DT_SIZE_K(32)>;
+		};
 
-        factory_data: partition@19D000 {
-            reg = <0x19D000 DT_SIZE_K(4)>;
-        };
+		factory_data: partition@19D000 {
+			reg = <0x19D000 DT_SIZE_K(4)>;
+		};
 
-        /* DFU partition to store SUIT manifests and Nordic Firmware update */
-        dfu_partition: partition@19E000 {
-            reg = <0x19E000 DT_SIZE_K(300)>;
-        };
-
-    };
+		/* DFU partition to store SUIT manifests and Nordic Firmware update */
+		dfu_partition: partition@19E000 {
+			reg = <0x19E000 DT_SIZE_K(300)>;
+		};
+	};
 };

--- a/applications/matter_bridge/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/applications/matter_bridge/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -19,9 +19,7 @@
 	cpuapp_rx_partitions: cpuapp-rx-partitions {
 		compatible = "nordic,owned-partitions", "fixed-partitions";
 		status = "okay";
-		perm-read;
-		perm-execute;
-		perm-secure;
+		nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RXS>;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
@@ -37,8 +35,7 @@
 	cpuapp_rw_partitions: cpuapp-rw-partitions {
 		compatible = "nordic,owned-partitions", "fixed-partitions";
 		status = "okay";
-		perm-read;
-		perm-write;
+		nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RW>;
 		#address-cells = <0x1>;
 		#size-cells = <0x1>;
 

--- a/doc/nrf/releases_and_maturity/migration/migration_guide_2.8.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_guide_2.8.rst
@@ -183,6 +183,49 @@ Serial LTE Modem (SLM)
    The :file:`overlay-native_tls.conf` overlay file is no longer supported with the ``thingy91/nrf9160/ns`` board target due to flash memory constraints.
    If you need to use native TLS with Thingy:91, you must disable features from the :file:`prj.conf` and :file:`overlay-native_tls.conf` configuration files to free up flash memory.
 
+Devicetree
+----------
+
+.. toggle::
+
+   The ``nordic,owned-memory`` and ``nordic,owned-partitions`` bindings have been updated, making these properties deprecated:
+
+     * ``owner-id``
+     * ``perm-read``
+     * ``perm-write``
+     * ``perm-execute``
+     * ``perm-secure``
+     * ``non-secure-callable``
+
+   It is recommended to use the ``nordic,access`` property instead.
+   The board files and sample overlays in the |NCS| are already updated to use it.
+   See :file:`ncs/zephyr/dts/bindings/reserved-memory/nordic,owned-memory.yaml` for more details.
+
+   If both of the new and deprecated properties are set on the same devicetree node, then only ``nordic,access`` will take effect.
+   Therefore, it may not be possible to override the default permissions of an existing memory node using the old properties.
+
+   Example before:
+
+   .. code-block:: devicetree
+
+      &cpuapp_ram0x_region {
+         compatible = "nordic,owned-memory";
+         owner-id = <2>;
+         perm-read;
+         perm-write;
+         perm-execute;
+         perm-secure;
+      };
+
+   Example after:
+
+   .. code-block:: devicetree
+
+      &cpuapp_ram0x_region {
+         compatible = "nordic,owned-memory";
+         nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RWXS>;
+      };
+
 Libraries
 =========
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -66,6 +66,17 @@ Build and configuration system
      This feature has never been functional.
      To configure the signing key, use any available Kconfig method.
 
+* Deprecated the following devicetree properties:
+
+  * ``owner-id``
+  * ``perm-read``
+  * ``perm-write``
+  * ``perm-execute``
+  * ``perm-secure``
+  * ``non-secure-callable``
+
+  It is recommended to replace them with the new devicetree property: ``nordic,access``.
+  See the :ref:`migration guide <migration_2.8_recommended>` for more information.
 
 Bootloaders and DFU
 ===================

--- a/lib/nrf_modem_lib/nrf_modem_lib.c
+++ b/lib/nrf_modem_lib/nrf_modem_lib.c
@@ -77,7 +77,7 @@ static const struct nrf_modem_bootloader_init_params bootloader_init_params = {
 
 static const struct nrf_modem_init_params init_params = {
 	.shmem.ctrl = {
-		.base = DT_REG_ADDR(DT_NODELABEL(cpuapp_cpucell_ipc_shm)),
+		.base = DT_REG_ADDR(DT_NODELABEL(cpuapp_cpucell_ipc_shm_ctrl)),
 		.size = CONFIG_NRF_MODEM_LIB_SHMEM_CTRL_SIZE,
 	},
 	.shmem.tx = {
@@ -91,6 +91,12 @@ static const struct nrf_modem_init_params init_params = {
 	.fault_handler = nrf_modem_fault_handler,
 	.dfu_handler = nrf_modem_lib_dfu_handler,
 };
+
+BUILD_ASSERT(
+	CONFIG_NRF_MODEM_LIB_SHMEM_CTRL_SIZE <=
+		DT_REG_SIZE(DT_NODELABEL(cpuapp_cpucell_ipc_shm_ctrl)),
+	"CONFIG_NRF_MODEM_LIB_SHMEM_CTRL_SIZE exceeds 'cpuapp_cpucell_ipc_shm_ctrl' in devicetree");
+
 #endif /* CONFIG_SOC_SERIES_NRF92X */
 
 #if CONFIG_NRF_MODEM_LIB_TRACE

--- a/samples/bluetooth/peripheral_uart/boards/nrf54h20dk_nrf54h20_cpurad.overlay
+++ b/samples/bluetooth/peripheral_uart/boards/nrf54h20dk_nrf54h20_cpurad.overlay
@@ -115,9 +115,7 @@
 &mram1x {
 	cpurad_rw_partitions: cpurad-rw-partitions {
 		compatible = "nordic,owned-partitions", "fixed-partitions";
-		perm-read;
-		perm-write;
-		perm-secure;
+		nordic,access = <NRF_OWNER_ID_RADIOCORE NRF_PERM_RWS>;
 		#address-cells = <1>;
 		#size-cells = <1>;
 

--- a/samples/matter/common/dts/nrf54h20/nrf54h20_cpuapp_memory_map.dtsi
+++ b/samples/matter/common/dts/nrf54h20/nrf54h20_cpuapp_memory_map.dtsi
@@ -31,9 +31,7 @@
 	cpuapp_rx_partitions: cpuapp-rx-partitions {
 		compatible = "nordic,owned-partitions", "fixed-partitions";
 		status = "okay";
-		perm-read;
-		perm-execute;
-		perm-secure;
+		nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RXS>;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
@@ -45,8 +43,7 @@
 	cpuapp_rw_partitions: cpuapp-rw-partitions {
 		compatible = "nordic,owned-partitions", "fixed-partitions";
 		status = "okay";
-		perm-read;
-		perm-write;
+		nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RW>;
 		#address-cells = < 0x1 >;
 		#size-cells = < 0x1 >;
 

--- a/samples/matter/common/dts/nrf54h20/nrf54h20_cpurad_memory_map.dtsi
+++ b/samples/matter/common/dts/nrf54h20/nrf54h20_cpurad_memory_map.dtsi
@@ -22,9 +22,7 @@
 	cpurad_rx_partitions: cpurad-rx-partitions {
 		compatible = "nordic,owned-partitions", "fixed-partitions";
 		status = "okay";
-		perm-read;
-		perm-execute;
-		perm-secure;
+		nordic,access = <NRF_OWNER_ID_RADIOCORE NRF_PERM_RXS>;
 		#address-cells = < 0x1 >;
 		#size-cells = < 0x1 >;
 		cpurad_slot0_partition: partition@66000 {

--- a/samples/openthread/cli/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/openthread/cli/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -19,9 +19,7 @@
 	cpuapp_rx_partitions: cpuapp-rx-partitions {
 		compatible = "nordic,owned-partitions", "fixed-partitions";
 		status = "okay";
-		perm-read;
-		perm-execute;
-		perm-secure;
+		nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RXS>;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
@@ -37,8 +35,7 @@
 	cpuapp_rw_partitions: cpuapp-rw-partitions {
 		compatible = "nordic,owned-partitions", "fixed-partitions";
 		status = "okay";
-		perm-read;
-		perm-write;
+		nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RW>;
 		#address-cells = < 0x1 >;
 		#size-cells = < 0x1 >;
 

--- a/samples/peripheral/radio_test/boards/nrf54h20dk_nrf54h20_cpurad.overlay
+++ b/samples/peripheral/radio_test/boards/nrf54h20dk_nrf54h20_cpurad.overlay
@@ -15,17 +15,19 @@
 	status = "disabled";
 };
 
+&cpurad_dma_region {
+	status = "disabled";
+};
+
+/* Take Application's DMA region, which is larger and unused. */
+cpurad_dma_region_alt: &cpuapp_dma_region {
+	status = "okay";
+	nordic,access = <NRF_OWNER_ID_RADIOCORE NRF_PERM_RW>;
+};
+
 &uart136 {
 	status = "okay";
-	memory-regions = <&cpurad_dma_region>;
-};
-
-&cpuapp_dma_region {
-	reg = <0xe80 0x80>;
-};
-
-&cpurad_dma_region {
-	reg = <0xf00 DT_SIZE_K(4)>;
+	memory-regions = <&cpurad_dma_region_alt>;
 };
 
 &dppic020 {

--- a/samples/suit/smp_transfer/sysbuild/nrf54h20dk_nrf54h20_memory_map.dtsi
+++ b/samples/suit/smp_transfer/sysbuild/nrf54h20dk_nrf54h20_memory_map.dtsi
@@ -16,9 +16,7 @@
 };
 &cpurad_rx_partitions {
 	compatible = "nordic,owned-partitions", "fixed-partitions";
-	perm-read;
-	perm-execute;
-	perm-secure;
+	nordic,access = <NRF_OWNER_ID_RADIOCORE NRF_PERM_RXS>;
 	#address-cells = < 0x1 >;
 	#size-cells = < 0x1 >;
 	cpurad_slot0_partition: partition@66000 {

--- a/snippets/nordic-bt-rpc/boards/nrf54h20dk_nrf54h20-mem-map-move.dtsi
+++ b/snippets/nordic-bt-rpc/boards/nrf54h20dk_nrf54h20-mem-map-move.dtsi
@@ -18,9 +18,7 @@
 &mram1x {
 	cpurad_rw_partitions: cpurad-rw-partitions {
 		compatible = "nordic,owned-partitions", "fixed-partitions";
-		perm-read;
-		perm-write;
-		perm-secure;
+		nordic,access = <NRF_OWNER_ID_RADIOCORE NRF_PERM_RWS>;
 		#address-cells = <1>;
 		#size-cells = <1>;
 

--- a/subsys/nrf_security/Kconfig
+++ b/subsys/nrf_security/Kconfig
@@ -56,7 +56,7 @@ if NRF_SECURITY
 config MBEDTLS_ENABLE_BUILTIN_KEYS
 	bool
 	default y if SOC_SERIES_NRF54LX && (HW_UNIQUE_KEY || IDENTITY_KEY)
-	default y if SOC_SERIES_NRF54HX && (SOC_NRF54H20_CPUSEC)
+	default y if SOC_SERIES_NRF54HX && (SOC_NRF54H20_CPUSEC || SOC_NRF54H20_ENGB_CPUSEC)
 	help
 	  Promptless option used to control if MBEDTLS should have support for builtin keys or not.
 
@@ -260,6 +260,9 @@ endchoice
 
 # This is for internal use only.
 config SOC_NRF54H20_CPUSEC
+	bool
+
+config SOC_NRF54H20_ENGB_CPUSEC
 	bool
 
 endmenu

--- a/subsys/nrf_security/src/drivers/cracen/psa_driver.Kconfig
+++ b/subsys/nrf_security/src/drivers/cracen/psa_driver.Kconfig
@@ -1853,7 +1853,7 @@ config PSA_NEED_CRACEN_PLATFORM_KEYS
 	default y
 	depends on PSA_WANT_ALG_GCM
 	depends on PSA_WANT_AES_KEY_SIZE_256
-	depends on SOC_NRF54H20_CPUSEC
+	depends on (SOC_NRF54H20_CPUSEC || SOC_NRF54H20_ENGB_CPUSEC)
 
 
 endmenu

--- a/tests/subsys/dfu/dfu_target/suit/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/subsys/dfu/dfu_target/suit/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -23,9 +23,7 @@
 	cpuapp_rw_partitions: cpuapp-rw-partitions {
 		compatible = "nordic,owned-partitions", "fixed-partitions";
 		status = "okay";
-		perm-read;
-		perm-write;
-		perm-secure;
+		nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RWS>;
 		#address-cells = < 0x1 >;
 		#size-cells = < 0x1 >;
 

--- a/tests/subsys/suit/cache_pool_digest/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/subsys/suit/cache_pool_digest/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -26,8 +26,7 @@
 	cpuapp_rw_partitions: cpuapp-rw-partitions {
 		compatible = "nordic,owned-partitions", "fixed-partitions";
 		status = "okay";
-		perm-read;
-		perm-write;
+		nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RW>;
 		#address-cells = < 0x1 >;
 		#size-cells = < 0x1 >;
 

--- a/tests/subsys/suit/cache_sink/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/subsys/suit/cache_sink/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -15,8 +15,7 @@
 	cpuapp_rw_partitions: cpuapp-rw-partitions {
 		compatible = "nordic,owned-partitions", "fixed-partitions";
 		status = "okay";
-		perm-read;
-		perm-write;
+		nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RW>;
 		#address-cells = < 0x1 >;
 		#size-cells = < 0x1 >;
 

--- a/tests/subsys/suit/flash_sink/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/subsys/suit/flash_sink/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -15,8 +15,7 @@
 	cpuapp_rw_partitions: cpuapp-rw-partitions {
 		compatible = "nordic,owned-partitions", "fixed-partitions";
 		status = "okay";
-		perm-read;
-		perm-write;
+		nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RW>;
 		#address-cells = < 0x1 >;
 		#size-cells = < 0x1 >;
 

--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: ed414beb4617361fbf55f9a15fdf5f489aff6be2
+      revision: 3bedb2dfd9d68d08d5bf9405ce92c7e2bf11d4e7
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull in updated Nordic owned memory bindings and align NCS applications, samples, snippets, and tests. `nordic,access` replaces the `perm-*` properties.