### PR TITLE
samples: matter: Add support for migrating DAC to KMU fo NRF54L

### DIFF
--- a/doc/nrf/protocols/matter/end_product/security.rst
+++ b/doc/nrf/protocols/matter/end_product/security.rst
@@ -111,7 +111,7 @@ This is a reference configuration that can be modified in the production firmwar
      - PSA Crypto API
      - CRACEN [2]_
      - Yes
-     - Trusted Storage library + Hardware Unique Key (HUK)
+     - Trusted Storage library + Hardware Unique Key (HUK) + Key Management Unit (KMU)
    * - nRF54L15 SoC + Trusted Firmware-M (TF-M)
      - Thread
      - PSA Crypto API
@@ -128,6 +128,84 @@ This is a reference configuration that can be modified in the production firmwar
        For all other operations not supported by CRACEN, the Oberon backend is used.
        To use the Oberon backend for specific cryptographic operations supported by both drivers, disable those operations in the CRACEN driver, as it takes priority when both are enabled.
        See the :ref:`nrf_security_drivers` documentation for more information.
+
+.. _matter_platforms_security_dac_priv_key:
+
+Storing Device Attestation Certificate private key
+**************************************************
+
+In Matter samples based on the PSA crypto API, the Device Attestation Certificate's private key, which exists in the factory data set, can be migrated to secure storage.
+The secure storage used depends on the platform and the cryptographic backend.
+
+To enable the migration of the DAC private key from the factory data set to secure storage, set the :kconfig:option:`CONFIG_CHIP_CRYPTO_PSA_MIGRATE_DAC_PRIV_KEY` Kconfig option to ``y``.
+
+Currently, this feature is available only for the PSA crypto API.
+See the following table to learn about the default secure storage backends for the DAC private key and the available secure storage backends for each platform:
+
+.. list-table:: Matter secure storage
+   :widths: auto
+   :header-rows: 1
+
+   * - Platform
+     - Default secure storage backend for DAC private key
+     - Available secure storage backends
+   * - nRF52840 SoC
+     - Trusted Storage library + SHA-256 hash
+     - Trusted Storage library + SHA-256 hash
+   * - nRF5340 SoC
+     - Trusted Storage library + Hardware Unique Key (HUK)
+     - | Trusted Storage library + Hardware Unique Key (HUK),
+       | Trusted Storage library + SHA-256 hash
+   * - nRF5340 SoC + nRF7002 companion IC
+     - Not available
+     - Not available
+   * - nRF54L15 SoC
+     - Trusted Storage library + Hardware Unique Key (HUK)
+     - | Key Management Unit (KMU),
+       | Trusted Storage library + Hardware Unique Key (HUK),
+       | Trusted Storage library + SHA-256 hash
+   * - nRF54L15 SoC + Trusted Firmware-M (TF-M)
+     - Trusted Firmware-M (TF-M) Storage
+     - | Key Management Unit (KMU),
+       | Trusted Firmware-M (TF-M) Storage
+
+.. _matter_platforms_security_dac_priv_key_its:
+
+DAC in Trusted Storage library
+==============================
+
+The Device Attestation Certificates private key can be stored in the Trusted Storage library.
+The key is encrypted with the AEAD key derived from the Hardware Unique Key (HUK) or a SHA-256 hash.
+This storage backend is selected by default for all platforms that support the PSA crypto API.
+
+To enable storing the DAC private key in the Trusted Storage library, set the :kconfig:option:`CONFIG_CHIP_CRYPTO_PSA_DAC_PRIV_KEY_ITS` Kconfig option to ``y``.
+To select which encryption to use, set one of the following Kconfig options:
+
+- To use key derivation from HUK, set :kconfig:option:`CONFIG_TRUSTED_STORAGE_BACKEND_AEAD_KEY_DERIVE_FROM_HUK` to ``y``.
+- To use key derivation from a SHA-256 hash, set :kconfig:option:`CONFIG_TRUSTED_STORAGE_BACKEND_AEAD_KEY_HASH_UID` to ``y``.
+
+Encryption with the AEAD key derived from the Hardware Unique Key (HUK) is available only on the nRF5340 and nRF54L platforms.
+
+.. _matter_platforms_security_dac_priv_key_kmu:
+
+DAC in Key Management Unit (KMU)
+================================
+
+The Key Management Unit (KMU) is a hardware peripheral that provides secure storage for cryptographic keys.
+It is available in the nRF54L Series SoCs and can be used to store the DAC private key.
+This storage backend can be used with Trusted Firmware-M (TF-M).
+
+You can enable storing the DAC private key in the KMU by setting the :kconfig:option:`CONFIG_CHIP_CRYPTO_PSA_DAC_PRIV_KEY_KMU` Kconfig option to ``y``.
+
+You can additionally encrypt the DAC private key in the KMU storage by setting the :kconfig:option:`CONFIG_CHIP_CRYPTO_PSA_DAC_PRIV_KEY_KMU_ENCRYPTED` Kconfig option to ``y``.
+This operation requires two additional KMU slots to store the nonce and the authentication tag, making the total number of slots used four.
+If the :kconfig:option:`CONFIG_CHIP_CRYPTO_PSA_DAC_PRIV_KEY_KMU_ENCRYPTED` Kconfig option is set to ``n``, then the DAC private key is stored in the KMU without encryption and utilizes two KMU slots.
+
+By default, the DAC private key occupies the last slots dedicated for application purposes.
+For the non-encrypted version, it occupies last two slots (178 and 179), and for the encrypted version, it occupies the last four slots (176-179).
+You can change the default slots by setting the :kconfig:option:`CONFIG_CHIP_CRYPTO_PSA_DAC_PRIV_KEY_KMU_SLOT` Kconfig option to the first slot number of the desired slots, making sure that all slots fit within the possible range.
+This means you can set it to slot numbers 0-176 for encrypted, or 0-178 for non-encrypted.
+To read more about KMU slots, see the :ref:`ug_nrf54l_crypto_kmu_slots` section of the :ref:`ug_nrf54l_cryptography` page, which details the KMU peripheral.
 
 Securing production devices
 ***************************

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -219,6 +219,8 @@ Matter
   * The :ref:`ug_matter_device_memory_profiling` section to the :ref:`ug_matter_device_optimizing_memory` page.
     The section contains useful commands for measuring memory and troubleshooting tips.
   * The ZMS file subsystem to all devices that contain RRAM, such as the nRF54L Series devices.
