### PR TITLE
scripts: west_commands: genboard: support current NCS only

### DIFF
--- a/scripts/west_commands/genboard/config.yml
+++ b/scripts/west_commands/genboard/config.yml
@@ -37,7 +37,6 @@ products:
           - name: qdaa
             ram: 128
             flash: 512
-            since: 2.5.0
           - name: qiaa
             ram: 128
             flash: 512
@@ -46,7 +45,6 @@ products:
           - name: qfaa
             ram: 256
             flash: 1024
-            since: 2.5.0
           - name: qiaa
             ram: 256
             flash: 1024
@@ -68,7 +66,6 @@ products:
       - name: nrf54l15
         variants:
           - name: qfaa
-            since: 2.7.0
             cores:
               - name: cpuapp
                 arch: arm
@@ -82,14 +79,12 @@ products:
             ram: 256
             flash: 1024
             ns: true
-            since: 2.5.0
       - name: nrf9151
         variants:
           - name: laca
             ram: 256
             flash: 1024
             ns: true
-            since: 2.6.0
       - name: nrf9160
         variants:
           - name: sica
@@ -99,7 +94,6 @@ products:
       - name: nrf9161
         variants:
           - name: laca
-            since: 2.5.0
             ram: 256
             flash: 1024
             ns: true

--- a/scripts/west_commands/genboard/templates/nrf52/Kconfig.board.jinja2
+++ b/scripts/west_commands/genboard/templates/nrf52/Kconfig.board.jinja2
@@ -1,7 +1,2 @@
 config BOARD_{{ board | upper }}
-{% if ncs_version < hwmv2_since %}
-	bool "{{ board_desc }}"
-	depends on SOC_{{ soc | upper }}_{{ variant | upper}}
-{% else %}
 	select SOC_{{ soc | upper }}_{{ variant | upper}}
-{% endif %}

--- a/scripts/west_commands/genboard/templates/nrf52/Kconfig.defconfig.jinja2
+++ b/scripts/west_commands/genboard/templates/nrf52/Kconfig.defconfig.jinja2
@@ -1,10 +1,5 @@
 if BOARD_{{ board | upper }}
 
-{% if ncs_version < hwmv2_since %}
-config BOARD
-	default "{{ board }}"
-
-{% endif %}
 config BT_CTLR
 	default BT
 

--- a/scripts/west_commands/genboard/templates/nrf52/board.cmake.jinja2
+++ b/scripts/west_commands/genboard/templates/nrf52/board.cmake.jinja2
@@ -2,9 +2,7 @@ board_runner_args(jlink "--device={{ soc | replace("nrf", "nRF") }}_xx{{ variant
 board_runner_args(pyocd "--target={{ soc }}" "--frequency=4000000")
 
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
-{% if ncs_version >= (2, 4, 0) %}
 include(${ZEPHYR_BASE}/boards/common/nrfutil.board.cmake)
-{% endif %}
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd-nrf5.board.cmake)

--- a/scripts/west_commands/genboard/templates/nrf52/board.dts.jinja2
+++ b/scripts/west_commands/genboard/templates/nrf52/board.dts.jinja2
@@ -25,27 +25,6 @@
 		};
 
 {% if soc == "nrf52840" %}
-{% if ncs_version <= (2, 4, 0) %}
-		slot0_partition: partition@c000 {
-			label = "image-0";
-			reg = <0x0000c000 DT_SIZE_K(412)>;
-		};
-
-		slot1_partition: partition@73000 {
-			label = "image-1";
-			reg = <0x00073000 DT_SIZE_K(412)>;
-		};
-
-		scratch_partition: partition@da000 {
-			label = "image-scratch";
-			reg = <0xda000 DT_SIZE_K(120)>;
-		};
-
-		storage_partition: partition@f8000 {
-			label = "storage";
-			reg = <0x000f8000 DT_SIZE_K(32)>;
-		};
-{% else %}
 		slot0_partition: partition@c000 {
 			label = "image-0";
 			reg = <0x0000c000 DT_SIZE_K(472)>;
@@ -60,29 +39,7 @@
 			label = "storage";
 			reg = <0x000f8000 DT_SIZE_K(32)>;
 		};
-{% endif %}
 {% elif soc == "nrf52833" or soc == "nrf52832" %}
