### PR TITLE
[Backport v2.8-branch] tests: benchmarks: peripheral_load: fix test

### DIFF
--- a/tests/benchmarks/peripheral_load/src/common.h
+++ b/tests/benchmarks/peripheral_load/src/common.h
@@ -49,7 +49,7 @@ extern atomic_t completed_threads;
 
 /* FLASH thread: */
 #define FLASH_THREAD_COUNT_MAX	(40)
-#define FLASH_THREAD_STACKSIZE	(1024)
+#define FLASH_THREAD_STACKSIZE	(2048)
 #define FLASH_THREAD_PRIORITY	(5)
 #define FLASH_THREAD_SLEEP		(200)
 


### PR DESCRIPTION
Backport af40990348bf433602be4c41f5c7ab47cd4fbf3d from #18788.