### PR TITLE
[Backport v2.8-branch] net: Ensure MQTT message ID is non-zero

### DIFF
--- a/include/net/mqtt_helper.h
+++ b/include/net/mqtt_helper.h
@@ -131,6 +131,15 @@ int mqtt_helper_subscribe(struct mqtt_subscription_list *sub_list);
  */
 int mqtt_helper_publish(const struct mqtt_publish_param *param);
 
+/** @brief Get a message ID.
+ *
+ *  @note Will not return 0 as it is reserved for invalid message IDs, see MQTT specification.
+ *	  Returned values increment by one for each call.
+ *
+ *  @return Message ID, positive non-zero value.
+ */
+uint16_t mqtt_helper_msg_id_get(void);
+
 /** @brief Deinitialize library. Must be called when all MQTT operations are done to
  *	   release resources and allow for a new client. The client must be in a disconnected state.
  *

--- a/samples/net/mqtt/src/modules/transport/transport.c
+++ b/samples/net/mqtt/src/modules/transport/transport.c
@@ -132,7 +132,7 @@ static void publish(struct payload *payload)
 		.message.payload.data = payload->string,
 		.message.payload.len = strlen(payload->string),
 		.message.topic.qos = MQTT_QOS_1_AT_LEAST_ONCE,
-		.message_id = k_uptime_get_32(),
+		.message_id = mqtt_helper_msg_id_get(),
 		.message.topic.topic.utf8 = pub_topic,
 		.message.topic.topic.size = strlen(pub_topic),
 	};

--- a/subsys/net/lib/aws_iot/src/aws_iot.c
+++ b/subsys/net/lib/aws_iot/src/aws_iot.c
@@ -627,7 +627,8 @@ int aws_iot_send(const struct aws_iot_data *const tx_data)
 	}
 
 	/* Assign a random message ID if the ID has not been provided by the application. */
-	param.message_id = (tx_data->message_id == 0) ? k_cycle_get_32() : tx_data->message_id;
+	param.message_id = (tx_data->message_id == 0) ? mqtt_helper_msg_id_get() :
+							tx_data->message_id;
 
 	LOG_DBG("Using message ID %d", param.message_id);
 	LOG_DBG("Publishing to topic: %s", (char *)param.message.topic.topic.utf8);

--- a/subsys/net/lib/aws_jobs/src/aws_jobs.c
+++ b/subsys/net/lib/aws_jobs/src/aws_jobs.c
@@ -214,6 +214,7 @@ static int publish(struct mqtt_client *const client, const uint8_t *job_id,
 		   size_t payload_data_len, uint8_t *topic_buf)
 {
 	struct mqtt_topic topic;
+	uint32_t msg_id = k_cycle_get_32();
 
 	int ret = construct_topic(client->client_id.utf8, job_id, conf,
 				  topic_buf, &topic, true);
@@ -229,7 +230,7 @@ static int publish(struct mqtt_client *const client, const uint8_t *job_id,
 		.message.topic = topic,
 		.message.payload.data = payload_data,
 		.message.payload.len = payload_data_len,
-		.message_id = k_cycle_get_32(),
+		.message_id = (uint16_t)msg_id ? msg_id : 1,
 		.dup_flag = 0,
 		.retain_flag = 0,
 	};

--- a/subsys/net/lib/azure_iot_hub/src/azure_iot_hub.c
+++ b/subsys/net/lib/azure_iot_hub/src/azure_iot_hub.c
@@ -185,7 +185,7 @@ static int topic_subscribe(void)
 	struct mqtt_subscription_list sub_list = {
 		.list = sub_topics,
 		.list_count = ARRAY_SIZE(sub_topics),
-		.message_id = k_uptime_get_32(),
+		.message_id = mqtt_helper_msg_id_get(),
 	};
 
 	err = mqtt_helper_subscribe(&sub_list);
@@ -932,7 +932,7 @@ int azure_iot_hub_send(const struct azure_iot_hub_msg *const msg)
 		.message.payload.data = msg->payload.ptr,
 		.message.payload.len = msg->payload.size,
 		.message.topic.qos = msg->qos,
-		.message_id = msg->message_id,
+		.message_id = (msg->message_id == 0) ? mqtt_helper_msg_id_get() : msg->message_id,
 		.dup_flag = msg->dup_flag,
 		.retain_flag = msg->retain_flag,
 	};

--- a/subsys/net/lib/azure_iot_hub/src/azure_iot_hub_dps.c
+++ b/subsys/net/lib/azure_iot_hub/src/azure_iot_hub_dps.c
@@ -394,7 +394,7 @@ static void reg_status_request_send(void)
 		.message.payload.data = NULL,
 		.message.payload.len = 0,
 		.message.topic.qos = MQTT_QOS_1_AT_LEAST_ONCE,
