### PR TITLE
samples: protocols_serialization: server: use ZMS on 54L15

### DIFF
--- a/samples/nrf_rpc/protocols_serialization/server/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/nrf_rpc/protocols_serialization/server/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -8,3 +8,9 @@ CONFIG_NRF_RPC_THREAD_STACK_SIZE=6144
 
 # USE HASH UID instead of HUK for this sample, because Partition Manager is not available
 CONFIG_TRUSTED_STORAGE_BACKEND_AEAD_KEY_HASH_UID=y
+
+# Workaround required as Zephyr L2 implies usage of NVS backend for settings.
+# It should be removed once the proper fix will be applied in Zephyr.
+CONFIG_NVS=n
+CONFIG_ZMS=y
+CONFIG_SETTINGS_ZMS=y

--- a/samples/nrf_rpc/protocols_serialization/server/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/nrf_rpc/protocols_serialization/server/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -8,3 +8,9 @@ CONFIG_NRF_RPC_THREAD_STACK_SIZE=6144
 
 # USE HASH UID instead of HUK for this sample, because Partition Manager is not available
 CONFIG_TRUSTED_STORAGE_BACKEND_AEAD_KEY_HASH_UID=y
+
+# Workaround required as Zephyr L2 implies usage of NVS backend for settings.
+# It should be removed once the proper fix will be applied in Zephyr.
+CONFIG_NVS=n
+CONFIG_ZMS=y
+CONFIG_SETTINGS_ZMS=y


### PR DESCRIPTION
The trusted storage library's storage backend now requires using ZMS instead of NVS on the nRF54l15.
Make the same additions than in
3ad9997ca9d769a0c37bdd03abaea90cb512b91f.