### PR TITLE
net: openthread: rpc: fix uninitialized variable

### DIFF
--- a/subsys/net/openthread/rpc/client/ot_rpc_thread.c
+++ b/subsys/net/openthread/rpc/client/ot_rpc_thread.c
@@ -145,7 +145,7 @@ otDeviceRole otThreadGetDeviceRole(otInstance *aInstance)
 otError otThreadSetLinkMode(otInstance *aInstance, otLinkModeConfig aConfig)
 {
 	struct nrf_rpc_cbor_ctx ctx;
-	uint8_t mode_mask;
+	uint8_t mode_mask = 0;
 
 	ARG_UNUSED(aInstance);
 


### PR DESCRIPTION
This caused unit test failures on QEMU Cortex M3.