### PR TITLE
applications: nrf5340_audio: Handle PD=0 in broadcast_sink

### DIFF
--- a/applications/nrf5340_audio/broadcast_sink/main.c
+++ b/applications/nrf5340_audio/broadcast_sink/main.c
@@ -253,7 +253,6 @@ static void le_audio_msg_sub_thread(void)
 
 			ret = audio_datapath_pres_delay_us_set(pres_delay_us);
 			if (ret) {
-				LOG_ERR("Failed to set presentation delay to %d", pres_delay_us);
 				break;
 			}
 

--- a/applications/nrf5340_audio/src/audio/audio_datapath.c
+++ b/applications/nrf5340_audio/src/audio/audio_datapath.c
@@ -866,7 +866,8 @@ ZBUS_LISTENER_DEFINE(sdu_ref_msg_listen, audio_datapath_sdu_ref_update);
 int audio_datapath_pres_delay_us_set(uint32_t delay_us)
 {
 	if (!IN_RANGE(delay_us, CONFIG_AUDIO_MIN_PRES_DLY_US, CONFIG_AUDIO_MAX_PRES_DLY_US)) {
-		LOG_WRN("Presentation delay not supported: %d", delay_us);
+		LOG_WRN("Presentation delay not supported: %d us", delay_us);
+		LOG_WRN("Keeping current value: %d us", ctrl_blk.pres_comp.pres_delay_us);
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
- If presentation delay is set to 0, use the default and print a warning.
- OCT-2952