### PR TITLE
Bluetooth: GATT DM: Schedule host cbs in work q

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -191,6 +191,10 @@ Bluetooth® LE
   The SoftDevice Controller driver uses a devicetree node named ``bt_hci_sdc`` with a devicetree binding compatible with ``nordic,bt-hci-sdc``.
   The Zephyr Bluetooth LE Controller uses a devicetree node named ``bt_hci_controller`` with a devicetree binding compatible with ``zephyr,bt-hci-ll-sw-split``.
   Applications using the Zephyr Bluetooth Controller need to be updated (see the :ref:`migration guide <migration_2.8>`).
+* Host calls in GATT Discovery Manager (DM) callbacks are now scheduled in a workqueue.
+  The :kconfig:option:`BT_GATT_DM_WORKQ_CHOICE` Kconfig option allows you to select the workqueue implementation.
+  You can select either a workqueue specific to GATT DM (default) or the system workqueue.
+  You can use the system workqueue if creating a new thread is not viable due to memory constraints, but it is not recommended to have potential blocking calls in the system workqueue.
 
 Bluetooth Mesh
 --------------

--- a/subsys/bluetooth/Kconfig.discovery
+++ b/subsys/bluetooth/Kconfig.discovery
@@ -11,6 +11,51 @@ menuconfig BT_GATT_DM
 
 if BT_GATT_DM
 
+choice BT_GATT_DM_WORKQ_CHOICE
+	prompt "GATT Discovery Manager workqueue selection"
+	default BT_GATT_DM_WORKQ_OWN
+	help
+	  Select the workqueue implementation for GATT Discovery Manager.
+
+config BT_GATT_DM_WORKQ_OWN
+	bool "Use own workqueue"
+	help
+	  Use own workqueue for GATT Discovery Manager.
+
+config BT_GATT_DM_WORKQ_SYS
+	bool "Use system workqueue"
+	select EXPERIMENTAL
+	help
+	  Use system workqueue for GATT Discovery Manager. Can be used if creating a new thread
+	  is not viable due to memory constraints, but it is not recommended to have potential
+	  blocking calls in the system workqueue.
+
+endchoice
+
+if BT_GATT_DM_WORKQ_OWN
+
+config BT_GATT_DM_WORKQ_STACK_SIZE
+	# Hidden option for workqueue stack size. Should be derived from system
+	# requirements.
+	int
+	default 1300 if BT_GATT_CACHING
+	default 1140 if BT_TINYCRYPT_ECC
+	default 1024
+
+config BT_GATT_DM_WORKQ_PRIO
+	int "GATT Discovery Manager workqueue priority."
+	default 10
+	help
+	  Priority level for the GATT Discovery Manager workqueue.
+
+config BT_GATT_DM_WORKQ_INIT_PRIO
+	int "GATT Discovery Manager workqueue init priority"
+	default 50
+	help
+	  Init priority level to setup the GATT Discovery Manager workqueue.
+
+endif # BT_GATT_DM_WORKQ_OWN
+
 config BT_GATT_DM_MAX_ATTRS
 	int "Maximum number of attributes that can be present in the discovered service"
 	default 35


### PR DESCRIPTION
Moves host calls in discovery manager callbacks to be scheduled in a separate work queue to improve robustness.