### PR TITLE
CODEOWNERS: Improve missing entry detection

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,8 +4,10 @@
 # Order is important; the last matching pattern takes the most
 # precedence.
 
-# No general default entry with `*`. Instead the compliance workflow verifies
-# that all new files are covered by an entry in the CODEOWNERS file.
+# The default entry with `*` only applies to GitHub adding reviewers.
+# The compliance workflow verifies that all new files are covered by an
+# entry in the CODEOWNERS file, but skips this `*` entry altogether.
+*					  @nrfconnect/ncs-code-owners
 
 # Root folder
 /.*					  @nrfconnect/ncs-code-owners
@@ -25,7 +27,6 @@
 /.vscode/                                 @FilipZajdel
 
 # Applications
-/applications/				  @nrfconnect/ncs-code-owners
 /applications/asset_tracker_v2/           @nrfconnect/ncs-cia @coderbyheart
 /applications/connectivity_bridge/        @nrfconnect/ncs-cia @nordic-auko
 /applications/ipc_radio/                  @nrfconnect/ncs-si-muffin
@@ -41,7 +42,7 @@
 /applications/**/*.rst                    @nrfconnect/ncs-doc-owners
 
 # Boards
-/boards/                                  @nrfconnect/ncs-co-boards
+/boards/nordic/nrf52*                     @nrfconnect/ncs-co-boards @nrfconnect/ncs-si-bluebagel
 /boards/nordic/thingy91*                  @nrfconnect/ncs-co-boards @nrfconnect/ncs-cia
 /boards/shields/coverage_support/         @nrfconnect/ncs-low-level-test
 
@@ -64,54 +65,71 @@
 /doc/nrf/app_dev/device_guides/nrf54l/    @annwoj
 
 # Drivers
-/drivers/                                 @nrfconnect/ncs-co-drivers
+/drivers/bluetooth/                       @nrfconnect/ncs-co-drivers @nrfconnect/ncs-dragoon
+/drivers/entropy/                         @nrfconnect/ncs-co-drivers @nrfconnect/ncs-aegir
+/drivers/flash/                           @nrfconnect/ncs-co-drivers
 /drivers/gpio/                            @nrfconnect/ncs-co-drivers @masz-nordic
+/drivers/hw_cc3xx/                        @nrfconnect/ncs-co-drivers @nrfconnect/ncs-aegir
+/drivers/mpsl/                            @nrfconnect/ncs-co-drivers @nrfconnect/ncs-dragoon
+/drivers/net/                             @nrfconnect/ncs-co-drivers @doki-nordic
 /drivers/serial/                          @nrfconnect/ncs-co-drivers @nordic-krch
 /drivers/sensor/bh1749/                   @nrfconnect/ncs-co-drivers @nrfconnect/ncs-cia
 /drivers/sensor/bme68x_iaq/               @nrfconnect/ncs-co-drivers @nrfconnect/ncs-cia
 /drivers/sensor/paw3212/                  @nrfconnect/ncs-co-drivers @nrfconnect/ncs-si-bluebagel
 /drivers/sensor/pmw3360/                  @nrfconnect/ncs-co-drivers @nrfconnect/ncs-si-bluebagel
+/drivers/sensor/sensor_sim/               @nrfconnect/ncs-co-drivers @nrfconnect/ncs-cia
+/drivers/sensor/sensor_stub/              @nrfconnect/ncs-co-drivers @nrfconnect/ncs-cia
 
 # Devicetree
 /dts/                                     @nrfconnect/ncs-co-drivers
 
 # External
-/ext/                                     @carlescufi
+/ext/curl/                                @nrfconnect/ncs-code-owners @jhirsi
+/ext/freebsd-getopt/                      @nrfconnect/ncs-code-owners
+/ext/iperf3/                              @nrfconnect/ncs-code-owners @jhirsi
 
 # Include
-/include/                                 @nrfconnect/ncs-code-owners
-/include/net/azure_*                      @nrfconnect/ncs-cia @coderbyheart
-/include/net/wifi_credentials.h           @nrfconnect/ncs-cia
-/include/net/nrf_cloud_*                  @nrfconnect/ncs-nrf-cloud
 /include/audio/                           @nrfconnect/ncs-audio
 /include/audio_module/                    @nrfconnect/ncs-audio
 /include/bluetooth/                       @nrfconnect/ncs-si-muffin @nrfconnect/ncs-dragoon
-/include/bluetooth/services/fast_pair/    @nrfconnect/ncs-si-bluebagel
 /include/bluetooth/adv_prov.h             @nrfconnect/ncs-si-bluebagel
 /include/bluetooth/mesh/                  @nrfconnect/ncs-paladin
+/include/bluetooth/services/fast_pair/    @nrfconnect/ncs-si-bluebagel
 /include/caf/                             @nrfconnect/ncs-si-muffin @nrfconnect/ncs-si-bluebagel
+/include/debug/				  @nrfconnect/ncs-co-drivers
 /include/debug/ppi_trace.h                @nrfconnect/ncs-co-drivers @nordic-krch
