### PR TITLE
suit: Remove unused memory ranges

### DIFF
--- a/samples/suit/smp_transfer/sysbuild/nrf54h20dk_nrf54h20_memory_map.dtsi
+++ b/samples/suit/smp_transfer/sysbuild/nrf54h20dk_nrf54h20_memory_map.dtsi
@@ -13,7 +13,20 @@
 	cpuapp_recovery_partition: partition@e5000 {
 		reg = <0xe5000 DT_SIZE_K(72)>;
 	};
+
+	/* Delete PPR code partition */
+	/delete-node/ partition@e4000;
+	cpuppr_code_partition: partition@a5010 {
+		reg = < 0xa5010 0x10 >;
+	};
+
+	/* Delete FLPR code partition */
+	/delete-node/ partition@f4000;
+	cpuflpr_code_partition: partition@a5020 {
+		reg = < 0xa5020 0x10 >;
+	};
 };
+
 &cpurad_rx_partitions {
 	compatible = "nordic,owned-partitions", "fixed-partitions";
 	nordic,access = <NRF_OWNER_ID_RADIOCORE NRF_PERM_RXS>;


### PR DESCRIPTION
FLPR and PPR code partiotions ar not used in SUIT smp_transfer sample, so their partitions should not be included inside UICRs. Such partitions may open doors for potential vulnerabilities.

Ref: NCSDK-30017