### PR TITLE
nrf_security: Fix MBEDTLS_CFG_FILE Kconfig symbol

### DIFF
--- a/subsys/nrf_security/Kconfig
+++ b/subsys/nrf_security/Kconfig
@@ -61,11 +61,7 @@ config MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS
 	  Promptless option used to control if the PSA Crypto core should have support for builtin keys or not.
 
 config MBEDTLS_CFG_FILE
-	string "mbed TLS configuration file"
 	default "nrf-config.h"
-	help
-	  Name of the config file for mbed TLS. This configuration file is used
-	  in configurations with or without PSA APIs supported.
 
 config MBEDTLS_PSA_CRYPTO_CONFIG
 	bool


### PR DESCRIPTION
Removes a prompt, type and duplicated help text from this symbol as this is an override symbol only