+/include/dfu/				  @nrfconnect/ncs-code-owners
 /include/dfu/dfu_target_suit.h            @nrfconnect/ncs-charon
 /include/dfu/suit_dfu_fetch_source.h      @nrfconnect/ncs-charon
 /include/dfu/suit_dfu.h                   @nrfconnect/ncs-charon
-/include/drivers/                         @nrfconnect/ncs-co-drivers
+/include/drivers/flash/                   @nrfconnect/ncs-co-drivers
 /include/drivers/gpio/                    @nrfconnect/ncs-co-drivers @masz-nordic
-/include/dult.h                           @nrfconnect/ncs-si-bluebagel
+/include/drivers/bme68x_iaq.h             @nrfconnect/ncs-co-drivers @nrfconnect/ncs-cia
+/include/drivers/sensor_sim.h             @nrfconnect/ncs-co-drivers @nrfconnect/ncs-cia
+/include/drivers/sensor_stub.h            @nrfconnect/ncs-co-drivers @nrfconnect/ncs-cia
+/include/emds/                            @balaklaka @nrfconnect/ncs-paladin
+/include/fem_al/                          @nrfconnect/ncs-dragoon
 /include/logging/                         @nrfconnect/ncs-protocols-serialization
+/include/mgmt/                            @nrfconnect/ncs-pluto
+/include/modem/                           @nrfconnect/ncs-modem
 /include/mpsl/                            @nrfconnect/ncs-dragoon
-/include/net/                             @nrfconnect/ncs-co-networking
+/include/net/azure_*                      @nrfconnect/ncs-cia @coderbyheart
+/include/net/nrf_cloud_*                  @nrfconnect/ncs-nrf-cloud
+/include/net/wifi_credentials.h           @nrfconnect/ncs-cia
 /include/nfc/                             @nrfconnect/ncs-co-drivers @nrfconnect/ncs-si-muffin
 /include/nrf_compress/                    @nordicjm
+/include/nrf_rpc/                         @nrfconnect/ncs-co-drivers @nrfconnect/ncs-si-muffin
+/include/power/                           @nrfconnect/ncs-co-drivers
 /include/sdfw/                            @nrfconnect/ncs-aurora
 /include/sdfw/sdfw_services/extmem_remote.h @nrfconnect/ncs-charon
 /include/sdfw/sdfw_services/suit_service.h @nrfconnect/ncs-charon
+/include/sdp/                             @nrfconnect/ncs-ll-ursus
 /include/shell/                           @nordic-krch
+/include/tfm/                             @nrfconnect/ncs-aegir
+/include/zigbee/                          @nrfconnect/ncs-zigbee
+/include/dult.h                           @nrfconnect/ncs-si-bluebagel
 
 # Libraries
-/lib/					  @nrfconnect/ncs-code-owners
-/lib/bin/                                 @nrfconnect/ncs-co-networking @lemrey
-/lib/bin/lwm2m_carrier/                   @nrfconnect/ncs-carrier
-/lib/boot_banner/                         @nordicjm
 /lib/adp536x/                             @nrfconnect/ncs-cia
 /lib/at_cmd_parser/                       @nrfconnect/ncs-co-networking @nrfconnect/ncs-modem
 /lib/at_cmd_custom/                       @nrfconnect/ncs-modem
@@ -119,55 +137,61 @@
 /lib/at_monitor/                          @nrfconnect/ncs-co-networking @nrfconnect/ncs-modem
 /lib/at_parser/                           @nrfconnect/ncs-co-networking @nrfconnect/ncs-modem
 /lib/at_shell/                            @nrfconnect/ncs-cia
-/lib/gcf_sms/                             @nrfconnect/ncs-modem
-/lib/nrf_modem_lib/                       @nrfconnect/ncs-co-networking @nrfconnect/ncs-modem
+/lib/bin/                                 @nrfconnect/ncs-co-networking @lemrey
+/lib/bin/lwm2m_carrier/                   @nrfconnect/ncs-carrier
+/lib/boot_banner/                         @nordicjm
+/lib/contin_array/                        @nrfconnect/ncs-audio
+/lib/data_fifo/                           @nrfconnect/ncs-audio
+/lib/date_time/                           @trantanen @tokangas
+/lib/dk_buttons_and_leds/                 @nrfconnect/ncs-si-muffin
 /lib/edge_impulse/                        @nrfconnect/ncs-si-muffin
+/lib/fatal_error/                         @nordic-krch
 /lib/fem_al/                              @nrfconnect/ncs-si-muffin
-/lib/fprotect/                            @nrfconnect/ncs-pluto
 /lib/flash_patch/                         @nrfconnect/ncs-pluto
+/lib/fprotect/                            @nrfconnect/ncs-pluto
+/lib/gcf_sms/                             @nrfconnect/ncs-modem
+/lib/hw_id/                               @nrfconnect/ncs-cia
+/lib/hw_unique_key/                       @nrfconnect/ncs-aegir
+/lib/identity_key/                        @nrfconnect/ncs-aegir
 /lib/location/                            @trantanen @jhirsi @tokangas
 /lib/lte_link_control/                    @tokangas @trantanen @jhirsi @nrfconnect/ncs-modem
 /lib/modem_antenna/                       @tokangas @nrfconnect/ncs-modem
