### PR TITLE
doc: Matter: Add shared configurations page

### DIFF
--- a/applications/matter_bridge/doc/matter_bridge_description.rst
+++ b/applications/matter_bridge/doc/matter_bridge_description.rst
@@ -388,70 +388,78 @@ Check and configure the following configuration options:
 .. _CONFIG_BRIDGED_DEVICE_IMPLEMENTATION:
 
 CONFIG_BRIDGED_DEVICE_IMPLEMENTATION
-   Select bridged device implementation.
+   ``bool`` - Select bridged device implementation.
    See the :ref:`matter_bridge_app_bridged_support_configs` section for more information.
    Accepts the following values:
 
    .. _CONFIG_BRIDGED_DEVICE_SIMULATED:
 
    CONFIG_BRIDGED_DEVICE_SIMULATED
-      Implement a simulated bridged device.
+      ``bool`` - Implement a simulated bridged device.
       You must also configure :ref:`CONFIG_BRIDGED_DEVICE_SIMULATED_ONOFF_IMPLEMENTATION <CONFIG_BRIDGED_DEVICE_SIMULATED_ONOFF_IMPLEMENTATION>`
 
    .. _CONFIG_BRIDGED_DEVICE_BT:
 
    CONFIG_BRIDGED_DEVICE_BT
-      Implement a Bluetooth LE bridged device.
+      ``bool`` - Implement a Bluetooth LE bridged device.
 
 .. _CONFIG_BRIDGE_HUMIDITY_SENSOR_BRIDGED_DEVICE:
 
 CONFIG_BRIDGE_HUMIDITY_SENSOR_BRIDGED_DEVICE
-   Enable support for Humidity Sensor bridged device.
+   ``bool`` - Enable support for Humidity Sensor bridged device.
 
 .. _CONFIG_BRIDGE_ONOFF_LIGHT_BRIDGED_DEVICE:
 
 CONFIG_BRIDGE_ONOFF_LIGHT_BRIDGED_DEVICE
-   Enable support for OnOff Light bridged device.
+   ``bool`` - Enable support for OnOff Light bridged device.
 
 .. _CONFIG_BRIDGE_SWITCH_BRIDGED_DEVICE:
 
 CONFIG_BRIDGE_SWITCH_BRIDGED_DEVICE
-   Enable support for a switch bridged device.
+   ``bool`` - Enable support for a switch bridged device.
    Accepts the following values:
 
    .. _CONFIG_BRIDGE_GENERIC_SWITCH_BRIDGED_DEVICE:
 
    CONFIG_BRIDGE_GENERIC_SWITCH_BRIDGED_DEVICE
-      Enable support for Generic Switch bridged device.
+      ``bool`` - Enable support for Generic Switch bridged device.
 
    .. _CONFIG_BRIDGE_ONOFF_LIGHT_SWITCH_BRIDGED_DEVICE:
 
    CONFIG_BRIDGE_ONOFF_LIGHT_SWITCH_BRIDGED_DEVICE
-      Enable support for OnOff Light Switch bridged device.
+      ``bool`` - Enable support for OnOff Light Switch bridged device.
 
 .. _CONFIG_BRIDGE_TEMPERATURE_SENSOR_BRIDGED_DEVICE:
 
 CONFIG_BRIDGE_TEMPERATURE_SENSOR_BRIDGED_DEVICE
-   Enable support for Temperature Sensor bridged device.
+   ``bool`` - Enable support for Temperature Sensor bridged device.
 
-If you selected the simulated device implementation using the :ref:`CONFIG_BRIDGED_DEVICE_SIMULATED <CONFIG_BRIDGED_DEVICE_SIMULATED>` Kconfig option, also check and configure the following option:
+.. _CONFIG_BRIDGE_MIGRATE_PRE_2_7_0:
+
+CONFIG_BRIDGE_MIGRATE_PRE_2_7_0
+``bool`` - Enable migration of bridged device data stored in old scheme from pre nRF SDK 2.7.0 releases.
+
+.. _CONFIG_BRIDGE_MIGRATE_VERSION_1:
+
+CONFIG_BRIDGE_MIGRATE_VERSION_1
+``bool`` - Enable migration of bridged device data stored in version 1 of new scheme.If you selected the simulated device implementation using the :ref:`CONFIG_BRIDGED_DEVICE_SIMULATED <CONFIG_BRIDGED_DEVICE_SIMULATED>` Kconfig option, also check and configure the following option:
 
 .. _CONFIG_BRIDGED_DEVICE_SIMULATED_ONOFF_IMPLEMENTATION:
 
 CONFIG_BRIDGED_DEVICE_SIMULATED_ONOFF_IMPLEMENTATION
-   Select the simulated OnOff device implementation.
+   ``bool`` - Select the simulated OnOff device implementation.
    Accepts the following values:
 
    .. _CONFIG_BRIDGED_DEVICE_SIMULATED_ONOFF_AUTOMATIC:
 
    CONFIG_BRIDGED_DEVICE_SIMULATED_ONOFF_AUTOMATIC
-      Automatically simulated OnOff device.
+      ``bool`` - Automatically simulated OnOff device.
       The simulated device automatically changes its state periodically.
 
    .. _CONFIG_BRIDGED_DEVICE_SIMULATED_ONOFF_SHELL:
 
    CONFIG_BRIDGED_DEVICE_SIMULATED_ONOFF_SHELL
-      Shell-controlled simulated OnOff device.
+      ``bool`` - Shell-controlled simulated OnOff device.
       The state of the simulated device is changed using shell commands.
 
 If you selected the Bluetooth LE device implementation using the :ref:`CONFIG_BRIDGED_DEVICE_BT <CONFIG_BRIDGED_DEVICE_BT>` Kconfig option, also check and configure the following options:
