### PR TITLE
[Backport v2.8-branch] doc: Mesh maturity to supported for nRF54L15

### DIFF
--- a/doc/nrf/releases_and_maturity/software_maturity.rst
+++ b/doc/nrf/releases_and_maturity/software_maturity.rst
@@ -211,7 +211,7 @@ The following table indicates the software maturity levels of the support for ea
      - Supported
      - Supported
      - --
-     - Experimental
+     - Supported
      - --
      - --
      - --


### PR DESCRIPTION
Backport d697d73e6f29c2efc9de36b1c864c347d0347da5 from #18604.