### PR TITLE
Bluetooth: Mesh: Removed support for nrf54l15pdk

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -444,7 +444,7 @@ Bluetooth Fast Pair samples
 Bluetooth Mesh samples
 ----------------------
 
-* Added support for the :ref:`zephyr:nrf54l15dk_nrf54l15` board in the following samples:
+* Added support for the :ref:`zephyr:nrf54l15dk_nrf54l15` board and removed support for the nRF54L15 PDK in the following samples:
 
   * :ref:`bluetooth_mesh_sensor_client`
   * :ref:`bluetooth_mesh_sensor_server`

--- a/samples/bluetooth/mesh/ble_peripheral_lbs_coex/sample.yaml
+++ b/samples/bluetooth/mesh/ble_peripheral_lbs_coex/sample.yaml
@@ -11,7 +11,6 @@ tests:
       - nrf52833dk/nrf52833
       - nrf21540dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuapp
     platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf52833dk/nrf52833 nrf21540dk/nrf52840
-        nrf54l15dk/nrf54l15/cpuapp nrf54l15pdk/nrf54l15/cpuapp
+        nrf54l15dk/nrf54l15/cpuapp
     tags: bluetooth ci_build sysbuild

--- a/samples/bluetooth/mesh/chat/sample.yaml
+++ b/samples/bluetooth/mesh/chat/sample.yaml
@@ -10,7 +10,6 @@ tests:
       - nrf52840dk/nrf52840
       - nrf21540dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuapp
     platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf21540dk/nrf52840
-        nrf54l15dk/nrf54l15/cpuapp nrf54l15pdk/nrf54l15/cpuapp
+        nrf54l15dk/nrf54l15/cpuapp
     tags: bluetooth ci_build sysbuild

--- a/samples/bluetooth/mesh/dfu/distributor/README.rst
+++ b/samples/bluetooth/mesh/dfu/distributor/README.rst
@@ -166,7 +166,7 @@ The management subsystem uses the Simple Management Protocol (SMP), provided by 
 This sample supports Bluetooth Low Energy and UART as the SMP transport.
 See :ref:`zephyr:device_mgmt` for more information about Mcumgr and SMP.
 
-In this sample, the device flash is split into fixed partitions using devicetree as defined in :zephyr_file:`nrf52840dk_nrf52840.dts<boards/nordic/nrf52840dk/nrf52840dk_nrf52840.dts>`  and :zephyr_file:`nrf54l15pdk_nrf54l15_cpuapp.dts<boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15_cpuapp.dts>`.
+In this sample, the device flash is split into fixed partitions using devicetree as defined in :zephyr_file:`nrf52840dk_nrf52840.dts<boards/nordic/nrf52840dk/nrf52840dk_nrf52840.dts>`  and :zephyr_file:`nrf54l15dk_nrf54l15_cpuapp.dts<boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l15_cpuapp.dts>`.
 The firmware image that is to be distributed over Bluetooth Mesh network should be stored at slot-1.
 The sample uses :ref:`zephyr:flash_map_api` to read the firmware image from slot-1 when distributes it to Target nodes.
 

--- a/samples/bluetooth/mesh/dfu/distributor/sample.yaml
+++ b/samples/bluetooth/mesh/dfu/distributor/sample.yaml
@@ -6,17 +6,15 @@ tests:
     build_only: true
     integration_platforms:
       - nrf52840dk/nrf52840
-      - nrf54l15pdk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf54l15pdk/nrf54l15/cpuapp nrf54l15dk/nrf54l15/cpuapp
+    platform_allow: nrf52840dk/nrf52840 nrf54l15dk/nrf54l15/cpuapp
     tags: bluetooth ci_build sysbuild
   sample.bluetooth.mesh_dfu_distributor.smp_bt_auth:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf52840dk/nrf52840
-      - nrf54l15pdk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf54l15pdk/nrf54l15/cpuapp nrf54l15dk/nrf54l15/cpuapp
+    platform_allow: nrf52840dk/nrf52840 nrf54l15dk/nrf54l15/cpuapp
     extra_args: OVERLAY_CONFIG=overlay-smp-bt-auth.conf
     tags: bluetooth ci_build sysbuild

