### PR TITLE
samples: matter: Enable Matter OTA on nRF54H20

### DIFF
--- a/config/suit/templates/nrf54h20/matter/v1/app_envelope.yaml.jinja2
+++ b/config/suit/templates/nrf54h20/matter/v1/app_envelope.yaml.jinja2
@@ -103,6 +103,38 @@ SUIT_Envelope_Tagged:
 {%- else %}
     suit-install:
 {%- endif %}
+    - suit-directive-set-component-index: 1
+    - suit-directive-override-parameters:
+{%- if 'CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI' in application['config'] and application['config']['CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI'] != '' %}
+        suit-parameter-uri: '{{ application['config']['CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI'] }}'
+{%- else %}
+        suit-parameter-uri: 'file://{{ application['filename'] }}'
+{%- endif %}
+        suit-parameter-image-digest:
+          suit-digest-algorithm-id: cose-alg-sha-256
+          suit-digest-bytes:
+            file: {{ application['binary'] }}
+    - suit-directive-fetch:
+      - suit-send-record-failure
+    - suit-condition-image-match:
+      - suit-send-record-success
+      - suit-send-record-failure
+      - suit-send-sysinfo-success
+      - suit-send-sysinfo-failure
+    - suit-directive-set-component-index: 0
+    - suit-directive-override-parameters:
+        suit-parameter-source-component: 1
+    - suit-directive-copy:
+      - suit-send-record-failure
+    - suit-condition-image-match:
+      - suit-send-record-success
+      - suit-send-record-failure
+      - suit-send-sysinfo-success
+      - suit-send-sysinfo-failure
+    suit-text:
+      suit-digest-algorithm-id: cose-alg-sha-256
+
+    suit-candidate-verification:
 {%- if flash_companion is defined %}
     - suit-directive-set-component-index: 1
     - suit-directive-override-parameters:
@@ -149,44 +181,6 @@ SUIT_Envelope_Tagged:
       - suit-send-record-failure
       - suit-send-sysinfo-success
       - suit-send-sysinfo-failure
-    - suit-directive-set-component-index: 0
-    - suit-directive-override-parameters:
-        suit-parameter-source-component: 1
-    - suit-directive-copy:
-      - suit-send-record-failure
-    - suit-condition-image-match:
-      - suit-send-record-success
-      - suit-send-record-failure
-      - suit-send-sysinfo-success
-      - suit-send-sysinfo-failure
-    suit-text:
-      suit-digest-algorithm-id: cose-alg-sha-256
-
-    suit-candidate-verification:
-    - suit-directive-set-component-index: 1
-    - suit-directive-override-parameters:
-{%- if 'CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI' in application['config'] and application['config']['CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI'] != '' %}
-        suit-parameter-uri: '{{ application['config']['CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI'] }}'
-{%- else %}
-        suit-parameter-uri: 'file://{{ application['filename'] }}'
-{%- endif %}
-        suit-parameter-image-digest:
-          suit-digest-algorithm-id: cose-alg-sha-256
-          suit-digest-bytes:
-            file: {{ application['binary'] }}
-    - suit-directive-fetch:
-      - suit-send-record-failure
-    - suit-directive-try-each:
-      - - suit-condition-image-match:
-          - suit-send-record-success
-          - suit-send-record-failure
-          - suit-send-sysinfo-success
-          - suit-send-sysinfo-failure
-      - - suit-condition-image-match:
-          - suit-send-record-success
-          - suit-send-record-failure
-          - suit-send-sysinfo-success
-          - suit-send-sysinfo-failure
 
     suit-manifest-component-id:
     - INSTLD_MFST

--- a/config/suit/templates/nrf54h20/matter/v1/rad_envelope.yaml.jinja2
+++ b/config/suit/templates/nrf54h20/matter/v1/rad_envelope.yaml.jinja2
@@ -127,7 +127,7 @@ SUIT_Envelope_Tagged:
 {%- if 'CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI' in radio['config'] and radio['config']['CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI'] != '' %}
         suit-parameter-uri: '{{ radio['config']['CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE_URI'] }}'
 {%- else %}
