### PR TITLE
[Backport v2.8-branch] Zigbee: fix error when using VERSION file in Zigbee project.

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -285,7 +285,7 @@ Thread
 Zigbee
 ------
 
-|no_changes_yet_note|
+* Fixed the :file:`zb_add_ota_header.py` script not being able to handle an ``APPLICATION_VERSION_STRING`` which includes a tweak, such as ``1.0.0+3``.
 
 Wi-Fi
 -----

--- a/scripts/bootloader/zb_add_ota_header.py
+++ b/scripts/bootloader/zb_add_ota_header.py
@@ -6,6 +6,7 @@
 
 import argparse
 import os
+import re
 import struct
 
 OTA_HEADER_FILE_ID               = 0x0BEEF11E
@@ -140,11 +141,11 @@ class OTA_header:
 
 def convert_version_string_to_int(s):
     """Convert from semver string "1.2.3", to integer 1020003"""
-    numbers = s.split('.')
-    if len(numbers) != 3:
-        raise ValueError('application-version-string parameter must be on the format x.y.z')
+    match = re.match(r'^([0-9]+)\.([0-9]+)\.([0-9])(?:\+[0-9]+)?$', s)
+    if match is None:
+        raise ValueError('application-version-string parameter must be on the format x.y.z or x.y.z+t')
     js = [0x100*0x10000, 0x10000, 1]
-    return sum([js[i] * int(numbers[i]) for i in range(3)])
+    return sum([js[i] * int(match.group(i+1)) for i in range(3)])
 
 def hex2int(x):
     """Convert hex to int."""


### PR DESCRIPTION
Backport faf75378d289409567f613f0a0dcfe691f490bcc from #17424.