### PR TITLE
[Backport v2.8-branch] doc: zigbee: add deprecation note to all Zigbee-related pages

### DIFF
--- a/applications/zigbee_weather_station/README.rst
+++ b/applications/zigbee_weather_station/README.rst
@@ -7,6 +7,8 @@ Thingy:53: Zigbee weather station
    :local:
    :depth: 2
 
+.. include:: /includes/zigbee_deprecation.txt
+
 The Zigbee weather station is an out-of-the-box application for the Nordic Thingy:53.
 It allows you to build a weather station that uses the Thingy:53's sensors to remotely gather different kinds of data, such as temperature, air pressure, and relative humidity.
 The application uses the Zigbee protocol, meaning the device can be paired and controlled remotely over a Zigbee network.

--- a/doc/nrf/includes/zigbee_deprecation.txt
+++ b/doc/nrf/includes/zigbee_deprecation.txt
@@ -1,0 +1,4 @@
+.. note::
+   Support for Zigbee R22 has been deprecated in |NCS| v2.8.0 and it will be removed in one of the future releases, following the :ref:`deprecation policy <api_deprecation>`.
+   As a result, the nRF52833, nRF52840 and nRF5340 SoCs are not recommended for new Zigbee designs.
+   Experimental support for Zigbee R23 is available for the nRF54L Series as an `nRF Connect SDK Add-on <nRF Connect SDK Add-ons_>`_.

--- a/doc/nrf/libraries/zigbee/index.rst
+++ b/doc/nrf/libraries/zigbee/index.rst
@@ -3,6 +3,8 @@
 Libraries for Zigbee
 ####################
 
+.. include:: /includes/zigbee_deprecation.txt
+
 |zigbee_description|
 See the :ref:`ug_zigbee` user guide for an overview of the technology.
 

--- a/doc/nrf/libraries/zigbee/osif.rst
+++ b/doc/nrf/libraries/zigbee/osif.rst
@@ -7,6 +7,8 @@ Zigbee ZBOSS OSIF
    :local:
    :depth: 2
 
+.. include:: /includes/zigbee_deprecation.txt
+
 The Zigbee ZBOSS OSIF layer subsystem acts as the linking layer between the :ref:`nrfxlib:zboss` and the |NCS|.
 
 .. _zigbee_osif_configuration:

--- a/doc/nrf/libraries/zigbee/shell.rst
+++ b/doc/nrf/libraries/zigbee/shell.rst
@@ -7,6 +7,8 @@ Zigbee shell
    :local:
    :depth: 2
 
+.. include:: /includes/zigbee_deprecation.txt
+
 The Zigbee shell library implements a set of Zigbee shell commands that allow you to control the device behavior and perform operations in the Zigbee network, such as steering the network, discovering devices, and reading the network properties.
 Enabling a device to work with these commands simplifies testing and debugging of an existing network and reduces the amount of reprogramming operations.
 

--- a/doc/nrf/libraries/zigbee/zigbee_app_utils.rst
+++ b/doc/nrf/libraries/zigbee/zigbee_app_utils.rst
@@ -7,6 +7,8 @@ Zigbee application utilities
    :local:
    :depth: 2
 
+.. include:: /includes/zigbee_deprecation.txt
+
 Zigbee application utilities library provides a set of components that are ready for use in Zigbee applications:
 
 * :ref:`lib_zigbee_signal_handler` for handling common ZBOSS stack signals.

--- a/doc/nrf/libraries/zigbee/zigbee_error_handler.rst
+++ b/doc/nrf/libraries/zigbee/zigbee_error_handler.rst
@@ -7,6 +7,8 @@ Zigbee error handler
    :local:
    :depth: 2
 
+.. include:: /includes/zigbee_deprecation.txt
+
 The Zigbee error handler library provides a set of macros that can be used to assert on nrfxlib's :ref:`nrfxlib:zboss` API return codes.
 The assertion is implemented by a call to the :c:func:`zb_osif_abort` function.
 Additionally, you can enable the library to log the error code name before the assertion.

--- a/doc/nrf/libraries/zigbee/zigbee_fota.rst
+++ b/doc/nrf/libraries/zigbee/zigbee_fota.rst
@@ -7,6 +7,8 @@ Zigbee FOTA
    :local:
    :depth: 2
 