@@ -459,29 +467,29 @@ If you selected the Bluetooth LE device implementation using the :ref:`CONFIG_BR
 .. _CONFIG_BRIDGE_BT_MAX_SCANNED_DEVICES:
 
 CONFIG_BRIDGE_BT_MAX_SCANNED_DEVICES
-   Set the maximum number of scanned devices.
+   ``int`` - Set the maximum number of scanned devices.
 
 .. _CONFIG_BRIDGE_BT_MINIMUM_SECURITY_LEVEL:
 
 CONFIG_BRIDGE_BT_MINIMUM_SECURITY_LEVEL
-   Set the minimum Bluetooth security level of bridged devices that the bridge device will accept.
+   ``int`` - Set the minimum Bluetooth security level of bridged devices that the bridge device will accept.
    Bridged devices using this or a higher level will be allowed to connect to the bridge.
    See the :ref:`matter_bridge_app_bt_security` section for more information.
 
 .. _CONFIG_BRIDGE_BT_RECOVERY_MAX_INTERVAL:
 
 CONFIG_BRIDGE_BT_RECOVERY_MAX_INTERVAL
-   Set the maximum time (in seconds) between recovery attempts when the Bluetooth LE connection to the bridged device is lost.
+   ``int`` - Set the maximum time (in seconds) between recovery attempts when the Bluetooth LE connection to the bridged device is lost.
 
 .. _CONFIG_BRIDGE_BT_RECOVERY_SCAN_TIMEOUT_MS:
 
 CONFIG_BRIDGE_BT_RECOVERY_SCAN_TIMEOUT_MS
-   Set the time (in milliseconds) within which the Bridge will try to re-establish a connection to the lost Bluetooth LE device.
+   ``int`` - Set the time (in milliseconds) within which the Bridge will try to re-establish a connection to the lost Bluetooth LE device.
 
 .. _CONFIG_BRIDGE_BT_SCAN_TIMEOUT_MS:
 
 CONFIG_BRIDGE_BT_SCAN_TIMEOUT_MS
-   Set the Bluetooth LE scan timeout in milliseconds.
+   ``int`` - Set the Bluetooth LE scan timeout in milliseconds.
 
 The following options affect how many bridged devices the application supports.
 See the :ref:`matter_bridge_app_bridged_support_configs` section for more information.
@@ -489,22 +497,12 @@ See the :ref:`matter_bridge_app_bridged_support_configs` section for more inform
 .. _CONFIG_BRIDGE_MAX_BRIDGED_DEVICES_NUMBER:
 
 CONFIG_BRIDGE_MAX_BRIDGED_DEVICES_NUMBER
-   Set the maximum number of physical non-Matter devices supported by the Bridge.
+   ``int`` - Set the maximum number of physical non-Matter devices supported by the Bridge.
 
 .. _CONFIG_BRIDGE_MAX_DYNAMIC_ENDPOINTS_NUMBER:
 
 CONFIG_BRIDGE_MAX_DYNAMIC_ENDPOINTS_NUMBER
-   Set the maximum number of dynamic endpoints supported by the Bridge.
-
-.. _CONFIG_BRIDGE_MIGRATE_PRE_2_7_0:
-
-CONFIG_BRIDGE_MIGRATE_PRE_2_7_0
-   Enable migration of bridged device data stored in old scheme from pre nRF SDK 2.7.0 releases.
-
-.. _CONFIG_BRIDGE_MIGRATE_VERSION_1:
-
-CONFIG_BRIDGE_MIGRATE_VERSION_1
-   Enable migration of bridged device data stored in version 1 of new scheme.
+   ``int`` - Set the maximum number of dynamic endpoints supported by the Bridge.
 
 .. _matter_bridge_app_bridged_support_configs:
 

--- a/doc/nrf/protocols/matter/end_product/test_event_triggers.rst
+++ b/doc/nrf/protocols/matter/end_product/test_event_triggers.rst
@@ -37,7 +37,7 @@ Default test event triggers
 ***************************
 
 You can use the pre-defined common test event triggers in your application.
-To disable them, set the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_TEST_EVENT_TRIGGERS_REGISTER_DEFAULTS` Kconfig option to ``n``.
+To disable them, set the :ref:`CONFIG_NCS_SAMPLE_MATTER_TEST_EVENT_TRIGGERS_REGISTER_DEFAULTS<CONFIG_NCS_SAMPLE_MATTER_TEST_EVENT_TRIGGERS_REGISTER_DEFAULTS>` Kconfig option to ``n``.
 
 The following table lists the available triggers and their activation codes:
 
@@ -65,7 +65,7 @@ The following table lists the available triggers and their activation codes:
       The maximum time delay is UINT16_MAX ms.
       The value is provided in HEX format.
   * - Block the Matter thread
-    - :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_WATCHDOG` = ``y``, and :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_DEFAULT` = ``y``
+    - :ref:`CONFIG_NCS_SAMPLE_MATTER_WATCHDOG<CONFIG_NCS_SAMPLE_MATTER_WATCHDOG>` = ``y``, and :ref:`CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_DEFAULT<CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_DEFAULT>` = ``y``
     - Block the Matter thread for specific amount of time.
       You can use this event trigger to check the :ref:`Matter Watchdog <ug_matter_device_watchdog>` functionality.
     - ``0xFFFFFFFF20000000`` - ``0xFFFFFFFF2000FFFF``
@@ -73,7 +73,7 @@ The following table lists the available triggers and their activation codes:
       The maximum time is UINT16_MAX s.
       The value is provided in HEX format.
   * - Block the Main thread
-    - :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_WATCHDOG` = ``y``, and :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_DEFAULT` = ``y``
+    - :ref:`CONFIG_NCS_SAMPLE_MATTER_WATCHDOG<CONFIG_NCS_SAMPLE_MATTER_WATCHDOG>` = ``y``, and :ref:`CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_DEFAULT<CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_DEFAULT>` = ``y``
     - Block the Main thread for specific amount of time.
       You can use this event trigger to check the :ref:`Matter Watchdog <ug_matter_device_watchdog>` functionality.
     - ``0xFFFFFFFF30000000`` - ``0xFFFFFFFF3000FFFF``
@@ -81,21 +81,21 @@ The following table lists the available triggers and their activation codes:
       The maximum time is UINT16_MAX s.
       The value is provided in HEX format.
   * - Diagnostic Logs User Data
-    - Enabled ``Diagnostic Logs`` cluster, and either the snippet `diagnostic-logs` attached (``-D<application_name>_SNIPPET=diagnostic-logs``) or both :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS` = ``y`` and :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_END_USER_LOGS` = ``y``.
+    - Enabled ``Diagnostic Logs`` cluster, and either the snippet ``matter-diagnostic-logs`` attached (``-D<application_name>_SNIPPET=matter-diagnostic-logs``) or both :ref:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS<CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS>` = ``y`` and :ref:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_END_USER_LOGS<CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_END_USER_LOGS>` = ``y``.
     - Trigger writing a specific number of ``u`` characters to the user diagnostics logs.
       The number of characters is determined by the value at the end of the event trigger value.
       The current supported maximum is 1023 bytes for single trigger call, and 4096 bytes of total data written.
     - ``0xFFFFFFFF40000000`` - ``0xFFFFFFFF40000400``
     - The range of ``0x0000`` - ``0x0400`` (from 1 Bytes to 1024 Bytes), ``0x0000`` to clear logs.
   * - Diagnostic Logs Network Data
