### PR TITLE
samples: edge_impulse: Add support for nRF54H20DK

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -279,7 +279,16 @@ DECT NR+ samples
 Edge Impulse samples
 --------------------
 
-|no_changes_yet_note|
+Edge Impulse samples
+--------------------
+
+* :ref:`ei_data_forwarder_sample` sample:
+
+  * Added support for the :ref:`zephyr:nrf54h20dk_nrf54h20` board.
+
+* :ref:`ei_wrapper_sample` sample:
+
+  * Added support for the :ref:`zephyr:nrf54h20dk_nrf54h20` board.
 
 Enhanced ShockBurst samples
 ---------------------------

--- a/samples/edge_impulse/data_forwarder/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/edge_impulse/data_forwarder/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	sensor_sim: sensor-sim {
+		compatible = "nordic,sensor-sim";
+		acc-signal = "wave";
+	};
+
+	chosen {
+		ncs,ei-uart = &uart136;
+	};
+};

--- a/samples/edge_impulse/data_forwarder/sample.yaml
+++ b/samples/edge_impulse/data_forwarder/sample.yaml
@@ -11,6 +11,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
       - nrf9160dk/nrf9160/ns
       - thingy91x/nrf9151/ns
     integration_platforms:
@@ -19,6 +20,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
       - nrf9160dk/nrf9160/ns
     platform_exclude: native_posix qemu_x86 qemu_cortex_m3
     tags: ci_build sysbuild ci_samples_edge_impulse

--- a/samples/edge_impulse/wrapper/sample.yaml
+++ b/samples/edge_impulse/wrapper/sample.yaml
@@ -18,6 +18,7 @@ common:
     - nrf5340dk/nrf5340/cpuapp
     - nrf5340dk/nrf5340/cpuapp/ns
     - nrf54l15dk/nrf54l15/cpuapp
+    - nrf54h20dk/nrf54h20/cpuapp
     - nrf9160dk/nrf9160/ns
     - qemu_cortex_m3
     - thingy91x/nrf9151/ns
@@ -27,6 +28,7 @@ common:
     - nrf5340dk/nrf5340/cpuapp
     - nrf5340dk/nrf5340/cpuapp/ns
     - nrf54l15dk/nrf54l15/cpuapp
+    - nrf54h20dk/nrf54h20/cpuapp
     - nrf9160dk/nrf9160/ns
     - qemu_cortex_m3
   platform_exclude: native_posix qemu_x86


### PR DESCRIPTION
Adds support for nRF54H20DK in the data_forwarder and wrapper samples.