### PR TITLE
doc: Bluetooth samples: fix tool references

### DIFF
--- a/samples/bluetooth/central_and_peripheral_hr/README.rst
+++ b/samples/bluetooth/central_and_peripheral_hr/README.rst
@@ -21,7 +21,7 @@ The sample supports the following development kits:
 
 .. include:: /includes/tfm.txt
 
-To test just the Bluetooth® LE Central Role operation, you need one of the following setups:
+To test just the Bluetooth LE Central Role operation, you need one of the following setups:
 
   * A smartphone or a tablet running a compatible application.
   * Another development kit running the :zephyr:code-sample:`ble_peripheral_hr` sample.
@@ -36,12 +36,12 @@ You can also mix devices when testing this sample.
 For a simple echo test, you only need one additional device.
 Alternatively, you can use a smartphone providing the HRS functionality and a development kit running the :zephyr:code-sample:`ble_central_hr` sample.
 
-For testing, you can also use `nRF Connect for Desktop`_.
+For testing, you can also use the `Bluetooth Low Energy app`_.
 
 Overview
 ********
 
-The sample demonstrates the following Bluetooth® LE roles:
+The sample demonstrates the following Bluetooth LE roles:
 
   * Central role - Scans for a remote device providing Heart Rate Service.
   * Peripheral role - Advertises and exposes a Heart Rate Service.
@@ -94,7 +94,7 @@ Building and running
 Testing
 =======
 
-After programming the sample to your development kit, test it either by connecting to other development kits that are running the :zephyr:code-sample:`ble_peripheral_hr` sample, or by using the Bluetooth Low Energy app from the `nRF Connect for Desktop`_, which emulates an HRS server.
+After programming the sample to your development kit, test it either by connecting to other development kits that are running the :zephyr:code-sample:`ble_peripheral_hr` sample, or by using the `Bluetooth Low Energy app`_ from the `nRF Connect for Desktop`_, which emulates an HRS server.
 
 Testing with other development kits
 -----------------------------------
@@ -161,8 +161,8 @@ Testing with other development kits
 
       The sample works now as relay for the Heart Rate Service.
 
-Testing with nRF Connect for Desktop
-------------------------------------
+Testing with Bluetooth Low Energy app
+-------------------------------------
 
 .. tabs::
 
@@ -171,7 +171,7 @@ Testing with nRF Connect for Desktop
       1. |connect_terminal_specific|
       #. Reset the development kit.
       #. Start `nRF Connect for Desktop`_.
-      #. Open the Bluetooth Low Energy app and select the connected dongle that is used for communication.
+      #. Open the `Bluetooth Low Energy app`_ and select the connected dongle that is used for communication.
       #. Open the **SERVER SETUP** tab.
       #. Click the dongle configuration and select :guilabel:`Load setup`.
       #. Load the :file:`hr_service.ncs` file that is located under :file:`samples/bluetooth/central_and_peripheral_hr` in the |NCS| folder structure.
@@ -203,7 +203,7 @@ Testing with nRF Connect for Desktop
 
                      Heart Rate Measurement Value: 128 bpm
 
-            The Bluetooth Low Energy app also detects the Central and Peripheral HRS sample Heart Rate Service.
+            The `Bluetooth Low Energy app`_ also detects the Central and Peripheral HRS sample Heart Rate Service.
 
          #. Enable the notification for the Heart Rate Measurement characteristic.
          #. Write again value ``06 80`` and click the :guilabel:`Play` button to send a notification.
@@ -217,7 +217,7 @@ Testing with nRF Connect for Desktop
       1. |connect_terminal_specific|
       #. Reset the development kit.
       #. Start `nRF Connect for Desktop`_.
-      #. Open the Bluetooth Low Energy app and select the connected dongle that is used for communication.
+      #. Open the `Bluetooth Low Energy app`_ and select the connected dongle that is used for communication.
       #. Open the **SERVER SETUP** tab.
       #. Click the dongle configuration and select :guilabel:`Load setup`.
       #. Load the :file:`hr_service.ncs` file that is located under :file:`samples/bluetooth/central_and_peripheral_hr` in the |NCS| folder structure.
@@ -249,7 +249,7 @@ Testing with nRF Connect for Desktop
 
                      Heart Rate Measurement Value: 128 bpm
 
-            The Bluetooth Low Energy app also detects the Central and Peripheral HRS sample Heart Rate Service.
+            The `Bluetooth Low Energy app`_ also detects the Central and Peripheral HRS sample Heart Rate Service.
 
          #. Enable the notification for the Heart Rate Measurement characteristic.
          #. Write again value ``06 80`` and click the :guilabel:`Play` button to send a notification.

--- a/samples/bluetooth/central_bas/README.rst
+++ b/samples/bluetooth/central_bas/README.rst
@@ -19,7 +19,7 @@ The sample supports the following development kits:
 
 .. include:: /includes/tfm.txt
 
-The sample also requires a device running a BAS Server to connect with (for example, another development kit running the :ref:`peripheral_hids_mouse` or :ref:`peripheral_hids_keyboard` sample, or a computer with a Bluetooth® Low Energy dongle and `nRF Connect for Desktop`_).
+The sample also requires a device running a BAS Server to connect with (for example, another development kit running the :ref:`peripheral_hids_mouse` or :ref:`peripheral_hids_keyboard` sample, or a computer with a Bluetooth® Low Energy dongle and the `Bluetooth Low Energy app`_).
 
 Overview
 ********
