### PR TITLE
[Backport v2.8-branch] samples: mpsl: timeslot: Fix build errors for 54L and 54H SoCs

### DIFF
--- a/samples/mpsl/timeslot/README.rst
+++ b/samples/mpsl/timeslot/README.rst
@@ -18,6 +18,7 @@ The sample supports any one of the following development kits:
 
 .. note::
    For the nRF5340 DK, this sample is only supported on the network core (``nrf5340dk_nrf5340_cpunet``), and the :ref:`nrf5340_empty_app_core` sample must be programmed to the application core.
+   For the nRF54H20 DK, this sample is only supported on the radio core (``nrf54h20dk_nrf4h20_cpurad``).
 
 Overview
 ********
@@ -30,9 +31,14 @@ The sample opens a timeslot session and starts requesting timeslots when a key i
 The first timeslot is always of type "earliest".
 Any following timeslots are of type "normal".
 In each timeslot callback, the signal type of the callback is posted to a message queue.
-Upon reception of the timeslot start signal, ``timer0`` is configured to be triggered before the timeslot ends.
+Upon reception of the timeslot start signal, ``mpsl timer0`` is configured to be triggered before the timeslot ends.
 A separate thread reads the message queue and prints the timeslot signal type.
 The timeslot session is closed when any key is pressed in the terminal.
+
+.. note::
+   For the nRF52 and nRF53 Series ``mpsl_timer0`` is the ``timer0`` instance.
+   For the nRF54L Series ``mpsl_timer0`` is the ``timer10`` instance.
+   For the nRF54H Series ``mpsl_timer0`` is the ``timer020`` instance.
 
 Building and running
 ********************

--- a/samples/mpsl/timeslot/sample.yaml
+++ b/samples/mpsl/timeslot/sample.yaml
@@ -9,5 +9,8 @@ tests:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpunet
+      - nrf54l15pdk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpurad
     platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpunet
+      nrf54l15pdk/nrf54l15/cpuapp nrf54h20dk/nrf54h20/cpurad
     tags: ci_build sysbuild ci_samples_mpsl

--- a/samples/mpsl/timeslot/src/main.c
+++ b/samples/mpsl/timeslot/src/main.c
@@ -29,9 +29,17 @@ LOG_MODULE_REGISTER(main, LOG_LEVEL_INF);
 
 #if defined(CONFIG_SOC_SERIES_NRF53X)
 	#define LOG_OFFLOAD_IRQn SWI1_IRQn
+	#define MPSL_TIMER0 NRF_TIMER0
 #elif defined(CONFIG_SOC_SERIES_NRF52X)
 	#define LOG_OFFLOAD_IRQn SWI1_EGU1_IRQn
-#endif
+	#define MPSL_TIMER0 NRF_TIMER0
+#elif defined(CONFIG_SOC_SERIES_NRF54LX)
+	#define LOG_OFFLOAD_IRQn EGU10_IRQn
+	#define MPSL_TIMER0 NRF_TIMER10
+#elif defined(CONFIG_SOC_SERIES_NRF54HX)
+	#define LOG_OFFLOAD_IRQn EGU020_IRQn
+	#define MPSL_TIMER0 NRF_TIMER020
+#endif /* CONFIG_SOC_SERIES_NRF53X */
 
 static bool request_in_cb = true;
 
@@ -127,9 +135,9 @@ static mpsl_timeslot_signal_return_param_t *mpsl_timeslot_callback(
 		/* Setup timer to trigger an interrupt (and thus the TIMER0
 		 * signal) before timeslot end.
 		 */
-		nrf_timer_cc_set(NRF_TIMER0, NRF_TIMER_CC_CHANNEL0,
+		nrf_timer_cc_set(MPSL_TIMER0, NRF_TIMER_CC_CHANNEL0,
 			TIMER_EXPIRY_US);
-		nrf_timer_int_enable(NRF_TIMER0, NRF_TIMER_INT_COMPARE0_MASK);
+		nrf_timer_int_enable(MPSL_TIMER0, NRF_TIMER_INT_COMPARE0_MASK);
 		input_data_len = ring_buf_put(&callback_high_priority_ring_buf, &input_data, 1);
 		if (input_data_len != 1) {
 			LOG_ERR("Full ring buffer, enqueue data with length %d", input_data_len);
@@ -139,8 +147,8 @@ static mpsl_timeslot_signal_return_param_t *mpsl_timeslot_callback(
 	case MPSL_TIMESLOT_SIGNAL_TIMER0:
 
 		/* Clear event */
-		nrf_timer_int_disable(NRF_TIMER0, NRF_TIMER_INT_COMPARE0_MASK);
-		nrf_timer_event_clear(NRF_TIMER0, NRF_TIMER_EVENT_COMPARE0);
+		nrf_timer_int_disable(MPSL_TIMER0, NRF_TIMER_INT_COMPARE0_MASK);
+		nrf_timer_event_clear(MPSL_TIMER0, NRF_TIMER_EVENT_COMPARE0);
 
 		if (request_in_cb) {
 			/* Request new timeslot when callback returns */


### PR DESCRIPTION
Backport e9520fbc67b8bbeef4b170e863e1a9cba327eceb from #18186.