### PR TITLE
[Backport v2.8-branch] tests: drivers: lpuart: Fix memory corruption

### DIFF
--- a/tests/drivers/lpuart/src/main.c
+++ b/tests/drivers/lpuart/src/main.c
@@ -395,7 +395,7 @@ static void counter_alarm_callback(const struct device *dev,
 
 static void floating_pins_start(int32_t tx_pin)
 {
-	struct test_data data;
+	static struct test_data data;
 
 	data.alarm_cfg.callback = counter_alarm_callback;
 	data.alarm_cfg.flags = COUNTER_ALARM_CFG_EXPIRE_WHEN_LATE;


### PR DESCRIPTION
Backport 077d132fcdd3148a2bd13c2553bf0aee1616e8e7 from #18720.