### PR TITLE
[Backport v2.8-branch] doc: deprecation notes for nrfjprog and nRF Command Line Tools

### DIFF
--- a/doc/nrf/app_dev/bootloaders_dfu/mcuboot_nsib/bootloader_signature_keys.rst
+++ b/doc/nrf/app_dev/bootloaders_dfu/mcuboot_nsib/bootloader_signature_keys.rst
@@ -217,6 +217,9 @@ To test that the bootloader no longer boots images signed with the earlier keys,
 
       nrfjprog -f nRF52 -r --verify --program build/zephyr/signed_by_b0_s0_image.hex --sectorerase
 
+   .. note::
+      |nrfjprog_deprecation_note|
+
 #. Observe the bootloader skipping the invalid image and booting the valid image in the other slot:
 
    .. code-block:: console

--- a/doc/nrf/app_dev/bootloaders_dfu/qspi_xip_split_image.rst
+++ b/doc/nrf/app_dev/bootloaders_dfu/qspi_xip_split_image.rst
@@ -217,6 +217,9 @@ Programming with the QSPI XIP split image
 Programming of the application is supported using the :ref:`standard procedure <programming>`.
 The standard procedure will program the firmware using the default nrfjprog configuration which, for QSPI, is PP4IO mode.
 
+.. note::
+      |nrfjprog_deprecation_note|
+
 Programming using a different SPI mode
 ======================================
 

