### PR TITLE
dm: Fix timeslot distance check

### DIFF
--- a/subsys/dm/timeslot_queue.c
+++ b/subsys/dm/timeslot_queue.c
@@ -65,7 +65,6 @@ static bool is_request_exist(struct dm_request *req)
 int timeslot_queue_append(struct dm_request *req, uint32_t start_ref_tick,
 			  uint32_t window_len_us, uint32_t timeslot_len_us)
 {
-	uint32_t distance;
 	uint32_t start_time;
 	uint32_t delay;
 	size_t list_size;
@@ -84,13 +83,19 @@ int timeslot_queue_append(struct dm_request *req, uint32_t start_ref_tick,
 			return -EAGAIN;
 		}
 
+		/* Check that the new timeslot does not overlap with a previous one.
+		 * Timeslots are added with a fixed distance from "now" and are therefore
+		 * always appended to the end of the queue. This means that we only
+		 * need to check that the start of the new timeslot does not fall into
+		 * the last timeslot in the queue.
+		 */
 		list_lock();
 		last = SYS_SLIST_PEEK_TAIL_CONTAINER(&timeslot_list, last, node);
 		list_unlock();
 
-		distance = time_distance_get(last->timeslot_req.start_time, start_time);
-		if (distance < US_TO_RTC_TICKS(last->timeslot_req.timeslot_length_us +
-					       MIN_TIME_BETWEEN_TIMESLOTS_US)) {
+		if (start_time < last->timeslot_req.start_time +
+					 US_TO_RTC_TICKS(last->timeslot_req.timeslot_length_us +
+							 MIN_TIME_BETWEEN_TIMESLOTS_US)) {
 			return -EBUSY;
 		}
 	}


### PR DESCRIPTION
The distance check to the next timeslot was broken, resulting in a condition which would always be false. This means that in total, there would always be a single timeslot be scheduled for the ranging, at most. Fixed this check.