### PR TITLE
doc: wayland: update desktop app names

### DIFF
--- a/applications/asset_tracker_v2/doc/asset_tracker_v2_description.rst
+++ b/applications/asset_tracker_v2/doc/asset_tracker_v2_description.rst
@@ -180,9 +180,9 @@ Testing
 After programming the application and all the prerequisites to your development kit, test the application by performing the following steps:
 
 1. |connect_kit|
-#. Connect to the kit with a terminal emulator (for example, `nRF Connect Serial Terminal`_).
-   You can also use the :guilabel:`Open Serial Terminal` option of the `Cellular Monitor`_ app to open the Serial Terminal.
-   Using the Cellular Monitor app in combination with the nRF Connect Serial Terminal shows how the modem responds to the different modem commands.
+#. Connect to the kit with a terminal emulator (for example, the `Serial Terminal app`_).
+   You can also use the :guilabel:`Open Serial Terminal` option of the `Cellular Monitor app`_ to open the Serial Terminal app.
+   Using the Cellular Monitor app in combination with the Serial Terminal app shows how the modem responds to the different modem commands.
 #. Reset the development kit.
 #. Observe in the terminal window that application boots as shown in the following output::
 

--- a/applications/machine_learning/app_desc.rst
+++ b/applications/machine_learning/app_desc.rst
@@ -539,7 +539,7 @@ After programming the application, perform the following steps to test the nRF M
    After a brief delay, the Bluetooth connection between the sample and the Thingy is established.
    The Thingy forwards the sensor readouts over NUS.
    The LED on the Thingy starts to blink rapidly.
-#. Connect to the sample with a terminal emulator (for example, `nRF Connect Serial Terminal`_).
+#. Connect to the sample with a terminal emulator (for example, the `Serial Terminal app`_).
    See :ref:`test_and_optimize` for the required settings.
 #. Observe the sensor readouts represented as comma-separated values.
    Every line represents a single sensor readout.
@@ -568,7 +568,7 @@ After programming the application, perform the following steps to test the nRF M
    This signal is marked as an anomaly by the machine learning model, and **LED1** starts breathing.
 #. Press and hold **Button 1** for more than five seconds to switch to the data forwarding mode.
    After the mode is switched, **LED1** starts to blink rapidly.
-#. Connect to the development kit with a terminal emulator (for example, `nRF Connect Serial Terminal`_).
+#. Connect to the development kit with a terminal emulator (for example, the `Serial Terminal app`_).
    See :ref:`test_and_optimize` for the required settings.
 #. Observe the sensor readouts represented as comma-separated values.
    Every line represents a single sensor readout.
@@ -595,7 +595,7 @@ After programming the application, perform the following steps to test the nRF M
    This signal is marked as an anomaly by the machine learning model, and **LED1** starts breathing.
 #. Press and hold **Button 0** for more than five seconds to switch to the data forwarding mode.
    After the mode is switched, **LED1** starts to blink rapidly.
-#. Connect to the development kit with a terminal emulator (for example, `nRF Connect Serial Terminal`_).
+#. Connect to the development kit with a terminal emulator (for example, the `Serial Terminal app`_).
    See :ref:`test_and_optimize` for the required settings.
 #. Observe the sensor readouts represented as comma-separated values.
    Every line represents a single sensor readout.

--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -407,18 +407,18 @@ To connect to an nRF91 Series DK with a PC:
 1. Verify that ``UART_0`` is selected in the application.
    It is defined in the default configuration.
 
-2. Use `nRF Connect Serial Terminal`_ to connect to the development kit.
+2. Use the `Serial Terminal app`_ to connect to the development kit.
    See :ref:`serial_terminal_connect` for instructions.
-   You can also use the :guilabel:`Open Serial Terminal` option of the `Cellular Monitor`_ app to open the Serial Terminal.
-   Using the Cellular Monitor app in combination with the nRF Connect Serial Terminal shows how the modem responds to the different modem commands.
+   You can also use the :guilabel:`Open Serial Terminal` option of the `Cellular Monitor app`_ to open the Serial Terminal app.
+   Using the Cellular Monitor app in combination with the Serial Terminal app shows how the modem responds to the different modem commands.
    You can then use this connection to send or receive AT commands over UART, and to see the log output of the development kit.
 
-   Instead of using nRF Connect Serial Terminal, you can use PuTTY to establish a terminal connection to the development kit, using the :ref:`default serial port connection settings <test_and_optimize>`.
+   Instead of using the Serial Terminal app, you can use PuTTY to establish a terminal connection to the development kit, using the :ref:`default serial port connection settings <test_and_optimize>`.
 
    .. note::
 
       The default AT command terminator is a carriage return followed by a line feed (``\r\n``).
-      nRF Connect Serial Terminal supports this format.
+      The Serial Terminal app supports this format.
       If you want to use another terminal emulator, make sure that the configured AT command terminator corresponds to the line terminator of your terminal.
       When using PuTTY, you must set the :ref:`CONFIG_SLM_CR_TERMINATION <CONFIG_SLM_CR_TERMINATION>` SLM configuration option.
       See :ref:`slm_config_options` for more details.
@@ -642,8 +642,8 @@ If you have an nRF52 Series DK running a client application, you can also use th
 |test_sample|
 
 1. |connect_kit|
-#. :ref:`Connect to the kit with nRF Connect Serial Terminal <serial_terminal_connect>`.
-   You can also use the :guilabel:`Open Serial Terminal` option of the `Cellular Monitor`_ app to open the Serial Terminal.
+#. :ref:`Connect to the kit with the Serial Terminal app <serial_terminal_connect>`.
+   You can also use the :guilabel:`Open Serial Terminal` option of the `Cellular Monitor app`_ to open the Serial Terminal app.
    If you want to use a different terminal emulator, see :ref:`slm_connecting_91dk_pc`.
 #. Reset the kit.
 #. Observe that the development kit sends a ``Ready\r\n`` message on UART.

--- a/applications/serial_lte_modem/doc/slm_testing.rst
+++ b/applications/serial_lte_modem/doc/slm_testing.rst
@@ -377,8 +377,8 @@ TLS client
 Before completing this test, you must update the CA certificate, the client certificate, and the private key to be used for the TLS connection in the modem.
 The credentials must use the security tag 16842755.
 
-To store the credentials in the modem, use the Cellular Monitor app.
-See `Managing credentials`_ in the Cellular Monitor User Guide for instructions.
+To store the credentials in the modem, use the `Cellular Monitor app`_.
+See `Managing credentials`_ in the Cellular Monitor app documentation for instructions.
 
 You must register the corresponding credentials on the server side.
 

--- a/doc/nrf/app_dev/device_guides/nrf52/features.rst
+++ b/doc/nrf/app_dev/device_guides/nrf52/features.rst
@@ -10,7 +10,7 @@ Features of nRF52 Series
 The nRF52 Series of System-on-Chip (SoC) devices embed an Arm Cortex-M4 processor with Nordic Semiconductor's 2.4 GHz RF transceivers.
 All of the nRF52 Series SoCs have support for Bluetooth® 5 features, in addition to multiprotocol capabilities.
 
-To get started with the nRF52 Series, download and run the `Quick Start`_ application from `nRF Connect for Desktop`_.
+To get started with the nRF52 Series, download and run the `Quick Start app`_ in `nRF Connect for Desktop`_.
 
 For additional information, see the following documentation:
 

--- a/doc/nrf/app_dev/device_guides/nrf53/features_nrf53.rst
+++ b/doc/nrf/app_dev/device_guides/nrf53/features_nrf53.rst
@@ -10,7 +10,7 @@ Features of nRF53 Series
 The nRF53 Series System-on-Chips (SoC) integrate a high-performance Arm® Cortex®-M33 dual-core processor with a 2.4 GHz RF transceiver, in addition to advanced security features.
 All nRF53 Series SoC support Bluetooth® 5.1 and Bluetooth Mesh, in addition to multiprotocol capabilities.
 
-To get started with the nRF5340 DK, download and run the `Quick Start`_ application from `nRF Connect for Desktop`_.
+To get started with the nRF5340 DK, download and run the `Quick Start app`_ in `nRF Connect for Desktop`_.
 
 For additional information, refer to the following resources:
 

--- a/doc/nrf/app_dev/device_guides/nrf53/thingy53_application_guide.rst
+++ b/doc/nrf/app_dev/device_guides/nrf53/thingy53_application_guide.rst
@@ -28,7 +28,7 @@ Updating firmware image for Thingy:53
 *************************************
 
 You can program the firmware on the Nordic Thingy:53 using an external debug probe and 10-pin JTAG cable, as described in :ref:`thingy53_building_pgming`, using either :ref:`Visual Studio Code <thingy53_build_pgm_vscode>` or :ref:`command line <thingy53_build_pgm_command_line>`.
-You can also update applications running on both the network and application core using the built-in MCUboot bootloader and `nRF Connect Programmer`_ or the `nRF Programmer`_ app for Android and iOS.
+You can also update applications running on both the network and application core using the built-in MCUboot bootloader and the `Programmer app`_ for desktop or the `nRF Programmer`_ app for Android and iOS.
 You can also update the prebuilt application images that way.
 
 See :ref:`thingy53_gs_updating_firmware` for details about updating firmware image.
@@ -54,7 +54,7 @@ You can program the precompiled firmware image using one of the following ways:
   In this scenario, the Thingy is connected directly to your PC through USB.
   For details, refer to the :ref:`thingy53_app_mcuboot_bootloader` section.
 
-  See the :ref:`thingy53_gs_updating_usb` section in the :ref:`ug_thingy53_gs` guide for the detailed procedures on how to program the Thingy:53 using `nRF Connect Programmer`_.
+  See the :ref:`thingy53_gs_updating_usb` section in the :ref:`ug_thingy53_gs` guide for the detailed procedures on how to program the Thingy:53 using the `Programmer app`_.
 * Update the firmware over-the-air (OTA) using Bluetooth LE and the nRF Programmer mobile application for Android or iOS.
   To use this method, the application that is currently programmed on Thingy:53 must support it.
   For details, refer to :ref:`thingy53_app_fota_smp` section.

--- a/doc/nrf/app_dev/device_guides/nrf70/index.rst
+++ b/doc/nrf/app_dev/device_guides/nrf70/index.rst
@@ -35,28 +35,28 @@ Zephyr and the |NCS| provide support for developing networking applications with
      - PCA10095
      - ``nrf5340dk/nrf5340/cpuapp``
      - | `Product Specification <nRF5340 Product Specification_>`_
-       | `Quick Start`_
+       | `Quick Start app`_
        | `User Guide <nRF5340 DK User Guide_>`_
    * - :ref:`zephyr:nrf52840dk_nrf52840`
      - nRF7002 EK
      - PCA10056
      - ``nrf52840dk/nrf52840``
      - | `Product Specification <nRF52840 Product Specification_>`_
-       | `Quick Start`_
+       | `Quick Start app`_
        | `User Guide <nRF52840 DK User Guide_>`_
    * - :ref:`zephyr:nrf9151dk_nrf9151`
      - nRF7002 EK
      - PCA10171
      - ``nrf9151dk/nrf9151/ns``
      - | `Product Specification <nRF9151 Product Specification_>`_
