### PR TITLE
net: openthread: rpc: using nrf_rpc encoders and decoders on servers

### DIFF
--- a/subsys/net/openthread/rpc/client/ot_rpc_coap.c
+++ b/subsys/net/openthread/rpc/client/ot_rpc_coap.c
@@ -200,8 +200,7 @@ const uint8_t *otCoapMessageGetToken(const otMessage *aMessage)
 	nrf_rpc_decode_buffer(&ctx, token, sizeof(token));
 
 	if (!nrf_rpc_decoding_done_and_check(&ot_group, &ctx)) {
-		nrf_rpc_err(-EBADMSG, NRF_RPC_ERR_SRC_RECV, &ot_group,
-			    OT_RPC_CMD_COAP_MESSAGE_GET_TOKEN, NRF_RPC_PACKET_TYPE_RSP);
+		ot_rpc_report_rsp_decoding_error(OT_RPC_CMD_COAP_MESSAGE_GET_TOKEN);
 	}
 
 	return token;

--- a/subsys/net/openthread/rpc/client/ot_rpc_diag.c
+++ b/subsys/net/openthread/rpc/client/ot_rpc_diag.c
@@ -27,20 +27,20 @@ static otMeshLocalPrefix mesh_prefix;
 
 static void get_uint_t(int id, void *result, size_t result_size)
 {
+	const size_t cbor_buffer_size = 0;
 	struct nrf_rpc_cbor_ctx ctx;
-	uint32_t value;
 
-	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, 0);
+	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, cbor_buffer_size);
 
 	nrf_rpc_cbor_cmd_rsp_no_err(&ot_group, id, &ctx);
 
-	value = nrf_rpc_decode_uint(&ctx);
-	if (!nrf_rpc_decoding_done_and_check(&ot_group, &ctx)) {
+	if (!zcbor_uint_decode(ctx.zs, result, result_size)) {
+		nrf_rpc_cbor_decoding_done(&ot_group, &ctx);
 		ot_rpc_report_rsp_decoding_error(id);
 		return;
 	}
 
-	memcpy(result, &value, result_size);
+	nrf_rpc_cbor_decoding_done(&ot_group, &ctx);
 }
 
 static int get_string(int id, char *buffer, size_t buffer_size)

--- a/subsys/net/openthread/rpc/common/ot_rpc_common.c
+++ b/subsys/net/openthread/rpc/common/ot_rpc_common.c
@@ -223,42 +223,21 @@ void ot_rpc_decode_message_info(struct nrf_rpc_cbor_ctx *ctx, otMessageInfo *aMe
 	aMessageInfo->mMulticastLoop = nrf_rpc_decode_bool(ctx);
 }
 
-bool ot_rpc_encode_service_config(struct nrf_rpc_cbor_ctx *ctx, const otServiceConfig *config)
+void ot_rpc_encode_service_config(struct nrf_rpc_cbor_ctx *ctx, const otServiceConfig *config)
 {
 
 	if (config == NULL) {
-		return zcbor_nil_put(ctx->zs, NULL);
+		nrf_rpc_encode_null(ctx);
+		return;
 	}
 
-	if (!zcbor_uint_encode(ctx->zs, &config->mServiceId, sizeof(config->mServiceId))) {
-		return false;
-	}
-
-	if (!zcbor_uint_encode(ctx->zs, &config->mEnterpriseNumber,
-			       sizeof(config->mEnterpriseNumber))) {
-		return false;
-	}
-
-	if (!zcbor_bstr_encode_ptr(ctx->zs, (const char *)&config->mServiceData,
-				   config->mServiceDataLength)) {
-		return false;
-	}
-
-	if (!zcbor_bool_put(ctx->zs, config->mServerConfig.mStable)) {
-		return false;
-	}
-
-	if (!zcbor_bstr_encode_ptr(ctx->zs, (const char *)&config->mServerConfig.mServerData,
-				   config->mServerConfig.mServerDataLength)) {
-		return false;
-	}
-
-	if (!zcbor_uint_encode(ctx->zs, &config->mServerConfig.mRloc16,
-			       sizeof(config->mServerConfig.mRloc16))) {
-		return false;
-	}
-
-	return true;
+	nrf_rpc_encode_uint(ctx, config->mServiceId);
+	nrf_rpc_encode_uint(ctx, config->mEnterpriseNumber);
+	nrf_rpc_encode_buffer(ctx, config->mServiceData, config->mServiceDataLength);
+	nrf_rpc_encode_bool(ctx, config->mServerConfig.mStable);
+	nrf_rpc_encode_buffer(ctx, config->mServerConfig.mServerData,
+			      config->mServerConfig.mServerDataLength);
+	nrf_rpc_encode_uint(ctx, config->mServerConfig.mRloc16);
 }
 
 void ot_rpc_decode_service_config(struct nrf_rpc_cbor_ctx *ctx, otServiceConfig *config)
