### PR TITLE
doc: nrfvsc: edits to general docs

### DIFF
--- a/doc/nrf/app_dev/config_and_build/building.rst
+++ b/doc/nrf/app_dev/config_and_build/building.rst
@@ -16,12 +16,13 @@ Just as for creating the application, you can build the application using either
 
    .. group-tab:: nRF Connect for VS Code
 
-      For instructions about building with the |nRFVSC|, see `How to build an application`_ in the extension documentation.
+      To build with the |nRFVSC|, you first need to create a build configuration.
+      For instructions, see `How to build an application`_ in the extension documentation.
 
       By default, the extension runs both stages of the CMake build (:ref:`configuration phase and building phase <app_build_system>`).
       If you want to only set up the build configuration without building it, make sure the :guilabel:`Build after generating configuration` is not selected.
 
-      To build with :ref:`configuration_system_overview_sysbuild`, select the :guilabel:`Use sysbuild` checkbox.
+      To build with :ref:`configuration_system_overview_sysbuild`, :ref:`keep the default setting selected <sysbuild_enabled_ncs>` or select the :guilabel:`Use sysbuild` radio button.
 
       If you want to build with custom options or scripts, read about `Binding custom tasks to actions`_ in the extension documentation.
 

--- a/doc/nrf/app_dev/config_and_build/cmake/index.rst
+++ b/doc/nrf/app_dev/config_and_build/cmake/index.rst
@@ -115,12 +115,14 @@ This is how you can specify them:
       See `How to build an application`_ in the |nRFVSC| documentation.
       You can specify the additional configuration variables when `setting up a build configuration <How to build an application_>`_:
 
-      * :makevar:`FILE_SUFFIX` (and :makevar:`CONF_FILE`) - Select the configuration in the :guilabel:`Configuration` menu.
-      * :makevar:`EXTRA_CONF_FILE` - Add the Kconfig fragment file in the :guilabel:`Kconfig fragments` menu.
-      * :makevar:`EXTRA_DTC_OVERLAY_FILE` - Add the devicetree overlays in the :guilabel:`Devicetree overlays` menu.
+      * :makevar:`FILE_SUFFIX` (and :makevar:`CONF_FILE`) - Select the configuration in the :guilabel:`Base configuration files` menu.
+      * :makevar:`EXTRA_CONF_FILE` - Add the Kconfig fragment file in the :guilabel:`Extra Kconfig fragments` menu.
+      * :makevar:`DTC_OVERLAY_FILE` - Select the configuration in the :guilabel:`Base devicetree overlays` menu.
+      * :makevar:`EXTRA_DTC_OVERLAY_FILE` - Add the devicetree overlays in the :guilabel:`Extra devicetree overlays` menu.
+      * :makevar:`SNIPPET` - Select the snippet from the list in the :guilabel:`Snippets` menu.
       * Other variables - Provide CMake arguments in the :guilabel:`Extra CMake arguments` field, preceded by ``--``.
 
-      For example, to build the :ref:`location_sample` sample for the nRF9161 DK with the nRF7002 EK Wi-Fi support, select ``nrf9161dk/nrf9161/ns`` in the :guilabel:`Board` menu, :file:`overlay-nrf7002ek-wifi-scan-only.conf` in the :guilabel:`Kconfig fragments` menu, and provide ``-- -DSHIELD=nrf7002ek`` in the :guilabel:`Extra CMake arguments` field.
+      For example, to build the :ref:`location_sample` sample for the nRF9161 DK with the nRF7002 EK Wi-Fi support, select ``nrf9161dk/nrf9161/ns`` in the :guilabel:`Board` menu, :file:`overlay-nrf7002ek-wifi-scan-only.conf` in the :guilabel:`Extra Kconfig fragments` menu, and provide ``-- -DSHIELD=nrf7002ek`` in the :guilabel:`Extra CMake arguments` field.
 
    .. group-tab:: Command line
 

--- a/doc/nrf/app_dev/config_and_build/config_and_build_system.rst
+++ b/doc/nrf/app_dev/config_and_build/config_and_build_system.rst
@@ -273,12 +273,13 @@ Sysbuild enabled by default
 
 :ref:`configuration_system_overview_sysbuild` in the |NCS| works differently than in Zephyr.
 
-The |NCS| `modifies the default behavior <sdk-zephyr west build patch_>`_ of ``west build``, so that the :ref:`standard building procedure <building>` will use sysbuild by default for :ref:`repository applications <create_application_types_repository>` in the :ref:`SDK repositories <dm_repo_types>`.
+The |NCS| `modifies the default behavior <sdk-zephyr west build patch_>`_ of ``west build``: the :ref:`standard building procedure <building>` in the |NCS| uses sysbuild by default for all types of applications in the :ref:`SDK repositories <dm_repo_types>`.
+This includes :ref:`repository applications <create_application_types_repository>` and the out-of-tree applications (:ref:`workspace <create_application_types_workspace>` and :ref:`freestanding applications <create_application_types_freestanding>`).
+
 For this reason, unlike in Zephyr, ``--sysbuild`` does not have to be explicitly mentioned in the command prompt when building a repository application.
 This setting only applies to repositories delivered with the |NCS|, to maintain compatibility with child/parent images.
 