+.. include:: /includes/zigbee_deprecation.txt
+
 The Zigbee firmware over-the-air (Zigbee FOTA) library provides Zigbee endpoint definition, which implements clusters responsible for transferring a firmware file through the Zigbee network.
 The received data is passed as an upgrade candidate through the :ref:`lib_dfu_multi_image` library API to the :ref:`lib_dfu_target`.
 

--- a/doc/nrf/libraries/zigbee/zigbee_logger_eprxzcl.rst
+++ b/doc/nrf/libraries/zigbee/zigbee_logger_eprxzcl.rst
@@ -7,6 +7,8 @@ Zigbee endpoint logger
    :local:
    :depth: 2
 
+.. include:: /includes/zigbee_deprecation.txt
+
 .. zigbee_logger_endpoint_intro_start
 
 The Zigbee endpoint logger library provides the :c:func:`zigbee_logger_eprxzcl_ep_handler` function.

--- a/doc/nrf/libraries/zigbee/zigbee_zcl_scenes.rst
+++ b/doc/nrf/libraries/zigbee/zigbee_zcl_scenes.rst
@@ -7,6 +7,8 @@ Zigbee ZCL scene helper
    :local:
    :depth: 2
 
+.. include:: /includes/zigbee_deprecation.txt
+
 The Zigbee ZCL scene helper library provides a set of functions that implement the callbacks required by the ZCL scene cluster in the application.
 You can use this library to implement these mandatory callbacks and save the configured scenes in the non-volatile memory.
 For this purpose, it uses Zephyr's :ref:`settings_api` subsystem.

--- a/doc/nrf/protocols/zigbee/architectures.rst
+++ b/doc/nrf/protocols/zigbee/architectures.rst
@@ -7,6 +7,8 @@ Zigbee architectures
    :local:
    :depth: 2
 
+.. include:: /includes/zigbee_deprecation.txt
+
 This page describes the platform designs that are possible with the Zigbee stack on Nordic Semiconductor devices.
 
 The designs are described from the least to the most complex, that is from simple applications that consist of a single chip running single or multiple protocols to scenarios in which the nRF SoC acts as a network co-processor when the application is running on a much more powerful host processor.

--- a/doc/nrf/protocols/zigbee/commissioning.rst
+++ b/doc/nrf/protocols/zigbee/commissioning.rst
@@ -7,6 +7,8 @@ Zigbee commissioning
    :local:
    :depth: 2
 
+.. include:: /includes/zigbee_deprecation.txt
+
 Commissioning is a process that allows a new Zigbee device to join a Zigbee network.
 The device is configured into the network, so that it can start communicating with other network nodes.
 If there is no network to join, the commissioning procedure ensures that a new network is created.

--- a/doc/nrf/protocols/zigbee/configuring.rst
+++ b/doc/nrf/protocols/zigbee/configuring.rst
@@ -7,6 +7,8 @@ Configuring Zigbee in |NCS|
    :local:
    :depth: 2
 
+.. include:: /includes/zigbee_deprecation.txt
+
 This page describes what is needed to start working with Zigbee in the |NCS|.
 
 .. _zigbee_ug_libs:

--- a/doc/nrf/protocols/zigbee/configuring_libraries.rst
+++ b/doc/nrf/protocols/zigbee/configuring_libraries.rst
@@ -7,6 +7,8 @@ Configuring Zigbee libraries in |NCS|
    :local:
    :depth: 2
 
+.. include:: /includes/zigbee_deprecation.txt
+
 The Zigbee protocol in |NCS| can be customized by enabling and configuring several :ref:`Zigbee libraries <lib_zigbee>`.
 This page lists options and steps required for configuring each of them.
 

--- a/doc/nrf/protocols/zigbee/configuring_zboss_traces.rst
+++ b/doc/nrf/protocols/zigbee/configuring_zboss_traces.rst
@@ -7,6 +7,8 @@ Configuring ZBOSS traces in |NCS|
    :local:
    :depth: 2
 