-    - Enabled ``Diagnostic Logs`` cluster, and either the snippet `diagnostic-logs` attached (``-D<application_name>_SNIPPET=diagnostic-logs``) or both :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS` = ``y`` and :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_NETWORK_LOGS` = ``y``.
+    - Enabled ``Diagnostic Logs`` cluster, and either the snippet ``matter-diagnostic-logs`` attached (``-D<application_name>_SNIPPET=matter-diagnostic-logs``) or both :ref:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS<CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS>` = ``y`` and :ref:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_NETWORK_LOGS<CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_NETWORK_LOGS>` = ``y``.
     - Trigger writing a specific number of ``n`` characters to the network diagnostics logs.
       The number of characters is determined by the value at the end of the event trigger value.
       The current supported maximum is 1023 bytes for single trigger call, and 4096 bytes of total data written.
     - ``0xFFFFFFFF50000000`` - ``0xFFFFFFFF50000400``
     - The range of ``0x0000`` - ``0x0400`` (from 1 Bytes to 1024 Bytes), ``0x0000`` to clear logs.
   * - Diagnostic Crash Logs
-    - Either the snippet `diagnostic-logs` attached (``-D<application_name>_SNIPPET=diagnostic-logs``) or both :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS` = ``y`` and :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_CRASH_LOGS` = ``y``, and enabled ``Diagnostic Logs`` cluster.
+    - Either the snippet ``matter-diagnostic-logs`` attached (``-D<application_name>_SNIPPET=matter-diagnostic-logs``) or both :ref:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS<CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS>` = ``y`` and :ref:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_CRASH_LOGS<CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_CRASH_LOGS>` = ``y``, and enabled ``Diagnostic Logs`` cluster.
     - Trigger a simple crash that relies on execution of the undefined instruction attempt.
     - ``0xFFFFFFFF60000000``
     - No additional value supported.
@@ -273,7 +273,7 @@ A new event trigger consists of two fields: ``Mask``, and ``Callback``.
 * The ``Callback`` field is a callback function that will be invoked when the device receives a corresponding activation code.
 
 The maximum number of event triggers that can be registered is configurable.
-To adjust this limit, set the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_TEST_EVENT_TRIGGERS_MAX` Kconfig option to the desired value.
+To adjust this limit, set the :ref:`CONFIG_NCS_SAMPLE_MATTER_TEST_EVENT_TRIGGERS_MAX<CONFIG_NCS_SAMPLE_MATTER_TEST_EVENT_TRIGGERS_MAX>` Kconfig option to the desired value.
 
 To register a new test event trigger, follow these steps:
 
@@ -353,7 +353,7 @@ Use the following example as a guide to register an existing event trigger handl
 
   /* Remember to check the CHIP_ERROR return code */
 
-If the returning ``CHIP_ERROR`` code is equal to ``CHIP_ERROR_NO_MEMORY``, you need to increase the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_TEST_EVENT_TRIGGERS_MAX_TRIGGERS_DELEGATES` Kconfig option to the higher value.
+If the returning ``CHIP_ERROR`` code is equal to ``CHIP_ERROR_NO_MEMORY``, you need to increase the :ref:`CONFIG_NCS_SAMPLE_MATTER_TEST_EVENT_TRIGGERS_MAX_TRIGGERS_DELEGATES<CONFIG_NCS_SAMPLE_MATTER_TEST_EVENT_TRIGGERS_MAX_TRIGGERS_DELEGATES>` Kconfig option to the higher value.
 
 For example, you can register and use the ``OTATestEventTriggerHandler`` handler and trigger pre-defined Matter OTA DFU behaviors using the following code:
 
@@ -367,7 +367,7 @@ Usage
 *****
 
 The Matter test event triggers feature is enabled by default for all Matter samples.
-To disable it, set the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_TEST_EVENT_TRIGGERS` Kconfig option to ``n``.
+To disable it, set the :ref:`CONFIG_NCS_SAMPLE_MATTER_TEST_EVENT_TRIGGERS<CONFIG_NCS_SAMPLE_MATTER_TEST_EVENT_TRIGGERS>` Kconfig option to ``n``.
 
 To trigger a specific event on the device, run the following command:
 

--- a/doc/nrf/protocols/matter/end_product/watchdog.rst
+++ b/doc/nrf/protocols/matter/end_product/watchdog.rst
@@ -27,10 +27,10 @@ This approach eliminates the need to directly call the ``Feed()`` method in your
 A time window specifies the period within which the feeding signal must be sent to each watchdog channel to reset the timer and prevent the device from rebooting.
 If the feeding signal is sent after the time window has elapsed, it does not prevent the device from rebooting.
 
-To enable the Matter watchdog feature in a matter sample, set the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_WATCHDOG` Kconfig option to ``y``.
+To enable the Matter watchdog feature in a Matter sample, set the :ref:`CONFIG_NCS_SAMPLE_MATTER_WATCHDOG<CONFIG_NCS_SAMPLE_MATTER_WATCHDOG>` Kconfig option to ``y``.
 The feature is enabled by default for the release build type in all Matter samples and applications.
 
-To set the timeout for the watchdog timer, configure the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_TIMEOUT` with a value in milliseconds.
+To set the timeout for the watchdog timer, configure the :ref:`CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_TIMEOUT<CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_TIMEOUT>` with a value in milliseconds.
 By default, the timeout is set to 10 seconds.
 
 .. note::
@@ -51,8 +51,8 @@ If pause mode is enabled, the device will only reboot if the task feeding the wa
 Pause mode is less accurate and may cause the device to reboot later than expected, but it allows feeding the watchdog only when the CPU is active.
 Non-pause mode requires periodic feeding to avoid a timeout, impacting power consumption as the CPU must wake up periodically.
 
-To enable pause mode while CPU is in the idle state, set the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_PAUSE_IN_SLEEP` Kconfig option to ``y``.
-To enable pause mode during debugging, set the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_PAUSE_ON_DEBUG` Kconfig option to ``y``.
+To enable pause mode while CPU is in the idle state, set the :ref:`CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_PAUSE_IN_SLEEP<CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_PAUSE_IN_SLEEP>` Kconfig option to ``y``.
+To enable pause mode during debugging, set the :ref:`CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_PAUSE_ON_DEBUG<CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_PAUSE_ON_DEBUG>` Kconfig option to ``y``.
 
 By default, Matter samples enable the pause mode only during debugging.
 
@@ -273,7 +273,7 @@ Default Matter watchdog implementation
 
 In the Matter common module, there is a default implementation of two watchdog sources that are automatically created for the release build version of a Matter sample.
 One source is dedicated to monitoring the Main thread, and the other is dedicated to monitoring the Matter thread.
-If at least one of the threads is blocked for a longer time than the value specified in the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_TIMEOUT` Kconfig option, a reboot will occur.
+If at least one of the threads is blocked for a longer time than the value specified in the :ref:`CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_TIMEOUT<CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_TIMEOUT>` Kconfig option, a reboot will occur.
 The ``Nrf::Watchdog::Enable()``, and ``InstallSource(WatchdogSource &source)`` functions are called automatically.
 
