### PR TITLE
applications: connectivity_bridge: Increase buffers for Thingy:91 X

### DIFF
--- a/applications/connectivity_bridge/src/modules/Kconfig
+++ b/applications/connectivity_bridge/src/modules/Kconfig
@@ -98,6 +98,7 @@ config BRIDGE_BUF_SIZE
 
 config BRIDGE_UART_BUF_COUNT
 	int "UART buffer block count"
+	default 16 if BOARD_THINGY91X_NRF5340_CPUAPP
 	default 3
 	range 3 255
 	help


### PR DESCRIPTION
Increase buffer count for Thingy:91 X to be able to capture modem traces without running out of memory.