### PR TITLE
doc: nRF5340 audio fixes

### DIFF
--- a/applications/nrf5340_audio/doc/building.rst
+++ b/applications/nrf5340_audio/doc/building.rst
@@ -42,19 +42,27 @@ You can now program the development kit.
 Building and programming using script
 *************************************
 
-The suggested method for building each of the applications and programming it to the development kit is running the :file:`buildprog.py` Python script, which is located in the :file:`applications/nrf5340_audio/tools/buildprog` directory.
+The suggested method for building each of the applications and programming it to the development kit is running the :file:`buildprog.py` Python script.
 The script automates the process of selecting :ref:`configuration files <nrf53_audio_app_configuration_files>` and building different applications.
 This eases the process of building and programming images for multiple development kits.
+
+The script is located in the :file:`applications/nrf5340_audio/tools/buildprog` directory.
 
 Preparing the JSON file
 =======================
 
 The script depends on the settings defined in the :file:`nrf5340_audio_dk_devices.json` file.
-Before using the script, make sure to update this file with the following information for each development kit you want to use:
+Before using the script, make sure to update this file with the following information for each development kit you want to use.
+This is how the file looks by default:
+
+.. literalinclude:: ../tools/buildprog/nrf5340_audio_dk_devices.json
+    :language: json
+
+When preparing the JSON file, update the following fields:
 
 * ``nrf5340_audio_dk_snr`` -- This field lists the SEGGER serial number.
-  You can check this number on the sticker on the nRF5340 Audio development kit.
-  Alternatively, connect the development kit to your PC and run ``nrfjprog -i`` in a command window to print the SEGGER serial number of the kit.
+  You can check this ten-digit number on the sticker on the nRF5340 Audio development kit.
+  Alternatively, connect the development kit to your PC and run ``nrfjprog -i`` in a command window to print the SEGGER serial number of all connected kits.
 * ``nrf5340_audio_dk_dev`` -- This field assigns the specific nRF5340 Audio development kit to be ``headset`` or ``gateway``.
 * ``channel`` -- This field is valid only for headsets.
   It sets the channels on which the headset is meant to work.
@@ -65,107 +73,137 @@ Before using the script, make sure to update this file with the following inform
 Running the script
 ==================
 
+The script handles building and parallel programming of multiple kits.
+The following sections explain these two steps separately.
+
+Script parameters for building
+------------------------------
+
 After editing the :file:`nrf5340_audio_dk_devices.json` file, run :file:`buildprog.py` to build the firmware for the development kits.
 The building command for running the script requires providing the following parameters:
 
-* Core type (``-c`` parameter): ``app``, ``net``, or ``both``
-* Application version (``-b`` parameter): either ``release`` or ``debug``
-* Device type (``-d`` parameter): ``headset``, ``gateway``, or ``both``
+.. list-table:: Parameters for the script
+   :header-rows: 1
 
-See the following examples of the parameter usage with the command run from the :file:`buildprog` directory:
+   * - Parameter
+     - Description
+     - Options
+     - More information
+   * - Core type (``-c``)
+     - Specifies the core type.
+     - ``app``, ``net``, ``both``
+     - :ref:`nrf53_audio_app_overview_architecture`
+   * - Application version (``-b``)
+     - Specifies the application version.
+     - ``release``, ``debug``
+     - | :ref:`nrf53_audio_app_configuration_files`
+       | **Note:** For FOTA DFU, you must use :ref:`nrf53_audio_app_building_standard`.
+   * - Device type (``-d``)
+     - Specifies the device type.
+     - ``headset``, ``gateway``, ``both``
+     - :ref:`nrf53_audio_app_overview_gateway_headsets`
 
-* Example 1: The following command builds headset and gateway applications using the script for the application core with the ``debug`` application version:
+For example, the following command builds headset and gateway applications using the script for the application core with the ``debug`` application version:
 
-  .. code-block:: console
+.. code-block:: console
 
-     python buildprog.py -c app -b debug -d both
+   python buildprog.py -c app -b debug -d both
 
 The command can be run from any location, as long as the correct path to :file:`buildprog.py` is given.
 
-The build files are saved in the :file:`applications/nrf5340_audio/build` directory.
+The build files are saved in separate subdirectories in the :file:`applications/nrf5340_audio/build` directory.
 The script creates a directory for each application version and device type combination.
 For example, when running the command above, the script creates the :file:`dev_gateway/build_debug` and :file:`dev_headset/build_debug` directories.
 
