### PR TITLE
manifest: MCUboot fixes to PSA crypto

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -132,7 +132,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: v2.1.0-ncs2-rc1
+      revision: pull/362/head
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR


### PR DESCRIPTION
Fixes for broken crypto builds.

Backporting fix from MCUboot v2.1.0-ncs2

https://github.com/nrfconnect/sdk-nrf/pull/18229