### PR TITLE
samples: Add support for nRF54L05/L10 build targets in some samples

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -286,9 +286,13 @@ Bluetooth samples
 
   * The :ref:`channel_sounding_ras_reflector` sample demonstrating how to implement a Channel Sounding Reflector that exposes the Ranging Responder GATT Service.
   * The :ref:`channel_sounding_ras_initiator` sample demonstrating basic distance estimation with Channel Sounding by setting up a Channel Sounding Initiator that acts as a Ranging Requestor GATT Client.
-  * Support for the ``nrf54l15dk/nrf54l05/cpuapp`` and ``nrf54l15dk/nrf54l10/cpuapp`` board targets in the following sample:
+  * Support for the ``nrf54l15dk/nrf54l05/cpuapp`` and ``nrf54l15dk/nrf54l10/cpuapp`` board targets in the following samples:
 
+    * :ref:`direct_test_mode`
     * :ref:`peripheral_hids_mouse`
+    * :ref:`peripheral_lbs`
+    * :ref:`power_profiling`
+    * :ref:`peripheral_uart`
 
 * Updated:
 
@@ -409,7 +413,7 @@ nRF5340 samples
 Peripheral samples
 ------------------
 
-|no_changes_yet_note|
+* Added support for the ``nrf54l15dk/nrf54l05/cpuapp`` and ``nrf54l15dk/nrf54l10/cpuapp`` board targets in the :ref:`radio_test` sample.
 
 PMIC samples
 ------------

--- a/samples/bluetooth/direct_test_mode/boards/nrf54l15dk_nrf54l05_cpuapp.conf
+++ b/samples/bluetooth/direct_test_mode/boards/nrf54l15dk_nrf54l05_cpuapp.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable the unsupported driver
+CONFIG_NRFX_TIMER0=n
+CONFIG_NRFX_TIMER1=n
+CONFIG_NRFX_TIMER2=n
+
+# Use necessary peripherals
+CONFIG_NRFX_TIMER20=y
+CONFIG_NRFX_TIMER10=y
+CONFIG_NRFX_GPPI=y

--- a/samples/bluetooth/direct_test_mode/boards/nrf54l15dk_nrf54l05_cpuapp.overlay
+++ b/samples/bluetooth/direct_test_mode/boards/nrf54l15dk_nrf54l05_cpuapp.overlay
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		ncs,dtm-uart = &uart20;
+	};
+};
+
+&uart20 {
+	status = "okay";
+	current-speed = <19200>;
+};
+
+&radio {
+	status = "okay";
+	/* This is a number of antennas that are available on antenna matrix
+	 * designed by Nordic. For more information see README.rst.
+	 */
+	dfe-antenna-num = <12>;
+	/* This is a setting that enables antenna 12 (in antenna matrix designed
+	 * by Nordic) for PDU. For more information see README.rst.
+	 */
+	dfe-pdu-antenna = <0x0>;
+
+	/* These are GPIO pin numbers that are provided to
+	 * Radio peripheral. The pins will be acquired by Radio to
+	 * drive antenna switching.
+	 * Pin numbers are selected to drive switches on antenna matrix
+	 * desinged by Nordic. For more information see README.rst.
+	 */
+	dfegpio0-gpios = <&gpio0 4 0>;
+	dfegpio1-gpios = <&gpio0 5 0>;
+	dfegpio2-gpios = <&gpio0 6 0>;
+	dfegpio3-gpios = <&gpio0 7 0>;
+};

--- a/samples/bluetooth/direct_test_mode/boards/nrf54l15dk_nrf54l10_cpuapp.conf
+++ b/samples/bluetooth/direct_test_mode/boards/nrf54l15dk_nrf54l10_cpuapp.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable the unsupported driver
+CONFIG_NRFX_TIMER0=n
+CONFIG_NRFX_TIMER1=n
+CONFIG_NRFX_TIMER2=n
+
+# Use necessary peripherals
+CONFIG_NRFX_TIMER20=y
+CONFIG_NRFX_TIMER10=y
+CONFIG_NRFX_GPPI=y

