### PR TITLE
lib: edge_impulse: Fix providing API key during zip download

### DIFF
--- a/lib/edge_impulse/CMakeLists.txt
+++ b/lib/edge_impulse/CMakeLists.txt
@@ -59,8 +59,8 @@ include(ExternalProject)
 ExternalProject_Add(edge_impulse_project
     URL              ${EI_URI_LIST}
     HTTP_HEADER      "Accept: application/zip"
-    DOWNLOAD_EXTRACT_TIMESTAMP True
                      ${EI_API_KEY_HEADER}
+    DOWNLOAD_EXTRACT_TIMESTAMP True
     PREFIX           ${EDGE_IMPULSE_DIR}
     SOURCE_DIR       ${EDGE_IMPULSE_SOURCE_DIR}
     BINARY_DIR       ${EDGE_IMPULSE_BINARY_DIR}


### PR DESCRIPTION
Change fixes an issue where EI_API_KEY_HEADER is not part of the HTTP header. The issue causes problems with downloading zip file with a machine learning model directly from private Edge Impulse studio project.

Jira: NCSIDB-1375