### PR TITLE
applications: nrf_desktop: Add HID reportq documentation

### DIFF
--- a/applications/nrf_desktop/doc/hid_forward.rst
+++ b/applications/nrf_desktop/doc/hid_forward.rst
@@ -32,16 +32,23 @@ Complete the following steps to configure the module:
    Make sure that both :ref:`CONFIG_DESKTOP_ROLE_HID_DONGLE <config_desktop_app_options>` and :ref:`CONFIG_DESKTOP_BT_CENTRAL <config_desktop_app_options>` are enabled.
    The HID forward application module is enabled by the :ref:`CONFIG_DESKTOP_HID_FORWARD_ENABLE <config_desktop_app_options>` option which is implied by the :ref:`CONFIG_DESKTOP_BT_CENTRAL <config_desktop_app_options>` option together with other application modules.
    These modules are required for HID dongle that forwards the data from HID peripherals connected over Bluetooth.
-#. The :ref:`CONFIG_DESKTOP_HID_FORWARD_ENABLE <config_desktop_app_options>` option selects :kconfig:option:`CONFIG_BT_HOGP` to automatically enable the :ref:`hogp_readme`.
-   An nRF Desktop dongle does not generate its own HID input reports.
-   The dongle uses |hid_forward| to forward the HID reports.
-   The reports are received by the HID service client from the peripherals connected over Bluetooth.
 
-   .. note::
+   * The :ref:`CONFIG_DESKTOP_HID_FORWARD_ENABLE <config_desktop_app_options>` option selects :kconfig:option:`CONFIG_BT_HOGP` to automatically enable the :ref:`hogp_readme`.
+     An nRF Desktop dongle does not generate its own HID input reports.
+     The dongle uses |hid_forward| to forward the HID reports.
+     The reports are received by the HID service client from the peripherals connected over Bluetooth.
+
+     .. note::
        The maximum number of supported HID reports (:kconfig:option:`CONFIG_BT_HOGP_REPORTS_MAX`) is set by default for the nRF Desktop dongle, which supports two peripherals with an average of six HID reports each.
        Make sure to align this configuration value for other use cases, for example, if the dongle supports more peripherals.
 
-#. nRF Desktop dongle can forward either mouse or keyboard boot reports.
+   * The :ref:`CONFIG_DESKTOP_HID_FORWARD_ENABLE <config_desktop_app_options>` option selects :ref:`CONFIG_DESKTOP_HID_REPORTQ <config_desktop_app_options>` to automatically enable the HID report queue utility.
+     The HID report queue utility is used to locally enqueue reports at the source to prevent HID report drops.
+     If needed, you can update the maximum number of enqueued HID reports (:ref:`CONFIG_DESKTOP_HID_REPORTQ_MAX_ENQUEUED_REPORTS <config_desktop_app_options>`).
+     See :ref:`nrf_desktop_hid_reportq` documentation for details.
+
+#. Check the chosen HID boot protocol.
+   The nRF Desktop dongle can forward either mouse or keyboard boot reports.
    The forwarded boot report type is specified using the following Kconfig options:
 
    * :ref:`CONFIG_DESKTOP_HID_BOOT_INTERFACE_KEYBOARD <config_desktop_app_options>` - This option enables forwarding keyboard boot reports.
@@ -50,8 +57,6 @@ Complete the following steps to configure the module:
    Those options affect :ref:`nrf_desktop_usb_state` that subscribes for HID boot reports.
    The Dongle forwards HID reports from both mouse and keyboard, and so either option works if you want to have the Dongle work as boot mouse or boot keyboard.
    For more information about the configuration of the HID boot protocol, see the boot protocol configuration section in the :ref:`nrf_desktop_usb_state` documentation.
-
-You can set the queued HID input reports limit using the :ref:`CONFIG_DESKTOP_HID_FORWARD_MAX_ENQUEUED_REPORTS <config_desktop_app_options>` Kconfig option.
 
 Implementation details
 **********************
