### PR TITLE
net: nrf_cloud_coap: Separate nrf cloud coap sec tags

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -968,6 +968,7 @@ Libraries for networking
     * Experimental support for shadow transform requests over MQTT using the :c:func:`nrf_cloud_shadow_transform_request` function.
       This functionality is enabled by the :kconfig:option:`CONFIG_NRF_CLOUD_MQTT_SHADOW_TRANSFORMS` Kconfig option.
     * The :kconfig:option:`CONFIG_NRF_CLOUD_COMBINED_CA_CERT_SIZE_THRESHOLD` and :kconfig:option:`CONFIG_NRF_CLOUD_COAP_CA_CERT_SIZE_THRESHOLD` Kconfig options to compare with the current root CA certificate size.
+    * The functions :c:func:`nrf_cloud_sec_tag_coap_jwt_set` and :c:func:`nrf_cloud_sec_tag_coap_jwt_get` to set and get the sec tag used for nRF Cloud CoAP JWT signing.
 
   * Updated:
 
@@ -1010,6 +1011,7 @@ Libraries for networking
   * Removed the experimental status (:kconfig:option:`CONFIG_EXPERIMENTAL`) from the :kconfig:option:`CONFIG_NRF_CLOUD_COAP_DOWNLOADS` Kconfig option.
 
   * Added the :kconfig:option:`CONFIG_NRF_CLOUD_COAP_DISCONNECT_ON_FAILED_REQUEST` Kconfig option to disconnect the CoAP client on a failed request.
+  * Added the :kconfig:option:`CONFIG_NRF_CLOUD_COAP_JWT_SEC_TAG` Kconfig option to allow for a separate sec tag to be used for nRF Cloud CoAP JWT signing.
 
 * :ref:`lib_lwm2m_client_utils` library:
 

--- a/include/net/nrf_cloud.h
+++ b/include/net/nrf_cloud.h
@@ -1216,6 +1216,10 @@ int nrf_cloud_credentials_configured_check(void);
  * @note This API only needs to be called if the default configured sec tag value is no
  *       longer applicable. This function does not perform any management of the
  *       device's connection to nRF Cloud.
+ *       For CoAP, changing this value will change the sec tag used for the DTLS connection only.
+ *       Use @ref nrf_cloud_sec_tag_coap_jwt_set to set the sec tag used for JWT signing.
+ *       For normal operation, the DTLS and JWT sec tags should be the same. They should only
+ *       differ for debugging purposes (network traffic decryption).
  *
  * @param sec_tag The sec tag.
  *
@@ -1228,6 +1232,31 @@ void nrf_cloud_sec_tag_set(const sec_tag_t sec_tag);
  * @return The sec tag.
  */
 sec_tag_t nrf_cloud_sec_tag_get(void);
+
+/**
+ * @brief Set the sec tag containing the private key used to sign CoAP JWTs for nRF Cloud
+ *        authentication.
+ *        The default sec tag value is @kconfig{CONFIG_NRF_CLOUD_COAP_JWT_SEC_TAG}.
+ *
+ * @note This API requires @kconfig{CONFIG_NRF_CLOUD_COAP} to be enabled.
+ *       This API only needs to be called if the default configured sec tag value is no
+ *       longer applicable. This function does not perform any management of the
+ *       device's authentication status with nRF Cloud.
+ *
+ * @param sec_tag The sec tag.
+ *
+ */
+void nrf_cloud_sec_tag_coap_jwt_set(const sec_tag_t sec_tag);
+
+/**
+ * @brief Get the sec tag containing the private key used to sign CoAP JWTs for nRF Cloud
+ *        authentication.
+ *
+ * @note This API requires @kconfig{CONFIG_NRF_CLOUD_COAP} to be enabled.
+ *
+ * @return The sec tag.
+ */
+sec_tag_t nrf_cloud_sec_tag_coap_jwt_get(void);
 
 /** @} */
 

