### PR TITLE
samples: dect: dect_phy: dect_shell: updates due to recent libmodem api changes

### DIFF
--- a/samples/dect/dect_phy/dect_shell/src/dect/dect_phy_ctrl.c
+++ b/samples/dect/dect_phy/dect_shell/src/dect/dect_phy_ctrl.c
@@ -674,6 +674,12 @@ static void dect_phy_ctrl_mdm_on_capability_get_cb(
 	}
 }
 
+static void dect_phy_ctrl_mdm_on_stf_cover_seq_control_cb(
+	const uint64_t *time, enum nrf_modem_dect_phy_err err)
+{
+	printk("WARN: Unexpectedly in %s\n", (__func__));
+}
+
 static void dect_phy_ctrl_mdm_on_deinit_cb(const uint64_t *time, enum nrf_modem_dect_phy_err err)
 {
 	ctrl_data.phy_api_initialized = false;
@@ -693,6 +699,7 @@ static const struct nrf_modem_dect_phy_callbacks dect_phy_api_config = {
 	.link_config = dect_phy_ctrl_mdm_on_link_configuration_cb,
 	.time_get = dect_phy_ctrl_mdm_time_query_cb,
 	.capability_get = dect_phy_ctrl_mdm_on_capability_get_cb,
+	.stf_cover_seq_control = dect_phy_ctrl_mdm_on_stf_cover_seq_control_cb,
 	.deinit = dect_phy_ctrl_mdm_on_deinit_cb,
 };
 

--- a/samples/dect/dect_phy/dect_shell/src/dect/perf/dect_phy_perf.c
+++ b/samples/dect/dect_phy/dect_shell/src/dect/perf/dect_phy_perf.c
@@ -655,6 +655,12 @@ static void dect_phy_perf_capability_get_cb(const uint64_t *time, enum nrf_modem
 	}
 }
 
