### PR TITLE
doc: updating: add link to supported shells

### DIFF
--- a/doc/nrf/installation/updating.rst
+++ b/doc/nrf/installation/updating.rst
@@ -67,6 +67,8 @@ Depending on your preferred development method, you can start the correct CLI to
 
       ..
 
+      See the documentation for nRF Util's `Toolchain Manager command`_ for the list of supported shells.
+
 .. _gs_updating_repos:
 .. _gs_updating_repos_examples:
 .. _updating_repos_examples:


### PR DESCRIPTION
Added a link to the list of shells supported by nRF Util's toolchain manager command. NRFU-1283.