### PR TITLE
Add snippet for RAM trace backend and update documentation

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -257,8 +257,9 @@
 /snippets/                                @nrfconnect/ncs-co-boards @nrfconnect/ncs-co-build-system
 /snippets/emulated*/                      @masz-nordic
 /snippets/hw-flow-control/                @nrfconnect/ncs-low-level-test @miha-nordic
-/snippets/nrf91-modem-trace-ext-flash/    @nrfconnect/ncs-cia
-/snippets/nrf91-modem-trace-uart/         @eivindj-nordic
+/snippets/nrf91-modem-trace-ext-flash/    @nrfconnect/ncs-cia @nrfconnect/ncs-modem
+/snippets/nrf91-modem-trace-ram/          @nrfconnect/ncs-modem
+/snippets/nrf91-modem-trace-uart/         @nrfconnect/ncs-modem
 /snippets/tfm-enable-share-uart/          @nrfconnect/ncs-cia
 /snippets/nrf70-driver-verbose-debug/     @krish2718 @sachinthegreen
 /snippets/nrf70-driver-debug/             @krish2718 @sachinthegreen

--- a/doc/nrf/app_dev/device_guides/nrf91/nrf91_snippet.rst
+++ b/doc/nrf/app_dev/device_guides/nrf91/nrf91_snippet.rst
@@ -22,6 +22,9 @@ On nRF91 Series devices, you can enable the following functionalities using snip
    * - :ref:`nrf91_modem_trace_uart_snippet`
      - ``nrf91-modem-trace-uart``
      - :ref:`All nRF91 Series board targets <ug_nrf91>`
+   * - :ref:`nrf91_modem_trace_ram_snippet`
+     - ``nrf91-modem-trace-ram``
+     - :ref:`All nRF91 Series board targets <ug_nrf91>`
    * - :ref:`tfm_enable_share_uart`
      - ``tfm-enable-share-uart``
      - :ref:`All nRF91 Series board targets <ug_nrf91>`
@@ -40,6 +43,21 @@ To enable modem traces with the flash backend, use the following command pattern
    :class: highlight
 
    west build --board *board_target* -- -D<image_name>_SNIPPET="nrf91-modem-trace-ext-flash"
+
+.. _nrf91_modem_trace_ram_snippet:
+
+nRF91 modem traces with RAM backend using snippets
+****************************************************
+
+The ``nrf91-modem-trace-ram`` snippet enables modem tracing and configures it to store modem traces to a dedicated partition on the RAM.
+To change the partition size, the project needs to configure the :kconfig:option:`CONFIG_CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_RAM_LENGTH` Kconfig option.
+
+To enable modem traces with the RAM backend, use the following command pattern, where *board_target* corresponds to your board target and `<image_name>` to your application image name:
+
+.. parsed-literal::
+   :class: highlight
+
+   west build --board *board_target* -- -D<image_name>_SNIPPET="nrf91-modem-trace-ram"
 
 .. _nrf91_modem_trace_uart_snippet:
 

--- a/doc/nrf/libraries/modem/nrf_modem_lib/nrf_modem_lib_trace.rst
+++ b/doc/nrf/libraries/modem/nrf_modem_lib/nrf_modem_lib_trace.rst
@@ -16,6 +16,8 @@ The trace backend can be selected in one of the following ways:
   See :ref:`nrf91_modem_trace_rtt_snippet` for more details.
 * Adding the ``nrf91-modem-trace-ext-flash`` snippet to store modem traces in external flash.
   See :ref:`nrf91_modem_trace_ext_flash_snippet` for more details.
+* Adding the ``nrf91-modem-trace-ram`` snippet to store modem traces in RAM.
+  See :ref:`nrf91_modem_trace_ram_snippet` for more details.
 
 To reduce the amount of trace data sent from the modem, a different trace level can be selected.
 Complete the following steps to configure the modem trace level at compile time:

--- a/doc/nrf/libraries/modem/nrf_modem_lib/nrf_modem_lib_trace.rst
+++ b/doc/nrf/libraries/modem/nrf_modem_lib/nrf_modem_lib_trace.rst
@@ -7,14 +7,15 @@ Modem trace module
    :local:
    :depth: 2
 
-To enable the tracing functionality, enable the :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE` Kconfig in your project configuration.
 The module is implemented in :file:`nrf/lib/nrf_modem_lib/nrf_modem_lib_trace.c` and consists of a thread that initializes, deinitializes, and forwards modem traces to a backend.
 The trace backend can be selected in one of the following ways:
 
 * Adding the ``nrf91-modem-trace-uart`` snippet to send modem traces over UART.
   See :ref:`nrf91_modem_trace_uart_snippet` for more details.
-* Enabling the :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_RTT` Kconfig option to send modem traces over SEGGER RTT.
-* Enabling the :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_FLASH` Kconfig option to write modem traces to external flash.
+* Adding the ``nrf91-modem-trace-rtt`` snippet to send modem traces over RTT.
+  See :ref:`nrf91_modem_trace_rtt_snippet` for more details.
+* Adding the ``nrf91-modem-trace-ext-flash`` snippet to store modem traces in external flash.
+  See :ref:`nrf91_modem_trace_ext_flash_snippet` for more details.
 
 To reduce the amount of trace data sent from the modem, a different trace level can be selected.
 Complete the following steps to configure the modem trace level at compile time:

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -71,7 +71,7 @@ See also the `MCUboot`_ section.
 Developing with nRF91 Series
 ============================
 
-|no_changes_yet_note|
+* Added the :ref:`nRF91 modem tracing with RAM backend snippet <nrf91_modem_trace_ram_snippet>` to enable modem tracing using the RAM trace backend.
 
 Developing with nRF70 Series
 ============================

--- a/snippets/nrf91-modem-trace-ram/modem-trace-ram.conf
+++ b/snippets/nrf91-modem-trace-ram/modem-trace-ram.conf
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_NRF_MODEM_LIB_TRACE=y
+
+# Modem trace flash backend
+CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_RAM=y

--- a/snippets/nrf91-modem-trace-ram/snippet.yml
+++ b/snippets/nrf91-modem-trace-ram/snippet.yml
@@ -1,0 +1,3 @@
+name: nrf91-modem-trace-ram
+append:
+  EXTRA_CONF_FILE: modem-trace-ram.conf


### PR DESCRIPTION
Together with #16847, all trace backends in NCS are now enabled by including a snippet when building the application.  