### PR TITLE
Applications: Audio: Resolved coverity issues

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/bt_management/scanning/bt_mgmt_scan_for_broadcast.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/scanning/bt_mgmt_scan_for_broadcast.c
@@ -41,7 +41,7 @@ static char const *srch_name;
 static uint32_t srch_brdcast_id = BRDCAST_ID_NOT_USED;
 static struct bt_le_per_adv_sync *pa_sync;
 static const struct bt_bap_scan_delegator_recv_state *req_recv_state;
-static uint8_t bt_mgmt_broadcast_code[BT_AUDIO_BROADCAST_CODE_SIZE];
+static uint8_t bt_mgmt_broadcast_code[BT_ISO_BROADCAST_CODE_SIZE];
 
 struct broadcast_source {
 	char name[BLE_SEARCH_NAME_MAX_LEN];
@@ -363,13 +363,13 @@ static int pa_sync_term_req_cb(struct bt_conn *conn,
 
 static void broadcast_code_cb(struct bt_conn *conn,
 			      const struct bt_bap_scan_delegator_recv_state *recv_state,
-			      const uint8_t broadcast_code[BT_AUDIO_BROADCAST_CODE_SIZE])
+			      const uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE])
 {
 	int ret;
 	struct bt_mgmt_msg msg;
 
 	LOG_DBG("Broadcast code received for %p", (void *)recv_state);
-	memcpy(bt_mgmt_broadcast_code, broadcast_code, BT_AUDIO_BROADCAST_CODE_SIZE);
+	memcpy(bt_mgmt_broadcast_code, broadcast_code, BT_ISO_BROADCAST_CODE_SIZE);
 
 	msg.event = BT_MGMT_BROADCAST_CODE_RECEIVED;
 	ret = zbus_chan_pub(&bt_mgmt_chan, &msg, K_NO_WAIT);

--- a/applications/nrf5340_audio/src/bluetooth/bt_rendering_and_capture/volume/bt_vol_ctlr.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_rendering_and_capture/volume/bt_vol_ctlr.c
@@ -11,8 +11,6 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/audio/vcp.h>
 
-#include "macros_common.h"
-
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_vol_ctlr, CONFIG_BT_VOL_LOG_LEVEL);
 

--- a/applications/nrf5340_audio/src/bluetooth/bt_rendering_and_capture/volume/bt_vol_rend.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_rendering_and_capture/volume/bt_vol_rend.c
@@ -11,7 +11,6 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/audio/vcp.h>
 
-#include "macros_common.h"
 #include "bt_rendering_and_capture.h"
 
 #include <zephyr/logging/log.h>

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/broadcast_sink.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/broadcast_sink.c
@@ -446,7 +446,15 @@ static void base_recv_cb(struct bt_bap_broadcast_sink *sink, const struct bt_bap
 
 	if (suitable_stream_found) {
 		/* Set the initial active stream based on the defined channel of the device */
-		channel_assignment_get((enum audio_channel *)&active_stream_index);
+		enum audio_channel audio_channel_temp;
+
+		channel_assignment_get(&audio_channel_temp);
+		if (audio_channel_temp > AUDIO_CH_NUM) {
+			LOG_ERR("Invalid channel assignment");
+			return;
+		}
+
+		active_stream_index = (uint8_t)audio_channel_temp;
 
 		/** If the stream matching channel is not present, revert back to first BIS, e.g.
 		 *  mono stream but channel assignment is RIGHT

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/broadcast_source.h
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/broadcast_source.h
@@ -100,7 +100,7 @@ struct broadcast_source_big {
 	uint8_t num_subgroups;
 	uint8_t packing;
 	bool encryption;
-	uint8_t broadcast_code[BT_AUDIO_BROADCAST_CODE_SIZE + 1];
+	uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE];
 	char broadcast_name[BROADCAST_SOURCE_ADV_NAME_MAX + 1];
 	char adv_name[CONFIG_BT_DEVICE_NAME_MAX + 1];
 	bool fixed_id;

--- a/applications/nrf5340_audio/src/modules/lc3_streamer.c
+++ b/applications/nrf5340_audio/src/modules/lc3_streamer.c
@@ -20,6 +20,10 @@ struct k_work_q lc3_streamer_work_q;
 
 #define LC3_STREAMER_BUFFER_NUM_FRAMES 2
 
+#if CONFIG_SD_CARD_LC3_STREAMER_MAX_NUM_STREAMS > UINT8_MAX
+#error "CONFIG_SD_CARD_LC3_STREAMER_MAX_NUM_STREAMS must be less than or equal to UINT8_MAX"
+#endif
+
 enum lc3_stream_states {
 	/* Stream ready to load file and start streaming */
 	STREAM_IDLE = 0,
@@ -342,7 +346,7 @@ int lc3_streamer_stream_register(const char *const filename, uint8_t *const stre
 	}
 
 	/* Check that there's room for the filename and a NULL terminating char */
-	if (strlen(filename) > CONFIG_FS_FATFS_MAX_LFN - 1) {
+	if (strlen(filename) > (ARRAY_SIZE(streams[*streamer_idx].filename) - 1)) {
 		LOG_ERR("Filename too long");
 		return -EINVAL;
 	}
@@ -369,7 +373,7 @@ int lc3_streamer_stream_register(const char *const filename, uint8_t *const stre
 		return ret;
 	}
 
-	strncpy(streams[*streamer_idx].filename, filename, strlen(filename));
+	strcpy(streams[*streamer_idx].filename, filename);
 
 	ret = data_fifo_init(&streams[*streamer_idx].fifo);
 	if (ret) {

--- a/applications/nrf5340_audio/src/modules/lc3_streamer.h
+++ b/applications/nrf5340_audio/src/modules/lc3_streamer.h
@@ -65,7 +65,7 @@ bool lc3_streamer_file_compatible_check(const char *const filename,
  *
  * @retval 0		Success.
  * @retval -EINVAL	Invalid filename or streamer_idx.
- * @retval -EAGAIN	No stream slot is available
+ * @retval -EAGAIN	No stream slot is available.
  * @retval -EFAULT	Module has not been initialized.
  */
 int lc3_streamer_stream_register(const char *const filename, uint8_t *const streamer_idx,

--- a/samples/bluetooth/broadcast_config_tool/src/main.c
+++ b/samples/bluetooth/broadcast_config_tool/src/main.c
@@ -1599,9 +1599,9 @@ static int cmd_encrypt(const struct shell *shell, size_t argc, char **argv)
 			return -EINVAL;
 		}
 
-		if (strlen(argv[3]) > BT_AUDIO_BROADCAST_CODE_SIZE) {
+		if (strlen(argv[3]) > BT_ISO_BROADCAST_CODE_SIZE) {
 			shell_error(shell, "Broadcast code must be %d characters long",
-				    BT_AUDIO_BROADCAST_CODE_SIZE);
+				    BT_ISO_BROADCAST_CODE_SIZE);
 			return -EINVAL;
 		}
 		memset(broadcast_param[big_index].broadcast_code, '\0',


### PR DESCRIPTION
- OCT-3180
- Removed all BT_AUDIO_BROADCAST_CODE_SIZE. Ref: https://github.com/zephyrproject-rtos/zephyr/pull/80217