### PR TITLE
samples: matter: Add guide on how to flash factory data on nRF54H

### DIFF
--- a/applications/matter_bridge/doc/matter_bridge_description.rst
+++ b/applications/matter_bridge/doc/matter_bridge_description.rst
@@ -697,6 +697,17 @@ The application supports the following configurations:
 
        Enables the Matter Bridge to work with Wi-Fi on nRF5340 DK.
 
+Factory data support
+====================
+
+.. include:: ../../../samples/matter/lock/README.rst
+    :start-after: matter_door_lock_sample_factory_data_start
+    :end-before: matter_door_lock_sample_factory_data_end
+
+.. include:: ../../../samples/matter/lock/README.rst
+    :start-after: matter_door_lock_sample_factory_data_nrf54h20_start
+    :end-before: matter_door_lock_sample_factory_data_nrf54h20_end
+
 Building and running
 ********************
 

--- a/samples/matter/common/dts/nrf54h20/nrf54h20_cpuapp_memory_map.dtsi
+++ b/samples/matter/common/dts/nrf54h20/nrf54h20_cpuapp_memory_map.dtsi
@@ -12,6 +12,7 @@
 	aliases {
 		factory-data = &factory_data;
 		factory-data-memory-region = &cpuapp_rw_partitions;
+		factory-data-location = &mram1x;
 	};
 };
 

--- a/samples/matter/lock/README.rst
+++ b/samples/matter/lock/README.rst
@@ -363,6 +363,44 @@ To learn more about factory data, read the :doc:`matter:nrfconnect_factory_data_
 
 .. matter_door_lock_sample_factory_data_end
 
+.. matter_door_lock_sample_factory_data_nrf54h20_start
+
+Merging the factory data hex file with the firmware hex file is currently not available on the nRF54H20 DK.
+The factory data support is disabled by default on this board.
+You can still use it, but you need to flash the :file:`factory_data.hex` file manually.
+
+To use factory data on the nRF54H20 DK, complete the following steps:
+
+1. Flash the :file:`factory_data.hex` file into the device using the following command:
+
+   .. code-block:: console
+
+      nrfutil device program --firmware build/template/zephyr/factory_data.hex
+
+#. Enable factory data support by building the sample with the :kconfig:option:`CONFIG_CHIP_FACTORY_DATA` Kconfig option set to ``y`` using the following command:
+
+   .. code-block:: console
+
+      west build -p -b nrf54h20dk/nrf54h20/cpuapp -- -DCONFIG_CHIP_FACTORY_DATA=y
+
+#. Flash the firmware into the device:
+
+   .. code-block:: console
+
+      west flash --erase
+
+The ``west flash --erase`` command does not clear the factory data partition.
+If you want to clear it, use the following command, and fill the ``<address>`` argument as an address of the factory data partition.
+By default, the address is set to ``0xe174000``.
+
+.. code-block:: console
+
+   nrfutil device erase --pages <address>
+
+Migrating the DAC private key from the factory data set to Trusted Storage is not supported yet on nRF54H20 DK.
+
+.. matter_door_lock_sample_factory_data_nrf54h20_end
+
 User interface
 **************
 

--- a/samples/matter/template/README.rst
+++ b/samples/matter/template/README.rst
@@ -161,6 +161,10 @@ Factory data support
     :start-after: matter_door_lock_sample_factory_data_start
     :end-before: matter_door_lock_sample_factory_data_end
 
+.. include:: ../lock/README.rst
+    :start-after: matter_door_lock_sample_factory_data_nrf54h20_start
+    :end-before: matter_door_lock_sample_factory_data_nrf54h20_end
+
 User interface
 **************
 

--- a/west.yml
+++ b/west.yml
@@ -161,7 +161,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 668f104204ca3856818283d970501bd2a0e21f91
+      revision: 95a8c0fbcc94deb32c9365c5e88279d9292f8fdd
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
Until we do not have a proper solution for merging the factory data hex file with the firmware hex file, we need to flash the factory data manually. This commit allows doing that on nRF54H20 DK and describes how to do it in Matter samples.