@@ -68,7 +68,7 @@ Building and running
 Testing
 =======
 
-After programming the sample to your development kit, you can test it either by connecting to another kit that is running the :ref:`peripheral_hids_keyboard` or :ref:`peripheral_hids_mouse` sample, or by using `nRF Connect for Desktop`_ that emulates a BAS Server.
+After programming the sample to your development kit, you can test it either by connecting to another kit that is running the :ref:`peripheral_hids_keyboard` or :ref:`peripheral_hids_mouse` sample, or by using the `Bluetooth Low Energy app`_ that emulates a BAS Server.
 
 
 Testing with another kit
@@ -119,8 +119,8 @@ Testing with another kit
             [xx.xx.xx.xx.xx.xx (random)]: Battery read: 97%
 
 
-Testing with nRF Connect for Desktop
-------------------------------------
+Testing with Bluetooth Low Energy app
+-------------------------------------
 
 .. tabs::
 
@@ -129,7 +129,7 @@ Testing with nRF Connect for Desktop
       1. |connect_terminal_specific|
       #. Reset the kit.
       #. Start `nRF Connect for Desktop`_.
-      #. Open the Bluetooth Low Energy app and select the connected dongle that is used for communication.
+      #. Open the `Bluetooth Low Energy app`_ and select the connected dongle that is used for communication.
       #. Open the :guilabel:`SERVER SETUP` tab.
          Click the dongle configuration and select :guilabel:`Load setup`.
          Load the :file:`hids_keyboard.ncs` file that is located under :file:`samples/bluetooth/central_bas` in the |NCS| folder structure.
@@ -137,7 +137,7 @@ Testing with nRF Connect for Desktop
       #. Open the :guilabel:`CONNECTION MAP` tab.
          Click the dongle configuration and select :guilabel:`Advertising setup`.
 
-         The current version of the Bluetooth Low Energy app cannot store the advertising setup, so it must be configured manually.
+         The current version of the app cannot store the advertising setup, so it must be configured manually.
          See the following image for the required target configuration:
 
          .. figure:: /images/bt_central_hids_nrfc_ad.png
@@ -178,7 +178,7 @@ Testing with nRF Connect for Desktop
       1. |connect_terminal_specific|
       #. Reset the kit.
       #. Start `nRF Connect for Desktop`_.
-      #. Open the Bluetooth Low Energy app and select the connected dongle that is used for communication.
+      #. Open the `Bluetooth Low Energy app`_ and select the connected dongle that is used for communication.
       #. Open the :guilabel:`SERVER SETUP` tab.
          Click the dongle configuration and select :guilabel:`Load setup`.
          Load the :file:`hids_keyboard.ncs` file that is located under :file:`samples/bluetooth/central_bas` in the |NCS| folder structure.
@@ -186,7 +186,7 @@ Testing with nRF Connect for Desktop
       #. Open the :guilabel:`CONNECTION MAP` tab.
          Click the dongle configuration and select :guilabel:`Advertising setup`.
 
-         The current version of the Bluetooth Low Energy app cannot store the advertising setup, so it must be configured manually.
+         The current version of the app cannot store the advertising setup, so it must be configured manually.
          See the following image for the required target configuration:
 
          .. figure:: /images/bt_central_hids_nrfc_ad.png

--- a/samples/bluetooth/central_hids/README.rst
+++ b/samples/bluetooth/central_hids/README.rst
@@ -22,7 +22,7 @@ The sample supports the following development kits:
 
 .. include:: /includes/tfm.txt
 
-The sample also requires a HIDS device to connect with (for example, another development kit running the :ref:`peripheral_hids_mouse` sample or :ref:`peripheral_hids_keyboard` sample, or a computer with a Bluetooth Low Energy dongle and `nRF Connect for Desktop`_).
+The sample also requires a HIDS device to connect with (for example, another development kit running the :ref:`peripheral_hids_mouse` sample or :ref:`peripheral_hids_keyboard` sample, or a computer with a Bluetooth Low Energy dongle and the `Bluetooth Low Energy app`_).
 
 Overview
 ********
@@ -102,7 +102,7 @@ Building and Running
 Testing
 =======
 
-After programming the sample to your development kit, you can test it either by connecting to another development kit that is running the :ref:`peripheral_hids_keyboard` sample, or by using `nRF Connect for Desktop`_ that emulates a HIDS server.
+After programming the sample to your development kit, you can test it either by connecting to another development kit that is running the :ref:`peripheral_hids_keyboard` sample, or by using the `Bluetooth Low Energy app`_ that emulates a HIDS server.
 
 
 Testing with another development kit
@@ -197,8 +197,8 @@ Testing with another development kit
             Received data (size: 1, data[0]: 0x2)
 
 
-Testing with nRF Connect for Desktop
-------------------------------------
+Testing with Bluetooth Low Energy app
+-------------------------------------
 
 .. tabs::
 
@@ -207,7 +207,7 @@ Testing with nRF Connect for Desktop
       1. |connect_terminal_specific|
       #. Reset the kit.
       #. Start `nRF Connect for Desktop`_.
-      #. Open the Bluetooth Low Energy app and select the connected dongle that is used for communication.
+      #. Open the `Bluetooth Low Energy app`_ and select the connected dongle that is used for communication.
       #. Open the :guilabel:`SERVER SETUP` tab.
          Click the dongle configuration and select :guilabel:`Load setup`.
          Load the :file:`hids_keyboard.ncs` file that is located under :file:`samples/bluetooth/central_hids` in the |NCS| folder structure.
