### PR TITLE
samples: psa_tls: Add short delay between creating sockets

### DIFF
--- a/samples/crypto/psa_tls/src/psa_tls_functions_server.c
+++ b/samples/crypto/psa_tls/src/psa_tls_functions_server.c
@@ -132,5 +132,8 @@ void process_psa_tls(void)
 		LOG_INF("Closing TLS connection");
 		(void)close(client);
 		(void)close(sock);
+
+		/* Give some time to properly close sockets before creating new ones */
+		k_sleep(K_MSEC(200));
 	}
 }


### PR DESCRIPTION
Added 200ms sleep after closing server socket to prevent "port in use" errors when creating a new socket.