### PR TITLE
doc: Add known issue for DRGN-23231 (deadlock on link loss)

### DIFF
--- a/doc/nrf/releases_and_maturity/known_issues.rst
+++ b/doc/nrf/releases_and_maturity/known_issues.rst
@@ -144,6 +144,15 @@ KRKNWK-14299: NRPA MAC address cannot be set in Zephyr
 Bluetooth LE
 ============
 
+.. rst-class:: v2-7-0 v2-6-2 v2-6-1 v2-6-0 v2-5-3 v2-5-2 v2-4-4 v2-4-3
+
+DRGN-23231: The Bluetooth subsystem may sometimes deadlock when a Bluetooth link is lost during data transfer
+  When this happens, the disconnected event is never delivered to the application.
+  The issue occurs when the :kconfig:option:`CONFIG_BT_HCI_ACL_FLOW_CONTROL` Kconfig option is enabled.
+  This option is enabled by default on the nRF5340 DK.
+
+  **Affected platforms:** nRF5340
+
 .. rst-class:: v2-7-0
 
 DRGN-22930 The SoftDevice Controller may de-reference a ``NULL`` pointer

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -142,6 +142,10 @@ Amazon Sidewalk
 Bluetooth® LE
 -------------
 
+* Fixed an issue where the Bluetooth subsystem deadlocked when a Bluetooth link was lost during data transfer.
+  In this scenario, the disconnected event was never delivered to the application.
+  The issue only occurred when the :kconfig:option:`CONFIG_BT_HCI_ACL_FLOW_CONTROL` Kconfig option was enabled.
+  This option is enabled by default on the nRF5340 DK.
 * The correct SoftDevice Controller library :kconfig:option:`CONFIG_BT_LL_SOFTDEVICE_MULTIROLE` will now be selected automatically when using coexistence based on :kconfig:option:`CONFIG_MPSL_CX` for nRF52-series devices.
 * Added the APIs :c:func:`bt_hci_err_to_str` and :c:func:`bt_security_err_to_str` to allow printing error codes as strings.
   Each API returns string representations of the error codes when the corresponding Kconfig option, :kconfig:option:`CONFIG_BT_HCI_ERR_TO_STR` or :kconfig:option:`CONFIG_BT_SECURITY_ERR_TO_STR`, is enabled.


### PR DESCRIPTION
Adds an issue which appeared as a result of the fix in DRGN-21085. The issue is fixed for NCS 2.8.0