-       | `Quick Start`_
+       | `Quick Start app`_
        | `User Guide <nRF9151 DK Hardware_>`_
    * - :ref:`zephyr:nrf9161dk_nrf9161`
      - nRF7002 EK
      - PCA10153
      - ``nrf9161dk/nrf9161/ns``
      - | `Product Specification <nRF9161 Product Specification_>`_
-       | `Quick Start`_
+       | `Quick Start app`_
        | `User Guide <nRF9161 DK Hardware_>`_
    * - :ref:`zephyr:nrf9160dk_nrf9160`
      - nRF7002 EK
@@ -81,7 +81,7 @@ Zephyr and the |NCS| provide support for developing networking applications with
      - nRF7002 EB
      - PCA20053
      - ``nrf54l15dk/nrf54l15/cpuapp``
-     - | `Quick Start`_
+     - | `Quick Start app`_
        | :ref:`Developing with nRF54L Series <ug_nrf54l15_gs>`
 
 

--- a/doc/nrf/app_dev/device_guides/nrf91/index.rst
+++ b/doc/nrf/app_dev/device_guides/nrf91/index.rst
@@ -25,7 +25,7 @@ Zephyr and the |NCS| provide support for developing cellular applications using 
      - PCA10153
      - ``nrf9161dk/nrf9161``, ``nrf9161dk/nrf9161/ns``
      - | `Product Specification <nRF9161 Product Specification_>`_
-       | `Quick Start`_
+       | `Quick Start app`_
        | `User Guide <nRF9161 DK Hardware_>`_
      - | `nRF9161 DK product page`_
        | `nRF9161 System in Package (SiP) <nRF9161 product website_>`_
@@ -41,7 +41,7 @@ Zephyr and the |NCS| provide support for developing cellular applications using 
      - PCA10171
      - ``nrf9151dk/nrf9151``, ``nrf9151dk/nrf9151/ns``
      - | `Product Specification <nRF9151 Product Specification_>`_
-       | `Quick Start`_
+       | `Quick Start app`_
        | `User Guide <nRF9151 DK Hardware_>`_
      - | `nRF9151 DK product page`_
        | `nRF9151 System in Package (SiP) <nRF9151 product website_>`_

--- a/doc/nrf/app_dev/device_guides/nrf91/nrf91_board_controllers.rst
+++ b/doc/nrf/app_dev/device_guides/nrf91/nrf91_board_controllers.rst
@@ -23,7 +23,7 @@ The following sections have a complete list of configuration options available f
 * `Board control <nRF9151 DK board control section in the nRF9151 DK User Guide_>`_  in the nRF9151 DK Hardware guide
 
 The nRF5340 IMCU comes preprogrammed with J-Link SEGGER OB and board controller firmware.
-If you want to change the default configuration of the DK, you can use the `nRF Connect Board Configurator`_ app in `nRF Connect for Desktop`_ .
+If you want to change the default configuration of the DK, you can use the `Board Configurator app`_ in `nRF Connect for Desktop`_ .
 
 To update board controller firmware on the nRF9161 DK, download the `nRF9161 DK board controller firmware`_ from the nRF9161 DK downloads page.
 To program the HEX file, use `nRF Util`_.

--- a/doc/nrf/app_dev/device_guides/nrf91/nrf91_cloud_certificate.rst
+++ b/doc/nrf/app_dev/device_guides/nrf91/nrf91_cloud_certificate.rst
@@ -92,7 +92,7 @@ After downloading the certificate, you must provision it to your DK.
 
 Complete the following steps to provision the certificate:
 
-1. Start nRF Connect for Desktop and install the `Cellular Monitor`_ app.
+1. Start nRF Connect for Desktop and install the `Cellular Monitor app`_.
 #. Open the Cellular Monitor app.
 #. Connect the DK to the computer with a micro-USB cable, and turn it on.
 #. Click :guilabel:`Select device` and select the DK from the drop-down list.
@@ -102,36 +102,36 @@ Complete the following steps to provision the certificate:
       .. group-tab:: nRF91x1 DK
 
          .. figure:: images/cellularmonitor_selectdevice_nrf9151.png
-            :alt: Cellular Monitor - Select device (nRF9151 DK shown)
+            :alt: Cellular Monitor app - Select device (nRF9151 DK shown)
 
-            Cellular Monitor - Select device (nRF9151 DK shown)
+            Cellular Monitor app - Select device (nRF9151 DK shown)
 
       .. group-tab:: nRF9160 DK
 
          .. figure:: images/cellularmonitor_selectdevice1_nrf9160.png
-            :alt: Cellular Monitor - Select device
+            :alt: Cellular Monitor app - Select device
 
-            Cellular Monitor - Select device
+            Cellular Monitor app - Select device
 
    The drop-down text changes to the type of the selected device, with the SEGGER ID below the name.
 
-#. Click the :guilabel:`Open Serial Terminal` option of the `Cellular Monitor`_ app to open the Serial Terminal.
+#. Click the :guilabel:`Open Serial Terminal` option of the `Cellular Monitor app`_ to open the Serial Terminal app.
 
    .. tabs::
 
       .. group-tab:: nRF91x1 DK
 
          .. figure:: images/cellularmonitor_open_serial_terminal_nrf9151.png
-            :alt: Cellular Monitor - Open Serial Terminal (nRF9151 DK shown)
+            :alt: Cellular Monitor app - Open Serial Terminal (nRF9151 DK shown)
 
-            Cellular Monitor - Open Serial Terminal (nRF9151 DK shown)
+            Cellular Monitor app - Open Serial Terminal (nRF9151 DK shown)
 
       .. group-tab:: nRF9160 DK
 
          .. figure:: images/cellularmonitor_open_serial_terminal.png
-            :alt: Cellular Monitor - Open Serial Terminal (nRF9151 DK shown)
+            :alt: Cellular Monitor app - Open Serial Terminal (nRF9151 DK shown)
 
-            Cellular Monitor - Open Serial Terminal (nRF9151 DK shown)
+            Cellular Monitor app - Open Serial Terminal (nRF9151 DK shown)
 
 #. Enter ``AT+CFUN=4`` in the text field for AT commands and click :guilabel:`Send`.
    This AT command sets the modem to offline state.
@@ -148,16 +148,16 @@ Complete the following steps to provision the certificate:
       .. group-tab:: nRF91x1 DK
 
          .. figure:: images/cellularmonitor_navigationcertificatemanager_nrf9151.png
-            :alt: Cellular Monitor - Certificate Manager (nRF9151 DK shown)
+            :alt: Cellular Monitor app - Certificate Manager (nRF9151 DK shown)
 
-            Cellular Monitor - Certificate Manager (nRF9151 DK shown)
+            Cellular Monitor app - Certificate Manager (nRF9151 DK shown)
 
       .. group-tab:: nRF9160 DK
 
          .. figure:: images/cellularmonitor_navigationcertificatemanager.png
-            :alt: Cellular Monitor - Certificate Manager
+            :alt: Cellular Monitor app - Certificate Manager
 
-            Cellular Monitor - Certificate Manager
+            Cellular Monitor app - Certificate Manager
 
 #. Click :guilabel:`Load from JSON` and select the :file:`*.cert.json` file that you downloaded from nRF Cloud.
    Alternatively, you can drag and drop the file onto the GUI.

--- a/doc/nrf/app_dev/device_guides/nrf91/nrf91_features.rst
+++ b/doc/nrf/app_dev/device_guides/nrf91/nrf91_features.rst
@@ -115,10 +115,10 @@ There are two ways to update the modem firmware:
 Full update
   You can use either a wired or a wireless connection to do a full update of the modem firmware:
 
-  * When using a wired connection, you can use either the `nRF Connect Programmer`_, which is part of `nRF Connect for Desktop`_, or the `nRF pynrfjprog`_ Python package.
+  * When using a wired connection, you can use either the `Programmer app`_, which is part of `nRF Connect for Desktop`_, or the `nRF pynrfjprog`_ Python package.
     Both methods use the Simple Management Protocol (SMP) to provide an interface over UART, which enables the device to perform the update.
 
-    * You can use the nRF Connect Programmer to perform the update, regardless of the images that are part of the existing firmware of the device.
+    * You can use the Programmer app to perform the update, regardless of the images that are part of the existing firmware of the device.
       For example, you can update the modem on an nRF9160 DK using the instructions described in the :ref:`nrf9160_updating_fw_modem` section.
 
     * You can also use the nRF pynrfjprog Python package to perform the update, as long as a custom application image integrating the ``lib_fmfu_mgmt`` subsystem is included in the existing firmware of the device.
@@ -207,8 +207,8 @@ For more information on the integration, see :ref:`nrf_modem_lib_readme`.
 Modem trace
 ===========
 
-The modem traces of the nRF91 Series modem can be captured using the Cellular Monitor.
-For more information on how to collect traces using Cellular Monitor, see the `Cellular Monitor`_ documentation.
+The modem traces of the nRF91 Series modem can be captured using the Cellular Monitor app.
+For more information on how to do this, see the `Cellular Monitor app`_ documentation.
 To enable the modem traces in the modem and to forward them to the :ref:`modem_trace_module` over UART, include the ``nrf91-modem-trace-uart`` snippet while building your application as described in :ref:`nrf91_modem_trace_uart_snippet`.
 
 .. note::

--- a/doc/nrf/app_dev/device_guides/nrf91/nrf91_programming.rst
+++ b/doc/nrf/app_dev/device_guides/nrf91/nrf91_programming.rst
@@ -63,9 +63,9 @@ The following table shows the different types of build files that are generated 
 +-----------------------+----------------------------------------+----------------------------------------------------------------+
 | File                  | File format                            | Programming scenario                                           |
 +=======================+========================================+================================================================+
-|:file:`merged.hex`     | Full image, HEX format                 | Using an external debug probe and nRF Connect Programmer.      |
+|:file:`merged.hex`     | Full image, HEX format                 | Using an external debug probe and the `Programmer app`_.       |
 +-----------------------+----------------------------------------+----------------------------------------------------------------+
-|:file:`app_signed.hex` | MCUboot compatible image, HEX format   | Using the built-in bootloader and nRF Connect Programmer.      |
+|:file:`app_signed.hex` | MCUboot compatible image, HEX format   | Using the built-in bootloader and the `Programmer app`_.       |
 +-----------------------+----------------------------------------+----------------------------------------------------------------+
 |:file:`app_update.bin` | MCUboot compatible image, binary format|* Using the built-in bootloader and mcumgr command line tool.   |
 |                       |                                        |* For FOTA updates.                                             |
@@ -78,7 +78,7 @@ It is recommended to use an external debug probe to program the Thingy:91.
 
 .. note::
 