+/lib/modem_attest_token/                  @jayteemo
 /lib/modem_battery/                       @nrfconnect/ncs-modem
 /lib/modem_info/                          @nrfconnect/ncs-co-networking @nrfconnect/ncs-modem
+/lib/modem_jwt/                           @nrfconnect/ncs-iot-oulu @nrfconnect/ncs-modem
 /lib/modem_key_mgmt/                      @nrfconnect/ncs-co-networking @nrfconnect/ncs-modem
+/lib/modem_slm/                           @nrfconnect/ncs-iot-oulu
 /lib/multithreading_lock/                 @nrfconnect/ncs-dragoon
+/lib/nrf_modem_lib/                       @nrfconnect/ncs-co-networking @nrfconnect/ncs-modem
+/lib/pcm_mix/                             @nrfconnect/ncs-audio
+/lib/pcm_stream_channel_modifier/         @nrfconnect/ncs-audio
 /lib/pdn/                                 @nrfconnect/ncs-co-networking @nrfconnect/ncs-modem
+/lib/qos/                                 @nrfconnect/ncs-cia
 /lib/ram_pwrdn/                           @MarekPorwisz
-/lib/fatal_error/                         @nordic-krch
+/lib/sample_rate_converter/               @nrfconnect/ncs-audio
 /lib/sfloat/                              @nrfconnect/ncs-si-muffin
 /lib/sms/                                 @trantanen @tokangas
 /lib/st25r3911b/                          @nrfconnect/ncs-si-muffin
 /lib/supl/                                @nrfconnect/ncs-co-networking @tokangas
-/lib/date_time/                           @trantanen @tokangas
-/lib/hw_id/                               @nrfconnect/ncs-cia
-/lib/wave_gen/                            @nrfconnect/ncs-si-muffin
-/lib/hw_unique_key/                       @nrfconnect/ncs-aegir
-/lib/identity_key/                        @nrfconnect/ncs-aegir
-/lib/modem_jwt/                           @nrfconnect/ncs-iot-oulu @nrfconnect/ncs-modem
-/lib/modem_slm/                           @nrfconnect/ncs-iot-oulu
-/lib/modem_attest_token/                  @jayteemo
-/lib/qos/                                 @nrfconnect/ncs-cia
-/lib/contin_array/                        @nrfconnect/ncs-audio
-/lib/data_fifo/                           @nrfconnect/ncs-audio
-/lib/pcm_mix/                             @nrfconnect/ncs-audio
-/lib/pcm_stream_channel_modifier/         @nrfconnect/ncs-audio
-/lib/sample_rate_converter/               @nrfconnect/ncs-audio
 /lib/tone/                                @nrfconnect/ncs-audio
+/lib/wave_gen/                            @nrfconnect/ncs-si-muffin
 
 # Modules
-/modules/                                 @nrfconnect/ncs-co-build-system
-/modules/mcuboot/                         @nrfconnect/ncs-pluto
+/modules/azure-sdk-for-c/                 @nrfconnect/ncs-cia @plskeggs
 /modules/cjson/                           @nrfconnect/ncs-cia @plskeggs
-/modules/trusted-firmware-m/              @nrfconnect/ncs-aegir
 /modules/coremark/                        @nrfconnect/ncs-si-bluebagel
+/modules/mcuboot/                         @nrfconnect/ncs-pluto
+/modules/memfault-firmware-sdk/           @nrfconnect/ncs-cia @plskeggs
+/modules/nrfxlib/			  @nrfconnect/ncs-code-owners
+/modules/trusted-firmware-m/              @nrfconnect/ncs-aegir
+/modules/wfa-qt/			  @nrfconnect/ncs-wifi
 
 # Samples
-/samples/                                 @nrfconnect/ncs-code-owners
 /samples/CMakeLists.txt                   @nrfconnect/ncs-co-build-system
-/samples/net/                             @nrfconnect/ncs-cia @nrfconnect/ncs-modem
-/samples/sensor/bh1749/                   @nrfconnect/ncs-cia
-/samples/sensor/bme68x_iaq/               @nrfconnect/ncs-cia
+/samples/app_event_manager/               @nrfconnect/ncs-si-muffin @nrfconnect/ncs-si-bluebagel
+/samples/app_event_manager_profiler_tracer/ @nrfconnect/ncs-si-muffin @nrfconnect/ncs-si-bluebagel
+/samples/benchmarks/coremark/             @nrfconnect/ncs-si-bluebagel
 /samples/bluetooth/                       @nrfconnect/ncs-si-muffin @nrfconnect/ncs-dragoon
 /samples/bluetooth/broadcast_config_tool/ @nrfconnect/ncs-audio
 /samples/bluetooth/mesh/                  @nrfconnect/ncs-paladin
