### PR TITLE
samples: protocols_serialization: server: use PSA for SMP

### DIFF
--- a/samples/nrf_rpc/protocols_serialization/server/Kconfig
+++ b/samples/nrf_rpc/protocols_serialization/server/Kconfig
@@ -22,6 +22,20 @@ config LOG_BACKEND_RTT
 config LOG_BACKEND_UART
 	default n
 
+if SOC_NRF54L15
+
+config BT_CTLR_ECDH
+	default n
+
+config BT_USE_PSA_API
+	default y if BT_TINYCRYPT_ECC
+	select PSA_WANT_ALG_ECB_NO_PADDING
+
+config BT_LONG_WQ_STACK_SIZE
+	default 2048 if BT_USE_PSA_API
+
+endif
+
 config NRF_PS_SERVER_FATAL_ERROR_TRIGGER
 	bool "Fatal error trigger"
 	help


### PR DESCRIPTION
Default to using host crypto that employs PSA crypto API when SMP gets enabled. This removes the dependency on oberon and reduces the code size when using both "ble" and "openthread" snippets since OpenThread already uses PSA.
Increase BT long work stack size when PSA is used by BLE to avoid stack overflows.