### PR TITLE
scripts: tools-versions-*.yml: update zephyr-sdk==0.17.0

### DIFF
--- a/scripts/tools-versions-darwin.yml
+++ b/scripts/tools-versions-darwin.yml
@@ -16,8 +16,8 @@ west:
 nanopb:
   version: 0.4.6
 zephyr-sdk:
-  version: 0.16.8
-  architectures: # https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.16.8
+  version: 0.17.0
+  architectures: # https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.17.0
     - arm-zephyr-eabi
     - riscv64-zephyr-elf
 doxygen:

--- a/scripts/tools-versions-linux.yml
+++ b/scripts/tools-versions-linux.yml
@@ -17,8 +17,8 @@ gn:
 nanopb:
   version: 0.4.6
 zephyr-sdk:
-  version: 0.16.8
-  architectures: # https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.16.8
+  version: 0.17.0
+  architectures: # https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.17.0
     - arm-zephyr-eabi
     - riscv64-zephyr-elf
 ccache:

--- a/scripts/tools-versions-win10.yml
+++ b/scripts/tools-versions-win10.yml
@@ -15,8 +15,8 @@ west:
 nanopb:
   version: 0.4.6
 zephyr-sdk:
-  version: 0.16.8
-  architectures: # https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.16.8
+  version: 0.17.0
+  architectures: # https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.17.0
     - arm-zephyr-eabi
     - riscv64-zephyr-elf
 doxygen:


### PR DESCRIPTION
https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.17.0
Release Highlights:
-   all: Require glibc 2.28
-   arm-zephyr-eabi: includes ARMv7-R multi-libs

Signed-off-by: Thomas Stilwell <thomas.stilwell@nordicsemi.no>
