### PR TITLE
[Backport v2.8-branch] doc: nrf_security: fix doc for cracen driver

### DIFF
--- a/doc/nrf/libraries/security/nrf_security/doc/driver_config.rst
+++ b/doc/nrf/libraries/security/nrf_security/doc/driver_config.rst
@@ -23,9 +23,9 @@ To enable a PSA driver, set the configurations in the following table:
 +===============+==================================================+=====================================================+
 | nrf_cc3xx     | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_CC3XX` | Only on nRF52840, nRF91 Series, and nRF5340 devices |
 +---------------+--------------------------------------------------+-----------------------------------------------------+
-| nrf_oberon    | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_OBERON`|                                                     |
-+---------------+--------------------------------------------------+-----------------------------------------------------+
 | nrf_cracen    | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_CRACEN`| Only on nRF54L Series devices                       |
++---------------+--------------------------------------------------+-----------------------------------------------------+
+| nrf_oberon    | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_OBERON`|                                                     |
 +---------------+--------------------------------------------------+-----------------------------------------------------+
 
 If multiple drivers are enabled, the first ordered item in this table takes precedence for an enabled cryptographic feature, unless the driver does not enable or support it.
@@ -106,7 +106,9 @@ The following table shows key type support for each driver:
 | DH Public Key         | Not supported             | Not supported              | Not supported             |
 +-----------------------+---------------------------+----------------------------+---------------------------+
 
-The option :kconfig:option:`CONFIG_PSA_USE_CC3XX_KEY_MANAGEMENT_DRIVER` enables the :ref:`nrf_security_drivers_cc3xx` for all supported key types.
+The Kconfig option :kconfig:option:`CONFIG_PSA_USE_CC3XX_KEY_MANAGEMENT_DRIVER` enables the :ref:`nrf_security_drivers_cc3xx` for all supported key types.
+
+The Kconfig option :kconfig:option:`CONFIG_PSA_USE_CRACEN_KEY_MANAGEMENT_DRIVER` enables the :ref:`nrf_security_drivers_cracen` for all supported key types.
 
 Cipher configurations
 *********************
@@ -154,9 +156,11 @@ The following table shows cipher algorithm support for each driver:
 | Stream cipher         | Supported                 | Supported                  | Supported                 |
 +-----------------------+---------------------------+----------------------------+---------------------------+
 
-The option :kconfig:option:`CONFIG_PSA_USE_CC3XX_CIPHER_DRIVER` enables the :ref:`nrf_security_drivers_cc3xx` for all supported algorithms.
+The Kconfig option :kconfig:option:`CONFIG_PSA_USE_CC3XX_CIPHER_DRIVER` enables the :ref:`nrf_security_drivers_cc3xx` for all supported algorithms.
 
 The configuration of the :ref:`nrf_security_drivers_oberon` is automatically generated based on the user-enabled algorithms in `Cipher configurations`_.
+
+The Kconfig option :kconfig:option:`CONFIG_PSA_USE_CRACEN_CIPHER_DRIVER` enables the :ref:`nrf_security_drivers_cracen` for all supported algorithms.
 
 Key size configuration is supported as described in `AES key size configuration`_, for all algorithms except the stream cipher.
 
@@ -189,7 +193,9 @@ The following table shows Key agreement support for each driver:
 | FFDH                    | Not supported             | Not supported              | Not supported             |
 +-------------------------+---------------------------+----------------------------+---------------------------+
 
-The option :kconfig:option:`CONFIG_PSA_USE_CC3XX_KEY_AGREEMENT_DRIVER` enables the :ref:`nrf_security_drivers_cc3xx` for all supported algorithms.
+The Kconfig option :kconfig:option:`CONFIG_PSA_USE_CC3XX_KEY_AGREEMENT_DRIVER` enables the :ref:`nrf_security_drivers_cc3xx` for all supported algorithms.
+
+The Kconfig option :kconfig:option:`CONFIG_PSA_USE_CRACEN_KEY_AGREEMENT_DRIVER` enables the :ref:`nrf_security_drivers_cracen` for all supported algorithms.
 
 The algorithm support when using ECC key types is dependent on one or more Kconfig options enabling curve support according to `ECC curve configurations`_.
 
@@ -253,6 +259,8 @@ The following table shows key derivation function (KDF) support for each driver:
 
 The configuration of the :ref:`nrf_security_drivers_oberon` is automatically generated based on the user-enabled algorithms in `Key derivation function configurations`_.
 