-To disable the default Matter watchdog implementation, set the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_DEFAULT` Kconfig option to ``n``.
+To disable the default Matter watchdog implementation, set the :ref:`CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_DEFAULT<CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_DEFAULT>` Kconfig option to ``n``.

--- a/doc/nrf/protocols/matter/getting_started/advanced_kconfigs.rst
+++ b/doc/nrf/protocols/matter/getting_started/advanced_kconfigs.rst
@@ -101,7 +101,7 @@ Matter Settings shell commands
 You can enable the Matter Settings shell commands to monitor the current usage of the Zephyr Settings using :ref:`NVS (Non-Volatile Storage) <zephyr:nvs_api>` or :ref:`ZMS (Zephyr Memory Storage) <zephyr:zms_api>` backends.
 These commands are useful for verifying that the ``settings`` partition has the proper size and meets the application requirements.
 
-To enable the Matter Settings shell module, set the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_SETTINGS_SHELL` Kconfig option to ``y``.
+To enable the Matter Settings shell module, set the :ref:`CONFIG_NCS_SAMPLE_MATTER_SETTINGS_SHELL<CONFIG_NCS_SAMPLE_MATTER_SETTINGS_SHELL>` Kconfig option to ``y``.
 
 You can use the following shell commands:
 
@@ -204,7 +204,7 @@ Persistent storage
 ==================
 
 The persistent storage module allows for the application data and configuration to survive a device reboot.
-|NCS| Matter applications use one generic Persistent Storage API that can be enabled by the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_PERSISTENT_STORAGE` Kconfig option.
+|NCS| Matter applications use one generic Persistent Storage API that can be enabled by the :ref:`CONFIG_NCS_SAMPLE_MATTER_PERSISTENT_STORAGE<CONFIG_NCS_SAMPLE_MATTER_PERSISTENT_STORAGE>` Kconfig option.
 This API consists of methods with ``Secure`` and ``NonSecure`` prefixes, which handle secure (ARM Platform Security Architecture Persistent Storage) and non-secure (raw Zephyr settings) storage operations, respectively.
 
 You can learn more details about the Persistent Storage API from the :file:`ncs/nrf/samples/matter/common/src/persistent_storage/persistent_storage.h` header file.
@@ -212,21 +212,21 @@ You can learn more details about the Persistent Storage API from the :file:`ncs/
 The interface is implemented by two available backends.
 Both can be used simultaneously by controlling the following Kconfig options:
 
-* :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_SETTINGS_STORAGE_BACKEND` - Activates the implementation that takes advantage of the raw :ref:`Zephyr settings<zephyr:settings_api>`.
+* :ref:`CONFIG_NCS_SAMPLE_MATTER_SETTINGS_STORAGE_BACKEND<CONFIG_NCS_SAMPLE_MATTER_SETTINGS_STORAGE_BACKEND>` - Activates the implementation that takes advantage of the raw :ref:`Zephyr settings<zephyr:settings_api>`.
   This backend implements ``NonSecure`` methods of the Persistent Storage API and returns ``PSErrorCode::NotSupported`` for ``Secure`` methods.
-* :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_SECURE_STORAGE_BACKEND` - Activates the module based on the ARM PSA Protected Storage API implementation from the :ref:`trusted_storage_readme` |NCS| library.
+* :ref:`CONFIG_NCS_SAMPLE_MATTER_SECURE_STORAGE_BACKEND<CONFIG_NCS_SAMPLE_MATTER_SECURE_STORAGE_BACKEND>` - Activates the module based on the ARM PSA Protected Storage API implementation from the :ref:`trusted_storage_readme` |NCS| library.
   This backend implements ``Secure`` methods of the Persistent Storage API and returns ``PSErrorCode::NotSupported`` for ``NonSecure`` methods.
 
 Both backends allow you to control the maximum length of a string-type key under which an asset can be stored.
-You can do this using the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_STORAGE_MAX_KEY_LEN` Kconfig option.
+You can do this using the :ref:`CONFIG_NCS_SAMPLE_MATTER_STORAGE_MAX_KEY_LEN<CONFIG_NCS_SAMPLE_MATTER_STORAGE_MAX_KEY_LEN>` Kconfig option.
 
-If both backends are activated at the same time (:kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_SETTINGS_STORAGE_BACKEND` and :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_SECURE_STORAGE_BACKEND` enabled) all methods of the generic interface are supported.
+If both backends are activated at the same time (:ref:`CONFIG_NCS_SAMPLE_MATTER_SETTINGS_STORAGE_BACKEND<CONFIG_NCS_SAMPLE_MATTER_SETTINGS_STORAGE_BACKEND>` and :ref:`CONFIG_NCS_SAMPLE_MATTER_SECURE_STORAGE_BACKEND<CONFIG_NCS_SAMPLE_MATTER_SECURE_STORAGE_BACKEND>` enabled), all methods of the generic interface are supported.
 
 Similarly to the non-secure backend, the secure backend leverages the Zephyr Settings to interface with the FLASH memory.
 
 Additionally, in case of the secure storage backend, the following Kconfig options control the storage limits:
 
-* :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_SECURE_STORAGE_MAX_ENTRY_NUMBER` - Defines the maximum number or assets that can be stored in the secure storage.
+* :ref:`CONFIG_NCS_SAMPLE_MATTER_SECURE_STORAGE_MAX_ENTRY_NUMBER<CONFIG_NCS_SAMPLE_MATTER_SECURE_STORAGE_MAX_ENTRY_NUMBER>` - Defines the maximum number or assets that can be stored in the secure storage.
 * :kconfig:option:`CONFIG_TRUSTED_STORAGE_BACKEND_AEAD_MAX_DATA_SIZE` - Defines the maximum length of the secret that is stored.
 
 .. _ug_matter_configuration_diagnostic_logs:
@@ -260,26 +260,26 @@ After receiving the read request from the Matter controller, the device reads th
 The device sends converted logs to the Matter controller as a response.
 
 After the crash data is successfully read, it will be removed and further read attempts will notify the user that there is no available data to read.
-To keep the crash log in the memory after reading it, set the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_REMOVE_CRASH_AFTER_READ` Kconfig option to ``n``.
+To keep the crash log in the memory after reading it, set the :ref:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_REMOVE_CRASH_AFTER_READ<CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_REMOVE_CRASH_AFTER_READ>` Kconfig option to ``n``.
 
-Network and end user logs
+Network and end-user logs
 -------------------------
 
-The diagnostic network and end user logs are saved in the dedicated retained RAM partitions.
+The diagnostic network and end-user logs are saved in the dedicated retained RAM partitions.
 The logs are not removed after reading, but when attempting to write new logs to an already full buffer, the oldest logs are replaced.
 
-The diagnostic network and end user logs are designed to be pushed when requested by the user.
+The diagnostic network and end-user logs are designed to be pushed when requested by the user.
 This can result in the same information being passed by multiple APIs, which is usually not desirable behavior.
