### PR TITLE
doc: Misc security and crypto doc updates

### DIFF
--- a/doc/nrf/libraries/security/nrf_security/doc/driver_config.rst
+++ b/doc/nrf/libraries/security/nrf_security/doc/driver_config.rst
@@ -209,25 +209,27 @@ Key derivation function configurations
 
 To enable key derivation function (KDF) support, set one or more of the Kconfig options in the following table:
 
-+--------------------------+---------------------------------------------------------------+
-| KDF algorithm            | Configuration option                                          |
-+==========================+===============================================================+
-| HKDF                     | :kconfig:option:`CONFIG_PSA_WANT_ALG_HKDF`                    |
-+--------------------------+---------------------------------------------------------------+
-| HKDF-Extract             | :kconfig:option:`CONFIG_PSA_WANT_ALG_HKDF_EXTRACT`            |
-+--------------------------+---------------------------------------------------------------+
-| HKDF-Expand              | :kconfig:option:`CONFIG_PSA_WANT_ALG_HKDF_EXPAND`             |
-+--------------------------+---------------------------------------------------------------+
-| PBKDF2-HMAC              | :kconfig:option:`CONFIG_PSA_WANT_ALG_PBKDF2_HMAC`             |
-+--------------------------+---------------------------------------------------------------+
-| PBKDF2-AES-CMAC-PRF-128  | :kconfig:option:`CONFIG_PSA_WANT_ALG_PBKDF2_AES_CMAC_PRF_128` |
-+--------------------------+---------------------------------------------------------------+
-| TLS 1.2 PRF              | :kconfig:option:`CONFIG_PSA_WANT_ALG_TLS12_PRF`               |
-+--------------------------+---------------------------------------------------------------+
-| TLS 1.2 PSK to MS        | :kconfig:option:`CONFIG_PSA_WANT_ALG_TLS12_PSK_TO_MS`         |
-+--------------------------+---------------------------------------------------------------+
-| TLS 1.2 EC J-PAKE to PMS | :kconfig:option:`CONFIG_PSA_WANT_ALG_TLS12_ECJPAKE_TO_PMS`    |
-+--------------------------+---------------------------------------------------------------+
++-----------------------------+---------------------------------------------------------------+
+| KDF algorithm               | Configuration option                                          |
++=============================+===============================================================+
+| HKDF                        | :kconfig:option:`CONFIG_PSA_WANT_ALG_HKDF`                    |
++-----------------------------+---------------------------------------------------------------+
+| HKDF-Extract                | :kconfig:option:`CONFIG_PSA_WANT_ALG_HKDF_EXTRACT`            |
++-----------------------------+---------------------------------------------------------------+
+| HKDF-Expand                 | :kconfig:option:`CONFIG_PSA_WANT_ALG_HKDF_EXPAND`             |
++-----------------------------+---------------------------------------------------------------+
+| PBKDF2-HMAC                 | :kconfig:option:`CONFIG_PSA_WANT_ALG_PBKDF2_HMAC`             |
++-----------------------------+---------------------------------------------------------------+
+| PBKDF2-AES-CMAC-PRF-128     | :kconfig:option:`CONFIG_PSA_WANT_ALG_PBKDF2_AES_CMAC_PRF_128` |
++-----------------------------+---------------------------------------------------------------+
+| TLS 1.2 PRF                 | :kconfig:option:`CONFIG_PSA_WANT_ALG_TLS12_PRF`               |
++-----------------------------+---------------------------------------------------------------+
+| TLS 1.2 PSK to MS           | :kconfig:option:`CONFIG_PSA_WANT_ALG_TLS12_PSK_TO_MS`         |
++-----------------------------+---------------------------------------------------------------+
+| TLS 1.2 EC J-PAKE to PMS    | :kconfig:option:`CONFIG_PSA_WANT_ALG_TLS12_ECJPAKE_TO_PMS`    |
++-----------------------------+---------------------------------------------------------------+
+| SP 800-108r1 CMAC w/counter | :kconfig:option:`CONFIG_PSA_WANT_ALG_SP800_108_COUNTER_CMAC`  |
++-----------------------------+---------------------------------------------------------------+
 
 
 Key derivation function support
@@ -235,25 +237,27 @@ Key derivation function support
 
 The following table shows key derivation function (KDF) support for each driver:
 
