### PR TITLE
net: openthread: rpc: don't bring interface up in IF_ENABLE command

### DIFF
--- a/subsys/net/openthread/rpc/server/ot_rpc_if.c
+++ b/subsys/net/openthread/rpc/server/ot_rpc_if.c
@@ -91,12 +91,6 @@ static void ot_rpc_cmd_if_enable(const struct nrf_rpc_group *group, struct nrf_r
 		goto out;
 	}
 
-	ret = enable ? net_if_up(iface) : net_if_down(iface);
-	if (ret) {
-		NET_ERR("Failed to bring interface %s", enable ? "up" : "down");
-		goto out;
-	}
-
 	if (recv_net_context != NULL) {
 		net_context_put(recv_net_context);
 		recv_net_context = NULL;


### PR DESCRIPTION
The OpenThread RPC server starts the network interface automatically on boot because otherwise no frames are delivered to the OpenThread stack.

Therefore, don't bring the interface up or down when IF_ENABLE RPC command is received. Instead, assume that IF_ENABLE command only indicates that the client has brought its interface up or down, and that it is
interested (or not) in receiving all incoming packets.