### PR TITLE
codeowners: change owners of `/subsys/net/openthread/rpc`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -313,6 +313,7 @@
 /subsys/net/lib/wifi_credentials/         @nrfconnect/ncs-cia
 /subsys/net/lib/softap_wifi_provision/    @nrfconnect/ncs-cia
 /subsys/net/openthread/                   @nrfconnect/ncs-co-networking @nrfconnect/ncs-thread
+/subsys/net/openthread/rpc/               @nrfconnect/ncs-protocols-serialization
 /subsys/nfc/                              @nrfconnect/ncs-si-muffin
 /subsys/nfc/rpc/                          @nrfconnect/ncs-protocols-serialization
 /subsys/nrf_compress/                     @nordicjm


### PR DESCRIPTION
`/subsys/net/openthread/rpc` should be owned by
`@nrfconnect/ncs-protocols-serialization` group