### PR TITLE
suit: cache partitions in zip file && separate files for recovery image cache partitions

### DIFF
--- a/cmake/sysbuild/suit.cmake
+++ b/cmake/sysbuild/suit.cmake
@@ -83,9 +83,14 @@ function(suit_generate_dfu_zip)
     GLOBAL PROPERTY
     SUIT_DFU_ARTIFACTS
   )
+  get_property(
+    additional_script_params
+    GLOBAL PROPERTY
+    SUIT_DFU_ZIP_ADDITIONAL_SCRIPT_PARAMS
+  )
 
   set(root_name "${SB_CONFIG_SUIT_ENVELOPE_ROOT_ARTIFACT_NAME}.suit")
-  set(script_params "${root_name}type=suit-envelope")
+  set(script_params "${root_name}type=suit-envelope;${additional_script_params}")
 
   include(${ZEPHYR_NRF_MODULE_DIR}/cmake/fw_zip.cmake)
 
@@ -339,13 +344,16 @@ function(suit_create_package)
         "--input" "\"${IMAGE_CACHE_URI},${BINARY_DIR}/zephyr/${BINARY_FILE}.bin\""
       )
     endforeach()
-    list(APPEND CACHE_CREATE_ARGS "--output-file" "${SUIT_ROOT_DIRECTORY}dfu_cache_partition_${CACHE_PARTITION_NUM}.bin")
 
     if(SUIT_DFU_CACHE_PARTITION_${CACHE_PARTITION_NUM}_EB_SIZE)
       list(APPEND CACHE_CREATE_ARGS "--eb-size" "${SUIT_DFU_CACHE_PARTITION_${CACHE_PARTITION_NUM}_EB_SIZE}")
     endif()
 
-    suit_create_cache_partition("${CACHE_CREATE_ARGS}")
+    suit_create_cache_partition(
+      "${CACHE_CREATE_ARGS}"
+      "${SUIT_ROOT_DIRECTORY}dfu_cache_partition_${CACHE_PARTITION_NUM}.bin"
+      ${CACHE_PARTITION_NUM}
+    )
   endforeach()
 
   if(SB_CONFIG_SUIT_BUILD_RECOVERY)

--- a/cmake/sysbuild/suit_utilities.cmake
+++ b/cmake/sysbuild/suit_utilities.cmake
@@ -84,7 +84,10 @@ function(suit_create_envelope input_file output_file create_signature)
   endif()
 endfunction()
 
-function(suit_create_cache_partition args)
+function(suit_create_cache_partition args output_file partition_num)
+
+  list(APPEND args "--output-file" "${output_file}")
+
   set_property(
     GLOBAL APPEND PROPERTY SUIT_POST_BUILD_COMMANDS
     COMMAND ${PYTHON_EXECUTABLE} ${SUIT_GENERATOR_CLI_SCRIPT}
@@ -92,4 +95,9 @@ function(suit_create_cache_partition args)
     ${args}
     BYPRODUCTS ${output_file}
   )
+
+  get_filename_component(output_file_name ${output_file} NAME)
+
+  set_property(GLOBAL APPEND PROPERTY SUIT_DFU_ARTIFACTS ${output_file})
+  set_property(GLOBAL APPEND PROPERTY SUIT_DFU_ZIP_ADDITIONAL_SCRIPT_PARAMS "${output_file_name}type=cache;${output_file_name}partition=${partition_num};")
 endfunction()

--- a/cmake/sysbuild/suit_utilities.cmake
+++ b/cmake/sysbuild/suit_utilities.cmake
@@ -84,7 +84,7 @@ function(suit_create_envelope input_file output_file create_signature)
   endif()
 endfunction()
 
-function(suit_create_cache_partition args output_file partition_num)
+function(suit_create_cache_partition args output_file partition_num recovery)
 
   list(APPEND args "--output-file" "${output_file}")
 
@@ -98,6 +98,13 @@ function(suit_create_cache_partition args output_file partition_num)
 
   get_filename_component(output_file_name ${output_file} NAME)
 
-  set_property(GLOBAL APPEND PROPERTY SUIT_DFU_ARTIFACTS ${output_file})
-  set_property(GLOBAL APPEND PROPERTY SUIT_DFU_ZIP_ADDITIONAL_SCRIPT_PARAMS "${output_file_name}type=cache;${output_file_name}partition=${partition_num};")
+  if (recovery)
+    set_property(GLOBAL APPEND PROPERTY SUIT_RECOVERY_DFU_ARTIFACTS ${output_file})
+    set_property(GLOBAL APPEND PROPERTY SUIT_RECOVERY_DFU_ZIP_ADDITIONAL_SCRIPT_PARAMS
+                 "${output_file_name}type=cache;${output_file_name}partition=${partition_num};")
+  else()
+    set_property(GLOBAL APPEND PROPERTY SUIT_DFU_ARTIFACTS ${output_file})
+    set_property(GLOBAL APPEND PROPERTY SUIT_DFU_ZIP_ADDITIONAL_SCRIPT_PARAMS
+                 "${output_file_name}type=cache;${output_file_name}partition=${partition_num};")
+  endif()
 endfunction()

--- a/config/suit/templates/nrf54h20/default/v1/rad_recovery_envelope.yaml.jinja2
+++ b/config/suit/templates/nrf54h20/default/v1/rad_recovery_envelope.yaml.jinja2
@@ -101,7 +101,7 @@ SUIT_Envelope_Tagged:
     - RFC4122_UUID:
         namespace: {{ mpi_rad_recovery_vendor_name }}
         name: {{ mpi_rad_recovery_class_name }}
-  suit-integrated-payloads:
 {%- if 'CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE' not in rad_recovery['config'] or rad_recovery['config']['CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE'] == '' %}
+  suit-integrated-payloads:
     '#{{ rad_recovery['name'] }}': {{ rad_recovery['binary'] }}
 {%- endif %}

--- a/samples/suit/smp_transfer/sample.yaml
+++ b/samples/suit/smp_transfer/sample.yaml
@@ -49,8 +49,6 @@ tests:
     extra_args:
       - FILE_SUFFIX=bt
       - SB_CONFIG_SUIT_BUILD_RECOVERY=y
-    extra_configs:
-      - CONFIG_SUIT_DFU_CANDIDATE_PROCESSING_FULL=y
     tags: suit bluetooth ci_samples_suit
 
   sample.suit.smp_transfer.full_processing.extflash.bt:


### PR DESCRIPTION
This PR addresses two functionalities:

1) Allowing putting the SUIT DFU cache partitions in the DFU zip file, so that the file matches the agreed format

2) Separating the dfu_cache partitions used when building the main application from the dfu_cache partitions created when buillding the recovery images 