### PR TITLE
Do not Review: Move CRACEN mutexes to threading_alt.c

### DIFF
--- a/subsys/nrf_security/Kconfig.psa
+++ b/subsys/nrf_security/Kconfig.psa
@@ -12,6 +12,17 @@ config MBEDTLS_PSA_CRYPTO_C
 	  Enable the Platform Security Architecture cryptography API.
 	  Corresponds to setting in mbed TLS config file.
 
+config MBEDTLS_PSA_CRYPTO_DISABLE_THREAD_SAFETY
+	bool
+	prompt "Disable PSA crypto thread safety"
+	help
+	  Setting this configuration disables thread-safety for front-end PSA crypto APIs.
+	  This disables the three mutexes that was added in Mbed TLS 3.6.0 that is built
+	  into the PSA core without disabling mutexes used by the legacy Mbed TLS APIs or
+	  in HW accelerators.
+	  The addition of mutexes for legacy APIs and HW accelerators is still controlled
+	  by enabling the Kconfig MBEDTLS_TREADING_C in the build.
+
 if MBEDTLS_PSA_CRYPTO_C
 
 config MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER

--- a/subsys/nrf_security/cmake/psa_crypto_want_config.cmake
+++ b/subsys/nrf_security/cmake/psa_crypto_want_config.cmake
@@ -139,6 +139,12 @@ kconfig_check_and_set_base_to_one(PSA_WANT_ALG_SP800_108_COUNTER_HMAC)
 
 kconfig_check_and_set_base_int(PSA_MAX_RSA_KEY_BITS)
 
