### PR TITLE
suit: Add support for new suit-install key

### DIFF
--- a/config/suit/templates/nrf54h20/default/v1/app_envelope.yaml.jinja2
+++ b/config/suit/templates/nrf54h20/default/v1/app_envelope.yaml.jinja2
@@ -74,7 +74,12 @@ SUIT_Envelope_Tagged:
     suit-current-version: {{ DEFAULT_VERSION }}
 {%- endif %}
 
+{%- if application['dt'].label2node['suit_storage_partition'].regs[0].size == 24576 %}
+    # Application DTS contains larger SUIT storage - use legacy encoding
+    suit-install-legacy:
+{%- else %}
     suit-install:
+{%- endif %}
     - suit-directive-set-component-index: 1
     - suit-directive-override-parameters:
 {%- if 'CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI' in application['config'] and application['config']['CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI'] != '' %}

--- a/config/suit/templates/nrf54h20/default/v1/app_recovery_envelope.yaml.jinja2
+++ b/config/suit/templates/nrf54h20/default/v1/app_recovery_envelope.yaml.jinja2
@@ -139,7 +139,12 @@ SUIT_Envelope_Tagged:
     suit-current-version: {{ DEFAULT_VERSION }}
 {%- endif %}
 
+{%- if application['dt'].label2node['suit_storage_partition'].regs[0].size == 24576 %}
+    # Application DTS contains larger SUIT storage - use legacy encoding
+    suit-install-legacy:
+{%- else %}
     suit-install:
+{%- endif %}
 {%- if rad_recovery is defined %}
     - suit-directive-set-component-index: 1
     - suit-directive-override-parameters:

--- a/config/suit/templates/nrf54h20/default/v1/rad_envelope.yaml.jinja2
+++ b/config/suit/templates/nrf54h20/default/v1/rad_envelope.yaml.jinja2
@@ -79,7 +79,12 @@ SUIT_Envelope_Tagged:
     suit-current-version: {{ DEFAULT_VERSION }}
 {%- endif %}
 
+{%- if radio['dt'].label2node['suit_storage_partition'].regs[0].size == 24576 %}
+    # Radio DTS contains larger SUIT storage - use legacy encoding
+    suit-install-legacy:
+{%- else %}
     suit-install:
+{%- endif %}
     - suit-directive-set-component-index: 1
     - suit-directive-override-parameters:
 {%- if 'CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI' in radio['config'] and radio['config']['CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI'] != '' %}

--- a/config/suit/templates/nrf54h20/default/v1/rad_recovery_envelope.yaml.jinja2
+++ b/config/suit/templates/nrf54h20/default/v1/rad_recovery_envelope.yaml.jinja2
@@ -69,7 +69,13 @@ SUIT_Envelope_Tagged:
 {%- elif DEFAULT_VERSION is defined %}
     suit-current-version: {{ DEFAULT_VERSION }}
 {%- endif %}
+
+{%- if radio['dt'].label2node['suit_storage_partition'].regs[0].size == 24576 %}
+    # Radio DTS contains larger SUIT storage - use legacy encoding
+    suit-install-legacy:
+{%- else %}
     suit-install:
+{%- endif %}
     - suit-directive-set-component-index: 1
     - suit-directive-override-parameters:
         suit-parameter-uri: '#{{ rad_recovery['name'] }}'

--- a/config/suit/templates/nrf54h20/default/v1/root_with_binary_nordic_top.yaml.jinja2
+++ b/config/suit/templates/nrf54h20/default/v1/root_with_binary_nordic_top.yaml.jinja2
@@ -120,7 +120,12 @@ SUIT_Envelope_Tagged:
     suit-current-version: {{ DEFAULT_VERSION }}
 {%- endif %}
 
+{%- if main_config['dt'].label2node['suit_storage_partition'].regs[0].size == 24576 %}
+    # Main DTS contains larger SUIT storage - use legacy encoding
+    suit-install-legacy:
+{%- else %}
     suit-install:
+{%- endif %}
     - suit-directive-set-component-index: 0
 {%- if radio is defined %}
     - suit-directive-override-parameters:

--- a/config/suit/templates/nrf54h20/matter/v1/app_envelope.yaml.jinja2
+++ b/config/suit/templates/nrf54h20/matter/v1/app_envelope.yaml.jinja2
@@ -96,7 +96,13 @@ SUIT_Envelope_Tagged:
     - suit-directive-fetch:
       - suit-send-record-failure
 {%- endif %}
+
+{%- if application['dt'].label2node['suit_storage_partition'].regs[0].size == 24576 %}
+    # Application DTS contains larger SUIT storage - use legacy encoding
+    suit-install-legacy:
+{%- else %}
     suit-install:
+{%- endif %}
 {%- if flash_companion is defined %}
     - suit-directive-set-component-index: 1
     - suit-directive-override-parameters:

