### PR TITLE
test-spec: add dep for CI-doc-internal

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -14,15 +14,19 @@
 
 "CI-tool-test-linux":
   - "scripts/requirements*.txt"
-  - "scripts/tools-versions-linux.txt"
+  - "scripts/tools-versions-linux.yml"
 
 "CI-tool-test-win":
   - "scripts/requirements*.txt"
-  - "scripts/tools-versions-win10.txt"
+  - "scripts/tools-versions-win10.yml"
 
 "CI-tool-test-darwin":
   - "scripts/requirements*.txt"
-  - "scripts/tools-versions-darwin.txt"
+  - "scripts/tools-versions-darwin.yml"
+
+"CI-doc-internal":
+  - "doc/requirements.txt"
+  - "scripts/tools-versions-linux.yml"
 
 "CI-iot-serial-lte-modem-test":
   - "applications/serial_lte_modem/**/*"


### PR DESCRIPTION
Dependency for tool's definition used for doc build. Fix dep for tools-versions: txt->yml.