### PR TITLE
doc: remove all Doxygen rst utilities/references

### DIFF
--- a/doc/nrf/nrf.doxyfile.in
+++ b/doc/nrf/nrf.doxyfile.in
@@ -279,13 +279,7 @@ TAB_SIZE               = 8
 # with the commands \{ and \} for these it is advised to use the version @{ and
 # @} or use a double escape (\\{ and \\})
 
-ALIASES                = "rst=\verbatim embed:rst" \
-                         "endrst=\endverbatim" \
-                         "rststar=\verbatim embed:rst:leading-asterisk" \
-                         "endrststar=\endverbatim" \
-                         "r=\verbatim embed:rst:leading-asterisk" \
-                         "er=\endverbatim" \
-                         "kconfig{1}=\verbatim embed:rst:inline :kconfig:option:`\1` \endverbatim" \
+ALIASES                = "kconfig{1}=\verbatim \1 \endverbatim" \
                          "req=\xrefitem req \"Requirement\" \"Requirements\""
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources

--- a/doc/nrfx/nrfx.doxyfile.in
+++ b/doc/nrfx/nrfx.doxyfile.in
@@ -285,8 +285,8 @@ TAB_SIZE               = 4
 # with the commands \{ and \} for these it is advised to use the version @{ and
 # @} or use a double escape (\\{ and \\})
 
-ALIASES                = "tagGreenTick=\htmlonly<CENTER><font color=\"green\">✔</font></CENTER>\endhtmlonly \xmlonly<verbatim>embed:rst:inline :green:`✔`</verbatim>\endxmlonly" \
-                         "tagRedCross=\htmlonly<CENTER><font color=\"red\">✖</font></CENTER>\endhtmlonly \xmlonly<verbatim>embed:rst:inline :red:`✖`</verbatim>\endxmlonly" \
+ALIASES                = "tagGreenTick=\htmlonly<CENTER><font color=\"green\">✔</font></CENTER>\endhtmlonly" \
+                         "tagRedCross=\htmlonly<CENTER><font color=\"red\">✖</font></CENTER>\endhtmlonly" \
                          "nRF5340pinAssignmentsURL=\"https://infocenter.nordicsemi.com/index.jsp?topic=%2Fps_nrf5340%2Fchapters%2Fpin.html\"" \
                          "refhal{1}=\sa \1 \copydoc \1"
 

--- a/doc/nrfxlib/nrfxlib.doxyfile.in
+++ b/doc/nrfxlib/nrfxlib.doxyfile.in
@@ -279,13 +279,7 @@ TAB_SIZE               = 8
 # with the commands \{ and \} for these it is advised to use the version @{ and
 # @} or use a double escape (\\{ and \\})
 
-ALIASES                = "rst=\verbatim embed:rst" \
-                         "endrst=\endverbatim" \
-                         "rststar=\verbatim embed:rst:leading-asterisk" \
-                         "endrststar=\endverbatim" \
-                         "r=\verbatim embed:rst:leading-asterisk" \
-                         "er=\endverbatim" \
-                         "kconfig{1}=\verbatim embed:rst:inline :kconfig:option:`\1` \endverbatim" \
+ALIASES                = "kconfig{1}=\verbatim \1 \endverbatim" \
                          "req=\xrefitem req \"Requirement\" \"Requirements\""
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources

--- a/doc/zephyr/zephyr.doxyfile.in
+++ b/doc/zephyr/zephyr.doxyfile.in
@@ -279,21 +279,22 @@ TAB_SIZE               = 8
 # with the commands \{ and \} for these it is advised to use the version @{ and
 # @} or use a double escape (\\{ and \\})
 
-ALIASES                = "rst=\verbatim embed:rst:leading-asterisk" \
-                         endrst=\endverbatim \
-                         "kconfig{1}=\htmlonly <code>\1</code> \endhtmlonly \xmlonly <verbatim>embed:rst:inline :kconfig:option:`\1`</verbatim> \endxmlonly" \
+ALIASES                = "kconfig{1}=\verbatim \1 \endverbatim" \
                          "req{1}=\ref ZEPH_\1 \"ZEPH-\1\"" \
                          "satisfy{1}=\xrefitem satisfy \"Satisfies requirement\" \"Requirement Implementation\" \1" \
                          "verify{1}=\xrefitem verify \"Verifies requirement\" \"Requirement Verification\" \1" \
+                         "kconfig_dep{1}=\attention Available only when the following Kconfig option is enabled: \kconfig{\1}." \
+                         "kconfig_dep{2}=\attention Available only when the following Kconfig options are enabled: \kconfig{\1}, \kconfig{\2}." \
+                         "kconfig_dep{3}=\attention Available only when the following Kconfig options are enabled: \kconfig{\1}, \kconfig{\2}, \kconfig{\3}." \
                          "funcprops=\par \"Function properties (list may not be complete)\"" \