-        suit-parameter-uri: '#{{ radio['name'] }}'
+        suit-parameter-uri: 'file://{{ radio['filename'] }}'
 {%- endif %}
         suit-parameter-image-digest:
           suit-digest-algorithm-id: cose-alg-sha-256
@@ -135,17 +135,11 @@ SUIT_Envelope_Tagged:
             file: {{ radio['binary'] }}
     - suit-directive-fetch:
       - suit-send-record-failure
-    - suit-directive-try-each:
-      - - suit-condition-image-match:
-          - suit-send-record-success
-          - suit-send-record-failure
-          - suit-send-sysinfo-success
-          - suit-send-sysinfo-failure
-      - - suit-condition-image-match:
-          - suit-send-record-success
-          - suit-send-record-failure
-          - suit-send-sysinfo-success
-          - suit-send-sysinfo-failure
+    - suit-condition-image-match:
+      - suit-send-record-success
+      - suit-send-record-failure
+      - suit-send-sysinfo-success
+      - suit-send-sysinfo-failure
 
     suit-manifest-component-id:
     - INSTLD_MFST

--- a/samples/matter/lock/Kconfig.sysbuild
+++ b/samples/matter/lock/Kconfig.sysbuild
@@ -79,18 +79,16 @@ endif # BOOTLOADER_MCUBOOT
 
 if SOC_SERIES_NRF54HX
 
-# Currently Matter OTA is not available for nRF54 SoC series
-config MATTER_OTA
-	default n if SOC_SERIES_NRF54HX
-
 config SUIT_ENVELOPE
 	default y
 
 config SUIT_BUILD_FLASH_COMPANION
 	default y
 
-endif # SOC_SERIES_NRF54HX
+config SUIT_MULTI_IMAGE_PACKAGE_BUILD
+	default y if MATTER_OTA
 
+endif # SOC_SERIES_NRF54HX
 
 #### Enable generating factory data
 config MATTER_FACTORY_DATA_GENERATE

--- a/samples/matter/template/Kconfig.sysbuild
+++ b/samples/matter/template/Kconfig.sysbuild
@@ -79,15 +79,14 @@ endif # BOOTLOADER_MCUBOOT
 
 if SOC_SERIES_NRF54HX
 
-# Currently Matter OTA is not available for nRF54 SoC series
-config MATTER_OTA
-	default n if SOC_SERIES_NRF54HX
-
 config SUIT_ENVELOPE
 	default y
 
 config SUIT_BUILD_FLASH_COMPANION
 	default y
+
+config SUIT_MULTI_IMAGE_PACKAGE_BUILD
+	default y if MATTER_OTA
 
 endif # SOC_SERIES_NRF54HX
 

--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -531,14 +531,9 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_post_cmake)
 
   if(SB_CONFIG_MATTER_OTA)
     include(${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/zephyr/ota-image_sysbuild.cmake)
-    if(SB_CONFIG_DFU_MULTI_IMAGE_PACKAGE_BUILD)
+    if(SB_CONFIG_DFU_MULTI_IMAGE_PACKAGE_BUILD OR SB_CONFIG_SUIT_MULTI_IMAGE_PACKAGE_BUILD)
       chip_ota_image(chip-ota-image
         INPUT_FILES ${CMAKE_BINARY_DIR}/dfu_multi_image.bin
-        OUTPUT_FILE ${CMAKE_BINARY_DIR}/${SB_CONFIG_MATTER_OTA_IMAGE_FILE_NAME}
-      )
-    elseif(SB_CONFIG_SUIT_ENVELOPE)
-      chip_ota_image(chip-ota-image
-        INPUT_FILES ${CMAKE_BINARY_DIR}/DFU/root.suit
         OUTPUT_FILE ${CMAKE_BINARY_DIR}/${SB_CONFIG_MATTER_OTA_IMAGE_FILE_NAME}
       )
     endif()

--- a/west.yml
+++ b/west.yml
@@ -161,7 +161,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 5148b72bda4773ccaaf7df52149f765f01248079
+      revision: 1fb979258d6bf71c2cb049d24d97a087e7a2de0c
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
Enabled DFU over Matter OTA for nRF54H20 target.
It works using dfu_target_suit and dfu_multi_target implementations.