### PR TITLE
net: openthread: rpc: using nrf_rpc encoders and decoders

### DIFF
--- a/subsys/net/openthread/rpc/client/ot_rpc_cli.c
+++ b/subsys/net/openthread/rpc/client/ot_rpc_cli.c
@@ -6,7 +6,7 @@
 
 #include <ot_rpc_ids.h>
 #include <ot_rpc_common.h>
-
+#include <nrf_rpc/nrf_rpc_serialize.h>
 #include <nrf_rpc_cbor.h>
 
 #include <openthread/cli.h>
@@ -37,7 +37,7 @@ void otCliInputLine(char *aBuf)
 	struct nrf_rpc_cbor_ctx ctx;
 
 	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, cbor_buffer_size);
-	zcbor_tstr_encode_ptr(ctx.zs, aBuf, buffer_len);
+	nrf_rpc_encode_str(&ctx, aBuf, buffer_len);
 
 	nrf_rpc_cbor_cmd_no_err(&ot_group, OT_RPC_CMD_CLI_INPUT_LINE, &ctx, ot_rpc_decode_void,
 				NULL);

--- a/subsys/net/openthread/rpc/client/ot_rpc_coap.c
+++ b/subsys/net/openthread/rpc/client/ot_rpc_coap.c
@@ -333,7 +333,7 @@ static void ot_rpc_cmd_coap_resource_handler(const struct nrf_rpc_group *group,
 	ot_rpc_decode_message_info(ctx, &message_info);
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_RESOURCE_HANDLER);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_RESOURCE_HANDLER);
 		return;
 	}
 
@@ -378,7 +378,7 @@ static void ot_rpc_cmd_coap_default_handler(const struct nrf_rpc_group *group,
 	ot_rpc_decode_message_info(ctx, &message_info);
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_DEFAULT_HANDLER);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_DEFAULT_HANDLER);
 		return;
 	}
 
@@ -445,12 +445,12 @@ static void ot_rpc_cmd_coap_response_handler(const struct nrf_rpc_group *group,
 	error = nrf_rpc_decode_uint(ctx);
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_RESPONSE_HANDLER);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_RESPONSE_HANDLER);
 		return;
 	}
 
 	if (request_rep == 0 || request_rep > ARRAY_SIZE(requests)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_RESPONSE_HANDLER);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_RESPONSE_HANDLER);
 		return;
 	}
 

--- a/subsys/net/openthread/rpc/client/ot_rpc_diag.c
+++ b/subsys/net/openthread/rpc/client/ot_rpc_diag.c
@@ -36,7 +36,7 @@ static void get_uint_t(int id, void *result, size_t result_size)
 
 	value = nrf_rpc_decode_uint(&ctx);
 	if (!nrf_rpc_decoding_done_and_check(&ot_group, &ctx)) {
-		ot_rpc_report_decoding_error(id);
+		ot_rpc_report_rsp_decoding_error(id);
 		return;
 	}
 
@@ -59,7 +59,7 @@ static int get_string(int id, char *buffer, size_t buffer_size)
 	}
 
 	if (!nrf_rpc_decoding_done_and_check(&ot_group, &ctx)) {
-		ot_rpc_report_decoding_error(id);
+		ot_rpc_report_rsp_decoding_error(id);
 		return 0;
 	}
 
@@ -93,7 +93,7 @@ const otExtAddress *otLinkGetExtendedAddress(otInstance *aInstance)
 
 	if (ret_size != sizeof(mac.m8)) {
 		LOG_ERR("Received mac addr size is too short");
-		ot_rpc_report_decoding_error(OT_RPC_CMD_LINK_GET_EXTENDED_ADDRESS);
+		ot_rpc_report_rsp_decoding_error(OT_RPC_CMD_LINK_GET_EXTENDED_ADDRESS);
 	}
 
 	return &mac;

--- a/subsys/net/openthread/rpc/client/ot_rpc_if.c
+++ b/subsys/net/openthread/rpc/client/ot_rpc_if.c
@@ -231,7 +231,7 @@ static void ot_rpc_cmd_if_receive(const struct nrf_rpc_group *group, struct nrf_
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
 		NET_ERR("Failed to decode packet data");
-		ot_rpc_report_decoding_error(OT_RPC_CMD_IF_RECEIVE);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_IF_RECEIVE);
 		if (pkt) {
 			net_pkt_unref(pkt);
 		}

--- a/subsys/net/openthread/rpc/client/ot_rpc_instance.c
+++ b/subsys/net/openthread/rpc/client/ot_rpc_instance.c
@@ -129,7 +129,7 @@ static void ot_rpc_cmd_state_changed(const struct nrf_rpc_group *group,
 	flags = nrf_rpc_decode_uint(ctx);
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_STATE_CHANGED);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_STATE_CHANGED);
 		return;
 	}
 

--- a/subsys/net/openthread/rpc/client/ot_rpc_ip6.c
+++ b/subsys/net/openthread/rpc/client/ot_rpc_ip6.c
@@ -153,7 +153,7 @@ bool otIp6IsEnabled(otInstance *aInstance)
 	enabled = nrf_rpc_decode_bool(&ctx);
 
 	if (!nrf_rpc_decoding_done_and_check(&ot_group, &ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_IP6_IS_ENABLED);
+		ot_rpc_report_rsp_decoding_error(OT_RPC_CMD_IP6_IS_ENABLED);
 	}
 
 	return enabled;

--- a/subsys/net/openthread/rpc/client/ot_rpc_link.c
+++ b/subsys/net/openthread/rpc/client/ot_rpc_link.c
@@ -40,7 +40,7 @@ uint32_t otLinkGetPollPeriod(otInstance *aInstance)
 	poll_period = nrf_rpc_decode_uint(&ctx);
 
 	if (!nrf_rpc_decoding_done_and_check(&ot_group, &ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_LINK_GET_POLL_PERIOD);
+		ot_rpc_report_rsp_decoding_error(OT_RPC_CMD_LINK_GET_POLL_PERIOD);
 	}
 
 	return poll_period;

--- a/subsys/net/openthread/rpc/client/ot_rpc_link.c
+++ b/subsys/net/openthread/rpc/client/ot_rpc_link.c
@@ -12,55 +12,35 @@
 
 #include <openthread/link.h>
 
-static otError decode_ot_error(struct nrf_rpc_cbor_ctx *ctx)
-{
-	otError error;
-
-	if (!zcbor_uint_decode(ctx->zs, &error, sizeof(error))) {
-		error = OT_ERROR_PARSE;
-	}
-
-	nrf_rpc_cbor_decoding_done(&ot_group, ctx);
-
-	return error;
-}
-
 otError otLinkSetPollPeriod(otInstance *aInstance, uint32_t aPollPeriod)
 {
 	struct nrf_rpc_cbor_ctx ctx;
+	otError error;
 
 	ARG_UNUSED(aInstance);
 
 	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, 5);
+	nrf_rpc_encode_uint(&ctx, aPollPeriod);
+	nrf_rpc_cbor_cmd_no_err(&ot_group, OT_RPC_CMD_LINK_SET_POLL_PERIOD, &ctx,
+				ot_rpc_decode_error, &error);
 
-	if (!zcbor_uint_encode(ctx.zs, &aPollPeriod, sizeof(aPollPeriod))) {
-		NRF_RPC_CBOR_DISCARD(&ot_group, ctx);
-		return OT_ERROR_INVALID_ARGS;
-	}
-
-	nrf_rpc_cbor_cmd_rsp_no_err(&ot_group, OT_RPC_CMD_LINK_SET_POLL_PERIOD, &ctx);
-
-	return decode_ot_error(&ctx);
+	return error;
 }
 
 uint32_t otLinkGetPollPeriod(otInstance *aInstance)
 {
 	struct nrf_rpc_cbor_ctx ctx;
-	uint32_t poll_period = 0;
-	bool decoded_ok;
+	uint32_t poll_period;
 
 	ARG_UNUSED(aInstance);
 
 	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, 0);
 
 	nrf_rpc_cbor_cmd_rsp_no_err(&ot_group, OT_RPC_CMD_LINK_GET_POLL_PERIOD, &ctx);
