### PR TITLE
nrf54l: Removing hardcoded clock frequency

### DIFF
--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -237,6 +237,13 @@ if(CONFIG_NFCT_PINS_AS_GPIOS OR CONFIG_TFM_NFCT_PINS_AS_GPIOS)
   )
 endif()
 
+if(CONFIG_TFM_CPU_FREQ_MHZ)
+  set_property(TARGET zephyr_property_target
+    APPEND PROPERTY TFM_CMAKE_OPTIONS
+    -DTFM_CPU_FREQ_MHZ=${CONFIG_TFM_CPU_FREQ_MHZ}
+  )
+endif()
+
 if(CONFIG_NRF_TRACE_PORT)
   set_property(TARGET zephyr_property_target
     APPEND PROPERTY TFM_CMAKE_OPTIONS

--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -291,6 +291,17 @@ config TFM_PROFILE_TYPE_MINIMAL
 	  and reproduce the desired configuration through kconfig fragments.
 endchoice
 
+config TFM_CPU_FREQ_MHZ
+	int
+	default $(div, $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency), 1000000) \
+		if $(dt_node_has_prop,/cpus/cpu@0,clock-frequency)
+	default $(div, $(dt_node_int_prop_int,/cpus/cpu@1,clock-frequency), 1000000) \
+		if $(dt_node_has_prop,/cpus/cpu@1,clock-frequency)
+	default 128
+	help
+	  Gives access to the cpu-clock frequency from the device tree when
+	  building with TF-m.
+
 config TFM_NFCT_PINS_AS_GPIOS
 	bool
 	default y if !DT_HAS_NORDIC_NRF_NFCT_ENABLED

--- a/modules/trusted-firmware-m/tfm_boards/CMakeLists.txt
+++ b/modules/trusted-firmware-m/tfm_boards/CMakeLists.txt
@@ -146,6 +146,9 @@ if (CONFIG_NFCT_PINS_AS_GPIOS)
   target_compile_definitions(platform_s PUBLIC CONFIG_NFCT_PINS_AS_GPIOS)
 endif()
 
+if (TFM_CPU_FREQ_MHZ)
+  target_compile_definitions(platform_s PUBLIC NRF_CONFIG_CPU_FREQ_MHZ=${TFM_CPU_FREQ_MHZ})
+endif()
 
 if (CONFIG_NRF_TRACE_PORT)
   target_compile_definitions(platform_s PUBLIC ENABLE_TRACE)

--- a/modules/trusted-firmware-m/tfm_boards/nrf54l15_cpuapp/ns/cpuarch_ns.cmake
+++ b/modules/trusted-firmware-m/tfm_boards/nrf54l15_cpuapp/ns/cpuarch_ns.cmake
@@ -7,6 +7,4 @@
 set(PLATFORM_DIR  ${CMAKE_CURRENT_LIST_DIR})
 set(PLATFORM_PATH ${CMAKE_CURRENT_LIST_DIR})
 
-add_compile_definitions(NRF_CONFIG_CPU_FREQ_MHZ=128)
-
 include(${CMAKE_CURRENT_LIST_DIR}/common/nrf54l15/cpuarch.cmake)

--- a/modules/trusted-firmware-m/tfm_boards/ns/CMakeLists.txt
+++ b/modules/trusted-firmware-m/tfm_boards/ns/CMakeLists.txt
@@ -52,6 +52,7 @@ if(TFM_PARTITION_PLATFORM)
         PUBLIC
         FIRMWARE_INFO_MAGIC=${FIRMWARE_INFO_MAGIC}
         EXT_API_MAGIC=${EXT_API_MAGIC}
+        NRF_CONFIG_CPU_FREQ_MHZ=${NRF_CONFIG_CPU_FREQ_MHZ}
     )
 
     target_sources(platform_ns

--- a/tests/tfm/tfm_psa_test/CMakeLists.txt
+++ b/tests/tfm/tfm_psa_test/CMakeLists.txt
@@ -110,6 +110,7 @@ ExternalProject_Add(tfm_psa_arch_test_app
                 -DCMAKE_BUILD_TYPE=${tfm_ns_CMAKE_BUILD_TYPE}
                 -DTEST_PSA_API=${TEST_PSA_API}
                 -DZEPHYR_NRF_MODULE_DIR=${ZEPHYR_NRF_MODULE_DIR}
+                -DNRF_CONFIG_CPU_FREQ_MHZ=${CONFIG_TFM_CPU_FREQ_MHZ}
     BUILD_COMMAND ${CMAKE_COMMAND} --build .
     INSTALL_COMMAND ""
     BUILD_ALWAYS True

--- a/tests/tfm/tfm_regression_test/CMakeLists.txt
+++ b/tests/tfm/tfm_regression_test/CMakeLists.txt
@@ -68,6 +68,7 @@ ExternalProject_Add(tfm_regression_test_app
                 -DQCBOR_PATH${QCBOR_PATH_TYPE}=${CONFIG_TFM_QCBOR_PATH}
                 -DCMAKE_BUILD_TYPE=RelWithDebInfo
                 -DZEPHYR_NRF_MODULE_DIR=${ZEPHYR_NRF_MODULE_DIR}
+                -DNRF_CONFIG_CPU_FREQ_MHZ=${CONFIG_TFM_CPU_FREQ_MHZ}
     BUILD_COMMAND ${CMAKE_COMMAND} --build .
     INSTALL_COMMAND ""
     BUILD_ALWAYS True


### PR DESCRIPTION
Adding in config that takes clock-frequency from device tree and passes it to TF-m.
Removing hardcoded NRF_CONFIG_CPU_FREQ_MHZ