### PR TITLE
samples: matter: Created configuration with LEDs disabled

### DIFF
--- a/doc/nrf/protocols/matter/getting_started/low_power_configuration.rst
+++ b/doc/nrf/protocols/matter/getting_started/low_power_configuration.rst
@@ -202,6 +202,18 @@ Disable unused pins and peripherals
    :start-after: disable_unused_pins_start
    :end-before: disable_unused_pins_end
 
+Disable LEDs module
+===================
+
+When performing the power measurements on various development kits, the LEDs can either be included in the measurement circuit or not:
+
+* For the nRF52840 DK and nRF5340 DK, the LEDs are excluded from the measurement circuit, so they can be enabled for the low power configuration and it is not going to impact the measurement results.
+* For the nRF54L15 DK, the MOSFET transistors controlling the LEDs are included in the measurement circuit.
+  This results in measurement results being increased by an additional, small leakage current that appears if an LED is turned on.
+  To measure the current consumption of the nRF54L15 SoC without including development kit components, such as LEDs, it is recommended to disable them.
+
+To disable LEDs in the Matter samples and applications, set the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_LEDS` Kconfig option to ``n``.
+
 .. _ug_matter_enable_pm_module:
 
 Enable Device Power Management module

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -589,6 +589,7 @@ Matter samples
   * Support for the nRF54L15 DK.
   * Support for :ref:`Trusted Firmware-M <ug_tfm>` on the nRF54L15 SoC.
   * The :ref:`matter_smoke_co_alarm_sample` sample that demonstrates implementation of Matter Smoke CO alarm device type.
+  * The :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_LEDS` Kconfig option, which can be used to disable the LEDs in the Matter sample or application.
 
 * :ref:`matter_lock_sample` sample:
 

--- a/samples/matter/common/src/Kconfig
+++ b/samples/matter/common/src/Kconfig
@@ -40,6 +40,13 @@ config NCS_SAMPLE_MATTER_FACTORY_RESET_ON_KEY_MIGRATION_FAILURE
 	  Allow device to perform factory reset if the operational key for Fabric has not been migrated
 	  properly to PSA ITS storage.
 
+config NCS_SAMPLE_MATTER_LEDS
+	bool "Enable LEDs usage"
+	default y
+	depends on DK_LIBRARY
+	help
+	  Enables LEDs module to be used in the application.
+
 config NCS_SAMPLE_MATTER_SETTINGS_SHELL
 	bool "Settings shell for Matter purposes"
 	default y if CHIP_MEMORY_PROFILING

--- a/samples/matter/common/src/board/board.cpp
+++ b/samples/matter/common/src/board/board.cpp
@@ -29,6 +29,7 @@ Board Board::sInstance;
 bool Board::Init(button_handler_t buttonHandler, LedStateHandler ledStateHandler)
 {
 #ifdef CONFIG_DK_LIBRARY
+#ifdef CONFIG_NCS_SAMPLE_MATTER_LEDS
 	/* Initialize LEDs */
 	LEDWidget::InitGpio();
 	LEDWidget::SetStateUpdateCallback(LEDStateUpdateHandler);
@@ -40,6 +41,7 @@ bool Board::Init(button_handler_t buttonHandler, LedStateHandler ledStateHandler
 	mLED3.Init(DK_LED3);
 	mLED4.Init(DK_LED4);
 #endif
+#endif /* CONFIG_NCS_SAMPLE_MATTER_LEDS */
 
 	/* Initialize buttons */
 	int ret = dk_buttons_init(ButtonEventHandler);

--- a/samples/matter/lock/sample.yaml
+++ b/samples/matter/lock/sample.yaml
@@ -86,3 +86,12 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf54l15dk/nrf54l15/cpuapp
     tags: sysbuild ci_samples_matter
+  sample.matter.lock.release.nrf54l15.power_consumption:
+    sysbuild: true
+    build_only: true
+    extra_args: FILE_SUFFIX=release CONFIG_NCS_SAMPLE_MATTER_LEDS=n
+      CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y CONFIG_NCS_SAMPLE_MATTER_WATCHDOG=n
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
+    platform_allow: nrf54l15dk/nrf54l15/cpuapp
+    tags: sysbuild ci_samples_matter

--- a/samples/matter/smoke_co_alarm/sample.yaml
+++ b/samples/matter/smoke_co_alarm/sample.yaml
@@ -32,3 +32,12 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
     platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf54l15dk/nrf54l15/cpuapp
     tags: sysbuild ci_samples_matter
+  sample.matter.smoke_co_alarm.release.nrf54l15.power_consumption:
+    sysbuild: true
+    build_only: true
+    extra_args: FILE_SUFFIX=release CONFIG_NCS_SAMPLE_MATTER_LEDS=n
+      CONFIG_NCS_SAMPLE_MATTER_WATCHDOG=n
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
+    platform_allow: nrf54l15dk/nrf54l15/cpuapp
+    tags: sysbuild ci_samples_matter

--- a/samples/matter/window_covering/sample.yaml
+++ b/samples/matter/window_covering/sample.yaml
@@ -36,3 +36,12 @@ tests:
     platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
       nrf54l15dk/nrf54l15/cpuapp
     tags: sysbuild ci_samples_matter
+  sample.matter.window_cover.release.nrf54l15.power_consumption:
+    sysbuild: true
+    build_only: true
+    extra_args: FILE_SUFFIX=release CONFIG_NCS_SAMPLE_MATTER_LEDS=n
+      CONFIG_NCS_SAMPLE_MATTER_WATCHDOG=n
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
+    platform_allow: nrf54l15dk/nrf54l15/cpuapp
+    tags: sysbuild ci_samples_matter


### PR DESCRIPTION
Added Kconfig that allows to disable LEDs initialization and created a configuration that uses it for nRF54L15. This is required for the power measurement purposes.