### PR TITLE
samples: cellular: location: add missing Kconfig options to doc

### DIFF
--- a/samples/cellular/location/README.rst
+++ b/samples/cellular/location/README.rst
@@ -71,13 +71,13 @@ Building and running
 nRF91 Series DK with nRF7002 EK Wi-Fi support
 =============================================
 
-To build the sample with nRF91 Series DK and nRF7002 EK Wi-Fi support, use the ``-DSHIELD=nrf7002ek`` and  ``-DEXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf`` options.
+To build the sample with nRF91 Series DK and nRF7002 EK Wi-Fi support, use the ``-DSHIELD=nrf7002ek``, ``-DEXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf``, ``-DSB_CONFIG_WIFI_NRF70=y``, and ``-DSB_CONFIG_WIFI_NRF70_SCAN_ONLY=y`` options.
 For example:
 
 .. parsed-literal::
    :class: highlight
 
-   west build -p -b *board_target* -- -DSHIELD=nrf7002ek -DEXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf
+   west build -p -b *board_target* -- -DSHIELD=nrf7002ek -DEXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf -DSB_CONFIG_WIFI_NRF70=y -DSB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
 
 |board_target|
 
@@ -86,12 +86,12 @@ See :ref:`cmake_options` for more instructions on how to add these options.
 Thingy:91 X Wi-Fi support
 =========================
 
-To build the Location sample with Thingy:91 X Wi-Fi support, use the ``-DDTC_OVERLAY_FILE=thingy91x_wifi.overlay`` and  ``-DEXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf`` options.
+To build the Location sample with Thingy:91 X Wi-Fi support, use the ``-DDTC_OVERLAY_FILE=thingy91x_wifi.overlay``, ``-DEXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf``, ``-DSB_CONFIG_WIFI_NRF70=y``, and ``-DSB_CONFIG_WIFI_NRF70_SCAN_ONLY=y`` options.
 For example:
 
 .. code-block:: console
 
-   west build -p -b thingy91x_nrf9151_ns -- -DDTC_OVERLAY_FILE=thingy91x_wifi.overlay -DEXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf
+   west build -p -b thingy91x/nrf9151/ns -- -DDTC_OVERLAY_FILE=thingy91x_wifi.overlay -DEXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf -DSB_CONFIG_WIFI_NRF70=y -DSB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
 
 See :ref:`cmake_options` for more instructions on how to add these options.
 


### PR DESCRIPTION
Added missing Wi-Fi support Kconfig options to documentation.