### PR TITLE
[Backport v2.8-branch] applications: nrf5340_audio: Use scan reponse for DFU name

### DIFF
--- a/applications/nrf5340_audio/sample.yaml
+++ b/applications/nrf5340_audio/sample.yaml
@@ -22,3 +22,5 @@ tests:
     extra_args: FILE_SUFFIX=release CONFIG_AUDIO_DEV=2 CONFIG_TRANSPORT_BIS=y
   applications.nrf5340_audio.headset_unicast_sd_card:
     extra_args: FILE_SUFFIX=release CONFIG_AUDIO_DEV=1 CONFIG_SD_CARD_PLAYBACK=y
+  applications.nrf5340_audio.headset_dfu:
+    extra_args: FILE_SUFFIX=release CONFIG_AUDIO_DEV=1 FILE_SUFFIX=fota

--- a/applications/nrf5340_audio/src/bluetooth/bt_management/dfu/bt_mgmt_dfu.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/dfu/bt_mgmt_dfu.c
@@ -23,19 +23,21 @@ LOG_MODULE_REGISTER(bt_mgmt_dfu, CONFIG_BT_MGMT_DFU_LOG_LEVEL);
 #define DEVICE_NAME_DFU	    CONFIG_BT_DFU_DEVICE_NAME
 #define DEVICE_NAME_DFU_LEN (sizeof(DEVICE_NAME_DFU) - 1)
 
-/* Advertising data for SMP_SVR UUID */
-static struct bt_le_adv_param adv_param;
 static const struct bt_data ad_peer[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
 	BT_DATA_BYTES(BT_DATA_UUID128_ALL, 0x84, 0xaa, 0x60, 0x74, 0x52, 0x8a, 0x8b, 0x86, 0xd3,
 		      0x4c, 0xb7, 0x1d, 0x1d, 0xdc, 0x53, 0x8d),
 };
 
+/* Set aside space for name to be in scan response */
+static struct bt_data sd_peer[1];
+
 static void smp_adv(void)
 {
 	int ret;
 
-	ret = bt_le_adv_start(&adv_param, ad_peer, ARRAY_SIZE(ad_peer), NULL, 0);
+	ret = bt_le_adv_start(BT_LE_ADV_CONN, ad_peer, ARRAY_SIZE(ad_peer), sd_peer,
+			      ARRAY_SIZE(sd_peer));
 	if (ret) {
 		LOG_ERR("SMP_SVR Advertising failed to start (ret %d)", ret);
 		return;
@@ -63,26 +65,46 @@ static struct bt_conn_cb dfu_conn_callbacks = {
 
 static void dfu_set_bt_name(void)
 {
-	char name[CONFIG_BT_DEVICE_NAME_MAX] = {0};
+	int ret;
+	static char name[CONFIG_BT_DEVICE_NAME_MAX];
 
 	strlcpy(name, CONFIG_BT_DEVICE_NAME, CONFIG_BT_DEVICE_NAME_MAX);
-	strlcat(name, "_", CONFIG_BT_DEVICE_NAME_MAX);
+	ret = strlcat(name, "_", CONFIG_BT_DEVICE_NAME_MAX);
+	if (ret >= CONFIG_BT_DEVICE_NAME_MAX) {
+		LOG_ERR("Failed to set full BT name, will truncate");
+	}
+
 #if (CONFIG_AUDIO_DEV == GATEWAY)
-	strlcat(name, GW_TAG, CONFIG_BT_DEVICE_NAME_MAX);
+	ret = strlcat(name, GW_TAG, CONFIG_BT_DEVICE_NAME_MAX);
+	if (ret >= CONFIG_BT_DEVICE_NAME_MAX) {
+		LOG_ERR("Failed to set full BT name, will truncate");
+	}
 #else
 	enum audio_channel channel;
 
 	channel_assignment_get(&channel);
 
 	if (channel == AUDIO_CH_L) {
-		strlcat(name, CH_L_TAG, CONFIG_BT_DEVICE_NAME_MAX);
+		ret = strlcat(name, CH_L_TAG, CONFIG_BT_DEVICE_NAME_MAX);
+		if (ret >= CONFIG_BT_DEVICE_NAME_MAX) {
+			LOG_ERR("Failed to set full BT name, will truncate");
+		}
 	} else {
-		strlcat(name, CH_R_TAG, CONFIG_BT_DEVICE_NAME_MAX);
+		ret = strlcat(name, CH_R_TAG, CONFIG_BT_DEVICE_NAME_MAX);
+		if (ret >= CONFIG_BT_DEVICE_NAME_MAX) {
+			LOG_ERR("Failed to set full BT name, will truncate");
+		}
 	}
 
 #endif
-	strlcat(name, "_DFU", CONFIG_BT_DEVICE_NAME_MAX);
-	bt_set_name(name);
+	ret = strlcat(name, "_DFU", CONFIG_BT_DEVICE_NAME_MAX);
+	if (ret >= CONFIG_BT_DEVICE_NAME_MAX) {
+		LOG_ERR("Failed to set full BT name, will truncate");
+	}
+
+	sd_peer[0].type = BT_DATA_NAME_COMPLETE;
+	sd_peer[0].data_len = strlen(name);
+	sd_peer[0].data = name;
 }
 
 void bt_mgmt_dfu_start(void)
@@ -90,7 +112,6 @@ void bt_mgmt_dfu_start(void)
 	LOG_INF("Entering SMP server mode");
 
 	bt_conn_cb_register(&dfu_conn_callbacks);
-	adv_param = *BT_LE_ADV_CONN_NAME;
 	dfu_set_bt_name();
 	smp_adv();
 


### PR DESCRIPTION
Backport dca02acf4400709d3199fc9d8057d4f32072b2f2 from #18169.