@@ -175,23 +199,10 @@
 /samples/bluetooth/direction_finding_connectionless_tx/ @ppryga-nordic
 /samples/bluetooth/fast_pair/             @nrfconnect/ncs-si-bluebagel
 /samples/bootloader/                      @nrfconnect/ncs-pluto
-/samples/matter/                          @nrfconnect/ncs-matter
-/samples/crypto/                          @nrfconnect/ncs-aegir
-/samples/debug/memfault/                  @nrfconnect/ncs-cia
-/samples/debug/ppi_trace/                 @nordic-krch
-/samples/hw_id/                           @nrfconnect/ncs-cia
-/samples/edge_impulse/                    @nrfconnect/ncs-si-muffin
-/samples/esb/                             @lemrey
-/samples/app_event_manager/               @nrfconnect/ncs-si-muffin @nrfconnect/ncs-si-bluebagel
-/samples/event_manager_proxy/             @nrfconnect/ncs-si-muffin
-/samples/gazell/                          @leewkb4567
-/samples/keys/                            @nrfconnect/ncs-aegir
-/samples/mpsl/                            @nrfconnect/ncs-dragoon
-/samples/nfc/                             @nrfconnect/ncs-si-muffin
-/samples/nrf_rpc/                         @nrfconnect/ncs-si-muffin
-/samples/nrf5340/empty_app_core/          @nrfconnect/ncs-si-muffin
+/samples/caf/                             @nrfconnect/ncs-si-muffin @nrfconnect/ncs-si-bluebagel
+/samples/caf_sensor_manager/              @nrfconnect/ncs-si-muffin @nrfconnect/ncs-si-bluebagel
 /samples/cellular/                        @nrfconnect/ncs-co-networking @nrfconnect/ncs-modem
-/samples/cellular/battery/                @MirkoCovizzi
+/samples/cellular/battery/                @nrfconnect/ncs-modem
 /samples/cellular/location/               @trantanen @jhirsi @tokangas
 /samples/cellular/lwm2m_carrier/          @nrfconnect/ncs-carrier
 /samples/cellular/lwm2m_client/           @nrfconnect/ncs-co-networking @nrfconnect/ncs-iot-oulu
@@ -199,23 +210,47 @@
 /samples/cellular/nidd/                   @stig-bjorlykke
 /samples/cellular/nrf_cloud_*             @nrfconnect/ncs-nrf-cloud
 /samples/cellular/nrf_provisioning/       @nrfconnect/ncs-iot-oulu
-/samples/cellular/modem_trace_flash/      @eivindj-nordic
+/samples/cellular/modem_trace_flash/      @nrfconnect/ncs-modem
 /samples/cellular/slm_shell/              @nrfconnect/ncs-iot-oulu
 /samples/cellular/sms/                    @trantanen @tokangas
-/samples/openthread/                      @nrfconnect/ncs-co-networking @nrfconnect/ncs-thread
-/samples/nrf_profiler/                    @nrfconnect/ncs-si-bluebagel
-/samples/nrf_rpc/protocols_serialization/ @nrfconnect/ncs-protocols-serialization
-/samples/peripheral/radio_test/           @nrfconnect/ncs-si-muffin
-/samples/peripheral/lpuart/               @nordic-krch
-/samples/peripheral/802154_phy_test/      @nrfconnect/ncs-radio-sw
-/samples/peripheral/802154_sniffer/       @e-rk
-/samples/tfm/                             @nrfconnect/ncs-aegir
-/samples/zigbee/                          @nrfconnect/ncs-zigbee
+/samples/common/                          @nrfconnect/ncs-si-muffin @nrfconnect/ncs-si-bluebagel
+/samples/crypto/                          @nrfconnect/ncs-aegir
+/samples/debug/memfault/                  @nrfconnect/ncs-cia
+/samples/debug/ppi_trace/                 @nordic-krch
+/samples/dect/dect_phy/dect_shell/	  @jhirsi
+/samples/dect/dect_phy/hello_dect/        @nrfconnect/ncs-modem
+/samples/edge_impulse/                    @nrfconnect/ncs-si-muffin
+/samples/esb/                             @nrfconnect/ncs-si-muffin
+/samples/event_manager_proxy/             @nrfconnect/ncs-si-muffin
+/samples/gazell/                          @leewkb4567
+/samples/hw_id/                           @nrfconnect/ncs-cia
+/samples/ipc/ipc_service/                 @nrfconnect/ncs-si-muffin
+/samples/keys/                            @nrfconnect/ncs-aegir
+/samples/matter/                          @nrfconnect/ncs-matter
+/samples/mpsl/                            @nrfconnect/ncs-dragoon
+/samples/net/                             @nrfconnect/ncs-cia @nrfconnect/ncs-modem
+/samples/nfc/                             @nrfconnect/ncs-si-muffin
 /samples/nrf5340/netboot/                 @nrfconnect/ncs-pluto
 /samples/nrf5340/multiprotocol_rpmsg/     @hubertmis
