### PR TITLE
samples: Bluetooth: Default Direction Finding Connectionless Tx to AoA

### DIFF
--- a/samples/bluetooth/direction_finding_connectionless_tx/README.rst
+++ b/samples/bluetooth/direction_finding_connectionless_tx/README.rst
@@ -48,11 +48,20 @@ Configuration
 Angle of arrival mode
 =====================
 
-To build this sample with AoA mode only, set :makevar:`EXTRA_CONF_FILE` to the :file:`overlay-aoa.conf` file using the respective :ref:`CMake option <cmake_options>`.
+This sample builds the angle of arrival (AoA) mode by default.
+
+.. bt_dir_finding_tx_aoa_mode_end
+
+.. bt_dir_finding_tx_aod_mode_start
+
+Angle of departure mode
+=======================
+
+To build this sample with the angle of departure (AoD) mode, set :makevar:`EXTRA_CONF_FILE` to ``overlay-aod.conf;overlay-bt_ll_sw_split.conf`` and set :makevar:`SNIPPET` to ``bt-ll-sw-split`` using the respective :ref:`CMake option <cmake_options>`.
 
 For more information about configuration files in the |NCS|, see :ref:`app_build_system`.
 
-.. bt_dir_finding_tx_aoa_mode_end
+.. bt_dir_finding_tx_aod_mode_end
 
 .. bt_dir_finding_tx_ant_aod_start
 

--- a/samples/bluetooth/direction_finding_connectionless_tx/overlay-aoa.conf
+++ b/samples/bluetooth/direction_finding_connectionless_tx/overlay-aoa.conf
@@ -1,9 +1,0 @@
-#
-# Copyright (c) 2021 Nordic Semiconductor ASA
-#
-# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
-#
-
-# Disable AoD Feature (antenna switching) in Tx mode in Controller and Host
-CONFIG_BT_CTLR_DF_ANT_SWITCH_TX=n
-CONFIG_BT_DF_CTE_TX_AOD=n

--- a/samples/bluetooth/direction_finding_connectionless_tx/overlay-aod.conf
+++ b/samples/bluetooth/direction_finding_connectionless_tx/overlay-aod.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Enable AoD Feature (antenna switching) in Tx mode in Controller and Host
+CONFIG_BT_CTLR_DF_ANT_SWITCH_TX=y
+CONFIG_BT_DF_CTE_TX_AOD=y

--- a/samples/bluetooth/direction_finding_connectionless_tx/prj.conf
+++ b/samples/bluetooth/direction_finding_connectionless_tx/prj.conf
@@ -14,3 +14,7 @@ CONFIG_BT_BROADCASTER=y
 # Enable Direction Finding Feature including AoA and AoD
 CONFIG_BT_DF=y
 CONFIG_BT_DF_CONNECTIONLESS_CTE_TX=y
+
+# Disable AoD Feature (antenna switching) in Tx mode in Controller and Host
+CONFIG_BT_CTLR_DF_ANT_SWITCH_TX=n
+CONFIG_BT_DF_CTE_TX_AOD=n

--- a/samples/bluetooth/direction_finding_connectionless_tx/sample.yaml
+++ b/samples/bluetooth/direction_finding_connectionless_tx/sample.yaml
@@ -4,8 +4,6 @@ sample:
 tests:
   sample.bluetooth.direction_finding_connectionless_tx.aoa.sdc.nrf52_nrf53:
     sysbuild: true
-    extra_args:
-      - OVERLAY_CONFIG="overlay-aoa.conf"
     build_only: true
     platform_allow:
       - nrf52833dk/nrf52833
@@ -20,7 +18,7 @@ tests:
     sysbuild: false
     build_only: true
     extra_args:
-      - OVERLAY_CONFIG="overlay-aoa.conf;overlay-bt_ll_sw_split.conf"
+      - OVERLAY_CONFIG="overlay-bt_ll_sw_split.conf"
       - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf52833dk/nrf52833
@@ -33,7 +31,6 @@ tests:
     sysbuild: true
     build_only: true
     extra_args:
-      - OVERLAY_CONFIG="overlay-aoa.conf"
       - ipc_radio_OVERLAY_CONFIG="../../overlay-bt_ll_sw_split.conf"
       - ipc_radio_SNIPPET="bt-ll-sw-split"
     platform_allow:
@@ -45,7 +42,7 @@ tests:
     sysbuild: false
     build_only: true
     extra_args:
-      - OVERLAY_CONFIG="overlay-bt_ll_sw_split.conf"
+      - OVERLAY_CONFIG="overlay-aod.conf;overlay-bt_ll_sw_split.conf"
       - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf52833dk/nrf52833
@@ -58,6 +55,7 @@ tests:
     sysbuild: true
     build_only: true
     extra_args:
+      - OVERLAY_CONFIG="overlay-aod.conf"
       - ipc_radio_OVERLAY_CONFIG="../../overlay-bt_ll_sw_split.conf"
       - ipc_radio_SNIPPET="bt-ll-sw-split"
     platform_allow:


### PR DESCRIPTION
Use Angle of Arrival mode as default for Direction Finding Connectionless Tx sample.

Related to DRGN-23590