+.. include:: /includes/zigbee_deprecation.txt
+
 The :ref:`nrfxlib:zboss` (ZBOSS stack) comes included in the |NCS| in a set of precompiled libraries, which can complicate the debugging process.
 To help with that, the ZBOSS stack can be configured to print trace logs that allow you to trace the stack behavior.
 This page describes how to enable and configure ZBOSS trace logs.

--- a/doc/nrf/protocols/zigbee/index.rst
+++ b/doc/nrf/protocols/zigbee/index.rst
@@ -3,6 +3,8 @@
 Zigbee
 ######
 
+.. include:: /includes/zigbee_deprecation.txt
+
 .. zigbee_ug_intro_start
 
 Zigbee is a portable, low-power software networking protocol that provides connectivity over a mesh network based on the IEEE 802.15.4 radio protocol.

--- a/doc/nrf/protocols/zigbee/memory.rst
+++ b/doc/nrf/protocols/zigbee/memory.rst
@@ -7,6 +7,8 @@ Zigbee memory requirements
    :local:
    :depth: 2
 
+.. include:: /includes/zigbee_deprecation.txt
+
 This page provides information about the amount of flash memory and RAM that is required by :ref:`zigbee_samples`, as well as stack memory requirements for ``main`` and ``zboss`` threads.
 Use it to check if your application has enough space for a given configuration.
 Values are provided for :ref:`ZBOSS libraries <nrfxlib:zboss>`.

--- a/doc/nrf/protocols/zigbee/other_ecosystems.rst
+++ b/doc/nrf/protocols/zigbee/other_ecosystems.rst
@@ -7,6 +7,8 @@ Configuring Zigbee samples for other ecosystems
    :local:
    :depth: 2
 
+.. include:: /includes/zigbee_deprecation.txt
+
 You can configure :ref:`zigbee_samples` in |NCS| that you program onto Nordic Semiconductor's hardware platforms to make them work within Zigbee networks of other ecosystems, such as Amazon Alexa, IKEA TRÅDFRI, or Philips Hue.
 This is only possible for Zigbee networks of other ecosystems that include the Trust Center.
 

--- a/doc/nrf/protocols/zigbee/qsg.rst
+++ b/doc/nrf/protocols/zigbee/qsg.rst
@@ -7,6 +7,8 @@ Zigbee quick start guide
    :local:
    :depth: 2
 
+.. include:: /includes/zigbee_deprecation.txt
+
 This guide demonstrates some of the basic concepts of the Zigbee network using the |NCS| and the |nRFVSC|.
 It guides you through the installation of the required tools and programming of the required samples.
 

--- a/doc/nrf/protocols/zigbee/supported_features.rst
+++ b/doc/nrf/protocols/zigbee/supported_features.rst
@@ -7,6 +7,8 @@ Supported Zigbee features
    :local:
    :depth: 2
 
+.. include:: /includes/zigbee_deprecation.txt
+
 The |NCS|'s Zigbee protocol uses the ZBOSS library, a third-party precompiled Zigbee stack.
 It includes all mandatory features of the |zigbee_version| specification and provides an Application Programming Interface (API) to access different services.
 The stack comes with the following features:

--- a/doc/nrf/protocols/zigbee/tools.rst
+++ b/doc/nrf/protocols/zigbee/tools.rst
@@ -7,6 +7,8 @@ Zigbee tools
    :local:
    :depth: 2
 
+.. include:: /includes/zigbee_deprecation.txt
+
 The tools listed on this page can be helpful when developing your Zigbee application with the |NCS|.
 
 .. _ug_zigbee_tools_sniffer:

--- a/doc/nrf/releases_and_maturity/software_maturity.rst
+++ b/doc/nrf/releases_and_maturity/software_maturity.rst
@@ -1126,6 +1126,8 @@ The following table indicates the software maturity levels of the support for ea
 Zigbee feature support
 **********************
 
+.. include:: /includes/zigbee_deprecation.txt
+
 The following table indicates the software maturity levels of the support for each Zigbee feature:
 
 .. toggle::

--- a/doc/nrf/samples/zigbee.rst
+++ b/doc/nrf/samples/zigbee.rst
@@ -3,6 +3,8 @@
 Zigbee samples
 ##############
 
