### PR TITLE
nrf_rpc: detect reboot of the remote

### DIFF
--- a/samples/nrf_rpc/protocols_serialization/client/src/main.c
+++ b/samples/nrf_rpc/protocols_serialization/client/src/main.c
@@ -9,10 +9,40 @@
 #include <nrf_rpc.h>
 
 LOG_MODULE_REGISTER(nrf_ps_client, CONFIG_NRF_PS_CLIENT_LOG_LEVEL);
+NRF_RPC_GROUP_DECLARE(ot_group);
+NRF_RPC_GROUP_DECLARE(bt_rpc_grp);
 
 static void err_handler(const struct nrf_rpc_err_report *report)
 {
 	LOG_ERR("nRF RPC error %d ocurred. See nRF RPC logs for more details", report->code);
+}
+
+static void bound_handler(const struct nrf_rpc_group *group)
+{
+#ifdef CONFIG_OPENTHREAD_RPC_CLIENT
+	static bool ot_group_initialized;
+
+	if (group == &ot_group) {
+		if (ot_group_initialized) {
+			LOG_WRN("OT RPC peer reset detected");
+			/* The code to restore the state of OT on the server can be added here */
+		} else {
+			ot_group_initialized = true;
+		}
+	}
+#endif
+#ifdef CONFIG_BT_RPC_CLIENT
+	static bool bt_group_initialized;
+
+	if (group == &bt_rpc_grp) {
+		if (bt_group_initialized) {
+			LOG_WRN("BT RPC peer reset detected");
+			/* The code to restore the state of BT on the server can be added here */
+		} else {
+			bt_group_initialized = true;
+		}
+	}
+#endif
 }
 
 int main(void)
@@ -20,6 +50,8 @@ int main(void)
 	int ret;
 
 	LOG_INF("Initializing RPC client");
+
+	nrf_rpc_set_bound_handler(bound_handler);
 
 	ret = nrf_rpc_init(err_handler);
 

--- a/west.yml
+++ b/west.yml
@@ -146,7 +146,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: b3f964ad783cc0d32c27829faddc7836d6175993
+      revision: 7777351c2babe02f49c10868c1a39104e42553b3
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Pull new nRF RPC API that can be used to detect reboot of the remote. Use the API in protocols_serialization client.