### PR TITLE
samples: cellular: Change deprecated OVERLAY_CONFIG and DTC_OVERLAY_FILE

### DIFF
--- a/samples/cellular/gnss/sample.yaml
+++ b/samples/cellular/gnss/sample.yaml
@@ -81,7 +81,7 @@ tests:
       - CONFIG_MODEM_ANTENNA_GNSS_EXTERNAL=y
       - CONFIG_LOG_BUFFER_SIZE=2048
     extra_args:
-      - OVERLAY_CONFIG=overlay-pgps.conf
+      - EXTRA_CONF_FILE=overlay-pgps.conf
       - gnss_SNIPPET="nrf91-modem-trace-uart"
     integration_platforms:
       - nrf9151dk/nrf9151/ns

--- a/samples/cellular/http_update/application_update/sample.yaml
+++ b/samples/cellular/http_update/application_update/sample.yaml
@@ -16,7 +16,7 @@ tests:
   sample.cellular.http_update.application_update.lwm2m_carrier:
     sysbuild: true
     build_only: true
-    extra_args: OVERLAY_CONFIG=overlay-carrier.conf
+    extra_args: EXTRA_CONF_FILE=overlay-carrier.conf
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns

--- a/samples/cellular/location/sample.yaml
+++ b/samples/cellular/location/sample.yaml
@@ -20,7 +20,7 @@ tests:
   sample.cellular.location.pgps:
     sysbuild: true
     build_only: true
-    extra_args: OVERLAY_CONFIG=overlay-pgps.conf
+    extra_args: EXTRA_CONF_FILE=overlay-pgps.conf
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
@@ -41,7 +41,7 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    extra_args: SHIELD=nrf7002ek_nrf7000 OVERLAY_CONFIG=overlay-nrf700x-wifi-scan-only.conf
+    extra_args: SHIELD=nrf7002ek_nrf7000 EXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf
                 SB_CONFIG_WIFI_NRF70=y SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
     tags: ci_build sysbuild ci_samples_cellular
   sample.cellular.location.nrf7000ek_wifi:
@@ -55,7 +55,7 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    extra_args: SHIELD=nrf7002ek_nrf7000 OVERLAY_CONFIG=overlay-nrf700x-wifi-scan-only.conf
+    extra_args: SHIELD=nrf7002ek_nrf7000 EXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf
                 CONFIG_WIFI_NM_WPA_SUPPLICANT=n SB_CONFIG_WIFI_NRF70=y
                 SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
     tags: ci_build sysbuild ci_samples_cellular
@@ -66,8 +66,8 @@ tests:
       - thingy91x/nrf9151/ns
     platform_allow:
       - thingy91x/nrf9151/ns
-    extra_args: OVERLAY_CONFIG=overlay-nrf700x-wifi-scan-only.conf
-                DTC_OVERLAY_FILE=thingy91x_wifi.overlay
+    extra_args: EXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf
+                EXTRA_DTC_OVERLAY_FILE=thingy91x_wifi.overlay
                 SB_CONFIG_WIFI_NRF70=y SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
     tags: ci_build sysbuild ci_samples_cellular
 

--- a/samples/cellular/modem_shell/sample.yaml
+++ b/samples/cellular/modem_shell/sample.yaml
@@ -146,7 +146,7 @@ tests:
     sysbuild: true
     build_only: true
     extra_args: EXTRA_CONF_FILE=overlay-modem_fota_full.conf
-                DTC_OVERLAY_FILE="nrf9160dk_ext_flash.overlay"
+                EXTRA_DTC_OVERLAY_FILE="nrf9160dk_ext_flash.overlay"
     integration_platforms:
       - nrf9160dk/nrf9160/ns
     platform_allow: nrf9160dk/nrf9160/ns
@@ -155,7 +155,7 @@ tests:
     sysbuild: true
     build_only: true
     extra_args: EXTRA_CONF_FILE=overlay-modem_fota_full.conf
-                DTC_OVERLAY_FILE="nrf9161dk_ext_flash.overlay"
+                EXTRA_DTC_OVERLAY_FILE="nrf9161dk_ext_flash.overlay"
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9161dk/nrf9161/ns
@@ -283,7 +283,7 @@ tests:
   sample.cellular.modem_shell.ppp:
     sysbuild: true
     build_only: true
-    extra_args: EXTRA_CONF_FILE=overlay-ppp.conf DTC_OVERLAY_FILE="ppp.overlay"
+    extra_args: EXTRA_CONF_FILE=overlay-ppp.conf EXTRA_DTC_OVERLAY_FILE="ppp.overlay"
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
@@ -296,7 +296,7 @@ tests:
   sample.cellular.modem_shell.bt:
     sysbuild: true
     build_only: true
-    extra_args: EXTRA_CONF_FILE=overlay-bt.conf DTC_OVERLAY_FILE="bt.overlay"
+    extra_args: EXTRA_CONF_FILE=overlay-bt.conf EXTRA_DTC_OVERLAY_FILE="bt.overlay"
     integration_platforms:
       - nrf9160dk/nrf9160/ns
     platform_allow: nrf9160dk/nrf9160/ns
@@ -332,7 +332,7 @@ tests:
     platform_allow:
       - thingy91x/nrf9151/ns
     extra_args: EXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf
-                DTC_OVERLAY_FILE=thingy91x_wifi.overlay
+                EXTRA_DTC_OVERLAY_FILE=thingy91x_wifi.overlay
                 SB_CONFIG_WIFI_NRF70=y SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
     tags: ci_build sysbuild ci_samples_cellular
   sample.cellular.modem_shell.modem_trace_shell_ext_flash:


### PR DESCRIPTION
Replace deprecated `OVERLAY_CONFIG` with `EXTRA_CONF_FILE`. Replace deprecated `DTC_OVERLAY_FILE` with `EXTRA_DTC_OVERLAY_FILE`.