### PR TITLE
samples: openthread: fix usb snippet doc for nrf54l15

### DIFF
--- a/samples/openthread/cli/README.rst
+++ b/samples/openthread/cli/README.rst
@@ -97,6 +97,10 @@ Snippets
 The following snippets are available:
 
 * ``usb`` - Enables USB transport support.
+
+  .. note::
+     The ``usb`` snippet is not supported for the ``nrf54l15dk/nrf54l15/cpuapp`` board target.
+
 * ``logging`` - Enables logging using RTT.
   For additional options, refer to :ref:`RTT logging <ug_logging_backends_rtt>`.
 * ``debug`` - Enables debugging the Thread sample with GDB thread awareness.

--- a/samples/openthread/coprocessor/README.rst
+++ b/samples/openthread/coprocessor/README.rst
@@ -109,6 +109,10 @@ The following snippets are available:
 * ``logging`` - Enables logging using RTT.
   For additional options, refer to :ref:`RTT logging <ug_logging_backends_rtt>`.
 * ``usb`` - Enables emulating a serial port over USB for Spinel communication with the host.
+
+  .. note::
+     The ``usb`` snippet is not supported for the ``nrf54l15dk/nrf54l15/cpuapp`` board target.
+
 * ``hci`` - Enables support for the Bluetooth HCI interface parallel to :ref:`Thread RCP <thread_architectures_designs_cp_rcp>`.
 
 FEM support


### PR DESCRIPTION
add information that usb snippet is not supported for nrf54l15