### PR TITLE
samples: bluetooth: mesh: align usage of BT_LE_ADV_CONN with NCS

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -396,6 +396,11 @@ Bluetooth Mesh samples
   * :ref:`ble_mesh_dfu_target`
   * :ref:`ble_mesh_dfu_distributor`
 
+* :ref:`bluetooth_ble_peripheral_lbs_coex` sample:
+
+  * Updated the usage of the :c:macro:`BT_LE_ADV_CONN` macro.
+    See the Bluetooth Host section in Zephyr's :ref:`zephyr:migration_3.7`.
+
 Cellular samples
 ----------------
 


### PR DESCRIPTION
Align the usage of BT_LE_ADV_CONN inline declaration helper with the rest of the NCS.

Also global declaration of adv_params is optimised and cause bus failures during runtime, thus adding only lbs_conn_id to discern mesh services.