### PR TITLE
suit: Manifest allowing to check recovery button from companion

### DIFF
--- a/config/suit/templates/nrf54h20/default/v1/app_recovery_local_envelope.yaml.jinja2
+++ b/config/suit/templates/nrf54h20/default/v1/app_recovery_local_envelope.yaml.jinja2
@@ -65,6 +65,12 @@ SUIT_Envelope_Tagged:
           - suit-send-sysinfo-failure
     suit-invoke:
     - suit-directive-set-component-index: 0
+{%- if 'CONFIG_SUIT_RECOVERY_BUTTON' in app_recovery_img['config'] and app_recovery_img['config'][CONFIG_SUIT_RECOVERY_BUTTON] != ''  %}
+    - suit-directive-override-parameters:
+        suit-parameter-invoke-args:
+          suit-synchronous-invoke: True
+          suit-timeout: 1000
+{%- endif %}
     - suit-directive-invoke:
       - suit-send-record-failure
 

--- a/config/suit/templates/nrf54h20/default/v1/root_with_binary_nordic_top.yaml.jinja2
+++ b/config/suit/templates/nrf54h20/default/v1/root_with_binary_nordic_top.yaml.jinja2
@@ -16,6 +16,15 @@
 {%- else %}
   {%- set nordic_top = False %}
 {%- endif %}
+{%- if 'SB_CONFIG_SUIT_RECOVERY_APPLICATION_IMAGE_MANIFEST_APP_LOCAL_3' in sysbuild['config'] and sysbuild['config']['SB_CONFIG_SUIT_RECOVERY_APPLICATION_IMAGE_MANIFEST_APP_LOCAL_3'] != '' %}
+  {%- set mpi_app_recovery_local_vendor_name = main_config['config']['CONFIG_SUIT_MPI_APP_LOCAL_3_VENDOR_NAME']|default('nordicsemi.com') %}
+  {%- set mpi_app_recovery_local_class_name = main_config['config']['CONFIG_SUIT_MPI_APP_LOCAL_3_CLASS_NAME']|default('nRF54H20_sample_app_3') %}
+{%- endif %}
+{%- if app_recovery_img is defined and 'CONFIG_SUIT_RECOVERY_BUTTON' in app_recovery_img['config'] and app_recovery_img['config'][CONFIG_SUIT_RECOVERY_BUTTON] != ''  %}
+  {%- set recovery_button_check_on_invoke = True %}
+{%- else %}
+  {%- set recovery_button_check_on_invoke = False %}
+{%- endif %}
 SUIT_Envelope_Tagged:
   suit-authentication-wrapper:
     SuitDigest:
@@ -33,14 +42,14 @@ SUIT_Envelope_Tagged:
       suit-components:
       - - CAND_MFST
         - 0
-{%- if radio is defined %}
+{% if recovery_button_check_on_invoke %}
     {%- set component_index = component_index + 1 %}
-    {%- set rad_component_index = component_index %}
-    {{- component_list.append( rad_component_index ) or ""}}
+    {%- set app_recovery_local_component_index = component_index %}
+    {{- component_list.append( app_recovery_local_component_index ) or ""}}
       - - INSTLD_MFST
         - RFC4122_UUID:
-            namespace: {{ mpi_radio_vendor_name }}
-            name: {{ mpi_radio_class_name }}
+            namespace: {{ mpi_app_recovery_local_vendor_name }}
+            name: {{ mpi_app_recovery_local_class_name }}
 {%- endif %}
 {%- if application is defined %}
     {%- set component_index = component_index + 1 %}
@@ -50,6 +59,15 @@ SUIT_Envelope_Tagged:
         - RFC4122_UUID:
             namespace: {{ mpi_application_vendor_name }}
             name: {{ mpi_application_class_name }}
+{%- endif %}
+{%- if radio is defined %}
+    {%- set component_index = component_index + 1 %}
+    {%- set rad_component_index = component_index %}
+    {{- component_list.append( rad_component_index ) or ""}}
+      - - INSTLD_MFST
+        - RFC4122_UUID:
+            namespace: {{ mpi_radio_vendor_name }}
+            name: {{ mpi_radio_class_name }}
 {%- endif %}
 
 {%- set component_list_without_top = component_list[:] %}

--- a/samples/suit/smp_transfer/sysbuild/recovery.overlay
+++ b/samples/suit/smp_transfer/sysbuild/recovery.overlay
@@ -8,6 +8,6 @@
 
 / {
 	chosen {
-		recovery-button = &button0;
+		ncs,recovery-button = &button0;
 	};
 };

--- a/subsys/suit/recovery_button/Kconfig
+++ b/subsys/suit/recovery_button/Kconfig
@@ -4,9 +4,11 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+DT_CHOSEN_NCS_RECOVERY_BUTTON := ncs,recovery-button
+
 config SUIT_RECOVERY_BUTTON
 	bool "Enable SUIT enter recovery button checking on startup"
-	depends on $(dt_chosen_enabled,recovery-button)
+	depends on $(dt_chosen_enabled,$(DT_CHOSEN_NCS_RECOVERY_BUTTON))
 	select SSF_SUIT_SERVICE_ENABLED
 	help
 	  This will make the firmware check if the recovery button specified in the

--- a/subsys/suit/recovery_button/src/suit_recovery_button.c
+++ b/subsys/suit/recovery_button/src/suit_recovery_button.c
@@ -9,7 +9,7 @@
 #include <nrfx_gpiote.h>
 #include <sdfw/sdfw_services/suit_service.h>
 
-#define RECOVERY_BUTTON_NODE DT_CHOSEN(recovery_button)
+#define RECOVERY_BUTTON_NODE DT_CHOSEN(ncs_recovery_button)
 #define RECOVERY_BUTTON_PIN DT_GPIO_PIN(RECOVERY_BUTTON_NODE, gpios)
 #define RECOVERY_BUTTON_PORT_NUM DT_PROP(DT_GPIO_CTLR(RECOVERY_BUTTON_NODE, gpios), port)
 #define RECOVERY_BUTTON_FLAGS DT_GPIO_FLAGS(RECOVERY_BUTTON_NODE, gpios)
@@ -22,7 +22,7 @@
 #define RECOVERY_BUTTON_PRESSED(pin_value) (RECOVERY_BUTTON_FLAGS & GPIO_ACTIVE_LOW ? (!pin_value) \
 					    : pin_value)
 
-BUILD_ASSERT(DT_NODE_EXISTS(DT_CHOSEN(recovery_button)), "No recovery button chosen in dts");
+BUILD_ASSERT(DT_NODE_EXISTS(DT_CHOSEN(ncs_recovery_button)), "No recovery button chosen in dts");
 
 static int recovery_button_check(void)
 {

--- a/west.yml
+++ b/west.yml
@@ -241,7 +241,7 @@ manifest:
           upstream-sha: c6eaeda5a1c1c5dbb24dce7e027340cb8893a77b
           compare-by-default: false
     - name: suit-generator
-      revision: 9c5e8f16ef49e5ffbdeabc87ffd60b82b1fd72b0
+      revision: 8f9ce9039e6fb8584dc915944b2bc275856757c0
       path: modules/lib/suit-generator
     - name: suit-processor
       revision: c97fbb352687383378d9ee2f5017668ebaac9fc7


### PR DESCRIPTION
This commit adds the possibility to run a companion image which checks the need of entering foreground update mode based on pressing a button.