+  * Migration of the Device Attestation Certificates private key to Key Management Unit (KMU) for the nRF54L Series SoCs.
+    See :ref:`matter_platforms_security_dac_priv_key_kmu` to learn how to enable it in your sample.
 
 * Changed:
 
@@ -227,6 +229,8 @@ Matter
     The new Kconfig option now works for both NVS and ZMS file system backends.
   * The firmware version format used for informational purposes when using the :file:``VERSION`` file.
     The format now includes the optional ``EXTRAVERSION`` component.
+  * Storing the Device Attestation Certificates private key in the Trusted Storage library to be enabled for all platforms that support the PSA crypto API.
+    See :ref:`matter_platforms_security_dac_priv_key_its` for more information.
 
 Matter fork
 +++++++++++
@@ -597,6 +601,10 @@ Matter samples
 * :ref:`matter_lock_sample` sample:
 
     * Added :ref:`Matter Lock schedule snippet <matter_lock_snippets>`, and updated the documentation to use the snippet.
+
+* :ref:`matter_template_sample` sample:
+
+    * Updated the DAC private key migration from factory data to KMU to be enabled for the nRF54L Series SoCs by default.
 
 * Enabled the :ref:`ug_thread_build_report` generation in all samples.
 * Removed support for the nRF54L15 PDK in all samples.

--- a/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -21,3 +21,6 @@ CONFIG_MBEDTLS_THREADING_C=n
 # Workaround required as Zephyr L2 implies usage of NVS backend for settings.
 # It should be removed once the proper fix will be applied in Zephyr.
 CONFIG_NVS=n
+
+# Enable DAC key migration to KMU
+CONFIG_CHIP_CRYPTO_PSA_DAC_PRIV_KEY_KMU=y

--- a/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
+++ b/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
@@ -22,3 +22,6 @@ CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
 # Workaround required as Zephyr L2 implies usage of NVS backend for settings.
 # It should be removed once the proper fix will be applied in Zephyr.
 CONFIG_NVS=n
+
+# Enable DAC key migration to KMU
+CONFIG_CHIP_CRYPTO_PSA_DAC_PRIV_KEY_KMU=y

--- a/west.yml
+++ b/west.yml
@@ -161,7 +161,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 1fb979258d6bf71c2cb049d24d97a087e7a2de0c
+      revision: 5580536ab0013db53ef7e0607638e1943400e5ae
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
Device Attestation Certificates private key can be migrated from factory data to Key Management Unit (KMU) on nRF54L SoC series now in Matter samples.
Added support and documentation.