### PR TITLE
samples: crypto: Added missing mbed TLS heap configuration

### DIFF
--- a/samples/crypto/aes_gcm/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/crypto/aes_gcm/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
+CONFIG_PSA_CRYPTO_DRIVER_CRACEN=y
+
+# Mbedtls configuration
+CONFIG_MBEDTLS_ENABLE_HEAP=y
+CONFIG_MBEDTLS_HEAP_SIZE=8192

--- a/samples/crypto/ecjpake/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/crypto/ecjpake/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
+CONFIG_PSA_CRYPTO_DRIVER_CRACEN=y
+
+# Mbedtls configuration
+CONFIG_MBEDTLS_ENABLE_HEAP=y
+CONFIG_MBEDTLS_HEAP_SIZE=8192

--- a/samples/crypto/eddsa/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/crypto/eddsa/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
+CONFIG_PSA_CRYPTO_DRIVER_CRACEN=y
+
+# Mbedtls configuration
+CONFIG_MBEDTLS_ENABLE_HEAP=y
+CONFIG_MBEDTLS_HEAP_SIZE=8192

--- a/samples/crypto/pbkdf2/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/crypto/pbkdf2/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
+CONFIG_PSA_CRYPTO_DRIVER_CRACEN=y
+
+# Mbedtls configuration
+CONFIG_MBEDTLS_ENABLE_HEAP=y
+CONFIG_MBEDTLS_HEAP_SIZE=8192

--- a/samples/crypto/spake2p/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/samples/crypto/spake2p/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+# Using hardware crypto accelerator
+CONFIG_PSA_CRYPTO_DRIVER_OBERON=y
+CONFIG_PSA_CRYPTO_DRIVER_CC3XX=y
+
+# Mbedtls configuration
+CONFIG_MBEDTLS_ENABLE_HEAP=y
+CONFIG_MBEDTLS_HEAP_SIZE=8192

--- a/samples/crypto/spake2p/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/crypto/spake2p/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
+CONFIG_PSA_CRYPTO_DRIVER_CRACEN=y
+
+# Mbedtls configuration
+CONFIG_MBEDTLS_ENABLE_HEAP=y
+CONFIG_MBEDTLS_HEAP_SIZE=8192


### PR DESCRIPTION
A few crypto sample targets were missing proper mbed TLS heap configuration.

test_crypto: PR-682