-                         "reschedule=\htmlonly reschedule \endhtmlonly \xmlonly <verbatim>embed:rst:inline :ref:`api_term_reschedule`</verbatim> \endxmlonly" \
-                         "sleep=\htmlonly sleep \endhtmlonly \xmlonly <verbatim>embed:rst:inline :ref:`api_term_sleep`</verbatim> \endxmlonly" \
-                         "no_wait=\htmlonly no-wait \endhtmlonly \xmlonly <verbatim>embed:rst:inline :ref:`api_term_no-wait`</verbatim> \endxmlonly" \
-                         "isr_ok=\htmlonly isr-ok \endhtmlonly \xmlonly <verbatim>embed:rst:inline :ref:`api_term_isr-ok`</verbatim> \endxmlonly" \
-                         "pre_kernel_ok=\htmlonly pre-kernel-ok \endhtmlonly \xmlonly <verbatim>embed:rst:inline :ref:`api_term_pre-kernel-ok`</verbatim> \endxmlonly" \
-                         "async=\htmlonly async \endhtmlonly \xmlonly <verbatim>embed:rst:inline :ref:`api_term_async`</verbatim> \endxmlonly" \
+                         "reschedule=\qualifier reschedule" \
+                         "sleep=\qualifier sleep" \
+                         "no_wait=\qualifier no-wait" \
+                         "isr_ok=\qualifier isr-ok" \
+                         "pre_kernel_ok=\qualifier pre-kernel-ok" \
+                         "async=\qualifier async" \
                          "atomic_api=As for all atomic APIs, includes a full/sequentially-consistent memory barrier (where applicable)." \
-                         "supervisor=\htmlonly supervisor \endhtmlonly \xmlonly <verbatim>embed:rst:inline :ref:`api_term_supervisor`</verbatim> \endxmlonly"
+                         "supervisor=\qualifier supervisor"
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For

