### PR TITLE
net: lib: wifi_credentials: Add EAP_SHA256 and auto-personal modes.

### DIFF
--- a/subsys/net/lib/wifi_credentials/wifi_credentials.c
+++ b/subsys/net/lib/wifi_credentials/wifi_credentials.c
@@ -136,8 +136,13 @@ int wifi_credentials_get_by_ssid_personal_struct(const char *ssid, size_t ssid_l
 	    buf->header.type != WIFI_SECURITY_TYPE_PSK &&
 	    buf->header.type != WIFI_SECURITY_TYPE_PSK_SHA256 &&
 	    buf->header.type != WIFI_SECURITY_TYPE_SAE &&
+	    buf->header.type != WIFI_SECURITY_TYPE_SAE_HNP &&
+	    buf->header.type != WIFI_SECURITY_TYPE_SAE_H2E &&
+	    buf->header.type != WIFI_SECURITY_TYPE_SAE_AUTO &&
 	    buf->header.type != WIFI_SECURITY_TYPE_EAP_TLS &&
-	    buf->header.type != WIFI_SECURITY_TYPE_WPA_PSK) {
+	    buf->header.type != WIFI_SECURITY_TYPE_WPA_PSK &&
+	    buf->header.type != WIFI_SECURITY_TYPE_EAP_TLS_SHA256 &&
+	    buf->header.type != WIFI_SECURITY_TYPE_WPA_AUTO_PERSONAL) {
 		LOG_ERR("Requested WiFi credentials entry is corrupted");
 		ret = -EPROTO;
 		goto exit;

--- a/subsys/net/lib/wifi_mgmt_ext/wifi_mgmt_ext.c
+++ b/subsys/net/lib/wifi_mgmt_ext/wifi_mgmt_ext.c
@@ -49,6 +49,17 @@ static const char client_cert2_test[] = {
 static const char client_key2_test[] = {
 	#include <wifi_enterprise_test_certs/client-key2.pem.inc>
 	'\0'};
+
+static bool is_enterprise_security(enum wifi_security_type security)
+{
+	switch (security) {
+	case WIFI_SECURITY_TYPE_EAP_TLS:
+	case WIFI_SECURITY_TYPE_EAP_TLS_SHA256:
+		return true;
+	default:
+		return false;
+	}
+}
 #endif /* CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE */
 
 static int __stored_creds_to_params(struct wifi_credentials_personal *creds,
@@ -100,7 +111,7 @@ static int __stored_creds_to_params(struct wifi_credentials_personal *creds,
 	/* Defaults */
 	params->security = creds->header.type;
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE
-	if (params->security == WIFI_SECURITY_TYPE_EAP_TLS) {
+	if (is_enterprise_security(params->security)) {
 		if (creds->header.key_passwd_length > 0) {
 			key_passwd = (char *)k_malloc(creds->header.key_passwd_length + 1);
 			if (!key_passwd) {
@@ -225,7 +236,7 @@ static int add_network_from_credentials_struct_personal(struct wifi_credentials_
 
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE
 	/* Load the enterprise credentials if needed */
-	if (cnx_params.security == WIFI_SECURITY_TYPE_EAP_TLS) {
+	if (is_enterprise_security(cnx_params.security)) {
 		wifi_set_enterprise_creds(iface);
 	}
 #endif


### PR DESCRIPTION
WPA_EAP_SHA256 support is missing in Wi-Fi credentials and wifi_mgmt_ext libraries, which results in failures when MFP is configured as `required` in AP.

Fixes SHEL-3256.