### PR TITLE
mpsl: cx: Fix include dependency for 1wire and 3wire coex drivers

### DIFF
--- a/subsys/mpsl/cx/1wire/mpsl_cx_1wire.c
+++ b/subsys/mpsl/cx/1wire/mpsl_cx_1wire.c
@@ -22,6 +22,7 @@
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/gpio.h>
+#include <soc_nrf_common.h>
 
 #include "hal/nrf_gpio.h"
 #include <nrfx_gpiote.h>

--- a/subsys/mpsl/cx/3wire/mpsl_cx_3wire.c
+++ b/subsys/mpsl/cx/3wire/mpsl_cx_3wire.c
@@ -25,6 +25,7 @@
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/gpio.h>
+#include <soc_nrf_common.h>
 
 #include "hal/nrf_gpio.h"
 #include <nrfx_gpiote.h>


### PR DESCRIPTION
These files use NRF_DT_GPIOTE_INST which is provided by soc_nrf_common.h. 
Include this as it is not implicitly included on bsim platforms.