### PR TITLE
doc: zigbee: NCP Host v2.2.4

### DIFF
--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -89,8 +89,8 @@
 .. ### Zigbee & ZBOSS shortcuts
 
 .. |zigbee_version| replace:: Zigbee 3.0
-.. |zboss_version| replace:: 3.11.4.0
-.. |zigbee_ncp_package_version| replace:: 2.2.3
+.. |zboss_version| replace:: 3.11.5.0
+.. |zigbee_ncp_package_version| replace:: 2.2.4
 .. |zigbee_description| replace:: Zigbee is a portable, low-power software networking protocol that provides connectivity over an 802.15.4-based mesh network.
 .. |enable_zigbee_before_testing| replace:: Make sure to configure the Zigbee stack before building and testing this sample.
    See :ref:`ug_zigbee_configuring` for more information.


### PR DESCRIPTION
Updated NCP Host version shortcut to v2.2.4.

----

Changelog covered by @edmont in https://github.com/nrfconnect/sdk-nrf/pull/18192#issuecomment-2457250970