### PR TITLE
[Backport v2.8-branch] samples: matter: Fix random crashes while Cracen is used

### DIFF
--- a/samples/matter/light_bulb/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/light_bulb/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -14,10 +14,6 @@ CONFIG_MPSL_WORK_STACK_SIZE=2048
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
 
-# Workaround: Disable MBEDTLS threading, as in the Mbed TLS 3.6.x the mutexes were added, what sometimes
-# leads to bus faults when OpenThread calls psa_get_and_lock_key_slot on SRP service removal.
-# This brings back the behavior that was proven to work before.
-CONFIG_MBEDTLS_THREADING_C=n
 # Workaround required as Zephyr L2 implies usage of NVS backend for settings.
 # It should be removed once the proper fix will be applied in Zephyr.
 CONFIG_NVS=n

--- a/samples/matter/light_switch/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/light_switch/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -19,8 +19,3 @@ CONFIG_NVS=n
 
 # Low Power mode
 CONFIG_POWEROFF=y
-
-# Workaround: Disable MBEDTLS threading, as in the Mbed TLS 3.6.x the mutexes were added, what sometimes
-# leads to bus faults when OpenThread calls psa_get_and_lock_key_slot on SRP service removal.
-# This brings back the behavior that was proven to work before.
-CONFIG_MBEDTLS_THREADING_C=n

--- a/samples/matter/lock/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/lock/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -19,8 +19,3 @@ CONFIG_NVS=n
 
 # Low Power mode
 CONFIG_POWEROFF=y
-
-# Workaround: Disable MBEDTLS threading, as in the Mbed TLS 3.6.x the mutexes were added, what sometimes
-# leads to bus faults when OpenThread calls psa_get_and_lock_key_slot on SRP service removal.
-# This brings back the behavior that was proven to work before.
-CONFIG_MBEDTLS_THREADING_C=n

--- a/samples/matter/smoke_co_alarm/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/smoke_co_alarm/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -19,8 +19,3 @@ CONFIG_NVS=n
 
 # Low Power mode
 CONFIG_POWEROFF=y
-
-# Workaround: Disable MBEDTLS threading, as in the Mbed TLS 3.6.x the mutexes were added, what sometimes
-# leads to bus faults when OpenThread calls psa_get_and_lock_key_slot on SRP service removal.
-# This brings back the behavior that was proven to work before.
-CONFIG_MBEDTLS_THREADING_C=n

--- a/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -14,10 +14,6 @@ CONFIG_MPSL_WORK_STACK_SIZE=2048
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
 
-# Workaround: Disable MBEDTLS threading, as in the Mbed TLS 3.6.x the mutexes were added, what sometimes
-# leads to bus faults when OpenThread calls psa_get_and_lock_key_slot on SRP service removal.
-# This brings back the behavior that was proven to work before.
-CONFIG_MBEDTLS_THREADING_C=n
 # Workaround required as Zephyr L2 implies usage of NVS backend for settings.
 # It should be removed once the proper fix will be applied in Zephyr.
 CONFIG_NVS=n

--- a/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp_internal.conf
+++ b/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp_internal.conf
@@ -52,8 +52,3 @@ CONFIG_NCS_SAMPLE_MATTER_WATCHDOG=y
 # Enable LTO
 CONFIG_LTO=y
 CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
-
-# Workaround: Disable MBEDTLS threading, as in the Mbed TLS 3.6.x the mutexes were added, what sometimes
-# leads to bus faults when OpenThread calls psa_get_and_lock_key_slot on SRP service removal.
-# This brings back the behavior that was proven to work before.
-CONFIG_MBEDTLS_THREADING_C=n

--- a/samples/matter/thermostat/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/thermostat/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -14,10 +14,6 @@ CONFIG_MPSL_WORK_STACK_SIZE=2048
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
 
-# Workaround: Disable MBEDTLS threading, as in the Mbed TLS 3.6.x the mutexes were added, what sometimes
-# leads to bus faults when OpenThread calls psa_get_and_lock_key_slot on SRP service removal.
-# This brings back the behavior that was proven to work before.
-CONFIG_MBEDTLS_THREADING_C=n
 # Workaround required as Zephyr L2 implies usage of NVS backend for settings.
 # It should be removed once the proper fix will be applied in Zephyr.
 CONFIG_NVS=n

--- a/samples/matter/window_covering/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/window_covering/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -19,8 +19,3 @@ CONFIG_NVS=n
 
 # Low Power mode
 CONFIG_POWEROFF=y
-
-# Workaround: Disable MBEDTLS threading, as in the Mbed TLS 3.6.x the mutexes were added, what sometimes
-# leads to bus faults when OpenThread calls psa_get_and_lock_key_slot on SRP service removal.
-# This brings back the behavior that was proven to work before.
-CONFIG_MBEDTLS_THREADING_C=n

--- a/subsys/nrf_security/src/utils/nrf_security_mutexes.c
+++ b/subsys/nrf_security/src/utils/nrf_security_mutexes.c
@@ -19,7 +19,7 @@
 
 void nrf_security_mutex_init(mbedtls_threading_mutex_t * mutex)
 {
-	if((mutex->flags & NRF_SECURITY_MUTEX_FLAGS_INITIALIZED) != 0) {
+	if ((mutex->flags & NRF_SECURITY_MUTEX_FLAGS_INITIALIZED) == 0) {
 		k_mutex_init(&mutex->mutex);
 	}
 
@@ -33,7 +33,7 @@ void nrf_security_mutex_free(mbedtls_threading_mutex_t * mutex)
 
 int nrf_security_mutex_lock(mbedtls_threading_mutex_t * mutex)
 {
-	if((mutex->flags & NRF_SECURITY_MUTEX_FLAGS_INITIALIZED) != 0) {
+	if ((mutex->flags & NRF_SECURITY_MUTEX_FLAGS_INITIALIZED) != 0) {
 		return k_mutex_lock(&mutex->mutex, K_FOREVER);
 	} else {
 		return -EINVAL;
@@ -42,7 +42,7 @@ int nrf_security_mutex_lock(mbedtls_threading_mutex_t * mutex)
 
 int nrf_security_mutex_unlock(mbedtls_threading_mutex_t * mutex)
 {
-	if((mutex->flags & NRF_SECURITY_MUTEX_FLAGS_INITIALIZED) != 0) {
+	if ((mutex->flags & NRF_SECURITY_MUTEX_FLAGS_INITIALIZED) != 0) {
 		return k_mutex_unlock(&mutex->mutex);
 	} else {
 		return -EINVAL;


### PR DESCRIPTION
Backport d290578a5c17cbbb23578f299c7afc329dc7af25~2..d290578a5c17cbbb23578f299c7afc329dc7af25 from #18181.