-Because of this, for the network and the end user logs the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_REDIRECT` Kconfig option is enabled by default.
+Because of this, for the network and the end-user logs the :ref:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_REDIRECT<CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_REDIRECT>` Kconfig option is enabled by default.
 
 With the Kconfig option enabled, the redirect functionality takes logs passed to the Zephyr logger and saves them in the retained RAM as Matter diagnostic logs.
 Only the following logs are redirected:
 
 * Logs from the ``chip`` module are redirected into diagnostic network logs.
-* Logs from the ``app`` module are redirected into diagnostic end user logs.
+* Logs from the ``app`` module are redirected into diagnostic end-user logs.
 
-You can disable the redirect functionality by disabling the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_REDIRECT` Kconfig option.
-You can then push the network or end user logs using dedicated API in your application, like in the following code snippet:
+You can disable the redirect functionality by disabling the :ref:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_REDIRECT<CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_REDIRECT>` Kconfig option.
+You can then push the network or end-user logs using dedicated API in your application, like in the following code snippet:
 
 .. code-block:: C++
 
@@ -303,26 +303,26 @@ You can, for example, increase the partition sizes to be able to store more logs
 
 The snippet sets the following Kconfig options:
 
-  * :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS` to ``y``.
-  * :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_CRASH_LOGS` to ``y``.
-  * :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_REMOVE_CRASH_AFTER_READ` to ``y``.
-  * :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_END_USER_LOGS` to ``y``.
-  * :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_NETWORK_LOGS` to ``y``.
+  * :ref:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS<CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS>` to ``y``.
+  * :ref:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_CRASH_LOGS<CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_CRASH_LOGS>` to ``y``.
+  * :ref:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_REMOVE_CRASH_AFTER_READ<CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_REMOVE_CRASH_AFTER_READ>` to ``y``.
+  * :ref:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_END_USER_LOGS<CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_END_USER_LOGS>` to ``y``.
+  * :ref:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_NETWORK_LOGS<CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_NETWORK_LOGS>` to ``y``.
   * :kconfig:option:`CONFIG_LOG_MODE_DEFERRED` to ``y``.
   * :kconfig:option:`CONFIG_LOG_RUNTIME_FILTERING` to ``n``.
 
-Deferred logs mode (:kconfig:option:`CONFIG_LOG_MODE_DEFERRED`) is enabled because it is required by the log redirection functionality (:kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_REDIRECT`), which is enabled by default for diagnostic network and end user logs.
+Deferred logs mode (:kconfig:option:`CONFIG_LOG_MODE_DEFERRED`) is enabled because it is required by the log redirection functionality (:ref:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_REDIRECT<CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_REDIRECT>`), which is enabled by default for diagnostic network and end-user logs.
 
 .. note::
 
-  You cannot set the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS` Kconfig option separately without adding the devicetree overlays contained in the snippet.
+  You cannot set the :ref:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS<CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS>` Kconfig option separately without adding the devicetree overlays contained in the snippet.
   Instead, if you want to use just some of the diagnostic logs functionality, use the snippet and set the Kconfig options for the other functionalities to ``n``.
 
-To use the snippet when building a sample, add ``-D<project_name>_SNIPPET=diagnostic-logs`` to the west arguments list.
+To use the snippet when building a sample, add ``-D<project_name>_SNIPPET=matter-diagnostic-logs`` to the west arguments list.
 
-Example for the ``nrf52840dk_nrf52840`` target board and the :ref:`matter_lock_sample` sample:
+Example for the ``nrf52840dk/nrf52840`` board target and the :ref:`matter_lock_sample` sample:
 
 .. parsed-literal::
    :class: highlight
 
-   west build -b nrf52840dk/nrf52840 -- -Dlock_SNIPPET=diagnostic-logs
+   west build -b nrf52840dk/nrf52840 -- -Dlock_SNIPPET=matter-diagnostic-logs

--- a/doc/nrf/protocols/matter/getting_started/low_power_configuration.rst
+++ b/doc/nrf/protocols/matter/getting_started/low_power_configuration.rst
@@ -241,7 +241,7 @@ When performing the power measurements on various development kits, the LEDs can
   This results in measurement results being increased by an additional, small leakage current that appears if an LED is turned on.
   To measure the current consumption of the nRF54L15 SoC without including development kit components, such as LEDs, it is recommended to disable them.
 
-To disable LEDs in the Matter samples and applications, set the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_LEDS` Kconfig option to ``n``.
+To disable LEDs in the Matter samples and applications, set the :ref:`CONFIG_NCS_SAMPLE_MATTER_LEDS <CONFIG_NCS_SAMPLE_MATTER_LEDS>` Kconfig option to ``n``.
 
 .. _ug_matter_enable_pm_module:
 

--- a/doc/nrf/protocols/matter/getting_started/memory_optimization.rst
+++ b/doc/nrf/protocols/matter/getting_started/memory_optimization.rst
@@ -66,8 +66,8 @@ Alternatively, you can enable each option separately.
 
 The Kconfig option enables the following functionalities on the Matter device:
 
-- :ref:`ug_matter_configuring_settings_shell` by setting the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_SETTINGS_SHELL` Kconfig option to ``y``.
-- :doc:`matter:nrfconnect_examples_cli` by setting the :kconfig:option:`CONFIG_CHIP_LIB_SHELL` Kconfig option to ``y``.
+- :ref:`ug_matter_configuring_settings_shell` by setting the :ref:`CONFIG_NCS_SAMPLE_MATTER_SETTINGS_SHELL<CONFIG_NCS_SAMPLE_MATTER_SETTINGS_SHELL>` Kconfig option to ``y``.
+- :doc:`Command-line interface <matter:nrfconnect_examples_cli>` by setting the :kconfig:option:`CONFIG_CHIP_LIB_SHELL` Kconfig option to ``y``.
 - Zephyr Kernel commands by setting the :kconfig:option:`CONFIG_KERNEL_SHELL` Kconfig option to ``y``.
 - Zephyr Settings shell by setting the :kconfig:option:`CONFIG_SETTINGS_SHELL` Kconfig option to ``y``.
 - OpenThread shell by setting the :kconfig:option:`CONFIG_OPENTHREAD_SHELL` Kconfig option to ``y`` if you build the Matter over Thread variant.

--- a/doc/nrf/releases_and_maturity/known_issues.rst
+++ b/doc/nrf/releases_and_maturity/known_issues.rst
@@ -521,12 +521,12 @@ KRKNWK-19300: The Matter weather station application has NVS size inconsistent w
 .. rst-class:: v2-7-0
 
 KRKNWK-19199: Matter Lock and Matter Template samples cannot be built in the release configuration for the nRF54H20 platform
