### PR TITLE
[Backport v2.8-branch] samples: peripheral_power_profiling: Remove unused buttons from DTS

### DIFF
--- a/samples/bluetooth/peripheral_power_profiling/app.overlay
+++ b/samples/bluetooth/peripheral_power_profiling/app.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	aliases {
+		/delete-property/ sw2;
+		/delete-property/ sw3;
+	};
+};
+
+/delete-node/ &button2;
+/delete-node/ &button3;


### PR DESCRIPTION
Backport b99305c34d77864ed2478cbd48efffe5444446cc from #18555.