-{% if ncs_version <= (2, 4, 0) %}
-		slot0_partition: partition@c000 {
-			label = "image-0";
-			reg = <0x0000c000 DT_SIZE_K(200)>;
-		};
-
-		slot1_partition: partition@3e000 {
-			label = "image-1";
-			reg = <0x0003e000 DT_SIZE_K(200)>;
-		};
-
-		scratch_partition: partition@70000 {
-			label = "image-scratch";
-			reg = <0x70000 DT_SIZE_K(40)>;
-		};
-
-		storage_partition: partition@7a000 {
-			label = "storage";
-			reg = <0x0007a000 DT_SIZE_K(24)>;
-		};
-{% else %}
 		slot0_partition: partition@c000 {
 			label = "image-0";
 			reg = <0x0000c000 DT_SIZE_K(220)>;
@@ -97,7 +54,6 @@
 			label = "storage";
 			reg = <0x0007a000 DT_SIZE_K(24)>;
 		};
-{% endif %}
 {% elif soc == "nrf52820" %}
 		slot0_partition: partition@c000 {
 			label = "image-0";
@@ -114,27 +70,6 @@
 			reg = <0x0003a000 DT_SIZE_K(24)>;
 		};
 {% elif soc == "nrf52811" or soc == "nrf52810" or soc == "nrf52805" %}
-{% if ncs_version <= (2, 4, 0) %}
-		slot0_partition: partition@c000 {
-			label = "image-0";
-			reg = <0x0000c000 DT_SIZE_K(52)>;
-		};
-
-		slot1_partition: partition@19000 {
-			label = "image-1";
-			reg = <0x0001a000 DT_SIZE_K(52)>;
-		};
-
-		scratch_partition: partition@26000 {
-			label = "image-scratch";
-			reg = <0x26000 DT_SIZE_K(12)>;
-		};
-
-		storage_partition: partition@29000 {
-			label = "storage";
-			reg = <0x00029000 DT_SIZE_K(28)>;
-		};
-{% else %}
 		slot0_partition: partition@c000 {
 			label = "image-0";
 			reg = <0x0000c000 DT_SIZE_K(56)>;
@@ -149,8 +84,6 @@
 			label = "storage";
 			reg = <0x00028000 DT_SIZE_K(32)>;
 		};
-{% endif %}
-
 {% endif %}
 	};
 };

--- a/scripts/west_commands/genboard/templates/nrf52/board_defconfig.jinja2
+++ b/scripts/west_commands/genboard/templates/nrf52/board_defconfig.jinja2
@@ -1,12 +1,2 @@
-{% if ncs_version < hwmv2_since %}
-CONFIG_SOC_SERIES_{{ series | upper }}X=y
-CONFIG_SOC_{{ soc | upper }}_{{ variant | upper }}=y
-CONFIG_BOARD_{{ board | upper }}=y
-
-{% endif %}
 CONFIG_ARM_MPU=y
 CONFIG_HW_STACK_PROTECTION=y
-
-{% if ncs_version <= (2, 6, 0) %}
-CONFIG_PINCTRL=y
-{% endif %}

--- a/scripts/west_commands/genboard/templates/nrf52/board_twister.yml.jinja2
+++ b/scripts/west_commands/genboard/templates/nrf52/board_twister.yml.jinja2
@@ -1,8 +1,4 @@
-{% if ncs_version < hwmv2_since %}
-identifier: {{ board }}
-{% else %}
 identifier: {{ board }}/{{ soc }}
-{% endif %}
 name: {{ board_desc }}
 vendor: {{ vendor }}
 type: mcu
@@ -11,5 +7,4 @@ ram: {{ target["ram"] }}
 flash: {{ target["flash"] }}
 toolchain:
   - zephyr
-supported:
-  - gpio
+supported: []

