### PR TITLE
samples: wifi: Fix 54 series docs

### DIFF
--- a/samples/wifi/radio_test/sample.yaml
+++ b/samples/wifi/radio_test/sample.yaml
@@ -79,6 +79,9 @@ tests:
     extra_args:
       - radio_test_SHIELD="nrf7002eb_interposer_p1;nrf7002eb"
       - SNIPPET=nrf70-wifi
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp

--- a/samples/wifi/scan/sample.yaml
+++ b/samples/wifi/scan/sample.yaml
@@ -52,6 +52,9 @@ tests:
     extra_args:
       - scan_SHIELD=nrf7002eb_interposer_p1 nrf7002eb
       - scan_SNIPPET=nrf70-wifi
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp

--- a/samples/wifi/shell/sample.yaml
+++ b/samples/wifi/shell/sample.yaml
@@ -209,6 +209,9 @@ tests:
     extra_args:
       - shell_SHIELD=nrf7002eb_interposer_p1 nrf7002eb
       - shell_SNIPPET=nrf70-wifi
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp

--- a/samples/wifi/sta/sample.yaml
+++ b/samples/wifi/sta/sample.yaml
@@ -64,6 +64,9 @@ tests:
     extra_args:
       - sta_SHIELD=nrf7002eb_interposer_p1 nrf7002eb
       - sta_SNIPPET=nrf70-wifi
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp


### PR DESCRIPTION
Due to missing integration platforms, 54 Series doesn't show in the auto generated table in the README.

It was broken in 8ae6472d41 ("samples: wifi: shell: Update nrf7002eb_interposer tests").