### PR TITLE
samples: cellular: modem_shell: redmob: Don't pass enum to scanf

### DIFF
--- a/samples/cellular/modem_shell/src/link/link_shell.c
+++ b/samples/cellular/modem_shell/src/link/link_shell.c
@@ -2042,11 +2042,13 @@ static int link_shell_redmob(const struct shell *shell, size_t argc, char **argv
 	}
 	if (operation == LINK_OPERATION_READ) {
 		enum link_reduced_mobility_mode mode;
+		uint16_t mode_tmp;
 
-		ret = nrf_modem_at_scanf("AT%REDMOB?", "%%REDMOB: %hu", &mode);
+		ret = nrf_modem_at_scanf("AT%REDMOB?", "%%REDMOB: %hu", &mode_tmp);
 		if (ret != 1) {
 			mosh_error("Cannot get reduced mobility mode: %d", ret);
 		} else {
+			mode = mode_tmp;
 			mosh_print(
 				"Reduced mobility mode read successfully: %s",
 				link_shell_redmob_mode_to_string(mode, snum));


### PR DESCRIPTION
When passing enum type into scanf, there will be a compilation warning:

```
nrf/samples/cellular/modem_shell/src/link/link_shell.c:2046:69: warning:
format '%hu' expects argument of type 'short unsigned int *',
but argument 3 has type 'enum link_reduced_mobility_mode *' [-Wformat=]
2046 | ret = nrf_modem_at_scanf("AT%REDMOB?", "%%REDMOB: %hu", &mode);
```

Regression from PR #17579. I don't know why twister didn't capture this for that PR.