### PR TITLE
lib: nrf_modem_lib: set data cache alignment to 32 bytes

### DIFF
--- a/lib/nrf_modem_lib/nrf_modem_os_rpc.c
+++ b/lib/nrf_modem_lib/nrf_modem_os_rpc.c
@@ -18,7 +18,9 @@
 #include <zephyr/ipc/icmsg.h>
 #include <zephyr/ipc/pbuf.h>
 
-#define DCACHE_LINE_SIZE 0
+#define DCACHE_LINE_SIZE (CONFIG_DCACHE_LINE_SIZE)
+BUILD_ASSERT(DCACHE_LINE_SIZE == 32
+	     "Unexpected data cache line size " STRINGIFY(DCACHE_LINE_SIZE) ", expected 32");
 
 /** Structure to hold pbuf configuration and data. */
 struct nrf_modem_pbuf {


### PR DESCRIPTION
The nRF9280 application core has data cache with a cache line width of 32 bytes. Set the dcache alignment of ICMsg pbuf to 32 bytes to align.