### PR TITLE
samples: fast_pair: locator_tag: Enable CONFIG_BT_CONN_TX_NOTIFY_WQ

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -442,6 +442,9 @@ Bluetooth Fast Pair samples
 
   * The values for the :kconfig:option:`CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL` Kconfig option in all configurations, and for the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_TX_POWER_CORRECTION_VAL` Kconfig option in configurations with the Find My Device Network (FMDN) extension support.
     The values are now aligned with the Fast Pair requirements.
+  * The sample configurations to use a separate workqueue for connection TX notify processing (:kconfig:option:`CONFIG_BT_CONN_TX_NOTIFY_WQ`).
+    This is done to work around the timeout in MPSL flash synchronization (``NCSDK-29354`` known issue).
+    See :ref:`known_issues` for details.
 
 * :ref:`fast_pair_locator_tag` sample:
 

--- a/samples/bluetooth/fast_pair/input_device/prj.conf
+++ b/samples/bluetooth/fast_pair/input_device/prj.conf
@@ -44,6 +44,10 @@ CONFIG_BT_ADV_PROV_GAP_APPEARANCE_SD=y
 #   * nrf5340dk/nrf5340/cpuapp(/ns)
 CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL=-15
 
+# Use a separate workqueue for connection TX notify processing. This is done to work
+# around the MPSL flash synchronization timeout known issue (NCSDK-29354).
+CONFIG_BT_CONN_TX_NOTIFY_WQ=y
+
 # Disable automatic initiation of PHY updates.
 # Workaround to prevent disconnection with reason 42 (BT_HCI_ERR_DIFF_TRANS_COLLISION).
 # Some Android phones reply to the LL_PHY_REQ and at the same time initiate a connection

--- a/samples/bluetooth/fast_pair/locator_tag/configuration/prj.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/configuration/prj.conf
@@ -38,6 +38,10 @@ CONFIG_BT_ADV_PROV_FAST_PAIR=y
 CONFIG_BT_ADV_PROV_DEVICE_NAME=y
 CONFIG_BT_ADV_PROV_DEVICE_NAME_SD=y
 
+# Use a separate workqueue for connection TX notify processing. This is done to work
+# around the MPSL flash synchronization timeout known issue (NCSDK-29354).
+CONFIG_BT_CONN_TX_NOTIFY_WQ=y
+
 # Disable automatic initiation of PHY updates.
 # Workaround to prevent disconnection with reason 42 (BT_HCI_ERR_DIFF_TRANS_COLLISION).
 # Some Android phones reply to the LL_PHY_REQ and at the same time initiate a connection

--- a/samples/bluetooth/fast_pair/locator_tag/configuration/prj_release.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/configuration/prj_release.conf
@@ -50,6 +50,10 @@ CONFIG_BT_ADV_PROV_FAST_PAIR=y
 CONFIG_BT_ADV_PROV_DEVICE_NAME=y
 CONFIG_BT_ADV_PROV_DEVICE_NAME_SD=y
 
+# Use a separate workqueue for connection TX notify processing. This is done to work
+# around the MPSL flash synchronization timeout known issue (NCSDK-29354).
+CONFIG_BT_CONN_TX_NOTIFY_WQ=y
+
 # Disable automatic initiation of PHY updates.
 # Workaround to prevent disconnection with reason 42 (BT_HCI_ERR_DIFF_TRANS_COLLISION).
 # Some Android phones reply to the LL_PHY_REQ and at the same time initiate a connection


### PR DESCRIPTION
Change enables CONFIG_BT_CONN_TX_NOTIFY_WQ to work around the MPSL flash synchronization timeout known issue.

Jira: NCSDK-29354