### PR TITLE
samples: protocols_serialization: client: fix "ot thread"

### DIFF
--- a/samples/nrf_rpc/protocols_serialization/client/src/ot_shell.c
+++ b/samples/nrf_rpc/protocols_serialization/client/src/ot_shell.c
@@ -330,11 +330,11 @@ static otError ot_cli_command_state(const struct shell *sh, size_t argc, char *a
 
 static otError ot_cli_command_thread(const struct shell *sh, size_t argc, char *argv[])
 {
-	if (strcmp(argv[2], "start")) {
+	if (strcmp(argv[1], "start") == 0) {
 		return otThreadSetEnabled(NULL, true);
 	}
 
-	if (strcmp(argv[2], "stop")) {
+	if (strcmp(argv[1], "stop") == 0) {
 		return otThreadSetEnabled(NULL, false);
 	}
 


### PR DESCRIPTION
Fix argument parsing for "ot thread" shell command to be able to properly stop thread.