### PR TITLE
applications: nrf5340_audio: Change source of inline functions to Zephyr

### DIFF
--- a/samples/bluetooth/broadcast_config_tool/README.rst
+++ b/samples/bluetooth/broadcast_config_tool/README.rst
@@ -15,6 +15,7 @@ In the BIS gateway mode, transmitting audio from the broadcast source happens us
 The following limitations apply to this sample:
 
 * Audio input: Pre-encoded LC3 data from an SD-card.
+  See :ref:`broadcast_configuration_tool_configuration_sd` for more information.
 * Maximum two BIG with four BIS streams each.
 
 .. _broadcast_configuration_tool_requirements:
@@ -761,6 +762,15 @@ The sample is pre-configured with a generous default memory allocation, suitable
 You can modify these default settings in the :file:`prj.conf` file.
 Using aggressive configurations can reduce air time availability for all streams, depending on the combination of options selected (like high bitrates, increased re-transmits, specific PHY settings).
 
+.. _broadcast_configuration_tool_configuration_sd:
+
+SD card setup
+*************
+
+The sample only supports pre-encoded LC3 data stored as LC3 files on an SD card.
+
+Make sure you format the SD card with a FAT file system.
+
 .. _broadcast_configuration_tool_building:
 
 Building and running
@@ -782,6 +792,7 @@ In this testing procedure, the development kit is programmed with the Broadcast 
 
 To test the Broadcast Configuration Tool sample, complete the following steps:
 
+1. Insert the SD card loaded with the pre-encoded LC3 data.
 #. Turn on the development kit.
 #. Set up the serial connection with the development kit.
 #. Configure a BIG using use case 1:

--- a/samples/bluetooth/broadcast_config_tool/include/broadcast_config_tool.h
+++ b/samples/bluetooth/broadcast_config_tool/include/broadcast_config_tool.h
@@ -78,18 +78,6 @@ struct bap_preset {
 	char name[PRESET_NAME_MAX];
 };
 
