### PR TITLE
tools: remove aarch64-zephyr-elf and x86_64-zephyr-elf

### DIFF
--- a/scripts/tools-versions-darwin.yml
+++ b/scripts/tools-versions-darwin.yml
@@ -18,8 +18,6 @@ nanopb:
 zephyr-sdk:
   version: 0.16.8
   architectures: # https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.16.8
-    - aarch64-zephyr-elf
-    - x86_64-zephyr-elf
     - arm-zephyr-eabi
     - riscv64-zephyr-elf
 doxygen:

--- a/scripts/tools-versions-linux.yml
+++ b/scripts/tools-versions-linux.yml
@@ -19,8 +19,6 @@ nanopb:
 zephyr-sdk:
   version: 0.16.8
   architectures: # https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.16.8
-    - aarch64-zephyr-elf
-    - x86_64-zephyr-elf
     - arm-zephyr-eabi
     - riscv64-zephyr-elf
 ccache:

--- a/scripts/tools-versions-win10.yml
+++ b/scripts/tools-versions-win10.yml
@@ -17,8 +17,6 @@ nanopb:
 zephyr-sdk:
   version: 0.16.8
   architectures: # https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.16.8
-    - aarch64-zephyr-elf
-    - x86_64-zephyr-elf
     - arm-zephyr-eabi
     - riscv64-zephyr-elf
 doxygen:


### PR DESCRIPTION
These compilers are not used in automation, only referenced in docs.
We can make customer bundle smaller by omitting them.

This PR replaces https://github.com/nrfconnect/sdk-nrf/pull/17718

Discussion about this change is in `NRFU-1082`

Signed-off-by: Thomas Stilwell <Thomas.Stilwell@nordicsemi.no>
