### PR TITLE
samples/nrf_compress/mcuboot_update: use nRF54l doc references

### DIFF
--- a/samples/nrf_compress/mcuboot_update/README.rst
+++ b/samples/nrf_compress/mcuboot_update/README.rst
@@ -62,7 +62,7 @@ For the testing scenario to work, make sure you meet the following requirements:
 * Your update image differs from the base image so that the update can be applied.
 * You changed the firmware version by setting :kconfig:option:`CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION` to ``"2.0.0"``.
 * You set the :kconfig:option:`CONFIG_OUTPUT_BOOT_MESSAGE` Kconfig option to ``y``.
-* You are familiar with the FOTA over Bluetooth LE method (see :ref:`the guide for the nRF52840 DK <ug_nrf52_developing_ble_fota_steps>` and :ref:`the guide for the nRF5340 DK <ug_nrf53_developing_ble_fota_steps>`).
+* You are familiar with the FOTA over Bluetooth LE method (see :ref:`the guide for the nRF52840 DK <ug_nrf52_developing_ble_fota_steps>`, :ref:`the guide for the nRF5340 DK <ug_nrf53_developing_ble_fota_steps>`, and :ref:`the guide for the nRF54L15 DK <ug_nrf54l_developing_ble_fota_steps>`).
 * You have the `nRF Connect Device Manager`_ mobile app installed on your smartphone to update your device with the new firmware over Bluetooth LE.
 
 Meeting these requirements requires rebuilding the sample.
@@ -77,7 +77,7 @@ Meeting these requirements requires rebuilding the sample.
 
    * :ref:`Testing steps for FOTA over Bluetooth LE with nRF52840 <ug_nrf52_developing_ble_fota_steps_testing>`
    * :ref:`Testing steps for FOTA over Bluetooth LE with nRF5340 <ug_nrf53_developing_ble_fota_steps_testing>`
-   * *Not yet available*: Testing steps for FOTA over Bluetooth LE with nRF54L15
+   * :ref:`Testing steps for FOTA over Bluetooth LE with nRF54L15 <ug_nrf54l_developing_ble_fota_steps_testing>`
 
 #. Once the firmware update has been loaded, check the UART output.
    See the following `Sample output`_ section.


### PR DESCRIPTION
fota_update documentation was added so it can be referenced in the sample documentation.