### PR TITLE
applications: nrf_desktop: Update click detector def files

### DIFF
--- a/applications/nrf_desktop/configuration/nrf52810dmouse_nrf52810/click_detector_def.h
+++ b/applications/nrf_desktop/configuration/nrf52810dmouse_nrf52810/click_detector_def.h
@@ -16,8 +16,10 @@
 const struct {} click_detector_def_include_once;
 
 static const struct click_detector_config click_detector_config[] = {
+#if CONFIG_DESKTOP_BLE_PEER_CONTROL
 	{
 		.key_id = CONFIG_DESKTOP_BLE_PEER_CONTROL_BUTTON,
 		.consume_button_event = false,
 	},
+#endif /* CONFIG_DESKTOP_BLE_PEER_CONTROL */
 };

--- a/applications/nrf_desktop/configuration/nrf52820dongle_nrf52820/click_detector_def.h
+++ b/applications/nrf_desktop/configuration/nrf52820dongle_nrf52820/click_detector_def.h
@@ -16,8 +16,10 @@
 const struct {} click_detector_def_include_once;
 
 static const struct click_detector_config click_detector_config[] = {
+#if CONFIG_DESKTOP_BLE_PEER_CONTROL
 	{
 		.key_id = CONFIG_DESKTOP_BLE_PEER_CONTROL_BUTTON,
 		.consume_button_event = true,
 	},
+#endif /* CONFIG_DESKTOP_BLE_PEER_CONTROL */
 };

--- a/applications/nrf_desktop/configuration/nrf52833dk_nrf52820/click_detector_def.h
+++ b/applications/nrf_desktop/configuration/nrf52833dk_nrf52820/click_detector_def.h
@@ -16,8 +16,10 @@
 const struct {} click_detector_def_include_once;
 
 static const struct click_detector_config click_detector_config[] = {
+#if CONFIG_DESKTOP_BLE_PEER_CONTROL
 	{
 		.key_id = CONFIG_DESKTOP_BLE_PEER_CONTROL_BUTTON,
 		.consume_button_event = true,
 	},
+#endif /* CONFIG_DESKTOP_BLE_PEER_CONTROL */
 };

--- a/applications/nrf_desktop/configuration/nrf52833dk_nrf52833/click_detector_def.h
+++ b/applications/nrf_desktop/configuration/nrf52833dk_nrf52833/click_detector_def.h
@@ -16,8 +16,10 @@
 const struct {} click_detector_def_include_once;
 
 static const struct click_detector_config click_detector_config[] = {
+#if CONFIG_DESKTOP_BLE_PEER_CONTROL
 	{
 		.key_id = CONFIG_DESKTOP_BLE_PEER_CONTROL_BUTTON,
 		.consume_button_event = true,
 	},
+#endif /* CONFIG_DESKTOP_BLE_PEER_CONTROL */
 };

--- a/applications/nrf_desktop/configuration/nrf52833dongle_nrf52833/click_detector_def.h
+++ b/applications/nrf_desktop/configuration/nrf52833dongle_nrf52833/click_detector_def.h
@@ -16,8 +16,10 @@
 const struct {} click_detector_def_include_once;
 
 static const struct click_detector_config click_detector_config[] = {
+#if CONFIG_DESKTOP_BLE_PEER_CONTROL
 	{
 		.key_id = CONFIG_DESKTOP_BLE_PEER_CONTROL_BUTTON,
 		.consume_button_event = true,
 	},
+#endif /* CONFIG_DESKTOP_BLE_PEER_CONTROL */
 };

--- a/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/click_detector_def.h
+++ b/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/click_detector_def.h
@@ -16,8 +16,10 @@
 const struct {} click_detector_def_include_once;
 
 static const struct click_detector_config click_detector_config[] = {
+#if CONFIG_DESKTOP_BLE_PEER_CONTROL
 	{
 		.key_id = CONFIG_DESKTOP_BLE_PEER_CONTROL_BUTTON,
 		.consume_button_event = false,
 	},
+#endif /* CONFIG_DESKTOP_BLE_PEER_CONTROL */
 };

--- a/applications/nrf_desktop/configuration/nrf52840dongle_nrf52840/click_detector_def.h
+++ b/applications/nrf_desktop/configuration/nrf52840dongle_nrf52840/click_detector_def.h
@@ -16,8 +16,10 @@
 const struct {} click_detector_def_include_once;
 
 static const struct click_detector_config click_detector_config[] = {
+#if CONFIG_DESKTOP_BLE_PEER_CONTROL
 	{
 		.key_id = CONFIG_DESKTOP_BLE_PEER_CONTROL_BUTTON,
 		.consume_button_event = true,
 	},
+#endif /* CONFIG_DESKTOP_BLE_PEER_CONTROL */
 };

