### PR TITLE
applications: nrf_desktop: Update way of setting APPLICATION_CONFIG_DIR

### DIFF
--- a/applications/nrf_desktop/CMakeLists.txt
+++ b/applications/nrf_desktop/CMakeLists.txt
@@ -8,6 +8,9 @@ cmake_minimum_required(VERSION 3.20.0)
 
 ################################################################################
 
+# The application uses the configuration/<board> scheme for configuration files.
+set(APPLICATION_CONFIG_DIR "${CMAKE_CURRENT_LIST_DIR}/configuration/\${NORMALIZED_BOARD_TARGET}")
+
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project("nRF52 Desktop"
         VERSION 0.1)

--- a/applications/nrf_desktop/sysbuild/CMakeLists.txt
+++ b/applications/nrf_desktop/sysbuild/CMakeLists.txt
@@ -7,11 +7,9 @@
 # The application uses the configuration/<board> scheme for configuration files.
 set(SB_APPLICATION_CONFIG_DIR "${CMAKE_CURRENT_LIST_DIR}/../configuration/\${NORMALIZED_BOARD_TARGET}")
 
-# Redirect images' configuration directories to use those in the board configuration directory
-set(nrf_desktop_APPLICATION_CONFIG_DIR
-    "${CMAKE_CURRENT_LIST_DIR}/../configuration/\${NORMALIZED_BOARD_TARGET}"
-    CACHE INTERNAL "Application configuration dir controlled by sysbuild"
-)
+# The main application configuration directory is defined by the main application's
+# `CMakeLists.txt` file (this allows to avoid dependency on main application name).
+# Redirect other images' configuration directories to redefine configuration.
 set(mcuboot_APPLICATION_CONFIG_DIR
     "${CMAKE_CURRENT_LIST_DIR}/../configuration/\${NORMALIZED_BOARD_TARGET}/images/mcuboot"
     CACHE INTERNAL "Application configuration dir controlled by sysbuild"


### PR DESCRIPTION
Set APPLICATION_CONFIG_DIR in application's CMakeLists.txt (previously was done through sysbuild). This is done to allow building application after copy-pasting the source directory to another location.

Jira: NCSDK-29876