@@ -215,7 +215,7 @@ Testing with nRF Connect for Desktop
       #. Open the :guilabel:`CONNECTION MAP` tab.
          Click the dongle configuration and select :guilabel:`Advertising setup`.
 
-         The current version of nRF Connect cannot store the advertising setup, so it must be configured manually.
+         The current version of the app cannot store the advertising setup, so it must be configured manually.
          See the following image for the required target configuration:
 
          .. figure:: /images/bt_central_hids_nrfc_ad.png
@@ -254,7 +254,7 @@ Testing with nRF Connect for Desktop
       1. |connect_terminal_specific|
       #. Reset the kit.
       #. Start `nRF Connect for Desktop`_.
-      #. Open the Bluetooth Low Energy app and select the connected dongle that is used for communication.
+      #. Open the `Bluetooth Low Energy app`_ and select the connected dongle that is used for communication.
       #. Open the :guilabel:`SERVER SETUP` tab.
          Click the dongle configuration and select :guilabel:`Load setup`.
          Load the :file:`hids_keyboard.ncs` file that is located under :file:`samples/bluetooth/central_hids` in the |NCS| folder structure.
@@ -262,7 +262,7 @@ Testing with nRF Connect for Desktop
       #. Open the :guilabel:`CONNECTION MAP` tab.
          Click the dongle configuration and select :guilabel:`Advertising setup`.
 
-         The current version of nRF Connect cannot store the advertising setup, so it must be configured manually.
+         The current version of the app cannot store the advertising setup, so it must be configured manually.
          See the following image for the required target configuration:
 
          .. figure:: /images/bt_central_hids_nrfc_ad.png

--- a/samples/bluetooth/direct_test_mode/README.rst
+++ b/samples/bluetooth/direct_test_mode/README.rst
@@ -22,7 +22,7 @@ Additionally, the sample requires one of the following testing devices:
   See :ref:`direct_test_mode_testing_anritsu`.
 * Another development kit with the same sample.
   See :ref:`direct_test_mode_testing_board`.
-* A computer with the Direct Test Mode app available in the `nRF Connect for Desktop`_.
+* A computer with the `Direct Test Mode app`_ available in the `nRF Connect for Desktop`_.
   See :ref:`direct_test_mode_testing_app`.
 
 Overview
@@ -36,7 +36,7 @@ The sample uses Direct Test Mode (DTM) to test the operation of the following fe
 * Packet error rate
 * Intermodulation performance
 
-Test procedures are defined in the document `Bluetooth® Low Energy RF PHY Test Specification <Bluetooth Low Energy RF PHY Test Specification_>`_: Document number RF-PHY.TS.p15
+Test procedures are defined in the document `Bluetooth Low Energy RF PHY Test Specification <Bluetooth Low Energy RF PHY Test Specification_>`_: Document number RF-PHY.TS.p15
 
 You can carry out conformance tests using dedicated test equipment, such as the Anritsu MT8852 or similar, with an nRF5 running the DTM sample set as device under test (DUT).
 
@@ -455,8 +455,8 @@ Testing with another development kit
 
 .. _direct_test_mode_testing_app:
 
-Testing with nRF Connect for Desktop
-------------------------------------
+Testing with Direct Test Mode app
+---------------------------------
 
 1. |connect_kit|
 #. Connect the kit with a terminal emulator that supports encoding and decoding in the HEX format.
@@ -464,7 +464,7 @@ Testing with nRF Connect for Desktop
 #. Start the ``TRANSMITTER_TEST`` by sending the ``0x80 0x96`` DTM command to the connected development kit.
    This command triggers TX activity on 2402 MHz frequency (1st channel) with ``10101010`` packet pattern and 37-byte packet length.
 #. Observe that you received the ``TEST_STATUS_EVENT`` packet in response with the SUCCESS status field: ``0x00 0x00``.
-#. Start the Direct Test Mode app in nRF Connect for Desktop and select the development kit to communicate with.
+#. Start the `Direct Test Mode app`_ in `nRF Connect for Desktop`_ and select the development kit to communicate with.
 #. Set the Receiver mode and 37th channel in the test configuration menu.
 #. Start the test.
 #. On the application chart, observe that the number of RX packets is increasing for the 2402 MHz channel.

--- a/samples/bluetooth/peripheral_ams_client/README.rst
+++ b/samples/bluetooth/peripheral_ams_client/README.rst
@@ -18,7 +18,7 @@ The sample supports the following development kits:
 
 .. include:: /includes/tfm.txt
 
-The sample also requires a device running an AMS Server to connect with (for example, an iPhone, or a computer with a Bluetooth® Low Energy dongle and nRF Connect for Desktop).
+The sample also requires a device running an AMS Server to connect with (for example, an iPhone, or a computer with a Bluetooth® Low Energy dongle and the `Bluetooth Low Energy app`_).
 
 Overview
 ********
@@ -93,7 +93,7 @@ Building and running
 Testing
 =======
 
-After programming the sample to your development kit, you can test it either by connecting to an iOS device or by using the Bluetooth Low Energy app of `nRF Connect for Desktop`_ that emulates an AMS Server.
+After programming the sample to your development kit, you can test it either by connecting to an iOS device or by using the `Bluetooth Low Energy app`_ of `nRF Connect for Desktop`_ that emulates an AMS Server.
 
 Testing with an iOS device
 --------------------------
@@ -126,12 +126,12 @@ Testing with an iOS device
       #. Press **Button 2** to jump to the next song.
       #. Press **Button 3** to jump to the previous song.
 
