### PR TITLE
bluetooth: controller: option to defer unknown VS commands

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -112,6 +112,12 @@ config SYSTEM_WORKQUEUE_STACK_SIZE
 	int
 	default 2048 if BT_LL_SOFTDEVICE
 
+config BT_CTLR_SDC_VS_CMD_UNKNOWN_APP_HANDLE
+	bool "Defer handling of unknown vendor-specific commands to the application"
+	help
+	  If an unknown vendor-specific command is received, forward it to the application for
+	  handling instead of dropping. The expected function name is `sdc_hci_cmd_vs_app_put`.
+
 config BT_CTLR_SDC_LLPM
 	bool "Enable Low Latency Packet Mode support"
 	select BT_CONN_PARAM_ANY if !BT_HCI_RAW

--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -1630,6 +1630,9 @@ static uint8_t le_controller_cmd_put(uint8_t const * const cmd,
 	}
 }
 
+uint8_t sdc_hci_cmd_vs_app_put(uint8_t const *const cmd, uint8_t *const raw_event_out,
+			       uint8_t *param_length_out);
+
 #if defined(CONFIG_BT_HCI_VS)
 static uint8_t vs_cmd_put(uint8_t const *const cmd, uint8_t *const raw_event_out,
 			  uint8_t *param_length_out)
@@ -1773,7 +1776,11 @@ static uint8_t vs_cmd_put(uint8_t const *const cmd, uint8_t *const raw_event_out
 		(sdc_hci_cmd_vs_conn_anchor_point_update_event_report_enable_t const *)cmd_params);
 #endif
 	default:
+#if defined(CONFIG_BT_CTLR_SDC_VS_CMD_UNKNOWN_APP_HANDLE)
+		return sdc_hci_cmd_vs_app_put(cmd, raw_event_out, param_length_out);
+#else
 		return BT_HCI_ERR_UNKNOWN_CMD;
+#endif
 	}
 }
 #endif /* CONFIG_BT_HCI_VS */


### PR DESCRIPTION
Add a Kconfig option to enable deferring the handling of unknown vendor specific commands to the application, instead of unconditionally dropping them.

The expected use case for this option is for re-using the already present HCI link between two separate microcontrollers (e.g. nRF91 + nRF52) as a communications channel. The obvious way to enable this is through a vendor specific command, but this requires the HCI shim to not unconditionally drop commands it does not know about.

An alternate implementation option is to register a callback function with a dedicated function (`sdc_register_default_vs_handler` or similar), instead of hardcoding the expected function name. The current approach does have precedence in the LTE modem fault handling code however.

Changelog will be added once implementation is confirmed