### PR TITLE
[Backport v2.7-branch] ci: stale: allow DNM

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,5 +16,5 @@ jobs:
         days-before-close: 14
         stale-issue-label: 'Stale'
         stale-pr-label: 'Stale'
-        exempt-pr-labels: 'DNM,In progress,RFC'
+        exempt-pr-labels: 'In progress,RFC'
         exempt-issue-labels: 'In progress,Enhancement,Feature,Feature Request,RFC,Meta'


### PR DESCRIPTION
Backport 9bde284f4c9c14df4117a1638aca10ce3ca11b78 from #17670.