### PR TITLE
doc: wifi: fix typo in nRF7002 EB guide

### DIFF
--- a/doc/nrf/app_dev/device_guides/nrf70/nrf7002eb_dev_guide.rst
+++ b/doc/nrf/app_dev/device_guides/nrf70/nrf7002eb_dev_guide.rst
@@ -117,11 +117,11 @@ Alternatively, add the shield in the project's :file:`CMakeLists.txt` file by us
    set(SHIELD nrf7002eb)
 
 To build for the nRF7002 EB with nRF54H20 DK, use the ``nrf54h20dk/nrf54h20/cpuapp`` board target with the CMake ``SHIELD`` variable set to ``nrf7002eb_interposer_p1 nrf7002eb``.
-To build for a custom target, set ``-DSHIELD=nrf7002eb_interposer_p1;nrf7002eb`` when you invoke ``west build`` or ``cmake`` in your |NCS| application.
+To build for a custom target, set ``-DSHIELD="nrf7002eb_interposer_p1;nrf7002eb"`` when you invoke ``west build`` or ``cmake`` in your |NCS| application.
 Alternatively, you can add the shield in the project's :file:`CMakeLists.txt` file by using the ``set(SHIELD nrf7002eb_interposer_p1 nrf7002eb)`` command.
 
 To build for the nRF7002 EB with the nRF54L15 DK, use the ``nrf54l15dk/nrf54l15/cpuapp`` board target with the CMake ``SHIELD`` variable set to ``nrf7002eb_interposer_p1 nrf7002eb``.
-To build for a custom target, set ``-DSHIELD=nrf7002eb_interposer_p1;nrf7002eb`` when you invoke ``west build`` or ``cmake`` in your |NCS| application.
+To build for a custom target, set ``-DSHIELD="nrf7002eb_interposer_p1;nrf7002eb"`` when you invoke ``west build`` or ``cmake`` in your |NCS| application.
 Alternatively, you can add the shield in the project's :file:`CMakeLists.txt` file by using the ``set(SHIELD nrf7002eb_interposer_p1 nrf7002eb)`` command.
 
 Limitations when building with nRF54H20 DK and nRF54L15 DK


### PR DESCRIPTION
Add missing quotation marks around the shield target in Developing with nRF7002 EB guide.

NCSDK-30477