### PR TITLE
doc: software_maturity: fast_pair: update status for nRF54L15

### DIFF
--- a/doc/nrf/releases_and_maturity/software_maturity.rst
+++ b/doc/nrf/releases_and_maturity/software_maturity.rst
@@ -1189,7 +1189,7 @@ The following table indicates the software maturity levels of the support for Go
         - Supported
         - Experimental
         - --
-        - Experimental
+        - Supported
         - --
         - --
         - --
@@ -1229,7 +1229,7 @@ The following table indicates the software maturity levels of the support for ea
         - Supported
         - Experimental
         - --
-        - Experimental
+        - Supported
         - --
         - --
         - --
@@ -1285,7 +1285,7 @@ The following table indicates the software maturity levels of the support for ea
         - Supported
         - Experimental
         - --
-        - Experimental
+        - Supported
         - --
         - --
         - --


### PR DESCRIPTION
Updated the software maturity levels in the Google Fast Pair category for the nRF54L15 device to declare the "Supported" level for the locator tag use case and its feature depedencies.

Ref: NCSDK-29887