-  In the DTS overlay file for the ``nrf54h20dk/nrf54h20/cpuapp`` target, the watchdog configuration is missing, whereas in the release configuration, the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_WATCHDOG` Kconfig option is set to ``y``.
+  In the DTS overlay file for the ``nrf54h20dk/nrf54h20/cpuapp`` target, the watchdog configuration is missing, whereas in the release configuration, the :ref:`CONFIG_NCS_SAMPLE_MATTER_WATCHDOG<CONFIG_NCS_SAMPLE_MATTER_WATCHDOG>` Kconfig option is set to ``y``.
   Building samples with :makevar:`FILE_SUFFIX` variable set to ``release`` will fail for the ``nrf54h20dk/nrf54h20/cpuapp`` target.
 
   **Affected platforms:** nRF54H20
 
-  **Workaround:** While building the Matter Lock or Matter Template sample with the :makevar:`FILE_SUFFIX` variable set to ``release``, set the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_WATCHDOG` Kconfig option to ``n``.
+  **Workaround:** While building the Matter Lock or Matter Template sample with the :makevar:`FILE_SUFFIX` variable set to ``release``, set the :ref:`CONFIG_NCS_SAMPLE_MATTER_WATCHDOG<CONFIG_NCS_SAMPLE_MATTER_WATCHDOG>` Kconfig option to ``n``.
 
 .. rst-class:: v2-7-0
 

--- a/doc/nrf/releases_and_maturity/migration/migration_guide_2.6.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_guide_2.6.rst
@@ -71,10 +71,10 @@ Matter
        To :ref:`inherit Thread certification <ug_matter_device_certification_reqs_dependent>` from Nordic Semiconductor, you must use the PSA Crypto API backend.
      * The device can automatically migrate all operational keys from the Matter's generic persistent storage to the PSA ITS secure storage.
        This means that all keys needed to establish the secure connection between Matter nodes will be moved to the PSA ITS secure storage.
-       To enable operational keys migration, set the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS` Kconfig option to ``y``.
+       To enable operational keys migration, set the :ref:`CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS<CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS>` Kconfig option to ``y``.
 
        The default reaction to migration failure in |NCS| Matter samples is a factory reset of the device.
-       To change the default reaction, set the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_FACTORY_RESET_ON_KEY_MIGRATION_FAILURE` Kconfig option to ``n`` and implement the reaction in your Matter event handler.
+       To change the default reaction, set the :ref:`CONFIG_NCS_SAMPLE_MATTER_FACTORY_RESET_ON_KEY_MIGRATION_FAILURE<CONFIG_NCS_SAMPLE_MATTER_FACTORY_RESET_ON_KEY_MIGRATION_FAILURE>` Kconfig option to ``n`` and implement the reaction in your Matter event handler.
      * When the Device Attestation Certificate (DAC) private key exists in the factory data set, it can migrate to the PSA ITS secure storage.
 
        You can also have the DAC private key replaced by zeros in the factory data partition by setting the :kconfig:option:`CONFIG_CHIP_CRYPTO_PSA_MIGRATE_DAC_PRIV_KEY` Kconfig option to ``y``.

--- a/doc/nrf/releases_and_maturity/migration/migration_guide_2.9.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_guide_2.9.rst
@@ -94,7 +94,7 @@ Matter
         Previously, the :ref:`ug_matter_device_watchdog_pause_mode` was enabled by default for all Matter samples.
         Now, this mode is disabled and all Matter watchdog sources must be fed within the specified time window.
 
-        To re-enable the pause mode, set the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_PAUSE_IN_SLEEP` Kconfig option to ``y``.
+        To re-enable the pause mode, set the :ref:`CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_PAUSE_IN_SLEEP<CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_PAUSE_IN_SLEEP>` Kconfig option to ``y``.
 
 Libraries
 =========

--- a/doc/nrf/releases_and_maturity/releases/release-notes-2.6.0.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-2.6.0.rst
@@ -308,10 +308,10 @@ Matter
   * Migration of the Node Operational Key Pair (NOK) from the generic Matter persistent storage to the PSA ITS secure storage.
     All existing NOKs for all Matter fabrics will be migrated to the PSA ITS secure storage at boot.
     After the migration, generic Matter persistent storage entries in the settings storage will be removed and are no longer available.
-    To enable operational keys migration, set the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS` Kconfig option to ``y``.
+    To enable operational keys migration, set the :ref:`CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS<CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS>` Kconfig option to ``y``.
 
     In |NCS| Matter samples, the default reaction to migration failure is a factory reset of the device.
-    To change the default reaction, set the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_FACTORY_RESET_ON_KEY_MIGRATION_FAILURE` Kconfig option to ``n``.
+    To change the default reaction, set the :ref:`CONFIG_NCS_SAMPLE_MATTER_FACTORY_RESET_ON_KEY_MIGRATION_FAILURE<CONFIG_NCS_SAMPLE_MATTER_FACTORY_RESET_ON_KEY_MIGRATION_FAILURE>` Kconfig option to ``n``.
   * Experimental support for building Matter samples and applications with Link Time Optimization (LTO).
     To enable it, set the :kconfig:option:`CONFIG_LTO` and :kconfig:option:`CONFIG_ISR_TABLES_LOCAL_DECLARATION` Kconfig options to ``y``.
   * Documentation page about :ref:`ug_matter_gs_matter_api`.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -440,6 +440,8 @@ Keys samples
 Matter samples
 --------------
 
+* Added the :ref:`matter_samples_config` page that documents Kconfig options and snippets used by Matter samples and applications.
+
 * Updated:
 
   * All Matter samples that support low-power mode to enable the :ref:`lib_ram_pwrdn` feature.
@@ -447,7 +449,7 @@ Matter samples
   * All Matter samples to enable the ZMS file subsystem in all devices that contain MRAM, such as the nRF54H Series devices.
 
 * Disabled pausing Matter watchdog while CPU is in idle state in all Matter samples.
-  To enable it set the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_PAUSE_IN_SLEEP` Kconfig option to ``y``.
+  To enable it set the :ref:`CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_PAUSE_IN_SLEEP<CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_PAUSE_IN_SLEEP>` Kconfig option to ``y``.
 
 * :ref:`matter_template_sample` sample:
 
@@ -754,5 +756,9 @@ cJSON
 Documentation
 =============
 
-* Added Nordic Thingy:91 X to the list of devices supported by the `Quick Start app`_ on the :ref:`gsg_guides` page.
+* Added:
+
+  * Nordic Thingy:91 X to the list of devices supported by the `Quick Start app`_ on the :ref:`gsg_guides` page.
+  * The :ref:`matter_samples_config` page that documents Kconfig options and snippets shared by Matter samples and applications.
+
 * Fixed an issue on the :ref:`install_ncs` page where an incorrect directory path was provided for Linux and macOS at the end of the :ref:`cloning_the_repositories_win` section.

