### PR TITLE
CI: Fetch last commits for src package

### DIFF
--- a/.github/workflows/src-mirror.yml
+++ b/.github/workflows/src-mirror.yml
@@ -11,7 +11,6 @@ jobs:
       - name: Checkout sources
         uses: nrfconnect/action-checkout-west-update@main
         with:
-          git-fetch-depth: 0
           path: workspace/nrf
           west-update-args: '--group-filter=+babblesim,+sidewalk'
 


### PR DESCRIPTION
Use default depth=1 to fetch only last commits while building src package for artifactory