### PR TITLE
samples: nrf_rpc: ps: fix shell commands after server restart

### DIFF
--- a/samples/nrf_rpc/protocols_serialization/client/src/main.c
+++ b/samples/nrf_rpc/protocols_serialization/client/src/main.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include "ot_shell.h"
+
 #include <zephyr/logging/log.h>
 
 #include <nrf_rpc.h>
@@ -25,6 +27,7 @@ static void bound_handler(const struct nrf_rpc_group *group)
 	if (group == &ot_group) {
 		if (ot_group_initialized) {
 			LOG_WRN("OT RPC peer reset detected");
+			ot_shell_server_restarted();
 			/* The code to restore the state of OT on the server can be added here */
 		} else {
 			ot_group_initialized = true;

--- a/samples/nrf_rpc/protocols_serialization/client/src/ot_shell.c
+++ b/samples/nrf_rpc/protocols_serialization/client/src/ot_shell.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include "ot_shell.h"
+
 #include <zephyr/shell/shell.h>
 #include <zephyr/net/net_ip.h>
 
@@ -18,6 +20,7 @@
 
 #include <string.h>
 
+static bool ot_cli_is_initialized;
 static otUdpSocket udp_socket;
 static const char udp_payload[] = "Hello OpenThread World!";
 #define PORT 1212
@@ -33,14 +36,12 @@ static int ot_cli_output_cb(void *context, const char *format, va_list arg)
 
 static void ot_cli_lazy_init(const struct shell *sh)
 {
-	static bool is_initialized;
-
-	if (is_initialized) {
+	if (ot_cli_is_initialized) {
 		return;
 	}
 
 	otCliInit(NULL, ot_cli_output_cb, (void *)sh);
-	is_initialized = true;
+	ot_cli_is_initialized = true;
 }
 
 typedef otError(*ot_cli_command_handler_t)(const struct shell *, size_t argc, char *argv[]);
@@ -764,3 +765,8 @@ SHELL_CMD_ARG_REGISTER(ot, &ot_cmds,
 		       "OpenThread subcommands\n"
 		       "Use \"ot help\" to get the list of subcommands",
 		       cmd_ot, 2, 255);
+
+void ot_shell_server_restarted(void)
+{
+	ot_cli_is_initialized = false;
+}

--- a/samples/nrf_rpc/protocols_serialization/client/src/ot_shell.h
+++ b/samples/nrf_rpc/protocols_serialization/client/src/ot_shell.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef OT_SHELL_H_
+#define OT_SHELL_H_
+
+void ot_shell_server_restarted(void);
+
+#endif


### PR DESCRIPTION
When server restarts, clear the flag indicating that the CLI has already been initialized on the server, so that it is re-initialized before the next otCliInputLine().