+# Enable PSA crypto (core) thread safety based on checking that MBEDTLS_THREADING_C
+# is set but not MBEDTLS_PSA_CRYPTO_DISABLE_THREAD_SAFETY
+if(CONFIG_MBEDTLS_THREADING_C AND NOT CONFIG_MBEDTLS_PSA_CRYPTO_DISABLE_THREAD_SAFETY)
+  set(PSA_CRYPTO_THREAD_SAFE True)
+endif()
+
 # Create the Mbed TLS PSA crypto config file (Contains all the PSA_WANT definitions)
 configure_file(${NRF_SECURITY_ROOT}/configs/psa_crypto_want_config.h.template
   ${generated_include_path}/${CONFIG_MBEDTLS_PSA_CRYPTO_CONFIG_FILE}

--- a/subsys/nrf_security/configs/psa_crypto_config.h.template
+++ b/subsys/nrf_security/configs/psa_crypto_config.h.template
@@ -446,6 +446,7 @@
 #cmakedefine MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG
 #cmakedefine MBEDTLS_PSA_KEY_SLOT_COUNT                         @MBEDTLS_PSA_KEY_SLOT_COUNT@
 
+
 #include <psa/core_unsupported_ciphers_check.h>
 
 #include <check_crypto_config.h>

--- a/subsys/nrf_security/configs/psa_crypto_want_config.h.template
+++ b/subsys/nrf_security/configs/psa_crypto_want_config.h.template
@@ -145,4 +145,7 @@
 /* The Adjusting is done in this file */
 #define PSA_CRYPTO_ADJUST_KEYPAIR_TYPES_H
 
+/* Configuration for PSA crypto front-end APIs being thread safe */
+#cmakedefine PSA_CRYPTO_THREAD_SAFE
+
 #endif /* PSA_CRYPTO_CONFIG_H */

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen.c
@@ -14,7 +14,7 @@
 
 #include "common.h"
 #include "microcode_binary.h"
-#include <nrf_security_mutexes.h>
+#include <threading_alt.h>
 
 #if !defined(CONFIG_BUILD_WITH_TFM)
 #define LOG_ERR_MSG(msg) LOG_ERR(msg)

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen.c
@@ -24,7 +24,7 @@
 
 static int users;
 
-NRF_SECURITY_MUTEX_DEFINE(cracen_mutex);
+extern mbedtls_threading_mutex_t cracen_mutex;
 
 LOG_MODULE_REGISTER(cracen, CONFIG_CRACEN_LOG_LEVEL);
 
@@ -51,7 +51,8 @@ static void cracen_load_microcode(void)
 
 void cracen_acquire(void)
 {
-	nrf_security_mutex_lock(&cracen_mutex);
+	__ASSERT(mbedtls_mutex_lock(&cracen_mutex) == 0,
+		"cracen_mutex not initialized (lock)");
 
 	if (users++ == 0) {
 		nrf_cracen_module_enable(NRF_CRACEN, CRACEN_ENABLE_CRYPTOMASTER_Msk |
@@ -61,13 +62,14 @@ void cracen_acquire(void)
 		LOG_DBG_MSG("Powered on CRACEN.");
 	}
 
-	nrf_security_mutex_unlock(&cracen_mutex);
+	__ASSERT(mbedtls_mutex_unlock(&cracen_mutex) == 0,
+		"cracen_mutex not initialized (unlock)");
 }
 
 void cracen_release(void)
 {
-	nrf_security_mutex_lock(&cracen_mutex);
-
+	__ASSERT(mbedtls_mutex_lock(&cracen_mutex) == 0,
+		"cracen_mutex not initialized (lock)");
 	if (--users == 0) {
 		/* Disable IRQs in the ARM NVIC as the first operation to be
 		 * sure no IRQs fire while we are turning CRACEN off.
@@ -102,7 +104,8 @@ void cracen_release(void)
 		LOG_DBG_MSG("Powered off CRACEN.");
 	}
 
-	nrf_security_mutex_unlock(&cracen_mutex);
+	__ASSERT(mbedtls_mutex_unlock(&cracen_mutex) == 0,
+		"cracen_mutex not initialized (unlock)");
 }
 
 #define CRACEN_NOT_INITIALIZED 0x207467

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/ctr_drbg.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/ctr_drbg.c
@@ -22,7 +22,7 @@
 #include <sxsymcrypt/keyref.h>
 
 #include <zephyr/kernel.h>
-#include <nrf_security_mutexes.h>
+#include <threading_alt.h>
 
 #define MAX_BITS_PER_REQUEST (1 << 19)		 /* NIST.SP.800-90Ar1:Table 3 */
 #define RESEED_INTERVAL	     ((uint64_t)1 << 48) /* 2^48 as per NIST spec */

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/key_management.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/key_management.c
@@ -1341,7 +1341,8 @@ psa_status_t cracen_export_key(const psa_key_attributes_t *attributes, const uin
 		 * use case. Here the decision was to avoid defining another mutex to handle the
 		 * push buffer for the rest of the use cases.
 		 */
-		nrf_security_mutex_lock(&cracen_mutex_symmetric);
+		__ASSERT(mbedtls_mutex_lock(&cracen_mutex_symmetric) == 0,
+			"cracen_mutex_symmetric not initialized (lock)");
 		status = cracen_kmu_prepare_key(key_buffer);
 		if (status == SX_OK) {
 			memcpy(data, kmu_push_area, key_out_size);
@@ -1349,7 +1350,8 @@ psa_status_t cracen_export_key(const psa_key_attributes_t *attributes, const uin
 		}
 
 		(void)cracen_kmu_clean_key(key_buffer);
-		nrf_security_mutex_unlock(&cracen_mutex_symmetric);
+		__ASSERT(mbedtls_mutex_unlock(&cracen_mutex_symmetric) == 0,
+			"cracen_mutex_symmetric not initialized (unlock)");
 
 		return silex_statuscodes_to_psa(status);
 	}
@@ -1385,7 +1387,8 @@ psa_status_t cracen_copy_key(psa_key_attributes_t *attributes, const uint8_t *so
 	psa_status_t psa_status;
 	size_t key_size = PSA_BITS_TO_BYTES(psa_get_key_bits(attributes));
 
-	nrf_security_mutex_lock(&cracen_mutex_symmetric);
+	__ASSERT(mbedtls_mutex_lock(&cracen_mutex_symmetric) == 0,
+		"cracen_mutex_symmetric not initialized (lock)");
 	status = cracen_kmu_prepare_key(source_key);
 
 	if (status == SX_OK) {
@@ -1397,7 +1400,8 @@ psa_status_t cracen_copy_key(psa_key_attributes_t *attributes, const uint8_t *so
 	}
 
 	(void)cracen_kmu_clean_key(source_key);
-	nrf_security_mutex_unlock(&cracen_mutex_symmetric);
+	__ASSERT(mbedtls_mutex_unlock(&cracen_mutex_symmetric) == 0,
+		"cracen_mutex_symmetric not initialized (unlock)");
 
 	if (status != SX_OK) {
 		return silex_statuscodes_to_psa(status);

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/key_management.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/key_management.c
@@ -9,7 +9,7 @@
 #include <cracen/mem_helpers.h>
 #include "cracen_psa.h"
 #include "platform_keys/platform_keys.h"
-#include <nrf_security_mutexes.h>
+#include <threading_alt.h>
 
 #include <sicrypto/drbghash.h>
 #include <sicrypto/ecc.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/kmu.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/kmu.c
@@ -7,7 +7,7 @@
 #include <cracen/mem_helpers.h>
 #include <cracen/statuscodes.h>
 #include <cracen/lib_kmu.h>
-#include <nrf_security_mutexes.h>
+#include <threading_alt.h>
 #include <nrfx.h>
 #include <psa/crypto.h>
 #include <stdint.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/kmu.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/kmu.c
@@ -844,13 +844,15 @@ static psa_status_t push_kmu_key_to_ram(uint8_t *key_buffer, size_t key_buffer_s
 	 * Here the decision was to avoid defining another mutex to handle the push buffer for the
 	 * rest of the use cases.
 	 */
-	nrf_security_mutex_lock(&cracen_mutex_symmetric);
+	__ASSERT(mbedtls_mutex_lock(&cracen_mutex_symmetric) == 0,
+			"cracen_mutex_symmetric not initialized (lock)");
 	status = silex_statuscodes_to_psa(cracen_kmu_prepare_key(key_buffer));
 	if (status == PSA_SUCCESS) {
 		memcpy(key_buffer, kmu_push_area, key_buffer_size);
 		safe_memzero(kmu_push_area, sizeof(kmu_push_area));
 	}
-	nrf_security_mutex_unlock(&cracen_mutex_symmetric);
+	__ASSERT(mbedtls_mutex_unlock(&cracen_mutex_symmetric) == 0,
+		"cracen_mutex_symmetric not initialized (unlock)");
 
 	return status;
 }

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/prng_pool.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/prng_pool.c
@@ -10,7 +10,7 @@
 #include <cracen/statuscodes.h>
 #include <security/cracen.h>
 #include <zephyr/kernel.h>
-#include <nrf_security_mutexes.h>
+#include <threading_alt.h>
 
 /* We want to avoid reserving excessive RAM and invoking
  * the PRNG too often. 32 was arbitrarily chosen here

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/prng_pool.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/prng_pool.c
@@ -24,13 +24,16 @@ static uint32_t prng_pool[PRNG_POOL_SIZE];
 static uint32_t prng_pool_remaining;
 
 
-NRF_SECURITY_MUTEX_DEFINE(cracen_prng_pool_mutex);
+extern mbedtls_threading_mutex_t cracen_mutex_prng_pool;
+
+
 
 int cracen_prng_value_from_pool(uint32_t *prng_value)
 {
 	int status = SX_OK;
 
-	nrf_security_mutex_lock(&cracen_prng_pool_mutex);
+	__ASSERT(mbedtls_mutex_lock(&cracen_mutex_prng_pool) == 0,
+		"cracen_mutex_prng_pool not initialized (lock)");
 
 	if (prng_pool_remaining == 0) {
 		psa_status_t psa_status =
@@ -47,6 +50,7 @@ int cracen_prng_value_from_pool(uint32_t *prng_value)
 	prng_pool_remaining--;
 
 exit:
-	nrf_security_mutex_unlock(&cracen_prng_pool_mutex);
+	__ASSERT(mbedtls_mutex_unlock(&cracen_mutex_prng_pool) == 0,
+		"cracen_mutex_prng_pool not initialized (unlock)");
 	return status;
 }

--- a/subsys/nrf_security/src/drivers/cracen/silexpk/target/baremetal_ba414e_with_ik/pk_baremetal.c
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/target/baremetal_ba414e_with_ik/pk_baremetal.c
@@ -21,7 +21,7 @@
 
 #include <hal/nrf_cracen.h>
 #include <security/cracen.h>
-#include <nrf_security_mutexes.h>
+#include <threading_alt.h>
 
 #ifndef ADDR_BA414EP_REGS_BASE
 #define ADDR_BA414EP_REGS_BASE CRACEN_ADDR_BA414EP_REGS_BASE

--- a/subsys/nrf_security/src/drivers/cracen/silexpk/target/baremetal_ba414e_with_ik/pk_baremetal.c
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/target/baremetal_ba414e_with_ik/pk_baremetal.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/kernel.h>
 
+#include <cracen/membarriers.h>
 #include "../hw/ba414/regs_addr.h"
 #include <silexpk/core.h>
 #include "../hw/ba414/pkhardware_ba414e.h"
@@ -111,7 +112,9 @@ void sx_pk_wrreg(struct sx_regs *regs, uint32_t addr, uint32_t v)
 	printk("sx_pk_wrreg(addr=0x%x, sum=0x%x, val=0x%x);\r\n", addr, (uint32_t)p, v);
 #endif
 
+	wmb(); /* comment for compliance */
 	*p = v;
+	rmb(); /* comment for compliance */
 }
 
 uint32_t sx_pk_rdreg(struct sx_regs *regs, uint32_t addr)
@@ -119,7 +122,9 @@ uint32_t sx_pk_rdreg(struct sx_regs *regs, uint32_t addr)
 	volatile uint32_t *p = (uint32_t *)(regs->base + addr);
 	uint32_t v;
 
+	wmb(); /* comment for compliance */
 	v = *p;
+	rmb(); /* comment for compliance */
 
 #ifdef INSTRUMENT_MMIO_WITH_PRINTFS
 	printk("sx_pk_rdreg(addr=0x%x, sum=0x%x);\r\n", addr, (uint32_t)p);

--- a/subsys/nrf_security/src/drivers/cracen/silexpk/target/baremetal_ba414e_with_ik/pk_baremetal.c
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/target/baremetal_ba414e_with_ik/pk_baremetal.c
@@ -52,7 +52,7 @@ struct sx_pk_cnx {
 
 struct sx_pk_cnx silex_pk_engine;
 
-NRF_SECURITY_MUTEX_DEFINE(cracen_mutex_asymmetric);
+extern mbedtls_threading_mutex_t cracen_mutex_asymmetric;
 
 bool ba414ep_is_busy(sx_pk_req *req)
 {
@@ -183,7 +183,9 @@ struct sx_pk_acq_req sx_pk_acquire_req(const struct sx_pk_cmd_def *cmd)
 {
 	struct sx_pk_acq_req req = {NULL, SX_OK};
 
-	nrf_security_mutex_lock(&cracen_mutex_asymmetric);
+	__ASSERT(mbedtls_mutex_lock(&cracen_mutex_asymmetric) == 0,
+		"cracen_mutex_asymmetric not initialized (lock)");
+
 	req.req = &silex_pk_engine.instance;
 	req.req->cmd = cmd;
 	req.req->cnx = &silex_pk_engine;
@@ -220,7 +222,8 @@ void sx_pk_release_req(sx_pk_req *req)
 	cracen_release();
 	req->cmd = NULL;
 	req->userctxt = NULL;
-	nrf_security_mutex_unlock(&cracen_mutex_asymmetric);
+	__ASSERT(mbedtls_mutex_unlock(&cracen_mutex_asymmetric) == 0,
+		"cracen_mutex_asymmetric not initialized (unlock)");
 }
 
 struct sx_regs *sx_pk_get_regs(void)

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/platform/baremetal/cmdma_hw.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/platform/baremetal/cmdma_hw.c
@@ -12,7 +12,7 @@
 #include <security/cracen.h>
 #include <cracen/statuscodes.h>
 
-#include <nrf_security_mutexes.h>
+#include <threading_alt.h>
 
 #include <zephyr/kernel.h>
 /* Enable interrupts showing that an operation finished or aborted.

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/platform/baremetal/cmdma_hw.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/platform/baremetal/cmdma_hw.c
@@ -24,13 +24,13 @@
  */
 #define CMDMA_INTMASK_EN ((1 << 2) | (1 << 5) | (1 << 4))
 
-NRF_SECURITY_MUTEX_DEFINE(cracen_mutex_symmetric);
+extern mbedtls_threading_mutex_t cracen_mutex_symmetric;
 
 void sx_hw_reserve(struct sx_dmactl *dma)
 {
 	cracen_acquire();
-	nrf_security_mutex_lock(&cracen_mutex_symmetric);
-
+	__ASSERT(mbedtls_mutex_lock(&cracen_mutex_symmetric) == 0,
+		"cracen_mutex_symmetric not initialized (lock)");
 	if (dma) {
 		dma->hw_acquired = true;
 	}
@@ -48,7 +48,8 @@ void sx_cmdma_release_hw(struct sx_dmactl *dma)
 {
 	if (dma == NULL || dma->hw_acquired) {
 		cracen_release();
-		nrf_security_mutex_unlock(&cracen_mutex_symmetric);
+		__ASSERT(mbedtls_mutex_unlock(&cracen_mutex_symmetric) == 0,
+			"cracen_mutex_symmetric not initialized (unlock)");
 		if (dma) {
 			dma->hw_acquired = false;
 		}

--- a/subsys/nrf_security/src/threading/include/threading_alt.h
+++ b/subsys/nrf_security/src/threading/include/threading_alt.h
@@ -10,4 +10,10 @@
 #include "mbedtls/build_info.h"
 #include "nrf_security_mutexes.h"
 
+/* Give access to the threading function-pointer prototypes (always used) */
+extern void (*mbedtls_mutex_init)(mbedtls_threading_mutex_t *mutex);
+extern void (*mbedtls_mutex_free)(mbedtls_threading_mutex_t *mutex);
+extern int (*mbedtls_mutex_lock)(mbedtls_threading_mutex_t *mutex);
+extern int (*mbedtls_mutex_unlock)(mbedtls_threading_mutex_t *mutex);
+
 #endif /* MBEDTLS_THREADING_ALT_H */

--- a/subsys/nrf_security/src/threading/threading.cmake
+++ b/subsys/nrf_security/src/threading/threading.cmake
@@ -7,7 +7,7 @@
 # This file includes threading support required by the PSA crypto core
 # Which was added in Mbed TLS 3.6.0.
 
-if(CONFIG_MBEDTLS_THREADING_C AND NOT (CONFIG_PSA_CRYPTO_DRIVER_CC3XX OR CONFIG_CC3XX_BACKEND))
+if(NOT (CONFIG_PSA_CRYPTO_DRIVER_CC3XX OR CONFIG_CC3XX_BACKEND))
 
   append_with_prefix(src_crypto_base ${CMAKE_CURRENT_LIST_DIR}
     threading_alt.c

--- a/subsys/nrf_security/src/threading/threading_alt.c
+++ b/subsys/nrf_security/src/threading/threading_alt.c
@@ -32,23 +32,32 @@ NRF_SECURITY_MUTEX_DEFINE(cracen_mutex_asymmetric);
 NRF_SECURITY_MUTEX_DEFINE(cracen_mutex_symmetric);
 #endif
 
+static bool inline is_pre_kernel_or_isr(void)
+{
+#if defined(CONFIG_MULTITHREADING) && !defined(__NRF_TFM__)
+    return k_is_pre_kernel() || k_is_in_isr();
+#else
+    return 0;
+#endif
+}
+
 static void mbedtls_mutex_init_fn(mbedtls_threading_mutex_t * mutex)
 {
-    if(!k_is_pre_kernel() && !k_is_in_isr()) {
+    if(!is_pre_kernel_or_isr()) {
         nrf_security_mutex_init(mutex);
     }
 }
 
 static void mbedtls_mutex_free_fn(mbedtls_threading_mutex_t * mutex)
 {
-    if(!k_is_pre_kernel() && !k_is_in_isr()) {
+    if(!is_pre_kernel_or_isr()) {
         nrf_security_mutex_free(mutex);
     }
 }
 
 static int mbedtls_mutex_lock_fn(mbedtls_threading_mutex_t * mutex)
 {
-    if(!k_is_pre_kernel() && !k_is_in_isr()) {
+    if(!is_pre_kernel_or_isr()) {
         return nrf_security_mutex_lock(mutex);
     } else {
         return 0;
@@ -57,7 +66,7 @@ static int mbedtls_mutex_lock_fn(mbedtls_threading_mutex_t * mutex)
 
 static int mbedtls_mutex_unlock_fn(mbedtls_threading_mutex_t * mutex)
 {
-    if(!k_is_pre_kernel() && !k_is_in_isr()) {
+    if(!is_pre_kernel_or_isr()) {
         return nrf_security_mutex_unlock(mutex);
     } else {
         return 0;

--- a/subsys/nrf_security/src/threading/threading_alt.c
+++ b/subsys/nrf_security/src/threading/threading_alt.c
@@ -24,6 +24,14 @@ NRF_SECURITY_MUTEX_DEFINE(mbedtls_threading_key_slot_mutex);
 NRF_SECURITY_MUTEX_DEFINE(mbedtls_threading_psa_globaldata_mutex);
 NRF_SECURITY_MUTEX_DEFINE(mbedtls_threading_psa_rngdata_mutex);
 
+#if defined(CONFIG_PSA_CRYPTO_DRIVER_CRACEN)
+NRF_SECURITY_MUTEX_DEFINE(cracen_mutex);
+NRF_SECURITY_MUTEX_DEFINE(cracen_mutex_prng_context);
+NRF_SECURITY_MUTEX_DEFINE(cracen_mutex_prng_pool);
+NRF_SECURITY_MUTEX_DEFINE(cracen_mutex_asymmetric);
+NRF_SECURITY_MUTEX_DEFINE(cracen_mutex_symmetric);
+#endif
+
 static void mbedtls_mutex_init_fn(mbedtls_threading_mutex_t * mutex)
 {
     if(!k_is_pre_kernel() && !k_is_in_isr()) {
@@ -66,6 +74,13 @@ static int post_kernel_init(void)
     mbedtls_mutex_init(&mbedtls_threading_key_slot_mutex);
     mbedtls_mutex_init(&mbedtls_threading_psa_globaldata_mutex);
     mbedtls_mutex_init(&mbedtls_threading_psa_rngdata_mutex);
+#if defined(CONFIG_PSA_CRYPTO_DRIVER_CRACEN)
+    mbedtls_mutex_init(&cracen_mutex);
+    mbedtls_mutex_init(&cracen_mutex_prng_context);
+    mbedtls_mutex_init(&cracen_mutex_prng_pool);
+    mbedtls_mutex_init(&cracen_mutex_asymmetric);
+    mbedtls_mutex_init(&cracen_mutex_symmetric);
+#endif
     return 0;
 }
 

--- a/west.yml
+++ b/west.yml
@@ -145,7 +145,7 @@ manifest:
     - name: oberon-psa-crypto
       path: modules/crypto/oberon-psa-crypto
       repo-path: sdk-oberon-psa-crypto
-      revision: b41e899e7302462eb952b0b6a7c6903e368fb395
+      revision: pull/16/head
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib


### PR DESCRIPTION
This PR changes CRACEN to use Mbed TLS threading primitives instead of directly calling nrf_security_mutex APIs.

**This PR is not ready for review and is only used to run tests for some complex ABI compliance issues with OpenThread** 

