### PR TITLE
nrf_security: cracen: add missing header

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/common.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/common.c
@@ -5,6 +5,7 @@
  */
 
 #include "common.h"
+#include "platform_keys/platform_keys.h"
 
 #include <cracen/lib_kmu.h>
 #include <cracen/mem_helpers.h>


### PR DESCRIPTION
Ref: NCSDK-NONE