### PR TITLE
[Backport v2.8-branch] applications: connectivity_bridge: Increase buffers for Thingy:91 X

### DIFF
--- a/applications/connectivity_bridge/src/modules/Kconfig
+++ b/applications/connectivity_bridge/src/modules/Kconfig
@@ -98,6 +98,7 @@ config BRIDGE_BUF_SIZE
 
 config BRIDGE_UART_BUF_COUNT
 	int "UART buffer block count"
+	default 16 if BOARD_THINGY91X_NRF5340_CPUAPP
 	default 3
 	range 3 255
 	help


### PR DESCRIPTION
Backport fbb05eb93233b70127d80ab6529d4332963202d8 from #18670.