### PR TITLE
samples: bluetooth: Add CONFIG_FPU to ranging requestor sample

### DIFF
--- a/samples/bluetooth/channel_sounding_ras_initiator/prj.conf
+++ b/samples/bluetooth/channel_sounding_ras_initiator/prj.conf
@@ -34,4 +34,8 @@ CONFIG_BT_CTLR_DATA_LENGTH_MAX=251
 # This allows CS and ACL to use different PHYs
 CONFIG_BT_TRANSMIT_POWER_CONTROL=y
 
+# This improves the performance of floating-point operations
+CONFIG_FPU=y
+CONFIG_FPU_SHARING=y
+
 CONFIG_CBPRINTF_FP_SUPPORT=y


### PR DESCRIPTION
Using the FPU to accelerate floating point operations improves the runtime performance of estimate_distance() significantly.

runtime without FPU: ~13.5 ms
runtime with FPU:    ~7ms