### PR TITLE
tests: benchmarks: multicore: idle_uarte: radio sleeps forever

### DIFF
--- a/tests/benchmarks/multicore/idle_uarte/remote/src/main.c
+++ b/tests/benchmarks/multicore/idle_uarte/remote/src/main.c
@@ -8,10 +8,7 @@
 
 int main(void)
 {
-	k_msleep(500);
-	while (1) {
-		k_msleep(2000);
-	}
+	k_sleep(K_FOREVER);
 
 	return 0;
 }


### PR DESCRIPTION
Do not wakeup radio as it make current measurements noisy.