-   If you do not have an external debug probe available to program the Thingy:91, you can directly program by :ref:`using the USB (MCUboot) method and nRF Connect Programmer <programming_thingy>`.
+   If you do not have an external debug probe available to program the Thingy:91, you can directly program by :ref:`using the USB (MCUboot) method and the Programmer app <programming_thingy>`.
    In this scenario, use the :file:`app_signed.hex` firmware image file.
 
 .. note::

--- a/doc/nrf/app_dev/device_guides/nrf91/thingy91_connecting.rst
+++ b/doc/nrf/app_dev/device_guides/nrf91/thingy91_connecting.rst
@@ -7,7 +7,7 @@ Connecting to Thingy:91
    :local:
    :depth: 2
 
-You can connect to Thingy:91 wirelessly (using the `nRF Toolbox`_ app) or over a serial connection (using `nRF Connect Serial Terminal`_, `Cellular Monitor`_, or a serial terminal).
+You can connect to Thingy:91 wirelessly (using the `nRF Toolbox`_ app) or over a serial connection (using the `Serial Terminal app`_, the `Cellular Monitor app`_, or a serial terminal).
 
 Using nRF Toolbox
 *****************
@@ -39,8 +39,8 @@ Thingy:91 uses the following UART baud rate configuration:
    * - UART_1
      - 1000000
 
-Using nRF Connect Serial Terminal
-*********************************
+Using the Serial Terminal app
+*****************************
 
-You can use the `nRF Connect Serial Terminal`_ application to get debug output and send AT commands to the Thingy:91.
-In the case of nRF Connect Serial Terminal or Cellular Monitor, the baud rate for the communication is set automatically.
+You can use the `Serial Terminal app`_ to get debug output and send AT commands to the Thingy:91.
+In the case of the Serial Terminal or the Cellular Monitor apps, the baud rate for the communication is set automatically.

--- a/doc/nrf/app_dev/device_guides/pmic/npm1300.rst
+++ b/doc/nrf/app_dev/device_guides/pmic/npm1300.rst
@@ -63,21 +63,21 @@ The following boards in the `Zephyr`_ open source project and in the |NCS| are c
      - PCA10095
      - ``nrf5340dk/nrf5340/cpuapp``
      - | `Product Specification <nRF5340 Product Specification_>`_
-       | `Quick Start`_
+       | `Quick Start app`_
        | `User Guide <nRF5340 DK User Guide_>`_
    * - :ref:`zephyr:nrf52840dk_nrf52840`
      - nPM1300 EK
      - PCA10056
      - ``nrf52840dk/nrf52840``
      - | `Product Specification <nRF52840 Product Specification_>`_
-       | `Quick Start`_
+       | `Quick Start app`_
        | `User Guide <nRF52840 DK User Guide_>`_
    * - :ref:`zephyr:nrf52dk_nrf52832`
      - nPM1300 EK
      - PCA10040
      - ``nrf52dk/nrf52832``
      - | `Product Specification <nRF52832 Product Specification_>`_
-       | `Quick Start`_
+       | `Quick Start app`_
        | `User Guide <nRF52 DK User Guide_>`_
 
 PMIC samples and libraries
@@ -90,17 +90,17 @@ The |NCS| also provides the :ref:`nrfxlib:nrf_fuel_gauge` that processes battery
 PMIC tools
 **********
 
-The :ref:`nrfxlib:nrf_fuel_gauge` is supported by the `nPM PowerUP`_ application from `nRF Connect for Desktop`_.
+The :ref:`nrfxlib:nrf_fuel_gauge` is supported by the `nPM PowerUP app`_ in `nRF Connect for Desktop`_.
 You can use this application together with the library to derive a battery model for your product.
 For this purpose, you can use the nPM1300 EK either alone (to use the built-in battery models) or together with the additional `nPM Fuel Gauge Board`_ (to generate a custom battery model).
 See `Evaluate nPM1300 using nPM PowerUP`_ in the `nPM1300 EK User Guide`_ for more information.
 
 .. _ug_npm1300_developing_overlay_import:
 
-Importing an overlay from nPM PowerUP
-=====================================
+Importing an overlay from the nPM PowerUP app
+=============================================
 
-The nPM PowerUP application from nRF Connect for Desktop supports exporting a full configuration of the nPM1300 in devicetree overlay format.
+The nPM PowerUP app from nRF Connect for Desktop supports exporting a full configuration of the nPM1300 in devicetree overlay format.
 You can use this exported overlay file to quickly configure the nPM1300 in your application.
 
 If there is no overlay file for your project, include the file directly in your application folder with the name :file:`app.overlay`.

--- a/doc/nrf/app_dev/device_guides/working_with_nrf/nrf54h/ug_nrf54h20_gs.rst
+++ b/doc/nrf/app_dev/device_guides/working_with_nrf/nrf54h/ug_nrf54h20_gs.rst
@@ -158,7 +158,7 @@ Installing the Terminal application
 ***********************************
 
 On your computer, install `nRF Connect for Desktop`_.
-You must also install a terminal emulator, such as `nRF Connect Serial Terminal`_ (from the nRF Connect for Desktop application) or the nRF Terminal (part of the `nRF Connect for Visual Studio Code`_ extension).
+You must also install a terminal emulator, such as the `Serial Terminal app`_ (from the nRF Connect for Desktop application) or the nRF Terminal (part of the `nRF Connect for Visual Studio Code`_ extension).
 Both of these terminal emulators start the required :ref:`toolchain environment <using_toolchain_environment>`.
 
 Installing nRF Util and its commands
@@ -319,7 +319,7 @@ The logs are output over UART.
 
 To read the logs from the :zephyr:code-sample:`sysbuild_hello_world` sample programmed to the nRF54H20 DK, complete the following steps:
 
-1. Connect to the DK with a terminal emulator (for example, `nRF Connect Serial Terminal`_) using the :ref:`default serial port connection settings <test_and_optimize>`.
+1. Connect to the DK with a terminal emulator (for example, the `Serial Terminal app`_) using the :ref:`default serial port connection settings <test_and_optimize>`.
 #. Press the **Reset** button on the PCB to reset the DK.
 #. Observe the console output for the application core:
 

--- a/doc/nrf/app_dev/device_guides/working_with_nrf/nrf54h/ug_nrf54h20_suit_external_memory.rst
+++ b/doc/nrf/app_dev/device_guides/working_with_nrf/nrf54h/ug_nrf54h20_suit_external_memory.rst
@@ -90,7 +90,7 @@ Alternatively, you can follow the following steps to manually enable external me
 Common steps for both push and fetch models
 ===========================================
 
-1. Turn on the external flash chip on the nRF54H20 DK using the `nRF Connect Board Configurator`_ app within `nRF Connect for Desktop`_ .
+1. Turn on the external flash chip on the nRF54H20 DK using the `Board Configurator app`_ in `nRF Connect for Desktop`_ .
 
    .. note::
       This step is needed only on nRF54H20 DK. Skip this step if you are using different hardware.

--- a/doc/nrf/app_dev/programming.rst
+++ b/doc/nrf/app_dev/programming.rst
@@ -33,7 +33,7 @@ For example, if you are working with an nRF9160 DK, you need to select the corre
 Programming to Thingy:91 also requires a :ref:`similar step <building_pgming>`, but using a different switch (**SW2**).
 
 Programming the nRF52840 Dongle
-  To program the nRF52840 Dongle instead of a development kit, follow the programming instructions in :ref:`zephyr:nrf52840dongle_nrf52840` or use the `nRF Connect Programmer app <Programming the nRF52840 Dongle_>`_.
+  To program the nRF52840 Dongle instead of a development kit, follow the programming instructions in :ref:`zephyr:nrf52840dongle_nrf52840` or use the `Programmer app <Programming the nRF52840 Dongle_>`_.
 
 .. _programming_params:
 

--- a/doc/nrf/external_comp/nrf_cloud.rst
+++ b/doc/nrf/external_comp/nrf_cloud.rst
@@ -194,7 +194,7 @@ A device can successfully connect to `nRF Cloud`_ using MQTT if the following re
 
      Alternatively, use the nRF Cloud REST API to do this.
 
-  #. Program the credentials in the JSON file into the device using the `Cellular Monitor`_ app.
+  #. Program the credentials in the JSON file into the device using the `Cellular Monitor app`_.
 
   The private key is exposed during these steps, and therefore, this is the less secure option.
   See :ref:`nrf9160_ug_updating_cloud_certificate` for details.

--- a/doc/nrf/gsg_guides.rst
+++ b/doc/nrf/gsg_guides.rst
@@ -7,7 +7,7 @@ Quick Start
 
 .. quick_start_table_start
 
-Use the `Quick Start`_ app, available from `nRF Connect for Desktop`_, to familiarize yourself with the |NCS| tools and components for some of the devices supported by the |NCS|.
+Use the `Quick Start app`_, available from `nRF Connect for Desktop`_, to familiarize yourself with the |NCS| tools and components for some of the devices supported by the |NCS|.
 The application uses Nordic Semiconductor tools and precompiled binaries and does not require installing the |NCS|.
 
 .. important::
@@ -23,7 +23,7 @@ The application uses Nordic Semiconductor tools and precompiled binaries and doe
 +----------------------+                                                                +--------------------------------+
 | nRF9151 DK           |                                                                | `nRF9151 DK Hardware`_         |
 +----------------------+                                                                +--------------------------------+
-| nRF54L15 DK          |  `Quick Start`_ app                                            | *Not yet available*            |
+| nRF54L15 DK          |  `Quick Start app`_                                            | *Not yet available*            |
 +----------------------+                                                                +--------------------------------+
 | nRF5340 DK           |                                                                | `nRF5340 DK User Guide`_       |
 +----------------------+                                                                +--------------------------------+
@@ -33,7 +33,7 @@ The application uses Nordic Semiconductor tools and precompiled binaries and doe
 +----------------------+                                                                +--------------------------------+
 | nRF52 DK             |                                                                | `nRF52 DK User Guide`_         |
 +----------------------+----------------------------------------------------------------+--------------------------------+
-| nRF54H20 DK          | :ref:`ug_nrf54h20_gs` - *Quick Start support coming soon*      | *Not yet available*            |
+| nRF54H20 DK          | :ref:`ug_nrf54h20_gs` - *Quick Start app support coming soon*  | *Not yet available*            |
 +----------------------+----------------------------------------------------------------+--------------------------------+
 | nRF7002 DK           | :ref:`ug_nrf7002_gs`                                           | `nRF7002 DK Hardware`_         |
 +----------------------+----------------------------------------------------------------+--------------------------------+

--- a/doc/nrf/gsg_guides/nrf7002_gs.rst
+++ b/doc/nrf/gsg_guides/nrf7002_gs.rst
@@ -194,8 +194,8 @@ Installing the required software
 On your computer, install `nRF Connect for Desktop`_.
 After installing and starting the application, install the Programmer app.
 
-You must also install a terminal emulator, such as `nRF Connect Serial Terminal`_, the nRF Terminal (part of the `nRF Connect for Visual Studio Code`_ extension), or PuTTY.
-nRF Connect Serial Terminal is the recommended method for :ref:`nrf70_gs_connecting`.
+You must also install a terminal emulator, such as the `Serial Terminal app`_, the nRF Terminal (part of the `nRF Connect for Visual Studio Code`_ extension), or PuTTY.
+The Serial Terminal app is the recommended method for :ref:`nrf70_gs_connecting`.
 
 On your mobile device, install the `nRF Connect for Mobile`_ application from the corresponding application store.
 