--- a/include/net/nrf_cloud_rest.h
+++ b/include/net/nrf_cloud_rest.h
@@ -181,7 +181,7 @@ struct nrf_cloud_rest_pgps_request {
  *
  * @retval 0 If successful.
  *          Otherwise, a (negative) error code is returned.
- *          See @verbatim embed:rst:inline :ref:`nrf_cloud_rest_failure` @endverbatim for details.
+ *          See "nRF Cloud: Request Failure" for details.
  */
 int nrf_cloud_rest_location_get(struct nrf_cloud_rest_context *const rest_ctx,
 	struct nrf_cloud_rest_location_request const *const request,
@@ -210,7 +210,7 @@ int nrf_cloud_rest_location_get(struct nrf_cloud_rest_context *const rest_ctx,
  *		request type.
  *           - -ENOBUFS will be returned, and an error message printed, if there is not enough
  *             buffer space to store retrieved AGNSS data.
- *           - See @verbatim embed:rst:inline :ref:`nrf_cloud_rest_failure` @endverbatim for all
+ *           - See "nRF Cloud: Request Failure" for all
  *             other possible error codes.
  *
  */
@@ -231,7 +231,7 @@ int nrf_cloud_rest_agnss_data_get(struct nrf_cloud_rest_context *const rest_ctx,
  *
  * @retval 0 If successful.
  *          Otherwise, a (negative) error code is returned.
- *          See @verbatim embed:rst:inline :ref:`nrf_cloud_rest_failure` @endverbatim for details.
+ *          See "nRF Cloud: Request Failure" for details.
  */
 int nrf_cloud_rest_pgps_data_get(struct nrf_cloud_rest_context *const rest_ctx,
 	struct nrf_cloud_rest_pgps_request const *const request);
@@ -252,7 +252,7 @@ int nrf_cloud_rest_pgps_data_get(struct nrf_cloud_rest_context *const rest_ctx,
  *
  * @retval 0 If successful.
  *          Otherwise, a (negative) error code is returned.
- *          See @verbatim embed:rst:inline :ref:`nrf_cloud_rest_failure` @endverbatim for details.
+ *          See "nRF Cloud: Request Failure" for details.
  */
 int nrf_cloud_rest_fota_job_get(struct nrf_cloud_rest_context *const rest_ctx,
 	const char *const device_id, struct nrf_cloud_fota_job_info *const job);
@@ -278,7 +278,7 @@ void nrf_cloud_rest_fota_job_free(struct nrf_cloud_fota_job_info *const job);
  *
  * @retval 0 If successful.
  *          Otherwise, a (negative) error code is returned.
- *          See @verbatim embed:rst:inline :ref:`nrf_cloud_rest_failure` @endverbatim for details.
+ *          See "nRF Cloud: Request Failure" for details.
  */
 int nrf_cloud_rest_fota_job_update(struct nrf_cloud_rest_context *const rest_ctx,
 	const char *const device_id, const char *const job_id,
@@ -298,7 +298,7 @@ int nrf_cloud_rest_fota_job_update(struct nrf_cloud_rest_context *const rest_ctx
  *
  * @retval 0 If successful.
  *           Otherwise, a (negative) error code is returned.
- *           See @verbatim embed:rst:inline :ref:`nrf_cloud_rest_failure` @endverbatim for details.
+ *           See "nRF Cloud: Request Failure" for details.
  */
 int nrf_cloud_rest_shadow_transform_request(struct nrf_cloud_rest_context *const rest_ctx,
 	const char *const device_id, char const *const transform);
@@ -312,7 +312,7 @@ int nrf_cloud_rest_shadow_transform_request(struct nrf_cloud_rest_context *const
  *
  * @retval 0 If successful.
  *          Otherwise, a (negative) error code is returned.
- *          See @verbatim embed:rst:inline :ref:`nrf_cloud_rest_failure` @endverbatim for details.
+ *          See "nRF Cloud: Request Failure" for details.
  */
 int nrf_cloud_rest_shadow_state_update(struct nrf_cloud_rest_context *const rest_ctx,
 	const char *const device_id, const char * const shadow_json);
@@ -326,7 +326,7 @@ int nrf_cloud_rest_shadow_state_update(struct nrf_cloud_rest_context *const rest
  *
  * @retval 0 If successful.
  *         Otherwise, a (negative) error code is returned.
- *         See @verbatim embed:rst:inline :ref:`nrf_cloud_rest_failure` @endverbatim for details.
+ *         See "nRF Cloud: Request Failure" for details.
  */
 int nrf_cloud_rest_shadow_service_info_update(struct nrf_cloud_rest_context *const rest_ctx,
 	const char *const device_id, const struct nrf_cloud_svc_info * const svc_inf);
@@ -340,7 +340,7 @@ int nrf_cloud_rest_shadow_service_info_update(struct nrf_cloud_rest_context *con
  *
  * @retval 0 If successful.
  *         Otherwise, a (negative) error code is returned.
- *         See @verbatim embed:rst:inline :ref:`nrf_cloud_rest_failure` @endverbatim for details.
+ *         See "nRF Cloud: Request Failure" for details.
  */
 int nrf_cloud_rest_shadow_device_status_update(struct nrf_cloud_rest_context *const rest_ctx,
 	const char *const device_id, const struct nrf_cloud_device_status *const dev_status);
@@ -390,7 +390,7 @@ int nrf_cloud_rest_jitp(const sec_tag_t nrf_cloud_sec_tag);
  *
  * @retval 0 If successful.
  *          Otherwise, a (negative) error code is returned.
- *          See @verbatim embed:rst:inline :ref:`nrf_cloud_rest_failure` @endverbatim for details.
+ *          See "nRF Cloud: Request Failure" for details.
  */
 int nrf_cloud_rest_send_device_message(struct nrf_cloud_rest_context *const rest_ctx,
 	const char *const device_id, const char *const json_msg, const bool bulk,
@@ -405,7 +405,7 @@ int nrf_cloud_rest_send_device_message(struct nrf_cloud_rest_context *const rest
  *
  * @retval 0 If successful.
  *          Otherwise, a (negative) error code is returned.
- *          See @verbatim embed:rst:inline :ref:`nrf_cloud_rest_failure` @endverbatim for details.
+ *          See "nRF Cloud: Request Failure" for details.
  */
 int nrf_cloud_rest_send_location(struct nrf_cloud_rest_context *const rest_ctx,
 	const char *const device_id, const struct nrf_cloud_gnss_data * const gnss);
@@ -421,7 +421,7 @@ int nrf_cloud_rest_send_location(struct nrf_cloud_rest_context *const rest_ctx,
  *
  * @retval 0 If successful.
  *         Otherwise, a (negative) error code is returned.
- *         See @verbatim embed:rst:inline :ref:`nrf_cloud_rest_failure` @endverbatim for details.
+ *         See "nRF Cloud: Request Failure" for details.
  */
 int nrf_cloud_rest_device_status_message_send(struct nrf_cloud_rest_context *const rest_ctx,
 	const char *const device_id, const struct nrf_cloud_device_status *const dev_status,

--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 06d6b00c41b1ce0cd9e3ffc3d53958e4b5dc052b
+      revision: a735c24d172361298102d4dc29fe22397f99f26a
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
We no longer insert Doxygen content in Sphinx after the removal of breathe, so let's align Doxyfiles and fix some broken references.