@@ -63,7 +68,10 @@ Interaction with the USB
 
 The :ref:`nrf_desktop_usb_state` can be configured to have one or more instances of the HID-class USB device.
 If there is more than one instance of the HID-class USB device, this number must match the maximum number of bonded Bluetooth peripheral devices.
-Each instance of HID-class USB device subscribes to HID reports forwarded by the |hid_forward|.
+Each USB HID class instance subscribes to HID reports forwarded by the |hid_forward|.
+Each USB HID class instance is assigned a separate :ref:`nrf_desktop_hid_reportq` instance when the related HID subscriber connects.
+The assigned HID report queue instance is freed when the related HID subscriber disconnects.
+Subscriber state changes are tracked relying on :c:struct:`hid_report_subscriber_event`.
 
 The |hid_forward| has an array of subscribers, one for each HID-class USB device.
 The possible cases that impact how the host to which the nRF desktop dongle is connected interprets the reports are as follows:
@@ -93,33 +101,27 @@ Forwarding HID input reports
 
 After :ref:`nrf_desktop_ble_discovery` successfully discovers a connected peripheral, the |hid_forward| automatically subscribes for every HID input report provided by the peripheral.
 The subscriber can use either the HID boot protocol or the HID report protocol, but both protocols cannot be used at the same time.
-In the current implementation, the :ref:`nrf_desktop_usb_state` supports either the HID boot keyboard or the HID boot mouse reports, because the HID boot protocol code is set using a single Kconfig option that is common for all of the instances of the USB HID.
+In the current implementation, the :ref:`nrf_desktop_usb_state` supports either the HID boot keyboard or the HID boot mouse reports, because the application does not support assigning HID boot protocol code separately for each USB HID instance.
 
 The :c:func:`hogp_read` callback is called when HID input report is received from the connected peripheral.
-The received HID input report data is converted to ``hid_report_event``.
+The received HID input report data is passed to the HID report queue and converted to a :c:struct:`hid_report_event`.
 
-``hid_report_event`` is submitted and then the HID-class USB device configured by :ref:`nrf_desktop_usb_state` forwards it to the host.
-When a HID report is sent to the host by the HID-class USB device, the |hid_forward| receives a ``hid_report_sent_event`` with the identifier of this device.
+The :c:struct:`hid_report_event` is submitted by the HID report queue and the HID-class USB device configured by :ref:`nrf_desktop_usb_state` forwards it to the host.
+When a HID report is sent to the host by the HID-class USB instance, the |hid_forward| receives a :c:struct:`hid_report_sent_event` with the identifier of the instance.
+The |hid_forward| notifies the HID report queue to ensure proper HID report flow.
 
 Enqueuing incoming HID input reports
 ------------------------------------
 
-The |hid_forward| forwards only one HID input report to the HID-class USB device at a time.
-Another HID input report may be received from a peripheral connected over Bluetooth before the previous one was sent.
-In that case, ``hid_report_event`` is enqueued and submitted later.
-Up to the number of reports specified in :ref:`CONFIG_DESKTOP_HID_FORWARD_MAX_ENQUEUED_REPORTS <config_desktop_app_options>` Kconfig option can be enqueued at a time for each report type and for each HID subscriber (HID-class USB device).
-If there is not enough space to enqueue a new event, the module drops the oldest enqueued event (of the same type) that was enqueued for a given HID subscriber.
-
-Upon receiving the ``hid_report_sent_event``, the |hid_forward| submits the ``hid_report_event`` enqueued for the peripheral that is associated with the HID-class USB device.
-The enqueued report to be sent is chosen by the |hid_forward| in the round-robin fashion.
-The report of the next type will be sent if available.
-If not available, the next report type will be checked until a report is found or there is no report in any of the queues.
-If there is no ``hid_report_event`` in the queue, the module waits for receiving data from peripherals.
+USB HID class instances limit the maximum number of HID input reports that can be handled simultaneously.
+The number of HID input reports received from HID peripherals connected over Bluetooth LE may exceed the limit.
+If needed, the |hid_forward| relies on the HID report queue to locally enqueue HID input reports before providing them to the USB HID subscriber.
+All HID input reports received from a HID peripheral go through the HID report queue utility associated with a given USB HID instance.
 
 Forwarding HID output reports
 =============================
 