+	poll_period = nrf_rpc_decode_uint(&ctx);
 
-	decoded_ok = zcbor_uint_decode(ctx.zs, &poll_period, sizeof(poll_period));
-	nrf_rpc_cbor_decoding_done(&ot_group, &ctx);
-
-	if (!decoded_ok) {
-		nrf_rpc_err(-EBADMSG, NRF_RPC_ERR_SRC_RECV, &ot_group,
-			    OT_RPC_CMD_LINK_GET_POLL_PERIOD, NRF_RPC_PACKET_TYPE_RSP);
+	if (!nrf_rpc_decoding_done_and_check(&ot_group, &ctx)) {
+		ot_rpc_report_decoding_error(OT_RPC_CMD_LINK_GET_POLL_PERIOD);
 	}
 
 	return poll_period;

--- a/subsys/net/openthread/rpc/client/ot_rpc_message.c
+++ b/subsys/net/openthread/rpc/client/ot_rpc_message.c
@@ -23,37 +23,23 @@ otError otMessageAppend(otMessage *aMessage, const void *aBuf, uint16_t aLength)
 	otError error = OT_ERROR_NONE;
 
 	if (aLength == 0 || aBuf == NULL) {
-		error = OT_ERROR_NONE;
-		goto exit;
+		return error;
 	}
 
 	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, aLength + sizeof(key) + 5);
-
-	if (!zcbor_uint_encode(ctx.zs, &key, sizeof(key))) {
-		NRF_RPC_CBOR_DISCARD(&ot_group, ctx);
-		error = OT_ERROR_INVALID_ARGS;
-		goto exit;
-	}
-
-	if (!zcbor_bstr_encode_ptr(ctx.zs, aBuf, aLength)) {
-		NRF_RPC_CBOR_DISCARD(&ot_group, ctx);
-		error = OT_ERROR_INVALID_ARGS;
-		goto exit;
-	}
-
+	nrf_rpc_encode_uint(&ctx, key);
+	nrf_rpc_encode_buffer(&ctx, aBuf, aLength);
 	nrf_rpc_cbor_cmd_no_err(&ot_group, OT_RPC_CMD_MESSAGE_APPEND, &ctx, ot_rpc_decode_error,
 				&error);
 
-exit:
 	return error;
 }
 
 otMessage *otUdpNewMessage(otInstance *aInstance, const otMessageSettings *aSettings)
 {
 	otMessage *msg = NULL;
-	bool decoded_ok;
 	struct nrf_rpc_cbor_ctx ctx;
-	ot_msg_key key = 0;
+	ot_msg_key key;
 
 	ARG_UNUSED(aInstance);
 
@@ -63,12 +49,10 @@ otMessage *otUdpNewMessage(otInstance *aInstance, const otMessageSettings *aSett
 
 	nrf_rpc_cbor_cmd_rsp_no_err(&ot_group, OT_RPC_CMD_UDP_NEW_MESSAGE, &ctx);
 
-	decoded_ok = zcbor_uint_decode(ctx.zs, &key, sizeof(key));
-	nrf_rpc_cbor_decoding_done(&ot_group, &ctx);
-
-	if (!decoded_ok) {
-		nrf_rpc_err(-EBADMSG, NRF_RPC_ERR_SRC_RECV, &ot_group, OT_RPC_CMD_UDP_NEW_MESSAGE,
-			    NRF_RPC_PACKET_TYPE_RSP);
+	key = nrf_rpc_decode_uint(&ctx);
+	if (!nrf_rpc_decoding_done_and_check(&ot_group, &ctx)) {
+		ot_rpc_report_decoding_error(OT_RPC_CMD_UDP_NEW_MESSAGE);
+		return msg;
 	}
 
 	msg = (otMessage *)key;
@@ -82,14 +66,12 @@ void otMessageFree(otMessage *aMessage)
 
 	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, sizeof(ot_msg_key) + 1);
 
-	if (!zcbor_uint32_encode(ctx.zs, &key)) {
-		NRF_RPC_CBOR_DISCARD(&ot_group, ctx);
-		return;
-	}
-
+	nrf_rpc_encode_uint(&ctx, key);
 	nrf_rpc_cbor_cmd_rsp_no_err(&ot_group, OT_RPC_CMD_MESSAGE_FREE, &ctx);
 
-	nrf_rpc_cbor_decoding_done(&ot_group, &ctx);
+	if (!nrf_rpc_decoding_done_and_check(&ot_group, &ctx)) {
+		ot_rpc_report_decoding_error(OT_RPC_CMD_MESSAGE_FREE);
+	}
 }
 
 uint16_t otMessageGetLength(const otMessage *aMessage)
@@ -97,26 +79,19 @@ uint16_t otMessageGetLength(const otMessage *aMessage)
 	struct nrf_rpc_cbor_ctx ctx;
 	ot_msg_key key = (ot_msg_key)aMessage;
 	uint16_t ret = 0;
-	bool decoded_ok;
 
 	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, sizeof(uint32_t) + 1);
 
-	if (!zcbor_uint32_encode(ctx.zs, &key)) {
-		NRF_RPC_CBOR_DISCARD(&ot_group, ctx);
-		goto exit;
-	}
-
+	nrf_rpc_encode_uint(&ctx, key);
 	nrf_rpc_cbor_cmd_rsp_no_err(&ot_group, OT_RPC_CMD_MESSAGE_GET_LENGTH, &ctx);
 
-	decoded_ok = zcbor_uint_decode(ctx.zs, &ret, sizeof(ret));
-	nrf_rpc_cbor_decoding_done(&ot_group, &ctx);
+	ret = nrf_rpc_decode_uint(&ctx);
 
-	if (!decoded_ok) {
-		nrf_rpc_err(-EBADMSG, NRF_RPC_ERR_SRC_RECV, &ot_group,
-			    OT_RPC_CMD_MESSAGE_GET_LENGTH, NRF_RPC_PACKET_TYPE_RSP);
+	if (!nrf_rpc_decoding_done_and_check(&ot_group, &ctx)) {
+		ot_rpc_report_decoding_error(OT_RPC_CMD_MESSAGE_GET_LENGTH);
+		return 0;
 	}
 
-exit:
 	return ret;
 }
 
@@ -125,26 +100,19 @@ uint16_t otMessageGetOffset(const otMessage *aMessage)
 	struct nrf_rpc_cbor_ctx ctx;
 	ot_msg_key key = (ot_msg_key)aMessage;
 	uint16_t ret = 0;
-	bool decoded_ok;
 
-	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, sizeof(uint32_t) + 2);
+	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, sizeof(uint32_t) + 1);
 
-	if (!zcbor_uint32_encode(ctx.zs, &key)) {
-		NRF_RPC_CBOR_DISCARD(&ot_group, ctx);
-		goto exit;
-	}
-
+	nrf_rpc_encode_uint(&ctx, key);
 	nrf_rpc_cbor_cmd_rsp_no_err(&ot_group, OT_RPC_CMD_MESSAGE_GET_OFFSET, &ctx);
 
-	decoded_ok = zcbor_uint_decode(ctx.zs, &ret, sizeof(ret));
-	nrf_rpc_cbor_decoding_done(&ot_group, &ctx);
+	ret = nrf_rpc_decode_uint(&ctx);
 
-	if (!decoded_ok) {
-		nrf_rpc_err(-EBADMSG, NRF_RPC_ERR_SRC_RECV, &ot_group,
-			    OT_RPC_CMD_MESSAGE_GET_OFFSET, NRF_RPC_PACKET_TYPE_RSP);
+	if (!nrf_rpc_decoding_done_and_check(&ot_group, &ctx)) {
+		ot_rpc_report_decoding_error(OT_RPC_CMD_MESSAGE_GET_OFFSET);
+		return 0;
 	}
 
-exit:
 	return ret;
 }
 
