### PR TITLE
 [Backport v2.8-branch] manifest: sdk-zephyr: wifi: nrf70: Fix EAP AKM

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 3328399bd0e0d94febf9928950b1576138a2e8c2
+      revision: pull/2241/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -149,7 +149,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: f84a3202cad08e0b8b6d2c28bbdabc5589473f86
+      revision: pull/1564/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Update firmware blobs to fix EAP AKM.