### PR TITLE
builtin_keys: Enable keys on FP1 DKs

### DIFF
--- a/subsys/nrf_security/Kconfig
+++ b/subsys/nrf_security/Kconfig
@@ -56,7 +56,7 @@ if NRF_SECURITY
 config MBEDTLS_ENABLE_BUILTIN_KEYS
 	bool
 	default y if SOC_SERIES_NRF54LX && (HW_UNIQUE_KEY || IDENTITY_KEY)
-	default y if SOC_SERIES_NRF54HX && (SOC_NRF54H20_CPUSEC)
+	default y if SOC_SERIES_NRF54HX && (SOC_NRF54H20_CPUSEC || SOC_NRF54H20_ENGB_CPUSEC)
 	help
 	  Promptless option used to control if MBEDTLS should have support for builtin keys or not.
 
@@ -260,6 +260,9 @@ endchoice
 
 # This is for internal use only.
 config SOC_NRF54H20_CPUSEC
+	bool
+
+config SOC_NRF54H20_ENGB_CPUSEC
 	bool
 
 endmenu

--- a/subsys/nrf_security/src/drivers/cracen/psa_driver.Kconfig
+++ b/subsys/nrf_security/src/drivers/cracen/psa_driver.Kconfig
@@ -1853,7 +1853,7 @@ config PSA_NEED_CRACEN_PLATFORM_KEYS
 	default y
 	depends on PSA_WANT_ALG_GCM
 	depends on PSA_WANT_AES_KEY_SIZE_256
-	depends on SOC_NRF54H20_CPUSEC
+	depends on (SOC_NRF54H20_CPUSEC || SOC_NRF54H20_ENGB_CPUSEC)
 
 
 endmenu


### PR DESCRIPTION
Both FP1 and FP1.1 DKs should support builtin keys to verify Nordic manifests.

Ref: NCSDK-NONE