@@ -293,72 +272,28 @@ void ot_rpc_decode_service_config(struct nrf_rpc_cbor_ctx *ctx, otServiceConfig 
 	config->mServerConfig.mRloc16 = nrf_rpc_decode_uint(ctx);
 }
 
-bool ot_rpc_encode_border_router_config(struct nrf_rpc_cbor_ctx *ctx,
+void ot_rpc_encode_border_router_config(struct nrf_rpc_cbor_ctx *ctx,
 					const otBorderRouterConfig *config)
 {
-	signed int tmp;
-
 	if (config == NULL) {
-		return zcbor_nil_put(ctx->zs, NULL);
+		nrf_rpc_encode_null(ctx);
+		return;
 	}
 
-	if (!zcbor_bstr_encode_ptr(ctx->zs, (const char *)config->mPrefix.mPrefix.mFields.m8,
-				   OT_IP6_ADDRESS_SIZE)) {
-		return false;
-	}
-
-	if (!zcbor_uint_encode(ctx->zs, &config->mPrefix.mLength,
-			       sizeof(config->mPrefix.mLength))) {
-		return false;
-	}
-
-	tmp = config->mPreference;
-
-	if (!zcbor_int_encode(ctx->zs, &tmp, sizeof(tmp))) {
-		return false;
-	}
-
-	if (!zcbor_bool_put(ctx->zs, config->mPreferred)) {
-		return false;
-	}
-
-	if (!zcbor_bool_put(ctx->zs, config->mSlaac)) {
-		return false;
-	}
-
-	if (!zcbor_bool_put(ctx->zs, config->mDhcp)) {
-		return false;
-	}
-
-	if (!zcbor_bool_put(ctx->zs, config->mConfigure)) {
-		return false;
-	}
-
-	if (!zcbor_bool_put(ctx->zs, config->mDefaultRoute)) {
-		return false;
-	}
-
-	if (!zcbor_bool_put(ctx->zs, config->mOnMesh)) {
-		return false;
-	}
-
-	if (!zcbor_bool_put(ctx->zs, config->mStable)) {
-		return false;
-	}
-
-	if (!zcbor_bool_put(ctx->zs, config->mNdDns)) {
-		return false;
-	}
-
-	if (!zcbor_bool_put(ctx->zs, config->mDp)) {
-		return false;
-	}
-
-	if (!zcbor_uint_encode(ctx->zs, &config->mRloc16, sizeof(config->mRloc16))) {
-		return false;
-	}
-
-	return true;
+	nrf_rpc_encode_buffer(ctx, config->mPrefix.mPrefix.mFields.m8,
+			      OT_IP6_ADDRESS_SIZE);
+	nrf_rpc_encode_uint(ctx, config->mPrefix.mLength);
+	nrf_rpc_encode_int(ctx, config->mPreference);
+	nrf_rpc_encode_bool(ctx, config->mPreferred);
+	nrf_rpc_encode_bool(ctx, config->mSlaac);
+	nrf_rpc_encode_bool(ctx, config->mDhcp);
+	nrf_rpc_encode_bool(ctx, config->mConfigure);
+	nrf_rpc_encode_bool(ctx, config->mDefaultRoute);
+	nrf_rpc_encode_bool(ctx, config->mOnMesh);
+	nrf_rpc_encode_bool(ctx, config->mStable);
+	nrf_rpc_encode_bool(ctx, config->mNdDns);
+	nrf_rpc_encode_bool(ctx, config->mDp);
+	nrf_rpc_encode_uint(ctx, config->mRloc16);
 }
 
 void ot_rpc_decode_border_router_config(struct nrf_rpc_cbor_ctx *ctx, otBorderRouterConfig *config)

--- a/subsys/net/openthread/rpc/common/ot_rpc_common.h
+++ b/subsys/net/openthread/rpc/common/ot_rpc_common.h
@@ -79,10 +79,10 @@ void ot_rpc_report_cmd_decoding_error(uint8_t cmd_evt_id);
 void ot_rpc_report_rsp_decoding_error(uint8_t cmd_evt_id);
 void ot_rpc_decode_message_info(struct nrf_rpc_cbor_ctx *ctx, otMessageInfo *aMessageInfo);
 void ot_rpc_encode_message_info(struct nrf_rpc_cbor_ctx *ctx, const otMessageInfo *aMessageInfo);
-bool ot_rpc_encode_service_config(struct nrf_rpc_cbor_ctx *ctx,
+void ot_rpc_encode_service_config(struct nrf_rpc_cbor_ctx *ctx,
 				  const otServiceConfig *service_config);
 void ot_rpc_decode_service_config(struct nrf_rpc_cbor_ctx *ctx, otServiceConfig *service_config);
-bool ot_rpc_encode_border_router_config(struct nrf_rpc_cbor_ctx *ctx,
+void ot_rpc_encode_border_router_config(struct nrf_rpc_cbor_ctx *ctx,
 					const otBorderRouterConfig *service_config);
 void ot_rpc_decode_border_router_config(struct nrf_rpc_cbor_ctx *ctx,
 					otBorderRouterConfig *service_config);

--- a/subsys/net/openthread/rpc/server/ot_rpc_link.c
+++ b/subsys/net/openthread/rpc/server/ot_rpc_link.c
@@ -19,25 +19,21 @@ static void ot_rpc_cmd_set_poll_period(const struct nrf_rpc_group *group,
 				       struct nrf_rpc_cbor_ctx *ctx, void *handler_data)
 {
 	uint32_t poll_period;
-	bool decoded_ok;
 	otError error;
 	struct nrf_rpc_cbor_ctx rsp_ctx;
 
-	decoded_ok = zcbor_uint_decode(ctx->zs, &poll_period, sizeof(poll_period));
-	nrf_rpc_cbor_decoding_done(group, ctx);
-
-	if (!decoded_ok) {
-		error = OT_ERROR_INVALID_ARGS;
-		goto out;
+	poll_period = nrf_rpc_decode_uint(ctx);
+	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_LINK_SET_POLL_PERIOD);
+		return;
 	}
 
 	openthread_api_mutex_lock(openthread_get_default_context());
 	error = otLinkSetPollPeriod(openthread_get_default_instance(), poll_period);
 	openthread_api_mutex_unlock(openthread_get_default_context());
 
-out:
 	NRF_RPC_CBOR_ALLOC(group, rsp_ctx, 5);
-	zcbor_uint_encode(rsp_ctx.zs, &error, sizeof(error));
+	nrf_rpc_encode_uint(&rsp_ctx, error);
 	nrf_rpc_cbor_rsp_no_err(group, &rsp_ctx);
 }
 
@@ -54,7 +50,7 @@ static void ot_rpc_cmd_get_poll_period(const struct nrf_rpc_group *group,
 	openthread_api_mutex_unlock(openthread_get_default_context());
 
 	NRF_RPC_CBOR_ALLOC(group, rsp_ctx, 5);
-	zcbor_uint_encode(rsp_ctx.zs, &poll_period, sizeof(poll_period));
+	nrf_rpc_encode_uint(&rsp_ctx, poll_period);
 	nrf_rpc_cbor_rsp_no_err(group, &rsp_ctx);
 }
 

--- a/subsys/net/openthread/rpc/server/ot_rpc_netdata.c
+++ b/subsys/net/openthread/rpc/server/ot_rpc_netdata.c
@@ -37,7 +37,7 @@ static void ot_rpc_cmd_netdata_get(const struct nrf_rpc_group *group, struct nrf
 
 	if (!netdata) {
 		nrf_rpc_err(-ENOMEM, NRF_RPC_ERR_SRC_RECV, group, OT_RPC_CMD_NETDATA_GET,
-			    NRF_RPC_PACKET_TYPE_RSP);
+			    NRF_RPC_PACKET_TYPE_CMD);
 		return;
 	}
 
@@ -63,43 +63,26 @@ static void ot_rpc_cmd_get_next_service(const struct nrf_rpc_group *group,
 					struct nrf_rpc_cbor_ctx *ctx, void *handler_data)
 {
 	struct nrf_rpc_cbor_ctx rsp_ctx;
-	otError error = OT_ERROR_NONE;
+	otError error;
 	otNetworkDataIterator iterator;
-	bool decoded_ok = false;
 	otServiceConfig service_config;
 
-	NRF_RPC_CBOR_ALLOC(group, rsp_ctx, sizeof(error) + sizeof(service_config) + 7);
-
-	decoded_ok = zcbor_uint_decode(ctx->zs, &iterator, sizeof(iterator));
-
-	if (!decoded_ok) {
-		error = OT_ERROR_INVALID_ARGS;
-		goto exit;
+	iterator = nrf_rpc_decode_uint(ctx);
+	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_NETDATA_GET_NEXT_SERVICE);
+		return;
 	}
-
-	nrf_rpc_cbor_decoding_done(group, ctx);
 
 	openthread_api_mutex_lock(openthread_get_default_context());
 	error = otNetDataGetNextService(openthread_get_default_instance(), &iterator,
 					&service_config);
 	openthread_api_mutex_unlock(openthread_get_default_context());
 
-	if (!zcbor_uint_encode(rsp_ctx.zs, &iterator, sizeof(iterator))) {
-		error = OT_ERROR_FAILED;
-		goto exit;
-	}
+	NRF_RPC_CBOR_ALLOC(group, rsp_ctx, sizeof(error) + sizeof(service_config) + 7);
 
-	if (error == OT_ERROR_NONE) {
-		ot_rpc_encode_service_config(&rsp_ctx, &service_config);
-	} else {
-		ot_rpc_encode_service_config(&rsp_ctx, NULL);
-	}
-
-exit:
-	if (!decoded_ok) {
-		nrf_rpc_cbor_decoding_done(group, ctx);
-	}
-	zcbor_uint_encode(rsp_ctx.zs, &error, sizeof(error));
+	nrf_rpc_encode_uint(&rsp_ctx, iterator);
+	ot_rpc_encode_service_config(&rsp_ctx, error == OT_ERROR_NONE ? &service_config : NULL);
+	nrf_rpc_encode_uint(&rsp_ctx, error);
 	nrf_rpc_cbor_rsp_no_err(group, &rsp_ctx);
 }
 
@@ -108,42 +91,25 @@ static void ot_rpc_cmd_netdata_get_next_on_mesh_prefix(const struct nrf_rpc_grou
 						       void *handler_data)
 {
 	struct nrf_rpc_cbor_ctx rsp_ctx;
-	otError error = OT_ERROR_NONE;
+	otError error;
 	otNetworkDataIterator iterator;
-	bool decoded_ok = false;
 	otBorderRouterConfig config;
 
-	NRF_RPC_CBOR_ALLOC(group, rsp_ctx, sizeof(error) + sizeof(config) + 14);
-
-	decoded_ok = zcbor_uint_decode(ctx->zs, &iterator, sizeof(iterator));
-
-	if (!decoded_ok) {
-		error = OT_ERROR_INVALID_ARGS;
-		goto exit;
+	iterator = nrf_rpc_decode_uint(ctx);
+	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_NETDATA_GET_NEXT_ON_MESH_PREFIX);
+		return;
 	}
-
-	nrf_rpc_cbor_decoding_done(group, ctx);
 
 	openthread_api_mutex_lock(openthread_get_default_context());
 	error = otNetDataGetNextOnMeshPrefix(openthread_get_default_instance(), &iterator, &config);
 	openthread_api_mutex_unlock(openthread_get_default_context());
 
-	if (!zcbor_uint_encode(rsp_ctx.zs, &iterator, sizeof(iterator))) {
-		error = OT_ERROR_FAILED;
-		goto exit;
-	}
+	NRF_RPC_CBOR_ALLOC(group, rsp_ctx, sizeof(error) + sizeof(config) + 14);
 
-	if (error == OT_ERROR_NONE) {
-		ot_rpc_encode_border_router_config(&rsp_ctx, &config);
-	} else {
-		ot_rpc_encode_border_router_config(&rsp_ctx, NULL);
-	}
-
-exit:
-	if (!decoded_ok) {
-		nrf_rpc_cbor_decoding_done(group, ctx);
-	}
-	zcbor_uint_encode(rsp_ctx.zs, &error, sizeof(error));
+	nrf_rpc_encode_uint(&rsp_ctx, iterator);
+	ot_rpc_encode_border_router_config(&rsp_ctx, error == OT_ERROR_NONE ? &config : NULL);
+	nrf_rpc_encode_uint(&rsp_ctx, error);
 	nrf_rpc_cbor_rsp_no_err(group, &rsp_ctx);
 }
 