@@ -152,9 +120,8 @@ uint16_t otMessageRead(const otMessage *aMessage, uint16_t aOffset, void *aBuf, 
 {
 	struct nrf_rpc_cbor_ctx ctx;
 	ot_msg_key key = (ot_msg_key)aMessage;
-	uint16_t ret = 0;
-	struct zcbor_string zst;
-	bool decoded_ok;
+	size_t size = 0;
+	const void *buf = NULL;
 
 	if (aLength == 0 || aBuf == NULL || aMessage == NULL) {
 		return 0;
@@ -162,50 +129,22 @@ uint16_t otMessageRead(const otMessage *aMessage, uint16_t aOffset, void *aBuf, 
 
 	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, sizeof(key) + sizeof(aOffset) + sizeof(aLength) + 5);
 
-	if (!zcbor_uint_encode(ctx.zs, &key, sizeof(key))) {
-		NRF_RPC_CBOR_DISCARD(&ot_group, ctx);
-		goto exit;
-	}
-
-	if (!zcbor_uint_encode(ctx.zs, &aOffset, sizeof(aOffset))) {
-		NRF_RPC_CBOR_DISCARD(&ot_group, ctx);
-		goto exit;
-	}
-
-	if (!zcbor_uint_encode(ctx.zs, &aLength, sizeof(aLength))) {
-		NRF_RPC_CBOR_DISCARD(&ot_group, ctx);
-		goto exit;
-	}
+	nrf_rpc_encode_uint(&ctx, key);
+	nrf_rpc_encode_uint(&ctx, aOffset);
+	nrf_rpc_encode_uint(&ctx, aLength);
 
 	nrf_rpc_cbor_cmd_rsp_no_err(&ot_group, OT_RPC_CMD_MESSAGE_READ, &ctx);
 
-	if (zcbor_nil_expect(ctx.zs, NULL)) {
-		nrf_rpc_cbor_decoding_done(&ot_group, &ctx);
-		goto exit;
+	buf = nrf_rpc_decode_buffer_ptr_and_size(&ctx, &size);
+
+	if (buf && size) {
+		memcpy(aBuf, buf, MIN(size, aLength));
 	}
 
-	if (ctx.zs->constant_state->error != ZCBOR_ERR_WRONG_TYPE) {
-		nrf_rpc_cbor_decoding_done(&ot_group, &ctx);
-		goto exit;
+	if (!nrf_rpc_decoding_done_and_check(&ot_group, &ctx)) {
+		ot_rpc_report_decoding_error(OT_RPC_CMD_MESSAGE_READ);
+		return 0;
 	}
 
-	zcbor_pop_error(ctx.zs);
-
-	decoded_ok = zcbor_bstr_decode(ctx.zs, &zst);
-
-	if (!decoded_ok) {
-		nrf_rpc_err(-EBADMSG, NRF_RPC_ERR_SRC_RECV, &ot_group, OT_RPC_CMD_MESSAGE_READ,
-			    NRF_RPC_PACKET_TYPE_RSP);
-		nrf_rpc_cbor_decoding_done(&ot_group, &ctx);
-		goto exit;
-	}
-
-	ret = zst.len < aLength ? zst.len : aLength;
-
-	memcpy(aBuf, zst.value, ret);
-
-	nrf_rpc_cbor_decoding_done(&ot_group, &ctx);
-
-exit:
-	return ret;
+	return MIN(size, aLength);
 }

--- a/subsys/net/openthread/rpc/client/ot_rpc_message.c
+++ b/subsys/net/openthread/rpc/client/ot_rpc_message.c
@@ -51,7 +51,7 @@ otMessage *otUdpNewMessage(otInstance *aInstance, const otMessageSettings *aSett
 
 	key = nrf_rpc_decode_uint(&ctx);
 	if (!nrf_rpc_decoding_done_and_check(&ot_group, &ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_UDP_NEW_MESSAGE);
+		ot_rpc_report_rsp_decoding_error(OT_RPC_CMD_UDP_NEW_MESSAGE);
 		return msg;
 	}
 
@@ -70,7 +70,7 @@ void otMessageFree(otMessage *aMessage)
 	nrf_rpc_cbor_cmd_rsp_no_err(&ot_group, OT_RPC_CMD_MESSAGE_FREE, &ctx);
 
 	if (!nrf_rpc_decoding_done_and_check(&ot_group, &ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_MESSAGE_FREE);
+		ot_rpc_report_rsp_decoding_error(OT_RPC_CMD_MESSAGE_FREE);
 	}
 }
 
@@ -88,7 +88,7 @@ uint16_t otMessageGetLength(const otMessage *aMessage)
 	ret = nrf_rpc_decode_uint(&ctx);
 
 	if (!nrf_rpc_decoding_done_and_check(&ot_group, &ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_MESSAGE_GET_LENGTH);
+		ot_rpc_report_rsp_decoding_error(OT_RPC_CMD_MESSAGE_GET_LENGTH);
 		return 0;
 	}
 
@@ -109,7 +109,7 @@ uint16_t otMessageGetOffset(const otMessage *aMessage)
 	ret = nrf_rpc_decode_uint(&ctx);
 
 	if (!nrf_rpc_decoding_done_and_check(&ot_group, &ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_MESSAGE_GET_OFFSET);
+		ot_rpc_report_rsp_decoding_error(OT_RPC_CMD_MESSAGE_GET_OFFSET);
 		return 0;
 	}
 
@@ -142,7 +142,7 @@ uint16_t otMessageRead(const otMessage *aMessage, uint16_t aOffset, void *aBuf, 
 	}
 
 	if (!nrf_rpc_decoding_done_and_check(&ot_group, &ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_MESSAGE_READ);
+		ot_rpc_report_rsp_decoding_error(OT_RPC_CMD_MESSAGE_READ);
 		return 0;
 	}
 

--- a/subsys/net/openthread/rpc/client/ot_rpc_netdata.c
+++ b/subsys/net/openthread/rpc/client/ot_rpc_netdata.c
@@ -33,7 +33,7 @@ otError otNetDataGet(otInstance *aInstance, bool aStable, uint8_t *aData, uint8_
 	error = nrf_rpc_decode_uint(&ctx);
 
 	if (!nrf_rpc_decoding_done_and_check(&ot_group, &ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_NETDATA_GET);
+		ot_rpc_report_rsp_decoding_error(OT_RPC_CMD_NETDATA_GET);
 		return OT_ERROR_FAILED;
 	}
 
@@ -55,7 +55,7 @@ otError otNetDataGetNextService(otInstance *aInstance, otNetworkDataIterator *aI
 	error = nrf_rpc_decode_uint(&ctx);
 
 	if (!nrf_rpc_decoding_done_and_check(&ot_group, &ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_NETDATA_GET_NEXT_SERVICE);
+		ot_rpc_report_rsp_decoding_error(OT_RPC_CMD_NETDATA_GET_NEXT_SERVICE);
 		return OT_ERROR_FAILED;
 	}
 
@@ -78,7 +78,7 @@ otError otNetDataGetNextOnMeshPrefix(otInstance *aInstance, otNetworkDataIterato
 	error = nrf_rpc_decode_uint(&ctx);
 
 	if (!nrf_rpc_decoding_done_and_check(&ot_group, &ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_NETDATA_GET_NEXT_ON_MESH_PREFIX);
+		ot_rpc_report_rsp_decoding_error(OT_RPC_CMD_NETDATA_GET_NEXT_ON_MESH_PREFIX);
 		return OT_ERROR_FAILED;
 	}
 

--- a/subsys/net/openthread/rpc/client/ot_rpc_srp_client.c
+++ b/subsys/net/openthread/rpc/client/ot_rpc_srp_client.c
@@ -354,7 +354,7 @@ static void ot_rpc_cmd_srp_client_cb(const struct nrf_rpc_group *group,
 		if (!service_prev_next) {
 			/* Provided service pointer unknown to the client */
 			nrf_rpc_cbor_decoding_done(&ot_group, ctx);
-			ot_rpc_report_decoding_error(OT_RPC_CMD_SRP_CLIENT_CB);
+			ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_SRP_CLIENT_CB);
 			return;
 		}
 
@@ -369,7 +369,7 @@ static void ot_rpc_cmd_srp_client_cb(const struct nrf_rpc_group *group,
 	}
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_SRP_CLIENT_CB);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_SRP_CLIENT_CB);
 		return;
 	}
 
@@ -392,7 +392,7 @@ static void ot_rpc_cmd_srp_client_auto_start_cb(const struct nrf_rpc_group *grou
 	addr.mPort = nrf_rpc_decode_uint(ctx);
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_SRP_CLIENT_AUTO_START_CB);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_SRP_CLIENT_AUTO_START_CB);
 		return;
 	}
 

--- a/subsys/net/openthread/rpc/client/ot_rpc_thread.c
+++ b/subsys/net/openthread/rpc/client/ot_rpc_thread.c
@@ -42,7 +42,7 @@ static void ot_rpc_thread_discover_cb_rpc_handler(const struct nrf_rpc_group *gr
 	callback = (otHandleActiveScanResult)nrf_rpc_decode_callback_call(ctx);
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_THREAD_DISCOVER_CB);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_THREAD_DISCOVER_CB);
 		return;
 	}
 
