### PR TITLE
samples: tfm: add RNG config for tfm_psa_template

### DIFF
--- a/samples/tfm/tfm_psa_template/prj.conf
+++ b/samples/tfm/tfm_psa_template/prj.conf
@@ -66,3 +66,6 @@ CONFIG_LOG_MODE_IMMEDIATE=y
 
 # Enable TFM isolation level 2
 CONFIG_TFM_ISOLATION_LEVEL=2
+
+# Initial Attestation requires RNG
+CONFIG_PSA_WANT_GENERATE_RANDOM=y


### PR DESCRIPTION
The Initial Attestation service requires RNG config to be able to attest the boot seed claim.