--- a/doc/nrf/gsg_guides/nrf9160_gs.rst
+++ b/doc/nrf/gsg_guides/nrf9160_gs.rst
@@ -40,13 +40,13 @@ On your computer, one of the following operating systems:
 .. _nrf9160_gs_installing_software:
 .. _nrf9160_gs_updating_fw:
 
-Getting started using Quick Start
-*********************************
+Getting started using the Quick Start app
+*****************************************
 
 To work with the nRF9160 DK firmware and certificates, complete the following steps:
 
 1. Install `nRF Connect for Desktop`_.
-#. Start nRF Connect for Desktop and install the Quick Start application, a cross-platform tool for guided setup and installation procedures.
+   This also automatically installs the `Quick Start app`_, a cross-platform tool for guided setup and installation procedures.
 #. Prepare your DK:
 
    a. Punch out the nano-SIM from the SIM card and plug it into the SIM card holder on the nRF9160 DK.

--- a/doc/nrf/gsg_guides/thingy91_gsg.rst
+++ b/doc/nrf/gsg_guides/thingy91_gsg.rst
@@ -47,7 +47,7 @@ Before you start updating the modem firmware and application on the Thingy:91, y
 
 Complete the following steps to prepare the Thingy:91 for setup:
 
-1. Install the `Cellular Monitor`_ app on the computer:
+1. Install the `Cellular Monitor app`_ on the computer:
 
    a. Go to `nRF Connect for Desktop Downloads <Download nRF Connect for Desktop_>`_.
    #. Download and install nRF Connect for Desktop.
@@ -104,22 +104,22 @@ Before you start, make sure the Thingy:91 is connected to the computer with a mi
 
 To update the firmware on the Thingy:91, complete the following steps:
 
-1. Open the `Cellular Monitor`_ app.
+1. Open the `Cellular Monitor app`_.
 #. Click :guilabel:`SELECT DEVICE` and select the Thingy:91 from the drop-down list.
 
    .. figure:: images/cellularmonitor_selectdevice_thingy91.png
-      :alt: Cellular Monitor - Select device
+      :alt: Cellular Monitor app - Select device
 
-      Cellular Monitor - Select device
+      Cellular Monitor app - Select device
 
    The drop-down text changes to the type of the selected device, with its SEGGER ID below the name.
 
 #. Click :guilabel:`Program device` in the **ADVANCED OPTIONS** section.
 
    .. figure:: images/cellularmonitor_programdevice_thingy91.png
-      :alt: Cellular Monitor - Program device
+      :alt: Cellular Monitor app - Program device
 
-      Cellular Monitor - Program device
+      Cellular Monitor app - Program device
 
    The **Program sample app** window appears, displaying applications you can program to the Thingy:91.
 
@@ -127,9 +127,9 @@ To update the firmware on the Thingy:91, complete the following steps:
    Asset Tracker v2 is an application that simulates sensor data and transmits it to Nordic Semiconductor's cloud solution, `nRF Cloud`_.
 
    .. figure:: images/cellularmonitor_selectassettracker.png
-      :alt: Cellular Monitor - Select Asset Tracker V2
+      :alt: Cellular Monitor app - Select Asset Tracker V2
 
-      Cellular Monitor - Select Asset Tracker V2
+      Cellular Monitor app - Select Asset Tracker V2
 
    The **Program Modem Firmware (Optional)** window appears.
 
@@ -138,9 +138,9 @@ To update the firmware on the Thingy:91, complete the following steps:
    The **Program Mode Firmware (Optional)** window expands to display additional information.
 
    .. figure:: images/cellularmonitor_enablemcuboot.png
-      :alt: Cellular Monitor - Enable MCUboot
+      :alt: Cellular Monitor app - Enable MCUboot
 
-      Cellular Monitor - Enable MCUboot
+      Cellular Monitor app - Enable MCUboot
 
 #. Switch off the Thingy:91.
 #. Press **SW3** while switching **SW1** to the **ON** position to enable MCUboot mode.
@@ -179,9 +179,9 @@ To update the firmware on the Thingy:91, complete the following steps:
    #. Copy the ICCID by clicking on the **ICCID** label or the displayed ICCID number in the **Sim** section.
 
       .. figure:: images/cellularmonitor_iccid.png
-         :alt: Cellular Monitor - ICCID
+         :alt: Cellular Monitor app - ICCID
 
-         Cellular Monitor - ICCID
+         Cellular Monitor app - ICCID
 
       .. note::
          The ICCID copied here has 20 digits.

--- a/doc/nrf/includes/cert-flashing.txt
+++ b/doc/nrf/includes/cert-flashing.txt
@@ -3,7 +3,7 @@ To provision the certificates and the private key to the nRF91 Series modem, com
 1. `Download nRF Connect for Desktop`_.
 #. Update the modem firmware on the onboard modem of the nRF91 Series device to the latest version by following the steps in :ref:`nrf9160_gs_updating_fw_modem`.
 #. Build and program the :ref:`at_client_sample` sample to the nRF91 Series device as explained in :ref:`building` and :ref:`programming`.
-#. Launch the `Cellular Monitor`_ application, which is part of `nRF Connect for Desktop`_.
+#. Launch the `Cellular Monitor app`_ in `nRF Connect for Desktop`_.
 #. Click :guilabel:`CERTIFICATE MANAGER` located at the upper right corner.
 #. Copy the server root certificate into the ``CA certificate`` entry.
 #. Copy and paste the device certificate and the private key into the respective entries (``Client certificate``, ``Private key``).

--- a/doc/nrf/libraries/modem/nrf_modem_lib/nrf_modem_lib_trace.rst
+++ b/doc/nrf/libraries/modem/nrf_modem_lib/nrf_modem_lib_trace.rst
@@ -104,7 +104,7 @@ Sending traces over UART on an nRF91 Series DK
 To send modem traces over UART on an nRF91 Series DK, configuration must be added for the UART device in the devicetree and Kconfig.
 This is done by adding the :ref:`modem trace UART snippet <nrf91_modem_trace_uart_snippet>` when building and programming.
 
-Use the `Cellular Monitor`_ app for capturing and analyzing modem traces.
+Use the `Cellular Monitor app`_ for capturing and analyzing modem traces.
 
 TF-M logging must use the same UART as the application.
 For more details, see :ref:`shared TF-M logging <tfm_enable_share_uart>`.
