### PR TITLE
samples: bluetooth: fast_pair: locator tag: update nrf54l15 partitions

### DIFF
--- a/samples/bluetooth/fast_pair/locator_tag/configuration/pm_static_nrf54l15dk_nrf54l15_cpuapp.yml
+++ b/samples/bluetooth/fast_pair/locator_tag/configuration/pm_static_nrf54l15dk_nrf54l15_cpuapp.yml
@@ -1,10 +1,10 @@
 mcuboot:
   address: 0x0
   region: flash_primary
-  size: 0x4000
+  size: 0x5000
 
 mcuboot_primary:
-  address: 0x4000
+  address: 0x5000
   orig_span: &id001
   - app
   - mcuboot_pad
@@ -12,15 +12,15 @@ mcuboot_primary:
   size: 0xb8000
   span: *id001
 mcuboot_pad:
-  address: 0x4000
+  address: 0x5000
   region: flash_primary
   size: 0x800
 app:
-  address: 0x4800
+  address: 0x5800
   region: flash_primary
   size: 0xb7800
 mcuboot_primary_app:
-  address: 0x4800
+  address: 0x5800
   orig_span: &id002
   - app
   region: flash_primary
@@ -28,7 +28,7 @@ mcuboot_primary_app:
   span: *id002
 
 mcuboot_secondary:
-  address: 0xbc000
+  address: 0xbd000
   orig_span: &id003
   - mcuboot_secondary_pad
   - mcuboot_secondary_app
@@ -37,19 +37,19 @@ mcuboot_secondary:
   span: *id003
 mcuboot_secondary_pad:
   region: flash_primary
-  address: 0xbc000
+  address: 0xbd000
   size: 0x800
 mcuboot_secondary_app:
   region: flash_primary
-  address: 0xbc800
+  address: 0xbd800
   size: 0xb7800
 
 bt_fast_pair:
-  address: 0x174000
+  address: 0x175000
   region: flash_primary
   size: 0x1000
 
 settings_storage:
-  address: 0x175000
+  address: 0x176000
   region: flash_primary
-  size: 0x8000
+  size: 0x7000


### PR DESCRIPTION
Updated the partition map for the nRF54L15 DK in the Fast Pair Locator Tag sample to provide more space for the MCUboot bootloader.

Ref: NCSDK-29504