### PR TITLE
manifest: sdk-zephyr: Pull PRF-256 PSA implementation for hostap

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: d3d3f66845737630687c9018cdb687319b74ec17
+      revision: pull/2085/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This pulls in PRF-256 PSA implementation for hostap from upstream.