### PR TITLE
tests: benchmarks: power_consumption: gpio: prevent irq when toggling

### DIFF
--- a/tests/benchmarks/power_consumption/common/main.c
+++ b/tests/benchmarks/power_consumption/common/main.c
@@ -19,11 +19,11 @@ void timer_handler(struct k_timer *dummy)
 {
 	if (state == true) {
 		state = false;
-		gpio_pin_set_dt(&led, 0);
+		gpio_pin_set_dt(&led, 1);
 		k_thread_resume(thread_id);
 	} else {
 		state = true;
-		gpio_pin_set_dt(&led, 1);
+		gpio_pin_set_dt(&led, 0);
 		k_thread_suspend(thread_id);
 	}
 }

--- a/tests/benchmarks/power_consumption/gpio/src/driver_test.c
+++ b/tests/benchmarks/power_consumption/gpio/src/driver_test.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/kernel.h>
+#include <zephyr/irq.h>
 
 #define OUTPUT_NODE DT_ALIAS(out0)
 #define INPUT_NODE  DT_ALIAS(in0)
@@ -24,6 +25,7 @@ void input_active(const struct device *dev, struct gpio_callback *cb, uint32_t p
 void thread_definition(void)
 {
 	int rc;
+	unsigned int key;
 
 	rc = gpio_is_ready_dt(&input);
 	__ASSERT_NO_MSG(rc);
@@ -45,12 +47,12 @@ void thread_definition(void)
 
 	while (1) {
 		counter = 0;
+		key = irq_lock();
 		rc = gpio_pin_set_dt(&output, 0);
-		__ASSERT_NO_MSG(rc == 0);
 		rc = gpio_pin_set_dt(&output, 1);
 		rc = gpio_pin_set_dt(&output, 0);
+		irq_unlock(key);
 		__ASSERT_NO_MSG(counter == 1);
-		__ASSERT_NO_MSG(rc == 0);
 
 		k_msleep(10);
 	}


### PR DESCRIPTION
There should be single, short impulse at pin.
If it will be interrupted by irq at state high,
will trigger irq loop.

Additionally, do not light LED when sleeping.