### PR TITLE
boards: shields: coverage_support: force hw-flow-control at coverage

### DIFF
--- a/boards/shields/coverage_support/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/boards/shields/coverage_support/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -18,3 +18,7 @@
 &cpurad_slot0_partition {
 	reg = <0x66000 DT_SIZE_K(128)>;
 };
+
+&uart136 {
+	hw-flow-control;
+};

--- a/boards/shields/coverage_support/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/boards/shields/coverage_support/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -11,3 +11,7 @@
 &slot0_partition {
 	reg = <0x10000 DT_SIZE_K(388)>;
 };
+
+&uart20 {
+	hw-flow-control;
+};


### PR DESCRIPTION
Needed to receive all data from DK.