### PR TITLE
[Backport v2.8-branch] doc: Add NFC entry in the SW Maturity Level page.

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -1542,7 +1542,7 @@
 .. _`NFC Forum specification overview`: https://nfc-forum.org/build/specifications
 .. _`Bluetooth Secure Simple Pairing Using NFC`: https://nfc-forum.org/build/specifications#application-documents
 
-.. _`ISO/IEC 7816-4`: https://www.iso.org/standard/54550.html
+.. _`ISO/IEC 7816-4`: https://www.iso.org/standard/77180.html
 
 .. _`802.15.2-2003 specification`: https://standards.ieee.org/standard/802_15_2-2003.html
 

--- a/doc/nrf/releases_and_maturity/software_maturity.rst
+++ b/doc/nrf/releases_and_maturity/software_maturity.rst
@@ -258,6 +258,20 @@ The following table indicates the software maturity levels of the support for ea
      - --
      - --
      - --
+   * - **NFC**
+     - --
+     - --
+     - --
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Experimental
+     - Supported
+     - --
+     - --
+     - --
+     - --
    * - **Sidewalk**
      - --
      - --
@@ -1122,6 +1136,146 @@ The following table indicates the software maturity levels of the support for ea
         - --
         - --
         - --
+
+NFC features support
+********************
+
+The following table indicates the software maturity levels of the support for each NFC feature:
+
+.. toggle::
+
+  .. list-table::
+      :widths: auto
+      :header-rows: 1
+
+      * -
+        - nRF52810
+        - nRF52811
+        - nRF52820
+        - nRF52832
+        - nRF52833
+        - nRF52840
+        - nRF5340
+        - nRF54H20
+        - nRF54L15
+        - nRF9131
+        - nRF9151
+        - nRF9160
+        - nRF9161
+      * - **NFC Type 2 Tag (read-only)**
+        - --
+        - --
+        - --
+        - Supported
+        - Supported
+        - Supported
+        - Supported
+        - Experimental
+        - Supported
+        - --
+        - --
+        - --
+        - --
+      * - **NFC Type 4 Tag (read/write)**
+        - --
+        - --
+        - --
+        - Supported
+        - Supported
+        - Supported
+        - Supported
+        - Experimental
+        - Supported
+        - --
+        - --
+        - --
+        - --
+      * - **NFC Reader/Writer (polling device)**
+        - --
+        - --
+        - --
+        - Supported
+        - Supported
+        - Supported
+        - Supported
+        - --
+        - --
+        - --
+        - --
+        - --
+        - --
+      * - **NFC ISO-DEP protocol (ISO/IEC 14443-4)**
+        - --
+        - --
+        - --
+        - Supported
+        - Supported
+        - Supported
+        - Supported
+        - Experimental
+        - Supported
+        - --
+        - --
+        - --
+        - --
+      * - **NDEF encoding/decoding**
+        - --
+        - --
+        - --
+        - Supported
+        - Supported
+        - Supported
+        - Supported
+        - Experimental
+        - Supported
+        - --
+        - --
+        - --
+        - --
+      * - **NFC Record Type Definitions: URI, Text, Connection Handover**
+        - --
+        - --
+        - --
+        - Supported
+        - Supported
+        - Supported
+        - Supported
+        - Experimental
+        - Supported
+        - --
+        - --
+        - --
+        - --
+      * - **NFC Connection Hadover to Bluetooth carrier, Static and Negotiated Handover**
+        - --
+        - --
+        - --
+        - Supported
+        - Supported
+        - Supported
+        - Supported
+        - Experimental
+        - Supported
+        - --
+        - --
+        - --
+        - --
+      * - **NFC Tag NDEF Exchange Protocol (TNEP)**
+        - --
+        - --
+        - --
+        - Supported
+        - Supported
+        - Supported
+        - Supported
+        - Experimental\ :sup:`1`
+        - Supported\ :sup:`1`
+        - --
+        - --
+        - --
+        - --
+
+  | [1]: Only supported on the NFC Tag device
 
 Zigbee feature support
 **********************


### PR DESCRIPTION
Backport 49bcdd3c6d66cca7e51d3a8d7f826d1ff411ecfb from #18820.