### PR TITLE
[Backport v2.8-branch] caf: ble_state: Block enabling CONFIG_CAF_BLE_USE_LLPM on nRF53

### DIFF
--- a/doc/nrf/libraries/caf/ble_state.rst
+++ b/doc/nrf/libraries/caf/ble_state.rst
@@ -36,6 +36,7 @@ The following Kconfig options are also available for this module:
 * :kconfig:option:`CONFIG_CAF_BLE_USE_LLPM` - This option enables the Low Latency Packet Mode (LLPM).
   If the Bluetooth controller is enabled as part of the application, this option is enabled by default and depends on :kconfig:option:`CONFIG_BT_CTLR_SDC_LLPM`.
   Otherwise, this option is disabled and can be enabled manually.
+  Before enabling the option manually, make sure that the used Bluetooth controller supports the LLPM.
 * :kconfig:option:`CONFIG_CAF_BLE_STATE_SECURITY_REQ` - This option enables setting the security level 2 for a Bluetooth LE connection automatically, right after the connection is established.
   The security level 2 or higher enables connection encryption.
   The device disconnects if establishing the connection security level 2 fails.
@@ -81,4 +82,5 @@ After :c:struct:`ble_peer_event` about disconnection or connection failure is re
 Low Latency Packet Mode
 =======================
 
-If Nordic Semiconductor's SoftDevice Bluetooth LE Link Layer is selected (:kconfig:option:`CONFIG_BT_LL_SOFTDEVICE`) and the :kconfig:option:`CONFIG_CAF_BLE_USE_LLPM` option is enabled, the |ble_state| sends a Bluetooth HCI command to enable the LLPM when Bluetooth is ready.
+If the :kconfig:option:`CONFIG_CAF_BLE_USE_LLPM` option is enabled, the |ble_state| sends a Bluetooth HCI command to enable the LLPM when Bluetooth is ready.
+The LLPM is a proprietary Bluetooth extension from Nordic Semiconductor that requires using Nordic Semiconductor's SoftDevice Bluetooth LE Link Layer.

--- a/subsys/caf/modules/Kconfig.ble_state
+++ b/subsys/caf/modules/Kconfig.ble_state
@@ -59,12 +59,15 @@ config CAF_BLE_STATE_EXCHANGE_MTU
 config CAF_BLE_USE_LLPM
 	bool "Enable Low Latency Packet Mode (LLPM)"
 	depends on (BT_CTLR_SDC_LLPM || !BT_CTLR)
+	depends on !SOC_SERIES_NRF53X
 	default y if BT_CTLR
 	help
 	  LLPM is a proprietary Bluetooth extension from Nordic Semiconductor. It is designed for
 	  applications in which the interface response time is critical for the user. It introduces
 	  the possibility to reduce the connection interval to 1 ms for one link. LLPM parameters
 	  can be used for a given connection only if it's supported by both peripheral and central.
+
+	  nRF53 SoC Series does not support the LLPM extension.
 
 module = CAF_BLE_STATE
 module-str = caf module BLE state


### PR DESCRIPTION
Backport fdf865b10ecc66b24e6639c2c78955c5abbd956e from #18671.