### PR TITLE
lib: modem_info: Remove APP_VERSION generation with git describe

### DIFF
--- a/lib/modem_info/CMakeLists.txt
+++ b/lib/modem_info/CMakeLists.txt
@@ -8,30 +8,6 @@ zephyr_library()
 zephyr_library_sources(modem_info.c)
 zephyr_library_sources(modem_info_params.c)
 
-find_package(Git QUIET)
-if(NOT APP_VERSION AND GIT_FOUND)
-  execute_process(
-    COMMAND ${GIT_EXECUTABLE} describe --abbrev=12
-    WORKING_DIRECTORY                ${ZEPHYR_NRF_MODULE_DIR}
-    OUTPUT_VARIABLE                  APP_VERSION
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    ERROR_STRIP_TRAILING_WHITESPACE
-    ERROR_VARIABLE                   stderr
-    RESULT_VARIABLE                  return_code
-  )
-  if(return_code)
-    message(STATUS "git describe failed: ${stderr}; ${KERNEL_VERSION_STRING} will be used instead")
-  elseif(CMAKE_VERBOSE_MAKEFILE)
-    message(STATUS "git describe stderr: ${stderr}")
-  endif()
-endif()
-
-if(APP_VERSION)
-  zephyr_compile_definitions(
-    APP_VERSION=${APP_VERSION}
-  )
-endif()
-
 if(NOT PROJECT_NAME)
   zephyr_compile_definitions(
     PROJECT_NAME=${CMAKE_PROJECT_NAME}

--- a/lib/modem_info/modem_info_params.c
+++ b/lib/modem_info/modem_info_params.c
@@ -8,6 +8,8 @@
 #include <string.h>
 #include <stdlib.h>
 #include <modem/modem_info.h>
+#include <ncs_version.h>
+#include <ncs_commit.h>
 #include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(modem_info_params);
@@ -42,7 +44,7 @@ int modem_info_params_init(struct modem_param_info *modem)
 	modem->device.battery.type		= MODEM_INFO_BATTERY;
 	modem->device.imei.type			= MODEM_INFO_IMEI;
 	modem->device.board			= CONFIG_BOARD;
-	modem->device.app_version		= STRINGIFY(APP_VERSION);
+	modem->device.app_version		= NCS_VERSION_STRING "-" NCS_COMMIT_STRING;
 
 #ifdef PROJECT_NAME
 	modem->device.app_name			= STRINGIFY(PROJECT_NAME);

--- a/samples/cellular/modem_shell/src/cloud/cloud_lwm2m.c
+++ b/samples/cellular/modem_shell/src/cloud/cloud_lwm2m.c
@@ -49,7 +49,7 @@ static char utc_offset[UTC_OFFSET_STR_LEN] = "";
 static char timezone[TIMEZONE_STR_LEN] = "";
 #define APP_DEVICE_TYPE "OMA-LWM2M Client"
 #if defined(APP_VERSION)
-#define CLIENT_SW_VER STRINGIFY(APP_VERSION)
+#define CLIENT_SW_VER (NCS_VERSION_STRING "-" NCS_COMMIT_STRING)
 #else
 #define CLIENT_SW_VER "unknown"
 #endif

--- a/samples/cellular/modem_shell/src/utils/mosh_print.c
+++ b/samples/cellular/modem_shell/src/utils/mosh_print.c
@@ -15,6 +15,8 @@
 #include <zephyr/shell/shell.h>
 #include <modem/modem_info.h>
 #include <net/nrf_cloud.h>
+#include <ncs_version.h>
+#include <ncs_commit.h>
 
 #include "mosh_print.h"
 
@@ -180,11 +182,7 @@ void mosh_print_version_info(void)
 	/* shell_print() is not used here, because this function is called early during
 	 * application startup and the shell might not be ready yet.
 	 */
-#if defined(APP_VERSION)
-	printk("\nMOSH version:       %s\n", STRINGIFY(APP_VERSION));
-#else
-	printk("\nMOSH version:       unknown\n");
-#endif
+	printk("\nMOSH version:       %s-%s\n", NCS_VERSION_STRING, NCS_COMMIT_STRING);
 
 #if defined(BUILD_ID)
 	printk("MOSH build id:      v%s\n", STRINGIFY(BUILD_ID));


### PR DESCRIPTION
APP_VERSION should not be compile definition but rather come from an include file. This is discussed in
https://github.com/zephyrproject-rtos/zephyr/issues/39503

Starting to use NCS_VERSION_STRING and NCS_COMMIT_STRING, which have become available in: https://github.com/nrfconnect/sdk-nrf/pull/11956

The version string in MOSH used to be:
```
*** Booting nRF Connect SDK v2.7.99-5acb73401254 ***
*** Using Zephyr OS v3.7.99-b83478a230e7 ***

mosh:~$
MOSH version:       v2.7.99-cs2-449-g5acb73401254
```

And now it is:

```
*** Booting nRF Connect SDK v2.7.99-7f59f2434142 ***
*** Using Zephyr OS v3.7.99-b83478a230e7 ***

mosh:~$
MOSH version:       2.7.99-7f59f2434142
```

So it will miss the `cs2/rc1` etc. part and the number after that. In addition there is no `g` character before the commit SHA.