--- a/samples/bluetooth/mesh/dfu/target/sample.yaml
+++ b/samples/bluetooth/mesh/dfu/target/sample.yaml
@@ -7,8 +7,6 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf52840dongle/nrf52840
-      - nrf54l15pdk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf52840dongle/nrf52840 nrf54l15pdk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp
+    platform_allow: nrf52840dk/nrf52840 nrf52840dongle/nrf52840 nrf54l15dk/nrf54l15/cpuapp
     tags: bluetooth ci_build sysbuild

--- a/samples/bluetooth/mesh/light/README.rst
+++ b/samples/bluetooth/mesh/light/README.rst
@@ -39,7 +39,7 @@ The configuration overlay file :file:`overlay-dfu.conf` and the :ref:`sysbuild <
 
 * nrf52840dk/nrf52840
 * nrf21540dk/nrf52840
-* nrf54l15pdk/nrf54l15/cpuapp
+* nrf54l15dk/nrf54l15/cpuapp
 
 While this overlay configuration is only applicable for the mentioned platforms in this sample, DFU over Bluetooth Low Energy may be used on other platforms as well.
 
@@ -134,7 +134,7 @@ DFU configuration
 
 .. tabs::
 
-   .. tab:: nRF52840 DK and nRF54L15 PDK
+   .. tab:: nRF52840 DK and nRF54L15 DK
 
       To enable the DFU feature for the nRF52840 and nRF54L15 development kits, set :makevar:`SB_CONF_FILE` to :file:`sysbuild-dfu.conf` and :makevar:`EXTRA_CONF_FILE` to :file:`overlay-dfu.conf` when building the sample.
       For example, when building from the command line, use the following command, where *board_target* is the target for the development kit for which you are building:

--- a/samples/bluetooth/mesh/light/sample.yaml
+++ b/samples/bluetooth/mesh/light/sample.yaml
@@ -13,12 +13,10 @@ tests:
       - nrf5340dk/nrf5340/cpuapp/ns
       - thingy53/nrf5340/cpuapp
       - nrf21540dk/nrf52840
-      - nrf54l15pdk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
     platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
       nrf5340dk/nrf5340/cpuapp/ns thingy53/nrf5340/cpuapp
-      nrf21540dk/nrf52840 nrf52833dk/nrf52833 nrf54l15pdk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp
+      nrf21540dk/nrf52840 nrf52833dk/nrf52833 nrf54l15dk/nrf54l15/cpuapp
     tags: bluetooth ci_build sysbuild
   sample.bluetooth.mesh.light.dfu:
     sysbuild: true
@@ -26,10 +24,8 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf21540dk/nrf52840
-      - nrf54l15pdk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf21540dk/nrf52840 nrf54l15pdk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp
+    platform_allow: nrf52840dk/nrf52840 nrf21540dk/nrf52840 nrf54l15dk/nrf54l15/cpuapp
     extra_args:
       - EXTRA_CONF_FILE=overlay-dfu.conf
       - SB_CONF_FILE=sysbuild-dfu.conf

--- a/samples/bluetooth/mesh/light_ctrl/sample.yaml
+++ b/samples/bluetooth/mesh/light_ctrl/sample.yaml
@@ -15,11 +15,10 @@ tests:
       - nrf21540dk/nrf52840
       - nrf52840dongle/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuapp
     platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
       nrf5340dk/nrf5340/cpuapp/ns thingy53/nrf5340/cpuapp
       nrf21540dk/nrf52840 nrf52833dk/nrf52833 nrf52840dongle/nrf52840
-      nrf54l15dk/nrf54l15/cpuapp nrf54l15pdk/nrf54l15/cpuapp
+      nrf54l15dk/nrf54l15/cpuapp
     tags: bluetooth ci_build sysbuild
   sample.bluetooth.mesh.light_ctrl.emds:
     sysbuild: true
@@ -34,9 +33,7 @@ tests:
       - thingy53/nrf5340/cpuapp
       - nrf21540dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuapp
     platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
       nrf5340dk/nrf5340/cpuapp/ns thingy53/nrf5340/cpuapp
       nrf21540dk/nrf52840 nrf52833dk/nrf52833 nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15pdk/nrf54l15/cpuapp
     tags: bluetooth ci_build sysbuild

--- a/samples/bluetooth/mesh/light_dimmer/sample.yaml
+++ b/samples/bluetooth/mesh/light_dimmer/sample.yaml
@@ -15,9 +15,8 @@ tests:
       - nrf21540dk/nrf52840
       - nrf52840dongle/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuapp
     platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
       nrf5340dk/nrf5340/cpuapp/ns thingy53/nrf5340/cpuapp
       nrf21540dk/nrf52840 nrf52833dk/nrf52833 nrf52840dongle/nrf52840
-      nrf54l15dk/nrf54l15/cpuapp nrf54l15pdk/nrf54l15/cpuapp
+      nrf54l15dk/nrf54l15/cpuapp
     tags: bluetooth ci_build sysbuild

--- a/samples/bluetooth/mesh/light_switch/sample.yaml
+++ b/samples/bluetooth/mesh/light_switch/sample.yaml
@@ -14,11 +14,9 @@ tests:
       - thingy53/nrf5340/cpuapp
       - nrf21540dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuapp
     platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
       nrf5340dk/nrf5340/cpuapp/ns thingy53/nrf5340/cpuapp
       nrf21540dk/nrf52840 nrf52833dk/nrf52833 nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15pdk/nrf54l15/cpuapp
     tags: bluetooth ci_build sysbuild
   sample.bluetooth.mesh.light_switch.lpn:
     sysbuild: true
@@ -28,8 +26,7 @@ tests:
       - nrf52840dk/nrf52840
       - nrf52833dk/nrf52833
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuapp
     platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf52833dk/nrf52833
-      nrf54l15dk/nrf54l15/cpuapp nrf54l15pdk/nrf54l15/cpuapp
+      nrf54l15dk/nrf54l15/cpuapp
     extra_args: OVERLAY_CONFIG=overlay-lpn.conf
     tags: bluetooth ci_build sysbuild

--- a/samples/bluetooth/mesh/sensor_client/sample.yaml
+++ b/samples/bluetooth/mesh/sensor_client/sample.yaml
@@ -10,7 +10,6 @@ tests:
       - nrf52840dk/nrf52840
       - nrf21540dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuapp
     platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf21540dk/nrf52840
-      nrf54l15dk/nrf54l15/cpuapp nrf54l15pdk/nrf54l15/cpuapp
+      nrf54l15dk/nrf54l15/cpuapp
     tags: bluetooth ci_build sysbuild

--- a/samples/bluetooth/mesh/sensor_server/sample.yaml
+++ b/samples/bluetooth/mesh/sensor_server/sample.yaml
@@ -11,9 +11,7 @@ tests:
       - thingy53/nrf5340/cpuapp
       - nrf21540dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuapp
     platform_allow: >
       nrf52dk/nrf52832 nrf52840dk/nrf52840 thingy53/nrf5340/cpuapp
       nrf21540dk/nrf52840 nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15pdk/nrf54l15/cpuapp
     tags: bluetooth ci_build sysbuild

--- a/samples/bluetooth/mesh/silvair_enocean/sample.yaml
+++ b/samples/bluetooth/mesh/silvair_enocean/sample.yaml
@@ -13,8 +13,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf21540dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuapp
     platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
       nrf5340dk/nrf5340/cpuapp/ns nrf21540dk/nrf52840 nrf52833dk/nrf52833
-      nrf54l15dk/nrf54l15/cpuapp nrf54l15pdk/nrf54l15/cpuapp
+      nrf54l15dk/nrf54l15/cpuapp
     tags: bluetooth ci_build sysbuild

--- a/tests/subsys/emds/emds_api/testcase.yaml
+++ b/tests/subsys/emds/emds_api/testcase.yaml
@@ -2,9 +2,7 @@ tests:
   emds.api:
     sysbuild: true
     platform_allow: nrf52840dk/nrf52840 nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15pdk/nrf54l15/cpuapp
     tags: emds sysbuild ci_tests_subsys_emds
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuapp

--- a/tests/subsys/emds/emds_flash/testcase.yaml
+++ b/tests/subsys/emds/emds_flash/testcase.yaml
@@ -2,9 +2,7 @@ tests:
   emds.flash:
     sysbuild: true
     platform_allow: nrf52840dk/nrf52840 nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15pdk/nrf54l15/cpuapp
     tags: emds sysbuild ci_tests_subsys_emds
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuapp


### PR DESCRIPTION
Removed support for the nrf54l15pdk, as we now have support for the nrf54l15dk. This is done both for the Bluetooth Mesh samples and the EMDS tests.