### PR TITLE
suit: Remove the possibility to erase RAM regions

### DIFF
--- a/subsys/suit/stream/stream_sinks/src/suit_ram_sink.c
+++ b/subsys/suit/stream/stream_sinks/src/suit_ram_sink.c
@@ -16,7 +16,6 @@
 
 LOG_MODULE_REGISTER(suit_ram_sink, CONFIG_SUIT_LOG_LEVEL);
 
-static suit_plat_err_t erase(void *ctx);
 static suit_plat_err_t write(void *ctx, const uint8_t *buf, size_t size);
 static suit_plat_err_t seek(void *ctx, size_t offset);
 static suit_plat_err_t used_storage(void *ctx, size_t *size);
@@ -76,7 +75,7 @@ suit_plat_err_t suit_ram_sink_get(struct stream_sink *sink, uint8_t *dst, size_t
 			ctx->ptr = dst;
 			ctx->in_use = true;
 
-			sink->erase = erase;
+			sink->erase = NULL;
 			sink->write = write;
 			sink->seek = seek;
 			sink->flush = NULL;
@@ -93,25 +92,6 @@ suit_plat_err_t suit_ram_sink_get(struct stream_sink *sink, uint8_t *dst, size_t
 
 	LOG_ERR("Invalid arguments.");
 	return SUIT_PLAT_ERR_INVAL;
-}
-
-static suit_plat_err_t erase(void *ctx)
-{
-	if (ctx != NULL) {
-		struct ram_ctx *ram_ctx = (struct ram_ctx *)ctx;
-		size_t size = ram_ctx->offset_limit - (size_t)ram_ctx->ptr;
-
-		uint8_t *dst = (uint8_t *)suit_memory_global_address_to_ram_address(
-			(uintptr_t)ram_ctx->ptr);
-
-		if (dst == NULL) {
-			return SUIT_PLAT_ERR_INVAL;
-		}
-
-		memset(dst, 0, size);
-	}
-
-	return SUIT_PLAT_SUCCESS;
 }
 
 static suit_plat_err_t write(void *ctx, const uint8_t *buf, size_t size)

--- a/tests/subsys/suit/ram_sink/src/main.c
+++ b/tests/subsys/suit/ram_sink/src/main.c
@@ -226,21 +226,3 @@ ZTEST(ram_sink_tests, test_ram_sink_write_NOK)
 	err = ram_sink.release(ram_sink.ctx);
 	zassert_equal(err, SUIT_PLAT_SUCCESS, "ram_sink.release failed - error %i", err);
 }
-
-ZTEST(ram_sink_tests, test_ram_sink_erase_OK)
-{
-	struct stream_sink ram_sink;
-
-	int err = suit_ram_sink_get(&ram_sink, TEST_DST, sizeof(test_data));
-
-	zassert_equal(err, SUIT_PLAT_SUCCESS, "suit_ram_sink_get failed - error %i", err);
-
-	err = ram_sink.erase(ram_sink.ctx);
-	zassert_equal(err, SUIT_PLAT_SUCCESS, "ram_sink.erase failed - error %i", err);
-
-	err = ram_sink.erase(NULL);
-	zassert_equal(err, SUIT_PLAT_SUCCESS, "ram_sink.erase failed - error %i", err);
-
-	err = ram_sink.release(ram_sink.ctx);
-	zassert_equal(err, SUIT_PLAT_SUCCESS, "ram_sink.release failed - error %i", err);
-}


### PR DESCRIPTION
There is not point to do so and it negatively affects SUIT boot time (+2.8ms).

Ref: NCSDK-30155