### PR TITLE
manifest: Update sdk-zephyr to bring MPSL flash sync timeout fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 8411e6a346838a2d0980b28e9add8b29a06d711f
+      revision: pull/2107/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Change cherry-picks commit that allows to workaround MPSL flash sync timeout issue.

Jira: NCSDK-29354
Jira: DRGN-23363