### PR TITLE
[Backport v2.8-branch] samples: matter: Enable storing DAC priv key in KMU by default.

### DIFF
--- a/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -17,6 +17,3 @@ CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
 # Workaround required as Zephyr L2 implies usage of NVS backend for settings.
 # It should be removed once the proper fix will be applied in Zephyr.
 CONFIG_NVS=n
-
-# Enable DAC key migration to KMU
-CONFIG_CHIP_CRYPTO_PSA_DAC_PRIV_KEY_KMU=y

--- a/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
+++ b/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
@@ -19,6 +19,3 @@ CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
 # Workaround required as Zephyr L2 implies usage of NVS backend for settings.
 # It should be removed once the proper fix will be applied in Zephyr.
 CONFIG_NVS=n
-
-# Enable DAC key migration to KMU
-CONFIG_CHIP_CRYPTO_PSA_DAC_PRIV_KEY_KMU=y

--- a/west.yml
+++ b/west.yml
@@ -161,7 +161,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: f67310e6166ce4738985168fb3d74c5314539688
+      revision: 331c0da760fd747614ef44784b222efb7e8df48c
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
Enabled storing the DAC private key in KMU if it is available.