### PR TITLE
tests: Add nrfprovision package to requirements-ci.txt

### DIFF
--- a/scripts/requirements-ci.txt
+++ b/scripts/requirements-ci.txt
@@ -14,3 +14,4 @@ qrcode
 stringcase==1.2.0
 toml
 wget
+nrfprovision


### PR DESCRIPTION
nrfprovision package is required by west ncs-provision command. As we added tests to regression, we need to inform CI, that this must be installed.