-+--------------------------+--------------------------+----------------------------+---------------------------+
-| KDF algorithm            | nrf_cc3xx driver support | nrf_oberon driver support  | nrf_cracen driver support |
-+==========================+==========================+============================+===========================+
-| HKDF                     | Not supported            | Supported                  | Supported                 |
-+--------------------------+--------------------------+----------------------------+---------------------------+
-| HKDF-Extract             | Not supported            | Supported                  | Not Supported             |
-+--------------------------+--------------------------+----------------------------+---------------------------+
-| HKDF-Expand              | Not supported            | Supported                  | Not Supported             |
-+--------------------------+--------------------------+----------------------------+---------------------------+
-| PBKDF2-HMAC              | Not supported            | Supported                  | Supported                 |
-+--------------------------+--------------------------+----------------------------+---------------------------+
-| PBKDF2-AES-CMAC-PRF-128  | Not supported            | Supported                  | Supported                 |
-+--------------------------+--------------------------+----------------------------+---------------------------+
-| TLS 1.2 PRF              | Not supported            | Supported                  | Not Supported             |
-+--------------------------+--------------------------+----------------------------+---------------------------+
-| TLS 1.2 PSK to MS        | Not supported            | Supported                  | Not Supported             |
-+--------------------------+--------------------------+----------------------------+---------------------------+
-| TLS 1.2 EC J-PAKE to PMS | Not supported            | Supported                  | Supported                 |
-+--------------------------+--------------------------+----------------------------+---------------------------+
++------------------------------+--------------------------+----------------------------+---------------------------+
+| KDF algorithm                | nrf_cc3xx driver support | nrf_oberon driver support  | nrf_cracen driver support |
++==============================+==========================+============================+===========================+
+| HKDF                         | Not supported            | Supported                  | Supported                 |
++------------------------------+--------------------------+----------------------------+---------------------------+
+| HKDF-Extract                 | Not supported            | Supported                  | Not Supported             |
++------------------------------+--------------------------+----------------------------+---------------------------+
+| HKDF-Expand                  | Not supported            | Supported                  | Not Supported             |
++------------------------------+--------------------------+----------------------------+---------------------------+
+| PBKDF2-HMAC                  | Not supported            | Supported                  | Supported                 |
++------------------------------+--------------------------+----------------------------+---------------------------+
+| PBKDF2-AES-CMAC-PRF-128      | Not supported            | Supported                  | Supported                 |
++------------------------------+--------------------------+----------------------------+---------------------------+
+| TLS 1.2 PRF                  | Not supported            | Supported                  | Not Supported             |
++------------------------------+--------------------------+----------------------------+---------------------------+
+| TLS 1.2 PSK to MS            | Not supported            | Supported                  | Not Supported             |
++------------------------------+--------------------------+----------------------------+---------------------------+
+| TLS 1.2 EC J-PAKE to PMS     | Not supported            | Supported                  | Supported                 |
++------------------------------+--------------------------+----------------------------+---------------------------+
+| SP 800-108r1 CMAC w/counter  | Not supported            | Not supported              | Supported                 |
++------------------------------+--------------------------+----------------------------+---------------------------+
 
 The configuration of the :ref:`nrf_security_drivers_oberon` is automatically generated based on the user-enabled algorithms in `Key derivation function configurations`_.
 

--- a/doc/nrf/libraries/security/nrf_security/doc/drivers.rst
+++ b/doc/nrf/libraries/security/nrf_security/doc/drivers.rst
@@ -83,7 +83,7 @@ To enable the :ref:`nrf_oberon_readme` PSA driver, set the :kconfig:option:`CONF
 CRACEN driver
 *************
 
-The CRACEN driver provides entropy and hardware-accelerated cryptography using the CRACEN (Crypto Accelerator Engine) peripheral.
+The CRACEN driver provides entropy and hardware-accelerated cryptography using the Crypto Accelerator Engine (CRACEN) peripheral.
 This driver is only available on nRF54L Series devices.
 
 Enabling the CRACEN driver
@@ -93,8 +93,10 @@ The CRACEN driver can be enabled by setting the :kconfig:option:`CONFIG_PSA_CRYP
 
 The nrf_oberon driver may then be disabled by using the Kconfig option :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_OBERON` (``CONFIG_PSA_CRYPTO_DRIVER_OBERON=n``).
 
+For more details on the nRF54L Series cryptography operations and the related configuration, see :ref:`ug_nrf54l_cryptography`.
+
 .. note::
-   On nRF54L Series devices, CRACEN is the only source of entropy.
+   On the nRF54L Series devices, CRACEN is the only source of entropy.
    Therefore, it is not possible to disable the :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_CRACEN` option when the Zephyr entropy driver is enabled.
 
 Legacy Mbed TLS

--- a/doc/nrf/security.rst
+++ b/doc/nrf/security.rst
@@ -39,13 +39,14 @@ Some of them are documented in detail in other parts of this documentation, whil
       On nRF5340 and nRF91 Series devices, TF-M is used to configure and boot an application with :ref:`CMSE enabled <app_boards_spe_nspe_cpuapp_ns>`.
     - See :ref:`ug_tfm`.
     - | - :ref:`tfm_samples`
-      | - :ref:`cryptography samples <crypto_samples>`
+      | - :ref:`crypto_samples`
       | - :ref:`https_client` sample
       | - :ref:`openthread_samples`
       | - :ref:`TF-M integration samples <zephyr:tfm_integration-samples>` in Zephyr
   * - Cryptographic operations (:ref:`nrf_security`)
     - The :ref:`nrf_security` library acts as an orchestrator for the different cryptographic libraries available in the system.
       HW accelerated libraries are prioritized over SW libraries when both are enabled.
+      | Find more information on nRF54L Series-specific cryptography operations and the related configuration in :ref:`ug_nrf54l_cryptography`.
     - :kconfig:option:`CONFIG_NRF_SECURITY` (:ref:`more info<nrf_security_config>`)
     - | - :ref:`nrf_security` library with :ref:`nrf_security_drivers`
       | - :ref:`nrfxlib:crypto`

--- a/doc/nrf/security/trusted_storage.rst
+++ b/doc/nrf/security/trusted_storage.rst
@@ -43,6 +43,18 @@ The table below gives an overview of the trusted storage support for the product
      - Yes
      - Yes
      - No
+   * - nRF54L15 with TF-M
+     - TF-M secure storage service
+     - Yes
+     - Yes
+     - Yes
+     - Yes
+   * - nRF54L15 without TF-M
+     - Trusted storage library
+     - Partial [1]_
+     - Yes
+     - Yes
+     - Yes
    * - nRF5340 with TF-M
      - TF-M secure storage service
      - Yes


### PR DESCRIPTION
A few updates to security and crypto doc for
NCS 2.8.0 release. Among others:
Security page
nRF Security lib
TF-M
Trusted storage
Access port protection
HUK