+/samples/nrf_rpc/                         @nrfconnect/ncs-si-muffin
+/samples/sensor/bh1749/                   @nrfconnect/ncs-cia
+/samples/sensor/bme68x_iaq/               @nrfconnect/ncs-cia
+/samples/nrf5340/empty_app_core/          @nrfconnect/ncs-si-muffin
+/samples/nrf_compress/                    @nordicjm
+/samples/nrf_profiler/                    @nrfconnect/ncs-si-bluebagel
+/samples/nrf_rpc/protocols_serialization/ @nrfconnect/ncs-protocols-serialization
+/samples/openthread/                      @nrfconnect/ncs-co-networking @nrfconnect/ncs-thread
+/samples/peripheral/802154_phy_test/      @nrfconnect/ncs-radio-sw
+/samples/peripheral/802154_sniffer/       @e-rk
+/samples/peripheral/lpuart/               @nordic-krch
+/samples/peripheral/radio_test/           @nrfconnect/ncs-si-muffin
+/samples/pmic/native/                     @nordic-auko
 /samples/sdfw/                            @nrfconnect/ncs-aurora
 /samples/sdfw/ssf_client/                 @anhmolt
+/samples/sensor/bh1749/                   @nrfconnect/ncs-co-drivers @nrfconnect/ncs-cia
+/samples/sensor/bme68x_iaq/               @nrfconnect/ncs-co-drivers @nrfconnect/ncs-cia
 /samples/suit/                            @nrfconnect/ncs-charon
+/samples/tfm/                             @nrfconnect/ncs-aegir
 /samples/wifi/provisioning/ble/           @wentong-li @bama-nordic
 /samples/wifi/provisioning/softap/        @nrfconnect/ncs-cia
 /samples/wifi/radio_test/                 @bama-nordic @sachinthegreen
@@ -230,11 +265,10 @@
 /samples/wifi/softap/                     @D-Triveni @krish2718
 /samples/wifi/monitor/                    @D-Triveni
 /samples/wifi/promiscuous/                @D-Triveni
-/samples/benchmarks/coremark/             @nrfconnect/ncs-si-bluebagel
+/samples/zigbee/                          @nrfconnect/ncs-zigbee
 /samples/**/*.rst                         @nrfconnect/ncs-doc-owners
 
 # Scripts
-/scripts/                                 @nrfconnect/ncs-code-owners
 /scripts/docker/                          @nrfconnect/ncs-ci
 /scripts/ci/tags.yaml                     @nordic-piks @PerMac @katgiadla
 /scripts/ci/twister_ignore.txt            @nordic-piks @PerMac @katgiadla
@@ -254,23 +288,24 @@
 /share/			                  @nrfconnect/ncs-co-build-system
 
 # Snippets
-/snippets/                                @nrfconnect/ncs-co-boards @nrfconnect/ncs-co-build-system
+/snippets/ci-shell/                       @nrfconnect/ncs-protocols-serialization
 /snippets/emulated*/                      @masz-nordic
 /snippets/hw-flow-control/                @nrfconnect/ncs-low-level-test @miha-nordic
-/snippets/nrf91-modem-trace-ext-flash/    @nrfconnect/ncs-cia
-/snippets/nrf91-modem-trace-uart/         @eivindj-nordic
-/snippets/tfm-enable-share-uart/          @nrfconnect/ncs-cia
-/snippets/nrf70-driver-verbose-debug/     @krish2718 @sachinthegreen
-/snippets/nrf70-driver-debug/             @krish2718 @sachinthegreen
-/snippets/wpa-supplicant-debug/           @krish2718 @sachinthegreen
-/snippets/nrf70-fw-patch-ext-flash/       @krish2718 @sachinthegreen
-/snippets/nordic-bt-rpc/                  @ppryga-nordic
 /snippets/matter-diagnostic-logs/         @nrfconnect/ncs-matter
-/snippets/ci-shell/                       @nrfconnect/ncs-protocols-serialization
+/snippets/nordic-bt-rpc/                  @ppryga-nordic
+/snippets/nrf70-driver-debug/             @krish2718 @sachinthegreen
+/snippets/nrf70-driver-verbose-debug/     @krish2718 @sachinthegreen
+/snippets/nrf70-fw-patch-ext-flash/       @krish2718 @sachinthegreen
+/snippets/nrf70-wifi/                     @krish2718 @sachinthegreen
+/snippets/nrf91-modem-trace-ext-flash/    @nrfconnect/ncs-cia
+/snippets/nrf91-modem-trace-uart/         @nrfconnect/ncs-modem
+/snippets/tfm-enable-share-uart/          @nrfconnect/ncs-cia
+/snippets/wpa-supplicant-debug/           @krish2718 @sachinthegreen
 /snippets/zperf/                          @nrfconnect/ncs-protocols-serialization
 
 # Subsystems
-/subsys/                                  @nrfconnect/ncs-code-owners
+/subsys/app_event_manager/                @nrfconnect/ncs-si-muffin @nrfconnect/ncs-si-bluebagel
+/subsys/app_event_manager_profiler_tracer/    @nrfconnect/ncs-si-bluebagel
 /subsys/audio/audio_module_template/      @nrfconnect/ncs-audio
 /subsys/audio_module/                     @nrfconnect/ncs-audio
 /subsys/bluetooth/                        @nrfconnect/ncs-si-muffin @nrfconnect/ncs-dragoon