+static void dect_phy_perf_stf_cover_seq_control_cb(
+	const uint64_t *time, enum nrf_modem_dect_phy_err err)
+{
+	printk("WARN: Unexpectedly in %s\n", (__func__));
+}
+
 static void dect_phy_perf_deinit_cb(const uint64_t *time, enum nrf_modem_dect_phy_err err)
 {
 	dect_phy_ctrl_msgq_non_data_op_add(DECT_PHY_CTRL_OP_PERF_CMD_DONE);
@@ -672,6 +678,7 @@ static const struct nrf_modem_dect_phy_callbacks perf_phy_api_config = {
 	.link_config = dect_phy_perf_link_configuration_cb,
 	.time_get = dect_phy_perf_time_query_cb,
 	.capability_get = dect_phy_perf_capability_get_cb,
+	.stf_cover_seq_control = dect_phy_perf_stf_cover_seq_control_cb,
 	.deinit = dect_phy_perf_deinit_cb,
 };
 

--- a/samples/dect/dect_phy/dect_shell/src/dect/ping/dect_phy_ping.c
+++ b/samples/dect/dect_phy/dect_shell/src/dect/ping/dect_phy_ping.c
@@ -785,6 +785,12 @@ static void dect_phy_ping_capability_get_cb(const uint64_t *time, enum nrf_modem
 	dect_app_modem_time_save(time);
 }
 
+static void dect_phy_ping_stf_cover_seq_control_cb(
+	const uint64_t *time, enum nrf_modem_dect_phy_err err)
+{
+	printk("WARN: Unexpectedly in %s\n", (__func__));
+}
+
 static void dect_phy_ping_deinit_cb(const uint64_t *time, enum nrf_modem_dect_phy_err err)
 {
 	dect_phy_ctrl_msgq_non_data_op_add(DECT_PHY_CTRL_OP_PING_CMD_DONE);
@@ -802,6 +808,7 @@ static const struct nrf_modem_dect_phy_callbacks ping_phy_api_config = {
 	.link_config = dect_phy_ping_link_configuration_cb,
 	.time_get = dect_phy_ping_time_query_cb,
 	.capability_get = dect_phy_ping_capability_get_cb,
+	.stf_cover_seq_control = dect_phy_ping_stf_cover_seq_control_cb,
 	.deinit = dect_phy_ping_deinit_cb,
 };
 

--- a/samples/dect/dect_phy/dect_shell/src/dect/rf_tool/dect_phy_rf_tool.c
+++ b/samples/dect/dect_phy/dect_shell/src/dect/rf_tool/dect_phy_rf_tool.c
@@ -132,7 +132,7 @@ static bool dect_phy_rf_tool_rx_mode(enum dect_phy_rf_tool_mode mode);
 
 /**************************************************************************************************/
 
-void dect_phy_rf_tool_initialize_cb(const uint64_t *time, int16_t temperature,
+static void dect_phy_rf_tool_initialize_cb(const uint64_t *time, int16_t temperature,
 				    enum nrf_modem_dect_phy_err status,
 				    const struct nrf_modem_dect_phy_modem_cfg *modem_configuration)
 {
@@ -149,13 +149,13 @@ void dect_phy_rf_tool_initialize_cb(const uint64_t *time, int16_t temperature,
 					  sizeof(struct dect_phy_common_op_initialized_params));
 }
 
-void dect_phy_rf_tool_rx_op_stop_cb(uint64_t const *time, enum nrf_modem_dect_phy_err status,
+static void dect_phy_rf_tool_rx_op_stop_cb(uint64_t const *time, enum nrf_modem_dect_phy_err status,
 				    uint32_t handle)
 {
 	dect_app_modem_time_save(time);
 }
 
-void dect_phy_rf_tool_op_complete_cb(uint64_t const *time, int16_t temperature,
+static void dect_phy_rf_tool_op_complete_cb(uint64_t const *time, int16_t temperature,
 				     enum nrf_modem_dect_phy_err status, uint32_t handle)
 {
 	struct dect_phy_common_op_completed_params rf_tool_op_completed_params = {
@@ -196,7 +196,7 @@ static void dect_phy_rf_tool_rx_pcc_cb(uint64_t const *time,
 					  sizeof(struct dect_phy_common_op_pcc_rcv_params));
 }
 
-void dect_phy_rf_tool_pcc_crc_failure_cb(
+static void dect_phy_rf_tool_pcc_crc_failure_cb(
 	uint64_t const *time, struct nrf_modem_dect_phy_rx_pcc_crc_failure const *crc_failure)
 {
 	struct dect_phy_common_op_pcc_crc_fail_params pdc_crc_fail_params = {
@@ -210,7 +210,7 @@ void dect_phy_rf_tool_pcc_crc_failure_cb(
 					  sizeof(struct dect_phy_common_op_pcc_crc_fail_params));
 }
 
-void dect_phy_rf_tool_rx_pdc_cb(uint64_t const *time,
+static void dect_phy_rf_tool_rx_pdc_cb(uint64_t const *time,
 				struct nrf_modem_dect_phy_rx_pdc_status const *p_rx_status,
 				void const *p_data, uint32_t length)
 {
@@ -240,7 +240,7 @@ void dect_phy_rf_tool_rx_pdc_cb(uint64_t const *time,
 	}
 }
 
-void dect_phy_rf_tool_on_pdc_crc_failure_cb(
+static void dect_phy_rf_tool_on_pdc_crc_failure_cb(
 	uint64_t const *time, struct nrf_modem_dect_phy_rx_pdc_crc_failure const *crc_failure)
 {
 	struct dect_phy_common_op_pdc_crc_fail_params pdc_crc_fail_params = {
@@ -254,29 +254,37 @@ void dect_phy_rf_tool_on_pdc_crc_failure_cb(
 					  sizeof(struct dect_phy_common_op_pdc_crc_fail_params));
 }
 
-void dect_phy_rf_tool_on_rssi_cb(const uint64_t *time,
+static void dect_phy_rf_tool_on_rssi_cb(const uint64_t *time,
 				 const struct nrf_modem_dect_phy_rssi_meas *p_result)
 {
 	printk("WARN: Unexpectedly in %s\n", (__func__));
 }
 
-void dect_phy_rf_tool_link_configuration_cb(uint64_t const *time,
+static void dect_phy_rf_tool_link_configuration_cb(uint64_t const *time,
 					    enum nrf_modem_dect_phy_err status)
 {
 	printk("WARN: Unexpectedly in %s\n", (__func__));
 }
 
-void dect_phy_rf_tool_time_query_cb(uint64_t const *time, enum nrf_modem_dect_phy_err status)
+static void dect_phy_rf_tool_time_query_cb(
+	uint64_t const *time, enum nrf_modem_dect_phy_err status)
 {
 }
 
-void dect_phy_rf_tool_capability_get_cb(const uint64_t *time, enum nrf_modem_dect_phy_err err,
-					const struct nrf_modem_dect_phy_capability *capabilities)
+static void dect_phy_rf_tool_capability_get_cb(
+	const uint64_t *time, enum nrf_modem_dect_phy_err err,
+	const struct nrf_modem_dect_phy_capability *capabilities)
 {
 	dect_app_modem_time_save(time);
 }
 
-void dect_phy_rf_tool_deinit_cb(const uint64_t *time, enum nrf_modem_dect_phy_err err)
+static void dect_phy_rf_tool_stf_cover_seq_control_cb(
+	const uint64_t *time, enum nrf_modem_dect_phy_err err)
+{
+	printk("WARN: Unexpectedly in %s\n", (__func__));
+}
+
+static void dect_phy_rf_tool_deinit_cb(const uint64_t *time, enum nrf_modem_dect_phy_err err)
 {
 	dect_phy_rf_tool_msgq_non_data_op_add(DECT_PHY_RF_TOOL_EVT_MDM_DEINITIALIZED);
 }
@@ -293,6 +301,7 @@ static const struct nrf_modem_dect_phy_callbacks rf_tool_phy_api_config = {
 	.link_config = dect_phy_rf_tool_link_configuration_cb,
 	.time_get = dect_phy_rf_tool_time_query_cb,
 	.capability_get = dect_phy_rf_tool_capability_get_cb,
+	.stf_cover_seq_control = dect_phy_rf_tool_stf_cover_seq_control_cb,
 	.deinit = dect_phy_rf_tool_deinit_cb,
 };
 


### PR DESCRIPTION
Updates due to recent libmodem api changes for adding stf_cover_seq_control callback.