### PR TITLE
Bluetooth: Controller: Update sdk-nrf power management util implement…

### DIFF
--- a/subsys/mpsl/pm/mpsl_pm_utils.c
+++ b/subsys/mpsl/pm/mpsl_pm_utils.c
@@ -26,8 +26,6 @@ LOG_MODULE_REGISTER(mpsl_pm_utils, CONFIG_MPSL_LOG_LEVEL);
 static void m_work_handler(struct k_work *work);
 static K_WORK_DELAYABLE_DEFINE(pm_work, m_work_handler);
 
-#define RETRY_TIME_MAX_US (UINT32_MAX - TIME_TO_REGISTER_EVENT_IN_ZEPHYR_US)
-
 static uint8_t                          m_pm_prev_flag_value;
 static bool                             m_pm_event_is_registered;
 static uint32_t                         m_prev_lat_value_us;
@@ -73,12 +71,32 @@ void mpsl_pm_utils_work_handler(void)
 		/* In case we missed a state and are in zero-latency, set low-latency.*/
 		m_update_latency_request(PM_MAX_LATENCY_HCI_COMMANDS_US);
 
-		/* Event scheduled */
-		if (params.event_time_abs_us > UINT32_MAX) {
-			mpsl_work_schedule(&pm_work, K_USEC(RETRY_TIME_MAX_US));
+		/* Note: Considering an overflow could only happen if the system runs many years,
+		 * it needen't be considered here.
+		 */
+		int64_t current_time_us = k_uptime_get() * 1000;
+		uint64_t relative_time_us = params.event_time_abs_us - current_time_us;
+		uint64_t max_cycles_until_event = k_us_to_cyc_floor64(relative_time_us);
+
+		if (max_cycles_until_event > UINT32_MAX) {
+			/* The event is too far in the future and would
+			 * exceed the 32-bit cycle limit.
+			 */
+			uint64_t event_delay_us = params.event_time_abs_us - current_time_us -
+						  TIME_TO_REGISTER_EVENT_IN_ZEPHYR_US;
+#ifdef CONFIG_TIMEOUT_64BIT
+			mpsl_work_schedule(&pm_work, K_USEC(event_delay_us));
+#else
+			if (event_delay_us > UINT32_MAX) {
+				mpsl_work_schedule(&pm_work, K_USEC(UINT32_MAX));
+			} else {
+				mpsl_work_schedule(&pm_work, K_USEC((uint32_t)event_delay_us));
+			}
+#endif
 			return;
 		}
 
+		/* Event scheduled */
 		if (m_pm_event_is_registered) {
 			pm_policy_event_update(&m_evt,
 					       k_us_to_cyc_floor32(params.event_time_abs_us));

--- a/tests/subsys/mpsl/pm/CMakeLists.txt
+++ b/tests/subsys/mpsl/pm/CMakeLists.txt
@@ -13,6 +13,7 @@ project(pm_test)
 test_runner_generate(pm_test.c)
 
 # Create mocks for pm module.
+cmock_handle(${CMAKE_CURRENT_SOURCE_DIR}/kernel_minimal_mock.h)
 cmock_handle(${ZEPHYR_BASE}/include/zephyr/pm/policy.h)
 cmock_handle(${ZEPHYR_NRFXLIB_MODULE_DIR}/mpsl/include/mpsl_pm.h)
 cmock_handle(${ZEPHYR_NRFXLIB_MODULE_DIR}/mpsl/include/mpsl_pm_config.h)
@@ -29,7 +30,7 @@ target_include_directories(app PRIVATE src)
 
 # Preinclude file to the UUT to redefine mpsl_work_schedule().
 set_property(SOURCE ${ZEPHYR_NRF_MODULE_DIR}/subsys/mpsl/pm/mpsl_pm_utils.c
-        PROPERTY COMPILE_FLAGS "-include mocks/mpsl_work.h")
+        PROPERTY COMPILE_FLAGS "-include mocks/kernel_minimal_mock.h -include mocks/mpsl_work.h")
 
 # Options that cannot be passed through Kconfig fragments.
 target_compile_options(app PRIVATE

--- a/tests/subsys/mpsl/pm/kernel_minimal_mock.h
+++ b/tests/subsys/mpsl/pm/kernel_minimal_mock.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+#ifndef ZEPHYR_INCLUDE_KERNEL_H_
+#define ZEPHYR_INCLUDE_KERNEL_H_
+/* CMock chokes on zephyr/kernel.h, so we define the minimum required to build
+ * mpsl_pm and tests, then let CMock generate mocks from this file instead.
+ */
+#include <stdint.h>
+struct k_work {
+};
+typedef struct k_timeout {
+	uint64_t value;
+} k_timeout_t;
+struct k_work_delayable {
+	void *handler;
+};
+#define Z_WORK_DELAYABLE_INITIALIZER(work_handler) {work_handler}
+#define K_WORK_DELAYABLE_DEFINE(work, work_handler)                                                \
+	struct k_work_delayable work = Z_WORK_DELAYABLE_INITIALIZER(work_handler)
+k_timeout_t K_USEC(uint64_t d);
+int64_t k_uptime_get(void);
+#endif

--- a/tests/subsys/mpsl/pm/pm_test.c
+++ b/tests/subsys/mpsl/pm/pm_test.c
@@ -14,15 +14,13 @@
 #include "cmock_mpsl_pm.h"
 #include "cmock_mpsl_pm_config.h"
 #include "cmock_mpsl_work.h"
+#include "cmock_kernel_minimal_mock.h"
 
 #include <mpsl/mpsl_pm_utils.h>
-#include <zephyr/kernel.h>
-
 
 #define PM_MAX_LATENCY_HCI_COMMANDS_US 499999
 
 #define TIME_TO_REGISTER_EVENT_IN_ZEPHYR_US 1000
-#define RETRY_TIME_MAX_US (UINT32_MAX - TIME_TO_REGISTER_EVENT_IN_ZEPHYR_US)
 
 /* Mock implementation for mpsl_work_q*/
 struct k_work_q mpsl_work_q;
@@ -55,6 +53,7 @@ typedef struct {
 	uint64_t event_time_us;
 	latency_func_t latency_func;
 	uint64_t latency_us;
+	int64_t curr_time_ms;
 } test_vector_t;
 
 void run_test(test_vector_t *p_test_vectors, int num_test_vctr)
@@ -79,10 +78,12 @@ void run_test(test_vector_t *p_test_vectors, int num_test_vctr)
 
 			switch (v.event_func) {
 			case EVENT_FUNC_REGISTER:
+				__cmock_k_uptime_get_ExpectAndReturn(v.curr_time_ms);
 				__cmock_pm_policy_event_register_Expect(0, v.event_time_us);
 				__cmock_pm_policy_event_register_IgnoreArg_evt();
 				break;
 			case EVENT_FUNC_UPDATE:
+				__cmock_k_uptime_get_ExpectAndReturn(v.curr_time_ms);
 				__cmock_pm_policy_event_update_Expect(0, v.event_time_us);
 				__cmock_pm_policy_event_update_IgnoreArg_evt();
 				break;
@@ -90,7 +91,11 @@ void run_test(test_vector_t *p_test_vectors, int num_test_vctr)
 				__cmock_pm_policy_event_unregister_ExpectAnyArgs();
 				break;
 			case EVENT_FUNC_DELAY_SCHEDULING:
-				__cmock_mpsl_work_schedule_Expect(0, K_USEC(v.event_time_us));
+				__cmock_k_uptime_get_ExpectAndReturn(v.curr_time_ms);
+				__cmock_K_USEC_ExpectAndReturn(
+					v.event_time_us, (k_timeout_t){v.event_time_us + 100});
+				__cmock_mpsl_work_schedule_Expect(
+					0, (k_timeout_t){v.event_time_us + 100});
 				__cmock_mpsl_work_schedule_IgnoreArg_dwork();
 				break;
 			case EVENT_FUNC_NONE:
@@ -118,7 +123,7 @@ void test_init_only(void)
 	test_vector_t test_vectors[] = {
 		{true, false, {0, MPSL_PM_EVENT_STATE_NO_EVENTS_LEFT, 0},
 		 EVENT_FUNC_NONE, 0,
-		 LATENCY_FUNC_REGISTER, PM_MAX_LATENCY_HCI_COMMANDS_US},
+		 LATENCY_FUNC_REGISTER, PM_MAX_LATENCY_HCI_COMMANDS_US, 0},
 	};
 	run_test(&test_vectors[0], ARRAY_SIZE(test_vectors));
 }
@@ -129,10 +134,10 @@ void test_no_events(void)
 		/* Init then no events*/
 		{true, false, {0, MPSL_PM_EVENT_STATE_NO_EVENTS_LEFT, 0},
 		 EVENT_FUNC_NONE, 0,
-		 LATENCY_FUNC_REGISTER, PM_MAX_LATENCY_HCI_COMMANDS_US},
+		 LATENCY_FUNC_REGISTER, PM_MAX_LATENCY_HCI_COMMANDS_US, 0},
 		{false, false, {0, MPSL_PM_EVENT_STATE_NO_EVENTS_LEFT, 0},
 		 EVENT_FUNC_NONE, 0,
-		 LATENCY_FUNC_NONE, 0},
+		 LATENCY_FUNC_NONE, 0, 0},
 	};
 	run_test(&test_vectors[0], ARRAY_SIZE(test_vectors));
 }
