### PR TITLE
applications: matter_bridge: Increase heap size

### DIFF
--- a/applications/matter_bridge/prj.conf
+++ b/applications/matter_bridge/prj.conf
@@ -51,3 +51,6 @@ CONFIG_CHIP_FACTORY_DATA_BUILD=y
 # Enable LTO to decrease the flash usage.
 CONFIG_LTO=y
 CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
+# Increase heap size to accommodate the memory required for additional bridged devices.
+CONFIG_CHIP_MALLOC_SYS_HEAP_SIZE=16384

--- a/applications/matter_bridge/prj_release.conf
+++ b/applications/matter_bridge/prj_release.conf
@@ -55,3 +55,6 @@ CONFIG_CHIP_ENABLE_READ_CLIENT=y
 
 # Enable Watchdog
 CONFIG_NCS_SAMPLE_MATTER_WATCHDOG=y
+
+# Increase heap size to accommodate the memory required for additional bridged devices.
+CONFIG_CHIP_MALLOC_SYS_HEAP_SIZE=16384


### PR DESCRIPTION
Increase heap size to accommodate the memory required for additional bridged devices.