### PR TITLE
Bluetooth: Mesh: Fix scene recall in light_ctrl_srv

### DIFF
--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -562,6 +562,12 @@ static void timeout(struct k_work *work)
 	if (!is_enabled(srv)) {
 		if (srv->resume && atomic_test_and_clear_bit(&srv->flags, FLAG_RESUME_TIMER)) {
 			LOG_DBG("Resuming LC server");
+			if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
+				/* Resuming the LC server invalidates the current scene as it takes
+				 * control over states that are stored with the scene.
+				 */
+				bt_mesh_scene_invalidate(srv->model);
+			}
 			ctrl_enable(srv);
 			store(srv, FLAG_STORE_STATE);
 		}


### PR DESCRIPTION
Previously, the scene recall was not working as expected in the
following case: If a single scene is stored when the light is on, and
then the light is dimmed/turned off by the controller, the current
scene would not be invalidated and recalling the scene would do nothing.

This commit fixes the issue by invalidating the current scene when the
light controller is re-enabled as a result of the resume timeout.