--- a/scripts/west_commands/genboard/templates/nrf53/Kconfig.board.jinja2
+++ b/scripts/west_commands/genboard/templates/nrf53/Kconfig.board.jinja2
@@ -1,20 +1,4 @@
-{% if ncs_version < hwmv2_since %}
-if SOC_NRF5340_CPUAPP_QKAA
-
-config BOARD_{{ board | upper }}_CPUAPP
-	bool "{{ board_desc }} (CPUAPP)"
-
-config BOARD_{{ board | upper }}_CPUAPP_NS
-	bool "{{ board_desc }} (CPUAPP Non-Secure)"
-
-endif # SOC_NRF5340_CPUAPP_QKAA
-
-config BOARD_{{ board | upper }}_CPUNET
-	bool "{{ board_desc }} (CPUNET)"
-	depends on SOC_NRF5340_CPUNET_QKAA
-{% else %}
 config BOARD_{{ board | upper }}
 	select SOC_NRF5340_CPUAPP_QKAA if BOARD_{{ board | upper }}_NRF5340_CPUAPP
 	select SOC_NRF5340_CPUAPP_QKAA if BOARD_{{ board | upper }}_NRF5340_CPUAPP_NS
 	select SOC_NRF5340_CPUNET_QKAA if BOARD_{{ board | upper }}_NRF5340_CPUNET
-{% endif %}

--- a/scripts/west_commands/genboard/templates/nrf53/Kconfig.defconfig.jinja2
+++ b/scripts/west_commands/genboard/templates/nrf53/Kconfig.defconfig.jinja2
@@ -1,14 +1,5 @@
-{% if ncs_version < hwmv2_since %}
-if  BOARD_{{ board | upper }}_CPUAPP || BOARD_{{ board | upper }}_CPUAPP_NS
-{% else %}
 if  BOARD_{{ board | upper }}_NRF5340_CPUAPP || BOARD_{{ board | upper }}_NRF5340_CPUAPP_NS
-{% endif %}
 
-{% if ncs_version < hwmv2_since %}
-config BOARD
-	default "{{ board }}_cpuapp"
-
-{% endif %}
 # Code Partition:
 #
 # For the secure version of the board the firmware is linked at the beginning
@@ -35,11 +26,7 @@ config BOARD
 DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
 DT_CHOSEN_Z_SRAM_PARTITION := zephyr,sram-secure-partition
 
-{% if ncs_version < hwmv2_since %}
-if BOARD_{{ board | upper }}_CPUAPP && TRUSTED_EXECUTION_SECURE
-{% else %}
 if BOARD_{{ board | upper }}_NRF5340_CPUAPP && TRUSTED_EXECUTION_SECURE
-{% endif %}
 
 config FLASH_LOAD_SIZE
 	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
@@ -47,17 +34,9 @@ config FLASH_LOAD_SIZE
 config SRAM_SIZE
 	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_SRAM_PARTITION),0,K)
 
-{% if ncs_version < hwmv2_since %}
-endif # BOARD_{{ board | upper }}_CPUAPP && TRUSTED_EXECUTION_SECURE
-{% else %}
 endif # BOARD_{{ board | upper }}_NRF5340_CPUAPP && TRUSTED_EXECUTION_SECURE
-{% endif %}
 
-{% if ncs_version < hwmv2_since %}
-if BOARD_{{ board | upper }}_CPUAPP_NS
-{% else %}
 if BOARD_{{ board | upper }}_NRF5340_CPUAPP_NS
-{% endif %}
 
 config FLASH_LOAD_OFFSET
 	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
@@ -65,65 +44,20 @@ config FLASH_LOAD_OFFSET
 config FLASH_LOAD_SIZE
 	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
 
-{% if ncs_version < hwmv2_since %}
-endif # BOARD_{{ board | upper }}_CPUAPP_NS
-{% else %}
 endif # BOARD_{{ board | upper }}_NRF5340_CPUAPP_NS
-{% endif %}
 
-{% if ncs_version >= (2, 7, 99) %}
 config BT_HCI_IPC
 	default y if BT
 
 config HEAP_MEM_POOL_ADD_SIZE_BOARD
 	int
 	default 4096 if BT_HCI_IPC
-{% elif ncs_version >= (2, 7, 0) %}
-choice BT_HCI_BUS_TYPE
-	default BT_HCI_IPC if BT
-endchoice
 
