### PR TITLE
samples: dect_phy: dect_shell: sett: band 4 support

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -308,6 +308,7 @@ DECT NR+ samples
       This is not a full MAC implementation and not fully compliant with DECT NR+ MAC specification (`ETSI TS 103 636-4`_).
     * The ``startup_cmd`` command.
       This command is used to store shell commands to be run sequentially after bootup.
+    * Band 4 support for nRF9151 with modem firmware v1.0.2.
 
   * Updated:
 

--- a/samples/dect/dect_phy/dect_shell/README.rst
+++ b/samples/dect/dect_phy/dect_shell/README.rst
@@ -84,11 +84,16 @@ Examples
 
      dect sett --tx_pwr -16
 
-* Change the default band to ``2`` (has impact when automatic channel selection is used, in other words, the set channel is zero in ``dect rssi_scan`` or in ``dect mac beacon_start`` command):
+* Change the default band to ``2`` (has impact when automatic channel selection is used, in other words, when the set channel is zero in ``dect rssi_scan`` or in ``dect mac beacon_start`` command):
 
   .. code-block:: console
 
      dect sett -b 2
+
+.. caution::
+   There might be region-specific limitations for radio channel usage.
+   See Regulations and Channel frequency sections of the :ref:`nrfxlib:nrf_modem_dect_phy` page for using different DECT NR+ radio bands and channels in different regions.
+   Make sure to always measure the channel with the ``dect rssi_scan`` command before accessing the band.
 
 RSSI measurement
 ================

