### PR TITLE
[Backport v2.8-branch] doc: update tag file for 2.8

### DIFF
--- a/doc/_zoomin/ncs.tags.yml
+++ b/doc/_zoomin/ncs.tags.yml
@@ -9,50 +9,71 @@ mapping_global:
 # Tags for individual topics:
 mapping_topics:
   - nrf/index.html: ["nrf91-series", "nrf70-series", "nrf54-series", "nrf53-series", "nrf52-series",
-                     "nrf7002", "nrf7001", "nrf7000", "nrf9160", "thingy91", "nrf9161", "nrf9151",
-                     "nrf9131", "nrf54h20", "nrf54l15", "nrf5340", "thingy53", "nrf52840",
-                     "nrf52833", "nrf52832", "nrf52820", "nrf52811", "nrf52810", "nrf52805",
-                     "nrf21540", "npm1100", "npm1300", "npm6001"]
+                     "nrf7002", "nrf7001", "nrf7000", "nrf9160", "thingy91", "thingy91x", "nrf9161",
+                     "nrf9151", "nrf9131", "nrf54h20", "nrf54l15", "nrf54l05", "nrf54l10",
+                     "nrf5340", "thingy53", "nrf52840", "nrf52833", "nrf52832", "nrf52820",
+                     "nrf52811", "nrf52810", "nrf52805", "nrf21540", "npm1100", "npm1300",
+                     "npm6001"]
   - nrf/gsg_guides.html: ["nrf91-series", "nrf70-series", "nrf54-series", "nrf53-series",
                           "nrf52-series", "nrf7002", "nrf7001", "nrf7000", "nrf9160", "thingy91",
-                          "nrf9161", "nrf9151", "nrf9131", "nrf54h20", "nrf54l15", "nrf5340",
-                          "thingy53", "nrf52840", "nrf52833", "nrf52832", "nrf52820", "nrf52811",
-                          "nrf52810", "nrf52805", "nrf21540", "npm1100", "npm1300", "npm6001",
-                          "development-kits", "prototyping-platforms", "evaluation-kits", "pmic"]
+                          "thingy91x", "nrf9161", "nrf9151", "nrf9131", "nrf54h20", "nrf54l15",
+                          "nrf54l05", "nrf54l10", "nrf5340", "thingy53", "nrf52840", "nrf52833",
+                          "nrf52832", "nrf52820", "nrf52811", "nrf52810", "nrf52805", "nrf21540",
+                          "npm1100", "npm1300", "npm6001", "development-kits",
+                          "prototyping-platforms", "evaluation-kits", "pmic"]
   - nrf/gsg_guides/nrf9160_gs.html: ["nrf91-series", "nrf9160", "nrf-cloud", "development-kits",
                                      "lte"]
   - nrf/gsg_guides/thingy91_gsg.html: ["nrf91-series", "thingy91", "nrf9160", "nrf52840", "lte",
                                        "prototyping-platforms"]
   - nrf/gsg_guides/nrf7002_gs.html: ["nrf70-series", "nrf7002", "development-kits"]
   - nrf/gsg_guides/thingy53_gs.html: ["nrf53-series", "thingy53", "prototyping-platforms"]
