### PR TITLE
location + Wi-Fi: Remove tests from Quarantine

### DIFF
--- a/samples/cellular/nrf_cloud_multi_service/overlay-nrf7002ek-wifi-scan-only.conf
+++ b/samples/cellular/nrf_cloud_multi_service/overlay-nrf7002ek-wifi-scan-only.conf
@@ -50,7 +50,3 @@ CONFIG_NET_MAX_CONTEXTS=5
 
 # Disable LED patterns, enabling WiFi scanning takes control of two LEDs
 CONFIG_LED_INDICATION_DISABLED=y
-
-# Temporary tweak: Disable wifi_mgmt buffer offload; It causes scans to fail in scan-only mode.
-# To be removed when SHEL-3213 is resolved
-DCONFIG_NRF_WIFI_MGMT_BUFF_OFFLOAD=n

--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -11,23 +11,6 @@
   comment: "https://nordicsemi.atlassian.net/browse/KRKNWK-19027"
 
 - scenarios:
-    - ".*nrf7002eb.*"
-    - ".*nrf7002_eb.*"
-    - applications.matter_bridge.lto.br_ble.nrf54h20.wifi
-    - applications.matter_bridge.release.br_ble.nrf54h20.wifi
-  comment: "nRF7002EB not support in the upstream nRF70 driver yet"
-
-- scenarios:
-    - sample.cellular.modem_shell.location_service_ext_pgps_nrf7002ek_wifi
-    - sample.cellular.nrf7002ek_wifi.scan
-    - sample.cellular.nrf7002ek_wifi.conn
-  platforms:
-    - nrf9161dk/nrf9161/ns
-    - nrf5340dk/nrf5340/cpuapp/ns
-    - nrf9151dk/nrf9151/ns
-  comment: "Unknown failures using NS (TF-M), unable to replicate locally, temporarily excluded"
-
-- scenarios:
     - net.lib.wifi_credentials_backend_psa
   comment: "Fix not known at time of upmerge, temporarily excluded to be fixed after upmerge"
 


### PR DESCRIPTION
1. Revert a config change causing build error due to typo
2. Remove location + wifi tests from quarantine