### PR TITLE
docker: Bump nrfutil-device version to 2.6.4

### DIFF
--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -2,12 +2,12 @@ FROM ubuntu:22.04
 
 ARG VERSION
 ENV HOME=/opt
-RUN apt-get update && apt-get install -y wget ca-certificates qemu-system-arm libffi7 git \
+RUN apt-get update && apt-get install -y wget ca-certificates qemu-system-arm git \
     libxcb-render-util0 libxcb-shape0 libxcb-icccm4  libxcb-keysyms1 libxcb-image0 libxkbcommon-x11-0 libsm6 libice6 udev \
     && rm -rf /var/lib/apt/lists/*
 RUN wget https://developer.nordicsemi.com/.pc-tools/nrfutil/x64-linux/nrfutil -q -O /usr/local/bin/nrfutil  \
     && chmod +x /usr/local/bin/nrfutil \
-    && nrfutil install device=2.5.4 \
+    && nrfutil install device=2.6.4 \
     && nrfutil install toolchain-manager=0.15.0
 RUN nrfutil toolchain-manager install --toolchain-bundle-id $VERSION \
     && nrfutil toolchain-manager env --as-script > /opt/toolchain-env.sh \


### PR DESCRIPTION
Additionally, remove libffi7 which is included in bundle.