### PR TITLE
doc: bootloader_partitioning: add info about VSC

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -860,6 +860,7 @@
 .. _`Debugging overview`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/guides/debug_concepts.html
 .. _`How to debug`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/guides/debug_use.html
 .. _`How to debug applications for a multi-core System on Chip`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/guides/debug_use.html#how-to-debug-applications-for-a-multi-core-system-on-chip
+.. _`How to work with the Memory Explorer`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/guides/debug_mem_explorer.html
 .. _`source control with west`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/guides/west_about.html
 .. _`west module management`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/guides/west_module_management.html
 .. _`Custom launch and debug configurations`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/guides/debug_custom.html

--- a/scripts/partition_manager/partition_manager.rst
+++ b/scripts/partition_manager/partition_manager.rst
@@ -565,8 +565,6 @@ After the ``nordic,pm-ext-flash`` value is set, you can place partitions in the 
 
 See :ref:`ug_bootloader_external_flash` for more details on using external flash memory with MCUboot.
 
-.. _pm_build_system:
-
 A partition can be accessible at runtime only if the flash device where it resides has its driver enabled at compile time.
 Partition manager ignores partitions that are located in a region without its driver enabled.
 To let partition manager know which Kconfig option ensures the existence of the driver, the option ``DEFAULT_DRIVER_KCONFIG`` is used.
@@ -591,6 +589,8 @@ As partition manager does not know if partitions are used at runtime, consider t
 
    When using an application configured with an MCUboot child image, both images use the same partition manager configuration, which means that the app and MCUboot have exactly the same partition maps.
    The accessibility at runtime of flash partitions depends on the configurations of both the application and MCUboot and the values they give to the ``DEFAULT_DRIVER_KCONFIG`` option of the partition manager region specification.
+
+.. _pm_build_system:
 
 Build system
 ************


### PR DESCRIPTION
Edited the structure of bootloader_partitioning page to mention memory reports of the VSC extension alongside partition_manager_report. Fixed some formatting and structure issues and typos. VSC-2712.