### PR TITLE
scripts: ci: Update twister tags for SoftDevice Controller and MPSL

### DIFF
--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -63,6 +63,7 @@ bluetooth:
     - nrf/tests/bluetooth/
     - nrf/tests/subsys/bluetooth/
     - nrfxlib/crypto/
+    - nrfxlib/mpsl/fem/include
     - nrfxlib/mpsl/include/
     - nrfxlib/softdevice_controller/include/
     - zephyr/cmake/

--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -64,7 +64,6 @@ bluetooth:
     - nrf/tests/subsys/bluetooth/
     - nrfxlib/crypto/
     - nrfxlib/mpsl/include/
-    - nrfxlib/mpsl/lib/
     - nrfxlib/softdevice_controller/include/
     - zephyr/cmake/
     - zephyr/drivers/bluetooth/

--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -66,7 +66,6 @@ bluetooth:
     - nrfxlib/mpsl/include/
     - nrfxlib/mpsl/lib/
     - nrfxlib/softdevice_controller/include/
-    - nrfxlib/softdevice_controller/lib/
     - zephyr/cmake/
     - zephyr/drivers/bluetooth/
     - zephyr/include/zephyr/bluetooth/


### PR DESCRIPTION
The intention is to speedup the CI plans running when updating the SoftDevice Controller and MPSL library revision. This is currently increasing the CI execution time by around 50 - 60 minutes.
    
Building samples and tests is unlikely to fail when the API is unchanged.
What can fail:
* Linking (undefined functions). This will likely have been caught before pushing a library update or when running tests.
* RAM/FLASH overflow because of increased static ram or flash usage. Out of experience this is unlikely to happen

Also added a missing entry for the MPSL FEM API.