### PR TITLE
samples: Bluetooth: 54H20 support for iso_combined_bis_and_cis sample

### DIFF
--- a/samples/bluetooth/iso_combined_bis_and_cis/sample.yaml
+++ b/samples/bluetooth/iso_combined_bis_and_cis/sample.yaml
@@ -10,9 +10,11 @@ tests:
       - nrf52833dk/nrf52833
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52833dk/nrf52833
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
     tags: bluetooth ci_build sysbuild


### PR DESCRIPTION
Added 54H20 to sample.yaml for iso_combined_bis_and_cis