### PR TITLE
net: openthread: rpc: add unit tests for otNetDataXXX

### DIFF
--- a/subsys/net/openthread/rpc/common/ot_rpc_common.c
+++ b/subsys/net/openthread/rpc/common/ot_rpc_common.c
@@ -276,8 +276,8 @@ void ot_rpc_decode_service_config(struct nrf_rpc_cbor_ctx *ctx, otServiceConfig 
 
 	buf = nrf_rpc_decode_buffer_ptr_and_size(ctx, &size);
 	if (buf && size) {
-		size = MIN(size, sizeof(config->mServerConfig.mServerData));
-		memcpy(config->mServerConfig.mServerData, buf, size);
+		size = MIN(size, sizeof(config->mServiceData));
+		memcpy(config->mServiceData, buf, size);
 		config->mServiceDataLength = size;
 	}
 
@@ -285,8 +285,8 @@ void ot_rpc_decode_service_config(struct nrf_rpc_cbor_ctx *ctx, otServiceConfig 
 
 	buf = nrf_rpc_decode_buffer_ptr_and_size(ctx, &size);
 	if (buf && size) {
-		size = MIN(size, sizeof(config->mServiceData));
-		memcpy(config->mServiceData, buf, size);
+		size = MIN(size, sizeof(config->mServerConfig.mServerData));
+		memcpy(config->mServerConfig.mServerData, buf, size);
 		config->mServerConfig.mServerDataLength = size;
 	}
 
@@ -314,7 +314,7 @@ bool ot_rpc_encode_border_router_config(struct nrf_rpc_cbor_ctx *ctx,
 
 	tmp = config->mPreference;
 
-	if (!zcbor_uint_encode(ctx->zs, &tmp, sizeof(tmp))) {
+	if (!zcbor_int_encode(ctx->zs, &tmp, sizeof(tmp))) {
 		return false;
 	}
 

--- a/tests/subsys/net/openthread/rpc/client/src/netdata_suite.c
+++ b/tests/subsys/net/openthread/rpc/client/src/netdata_suite.c
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <mock_nrf_rpc_transport.h>
+#include <ot_rpc_ids.h>
+#include <ot_rpc_types.h>
+#include <test_rpc_env.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+
+#include <openthread/netdata.h>
+
+/* Fake functions */
+
+static void nrf_rpc_err_handler(const struct nrf_rpc_err_report *report)
+{
+	zassert_ok(report->code);
+}
+
+static void tc_setup(void *f)
+{
+	mock_nrf_rpc_tr_expect_add(RPC_INIT_REQ, RPC_INIT_RSP);
+	zassert_ok(nrf_rpc_init(nrf_rpc_err_handler));
+	mock_nrf_rpc_tr_expect_reset();
+}
+
+/* Test serialization of otNetDataGet() */
+ZTEST(ot_rpc_netdata, test_otNetDataGet)
+{
+	const uint8_t exp_netdata[] = {NETDATA};
+	otError error;
+	/* Make the buffer slightly bigger than the actual data */
+	uint8_t netdata[NETDATA_LENGTH + 1];
+	uint8_t netdata_len = sizeof(netdata);
+
+	mock_nrf_rpc_tr_expect_add(
+		RPC_CMD(OT_RPC_CMD_NETDATA_GET, CBOR_TRUE, CBOR_UINT8(NETDATA_LENGTH + 1)),
+		RPC_RSP(OT_ERROR_NONE, CBOR_NETDATA));
+	error = otNetDataGet(NULL, true, netdata, &netdata_len);
+	mock_nrf_rpc_tr_expect_done();
+
+	zassert_equal(error, OT_ERROR_NONE);
+	zassert_equal(netdata_len, NETDATA_LENGTH);
+	zassert_mem_equal(netdata, exp_netdata, NETDATA_LENGTH);
+}
+
+/* Test serialization of otNetDataGet() returning OT_ERROR_NO_BUFS */
+ZTEST(ot_rpc_netdata, test_otNetDataGet_nobufs)
+{
+	otError error;
+	/* Make the buffer slightly smaller than the actual data */
+	uint8_t netdata[NETDATA_LENGTH - 1];
+	uint8_t netdata_len = sizeof(netdata);
+
+	mock_nrf_rpc_tr_expect_add(
+		RPC_CMD(OT_RPC_CMD_NETDATA_GET, CBOR_FALSE, CBOR_UINT8(NETDATA_LENGTH - 1)),
+		RPC_RSP(OT_ERROR_NO_BUFS));
+	error = otNetDataGet(NULL, false, netdata, &netdata_len);
+	mock_nrf_rpc_tr_expect_done();
+
+	zassert_equal(error, OT_ERROR_NO_BUFS);
+}
+
+/* Test serialization of otNetDataGetNextService() returning OT_ERROR_NONE */
+ZTEST(ot_rpc_netdata, test_otNetDataGetNextService)
+{
+	const uint8_t exp_svc_data[] = {NETDATA_SVC_DATA};
+	const uint8_t exp_svr_data[] = {NETDATA_SVR_DATA};
+	otError error;
+	otNetworkDataIterator iter = UINT32_MAX - 1;
+	otServiceConfig service;
+
+	mock_nrf_rpc_tr_expect_add(
+		RPC_CMD(OT_RPC_CMD_NETDATA_GET_NEXT_SERVICE, CBOR_UINT32(UINT32_MAX - 1)),
+		RPC_RSP(CBOR_UINT32(UINT32_MAX), CBOR_NETDATA_SVC, OT_ERROR_NONE));
+	error = otNetDataGetNextService(NULL, &iter, &service);
+	mock_nrf_rpc_tr_expect_done();
+
+	zassert_equal(error, OT_ERROR_NONE);
+	zassert_equal(iter, UINT32_MAX);
+	zassert_equal(service.mServiceId, NETDATA_SVC_ID);
+	zassert_equal(service.mEnterpriseNumber, NETDATA_SVC_ENTERPRISE);
+	zassert_equal(service.mServiceDataLength, sizeof(exp_svc_data));
+	zassert_mem_equal(service.mServiceData, exp_svc_data, service.mServiceDataLength);
+	zassert_true(service.mServerConfig.mStable);
+	zassert_equal(service.mServerConfig.mServerDataLength, sizeof(exp_svr_data));
+	zassert_mem_equal(service.mServerConfig.mServerData, exp_svr_data,
+			  service.mServerConfig.mServerDataLength);
+	zassert_equal(service.mServerConfig.mRloc16, NETDATA_SVR_RLOC);
+}
+
+/* Test serialization of otNetDataGetNextOnMeshPrefix() returning OT_ERROR_NONE */
+ZTEST(ot_rpc_netdata, test_otNetDataGetNextOnMeshPrefix)
+{
+	const uint8_t exp_prefix[] = {ADDR_1};
+	otError error;
+	otNetworkDataIterator iter = UINT32_MAX - 1;
+	otBorderRouterConfig br;
+
+	mock_nrf_rpc_tr_expect_add(
+		RPC_CMD(OT_RPC_CMD_NETDATA_GET_NEXT_ON_MESH_PREFIX, CBOR_UINT32(UINT32_MAX - 1)),
+		RPC_RSP(CBOR_UINT32(UINT32_MAX), CBOR_NETDATA_BR, OT_ERROR_NONE));
+	error = otNetDataGetNextOnMeshPrefix(NULL, &iter, &br);
+	mock_nrf_rpc_tr_expect_done();
+
+	zassert_equal(error, OT_ERROR_NONE);
+	zassert_equal(iter, UINT32_MAX);
+	zassert_equal(br.mPrefix.mLength, 64);
+	zassert_mem_equal(br.mPrefix.mPrefix.mFields.m8, exp_prefix, 64 / 8);
+	zassert_equal(br.mPreference, -1);
+	zassert_true(br.mPreferred);
+	zassert_false(br.mSlaac);
+	zassert_true(br.mDhcp);
+	zassert_false(br.mConfigure);
+	zassert_true(br.mDefaultRoute);
+	zassert_false(br.mOnMesh);
+	zassert_true(br.mStable);
+	zassert_false(br.mNdDns);
+	zassert_true(br.mDp);
+}
+
+ZTEST_SUITE(ot_rpc_netdata, NULL, NULL, tc_setup, NULL, NULL);

--- a/tests/subsys/net/openthread/rpc/common/test_rpc_env.h
+++ b/tests/subsys/net/openthread/rpc/common/test_rpc_env.h
@@ -53,7 +53,6 @@
 #define HOP_LIMIT 64
 #define DNS_NAME                                                                                   \
 	STR_SEQUENCE(63), '.', STR_SEQUENCE(63), '.', STR_SEQUENCE(63), '.', STR_SEQUENCE(63)
-
 #define MADDR_FF02_1  0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01
 #define EXT_ADDR      0x48, INT_SEQUENCE(OT_EXT_ADDRESS_SIZE)
 #define NWK_NAME      0x70, INT_SEQUENCE(OT_NETWORK_NAME_MAX_SIZE)
@@ -81,3 +80,20 @@
 #define CBOR_ADDR1 0x50, ADDR_1
 
 #define CBOR_SOC_ADDR CBOR_ADDR1, CBOR_UINT16(1024)
+
+#define NETDATA_LENGTH	       254
+#define NETDATA		       INT_SEQUENCE(NETDATA_LENGTH)
+#define NETDATA_SVC_ID	       0x51
+#define NETDATA_SVC_ENTERPRISE 0x51012345
+#define NETDATA_SVC_DATA       INT_SEQUENCE(OT_SERVICE_DATA_MAX_SIZE)
+#define NETDATA_SVR_DATA       INT_SEQUENCE(OT_SERVER_DATA_MAX_SIZE)
+#define NETDATA_SVR_RLOC       0x1234
+#define NETDATA_BR_RLOC	       0x2345
+#define CBOR_NETDATA	       0x58, NETDATA_LENGTH, NETDATA
+#define CBOR_NETDATA_SVC                                                                           \
+	CBOR_UINT8(NETDATA_SVC_ID), CBOR_UINT32(NETDATA_SVC_ENTERPRISE), 0x58,                     \
+		OT_SERVICE_DATA_MAX_SIZE, NETDATA_SVC_DATA, CBOR_TRUE, 0x58,                       \
+		OT_SERVER_DATA_MAX_SIZE, NETDATA_SVR_DATA, CBOR_UINT16(NETDATA_SVR_RLOC)
+#define CBOR_NETDATA_BR                                                                            \
+	CBOR_ADDR1, CBOR_UINT8(64), 0x20, CBOR_TRUE, CBOR_FALSE, CBOR_TRUE, CBOR_FALSE, CBOR_TRUE, \
+		CBOR_FALSE, CBOR_TRUE, CBOR_FALSE, CBOR_TRUE, CBOR_UINT16(NETDATA_BR_RLOC)

--- a/tests/subsys/net/openthread/rpc/server/src/ip6_suite.c
+++ b/tests/subsys/net/openthread/rpc/server/src/ip6_suite.c
@@ -27,11 +27,6 @@ FAKE_VALUE_FUNC(otError, otIp6SubscribeMulticastAddress, otInstance *, const otI
 FAKE_VALUE_FUNC(otError, otIp6UnsubscribeMulticastAddress, otInstance *, const otIp6Address *);
 FAKE_VALUE_FUNC(otError, otIp6SetEnabled, otInstance *, bool);
 FAKE_VALUE_FUNC(bool, otIp6IsEnabled, otInstance *);
-FAKE_VALUE_FUNC(otError, otNetDataGet, otInstance *, bool, uint8_t *, uint8_t *);
-FAKE_VALUE_FUNC(otError, otNetDataGetNextService, otInstance *, otNetworkDataIterator *,
-		otServiceConfig *);
-FAKE_VALUE_FUNC(otError, otNetDataGetNextOnMeshPrefix, otInstance *, otNetworkDataIterator *,
-		otBorderRouterConfig *);
 
 #define FOREACH_FAKE(f)                                                                            \
 	f(otCliInit);                                                                              \
@@ -41,10 +36,7 @@ FAKE_VALUE_FUNC(otError, otNetDataGetNextOnMeshPrefix, otInstance *, otNetworkDa
 	f(otIp6SubscribeMulticastAddress);                                                         \
 	f(otIp6UnsubscribeMulticastAddress);                                                       \
 	f(otIp6SetEnabled);                                                                        \
-	f(otIp6IsEnabled);                                                                         \
-	f(otNetDataGet);                                                                           \
-	f(otNetDataGetNextService);                                                                \
-	f(otNetDataGetNextOnMeshPrefix);
+	f(otIp6IsEnabled);
 
 static void nrf_rpc_err_handler(const struct nrf_rpc_err_report *report)
 {

--- a/tests/subsys/net/openthread/rpc/server/src/netdata_suite.c
+++ b/tests/subsys/net/openthread/rpc/server/src/netdata_suite.c
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <mock_nrf_rpc_transport.h>
+#include <ot_rpc_ids.h>
+#include <ot_rpc_message.h>
+#include <test_rpc_env.h>
+
+#include <zephyr/fff.h>
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+
+#include <openthread/netdata.h>
+
+/* Fake functions */
+
+FAKE_VALUE_FUNC(otError, otNetDataGet, otInstance *, bool, uint8_t *, uint8_t *);
+FAKE_VALUE_FUNC(otError, otNetDataGetNextService, otInstance *, otNetworkDataIterator *,
+		otServiceConfig *);
+FAKE_VALUE_FUNC(otError, otNetDataGetNextOnMeshPrefix, otInstance *, otNetworkDataIterator *,
+		otBorderRouterConfig *);
+
+#define FOREACH_FAKE(f)                                                                            \
+	f(otNetDataGet);                                                                           \
+	f(otNetDataGetNextService);                                                                \
+	f(otNetDataGetNextOnMeshPrefix);
+
+static void nrf_rpc_err_handler(const struct nrf_rpc_err_report *report)
+{
+	zassert_ok(report->code);
+}
+
+static void tc_setup(void *f)
+{
+	mock_nrf_rpc_tr_expect_add(RPC_INIT_REQ, RPC_INIT_RSP);
+	zassert_ok(nrf_rpc_init(nrf_rpc_err_handler));
+	mock_nrf_rpc_tr_expect_reset();
+
+	FOREACH_FAKE(RESET_FAKE);
+	FFF_RESET_HISTORY();
+}
+
+static otError ot_netdata_get(otInstance *instance, bool stable, uint8_t *out, uint8_t *out_len)
+{
+	const uint8_t netdata[] = {NETDATA};
+
+	if (sizeof(netdata) > *out_len) {
+		return OT_ERROR_NO_BUFS;
+	}
+
+	memcpy(out, netdata, sizeof(netdata));
+	*out_len = sizeof(netdata);
+
+	return OT_ERROR_NONE;
+}
+
+/*
+ * Test reception of otNetDataGet() command.
+ * Test serialization of the result: OT_ERROR_NONE.
+ */
+ZTEST(ot_rpc_netdata, test_otNetDataGet)
+{
+	otNetDataGet_fake.custom_fake = ot_netdata_get;
+
+	mock_nrf_rpc_tr_expect_add(RPC_RSP(OT_ERROR_NONE, CBOR_NETDATA), NO_RSP);
+	mock_nrf_rpc_tr_receive(
+		RPC_CMD(OT_RPC_CMD_NETDATA_GET, CBOR_TRUE, CBOR_UINT8(NETDATA_LENGTH + 1)));
+	mock_nrf_rpc_tr_expect_done();
+
+	zassert_equal(otNetDataGet_fake.call_count, 1);
+	zassert_true(otNetDataGet_fake.arg1_val);
+}
+
+/*
+ * Test reception of otNetDataGet() command.
+ * Test serialization of the result: OT_ERROR_NO_BUFS.
+ */
+ZTEST(ot_rpc_netdata, test_otNetDataGet_nobufs)
+{
+	otNetDataGet_fake.custom_fake = ot_netdata_get;
+
+	mock_nrf_rpc_tr_expect_add(RPC_RSP(OT_ERROR_NO_BUFS), NO_RSP);
+	mock_nrf_rpc_tr_receive(
+		RPC_CMD(OT_RPC_CMD_NETDATA_GET, CBOR_FALSE, CBOR_UINT8(NETDATA_LENGTH - 1)));
+	mock_nrf_rpc_tr_expect_done();
+
+	zassert_equal(otNetDataGet_fake.call_count, 1);
+	zassert_false(otNetDataGet_fake.arg1_val);
+}
+
+static otError ot_netdata_get_next_service(otInstance *instance, otNetworkDataIterator *iter,
+					   otServiceConfig *service)
+{
+	const uint8_t svc_data[] = {NETDATA_SVC_DATA};
+	const uint8_t svr_data[] = {NETDATA_SVR_DATA};
+
+	/* Just increment the iterator */
+	++*iter;
+
+	service->mServiceId = NETDATA_SVC_ID;
+	service->mEnterpriseNumber = NETDATA_SVC_ENTERPRISE;
+	service->mServiceDataLength = sizeof(svc_data);
+	memcpy(service->mServiceData, svc_data, sizeof(svc_data));
+	service->mServerConfig.mServerDataLength = sizeof(svr_data);
+	memcpy(service->mServerConfig.mServerData, svr_data, sizeof(svr_data));
+	service->mServerConfig.mStable = true;
+	service->mServerConfig.mRloc16 = NETDATA_SVR_RLOC;
+
+	return OT_ERROR_NONE;
+}
+
+/*
+ * Test reception of otNetDataGetNextService() command.
+ * Test serialization of the result: OT_ERROR_NONE.
+ */
+ZTEST(ot_rpc_netdata, test_otNetDataGetNextService)
+{
+	otNetDataGetNextService_fake.custom_fake = ot_netdata_get_next_service;
+
+	mock_nrf_rpc_tr_expect_add(
+		RPC_RSP(CBOR_UINT32(UINT32_MAX), CBOR_NETDATA_SVC, OT_ERROR_NONE), NO_RSP);
+	mock_nrf_rpc_tr_receive(
+		RPC_CMD(OT_RPC_CMD_NETDATA_GET_NEXT_SERVICE, CBOR_UINT32(UINT32_MAX - 1)));
+	mock_nrf_rpc_tr_expect_done();
+
+	zassert_equal(otNetDataGetNextService_fake.call_count, 1);
+}
+
+static otError ot_netdata_get_next_on_mesh_prefix(otInstance *instance, otNetworkDataIterator *iter,
+						  otBorderRouterConfig *br)
+{
+	const uint8_t prefix[] = {ADDR_1};
+
+	/* Just increment the iterator */
+	++*iter;
+
+	memcpy(br->mPrefix.mPrefix.mFields.m8, prefix, sizeof(prefix));
+	br->mPrefix.mLength = 64;
+	br->mPreference = -1;
+	br->mPreferred = true;
+	br->mSlaac = false;
+	br->mDhcp = true;
+	br->mConfigure = false;
+	br->mDefaultRoute = true;
+	br->mOnMesh = false;
+	br->mStable = true;
+	br->mNdDns = false;
+	br->mDp = true;
+	br->mRloc16 = NETDATA_BR_RLOC;
+
+	return OT_ERROR_NONE;
+}
+
+/*
+ * Test reception of otNetDataGetNextOnMeshPrefix() command.
+ * Test serialization of the result: OT_ERROR_NONE.
+ */
+ZTEST(ot_rpc_netdata, test_otNetDataGetNextOnMeshPrefix)
+{
+	otNetDataGetNextOnMeshPrefix_fake.custom_fake = ot_netdata_get_next_on_mesh_prefix;
+
+	mock_nrf_rpc_tr_expect_add(RPC_RSP(CBOR_UINT32(UINT32_MAX), CBOR_NETDATA_BR, OT_ERROR_NONE),
+				   NO_RSP);
+	mock_nrf_rpc_tr_receive(
+		RPC_CMD(OT_RPC_CMD_NETDATA_GET_NEXT_ON_MESH_PREFIX, CBOR_UINT32(UINT32_MAX - 1)));
+	mock_nrf_rpc_tr_expect_done();
+
+	zassert_equal(otNetDataGetNextOnMeshPrefix_fake.call_count, 1);
+}
+
+ZTEST_SUITE(ot_rpc_netdata, NULL, NULL, tc_setup, NULL, NULL);


### PR DESCRIPTION
1. Add unit tests for APIs implemented in ot_rpc_netdata.c
2. Fix the implementation of otNetDataGet() not to use the output length if the function returns an error.