### PR TITLE
samples: bluetooth: fast_pair: locator_tag: enable fprotect in mcuboot

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -301,7 +301,9 @@ Bluetooth samples
 Bluetooth Fast Pair samples
 ---------------------------
 
-|no_changes_yet_note|
+* :ref:`fast_pair_locator_tag` sample:
+
+  * Updated the MCUboot bootloader configuration for the :ref:`zephyr:nrf54l15dk_nrf54l15` board target to enable the :kconfig:option:`CONFIG_FPROTECT` Kconfig option that is used to protect the bootloader partition against memory corruption.
 
 Bluetooth Mesh samples
 ----------------------

--- a/samples/bluetooth/fast_pair/locator_tag/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -12,6 +12,3 @@ CONFIG_SPI_NOR=n
 # Optimize memory usage (Locator tag disables system clock for MCUboot image).
 CONFIG_NRF_GRTC_TIMER=n
 CONFIG_NRF_GRTC_START_SYSCOUNTER=n
-
-# Fprotect is currently not supported.
-CONFIG_FPROTECT=n


### PR DESCRIPTION
Enabled the CONFIG_FPROTECT Kconfig option in the MCUboot configuration for the nRF54L15 DK target that is part of the Fast Pair Locator Tag sample.

Ref: NCSDK-30725