### PR TITLE
samples: fast_pair: input_device: enable zms for nRF54H20 target

### DIFF
--- a/samples/bluetooth/fast_pair/input_device/Kconfig
+++ b/samples/bluetooth/fast_pair/input_device/Kconfig
@@ -10,7 +10,7 @@ config SETTINGS
 	default y
 
 config ZMS
-	default y if SOC_FLASH_NRF_RRAM
+	default y if (SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
 
 config NVS
-	default y if !SOC_FLASH_NRF_RRAM
+	default y if !(SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)


### PR DESCRIPTION
Enabled the ZMS file system for the nRF54H20 DK in the Fast Pair Input Device sample. All board targets with the MRAM technology now use ZMS by default in this sample.