### PR TITLE
net: lib: fota_download: fix for native TLS in download client

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -1041,6 +1041,10 @@ Libraries for networking
 
   * Updated to use INF log level when the cloud side changes the log level.
 
+* :ref:`lib_fota_download` library:
+
+  * Fixed an issue where the download client instance did not use native TLS although the :kconfig:option:`CONFIG_FOTA_DOWNLOAD_NATIVE_TLS` Kconfig option was enabled.
+
 * :ref:`lib_nrf_cloud_fota` library:
 
   * Added:

--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -670,19 +670,19 @@ static int fota_download_object_init(void)
 {
 	int err;
 
-#ifdef CONFIG_FOTA_DOWNLOAD_NATIVE_TLS
-	/* Enable native TLS for the download client socket
-	 * if configured.
-	 */
-	dlc.set_native_tls = CONFIG_FOTA_DOWNLOAD_NATIVE_TLS;
-#endif
-
 	k_work_init_delayable(&dlc_with_offset_work, download_with_offset);
 
 	err = download_client_init(&dlc, download_client_callback);
 	if (err != 0) {
 		return err;
 	}
+
+#ifdef CONFIG_FOTA_DOWNLOAD_NATIVE_TLS
+	/* Enable native TLS for the download client socket
+	 * if configured.
+	 */
+	dlc.set_native_tls = true;
+#endif
 
 	initialized = true;
 	return 0;


### PR DESCRIPTION
The download client init is clearing the DLC struct. Therefore, the use_native_tls field has to be set after the initialization.