### PR TITLE
nRF54H20 PSA RNG and mbedtls legacy fix

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -514,6 +514,8 @@
 /samples/wifi/softap/                     @D-Triveni @krish2718
 /samples/wifi/monitor/                    @D-Triveni
 /samples/wifi/promiscuous/                @D-Triveni
+/samples/wifi/thread_coex/                @D-Triveni @nrfconnect/ncs-co-networking @nrfconnect/ncs-thread
+/samples/wifi/wfa_qt_app/                 @krish2718 @D-Triveni
 /samples/zigbee/                          @nrfconnect/ncs-zigbee
 
 /samples/app_event_manager/*.rst          @nrfconnect/ncs-si-muffin-doc @nrfconnect/ncs-si-bluebagel-doc

--- a/applications/matter_bridge/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/applications/matter_bridge/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -9,10 +9,6 @@ CONFIG_CHIP_QSPI_NOR=n
 
 CONFIG_MPU_STACK_GUARD=n
 
-# Enable PSA crypto from SSF client
-CONFIG_PSA_SSF_CRYPTO_CLIENT=y
-CONFIG_SSF_PSA_CRYPTO_SERVICE_ENABLED=y
-
 # TODO: Enable factory data once it is available
 CONFIG_CHIP_FACTORY_DATA=n
 

--- a/samples/suit/flash_companion/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/suit/flash_companion/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -43,6 +43,6 @@
 	status = "disabled";
 };
 
-&prng {
+&psa_rng {
 	status = "disabled";
 };

--- a/samples/wifi/ble_coex/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/samples/wifi/ble_coex/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable Oberon PSA crypto drivers
+CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
+
+# Enable PSA crypto from SSF client
+CONFIG_PSA_SSF_CRYPTO_CLIENT=y
+CONFIG_SSF_PSA_CRYPTO_SERVICE_ENABLED=y
+
+# Disable Data Cache
+CONFIG_DCACHE=n

--- a/samples/wifi/ble_coex/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/wifi/ble_coex/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&cpusec_cpuapp_ipc {
+	status = "okay";
+};
+
+&cpuapp_ram0x_region {
+	status = "okay";
+};
+
+&cpusec_bellboard {
+	status = "okay";
+};
+
+&cpuapp_bellboard {
+	status = "okay";
+};

--- a/samples/wifi/monitor/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/samples/wifi/monitor/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable Oberon PSA crypto drivers
+CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
+
+# Enable PSA crypto from SSF client
+CONFIG_PSA_SSF_CRYPTO_CLIENT=y
+CONFIG_SSF_PSA_CRYPTO_SERVICE_ENABLED=y
+
+# Disable Data Cache
+CONFIG_DCACHE=n

--- a/samples/wifi/monitor/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/wifi/monitor/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&cpusec_cpuapp_ipc {
+	status = "okay";
+};
+
+&cpuapp_ram0x_region {
+	status = "okay";
+};
+
+&cpusec_bellboard {
+	status = "okay";
+};
+
+&cpuapp_bellboard {
+	status = "okay";
+};

--- a/samples/wifi/promiscuous/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/samples/wifi/promiscuous/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable Oberon PSA crypto drivers
+CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
+
+# Enable PSA crypto from SSF client
+CONFIG_PSA_SSF_CRYPTO_CLIENT=y
+CONFIG_SSF_PSA_CRYPTO_SERVICE_ENABLED=y
+
+# Disable Data Cache
+CONFIG_DCACHE=n

--- a/samples/wifi/promiscuous/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/wifi/promiscuous/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&cpusec_cpuapp_ipc {
+	status = "okay";
+};
+
+&cpuapp_ram0x_region {
+	status = "okay";
+};
+
+&cpusec_bellboard {
+	status = "okay";
+};
+
+&cpuapp_bellboard {
+	status = "okay";
+};

--- a/samples/wifi/provisioning/ble/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/samples/wifi/provisioning/ble/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable Oberon PSA crypto drivers
+CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
+
+# Enable PSA crypto from SSF client
+CONFIG_PSA_SSF_CRYPTO_CLIENT=y
+CONFIG_SSF_PSA_CRYPTO_SERVICE_ENABLED=y
+
+# Disable Data Cache
+CONFIG_DCACHE=n

--- a/samples/wifi/provisioning/ble/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/wifi/provisioning/ble/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&cpusec_cpuapp_ipc {
+	status = "okay";
+};
+
+&cpuapp_ram0x_region {
+	status = "okay";
+};
+
+&cpusec_bellboard {
+	status = "okay";
+};
+
+&cpuapp_bellboard {
+	status = "okay";
+};

--- a/samples/wifi/provisioning/softap/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/samples/wifi/provisioning/softap/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable Oberon PSA crypto drivers
+CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
+
+# Enable PSA crypto from SSF client
+CONFIG_PSA_SSF_CRYPTO_CLIENT=y
+CONFIG_SSF_PSA_CRYPTO_SERVICE_ENABLED=y
+
+# Disable Data Cache
+CONFIG_DCACHE=n

--- a/samples/wifi/provisioning/softap/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/wifi/provisioning/softap/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&cpusec_cpuapp_ipc {
+	status = "okay";
+};
+
+&cpuapp_ram0x_region {
+	status = "okay";
+};
+
+&cpusec_bellboard {
+	status = "okay";
+};
+
+&cpuapp_bellboard {
+	status = "okay";
+};

--- a/samples/wifi/radio_test/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/samples/wifi/radio_test/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable Oberon PSA crypto drivers
+CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
+
+# Enable PSA crypto from SSF client
+CONFIG_PSA_SSF_CRYPTO_CLIENT=y
+CONFIG_SSF_PSA_CRYPTO_SERVICE_ENABLED=y
+
+# Disable Data Cache
+CONFIG_DCACHE=n

--- a/samples/wifi/radio_test/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/wifi/radio_test/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&cpusec_cpuapp_ipc {
+	status = "okay";
+};
+
+&cpuapp_ram0x_region {
+	status = "okay";
+};
+
+&cpusec_bellboard {
+	status = "okay";
+};
+
+&cpuapp_bellboard {
+	status = "okay";
+};

--- a/samples/wifi/raw_tx_packet/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/samples/wifi/raw_tx_packet/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable Oberon PSA crypto drivers
+CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
+
+# Enable PSA crypto from SSF client
+CONFIG_PSA_SSF_CRYPTO_CLIENT=y
+CONFIG_SSF_PSA_CRYPTO_SERVICE_ENABLED=y
+
+# Disable Data Cache
+CONFIG_DCACHE=n

--- a/samples/wifi/raw_tx_packet/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/wifi/raw_tx_packet/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&cpusec_cpuapp_ipc {
+	status = "okay";
+};
+
+&cpuapp_ram0x_region {
+	status = "okay";
+};
+
+&cpusec_bellboard {
+	status = "okay";
+};
+
+&cpuapp_bellboard {
+	status = "okay";
+};

--- a/samples/wifi/scan/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/samples/wifi/scan/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable Oberon PSA crypto drivers
+CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
+
+# Enable PSA crypto from SSF client
+CONFIG_PSA_SSF_CRYPTO_CLIENT=y
+CONFIG_SSF_PSA_CRYPTO_SERVICE_ENABLED=y
+
+# Disable Data Cache
+CONFIG_DCACHE=n

--- a/samples/wifi/scan/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/wifi/scan/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&cpusec_cpuapp_ipc {
+	status = "okay";
+};
+
+&cpuapp_ram0x_region {
+	status = "okay";
+};
+
+&cpusec_bellboard {
+	status = "okay";
+};
+
+&cpuapp_bellboard {
+	status = "okay";
+};

--- a/samples/wifi/shell/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/samples/wifi/shell/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable Oberon PSA crypto drivers
+CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
+
+# Enable PSA crypto from SSF client
+CONFIG_PSA_SSF_CRYPTO_CLIENT=y
+CONFIG_SSF_PSA_CRYPTO_SERVICE_ENABLED=y
+
+# Disable Data Cache
+CONFIG_DCACHE=n

--- a/samples/wifi/shell/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/wifi/shell/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&cpusec_cpuapp_ipc {
+	status = "okay";
+};
+
+&cpuapp_ram0x_region {
+	status = "okay";
+};
+
+&cpusec_bellboard {
+	status = "okay";
+};
+
+&cpuapp_bellboard {
+	status = "okay";
+};

--- a/samples/wifi/shutdown/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/samples/wifi/shutdown/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable Oberon PSA crypto drivers
+CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
+
+# Enable PSA crypto from SSF client
+CONFIG_PSA_SSF_CRYPTO_CLIENT=y
+CONFIG_SSF_PSA_CRYPTO_SERVICE_ENABLED=y
+
+# Disable Data Cache
+CONFIG_DCACHE=n

--- a/samples/wifi/shutdown/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/wifi/shutdown/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&cpusec_cpuapp_ipc {
+	status = "okay";
+};
+
+&cpuapp_ram0x_region {
+	status = "okay";
+};
+
+&cpusec_bellboard {
+	status = "okay";
+};
+
+&cpuapp_bellboard {
+	status = "okay";
+};

--- a/samples/wifi/softap/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/samples/wifi/softap/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable Oberon PSA crypto drivers
+CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
+
+# Enable PSA crypto from SSF client
+CONFIG_PSA_SSF_CRYPTO_CLIENT=y
+CONFIG_SSF_PSA_CRYPTO_SERVICE_ENABLED=y
+
+# Disable Data Cache
+CONFIG_DCACHE=n

--- a/samples/wifi/softap/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/wifi/softap/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&cpusec_cpuapp_ipc {
+	status = "okay";
+};
+
+&cpuapp_ram0x_region {
+	status = "okay";
+};
+
+&cpusec_bellboard {
+	status = "okay";
+};
+
+&cpuapp_bellboard {
+	status = "okay";
+};

--- a/samples/wifi/sta/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/samples/wifi/sta/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable Oberon PSA crypto drivers
+CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
+
+# Enable PSA crypto from SSF client
+CONFIG_PSA_SSF_CRYPTO_CLIENT=y
+CONFIG_SSF_PSA_CRYPTO_SERVICE_ENABLED=y
+
+# Disable Data Cache
+CONFIG_DCACHE=n

--- a/samples/wifi/sta/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/wifi/sta/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&cpusec_cpuapp_ipc {
+	status = "okay";
+};
+
+&cpuapp_ram0x_region {
+	status = "okay";
+};
+
+&cpusec_bellboard {
+	status = "okay";
+};
+
+&cpuapp_bellboard {
+	status = "okay";
+};

--- a/samples/wifi/thread_coex/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/samples/wifi/thread_coex/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable Oberon PSA crypto drivers
+CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
+
+# Enable PSA crypto from SSF client
+CONFIG_PSA_SSF_CRYPTO_CLIENT=y
+CONFIG_SSF_PSA_CRYPTO_SERVICE_ENABLED=y
+
+# Disable Data Cache
+CONFIG_DCACHE=n

--- a/samples/wifi/thread_coex/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/wifi/thread_coex/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&cpusec_cpuapp_ipc {
+	status = "okay";
+};
+
+&cpuapp_ram0x_region {
+	status = "okay";
+};
+
+&cpusec_bellboard {
+	status = "okay";
+};
+
+&cpuapp_bellboard {
+	status = "okay";
+};

--- a/samples/wifi/throughput/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/samples/wifi/throughput/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable Oberon PSA crypto drivers
+CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
+
+# Enable PSA crypto from SSF client
+CONFIG_PSA_SSF_CRYPTO_CLIENT=y
+CONFIG_SSF_PSA_CRYPTO_SERVICE_ENABLED=y
+
+# Disable Data Cache
+CONFIG_DCACHE=n

--- a/samples/wifi/throughput/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/wifi/throughput/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&cpusec_cpuapp_ipc {
+	status = "okay";
+};
+
+&cpuapp_ram0x_region {
+	status = "okay";
+};
+
+&cpusec_bellboard {
+	status = "okay";
+};
+
+&cpuapp_bellboard {
+	status = "okay";
+};

--- a/samples/wifi/twt/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/samples/wifi/twt/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable Oberon PSA crypto drivers
+CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
+
+# Enable PSA crypto from SSF client
+CONFIG_PSA_SSF_CRYPTO_CLIENT=y
+CONFIG_SSF_PSA_CRYPTO_SERVICE_ENABLED=y
+
+# Disable Data Cache
+CONFIG_DCACHE=n

--- a/samples/wifi/twt/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/wifi/twt/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&cpusec_cpuapp_ipc {
+	status = "okay";
+};
+
+&cpuapp_ram0x_region {
+	status = "okay";
+};
+
+&cpusec_bellboard {
+	status = "okay";
+};
+
+&cpuapp_bellboard {
+	status = "okay";
+};

--- a/samples/wifi/wfa_qt_app/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/samples/wifi/wfa_qt_app/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable Oberon PSA crypto drivers
+CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
+
+# Enable PSA crypto from SSF client
+CONFIG_PSA_SSF_CRYPTO_CLIENT=y
+CONFIG_SSF_PSA_CRYPTO_SERVICE_ENABLED=y
+
+# Disable Data Cache
+CONFIG_DCACHE=n

--- a/samples/wifi/wfa_qt_app/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/wifi/wfa_qt_app/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&cpusec_cpuapp_ipc {
+	status = "okay";
+};
+
+&cpuapp_ram0x_region {
+	status = "okay";
+};
+
+&cpusec_bellboard {
+	status = "okay";
+};
+
+&cpuapp_bellboard {
+	status = "okay";
+};

--- a/subsys/nrf_security/CMakeLists.txt
+++ b/subsys/nrf_security/CMakeLists.txt
@@ -43,11 +43,6 @@ if(CONFIG_BUILD_WITH_TFM OR CONFIG_PSA_SSF_CRYPTO_CLIENT)
   # We enable either TF-M or the SSF client PSA crypto interface but we are
   # not in the secure image build
 
-  # Add replacement platform.c for NS build
-  list(APPEND src_zephyr
-    ${ARM_MBEDTLS_PATH}/library/platform.c
-  )
-
   # The current version of the mbed TLS deliverables requires mbedcrypto built
   # and linked in the NS image (e.g. for mbedtls and mbedx509 library).
   # If CC3XX_BACKEND is enabled, configurations need to be converted to
@@ -55,8 +50,12 @@ if(CONFIG_BUILD_WITH_TFM OR CONFIG_PSA_SSF_CRYPTO_CLIENT)
 
   get_cmake_property(all_vars VARIABLES)
 
-  # 1. Non-secure should not build the PSA core or drivers
-  set(CONFIG_MBEDTLS_PSA_CRYPTO_C               False)
+  # 1. TF-M enabled samples should not enable the PSA core or drivers
+  #    We still need to state CONFIG_MBEDTLS_PSA_CRYPTO_C for 
+  #    nRF54H20 devices which is not the same as an NS build...
+  if(NOT CONFIG_PSA_SSF_CRYPTO_CLIENT)
+    set(CONFIG_MBEDTLS_PSA_CRYPTO_C               False)
+  endif()
 
   # 2. Enable OBERON_BACKEND, disable CC3XX_BACKEND
   set(CONFIG_NRF_OBERON                         True)

--- a/subsys/nrf_security/Kconfig
+++ b/subsys/nrf_security/Kconfig
@@ -36,6 +36,7 @@ config NRF_SECURITY
 	default y if BUILD_WITH_TFM
 	# entropy is provided by PSA and NRF_SECURITY on NRF54LX
 	default y if ENTROPY_PSA_CRYPTO_RNG && SOC_SERIES_NRF54LX
+	default y if (SOC_NRF54H20_CPUAPP || SOC_NRF54H20_CPURAD) && ENTROPY_GENERATOR
 	select DISABLE_MBEDTLS_BUILTIN if MBEDTLS
 	# NCS does not use TF-M's BL2 bootloader, but uses it's own fork
 	# of MCUBoot instead (CONFIG_BOOTLOADER_MCUBOOT).

--- a/subsys/nrf_security/Kconfig.legacy
+++ b/subsys/nrf_security/Kconfig.legacy
@@ -337,6 +337,7 @@ config OBERON_BACKEND
 	prompt "Configuration to enable nrf_oberon for legacy mbed TLS APIs"
 	select NRF_OBERON
 	depends on !(CC3XX_BACKEND_FORCED || CC3XX_BACKEND)
+	default y if PSA_SSF_CRYPTO_CLIENT
 	help
 	  This configuration enables legacy mbed TLS APIs using nrf_oberon.
 	  PSA_CRYPTO_DRIVER_OBERON should be used instead and will replace this once

--- a/subsys/nrf_security/configs/psa_crypto_config.h.template
+++ b/subsys/nrf_security/configs/psa_crypto_config.h.template
@@ -446,8 +446,10 @@
 #cmakedefine MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG
 #cmakedefine MBEDTLS_PSA_KEY_SLOT_COUNT                         @MBEDTLS_PSA_KEY_SLOT_COUNT@
 
+#if !defined(CONFIG_PSA_CORE_DISABLED)
 #include <psa/core_unsupported_ciphers_check.h>
 
 #include <check_crypto_config.h>
+#endif /* !CONFIG_PSA_CORE_DISABLED */
 
 #endif /* PSA_CRYPTO_USER_CONFIG_H */

