### PR TITLE
esb: Fix dynamic interrupts usage

### DIFF
--- a/samples/esb/esb_prx/sample.yaml
+++ b/samples/esb/esb_prx/sample.yaml
@@ -42,10 +42,17 @@ tests:
       - CONFIG_ESB_DYNAMIC_INTERRUPTS=y
       - CONFIG_DYNAMIC_INTERRUPTS=y
       - CONFIG_DYNAMIC_DIRECT_INTERRUPTS=y
+      - CONFIG_MPSL_DYNAMIC_INTERRUPTS=y
     integration_platforms:
       - nrf5340dk/nrf5340/cpunet
       - nrf52840dk/nrf52840
-    platform_allow: nrf5340dk/nrf5340/cpunet nrf52840dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpurad
+    platform_allow: >
+      nrf5340dk/nrf5340/cpunet
+      nrf52840dk/nrf52840
+      nrf54l15dk/nrf54l15/cpuapp
+      nrf54h20dk/nrf54h20/cpurad
     tags: esb ci_build sysbuild ci_samples_esb
   sample.esb.prx.nrf5340_nrf21540:
     sysbuild: true

--- a/samples/esb/esb_ptx/sample.yaml
+++ b/samples/esb/esb_ptx/sample.yaml
@@ -42,10 +42,17 @@ tests:
       - CONFIG_ESB_DYNAMIC_INTERRUPTS=y
       - CONFIG_DYNAMIC_INTERRUPTS=y
       - CONFIG_DYNAMIC_DIRECT_INTERRUPTS=y
+      - CONFIG_MPSL_DYNAMIC_INTERRUPTS=y
     integration_platforms:
       - nrf5340dk/nrf5340/cpunet
       - nrf52840dk/nrf52840
-    platform_allow: nrf5340dk/nrf5340/cpunet nrf52840dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpurad
+    platform_allow: >
+      nrf5340dk/nrf5340/cpunet
+      nrf52840dk/nrf52840
+      nrf54l15dk/nrf54l15/cpuapp
+      nrf54h20dk/nrf54h20/cpurad
     tags: esb ci_build sysbuild ci_samples_esb
   sample.esb.ptx.nrf5340_nrf21540:
     sysbuild: true

--- a/subsys/esb/esb.c
+++ b/subsys/esb/esb.c
@@ -1625,7 +1625,7 @@ static void evt_dynamic_irq_handler(const void *args)
 {
 	ARG_UNUSED(args);
 	if (IS_ENABLED(ESB_EVT_USING_EGU)) {
-		nrf_egu_event_clear(ESB_EGU, ESB_EGU_EVT_TASK);
+		nrf_egu_event_clear(ESB_EGU, ESB_EGU_EVT_EVENT);
 	}
 	esb_evt_irq_handler();
 	ISR_DIRECT_PM();


### PR DESCRIPTION
Fixed dynamic interrupts implementation.
Updated sample.yaml with a test case for dynamic interrupts.
