### PR TITLE
samples: bluetooth: mesh: dfu: distributor: Fix RTT support

### DIFF
--- a/samples/bluetooth/mesh/dfu/distributor/prj.conf
+++ b/samples/bluetooth/mesh/dfu/distributor/prj.conf
@@ -103,3 +103,7 @@ CONFIG_SEGGER_RTT_BUFFER_SIZE_DOWN=100
 # MCUmgr UART transport
 CONFIG_BASE64=y
 CONFIG_MCUMGR_TRANSPORT_UART=y
+
+# This option may not be enabled automatically for some boards. Enabling it explicitly to avoid
+# missing configuration.
+CONFIG_USE_SEGGER_RTT=y

--- a/samples/bluetooth/mesh/dfu/distributor/sysbuild/mcuboot.conf
+++ b/samples/bluetooth/mesh/dfu/distributor/sysbuild/mcuboot.conf
@@ -1,0 +1,4 @@
+# RTT is used for interacting with the distributor over shell. Having it enabled in mcuboot will
+# require a user to manually provide correct _SEGGER_RTT address otherwise RTT Viewer will pick
+# wrong buffer and shell will not work.
+CONFIG_USE_SEGGER_RTT=n


### PR DESCRIPTION
This PR fixes 2 issues:
- explicitly disables RTT support in mcuboot which made JLink RTT Viewer select wrong RTT Control Block;
- explicitly enables RTT support in the sample as it turned out to not be enabled by default and is not enabled through any other Kconfig option on nRF54L15;