### PR TITLE
samples: benchmarks: coremark: remove support for nrf54l15pdk

### DIFF
--- a/samples/benchmarks/coremark/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/benchmarks/coremark/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -1,6 +1,0 @@
-#
-# Copyright (c) 2024 Nordic Semiconductor ASA
-#
-# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
-
-CONFIG_COREMARK_ITERATIONS=4000

--- a/samples/benchmarks/coremark/sample.yaml
+++ b/samples/benchmarks/coremark/sample.yaml
@@ -14,7 +14,6 @@ tests:
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
@@ -22,7 +21,6 @@ tests:
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     tags: ci_build sysbuild ci_samples_benchmarks
     harness: console
@@ -54,7 +52,6 @@ tests:
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
@@ -62,7 +59,6 @@ tests:
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     tags: ci_build sysbuild ci_samples_benchmarks
     extra_args: EXTRA_CONF_FILE="prj_static_memory.conf"
@@ -75,7 +71,6 @@ tests:
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
@@ -83,7 +78,6 @@ tests:
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     tags: ci_build sysbuild ci_samples_benchmarks
     extra_args: EXTRA_CONF_FILE="prj_multiple_threads.conf"

--- a/scripts/quarantine_integration.yaml
+++ b/scripts/quarantine_integration.yaml
@@ -533,7 +533,6 @@
     - nrf52833dk/nrf52833
     - nrf5340dk/nrf5340/cpuapp
     - nrf54l15dk/nrf54l15/cpuapp
-    - nrf54l15pdk/nrf54l15/cpuapp
     - nrf54h20dk/nrf54h20/cpuapp
   comment: "Configurations excluded to limit resources usage in integration builds"
 
@@ -544,7 +543,6 @@
     - nrf52833dk/nrf52833
     - nrf5340dk/nrf5340/cpuapp
     - nrf54l15dk/nrf54l15/cpuapp
-    - nrf54l15pdk/nrf54l15/cpuapp
     - nrf54h20dk/nrf54h20/cpuapp
   comment: "Configurations excluded to limit resources usage in integration builds"
 


### PR DESCRIPTION
Removed support for the nRF54L15 PDK target in the CoreMark sample.