@@ -143,11 +148,11 @@ void test_high_prio_changed_params(void)
 		/* Init. */
 		{true, false, {0, MPSL_PM_EVENT_STATE_NO_EVENTS_LEFT, 0},
 		 EVENT_FUNC_NONE, 0,
-		 LATENCY_FUNC_REGISTER, PM_MAX_LATENCY_HCI_COMMANDS_US},
+		 LATENCY_FUNC_REGISTER, PM_MAX_LATENCY_HCI_COMMANDS_US, 0},
 		/* Pretend high prio changed parameters while we read them. */
 		{false, false, {10000, MPSL_PM_EVENT_STATE_BEFORE_EVENT, 1},
 		 EVENT_FUNC_NONE, 0,
-		 LATENCY_FUNC_NONE, 0},
+		 LATENCY_FUNC_NONE, 0, 0},
 	};
 	run_test(&test_vectors[0], ARRAY_SIZE(test_vectors));
 }
@@ -158,19 +163,19 @@ void test_latency_request(void)
 		/* Init. */
 		{true, false, {0, MPSL_PM_EVENT_STATE_NO_EVENTS_LEFT, 0},
 		 EVENT_FUNC_NONE, 0,
-		 LATENCY_FUNC_REGISTER, PM_MAX_LATENCY_HCI_COMMANDS_US},
+		 LATENCY_FUNC_REGISTER, PM_MAX_LATENCY_HCI_COMMANDS_US, 0},
 		/* Check low-latency is set. */
 		{false, true, {0, MPSL_PM_EVENT_STATE_NO_EVENTS_LEFT, 1},
 		 EVENT_FUNC_NONE, 0,
-		 LATENCY_FUNC_NONE, 0},
+		 LATENCY_FUNC_NONE, 0, 0},
 		/* Set zero-latency. */
 		{false, true, {0, MPSL_PM_EVENT_STATE_IN_EVENT, 2},
 		 EVENT_FUNC_NONE, 0,
-		 LATENCY_FUNC_UPDATE, 0},
+		 LATENCY_FUNC_UPDATE, 0, 0},
 		/* Set low-latency. */
 		{false, true, {0, MPSL_PM_EVENT_STATE_NO_EVENTS_LEFT, 3},
 		 EVENT_FUNC_NONE, 0,
-		 LATENCY_FUNC_UPDATE, PM_MAX_LATENCY_HCI_COMMANDS_US},
+		 LATENCY_FUNC_UPDATE, PM_MAX_LATENCY_HCI_COMMANDS_US, 0},
 	};
 	run_test(&test_vectors[0], ARRAY_SIZE(test_vectors));
 }
