### PR TITLE
samples: dect_phy: dect_shell: ping/perf/rf_tool: band #4 support

### DIFF
--- a/samples/dect/dect_phy/dect_shell/src/dect/perf/dect_phy_perf.c
+++ b/samples/dect/dect_phy/dect_shell/src/dect/perf/dect_phy_perf.c
@@ -1860,9 +1860,12 @@ static void dect_phy_perf_phy_init(struct nrf_modem_dect_phy_init_params *init_p
 int dect_phy_perf_cmd_handle(struct dect_phy_perf_params *params)
 {
 	int ret;
+	struct dect_phy_settings *current_settings = dect_common_settings_ref_get();
 	struct nrf_modem_dect_phy_init_params perf_phy_init_params = {
 		.harq_rx_expiry_time_us = params->mdm_init_harq_expiry_time_us,
 		.harq_rx_process_count = params->mdm_init_harq_process_count,
+		.reserved = 0,
+		.band4_support = ((current_settings->common.band_nbr == 4) ? 1 : 0),
 	};
 
 	if (perf_data.perf_ongoing) {

--- a/samples/dect/dect_phy/dect_shell/src/dect/ping/dect_phy_ping.c
+++ b/samples/dect/dect_phy/dect_shell/src/dect/ping/dect_phy_ping.c
@@ -2062,6 +2062,8 @@ int dect_phy_ping_cmd_handle(struct dect_phy_ping_params *params)
 	struct nrf_modem_dect_phy_init_params ping_phy_init_params = {
 		.harq_rx_expiry_time_us = current_settings->harq.mdm_init_harq_expiry_time_us,
 		.harq_rx_process_count = current_settings->harq.mdm_init_harq_process_count,
+		.reserved = 0,
+		.band4_support = ((current_settings->common.band_nbr == 4) ? 1 : 0),
 	};
 	int ret;
 

--- a/samples/dect/dect_phy/dect_shell/src/dect/rf_tool/dect_phy_rf_tool.c
+++ b/samples/dect/dect_phy/dect_shell/src/dect/rf_tool/dect_phy_rf_tool.c
@@ -881,6 +881,8 @@ static void dect_phy_rf_tool_phy_init(void)
 	struct nrf_modem_dect_phy_init_params rf_tool_phy_init_params = {
 		.harq_rx_expiry_time_us = current_settings->harq.mdm_init_harq_expiry_time_us,
 		.harq_rx_process_count = current_settings->harq.mdm_init_harq_process_count,
+		.reserved = 0,
+		.band4_support = ((current_settings->common.band_nbr == 4) ? 1 : 0),
 	};
 	int ret = nrf_modem_dect_phy_callback_set(&rf_tool_phy_api_config);
 


### PR DESCRIPTION
Adding B4 support also for ping, perf and rf_tool commands that are having their own mdm phy api initialization.
Jira: MOSH-622