### PR TITLE
doc: Add missing doc entries in the code owner file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -193,6 +193,7 @@
 /doc/nrf/libraries/others/hw_id.rst       @nrfconnect/ncs-cia-doc
 /doc/nrf/libraries/others/index.rst       @nrfconnect/ncs-doc-leads
 /doc/nrf/libraries/others/network_core_monitor.rst @nrfconnect/ncs-si-muffin-doc
+/doc/nrf/libraries/others/nrf_compression.rst @nrfconnect/ncs-vestavind-doc
 /doc/nrf/libraries/others/nrf_profiler.rst @nrfconnect/ncs-si-bluebagel-doc
 /doc/nrf/libraries/others/pcm_mix.rst     @nrfconnect/ncs-audio-doc
 /doc/nrf/libraries/others/pcm_stream_channel_modifier.rst @nrfconnect/ncs-audio-doc
@@ -498,7 +499,8 @@
 /samples/crypto/**/*.rst                  @nrfconnect/ncs-aegir-doc
 /samples/debug/memfault/*.rst             @nrfconnect/ncs-cia-doc
 /samples/debug/ppi_trace/*.rst            @nrfconnect/ncs-doc-leads
-/samples/dect/**/*.rst                    @nrfconnect/ncs-modem-doc
+/samples/dect/dect_phy/dect_shell/*.rst   @nrfconnect/ncs-iot-positioning-doc
+/samples/dect/dect_phy/hello_dect/*.rst   @nrfconnect/ncs-modem-doc
 /samples/esb/**/*.rst                     @nrfconnect/ncs-si-muffin-doc
 /samples/edge_impulse/**/*.rst            @nrfconnect/ncs-si-muffin-doc
 /samples/event_manager_proxy/*.rst        @nrfconnect/ncs-si-muffin-doc
@@ -517,6 +519,7 @@
 /samples/nrf5340/multiprotocol_rpmsg/*.rst @nrfconnect/ncs-doc-leads
 /samples/nrf5340/netboot/*.rst            @nrfconnect/ncs-pluto-doc
 /samples/nrf5340/remote_shell/*.rst       @nrfconnect/ncs-si-muffin-doc
+/samples/nrf_compress/mcuboot_update/*.rst @nrfconnect/ncs-vestavind-doc
 /samples/nrf_profiler/*.rst               @nrfconnect/ncs-si-bluebagel-doc
 /samples/nrf_rpc/entropy_nrf53/*.rst      @nrfconnect/ncs-si-muffin-doc
 /samples/nrf_rpc/protocols_serialization/**/*.rst @nrfconnect/ncs-terahertz-doc


### PR DESCRIPTION
Add missing doc entries for RST ownership  in the code owner file