### PR TITLE
samples: dect_phy: dect_shell: mac: rach_tx: interval support

### DIFF
--- a/samples/dect/dect_phy/dect_shell/README.rst
+++ b/samples/dect/dect_phy/dect_shell/README.rst
@@ -639,6 +639,8 @@ Example: starting of cluster beacon and sending RA data to it
 
   .. code-block:: console
 
+      desh:~$ dect sett --reset
+      desh:~$ dect sett -t 1245
       desh:~$ dect mac beacon_scan -c 1659
       -----------------------------------------------------------------------------
       Beacon scan started.
@@ -823,6 +825,18 @@ Example: starting of cluster beacon and sending RA data to it
             IE type: Padding (0 byte)
             Payload length: 0
             Received padding data, len 0, payload is not printed
+
+* PT/client side - Send JSON-formatted periodic RA data in 10-second intervals with the current modem temperature to the scanned beacon:
+
+  .. code-block:: console
+
+      desh:~$ dect mac rach_tx -t 1234 -d "Data from device 1245" -i 10 -j
+
+* PT/client side - Stop periodic RA data sending:
+
+  .. code-block:: console
+
+      desh:~$ dect mac rach_tx stop
 
 * PT/client side - Send association release to the scanned beacon:
 

--- a/samples/dect/dect_phy/dect_shell/src/dect/common/dect_app_time.c
+++ b/samples/dect/dect_phy/dect_shell/src/dect/common/dect_app_time.c
@@ -9,7 +9,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "nrf_modem_dect_phy.h"
+#include <nrf_modem_dect_phy.h>
 
 #include "dect_app_time.h"
 

--- a/samples/dect/dect_phy/dect_shell/src/dect/common/dect_common.h
+++ b/samples/dect/dect_phy/dect_shell/src/dect/common/dect_common.h
@@ -10,7 +10,7 @@
 #include <zephyr/kernel.h>
 #include <modem/nrf_modem_lib.h>
 #include <nrf_modem_at.h>
-#include "nrf_modem_dect_phy.h"
+#include <nrf_modem_dect_phy.h>
 
 #define DECT_MAX_TBS	  5600
 #define DECT_DATA_MAX_LEN (DECT_MAX_TBS / 8)

--- a/samples/dect/dect_phy/dect_shell/src/dect/common/dect_common_pdu.c
+++ b/samples/dect/dect_phy/dect_shell/src/dect/common/dect_common_pdu.c
@@ -9,8 +9,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <zephyr/shell/shell.h>
+#include <nrf_modem_dect_phy.h>
+
 #include "desh_print.h"
-#include "nrf_modem_dect_phy.h"
 
 #include "dect_common.h"
 #include "dect_common_utils.h"

--- a/samples/dect/dect_phy/dect_shell/src/dect/common/dect_common_settings.c
+++ b/samples/dect/dect_phy/dect_shell/src/dect/common/dect_common_settings.c
@@ -12,9 +12,9 @@
 #include <zephyr/shell/shell.h>
 #include <zephyr/settings/settings.h>
 #include <zephyr/random/random.h>
+#include <nrf_modem_dect_phy.h>
 
 #include "desh_print.h"
-#include "nrf_modem_dect_phy.h"
 #include "dect_common.h"
 #include "dect_common_settings.h"
 

--- a/samples/dect/dect_phy/dect_shell/src/dect/common/dect_phy_common.h
+++ b/samples/dect/dect_phy/dect_shell/src/dect/common/dect_phy_common.h
@@ -10,7 +10,7 @@
 #include <zephyr/kernel.h>
 #include <modem/nrf_modem_lib.h>
 #include <nrf_modem_at.h>
-#include "nrf_modem_dect_phy.h"
+#include <nrf_modem_dect_phy.h>
 #include "dect_common.h"
 
 /******************************************************************************/

--- a/samples/dect/dect_phy/dect_shell/src/dect/common/dect_phy_common_rx.c
+++ b/samples/dect/dect_phy/dect_shell/src/dect/common/dect_phy_common_rx.c
@@ -9,7 +9,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "nrf_modem_dect_phy.h"
+#include <nrf_modem_dect_phy.h>
 
 static uint16_t last_rx_op_channel;
 

--- a/samples/dect/dect_phy/dect_shell/src/dect/common/dect_phy_common_rx.h
+++ b/samples/dect/dect_phy/dect_shell/src/dect/common/dect_phy_common_rx.h
@@ -7,7 +7,7 @@
 #ifndef DECT_PHY_COMMON_RX_H
 #define DECT_PHY_COMMON_RX_H
 
