### PR TITLE
samples: cellular: nrf_cloud_rest_*: make credentials check optional

### DIFF
--- a/doc/nrf/external_comp/nrf_cloud.rst
+++ b/doc/nrf/external_comp/nrf_cloud.rst
@@ -253,7 +253,7 @@ The following samples demonstrate nRF Cloud-specific functionality using REST:
 
 * :ref:`nrf_cloud_rest_fota`
 * :ref:`nrf_cloud_rest_device_message`
-* :ref:`nrf_cloud_rest_cell_pos_sample`
+* :ref:`nrf_cloud_rest_cell_location`
 
 Other related samples and applications that use nRF Cloud services:
 

--- a/doc/nrf/releases_and_maturity/known_issues.rst
+++ b/doc/nrf/releases_and_maturity/known_issues.rst
@@ -2633,7 +2633,7 @@ IRIS-7398: The :ref:`nrf_cloud_multi_service` sample does not support using the 
 
 .. rst-class:: v2-8-0 v2-7-0 v2-6-2 v2-6-1 v2-6-0 v2-5-3 v2-5-2 v2-5-1 v2-5-0 v2-4-4 v2-4-3 v2-4-2 v2-4-1 v2-4-0 v2-3-0 v2-2-0 v2-1-4 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0
 
-IRIS-7381: :ref:`nrf_cloud_rest_cell_pos_sample` sample might attempt to take a neighbor cell measurement when a measurement is already in progress
+IRIS-7381: :ref:`nrf_cloud_rest_cell_location` sample might attempt to take a neighbor cell measurement when a measurement is already in progress
   If cell information changes during a neighbor cell measurement, the sample will attempt to start a new measurement, resulting in warning and error log messages.
 
   **Affected platforms:** nRF9160, nRF9161

--- a/doc/nrf/releases_and_maturity/releases/release-notes-2.0.0.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-2.0.0.rst
@@ -357,7 +357,7 @@ nRF9160 samples
   * :ref:`modem_callbacks_sample` sample, showcasing initialization and de-initialization callbacks.
   * :ref:`nrf_cloud_multi_service` sample, demonstrating a simple but robust integration of location services, FOTA, sensor sampling, and more.
   * Shell functionality to HTTP Update samples.
-  * :ref:`nrf_cloud_rest_cell_pos_sample` sample, demonstrating how to use the :ref:`lib_nrf_cloud_rest` library to perform cellular positioning requests.
+  * :ref:`nrf_cloud_rest_cell_location` sample, demonstrating how to use the :ref:`lib_nrf_cloud_rest` library to perform cellular positioning requests.
   * :ref:`ciphersuites` sample, demonstrating how to use TLS cipher suites.
 
 * Secure Partition Manager (rather than TF-M) is enabled by default for the applications and samples that support Thingy:91.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-2.2.0.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-2.2.0.rst
@@ -472,7 +472,7 @@ nRF9160 samples
   * Removed A-GPS and P-GPS processing.
     It is now handled by the :ref:`lib_nrf_cloud` library.
 
-* Renamed the nRF9160: nRF Cloud REST cellular position sample to :ref:`nrf_cloud_rest_cell_pos_sample` sample.
+* Renamed the nRF9160: nRF Cloud REST cellular position sample to :ref:`nrf_cloud_rest_cell_location` sample.
   Sample files are moved from ``samples/nrf9160/nrf_cloud_rest_cell_pos`` to ``samples/nrf9160/nrf_cloud_rest_cell_location``.
 
 Trusted Firmware-M (TF-M) samples

--- a/doc/nrf/releases_and_maturity/releases/release-notes-2.3.0.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-2.3.0.rst
@@ -499,7 +499,7 @@ nRF9160 samples
     * Timeout command-line arguments for the ``location get`` command changed from integers in milliseconds to floating-point values in seconds.
     * Replaced deprecated LwM2M API calls with calls to new functions.
 
-* :ref:`nrf_cloud_rest_cell_pos_sample` sample:
+* :ref:`nrf_cloud_rest_cell_location` sample:
 
   * Added the usage of GCI search option if running modem firmware v1.3.4.
   * Updated the sample to wait for RRC idle mode before requesting neighbor cell measurements.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-2.5.0.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-2.5.0.rst
@@ -606,7 +606,7 @@ Cellular samples (renamed from nRF9160 samples)
 
   * Updated the TF-M Mbed TLS overlay to fix an issue when connecting to the server.
 
-* :ref:`nrf_cloud_rest_cell_pos_sample` sample:
+* :ref:`nrf_cloud_rest_cell_location` sample:
 
   * Added:
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-2.6.0.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-2.6.0.rst
@@ -765,7 +765,7 @@ Cellular samples
     * The sample now uses the functions in the :file:`nrf_cloud_fota_poll.c` and :file:`nrf_cloud_fota_common.c` files.
     * The :kconfig:option:`CONFIG_AT_HOST_STACK_SIZE` Kconfig option value has been increased to 2048 bytes since nRF Cloud credentials are sometimes longer than 1024 bytes.
 
