### PR TITLE
doc: Mesh maturity to supported for nRF54L15

### DIFF
--- a/doc/nrf/releases_and_maturity/software_maturity.rst
+++ b/doc/nrf/releases_and_maturity/software_maturity.rst
@@ -211,7 +211,7 @@ The following table indicates the software maturity levels of the support for ea
      - Supported
      - Supported
      - --
-     - Experimental
+     - Supported
      - --
      - --
      - --


### PR DESCRIPTION
Changed the software maturity level for Bluetooth Mesh to Supported for the nRF54L15.