### PR TITLE
cmake: sysbuild: Fix not configuring key file strings

### DIFF
--- a/cmake/sysbuild/debug_keys.cmake
+++ b/cmake/sysbuild/debug_keys.cmake
@@ -47,12 +47,14 @@ if(NOT SB_CONFIG_SECURE_BOOT_SIGNING_CUSTOM AND "${SB_CONFIG_SECURE_BOOT_SIGNING
     )
   set(SIGN_KEY_FILE_DEPENDS debug_sign_key_target)
 else()
-  if(IS_ABSOLUTE ${SB_CONFIG_SECURE_BOOT_SIGNING_KEY_FILE})
-    set(SIGNATURE_PRIVATE_KEY_FILE ${SB_CONFIG_SECURE_BOOT_SIGNING_KEY_FILE})
+  string(CONFIGURE "${SB_CONFIG_SECURE_BOOT_SIGNING_KEY_FILE}" keyfile)
+  if(IS_ABSOLUTE ${keyfile})
+    set(SIGNATURE_PRIVATE_KEY_FILE ${keyfile})
   else()
     # Resolve path relative to the application configuration directory.
-    set(SIGNATURE_PRIVATE_KEY_FILE ${APPLICATION_CONFIG_DIR}/${SB_CONFIG_SECURE_BOOT_SIGNING_KEY_FILE})
+    set(SIGNATURE_PRIVATE_KEY_FILE ${APPLICATION_CONFIG_DIR}/${keyfile})
   endif()
+  set(keyfile)
 
   if(NOT EXISTS ${SIGNATURE_PRIVATE_KEY_FILE})
     message(FATAL_ERROR "Config points to non-existing PEM file '${SIGNATURE_PRIVATE_KEY_FILE}'")

--- a/cmake/sysbuild/image_signing.cmake
+++ b/cmake/sysbuild/image_signing.cmake
@@ -19,6 +19,8 @@ endfunction()
 function(zephyr_mcuboot_tasks)
   set(keyfile "${CONFIG_MCUBOOT_SIGNATURE_KEY_FILE}")
   set(keyfile_enc "${CONFIG_MCUBOOT_ENCRYPTION_KEY_FILE}")
+  string(CONFIGURE "${keyfile}" keyfile)
+  string(CONFIGURE "${keyfile_enc}" keyfile_enc)
 
   if(NOT "${CONFIG_MCUBOOT_GENERATE_UNSIGNED_IMAGE}")
     # Check for misconfiguration.

--- a/cmake/sysbuild/sign.cmake
+++ b/cmake/sysbuild/sign.cmake
@@ -30,8 +30,8 @@ function(b0_gen_keys)
       -out ${SIGNATURE_PUBLIC_KEY_FILE}
       )
   elseif(SB_CONFIG_SECURE_BOOT_SIGNING_CUSTOM)
-    set(SIGNATURE_PUBLIC_KEY_FILE ${SB_CONFIG_SECURE_BOOT_SIGNING_PUBLIC_KEY})
-    set(SIGNATURE_PUBLIC_KEY_FILE ${SB_CONFIG_SECURE_BOOT_SIGNING_PUBLIC_KEY} PARENT_SCOPE)
+    string(CONFIGURE "${SB_CONFIG_SECURE_BOOT_SIGNING_PUBLIC_KEY}" SIGNATURE_PUBLIC_KEY_FILE)
+    set(SIGNATURE_PUBLIC_KEY_FILE ${SIGNATURE_PUBLIC_KEY_FILE} PARENT_SCOPE)
 
     if(NOT EXISTS ${SIGNATURE_PUBLIC_KEY_FILE} OR IS_DIRECTORY ${SIGNATURE_PUBLIC_KEY_FILE})
       message(WARNING "Invalid public key file: ${SIGNATURE_PUBLIC_KEY_FILE}")
@@ -165,6 +165,7 @@ function(b0_sign_image slot)
       )
   elseif(SB_CONFIG_SECURE_BOOT_SIGNING_CUSTOM)
     set(custom_sign_cmd "${SB_CONFIG_SECURE_BOOT_SIGNING_COMMAND}")
+    string(CONFIGURE "${custom_sign_cmd}" custom_sign_cmd)
 
     if (("${custom_sign_cmd}" STREQUAL "") OR (NOT EXISTS ${SIGNATURE_PUBLIC_KEY_FILE}))
       message(FATAL_ERROR "You must specify a signing command and valid public key file for custom signing.")


### PR DESCRIPTION
Fixes an issue whereby key file Kconfig values could have contained CMake variables which should have been configured to proper strings