-Testing with nRF Connect for Desktop
-------------------------------------
+Testing with Bluetooth Low Energy app
+-------------------------------------
 
 #. |connect_terminal_specific|
 #. Reset the kit.
-#. Start the Bluetooth Low Energy app of `nRF Connect for Desktop`_ and select the connected dongle that is used for communication.
+#. Start the `Bluetooth Low Energy app`_ of `nRF Connect for Desktop`_ and select the connected dongle that is used for communication.
 #. Set up the server:
    a. Select the **Server setup** tab.
    #. Select :guilabel:`Dongle configuration` > :guilabel:`Load setup`.
@@ -140,7 +140,8 @@ Testing with nRF Connect for Desktop
 #. Select the :guilabel:`Connection Map` tab.
 #. Select :guilabel:`Dongle configuration` > :guilabel:`Security parameters`.
 #. Check :guilabel:`Perform Bonding`, and click :guilabel:`Apply`.
-#. Connect to the device from the Bluetooth Low Energy app. The device is advertising as "Nordic_AMS".
+#. Connect to the device from the app.
+   The device is advertising as "Nordic_AMS".
 #. Wait until the bond is established.
    Verify that the UART data is received as follows::
 
@@ -149,7 +150,7 @@ Testing with nRF Connect for Desktop
       Security changed: xx:xx:xx:xx:xx:xx (random) level 2
       Pairing completed: xx:xx:xx:xx:xx:xx (random), bonded: 1
 
-#. After bonding, verify in the Bluetooth Low Energy app that the **Client Characteristic Configuration** (CCCD) value for **Apple Remote Command** and **Apple Entity Update** are set to ``01 00``.
+#. After bonding, verify in the app that the **Client Characteristic Configuration** (CCCD) value for **Apple Remote Command** and **Apple Entity Update** are set to ``01 00``.
 
 Music setup
 ^^^^^^^^^^^
@@ -160,7 +161,7 @@ Music setup
 
       Complete the following steps to initiate a music player setup:
 
-      #. In the Bluetooth Low Energy app, verify that the **Apple Entity Update** is initiated to ``00 00 01 02``.
+      #. In the `Bluetooth Low Energy app`_, verify that the **Apple Entity Update** is initiated to ``00 00 01 02``.
          The following table lists the attributes requested by the MR.
 
          +--------------+-------+----------------+
@@ -176,7 +177,7 @@ Music setup
          +--------------+-------+----------------+
 
       #. Press **Button 1** to enable track attributes notification.
-      #. In the Bluetooth Low Energy app, verify that the **Apple Entity Update** is updated to ``02 00 01 02 03``.
+      #. In the app, verify that the **Apple Entity Update** is updated to ``02 00 01 02 03``.
          The following table lists the attributes requested by the MR.
 
          +--------------+-------+----------------+
@@ -260,7 +261,7 @@ Music setup
 
       Complete the following steps to initiate a music player setup:
 
-      #. In the Bluetooth Low Energy app, verify that the **Apple Entity Update** is initiated to ``00 00 01 02``.
+      #. In the `Bluetooth Low Energy app`_, verify that the **Apple Entity Update** is initiated to ``00 00 01 02``.
          The following table lists the attributes requested by the MR.
 
          +--------------+-------+----------------+
@@ -276,7 +277,7 @@ Music setup
          +--------------+-------+----------------+
 
       #. Press **Button 0** to enable track attributes notification.
-      #. In the Bluetooth Low Energy app, verify that the **Apple Entity Update** is updated to ``02 00 01 02 03``.
+      #. In the app, verify that the **Apple Entity Update** is updated to ``02 00 01 02 03``.
          The following table lists the attributes requested by the MR.
 
          +--------------+-------+----------------+
@@ -366,7 +367,7 @@ To test an audio playback, complete the following steps:
    .. group-tab:: nRF52 and nRF53 DKs
 
       #. Press **Button 2** to start audio playback.
-      #. In the Bluetooth Low Energy app, verify that the **Apple Remote Command** is updated to ``02``.
+      #. In the `Bluetooth Low Energy app`_, verify that the **Apple Remote Command** is updated to ``02``.
       #. Set the **Apple Entity Update** value to ``00 01 00 31 2C 31 2E 30 2C 30 2E 30 31 34``.
       #. Verify that the UART output is as follows::
 
@@ -421,7 +422,7 @@ Next track
       To test the next track feature, complete the following steps:
 
       #. Press **Button 3** to jump to next song.
-      #. In the Bluetooth Low Energy app, verify that the **Apple Remote Command** is updated to ``03``.
+      #. In the `Bluetooth Low Energy app`_, verify that the **Apple Remote Command** is updated to ``03``.
       #. Set the **Apple Entity Update** value to ``02 03 00 31 38 30 2E 30 30 30``.
       #. Verify that the UART output is as follows::
 
@@ -441,7 +442,7 @@ Next track
       To test the next track feature, complete the following steps:
 
       #. Press **Button 2** to jump to next song.
-      #. In the Bluetooth Low Energy app, verify that the **Apple Remote Command** is updated to ``03``.
+      #. In the `Bluetooth Low Energy app`_, verify that the **Apple Remote Command** is updated to ``03``.
       #. Set the **Apple Entity Update** value to ``02 03 00 31 38 30 2E 30 30 30``.
       #. Verify that the UART output is as follows::
 