@@ -178,7 +178,7 @@ To enable modem traces with RTT, enable the :kconfig:option:`CONFIG_NRF_MODEM_LI
 
 The traces can be captured using the J-Link RTT logger software.
 This produces a RAW binary trace file with a ``.log`` extension.
-The RAW binary trace file can be converted to PCAP with the :guilabel:`Open trace file in Wireshark` option in the `Cellular Monitor`_ app of `nRF Connect for Desktop`_.
+The RAW binary trace file can be converted to PCAP with the :guilabel:`Open trace file in Wireshark` option in the `Cellular Monitor app`_ in `nRF Connect for Desktop`_.
 By default, files with the ``.log`` extension are not shown.
 
 .. _adding_custom_modem_trace_backends:

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -375,6 +375,7 @@
 .. _`nRF Connect SDK v2.0.0 webinar`: https://www.nordicsemi.com/Events/2022/Webinar-Exciting-new-features-in-nRF-Connect-SDK-v2?utm_campaign=2022%20Webinars&utm_source=developer.nordicsemi.com&utm_medium=Webinar%20registration%20%7C%20nRF%20Connect%20SDK%20v2.0&utm_content=Webinar%20registration%20%7C%20nRF%20Connect%20SDK%20v2.0
 .. _`nRF Connect SDK v1.9.0 webinar`: https://www.nordicsemi.com/Events/2022/Webinar-Exciting-new-features-in-nRF-Connect-SDK-v19?utm_campaign=2022%20Webinars&utm_source=developer.nordicsemi.com&utm_medium=In-line%20text%20%7C%20nRF%20Connect%20SDK%20v1.9%20%7C%20Link%20to%20webinar
 .. _`Adding Device Firmware Update (DFU/FOTA) Support in nRF Connect SDK`: https://www.nordicsemi.com/Events/2024/Webinar-Adding-Device-Firmware-Update-DFU-FOTA-Support-in-nRF-Connect-SDK
+
 .. #### Source: www.nordicsemi.com/*/Development-Tools
 
 .. _`nRF Command Line Tools`:
@@ -607,25 +608,25 @@
 .. _`Getting started guide for nRF Asset Tracker for Azure`: https://docs.nordicsemi.com/bundle/nrf-asset-tracker-saga/page/docs/azure/GettingStarted/Index.html
 .. _`nRF Asset Tracker Memfault integration`: https://docs.nordicsemi.com/bundle/nrf-asset-tracker-saga/page/docs/memfault/Index.html
 
-.. _`nRF Connect Board Configurator`: https://docs.nordicsemi.com/bundle/nrf-connect-board-configurator/page/index.html
+.. _`Board Configurator app`: https://docs.nordicsemi.com/bundle/nrf-connect-board-configurator/page/index.html
 
-.. _`Serial Terminal from nRF Connect for Desktop`: https://docs.nordicsemi.com/bundle/nrf-connect-serial-terminal/page/index.html
-.. _`nRF Connect Serial Terminal`: https://docs.nordicsemi.com/bundle/nrf-connect-serial-terminal/page/index.html
-.. _`Connecting using Serial Terminal`: https://docs.nordicsemi.com/bundle/nrf-connect-serial-terminal/page/connecting.html
-.. _`Serial Terminal configuration`: https://docs.nordicsemi.com/bundle/nrf-connect-serial-terminal/page/configuration.html
-.. _`nRF Connect Bluetooth Low Energy`: https://docs.nordicsemi.com/bundle/nrf-connect-ble/page/index.html
-.. _`Cellular Monitor`: https://docs.nordicsemi.com/bundle/nrf-connect-cellularmonitor/page/index.html
-.. _`nPM PowerUP`: https://docs.nordicsemi.com/bundle/nrf-connect-npm/page/index.html
-.. _`Quick Start`: https://docs.nordicsemi.com/bundle/nrf-connect-quickstart/page/index.html
-.. _`RSSI Viewer`: https://docs.nordicsemi.com/bundle/nrf-connect-rssi-viewer/page/index.html
+.. _`Bluetooth Low Energy app`: https://docs.nordicsemi.com/bundle/nrf-connect-ble/page/index.html
 
+.. _`Cellular Monitor app`: https://docs.nordicsemi.com/bundle/nrf-connect-cellularmonitor/page/index.html
 .. _`Managing credentials`: https://docs.nordicsemi.com/bundle/nrf-connect-cellularmonitor/page/managing_credentials.html
 
-.. _`nRF Connect Direct Test Mode`: https://docs.nordicsemi.com/bundle/nrf-connect-direct-test-mode/page/index.html
+.. _`nPM PowerUP app`: https://docs.nordicsemi.com/bundle/nrf-connect-npm/page/index.html
+.. _`Quick Start app`: https://docs.nordicsemi.com/bundle/nrf-connect-quickstart/page/index.html
+.. _`RSSI Viewer app`: https://docs.nordicsemi.com/bundle/nrf-connect-rssi-viewer/page/index.html
 
-.. _`nRF Connect Programmer`: https://docs.nordicsemi.com/bundle/nrf-connect-programmer/page/index.html
+.. _`Direct Test Mode app`: https://docs.nordicsemi.com/bundle/nrf-connect-direct-test-mode/page/index.html
+
+.. _`Programmer app`: https://docs.nordicsemi.com/bundle/nrf-connect-programmer/page/index.html
 .. _`Programming the nRF52840 Dongle`:
 .. _`Programming a Development Kit`: https://docs.nordicsemi.com/bundle/nrf-connect-programmer/page/programming_dk.html
+
+.. _`Serial Terminal app`: https://docs.nordicsemi.com/bundle/nrf-connect-serial-terminal/page/index.html
+.. _`Connecting using the Serial Terminal app`: https://docs.nordicsemi.com/bundle/nrf-connect-serial-terminal/page/connecting.html
 
 .. _`nRF Thread Topology Monitor`: https://docs.nordicsemi.com/bundle/ug_nrf_ttm/page/UG/nrf_ttm/ttm_introduction.html
 .. _`nRF Sniffer for 802.15.4`: https://docs.nordicsemi.com/bundle/ug_sniffer_802154/page/UG/sniffer_802154/intro_802154.html
@@ -634,7 +635,7 @@
 .. _`Power Profiler Kit II (PPK2)`: https://docs.nordicsemi.com/bundle/ug_ppk2/page/UG/ppk/PPK_user_guide_Intro.html
 .. _`Install the Power Profiler app`: https://docs.nordicsemi.com/bundle/ug_ppk2/page/UG/common/nrf_connect_app_installing.html
 .. _`Using the Power Profiler app`: https://docs.nordicsemi.com/bundle/ug_ppk2/page/UG/ppk/PPK_user_guide_Running_the_software.html
-.. _`nRF Connect Power Profiler`: https://docs.nordicsemi.com/bundle/nrf-connect-ppk/page/index.html
+.. _`Power Profiler app`: https://docs.nordicsemi.com/bundle/nrf-connect-ppk/page/index.html
 
 .. _`Electrical specification for nRF7002`: https://docs.nordicsemi.com/bundle/ps_nrf7002/page/chapters/elspec/doc/electrical_specification.html
 

--- a/doc/nrf/releases_and_maturity/known_issues.rst
+++ b/doc/nrf/releases_and_maturity/known_issues.rst
@@ -1747,7 +1747,7 @@ The issues in this section are related to the :ref:`serial_lte_modem` applicatio
 .. rst-class:: wontfix v2-8-0 v2-7-0 v2-6-2 v2-6-1 v2-6-0 v2-5-3 v2-5-2 v2-5-1 v2-5-0 v2-4-4 v2-4-3 v2-4-2 v2-4-1 v2-4-0
 
 NCSDK-20457: Modem traces captured through UART are corrupted if RTT logs are simultaneously captured
-  When capturing modem traces through UART with `Cellular Monitor`_ app and simultaneously capturing RTT logs, for example, with J-Link RTT Viewer, the modem trace misses packets, and captured packets might have incorrect information.
+  When capturing modem traces through UART with the `Cellular Monitor app`_ and simultaneously capturing RTT logs, for example, with J-Link RTT Viewer, the modem trace misses packets, and captured packets might have incorrect information.
 
   **Affected platforms:** nRF9160, nRF9161, nRF9151
 

--- a/doc/nrf/releases_and_maturity/migration/2.4.99-cs3_to_2.6.99-cs2/migration_guide_2.4.99-cs3_to_2.6.99-cs2_environment.rst
+++ b/doc/nrf/releases_and_maturity/migration/2.4.99-cs3_to_2.6.99-cs2/migration_guide_2.4.99-cs3_to_2.6.99-cs2_environment.rst
@@ -233,12 +233,12 @@ After you have updated the toolchain, complete the following steps to get the |N
 Updating the Terminal application
 *********************************
 
-To update `Serial Terminal from nRF Connect for Desktop`, follow these steps:
+To update the `Serial Terminal app`_, follow these steps:
 
-1. On your computer, open `nRF Connect for Desktop`_
+1. On your computer, open `nRF Connect for Desktop`_.
    If there is an update available, a pop up will notify you of its availability.
 #. If available, install the update from the pop up screen.
-#. Update `Serial Terminal from nRF Connect for Desktop`.
+#. Update the Serial Terminal app.
 
 If you are using the nRF Terminal application part of the `nRF Connect for Visual Studio Code`_ extension, open Visual Studio Code instead and ensure you are running the newest version of both the editor and the extension.
 

--- a/doc/nrf/releases_and_maturity/migration/nRF54H20_migration_2.7/migration_guide_2.6.99-cs2_to_2_7_environment.rst
+++ b/doc/nrf/releases_and_maturity/migration/nRF54H20_migration_2.7/migration_guide_2.6.99-cs2_to_2_7_environment.rst
@@ -112,12 +112,12 @@ To proceed with the update, complete the following steps:
 Updating the Terminal application
 *********************************
 
-To update `Serial Terminal from nRF Connect for Desktop`, follow these steps:
+To update the `Serial Terminal app`_, follow these steps:
 
-1. On your computer, open `nRF Connect for Desktop`_
+1. On your computer, open `nRF Connect for Desktop`_.
    If there is an update available, a pop up will notify you of its availability.
 #. If available, install the update from the pop up screen.
-#. Update `Serial Terminal from nRF Connect for Desktop`.
+#. Update the Serial Terminal app.
 
 If you are using the nRF Terminal application part of the `nRF Connect for Visual Studio Code`_ extension, open Visual Studio Code instead and ensure you are running the newest version of both the editor and the extension.
 

--- a/doc/nrf/releases_and_maturity/migration/nRF54H20_migration_2.7/transition_guide_2.4.99-cs3_to_2.7_environment.rst
+++ b/doc/nrf/releases_and_maturity/migration/nRF54H20_migration_2.7/transition_guide_2.4.99-cs3_to_2.7_environment.rst
@@ -159,12 +159,12 @@ To install the toolchain and the SDK using the Toolchain Manager app, complete t
 Updating the Terminal application
 *********************************
 
-To update `Serial Terminal from nRF Connect for Desktop`, follow these steps:
+To update the `Serial Terminal app`_, follow these steps:
 
-1. On your computer, open `nRF Connect for Desktop`_
+1. On your computer, open `nRF Connect for Desktop`_.
    If there is an update available, a pop up will notify you of its availability.
 #. If available, install the update from the pop up screen.
-#. Update `Serial Terminal from nRF Connect for Desktop`.
+#. Update the Serial Terminal app.
 
 If you are using the nRF Terminal application part of the `nRF Connect for Visual Studio Code`_ extension, open Visual Studio Code instead and ensure you are running the newest version of both the editor and the extension.
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-2.5.0.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-2.5.0.rst
@@ -1330,8 +1330,8 @@ Documentation
     * :ref:`release_notes`, :ref:`software_maturity`, :ref:`known_issues`, :ref:`glossary`, and :ref:`dev-model` are now located under :ref:`releases_and_maturity`.
 
   * The :ref:`ug_thread` documentation to improve the overall presentation and add additional details where necessary.
-  * The :ref:`ug_nrf9160_gs` and :ref:`ug_thingy91_gsg` instructions to use `Cellular Monitor`_ instead of Programmer for the :ref:`nrf9160_gs_updating_fw` and :ref:`thingy91_update_firmware` sections, respectively.
+  * The :ref:`ug_nrf9160_gs` and :ref:`ug_thingy91_gsg` instructions to use the `Cellular Monitor app`_ instead of Programmer for the :ref:`nrf9160_gs_updating_fw` and :ref:`thingy91_update_firmware` sections, respectively.
     The instructions for using Programmer were moved to the :ref:`ug_nrf9160` and :ref:`ug_thingy91` pages.
-  * All instances of LTE Link Monitor and Trace Collector apps by replacing them with `nRF Connect Serial Terminal`_ and `Cellular Monitor`_ apps.
+  * All instances of LTE Link Monitor and Trace Collector apps by replacing them with the `Serial Terminal app`_ and the `Cellular Monitor app`_.
   * Renamed nRF91 AT Commands Reference Guide to `nRF9160 AT Commands Reference Guide`_, and added references to the `nRF91x1 AT Commands Reference Guide`_ in the documentation.
   * All references to GNSS assistance from ``A-GPS`` to `A-GNSS`_.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-2.6.0.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-2.6.0.rst
@@ -195,7 +195,7 @@ Working with nRF91 Series
 
   * The :ref:`ug_nrf9160_gs` and :ref:`ug_thingy91_gsg` pages so that instructions in the :ref:`nrf9160_gs_connecting_dk_to_cloud` and :ref:`thingy91_connect_to_cloud` sections, respectively, match the updated nRF Cloud workflow.
   * The :ref:`ug_nrf9160_gs` by replacing the Updating the DK firmware section with a new :ref:`nrf9160_gs_installing_software` section.
-    This new section includes steps for using Quick Start, a new application in `nRF Connect for Desktop`_ that streamlines the getting started process with the nRF91 Series DKs.
+    This new section includes steps for using the `Quick Start app`_, a new application in `nRF Connect for Desktop`_ that streamlines the getting started process with the nRF91 Series DKs.
   * :ref:`ug_nrf9160` user guide by separating the information about snippets into its own page, :ref:`ug_nrf91_snippet`.
 
 Working with nRF70 Series

--- a/doc/nrf/releases_and_maturity/releases/release-notes-2.8.0.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-2.8.0.rst
@@ -328,7 +328,7 @@ Developing with nRF54L Series
   * The :ref:`ug_nrf54l_developing_provision_kmu` page, including instructions on generating keys and provisioning them to the board.
 
 * Updated the name and the structure of the section, with :ref:`ug_nrf54l` as the landing page.
-* Removed the Getting started with the nRF54L15 PDK page, and instead included the information about the `Quick Start`_ app support.
+* Removed the Getting started with the nRF54L15 PDK page, and instead included the information about the `Quick Start app`_ support.
 
 Security
 ========
@@ -1546,4 +1546,4 @@ Documentation
   * The Device configuration guides section and moved its contents to :ref:`ug_app_dev`.
   * The Advanced building procedures page and moved its contents to the :ref:`building` page.
   * The standalone pages for getting started with nRF52 Series and with the nRF5340 DK.
-    These pages have been replaced by the `Quick Start`_ app that now supports the nRF52 Series devices and the nRF5340 DK.
+    These pages have been replaced by the `Quick Start app`_ that now supports the nRF52 Series devices and the nRF5340 DK.

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -25,25 +25,25 @@
 .. |connect_kit| replace:: Connect the kit to the computer using a USB cable.
    The kit is assigned a COM port (Windows) or ttyACM device (Linux), which is visible in the Device Manager.
 
-.. |connect_terminal_generic| replace:: Connect to the device with a terminal emulator (for example, nRF Connect Serial Terminal).
+.. |connect_terminal_generic| replace:: Connect to the device with a terminal emulator (for example, the `Serial Terminal app`_).
    See :ref:`test_and_optimize` for the required settings and steps.
 
-.. |connect_terminal| replace:: Connect to the kit with a terminal emulator (for example, nRF Connect Serial Terminal).
+.. |connect_terminal| replace:: Connect to the kit with a terminal emulator (for example, the `Serial Terminal app`_).
    See :ref:`test_and_optimize` for the required settings and steps.
 
-.. |connect_terminal_specific| replace:: Connect to the kit that runs this sample with a terminal emulator (for example, nRF Connect Serial Terminal).
+.. |connect_terminal_specific| replace:: Connect to the kit that runs this sample with a terminal emulator (for example, the `Serial Terminal app`_).
    See :ref:`test_and_optimize` for the required settings and steps.
 
-.. |connect_terminal_both| replace:: Connect to both kits with a terminal emulator (for example, nRF Connect Serial Terminal).
+.. |connect_terminal_both| replace:: Connect to both kits with a terminal emulator (for example, the `Serial Terminal app`_).
    See :ref:`test_and_optimize` for the required settings and steps.
 
-.. |connect_terminal_ANSI| replace:: Open a serial port connection to the kit using a terminal emulator that supports VT100/ANSI escape characters (for example, nRF Connect Serial Terminal).
+.. |connect_terminal_ANSI| replace:: Open a serial port connection to the kit using a terminal emulator that supports VT100/ANSI escape characters (for example, the `Serial Terminal app`_).
    See :ref:`test_and_optimize` for the required settings and steps.
 
-.. |connect_terminal_specific_ANSI| replace:: Connect to the kit that runs this sample with a terminal emulator that supports VT100/ANSI escape characters (for example, nRF Connect Serial Terminal).
+.. |connect_terminal_specific_ANSI| replace:: Connect to the kit that runs this sample with a terminal emulator that supports VT100/ANSI escape characters (for example, the `Serial Terminal app`_).
    See :ref:`test_and_optimize` for the required settings and steps.
 
-.. |connect_terminal_both_ANSI| replace:: Connect to both kits with a terminal emulator that supports VT100/ANSI escape characters (for example, nRF Connect Serial Terminal).
+.. |connect_terminal_both_ANSI| replace:: Connect to both kits with a terminal emulator that supports VT100/ANSI escape characters (for example, the `Serial Terminal app`_).
    See :ref:`test_and_optimize` for the required settings and steps.
 
 .. |ANSI| replace:: that supports VT100/ANSI escape characters

--- a/doc/nrf/test_and_optimize.rst
+++ b/doc/nrf/test_and_optimize.rst
@@ -40,9 +40,9 @@ Use one of the following methods:
 
 .. tabs::
 
-   .. group-tab:: nRF Connect Serial Terminal
+   .. group-tab:: Serial Terminal app
 
-      You can use the `nRF Connect Serial Terminal`_ app, which you can install from `nRF Connect for Desktop`_.
+      You can use the `Serial Terminal app`_, which you can install from `nRF Connect for Desktop`_.
       It establishes serial communication with the device, sends commands through UART, and also displays the UART output.
 
       The app is available for Windows, Linux, and macOS.
@@ -57,9 +57,9 @@ Use one of the following methods:
       #. Configure the serial port connection parameters using the default serial port connection settings listed at the top of this page.
       #. Click :guilabel:`Connect to port`.
 
-      nRF Connect Serial Terminal starts the serial communication with the kit.
+      The Serial Terminal app starts the serial communication with the kit.
 
-      For more information about how to connect using the app, see the `steps in the Serial Terminal documentation <Connecting using Serial Terminal_>`_.
+      For more information about how to connect using the app, see the `steps in the Serial Terminal documentation <Connecting using the Serial Terminal app_>`_.
 
    .. group-tab:: nRF Connect for Visual Studio Code
 

--- a/doc/nrf/test_and_optimize/debugging.rst
+++ b/doc/nrf/test_and_optimize/debugging.rst
@@ -159,19 +159,19 @@ The following debugging tools are most commonly used in different areas of the |
    * - Tool
      - Purpose
      - Area
-   * - `nRF Connect Bluetooth Low Energy`_
+   * - `Bluetooth Low Energy app`_
      - Configure and test Bluetooth Low Energy devices. Available from `nRF Connect for Desktop`_.
      - :ref:`ug_bt`
-   * - `nRF Connect Cellular Monitor <Cellular Monitor_>`_
+   * - `Cellular Monitor app`_
      - Capture and analyze modem traces to evaluate communication and view network parameters. Available from `nRF Connect for Desktop`_.
      - :ref:`ug_lte`
-   * - `nRF Connect Direct Test Mode`_
+   * - `Direct Test Mode app`_
      - Perform RF PHY checks of Bluetooth Low Energy devices using a GUI for the Bluetooth-specified Direct Test Mode. Available from `nRF Connect for Desktop`_.
      - :ref:`ug_bt`
-   * - `nRF Connect RSSI Viewer <RSSI Viewer_>`_
+   * - `RSSI Viewer app`_
      - Visualize RSSI and frequency in the 2.4-GHz band in real time. Available from `nRF Connect for Desktop`_.
      - :ref:`ug_bt`
-   * - `nRF Connect Power Profiler`_
+   * - `Power Profiler app`_
      - Measure the real-time power consumption of your designs. Available from `nRF Connect for Desktop`_.
      - :ref:`ug_bt`, :ref:`ug_lte`, :ref:`ug_matter`, :ref:`ug_thread`, :ref:`ug_wifi`, :ref:`ug_zigbee`
    * - `Online Power Profiler (OPP)`_

--- a/samples/bluetooth/conn_time_sync/README.rst
+++ b/samples/bluetooth/conn_time_sync/README.rst
@@ -23,7 +23,7 @@ You need at least two development kits to test this sample:
 
 You can use mix different development kits from the list above.
 
-Additionally, the sample requires connecting each development kit to a serial terminal and using a terminal emulator (for example, `nRF Connect Serial Terminal`_).
+Additionally, the sample requires connecting each development kit to a serial terminal and using a terminal emulator (for example, the `Serial Terminal app`_).
 
 To observe that the LEDs are toggled synchronously, use a logic analyzer or an oscilloscope.
 
@@ -131,7 +131,7 @@ Testing
 
 After programming the sample to all development kits, perform the following steps to test it:
 
-1. Connect to the kits with a terminal emulator (for example, `nRF Connect Serial Terminal`_).
+1. Connect to the kits with a terminal emulator (for example, the `Serial Terminal app`_).
    See :ref:`test_and_optimize` for the required settings and steps.
 #. Reset the kits.
 #. In one of the terminal emulators, type ``c`` to start the application in the Central role.

--- a/samples/bluetooth/event_trigger/README.rst
+++ b/samples/bluetooth/event_trigger/README.rst
@@ -37,7 +37,7 @@ Testing
 
 After programming the sample to both development kits, test it by performing the following steps:
 
-1. Connect to both kits with a terminal emulator (for example, `nRF Connect Serial Terminal`_).
+1. Connect to both kits with a terminal emulator (for example, the `Serial Terminal app`_).
    See :ref:`test_and_optimize` for the required settings and steps.
 #. Reset both kits.
 

--- a/samples/bluetooth/llpm/README.rst
+++ b/samples/bluetooth/llpm/README.rst
@@ -102,7 +102,7 @@ Testing
 
 After programming the sample to both development kits, test it by performing the following steps:
 
-1. Connect to both kits with a terminal emulator (for example, `nRF Connect Serial Terminal`_).
+1. Connect to both kits with a terminal emulator (for example, the `Serial Terminal app`_).
    See :ref:`test_and_optimize` for the required settings and steps.
 #. Reset both kits.
 #. In one of the terminal emulators, type "c" to start the application on the connected board in the central (tester) role.

--- a/samples/bluetooth/peripheral_uart/README.rst
+++ b/samples/bluetooth/peripheral_uart/README.rst
@@ -26,7 +26,7 @@ The sample supports the following development kits:
    * When used with :ref:`zephyr:nrf5340dk_nrf5340`, the sample might support the MCUboot bootloader with serial recovery of the networking core image.
 
 The sample also requires using a compatible application for `Testing`_.
-You can use the `nRF Connect Bluetooth Low Energy`_ or `nRF Connect for Mobile`_ applications (or other similar applications, such as `nRF Blinky`_ or `nRF Toolbox`_).
+You can use the `Bluetooth Low Energy app`_ for desktop or the `nRF Connect for Mobile`_ (or other similar applications, such as `nRF Blinky`_ or `nRF Toolbox`_).
 Using mobile applications for testing requires a smartphone or tablet.
 
 You can also test the application with the :ref:`central_uart` sample.
@@ -321,11 +321,11 @@ Testing with Bluetooth Low Energy app
 -------------------------------------
 
 If you have an nRF52 Series DK with the Peripheral UART sample and either a dongle or second Nordic Semiconductor development kit that supports Bluetooth Low Energy, you can test the sample on your computer.
-Use the `nRF Connect Bluetooth Low Energy`_ app in `nRF Connect for Desktop`_ for testing.
+Use the `Bluetooth Low Energy app`_ in `nRF Connect for Desktop`_ for testing.
 
 To perform the test, complete the following steps:
 
-1. Install the nRF Connect Bluetooth Low Energy app in `nRF Connect for Desktop`_.
+1. Install the Bluetooth Low Energy app in `nRF Connect for Desktop`_.
 #. Connect to your nRF52 Series DK.
 #. Connect the dongle or second development kit to a USB port of your computer.
 #. Open the Bluetooth Low Energy app.
@@ -334,7 +334,7 @@ To perform the test, complete the following steps:
 
    .. note::
       If the dongle or the second development kit has not been used with the Bluetooth Low Energy app before, you may be asked to update the J-Link firmware and connectivity firmware on the nRF SoC to continue.
-      When the nRF SoC has been updated with the correct firmware, the nRF Connect Bluetooth Low Energy app finishes connecting to your device over USB.
+      When the nRF SoC has been updated with the correct firmware, the Bluetooth Low Energy app finishes connecting to your device over USB.
       When the connection is established, the device appears in the main view.
 
 #. Click :guilabel:`Start scan`.

--- a/samples/bluetooth/radio_notification_cb/README.rst
+++ b/samples/bluetooth/radio_notification_cb/README.rst
@@ -39,7 +39,7 @@ Testing
 
 After programming the sample to both development kits, perform the following steps to test it:
 
-1. Connect to both kits with a terminal emulator (for example, `nRF Connect Serial Terminal`_).
+1. Connect to both kits with a terminal emulator (for example, the `Serial Terminal app`_).
    See :ref:`test_and_optimize` for the required settings and steps.
 #. Reset both kits.
 #. In one of the terminal emulators, type ``c`` to start the application on the connected board in the central role.

--- a/samples/bluetooth/subrating/README.rst
+++ b/samples/bluetooth/subrating/README.rst
@@ -77,7 +77,7 @@ Testing
 
 After programming the sample to both development kits, test it by performing the following steps:
 
-1. Connect to both kits with a terminal emulator (for example, `nRF Connect Serial Terminal`_).
+1. Connect to both kits with a terminal emulator (for example, the `Serial Terminal app`_).
    See :ref:`test_and_optimize` for the required settings and steps.
 #. Reset both kits.
 #. In one of the terminal emulators, type ``c`` to start the application on the connected board in the central role.

--- a/samples/cellular/at_client/README.rst
+++ b/samples/cellular/at_client/README.rst
@@ -24,7 +24,7 @@ Overview
 
 The AT Client sample acts as a proxy for sending directives to the nRF91 Series modem using AT commands.
 This facilitates the reading of responses or analyzing of events related to the nRF91 Series modem.
-You can initiate the commands manually from a terminal such as the `nRF Connect Serial Terminal`_, or visually using the `Cellular Monitor`_ app.
+You can initiate the commands manually from a terminal such as the `Serial Terminal app`_, or visually using the `Cellular Monitor app`_.
 Both apps are part of `nRF Connect for Desktop`_.
 
 For more information on the AT commands, see the `nRF91x1 AT Commands Reference Guide`_  or `nRF9160 AT Commands Reference Guide`_ depending on the SiP you are using.
@@ -47,7 +47,7 @@ Testing
 After programming the sample to your development kit, test it by performing the following steps:
 
 1. Press the reset button on the nRF91 Series DK to reboot the kit and start the AT Client sample.
-#. :ref:`Connect to the nRF91 Series DK with nRF Connect Serial Terminal <serial_terminal_connect>`.
+#. :ref:`Connect to the nRF91 Series DK with the Serial Terminal app <serial_terminal_connect>`.
 #. Run the following commands from the Serial Terminal:
 
    a. Enter the command: :command:`AT+CFUN?`.

--- a/samples/cellular/lte_ble_gateway/README.rst
+++ b/samples/cellular/lte_ble_gateway/README.rst
@@ -111,7 +111,7 @@ Program the board controller as follows:
          west build --board nrf9160dk@1.1.0/nrf52840
 
 #. Verify that the programming was successful.
-   Use a terminal emulator, like `nRF Connect Serial Terminal`_, to connect to the second serial port and check the output.
+   Use a terminal emulator, like the `Serial Terminal app`_, to connect to the second serial port and check the output.
    See :ref:`test_and_optimize` for the required settings and steps.
 
 After programming the board controller, you must program the main controller with the LTE Sensor Gateway sample.
@@ -131,7 +131,7 @@ Program the main controller as follows:
          west build --board nrf9160dk@1.1.0/nrf9160/ns
 
 #. Verify that the programming was successful.
-   To do so, use a terminal emulator, like nRF Connect Serial Terminal, to connect to the first serial port and check the output.
+   Use a terminal emulator, like the Serial Terminal app, to connect to the first serial port and check the output.
    See :ref:`test_and_optimize` for the required settings and steps.
 
 Testing

--- a/samples/cellular/lwm2m_carrier/provisioning.rst
+++ b/samples/cellular/lwm2m_carrier/provisioning.rst
@@ -31,7 +31,7 @@ Alternatively, you can also write the certificates beforehand using the :ref:`at
 
 To pre-program the certificates, use one of the following methods:
 
