### PR TITLE
[Backport v2.8-branch] samples: peripheral_power_profiling: Add Kconfig option to disable LEDs

### DIFF
--- a/samples/bluetooth/peripheral_power_profiling/Kconfig
+++ b/samples/bluetooth/peripheral_power_profiling/Kconfig
@@ -71,6 +71,11 @@ config BT_POWER_PROFILING_NON_CONNECTABLE_ADV_INTERVAL_MAX
 	help
 	  Non-connectable advertising maximum interval in 0.625 milliseconds unit.
 
+config BT_POWER_PROFILING_LED_DISABLED
+	bool "Disable LEDs"
+	help
+	  Disables the LEDs to reduce power consumption.
+
 config SETTINGS
 	default y
 

--- a/samples/bluetooth/peripheral_power_profiling/README.rst
+++ b/samples/bluetooth/peripheral_power_profiling/README.rst
@@ -218,6 +218,11 @@ CONFIG_BT_POWER_PROFILING_NON_CONNECTABLE_ADV_INTERVAL_MIN - Non-connectable adv
 CONFIG_BT_POWER_PROFILING_NON_CONNECTABLE_ADV_INTERVAL_MAX - Non-connectable advertising maximum interval
    Sets the non-connectable advertising maximum interval in 0.625 milliseconds unit.
 
+.. _CONFIG_BT_POWER_PROFILING_LED_DISABLED:
+
+CONFIG_BT_POWER_PROFILING_LED_DISABLED - Disable LEDs
+   Disables the LEDs to reduce power consumption.
+
 Building and running
 ********************
 


### PR DESCRIPTION
Backport d11c5181de995c3ee5ba73dc3da37558dc05b234 from #18625.