### PR TITLE
[Backport v2.8-branch] subsys: wifi_creds: Fix help output

### DIFF
--- a/subsys/net/lib/wifi_credentials/wifi_credentials_shell.c
+++ b/subsys/net/lib/wifi_credentials/wifi_credentials_shell.c
@@ -314,7 +314,7 @@ SHELL_SUBCMD_ADD((nwifi_cred), add, NULL,
 		 "<-s --ssid \"<SSID>\">: SSID.\n"
 		 "[-c --channel]: Channel that needs to be scanned for connection. 0:any channel.\n"
 		 "[-b, --band] 0: any band (2:2.4GHz, 5:5GHz, 6:6GHz]\n"
-		 "[-p, --psk]: Passphrase (valid only for secure SSIDs)\n"
+		 "[-p, --passphrase]: Passphrase (valid only for secure SSIDs)\n"
 		 "[-k, --key-mgmt]: Key Management type (valid only for secure SSIDs)\n"
 		 "0:None, 1:WPA2-PSK, 2:WPA2-PSK-256, 3:SAE-HNP, 4:SAE-H2E, 5:SAE-AUTO, 6:WAPI,"
 		 " 7:EAP-TLS, 8:WEP, 9: WPA-PSK, 10: WPA-Auto-Personal, 11: DPP\n"
@@ -322,7 +322,7 @@ SHELL_SUBCMD_ADD((nwifi_cred), add, NULL,
 		 ": 0:Disable, 1:Optional, 2:Required.\n"
 		 "[-m, --bssid]: MAC address of the AP (BSSID).\n"
 		 "[-t, --timeout]: Timeout for the connection attempt (in seconds).\n"
-		 "[-a, --anon-id]: Anonymous identity for enterprise mode.\n"
+		 "[-a, --identity]: Identity for enterprise mode.\n"
 		 "[-K, --key-passwd]: Private key passwd for enterprise mode.\n"
 		 "[-h, --help]: Print out the help for the connect command.\n",
 		 cmd_add_network, 2, 12);


### PR DESCRIPTION
Backport d9d598f1fb6952a16bd0c1b022cfc6c4b794952d from #18302.