### PR TITLE
suit: Fix external flash template manifest

### DIFF
--- a/samples/suit/smp_transfer/suit/nrf54h20/root_with_binary_nordic_top_extflash.yaml.jinja2
+++ b/samples/suit/smp_transfer/suit/nrf54h20/root_with_binary_nordic_top_extflash.yaml.jinja2
@@ -163,9 +163,9 @@ SUIT_Envelope_Tagged:
     suit-install:
 {%- endif %}
     - suit-directive-set-component-index: 0
-{%- if radio is defined %}
+{%- if application is defined %}
     - suit-directive-override-parameters:
-        suit-parameter-uri: '#{{ radio['name'] }}'
+        suit-parameter-uri: '#{{ application['name'] }}'
     - suit-directive-fetch:
       - suit-send-record-failure
     - suit-condition-dependency-integrity:
@@ -179,9 +179,9 @@ SUIT_Envelope_Tagged:
       - suit-send-sysinfo-success
       - suit-send-sysinfo-failure
 {%- endif %}
-{%- if application is defined %}
+{%- if radio is defined %}
     - suit-directive-override-parameters:
-        suit-parameter-uri: '#{{ application['name'] }}'
+        suit-parameter-uri: '#{{ radio['name'] }}'
     - suit-directive-fetch:
       - suit-send-record-failure
     - suit-condition-dependency-integrity:
@@ -214,13 +214,16 @@ SUIT_Envelope_Tagged:
 
     suit-candidate-verification:
     - suit-directive-set-component-index: 0
-{%- if radio is defined %}
+# DO NOT CHANGE THE ORDER OF INSTALLING THE MANIFESTS HERE
+# The application manifest boots the flash companion image,
+# so it is needed to be processed before the radio image.
+{%- if application is defined %}
     - suit-directive-override-parameters:
-        suit-parameter-uri: '#{{ radio['name'] }}'
+        suit-parameter-uri: '#{{ application['name'] }}'
         suit-parameter-image-digest:
           suit-digest-algorithm-id: cose-alg-sha-256
           suit-digest-bytes:
-            envelope: {{ artifacts_folder ~ radio['name'] }}.suit
+            envelope: {{ artifacts_folder ~ application['name'] }}.suit
     - suit-directive-fetch:
       - suit-send-record-failure
     - suit-condition-image-match:
@@ -239,13 +242,13 @@ SUIT_Envelope_Tagged:
       - suit-send-sysinfo-success
       - suit-send-sysinfo-failure
 {%- endif %}
-{%- if application is defined %}
+{%- if radio is defined %}
     - suit-directive-override-parameters:
-        suit-parameter-uri: '#{{ application['name'] }}'
+        suit-parameter-uri: '#{{ radio['name'] }}'
         suit-parameter-image-digest:
           suit-digest-algorithm-id: cose-alg-sha-256
           suit-digest-bytes:
-            envelope: {{ artifacts_folder ~ application['name'] }}.suit
+            envelope: {{ artifacts_folder ~ radio['name'] }}.suit
     - suit-directive-fetch:
       - suit-send-record-failure
     - suit-condition-image-match:


### PR DESCRIPTION
The radio and application manifests were booted in the wrong order - thus, there was an attempt to fetch
the radio manifest, before the flash_companion (started by the app manifest) was booted.