### PR TITLE
wifi: Fix nRF70 FW blobs strategy

### DIFF
--- a/subsys/net/lib/nrf70_fw_ext/CMakeLists.txt
+++ b/subsys/net/lib/nrf70_fw_ext/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-if(NOT CONFIG_NRF_WIFI_PATCHES_BUILTIN)
+if(NOT CONFIG_NRF_WIFI_PATCHES_EXT_FLASH_DISABLED)
   zephyr_library_sources(ext_fw_load.c)
   if(CONFIG_NRF_WIFI_PATCHES_EXT_FLASH_XIP)
     # Run patches from the external flash (XIP). No need to copy.

--- a/subsys/net/lib/nrf70_fw_ext/CMakeLists.txt
+++ b/subsys/net/lib/nrf70_fw_ext/CMakeLists.txt
@@ -4,6 +4,10 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+if(CONFIG_NRF_WIFI_BUILD_ONLY_MODE)
+  return()
+endif()
+
 if(CONFIG_NRF_WIFI_PATCHES_EXT_FLASH_DISABLED)
   # The C source is same as that for built-in
   zephyr_library_sources(${ZEPHYR_BASE}/drivers/wifi/nrfwifi/src/fw_load.c)

--- a/subsys/net/lib/nrf70_fw_ext/CMakeLists.txt
+++ b/subsys/net/lib/nrf70_fw_ext/CMakeLists.txt
@@ -4,10 +4,41 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-if(NOT CONFIG_NRF_WIFI_PATCHES_EXT_FLASH_DISABLED)
+if(CONFIG_NRF_WIFI_PATCHES_EXT_FLASH_DISABLED)
+  # The C source is same as that for built-in
+  zephyr_library_sources(${ZEPHYR_BASE}/drivers/wifi/nrfwifi/src/fw_load.c)
+else()
   zephyr_library_sources(ext_fw_load.c)
   if(CONFIG_NRF_WIFI_PATCHES_EXT_FLASH_XIP)
     # Run patches from the external flash (XIP). No need to copy.
     zephyr_code_relocate(FILES ext_fw_load.c LOCATION EXTFLASH_RODATA NOCOPY)
   endif()
+endif()
+
+if(DEFINED CONFIG_NRF_WIFI_PATCHES_EXT_FLASH_DISABLED OR
+   DEFINED CONFIG_NRF_WIFI_PATCHES_EXT_FLASH_XIP)
+  # NCS doesn't rely on hal_nordic blobs for nRF70 device driver
+  set(FW_BINS_BASE ${ZEPHYR_NRFXLIB_MODULE_DIR}/nrf_wifi/ncs_fw_blobs)
+  # RPU FW patch binaries based on the selected configuration
+  if(CONFIG_NRF70_SYSTEM_MODE)
+    set(NRF70_PATCH ${FW_BINS_BASE}/default/nrf70.bin)
+  elseif(CONFIG_NRF70_RADIO_TEST)
+    set(NRF70_PATCH ${FW_BINS_BASE}/radio_test/nrf70.bin)
+  elseif(CONFIG_NRF70_SCAN_ONLY)
+    set(NRF70_PATCH ${FW_BINS_BASE}/scan_only/nrf70.bin)
+  elseif (CONFIG_NRF70_SYSTEM_WITH_RAW_MODES)
+    set(NRF70_PATCH ${FW_BINS_BASE}/system_with_raw/nrf70.bin)
+  else()
+    # Error
+    message(FATAL_ERROR "Unsupported nRF70 patch configuration")
+  endif()
+
+  set(gen_inc_dir ${ZEPHYR_BINARY_DIR}/misc/generated)
+  zephyr_include_directories(${gen_inc_dir})
+  set(gen_dir ${gen_inc_dir}/nrf70_fw_patch)
+  generate_inc_file_for_target(
+    nrfwifi
+    ${NRF70_PATCH}
+    ${gen_dir}/nrf70.bin.inc
+  )
 endif()

--- a/subsys/net/lib/nrf70_fw_ext/Kconfig
+++ b/subsys/net/lib/nrf70_fw_ext/Kconfig
@@ -4,10 +4,16 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-if WIFI_NRF70 && !NRF_WIFI_BUILD_ONLY_MODE
+if WIFI_NRF70
+
+# NCS always uses the external handling of the nRF70 FW patches
+choice NRF_WIFI_FW_BLOB_HANDLING
+	default NRF_WIFI_PATCHES_EXTERNAL
+endchoice
 
 choice NRF_WIFI_PATCHES_EXT_FLASH_SUPPORT
-	bool "Store nRF700x FW patches in external flash"
+	prompt "Store nRF700x FW patches in external flash"
+	default NRF_WIFI_PATCHES_EXT_FLASH_DISABLED
 	help
 	  Select this option to store nRF700x FW patches in external flash.
 	  This option helps to reduce the code memory size of the application, but
@@ -15,7 +21,6 @@ choice NRF_WIFI_PATCHES_EXT_FLASH_SUPPORT
 
 config NRF_WIFI_PATCHES_EXT_FLASH_DISABLED
 	bool "Store nRF700x FW patches in RAM"
-	select NRF_WIFI_PATCHES_BUILTIN
 
 config NRF_WIFI_PATCHES_EXT_FLASH_XIP
 	bool "Relocate nRF700x FW patches to external memory and execute from there"

--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: fe339b14b3effd069458f5e4710f17cda8295229
+      revision: 8d6fc59bf40a9de47a4dc982cfa71738453fab70
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above

--- a/west.yml
+++ b/west.yml
@@ -149,7 +149,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: ea7d680ce61310fa6198a23c7daf09369e5215aa
+      revision: 18691287cb87b9ba2ca621ce138c3b95fd03c2d2
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
NCS uses nRF70 blobs from `sdk-nrfxlib` directly without the need for `west blobs fetch hal_nordic` but upstream still uses the `west blobs fetch hal_nordic` which picks up from `sdk-nrfxlib` but a different ~branch `nrf70-devel`~ directory `upstream_fw_blobs` instead of `ncs_fw_blobs`.