@@ -459,8 +460,8 @@ Next track
 Disconnect
 ^^^^^^^^^^
 
-Disconnect the device in the Bluetooth Low Energy app.
-As the bond information is preserved by the Bluetooth Low Energy app, you can immediately reconnect to the device by clicking :guilabel:`Connect`.
+Disconnect the device in the `Bluetooth Low Energy app`_.
+As the bond information is preserved by the app, you can immediately reconnect to the device by clicking :guilabel:`Connect`.
 
 Dependencies
 ************

--- a/samples/bluetooth/peripheral_ancs_client/README.rst
+++ b/samples/bluetooth/peripheral_ancs_client/README.rst
@@ -18,7 +18,7 @@ The sample supports the following development kits:
 
 .. include:: /includes/tfm.txt
 
-The sample also requires a device running an ANCS Server to connect with (for example, an iPhone which runs iOS, or a Bluetooth® Low Energy dongle and nRF Connect for Desktop).
+The sample also requires a device running an ANCS Server to connect with (for example, an iPhone which runs iOS, or a Bluetooth® Low Energy dongle and the `Bluetooth Low Energy app`_).
 
 User interface
 **************
@@ -80,7 +80,7 @@ Building and running
 Testing
 =======
 
-After programming the sample to your development kit, you can test it either by connecting to an iOS device or by using `nRF Connect for Desktop`_ that emulates an ANCS Server.
+After programming the sample to your development kit, you can test it either by connecting to an iOS device or by using the `Bluetooth Low Energy app`_ that emulates an ANCS Server.
 
 Testing with an iOS device
 --------------------------
@@ -111,13 +111,13 @@ Testing with an iOS device
          For example, requesting the app attributes for "com.apple.mobilecal" yields "Calendar".
       #. If the notification has a flag for a positive or negative action, perform the notification action with **Button 2** or **Button 3**, respectively.
 
-Testing with nRF Connect for Desktop
-------------------------------------
+Testing with Bluetooth Low Energy app
+-------------------------------------
 
 #. |connect_terminal_specific|
 #. Reset the kit.
 #. Start `nRF Connect for Desktop`_.
-#. Open the Bluetooth Low Energy app and select the connected dongle that is used for communication.
+#. Open the `Bluetooth Low Energy app`_ and select the connected dongle that is used for communication.
 #. Click the :guilabel:`SERVER SETUP` tab.
    Click the dongle configuration and select :guilabel:`Load setup`.
    Load the :file:`ANCS_central.ncs` file that is located under :file:`samples/bluetooth/peripheral_ancs_client` in the |NCS| folder structure.
@@ -125,7 +125,8 @@ Testing with nRF Connect for Desktop
 #. Click the :guilabel:`CONNECTION MAP` tab.
    Click the dongle configuration and select :guilabel:`Security parameters`.
    Check :guilabel:`Perform Bonding`, and click :guilabel:`Apply`.
-#. Connect to the device from nRF Connect. The device is advertising as "ANCS".
+#. Connect to the device from the app.
+   The device is advertising as "ANCS".
 #. Wait until the bond is established. Verify that the UART data is received as follows::
 
       Connected xx:xx:xx:xx:xx:xx (random)
@@ -134,7 +135,7 @@ Testing with nRF Connect for Desktop
       GATT Service could not be found during the discovery
       The discovery procedure for ANCS succeeded
 
-#. After bonding, verify in the Bluetooth Low Energy app that the **Client Characteristic Configuration** (CCCD) value for **Apple Notification Source** and **Apple Data Source** are set to ``01 00``.
+#. After bonding, verify in the app that the **Client Characteristic Configuration** (CCCD) value for **Apple Notification Source** and **Apple Data Source** are set to ``01 00``.
 
 Send an iOS notification to the application
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -155,7 +156,7 @@ The following table shows the format of a notification that you can send to the 
    | Notification UID | 01 02 03 04   | 67305985 (0x4030201)     |
    +------------------+---------------+--------------------------+
 
-#. In the Bluetooth Low Energy app, set the value of **Apple Notification Source** to ``00 18 06 02 01 02 03 04`` and click :guilabel:`Update`.
+#. In the `Bluetooth Low Energy app`_, set the value of **Apple Notification Source** to ``00 18 06 02 01 02 03 04`` and click :guilabel:`Update`.
 #. Verify that the UART data is received as follows::
 
       Notification
@@ -258,7 +259,7 @@ The following table shows the format of a response that contains some of the req
    .. group-tab:: nRF52 and nRF53 DKs
 
       #. Press **Button 1** to request notification attributes for the iOS notification that was received.
-      #. In the Bluetooth Low Energy app, verify that the **Apple Control Point** is updated to ``00 01 02 03 04 00 01 20 00 02 20 00 03 20 00 04 05 06 07``.
+      #. In the `Bluetooth Low Energy app`_, verify that the **Apple Control Point** is updated to ``00 01 02 03 04 00 01 20 00 02 20 00 03 20 00 04 05 06 07``.
       #. Respond to the request by sending two notification attributes: the title and the message.
          Set the **Apple Data Source** value in the Server to ``00 01 02 03 04 01 03 00 6E 52 46 03 02 00 35 32``.
       #. The application will print the received data on UART.
@@ -275,7 +276,7 @@ The following table shows the format of a response that contains some of the req
    .. group-tab:: nRF54 DKs
 
       #. Press **Button 0** to request notification attributes for the iOS notification that was received.
