### PR TITLE
suit: Add tests for suit_execution_mode_failed

### DIFF
--- a/tests/subsys/suit/orchestrator/orchestrator_sdfw/src/test_boot_mode.c
+++ b/tests/subsys/suit/orchestrator/orchestrator_sdfw/src/test_boot_mode.c
@@ -161,6 +161,12 @@ ZTEST(orchestrator_boot_tests, test_boot_invalid_exec_mode)
 	/* ... and the execution mode remains unchanged */
 	zassert_equal(EXECUTION_MODE_POST_INVOKE, suit_execution_mode_get(),
 		      "Execution mode modified");
+	/* ... and execution mode does not indicate a failed state */
+	zassert_equal(false, suit_execution_mode_failed(), "The device entered failed mode");
+	/* ... and execution mode does not indicate boot mode */
+	zassert_equal(false, suit_execution_mode_booting(), "The device did not left boot mode");
+	/* ... and execution mode does not indicate update mode */
+	zassert_equal(false, suit_execution_mode_updating(), "The device entered update mode");
 }
 
 ZTEST(orchestrator_boot_tests, test_no_root_envelope)
@@ -191,6 +197,12 @@ ZTEST(orchestrator_boot_tests, test_no_root_envelope)
 		      "Emergency flag not set");
 	/* ... and the execution mode remains unchanged */
 	zassert_equal(EXECUTION_MODE_INVOKE, suit_execution_mode_get(), "Execution mode modified");
+	/* ... and execution mode does not indicate a failed state */
+	zassert_equal(false, suit_execution_mode_failed(), "The device entered failed mode");
+	/* ... and execution mode indicates boot mode */
+	zassert_equal(true, suit_execution_mode_booting(), "The device left boot mode");
+	/* ... and execution mode does not indicate update mode */
+	zassert_equal(false, suit_execution_mode_updating(), "The device entered update mode");
 }
 
 ZTEST(orchestrator_boot_tests, test_invalid_root_envelope)

--- a/tests/subsys/suit/orchestrator/orchestrator_sdfw/src/test_common.c
+++ b/tests/subsys/suit/orchestrator/orchestrator_sdfw/src/test_common.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/ztest.h>
+
+#include <suit_execution_mode.h>
+
+void check_startup_failure(void)
+{
+	suit_execution_mode_t mode_before = suit_execution_mode_get();
+	bool has_failed = suit_execution_mode_failed();
+
+	if (suit_execution_mode_booting()) {
+		/* Update execution mode to leave transient states. */
+		suit_execution_mode_startup_failed();
+
+		/* If the device was booting - it should enter EXECUTION_MODE_FAIL_STARTUP state. */
+		zassert_equal(false, suit_execution_mode_booting(),
+			      "The device did not left boot mode");
+		zassert_equal(false, suit_execution_mode_updating(),
+			      "The device entered update mode");
+		zassert_equal(true, suit_execution_mode_failed(),
+			      "The device did not enter failed mode");
+		zassert_equal(EXECUTION_MODE_FAIL_STARTUP, suit_execution_mode_get(),
+			      "FAILED state not set after boot startup failed");
+	} else if (suit_execution_mode_updating()) {
+		/* Update execution mode to leave transient states. */
+		suit_execution_mode_startup_failed();
+
+		/* If the device was updating - it should enter EXECUTION_MODE_FAIL_STARTUP state.
+		 */
+		zassert_equal(false, suit_execution_mode_booting(), "The device entered boot mode");
+		zassert_equal(false, suit_execution_mode_updating(),
+			      "The device did not left update mode");
+		zassert_equal(true, suit_execution_mode_failed(),
+			      "The device did not enter failed mode");
+		zassert_equal(EXECUTION_MODE_FAIL_STARTUP, suit_execution_mode_get(),
+			      "FAILED state not set after update startup failed");
+	} else {
+		/* Update execution mode to leave transient states. */
+		suit_execution_mode_startup_failed();
+
+		/* If the device was in final state - it should stay in the same state state. */
+		zassert_equal(false, suit_execution_mode_booting(), "The device entered boot mode");
+		zassert_equal(false, suit_execution_mode_updating(),
+			      "The device entered update mode");
+		zassert_equal(has_failed, suit_execution_mode_failed(),
+			      "The device changed failed mode");
+		zassert_equal(mode_before, suit_execution_mode_get(),
+			      "Unexpected execution mode change");
+	}
+}

--- a/tests/subsys/suit/orchestrator/orchestrator_sdfw/src/test_common.h
+++ b/tests/subsys/suit/orchestrator/orchestrator_sdfw/src/test_common.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef TEST_STARTUP_FAILURE_COMMON_H__
+#define TEST_STARTUP_FAILURE_COMMON_H__
+
+/**
+ * @brief Assert that calling @ref suit_execution_mode_startup_failed in the current state
+ *        is correctly handled.
+ */
+void check_startup_failure(void);
+
+#endif /* TEST_STARTUP_FAILURE_COMMON_H__ */

--- a/tests/subsys/suit/orchestrator/orchestrator_sdfw/src/test_init.c
+++ b/tests/subsys/suit/orchestrator/orchestrator_sdfw/src/test_init.c
@@ -13,6 +13,7 @@
 #include <zephyr/drivers/flash.h>
 #include <zephyr/storage/flash_map.h>
 #include <suit_plat_mem_util.h>
+#include "test_common.h"
 
 #if DT_NODE_EXISTS(DT_NODELABEL(cpuapp_suit_storage))
 #define SUIT_STORAGE_OFFSET FIXED_PARTITION_OFFSET(cpuapp_suit_storage)