@@ -181,15 +186,15 @@ void test_register_and_derigster_event(void)
 		/* Init. */
 		{true, false, {0, MPSL_PM_EVENT_STATE_NO_EVENTS_LEFT, 0},
 		 EVENT_FUNC_NONE, 0,
-		 LATENCY_FUNC_REGISTER, PM_MAX_LATENCY_HCI_COMMANDS_US},
+		 LATENCY_FUNC_REGISTER, PM_MAX_LATENCY_HCI_COMMANDS_US, 0},
 		/* Register event. */
 		{false, true, {10000, MPSL_PM_EVENT_STATE_BEFORE_EVENT, 1},
 		 EVENT_FUNC_REGISTER, 10000,
-		 LATENCY_FUNC_NONE, 0},
+		 LATENCY_FUNC_NONE, 0, 0},
 		/* Deregister event. */
 		{false, true, {0, MPSL_PM_EVENT_STATE_NO_EVENTS_LEFT, 2},
 		 EVENT_FUNC_UNREGISTER, 0,
-		 LATENCY_FUNC_NONE, 0},
+		 LATENCY_FUNC_NONE, 0, 0},
 	};
 	run_test(&test_vectors[0], ARRAY_SIZE(test_vectors));
 }
@@ -200,19 +205,19 @@ void test_register_enter_and_derigster_event(void)
 		/* Init. */
 		{true, false, {0, MPSL_PM_EVENT_STATE_NO_EVENTS_LEFT, 0},
 		 EVENT_FUNC_NONE, 0,
-		 LATENCY_FUNC_REGISTER, PM_MAX_LATENCY_HCI_COMMANDS_US},
+		 LATENCY_FUNC_REGISTER, PM_MAX_LATENCY_HCI_COMMANDS_US, 0},
 		 /* Register event. */
 		{false, true, {10000, MPSL_PM_EVENT_STATE_BEFORE_EVENT, 1},
 		 EVENT_FUNC_REGISTER, 10000,
-		 LATENCY_FUNC_NONE, 0},
+		 LATENCY_FUNC_NONE, 0, 0},
 		/* Pretend to be in event */
 		{false, true, {0, MPSL_PM_EVENT_STATE_IN_EVENT, 2},
 		 EVENT_FUNC_NONE, 0,
-		 LATENCY_FUNC_UPDATE, 0},
+		 LATENCY_FUNC_UPDATE, 0, 0},
 		/* Deregister event. */
 		{false, true, {0, MPSL_PM_EVENT_STATE_NO_EVENTS_LEFT, 3},
 		 EVENT_FUNC_UNREGISTER, 0,
-		 LATENCY_FUNC_UPDATE, PM_MAX_LATENCY_HCI_COMMANDS_US},
+		 LATENCY_FUNC_UPDATE, PM_MAX_LATENCY_HCI_COMMANDS_US, 0},
 	};
 	run_test(&test_vectors[0], ARRAY_SIZE(test_vectors));
 }