--- a/doc/nrf/samples/matter.rst
+++ b/doc/nrf/samples/matter.rst
@@ -96,3 +96,4 @@ In addition to these samples, check also the following Matter applications:
    :glob:
 
    ../../../samples/matter/*/README
+   ../../../samples/matter/common/config

--- a/samples/matter/common/config.rst
+++ b/samples/matter/common/config.rst
@@ -1,0 +1,250 @@
+.. _matter_samples_config:
+
+Shared configurations in Matter samples
+#######################################
+
+.. contents::
+   :local:
+   :depth: 2
+
+This page lists Kconfig options and snippets shared by :ref:`matter_samples` in the |NCS|.
+See the :ref:`ug_matter_device_advanced_kconfigs` page for more detailed information.
+
+.. _matter_samples_kconfig:
+
+Configuration options
+*********************
+
+Check and configure the following configuration options:
+
+.. _CONFIG_NCS_SAMPLE_MATTER_APP_TASK_QUEUE_SIZE:
+
+CONFIG_NCS_SAMPLE_MATTER_APP_TASK_QUEUE_SIZE
+  ``int`` - Define the maximum number of tasks the queue dedicated for application tasks that have to be run in the application thread context.
+
+.. _CONFIG_NCS_SAMPLE_MATTER_APP_TASK_MAX_SIZE:
+
+CONFIG_NCS_SAMPLE_MATTER_APP_TASK_MAX_SIZE
+  ``int`` - Define the maximum size (in bytes) of an application task that can be put in the task queue.
+
+.. _CONFIG_NCS_SAMPLE_MATTER_CUSTOM_BLUETOOTH_ADVERTISING:
+
+CONFIG_NCS_SAMPLE_MATTER_CUSTOM_BLUETOOTH_ADVERTISING
+  ``bool`` - Disable the default Bluetooth advertising start, which is defined in the :file:`board.cpp` file.
+  This allows you to use a custom one.
+
+.. _CONFIG_NCS_SAMPLE_MATTER_LEDS:
+
+CONFIG_NCS_SAMPLE_MATTER_LEDS
+  ``bool`` - Enable the LEDs module to be used.
+
+.. _CONFIG_NCS_SAMPLE_MATTER_SETTINGS_SHELL:
+
+CONFIG_NCS_SAMPLE_MATTER_SETTINGS_SHELL
+  ``bool`` - Enable using :ref:`ug_matter_configuring_settings_shell`.
+
+.. _CONFIG_NCS_SAMPLE_MATTER_TEST_SHELL:
+
+CONFIG_NCS_SAMPLE_MATTER_TEST_SHELL
+  ``bool`` - Enable support for test-specific shell commands in Matter applications.
+
+.. _CONFIG_NCS_SAMPLE_MATTER_ZAP_FILES_PATH:
+
+CONFIG_NCS_SAMPLE_MATTER_ZAP_FILES_PATH
+  ``string`` - Set the path under which ZAP files are located.
+
+Diagnostics logs
+================
+
+You can configure the :ref:`ug_matter_configuration_diagnostic_logs` support for Matter applications using the following options:
+
+.. _CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS:
+
+CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS
+  ``bool`` - Enable support for diagnostics logs.
+  Diagnostics logs allow the Matter controller to read end-user, network, and crash logs from the Matter device.
+
+.. _CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_MAX_SIMULTANEOUS_SESSIONS:
+
+CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_MAX_SIMULTANEOUS_SESSIONS
+  ``int`` - Define the maximum number of simultaneous sessions.
+
+.. _CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_CRASH_LOGS:
+
+CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_CRASH_LOGS
+  ``bool`` - Enable support for storing crash logs when the crash occurs.
+
+  Also check and configure the following option:
+
+  .. _CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_REMOVE_CRASH_AFTER_READ:
+
+  CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_REMOVE_CRASH_AFTER_READ
+    ``bool`` - Set whether the last crash log is removed after it is read.
+    Disable this option to read the last crash log multiple times.
+
+.. _CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_END_USER_LOGS:
+
+CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_END_USER_LOGS
+	``bool`` - Enable support for capturing end-user diagnostic logs.
+
+.. _CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_NETWORK_LOGS:
+
+CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_NETWORK_LOGS
+	``bool`` - Enable support for capturing network diagnostic logs.
+
+.. _CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_TEST:
+
+ONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_TEST
+	``bool`` - Enable the testing module for the diagnostic logs cluster.
+
+.. _CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_REDIRECT:
+
+CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_REDIRECT
+	``bool`` - Enable the redirection of logs to the diagnostic logs module.
+
+  This option enables only redirection of logs from the ``chip`` module (as diagnostic network logs) and from the ``app`` module (as diagnostic end-user logs).
+
+Migration of operational keys
+=============================
+
+You can configure the migration of operational keys using the following options:
+
+.. _CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS:
+
+CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS
+  ``bool`` - Enable migration of the operational keys stored in the persistent storage to the PSA ITS secure storage.
+
+  Use this feature when you update the firmware of in-field devices that run the Mbed TLS cryptography backend to new firmware based on PSA Crypto API.
+
+.. _CONFIG_NCS_SAMPLE_MATTER_FACTORY_RESET_ON_KEY_MIGRATION_FAILURE:
+
+CONFIG_NCS_SAMPLE_MATTER_FACTORY_RESET_ON_KEY_MIGRATION_FAILURE
+  ``bool`` - Enable the device to perform a factory reset if the operational key for the fabric has not been migrated properly to the PSA ITS secure storage.
+
+Persistent storage
+==================
+
+You can configure :ref:`ug_matter_persistent_storage` using the following options:
+
+.. _CONFIG_NCS_SAMPLE_MATTER_PERSISTENT_STORAGE:
+
+CONFIG_NCS_SAMPLE_MATTER_PERSISTENT_STORAGE
+  ``bool`` - Enable Matter persistent storage support.
+
+  You must also enable one or both of the following Kconfig options to select which backend is used:
+
+  .. _CONFIG_NCS_SAMPLE_MATTER_SETTINGS_STORAGE_BACKEND:
+
+  CONFIG_NCS_SAMPLE_MATTER_SETTINGS_STORAGE_BACKEND
+    ``bool`` - Enable a Zephyr settings-based storage implementation for Matter applications.
+
+  .. _CONFIG_NCS_SAMPLE_MATTER_SECURE_STORAGE_BACKEND:
+
+  CONFIG_NCS_SAMPLE_MATTER_SECURE_STORAGE_BACKEND
+    ``bool`` - Enable the ARM PSA Protected Storage API implementation that imitates Zephyr Settings' key-value data format.
+
+    * If building with CMSE enabled (``*/ns``), the TF-M and Secure Domain PSA Protected Storage implementation is used by default.
+    * If building with CMSE disabled (``*/cpuapp``), the Trusted Storage library must be used.
+
+.. _CONFIG_NCS_SAMPLE_MATTER_STORAGE_MAX_KEY_LEN:
+
+CONFIG_NCS_SAMPLE_MATTER_STORAGE_MAX_KEY_LEN
+	``int`` - Set the maximum length (in bytes) of the key under which the asset can be stored.
+
+If you enabled the secure ARM PSA Protected Storage API implementation using :ref:`CONFIG_NCS_SAMPLE_MATTER_SECURE_STORAGE_BACKEND<CONFIG_NCS_SAMPLE_MATTER_SECURE_STORAGE_BACKEND>`, also check and configure the following options:
+
+.. _CONFIG_NCS_SAMPLE_MATTER_SECURE_STORAGE_MAX_ENTRY_NUMBER:
+
+CONFIG_NCS_SAMPLE_MATTER_SECURE_STORAGE_MAX_ENTRY_NUMBER
+	``int`` - Set the maximum number of entries that can be stored securely.
+
+.. _CONFIG_NCS_SAMPLE_MATTER_SECURE_STORAGE_PSA_KEY_VALUE_OFFSET:
+
+CONFIG_NCS_SAMPLE_MATTER_SECURE_STORAGE_PSA_KEY_VALUE_OFFSET
+	``hex`` - Set the PSA key offset dedicated for the Matter application.
+
+Test event triggers
+===================
+
+You can configure :ref:`test event triggers <ug_matter_test_event_triggers>` using the following options:
+
+.. _CONFIG_NCS_SAMPLE_MATTER_TEST_EVENT_TRIGGERS:
+
+CONFIG_NCS_SAMPLE_MATTER_TEST_EVENT_TRIGGERS
+  ``bool`` - Enable support for test event triggers.
+
+.. _CONFIG_NCS_SAMPLE_MATTER_TEST_EVENT_TRIGGERS_MAX:
+
+CONFIG_NCS_SAMPLE_MATTER_TEST_EVENT_TRIGGERS_MAX
+  ``int`` - Define the maximum number of event triggers.
+
+.. _CONFIG_NCS_SAMPLE_MATTER_TEST_EVENT_TRIGGERS_REGISTER_DEFAULTS:
+
+CONFIG_NCS_SAMPLE_MATTER_TEST_EVENT_TRIGGERS_REGISTER_DEFAULTS
+  ``bool`` - Automatically register default event triggers, such as factory reset, device reboot, and OTA start query.
+
+.. _CONFIG_NCS_SAMPLE_MATTER_TEST_EVENT_TRIGGERS_MAX_TRIGGERS_DELEGATES:
+
+CONFIG_NCS_SAMPLE_MATTER_TEST_EVENT_TRIGGERS_MAX_TRIGGERS_DELEGATES
+  ``int`` - Define the maximum number of implementations of the ``TestEventTriggerDelegate`` class to be registered in the nRF test event triggers class.
+
+Matter watchdog
+===============
+
+You can configure the :ref:`ug_matter_device_watchdog` feature using the following options:
+
+.. _CONFIG_NCS_SAMPLE_MATTER_WATCHDOG:
+
+CONFIG_NCS_SAMPLE_MATTER_WATCHDOG
+	``bool`` - Enable the watchdog feature for Matter applications.
+
+.. _CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_PAUSE_IN_SLEEP:
+
+CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_PAUSE_IN_SLEEP
+  ``bool`` - Pause the watchdog feature while the CPU is in the idle state.
+
+.. _CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_PAUSE_ON_DEBUG:
+
+CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_PAUSE_ON_DEBUG
+  ``bool`` - Pause the watchdog feature while the CPU is halted by the debugger.
+
+.. _CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_DEFAULT:
+
+CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_DEFAULT
+  ``bool`` - Use the default watchdog objects that are created in the :file:`matter_init.cpp` file.
+  These watchdog objects are dedicated for the Main and Matter threads, and initialized to value of the :ref:`CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_DEFAULT_FEED_TIME<CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_DEFAULT_FEED_TIME>` Kconfig option.
+
+.. _CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_DEFAULT_FEED_TIME:
+
+CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_DEFAULT_FEED_TIME
+  ``int`` - Set the default interval (in milliseconds) for calling the feeding callback, if it exists.
+
+.. _CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_TIMEOUT:
+
+CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_TIMEOUT
+  ``int`` - Set the default maximum time window (in milliseconds) for receiving the feeding signal.
+  The feeding signal must be received from all created watchdog sources to reset the watchdog object's timer.
+
+.. _CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_EVENT_TRIGGERS:
+
+CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_EVENT_TRIGGERS
+  ``bool`` - Enable the default test event triggers that are used for watchdog-testing purposes.
+
+Snippets
+********
+
+Matter samples provide predefined :ref:`zephyr:snippets` for typical use cases.
+The snippets are in the :file:`nrf/snippets` directory of the |NCS|.
+For more information about using snippets, see :ref:`zephyr:using-snippets` in the Zephyr documentation.
+
+Specify the corresponding snippet names in the :makevar:`SNIPPET` CMake option for the application configuration.
+The following is an example command for the ``nrf52840dk/nrf52840`` board target that adds the ``matter-diagnostic-logs`` snippet to the :ref:`matter_lock_sample` sample:
+
+.. code-block::
+
+   west build -b nrf52840dk/nrf52840 -- -Dlock_SNIPPET=matter-diagnostic-logs
+
+The following snippets are available:
+
+* ``matter-diagnostic-logs`` - Enables the set of configurations needed for full Matter diagnostic logs support.
+  See :ref:`ug_matter_diagnostic_logs_snippet` in the Matter protocol section for more information.

