### PR TITLE
manifest: Update MCUboot to bring in ASN.1 bypass

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -132,7 +132,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 94212b4e3853b7b09acf0e2e1ec2b895bbbb2948
+      revision: pull/347/head
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR


### PR DESCRIPTION
The commit updates MCUboot to revision that brings in ASN.1 bypass, allowing to remove ASN.1 processing of build int ED25519 public key, which results in reduced code size.