@@ -278,6 +313,7 @@
 /subsys/bluetooth/controller/             @nrfconnect/ncs-dragoon
 /subsys/bluetooth/host_extensions/        @nrfconnect/ncs-dragoon
 /subsys/bluetooth/mesh/                   @nrfconnect/ncs-paladin
+/subsys/bluetooth/rpc/                    @nrfconnect/ncs-si-bluebagel
 /subsys/bluetooth/services/fast_pair/     @nrfconnect/ncs-si-bluebagel
 /subsys/bluetooth/services/wifi_prov/     @wentong-li @bama-nordic
 /subsys/bootloader/                       @nrfconnect/ncs-pluto
@@ -287,17 +323,15 @@
 /subsys/dfu/dfu_multi_image/              @Damian-Nordic
 /subsys/dm/                               @nrfconnect/ncs-si-muffin
 /subsys/dult/                             @nrfconnect/ncs-si-bluebagel
-/subsys/ieee802154/                       @nrfconnect/ncs-co-networking @nrfconnect/ncs-radio-sw
-/subsys/mgmt/                             @nrfconnect/ncs-pluto
-/subsys/mgmt/suitfu/                      @nrfconnect/ncs-charon
 /subsys/emds/                             @balaklaka @nrfconnect/ncs-paladin
 /subsys/esb/                              @lemrey
-/subsys/app_event_manager/                @nrfconnect/ncs-si-muffin @nrfconnect/ncs-si-bluebagel
-/subsys/app_event_manager_profiler_tracer/    @nrfconnect/ncs-si-bluebagel
 /subsys/event_manager_proxy/              @nrfconnect/ncs-si-muffin
 /subsys/fw_info/                          @nrfconnect/ncs-pluto
 /subsys/gazell/                           @leewkb4567
+/subsys/ieee802154/                       @nrfconnect/ncs-co-networking @nrfconnect/ncs-radio-sw
 /subsys/logging/                          @nrfconnect/ncs-protocols-serialization
+/subsys/mgmt/                             @nrfconnect/ncs-pluto
+/subsys/mgmt/suitfu/                      @nrfconnect/ncs-charon
 /subsys/mpsl/                             @nrfconnect/ncs-dragoon
 /subsys/mpsl/cx/                          @ankuns @martintv
 /subsys/mpsl/fem/                         @ankuns @martintv
@@ -315,22 +349,22 @@
 /subsys/net/lib/softap_wifi_provision/    @nrfconnect/ncs-cia
 /subsys/net/openthread/                   @nrfconnect/ncs-co-networking @nrfconnect/ncs-thread
 /subsys/net/openthread/rpc/               @nrfconnect/ncs-protocols-serialization
+/subsys/net_core_monitor/                 @nrfconnect/ncs-si-muffin
 /subsys/nfc/                              @nrfconnect/ncs-si-muffin
 /subsys/nfc/rpc/                          @nrfconnect/ncs-protocols-serialization
 /subsys/nrf_compress/                     @nordicjm
+/subsys/nrf_profiler/                     @nrfconnect/ncs-si-bluebagel
 /subsys/nrf_rpc/                          @nrfconnect/ncs-si-muffin
+/subsys/nrf_security/                     @nrfconnect/ncs-aegir
 /subsys/partition_manager/                @nordicjm @tejlmand
 /subsys/pcd/                              @nrfconnect/ncs-pluto
-/subsys/nrf_profiler/                     @nrfconnect/ncs-si-bluebagel
-/subsys/shell/                            @nordic-krch
 /subsys/sdfw_services/                    @nrfconnect/ncs-aurora
 /subsys/sdfw_services/services/extmem/    @nrfconnect/ncs-charon
 /subsys/sdfw_services/services/suit_service/ @nrfconnect/ncs-charon
+/subsys/shell/                            @nordic-krch
 /subsys/suit/                             @nrfconnect/ncs-charon
-/subsys/nrf_security/                     @nrfconnect/ncs-aegir
 /subsys/trusted_storage/                  @nrfconnect/ncs-aegir
 /subsys/uart_async_adapter/               @nrfconnect/ncs-si-muffin
-/subsys/net_core_monitor/                 @nrfconnect/ncs-si-muffin
 /subsys/zigbee/                           @nrfconnect/ncs-zigbee
 
 # Sysbuild
@@ -339,61 +373,61 @@
 /sysbuild/suit.cmake                      @nrfconnect/ncs-charon
 
 # Tests
-/tests/                                   @nrfconnect/ncs-co-verification @katgiadla
 /tests/benchmarks/                        @nrfconnect/ncs-low-level-test
 /tests/benchmarks/multicore/              @carlescufi @nrfconnect/ncs-low-level-test
 /tests/benchmarks/multicore/idle/         @adamkondraciuk @nrfconnect/ncs-low-level-test
 /tests/benchmarks/multicore/idle_gpio/    @adamkondraciuk @nrfconnect/ncs-low-level-test
 /tests/benchmarks/multicore/idle_with_pwm/  @nrfconnect/ncs-low-level-test
