### PR TITLE
bootloader: bl_crypto: Add SHA512 support

### DIFF
--- a/include/bl_crypto.h
+++ b/include/bl_crypto.h
@@ -14,7 +14,6 @@ extern "C" {
 #include <zephyr/types.h>
 #include <fw_info.h>
 
-
 /** @defgroup bl_crypto Bootloader crypto functions
  * @{
  */
@@ -25,18 +24,33 @@ extern "C" {
 #define ESIGINV  102
 
 
-#if CONFIG_SB_CRYPTO_OBERON_SHA256
-	#include <ocrypto_sha256.h>
-	#define SHA256_CTX_SIZE sizeof(ocrypto_sha256_ctx)
-	typedef ocrypto_sha256_ctx bl_sha256_ctx_t;
-#elif CONFIG_SB_CRYPTO_CC310_SHA256
-	#include <nrf_cc310_bl_hash_sha256.h>
-	#define SHA256_CTX_SIZE sizeof(nrf_cc310_bl_hash_context_sha256_t)
-	typedef nrf_cc310_bl_hash_context_sha256_t bl_sha256_ctx_t;
+#if defined(CONFIG_SB_CRYPTO_OBERON_SHA256)
+/* SHA256 (oberon) */
+#include <ocrypto_sha256.h>
+
+#define SHA256_CTX_SIZE sizeof(ocrypto_sha256_ctx)
+
+typedef ocrypto_sha256_ctx bl_sha256_ctx_t;
+#elif defined(CONFIG_SB_CRYPTO_CC310_SHA256)
+/* SHA256 (cc310) */
+#include <nrf_cc310_bl_hash_sha256.h>
+
+#define SHA256_CTX_SIZE sizeof(nrf_cc310_bl_hash_context_sha256_t)
+
+typedef nrf_cc310_bl_hash_context_sha256_t bl_sha256_ctx_t;
+#elif defined(CONFIG_SB_CRYPTO_PSA_SHA512)
+/* SHA512 (PSA) */
+#include <psa/crypto.h>
+#include <psa/crypto_extra.h>
+
+#define SHA512_CTX_SIZE sizeof(psa_hash_operation_t)
+
+typedef psa_hash_operation_t bl_sha512_ctx_t;
 #else
-	#define SHA256_CTX_SIZE 256
-	// uint32_t to make sure it is aligned equally as the other contexts.
-	typedef uint32_t bl_sha256_ctx_t[SHA256_CTX_SIZE/4];
+/* SHA256 fallback */
+#define SHA256_CTX_SIZE 256
+/* uint32_t to make sure it is aligned equally as the other contexts. */
+typedef uint32_t bl_sha256_ctx_t[SHA256_CTX_SIZE/4];
 #endif
 
 /**
@@ -95,7 +109,6 @@ int bl_root_of_trust_verify_external(const uint8_t *public_key,
 				     const uint8_t *signature,
 				     const uint8_t *firmware,
 				     const uint32_t firmware_len);
-
 
 /**
  * @brief Initialize a sha256 operation context variable.
@@ -169,6 +182,60 @@ int bl_sha256_verify(const uint8_t *data, uint32_t data_len, const uint8_t *expe
 typedef int (*bl_sha256_verify_t)(const uint8_t *data, uint32_t data_len,
 				const uint8_t *expected);
 
+/**
+ * @brief Initialize a sha512 operation context variable.
+ *
+ * @param[out]  ctx  Context to be initialized.
+ *
+ * @retval 0         On success.
+ * @retval -EINVAL   If @p ctx was NULL.
+ */
+int bl_sha512_init(bl_sha512_ctx_t *ctx);
+
+/**
+ * @brief Hash a portion of data.
+ *
+ * @note @p ctx must be initialized before being used in this function.
+ *       An uninitialized @p ctx might not be reported as an error. Also,
+ *       @p ctx must not be used if it has been finalized, though this might
+ *       also not be reported as an error.
+ *
+ * @param[in]  ctx       Context variable. Must have been initialized.
+ * @param[in]  data      Data to hash.
+ * @param[in]  data_len  Length of @p data.
+ *
+ * @retval 0         On success.
+ * @retval -EINVAL   If @p ctx was NULL, uninitialized, or corrupted.
+ * @retval -ENOSYS   If the context has already been finalized.
+ */
+int bl_sha512_update(bl_sha512_ctx_t *ctx, const uint8_t *data, uint32_t data_len);
+
+/**
+ * @brief Finalize a hash result.
+ *
+ * @param[in]  ctx       Context variable.
+ * @param[out] output    Where to put the resulting digest. Must be at least
+ *                       64 bytes long.
+ *
+ * @retval 0         On success.
+ * @retval -EINVAL   If @p ctx was NULL or corrupted, or @p output was NULL.
+ */
+int bl_sha512_finalize(bl_sha512_ctx_t *ctx, uint8_t *output);
+
+/**
+ * @brief Calculate a digest and verify it directly.
+ *
+ * @param[in]  data      The data to hash.
+ * @param[in]  data_len  The length of @p data.
+ * @param[in]  expected  The expected digest over @p data.
+ *
+ * @retval 0          If the procedure succeeded and the resulting digest is
+ *                    identical to @p expected.
+ * @retval -EHASHINV  If the procedure succeeded, but the digests don't match.
+ * @return Any error code from @ref bl_sha512_init, @ref bl_sha512_update, or
+ *         @ref bl_sha512_finalize if something else went wrong.
+ */
+int bl_sha512_verify(const uint8_t *data, uint32_t data_len, const uint8_t *expected);
 
 /**
  * @brief Validate a secp256r1 signature.
@@ -195,6 +262,23 @@ typedef int (*bl_secp256r1_validate_t)(
 			  const uint8_t *signature,
 			  const uint8_t *public_key);
 
+/**
+ * @brief Validate an ed25519 signature.
+ *
+ * @param[in]  hash        The hash to validate against.
+ * @param[in]  hash_len    The length of the hash.
+ * @param[in]  signature   The signature to validate.
+ * @param[in]  public_key  The public key to validate with.
+ *
+ * @retval 0         The operation succeeded and the signature is valid for the
+ *                   hash.
+ * @retval -EINVAL   A parameter was NULL, or the @p hash_len was not 32 bytes.
+ * @retval -ESIGINV  The signature validation failed.
+ */
+int bl_ed25519_validate(const uint8_t *hash,
+			  uint32_t hash_len,
+			  const uint8_t *signature,
+			  const uint8_t *public_key);
 
 /**
  * @brief Structure describing the BL_ROT_VERIFY EXT_API.

--- a/subsys/bootloader/bl_crypto/CMakeLists.txt
+++ b/subsys/bootloader/bl_crypto/CMakeLists.txt
@@ -9,32 +9,34 @@ zephyr_library_sources(bl_crypto.c)
 zephyr_library_link_libraries(nrfxlib_crypto)
 zephyr_link_libraries(nrfxlib_crypto)
 
-if (CONFIG_SB_CRYPTO_OBERON_ECDSA_SECP256R1)
+if(CONFIG_SB_CRYPTO_OBERON_ECDSA_SECP256R1)
   zephyr_library_sources(bl_crypto_oberon_ecdsa.c)
-elseif (CONFIG_SB_CRYPTO_CC310_ECDSA_SECP256R1)
+elseif(CONFIG_SB_CRYPTO_CC310_ECDSA_SECP256R1)
   zephyr_library_sources(
     bl_crypto_cc310_ecdsa.c
     bl_crypto_cc310_common.c
     )
-elseif (CONFIG_SB_CRYPTO_CLIENT_ECDSA_SECP256R1)
+elseif(CONFIG_SB_CRYPTO_CLIENT_ECDSA_SECP256R1)
   zephyr_library_sources(../bl_crypto_client/bl_crypto_client.c)
-elseif (CONFIG_SB_CRYPTO_NO_ECDSA_SECP256R1)
+elseif(CONFIG_SB_CRYPTO_NO_ECDSA_SECP256R1)
   # Do nothing
 else()
   message(FATAL_ERROR "No signature implementation chosen for bootloader.")
 endif()
 
-if (CONFIG_SB_CRYPTO_OBERON_SHA256)
+if(CONFIG_SB_CRYPTO_OBERON_SHA256)
   zephyr_library_sources(bl_crypto_oberon_hash.c)
-elseif (CONFIG_SB_CRYPTO_CC310_SHA256)
+elseif(CONFIG_SB_CRYPTO_CC310_SHA256)
   zephyr_library_sources(
     bl_crypto_cc310_hash.c
     bl_crypto_cc310_common.c
     )
-elseif (CONFIG_SB_CRYPTO_CLIENT_SHA256)
+elseif(CONFIG_SB_CRYPTO_CLIENT_SHA256)
   zephyr_library_sources(../bl_crypto_client/bl_crypto_client.c)
-elseif (CONFIG_SB_CRYPTO_NO_SHA256)
+elseif(CONFIG_SB_CRYPTO_NO_SHA256)
   # Do nothing
+elseif(CONFIG_SB_CRYPTO_PSA_SHA512)
+  zephyr_library_sources(bl_crypto_sha512.c)
 else()
   message(FATAL_ERROR "No hash implementation chosen for bootloader.")
 endif()

--- a/subsys/bootloader/bl_crypto/Kconfig
+++ b/subsys/bootloader/bl_crypto/Kconfig
@@ -14,9 +14,14 @@ menuconfig SECURE_BOOT_CRYPTO
 if (SECURE_BOOT_CRYPTO)
 config SB_ECDSA_SECP256R1
 	bool
+
 config SB_RSA_PSS2048
 	bool
+
 config SB_SHA256
+	bool
+
+config SB_SHA512
 	bool
 
 config SB_SIGNATURE_LEN
@@ -30,7 +35,8 @@ config SB_PUBLIC_KEY_LEN
 	default 256 if SB_RSA_PSS2048
 
 config SB_HASH_LEN
-	def_int 32
+	def_int 64 if SB_SHA512
+	def_int 32 if SB_SHA256
 
 choice SB_CRYPTO_SIG
 	prompt "Firmware verification Algorithm"
@@ -40,29 +46,29 @@ choice SB_CRYPTO_SIG
 	help
 	  Crypto implementation to use for signature verification of firmware in Bootloader.
 
-	config SB_CRYPTO_OBERON_ECDSA_SECP256R1
-		bool "Software ECDSA secp256r1"
-		select SB_ECDSA_SECP256R1
-		help
-		  Software implementation of ECDSA with NIST curve secp256r1.
+config SB_CRYPTO_OBERON_ECDSA_SECP256R1
+	bool "Software ECDSA secp256r1"
+	select SB_ECDSA_SECP256R1
+	help
+	  Software implementation of ECDSA with NIST curve secp256r1.
 
-	config SB_CRYPTO_CC310_ECDSA_SECP256R1
-		bool "Hardware ECDSA secp256r1" if HAS_HW_NRF_CC310
-		select NRF_CC310_BL
-		select SB_ECDSA_SECP256R1
-		help
-		  Hardware implementation of ECDSA with NIST curve secp256r1.
+config SB_CRYPTO_CC310_ECDSA_SECP256R1
+	bool "Hardware ECDSA secp256r1" if HAS_HW_NRF_CC310
+	select NRF_CC310_BL
+	select SB_ECDSA_SECP256R1
+	help
+	  Hardware implementation of ECDSA with NIST curve secp256r1.
 
-	config SB_CRYPTO_CLIENT_ECDSA_SECP256R1
-		bool "Use another image's ECDSA secp256r1 implementation"
-		select BL_SECP256R1_EXT_API_ATLEAST_REQUIRED
-		select SB_ECDSA_SECP256R1
-		help
-		  Using EXT_APIs from fw_info.
+config SB_CRYPTO_CLIENT_ECDSA_SECP256R1
+	bool "Use another image's ECDSA secp256r1 implementation"
+	select BL_SECP256R1_EXT_API_ATLEAST_REQUIRED
+	select SB_ECDSA_SECP256R1
+	help
+	  Using EXT_APIs from fw_info.
 
-	config SB_CRYPTO_NO_ECDSA_SECP256R1
-		bool "Disable secp256r1 support"
-		select SB_ECDSA_SECP256R1
+config SB_CRYPTO_NO_ECDSA_SECP256R1
+	bool "Disable secp256r1 support"
+	select SB_ECDSA_SECP256R1
 
 	#config SB_CRYPTO_OBERON_RSA_2048
 	#	bool #"Software RSA-PSS 2048-bits"
@@ -90,29 +96,40 @@ choice SB_CRYPTO_HASH
 	help
 	  Crypto implementation to use for hash generation in Bootloader.
 
-	config SB_CRYPTO_OBERON_SHA256
-		bool "Software SHA256"
-		select SB_SHA256
-		help
-		  Software implementation of SHA256.
+config SB_CRYPTO_OBERON_SHA256
+	bool "Software SHA256"
+	select SB_SHA256
+	help
+	  Software implementation of SHA256.
 
-	config SB_CRYPTO_CC310_SHA256
-		bool "Hardware SHA256" if HAS_HW_NRF_CC310
-		select NRF_CC310_BL
-		select SB_SHA256
-		help
-		  Hardware implementation of SHA256.
+config SB_CRYPTO_CC310_SHA256
+	bool "Hardware SHA256" if HAS_HW_NRF_CC310
+	select NRF_CC310_BL
+	select SB_SHA256
+	help
+	  Hardware implementation of SHA256.
 
-	config SB_CRYPTO_CLIENT_SHA256
-		bool "Use another image's SHA256 implementation"
-		select BL_SHA256_EXT_API_ATLEAST_REQUIRED
-		select SB_SHA256
-		help
-		  Using EXT_APIs from fw_info.
+config SB_CRYPTO_CLIENT_SHA256
+	bool "Use another image's SHA256 implementation"
+	select BL_SHA256_EXT_API_ATLEAST_REQUIRED
+	select SB_SHA256
+	help
+	  Using EXT_APIs from fw_info.
 
-	config SB_CRYPTO_NO_SHA256
-		bool "Disable SHA256 support"
-		select SB_SHA256
+config SB_CRYPTO_NO_SHA256
+	bool "Disable SHA256 support"
+	select SB_SHA256
+
+config SB_CRYPTO_PSA_SHA512
+	bool "PSA SHA512 support"
+	depends on NRF_SECURITY
+	select SB_SHA512
+	select PSA_WANT_ALG_SHA_512
+	select PSA_WANT_ALG_PURE_EDDSA
+	select PSA_WANT_ECC_TWISTED_EDWARDS_255
+	select PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT
+	help
+	  Use PSA crypto for SHA512 support.
 
 endchoice
 
@@ -122,16 +139,20 @@ flags = 2
 ver = 1
 source "${ZEPHYR_BASE}/../nrf/subsys/fw_info/Kconfig.template.fw_info_ext_api"
 
+if SB_SHA256
 EXT_API = BL_SHA256
 id = 0x1002
 flags = 0
 ver = 1
 source "${ZEPHYR_BASE}/../nrf/subsys/fw_info/Kconfig.template.fw_info_ext_api"
+endif
 
+if SB_ECDSA_SECP256R1
 EXT_API = BL_SECP256R1
 id = 0x1003
 flags = 1
 ver = 1
 source "${ZEPHYR_BASE}/../nrf/subsys/fw_info/Kconfig.template.fw_info_ext_api"
+endif
 
 endif # SECURE_BOOT_CRYPTO

--- a/subsys/bootloader/bl_crypto/bl_crypto_sha512.c
+++ b/subsys/bootloader/bl_crypto/bl_crypto_sha512.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/types.h>
+#include <bl_crypto.h>
+#include <bl_storage.h>
+#include <fw_info.h>
+#include <psa/crypto.h>
+
+int bl_sha512_init(bl_sha512_ctx_t * const ctx)
+{
+	*ctx = psa_hash_operation_init();
+	return (int)psa_hash_setup(ctx, PSA_ALG_SHA_512);
+}
+
+int bl_sha512_update(bl_sha512_ctx_t *ctx, const uint8_t *data, uint32_t data_len)
+{
+	return (int)psa_hash_update(ctx, data, data_len);
+}
+
+int bl_sha512_finalize(bl_sha512_ctx_t *ctx, uint8_t *output)
+{
+	size_t hash_length = 0;
+	/* Assumes the output buffer is at least the expected size of the hash */
+	return (int)psa_hash_finish(ctx, output, PSA_HASH_LENGTH(PSA_ALG_SHA_512), &hash_length);
+}
+
+int get_hash(uint8_t *hash, const uint8_t *data, uint32_t data_len, bool external)
+{
+	bl_sha512_ctx_t ctx;
+	int rc;
+
+	rc = bl_sha512_init(&ctx);
+
+	if (rc != 0) {
+		return rc;
+	}
+
+	rc = bl_sha512_update(&ctx, data, data_len);
+
+	if (rc != 0) {
+		return rc;
+	}
+
+	rc = bl_sha512_finalize(&ctx, hash);
+	return rc;
+}


### PR DESCRIPTION
Adds support for SHA512 as the hash algorithm in the bl_crypto module using PSA