+The Kconfig option :kconfig:option:`CONFIG_PSA_USE_CRACEN_KEY_DERIVATION_DRIVER` enables the :ref:`nrf_security_drivers_cracen` for all supported algorithms.
+
 MAC configurations
 ******************
 
@@ -283,9 +291,11 @@ The following table shows MAC algorithm support for each driver:
 | CBC-MAC        | Not supported            | Not supported              | Not  Supported            |
 +----------------+--------------------------+----------------------------+---------------------------+
 
-The option :kconfig:option:`CONFIG_PSA_USE_CC3XX_MAC_DRIVER` enables the :ref:`nrf_security_drivers_cc3xx` for all supported algorithms.
+The Kconfig option :kconfig:option:`CONFIG_PSA_USE_CC3XX_MAC_DRIVER` enables the :ref:`nrf_security_drivers_cc3xx` for all supported algorithms.
 
 The configuration of the :ref:`nrf_security_drivers_oberon` is automatically generated based on the user-enabled algorithms in `MAC configurations`_.
+
+The Kconfig option :kconfig:option:`CONFIG_PSA_USE_CRACEN_MAC_DRIVER` enables the :ref:`nrf_security_drivers_cracen` for all supported algorithms.
 
 Key size configuration for CMAC is supported as described in `AES key size configuration`_.
 
@@ -323,9 +333,11 @@ The following table shows AEAD algorithm support for each driver:
 | ChaCha20-Poly1305     | Supported                 | Supported                 | Supported                 |
 +-----------------------+---------------------------+---------------------------+---------------------------+
 
-The option :kconfig:option:`CONFIG_PSA_USE_CC3XX_AEAD_DRIVER` enables the :ref:`nrf_security_drivers_cc3xx` for all supported algorithms.
+The Kconfig option :kconfig:option:`CONFIG_PSA_USE_CC3XX_AEAD_DRIVER` enables the :ref:`nrf_security_drivers_cc3xx` for all supported algorithms.
 
 Configuration of the :ref:`nrf_security_drivers_oberon` is automatically generated based on the user-enabled algorithms in `AEAD configurations`_.
+
+The Kconfig option :kconfig:option:`CONFIG_PSA_USE_CRACEN_AEAD_DRIVER` enables the :ref:`nrf_security_drivers_cracen` for all supported algorithms.
 
 Key size configuration for CCM and GCM is supported as described in `AES key size configuration`_.
 
@@ -392,9 +404,11 @@ The following table shows asymmetric signature algorithm support for each driver
 | RSA PSS any salt                | Not supported             | Supported                  | Not Supported             |
 +---------------------------------+---------------------------+----------------------------+---------------------------+
 
-The option :kconfig:option:`CONFIG_PSA_USE_CC3XX_ASYMMETRIC_SIGNATURE_DRIVER` enables the driver :ref:`nrf_security_drivers_cc3xx` for all supported algorithms.
+The Kconfig option :kconfig:option:`CONFIG_PSA_USE_CC3XX_ASYMMETRIC_SIGNATURE_DRIVER` enables the driver :ref:`nrf_security_drivers_cc3xx` for all supported algorithms.
 
 Configuration of the :ref:`nrf_security_drivers_oberon` driver is automatically generated based on the user-enabled algorithms in `Asymmetric signature configurations`_.
+
+The Kconfig option :kconfig:option:`CONFIG_PSA_USE_CRACEN_ASYMMETRIC_SIGNATURE_DRIVER` enables the driver :ref:`nrf_security_drivers_cracen` for all supported algorithms.
 
 The algorithm support when using ECC key types is dependent on one or more Kconfig options enabling curve support according to `ECC curve configurations`_.
 
@@ -432,9 +446,11 @@ The following table shows asymmetric encryption algorithm support for each drive
 | RSA PKCS#1 v1.5 crypt           | Supported                 | Supported                  | Supported                 |
 +---------------------------------+---------------------------+----------------------------+---------------------------+
 
-The option :kconfig:option:`CONFIG_PSA_USE_CC3XX_ASYMMETRIC_ENCRYPTION_DRIVER` enables the :ref:`nrf_security_drivers_cc3xx` for all supported algorithms.
+The Kconfig option :kconfig:option:`CONFIG_PSA_USE_CC3XX_ASYMMETRIC_ENCRYPTION_DRIVER` enables the :ref:`nrf_security_drivers_cc3xx` for all supported algorithms.
 
 Configuration of the :ref:`nrf_security_drivers_oberon` is automatically generated based on the user-enabled algorithms in `Asymmetric encryption configurations`_.