@@ -117,7 +117,7 @@ otDeviceRole otThreadGetDeviceRole(otInstance *aInstance)
 	role = nrf_rpc_decode_uint(&ctx);
 
 	if (!nrf_rpc_decoding_done_and_check(&ot_group, &ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_THREAD_GET_DEVICE_ROLE);
+		ot_rpc_report_rsp_decoding_error(OT_RPC_CMD_THREAD_GET_DEVICE_ROLE);
 	}
 
 	return role;
@@ -166,7 +166,7 @@ otLinkModeConfig otThreadGetLinkMode(otInstance *aInstance)
 	mode_mask = nrf_rpc_decode_uint(&ctx);
 
 	if (!nrf_rpc_decoding_done_and_check(&ot_group, &ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_THREAD_GET_LINK_MODE);
+		ot_rpc_report_rsp_decoding_error(OT_RPC_CMD_THREAD_GET_LINK_MODE);
 		mode_mask = 0;
 	}
 

--- a/subsys/net/openthread/rpc/client/ot_rpc_udp.c
+++ b/subsys/net/openthread/rpc/client/ot_rpc_udp.c
@@ -99,7 +99,7 @@ static void ot_rpc_cmd_udp_receive_cb(const struct nrf_rpc_group *group,
 	ot_rpc_decode_message_info(ctx, &message_info);
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_UDP_RECEIVE_CB);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_UDP_RECEIVE_CB);
 		return;
 	}
 

--- a/subsys/net/openthread/rpc/common/ot_rpc_common.c
+++ b/subsys/net/openthread/rpc/common/ot_rpc_common.c
@@ -177,113 +177,45 @@ void ot_rpc_report_decoding_error(uint8_t cmd_evt_id)
 	nrf_rpc_err(-EBADMSG, NRF_RPC_ERR_SRC_RECV, &ot_group, cmd_evt_id, NRF_RPC_PACKET_TYPE_CMD);
 }
 
-bool ot_rpc_encode_message_info(struct nrf_rpc_cbor_ctx *ctx, const otMessageInfo *aMessageInfo)
+void ot_rpc_encode_message_info(struct nrf_rpc_cbor_ctx *ctx, const otMessageInfo *aMessageInfo)
 {
-	uint8_t tmp;
-
-	if (!zcbor_bstr_encode_ptr(ctx->zs, (const char *)&aMessageInfo->mSockAddr.mFields.m8,
-				   sizeof(aMessageInfo->mSockAddr))) {
-		return false;
-	}
-
-	if (!zcbor_bstr_encode_ptr(ctx->zs, (const char *)&aMessageInfo->mPeerAddr.mFields.m8,
-				   sizeof(aMessageInfo->mPeerAddr))) {
-		return false;
-	}
-
-	if (!zcbor_uint_encode(ctx->zs, &aMessageInfo->mSockPort,
-			       sizeof(aMessageInfo->mSockPort))) {
-		return false;
-	}
-
-	if (!zcbor_uint_encode(ctx->zs, &aMessageInfo->mPeerPort,
-			       sizeof(aMessageInfo->mPeerPort))) {
-		return false;
-	}
-
-	if (!zcbor_uint_encode(ctx->zs, &aMessageInfo->mHopLimit,
-			       sizeof(aMessageInfo->mHopLimit))) {
-		return false;
-	}
-
-	tmp = aMessageInfo->mEcn;
-	if (!zcbor_uint_encode(ctx->zs, &tmp, sizeof(tmp))) {
-		return false;
-	}
-
-	if (!zcbor_bool_put(ctx->zs, aMessageInfo->mIsHostInterface)) {
-		return false;
-	}
-
-	if (!zcbor_bool_put(ctx->zs, aMessageInfo->mAllowZeroHopLimit)) {
-		return false;
-	}
-
-	if (!zcbor_bool_put(ctx->zs, aMessageInfo->mMulticastLoop)) {
-		return false;
-	}
-
-	return true;
+	nrf_rpc_encode_buffer(ctx, aMessageInfo->mSockAddr.mFields.m8,
+			      sizeof(aMessageInfo->mSockAddr));
+	nrf_rpc_encode_buffer(ctx, aMessageInfo->mPeerAddr.mFields.m8,
+			      sizeof(aMessageInfo->mPeerAddr));
+	nrf_rpc_encode_uint(ctx, aMessageInfo->mSockPort);
+	nrf_rpc_encode_uint(ctx, aMessageInfo->mPeerPort);
+	nrf_rpc_encode_uint(ctx, aMessageInfo->mHopLimit);
+	nrf_rpc_encode_uint(ctx, aMessageInfo->mEcn);
+	nrf_rpc_encode_bool(ctx, aMessageInfo->mIsHostInterface);
+	nrf_rpc_encode_bool(ctx, aMessageInfo->mAllowZeroHopLimit);
+	nrf_rpc_encode_bool(ctx, aMessageInfo->mMulticastLoop);
 }
 