-config HEAP_MEM_POOL_ADD_SIZE_BOARD
-	int
-	default 4096 if BT_HCI_IPC
-{% elif ncs_version >= (2, 6, 0) %}
-choice BT_HCI_BUS_TYPE
-	default BT_HCI_IPC if BT
-endchoice
-
-config HEAP_MEM_POOL_SIZE
-	default 4096 if BT_HCI_IPC
-{% else %}
-choice BT_HCI_BUS_TYPE
-	default BT_RPMSG if BT
-endchoice
-
-config HEAP_MEM_POOL_SIZE
-	default 4096 if BT_RPMSG
-{% endif %}
-
-{% if ncs_version < hwmv2_since %}
-endif #  BOARD_{{ board | upper }}_CPUAPP || BOARD_{{ board | upper }}_CPUAPP_NS
-{% else %}
 endif #  BOARD_{{ board | upper }}_NRF5340_CPUAPP || BOARD_{{ board | upper }}_NRF5340_CPUAPP_NS
-{% endif %}
 
-{% if ncs_version < hwmv2_since %}
-if BOARD_{{ board | upper }}_CPUNET
-{% else %}
 if BOARD_{{ board | upper }}_NRF5340_CPUNET
-{% endif %}
 
-{% if ncs_version < hwmv2_since %}
-config BOARD
-	default "{{ board }}_cpunet"
-
-{% endif %}
 config BT_CTLR
 	default y if BT
 
-{% if ncs_version < hwmv2_since %}
-endif # BOARD_{{ board | upper }}_CPUNET
-{% else %}
 endif # BOARD_{{ board | upper }}_NRF5340_CPUNET
-{% endif %}

--- a/scripts/west_commands/genboard/templates/nrf53/board-cpuapp_partitioning.dtsi.jinja2
+++ b/scripts/west_commands/genboard/templates/nrf53/board-cpuapp_partitioning.dtsi.jinja2
@@ -44,23 +44,11 @@
 			reg = <0x000c0000 DT_SIZE_K(192)>;
 		};
 
-{% if ncs_version <= (2, 4, 0) %}
-		scratch_partition: partition@f0000 {
-			label = "image-scratch";
-			reg = <0x000f0000 DT_SIZE_K(40)>;
-		};
-
-		storage_partition: partition@f8000 {
-			label = "storage";
-			reg = <0x000f8000 DT_SIZE_K(24)>;
-		};
-{% else %}
 		/* 0xf0000 to 0xf7fff reserved for TF-M partitions */
 		storage_partition: partition@f8000 {
 			label = "storage";
 			reg = <0x000f8000 DT_SIZE_K(32)>;
 		};
-{% endif %}
 	};
 };
 

--- a/scripts/west_commands/genboard/templates/nrf53/board.cmake.jinja2
+++ b/scripts/west_commands/genboard/templates/nrf53/board.cmake.jinja2
@@ -1,8 +1,4 @@
-{% if ncs_version < hwmv2_since %}
-if(CONFIG_BOARD_{{ board | upper }}_CPUAPP_NS)
-{% else %}
 if(CONFIG_BOARD_{{ board | upper }}_NRF5340_CPUAPP_NS)
-{% endif %}
   set(TFM_PUBLIC_KEY_FORMAT "full")
 endif()
 
@@ -10,24 +6,14 @@ if(CONFIG_TFM_FLASH_MERGED_BINARY)
   set_property(TARGET runners_yaml_props_target PROPERTY hex_file "${CMAKE_BINARY_DIR}/tfm_merged.hex")
 endif()
 
-{% if ncs_version < hwmv2_since %}
-if(CONFIG_BOARD_{{ board | upper }}_CPUAPP OR CONFIG_BOARD_{{ board | upper }}_CPUAPP_NS)
-{% else %}
 if(CONFIG_BOARD_{{ board | upper }}_NRF5340_CPUAPP OR CONFIG_BOARD_{{ board | upper }}_NRF5340_CPUAPP_NS)
-{% endif %}
   board_runner_args(jlink "--device=nrf5340_xxaa_app" "--speed=4000")
 endif()
 
-{% if ncs_version < hwmv2_since %}
-if(CONFIG_BOARD_{{ board | upper }}_CPUNET)
-{% else %}
 if(CONFIG_BOARD_{{ board | upper }}_NRF5340_CPUNET)
