### PR TITLE
[Backport v2.8-branch] lib: nrf_modem_lib: set data cache alignment to 32 bytes

### DIFF
--- a/lib/nrf_modem_lib/nrf_modem_os_rpc.c
+++ b/lib/nrf_modem_lib/nrf_modem_os_rpc.c
@@ -18,7 +18,9 @@
 #include <zephyr/ipc/icmsg.h>
 #include <zephyr/ipc/pbuf.h>
 
-#define DCACHE_LINE_SIZE 0
+#define DCACHE_LINE_SIZE (CONFIG_DCACHE_LINE_SIZE)
+BUILD_ASSERT(DCACHE_LINE_SIZE == 32
+	     "Unexpected data cache line size " STRINGIFY(DCACHE_LINE_SIZE) ", expected 32");
 
 /** Structure to hold pbuf configuration and data. */
 struct nrf_modem_pbuf {


### PR DESCRIPTION
Backport 6a08601d3a49a52f310a271eac148edb5ac81a7b from #18432.