### PR TITLE
applications: serial_lte_modem: Remove AT-command workarounds

### DIFF
--- a/applications/serial_lte_modem/src/gnss/slm_at_gnss.c
+++ b/applications/serial_lte_modem/src/gnss/slm_at_gnss.c
@@ -688,8 +688,7 @@ static void gnss_event_handler(int event)
 	}
 }
 
-SLM_AT_CMD_CUSTOM(xgps_set, "AT#XGPS=", handle_at_gps);
-SLM_AT_CMD_CUSTOM(xgps_read, "AT#XGPS?", handle_at_gps);
+SLM_AT_CMD_CUSTOM(xgps, "AT#XGPS", handle_at_gps);
 static int handle_at_gps(enum at_parser_cmd_type cmd_type, struct at_parser *parser,
 			 uint32_t param_count)
 {

--- a/applications/serial_lte_modem/src/gpio/slm_at_gpio.c
+++ b/applications/serial_lte_modem/src/gpio/slm_at_gpio.c
@@ -224,8 +224,7 @@ static int handle_at_gpio_configure(enum at_parser_cmd_type cmd_type,
 	return err;
 }
 
-SLM_AT_CMD_CUSTOM(xgpio_set, "AT#XGPIO=", handle_at_gpio_operate);
-SLM_AT_CMD_CUSTOM(xgpio_read, "AT#XGPIO?", handle_at_gpio_operate);
+SLM_AT_CMD_CUSTOM(xgpio, "AT#XGPIO", handle_at_gpio_operate);
 static int handle_at_gpio_operate(enum at_parser_cmd_type cmd_type, struct at_parser *parser,
 				  uint32_t)
 {

--- a/applications/serial_lte_modem/src/nrfcloud/slm_at_nrfcloud.c
+++ b/applications/serial_lte_modem/src/nrfcloud/slm_at_nrfcloud.c
@@ -540,8 +540,7 @@ static int nrf_cloud_datamode_callback(uint8_t op, const uint8_t *data, int len,
 	return ret;
 }
 
-SLM_AT_CMD_CUSTOM(xnrfcloud_set, "AT#XNRFCLOUD=", handle_at_nrf_cloud);
-SLM_AT_CMD_CUSTOM(xnrfcloud_read, "AT#XNRFCLOUD?", handle_at_nrf_cloud);
+SLM_AT_CMD_CUSTOM(xnrfcloud, "AT#XNRFCLOUD", handle_at_nrf_cloud);
 static int handle_at_nrf_cloud(enum at_parser_cmd_type cmd_type, struct at_parser *parser,
 			       uint32_t param_count)
 {

--- a/applications/serial_lte_modem/src/slm_at_socket.c
+++ b/applications/serial_lte_modem/src/slm_at_socket.c
@@ -972,8 +972,7 @@ static int socket_datamode_callback(uint8_t op, const uint8_t *data, int len, ui
 	return ret;
 }
 
-SLM_AT_CMD_CUSTOM(xsocket_set, "AT#XSOCKET=", handle_at_socket);
-SLM_AT_CMD_CUSTOM(xsocket_read, "AT#XSOCKET?", handle_at_socket);
+SLM_AT_CMD_CUSTOM(xsocket, "AT#XSOCKET", handle_at_socket);
 static int handle_at_socket(enum at_parser_cmd_type cmd_type, struct at_parser *parser,
 			    uint32_t param_count)
 {
@@ -1040,8 +1039,7 @@ static int handle_at_socket(enum at_parser_cmd_type cmd_type, struct at_parser *
 	return err;
 }
 
-SLM_AT_CMD_CUSTOM(xssocket_set, "AT#XSSOCKET=", handle_at_secure_socket);
-SLM_AT_CMD_CUSTOM(xssocket_read, "AT#XSSOCKET?", handle_at_secure_socket);
+SLM_AT_CMD_CUSTOM(xssocket, "AT#XSSOCKET", handle_at_secure_socket);
 static int handle_at_secure_socket(enum at_parser_cmd_type cmd_type,
 				   struct at_parser *parser, uint32_t param_count)
 {
@@ -1405,16 +1403,6 @@ SLM_AT_CMD_CUSTOM(xsend, "AT#XSEND", handle_at_send);
 static int handle_at_send(enum at_parser_cmd_type cmd_type, struct at_parser *parser,
 			  uint32_t param_count)
 {
-	char at_cmd[32] = {0};
-	size_t at_cmd_size = sizeof(at_cmd);
-
-	if (util_string_get(parser, 0, at_cmd, &at_cmd_size)) {
-		return -EINVAL;
-	}
-	if (!strncasecmp(at_cmd, "AT#XSENDTO", strlen("AT#XSENDTO"))) {
-		return handle_at_sendto(cmd_type, parser, param_count);
-	}
-
 	int err = -EINVAL;
 	char data[SLM_MAX_PAYLOAD_SIZE + 1] = {0};
 	int size;
@@ -1440,8 +1428,7 @@ static int handle_at_send(enum at_parser_cmd_type cmd_type, struct at_parser *pa
 	return err;
 }
 
-SLM_AT_CMD_CUSTOM(xrecv_set, "AT#XRECV=", handle_at_recv);
-SLM_AT_CMD_CUSTOM(xrecv_read, "AT#XRECV?", handle_at_recv);
+SLM_AT_CMD_CUSTOM(xrecv, "AT#XRECV", handle_at_recv);
 static int handle_at_recv(enum at_parser_cmd_type cmd_type, struct at_parser *parser,
 			  uint32_t param_count)
 {

--- a/applications/serial_lte_modem/src/twi/slm_at_twi.c
+++ b/applications/serial_lte_modem/src/twi/slm_at_twi.c
@@ -160,8 +160,7 @@ static int handle_at_twi_list(enum at_parser_cmd_type cmd_type, struct at_parser
 	return err;
 }
 
-SLM_AT_CMD_CUSTOM(xtwiw_set, "AT#XTWIW=", handle_at_twi_write);
-SLM_AT_CMD_CUSTOM(xtwiw_read, "AT#XTWIW?", handle_at_twi_write);
+SLM_AT_CMD_CUSTOM(xtwiw, "AT#XTWIW", handle_at_twi_write);
 static int handle_at_twi_write(enum at_parser_cmd_type cmd_type, struct at_parser *parser,
 			       uint32_t param_count)
 {


### PR DESCRIPTION
Previously, AT_CMD_CUSTOM did not correctly handle multiple commands which started the same, but were of varying length. This was fixed some time ago, so remove the workarounds in SLM.