@@ -223,23 +228,23 @@ void test_register_update_enter_and_deregister_event(void)
 		/* Init. */
 		{true, false, {0, MPSL_PM_EVENT_STATE_NO_EVENTS_LEFT, 0},
 		 EVENT_FUNC_NONE, 0,
-		 LATENCY_FUNC_REGISTER, PM_MAX_LATENCY_HCI_COMMANDS_US},
+		 LATENCY_FUNC_REGISTER, PM_MAX_LATENCY_HCI_COMMANDS_US, 0},
 		/* Register event. */
 		{false, true, {10000, MPSL_PM_EVENT_STATE_BEFORE_EVENT, 1},
 		 EVENT_FUNC_REGISTER, 10000,
-		 LATENCY_FUNC_NONE, 0},
+		 LATENCY_FUNC_NONE, 0, 0},
 		/* Update event. */
 		{false, true, {15000, MPSL_PM_EVENT_STATE_BEFORE_EVENT, 2},
 		 EVENT_FUNC_UPDATE, 15000,
-		 LATENCY_FUNC_NONE, 0},
+		 LATENCY_FUNC_NONE, 0, 0},
 		/* Pretend to be in event */
 		{false, true, {0, MPSL_PM_EVENT_STATE_IN_EVENT, 3},
 		 EVENT_FUNC_NONE, 0,
-		 LATENCY_FUNC_UPDATE, 0},
+		 LATENCY_FUNC_UPDATE, 0, 0},
 		/* Deregister event. */
 		{false, true, {0, MPSL_PM_EVENT_STATE_NO_EVENTS_LEFT, 4},
 		 EVENT_FUNC_UNREGISTER, 0,
-		 LATENCY_FUNC_UPDATE, PM_MAX_LATENCY_HCI_COMMANDS_US},
+		 LATENCY_FUNC_UPDATE, PM_MAX_LATENCY_HCI_COMMANDS_US, 0},
 	};
 	run_test(&test_vectors[0], ARRAY_SIZE(test_vectors));
 }