-When the |hid_forward| receives a ``hid_report_event`` that contains an output report from a :ref:`nrf_desktop_usb_state`, it tries to forward the output report.
+When the |hid_forward| receives a :c:struct:`hid_report_event` that contains an output report from a :ref:`nrf_desktop_usb_state`, it tries to forward the output report.
 The HID output report is forwarded to all of the Bluetooth connected peripherals that forward the HID data to the HID subscriber that is source of the HID output report.
 The HID output report is never forwarded to peripheral that does not support it.
 

--- a/applications/nrf_desktop/doc/hid_reportq.rst
+++ b/applications/nrf_desktop/doc/hid_reportq.rst
@@ -1,0 +1,84 @@
+.. _nrf_desktop_hid_reportq:
+
+HID report queue utility
+########################
+
+.. contents::
+   :local:
+   :depth: 2
+
+A HID subscriber (for example, a USB HID class instance handled by :ref:`nrf_desktop_usb_state`) limits the maximum number of HID input reports that can be handled simultaneously.
+Enqueuing HID input reports locally at the source is necessary to prevent HID report drops when receiving more HID reports than can be handled by the subscriber.
+The HID report queue utility can be used by an application module to simplify enqueuing HID input reports received from connected HID peripherals before providing them to HID subscriber.
+
+Configuration
+*************
+
+Make sure that heap size (:kconfig:option:`CONFIG_HEAP_MEM_POOL_SIZE`) is large enough to handle the worst possible use case.
+Data structures used to enqueue HID reports are dynamically allocated using the :c:func:`k_malloc` function.
+When no longer needed, the structures are freed using the :c:func:`k_free` function.
+
+Use the :ref:`CONFIG_DESKTOP_HID_REPORTQ <config_desktop_app_options>` Kconfig option to enable the utility.
+You can use the utility only on HID dongles (:ref:`CONFIG_DESKTOP_ROLE_HID_DONGLE <config_desktop_app_options>`).
+
+You can configure the following properties:
+
+* Maximum number of enqueued HID reports (:ref:`CONFIG_DESKTOP_HID_REPORTQ_MAX_ENQUEUED_REPORTS <config_desktop_app_options>`)
+* Number of supported HID report queues (:ref:`CONFIG_DESKTOP_HID_REPORTQ_QUEUE_COUNT <config_desktop_app_options>`)
+
+See Kconfig help for more details.
+
+Using HID report queue
+**********************
+
+You can use the utility in a HID dongle's application module that handles receiving HID input reports from HID peripherals.
+The module uses the utility as a middleware between a connected HID peripheral and a HID subscriber.
+The module passes the received HID input report to the HID report queue utility.
+The HID report queue utility submits the :c:struct:`hid_report_event` to pass the HID input report to the HID subscriber.
+The following sections describe how to integrate HID report queue APIs in an application module.
+
+The :ref:`nrf_desktop_hid_forward` is an example of an application module that uses the HID report queue utility.
+Refer to the module's implementation (:file:`src/modules/hid_forward.c`) for an example of HID report queue integration.
+
+Allocation
+==========
+
+A HID report queue instance must be allocated with the :c:func:`hid_reportq_alloc` function before it is used.
+A separate HID report queue object needs to be allocated for each HID report subscriber.
+During allocation, the caller specifies the HID subscriber identifier.
+The :c:func:`hid_reportq_get_sub_id` function can be used to access the identifier later.
+After the HID report queue object is no longer used, it should be freed using the :c:func:`hid_reportq_free` function.
+
+HID subscriptions
+=================
+
+A HID report queue instance tracks HID input report subscriptions enabled by a HID subscriber.
+You can use the :c:func:`hid_reportq_subscribe` and :c:func:`hid_reportq_unsubscribe` functions to update the state of enabled subscriptions.
+The functions should be called while handling a :c:struct:`hid_report_subscription_event` in the module using the HID reportq utility.
+You can use the :c:func:`hid_reportq_is_subscribed` function to check if the subscription is enabled for the specified HID input report.
+
+Enqueuing HID input reports
+===========================
+
+If an application module uses the HID report queue instance to locally enqueue HID input reports for a given HID subscriber, every HID report intended for the subscriber should go through the HID report queue.
+The application module can call the :c:func:`hid_reportq_report_add` function for a received HID input report to pass the report to the HID report queue utility.
+The function allocates a :c:struct:`hid_report_event` for the received HID input report.
+If a HID subscriber can handle the :c:struct:`hid_report_event`, the event is instantly passed to the subscriber.
+Otherwise, the event is enqueued and will be submitted later.
+
+When a HID subscriber (for example, a USB HID class instance) delivers a HID input report to the HID host (on :c:struct:`hid_report_sent_event`), the :c:func:`hid_reportq_report_sent` API needs to be called to notify the HID report queue.
+This allows the queue to track the state of HID reports provided to the HID subscriber.
+If the HID report queue contains an enqueued report, the queue object will instantly submit the subsequent :c:struct:`hid_report_event`.
+The enqueued report to be sent is chosen in the round-robin fashion from HID report IDs with enabled subscription.
+The report with the next report ID will be sent if available.
+If not available, the next report IDs will be checked until a report is found or until the utility detects that there are no more enqueued reports.
+
+API documentation
+*****************
+
+Application modules can use the following API of the HID report queue:
+
+| Header file: :file:`applications/nrf_desktop/src/util/hid_reportq.h`
+| Source file: :file:`applications/nrf_desktop/src/util/hid_reportq.c`
+
+.. doxygengroup:: hid_reportq

