### PR TITLE
ci: stale: be more agressive

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,11 +10,9 @@ jobs:
     - uses: actions/stale@v9
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-pr-message: 'This pull request has been marked as stale because it has been open (more than) 60 days with no activity. Remove the stale label or add a comment saying that you would like to have the label removed otherwise this pull request will automatically be closed in 14 days. Note, that you can always re-open a closed pull request at any time.'
-        stale-issue-message: 'This issue has been marked as stale because it has been open (more than) 60 days with no activity. Remove the stale label or add a comment saying that you would like to have the label removed otherwise this issue will automatically be closed in 14 days. Note, that you can always re-open a closed issue at any time.'
-        days-before-stale: 60
-        days-before-close: 14
+        stale-pr-message: 'This pull request has been marked as stale because it has been open (more than) 30 days with no activity. Remove the stale label or add a comment saying that you would like to have the label removed otherwise this pull request will automatically be closed in 7 days. Note, that you can always re-open a closed pull request at any time.'
+        stale-issue-message: 'This issue has been marked as stale because it has been open (more than) 30 days with no activity. Remove the stale label or add a comment saying that you would like to have the label removed otherwise this issue will automatically be closed in 7 days. Note, that you can always re-open a closed issue at any time.'
+        days-before-stale: 30
+        days-before-close: 7
         stale-issue-label: 'Stale'
         stale-pr-label: 'Stale'
-        exempt-pr-labels: 'In progress,RFC'
-        exempt-issue-labels: 'In progress,Enhancement,Feature,Feature Request,RFC,Meta'


### PR DESCRIPTION
- 30 days instead of 60
- Give 1 week instead of 2
- No label exemption, also delete unused issue labels (NCS does not have issues)