-{% endif %}
   board_runner_args(jlink "--device=nrf5340_xxaa_net" "--speed=4000")
 endif()
 
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
-{% if ncs_version >= (2, 4, 0) %}
 include(${ZEPHYR_BASE}/boards/common/nrfutil.board.cmake)
-{% endif %}
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/scripts/west_commands/genboard/templates/nrf53/board_defconfig.jinja2
+++ b/scripts/west_commands/genboard/templates/nrf53/board_defconfig.jinja2
@@ -1,9 +1,3 @@
-{% if ncs_version < hwmv2_since %}
-CONFIG_SOC_SERIES_NRF53X=y
-CONFIG_SOC_NRF5340_{{ target['core'] | upper }}_{{ variant | upper }}=y
-CONFIG_BOARD_{{ board | upper }}_{{ target['core'] | upper }}=y
-
-{% endif %}
 CONFIG_ARM_MPU=y
 CONFIG_HW_STACK_PROTECTION=y
 
@@ -12,8 +6,4 @@ CONFIG_ARM_TRUSTZONE_M=y
 {% if target.get('ns') %}
 CONFIG_TRUSTED_EXECUTION_NONSECURE=y
 {% endif %}
-
-{% endif %}
-{% if ncs_version <= (2, 6, 0) %}
-CONFIG_PINCTRL=y
 {% endif %}

--- a/scripts/west_commands/genboard/templates/nrf53/board_twister.yml.jinja2
+++ b/scripts/west_commands/genboard/templates/nrf53/board_twister.yml.jinja2
@@ -1,8 +1,4 @@
-{% if ncs_version < hwmv2_since %}
-identifier: {{ board }}_{{ target['core'] }}
-{% else %}
 identifier: {{ board }}/nrf5340/{{ target['core'] }}{{ '/ns' if target['ns'] else '' }}
-{% endif %}
 name: {{ board_desc }}
 vendor: {{ vendor }}
 type: mcu
@@ -21,5 +17,4 @@ flash: 1024
 {% endif %}
 toolchain:
   - zephyr
-supported:
-  - gpio
+supported: []

--- a/scripts/west_commands/genboard/templates/nrf54l/board_twister.yml.jinja2
+++ b/scripts/west_commands/genboard/templates/nrf54l/board_twister.yml.jinja2
@@ -7,5 +7,4 @@ toolchain:
 sysbuild: true
 ram: {{ target['ram'] }}
 flash: {{ target['flash'] }}
-supported:
-  - gpio
+supported: []

--- a/scripts/west_commands/genboard/templates/nrf91/Kconfig.board.jinja2
+++ b/scripts/west_commands/genboard/templates/nrf91/Kconfig.board.jinja2
@@ -1,7 +1,2 @@
 config BOARD_{{ board | upper }}
-{% if ncs_version < hwmv2_since %}
-	bool "{{ board_desc }}"
-	depends on SOC_{{ soc | upper }}_{{ variant | upper}}
-{% else %}
 	select SOC_{{ soc | upper }}_{{ variant | upper}}
-{% endif %}

--- a/scripts/west_commands/genboard/templates/nrf91/Kconfig.defconfig.jinja2
+++ b/scripts/west_commands/genboard/templates/nrf91/Kconfig.defconfig.jinja2
@@ -1,13 +1,4 @@
-{% if ncs_version < hwmv2_since %}
-config BOARD
-	default "{{ board }}"
-
-{% endif %}
-{% if ncs_version < hwmv2_since %}
-if  BOARD_{{ board | upper }} || BOARD_{{ board | upper }}_NS
-{% else %}
 if  BOARD_{{ board | upper }}_{{ soc | upper }} || BOARD_{{ board | upper }}_{{ soc | upper }}_NS
-{% endif %}
 
 # For the secure version of the board the firmware is linked at the beginning of
 # the flash, or into the code-partition defined in DT if it is intended to be
@@ -23,17 +14,9 @@ DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
 
 config FLASH_LOAD_SIZE
 	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
-{% if ncs_version < hwmv2_since %}
-	depends on BOARD_{{ board | upper }} && TRUSTED_EXECUTION_SECURE
-{% else %}
 	depends on BOARD_{{ board | upper }}_{{ soc | upper }} && TRUSTED_EXECUTION_SECURE
-{% endif %}
 
