### PR TITLE
applications: nrf_desktop: Add a new Kconfig for HID forward

### DIFF
--- a/applications/nrf_desktop/src/modules/Kconfig.hid_forward
+++ b/applications/nrf_desktop/src/modules/Kconfig.hid_forward
@@ -18,6 +18,19 @@ config DESKTOP_HID_FORWARD_ENABLE
 
 if DESKTOP_HID_FORWARD_ENABLE
 
+config DESKTOP_HID_FORWARD_SUBSCRIBER_COUNT
+	int "Number of HID subscribers"
+	range 1 255
+	default DESKTOP_HID_DONGLE_BOND_COUNT
+	help
+	  By default, the module uses a dedicated HID subscriber (USB HID class
+	  instance) for every BLE bonded HID peripheral. Set this option to 1 to
+	  forward all of the HID reports received from HID peripherals to one
+	  subscriber (required if using a single USB HID instance).
+
+	  The configured number of HID subscribers must match number of USB HID
+	  class instances.
+
 config BT_HOGP_REPORTS_MAX
 	default 12
 	help

--- a/applications/nrf_desktop/src/modules/hid_forward.c
+++ b/applications/nrf_desktop/src/modules/hid_forward.c
@@ -58,7 +58,7 @@ struct hids_peripheral {
 	uint8_t sub_id;
 };
 
-static struct subscriber subscribers[CONFIG_DESKTOP_HID_DONGLE_BOND_COUNT];
+static struct subscriber subscribers[CONFIG_DESKTOP_HID_FORWARD_SUBSCRIBER_COUNT];
 static bt_addr_le_t peripheral_address[CONFIG_BT_MAX_PAIRED];
 static struct hids_peripheral peripherals[CONFIG_BT_MAX_CONN];
 static uint8_t peripheral_cache[CONFIG_BT_MAX_CONN];
@@ -68,7 +68,7 @@ static bool suspended;
 static void hogp_out_rep_write_cb(struct bt_hogp *hogp, struct bt_hogp_rep_info *rep, uint8_t err);
 static int send_hid_out_report(struct bt_hogp *hogp, const uint8_t *data, size_t size);
 
-#if CONFIG_DESKTOP_HID_DONGLE_BOND_COUNT > 1
+#if CONFIG_DESKTOP_HID_FORWARD_SUBSCRIBER_COUNT > 1
 static void verify_data(const struct bt_bond_info *info, void *user_data)
 {
 	for (size_t i = 0; i < ARRAY_SIZE(peripheral_address); i++) {
@@ -116,7 +116,7 @@ static int verify_peripheral_address(void)
 
 SETTINGS_STATIC_HANDLER_DEFINE(hid_forward, MODULE_NAME, NULL, settings_set,
 			       verify_peripheral_address, NULL);
-#endif /* CONFIG_DESKTOP_HID_DONGLE_BOND_COUNT > 1 */
+#endif /* CONFIG_DESKTOP_HID_FORWARD_SUBSCRIBER_COUNT > 1 */
 
 static int store_peripheral_address(void)
 {


### PR DESCRIPTION
Change allows configuring HID subscriber count in HID forward. This is needed in case a single USB HID instance is used for all of the HID peripherals connected over Bluetooth LE.

Jira: NCSDK-30002