### PR TITLE
[Backport v2.8-branch] tests: benchmarks: increase idle HPU feature test timeout

### DIFF
--- a/tests/benchmarks/multicore/idle_hpu_temp_meas/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_hpu_temp_meas/testcase.yaml
@@ -15,3 +15,4 @@ tests:
       fixture: ppk_power_measure
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_hpu_feature"
+    timeout: 90


### PR DESCRIPTION
Backport 2c1c856bd46a2a26374a26e8e6be41271c579ab5 from #18650.