### PR TITLE
samples: peripheral_power_profiling: Remove unused buttons from DTS

### DIFF
--- a/samples/bluetooth/peripheral_power_profiling/app.overlay
+++ b/samples/bluetooth/peripheral_power_profiling/app.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	aliases {
+		/delete-property/ sw2;
+		/delete-property/ sw3;
+	};
+};
+
+/delete-node/ &button2;
+/delete-node/ &button3;


### PR DESCRIPTION
Removed unused buttons from DTS, no longer wake up the application.
This ensures that these buttons are not initialized by the dk_buttons_and_leds library.