### PR TITLE
samples: matter: build nrf54h20 without migration manager

### DIFF
--- a/samples/matter/template/sample.yaml
+++ b/samples/matter/template/sample.yaml
@@ -11,10 +11,9 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf7002dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
     platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf7002dk/nrf5340/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp nrf54h20dk/nrf54h20/cpuapp nrf54l15dk/nrf54l15/cpuapp/ns
+      nrf54l15dk/nrf54l15/cpuapp nrf54l15dk/nrf54l15/cpuapp/ns
     tags: sysbuild ci_samples_matter
   sample.matter.template.release:
     sysbuild: true
@@ -26,10 +25,9 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf7002dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
     platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf7002dk/nrf5340/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp nrf54h20dk/nrf54h20/cpuapp nrf54l15dk/nrf54l15/cpuapp/ns
+      nrf54l15dk/nrf54l15/cpuapp nrf54l15dk/nrf54l15/cpuapp/ns
     tags: sysbuild ci_samples_matter
   sample.matter.template.lto:
     sysbuild: true
@@ -54,10 +52,17 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf7002dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
     platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf7002dk/nrf5340/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp nrf54h20dk/nrf54h20/cpuapp nrf54l15dk/nrf54l15/cpuapp/ns
+      nrf54l15dk/nrf54l15/cpuapp nrf54l15dk/nrf54l15/cpuapp/ns
+    tags: sysbuild ci_samples_matter
+  sample.matter.template.smp_dfu.nrf54h20:
+    sysbuild: true
+    build_only: true
+    extra_args: CONFIG_CHIP_DFU_OVER_BT_SMP=y
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+    platform_allow: nrf54h20dk/nrf54h20/cpuapp
     tags: sysbuild ci_samples_matter
   sample.matter.template.nrf54h20.nrf7002eb:
     sysbuild: true


### PR DESCRIPTION
build nrf54h20 without migration manager as it is not ready for this platform yet.