### PR TITLE
manifest: sdk-zephyr: [Backport v3.7.99-ncs1-branch] [nrf fromtree] doc: ipc: Add detailed protocol specs for ICMsg

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: dabbd681e46e9b683776e387b7d7953a75d54093
+      revision: pull/2174/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Manifest update for: https://github.com/nrfconnect/sdk-zephyr/pull/2174