### PR TITLE
samples: bluetooth: fast_pair: input_device: Improve nRF54H20 memory map

### DIFF
--- a/samples/bluetooth/fast_pair/input_device/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/bluetooth/fast_pair/input_device/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -5,14 +5,12 @@
  */
 
 &mram1x {
-	/delete-node/ cpuapp_rw_partitions;
+	/delete-node/ cpuapp-rw-partitions;
 
 	cpuapp_rw_partitions: cpuapp-rw-partitions {
 		compatible = "nordic,owned-partitions", "fixed-partitions";
 		status = "okay";
-		perm-read;
-		perm-write;
-		perm-secure;
+		nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RWS>;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
@@ -20,13 +18,13 @@
 			reg = <0x100000 DT_SIZE_K(908)>;
 		};
 
-		storage_partition: partition@1e3000 {
-			reg = <0x1e3000 DT_SIZE_K(20)>;
+		/* Align the partition size to 4096 B to avoid gaps. */
+		bt_fast_pair_partition: partition@1e3000 {
+			reg = <0x1e3000 DT_SIZE_K(4)>;
 		};
 
-		bt_fast_pair_partition: partition@1e8fb8 {
-			label = "bt_fast_pair";
-			reg = <0x1e8fb8 0x48>;
+		storage_partition: partition@1e4000 {
+			reg = <0x1e4000 DT_SIZE_K(20)>;
 		};
 	};
 };


### PR DESCRIPTION
Puts Fast Pair provisioning partition right before the storage
partition.
Aligns partition sizes and addresses to be a multiple of 0x10, which is
the write block size for MRAM.
Keeps the storage partition at address divisible by 0x1000, as this is
the storage sector size.
Fixes the cpuapp_rw_partitions node deletion (earlier it was done
incorrectly).

Jira: NCSDK-30269