### PR TITLE
scripts/requirents-extra: add nrfprovision

### DIFF
--- a/scripts/requirements-extra.txt
+++ b/scripts/requirements-extra.txt
@@ -7,3 +7,5 @@ zcbor>=0.8.0
 nrfcredstore>=1.0.0,<2
 idna>=3.7 # https://github.com/advisories/GHSA-jjg7-2v4v-x38h
 libusb>=1.0.26
+--extra-index-url https://files.nordicsemi.com/artifactory/api/pypi/nordic-pypi/simple
+nrfprovision>=0.9.0


### PR DESCRIPTION
Added requirement of nrfprovision script which is temporary script needed for west ncs-provision script
(nRF54L15 KMU provisioning)