### PR TITLE
doc: trusted storage lib doc update with zms

### DIFF
--- a/doc/nrf/libraries/security/trusted_storage.rst
+++ b/doc/nrf/libraries/security/trusted_storage.rst
@@ -83,8 +83,11 @@ Before using the trusted storage library with its default settings and options, 
 * The hardware unique key (HUK) :ref:`library <lib_hw_unique_key>` and :ref:`sample <hw_unique_key_usage>` are enabled and ready for use to derive an AEAD key.
 * Zephyr's settings subsystem has to be enabled for use by setting the Kconfig option :kconfig:option:`CONFIG_SETTINGS`.
 
-  * The settings subsystem uses the :ref:`zephyr:nvs_api` file system by default.
-    This file system has to be mounted to a mount point at application startup. For more information about this, see :ref:`zephyr:file_system_api`.
+  * The library supports two storage options for the settings subsystem, :ref:`zephyr:zms_api` and :ref:`zephyr:nvs_api`.
+    ZMS is the only allowed storage option for nRF54L Series devices, while other devices using the trusted storage library can choose between the two options.
+  * You have to mount the file system to a mount point at application startup.
+    For more information about how to do this, see :ref:`zephyr:file_system_api`.
+    Also, see the Mounting the Storage system section of the :ref:`ZMS documentation <zephyr:zms_api>`.
 
 .. _trusted_storage_configuration:
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -1110,7 +1110,9 @@ Other libraries
 Security libraries
 ------------------
 
-|no_changes_yet_note|
+* :ref:`trusted_storage_readme` library:
+
+  * Added support for Zephyr Memory Storage (ZMS), as an alternative to the NVS file system.
 
 Shell libraries
 ---------------


### PR DESCRIPTION
Updated docs for trusted storage library to contain ZMS support in addition to NVS