### PR TITLE
samples: wifi: radio_test: Add 54H/L support to radio test sample

### DIFF
--- a/samples/wifi/radio_test/sample.yaml
+++ b/samples/wifi/radio_test/sample.yaml
@@ -73,3 +73,13 @@ tests:
     build_only: true
     platform_allow: thingy91x/nrf9151/ns
     tags: ci_build sysbuild ci_samples_wifi
+  sample.nrf54_nrf7002eb.radio_test:
+    sysbuild: true
+    build_only: true
+    extra_args:
+      - radio_test_SHIELD=nrf7002eb_interposer_p1
+      - radio_test_SHIELD=nrf7002eb
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags: ci_build sysbuild ci_samples_wifi


### PR DESCRIPTION
Add build support for 54H/L targets for radio_test sample.