### PR TITLE
partition_manager: Make tfm storage partions avoid partitioning conflict

### DIFF
--- a/subsys/partition_manager/pm.yml.tfm
+++ b/subsys/partition_manager/pm.yml.tfm
@@ -30,31 +30,19 @@ tfm_storage:
 
 tfm_ps:
   placement:
-#ifdef CONFIG_BOOTLOADER_MCUBOOT
-    before: mcuboot_primary
-#else
-    before: tfm_nonsecure
-#endif
+    after: [mcuboot, tfm_secure]
   inside: tfm_storage
   size: CONFIG_PM_PARTITION_SIZE_TFM_PROTECTED_STORAGE
 
 tfm_its:
   placement:
-#ifdef CONFIG_BOOTLOADER_MCUBOOT
-    before: mcuboot_primary
-#else
-    before: tfm_nonsecure
-#endif
+    after: [mcuboot, tfm_secure]
   inside: tfm_storage
   size: CONFIG_PM_PARTITION_SIZE_TFM_INTERNAL_TRUSTED_STORAGE
 
 tfm_otp_nv_counters:
   placement:
-#ifdef CONFIG_BOOTLOADER_MCUBOOT
-    before: mcuboot_primary
-#else
-    before: tfm_nonsecure
-#endif
+    after: [mcuboot, tfm_secure]
   inside: tfm_storage
   size: CONFIG_PM_PARTITION_SIZE_TFM_OTP_NV_COUNTERS
 


### PR DESCRIPTION
With the previous method, both tfm_storage partitions (its, ps, etc) were placed "before: mcuboot_primary". This could lead to a case where mcuboot was placed after the tfm_storage partitions. To avoid this, instead place "after" mcuboot or tfm_secure.

To be a bit specific: The mentioned bug happened when I tried to build with dual bootloaders and the nRF54L15.