### PR TITLE
tests: benchmarks: power_consumption: modify spi test.

### DIFF
--- a/tests/benchmarks/power_consumption/spi/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/benchmarks/power_consumption/spi/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,6 @@
+&spi131 {
+	zephyr,pm-device-runtime-auto;
+};
+&exmif {
+	status = "disabled";
+};

--- a/tests/benchmarks/power_consumption/spi/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/benchmarks/power_consumption/spi/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,3 @@
+&spi21 {
+	zephyr,pm-device-runtime-auto;
+};


### PR DESCRIPTION
Add overlays to enable device runtime PM for spi and reduce power consumption level during test.