### PR TITLE
[Backport v2.8-branch] applications: nrf_desktop: Mark DVFS module as experimental

### DIFF
--- a/applications/nrf_desktop/src/modules/Kconfig.dvfs
+++ b/applications/nrf_desktop/src/modules/Kconfig.dvfs
@@ -5,8 +5,9 @@
 #
 
 menuconfig DESKTOP_DVFS
-	bool "DVFS module"
+	bool "DVFS module [EXPERIMENTAL]"
 	depends on SOC_NRF54H20_CPUAPP
+	select EXPERIMENTAL
 	select NRFS_DVFS_SERVICE_ENABLED
 	select CLOCK_CONTROL
 	select CLOCK_CONTROL_NRF2


### PR DESCRIPTION
Backport 95e5c94517a04c2942fb6e26a8352b4114be5995 from #18194.