@@ -94,6 +95,14 @@ ZTEST(orchestrator_init_tests, test_empty_storage)
 		      "Regular boot not triggered");
 	/* ... and orchestrator is initialized */
 	zassert_equal(0, err, "Orchestrator not initialized");
+	/* ... and execution mode does not indicate a failed state */
+	zassert_equal(false, suit_execution_mode_failed(), "The device entered failed mode");
+	/* ... and execution mode indicates boot mode */
+	zassert_equal(true, suit_execution_mode_booting(), "The device did not enter boot mode");
+	/* ... and execution mode does not indicate update mode */
+	zassert_equal(false, suit_execution_mode_updating(), "The device entered update mode");
+	/* ... and the startup failure is correctly handled */
+	check_startup_failure();
 }
 
 ZTEST(orchestrator_init_tests, test_empty_storage_with_update_flag)
@@ -112,6 +121,14 @@ ZTEST(orchestrator_init_tests, test_empty_storage_with_update_flag)
 		      "Regular update not triggered");
 	/* ... and orchestrator is initialized */
 	zassert_equal(0, err, "Orchestrator not initialized");
+	/* ... and execution mode does not indicate a failed state */
+	zassert_equal(false, suit_execution_mode_failed(), "The device entered failed mode");
+	/* ... and execution mode does not indicate boot mode */
+	zassert_equal(false, suit_execution_mode_booting(), "The device entered boot mode");
+	/* ... and execution mode indicates update mode */
+	zassert_equal(true, suit_execution_mode_updating(), "The device did not enter update mode");
+	/* ... and the startup failure is correctly handled */
+	check_startup_failure();
 }
 
 ZTEST(orchestrator_init_tests, test_empty_storage_with_recovery_flag)
@@ -130,6 +147,14 @@ ZTEST(orchestrator_init_tests, test_empty_storage_with_recovery_flag)
 		      "Recovery mode not triggered");
 	/* ... and orchestrator is initialized */
 	zassert_equal(0, err, "Orchestrator not initialized");
+	/* ... and execution mode does not indicate a failed state */
+	zassert_equal(false, suit_execution_mode_failed(), "The device entered failed mode");
+	/* ... and execution mode indicates boot mode */
+	zassert_equal(true, suit_execution_mode_booting(), "The device did not enter boot mode");
+	/* ... and execution mode does not indicate update mode */
+	zassert_equal(false, suit_execution_mode_updating(), "The device entered update mode");
+	/* ... and the startup failure is correctly handled */
+	check_startup_failure();
 }
 
 ZTEST(orchestrator_init_tests, test_empty_storage_with_update_recovery_flag)
@@ -149,4 +174,12 @@ ZTEST(orchestrator_init_tests, test_empty_storage_with_update_recovery_flag)
 		      "Emergency recovery update not triggered");
 	/* ... and orchestrator is initialized */
 	zassert_equal(0, err, "Orchestrator not initialized");
+	/* ... and execution mode does not indicate a failed state */
+	zassert_equal(false, suit_execution_mode_failed(), "The device entered failed mode");
+	/* ... and execution mode does not indicate boot mode */
+	zassert_equal(false, suit_execution_mode_booting(), "The device entered boot mode");
+	/* ... and execution mode indicates update mode */
+	zassert_equal(true, suit_execution_mode_updating(), "The device did not enter update mode");
+	/* ... and the startup failure is correctly handled */
+	check_startup_failure();
 }

--- a/tests/subsys/suit/orchestrator/orchestrator_sdfw/src/test_recovery_boot_mode.c
+++ b/tests/subsys/suit/orchestrator/orchestrator_sdfw/src/test_recovery_boot_mode.c
@@ -164,6 +164,12 @@ ZTEST(orchestrator_recovery_boot_tests, test_rec_no_recovery_envelope)
 	/* ... and the execution mode is set to the FAIL INVOKE RECOVERY */
 	zassert_equal(EXECUTION_MODE_FAIL_INVOKE_RECOVERY, suit_execution_mode_get(),
 		      "Execution mode not changed to the FAIL INVOKE RECOVERY");
+	/* ... and execution mode indicates a failed state */
+	zassert_equal(true, suit_execution_mode_failed(), "The device does not enter failed mode");
+	/* ... and execution mode does not indicate boot mode */
+	zassert_equal(false, suit_execution_mode_booting(), "The device did not left boot mode");
+	/* ... and execution mode does not indicate update mode */
+	zassert_equal(false, suit_execution_mode_updating(), "The device entered update mode");
 }
 
 ZTEST(orchestrator_recovery_boot_tests, test_rec_invalid_recovery_envelope)
@@ -230,6 +236,12 @@ ZTEST(orchestrator_recovery_boot_tests, test_rec_valid_recovery_envelope)
 	/* ... and the execution mode is set to the POST INVOKE RECOVERY */
 	zassert_equal(EXECUTION_MODE_POST_INVOKE_RECOVERY, suit_execution_mode_get(),
 		      "Execution mode not changed to the POST INVOKE RECOVERY");
+	/* ... and execution mode does not indicate a failed state */
+	zassert_equal(false, suit_execution_mode_failed(), "The device entered failed mode");
+	/* ... and execution mode does not indicate boot mode */
+	zassert_equal(false, suit_execution_mode_booting(), "The device did not left boot mode");
+	/* ... and execution mode does not indicate update mode */
+	zassert_equal(false, suit_execution_mode_updating(), "The device entered update mode");
 }
 
 ZTEST(orchestrator_recovery_boot_tests, test_rec_seq_no_validate)


### PR DESCRIPTION
Add tests that verify execution mode transitions as a result of suit_execution_mode_failed API call.

Ref: NCSDK-29623