### PR TITLE
samples: matter: Disabled Mbed TLS threading for nRF54L15

### DIFF
--- a/samples/matter/common/src/persistent_storage/persistent_storage_shell.cpp
+++ b/samples/matter/common/src/persistent_storage/persistent_storage_shell.cpp
@@ -6,9 +6,9 @@
 
 #include "persistent_storage_shell.h"
 
-#if defined(CONFIG_NVS)
+#if defined(CONFIG_SETTINGS_NVS)
 #include <zephyr/fs/nvs.h>
-#elif defined(CONFIG_ZMS)
+#elif defined(CONFIG_SETTINGS_ZMS)
 #include <zephyr/fs/zms.h>
 #endif
 #include <zephyr/settings/settings.h>
@@ -18,9 +18,9 @@ using namespace Nrf;
 
 namespace
 {
-#if defined(CONFIG_NVS)
+#if defined(CONFIG_SETTINGS_NVS)
 nvs_fs *sStorage = nullptr;
-#elif defined(CONFIG_ZMS)
+#elif defined(CONFIG_SETTINGS_ZMS)
 zms_fs *sStorage = nullptr;
 #endif
 
@@ -32,9 +32,9 @@ struct SettingsParams {
 
 int CalculateFreeSpace()
 {
-#if defined(CONFIG_NVS)
+#if defined(CONFIG_SETTINGS_NVS)
 	return nvs_calc_free_space(sStorage);
-#elif defined(CONFIG_ZMS)
+#elif defined(CONFIG_SETTINGS_ZMS)
 	return zms_calc_free_space(sStorage);
 #endif
 }
@@ -133,9 +133,9 @@ bool PersistentStorageShell::Init()
 		return false;
 	}
 
-#if defined(CONFIG_NVS)
+#if defined(CONFIG_SETTINGS_NVS)
 	sStorage = reinterpret_cast<nvs_fs *>(storage);
-#elif defined(CONFIG_ZMS)
+#elif defined(CONFIG_SETTINGS_ZMS)
 	sStorage = reinterpret_cast<zms_fs *>(storage);
 #endif
 

--- a/samples/matter/light_bulb/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/light_bulb/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -10,7 +10,11 @@ CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 # nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
 CONFIG_CHIP_MALLOC_SYS_HEAP_SIZE=10240
 CONFIG_MPSL_WORK_STACK_SIZE=2048
-CONFIG_CHIP_TASK_STACK_SIZE=7168
 
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
+
+# Workaround: Disable MBEDTLS threading, as in the Mbed TLS 3.6.x the mutexes were added, what sometimes
+# leads to bus faults when OpenThread calls psa_get_and_lock_key_slot on SRP service removal.
+# This brings back the behavior that was proven to work before.
+CONFIG_MBEDTLS_THREADING_C=n

--- a/samples/matter/light_bulb/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/light_bulb/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -18,3 +18,6 @@ CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
 # leads to bus faults when OpenThread calls psa_get_and_lock_key_slot on SRP service removal.
 # This brings back the behavior that was proven to work before.
 CONFIG_MBEDTLS_THREADING_C=n
+# Workaround required as Zephyr L2 implies usage of NVS backend for settings.
+# It should be removed once the proper fix will be applied in Zephyr.
+CONFIG_NVS=n

--- a/samples/matter/light_bulb/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
+++ b/samples/matter/light_bulb/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
@@ -22,3 +22,6 @@ CONFIG_CHIP_CRYPTO_PSA_MIGRATE_DAC_PRIV_KEY=y
 
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
+# Workaround required as Zephyr L2 implies usage of NVS backend for settings.
+# It should be removed once the proper fix will be applied in Zephyr.
+CONFIG_NVS=n

--- a/samples/matter/light_switch/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/light_switch/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -10,10 +10,14 @@ CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 # nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
 CONFIG_CHIP_MALLOC_SYS_HEAP_SIZE=10240
 CONFIG_MPSL_WORK_STACK_SIZE=2048
-CONFIG_CHIP_TASK_STACK_SIZE=7168
 
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
 
 # Low Power mode
 CONFIG_POWEROFF=y
+
+# Workaround: Disable MBEDTLS threading, as in the Mbed TLS 3.6.x the mutexes were added, what sometimes
+# leads to bus faults when OpenThread calls psa_get_and_lock_key_slot on SRP service removal.
+# This brings back the behavior that was proven to work before.
+CONFIG_MBEDTLS_THREADING_C=n

--- a/samples/matter/light_switch/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/light_switch/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -13,6 +13,9 @@ CONFIG_MPSL_WORK_STACK_SIZE=2048
 
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
+# Workaround required as Zephyr L2 implies usage of NVS backend for settings.
+# It should be removed once the proper fix will be applied in Zephyr.
+CONFIG_NVS=n
 
 # Low Power mode
 CONFIG_POWEROFF=y

--- a/samples/matter/light_switch/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
+++ b/samples/matter/light_switch/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
@@ -22,3 +22,6 @@ CONFIG_CHIP_CRYPTO_PSA_MIGRATE_DAC_PRIV_KEY=y
 
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
+# Workaround required as Zephyr L2 implies usage of NVS backend for settings.
+# It should be removed once the proper fix will be applied in Zephyr.
+CONFIG_NVS=n

--- a/samples/matter/lock/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/lock/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -10,10 +10,14 @@ CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 # nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
 CONFIG_CHIP_MALLOC_SYS_HEAP_SIZE=10240
 CONFIG_MPSL_WORK_STACK_SIZE=2048
-CONFIG_CHIP_TASK_STACK_SIZE=7168
 
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
 
 # Low Power mode
 CONFIG_POWEROFF=y
+
+# Workaround: Disable MBEDTLS threading, as in the Mbed TLS 3.6.x the mutexes were added, what sometimes
+# leads to bus faults when OpenThread calls psa_get_and_lock_key_slot on SRP service removal.
+# This brings back the behavior that was proven to work before.
+CONFIG_MBEDTLS_THREADING_C=n

--- a/samples/matter/lock/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/lock/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -13,6 +13,9 @@ CONFIG_MPSL_WORK_STACK_SIZE=2048
 
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
+# Workaround required as Zephyr L2 implies usage of NVS backend for settings.
+# It should be removed once the proper fix will be applied in Zephyr.
+CONFIG_NVS=n
 
 # Low Power mode
 CONFIG_POWEROFF=y

--- a/samples/matter/lock/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
+++ b/samples/matter/lock/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
@@ -22,3 +22,6 @@ CONFIG_CHIP_CRYPTO_PSA_MIGRATE_DAC_PRIV_KEY=y
 
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
+# Workaround required as Zephyr L2 implies usage of NVS backend for settings.
+# It should be removed once the proper fix will be applied in Zephyr.
+CONFIG_NVS=n

--- a/samples/matter/smoke_co_alarm/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/smoke_co_alarm/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -10,10 +10,14 @@ CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 # nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
 CONFIG_CHIP_MALLOC_SYS_HEAP_SIZE=10240
 CONFIG_MPSL_WORK_STACK_SIZE=2048
-CONFIG_CHIP_TASK_STACK_SIZE=7168
 
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
 
 # Low Power mode
 CONFIG_POWEROFF=y
+
+# Workaround: Disable MBEDTLS threading, as in the Mbed TLS 3.6.x the mutexes were added, what sometimes
+# leads to bus faults when OpenThread calls psa_get_and_lock_key_slot on SRP service removal.
+# This brings back the behavior that was proven to work before.
+CONFIG_MBEDTLS_THREADING_C=n

--- a/samples/matter/smoke_co_alarm/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/smoke_co_alarm/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -13,6 +13,9 @@ CONFIG_MPSL_WORK_STACK_SIZE=2048
 
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
+# Workaround required as Zephyr L2 implies usage of NVS backend for settings.
+# It should be removed once the proper fix will be applied in Zephyr.
+CONFIG_NVS=n
 
 # Low Power mode
 CONFIG_POWEROFF=y

--- a/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -10,7 +10,11 @@ CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 # nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
 CONFIG_CHIP_MALLOC_SYS_HEAP_SIZE=10240
 CONFIG_MPSL_WORK_STACK_SIZE=2048
-CONFIG_CHIP_TASK_STACK_SIZE=7168
 
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
+
+# Workaround: Disable MBEDTLS threading, as in the Mbed TLS 3.6.x the mutexes were added, what sometimes
+# leads to bus faults when OpenThread calls psa_get_and_lock_key_slot on SRP service removal.
+# This brings back the behavior that was proven to work before.
+CONFIG_MBEDTLS_THREADING_C=n

--- a/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -18,3 +18,6 @@ CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
 # leads to bus faults when OpenThread calls psa_get_and_lock_key_slot on SRP service removal.
 # This brings back the behavior that was proven to work before.
 CONFIG_MBEDTLS_THREADING_C=n
+# Workaround required as Zephyr L2 implies usage of NVS backend for settings.
+# It should be removed once the proper fix will be applied in Zephyr.
+CONFIG_NVS=n

--- a/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp_internal.conf
+++ b/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp_internal.conf
@@ -10,7 +10,6 @@ CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 # nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
 CONFIG_CHIP_MALLOC_SYS_HEAP_SIZE=10240
 CONFIG_MPSL_WORK_STACK_SIZE=2048
-CONFIG_CHIP_TASK_STACK_SIZE=7168
 
 # Set the ZMS sector count to match the settings partition size that is 44 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=11
@@ -50,3 +49,8 @@ CONFIG_NCS_SAMPLE_MATTER_WATCHDOG=y
 # Enable LTO
 CONFIG_LTO=y
 CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
+# Workaround: Disable MBEDTLS threading, as in the Mbed TLS 3.6.x the mutexes were added, what sometimes
+# leads to bus faults when OpenThread calls psa_get_and_lock_key_slot on SRP service removal.
+# This brings back the behavior that was proven to work before.
+CONFIG_MBEDTLS_THREADING_C=n

--- a/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp_internal.conf
+++ b/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp_internal.conf
@@ -13,6 +13,9 @@ CONFIG_MPSL_WORK_STACK_SIZE=2048
 
 # Set the ZMS sector count to match the settings partition size that is 44 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=11
+# Workaround required as Zephyr L2 implies usage of NVS backend for settings.
+# It should be removed once the proper fix will be applied in Zephyr.
+CONFIG_NVS=n
 
 # Disable SPI
 CONFIG_CHIP_SPI_NOR=n

--- a/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
+++ b/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
@@ -19,3 +19,6 @@ CONFIG_CHIP_CRYPTO_PSA_MIGRATE_DAC_PRIV_KEY=y
 
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
+# Workaround required as Zephyr L2 implies usage of NVS backend for settings.
+# It should be removed once the proper fix will be applied in Zephyr.
+CONFIG_NVS=n

--- a/samples/matter/thermostat/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/thermostat/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -10,7 +10,11 @@ CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 # nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
 CONFIG_CHIP_MALLOC_SYS_HEAP_SIZE=10240
 CONFIG_MPSL_WORK_STACK_SIZE=2048
-CONFIG_CHIP_TASK_STACK_SIZE=7168
 
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
+
+# Workaround: Disable MBEDTLS threading, as in the Mbed TLS 3.6.x the mutexes were added, what sometimes
+# leads to bus faults when OpenThread calls psa_get_and_lock_key_slot on SRP service removal.
+# This brings back the behavior that was proven to work before.
+CONFIG_MBEDTLS_THREADING_C=n

--- a/samples/matter/thermostat/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/thermostat/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -18,3 +18,6 @@ CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
 # leads to bus faults when OpenThread calls psa_get_and_lock_key_slot on SRP service removal.
 # This brings back the behavior that was proven to work before.
 CONFIG_MBEDTLS_THREADING_C=n
+# Workaround required as Zephyr L2 implies usage of NVS backend for settings.
+# It should be removed once the proper fix will be applied in Zephyr.
+CONFIG_NVS=n

--- a/samples/matter/thermostat/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
+++ b/samples/matter/thermostat/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
@@ -22,3 +22,6 @@ CONFIG_CHIP_CRYPTO_PSA_MIGRATE_DAC_PRIV_KEY=y
 
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
+# Workaround required as Zephyr L2 implies usage of NVS backend for settings.
+# It should be removed once the proper fix will be applied in Zephyr.
+CONFIG_NVS=n

--- a/samples/matter/window_covering/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/window_covering/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -10,10 +10,14 @@ CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 # nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
 CONFIG_CHIP_MALLOC_SYS_HEAP_SIZE=10240
 CONFIG_MPSL_WORK_STACK_SIZE=2048
-CONFIG_CHIP_TASK_STACK_SIZE=7168
 
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
 
 # Low Power mode
 CONFIG_POWEROFF=y
+
+# Workaround: Disable MBEDTLS threading, as in the Mbed TLS 3.6.x the mutexes were added, what sometimes
+# leads to bus faults when OpenThread calls psa_get_and_lock_key_slot on SRP service removal.
+# This brings back the behavior that was proven to work before.
+CONFIG_MBEDTLS_THREADING_C=n

--- a/samples/matter/window_covering/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/window_covering/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -13,6 +13,9 @@ CONFIG_MPSL_WORK_STACK_SIZE=2048
 
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
+# Workaround required as Zephyr L2 implies usage of NVS backend for settings.
+# It should be removed once the proper fix will be applied in Zephyr.
+CONFIG_NVS=n
 
 # Low Power mode
 CONFIG_POWEROFF=y

--- a/samples/matter/window_covering/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
+++ b/samples/matter/window_covering/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
@@ -22,3 +22,6 @@ CONFIG_CHIP_CRYPTO_PSA_MIGRATE_DAC_PRIV_KEY=y
 
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
+# Workaround required as Zephyr L2 implies usage of NVS backend for settings.
+# It should be removed once the proper fix will be applied in Zephyr.
+CONFIG_NVS=n

--- a/west.yml
+++ b/west.yml
@@ -161,7 +161,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 5148b72bda4773ccaaf7df52149f765f01248079
+      revision: 1fb979258d6bf71c2cb049d24d97a087e7a2de0c
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
After introducing mutexes in Mbed TLS, there are sometimes bus faults visible on the nRF54L15. Temporarily it has to be disabled as a workaround, to bring back the stable behavior.

By the way pulled connectedhomeip fix increasing the CHIP stack size for nRF54L15.