### PR TITLE
[Backport v2.8-branch] lib: sms: No warning log for unregistration failure

### DIFF
--- a/lib/sms/sms.c
+++ b/lib/sms/sms.c
@@ -379,7 +379,8 @@ static void sms_uninit(void)
 		return;
 	} else if (ret > 0) {
 		/* Modem returned an error, assume that there is no registration anymore. */
-		LOG_WRN("Failed to unregister the SMS client from modem, err: %d", ret);
+		LOG_DBG("Failed to unregister the SMS client from modem, err: %d. "
+			"Might be that SMS had already been unregistered.", ret);
 	}
 
 	LOG_DBG("SMS client unregistered");


### PR DESCRIPTION
Backport a75cea7c5c1b2ecea670209458630074900b25f2 from #18403.