### PR TITLE
bluetooth: controller: hci_driver: Add option to enable power class 1

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -584,5 +584,13 @@ config BT_CTLR_SDC_CS_COUNT
 	help
 	  Set the number of concurrent connections that can support Channel Sounding procedure.
 
+config BT_CTLR_SDC_LE_POWER_CLASS_1
+	bool "Device supports transmitting at LE Power Class 1 level"
+	default y if BT_CTLR_TX_PWR_ANTENNA >= 10
+	help
+	  This should be set if the device supports transmitting above +10dBm.
+	  See Bluetooth Core Specification, Vol 6, Part A, Section 3
+	  Transmitter Characteristics for more information.
+
 endmenu
 endif  # BT_LL_SOFTDEVICE

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -945,6 +945,13 @@ static int configure_supported_features(void)
 		}
 	}
 
+	if (IS_ENABLED(CONFIG_BT_CTLR_SDC_LE_POWER_CLASS_1)) {
+		err = sdc_support_le_power_class_1();
+		if (err) {
+			return -ENOTSUP;
+		}
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
This KConfig enables the feature bit for power class 1 in the controller.

Required if a customer wants to transmit at >10dBm