### PR TITLE
[Backport v2.8-branch] tests: benchmarks: power_consumption: qdec: enable PM_DEVICE

### DIFF
--- a/tests/benchmarks/power_consumption/qdec/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/tests/benchmarks/power_consumption/qdec/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -1,9 +1,5 @@
 CONFIG_NRFS=y
 
-# Enable runtime power management for peripheral
-CONFIG_PM_DEVICE=y
-CONFIG_PM_DEVICE_RUNTIME=y
-
 CONFIG_PM=y
 CONFIG_PM_S2RAM=y
 CONFIG_POWEROFF=y

--- a/tests/benchmarks/power_consumption/qdec/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/benchmarks/power_consumption/qdec/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -28,6 +28,14 @@
 				<NRF_PSEL(QDEC_B, 1, 10)>;
 		};
 	};
+
+	qdec_sleep_pinctrl: qdec_sleep_pinctrl {
+		group1 {
+			psels = <NRF_PSEL(QDEC_A, 1, 8)>,
+				<NRF_PSEL(QDEC_B, 1, 10)>;
+			low-power-enable;
+		};
+	};
 };
 
 &gpio1 {
@@ -37,7 +45,9 @@
 &qdec20 {
 	status = "okay";
 	pinctrl-0 = <&qdec_pinctrl>;
-	pinctrl-names = "default";
+	pinctrl-1 = <&qdec_sleep_pinctrl>;
+	pinctrl-names = "default", "sleep";
 	steps = <127>;
 	led-pre = <500>;
+	zephyr,pm-device-runtime-auto;
 };

--- a/tests/benchmarks/power_consumption/qdec/prj.conf
+++ b/tests/benchmarks/power_consumption/qdec/prj.conf
@@ -1,5 +1,9 @@
 CONFIG_SENSOR=y
 
+# Enable runtime power management for peripheral
+CONFIG_PM_DEVICE=y
+CONFIG_PM_DEVICE_RUNTIME=y
+
 CONFIG_CONSOLE=n
 CONFIG_UART_CONSOLE=n
 CONFIG_SERIAL=n


### PR DESCRIPTION
Backport f09040864509648400c0eedea3868c5e1116375c from #18636.