### PR TITLE
samples: fast_pair: locator_tag: Update setting APPLICATION_CONFIG_DIR

### DIFF
--- a/samples/bluetooth/fast_pair/locator_tag/CMakeLists.txt
+++ b/samples/bluetooth/fast_pair/locator_tag/CMakeLists.txt
@@ -18,6 +18,9 @@ if(NOT DEFINED FP_MODEL_ID AND NOT DEFINED FP_ANTI_SPOOFING_KEY AND NOT SYSBUILD
   set(FP_ANTI_SPOOFING_KEY "rie10A7ONqwd77VmkxGsblPUbMt384qjDgcEJ/ctT9Y=")
 endif()
 
+# The sample uses a separate directory for configuration files.
+set(APPLICATION_CONFIG_DIR "${CMAKE_CURRENT_LIST_DIR}/configuration")
+
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(locator_tag)
 

--- a/samples/bluetooth/fast_pair/locator_tag/sysbuild/CMakeLists.txt
+++ b/samples/bluetooth/fast_pair/locator_tag/sysbuild/CMakeLists.txt
@@ -4,11 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-set(locator_tag_APPLICATION_CONFIG_DIR
-    "${CMAKE_CURRENT_LIST_DIR}/../configuration"
-    CACHE INTERNAL "Application configuration dir controlled by sysbuild"
-)
-
 # The sample uses the sysbuild/configuration/<board> scheme for the sysbuild configuration files.
 set(SB_APPLICATION_CONFIG_DIR
     "${CMAKE_CURRENT_LIST_DIR}/configuration/\${NORMALIZED_BOARD_TARGET}")


### PR DESCRIPTION
Set APPLICATION_CONFIG_DIR in samples's CMakeLists.txt (previously set through sysbuild). This is done to allow building sample after copy-pasting the source directory to another location.

Jira: NCSDK-29876