### PR TITLE
applications: nrf_desktop: Remove outdated Kconfig help

### DIFF
--- a/applications/nrf_desktop/src/modules/Kconfig.config_channel
+++ b/applications/nrf_desktop/src/modules/Kconfig.config_channel
@@ -60,9 +60,6 @@ config DESKTOP_CONFIG_CHANNEL_DFU_ENABLE
 	depends on (SSF_SUIT_SERVICE_ENABLED || !SUIT)
 	help
 	  This option enables DFU over the config channel.
-	  The option automatically enables 8-bit write block size emulation to
-	  ensure that update images with size unaligned to word size can be
-	  handled while writing to SoC FLASH.
 
 if DESKTOP_CONFIG_CHANNEL_DFU_ENABLE
 


### PR DESCRIPTION
Change removes outdated part of configuration channel DFU Kconfig option's help.