### PR TITLE
doc: nrf: filter redirect warnings

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -266,6 +266,7 @@
 /doc/nrf/templates/                       @nrfconnect/ncs-doc-leads
 /doc/nrf/test_and_optimize/               @nrfconnect/ncs-doc-leads
 /doc/nrf/test_and_optimize/optimizing/power_nrf91.rst @nrfconnect/ncs-cia-doc
+/doc/nrf/warnings.txt                     @nrfconnect/ncs-co-doc
 
 /doc/**/*.svg                             @nrfconnect/ncs-doc-leads
 /doc/**/*.png                             @nrfconnect/ncs-doc-leads

--- a/doc/nrf/conf.py
+++ b/doc/nrf/conf.py
@@ -55,6 +55,7 @@ extensions = [
     "notfound.extension",
     "ncs_tool_versions",
     "page_filter",
+    "warnings_filter",
 ]
 
 linkcheck_ignore = [
@@ -213,6 +214,10 @@ manifest_revisions_table_manifest = NRF_BASE / "west.yml"
 notfound_urls_prefix = "/nRF_Connect_SDK/doc/{}/nrf/".format(
     "latest" if version.endswith("99") else version
 )
+
+# -- Options for warnings_filter -----------------------------------------------
+
+warnings_filter_config = str(NRF_BASE / "doc" / "nrf" / "warnings.txt")
 
 def setup(app):
     app.add_css_file("css/nrf.css")

--- a/doc/nrf/warnings.txt
+++ b/doc/nrf/warnings.txt
@@ -1,0 +1,1 @@
+.*is not a valid destination for a redirect.*


### PR DESCRIPTION
It looks like the redirects extension is reporting some invalid warnings. Filter them while investigation happens.