-Programming with the script
-   The development kits are programmed according to the serial numbers set in the JSON file.
-   Make sure to connect the development kits to your PC using USB and turn them on using the **POWER** switch before you run the command.
+Script parameters for programming
+---------------------------------
 
-   The following parameters are available for programming:
+The script can program the build files as part of the same `python buildprog.py` command used for building.
+Use one of the following programming parameters:
 
-   * Programming (``-p`` parameter) -- If you run the building script with this parameter, you can program one or both of the cores after building the files.
-   * Sequential programming (``-s`` parameter) -- If you encounter problems while programming, include this parameter alongside other parameters to program sequentially.
+* Programming (``-p`` parameter) -- If you run the ``buildprog`` script with this parameter, you can program one or both of the cores after building the files.
+* Sequential programming (``-s`` parameter) -- If you encounter problems while programming, include this parameter alongside other parameters to program sequentially.
 
-   The command for programming can look as follows:
+.. note::
+    The development kits are programmed according to the serial numbers set in the JSON file.
+    Make sure to connect the development kits to your PC using USB and turn them on using the **POWER** switch before you run the script with the programming parameter.
+
+The command for programming can look as follows:
+
+.. code-block:: console
+
+   python buildprog.py -c both -b debug -d both -p
+
+This command builds the headset and the gateway applications with ``debug`` version of both the application core binary and the network core binary - and programs each to its respective core.
+If you want to rebuild from scratch, you can add the ``--pristine`` parameter to the command (west's ``-p`` for cannot be used for a pristine build with the script).
+
+.. note::
+   If the programming command fails because of a :ref:`readback protection error <readback_protection_error>`, run :file:`buildprog.py` with the ``--recover_on_fail`` or ``-f`` parameter to recover and re-program automatically when programming fails.
+   For example, using the programming command example above:
 
    .. code-block:: console
 
-      python buildprog.py -c both -b debug -d both -p
-
-   This command builds the headset and the gateway applications with ``debug`` version of both the application core binary and the network core binary - and programs each to its respective core.
-
-   .. note::
-      If the programming command fails because of a :ref:`readback protection error <readback_protection_error>`, run :file:`buildprog.py` with the ``--recover_on_fail`` or ``-f`` parameter to recover and re-program automatically when programming fails.
-      For example, using the programming command example above:
-
-      .. code-block:: console
-
-         python buildprog.py -c both -b debug -d both -p --recover_on_fail
+      python buildprog.py -c both -b debug -d both -p --recover_on_fail
 
 Getting help
-   Run ``python buildprog.py -h`` for information about all available script parameters.
+------------
+
+Run ``python buildprog.py -h`` for information about all available script parameters.
 
 Configuration table overview
-   When running the script command, a table similar to the following one is displayed to provide an overview of the selected options and parameter values:
+----------------------------
 
-   .. code-block:: console
+When running the script command, a table similar to the following one is displayed to provide an overview of the selected options and parameter values:
 
-      +------------+----------+---------+--------------+---------------------+---------------------+
-      | snr        | snr conn | device  | only reboot  | core app programmed | core net programmed |
-      +------------+----------+---------+--------------+---------------------+---------------------+
-      | 1010101010 | True     | headset | Not selected | Selected TBD        | Not selected        |
-      | 2020202020 | True     | gateway | Not selected | Selected TBD        | Not selected        |
-      | 3030303030 | True     | headset | Not selected | Selected TBD        | Not selected        |
-      +------------+----------+---------+--------------+---------------------+---------------------+
+.. code-block:: console
 
-   See the following table for the meaning of each column and the list of possible values:
+   +------------+----------+---------+--------------+---------------------+---------------------+
+   | snr        | snr conn | device  | only reboot  | core app programmed | core net programmed |
+   +------------+----------+---------+--------------+---------------------+---------------------+
+   | 1010101010 | True     | headset | Not selected | Selected TBD        | Not selected        |
+   | 2020202020 | True     | gateway | Not selected | Selected TBD        | Not selected        |
+   | 3030303030 | True     | headset | Not selected | Selected TBD        | Not selected        |
+   +------------+----------+---------+--------------+---------------------+---------------------+
 
-   +-----------------------+-----------------------------------------------------------------------------------------------------+-------------------------------------------------+
-   | Column                | Indication                                                                                          | Possible values                                 |
-   +=======================+=====================================================================================================+=================================================+
-   | ``snr``               | Serial number of the device, as provided in the :file:`nrf5340_audio_dk_devices.json` file.         | Serial number.                                  |
-   +-----------------------+-----------------------------------------------------------------------------------------------------+-------------------------------------------------+
-   | ``snr conn``          | Whether the device with the provided serial number is connected to the PC with a serial connection. | ``True`` - Connected.                           |
-   |                       |                                                                                                     +-------------------------------------------------+
-   |                       |                                                                                                     | ``False`` - Not connected.                      |
-   +-----------------------+-----------------------------------------------------------------------------------------------------+-------------------------------------------------+
-   | ``device``            | Device type, as provided in the :file:`nrf5340_audio_dk_devices.json` file.                         | ``headset`` - Headset.                          |
-   |                       |                                                                                                     +-------------------------------------------------+
-   |                       |                                                                                                     | ``gateway`` - Gateway.                          |
-   +-----------------------+-----------------------------------------------------------------------------------------------------+-------------------------------------------------+
-   | ``only reboot``       | Whether the device is to be only reset and not programmed.                                          | ``Not selected`` - No reset.                    |
-   |                       | This depends on the ``-r`` parameter in the command, which overrides other parameters.              +-------------------------------------------------+
-   |                       |                                                                                                     | ``Selected TBD`` - Only reset requested.        |
-   |                       |                                                                                                     +-------------------------------------------------+
-   |                       |                                                                                                     | ``Done`` - Reset done.                          |
-   |                       |                                                                                                     +-------------------------------------------------+
-   |                       |                                                                                                     | ``Failed`` - Reset failed.                      |
-   +-----------------------+-----------------------------------------------------------------------------------------------------+-------------------------------------------------+
-   |``core app programmed``| Whether the application core is to be programmed.                                                   | ``Not selected`` - Core will not be programmed. |
-   |                       | This depends on the value provided to the ``-c`` parameter (see above).                             +-------------------------------------------------+
-   |                       |                                                                                                     | ``Selected TBD`` - Programming requested.       |
-   |                       |                                                                                                     +-------------------------------------------------+
-   |                       |                                                                                                     | ``Done`` - Programming done.                    |
-   |                       |                                                                                                     +-------------------------------------------------+
-   |                       |                                                                                                     | ``Failed`` - Programming failed.                |
-   +-----------------------+-----------------------------------------------------------------------------------------------------+-------------------------------------------------+
-   |``core net programmed``| Whether the network core is to be programmed.                                                       | ``Not selected`` - Core will not be programmed. |
-   |                       | This depends on the value provided to the ``-c`` parameter (see above).                             +-------------------------------------------------+
-   |                       |                                                                                                     | ``Selected TBD`` - Programming requested.       |
-   |                       |                                                                                                     +-------------------------------------------------+
-   |                       |                                                                                                     | ``Done`` - Programming done.                    |
-   |                       |                                                                                                     +-------------------------------------------------+
-   |                       |                                                                                                     | ``Failed`` - Programming failed.                |
-   +-----------------------+-----------------------------------------------------------------------------------------------------+-------------------------------------------------+
+See the following table for the meaning of each column and the list of possible values:
+
++-----------------------+-----------------------------------------------------------------------------------------------------+-------------------------------------------------+
+| Column                | Indication                                                                                          | Possible values                                 |
++=======================+=====================================================================================================+=================================================+
+| ``snr``               | Serial number of the device, as provided in the :file:`nrf5340_audio_dk_devices.json` file.         | Serial number.                                  |
++-----------------------+-----------------------------------------------------------------------------------------------------+-------------------------------------------------+
+| ``snr conn``          | Whether the device with the provided serial number is connected to the PC with a serial connection. | ``True`` - Connected.                           |
+|                       |                                                                                                     +-------------------------------------------------+
+|                       |                                                                                                     | ``False`` - Not connected.                      |
++-----------------------+-----------------------------------------------------------------------------------------------------+-------------------------------------------------+
+| ``device``            | Device type, as provided in the :file:`nrf5340_audio_dk_devices.json` file.                         | ``headset`` - Headset.                          |
+|                       |                                                                                                     +-------------------------------------------------+
+|                       |                                                                                                     | ``gateway`` - Gateway.                          |
++-----------------------+-----------------------------------------------------------------------------------------------------+-------------------------------------------------+
+| ``only reboot``       | Whether the device is to be only reset and not programmed.                                          | ``Not selected`` - No reset.                    |
+|                       | This depends on the ``-r`` parameter in the command, which overrides other parameters.              +-------------------------------------------------+
+|                       |                                                                                                     | ``Selected TBD`` - Only reset requested.        |
+|                       |                                                                                                     +-------------------------------------------------+
+|                       |                                                                                                     | ``Done`` - Reset done.                          |
+|                       |                                                                                                     +-------------------------------------------------+
+|                       |                                                                                                     | ``Failed`` - Reset failed.                      |
++-----------------------+-----------------------------------------------------------------------------------------------------+-------------------------------------------------+
+|``core app programmed``| Whether the application core is to be programmed.                                                   | ``Not selected`` - Core will not be programmed. |
+|                       | This depends on the value provided to the ``-c`` parameter (see above).                             +-------------------------------------------------+
+|                       |                                                                                                     | ``Selected TBD`` - Programming requested.       |
+|                       |                                                                                                     +-------------------------------------------------+
+|                       |                                                                                                     | ``Done`` - Programming done.                    |
+|                       |                                                                                                     +-------------------------------------------------+
+|                       |                                                                                                     | ``Failed`` - Programming failed.                |
++-----------------------+-----------------------------------------------------------------------------------------------------+-------------------------------------------------+
+|``core net programmed``| Whether the network core is to be programmed.                                                       | ``Not selected`` - Core will not be programmed. |
+|                       | This depends on the value provided to the ``-c`` parameter (see above).                             +-------------------------------------------------+
+|                       |                                                                                                     | ``Selected TBD`` - Programming requested.       |
+|                       |                                                                                                     +-------------------------------------------------+
+|                       |                                                                                                     | ``Done`` - Programming done.                    |
+|                       |                                                                                                     +-------------------------------------------------+
+|                       |                                                                                                     | ``Failed`` - Programming failed.                |
++-----------------------+-----------------------------------------------------------------------------------------------------+-------------------------------------------------+
 
 .. _nrf53_audio_app_building_standard:
 
@@ -221,7 +259,7 @@ Complete the following steps to build the application:
       * For headset device: ``-DCONFIG_AUDIO_DEV=1``
       * For gateway device: ``-DCONFIG_AUDIO_DEV=2``
 
-   #. Choose the application version by using one of the following options:
+   #. Choose the application version (:ref:`nrf53_audio_app_building_config_files`) by using one of the following options:
 
       * For the debug version: No build flag needed.
       * For the release version: ``-DFILE_SUFFIX=release``
@@ -233,10 +271,24 @@ Complete the following steps to build the application:
 
       west build -b nrf5340_audio_dk/nrf5340/cpuapp --pristine -- -DCONFIG_AUDIO_DEV=1 -DFILE_SUFFIX=release
 
-   Unlike when :ref:`nrf53_audio_app_building_script`, this command creates the build files directly in the :file:`build` directory.
-   This means that you first need to program the headset development kits before you build and program gateway development kits.
-   Alternatively, you can add the ``-d`` parameter to the ``west`` command to specify a custom build folder. This lets you build firmware for both
-   headset and gateway before programming any development kits.
+   This command creates the build files for headset device directly in the :file:`build` directory.
+   What this means is that you cannot create build files for all devices you want to program, because the subsequent commands will overwrite the files in the :file:`build` directory.
+
+   To work around this standard west behavior, you can add the ``-d`` parameter to the ``west`` command to specify a custom build folder for each device.
+   This way, you can build firmware for headset and gateway to separate directories before programming the development kits.
+   Alternatively, you can use the :ref:`nrf53_audio_app_building_script`, which handles this automatically.
+
+Building the application for FOTA
+---------------------------------
+
+The following command example builds the application for :ref:`nrf53_audio_app_fota`:
+
+.. code-block:: console
+
+   west build -b nrf5340_audio_dk/nrf5340/cpuapp --pristine -- -DCONFIG_AUDIO_DEV=1 -DFILE_SUFFIX=fota
+
+The command uses ``-DFILE_SUFFIX=fota`` to pick :file:`prj_fota.conf` instead of the default :file:`prj.conf`.
+It also uses the ``--pristine`` to clean the existing directory before starting the build process.
 
 Programming the application
 ===========================
@@ -246,19 +298,21 @@ After building the files for the development kit you want to program, follow the
 When using the default CIS configuration, if you want to use two headset devices, you must also populate the UICR with the desired channel for each headset.
 Use the following commands, depending on which headset you want to populate:
 
-* Left headset:
+* Left headset (``--val 0``):
 
    .. code-block:: console
 
       nrfjprog --memwr 0x00FF80F4 --val 0
 
-* Right headset:
+* Right headset (``--val 1``):
 
    .. code-block:: console
 
       nrfjprog --memwr 0x00FF80F4 --val 1
 
-Select the correct board when prompted with the popup or add the ``--snr`` parameter followed by the SEGGER serial number of the correct board at the end of the ``nrfjprog`` command.
+Select the correct board when prompted with the popup.
+Alternatively, you can add the ``--snr`` parameter followed by the SEGGER serial number of the correct board at the end of the ``nrfjprog`` command.
+You can check the serial numbers of the connected devices with the ``nrfjprog -i`` command.
 
 .. note::
    |usb_known_issues|

--- a/applications/nrf5340_audio/doc/fota.rst
+++ b/applications/nrf5340_audio/doc/fota.rst
@@ -68,9 +68,17 @@ The first part of these names is based on :kconfig:option:`CONFIG_BT_DEVICE_NAME
    This is due to restrictions in the DFU system, and the error print is expected.
    The DFU process should still complete successfully.
 
+Building the FOTA configuration
+*******************************
+
+Use the :ref:`nrf53_audio_app_building_standard` procedure to build the nRF5340 Audio applications with the FOTA configuration.
+Make sure to provide the :ref:`correct configuration file <nrf53_audio_app_building_config_files>` :file:`prj_fota.conf` when running the build command.
+
+The :ref:`script-based method <nrf53_audio_app_building_script_running>` does not support building and programming the FOTA upgrades.
+
 .. _nrf53_audio_unicast_client_app_testing_steps_fota:
 
 Testing FOTA upgrades
-=====================
+*********************
 
 To test FOTA for the nRF5340 Audio application, ensure the application is in the DFU mode, and then follow the testing steps in the FOTA over Bluetooth Low Energy section of :ref:`ug_nrf53_developing_ble_fota` (you can skip the configuration steps).

--- a/applications/nrf5340_audio/doc/requirements.rst
+++ b/applications/nrf5340_audio/doc/requirements.rst
@@ -60,5 +60,8 @@ For each application, only one of the following :file:`.conf` files is included 
   No debug features are enabled in the release application version.
   When building using the command line, you must explicitly specify if :file:`prj_release.conf` is going to be included instead of :file:`prj.conf`.
   See :ref:`nrf53_audio_app_building` for details.
-
-This file contains the necessary configurations for nRF5340 Audio applications to run the :zephyr:code-sample:`bluetooth_hci_ipc` sample with :ref:`SoftDevice Controller for LE Isochronous Channels <nrfxlib:softdevice_controller_iso>` support.
+* :file:`prj_fota.conf` is the optional configuration file used for FOTA DFU.
+  When used, the build system builds the debug version of the application (:file:`prj.conf`), but with the features needed to perform DFU over Bluetooth LE.
+  It also includes bootloaders so that the applications on both the application core and network core can be updated.
+  When building using the command line, you must explicitly specify if :file:`prj_fota.conf` is going to be included instead of :file:`prj.conf`.
+  See :ref:`nrf53_audio_app_fota` for more information.

--- a/applications/nrf5340_audio/doc/requirements.rst
+++ b/applications/nrf5340_audio/doc/requirements.rst
@@ -61,5 +61,4 @@ For each application, only one of the following :file:`.conf` files is included 
   When building using the command line, you must explicitly specify if :file:`prj_release.conf` is going to be included instead of :file:`prj.conf`.
   See :ref:`nrf53_audio_app_building` for details.
 
-In addition, the application features the :file:`child_image` directory with :file:`hci_ipc.conf`.
 This file contains the necessary configurations for nRF5340 Audio applications to run the :zephyr:code-sample:`bluetooth_hci_ipc` sample with :ref:`SoftDevice Controller for LE Isochronous Channels <nrfxlib:softdevice_controller_iso>` support.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -202,7 +202,7 @@ Matter Bridge
 nRF5340 Audio
 -------------
 
-|no_changes_yet_note|
+* Updated the documentation for :ref:`nrf53_audio_app_building` with cross-links and additional information, based on user feedback.
 
 nRF Desktop
 -----------


### PR DESCRIPTION
- doc: nrf5340_audio: remove child image mention

   Removed the mention of the child image directory from the docs.
   The application uses sysbuild as other applications.
   This mention was a doc bug.
   OCT-3244 and NCSDK-30393.

- doc: nrf5340_audio: clarify building steps

   Provided extra information for the building steps, including
   cross-links. Updated configuration file list. Added a section on the
   FOTA page about building. TECHDOC-3100.