-/tests/bluetooth/tester/                  @carlescufi @nrfconnect/ncs-paladin
 /tests/bluetooth/iso/                     @nrfconnect/ncs-audio @Frodevan
+/tests/bluetooth/tester/                  @carlescufi @nrfconnect/ncs-paladin
 /tests/crypto/                            @stephen-nordic @magnev
-/tests/drivers/flash_patch/               @nrfconnect/ncs-pluto
 /tests/drivers/flash/flash_rpc/           @nrfconnect/ncs-pluto
+/tests/drivers/flash_patch/               @nrfconnect/ncs-pluto
 /tests/drivers/fprotect/                  @nrfconnect/ncs-pluto
 /tests/drivers/lpuart/                    @nordic-krch
 /tests/drivers/nrfx_integration_test/     @nrfconnect/ncs-co-drivers
 /tests/drivers/pwm/gpio_loopback/         @nrfconnect/ncs-low-level-test
 /tests/drivers/sensor/multicore_temp/     @nrfconnect/ncs-low-level-test
-/tests/lib/at_parser/                     @MirkoCovizzi
-/tests/lib/at_cmd_parser/                 @lemrey
-/tests/lib/at_cmd_custom/                 @eivindj-nordic
+/tests/lib/at_cmd_parser/                 @nrfconnect/ncs-modem
+/tests/lib/at_cmd_custom/                 @nrfconnect/ncs-modem
+/tests/lib/at_parser/                     @nrfconnect/ncs-modem
+/tests/lib/contin_array/                  @nrfconnect/ncs-audio
+/tests/lib/data_fifo/                     @nrfconnect/ncs-audio
 /tests/lib/date_time/                     @trantanen @tokangas
 /tests/lib/edge_impulse/                  @nrfconnect/ncs-si-muffin
-/tests/lib/nrf_fuel_gauge/                @nordic-auko
-/tests/lib/gcf_sms/                       @eivindj-nordic
+/tests/lib/gcf_sms/                       @nrfconnect/ncs-modem
 /tests/lib/hw_unique_key*/                @nrfconnect/ncs-aegir
 /tests/lib/hw_id/                         @nrfconnect/ncs-cia
 /tests/lib/location/                      @trantanen @tokangas
 /tests/lib/lte_lc/                        @trantanen @tokangas
 /tests/lib/lte_lc_api/                    @trantanen @tokangas
-/tests/lib/modem_jwt/                     @nrfconnect/ncs-iot-oulu
-/tests/lib/modem_battery/                 @MirkoCovizzi
+/tests/lib/modem_battery/                 @nrfconnect/ncs-modem
 /tests/lib/modem_info/                    @nrfconnect/ncs-cia
-/tests/lib/qos/                           @nrfconnect/ncs-cia
-/tests/lib/sfloat/                        @nrfconnect/ncs-si-muffin
-/tests/lib/sms/                           @trantanen @tokangas
-/tests/lib/nrf_modem_lib/                 @lemrey @MirkoCovizzi
-/tests/lib/nrf_modem_lib/nrf9x_sockets/   @MirkoCovizzi
-/tests/lib/pdn/                           @lemrey @eivindj-nordic
-/tests/lib/ram_pwrdn/                     @Damian-Nordic
-/tests/lib/contin_array/                  @nrfconnect/ncs-audio
-/tests/lib/data_fifo/                     @nrfconnect/ncs-audio
+/tests/lib/modem_jwt/                     @nrfconnect/ncs-iot-oulu
+/tests/lib/nrf_fuel_gauge/                @nordic-auko
+/tests/lib/nrf_modem_lib/                 @nrfconnect/ncs-modem
+/tests/lib/nrf_modem_lib/nrf9x_sockets/   @nrfconnect/ncs-modem
+/tests/lib/pdn/                           @nrfconnect/ncs-modem
 /tests/lib/pcm_mix/                       @nrfconnect/ncs-audio
 /tests/lib/pcm_stream_channel_modifier/   @nrfconnect/ncs-audio
+/tests/lib/qos/                           @nrfconnect/ncs-cia
+/tests/lib/ram_pwrdn/                     @Damian-Nordic
 /tests/lib/sample_rate_converter/         @nrfconnect/ncs-audio
+/tests/lib/sfloat/                        @nrfconnect/ncs-si-muffin
+/tests/lib/sms/                           @trantanen @tokangas
 /tests/lib/tone/                          @nrfconnect/ncs-audio
 /tests/mocks/nrf_rpc/                     @nrfconnect/ncs-protocols-serialization
 /tests/modules/lib/zcbor/                 @oyvindronningstad
 /tests/modules/mcuboot/direct_xip/        @nrfconnect/ncs-pluto
 /tests/modules/mcuboot/external_flash/    @nrfconnect/ncs-pluto
 /tests/nrf5340_audio/                     @nrfconnect/ncs-audio @nordic-auko
