### PR TITLE
[Backport v2.8-branch] samples: cellular: nrf_cloud_multi_service: More modem RX shared memory

### DIFF
--- a/samples/cellular/nrf_cloud_multi_service/prj.conf
+++ b/samples/cellular/nrf_cloud_multi_service/prj.conf
@@ -40,9 +40,9 @@ CONFIG_AT_HOST_STACK_SIZE=2048
 # Extended memory heap size needed both for PGPS and for encoding JSON-based nRF Cloud Device Messages.
 CONFIG_HEAP_MEM_POOL_SIZE=19000
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
-# The default modem shared memory buffers are significantly larger than required for this sample
+# The default modem shared memory buffer for TX is significantly larger than required.
+# RX buffer has to be larger because the sample reads certificates so using default value.
 CONFIG_NRF_MODEM_LIB_SHMEM_TX_SIZE=4096
-CONFIG_NRF_MODEM_LIB_SHMEM_RX_SIZE=4096
 
 # Enable Networking and Connection Manager.
 CONFIG_NETWORKING=y


### PR DESCRIPTION
Backport 1b9c39408b1f9eec99ed50ca8df18034bad8039c from #18468.