### PR TITLE
samples: matter: Replace `z_arch_esf_t` with `struct arch_esf`

### DIFF
--- a/samples/matter/common/src/diagnostic/diagnostic_logs_crash.h
+++ b/samples/matter/common/src/diagnostic/diagnostic_logs_crash.h
@@ -19,7 +19,7 @@ using namespace chip;
 namespace Nrf
 {
 struct CrashDescription {
-	z_arch_esf_t Esf = {};
+	struct arch_esf Esf = {};
 	unsigned int Reason = 0;
 	const char *ThreadName = nullptr;
 	uint32_t *ThreadInt = 0;


### PR DESCRIPTION
Fix deprecation warning by replacing `z_arch_esf_t` with `struct arch_esf`.