### PR TITLE
samples: bluetooth: hids: enable zms for nRF54H20 target

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -241,6 +241,16 @@ Bluetooth samples
 
   * The :ref:`channel_sounding_ras_reflector` sample demonstrating how to implement a Channel Sounding Reflector that exposes the Ranging Responder GATT Service.
 
+* Updated:
+
+  * Configurations of the following Bluetooth samples to make the :ref:`Zephyr Memory Storage (ZMS) <zephyr:zms_api>` the default settings backend for all board targets that use the MRAM technology:
+
+      * :ref:`bluetooth_central_hids`
+      * :ref:`peripheral_hids_keyboard`
+      * :ref:`peripheral_hids_mouse`
+
+    As a result, all :ref:`zephyr:nrf54h20dk_nrf54h20` configurations of the affected samples were migrated from the NVS settings backend to the ZMS settings backend.
+
 Bluetooth Fast Pair samples
 ---------------------------
 

--- a/samples/bluetooth/central_hids/Kconfig
+++ b/samples/bluetooth/central_hids/Kconfig
@@ -10,7 +10,7 @@ config SETTINGS
 	default y
 
 config ZMS
-	default y if SOC_FLASH_NRF_RRAM
+	default y if (SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
 
 config NVS
-	default y if !SOC_FLASH_NRF_RRAM
+	default y if !(SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)

--- a/samples/bluetooth/peripheral_hids_keyboard/Kconfig
+++ b/samples/bluetooth/peripheral_hids_keyboard/Kconfig
@@ -22,9 +22,9 @@ config SETTINGS
 	default y
 
 config ZMS
-	default y if SOC_FLASH_NRF_RRAM
+	default y if (SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
 
 config NVS
-	default y if !SOC_FLASH_NRF_RRAM
+	default y if !(SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
 
 endmenu

--- a/samples/bluetooth/peripheral_hids_mouse/Kconfig
+++ b/samples/bluetooth/peripheral_hids_mouse/Kconfig
@@ -17,8 +17,8 @@ config BT_HIDS_SECURITY_ENABLED
 	select FLASH_PAGE_LAYOUT
 	select FLASH_MAP
 	select SETTINGS
-	imply ZMS if SOC_FLASH_NRF_RRAM
-	imply NVS if !SOC_FLASH_NRF_RRAM
+	imply ZMS if (SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
+	imply NVS if !(SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
 	help
 	  "Enable BLE security for the HIDS service"
 


### PR DESCRIPTION
Enabled the ZMS file system for the nRF54H20 DK in the Bluetooth HIDS samples. All board targets with the MRAM technology now use ZMS by default.

Ref: NCSDK-30318