### PR TITLE
nrf_security: Refactor Cracen IKG keys

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_key_ids.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_key_ids.h
@@ -13,10 +13,6 @@
 
 #define CRACEN_PROTECTED_RAM_AES_KEY0_ID ((uint32_t)0x7fffc004)
 
-#define CRACEN_IDENTITY_KEY_SLOT_NUMBER 0
-#define CRACEN_MKEK_SLOT_NUMBER		1
-#define CRACEN_MEXT_SLOT_NUMBER		2
-
 #define PSA_KEY_LOCATION_CRACEN ((psa_key_location_t)(0x800000 | ('N' << 8)))
 
 /*

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/key_management.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/key_management.c
@@ -24,6 +24,7 @@
 #include <stddef.h>
 #include <string.h>
 #include <sxsymcrypt/trng.h>
+#include <sxsymcrypt/keyref.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/byteorder.h>
 
@@ -1147,6 +1148,25 @@ psa_status_t cracen_generate_key(const psa_key_attributes_t *attributes, uint8_t
 	return PSA_ERROR_NOT_SUPPORTED;
 }
 
+static void cracen_set_ikg_key_buffer(psa_key_attributes_t *attributes,
+				      psa_drv_slot_number_t slot_number, uint8_t *key_buffer)
+{
+	ikg_opaque_key *ikg_key = (ikg_opaque_key *)key_buffer;
+
+	switch (slot_number) {
+	case CRACEN_BUILTIN_IDENTITY_KEY_ID:
+		/* The slot_number is not used with the identity key */
+		break;
+	case CRACEN_BUILTIN_MKEK_ID:
+		ikg_key->slot_number = CRACEN_INTERNAL_HW_KEY1_ID;
+		break;
+	case CRACEN_BUILTIN_MEXT_ID:
+		ikg_key->slot_number = CRACEN_INTERNAL_HW_KEY2_ID;
+		break;
+	}
+
+	ikg_key->owner_id = MBEDTLS_SVC_KEY_ID_GET_OWNER_ID(psa_get_key_id(attributes));
+}
 
 psa_status_t cracen_get_builtin_key(psa_drv_slot_number_t slot_number,
 				    psa_key_attributes_t *attributes, uint8_t *key_buffer,
@@ -1160,7 +1180,7 @@ psa_status_t cracen_get_builtin_key(psa_drv_slot_number_t slot_number,
 	 * attributes, and update the `lifetime` field to be more specific.
 	 */
 	switch (slot_number) {
-	case CRACEN_IDENTITY_KEY_SLOT_NUMBER:
+	case CRACEN_BUILTIN_IDENTITY_KEY_ID:
 		psa_set_key_lifetime(attributes, PSA_KEY_LIFETIME_FROM_PERSISTENCE_AND_LOCATION(
 							 CRACEN_KEY_PERSISTENCE_READ_ONLY,
 							 PSA_KEY_LOCATION_CRACEN));
@@ -1183,18 +1203,15 @@ psa_status_t cracen_get_builtin_key(psa_drv_slot_number_t slot_number,
 		 */
 		if (key_buffer_size >= opaque_key_size) {
 			*key_buffer_length = opaque_key_size;
-			*((ikg_opaque_key *)key_buffer) =
-				(ikg_opaque_key){.slot_number = slot_number,
-						 .owner_id = MBEDTLS_SVC_KEY_ID_GET_OWNER_ID(
-							 psa_get_key_id(attributes))};
+			cracen_set_ikg_key_buffer(attributes, slot_number, key_buffer);
 			return PSA_SUCCESS;
 		} else {
 			return PSA_ERROR_BUFFER_TOO_SMALL;
 		}
 		break;
 
-	case CRACEN_MKEK_SLOT_NUMBER:
-	case CRACEN_MEXT_SLOT_NUMBER:
+	case CRACEN_BUILTIN_MKEK_ID:
+	case CRACEN_BUILTIN_MEXT_ID:
 		psa_set_key_lifetime(attributes, PSA_KEY_LIFETIME_FROM_PERSISTENCE_AND_LOCATION(
 							 CRACEN_KEY_PERSISTENCE_READ_ONLY,
 							 PSA_KEY_LOCATION_CRACEN));
@@ -1213,10 +1230,7 @@ psa_status_t cracen_get_builtin_key(psa_drv_slot_number_t slot_number,
 		 */
 		if (key_buffer_size >= opaque_key_size) {
 			*key_buffer_length = opaque_key_size;
-			*((ikg_opaque_key *)key_buffer) =
-				(ikg_opaque_key){.slot_number = slot_number,
-						 .owner_id = MBEDTLS_SVC_KEY_ID_GET_OWNER_ID(
-							 psa_get_key_id(attributes))};
+			cracen_set_ikg_key_buffer(attributes, slot_number, key_buffer);
 			return PSA_SUCCESS;
 		} else {
 			return PSA_ERROR_BUFFER_TOO_SMALL;
@@ -1239,21 +1253,30 @@ psa_status_t mbedtls_psa_platform_get_builtin_key(mbedtls_svc_key_id_t key_id,
 						  psa_key_lifetime_t *lifetime,
 						  psa_drv_slot_number_t *slot_number)
 {
+/* For nRF54H20 devices all the builtin keys are considered platform keys,
+ * these include the IKG keys. The IKG keys in these devices don't directly
+ * use the CRACEN_BUILTIN_ ids, they use the IDs defined in  the file
+ * nrf_platform_key_ids.h.
+ * The function cracen_platform_get_key_slot will do the matching between the
+ * platform key ids and the Cracen bulitin ids.
+ */
+#if CONFIG_PSA_NEED_CRACEN_PLATFORM_KEYS
+	return cracen_platform_get_key_slot(key_id, lifetime, slot_number);
+#else
+
 	switch (MBEDTLS_SVC_KEY_ID_GET_KEY_ID(key_id)) {
 	case CRACEN_BUILTIN_IDENTITY_KEY_ID:
-		*slot_number = CRACEN_IDENTITY_KEY_SLOT_NUMBER;
+		*slot_number = CRACEN_BUILTIN_IDENTITY_KEY_ID;
 		break;
 	case CRACEN_BUILTIN_MKEK_ID:
-		*slot_number = CRACEN_MKEK_SLOT_NUMBER;
+		*slot_number = CRACEN_BUILTIN_MKEK_ID;
 		break;
 	case CRACEN_BUILTIN_MEXT_ID:
-		*slot_number = CRACEN_MEXT_SLOT_NUMBER;
+		*slot_number = CRACEN_BUILTIN_MEXT_ID;
 		break;
 	default:
 #if CONFIG_PSA_NEED_CRACEN_KMU_DRIVER
 		return cracen_kmu_get_key_slot(key_id, lifetime, slot_number);
-#elif CONFIG_PSA_NEED_CRACEN_PLATFORM_KEYS
-		return cracen_platform_get_key_slot(key_id, lifetime, slot_number);
 #else
 		return PSA_ERROR_DOES_NOT_EXIST;
 #endif
@@ -1263,6 +1286,7 @@ psa_status_t mbedtls_psa_platform_get_builtin_key(mbedtls_svc_key_id_t key_id,
 								   PSA_KEY_LOCATION_CRACEN);
 
 	return PSA_SUCCESS;
+#endif /* CONFIG_PSA_NEED_CRACEN_PLATFORM_KEYS */
 }
 
 psa_status_t cracen_export_key(const psa_key_attributes_t *attributes, const uint8_t *key_buffer,

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/platform_keys/platform_keys.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/platform_keys/platform_keys.h
@@ -16,6 +16,10 @@ psa_status_t cracen_platform_get_builtin_key(psa_drv_slot_number_t slot_number,
 psa_status_t cracen_platform_keys_get_size(psa_key_attributes_t const *attributes,
 					   size_t *key_size);
 
+bool cracen_platform_keys_is_ikg_key(psa_key_attributes_t const *attributes);
+
+uint32_t cracen_platform_keys_get_owner(psa_key_attributes_t const *attributes);
+
 psa_status_t cracen_platform_get_key_slot(mbedtls_svc_key_id_t key_id, psa_key_lifetime_t *lifetime,
 					  psa_drv_slot_number_t *slot_number);
 


### PR DESCRIPTION
This fixes an issue where the KMU keys 0-2 on the nRF54L15 cannot be used to store keys.

This refactors how we handle the IKG key IDs for
Cracen. Before this change we used the internal
Cracen IKG key identifiers inside the builtin key
driver. This had an issue because both the KMU keys and the IKG internal key IDs share the IDs 0-2.

To avoid this collision the IKG handling is refactored to use the reserved Cracen PSA key identifiers in the driver level and only use the internal key intentifiers deeper in the implementation in order to avoid the conflicts.

This also removes unused structs related to the IKG keys and unused code as well.

test_crypto: PR-765
