### PR TITLE
samples: bluetooth: hids: clean up nRF54L15 PDK references

### DIFF
--- a/samples/bluetooth/central_hids/sample.yaml
+++ b/samples/bluetooth/central_hids/sample.yaml
@@ -8,7 +8,9 @@ tests:
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
     tags: bluetooth sysbuild
   sample.bluetooth.central_hids.build:
     sysbuild: true
@@ -19,9 +21,12 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
-      nrf5340dk/nrf5340/cpuapp/ns nrf54l15pdk/nrf54l15/cpuapp nrf54l15dk/nrf54l15/cpuapp
-      nrf54h20dk/nrf54h20/cpuapp
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
     tags: bluetooth ci_build sysbuild

--- a/samples/bluetooth/peripheral_hids_keyboard/sample.yaml
+++ b/samples/bluetooth/peripheral_hids_keyboard/sample.yaml
@@ -8,7 +8,9 @@ tests:
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
     tags: bluetooth sysbuild
   sample.bluetooth.peripheral_hids_keyboard.build:
     sysbuild: true
@@ -19,9 +21,12 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
-      nrf5340dk/nrf5340/cpuapp/ns nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15pdk/nrf54l15/cpuapp nrf54h20dk/nrf54h20/cpuapp
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
     tags: bluetooth ci_build sysbuild

--- a/samples/bluetooth/peripheral_hids_mouse/sample.yaml
+++ b/samples/bluetooth/peripheral_hids_mouse/sample.yaml
@@ -8,7 +8,9 @@ tests:
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
     tags: bluetooth sysbuild
   sample.bluetooth.peripheral_hids_mouse.build:
     sysbuild: true
@@ -19,11 +21,14 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
-      nrf5340dk/nrf5340/cpuapp/ns nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15pdk/nrf54l15/cpuapp nrf54h20dk/nrf54h20/cpuapp
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
     tags: bluetooth ci_build sysbuild
   sample.bluetooth.peripheral_hids_mouse.ble_rpc:
     sysbuild: true
@@ -34,7 +39,9 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf5340dk/nrf5340/cpuapp nrf54h20dk/nrf54h20/cpuapp
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
     tags: bluetooth ci_build sysbuild
   sample.bluetooth.peripheral_hids_mouse.no_sec:
     sysbuild: true
@@ -43,14 +50,18 @@ tests:
       - CONFIG_BT_HIDS_SECURITY_ENABLED=n
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
     tags: bluetooth ci_build sysbuild
   # Build integration regression protection.
   sample.nrf_security.bluetooth.integration:
     sysbuild: true
     build_only: true
     extra_args: CONFIG_NRF_SECURITY=y CONFIG_BOOTLOADER_MCUBOOT=y
-    platform_allow: nrf5340dk/nrf5340/cpuapp
     integration_platforms:
+      - nrf5340dk/nrf5340/cpuapp
+    platform_allow:
       - nrf5340dk/nrf5340/cpuapp
     tags: bluetooth sysbuild


### PR DESCRIPTION
Cleaned up references to the nRF54L15 PDK in Bluetooth HIDS samples.

Improved YAML test description of Bluetooth HIDS samples.

Ref: NCSDK-30332