-bool ot_rpc_decode_message_info(struct nrf_rpc_cbor_ctx *ctx, otMessageInfo *aMessageInfo)
+void ot_rpc_decode_message_info(struct nrf_rpc_cbor_ctx *ctx, otMessageInfo *aMessageInfo)
 {
-	struct zcbor_string zst;
-	uint8_t tmp_uint;
-	bool tmp_bool;
+	size_t size = 0;
+	const void *buf = NULL;
 
-	if (!zcbor_bstr_decode(ctx->zs, &zst)) {
-		return false;
+	buf = nrf_rpc_decode_buffer_ptr_and_size(ctx, &size);
+	if (buf && size) {
+		size = MIN(size, sizeof(aMessageInfo->mSockAddr.mFields.m8));
+		memcpy(aMessageInfo->mSockAddr.mFields.m8, buf, size);
 	}
 
-	memcpy(&aMessageInfo->mSockAddr.mFields.m8, zst.value, zst.len);
-
-	if (!zcbor_bstr_decode(ctx->zs, &zst)) {
-		return false;
+	buf = nrf_rpc_decode_buffer_ptr_and_size(ctx, &size);
+	if (buf && size) {
+		size = MIN(size, sizeof(aMessageInfo->mPeerAddr.mFields.m8));
+		memcpy(aMessageInfo->mPeerAddr.mFields.m8, buf, size);
 	}
 
-	memcpy(&aMessageInfo->mPeerAddr.mFields.m8, zst.value, zst.len);
-
-	if (!zcbor_uint_decode(ctx->zs, &aMessageInfo->mSockPort,
-			       sizeof(aMessageInfo->mSockPort))) {
-		return false;
-	}
-
-	if (!zcbor_uint_decode(ctx->zs, &aMessageInfo->mPeerPort,
-			       sizeof(aMessageInfo->mPeerPort))) {
-		return false;
-	}
-
-	if (!zcbor_uint_decode(ctx->zs, &aMessageInfo->mHopLimit,
-			       sizeof(aMessageInfo->mHopLimit))) {
-		return false;
-	}
-
-	if (!zcbor_uint_decode(ctx->zs, &tmp_uint, sizeof(tmp_uint))) {
-		return false;
-	}
-
-	aMessageInfo->mEcn = tmp_uint;
-
-	if (!zcbor_bool_decode(ctx->zs, &tmp_bool)) {
-		return false;
-	}
-
-	aMessageInfo->mIsHostInterface = tmp_bool;
-
-	if (!zcbor_bool_decode(ctx->zs, &tmp_bool)) {
-		return false;
-	}
-
-	aMessageInfo->mAllowZeroHopLimit = tmp_bool;
-
-	if (!zcbor_bool_decode(ctx->zs, &tmp_bool)) {
-		return false;
-	}
-
-	aMessageInfo->mMulticastLoop = tmp_bool;
-
-	return true;
+	aMessageInfo->mSockPort = nrf_rpc_decode_uint(ctx);
+	aMessageInfo->mPeerPort = nrf_rpc_decode_uint(ctx);
+	aMessageInfo->mHopLimit = nrf_rpc_decode_uint(ctx);
+	aMessageInfo->mEcn = nrf_rpc_decode_uint(ctx);
+	aMessageInfo->mIsHostInterface = nrf_rpc_decode_bool(ctx);
+	aMessageInfo->mAllowZeroHopLimit = nrf_rpc_decode_bool(ctx);
+	aMessageInfo->mMulticastLoop = nrf_rpc_decode_bool(ctx);
 }
 
 bool ot_rpc_encode_service_config(struct nrf_rpc_cbor_ctx *ctx, const otServiceConfig *config)
@@ -324,58 +256,36 @@ bool ot_rpc_encode_service_config(struct nrf_rpc_cbor_ctx *ctx, const otServiceC
 	return true;
 }
 
-bool ot_rpc_decode_service_config(struct nrf_rpc_cbor_ctx *ctx, otServiceConfig *config)
+void ot_rpc_decode_service_config(struct nrf_rpc_cbor_ctx *ctx, otServiceConfig *config)
 {
+	size_t size = 0;
+	const void *buf = NULL;
 
-	struct zcbor_string zst;
-	bool tmp;
-
-	if (zcbor_nil_expect(ctx->zs, NULL)) {
+	if (nrf_rpc_decode_is_null(ctx)) {
 		memset(config, 0, sizeof(otServerConfig));
-		return true;
+		return;
 	}
 
-	if (ctx->zs->constant_state->error != ZCBOR_ERR_WRONG_TYPE) {
-		return false;
+	config->mServiceId = nrf_rpc_decode_uint(ctx);
+	config->mEnterpriseNumber = nrf_rpc_decode_uint(ctx);
+
+	buf = nrf_rpc_decode_buffer_ptr_and_size(ctx, &size);
+	if (buf && size) {
+		size = MIN(size, sizeof(config->mServerConfig.mServerData));
+		memcpy(config->mServerConfig.mServerData, buf, size);
+		config->mServiceDataLength = size;
 	}
 
-	zcbor_pop_error(ctx->zs);
+	config->mServerConfig.mStable = nrf_rpc_decode_bool(ctx);
 
-	if (!zcbor_uint_decode(ctx->zs, &config->mServiceId, sizeof(config->mServiceId))) {
-		return false;
+	buf = nrf_rpc_decode_buffer_ptr_and_size(ctx, &size);
+	if (buf && size) {
+		size = MIN(size, sizeof(config->mServiceData));
+		memcpy(config->mServiceData, buf, size);
+		config->mServerConfig.mServerDataLength = size;
 	}
 
-	if (!zcbor_uint_decode(ctx->zs, &config->mEnterpriseNumber,
-			       sizeof(config->mEnterpriseNumber))) {
-		return false;
-	}
-
-	if (!zcbor_bstr_decode(ctx->zs, &zst)) {
-		return false;
-	}
-
-	config->mServiceDataLength = zst.len;
-	memcpy(config->mServiceData, zst.value, zst.len);
-
-	if (!zcbor_bool_decode(ctx->zs, &tmp)) {
-		return false;
-	}
-
-	config->mServerConfig.mStable = tmp;
-
-	if (!zcbor_bstr_decode(ctx->zs, &zst)) {
-		return false;
-	}
-
-	config->mServerConfig.mServerDataLength = zst.len;
-	memcpy(config->mServerConfig.mServerData, zst.value, zst.len);
-
-	if (!zcbor_uint_decode(ctx->zs, &config->mServerConfig.mRloc16,
-			       sizeof(config->mServerConfig.mRloc16))) {
-		return false;
-	}
-
-	return true;
+	config->mServerConfig.mRloc16 = nrf_rpc_decode_uint(ctx);
 }
 
 bool ot_rpc_encode_border_router_config(struct nrf_rpc_cbor_ctx *ctx,
@@ -446,97 +356,32 @@ bool ot_rpc_encode_border_router_config(struct nrf_rpc_cbor_ctx *ctx,
 	return true;
 }
 
-bool ot_rpc_decode_border_router_config(struct nrf_rpc_cbor_ctx *ctx, otBorderRouterConfig *config)
+void ot_rpc_decode_border_router_config(struct nrf_rpc_cbor_ctx *ctx, otBorderRouterConfig *config)
 {
-	struct zcbor_string zst;
-	bool tmp_bool;
-	signed int tmp_signed;
+	size_t size = 0;
+	const void *buf = NULL;
 
-	if (zcbor_nil_expect(ctx->zs, NULL)) {
+	if (nrf_rpc_decode_is_null(ctx)) {
 		memset(config, 0, sizeof(otBorderRouterConfig));
-		return true;
+		return;
 	}
 
-	if (ctx->zs->constant_state->error != ZCBOR_ERR_WRONG_TYPE) {
-		return false;
+	buf = nrf_rpc_decode_buffer_ptr_and_size(ctx, &size);
+	if (buf && size) {
+		size = MIN(size, sizeof(config->mPrefix.mPrefix.mFields.m8));
+		memcpy(config->mPrefix.mPrefix.mFields.m8, buf, size);
 	}
 
-	zcbor_pop_error(ctx->zs);
-
-	if (!zcbor_bstr_decode(ctx->zs, &zst)) {
-		return false;
-	}
-
-	memcpy(config->mPrefix.mPrefix.mFields.m8, zst.value, zst.len);
-
-	if (!zcbor_uint_decode(ctx->zs, &config->mPrefix.mLength,
-			       sizeof(config->mPrefix.mLength))) {
-		return false;
-	}
-
-	if (!zcbor_uint_decode(ctx->zs, &tmp_signed, sizeof(tmp_signed))) {
-		return false;
-	}
-
-	config->mPreference = tmp_signed;
-
-	if (!zcbor_bool_decode(ctx->zs, &tmp_bool)) {
-		return false;
-	}
-
-	config->mPreferred = tmp_bool;
-
-	if (!zcbor_bool_decode(ctx->zs, &tmp_bool)) {
-		return false;
-	}
-
-	config->mSlaac = tmp_bool;
-
-	if (!zcbor_bool_decode(ctx->zs, &tmp_bool)) {
-		return false;
-	}
-
-	config->mDhcp = tmp_bool;
-
-	if (!zcbor_bool_decode(ctx->zs, &tmp_bool)) {
-		return false;
-	}
-
-	config->mConfigure = tmp_bool;
-
-	if (!zcbor_bool_decode(ctx->zs, &tmp_bool)) {
-		return false;
-	}
-
-	config->mDefaultRoute = tmp_bool;
-
-	if (!zcbor_bool_decode(ctx->zs, &tmp_bool)) {
-		return false;
-	}
-
-	config->mOnMesh = tmp_bool;
-
-	if (!zcbor_bool_decode(ctx->zs, (bool *)&tmp_bool)) {
-		return false;
-	}
-
-	config->mStable = tmp_bool;
-
-	if (!zcbor_bool_decode(ctx->zs, (bool *)&tmp_bool)) {
-		return false;
-	}
-
-	config->mNdDns = tmp_bool;
-
-	if (!zcbor_bool_decode(ctx->zs, (bool *)&tmp_bool)) {
-		return false;
-	}
-
-	config->mDp = tmp_bool;
-
-	if (!zcbor_uint_decode(ctx->zs, &config->mRloc16, sizeof(config->mRloc16))) {
-		return false;
-	}
-
-	return true;
+	config->mPrefix.mLength = nrf_rpc_decode_uint(ctx);
+	config->mPreference = nrf_rpc_decode_int(ctx);
+	config->mPreferred = nrf_rpc_decode_bool(ctx);
+	config->mSlaac = nrf_rpc_decode_bool(ctx);
+	config->mDhcp = nrf_rpc_decode_bool(ctx);
+	config->mConfigure = nrf_rpc_decode_bool(ctx);
+	config->mDefaultRoute = nrf_rpc_decode_bool(ctx);
+	config->mOnMesh = nrf_rpc_decode_bool(ctx);
+	config->mStable = nrf_rpc_decode_bool(ctx);
+	config->mNdDns = nrf_rpc_decode_bool(ctx);
+	config->mDp = nrf_rpc_decode_bool(ctx);
+	config->mRloc16 = nrf_rpc_decode_uint(ctx);
 }

--- a/subsys/net/openthread/rpc/common/ot_rpc_common.c
+++ b/subsys/net/openthread/rpc/common/ot_rpc_common.c
@@ -172,9 +172,14 @@ void ot_rpc_encode_message_settings(struct nrf_rpc_cbor_ctx *ctx, const otMessag
 	nrf_rpc_encode_uint(ctx, settings->mPriority);
 }
 
-void ot_rpc_report_decoding_error(uint8_t cmd_evt_id)
+void ot_rpc_report_cmd_decoding_error(uint8_t cmd_evt_id)
 {
 	nrf_rpc_err(-EBADMSG, NRF_RPC_ERR_SRC_RECV, &ot_group, cmd_evt_id, NRF_RPC_PACKET_TYPE_CMD);
+}
+
+void ot_rpc_report_rsp_decoding_error(uint8_t cmd_evt_id)
+{
+	nrf_rpc_err(-EBADMSG, NRF_RPC_ERR_SRC_RECV, &ot_group, cmd_evt_id, NRF_RPC_PACKET_TYPE_RSP);
 }
 
 void ot_rpc_encode_message_info(struct nrf_rpc_cbor_ctx *ctx, const otMessageInfo *aMessageInfo)

--- a/subsys/net/openthread/rpc/common/ot_rpc_common.h
+++ b/subsys/net/openthread/rpc/common/ot_rpc_common.h
@@ -78,13 +78,13 @@ void ot_rpc_encode_message_settings(struct nrf_rpc_cbor_ctx *ctx,
 /* The function reports about command decoding error (not responses). */
 void ot_rpc_report_decoding_error(uint8_t cmd_evt_id);
 
-bool ot_rpc_decode_message_info(struct nrf_rpc_cbor_ctx *ctx, otMessageInfo *aMessageInfo);
-bool ot_rpc_encode_message_info(struct nrf_rpc_cbor_ctx *ctx, const otMessageInfo *aMessageInfo);
+void ot_rpc_decode_message_info(struct nrf_rpc_cbor_ctx *ctx, otMessageInfo *aMessageInfo);
+void ot_rpc_encode_message_info(struct nrf_rpc_cbor_ctx *ctx, const otMessageInfo *aMessageInfo);
 bool ot_rpc_encode_service_config(struct nrf_rpc_cbor_ctx *ctx,
 				  const otServiceConfig *service_config);
-bool ot_rpc_decode_service_config(struct nrf_rpc_cbor_ctx *ctx, otServiceConfig *service_config);
+void ot_rpc_decode_service_config(struct nrf_rpc_cbor_ctx *ctx, otServiceConfig *service_config);
 bool ot_rpc_encode_border_router_config(struct nrf_rpc_cbor_ctx *ctx,
 					const otBorderRouterConfig *service_config);
-bool ot_rpc_decode_border_router_config(struct nrf_rpc_cbor_ctx *ctx,
+void ot_rpc_decode_border_router_config(struct nrf_rpc_cbor_ctx *ctx,
 					otBorderRouterConfig *service_config);
 #endif /* OT_RPC_COMMON_H_ */

--- a/subsys/net/openthread/rpc/common/ot_rpc_common.h
+++ b/subsys/net/openthread/rpc/common/ot_rpc_common.h
@@ -75,9 +75,8 @@ otMessageSettings *ot_rpc_decode_message_settings(struct nrf_rpc_cbor_ctx *ctx,
 						  otMessageSettings *settings);
 void ot_rpc_encode_message_settings(struct nrf_rpc_cbor_ctx *ctx,
 				    const otMessageSettings *settings);
-/* The function reports about command decoding error (not responses). */
-void ot_rpc_report_decoding_error(uint8_t cmd_evt_id);
-
+void ot_rpc_report_cmd_decoding_error(uint8_t cmd_evt_id);
+void ot_rpc_report_rsp_decoding_error(uint8_t cmd_evt_id);
 void ot_rpc_decode_message_info(struct nrf_rpc_cbor_ctx *ctx, otMessageInfo *aMessageInfo);
 void ot_rpc_encode_message_info(struct nrf_rpc_cbor_ctx *ctx, const otMessageInfo *aMessageInfo);
 bool ot_rpc_encode_service_config(struct nrf_rpc_cbor_ctx *ctx,

--- a/subsys/net/openthread/rpc/server/ot_rpc_coap.c
+++ b/subsys/net/openthread/rpc/server/ot_rpc_coap.c
@@ -65,7 +65,7 @@ static void ot_rpc_cmd_coap_new_message(const struct nrf_rpc_group *group,
 	settings = ot_rpc_decode_message_settings(ctx, &settings_buf);
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_NEW_MESSAGE);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_NEW_MESSAGE);
 		return;
 	}
 
@@ -107,14 +107,14 @@ static void ot_rpc_cmd_coap_message_init(const struct nrf_rpc_group *group,
 	code = nrf_rpc_decode_uint(ctx);
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_MESSAGE_INIT);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_MESSAGE_INIT);
 		return;
 	}
 
 	message = ot_msg_get(message_rep);
 
 	if (!message) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_MESSAGE_INIT);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_MESSAGE_INIT);
 		return;
 	}
 
@@ -145,7 +145,7 @@ static void ot_rpc_cmd_coap_message_init_response(const struct nrf_rpc_group *gr
 	code = nrf_rpc_decode_uint(ctx);
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_MESSAGE_INIT_RESPONSE);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_MESSAGE_INIT_RESPONSE);
 		return;
 	}
 
@@ -153,7 +153,7 @@ static void ot_rpc_cmd_coap_message_init_response(const struct nrf_rpc_group *gr
 	request = ot_msg_get(request_rep);
 
 	if (!response || !request) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_MESSAGE_INIT_RESPONSE);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_MESSAGE_INIT_RESPONSE);
 		return;
 	}
 
