### PR TITLE
applications: nrf_desktop: Switch to ZMS for RRAM-based devices

### DIFF
--- a/applications/nrf_desktop/src/modules/Kconfig.caf_settings_loader.default
+++ b/applications/nrf_desktop/src/modules/Kconfig.caf_settings_loader.default
@@ -10,7 +10,8 @@ config DESKTOP_SETTINGS_LOADER
 	bool "Settings loader module (CAF)"
 	select CAF_SETTINGS_LOADER
 	select SETTINGS
-	imply NVS
+	imply ZMS if SOC_FLASH_NRF_RRAM
+	imply NVS if !SOC_FLASH_NRF_RRAM
 	imply FLASH
 	imply FLASH_MAP
 	imply FLASH_PAGE_LAYOUT
@@ -18,23 +19,34 @@ config DESKTOP_SETTINGS_LOADER
 	  nRF Desktop uses settings loader module from Common Application
 	  Framework (CAF).
 
-	  By default, nRF Desktop application uses non-volatile storage backend
-	  and the settings partition is located in internal FLASH.
+	  The settings partition is located in internal non-volatile memory.
+	  By default, nRF Desktop application, depending on the non-volatile
+	  memory technology used by the device, uses either the Zephyr Memory
+	  Storage (ZMS) or Non-Volatile Storage (NVS) settings backend.
+	  ZMS is used for the devices with the RRAM non-volatile memory that
+	  do not require explicit erase. Otherwise, the NVS is used.
 
 if DESKTOP_SETTINGS_LOADER
 
-choice SETTINGS_BACKEND
-	default SETTINGS_NVS
-	help
-	  By default, nRF Desktop application uses non-volatile storage
-	  settings backend.
-endchoice
+if NVS
 
 config NVS_LOG_LEVEL
 	default 2
 	help
 	  The nRF Desktop shows only warning and error logs related to the NVS.
 	  This is done to avoid flooding logs.
+
+endif # NVS
+
+if ZMS
+
+config ZMS_LOG_LEVEL
+	default 2
+	help
+	  The nRF Desktop shows only warning and error logs related to the ZMS.
+	  This is done to avoid flooding logs.
+
+endif # ZMS
 
 config SETTINGS_DYNAMIC_HANDLERS
 	default n


### PR DESCRIPTION
Switched to using the Zephyr Memory Storage (ZMS) instead of Non-Volatile Storage (NVS) for all devices that uses the RRAM non-volatile memory (currently only the nRF54L15).

Jira: NCSDK-29634