### PR TITLE
[Backport v2.8-branch] samples: matter: fix fprotect for mcuboot

### DIFF
--- a/samples/matter/light_bulb/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/light_bulb/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -16,11 +16,6 @@ CONFIG_SPI_NOR=y
 CONFIG_SPI_NOR_SFDP_DEVICETREE=y
 CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
 
-# TODO: NCSDK-28931: Cannot use fprotect twice, so disable it in MCUboot to
-# test protecting Matter factory data. It can be enabled while there is a support
-# for protection more than one region.
-CONFIG_FPROTECT=n
-
 # required by SPI driver
 CONFIG_MULTITHREADING=y
 

--- a/samples/matter/light_bulb/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/light_bulb/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -16,11 +16,6 @@ CONFIG_SPI_NOR=y
 CONFIG_SPI_NOR_SFDP_DEVICETREE=y
 CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
 
-# TODO: NCSDK-28931: Cannot use fprotect twice, so disable it in MCUboot to
-# test protecting Matter factory data. It can be enabled while there is a support
-# for protection more than one region.
-CONFIG_FPROTECT=n
-
 # required by SPI driver
 CONFIG_MULTITHREADING=y
 

--- a/samples/matter/light_switch/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/light_switch/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -16,11 +16,6 @@ CONFIG_SPI_NOR=y
 CONFIG_SPI_NOR_SFDP_DEVICETREE=y
 CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
 
-# TODO: NCSDK-28931: Cannot use fprotect twice, so disable it in MCUboot to
-# test protecting Matter factory data. It can be enabled while there is a support
-# for protection more than one region.
-CONFIG_FPROTECT=n
-
 # required by SPI driver
 CONFIG_MULTITHREADING=y
 

--- a/samples/matter/light_switch/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/light_switch/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -16,11 +16,6 @@ CONFIG_SPI_NOR=y
 CONFIG_SPI_NOR_SFDP_DEVICETREE=y
 CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
 
-# TODO: NCSDK-28931: Cannot use fprotect twice, so disable it in MCUboot to
-# test protecting Matter factory data. It can be enabled while there is a support
-# for protection more than one region.
-CONFIG_FPROTECT=n
-
 # required by SPI driver
 CONFIG_MULTITHREADING=y
 

--- a/samples/matter/lock/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/lock/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -16,11 +16,6 @@ CONFIG_SPI_NOR=y
 CONFIG_SPI_NOR_SFDP_DEVICETREE=y
 CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
 
-# TODO: NCSDK-28931: Cannot use fprotect twice, so disable it in MCUboot to
-# test protecting Matter factory data. It can be enabled while there is a support
-# for protection more than one region.
-CONFIG_FPROTECT=n
-
 # required by SPI driver
 CONFIG_MULTITHREADING=y
 

--- a/samples/matter/lock/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/lock/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -16,11 +16,6 @@ CONFIG_SPI_NOR=y
 CONFIG_SPI_NOR_SFDP_DEVICETREE=y
 CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
 
-# TODO: NCSDK-28931: Cannot use fprotect twice, so disable it in MCUboot to
-# test protecting Matter factory data. It can be enabled while there is a support
-# for protection more than one region.
-CONFIG_FPROTECT=n
-
 # required by SPI driver
 CONFIG_MULTITHREADING=y
 

--- a/samples/matter/template/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/template/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -16,11 +16,6 @@ CONFIG_SPI_NOR=y
 CONFIG_SPI_NOR_SFDP_DEVICETREE=y
 CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
 
-# TODO: NCSDK-28931: Cannot use fprotect twice, so disable it in MCUboot to
-# test protecting Matter factory data. It can be enabled while there is a support
-# for protection more than one region.
-CONFIG_FPROTECT=n
-
 # required by SPI driver
 CONFIG_MULTITHREADING=y
 

--- a/samples/matter/template/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp_internal.conf
+++ b/samples/matter/template/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp_internal.conf
@@ -4,10 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# TODO: NCSDK-28931: Cannot use fprotect twice, so disable it in MCUboot to
-# test protecting Matter factory data. It can be enabled while there is a support
-# for protection more than one region.
-CONFIG_FPROTECT=n
 # TODO: Workaround, disable memory guard to avoid false faults in application after boot
 CONFIG_HW_STACK_PROTECTION=n
 

--- a/samples/matter/template/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/template/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -16,11 +16,6 @@ CONFIG_SPI_NOR=y
 CONFIG_SPI_NOR_SFDP_DEVICETREE=y
 CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
 
-# TODO: NCSDK-28931: Cannot use fprotect twice, so disable it in MCUboot to
-# test protecting Matter factory data. It can be enabled while there is a support
-# for protection more than one region.
-CONFIG_FPROTECT=n
-
 # required by SPI driver
 CONFIG_MULTITHREADING=y
 

--- a/samples/matter/thermostat/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/thermostat/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -16,11 +16,6 @@ CONFIG_SPI_NOR=y
 CONFIG_SPI_NOR_SFDP_DEVICETREE=y
 CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
 
-# TODO: NCSDK-28931: Cannot use fprotect twice, so disable it in MCUboot to
-# test protecting Matter factory data. It can be enabled while there is a support
-# for protection more than one region.
-CONFIG_FPROTECT=n
-
 # required by SPI driver
 CONFIG_MULTITHREADING=y
 

--- a/samples/matter/thermostat/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/thermostat/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -16,11 +16,6 @@ CONFIG_SPI_NOR=y
 CONFIG_SPI_NOR_SFDP_DEVICETREE=y
 CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
 
-# TODO: NCSDK-28931: Cannot use fprotect twice, so disable it in MCUboot to
-# test protecting Matter factory data. It can be enabled while there is a support
-# for protection more than one region.
-CONFIG_FPROTECT=n
-
 # required by SPI driver
 CONFIG_MULTITHREADING=y
 

--- a/samples/matter/window_covering/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/window_covering/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -16,11 +16,6 @@ CONFIG_SPI_NOR=y
 CONFIG_SPI_NOR_SFDP_DEVICETREE=y
 CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
 
-# TODO: NCSDK-28931: Cannot use fprotect twice, so disable it in MCUboot to
-# test protecting Matter factory data. It can be enabled while there is a support
-# for protection more than one region.
-CONFIG_FPROTECT=n
-
 # required by SPI driver
 CONFIG_MULTITHREADING=y
 

--- a/samples/matter/window_covering/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/samples/matter/window_covering/sysbuild/mcuboot/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -16,11 +16,6 @@ CONFIG_SPI_NOR=y
 CONFIG_SPI_NOR_SFDP_DEVICETREE=y
 CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
 
-# TODO: NCSDK-28931: Cannot use fprotect twice, so disable it in MCUboot to
-# test protecting Matter factory data. It can be enabled while there is a support
-# for protection more than one region.
-CONFIG_FPROTECT=n
-
 # required by SPI driver
 CONFIG_MULTITHREADING=y
 

--- a/west.yml
+++ b/west.yml
@@ -161,7 +161,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 331c0da760fd747614ef44784b222efb7e8df48c
+      revision: 4b61fdbc17066a15fbb78c4423c0d86b9d7d8e52
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
Disable `FPROTECT` in app and reenable it in mcuboot for nrf54l15

manual backport from https://github.com/nrfconnect/sdk-nrf/pull/18580