### PR TITLE
[Backport v2.8-branch] doc improvement: Add info about ZMS in the migration guide

### DIFF
--- a/doc/nrf/releases_and_maturity/migration/migration_guide_2.8.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_guide_2.8.rst
@@ -33,6 +33,14 @@ Samples and applications
 
 This section describes the changes related to samples and applications.
 
+nRF54L Series
+-------------
+
+.. toggle::
+
+   * Use the :ref:`ZMS (Zephyr Memory Storage) <zephyr:zms_api>` storage system for all devices with RRAM memory technology, such as the nRF54L Series devices.
+     See the :ref:`memory_storage` page for more details on how to enable ZMS for the nRF54L Series devices.
+
 Serial LTE Modem (SLM)
 ----------------------
 


### PR DESCRIPTION
Backport 6c93155f8f1ecaff1909f2ac1c1cff6127ae38db from #18143.