### PR TITLE
applications: nrf5340_audio: Fix HFClock calculation

### DIFF
--- a/applications/nrf5340_audio/src/audio/audio_datapath.c
+++ b/applications/nrf5340_audio/src/audio/audio_datapath.c
@@ -69,9 +69,9 @@ LOG_MODULE_REGISTER(audio_datapath, CONFIG_AUDIO_DATAPATH_LOG_LEVEL);
 #define PRES_COMP_NUM_DATA_PTS (DRIFT_MEAS_PERIOD_US / CONFIG_AUDIO_FRAME_DURATION_US)
 
 /* Audio clock - nRF5340 Analog Phase-Locked Loop (APLL) */
-#define APLL_FREQ_CENTER 39854
-#define APLL_FREQ_MIN	 36834
-#define APLL_FREQ_MAX	 42874
+#define APLL_FREQ_MIN	 HFCLKAUDIO_12_165_MHZ
+#define APLL_FREQ_CENTER HFCLKAUDIO_12_288_MHZ
+#define APLL_FREQ_MAX	 HFCLKAUDIO_12_411_MHZ
 /* Use nanoseconds to reduce rounding errors */
 /* clang-format off */
 #define APLL_FREQ_ADJ(t) (-((t)*1000) / 331)

--- a/applications/nrf5340_audio/src/modules/audio_i2s.c
+++ b/applications/nrf5340_audio/src/modules/audio_i2s.c
@@ -16,8 +16,6 @@
 
 #define I2S_NL DT_NODELABEL(i2s0)
 
-#define HFCLKAUDIO_12_288_MHZ 0x9BAE
-
 enum audio_i2s_state {
 	AUDIO_I2S_STATE_UNINIT,
 	AUDIO_I2S_STATE_IDLE,

--- a/applications/nrf5340_audio/src/modules/audio_i2s.h
+++ b/applications/nrf5340_audio/src/modules/audio_i2s.h
@@ -15,6 +15,17 @@
  * be 10 or 7.5 ms. Since we can't have floats in a define we use 15/2 instead
  */
 
+/**
+ * Calculation:
+ * FREQ_VALUE = 2^16 * ((12 * f_out / 32M) - 4)
+ * f_out == 12.288
+ * 39845.888 = 2^16 * ((12 * 12.288 / 32M) - 4)
+ * 39846 = 0x9BA6
+ */
+#define HFCLKAUDIO_12_288_MHZ 0x9BA6
+#define HFCLKAUDIO_12_165_MHZ 0x8FD8
+#define HFCLKAUDIO_12_411_MHZ 0xA774
+
 #if ((CONFIG_AUDIO_FRAME_DURATION_US == 7500) && CONFIG_SW_CODEC_LC3)
 
 #define FRAME_SIZE_BYTES                                                                           \


### PR DESCRIPTION
- Fixes bug where the calculation for HFClock was entered incorrectly
 - Old value: 39854
 - New correct value: 39845.888
- OCT-NONE