### PR TITLE
applications: nrf_desktop: enable zms for nrf54h20 DK target

### DIFF
--- a/applications/nrf_desktop/doc/settings_loader.rst
+++ b/applications/nrf_desktop/doc/settings_loader.rst
@@ -33,7 +33,11 @@ For details on the default configuration alignment, see the following sections.
 Settings backend
 ================
 
-By default, nRF Desktop devices use non-volatile storage settings backend (:kconfig:option:`CONFIG_SETTINGS_NVS`).
+By default, the nRF Desktop application, depending on the non-volatile memory technology used by the device, uses one of the following settings backends:
+
+* :ref:`Zephyr Memory Storage (ZMS) <zephyr:zms_api>` - Used for the devices with non-volatile memory that do not require explicit erase (MRAM, RRAM).
+* :ref:`Non-Volatile Storage (NVS) <zephyr:nvs_api>` - Used for the devices with non-volatile memory that require explicit erase (FLASH).
+
 The storage partition is located in the internal non-volatile memory.
 
 Settings load in a separate thread

--- a/applications/nrf_desktop/src/modules/Kconfig.caf_settings_loader.default
+++ b/applications/nrf_desktop/src/modules/Kconfig.caf_settings_loader.default
@@ -10,8 +10,8 @@ config DESKTOP_SETTINGS_LOADER
 	bool "Settings loader module (CAF)"
 	select CAF_SETTINGS_LOADER
 	select SETTINGS
-	imply ZMS if SOC_FLASH_NRF_RRAM
-	imply NVS if !SOC_FLASH_NRF_RRAM
+	imply ZMS if (SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
+	imply NVS if !(SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
 	imply FLASH
 	imply FLASH_MAP
 	imply FLASH_PAGE_LAYOUT
@@ -23,8 +23,8 @@ config DESKTOP_SETTINGS_LOADER
 	  By default, nRF Desktop application, depending on the non-volatile
 	  memory technology used by the device, uses either the Zephyr Memory
 	  Storage (ZMS) or Non-Volatile Storage (NVS) settings backend.
-	  ZMS is used for the devices with the RRAM non-volatile memory that
-	  do not require explicit erase. Otherwise, the NVS is used.
+	  ZMS is used for the devices with the RRAM or MRAM non-volatile memory
+	  that do not require explicit erase. Otherwise, the NVS is used.
 
 if DESKTOP_SETTINGS_LOADER
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -203,7 +203,11 @@ nRF5340 Audio
 nRF Desktop
 -----------
 
-* Updated the :ref:`zephyr:nrf54h20dk_nrf54h20` release configuration to enable the :ref:`nrf_desktop_watchdog`.
+* Updated:
+
+  * The :ref:`nrf_desktop_settings_loader` to make the :ref:`Zephyr Memory Storage (ZMS) <zephyr:zms_api>` the default settings backend for all board targets that use the MRAM technology.
+    As a result, all :ref:`zephyr:nrf54h20dk_nrf54h20` configurations were migrated from the NVS settings backend to the ZMS settings backend.
+  * The :ref:`zephyr:nrf54h20dk_nrf54h20` release configuration to enable the :ref:`nrf_desktop_watchdog`.
 
 nRF Machine Learning (Edge Impulse)
 -----------------------------------


### PR DESCRIPTION
Enabled the ZMS file system for the nRF54H20 DK in the nRF Desktop application. All board targets with the MRAM technology now use ZMS by default.

Ref: NCSDK-30319