--- a/config/suit/templates/nrf54h20/matter/v1/rad_envelope.yaml.jinja2
+++ b/config/suit/templates/nrf54h20/matter/v1/rad_envelope.yaml.jinja2
@@ -87,7 +87,13 @@ SUIT_Envelope_Tagged:
     - suit-directive-fetch:
       - suit-send-record-failure
 {%- endif %}
+
+{%- if radio['dt'].label2node['suit_storage_partition'].regs[0].size == 24576 %}
+    # Radio DTS contains larger SUIT storage - use legacy encoding
+    suit-install-legacy:
+{%- else %}
     suit-install:
+{%- endif %}
     - suit-directive-set-component-index: 1
     - suit-directive-override-parameters:
 {%- if 'CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI' in radio['config'] and radio['config']['CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI'] != '' %}

--- a/config/suit/templates/nrf54h20/matter/v1/root_with_binary_nordic_top.yaml.jinja2
+++ b/config/suit/templates/nrf54h20/matter/v1/root_with_binary_nordic_top.yaml.jinja2
@@ -156,7 +156,12 @@ SUIT_Envelope_Tagged:
       - suit-send-sysinfo-failure
 {%- endif %}
 
+{%- if main_config['dt'].label2node['suit_storage_partition'].regs[0].size == 24576 %}
+    # Main DTS contains larger SUIT storage - use legacy encoding
+    suit-install-legacy:
+{%- else %}
     suit-install:
+{%- endif %}
     - suit-directive-set-component-index: 0
 {%- if application is defined %}
     - suit-directive-override-parameters:

--- a/samples/suit/smp_transfer/suit/nrf54h20/app_envelope_extflash.yaml.jinja2
+++ b/samples/suit/smp_transfer/suit/nrf54h20/app_envelope_extflash.yaml.jinja2
@@ -94,7 +94,13 @@ SUIT_Envelope_Tagged:
     - suit-directive-fetch:
       - suit-send-record-failure
 {%- endif %}
+
+{%- if application['dt'].label2node['suit_storage_partition'].regs[0].size == 24576 %}
+    # Application DTS contains larger SUIT storage - use legacy encoding
+    suit-install-legacy:
+{%- else %}
     suit-install:
+{%- endif %}
 {%- if flash_companion is defined %}
     - suit-directive-set-component-index: 1
     - suit-directive-override-parameters:

--- a/samples/suit/smp_transfer/suit/nrf54h20/rad_envelope_extflash.yaml.jinja2
+++ b/samples/suit/smp_transfer/suit/nrf54h20/rad_envelope_extflash.yaml.jinja2
@@ -85,7 +85,13 @@ SUIT_Envelope_Tagged:
     - suit-directive-fetch:
       - suit-send-record-failure
 {%- endif %}
+
+{%- if radio['dt'].label2node['suit_storage_partition'].regs[0].size == 24576 %}
+    # Radio DTS contains larger SUIT storage - use legacy encoding
+    suit-install-legacy:
+{%- else %}
     suit-install:
+{%- endif %}
     - suit-directive-set-component-index: 1
     - suit-directive-override-parameters:
 {%- if 'CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI' in radio['config'] and radio['config']['CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI'] != '' %}

--- a/samples/suit/smp_transfer/suit/nrf54h20/root_with_binary_nordic_top_extflash.yaml.jinja2
+++ b/samples/suit/smp_transfer/suit/nrf54h20/root_with_binary_nordic_top_extflash.yaml.jinja2
@@ -156,7 +156,12 @@ SUIT_Envelope_Tagged:
       - suit-send-sysinfo-failure
 {%- endif %}
 
+{%- if application['dt'].label2node['suit_storage_partition'].regs[0].size == 24576 %}
+    # Application DTS contains larger SUIT storage - use legacy encoding
+    suit-install-legacy:
+{%- else %}
     suit-install:
+{%- endif %}
     - suit-directive-set-component-index: 0
 {%- if application is defined %}
     - suit-directive-override-parameters:

--- a/west.yml
+++ b/west.yml
@@ -246,7 +246,7 @@ manifest:
           upstream-sha: c6eaeda5a1c1c5dbb24dce7e027340cb8893a77b
           compare-by-default: false
     - name: suit-generator
-      revision: 199ed3c77536e5552fb8a6505639c465655ec775
+      revision: 6d31d4f4c761b8fb7c6dc5c8a3c09bd354943957
       path: modules/lib/suit-generator
     - name: suit-processor
       revision: 4e03623523cefb125c77b12f3d876f14e83f2603


### PR DESCRIPTION
With the SUIT manifest specification rev 27 the SUIT install key has changed.
Add logic inside templates, so a proper value for a proper build context will be chosen.

test-sdk-nrf: test-nrf-pr-17828