### PR TITLE
tests: benchmarks: increase idle HPU feature test timeout

### DIFF
--- a/tests/benchmarks/multicore/idle_hpu_temp_meas/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_hpu_temp_meas/testcase.yaml
@@ -15,3 +15,4 @@ tests:
       fixture: ppk_power_measure
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_hpu_feature"
+    timeout: 90


### PR DESCRIPTION
Default 60s is to low and the test timed out, set to 90s