### PR TITLE
Nrfx 6388 assembly mgmt west build

### DIFF
--- a/applications/sdp/gpio/CMakeLists.txt
+++ b/applications/sdp/gpio/CMakeLists.txt
@@ -10,9 +10,13 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(emulated_gpio)
 
 sdp_assembly_generate("${CMAKE_SOURCE_DIR}/src/hrt/hrt.c")
+sdp_assembly_check("${CMAKE_SOURCE_DIR}/src/hrt/hrt.c")
+sdp_assembly_prepare_install("${CMAKE_SOURCE_DIR}/src/hrt/hrt.c")
 
 target_sources(app PRIVATE src/main.c)
 target_sources(app PRIVATE src/hrt/hrt.s)
 target_sources_ifdef(CONFIG_GPIO_NRFE_EGPIO_BACKEND_ICMSG app PRIVATE src/backend/backend_icmsg.c)
 target_sources_ifdef(CONFIG_GPIO_NRFE_EGPIO_BACKEND_ICBMSG app PRIVATE src/backend/backend_icmsg.c)
 target_sources_ifdef(CONFIG_GPIO_NRFE_EGPIO_BACKEND_MBOX app PRIVATE  src/backend/backend_mbox.c)
+
+add_dependencies(app asm_check)

--- a/cmake/sdp.cmake
+++ b/cmake/sdp.cmake
@@ -49,3 +49,41 @@ function(sdp_assembly_generate hrt_srcs)
   add_dependencies(asm_gen syscall_list_h_target)
 
 endfunction()
+
+function(sdp_assembly_check hrt_srcs)
+  set(asm_check_msg "Checking if ASM files for Hard Real Time have changed.")
+
+  if(TARGET asm_check)
+    message(FATAL_ERROR "sdp_assembly_check() already called, please note that
+      sdp_assembly_check() must be called only once with a list of all source files."
+    )
+  endif()
+
+  string(REPLACE ";" "$<SEMICOLON>" hrt_srcs_semi "${hrt_srcs}")
+
+  add_custom_target(asm_check
+    COMMAND ${CMAKE_COMMAND} -D hrt_srcs="${hrt_srcs_semi}" -P ${ZEPHYR_NRF_MODULE_DIR}/cmake/sdp_asm_check.cmake
+    COMMENT ${asm_check_msg}
+  )
+
+  add_dependencies(asm_check asm_gen)
+
+endfunction()
+
+function(sdp_assembly_prepare_install hrt_srcs)
+  set(asm_install_msg "Updating ASM files for Hard Real Time.")
+
+  if(TARGET asm_install)
+    message(FATAL_ERROR "sdp_assembly_prepare_install() already called, please note that
+      sdp_assembly_prepare_install() must be called only once with a list of all source files."
+    )
+  endif()
+
+  string(REPLACE ";" "$<SEMICOLON>" hrt_srcs_semi "${hrt_srcs}")
+
+  add_custom_target(asm_install
+    COMMAND ${CMAKE_COMMAND} -D hrt_srcs="${hrt_srcs_semi}" -P ${ZEPHYR_NRF_MODULE_DIR}/cmake/sdp_asm_install.cmake
+    COMMENT ${asm_install_msg}
+  )
+
+endfunction()

--- a/cmake/sdp_asm_check.cmake
+++ b/cmake/sdp_asm_check.cmake
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+function(asm_check)
+
+  foreach(hrt_src ${hrt_srcs})
+    get_filename_component(asm_filename ${hrt_src} NAME_WE)  # filename without extension
+    get_filename_component(src_dir ${hrt_src} DIRECTORY)
+
+    execute_process(COMMAND ${CMAKE_COMMAND} -E compare_files --ignore-eol
+                    ${src_dir}/${asm_filename}.s ${asm_filename}-temp.s
+                    RESULT_VARIABLE compare_result)
+
+    if( compare_result EQUAL 0)
+      message("File ${asm_filename}.s has not changed.")
+    elseif( compare_result EQUAL 1)
+      message(WARNING "${asm_filename}.s ASM file content has changed.\
+              If you want to include the new ASM in build, \
+              please run `ninja asm_install` in FLPR build directory and build again")
+    else()
+      message("Something went wrong when comparing ${asm_filename}.s and ${asm_filename}-temp.s")
+    endif()
+  endforeach()
+
+endfunction(asm_check)
+
+asm_check()

--- a/cmake/sdp_asm_install.cmake
+++ b/cmake/sdp_asm_install.cmake
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+function(asm_install)
+
+  foreach(hrt_src ${hrt_srcs})
+    get_filename_component(asm_filename ${hrt_src} NAME_WE)  # filename without extension
+    get_filename_component(src_dir ${hrt_src} DIRECTORY)
+
+    file(RENAME ${asm_filename}-temp.s ${src_dir}/${asm_filename}.s RESULT rename_result)
+
+    if (rename_result EQUAL 0)
+        message("Updated ${asm_filename}.s ASM file.")
+    else()
+        message(WARNING "${asm_filename}.s cannot be updated, new ASM does not exist. Please run ninja asm_gen to create one.")
+    endif()
+
+  endforeach()
+
+endfunction(asm_install)
+
+asm_install()


### PR DESCRIPTION
Add two new CMake targets: `asm_check` and `asm_update`.

`asm_check` will check if content of the already existing ASM file and the new generated by `asm_gen` are the same. If they are the same, the newly generated is removed. If they are different, a warning is printed to update ASM file, if the new one should be included in build.

`asm_update` will replace the already existing ASM file with the new one generated by `asm_gen`. If the new ASM file does not exist, a warning is printed.

I created two new CMake scripts (`sdp_asm_check` and `sdp_asm_update`) for these targets because I could not find a way to pass the logic to `add_custom_target` directly/in line. If there is a way of doing that without creating new CMake scripts, please let me know.

In the last commit `asm_check` is added as a dependency for `flpr_egpio` application. It is done in order to check ASM files automatically at the start of the build, no matter if a sysbuild application including eGPIO is build or eGPIO firmware only.

~Based on #17638~ Rebased on main
