### PR TITLE
samples: matter: Enable ZMS in nRF54H20

### DIFF
--- a/applications/matter_bridge/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/applications/matter_bridge/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -13,6 +13,15 @@ CONFIG_MPU_STACK_GUARD=n
 CONFIG_PSA_SSF_CRYPTO_CLIENT=y
 CONFIG_SSF_PSA_CRYPTO_SERVICE_ENABLED=y
 
+# Disable Data Cache
+CONFIG_DCACHE=n
+
+# Set the ZMS sector count to match the settings partition size that is 32 kB for this application.
+CONFIG_SETTINGS_ZMS_SECTOR_COUNT=8
+# Workaround required as Zephyr L2 implies usage of NVS backend for settings.
+# It should be removed once the proper fix will be applied in Zephyr.
+CONFIG_NVS=n
+
 # TODO: Enable factory data once it is available
 CONFIG_CHIP_FACTORY_DATA=n
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -386,8 +386,11 @@ Keys samples
 Matter samples
 --------------
 
-* Updated all Matter samples that support low-power mode to enable the :ref:`lib_ram_pwrdn` feature.
-  It is enabled by default for the release configuration of the :ref:`matter_lock_sample`, :ref:`matter_light_switch_sample`, :ref:`matter_smoke_co_alarm_sample`, and :ref:`matter_window_covering_sample` samples.
+* Updated:
+
+  * All Matter samples that support low-power mode to enable the :ref:`lib_ram_pwrdn` feature.
+    It is enabled by default for the release configuration of the :ref:`matter_lock_sample`, :ref:`matter_light_switch_sample`, :ref:`matter_smoke_co_alarm_sample`, and :ref:`matter_window_covering_sample` samples.
+  * All Matter samples to enable the ZMS file subsystem in all devices that contain MRAM, such as the nRF54H Series devices.
 
 * :ref:`matter_template_sample` sample:
 

--- a/samples/matter/lock/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/samples/matter/lock/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -18,6 +18,12 @@ CONFIG_DCACHE=n
 # It will add the application firmware to the cache partition.
 CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE=y
 
+# Set the ZMS sector count to match the settings partition size that is 32 kB for this application.
+CONFIG_SETTINGS_ZMS_SECTOR_COUNT=8
+# Workaround required as Zephyr L2 implies usage of NVS backend for settings.
+# It should be removed once the proper fix will be applied in Zephyr.
+CONFIG_NVS=n
+
 # TODO: Enable factory data once it is available
 CONFIG_CHIP_FACTORY_DATA=n
 CONFIG_CHIP_CRYPTO_PSA_MIGRATE_DAC_PRIV_KEY=n

--- a/samples/matter/template/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/samples/matter/template/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -14,6 +14,12 @@ CONFIG_SSF_PSA_CRYPTO_SERVICE_ENABLED=y
 # Disable Data Cache
 CONFIG_DCACHE=n
 
+# Set the ZMS sector count to match the settings partition size that is 32 kB for this application.
+CONFIG_SETTINGS_ZMS_SECTOR_COUNT=8
+# Workaround required as Zephyr L2 implies usage of NVS backend for settings.
+# It should be removed once the proper fix will be applied in Zephyr.
+CONFIG_NVS=n
+
 # Enable cache processing for application core.
 # It will add the application firmware to the cache partition.
 CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE=y

--- a/west.yml
+++ b/west.yml
@@ -158,7 +158,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 6c1a9c51256fa3bea98bcdbf31d8a6aeef006a19
+      revision: 9a6edcf725a9766e513fe789745da92e0f640cb1
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
Enabled ZMS as Settings backend for nRF54H20 samples and other MRAM-based device that support it.