+
+The Kconfig option :kconfig:option:`CONFIG_PSA_USE_CRACEN_ASYMMETRIC_DRIVER` enables the :ref:`nrf_security_drivers_cracen` for all supported algorithms.
 
 RSA key size configuration is supported as described in `RSA key size configuration`_.
 
@@ -592,7 +608,9 @@ The following table shows ECC curve support for each driver:
 | FRP256v1                 | Not supported             | Not supported              | Not supported             |
 +--------------------------+---------------------------+----------------------------+---------------------------+
 
-The option :kconfig:option:`CONFIG_PSA_USE_CC3XX_KEY_MANAGEMENT_DRIVER` enables the :ref:`nrf_security_drivers_cc3xx` for key management using ECC curves.
+The Kconfig option :kconfig:option:`CONFIG_PSA_USE_CC3XX_KEY_MANAGEMENT_DRIVER` enables the :ref:`nrf_security_drivers_cc3xx` for key management using ECC curves.
+
+The Kconfig option :kconfig:option:`CONFIG_PSA_USE_CRACEN_KEY_MANAGEMENT_DRIVER` enables the :ref:`nrf_security_drivers_cracen` for key management using ECC curves.
 
 RNG configurations
 ******************
@@ -618,14 +636,15 @@ When RNG is enabled, set at least one of the configurations in the following tab
 RNG support
 ===========
 
-There are no public configurations for entropy and PRNG algorithm support and the choice of drivers that provide support is automatic.
-
-The PSA drivers using the Arm CryptoCell peripheral is enabled by default for nRF52840, nRF91 Series, and nRF5340 devices.
-
-For devices without a hardware-accelerated cryptographic engine, entropy is provided by the nRF RNG peripheral. PRNG support is provided by the Oberon PSA driver, which is implemented using software.
+The PSA drivers using the Arm CryptoCell peripheral are enabled by default for nRF52840, nRF91 Series, and nRF5340 devices.
 
 .. note::
    When using CryptoCell, only 1024 bytes can be requested at a time.
+
+For devices without a hardware-accelerated cryptographic engine, entropy is provided by the nRF RNG peripheral.
+PRNG support is provided by the Oberon PSA driver, which is implemented using software.
+
+The Kconfig option :kconfig:option:`CONFIG_PSA_USE_CRACEN_CTR_DRBG_DRIVER` enables the :ref:`nrf_security_drivers_cracen` for the CTR-DRBG algorithm.
 
 Hash configurations
 *******************
@@ -717,9 +736,11 @@ The following table shows hash algorithm support for each driver:
 | RIPEMD160             | Not supported              | Not supported             | Not supported             |
 +-----------------------+----------------------------+---------------------------+---------------------------+
 
-The option :kconfig:option:`CONFIG_PSA_USE_CC3XX_HASH_DRIVER` enables the :ref:`nrf_security_drivers_cc3xx` for all supported algorithms.
+The Kconfig option :kconfig:option:`CONFIG_PSA_USE_CC3XX_HASH_DRIVER` enables the :ref:`nrf_security_drivers_cc3xx` for all supported algorithms.
 
 The configuration of the :ref:`nrf_security_drivers_oberon` is automatically generated based on the user-enabled algorithms in `Hash configurations`_.
+
+The Kconfig option :kconfig:option:`CONFIG_PSA_USE_CRACEN_HASH_DRIVER` enables the :ref:`nrf_security_drivers_cracen` for all supported algorithms.
 
 Password-authenticated key exchange configurations
 **************************************************
@@ -761,6 +782,8 @@ The following table shows PAKE algorithm support for each driver:
 +-----------------------+--------------------------+---------------------------+---------------------------+
 
 Configuration of the :ref:`nrf_security_drivers_oberon` is automatically generated based on the user-enabled algorithms in  `Password-authenticated key exchange configurations`_.
+
+The Kconfig option :kconfig:option:`CONFIG_PSA_USE_CRACEN_PAKE_DRIVER` enables the :ref:`nrf_security_drivers_cracen` for all supported algorithms.
 
 Key size configurations
 ***********************


### PR DESCRIPTION
Backport 829e4faee5bf7697bed67672a5491aea927a98d0 from #18464.