### PR TITLE
suit: Add API to halt Cortex cores

### DIFF
--- a/subsys/suit/platform/sdfw/include/suit_cpu_run.h
+++ b/subsys/suit/platform/sdfw/include/suit_cpu_run.h
@@ -15,6 +15,20 @@ extern "C" {
 #endif
 
 /**
+ * @brief Halt specified CPU.
+ *
+ * @note Implementation depends on SoC on which it's built.
+ *
+ * @param[in] cpu_id  ID of CPU to be halted
+ *
+ * @retval SUIT_PLAT_SUCCESS          in case of successful halt
+ * @retval SUIT_PLAT_ERR_CRASH        if CPU halt failed
+ * @retval SUIT_PLAT_ERR_UNSUPPORTED  if handling CPU halt is not supported
+ * @retval SUIT_PLAT_ERR_INVAL        if CPU ID is unknown
+ */
+suit_plat_err_t suit_plat_cpu_halt(uint8_t cpu_id);
+
+/**
  * @brief Run specified CPU.
  *
  * @note Implementation depends on SoC on which it's built.

--- a/subsys/suit/platform/sdfw/src/runners/suit_run_nrf54h20.c
+++ b/subsys/suit/platform/sdfw/src/runners/suit_run_nrf54h20.c
@@ -18,6 +18,56 @@
 
 LOG_MODULE_REGISTER(suit_plat_run, CONFIG_SUIT_LOG_LEVEL);
 
+/** Bitmask indicating, which CPU IDs were invoked.
+ *
+ * @note Since it is not possible to invoke the same CPU twice or halt a CPU that
+ *       was not invoked, this value is used to detect those unsupported operations.
+ */
+static uint32_t running_cpus;
+
+suit_plat_err_t suit_plat_cpu_halt(uint8_t cpu_id)
+{
+	int ret = 0;
+
+	switch (cpu_id) {
+	case NRF_PROCESSOR_APPLICATION: /* AppCore */
+	case NRF_PROCESSOR_RADIOCORE:	/* RadioCore */
+#ifdef CONFIG_SDFW_RESET_HANDLING_ENABLED
+		if ((running_cpus & BIT(cpu_id)) != 0) {
+			LOG_ERR("Halting Cortex core %d not supported", cpu_id);
+			ret = SUIT_PLAT_ERR_UNSUPPORTED;
+		} else {
+			LOG_INF("Cortex core %d is not running - skip CPU halt", cpu_id);
+		}
+#else  /* CONFIG_SDFW_RESET_HANDLING_ENABLED */
+		LOG_WRN("Cortex core handling not supported - skip CPU %d halt", cpu_id);
+#endif /* CONFIG_SDFW_RESET_HANDLING_ENABLED */
+		break;
+
+	case NRF_PROCESSOR_SYSCTRL: /* SysCtrl */
+		LOG_ERR("Halting SysCtrl is not supported");
+		return SUIT_PLAT_ERR_UNSUPPORTED;
+
+	case NRF_PROCESSOR_PPR:	 /* PPR(VPR) */
+	case NRF_PROCESSOR_FLPR: /* FLPR(VPR) */
+		LOG_ERR("Application VPR %d halt is not supported in SUIT", cpu_id);
+		return SUIT_PLAT_ERR_UNSUPPORTED;
+
+	default:
+		LOG_ERR("Unsupported CPU ID: %d", cpu_id);
+		return SUIT_PLAT_ERR_INVAL;
+	}
+
+	if (ret != 0) {
+		LOG_ERR("Failed to halt CPU %d (err: %d)", cpu_id, ret);
+		return SUIT_PLAT_ERR_CRASH;
+	}
+
+	running_cpus &= ~BIT(cpu_id);
+
+	return SUIT_PLAT_SUCCESS;
+}
+
 suit_plat_err_t suit_plat_cpu_run(uint8_t cpu_id, uintptr_t run_address)
 {
 	int ret = 0;
@@ -26,9 +76,14 @@ suit_plat_err_t suit_plat_cpu_run(uint8_t cpu_id, uintptr_t run_address)
 	case NRF_PROCESSOR_APPLICATION: /* AppCore */
 	case NRF_PROCESSOR_RADIOCORE:	/* RadioCore */
 #ifdef CONFIG_SDFW_RESET_HANDLING_ENABLED
-		LOG_INF("Starting Cortex core %d from address 0x%lx", cpu_id, run_address);
-		/* Single run address implies no NSVTOR, so keep at reset value of 0x0. */
-		ret = reset_mgr_init_and_boot_processor(cpu_id, run_address, 0);
+		if ((running_cpus & BIT(cpu_id)) == 0) {
+			LOG_INF("Starting Cortex core %d from address 0x%lx", cpu_id, run_address);
+			/* Single run address implies no NSVTOR, so keep at reset value of 0x0. */
+			ret = reset_mgr_init_and_boot_processor(cpu_id, run_address, 0);
+		} else {
+			LOG_ERR("Cortex core %d is running - fail CPU start", cpu_id);
+			return SUIT_PLAT_ERR_INCORRECT_STATE;
+		}
 #else  /* CONFIG_SDFW_RESET_HANDLING_ENABLED */
 		LOG_WRN("Cortex core handling not supported - skip CPU %d start", cpu_id);
 #endif /* CONFIG_SDFW_RESET_HANDLING_ENABLED */
@@ -58,6 +113,8 @@ suit_plat_err_t suit_plat_cpu_run(uint8_t cpu_id, uintptr_t run_address)
 			ret);
 		return SUIT_PLAT_ERR_CRASH;
 	}
+
+	running_cpus |= BIT(cpu_id);
 
 	return SUIT_PLAT_SUCCESS;
 }

--- a/subsys/suit/platform/sdfw/src/runners/suit_run_posix.c
+++ b/subsys/suit/platform/sdfw/src/runners/suit_run_posix.c
@@ -17,6 +17,20 @@
 
 LOG_MODULE_REGISTER(suit_plat_run, CONFIG_SUIT_LOG_LEVEL);
 
+suit_plat_err_t suit_plat_cpu_halt(uint8_t cpu_id)
+{
+	switch (cpu_id) {
+	case NRF_PROCESSORPOSIX_1:
+	case NRF_PROCESSORPOSIX_2:
+		LOG_INF("Mock AppCore/RadioCore halt");
+		return SUIT_PLAT_SUCCESS;
+
+	default:
+		LOG_ERR("Unsupported CPU ID (%d)", cpu_id);
+		return SUIT_PLAT_ERR_INVAL;
+	}
+}
+
 suit_plat_err_t suit_plat_cpu_run(uint8_t cpu_id, uintptr_t run_address)
 {
 	switch (cpu_id) {


### PR DESCRIPTION
Add internal API that allows to halt Cortex cores.

Ref: NCSDK-29997