### PR TITLE
samples: matter: Enable storing DAC priv key in KMU by default.

### DIFF
--- a/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -17,6 +17,3 @@ CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
 # Workaround required as Zephyr L2 implies usage of NVS backend for settings.
 # It should be removed once the proper fix will be applied in Zephyr.
 CONFIG_NVS=n
-
-# Enable DAC key migration to KMU
-CONFIG_CHIP_CRYPTO_PSA_DAC_PRIV_KEY_KMU=y

--- a/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
+++ b/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
@@ -19,6 +19,3 @@ CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
 # Workaround required as Zephyr L2 implies usage of NVS backend for settings.
 # It should be removed once the proper fix will be applied in Zephyr.
 CONFIG_NVS=n
-
-# Enable DAC key migration to KMU
-CONFIG_CHIP_CRYPTO_PSA_DAC_PRIV_KEY_KMU=y

--- a/west.yml
+++ b/west.yml
@@ -161,7 +161,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 95a8c0fbcc94deb32c9365c5e88279d9292f8fdd
+      revision: aa968a63f9ed2385dec7b7d2fbfe7dfddc873f4c
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
Enabled storing the DAC private key in KMU if it is available.