### PR TITLE
samples: protocols_serialization: fix button removal

### DIFF
--- a/samples/nrf_rpc/protocols_serialization/client/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/nrf_rpc/protocols_serialization/client/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -9,12 +9,16 @@
 	};
 
 	/* delete all buttons except button0 to free GPIO pins assigned to uart21 below */
-	buttons {
-		/delete-node/ button1;
-		/delete-node/ button2;
-		/delete-node/ button3;
+	aliases {
+		/delete-property/ sw1;
+		/delete-property/ sw2;
+		/delete-property/ sw3;
 	};
 };
+
+/delete-node/ &button1;
+/delete-node/ &button2;
+/delete-node/ &button3;
 
 &pinctrl {
 	uart21_default: uart21_default {

--- a/samples/nrf_rpc/protocols_serialization/server/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/nrf_rpc/protocols_serialization/server/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -9,12 +9,16 @@
 	};
 
 	/* delete all buttons except button0 to free GPIO pins assigned to uart21 below */
-	buttons {
-		/delete-node/ button1;
-		/delete-node/ button2;
-		/delete-node/ button3;
+	aliases {
+		/delete-property/ sw1;
+		/delete-property/ sw2;
+		/delete-property/ sw3;
 	};
 };
+
+/delete-node/ &button1;
+/delete-node/ &button2;
+/delete-node/ &button3;
 
 &pinctrl {
 	uart21_default: uart21_default {

--- a/samples/nrf_rpc/protocols_serialization/server/src/fatal_error_trigger.c
+++ b/samples/nrf_rpc/protocols_serialization/server/src/fatal_error_trigger.c
@@ -14,9 +14,8 @@ LOG_MODULE_DECLARE(nrf_ps_server, CONFIG_NRF_PS_SERVER_LOG_LEVEL);
 
 static void button_handler(uint32_t button_state, uint32_t has_changed)
 {
-	LOG_ERR("Fatal error button pressed - triggering k_oops");
-
 	if (button_state & DK_BTN1_MSK) {
+		LOG_ERR("Fatal error button pressed - triggering k_oops");
 		k_oops();
 	}
 }


### PR DESCRIPTION
Remove buttons forbidden due to overlapping with UART correctly, including swX aliases.