### PR TITLE
[Backport v2.8-branch] tests: benchmarks: current_consumption: system_off: adjust test fun

### DIFF
--- a/tests/benchmarks/current_consumption/system_off/testcase.yaml
+++ b/tests/benchmarks/current_consumption/system_off/testcase.yaml
@@ -31,7 +31,7 @@ tests:
     harness_config:
       fixture: ppk_power_measure
       pytest_root:
-        - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_with_wakeups"
+        - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_with_wakeups_systemoff_retention"
     timeout: 80
   benchmarks.current_consumption.systemoff.grtc_wakeup:
     platform_allow:


### PR DESCRIPTION
Backport 3bcaa159befe29ddf6f305378e6d55a5544ca5a8 from #18646.