### PR TITLE
[Backport v2.8-branch] tests: benchmarks: Correct UARTE test with automatic PM

### DIFF
--- a/tests/benchmarks/multicore/idle_uarte/Kconfig
+++ b/tests/benchmarks/multicore/idle_uarte/Kconfig
@@ -1,5 +1,0 @@
-source "Kconfig.zephyr"
-
-config TEST_AUTOMATIC_POWER_CONTROL
-	default n
-	bool "Enable testing without manual UART disable/enable"

--- a/tests/benchmarks/multicore/idle_uarte/src/main.c
+++ b/tests/benchmarks/multicore/idle_uarte/src/main.c
@@ -5,11 +5,10 @@
  */
 
 #include <zephyr/drivers/uart.h>
+#include <zephyr/pm/device.h>
 #include <zephyr/pm/device_runtime.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/pm/device.h>
-#include <zephyr/pm/device_runtime.h>
 
 /* Note: logging is normally disabled for this test
  * Enable only for debugging purposes
@@ -141,28 +140,16 @@ int main(void)
 		pm_device_runtime_enable(console_dev);
 	}
 
-#if defined(CONFIG_TEST_AUTOMATIC_POWER_CONTROL)
-	enable_uart_rx();
-#endif
-
 	while (1) {
 		printk("Hello\n");
-
-#if !defined(CONFIG_TEST_AUTOMATIC_POWER_CONTROL)
 		enable_uart_rx();
-#endif
-
 		printk("UART test transmission\n");
 		err = uart_tx(uart_dev, test_pattern, TEST_BUFFER_LEN, UART_ACTION_BASE_TIMEOUT_US);
 		if (err != 0) {
 			printk("Unexpected error when sending UART TX data: %d\n", err);
 			return -1;
 		}
-
-#if !defined(CONFIG_TEST_AUTOMATIC_POWER_CONTROL)
 		disable_uart_rx();
-#endif
-
 		printk("Good night\n");
 		k_msleep(2000);
 	}

--- a/tests/benchmarks/multicore/idle_uarte/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_uarte/testcase.yaml
@@ -41,7 +41,10 @@ tests:
     extra_args:
       - SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
       - DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_normal.overlay"
-      - CONFIG_TEST_AUTOMATIC_POWER_CONTROL=y
+      - CONFIG_PRINTK=y
+      - CONFIG_LOG=y
+      - CONFIG_CONSOLE=y
+      - CONFIG_UART_CONSOLE=y
     harness_config:
       fixture: gpio_loopback
       pytest_root:


### PR DESCRIPTION
Backport db1d0d7f50f96aa7e2a0ed45fb884541eb933192 from #18767.