-		.message_id = k_uptime_get_32(),
+		.message_id = mqtt_helper_msg_id_get(),
 	};
 	char topic[CONFIG_AZURE_IOT_HUB_DPS_TOPIC_BUFFER_SIZE];
 	size_t topic_len;
@@ -603,7 +603,7 @@ static int topic_subscribe(void)
 	struct mqtt_subscription_list sub_list = {
 		.list = &dps_sub_topic,
 		.list_count = 1,
-		.message_id = k_uptime_get_32(),
+		.message_id = mqtt_helper_msg_id_get(),
 	};
 
 	for (size_t i = 0; i < sub_list.list_count; i++) {
@@ -626,7 +626,7 @@ static int dps_send_reg_request(void)
 {
 	struct mqtt_publish_param param = {
 		.message.topic.qos = MQTT_QOS_1_AT_LEAST_ONCE,
-		.message_id = k_uptime_get_32(),
+		.message_id = mqtt_helper_msg_id_get(),
 	};
 	char topic_buf[CONFIG_AZURE_IOT_HUB_DPS_TOPIC_BUFFER_SIZE];
 	size_t topic_len = sizeof(topic_buf);

--- a/subsys/net/lib/mqtt_helper/mqtt_helper.c
+++ b/subsys/net/lib/mqtt_helper/mqtt_helper.c
@@ -649,6 +649,11 @@ int mqtt_helper_subscribe(struct mqtt_subscription_list *sub_list)
 
 	__ASSERT_NO_MSG(sub_list != NULL);
 
+	if (sub_list->message_id == 0) {
+		LOG_ERR("Invalid message ID");
+		return -EINVAL;
+	}
+
 	if (!mqtt_state_verify(MQTT_STATE_CONNECTED)) {
 		LOG_ERR("Library is in the wrong state (%s), %s required",
 			state_name_get(mqtt_state_get()),
@@ -675,6 +680,11 @@ int mqtt_helper_publish(const struct mqtt_publish_param *param)
 		param->message.topic.topic.size,
 		(char *)param->message.topic.topic.utf8);
 
+	if (param->message_id == 0) {
+		LOG_ERR("Invalid message ID");
+		return -EINVAL;
+	}
+
 	if (!mqtt_state_verify(MQTT_STATE_CONNECTED)) {
 		LOG_ERR("Library is in the wrong state (%s), %s required",
 			state_name_get(mqtt_state_get()),
@@ -684,6 +694,19 @@ int mqtt_helper_publish(const struct mqtt_publish_param *param)
 	}
 
 	return mqtt_publish(&mqtt_client, param);
+}
+
+uint16_t mqtt_helper_msg_id_get(void)
+{
+	static uint16_t id;
+
+	id++;
+
+	if (id == 0) {
+		id++;
+	}
+
+	return id;
 }
 
 int mqtt_helper_deinit(void)

--- a/tests/subsys/net/lib/aws_iot/src/aws_iot_test.c
+++ b/tests/subsys/net/lib/aws_iot/src/aws_iot_test.c
@@ -160,6 +160,7 @@ void test_connect_should_use_static_connection_parameters(void)
 
 	__cmock_mqtt_helper_connect_Stub(&mqtt_helper_connect_stub);
 	__cmock_mqtt_helper_publish_ExpectAnyArgsAndReturn(0);
+	__cmock_mqtt_helper_msg_id_get_ExpectAndReturn(1);
 
 	test_mqtt_helper_cfg.cb.on_connack(MQTT_RESULT_SUCCESS, MQTT_SESSION_VALID);
 
@@ -181,6 +182,7 @@ void test_connect_should_use_run_time_parameters(void)
 
 	__cmock_mqtt_helper_connect_Stub(&mqtt_helper_connect_stub);
 	__cmock_mqtt_helper_publish_ExpectAnyArgsAndReturn(0);
+	__cmock_mqtt_helper_msg_id_get_ExpectAndReturn(1);
 
 	test_mqtt_helper_cfg.cb.on_connack(MQTT_RESULT_SUCCESS, MQTT_SESSION_VALID);
 
@@ -201,6 +203,7 @@ void test_connect_should_return_success(void)
 
 	__cmock_mqtt_helper_connect_ExpectAnyArgsAndReturn(0);
 	__cmock_mqtt_helper_publish_ExpectAnyArgsAndReturn(0);
+	__cmock_mqtt_helper_msg_id_get_ExpectAndReturn(1);
 
 	test_mqtt_helper_cfg.cb.on_connack(MQTT_RESULT_SUCCESS, MQTT_SESSION_VALID);
 
@@ -332,6 +335,7 @@ void test_on_connack_should_notify_connected_without_subscribing(void)
 	mqtt_helper_handlers_register(event_handler);
 
 	__cmock_mqtt_helper_publish_ExpectAnyArgsAndReturn(0);
+	__cmock_mqtt_helper_msg_id_get_ExpectAndReturn(1);
 
 	event_type_expected = AWS_IOT_EVT_CONNECTED;
 
@@ -395,6 +399,7 @@ void test_on_suback_should_notify_connected_on_acked_subscription_lists(void)
 	test_on_connack_should_notify_connected_with_subscribing();
 
 	__cmock_mqtt_helper_publish_ExpectAnyArgsAndReturn(0);
+	__cmock_mqtt_helper_msg_id_get_ExpectAndReturn(1);
 
 	event_type_expected = AWS_IOT_EVT_CONNECTED;
 

--- a/tests/subsys/net/lib/azure_iot_hub/dps/src/azure_iot_hub_dps_test.c
+++ b/tests/subsys/net/lib/azure_iot_hub/dps/src/azure_iot_hub_dps_test.c
@@ -426,6 +426,7 @@ void test_on_publish_assigning(void)
 	__cmock_mqtt_helper_init_ExpectAnyArgsAndReturn(0);
 	__cmock_mqtt_helper_connect_Stub(mqtt_helper_connect_stub_defaults);
 	__cmock_mqtt_helper_publish_ExpectAnyArgsAndReturn(0);
+	__cmock_mqtt_helper_msg_id_get_ExpectAndReturn(1);
 
 	err = azure_iot_hub_dps_init(&config);
 	TEST_ASSERT_EQUAL(0, err);

--- a/tests/subsys/net/lib/azure_iot_hub/iot_hub/src/azure_iot_hub_test.c
+++ b/tests/subsys/net/lib/azure_iot_hub/iot_hub/src/azure_iot_hub_test.c
@@ -341,6 +341,7 @@ void test_azure_iot_hub_send(void)
 	};
 
 	__cmock_mqtt_helper_publish_Stub(mqtt_helper_publish_stub);
+	__cmock_mqtt_helper_msg_id_get_ExpectAndReturn(1);
 
 	iot_hub_state = STATE_CONNECTED;
 
@@ -370,6 +371,7 @@ void test_azure_iot_hub_send_1_property(void)
 	};
 
 	__cmock_mqtt_helper_publish_Stub(mqtt_helper_publish_1_prop_stub);
+	__cmock_mqtt_helper_msg_id_get_ExpectAndReturn(1);
 
 	iot_hub_state = STATE_CONNECTED;
 
@@ -412,6 +414,7 @@ void test_azure_iot_hub_send_2_properties(void)
 	};
 
 	__cmock_mqtt_helper_publish_Stub(mqtt_helper_publish_2_props_stub);
