### PR TITLE
suit: Return volatile key IDs from MCI

### DIFF
--- a/subsys/suit/mci/include/suit_mci.h
+++ b/subsys/suit/mci/include/suit_mci.h
@@ -160,6 +160,25 @@ mci_err_t suit_mci_manifest_class_id_validate(const suit_manifest_class_id_t *cl
 mci_err_t suit_mci_signing_key_id_validate(const suit_manifest_class_id_t *class_id,
 					   uint32_t key_id);
 
+#ifdef CONFIG_ZTEST
+/**
+ * @brief Return key ID bits assigned to the manifest.
+ *
+ * @details This API is dedicated for tests that import volatile keys during setup.
+ *          In such case, the key ID is returned by PSA APIs and cannot be predicted.
+ *
+ * @param[in]   class_id	Manifest class id
+ * @param[out]  key_id		Identifier of key utilized for manifest signing.
+ *
+ * @retval SUIT_PLAT_SUCCESS        on success
+ * @retval SUIT_PLAT_ERR_INVAL      invalid parameter, i.e. null pointer
+ * @retval MCI_ERR_MANIFESTCLASSID  manifest class id unsupported
+ * @retval MCI_ERR_WRONGKEYID       provided key ID is invalid for signing
+ *                                  for provided manifest class
+ */
+mci_err_t suit_mci_signing_key_id_get(const suit_manifest_class_id_t *class_id, uint32_t *key_id);
+#endif /* CONFIG_ZTEST */
+
 /**
  * @brief Verifies if manifest with specific class id is entitled to start (invoke) code on specific
  * processor

--- a/subsys/suit/platform/sdfw/src/suit_plat_authenticate.c
+++ b/subsys/suit/platform/sdfw/src/suit_plat_authenticate.c
@@ -75,6 +75,14 @@ int suit_plat_authenticate_manifest(struct zcbor_string *manifest_component_id,
 		return SUIT_ERR_AUTHENTICATION;
 	}
 
+#ifdef CONFIG_ZTEST
+	ret = suit_mci_signing_key_id_get(class_id, &public_key_id);
+	if (ret != SUIT_PLAT_SUCCESS) {
+		LOG_ERR("Unable to find volatile key ID: MCI err %i", ret);
+		return SUIT_ERR_AUTHENTICATION;
+	}
+#endif /* CONFIG_ZTEST */
+
 #ifdef MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER
 	mbedtls_svc_key_id_t key;
 

--- a/tests/subsys/suit/common/mci_test/mci_test.c
+++ b/tests/subsys/suit/common/mci_test/mci_test.c
@@ -239,6 +239,14 @@ int suit_mci_signing_key_id_validate(const suit_manifest_class_id_t *class_id, u
 		return MCI_ERR_MANIFESTCLASSID;
 	}
 
+#ifdef CONFIG_ZTEST
+#if defined(CONFIG_MBEDTLS) || defined(CONFIG_NRF_SECURITY)
+	if (PSA_KEY_ID_VENDOR_MIN == key_id) {
+		return SUIT_PLAT_SUCCESS;
+	}
+#endif /* CONFIG_MBEDTLS || CONFIG_NRF_SECURITY*/
+#endif /* CONFIG_ZTEST */
+
 	if ((manifest_config->signing_key_bits & manifest_config->signing_key_mask) !=
 	    (key_id & manifest_config->signing_key_mask)) {
 		return MCI_ERR_WRONGKEYID;
@@ -246,6 +254,29 @@ int suit_mci_signing_key_id_validate(const suit_manifest_class_id_t *class_id, u
 
 	return SUIT_PLAT_SUCCESS;
 }
+
+#ifdef CONFIG_ZTEST
+int suit_mci_signing_key_id_get(const suit_manifest_class_id_t *class_id, uint32_t *key_id)
+{
+	if ((NULL == class_id) || (NULL == key_id)) {
+		return SUIT_PLAT_ERR_INVAL;
+	}
+
+	const manifest_config_t *manifest_config = find_manifest_config(class_id);
+
+	if (NULL == manifest_config) {
+		return MCI_ERR_MANIFESTCLASSID;
+	}
+
+#if defined(CONFIG_MBEDTLS) || defined(CONFIG_NRF_SECURITY)
+	if (PSA_KEY_ID_VENDOR_MIN == *key_id) {
+		*key_id = manifest_config->signing_key_bits;
+	}
+#endif /* CONFIG_MBEDTLS || CONFIG_NRF_SECURITY*/
+
+	return SUIT_PLAT_SUCCESS;
+}
+#endif /* CONFIG_ZTEST */
 
 int suit_mci_processor_start_rights_validate(const suit_manifest_class_id_t *class_id,
 					     int processor_id)

--- a/tests/subsys/suit/unit/mocks/include/mock_suit_mci.h
+++ b/tests/subsys/suit/unit/mocks/include/mock_suit_mci.h
@@ -34,6 +34,7 @@ FAKE_VALUE_FUNC(int, suit_mci_independent_update_policy_get, const suit_manifest
 		suit_independent_updateability_policy_t *);
 FAKE_VALUE_FUNC(int, suit_mci_manifest_class_id_validate, const suit_manifest_class_id_t *);
 FAKE_VALUE_FUNC(int, suit_mci_signing_key_id_validate, const suit_manifest_class_id_t *, uint32_t);
+FAKE_VALUE_FUNC(int, suit_mci_signing_key_id_get, const suit_manifest_class_id_t *, uint32_t *);
 FAKE_VALUE_FUNC(int, suit_mci_processor_start_rights_validate, const suit_manifest_class_id_t *,
 		int);
 FAKE_VALUE_FUNC(int, suit_mci_memory_access_rights_validate, const suit_manifest_class_id_t *,
@@ -65,6 +66,7 @@ static inline void mock_suit_mci_reset(void)
 	RESET_FAKE(suit_mci_independent_update_policy_get);
 	RESET_FAKE(suit_mci_manifest_class_id_validate);
 	RESET_FAKE(suit_mci_signing_key_id_validate);
+	RESET_FAKE(suit_mci_signing_key_id_get);
 	RESET_FAKE(suit_mci_processor_start_rights_validate);
 	RESET_FAKE(suit_mci_memory_access_rights_validate);
 	RESET_FAKE(suit_mci_platform_specific_component_rights_validate);


### PR DESCRIPTION
In some cases, there is a need to use volatile keys for signing manifests. In such case, it is the PSA API that sets the key ID value, not the manifest.
Add a simple MCI API helper function to return the assigned key ID and handlers inside manifest authentication routines.

Ref: NCSDK-NONE