### PR TITLE
Pull upstream fixes for Mesh

### DIFF
--- a/subsys/bluetooth/mesh/rpl.c
+++ b/subsys/bluetooth/mesh/rpl.c
@@ -134,3 +134,6 @@ void bt_mesh_rpl_reset(void)
 
 void bt_mesh_rpl_pending_store(uint16_t addr)
 {}
+
+void bt_mesh_rpl_pending_store_all_nodes(void)
+{}

--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: be00e5a236d2cd71583a36e4c93cb3400a2faff0
+      revision: e516ad354c34483e8050871fd7c915c72bc2f4fd
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
- Adds an empty `bt_mesh_rpl_pending_store_all_nodes` function to `rpl.c` to avoid compilation errors when EMDS is enabled.
- Updates sdk-zephyr manifest
