### PR TITLE
nrf_security: Mbedlts threading dependency fix

### DIFF
--- a/subsys/nrf_security/Kconfig.legacy
+++ b/subsys/nrf_security/Kconfig.legacy
@@ -23,6 +23,7 @@ config MBEDTLS_MEMORY_BUFFER_ALLOC_C
 config MBEDTLS_THREADING_C
 	bool "Threading support for Mbed TLS and PSA crypto"
 	default y if CC3XX_BACKEND || MBEDTLS_PSA_CRYPTO_C
+	depends on MULTITHREADING
 	help
 	  Threading support is used when PSA crypto is built locally or
 	  when legacy APIs implemented using CryptoCell is in use.


### PR DESCRIPTION
    Make the MbedTLS threading configuration to depend on
    the multithreading Kconfig option. The multithreading
    configuration is required by both the PSA crypto
    implementation which uses the Zephyr mutexes and
    also by the MbedTLS legacy implementation which
    may not use Zephyr mutexes for CC3XX.