### PR TITLE
applications: Fixed assert on Matter bridge

### DIFF
--- a/applications/matter_bridge/src/simulated_providers/simulated_humidity_sensor_data_provider.cpp
+++ b/applications/matter_bridge/src/simulated_providers/simulated_humidity_sensor_data_provider.cpp
@@ -56,24 +56,23 @@ void SimulatedHumiditySensorDataProvider::TimerTimeoutCallback(k_timer *timer)
 		return;
 	}
 
-	SimulatedHumiditySensorDataProvider *provider =
-		reinterpret_cast<SimulatedHumiditySensorDataProvider *>(timer->user_data);
+	DeviceLayer::PlatformMgr().ScheduleWork(
+		[](intptr_t p) {
+			SimulatedHumiditySensorDataProvider *provider =
+				reinterpret_cast<SimulatedHumiditySensorDataProvider *>(p);
 
-	/* Get some random data to emulate sensor measurements. */
-	provider->mHumidity =
-		chip::Crypto::GetRandU16() % (kMaxRandomTemperature - kMinRandomTemperature) + kMinRandomTemperature;
+			/* Get some random data to emulate sensor measurements. */
+			provider->mHumidity =
+				chip::Crypto::GetRandU16() % (kMaxRandomTemperature - kMinRandomTemperature) +
+				kMinRandomTemperature;
 
-	LOG_INF("SimulatedHumiditySensorDataProvider: Updated humidity value to %d", provider->mHumidity);
+			LOG_INF("SimulatedHumiditySensorDataProvider: Updated humidity value to %d",
+				provider->mHumidity);
 
-	DeviceLayer::PlatformMgr().ScheduleWork(NotifyAttributeChange, reinterpret_cast<intptr_t>(provider));
-}
-
-void SimulatedHumiditySensorDataProvider::NotifyAttributeChange(intptr_t context)
-{
-	SimulatedHumiditySensorDataProvider *provider =
-		reinterpret_cast<SimulatedHumiditySensorDataProvider *>(context);
-
-	provider->NotifyUpdateState(Clusters::RelativeHumidityMeasurement::Id,
-				    Clusters::RelativeHumidityMeasurement::Attributes::MeasuredValue::Id,
-				    &provider->mHumidity, sizeof(provider->mHumidity));
+			provider->NotifyUpdateState(
+				Clusters::RelativeHumidityMeasurement::Id,
+				Clusters::RelativeHumidityMeasurement::Attributes::MeasuredValue::Id,
+				&provider->mHumidity, sizeof(provider->mHumidity));
+		},
+		reinterpret_cast<intptr_t>(timer->user_data));
 }

--- a/applications/matter_bridge/src/simulated_providers/simulated_humidity_sensor_data_provider.h
+++ b/applications/matter_bridge/src/simulated_providers/simulated_humidity_sensor_data_provider.h
@@ -17,8 +17,6 @@ public:
 			       size_t dataSize) override;
 	CHIP_ERROR UpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer) override;
 
-	static void NotifyAttributeChange(intptr_t context);
-
 private:
 	static void TimerTimeoutCallback(k_timer *timer);
 

--- a/applications/matter_bridge/src/simulated_providers/simulated_temperature_sensor_data_provider.cpp
+++ b/applications/matter_bridge/src/simulated_providers/simulated_temperature_sensor_data_provider.cpp
@@ -56,24 +56,22 @@ void SimulatedTemperatureSensorDataProvider::TimerTimeoutCallback(k_timer *timer
 		return;
 	}
 
-	SimulatedTemperatureSensorDataProvider *provider =
-		reinterpret_cast<SimulatedTemperatureSensorDataProvider *>(timer->user_data);
+	DeviceLayer::PlatformMgr().ScheduleWork(
+		[](intptr_t p) {
+			SimulatedTemperatureSensorDataProvider *provider =
+				reinterpret_cast<SimulatedTemperatureSensorDataProvider *>(p);
 
-	/* Get some random data to emulate sensor measurements. */
-	provider->mTemperature =
-		chip::Crypto::GetRandU16() % (kMaxRandomTemperature - kMinRandomTemperature) + kMinRandomTemperature;
+			/* Get some random data to emulate sensor measurements. */
+			provider->mTemperature =
+				chip::Crypto::GetRandU16() % (kMaxRandomTemperature - kMinRandomTemperature) +
+				kMinRandomTemperature;
 
-	LOG_INF("SimulatedTemperatureSensorDataProvider: Updated temperature value to %d", provider->mTemperature);
+			LOG_INF("SimulatedTemperatureSensorDataProvider: Updated temperature value to %d",
+				provider->mTemperature);
 
-	DeviceLayer::PlatformMgr().ScheduleWork(NotifyAttributeChange, reinterpret_cast<intptr_t>(provider));
-}
-
-void SimulatedTemperatureSensorDataProvider::NotifyAttributeChange(intptr_t context)
-{
-	SimulatedTemperatureSensorDataProvider *provider =
-		reinterpret_cast<SimulatedTemperatureSensorDataProvider *>(context);
-
-	provider->NotifyUpdateState(Clusters::TemperatureMeasurement::Id,
-				    Clusters::TemperatureMeasurement::Attributes::MeasuredValue::Id,
-				    &provider->mTemperature, sizeof(provider->mTemperature));
+			provider->NotifyUpdateState(Clusters::TemperatureMeasurement::Id,
+						    Clusters::TemperatureMeasurement::Attributes::MeasuredValue::Id,
+						    &provider->mTemperature, sizeof(provider->mTemperature));
+		},
+		reinterpret_cast<intptr_t>(timer->user_data));
 }

--- a/applications/matter_bridge/src/simulated_providers/simulated_temperature_sensor_data_provider.h
+++ b/applications/matter_bridge/src/simulated_providers/simulated_temperature_sensor_data_provider.h
@@ -12,7 +12,9 @@
 
 class SimulatedTemperatureSensorDataProvider : public Nrf::BridgedDeviceDataProvider {
 public:
-	SimulatedTemperatureSensorDataProvider(UpdateAttributeCallback updateCallback, InvokeCommandCallback commandCallback) : Nrf::BridgedDeviceDataProvider(updateCallback, commandCallback)
+	SimulatedTemperatureSensorDataProvider(UpdateAttributeCallback updateCallback,
+					       InvokeCommandCallback commandCallback)
+		: Nrf::BridgedDeviceDataProvider(updateCallback, commandCallback)
 	{
 	}
 	~SimulatedTemperatureSensorDataProvider() { k_timer_stop(&mTimer); }
@@ -23,8 +25,6 @@ public:
 	CHIP_ERROR UpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer) override;
 
 private:
-	static void NotifyAttributeChange(intptr_t context);
-
 	static constexpr uint16_t kMeasurementsIntervalMs = 10000;
 	static constexpr int16_t kMinRandomTemperature = -10;
 	static constexpr int16_t kMaxRandomTemperature = 10;

--- a/samples/matter/common/src/bridge/matter_bridged_device.h
+++ b/samples/matter/common/src/bridge/matter_bridged_device.h
@@ -135,8 +135,6 @@ public:
 	static constexpr uint16_t GetIdentifyClusterRevision() { return 4; }
 	static constexpr uint32_t GetIdentifyClusterFeatureMap() { return 0; }
 
-	static void NotifyAttributeChange(intptr_t context);
-
 	EmberAfEndpointType *mEp;
 	const EmberAfDeviceType *mDeviceTypeList;
 	size_t mDeviceTypeListSize;


### PR DESCRIPTION
After the last Zephyr up-merge, getting rand number from the timer callback leads to the crypto assert.
Added scheduling rand operation to the application event.