### PR TITLE
tests: subsys: bluetooth: fast_pair: Add nRF54H20 support

### DIFF
--- a/tests/subsys/bluetooth/fast_pair/crypto/testcase.yaml
+++ b/tests/subsys/bluetooth/fast_pair/crypto/testcase.yaml
@@ -7,12 +7,14 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
     tags: sysbuild bluetooth
   fast_pair.crypto.psa:
     sysbuild: true
@@ -23,6 +25,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
@@ -30,6 +33,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54h20dk/nrf54h20/cpuapp
     extra_args: FILE_SUFFIX=psa
     tags: sysbuild bluetooth
   fast_pair.crypto.tinycrypt:
@@ -40,6 +44,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
       - qemu_cortex_m3
     integration_platforms:
       - nrf52dk/nrf52832
@@ -47,6 +52,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
       - qemu_cortex_m3
     extra_args: FILE_SUFFIX=tinycrypt
     tags: sysbuild bluetooth

--- a/tests/subsys/bluetooth/fast_pair/storage/account_key_storage/testcase.yaml
+++ b/tests/subsys/bluetooth/fast_pair/storage/account_key_storage/testcase.yaml
@@ -7,6 +7,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
       - qemu_cortex_m3
     integration_platforms:
       - nrf52dk/nrf52832
@@ -14,6 +15,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
       - qemu_cortex_m3
     tags: sysbuild bluetooth
   fast_pair.storage.account_key_storage.6keys:
@@ -64,6 +66,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
       - qemu_cortex_m3
     integration_platforms:
       - nrf52dk/nrf52832
@@ -71,6 +74,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
       - qemu_cortex_m3
     extra_args: CONFIG_TEST_BT_FAST_PAIR_STORAGE_OWNER_ACCOUNT_KEY=y
     tags: sysbuild bluetooth

--- a/tests/subsys/bluetooth/fast_pair/storage/factory_reset/testcase.yaml
+++ b/tests/subsys/bluetooth/fast_pair/storage/factory_reset/testcase.yaml
@@ -8,12 +8,14 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
     tags: sysbuild bluetooth
   fast_pair.storage.factory_reset.no_reboot:
     sysbuild: true
@@ -79,12 +81,14 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
     extra_args: CONFIG_TEST_BT_FAST_PAIR_STORAGE_OWNER_ACCOUNT_KEY=y
     tags: sysbuild bluetooth
   fast_pair.storage.factory_reset.ak_minimal_backend_no_reboot:


### PR DESCRIPTION
Adds nRF54H20 support in Fast Pair tests.

Jira: NCSDK-30335
Jira: NCSDK-30336