-{% if ncs_version < hwmv2_since %}
-if BOARD_{{ board | upper }}_NS
-{% else %}
 if BOARD_{{ board | upper }}_{{ soc | upper }}_NS
-{% endif %}
 
 config FLASH_LOAD_OFFSET
 	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
@@ -41,14 +24,6 @@ config FLASH_LOAD_OFFSET
 config FLASH_LOAD_SIZE
 	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
 
-{% if ncs_version < hwmv2_since %}
-endif # BOARD_{{ board | upper }}_NS
-{% else %}
 endif # BOARD_{{ board | upper }}_{{ soc | upper }}_NS
-{% endif %}
 
-{% if ncs_version < hwmv2_since %}
-endif # BOARD_{{ board | upper }} || BOARD_{{ board | upper }}_NS
-{% else %}
 endif # BOARD_{{ board | upper }}_{{ soc | upper }} || BOARD_{{ board | upper }}_{{ soc | upper }}_NS
-{% endif %}

--- a/scripts/west_commands/genboard/templates/nrf91/board-partitioning.dtsi.jinja2
+++ b/scripts/west_commands/genboard/templates/nrf91/board-partitioning.dtsi.jinja2
@@ -29,27 +29,6 @@
 			reg = <0x00010000 DT_SIZE_K(256)>;
 		};
 
-{% if ncs_version <= (2, 4, 0) %}
-		slot0_ns_partition: partition@50000 {
-			label = "image-0-nonsecure";
-			reg = <0x00050000 DT_SIZE_K(192)>;
-		};
-
-		slot1_partition: partition@80000 {
-			label = "image-1";
-			reg = <0x00085000 DT_SIZE_K(256)>;
-		};
-
-		slot1_ns_partition: partition@c0000 {
-			label = "image-1-nonsecure";
-			reg = <0x000c5000 DT_SIZE_K(192)>;
-		};
-
-		scratch_partition: partition@f0000 {
-			label = "image-scratch";
-			reg = <0x000f0000 DT_SIZE_K(40)>;
-		};
-{% else %}
 		slot0_ns_partition: partition@50000 {
 			label = "image-0-nonsecure";
 			reg = <0x00050000 DT_SIZE_K(212)>;
@@ -64,7 +43,6 @@
 			label = "image-1-nonsecure";
 			reg = <0x000c5000 DT_SIZE_K(212)>;
 		};
