### PR TITLE
applications: nrf_desktop: Constlat module updates

### DIFF
--- a/applications/nrf_desktop/src/modules/Kconfig.hotfixes
+++ b/applications/nrf_desktop/src/modules/Kconfig.hotfixes
@@ -18,6 +18,7 @@ config DESKTOP_HFCLK_LOCK_ENABLE
 config DESKTOP_CONSTLAT_ENABLE
 	bool "Constant latency interrupts"
 	depends on !SOC_SERIES_NRF54LX
+	depends on !SOC_SERIES_NRF54HX
 	select NRFX_POWER
 	help
 	  When enabled, the SoC uses configuration for constant latency
@@ -27,6 +28,10 @@ config DESKTOP_CONSTLAT_ENABLE
 	  Currently, the nRF54L Series SoCs do not support the nrfx POWER driver
 	  (CONFIG_NRFX_POWER). Because of that, the hotfix cannot be used by
 	  these SoCs.
+
+	  nRF54H Series SoCs do not enable constant latency interrupts through
+	  the nrfx POWER driver. This SoC series is currently not supported
+	  by the hotfix.
 
 config DESKTOP_CONSTLAT_DISABLE_ON_STANDBY
 	bool "Disable constant latency interrupts on standby"

--- a/applications/nrf_desktop/src/modules/Kconfig.hotfixes
+++ b/applications/nrf_desktop/src/modules/Kconfig.hotfixes
@@ -17,11 +17,16 @@ config DESKTOP_HFCLK_LOCK_ENABLE
 
 config DESKTOP_CONSTLAT_ENABLE
 	bool "Constant latency interrupts"
+	depends on !SOC_SERIES_NRF54LX
 	select NRFX_POWER
 	help
-	  When enabled SoC will use configuration for constant latency
+	  When enabled, the SoC uses configuration for constant latency
 	  interrupts. This reduces interrupt propagation time but increases
 	  power consumption.
+
+	  Currently, the nRF54L Series SoCs do not support the nrfx POWER driver
+	  (CONFIG_NRFX_POWER). Because of that, the hotfix cannot be used by
+	  these SoCs.
 
 config DESKTOP_CONSTLAT_DISABLE_ON_STANDBY
 	bool "Disable constant latency interrupts on standby"

--- a/applications/nrf_desktop/src/modules/Kconfig.hotfixes
+++ b/applications/nrf_desktop/src/modules/Kconfig.hotfixes
@@ -25,6 +25,7 @@ config DESKTOP_CONSTLAT_ENABLE
 
 config DESKTOP_CONSTLAT_DISABLE_ON_STANDBY
 	bool "Disable constant latency interrupts on standby"
+	depends on CAF_PM_EVENTS
 	depends on DESKTOP_CONSTLAT_ENABLE
 	help
 	  When enabled constant latency interrupts will be disabled when

--- a/applications/nrf_desktop/src/modules/Kconfig.hotfixes
+++ b/applications/nrf_desktop/src/modules/Kconfig.hotfixes
@@ -17,6 +17,7 @@ config DESKTOP_HFCLK_LOCK_ENABLE
 
 config DESKTOP_CONSTLAT_ENABLE
 	bool "Constant latency interrupts"
+	select NRFX_POWER
 	help
 	  When enabled SoC will use configuration for constant latency
 	  interrupts. This reduces interrupt propagation time but increases

--- a/applications/nrf_desktop/src/modules/constlat.c
+++ b/applications/nrf_desktop/src/modules/constlat.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
-#include <hal/nrf_power.h>
+#include <nrfx_power.h>
 
 #define MODULE constlat
 #include <caf/events/module_state_event.h>
@@ -25,8 +25,8 @@ static void constlat_on(void)
 		return;
 	}
 
-	nrf_power_task_trigger(NRF_POWER, NRF_POWER_TASK_CONSTLAT);
-	LOG_INF("Constant latency enabled");
+	(void)nrfx_power_constlat_mode_request();
+	LOG_INF("Constant latency requested");
 
 	enabled = true;
 }
@@ -37,8 +37,8 @@ static void constlat_off(void)
 		return;
 	}
 
-	nrf_power_task_trigger(NRF_POWER, NRF_POWER_TASK_LOWPWR);
-	LOG_INF("Constant latency disabled");
+	(void)nrfx_power_constlat_mode_free();
+	LOG_INF("Constant latency freed");
 
 	enabled = false;
 }

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -369,6 +369,8 @@ nRF Desktop
   * The partition memory configurations for the :ref:`zephyr:nrf54l15dk_nrf54l15` board to optimize the size of the MCUboot bootloader partition.
   * The :ref:`nrf_desktop_constlat` to use the :c:func:`nrfx_power_constlat_mode_request` and :c:func:`nrfx_power_constlat_mode_free` functions instead of :c:func:`nrf_power_task_trigger` to control requesting Constant Latency sub-power mode.
     This ensures correct behavior if another source requests Constant Latency sub-power mode through the nrfx API.
+  * The :ref:`CONFIG_DESKTOP_CONSTLAT_DISABLE_ON_STANDBY <config_desktop_app_options>` Kconfig option depends on :kconfig:option:`CONFIG_CAF_PM_EVENTS`.
+    CAF Power Management events support is necessary to disable constant latency interrupts on standby.
 
 nRF Machine Learning (Edge Impulse)
 -----------------------------------

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -367,6 +367,8 @@ nRF Desktop
   * The :ref:`nrf_desktop_dfu_mcumgr` to enable the MCUmgr handler that is used to report the bootloader information (see the :kconfig:option:`CONFIG_MCUMGR_GRP_OS_BOOTLOADER_INFO` Kconfig option).
   * The MCUboot image configurations for the :ref:`zephyr:nrf54l15dk_nrf54l15` board to enable Link Time Optimization (LTO) (see the :kconfig:option:`CONFIG_LTO` Kconfig option) and reduce the memory footprint of the bootloader.
   * The partition memory configurations for the :ref:`zephyr:nrf54l15dk_nrf54l15` board to optimize the size of the MCUboot bootloader partition.
+  * The :ref:`nrf_desktop_constlat` to use the :c:func:`nrfx_power_constlat_mode_request` and :c:func:`nrfx_power_constlat_mode_free` functions instead of :c:func:`nrf_power_task_trigger` to control requesting Constant Latency sub-power mode.
+    This ensures correct behavior if another source requests Constant Latency sub-power mode through the nrfx API.
 
 nRF Machine Learning (Edge Impulse)
 -----------------------------------


### PR DESCRIPTION
PR introduces constlat module updates:

- switches to using nrfx_power_constlat APIs
- adds missing CAF PM events dependency
- prevents enabling module on nRF54H/nRF54L SoC - these SoCs are currently not supported

Jira: NCSDK-29534