### PR TITLE
[Backport v2.8-branch] quarantine: wifi provisioning tests on macOS

### DIFF
--- a/scripts/quarantine_windows_mac.yaml
+++ b/scripts/quarantine_windows_mac.yaml
@@ -40,4 +40,7 @@
   platforms:
     - nrf5340dk/nrf5340/cpuapp
     - nrf5340dk/nrf5340/cpuapp/ns
+    - nrf7002dk/nrf5340/cpuapp
+    - nrf7002dk/nrf5340/cpuapp/ns
+    - thingy53/nrf5340/cpuapp/ns
   comment: "https://nordicsemi.atlassian.net/browse/SHEL-3161"


### PR DESCRIPTION
Backport db0b80c8d5ffa81b1fe528e650e6f62afc6c79ef from #18800.