--- a/doc/nrf/app_dev/device_guides/nrf53/building_nrf53.rst
+++ b/doc/nrf/app_dev/device_guides/nrf53/building_nrf53.rst
@@ -56,6 +56,8 @@ To program the nRF5340 DK from the command line, use either west (which uses nrf
 .. note::
    Programming the nRF5340 DK from the command line with west requires the `nRF Command Line Tools`_ v10.12.0 or later.
 
+   |nrf_CLT_deprecation_note|
+
 .. tabs::
 
    .. group-tab:: Separate images

--- a/doc/nrf/app_dev/device_guides/nrf53/qspi_xip_guide_nrf5340.rst
+++ b/doc/nrf/app_dev/device_guides/nrf53/qspi_xip_guide_nrf5340.rst
@@ -205,6 +205,9 @@ Programming the project
 For the nRF5340 DK and other boards equipped with flash working in the QSPI mode, use the :ref:`standard programming command <programming>` (``west flash``).
 For other cases, set up a configuration file for nrfjprog, as described in the following section.
 
+.. note::
+      |nrfjprog_deprecation_note|
+
 Programming to external flash in SPI/DSPI mode
 ==============================================
 

--- a/doc/nrf/app_dev/device_guides/nrf70/fw_patches_ext_flash.rst
+++ b/doc/nrf/app_dev/device_guides/nrf70/fw_patches_ext_flash.rst
@@ -188,6 +188,9 @@ For example, for nrfjprog:
 
    nrfjprog -f nrf53 -s 0 --program build/merged.hex ---sectorerase --qspisectorerase --verify --reset
 
+.. note::
+      |nrfjprog_deprecation_note|
+
 Updating firmware patches
 =========================
 

--- a/doc/nrf/app_dev/device_guides/nrf91/nrf91_board_controllers.rst
+++ b/doc/nrf/app_dev/device_guides/nrf91/nrf91_board_controllers.rst
@@ -41,6 +41,9 @@ The nRF52840 SoC on the DK comes preprogrammed with a firmware.
 If you need to restore the original firmware at some point, download the `nRF9160 DK board controller firmware`_ from the nRF9160 DK downloads page.
 To program the HEX file, use nrfjprog (which is part of the `nRF Command Line Tools`_).
 
+.. note::
+      |nrfjprog_deprecation_note|
+
 If you want to route some pins differently from what is done in the preprogrammed firmware, program the :zephyr:code-sample:`hello_world` sample instead of the preprogrammed firmware.
 Build the sample (located under :file:`ncs/zephyr/samples/hello_world`) for the ``nrf9160dk_nrf52840`` board target.
 To change the routing options, enable or disable the corresponding devicetree nodes for that board as needed.

--- a/doc/nrf/app_dev/device_guides/working_with_nrf/nrf54h/ug_nrf54h20_debugging.rst
+++ b/doc/nrf/app_dev/device_guides/working_with_nrf/nrf54h/ug_nrf54h20_debugging.rst
@@ -76,6 +76,9 @@ To debug a specific core using ``JLinkExe`` do the following:
    * Check the ``SEGGER ID`` printed on the label on the bottom side of the DK.
    * Run the ``nrfjprog --ids`` command.
 
+      .. note::
+         |nrfjprog_deprecation_note|
+
    If just one DK is connected to the machine, defining ``SEGGER-ID`` is not necessary.
    If more than one DK is connected to the machine and ``SEGGER-ID`` is undefined, a pop up window will appear where you can manually select the ID of the DK you want to run J-Link on.
 

--- a/doc/nrf/app_dev/device_guides/working_with_nrf/nrf54h/ug_nrf54h20_gs.rst
+++ b/doc/nrf/app_dev/device_guides/working_with_nrf/nrf54h/ug_nrf54h20_gs.rst
@@ -54,6 +54,9 @@ You also need the following:
      Before running the initial J-Link installation from the `nRF Command Line Tools`_ package, ensure not to have any other J-Link executables on your system.
      If you have other J-Link installations, uninstall them before proceeding.
 
+   .. note::
+      |nrf_CLT_deprecation_note|
+
 * On Windows, SEGGER USB Driver for J-Link from `SEGGER J-Link`_ |jlink_ver|.
 
    .. note::

--- a/doc/nrf/gsg_guides/nrf7002_gs.rst
+++ b/doc/nrf/gsg_guides/nrf7002_gs.rst
@@ -329,6 +329,8 @@ Follow the instructions in the :ref:`building` page to build and the :ref:`progr
 .. note::
    To flash and debug applications on the nRF7002 DK, you must use the `nRF Command Line Tools`_ version 10.12.0 or above.
 
+   |nrf_CLT_deprecation_note|
+
 Debugging
 =========
 

--- a/doc/nrf/installation/recommended_versions.rst
+++ b/doc/nrf/installation/recommended_versions.rst
@@ -375,6 +375,9 @@ nRF Command Line Tools
 Among others, this package includes the nrfjprog executable and library, which the west command uses by default to program the development kits.
 For more information on nrfjprog, see `Programming SoCs with nrfjprog`_.
 
+.. note::
+    |nrf_CLT_deprecation_note|
+
 It is recommended to use the latest version of the package when you :ref:`installing_vsc`.
 
 |nRFVSC|

--- a/doc/nrf/protocols/zigbee/qsg.rst
+++ b/doc/nrf/protocols/zigbee/qsg.rst
@@ -103,7 +103,6 @@ For this quick start guide, we will install the following software:
 * Toolchain Manager - An application for installing the full |NCS| toolchain.
 * Microsoft's |VSC| - The recommended IDE for the |NCS|.
 * |nRFVSC| - An add-on for |VSC| that allows you to develop applications for the |NCS|.
-* nRF Command Line Tools - A set of mandatory tools for working with the |NCS|.
 * SEGGER J-Link - Tool for handling the serial connection.
 
 .. rst-class:: numbered-step

--- a/doc/nrf/security/ap_protect.rst
+++ b/doc/nrf/security/ap_protect.rst
@@ -233,6 +233,9 @@ To lock the ``UICR.APPROTECT`` register, complete the following steps:
 
    nrfjprog --rbp ALL
 
+.. note::
+    |nrfjprog_deprecation_note|
+
 This command enables the hardware AP-Protect (and Secure AP-Protect) and resets the device.
 
 .. _app_secure_approtect:
@@ -309,5 +312,8 @@ To enable only the hardware Secure AP-Protect mechanism, run the following comma
 .. code-block:: console
 
    nrfjprog --rbp SECURE
+
+.. note::
+    |nrfjprog_deprecation_note|
 
 This command enables hardware Secure AP-Protect and resets the device.

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -65,6 +65,8 @@
 .. |Thingy91| replace:: Thingy:91 (PCA20035) - see :ref:`ug_thingy91`
 .. |nRF21540DK| replace:: nRF21540 DK board (PCA10112)
 
+.. |thingy52_not_supported_note| replace:: Despite being supported in :ref:`Zephyr <zephyr:thingy52_nrf52832>`, the |NCS| does not support `Nordic Thingy:52`_.
+
 .. ### FOTA shortcuts
 
 .. |fota_upgrades_def| replace:: You can update the firmware of the device over the air, thus without a wired connection.
@@ -78,6 +80,21 @@
    The extension includes an interface for managing SDK and toolchain installations, an interface to the compiler and linker, an RTOS-aware debugger, a seamless interface to the |NCS|, and a serial terminal.
 .. |VSC| replace:: Visual Studio Code
 .. |nRFVSC| replace:: nRF Connect for VS Code extension
+
+.. ### Deprecation shortcuts
+
+.. |file_suffix_related_deprecation_note| replace:: This feature is deprecated and is being replaced by :ref:`suffix-based configurations <app_build_file_suffixes>`.
+    You can continue to use it until the transition is complete in the |NCS| and the feature is removed in one of the upcoming |NCS| releases.
+
+.. |sysbuild_related_deprecation_note| replace:: This feature is deprecated and is being replaced by Zephyr's :ref:`zephyr:sysbuild`.
+   You can continue to use it until the transition is complete in the |NCS| and the feature is removed in one of the upcoming |NCS| releases.
+   For more information, see :ref:`zephyr:sysbuild`, :ref:`sysbuild_images`, :ref:`zephyr_samples_sysbuild`, and :ref:`sysbuild_forced_options`.
+
+.. |nrfjprog_deprecation_note| replace:: Starting with the |NCS| v2.8.0, nrfjprog is officially deprecated and will be removed in an upcoming release.
+   Transition to using `nRF Util (device command) <Device command overview_>`_ for all related tasks going forward.
+
+.. |nrf_CLT_deprecation_note| replace:: Starting with the |NCS| v2.8.0, the nRF Command Line Tools are officially deprecated and will be removed in an upcoming release.
+   Transition to using `nRF Util`_ for all related tasks going forward.
 
 .. ### Thread usage shortcuts
 
@@ -198,6 +215,7 @@
    For these reasons, providing a general guide on how to test with external devices is challenging.
    The suggested approach is to test with Nordic Semiconductor devices on both sides first to verify basic functionalities and get familiar with the solution before using custom devices.
    Contact `Technical Support team <DevZone_>`_ if you need assistance.
+
 .. |usb_known_issues| replace:: Make sure to check the :ref:`nRF5340 Audio application known issues <known_issues_nrf5340audio>` related to serial connection with the USB.
 
 .. |trusted_execution| replace:: nRF5340 and nRF9160
@@ -223,19 +241,10 @@
 
 .. |board_target| replace:: Replace the *board_target* with the board target of the nRF91 Series device you are using (see the Requirements section).
 
-.. |thingy52_not_supported_note| replace:: Despite being supported in :ref:`Zephyr <zephyr:thingy52_nrf52832>`, the |NCS| does not support `Nordic Thingy:52`_.
-
-.. |sysbuild_related_deprecation_note| replace:: This feature is deprecated and is being replaced by Zephyr's :ref:`zephyr:sysbuild`.
-   You can continue to use it until the transition is complete in the |NCS| and the feature is removed in one of the upcoming |NCS| releases.
-   For more information, see :ref:`zephyr:sysbuild`, :ref:`sysbuild_images`, :ref:`zephyr_samples_sysbuild`, and :ref:`sysbuild_forced_options`.
-
 .. |sysbuild_autoenabled_ncs| replace:: When building :ref:`repository applications <create_application_types_repository>` in the :ref:`SDK repositories <dm_repo_types>`, building with sysbuild is :ref:`enabled by default <sysbuild_enabled_ncs>`.
    If you work with out-of-tree :ref:`freestanding applications <create_application_types_freestanding>`, you need to manually pass the ``--sysbuild`` parameter to every build command or :ref:`configure west to always use it <sysbuild_enabled_ncs_configuring>`.
 
 .. |parameters_override_west_config| replace:: The parameters and options passed in the command line always take precedence over ``west config`` settings.
-
-.. |file_suffix_related_deprecation_note| replace:: This feature is deprecated and is being replaced by :ref:`suffix-based configurations <app_build_file_suffixes>`.
-    You can continue to use it until the transition is complete in the |NCS| and the feature is removed in one of the upcoming |NCS| releases.
 
 .. |multi_image| replace:: These samples are built for the application core and, by default, include the network core application as child image in a multi-image build (see :ref:`ug_nrf5340_multi_image`).
 

--- a/samples/nrf5340/netboot/README.rst
+++ b/samples/nrf5340/netboot/README.rst
@@ -122,6 +122,8 @@ After programming the sample to your development kit, complete the following ste
       Typically, the update image is received through serial interface or Bluetooth.
       For testing purposes, use nrfjprog to program the update image directly into the update slot.
 
+   .. note::
+      |nrfjprog_deprecation_note|
 
 #. Reset the kit.
 #. Observe that the output includes the following lines indicating that the MCUBoot in the application core has read the update image and performed a firmware update of the network core:

--- a/samples/wifi/ble_coex/README.rst
+++ b/samples/wifi/ble_coex/README.rst
@@ -198,6 +198,9 @@ Testing
 
       nrfjprog --com
 
+   .. note::
+         |nrfjprog_deprecation_note|
+
    This command returned the following output in the setup used to run the coexistence tests.
 
    .. code-block:: console

--- a/samples/wifi/shell/README.rst
+++ b/samples/wifi/shell/README.rst
@@ -96,6 +96,9 @@ The following is an example of the CLI commands:
    # If you see NRF5340_xxAA_REV1, proceed with flashing:
    west flash --erase
 
+.. note::
+    |nrfjprog_deprecation_note|
+
 See also :ref:`cmake_options` for instructions on how to provide CMake options.
 
 

--- a/samples/wifi/thread_coex/README.rst
+++ b/samples/wifi/thread_coex/README.rst
@@ -181,6 +181,9 @@ Testing
 
       nrfjprog --com
 
+   .. note::
+         |nrfjprog_deprecation_note|
+
    This command returned the following output in the setup used to run the coexistence tests.
 
    .. code-block:: console


### PR DESCRIPTION
Backport 6a8528257bedfb5b16a8ba85699e923a553f394a from #18743.