### PR TITLE
samples: matter: Disable NVS in Matter sample for nRF54L15

### DIFF
--- a/samples/matter/light_bulb/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/light_bulb/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -14,3 +14,4 @@ CONFIG_CHIP_TASK_STACK_SIZE=7168
 
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
+CONFIG_NVS=n

--- a/samples/matter/light_bulb/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
+++ b/samples/matter/light_bulb/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
@@ -22,3 +22,4 @@ CONFIG_CHIP_CRYPTO_PSA_MIGRATE_DAC_PRIV_KEY=y
 
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
+CONFIG_NVS=n

--- a/samples/matter/light_switch/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/light_switch/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -14,6 +14,7 @@ CONFIG_CHIP_TASK_STACK_SIZE=7168
 
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
+CONFIG_NVS=n
 
 # Low Power mode
 CONFIG_POWEROFF=y

--- a/samples/matter/light_switch/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
+++ b/samples/matter/light_switch/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
@@ -22,3 +22,4 @@ CONFIG_CHIP_CRYPTO_PSA_MIGRATE_DAC_PRIV_KEY=y
 
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
+CONFIG_NVS=n

--- a/samples/matter/lock/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/lock/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -14,6 +14,7 @@ CONFIG_CHIP_TASK_STACK_SIZE=7168
 
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
+CONFIG_NVS=n
 
 # Low Power mode
 CONFIG_POWEROFF=y

--- a/samples/matter/lock/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
+++ b/samples/matter/lock/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
@@ -22,3 +22,4 @@ CONFIG_CHIP_CRYPTO_PSA_MIGRATE_DAC_PRIV_KEY=y
 
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
+CONFIG_NVS=n

--- a/samples/matter/smoke_co_alarm/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/smoke_co_alarm/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -14,6 +14,7 @@ CONFIG_CHIP_TASK_STACK_SIZE=7168
 
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
+CONFIG_NVS=n
 
 # Low Power mode
 CONFIG_POWEROFF=y

--- a/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -14,3 +14,4 @@ CONFIG_CHIP_TASK_STACK_SIZE=7168
 
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
+CONFIG_NVS=n

--- a/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp_internal.conf
+++ b/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp_internal.conf
@@ -14,6 +14,7 @@ CONFIG_CHIP_TASK_STACK_SIZE=7168
 
 # Set the ZMS sector count to match the settings partition size that is 44 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=11
+CONFIG_NVS=n
 
 # Disable SPI
 CONFIG_CHIP_SPI_NOR=n

--- a/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
+++ b/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
@@ -19,3 +19,4 @@ CONFIG_CHIP_CRYPTO_PSA_MIGRATE_DAC_PRIV_KEY=y
 
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
+CONFIG_NVS=n

--- a/samples/matter/thermostat/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/thermostat/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -14,3 +14,4 @@ CONFIG_CHIP_TASK_STACK_SIZE=7168
 
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
+CONFIG_NVS=n

--- a/samples/matter/thermostat/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
+++ b/samples/matter/thermostat/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
@@ -22,3 +22,4 @@ CONFIG_CHIP_CRYPTO_PSA_MIGRATE_DAC_PRIV_KEY=y
 
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
+CONFIG_NVS=n

--- a/samples/matter/window_covering/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/window_covering/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -14,6 +14,7 @@ CONFIG_CHIP_TASK_STACK_SIZE=7168
 
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
+CONFIG_NVS=n
 
 # Low Power mode
 CONFIG_POWEROFF=y

--- a/samples/matter/window_covering/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
+++ b/samples/matter/window_covering/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
@@ -22,3 +22,4 @@ CONFIG_CHIP_CRYPTO_PSA_MIGRATE_DAC_PRIV_KEY=y
 
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
+CONFIG_NVS=n


### PR DESCRIPTION
We need to disable NVS manually in each sample due to setting it in Zephyr's Openthread port.