### PR TITLE
[Backport v2.8-branch] tests: benchmarks: power_consumption: adc: multicore app for nrf54h20

### DIFF
--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -1271,6 +1271,7 @@ ci_tests_benchmarks_current_consumption:
     - nrf/include/nfc/
     - nrf/subsys/nfc/
     - nrf/tests/benchmarks/current_consumption/
+    - nrf/tests/benchmarks/power_consumption/
     - nrfxlib/nfc/
     - zephyr/boards/nordic/
     - zephyr/drivers/gpio/
@@ -1283,6 +1284,7 @@ ci_tests_benchmarks_current_consumption:
     - zephyr/drivers/spi/
     - zephyr/drivers/counter/
     - zephyr/soc/nordic/
+    - zephyr/drivers/sensor/nordic/temp/
 
 ci_tests_drivers_egpio:
   files:

--- a/tests/benchmarks/power_consumption/adc/Kconfig.sysbuild
+++ b/tests/benchmarks/power_consumption/adc/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+
+config REMOTE_BOARD
+	string "The board used for remote target"

--- a/tests/benchmarks/power_consumption/adc/sysbuild.cmake
+++ b/tests/benchmarks/power_consumption/adc/sysbuild.cmake
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+if(NOT "${SB_CONFIG_REMOTE_BOARD}" STREQUAL "")
+  ExternalZephyrProject_Add(
+    APPLICATION remote_sleep_forever
+    SOURCE_DIR ${APP_DIR}/../common/remote_sleep_forever
+    BOARD ${SB_CONFIG_REMOTE_BOARD}
+    BOARD_REVISION ${BOARD_REVISION}
+  )
+
+  add_dependencies(adc remote_sleep_forever)
+  sysbuild_add_dependencies(FLASH adc remote_sleep_forever)
+endif()

--- a/tests/benchmarks/power_consumption/adc/sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
+++ b/tests/benchmarks/power_consumption/adc/sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
@@ -1,0 +1,1 @@
+SB_CONFIG_REMOTE_BOARD="nrf54h20dk/nrf54h20/cpurad"

--- a/tests/benchmarks/power_consumption/adc/testcase.yaml
+++ b/tests/benchmarks/power_consumption/adc/testcase.yaml
@@ -13,10 +13,13 @@ tests:
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_thread_suspend_resume_adc_54L"
   benchmarks.power_consumption.adc_nrf54h:
+    sysbuild: true
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
+    extra_args:
+      SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
     harness: pytest
     harness_config:
       fixture: ppk_power_measure

--- a/tests/benchmarks/power_consumption/adc_async/Kconfig.sysbuild
+++ b/tests/benchmarks/power_consumption/adc_async/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+
+config REMOTE_BOARD
+	string "The board used for remote target"

--- a/tests/benchmarks/power_consumption/adc_async/sysbuild.cmake
+++ b/tests/benchmarks/power_consumption/adc_async/sysbuild.cmake
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+if(NOT "${SB_CONFIG_REMOTE_BOARD}" STREQUAL "")
+  ExternalZephyrProject_Add(
+    APPLICATION remote_sleep_forever
+    SOURCE_DIR ${APP_DIR}/../common/remote_sleep_forever
+    BOARD ${SB_CONFIG_REMOTE_BOARD}
+    BOARD_REVISION ${BOARD_REVISION}
+  )
+
+  add_dependencies(adc_async remote_sleep_forever)
+  sysbuild_add_dependencies(FLASH adc_async remote_sleep_forever)
+endif()

--- a/tests/benchmarks/power_consumption/adc_async/sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
+++ b/tests/benchmarks/power_consumption/adc_async/sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
@@ -1,0 +1,1 @@
+SB_CONFIG_REMOTE_BOARD="nrf54h20dk/nrf54h20/cpurad"

--- a/tests/benchmarks/power_consumption/adc_async/testcase.yaml
+++ b/tests/benchmarks/power_consumption/adc_async/testcase.yaml
@@ -13,10 +13,13 @@ tests:
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_thread_suspend_resume_adc_async_54L"
   benchmarks.power_consumption.adc_async_nrf54h:
+    sysbuild: true
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
+    extra_args:
+      SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
     harness: pytest
     harness_config:
       fixture: ppk_power_measure

--- a/tests/benchmarks/power_consumption/flash/Kconfig.sysbuild
+++ b/tests/benchmarks/power_consumption/flash/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+
+config REMOTE_BOARD
+	string "The board used for remote target"

--- a/tests/benchmarks/power_consumption/flash/sysbuild.cmake
+++ b/tests/benchmarks/power_consumption/flash/sysbuild.cmake
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+if(NOT "${SB_CONFIG_REMOTE_BOARD}" STREQUAL "")
+  ExternalZephyrProject_Add(
+    APPLICATION remote_sleep_forever
+    SOURCE_DIR ${APP_DIR}/../common/remote_sleep_forever
+    BOARD ${SB_CONFIG_REMOTE_BOARD}
+    BOARD_REVISION ${BOARD_REVISION}
+  )
+
+  add_dependencies(flash remote_sleep_forever)
+  sysbuild_add_dependencies(FLASH flash remote_sleep_forever)
+endif()