--- a/samples/bluetooth/direct_test_mode/boards/nrf54l15dk_nrf54l10_cpuapp.overlay
+++ b/samples/bluetooth/direct_test_mode/boards/nrf54l15dk_nrf54l10_cpuapp.overlay
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		ncs,dtm-uart = &uart20;
+	};
+};
+
+&uart20 {
+	status = "okay";
+	current-speed = <19200>;
+};
+
+&radio {
+	status = "okay";
+	/* This is a number of antennas that are available on antenna matrix
+	 * designed by Nordic. For more information see README.rst.
+	 */
+	dfe-antenna-num = <12>;
+	/* This is a setting that enables antenna 12 (in antenna matrix designed
+	 * by Nordic) for PDU. For more information see README.rst.
+	 */
+	dfe-pdu-antenna = <0x0>;
+
+	/* These are GPIO pin numbers that are provided to
+	 * Radio peripheral. The pins will be acquired by Radio to
+	 * drive antenna switching.
+	 * Pin numbers are selected to drive switches on antenna matrix
+	 * desinged by Nordic. For more information see README.rst.
+	 */
+	dfegpio0-gpios = <&gpio0 4 0>;
+	dfegpio1-gpios = <&gpio0 5 0>;
+	dfegpio2-gpios = <&gpio0 6 0>;
+	dfegpio3-gpios = <&gpio0 7 0>;
+};

--- a/samples/bluetooth/direct_test_mode/sample.yaml
+++ b/samples/bluetooth/direct_test_mode/sample.yaml
@@ -9,9 +9,12 @@ tests:
       - nrf5340dk/nrf5340/cpunet
       - nrf21540dk/nrf52840
       - nrf52840dk/nrf52840
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
     platform_allow: nrf5340dk/nrf5340/cpunet nrf21540dk/nrf52840 nrf52840dk/nrf52840
+                    nrf54l15dk/nrf54l05/cpuapp nrf54l15dk/nrf54l10/cpuapp
                     nrf54l15dk/nrf54l15/cpuapp nrf54h20dk/nrf54h20/cpurad
     tags: bluetooth ci_build sysbuild
   sample.bluetooth.direct_test_mode.hci:

--- a/samples/bluetooth/peripheral_lbs/sample.yaml
+++ b/samples/bluetooth/peripheral_lbs/sample.yaml
@@ -12,12 +12,14 @@ tests:
       - nrf5340dk/nrf5340/cpuapp/ns
       - thingy53/nrf5340/cpuapp
       - thingy53/nrf5340/cpuapp/ns
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840
       nrf5340dk/nrf5340/cpuapp nrf5340dk/nrf5340/cpuapp/ns thingy53/nrf5340/cpuapp
-      thingy53/nrf5340/cpuapp/ns nrf54l15dk/nrf54l15/cpuapp
-      nrf54h20dk/nrf54h20/cpuapp
+      thingy53/nrf5340/cpuapp/ns nrf54l15dk/nrf54l05/cpuapp nrf54l15dk/nrf54l10/cpuapp
+      nrf54l15dk/nrf54l15/cpuapp nrf54h20dk/nrf54h20/cpuapp
     tags: bluetooth ci_build sysbuild
   sample.bluetooth.peripheral_lbs_minimal:
     sysbuild: true

--- a/samples/bluetooth/peripheral_power_profiling/boards/nrf54l15dk_nrf54l05_cpuapp.conf
+++ b/samples/bluetooth/peripheral_power_profiling/boards/nrf54l15dk_nrf54l05_cpuapp.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_PM_DEVICE=y
+CONFIG_PM_DEVICE_RUNTIME=y

--- a/samples/bluetooth/peripheral_power_profiling/boards/nrf54l15dk_nrf54l05_cpuapp.overlay
+++ b/samples/bluetooth/peripheral_power_profiling/boards/nrf54l15dk_nrf54l05_cpuapp.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	aliases {
+		/delete-property/ sw2;
+		/delete-property/ sw3;
+	};
+};
+
+/delete-node/ &button2;
+/delete-node/ &button3;
+
+&uart20 {
+	zephyr,pm-device-runtime-auto;
+};

--- a/samples/bluetooth/peripheral_power_profiling/boards/nrf54l15dk_nrf54l10_cpuapp.conf
+++ b/samples/bluetooth/peripheral_power_profiling/boards/nrf54l15dk_nrf54l10_cpuapp.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_PM_DEVICE=y
+CONFIG_PM_DEVICE_RUNTIME=y

--- a/samples/bluetooth/peripheral_power_profiling/boards/nrf54l15dk_nrf54l10_cpuapp.overlay
+++ b/samples/bluetooth/peripheral_power_profiling/boards/nrf54l15dk_nrf54l10_cpuapp.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	aliases {
+		/delete-property/ sw2;
+		/delete-property/ sw3;
+	};
+};
+
+/delete-node/ &button2;
+/delete-node/ &button3;
+
+&uart20 {
+	zephyr,pm-device-runtime-auto;
+};

--- a/samples/bluetooth/peripheral_power_profiling/sample.yaml
+++ b/samples/bluetooth/peripheral_power_profiling/sample.yaml
@@ -11,9 +11,12 @@ tests:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
     platform_allow: nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp nrf5340dk/nrf5340/cpuapp/ns nrf54l15dk/nrf54l15/cpuapp
