### PR TITLE
samples: dect_phy: dect_shell: ping client: LBT support

### DIFF
--- a/samples/dect/dect_phy/dect_shell/src/dect/dect_phy_shell.h
+++ b/samples/dect/dect_phy/dect_shell/src/dect/dect_phy_shell.h
@@ -106,6 +106,8 @@ struct dect_phy_ping_params {
 	int32_t ping_count;
 	int8_t tx_power_dbm;
 	uint8_t tx_mcs;
+	uint8_t tx_lbt_period_symbols;
+	int8_t tx_lbt_rssi_busy_threshold_dbm;
 	uint8_t slot_count;
 
 	int8_t expected_rx_rssi_level;


### PR DESCRIPTION
LBT can be enabled by using following hook:
--c_tx_lbt_period <symbol_count>, where range is 2-110. Zero disables LBT which is also a default.
Additionally, --c_tx_lbt_busy_th <dbm>, can be used to set a custom threshold for LBT busy channel detection. Default is from RSSI scan BUSY threshold from settings.
Jira: MOSH-633