-{% endif %}
 
 		storage_partition: partition@fa000 {
 			label = "storage";

--- a/scripts/west_commands/genboard/templates/nrf91/board.cmake.jinja2
+++ b/scripts/west_commands/genboard/templates/nrf91/board.cmake.jinja2
@@ -1,8 +1,4 @@
-{% if ncs_version < hwmv2_since %}
-if(CONFIG_BOARD_{{ board | upper }}_NS)
-{% else %}
 if(CONFIG_BOARD_{{ board | upper }}_{{ soc | upper }}_NS)
-{% endif %}
   set(TFM_PUBLIC_KEY_FORMAT "full")
 endif()
 

--- a/scripts/west_commands/genboard/templates/nrf91/board_defconfig.jinja2
+++ b/scripts/west_commands/genboard/templates/nrf91/board_defconfig.jinja2
@@ -1,17 +1,7 @@
-{% if ncs_version < hwmv2_since %}
-CONFIG_SOC_SERIES_NRF91X=y
-CONFIG_SOC_{{ soc | upper }}_{{ variant | upper }}=y
-CONFIG_BOARD_{{ board | upper }}=y
-
-{% endif %}
 CONFIG_ARM_MPU=y
 CONFIG_HW_STACK_PROTECTION=y
 
 CONFIG_ARM_TRUSTZONE_M=y
 {% if target.get('ns') %}
 CONFIG_TRUSTED_EXECUTION_NONSECURE=y
-{% endif %}
-
-{% if ncs_version <= (2, 6, 0) %}
-CONFIG_PINCTRL=y
 {% endif %}

--- a/scripts/west_commands/genboard/templates/nrf91/board_twister.yml.jinja2
+++ b/scripts/west_commands/genboard/templates/nrf91/board_twister.yml.jinja2
@@ -1,8 +1,4 @@
-{% if ncs_version < hwmv2_since %}
-identifier: {{ board }}
-{% else %}
 identifier: {{ board }}/{{ soc }}{{ '/ns' if target['ns'] else '' }}
-{% endif %}
 name: {{ board_desc }}
 vendor: {{ vendor }}
 type: mcu
@@ -16,5 +12,4 @@ flash: 1024
 {% endif %}
 toolchain:
   - zephyr
-supported:
-  - gpio
+supported: []

--- a/scripts/west_commands/genboard/west-ncs-genboard-test.sh
+++ b/scripts/west_commands/genboard/west-ncs-genboard-test.sh
@@ -7,52 +7,29 @@ NCS_BASE="$SCRIPTDIR/../../.."
 
 SOC=${1}
 
-declare -a NCS_VERSIONS=(
-	"2.0.0"
-	"2.1.0"
-	"2.2.0"
-	"2.3.0"
-	"2.4.0"
-	"2.5.0"
-	"2.6.0"
-	"2.7.0"
-	"2.8.0"
-	"2.8.99"
-)
-
 declare -a SOCS=(
-	"nrf52805 caaa 2.0.0"
-	"nrf52810 qfaa 2.0.0"
-	"nrf52811 qfaa 2.0.0"
-	"nrf52820 qdaa 2.0.0"
-	"nrf52832 ciaa 2.0.0"
-	"nrf52832 qfaa 2.0.0"
-	"nrf52832 qfab 2.0.0"
-	"nrf52833 qdaa 2.5.0"
-	"nrf52833 qiaa 2.0.0"
-	"nrf52840 qfaa 2.5.0"
-	"nrf52840 qiaa 2.0.0"
-	"nrf5340 qkaa 2.0.0"
-	"nrf54l15 qfaa 2.7.0"
-	"nrf9131 laca 2.5.0"
-	"nrf9151 laca 2.6.0"
-	"nrf9160 sica 2.0.0"
-	"nrf9161 laca 2.5.0"
+	"nrf52805 caaa"
+	"nrf52810 qfaa"
+	"nrf52811 qfaa"
+	"nrf52820 qdaa"
+	"nrf52832 ciaa"
+	"nrf52832 qfaa"
+	"nrf52832 qfab"
+	"nrf52833 qdaa"
+	"nrf52833 qiaa"
+	"nrf52840 qfaa"
+	"nrf52840 qiaa"
+	"nrf5340 qkaa"
+	"nrf54l15 qfaa"
+	"nrf9131 laca"
+	"nrf9151 laca"
+	"nrf9160 sica"
+	"nrf9161 laca"
 )
 
 HELLO_WORLD="$NCS_BASE/../zephyr/samples/hello_world"
 
-# https://stackoverflow.com/questions/4023830
-verlte() {
-	printf '%s\n' "$1" "$2" | sort -C -V
-}
-
-verlt() {
-	! verlte "$2" "$1"
-}
-
-rm -rf $NCS_BASE/boards/arm/testvnd $NCS_BASE/boards/testvnd
-BRANCH=$(git rev-parse --abbrev-ref HEAD)
+rm -rf $NCS_BASE/boards/testvnd
 
 for soc in "${SOCS[@]}"; do
 	read -a socarr <<< "$soc"
@@ -62,91 +39,34 @@ for soc in "${SOCS[@]}"; do
 		continue
 	fi
 
-	for ncs_version in "${NCS_VERSIONS[@]}"; do
-		ncs_version_esc="${ncs_version//./_}"
+	board=brd_${socarr[0]}_${socarr[1]}
 
-		if verlt $ncs_version ${socarr[2]}; then
-			echo "Skipping ${socarr[0]}-${socarr[1]} for NCS $ncs_version (unsupported)"
-			continue;
-		fi
+	echo "Generating board: $board"
 
-		board=brd_${socarr[0]}_${socarr[1]}_$ncs_version_esc
+	west ncs-genboard \
+		-o $NCS_BASE/boards \
+		-e "testvnd" \
+		-b $board \
+		-d "Test Board" \
+		-s ${socarr[0]} \
+		-v ${socarr[1]} \
 
-		echo "Generating board: $board"
+	echo "Building hello_world for: $board"
 
-		west ncs-genboard \
-			-o $NCS_BASE/boards \
-			-e "testvnd" \
-			-b $board \
-			-d "Test Board" \
-			-s ${socarr[0]} \
-			-v ${socarr[1]} \
-			-n "$ncs_version"
-	done
-done
-
-for ncs_version in "${NCS_VERSIONS[@]}"
-do
-	ncs_version_esc="${ncs_version//./_}"
-
-	echo "Switching to NCS $ncs_version"
-
-	LATEST=".*99"
-	if [[ ${ncs_version} =~ $LATEST ]]; then
-		git checkout main
-	else
-		git checkout v$ncs_version
+	if [[ ${socarr[0]} == nrf52* ]]; then
+		west build -p -b $board $HELLO_WORLD
+	elif [[ ${socarr[0]} == nrf53* ]]; then
+		west build -p -b $board/${socarr[0]}/cpuapp $HELLO_WORLD
+		west build -p -b $board/${socarr[0]}/cpuapp/ns $HELLO_WORLD
+		west build -p -b $board/${socarr[0]}/cpunet $HELLO_WORLD
+	elif [[ ${socarr[0]} == nrf54l* ]]; then
+		west build -p -b $board/${socarr[0]}/cpuapp $HELLO_WORLD
+		# west build -p -b $board/${socarr[0]}/cpuflpr $HELLO_WORLD
+		# west build -p -b $board/${socarr[0]}/cpuflpr/xip $HELLO_WORLD
+	elif [[ ${socarr[0]} == nrf91* ]]; then
+		west build -p -b $board/${socarr[0]} $HELLO_WORLD
+		west build -p -b $board/${socarr[0]}/ns $HELLO_WORLD
 	fi
-	west update
 
-	for soc in "${SOCS[@]}"; do
-		read -a socarr <<< "$soc"
-
-		if [ ! -z "$SOC" ] && [ $SOC != ${socarr[0]} ]; then
-			echo "Skipping ${socarr[0]} (not requested)"
-			continue
-		fi
-
-		if verlt $ncs_version ${socarr[2]}; then
-			continue;
-		fi
-
-		board=brd_${socarr[0]}_${socarr[1]}_$ncs_version_esc
-
-		echo "Building for: $board"
-
-		if [[ ${socarr[0]} == nrf52* ]]; then
-			west build -p -b $board $HELLO_WORLD
-		elif [[ ${socarr[0]} == nrf53* ]]; then
-			if verlt $ncs_version "2.7.0"; then
-				west build -p -b ${board}_cpuapp $HELLO_WORLD
-				if verlte "2.6.0" $ncs_version; then
-					west build -p -b ${board}_cpuapp_ns $HELLO_WORLD
-				fi
-				west build -p -b ${board}_cpunet $HELLO_WORLD
-			else
-				west build -p -b $board/${socarr[0]}/cpuapp $HELLO_WORLD
-				west build -p -b $board/${socarr[0]}/cpuapp/ns $HELLO_WORLD
-				west build -p -b $board/${socarr[0]}/cpunet $HELLO_WORLD
-			fi
-		elif [[ ${socarr[0]} == nrf54l* ]]; then
-			west build -p -b $board/${socarr[0]}/cpuapp $HELLO_WORLD
-			# west build -p -b $board/${socarr[0]}/cpuflpr $HELLO_WORLD
-			# west build -p -b $board/${socarr[0]}/cpuflpr/xip $HELLO_WORLD
-		elif [[ ${socarr[0]} == nrf91* ]]; then
-			if verlt $ncs_version "2.7.0"; then
-				west build -p -b $board $HELLO_WORLD
-				if verlte "2.6.0" $ncs_version; then
-					west build -p -b ${board}_ns $HELLO_WORLD
-				fi
-			else
-				west build -p -b $board/${socarr[0]} $HELLO_WORLD
-				west build -p -b $board/${socarr[0]}/ns $HELLO_WORLD
-			fi
-		fi
-	done
+	rm -rf $NCS_BASE/boards/testvnd
 done
-
-rm -rf $NCS_BASE/boards/arm/brd_* $NCS_BASE/boards/testvnd
-git checkout $BRANCH
-west update


### PR DESCRIPTION
Maintaining multiversion compatibility is a nightmare, so lets make the tool support the current NCS version, ie, the one in the same tree.