### PR TITLE
manifest: sdk-zephyr: Bluetooth: Host: Downstream 21.10.2024

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 06d6b00c41b1ce0cd9e3ffc3d53958e4b5dc052b
+      revision: pull/2139/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull Bluetooth Host upstream changes.

test-sdk-nrf: DRGN-23200_host_disconnects_upon_att_timeout