### PR TITLE
samples: wifi: Remove support for nRF54L15 PDK from Wi-Fi samples

### DIFF
--- a/samples/wifi/scan/sample.yaml
+++ b/samples/wifi/scan/sample.yaml
@@ -52,6 +52,5 @@ tests:
       - scan_SNIPPET=nrf70-wifi
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
     tags: ci_build sysbuild ci_samples_wifi

--- a/samples/wifi/shell/sample.yaml
+++ b/samples/wifi/shell/sample.yaml
@@ -211,7 +211,6 @@ tests:
       - shell_SNIPPET=nrf70-wifi
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
     tags: ci_build sysbuild ci_samples_wifi
   # Used by QA and also acts as a memory stress test

--- a/samples/wifi/sta/sample.yaml
+++ b/samples/wifi/sta/sample.yaml
@@ -66,6 +66,5 @@ tests:
       - sta_SNIPPET=nrf70-wifi
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
     tags: ci_build sysbuild ci_samples_wifi


### PR DESCRIPTION
As nRF54L15PDK support is deprecated, remove support from Wi-Fi samples.

Fixes SHEL-3152.