+      nrf5340dk/nrf5340/cpuapp nrf5340dk/nrf5340/cpuapp/ns nrf54l15dk/nrf54l05/cpuapp
+      nrf54l15dk/nrf54l10/cpuapp nrf54l15dk/nrf54l15/cpuapp
     tags: bluetooth ci_build sysbuild
 
   sample.bluetooth.peripheral_power_profiling.auto_conn_advert_lfrc_0dBm_100ms:

--- a/samples/bluetooth/peripheral_uart/boards/nrf54l15dk_nrf54l05_cpuapp.conf
+++ b/samples/bluetooth/peripheral_uart/boards/nrf54l15dk_nrf54l05_cpuapp.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable the unspupported UART0 driver
+CONFIG_NRFX_UARTE0=n

--- a/samples/bluetooth/peripheral_uart/boards/nrf54l15dk_nrf54l05_cpuapp.overlay
+++ b/samples/bluetooth/peripheral_uart/boards/nrf54l15dk_nrf54l05_cpuapp.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,nus-uart = &uart20;
+	};
+};

--- a/samples/bluetooth/peripheral_uart/boards/nrf54l15dk_nrf54l10_cpuapp.conf
+++ b/samples/bluetooth/peripheral_uart/boards/nrf54l15dk_nrf54l10_cpuapp.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable the unspupported UART0 driver
+CONFIG_NRFX_UARTE0=n

--- a/samples/bluetooth/peripheral_uart/boards/nrf54l15dk_nrf54l10_cpuapp.overlay
+++ b/samples/bluetooth/peripheral_uart/boards/nrf54l15dk_nrf54l10_cpuapp.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,nus-uart = &uart20;
+	};
+};

--- a/samples/bluetooth/peripheral_uart/sample.yaml
+++ b/samples/bluetooth/peripheral_uart/sample.yaml
@@ -7,7 +7,8 @@ tests:
     build_only: true
     platform_allow: nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840
       nrf5340dk/nrf5340/cpuapp nrf5340dk/nrf5340/cpuapp/ns thingy53/nrf5340/cpuapp
-      thingy53/nrf5340/cpuapp/ns nrf21540dk/nrf52840 nrf54l15dk/nrf54l15/cpuapp
+      thingy53/nrf5340/cpuapp/ns nrf21540dk/nrf52840 nrf54l15dk/nrf54l05/cpuapp
+      nrf54l15dk/nrf54l10/cpuapp nrf54l15dk/nrf54l15/cpuapp
       nrf54h20dk/nrf54h20/cpuapp nrf54h20dk/nrf54h20/cpurad
     integration_platforms:
       - nrf52dk/nrf52832
@@ -18,6 +19,8 @@ tests:
       - thingy53/nrf5340/cpuapp
       - thingy53/nrf5340/cpuapp/ns
       - nrf21540dk/nrf52840
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54h20dk/nrf54h20/cpurad

--- a/samples/peripheral/radio_test/boards/nrf54l15dk_nrf54l05_cpuapp.conf
+++ b/samples/peripheral/radio_test/boards/nrf54l15dk_nrf54l05_cpuapp.conf
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable the unsupported driver
+CONFIG_NRFX_TIMER0=n
+
+# Enable the necessary drivers
+CONFIG_NRFX_TIMER10=y
+CONFIG_NRFX_GPPI=y

--- a/samples/peripheral/radio_test/boards/nrf54l15dk_nrf54l10_cpuapp.conf
+++ b/samples/peripheral/radio_test/boards/nrf54l15dk_nrf54l10_cpuapp.conf
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable the unsupported driver
+CONFIG_NRFX_TIMER0=n
+
+# Enable the necessary drivers
+CONFIG_NRFX_TIMER10=y
+CONFIG_NRFX_GPPI=y

--- a/samples/peripheral/radio_test/sample.yaml
+++ b/samples/peripheral/radio_test/sample.yaml
@@ -10,11 +10,14 @@ tests:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpunet
       - nrf7002dk/nrf5340/cpunet
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
     platform_allow: >
       nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpunet nrf7002dk/nrf5340/cpunet
-      nrf54l15dk/nrf54l15/cpuapp nrf54h20dk/nrf54h20/cpurad
+      nrf54l15dk/nrf54l05/cpuapp nrf54l15dk/nrf54l10/cpuapp nrf54l15dk/nrf54l15/cpuapp
+      nrf54h20dk/nrf54h20/cpurad
     tags: ci_build sysbuild ci_samples_peripheral_radio_test
   sample.peripheral.radio_test.nrf5340_nrf21540:
     sysbuild: true


### PR DESCRIPTION
The prioritized samples to add L05 and L10 targets were: BLE: peripheral_lbs, peripheral_uart, peripheral_power_profiling, direct_test_mode and peripheral:radio_test.