-* :ref:`nrf_cloud_rest_cell_pos_sample` sample:
+* :ref:`nrf_cloud_rest_cell_location` sample:
 
   * Added:
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-2.7.0.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-2.7.0.rst
@@ -707,7 +707,7 @@ Cellular samples
 
   * Removed ESP8266 Wi-Fi DTC and Kconfig overlay files.
 
-* :ref:`nrf_cloud_rest_cell_pos_sample` sample:
+* :ref:`nrf_cloud_rest_cell_location` sample:
 
   * Added the :ref:`CONFIG_REST_CELL_SEND_DEVICE_STATUS <CONFIG_REST_CELL_SEND_DEVICE_STATUS>` Kconfig option to control sending device status on initial connection.
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-2.8.0.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-2.8.0.rst
@@ -812,7 +812,7 @@ Cellular samples
 
   * Removed redundant logging that is now done by the :ref:`lib_nrf_cloud` library.
 
-* :ref:`nrf_cloud_rest_cell_pos_sample` sample:
+* :ref:`nrf_cloud_rest_cell_location` sample:
 
   * Removed redundant logging that is now done by the :ref:`lib_nrf_cloud` library.
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -267,7 +267,7 @@ Cellular samples
 
 * Updated the :kconfig:option:`CONFIG_NRF_CLOUD_CHECK_CREDENTIALS` Kconfig option to be optional and enabled by default for the following samples:
 
-  * :ref:`nrf_cloud_rest_cell_pos_sample`
+  * :ref:`nrf_cloud_rest_cell_location`
   * :ref:`nrf_cloud_rest_device_message`
   * :ref:`nrf_cloud_rest_fota`
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -265,12 +265,17 @@ Bluetooth Mesh samples
 Cellular samples
 ----------------
 
+* Updated the :kconfig:option:`CONFIG_NRF_CLOUD_CHECK_CREDENTIALS` Kconfig option to be optional and enabled by default for the following samples:
+
+  * :ref:`nrf_cloud_rest_cell_pos_sample`
+  * :ref:`nrf_cloud_rest_device_message`
+  * :ref:`nrf_cloud_rest_fota`
+
 * :ref:`location_sample` sample:
 
   * Updated:
 
     * The Thingy:91 X build to support Wi-Fi by default without overlays.
-
 
 Cryptography samples
 --------------------

--- a/samples/cellular/nrf_cloud_rest_cell_location/README.rst
+++ b/samples/cellular/nrf_cloud_rest_cell_location/README.rst
@@ -1,4 +1,4 @@
-.. _nrf_cloud_rest_cell_pos_sample:
+.. _nrf_cloud_rest_cell_location:
 
 Cellular: nRF Cloud REST cellular location
 ##########################################

--- a/samples/cellular/nrf_cloud_rest_cell_location/src/main.c
+++ b/samples/cellular/nrf_cloud_rest_cell_location/src/main.c
@@ -579,6 +579,7 @@ static void connect_to_network(void)
 
 static void check_credentials(void)
 {
+#if defined(CONFIG_NRF_CLOUD_CHECK_CREDENTIALS)
 	int err = nrf_cloud_credentials_configured_check();
 
 	if ((err == -ENOTSUP) || (err == -ENOPROTOOPT)) {
@@ -589,6 +590,9 @@ static void check_credentials(void)
 		LOG_ERR("nrf_cloud_credentials_configured_check() failed, error: %d", err);
 		LOG_WRN("Continuing without verifying that credentials are installed");
 	}
+#else
+	LOG_DBG("nRF Cloud credentials check not enabled");
+#endif /* defined(CONFIG_NRF_CLOUD_CHECK_CREDENTIALS) */
 }
 
 int main(void)

--- a/samples/cellular/nrf_cloud_rest_fota/src/main.c
+++ b/samples/cellular/nrf_cloud_rest_fota/src/main.c
@@ -472,6 +472,7 @@ static void sample_reboot(enum nrf_cloud_fota_reboot_status status)
 
 static void check_credentials(void)
 {
+#if defined(CONFIG_NRF_CLOUD_CHECK_CREDENTIALS)
 	int err = nrf_cloud_credentials_configured_check();
 
 	if (err == -ENOTSUP) {
@@ -485,6 +486,9 @@ static void check_credentials(void)
 		LOG_ERR("nrf_cloud_credentials_configured_check() failed, error: %d", err);
 		LOG_WRN("Continuing without verifying that credentials are installed");
 	}
+#else
+	LOG_DBG("nRF Cloud credentials check not enabled");
+#endif /* defined(CONFIG_NRF_CLOUD_CHECK_CREDENTIALS) */
 }
 
 int main(void)


### PR DESCRIPTION
This patch makes it possible to build the nRF Cloud REST samples without checking the credentials. Jira: IRIS-9758