### PR TITLE
[Backport v2.8-branch] nrf_compress: Lower default chunk size

### DIFF
--- a/subsys/nrf_compress/Kconfig
+++ b/subsys/nrf_compress/Kconfig
@@ -61,7 +61,7 @@ endmenu
 
 config NRF_COMPRESS_CHUNK_SIZE
 	int "Chunk size"
-	default 4096
+	default 256
 	help
 	  The chunk size is the default maximum amount of data that if returned by the
 	  decompress_bytes_needed() function. The value is returned by the decompress bytes


### PR DESCRIPTION
Backport c57bce0f9078e6ffdbea185cc5a250e84f4750eb from #18489.