### PR TITLE
manifest: Update MCUboot with fix removing default mbedTSL cfg

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -132,7 +132,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 720fa02787366f9f787b847194f6814921147770
+      revision: 68b96b802cdeef77ce4200e776afa46f6d3cfb66
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR


### PR DESCRIPTION
The commit updates sdk-mcuboot to bring in [nrf noup] commit that removed setting default mbedTSL configuration in prj.conf, CONFIG_MBEDTLS_CFG_FILE="mcuboot-mbedtls-cfg.h",
that was overriding setting nrf-config.h, as the configuration.