### PR TITLE
tests: drivers: pwm: gpio_loopback: Enable test on PWM120 instance

### DIFF
--- a/tests/drivers/pwm/gpio_loopback/Kconfig
+++ b/tests/drivers/pwm/gpio_loopback/Kconfig
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config TEST_PWM_PERIOD_USEC
+	int "PWM period in microseconds"
+	default 200000
+	help
+	  Set PWM signal period to TEST_PWM_PERIOD_USEC microseconds.
+	  In the test, PWM pulse width will be set to half of this value.
+	  The maximum allowable PWM period value is limited by the hardware design.
+
+source "Kconfig.zephyr"

--- a/tests/drivers/pwm/gpio_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_0.overlay
+++ b/tests/drivers/pwm/gpio_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_0.overlay
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/gpio/nordic-nrf-gpio.h>
+
+/* Test requires wire connection between:
+ *  - PWM120 OUT[0] at P7.0
+ *  - GPIO input at P1.09
+ */
+
+/ {
+	pwm_to_gpio_loopback: pwm_to_gpio_loopback {
+		compatible = "test-pwm-to-gpio-loopback";
+		pwms = <&pwm120 0 0 PWM_POLARITY_NORMAL>;
+		gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&pinctrl {
+	pwm_default: pwm_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 7, 0)>;
+		};
+	};
+	pwm_sleep: pwm_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 7, 0)>;
+			low-power-enable;
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&pwm120 {
+	status = "okay";
+	pinctrl-0 = <&pwm_default>;
+	pinctrl-1 = <&pwm_sleep>;
+	pinctrl-names = "default", "sleep";
+	memory-regions = <&dma_fast_region>;
+};
+
+&dma_fast_region {
+	status = "okay";
+};
+
+&pwm130 {
+	status = "disabled";
+};

--- a/tests/drivers/pwm/gpio_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_1.overlay
+++ b/tests/drivers/pwm/gpio_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_1.overlay
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/gpio/nordic-nrf-gpio.h>
+
+/* Test requires wire connection between:
+ *  - PWM120 OUT[1] at P7.1
+ *  - GPIO input at P1.05
+ */
+
+/ {
+	pwm_to_gpio_loopback: pwm_to_gpio_loopback {
+		compatible = "test-pwm-to-gpio-loopback";
+		pwms = <&pwm120 1 0 PWM_POLARITY_NORMAL>;
+		gpios = <&gpio1 5 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&pinctrl {
+	pwm_default: pwm_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT1, 7, 1)>;
+		};
+	};
+	pwm_sleep: pwm_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT1, 7, 1)>;
+			low-power-enable;
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&pwm120 {
+	status = "okay";
+	pinctrl-0 = <&pwm_default>;
+	pinctrl-1 = <&pwm_sleep>;
+	pinctrl-names = "default", "sleep";
+	memory-regions = <&dma_fast_region>;
+};
+
+&dma_fast_region {
+	status = "okay";
+};
+
+&pwm130 {
+	status = "disabled";
+};

--- a/tests/drivers/pwm/gpio_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_6.overlay
+++ b/tests/drivers/pwm/gpio_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_6.overlay
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/gpio/nordic-nrf-gpio.h>
+
+/* Test requires wire connection between:
+ *  - PWM120 OUT[2] at P7.6
+ *  - GPIO input at P1.06
+ */
+
+/ {
+	pwm_to_gpio_loopback: pwm_to_gpio_loopback {
+		compatible = "test-pwm-to-gpio-loopback";
+		pwms = <&pwm120 2 0 PWM_POLARITY_NORMAL>;
+		gpios = <&gpio1 6 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&pinctrl {
+	pwm_default: pwm_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT2, 7, 6)>;
+		};
+	};
+	pwm_sleep: pwm_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT2, 7, 6)>;
+			low-power-enable;
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&pwm120 {
+	status = "okay";
+	pinctrl-0 = <&pwm_default>;
+	pinctrl-1 = <&pwm_sleep>;
+	pinctrl-names = "default", "sleep";
+	memory-regions = <&dma_fast_region>;
+};
+
+&dma_fast_region {
+	status = "okay";
+};
+
+&pwm130 {
+	status = "disabled";
+};

--- a/tests/drivers/pwm/gpio_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_7.overlay
+++ b/tests/drivers/pwm/gpio_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_7.overlay
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/gpio/nordic-nrf-gpio.h>
+
+/* Test requires wire connection between:
+ *  - PWM120 OUT[3] at P7.7
+ *  - GPIO input at P1.08
+ */
+
+/ {
+	pwm_to_gpio_loopback: pwm_to_gpio_loopback {
+		compatible = "test-pwm-to-gpio-loopback";
+		pwms = <&pwm120 3 0 PWM_POLARITY_NORMAL>;
+		gpios = <&gpio1 8 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&pinctrl {
+	pwm_default: pwm_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT3, 7, 7)>;
+		};
+	};
+	pwm_sleep: pwm_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT3, 7, 7)>;
+			low-power-enable;
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&pwm120 {
+	status = "okay";
+	pinctrl-0 = <&pwm_default>;
+	pinctrl-1 = <&pwm_sleep>;
+	pinctrl-names = "default", "sleep";
+	memory-regions = <&dma_fast_region>;
+};
+
+&dma_fast_region {
+	status = "okay";
+};
+
+&pwm130 {
+	status = "disabled";
+};

--- a/tests/drivers/pwm/gpio_loopback/src/main.c
+++ b/tests/drivers/pwm/gpio_loopback/src/main.c
@@ -18,6 +18,10 @@ static void *pwm_loopback_setup(void)
 	k_object_access_grant(out.dev, k_current_get());
 	k_object_access_grant(in.port, k_current_get());
 
+	TC_PRINT("Testing PWM device %s, channel %d\n", out.dev->name, out.channel);
+	TC_PRINT("GPIO loopback at %s, pin %d\n", in.port->name, in.pin);
+	TC_PRINT("===================================================================\n");
+
 	return NULL;
 }
 

--- a/tests/drivers/pwm/gpio_loopback/testcase.yaml
+++ b/tests/drivers/pwm/gpio_loopback/testcase.yaml
@@ -19,3 +19,41 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15pdk/nrf54l15/cpuapp
+
+  drivers.pwm.gpio_loopback.fast_p7_0:
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+    extra_args:
+      DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_0.overlay"
+      CONFIG_TEST_PWM_PERIOD_USEC=10000
+
+  drivers.pwm.gpio_loopback.fast_p7_1:
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+    extra_args:
+      DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_1.overlay"
+      CONFIG_TEST_PWM_PERIOD_USEC=10000
+
+  drivers.pwm.gpio_loopback.fast_p7_6:
+    build_only: true
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+    extra_args:
+      DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_6.overlay"
+      CONFIG_TEST_PWM_PERIOD_USEC=10000
+
+  drivers.pwm.gpio_loopback.fast_p7_7:
+    build_only: true
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+    extra_args:
+      DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_7.overlay"
+      CONFIG_TEST_PWM_PERIOD_USEC=10000


### PR DESCRIPTION
Check if fast PWM instance PWM120 is working correctly.
Check that PWM signal can be generated on all four PWM channels.