--- a/subsys/net/openthread/rpc/server/ot_rpc_udp.c
+++ b/subsys/net/openthread/rpc/server/ot_rpc_udp.c
@@ -93,19 +93,15 @@ exit:
 static void ot_rpc_udp_open(const struct nrf_rpc_group *group, struct nrf_rpc_cbor_ctx *ctx,
 			    void *handler_data)
 {
-	bool decoded_ok;
 	struct nrf_rpc_cbor_ctx rsp_ctx;
 	nrf_udp_socket *socket = NULL;
-	otError error = OT_ERROR_NONE;
+	otError error;
 	ot_socket_key key;
 
-	decoded_ok = zcbor_uint_decode(ctx->zs, &key, sizeof(key));
-
-	nrf_rpc_cbor_decoding_done(group, ctx);
-
-	if (!decoded_ok) {
-		error = OT_ERROR_INVALID_ARGS;
-		goto exit;
+	key = nrf_rpc_decode_uint(ctx);
+	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_UDP_OPEN);
+		return;
 	}
 
 	socket = nrf_udp_alloc_socket(key);
@@ -126,7 +122,7 @@ exit:
 	}
 
 	NRF_RPC_CBOR_ALLOC(group, rsp_ctx, sizeof(error) + 1);
-	zcbor_uint_encode(rsp_ctx.zs, &error, sizeof(error));
+	nrf_rpc_encode_uint(&rsp_ctx, error);
 	nrf_rpc_cbor_rsp_no_err(group, &rsp_ctx);
 }
 