@@ -181,14 +181,14 @@ static void ot_rpc_cmd_coap_message_append_uri_path_options(const struct nrf_rpc
 	nrf_rpc_decode_str(ctx, uri, sizeof(uri));
 
 	if (!nrf_rpc_decode_valid(ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_MESSAGE_APPEND_URI_PATH_OPTIONS);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_MESSAGE_APPEND_URI_PATH_OPTIONS);
 		return;
 	}
 
 	message = ot_msg_get(message_rep);
 
 	if (!message) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_MESSAGE_APPEND_URI_PATH_OPTIONS);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_MESSAGE_APPEND_URI_PATH_OPTIONS);
 		return;
 	}
 
@@ -215,14 +215,14 @@ static void ot_rpc_cmd_coap_message_set_payload_marker(const struct nrf_rpc_grou
 	message_rep = nrf_rpc_decode_uint(ctx);
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_MESSAGE_SET_PAYLOAD_MARKER);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_MESSAGE_SET_PAYLOAD_MARKER);
 		return;
 	}
 
 	message = ot_msg_get(message_rep);
 
 	if (!message) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_MESSAGE_SET_PAYLOAD_MARKER);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_MESSAGE_SET_PAYLOAD_MARKER);
 		return;
 	}
 
@@ -247,14 +247,14 @@ static void ot_rpc_cmd_coap_message_get_type(const struct nrf_rpc_group *group,
 	message_rep = nrf_rpc_decode_uint(ctx);
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_MESSAGE_GET_TYPE);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_MESSAGE_GET_TYPE);
 		return;
 	}
 
 	message = ot_msg_get(message_rep);
 
 	if (!message) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_MESSAGE_GET_TYPE);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_MESSAGE_GET_TYPE);
 		return;
 	}
 
