### PR TITLE
quarantine: wifi provisioning tests on macOS

### DIFF
--- a/scripts/quarantine_windows_mac.yaml
+++ b/scripts/quarantine_windows_mac.yaml
@@ -36,6 +36,7 @@
     - sample.nrf7001_eks.ble-wifi-provision
     - sample.nrf7002_eks.ble-wifi-provision
     - sample.nrf7002.ble-wifi-provision
+    - sample.nrf7002_eb.thingy53.ble-wifi-provision
     - sample.softap.wifi.provision
   platforms:
     - nrf5340dk/nrf5340/cpuapp
@@ -43,4 +44,5 @@
     - nrf7002dk/nrf5340/cpuapp
     - nrf7002dk/nrf5340/cpuapp/ns
     - thingy53/nrf5340/cpuapp/ns
+    - thingy53/nrf5340/cpuapp
   comment: "https://nordicsemi.atlassian.net/browse/SHEL-3161"


### PR DESCRIPTION
nanoPb generated files are not correct. seems to be conflict in Mac toolchain