### PR TITLE
[Backport v2.8-branch] dokcer: Bump nrfutil device to version 2.7.2

### DIFF
--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y wget ca-certificates qemu-system-arm gi
     && rm -rf /var/lib/apt/lists/*
 RUN wget https://developer.nordicsemi.com/.pc-tools/nrfutil/x64-linux/nrfutil -q -O /usr/local/bin/nrfutil  \
     && chmod +x /usr/local/bin/nrfutil \
-    && nrfutil install device=2.6.4 \
+    && nrfutil install device=2.7.2 \
     && nrfutil install toolchain-manager=0.15.0
 RUN nrfutil toolchain-manager install --toolchain-bundle-id $VERSION \
     && nrfutil toolchain-manager env --as-script > /opt/toolchain-env.sh \


### PR DESCRIPTION
Backport 74ec8d27eb9ac759e32080753dc883fd82402159 from #18135.