+.. include:: /includes/zigbee_deprecation.txt
+
 The nRF Connect SDK provides the following samples showcasing the :ref:`ug_zigbee` protocol.
 You can build the samples for various boards and configure them for different usage scenarios.
 

--- a/samples/zigbee/light_bulb/README.rst
+++ b/samples/zigbee/light_bulb/README.rst
@@ -7,6 +7,8 @@ Zigbee: Light bulb
    :local:
    :depth: 2
 
+.. include:: /includes/zigbee_deprecation.txt
+
 This :ref:`Zigbee <ug_zigbee>` Light bulb sample demonstrates a simple light bulb whose brightness can be adjusted by another device.
 
 You can use this sample with the :ref:`Zigbee Network coordinator <zigbee_network_coordinator_sample>` and the :ref:`Zigbee Light switch <zigbee_light_switch_sample>` to set up a basic Zigbee network.

--- a/samples/zigbee/light_switch/README.rst
+++ b/samples/zigbee/light_switch/README.rst
@@ -7,6 +7,8 @@ Zigbee: Light switch
    :local:
    :depth: 2
 
+.. include:: /includes/zigbee_deprecation.txt
+
 You can use the :ref:`Zigbee <ug_zigbee>` Light switch sample to change the state of light sources on other devices within the same Zigbee network.
 
 You can use it together with the :ref:`Zigbee Network coordinator <zigbee_network_coordinator_sample>` and the :ref:`Zigbee Light bulb <zigbee_light_bulb_sample>` samples to set up a basic Zigbee network.

--- a/samples/zigbee/ncp/README.rst
+++ b/samples/zigbee/ncp/README.rst
@@ -7,6 +7,8 @@ Zigbee: NCP
    :local:
    :depth: 2
 
+.. include:: /includes/zigbee_deprecation.txt
+
 The :ref:`Zigbee <ug_zigbee>` NCP sample demonstrates the usage of Zigbee's :ref:`ug_zigbee_platform_design_ncp_details` architecture.
 
 Together with the source code from :ref:`ug_zigbee_tools_ncp_host`, you can use this sample to create a complete and functional Zigbee device.

--- a/samples/zigbee/network_coordinator/README.rst
+++ b/samples/zigbee/network_coordinator/README.rst
@@ -7,6 +7,8 @@ Zigbee: Network coordinator
    :local:
    :depth: 2
 
+.. include:: /includes/zigbee_deprecation.txt
+
 This :ref:`Zigbee <ug_zigbee>` Network coordinator sample establishes the Zigbee network and commissions Zigbee devices that want to join the network.
 
 You can use this sample together with the :ref:`Zigbee Light bulb <zigbee_light_bulb_sample>` and the :ref:`Zigbee Light switch <zigbee_light_switch_sample>` to set up a basic Zigbee network.

--- a/samples/zigbee/shell/README.rst
+++ b/samples/zigbee/shell/README.rst
@@ -7,6 +7,8 @@ Zigbee: Shell
    :local:
    :depth: 2
 
+.. include:: /includes/zigbee_deprecation.txt
+
 This :ref:`Zigbee <ug_zigbee>` Shell sample demonstrates a Zigbee router (with the possibility of being a coordinator) that uses the :ref:`lib_zigbee_shell` library for interaction.
 
 You can use this sample for several purposes, including:

--- a/samples/zigbee/template/README.rst
+++ b/samples/zigbee/template/README.rst
@@ -7,6 +7,8 @@ Zigbee: Template
    :local:
    :depth: 2
 
+.. include:: /includes/zigbee_deprecation.txt
+
 This :ref:`Zigbee <ug_zigbee>` sample is a minimal implementation of the Zigbee Router role.
 
 You can use this sample as the starting point for developing your own Zigbee device.

--- a/subsys/zigbee/Kconfig
+++ b/subsys/zigbee/Kconfig
@@ -5,7 +5,8 @@
 #
 
 menuconfig ZIGBEE
-	bool "Enable Zigbee stack"
+	bool "Enable Zigbee stack [DEPRECATED]"
+	select DEPRECATED
 	imply FPU
 	select APP_LINK_WITH_ZBOSS
 	select PM_SINGLE_IMAGE


### PR DESCRIPTION
Backport f952ec4a69495d42b32a95da396947622f329cb9 from #18705.