@@ -278,14 +278,14 @@ static void ot_rpc_cmd_coap_message_get_code(const struct nrf_rpc_group *group,
 	message_rep = nrf_rpc_decode_uint(ctx);
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_MESSAGE_GET_CODE);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_MESSAGE_GET_CODE);
 		return;
 	}
 
 	message = ot_msg_get(message_rep);
 
 	if (!message) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_MESSAGE_GET_CODE);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_MESSAGE_GET_CODE);
 		return;
 	}
 
@@ -309,14 +309,14 @@ static void ot_rpc_cmd_coap_message_get_message_id(const struct nrf_rpc_group *g
 	message_rep = nrf_rpc_decode_uint(ctx);
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_MESSAGE_GET_MESSAGE_ID);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_MESSAGE_GET_MESSAGE_ID);
 		return;
 	}
 
 	message = ot_msg_get(message_rep);
 
 	if (!message) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_MESSAGE_GET_MESSAGE_ID);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_MESSAGE_GET_MESSAGE_ID);
 		return;
 	}
 
@@ -342,14 +342,14 @@ static void ot_rpc_cmd_coap_message_get_token_length(const struct nrf_rpc_group 
 	message_rep = nrf_rpc_decode_uint(ctx);
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_MESSAGE_GET_TOKEN_LENGTH);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_MESSAGE_GET_TOKEN_LENGTH);
 		return;
 	}
 
 	message = ot_msg_get(message_rep);
 
 	if (!message) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_MESSAGE_GET_TOKEN_LENGTH);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_MESSAGE_GET_TOKEN_LENGTH);
 		return;
 	}
 
@@ -376,14 +376,14 @@ static void ot_rpc_cmd_coap_message_get_token(const struct nrf_rpc_group *group,
 	message_rep = nrf_rpc_decode_uint(ctx);
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_MESSAGE_GET_TOKEN);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_MESSAGE_GET_TOKEN);
 		return;
 	}
 
 	message = ot_msg_get(message_rep);
 
 	if (!message) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_MESSAGE_GET_TOKEN);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_MESSAGE_GET_TOKEN);
 		return;
 	}
 
@@ -410,7 +410,7 @@ static void ot_rpc_cmd_coap_start(const struct nrf_rpc_group *group, struct nrf_
 	port = nrf_rpc_decode_uint(ctx);
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_START);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_START);
 		return;
 	}
 
@@ -430,7 +430,7 @@ static void ot_rpc_cmd_coap_stop(const struct nrf_rpc_group *group, struct nrf_r
 	otError error;
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_STOP);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_STOP);
 		return;
 	}
 
@@ -481,7 +481,7 @@ static void ot_rpc_cmd_coap_add_resource(const struct nrf_rpc_group *group,
 	nrf_rpc_decode_str(ctx, uri, sizeof(uri));
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_ADD_RESOURCE);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_ADD_RESOURCE);
 		return;
 	}
 
@@ -526,7 +526,7 @@ static void ot_rpc_cmd_coap_remove_resource(const struct nrf_rpc_group *group,
 	nrf_rpc_decode_str(ctx, uri, sizeof(uri));
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_REMOVE_RESOURCE);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_REMOVE_RESOURCE);
 		return;
 	}
 
@@ -582,7 +582,7 @@ static void ot_rpc_cmd_coap_set_default_handler(const struct nrf_rpc_group *grou
 	enabled = nrf_rpc_decode_bool(ctx);
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_SET_DEFAULT_HANDLER);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_SET_DEFAULT_HANDLER);
 		return;
 	}
 
@@ -643,14 +643,14 @@ static void ot_rpc_cmd_coap_send_request(const struct nrf_rpc_group *group,
 	request_rep = nrf_rpc_decode_uint(ctx);
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_SEND_REQUEST);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_SEND_REQUEST);
 		return;
 	}
 
 	message = ot_msg_get(message_rep);
 
 	if (!message) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_SEND_REQUEST);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_SEND_REQUEST);
 		return;
 	}
 
@@ -681,14 +681,14 @@ static void ot_rpc_cmd_coap_send_response(const struct nrf_rpc_group *group,
 	ot_rpc_decode_message_info(ctx, &message_info);
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_SEND_RESPONSE);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_SEND_RESPONSE);
 		return;
 	}
 
 	message = ot_msg_get(message_rep);
 
 	if (!message) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_COAP_SEND_RESPONSE);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_SEND_RESPONSE);
 		return;
 	}
 

--- a/subsys/net/openthread/rpc/server/ot_rpc_dataset.c
+++ b/subsys/net/openthread/rpc/server/ot_rpc_dataset.c
@@ -21,7 +21,7 @@ static void ot_rpc_dataset_is_commissioned_rpc_handler(const struct nrf_rpc_grou
 	bool result;
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_DATASET_IS_COMMISSIONED);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_DATASET_IS_COMMISSIONED);
 		return;
 	}
 
@@ -47,7 +47,7 @@ static void ot_rpc_data_set_active_tlvs_rpc_handler(const struct nrf_rpc_group *
 	ot_rpc_decode_dataset_tlvs(group, ctx, &data_ptr);
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_DATASET_SET_ACTIVE_TLVS);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_DATASET_SET_ACTIVE_TLVS);
 		return;
 	}
 
@@ -83,7 +83,7 @@ static void ot_rpc_data_get_active_tlvs_rpc_handler(const struct nrf_rpc_group *
 	otError error;
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_DATASET_GET_ACTIVE_TLVS);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_DATASET_GET_ACTIVE_TLVS);
 		return;
 	}
 
@@ -107,7 +107,7 @@ static void ot_rpc_dataset_set_active_rpc_handler(const struct nrf_rpc_group *gr
 	ot_rpc_decode_dataset(group, ctx, &data_ptr);
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_DATASET_SET_ACTIVE);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_DATASET_SET_ACTIVE);
 		return;
 	}
 
@@ -134,7 +134,7 @@ static void ot_rpc_dataset_get_active_rpc_handler(const struct nrf_rpc_group *gr
 	otError error;
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_DATASET_GET_ACTIVE);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_DATASET_GET_ACTIVE);
 		return;
 	}
 

--- a/subsys/net/openthread/rpc/server/ot_rpc_instance.c
+++ b/subsys/net/openthread/rpc/server/ot_rpc_instance.c
@@ -88,13 +88,13 @@ static void ot_rpc_cmd_instance_get_id(const struct nrf_rpc_group *group,
 	instance = (otInstance *)nrf_rpc_decode_uint(ctx);
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_INSTANCE_GET_ID);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_INSTANCE_GET_ID);
 		return;
 	}
 
 	if (instance != openthread_get_default_instance()) {
 		/* The instance is unknown to the OT RPC server. */
-		ot_rpc_report_decoding_error(OT_RPC_CMD_INSTANCE_GET_ID);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_INSTANCE_GET_ID);
 		return;
 	}
 
@@ -117,13 +117,13 @@ static void ot_rpc_cmd_instance_is_initialized(const struct nrf_rpc_group *group
 	instance = (otInstance *)nrf_rpc_decode_uint(ctx);
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_INSTANCE_GET_ID);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_INSTANCE_GET_ID);
 		return;
 	}
 
 	if (instance != openthread_get_default_instance()) {
 		/* The instance is unknown to the OT RPC server. */
-		ot_rpc_report_decoding_error(OT_RPC_CMD_INSTANCE_GET_ID);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_INSTANCE_GET_ID);
 		return;
 	}
 
@@ -146,13 +146,13 @@ static void ot_rpc_cmd_instance_finalize(const struct nrf_rpc_group *group,
 	instance = (otInstance *)nrf_rpc_decode_uint(ctx);
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_INSTANCE_GET_ID);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_INSTANCE_GET_ID);
 		return;
 	}
 
 	if (instance != openthread_get_default_instance()) {
 		/* The instance is unknown to the OT RPC server. */
-		ot_rpc_report_decoding_error(OT_RPC_CMD_INSTANCE_GET_ID);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_INSTANCE_GET_ID);
 		return;
 	}
 
