### PR TITLE
subsys: nrf_security: update the zephyr kernel library full path in n…

### DIFF
--- a/subsys/nrf_security/src/utils/nrf_security_utils.cmake
+++ b/subsys/nrf_security/src/utils/nrf_security_utils.cmake
@@ -35,7 +35,7 @@ else()
   # it seems to be to link with a full path instead.
   target_link_libraries(nrf_security_utils
     PRIVATE
-      ${CMAKE_BINARY_DIR}/zephyr/kernel/libkernel.a
+      ${PROJECT_BINARY_DIR}/kernel/libkernel.a
   )
 endif()
 


### PR DESCRIPTION
…rf_security_utils

Since one application project may have different build tree path than others, use the full path to project build directory for linking to the kernel library.