-* Build and flash the :ref:`at_client_sample` sample and provision the certificates using AT commands and the `Cellular Monitor`_ application.
+* Build and flash the :ref:`at_client_sample` sample and provision the certificates using AT commands and the `Cellular Monitor app`_.
   See `Managing credentials`_ for more information.
 * Build and flash the LwM2M carrier sample, while making sure that:
 

--- a/samples/cellular/lwm2m_carrier/sample_description.rst
+++ b/samples/cellular/lwm2m_carrier/sample_description.rst
@@ -140,7 +140,7 @@ Testing
 After programming the sample and all prerequisites to the development kit, test it by performing the following steps:
 
 1. Connect the USB cable and power on or reset your nRF91 Series DK.
-#. Use a terminal emulator, like `nRF Connect Serial Terminal`_, to connect to the serial port.
+#. Use a terminal emulator, like the `Serial Terminal app`_, to connect to the serial port.
    See :ref:`test_and_optimize` for the required settings and steps.
 #. Observe that the kit prints the following information::
 

--- a/samples/cellular/modem_shell/README.rst
+++ b/samples/cellular/modem_shell/README.rst
@@ -1017,9 +1017,9 @@ To program the certificates and connect to nRF Cloud, complete the following ste
       mosh:~$ at at_cmd_mode start
 
 #. Disconnect the MoSh terminal.
