### PR TITLE
net: lwm2m_client_utils: Clear sec_tag content when overwriting

### DIFF
--- a/tests/subsys/net/lib/lwm2m_client_utils/src/security.c
+++ b/tests/subsys/net/lib/lwm2m_client_utils/src/security.c
@@ -502,11 +502,19 @@ ZTEST(lwm2m_client_utils_security, test_load_credentials_PSK)
 	modem_key_mgmt_write_fake.custom_fake = write_to_modem;
 	modem_key_mgmt_exists_fake.custom_fake = modem_key_mgmt_exists_custom_fake;
 	ctx.bootstrap_mode = false;
+	keys_exist = true;
 
 	rc = ctx.load_credentials(&ctx);
 	zassert_equal(rc, 0, "wrong return value");
-	zassert_equal(modem_key_mgmt_exists_fake.call_count, 5, "Did not check existing (%d)",
+	zassert_equal(modem_key_mgmt_exists_fake.call_count, 8, "Did not check existing (%d)",
 		      modem_key_mgmt_exists_fake.call_count);
+	zassert_equal(modem_key_mgmt_delete_fake.call_count, 3, "Did not remove old keys");
+	zassert_equal(modem_key_mgmt_delete_fake.arg1_history[0], MODEM_KEY_MGMT_CRED_TYPE_CA_CHAIN,
+		      "");
+	zassert_equal(modem_key_mgmt_delete_fake.arg1_history[1],
+		      MODEM_KEY_MGMT_CRED_TYPE_PUBLIC_CERT, "");
+	zassert_equal(modem_key_mgmt_delete_fake.arg1_history[2],
+		      MODEM_KEY_MGMT_CRED_TYPE_PRIVATE_CERT, "");
 	zassert_equal(modem_key_mgmt_write_fake.call_count, 2, "Did not write PSK");
 	zassert_equal(lte_lc_func_mode_set_fake.call_count, 1, "Did not set mode");
 	zassert_equal(lte_lc_func_mode_set_fake.arg0_val, LTE_LC_FUNC_MODE_OFFLINE,

--- a/tests/subsys/net/lib/lwm2m_client_utils/src/stubs.c
+++ b/tests/subsys/net/lib/lwm2m_client_utils/src/stubs.c
@@ -56,6 +56,7 @@ DEFINE_FAKE_VALUE_FUNC(int, modem_key_mgmt_exists, nrf_sec_tag_t, enum modem_key
 		       bool *);
 DEFINE_FAKE_VALUE_FUNC(int, modem_key_mgmt_write, nrf_sec_tag_t, enum modem_key_mgmt_cred_type,
 		       const void *, size_t);
+DEFINE_FAKE_VALUE_FUNC(int, modem_key_mgmt_delete, nrf_sec_tag_t, enum modem_key_mgmt_cred_type);
 DEFINE_FAKE_VALUE_FUNC(int, lte_lc_func_mode_set, enum lte_lc_func_mode);
 DEFINE_FAKE_VALUE_FUNC(int, lte_lc_connect);
 DEFINE_FAKE_VALUE_FUNC(int, lte_lc_offline);

--- a/tests/subsys/net/lib/lwm2m_client_utils/src/stubs.h
+++ b/tests/subsys/net/lib/lwm2m_client_utils/src/stubs.h
@@ -50,6 +50,7 @@ DECLARE_FAKE_VALUE_FUNC(int, modem_key_mgmt_exists, nrf_sec_tag_t, enum modem_ke
 			bool *);
 DECLARE_FAKE_VALUE_FUNC(int, modem_key_mgmt_write, nrf_sec_tag_t, enum modem_key_mgmt_cred_type,
 			const void *, size_t);
+DECLARE_FAKE_VALUE_FUNC(int, modem_key_mgmt_delete, nrf_sec_tag_t, enum modem_key_mgmt_cred_type);
 DECLARE_FAKE_VALUE_FUNC(int, lte_lc_func_mode_set, enum lte_lc_func_mode);
 DECLARE_FAKE_VALUE_FUNC(int, lte_lc_connect);
 DECLARE_FAKE_VALUE_FUNC(int, lte_lc_offline);
@@ -140,6 +141,7 @@ DECLARE_FAKE_VOID_FUNC(boot_write_img_confirmed);
 	FUNC(lwm2m_rd_client_update)                    \
 	FUNC(modem_key_mgmt_exists)                     \
 	FUNC(modem_key_mgmt_write)                      \
+	FUNC(modem_key_mgmt_delete)			\
 	FUNC(modem_info_init)                           \
 	FUNC(modem_info_params_init)                    \
 	FUNC(modem_info_params_get)                     \


### PR DESCRIPTION
When writing new content to security tag, clear existing information first, that might cause problems.

For example, when writing PSK, delete all certificates. When writing certificates, delete all PSK data.