-#include "nrf_modem_dect_phy.h"
+#include <nrf_modem_dect_phy.h>
 
 /* Due to lack of information of a carrier/channel in pdc_cb from libmodem/modem,
  * a small wrapper for RX operations is needed to have a glue to which channel pdc_cb is for.

--- a/samples/dect/dect_phy/dect_shell/src/dect/dect_phy_ctrl.h
+++ b/samples/dect/dect_phy/dect_shell/src/dect/dect_phy_ctrl.h
@@ -49,6 +49,8 @@ void dect_phy_ctrl_rx_stop(void);
 
 int dect_phy_ctrl_time_query(void);
 
+int dect_phy_ctrl_modem_temperature_get(void);
+
 /******************************************************************************/
 
 typedef void (*dect_phy_ctrl_rssi_scan_completed_callback_t)(

--- a/samples/dect/dect_phy/dect_shell/src/dect/dect_phy_rx.c
+++ b/samples/dect/dect_phy/dect_shell/src/dect/dect_phy_rx.c
@@ -10,11 +10,10 @@
 #include <stdlib.h>
 #include <zephyr/shell/shell.h>
 
+#include <nrf_modem_dect_phy.h>
+
 #include "desh_print.h"
-#include "nrf_modem_dect_phy.h"
-
 #include "dect_phy_shell.h"
-
 #include "dect_phy_scan.h"
 #include "dect_phy_rx.h"
 

--- a/samples/dect/dect_phy/dect_shell/src/dect/dect_phy_scan.c
+++ b/samples/dect/dect_phy/dect_shell/src/dect/dect_phy_scan.c
@@ -9,8 +9,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <zephyr/shell/shell.h>
+#include <nrf_modem_dect_phy.h>
+
 #include "desh_print.h"
-#include "nrf_modem_dect_phy.h"
 
 #include "dect_common_utils.h"
 #include "dect_phy_common_rx.h"

--- a/samples/dect/dect_phy/dect_shell/src/dect/dect_phy_shell.c
+++ b/samples/dect/dect_phy/dect_shell/src/dect/dect_phy_shell.c
@@ -19,7 +19,7 @@
 #include <modem/nrf_modem_lib.h>
 #include <nrf_modem_at.h>
 
-#include "nrf_modem_dect_phy.h"
+#include <nrf_modem_dect_phy.h>
 
 #include "dect_common_utils.h"
 #include "dect_phy_api_scheduler.h"

--- a/samples/dect/dect_phy/dect_shell/src/dect/dect_phy_shell.h
+++ b/samples/dect/dect_phy/dect_shell/src/dect/dect_phy_shell.h
@@ -8,7 +8,7 @@
 #define DECT_PHY_SHELL_H
 
 #include <zephyr/kernel.h>
-#include "nrf_modem_dect_phy.h"
+#include <nrf_modem_dect_phy.h>
 
 #include "dect_common.h"
 #include "dect_common_settings.h"
@@ -185,10 +185,11 @@ struct dect_phy_common_op_event_msgq_item {
 
 #define DECT_PHY_MAC_BEACON_RA_RESP_TX_HANDLE 1000
 
-#define DECT_PHY_MAC_CLIENT_RA_TX_HANDLE	      1001
-#define DECT_PHY_MAC_CLIENT_ASSOCIATION_TX_HANDLE     1002
-#define DECT_PHY_MAC_CLIENT_ASSOCIATION_RX_HANDLE     1003
-#define DECT_PHY_MAC_CLIENT_ASSOCIATION_REL_TX_HANDLE 1004
+#define DECT_PHY_MAC_CLIENT_RA_TX_HANDLE		1001
+#define DECT_PHY_MAC_CLIENT_RA_TX_CONTINUOUS_HANDLE	1002
+#define DECT_PHY_MAC_CLIENT_ASSOCIATION_TX_HANDLE	1003
+#define DECT_PHY_MAC_CLIENT_ASSOCIATION_RX_HANDLE	1004
+#define DECT_PHY_MAC_CLIENT_ASSOCIATION_REL_TX_HANDLE	1005
 
 
 #define DECT_PHY_PERF_TX_HANDLE_START 10000

--- a/samples/dect/dect_phy/dect_shell/src/dect/mac/dect_phy_mac.c
+++ b/samples/dect/dect_phy/dect_shell/src/dect/mac/dect_phy_mac.c
@@ -9,9 +9,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <zephyr/shell/shell.h>
-#include "desh_print.h"
-#include "nrf_modem_dect_phy.h"
+#include <nrf_modem_dect_phy.h>
 
+#include "desh_print.h"
 #include "dect_common.h"
 #include "dect_phy_common.h"
 #include "dect_common_utils.h"

--- a/samples/dect/dect_phy/dect_shell/src/dect/mac/dect_phy_mac_client.h
+++ b/samples/dect/dect_phy/dect_shell/src/dect/mac/dect_phy_mac_client.h
@@ -12,8 +12,11 @@
 
 /******************************************************************************/
 
-int dect_phy_mac_client_rach_tx(struct dect_phy_mac_nbr_info_list_item *target_nbr,
-				struct dect_phy_mac_rach_tx_params *params);
+int dect_phy_mac_client_rach_tx_start(
+	struct dect_phy_mac_nbr_info_list_item *target_nbr,
+	struct dect_phy_mac_rach_tx_params *params);
+
+void dect_mac_client_rach_tx_stop(void);
 
 int dect_phy_mac_client_associate(struct dect_phy_mac_nbr_info_list_item *target_nbr,
 				  struct dect_phy_mac_associate_params *params);

--- a/samples/dect/dect_phy/dect_shell/src/dect/mac/dect_phy_mac_common.h
+++ b/samples/dect/dect_phy/dect_shell/src/dect/mac/dect_phy_mac_common.h
@@ -31,8 +31,10 @@ struct dect_phy_mac_beacon_scan_params {
 
 struct dect_phy_mac_rach_tx_params {
 	uint32_t target_long_rd_id;
+	bool get_mdm_temp;
 	uint8_t mcs;
 	int8_t tx_power_dbm;
+	uint16_t interval_secs;
 
 	char tx_data_str[DECT_DATA_MAX_LEN]; /* Note: cannot be that much on payload */
 };

--- a/samples/dect/dect_phy/dect_shell/src/dect/mac/dect_phy_mac_ctrl.c
+++ b/samples/dect/dect_phy/dect_shell/src/dect/mac/dect_phy_mac_ctrl.c
@@ -282,7 +282,7 @@ int dect_phy_mac_ctrl_dissociate(struct dect_phy_mac_associate_params *params)
 
 /**************************************************************************************************/
 
-int dect_phy_mac_ctrl_rach_tx(struct dect_phy_mac_rach_tx_params *params)
+int dect_phy_mac_ctrl_rach_tx_start(struct dect_phy_mac_rach_tx_params *params)
 {
 	struct dect_phy_mac_nbr_info_list_item *scan_info =
 		dect_phy_mac_nbr_info_get_by_long_rd_id(params->target_long_rd_id);
@@ -299,12 +299,19 @@ int dect_phy_mac_ctrl_rach_tx(struct dect_phy_mac_rach_tx_params *params)
 		return ret;
 	}
 
-	ret = dect_phy_mac_client_rach_tx(scan_info, params);
+	ret = dect_phy_mac_client_rach_tx_start(scan_info, params);
 	if (ret) {
 		desh_error("Cannot start client_rach_tx: %d\n", ret);
 	}
 
 	return ret;
+}
+
+int dect_phy_mac_ctrl_rach_tx_stop(void)
+{
+	dect_mac_client_rach_tx_stop();
+	dect_phy_ctrl_ext_command_stop();
+	return 0;
 }
 
 /**************************************************************************************************/
@@ -325,7 +332,8 @@ void dect_phy_mac_ctrl_th_phy_api_mdm_op_complete_cb(
 							  tmp_str);
 		if (params->handle == DECT_PHY_MAC_BEACON_TX_HANDLE) {
 			desh_error("%s: cannot TX beacon: %s", __func__, tmp_str);
-		} else if (params->handle == DECT_PHY_MAC_CLIENT_RA_TX_HANDLE) {
+		} else if (params->handle == DECT_PHY_MAC_CLIENT_RA_TX_HANDLE ||
+			   params->handle == DECT_PHY_MAC_CLIENT_RA_TX_CONTINUOUS_HANDLE) {
 			if (params->status == NRF_MODEM_DECT_PHY_ERR_LBT_CHANNEL_BUSY) {
 				desh_warn("%s: cannot TX client data due to LBT, "
 					  "channel was busy",
@@ -338,7 +346,8 @@ void dect_phy_mac_ctrl_th_phy_api_mdm_op_complete_cb(
 				   params->handle, tmp_str);
 		}
 	} else {
-		if (params->handle == DECT_PHY_MAC_CLIENT_RA_TX_HANDLE) {
+		if (params->handle == DECT_PHY_MAC_CLIENT_RA_TX_HANDLE ||
+		    params->handle == DECT_PHY_MAC_CLIENT_RA_TX_CONTINUOUS_HANDLE) {
 			desh_print("Client data TX completed.");
 		} else if (params->handle == DECT_PHY_MAC_CLIENT_ASSOCIATION_TX_HANDLE) {
 			desh_print("TX for Association Request completed.");

--- a/samples/dect/dect_phy/dect_shell/src/dect/mac/dect_phy_mac_ctrl.h
+++ b/samples/dect/dect_phy/dect_shell/src/dect/mac/dect_phy_mac_ctrl.h
@@ -22,7 +22,8 @@ enum dect_phy_mac_ctrl_beacon_stop_cause {
 int dect_phy_mac_ctrl_cluster_beacon_start(struct dect_phy_mac_beacon_start_params *params);
 void dect_phy_mac_ctrl_cluster_beacon_stop(enum dect_phy_mac_ctrl_beacon_stop_cause cause);
 int dect_phy_mac_ctrl_beacon_scan_start(struct dect_phy_mac_beacon_scan_params *params);
-int dect_phy_mac_ctrl_rach_tx(struct dect_phy_mac_rach_tx_params *params);
+int dect_phy_mac_ctrl_rach_tx_start(struct dect_phy_mac_rach_tx_params *params);
+int dect_phy_mac_ctrl_rach_tx_stop(void);
 int dect_phy_mac_ctrl_associate(struct dect_phy_mac_associate_params *params);
 int dect_phy_mac_ctrl_dissociate(struct dect_phy_mac_associate_params *params);
 

--- a/samples/dect/dect_phy/dect_shell/src/dect/mac/dect_phy_mac_pdu.c
+++ b/samples/dect/dect_phy/dect_shell/src/dect/mac/dect_phy_mac_pdu.c
@@ -9,9 +9,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <zephyr/shell/shell.h>
-#include "desh_print.h"
-#include "nrf_modem_dect_phy.h"
 
+#include <nrf_modem_dect_phy.h>
+
+#include "desh_print.h"
 #include "dect_common.h"
 #include "dect_common_utils.h"
 #include "dect_common_pdu.h"

--- a/samples/dect/dect_phy/dect_shell/src/dect/perf/dect_phy_perf.c
+++ b/samples/dect/dect_phy/dect_shell/src/dect/perf/dect_phy_perf.c
@@ -14,9 +14,10 @@
 
 #include <dk_buttons_and_leds.h>
 
+#include <nrf_modem_dect_phy.h>
+
 #include "desh_defines.h"
 #include "desh_print.h"
-#include "nrf_modem_dect_phy.h"
 #include "dect_phy_common_rx.h"
 #include "dect_common_utils.h"
 #include "dect_phy_api_scheduler.h"

--- a/samples/dect/dect_phy/dect_shell/src/dect/perf/dect_phy_perf_pdu.c
+++ b/samples/dect/dect_phy/dect_shell/src/dect/perf/dect_phy_perf_pdu.c
@@ -9,9 +9,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <zephyr/shell/shell.h>
-#include "desh_print.h"
-#include "nrf_modem_dect_phy.h"
+#include <nrf_modem_dect_phy.h>
 
+#include "desh_print.h"
 #include "dect_common_utils.h"
 #include "dect_phy_perf_pdu.h"
 

--- a/samples/dect/dect_phy/dect_shell/src/dect/ping/dect_phy_ping.c
+++ b/samples/dect/dect_phy/dect_shell/src/dect/ping/dect_phy_ping.c
@@ -13,10 +13,10 @@
 #include <zephyr/sys/byteorder.h>
 
 #include <dk_buttons_and_leds.h>
+#include <nrf_modem_dect_phy.h>
 
 #include "desh_defines.h"
 #include "desh_print.h"
-#include "nrf_modem_dect_phy.h"
 
 #include "dect_phy_common_rx.h"
 #include "dect_common_settings.h"

--- a/samples/dect/dect_phy/dect_shell/src/dect/ping/dect_phy_ping_pdu.c
+++ b/samples/dect/dect_phy/dect_shell/src/dect/ping/dect_phy_ping_pdu.c
@@ -9,9 +9,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <zephyr/shell/shell.h>
-#include "desh_print.h"
-#include "nrf_modem_dect_phy.h"
+#include <nrf_modem_dect_phy.h>
 
+#include "desh_print.h"
 #include "dect_common_utils.h"
 #include "dect_common_pdu.h"
 #include "dect_phy_ping_pdu.h"

--- a/samples/dect/dect_phy/dect_shell/src/dect/rf_tool/dect_phy_rf_tool.c
+++ b/samples/dect/dect_phy/dect_shell/src/dect/rf_tool/dect_phy_rf_tool.c
@@ -13,10 +13,10 @@
 #include <zephyr/sys/byteorder.h>
 
 #include <dk_buttons_and_leds.h>
+#include <nrf_modem_dect_phy.h>
 
 #include "desh_defines.h"
 #include "desh_print.h"
-#include "nrf_modem_dect_phy.h"
 #include "dect_phy_common_rx.h"
 #include "dect_common_utils.h"
 #include "dect_phy_api_scheduler.h"


### PR DESCRIPTION
Added a an option to send data in intervals: --interval <secs>
Additionally, in addition to given data, to include also modem temperature to data in json format: --get_mdm_temp