### PR TITLE
samples: cellular: location | modem_shell | asset_tracker_v2: Modem UART traces with Wi-Fi

### DIFF
--- a/applications/asset_tracker_v2/overlay-nrf7002ek-wifi-scan-only.conf
+++ b/applications/asset_tracker_v2/overlay-nrf7002ek-wifi-scan-only.conf
@@ -6,9 +6,6 @@
 
 # Overlay to use nRF7002 EK on top of nrf91 DK for Wi-Fi scanning
 
-# Disable modem traces as UART1 is disabled
-CONFIG_NRF_MODEM_LIB_TRACE=n
-
 # Does not work with buttons and LEDs
 CONFIG_UI_MODULE=n
 CONFIG_LED_CONTROL=n

--- a/samples/cellular/location/overlay-nrf700x-wifi-scan-only.conf
+++ b/samples/cellular/location/overlay-nrf700x-wifi-scan-only.conf
@@ -8,9 +8,6 @@
 # * nRF7002 EK on top of nRF91 Series DK
 # * Thingy:91 X
 
-# Disable modem traces as UART1 is disabled
-CONFIG_NRF_MODEM_LIB_TRACE=n
-
 CONFIG_LOCATION_METHOD_WIFI=y
 CONFIG_LOCATION_SERVICE_NRF_CLOUD=y
 

--- a/samples/cellular/modem_shell/overlay-nrf700x-wifi-scan-only.conf
+++ b/samples/cellular/modem_shell/overlay-nrf700x-wifi-scan-only.conf
@@ -8,9 +8,6 @@
 # * nRF7002 EK on top of nRF91 Series DK
 # * Thingy:91 X
 
-# Disable modem traces as UART1 is disabled
-CONFIG_NRF_MODEM_LIB_TRACE=n
-
 CONFIG_LOCATION_METHOD_WIFI=y
 
 # Align this with CONFIG_NRF_WIFI_SCAN_MAX_BSS_CNT.


### PR DESCRIPTION
`CONFIG_NRF_MODEM_LIB_TRACE=n` had been defined in nrf700x overlay because that was needed long time ago to make nrf91+nrf7002ek to work.
Removing it now to allow use of modem UART traces with Wi-Fi builds utilizing `nrf91-modem-trace-uart` snippet.

This change enables modem UART traces with Wi-Fi builds for nRF91 DKs and Thingy91x.