### PR TITLE
samples: tfm: Do not fprotect MCUboot for nRF54L15

### DIFF
--- a/samples/tfm/tfm_psa_template/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/tfm/tfm_psa_template/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -1,0 +1,2 @@
+# Not yet supported for MCUboot and nRF54L15
+CONFIG_FPROTECT=n


### PR DESCRIPTION
Not yet supported, so disabling it in this sample for now.