### PR TITLE
snippets: emulate the nRF54L05 and the nRF54L10 RAM and RRAM sizes

### DIFF
--- a/snippets/emulated-nrf54l05/README.rst
+++ b/snippets/emulated-nrf54l05/README.rst
@@ -1,0 +1,23 @@
+.. _emulated-nrf54l05:
+
+nRF54L05 snippet
+################
+
+.. contents::
+   :local:
+   :depth: 2
+
+Overview
+********
+
+This snippet (``emulated-nrf54l05``) emulates nRF54L10 on the nRF54L15 DK.
+
+Supported SoCs and boards
+*************************
+
+.. warning:
+   This snippet cannot be used with the FLPR core because all memory, including RAM and RRAM, is allocated to the application core.
+
+Currently, the only SoC and board supported for use with the snippet is:
+
+* :ref:`zephyr:nrf54l15dk_nrf54l15`

--- a/snippets/emulated-nrf54l05/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/snippets/emulated-nrf54l05/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&cpuapp_sram {
+	reg = <0x20000000 DT_SIZE_K(96)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(96)>;
+};
+
+&cpuapp_rram {
+	reg = <0x0 DT_SIZE_K(500)>;
+};
+
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot0_ns_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &slot1_ns_partition;
+/delete-node/ &storage_partition;
+
+&cpuapp_rram {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x0 DT_SIZE_K(64)>;
+		};
+		slot0_partition: partition@10000 {
+			label = "image-0";
+			reg = <0x10000 DT_SIZE_K(100)>;
+		};
+		slot0_ns_partition: partition@29000 {
+			label = "image-0-nonsecure";
+			reg = <0x29000 DT_SIZE_K(100)>;
+		};
+		slot1_partition: partition@42000 {
+			label = "image-1";
+			reg = <0x42000 DT_SIZE_K(100)>;
+		};
+		slot1_ns_partition: partition@5b000 {
+			label = "image-1-nonsecure";
+			reg = <0x5b000 DT_SIZE_K(100)>;
+		};
+		storage_partition: partition@74000 {
+			label = "storage";
+			reg = <0x74000 DT_SIZE_K(36)>;
+		};
+	};
+};

--- a/snippets/emulated-nrf54l05/snippet.yml
+++ b/snippets/emulated-nrf54l05/snippet.yml
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+name: emulated-nrf54l05
+
+boards:
+  nrf54l15dk/nrf54l15/cpuapp:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/nrf54l15dk_nrf54l15_cpuapp.overlay

--- a/snippets/emulated-nrf54l10/README.rst
+++ b/snippets/emulated-nrf54l10/README.rst
@@ -1,0 +1,23 @@
+.. _emulated-nrf54l10:
+
+nRF54L10 snippet
+################
+
+.. contents::
+   :local:
+   :depth: 2
+
+Overview
+********
+
+This snippet (``emulated-nrf54l10``) emulates nRF54L10 on the nRF54L15 DK.
+
+Supported SoCs and boards
+*************************
+
+.. warning:
+   This snippet cannot be used with the FLPR core because all memory, including RAM and RRAM, is allocated to the application core.
+
+Currently, the only SoC and board supported for use with the snippet is:
+
+* :ref:`zephyr:nrf54l15dk_nrf54l15`

--- a/snippets/emulated-nrf54l10/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/snippets/emulated-nrf54l10/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&cpuapp_sram {
+	reg = <0x20000000 DT_SIZE_K(192)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(192)>;
+};
+
+&cpuapp_rram {
+	reg = <0x0 DT_SIZE_K(1022)>;
+};
+
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot0_ns_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &slot1_ns_partition;
+/delete-node/ &storage_partition;
+
+&cpuapp_rram {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x0 DT_SIZE_K(64)>;
+		};
+		slot0_partition: partition@10000 {
+			label = "image-0";
+			reg = <0x10000 DT_SIZE_K(230)>;
+		};
+		slot0_ns_partition: partition@49800 {
+			label = "image-0-nonsecure";
+			reg = <0x49800 DT_SIZE_K(230)>;
+		};
+		slot1_partition: partition@83000 {
+			label = "image-1";
+			reg = <0x83000 DT_SIZE_K(230)>;
+		};
+		slot1_ns_partition: partition@bc800 {
+			label = "image-1-nonsecure";
+			reg = <0xbc800 DT_SIZE_K(230)>;
+		};
+		storage_partition: partition@f6000 {
+			label = "storage";
+			reg = <0xf6000 DT_SIZE_K(38)>;
+		};
+	};
+};

--- a/snippets/emulated-nrf54l10/snippet.yml
+++ b/snippets/emulated-nrf54l10/snippet.yml
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+name: emulated-nrf54l10
+
+boards:
+  nrf54l15dk/nrf54l15/cpuapp:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/nrf54l15dk_nrf54l15_cpuapp.overlay


### PR DESCRIPTION
Note that this is *not* compatible with enabling FLPR.