-      #. In the Bluetooth Low Energy app, verify that the **Apple Control Point** is updated to ``00 01 02 03 04 00 01 20 00 02 20 00 03 20 00 04 05 06 07``.
+      #. In the `Bluetooth Low Energy app`_, verify that the **Apple Control Point** is updated to ``00 01 02 03 04 00 01 20 00 02 20 00 03 20 00 04 05 06 07``.
       #. Respond to the request by sending two notification attributes: the title and the message.
          Set the **Apple Data Source** value in the Server to ``00 01 02 03 04 01 03 00 6E 52 46 03 02 00 35 32``.
       #. The application will print the received data on UART.
@@ -328,7 +329,7 @@ The following table shows the format of a response that contains the requested a
    .. group-tab:: nRF52 and nRF53 DKs
 
       #. Press **Button 2** to request app attributes for the app with the app identifier "com" (the last received app identifier).
-      #. In the Bluetooth Low Energy app, verify that the **Apple Control Point** is updated to ``01 63 6F 6D 00 00``.
+      #. In the `Bluetooth Low Energy app`_, verify that the **Apple Control Point** is updated to ``01 63 6F 6D 00 00``.
       #. Respond to the request by sending the app attribute.
          Set the **Apple Data Source** value in the Server to ``01 63 6F 6D 00 00 04 00 4D 61 69 6C``.
       #. The application will print the received data on UART. Verify that the UART output is as follows::
@@ -338,7 +339,7 @@ The following table shows the format of a response that contains the requested a
    .. group-tab:: nRF54 DKs
 
       #. Press **Button 1** to request app attributes for the app with the app identifier "com" (the last received app identifier).
-      #. In the Bluetooth Low Energy app, verify that the **Apple Control Point** is updated to ``01 63 6F 6D 00 00``.
+      #. In the `Bluetooth Low Energy app`_, verify that the **Apple Control Point** is updated to ``01 63 6F 6D 00 00``.
       #. Respond to the request by sending the app attribute.
          Set the **Apple Data Source** value in the Server to ``01 63 6F 6D 00 00 04 00 4D 61 69 6C``.
       #. The application will print the received data on UART. Verify that the UART output is as follows::
@@ -348,7 +349,7 @@ The following table shows the format of a response that contains the requested a
 Disconnect
 ^^^^^^^^^^
 
-Disconnect the device in the Bluetooth Low Energy app.
+Disconnect the device in the `Bluetooth Low Energy app`_.
 As the bond information is preserved by the app, you can immediately reconnect to the device by clicking :guilabel:`Connect`.
 
 Dependencies

--- a/samples/bluetooth/peripheral_bms/README.rst
+++ b/samples/bluetooth/peripheral_bms/README.rst
@@ -16,7 +16,7 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
-The sample also requires a Bluetooth® Low Energy dongle and nRF Connect for Desktop.
+The sample also requires a Bluetooth® Low Energy dongle and the `Bluetooth Low Energy app`_.
 
 Overview
 ********
@@ -65,7 +65,7 @@ Testing
 1. |connect_terminal_specific|
 #. Reset the kit.
 #. Start `nRF Connect for Desktop`_.
-#. Open the Bluetooth Low Energy app and select the connected device that is used for communication.
+#. Open the `Bluetooth Low Energy app`_ and select the connected device that is used for communication.
 #. Connect to the device from the app.
    The device is advertising as "Nordic_BMS".
 #. Bind with the device:
@@ -77,7 +77,7 @@ Testing
    #. Click :guilabel:`Pair`.
 
 #. Check the logs to verify that the connection security is updated.
-#. Disconnect the device in nRF Connect.
+#. Disconnect the device in the app.
 #. Reconnect again and verify that the connection security is updated automatically.
 #. Verify that the Feature Characteristic of the Bond Management Service displays ``10 08 02``.
    This means that the following features are supported:

--- a/samples/bluetooth/peripheral_cts_client/README.rst
+++ b/samples/bluetooth/peripheral_cts_client/README.rst
@@ -18,7 +18,7 @@ The sample supports the following development kits:
 
 .. include:: /includes/tfm.txt
 
-The sample also requires a device running a CTS Server to connect with (for example, a Bluetooth® Low Energy dongle and nRF Connect for Desktop).
+The sample also requires a device running a CTS Server to connect with (for example, a Bluetooth® Low Energy dongle and the `Bluetooth Low Energy app`_).
 
 Overview
 ********
@@ -69,7 +69,7 @@ Building and running
 Testing
 =======
 
-After programming the sample to your development kit, you can test it with `nRF Connect for Desktop`_ by performing the following steps.
+After programming the sample to your development kit, you can test it with the `Bluetooth Low Energy app`_ by performing the following steps.
 
 .. tabs::
 
@@ -78,7 +78,7 @@ After programming the sample to your development kit, you can test it with `nRF 
       1. |connect_terminal_specific|
       #. Reset the kit.
       #. Start `nRF Connect for Desktop`_
-      #. Open the Bluetooth Low Energy app and select the connected dongle that is used for communication.
+      #. Open the `Bluetooth Low Energy app`_ and select the connected dongle that is used for communication.
       #. Open the :guilabel:`SERVER SETUP` tab.
          Click the dongle configuration and select **Load setup**.
          Load the :file:`cts_central.ncs` file that is located under :file:`samples/bluetooth/peripheral_cts_client` in the |NCS| folder structure.
@@ -140,15 +140,15 @@ After programming the sample to your development kit, you can test it with `nRF 
                External update  0
                Manual update    0
 
