### PR TITLE
[Backport v2.8-branch] Bluetooth: Initialize conn passed to bt_conn_le_create to NULL

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/bt_management/scanning/bt_mgmt_scan_for_conn.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/scanning/bt_mgmt_scan_for_conn.c
@@ -43,7 +43,7 @@ static void bond_connect(const struct bt_bond_info *bond_info, void *user_data)
 {
 	int ret;
 	const bt_addr_le_t *adv_addr = user_data;
-	struct bt_conn *conn;
+	struct bt_conn *conn = NULL;
 	char addr_string[BT_ADDR_LE_STR_LEN];
 
 	if (!bt_addr_le_cmp(&bond_info->addr, adv_addr)) {
@@ -137,7 +137,7 @@ static bool device_name_check(struct bt_data *data, void *user_data)
 {
 	int ret;
 	bt_addr_le_t *addr = user_data;
-	struct bt_conn *conn;
+	struct bt_conn *conn = NULL;
 	char addr_string[BT_ADDR_LE_STR_LEN];
 
 	/* We only care about LTVs with name */
@@ -197,7 +197,7 @@ static bool csip_found(struct bt_data *data, void *user_data)
 {
 	int ret;
 	bt_addr_le_t *addr = user_data;
-	struct bt_conn *conn;
+	struct bt_conn *conn = NULL;
 	char addr_string[BT_ADDR_LE_STR_LEN];
 
 	if (!bt_csip_set_coordinator_is_set_member(server_sirk, data)) {

--- a/samples/bluetooth/central_bas/src/main.c
+++ b/samples/bluetooth/central_bas/src/main.c
@@ -68,7 +68,7 @@ static void scan_filter_no_match(struct bt_scan_device_info *device_info,
 				 bool connectable)
 {
 	int err;
-	struct bt_conn *conn;
+	struct bt_conn *conn = NULL;
 	char addr[BT_ADDR_LE_STR_LEN];
 
 	if (device_info->recv_info->adv_type == BT_GAP_ADV_TYPE_ADV_DIRECT_IND) {

--- a/samples/bluetooth/central_hids/src/main.c
+++ b/samples/bluetooth/central_hids/src/main.c
@@ -96,7 +96,7 @@ static void scan_filter_no_match(struct bt_scan_device_info *device_info,
 				 bool connectable)
 {
 	int err;
-	struct bt_conn *conn;
+	struct bt_conn *conn = NULL;
 	char addr[BT_ADDR_LE_STR_LEN];
 
 	if (device_info->recv_info->adv_type == BT_GAP_ADV_TYPE_ADV_DIRECT_IND) {

--- a/samples/bluetooth/central_nfc_pairing/src/main.c
+++ b/samples/bluetooth/central_nfc_pairing/src/main.c
@@ -120,7 +120,7 @@ static void scan_filter_no_match(struct bt_scan_device_info *device_info,
 				 bool connectable)
 {
 	int err;
-	struct bt_conn *conn;
+	struct bt_conn *conn = NULL;
 	char addr[BT_ADDR_LE_STR_LEN];
 
 	if (device_info->recv_info->adv_type == BT_GAP_ADV_TYPE_ADV_DIRECT_IND) {

--- a/samples/bluetooth/iso_combined_bis_and_cis/src/combined_bis_cis.c
+++ b/samples/bluetooth/iso_combined_bis_and_cis/src/combined_bis_cis.c
@@ -101,7 +101,7 @@ static void scan_recv(const struct bt_le_scan_recv_info *info, struct net_buf_si
 	const struct bt_le_conn_param *conn_param =
 		BT_LE_CONN_PARAM(ACL_INTERVAL_BLE_UNITS, ACL_INTERVAL_BLE_UNITS, 0, 400);
 
-	struct bt_conn *conn;
+	struct bt_conn *conn = NULL;
 	int err = bt_conn_le_create(info->addr, BT_CONN_LE_CREATE_CONN, conn_param, &conn);
 
 	if (err) {

--- a/samples/bluetooth/iso_time_sync/src/cis_central.c
+++ b/samples/bluetooth/iso_time_sync/src/cis_central.c
@@ -83,7 +83,7 @@ static void scan_recv(const struct bt_le_scan_recv_info *info, struct net_buf_si
 		return;
 	}
 
-	struct bt_conn *conn;
+	struct bt_conn *conn = NULL;
 	int err = bt_conn_le_create(info->addr, BT_CONN_LE_CREATE_CONN, BT_LE_CONN_PARAM_DEFAULT,
 				    &conn);
 	if (err) {

--- a/samples/bluetooth/radio_notification_cb/src/central.c
+++ b/samples/bluetooth/radio_notification_cb/src/central.c
@@ -54,7 +54,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 		return;
 	}
 
-	struct bt_conn *unused_conn;
+	struct bt_conn *unused_conn = NULL;
 
 	err = bt_conn_le_create(addr, BT_CONN_LE_CREATE_CONN,
 				BT_LE_CONN_PARAM_DEFAULT, &unused_conn);

--- a/subsys/bluetooth/rpc/host/bt_rpc_conn_host.c
+++ b/subsys/bluetooth/rpc/host/bt_rpc_conn_host.c
@@ -555,7 +555,7 @@ static void bt_conn_le_create_rpc_handler(const struct nrf_rpc_group *group,
 	const bt_addr_le_t *peer;
 	struct bt_conn_le_create_param create_param;
 	struct bt_le_conn_param conn_param;
-	struct bt_conn *conn_data;
+	struct bt_conn *conn_data = NULL;
 	struct bt_conn **conn = &conn_data;
 	size_t buffer_size_max = 8;
 

--- a/subsys/bluetooth/scan.c
+++ b/subsys/bluetooth/scan.c
@@ -483,7 +483,7 @@ static void scan_connect_with_target(struct bt_scan_control *control,
 	}
 
 	/* Establish connection. */
-	struct bt_conn *conn;
+	struct bt_conn *conn = NULL;
 
 	/* Stop scanning. */
 	bt_scan_stop();

--- a/tests/bluetooth/iso/modules/central.c
+++ b/tests/bluetooth/iso/modules/central.c
@@ -198,7 +198,7 @@ static int device_found(uint8_t type, const uint8_t *data, uint8_t data_len,
 			const bt_addr_le_t *addr)
 {
 	int ret;
-	struct bt_conn *conn;
+	struct bt_conn *conn = NULL;
 
 	if (all_peers_connected()) {
 		LOG_DBG("All peripherals connected");


### PR DESCRIPTION
Backport 9ad182c516d1c9ad329e8dd4d8b31c296cc8e99a~4..9ad182c516d1c9ad329e8dd4d8b31c296cc8e99a from #18540.