--- a/subsys/nrf_security/src/CMakeLists.txt
+++ b/subsys/nrf_security/src/CMakeLists.txt
@@ -119,15 +119,11 @@ append_with_prefix(src_crypto_base ${ARM_MBEDTLS_PATH}/library
   constant_time.c
 )
 
-# Legacy APIs were missing files added by Oberon PSA core (not built in
-# certain instances. This adds the same platform support as the Oberon PSA core)
-if(NOT CONFIG_MBEDTLS_PSA_CRYPTO_C)
-  append_with_prefix(src_crypto_base  ${OBERON_PSA_CORE_PATH}/library/
-    platform.c
-    platform_util.c
-  )
-endif()
-
+# Add platform files both with and without PSA core enabled
+append_with_prefix(src_crypto_base ${OBERON_PSA_CORE_PATH}/library/
+  platform.c
+  platform_util.c
+)
 
 # Add threading support for PSA core (if enabled)
 include(${CMAKE_CURRENT_LIST_DIR}/threading/threading.cmake)
@@ -195,7 +191,7 @@ target_compile_options(${mbedcrypto_target}
 )
 
 # Add PSA core
-if(CONFIG_MBEDTLS_PSA_CRYPTO_C)
+if(CONFIG_MBEDTLS_PSA_CRYPTO_C AND NOT CONFIG_PSA_CORE_DISABLED)
   add_subdirectory(core)
 endif()
 

--- a/subsys/nrf_security/src/core/nrf_oberon/CMakeLists.txt
+++ b/subsys/nrf_security/src/core/nrf_oberon/CMakeLists.txt
@@ -5,11 +5,6 @@
 #
 
 append_with_prefix(src_crypto_core_oberon ${OBERON_PSA_CORE_PATH}/library/
-  platform.c
-  platform_util.c
-)
-
-append_with_prefix(src_crypto_core_oberon ${OBERON_PSA_CORE_PATH}/library/
   psa_crypto.c
   psa_crypto_client.c
   psa_crypto_slot_management.c
@@ -53,4 +48,3 @@ target_link_libraries(${mbedcrypto_target}
   PRIVATE
     oberon_psa_core
 )
-

--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 8ceab93c866d584201621703dee15a77107e7363
+      revision: pull/2135/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This commit adds basic legacy support for nRF54H20 devices as well as trying to give PSA RNG support for nRF54H20 devices from CPUAPP/CPURAD