+	__cmock_mqtt_helper_msg_id_get_ExpectAndReturn(1);
 
 	iot_hub_state = STATE_CONNECTED;
 
@@ -493,6 +496,8 @@ void test_azure_iot_hub_send_too_long_topic(void)
 		.topic.property_count = ARRAY_SIZE(properties),
 	};
 
+	__cmock_mqtt_helper_msg_id_get_ExpectAndReturn(1);
+
 	iot_hub_state = STATE_CONNECTED;
 
 	TEST_ASSERT_EQUAL(-EMSGSIZE, azure_iot_hub_send(&msg));
@@ -509,6 +514,7 @@ void test_azure_iot_hub_send_twin_get_request(void)
 	};
 
 	__cmock_mqtt_helper_publish_Stub(mqtt_helper_publish_twin_request_stub);
+	__cmock_mqtt_helper_msg_id_get_ExpectAndReturn(1);
 
 	iot_hub_state = STATE_CONNECTED;
 
@@ -530,6 +536,7 @@ void test_azure_iot_hub_send_twin_update_reported(void)
 	};
 
 	__cmock_mqtt_helper_publish_Stub(mqtt_helper_publish_twin_update_reported_stub);
+	__cmock_mqtt_helper_msg_id_get_ExpectAndReturn(1);
 
 	iot_hub_state = STATE_CONNECTED;
 
@@ -541,6 +548,8 @@ void test_azure_iot_hub_send_invalid_topic_type(void)
 	struct azure_iot_hub_msg msg = {
 		.topic.type = AZURE_IOT_HUB_TOPIC_UNKNOWN + 10,
 	};
+
+	__cmock_mqtt_helper_msg_id_get_ExpectAndReturn(1);
 
 	iot_hub_state = STATE_CONNECTED;
 
@@ -560,6 +569,9 @@ void test_azure_iot_hub_send_not_connected(void)
 			.size = TEST_REQUEST_ID_LEN,
 		},
 	};
+
+
+	__cmock_mqtt_helper_msg_id_get_ExpectAndReturn(1);
 
 	TEST_ASSERT_EQUAL(-ENOTCONN, azure_iot_hub_send(&msg));
 }


### PR DESCRIPTION
Backport a732d97c7277d0545f72e7431f6ad9c0e6837304 from #18349.