### PR TITLE
samples: wifi: radio_test: Fix crash during temp and rssi get

### DIFF
--- a/samples/wifi/radio_test/src/nrf_wifi_radio_test_shell.c
+++ b/samples/wifi/radio_test/src/nrf_wifi_radio_test_shell.c
@@ -1617,25 +1617,10 @@ static int nrf_wifi_radio_get_temperature(const struct shell *shell,
 					  const char *argv[])
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
-	char *ptr = NULL;
-	unsigned long val = 0;
 	int ret = -ENOEXEC;
 
-	val = strtoul(argv[1], &ptr, 10);
-
-	if (val > 1) {
-		shell_fprintf(shell,
-			      SHELL_ERROR,
-			      "Invalid value %lu\n",
-			      val);
-		shell_help(shell);
+	if (!check_test_in_prog(shell)) {
 		goto out;
-	}
-
-	if (val == 1) {
-		if (!check_test_in_prog(shell)) {
-			goto out;
-		}
 	}
 
 	ctx->rf_test_run = true;
@@ -1664,25 +1649,10 @@ static int nrf_wifi_radio_get_rf_rssi(const struct shell *shell,
 				      const char *argv[])
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
-	char *ptr = NULL;
-	unsigned long val = 0;
 	int ret = -ENOEXEC;
 
-	val = strtoul(argv[1], &ptr, 10);
-
-	if (val > 1) {
-		shell_fprintf(shell,
-			      SHELL_ERROR,
-			      "Invalid value %lu\n",
-			      val);
-		shell_help(shell);
+	if (!check_test_in_prog(shell)) {
 		goto out;
-	}
-
-	if (val == 1) {
-		if (!check_test_in_prog(shell)) {
-			goto out;
-		}
 	}
 
 	ctx->rf_test_run = true;


### PR DESCRIPTION
    samples: wifi: radio_test: Fix crash during temp and rssi get
    
    Get temperature and RSSI commands don't take any args, but due to
    copy-paste, the code tries to parse the args, argv[1] without any NULL
    or boundary checks causing a crash.
    
    This bug is quite old but in nRF53 (and 52) the address 0x0 is a valid
    address (IIRC mapped to begining of external flash), so, the conversion
    to string passes, though it returns garbage but the check for the
    returned value is completely unnecessary, so it doesn't matter if that
    is invoked or not, because of this, the issue was hidden.
    
    In nRF54H the address 0x0 is not mapped and is considered invalid and
    leading to the crash.