### PR TITLE
ci: Add subsys/trusted_storage to sidewalk dependancies

### DIFF
--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -375,6 +375,7 @@ Sidewalk:
     - nrf/subsys/nrf_security/
     - nrf/subsys/partition_manager/
     - nrf/subsys/pcd/
+    - nrf/subsys/trusted_storage/
     - nrfxlib/crypto/
     - sidewalk/
     - zephyr/include/dfu/


### PR DESCRIPTION
Changes in subsys/trusted_storage will now trigger sidewalk samples build in CI.