@@ -134,9 +130,9 @@ static void ot_rpc_udp_send(const struct nrf_rpc_group *group, struct nrf_rpc_cb
 			    void *handler_data)
 {
 	struct nrf_rpc_cbor_ctx rsp_ctx;
-	otError error = OT_ERROR_NONE;
-	ot_socket_key soc_key = 0;
-	ot_msg_key msg_key = 0;
+	otError error;
+	ot_socket_key soc_key;
+	ot_msg_key msg_key;
 	nrf_udp_socket *socket;
 	otMessageInfo message_info;
 	otMessage *message;
@@ -171,53 +167,30 @@ static void ot_rpc_udp_send(const struct nrf_rpc_group *group, struct nrf_rpc_cb
 
 exit:
 	NRF_RPC_CBOR_ALLOC(group, rsp_ctx, sizeof(error) + 1);
-	zcbor_uint_encode(rsp_ctx.zs, &error, sizeof(error));
+	nrf_rpc_encode_uint(&rsp_ctx, error);
 	nrf_rpc_cbor_rsp_no_err(group, &rsp_ctx);
 }
 
 static void ot_rpc_udp_bind(const struct nrf_rpc_group *group, struct nrf_rpc_cbor_ctx *ctx,
 			    void *handler_data)
 {
-	otError error = OT_ERROR_NONE;
+	otError error;
 	struct nrf_rpc_cbor_ctx rsp_ctx;
-	bool decoded_ok;
-	ot_socket_key soc_key = 0;
+	ot_socket_key soc_key;
 	nrf_udp_socket *socket;
 	otSockAddr sock_name;
 	otNetifIdentifier netif;
-	struct zcbor_string zstr;
 
-	decoded_ok = zcbor_uint_decode(ctx->zs, &soc_key, sizeof(soc_key));
+	soc_key = nrf_rpc_decode_uint(ctx);
+	nrf_rpc_decode_buffer(ctx, sock_name.mAddress.mFields.m8,
+			      sizeof(sock_name.mAddress.mFields.m8));
+	sock_name.mPort = nrf_rpc_decode_uint(ctx);
+	netif = nrf_rpc_decode_uint(ctx);
 
-	if (!decoded_ok) {
-		error = OT_ERROR_INVALID_ARGS;
-		goto exit;
+	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_UDP_BIND);
+		return;
 	}
-
-	decoded_ok = zcbor_bstr_decode(ctx->zs, &zstr);
-
-	if (!decoded_ok) {
-		error = OT_ERROR_INVALID_ARGS;
-		goto exit;
-	}
-
-	memcpy(&sock_name.mAddress.mFields.m8, zstr.value, zstr.len);
-
-	decoded_ok = zcbor_uint_decode(ctx->zs, &sock_name.mPort, sizeof(sock_name.mPort));
-
-	if (!decoded_ok) {
-		error = OT_ERROR_INVALID_ARGS;
-		goto exit;
-	}
-
-	decoded_ok = zcbor_uint_decode(ctx->zs, &netif, sizeof(netif));
-
-	if (!decoded_ok) {
-		error = OT_ERROR_INVALID_ARGS;
-		goto exit;
-	}
-
-	nrf_rpc_cbor_decoding_done(group, ctx);
 
 	socket = nrf_udp_find_socket(soc_key);
 
@@ -231,33 +204,24 @@ static void ot_rpc_udp_bind(const struct nrf_rpc_group *group, struct nrf_rpc_cb
 	openthread_api_mutex_unlock(openthread_get_default_context());
 
 exit:
-	if (!decoded_ok) {
-		nrf_rpc_cbor_decoding_done(group, ctx);
-		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_UDP_BIND);
-	}
-
 	NRF_RPC_CBOR_ALLOC(group, rsp_ctx, sizeof(error) + 1);
-	zcbor_uint_encode(rsp_ctx.zs, &error, sizeof(error));
+	nrf_rpc_encode_uint(&rsp_ctx, error);
 	nrf_rpc_cbor_rsp_no_err(group, &rsp_ctx);
 }
 
 static void ot_rpc_udp_close(const struct nrf_rpc_group *group, struct nrf_rpc_cbor_ctx *ctx,
 			     void *handler_data)
 {
-	otError error = OT_ERROR_NONE;
-	ot_socket_key soc_key = 0;
+	otError error;
+	ot_socket_key soc_key;
 	struct nrf_rpc_cbor_ctx rsp_ctx;
-	bool decoded_ok;
 	nrf_udp_socket *socket;
 
-	decoded_ok = zcbor_uint_decode(ctx->zs, &soc_key, sizeof(soc_key));
-
-	if (!decoded_ok) {
-		error = OT_ERROR_INVALID_ARGS;
-		goto exit;
+	soc_key = nrf_rpc_decode_uint(ctx);
+	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_UDP_CLOSE);
+		return;
 	}