-      #. Disconnect the device in the Bluetooth Low Energy app.
-      #. As bond information is preserved by the Bluetooth Low Energy app, you can immediately reconnect to the device by clicking the :guilabel:`Connect` button again.
+      #. Disconnect the device in the app.
+      #. As bond information is preserved by the app, you can immediately reconnect to the device by clicking the :guilabel:`Connect` button again.
 
    .. group-tab:: nRF54 DKs
 
       1. |connect_terminal_specific|
       #. Reset the kit.
       #. Start `nRF Connect for Desktop`_
-      #. Open the Bluetooth Low Energy app and select the connected dongle that is used for communication.
+      #. Open the `Bluetooth Low Energy app`_ and select the connected dongle that is used for communication.
       #. Open the :guilabel:`SERVER SETUP` tab.
          Click the dongle configuration and select **Load setup**.
          Load the :file:`cts_central.ncs` file that is located under :file:`samples/bluetooth/peripheral_cts_client` in the |NCS| folder structure.
@@ -210,8 +210,8 @@ After programming the sample to your development kit, you can test it with `nRF 
                External update  0
                Manual update    0
 
-      #. Disconnect the device in the Bluetooth Low Energy app.
-      #. As bond information is preserved by the Bluetooth Low Energy app, you can immediately reconnect to the device by clicking the :guilabel:`Connect` button again.
+      #. Disconnect the device in the app.
+      #. As bond information is preserved by the app, you can immediately reconnect to the device by clicking the :guilabel:`Connect` button again.
 
 Dependencies
 ************

--- a/samples/bluetooth/peripheral_hids_keyboard/README.rst
+++ b/samples/bluetooth/peripheral_hids_keyboard/README.rst
@@ -203,10 +203,10 @@ To test with a Microsoft Windows computer that has a Bluetooth radio, complete t
       #. Disconnect the computer from the device by removing the device from the computer's devices list.
 
 
-Testing with nRF Connect for Desktop
-------------------------------------
+Testing with Bluetooth Low Energy app
+-------------------------------------
 
-To test with `nRF Connect for Desktop`_, complete the following steps:
+To test with the `Bluetooth Low Energy app`_, complete the following steps:
 
 .. tabs::
 
@@ -217,7 +217,7 @@ To test with `nRF Connect for Desktop`_, complete the following steps:
          A blinking **LED 1** indicates that the device is advertising.
       #. |connect_terminal|
       #. Start `nRF Connect for Desktop`_.
-      #. Open the Bluetooth Low Energy app.
+      #. Open the `Bluetooth Low Energy app`_.
       #. Connect to the device from the app. The device is advertising as "NCS HIDS keyboard".
       #. Pair the devices:
 
@@ -247,7 +247,7 @@ To test with `nRF Connect for Desktop`_, complete the following steps:
          Observe that two notifications are received on one of the HID Report characteristics, denoting press and release for one character of the test message.
          The first one has the value ``02000F0000000000``, the second has the value ``0200000000000000``.
          These values correspond to press and release of character "l" with the Shift key pressed.
-      #. In the Bluetooth Low Energy app, select the HID Report (which has UUID ``0x2A4D`` and the properties ``Read``, ``WriteWithoutResponse``, and ``Write``).
+      #. In the app, select the HID Report (which has UUID ``0x2A4D`` and the properties ``Read``, ``WriteWithoutResponse``, and ``Write``).
          Enter ``02`` in the text box and click the :guilabel:`tick mark` button.
          This sets the modifier bit of the Output Report to 02, which simulates turning Caps Lock ON.
 
@@ -257,10 +257,10 @@ To test with `nRF Connect for Desktop`_, complete the following steps:
          This sets the modifier bit to 00, which simulates turning Caps Lock OFF.
 
          Observe that **LED 3** turns off.
-      #. Disconnect the device in the Bluetooth Low Energy app.
+      #. Disconnect the device in the app.
          Observe that no new notifications are received.
       #. If the advertising did not start automatically, press **Button 4** to continue advertising.
-      #. As bond information is preserved by the Bluetooth Low Energy app, you can immediately reconnect to the device by clicking the :guilabel:`Connect` button again.
+      #. As bond information is preserved by the app, you can immediately reconnect to the device by clicking the :guilabel:`Connect` button again.
 
    .. group-tab:: nRF54 DKs
 
@@ -269,8 +269,9 @@ To test with `nRF Connect for Desktop`_, complete the following steps:
          A blinking **LED 0** indicates that the device is advertising.
       #. |connect_terminal|
       #. Start `nRF Connect for Desktop`_.
-      #. Open the Bluetooth Low Energy app.
-      #. Connect to the device from the app. The device is advertising as "NCS HIDS keyboard".
+      #. Open the `Bluetooth Low Energy app`_.
+      #. Connect to the device from the app.
+         The device is advertising as "NCS HIDS keyboard".
       #. Pair the devices:
 
          a. Click the :guilabel:`Settings` button for the device in the app.
@@ -299,7 +300,7 @@ To test with `nRF Connect for Desktop`_, complete the following steps:
          Observe that two notifications are received on one of the HID Report characteristics, denoting press and release for one character of the test message.
          The first one has the value ``02000F0000000000``, the second has the value ``0200000000000000``.
          These values correspond to press and release of character "l" with the Shift key pressed.
-      #. In the Bluetooth Low Energy app, select the HID Report (which has UUID ``0x2A4D`` and the properties ``Read``, ``WriteWithoutResponse``, and ``Write``).
+      #. In the app, select the HID Report (which has UUID ``0x2A4D`` and the properties ``Read``, ``WriteWithoutResponse``, and ``Write``).
          Enter ``02`` in the text box and click the :guilabel:`tick mark` button.
          This sets the modifier bit of the Output Report to 02, which simulates turning Caps Lock ON.
 
@@ -309,10 +310,10 @@ To test with `nRF Connect for Desktop`_, complete the following steps:
          This sets the modifier bit to 00, which simulates turning Caps Lock OFF.
 
          Observe that **LED 2** turns off.
-      #. Disconnect the device in the Bluetooth Low Energy app.
+      #. Disconnect the device in the app.
          Observe that no new notifications are received.
       #. If the advertising did not start automatically, press **Button 3** to continue advertising.
-      #. As bond information is preserved by the Bluetooth Low Energy app, you can immediately reconnect to the device by clicking the :guilabel:`Connect` button again.
+      #. As bond information is preserved by the app, you can immediately reconnect to the device by clicking the :guilabel:`Connect` button again.
 
 
 Testing with Android using NFC for pairing

--- a/samples/bluetooth/peripheral_power_profiling/README.rst
+++ b/samples/bluetooth/peripheral_power_profiling/README.rst
@@ -81,7 +81,7 @@ The following parameters have an impact on power consumption:
    * Notifications data size and interval
 
 You can configure these parameters with the Kconfig options.
-If your central device is the Bluetooth Low Energy app from `nRF Connect for Desktop`_, you can use it to change the current connection parameters.
+If your central device is the `Bluetooth Low Energy app`_ from `nRF Connect for Desktop`_, you can use it to change the current connection parameters.
 
 Example measurements:
 
@@ -237,11 +237,11 @@ This testing procedure assumes that you are using `nRF Connect for Mobile`_ or `
 After programming the sample to your development kit, you need another device for measuring the power consumption.
 `Power Profiler Kit II (PPK2)`_ is the recommended device for the measurement.
 