--- a/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/click_detector_def.h
+++ b/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/click_detector_def.h
@@ -16,8 +16,10 @@
 const struct {} click_detector_def_include_once;
 
 static const struct click_detector_config click_detector_config[] = {
+#if CONFIG_DESKTOP_BLE_PEER_CONTROL
 	{
 		.key_id = CONFIG_DESKTOP_BLE_PEER_CONTROL_BUTTON,
 		.consume_button_event = true,
 	},
+#endif /* CONFIG_DESKTOP_BLE_PEER_CONTROL */
 };

--- a/applications/nrf_desktop/configuration/nrf52dmouse_nrf52832/click_detector_def.h
+++ b/applications/nrf_desktop/configuration/nrf52dmouse_nrf52832/click_detector_def.h
@@ -16,8 +16,10 @@
 const struct {} click_detector_def_include_once;
 
 static const struct click_detector_config click_detector_config[] = {
+#if CONFIG_DESKTOP_BLE_PEER_CONTROL
 	{
 		.key_id = CONFIG_DESKTOP_BLE_PEER_CONTROL_BUTTON,
 		.consume_button_event = false,
 	},
+#endif /* CONFIG_DESKTOP_BLE_PEER_CONTROL */
 };

--- a/applications/nrf_desktop/configuration/nrf52kbd_nrf52832/click_detector_def.h
+++ b/applications/nrf_desktop/configuration/nrf52kbd_nrf52832/click_detector_def.h
@@ -16,8 +16,10 @@
 const struct {} click_detector_def_include_once;
 
 static const struct click_detector_config click_detector_config[] = {
+#if CONFIG_DESKTOP_BLE_PEER_CONTROL
 	{
 		.key_id = CONFIG_DESKTOP_BLE_PEER_CONTROL_BUTTON,
 		.consume_button_event = true,
 	},
+#endif /* CONFIG_DESKTOP_BLE_PEER_CONTROL */
 };

--- a/applications/nrf_desktop/configuration/nrf5340dk_nrf5340_cpuapp/click_detector_def.h
+++ b/applications/nrf_desktop/configuration/nrf5340dk_nrf5340_cpuapp/click_detector_def.h
@@ -16,8 +16,10 @@
 const struct {} click_detector_def_include_once;
 
 static const struct click_detector_config click_detector_config[] = {
+#if CONFIG_DESKTOP_BLE_PEER_CONTROL
 	{
 		.key_id = CONFIG_DESKTOP_BLE_PEER_CONTROL_BUTTON,
 		.consume_button_event = true,
 	},
+#endif /* CONFIG_DESKTOP_BLE_PEER_CONTROL */
 };

--- a/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/click_detector_def.h
+++ b/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/click_detector_def.h
@@ -16,8 +16,10 @@
 const struct {} click_detector_def_include_once;
 
 static const struct click_detector_config click_detector_config[] = {
+#if CONFIG_DESKTOP_BLE_PEER_CONTROL
 	{
 		.key_id = CONFIG_DESKTOP_BLE_PEER_CONTROL_BUTTON,
 		.consume_button_event = false,
 	},
+#endif /* CONFIG_DESKTOP_BLE_PEER_CONTROL */
 };

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l15_cpuapp/click_detector_def.h
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l15_cpuapp/click_detector_def.h
@@ -16,8 +16,10 @@
 const struct {} click_detector_def_include_once;
 
 static const struct click_detector_config click_detector_config[] = {
+#if CONFIG_DESKTOP_BLE_PEER_CONTROL
 	{
 		.key_id = CONFIG_DESKTOP_BLE_PEER_CONTROL_BUTTON,
 		.consume_button_event = false,
 	},
+#endif /* CONFIG_DESKTOP_BLE_PEER_CONTROL */
 };

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -208,6 +208,7 @@ nRF Desktop
   * The :ref:`nrf_desktop_settings_loader` to make the :ref:`Zephyr Memory Storage (ZMS) <zephyr:zms_api>` the default settings backend for all board targets that use the MRAM technology.
     As a result, all :ref:`zephyr:nrf54h20dk_nrf54h20` configurations were migrated from the NVS settings backend to the ZMS settings backend.
   * The :ref:`zephyr:nrf54h20dk_nrf54h20` release configuration to enable the :ref:`nrf_desktop_watchdog`.
+  * The configuration files of the :ref:`nrf_desktop_click_detector` (:file:`click_detector_def.h`) to allow using them also when Bluetooth LE peer control using a dedicated button (:ref:`CONFIG_DESKTOP_BLE_PEER_CONTROL <config_desktop_app_options>`) is disabled.
 
 nRF Machine Learning (Edge Impulse)
 -----------------------------------


### PR DESCRIPTION
Change updates click detector def files to allow using them also when Bluetooth LE peer control is disabled in the configuration. Without the change, files would need to be updated manually together with disabling Bluetooth LE peer control.

Jira: NCSDK-29721