### PR TITLE
applications: nrf_desktop: Add Kconfig guards

### DIFF
--- a/applications/nrf_desktop/src/modules/Kconfig.caf_ble_state.default
+++ b/applications/nrf_desktop/src/modules/Kconfig.caf_ble_state.default
@@ -8,6 +8,7 @@
 
 config DESKTOP_BLE_STATE
 	bool "Bluetooth LE state module (CAF)"
+	depends on BT
 	select CAF_BLE_STATE
 	help
 	  nRF Desktop uses Bluetooth LE state module from Common Application


### PR DESCRIPTION
Adds Kconfig guards to prevent configuration errors or build errors when Bluetooth has been de-selected

(Don't know if the click detector one will work with an empty array or not, have not tried it on a board. Changes are so that if someone configures this then changes options using menuconfig, it does not break the build)