### PR TITLE
[Backport v2.8-branch] partition_manager: Small fix to make vpr_launcher work on the nrf54l15DK

### DIFF
--- a/subsys/partition_manager/CMakeLists.txt
+++ b/subsys/partition_manager/CMakeLists.txt
@@ -134,7 +134,7 @@ if (CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_FLASH)
   ncs_add_partition_manager_config(pm.yml.modem_trace)
 endif()
 
-if (CONFIG_SOC_NRF54L15_ENGA_CPUFLPR OR SOC_NRF54L15_ENGA_CPUFLPR)
+if (CONFIG_SOC_NRF54L15_ENGA_CPUFLPR OR CONFIG_SOC_NRF54L15_CPUFLPR)
   ncs_add_partition_manager_config(pm.yml.vpr_launcher)
 endif()
 


### PR DESCRIPTION
Backport c1df16d8bd958e1ff60b7c8b5163456827e14928 from #18388.