--- a/samples/dect/dect_phy/dect_shell/src/dect/common/dect_common.h
+++ b/samples/dect/dect_phy/dect_shell/src/dect/common/dect_common.h
@@ -196,10 +196,6 @@ typedef struct {
 
 /************************************************************************************************/
 
-/* Not in dect specs. This sub GHz band only with custom modem */
-#define DECT_PHY_SUPPORTED_CHANNEL_BAND_868_FREE_ISM_MIN 479
-#define DECT_PHY_SUPPORTED_CHANNEL_BAND_868_FREE_ISM_MAX 485
-
 /* Supported DECT bands. See ETSI TS 103 636-2 v1.3.1 Table 5.4.2-1. (3rd column) */
 
 #define DECT_PHY_SUPPORTED_CHANNEL_BAND1_MIN 1657
@@ -208,7 +204,6 @@ typedef struct {
 #define DECT_PHY_SUPPORTED_CHANNEL_BAND2_MIN 1680
 #define DECT_PHY_SUPPORTED_CHANNEL_BAND2_MAX 1700
 
-/* This sub GHz band only with custom modem */
 #define DECT_PHY_SUPPORTED_CHANNEL_BAND4_MIN 524
 #define DECT_PHY_SUPPORTED_CHANNEL_BAND4_MAX 552
 
@@ -217,8 +212,6 @@ typedef struct {
 
 #define DECT_PHY_SUPPORTED_CHANNEL_BAND22_MIN 1691
 #define DECT_PHY_SUPPORTED_CHANNEL_BAND22_MAX 1711
-
-#define DECT_PHY_BAND_IS_CUSTOM_LOW(x) (x == 4 || x == 868)
 
 /************************************************************************************************/
 

--- a/samples/dect/dect_phy/dect_shell/src/dect/common/dect_common_utils.c
+++ b/samples/dect/dect_phy/dect_shell/src/dect/common/dect_common_utils.c
@@ -355,9 +355,6 @@ bool dect_common_utils_channel_is_supported(uint16_t band_nbr, uint16_t channel,
 	} else if (band_nbr == 22) {
 		return (channel >= DECT_PHY_SUPPORTED_CHANNEL_BAND22_MIN &&
 			channel <= DECT_PHY_SUPPORTED_CHANNEL_BAND22_MAX);
-	} else if (band_nbr == 868) {
-		return (channel >= DECT_PHY_SUPPORTED_CHANNEL_BAND_868_FREE_ISM_MIN &&
-			channel <= DECT_PHY_SUPPORTED_CHANNEL_BAND_868_FREE_ISM_MAX);
 	} else {
 		return false;
 	}
@@ -375,8 +372,6 @@ uint16_t dect_common_utils_channel_max_on_band(uint16_t band_nbr)
 		return DECT_PHY_SUPPORTED_CHANNEL_BAND9_MAX;
 	} else if (band_nbr == 22) {
 		return DECT_PHY_SUPPORTED_CHANNEL_BAND22_MAX;
-	} else if (band_nbr == 868) {
-		return DECT_PHY_SUPPORTED_CHANNEL_BAND_868_FREE_ISM_MAX;
 	} else {
 		return 0;
 	}
@@ -394,8 +389,6 @@ uint16_t dect_common_utils_channel_min_on_band(uint16_t band_nbr)
 		return DECT_PHY_SUPPORTED_CHANNEL_BAND9_MIN;
 	} else if (band_nbr == 22) {
 		return DECT_PHY_SUPPORTED_CHANNEL_BAND22_MIN;
-	} else if (band_nbr == 868) {
-		return DECT_PHY_SUPPORTED_CHANNEL_BAND_868_FREE_ISM_MIN;
 	} else {
 		return 0;
 	}

--- a/samples/dect/dect_phy/dect_shell/src/dect/mac/dect_phy_mac_shell.c
+++ b/samples/dect/dect_phy/dect_shell/src/dect/mac/dect_phy_mac_shell.c
@@ -55,7 +55,8 @@ static const char dect_phy_mac_beacon_scan_usage_str[] =
 	"Options:\n"
 	"  -c <integer>,                        Channel nbr to be scanned for a beacon.\n"
 	"                                       Ranges: band #1: 1657-1677, band #2 1680-1700,\n"
-	"                                       band #9 1691-1711. Zero value: all in a set band.\n"
+	"                                       band #4 524-552, band #9 1703-1711,\n"
+	"                                       band #22 1691-1711. Zero value: all in a set band.\n"
 	"                                       Default: 1665.\n"
 	"  -t, --scan_time <integer>,           Scanning duration in seconds (default: 4 "
 	"seconds).\n"
@@ -186,7 +187,8 @@ static const char dect_phy_mac_beacon_start_cmd_usage_str[] =
 	"Options:\n"
 	"  -c <integer>,               Used channel for a beacon.\n"
 	"                              Ranges: band #1: 1657-1677 (only odd numbers),\n"
-	"                              band #2 1680-1700, band #9 1691-1711.\n"
+	"                              band #2 1680-1700, band #4 524-552, band #9 1703-1711,\n"
+	"                              band #22 1691-1711.\n"
 	"                              Default: 0, i.e. automatic selection of\n"
 	"                              free/possible channel on a set band.\n"
 	"  -p, --tx_pwr <dbm>,         Set beacon broadcast power (dBm), default: -16.\n"
@@ -273,7 +275,7 @@ static const char dect_phy_mac_associate_cmd_usage_str[] =
 	"  -m, --tx_mcs <integer>, TX MCS (integer). Default: 0.\n"
 	"Note: LBT (Listen Before Talk) is enabled as a default for a min period,\n"
 	"      but the LBT max RSSI threshold can be configured in settings\n"
-	"      (dect sett ----rssi_scan_busy_th <dbm>).\n";
+	"      (dect sett --rssi_scan_busy_th <dbm>).\n";
 
 /* Specifying the expected options (both long and short): */
 static struct option long_options_associate[] = {{"tx_pwr", required_argument, 0, 'p'},
@@ -356,7 +358,7 @@ static const char dect_phy_mac_dissociate_cmd_usage_str[] =
 	"  -m, --tx_mcs <integer>, TX MCS (integer). Default: 0.\n"
 	"Note: LBT (Listen Before Talk) is enabled as a default for a min period,\n"
 	"      but the LBT max RSSI threshold can be configured in settings\n"
-	"      (dect sett ----rssi_scan_busy_th <dbm>).\n";
+	"      (dect sett --rssi_scan_busy_th <dbm>).\n";
 
 /* Specifying the expected options (both long and short): */
 static struct option long_options_dissociate[] = {
@@ -443,7 +445,7 @@ static const char dect_phy_mac_rach_tx_cmd_usage_str[] =
 	"                                  is encoded in JSON.\n"
 	"Note: LBT (Listen Before Talk) is enabled as a default for a min period,\n"
 	"      but the LBT max RSSI threshold can be configured in settings\n"
-	"      (dect sett ----rssi_scan_busy_th <dbm>).\n";
+	"      (dect sett --rssi_scan_busy_th <dbm>).\n";
 
 #define DECT_PHY_MAC_RACH_TX_DATA_JSON_OVERHEAD 30
 


### PR DESCRIPTION
Doing PHY API initialization when changing from/to band 4. 
Additionally, removing free-ISM support from code.
Note: band #4 support only with nRF9151 and modem mfw 1.0.2.
Jira: MOSH-622