### PR TITLE
mgmt: suitfu: Automatically enable SUITFU bootloader information hook

### DIFF
--- a/subsys/mgmt/suitfu/Kconfig
+++ b/subsys/mgmt/suitfu/Kconfig
@@ -38,7 +38,9 @@ config MGMT_SUITFU_GRP_IMG
 config MGMT_SUITFU_GRP_OS_BOOTLOADER_INFO_HOOK
 	bool "Bootloader identification hook"
 	default y
-	depends on MCUMGR_GRP_OS_BOOTLOADER_INFO_HOOK
+	depends on MCUMGR_GRP_OS_BOOTLOADER_INFO
+	select MCUMGR_GRP_OS_BOOTLOADER_INFO_HOOK
+	select MCUMGR_MGMT_NOTIFICATION_HOOKS
 
 config MGMT_SUITFU_GRP_SUIT
 	bool "Extended SUIT commands over USER group"


### PR DESCRIPTION
Change automatically enables SUITFU bootloader information hook if bootloader information support is enabled. This is done to ensure that proper bootloader would be reported over SMP.

Jira: NCSDK-29287