### PR TITLE
doc: Update code owners to remove incorrect assignments

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -386,11 +386,11 @@
 /lib/wave_gen/                            @nrfconnect/ncs-si-muffin
 
 # Modules
-/modules/azure-sdk-for-c/                 @nrfconnect/ncs-cia @plskeggs
-/modules/cjson/                           @nrfconnect/ncs-cia @plskeggs
+/modules/azure-sdk-for-c/                 @nrfconnect/ncs-cia
+/modules/cjson/                           @nrfconnect/ncs-cia @nrfconnect/ncs-nrf-cloud
 /modules/coremark/                        @nrfconnect/ncs-si-bluebagel
 /modules/mcuboot/                         @nrfconnect/ncs-pluto
-/modules/memfault-firmware-sdk/           @nrfconnect/ncs-cia @plskeggs
+/modules/memfault-firmware-sdk/           @nrfconnect/ncs-cia
 /modules/nrfxlib/                         @nrfconnect/ncs-code-owners
 /modules/trusted-firmware-m/              @nrfconnect/ncs-aegir
 /modules/wfa-qt/                          @nrfconnect/ncs-wifi


### PR DESCRIPTION
@plskeggs was incorrectly added as a code owner for /modules/azure-sdk-for-c and for/modules/memfault-firmware-sdk.

Remove those, and change the remaining assignment on /modules/cjson to @nrfconnect/ncs-nrf-cloud.