--- a/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_coap
+++ b/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_coap
@@ -23,6 +23,22 @@ config NRF_CLOUD_COAP_SERVER_HOSTNAME
 config NRF_CLOUD_COAP_SEC_TAG
 	int "Security tag for credentials"
 	default NRF_CLOUD_SEC_TAG
+	help
+	  Security tag containing the nRF Cloud CoAP CA certificate and private key required for
+	  the DTLS connection to nRF Cloud.
+	  NRF_CLOUD_COAP_JWT_SEC_TAG defaults to the same sec tag value, so the private key
+	  is also used for authentication.
+
+config NRF_CLOUD_COAP_JWT_SEC_TAG
+	int "[For Debug Use] Security tag for JWT credentials"
+	default NRF_CLOUD_COAP_SEC_TAG
+	help
+	  Security tag containing the private key used to sign CoAP JWTs for nRF Cloud
+	  authentication.
+	  The private key in this sec tag must have its corresponding public key registered for
+	  the device on nRF Cloud.
+	  Using this option allows for a different private key to be stored in
+	  NRF_CLOUD_COAP_SEC_TAG that can be used to decrypt DTLS traffic.
 
 config NRF_CLOUD_COAP_SERVER_PORT
 	int "CoAP server port"

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_info.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_info.c
@@ -148,6 +148,10 @@ int nrf_cloud_print_details(void)
 	LOG_INF("Sec tag:           %d", nrf_cloud_sec_tag_get());
 	LOG_INF("Host name:         %s", host_name);
 
+#if defined(CONFIG_NRF_CLOUD_COAP)
+	LOG_INF("-CoAP JWT: %d", nrf_cloud_sec_tag_coap_jwt_get());
+#endif
+
 #endif /* CONFIG_NRF_CLOUD_VERBOSE_DETAILS */
 
 	return err;

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_jwt.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_jwt.c
@@ -470,12 +470,14 @@ int nrf_cloud_jwt_generate(uint32_t time_valid_s, char *const jwt_buf, size_t jw
 	const char *id_ptr;
 	struct jwt_data jwt = {
 		.audience = NULL,
-		.sec_tag = nrf_cloud_sec_tag_get(),
 		.key = JWT_KEY_TYPE_CLIENT_PRIV,
 		.alg = JWT_ALG_TYPE_ES256,
 		.jwt_buf = jwt_buf,
 		.jwt_sz = jwt_buf_sz
 	};
+
+	jwt.sec_tag = IS_ENABLED(CONFIG_NRF_CLOUD_COAP) ?
+		      nrf_cloud_sec_tag_coap_jwt_get() : nrf_cloud_sec_tag_get();
 
 #if defined(CONFIG_MODEM_JWT)
 	/* Check if modem time is valid */

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_sec_tag.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_sec_tag.c
@@ -26,3 +26,18 @@ sec_tag_t nrf_cloud_sec_tag_get(void)
 {
 	return nrf_cloud_sec_tag;
 }
+
+#if defined(CONFIG_NRF_CLOUD_COAP)
+static sec_tag_t coap_jwt_sec_tag = CONFIG_NRF_CLOUD_COAP_JWT_SEC_TAG;
+
+void nrf_cloud_sec_tag_coap_jwt_set(const sec_tag_t sec_tag)
+{
+	coap_jwt_sec_tag = sec_tag;
+	LOG_DBG("CoAP JWT sec tag updated: %d", coap_jwt_sec_tag);
+}
+
+sec_tag_t nrf_cloud_sec_tag_coap_jwt_get(void)
+{
+	return coap_jwt_sec_tag;
+}
+#endif /* CONFIG_NRF_CLOUD_COAP */


### PR DESCRIPTION
Separate sec tags used for JWT generation and DTLS. This makes it possible to point the DTLS sec tag to a dev tag to get decrypted DTLS traffic in modem traces.