### PR TITLE
doc: nrf: drivers: Add TX power calculation

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -99,7 +99,7 @@
 /doc/nrf/drivers/sensor_sim.rst           @nrfconnect/ncs-si-muffin-doc
 /doc/nrf/drivers/sensor_stub.rst          @nrfconnect/ncs-si-muffin-doc
 /doc/nrf/drivers/uart_ipc.rst             @nrfconnect/ncs-doc-leads
-/doc/nrf/drivers/wifi/                    @sachinthegreen @krish2718
+/doc/nrf/drivers/wifi/*.rst               @nrfconnect/ncs-wifi-doc
 /doc/nrf/drivers/wifi.rst                 @nrfconnect/ncs-wifi-doc
 /doc/nrf/drivers/uart_nrf_sw_lpuart.rst   @nrfconnect/ncs-doc-leads
 /doc/nrf/external_comp/avsystem.rst       @nrfconnect/ncs-iot-oulu-tampere-doc

--- a/doc/nrf/drivers/wifi/nrf70_native.rst
+++ b/doc/nrf/drivers/wifi/nrf70_native.rst
@@ -118,3 +118,31 @@ To configure 15 dBm, use the value ``15``.
    };
 
 See the DTS binding documentation for more information.
+
+.. _nrf70_wifi_tx_power_calculation:
+
+TX power calculation
+********************
+
+This section describes how to determine the accurate transmit (TX) power on the nRF70 Series development platforms.
+The driver will always attempt to set the TX power to the maximum supported level, while ensuring the following constraints are met:
+
+* EVM and Spectral Emission Mask (SEM) for the modulation type or data rate (IEEE 802.11 requirement).
+* In-band regulatory power limits (FCC and CE certification requirements).
+* Out-of-band regulatory power limits (FCC and CE certification requirements).
+
+You can calculate the TX power by using the following formula:
+
+.. math::
+   \begin{aligned}
+   \text{TX power} = \min \left( (P_{\text{reg}} - \text{AntGain}), P_{\text{max}} \right) - \text{EdgeBackoff}
+   \end{aligned}
+
+where the following parameters are used:
+
+* :math:`P_\text{reg}` is the applicable regulatory power limit, as described in :ref:`ug_nrf70_developing_regulatory_support`.
+* ``AntGain`` is the compensation for the antenna gain in the TX direction, as described in `Antenna gain compensation`_.
+* ``EdgeBackoff`` is the backoff applied to band edge channels, as described in `Band edge compensation`_.
+* :math:`P_\text{max} = min (P_\text{ps} , P_\text{max-tx-pwr})`
+* :math:`P_\text{ps}`  is the maximum power level for the package type, modulation, and band as described in `Electrical specification for nRF7002`_.
+* :math:`P_\text{max-tx-pwr}` is the sub-band power limit, dependent on the PCB design.

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -770,6 +770,8 @@
 .. _`nRF7002 EB castellated edge holes`: https://docs.nordicsemi.com/bundle/ug_nrf7002_eb/page/UG/nrf7002_EB/castellated_mounting_holes.html
 .. _`nRF7002 EK`: https://docs.nordicsemi.com/bundle/ug_nrf7002_ek/page/UG/nrf7002_EK/intro.html
 .. _`nRF7002 companion IC`: https://docs.nordicsemi.com/bundle/ug_nrf7002_ek/page/UG/nrf7002_EK/hw_wifi_companion_ic.html
+.. _`Antenna gain compensation`: https://docs.nordicsemi.com/bundle/nan_046/page/APP/nan_046/antenna_compensation.html
+.. _`Band edge compensation`: https://docs.nordicsemi.com/bundle/nan_046/page/APP/nan_046/band_compensation.html
 
 .. _`Programming SoCs with nrfjprog`: https://docs.nordicsemi.com/bundle/ug_nrf_cltools/page/UG/cltools/nrf_nrfjprogexe.html
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -487,7 +487,7 @@ This section provides detailed lists of changes by :ref:`driver <drivers>`.
 Wi-Fi drivers
 -------------
 
-|no_changes_yet_note|
+* Added the :ref:`nrf70_wifi_tx_power_calculation` section to the :ref:`nrf70_wifi` page.
 
 Libraries
 =========


### PR DESCRIPTION
[SHEL-3276] Add TX power calculation in nrf70 driver documentation.

[SHEL-3276]: https://nordicsemi.atlassian.net/browse/SHEL-3276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