--- a/samples/matter/lock/README.rst
+++ b/samples/matter/lock/README.rst
@@ -81,8 +81,8 @@ The credentials can be used to control remote access to the bolt lock.
 The PIN code assigned by the Matter controller is stored persistently, which means that it can survive a device reboot.
 Depending on the IPv6 network technology in use, the following storage backends are supported by default to store the PIN code credential:
 
-* Matter over Thread - secure storage backend (:kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_SECURE_STORAGE_BACKEND` Kconfig option enabled by default).
-* Matter over Wi-Fi - non-secure storage backend (:kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_SETTINGS_STORAGE_BACKEND` Kconfig option enabled by default).
+* Matter over Thread - secure storage backend (:ref:`CONFIG_NCS_SAMPLE_MATTER_SECURE_STORAGE_BACKEND<CONFIG_NCS_SAMPLE_MATTER_SECURE_STORAGE_BACKEND>` Kconfig option enabled by default).
+* Matter over Wi-Fi - non-secure storage backend (:ref:`CONFIG_NCS_SAMPLE_MATTER_SETTINGS_STORAGE_BACKEND<CONFIG_NCS_SAMPLE_MATTER_SETTINGS_STORAGE_BACKEND>` Kconfig option enabled by default).
 
 You can learn more about the |NCS| Matter persistent storage module and its configuration in the :ref:`ug_matter_persistent_storage` section of the :ref:`ug_matter_device_advanced_kconfigs` documentation.
 


### PR DESCRIPTION
The Matter samples share some configurations. In the case of the Kconfig options, these are not picked up by the docs build system. This adds a separate page where these options are documented.