### PR TITLE
[Backport v2.8-branch] nrf_security: Refactor mutexes to fix incorrect usage

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen.c
@@ -51,7 +51,7 @@ static void cracen_load_microcode(void)
 
 void cracen_acquire(void)
 {
-	nrf_security_mutex_lock(&cracen_mutex);
+	nrf_security_mutex_lock(cracen_mutex);
 
 	if (users++ == 0) {
 		nrf_cracen_module_enable(NRF_CRACEN, CRACEN_ENABLE_CRYPTOMASTER_Msk |
@@ -61,12 +61,12 @@ void cracen_acquire(void)
 		LOG_DBG_MSG("Powered on CRACEN.");
 	}
 
-	nrf_security_mutex_unlock(&cracen_mutex);
+	nrf_security_mutex_unlock(cracen_mutex);
 }
 
 void cracen_release(void)
 {
-	nrf_security_mutex_lock(&cracen_mutex);
+	nrf_security_mutex_lock(cracen_mutex);
 
 	if (--users == 0) {
 		/* Disable IRQs in the ARM NVIC as the first operation to be
@@ -102,7 +102,7 @@ void cracen_release(void)
 		LOG_DBG_MSG("Powered off CRACEN.");
 	}
 
-	nrf_security_mutex_unlock(&cracen_mutex);
+	nrf_security_mutex_unlock(cracen_mutex);
 }
 
 #define CRACEN_NOT_INITIALIZED 0x207467

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/key_management.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/key_management.c
@@ -31,7 +31,7 @@
 
 extern const uint8_t cracen_N3072[384];
 
-extern mbedtls_threading_mutex_t cracen_mutex_symmetric;
+extern nrf_security_mutex_t cracen_mutex_symmetric;
 
 #define DEFAULT_KEY_SIZE(bits) (bits), PSA_BITS_TO_BYTES(bits), (1 + 2 * PSA_BITS_TO_BYTES(bits))
 static struct {
@@ -1341,7 +1341,7 @@ psa_status_t cracen_export_key(const psa_key_attributes_t *attributes, const uin
 		 * use case. Here the decision was to avoid defining another mutex to handle the
 		 * push buffer for the rest of the use cases.
 		 */
-		nrf_security_mutex_lock(&cracen_mutex_symmetric);
+		nrf_security_mutex_lock(cracen_mutex_symmetric);
 		status = cracen_kmu_prepare_key(key_buffer);
 		if (status == SX_OK) {
 			memcpy(data, kmu_push_area, key_out_size);
@@ -1349,7 +1349,7 @@ psa_status_t cracen_export_key(const psa_key_attributes_t *attributes, const uin
 		}
 
 		(void)cracen_kmu_clean_key(key_buffer);
-		nrf_security_mutex_unlock(&cracen_mutex_symmetric);
+		nrf_security_mutex_unlock(cracen_mutex_symmetric);
 
 		return silex_statuscodes_to_psa(status);
 	}
@@ -1385,7 +1385,7 @@ psa_status_t cracen_copy_key(psa_key_attributes_t *attributes, const uint8_t *so
 	psa_status_t psa_status;
 	size_t key_size = PSA_BITS_TO_BYTES(psa_get_key_bits(attributes));
 
-	nrf_security_mutex_lock(&cracen_mutex_symmetric);
+	nrf_security_mutex_lock(cracen_mutex_symmetric);
 	status = cracen_kmu_prepare_key(source_key);
 
 	if (status == SX_OK) {
@@ -1397,7 +1397,7 @@ psa_status_t cracen_copy_key(psa_key_attributes_t *attributes, const uint8_t *so
 	}
 
 	(void)cracen_kmu_clean_key(source_key);
-	nrf_security_mutex_unlock(&cracen_mutex_symmetric);
+	nrf_security_mutex_unlock(cracen_mutex_symmetric);
 
 	if (status != SX_OK) {
 		return silex_statuscodes_to_psa(status);

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/kmu.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/kmu.c
@@ -29,7 +29,7 @@
 
 #define SECONDARY_SLOT_METADATA_VALUE UINT32_MAX
 
-extern mbedtls_threading_mutex_t cracen_mutex_symmetric;
+extern nrf_security_mutex_t cracen_mutex_symmetric;
 
 /* The section .nrf_kmu_reserved_push_area is placed at the top RAM address
  * by the linker scripts. We do that for both the secure and non-secure builds.
@@ -844,13 +844,13 @@ static psa_status_t push_kmu_key_to_ram(uint8_t *key_buffer, size_t key_buffer_s
 	 * Here the decision was to avoid defining another mutex to handle the push buffer for the
 	 * rest of the use cases.
 	 */
-	nrf_security_mutex_lock(&cracen_mutex_symmetric);
+	nrf_security_mutex_lock(cracen_mutex_symmetric);
 	status = silex_statuscodes_to_psa(cracen_kmu_prepare_key(key_buffer));
 	if (status == PSA_SUCCESS) {
 		memcpy(key_buffer, kmu_push_area, key_buffer_size);
 		safe_memzero(kmu_push_area, sizeof(kmu_push_area));
 	}
-	nrf_security_mutex_unlock(&cracen_mutex_symmetric);
+	nrf_security_mutex_unlock(cracen_mutex_symmetric);
 
 	return status;
 }

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/prng_pool.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/prng_pool.c
@@ -30,7 +30,7 @@ int cracen_prng_value_from_pool(uint32_t *prng_value)
 {
 	int status = SX_OK;
 
-	nrf_security_mutex_lock(&cracen_prng_pool_mutex);
+	nrf_security_mutex_lock(cracen_prng_pool_mutex);
 
 	if (prng_pool_remaining == 0) {
 		psa_status_t psa_status =
@@ -47,6 +47,6 @@ int cracen_prng_value_from_pool(uint32_t *prng_value)
 	prng_pool_remaining--;
 
 exit:
-	nrf_security_mutex_unlock(&cracen_prng_pool_mutex);
+	nrf_security_mutex_unlock(cracen_prng_pool_mutex);
 	return status;
 }

--- a/subsys/nrf_security/src/drivers/cracen/silexpk/target/baremetal_ba414e_with_ik/pk_baremetal.c
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/target/baremetal_ba414e_with_ik/pk_baremetal.c
@@ -183,7 +183,7 @@ struct sx_pk_acq_req sx_pk_acquire_req(const struct sx_pk_cmd_def *cmd)
 {
 	struct sx_pk_acq_req req = {NULL, SX_OK};
 
-	nrf_security_mutex_lock(&cracen_mutex_asymmetric);
+	nrf_security_mutex_lock(cracen_mutex_asymmetric);
 	req.req = &silex_pk_engine.instance;
 	req.req->cmd = cmd;
 	req.req->cnx = &silex_pk_engine;
@@ -220,7 +220,7 @@ void sx_pk_release_req(sx_pk_req *req)
 	cracen_release();
 	req->cmd = NULL;
 	req->userctxt = NULL;
-	nrf_security_mutex_unlock(&cracen_mutex_asymmetric);
+	nrf_security_mutex_unlock(cracen_mutex_asymmetric);
 }
 
 struct sx_regs *sx_pk_get_regs(void)

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/platform/baremetal/cmdma_hw.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/platform/baremetal/cmdma_hw.c
@@ -29,7 +29,7 @@ NRF_SECURITY_MUTEX_DEFINE(cracen_mutex_symmetric);
 void sx_hw_reserve(struct sx_dmactl *dma)
 {
 	cracen_acquire();
-	nrf_security_mutex_lock(&cracen_mutex_symmetric);
+	nrf_security_mutex_lock(cracen_mutex_symmetric);
 
 	if (dma) {
 		dma->hw_acquired = true;
@@ -48,7 +48,7 @@ void sx_cmdma_release_hw(struct sx_dmactl *dma)
 {
 	if (dma == NULL || dma->hw_acquired) {
 		cracen_release();
-		nrf_security_mutex_unlock(&cracen_mutex_symmetric);
+		nrf_security_mutex_unlock(cracen_mutex_symmetric);
 		if (dma) {
 			dma->hw_acquired = false;
 		}

--- a/subsys/nrf_security/src/threading/include/threading_alt.h
+++ b/subsys/nrf_security/src/threading/include/threading_alt.h
@@ -1,13 +1,14 @@
 /*
- * Copyright (c) 2023, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2024 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 #ifndef MBEDTLS_THREADING_ALT_H
 #define MBEDTLS_THREADING_ALT_H
 
-#include "mbedtls/build_info.h"
-#include "nrf_security_mutexes.h"
+#include <zephyr/kernel.h>
+
+typedef struct k_mutex mbedtls_threading_mutex_t;
 
 #endif /* MBEDTLS_THREADING_ALT_H */

--- a/subsys/nrf_security/src/threading/threading_alt.c
+++ b/subsys/nrf_security/src/threading/threading_alt.c
@@ -1,8 +1,7 @@
-
 /*
- * Copyright (c) 2023, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2024 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: BSD-3-Clause OR Arm’s non-OSI source license
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 #include "threading_alt.h"
@@ -11,62 +10,32 @@
 #include <string.h>
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
+#include <zephyr/sys/__assert.h>
 
-#include "nrf_security_mutexes.h"
+K_MUTEX_DEFINE(mbedtls_threading_key_slot_mutex);
+K_MUTEX_DEFINE(mbedtls_threading_psa_globaldata_mutex);
+K_MUTEX_DEFINE(mbedtls_threading_psa_rngdata_mutex);
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
-
-NRF_SECURITY_MUTEX_DEFINE(mbedtls_threading_key_slot_mutex);
-NRF_SECURITY_MUTEX_DEFINE(mbedtls_threading_psa_globaldata_mutex);
-NRF_SECURITY_MUTEX_DEFINE(mbedtls_threading_psa_rngdata_mutex);
-
-static void mbedtls_mutex_init_fn(mbedtls_threading_mutex_t * mutex)
+void mbedtls_mutex_init_fn(mbedtls_threading_mutex_t *mutex)
 {
-    if(!k_is_pre_kernel() && !k_is_in_isr()) {
-        nrf_security_mutex_init(mutex);
-    }
+	k_mutex_init(mutex);
 }
 
-static void mbedtls_mutex_free_fn(mbedtls_threading_mutex_t * mutex)
+void mbedtls_mutex_free_fn(mbedtls_threading_mutex_t *mutex)
 {
-    if(!k_is_pre_kernel() && !k_is_in_isr()) {
-        nrf_security_mutex_free(mutex);
-    }
 }
 
-static int mbedtls_mutex_lock_fn(mbedtls_threading_mutex_t * mutex)
+int mbedtls_mutex_lock_fn(mbedtls_threading_mutex_t *mutex)
 {
-    if(!k_is_pre_kernel() && !k_is_in_isr()) {
-        return nrf_security_mutex_lock(mutex);
-    } else {
-        return 0;
-    }
+	return k_mutex_lock(mutex, K_FOREVER);
 }
 
-static int mbedtls_mutex_unlock_fn(mbedtls_threading_mutex_t * mutex)
+int mbedtls_mutex_unlock_fn(mbedtls_threading_mutex_t *mutex)
 {
-    if(!k_is_pre_kernel() && !k_is_in_isr()) {
-        return nrf_security_mutex_unlock(mutex);
-    } else {
-        return 0;
-    }
+	return k_mutex_unlock(mutex);
 }
 
 void (*mbedtls_mutex_init)(mbedtls_threading_mutex_t *mutex) = mbedtls_mutex_init_fn;
 void (*mbedtls_mutex_free)(mbedtls_threading_mutex_t *mutex) = mbedtls_mutex_free_fn;
 int (*mbedtls_mutex_lock)(mbedtls_threading_mutex_t *mutex) = mbedtls_mutex_lock_fn;
 int (*mbedtls_mutex_unlock)(mbedtls_threading_mutex_t *mutex) = mbedtls_mutex_unlock_fn;
-
-static int post_kernel_init(void)
-{
-    mbedtls_mutex_init(&mbedtls_threading_key_slot_mutex);
-    mbedtls_mutex_init(&mbedtls_threading_psa_globaldata_mutex);
-    mbedtls_mutex_init(&mbedtls_threading_psa_rngdata_mutex);
-    return 0;
-}
-
-SYS_INIT(post_kernel_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/subsys/nrf_security/src/utils/nrf_security_mutexes.c
+++ b/subsys/nrf_security/src/utils/nrf_security_mutexes.c
@@ -11,63 +11,35 @@
 #include <stdbool.h>
 #include "nrf_security_mutexes.h"
 
-#if !defined(__NRF_TFM__)
+#ifdef NRF_SECURITY_MUTEX_IMPLEMENTATION
 #include <zephyr/kernel.h>
 #endif
 
-#if defined(CONFIG_MULTITHREADING) && !defined(__NRF_TFM__)
-
-void nrf_security_mutex_init(mbedtls_threading_mutex_t * mutex)
+#ifdef NRF_SECURITY_MUTEX_IMPLEMENTATION
+int nrf_security_mutex_lock(nrf_security_mutex_t mutex)
 {
-	if ((mutex->flags & NRF_SECURITY_MUTEX_FLAGS_INITIALIZED) == 0) {
-		k_mutex_init(&mutex->mutex);
-	}
+	int ret = k_mutex_lock(mutex, K_FOREVER);
 
-	mutex->flags |= NRF_SECURITY_MUTEX_FLAGS_INITIALIZED;
+	__ASSERT_NO_MSG(ret == 0);
+	return ret;
 }
 
-void nrf_security_mutex_free(mbedtls_threading_mutex_t * mutex)
+int nrf_security_mutex_unlock(nrf_security_mutex_t mutex)
 {
-	(void)mutex;
-}
+	int ret = k_mutex_unlock(mutex);
 
-int nrf_security_mutex_lock(mbedtls_threading_mutex_t * mutex)
-{
-	if ((mutex->flags & NRF_SECURITY_MUTEX_FLAGS_INITIALIZED) != 0) {
-		return k_mutex_lock(&mutex->mutex, K_FOREVER);
-	} else {
-		return -EINVAL;
-	}
-}
-
-int nrf_security_mutex_unlock(mbedtls_threading_mutex_t * mutex)
-{
-	if ((mutex->flags & NRF_SECURITY_MUTEX_FLAGS_INITIALIZED) != 0) {
-		return k_mutex_unlock(&mutex->mutex);
-	} else {
-		return -EINVAL;
-	}
+	__ASSERT_NO_MSG(ret == 0);
+	return ret;
 }
 
 #else
-
-void nrf_security_mutex_init(mbedtls_threading_mutex_t * mutex)
-{
-	(void)mutex;
-}
-
-void nrf_security_mutex_free(mbedtls_threading_mutex_t * mutex)
-{
-	(void)mutex;
-}
-
-int nrf_security_mutex_lock(mbedtls_threading_mutex_t * mutex)
+int nrf_security_mutex_lock(nrf_security_mutex_t mutex)
 {
 	(void)mutex;
 	return 0;
 }
 
-int nrf_security_mutex_unlock(mbedtls_threading_mutex_t * mutex)
+int nrf_security_mutex_unlock(nrf_security_mutex_t mutex)
 {
 	(void)mutex;
 	return 0;

--- a/subsys/nrf_security/src/utils/nrf_security_mutexes.h
+++ b/subsys/nrf_security/src/utils/nrf_security_mutexes.h
@@ -12,46 +12,28 @@
  * One is backed by Zephyr events APIs (k_mutex_*), and other assumes
  * there are no threads thus it always returns success without doing anything.
  */
+
 #ifndef NRF_SECURITY_MUTEXES_H
 #define NRF_SECURITY_MUTEXES_H
 
 #include <stdint.h>
 
 #if defined(CONFIG_MULTITHREADING) && !defined(__NRF_TFM__)
-
-#include <zephyr/kernel.h>
-
-typedef enum {
-	NRF_SECURITY_MUTEX_FLAGS_NONE = 0,
-	NRF_SECURITY_MUTEX_FLAGS_INITIALIZED = 1 << 0,
-} NRF_SECURITY_MUTEX_FLAGS;
-
-typedef struct { 
-	uint32_t 	flags;
-	struct k_mutex 	mutex; 
-} mbedtls_threading_mutex_t;
-
-#define NRF_SECURITY_MUTEX_DEFINE(mutex_name) mbedtls_threading_mutex_t mutex_name = {0}
-#else
-/* The uint32_t here is just a placeholder, this mutex type is not used */
-typedef uint32_t mbedtls_threading_mutex_t;
-#define NRF_SECURITY_MUTEX_DEFINE(mutex_name) mbedtls_threading_mutex_t mutex_name;
-
+#define NRF_SECURITY_MUTEX_IMPLEMENTATION
 #endif
 
-/**
- * @brief Initialize a mutex.
- *
- * @param[in] mutex The mutex to initialized.
- */
-void nrf_security_mutex_init(mbedtls_threading_mutex_t * mutex);
+#ifdef NRF_SECURITY_MUTEX_IMPLEMENTATION
+typedef struct k_mutex *nrf_security_mutex_t;
+#define NRF_SECURITY_MUTEX_DEFINE(mutex_name)                                                      \
+	K_MUTEX_DEFINE(k_##mutex_name);                                                            \
+	nrf_security_mutex_t mutex_name = &k_##mutex_name;
 
-/**
- * @brief Free a mutex.
- *
- * @param[in] mutex The mutex to free.
- */
-void nrf_security_mutex_free(mbedtls_threading_mutex_t * mutex);
+#else
+/* The uint8_t here is just a placeholder, this mutex type is not used */
+typedef uint8_t nrf_security_mutex_t;
+#define NRF_SECURITY_MUTEX_DEFINE(mutex_name) nrf_security_mutex_t mutex_name;
+
+#endif
 
 /**
  * @brief Lock a mutex.
@@ -61,7 +43,7 @@ void nrf_security_mutex_free(mbedtls_threading_mutex_t * mutex);
  * @return Returns 0 if the mutex was successfully locked; otherwise, it returns
  *         an error code from the k_mutex_lock() function.
  */
-int nrf_security_mutex_lock(mbedtls_threading_mutex_t * mutex);
+int nrf_security_mutex_lock(nrf_security_mutex_t mutex);
 
 /**
  * @brief Unlock a mutex.
@@ -71,6 +53,6 @@ int nrf_security_mutex_lock(mbedtls_threading_mutex_t * mutex);
  * @return Returns 0 if the mutex was successfully unlocked; otherwise, it returns
  *         an error code from the k_mutex_unlock() function.
  */
-int nrf_security_mutex_unlock(mbedtls_threading_mutex_t * mutex);
+int nrf_security_mutex_unlock(nrf_security_mutex_t mutex);
 
 #endif /* NRF_SECURITY_MUTEXES_H */


### PR DESCRIPTION
Backport 16654ce2e3379185df257f02c5bf525f886b14b1 from #18366.