### PR TITLE
CODEOWNERS: fix owners for tests/benchmarks/multicore/idle

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -377,9 +377,9 @@
 # Tests
 /tests/benchmarks/                        @nrfconnect/ncs-low-level-test
 /tests/benchmarks/multicore/              @carlescufi @nrfconnect/ncs-low-level-test
+/tests/benchmarks/multicore/idle*         @nrfconnect/ncs-low-level-test
 /tests/benchmarks/multicore/idle/         @adamkondraciuk @nrfconnect/ncs-low-level-test
 /tests/benchmarks/multicore/idle_gpio/    @adamkondraciuk @nrfconnect/ncs-low-level-test
-/tests/benchmarks/multicore/idle*         @nrfconnect/ncs-low-level-test
 /tests/bluetooth/iso/                     @nrfconnect/ncs-audio @Frodevan
 /tests/bluetooth/tester/                  @carlescufi @nrfconnect/ncs-paladin
 /tests/crypto/                            @stephen-nordic @magnev


### PR DESCRIPTION
List owners from general to more specific.