### PR TITLE
Some fixes for west ncs-genboard

### DIFF
--- a/scripts/west_commands/genboard/templates/nrf54l/Kconfig.board.jinja2
+++ b/scripts/west_commands/genboard/templates/nrf54l/Kconfig.board.jinja2
@@ -1,5 +1,5 @@
 config BOARD_{{ board | upper }}
-	select SOC_{{ soc | upper }}_ENGA_CPUAPP if BOARD_{{ board | upper }}_{{ soc | upper }}_CPUAPP
-	select SOC_{{ soc | upper }}_ENGA_CPUFLPR if \
+	select SOC_{{ soc | upper }}_CPUAPP if BOARD_{{ board | upper }}_{{ soc | upper }}_CPUAPP
+	select SOC_{{ soc | upper }}_CPUFLPR if \
 		BOARD_{{ board | upper }}_{{ soc | upper }}_CPUFLPR || \
 		BOARD_{{ board | upper }}_{{ soc | upper }}_CPUFLPR_XIP

--- a/scripts/west_commands/genboard/west-ncs-genboard-test.sh
+++ b/scripts/west_commands/genboard/west-ncs-genboard-test.sh
@@ -16,7 +16,8 @@ declare -a NCS_VERSIONS=(
 	"2.5.0"
 	"2.6.0"
 	"2.7.0"
-	"2.7.99"
+	"2.8.0"
+	"2.8.99"
 )
 
 declare -a SOCS=(


### PR DESCRIPTION
Fixes for nRF54L15, add NCS 2.8.0 support to test script.