### PR TITLE
tests: benchmarks: multicore: idle_gpio: use gpio_loopback fixture

### DIFF
--- a/tests/benchmarks/multicore/idle_gpio/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_gpio/testcase.yaml
@@ -38,7 +38,7 @@ tests:
       remote_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpurad_s2ram.overlay;boards/wakeup_from_uart_pins.overlay"
     harness: pytest
     harness_config:
-      fixture: ppk_power_measure
+      fixture: gpio_loopback
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_with_wakeups_two_cores"
     timeout: 120


### PR DESCRIPTION
To prevent using boards with shields.