### PR TITLE
bluetooth: samples: iso_time_sync: Fix BIS bitfield

### DIFF
--- a/samples/bluetooth/iso_time_sync/src/bis_receiver.c
+++ b/samples/bluetooth/iso_time_sync/src/bis_receiver.c
@@ -167,7 +167,7 @@ void bis_receiver_start(uint8_t bis_index_to_sync_to)
 		memset(&big_sync_param, 0, sizeof(big_sync_param));
 		big_sync_param.bis_channels = iso_rx_channels_get();
 		big_sync_param.num_bis = 1;
-		big_sync_param.bis_bitfield = BIT(bis_index_to_sync_to);
+		big_sync_param.bis_bitfield = BIT(bis_index_to_sync_to - 1);
 		big_sync_param.mse = BT_ISO_SYNC_MSE_ANY;
 		big_sync_param.sync_timeout = 100; /* in 10 ms units */
 


### PR DESCRIPTION
For BIS 1 -> BIT(0) needs to be set, however this was setting BIT(1). Fix this so it syncs to correct BIS.