-#. Connect and use `Cellular Monitor`_  to store the certificates to the modem (default nRF Cloud security tag).
+#. Connect and use the `Cellular Monitor app`_ to store the certificates to the modem (default nRF Cloud security tag).
 
-   See `Managing credentials`_ in the Cellular Monitor user guide for instructions.
+   See `Managing credentials`_ in the Cellular Monitor app documentation for instructions.
 #. Reconnect the MoSh terminal and press ``ctrl-x`` and ``ctrl-q`` to exit the AT command mode.
 #. Set the modem to normal mode to activate LTE:
 
@@ -1108,7 +1108,7 @@ After programming the development kit, test it in the Linux environment by perfo
 1. Connect the development kit to the computer using a USB cable.
    The development kit is assigned a ttyACM device (Linux).
 
-#. Open a serial connection to the development kit (/dev/ttyACM2) with a terminal |ANSI| (for example, nRF Connect Serial Terminal).
+#. Open a serial connection to the development kit (/dev/ttyACM2) with a terminal |ANSI| (for example, the `Serial Terminal app`_).
    See :ref:`test_and_optimize` for the required settings and steps.
 
 #. Reset the development kit.

--- a/samples/cellular/modem_trace_flash/README.rst
+++ b/samples/cellular/modem_trace_flash/README.rst
@@ -83,7 +83,7 @@ Testing
 After programming the sample and board controller firmware (as mentioned in Requirements section) to your development kit, test it by performing the following steps:
 
 #. |connect_kit|
-#. Open the `Cellular Monitor`_ desktop application and connect the DK.
+#. Open the `Cellular Monitor app`_ and connect the DK.
 #. Select :guilabel:`Autoselect` from the **Modem trace database** drop-down menu, or a modem firmware version that is programmed on the DK.
 #. Select :guilabel:`Reset device on start`.
 #. Make sure that either :guilabel:`Open in Wireshark` or :guilabel:`Save trace file to disk` is selected.
