### PR TITLE
[Backport v2.8-branch] net: openthread: rpc: don't bring interface up in IF_ENABLE command

### DIFF
--- a/subsys/net/openthread/rpc/server/ot_rpc_if.c
+++ b/subsys/net/openthread/rpc/server/ot_rpc_if.c
@@ -91,12 +91,6 @@ static void ot_rpc_cmd_if_enable(const struct nrf_rpc_group *group, struct nrf_r
 		goto out;
 	}
 
-	ret = enable ? net_if_up(iface) : net_if_down(iface);
-	if (ret) {
-		NET_ERR("Failed to bring interface %s", enable ? "up" : "down");
-		goto out;
-	}
-
 	if (recv_net_context != NULL) {
 		net_context_put(recv_net_context);
 		recv_net_context = NULL;


### PR DESCRIPTION
Backport fccaa085ed526084a1b2d5454d6d879283037569 from #18611.