-
-	nrf_rpc_cbor_decoding_done(group, ctx);
 
 	socket = nrf_udp_find_socket(soc_key);
 
@@ -273,51 +237,29 @@ static void ot_rpc_udp_close(const struct nrf_rpc_group *group, struct nrf_rpc_c
 	nrf_udp_free_socket(soc_key);
 
 exit:
-	if (!decoded_ok) {
-		nrf_rpc_cbor_decoding_done(group, ctx);
-		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_UDP_CLOSE);
-	}
-
 	NRF_RPC_CBOR_ALLOC(group, rsp_ctx, sizeof(error) + 1);
-	zcbor_uint_encode(rsp_ctx.zs, &error, sizeof(error));
+	nrf_rpc_encode_uint(&rsp_ctx, error);
 	nrf_rpc_cbor_rsp_no_err(group, &rsp_ctx);
 }
 
 static void ot_rpc_udp_connect(const struct nrf_rpc_group *group, struct nrf_rpc_cbor_ctx *ctx,
 			       void *handler_data)
 {
-	otError error = OT_ERROR_NONE;
+	otError error;
 	struct nrf_rpc_cbor_ctx rsp_ctx;
-	bool decoded_ok;
-	struct zcbor_string zstr;
 	otSockAddr sock_name;
-	ot_socket_key soc_key = 0;
+	ot_socket_key soc_key;
 	nrf_udp_socket *socket;
 
-	decoded_ok = zcbor_uint_decode(ctx->zs, &soc_key, sizeof(soc_key));
+	soc_key = nrf_rpc_decode_uint(ctx);
+	nrf_rpc_decode_buffer(ctx, sock_name.mAddress.mFields.m8,
+			      sizeof(sock_name.mAddress.mFields.m8));
+	sock_name.mPort = nrf_rpc_decode_uint(ctx);
 
-	if (!decoded_ok) {
-		error = OT_ERROR_INVALID_ARGS;
-		goto exit;
+	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
+		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_UDP_CONNECT);
+		return;
 	}