@@ -92,7 +92,7 @@ After programming the sample and board controller firmware (as mentioned in Requ
    The button changes to :guilabel:`Stop` and is greyed out.
 #. When the console output  ``Flushed modem traces to flash`` is received in Serial Terminal, press **Button 1** on the development kit.
    If you are not using a serial terminal, you can approximately wait for one minute after clicking the :guilabel:`Start` button, and then press **Button 1**.
-#. Observe modem traces received on the Cellular Monitor desktop application.
+#. Observe modem traces received on the Cellular Monitor app.
 
 .. note::
    Since the external flash is erased at startup, there will be a few seconds of delay before the first console output is received from the sample.

--- a/samples/cellular/nrf_cloud_multi_service/README.rst
+++ b/samples/cellular/nrf_cloud_multi_service/README.rst
@@ -1084,7 +1084,7 @@ If you have :ref:`enabled support <nrf_cloud_multi_service_building_provisioning
 
    The nRF Cloud Provisioning Service auto-onboarding is compatible with CoAP, REST and MQTT connectivity with nRF Cloud.
 
-   With this method, use the nRF Connect Serial Terminal program and the nRF Cloud portal.
+   With this method, use the `Serial Terminal app`_ and the nRF Cloud portal.
    The device ID used in nRF Cloud portal requires the UUID format and not the 'nrf-\ *IMEI*\ ' format.
    See `device claiming <nRF Cloud device claiming_>`_ for more information.
 

--- a/samples/crypto/psa_tls/README.rst
+++ b/samples/crypto/psa_tls/README.rst
@@ -130,7 +130,7 @@ After programming the sample to your development kit, complete the following ste
 
    .. tab:: Server test
 
-      1. Start a terminal emulator like nRF Connect Serial Terminal and connect to the used serial port with the standard UART settings.
+      1. Start a terminal emulator like the `Serial Terminal app`_ and connect to the used serial port with the standard UART settings.
          See :ref:`test_and_optimize` for more information.
       #. Observe the logs from the application using the terminal emulator.
       #. Start the ``eth_rtt_link`` executable as a superuser with your development kit's SEGGER ID and the following IPv4 address as parameters:
@@ -166,7 +166,7 @@ After programming the sample to your development kit, complete the following ste
 
    .. tab:: Client test
 
-      1. Start a terminal emulator like nRF Connect Serial Terminal and connect to the used serial port with the standard UART settings.
+      1. Start a terminal emulator like the `Serial Terminal app`_ and connect to the used serial port with the standard UART settings.
          See :ref:`test_and_optimize` for more information.
       #. Observe the logs from the application using the terminal emulator.
       #. Start the ``eth_rtt_link`` executable as a superuser with your development kit's SEGGER ID and the following IPv4 address as parameters:
@@ -204,7 +204,7 @@ After programming the sample to your development kit, complete the following ste
 
       Use ``dtls.conf`` overlay when building the sample to enable DTLS support.
 
-      1. Start a terminal emulator like nRF Connect Serial Terminal and connect to the used serial port with the standard UART settings.
+      1. Start a terminal emulator like the `Serial Terminal app`_ and connect to the used serial port with the standard UART settings.
          See :ref:`test_and_optimize` for more information.
       #. Observe the logs from the application using the terminal emulator.
       #. Start the ``eth_rtt_link`` executable as a superuser with your development kit's SEGGER ID and the following IPv4 address as parameters:
@@ -242,7 +242,7 @@ After programming the sample to your development kit, complete the following ste
 
       Use ``dtls.conf`` overlay when building the sample to enable DTLS support.
 
-      1. Start a terminal emulator like nRF Connect Serial Terminal and connect to the used serial port with the standard UART settings.
+      1. Start a terminal emulator like the `Serial Terminal app`_ and connect to the used serial port with the standard UART settings.
          See :ref:`test_and_optimize` for more information.
       #. Observe the logs from the application using the terminal emulator.
       #. Start the ``eth_rtt_link`` executable as a superuser with your development kit's SEGGER ID and the following IPv4 address as parameters:

--- a/samples/esb/esb_prx/README.rst
+++ b/samples/esb/esb_prx/README.rst
@@ -69,7 +69,7 @@ Complete the following steps to test both the Transmitter and Receiver samples:
 
 1. Power on both kits.
 #. Observe that the LEDs change synchronously on both kits.
-#. Optionally, connect to the kits with a terminal emulator (for example, nRF Connect Serial Terminal).
+#. Optionally, connect to the kits with a terminal emulator (for example, the `Serial Terminal app`_).
    See :ref:`test_and_optimize` for the required settings and steps.
 #. Observe the logging output for both kits.
 

--- a/samples/esb/esb_ptx/README.rst
+++ b/samples/esb/esb_ptx/README.rst
@@ -69,7 +69,7 @@ Complete the following steps to test both the Transmitter and Receiver samples:
 
 1. Power on both kits.
 #. Observe that the LEDs change synchronously on both kits.
-#. Optionally, connect to the kits with a terminal emulator (for example, nRF Connect Serial Terminal).
+#. Optionally, connect to the kits with a terminal emulator (for example, the `Serial Terminal app`_).
    See :ref:`test_and_optimize` for the required settings and steps.
 #. Observe the logging output for both kits.
 

--- a/samples/gazell/gzll_ack_payload_host/README.rst
+++ b/samples/gazell/gzll_ack_payload_host/README.rst
@@ -106,7 +106,7 @@ After programming the Device sample on one of the development kits and the Host 
    Observe that the Host sample turns off **LED 1** on the other kit.
 #. Press **Button 2** for the Host sample.
    Observe that the Device sample turns off **LED 2** on the other kit.
-#. Optionally, connect to the kits with a terminal emulator (for example, nRF Connect Serial Terminal).
+#. Optionally, connect to the kits with a terminal emulator (for example, the `Serial Terminal app`_).
    See :ref:`test_and_optimize` for the required settings and steps.
 #. Observe the logging output for both kits.
 

--- a/samples/net/aws_iot/README.rst
+++ b/samples/net/aws_iot/README.rst
@@ -210,7 +210,7 @@ The *modem_version* parameter in messages published to AWS IoT will not be prese
 .. note::
    For nRF91 Series devices, the output differs from the above example output.
    This is because the sample enables the :ref:`lib_at_host` library using the :kconfig:option:`CONFIG_AT_HOST_LIBRARY` option.
-   This library makes it possible to send AT commands to the nRF91 Series modem and receive responses using the `Cellular Monitor`_ app from nRF Connect for Desktop.
+   This library makes it possible to send AT commands to the nRF91 Series modem and receive responses using the `Cellular Monitor app`_ in nRF Connect for Desktop.
    The additional logs are AT command responses that the modem sends to the application core that are forwarded over UART to be displayed on any of these nRF Connect for Desktop apps.
 
 To observe incoming messages in the AWS IoT console, follow the steps documented in :ref:`aws_iot_testing_and_debugging`.
@@ -233,7 +233,7 @@ Troubleshooting
 
 To enable more verbose logging from the AWS IoT library, enable the :kconfig:option:`CONFIG_AWS_IOT_LOG_LEVEL_DBG` option.
 
-* If you have issues with connectivity on nRF91 Series devices, see the `Cellular Monitor`_ documentation to learn how to capture modem traces in order to debug network traffic in Wireshark.
+* If you have issues with connectivity on nRF91 Series devices, see the `Cellular Monitor app`_ documentation to learn how to capture modem traces in order to debug network traffic in Wireshark.
   The sample enables modem traces by default.
 * If you have issues with the sample, refer to :ref:`testing`.
 * For issues related to connection towards AWS IoT, refer to :ref:`AWS IoT library troubleshooting <aws_iot_troubleshooting>`.

--- a/samples/net/http_server/README.rst
+++ b/samples/net/http_server/README.rst
@@ -327,7 +327,7 @@ The following serial output is from the terminal window that performs the HTTP c
 Troubleshooting
 ***************
 
-If you have issues with connectivity on nRF91 Series devices, see the `Cellular Monitor`_ documentation to learn how to capture modem traces to debug network traffic in Wireshark.
+If you have issues with connectivity on nRF91 Series devices, see the `Cellular Monitor app`_ documentation to learn how to capture modem traces to debug network traffic in Wireshark.
 Modem traces can be enabled by providing a snippet with the west build command as shown in the following example for nRF9161 DK:
 
 .. code-block:: console

--- a/samples/net/mqtt/doc/description.rst
+++ b/samples/net/mqtt/doc/description.rst
@@ -244,7 +244,7 @@ The sample output showing IPv6, but for a different build configuration using LT
 .. note::
    For nRF91 Series devices, the output differs from the above example output.
    This is because the sample enables the :ref:`lib_at_host` library using the :kconfig:option:`CONFIG_AT_HOST_LIBRARY` option.
-   This library makes it possible to send AT commands to the nRF91 Series modem and receive responses using the `Cellular Monitor`_ app from nRF Connect for Desktop.
+   This library makes it possible to send AT commands to the nRF91 Series modem and receive responses using the `Cellular Monitor app`_ in nRF Connect for Desktop.
    The additional logs are AT command responses that the modem sends to the application core that are forwarded over UART to be displayed on any of these nRF Connect for Desktop apps.
 
 Reconnection logic
@@ -285,7 +285,7 @@ Troubleshooting
 
 To enable more verbose logging from the MQTT helper library, enable the :kconfig:option:`CONFIG_MQTT_HELPER_LOG_LEVEL_DBG` option.
 
-* If you have issues with connectivity on nRF91 Series devices, see the `Cellular Monitor`_ documentation to learn how to capture modem traces in order to debug network traffic in Wireshark.
+* If you have issues with connectivity on nRF91 Series devices, see the `Cellular Monitor app`_ documentation to learn how to capture modem traces in order to debug network traffic in Wireshark.
   The sample enables modem traces by default.
 * Public MQTT brokers might be unstable.
   If you have trouble connecting to the MQTT broker, try switching to another broker by changing the value of the :ref:`CONFIG_MQTT_SAMPLE_TRANSPORT_BROKER_HOSTNAME <CONFIG_MQTT_SAMPLE_TRANSPORT_BROKER_HOSTNAME>` configuration option.

--- a/samples/net/udp/README.rst
+++ b/samples/net/udp/README.rst
@@ -104,7 +104,7 @@ After programming the sample to your device, test it by performing the following
 Troubleshooting
 ===============
 
-If you have issues with connectivity on nRF91 Series devices, see the `Cellular Monitor`_ documentation to learn how to capture modem traces in order to debug network traffic in Wireshark.
+If you have issues with connectivity on nRF91 Series devices, see the `Cellular Monitor app`_ documentation to learn how to capture modem traces in order to debug network traffic in Wireshark.
 This sample enables modem traces by default.
 
 Dependencies

--- a/samples/openthread/coap_client/README.rst
+++ b/samples/openthread/coap_client/README.rst
@@ -243,7 +243,7 @@ When you have set up nRF Toolbox, complete the following steps after the standar
 Sample output
 =============
 
-You can observe the sample logging output with a terminal emulator |ANSI| (for example, nRF Connect Serial Terminal).
+You can observe the sample logging output with a terminal emulator |ANSI| (for example, the `Serial Terminal app`_).
 See :ref:`test_and_optimize` for the required settings and steps.
 
 Dependencies

--- a/samples/openthread/coap_server/README.rst
+++ b/samples/openthread/coap_server/README.rst
@@ -112,7 +112,7 @@ After building the sample and programming it to your development kit, complete t
 Running OpenThread CLI commands
 -------------------------------
 
-You can connect to any of the Simple CoAP Server or Simple CoAP Client nodes with a terminal emulator |ANSI| (for example, nRF Connect Serial Terminal).
+You can connect to any of the Simple CoAP Server or Simple CoAP Client nodes with a terminal emulator |ANSI| (for example, the `Serial Terminal app`_).
 See :ref:`test_and_optimize` for the required settings and steps.
 
 Once the serial connection is ready, you can run OpenThread CLI commands.

--- a/samples/peripheral/radio_test/README.rst
+++ b/samples/peripheral/radio_test/README.rst
@@ -31,7 +31,7 @@ The sample also requires one of the following testing devices:
 
   * Another development kit with the same sample.
     See :ref:`radio_test_testing_board`.
-  * Another development kit connected to a PC with the `RSSI Viewer`_ application (available in the `nRF Connect for Desktop`_).
+  * Another development kit connected to a PC with the `RSSI Viewer app`_ (available in the `nRF Connect for Desktop`_).
     See :ref:`radio_test_testing_rssi`.
 
 .. note::
@@ -257,8 +257,8 @@ Complete the following steps:
 
 .. _radio_test_testing_rssi:
 
-Testing with RSSI Viewer
-------------------------
+Testing with the RSSI Viewer app
+--------------------------------
 
 Complete the following steps:
 
@@ -269,7 +269,7 @@ Complete the following steps:
 #. Set the end channel with the ``end_channel`` command to 60.
 #. Set the time on channel with the ``time_on_channel`` command to 50 ms.
 #. Set the kit in the TX sweep mode using the ``start_tx_sweep`` command.
-#. Start the `RSSI Viewer`_ application and select the kit to communicate with.
+#. Start the `RSSI Viewer app`_ and select the kit to communicate with.
 #. On the application chart, observe the TX sweep in the form of a wave that starts at 2420 MHz frequency and ends with 2480 MHz.
 
 Dependencies

--- a/samples/zigbee/light_switch/README.rst
+++ b/samples/zigbee/light_switch/README.rst
@@ -315,7 +315,7 @@ You can now control the devices either with the buttons on the development kits 
 Sample output
 -------------
 
-You can observe the sample logging output through a serial port after connecting with a terminal emulator (for example, nRF Connect Serial Terminal).
+You can observe the sample logging output through a serial port after connecting with a terminal emulator (for example, the `Serial Terminal app`_).
 See :ref:`test_and_optimize` for the required settings and steps.
 
 Dependencies

--- a/samples/zigbee/ncp/README.rst
+++ b/samples/zigbee/ncp/README.rst
@@ -211,11 +211,11 @@ nRF5 SDK Bootloader
 When the sample is built for ``nrf52840dongle/nrf52840``, the build system does not produce an upgrade image.
 To upgrade the dongle, you can use one of the following options:
 
-* nRF Connect Programmer application (part of `nRF Connect for Desktop`_).
+* `Programmer app`_ (part of `nRF Connect for Desktop`_).
 
-  For more details, see `Programming the nRF52840 Dongle`_ in the nRF Connect Programmer user guide.
+  For more details, see `Programming the nRF52840 Dongle`_ in the Programmer app documentation.
 
-* `nRF Util`_ tool, if you do not want to use the nRF Connect Programmer application.
+* `nRF Util`_ tool, if you do not want to use the Programmer app.
 
   To generate a DFU package, see `Generating DFU packages`_ in the nRF Util user guide.
   Upgrading the dongle using this method requires putting the dongle into the DFU mode.


### PR DESCRIPTION
Updated nRF Connect for Desktop app names to match the application. Dropped `nRF Connect` from the name and added `app` after. Reasons in NCD-1066.