### PR TITLE
boards: thingy91x: add secondary_1 partitions

### DIFF
--- a/boards/nordic/thingy91x/thingy91x_nrf5340_pm_static.yml
+++ b/boards/nordic/thingy91x/thingy91x_nrf5340_pm_static.yml
@@ -43,7 +43,7 @@ s1_image:
   region: flash_primary
 mcuboot_primary:
   address: 0x30000
-  size: 0x64000
+  size: 0x44000
   span: [mcuboot_pad, app]
   region: flash_primary
 mcuboot_pad:
@@ -52,22 +52,26 @@ mcuboot_pad:
   region: flash_primary
 mcuboot_primary_app:
   address: 0x30200
-  size: 0x63e00
+  size: 0x43e00
   span: [app]
   region: flash_primary
 app_image:
   address: 0x30200
-  size: 0x63e00
+  size: 0x43e00
   span: [app]
   region: flash_primary
 app:
   address: 0x30200
-  size: 0x63e00
+  size: 0x43e00
   region: flash_primary
 mcuboot_secondary:
-  address: 0x94000
-  size: 0x64000
+  address: 0x74000
+  size: 0x44000
   region: flash_primary
+mcuboot_secondary_1:
+  address: 0xB8000
+  region: flash_primary
+  size: 0x40000
 settings_storage:
   address: 0xf8000
   size: 0x8000

--- a/boards/nordic/thingy91x/thingy91x_nrf5340_pm_static_ext_flash.yml
+++ b/boards/nordic/thingy91x/thingy91x_nrf5340_pm_static_ext_flash.yml
@@ -70,16 +70,21 @@ settings_storage:
   region: flash_primary
 
 external_flash:
-  device: GD25LB256E
+  device: DT_CHOSEN(nordic_pm_ext_flash)
   address: 0x0
   size: 0x2000000
   span: [mcuboot_secondary]
   region: external_flash
 mcuboot_secondary:
-  device: GD25LB256E
+  device: DT_CHOSEN(nordic_pm_ext_flash)
   address: 0x0
   size: 0xcc000
   share_size: [mcuboot_primary]
+  region: external_flash
+mcuboot_secondary_1:
+  address: 0xcc000
+  size: 0x40000
+  device: DT_CHOSEN(nordic_pm_ext_flash)
   region: external_flash
 pcd_sram:
   address: 0x20000000


### PR DESCRIPTION
This patch adds the secondary_1 partitions to thingy91x/nrf53 to ensure a working mcuboot setup.