### PR TITLE
matter: include EXTRAVERSION in Matter software version string

### DIFF
--- a/doc/nrf/protocols/matter/end_product/versioning.rst
+++ b/doc/nrf/protocols/matter/end_product/versioning.rst
@@ -16,13 +16,14 @@ There are two primary approaches for maintaining versioning:
 * Utilizing a :file:`VERSION` file as detailed on the :ref:`app-version-details` page of the Zephyr Project documentation.
   This method involves defining the version information in a specific file format.
 
-* Implementing dedicated Kconfig configurations.
-  This approach uses Kconfig system configurations to set and manage the versioning details.
+* Utilizing dedicated Kconfig configurations.
+  This approach uses Kconfig options to set and manage the versioning details.
 
 Choose the approach that best aligns with your project requirements and infrastructure.
 
 .. note::
-  These approaches should not be used simultaneously.
+  These approaches cannot be used simultaneously.
+  The Kconfig options for configuring the versioning details are unavailable if the :file:`VERSION` file is present.
 
 Using :file:`VERSION` file
 **************************
@@ -35,6 +36,7 @@ To implement versioning based on a :file:`VERSION` file, you must create a file 
     VERSION_MINOR =
     PATCHLEVEL =
     VERSION_TWEAK =
+    EXTRAVERSION =
 
 .. note::
    You must assign a value to at least one of the variables.
@@ -48,13 +50,20 @@ For example:
    VERSION_MINOR = 5
    PATCHLEVEL = 99
    VERSION_TWEAK = 0
+   EXTRAVERSION = dev
 
-A :file:`VERSION` file is responsible for assigning values in the following format for:
+The :file:`VERSION` file is used to derive the firmware version in the following format for:
 
-* MCUboot version: ``MAJOR . MINOR . PATCHLEVEL + TWEAK``.
-  The above example would be formatted as ``2 . 5 . 99 + 0``.
-* Matter OTA: in the 32-bit integer where each variable is 8 bits long.
+* MCUboot image: ``MAJOR.MINOR.PATCHLEVEL+TWEAK``.
+  The above example would be formatted as ``2.5.99+0``.
+* Matter OTA image: 32-bit integer where each numeric variable is represented by 8 bits within the integer.
   The above example would be formatted as ``0x02056300``.
+* Informational purposes, for example displayed in the ecosystem applications:
+
+  * If ``EXTRAVERSION`` is non-empty: ``MAJOR.MINOR.PATCHLEVEL-EXTRA+TWEAK``.
+    The above example would be formatted as ``2.5.99-dev+0``.
+  * Otherwise: ``MAJOR.MINOR.PATCHLEVEL+TWEAK``.
+    The above example would be formatted as ``2.5.99+0``.
 
 Using Kconfig options
 *********************

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -224,6 +224,8 @@ Matter
   * The default Trusted Storage AEAD key to Hardware Unique Key (HUK) for supported nRF54L Series devices.
   * Renamed the ``CONFIG_CHIP_FACTORY_RESET_ERASE_NVS`` Kconfig option to :kconfig:option:`CONFIG_CHIP_FACTORY_RESET_ERASE_SETTINGS`.
     The new Kconfig option now works for both NVS and ZMS file system backends.
+  * The firmware version format used for informational purposes when using the :file:``VERSION`` file.
+    The format now includes the optional ``EXTRAVERSION`` component.
 
 Matter fork
 +++++++++++

--- a/west.yml
+++ b/west.yml
@@ -161,7 +161,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 171a1d323bf91ac7a655f93c70c18ebb6c1a2253
+      revision: 731aac5c8941bf0f0a9f10c759f533e5b01f80eb
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
Switch the Matter software version string from
APP_VERSION_TWEAK_STRING to APP_VERSION_EXTENDED_STRING.