### PR TITLE
manifest: sidewalk update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -210,7 +210,7 @@ manifest:
           compare-by-default: false
     - name: sidewalk
       repo-path: sdk-sidewalk
-      revision: 34568df6fb89567332e4b628e89233422d07223e
+      revision: f86b62159d1f1055cd3c94dc010c2924d2fc47fa
       groups:
         - sidewalk
     - name: find-my


### PR DESCRIPTION
Sidewalk update for NCS v2.8.0

This is a placeholder task for update Sidewalk revision in west manifest with the following changes:

nrf54L15 DK support

- [x] https://github.com/nrfconnect/sdk-sidewalk/pull/630

v1.17 lbiraries 

- [x] https://github.com/nrfconnect/sdk-sidewalk/pull/613
- [x] https://github.com/nrfconnect/sdk-sidewalk/pull/625