--- a/tests/benchmarks/power_consumption/flash/sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
+++ b/tests/benchmarks/power_consumption/flash/sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
@@ -1,0 +1,1 @@
+SB_CONFIG_REMOTE_BOARD="nrf54h20dk/nrf54h20/cpurad"

--- a/tests/benchmarks/power_consumption/flash/testcase.yaml
+++ b/tests/benchmarks/power_consumption/flash/testcase.yaml
@@ -13,11 +13,14 @@ tests:
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_thread_suspend_resume_flash_54L"
   benchmarks.power_consumption.flash_nrf54h:
-    harness: pytest
+    sysbuild: true
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
+    extra_args:
+      SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
+    harness: pytest
     harness_config:
       fixture: ppk_power_measure
       pytest_root:

--- a/tests/benchmarks/power_consumption/i2c/Kconfig.sysbuild
+++ b/tests/benchmarks/power_consumption/i2c/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+
+config REMOTE_BOARD
+	string "The board used for remote target"

--- a/tests/benchmarks/power_consumption/i2c/sysbuild.cmake
+++ b/tests/benchmarks/power_consumption/i2c/sysbuild.cmake
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+if(NOT "${SB_CONFIG_REMOTE_BOARD}" STREQUAL "")
+  ExternalZephyrProject_Add(
+    APPLICATION remote_sleep_forever
+    SOURCE_DIR ${APP_DIR}/../common/remote_sleep_forever
+    BOARD ${SB_CONFIG_REMOTE_BOARD}
+    BOARD_REVISION ${BOARD_REVISION}
+  )
+
+  add_dependencies(i2c remote_sleep_forever)
+  sysbuild_add_dependencies(FLASH i2c remote_sleep_forever)
+endif()

--- a/tests/benchmarks/power_consumption/i2c/sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
+++ b/tests/benchmarks/power_consumption/i2c/sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
@@ -1,0 +1,1 @@
+SB_CONFIG_REMOTE_BOARD="nrf54h20dk/nrf54h20/cpurad"

--- a/tests/benchmarks/power_consumption/i2c/testcase.yaml
+++ b/tests/benchmarks/power_consumption/i2c/testcase.yaml
@@ -16,12 +16,14 @@ tests:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_thread_suspend_resume_i2c_54L"
   benchmarks.power_consumption.i2c_nrf54h:
     harness: pytest
+    sysbuild: true
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
       - SHIELD=pca63566
+      - SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
     harness_config:
       fixture: pca63566
       pytest_root:

--- a/tests/benchmarks/power_consumption/spi/Kconfig.sysbuild
+++ b/tests/benchmarks/power_consumption/spi/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+
+config REMOTE_BOARD
+	string "The board used for remote target"

--- a/tests/benchmarks/power_consumption/spi/sysbuild.cmake
+++ b/tests/benchmarks/power_consumption/spi/sysbuild.cmake
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+if(NOT "${SB_CONFIG_REMOTE_BOARD}" STREQUAL "")
+  ExternalZephyrProject_Add(
+    APPLICATION remote_sleep_forever
+    SOURCE_DIR ${APP_DIR}/../common/remote_sleep_forever
+    BOARD ${SB_CONFIG_REMOTE_BOARD}
+    BOARD_REVISION ${BOARD_REVISION}
+  )
+
+  add_dependencies(spi remote_sleep_forever)
+  sysbuild_add_dependencies(FLASH spi remote_sleep_forever)
+endif()

--- a/tests/benchmarks/power_consumption/spi/sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
+++ b/tests/benchmarks/power_consumption/spi/sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
@@ -1,0 +1,1 @@
+SB_CONFIG_REMOTE_BOARD="nrf54h20dk/nrf54h20/cpurad"

--- a/tests/benchmarks/power_consumption/spi/testcase.yaml
+++ b/tests/benchmarks/power_consumption/spi/testcase.yaml
@@ -16,12 +16,14 @@ tests:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_thread_suspend_resume_spi_54L"
   benchmarks.power_consumption.spi_nrf54h:
     harness: pytest
+    sysbuild: true
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
       - SHIELD=pca63566
+      - SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
     harness_config:
       fixture: pca63566
       pytest_root:

--- a/tests/benchmarks/power_consumption/timer_waiting/Kconfig.sysbuild
+++ b/tests/benchmarks/power_consumption/timer_waiting/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+
+config REMOTE_BOARD
+	string "The board used for remote target"

--- a/tests/benchmarks/power_consumption/timer_waiting/sysbuild.cmake
+++ b/tests/benchmarks/power_consumption/timer_waiting/sysbuild.cmake
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+if(NOT "${SB_CONFIG_REMOTE_BOARD}" STREQUAL "")
+  ExternalZephyrProject_Add(
+    APPLICATION remote_sleep_forever
+    SOURCE_DIR ${APP_DIR}/../common/remote_sleep_forever
+    BOARD ${SB_CONFIG_REMOTE_BOARD}
+    BOARD_REVISION ${BOARD_REVISION}
+  )
+
+  add_dependencies(timer_waiting remote_sleep_forever)
+  sysbuild_add_dependencies(FLASH timer_waiting remote_sleep_forever)
+endif()

