### PR TITLE
[Backport v2.8-branch] tests: benchmarks: power_consumption: uart test fixups

### DIFF
--- a/tests/benchmarks/power_consumption/uart_async/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/benchmarks/power_consumption/uart_async/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,3 @@
+&uart136 {
+	zephyr,pm-device-runtime-auto;
+};

--- a/tests/benchmarks/power_consumption/uart_async/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/benchmarks/power_consumption/uart_async/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,3 @@
+&uart20 {
+	zephyr,pm-device-runtime-auto;
+};

--- a/tests/benchmarks/power_consumption/uart_async/src/driver_test.c
+++ b/tests/benchmarks/power_consumption/uart_async/src/driver_test.c
@@ -43,6 +43,6 @@ void thread_definition(void)
 			printk("Issue with transferring data, terminating thread.");
 			return;
 		}
-		k_usleep(200);
+		k_usleep(400);
 	}
 }

--- a/tests/benchmarks/power_consumption/uart_polling/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/benchmarks/power_consumption/uart_polling/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,3 @@
+&uart136 {
+	zephyr,pm-device-runtime-auto;
+};

--- a/tests/benchmarks/power_consumption/uart_polling/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/benchmarks/power_consumption/uart_polling/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,3 @@
+&uart20 {
+	zephyr,pm-device-runtime-auto;
+};


### PR DESCRIPTION
Backport b01a58ad2c56ebfdfe1557777d7badabff4aed38 from #18334.