### PR TITLE
samples: cellular: udp: Add thingy91x

### DIFF
--- a/samples/cellular/udp/sample.yaml
+++ b/samples/cellular/udp/sample.yaml
@@ -9,6 +9,7 @@ tests:
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
       - thingy91/nrf9160/ns
+      - thingy91x/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns


### PR DESCRIPTION
This patch adds the thingy91x as a supported board for the cellular udp sample.