### PR TITLE
samples: matter: Update release reference sample to 2.9.0 reference

### DIFF
--- a/samples/matter/light_bulb/sample.yaml
+++ b/samples/matter/light_bulb/sample.yaml
@@ -100,11 +100,3 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     tags: sysbuild ci_samples_matter
-  sample.matter.light_bulb.debug.reference:
-    sysbuild: true
-    build_only: true
-    integration_platforms:
-      - nrf54l15dk/nrf54l15/cpuapp
-    extra_args: light_bulb_SNIPPET="diagnostic-logs"
-    platform_allow: nrf54l15dk/nrf54l15/cpuapp
-    tags: sysbuild ci_samples_matter

--- a/samples/matter/smoke_co_alarm/sample.yaml
+++ b/samples/matter/smoke_co_alarm/sample.yaml
@@ -41,3 +41,11 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
     platform_allow: nrf54l15dk/nrf54l15/cpuapp
     tags: sysbuild ci_samples_matter
+  sample.matter.smoke_co_alarm.debug.reference:
+    sysbuild: true
+    build_only: true
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
+    extra_args: smoke_co_alarm_SNIPPET="diagnostic-logs"
+    platform_allow: nrf54l15dk/nrf54l15/cpuapp
+    tags: sysbuild ci_samples_matter


### PR DESCRIPTION
In incoming release we are going to focus the most onsmoke co alarm. This PR removes our release reference sample for 2.8.0 ncs realease and adds smoke co alarm on nRF54L15 with diagnostic logs as a new reference.