### PR TITLE
Bluetooth: controller: default `BT_LL_SW_SPLIT` on BabbleSim

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -6,7 +6,7 @@
 
 choice BT_LL_CHOICE
 	prompt "Bluetooth Link Layer Selection"
-	default BT_LL_SOFTDEVICE
+	default BT_LL_SOFTDEVICE if !SOC_SERIES_BSIM_NRFXX
 
 config BT_LL_SOFTDEVICE
 	bool "SoftDevice Link Layer"


### PR DESCRIPTION
As BabbleSim is not supported externally, as documented by `BT_CTLR_SDC_BSIM_BUILD`, do not attempt to use it by default on BabbleSim boards.

This change leaves open the option for internal Nordic developers to set `CONFIG_BT_LL_SOFTDEVICE=y` for BabbleSim testing.

The lack of external support is also confirmed through this [DevZone post](https://devzone.nordicsemi.com/f/nordic-q-a/105782/using-babblesim-with-softdevice-controller).