### PR TITLE
Samples: Bluetooth: conn time sync fix

### DIFF
--- a/samples/bluetooth/conn_time_sync/README.rst
+++ b/samples/bluetooth/conn_time_sync/README.rst
@@ -29,8 +29,16 @@ To observe that the LEDs are toggled synchronously, use a logic analyzer or an o
 
 Overview
 ********
+.. tabs::
 
-The Central and Peripheral devices toggle **LED 1** synchronously and within a few microseconds of one another.
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      The Central and Peripheral devices toggle **LED 2** synchronously and within a few microseconds of one another.
+
+   .. group-tab:: nRF54 DKs
+
+      The Central and Peripheral devices toggle **LED 1** synchronously and within a few microseconds of one another.
+
 The LEDs are toggled at the timestamp specified by the Central device.
 
 Clock synchronization
@@ -99,9 +107,17 @@ On nRF52 and nRF53 Series devices, you also need one RTC peripheral, one TIMER p
 
 User interface
 **************
+.. tabs::
 
-LED 1:
-   Blinks simultaneously on all devices after synchronization takes place.
+   .. group-tab:: nRF52 and nRF53 DKs
+
+      LED 2:
+         Blinks simultaneously on all devices after synchronization takes place.
+
+   .. group-tab:: nRF54 DKs
+
+      LED 1:
+         Blinks simultaneously on all devices after synchronization takes place.
 
 Building and running
 ********************

--- a/samples/bluetooth/conn_time_sync/src/timed_led_toggle.c
+++ b/samples/bluetooth/conn_time_sync/src/timed_led_toggle.c
@@ -54,8 +54,8 @@ int timed_led_toggle_init(void)
 	const nrfx_gpiote_task_config_t task_cfg_led_toggle = {
 		.task_ch = gpiote_chan_led_toggle,
 		.polarity = NRF_GPIOTE_POLARITY_TOGGLE,
-		.init_val = (led.dt_flags & GPIO_ACTIVE_HIGH) ?
-			NRF_GPIOTE_INITIAL_VALUE_LOW : NRF_GPIOTE_INITIAL_VALUE_HIGH,
+		.init_val = (led.dt_flags & GPIO_ACTIVE_LOW) ?
+			NRF_GPIOTE_INITIAL_VALUE_HIGH : NRF_GPIOTE_INITIAL_VALUE_LOW,
 	};
 
 	if (nrfx_gpiote_output_configure(&gpiote, LED_PIN, &gpiote_output_cfg,


### PR DESCRIPTION
This commit fixes the following:
  * Fix a bug in the initialization of `init_val` in the GPIOTE task used for the LED, where it would always be initialized to `NRF_GPIOTE_INITIAL_VALUE_HIGH` and not take the dt_flags into account. This made the LED toggle with inverted polarity on platforms where the LEDs are active high.
  * Update references to LED numbers in the README to match the actual sample behavior.