### PR TITLE
[Backport v2.8-branch] doc: nrf70: Fix 54 Series shields

### DIFF
--- a/doc/nrf/app_dev/device_guides/nrf70/index.rst
+++ b/doc/nrf/app_dev/device_guides/nrf70/index.rst
@@ -110,7 +110,7 @@ The following nRF70 Series shields are available and defined in the :file:`nrf/b
        | `User Guide <nRF7002 EK User Guide_>`_
    * - nRF7002 :term:`Expansion Board (EB)`
      - PCA63561
-     - ``nrf7002eb``, ``nrf700x_nrf54h20dk``, ``nrf700x_nrf54l15pdk``
+     - ``nrf7002eb``, ``nrf7002eb_interposer_p1`` (nRF54 Series)
      - | :ref:`Development guide <ug_nrf7002eb_gs>`
        | `User Guide <nRF7002 EB User Guide_>`_
 

--- a/doc/nrf/app_dev/device_guides/nrf70/index.rst
+++ b/doc/nrf/app_dev/device_guides/nrf70/index.rst
@@ -77,11 +77,13 @@ Zephyr and the |NCS| provide support for developing networking applications with
      - ``nrf54h20dk/nrf54h20/cpuapp``
      - | `nRF54H20 Objective Product Specification 0.3.1`_
        | :ref:`Getting started <ug_nrf54h20_gs>`
-   * - :ref:`zephyr:nrf54l15pdk_nrf54l15`
+   * - :ref:`zephyr:nrf54l15dk_nrf54l15`
      - nRF7002 EB
      - PCA20053
-     - ``nrf54l15pdk/nrf54l15/cpuapp``
-     - :ref:`Getting started <ug_nrf54l15_gs>`
+     - ``nrf54l15dk/nrf54l15/cpuapp``
+     - | `Quick Start`_
+       | :ref:`Developing with nRF54L Series <ug_nrf54l15_gs>`
+
 
 
 The following nRF70 Series shields are available and defined in the :file:`nrf/boards/shields` folder:

--- a/doc/nrf/app_dev/device_guides/nrf70/nrf7002eb_dev_guide.rst
+++ b/doc/nrf/app_dev/device_guides/nrf70/nrf7002eb_dev_guide.rst
@@ -116,13 +116,13 @@ Alternatively, add the shield in the project's :file:`CMakeLists.txt` file by us
 
    set(SHIELD nrf7002eb)
 
-To build for the nRF7002 EB with nRF54H20 DK, use the ``nrf54h20dk/nrf54h20/cpuapp`` board target with the CMake ``SHIELD`` variable set to ``nrf700x_nrf54h20dk``.
-To build for a custom target, set ``-DSHIELD=nrf700x_nrf54h20dk`` when you invoke ``west build`` or ``cmake`` in your |NCS| application.
-Alternatively, you can add the shield in the project's :file:`CMakeLists.txt` file by using the ``set(SHIELD nrf700x_nrf54h20dk)`` command.
+To build for the nRF7002 EB with nRF54H20 DK, use the ``nrf54h20dk/nrf54h20/cpuapp`` board target with the CMake ``SHIELD`` variable set to ``nrf7002eb_interposer_p1 nrf7002eb``.
+To build for a custom target, set ``-DSHIELD=nrf7002eb_interposer_p1;nrf7002eb`` when you invoke ``west build`` or ``cmake`` in your |NCS| application.
+Alternatively, you can add the shield in the project's :file:`CMakeLists.txt` file by using the ``set(SHIELD nrf7002eb_interposer_p1 nrf7002eb)`` command.
 
-To build for the nRF7002 EB with the nRF54L15 PDK, use the ``nrf54l15pdk/nrf54l15/cpuapp`` board target with the CMake ``SHIELD`` variable set to ``nrf700x_nrf54l15pdk``.
-To build for a custom target, set ``-DSHIELD=nrf700x_nrf54l15pdk`` when you invoke ``west build`` or ``cmake`` in your |NCS| application.
-Alternatively, you can add the shield in the project's :file:`CMakeLists.txt` file by using the ``set(SHIELD nrf700x_nrf54l15pdk)`` command.
+To build for the nRF7002 EB with the nRF54L15 PDK, use the ``nrf54l15pdk/nrf54l15/cpuapp`` board target with the CMake ``SHIELD`` variable set to ``nrf7002eb_interposer_p1 nrf7002eb``.
+To build for a custom target, set ``-DSHIELD=nrf7002eb_interposer_p1;nrf7002eb`` when you invoke ``west build`` or ``cmake`` in your |NCS| application.
+Alternatively, you can add the shield in the project's :file:`CMakeLists.txt` file by using the ``set(SHIELD nrf7002eb_interposer_p1 nrf7002eb)`` command.
 
 Limitations when building with nRF54H20 DK and nRF54L15 PDK
 ***********************************************************

--- a/doc/nrf/app_dev/device_guides/nrf70/nrf7002eb_dev_guide.rst
+++ b/doc/nrf/app_dev/device_guides/nrf70/nrf7002eb_dev_guide.rst
@@ -1,5 +1,5 @@
 .. _ug_nrf7002eb_gs:
-.. _ug_nrf7002eb_nrf54l15pdk_gs:
+.. _ug_nrf7002eb_nrf54l15dk_gs:
 .. _ug_nrf7002eb_nrf54h20dk_gs:
 
 Developing with nRF7002 EB
@@ -12,7 +12,7 @@ Developing with nRF7002 EB
 The nRF7002 :term:`Expansion Board (EB)` (PCA63561), part of the `nRF70 Series Family <nRF70 Series product page_>`_, can be used to provide Wi-Fi® connectivity to compatible development or evaluation boards through the nRF7002 Wi-Fi 6 companion IC.
 For example, you can use it with the :ref:`Nordic Thingy:53 <ug_thingy53>`, an IoT prototyping platform from Nordic Semiconductor.
 
-You can also use the nRF7002 EB to provide Wi-Fi connectivity to the :ref:`zephyr:nrf54h20dk_nrf54h20` and :ref:`zephyr:nrf54l15pdk_nrf54l15`.
+You can also use the nRF7002 EB to provide Wi-Fi connectivity to the :ref:`zephyr:nrf54h20dk_nrf54h20` and :ref:`zephyr:nrf54l15dk_nrf54l15`.
 
 .. figure:: images/nRF7002eb.png
    :alt: nRF7002 EB
@@ -29,10 +29,10 @@ The castellated holes on the side of the board allow the EB to be used as a brea
 This way, you can provide Wi-Fi capabilities to develop Wi-Fi applications with another System on Chip (SoC), MPU, or MCU host.
 For the pinout of the castellated holes, see `nRF7002 EB castellated edge holes`_ in the board's `Hardware User Guide <nRF7002 EB User Guide_>`_.
 
-Pin mapping for the nRF54H20 DK and the nRF54L15 PDK
-****************************************************
+Pin mapping for the nRF54H20 DK and the nRF54L15 DK
+***************************************************
 
-For nRF54H20 DK and nRF54L15 PDK, refer to the following tables for the pin mapping for these kits:
+For nRF54H20 DK and nRF54L15 DK, refer to the following tables for the pin mapping for these kits:
 
 .. tabs::
 
@@ -65,10 +65,10 @@ For nRF54H20 DK and nRF54L15 PDK, refer to the following tables for the pin mapp
       .. note::
          Connect ``VIO`` to 1.8 V and ``VBAT`` to 3.6 V and ``GND``.
 
-   .. group-tab:: nRF54L15 PDK
+   .. group-tab:: nRF54L15 DK
 
       +-----------------------------------+-------------------+-----------------------------------------------+
-      | nRF70 Series pin name (EB name)   | nRF54L15 PDK pins | Function                                      |
+      | nRF70 Series pin name (EB name)   | nRF54L15 DK pins | Function                                       |
       +===================================+===================+===============================================+
       | CLK (CLK)                         | P1.11             | SPI Clock                                     |
       +-----------------------------------+-------------------+-----------------------------------------------+
@@ -120,15 +120,15 @@ To build for the nRF7002 EB with nRF54H20 DK, use the ``nrf54h20dk/nrf54h20/cpua
 To build for a custom target, set ``-DSHIELD=nrf7002eb_interposer_p1;nrf7002eb`` when you invoke ``west build`` or ``cmake`` in your |NCS| application.
 Alternatively, you can add the shield in the project's :file:`CMakeLists.txt` file by using the ``set(SHIELD nrf7002eb_interposer_p1 nrf7002eb)`` command.
 
-To build for the nRF7002 EB with the nRF54L15 PDK, use the ``nrf54l15pdk/nrf54l15/cpuapp`` board target with the CMake ``SHIELD`` variable set to ``nrf7002eb_interposer_p1 nrf7002eb``.
+To build for the nRF7002 EB with the nRF54L15 DK, use the ``nrf54l15dk/nrf54l15/cpuapp`` board target with the CMake ``SHIELD`` variable set to ``nrf7002eb_interposer_p1 nrf7002eb``.
 To build for a custom target, set ``-DSHIELD=nrf7002eb_interposer_p1;nrf7002eb`` when you invoke ``west build`` or ``cmake`` in your |NCS| application.
 Alternatively, you can add the shield in the project's :file:`CMakeLists.txt` file by using the ``set(SHIELD nrf7002eb_interposer_p1 nrf7002eb)`` command.
 
-Limitations when building with nRF54H20 DK and nRF54L15 PDK
-***********************************************************
+Limitations when building with nRF54H20 DK and nRF54L15 DK
+**********************************************************
 
 The Wi-Fi support is experimental and has the following limitations:
 
 * It only supports STA mode.
 * It is only suitable for low-throughput applications.
-* For nRF54L15 PDK, WPA3 security mode is not supported.
+* For nRF54L15 DK, WPA3 security mode is not supported.

--- a/doc/nrf/releases_and_maturity/software_maturity.rst
+++ b/doc/nrf/releases_and_maturity/software_maturity.rst
@@ -1307,7 +1307,7 @@ The following table indicates the software maturity levels of the support for ea
         - --
         - --
         - --
-        - Experimental\ :sup:`2`
+        - Supported\ :sup:`2`
         - --
         - --
         - --

--- a/doc/nrf/releases_and_maturity/software_maturity.rst
+++ b/doc/nrf/releases_and_maturity/software_maturity.rst
@@ -1388,8 +1388,8 @@ The following table indicates the software maturity levels of the support for ea
    | [1]: Only with nRF7002 DK, nRF7002 DK in nRF7001 emulation mode, nRF7002 EB, nRF7002 EK or nRF7002 EK in nRF7001 emulation mode
    | [2]: Only with nRF7002 DK, nRF7002 DK in nRF7001 emulation mode or nRF7002 EK
    | [3]: Only with nRF7002 EK or nRF7002 EK in nRF7001 emulation mode
-   | [4]: Only with nRF700X_nRF54H20DK
-   | [5]: Only with nRF700X_nRF54L15PDK
+   | [4]: Only with nrf7002 EB and nRF7002 EB-interposer
+   | [5]: Only with nrf7002 EB and nRF7002 EB-interposer
    | [6]: Only with nRF7002 EK, nRF7002 EK in nRF7000 emulation mode or nRF7002 EK in nRF7001 emulation mode
    | [7]: Only with nRF7002 DK, nRF7002 EB, nRF7002 EK, nRF7002 EK in nRF7000 emulation mode or nRF7002 EK in nRF7001 emulation mode
 


### PR DESCRIPTION
Backport c69c6d9d024d70dfbc8ef9a3c3fcd6c1c7e581cd~3..c69c6d9d024d70dfbc8ef9a3c3fcd6c1c7e581cd from #18610.