### PR TITLE
partition_manager: Align tfm_nonsecure partition for 54L15

### DIFF
--- a/subsys/partition_manager/pm.yml.tfm
+++ b/subsys/partition_manager/pm.yml.tfm
@@ -7,7 +7,12 @@ tfm_sram:
   region: sram_primary
 
 tfm:
-  placement: {before: [app]}
+  placement:
+    before: [app]
+#ifdef CONFIG_BOOTLOADER_MCUBOOT
+    align: {end: CONFIG_NRF_TRUSTZONE_FLASH_REGION_SIZE}
+#endif
+
   size: CONFIG_PM_PARTITION_SIZE_TFM
 #ifdef CONFIG_BOOTLOADER_MCUBOOT
   inside: mcuboot_primary_app
@@ -34,6 +39,7 @@ tfm_ps:
     before: mcuboot_primary
 #else
     before: tfm_nonsecure
+    align: {end: CONFIG_NRF_TRUSTZONE_FLASH_REGION_SIZE}
 #endif
   inside: tfm_storage
   size: CONFIG_PM_PARTITION_SIZE_TFM_PROTECTED_STORAGE
@@ -44,6 +50,7 @@ tfm_its:
     before: mcuboot_primary
 #else
     before: tfm_nonsecure
+    align: {end: CONFIG_NRF_TRUSTZONE_FLASH_REGION_SIZE}
 #endif
   inside: tfm_storage
   size: CONFIG_PM_PARTITION_SIZE_TFM_INTERNAL_TRUSTED_STORAGE
@@ -54,6 +61,7 @@ tfm_otp_nv_counters:
     before: mcuboot_primary
 #else
     before: tfm_nonsecure
+    align: {end: CONFIG_NRF_TRUSTZONE_FLASH_REGION_SIZE}
 #endif
   inside: tfm_storage
   size: CONFIG_PM_PARTITION_SIZE_TFM_OTP_NV_COUNTERS


### PR DESCRIPTION
Partitions just before tfm_nonsecure should align with memory regions for SPE/NSPE RRAM. If multiple tfm_storage partitions have to be aligned, this may result in multiple EMPTY partitions, but I could not find a better way to solve this, as the tfm_nonsecure 'span' can not 'align'.