### PR TITLE
lib: edge_impulse: fix api key header

### DIFF
--- a/lib/edge_impulse/CMakeLists.txt
+++ b/lib/edge_impulse/CMakeLists.txt
@@ -59,8 +59,8 @@ include(ExternalProject)
 ExternalProject_Add(edge_impulse_project
     URL              ${EI_URI_LIST}
     HTTP_HEADER      "Accept: application/zip"
-    DOWNLOAD_EXTRACT_TIMESTAMP True
                      ${EI_API_KEY_HEADER}
+    DOWNLOAD_EXTRACT_TIMESTAMP True
     PREFIX           ${EDGE_IMPULSE_DIR}
     SOURCE_DIR       ${EDGE_IMPULSE_SOURCE_DIR}
     BINARY_DIR       ${EDGE_IMPULSE_BINARY_DIR}


### PR DESCRIPTION
The Edge Impulse key API header must be in the header for the downloading of a private project to be done properly.