### PR TITLE
suitfu: Allow to skip DFU initialization

### DIFF
--- a/subsys/mgmt/suitfu/Kconfig
+++ b/subsys/mgmt/suitfu/Kconfig
@@ -4,10 +4,8 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-menu "SUIT-based Firmware Update Management"
-
-config MGMT_SUITFU
-	bool "Serial SUIT Firmware Update support"
+menuconfig MGMT_SUITFU
+	bool "SUIT-based Firmware Update Management"
 	depends on MCUMGR
 	depends on SSF_SUIT_SERVICE_ENABLED
 	depends on FLASH
@@ -15,6 +13,16 @@ config MGMT_SUITFU
 	select MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_5
 	select MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_3
 
+if MGMT_SUITFU
+
+config MGMT_SUITFU_INITIALIZE_SUIT
+	bool "Initialize the SUIT DFU library on startup"
+	default y
+	help
+	  If enabled, SUIT modules will be enabled using the suit_dfu_initialize()
+	  as part of the system startup.
+	  Otherwise, this API must be called if a device uses SUIT DFU, before any
+	  transport layer (such as SMP server, DFU target, USB) is initialized.
 
 config MGMT_SUITFU_TRIGGER_UPDATE_RESET_DELAY_MS
 	int "Delay between update trigger and the last firmware chunk, in ms"
@@ -92,4 +100,4 @@ module-dep=LOG
 module-str=SUIT-based Firmware Update Management
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
 
-endmenu
+endif # MGMT_SUITFU

--- a/subsys/mgmt/suitfu/src/suitfu_mgmt.c
+++ b/subsys/mgmt/suitfu/src/suitfu_mgmt.c
@@ -261,7 +261,11 @@ int suitfu_mgmt_init(void)
 #ifdef CONFIG_MGMT_SUITFU_GRP_OS_BOOTLOADER_INFO_HOOK
 	suitfu_mgmt_register_bootloader_info_hook();
 #endif /* CONFIG_MGMT_SUITFU_GRP_OS_BOOTLOADER_INFO_HOOK */
+#ifdef CONFIG_MGMT_SUITFU_INITIALIZE_SUIT
 	return suit_dfu_initialize();
+#else
+	return 0;
+#endif /* CONFIG_MGMT_SUITFU_INITIALIZE_SUIT */
 }
 
 SYS_INIT(suitfu_mgmt_init, APPLICATION, 0);

--- a/subsys/suit/cache/src/suit_dfu_cache_helpers.c
+++ b/subsys/suit/cache/src/suit_dfu_cache_helpers.c
@@ -149,6 +149,10 @@ suit_plat_err_t suit_dfu_cache_partition_is_initialized(struct dfu_cache_pool *p
 			return SUIT_PLAT_ERR_NOT_FOUND;
 		}
 
+		if (err != SUIT_PLAT_SUCCESS) {
+			return SUIT_PLAT_ERR_IO;
+		}
+
 		return SUIT_PLAT_SUCCESS;
 	}
 

--- a/subsys/suit/cache/src/suit_dfu_cache_internal.h
+++ b/subsys/suit/cache/src/suit_dfu_cache_internal.h
@@ -62,7 +62,9 @@ suit_plat_err_t suit_dfu_cache_partition_slot_foreach(struct dfu_cache_pool *cac
  *
  * @param cache_pool  Pointer to the SUIT cache pool structure.
  *
- * @return SUIT_PLAT_SUCCESS in case of success, otherwise error code
+ * @retval SUIT_PLAT_ERR_IO        if unable to read parition contents.
+ * @retval SUIT_PLAT_ERR_NOT_FOUND if partition contains inconsistent data.
+ * @retval SUIT_PLAT_SUCCESS       if partition initialized.
  */
 suit_plat_err_t suit_dfu_cache_partition_is_initialized(struct dfu_cache_pool *cache_pool);
 
@@ -86,8 +88,7 @@ suit_plat_err_t suit_dfu_cache_partition_is_empty(struct dfu_cache_pool *cache_p
  * @return SUIT_PLAT_SUCCESS in case of success, otherwise error code
  */
 suit_plat_err_t suit_dfu_cache_partition_find_free_space(struct dfu_cache_pool *cache_pool,
-							 uintptr_t *address,
-							 bool *needs_erase);
+							 uintptr_t *address, bool *needs_erase);
 
 /**
  * @brief Memcpy-like helper for writing streamable data into a memory buffer.

--- a/subsys/suit/cache/src/suit_dfu_cache_rw.c
+++ b/subsys/suit/cache/src/suit_dfu_cache_rw.c
@@ -456,7 +456,7 @@ suit_plat_err_t suit_dfu_cache_validate_content(void)
 
 			suit_plat_err_t err = suit_dfu_cache_partition_is_initialized(&cache_pool);
 
-			if (err != SUIT_PLAT_SUCCESS) {
+			if (err == SUIT_PLAT_ERR_NOT_FOUND) {
 				LOG_INF("DFU Cache pool, id: %d does not contain valid content",
 					partition->id);
 
@@ -466,6 +466,10 @@ suit_plat_err_t suit_dfu_cache_validate_content(void)
 						partition->id);
 					erase_on_sink(partition->address, partition->size);
 				}
+			} else if (err != SUIT_PLAT_SUCCESS) {
+				LOG_ERR("DFU Cache pool, id: %d unavailable, err: %d",
+					partition->id, err);
+				return err;
 			}
 		}
 	}


### PR DESCRIPTION
Add Kconfig to skip SUIT DFU module initialization on system startup.

Ref: NCSDK-NONE