--- a/applications/nrf_desktop/modules.rst
+++ b/applications/nrf_desktop/modules.rst
@@ -50,6 +50,7 @@ These are valid for events that have many listeners or sources, and are gathered
    doc/fn_keys.rst
    doc/bas.rst
    doc/hid_forward.rst
+   doc/hid_reportq.rst
    doc/hid_state.rst
    doc/hid_state_pm.rst
    doc/hids.rst

--- a/applications/nrf_desktop/src/util/hid_reportq.h
+++ b/applications/nrf_desktop/src/util/hid_reportq.h
@@ -58,6 +58,12 @@ const void *hid_reportq_get_sub_id(struct hid_reportq *q);
 /**
  * @brief Add a HID report to the queue.
  *
+ * The function returns an error if HID report subscription is disabled for the added HID report.
+ *
+ * If number of enqueued reports with a given report ID exceeds limit defined by the configuration
+ * (@kconfig{CONFIG_DESKTOP_HID_REPORTQ_MAX_ENQUEUED_REPORTS}), the oldest enqueued HID report with
+ * the ID is dropped.
+ *
  * @param[in] q		Pointer to the queue instance.
  * @param[in] src_id    ID of HID report source.
  * @param[in] rep_id	HID report ID.
@@ -98,6 +104,9 @@ void hid_reportq_subscribe(struct hid_reportq *q, uint8_t rep_id);
 
 /**
  * @brief Unsubscribe from HID report with given ID.
+ *
+ * Disabling subscription for a given HID report ID, drops all of the enqueued HID reports related
+ * to the ID.
  *
  * @param[in] q		Pointer to the queue instance.
  * @param[in] rep_id	HID report ID.


### PR DESCRIPTION
Change introduces documentation for the HID report queue utility.

Jira: NCSDK-28433