### PR TITLE
nrf_security: fix broken builtin key support for nrf54h

### DIFF
--- a/subsys/nrf_security/CMakeLists.txt
+++ b/subsys/nrf_security/CMakeLists.txt
@@ -117,8 +117,7 @@ target_compile_definitions(psa_crypto_library_config
 # The name and intent of this comes from TF-M distribution
 add_library(psa_interface INTERFACE)
 
-# In nRF54L this configuration is required for the HUK keys to work
-if(CONFIG_SOC_SERIES_NRF54LX AND (CONFIG_HW_UNIQUE_KEY OR CONFIG_IDENTITY_KEY))
+if(CONFIG_MBEDTLS_ENABLE_BUILTIN_KEYS)
 # Add config files required for PSA crypto interface
 target_compile_definitions(psa_interface
   INTERFACE

--- a/subsys/nrf_security/Kconfig
+++ b/subsys/nrf_security/Kconfig
@@ -53,6 +53,13 @@ config PSA_PROMPTLESS
 
 if NRF_SECURITY
 
+config MBEDTLS_ENABLE_BUILTIN_KEYS
+	bool
+	default y if SOC_SERIES_NRF54LX && (HW_UNIQUE_KEY || IDENTITY_KEY)
+	default y if SOC_SERIES_NRF54HX && (SOC_NRF54H20_CPUSEC)
+	help
+	  Promptless option used to control if MBEDTLS should have support for builtin keys or not.
+
 config MBEDTLS_CFG_FILE
 	string "mbed TLS configuration file"
 	default "nrf-config.h"


### PR DESCRIPTION
It was no longer enabled after the upmerge.

Ref: NCSDK-29546