### PR TITLE
doc: nrf: Add a section about hostap

### DIFF
--- a/doc/nrf/app_dev/device_guides/nrf70/features.rst
+++ b/doc/nrf/app_dev/device_guides/nrf70/features.rst
@@ -55,3 +55,39 @@ The nRF70 Series devices also support the following functionalities:
 Peer-to-peer support in the form of Wi-Fi Direct® will be available in the future.
 
 See the :ref:`ug_wifi` documentation for more information related to Wi-Fi modes of operation.
+
+.. _ug_nrf70_features_hostap:
+
+hostap
+******
+
+The nRF70 Series devices use the `WPA Supplicant`_ to implement full Wi-Fi functionality.
+The WPA supplicant is part of the ``hostap`` project and is a widely used implementation of the IEEE 802.11i standard for wireless LAN security.
+The WPA supplicant is a software component that implements the Wi-Fi Protected Access (WPA™), WPA2™ and WPA3™ security protocols.
+
+The nRF70 Series devices use `Zephyr hostap fork`_, a fork of the hostap project that is integrated with the Zephyr RTOS.
+The WPA supplicant is integrated with the Zephyr RTOS and registers as a Wi-Fi network manager in the Zephyr networking stack.
+See `Zephyr Wi-Fi NM API`_ for details.
+The `Zephyr Wi-Fi management`_ layer in Zephyr uses the Wi-Fi network manager to manage the Wi-Fi interface.
+
+The nRF70 Series driver registers as a Wi-Fi device in the Zephyr networking stack and provides the Wi-Fi interface to the WPA supplicant.
+The WPA supplicant then manages the Wi-Fi interface and provides the Wi-Fi functionality to the application.
+
+.. note::
+
+      The WPA supplicant is only used for System mode to offer full Wi-Fi functionality.
+      It is not used in other modes, for example, Scan-only mode.
+
+Supported hostap features in the |NCS|
+======================================
+
+The `Zephyr hostap fork`_ supports a wide range of Wi-Fi features and functionalities.
+The nRF70 Series devices use the Zephyr hostap fork but only implement a subset of the features supported by the fork.
+
+The nRF70 Series devices support the following features:
+
+* Wi-Fi 6 support.
+* Station mode.
+* SoftAP mode - Based on ``wpa_supplicant``.
+* WPA2-PSK and WPA3-SAE security modes.
+* WPA2-EAP-TLS security mode.

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -23,6 +23,8 @@
 .. _`Zephyr net capture`: https://docs.zephyrproject.org/latest/samples/net/capture/README.html
 .. _`Zephyr net capture Linux setup`: https://docs.zephyrproject.org/latest/connectivity/networking/usbnet_setup.html#usb-device-networking-setup
 .. _`Zephyr net DHCPv4 server`: https://docs.zephyrproject.org/apidoc/latest/group__dhcpv4__server.html
+.. _`Zephyr Wi-Fi NM API`: https://docs.zephyrproject.org/apidoc/latest/wifi__nm_8h.html
+.. _`Zephyr Wi-Fi management`: https://docs.zephyrproject.org/latest/connectivity/networking/api/wifi.html
 
 .. ### Source: github.com
 
@@ -202,6 +204,8 @@
 .. _`Memfault firmware SDK`: https://github.com/memfault/memfault-firmware-sdk
 .. _`Memfault WebBluetooth Client source code`: https://github.com/memfault/web-ble-example/blob/main/mds.js
 .. _`Memfault-SDK`: https://github.com/memfault/memfault-firmware-sdk
+
+.. _`Zephyr hostap fork`: https://github.com/zephyrproject-rtos/hostap
 
 .. ### Source: github.io
 


### PR DESCRIPTION
Now that we use upstream Zephyr fork for hostap, we need to document the scope of features supported in NCS as it's only a subset of upstream Zephyr.