-#define CONTEXT_NAME_LEN_MAX 20
-struct audio_context {
-	enum bt_audio_context context;
-	char name[CONTEXT_NAME_LEN_MAX];
-};
-
-#define LOCATION_NAME_LEN_MAX 5
-struct audio_location {
-	enum bt_audio_location location;
-	char name[5];
-};
-
 static struct bap_preset bap_presets[] = {
 	{.preset = &lc3_preset_8_1_1, .name = "8_1_1"},
 	{.preset = &lc3_preset_8_2_1, .name = "8_2_1"},
@@ -121,22 +109,15 @@ static struct bap_preset bap_presets[] = {
 	{.preset = &lc3_preset_48_6_2, .name = "48_6_2"},
 };
 
-static struct audio_context contexts[] = {
-	{.context = BT_AUDIO_CONTEXT_TYPE_PROHIBITED, .name = "Prohibited"},
-	{.context = BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED, .name = "Unspecified"},
-	{.context = BT_AUDIO_CONTEXT_TYPE_CONVERSATIONAL, .name = "Conversational"},
-	{.context = BT_AUDIO_CONTEXT_TYPE_MEDIA, .name = "Media"},
-	{.context = BT_AUDIO_CONTEXT_TYPE_GAME, .name = "Game"},
-	{.context = BT_AUDIO_CONTEXT_TYPE_INSTRUCTIONAL, .name = "Instructional"},
-	{.context = BT_AUDIO_CONTEXT_TYPE_VOICE_ASSISTANTS, .name = "Voice assistants"},
-	{.context = BT_AUDIO_CONTEXT_TYPE_LIVE, .name = "Live"},
-	{.context = BT_AUDIO_CONTEXT_TYPE_SOUND_EFFECTS, .name = "Sound effects"},
-	{.context = BT_AUDIO_CONTEXT_TYPE_NOTIFICATIONS, .name = "Notifications"},
-	{.context = BT_AUDIO_CONTEXT_TYPE_RINGTONE, .name = "Ringtone"},
-	{.context = BT_AUDIO_CONTEXT_TYPE_ALERTS, .name = "Alerts"},
-	{.context = BT_AUDIO_CONTEXT_TYPE_EMERGENCY_ALARM, .name = "Emergency alarm"},
+#define LOCATION_NAME_LEN_MAX 4
+struct audio_location {
+	enum bt_audio_location location;
+	char name[LOCATION_NAME_LEN_MAX + 1];
 };
 
+/* Note: If there is any change to the specification of audio
+ *       locations then this structure must be checked for conformance.
+ */
 static struct audio_location locations[] = {
 	{.location = BT_AUDIO_LOCATION_MONO_AUDIO, .name = "MA"},
 	{.location = BT_AUDIO_LOCATION_FRONT_LEFT, .name = "FL"},
@@ -191,105 +172,5 @@ static struct usecase_info pre_defined_use_cases[] = {
 	{.use_case = PERSONAL_SHARING, .name = "Personal sharing"},
 	{.use_case = PERSONAL_MULTI_LANGUAGE, .name = "Personal multi-language"},
 };
-
-static inline char *location_bit_to_str(enum bt_audio_location location)
-{
-	switch (location) {
-	case BT_AUDIO_LOCATION_MONO_AUDIO:
-		return "Mono Audio";
-	case BT_AUDIO_LOCATION_FRONT_LEFT:
-		return "Front Left";
-	case BT_AUDIO_LOCATION_FRONT_RIGHT:
-		return "Front Right";
-	case BT_AUDIO_LOCATION_FRONT_CENTER:
-		return "Front Center";
-	case BT_AUDIO_LOCATION_LOW_FREQ_EFFECTS_1:
-		return "Low Frequency 1";
-	case BT_AUDIO_LOCATION_BACK_LEFT:
-		return "Back Left";
-	case BT_AUDIO_LOCATION_BACK_RIGHT:
-		return "Back Right";
-	case BT_AUDIO_LOCATION_FRONT_LEFT_OF_CENTER:
-		return "Front Left of Center";
-	case BT_AUDIO_LOCATION_FRONT_RIGHT_OF_CENTER:
-		return "Front Right of Center";
-	case BT_AUDIO_LOCATION_BACK_CENTER:
-		return "Back Center";
-	case BT_AUDIO_LOCATION_LOW_FREQ_EFFECTS_2:
-		return "Low Frequency 2";
-	case BT_AUDIO_LOCATION_SIDE_LEFT:
-		return "Side Left";
-	case BT_AUDIO_LOCATION_SIDE_RIGHT:
-		return "Side Right";
-	case BT_AUDIO_LOCATION_TOP_FRONT_LEFT:
-		return "Top Front Left";
-	case BT_AUDIO_LOCATION_TOP_FRONT_RIGHT:
-		return "Top Front Right";
-	case BT_AUDIO_LOCATION_TOP_FRONT_CENTER:
-		return "Top Front Center";
-	case BT_AUDIO_LOCATION_TOP_CENTER:
-		return "Top Center";
-	case BT_AUDIO_LOCATION_TOP_BACK_LEFT:
-		return "Top Back Left";
-	case BT_AUDIO_LOCATION_TOP_BACK_RIGHT:
-		return "Top Back Right";
-	case BT_AUDIO_LOCATION_TOP_SIDE_LEFT:
-		return "Top Side Left";
-	case BT_AUDIO_LOCATION_TOP_SIDE_RIGHT:
-		return "Top Side Right";
-	case BT_AUDIO_LOCATION_TOP_BACK_CENTER:
-		return "Top Back Center";
-	case BT_AUDIO_LOCATION_BOTTOM_FRONT_CENTER:
-		return "Bottom Front Center";
-	case BT_AUDIO_LOCATION_BOTTOM_FRONT_LEFT:
-		return "Bottom Front Left";
-	case BT_AUDIO_LOCATION_BOTTOM_FRONT_RIGHT:
-		return "Bottom Front Right";
-	case BT_AUDIO_LOCATION_FRONT_LEFT_WIDE:
-		return "Front Left Wide";
-	case BT_AUDIO_LOCATION_FRONT_RIGHT_WIDE:
-		return "Front Right Wide";
-	case BT_AUDIO_LOCATION_LEFT_SURROUND:
-		return "Left Surround";
-	case BT_AUDIO_LOCATION_RIGHT_SURROUND:
-		return "Right Surround";
-	default:
-		return "Unknown";
-	}
-}
-
-static inline char *context_bit_to_str(enum bt_audio_context context)
-{
-	switch (context) {
-	case BT_AUDIO_CONTEXT_TYPE_PROHIBITED:
-		return "Prohibited";
-	case BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED:
-		return "Unspecified";
-	case BT_AUDIO_CONTEXT_TYPE_CONVERSATIONAL:
-		return "Conversational";
-	case BT_AUDIO_CONTEXT_TYPE_MEDIA:
-		return "Media";
-	case BT_AUDIO_CONTEXT_TYPE_GAME:
-		return "Game";
-	case BT_AUDIO_CONTEXT_TYPE_INSTRUCTIONAL:
-		return "Instructional";
-	case BT_AUDIO_CONTEXT_TYPE_VOICE_ASSISTANTS:
-		return "Voice assistant";
-	case BT_AUDIO_CONTEXT_TYPE_LIVE:
-		return "Live";
-	case BT_AUDIO_CONTEXT_TYPE_SOUND_EFFECTS:
-		return "Sound effects";
-	case BT_AUDIO_CONTEXT_TYPE_NOTIFICATIONS:
-		return "Notifications";
-	case BT_AUDIO_CONTEXT_TYPE_RINGTONE:
-		return "Ringtone";
-	case BT_AUDIO_CONTEXT_TYPE_ALERTS:
-		return "Alerts";
-	case BT_AUDIO_CONTEXT_TYPE_EMERGENCY_ALARM:
-		return "Emergency alarm";
-	default:
-		return "Unknown";
-	}
-}
 
 #endif /* _BROADCAST_CONFIG_TOOL_H_ */


### PR DESCRIPTION
OCT-3115

The static inline functions in broadcast_config_tool.h has been moved to upstream Zephyr. We need to remove the functions from broadcast_config_tool.h and use these instead.