### PR TITLE
Samples: Bluetooth: Mesh: Fix MPSL uninit in light_ctrl

### DIFF
--- a/samples/bluetooth/mesh/light_ctrl/overlay-emds.conf
+++ b/samples/bluetooth/mesh/light_ctrl/overlay-emds.conf
@@ -5,3 +5,9 @@
 #
 CONFIG_EMDS=y
 CONFIG_BT_MESH_RPL_STORAGE_MODE_EMDS=y
+
+# MPSL dynamic interrupts required to be able to uninitialize MPSL before
+# storing EMDS data.
+CONFIG_DYNAMIC_INTERRUPTS=y
+CONFIG_DYNAMIC_DIRECT_INTERRUPTS=y
+CONFIG_MPSL_DYNAMIC_INTERRUPTS=y

--- a/samples/bluetooth/mesh/light_ctrl/src/main.c
+++ b/samples/bluetooth/mesh/light_ctrl/src/main.c
@@ -7,6 +7,7 @@
 /** @file
  *  @brief Nordic mesh light fixture sample
  */
+#include <zephyr/logging/log_ctrl.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <bluetooth/mesh/models.h>
 #include <bluetooth/mesh/dk_prov.h>
@@ -46,6 +47,8 @@ static void button_handler_cb(uint32_t pressed, uint32_t changed)
 
 static void app_emds_cb(void)
 {
+	/* Flush logs before halting. */
+	log_panic();
 	dk_set_leds(DK_LED2_MSK | DK_LED3_MSK | DK_LED4_MSK);
 	k_fatal_halt(K_ERR_CPU_EXCEPTION);
 }
@@ -55,8 +58,11 @@ static void isr_emds_cb(void *arg)
 	ARG_UNUSED(arg);
 
 #if defined(CONFIG_BT_CTLR)
-	/* Stop mpsl to reduce power usage. */
-	mpsl_lib_uninit();
+	int32_t err = mpsl_lib_uninit();
+
+	if (err != 0) {
+		printk("Could not stop MPSL (err %d)\n", err);
+	}
 #endif
 
 	emds_store();


### PR DESCRIPTION
This fixes a problem in the light_ctrl sample where the call to `mpsl_lib_uninit` would not do anything because the required Kconfig options were not set.

  * Add the required Kconfig options
  * Add error checking for the call to `mpsl_lib_uninit` and a call to `log_panic` to make sure this error message is actually printed before the sample halts after pressing the EMDS button.