### PR TITLE
tests: benchmarks: multicore: Increase HPU test suite timeout

### DIFF
--- a/tests/benchmarks/multicore/idle_hpu_temp_meas/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_hpu_temp_meas/testcase.yaml
@@ -15,4 +15,4 @@ tests:
       fixture: ppk_power_measure
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_hpu_feature"
-    timeout: 90
+    timeout: 120


### PR DESCRIPTION
90s is still not enough, increase to 120s