### PR TITLE
pm: zms: fix autoconf.h include

### DIFF
--- a/subsys/partition_manager/pm.yml.zms
+++ b/subsys/partition_manager/pm.yml.zms
@@ -1,4 +1,4 @@
-#include <autoconf.h>
+#include <zephyr/autoconf.h>
 
 # In nRF54L15 we place the TF-M non-secure storage partitions after the
 # TF-M non-secure application to avoid splitting the secure/non-secure


### PR DESCRIPTION
During the last Zephyr upmerge the includes changed from autoconf.h to <zephyr/autoconf.h>
Fix this for the zms partition table