### PR TITLE
[Backport v2.8-branch] doc: openthread: cleanup and align for nRF54L

### DIFF
--- a/doc/nrf/includes/sample_board_rows.txt
+++ b/doc/nrf/includes/sample_board_rows.txt
@@ -237,3 +237,9 @@
 .. nrf54l15dk_nrf54l15_cpuapp_ns
 
 | :ref:`nRF54L15 DK <ug_nrf54l>` | PCA10156 | :ref:`nrf54l15dk <zephyr:nrf54l15dk_nrf54l15>` | ``nrf54l15dk/nrf54l15/cpuapp/ns`` |
+
+.. nrf54l15dk_nrf54l15_cpuapp_and_cpuapp_ns
+
+| :ref:`nRF54L15 DK <ug_nrf54l>` | PCA10156 | :ref:`nrf54l15dk <zephyr:nrf54l15dk_nrf54l15>` | ``nrf54l15dk/nrf54l15/cpuapp``    |
+|                                |          |                                                |                                   |
+|                                |          |                                                | ``nrf54l15dk/nrf54l15/cpuapp/ns`` |

--- a/doc/nrf/protocols/thread/configuring.rst
+++ b/doc/nrf/protocols/thread/configuring.rst
@@ -265,11 +265,9 @@ Minimal Thread Device (MTD)
 Trusted Firmware-M support options
 ==================================
 
-To configure your Thread application on the nRF5340 DK to run with Trusted Firmware-M, use the ``nrf5340dk/nrf5340/cpuapp/ns`` board target and enable the following Kconfig options:
+To configure your Thread application to run with Trusted Firmware-M, use the following board target:
 
-* :kconfig:option:`CONFIG_BUILD_WITH_TFM`
-* :kconfig:option:`CONFIG_OPENTHREAD_CRYPTO_PSA`
-
-In the |NCS|, these options are enabled by default for the :ref:`application core <ug_nrf5340_intro_app_core>` of the :ref:`openthread_samples` that can be programmed with the ``nrf5340dk/nrf5340/cpuapp/ns`` board target.
+* ``nrf5340dk/nrf5340/cpuapp/ns`` for the nRF5340 DK
+* ``nrf54l15dk/nrf54l15/cpuapp/ns``` for the nRF54L15 DK
 
 For more Trusted Firmware-M documentation, see :ref:`ug_tfm` and the official `TF-M documentation`_.

--- a/doc/nrf/protocols/thread/overview/architectures.rst
+++ b/doc/nrf/protocols/thread/overview/architectures.rst
@@ -56,14 +56,14 @@ This design has the following advantages:
 
 It has the following disadvantages:
 
-* For some use cases, the nRF52 Series and nRF53 Series MCUs can be too slow (for example, when the application does complex data processing).
+* For some use cases, the nRF52 Series, nRF53 Series and nRF54L Series MCUs can be too slow (for example, when the application does complex data processing).
 * The application and the network share flash and RAM space, which can limit the application functionality.
 * Might require external flash for DFU if the secondary application slot does not fit in the primary memory because of increased application size.
 
 .. figure:: images/thread_platform_design_soc.svg
-   :alt: Thread-only architecture (nRF52)
+   :alt: Thread-only architecture (nRF52, nRF54L)
 
-   Thread-only architecture on nRF52 Series devices
+   Thread-only architecture on nRF52 Series and nRF54L Series devices
 
 .. figure:: images/thread_platform_design_nRF53.svg
    :alt: Thread-only architecture (nRF53)
@@ -74,14 +74,14 @@ This platform design is suitable for the following development kits:
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf21540dk_nrf52840
+   :rows: nrf52840dk_nrf52840, nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf54l15dk_nrf54l15_cpuapp_and_cpuapp_ns, nrf21540dk_nrf52840
 
 .. _thread_architectures_designs_soc_designs_multiprotocol:
 
 Single-chip, multiprotocol (SoC)
 ================================
 
-nRF52 and nRF53 Series devices support multiple wireless technologies, including IEEE 802.15.4 and Bluetooth® Low Energy (Bluetooth LE).
+nRF52 Series, nRF53 Series and nRF54L Series devices support multiple wireless technologies, including IEEE 802.15.4 and Bluetooth® Low Energy (Bluetooth LE).
 
 In a single-chip, multiprotocol design, the application layer and OpenThread run on the same processor.
 
@@ -95,9 +95,9 @@ It has the following disadvantages:
 * Bluetooth LE activity can degrade the connectivity on Thread if not implemented with efficiency in mind.
 
 .. figure:: images/thread_platform_design_multi.svg
-   :alt: Multiprotocol Thread and Bluetooth LE architecture (nRF52)
+   :alt: Multiprotocol Thread and Bluetooth LE architecture (nRF52, nRF54L)
 
-   Multiprotocol Thread and Bluetooth LE architecture on nRF52 Series devices
+   Multiprotocol Thread and Bluetooth LE architecture on nRF52 Series and nRF54L Series devices
 
 .. figure:: images/thread_platform_design_nRF53_multi.svg
    :alt: Multiprotocol Thread and Bluetooth LE architecture (nRF53)
@@ -110,7 +110,7 @@ This platform design is suitable for the following development kits:
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns
+   :rows: nrf52840dk_nrf52840, nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf54l15dk_nrf54l15_cpuapp_and_cpuapp_ns
 
 .. _thread_architectures_designs_cp:
 
@@ -190,7 +190,7 @@ This platform design is suitable for the following development kits:
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf21540dk_nrf52840
+   :rows: nrf52833dk_nrf52833, nrf52840dk_nrf52840, nrf54l15dk_nrf54l15_cpuapp_and_cpuapp_ns, nrf21540dk_nrf52840
 
 .. _thread_architectures_designs_cp_uart:
 

--- a/doc/nrf/protocols/thread/overview/ot_memory.rst
+++ b/doc/nrf/protocols/thread/overview/ot_memory.rst
@@ -41,7 +41,7 @@ See :ref:`thread_device_types` for more information on device types, and :ref:`t
 nRF54L15 DK RAM and flash memory requirements
 *********************************************
 
