### PR TITLE
scripts: quarantine_zephyr: Add quarantine for scenarios on nrf54l15{p}dk

### DIFF
--- a/scripts/quarantine_zephyr.yaml
+++ b/scripts/quarantine_zephyr.yaml
@@ -187,6 +187,12 @@
     - nrf54l15pdk/nrf54l15/cpuflpr
   comment: "Missing support for nrf54l15pdk"
 
+- scenarios:
+    - sample.filesystem.fat_fs.nrf54l15dk
+  platforms:
+    - nrf54l15dk/nrf54l15/cpuapp
+  comment: "Test not aligned for nrf54l15 - missing PM configuration"
+
 # ---------------------------------   Won't fix section -----------------------------------
 
 - scenarios:

--- a/scripts/quarantine_zephyr.yaml
+++ b/scripts/quarantine_zephyr.yaml
@@ -180,6 +180,13 @@
     - nrf9160dk/nrf9160/ns
   comment: "https://nordicsemi.atlassian.net/browse/NCSDK-29462"
 
+- scenarios:
+    - drivers.watchdog
+  platforms:
+    - nrf54l15pdk/nrf54l15/cpuapp
+    - nrf54l15pdk/nrf54l15/cpuflpr
+  comment: "Missing support for nrf54l15pdk"
+
 # ---------------------------------   Won't fix section -----------------------------------
 
 - scenarios:

--- a/scripts/quarantine_zephyr.yaml
+++ b/scripts/quarantine_zephyr.yaml
@@ -193,6 +193,12 @@
     - nrf54l15dk/nrf54l15/cpuapp
   comment: "Test not aligned for nrf54l15 - missing PM configuration"
 
+- scenarios:
+    - sample.bluetooth.hci_uart.nrf54l15.all
+  platforms:
+    - nrf54l15dk/nrf54l15/cpuapp
+  comment: "Test not aligned for nrf54l15 - missing snippet settings"
+
 # ---------------------------------   Won't fix section -----------------------------------
 
 - scenarios:


### PR DESCRIPTION
The scenarios are added due to missing support for nrf54l15pdk or bugs on nrf54l15dk on sdk-zephyr.

The issues will fix later.
