### PR TITLE
[Backport v2.8-branch] samples: nrf_rpc: protocols_serialization: remove nrf54l pdk support

### DIFF
--- a/samples/nrf_rpc/protocols_serialization/client/sample.yaml
+++ b/samples/nrf_rpc/protocols_serialization/client/sample.yaml
@@ -7,37 +7,31 @@ tests:
     platform_allow: >
       nrf52840dk/nrf52840
       nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15pdk/nrf54l15/cpuapp
     tags: ci_build ci_samples_nrf_rpc
     extra_args: >
       SNIPPET="ble"
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuapp
   samples.nrf_rpc.protocols_serialization.client.rpc_ot:
     build_only: true
     platform_allow: >
       nrf52840dk/nrf52840
       nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15pdk/nrf54l15/cpuapp
     tags: ci_build ci_samples_nrf_rpc
     extra_args: >
       SNIPPET="openthread"
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuapp
   samples.nrf_rpc.protocols_serialization.client.rpc:
     build_only: true
     platform_allow: >
       nrf52840dk/nrf52840
       nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15pdk/nrf54l15/cpuapp
     tags: ci_build ci_samples_nrf_rpc
     extra_args: >
       SNIPPET="ble;openthread;debug;coex;log_rpc"
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuapp

--- a/samples/nrf_rpc/protocols_serialization/client/snippets/nfc/nfc.conf
+++ b/samples/nrf_rpc/protocols_serialization/client/snippets/nfc/nfc.conf
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# Enable and configure Bluetooth LE
 CONFIG_NFC_RPC=y
 CONFIG_NFC_RPC_CLIENT=y
 

--- a/samples/nrf_rpc/protocols_serialization/server/sample.yaml
+++ b/samples/nrf_rpc/protocols_serialization/server/sample.yaml
@@ -7,37 +7,31 @@ tests:
     platform_allow: >
       nrf52840dk/nrf52840
       nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15pdk/nrf54l15/cpuapp
     tags: ci_build ci_samples_nrf_rpc
     extra_args: >
       SNIPPET="ble"
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuapp
   samples.nrf_rpc.protocols_serialization.server.rpc_ot:
     build_only: true
     platform_allow: >
       nrf52840dk/nrf52840
       nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15pdk/nrf54l15/cpuapp
     tags: ci_build ci_samples_nrf_rpc
     extra_args: >
       SNIPPET="openthread"
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuapp
   samples.nrf_rpc.protocols_serialization.server.rpc:
     build_only: true
     platform_allow: >
       nrf52840dk/nrf52840
       nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15pdk/nrf54l15/cpuapp
     tags: ci_build ci_samples_nrf_rpc
     extra_args: >
       SNIPPET="ble;openthread;debug;coex;log_rpc"
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuapp

--- a/samples/nrf_rpc/protocols_serialization/server/snippets/nfc/nfc.conf
+++ b/samples/nrf_rpc/protocols_serialization/server/snippets/nfc/nfc.conf
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# Enable and configure Bluetooth LE
 CONFIG_NFC_RPC=y
 CONFIG_NFC_RPC_SERVER=y
 


### PR DESCRIPTION
Backport f43fe95c89648b7f8175dfdffee6f2fb3fddc637~2..f43fe95c89648b7f8175dfdffee6f2fb3fddc637 from #18177.