-Testing with nRF Connect for Desktop and Power Profiler Kit II (PPK2)
----------------------------------------------------------------------
+Testing with Bluetooth Low Energy app and Power Profiler Kit II (PPK2)
+----------------------------------------------------------------------
 
 1. Set up `Power Profiler Kit II (PPK2)`_ and prepare your development kit for current measurement.
-#. Run the Power Profiler app from nRF Connect for Desktop.
+#. Run the `Power Profiler app`_ from nRF Connect for Desktop.
 #. |connect_terminal_ANSI|
 #. Reset your development kit.
 #. Observe that the sample starts.
@@ -252,7 +252,7 @@ Testing with nRF Connect for Desktop and Power Profiler Kit II (PPK2)
 
    You can measure power consumption during advertising with different intervals.
    Use the Kconfig options to change the interval or other parameters.
-#. Connect to the device through the Bluetooth Low Energy app.
+#. Connect to the device through the `Bluetooth Low Energy app`_.
 
    Observe the power consumption on the current connection interval.
 #. Set different connection parameters:

--- a/samples/bluetooth/peripheral_uart/README.rst
+++ b/samples/bluetooth/peripheral_uart/README.rst
@@ -320,21 +320,21 @@ To perform the test, complete the following steps:
 Testing with Bluetooth Low Energy app
 -------------------------------------
 
-If you have an nRF52 Series DK with the Peripheral UART sample and either a dongle or second Nordic Semiconductor development kit that supports Bluetooth Low Energy, you can test the sample on your computer.
+If you have an nRF52 Series DK with the Peripheral UART sample and either a dongle or second Nordic Semiconductor development kit that supports the `Bluetooth Low Energy app`_, you can test the sample on your computer.
 Use the `Bluetooth Low Energy app`_ in `nRF Connect for Desktop`_ for testing.
 
 To perform the test, complete the following steps:
 
-1. Install the Bluetooth Low Energy app in `nRF Connect for Desktop`_.
+1. Install the `Bluetooth Low Energy app`_ in `nRF Connect for Desktop`_.
 #. Connect to your nRF52 Series DK.
 #. Connect the dongle or second development kit to a USB port of your computer.
-#. Open the Bluetooth Low Energy app.
+#. Open the app.
 #. Select the serial port that corresponds to the dongle or the second development kit.
    Do not select the kit you want to test just yet.
 
    .. note::
       If the dongle or the second development kit has not been used with the Bluetooth Low Energy app before, you may be asked to update the J-Link firmware and connectivity firmware on the nRF SoC to continue.
-      When the nRF SoC has been updated with the correct firmware, the Bluetooth Low Energy app finishes connecting to your device over USB.
+      When the nRF SoC has been updated with the correct firmware, the app finishes connecting to your device over USB.
       When the connection is established, the device appears in the main view.
 
 #. Click :guilabel:`Start scan`.
@@ -351,7 +351,7 @@ To perform the test, complete the following steps:
 #. In the terminal emulator, enter any text, for example ``Hello``.
 
    The data is transmitted to the DK that runs the Peripheral UART sample.
-   The **UART TX** characteristic displayed in the Bluetooth Low Energy app changes to the corresponding ASCII value.
+   The **UART TX** characteristic displayed in the app changes to the corresponding ASCII value.
    For example, the value for ``Hello`` is ``48 65 6C 6C 6F``.
 
 Dependencies


### PR DESCRIPTION
NCSDK-30523
Changing testing tool links from nRF Connect for Desktop to Bluetooth Low Energy app.