@@ -176,13 +176,13 @@ static void ot_rpc_cmd_instance_erase_persistent_info(const struct nrf_rpc_group
 	instance = (otInstance *)nrf_rpc_decode_uint(ctx);
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_INSTANCE_GET_ID);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_INSTANCE_GET_ID);
 		return;
 	}
 
 	if (instance != openthread_get_default_instance()) {
 		/* The instance is unknown to the OT RPC server. */
-		ot_rpc_report_decoding_error(OT_RPC_CMD_INSTANCE_GET_ID);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_INSTANCE_GET_ID);
 		return;
 	}
 

--- a/subsys/net/openthread/rpc/server/ot_rpc_link.c
+++ b/subsys/net/openthread/rpc/server/ot_rpc_link.c
@@ -65,7 +65,7 @@ static void ot_rpc_cmd_set_max_frame_retries_direct(const struct nrf_rpc_group *
 	uint8_t max_retries = nrf_rpc_decode_uint(ctx);
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_LINK_SET_MAX_FRAME_RETRIES_DIRECT);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_LINK_SET_MAX_FRAME_RETRIES_DIRECT);
 		return;
 	}
 
@@ -82,7 +82,7 @@ static void ot_rpc_cmd_set_max_frame_retries_indirect(const struct nrf_rpc_group
 	uint8_t max_retries = nrf_rpc_decode_uint(ctx);
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_LINK_SET_MAX_FRAME_RETRIES_INDIRECT);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_LINK_SET_MAX_FRAME_RETRIES_INDIRECT);
 		return;
 	}
 
@@ -99,7 +99,7 @@ static void ot_rpc_cmd_set_link_enabled(const struct nrf_rpc_group *group,
 	bool enabled = nrf_rpc_decode_bool(ctx);
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_LINK_SET_ENABLED);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_LINK_SET_ENABLED);
 		return;
 	}
 

--- a/subsys/net/openthread/rpc/server/ot_rpc_message.c
+++ b/subsys/net/openthread/rpc/server/ot_rpc_message.c
@@ -66,7 +66,7 @@ static void ot_rpc_msg_free(const struct nrf_rpc_group *group, struct nrf_rpc_cb
 	nrf_rpc_cbor_decoding_done(group, ctx);
 
 	if (!decoding_ok) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_MESSAGE_FREE);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_MESSAGE_FREE);
 		goto exit;
 	}
 
@@ -98,7 +98,7 @@ static void ot_rpc_msg_append(const struct nrf_rpc_group *group, struct nrf_rpc_
 
 	if (!decoding_ok) {
 		nrf_rpc_cbor_decoding_done(group, ctx);
-		ot_rpc_report_decoding_error(OT_RPC_CMD_MESSAGE_APPEND);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_MESSAGE_APPEND);
 		error = OT_ERROR_INVALID_ARGS;
 		goto exit;
 	}
@@ -107,7 +107,7 @@ static void ot_rpc_msg_append(const struct nrf_rpc_group *group, struct nrf_rpc_
 
 	if (!decoding_ok) {
 		nrf_rpc_cbor_decoding_done(group, ctx);
-		ot_rpc_report_decoding_error(OT_RPC_CMD_MESSAGE_APPEND);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_MESSAGE_APPEND);
 		error = OT_ERROR_INVALID_ARGS;
 		goto exit;
 	}
@@ -169,7 +169,7 @@ static void ot_rpc_msg_length(const struct nrf_rpc_group *group, struct nrf_rpc_
 	nrf_rpc_cbor_decoding_done(group, ctx);
 
 	if (!decoding_ok) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_MESSAGE_APPEND);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_MESSAGE_APPEND);
 		goto exit;
 	}
 
@@ -202,7 +202,7 @@ static void ot_rpc_get_offset(const struct nrf_rpc_group *group, struct nrf_rpc_
 	nrf_rpc_cbor_decoding_done(group, ctx);
 
 	if (!decoding_ok) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_MESSAGE_APPEND);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_MESSAGE_APPEND);
 		goto exit;
 	}
 
@@ -235,19 +235,19 @@ static void ot_rpc_msg_read(const struct nrf_rpc_group *group, struct nrf_rpc_cb
 
 	if (!zcbor_uint_decode(ctx->zs, &key, sizeof(key))) {
 		nrf_rpc_cbor_decoding_done(group, ctx);
-		ot_rpc_report_decoding_error(OT_RPC_CMD_MESSAGE_APPEND);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_MESSAGE_APPEND);
 		goto exit;
 	}
 
 	if (!zcbor_uint_decode(ctx->zs, &offset, sizeof(offset))) {
 		nrf_rpc_cbor_decoding_done(group, ctx);
-		ot_rpc_report_decoding_error(OT_RPC_CMD_MESSAGE_APPEND);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_MESSAGE_APPEND);
 		goto exit;
 	}
 
 	if (!zcbor_uint_decode(ctx->zs, &length, sizeof(length))) {
 		nrf_rpc_cbor_decoding_done(group, ctx);
-		ot_rpc_report_decoding_error(OT_RPC_CMD_MESSAGE_APPEND);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_MESSAGE_APPEND);
 		goto exit;
 	}
 

--- a/subsys/net/openthread/rpc/server/ot_rpc_thread.c
+++ b/subsys/net/openthread/rpc/server/ot_rpc_thread.c
@@ -81,7 +81,7 @@ static void ot_rpc_thread_discover_rpc_handler(const struct nrf_rpc_group *group
 	cb_ctx = (void *)nrf_rpc_decode_uint(ctx);
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_THREAD_DISCOVER);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_THREAD_DISCOVER);
 		return;
 	}
 

--- a/subsys/net/openthread/rpc/server/ot_rpc_udp.c
+++ b/subsys/net/openthread/rpc/server/ot_rpc_udp.c
@@ -83,7 +83,7 @@ static void handle_udp_receive(void *context, otMessage *message, const otMessag
 	nrf_rpc_cbor_cmd_rsp_no_err(&ot_group, OT_RPC_CMD_UDP_RECEIVE_CB, &ctx);
 
 	if (!nrf_rpc_decoding_done_and_check(&ot_group, &ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_UDP_RECEIVE_CB);
+		ot_rpc_report_rsp_decoding_error(OT_RPC_CMD_UDP_RECEIVE_CB);
 	}
 
 exit:
@@ -148,7 +148,7 @@ static void ot_rpc_udp_send(const struct nrf_rpc_group *group, struct nrf_rpc_cb
 	ot_rpc_decode_message_info(ctx, &message_info);
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
-		ot_rpc_report_decoding_error(OT_RPC_CMD_UDP_SEND);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_UDP_SEND);
 		return;
 	}
 
@@ -233,7 +233,7 @@ static void ot_rpc_udp_bind(const struct nrf_rpc_group *group, struct nrf_rpc_cb
 exit:
 	if (!decoded_ok) {
 		nrf_rpc_cbor_decoding_done(group, ctx);
-		ot_rpc_report_decoding_error(OT_RPC_CMD_UDP_BIND);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_UDP_BIND);
 	}
 
 	NRF_RPC_CBOR_ALLOC(group, rsp_ctx, sizeof(error) + 1);
@@ -275,7 +275,7 @@ static void ot_rpc_udp_close(const struct nrf_rpc_group *group, struct nrf_rpc_c
 exit:
 	if (!decoded_ok) {
 		nrf_rpc_cbor_decoding_done(group, ctx);
-		ot_rpc_report_decoding_error(OT_RPC_CMD_UDP_CLOSE);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_UDP_CLOSE);
 	}
 
 	NRF_RPC_CBOR_ALLOC(group, rsp_ctx, sizeof(error) + 1);
@@ -333,7 +333,7 @@ static void ot_rpc_udp_connect(const struct nrf_rpc_group *group, struct nrf_rpc
 exit:
 	if (!decoded_ok) {
 		nrf_rpc_cbor_decoding_done(group, ctx);
-		ot_rpc_report_decoding_error(OT_RPC_CMD_UDP_BIND);
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_UDP_BIND);
 	}
 
 	NRF_RPC_CBOR_ALLOC(group, rsp_ctx, sizeof(error) + 1);


### PR DESCRIPTION
Commit adds refactoring openthread clients to use
nrf_rpc encoders and decoders instead of zcbor API.