### PR TITLE
samples: openthread: revert spellcheck fix for THCI

### DIFF
--- a/samples/openthread/cli/harness-thci/nRF_Connect_SDK_11_12.py
+++ b/samples/openthread/cli/harness-thci/nRF_Connect_SDK_11_12.py
@@ -240,7 +240,7 @@ class OpenThreadTHCI(object):
             **kwargs: Arbitrary keyword arguments
                       Includes 'EUI' and 'SerialPort'
         """
-        self.initialize(kwargs)
+        self.intialize(kwargs)
 
     @abstractmethod
     def _connect(self):
@@ -419,7 +419,7 @@ class OpenThreadTHCI(object):
         time.sleep(duration)
 
     @API
-    def initialize(self, params):
+    def intialize(self, params):
         """initialize the serial port with baudrate, timeout parameters"""
         self.mac = params.get("EUI")
         self.backboneNetif = params.get("Param8") or "eth0"

--- a/samples/openthread/cli/harness-thci/nRF_Connect_SDK_13_14.py
+++ b/samples/openthread/cli/harness-thci/nRF_Connect_SDK_13_14.py
@@ -241,7 +241,7 @@ class OpenThreadTHCI(object):
             **kwargs: Arbitrary keyword arguments
                       Includes 'EUI' and 'SerialPort'
         """
-        self.initialize(kwargs)
+        self.intialize(kwargs)
 
     @abstractmethod
     def _connect(self):
@@ -426,7 +426,7 @@ class OpenThreadTHCI(object):
         time.sleep(duration)
 
     @API
-    def initialize(self, params):
+    def intialize(self, params):
         """initialize the serial port with baudrate, timeout parameters"""
         self.mac = params.get("EUI")
         self.backboneNetif = params.get("Param8") or "eth0"


### PR DESCRIPTION
Reverting name change intialize -> initalize. To fix thread harness issues.