### PR TITLE
[Backport v2.8-branch] samples: openthread: fix csl period in THCI

### DIFF
--- a/samples/openthread/cli/harness-thci/nRF_Connect_SDK_11_12.py
+++ b/samples/openthread/cli/harness-thci/nRF_Connect_SDK_11_12.py
@@ -3085,11 +3085,8 @@ class OpenThreadTHCI(object):
         Args:
             period: csl period in ms
 
-        note: OT command 'csl period' accepts parameter in unit of 10 symbols,
-        period is converted from unit ms to ten symbols (160us per 10 symbols).
-
         """
-        cmd = "csl period %u" % (period * 6.25)
+        cmd = "csl period %u" % (period * 1000)
         return self.__executeCommand(cmd)[-1] == "Done"
 
     @staticmethod

--- a/samples/openthread/cli/harness-thci/nRF_Connect_SDK_13_14.py
+++ b/samples/openthread/cli/harness-thci/nRF_Connect_SDK_13_14.py
@@ -3139,7 +3139,7 @@ class OpenThreadTHCI(object):
         return self.__executeCommand(cmd)[-1] == "Done"
 
     @API
-    def setCSLperiod(self, period=3125):
+    def setCSLperiod(self, period=500):
         """set Csl Period
         Args:
             period: csl period in ms
@@ -3148,7 +3148,7 @@ class OpenThreadTHCI(object):
         period is converted from unit ms to ten symbols (160us per 10 symbols).
 
         """
-        cmd = "csl period %u" % (period * 160)
+        cmd = "csl period %u" % (period * 1000)
         return self.__executeCommand(cmd)[-1] == "Done"
 
     @staticmethod


### PR DESCRIPTION
Backport b3ee5e317651aaff6e128b1ed0a481df001536b4 from #18189.