-This setting does not apply to out-of-tree applications, such as :ref:`workspace <create_application_types_workspace>` or :ref:`freestanding applications <create_application_types_freestanding>`.
-In such cases, once you ported your application to sysbuild, it is up to you to either use the ``--sysbuild`` parameter on the command line every time you build or to :ref:`configure west to always use it <sysbuild_enabled_ncs_configuring>`.
+If you want to disable this feature, for example if you want to explicitly use the ``--sysbuild`` parameter on the command line every time you build, :ref:`configure west to disable this default setting <sysbuild_enabled_ncs_configuring>`.
 
 Moreover, this |NCS| setting does not apply to the following areas:
 

--- a/doc/nrf/app_dev/config_and_build/sysbuild/sysbuild_configuring_west.rst
+++ b/doc/nrf/app_dev/config_and_build/sysbuild/sysbuild_configuring_west.rst
@@ -3,16 +3,23 @@
 Configuring sysbuild usage in west
 ##################################
 
-The |NCS| has :ref:`sysbuild enabled by default <sysbuild_enabled_ncs>` for for :ref:`repository applications <create_application_types_repository>` in the :ref:`SDK repositories <dm_repo_types>`.
+The |NCS| has :ref:`sysbuild enabled by default <sysbuild_enabled_ncs>` for :ref:`all types of applications <create_application_types>` in the :ref:`SDK repositories <dm_repo_types>`.
 
-If you work with out-of-tree applications, such as :ref:`workspace <create_application_types_workspace>` or :ref:`freestanding applications <create_application_types_freestanding>`, you can configure your project to use sysbuild by default whenever invoking ``west build``.
+You can configure your project to not sysbuild by default whenever invoking ``west build``.
 You can do this either per-workspace, using the local configuration option, or for all your workspaces, using the global configuration option:
 
 .. tabs::
 
    .. group-tab:: Local sysbuild configuration
 
-      Use the following command to configure west to use sysbuild by default for building all projects in the current workspace (including any freestanding applications that are built against it):
+      Use the following command to configure west not to use sysbuild by default for building all projects in the current workspace:
+
+      .. parsed-literal::
+         :class: highlight
+
+         west config --local build.sysbuild False
+
+      Use the following command to configure west to use sysbuild by default:
 
       .. parsed-literal::
          :class: highlight
@@ -21,7 +28,14 @@ You can do this either per-workspace, using the local configuration option, or f
 
    .. group-tab:: Global sysbuild configuration
 
-      Use the following command to configure west to use sysbuild by default for building all projects in all workspaces:
+      Use the following command to configure west not to use sysbuild by default for building all projects in all workspaces:
+
+      .. parsed-literal::
+         :class: highlight
+
+         west config --global build.sysbuild False
+
+      Use the following command to configure west to use sysbuild by default:
 
       .. parsed-literal::
          :class: highlight

--- a/doc/nrf/installation/install_ncs.rst
+++ b/doc/nrf/installation/install_ncs.rst
@@ -102,10 +102,11 @@ Depending on your preferred development environment, complete the following step
       #. In the extension's :guilabel:`Welcome View`, click on :guilabel:`Manage toolchains`.
          The list of actions appears in the |VSC|'s quick pick.
       #. Click :guilabel:`Install Toolchain`.
-         The list of available toolchain versions appears in the |VSC|'s quick pick.
+         The list of available stable toolchain versions appears in the |VSC|'s quick pick.
       #. Select the toolchain version to install.
          The toolchain version should match the |NCS| version you are going to work with.
          If you have received a custom URL for installing the toolchain, you can provide it using the :guilabel:`Change Toolchain Index` button in the quick pick's header (wrench icon).
+         If you are working with a development tag, disable the filter in the quick pick's header to list all available toolchains.
          The toolchain installation starts in the background, as can be seen in the notification that appears.
 
       When you install the toolchain for the first time, the installed version is automatically selected for your project.
@@ -207,7 +208,7 @@ For more information about the repository and development model, see the :ref:`d
       #. In the extension's :guilabel:`Welcome View`, click on :guilabel:`Manage SDKs`.
          The list of actions appears in the |VSC|'s quick pick.
       #. Click :guilabel:`Install SDK`.
-         The list of available SDK versions appears in the |VSC|'s quick pick.
+         The list of available stable SDK versions appears in the |VSC|'s quick pick.
       #. Select the SDK version to install.
          |install_latest_version|
 


### PR DESCRIPTION
Edited sections about the nRF Connect for VSC in the general docs. Edited information about which apps sysbuild is enabled by default for. VSC-2711.

----

To be merged when the nRF Connect for VSC releases, before the final nRF Connect SDK v2.8.0 tag.