### PR TITLE
[Backport v2.8-branch] samples: peripheral_power_profiling: nrf54l: disable RAM retention

### DIFF
--- a/samples/bluetooth/peripheral_power_profiling/src/main.c
+++ b/samples/bluetooth/peripheral_power_profiling/src/main.c
@@ -27,6 +27,9 @@
 #include <nfc/ndef/le_oob_rec.h>
 
 #include <helpers/nrfx_reset_reason.h>
+#ifdef CONFIG_SOC_NRF54L15_CPUAPP
+#include <hal/nrf_memconf.h>
+#endif
 
 #include "pwr_service.h"
 
@@ -637,6 +640,14 @@ static void system_off(void)
 			} while ((err == 0) && (state == PM_DEVICE_STATE_ACTIVE));
 		}
 	}
+
+#ifdef CONFIG_SOC_NRF54L15_CPUAPP
+	/* Disable RAM retention in System OFF as it is not utilized by this sample. */
+	uint32_t ram_sections = 8;
+
+	nrf_memconf_ramblock_ret_mask_enable_set(NRF_MEMCONF, 0, BIT_MASK(ram_sections), false);
+	nrf_memconf_ramblock_ret2_mask_enable_set(NRF_MEMCONF, 0, BIT_MASK(ram_sections), false);
+#endif
 
 	sys_poweroff();
 }


### PR DESCRIPTION
Backport 672f66c03f31adb1166132beadcdb87cb4a40f6b from #18589.