### PR TITLE
manifest: Bring SHA512 fix for MCUboot serial recovery.

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -129,7 +129,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: e60dc3fbd7ce52d6fdc5352cf0a98c159c7a95f5
+      revision: bcdf6e24493a0c3de7c5f3a126a6b4075b2ad088
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR


### PR DESCRIPTION
Fix for non-working serial recovery with MCUboot configured for SHA512.

Fix for NCSDK-30244