### PR TITLE
doc: nrf: add parents=True to doxyrunner

### DIFF
--- a/doc/nrf/conf.py
+++ b/doc/nrf/conf.py
@@ -134,7 +134,7 @@ doxyrunner_fmt_vars = {
 }
 
 # create mbedtls config header (needed for Doxygen)
-doxyrunner_outdir.mkdir(exist_ok=True)
+doxyrunner_outdir.mkdir(exist_ok=True, parents=True)
 
 fin_path = NRF_BASE / "subsys" / "nrf_security" / "configs" / "legacy_crypto_config.h.template"
 fout_path = doxyrunner_outdir / "mbedtls_doxygen_config.h"


### PR DESCRIPTION
When building for linkcheck target, the build dir does not follow the same layout as in HTML dir, so some directories are not pre-created. This should likely be fixed better, but this workaround lets us run the target for now.