### PR TITLE
samples: matter: Enable RAM power-down feature for Matter samples

### DIFF
--- a/doc/nrf/protocols/matter/getting_started/low_power_configuration.rst
+++ b/doc/nrf/protocols/matter/getting_started/low_power_configuration.rst
@@ -258,3 +258,12 @@ Configure radio transmitter power
    :end-before: radio_power_end
 
 See :ref:`ug_matter_gs_transmission_power` for more information.
+
+Disable unused RAM sections
+***************************
+
+The :ref:`lib_ram_pwrdn` library allows you to disable unused sections of RAM and save power in low-power applications.
+Unused sections of RAM depend on the SoC architecture and the total amount of used static RAM.
+In Matter, you can use this feature by setting the :kconfig:option:`CONFIG_RAM_POWER_DOWN_LIBRARY` Kconfig option to ``y``.
+
+Once the feature is enabled, the :c:func:`power_down_unused_ram` function is called automatically in the :file:`matter_init.cpp` file during the initialization process.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -318,6 +318,9 @@ Keys samples
 Matter samples
 --------------
 
+* Updated all Matter samples that support low-power mode to enable the :ref:`lib_ram_pwrdn` feature.
+  It is enabled by default for the release configuration of the :ref:`matter_lock_sample`, :ref:`matter_light_switch_sample`, :ref:`matter_smoke_co_alarm_sample`, and :ref:`matter_window_covering_sample` samples.
+
 * :ref:`matter_template_sample` sample:
 
   * Updated the internal configuration for the :ref:`zephyr:nrf54l15dk_nrf54l15` target to use the DFU image compression and provide more memory space for the application.

--- a/samples/matter/common/src/app/matter_init.cpp
+++ b/samples/matter/common/src/app/matter_init.cpp
@@ -42,6 +42,10 @@
 #include "test/test_shell.h"
 #endif
 
+#ifdef CONFIG_RAM_POWER_DOWN_LIBRARY
+#include <ram_pwrdn.h>
+#endif
+
 #include <app/InteractionModelEngine.h>
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/server/OnboardingCodesUtil.h>
@@ -228,6 +232,11 @@ void DoInitChipServer(intptr_t /* unused */)
 
 	/* Set External Flash into sleep mode */
 	ExternalFlashManager::GetInstance().DoAction(ExternalFlashManager::Action::SLEEP);
+
+	/* Disable unused RAM blocks to reduce power consumption */
+#ifdef CONFIG_RAM_POWER_DOWN_LIBRARY
+	power_down_unused_ram();
+#endif
 
 	/* Initialize CHIP server */
 #ifdef CONFIG_CHIP_FACTORY_DATA

--- a/samples/matter/light_switch/prj_release.conf
+++ b/samples/matter/light_switch/prj_release.conf
@@ -21,6 +21,9 @@ CONFIG_CHIP_BLE_ADVERTISING_DURATION=60
 # Add support for LEDs and buttons on Nordic development kits
 CONFIG_DK_LIBRARY=y
 
+# Try to disable unused RAM blocks to reduce power consumption
+CONFIG_RAM_POWER_DOWN_LIBRARY=y
+
 # Bluetooth Low Energy configuration
 CONFIG_BT_DEVICE_NAME="MatterSwitch"
 

--- a/samples/matter/lock/prj_release.conf
+++ b/samples/matter/lock/prj_release.conf
@@ -31,6 +31,9 @@ CONFIG_PM_DEVICE=y
 # Enable system reset on fatal error
 CONFIG_RESET_ON_FATAL_ERROR=y
 
+# Try to disable unused RAM blocks to reduce power consumption
+CONFIG_RAM_POWER_DOWN_LIBRARY=y
+
 # Disable all debug features
 CONFIG_USE_SEGGER_RTT=n
 CONFIG_SHELL=n

--- a/samples/matter/smoke_co_alarm/prj_release.conf
+++ b/samples/matter/smoke_co_alarm/prj_release.conf
@@ -23,6 +23,9 @@ CONFIG_CHIP_BLE_ADVERTISING_DURATION=60
 # Add support for LEDs and buttons on Nordic development kits
 CONFIG_DK_LIBRARY=y
 
+# Try to disable unused RAM blocks to reduce power consumption
+CONFIG_RAM_POWER_DOWN_LIBRARY=y
+
 # Bluetooth Low Energy configuration
 CONFIG_BT_DEVICE_NAME="MatterSmoke"
 

--- a/samples/matter/window_covering/prj_release.conf
+++ b/samples/matter/window_covering/prj_release.conf
@@ -25,6 +25,9 @@ CONFIG_CHIP_BLE_ADVERTISING_DURATION=60
 # Add support for LEDs and buttons on Nordic development kits
 CONFIG_DK_LIBRARY=y
 
+# Try to disable unused RAM blocks to reduce power consumption
+CONFIG_RAM_POWER_DOWN_LIBRARY=y
+
 # PWM support
 CONFIG_PWM=y
 


### PR DESCRIPTION
Enabled the RAM power-down feature to disable some RAM banks if possible. Thanks to that we can reduce power consumption.