--- a/tests/benchmarks/power_consumption/timer_waiting/sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
+++ b/tests/benchmarks/power_consumption/timer_waiting/sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
@@ -1,0 +1,1 @@
+SB_CONFIG_REMOTE_BOARD="nrf54h20dk/nrf54h20/cpurad"

--- a/tests/benchmarks/power_consumption/timer_waiting/testcase.yaml
+++ b/tests/benchmarks/power_consumption/timer_waiting/testcase.yaml
@@ -39,24 +39,28 @@ tests:
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_for_timer_waiting_54L_16M"
   benchmarks.power_consumption.timer_waiting_16M_nrf54h:
+    sysbuild: true
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
       - DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_16M.overlay"
+      - SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
     harness: pytest
     harness_config:
       fixture: ppk_power_measure
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_for_timer_waiting_54H_16M"
   benchmarks.power_consumption.timer_waiting_320M_nrf54h:
+    sysbuild: true
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
       - DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_320M.overlay"
+      - SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
     harness: pytest
     harness_config:
       fixture: ppk_power_measure

--- a/tests/benchmarks/power_consumption/uart_async/Kconfig.sysbuild
+++ b/tests/benchmarks/power_consumption/uart_async/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+
+config REMOTE_BOARD
+	string "The board used for remote target"

--- a/tests/benchmarks/power_consumption/uart_async/sysbuild.cmake
+++ b/tests/benchmarks/power_consumption/uart_async/sysbuild.cmake
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+if(NOT "${SB_CONFIG_REMOTE_BOARD}" STREQUAL "")
+  ExternalZephyrProject_Add(
+    APPLICATION remote_sleep_forever
+    SOURCE_DIR ${APP_DIR}/../common/remote_sleep_forever
+    BOARD ${SB_CONFIG_REMOTE_BOARD}
+    BOARD_REVISION ${BOARD_REVISION}
+  )
+
+  add_dependencies(uart_async remote_sleep_forever)
+  sysbuild_add_dependencies(FLASH uart_async remote_sleep_forever)
+endif()

--- a/tests/benchmarks/power_consumption/uart_async/sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
+++ b/tests/benchmarks/power_consumption/uart_async/sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
@@ -1,0 +1,1 @@
+SB_CONFIG_REMOTE_BOARD="nrf54h20dk/nrf54h20/cpurad"

--- a/tests/benchmarks/power_consumption/uart_async/testcase.yaml
+++ b/tests/benchmarks/power_consumption/uart_async/testcase.yaml
@@ -13,10 +13,13 @@ tests:
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_thread_suspend_resume_uart_async_54L"
   benchmarks.power_consumption.uart_async_nrf54h:
+    sysbuild: true
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
+    extra_args:
+      SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
     harness: pytest
     harness_config:
       fixture: ppk_power_measure

--- a/tests/benchmarks/power_consumption/uart_polling/Kconfig.sysbuild
+++ b/tests/benchmarks/power_consumption/uart_polling/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+
+config REMOTE_BOARD
+	string "The board used for remote target"

--- a/tests/benchmarks/power_consumption/uart_polling/sysbuild.cmake
+++ b/tests/benchmarks/power_consumption/uart_polling/sysbuild.cmake
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+if(NOT "${SB_CONFIG_REMOTE_BOARD}" STREQUAL "")
+  ExternalZephyrProject_Add(
+    APPLICATION remote_sleep_forever
+    SOURCE_DIR ${APP_DIR}/../common/remote_sleep_forever
+    BOARD ${SB_CONFIG_REMOTE_BOARD}
+    BOARD_REVISION ${BOARD_REVISION}
+  )
+
+  add_dependencies(uart_polling remote_sleep_forever)
+  sysbuild_add_dependencies(FLASH uart_polling remote_sleep_forever)
+endif()

--- a/tests/benchmarks/power_consumption/uart_polling/sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
+++ b/tests/benchmarks/power_consumption/uart_polling/sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
@@ -1,0 +1,1 @@
+SB_CONFIG_REMOTE_BOARD="nrf54h20dk/nrf54h20/cpurad"

--- a/tests/benchmarks/power_consumption/uart_polling/testcase.yaml
+++ b/tests/benchmarks/power_consumption/uart_polling/testcase.yaml
@@ -13,10 +13,13 @@ tests:
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_thread_suspend_resume_uart_polling_54L"
   benchmarks.power_consumption.uart_poll_nrf54h:
+    sysbuild: true
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
+    extra_args:
+      SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
     harness: pytest
     harness_config:
       fixture: ppk_power_measure


### PR DESCRIPTION
Backport 3b99e7182fba5390c9d151027f32b2c8741e243b~8..3b99e7182fba5390c9d151027f32b2c8741e243b from #18826.