### PR TITLE
tests: benchmarks: multicore: add tag ppk_power_measure

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -379,7 +379,7 @@
 /tests/benchmarks/multicore/              @carlescufi @nrfconnect/ncs-low-level-test
 /tests/benchmarks/multicore/idle/         @adamkondraciuk @nrfconnect/ncs-low-level-test
 /tests/benchmarks/multicore/idle_gpio/    @adamkondraciuk @nrfconnect/ncs-low-level-test
-/tests/benchmarks/multicore/idle_with_pwm/  @nrfconnect/ncs-low-level-test
+/tests/benchmarks/multicore/idle*         @nrfconnect/ncs-low-level-test
 /tests/bluetooth/iso/                     @nrfconnect/ncs-audio @Frodevan
 /tests/bluetooth/tester/                  @carlescufi @nrfconnect/ncs-paladin
 /tests/crypto/                            @stephen-nordic @magnev

--- a/tests/benchmarks/multicore/idle_outside_of_main/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_outside_of_main/testcase.yaml
@@ -1,6 +1,6 @@
 common:
   sysbuild: true
-  tags: ci_build ci_tests_benchmarks_multicore
+  tags: ci_build ci_tests_benchmarks_multicore ppk_power_measure
 
 tests:
   benchmarks.multicore.idle_outside_of_main.nrf54h20dk_cpuapp_cpurad.s2ram:

--- a/tests/benchmarks/multicore/idle_spim/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_spim/testcase.yaml
@@ -14,6 +14,6 @@ tests:
       - SHIELD=pca63566
       - SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
     harness_config:
-      fixture: ppk_power_measure
+      fixture: pca63566
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_spim"

--- a/tests/benchmarks/multicore/idle_spim/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_spim/testcase.yaml
@@ -1,7 +1,7 @@
 common:
   sysbuild: true
   depends_on: spi
-  tags: ci_build ci_tests_benchmarks_multicore spim
+  tags: ci_build ci_tests_benchmarks_multicore spim ppk_power_measure
 
 tests:
   benchmarks.multicore.idle_spim.nrf54h20dk_cpuapp_cpurad.s2ram:

--- a/tests/benchmarks/multicore/idle_twim/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_twim/testcase.yaml
@@ -1,7 +1,7 @@
 common:
   sysbuild: true
   depends_on: i2c
-  tags: ci_build ci_tests_benchmarks_multicore twim
+  tags: ci_build ci_tests_benchmarks_multicore twim ppk_power_measure
 
 tests:
   benchmarks.multicore.idle_twim.nrf54h20dk_cpuapp_cpurad.s2ram:

--- a/tests/benchmarks/multicore/idle_twim/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_twim/testcase.yaml
@@ -14,6 +14,6 @@ tests:
       - SHIELD=pca63566
       - SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
     harness_config:
-      fixture: ppk_power_measure
+      fixture: pca63566
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_twim"

--- a/tests/benchmarks/multicore/idle_uarte/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_uarte/testcase.yaml
@@ -1,7 +1,7 @@
 common:
   sysbuild: true
   depends_on: gpio
-  tags: ci_build ci_tests_benchmarks_multicore uarte
+  tags: ci_build ci_tests_benchmarks_multicore uarte ppk_power_measure
 
 tests:
   benchmarks.multicore.idle_uarte.nrf54h20dk_cpuapp_cpurad.s2ram:


### PR DESCRIPTION
It is used to filter tests for execution with power measurements.