### PR TITLE
mgmt: suitfu: Make main image inactive in recovery

### DIFF
--- a/subsys/mgmt/suitfu/src/suitfu_mgmt_img.c
+++ b/subsys/mgmt/suitfu/src/suitfu_mgmt_img.c
@@ -255,8 +255,12 @@ static int suitfu_mgmt_img_state_read(struct smp_streamer *ctx)
 	}
 
 	if (ok) {
+#if !CONFIG_SUIT_RECOVERY
 		ok = ENCODE_FLAG(zse, "bootable", 1) && ENCODE_FLAG(zse, "confirmed", 1) &&
 		     ENCODE_FLAG(zse, "active", 1) && ENCODE_FLAG(zse, "permanent", 1);
+#else
+		ok = ENCODE_FLAG(zse, "pending", 1);
+#endif
 		LOG_DBG("Manifest flags encoded: %d", ok);
 	}
 


### PR DESCRIPTION
Until now even when in recovery firmware, the image group marked the main application image as active.

This caused that the mobile application was not able to recover the device - the confirm button for the new application image was greyed out.

This commit marks the main application as inactive when running the recovery firmware.