### PR TITLE
bluetooth: controller: Return an error if LLPM is not supported

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -108,7 +108,7 @@ Amazon Sidewalk
 Bluetooth® LE
 -------------
 
-|no_changes_yet_note|
+* Updated the Bluetooth LE SoftDevice Controller driver to make the :c:func:`hci_vs_sdc_llpm_mode_set` function return an error if Low Latency Packet Mode (LLPM) is not supported or not enabled in the Bluetooth LE Controller driver configuration (:kconfig:option:`CONFIG_BT_CTLR_SDC_LLPM`).
 
 Bluetooth Mesh
 --------------

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -116,7 +116,8 @@ config SYSTEM_WORKQUEUE_STACK_SIZE
 config BT_CTLR_SDC_LLPM
 	bool "Enable Low Latency Packet Mode support"
 	select BT_CONN_PARAM_ANY if !BT_HCI_RAW
-	depends on (SOC_SERIES_NRF52X || SOC_SERIES_NRF54LX || SOC_SERIES_NRF54HX)
+	depends on (SOC_SERIES_NRF52X || SOC_SERIES_NRF54LX || SOC_SERIES_NRF54HX || \
+		    SOC_SERIES_BSIM_NRF52X || SOC_SERIES_BSIM_NRF54LX)
 	help
 	  Low Latency Packet Mode (LLPM) is a Nordic proprietary addition
 	  which lets the application use connection intervals down to 1 ms.

--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -673,7 +673,9 @@ static void vs_supported_commands(sdc_hci_vs_supported_vs_commands_t *cmds)
 	memset(cmds, 0, sizeof(*cmds));
 
 	cmds->read_supported_vs_commands = 1;
+#if defined(CONFIG_BT_CTLR_SDC_LLPM)
 	cmds->llpm_mode_set = 1;
+#endif
 	cmds->conn_update = 1;
 	cmds->conn_event_extend = 1;
 	cmds->qos_conn_event_report_enable = 1;
@@ -1681,8 +1683,10 @@ static uint8_t vs_cmd_put(uint8_t const *const cmd, uint8_t *const raw_event_out
 		*param_length_out += sizeof(sdc_hci_cmd_vs_read_supported_vs_commands_return_t);
 		vs_supported_commands((void *)event_out_params);
 		return 0;
+#if CONFIG_BT_CTLR_SDC_LLPM
 	case SDC_HCI_OPCODE_CMD_VS_LLPM_MODE_SET:
 		return sdc_hci_cmd_vs_llpm_mode_set((void *)cmd_params);
+#endif /* CONFIG_BT_CTLR_SDC_LLPM */
 	case SDC_HCI_OPCODE_CMD_VS_CONN_UPDATE:
 		return sdc_hci_cmd_vs_conn_update((void *)cmd_params);
 	case SDC_HCI_OPCODE_CMD_VS_CONN_EVENT_EXTEND:


### PR DESCRIPTION
Return an error when handling LLPM enable command in case LLPM feature is not supported (e.g. on nRF53 SoC Series).

Jira: NCSDK-29545