### PR TITLE
samples: peripheral_power_profiling: Add support for nRF54H20 target

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -290,6 +290,10 @@ Bluetooth samples
 
     * :ref:`peripheral_hids_mouse`
 
+  * :ref:`power_profiling` sample:
+
+    * Added support for the :ref:`zephyr:nrf54h20dk_nrf54h20` board target.
+
 * Updated:
 
   * Configurations of the following Bluetooth samples to make the :ref:`Zephyr Memory Storage (ZMS) <zephyr:zms_api>` the default settings backend for all board targets that use the MRAM technology:

--- a/samples/bluetooth/peripheral_power_profiling/README.rst
+++ b/samples/bluetooth/peripheral_power_profiling/README.rst
@@ -39,6 +39,9 @@ This is the deepest power saving mode the system can enter.
 In this mode, all core functionalities are powered down, and most peripherals are non-functional or non-responsive.
 The only mechanisms that are functional in this mode are reset and wake-up.
 
+.. note::
+   Currently, the **System off** mode is not supported by this sample for the nRF54H20 platform.
+
 To wake up your development kit from the system off state, you have the following options:
 
 .. tabs::

--- a/samples/bluetooth/peripheral_power_profiling/src/main.c
+++ b/samples/bluetooth/peripheral_power_profiling/src/main.c
@@ -644,8 +644,13 @@ static void reset_reason_print(void)
 		printk("Wake up by NFC field detected\n");
 	} else if (reason & NRFX_RESET_REASON_OFF_MASK) {
 		printk("Wake up by the advertising start buttons\n");
+#if defined(NRF_RESETINFO)
+	} else if (reason & NRFX_RESET_REASON_LOCAL_SREQ_MASK) {
+		printk("Application soft reset detected\n");
+#else
 	} else if (reason & NRFX_RESET_REASON_SREQ_MASK) {
 		printk("Application soft reset detected\n");
+#endif /* defined(NRF_RESETINFO) */
 	} else if (reason & NRFX_RESET_REASON_RESETPIN_MASK) {
 		printk("Reset from pin-reset\n");
 	} else if (reason) {
@@ -657,6 +662,7 @@ static void reset_reason_print(void)
 
 static void system_off(void)
 {
+#if !IS_ENABLED(CONFIG_SOC_SERIES_NRF54HX)
 	printk("Powering off\n");
 
 	/* Clear the reset reason if it didn't do previously. */
@@ -685,6 +691,7 @@ static void system_off(void)
 #endif
 
 	sys_poweroff();
+#endif /* !IS_ENABLED(CONFIG_SOC_SERIES_NRF54HX) */
 }
 
 static void system_off_work_handler(struct k_work *work)
@@ -696,9 +703,11 @@ static void advertising_terminated(struct bt_le_ext_adv *adv, struct bt_le_ext_a
 {
 	if (!device_conn) {
 		printk("Adverting set %p, terminated.\n", (void *)adv);
+#if !IS_ENABLED(CONFIG_SOC_SERIES_NRF54HX)
 		printk("Scheduling system off\n");
 
 		k_work_schedule(&system_off_work, K_SECONDS(1));
+#endif /* !IS_ENABLED(CONFIG_SOC_SERIES_NRF54HX) */
 	}
 }
 


### PR DESCRIPTION
Added support for the nrf54h20 board target.
Currently, the System off mode is not supported by this sample for the nRF54H20 platform.