### PR TITLE
samples: nfc: writable_ndef_msg: Migrate from NVS to ZMS for nRF54

### DIFF
--- a/samples/nfc/writable_ndef_msg/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/samples/nfc/writable_ndef_msg/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_NVS=n
+CONFIG_ZMS=y

--- a/samples/nfc/writable_ndef_msg/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/nfc/writable_ndef_msg/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_NVS=n
+CONFIG_ZMS=y


### PR DESCRIPTION
These changes introduce the use of the ZMS file system instead of NVS for the nRF54 series.

Ref: NCSDK-29636