### PR TITLE
ci: docpublish upload to azure instead of nordicsemi.com

### DIFF
--- a/.github/workflows/docpublish.yml
+++ b/.github/workflows/docpublish.yml
@@ -7,7 +7,7 @@ on:
       - completed
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
@@ -17,23 +17,19 @@ jobs:
           workflow: docbuild.yml
           run_id: ${{ github.event.workflow_run.id }}
 
-      - name: Install dependencies
+      - name: Unzip html archive
+        working-directory: docs
         run: |
-          sudo apt install -y sshpass
+          OUTDIR=$(awk 'NR==1 { if ($3 ~ /^(latest|v([0-9a-z\.\-]+)|PR-[0-9]+)$/) print $3 }' monitor_*.txt)
+          echo "OUTDIR=$OUTDIR" >> "$GITHUB_ENV"
+          unzip legacy-ncs*.zip -d $OUTDIR
 
-      - name: Upload documentation
+      - name: Upload to Azure storage
+        working-directory: docs
         env:
-          SSHUSER: ${{ secrets.NCS_TRANSFER_DOC_USR }}
-          SSHPASS: ${{ secrets.NCS_TRANSFER_DOC_PWD }}
+          AZCOPY_CONCURRENCY_VALUE: 1024
         run: |
-          # trust server
-          mkdir -p ~/.ssh && \
-            ssh-keyscan -p 2222 transfer.nordicsemi.no >> ~/.ssh/known_hosts
-          # upload files
-          for file in docs/legacy*.zip docs/monitor*.txt; do
-            echo "put ${file}" | \
-              sshpass -e sftp -P 2222 -o BatchMode=no -b - $SSHUSER@transfer.nordicsemi.no
-          done
+         azcopy cp $OUTDIR "${{ vars.NCS_DOC_STORAGE_URL }}?${{ secrets.NCS_DOC_SAS}}" --recursive=true
 
       - name: Upload Zoomin documentation
         run: |
@@ -74,9 +70,9 @@ jobs:
           done
 
       - name: Add preview URL comment for PRs
-        uses: carlescufi/action-doc-url@main
+        uses: nrfconnect/action-doc-url@main
         with:
           github-token: ${{ secrets.NCS_GITHUB_TOKEN }}
-          urlroot: ${{ secrets.NCS_DOC_URL_ROOT }}
+          urlroot: ${{ vars.NCS_DOC_HOSTING_URL }}
           pr-prefix: "PR-"
           pr-file: docs/pr.txt

--- a/.github/workflows/docremove.yml
+++ b/.github/workflows/docremove.yml
@@ -7,24 +7,11 @@ on:
       - main
 
 jobs:
-  build:
+  remove:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Install dependencies
-        run: |
-          sudo apt install -y sshpass
-
-      - name: Request removal
+      - name: Try removal of PR-docs
         env:
-          SSHUSER: ${{ secrets.NCS_TRANSFER_DOC_USR }}
-          SSHPASS: ${{ secrets.NCS_TRANSFER_DOC_PWD }}
+          AZCOPY_CONCURRENCY_VALUE: 3000
         run: |
-          # create request file
-          echo "remove PR-${{ github.event.number }}" > monitor_${GITHUB_RUN_ID}.txt
-          # trust server
-          mkdir -p ~/.ssh && \
-            ssh-keyscan -p 2222 transfer.nordicsemi.no >> ~/.ssh/known_hosts
-          # upload request file
-          echo "put monitor_${GITHUB_RUN_ID}.txt" | \
-            sshpass -e sftp -P 2222 -o BatchMode=no -b - $SSHUSER@transfer.nordicsemi.no
+          azcopy rm "${{ vars.NCS_DOC_STORAGE_URL }}PR-${{ github.event.number }}?${{ secrets.NCS_DOC_SAS }}" --recursive=true || true


### PR DESCRIPTION
There is a plan to deprecate developer.nordicsemi.com for hosting documentation builds. Instead we plan to use Azure storage.