### PR TITLE
Samples: nRF Auracaster: Increased term width

### DIFF
--- a/samples/bluetooth/nrf_auraconfig/prj.conf
+++ b/samples/bluetooth/nrf_auraconfig/prj.conf
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-
 # General
 CONFIG_REBOOT=y
 CONFIG_DEBUG=y
@@ -44,7 +43,6 @@ CONFIG_DATA_FIFO=y
 
 # Enable NRFX_CLOCK for ACLK control
 CONFIG_NRFX_CLOCK=y
-
 CONFIG_NEWLIB_LIBC=y
 
 # Audio codec LC3 related defines
@@ -70,7 +68,6 @@ CONFIG_FS_FATFS_LFN_MODE_STACK=y
 
 # exFAT enabled to support longer file names and higher transfer speed
 CONFIG_FS_FATFS_EXFAT=y
-# Set the maximum file name length to 255
 CONFIG_FS_FATFS_MAX_LFN=255
 
 # Enable SPI interface
@@ -78,10 +75,8 @@ CONFIG_SPI=y
 
 # Enable ADC for board version readback
 CONFIG_ADC=y
-
 CONFIG_WATCHDOG=y
 CONFIG_TASK_WDT=y
-
 
 # Use this for debugging thread usage
 #CONFIG_LOG_THREAD_ID_PREFIX=y
@@ -98,6 +93,8 @@ CONFIG_SHELL_VT100_COMMANDS=y
 CONFIG_SHELL_VT100_COLORS=y
 CONFIG_SHELL_STACK_SIZE=8096
 CONFIG_SHELL_CMD_BUFF_SIZE=128
+CONFIG_SHELL_DEFAULT_TERMINAL_WIDTH=120
+
 ## Reduce shell memory usage
 CONFIG_SHELL_WILDCARD=n
 CONFIG_SHELL_HELP_ON_WRONG_ARGUMENT_COUNT=n
@@ -152,5 +149,4 @@ CONFIG_NRF5340_AUDIO_SD_CARD_LC3_FILE=y
 CONFIG_NRF5340_AUDIO_SD_CARD_LC3_STREAMER=y
 
 CONFIG_SD_CARD_LC3_STREAMER_STACK_SIZE=8000
-
 CONFIG_MODULE_SD_CARD_LOG_LEVEL_WRN=y


### PR DESCRIPTION
- OCT-3218
- Increased terminal width to avoid https://github.com/zephyrproject-rtos/zephyr/pull/78130/