### PR TITLE
net: nrf_cloud_coap: Separate nrf cloud coap sec tags

### DIFF
--- a/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_coap
+++ b/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_coap
@@ -24,6 +24,10 @@ config NRF_CLOUD_COAP_SEC_TAG
 	int "Security tag for credentials"
 	default NRF_CLOUD_SEC_TAG
 
+config NRF_CLOUD_COAP_JWT_SEC_TAG
+	int "Security tag for JWT credentials"
+	default NRF_CLOUD_COAP_SEC_TAG
+
 config NRF_CLOUD_COAP_SERVER_PORT
 	int "CoAP server port"
 	default 5684

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_sec_tag.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_sec_tag.c
@@ -11,7 +11,7 @@ LOG_MODULE_REGISTER(nrf_cloud_sec_tag, CONFIG_NRF_CLOUD_LOG_LEVEL);
 
 static sec_tag_t nrf_cloud_sec_tag =
 #if defined(CONFIG_NRF_CLOUD_COAP)
-	CONFIG_NRF_CLOUD_COAP_SEC_TAG;
+	CONFIG_NRF_CLOUD_COAP_JWT_SEC_TAG;
 #else
 	CONFIG_NRF_CLOUD_SEC_TAG;
 #endif


### PR DESCRIPTION
Separate sec tags used for JWT generation and DTLS. This makes it possible to point the DTLS sec tag to a dev tag to get decrypted DTLS traffic in modem traces.