@@ -250,54 +255,52 @@ void test_register_enter_and_update_event(void)
 		/* Init. */
 		{true, false, {0, MPSL_PM_EVENT_STATE_NO_EVENTS_LEFT, 0},
 		 EVENT_FUNC_NONE, 0,
-		 LATENCY_FUNC_REGISTER, PM_MAX_LATENCY_HCI_COMMANDS_US},
+		 LATENCY_FUNC_REGISTER, PM_MAX_LATENCY_HCI_COMMANDS_US, 0},
 		/* Register event. */
 		{false, true, {10000, MPSL_PM_EVENT_STATE_BEFORE_EVENT, 1},
 		 EVENT_FUNC_REGISTER, 10000,
-		 LATENCY_FUNC_NONE, 0},
+		 LATENCY_FUNC_NONE, 0, 0},
 		/* Pretend to be in event */
 		{false, true, {0, MPSL_PM_EVENT_STATE_IN_EVENT, 2},
 		 EVENT_FUNC_NONE, 0,
-		 LATENCY_FUNC_UPDATE, 0},
+		 LATENCY_FUNC_UPDATE, 0, 0},
 		/* Update event (before we get the state no events left). */
 		{false, true, {15000, MPSL_PM_EVENT_STATE_BEFORE_EVENT, 3},
 		 EVENT_FUNC_UPDATE, 15000,
-		 LATENCY_FUNC_UPDATE, PM_MAX_LATENCY_HCI_COMMANDS_US},
+		 LATENCY_FUNC_UPDATE, PM_MAX_LATENCY_HCI_COMMANDS_US, 0},
 	};
 	run_test(&test_vectors[0], ARRAY_SIZE(test_vectors));
 }
 
 void test_event_delayed_work(void)
 {
-	uint64_t retry_evt_time = (uint64_t)UINT32_MAX + (uint64_t)UINT32_MAX + 5000;
+	uint64_t event_time_us = (uint64_t)UINT32_MAX + 50000;
+	/* Make sure time until event will be more than UINT32_MAX cycles away. */
+	TEST_ASSERT_GREATER_THAN_INT64(UINT32_MAX, k_us_to_cyc_floor64(event_time_us));
+
 	test_vector_t test_vectors[] = {
 		/* Init. */
 		{true, false, {0, MPSL_PM_EVENT_STATE_NO_EVENTS_LEFT, 0},
 		 EVENT_FUNC_NONE, 0,
 		 LATENCY_FUNC_REGISTER, PM_MAX_LATENCY_HCI_COMMANDS_US},
-		/* Pretend we call workqueue delayed. */
-		{false, true, {retry_evt_time, MPSL_PM_EVENT_STATE_BEFORE_EVENT, 1},
-		 EVENT_FUNC_DELAY_SCHEDULING, RETRY_TIME_MAX_US,
-		 LATENCY_FUNC_NONE, 0},
-		/* Pretend we call workqueue delayed. */
-		{false, true, {retry_evt_time - RETRY_TIME_MAX_US,
-				MPSL_PM_EVENT_STATE_BEFORE_EVENT, 2},
-		 EVENT_FUNC_DELAY_SCHEDULING, RETRY_TIME_MAX_US,
-		 LATENCY_FUNC_NONE, 0},
-		/* Register event. */
-		{false, true, {retry_evt_time - RETRY_TIME_MAX_US - RETRY_TIME_MAX_US,
-				MPSL_PM_EVENT_STATE_BEFORE_EVENT, 3},
-		 EVENT_FUNC_REGISTER, retry_evt_time - RETRY_TIME_MAX_US -
-				      RETRY_TIME_MAX_US,
-		 LATENCY_FUNC_NONE, 0},
+		/* Event time after 32 bit cycles have wrapped, so schedule retry. */
+		{false, true, {event_time_us, MPSL_PM_EVENT_STATE_BEFORE_EVENT, 1},
+		 EVENT_FUNC_DELAY_SCHEDULING, event_time_us - 1000,
+		 LATENCY_FUNC_NONE, 0, 0},
+		/* Time has progressed until cycles will no longer wrap,
+		 * so register latency normally.
+		 */
+		{false, true, {event_time_us, MPSL_PM_EVENT_STATE_BEFORE_EVENT, 2},
+		 EVENT_FUNC_REGISTER, event_time_us,
+		 LATENCY_FUNC_NONE, 0, 100},
 		/* Pretend to be in event */
-		{false, true, {0, MPSL_PM_EVENT_STATE_IN_EVENT, 4},
+		{false, true, {0, MPSL_PM_EVENT_STATE_IN_EVENT, 3},
 		 EVENT_FUNC_NONE, 0,
-		 LATENCY_FUNC_UPDATE, 0},
+		 LATENCY_FUNC_UPDATE, 0, 0},
 		/* Deregister event. */
-		{false, true, {0, MPSL_PM_EVENT_STATE_NO_EVENTS_LEFT, 5},
+		{false, true, {0, MPSL_PM_EVENT_STATE_NO_EVENTS_LEFT, 4},
 		 EVENT_FUNC_UNREGISTER, 0,
-		 LATENCY_FUNC_UPDATE, PM_MAX_LATENCY_HCI_COMMANDS_US},
+		 LATENCY_FUNC_UPDATE, PM_MAX_LATENCY_HCI_COMMANDS_US, 0},
 	};
 	run_test(&test_vectors[0], ARRAY_SIZE(test_vectors));
 }


### PR DESCRIPTION
…ation

This is the contiunation of alignement PR to the current Zephyr Power management policy functions. In case we schedule an event (absolute time in us, uint64_t from our side) too far in the future, i.e. exceeding UINT32_MAX cycles, we can't register the event yet with the Zephyr Power Management, but have to call it at a later time.