### PR TITLE
[Backport v2.8-branch] samples: nrf_auraconfig: Update link to lc3 data

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -1661,7 +1661,7 @@
 
 .. _`ISO 639-2 code`: https://www.loc.gov/standards/iso639-2/php/code_list.php
 
-.. _`nRF Auracast configuration files`: https://files.nordicsemi.com/ui/repos/tree/General/ncs-audio/external/nRF_Aura_Config_Audio_Files.zip
+.. _`nRF Auracast configuration files`: https://files.nordicsemi.com/ui/repos/tree/General/ncs-audio/external/nRF-Aura-Config
 
 .. ### Temp: nRF54H and nRF54L related links, repositories, and documents
 


### PR DESCRIPTION
Backport 3804a4e10167b0e197ad900b67d92e84a52731f3 from #18759.