### PR TITLE
samples: Fix Wi-Fi and BLE combo radio test for 54H

### DIFF
--- a/samples/peripheral/radio_test/boards/nrf54h20dk_nrf54h20_cpurad_wifi_combo.overlay
+++ b/samples/peripheral/radio_test/boards/nrf54h20dk_nrf54h20_cpurad_wifi_combo.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&dppic020 {
+	status = "okay";
+	source-channels = < 0 1 >;
+	sink-channels = < 2 3 >;
+};

--- a/samples/wifi/radio_test/sample.yaml
+++ b/samples/wifi/radio_test/sample.yaml
@@ -77,6 +77,7 @@ tests:
     sysbuild: true
     build_only: true
     extra_args:
+      - FILE_SUFFIX=wifi_combo
       - radio_test_SHIELD="nrf7002eb_interposer_p1;nrf7002eb"
       - SNIPPET=nrf70-wifi
     integration_platforms:


### PR DESCRIPTION
When a combo radio test is used for 54H, the peripheral radio test uses the same console as Wi-Fi radio test causing UICR conflicts and failing to boot both APP and RAD.

Fix the conflicts by adding an overlay to use a separate console and also not to use APP RAM in RAD.

Fixes SHEL-3287.