-  - nrf/gsg_guides/gsg_other.html: ["nrf52-series", "nrf52840", "nrf52833",
-                                    "nrf52832", "nrf52820", "nrf52811", "nrf52810", "nrf52805",
-                                    "nrf53-series", "nrf5340", "thingy53", "nrf9161",
-                                    "nrf9160", "nrf9151", "thingy91", "development-kits",
-                                    "npm1300", "nrf54h20", "nrf54l15", "nrf7002", "evaluation-kits",
-                                    "pmic"]
+  - nrf/gsg_guides/gsg_other.html: ["nrf52-series", "nrf52840", "nrf52833", "nrf52832", "nrf52820",
+                                    "nrf52811", "nrf52810", "nrf52805", "nrf53-series", "nrf5340",
+                                    "thingy53", "nrf9161", "nrf9160", "nrf9151", "thingy91",
+                                    "development-kits", "npm1300", "nrf54h20", "nrf54l15",
+                                    "nrf54l05", "nrf54l10", "nrf7002", "evaluation-kits", "pmic"]
   - nrf/installation.html: ["nrf91-series", "nrf70-series", "nrf54-series", "nrf53-series",
                             "nrf52-series", "nrf7002", "nrf7001", "nrf7000", "nrf9160", "thingy91",
-                            "nrf9161", "nrf9151", "nrf9131", "nrf54h20", "nrf54l15", "nrf5340",
-                            "thingy53", "nrf52840", "nrf52833", "nrf52832", "nrf52820", "nrf52811",
-                            "nrf52810", "nrf52805", "nrf21540", "npm1100", "npm1300", "npm6001"]
+                            "thingy91x", "nrf9161", "nrf9151", "nrf9131", "nrf54h20", "nrf54l15",
+                            "nrf54l05", "nrf54l10", "nrf5340", "thingy53", "nrf52840", "nrf52833",
+                            "nrf52832", "nrf52820", "nrf52811", "nrf52810", "nrf52805", "nrf21540",
+                            "npm1100", "npm1300", "npm6001"]
   - nrf/installation/*.html: ["nrf91-series", "nrf70-series", "nrf54-series", "nrf53-series",
                               "nrf52-series", "nrf7002", "nrf7001", "nrf7000", "nrf9160",
-                              "thingy91", "nrf9161", "nrf9151", "nrf9131", "nrf54h20", "nrf54l15",
-                              "nrf5340", "thingy53", "nrf52840", "nrf52833", "nrf52832", "nrf52820",
-                              "nrf52811", "nrf52810", "nrf52805", "nrf21540", "npm1100",
-                              "npm1300", "npm6001"]
+                              "thingy91", "thingy91x", "nrf9161", "nrf9151", "nrf9131", "nrf54h20",
+                              "nrf54l15", "nrf54l05", "nrf54l10", "nrf5340", "thingy53", "nrf52840",
+                              "nrf52833", "nrf52832", "nrf52820", "nrf52811", "nrf52810",
+                              "nrf52805", "nrf21540", "npm1100", "npm1300", "npm6001"]
   - nrf/app_dev.html: ["nrf91-series", "nrf70-series", "nrf54-series", "nrf53-series",
                        "nrf52-series", "nrf7002", "nrf7001", "nrf7000", "nrf9160", "thingy91",
-                       "nrf9161", "nrf9151", "nrf9131", "nrf54h20", "nrf54l15", "nrf5340",
-                       "thingy53", "nrf52840", "nrf52833", "nrf52832", "nrf52820", "nrf52811",
-                       "nrf52810", "nrf52805", "nrf21540", "npm1100", "npm1300", "npm6001"]
-  - nrf/app_dev/*.html: ["nrf91-series", "nrf70-series", "nrf54-series", "nrf53-series",
-                         "nrf52-series", "nrf7002", "nrf7001", "nrf7000", "nrf9160", "thingy91",
-                         "nrf9161", "nrf9151", "nrf9131", "nrf54h20", "nrf54l15", "nrf5340",
-                         "thingy53", "nrf52840", "nrf52833", "nrf52832", "nrf52820", "nrf52811",
-                         "nrf52810", "nrf52805", "nrf21540", "npm1100", "npm1300", "npm6001"]
-  - nrf/app_dev/create_application.html: ["applications", "nrf-connect-vsc"]
+                       "thingy91x", "nrf9161", "nrf9151", "nrf9131", "nrf54h20", "nrf54l15",
+                       "nrf54l05", "nrf54l10", "nrf5340", "thingy53", "nrf52840", "nrf52833",
+                       "nrf52832", "nrf52820", "nrf52811", "nrf52810", "nrf52805", "nrf21540",
+                       "npm1100", "npm1300", "npm6001"]
+  - nrf/app_dev/create_application.html: ["nrf91-series", "nrf70-series", "nrf54-series",
+                                          "nrf53-series", "nrf52-series", "nrf7002", "nrf7001",
+                                          "nrf7000", "nrf9160", "thingy91", "thingy91x", "nrf9161",
+                                          "nrf9151", "nrf9131", "nrf54h20", "nrf54l15", "nrf54l05",
+                                          "nrf54l10", "nrf5340", "thingy53", "nrf52840", "nrf52833",
+                                          "nrf52832", "nrf52820", "nrf52811", "nrf52810",
+                                          "nrf52805", "nrf21540", "npm1100", "npm1300", "npm6001",
+                                          "applications", "nrf-connect-vsc"]
+  - nrf/app_dev/board_support/*.html: ["nrf91-series", "nrf70-series", "nrf54-series",
+                                       "nrf53-series", "nrf52-series", "nrf7002", "nrf7001",
+                                       "nrf7000", "nrf9160", "thingy91", "thingy91x", "nrf9161",
+                                       "nrf9151", "nrf9131", "nrf54h20", "nrf54l15", "nrf54l05",
+                                       "nrf54l10", "nrf5340", "thingy53", "nrf52840", "nrf52833",
+                                       "nrf52832", "nrf52820", "nrf52811", "nrf52810", "nrf52805",
+                                       "nrf21540", "npm1100", "npm1300", "npm6001"]
+  - nrf/app_dev/config_and_build/*.html: ["nrf91-series", "nrf70-series", "nrf54-series",
+                                          "nrf53-series", "nrf52-series", "nrf7002", "nrf7001",
+                                          "nrf7000", "nrf9160", "thingy91", "thingy91x", "nrf9161",
+                                          "nrf9151", "nrf9131", "nrf54h20", "nrf54l15", "nrf54l05",
+                                          "nrf54l10", nrf5340", "thingy53", "nrf52840", "nrf52833",
+                                          "nrf52832", "nrf52820", "nrf52811", "nrf52810",
+                                          "nrf52805", "nrf21540", "npm1100", "npm1300", "npm6001"]
+  - nrf/app_dev/config_and_build/config_and_build_system.html: ["applications", "samples",
+                                                                "kconfig"]
   - nrf/app_dev/config_and_build/cmake/index.html: ["applications", "samples", "kconfig",
                                                     "development-kits", "evaluation-kits",
                                                     "prototyping-platforms", "nrf-connect-vsc"]
@@ -70,19 +91,86 @@ mapping_topics:
   - nrf/app_dev/config_and_build/output_build_files.html: ["applications", "samples", "kconfig",
                                                            "development-kits", "evaluation-kits",
                                                            "prototyping-platforms"]
-  - nrf/app_dev/programming.html: ["applications", "samples", "development-kits", "evaluation-kits",
-                                   "prototyping-platforms"]
-  - nrf/app_dev/companion_components.html: ["applications", "samples", "development-kits",
+  - nrf/app_dev/programming.html: ["nrf91-series", "nrf70-series", "nrf54-series", "nrf53-series",
+                                   "nrf52-series", "nrf7002", "nrf7001", "nrf7000", "nrf9160",
+                                   "thingy91", "thingy91x", "nrf9161", "nnrf9151", "nrf9131",
+                                   "nrf54h20", "nrf54l15", "nrf54l05", "nrf54l10", "nrf5340",
+                                   "thingy53", "nrf52840", "nrf52833", "nrf52832", "nrf52820",
+                                   "nrf52811", "nrf52810", "nrf52805", "nrf21540", "npm1100",
+                                   "npm1300", "npm6001", "applications", "samples",
+                                   "development-kits", "evaluation-kits", "prototyping-platforms"]
+  - nrf/app_dev/companion_components.html: ["nrf91-series", "nrf70-series", "nrf54-series",
+                                            "nrf53-series", "nrf52-series", "nrf7002", "nrf7001",
+                                            "nrf7000", "nrf9160", "thingy91", "thingy91x",
+                                            "nrf9161", "nnrf9151", "nrf9131", "nrf54h20",
+                                            "nrf54l15", "nrf54l05", "nrf54l10", "nrf5340",
+                                            "thingy53", "nrf52840", "nrf52833", "nrf52832",
+                                            "nrf52820", "nrf52811", "nrf52810", "nrf52805",
+                                            "nrf21540", "npm1100", "npm1300", "npm6001",
+                                            "applications", "samples", "development-kits",
                                             "evaluation-kits", "prototyping-platforms"]
-  - nrf/app_dev/bootloaders_dfu/*.html: ["applications"]
+  - nrf/app_dev/bootloaders_dfu/index.html: ["nrf91-series", "nrf70-series", "nrf54-series",
+                                             "nrf53-series", "nrf52-series", "nrf7002", "nrf7001",
+                                             "nrf7000", "nrf9160", "thingy91", "thingy91x",
+                                             "nrf9161", "nrf9151", "nrf9131", "nrf54h20",
+                                             "nrf54l15", "nrf54l05", "nrf54l10", "nrf5340",
+                                             "thingy53", "nrf52840", "nrf52833", "nrf52832",
+                                             "nrf52820", "nrf52811", "nrf52810", "nrf52805",
+                                             "nrf21540", "npm1100", "npm1300", "npm6001"]
+  - nrf/app_dev/bootloaders_dfu/mcuboot_nsib/*.html: ["nrf91-series", "nrf70-series",
+                                                      "nrf54-series", "nrf53-series",
+                                                      "nrf52-series", "nrf7002", "nrf7001",
+                                                      "nrf7000", "nrf9160", "thingy91", "thingy91x",
+                                                      "nrf9161", "nrf9151", "nrf9131", "nrf54h20",
+                                                      "nrf54l15", "nrf54l05", "nrf54l10", "nrf5340",
+                                                      "thingy53", "nrf52840", "nrf52833",
+                                                      "nrf52832", "nrf52820", "nrf52811",
+                                                      "nrf52810", "nrf52805", "nrf21540", "npm1100",
+                                                      "npm1300", "npm6001", "applications"]
   - nrf/app_dev/bootloaders_dfu/mcuboot_nsib/bootloader_adding.html: ["kconfig"]
   - nrf/app_dev/bootloaders_dfu/mcuboot_nsib/bootloader_config.html: ["kconfig"]
-  - nrf/app_dev/device_guides/nrf91/index.html: ["nrf9160", "thingy91", "nrf9161", "nrf9151",
-                                                 "nrf9131", "development-kits", "dect-nr+",
-                                                 "prototyping-platforms"]
+  - nrf/app_dev/bootloaders_dfu/qspi_xip_split_image.html: ["nrf52840", "thingy53", "nrf5340"]
+  - nrf/app_dev/bootloaders_dfu/dfu_tools_mcumgr_cli.html: ["nrf91-series", "nrf70-series",
+                                                            "nrf54-series", "nrf53-series",
+                                                            "nrf52-series", "nrf7002", "nrf7001",
+                                                            "nrf7000", "nrf9160", "thingy91",
+                                                            "thingy91x", "nrf9161", "nrf9151",
+                                                            "nrf9131", "nrf54h20", "nrf54l15",
+                                                            "nrf54l05", "nrf54l10", "nrf5340",
+                                                            "thingy53", "nrf52840", "nrf52833",
+                                                            "nrf52832", "nrf52820", "nrf52811",
+                                                            "nrf52810", "nrf52805", "nrf21540",
+                                                            "npm1100", "npm1300", "npm6001"]
+  - nrf/app_dev/bootloaders_dfu/mcuboot_image_compression.html: ["nrf91-series", "nrf70-series",
+                                                                 "nrf54-series", "nrf53-series",
+                                                                 "nrf52-series", "nrf7002",
+                                                                 "nrf7001", "nrf7000", "nrf9160",
+                                                                 "thingy91", "thingy91x", "nrf9161",
+                                                                 "nrf9151", "nrf9131", "nrf54h20",
+                                                                 "nrf54l15", "nrf54l05", "nrf54l10",
+                                                                 "nrf5340", "thingy53", "nrf52840",
+                                                                 "nrf52833", "nrf52832", "nrf52820",
+                                                                 "nrf52811", "nrf52810", "nrf52805",
+                                                                 "nrf21540", "npm1100", "npm1300",
+                                                                 "npm6001"]
+  - nrf/app_dev/bootloaders_dfu/sysbuild_image_ids.html: ["nrf91-series", "nrf70-series",
+                                                          "nrf54-series", "nrf53-series",
+                                                          "nrf52-series", "nrf7002", "nrf7001",
+                                                          "nrf7000", "nrf9160", "thingy91",
+                                                          "thingy91x", "nrf9161", "nrf9151",
+                                                          "nrf9131", "nrf54h20", "nrf54l15",
+                                                          "nrf54l05", "nrf54l10", "nrf5340",
+                                                          "thingy53", "nrf52840", "nrf52833",
+                                                          "nrf52832", "nrf52820", "nrf52811",
+                                                          "nrf52810", "nrf52805", "nrf21540",
+                                                          "npm1100", "npm1300", "npm6001"]
+  - nrf/app_dev/device_guides/nrf91/index.html: ["nrf9160", "nrf9161", "thingy91", "thingy91x",
+                                                 "nrf9151", "nrf9131", "development-kits",
+                                                 "dect-nr+", "prototyping-platforms"]
   - nrf/app_dev/device_guides/nrf91/*.html: ["nrf91-series", "lte"]
-  - nrf/app_dev/device_guides/nrf91/nrf91_features.html: ["nrf9160", "thingy91", "nrf9151",
-                                                          "nrf9161", "nrf9131", "development-kits",
+  - nrf/app_dev/device_guides/nrf91/nrf91_features.html: ["nrf9160", "thingy91", "thingy91x",
+                                                          "nrf9151", "nrf9161", "nrf9131",
+                                                          "development-kits",
                                                           "prototyping-platforms", "dect-nr+"]
   - nrf/app_dev/device_guides/nrf91/nrf91_board_controllers.html: ["nrf9160", "nrf9161", "nrf9151",
                                                                    "nrf9161", "development-kits"]
@@ -94,24 +182,29 @@ mapping_topics:
                                                                            "development-kits"]
   - nrf/app_dev/device_guides/nrf91/thingy91_updating_fw_programmer.html: ["thingy91", "nrf9160",
                                                                            "prototyping-platforms"]
-  - nrf/app_dev/device_guides/nrf91/nrf91_building.html: ["nrf9160", "thingy91", "nrf9161",
-                                                          "nrf9151", "development-kits",
+  - nrf/app_dev/device_guides/nrf91/thingy91x_updating_fw_programmer.html: ["thingy91x", "nrf9151",
+                                                                            "prototyping-platforms"]
+  - nrf/app_dev/device_guides/nrf91/nrf91_building.html: ["nrf9160", "thingy91", "thingy91x",
+                                                          "nrf9161", "nrf9151", "development-kits",
                                                           "prototyping-platforms"]
-  - nrf/app_dev/device_guides/nrf91/nrf91_programming.html: ["nrf9160", "thingy91", "nrf9161",
-                                                             "nrf9151", "development-kits",
+  - nrf/app_dev/device_guides/nrf91/nrf91_programming.html: ["nrf9160", "thingy91", "thingy91x",
+                                                             "nrf9161", "nrf9151",
+                                                             "development-kits",
                                                              "prototyping-platforms"]
   - nrf/app_dev/device_guides/nrf91/nrf91_testing_at_client.html: ["nrf9160", "nrf9161", "nrf9151",
                                                                    "development-kits"]
-  - nrf/app_dev/device_guides/nrf91/nrf91_snippet.html: ["nrf9160", "thingy91", "nrf9161",
-                                                         "nrf9151", "nrf9131", "development-kits",
+  - nrf/app_dev/device_guides/nrf91/nrf91_snippet.html: ["nrf9160", "thingy91", "thingy91x",
+                                                         "nrf9161", "nrf9151", "nrf9131",
+                                                         "development-kits",
                                                          "prototyping-platforms"]
   - nrf/app_dev/device_guides/nrf91/nrf9160_external_flash.html: ["nrf9160", "development-kits"]
-  - nrf/app_dev/device_guides/nrf70/index.html: ["evaluation-kits"]
   - nrf/app_dev/device_guides/nrf70/*.html: ["nrf70-series", "nrf7002", "nrf7001", "nrf7000",
                                              "development-kits"]
+  - nrf/app_dev/device_guides/nrf70/index.html: ["evaluation-kits"]
   - nrf/app_dev/device_guides/nrf70/nrf7002ek_dev_guide.html: ["evaluation-kits"]
   - nrf/app_dev/device_guides/nrf70/constrained.html: ["kconfig"]
   - nrf/app_dev/device_guides/nrf54l/*.html: ["nrf54-series", "nrf54l15"]
+  - nrf/app_dev/device_guides/nrf54l/snippets.html: ["nrf54l05", "nrf54l10"]
   - nrf/app_dev/device_guides/nrf54h.html: ["nrf54-series", "nrf54h20", "development-kits"]
   - nrf/app_dev/device_guides/working_with_nrf/nrf54h/*.html: ["nrf54-series", "nrf54h20",
                                                                "development-kits"]
@@ -145,17 +238,18 @@ mapping_topics:
                                                "nrf7001", "nrf7000", "wifi"]
   - nrf/test_and_optimize.html: ["nrf91-series", "nrf70-series", "nrf54-series", "nrf53-series",
                                  "nrf52-series", "nrf7002", "nrf7001", "nrf7000", "nrf9160",
-                                 "thingy91", "nrf9161", "nrf9151", "nrf9131", "nrf54h20",
-                                 "nrf54l15", "nrf5340", "thingy53", "nrf52840", "nrf52833",
-                                 "nrf52832", "nrf52820", "nrf52811", "nrf52810", "nrf52805",
-                                 "nrf21540", "npm1100", "npm1300", "npm6001", "applications",
-                                 "samples"]
+                                 "thingy91", "thingy91x", "nrf9161", "nrf9151", "nrf9131",
+                                 "nrf54h20", "nrf54l15", "nrf54l05", "nrf54l10", "nrf5340",
+                                 "thingy53", "nrf52840", "nrf52833", "nrf52832", "nrf52820",
+                                 "nrf52811", "nrf52810", "nrf52805", "nrf21540", "npm1100",
+                                 "npm1300", "npm6001", "applications", "samples"]
   - nrf/test_and_optimize/*.html: ["nrf91-series", "nrf70-series", "nrf54-series", "nrf53-series",
                                    "nrf52-series", "nrf7002", "nrf7001", "nrf7000", "nrf9160",
-                                   "thingy91", "nrf9161", "nrf9151", "nrf9131", "nrf54h20",
-                                   "nrf54l15", "nrf5340", "thingy53", "nrf52840", "nrf52833",
-                                   "nrf52832", "nrf52820", "nrf52811", "nrf52810", "nrf52805",
-                                   "nrf21540", "npm1100", "npm1300", "npm6001"]
+                                   "thingy91", "thingy91x", "nrf9161", "nrf9151", "nrf9131",
+                                   "nrf54h20", "nrf54l15", "nrf54l05", "nrf54l10", "nrf5340",
+                                   "thingy53", "nrf52840", "nrf52833", "nrf52832", "nrf52820",
+                                   "nrf52811", "nrf52810", "nrf52805", "nrf21540", "npm1100",
+                                   "npm1300", "npm6001"]
   - nrf/test_and_optimize/optimizing/*.html: ["applications", "protocols"]
   - nrf/test_and_optimize/optimizing/memory.html: ["kconfig", "ble", "blemesh",
                                                    "gazell", "matter", "nfc", "thread", "zigbee",
@@ -208,10 +302,11 @@ mapping_topics:
   - nrf/protocols/wifi/station_mode/powersave.html: ["power-profiler-kit"]
   - nrf/applications.html: ["nrf91-series", "nrf70-series", "nrf54-series", "nrf53-series",
                             "nrf52-series", "nrf7002", "nrf7001", "nrf7000", "nrf9160", "thingy91",
-                            "nrf9161", "nrf9151", "nrf54h20", "nrf54l15", "nrf5340", "thingy53",
-                            "nrf52840", "nrf52833", "nrf52832", "nrf52820", "nrf52811", "nrf52810",
-                            "nrf52805", "nrf21540", "npm1100", "npm1300", "npm6001", "kconfig",
-                            "development-kits", "prototyping-platforms"]
+                            "thingy91x", "nrf9161", "nrf9151", "nrf54h20", "nrf54l15", "nrf54l05",
+                            "nrf54l10", "nrf5340", "thingy53", "nrf52840", "nrf52833", "nrf52832",
+                            "nrf52820", "nrf52811", "nrf52810", "nrf52805", "nrf21540", "npm1100",
+                            "npm1300", "npm6001", "kconfig", "development-kits",
+                            "prototyping-platforms"]
   - nrf/applications/*.html: ["applications", "kconfig"]
   - nrf/applications/connectivity_bridge/README.html: ["lte"]
   - nrf/applications/matter_bridge/*.html: ["matter", "wifi"]
@@ -226,10 +321,10 @@ mapping_topics:
   - nrf/applications/zigbee_weather_station/README.html: ["zigbee", "thingy53"]
   - nrf/samples.html: ["nrf91-series", "nrf70-series", "nrf54-series", "nrf53-series",
                        "nrf52-series", "nrf7002", "nrf7001", "nrf7000", "nrf9160", "thingy91",
-                       "nrf9161", "nrf9151", "nrf54h20", "nrf54l15", "nrf5340", "thingy53",
-                       "nrf52840", "nrf52833", "nrf52832", "nrf52820", "nrf52811", "nrf52810",
-                       "nrf52805", "nrf21540", "npm1100", "npm1300", "npm6001", "development-kits",
-                       "prototyping-platforms", "kconfig"]
+                       "thingy91x", "nrf9161", "nrf9151", "nrf54h20", "nrf54l15", "nrf54l05",
+                       "nrf54l10", "nrf5340", "thingy53", "nrf52840", "nrf52833", "nrf52832",
+                       "nrf52820", "nrf52811", "nrf52810", "nrf52805", "nrf21540", "npm1100",
+                       "npm1300", "npm6001", "development-kits", "prototyping-platforms", "kconfig"]
   - nrf/samples/*.html: ["samples", "kconfig"]
   - nrf/samples/amazon_sidewalk.html: ["sidewalk"]
   - nrf/samples/bl.html: ["ble"]
@@ -263,15 +358,15 @@ mapping_topics:
   - nrf/samples/wifi.html: ["wifi"]
   - nrf/samples/wifi/*.html: ["wifi"]
   - nrf/drivers/*.html: ["drivers"]
-  - nrf/drivers/wifi/nrf700x/nrf700x.html: ["wifi", "nrf70-series", "nrf7002", "nrf7001", "nrf7000"]
+  - nrf/drivers/wifi/*.html: ["wifi", "nrf70-series", "nrf7002", "nrf7001", "nrf7000"]
   - nrf/libraries/*.html: ["libraries", "kconfig"]
-  - nrf/libraries/bin/bt_ll_acs_nrf53/index.html: ["nrf5340", "development-kits"]
   - nrf/libraries/bin/lwm2m_carrier/*.html: ["nrf91-series", "nrf9161", "nrf9151", "nrf9160", "lte",
                                              "development-kits"]
   - nrf/libraries/bin/lwm2m_carrier/certification.html: ["certification"]
   - nrf/libraries/bluetooth_services/*.html: ["ble", "nrf52-series", "nrf52840", "nrf52833",
                                               "nrf52832", "nrf52820", "nrf52811", "nrf52810",
-                                              "nrf52805", "development-kits"]
+                                              "nrf52805", "nrf54-series", "nrf54h20", "nrf54l15",
+                                              "nrf54l05", "nrf54l10", "development-kits"]
   - nrf/libraries/bluetooth_services/mesh.html: ["blemesh"]
   - nrf/libraries/bluetooth_services/mesh/*.html: ["blemesh"]
   - nrf/libraries/gazell/*.html: ["gazell"]
@@ -305,10 +400,12 @@ mapping_topics:
   - nrf/libraries/others/fem_al.html: ["fem", "nrf21540"]
   - nrf/libraries/others/st25r3911b_nfc.html: ["nfc"]
   - nrf/libraries/zigbee/*.html: ["zigbee"]
+  - nrf/external_comp/bt_fast_pair.html: ["ble"]
   - nrf/external_comp/nrf_cloud.html: ["nrf-cloud"]
   - nrf/external_comp/avsystem.html: ["lte"]
   - nrf/releases_and_maturity/release_notes.html: ["release-notes"]
   - nrf/releases_and_maturity/releases/*.html: ["release-notes"]
+  - nrf/releases_and_maturity/abi_compatibility.html: ["nrf54h20"]
   - nrf/releases_and_maturity/software_maturity.html: ["sidewalk", "ble", "blemesh", "matter",
                                                        "thread", "zigbee", "wifi", "lte",
                                                        "dect-nr+"]
@@ -320,14 +417,15 @@ mapping_topics:
   - nrfxlib/lc3/*.html: ["nrf5340", "ble"]
   - nrfxlib/nrf_modem/*.html: ["nrf91-series", "nrf9160", "nrf9161", "nrf9151", "lte", "dect-nr+"]
   - nrfxlib/nrf_modem/doc/at_interface.html: ["at-commands"]
-  - nrfxlib/nrf_802154/README.html: ["nrf52-series", "nrf52840", "nrf52833", "nrf52832", "nrf52820",
-                                     "nrf52811", "nrf52810", "nrf52805", "multiprotocol"]
+  - nrfxlib/nrf_802154/README.html: ["nrf52-series", "nrf54-series", "nrf54h20", "nrf54l15",
+                                     "nrf54l05", "nrf54l10", "nrf52840", "nrf52833", "nrf52832",
+                                     "nrf52820", "nrf52811", "nrf52810", "nrf52805",
+                                     "multiprotocol"]
   - nrfxlib/nrf_802154/*.html: ["multiprotocol"]
   - nrfxlib/nrf_fuel_gauge/*.html: ["pmic", "npm1100", "npm1300", "npm6001", "evaluation-kits"]
   - nrfxlib/nfc/*.html: ["nrf52-series", "nrf53-series", "nfc"]
   - nrfxlib/openthread/*.html: ["thread"]
   - nrfxlib/nrf_dm/*.html: ["nrf52-series", "nrf53-series"]
-  - nrfxlib/nrf_wifi/*.html: ["wifi", "nrf70-series", "nrf7002", "nrf7001", "nrf7000", "drivers"]
   - nrfxlib/softdevice_controller/*.html: ["nrf52-series", "nrf53-series", "ble"]
   - nrfxlib/zboss/*.html: ["kconfig", "zigbee"]
   - nrfx/*.html: ["drivers"]


### PR DESCRIPTION
Backport 382805bbc81b7e6ef290732d653de2a3e32c2f20 from #18462.