### PR TITLE
manifest: Update bsim to version v2.4

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -277,7 +277,7 @@ manifest:
     - name: bsim
       repo-path: bsim_west
       remote: babblesim
-      revision: 9ee22c707970f6621adba0375841c0a609e24628
+      revision: 1f242f4ed7fc141fdfcfeca8d21c6d9e801179d7
       import:
         path-prefix: tools
     - name: bme68x


### PR DESCRIPTION
Main changes since v2.3:
* Support for immediate RSSI measurements during abort reevaluations
* Several minor improvements in the base components, including tolerating better under-setup docker images, improved C++ compatibility, a new sanity check for problematic user provided sim_ids, and other minor improvements.

Note: Like before, bsim remains fully backwards compatible