### PR TITLE
samples: nrf_rpc: protocols_serialization: use all [SR]RAM

### DIFF
--- a/samples/nrf_rpc/protocols_serialization/client/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/nrf_rpc/protocols_serialization/client/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -41,3 +41,18 @@
 	pinctrl-1 = <&uart21_sleep>;
 	pinctrl-names = "default", "sleep";
 };
+
+/* restore full RRAM and SRAM space - by default some parts are dedicated to FLRP */
+&cpuapp_rram {
+	reg = <0x0 DT_SIZE_K(1524)>;
+};
+
+&cpuapp_sram {
+	reg = <0x20000000 DT_SIZE_K(256)>;
+	ranges = <0x0 0x20000000  0x40000>;
+};
+
+&rram_controller {
+	/delete-node/ cpuflpr_sram;
+	/delete-node/ cpuflpr_rram;
+};

--- a/samples/nrf_rpc/protocols_serialization/client/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
+++ b/samples/nrf_rpc/protocols_serialization/client/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
@@ -41,3 +41,18 @@
 	pinctrl-1 = <&uart21_sleep>;
 	pinctrl-names = "default", "sleep";
 };
+
+/* restore full RRAM and SRAM space - by default some parts are dedicated to FLRP */
+&cpuapp_rram {
+	reg = <0x0 DT_SIZE_K(1524)>;
+};
+
+&cpuapp_sram {
+	reg = <0x20000000 DT_SIZE_K(256)>;
+	ranges = <0x0 0x20000000  0x40000>;
+};
+
+&rram_controller {
+	/delete-node/ cpuflpr_sram;
+	/delete-node/ cpuflpr_rram;
+};

--- a/samples/nrf_rpc/protocols_serialization/server/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/nrf_rpc/protocols_serialization/server/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -41,3 +41,18 @@
 	pinctrl-1 = <&uart21_sleep>;
 	pinctrl-names = "default", "sleep";
 };
+
+/* restore full RRAM and SRAM space - by default some parts are dedicated to FLRP */
+&cpuapp_rram {
+	reg = <0x0 DT_SIZE_K(1524)>;
+};
+
+&cpuapp_sram {
+	reg = <0x20000000 DT_SIZE_K(256)>;
+	ranges = <0x0 0x20000000  0x40000>;
+};
+
+&rram_controller {
+	/delete-node/ cpuflpr_sram;
+	/delete-node/ cpuflpr_rram;
+};

--- a/samples/nrf_rpc/protocols_serialization/server/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
+++ b/samples/nrf_rpc/protocols_serialization/server/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
@@ -41,3 +41,18 @@
 	pinctrl-1 = <&uart21_sleep>;
 	pinctrl-names = "default", "sleep";
 };
+
+/* restore full RRAM and SRAM space - by default some parts are dedicated to FLRP */
+&cpuapp_rram {
+	reg = <0x0 DT_SIZE_K(1524)>;
+};
+
+&cpuapp_sram {
+	reg = <0x20000000 DT_SIZE_K(256)>;
+	ranges = <0x0 0x20000000  0x40000>;
+};
+
+&rram_controller {
+	/delete-node/ cpuflpr_sram;
+	/delete-node/ cpuflpr_rram;
+};

--- a/samples/nrf_rpc/protocols_serialization/server/snippets/log_rpc/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/nrf_rpc/protocols_serialization/server/snippets/log_rpc/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -6,7 +6,7 @@
  / {
 	sram@2003FC00 {
 		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x2002EC00 DT_SIZE_K(1)>;
+		reg = <0x2003FC00 DT_SIZE_K(1)>;
 		zephyr,memory-region = "RetainedMem";
 		status = "okay";
 
@@ -31,5 +31,5 @@
 
 /* Reduce SRAM_CPUAPP usage by 1KB to account for non-init area */
 &cpuapp_sram {
-	reg = <0x20000000 DT_SIZE_K(187)>;
+	reg = <0x20000000 DT_SIZE_K(255)>;
 };

--- a/samples/nrf_rpc/protocols_serialization/server/snippets/log_rpc/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
+++ b/samples/nrf_rpc/protocols_serialization/server/snippets/log_rpc/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
@@ -6,7 +6,7 @@
  / {
 	sram@2003FC00 {
 		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x2002EC00 DT_SIZE_K(1)>;
+		reg = <0x2003FC00 DT_SIZE_K(1)>;
 		zephyr,memory-region = "RetainedMem";
 		status = "okay";
 
@@ -31,5 +31,5 @@
 
 /* Reduce SRAM_CPUAPP usage by 1KB to account for non-init area */
 &cpuapp_sram {
-	reg = <0x20000000 DT_SIZE_K(187)>;
+	reg = <0x20000000 DT_SIZE_K(255)>;
 };


### PR DESCRIPTION
Use all SRAM and RRAM space for the application in the protocols serialization samples.