+/tests/subsys/app_event_manager/          @nrfconnect/ncs-si-muffin @nrfconnect/ncs-si-bluebagel
 /tests/subsys/audio/audio_module_template/ @nrfconnect/ncs-audio
 /tests/subsys/audio_module/               @nrfconnect/ncs-audio
 /tests/subsys/bluetooth/gatt_dm/          @nrfconnect/ncs-si-muffin
-/tests/subsys/bluetooth/mesh/             @nrfconnect/ncs-paladin
 /tests/subsys/bluetooth/enocean/          @nrfconnect/ncs-paladin
 /tests/subsys/bluetooth/fast_pair/        @nrfconnect/ncs-si-bluebagel
+/tests/subsys/bluetooth/mesh/             @nrfconnect/ncs-paladin
 /tests/subsys/bootloader/                 @nrfconnect/ncs-pluto
 /tests/subsys/caf/                        @nrfconnect/ncs-si-muffin @nrfconnect/ncs-si-bluebagel
 /tests/subsys/debug/cpu_load/             @nordic-krch
@@ -401,29 +435,28 @@
 /tests/subsys/dfu/dfu_multi_image/        @Damian-Nordic
 /tests/subsys/emds/                       @balaklaka @nrfconnect/ncs-paladin
 /tests/subsys/event_manager_proxy/        @nrfconnect/ncs-si-muffin
-/tests/subsys/app_event_manager/          @nrfconnect/ncs-si-muffin @nrfconnect/ncs-si-bluebagel
 /tests/subsys/fw_info/                    @nrfconnect/ncs-pluto
 /tests/subsys/mpsl/                       @nrfconnect/ncs-dragoon
 /tests/subsys/net/lib/aws_*/              @nrfconnect/ncs-cia
 /tests/subsys/net/lib/azure_iot_hub/      @nrfconnect/ncs-cia
 /tests/subsys/net/lib/fota_download/      @nrfconnect/ncs-pluto
 /tests/subsys/net/lib/lwm2m_*/            @nrfconnect/ncs-iot-oulu
+/tests/subsys/net/lib/mqtt_helper/        @nrfconnect/ncs-cia
 /tests/subsys/net/lib/nrf_cloud/          @nrfconnect/ncs-nrf-cloud
 /tests/subsys/net/lib/nrf_provisioning/   @nrfconnect/ncs-iot-oulu
 /tests/subsys/net/lib/wifi_credentials*/  @nrfconnect/ncs-cia
-/tests/subsys/net/lib/mqtt_helper/        @nrfconnect/ncs-cia
 /tests/subsys/net/openthread/rpc/         @nrfconnect/ncs-protocols-serialization
 /tests/subsys/nfc/rpc/                    @nrfconnect/ncs-protocols-serialization
 /tests/subsys/nrf_compress/               @nordicjm
+/tests/subsys/nrf_profiler/               @nrfconnect/ncs-si-bluebagel
 /tests/subsys/partition_manager/region/   @nordicjm @tejlmand
 /tests/subsys/partition_manager/static_pm_file/  @nordicjm @tejlmand
 /tests/subsys/pcd/                        @nrfconnect/ncs-pluto
-/tests/subsys/nrf_profiler/               @nrfconnect/ncs-si-bluebagel
 /tests/subsys/sdfw_services/              @nrfconnect/ncs-aurora
-/tests/subsys/zigbee/                     @nrfconnect/ncs-zigbee
 /tests/subsys/suit/                       @nrfconnect/ncs-charon
 /tests/tfm/                               @nrfconnect/ncs-aegir @stephen-nordic @magnev
 /tests/unity/                             @nordic-krch
+/tests/subsys/zigbee/                     @nrfconnect/ncs-zigbee
 
 # CI specific west
 /test-manifests/99-default-test-nrf.yml   @nrfconnect/ncs-ci

--- a/scripts/ci/codeowners.py
+++ b/scripts/ci/codeowners.py
@@ -110,6 +110,10 @@ def ls_owned_files(codeowners):
                 continue
 
             git_patrn = match.group(1)
+            if git_patrn == '*':
+                logger.info('Skipping default \'*\' entry')
+                continue
+
             glob = git_pattern_to_glob(git_patrn)
             files = []
             for abs_path in top_path.glob(glob):


### PR DESCRIPTION
In order to handle missing entries in the CODEOWNERS file properly, a              
few changes are introduced in both the CODEOWNERS file and the script              
that checks for missing entries (scripts/ci/codeowners.py):                        
                                                                                   
- Add an '*' entry in the CODEOWNERS file. This ensures that GitHub                
  assigns someone (in this case ncs-code-owners) by default whenever a             
  PR introduces a file that is not covered by an entry in the file                 
- Remove the top-level section entries (i.e. applications/, samples/,              
  subsys/, etc). This is so that the script can catch missing files,               
  since catch-all entries like those mask those missing files                      
- Skip the processing of the '*' top-level entry in the script. This is            
  so that, while GitHub assigns someone to the PR, the entry doesn't               
  maks out every other missing file in PRs 

Also take the opportunity to add missing entries and sort the sections alphabetically. 