### PR TITLE
[Backport v2.8-branch] treewide: Modify the `wifi_cred add` command in examples

### DIFF
--- a/doc/nrf/includes/wifi_credentials_shell.txt
+++ b/doc/nrf/includes/wifi_credentials_shell.txt
@@ -9,9 +9,24 @@ Once you have flashed your device with this sample, connect to your device's UAR
 .. parsed-literal::
    :class: highlight
 
-   wifi_cred add *NetworkSSID* *SecurityMode (OPEN, WPA2-PSK, WPA2-PSK-SHA256, WPA3-SAE)* *NetworkPassword*
+   wifi_cred add -s *NetworkSSID* -k *SecurityMode* -p *NetworkPassword*
 
 Where *NetworkSSID* is replaced with the SSID of the Wi-Fi access point you want your device to connect to, and *NetworkPassword* is its password.
+*SecurityMode* is replaced by the number as listed here:
+
+* 0:None
+* 1:WPA2-PSK
+* 2:WPA2-PSK-256
+* 3:SAE-HNP
+* 4:SAE-H2E
+* 5:SAE-AUTO
+* 6:WAPI
+* 7:EAP-TLS
+* 8:WEP
+* 9:WPA-PSK
+* 10:WPA-Auto-Personal
+* 11:DPP
+
 If you are not sure which security mode to use, enable the :kconfig:option:`CONFIG_NET_L2_WIFI_SHELL` Kconfig option and use the ``wifi scan`` command to display a list of all accessible networks along with their corresponding security modes.
 Then either reboot the device or use the ``wifi_cred auto_connect`` command to manually trigger a connection attempt.
 

--- a/samples/cellular/nrf_cloud_multi_service/README.rst
+++ b/samples/cellular/nrf_cloud_multi_service/README.rst
@@ -1001,7 +1001,7 @@ Once your device has been flashed with this sample, you can add a credential by 
 .. parsed-literal::
    :class: highlight
 
-   wifi_cred add *NetworkSSID* WPA2-PSK *NetworkPassword*
+   wifi_cred add -s *NetworkSSID* -k 1 -p *NetworkPassword*
 
 Where *NetworkSSID* is replaced with the SSID of the Wi-Fi access point you want your device to connect to, and *NetworkPassword* is its password.
 Then either reboot the device or use the ``wifi_cred auto_connect`` command to manually trigger a connection attempt.

--- a/samples/net/http_server/README.rst
+++ b/samples/net/http_server/README.rst
@@ -289,7 +289,7 @@ The following serial UART output is displayed in the terminal emulator when runn
          *** Booting nRF Connect SDK v3.4.99-ncs1-4667-g883c3709f9c8 ***
          [00:00:00.529,632] <inf> http_server: HTTP Server sample started
          [00:00:00.554,504] <inf> http_server: Network interface brought up
-         uart:~$ wifi_cred add "cia-asusgold" WPA2-PSK thingy91rocks
+         uart:~$ wifi_cred add -s "cia-asusgold" -k 1 -p thingy91rocks
          uart:~$ wifi_cred auto_connect
          [00:00:53.984,100] <inf> http_server: Network connected
          [00:00:53.985,778] <inf> http_server: Waiting for IPv6 HTTP connections on port 81, sock 9

--- a/samples/wifi/shell/README.rst
+++ b/samples/wifi/shell/README.rst
@@ -272,11 +272,20 @@ It adds the following subcommands to interact with the :ref:`lib_wifi_credential
      - Description
    * - add
      - | Add a network to the credentials storage with following parameters:
-       | <SSID>
-       | <Passphrase> (optional: valid only for secured SSIDs)
-       | <BSSID> (optional)
-       | <Band> (optional: 2.4GHz, 5GHz)
-       | favorite (optional, makes the network higher priority in automatic connection)
+       | <-s --ssid \"<SSID>\">: SSID.
+       | [-c --channel]: Channel that needs to be scanned for connection. 0:any channel
+       | [-b, --band] 0: any band (2:2.4GHz, 5:5GHz, 6:6GHz)
+       | [-p, --passphrase]: Passphrase (valid only for secure SSIDs)
+       | [-k, --key-mgmt]: Key management type.
+       | 0:None, 1:WPA2-PSK, 2:WPA2-PSK-256, 3:SAE-HNP, 4:SAE-H2E, 5:SAE-AUTO, 6:WAPI,"
+       | " 7:EAP-TLS, 8:WEP, 9: WPA-PSK, 10: WPA-Auto-Personal, 11: DPP
+       | [-w, --ieee-80211w]: MFP (optional: needs security type to be specified)
+       | : 0:Disable, 1:Optional, 2:Required.
+       | [-m, --bssid]: MAC address of the AP (BSSID).
+       | [-t, --timeout]: Duration after which connection attempt needs to fail.
+       | [-a, --identity]: Identity for enterprise mode.
+       | [-K, --key-passwd]: Private key passwd for enterprise mode.
+       | [-h, --help]: Print out the help for the connect command.
    * - delete <SSID>
      - Removes network from credentials storage.
    * - list


### PR DESCRIPTION
Backport d05aa8982166ac45a26773ff6e403109f8a38e29 from #18272.