### PR TITLE
snippets: nrf70-wifi: Increase 54H Wi-Fi RAM

### DIFF
--- a/snippets/nrf70-wifi/nrf54h20_cpuapp.overlay
+++ b/snippets/nrf70-wifi/nrf54h20_cpuapp.overlay
@@ -30,3 +30,13 @@
 		reg = < 0x1df000 DT_SIZE_K(24) >;
 	};
 };
+
+/delete-node/ &cpurad_ram0x_region;
+&cpuapp_ram0x_region {
+	status = "okay";
+	reg = <0x2f010000 DT_SIZE_K(436)>;
+	ranges = <0x0 0x2f010000 0x6e000>;
+	cpuapp_data: memory@1000 {
+		reg = <0x1000 DT_SIZE_K(432)>;
+	};
+};


### PR DESCRIPTION
Wi-Fi needs higher RAM, reinstate the same RAM as earlier custom shield (now removed) for 54H.