### PR TITLE
nrf_security: cracen: ifdef for file inclusion

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/common.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/common.c
@@ -5,7 +5,7 @@
  */
 
 #include "common.h"
-#ifdef NRF54H_SERIES
+#ifdef CONFIG_PSA_NEED_CRACEN_PLATFORM_KEYS
 #include "platform_keys/platform_keys.h"
 #endif
 


### PR DESCRIPTION
Changed ifdef for conditional platform keys header file inclusion. Now it matches the ifdef around the function name that requires the header (cracen_platform_keys_get_size).

Ref: NCSDK-29561

Note: Previous value (NRF54H_SERIES) was causing build failures, even on nrf54h20.