-The following tables present memory requirements for samples running on the :ref:`nRF54L15 DK <programming_board_names>` (:ref:`nrf54l15dk <zephyr:nrf54l15dk_nrf54l15>`) with the software cryptography support provided by the :ref:`nrfxlib:nrf_oberon_readme` module.
+The following tables present memory requirements for samples running on the :ref:`nRF54L15 DK <programming_board_names>` (:ref:`nrf54l15dk <zephyr:nrf54l15dk_nrf54l15>`) with the cryptography support provided by the :ref:`nrf_security_drivers_cracen`.
 
 .. include:: memory_tables/nrf54l15.txt
 
@@ -50,7 +50,7 @@ The following tables present memory requirements for samples running on the :ref
 nRF5340 DK RAM and flash memory requirements
 *********************************************
 
-The following tables present memory requirements for samples running on the :ref:`nRF5340 DK <programming_board_names>` (:ref:`nrf5340dk <zephyr:nrf5340dk_nrf5340>`) with the software cryptography support provided by the :ref:`nrfxlib:nrf_oberon_readme` module.
+The following tables present memory requirements for samples running on the :ref:`nRF5340 DK <programming_board_names>` (:ref:`nrf5340dk <zephyr:nrf5340dk_nrf5340>`) with the cryptography support provided by the :ref:`nrf_security_drivers_oberon`.
 
 .. include:: memory_tables/nrf5340.txt
 
@@ -59,6 +59,6 @@ The following tables present memory requirements for samples running on the :ref
 nRF52840 DK RAM and flash memory requirements
 *********************************************
 
-The following tables present memory requirements for samples running on the :ref:`nRF52840 DK <programming_board_names>` (:ref:`nrf52840dk_nrf52840 <zephyr:nrf52840dk_nrf52840>`) with the software cryptography support provided by the :ref:`nrfxlib:nrf_oberon_readme` module.
+The following tables present memory requirements for samples running on the :ref:`nRF52840 DK <programming_board_names>` (:ref:`nrf52840dk_nrf52840 <zephyr:nrf52840dk_nrf52840>`) with the cryptography support provided by the :ref:`nrf_security_drivers_oberon`.
 
 .. include:: memory_tables/nrf52840.txt

--- a/doc/nrf/protocols/thread/overview/supported_features.rst
+++ b/doc/nrf/protocols/thread/overview/supported_features.rst
@@ -124,15 +124,6 @@ The Thread Domain operational configuration enables Thread Devices to join and p
 A user or network administrator may use functions of either Thread Commissioning or Thread Border Routers to set up a common Thread Domain operational configuration for Thread Devices.
 The Thread Devices can belong to different Thread networks or `Partitions <Thread Partitions_>`_ that have potentially different per-network credentials.
 
-.. _ug_thread_12_support_limitations:
-
-Limitations for Thread 1.2 support
-==================================
-
-The Thread 1.2 Specification support has the following limitation:
-
-* Due to code size limitation, the combination of complete set of Thread 1.2 features with the Bluetooth® LE multiprotocol support is not possible for the nRF52833 DKs.
-
 .. _thread_ug_supported_features_v13:
 
 Thread 1.3 features


### PR DESCRIPTION
Backport 56a2a16c79fa8f455401566eba2d12703469eebc~2..56a2a16c79fa8f455401566eba2d12703469eebc from #18311.