### PR TITLE
Deprecate legacy doc

### DIFF
--- a/doc/nrf/libraries/security/nrf_security/doc/backend_config.rst
+++ b/doc/nrf/libraries/security/nrf_security/doc/backend_config.rst
@@ -10,6 +10,10 @@ Legacy configurations and supported features
 
 This section covers the configurations available when using :ref:`legacy_crypto_support`.
 
+.. caution::
+   Legacy crypto toolbox APIs are marked as deprecated in the |NCS| version 2.8.0, and will be removed in a future version.
+   It is not recommended to use the legacy crypto toolbox APIs and the related configurations in any new designs.
+
 .. _nrf_security_backend_config_multiple:
 
 Configuring backends

--- a/doc/nrf/libraries/security/nrf_security/doc/configuration.rst
+++ b/doc/nrf/libraries/security/nrf_security/doc/configuration.rst
@@ -24,8 +24,16 @@ PSA core uses PSA drivers to implement the cryptographic features either in soft
 Legacy crypto support
 *********************
 
-To enable the legacy crypto support mode of nRF Security, set both the :kconfig:option:`CONFIG_NORDIC_SECURITY_BACKEND` and :kconfig:option:`CONFIG_NRF_SECURITY` Kconfig options along with additional configuration options, as described in :ref:`nrf_security_legacy_config`.
+To enable the legacy crypto support mode of nRF Security, set the :kconfig:option:`CONFIG_NORDIC_SECURITY_BACKEND` Kconfig option along with additional configuration options, as described in :ref:`nrf_security_legacy_config`.
 The legacy crypto support allows backwards compatibility for software that requires usage of Mbed TLS crypto toolbox functions prefixed with ``mbedtls_``.
+
+.. caution::
+   Mbed TLS legacy crypto toolbox APIs are marked as deprecated in the |NCS| version 2.8.0, and will be removed in a future version.
+   It is not recommended to use crypto toolbox functions prefixed with ``mbedtls_`` for any new designs.
+   Use the equivalent functionality from PSA crypto APIs instead.
+
+   Setting the Kconfig option :kconfig:option:`CONFIG_NORDIC_SECURITY_BACKEND` will also enable the Kconfig option :kconfig:option:`MBEDTLS_LEGACY_CRYPTO_C`, which will show a deprecation warning in the build output.
+   Use the Kconfig option :kconfig:option:`CONFIG_NRF_SECURITY` instead.
 
 Custom Mbed TLS configuration files
 ***********************************

--- a/doc/nrf/libraries/security/nrf_security/doc/configuration.rst
+++ b/doc/nrf/libraries/security/nrf_security/doc/configuration.rst
@@ -19,9 +19,6 @@ PSA crypto support is included by default when you enable nRF Security through t
 PSA crypto support is provided through PSA Crypto APIs and is implemented by PSA core.
 PSA core uses PSA drivers to implement the cryptographic features either in software, or using hardware accelerators.
 
-.. caution::
-   The PSA Crypto APIs are only thread safe when provided by TF-M.
-
 .. _legacy_crypto_support:
 
 Legacy crypto support

--- a/doc/nrf/libraries/security/nrf_security/doc/configuration.rst
+++ b/doc/nrf/libraries/security/nrf_security/doc/configuration.rst
@@ -32,9 +32,6 @@ Custom Mbed TLS configuration files
 
 The nRF Security Kconfig options are used to generate an Mbed TLS configuration file.
 
-Although not recommended, it is possible to provide a custom Mbed TLS configuration file by disabling :kconfig:option:`CONFIG_GENERATE_MBEDTLS_CFG_FILE`.
-See :ref:`nrf_security_tls_header`.
-
 Building with TF-M
 ******************
 


### PR DESCRIPTION
Documenting deprecation of legacy Mbed TLS crypto toolbox APIs 