### PR TITLE
tests: benchmarks: multicore: Fixes to power-state tests

### DIFF
--- a/tests/benchmarks/multicore/idle/CMakeLists.txt
+++ b/tests/benchmarks/multicore/idle/CMakeLists.txt
@@ -7,8 +7,9 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-if (NOT SYSBUILD)
-	message(WARNING
+
+if(NOT SYSBUILD)
+	message(FATAL_ERROR
 		" This is a multi-image application that should be built using sysbuild.\n"
 		" Add --sysbuild argument to west build command to prepare all the images.")
 endif()

--- a/tests/benchmarks/multicore/idle_gpio/CMakeLists.txt
+++ b/tests/benchmarks/multicore/idle_gpio/CMakeLists.txt
@@ -7,8 +7,9 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-if (NOT SYSBUILD)
-	message(WARNING
+
+if(NOT SYSBUILD)
+	message(FATAL_ERROR
 		" This is a multi-image application that should be built using sysbuild.\n"
 		" Add --sysbuild argument to west build command to prepare all the images.")
 endif()

--- a/tests/benchmarks/multicore/idle_outside_of_main/CMakeLists.txt
+++ b/tests/benchmarks/multicore/idle_outside_of_main/CMakeLists.txt
@@ -7,6 +7,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
 if(NOT SYSBUILD)
 	message(FATAL_ERROR
 		" This is a multi-image application that should be built using sysbuild.\n"

--- a/tests/benchmarks/multicore/idle_spim/CMakeLists.txt
+++ b/tests/benchmarks/multicore/idle_spim/CMakeLists.txt
@@ -7,6 +7,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
 if(NOT SYSBUILD)
 	message(FATAL_ERROR
 		" This is a multi-image application that should be built using sysbuild.\n"

--- a/tests/benchmarks/multicore/idle_spim/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_spim/testcase.yaml
@@ -12,7 +12,6 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
       - SHIELD=pca63566
-      - FILE_SUFFIX=s2ram
       - SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
     harness_config:
       fixture: ppk_power_measure

--- a/tests/benchmarks/multicore/idle_twim/CMakeLists.txt
+++ b/tests/benchmarks/multicore/idle_twim/CMakeLists.txt
@@ -7,6 +7,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
 if(NOT SYSBUILD)
 	message(FATAL_ERROR
 		" This is a multi-image application that should be built using sysbuild.\n"

--- a/tests/benchmarks/multicore/idle_twim/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_twim/testcase.yaml
@@ -12,7 +12,6 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
       - SHIELD=pca63566
-      - FILE_SUFFIX=s2ram
       - SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
     harness_config:
       fixture: ppk_power_measure

--- a/tests/benchmarks/multicore/idle_uarte/CMakeLists.txt
+++ b/tests/benchmarks/multicore/idle_uarte/CMakeLists.txt
@@ -7,6 +7,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
 if(NOT SYSBUILD)
 	message(FATAL_ERROR
 		" This is a multi-image application that should be built using sysbuild.\n"

--- a/tests/benchmarks/multicore/idle_uarte/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_uarte/testcase.yaml
@@ -11,7 +11,6 @@ tests:
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
-      - FILE_SUFFIX=s2ram
       - SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
     harness_config:
       fixture: ppk_power_measure

--- a/tests/benchmarks/multicore/idle_with_pwm/src/main.c
+++ b/tests/benchmarks/multicore/idle_with_pwm/src/main.c
@@ -89,7 +89,7 @@ int main(void)
 			return ret;
 		}
 
-		/* Sleep 1 second */
+		/* Sleep / enter low power state */
 		k_msleep(CONFIG_TEST_SLEEP_DURATION_MS);
 	}
 


### PR DESCRIPTION
Align CMakeLists.txt between related tests.
Remove unused FILE_SUFFIX.
Fix misleading comment in a source code.