-
-	decoded_ok = zcbor_bstr_decode(ctx->zs, &zstr);
-
-	if (!decoded_ok) {
-		error = OT_ERROR_INVALID_ARGS;
-		goto exit;
-	}
-
-	memcpy(&sock_name.mAddress.mFields.m8, zstr.value, zstr.len);
-
-	decoded_ok = zcbor_uint_decode(ctx->zs, &sock_name.mPort, sizeof(sock_name.mPort));
-
-	if (!decoded_ok) {
-		error = OT_ERROR_INVALID_ARGS;
-		goto exit;
-	}
-
-	nrf_rpc_cbor_decoding_done(group, ctx);
 
 	socket = nrf_udp_find_socket(soc_key);
 
@@ -331,13 +273,8 @@ static void ot_rpc_udp_connect(const struct nrf_rpc_group *group, struct nrf_rpc
 	openthread_api_mutex_unlock(openthread_get_default_context());
 
 exit:
-	if (!decoded_ok) {
-		nrf_rpc_cbor_decoding_done(group, ctx);
-		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_UDP_BIND);
-	}
-
 	NRF_RPC_CBOR_ALLOC(group, rsp_ctx, sizeof(error) + 1);
-	zcbor_uint_encode(rsp_ctx.zs, &error, sizeof(error));
+	nrf_rpc_encode_uint(&rsp_ctx, error);
 	nrf_rpc_cbor_rsp_no_err(group, &rsp_ctx);
 }
 


### PR DESCRIPTION
PR:
1. adds using encoders and decoders on ot servers;
2. makes using common decoding error handler
3. reverts get_uint_t refactoring to be endianness tolerant 