### PR TITLE
applications, samples, tests: use native YAML lists in twister config

### DIFF
--- a/applications/asset_tracker_v2/sample.yaml
+++ b/applications/asset_tracker_v2/sample.yaml
@@ -17,7 +17,10 @@ tests:
       - thingy91/nrf9160/ns
       - thingy91x/nrf9151/ns
       - native_sim
-    tags: ci_build sysbuild ci_applications_asset_tracker_v2
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_asset_tracker_v2
   applications.asset_tracker_v2.nrf_cloud-pgps:
     sysbuild: true
     build_only: true
@@ -31,7 +34,10 @@ tests:
       - nrf9160dk/nrf9160/ns
       - thingy91/nrf9160/ns
     extra_args: EXTRA_CONF_FILE=overlay-pgps.conf
-    tags: ci_build sysbuild ci_applications_asset_tracker_v2
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_asset_tracker_v2
   applications.asset_tracker_v2.nrf_cloud-no-agnss:
     sysbuild: true
     build_only: true
@@ -46,7 +52,10 @@ tests:
       - nrf9160dk/nrf9160/ns
       - thingy91/nrf9160/ns
     extra_args: CONFIG_NRF_CLOUD_AGNSS=n
-    tags: ci_build sysbuild ci_applications_asset_tracker_v2
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_asset_tracker_v2
   applications.asset_tracker_v2.aws:
     sysbuild: true
     build_only: true
@@ -65,7 +74,10 @@ tests:
     extra_configs:
       - CONFIG_AWS_IOT_BROKER_HOST_NAME="example-hostname.aws.com"
     extra_args: EXTRA_CONF_FILE="overlay-aws.conf"
-    tags: ci_build sysbuild ci_applications_asset_tracker_v2
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_asset_tracker_v2
   applications.asset_tracker_v2.aws-pgps:
     sysbuild: true
     build_only: true
@@ -82,7 +94,10 @@ tests:
     extra_configs:
       - CONFIG_AWS_IOT_BROKER_HOST_NAME="example-hostname.aws.com"
     extra_args: EXTRA_CONF_FILE="overlay-aws.conf;overlay-pgps.conf"
-    tags: ci_build sysbuild ci_applications_asset_tracker_v2
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_asset_tracker_v2
   applications.asset_tracker_v2.aws-all:
     sysbuild: true
     build_only: true
@@ -100,7 +115,10 @@ tests:
       - CONFIG_MEMFAULT_NCS_PROJECT_KEY="PROJECTKEY"
     extra_args: >
       EXTRA_CONF_FILE="overlay-aws.conf;overlay-pgps.conf;overlay-debug.conf;overlay-memfault.conf"
-    tags: ci_build sysbuild ci_applications_asset_tracker_v2
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_asset_tracker_v2
   applications.asset_tracker_v2.azure:
     sysbuild: true
     build_only: true
@@ -120,7 +138,10 @@ tests:
       - CONFIG_AZURE_IOT_HUB_DPS_HOSTNAME="global.azure-devices-provisioning.net"
       - CONFIG_AZURE_IOT_HUB_DPS_ID_SCOPE="IDSCOPE"
     extra_args: EXTRA_CONF_FILE="overlay-azure.conf"
-    tags: ci_build sysbuild ci_applications_asset_tracker_v2
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_asset_tracker_v2
   applications.asset_tracker_v2.debug:
     sysbuild: true
     build_only: true
@@ -137,7 +158,10 @@ tests:
       - thingy91/nrf9160/ns
       - native_sim
     extra_args: EXTRA_CONF_FILE=overlay-debug.conf
-    tags: ci_build sysbuild ci_applications_asset_tracker_v2
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_asset_tracker_v2
   applications.asset_tracker_v2.debug-memfault:
     sysbuild: true
     build_only: true
@@ -154,7 +178,10 @@ tests:
     extra_configs:
       - CONFIG_MEMFAULT_NCS_PROJECT_KEY="PROJECTKEY"
     extra_args: EXTRA_CONF_FILE="overlay-debug.conf;overlay-memfault.conf"
-    tags: ci_build sysbuild ci_applications_asset_tracker_v2
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_asset_tracker_v2
   applications.asset_tracker_v2.memfault:
     sysbuild: true
     build_only: true
@@ -171,7 +198,10 @@ tests:
     extra_configs:
       - CONFIG_MEMFAULT_NCS_PROJECT_KEY="PROJECTKEY"
     extra_args: EXTRA_CONF_FILE=overlay-memfault.conf
-    tags: ci_build sysbuild ci_applications_asset_tracker_v2
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_asset_tracker_v2
   applications.asset_tracker_v2.low-power:
     sysbuild: true
     build_only: true
@@ -186,7 +216,10 @@ tests:
       - nrf9160dk/nrf9160/ns
       - thingy91/nrf9160/ns
     extra_args: EXTRA_CONF_FILE=overlay-low-power.conf
-    tags: ci_build sysbuild ci_applications_asset_tracker_v2
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_asset_tracker_v2
   applications.asset_tracker_v2.carrier.nrf9160dk:
     sysbuild: true
     build_only: true
@@ -196,16 +229,23 @@ tests:
     integration_platforms:
       - nrf9160dk/nrf9160/ns
     extra_args: EXTRA_CONF_FILE=overlay-carrier.conf
-    tags: ci_build sysbuild ci_applications_asset_tracker_v2
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_asset_tracker_v2
   applications.asset_tracker_v2.carrier.thingy91:
     sysbuild: true
     build_only: true
     build_on_all: true
     platform_allow:
       - thingy91/nrf9160/ns
-    extra_args: EXTRA_CONF_FILE=overlay-carrier.conf
-      SB_CONFIG_THINGY91_STATIC_PARTITIONS_LWM2M_CARRIER=y
-    tags: ci_build sysbuild ci_applications_asset_tracker_v2
+    extra_args:
+      - EXTRA_CONF_FILE=overlay-carrier.conf
+      - SB_CONFIG_THINGY91_STATIC_PARTITIONS_LWM2M_CARRIER=y
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_asset_tracker_v2
   applications.asset_tracker_v2.carrier.nrf9161dk:
     sysbuild: true
     build_only: true
@@ -214,7 +254,10 @@ tests:
     integration_platforms:
       - nrf9161dk/nrf9161/ns
     extra_args: EXTRA_CONF_FILE=overlay-carrier.conf
-    tags: ci_build sysbuild ci_applications_asset_tracker_v2
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_asset_tracker_v2
   applications.asset_tracker_v2.carrier.nrf9151dk:
     sysbuild: true
     build_only: true
@@ -223,7 +266,10 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
     extra_args: EXTRA_CONF_FILE=overlay-carrier.conf
-    tags: ci_build sysbuild ci_applications_asset_tracker_v2
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_asset_tracker_v2
   applications.asset_tracker_v2.lwm2m.bootstrap-low_power:
     sysbuild: true
     build_only: true
@@ -240,7 +286,10 @@ tests:
     extra_configs:
       - CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP=y
     extra_args: EXTRA_CONF_FILE="overlay-lwm2m.conf;overlay-low-power.conf"
-    tags: ci_build sysbuild ci_applications_asset_tracker_v2
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_asset_tracker_v2
   applications.asset_tracker_v2.lwm2m.debug:
     sysbuild: true
     build_only: true
@@ -254,7 +303,10 @@ tests:
       - nrf9160dk/nrf9160/ns
       - thingy91/nrf9160/ns
     extra_args: EXTRA_CONF_FILE="overlay-lwm2m.conf;overlay-debug.conf"
-    tags: ci_build sysbuild ci_applications_asset_tracker_v2
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_asset_tracker_v2
   applications.asset_tracker_v2.lwm2m.debug-modem_trace:
     sysbuild: true
     build_only: true
@@ -266,9 +318,12 @@ tests:
     integration_platforms:
       - nrf9160dk/nrf9160/ns
     extra_args:
-      EXTRA_CONF_FILE="overlay-lwm2m.conf;overlay-debug.conf"
-      asset_tracker_v2_SNIPPET="nrf91-modem-trace-uart;tfm-enable-share-uart"
-    tags: ci_build sysbuild ci_applications_asset_tracker_v2
+      - EXTRA_CONF_FILE="overlay-lwm2m.conf;overlay-debug.conf"
+      - asset_tracker_v2_SNIPPET="nrf91-modem-trace-uart;tfm-enable-share-uart"
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_asset_tracker_v2
   applications.asset_tracker_v2.lwm2m.modem_trace:
     sysbuild: true
     build_only: true
@@ -282,9 +337,12 @@ tests:
       - nrf9160dk/nrf9160/ns
       - thingy91/nrf9160/ns
     extra_args:
-      EXTRA_CONF_FILE="overlay-lwm2m.conf"
-      asset_tracker_v2_SNIPPET="nrf91-modem-trace-uart;tfm-enable-share-uart"
-    tags: ci_build sysbuild ci_applications_asset_tracker_v2
+      - EXTRA_CONF_FILE="overlay-lwm2m.conf"
+      - asset_tracker_v2_SNIPPET="nrf91-modem-trace-uart;tfm-enable-share-uart"
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_asset_tracker_v2
   applications.asset_tracker_v2.lwm2m.memfault:
     sysbuild: true
     build_only: true
@@ -303,7 +361,10 @@ tests:
       - CONFIG_MEMFAULT_NCS_PROJECT_KEY="PROJECTKEY"
       - CONFIG_LOG_MODE_MINIMAL=y
     extra_args: EXTRA_CONF_FILE="overlay-lwm2m.conf;overlay-memfault.conf"
-    tags: ci_build sysbuild ci_applications_asset_tracker_v2
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_asset_tracker_v2
   applications.asset_tracker_v2.memfault-low-power:
     sysbuild: true
     build_only: true
@@ -322,34 +383,55 @@ tests:
     extra_configs:
       - CONFIG_MEMFAULT_NCS_PROJECT_KEY="PROJECTKEY"
     extra_args: EXTRA_CONF_FILE="overlay-low-power.conf;overlay-memfault.conf"
-    tags: ci_build sysbuild ci_applications_asset_tracker_v2
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_asset_tracker_v2
   applications.asset_tracker_v2.nrf7002ek_wifi.nrf9160dk:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf9160dk/nrf9160/ns
     platform_allow: nrf9160dk/nrf9160/ns
-    extra_args: SHIELD=nrf7002ek_nrf7000 EXTRA_CONF_FILE=overlay-nrf7002ek-wifi-scan-only.conf
-                SB_CONFIG_WIFI_NRF70=y SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
-    tags: ci_build sysbuild ci_applications_asset_tracker_v2
+    extra_args:
+      - SHIELD=nrf7002ek_nrf7000
+      - EXTRA_CONF_FILE=overlay-nrf7002ek-wifi-scan-only.conf
+      - SB_CONFIG_WIFI_NRF70=y
+      - SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_asset_tracker_v2
   applications.asset_tracker_v2.nrf7002ek_wifi.nrf9161dk:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf9161dk/nrf9161/ns
     platform_allow: nrf9161dk/nrf9161/ns
-    extra_args: SHIELD=nrf7002ek_nrf7000 EXTRA_CONF_FILE=overlay-nrf7002ek-wifi-scan-only.conf
-                SB_CONFIG_WIFI_NRF70=y SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
-    tags: ci_build sysbuild ci_applications_asset_tracker_v2
+    extra_args:
+      - SHIELD=nrf7002ek_nrf7000
+      - EXTRA_CONF_FILE=overlay-nrf7002ek-wifi-scan-only.conf
+      - SB_CONFIG_WIFI_NRF70=y
+      - SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_asset_tracker_v2
   applications.asset_tracker_v2.nrf7002ek_wifi.nrf9151dk:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf9151dk/nrf9151/ns
     platform_allow: nrf9151dk/nrf9151/ns
-    extra_args: SHIELD=nrf7002ek_nrf7000 EXTRA_CONF_FILE=overlay-nrf7002ek-wifi-scan-only.conf
-                SB_CONFIG_WIFI_NRF70=y SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
-    tags: ci_build sysbuild ci_applications_asset_tracker_v2
+    extra_args:
+      - SHIELD=nrf7002ek_nrf7000
+      - EXTRA_CONF_FILE=overlay-nrf7002ek-wifi-scan-only.conf
+      - SB_CONFIG_WIFI_NRF70=y
+      - SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_asset_tracker_v2
   applications.asset_tracker_v2.nrf7002ek_wifi-debug:
     sysbuild: true
     build_only: true
@@ -361,11 +443,15 @@ tests:
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
       - nrf9151dk/nrf9151/ns
-    extra_args: SHIELD=nrf7002ek_nrf7000
-                EXTRA_CONF_FILE="overlay-nrf7002ek-wifi-scan-only.conf;overlay-debug.conf"
-                SB_CONFIG_WIFI_NRF70=y SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
-    tags: ci_build sysbuild ci_applications_asset_tracker_v2
-
+    extra_args:
+      - SHIELD=nrf7002ek_nrf7000
+      - EXTRA_CONF_FILE="overlay-nrf7002ek-wifi-scan-only.conf;overlay-debug.conf"
+      - SB_CONFIG_WIFI_NRF70=y
+      - SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_asset_tracker_v2
   # Configuration which will be used by the positioning CI integration job to verify PRs
   applications.asset_tracker_v2.integration_config_positioning:
     sysbuild: true
@@ -379,4 +465,7 @@ tests:
       - nrf9151dk/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
-    tags: ci_build sysbuild ci_applications_asset_tracker_v2
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_asset_tracker_v2

--- a/applications/asset_tracker_v2/tests/debug_module/testcase.yaml
+++ b/applications/asset_tracker_v2/tests/debug_module/testcase.yaml
@@ -1,9 +1,15 @@
 tests:
   asset_tracker_v2.debug_module_test.tester:
     sysbuild: true
-    platform_allow: native_sim qemu_cortex_m3 nrf9160dk/nrf9160/ns
+    platform_allow:
+      - native_sim
+      - qemu_cortex_m3
+      - nrf9160dk/nrf9160/ns
     integration_platforms:
       - native_sim
       - qemu_cortex_m3
       - nrf9160dk/nrf9160/ns
-    tags: debug_module sysbuild ci_applications_asset_tracker_v2
+    tags:
+      - debug_module
+      - sysbuild
+      - ci_applications_asset_tracker_v2

--- a/applications/asset_tracker_v2/tests/json_common/testcase.yaml
+++ b/applications/asset_tracker_v2/tests/json_common/testcase.yaml
@@ -1,21 +1,33 @@
 tests:
   applications.asset_tracker_v2.cloud.cloud_codec.json_common.aws:
     sysbuild: true
-    platform_allow: nrf9160dk/nrf9160 native_sim qemu_cortex_m3
+    platform_allow:
+      - nrf9160dk/nrf9160
+      - native_sim
+      - qemu_cortex_m3
     integration_platforms:
       - nrf9160dk/nrf9160
       - native_sim
       - qemu_cortex_m3
-    tags: json_common_test-aws sysbuild ci_applications_asset_tracker_v2
+    tags:
+      - json_common_test-aws
+      - sysbuild
+      - ci_applications_asset_tracker_v2
     extra_configs:
       - CONFIG_CLOUD_CODEC_AWS_IOT=y
   applications.asset_tracker_v2.cloud.cloud_codec.json_common.azure:
     sysbuild: true
-    platform_allow: nrf9160dk/nrf9160 native_sim qemu_cortex_m3
+    platform_allow:
+      - nrf9160dk/nrf9160
+      - native_sim
+      - qemu_cortex_m3
     integration_platforms:
       - nrf9160dk/nrf9160
       - native_sim
       - qemu_cortex_m3
-    tags: json_common_test-azure sysbuild ci_applications_asset_tracker_v2
+    tags:
+      - json_common_test-azure
+      - sysbuild
+      - ci_applications_asset_tracker_v2
     extra_configs:
       - CONFIG_CLOUD_CODEC_AZURE_IOT_HUB=y

--- a/applications/asset_tracker_v2/tests/location_module/testcase.yaml
+++ b/applications/asset_tracker_v2/tests/location_module/testcase.yaml
@@ -1,9 +1,15 @@
 tests:
   asset_tracker_v2.location_module_test.tester:
     sysbuild: true
-    platform_allow: native_sim qemu_cortex_m3 nrf9160dk/nrf9160/ns
+    platform_allow:
+      - native_sim
+      - qemu_cortex_m3
+      - nrf9160dk/nrf9160/ns
     integration_platforms:
       - native_sim
       - qemu_cortex_m3
       - nrf9160dk/nrf9160/ns
-    tags: location_module sysbuild ci_applications_asset_tracker_v2
+    tags:
+      - location_module
+      - sysbuild
+      - ci_applications_asset_tracker_v2

--- a/applications/asset_tracker_v2/tests/lwm2m_codec_helpers/testcase.yaml
+++ b/applications/asset_tracker_v2/tests/lwm2m_codec_helpers/testcase.yaml
@@ -1,9 +1,15 @@
 tests:
   asset_tracker_v2.lwm2m_codec:
     sysbuild: true
-    platform_allow: native_sim qemu_cortex_m3 nrf9160dk/nrf9160/ns
+    platform_allow:
+      - native_sim
+      - qemu_cortex_m3
+      - nrf9160dk/nrf9160/ns
     integration_platforms:
       - native_sim
       - qemu_cortex_m3
       - nrf9160dk/nrf9160/ns
-    tags: lwm2m_codec sysbuild ci_applications_asset_tracker_v2
+    tags:
+      - lwm2m_codec
+      - sysbuild
+      - ci_applications_asset_tracker_v2

--- a/applications/asset_tracker_v2/tests/lwm2m_integration/testcase.yaml
+++ b/applications/asset_tracker_v2/tests/lwm2m_integration/testcase.yaml
@@ -1,9 +1,15 @@
 tests:
   asset_tracker_v2.lwm2m_integration:
     sysbuild: true
-    platform_allow: native_sim qemu_cortex_m3 nrf9160dk/nrf9160/ns
+    platform_allow:
+      - native_sim
+      - qemu_cortex_m3
+      - nrf9160dk/nrf9160/ns
     integration_platforms:
       - native_sim
       - qemu_cortex_m3
       - nrf9160dk/nrf9160/ns
-    tags: lwm2m_integration sysbuild ci_applications_asset_tracker_v2
+    tags:
+      - lwm2m_integration
+      - sysbuild
+      - ci_applications_asset_tracker_v2

--- a/applications/asset_tracker_v2/tests/nrf_cloud_codec/testcase.yaml
+++ b/applications/asset_tracker_v2/tests/nrf_cloud_codec/testcase.yaml
@@ -1,9 +1,15 @@
 tests:
   asset_tracker_v2.nrf_cloud_codec_test:
     sysbuild: true
-    platform_allow: native_sim qemu_cortex_m3 nrf9160dk/nrf9160/ns
+    platform_allow:
+      - native_sim
+      - qemu_cortex_m3
+      - nrf9160dk/nrf9160/ns
     integration_platforms:
       - native_sim
       - qemu_cortex_m3
       - nrf9160dk/nrf9160/ns
-    tags: nrf_cloud_codec sysbuild ci_applications_asset_tracker_v2
+    tags:
+      - nrf_cloud_codec
+      - sysbuild
+      - ci_applications_asset_tracker_v2

--- a/applications/asset_tracker_v2/tests/nrf_cloud_codec_mocked_cjson/testcase.yaml
+++ b/applications/asset_tracker_v2/tests/nrf_cloud_codec_mocked_cjson/testcase.yaml
@@ -1,8 +1,13 @@
 tests:
   asset_tracker_v2.nrf_cloud_codec_mocked_cjson_test:
     sysbuild: true
-    platform_allow: native_sim qemu_cortex_m3
+    platform_allow:
+      - native_sim
+      - qemu_cortex_m3
     integration_platforms:
       - native_sim
       - qemu_cortex_m3
-    tags: nrf_cloud_codec_mocked_cJSON sysbuild ci_applications_asset_tracker_v2
+    tags:
+      - nrf_cloud_codec_mocked_cJSON
+      - sysbuild
+      - ci_applications_asset_tracker_v2

--- a/applications/asset_tracker_v2/tests/ui_module/testcase.yaml
+++ b/applications/asset_tracker_v2/tests/ui_module/testcase.yaml
@@ -1,8 +1,13 @@
 tests:
   asset_tracker_v2.ui_module_test.tester:
     sysbuild: true
-    platform_allow: native_sim nrf9160dk/nrf9160/ns
+    platform_allow:
+      - native_sim
+      - nrf9160dk/nrf9160/ns
     integration_platforms:
       - native_sim
       - nrf9160dk/nrf9160/ns
-    tags: ui_module sysbuild ci_applications_asset_tracker_v2
+    tags:
+      - ui_module
+      - sysbuild
+      - ci_applications_asset_tracker_v2

--- a/applications/connectivity_bridge/sample.yaml
+++ b/applications/connectivity_bridge/sample.yaml
@@ -11,4 +11,6 @@ tests:
     integration_platforms:
       - thingy91/nrf52840
       - thingy91x/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags:
+      - ci_build
+      - sysbuild

--- a/applications/ipc_radio/sample.yaml
+++ b/applications/ipc_radio/sample.yaml
@@ -5,8 +5,14 @@ tests:
   applications.ipc_radio.hci:
     sysbuild: true
     build_only: true
-    platform_allow: nrf5340dk/nrf5340/cpunet thingy53/nrf5340/cpunet
-    tags: bluetooth ci_build sysbuild ci_applications_ipc_radio
+    platform_allow:
+      - nrf5340dk/nrf5340/cpunet
+      - thingy53/nrf5340/cpunet
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
+      - ci_applications_ipc_radio
     integration_platforms:
       - nrf5340dk/nrf5340/cpunet
       - thingy53/nrf5340/cpunet
@@ -14,8 +20,13 @@ tests:
   applications.ipc_radio.hci.sysbuild:
     sysbuild: true
     build_only: true
-    platform_allow: nrf5340dk/nrf5340/cpunet thingy53/nrf5340/cpunet
-    tags: bluetooth ci_build ci_applications_ipc_radio
+    platform_allow:
+      - nrf5340dk/nrf5340/cpunet
+      - thingy53/nrf5340/cpunet
+    tags:
+      - bluetooth
+      - ci_build
+      - ci_applications_ipc_radio
     integration_platforms:
       - nrf5340dk/nrf5340/cpunet
       - thingy53/nrf5340/cpunet
@@ -24,15 +35,26 @@ tests:
     sysbuild: true
     build_only: true
     platform_allow: nrf54h20dk/nrf54h20/cpurad
-    tags: bluetooth ci_build ci_applications_ipc_radio
+    tags:
+      - bluetooth
+      - ci_build
+      - ci_applications_ipc_radio
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpurad
-    extra_args: EXTRA_CONF_FILE=overlay-bt_hci_ipc.conf SB_CONFIG_PARTITION_MANAGER=n
+    extra_args:
+      - EXTRA_CONF_FILE=overlay-bt_hci_ipc.conf
+      - SB_CONFIG_PARTITION_MANAGER=n
   applications.ipc_radio.rpc:
     sysbuild: true
     build_only: true
-    platform_allow: nrf5340dk/nrf5340/cpunet thingy53/nrf5340/cpunet
-    tags: bluetooth ci_build sysbuild ci_applications_ipc_radio
+    platform_allow:
+      - nrf5340dk/nrf5340/cpunet
+      - thingy53/nrf5340/cpunet
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
+      - ci_applications_ipc_radio
     integration_platforms:
       - nrf5340dk/nrf5340/cpunet
       - thingy53/nrf5340/cpunet
@@ -40,8 +62,13 @@ tests:
   applications.ipc_radio.rpc.sysbuild:
     sysbuild: true
     build_only: true
-    platform_allow: nrf5340dk/nrf5340/cpunet thingy53/nrf5340/cpunet
-    tags: bluetooth ci_build ci_applications_ipc_radio
+    platform_allow:
+      - nrf5340dk/nrf5340/cpunet
+      - thingy53/nrf5340/cpunet
+    tags:
+      - bluetooth
+      - ci_build
+      - ci_applications_ipc_radio
     integration_platforms:
       - nrf5340dk/nrf5340/cpunet
       - thingy53/nrf5340/cpunet
@@ -50,15 +77,25 @@ tests:
     sysbuild: true
     build_only: true
     platform_allow: nrf54h20dk/nrf54h20/cpurad
-    tags: bluetooth ci_build ci_applications_ipc_radio
+    tags:
+      - bluetooth
+      - ci_build
+      - ci_applications_ipc_radio
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpurad
-    extra_args: EXTRA_CONF_FILE=overlay-bt_rpc.conf SB_CONFIG_PARTITION_MANAGER=n
+    extra_args:
+      - EXTRA_CONF_FILE=overlay-bt_rpc.conf
+      - SB_CONFIG_PARTITION_MANAGER=n
   applications.ipc_radio.802154:
     sysbuild: true
     build_only: true
-    platform_allow: nrf5340dk/nrf5340/cpunet thingy53/nrf5340/cpunet
-    tags: ci_build sysbuild ci_applications_ipc_radio
+    platform_allow:
+      - nrf5340dk/nrf5340/cpunet
+      - thingy53/nrf5340/cpunet
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_ipc_radio
     integration_platforms:
       - nrf5340dk/nrf5340/cpunet
       - thingy53/nrf5340/cpunet
@@ -66,8 +103,12 @@ tests:
   applications.ipc_radio.802154.sysbuild:
     sysbuild: true
     build_only: true
-    platform_allow: nrf5340dk/nrf5340/cpunet thingy53/nrf5340/cpunet
-    tags: ci_build ci_applications_ipc_radio
+    platform_allow:
+      - nrf5340dk/nrf5340/cpunet
+      - thingy53/nrf5340/cpunet
+    tags:
+      - ci_build
+      - ci_applications_ipc_radio
     integration_platforms:
       - nrf5340dk/nrf5340/cpunet
       - thingy53/nrf5340/cpunet
@@ -75,8 +116,14 @@ tests:
   applications.ipc_radio.hci802154:
     sysbuild: true
     build_only: true
-    platform_allow: nrf5340dk/nrf5340/cpunet thingy53/nrf5340/cpunet
-    tags: bluetooth ci_build sysbuild ci_applications_ipc_radio
+    platform_allow:
+      - nrf5340dk/nrf5340/cpunet
+      - thingy53/nrf5340/cpunet
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
+      - ci_applications_ipc_radio
     integration_platforms:
       - nrf5340dk/nrf5340/cpunet
       - thingy53/nrf5340/cpunet
@@ -84,8 +131,13 @@ tests:
   applications.ipc_radio.hci802154.sysbuild:
     sysbuild: true
     build_only: true
-    platform_allow: nrf5340dk/nrf5340/cpunet thingy53/nrf5340/cpunet
-    tags: bluetooth ci_build ci_applications_ipc_radio
+    platform_allow:
+      - nrf5340dk/nrf5340/cpunet
+      - thingy53/nrf5340/cpunet
+    tags:
+      - bluetooth
+      - ci_build
+      - ci_applications_ipc_radio
     integration_platforms:
       - nrf5340dk/nrf5340/cpunet
       - thingy53/nrf5340/cpunet

--- a/applications/machine_learning/sample.yaml
+++ b/applications/machine_learning/sample.yaml
@@ -17,7 +17,10 @@ tests:
       - thingy53/nrf5340/cpuapp/ns
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    tags: ci_build sysbuild ci_applications_machine_learning
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_machine_learning
   applications.machine_learning.zdebug_nus:
     sysbuild: true
     build_only: true
@@ -25,7 +28,10 @@ tests:
       - nrf52840dk/nrf52840
     integration_platforms:
       - nrf52840dk/nrf52840
-    tags: ci_build sysbuild ci_applications_machine_learning
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_machine_learning
     extra_args: FILE_SUFFIX=nus
   applications.machine_learning.zdebug_rtt:
     sysbuild: true
@@ -36,7 +42,10 @@ tests:
     integration_platforms:
       - thingy53/nrf5340/cpuapp
       - thingy53/nrf5340/cpuapp/ns
-    tags: ci_build sysbuild ci_applications_machine_learning
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_machine_learning
     extra_args: FILE_SUFFIX=rtt
   applications.machine_learning.zrelease:
     sysbuild: true
@@ -49,7 +58,10 @@ tests:
       - nrf52840dk/nrf52840
       - thingy53/nrf5340/cpuapp
       - thingy53/nrf5340/cpuapp/ns
-    tags: ci_build sysbuild ci_applications_machine_learning
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_machine_learning
     extra_args: FILE_SUFFIX=release
   applications.machine_learning.sensor_hub.zdebug.singlecore:
     build_only: true
@@ -58,10 +70,13 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
-    tags: ci_build sysbuild ci_applications_machine_learning
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_machine_learning
     extra_args:
-      machine_learning_SHIELD=pca63566
-      FILE_SUFFIX="singlecore"
+      - machine_learning_SHIELD=pca63566
+      - FILE_SUFFIX="singlecore"
   applications.machine_learning.sensor_hub.zdebug:
     build_only: true
     sysbuild: true
@@ -69,9 +84,12 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
-    tags: ci_build sysbuild ci_applications_machine_learning
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_machine_learning
     extra_args:
-      SB_CONFIG_ML_APP_INCLUDE_REMOTE_IMAGE=y
-      machine_learning_SNIPPET=nordic-ppr
-      machine_learning_SHIELD=pca63566_fwd
-      remote_SHIELD=pca63566
+      - SB_CONFIG_ML_APP_INCLUDE_REMOTE_IMAGE=y
+      - machine_learning_SNIPPET=nordic-ppr
+      - machine_learning_SHIELD=pca63566_fwd
+      - remote_SHIELD=pca63566

--- a/applications/matter_bridge/sample.yaml
+++ b/applications/matter_bridge/sample.yaml
@@ -5,108 +5,156 @@ tests:
   applications.matter_bridge.release:
     sysbuild: true
     build_only: true
-    extra_args: FILE_SUFFIX=release
-      CONFIG_BRIDGE_GENERIC_SWITCH_BRIDGED_DEVICE=n
-      CONFIG_BRIDGE_ONOFF_LIGHT_SWITCH_BRIDGED_DEVICE=y
+    extra_args:
+      - FILE_SUFFIX=release
+      - CONFIG_BRIDGE_GENERIC_SWITCH_BRIDGED_DEVICE=n
+      - CONFIG_BRIDGE_ONOFF_LIGHT_SWITCH_BRIDGED_DEVICE=y
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf7002dk/nrf5340/cpuapp nrf5340dk/nrf5340/cpuapp
-      nrf54h20dk/nrf54h20/cpuapp
-    tags: sysbuild ci_applications_matter
+    platform_allow:
+      - nrf7002dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+    tags:
+      - sysbuild
+      - ci_applications_matter
   applications.matter_bridge.lto:
     sysbuild: true
     build_only: true
-    extra_args: CONFIG_BRIDGE_GENERIC_SWITCH_BRIDGED_DEVICE=n
-      CONFIG_BRIDGE_ONOFF_LIGHT_SWITCH_BRIDGED_DEVICE=y
+    extra_args:
+      - CONFIG_BRIDGE_GENERIC_SWITCH_BRIDGED_DEVICE=n
+      - CONFIG_BRIDGE_ONOFF_LIGHT_SWITCH_BRIDGED_DEVICE=y
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf7002dk/nrf5340/cpuapp nrf5340dk/nrf5340/cpuapp
-      nrf54h20dk/nrf54h20/cpuapp
-    tags: sysbuild ci_applications_matter
+    platform_allow:
+      - nrf7002dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+    tags:
+      - sysbuild
+      - ci_applications_matter
   applications.matter_bridge.lto.br_ble:
     sysbuild: true
     build_only: true
-    extra_args: CONFIG_BRIDGED_DEVICE_BT=y
-      CONFIG_BRIDGE_GENERIC_SWITCH_BRIDGED_DEVICE=n
-      CONFIG_BRIDGE_ONOFF_LIGHT_SWITCH_BRIDGED_DEVICE=y
+    extra_args:
+      - CONFIG_BRIDGED_DEVICE_BT=y
+      - CONFIG_BRIDGE_GENERIC_SWITCH_BRIDGED_DEVICE=n
+      - CONFIG_BRIDGE_ONOFF_LIGHT_SWITCH_BRIDGED_DEVICE=y
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf7002dk/nrf5340/cpuapp nrf5340dk/nrf5340/cpuapp
-      nrf54h20dk/nrf54h20/cpuapp
-    tags: sysbuild ci_applications_matter
+    platform_allow:
+      - nrf7002dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+    tags:
+      - sysbuild
+      - ci_applications_matter
   applications.matter_bridge.release.br_ble:
     sysbuild: true
     build_only: true
-    extra_args: FILE_SUFFIX=release CONFIG_BRIDGED_DEVICE_BT=y
-      CONFIG_BRIDGE_GENERIC_SWITCH_BRIDGED_DEVICE=n
-      CONFIG_BRIDGE_ONOFF_LIGHT_SWITCH_BRIDGED_DEVICE=y
+    extra_args:
+      - FILE_SUFFIX=release
+      - CONFIG_BRIDGED_DEVICE_BT=y
+      - CONFIG_BRIDGE_GENERIC_SWITCH_BRIDGED_DEVICE=n
+      - CONFIG_BRIDGE_ONOFF_LIGHT_SWITCH_BRIDGED_DEVICE=y
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf7002dk/nrf5340/cpuapp nrf5340dk/nrf5340/cpuapp
-      nrf54h20dk/nrf54h20/cpuapp
-    tags: sysbuild ci_applications_matter
+    platform_allow:
+      - nrf7002dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+    tags:
+      - sysbuild
+      - ci_applications_matter
   applications.matter_bridge.lto.br_ble.smp_dfu:
     sysbuild: true
     build_only: true
-    extra_args: CONFIG_CHIP_DFU_OVER_BT_SMP=y CONFIG_BRIDGED_DEVICE_BT=y
-      CONFIG_BRIDGE_GENERIC_SWITCH_BRIDGED_DEVICE=n
-      CONFIG_BRIDGE_ONOFF_LIGHT_SWITCH_BRIDGED_DEVICE=y
+    extra_args:
+      - CONFIG_CHIP_DFU_OVER_BT_SMP=y
+      - CONFIG_BRIDGED_DEVICE_BT=y
+      - CONFIG_BRIDGE_GENERIC_SWITCH_BRIDGED_DEVICE=n
+      - CONFIG_BRIDGE_ONOFF_LIGHT_SWITCH_BRIDGED_DEVICE=y
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: sysbuild ci_applications_matter
+    tags:
+      - sysbuild
+      - ci_applications_matter
   applications.matter_bridge.lto.nrf5340.wifi:
     sysbuild: true
     build_only: true
-    extra_args: matter_bridge_SHIELD=nrf7002ek SB_CONFIG_WIFI_PATCHES_EXT_FLASH_STORE=y
-      mcuboot_CONFIG_UPDATEABLE_IMAGE_NUMBER=3 SB_CONFIG_WIFI_NRF70=y
-      SB_CONFIG_DFU_MULTI_IMAGE_PACKAGE_WIFI_FW_PATCH=y
-      CONFIG_CHIP_DFU_OVER_BT_SMP=y
-      FILE_SUFFIX=nrf70ek
+    extra_args:
+      - matter_bridge_SHIELD=nrf7002ek
+      - SB_CONFIG_WIFI_PATCHES_EXT_FLASH_STORE=y
+      - mcuboot_CONFIG_UPDATEABLE_IMAGE_NUMBER=3
+      - SB_CONFIG_WIFI_NRF70=y
+      - SB_CONFIG_DFU_MULTI_IMAGE_PACKAGE_WIFI_FW_PATCH=y
+      - CONFIG_CHIP_DFU_OVER_BT_SMP=y
+      - FILE_SUFFIX=nrf70ek
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: sysbuild ci_applications_matter
+    tags:
+      - sysbuild
+      - ci_applications_matter
   applications.matter_bridge.lto.br_ble.nrf54h20.wifi:
     sysbuild: true
     build_only: true
-    extra_args: SB_CONFIG_WIFI_NRF70=y CONFIG_CHIP_WIFI=y
-      matter_bridge_SHIELD="nrf7002eb_interposer_p1;nrf7002eb" CONFIG_BRIDGED_DEVICE_BT=y
+    extra_args:
+      - SB_CONFIG_WIFI_NRF70=y
+      - CONFIG_CHIP_WIFI=y
+      - matter_bridge_SHIELD="nrf7002eb_interposer_p1;nrf7002eb"
+      - CONFIG_BRIDGED_DEVICE_BT=y
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     platform_allow: nrf54h20dk/nrf54h20/cpuapp
-    tags: sysbuild ci_applications_matter
+    tags:
+      - sysbuild
+      - ci_applications_matter
   applications.matter_bridge.release.br_ble.nrf54h20.wifi:
     sysbuild: true
     build_only: true
-    extra_args: FILE_SUFFIX=release SB_CONFIG_WIFI_NRF70=y CONFIG_CHIP_WIFI=y
-      matter_bridge_SHIELD="nrf7002eb_interposer_p1;nrf7002eb" CONFIG_BRIDGED_DEVICE_BT=y
+    extra_args:
+      - FILE_SUFFIX=release
+      - SB_CONFIG_WIFI_NRF70=y
+      - CONFIG_CHIP_WIFI=y
+      - matter_bridge_SHIELD="nrf7002eb_interposer_p1;nrf7002eb"
+      - CONFIG_BRIDGED_DEVICE_BT=y
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     platform_allow: nrf54h20dk/nrf54h20/cpuapp
-    tags: sysbuild ci_applications_matter
+    tags:
+      - sysbuild
+      - ci_applications_matter
   applications.matter_bridge.lto.br_ble.memory_profiling:
     sysbuild: true
     build_only: true
-    extra_args: CONFIG_BRIDGE_GENERIC_SWITCH_BRIDGED_DEVICE=n
-      CONFIG_BRIDGE_ONOFF_LIGHT_SWITCH_BRIDGED_DEVICE=y
-      CONFIG_CHIP_MEMORY_PROFILING=y CONFIG_BRIDGED_DEVICE_BT=y
-      CONFIG_BRIDGE_MIGRATE_VERSION_1=n CONFIG_WIFI_NM_WPA_SUPPLICANT_WPA3=n
+    extra_args:
+      - CONFIG_BRIDGE_GENERIC_SWITCH_BRIDGED_DEVICE=n
+      - CONFIG_BRIDGE_ONOFF_LIGHT_SWITCH_BRIDGED_DEVICE=y
+      - CONFIG_CHIP_MEMORY_PROFILING=y
+      - CONFIG_BRIDGED_DEVICE_BT=y
+      - CONFIG_BRIDGE_MIGRATE_VERSION_1=n
+      - CONFIG_WIFI_NM_WPA_SUPPLICANT_WPA3=n
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf7002dk/nrf5340/cpuapp nrf5340dk/nrf5340/cpuapp
-      nrf54h20dk/nrf54h20/cpuapp
-    tags: sysbuild ci_applications_matter
+    platform_allow:
+      - nrf7002dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+    tags:
+      - sysbuild
+      - ci_applications_matter
   applications.matter_bridge.lto.smart_plug:
     sysbuild: true
     build_only: true
@@ -114,4 +162,6 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: sysbuild ci_applications_matter
+    tags:
+      - sysbuild
+      - ci_applications_matter

--- a/applications/matter_weather_station/sample.yaml
+++ b/applications/matter_weather_station/sample.yaml
@@ -11,48 +11,69 @@ tests:
     platform_exclude: thingy53/nrf5340/cpuapp/ns
     integration_platforms:
       - thingy53/nrf5340/cpuapp
-    tags: sysbuild ci_applications_matter
+    tags:
+      - sysbuild
+      - ci_applications_matter
   applications.matter_weather_station.debug:
     sysbuild: true
     build_only: true
-    extra_args: OVERLAY_CONFIG=overlay-factory_data.conf
-      FILE_SUFFIX=factory_data
-      CONFIG_CHIP_FACTORY_DATA=y SB_CONFIG_MATTER_FACTORY_DATA_GENERATE=y
+    extra_args:
+      - OVERLAY_CONFIG=overlay-factory_data.conf
+      - FILE_SUFFIX=factory_data
+      - CONFIG_CHIP_FACTORY_DATA=y
+      - SB_CONFIG_MATTER_FACTORY_DATA_GENERATE=y
     platform_allow: thingy53/nrf5340/cpuapp
     platform_exclude: thingy53/nrf5340/cpuapp/ns
     integration_platforms:
       - thingy53/nrf5340/cpuapp
-    tags: sysbuild ci_applications_matter
+    tags:
+      - sysbuild
+      - ci_applications_matter
   applications.matter_weather_station.release:
     sysbuild: true
     build_only: true
-    extra_args: OVERLAY_CONFIG=overlay-factory_data.conf CONF_FILE=prj_release.conf
-      FILE_SUFFIX=factory_data CONFIG_CHIP_FACTORY_DATA=y
-      SB_CONFIG_MATTER_FACTORY_DATA_GENERATE=y
+    extra_args:
+      - OVERLAY_CONFIG=overlay-factory_data.conf
+      - CONF_FILE=prj_release.conf
+      - FILE_SUFFIX=factory_data
+      - CONFIG_CHIP_FACTORY_DATA=y
+      - SB_CONFIG_MATTER_FACTORY_DATA_GENERATE=y
     platform_allow: thingy53/nrf5340/cpuapp
     platform_exclude: thingy53/nrf5340/cpuapp/ns
     integration_platforms:
       - thingy53/nrf5340/cpuapp
-    tags: sysbuild ci_applications_matter
+    tags:
+      - sysbuild
+      - ci_applications_matter
   applications.matter_weather_station.lto:
     sysbuild: true
     build_only: true
-    extra_args: OVERLAY_CONFIG=overlay-factory_data.conf
-      FILE_SUFFIX=factory_data CONFIG_CHIP_FACTORY_DATA=y
-      SB_CONFIG_MATTER_FACTORY_DATA_GENERATE=y
-      CONFIG_LTO=y CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+    extra_args:
+      - OVERLAY_CONFIG=overlay-factory_data.conf
+      - FILE_SUFFIX=factory_data
+      - CONFIG_CHIP_FACTORY_DATA=y
+      - SB_CONFIG_MATTER_FACTORY_DATA_GENERATE=y
+      - CONFIG_LTO=y
+      - CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
     platform_allow: thingy53/nrf5340/cpuapp
     platform_exclude: thingy53/nrf5340/cpuapp/ns
     integration_platforms:
       - thingy53/nrf5340/cpuapp
-    tags: sysbuild ci_applications_matter
+    tags:
+      - sysbuild
+      - ci_applications_matter
   applications.matter_weather_station.nrf7002eb:
     sysbuild: true
     build_only: true
-    extra_args: matter_weather_station_SHIELD=nrf7002eb FILE_SUFFIX=release
-                SB_CONFIG_WIFI_NRF70=y CONFIG_CHIP_WIFI=y
+    extra_args:
+      - matter_weather_station_SHIELD=nrf7002eb
+      - FILE_SUFFIX=release
+      - SB_CONFIG_WIFI_NRF70=y
+      - CONFIG_CHIP_WIFI=y
     platform_allow: thingy53/nrf5340/cpuapp
     platform_exclude: thingy53/nrf5340/cpuapp/ns
     integration_platforms:
       - thingy53/nrf5340/cpuapp
-    tags: sysbuild ci_applications_matter
+    tags:
+      - sysbuild
+      - ci_applications_matter

--- a/applications/nrf5340_audio/sample.yaml
+++ b/applications/nrf5340_audio/sample.yaml
@@ -7,19 +7,37 @@ common:
   platform_allow: nrf5340_audio_dk/nrf5340/cpuapp
   sysbuild: true
   build_only: true
-  tags: ci_build sysbuild
+  tags:
+    - ci_build
+    - sysbuild
 tests:
   applications.nrf5340_audio.default:
     extra_args: []
   applications.nrf5340_audio.headset_unicast:
-    extra_args: FILE_SUFFIX=release CONFIG_AUDIO_DEV=1
+    extra_args:
+      - FILE_SUFFIX=release
+      - CONFIG_AUDIO_DEV=1
   applications.nrf5340_audio.gateway_unicast:
-    extra_args: FILE_SUFFIX=release CONFIG_AUDIO_DEV=2
+    extra_args:
+      - FILE_SUFFIX=release
+      - CONFIG_AUDIO_DEV=2
   applications.nrf5340_audio.headset_broadcast:
-    extra_args: FILE_SUFFIX=release CONFIG_AUDIO_DEV=1 CONFIG_TRANSPORT_BIS=y
+    extra_args:
+      - FILE_SUFFIX=release
+      - CONFIG_AUDIO_DEV=1
+      - CONFIG_TRANSPORT_BIS=y
   applications.nrf5340_audio.gateway_broadcast:
-    extra_args: FILE_SUFFIX=release CONFIG_AUDIO_DEV=2 CONFIG_TRANSPORT_BIS=y
+    extra_args:
+      - FILE_SUFFIX=release
+      - CONFIG_AUDIO_DEV=2
+      - CONFIG_TRANSPORT_BIS=y
   applications.nrf5340_audio.headset_unicast_sd_card:
-    extra_args: FILE_SUFFIX=release CONFIG_AUDIO_DEV=1 CONFIG_SD_CARD_PLAYBACK=y
+    extra_args:
+      - FILE_SUFFIX=release
+      - CONFIG_AUDIO_DEV=1
+      - CONFIG_SD_CARD_PLAYBACK=y
   applications.nrf5340_audio.headset_dfu:
-    extra_args: FILE_SUFFIX=release CONFIG_AUDIO_DEV=1 FILE_SUFFIX=fota
+    extra_args:
+      - FILE_SUFFIX=release
+      - CONFIG_AUDIO_DEV=1
+      - FILE_SUFFIX=fota

--- a/applications/nrf_desktop/sample.yaml
+++ b/applications/nrf_desktop/sample.yaml
@@ -1,11 +1,13 @@
 sample:
   name: nRF Desktop - HID reference design
-  description: The nRF Desktop is an HID reference design application.
-    It can be configured to function as a mouse, keyboard or USB dongle
-    bridging radio connected HID peripheral.
+  description: The nRF Desktop is an HID reference design application. It can be configured
+    to function as a mouse, keyboard or USB dongle bridging radio connected HID peripheral.
 common:
   sysbuild: true
-  tags: ci_build sysbuild ci_applications_nrf_desktop
+  tags:
+    - ci_build
+    - sysbuild
+    - ci_applications_nrf_desktop
   harness_config:
     type: multi_line
     ordered: false
@@ -32,10 +34,18 @@ tests:
     harness: console
   applications.nrf_desktop.zdebug:
     build_only: true
-    platform_allow: >
-      nrf52dmouse/nrf52832 nrf52kbd/nrf52832 nrf52810dmouse/nrf52810 nrf52820dongle/nrf52820
-      nrf52833dk/nrf52820 nrf52833dk/nrf52833 nrf52833dongle/nrf52833 nrf52840dk/nrf52840
-      nrf52840dongle/nrf52840 nrf52840gmouse/nrf52840 nrf5340dk/nrf5340/cpuapp
+    platform_allow:
+      - nrf52dmouse/nrf52832
+      - nrf52kbd/nrf52832
+      - nrf52810dmouse/nrf52810
+      - nrf52820dongle/nrf52820
+      - nrf52833dk/nrf52820
+      - nrf52833dk/nrf52833
+      - nrf52833dongle/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf52840dongle/nrf52840
+      - nrf52840gmouse/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
     integration_platforms:
       - nrf52dmouse/nrf52832
       - nrf52kbd/nrf52832
@@ -59,20 +69,24 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
-    extra_args: FILE_SUFFIX=fast_pair
-                FP_MODEL_ID=0x8E717D
-                FP_ANTI_SPOOFING_KEY=dZxFzP7X9CcfLPC0apyRkmgsh3n2EbWo9NFNXfVuxAM=
+    extra_args:
+      - FILE_SUFFIX=fast_pair
+      - FP_MODEL_ID=0x8E717D
+      - FP_ANTI_SPOOFING_KEY=dZxFzP7X9CcfLPC0apyRkmgsh3n2EbWo9NFNXfVuxAM=
     timeout: 180
     harness: pytest
   applications.nrf_desktop.zdebug_fast_pair.gmouse:
     build_only: true
-    platform_allow: nrf52840dk/nrf52840 nrf52840gmouse/nrf52840
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52840gmouse/nrf52840
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf52840gmouse/nrf52840
-    extra_args: FILE_SUFFIX=fast_pair
-                FP_MODEL_ID=0x8E717D
-                FP_ANTI_SPOOFING_KEY=dZxFzP7X9CcfLPC0apyRkmgsh3n2EbWo9NFNXfVuxAM=
+    extra_args:
+      - FILE_SUFFIX=fast_pair
+      - FP_MODEL_ID=0x8E717D
+      - FP_ANTI_SPOOFING_KEY=dZxFzP7X9CcfLPC0apyRkmgsh3n2EbWo9NFNXfVuxAM=
   applications.nrf_desktop.zdebug_mcuboot_qspi:
     build_only: true
     platform_allow: nrf52840dk/nrf52840
@@ -81,16 +95,22 @@ tests:
     extra_args: FILE_SUFFIX=mcuboot_qspi
   applications.nrf_desktop.zdebug_mcuboot_smp:
     build_only: true
-    platform_allow: nrf52840dk/nrf52840 nrf52840gmouse/nrf52840
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52840gmouse/nrf52840
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf52840gmouse/nrf52840
     extra_args: FILE_SUFFIX=mcuboot_smp
   applications.nrf_desktop.zdebugwithshell:
     build_only: true
-    platform_allow: >
-      nrf52kbd/nrf52832 nrf52833dk/nrf52833 nrf52833dongle/nrf52833 nrf52840dk/nrf52840
-      nrf52840dongle/nrf52840 nrf52840gmouse/nrf52840
+    platform_allow:
+      - nrf52kbd/nrf52832
+      - nrf52833dk/nrf52833
+      - nrf52833dongle/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf52840dongle/nrf52840
+      - nrf52840gmouse/nrf52840
     integration_platforms:
       - nrf52kbd/nrf52832
       - nrf52833dk/nrf52833
@@ -146,8 +166,9 @@ tests:
     platform_allow: nrf5340dk/nrf5340/cpuapp
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
-    extra_args: SHIELD=nrf21540ek
-                ipc_radio_SHIELD=nrf21540ek
+    extra_args:
+      - SHIELD=nrf21540ek
+      - ipc_radio_SHIELD=nrf21540ek
     extra_configs:
       - CONFIG_CAF_BLE_USE_LLPM=n
   applications.nrf_desktop.zrelease:
@@ -186,17 +207,19 @@ tests:
     platform_allow: nrf52kbd/nrf52832
     integration_platforms:
       - nrf52kbd/nrf52832
-    extra_args: FILE_SUFFIX=release_fast_pair
-                FP_MODEL_ID=0x52FF02
-                FP_ANTI_SPOOFING_KEY=8E8ulwhSIp/skZeg27xmWv2SxRxTOagypHrf2OdrhGY=
+    extra_args:
+      - FILE_SUFFIX=release_fast_pair
+      - FP_MODEL_ID=0x52FF02
+      - FP_ANTI_SPOOFING_KEY=8E8ulwhSIp/skZeg27xmWv2SxRxTOagypHrf2OdrhGY=
   applications.nrf_desktop.zrelease_fast_pair.gmouse:
     build_only: true
     platform_allow: nrf52840gmouse/nrf52840
     integration_platforms:
       - nrf52840gmouse/nrf52840
-    extra_args: FILE_SUFFIX=release_fast_pair
-                FP_MODEL_ID=0x8E717D
-                FP_ANTI_SPOOFING_KEY=dZxFzP7X9CcfLPC0apyRkmgsh3n2EbWo9NFNXfVuxAM=
+    extra_args:
+      - FILE_SUFFIX=release_fast_pair
+      - FP_MODEL_ID=0x8E717D
+      - FP_ANTI_SPOOFING_KEY=dZxFzP7X9CcfLPC0apyRkmgsh3n2EbWo9NFNXfVuxAM=
   applications.nrf_desktop.zrelease_4llpmconn:
     build_only: true
     platform_allow: nrf52840dongle/nrf52840
@@ -205,8 +228,10 @@ tests:
     extra_args: FILE_SUFFIX=release_4llpmconn
   applications.nrf_desktop.zdebug.usb_next:
     build_only: true
-    platform_allow: >
-      nrf52840dk/nrf52840 nrf52840gmouse/nrf52840 nrf52840dongle/nrf52840
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52840gmouse/nrf52840
+      - nrf52840dongle/nrf52840
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf52840gmouse/nrf52840

--- a/applications/sdp/gpio/sample.yaml
+++ b/applications/sdp/gpio/sample.yaml
@@ -9,7 +9,10 @@ tests:
     build_only: true
     sysbuild: true
     platform_allow: nrf54l15dk/nrf54l15/cpuflpr
-    tags: ci_build sysbuild gpio
+    tags:
+      - ci_build
+      - sysbuild
+      - gpio
     required_snippets:
       - sdp-gpio-mbox
 
@@ -17,7 +20,10 @@ tests:
     build_only: true
     sysbuild: true
     platform_allow: nrf54l15dk/nrf54l15/cpuflpr
-    tags: ci_build sysbuild gpio
+    tags:
+      - ci_build
+      - sysbuild
+      - gpio
     required_snippets:
       - sdp-gpio-icmsg
 
@@ -25,6 +31,9 @@ tests:
     sysbuild: true
     build_only: true
     platform_allow: nrf54l15dk/nrf54l15/cpuflpr
-    tags: ci_build sysbuild gpio
+    tags:
+      - ci_build
+      - sysbuild
+      - gpio
     required_snippets:
       - sdp-gpio-icbmsg

--- a/applications/sdp/mspi/sample.yaml
+++ b/applications/sdp/mspi/sample.yaml
@@ -9,4 +9,7 @@ tests:
     build_only: true
     sysbuild: true
     platform_allow: nrf54l15dk/nrf54l15/cpuflpr
-    tags: ci_build sysbuild mspi
+    tags:
+      - ci_build
+      - sysbuild
+      - mspi

--- a/applications/serial_lte_modem/sample.yaml
+++ b/applications/serial_lte_modem/sample.yaml
@@ -18,7 +18,9 @@ tests:
       - nrf9131ek/nrf9131/ns
       - thingy91/nrf9160/ns
       - thingy91x/nrf9151/ns
-    tags: ci_build sysbuild
+    tags:
+      - ci_build
+      - sysbuild
   applications.serial_lte_modem.native_tls:
     sysbuild: true
     build_only: true
@@ -32,7 +34,9 @@ tests:
     integration_platforms:
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild
+    tags:
+      - ci_build
+      - sysbuild
   applications.serial_lte_modem.lwm2m_carrier:
     sysbuild: true
     build_only: true
@@ -46,17 +50,22 @@ tests:
     integration_platforms:
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild
+    tags:
+      - ci_build
+      - sysbuild
   applications.serial_lte_modem.lwm2m_carrier.softbank:
     sysbuild: true
     build_only: true
-    extra_args: EXTRA_CONF_FILE="overlay-carrier.conf;overlay-carrier-softbank.conf"
-      SB_EXTRA_CONF_FILE=sysbuild-softbank.conf
+    extra_args:
+      - EXTRA_CONF_FILE="overlay-carrier.conf;overlay-carrier-softbank.conf"
+      - SB_EXTRA_CONF_FILE=sysbuild-softbank.conf
     platform_allow:
       - nrf9160dk/nrf9160/ns
     integration_platforms:
       - nrf9160dk/nrf9160/ns
-    tags: ci_build sysbuild
+    tags:
+      - ci_build
+      - sysbuild
   applications.serial_lte_modem.lwm2m_carrier.lgu:
     sysbuild: true
     build_only: true
@@ -65,14 +74,19 @@ tests:
       - nrf9151dk/nrf9151/ns
     integration_platforms:
       - nrf9151dk/nrf9151/ns
-    tags: ci_build sysbuild
+    tags:
+      - ci_build
+      - sysbuild
   applications.serial_lte_modem.lwm2m_carrier.thingy91:
     sysbuild: true
     build_only: true
-    extra_args: EXTRA_CONF_FILE=overlay-carrier.conf
-      SB_CONFIG_THINGY91_STATIC_PARTITIONS_LWM2M_CARRIER=y
+    extra_args:
+      - EXTRA_CONF_FILE=overlay-carrier.conf
+      - SB_CONFIG_THINGY91_STATIC_PARTITIONS_LWM2M_CARRIER=y
     platform_allow:
       - thingy91/nrf9160/ns
     integration_platforms:
       - thingy91/nrf9160/ns
-    tags: ci_build sysbuild
+    tags:
+      - ci_build
+      - sysbuild

--- a/applications/zigbee_weather_station/sample.yaml
+++ b/applications/zigbee_weather_station/sample.yaml
@@ -6,7 +6,10 @@ tests:
     sysbuild: true
     build_only: true
     platform_allow: thingy53/nrf5340/cpuapp
-    tags: ci_build sysbuild zigbee
+    tags:
+      - ci_build
+      - sysbuild
+      - zigbee
     extra_args: FILE_SUFFIX=release
     integration_platforms:
       - thingy53/nrf5340/cpuapp
@@ -14,4 +17,8 @@ tests:
     sysbuild: true
     build_only: true
     platform_allow: thingy53/nrf5340/cpuapp
-    tags: ci_build debug sysbuild zigbee
+    tags:
+      - ci_build
+      - debug
+      - sysbuild
+      - zigbee

--- a/samples/app_event_manager/sample.yaml
+++ b/samples/app_event_manager/sample.yaml
@@ -34,7 +34,9 @@ tests:
       - nrf9160dk/nrf9160/ns
       - nrf21540dk/nrf52840
       - nrf54h20dk/nrf54h20/cpuapp
-    tags: sysbuild ci_samples_app_event_manager
+    tags:
+      - sysbuild
+      - ci_samples_app_event_manager
   sample.app_event_manager_shell:
     sysbuild: true
     build_only: false
@@ -59,7 +61,9 @@ tests:
     extra_configs:
       - CONFIG_SHELL=y
     platform_exclude: native_sim
-    tags: sysbuild ci_samples_app_event_manager
+    tags:
+      - sysbuild
+      - ci_samples_app_event_manager
   sample.app_event_manager_shell.native_sim:
     sysbuild: true
     build_only: false
@@ -69,4 +73,6 @@ tests:
     platform_allow: native_sim
     integration_platforms:
       - native_sim
-    tags: sysbuild ci_samples_app_event_manager
+    tags:
+      - sysbuild
+      - ci_samples_app_event_manager

--- a/samples/app_event_manager_profiler_tracer/sample.yaml
+++ b/samples/app_event_manager_profiler_tracer/sample.yaml
@@ -16,4 +16,7 @@ tests:
       - nrf52840dk/nrf52840
       - nrf9160dk/nrf9160/ns
       - nrf21540dk/nrf52840
-    tags: ci_build sysbuild ci_samples_app_event_manager_profiler_tracer
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_app_event_manager_profiler_tracer

--- a/samples/benchmarks/coremark/sample.yaml
+++ b/samples/benchmarks/coremark/sample.yaml
@@ -1,9 +1,9 @@
 sample:
   name: CoreMark Benchmark
-  description: CoreMark sample for the CPU performance evaluation.
-               Sample runs the CoreMark benchmark that measures the CPU efficiency
-               performing different algorithms like state machine, CRC calculation,
-               matrix manipulation and list processing (find and sort).
+  description: CoreMark sample for the CPU performance evaluation. Sample runs the
+    CoreMark benchmark that measures the CPU efficiency performing different algorithms
+    like state machine, CRC calculation, matrix manipulation and list processing (find
+    and sort).
 tests:
   sample.benchmark.coremark:
     sysbuild: true
@@ -26,7 +26,10 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    tags: ci_build sysbuild ci_samples_benchmarks
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_benchmarks
   sample.benchmark.coremark.flash_and_run:
     sysbuild: true
     build_only: false
@@ -48,7 +51,10 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    tags: ci_build sysbuild ci_samples_benchmarks
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_benchmarks
     harness: console
     harness_config:
       ordered: false
@@ -78,7 +84,10 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    tags: ci_build sysbuild ci_samples_benchmarks
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_benchmarks
     extra_args: FILE_SUFFIX=heap_memory
   sample.benchmark.coremark.static_memory:
     sysbuild: true
@@ -101,7 +110,10 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    tags: ci_build sysbuild ci_samples_benchmarks
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_benchmarks
     extra_args: FILE_SUFFIX=static_memory
   sample.benchmark.coremark.multiple_threads:
     sysbuild: true
@@ -124,5 +136,8 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    tags: ci_build sysbuild ci_samples_benchmarks
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_benchmarks
     extra_args: FILE_SUFFIX=multiple_threads

--- a/samples/bluetooth/central_and_peripheral_hr/sample.yaml
+++ b/samples/bluetooth/central_and_peripheral_hr/sample.yaml
@@ -12,7 +12,14 @@ tests:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
-      nrf5340dk/nrf5340/cpuapp/ns nrf54l15dk/nrf54l15/cpuapp
-      nrf54h20dk/nrf54h20/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/central_bas/sample.yaml
+++ b/samples/bluetooth/central_bas/sample.yaml
@@ -8,8 +8,12 @@ tests:
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840
-    tags: bluetooth sysbuild
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+    tags:
+      - bluetooth
+      - sysbuild
   sample.bluetooth.central_bas.build:
     sysbuild: true
     build_only: true
@@ -20,6 +24,14 @@ tests:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
-      nrf5340dk/nrf5340/cpuapp/ns nrf54l15dk/nrf54l15/cpuapp nrf54h20dk/nrf54h20/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/central_hids/sample.yaml
+++ b/samples/bluetooth/central_hids/sample.yaml
@@ -11,7 +11,9 @@ tests:
     platform_allow:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
-    tags: bluetooth sysbuild
+    tags:
+      - bluetooth
+      - sysbuild
   sample.bluetooth.central_hids.build:
     sysbuild: true
     build_only: true
@@ -29,4 +31,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/central_hr_coded/sample.yaml
+++ b/samples/bluetooth/central_hr_coded/sample.yaml
@@ -11,6 +11,12 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf54l15dk/nrf54l15/cpuapp
-      nrf54h20dk/nrf54h20/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/central_nfc_pairing/sample.yaml
+++ b/samples/bluetooth/central_nfc_pairing/sample.yaml
@@ -9,5 +9,11 @@ tests:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf52dk/nrf52832 nrf5340dk/nrf5340/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52dk/nrf52832
+      - nrf5340dk/nrf5340/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/central_smp_client/sample.yaml
+++ b/samples/bluetooth/central_smp_client/sample.yaml
@@ -9,8 +9,13 @@ tests:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf54l15dk/nrf54l15/cpuapp
-    tags: bluetooth sysbuild
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - bluetooth
+      - sysbuild
   sample.bluetooth.central_dfu_smp.build:
     sysbuild: true
     build_only: true
@@ -19,6 +24,12 @@ tests:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
-      nrf5340dk/nrf5340/cpuapp/ns
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/central_uart/sample.yaml
+++ b/samples/bluetooth/central_uart/sample.yaml
@@ -13,10 +13,18 @@ tests:
       - nrf21540dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp nrf5340dk/nrf5340/cpuapp/ns nrf21540dk/nrf52840
-      nrf54l15dk/nrf54l15/cpuapp nrf54h20dk/nrf54h20/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf21540dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
   sample.bluetooth.central_uart.bt_rpc:
     sysbuild: true
     build_only: true
@@ -26,5 +34,10 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf5340dk/nrf5340/cpuapp nrf54h20dk/nrf54h20/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/channel_sounding_ras_initiator/sample.yaml
+++ b/samples/bluetooth/channel_sounding_ras_initiator/sample.yaml
@@ -1,5 +1,6 @@
 sample:
-  description: Bluetooth Low Energy Channel Sounding Initiator with Ranging Service Requestor
+  description: Bluetooth Low Energy Channel Sounding Initiator with Ranging Service
+    Requestor
   name: Bluetooth LE Channel Sounding Initiator with RREQ
 tests:
   sample.bluetooth.channel_sounding_ras_initiator:
@@ -13,4 +14,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/channel_sounding_ras_reflector/sample.yaml
+++ b/samples/bluetooth/channel_sounding_ras_reflector/sample.yaml
@@ -1,5 +1,6 @@
 sample:
-  description: Bluetooth Low Energy Channel Sounding Reflector with Ranging Service Responder
+  description: Bluetooth Low Energy Channel Sounding Reflector with Ranging Service
+    Responder
   name: Bluetooth LE Channel Sounding Reflector with RRSP
 tests:
   sample.bluetooth.channel_sounding_ras_reflector:
@@ -13,4 +14,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/conn_time_sync/sample.yaml
+++ b/samples/bluetooth/conn_time_sync/sample.yaml
@@ -21,4 +21,7 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/direct_test_mode/sample.yaml
+++ b/samples/bluetooth/direct_test_mode/sample.yaml
@@ -13,10 +13,18 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
-    platform_allow: nrf5340dk/nrf5340/cpunet nrf21540dk/nrf52840 nrf52840dk/nrf52840
-                    nrf54l15dk/nrf54l05/cpuapp nrf54l15dk/nrf54l10/cpuapp
-                    nrf54l15dk/nrf54l15/cpuapp nrf54h20dk/nrf54h20/cpurad
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf5340dk/nrf5340/cpunet
+      - nrf21540dk/nrf52840
+      - nrf52840dk/nrf52840
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpurad
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
   sample.bluetooth.direct_test_mode.hci:
     sysbuild: true
     build_only: true
@@ -27,9 +35,16 @@ tests:
       - nrf52840dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
-    platform_allow: nrf5340dk/nrf5340/cpunet nrf21540dk/nrf52840 nrf52840dk/nrf52840
-                    nrf54l15dk/nrf54l15/cpuapp nrf54h20dk/nrf54h20/cpurad
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf5340dk/nrf5340/cpunet
+      - nrf21540dk/nrf52840
+      - nrf52840dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpurad
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
   sample.bluetooth.direct_test_mode.nrf5340_nrf21540:
     sysbuild: true
     build_only: true
@@ -37,7 +52,10 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpunet
     platform_allow: nrf5340dk/nrf5340/cpunet
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
   sample.bluetooth.direct_test_mode.nrf5340_usb:
     sysbuild: true
     build_only: true
@@ -45,15 +63,23 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpunet
     platform_allow: nrf5340dk/nrf5340/cpunet
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
   sample.bluetooth.direct_test_mode.nrf5340_nrf21540_usb:
     sysbuild: true
     build_only: true
-    extra_args: SHIELD=nrf21540ek FILE_SUFFIX=usb
+    extra_args:
+      - SHIELD=nrf21540ek
+      - FILE_SUFFIX=usb
     integration_platforms:
       - nrf5340dk/nrf5340/cpunet
     platform_allow: nrf5340dk/nrf5340/cpunet
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
   sample.bluetooth.direct_test_mode.nrf5340_nrf21540.no_automatic_power:
     sysbuild: true
     build_only: true
@@ -63,7 +89,10 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpunet
     platform_allow: nrf5340dk/nrf5340/cpunet
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
   sample.bluetooth.direct_test_mode.nrf5340_no_dfe:
     sysbuild: true
     build_only: true
@@ -71,4 +100,7 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpunet
     platform_allow: nrf5340dk/nrf5340/cpunet
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/direction_finding_central/sample.yaml
+++ b/samples/bluetooth/direction_finding_central/sample.yaml
@@ -1,12 +1,18 @@
 sample:
   name: Direction Finding Central
-  description: Sample application showing central role of Direction Finding in connected mode
+  description: Sample application showing central role of Direction Finding in connected
+    mode
 tests:
   sample.bluetooth.direction_finding_central_nrf:
     sysbuild: true
     build_only: true
-    platform_allow: nrf52833dk/nrf52833 nrf52833dk/nrf52820 nrf5340dk/nrf5340/cpuapp
-    tags: bluetooth sysbuild
+    platform_allow:
+      - nrf52833dk/nrf52833
+      - nrf52833dk/nrf52820
+      - nrf5340dk/nrf5340/cpuapp
+    tags:
+      - bluetooth
+      - sysbuild
     integration_platforms:
       - nrf52833dk/nrf52833
       - nrf52833dk/nrf52820
@@ -15,8 +21,13 @@ tests:
     sysbuild: true
     extra_args: OVERLAY_CONFIG="overlay-aod.conf"
     build_only: true
-    platform_allow: nrf52833dk/nrf52833 nrf52833dk/nrf52820 nrf5340dk/nrf5340/cpuapp
-    tags: bluetooth sysbuild
+    platform_allow:
+      - nrf52833dk/nrf52833
+      - nrf52833dk/nrf52820
+      - nrf5340dk/nrf5340/cpuapp
+    tags:
+      - bluetooth
+      - sysbuild
     integration_platforms:
       - nrf52833dk/nrf52833
       - nrf52833dk/nrf52820

--- a/samples/bluetooth/direction_finding_connectionless_rx/sample.yaml
+++ b/samples/bluetooth/direction_finding_connectionless_rx/sample.yaml
@@ -5,8 +5,13 @@ tests:
   sample.bluetooth.direction_finding_connectionless_rx_nrf:
     sysbuild: true
     build_only: true
-    platform_allow: nrf52833dk/nrf52833 nrf52833dk/nrf52820 nrf5340dk/nrf5340/cpuapp
-    tags: bluetooth sysbuild
+    platform_allow:
+      - nrf52833dk/nrf52833
+      - nrf52833dk/nrf52820
+      - nrf5340dk/nrf5340/cpuapp
+    tags:
+      - bluetooth
+      - sysbuild
     integration_platforms:
       - nrf52833dk/nrf52833
       - nrf52833dk/nrf52820
@@ -15,8 +20,13 @@ tests:
     sysbuild: true
     extra_args: OVERLAY_CONFIG="overlay-aod.conf"
     build_only: true
-    platform_allow: nrf52833dk/nrf52833 nrf52833dk/nrf52820 nrf5340dk/nrf5340/cpuapp
-    tags: bluetooth sysbuild
+    platform_allow:
+      - nrf52833dk/nrf52833
+      - nrf52833dk/nrf52820
+      - nrf5340dk/nrf5340/cpuapp
+    tags:
+      - bluetooth
+      - sysbuild
     integration_platforms:
       - nrf52833dk/nrf52833
       - nrf52833dk/nrf52820

--- a/samples/bluetooth/direction_finding_connectionless_tx/sample.yaml
+++ b/samples/bluetooth/direction_finding_connectionless_tx/sample.yaml
@@ -9,7 +9,9 @@ tests:
       - nrf52833dk/nrf52833
       - nrf52833dk/nrf52820
       - nrf5340dk/nrf5340/cpuapp
-    tags: bluetooth sysbuild
+    tags:
+      - bluetooth
+      - sysbuild
     integration_platforms:
       - nrf52833dk/nrf52833
       - nrf52833dk/nrf52820
@@ -35,7 +37,9 @@ tests:
       - ipc_radio_SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf5340dk/nrf5340/cpuapp
-    tags: bluetooth sysbuild
+    tags:
+      - bluetooth
+      - sysbuild
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
   sample.bluetooth.direction_finding_connectionless_tx.aod.bt_ll_sw_split.nrf52:
@@ -60,6 +64,8 @@ tests:
       - ipc_radio_SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf5340dk/nrf5340/cpuapp
-    tags: bluetooth sysbuild
+    tags:
+      - bluetooth
+      - sysbuild
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp

--- a/samples/bluetooth/direction_finding_peripheral/sample.yaml
+++ b/samples/bluetooth/direction_finding_peripheral/sample.yaml
@@ -1,6 +1,7 @@
 sample:
   name: Direction Finding Peripheral
-  description: Sample application showing peripheral role of Direction Finding in connected mode
+  description: Sample application showing peripheral role of Direction Finding in
+    connected mode
 tests:
   sample.bluetooth.direction_finding_peripheral.aoa.sdc.nrf52_nrf53:
     sysbuild: true
@@ -11,7 +12,9 @@ tests:
       - nrf52833dk/nrf52833
       - nrf52833dk/nrf52820
       - nrf5340dk/nrf5340/cpuapp
-    tags: bluetooth sysbuild
+    tags:
+      - bluetooth
+      - sysbuild
     integration_platforms:
       - nrf52833dk/nrf52833
       - nrf52833dk/nrf52820
@@ -38,7 +41,9 @@ tests:
       - ipc_radio_SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf5340dk/nrf5340/cpuapp
-    tags: bluetooth sysbuild
+    tags:
+      - bluetooth
+      - sysbuild
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
   sample.bluetooth.direction_finding_peripheral.all.bt_ll_sw_split.nrf52:
@@ -62,6 +67,8 @@ tests:
       - ipc_radio_SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf5340dk/nrf5340/cpuapp
-    tags: bluetooth sysbuild
+    tags:
+      - bluetooth
+      - sysbuild
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp

--- a/samples/bluetooth/enocean/sample.yaml
+++ b/samples/bluetooth/enocean/sample.yaml
@@ -8,5 +8,10 @@ tests:
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/event_trigger/sample.yaml
+++ b/samples/bluetooth/event_trigger/sample.yaml
@@ -21,4 +21,7 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/fast_pair/input_device/sample.yaml
+++ b/samples/bluetooth/fast_pair/input_device/sample.yaml
@@ -1,6 +1,7 @@
 sample:
   name: Fast Pair input device
-  description: Bluetooth Fast Pair Provider sample setup for the input device use case
+  description: Bluetooth Fast Pair Provider sample setup for the input device use
+    case
 tests:
   sample.bluetooth.fast_pair.input_device:
     build_only: true
@@ -19,4 +20,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/fast_pair/locator_tag/sample.yaml
+++ b/samples/bluetooth/fast_pair/locator_tag/sample.yaml
@@ -25,7 +25,10 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
       - thingy53/nrf5340/cpuapp
       - thingy53/nrf5340/cpuapp/ns
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
   sample.bluetooth.fast_pair.locator_tag.release:
     sysbuild: true
     build_only: true
@@ -49,5 +52,8 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
       - thingy53/nrf5340/cpuapp
       - thingy53/nrf5340/cpuapp/ns
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
     extra_args: FILE_SUFFIX=release

--- a/samples/bluetooth/hci_lpuart/sample.yaml
+++ b/samples/bluetooth/hci_lpuart/sample.yaml
@@ -7,4 +7,7 @@ tests:
     platform_allow: nrf9160dk/nrf52840
     integration_platforms:
       - nrf9160dk/nrf52840
-    tags: uart bluetooth sysbuild
+    tags:
+      - uart
+      - bluetooth
+      - sysbuild

--- a/samples/bluetooth/iso_combined_bis_and_cis/sample.yaml
+++ b/samples/bluetooth/iso_combined_bis_and_cis/sample.yaml
@@ -21,4 +21,7 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/iso_time_sync/sample.yaml
+++ b/samples/bluetooth/iso_time_sync/sample.yaml
@@ -21,4 +21,7 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/llpm/sample.yaml
+++ b/samples/bluetooth/llpm/sample.yaml
@@ -21,4 +21,7 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/mesh/ble_peripheral_lbs_coex/sample.yaml
+++ b/samples/bluetooth/mesh/ble_peripheral_lbs_coex/sample.yaml
@@ -13,6 +13,15 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf52833dk/nrf52833 nrf21540dk/nrf52840
-        nrf54l15dk/nrf54l15/cpuapp nrf54l15dk/nrf54l10/cpuapp nrf54l15dk/nrf54l05/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf52833dk/nrf52833
+      - nrf21540dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/mesh/chat/sample.yaml
+++ b/samples/bluetooth/mesh/chat/sample.yaml
@@ -12,6 +12,14 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf21540dk/nrf52840
-        nrf54l15dk/nrf54l15/cpuapp nrf54l15dk/nrf54l10/cpuapp nrf54l15dk/nrf54l05/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf21540dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/mesh/dfu/distributor/sample.yaml
+++ b/samples/bluetooth/mesh/dfu/distributor/sample.yaml
@@ -8,9 +8,14 @@ tests:
       - nrf52840dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l10/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
   sample.bluetooth.mesh_dfu_distributor.smp_bt_auth:
     sysbuild: true
     build_only: true
@@ -18,7 +23,12 @@ tests:
       - nrf52840dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l10/cpuapp
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
     extra_args: OVERLAY_CONFIG=overlay-smp-bt-auth.conf
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/mesh/dfu/target/sample.yaml
+++ b/samples/bluetooth/mesh/dfu/target/sample.yaml
@@ -9,6 +9,12 @@ tests:
       - nrf52840dongle/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf52840dongle/nrf52840 nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l10/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52840dongle/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/mesh/light/sample.yaml
+++ b/samples/bluetooth/mesh/light/sample.yaml
@@ -16,11 +16,21 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
-      nrf5340dk/nrf5340/cpuapp/ns thingy53/nrf5340/cpuapp
-      nrf21540dk/nrf52840 nrf52833dk/nrf52833 nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l10/cpuapp nrf54l15dk/nrf54l05/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - thingy53/nrf5340/cpuapp
+      - nrf21540dk/nrf52840
+      - nrf52833dk/nrf52833
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
   sample.bluetooth.mesh.light.dfu:
     sysbuild: true
     build_only: true
@@ -29,9 +39,15 @@ tests:
       - nrf21540dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf21540dk/nrf52840 nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l10/cpuapp
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf21540dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
     extra_args:
       - EXTRA_CONF_FILE=overlay-dfu.conf
       - SB_CONF_FILE=sysbuild-dfu.conf
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/mesh/light_ctrl/sample.yaml
+++ b/samples/bluetooth/mesh/light_ctrl/sample.yaml
@@ -17,11 +17,22 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
-      nrf5340dk/nrf5340/cpuapp/ns thingy53/nrf5340/cpuapp
-      nrf21540dk/nrf52840 nrf52833dk/nrf52833 nrf52840dongle/nrf52840
-      nrf54l15dk/nrf54l15/cpuapp nrf54l15dk/nrf54l10/cpuapp nrf54l15dk/nrf54l05/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - thingy53/nrf5340/cpuapp
+      - nrf21540dk/nrf52840
+      - nrf52833dk/nrf52833
+      - nrf52840dongle/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
   sample.bluetooth.mesh.light_ctrl.emds:
     sysbuild: true
     extra_args: OVERLAY_CONFIG="overlay-emds.conf"
@@ -37,8 +48,18 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
-      nrf5340dk/nrf5340/cpuapp/ns thingy53/nrf5340/cpuapp
-      nrf21540dk/nrf52840 nrf52833dk/nrf52833 nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l10/cpuapp nrf54l15dk/nrf54l05/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - thingy53/nrf5340/cpuapp
+      - nrf21540dk/nrf52840
+      - nrf52833dk/nrf52833
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/mesh/light_dimmer/sample.yaml
+++ b/samples/bluetooth/mesh/light_dimmer/sample.yaml
@@ -17,8 +17,19 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
-      nrf5340dk/nrf5340/cpuapp/ns thingy53/nrf5340/cpuapp
-      nrf21540dk/nrf52840 nrf52833dk/nrf52833 nrf52840dongle/nrf52840
-      nrf54l15dk/nrf54l15/cpuapp nrf54l15dk/nrf54l10/cpuapp nrf54l15dk/nrf54l05/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - thingy53/nrf5340/cpuapp
+      - nrf21540dk/nrf52840
+      - nrf52833dk/nrf52833
+      - nrf52840dongle/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/mesh/light_switch/sample.yaml
+++ b/samples/bluetooth/mesh/light_switch/sample.yaml
@@ -16,11 +16,21 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
-      nrf5340dk/nrf5340/cpuapp/ns thingy53/nrf5340/cpuapp
-      nrf21540dk/nrf52840 nrf52833dk/nrf52833 nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l10/cpuapp nrf54l15dk/nrf54l05/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - thingy53/nrf5340/cpuapp
+      - nrf21540dk/nrf52840
+      - nrf52833dk/nrf52833
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
   sample.bluetooth.mesh.light_switch.lpn:
     sysbuild: true
     build_only: true
@@ -31,7 +41,15 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf52833dk/nrf52833
-      nrf54l15dk/nrf54l15/cpuapp nrf54l15dk/nrf54l10/cpuapp nrf54l15dk/nrf54l05/cpuapp
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf52833dk/nrf52833
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
     extra_args: OVERLAY_CONFIG=overlay-lpn.conf
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/mesh/sensor_client/sample.yaml
+++ b/samples/bluetooth/mesh/sensor_client/sample.yaml
@@ -12,6 +12,14 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf21540dk/nrf52840
-      nrf54l15dk/nrf54l15/cpuapp nrf54l15dk/nrf54l10/cpuapp nrf54l15dk/nrf54l05/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf21540dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/mesh/sensor_server/sample.yaml
+++ b/samples/bluetooth/mesh/sensor_server/sample.yaml
@@ -13,8 +13,15 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
-    platform_allow: >
-      nrf52dk/nrf52832 nrf52840dk/nrf52840 thingy53/nrf5340/cpuapp
-      nrf21540dk/nrf52840 nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l10/cpuapp nrf54l15dk/nrf54l05/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - thingy53/nrf5340/cpuapp
+      - nrf21540dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/mesh/silvair_enocean/sample.yaml
+++ b/samples/bluetooth/mesh/silvair_enocean/sample.yaml
@@ -15,8 +15,17 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
-      nrf5340dk/nrf5340/cpuapp/ns nrf21540dk/nrf52840 nrf52833dk/nrf52833
-      nrf54l15dk/nrf54l15/cpuapp nrf54l15dk/nrf54l10/cpuapp
-      nrf54l15dk/nrf54l05/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf21540dk/nrf52840
+      - nrf52833dk/nrf52833
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/multiple_adv_sets/sample.yaml
+++ b/samples/bluetooth/multiple_adv_sets/sample.yaml
@@ -12,6 +12,14 @@ tests:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
-      nrf5340dk/nrf5340/cpuapp/ns nrf54l15dk/nrf54l15/cpuapp nrf54h20dk/nrf54h20/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/nrf_auraconfig/sample.yaml
+++ b/samples/bluetooth/nrf_auraconfig/sample.yaml
@@ -7,7 +7,10 @@ common:
   platform_allow: nrf5340_audio_dk/nrf5340/cpuapp
   sysbuild: true
   build_only: true
-  tags: ci_build sysbuild bluetooth
+  tags:
+    - ci_build
+    - sysbuild
+    - bluetooth
 tests:
   sample.bluetooth.nrf_auraconfig.build:
     extra_args: []

--- a/samples/bluetooth/nrf_dm/sample.yaml
+++ b/samples/bluetooth/nrf_dm/sample.yaml
@@ -12,9 +12,15 @@ tests:
       - nrf52833dk/nrf52833
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
-    platform_allow: >
-      nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
   sample.bluetooth.nrf_dm.timeslot.high_precision:
     sysbuild: true
     build_only: true
@@ -24,5 +30,11 @@ tests:
       - nrf52833dk/nrf52833
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
-    platform_allow: nrf52833dk/nrf52833 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/peripheral_ams_client/sample.yaml
+++ b/samples/bluetooth/peripheral_ams_client/sample.yaml
@@ -11,6 +11,13 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
-      nrf5340dk/nrf5340/cpuapp/ns nrf54h20dk/nrf54h20/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf54h20dk/nrf54h20/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/peripheral_ancs_client/sample.yaml
+++ b/samples/bluetooth/peripheral_ancs_client/sample.yaml
@@ -11,6 +11,13 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
-      nrf5340dk/nrf5340/cpuapp/ns nrf54h20dk/nrf54h20/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf54h20dk/nrf54h20/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/peripheral_bms/sample.yaml
+++ b/samples/bluetooth/peripheral_bms/sample.yaml
@@ -11,6 +11,13 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp nrf54h20dk/nrf54h20/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/peripheral_cgms/sample.yaml
+++ b/samples/bluetooth/peripheral_cgms/sample.yaml
@@ -13,7 +13,15 @@ tests:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp nrf5340dk/nrf5340/cpuapp/ns nrf54l15dk/nrf54l15/cpuapp
-      nrf54h20dk/nrf54h20/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/peripheral_cts_client/sample.yaml
+++ b/samples/bluetooth/peripheral_cts_client/sample.yaml
@@ -12,6 +12,14 @@ tests:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
-      nrf5340dk/nrf5340/cpuapp/ns nrf54l15dk/nrf54l15/cpuapp nrf54h20dk/nrf54h20/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/peripheral_gatt_dm/sample.yaml
+++ b/samples/bluetooth/peripheral_gatt_dm/sample.yaml
@@ -12,6 +12,14 @@ tests:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
-      nrf5340dk/nrf5340/cpuapp/ns nrf54l15dk/nrf54l15/cpuapp nrf54h20dk/nrf54h20/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/peripheral_hids_keyboard/sample.yaml
+++ b/samples/bluetooth/peripheral_hids_keyboard/sample.yaml
@@ -11,7 +11,9 @@ tests:
     platform_allow:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
-    tags: bluetooth sysbuild
+    tags:
+      - bluetooth
+      - sysbuild
   sample.bluetooth.peripheral_hids_keyboard.build:
     sysbuild: true
     build_only: true
@@ -29,4 +31,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/peripheral_hids_mouse/sample.yaml
+++ b/samples/bluetooth/peripheral_hids_mouse/sample.yaml
@@ -11,7 +11,9 @@ tests:
     platform_allow:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
-    tags: bluetooth sysbuild
+    tags:
+      - bluetooth
+      - sysbuild
   sample.bluetooth.peripheral_hids_mouse.build:
     sysbuild: true
     build_only: true
@@ -33,7 +35,10 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
   sample.bluetooth.peripheral_hids_mouse.ble_rpc:
     sysbuild: true
     build_only: true
@@ -46,7 +51,10 @@ tests:
     platform_allow:
       - nrf5340dk/nrf5340/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
   sample.bluetooth.peripheral_hids_mouse.no_sec:
     sysbuild: true
     build_only: true
@@ -58,14 +66,21 @@ tests:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
   # Build integration regression protection.
   sample.nrf_security.bluetooth.integration:
     sysbuild: true
     build_only: true
-    extra_args: CONFIG_NRF_SECURITY=y CONFIG_BOOTLOADER_MCUBOOT=y
+    extra_args:
+      - CONFIG_NRF_SECURITY=y
+      - CONFIG_BOOTLOADER_MCUBOOT=y
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow:
       - nrf5340dk/nrf5340/cpuapp
-    tags: bluetooth sysbuild
+    tags:
+      - bluetooth
+      - sysbuild

--- a/samples/bluetooth/peripheral_hr_coded/sample.yaml
+++ b/samples/bluetooth/peripheral_hr_coded/sample.yaml
@@ -11,6 +11,12 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf54l15dk/nrf54l15/cpuapp
-      nrf54h20dk/nrf54h20/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/peripheral_lbs/sample.yaml
+++ b/samples/bluetooth/peripheral_lbs/sample.yaml
@@ -16,11 +16,21 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp nrf5340dk/nrf5340/cpuapp/ns thingy53/nrf5340/cpuapp
-      thingy53/nrf5340/cpuapp/ns nrf54l15dk/nrf54l05/cpuapp nrf54l15dk/nrf54l10/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp nrf54h20dk/nrf54h20/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - thingy53/nrf5340/cpuapp
+      - thingy53/nrf5340/cpuapp/ns
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
   sample.bluetooth.peripheral_lbs_minimal:
     sysbuild: true
     build_only: true
@@ -30,8 +40,15 @@ tests:
       - nrf52dk/nrf52810
       - nrf52840dk/nrf52811
       - nrf52833dk/nrf52820
-    platform_allow: nrf52dk/nrf52805 nrf52dk/nrf52810 nrf52840dk/nrf52811 nrf52833dk/nrf52820
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52dk/nrf52805
+      - nrf52dk/nrf52810
+      - nrf52840dk/nrf52811
+      - nrf52833dk/nrf52820
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
   sample.bluetooth.peripheral_lbs_no_security:
     sysbuild: true
     build_only: true
@@ -45,11 +62,19 @@ tests:
       - thingy53/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp nrf5340dk/nrf5340/cpuapp/ns thingy53/nrf5340/cpuapp
-      thingy53/nrf5340/cpuapp/ns nrf54l15dk/nrf54l15/cpuapp
-      nrf54h20dk/nrf54h20/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - thingy53/nrf5340/cpuapp
+      - thingy53/nrf5340/cpuapp/ns
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
   sample.bluetooth.peripheral_lbs_bt_ota_dfu:
     sysbuild: true
     build_only: true
@@ -58,9 +83,15 @@ tests:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
-      nrf5340dk/nrf5340/cpuapp/ns
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
     extra_configs:
       - CONFIG_BOOTLOADER_MCUBOOT=y
       - CONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU=y
@@ -70,7 +101,10 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
     platform_allow: nrf52840dk/nrf52840
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
     extra_args: mcuboot_CONFIG_BOOT_DIRECT_XIP=y
     extra_configs:
       - CONFIG_BOOTLOADER_MCUBOOT=y
@@ -82,8 +116,13 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
     platform_allow: nrf52840dk/nrf52840
-    tags: bluetooth ci_build sysbuild
-    extra_args: mcuboot_CONFIG_BOOT_DIRECT_XIP=y mcuboot_CONFIG_BOOT_DIRECT_XIP_REVERT=y
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
+    extra_args:
+      - mcuboot_CONFIG_BOOT_DIRECT_XIP=y
+      - mcuboot_CONFIG_BOOT_DIRECT_XIP_REVERT=y
     extra_configs:
       - CONFIG_BOOTLOADER_MCUBOOT=y
       - CONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU=y

--- a/samples/bluetooth/peripheral_mds/sample.yaml
+++ b/samples/bluetooth/peripheral_mds/sample.yaml
@@ -15,6 +15,14 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
-    platform_allow: nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp nrf5340dk/nrf5340/cpuapp/ns nrf54l15dk/nrf54l15/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/peripheral_nfc_pairing/sample.yaml
+++ b/samples/bluetooth/peripheral_nfc_pairing/sample.yaml
@@ -12,6 +12,14 @@ tests:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf52dk/nrf52832 nrf5340dk/nrf5340/cpuapp
-      nrf5340dk/nrf5340/cpuapp/ns nrf54l15dk/nrf54l15/cpuapp nrf54h20dk/nrf54h20/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52dk/nrf52832
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/peripheral_power_profiling/sample.yaml
+++ b/samples/bluetooth/peripheral_power_profiling/sample.yaml
@@ -14,11 +14,19 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    platform_allow: nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp nrf5340dk/nrf5340/cpuapp/ns nrf54l15dk/nrf54l05/cpuapp
-      nrf54l15dk/nrf54l10/cpuapp nrf54l15dk/nrf54l15/cpuapp
-    tags: bluetooth ci_build sysbuild
-
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
   sample.bluetooth.peripheral_power_profiling.auto_conn_advert_lfrc_0dBm_100ms:
     sysbuild: true
     harness: pytest
@@ -32,7 +40,11 @@ tests:
       - CONFIG_BT_CTLR_TX_PWR_0=y
       - CONFIG_BT_POWER_PROFILING_DATA_LENGTH=31
       - CONFIG_BT_POWER_PROFILING_NOTIFICATION_INTERVAL=100
-    tags: bluetooth ci_build sysbuild ppk_power_measure
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
+      - ppk_power_measure
     harness_config:
       fixture: ppk_power_measure
       pytest_root:
@@ -52,7 +64,11 @@ tests:
       - CONFIG_BT_CTLR_TX_PWR_PLUS_8=y
       - CONFIG_BT_POWER_PROFILING_DATA_LENGTH=31
       - CONFIG_BT_POWER_PROFILING_NOTIFICATION_INTERVAL=100
-    tags: bluetooth ci_build sysbuild ppk_power_measure
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
+      - ppk_power_measure
     harness_config:
       fixture: ppk_power_measure
       pytest_root:
@@ -72,7 +88,11 @@ tests:
       - CONFIG_BT_CTLR_TX_PWR_0=y
       - CONFIG_BT_POWER_PROFILING_DATA_LENGTH=31
       - CONFIG_BT_POWER_PROFILING_NOTIFICATION_INTERVAL=100
-    tags: bluetooth ci_build sysbuild ppk_power_measure
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
+      - ppk_power_measure
     harness_config:
       fixture: ppk_power_measure
       pytest_root:
@@ -92,7 +112,11 @@ tests:
       - CONFIG_BT_CTLR_TX_PWR_PLUS_8=y
       - CONFIG_BT_POWER_PROFILING_DATA_LENGTH=31
       - CONFIG_BT_POWER_PROFILING_NOTIFICATION_INTERVAL=100
-    tags: bluetooth ci_build sysbuild ppk_power_measure
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
+      - ppk_power_measure
     harness_config:
       fixture: ppk_power_measure
       pytest_root:
@@ -112,7 +136,11 @@ tests:
       - CONFIG_BT_CTLR_TX_PWR_0=y
       - CONFIG_BT_POWER_PROFILING_DATA_LENGTH=31
       - CONFIG_BT_POWER_PROFILING_NOTIFICATION_INTERVAL=100
-    tags: bluetooth ci_build sysbuild ppk_power_measure
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
+      - ppk_power_measure
     harness_config:
       fixture: ppk_power_measure
       pytest_root:

--- a/samples/bluetooth/peripheral_rscs/sample.yaml
+++ b/samples/bluetooth/peripheral_rscs/sample.yaml
@@ -13,7 +13,15 @@ tests:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: >
-      nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf52833dk/nrf52833 nrf5340dk/nrf5340/cpuapp
-      nrf5340dk/nrf5340/cpuapp/ns nrf54l15dk/nrf54l15/cpuapp nrf54h20dk/nrf54h20/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf52833dk/nrf52833
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/peripheral_status/sample.yaml
+++ b/samples/bluetooth/peripheral_status/sample.yaml
@@ -14,10 +14,20 @@ tests:
       - thingy53/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf52dk/nrf52810
-      nrf5340dk/nrf5340/cpuapp nrf5340dk/nrf5340/cpuapp/ns thingy53/nrf5340/cpuapp
-      thingy53/nrf5340/cpuapp/ns nrf54l15dk/nrf54l15/cpuapp nrf54h20dk/nrf54h20/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf52dk/nrf52810
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - thingy53/nrf5340/cpuapp
+      - thingy53/nrf5340/cpuapp/ns
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
   sample.bluetooth.peripheral_nsms_no_security:
     sysbuild: true
     build_only: true
@@ -31,7 +41,17 @@ tests:
       - thingy53/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf52dk/nrf52810
-      nrf5340dk/nrf5340/cpuapp nrf5340dk/nrf5340/cpuapp/ns thingy53/nrf5340/cpuapp
-      thingy53/nrf5340/cpuapp/ns nrf54l15dk/nrf54l15/cpuapp nrf54h20dk/nrf54h20/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf52dk/nrf52810
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - thingy53/nrf5340/cpuapp
+      - thingy53/nrf5340/cpuapp/ns
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/peripheral_uart/sample.yaml
+++ b/samples/bluetooth/peripheral_uart/sample.yaml
@@ -5,11 +5,20 @@ tests:
   sample.bluetooth.peripheral_uart:
     sysbuild: true
     build_only: true
-    platform_allow: nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp nrf5340dk/nrf5340/cpuapp/ns thingy53/nrf5340/cpuapp
-      thingy53/nrf5340/cpuapp/ns nrf21540dk/nrf52840 nrf54l15dk/nrf54l05/cpuapp
-      nrf54l15dk/nrf54l10/cpuapp nrf54l15dk/nrf54l15/cpuapp
-      nrf54h20dk/nrf54h20/cpuapp nrf54h20dk/nrf54h20/cpurad
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - thingy53/nrf5340/cpuapp
+      - thingy53/nrf5340/cpuapp/ns
+      - nrf21540dk/nrf52840
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54h20dk/nrf54h20/cpurad
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52833dk/nrf52833
@@ -24,16 +33,26 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
   sample.bluetooth.peripheral_uart_cdc:
     sysbuild: true
     build_only: true
-    extra_args: OVERLAY_CONFIG=prj_cdc.conf DTC_OVERLAY_FILE="usb.overlay"
+    extra_args:
+      - OVERLAY_CONFIG=prj_cdc.conf
+      - DTC_OVERLAY_FILE="usb.overlay"
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf52833dk/nrf52833
-    platform_allow: nrf52840dk/nrf52840 nrf52833dk/nrf52833
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52833dk/nrf52833
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
   sample.bluetooth.peripheral_uart_minimal:
     sysbuild: true
     build_only: true
@@ -43,8 +62,15 @@ tests:
       - nrf52dk/nrf52810
       - nrf52840dk/nrf52811
       - nrf52833dk/nrf52820
-    platform_allow: nrf52dk/nrf52805 nrf52dk/nrf52810 nrf52840dk/nrf52811 nrf52833dk/nrf52820
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52dk/nrf52805
+      - nrf52dk/nrf52810
+      - nrf52840dk/nrf52811
+      - nrf52833dk/nrf52820
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
   sample.bluetooth.peripheral_uart_ble_rpc:
     sysbuild: true
     build_only: true
@@ -54,16 +80,30 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf5340dk/nrf5340/cpuapp nrf54h20dk/nrf54h20/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
   sample.bluetooth.peripheral_uart.security_disabled:
     sysbuild: true
     build_only: true
-    platform_allow: nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp nrf5340dk/nrf5340/cpuapp/ns thingy53/nrf5340/cpuapp
-      thingy53/nrf5340/cpuapp/ns nrf21540dk/nrf52840
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - thingy53/nrf5340/cpuapp
+      - thingy53/nrf5340/cpuapp/ns
+      - nrf21540dk/nrf52840
     integration_platforms:
       - nrf52840dk/nrf52840
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
     extra_configs:
       - CONFIG_BT_NUS_SECURITY_ENABLED=n

--- a/samples/bluetooth/peripheral_with_multiple_identities/sample.yaml
+++ b/samples/bluetooth/peripheral_with_multiple_identities/sample.yaml
@@ -19,4 +19,7 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/radio_coex_1wire/sample.yaml
+++ b/samples/bluetooth/radio_coex_1wire/sample.yaml
@@ -17,4 +17,7 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/radio_notification_cb/sample.yaml
+++ b/samples/bluetooth/radio_notification_cb/sample.yaml
@@ -21,4 +21,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/rpc_host/sample.yaml
+++ b/samples/bluetooth/rpc_host/sample.yaml
@@ -8,4 +8,7 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpunet
     platform_allow: nrf5340dk/nrf5340/cpunet
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/scanning_while_connecting/sample.yaml
+++ b/samples/bluetooth/scanning_while_connecting/sample.yaml
@@ -17,4 +17,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/shell_bt_nus/sample.yaml
+++ b/samples/bluetooth/shell_bt_nus/sample.yaml
@@ -12,6 +12,14 @@ tests:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
-      nrf5340dk/nrf5340/cpuapp/ns nrf54l15dk/nrf54l15/cpuapp nrf54h20dk/nrf54h20/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/subrating/sample.yaml
+++ b/samples/bluetooth/subrating/sample.yaml
@@ -23,4 +23,7 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/throughput/sample.yaml
+++ b/samples/bluetooth/throughput/sample.yaml
@@ -12,6 +12,14 @@ tests:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
-      nrf5340dk/nrf5340/cpuapp/ns nrf54l15dk/nrf54l15/cpuapp nrf54h20dk/nrf54h20/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bootloader/sample.yaml
+++ b/samples/bootloader/sample.yaml
@@ -24,4 +24,7 @@ tests:
       - nrf21540dk/nrf52840
     extra_args:
       - SB_CONFIG_PARTITION_MANAGER=n
-    tags: ci_build sysbuild ci_samples_bootloader
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_bootloader

--- a/samples/caf/sample.yaml
+++ b/samples/caf/sample.yaml
@@ -8,5 +8,11 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
-    tags: caf ci_build sysbuild ci_samples_caf
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+    tags:
+      - caf
+      - ci_build
+      - sysbuild
+      - ci_samples_caf

--- a/samples/caf_sensor_manager/sample.yaml
+++ b/samples/caf_sensor_manager/sample.yaml
@@ -7,7 +7,10 @@ tests:
     sysbuild: true
     build_only: false
     harness: console
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp qemu_cortex_m3
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - qemu_cortex_m3
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
@@ -20,43 +23,62 @@ tests:
         - "main state:READY"
         - "Send sensor buffer desc address:"
         - "sensor_data_aggregator_release_buffer_event"
-    tags: sysbuild ci_samples_caf_sensor_manager
+    tags:
+      - sysbuild
+      - ci_samples_caf_sensor_manager
   sample.caf_sensor_manager.nrf52840dk.power_consumption_test:
     sysbuild: true
     build_only: true
     platform_allow: nrf52840dk/nrf52840
     integration_platforms:
       - nrf52840dk/nrf52840
-    extra_args: CONFIG_SERIAL=n CONFIG_CONSOLE=n CONFIG_UART_CONSOLE=n CONFIG_LOG=n
-    tags: sysbuild ci_samples_caf_sensor_manager
+    extra_args:
+      - CONFIG_SERIAL=n
+      - CONFIG_CONSOLE=n
+      - CONFIG_UART_CONSOLE=n
+      - CONFIG_LOG=n
+    tags:
+      - sysbuild
+      - ci_samples_caf_sensor_manager
   sample.caf_sensor_manager.multi_core.power_consumption_test:
     sysbuild: true
     build_only: true
     platform_allow: nrf5340dk/nrf5340/cpuapp
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
-    extra_args: >
-      CONFIG_SERIAL=n CONFIG_CONSOLE=n CONFIG_UART_CONSOLE=n CONFIG_LOG=n remote_CONFIG_SERIAL=n
-      remote_CONFIG_CONSOLE=n remote_CONFIG_UART_CONSOLE=n remote_CONFIG_LOG=n
-    tags: sysbuild ci_samples_caf_sensor_manager
+    extra_args:
+      - CONFIG_SERIAL=n
+      - CONFIG_CONSOLE=n
+      - CONFIG_UART_CONSOLE=n
+      - CONFIG_LOG=n
+      - remote_CONFIG_SERIAL=n
+      - remote_CONFIG_CONSOLE=n
+      - remote_CONFIG_UART_CONSOLE=n
+      - remote_CONFIG_LOG=n
+    tags:
+      - sysbuild
+      - ci_samples_caf_sensor_manager
   sample.caf_sensor_manager.nrf5340dk_singlecore.power_consumption_test:
     sysbuild: true
     build_only: true
     platform_allow: nrf5340dk/nrf5340/cpuapp
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
-    extra_args: >
-      FILE_SUFFIX=singlecore
-      CONFIG_CONSOLE=n CONFIG_UART_CONSOLE=n CONFIG_LOG=n
-    tags: sysbuild ci_samples_caf_sensor_manager
+    extra_args:
+      - FILE_SUFFIX=singlecore
+      - CONFIG_CONSOLE=n
+      - CONFIG_UART_CONSOLE=n
+      - CONFIG_LOG=n
+    tags:
+      - sysbuild
+      - ci_samples_caf_sensor_manager
   sample.caf_sensor_manager.nrf5340dk_singlecore.correctness_test:
     sysbuild: true
     build_only: false
     platform_allow: nrf5340dk/nrf5340/cpuapp
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
-    extra_args:
-      FILE_SUFFIX=singlecore
+    extra_args: FILE_SUFFIX=singlecore
     harness: console
     harness_config:
       type: multi_line
@@ -66,7 +88,9 @@ tests:
         - "main state:READY"
         - "Send sensor buffer desc address:"
         - "sensor_data_aggregator_release_buffer_event"
-    tags: sysbuild ci_samples_caf_sensor_manager
+    tags:
+      - sysbuild
+      - ci_samples_caf_sensor_manager
   sample.caf_sensor_manager.nrf54h20.multicore:
     build_only: true
     sysbuild: true
@@ -74,10 +98,11 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
-    extra_args:
-      caf_sensor_manager_SNIPPET=nordic-ppr
-    tags: sysbuild ci_samples_caf_sensor_manager
+    extra_args: caf_sensor_manager_SNIPPET=nordic-ppr
+    tags:
 
+      - sysbuild
+      - ci_samples_caf_sensor_manager
   sample.caf_sensor_manager.nrf54h20.singlecore:
     build_only: true
     sysbuild: true
@@ -85,6 +110,7 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
-    extra_args:
-      FILE_SUFFIX=singlecore
-    tags: sysbuild ci_samples_caf_sensor_manager
+    extra_args: FILE_SUFFIX=singlecore
+    tags:
+      - sysbuild
+      - ci_samples_caf_sensor_manager

--- a/samples/cellular/at_client/sample.yaml
+++ b/samples/cellular/at_client/sample.yaml
@@ -14,4 +14,7 @@ tests:
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
       - thingy91x/nrf9151/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular

--- a/samples/cellular/at_monitor/sample.yaml
+++ b/samples/cellular/at_monitor/sample.yaml
@@ -12,4 +12,7 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular

--- a/samples/cellular/battery/sample.yaml
+++ b/samples/cellular/battery/sample.yaml
@@ -12,4 +12,7 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular

--- a/samples/cellular/ciphersuites/sample.yaml
+++ b/samples/cellular/ciphersuites/sample.yaml
@@ -12,4 +12,7 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular

--- a/samples/cellular/fmfu_smp_svr/sample.yaml
+++ b/samples/cellular/fmfu_smp_svr/sample.yaml
@@ -13,4 +13,7 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular

--- a/samples/cellular/gnss/sample.yaml
+++ b/samples/cellular/gnss/sample.yaml
@@ -12,8 +12,10 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild ci_samples_cellular
-
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   # Following configurations will be used by the positioning CI integration job to verify PRs
   sample.cellular.gnss.integration_config_positioning_agnss_nrfcloud_ltem_pvt:
     sysbuild: true
@@ -38,7 +40,10 @@ tests:
       - nrf9151dk/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.gnss.integration_config_positioning_agnss_nrfcloud_nbiot_nmea_lte_on:
     sysbuild: true
     build_only: true
@@ -62,7 +67,10 @@ tests:
       - nrf9151dk/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.gnss.integration_config_positioning_pgps_nrfcloud_ltem_nmea:
     sysbuild: true
     build_only: true
@@ -87,7 +95,10 @@ tests:
       - nrf9151dk/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.gnss.integration_config_positioning_gnss_ltem_pvt:
     sysbuild: true
     build_only: true
@@ -111,4 +122,7 @@ tests:
       - nrf9151dk/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular

--- a/samples/cellular/http_update/application_update/sample.yaml
+++ b/samples/cellular/http_update/application_update/sample.yaml
@@ -12,7 +12,10 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.http_update.application_update.lwm2m_carrier:
     sysbuild: true
     build_only: true
@@ -25,4 +28,7 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular

--- a/samples/cellular/http_update/modem_delta_update/sample.yaml
+++ b/samples/cellular/http_update/modem_delta_update/sample.yaml
@@ -12,4 +12,7 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular

--- a/samples/cellular/http_update/modem_full_update/sample.yaml
+++ b/samples/cellular/http_update/modem_full_update/sample.yaml
@@ -12,4 +12,7 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular

--- a/samples/cellular/location/sample.yaml
+++ b/samples/cellular/location/sample.yaml
@@ -16,7 +16,10 @@ tests:
       - nrf9161dk/nrf9161/ns
       - thingy91/nrf9160/ns
       - thingy91x/nrf9151/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.location.pgps:
     sysbuild: true
     build_only: true
@@ -29,7 +32,10 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.location.nrf7002ek_wifi:
     sysbuild: true
     build_only: true
@@ -41,9 +47,15 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    extra_args: SHIELD=nrf7002ek_nrf7000 EXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf
-                SB_CONFIG_WIFI_NRF70=y SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
-    tags: ci_build sysbuild ci_samples_cellular
+    extra_args:
+      - SHIELD=nrf7002ek_nrf7000
+      - EXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf
+      - SB_CONFIG_WIFI_NRF70=y
+      - SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.location.nrf7000ek_wifi:
     sysbuild: true
     build_only: true
@@ -55,11 +67,16 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    extra_args: SHIELD=nrf7002ek_nrf7000 EXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf
-                CONFIG_WIFI_NM_WPA_SUPPLICANT=n SB_CONFIG_WIFI_NRF70=y
-                SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
-    tags: ci_build sysbuild ci_samples_cellular
-
+    extra_args:
+      - SHIELD=nrf7002ek_nrf7000
+      - EXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf
+      - CONFIG_WIFI_NM_WPA_SUPPLICANT=n
+      - SB_CONFIG_WIFI_NRF70=y
+      - SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   # Configuration which will be used by the CI positioning integration job to verify PRs
   sample.cellular.location.integration_config_positioning:
     sysbuild: true
@@ -72,4 +89,7 @@ tests:
       - nrf9151dk/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular

--- a/samples/cellular/lte_ble_gateway/sample.yaml
+++ b/samples/cellular/lte_ble_gateway/sample.yaml
@@ -7,4 +7,7 @@ tests:
     integration_platforms:
       - nrf9160dk/nrf9160/ns
     platform_allow: nrf9160dk/nrf9160/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular

--- a/samples/cellular/lwm2m_carrier/sample.yaml
+++ b/samples/cellular/lwm2m_carrier/sample.yaml
@@ -12,7 +12,10 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.lwm2m_carrier.shell:
     sysbuild: true
     build_only: true
@@ -23,7 +26,10 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
     extra_args: EXTRA_CONF_FILE="overlay-shell.conf"
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.lwm2m_carrier.softbank:
     sysbuild: true
     build_only: true
@@ -33,9 +39,13 @@ tests:
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-    extra_args: EXTRA_CONF_FILE="overlay-softbank.conf"
-      SB_EXTRA_CONF_FILE="sysbuild-softbank.conf"
-    tags: ci_build sysbuild ci_samples_cellular
+    extra_args:
+      - EXTRA_CONF_FILE="overlay-softbank.conf"
+      - SB_EXTRA_CONF_FILE="sysbuild-softbank.conf"
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.lwm2m_carrier.lgu:
     sysbuild: true
     build_only: true
@@ -45,6 +55,10 @@ tests:
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-    extra_args: EXTRA_CONF_FILE="overlay-lgu.conf"
-      SB_EXTRA_CONF_FILE="sysbuild-lgu.conf"
-    tags: ci_build sysbuild ci_samples_cellular
+    extra_args:
+      - EXTRA_CONF_FILE="overlay-lgu.conf"
+      - SB_EXTRA_CONF_FILE="sysbuild-lgu.conf"
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular

--- a/samples/cellular/lwm2m_client/sample.yaml
+++ b/samples/cellular/lwm2m_client/sample.yaml
@@ -15,7 +15,10 @@ tests:
       - nrf9161dk/nrf9161/ns
       - thingy91/nrf9160/ns
       - thingy91x/nrf9151/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.lwm2m_client.afwu_extcpu:
     build_only: true
     extra_args:
@@ -25,4 +28,7 @@ tests:
       - nrf9160dk/nrf9160/ns
     platform_allow:
       - nrf9160dk/nrf9160/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular

--- a/samples/cellular/modem_callbacks/sample.yaml
+++ b/samples/cellular/modem_callbacks/sample.yaml
@@ -12,4 +12,7 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular

--- a/samples/cellular/modem_shell/sample.yaml
+++ b/samples/cellular/modem_shell/sample.yaml
@@ -12,7 +12,10 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell_debug:
     sysbuild: true
     build_only: true
@@ -25,7 +28,10 @@ tests:
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
     extra_args: EXTRA_CONF_FILE=overlay-debug.conf
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell.cloud_mqtt_only:
     sysbuild: true
     build_only: true
@@ -40,7 +46,10 @@ tests:
     extra_configs:
       - CONFIG_LOCATION_SERVICE_NRF_CLOUD_GNSS_POS_SEND=y
     extra_args: EXTRA_CONF_FILE=overlay-cloud_mqtt.conf
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell.cloud_mqtt_rest:
     sysbuild: true
     build_only: true
@@ -55,7 +64,10 @@ tests:
     extra_configs:
       - CONFIG_MOSH_CLOUD_MQTT=y
       - CONFIG_MOSH_CLOUD_REST=y
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell.cloud_coap_only:
     sysbuild: true
     build_only: true
@@ -70,7 +82,10 @@ tests:
     extra_configs:
       - CONFIG_LOCATION_SERVICE_NRF_CLOUD_GNSS_POS_SEND=y
     extra_args: EXTRA_CONF_FILE=overlay-cloud_coap.conf
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell.non_offloading_ip:
     sysbuild: true
     build_only: true
@@ -83,7 +98,10 @@ tests:
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
     extra_args: EXTRA_CONF_FILE=overlay-non-offloading.conf
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell.nrf7002ek_wifi:
     sysbuild: true
     build_only: true
@@ -95,9 +113,15 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    extra_args: SHIELD=nrf7002ek_nrf7000 EXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf
-                SB_CONFIG_WIFI_NRF70=y SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
-    tags: ci_build sysbuild ci_samples_cellular
+    extra_args:
+      - SHIELD=nrf7002ek_nrf7000
+      - EXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf
+      - SB_CONFIG_WIFI_NRF70=y
+      - SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell.nrf7000ek_wifi:
     sysbuild: true
     build_only: true
@@ -109,10 +133,16 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    extra_args: SHIELD=nrf7002ek_nrf7000 EXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf
-                CONFIG_WIFI_NM_WPA_SUPPLICANT=n SB_CONFIG_WIFI_NRF70=y
-                SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
-    tags: ci_build sysbuild ci_samples_cellular
+    extra_args:
+      - SHIELD=nrf7002ek_nrf7000
+      - EXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf
+      - CONFIG_WIFI_NM_WPA_SUPPLICANT=n
+      - SB_CONFIG_WIFI_NRF70=y
+      - SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell.nrf7002ek_wifi-debug:
     sysbuild: true
     build_only: true
@@ -124,10 +154,15 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    extra_args: SHIELD=nrf7002ek_nrf7000
-                EXTRA_CONF_FILE="overlay-nrf700x-wifi-scan-only.conf;overlay-debug.conf"
-                SB_CONFIG_WIFI_NRF70=y SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
-    tags: ci_build sysbuild ci_samples_cellular
+    extra_args:
+      - SHIELD=nrf7002ek_nrf7000
+      - EXTRA_CONF_FILE="overlay-nrf700x-wifi-scan-only.conf;overlay-debug.conf"
+      - SB_CONFIG_WIFI_NRF70=y
+      - SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell.app_fota:
     sysbuild: true
     build_only: true
@@ -139,30 +174,42 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    extra_args: EXTRA_CONF_FILE=overlay-app_fota.conf
-                SB_CONFIG_BOOTLOADER_MCUBOOT=y
-    tags: ci_build sysbuild ci_samples_cellular
+    extra_args:
+      - EXTRA_CONF_FILE=overlay-app_fota.conf
+      - SB_CONFIG_BOOTLOADER_MCUBOOT=y
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell.modem_fota_full.nrf9160:
     sysbuild: true
     build_only: true
-    extra_args: EXTRA_CONF_FILE=overlay-modem_fota_full.conf
-                EXTRA_DTC_OVERLAY_FILE="nrf9160dk_ext_flash.overlay"
+    extra_args:
+      - EXTRA_CONF_FILE=overlay-modem_fota_full.conf
+      - EXTRA_DTC_OVERLAY_FILE="nrf9160dk_ext_flash.overlay"
     integration_platforms:
       - nrf9160dk/nrf9160/ns
     platform_allow: nrf9160dk/nrf9160/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell.modem_fota_full.nrf91x1:
     sysbuild: true
     build_only: true
-    extra_args: EXTRA_CONF_FILE=overlay-modem_fota_full.conf
-                EXTRA_DTC_OVERLAY_FILE="nrf9161dk_ext_flash.overlay"
+    extra_args:
+      - EXTRA_CONF_FILE=overlay-modem_fota_full.conf
+      - EXTRA_DTC_OVERLAY_FILE="nrf9161dk_ext_flash.overlay"
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9161dk/nrf9161/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell.carrier:
     sysbuild: true
     build_only: true
@@ -175,7 +222,10 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell.lwm2m:
     sysbuild: true
     build_only: true
@@ -190,7 +240,10 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell.lwm2m_bootstrap:
     sysbuild: true
     build_only: true
@@ -205,7 +258,10 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell.lwm2m_pgps:
     sysbuild: true
     build_only: true
@@ -220,7 +276,10 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell.pgps:
     sysbuild: true
     build_only: true
@@ -233,7 +292,10 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell.pgps_coap:
     sysbuild: true
     build_only: true
@@ -246,7 +308,10 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell.location_service_ext:
     sysbuild: true
     build_only: true
@@ -261,16 +326,21 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell.location_service_ext_pgps_nrf7002ek_wifi:
     sysbuild: true
     build_only: true
     extra_configs:
       - CONFIG_LOCATION_SERVICE_EXTERNAL=y
       - CONFIG_NRF_CLOUD_PGPS_TRANSPORT_NONE=y
-    extra_args: SHIELD=nrf7002ek_nrf7000
-                EXTRA_CONF_FILE="overlay-cloud_mqtt.conf;overlay-pgps.conf;overlay-nrf700x-wifi-scan-only.conf"
-                SB_CONFIG_WIFI_NRF70=y SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
+    extra_args:
+      - SHIELD=nrf7002ek_nrf7000
+      - EXTRA_CONF_FILE="overlay-cloud_mqtt.conf;overlay-pgps.conf;overlay-nrf700x-wifi-scan-only.conf"
+      - SB_CONFIG_WIFI_NRF70=y
+      - SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
@@ -279,11 +349,16 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell.ppp:
     sysbuild: true
     build_only: true
-    extra_args: EXTRA_CONF_FILE=overlay-ppp.conf EXTRA_DTC_OVERLAY_FILE="ppp.overlay"
+    extra_args:
+      - EXTRA_CONF_FILE=overlay-ppp.conf
+      - EXTRA_DTC_OVERLAY_FILE="ppp.overlay"
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
@@ -292,15 +367,23 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell.bt:
     sysbuild: true
     build_only: true
-    extra_args: EXTRA_CONF_FILE=overlay-bt.conf EXTRA_DTC_OVERLAY_FILE="bt.overlay"
+    extra_args:
+      - EXTRA_CONF_FILE=overlay-bt.conf
+      - EXTRA_DTC_OVERLAY_FILE="bt.overlay"
     integration_platforms:
       - nrf9160dk/nrf9160/ns
     platform_allow: nrf9160dk/nrf9160/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell.rtt:
     sysbuild: true
     build_only: true
@@ -313,7 +396,10 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell.thingy91:
     sysbuild: true
     build_only: true
@@ -323,7 +409,10 @@ tests:
     platform_allow:
       - thingy91/nrf9160/ns
       - thingy91x/nrf9151/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell.thingy91x_wifi:
     sysbuild: true
     build_only: true
@@ -331,10 +420,15 @@ tests:
       - thingy91x/nrf9151/ns
     platform_allow:
       - thingy91x/nrf9151/ns
-    extra_args: EXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf
-                EXTRA_DTC_OVERLAY_FILE=thingy91x_wifi.overlay
-                SB_CONFIG_WIFI_NRF70=y SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
-    tags: ci_build sysbuild ci_samples_cellular
+    extra_args:
+      - EXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf
+      - EXTRA_DTC_OVERLAY_FILE=thingy91x_wifi.overlay
+      - SB_CONFIG_WIFI_NRF70=y
+      - SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell.modem_trace_shell_ext_flash:
     sysbuild: true
     build_only: true
@@ -349,7 +443,10 @@ tests:
     extra_args: modem_shell_SNIPPET="nrf91-modem-trace-ext-flash"
     extra_configs:
       - CONFIG_NRF_MODEM_LIB_SHELL_TRACE=y
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell.modem_trace_ram:
     sysbuild: true
     build_only: true
@@ -362,8 +459,10 @@ tests:
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
     extra_args: EXTRA_CONF_FILE="overlay-modem-trace-ram.conf"
-    tags: ci_build sysbuild ci_samples_cellular
-
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   # Configurations for different location method combinations
   sample.cellular.modem_shell.location_gnss_wifi_no_cellular:
     sysbuild: true
@@ -380,9 +479,15 @@ tests:
       - CONFIG_LOCATION_METHOD_GNSS=y
       - CONFIG_LOCATION_METHOD_CELLULAR=n
       - CONFIG_LOCATION_METHOD_WIFI=y
-    extra_args: SHIELD=nrf7002ek_nrf7000 EXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf
-                SB_CONFIG_WIFI_NRF70=y SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
-    tags: ci_build sysbuild ci_samples_cellular
+    extra_args:
+      - SHIELD=nrf7002ek_nrf7000
+      - EXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf
+      - SB_CONFIG_WIFI_NRF70=y
+      - SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell.location_wifi_cellular_no_gnss:
     sysbuild: true
     build_only: true
@@ -398,9 +503,15 @@ tests:
       - CONFIG_LOCATION_METHOD_GNSS=n
       - CONFIG_LOCATION_METHOD_CELLULAR=y
       - CONFIG_LOCATION_METHOD_WIFI=y
-    extra_args: SHIELD=nrf7002ek_nrf7000 EXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf
-                SB_CONFIG_WIFI_NRF70=y SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
-    tags: ci_build sysbuild ci_samples_cellular
+    extra_args:
+      - SHIELD=nrf7002ek_nrf7000
+      - EXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf
+      - SB_CONFIG_WIFI_NRF70=y
+      - SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell.location_wifi_no_cellular_no_gnss:
     sysbuild: true
     build_only: true
@@ -416,9 +527,15 @@ tests:
       - CONFIG_LOCATION_METHOD_GNSS=n
       - CONFIG_LOCATION_METHOD_CELLULAR=n
       - CONFIG_LOCATION_METHOD_WIFI=y
-    extra_args: SHIELD=nrf7002ek_nrf7000 EXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf
-                SB_CONFIG_WIFI_NRF70=y SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
-    tags: ci_build sysbuild ci_samples_cellular
+    extra_args:
+      - SHIELD=nrf7002ek_nrf7000
+      - EXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf
+      - SB_CONFIG_WIFI_NRF70=y
+      - SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell.location_gnss_no_wifi_no_cellular:
     sysbuild: true
     build_only: true
@@ -434,7 +551,10 @@ tests:
       - CONFIG_LOCATION_METHOD_GNSS=y
       - CONFIG_LOCATION_METHOD_CELLULAR=n
       - CONFIG_LOCATION_METHOD_WIFI=n
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell.location_cellular_no_wifi_no_gnss:
     sysbuild: true
     build_only: true
@@ -450,8 +570,10 @@ tests:
       - CONFIG_LOCATION_METHOD_GNSS=n
       - CONFIG_LOCATION_METHOD_CELLULAR=y
       - CONFIG_LOCATION_METHOD_WIFI=n
-    tags: ci_build sysbuild ci_samples_cellular
-
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   # Configurations with location data details and some location method combinations
   sample.cellular.modem_shell.location_gnss_wifi_cellular_details:
     sysbuild: true
@@ -469,9 +591,15 @@ tests:
       - CONFIG_LOCATION_METHOD_GNSS=y
       - CONFIG_LOCATION_METHOD_CELLULAR=y
       - CONFIG_LOCATION_METHOD_WIFI=y
-    extra_args: SHIELD=nrf7002ek_nrf7000 EXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf
-                SB_CONFIG_WIFI_NRF70=y SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
-    tags: ci_build sysbuild ci_samples_cellular
+    extra_args:
+      - SHIELD=nrf7002ek_nrf7000
+      - EXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf
+      - SB_CONFIG_WIFI_NRF70=y
+      - SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell.location_gnss_no_wifi_no_cellular_details:
     sysbuild: true
     build_only: true
@@ -488,7 +616,10 @@ tests:
       - CONFIG_LOCATION_METHOD_GNSS=y
       - CONFIG_LOCATION_METHOD_CELLULAR=n
       - CONFIG_LOCATION_METHOD_WIFI=n
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell.location_wifi_cellular_no_gnss_details:
     sysbuild: true
     build_only: true
@@ -505,9 +636,15 @@ tests:
       - CONFIG_LOCATION_METHOD_GNSS=n
       - CONFIG_LOCATION_METHOD_CELLULAR=y
       - CONFIG_LOCATION_METHOD_WIFI=y
-    extra_args: SHIELD=nrf7002ek_nrf7000 EXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf
-                SB_CONFIG_WIFI_NRF70=y SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
-    tags: ci_build sysbuild ci_samples_cellular
+    extra_args:
+      - SHIELD=nrf7002ek_nrf7000
+      - EXTRA_CONF_FILE=overlay-nrf700x-wifi-scan-only.conf
+      - SB_CONFIG_WIFI_NRF70=y
+      - SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell.location_gnss_cellular_no_wifi_details:
     sysbuild: true
     build_only: true
@@ -524,8 +661,10 @@ tests:
       - CONFIG_LOCATION_METHOD_GNSS=y
       - CONFIG_LOCATION_METHOD_CELLULAR=y
       - CONFIG_LOCATION_METHOD_WIFI=n
-    tags: ci_build sysbuild ci_samples_cellular
-
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   # Configurations with modem UART traces to make sure they fit into image.
   # Basic UART trace configuration is tested in sample.cellular.modem_shell.integration_config.
   sample.cellular.modem_shell_modem_uart_trace:
@@ -540,13 +679,16 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell.non_offloading_ip_modem_uart_trace:
     sysbuild: true
     build_only: true
     extra_args:
-      EXTRA_CONF_FILE=overlay-non-offloading.conf
-      modem_shell_SNIPPET="nrf91-modem-trace-uart"
+      - EXTRA_CONF_FILE=overlay-non-offloading.conf
+      - modem_shell_SNIPPET="nrf91-modem-trace-uart"
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
@@ -555,7 +697,10 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell.thingy91_modem_uart_trace:
     sysbuild: true
     build_only: true
@@ -566,8 +711,10 @@ tests:
     platform_allow:
       - thingy91/nrf9160/ns
       - thingy91x/nrf9151/ns
-    tags: ci_build sysbuild ci_samples_cellular
-
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   # Configuration which will be used by the CI integration job to verify PRs
   sample.cellular.modem_shell.integration_config:
     sysbuild: true
@@ -580,4 +727,7 @@ tests:
       - nrf9151dk/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular

--- a/samples/cellular/modem_trace_backend/sample.yaml
+++ b/samples/cellular/modem_trace_backend/sample.yaml
@@ -12,4 +12,7 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular

--- a/samples/cellular/modem_trace_flash/sample.yaml
+++ b/samples/cellular/modem_trace_flash/sample.yaml
@@ -12,4 +12,7 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular

--- a/samples/cellular/nidd/sample.yaml
+++ b/samples/cellular/nidd/sample.yaml
@@ -15,4 +15,7 @@ tests:
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
       - thingy91/nrf9160/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular

--- a/samples/cellular/nrf_cloud_multi_service/sample.yaml
+++ b/samples/cellular/nrf_cloud_multi_service/sample.yaml
@@ -16,16 +16,22 @@ tests:
       - nrf9161dk/nrf9161/ns
       - thingy91/nrf9160/ns
       - thingy91x/nrf9151/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.nrf_cloud_multi_service.mqtt.full:
     sysbuild: true
     build_only: true
     platform_allow: nrf9160dk/nrf9160/ns
     integration_platforms:
       - nrf9160dk/nrf9160/ns
-    extra_args: "EXTRA_CONF_FILE=\"overlay_full_modem_fota.conf;\
-      overlay_pgps_ext_flash.conf;overlay_mcuboot_ext_flash.conf\""
-    tags: ci_build sysbuild ci_samples_cellular
+    extra_args:
+      - "EXTRA_CONF_FILE=\"overlay_full_modem_fota.conf;overlay_pgps_ext_flash.conf;overlay_mcuboot_ext_flash.conf\""
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.nrf_cloud_multi_service.mqtt.min:
     sysbuild: true
     build_only: true
@@ -33,7 +39,10 @@ tests:
     integration_platforms:
       - nrf9160dk/nrf9160/ns
     extra_args: EXTRA_CONF_FILE="overlay_min_mqtt.conf"
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.nrf_cloud_multi_service.coap:
     sysbuild: true
     build_only: true
@@ -50,7 +59,10 @@ tests:
       - thingy91/nrf9160/ns
       - thingy91x/nrf9151/ns
     extra_args: EXTRA_CONF_FILE="overlay_coap.conf"
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.nrf_cloud_multi_service.coap.min:
     sysbuild: true
     build_only: true
@@ -58,7 +70,10 @@ tests:
     integration_platforms:
       - nrf9160dk/nrf9160/ns
     extra_args: EXTRA_CONF_FILE="overlay_coap.conf;overlay_min_coap.conf"
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.nrf_cloud_multi_service.coap.trace:
     sysbuild: true
     build_only: true
@@ -70,9 +85,13 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    extra_args: EXTRA_CONF_FILE="overlay-coap_nrf_provisioning.conf;overlay_coap.conf"
-      nrf_cloud_multi_service_SNIPPET=nrf91-modem-trace-uart
-    tags: ci_build sysbuild ci_samples_cellular
+    extra_args:
+      - EXTRA_CONF_FILE="overlay-coap_nrf_provisioning.conf;overlay_coap.conf"
+      - nrf_cloud_multi_service_SNIPPET=nrf91-modem-trace-uart
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.nrf7002ek_wifi.scan:
     sysbuild: true
     build_only: true
@@ -84,26 +103,38 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    extra_args: nrf_cloud_multi_service_SHIELD=nrf7002ek_nrf7000
-      EXTRA_CONF_FILE="overlay-nrf7002ek-wifi-scan-only.conf"
-      SB_CONF_FILE="sysbuild_nrf700x-wifi-scan.conf"
-    tags: ci_build sysbuild ci_samples_cellular
+    extra_args:
+      - nrf_cloud_multi_service_SHIELD=nrf7002ek_nrf7000
+      - EXTRA_CONF_FILE="overlay-nrf7002ek-wifi-scan-only.conf"
+      - SB_CONF_FILE="sysbuild_nrf700x-wifi-scan.conf"
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.nrf7002ek_wifi.conn:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp/ns
     platform_allow: nrf5340dk/nrf5340/cpuapp/ns
-    extra_args: nrf_cloud_multi_service_SHIELD=nrf7002ek
-      EXTRA_CONF_FILE="overlay_nrf700x_wifi_mqtt_no_lte.conf"
-      SB_CONF_FILE="sysbuild_nrf700x-wifi-conn.conf"
-    tags: ci_build sysbuild ci_samples_cellular
+    extra_args:
+      - nrf_cloud_multi_service_SHIELD=nrf7002ek
+      - EXTRA_CONF_FILE="overlay_nrf700x_wifi_mqtt_no_lte.conf"
+      - SB_CONF_FILE="sysbuild_nrf700x-wifi-conn.conf"
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.nrf7002dk_wifi.conn:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp/ns
     platform_allow: nrf7002dk/nrf5340/cpuapp/ns
-    extra_args: EXTRA_CONF_FILE="overlay_nrf700x_wifi_mqtt_no_lte.conf"
-      SB_CONF_FILE="sysbuild_nrf700x-wifi-conn.conf"
-    tags: ci_build sysbuild ci_samples_cellular
+    extra_args:
+      - EXTRA_CONF_FILE="overlay_nrf700x_wifi_mqtt_no_lte.conf"
+      - SB_CONF_FILE="sysbuild_nrf700x-wifi-conn.conf"
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular

--- a/samples/cellular/nrf_cloud_rest_cell_location/sample.yaml
+++ b/samples/cellular/nrf_cloud_rest_cell_location/sample.yaml
@@ -12,4 +12,7 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular

--- a/samples/cellular/nrf_cloud_rest_device_message/sample.yaml
+++ b/samples/cellular/nrf_cloud_rest_device_message/sample.yaml
@@ -12,4 +12,7 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular

--- a/samples/cellular/nrf_cloud_rest_fota/sample.yaml
+++ b/samples/cellular/nrf_cloud_rest_fota/sample.yaml
@@ -12,4 +12,7 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular

--- a/samples/cellular/nrf_provisioning/sample.yaml
+++ b/samples/cellular/nrf_provisioning/sample.yaml
@@ -11,4 +11,6 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: sysbuild ci_samples_cellular
+    tags:
+      - sysbuild
+      - ci_samples_cellular

--- a/samples/cellular/pdn/sample.yaml
+++ b/samples/cellular/pdn/sample.yaml
@@ -12,4 +12,7 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular

--- a/samples/cellular/slm_shell/sample.yaml
+++ b/samples/cellular/slm_shell/sample.yaml
@@ -9,5 +9,11 @@ tests:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf7002dk/nrf5340/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_cellular
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf7002dk/nrf5340/cpuapp
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular

--- a/samples/cellular/smp_svr/sample.yaml
+++ b/samples/cellular/smp_svr/sample.yaml
@@ -8,4 +8,7 @@ tests:
       - nrf9160dk/nrf52840
     platform_allow: nrf9160dk/nrf52840
     extra_args: EXTRA_DTC_OVERLAY_FILE="nrf9160dk_nrf52840_mcumgr_srv.overlay"
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular

--- a/samples/cellular/sms/sample.yaml
+++ b/samples/cellular/sms/sample.yaml
@@ -12,7 +12,10 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.sms.no_status_report:
     sysbuild: true
     build_only: true
@@ -26,4 +29,7 @@ tests:
       - nrf9161dk/nrf9161/ns
     extra_configs:
       - CONFIG_SMS_STATUS_REPORT=n
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular

--- a/samples/cellular/udp/sample.yaml
+++ b/samples/cellular/udp/sample.yaml
@@ -16,4 +16,7 @@ tests:
       - nrf9161dk/nrf9161/ns
       - thingy91/nrf9160/ns
       - thingy91x/nrf9151/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular

--- a/samples/cellular/uicc_lwm2m/sample.yaml
+++ b/samples/cellular/uicc_lwm2m/sample.yaml
@@ -15,4 +15,7 @@ tests:
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
       - thingy91/nrf9160/ns
-    tags: ci_build sysbuild ci_samples_cellular
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular

--- a/samples/crypto/aes_cbc/sample.yaml
+++ b/samples/crypto/aes_cbc/sample.yaml
@@ -6,11 +6,22 @@ sample:
 tests:
   sample.aes_cbc.cc3xx:
     sysbuild: true
-    tags: introduction psa cc3xx sysbuild ci_samples_crypto
-    platform_allow: >
-      nrf5340dk/nrf5340/cpuapp/ns nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160/ns
-      nrf9160dk/nrf9160 nrf52840dk/nrf52840 nrf9161dk/nrf9161 nrf9161dk/nrf9161/ns
-      nrf9151dk/nrf9151 nrf9151dk/nrf9151/ns
+    tags:
+      - introduction
+      - psa
+      - cc3xx
+      - sysbuild
+      - ci_samples_crypto
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160/ns
+      - nrf9160dk/nrf9160
+      - nrf52840dk/nrf52840
+      - nrf9161dk/nrf9161
+      - nrf9161dk/nrf9161/ns
+      - nrf9151dk/nrf9151
+      - nrf9151dk/nrf9151/ns
     harness: console
     harness_config:
       type: multi_line
@@ -28,12 +39,17 @@ tests:
       - nrf9151dk/nrf9151/ns
   sample.aes_cbc.cracen:
     sysbuild: true
-    tags: introduction psa cracen sysbuild ci_samples_crypto
-    platform_allow: >
-      nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp/ns
-      nrf54l15dk/nrf54l10/cpuapp
-      nrf54l15dk/nrf54l05/cpuapp
+    tags:
+      - introduction
+      - psa
+      - cracen
+      - sysbuild
+      - ci_samples_crypto
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
     harness: console
     harness_config:
       type: multi_line
@@ -46,7 +62,13 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
   sample.aes_cbc.cracen.crypto_service:
     sysbuild: true
-    tags: introduction psa cracen sysbuild crypto ci_samples_crypto
+    tags:
+      - introduction
+      - psa
+      - cracen
+      - sysbuild
+      - crypto
+      - ci_samples_crypto
     platform_allow: >
       nrf54h20dk/nrf54h20/cpuapp
     harness: console

--- a/samples/crypto/aes_ccm/sample.yaml
+++ b/samples/crypto/aes_ccm/sample.yaml
@@ -6,11 +6,22 @@ sample:
 tests:
   sample.aes_ccm.cc3xx:
     sysbuild: true
-    tags: introduction psa cc3xx sysbuild ci_samples_crypto
-    platform_allow: >
-      nrf5340dk/nrf5340/cpuapp/ns nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160/ns
-      nrf9160dk/nrf9160 nrf52840dk/nrf52840 nrf9161dk/nrf9161 nrf9161dk/nrf9161/ns
-      nrf9151dk/nrf9151 nrf9151dk/nrf9151/ns
+    tags:
+      - introduction
+      - psa
+      - cc3xx
+      - sysbuild
+      - ci_samples_crypto
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160/ns
+      - nrf9160dk/nrf9160
+      - nrf52840dk/nrf52840
+      - nrf9161dk/nrf9161
+      - nrf9161dk/nrf9161/ns
+      - nrf9151dk/nrf9151
+      - nrf9151dk/nrf9151/ns
     harness: console
     harness_config:
       type: multi_line
@@ -28,12 +39,17 @@ tests:
       - nrf9151dk/nrf9151/ns
   sample.aes_ccm.cracen:
     sysbuild: true
-    tags: introduction psa cracen sysbuild ci_samples_crypto
-    platform_allow: >
-      nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp/ns
-      nrf54l15dk/nrf54l10/cpuapp
-      nrf54l15dk/nrf54l05/cpuapp
+    tags:
+      - introduction
+      - psa
+      - cracen
+      - sysbuild
+      - ci_samples_crypto
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
     harness: console
     harness_config:
       type: multi_line
@@ -46,7 +62,13 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
   sample.aes_ccm.cracen.crypto_service:
     sysbuild: true
-    tags: introduction psa cracen sysbuild crypto ci_samples_crypto
+    tags:
+      - introduction
+      - psa
+      - cracen
+      - sysbuild
+      - crypto
+      - ci_samples_crypto
     platform_allow: >
       nrf54h20dk/nrf54h20/cpuapp
     harness: console

--- a/samples/crypto/aes_ctr/sample.yaml
+++ b/samples/crypto/aes_ctr/sample.yaml
@@ -6,11 +6,22 @@ sample:
 tests:
   sample.aes_ctr.cc3xx:
     sysbuild: true
-    tags: introduction psa cc3xx sysbuild ci_samples_crypto
-    platform_allow: >
-      nrf5340dk/nrf5340/cpuapp/ns nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160/ns
-      nrf9160dk/nrf9160 nrf52840dk/nrf52840 nrf9161dk/nrf9161 nrf9161dk/nrf9161/ns
-      nrf9151dk/nrf9151 nrf9151dk/nrf9151/ns
+    tags:
+      - introduction
+      - psa
+      - cc3xx
+      - sysbuild
+      - ci_samples_crypto
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160/ns
+      - nrf9160dk/nrf9160
+      - nrf52840dk/nrf52840
+      - nrf9161dk/nrf9161
+      - nrf9161dk/nrf9161/ns
+      - nrf9151dk/nrf9151
+      - nrf9151dk/nrf9151/ns
     harness: console
     harness_config:
       type: multi_line
@@ -28,12 +39,17 @@ tests:
       - nrf9151dk/nrf9151/ns
   sample.aes_ctr.cracen:
     sysbuild: true
-    tags: introduction psa cracen sysbuild ci_samples_crypto
-    platform_allow: >
-      nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp/ns
-      nrf54l15dk/nrf54l10/cpuapp
-      nrf54l15dk/nrf54l05/cpuapp
+    tags:
+      - introduction
+      - psa
+      - cracen
+      - sysbuild
+      - ci_samples_crypto
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
     harness: console
     harness_config:
       type: multi_line
@@ -46,7 +62,13 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
   sample.aes_ctr.cracen.crypto_service:
     sysbuild: true
-    tags: introduction psa cracen sysbuild crypto ci_samples_crypto
+    tags:
+      - introduction
+      - psa
+      - cracen
+      - sysbuild
+      - crypto
+      - ci_samples_crypto
     platform_allow: >
       nrf54h20dk/nrf54h20/cpuapp
     harness: console

--- a/samples/crypto/aes_gcm/sample.yaml
+++ b/samples/crypto/aes_gcm/sample.yaml
@@ -6,9 +6,15 @@ sample:
 tests:
   sample.aes_gcm.cc312:
     sysbuild: true
-    tags: introduction psa cc3xx sysbuild ci_samples_crypto
-    platform_allow: >
-      nrf5340dk/nrf5340/cpuapp/ns nrf5340dk/nrf5340/cpuapp
+    tags:
+      - introduction
+      - psa
+      - cc3xx
+      - sysbuild
+      - ci_samples_crypto
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf5340dk/nrf5340/cpuapp
     harness: console
     harness_config:
       type: multi_line
@@ -19,10 +25,20 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
   sample.aes_gcm.oberon:
     sysbuild: true
-    tags: introduction psa oberon sysbuild ci_samples_crypto
-    platform_allow: >
-      nrf52840dk/nrf52840 nrf9161dk/nrf9161 nrf9161dk/nrf9161/ns
-      nrf9160dk/nrf9160/ns nrf9160dk/nrf9160 nrf9151dk/nrf9151 nrf9151dk/nrf9151/ns
+    tags:
+      - introduction
+      - psa
+      - oberon
+      - sysbuild
+      - ci_samples_crypto
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf9161dk/nrf9161
+      - nrf9161dk/nrf9161/ns
+      - nrf9160dk/nrf9160/ns
+      - nrf9160dk/nrf9160
+      - nrf9151dk/nrf9151
+      - nrf9151dk/nrf9151/ns
     harness: console
     harness_config:
       type: multi_line
@@ -38,12 +54,17 @@ tests:
       - nrf9151dk/nrf9151/ns
   sample.aes_gcm.cracen:
     sysbuild: true
-    tags: introduction psa cracen sysbuild ci_samples_crypto
-    platform_allow: >
-      nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp/ns
-      nrf54l15dk/nrf54l10/cpuapp
-      nrf54l15dk/nrf54l05/cpuapp
+    tags:
+      - introduction
+      - psa
+      - cracen
+      - sysbuild
+      - ci_samples_crypto
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
     harness: console
     harness_config:
       type: multi_line
@@ -56,7 +77,13 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
   sample.aes_gcm.cracen.crypto_service:
     sysbuild: true
-    tags: introduction psa cracen sysbuild crypto ci_samples_crypto
+    tags:
+      - introduction
+      - psa
+      - cracen
+      - sysbuild
+      - crypto
+      - ci_samples_crypto
     platform_allow: >
       nrf54h20dk/nrf54h20/cpuapp
     harness: console

--- a/samples/crypto/chachapoly/sample.yaml
+++ b/samples/crypto/chachapoly/sample.yaml
@@ -6,11 +6,22 @@ sample:
 tests:
   sample.chachapoly.cc3xx:
     sysbuild: true
-    tags: introduction psa cc3xx sysbuild ci_samples_crypto
-    platform_allow: >
-      nrf5340dk/nrf5340/cpuapp/ns nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160/ns
-      nrf9160dk/nrf9160 nrf52840dk/nrf52840 nrf9161dk/nrf9161 nrf9161dk/nrf9161/ns
-      nrf9151dk/nrf9151 nrf9151dk/nrf9151/ns
+    tags:
+      - introduction
+      - psa
+      - cc3xx
+      - sysbuild
+      - ci_samples_crypto
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160/ns
+      - nrf9160dk/nrf9160
+      - nrf52840dk/nrf52840
+      - nrf9161dk/nrf9161
+      - nrf9161dk/nrf9161/ns
+      - nrf9151dk/nrf9151
+      - nrf9151dk/nrf9151/ns
     harness: console
     harness_config:
       type: multi_line
@@ -28,12 +39,17 @@ tests:
       - nrf9151dk/nrf9151/ns
   sample.chachapoly.cracen:
     sysbuild: true
-    tags: introduction psa cracen sysbuild ci_samples_crypto
-    platform_allow: >
-      nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp/ns
-      nrf54l15dk/nrf54l10/cpuapp
-      nrf54l15dk/nrf54l05/cpuapp
+    tags:
+      - introduction
+      - psa
+      - cracen
+      - sysbuild
+      - ci_samples_crypto
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
     harness: console
     harness_config:
       type: multi_line
@@ -46,7 +62,13 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
   sample.chachapoly.cracen.crypto_service:
     sysbuild: true
-    tags: introduction psa cracen sysbuild crypto ci_samples_crypto
+    tags:
+      - introduction
+      - psa
+      - cracen
+      - sysbuild
+      - crypto
+      - ci_samples_crypto
     platform_allow: >
       nrf54h20dk/nrf54h20/cpuapp
     harness: console

--- a/samples/crypto/ecdh/sample.yaml
+++ b/samples/crypto/ecdh/sample.yaml
@@ -6,11 +6,22 @@ sample:
 tests:
   sample.ecdh.cc3xx:
     sysbuild: true
-    tags: introduction psa cc3xx sysbuild ci_samples_crypto
-    platform_allow: >
-      nrf5340dk/nrf5340/cpuapp/ns nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160/ns
-      nrf9160dk/nrf9160 nrf52840dk/nrf52840 nrf9161dk/nrf9161 nrf9161dk/nrf9161/ns
-      nrf9151dk/nrf9151 nrf9151dk/nrf9151/ns
+    tags:
+      - introduction
+      - psa
+      - cc3xx
+      - sysbuild
+      - ci_samples_crypto
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160/ns
+      - nrf9160dk/nrf9160
+      - nrf52840dk/nrf52840
+      - nrf9161dk/nrf9161
+      - nrf9161dk/nrf9161/ns
+      - nrf9151dk/nrf9151
+      - nrf9151dk/nrf9151/ns
     harness: console
     harness_config:
       type: multi_line
@@ -28,12 +39,17 @@ tests:
       - nrf9151dk/nrf9151/ns
   sample.ecdh.cracen:
     sysbuild: true
-    tags: introduction psa cracen sysbuild ci_samples_crypto
-    platform_allow: >
-      nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp/ns
-      nrf54l15dk/nrf54l10/cpuapp
-      nrf54l15dk/nrf54l05/cpuapp
+    tags:
+      - introduction
+      - psa
+      - cracen
+      - sysbuild
+      - ci_samples_crypto
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
     harness: console
     harness_config:
       type: multi_line
@@ -46,7 +62,13 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
   sample.ecdh.cracen.crypto_service:
     sysbuild: true
-    tags: introduction psa cracen sysbuild crypto ci_samples_crypto
+    tags:
+      - introduction
+      - psa
+      - cracen
+      - sysbuild
+      - crypto
+      - ci_samples_crypto
     platform_allow: >
       nrf54h20dk/nrf54h20/cpuapp
     harness: console

--- a/samples/crypto/ecdsa/sample.yaml
+++ b/samples/crypto/ecdsa/sample.yaml
@@ -5,11 +5,22 @@ sample:
 tests:
   sample.ecdsa.cc3xx:
     sysbuild: true
-    tags: introduction psa cc3xx sysbuild ci_samples_crypto
-    platform_allow: >
-      nrf5340dk/nrf5340/cpuapp/ns nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160/ns
-      nrf9160dk/nrf9160 nrf52840dk/nrf52840 nrf9161dk/nrf9161 nrf9161dk/nrf9161/ns
-      nrf9151dk/nrf9151 nrf9151dk/nrf9151/ns
+    tags:
+      - introduction
+      - psa
+      - cc3xx
+      - sysbuild
+      - ci_samples_crypto
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160/ns
+      - nrf9160dk/nrf9160
+      - nrf52840dk/nrf52840
+      - nrf9161dk/nrf9161
+      - nrf9161dk/nrf9161/ns
+      - nrf9151dk/nrf9151
+      - nrf9151dk/nrf9151/ns
     harness: console
     harness_config:
       type: multi_line
@@ -27,7 +38,12 @@ tests:
       - nrf9151dk/nrf9151/ns
   sample.ecdsa.oberon:
     sysbuild: true
-    tags: introduction psa oberon sysbuild ci_samples_crypto
+    tags:
+      - introduction
+      - psa
+      - oberon
+      - sysbuild
+      - ci_samples_crypto
     platform_allow: >
       nrf5340dk/nrf5340/cpunet
     harness: console
@@ -39,12 +55,17 @@ tests:
       - nrf5340dk/nrf5340/cpunet
   sample.ecdsa.cracen:
     sysbuild: true
-    tags: introduction psa cracen sysbuild ci_samples_crypto
-    platform_allow: >
-      nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp/ns
-      nrf54l15dk/nrf54l10/cpuapp
-      nrf54l15dk/nrf54l05/cpuapp
+    tags:
+      - introduction
+      - psa
+      - cracen
+      - sysbuild
+      - ci_samples_crypto
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
     harness: console
     harness_config:
       type: multi_line
@@ -57,7 +78,13 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
   sample.ecdsa.cracen.crypto_service:
     sysbuild: true
-    tags: introduction psa cracen sysbuild crypto ci_samples_crypto
+    tags:
+      - introduction
+      - psa
+      - cracen
+      - sysbuild
+      - crypto
+      - ci_samples_crypto
     platform_allow: >
       nrf54h20dk/nrf54h20/cpuapp
     harness: console

--- a/samples/crypto/ecjpake/sample.yaml
+++ b/samples/crypto/ecjpake/sample.yaml
@@ -4,18 +4,23 @@ sample:
 tests:
   sample.ecjpake.oberon:
     sysbuild: true
-    tags: introduction psa oberon sysbuild ci_samples_crypto
-    platform_allow: >
-      nrf5340dk/nrf5340/cpuapp
-      nrf5340dk/nrf5340/cpuapp/ns
-      nrf9160dk/nrf9160
-      nrf9160dk/nrf9160/ns
-      nrf9160dk/nrf9160
-      nrf52840dk/nrf52840
-      nrf9161dk/nrf9161
-      nrf9161dk/nrf9161/ns
-      nrf9151dk/nrf9151
-      nrf9151dk/nrf9151/ns
+    tags:
+      - introduction
+      - psa
+      - oberon
+      - sysbuild
+      - ci_samples_crypto
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf9160dk/nrf9160
+      - nrf9160dk/nrf9160/ns
+      - nrf9160dk/nrf9160
+      - nrf52840dk/nrf52840
+      - nrf9161dk/nrf9161
+      - nrf9161dk/nrf9161/ns
+      - nrf9151dk/nrf9151
+      - nrf9151dk/nrf9151/ns
     harness: console
     harness_config:
       type: multi_line
@@ -33,12 +38,17 @@ tests:
       - nrf9151dk/nrf9151/ns
   sample.ecjpake.cracen:
     sysbuild: true
-    tags: introduction psa cracen sysbuild ci_samples_crypto
-    platform_allow: >
-      nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp/ns
-      nrf54l15dk/nrf54l10/cpuapp
-      nrf54l15dk/nrf54l05/cpuapp
+    tags:
+      - introduction
+      - psa
+      - cracen
+      - sysbuild
+      - ci_samples_crypto
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
     harness: console
     harness_config:
       type: multi_line
@@ -51,7 +61,13 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
   sample.ecjpake.cracen.crypto_service:
     sysbuild: true
-    tags: introduction psa cracen sysbuild crypto ci_samples_crypto
+    tags:
+      - introduction
+      - psa
+      - cracen
+      - sysbuild
+      - crypto
+      - ci_samples_crypto
     platform_allow: >
       nrf54h20dk/nrf54h20/cpuapp
     harness: console

--- a/samples/crypto/eddsa/sample.yaml
+++ b/samples/crypto/eddsa/sample.yaml
@@ -5,11 +5,22 @@ sample:
 tests:
   sample.eddsa.cc3xx:
     sysbuild: true
-    tags: introduction psa cc3xx sysbuild ci_samples_crypto
-    platform_allow: >
-      nrf5340dk/nrf5340/cpuapp/ns nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160/ns
-      nrf9160dk/nrf9160 nrf52840dk/nrf52840 nrf9161dk/nrf9161 nrf9161dk/nrf9161/ns
-      nrf9151dk/nrf9151 nrf9151dk/nrf9151/ns
+    tags:
+      - introduction
+      - psa
+      - cc3xx
+      - sysbuild
+      - ci_samples_crypto
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160/ns
+      - nrf9160dk/nrf9160
+      - nrf52840dk/nrf52840
+      - nrf9161dk/nrf9161
+      - nrf9161dk/nrf9161/ns
+      - nrf9151dk/nrf9151
+      - nrf9151dk/nrf9151/ns
     harness: console
     harness_config:
       type: multi_line
@@ -27,7 +38,12 @@ tests:
       - nrf9151dk/nrf9151/ns
   sample.eddsa.oberon:
     sysbuild: true
-    tags: introduction psa oberon sysbuild ci_samples_crypto
+    tags:
+      - introduction
+      - psa
+      - oberon
+      - sysbuild
+      - ci_samples_crypto
     platform_allow: >
       nrf5340dk/nrf5340/cpunet
     harness: console
@@ -39,12 +55,17 @@ tests:
       - nrf5340dk/nrf5340/cpunet
   sample.eddsa.cracen:
     sysbuild: true
-    tags: introduction psa cracen sysbuild ci_samples_crypto
-    platform_allow: >
-      nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp/ns
-      nrf54l15dk/nrf54l10/cpuapp
-      nrf54l15dk/nrf54l05/cpuapp
+    tags:
+      - introduction
+      - psa
+      - cracen
+      - sysbuild
+      - ci_samples_crypto
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
     harness: console
     harness_config:
       type: multi_line
@@ -57,7 +78,13 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
   sample.eddsa.cracen.crypto_service:
     sysbuild: true
-    tags: introduction psa cracen sysbuild crypto ci_samples_crypto
+    tags:
+      - introduction
+      - psa
+      - cracen
+      - sysbuild
+      - crypto
+      - ci_samples_crypto
     platform_allow: >
       nrf54h20dk/nrf54h20/cpuapp
     harness: console

--- a/samples/crypto/hkdf/sample.yaml
+++ b/samples/crypto/hkdf/sample.yaml
@@ -4,11 +4,22 @@ sample:
 tests:
   sample.hkdf.cc3xx:
     sysbuild: true
-    tags: introduction psa cc3xx sysbuild ci_samples_crypto
-    platform_allow: >
-      nrf5340dk/nrf5340/cpuapp/ns nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160/ns
-      nrf9160dk/nrf9160 nrf52840dk/nrf52840 nrf9161dk/nrf9161 nrf9161dk/nrf9161/ns
-      nrf9151dk/nrf9151 nrf9151dk/nrf9151/ns
+    tags:
+      - introduction
+      - psa
+      - cc3xx
+      - sysbuild
+      - ci_samples_crypto
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160/ns
+      - nrf9160dk/nrf9160
+      - nrf52840dk/nrf52840
+      - nrf9161dk/nrf9161
+      - nrf9161dk/nrf9161/ns
+      - nrf9151dk/nrf9151
+      - nrf9151dk/nrf9151/ns
     harness: console
     harness_config:
       type: multi_line
@@ -26,12 +37,17 @@ tests:
       - nrf9151dk/nrf9151/ns
   sample.hkdf.cracen:
     sysbuild: true
-    tags: introduction psa cracen sysbuild ci_samples_crypto
-    platform_allow: >
-      nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp/ns
-      nrf54l15dk/nrf54l10/cpuapp
-      nrf54l15dk/nrf54l05/cpuapp
+    tags:
+      - introduction
+      - psa
+      - cracen
+      - sysbuild
+      - ci_samples_crypto
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
     harness: console
     harness_config:
       type: multi_line
@@ -44,7 +60,13 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
   sample.hkdf.cracen.crypto_service:
     sysbuild: true
-    tags: introduction psa cracen sysbuild crypto ci_samples_crypto
+    tags:
+      - introduction
+      - psa
+      - cracen
+      - sysbuild
+      - crypto
+      - ci_samples_crypto
     platform_allow: >
       nrf54h20dk/nrf54h20/cpuapp
     harness: console

--- a/samples/crypto/hmac/sample.yaml
+++ b/samples/crypto/hmac/sample.yaml
@@ -6,11 +6,22 @@ sample:
 tests:
   sample.hmac.cc3xx:
     sysbuild: true
-    tags: introduction psa cc3xx sysbuild ci_samples_crypto
-    platform_allow: >
-      nrf5340dk/nrf5340/cpuapp/ns nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160/ns
-      nrf9160dk/nrf9160 nrf52840dk/nrf52840 nrf9161dk/nrf9161 nrf9161dk/nrf9161/ns
-      nrf9151dk/nrf9151 nrf9151dk/nrf9151/ns
+    tags:
+      - introduction
+      - psa
+      - cc3xx
+      - sysbuild
+      - ci_samples_crypto
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160/ns
+      - nrf9160dk/nrf9160
+      - nrf52840dk/nrf52840
+      - nrf9161dk/nrf9161
+      - nrf9161dk/nrf9161/ns
+      - nrf9151dk/nrf9151
+      - nrf9151dk/nrf9151/ns
     harness: console
     harness_config:
       type: multi_line
@@ -28,12 +39,17 @@ tests:
       - nrf9151dk/nrf9151/ns
   sample.hmac.cracen:
     sysbuild: true
-    tags: introduction psa cracen sysbuild ci_samples_crypto
-    platform_allow: >
-      nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp/ns
-      nrf54l15dk/nrf54l10/cpuapp
-      nrf54l15dk/nrf54l05/cpuapp
+    tags:
+      - introduction
+      - psa
+      - cracen
+      - sysbuild
+      - ci_samples_crypto
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
     harness: console
     harness_config:
       type: multi_line
@@ -46,7 +62,13 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
   sample.hmac.cracen.crypto_service:
     sysbuild: true
-    tags: introduction psa cracen sysbuild crypto ci_samples_crypto
+    tags:
+      - introduction
+      - psa
+      - cracen
+      - sysbuild
+      - crypto
+      - ci_samples_crypto
     platform_allow: >
       nrf54h20dk/nrf54h20/cpuapp
     harness: console

--- a/samples/crypto/pbkdf2/sample.yaml
+++ b/samples/crypto/pbkdf2/sample.yaml
@@ -4,11 +4,22 @@ sample:
 tests:
   sample.pbkdf2.cc3xx:
     sysbuild: true
-    tags: introduction psa cc3xx sysbuild ci_samples_crypto
-    platform_allow: >
-      nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160 nrf52840dk/nrf52840 nrf9161dk/nrf9161
-      nrf5340dk/nrf5340/cpuapp/ns nrf9160dk/nrf9160/ns nrf9161dk/nrf9161/ns
-      nrf9151dk/nrf9151 nrf9151dk/nrf9151/ns
+    tags:
+      - introduction
+      - psa
+      - cc3xx
+      - sysbuild
+      - ci_samples_crypto
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160
+      - nrf52840dk/nrf52840
+      - nrf9161dk/nrf9161
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf9160dk/nrf9160/ns
+      - nrf9161dk/nrf9161/ns
+      - nrf9151dk/nrf9151
+      - nrf9151dk/nrf9151/ns
     harness: console
     harness_config:
       type: multi_line
@@ -26,12 +37,17 @@ tests:
       - nrf9151dk/nrf9151/ns
   sample.pbkdf2.cracen:
     sysbuild: true
-    tags: introduction psa cracen sysbuild ci_samples_crypto
-    platform_allow: >
-      nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp/ns
-      nrf54l15dk/nrf54l10/cpuapp
-      nrf54l15dk/nrf54l05/cpuapp
+    tags:
+      - introduction
+      - psa
+      - cracen
+      - sysbuild
+      - ci_samples_crypto
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
     harness: console
     harness_config:
       type: multi_line
@@ -44,7 +60,13 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
   sample.pbkdf2.cracen.crypto_service:
     sysbuild: true
-    tags: introduction psa cracen sysbuild crypto ci_samples_crypto
+    tags:
+      - introduction
+      - psa
+      - cracen
+      - sysbuild
+      - crypto
+      - ci_samples_crypto
     platform_allow: >
       nrf54h20dk/nrf54h20/cpuapp
     harness: console

--- a/samples/crypto/persistent_key_usage/sample.yaml
+++ b/samples/crypto/persistent_key_usage/sample.yaml
@@ -7,11 +7,22 @@ sample:
 tests:
   sample.persistent_key_usage.cc3xx:
     sysbuild: true
-    tags: introduction psa cc3xx sysbuild ci_samples_crypto
-    platform_allow: >
-      nrf5340dk/nrf5340/cpuapp/ns nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160/ns
-      nrf9160dk/nrf9160 nrf52840dk/nrf52840 nrf9161dk/nrf9161 nrf9161dk/nrf9161/ns
-      nrf9151dk/nrf9151 nrf9151dk/nrf9151/ns
+    tags:
+      - introduction
+      - psa
+      - cc3xx
+      - sysbuild
+      - ci_samples_crypto
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160/ns
+      - nrf9160dk/nrf9160
+      - nrf52840dk/nrf52840
+      - nrf9161dk/nrf9161
+      - nrf9161dk/nrf9161/ns
+      - nrf9151dk/nrf9151
+      - nrf9151dk/nrf9151/ns
     harness: console
     harness_config:
       type: multi_line
@@ -29,12 +40,17 @@ tests:
       - nrf9151dk/nrf9151/ns
   sample.persistent_key_usage.cracen:
     sysbuild: true
-    tags: introduction psa cracen sysbuild ci_samples_crypto
-    platform_allow: >
-      nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp/ns
-      nrf54l15dk/nrf54l10/cpuapp
-      nrf54l15dk/nrf54l05/cpuapp
+    tags:
+      - introduction
+      - psa
+      - cracen
+      - sysbuild
+      - ci_samples_crypto
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
     harness: console
     harness_config:
       type: multi_line

--- a/samples/crypto/rng/sample.yaml
+++ b/samples/crypto/rng/sample.yaml
@@ -4,11 +4,22 @@ sample:
 tests:
   sample.rng.cc3xx:
     sysbuild: true
-    tags: introduction psa cc3xx sysbuild ci_samples_crypto
-    platform_allow: >
-      nrf5340dk/nrf5340/cpuapp/ns nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160/ns
-      nrf9160dk/nrf9160 nrf52840dk/nrf52840 nrf9161dk/nrf9161 nrf9161dk/nrf9161/ns
-      nrf9151dk/nrf9151 nrf9151dk/nrf9151/ns
+    tags:
+      - introduction
+      - psa
+      - cc3xx
+      - sysbuild
+      - ci_samples_crypto
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160/ns
+      - nrf9160dk/nrf9160
+      - nrf52840dk/nrf52840
+      - nrf9161dk/nrf9161
+      - nrf9161dk/nrf9161/ns
+      - nrf9151dk/nrf9151
+      - nrf9151dk/nrf9151/ns
     harness: console
     harness_config:
       type: multi_line
@@ -26,12 +37,17 @@ tests:
       - nrf9151dk/nrf9151/ns
   sample.rng.cracen:
     sysbuild: true
-    tags: introduction psa cracen sysbuild ci_samples_crypto
-    platform_allow: >
-      nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp/ns
-      nrf54l15dk/nrf54l10/cpuapp
-      nrf54l15dk/nrf54l05/cpuapp
+    tags:
+      - introduction
+      - psa
+      - cracen
+      - sysbuild
+      - ci_samples_crypto
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
     harness: console
     harness_config:
       type: multi_line
@@ -44,7 +60,13 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
   sample.rng.cracen.crypto_service:
     sysbuild: true
-    tags: introduction psa cracen sysbuild crypto ci_samples_crypto
+    tags:
+      - introduction
+      - psa
+      - cracen
+      - sysbuild
+      - crypto
+      - ci_samples_crypto
     platform_allow: >
       nrf54h20dk/nrf54h20/cpuapp
     harness: console

--- a/samples/crypto/rsa/sample.yaml
+++ b/samples/crypto/rsa/sample.yaml
@@ -5,11 +5,22 @@ sample:
 tests:
   sample.rsa.cc3xx:
     sysbuild: true
-    tags: introduction psa cc3xx sysbuild ci_samples_crypto
-    platform_allow: >
-      nrf5340dk/nrf5340/cpuapp/ns nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160/ns
-      nrf9160dk/nrf9160 nrf52840dk/nrf52840 nrf9161dk/nrf9161 nrf9161dk/nrf9161/ns
-      nrf9151dk/nrf9151 nrf9151dk/nrf9151/ns
+    tags:
+      - introduction
+      - psa
+      - cc3xx
+      - sysbuild
+      - ci_samples_crypto
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160/ns
+      - nrf9160dk/nrf9160
+      - nrf52840dk/nrf52840
+      - nrf9161dk/nrf9161
+      - nrf9161dk/nrf9161/ns
+      - nrf9151dk/nrf9151
+      - nrf9151dk/nrf9151/ns
     harness: console
     harness_config:
       type: multi_line
@@ -27,12 +38,17 @@ tests:
       - nrf9151dk/nrf9151/ns
   sample.rsa.cracen:
     sysbuild: true
-    tags: introduction psa cracen sysbuild ci_samples_crypto
-    platform_allow: >
-      nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp/ns
-      nrf54l15dk/nrf54l10/cpuapp
-      nrf54l15dk/nrf54l05/cpuapp
+    tags:
+      - introduction
+      - psa
+      - cracen
+      - sysbuild
+      - ci_samples_crypto
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
     harness: console
     harness_config:
       type: multi_line

--- a/samples/crypto/sha256/sample.yaml
+++ b/samples/crypto/sha256/sample.yaml
@@ -4,11 +4,22 @@ sample:
 tests:
   sample.sha256.cc3xx:
     sysbuild: true
-    tags: introduction psa cc3xx sysbuild ci_samples_crypto
-    platform_allow: >
-      nrf5340dk/nrf5340/cpuapp/ns nrf5340dk/nrf5340/cpuapp nrf9160dk/nrf9160/ns
-      nrf9160dk/nrf9160 nrf52840dk/nrf52840 nrf9161dk/nrf9161 nrf9161dk/nrf9161/ns
-      nrf9151dk/nrf9151 nrf9151dk/nrf9151/ns
+    tags:
+      - introduction
+      - psa
+      - cc3xx
+      - sysbuild
+      - ci_samples_crypto
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160/ns
+      - nrf9160dk/nrf9160
+      - nrf52840dk/nrf52840
+      - nrf9161dk/nrf9161
+      - nrf9161dk/nrf9161/ns
+      - nrf9151dk/nrf9151
+      - nrf9151dk/nrf9151/ns
     harness: console
     harness_config:
       type: multi_line
@@ -26,7 +37,12 @@ tests:
       - nrf9151dk/nrf9151/ns
   sample.sha256.oberon:
     sysbuild: true
-    tags: introduction psa oberon sysbuild ci_samples_crypto
+    tags:
+      - introduction
+      - psa
+      - oberon
+      - sysbuild
+      - ci_samples_crypto
     platform_allow: >
       nrf5340dk/nrf5340/cpunet
     harness: console
@@ -38,12 +54,17 @@ tests:
       - nrf5340dk/nrf5340/cpunet
   sample.sha256.cracen:
     sysbuild: true
-    tags: introduction psa cracen sysbuild ci_samples_crypto
-    platform_allow: >
-        nrf54l15dk/nrf54l15/cpuapp
-        nrf54l15dk/nrf54l15/cpuapp/ns
-        nrf54l15dk/nrf54l10/cpuapp
-        nrf54l15dk/nrf54l05/cpuapp
+    tags:
+      - introduction
+      - psa
+      - cracen
+      - sysbuild
+      - ci_samples_crypto
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
     harness: console
     harness_config:
       type: multi_line
@@ -59,25 +80,41 @@ tests:
     sysbuild: true
     build_only: true
     extra_args: SB_CONFIG_BOOTLOADER_MCUBOOT=y
-    platform_allow: nrf5340dk/nrf5340/cpuapp/ns nrf52840dk/nrf52840 nrf52833dk/nrf52833
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf52840dk/nrf52840
+      - nrf52833dk/nrf52833
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf52840dk/nrf52840
       - nrf52833dk/nrf52833
-    tags: sysbuild ci_samples_crypto
+    tags:
+      - sysbuild
+      - ci_samples_crypto
   sample.newlib_libc.sha256:
     sysbuild: true
     build_only: true
     extra_args: CONFIG_NEWLIB_LIBC=y
-    platform_allow: nrf5340dk/nrf5340/cpuapp/ns nrf52840dk/nrf52840 nrf54h20dk/nrf54h20/cpuapp
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf52840dk/nrf52840
+      - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf52840dk/nrf52840
       - nrf54h20dk/nrf54h20/cpuapp
-    tags: sysbuild ci_samples_crypto
+    tags:
+      - sysbuild
+      - ci_samples_crypto
   sample.sha256.cracen.crypto_service:
     sysbuild: true
-    tags: introduction psa cracen sysbuild crypto ci_samples_crypto
+    tags:
+      - introduction
+      - psa
+      - cracen
+      - sysbuild
+      - crypto
+      - ci_samples_crypto
     platform_allow: >
       nrf54h20dk/nrf54h20/cpuapp
     harness: console

--- a/samples/crypto/spake2p/sample.yaml
+++ b/samples/crypto/spake2p/sample.yaml
@@ -4,12 +4,22 @@ sample:
 tests:
   sample.spake2p.oberon:
     sysbuild: true
-    tags: introduction psa oberon sysbuild ci_samples_crypto
-    platform_allow: >
-      nrf5340dk/nrf5340/cpuapp nrf5340dk/nrf5340/cpuapp/ns
-      nrf9160dk/nrf9160 nrf52840dk/nrf52840
-      nrf9161dk/nrf9161 nrf9160dk/nrf9160/ns
-      nrf9161dk/nrf9161/ns nrf9151dk/nrf9151 nrf9151dk/nrf9151/ns
+    tags:
+      - introduction
+      - psa
+      - oberon
+      - sysbuild
+      - ci_samples_crypto
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf9160dk/nrf9160
+      - nrf52840dk/nrf52840
+      - nrf9161dk/nrf9161
+      - nrf9160dk/nrf9160/ns
+      - nrf9161dk/nrf9161/ns
+      - nrf9151dk/nrf9151
+      - nrf9151dk/nrf9151/ns
     harness: console
     harness_config:
       type: multi_line
@@ -27,12 +37,17 @@ tests:
       - nrf9151dk/nrf9151/ns
   sample.spake2p.cracen:
     sysbuild: true
-    tags: introduction psa cracen sysbuild ci_samples_crypto
-    platform_allow: >
-      nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp/ns
-      nrf54l15dk/nrf54l10/cpuapp
-      nrf54l15dk/nrf54l05/cpuapp
+    tags:
+      - introduction
+      - psa
+      - cracen
+      - sysbuild
+      - ci_samples_crypto
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
     harness: console
     harness_config:
       type: multi_line
@@ -45,7 +60,13 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
   sample.spake2p.cracen.crypto_service:
     sysbuild: true
-    tags: introduction psa cracen sysbuild crypto ci_samples_crypto
+    tags:
+      - introduction
+      - psa
+      - cracen
+      - sysbuild
+      - crypto
+      - ci_samples_crypto
     platform_allow: >
       nrf54h20dk/nrf54h20/cpuapp
     harness: console

--- a/samples/debug/memfault/sample.yaml
+++ b/samples/debug/memfault/sample.yaml
@@ -20,7 +20,10 @@ tests:
       - thingy91/nrf9160/ns
       - thingy91x/nrf9151/ns
       - nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_debug
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_debug
   sample.debug.memfault.etb:
     sysbuild: true
     build_only: true
@@ -41,4 +44,7 @@ tests:
       - thingy91/nrf9160/ns
       - thingy91x/nrf9151/ns
       - nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_debug
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_debug

--- a/samples/debug/ppi_trace/sample.yaml
+++ b/samples/debug/ppi_trace/sample.yaml
@@ -8,5 +8,12 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf9160dk/nrf9160
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf9160dk/nrf9160 nrf21540dk/nrf52840
-    tags: ci_build sysbuild ci_samples_debug
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf9160dk/nrf9160
+      - nrf21540dk/nrf52840
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_debug

--- a/samples/dect/dect_phy/dect_shell/sample.yaml
+++ b/samples/dect/dect_phy/dect_shell/sample.yaml
@@ -14,4 +14,7 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9161dk/nrf9161/ns
       - thingy91x/nrf9151/ns
-    tags: ci_build sysbuild ci_samples_dect
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_dect

--- a/samples/dect/dect_phy/hello_dect/sample.yaml
+++ b/samples/dect/dect_phy/hello_dect/sample.yaml
@@ -11,7 +11,10 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9161dk/nrf9161/ns
     extra_args: EXTRA_CONF_FILE="overlay-eu.conf"
-    tags: ci_build sysbuild ci_samples_dect
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_dect
   sample.dect_phy.dect_hello.us.sysbuild:
     sysbuild: true
     build_only: true
@@ -22,4 +25,7 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9161dk/nrf9161/ns
     extra_args: EXTRA_CONF_FILE="overlay-us.conf"
-    tags: ci_build sysbuild ci_samples_dect
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_dect

--- a/samples/edge_impulse/data_forwarder/sample.yaml
+++ b/samples/edge_impulse/data_forwarder/sample.yaml
@@ -22,5 +22,11 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf9160dk/nrf9160/ns
-    platform_exclude: native_sim qemu_x86 qemu_cortex_m3
-    tags: ci_build sysbuild ci_samples_edge_impulse
+    platform_exclude:
+      - native_sim
+      - qemu_x86
+      - qemu_cortex_m3
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_edge_impulse

--- a/samples/edge_impulse/wrapper/sample.yaml
+++ b/samples/edge_impulse/wrapper/sample.yaml
@@ -31,9 +31,13 @@ common:
     - nrf54h20dk/nrf54h20/cpuapp
     - nrf9160dk/nrf9160/ns
     - qemu_cortex_m3
-  platform_exclude: native_sim qemu_x86
+  platform_exclude:
+    - native_sim
+    - qemu_x86
 tests:
   sample.edge_impulse.wrapper:
     sysbuild: true
     build_only: false
-    tags: sysbuild ci_samples_edge_impulse
+    tags:
+      - sysbuild
+      - ci_samples_edge_impulse

--- a/samples/esb/esb_prx/sample.yaml
+++ b/samples/esb/esb_prx/sample.yaml
@@ -9,8 +9,16 @@ tests:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52810
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf52dk/nrf52810
-    tags: esb samples console sysbuild ci_samples_esb
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf52dk/nrf52810
+    tags:
+      - esb
+      - samples
+      - console
+      - sysbuild
+      - ci_samples_esb
   sample.esb.prx.build:
     sysbuild: true
     build_only: true
@@ -23,16 +31,20 @@ tests:
       - nrf21540dk/nrf52840
       - nrf54h20dk/nrf54h20/cpurad
       - nrf54l15dk/nrf54l15/cpuapp
-    platform_allow: >
-      nrf52dk/nrf52832
-      nrf52833dk/nrf52833
-      nrf52840dk/nrf52840
-      nrf52dk/nrf52810
-      nrf5340dk/nrf5340/cpunet
-      nrf21540dk/nrf52840
-      nrf54h20dk/nrf54h20/cpurad
-      nrf54l15dk/nrf54l15/cpuapp
-    tags: esb ci_build sysbuild ci_samples_esb
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf52dk/nrf52810
+      - nrf5340dk/nrf5340/cpunet
+      - nrf21540dk/nrf52840
+      - nrf54h20dk/nrf54h20/cpurad
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - esb
+      - ci_build
+      - sysbuild
+      - ci_samples_esb
   sample.esb.prx.dynamic_irq:
     sysbuild: true
     build_only: true
@@ -46,12 +58,16 @@ tests:
       - nrf52840dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
-    platform_allow: >
-      nrf5340dk/nrf5340/cpunet
-      nrf52840dk/nrf52840
-      nrf54l15dk/nrf54l15/cpuapp
-      nrf54h20dk/nrf54h20/cpurad
-    tags: esb ci_build sysbuild ci_samples_esb
+    platform_allow:
+      - nrf5340dk/nrf5340/cpunet
+      - nrf52840dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpurad
+    tags:
+      - esb
+      - ci_build
+      - sysbuild
+      - ci_samples_esb
   sample.esb.prx.nrf5340_nrf21540:
     sysbuild: true
     build_only: true
@@ -59,7 +75,11 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpunet
     platform_allow: nrf5340dk/nrf5340/cpunet
-    tags: esb ci_build sysbuild ci_samples_esb
+    tags:
+      - esb
+      - ci_build
+      - sysbuild
+      - ci_samples_esb
   sample.esb.prx.fast_switching:
     sysbuild: true
     build_only: true
@@ -70,4 +90,8 @@ tests:
       - nrf54h20dk/nrf54h20/cpurad
     platform_allow: >
       nrf54h20dk/nrf54h20/cpurad
-    tags: esb ci_build sysbuild ci_samples_esb
+    tags:
+      - esb
+      - ci_build
+      - sysbuild
+      - ci_samples_esb

--- a/samples/esb/esb_ptx/sample.yaml
+++ b/samples/esb/esb_ptx/sample.yaml
@@ -9,8 +9,16 @@ tests:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52810
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf52dk/nrf52810
-    tags: esb samples console sysbuild ci_samples_esb
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf52dk/nrf52810
+    tags:
+      - esb
+      - samples
+      - console
+      - sysbuild
+      - ci_samples_esb
   sample.esb.ptx.build:
     sysbuild: true
     build_only: true
@@ -23,16 +31,20 @@ tests:
       - nrf21540dk/nrf52840
       - nrf54h20dk/nrf54h20/cpurad
       - nrf54l15dk/nrf54l15/cpuapp
-    platform_allow: >
-      nrf52dk/nrf52832
-      nrf52833dk/nrf52833
-      nrf52840dk/nrf52840
-      nrf52dk/nrf52810
-      nrf5340dk/nrf5340/cpunet
-      nrf21540dk/nrf52840
-      nrf54h20dk/nrf54h20/cpurad
-      nrf54l15dk/nrf54l15/cpuapp
-    tags: esb ci_build sysbuild ci_samples_esb
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf52dk/nrf52810
+      - nrf5340dk/nrf5340/cpunet
+      - nrf21540dk/nrf52840
+      - nrf54h20dk/nrf54h20/cpurad
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - esb
+      - ci_build
+      - sysbuild
+      - ci_samples_esb
   sample.esb.ptx.dynamic_irq:
     sysbuild: true
     build_only: true
@@ -46,12 +58,16 @@ tests:
       - nrf52840dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
-    platform_allow: >
-      nrf5340dk/nrf5340/cpunet
-      nrf52840dk/nrf52840
-      nrf54l15dk/nrf54l15/cpuapp
-      nrf54h20dk/nrf54h20/cpurad
-    tags: esb ci_build sysbuild ci_samples_esb
+    platform_allow:
+      - nrf5340dk/nrf5340/cpunet
+      - nrf52840dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpurad
+    tags:
+      - esb
+      - ci_build
+      - sysbuild
+      - ci_samples_esb
   sample.esb.ptx.nrf5340_nrf21540:
     sysbuild: true
     build_only: true
@@ -59,7 +75,11 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpunet
     platform_allow: nrf5340dk/nrf5340/cpunet
-    tags: esb ci_build sysbuild ci_samples_esb
+    tags:
+      - esb
+      - ci_build
+      - sysbuild
+      - ci_samples_esb
   sample.esb.ptx.fast_switching:
     sysbuild: true
     build_only: true
@@ -70,4 +90,8 @@ tests:
       - nrf54h20dk/nrf54h20/cpurad
     platform_allow: >
       nrf54h20dk/nrf54h20/cpurad
-    tags: esb ci_build sysbuild ci_samples_esb
+    tags:
+      - esb
+      - ci_build
+      - sysbuild
+      - ci_samples_esb

--- a/samples/event_manager_proxy/sample.yaml
+++ b/samples/event_manager_proxy/sample.yaml
@@ -1,10 +1,14 @@
 sample:
-  description: Sample showing usage of sending the events to another core via Event Manager Proxy
+  description: Sample showing usage of sending the events to another core via Event
+    Manager Proxy
   name: Event Manager proxy sample
 
 common:
   sysbuild: true
-  tags: ipc ci_build ci_samples_event_manager_proxy
+  tags:
+    - ipc
+    - ci_build
+    - ci_samples_event_manager_proxy
   harness: console
   harness_config:
     type: multi_line
@@ -31,8 +35,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
-    extra_args:
-      FILE_SUFFIX=icmsg
+    extra_args: FILE_SUFFIX=icmsg
   sample.event_manager_proxy.nrf54h20dk_cpuapp:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp

--- a/samples/gazell/gzll_ack_payload_device/sample.yaml
+++ b/samples/gazell/gzll_ack_payload_device/sample.yaml
@@ -8,5 +8,11 @@ tests:
       - nrf52dk/nrf52832
       - nrf52833dk/nrf52833
       - nrf52840dk/nrf52840
-    platform_allow: nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840
-    tags: ci_build sysbuild ci_samples_gazell
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_gazell

--- a/samples/gazell/gzll_ack_payload_host/sample.yaml
+++ b/samples/gazell/gzll_ack_payload_host/sample.yaml
@@ -8,5 +8,11 @@ tests:
       - nrf52dk/nrf52832
       - nrf52833dk/nrf52833
       - nrf52840dk/nrf52840
-    platform_allow: nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840
-    tags: ci_build sysbuild ci_samples_gazell
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_gazell

--- a/samples/gazell/gzp_dynamic_pairing_device/sample.yaml
+++ b/samples/gazell/gzp_dynamic_pairing_device/sample.yaml
@@ -8,5 +8,11 @@ tests:
       - nrf52dk/nrf52832
       - nrf52833dk/nrf52833
       - nrf52840dk/nrf52840
-    platform_allow: nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840
-    tags: ci_build sysbuild ci_samples_gazell
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_gazell

--- a/samples/gazell/gzp_dynamic_pairing_host/sample.yaml
+++ b/samples/gazell/gzp_dynamic_pairing_host/sample.yaml
@@ -8,5 +8,11 @@ tests:
       - nrf52dk/nrf52832
       - nrf52833dk/nrf52833
       - nrf52840dk/nrf52840
-    platform_allow: nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840
-    tags: ci_build sysbuild ci_samples_gazell
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_gazell

--- a/samples/hw_id/sample.yaml
+++ b/samples/hw_id/sample.yaml
@@ -10,16 +10,25 @@ tests:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf9160dk/nrf9160
       - nrf9160dk/nrf9160/ns
-    platform_allow: >
-      nrf5340dk/nrf5340/cpuapp nrf5340dk/nrf5340/cpuapp/ns nrf9160dk/nrf9160 nrf9160dk/nrf9160/ns
-    tags: ci_build sysbuild ci_samples_hw_id
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf9160dk/nrf9160
+      - nrf9160dk/nrf9160/ns
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_hw_id
   sample.hw_id.uuid:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf9160dk/nrf9160/ns
     platform_allow: nrf9160dk/nrf9160/ns
-    tags: ci_build sysbuild ci_samples_hw_id
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_hw_id
     extra_args: OVERLAY_CONFIG=overlay-uuid.conf
   sample.hw_id.imei:
     sysbuild: true
@@ -27,7 +36,10 @@ tests:
     integration_platforms:
       - nrf9160dk/nrf9160/ns
     platform_allow: nrf9160dk/nrf9160/ns
-    tags: ci_build sysbuild ci_samples_hw_id
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_hw_id
     extra_args: OVERLAY_CONFIG=overlay-imei.conf
   sample.hw_id.ble:
     sysbuild: true
@@ -37,7 +49,13 @@ tests:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
-    platform_allow: >
-      nrf51dk/nrf51822 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf5340dk/nrf5340/cpuapp/ns
-    tags: ci_build sysbuild ci_samples_hw_id
+    platform_allow:
+      - nrf51dk/nrf51822
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_hw_id
     extra_args: OVERLAY_CONFIG=overlay-ble-mac.conf

--- a/samples/ipc/ipc_service/sample.yaml
+++ b/samples/ipc/ipc_service/sample.yaml
@@ -4,7 +4,9 @@ sample:
 
 common:
   sysbuild: true
-  tags: ipc ci_samples_ipc
+  tags:
+    - ipc
+    - ci_samples_ipc
   harness: console
   harness_config:
     type: multi_line
@@ -62,9 +64,9 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
     extra_configs:
       - CONFIG_APP_IPC_SERVICE_SEND_INTERVAL=35
-    extra_args: >
-      FILE_SUFFIX=icmsg
-      remote_CONFIG_APP_IPC_SERVICE_SEND_INTERVAL=200000000
+    extra_args:
+      - FILE_SUFFIX=icmsg
+      - remote_CONFIG_APP_IPC_SERVICE_SEND_INTERVAL=200000000
   sample.ipc.ipc_service.nrf5340dk_icmsg_cpunet_sending:
     platform_allow:
       - nrf5340dk/nrf5340/cpuapp
@@ -72,9 +74,9 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
     extra_configs:
       - CONFIG_APP_IPC_SERVICE_SEND_INTERVAL=200000000
-    extra_args: >
-      FILE_SUFFIX=icmsg
-      remote_CONFIG_APP_IPC_SERVICE_SEND_INTERVAL=1
+    extra_args:
+      - FILE_SUFFIX=icmsg
+      - remote_CONFIG_APP_IPC_SERVICE_SEND_INTERVAL=1
     harness_config:
       type: multi_line
       ordered: true
@@ -94,6 +96,6 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
-    extra_args: >
-      FILE_SUFFIX=cpuppr
-      ipc_service_SNIPPET=nordic-ppr
+    extra_args:
+      - FILE_SUFFIX=cpuppr
+      - ipc_service_SNIPPET=nordic-ppr

--- a/samples/keys/hw_unique_key/sample.yaml
+++ b/samples/keys/hw_unique_key/sample.yaml
@@ -2,7 +2,10 @@ sample:
   description: Generate and write random keys to the KMU.
   name: Random HW Unique Key
 common:
-  tags: huk keys ci_samples_keys
+  tags:
+    - huk
+    - keys
+    - ci_samples_keys
   platform_allow:
     - nrf5340dk/nrf5340/cpuapp
     - nrf5340dk/nrf5340/cpuapp/ns
@@ -39,4 +42,9 @@ common:
 tests:
   sample.keys.hw_unique_key:
     sysbuild: true
-    tags: huk ci_build sysbuild keys ci_samples_keys
+    tags:
+      - huk
+      - ci_build
+      - sysbuild
+      - keys
+      - ci_samples_keys

--- a/samples/keys/identity_key_generation/sample.yaml
+++ b/samples/keys/identity_key_generation/sample.yaml
@@ -2,7 +2,9 @@ sample:
   description: Generate and write identity key.
   name: Identity Key Generate
 common:
-  tags: keys ci_samples_keys
+  tags:
+    - keys
+    - ci_samples_keys
   platform_allow:
     - nrf5340dk/nrf5340/cpuapp
     - nrf9160dk/nrf9160
@@ -22,8 +24,11 @@ common:
 tests:
   sample.keys.identity_key_generate.random_key:
     sysbuild: true
-    tags: keys ci_build sysbuild ci_samples_keys
-
+    tags:
+      - keys
+      - ci_build
+      - sysbuild
+      - ci_samples_keys
   # The TFM regression tests rely on a specific key in order to pass.
   # This sample configuration is mainly useful for writing that expected key,
   # which is called a "dummy key".
@@ -31,4 +36,8 @@ tests:
     sysbuild: true
     extra_configs:
       - CONFIG_IDENTITY_KEY_DUMMY=y
-    tags: keys ci_build sysbuild ci_samples_keys
+    tags:
+      - keys
+      - ci_build
+      - sysbuild
+      - ci_samples_keys

--- a/samples/keys/identity_key_usage/sample.yaml
+++ b/samples/keys/identity_key_usage/sample.yaml
@@ -2,7 +2,9 @@ sample:
   description: Use a previously written identity key from KMU.
   name: Identity Key Usage
 common:
-  tags: keys ci_samples_keys
+  tags:
+    - keys
+    - ci_samples_keys
   platform_allow:
     - nrf5340dk/nrf5340/cpuapp
     - nrf9160dk/nrf9160
@@ -21,5 +23,9 @@ common:
 tests:
   sample.keys.identity_key_usage:
     sysbuild: true
-    tags: keys ci_build sysbuild ci_samples_keys
+    tags:
+      - keys
+      - ci_build
+      - sysbuild
+      - ci_samples_keys
     build_only: true

--- a/samples/matter/light_bulb/sample.yaml
+++ b/samples/matter/light_bulb/sample.yaml
@@ -11,48 +11,74 @@ tests:
       - nrf7002dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf7002dk/nrf5340/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp nrf54l15dk/nrf54l15/cpuapp/ns
-    tags: sysbuild ci_samples_matter
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf7002dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+    tags:
+      - sysbuild
+      - ci_samples_matter
   sample.matter.light_bulb.release:
     sysbuild: true
     build_only: true
-    extra_args: FILE_SUFFIX=release
-      SB_CONFIG_BOOTLOADER_MCUBOOT=y SB_CONFIG_PARTITION_MANAGER=y
+    extra_args:
+      - FILE_SUFFIX=release
+      - SB_CONFIG_BOOTLOADER_MCUBOOT=y
+      - SB_CONFIG_PARTITION_MANAGER=y
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf7002dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf7002dk/nrf5340/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp
-    tags: sysbuild ci_samples_matter
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf7002dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - sysbuild
+      - ci_samples_matter
   sample.matter.light_bulb.lto:
     sysbuild: true
     build_only: true
-    extra_args: CONFIG_LTO=y CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+    extra_args:
+      - CONFIG_LTO=y
+      - CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf7002dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf7002dk/nrf5340/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp
-    tags: sysbuild ci_samples_matter
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf7002dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - sysbuild
+      - ci_samples_matter
   sample.matter.light_bulb.ffs:
     sysbuild: true
     build_only: true
-    extra_args: >
-      CONFIG_CHIP_COMMISSIONABLE_DEVICE_TYPE=y CONFIG_CHIP_ROTATING_DEVICE_ID=y
-      CONFIG_CHIP_DEVICE_TYPE=257
+    extra_args:
+      - CONFIG_CHIP_COMMISSIONABLE_DEVICE_TYPE=y
+      - CONFIG_CHIP_ROTATING_DEVICE_ID=y
+      - CONFIG_CHIP_DEVICE_TYPE=257
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf7002dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf7002dk/nrf5340/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp
-    tags: sysbuild ci_samples_matter
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf7002dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - sysbuild
+      - ci_samples_matter
   sample.matter.light_bulb.debug.nrf21540ek:
     sysbuild: true
     build_only: true
@@ -60,38 +86,55 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
     platform_allow: nrf52840dk/nrf52840
-    tags: sysbuild ci_samples_matter
+    tags:
+      - sysbuild
+      - ci_samples_matter
   sample.matter.light_bulb.debug.nrf21540ek_fwd:
     sysbuild: true
     build_only: true
-    extra_args: light_bulb_SHIELD=nrf21540ek ipc_radio_SHIELD=nrf21540ek
+    extra_args:
+      - light_bulb_SHIELD=nrf21540ek
+      - ipc_radio_SHIELD=nrf21540ek
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: sysbuild ci_samples_matter
+    tags:
+      - sysbuild
+      - ci_samples_matter
   # Sample to execute load tests
   sample.matter.light_bulb.memory_profiling.persistent_subscriptions:
     sysbuild: true
     build_only: true
-    extra_args: CONFIG_CHIP_PERSISTENT_SUBSCRIPTIONS=y
-      CONFIG_CHIP_MEMORY_PROFILING=y CONFIG_SHELL_MINIMAL=y
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp
+    extra_args:
+      - CONFIG_CHIP_PERSISTENT_SUBSCRIPTIONS=y
+      - CONFIG_CHIP_MEMORY_PROFILING=y
+      - CONFIG_SHELL_MINIMAL=y
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    tags: sysbuild ci_samples_matter
+    tags:
+      - sysbuild
+      - ci_samples_matter
   sample.matter.light_bulb.lto.memory_profiling.persistent_subscriptions:
     sysbuild: true
     build_only: true
-    extra_args: CONFIG_CHIP_PERSISTENT_SUBSCRIPTIONS=y
-      CONFIG_CHIP_MEMORY_PROFILING=y CONFIG_SHELL_MINIMAL=y CONFIG_LTO=y
-      CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+    extra_args:
+      - CONFIG_CHIP_PERSISTENT_SUBSCRIPTIONS=y
+      - CONFIG_CHIP_MEMORY_PROFILING=y
+      - CONFIG_SHELL_MINIMAL=y
+      - CONFIG_LTO=y
+      - CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
     platform_allow: nrf7002dk/nrf5340/cpuapp
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
-    tags: sysbuild ci_samples_matter
+    tags:
+      - sysbuild
+      - ci_samples_matter
   sample.matter.light_bulb.aws:
     sysbuild: true
     build_only: true
@@ -99,4 +142,6 @@ tests:
     platform_allow: nrf7002dk/nrf5340/cpuapp
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
-    tags: sysbuild ci_samples_matter
+    tags:
+      - sysbuild
+      - ci_samples_matter

--- a/samples/matter/light_switch/sample.yaml
+++ b/samples/matter/light_switch/sample.yaml
@@ -11,34 +11,54 @@ tests:
       - nrf7002dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf7002dk/nrf5340/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp nrf54l15dk/nrf54l15/cpuapp/ns
-    tags: sysbuild ci_samples_matter
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf7002dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+    tags:
+      - sysbuild
+      - ci_samples_matter
   sample.matter.light_switch.release:
     sysbuild: true
     build_only: true
-    extra_args: FILE_SUFFIX=release
-      SB_CONFIG_BOOTLOADER_MCUBOOT=y SB_CONFIG_PARTITION_MANAGER=y
+    extra_args:
+      - FILE_SUFFIX=release
+      - SB_CONFIG_BOOTLOADER_MCUBOOT=y
+      - SB_CONFIG_PARTITION_MANAGER=y
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf7002dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf7002dk/nrf5340/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp
-    tags: sysbuild ci_samples_matter
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf7002dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - sysbuild
+      - ci_samples_matter
   sample.matter.light_switch.lto:
     sysbuild: true
     build_only: true
-    extra_args: CONFIG_LTO=y CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+    extra_args:
+      - CONFIG_LTO=y
+      - CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf7002dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf7002dk/nrf5340/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp
-    tags: sysbuild ci_samples_matter
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf7002dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - sysbuild
+      - ci_samples_matter
   sample.matter.light_switch.lit_icd:
     sysbuild: true
     build_only: true
@@ -47,18 +67,30 @@ tests:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf54l15dk/nrf54l15/cpuapp
-    tags: sysbuild ci_samples_matter
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - sysbuild
+      - ci_samples_matter
   # Sample to execute load tests
   sample.matter.light_switch.persistent_subscriptions:
     sysbuild: true
     build_only: true
-    extra_args: CONFIG_CHIP_PERSISTENT_SUBSCRIPTIONS=y CONFIG_WIFI_NM_WPA_SUPPLICANT_WPA3=n
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf7002dk/nrf5340/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp
+    extra_args:
+      - CONFIG_CHIP_PERSISTENT_SUBSCRIPTIONS=y
+      - CONFIG_WIFI_NM_WPA_SUPPLICANT_WPA3=n
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf7002dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf7002dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    tags: sysbuild ci_samples_matter
+    tags:
+      - sysbuild
+      - ci_samples_matter

--- a/samples/matter/lock/sample.yaml
+++ b/samples/matter/lock/sample.yaml
@@ -13,10 +13,17 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
       - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf7002dk/nrf5340/cpuapp
-      nrf7002dk/nrf5340/cpuapp/nrf7001 nrf54l15dk/nrf54l15/cpuapp
-      nrf54h20dk/nrf54h20/cpuapp nrf54l15dk/nrf54l15/cpuapp/ns
-    tags: sysbuild ci_samples_matter
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf7002dk/nrf5340/cpuapp
+      - nrf7002dk/nrf5340/cpuapp/nrf7001
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+    tags:
+      - sysbuild
+      - ci_samples_matter
   sample.matter.lock.release:
     sysbuild: true
     build_only: true
@@ -28,23 +35,37 @@ tests:
       - nrf7002dk/nrf5340/cpuapp/nrf7001
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf7002dk/nrf5340/cpuapp
-      nrf7002dk/nrf5340/cpuapp/nrf7001 nrf54l15dk/nrf54l15/cpuapp
-      nrf54h20dk/nrf54h20/cpuapp
-    tags: sysbuild ci_samples_matter
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf7002dk/nrf5340/cpuapp
+      - nrf7002dk/nrf5340/cpuapp/nrf7001
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+    tags:
+      - sysbuild
+      - ci_samples_matter
   sample.matter.lock.lto:
     sysbuild: true
     build_only: true
-    extra_args: CONFIG_LTO=y CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+    extra_args:
+      - CONFIG_LTO=y
+      - CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf7002dk/nrf5340/cpuapp
       - nrf7002dk/nrf5340/cpuapp/nrf7001
       - nrf54l15dk/nrf54l15/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf7002dk/nrf5340/cpuapp
-      nrf7002dk/nrf5340/cpuapp/nrf7001 nrf54l15dk/nrf54l15/cpuapp
-    tags: sysbuild ci_samples_matter
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf7002dk/nrf5340/cpuapp
+      - nrf7002dk/nrf5340/cpuapp/nrf7001
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - sysbuild
+      - ci_samples_matter
   sample.matter.lock.smp_dfu:
     sysbuild: true
     build_only: true
@@ -55,9 +76,15 @@ tests:
       - nrf7002dk/nrf5340/cpuapp
       - nrf7002dk/nrf5340/cpuapp/nrf7001
       - nrf54l15dk/nrf54l15/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf7002dk/nrf5340/cpuapp
-      nrf7002dk/nrf5340/cpuapp/nrf7001 nrf54l15dk/nrf54l15/cpuapp
-    tags: sysbuild ci_samples_matter
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf7002dk/nrf5340/cpuapp
+      - nrf7002dk/nrf5340/cpuapp/nrf7001
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - sysbuild
+      - ci_samples_matter
   sample.matter.lock.no_dfu.no_fd:
     sysbuild: true
     build_only: true
@@ -65,33 +92,54 @@ tests:
     integration_platforms:
       - nrf21540dk/nrf52840
     platform_allow: nrf21540dk/nrf52840
-    tags: sysbuild ci_samples_matter
+    tags:
+      - sysbuild
+      - ci_samples_matter
   sample.matter.lock.thread_wifi_switched.lto.smp_dfu:
     sysbuild: true
     build_only: true
-    extra_args: lock_SHIELD=nrf7002ek
-      FILE_SUFFIX=thread_wifi_switched SB_CONFIG_WIFI_PATCHES_EXT_FLASH_STORE=y
-      SB_CONFIG_MCUBOOT_UPDATEABLE_IMAGES=3 CONFIG_CHIP_DFU_OVER_BT_SMP=y
-      SB_CONFIG_WIFI_NRF70=y SB_CONFIG_DFU_MULTI_IMAGE_PACKAGE_WIFI_FW_PATCH=y
+    extra_args:
+      - lock_SHIELD=nrf7002ek
+      - FILE_SUFFIX=thread_wifi_switched
+      - SB_CONFIG_WIFI_PATCHES_EXT_FLASH_STORE=y
+      - SB_CONFIG_MCUBOOT_UPDATEABLE_IMAGES=3
+      - CONFIG_CHIP_DFU_OVER_BT_SMP=y
+      - SB_CONFIG_WIFI_NRF70=y
+      - SB_CONFIG_DFU_MULTI_IMAGE_PACKAGE_WIFI_FW_PATCH=y
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: sysbuild ci_samples_matter
+    tags:
+      - sysbuild
+      - ci_samples_matter
   sample.matter.lock.nus:
     sysbuild: true
     build_only: true
-    extra_args: CONFIG_CHIP_NUS=y CONFIG_BT_FIXED_PASSKEY=y CONFIG_CHIP_NUS_FIXED_PASSKEY=112233
+    extra_args:
+      - CONFIG_CHIP_NUS=y
+      - CONFIG_BT_FIXED_PASSKEY=y
+      - CONFIG_CHIP_NUS_FIXED_PASSKEY=112233
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf54l15dk/nrf54l15/cpuapp
-    tags: sysbuild ci_samples_matter
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - sysbuild
+      - ci_samples_matter
   sample.matter.lock.release.nrf54l15.power_consumption:
     sysbuild: true
     build_only: true
-    extra_args: FILE_SUFFIX=release CONFIG_NCS_SAMPLE_MATTER_LEDS=n
-      CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y CONFIG_NCS_SAMPLE_MATTER_WATCHDOG=n
+    extra_args:
+      - FILE_SUFFIX=release
+      - CONFIG_NCS_SAMPLE_MATTER_LEDS=n
+      - CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y
+      - CONFIG_NCS_SAMPLE_MATTER_WATCHDOG=n
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
     platform_allow: nrf54l15dk/nrf54l15/cpuapp
-    tags: sysbuild ci_samples_matter
+    tags:
+      - sysbuild
+      - ci_samples_matter

--- a/samples/matter/smoke_co_alarm/sample.yaml
+++ b/samples/matter/smoke_co_alarm/sample.yaml
@@ -10,44 +10,69 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l10/cpuapp
-    tags: sysbuild ci_samples_matter
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+    tags:
+      - sysbuild
+      - ci_samples_matter
   sample.matter.smoke_co_alarm.release:
     sysbuild: true
     build_only: true
-    extra_args: FILE_SUFFIX=release
-      SB_CONFIG_BOOTLOADER_MCUBOOT=y SB_CONFIG_PARTITION_MANAGER=y
+    extra_args:
+      - FILE_SUFFIX=release
+      - SB_CONFIG_BOOTLOADER_MCUBOOT=y
+      - SB_CONFIG_PARTITION_MANAGER=y
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l10/cpuapp
-    tags: sysbuild ci_samples_matter
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+    tags:
+      - sysbuild
+      - ci_samples_matter
   sample.matter.smoke_co_alarm.lto:
     sysbuild: true
     build_only: true
-    extra_args: CONFIG_LTO=y CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+    extra_args:
+      - CONFIG_LTO=y
+      - CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l10/cpuapp
-    tags: sysbuild ci_samples_matter
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+    tags:
+      - sysbuild
+      - ci_samples_matter
   sample.matter.smoke_co_alarm.release.nrf54l15.power_consumption:
     sysbuild: true
     build_only: true
-    extra_args: FILE_SUFFIX=release CONFIG_NCS_SAMPLE_MATTER_LEDS=n
-      CONFIG_NCS_SAMPLE_MATTER_WATCHDOG=n
+    extra_args:
+      - FILE_SUFFIX=release
+      - CONFIG_NCS_SAMPLE_MATTER_LEDS=n
+      - CONFIG_NCS_SAMPLE_MATTER_WATCHDOG=n
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
-    platform_allow: nrf54l15dk/nrf54l15/cpuapp nrf54l15dk/nrf54l10/cpuapp
-    tags: sysbuild ci_samples_matter
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+    tags:
+      - sysbuild
+      - ci_samples_matter
   sample.matter.smoke_co_alarm.debug.reference:
     sysbuild: true
     build_only: true
@@ -55,4 +80,6 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
     extra_args: smoke_co_alarm_SNIPPET="diagnostic-logs"
     platform_allow: nrf54l15dk/nrf54l15/cpuapp
-    tags: sysbuild ci_samples_matter
+    tags:
+      - sysbuild
+      - ci_samples_matter

--- a/samples/matter/template/sample.yaml
+++ b/samples/matter/template/sample.yaml
@@ -13,14 +13,22 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
       - nrf54l15dk/nrf54l10/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf7002dk/nrf5340/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp nrf54l15dk/nrf54l15/cpuapp/ns nrf54l15dk/nrf54l10/cpuapp
-    tags: sysbuild ci_samples_matter
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf7002dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
+    tags:
+      - sysbuild
+      - ci_samples_matter
   sample.matter.template.release:
     sysbuild: true
     build_only: true
-    extra_args: FILE_SUFFIX=release
-      CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS=y
+    extra_args:
+      - FILE_SUFFIX=release
+      - CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS=y
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
@@ -28,28 +36,44 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
       - nrf54l15dk/nrf54l10/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf7002dk/nrf5340/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp nrf54l15dk/nrf54l15/cpuapp/ns nrf54l15dk/nrf54l10/cpuapp
-    tags: sysbuild ci_samples_matter
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf7002dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
+    tags:
+      - sysbuild
+      - ci_samples_matter
   sample.matter.template.lto:
     sysbuild: true
     build_only: true
-    extra_args: CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS=y
-      CONFIG_LTO=y CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+    extra_args:
+      - CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS=y
+      - CONFIG_LTO=y
+      - CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf7002dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf7002dk/nrf5340/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp nrf54l15dk/nrf54l10/cpuapp
-    tags: sysbuild ci_samples_matter
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf7002dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+    tags:
+      - sysbuild
+      - ci_samples_matter
   sample.matter.template.smp_dfu:
     sysbuild: true
     build_only: true
-    extra_args: CONFIG_CHIP_DFU_OVER_BT_SMP=y
-      CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS=y
+    extra_args:
+      - CONFIG_CHIP_DFU_OVER_BT_SMP=y
+      - CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS=y
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
@@ -57,9 +81,16 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
       - nrf54l15dk/nrf54l10/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf7002dk/nrf5340/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp nrf54l15dk/nrf54l15/cpuapp/ns nrf54l15dk/nrf54l10/cpuapp
-    tags: sysbuild ci_samples_matter
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf7002dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
+    tags:
+      - sysbuild
+      - ci_samples_matter
   sample.matter.template.smp_dfu.nrf54h20:
     sysbuild: true
     build_only: true
@@ -67,7 +98,9 @@ tests:
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     platform_allow: nrf54h20dk/nrf54h20/cpuapp
-    tags: sysbuild ci_samples_matter
+    tags:
+      - sysbuild
+      - ci_samples_matter
   sample.matter.template.nrf54h20.nrf7002eb:
     sysbuild: true
     build_only: true
@@ -83,16 +116,22 @@ tests:
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     platform_allow: nrf54h20dk/nrf54h20/cpuapp
-    tags: sysbuild ci_samples_matter
+    tags:
+      - sysbuild
+      - ci_samples_matter
   sample.matter.template.release.internal.smp_dfu:
     sysbuild: true
     build_only: true
-    extra_args: FILE_SUFFIX=internal CONFIG_CHIP_DFU_OVER_BT_SMP=y
-      CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS=y
+    extra_args:
+      - FILE_SUFFIX=internal
+      - CONFIG_CHIP_DFU_OVER_BT_SMP=y
+      - CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS=y
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
     platform_allow: nrf54l15dk/nrf54l15/cpuapp
-    tags: sysbuild ci_samples_matter
+    tags:
+      - sysbuild
+      - ci_samples_matter
   sample.matter.template.cc3xx_backend:
     sysbuild: true
     build_only: true
@@ -100,5 +139,9 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
-    tags: sysbuild ci_samples_matter
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+    tags:
+      - sysbuild
+      - ci_samples_matter

--- a/samples/matter/thermostat/sample.yaml
+++ b/samples/matter/thermostat/sample.yaml
@@ -11,31 +11,51 @@ tests:
       - nrf7002dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf7002dk/nrf5340/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp nrf54l15dk/nrf54l15/cpuapp/ns
-    tags: sysbuild ci_samples_matter
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf7002dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+    tags:
+      - sysbuild
+      - ci_samples_matter
   sample.matter.thermostat.release:
     sysbuild: true
     build_only: true
-    extra_args: FILE_SUFFIX=release
-      SB_CONFIG_BOOTLOADER_MCUBOOT=y SB_CONFIG_PARTITION_MANAGER=y
+    extra_args:
+      - FILE_SUFFIX=release
+      - SB_CONFIG_BOOTLOADER_MCUBOOT=y
+      - SB_CONFIG_PARTITION_MANAGER=y
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf7002dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf7002dk/nrf5340/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp
-    tags: sysbuild ci_samples_matter
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf7002dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - sysbuild
+      - ci_samples_matter
   sample.matter.thermostat.lto:
     sysbuild: true
     build_only: true
-    extra_args: CONFIG_LTO=y CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+    extra_args:
+      - CONFIG_LTO=y
+      - CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf7002dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf7002dk/nrf5340/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp
-    tags: sysbuild ci_samples_matter
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf7002dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - sysbuild
+      - ci_samples_matter

--- a/samples/matter/window_covering/sample.yaml
+++ b/samples/matter/window_covering/sample.yaml
@@ -10,38 +10,59 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp nrf54l15dk/nrf54l15/cpuapp/ns
-    tags: sysbuild ci_samples_matter
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+    tags:
+      - sysbuild
+      - ci_samples_matter
   sample.matter.window_cover.release:
     sysbuild: true
     build_only: true
-    extra_args: FILE_SUFFIX=release
-      SB_CONFIG_BOOTLOADER_MCUBOOT=y SB_CONFIG_PARTITION_MANAGER=y
+    extra_args:
+      - FILE_SUFFIX=release
+      - SB_CONFIG_BOOTLOADER_MCUBOOT=y
+      - SB_CONFIG_PARTITION_MANAGER=y
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp
-    tags: sysbuild ci_samples_matter
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - sysbuild
+      - ci_samples_matter
   sample.matter.window_cover.lto:
     sysbuild: true
     build_only: true
-    extra_args: CONFIG_LTO=y CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+    extra_args:
+      - CONFIG_LTO=y
+      - CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp
-    tags: sysbuild ci_samples_matter
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - sysbuild
+      - ci_samples_matter
   sample.matter.window_cover.release.nrf54l15.power_consumption:
     sysbuild: true
     build_only: true
-    extra_args: FILE_SUFFIX=release CONFIG_NCS_SAMPLE_MATTER_LEDS=n
-      CONFIG_NCS_SAMPLE_MATTER_WATCHDOG=n
+    extra_args:
+      - FILE_SUFFIX=release
+      - CONFIG_NCS_SAMPLE_MATTER_LEDS=n
+      - CONFIG_NCS_SAMPLE_MATTER_WATCHDOG=n
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
     platform_allow: nrf54l15dk/nrf54l15/cpuapp
-    tags: sysbuild ci_samples_matter
+    tags:
+      - sysbuild
+      - ci_samples_matter

--- a/samples/mpsl/timeslot/sample.yaml
+++ b/samples/mpsl/timeslot/sample.yaml
@@ -21,4 +21,7 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
-    tags: ci_build sysbuild ci_samples_mpsl
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_mpsl

--- a/samples/net/aws_iot/sample.yaml
+++ b/samples/net/aws_iot/sample.yaml
@@ -3,7 +3,10 @@ sample:
 tests:
   sample.net.aws_iot:
     sysbuild: true
-    tags: ci_build sysbuild ci_samples_net
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
     build_only: true
     build_on_all: true
     integration_platforms:
@@ -24,7 +27,10 @@ tests:
       - native_sim
   sample.net.aws_iot.nrf54l15.wifi:
     sysbuild: true
-    tags: ci_build sysbuild ci_samples_net
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
     build_only: true
     build_on_all: true
     integration_platforms:

--- a/samples/net/azure_iot_hub/sample.yaml
+++ b/samples/net/azure_iot_hub/sample.yaml
@@ -16,7 +16,10 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf7002dk/nrf5340/cpuapp/ns
       - native_sim
-    tags: ci_build sysbuild ci_samples_net
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
   sample.net.azure_iot_hub.dps:
     sysbuild: true
     build_only: true
@@ -33,4 +36,7 @@ tests:
     extra_args: OVERLAY_CONFIG=overlay-dps.conf
     extra_configs:
       - CONFIG_AZURE_IOT_HUB_DPS_ID_SCOPE="test-scope"
-    tags: ci_build sysbuild ci_samples_net
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net

--- a/samples/net/coap_client/sample.yaml
+++ b/samples/net/coap_client/sample.yaml
@@ -19,7 +19,10 @@ tests:
       - thingy91/nrf9160/ns
       - nrf7002dk/nrf5340/cpuapp/ns
       - native_sim
-    tags: ci_build sysbuild ci_samples_net
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
   sample.net.coap_client.nrf54l15.wifi:
     sysbuild: true
     build_only: true
@@ -27,5 +30,8 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
-    tags: ci_build sysbuild ci_samples_net
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
     extra_args: coap_client_SHIELD="nrf7002eb_interposer_p1;nrf7002eb"

--- a/samples/net/download/sample.yaml
+++ b/samples/net/download/sample.yaml
@@ -12,7 +12,10 @@ tests:
       - nrf9161dk/nrf9161/ns
       - nrf7002dk/nrf5340/cpuapp/ns
       - native_sim
-    tags: ci_build sysbuild ci_samples_net
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
   sample.net.downloader.ci:
     sysbuild: true
     build_only: true
@@ -31,10 +34,16 @@ tests:
       - nrf9161dk/nrf9161/ns
       - nrf9151dk/nrf9151/ns
       - nrf7002dk/nrf5340/cpuapp/ns
-    tags: ci_build sysbuild ci_samples_net
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
   sample.net.downloader.nrf54l15.wifi:
     sysbuild: true
-    tags: ci_build sysbuild ci_samples_net
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
     build_only: true
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp

--- a/samples/net/http_server/sample.yaml
+++ b/samples/net/http_server/sample.yaml
@@ -7,7 +7,10 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp/ns
     platform_allow: nrf7002dk/nrf5340/cpuapp/ns
-    tags: ci_build sysbuild ci_samples_net
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
   sample.net.http_server.wifi.tls:
     sysbuild: true
     build_only: true
@@ -15,7 +18,10 @@ tests:
       - nrf7002dk/nrf5340/cpuapp/ns
     platform_allow: nrf7002dk/nrf5340/cpuapp/ns
     extra_args: OVERLAY_CONFIG=overlay-tls-nrf7002dk.conf
-    tags: ci_build sysbuild ci_samples_net
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
   sample.net.http_server.lte:
     sysbuild: true
     build_only: true
@@ -29,7 +35,10 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - thingy91/nrf9160/ns
-    tags: ci_build sysbuild ci_samples_net
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
   sample.net.http_server.lte.tls:
     sysbuild: true
     build_only: true
@@ -44,11 +53,16 @@ tests:
       - nrf9160dk/nrf9160/ns
       - thingy91/nrf9160/ns
     extra_args: OVERLAY_CONFIG=overlay-tls-nrf91.conf
-    tags: ci_build sysbuild ci_samples_net
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
   sample.net.http_server.emulation:
     build_only: true
     integration_platforms:
       - native_sim
     platform_allow:
       - native_sim
-    tags: ci_build ci_samples_net
+    tags:
+      - ci_build
+      - ci_samples_net

--- a/samples/net/https_client/sample.yaml
+++ b/samples/net/https_client/sample.yaml
@@ -16,7 +16,10 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf7002dk/nrf5340/cpuapp/ns
       - native_sim
-    tags: ci_build sysbuild ci_samples_net
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
   sample.net.https_client.lte.tfm-mbedtls:
     sysbuild: true
     build_only: true
@@ -28,7 +31,10 @@ tests:
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
       - nrf9151dk/nrf9151/ns
-    tags: ci_build sysbuild ci_samples_net
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
   sample.net.https_client.lte.pdn-ipv4:
     sysbuild: true
     build_only: true
@@ -41,7 +47,10 @@ tests:
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
       - nrf9151dk/nrf9151/ns
-    tags: ci_build sysbuild ci_samples_net
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
   sample.net.https_client.nrf54l15.wifi:
     sysbuild: true
     build_only: true
@@ -49,5 +58,8 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
-    tags: ci_build sysbuild ci_samples_net
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
     extra_args: https_client_SHIELD="nrf7002eb_interposer_p1;nrf7002eb"

--- a/samples/net/mqtt/sample.yaml
+++ b/samples/net/mqtt/sample.yaml
@@ -21,7 +21,10 @@ tests:
       - thingy91x/nrf9151/ns
       - nrf7002dk/nrf5340/cpuapp/ns
       - native_sim
-    tags: ci_build sysbuild ci_samples_net
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
   sample.net.mqtt.nrf70.tls:
     sysbuild: true
     build_only: true
@@ -29,20 +32,29 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp/ns
     platform_allow: nrf7002dk/nrf5340/cpuapp/ns
-    tags: ci_build sysbuild ci_samples_net
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
     extra_args: EXTRA_CONF_FILE=overlay-tls-nrf70.conf
   sample.net.mqtt.nrf54l15.wifi:
     sysbuild: true
     build_only: true
     platform_allow: nrf54l15dk/nrf54l15/cpuapp
-    tags: ci_build sysbuild ci_samples_net
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
     extra_args:
       - mqtt_SHIELD="nrf7002eb_interposer_p1;nrf7002eb"
   sample.net.mqtt.nrf54l15.wifi.tls:
     sysbuild: true
     build_only: true
     platform_allow: nrf54l15dk/nrf54l15/cpuapp
-    tags: ci_build sysbuild ci_samples_net
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
     extra_args:
       - mqtt_SHIELD="nrf7002eb_interposer_p1;nrf7002eb"
       - mqtt_EXTRA_CONF_FILE=overlay-tls-nrf54l15-nrf70.conf
@@ -62,12 +74,18 @@ tests:
       - nrf9151dk/nrf9151/ns
       - thingy91/nrf9160/ns
       - thingy91x/nrf9151/ns
-    tags: ci_build sysbuild ci_samples_net
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
     extra_args: EXTRA_CONF_FILE=overlay-tls-nrf91.conf
   sample.net.mqtt.native_sim.tls:
     sysbuild: true
     build_only: true
     build_on_all: true
     platform_allow: native_sim
-    tags: ci_build sysbuild ci_samples_net
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
     extra_args: EXTRA_CONF_FILE=overlay-tls-native_sim.conf

--- a/samples/net/udp/sample.yaml
+++ b/samples/net/udp/sample.yaml
@@ -16,7 +16,10 @@ tests:
       - nrf9151dk/nrf9151/ns
       - thingy91/nrf9160/ns
       - nrf7002dk/nrf5340/cpuapp/ns
-    tags: ci_build sysbuild ci_samples_net
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
   sample.net.udp.emulation:
     sysbuild: true
     build_only: true
@@ -24,7 +27,10 @@ tests:
       - native_sim
     platform_allow:
       - native_sim
-    tags: ci_build sysbuild ci_samples_net
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
   sample.net.udp.nrf54l15.wifi:
     sysbuild: true
     build_only: true
@@ -32,5 +38,8 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
-    tags: ci_build sysbuild ci_samples_net
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
     extra_args: udp_SHIELD="nrf7002eb_interposer_p1;nrf7002eb"

--- a/samples/nfc/record_launch_app/sample.yaml
+++ b/samples/nfc/record_launch_app/sample.yaml
@@ -12,11 +12,14 @@ tests:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    platform_allow: >
-      nrf52840dk/nrf52840
-      nrf52dk/nrf52832
-      nrf5340dk/nrf5340/cpuapp
-      nrf5340dk/nrf5340/cpuapp/ns
-      nrf54h20dk/nrf54h20/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp
-    tags: ci_build sysbuild ci_samples_nfc
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52dk/nrf52832
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_nfc

--- a/samples/nfc/record_text/sample.yaml
+++ b/samples/nfc/record_text/sample.yaml
@@ -12,11 +12,14 @@ tests:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    platform_allow: >
-      nrf52840dk/nrf52840
-      nrf52dk/nrf52832
-      nrf5340dk/nrf5340/cpuapp
-      nrf5340dk/nrf5340/cpuapp/ns
-      nrf54h20dk/nrf54h20/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp
-    tags: ci_build sysbuild ci_samples_nfc
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52dk/nrf52832
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_nfc

--- a/samples/nfc/shell/sample.yaml
+++ b/samples/nfc/shell/sample.yaml
@@ -12,11 +12,14 @@ tests:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    platform_allow: >
-      nrf52840dk/nrf52840
-      nrf52dk/nrf52832
-      nrf5340dk/nrf5340/cpuapp
-      nrf5340dk/nrf5340/cpuapp/ns
-      nrf54h20dk/nrf54h20/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp
-    tags: ci_build sysbuild ci_samples_nfc
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52dk/nrf52832
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_nfc

--- a/samples/nfc/system_off/sample.yaml
+++ b/samples/nfc/system_off/sample.yaml
@@ -11,10 +11,13 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
-    platform_allow: >
-      nrf52840dk/nrf52840
-      nrf52dk/nrf52832
-      nrf5340dk/nrf5340/cpuapp
-      nrf5340dk/nrf5340/cpuapp/ns
-      nrf54l15dk/nrf54l15/cpuapp
-    tags: ci_build sysbuild ci_samples_nfc
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52dk/nrf52832
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_nfc

--- a/samples/nfc/tag_reader/sample.yaml
+++ b/samples/nfc/tag_reader/sample.yaml
@@ -9,5 +9,11 @@ tests:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf52dk/nrf52832 nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_nfc
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52dk/nrf52832
+      - nrf5340dk/nrf5340/cpuapp
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_nfc

--- a/samples/nfc/tnep_poller/sample.yaml
+++ b/samples/nfc/tnep_poller/sample.yaml
@@ -9,5 +9,11 @@ tests:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf52dk/nrf52832 nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_nfc
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52dk/nrf52832
+      - nrf5340dk/nrf5340/cpuapp
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_nfc

--- a/samples/nfc/tnep_tag/sample.yaml
+++ b/samples/nfc/tnep_tag/sample.yaml
@@ -12,11 +12,14 @@ tests:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    platform_allow: >
-      nrf52840dk/nrf52840
-      nrf52dk/nrf52832
-      nrf5340dk/nrf5340/cpuapp
-      nrf5340dk/nrf5340/cpuapp/ns
-      nrf54h20dk/nrf54h20/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp
-    tags: ci_build sysbuild ci_samples_nfc
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52dk/nrf52832
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_nfc

--- a/samples/nfc/writable_ndef_msg/sample.yaml
+++ b/samples/nfc/writable_ndef_msg/sample.yaml
@@ -12,11 +12,14 @@ tests:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    platform_allow: >
-      nrf52840dk/nrf52840
-      nrf52dk/nrf52832
-      nrf5340dk/nrf5340/cpuapp
-      nrf5340dk/nrf5340/cpuapp/ns
-      nrf54h20dk/nrf54h20/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp
-    tags: ci_build sysbuild ci_samples_nfc
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52dk/nrf52832
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_nfc

--- a/samples/nrf5340/empty_app_core/sample.yaml
+++ b/samples/nrf5340/empty_app_core/sample.yaml
@@ -8,5 +8,9 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
       - nrf7002dk/nrf5340/cpuapp
-    platform_allow: nrf5340dk/nrf5340/cpuapp nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf7002dk/nrf5340/cpuapp
+    tags:
+      - ci_build
+      - sysbuild

--- a/samples/nrf5340/empty_net_core/sample.yaml
+++ b/samples/nrf5340/empty_net_core/sample.yaml
@@ -8,5 +8,9 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpunet
       - thingy53/nrf5340/cpunet
-    platform_allow: nrf5340dk/nrf5340/cpunet thingy53/nrf5340/cpunet
-    tags: ci_build sysbuild
+    platform_allow:
+      - nrf5340dk/nrf5340/cpunet
+      - thingy53/nrf5340/cpunet
+    tags:
+      - ci_build
+      - sysbuild

--- a/samples/nrf5340/netboot/sample.yaml
+++ b/samples/nrf5340/netboot/sample.yaml
@@ -7,7 +7,9 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpunet
     platform_allow: nrf5340dk/nrf5340/cpunet
-    tags: ci_build sysbuild
+    tags:
+      - ci_build
+      - sysbuild
   sample.nrf5340.netboot.minimal_size:
     sysbuild: true
     build_only: true
@@ -15,4 +17,6 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpunet
     platform_allow: nrf5340dk/nrf5340/cpunet
-    tags: ci_build sysbuild
+    tags:
+      - ci_build
+      - sysbuild

--- a/samples/nrf5340/remote_shell/sample.yaml
+++ b/samples/nrf5340/remote_shell/sample.yaml
@@ -8,7 +8,9 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags:
+      - ci_build
+      - sysbuild
   sample.nrf5340.remote_ipc_shell.uart.build:
     sysbuild: true
     build_only: true
@@ -17,4 +19,6 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild
+    tags:
+      - ci_build
+      - sysbuild

--- a/samples/nrf_compress/mcuboot_update/sample.yaml
+++ b/samples/nrf_compress/mcuboot_update/sample.yaml
@@ -1,6 +1,8 @@
 common:
   sysbuild: true
-  tags: sysbuild ci_samples_nrf_compress
+  tags:
+    - sysbuild
+    - ci_samples_nrf_compress
   build_only: true
 tests:
   nrf_compress.mcuboot_update:

--- a/samples/nrf_profiler/sample.yaml
+++ b/samples/nrf_profiler/sample.yaml
@@ -17,5 +17,11 @@ tests:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf9160dk/nrf9160/ns
       - nrf21540dk/nrf52840
-    platform_exclude: native_sim qemu_x86 qemu_cortex_m3
-    tags: ci_build sysbuild ci_samples_nrf_profiler
+    platform_exclude:
+      - native_sim
+      - qemu_x86
+      - qemu_cortex_m3
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_nrf_profiler

--- a/samples/nrf_rpc/entropy_nrf53/sample.yaml
+++ b/samples/nrf_rpc/entropy_nrf53/sample.yaml
@@ -8,4 +8,6 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: sysbuild ci_samples_nrf_rpc
+    tags:
+      - sysbuild
+      - ci_samples_nrf_rpc

--- a/samples/nrf_rpc/protocols_serialization/client/sample.yaml
+++ b/samples/nrf_rpc/protocols_serialization/client/sample.yaml
@@ -1,13 +1,16 @@
 sample:
   name: Protocols serialization client sample
-  description: Demonstrates serialization of Bluetooth LE and OpenThread API using nRF RPC
+  description: Demonstrates serialization of Bluetooth LE and OpenThread API using
+    nRF RPC
 tests:
   samples.nrf_rpc.protocols_serialization.client.rpc_ble:
     build_only: true
-    platform_allow: >
-      nrf52840dk/nrf52840
-      nrf54l15dk/nrf54l15/cpuapp
-    tags: ci_build ci_samples_nrf_rpc
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - ci_build
+      - ci_samples_nrf_rpc
     extra_args: >
       SNIPPET="ble"
     integration_platforms:
@@ -15,10 +18,12 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
   samples.nrf_rpc.protocols_serialization.client.rpc_ot:
     build_only: true
-    platform_allow: >
-      nrf52840dk/nrf52840
-      nrf54l15dk/nrf54l15/cpuapp
-    tags: ci_build ci_samples_nrf_rpc
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - ci_build
+      - ci_samples_nrf_rpc
     extra_args: >
       SNIPPET="openthread"
     integration_platforms:
@@ -26,10 +31,12 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
   samples.nrf_rpc.protocols_serialization.client.rpc:
     build_only: true
-    platform_allow: >
-      nrf52840dk/nrf52840
-      nrf54l15dk/nrf54l15/cpuapp
-    tags: ci_build ci_samples_nrf_rpc
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - ci_build
+      - ci_samples_nrf_rpc
     extra_args: >
       SNIPPET="ble;openthread;debug;coex;log_rpc"
     integration_platforms:

--- a/samples/nrf_rpc/protocols_serialization/server/sample.yaml
+++ b/samples/nrf_rpc/protocols_serialization/server/sample.yaml
@@ -1,13 +1,16 @@
 sample:
   name: Protocols serialization server sample
-  description: Demonstrates serialization of Bluetooth LE and OpenThread API using nRF RPC
+  description: Demonstrates serialization of Bluetooth LE and OpenThread API using
+    nRF RPC
 tests:
   samples.nrf_rpc.protocols_serialization.server.rpc_ble:
     build_only: true
-    platform_allow: >
-      nrf52840dk/nrf52840
-      nrf54l15dk/nrf54l15/cpuapp
-    tags: ci_build ci_samples_nrf_rpc
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - ci_build
+      - ci_samples_nrf_rpc
     extra_args: >
       SNIPPET="ble"
     integration_platforms:
@@ -15,10 +18,12 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
   samples.nrf_rpc.protocols_serialization.server.rpc_ot:
     build_only: true
-    platform_allow: >
-      nrf52840dk/nrf52840
-      nrf54l15dk/nrf54l15/cpuapp
-    tags: ci_build ci_samples_nrf_rpc
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - ci_build
+      - ci_samples_nrf_rpc
     extra_args: >
       SNIPPET="openthread"
     integration_platforms:
@@ -26,10 +31,12 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
   samples.nrf_rpc.protocols_serialization.server.rpc:
     build_only: true
-    platform_allow: >
-      nrf52840dk/nrf52840
-      nrf54l15dk/nrf54l15/cpuapp
-    tags: ci_build ci_samples_nrf_rpc
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - ci_build
+      - ci_samples_nrf_rpc
     extra_args: >
       SNIPPET="ble;openthread;debug;coex;log_rpc"
     integration_platforms:

--- a/samples/openthread/cli/sample.yaml
+++ b/samples/openthread/cli/sample.yaml
@@ -6,16 +6,19 @@ tests:
   sample.openthread.cli:
     sysbuild: true
     build_only: true
-    tags: ci_build sysbuild ci_samples_openthread
-    platform_allow: >
-      nrf52840dk/nrf52840
-      nrf52840dongle/nrf52840
-      nrf21540dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l10/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp/ns
-      nrf54h20dk/nrf54h20/cpuapp
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_openthread
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52840dongle/nrf52840
+      - nrf21540dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf52840dongle/nrf52840
@@ -28,19 +31,22 @@ tests:
   sample.openthread.cli.multiprotocol:
     sysbuild: true
     build_only: true
-    tags: ci_build sysbuild ci_samples_openthread
-    platform_allow: >
-      nrf52840dk/nrf52840
-      nrf52840dongle/nrf52840
-      nrf21540dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l10/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp/ns
-      nrf54h20dk/nrf54h20/cpuapp
-    extra_args: >
-      cli_SNIPPET="ci;logging;multiprotocol;tcp"
-      FILE_SUFFIX=ble
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_openthread
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52840dongle/nrf52840
+      - nrf21540dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54h20dk/nrf54h20/cpuapp
+    extra_args:
+      - cli_SNIPPET="ci;logging;multiprotocol;tcp"
+      - FILE_SUFFIX=ble
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf52840dongle/nrf52840
@@ -53,15 +59,18 @@ tests:
   sample.openthread.cli.singleprotocol:
     sysbuild: true
     build_only: true
-    tags: ci_build sysbuild ci_samples_openthread
-    platform_allow: >
-      nrf52840dk/nrf52840
-      nrf21540dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l10/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp/ns
-      nrf54h20dk/nrf54h20/cpuapp
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_openthread
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf21540dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54h20dk/nrf54h20/cpuapp
     extra_args: >
       cli_SNIPPET="ci;logging;tcp"
     integration_platforms:
@@ -75,14 +84,17 @@ tests:
   sample.openthread.cli.usb:
     sysbuild: true
     build_only: true
-    tags: ci_build sysbuild ci_samples_openthread
-    platform_allow: >
-      nrf52840dk/nrf52840
-      nrf21540dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp
-    extra_args: >
-      cli_SNIPPET="ci;logging;multiprotocol;tcp;usb"
-      FILE_SUFFIX=ble
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_openthread
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf21540dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+    extra_args:
+      - cli_SNIPPET="ci;logging;multiprotocol;tcp;usb"
+      - FILE_SUFFIX=ble
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf21540dk/nrf52840
@@ -90,10 +102,13 @@ tests:
   sample.openthread.cli.low_power:
     sysbuild: true
     build_only: true
-    tags: ci_build sysbuild ci_samples_openthread
-    platform_allow: >
-      nrf52840dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_openthread
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
     extra_args: >
       cli_SNIPPET="ci;low_power"
     integration_platforms:
@@ -103,28 +118,33 @@ tests:
   sample.nrf_security.openthread.integration:
     sysbuild: true
     build_only: true
-    tags: sysbuild ci_samples_openthread
+    tags:
+      - sysbuild
+      - ci_samples_openthread
     platform_allow: >
       nrf52840dk/nrf52840
-    extra_args: >
-      cli_SNIPPET=ci
-      CONFIG_NRF_SECURITY=y
+    extra_args:
+      - cli_SNIPPET=ci
+      - CONFIG_NRF_SECURITY=y
     integration_platforms:
       - nrf52840dk/nrf52840
   sample.openthread.cli.tcat:
     sysbuild: true
     build_only: true
-    tags: ci_build sysbuild ci_samples_openthread
-    platform_allow: >
-      nrf52840dk/nrf52840
-      nrf21540dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l10/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp/ns
-    extra_args: >
-      cli_SNIPPET="ci;tcat;tcp"
-      FILE_SUFFIX=ble
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_openthread
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf21540dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+    extra_args:
+      - cli_SNIPPET="ci;tcat;tcp"
+      - FILE_SUFFIX=ble
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf21540dk/nrf52840
@@ -135,13 +155,16 @@ tests:
   sample.openthread.cli.diag_gpio:
     sysbuild: true
     build_only: true
-    tags: ci_build sysbuild ci_samples_openthread
-    platform_allow: >
-      nrf52840dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l10/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp/ns
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_openthread
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
     extra_args: >
       cli_SNIPPET=diag_gpio
     integration_platforms:

--- a/samples/openthread/coap_client/sample.yaml
+++ b/samples/openthread/coap_client/sample.yaml
@@ -6,11 +6,14 @@ tests:
   sample.openthread.coap_client:
     sysbuild: true
     build_only: true
-    tags: ci_build sysbuild ci_samples_openthread
-    platform_allow: >
-      nrf52840dk/nrf52840
-      nrf21540dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_openthread
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf21540dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf21540dk/nrf52840
@@ -18,11 +21,14 @@ tests:
   sample.openthread.coap_client.ftd:
     sysbuild: true
     build_only: true
-    tags: ci_build sysbuild ci_samples_openthread
-    platform_allow: >
-      nrf52840dk/nrf52840
-      nrf21540dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_openthread
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf21540dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
     extra_args: >
       coap_client_SNIPPET="ci;logging"
     integration_platforms:
@@ -32,11 +38,14 @@ tests:
   sample.openthread.coap_client.mtd:
     sysbuild: true
     build_only: true
-    tags: ci_build sysbuild ci_samples_openthread
-    platform_allow: >
-      nrf52840dk/nrf52840
-      nrf21540dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_openthread
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf21540dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
     extra_args: >
       coap_client_SNIPPET="ci;logging;mtd"
     integration_platforms:
@@ -46,14 +55,17 @@ tests:
   sample.openthread.coap_client.mtd.multiprotocol_ble:
     sysbuild: true
     build_only: true
-    tags: ci_build sysbuild ci_samples_openthread
-    platform_allow: >
-      nrf52840dk/nrf52840
-      nrf21540dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp
-    extra_args: >
-      coap_client_SNIPPET="ci;logging;mtd;multiprotocol_ble"
-      FILE_SUFFIX=ble
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_openthread
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf21540dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+    extra_args:
+      - coap_client_SNIPPET="ci;logging;mtd;multiprotocol_ble"
+      - FILE_SUFFIX=ble
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf21540dk/nrf52840

--- a/samples/openthread/coap_server/sample.yaml
+++ b/samples/openthread/coap_server/sample.yaml
@@ -6,11 +6,14 @@ tests:
   sample.openthread.coap_server:
     sysbuild: true
     build_only: true
-    tags: ci_build sysbuild ci_samples_openthread
-    platform_allow: >
-      nrf52840dk/nrf52840
-      nrf21540dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_openthread
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf21540dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf21540dk/nrf52840
@@ -18,11 +21,14 @@ tests:
   sample.openthread.coap_server.ftd:
     sysbuild: true
     build_only: true
-    tags: ci_build sysbuild ci_samples_openthread
-    platform_allow: >
-      nrf52840dk/nrf52840
-      nrf21540dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_openthread
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf21540dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
     extra_args: >
       coap_server_SNIPPET="ci;logging"
     integration_platforms:

--- a/samples/openthread/coprocessor/sample.yaml
+++ b/samples/openthread/coprocessor/sample.yaml
@@ -6,16 +6,19 @@ tests:
   sample.openthread.coprocessor:
     sysbuild: true
     build_only: true
-    tags: ci_build sysbuild ci_samples_openthread
-    platform_allow: >
-      nrf52833dk/nrf52833
-      nrf52840dk/nrf52840
-      nrf52840dongle/nrf52840
-      nrf21540dk/nrf52840
-      nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l10/cpuapp
-      nrf54l15dk/nrf54l05/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp/ns
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_openthread
+    platform_allow:
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf52840dongle/nrf52840
+      - nrf21540dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
     integration_platforms:
       - nrf52833dk/nrf52833
       - nrf52840dk/nrf52840
@@ -28,16 +31,19 @@ tests:
   sample.openthread.coprocessor.vendor_hook:
     sysbuild: true
     build_only: true
-    tags: ci_build sysbuild ci_samples_openthread
-    platform_allow: >
-      nrf52833dk/nrf52833
-      nrf52840dk/nrf52840
-      nrf52840dongle/nrf52840
-      nrf21540dk/nrf52840
-      nrf54l15dk/nrf54l15/cpuapp
-      nrf54l15dk/nrf54l10/cpuapp
-      nrf54l15dk/nrf54l05/cpuapp
-      nrf54l15dk/nrf54l15/cpuapp/ns
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_openthread
+    platform_allow:
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf52840dongle/nrf52840
+      - nrf21540dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
     extra_args: >
       SNIPPET="ci;logging;vendor_hook"
     integration_platforms:
@@ -52,11 +58,14 @@ tests:
   sample.openthread.coprocessor.usb:
     sysbuild: true
     build_only: true
-    tags: ci_build sysbuild ci_samples_openthread
-    platform_allow: >
-      nrf52833dk/nrf52833
-      nrf52840dk/nrf52840
-      nrf21540dk/nrf52840
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_openthread
+    platform_allow:
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf21540dk/nrf52840
     extra_args: >
       SNIPPET="ci;usb"
     integration_platforms:
@@ -66,11 +75,14 @@ tests:
   sample.openthread.coprocessor.hci:
     sysbuild: true
     build_only: true
-    tags: ci_build sysbuild ci_samples_openthread
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_openthread
     extra_args: >
       SNIPPET="ci;hci"
-    platform_allow: >
-      nrf52840dk/nrf52840
-      nrf21540dk/nrf52840
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf21540dk/nrf52840
     integration_platforms:
       - nrf52840dk/nrf52840

--- a/samples/peripheral/802154_phy_test/sample.yaml
+++ b/samples/peripheral/802154_phy_test/sample.yaml
@@ -12,25 +12,47 @@ tests:
       - nrf5340dk/nrf5340/cpunet
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
-    platform_allow: nrf52833dk/nrf52833 nrf52840dk/nrf52840 nrf21540dk/nrf52840
-      nrf5340dk/nrf5340/cpunet nrf54l15dk/nrf54l15/cpuapp
-      nrf54h20dk/nrf54h20/cpurad
-    tags: ci_build ci_rs_build ci_rs_weekly sysbuild ci_samples_peripheral_802154
+    platform_allow:
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf21540dk/nrf52840
+      - nrf5340dk/nrf5340/cpunet
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpurad
+    tags:
+      - ci_build
+      - ci_rs_build
+      - ci_rs_weekly
+      - sysbuild
+      - ci_samples_peripheral_802154
   sample.peripheral.802154_phy_test.ant_div_mode_auto:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf21540dk/nrf52840
     platform_allow: nrf21540dk/nrf52840
-    tags: ci_build ci_rs_build ci_rs_weekly sysbuild ci_samples_peripheral_802154
-    extra_args: CONFIG_PTT_ANTENNA_DIVERSITY=y
-      CONFIG_PTT_ANT_MODE_AUTO=y
+    tags:
+      - ci_build
+      - ci_rs_build
+      - ci_rs_weekly
+      - sysbuild
+      - ci_samples_peripheral_802154
+    extra_args:
+      - CONFIG_PTT_ANTENNA_DIVERSITY=y
+      - CONFIG_PTT_ANT_MODE_AUTO=y
   sample.peripheral.802154_phy_test.ant_div_mode_manual:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf21540dk/nrf52840
     platform_allow: nrf21540dk/nrf52840
-    tags: ci_build ci_rs_build ci_rs_weekly ci_rs_integration sysbuild ci_samples_peripheral_802154
-    extra_args: CONFIG_PTT_ANTENNA_DIVERSITY=y
-      CONFIG_PTT_ANT_MODE_MANUAL=y
+    tags:
+      - ci_build
+      - ci_rs_build
+      - ci_rs_weekly
+      - ci_rs_integration
+      - sysbuild
+      - ci_samples_peripheral_802154
+    extra_args:
+      - CONFIG_PTT_ANTENNA_DIVERSITY=y
+      - CONFIG_PTT_ANT_MODE_MANUAL=y

--- a/samples/peripheral/802154_sniffer/sample.yaml
+++ b/samples/peripheral/802154_sniffer/sample.yaml
@@ -9,5 +9,11 @@ tests:
       - nrf52840dk/nrf52840
       - nrf52840dongle/nrf52840
       - nrf5340dk/nrf5340/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf52840dongle/nrf52840 nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_peripheral_802154
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52840dongle/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_peripheral_802154

--- a/samples/peripheral/lpuart/sample.yaml
+++ b/samples/peripheral/lpuart/sample.yaml
@@ -3,8 +3,11 @@ sample:
   name: Low Power UART
 
 common:
-  tags: ci_build sysbuild ci_samples_peripheral_lpuart
+  tags:
 
+    - ci_build
+    - sysbuild
+    - ci_samples_peripheral_lpuart
 tests:
   sample.peripheral.lpuart:
     sysbuild: true
@@ -83,9 +86,16 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    platform_allow: nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840 nrf9160dk/nrf9160/ns
-      nrf5340dk/nrf5340/cpuapp nrf21540dk/nrf52840 nrf54l15dk/nrf54l05/cpuapp
-      nrf54l15dk/nrf54l10/cpuapp nrf54l15dk/nrf54l15/cpuapp
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf9160dk/nrf9160/ns
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf21540dk/nrf52840
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
     tags: ppk_power_measure
     harness: pytest
     harness_config:
@@ -112,9 +122,16 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    platform_allow: nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840 nrf9160dk/nrf9160/ns
-      nrf5340dk/nrf5340/cpuapp nrf21540dk/nrf52840 nrf54l15dk/nrf54l05/cpuapp
-      nrf54l15dk/nrf54l10/cpuapp nrf54l15dk/nrf54l15/cpuapp
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
+      - nrf9160dk/nrf9160/ns
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf21540dk/nrf52840
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
     harness: console
     harness_config:
       fixture: gpio_loopback

--- a/samples/peripheral/radio_test/sample.yaml
+++ b/samples/peripheral/radio_test/sample.yaml
@@ -14,11 +14,19 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
-    platform_allow: >
-      nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpunet nrf7002dk/nrf5340/cpunet
-      nrf54l15dk/nrf54l05/cpuapp nrf54l15dk/nrf54l10/cpuapp nrf54l15dk/nrf54l15/cpuapp
-      nrf54h20dk/nrf54h20/cpurad
-    tags: ci_build sysbuild ci_samples_peripheral_radio_test
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpunet
+      - nrf7002dk/nrf5340/cpunet
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpurad
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_peripheral_radio_test
   sample.peripheral.radio_test.nrf5340_nrf21540:
     sysbuild: true
     build_only: true
@@ -26,7 +34,10 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpunet
     platform_allow: nrf5340dk/nrf5340/cpunet
-    tags: ci_build sysbuild ci_samples_peripheral_radio_test
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_peripheral_radio_test
   sample.peripheral.radio_test.nrf5340_usb:
     sysbuild: true
     build_only: true
@@ -34,15 +45,23 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpunet
     platform_allow: nrf5340dk/nrf5340/cpunet
-    tags: ci_build sysbuild ci_samples_peripheral_radio_test
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_peripheral_radio_test
   sample.peripheral.radio_test.nrf5340_nrf21540_usb:
     sysbuild: true
     build_only: true
-    extra_args: SHIELD=nrf21540ek FILE_SUFFIX=usb
+    extra_args:
+      - SHIELD=nrf21540ek
+      - FILE_SUFFIX=usb
     integration_platforms:
       - nrf5340dk/nrf5340/cpunet
     platform_allow: nrf5340dk/nrf5340/cpunet
-    tags: ci_build sysbuild ci_samples_peripheral_radio_test
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_peripheral_radio_test
   sample.peripheral.radio_test.nrf5340_nrf21540.no_automatic_power:
     sysbuild: true
     build_only: true
@@ -52,4 +71,7 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpunet
     platform_allow: nrf5340dk/nrf5340/cpunet
-    tags: ci_build sysbuild ci_samples_peripheral_radio_test
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_peripheral_radio_test

--- a/samples/pmic/native/npm1300_fuel_gauge/sample.yaml
+++ b/samples/pmic/native/npm1300_fuel_gauge/sample.yaml
@@ -18,12 +18,17 @@ common:
     - nrf54l15dk/nrf54l15/cpuapp
     - nrf54h20dk/nrf54h20/cpuapp
     - nrf9160dk/nrf9160
-  tags: pmic ci_samples_pmic
+  tags:
 
+    - pmic
+    - ci_samples_pmic
 tests:
   samples.npm1300_fuel_gauge:
     sysbuild: true
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
     harness: console
     tags: sysbuild
     harness_config:
@@ -36,7 +41,13 @@ tests:
         - "SoC: [0-9.]+, TTE: ([0-9.]+|nan), TTF: ([0-9.]+|nan)"
   samples.compile:
     sysbuild: true
-    platform_allow: nrf9160dk/nrf9160 nrf54l15dk/nrf54l15/cpuapp nrf54h20dk/nrf54h20/cpuapp
+    platform_allow:
+      - nrf9160dk/nrf9160
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
     harness: shield
-    tags: shield sysbuild ci_samples_pmic
+    tags:
+      - shield
+      - sysbuild
+      - ci_samples_pmic
     extra_args: SHIELD=npm1300_ek

--- a/samples/pmic/native/npm1300_one_button/sample.yaml
+++ b/samples/pmic/native/npm1300_one_button/sample.yaml
@@ -18,12 +18,17 @@ common:
     - nrf54l15dk/nrf54l15/cpuapp
     - nrf54h20dk/nrf54h20/cpuapp
     - nrf9160dk/nrf9160
-  tags: pmic ci_samples_pmic
+  tags:
 
+    - pmic
+    - ci_samples_pmic
 tests:
   samples.npm1300_one_button:
     sysbuild: true
-    platform_allow: nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
+    platform_allow:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
     harness: console
     harness_config:
       fixture: nPM1300_setup_eng_b
@@ -31,10 +36,18 @@ tests:
       ordered: true
       regex:
         - "PMIC device ok"
-    tags: sysbuild ci_samples_pmic
+    tags:
+      - sysbuild
+      - ci_samples_pmic
   samples.npm1300_one_button_compile:
     sysbuild: true
-    platform_allow: nrf9160dk/nrf9160 nrf54l15dk/nrf54l15/cpuapp nrf54h20dk/nrf54h20/cpuapp
+    platform_allow:
+      - nrf9160dk/nrf9160
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
     harness: shield
-    tags: shield sysbuild ci_samples_pmic
+    tags:
+      - shield
+      - sysbuild
+      - ci_samples_pmic
     extra_args: SHIELD=npm1300_ek

--- a/samples/sdfw/ssf_client/sample.yaml
+++ b/samples/sdfw/ssf_client/sample.yaml
@@ -6,12 +6,16 @@ sample:
 
 common:
   build_only: true
-  tags: ci_build ci_samples_sdfw
+  tags:
 
+    - ci_build
+    - ci_samples_sdfw
 tests:
   samples.sdfw.ssf_client:
     sysbuild: true
-    tags: sysbuild ci_samples_sdfw
+    tags:
+      - sysbuild
+      - ci_samples_sdfw
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
@@ -24,7 +28,9 @@ tests:
       - nrf9280pdk/nrf9280/cpurad
   samples.sdfw.ssf_client.logging.uart:
     sysbuild: true
-    tags: sysbuild ci_samples_sdfw
+    tags:
+      - sysbuild
+      - ci_samples_sdfw
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54h20dk/nrf54h20/cpurad

--- a/samples/sensor/bh1749/sample.yaml
+++ b/samples/sensor/bh1749/sample.yaml
@@ -8,4 +8,7 @@ tests:
     integration_platforms:
       - thingy91/nrf9160
     platform_allow: thingy91/nrf9160
-    tags: sensors sysbuild ci_samples_sensor
+    tags:
+      - sensors
+      - sysbuild
+      - ci_samples_sensor

--- a/samples/sensor/bme68x_iaq/sample.yaml
+++ b/samples/sensor/bme68x_iaq/sample.yaml
@@ -10,12 +10,15 @@ tests:
       - thingy91/nrf9160/ns
       - thingy53/nrf5340/cpuapp
       - thingy53/nrf5340/cpuapp/ns
-    platform_allow: >-
-      thingy91/nrf9160
-      thingy91/nrf9160/ns
-      thingy53/nrf5340/cpuapp
-      thingy53/nrf5340/cpuapp/ns
-    tags: sensors sysbuild ci_samples_sensor
+    platform_allow:
+      - thingy91/nrf9160
+      - thingy91/nrf9160/ns
+      - thingy53/nrf5340/cpuapp
+      - thingy53/nrf5340/cpuapp/ns
+    tags:
+      - sensors
+      - sysbuild
+      - ci_samples_sensor
   sample.sensor.bme68x.polling:
     sysbuild: true
     depends_on: i2c
@@ -25,22 +28,29 @@ tests:
       - thingy53/nrf5340/cpuapp
       - thingy53/nrf5340/cpuapp/ns
     extra_args: CONFIG_APP_TRIGGER=n
-    platform_allow: >-
-      thingy91/nrf9160
-      thingy91/nrf9160/ns
-      thingy53/nrf5340/cpuapp
-      thingy53/nrf5340/cpuapp/ns
-    tags: sensors sysbuild ci_samples_sensor
+    platform_allow:
+      - thingy91/nrf9160
+      - thingy91/nrf9160/ns
+      - thingy53/nrf5340/cpuapp
+      - thingy53/nrf5340/cpuapp/ns
+    tags:
+      - sensors
+      - sysbuild
+      - ci_samples_sensor
     harness: console
     harness_config:
       type: multi_line
       ordered: true
       regex:
-        - "(\\d+\\.\\d+); press: (\\d+\\.\\d+); humidity: (\\d+\\.\\d+); iaq: (\\d+)"
+        - "(\\d+\\.\\d+); press: (\\d+\\.\\d+); humidity: (\\d+\\.\\d+); iaq: (\\\
+        d+)"
   sample.sensor.bme68x.spi:
     sysbuild: true
     depends_on: spi
     harness: sensor
     platform_allow: >-
       nrf9160dk/nrf9160/ns
-    tags: sensors sysbuild ci_samples_sensor
+    tags:
+      - sensors
+      - sysbuild
+      - ci_samples_sensor

--- a/samples/suit/smp_transfer/sample.yaml
+++ b/samples/suit/smp_transfer/sample.yaml
@@ -13,25 +13,31 @@ common:
   sysbuild: true
 tests:
   sample.suit.smp_transfer:
-    tags: suit ci_samples_suit
-
+    tags:
+      - suit
+      - ci_samples_suit
   sample.suit.smp_transfer.bt:
     extra_args:
       - FILE_SUFFIX=bt
-    tags: suit bluetooth ci_samples_suit
-
+    tags:
+      - suit
+      - bluetooth
+      - ci_samples_suit
   sample.suit.smp_transfer.full_processing:
     extra_configs:
       - CONFIG_SUIT_DFU_CANDIDATE_PROCESSING_FULL=y
-    tags: suit ci_samples_suit
-
+    tags:
+      - suit
+      - ci_samples_suit
   sample.suit.smp_transfer.full_processing.bt:
     extra_args:
       - FILE_SUFFIX=bt
     extra_configs:
       - CONFIG_SUIT_DFU_CANDIDATE_PROCESSING_FULL=y
-    tags: suit bluetooth ci_samples_suit
-
+    tags:
+      - suit
+      - bluetooth
+      - ci_samples_suit
   sample.suit.smp_transfer.full_processing.extflash:
     extra_args:
       - EXTRA_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_extflash.overlay"
@@ -43,14 +49,17 @@ tests:
       - CONFIG_SUIT_ENVELOPE_TEMPLATE_FILENAME="app_envelope_extflash.yaml.jinja2"
       - CONFIG_SUIT_STREAM_SOURCE_FLASH=y
       - CONFIG_SUIT_DFU_CANDIDATE_PROCESSING_FULL=y
-    tags: suit ci_samples_suit
-
+    tags:
+      - suit
+      - ci_samples_suit
   sample.suit.smp_transfer.recovery:
     extra_args:
       - FILE_SUFFIX=bt
       - SB_CONFIG_SUIT_BUILD_RECOVERY=y
-    tags: suit bluetooth ci_samples_suit
-
+    tags:
+      - suit
+      - bluetooth
+      - ci_samples_suit
   sample.suit.smp_transfer.full_processing.extflash.bt:
     extra_args:
       - FILE_SUFFIX=bt
@@ -68,8 +77,10 @@ tests:
       - CONFIG_SUIT_ENVELOPE_TEMPLATE_FILENAME="app_envelope_extflash.yaml.jinja2"
       - CONFIG_SUIT_STREAM_SOURCE_FLASH=y
       - CONFIG_SUIT_DFU_CANDIDATE_PROCESSING_FULL=y
-    tags: suit bluetooth ci_samples_suit
-
+    tags:
+      - suit
+      - bluetooth
+      - ci_samples_suit
   sample.suit.smp_transfer.cache_push.extflash:
     extra_args:
       - EXTRA_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_extflash.overlay"
@@ -82,8 +93,9 @@ tests:
       - CONFIG_SUIT_ENVELOPE_TEMPLATE_FILENAME="app_envelope_extflash.yaml.jinja2"
       - CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE=y
       - CONFIG_SUIT_DFU_CANDIDATE_PROCESSING_PUSH_TO_CACHE=y
-    tags: suit ci_samples_suit
-
+    tags:
+      - suit
+      - ci_samples_suit
   sample.suit.smp_transfer.cache_push.extflash.bt:
     extra_args:
       - FILE_SUFFIX=bt
@@ -103,5 +115,7 @@ tests:
       - CONFIG_SUIT_ENVELOPE_TEMPLATE_FILENAME="app_envelope_extflash.yaml.jinja2"
       - CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE=y
       - CONFIG_SUIT_DFU_CANDIDATE_PROCESSING_PUSH_TO_CACHE=y
-
-    tags: suit bluetooth ci_samples_suit
+    tags:
+      - suit
+      - bluetooth
+      - ci_samples_suit

--- a/samples/tfm/provisioning_image/sample.yaml
+++ b/samples/tfm/provisioning_image/sample.yaml
@@ -2,7 +2,9 @@ sample:
   description: Initiates the provisioning of a TF-M image.
   name: Provisioning Image
 common:
-  tags: keys ci_samples_tfm
+  tags:
+    - keys
+    - ci_samples_tfm
   platform_allow:
     - nrf5340dk/nrf5340/cpuapp
     - nrf9151dk/nrf9151
@@ -22,4 +24,8 @@ common:
 tests:
   sample.tfm.provisioning_image:
     sysbuild: true
-    tags: keys ci_build sysbuild ci_samples_tfm
+    tags:
+      - keys
+      - ci_build
+      - sysbuild
+      - ci_samples_tfm

--- a/samples/tfm/provisioning_image_net_core/sample.yaml
+++ b/samples/tfm/provisioning_image_net_core/sample.yaml
@@ -8,4 +8,7 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_tfm
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_tfm

--- a/samples/tfm/tfm_hello_world/sample.yaml
+++ b/samples/tfm/tfm_hello_world/sample.yaml
@@ -1,9 +1,10 @@
 sample:
-  description: Hello World sample, the simplest Zephyr
-    application, with TF-M enabled
+  description: Hello World sample, the simplest Zephyr application, with TF-M enabled
   name: hello world TFM
 common:
-  tags: tfm ci_samples_tfm
+  tags:
+    - tfm
+    - ci_samples_tfm
   platform_allow:
     - nrf5340dk/nrf5340/cpuapp/ns
     - nrf9151dk/nrf9151/ns
@@ -22,25 +23,47 @@ common:
 tests:
   sample.tfm.helloworld:
     sysbuild: true
-    tags: ci_build sysbuild ci_samples_tfm
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_tfm
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp/ns
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp/ns
   sample.tfm.hello_world.bootloaders:
     sysbuild: true
-    tags: ci_build sysbuild ci_samples_tfm
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_tfm
     extra_args: FILE_SUFFIX=bootloaders
   sample.tfm.hello_world.bootloaders_debug:
     sysbuild: true
     build_only: true
-    tags: ci_build sysbuild ci_samples_tfm
-    extra_args: FILE_SUFFIX=bootloaders CONFIG_DEBUG_OPTIMIZATIONS=y
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_tfm
+    extra_args:
+      - FILE_SUFFIX=bootloaders
+      - CONFIG_DEBUG_OPTIMIZATIONS=y
   sample.tfm.hello_world.full:
     sysbuild: true
-    tags: ci_build sysbuild ci_samples_tfm
-    extra_args: CONFIG_TFM_PROFILE_TYPE_NOT_SET=y CONFIG_NRF_SECURITY=y
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_tfm
+    extra_args:
+      - CONFIG_TFM_PROFILE_TYPE_NOT_SET=y
+      - CONFIG_NRF_SECURITY=y
   sample.tfm.hello_world.lvl2:
     sysbuild: true
-    tags: ci_build sysbuild ci_samples_tfm
-    extra_args: CONFIG_TFM_IPC=y CONFIG_TFM_ISOLATION_LEVEL=2 CONFIG_TFM_PROFILE_TYPE_NOT_SET=y
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_tfm
+    extra_args:
+      - CONFIG_TFM_IPC=y
+      - CONFIG_TFM_ISOLATION_LEVEL=2
+      - CONFIG_TFM_PROFILE_TYPE_NOT_SET=y

--- a/samples/tfm/tfm_psa_template/sample.yaml
+++ b/samples/tfm/tfm_psa_template/sample.yaml
@@ -2,7 +2,9 @@ sample:
   description: TF-M PSA Template
   name: TF-M PSA Template
 common:
-  tags: tfm ci_samples_tfm
+  tags:
+    - tfm
+    - ci_samples_tfm
   platform_allow:
     - nrf5340dk/nrf5340/cpuapp/ns
     - nrf9151dk/nrf9151/ns
@@ -16,5 +18,8 @@ common:
 tests:
   sample.tfm.psa_template:
     sysbuild: true
-    tags: ci_build sysbuild ci_samples_tfm
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_tfm
     build_only: true

--- a/samples/tfm/tfm_secure_peripheral/sample.yaml
+++ b/samples/tfm/tfm_secure_peripheral/sample.yaml
@@ -3,7 +3,9 @@ sample:
   description: |
     TF-M sample demonstrating use of secure peripherals in a secure partition
 common:
-  tags: tfm ci_samples_tfm
+  tags:
+    - tfm
+    - ci_samples_tfm
   platform_allow:
     - nrf5340dk/nrf5340/cpuapp/ns
     - nrf9151dk/nrf9151/ns
@@ -23,4 +25,8 @@ common:
 tests:
   sample.tfm.secure_peripheral:
     sysbuild: true
-    tags: tfm ci_build sysbuild ci_samples_tfm
+    tags:
+      - tfm
+      - ci_build
+      - sysbuild
+      - ci_samples_tfm

--- a/samples/wifi/ble_coex/sample.yaml
+++ b/samples/wifi/ble_coex/sample.yaml
@@ -7,56 +7,86 @@ tests:
     build_only: true
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
-    extra_args: CONFIG_MPSL_CX=y ipc_radio_CONFIG_MPSL_CX=y
-                CONFIG_COEX_SEP_ANTENNAS=y
+    extra_args:
+      - CONFIG_MPSL_CX=y
+      - ipc_radio_CONFIG_MPSL_CX=y
+      - CONFIG_COEX_SEP_ANTENNAS=y
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002.ble_coex_sha_ant:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
-    extra_args: CONFIG_MPSL_CX=y ipc_radio_CONFIG_MPSL_CX=y
-                CONFIG_COEX_SEP_ANTENNAS=n
+    extra_args:
+      - CONFIG_MPSL_CX=y
+      - ipc_radio_CONFIG_MPSL_CX=y
+      - CONFIG_COEX_SEP_ANTENNAS=n
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7001.ble_coex:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp/nrf7001
-    extra_args: CONFIG_MPSL_CX=y ipc_radio_CONFIG_MPSL_CX=y
-                CONFIG_COEX_SEP_ANTENNAS=y
+    extra_args:
+      - CONFIG_MPSL_CX=y
+      - ipc_radio_CONFIG_MPSL_CX=y
+      - CONFIG_COEX_SEP_ANTENNAS=y
     platform_allow: nrf7002dk/nrf5340/cpuapp/nrf7001
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   # Daughter boards (EK's/EB's) do not have a shared antenna
   sample.nrf7002ek.ble_coex:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
-    extra_args: SHIELD=nrf7002ek
-                CONFIG_MPSL_CX=y ipc_radio_CONFIG_MPSL_CX=y
-                CONFIG_COEX_SEP_ANTENNAS=y
+    extra_args:
+      - SHIELD=nrf7002ek
+      - CONFIG_MPSL_CX=y
+      - ipc_radio_CONFIG_MPSL_CX=y
+      - CONFIG_COEX_SEP_ANTENNAS=y
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7001ek.ble_coex:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
-    extra_args: SHIELD=nrf7002ek_nrf7001
-                CONFIG_MPSL_CX=y ipc_radio_CONFIG_MPSL_CX=y
-                CONFIG_COEX_SEP_ANTENNAS=y
+    extra_args:
+      - SHIELD=nrf7002ek_nrf7001
+      - CONFIG_MPSL_CX=y
+      - ipc_radio_CONFIG_MPSL_CX=y
+      - CONFIG_COEX_SEP_ANTENNAS=y
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002_eb.thingy53.ble_coex:
     sysbuild: true
     build_only: true
-    extra_args: ble_coex_SHIELD=nrf7002eb
-                CONFIG_MPSL_CX=y ipc_radio_CONFIG_MPSL_CX=y
-                CONFIG_COEX_SEP_ANTENNAS=y
+    extra_args:
+      - ble_coex_SHIELD=nrf7002eb
+      - CONFIG_MPSL_CX=y
+      - ipc_radio_CONFIG_MPSL_CX=y
+      - CONFIG_COEX_SEP_ANTENNAS=y
     integration_platforms:
       - thingy53/nrf5340/cpuapp
     platform_allow: thingy53/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi

--- a/samples/wifi/monitor/sample.yaml
+++ b/samples/wifi/monitor/sample.yaml
@@ -1,6 +1,5 @@
 sample:
-  description: Wi-Fi Monitor sample
-    application
+  description: Wi-Fi Monitor sample application
   name: Wi-Fi Monitor sample
 tests:
   sample.nrf7002.monitor:
@@ -9,7 +8,10 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002_eks.monitor:
     sysbuild: true
     build_only: true
@@ -17,14 +19,20 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7001.monitor:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp/nrf7001
     platform_allow: nrf7002dk/nrf5340/cpuapp/nrf7001
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002eb_interposer_p1.nrf7002eb.monitor:
     sysbuild: true
     build_only: true
@@ -35,4 +43,7 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi

--- a/samples/wifi/offloaded_raw_tx/sample.yaml
+++ b/samples/wifi/offloaded_raw_tx/sample.yaml
@@ -1,6 +1,5 @@
 sample:
-  description: Wi-Fi Offloaded Raw Tx Packet sample
-    application
+  description: Wi-Fi Offloaded Raw Tx Packet sample application
   name: Wi-Fi Offloaded Raw Tx Packet sample
 tests:
   sample.nrf7002.offloaded_raw_tx:
@@ -9,7 +8,10 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002_eks.offloaded_raw_tx:
     sysbuild: true
     build_only: true
@@ -17,7 +19,10 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002eb_interposer_p1.nrf7002eb.offloaded_raw_tx:
     sysbuild: true
     build_only: true
@@ -30,4 +35,7 @@ tests:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi

--- a/samples/wifi/promiscuous/sample.yaml
+++ b/samples/wifi/promiscuous/sample.yaml
@@ -1,6 +1,5 @@
 sample:
-  description: Wi-Fi Promiscuous sample
-    application
+  description: Wi-Fi Promiscuous sample application
   name: Wi-Fi Promiscuous sample
 tests:
   sample.nrf7002.promiscuous:
@@ -9,7 +8,10 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002_eks.promiscuous:
     sysbuild: true
     build_only: true
@@ -17,14 +19,20 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7001.promiscuous:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp/nrf7001
     platform_allow: nrf7002dk/nrf5340/cpuapp/nrf7001
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
     skip: true
   sample.nrf7002eb_interposer_p1.nrf7002eb.promiscuous:
     sysbuild: true
@@ -36,4 +44,7 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi

--- a/samples/wifi/provisioning/ble/sample.yaml
+++ b/samples/wifi/provisioning/ble/sample.yaml
@@ -8,14 +8,20 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7001.ble-wifi-provision:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp/nrf7001
     platform_allow: nrf7002dk/nrf5340/cpuapp/nrf7001
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
     skip: true
   sample.nrf7002_eks.ble-wifi-provision:
     sysbuild: true
@@ -24,7 +30,10 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7001_eks.ble-wifi-provision:
     sysbuild: true
     build_only: true
@@ -32,7 +41,10 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002_eb.thingy53.ble-wifi-provision:
     sysbuild: true
     build_only: true
@@ -40,4 +52,7 @@ tests:
     integration_platforms:
       - thingy53/nrf5340/cpuapp
     platform_allow: thingy53/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi

--- a/samples/wifi/provisioning/softap/sample.yaml
+++ b/samples/wifi/provisioning/softap/sample.yaml
@@ -7,4 +7,7 @@ tests:
     platform_allow: nrf7002dk/nrf5340/cpuapp/ns
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp/ns
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi

--- a/samples/wifi/radio_test/sample.yaml
+++ b/samples/wifi/radio_test/sample.yaml
@@ -1,6 +1,5 @@
 sample:
-  description: Wi-Fi radio test sample
-    application
+  description: Wi-Fi radio test sample application
   name: Wi-Fi radio test
 tests:
   sample.nrf7002.radio_test:
@@ -9,14 +8,20 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7001.radio_test:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp/nrf7001
     platform_allow: nrf7002dk/nrf5340/cpuapp/nrf7001
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
     skip: true
   sample.nrf7002.radio_test_combo:
     sysbuild: true
@@ -25,15 +30,23 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf5340.radio_test_combo:
     sysbuild: true
     build_only: true
-    extra_args: SHIELD=nrf7002ek SB_CONFIG_SUPPORT_NETCORE_PERIPHERAL_RADIO_TEST=y
+    extra_args:
+      - SHIELD=nrf7002ek
+      - SB_CONFIG_SUPPORT_NETCORE_PERIPHERAL_RADIO_TEST=y
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002_eks.radio_test:
     sysbuild: true
     build_only: true
@@ -41,8 +54,13 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
       - nrf52840dk/nrf52840
-    platform_allow: nrf5340dk/nrf5340/cpuapp nrf52840dk/nrf52840
-    tags: ci_build sysbuild ci_samples_wifi
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf52840dk/nrf52840
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7001_eks.radio_test:
     sysbuild: true
     build_only: true
@@ -50,8 +68,13 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
       - nrf52840dk/nrf52840
-    platform_allow: nrf5340dk/nrf5340/cpuapp nrf52840dk/nrf52840
-    tags: ci_build sysbuild ci_samples_wifi
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf52840dk/nrf52840
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7000_eks.radio_test:
     sysbuild: true
     build_only: true
@@ -59,7 +82,10 @@ tests:
     integration_platforms:
       - nrf9160dk/nrf9160/ns
     platform_allow: nrf9160dk/nrf9160/ns
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002_eb.thingy53.radio_test:
     sysbuild: true
     build_only: true
@@ -67,12 +93,18 @@ tests:
     integration_platforms:
       - thingy53/nrf5340/cpuapp
     platform_allow: thingy53/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.thingy91x_nrf7002.radio_test:
     sysbuild: true
     build_only: true
     platform_allow: thingy91x/nrf9151/ns
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf54_nrf7002eb.radio_test:
     sysbuild: true
     build_only: true
@@ -86,4 +118,7 @@ tests:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi

--- a/samples/wifi/raw_tx_packet/sample.yaml
+++ b/samples/wifi/raw_tx_packet/sample.yaml
@@ -1,6 +1,5 @@
 sample:
-  description: Wi-Fi Raw Tx Packet sample
-    application
+  description: Wi-Fi Raw Tx Packet sample application
   name: Wi-Fi Raw Tx Packet sample
 tests:
   sample.nrf7002.raw_tx_packet:
@@ -9,7 +8,10 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002_eks.raw_tx_packet:
     sysbuild: true
     build_only: true
@@ -17,14 +19,20 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7001.raw_tx_packet:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp/nrf7001
     platform_allow: nrf7002dk/nrf5340/cpuapp/nrf7001
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002eb_interposer_p1.nrf7002eb.raw_tx_packet:
     sysbuild: true
     build_only: true
@@ -37,4 +45,7 @@ tests:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi

--- a/samples/wifi/scan/sample.yaml
+++ b/samples/wifi/scan/sample.yaml
@@ -1,6 +1,5 @@
 sample:
-  description: Wi-Fi scan sample
-    application
+  description: Wi-Fi scan sample application
   name: Wi-Fi scan
 tests:
   sample.nrf7000_eks.scan:
@@ -17,11 +16,16 @@ tests:
       - nrf52840dk/nrf52840
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7000_eks.raw_scan:
     sysbuild: true
     build_only: true
-    extra_args: SHIELD=nrf7002ek_nrf7000 CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS=y
+    extra_args:
+      - SHIELD=nrf7002ek_nrf7000
+      - CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS=y
     integration_platforms:
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
@@ -29,7 +33,10 @@ tests:
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
       - nrf9151dk/nrf9151/ns
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002_eb.thingy53.scan:
     sysbuild: true
     build_only: true
@@ -37,15 +44,23 @@ tests:
     integration_platforms:
       - thingy53/nrf5340/cpuapp
     platform_allow: thingy53/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.thingy91x_nrf7000.scan:
     sysbuild: true
     build_only: true
     integration_platforms:
       - thingy91x/nrf9151/ns
     platform_allow: thingy91x/nrf9151/ns
-    extra_args: SB_CONFIG_WIFI_NRF70=y SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
-    tags: ci_build sysbuild ci_samples_wifi
+    extra_args:
+      - SB_CONFIG_WIFI_NRF70=y
+      - SB_CONFIG_WIFI_NRF70_SCAN_ONLY=y
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002eb_interposer_p1.nrf7002eb.scan:
     sysbuild: true
     build_only: true
@@ -58,4 +73,7 @@ tests:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi

--- a/samples/wifi/shell/sample.yaml
+++ b/samples/wifi/shell/sample.yaml
@@ -1,6 +1,5 @@
 sample:
-  description: Wi-Fi shell sample
-    application
+  description: Wi-Fi shell sample application
   name: Wi-Fi shell
 tests:
   sample.nrf7002.shell:
@@ -9,7 +8,10 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   # Disable optional features to reduce memory usage
   sample.nrf7002.shell.disable_adv_features:
     sysbuild: true
@@ -18,14 +20,20 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7001.shell:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp/nrf7001
     platform_allow: nrf7002dk/nrf5340/cpuapp/nrf7001
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002_eks.shell:
     sysbuild: true
     build_only: true
@@ -33,17 +41,29 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
       - nrf52840dk/nrf52840
-    platform_allow: nrf5340dk/nrf5340/cpuapp nrf52840dk/nrf52840
-    tags: ci_build sysbuild ci_samples_wifi
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf52840dk/nrf52840
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7000_eks.shell:
     sysbuild: true
     build_only: true
-    extra_args: SHIELD=nrf7002ek_nrf7000 CONFIG_WIFI_NM_WPA_SUPPLICANT=n
+    extra_args:
+      - SHIELD=nrf7002ek_nrf7000
+      - CONFIG_WIFI_NM_WPA_SUPPLICANT=n
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
       - nrf52840dk/nrf52840
-    platform_allow: nrf5340dk/nrf5340/cpuapp nrf52840dk/nrf52840
-    tags: ci_build sysbuild ci_samples_wifi
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf52840dk/nrf52840
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7001_eks.shell:
     sysbuild: true
     build_only: true
@@ -51,16 +71,26 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
       - nrf52840dk/nrf52840
-    platform_allow: nrf5340dk/nrf5340/cpuapp nrf52840dk/nrf52840
-    tags: ci_build sysbuild ci_samples_wifi
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf52840dk/nrf52840
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002_eks_cpunet.shell:
     sysbuild: true
     build_only: true
-    extra_args: SHIELD=nrf7002ek CONFIG_SOC_NRF53_CPUNET_ENABLE=y
+    extra_args:
+      - SHIELD=nrf7002ek
+      - CONFIG_SOC_NRF53_CPUNET_ENABLE=y
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7000_eks_cpunet.shell:
     sysbuild: true
     build_only: true
@@ -71,15 +101,23 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7001_eks_cpunet.shell:
     sysbuild: true
     build_only: true
-    extra_args: SHIELD=nrf7002ek_nrf7001 CONFIG_SOC_NRF53_CPUNET_ENABLE=y
+    extra_args:
+      - SHIELD=nrf7002ek_nrf7001
+      - CONFIG_SOC_NRF53_CPUNET_ENABLE=y
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002.shell.zperf:
     sysbuild: true
     build_only: true
@@ -87,7 +125,10 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7001.shell.zperf:
     sysbuild: true
     build_only: true
@@ -95,7 +136,10 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp/nrf7001
     platform_allow: nrf7002dk/nrf5340/cpuapp/nrf7001
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002.shell.wpa_cli:
     sysbuild: true
     build_only: true
@@ -103,7 +147,10 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7001.shell.wpa_cli:
     sysbuild: true
     build_only: true
@@ -111,7 +158,10 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp/nrf7001
     platform_allow: nrf7002dk/nrf5340/cpuapp/nrf7001
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002.shell.scan_only_7002:
     sysbuild: true
     build_only: true
@@ -119,7 +169,10 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7000.shell.scan_only_91:
     sysbuild: true
     build_only: true
@@ -134,21 +187,32 @@ tests:
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
       - nrf9151dk/nrf9151/ns
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002.shell.scan_only_thingy91x:
     sysbuild: true
     build_only: true
-    extra_args: EXTRA_CONF_FILE=overlay-scan-only.conf CONFIG_WIFI_NM_WPA_SUPPLICANT=n
+    extra_args:
+      - EXTRA_CONF_FILE=overlay-scan-only.conf
+      - CONFIG_WIFI_NM_WPA_SUPPLICANT=n
     platform_allow:
       - thingy91x/nrf9151/ns
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002.shell.full_stack_thingy91x:
     sysbuild: true
     build_only: true
     extra_args: SB_CONFIG_THINGY91X_STATIC_PARTITIONS_NRF53_EXTERNAL_FLASH=y
     platform_allow:
       - thingy91x/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002.shell.otbr:
     sysbuild: true
     build_only: true
@@ -156,53 +220,78 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002.shell.posix_names:
     sysbuild: true
     build_only: true
-    extra_args: CONFIG_POSIX_API=n CONIFG_NET_SOCKETS_POSIX_NAMES=y
+    extra_args:
+      - CONFIG_POSIX_API=n
+      - CONIFG_NET_SOCKETS_POSIX_NAMES=y
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002_ns.shell:
     sysbuild: true
     build_only: true
     platform_allow: nrf7002dk/nrf5340/cpuapp/ns
-    tags: sysbuild ci_samples_wifi
+    tags:
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002_eb.thingy53.shell:
     sysbuild: true
     build_only: true
-    extra_args: shell_SHIELD=nrf7002eb CONFIG_SOC_NRF53_CPUNET_ENABLE=y
+    extra_args:
+      - shell_SHIELD=nrf7002eb
+      - CONFIG_SOC_NRF53_CPUNET_ENABLE=y
     integration_platforms:
       - thingy53/nrf5340/cpuapp
     platform_allow: thingy53/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.qspi.ext_flash_xip:
     sysbuild: true
     build_only: true
     extra_args:
-      shell_SHIELD=nrf7002ek
-      SB_CONFIG_WIFI_PATCHES_EXT_FLASH_XIP=y
-      SB_CONFIG_PARTITION_MANAGER=n
+      - shell_SHIELD=nrf7002ek
+      - SB_CONFIG_WIFI_PATCHES_EXT_FLASH_XIP=y
+      - SB_CONFIG_PARTITION_MANAGER=n
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
       - nrf52840dk/nrf52840
-    platform_allow: nrf5340dk/nrf5340/cpuapp nrf52840dk/nrf52840
-    tags: ci_build sysbuild ci_samples_wifi
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf52840dk/nrf52840
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.qspi.ext_flash_store:
     sysbuild: true
     build_only: true
     extra_args:
-      shell_SHIELD=nrf7002ek
-      shell_SNIPPET=nrf70-fw-patch-ext-flash
-      SB_CONFIG_PARTITION_MANAGER=n
-      SB_CONFIG_WIFI_PATCHES_EXT_FLASH_STORE=y
+      - shell_SHIELD=nrf7002ek
+      - shell_SNIPPET=nrf70-fw-patch-ext-flash
+      - SB_CONFIG_PARTITION_MANAGER=n
+      - SB_CONFIG_WIFI_PATCHES_EXT_FLASH_STORE=y
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
       - nrf52840dk/nrf52840
-    platform_allow: nrf5340dk/nrf5340/cpuapp nrf52840dk/nrf52840
-    tags: ci_build sysbuild ci_samples_wifi
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf52840dk/nrf52840
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002eb_interposer_p1.nrf7002eb.shell:
     sysbuild: true
     build_only: true
@@ -215,79 +304,97 @@ tests:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   # Used by QA and also acts as a memory stress test
   sample.nrf7001.superset:
     sysbuild: true
     build_only: true
     extra_args:
-      EXTRA_CONF_FILE=overlay-zperf.conf
-      CONFIG_NRF70_UTIL=y
-      CONFIG_WPA_CLI=y
-      CONFIG_NET_IPV4_FRAGMENT=y
-      CONFIG_NET_IPV4_FRAGMENT_MAX_PKT=24
+      - EXTRA_CONF_FILE=overlay-zperf.conf
+      - CONFIG_NRF70_UTIL=y
+      - CONFIG_WPA_CLI=y
+      - CONFIG_NET_IPV4_FRAGMENT=y
+      - CONFIG_NET_IPV4_FRAGMENT_MAX_PKT=24
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp/nrf7001
     platform_allow: nrf7002dk/nrf5340/cpuapp/nrf7001
-    tags: ci_build_superset sysbuild ci_samples_wifi
+    tags:
+      - ci_build_superset
+      - sysbuild
+      - ci_samples_wifi
   # Used by QA and also acts as a memory stress test
   sample.nrf7001_ek.superset:
     sysbuild: true
     build_only: true
     extra_args:
-      SHIELD=nrf7002ek_nrf7001
-      EXTRA_CONF_FILE=overlay-zperf.conf
-      CONFIG_NRF70_UTIL=y
-      CONFIG_WPA_CLI=y
-      CONFIG_NET_IPV4_FRAGMENT=y
-      CONFIG_NET_IPV4_FRAGMENT_MAX_PKT=24
+      - SHIELD=nrf7002ek_nrf7001
+      - EXTRA_CONF_FILE=overlay-zperf.conf
+      - CONFIG_NRF70_UTIL=y
+      - CONFIG_WPA_CLI=y
+      - CONFIG_NET_IPV4_FRAGMENT=y
+      - CONFIG_NET_IPV4_FRAGMENT_MAX_PKT=24
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build_superset sysbuild ci_samples_wifi
+    tags:
+      - ci_build_superset
+      - sysbuild
+      - ci_samples_wifi
   # Used by QA and also acts as a memory stress test
   sample.nrf7002.superset:
     sysbuild: true
     build_only: true
     extra_args:
-      EXTRA_CONF_FILE=overlay-zperf.conf
-      CONFIG_NRF70_UTIL=y
-      CONFIG_WPA_CLI=y
-      CONFIG_NET_IPV4_FRAGMENT=y
-      CONFIG_NET_IPV4_FRAGMENT_MAX_PKT=24
+      - EXTRA_CONF_FILE=overlay-zperf.conf
+      - CONFIG_NRF70_UTIL=y
+      - CONFIG_WPA_CLI=y
+      - CONFIG_NET_IPV4_FRAGMENT=y
+      - CONFIG_NET_IPV4_FRAGMENT_MAX_PKT=24
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build_superset sysbuild ci_samples_wifi
+    tags:
+      - ci_build_superset
+      - sysbuild
+      - ci_samples_wifi
   # Used by QA and also acts as a memory stress test
   sample.nrf7002_ek.superset:
     sysbuild: true
     build_only: true
     extra_args:
-      SHIELD=nrf7002ek
-      EXTRA_CONF_FILE=overlay-zperf.conf
-      CONFIG_NRF70_UTIL=y
-      CONFIG_WPA_CLI=y
-      CONFIG_NET_IPV4_FRAGMENT=y
-      CONFIG_NET_IPV4_FRAGMENT_MAX_PKT=24
+      - SHIELD=nrf7002ek
+      - EXTRA_CONF_FILE=overlay-zperf.conf
+      - CONFIG_NRF70_UTIL=y
+      - CONFIG_WPA_CLI=y
+      - CONFIG_NET_IPV4_FRAGMENT=y
+      - CONFIG_NET_IPV4_FRAGMENT_MAX_PKT=24
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build_superset sysbuild ci_samples_wifi
+    tags:
+      - ci_build_superset
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002.superset.debug:
     sysbuild: true
     build_only: true
     extra_args:
-      shell_SNIPPET="nrf70-driver-verbose-debug;wpa-supplicant-debug"
-      EXTRA_CONF_FILE=overlay-zperf.conf
-      CONFIG_NRF70_UTIL=y
-      CONFIG_WPA_CLI=y
-      CONFIG_NET_IPV4_FRAGMENT=y
-      CONFIG_NET_IPV4_FRAGMENT_MAX_PKT=24
+      - shell_SNIPPET="nrf70-driver-verbose-debug;wpa-supplicant-debug"
+      - EXTRA_CONF_FILE=overlay-zperf.conf
+      - CONFIG_NRF70_UTIL=y
+      - CONFIG_WPA_CLI=y
+      - CONFIG_NET_IPV4_FRAGMENT=y
+      - CONFIG_NET_IPV4_FRAGMENT_MAX_PKT=24
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build_superset sysbuild ci_samples_wifi
+    tags:
+      - ci_build_superset
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002.enterprise_mode:
     sysbuild: true
     build_only: true
@@ -295,7 +402,10 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002.ap:
     sysbuild: true
     build_only: true
@@ -303,51 +413,69 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002.with_overlay_raw_tx_packet:
     sysbuild: true
     build_only: true
     extra_args:
-      EXTRA_CONF_FILE=overlay-raw-tx.conf
-      SB_CONFIG_WIFI_NRF70_SYSTEM_WITH_RAW_MODES=y
+      - EXTRA_CONF_FILE=overlay-raw-tx.conf
+      - SB_CONFIG_WIFI_NRF70_SYSTEM_WITH_RAW_MODES=y
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002.with_overlay_monitor:
     sysbuild: true
     build_only: true
     extra_args:
-      EXTRA_CONF_FILE=overlay-monitor-mode.conf
-      SB_CONFIG_WIFI_NRF70_SYSTEM_WITH_RAW_MODES=y
+      - EXTRA_CONF_FILE=overlay-monitor-mode.conf
+      - SB_CONFIG_WIFI_NRF70_SYSTEM_WITH_RAW_MODES=y
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002.promiscuous_mode:
     sysbuild: true
     build_only: true
     extra_args:
-      EXTRA_CONF_FILE=overlay-promiscuous-mode.conf
-      SB_CONFIG_WIFI_NRF70_SYSTEM_WITH_RAW_MODES=y
+      - EXTRA_CONF_FILE=overlay-promiscuous-mode.conf
+      - SB_CONFIG_WIFI_NRF70_SYSTEM_WITH_RAW_MODES=y
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7001.promiscuous_mode_7001:
     sysbuild: true
     build_only: true
     extra_args:
-      EXTRA_CONF_FILE=overlay-promiscuous-mode.conf
-      SB_CONFIG_WIFI_NRF70_SYSTEM_WITH_RAW_MODES=y
+      - EXTRA_CONF_FILE=overlay-promiscuous-mode.conf
+      - SB_CONFIG_WIFI_NRF70_SYSTEM_WITH_RAW_MODES=y
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp/nrf7001
     platform_allow: nrf7002dk/nrf5340/cpuapp/nrf7001
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002.shell.psa:
     build_only: true
     extra_args: CONFIG_HOSTAP_CRYPTO_LEGACY_PSA=y
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi

--- a/samples/wifi/shutdown/sample.yaml
+++ b/samples/wifi/shutdown/sample.yaml
@@ -1,6 +1,5 @@
 sample:
-  description: Wi-Fi shutdown sample
-    application
+  description: Wi-Fi shutdown sample application
   name: Wi-Fi shutdown
 tests:
   sample.nrf7000_location.shutdown:
@@ -16,7 +15,10 @@ tests:
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
       - nrf9151dk/nrf9151/ns
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002eb_interposer_p1.nrf7002eb.shutdown:
     sysbuild: true
     build_only: true
@@ -29,4 +31,7 @@ tests:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi

--- a/samples/wifi/softap/sample.yaml
+++ b/samples/wifi/softap/sample.yaml
@@ -1,6 +1,5 @@
 sample:
-  description: Wi-Fi SoftAP sample
-    application
+  description: Wi-Fi SoftAP sample application
   name: Wi-Fi SoftAP
 tests:
   sample.nrf7002.softap:
@@ -9,7 +8,10 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002_eks.softap:
     sysbuild: true
     build_only: true
@@ -17,14 +19,20 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7001.softap:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp/nrf7001
     platform_allow: nrf7002dk/nrf5340/cpuapp/nrf7001
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7001_eks.softap:
     sysbuild: true
     build_only: true
@@ -32,7 +40,10 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002eb_interposer_p1.nrf7002eb.softap:
     sysbuild: true
     build_only: true
@@ -45,4 +56,7 @@ tests:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi

--- a/samples/wifi/sta/sample.yaml
+++ b/samples/wifi/sta/sample.yaml
@@ -1,6 +1,5 @@
 sample:
-  description: Wi-Fi station sample
-    application
+  description: Wi-Fi station sample application
   name: Wi-Fi station
 tests:
   sample.nrf7002.sta:
@@ -9,7 +8,10 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002.sta.no_wifi_ready:
     sysbuild: true
     build_only: true
@@ -17,14 +19,20 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7001.sta:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp/nrf7001
     platform_allow: nrf7002dk/nrf5340/cpuapp/nrf7001
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
     skip: true
   sample.nrf7002_eks.sta:
     sysbuild: true
@@ -33,11 +41,16 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
       - nrf52840dk/nrf52840
-    platform_allow: nrf5340dk/nrf5340/cpuapp nrf52840dk/nrf52840
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf52840dk/nrf52840
     extra_configs:
       - CONFIG_NET_TX_STACK_SIZE=3700
       - CONFIG_NET_RX_STACK_SIZE=3700
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7001_eks.sta:
     sysbuild: true
     build_only: true
@@ -45,11 +58,16 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
       - nrf52840dk/nrf52840
-    platform_allow: nrf5340dk/nrf5340/cpuapp nrf52840dk/nrf52840
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf52840dk/nrf52840
     extra_configs:
       - CONFIG_NET_TX_STACK_SIZE=3700
       - CONFIG_NET_RX_STACK_SIZE=3700
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002_eb.thingy53.sta:
     sysbuild: true
     build_only: true
@@ -57,7 +75,10 @@ tests:
     integration_platforms:
       - thingy53/nrf5340/cpuapp
     platform_allow: thingy53/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002eb_interposer_p1.nrf7002eb.sta:
     sysbuild: true
     build_only: true
@@ -70,4 +91,7 @@ tests:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi

--- a/samples/wifi/thread_coex/sample.yaml
+++ b/samples/wifi/thread_coex/sample.yaml
@@ -1,6 +1,5 @@
 sample:
-  description: Wi-Fi Thread coex sample
-    application
+  description: Wi-Fi Thread coex sample application
   name: Wi-Fi Thread coex
 tests:
   sample.nrf7002.thread_coex_sep_ant:
@@ -8,51 +7,77 @@ tests:
     build_only: true
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
-    extra_args: CONFIG_MPSL_CX=y ipc_radio_CONFIG_MPSL_CX=y
-                CONFIG_COEX_SEP_ANTENNAS=y
-                EXTRA_CONF_FILE="overlay-wifi-udp-client-thread-udp-client.conf"
+    extra_args:
+      - CONFIG_MPSL_CX=y
+      - ipc_radio_CONFIG_MPSL_CX=y
+      - CONFIG_COEX_SEP_ANTENNAS=y
+      - EXTRA_CONF_FILE="overlay-wifi-udp-client-thread-udp-client.conf"
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7001.thread_coex:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp/nrf7001
-    extra_args: CONFIG_MPSL_CX=y ipc_radio_CONFIG_MPSL_CX=y
-                CONFIG_COEX_SEP_ANTENNAS=y
-                EXTRA_CONF_FILE="overlay-wifi-udp-client-thread-udp-client.conf"
+    extra_args:
+      - CONFIG_MPSL_CX=y
+      - ipc_radio_CONFIG_MPSL_CX=y
+      - CONFIG_COEX_SEP_ANTENNAS=y
+      - EXTRA_CONF_FILE="overlay-wifi-udp-client-thread-udp-client.conf"
     platform_allow: nrf7002dk/nrf5340/cpuapp/nrf7001
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002ek.thread_coex:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
-    extra_args: SHIELD=nrf7002ek
-                CONFIG_MPSL_CX=y ipc_radio_CONFIG_MPSL_CX=y
-                CONFIG_COEX_SEP_ANTENNAS=y
-                EXTRA_CONF_FILE="overlay-wifi-udp-client-thread-udp-client.conf"
+    extra_args:
+      - SHIELD=nrf7002ek
+      - CONFIG_MPSL_CX=y
+      - ipc_radio_CONFIG_MPSL_CX=y
+      - CONFIG_COEX_SEP_ANTENNAS=y
+      - EXTRA_CONF_FILE="overlay-wifi-udp-client-thread-udp-client.conf"
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7001ek.thread_coex:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
-    extra_args: SHIELD=nrf7002ek_nrf7001
-                CONFIG_MPSL_CX=y ipc_radio_CONFIG_MPSL_CX=y
-                CONFIG_COEX_SEP_ANTENNAS=y
-                EXTRA_CONF_FILE="overlay-wifi-udp-client-thread-udp-client.conf"
+    extra_args:
+      - SHIELD=nrf7002ek_nrf7001
+      - CONFIG_MPSL_CX=y
+      - ipc_radio_CONFIG_MPSL_CX=y
+      - CONFIG_COEX_SEP_ANTENNAS=y
+      - EXTRA_CONF_FILE="overlay-wifi-udp-client-thread-udp-client.conf"
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002_eb.thingy53.thread_coex:
     sysbuild: true
     build_only: true
-    extra_args: thread_coex_SHIELD=nrf7002eb ipc_radio_SHIELD=nrf7002eb_coex
-                CONFIG_MPSL_CX=y ipc_radio_CONFIG_MPSL_CX=y
-                CONFIG_COEX_SEP_ANTENNAS=y
-                EXTRA_CONF_FILE="overlay-wifi-udp-client-thread-udp-client.conf"
+    extra_args:
+      - thread_coex_SHIELD=nrf7002eb
+      - ipc_radio_SHIELD=nrf7002eb_coex
+      - CONFIG_MPSL_CX=y
+      - ipc_radio_CONFIG_MPSL_CX=y
+      - CONFIG_COEX_SEP_ANTENNAS=y
+      - EXTRA_CONF_FILE="overlay-wifi-udp-client-thread-udp-client.conf"
     integration_platforms:
       - thingy53/nrf5340/cpuapp
     platform_allow: thingy53/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi

--- a/samples/wifi/throughput/sample.yaml
+++ b/samples/wifi/throughput/sample.yaml
@@ -1,6 +1,5 @@
 sample:
-  description: Wi-Fi throughput sample
-    application
+  description: Wi-Fi throughput sample application
   name: Wi-Fi throughput
 tests:
   sample.nrf7002.throughput:
@@ -9,7 +8,10 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002eb_interposer_p1.nrf7002eb.throughput:
     sysbuild: true
     build_only: true
@@ -20,8 +22,10 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
-
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   # Used by QA to measure memory footprints
   sample.nrf7002.iot_devices:
     sysbuild: true
@@ -30,7 +34,10 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002.high_performance:
     sysbuild: true
     build_only: true
@@ -38,7 +45,10 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002.memory_optimized:
     sysbuild: true
     build_only: true
@@ -46,7 +56,10 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002.rx_prioritized:
     sysbuild: true
     build_only: true
@@ -54,7 +67,10 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002.tx_prioritized:
     sysbuild: true
     build_only: true
@@ -62,4 +78,7 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi

--- a/samples/wifi/twt/sample.yaml
+++ b/samples/wifi/twt/sample.yaml
@@ -1,6 +1,5 @@
 sample:
-  description: Wi-Fi TWT sample
-    application
+  description: Wi-Fi TWT sample application
   name: Wi-Fi TWT sample
 tests:
   sample.wifi.twt:
@@ -11,7 +10,10 @@ tests:
     platform_allow: nrf7002dk/nrf5340/cpuapp
     # Dummy IP address for building the sample
     extra_args: CONFIG_TRAFFIC_GEN_REMOTE_IPV4_ADDR="1.2.3.4"
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002eb_interposer_p1.nrf7002eb.twt:
     sysbuild: true
     build_only: true
@@ -26,4 +28,7 @@ tests:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi

--- a/samples/wifi/wfa_qt_app/sample.yaml
+++ b/samples/wifi/wfa_qt_app/sample.yaml
@@ -8,7 +8,10 @@ tests:
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002_eks.wfa_qt_app:
     sysbuild: true
     build_only: true
@@ -16,7 +19,10 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf7002eb_interposer_p1.nrf7002eb.wfa_qt_app:
     sysbuild: true
     build_only: true
@@ -27,4 +33,7 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
-    tags: ci_build sysbuild ci_samples_wifi
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi

--- a/samples/zigbee/light_bulb/sample.yaml
+++ b/samples/zigbee/light_bulb/sample.yaml
@@ -10,20 +10,37 @@ tests:
       - nrf52833dk/nrf52833
       - nrf5340dk/nrf5340/cpuapp
       - nrf21540dk/nrf52840
-    platform_allow: nrf52840dk/nrf52840 nrf52833dk/nrf52833 nrf5340dk/nrf5340/cpuapp
-      nrf21540dk/nrf52840
-    tags: ci_build smoke sysbuild ci_samples_zigbee
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52833dk/nrf52833
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf21540dk/nrf52840
+    tags:
+      - ci_build
+      - smoke
+      - sysbuild
+      - ci_samples_zigbee
   sample.zigbee.light_bulb.with_shell:
     sysbuild: true
     build_only: true
-    extra_args: >
-      CONFIG_ZIGBEE_SHELL=y CONFIG_ZIGBEE_SHELL_DEBUG_CMD=y CONFIG_ZIGBEE_LOGGER_EP=n
-      CONFIG_ZIGBEE_SHELL_ENDPOINT=10 CONFIG_LOG_MODE_DEFERRED=y
+    extra_args:
+      - CONFIG_ZIGBEE_SHELL=y
+      - CONFIG_ZIGBEE_SHELL_DEBUG_CMD=y
+      - CONFIG_ZIGBEE_LOGGER_EP=n
+      - CONFIG_ZIGBEE_SHELL_ENDPOINT=10
+      - CONFIG_LOG_MODE_DEFERRED=y
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf52833dk/nrf52833
       - nrf5340dk/nrf5340/cpuapp
       - nrf21540dk/nrf52840
-    platform_allow: nrf52840dk/nrf52840 nrf52833dk/nrf52833 nrf5340dk/nrf5340/cpuapp
-      nrf21540dk/nrf52840
-    tags: ci_build shell sysbuild ci_samples_zigbee
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52833dk/nrf52833
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf21540dk/nrf52840
+    tags:
+      - ci_build
+      - shell
+      - sysbuild
+      - ci_samples_zigbee

--- a/samples/zigbee/light_switch/sample.yaml
+++ b/samples/zigbee/light_switch/sample.yaml
@@ -10,9 +10,16 @@ tests:
       - nrf52833dk/nrf52833
       - nrf5340dk/nrf5340/cpuapp
       - nrf21540dk/nrf52840
-    platform_allow: nrf52840dk/nrf52840 nrf52833dk/nrf52833 nrf5340dk/nrf5340/cpuapp
-      nrf21540dk/nrf52840
-    tags: ci_build smoke sysbuild ci_samples_zigbee
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52833dk/nrf52833
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf21540dk/nrf52840
+    tags:
+      - ci_build
+      - smoke
+      - sysbuild
+      - ci_samples_zigbee
   sample.zigbee.light_switch.current_measurement:
     sysbuild: true
     build_only: true
@@ -21,8 +28,15 @@ tests:
       - nrf52840dk/nrf52840
       - nrf52833dk/nrf52833
       - nrf5340dk/nrf5340/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf52833dk/nrf52833 nrf5340dk/nrf5340/cpuapp
-    tags: ci_build current_measurement sysbuild ci_samples_zigbee
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52833dk/nrf52833
+      - nrf5340dk/nrf5340/cpuapp
+    tags:
+      - ci_build
+      - current_measurement
+      - sysbuild
+      - ci_samples_zigbee
   sample.zigbee.light_switch.fota:
     sysbuild: true
     build_only: true
@@ -31,8 +45,14 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf21540dk/nrf52840
-    platform_allow: nrf52840dk/nrf52840 nrf21540dk/nrf52840
-    tags: ci_build smoke sysbuild ci_samples_zigbee
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf21540dk/nrf52840
+    tags:
+      - ci_build
+      - smoke
+      - sysbuild
+      - ci_samples_zigbee
   sample.zigbee.light_switch.fota.nrf5340dk:
     sysbuild: true
     build_only: true
@@ -41,25 +61,37 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build smoke sysbuild ci_samples_zigbee
+    tags:
+      - ci_build
+      - smoke
+      - sysbuild
+      - ci_samples_zigbee
   sample.zigbee.light_switch.fota_and_multiprotocol:
     sysbuild: true
     build_only: true
-    extra_args: >
-      FILE_SUFFIX=fota OVERLAY_CONFIG=overlay-multiprotocol_ble.conf
+    extra_args:
+      - FILE_SUFFIX=fota
+      - OVERLAY_CONFIG=overlay-multiprotocol_ble.conf
     integration_platforms:
       - nrf52840dk/nrf52840
     platform_allow: nrf52840dk/nrf52840
-    tags: ci_build sysbuild ci_samples_zigbee
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_zigbee
   sample.zigbee.light_switch.fota_and_multiprotocol.nrf5340dk:
     sysbuild: true
     build_only: true
-    extra_args: >
-      FILE_SUFFIX=fota OVERLAY_CONFIG=overlay-multiprotocol_ble.conf
+    extra_args:
+      - FILE_SUFFIX=fota
+      - OVERLAY_CONFIG=overlay-multiprotocol_ble.conf
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_zigbee
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_zigbee
   sample.zigbee.light_switch.multiprotocol:
     sysbuild: true
     build_only: true
@@ -68,19 +100,35 @@ tests:
       - nrf52840dk/nrf52840
       - nrf52833dk/nrf52833
       - nrf5340dk/nrf5340/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf52833dk/nrf52833 nrf5340dk/nrf5340/cpuapp
-    tags: ci_build sysbuild ci_samples_zigbee
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52833dk/nrf52833
+      - nrf5340dk/nrf5340/cpuapp
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_zigbee
   sample.zigbee.light_switch.with_shell:
     sysbuild: true
     build_only: true
-    extra_args: >
-      CONFIG_ZIGBEE_SHELL=y CONFIG_ZIGBEE_SHELL_DEBUG_CMD=y CONFIG_ZIGBEE_LOGGER_EP=n
-      CONFIG_ZIGBEE_SHELL_ENDPOINT=1 CONFIG_LOG_MODE_DEFERRED=y
+    extra_args:
+      - CONFIG_ZIGBEE_SHELL=y
+      - CONFIG_ZIGBEE_SHELL_DEBUG_CMD=y
+      - CONFIG_ZIGBEE_LOGGER_EP=n
+      - CONFIG_ZIGBEE_SHELL_ENDPOINT=1
+      - CONFIG_LOG_MODE_DEFERRED=y
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf52833dk/nrf52833
       - nrf5340dk/nrf5340/cpuapp
       - nrf21540dk/nrf52840
-    platform_allow: nrf52840dk/nrf52840 nrf52833dk/nrf52833 nrf5340dk/nrf5340/cpuapp
-      nrf21540dk/nrf52840
-    tags: ci_build shell sysbuild ci_samples_zigbee
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52833dk/nrf52833
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf21540dk/nrf52840
+    tags:
+      - ci_build
+      - shell
+      - sysbuild
+      - ci_samples_zigbee

--- a/samples/zigbee/ncp/sample.yaml
+++ b/samples/zigbee/ncp/sample.yaml
@@ -5,20 +5,32 @@ tests:
   sample.zigbee.ncp:
     sysbuild: true
     build_only: true
-    platform_allow: >
-      nrf52840dk/nrf52840 nrf52833dk/nrf52833 nrf21540dk/nrf52840 nrf5340dk/nrf5340/cpuapp
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52833dk/nrf52833
+      - nrf21540dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf52833dk/nrf52833
       - nrf21540dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
-    tags: sysbuild ci_samples_zigbee
+    tags:
+      - sysbuild
+      - ci_samples_zigbee
   sample.zigbee.ncp.usb:
     sysbuild: true
     build_only: true
-    platform_allow: nrf52840dk/nrf52840 nrf52833dk/nrf52833 nrf21540dk/nrf52840
-      nrf5340dk/nrf5340/cpuapp
-    tags: ci_build ncp sysbuild ci_samples_zigbee
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52833dk/nrf52833
+      - nrf21540dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+    tags:
+      - ci_build
+      - ncp
+      - sysbuild
+      - ci_samples_zigbee
     extra_args: FILE_SUFFIX=usb
     integration_platforms:
       - nrf52840dk/nrf52840
@@ -29,7 +41,11 @@ tests:
     sysbuild: true
     build_only: true
     platform_allow: nrf52840dongle/nrf52840
-    tags: ci_build ncp sysbuild ci_samples_zigbee
+    tags:
+      - ci_build
+      - ncp
+      - sysbuild
+      - ci_samples_zigbee
     extra_args: FILE_SUFFIX=dongle
     integration_platforms:
       - nrf52840dongle/nrf52840
@@ -40,4 +56,7 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
     platform_allow: nrf52840dk/nrf52840
-    tags: ci_build sysbuild ci_samples_zigbee
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_zigbee

--- a/samples/zigbee/network_coordinator/sample.yaml
+++ b/samples/zigbee/network_coordinator/sample.yaml
@@ -10,6 +10,13 @@ tests:
       - nrf52833dk/nrf52833
       - nrf5340dk/nrf5340/cpuapp
       - nrf21540dk/nrf52840
-    platform_allow: nrf52840dk/nrf52840 nrf52833dk/nrf52833 nrf5340dk/nrf5340/cpuapp
-      nrf21540dk/nrf52840
-    tags: ci_build smoke sysbuild ci_samples_zigbee
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52833dk/nrf52833
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf21540dk/nrf52840
+    tags:
+      - ci_build
+      - smoke
+      - sysbuild
+      - ci_samples_zigbee

--- a/samples/zigbee/shell/sample.yaml
+++ b/samples/zigbee/shell/sample.yaml
@@ -10,20 +10,34 @@ tests:
       - nrf52833dk/nrf52833
       - nrf5340dk/nrf5340/cpuapp
       - nrf21540dk/nrf52840
-    platform_allow: nrf52840dk/nrf52840 nrf52833dk/nrf52833 nrf5340dk/nrf5340/cpuapp
-      nrf21540dk/nrf52840
-    tags: ci_build shell sysbuild ci_samples_zigbee
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52833dk/nrf52833
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf21540dk/nrf52840
+    tags:
+      - ci_build
+      - shell
+      - sysbuild
+      - ci_samples_zigbee
   sample.zigbee.shell.usb:
     sysbuild: true
     build_only: true
-    extra_args:
-      FILE_SUFFIX=usb
+    extra_args: FILE_SUFFIX=usb
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf21540dk/nrf52840
       - nrf52833dk/nrf52833
       - nrf52840dongle/nrf52840
       - nrf5340dk/nrf5340/cpuapp
-    platform_allow: nrf52840dk/nrf52840 nrf21540dk/nrf52840 nrf52833dk/nrf52833
-      nrf52840dongle/nrf52840 nrf5340dk/nrf5340/cpuapp
-    tags: ci_build shell sysbuild ci_samples_zigbee
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf21540dk/nrf52840
+      - nrf52833dk/nrf52833
+      - nrf52840dongle/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+    tags:
+      - ci_build
+      - shell
+      - sysbuild
+      - ci_samples_zigbee

--- a/samples/zigbee/template/sample.yaml
+++ b/samples/zigbee/template/sample.yaml
@@ -10,6 +10,13 @@ tests:
       - nrf52833dk/nrf52833
       - nrf5340dk/nrf5340/cpuapp
       - nrf21540dk/nrf52840
-    platform_allow: nrf52840dk/nrf52840 nrf52833dk/nrf52833 nrf5340dk/nrf5340/cpuapp
-      nrf21540dk/nrf52840
-    tags: ci_build smoke sysbuild ci_samples_zigbee
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52833dk/nrf52833
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf21540dk/nrf52840
+    tags:
+      - ci_build
+      - smoke
+      - sysbuild
+      - ci_samples_zigbee

--- a/scripts/twister/alt/zephyr/samples/basic/blinky/sample.yaml
+++ b/scripts/twister/alt/zephyr/samples/basic/blinky/sample.yaml
@@ -18,11 +18,12 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
-    extra_args: SB_CONFIG_SDP=y
-                SB_CONFIG_SDP_GPIO=y
-                SB_CONFIG_SDP_GPIO_BACKEND_ICMSG=y
-                SB_CONFIG_PARTITION_MANAGER=n
-                EXTRA_DTC_OVERLAY_FILE="./boards/nrf54l15dk_nrf54l15_cpuapp_egpio.overlay"
+    extra_args:
+      - SB_CONFIG_SDP=y
+      - SB_CONFIG_SDP_GPIO=y
+      - SB_CONFIG_SDP_GPIO_BACKEND_ICMSG=y
+      - SB_CONFIG_PARTITION_MANAGER=n
+      - EXTRA_DTC_OVERLAY_FILE="./boards/nrf54l15dk_nrf54l15_cpuapp_egpio.overlay"
     harness: console
     harness_config:
       type: multi_line
@@ -37,11 +38,12 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
-    extra_args: SB_CONFIG_SDP=y
-                SB_CONFIG_SDP_GPIO=y
-                SB_CONFIG_SDP_GPIO_BACKEND_MBOX=y
-                SB_CONFIG_PARTITION_MANAGER=n
-                EXTRA_DTC_OVERLAY_FILE="./boards/nrf54l15dk_nrf54l15_cpuapp_egpio.overlay"
+    extra_args:
+      - SB_CONFIG_SDP=y
+      - SB_CONFIG_SDP_GPIO=y
+      - SB_CONFIG_SDP_GPIO_BACKEND_MBOX=y
+      - SB_CONFIG_PARTITION_MANAGER=n
+      - EXTRA_DTC_OVERLAY_FILE="./boards/nrf54l15dk_nrf54l15_cpuapp_egpio.overlay"
     harness: console
     harness_config:
       type: multi_line
@@ -56,11 +58,12 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
-    extra_args: SB_CONFIG_SDP=y
-                SB_CONFIG_SDP_GPIO=y
-                SB_CONFIG_SDP_GPIO_BACKEND_ICBMSG=y
-                SB_CONFIG_PARTITION_MANAGER=n
-                EXTRA_DTC_OVERLAY_FILE="./boards/nrf54l15dk_nrf54l15_cpuapp_egpio.overlay"
+    extra_args:
+      - SB_CONFIG_SDP=y
+      - SB_CONFIG_SDP_GPIO=y
+      - SB_CONFIG_SDP_GPIO_BACKEND_ICBMSG=y
+      - SB_CONFIG_PARTITION_MANAGER=n
+      - EXTRA_DTC_OVERLAY_FILE="./boards/nrf54l15dk_nrf54l15_cpuapp_egpio.overlay"
     harness: console
     harness_config:
       type: multi_line

--- a/scripts/twister/alt/zephyr/samples/sensor/accel_polling/sample.yaml
+++ b/scripts/twister/alt/zephyr/samples/sensor/accel_polling/sample.yaml
@@ -2,7 +2,10 @@ sample:
   name: Accelerometer polling sample
 common:
   depends_on: spi
-  tags: drivers spi sensors
+  tags:
+    - drivers
+    - spi
+    - sensors
   harness: console
 
 tests:
@@ -12,8 +15,8 @@ tests:
       fixture: pca63566
       type: one_line
       regex:
-        - "^\\s*[0-9A-Za-z_,+-.]*@[0-9A-Fa-f]* \\[m\/s\\^2\\]:    \
-           \\(\\s*-?[0-9\\.]*,\\s*-?[0-9\\.]*,\\s*-?[0-9\\.]*\\)$"
+        - "^\\s*[0-9A-Za-z_,+-.]*@[0-9A-Fa-f]* \\[m/s\\^2\\]:    \\(\\s*-?[0-9\\.]*,\\\
+        s*-?[0-9\\.]*,\\s*-?[0-9\\.]*\\)$"
     extra_args:
       - SHIELD=pca63566
     extra_configs:
@@ -28,8 +31,8 @@ tests:
       fixture: pca63566
       type: one_line
       regex:
-        - "^\\s*[0-9A-Za-z_,+-.]*@[0-9A-Fa-f]* \\[m\/s\\^2\\]:    \
-           \\(\\s*-?[0-9\\.]*,\\s*-?[0-9\\.]*,\\s*-?[0-9\\.]*\\)$"
+        - "^\\s*[0-9A-Za-z_,+-.]*@[0-9A-Fa-f]* \\[m/s\\^2\\]:    \\(\\s*-?[0-9\\.]*,\\\
+        s*-?[0-9\\.]*,\\s*-?[0-9\\.]*\\)$"
     extra_args:
       - accel_polling_SHIELD=pca63566
       - vpr_launcher_SHIELD=pca63566_fwd
@@ -41,8 +44,8 @@ tests:
       fixture: pca63566
       type: one_line
       regex:
-        - "^\\s*[0-9A-Za-z_,+-.]*@[0-9A-Fa-f]* \\[m\/s\\^2\\]:    \
-           \\(\\s*-?[0-9\\.]*,\\s*-?[0-9\\.]*,\\s*-?[0-9\\.]*\\)$"
+        - "^\\s*[0-9A-Za-z_,+-.]*@[0-9A-Fa-f]* \\[m/s\\^2\\]:    \\(\\s*-?[0-9\\.]*,\\\
+        s*-?[0-9\\.]*,\\s*-?[0-9\\.]*\\)$"
     extra_args:
       - SHIELD=pca63566;coverage_support
     extra_configs:
@@ -56,8 +59,8 @@ tests:
       fixture: pca63565
       type: one_line
       regex:
-        - "^\\s*[0-9A-Za-z_,+-.]*@[0-9A-Fa-f]* \\[m\/s\\^2\\]:    \
-           \\(\\s*-?[0-9\\.]*,\\s*-?[0-9\\.]*,\\s*-?[0-9\\.]*\\)$"
+        - "^\\s*[0-9A-Za-z_,+-.]*@[0-9A-Fa-f]* \\[m/s\\^2\\]:    \\(\\s*-?[0-9\\.]*,\\\
+        s*-?[0-9\\.]*,\\s*-?[0-9\\.]*\\)$"
     extra_args:
       - SHIELD=pca63565
     extra_configs:
@@ -71,8 +74,8 @@ tests:
       fixture: pca63565
       type: one_line
       regex:
-        - "^\\s*[0-9A-Za-z_,+-.]*@[0-9A-Fa-f]* \\[m\/s\\^2\\]:    \
-           \\(\\s*-?[0-9\\.]*,\\s*-?[0-9\\.]*,\\s*-?[0-9\\.]*\\)$"
+        - "^\\s*[0-9A-Za-z_,+-.]*@[0-9A-Fa-f]* \\[m/s\\^2\\]:    \\(\\s*-?[0-9\\.]*,\\\
+        s*-?[0-9\\.]*,\\s*-?[0-9\\.]*\\)$"
     extra_args:
       - SHIELD=pca63565;coverage_support
     extra_configs:
@@ -87,8 +90,8 @@ tests:
       fixture: pca63565
       type: one_line
       regex:
-        - "^\\s*[0-9A-Za-z_,+-.]*@[0-9A-Fa-f]* \\[m\/s\\^2\\]:    \
-           \\(\\s*-?[0-9\\.]*,\\s*-?[0-9\\.]*,\\s*-?[0-9\\.]*\\)$"
+        - "^\\s*[0-9A-Za-z_,+-.]*@[0-9A-Fa-f]* \\[m/s\\^2\\]:    \\(\\s*-?[0-9\\.]*,\\\
+        s*-?[0-9\\.]*,\\s*-?[0-9\\.]*\\)$"
     extra_args:
       - SHIELD=pca63565
       - vpr_launcher_DTC_OVERLAY_FILE="../../../../nrf/boards/shields/pca63565/boards/nrf54l15dk_nrf54l15_vpr_launcher.overlay"

--- a/scripts/twister/alt/zephyr/samples/sensor/bme680/sample.yaml
+++ b/scripts/twister/alt/zephyr/samples/sensor/bme680/sample.yaml
@@ -2,7 +2,10 @@ sample:
   name: BME680 Sensor sample
 common:
   depends_on: i2c
-  tags: drivers i2c sensors
+  tags:
+    - drivers
+    - i2c
+    - sensors
   harness: console
 
 tests:
@@ -12,7 +15,8 @@ tests:
       fixture: pca63566
       type: one_line
       regex:
-        - "^\\s*T:\\s*-?[0-9\\.]*; P:\\s*-?[0-9\\.]*; H: \\s*-?[0-9\\.]*; G:\\s*-?[0-9\\.]*$"
+        - "^\\s*T:\\s*-?[0-9\\.]*; P:\\s*-?[0-9\\.]*; H: \\s*-?[0-9\\.]*; G:\\s*-?[0-9\\\
+        .]*$"
     extra_args:
       - SHIELD=pca63566
     platform_allow: nrf54h20dk/nrf54h20/cpuapp
@@ -24,7 +28,8 @@ tests:
       fixture: pca63566
       type: one_line
       regex:
-        - "^\\s*T:\\s*-?[0-9\\.]*; P:\\s*-?[0-9\\.]*; H: \\s*-?[0-9\\.]*; G:\\s*-?[0-9\\.]*$"
+        - "^\\s*T:\\s*-?[0-9\\.]*; P:\\s*-?[0-9\\.]*; H: \\s*-?[0-9\\.]*; G:\\s*-?[0-9\\\
+        .]*$"
     extra_args:
       - bme680_SHIELD=pca63566
       - vpr_launcher_SHIELD=pca63566_fwd
@@ -36,7 +41,8 @@ tests:
       fixture: pca63566
       type: one_line
       regex:
-        - "^\\s*T:\\s*-?[0-9\\.]*; P:\\s*-?[0-9\\.]*; H: \\s*-?[0-9\\.]*; G:\\s*-?[0-9\\.]*$"
+        - "^\\s*T:\\s*-?[0-9\\.]*; P:\\s*-?[0-9\\.]*; H: \\s*-?[0-9\\.]*; G:\\s*-?[0-9\\\
+        .]*$"
     extra_args:
       - SHIELD=pca63566;coverage_support
     platform_allow: nrf54h20dk/nrf54h20/cpuapp
@@ -47,7 +53,8 @@ tests:
       fixture: pca63565
       type: one_line
       regex:
-        - "^\\s*T:\\s*-?[0-9\\.]*; P:\\s*-?[0-9\\.]*; H: \\s*-?[0-9\\.]*; G:\\s*-?[0-9\\.]*$"
+        - "^\\s*T:\\s*-?[0-9\\.]*; P:\\s*-?[0-9\\.]*; H: \\s*-?[0-9\\.]*; G:\\s*-?[0-9\\\
+        .]*$"
     extra_args:
       - SHIELD=pca63565
     platform_allow: nrf54l15dk/nrf54l15/cpuapp
@@ -58,7 +65,8 @@ tests:
       fixture: pca63565
       type: one_line
       regex:
-        - "^\\s*T:\\s*-?[0-9\\.]*; P:\\s*-?[0-9\\.]*; H: \\s*-?[0-9\\.]*; G:\\s*-?[0-9\\.]*$"
+        - "^\\s*T:\\s*-?[0-9\\.]*; P:\\s*-?[0-9\\.]*; H: \\s*-?[0-9\\.]*; G:\\s*-?[0-9\\\
+        .]*$"
     extra_args:
       - SHIELD=pca63565;coverage_support
     platform_allow: nrf54l15dk/nrf54l15/cpuapp
@@ -70,7 +78,8 @@ tests:
       fixture: pca63565
       type: one_line
       regex:
-        - "^\\s*T:\\s*-?[0-9\\.]*; P:\\s*-?[0-9\\.]*; H: \\s*-?[0-9\\.]*; G:\\s*-?[0-9\\.]*$"
+        - "^\\s*T:\\s*-?[0-9\\.]*; P:\\s*-?[0-9\\.]*; H: \\s*-?[0-9\\.]*; G:\\s*-?[0-9\\\
+        .]*$"
     extra_args:
       - SHIELD=pca63565
       - vpr_launcher_DTC_OVERLAY_FILE="../../../../nrf/boards/shields/pca63565/boards/nrf54l15dk_nrf54l15_vpr_launcher.overlay"

--- a/scripts/twister/alt/zephyr/tests/drivers/i2c/i2c_bme688/testcase.yaml
+++ b/scripts/twister/alt/zephyr/tests/drivers/i2c/i2c_bme688/testcase.yaml
@@ -1,5 +1,7 @@
 common:
-  tags: drivers i2c
+  tags:
+    - drivers
+    - i2c
   depends_on: i2c
   harness: ztest
 tests:

--- a/tests/benchmarks/current_consumption/gpio_idle/testcase.yaml
+++ b/tests/benchmarks/current_consumption/gpio_idle/testcase.yaml
@@ -1,7 +1,8 @@
 common:
   sysbuild: true
-  tags: ci_tests_benchmarks_current_consumption ppk_power_measure
-
+  tags:
+    - ci_tests_benchmarks_current_consumption
+    - ppk_power_measure
 tests:
   benchmarks.current_consumption.gpio_idle:
     platform_allow:

--- a/tests/benchmarks/current_consumption/grtc_idle/testcase.yaml
+++ b/tests/benchmarks/current_consumption/grtc_idle/testcase.yaml
@@ -1,7 +1,8 @@
 common:
   sysbuild: true
-  tags: ci_tests_benchmarks_current_consumption ppk_power_measure
-
+  tags:
+    - ci_tests_benchmarks_current_consumption
+    - ppk_power_measure
 tests:
   benchmarks.current_consumption.grtc_idle:
     platform_allow:

--- a/tests/benchmarks/current_consumption/multicore_system_off/testcase.yaml
+++ b/tests/benchmarks/current_consumption/multicore_system_off/testcase.yaml
@@ -1,7 +1,8 @@
 common:
   sysbuild: true
-  tags: ci_tests_benchmarks_current_consumption ppk_power_measure
-
+  tags:
+    - ci_tests_benchmarks_current_consumption
+    - ppk_power_measure
 tests:
   benchmarks.current_consumption.multicore_system_off:
     platform_allow:

--- a/tests/benchmarks/current_consumption/nfc_idle/testcase.yaml
+++ b/tests/benchmarks/current_consumption/nfc_idle/testcase.yaml
@@ -1,7 +1,8 @@
 common:
   sysbuild: true
-  tags: ci_tests_benchmarks_current_consumption ppk_power_measure
-
+  tags:
+    - ci_tests_benchmarks_current_consumption
+    - ppk_power_measure
 tests:
   benchmarks.current_consumption.nfc_idle:
     platform_allow:

--- a/tests/benchmarks/current_consumption/system_off/testcase.yaml
+++ b/tests/benchmarks/current_consumption/system_off/testcase.yaml
@@ -1,7 +1,8 @@
 common:
   sysbuild: true
-  tags: ci_tests_benchmarks_current_consumption ppk_power_measure
-
+  tags:
+    - ci_tests_benchmarks_current_consumption
+    - ppk_power_measure
 tests:
   benchmarks.current_consumption.systemoff.gpio_wakeup:
     platform_allow:

--- a/tests/benchmarks/current_consumption/uart_idle/testcase.yaml
+++ b/tests/benchmarks/current_consumption/uart_idle/testcase.yaml
@@ -1,7 +1,8 @@
 common:
   sysbuild: true
-  tags: ci_tests_benchmarks_current_consumption ppk_power_measure
-
+  tags:
+    - ci_tests_benchmarks_current_consumption
+    - ppk_power_measure
 tests:
   benchmarks.current_consumption.uart_idle:
     platform_allow:

--- a/tests/benchmarks/i2c_endless/testcase.yaml
+++ b/tests/benchmarks/i2c_endless/testcase.yaml
@@ -1,6 +1,9 @@
 common:
   depends_on: i2c
-  tags: drivers i2c ci_tests_benchmarks_i2c_endless
+  tags:
+    - drivers
+    - i2c
+    - ci_tests_benchmarks_i2c_endless
   harness: console
   harness_config:
     fixture: gpio_i2c_bridge_two_boards

--- a/tests/benchmarks/multicore/idle/testcase.yaml
+++ b/tests/benchmarks/multicore/idle/testcase.yaml
@@ -1,6 +1,8 @@
 common:
   sysbuild: true
-  tags: ci_build ci_tests_benchmarks_multicore
+  tags:
+    - ci_build
+    - ci_tests_benchmarks_multicore
   harness_config:
     type: multi_line
     ordered: true
@@ -16,8 +18,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
-    extra_args:
-      SB_CONF_FILE=sysbuild/nrf5340dk_nrf5340_cpunet.conf
+    extra_args: SB_CONF_FILE=sysbuild/nrf5340dk_nrf5340_cpunet.conf
 
   benchmarks.multicore.idle.nrf5340dk_cpuapp_cpunet_mcuboot:
     harness: console
@@ -27,8 +28,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
     extra_configs:
       - CONFIG_BOOTLOADER_MCUBOOT=y
-    extra_args:
-      SB_CONF_FILE=sysbuild/nrf5340dk_nrf5340_cpunet.conf
+    extra_args: SB_CONF_FILE=sysbuild/nrf5340dk_nrf5340_cpunet.conf
 
   benchmarks.multicore.idle.nrf54h20dk_cpuapp_cpuppr:
     harness: console
@@ -37,10 +37,9 @@ tests:
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
-      SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpuppr.conf
-      idle_SNIPPET=nordic-ppr
-      CONFIG_FIRST_SLEEP_OFFSET=y
-
+      - SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpuppr.conf
+      - idle_SNIPPET=nordic-ppr
+      - CONFIG_FIRST_SLEEP_OFFSET=y
   benchmarks.multicore.idle.nrf54h20dk_cpuapp_cpuppr_xip:
     harness: console
     platform_allow:
@@ -48,10 +47,9 @@ tests:
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
-      SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpuppr_xip.conf
-      idle_SNIPPET=nordic-ppr-xip
-      CONFIG_FIRST_SLEEP_OFFSET=y
-
+      - SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpuppr_xip.conf
+      - idle_SNIPPET=nordic-ppr-xip
+      - CONFIG_FIRST_SLEEP_OFFSET=y
   benchmarks.multicore.idle.nrf54h20dk_cpuapp_cpurad:
     harness: console
     platform_allow:
@@ -59,22 +57,32 @@ tests:
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
-      SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
-      CONFIG_FIRST_SLEEP_OFFSET=y
-
+      - SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
+      - CONFIG_FIRST_SLEEP_OFFSET=y
   benchmarks.multicore.idle.nrf54h20dk_cpuapp_cpurad.s2ram:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
-      SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
-      CONFIG_FIRST_SLEEP_OFFSET=y
-      CONFIG_PM=y CONFIG_PM_S2RAM=y CONFIG_POWEROFF=y CONFIG_PM_S2RAM_CUSTOM_MARKING=y
-      CONFIG_CONSOLE=n CONFIG_UART_CONSOLE=n CONFIG_SERIAL=n CONFIG_GPIO=n CONFIG_BOOT_BANNER=n
-      remote_CONFIG_PM=y remote_CONFIG_POWEROFF=y remote_CONFIG_CONSOLE=n
-      remote_CONFIG_UART_CONSOLE=n remote_CONFIG_SERIAL=n remote_CONFIG_GPIO=n
-      remote_CONFIG_BOOT_BANNER=n
+      - SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
+      - CONFIG_FIRST_SLEEP_OFFSET=y
+      - CONFIG_PM=y
+      - CONFIG_PM_S2RAM=y
+      - CONFIG_POWEROFF=y
+      - CONFIG_PM_S2RAM_CUSTOM_MARKING=y
+      - CONFIG_CONSOLE=n
+      - CONFIG_UART_CONSOLE=n
+      - CONFIG_SERIAL=n
+      - CONFIG_GPIO=n
+      - CONFIG_BOOT_BANNER=n
+      - remote_CONFIG_PM=y
+      - remote_CONFIG_POWEROFF=y
+      - remote_CONFIG_CONSOLE=n
+      - remote_CONFIG_UART_CONSOLE=n
+      - remote_CONFIG_SERIAL=n
+      - remote_CONFIG_GPIO=n
+      - remote_CONFIG_BOOT_BANNER=n
     harness: pytest
     harness_config:
       fixture: ppk_power_measure
@@ -88,14 +96,25 @@ tests:
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
-      SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
-      CONFIG_FIRST_SLEEP_OFFSET=y
-      CONFIG_PM=y CONFIG_PM_S2RAM=y CONFIG_POWEROFF=y CONFIG_PM_S2RAM_CUSTOM_MARKING=y
-      CONFIG_CONSOLE=n CONFIG_UART_CONSOLE=n CONFIG_SERIAL=n CONFIG_GPIO=n CONFIG_BOOT_BANNER=n
-      remote_CONFIG_PM=y remote_CONFIG_POWEROFF=y remote_CONFIG_CONSOLE=n
-      remote_CONFIG_UART_CONSOLE=n remote_CONFIG_SERIAL=n remote_CONFIG_GPIO=n
-      remote_CONFIG_BOOT_BANNER=n
-      DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_ram_high_usage.overlay"
+      - SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
+      - CONFIG_FIRST_SLEEP_OFFSET=y
+      - CONFIG_PM=y
+      - CONFIG_PM_S2RAM=y
+      - CONFIG_POWEROFF=y
+      - CONFIG_PM_S2RAM_CUSTOM_MARKING=y
+      - CONFIG_CONSOLE=n
+      - CONFIG_UART_CONSOLE=n
+      - CONFIG_SERIAL=n
+      - CONFIG_GPIO=n
+      - CONFIG_BOOT_BANNER=n
+      - remote_CONFIG_PM=y
+      - remote_CONFIG_POWEROFF=y
+      - remote_CONFIG_CONSOLE=n
+      - remote_CONFIG_UART_CONSOLE=n
+      - remote_CONFIG_SERIAL=n
+      - remote_CONFIG_GPIO=n
+      - remote_CONFIG_BOOT_BANNER=n
+      - DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_ram_high_usage.overlay"
     harness: pytest
     harness_config:
       fixture: ppk_power_measure
@@ -109,14 +128,25 @@ tests:
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
-      SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
-      CONFIG_FIRST_SLEEP_OFFSET=y
-      CONFIG_PM=y CONFIG_PM_S2RAM=y CONFIG_POWEROFF=y CONFIG_PM_S2RAM_CUSTOM_MARKING=y
-      CONFIG_CONSOLE=n CONFIG_UART_CONSOLE=n CONFIG_SERIAL=n CONFIG_GPIO=n CONFIG_BOOT_BANNER=n
-      remote_CONFIG_PM=y remote_CONFIG_POWEROFF=y remote_CONFIG_CONSOLE=n
-      remote_CONFIG_UART_CONSOLE=n remote_CONFIG_SERIAL=n remote_CONFIG_GPIO=n
-      remote_CONFIG_BOOT_BANNER=n
-      DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_ram_low_usage.overlay"
+      - SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
+      - CONFIG_FIRST_SLEEP_OFFSET=y
+      - CONFIG_PM=y
+      - CONFIG_PM_S2RAM=y
+      - CONFIG_POWEROFF=y
+      - CONFIG_PM_S2RAM_CUSTOM_MARKING=y
+      - CONFIG_CONSOLE=n
+      - CONFIG_UART_CONSOLE=n
+      - CONFIG_SERIAL=n
+      - CONFIG_GPIO=n
+      - CONFIG_BOOT_BANNER=n
+      - remote_CONFIG_PM=y
+      - remote_CONFIG_POWEROFF=y
+      - remote_CONFIG_CONSOLE=n
+      - remote_CONFIG_UART_CONSOLE=n
+      - remote_CONFIG_SERIAL=n
+      - remote_CONFIG_GPIO=n
+      - remote_CONFIG_BOOT_BANNER=n
+      - DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_ram_low_usage.overlay"
     harness: pytest
     harness_config:
       fixture: ppk_power_measure

--- a/tests/benchmarks/multicore/idle_adc/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_adc/testcase.yaml
@@ -1,8 +1,11 @@
 common:
   sysbuild: true
   depends_on: adc
-  tags: ci_build ci_tests_benchmarks_multicore adc ppk_power_measure
-
+  tags:
+    - ci_build
+    - ci_tests_benchmarks_multicore
+    - adc
+    - ppk_power_measure
 tests:
   benchmarks.multicore.idle_adc.nrf54h20dk_cpuapp_cpurad.s2ram:
     harness: pytest

--- a/tests/benchmarks/multicore/idle_clock_control/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_clock_control/testcase.yaml
@@ -1,7 +1,9 @@
 common:
   sysbuild: true
-  tags: ci_build ci_tests_benchmarks_multicore ppk_power_measure
-
+  tags:
+    - ci_build
+    - ci_tests_benchmarks_multicore
+    - ppk_power_measure
 tests:
   benchmarks.multicore.idle_clock_control:
     harness: pytest

--- a/tests/benchmarks/multicore/idle_comp/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_comp/testcase.yaml
@@ -1,7 +1,9 @@
 common:
   sysbuild: true
-  tags: ci_build ci_tests_benchmarks_multicore ppk_power_measure
-
+  tags:
+    - ci_build
+    - ci_tests_benchmarks_multicore
+    - ppk_power_measure
 tests:
   benchmarks.multicore.idle_comp.nrf54h20dk_cpuapp_cpurad.s2ram:
     harness: pytest

--- a/tests/benchmarks/multicore/idle_gpio/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_gpio/testcase.yaml
@@ -1,6 +1,8 @@
 common:
   sysbuild: true
-  tags: ci_build ci_tests_benchmarks_multicore
+  tags:
+    - ci_build
+    - ci_tests_benchmarks_multicore
   harness_config:
     type: multi_line
     ordered: true
@@ -15,10 +17,10 @@ tests:
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
-      FILE_SUFFIX=s2ram
-      SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
-      DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_s2ram.overlay"
-      remote_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpurad_s2ram.overlay"
+      - FILE_SUFFIX=s2ram
+      - SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
+      - DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_s2ram.overlay"
+      - remote_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpurad_s2ram.overlay"
     harness: pytest
     harness_config:
       fixture: ppk_power_measure
@@ -32,10 +34,10 @@ tests:
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
-      FILE_SUFFIX=s2ram
-      SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
-      DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_s2ram.overlay;boards/wakeup_from_uart_pins.overlay"
-      remote_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpurad_s2ram.overlay;boards/wakeup_from_uart_pins.overlay"
+      - FILE_SUFFIX=s2ram
+      - SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
+      - DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_s2ram.overlay;boards/wakeup_from_uart_pins.overlay"
+      - remote_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpurad_s2ram.overlay;boards/wakeup_from_uart_pins.overlay"
     harness: pytest
     harness_config:
       fixture: gpio_loopback

--- a/tests/benchmarks/multicore/idle_hpu_temp_meas/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_hpu_temp_meas/testcase.yaml
@@ -1,7 +1,10 @@
 common:
   sysbuild: true
-  tags: ci_build ci_tests_benchmarks_multicore hpu ppk_power_measure
-
+  tags:
+    - ci_build
+    - ci_tests_benchmarks_multicore
+    - hpu
+    - ppk_power_measure
 tests:
   benchmarks.multicore.idle_hpu_temp_meas:
     harness: pytest

--- a/tests/benchmarks/multicore/idle_ipc/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_ipc/testcase.yaml
@@ -1,7 +1,10 @@
 common:
   sysbuild: true
-  tags: ci_build ci_tests_benchmarks_multicore ipc ppk_power_measure
-
+  tags:
+    - ci_build
+    - ci_tests_benchmarks_multicore
+    - ipc
+    - ppk_power_measure
 tests:
   benchmarks.multicore.idle_ipc.nrf54h20dk_cpuapp_cpurad.s2ram:
     harness: pytest

--- a/tests/benchmarks/multicore/idle_outside_of_main/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_outside_of_main/testcase.yaml
@@ -1,7 +1,9 @@
 common:
   sysbuild: true
-  tags: ci_build ci_tests_benchmarks_multicore ppk_power_measure
-
+  tags:
+    - ci_build
+    - ci_tests_benchmarks_multicore
+    - ppk_power_measure
 tests:
   benchmarks.multicore.idle_outside_of_main.nrf54h20dk_cpuapp_cpurad.s2ram:
     harness: pytest

--- a/tests/benchmarks/multicore/idle_ppr/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_ppr/testcase.yaml
@@ -1,6 +1,8 @@
 common:
   sysbuild: true
-  tags: ci_build ci_tests_benchmarks_multicore
+  tags:
+    - ci_build
+    - ci_tests_benchmarks_multicore
   platform_allow:
     - nrf54h20dk/nrf54h20/cpuapp
   integration_platforms:
@@ -20,12 +22,12 @@ tests:
   benchmarks.multicore.idle_ppr.idle:
     tags: ppk_power_measure
     extra_args:
-      idle_ppr_CONF_FILE=prj_s2ram.conf
-      remote_rad_CONF_FILE=prj_s2ram.conf
-      remote_ppr_CONF_FILE=prj_s2ram.conf
-      idle_ppr_CONFIG_TEST_SLEEP_DURATION_MS=500
-      remote_rad_CONFIG_TEST_SLEEP_DURATION_MS=500
-      remote_ppr_CONFIG_TEST_SLEEP_DURATION_MS=500
+      - idle_ppr_CONF_FILE=prj_s2ram.conf
+      - remote_rad_CONF_FILE=prj_s2ram.conf
+      - remote_ppr_CONF_FILE=prj_s2ram.conf
+      - idle_ppr_CONFIG_TEST_SLEEP_DURATION_MS=500
+      - remote_rad_CONFIG_TEST_SLEEP_DURATION_MS=500
+      - remote_ppr_CONFIG_TEST_SLEEP_DURATION_MS=500
     harness: pytest
     harness_config:
       fixture: ppk_power_measure
@@ -35,9 +37,9 @@ tests:
   benchmarks.multicore.idle_ppr.s2ram:
     tags: ppk_power_measure
     extra_args:
-      idle_ppr_CONF_FILE=prj_s2ram.conf
-      remote_rad_CONF_FILE=prj_s2ram.conf
-      remote_ppr_CONF_FILE=prj_s2ram.conf
+      - idle_ppr_CONF_FILE=prj_s2ram.conf
+      - remote_rad_CONF_FILE=prj_s2ram.conf
+      - remote_ppr_CONF_FILE=prj_s2ram.conf
     harness: pytest
     harness_config:
       fixture: ppk_power_measure

--- a/tests/benchmarks/multicore/idle_pwm_led/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_pwm_led/testcase.yaml
@@ -1,6 +1,8 @@
 common:
   sysbuild: true
-  tags: ci_build ci_tests_benchmarks_multicore
+  tags:
+    - ci_build
+    - ci_tests_benchmarks_multicore
   platform_allow:
     - nrf54h20dk/nrf54h20/cpuapp
   integration_platforms:
@@ -20,10 +22,10 @@ tests:
   benchmarks.multicore.idle_pwm_led.nrf54h20dk_cpuapp_cpurad.idle:
     tags: ppk_power_measure
     extra_args:
-      idle_pwm_led_CONF_FILE=prj_s2ram.conf
-      remote_CONF_FILE=prj_s2ram.conf
-      idle_pwm_led_CONFIG_TEST_SLEEP_DURATION_MS=500
-      remote_CONFIG_TEST_SLEEP_DURATION_MS=500
+      - idle_pwm_led_CONF_FILE=prj_s2ram.conf
+      - remote_CONF_FILE=prj_s2ram.conf
+      - idle_pwm_led_CONFIG_TEST_SLEEP_DURATION_MS=500
+      - remote_CONFIG_TEST_SLEEP_DURATION_MS=500
     harness: pytest
     harness_config:
       fixture: ppk_power_measure
@@ -33,8 +35,8 @@ tests:
   benchmarks.multicore.idle_pwm_led.nrf54h20dk_cpuapp_cpurad.s2ram:
     tags: ppk_power_measure
     extra_args:
-      idle_pwm_led_CONF_FILE=prj_s2ram.conf
-      remote_CONF_FILE=prj_s2ram.conf
+      - idle_pwm_led_CONF_FILE=prj_s2ram.conf
+      - remote_CONF_FILE=prj_s2ram.conf
     harness: pytest
     harness_config:
       fixture: ppk_power_measure
@@ -44,11 +46,11 @@ tests:
   benchmarks.multicore.idle_pwm_led.nrf54h20dk_cpuapp_cpurad.idle_fast:
     tags: ppk_power_measure
     extra_args:
-      idle_pwm_led_CONF_FILE=prj_s2ram.conf
-      remote_CONF_FILE=prj_s2ram.conf
-      idle_pwm_led_CONFIG_TEST_SLEEP_DURATION_MS=500
-      remote_CONFIG_TEST_SLEEP_DURATION_MS=500
-      idle_pwm_led_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_0.overlay"
+      - idle_pwm_led_CONF_FILE=prj_s2ram.conf
+      - remote_CONF_FILE=prj_s2ram.conf
+      - idle_pwm_led_CONFIG_TEST_SLEEP_DURATION_MS=500
+      - remote_CONFIG_TEST_SLEEP_DURATION_MS=500
+      - idle_pwm_led_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_0.overlay"
     harness: pytest
     harness_config:
       fixture: ppk_power_measure
@@ -58,9 +60,9 @@ tests:
   benchmarks.multicore.idle_pwm_led.nrf54h20dk_cpuapp_cpurad.s2ram_fast:
     tags: ppk_power_measure
     extra_args:
-      idle_pwm_led_CONF_FILE=prj_s2ram.conf
-      remote_CONF_FILE=prj_s2ram.conf
-      idle_pwm_led_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_0.overlay"
+      - idle_pwm_led_CONF_FILE=prj_s2ram.conf
+      - remote_CONF_FILE=prj_s2ram.conf
+      - idle_pwm_led_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_0.overlay"
     harness: pytest
     harness_config:
       fixture: ppk_power_measure

--- a/tests/benchmarks/multicore/idle_spim/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_spim/testcase.yaml
@@ -1,8 +1,11 @@
 common:
   sysbuild: true
   depends_on: spi
-  tags: ci_build ci_tests_benchmarks_multicore spim ppk_power_measure
-
+  tags:
+    - ci_build
+    - ci_tests_benchmarks_multicore
+    - spim
+    - ppk_power_measure
 tests:
   benchmarks.multicore.idle_spim.nrf54h20dk_cpuapp_cpurad.s2ram:
     harness: pytest

--- a/tests/benchmarks/multicore/idle_spim_loopback/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_spim_loopback/testcase.yaml
@@ -1,6 +1,9 @@
 common:
   sysbuild: true
-  tags: ci_build ci_tests_benchmarks_multicore spim
+  tags:
+    - ci_build
+    - ci_tests_benchmarks_multicore
+    - spim
   platform_allow:
     - nrf54h20dk/nrf54h20/cpuapp
   integration_platforms:
@@ -27,8 +30,8 @@ tests:
   benchmarks.multicore.idle_spim_loopback.4_bytes.idle:
     tags: ppk_power_measure
     extra_args:
-      idle_spim_loopback_CONF_FILE=prj_s2ram.conf
-      idle_spim_loopback_CONFIG_TEST_SLEEP_DURATION_MS=500
+      - idle_spim_loopback_CONF_FILE=prj_s2ram.conf
+      - idle_spim_loopback_CONFIG_TEST_SLEEP_DURATION_MS=500
     harness: pytest
     harness_config:
       fixture: spi_loopback
@@ -37,8 +40,7 @@ tests:
 
   benchmarks.multicore.idle_spim_loopback.4_bytes.s2ram:
     tags: ppk_power_measure
-    extra_args:
-      idle_spim_loopback_CONF_FILE=prj_s2ram.conf
+    extra_args: idle_spim_loopback_CONF_FILE=prj_s2ram.conf
     harness: pytest
     harness_config:
       fixture: spi_loopback
@@ -47,7 +49,7 @@ tests:
 
   benchmarks.multicore.idle_spim_loopback.4_bytes.no_sleep_fast:
     extra_args:
-      idle_spim_loopback_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
+      - idle_spim_loopback_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
     harness: console
     harness_config:
       fixture: spi_loopback
@@ -62,9 +64,9 @@ tests:
   benchmarks.multicore.idle_spim_loopback.4_bytes.idle_fast:
     tags: ppk_power_measure
     extra_args:
-      idle_spim_loopback_CONF_FILE=prj_s2ram.conf
-      idle_spim_loopback_CONFIG_TEST_SLEEP_DURATION_MS=500
-      idle_spim_loopback_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
+      - idle_spim_loopback_CONF_FILE=prj_s2ram.conf
+      - idle_spim_loopback_CONFIG_TEST_SLEEP_DURATION_MS=500
+      - idle_spim_loopback_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
     harness: pytest
     harness_config:
       fixture: spi_loopback
@@ -74,8 +76,8 @@ tests:
   benchmarks.multicore.idle_spim_loopback.4_bytes.s2ram_fast:
     tags: ppk_power_measure
     extra_args:
-      idle_spim_loopback_CONF_FILE=prj_s2ram.conf
-      idle_spim_loopback_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
+      - idle_spim_loopback_CONF_FILE=prj_s2ram.conf
+      - idle_spim_loopback_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
     harness: pytest
     harness_config:
       fixture: spi_loopback
@@ -126,8 +128,7 @@ tests:
   #
 
   benchmarks.multicore.idle_spim_loopback.16_bytes.no_sleep:
-    extra_args:
-      idle_spim_loopback_CONFIG_DATA_FIELD=16
+    extra_args: idle_spim_loopback_CONFIG_DATA_FIELD=16
     harness: console
     harness_config:
       fixture: spi_loopback
@@ -142,9 +143,9 @@ tests:
   benchmarks.multicore.idle_spim_loopback.16_bytes.idle:
     tags: ppk_power_measure
     extra_args:
-      idle_spim_loopback_CONF_FILE=prj_s2ram.conf
-      idle_spim_loopback_CONFIG_TEST_SLEEP_DURATION_MS=500
-      idle_spim_loopback_CONFIG_DATA_FIELD=16
+      - idle_spim_loopback_CONF_FILE=prj_s2ram.conf
+      - idle_spim_loopback_CONFIG_TEST_SLEEP_DURATION_MS=500
+      - idle_spim_loopback_CONFIG_DATA_FIELD=16
     harness: pytest
     harness_config:
       fixture: spi_loopback
@@ -154,8 +155,8 @@ tests:
   benchmarks.multicore.idle_spim_loopback.16_bytes.s2ram:
     tags: ppk_power_measure
     extra_args:
-      idle_spim_loopback_CONF_FILE=prj_s2ram.conf
-      idle_spim_loopback_CONFIG_DATA_FIELD=16
+      - idle_spim_loopback_CONF_FILE=prj_s2ram.conf
+      - idle_spim_loopback_CONFIG_DATA_FIELD=16
     harness: pytest
     harness_config:
       fixture: spi_loopback
@@ -164,8 +165,8 @@ tests:
 
   benchmarks.multicore.idle_spim_loopback.16_bytes.no_sleep_fast:
     extra_args:
-      idle_spim_loopback_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
-      idle_spim_loopback_CONFIG_DATA_FIELD=16
+      - idle_spim_loopback_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
+      - idle_spim_loopback_CONFIG_DATA_FIELD=16
     harness: console
     harness_config:
       fixture: spi_loopback
@@ -180,10 +181,10 @@ tests:
   benchmarks.multicore.idle_spim_loopback.16_bytes.idle_fast:
     tags: ppk_power_measure
     extra_args:
-      idle_spim_loopback_CONF_FILE=prj_s2ram.conf
-      idle_spim_loopback_CONFIG_TEST_SLEEP_DURATION_MS=500
-      idle_spim_loopback_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
-      idle_spim_loopback_CONFIG_DATA_FIELD=16
+      - idle_spim_loopback_CONF_FILE=prj_s2ram.conf
+      - idle_spim_loopback_CONFIG_TEST_SLEEP_DURATION_MS=500
+      - idle_spim_loopback_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
+      - idle_spim_loopback_CONFIG_DATA_FIELD=16
     harness: pytest
     harness_config:
       fixture: spi_loopback
@@ -193,9 +194,9 @@ tests:
   benchmarks.multicore.idle_spim_loopback.16_bytes.s2ram_fast:
     tags: ppk_power_measure
     extra_args:
-      idle_spim_loopback_CONF_FILE=prj_s2ram.conf
-      idle_spim_loopback_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
-      idle_spim_loopback_CONFIG_DATA_FIELD=16
+      - idle_spim_loopback_CONF_FILE=prj_s2ram.conf
+      - idle_spim_loopback_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
+      - idle_spim_loopback_CONFIG_DATA_FIELD=16
     harness: pytest
     harness_config:
       fixture: spi_loopback
@@ -251,9 +252,9 @@ tests:
   benchmarks.multicore.idle_spim_loopback.4_bytes_cs_lock.s2ram_fast:
     tags: ppk_power_measure
     extra_args:
-      idle_spim_loopback_CONFIG_TEST_SPI_HOLD_ON_CS=y
-      idle_spim_loopback_CONF_FILE=prj_s2ram.conf
-      idle_spim_loopback_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
+      - idle_spim_loopback_CONFIG_TEST_SPI_HOLD_ON_CS=y
+      - idle_spim_loopback_CONF_FILE=prj_s2ram.conf
+      - idle_spim_loopback_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
     harness: pytest
     harness_config:
       fixture: spi_loopback
@@ -267,9 +268,9 @@ tests:
   benchmarks.multicore.idle_spim_loopback.4_bytes_spi_lock.s2ram_fast:
     tags: ppk_power_measure
     extra_args:
-      idle_spim_loopback_CONFIG_TEST_SPI_LOCK_ON=y
-      idle_spim_loopback_CONF_FILE=prj_s2ram.conf
-      idle_spim_loopback_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
+      - idle_spim_loopback_CONFIG_TEST_SPI_LOCK_ON=y
+      - idle_spim_loopback_CONF_FILE=prj_s2ram.conf
+      - idle_spim_loopback_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
     harness: pytest
     harness_config:
       fixture: spi_loopback
@@ -282,8 +283,8 @@ tests:
 
   benchmarks.multicore.idle_spim_loopback.4_bytes_cs_and_spi_lock.no_sleep:
     extra_args:
-      idle_spim_loopback_CONFIG_TEST_SPI_HOLD_ON_CS=y
-      idle_spim_loopback_CONFIG_TEST_SPI_LOCK_ON=y
+      - idle_spim_loopback_CONFIG_TEST_SPI_HOLD_ON_CS=y
+      - idle_spim_loopback_CONFIG_TEST_SPI_LOCK_ON=y
     harness: console
     harness_config:
       fixture: spi_loopback
@@ -300,10 +301,10 @@ tests:
   benchmarks.multicore.idle_spim_loopback.4_bytes_cs_and_spi_lock.idle:
     tags: ppk_power_measure
     extra_args:
-      idle_spim_loopback_CONFIG_TEST_SPI_HOLD_ON_CS=y
-      idle_spim_loopback_CONFIG_TEST_SPI_LOCK_ON=y
-      idle_spim_loopback_CONF_FILE=prj_s2ram.conf
-      idle_spim_loopback_CONFIG_TEST_SLEEP_DURATION_MS=500
+      - idle_spim_loopback_CONFIG_TEST_SPI_HOLD_ON_CS=y
+      - idle_spim_loopback_CONFIG_TEST_SPI_LOCK_ON=y
+      - idle_spim_loopback_CONF_FILE=prj_s2ram.conf
+      - idle_spim_loopback_CONFIG_TEST_SLEEP_DURATION_MS=500
     harness: pytest
     harness_config:
       fixture: spi_loopback
@@ -313,9 +314,9 @@ tests:
   benchmarks.multicore.idle_spim_loopback.4_bytes_cs_and_spi_lock.s2ram:
     tags: ppk_power_measure
     extra_args:
-      idle_spim_loopback_CONFIG_TEST_SPI_HOLD_ON_CS=y
-      idle_spim_loopback_CONFIG_TEST_SPI_LOCK_ON=y
-      idle_spim_loopback_CONF_FILE=prj_s2ram.conf
+      - idle_spim_loopback_CONFIG_TEST_SPI_HOLD_ON_CS=y
+      - idle_spim_loopback_CONFIG_TEST_SPI_LOCK_ON=y
+      - idle_spim_loopback_CONF_FILE=prj_s2ram.conf
     harness: pytest
     harness_config:
       fixture: spi_loopback
@@ -324,9 +325,9 @@ tests:
 
   benchmarks.multicore.idle_spim_loopback.4_bytes_cs_and_spi_lock.no_sleep_fast:
     extra_args:
-      idle_spim_loopback_CONFIG_TEST_SPI_HOLD_ON_CS=y
-      idle_spim_loopback_CONFIG_TEST_SPI_LOCK_ON=y
-      idle_spim_loopback_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
+      - idle_spim_loopback_CONFIG_TEST_SPI_HOLD_ON_CS=y
+      - idle_spim_loopback_CONFIG_TEST_SPI_LOCK_ON=y
+      - idle_spim_loopback_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
     harness: console
     harness_config:
       fixture: spi_loopback
@@ -343,11 +344,11 @@ tests:
   benchmarks.multicore.idle_spim_loopback.4_bytes_cs_and_spi_lock.idle_fast:
     tags: ppk_power_measure
     extra_args:
-      idle_spim_loopback_CONFIG_TEST_SPI_HOLD_ON_CS=y
-      idle_spim_loopback_CONFIG_TEST_SPI_LOCK_ON=y
-      idle_spim_loopback_CONF_FILE=prj_s2ram.conf
-      idle_spim_loopback_CONFIG_TEST_SLEEP_DURATION_MS=500
-      idle_spim_loopback_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
+      - idle_spim_loopback_CONFIG_TEST_SPI_HOLD_ON_CS=y
+      - idle_spim_loopback_CONFIG_TEST_SPI_LOCK_ON=y
+      - idle_spim_loopback_CONF_FILE=prj_s2ram.conf
+      - idle_spim_loopback_CONFIG_TEST_SLEEP_DURATION_MS=500
+      - idle_spim_loopback_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
     harness: pytest
     harness_config:
       fixture: spi_loopback
@@ -357,10 +358,10 @@ tests:
   benchmarks.multicore.idle_spim_loopback.4_bytes_cs_and_spi_lock.s2ram_fast:
     tags: ppk_power_measure
     extra_args:
-      idle_spim_loopback_CONFIG_TEST_SPI_HOLD_ON_CS=y
-      idle_spim_loopback_CONFIG_TEST_SPI_LOCK_ON=y
-      idle_spim_loopback_CONF_FILE=prj_s2ram.conf
-      idle_spim_loopback_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
+      - idle_spim_loopback_CONFIG_TEST_SPI_HOLD_ON_CS=y
+      - idle_spim_loopback_CONFIG_TEST_SPI_LOCK_ON=y
+      - idle_spim_loopback_CONF_FILE=prj_s2ram.conf
+      - idle_spim_loopback_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
     harness: pytest
     harness_config:
       fixture: spi_loopback
@@ -374,9 +375,9 @@ tests:
 
   benchmarks.multicore.idle_spim_loopback.4_bytes_cs_and_spi_lock_no_release.no_sleep:
     extra_args:
-      idle_spim_loopback_CONFIG_TEST_SPI_HOLD_ON_CS=y
-      idle_spim_loopback_CONFIG_TEST_SPI_LOCK_ON=y
-      idle_spim_loopback_CONFIG_TEST_SPI_RELEASE_BEFORE_SLEEP=n
+      - idle_spim_loopback_CONFIG_TEST_SPI_HOLD_ON_CS=y
+      - idle_spim_loopback_CONFIG_TEST_SPI_LOCK_ON=y
+      - idle_spim_loopback_CONFIG_TEST_SPI_RELEASE_BEFORE_SLEEP=n
     harness: console
     harness_config:
       fixture: spi_loopback
@@ -394,11 +395,11 @@ tests:
   benchmarks.multicore.idle_spim_loopback.4_bytes_cs_and_spi_lock_no_release.idle:
     tags: ppk_power_measure
     extra_args:
-      idle_spim_loopback_CONFIG_TEST_SPI_HOLD_ON_CS=y
-      idle_spim_loopback_CONFIG_TEST_SPI_LOCK_ON=y
-      idle_spim_loopback_CONFIG_TEST_SPI_RELEASE_BEFORE_SLEEP=n
-      idle_spim_loopback_CONF_FILE=prj_s2ram.conf
-      idle_spim_loopback_CONFIG_TEST_SLEEP_DURATION_MS=500
+      - idle_spim_loopback_CONFIG_TEST_SPI_HOLD_ON_CS=y
+      - idle_spim_loopback_CONFIG_TEST_SPI_LOCK_ON=y
+      - idle_spim_loopback_CONFIG_TEST_SPI_RELEASE_BEFORE_SLEEP=n
+      - idle_spim_loopback_CONF_FILE=prj_s2ram.conf
+      - idle_spim_loopback_CONFIG_TEST_SLEEP_DURATION_MS=500
     harness: pytest
     harness_config:
       fixture: spi_loopback
@@ -408,10 +409,10 @@ tests:
   benchmarks.multicore.idle_spim_loopback.4_bytes_cs_and_spi_lock_no_release.s2ram:
     tags: ppk_power_measure
     extra_args:
-      idle_spim_loopback_CONFIG_TEST_SPI_HOLD_ON_CS=y
-      idle_spim_loopback_CONFIG_TEST_SPI_LOCK_ON=y
-      idle_spim_loopback_CONFIG_TEST_SPI_RELEASE_BEFORE_SLEEP=n
-      idle_spim_loopback_CONF_FILE=prj_s2ram.conf
+      - idle_spim_loopback_CONFIG_TEST_SPI_HOLD_ON_CS=y
+      - idle_spim_loopback_CONFIG_TEST_SPI_LOCK_ON=y
+      - idle_spim_loopback_CONFIG_TEST_SPI_RELEASE_BEFORE_SLEEP=n
+      - idle_spim_loopback_CONF_FILE=prj_s2ram.conf
     harness: pytest
     harness_config:
       fixture: spi_loopback
@@ -420,10 +421,10 @@ tests:
 
   benchmarks.multicore.idle_spim_loopback.4_bytes_cs_and_spi_lock_no_release.no_sleep_fast:
     extra_args:
-      idle_spim_loopback_CONFIG_TEST_SPI_HOLD_ON_CS=y
-      idle_spim_loopback_CONFIG_TEST_SPI_LOCK_ON=y
-      idle_spim_loopback_CONFIG_TEST_SPI_RELEASE_BEFORE_SLEEP=n
-      idle_spim_loopback_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
+      - idle_spim_loopback_CONFIG_TEST_SPI_HOLD_ON_CS=y
+      - idle_spim_loopback_CONFIG_TEST_SPI_LOCK_ON=y
+      - idle_spim_loopback_CONFIG_TEST_SPI_RELEASE_BEFORE_SLEEP=n
+      - idle_spim_loopback_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
     harness: console
     harness_config:
       fixture: spi_loopback
@@ -441,12 +442,12 @@ tests:
   benchmarks.multicore.idle_spim_loopback.4_bytes_cs_and_spi_lock_no_release.idle_fast:
     tags: ppk_power_measure
     extra_args:
-      idle_spim_loopback_CONFIG_TEST_SPI_HOLD_ON_CS=y
-      idle_spim_loopback_CONFIG_TEST_SPI_LOCK_ON=y
-      idle_spim_loopback_CONFIG_TEST_SPI_RELEASE_BEFORE_SLEEP=n
-      idle_spim_loopback_CONF_FILE=prj_s2ram.conf
-      idle_spim_loopback_CONFIG_TEST_SLEEP_DURATION_MS=500
-      idle_spim_loopback_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
+      - idle_spim_loopback_CONFIG_TEST_SPI_HOLD_ON_CS=y
+      - idle_spim_loopback_CONFIG_TEST_SPI_LOCK_ON=y
+      - idle_spim_loopback_CONFIG_TEST_SPI_RELEASE_BEFORE_SLEEP=n
+      - idle_spim_loopback_CONF_FILE=prj_s2ram.conf
+      - idle_spim_loopback_CONFIG_TEST_SLEEP_DURATION_MS=500
+      - idle_spim_loopback_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
     harness: pytest
     harness_config:
       fixture: spi_loopback
@@ -456,11 +457,11 @@ tests:
   benchmarks.multicore.idle_spim_loopback.4_bytes_cs_and_spi_lock_no_release.s2ram_fast:
     tags: ppk_power_measure
     extra_args:
-      idle_spim_loopback_CONFIG_TEST_SPI_HOLD_ON_CS=y
-      idle_spim_loopback_CONFIG_TEST_SPI_LOCK_ON=y
-      idle_spim_loopback_CONFIG_TEST_SPI_RELEASE_BEFORE_SLEEP=n
-      idle_spim_loopback_CONF_FILE=prj_s2ram.conf
-      idle_spim_loopback_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
+      - idle_spim_loopback_CONFIG_TEST_SPI_HOLD_ON_CS=y
+      - idle_spim_loopback_CONFIG_TEST_SPI_LOCK_ON=y
+      - idle_spim_loopback_CONFIG_TEST_SPI_RELEASE_BEFORE_SLEEP=n
+      - idle_spim_loopback_CONF_FILE=prj_s2ram.conf
+      - idle_spim_loopback_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
     harness: pytest
     harness_config:
       fixture: spi_loopback

--- a/tests/benchmarks/multicore/idle_stm/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_stm/testcase.yaml
@@ -1,6 +1,8 @@
 common:
   sysbuild: true
-  tags: ci_build ci_tests_benchmarks_multicore
+  tags:
+    - ci_build
+    - ci_tests_benchmarks_multicore
   required_snippets:
     - nordic-log-stm
   platform_allow:
@@ -29,12 +31,12 @@ tests:
 
   benchmarks.multicore.idle_stm.nrf54h20dk_cpuapp_cpurad_cpuppr.idle:
     extra_args:
-      idle_stm_CONF_FILE=prj_s2ram.conf
-      remote_rad_CONF_FILE=prj_s2ram.conf
-      remote_ppr_CONF_FILE=prj_s2ram.conf
-      idle_stm_CONFIG_TEST_SLEEP_DURATION_MS=500
-      remote_rad_CONFIG_TEST_SLEEP_DURATION_MS=500
-      remote_ppr_CONFIG_TEST_SLEEP_DURATION_MS=500
+      - idle_stm_CONF_FILE=prj_s2ram.conf
+      - remote_rad_CONF_FILE=prj_s2ram.conf
+      - remote_ppr_CONF_FILE=prj_s2ram.conf
+      - idle_stm_CONFIG_TEST_SLEEP_DURATION_MS=500
+      - remote_rad_CONFIG_TEST_SLEEP_DURATION_MS=500
+      - remote_ppr_CONFIG_TEST_SLEEP_DURATION_MS=500
     harness: console
     harness_config:
       type: multi_line
@@ -55,9 +57,9 @@ tests:
 
   benchmarks.multicore.idle_stm.nrf54h20dk_cpuapp_cpurad_cpuppr.s2ram:
     extra_args:
-      idle_stm_CONF_FILE=prj_s2ram.conf
-      remote_rad_CONF_FILE=prj_s2ram.conf
-      remote_ppr_CONF_FILE=prj_s2ram.conf
+      - idle_stm_CONF_FILE=prj_s2ram.conf
+      - remote_rad_CONF_FILE=prj_s2ram.conf
+      - remote_ppr_CONF_FILE=prj_s2ram.conf
     harness: console
     harness_config:
       type: multi_line

--- a/tests/benchmarks/multicore/idle_twim/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_twim/testcase.yaml
@@ -1,8 +1,11 @@
 common:
   sysbuild: true
   depends_on: i2c
-  tags: ci_build ci_tests_benchmarks_multicore twim ppk_power_measure
-
+  tags:
+    - ci_build
+    - ci_tests_benchmarks_multicore
+    - twim
+    - ppk_power_measure
 tests:
   benchmarks.multicore.idle_twim.nrf54h20dk_cpuapp_cpurad.s2ram:
     harness: pytest

--- a/tests/benchmarks/multicore/idle_uarte/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_uarte/testcase.yaml
@@ -1,8 +1,11 @@
 common:
   sysbuild: true
   depends_on: gpio
-  tags: ci_build ci_tests_benchmarks_multicore uarte ppk_power_measure
-
+  tags:
+    - ci_build
+    - ci_tests_benchmarks_multicore
+    - uarte
+    - ppk_power_measure
 tests:
   benchmarks.multicore.idle_uarte.nrf54h20dk_cpuapp_cpurad.s2ram:
     harness: pytest

--- a/tests/benchmarks/multicore/idle_usb/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_usb/testcase.yaml
@@ -1,8 +1,11 @@
 common:
   sysbuild: true
   depends_on: usbd
-  tags: ci_build ci_tests_benchmarks_multicore usb ppk_power_measure
-
+  tags:
+    - ci_build
+    - ci_tests_benchmarks_multicore
+    - usb
+    - ppk_power_measure
 tests:
   benchmarks.multicore.idle_usb.nrf54h20dk_cpuapp_cpurad.s2ram:
     harness: pytest

--- a/tests/benchmarks/multicore/idle_wdt/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_wdt/testcase.yaml
@@ -1,6 +1,8 @@
 common:
   sysbuild: true
-  tags: ci_build ci_tests_benchmarks_multicore
+  tags:
+    - ci_build
+    - ci_tests_benchmarks_multicore
   platform_allow:
     - nrf54h20dk/nrf54h20/cpuapp
   integration_platforms:
@@ -20,10 +22,10 @@ tests:
   benchmarks.multicore.idle_wdt.nrf54h20dk_cpuapp_cpurad.idle:
     tags: ppk_power_measure
     extra_args:
-      idle_wdt_CONF_FILE=prj_s2ram.conf
-      remote_CONF_FILE=prj_s2ram.conf
-      idle_wdt_CONFIG_TEST_SLEEP_DURATION_MS=500
-      remote_CONFIG_TEST_SLEEP_DURATION_MS=500
+      - idle_wdt_CONF_FILE=prj_s2ram.conf
+      - remote_CONF_FILE=prj_s2ram.conf
+      - idle_wdt_CONFIG_TEST_SLEEP_DURATION_MS=500
+      - remote_CONFIG_TEST_SLEEP_DURATION_MS=500
     harness: pytest
     harness_config:
       fixture: ppk_power_measure
@@ -33,8 +35,8 @@ tests:
   benchmarks.multicore.idle_wdt.nrf54h20dk_cpuapp_cpurad.s2ram:
     tags: ppk_power_measure
     extra_args:
-      idle_wdt_CONF_FILE=prj_s2ram.conf
-      remote_CONF_FILE=prj_s2ram.conf
+      - idle_wdt_CONF_FILE=prj_s2ram.conf
+      - remote_CONF_FILE=prj_s2ram.conf
     harness: pytest
     harness_config:
       fixture: ppk_power_measure

--- a/tests/benchmarks/peripheral_load/sample.yaml
+++ b/tests/benchmarks/peripheral_load/sample.yaml
@@ -2,8 +2,18 @@ sample:
   name: Peripheral stress test
 
 common:
-  depends_on: adc gpio i2c pwm spi watchdog
-  tags: drivers spi sensors ci_tests_benchmarks_peripheral_load
+  depends_on:
+    - adc
+    - gpio
+    - i2c
+    - pwm
+    - spi
+    - watchdog
+  tags:
+    - drivers
+    - spi
+    - sensors
+    - ci_tests_benchmarks_peripheral_load
   harness: console
 
 tests:

--- a/tests/benchmarks/power_consumption/adc/testcase.yaml
+++ b/tests/benchmarks/power_consumption/adc/testcase.yaml
@@ -1,6 +1,7 @@
 common:
-  tags: ppk_power_measure ci_tests_benchmarks_current_consumption
-
+  tags:
+    - ppk_power_measure
+    - ci_tests_benchmarks_current_consumption
 tests:
   benchmarks.power_consumption.adc_nrf54l:
     integration_platforms:
@@ -18,8 +19,7 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
-    extra_args:
-      SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
+    extra_args: SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
     harness: pytest
     harness_config:
       fixture: ppk_power_measure

--- a/tests/benchmarks/power_consumption/adc_async/testcase.yaml
+++ b/tests/benchmarks/power_consumption/adc_async/testcase.yaml
@@ -1,6 +1,7 @@
 common:
-  tags: ppk_power_measure ci_tests_benchmarks_current_consumption
-
+  tags:
+    - ppk_power_measure
+    - ci_tests_benchmarks_current_consumption
 tests:
   benchmarks.power_consumption.adc_async_nrf54l:
     integration_platforms:
@@ -18,8 +19,7 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
-    extra_args:
-      SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
+    extra_args: SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
     harness: pytest
     harness_config:
       fixture: ppk_power_measure

--- a/tests/benchmarks/power_consumption/flash/testcase.yaml
+++ b/tests/benchmarks/power_consumption/flash/testcase.yaml
@@ -1,6 +1,7 @@
 common:
-  tags: ppk_power_measure ci_tests_benchmarks_current_consumption
-
+  tags:
+    - ppk_power_measure
+    - ci_tests_benchmarks_current_consumption
 tests:
   benchmarks.power_consumption.flash_nrf54l:
     harness: pytest
@@ -18,8 +19,7 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
-    extra_args:
-      SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
+    extra_args: SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
     harness: pytest
     harness_config:
       fixture: ppk_power_measure

--- a/tests/benchmarks/power_consumption/gpio/testcase.yaml
+++ b/tests/benchmarks/power_consumption/gpio/testcase.yaml
@@ -1,6 +1,7 @@
 common:
-  tags: ppk_power_measure ci_tests_benchmarks_current_consumption
-
+  tags:
+    - ppk_power_measure
+    - ci_tests_benchmarks_current_consumption
 tests:
   benchmarks.power_consumption.gpio_nrf54l:
     integration_platforms:

--- a/tests/benchmarks/power_consumption/i2c/testcase.yaml
+++ b/tests/benchmarks/power_consumption/i2c/testcase.yaml
@@ -1,6 +1,7 @@
 common:
-  tags: ppk_power_measure ci_tests_benchmarks_current_consumption
-
+  tags:
+    - ppk_power_measure
+    - ci_tests_benchmarks_current_consumption
 tests:
   benchmarks.power_consumption.i2c_nrf54l:
     harness: pytest

--- a/tests/benchmarks/power_consumption/lpcomp/testcase.yaml
+++ b/tests/benchmarks/power_consumption/lpcomp/testcase.yaml
@@ -1,6 +1,7 @@
 common:
-  tags: ppk_power_measure ci_tests_benchmarks_current_consumption
-
+  tags:
+    - ppk_power_measure
+    - ci_tests_benchmarks_current_consumption
 tests:
   benchmarks.power_consumption.lpcomp_nrf54l:
     integration_platforms:
@@ -18,8 +19,7 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
-    extra_args:
-      SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
+    extra_args: SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
     harness: pytest
     harness_config:
       fixture: gpio_loopback

--- a/tests/benchmarks/power_consumption/qdec/testcase.yaml
+++ b/tests/benchmarks/power_consumption/qdec/testcase.yaml
@@ -1,6 +1,9 @@
 common:
   sysbuild: true
-  tags: ci_tests_benchmarks_current_consumption ppk_power_measure sensors
+  tags:
+    - ci_tests_benchmarks_current_consumption
+    - ppk_power_measure
+    - sensors
   harness: pytest
 
 tests:

--- a/tests/benchmarks/power_consumption/spi/testcase.yaml
+++ b/tests/benchmarks/power_consumption/spi/testcase.yaml
@@ -1,6 +1,8 @@
 common:
-  tags: ppk_power_measure ci_tests_benchmarks_current_consumption
+  tags:
 
+    - ppk_power_measure
+    - ci_tests_benchmarks_current_consumption
 tests:
   benchmarks.power_consumption.spi_nrf54l:
     harness: pytest

--- a/tests/benchmarks/power_consumption/timer_waiting/testcase.yaml
+++ b/tests/benchmarks/power_consumption/timer_waiting/testcase.yaml
@@ -1,6 +1,7 @@
 common:
-  tags: ppk_power_measure ci_tests_benchmarks_current_consumption
-
+  tags:
+    - ppk_power_measure
+    - ci_tests_benchmarks_current_consumption
 tests:
   benchmarks.power_consumption.timer_waiting_128M_nrf54l:
     integration_platforms:

--- a/tests/benchmarks/power_consumption/uart_async/testcase.yaml
+++ b/tests/benchmarks/power_consumption/uart_async/testcase.yaml
@@ -1,6 +1,8 @@
 common:
-  tags: ppk_power_measure ci_tests_benchmarks_current_consumption
+  tags:
 
+    - ppk_power_measure
+    - ci_tests_benchmarks_current_consumption
 tests:
   benchmarks.power_consumption.uart_async_nrf54l:
     integration_platforms:
@@ -18,8 +20,7 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
-    extra_args:
-      SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
+    extra_args: SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
     harness: pytest
     harness_config:
       fixture: ppk_power_measure

--- a/tests/benchmarks/power_consumption/uart_interrupt/testcase.yaml
+++ b/tests/benchmarks/power_consumption/uart_interrupt/testcase.yaml
@@ -1,6 +1,8 @@
 common:
-  tags: ppk_power_measure ci_tests_benchmarks_current_consumption
+  tags:
 
+    - ppk_power_measure
+    - ci_tests_benchmarks_current_consumption
 tests:
   benchmarks.power_consumption.uart_interrupt_nrf54l:
     integration_platforms:
@@ -18,8 +20,7 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
-    extra_args:
-      SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
+    extra_args: SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
     harness: pytest
     harness_config:
       fixture: ppk_power_measure

--- a/tests/benchmarks/power_consumption/uart_polling/testcase.yaml
+++ b/tests/benchmarks/power_consumption/uart_polling/testcase.yaml
@@ -1,6 +1,8 @@
 common:
-  tags: ppk_power_measure ci_tests_benchmarks_current_consumption
+  tags:
 
+    - ppk_power_measure
+    - ci_tests_benchmarks_current_consumption
 tests:
   benchmarks.power_consumption.uart_poll_nrf54l:
     integration_platforms:
@@ -18,8 +20,7 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
-    extra_args:
-      SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
+    extra_args: SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
     harness: pytest
     harness_config:
       fixture: ppk_power_measure

--- a/tests/benchmarks/spi_endless/testcase.yaml
+++ b/tests/benchmarks/spi_endless/testcase.yaml
@@ -1,6 +1,9 @@
 common:
   depends_on: spi
-  tags: drivers spi ci_tests_benchmarks_spi_endless
+  tags:
+    - drivers
+    - spi
+    - ci_tests_benchmarks_spi_endless
   harness: console
   harness_config:
     fixture: gpio_spi_bridge_two_boards

--- a/tests/bluetooth/iso/testcase.yaml
+++ b/tests/bluetooth/iso/testcase.yaml
@@ -2,9 +2,14 @@ tests:
   bluetooth.bis_and_acl:
     sysbuild: true
     build_only: true
-    platform_allow: nrf5340dk/nrf5340/cpuapp nrf5340_audio_dk/nrf5340/cpuapp
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340_audio_dk/nrf5340/cpuapp
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340_audio_dk/nrf5340/cpuapp
-    tags: bis_and_acl sysbuild bluetooth
+    tags:
+      - bis_and_acl
+      - sysbuild
+      - bluetooth
     timeout: 20

--- a/tests/bluetooth/tester/testcase.yaml
+++ b/tests/bluetooth/tester/testcase.yaml
@@ -2,8 +2,13 @@ tests:
   bluetooth.general.tester.build:
     sysbuild: true
     build_only: true
-    platform_allow: nrf52840dk/nrf52840 nrf54l15dk/nrf54l15/cpuapp
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp

--- a/tests/crypto/testcase.yaml
+++ b/tests/crypto/testcase.yaml
@@ -14,7 +14,13 @@ tests:
       - nrf9151dk/nrf9151
       - nrf9160dk/nrf9160
       - nrf9161dk/nrf9161
-    tags: crypto ci_build legacy cc3xx_legacy sysbuild ci_tests_crypto
+    tags:
+      - crypto
+      - ci_build
+      - legacy
+      - cc3xx_legacy
+      - sysbuild
+      - ci_tests_crypto
     harness_config:
       type: multi_line
       regex:
@@ -35,7 +41,13 @@ tests:
       - nrf9151dk/nrf9151
       - nrf9160dk/nrf9160
       - nrf9161dk/nrf9161
-    tags: crypto ci_build legacy oberon_legacy sysbuild ci_tests_crypto
+    tags:
+      - crypto
+      - ci_build
+      - legacy
+      - oberon_legacy
+      - sysbuild
+      - ci_tests_crypto
     harness_config:
       type: multi_line
       regex:

--- a/tests/drivers/audio/pdm_loopback/testcase.yaml
+++ b/tests/drivers/audio/pdm_loopback/testcase.yaml
@@ -10,43 +10,42 @@ tests:
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l20pdk/nrf54l20/cpuapp
-    extra_args:
-      CONFIG_NRFX_TIMER00=y
+    extra_args: CONFIG_NRFX_TIMER00=y
   drivers.audio.pdm_loopback.nrf54l.1280khz:
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l20pdk/nrf54l20/cpuapp
     extra_args:
-      CONFIG_NRFX_TIMER00=y
-      CONFIG_TEST_PDM_SAMPLING_RATE=16000
-      CONFIG_TEST_PDM_EXPECTED_FREQUENCY=1280000
+      - CONFIG_NRFX_TIMER00=y
+      - CONFIG_TEST_PDM_SAMPLING_RATE=16000
+      - CONFIG_TEST_PDM_EXPECTED_FREQUENCY=1280000
   drivers.audio.pdm_loopback.nrf54l.1600khz:
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l20pdk/nrf54l20/cpuapp
     extra_args:
-      CONFIG_NRFX_TIMER00=y
-      CONFIG_TEST_PDM_SAMPLING_RATE=32000
-      CONFIG_TEST_PDM_EXPECTED_FREQUENCY=1600000
+      - CONFIG_NRFX_TIMER00=y
+      - CONFIG_TEST_PDM_SAMPLING_RATE=32000
+      - CONFIG_TEST_PDM_EXPECTED_FREQUENCY=1600000
   drivers.audio.pdm_loopback.nrf54h20.1000khz:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
-      CONFIG_NRFX_TIMER130=y
-      CONFIG_TEST_PDM_SAMPLING_TIME=10
-      CONFIG_TEST_USE_DMM=y
+      - CONFIG_NRFX_TIMER130=y
+      - CONFIG_TEST_PDM_SAMPLING_TIME=10
+      - CONFIG_TEST_USE_DMM=y
   drivers.audio.pdm_loopback.nrf54h20.1600khz:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
-      CONFIG_NRFX_TIMER130=y
-      CONFIG_TEST_PDM_SAMPLING_RATE=16000
-      CONFIG_TEST_PDM_EXPECTED_FREQUENCY=1600000
-      CONFIG_TEST_PDM_SAMPLING_TIME=10
-      CONFIG_TEST_USE_DMM=y
+      - CONFIG_NRFX_TIMER130=y
+      - CONFIG_TEST_PDM_SAMPLING_RATE=16000
+      - CONFIG_TEST_PDM_EXPECTED_FREQUENCY=1600000
+      - CONFIG_TEST_PDM_SAMPLING_TIME=10
+      - CONFIG_TEST_USE_DMM=y
   drivers.audio.pdm_loopback.nrf54h20.no_dmm:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
-      CONFIG_NRFX_TIMER130=y
-      CONFIG_TEST_PDM_SAMPLING_TIME=10
+      - CONFIG_NRFX_TIMER130=y
+      - CONFIG_TEST_PDM_SAMPLING_TIME=10

--- a/tests/drivers/flash_patch/testcase.yaml
+++ b/tests/drivers/flash_patch/testcase.yaml
@@ -1,16 +1,24 @@
 tests:
   flash_patch.flash_patch_off:
     sysbuild: true
-    platform_allow: nrf52840dk/nrf52840 nrf52833dk/nrf52833
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52833dk/nrf52833
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf52833dk/nrf52833
-    tags: flash_patch sysbuild
+    tags:
+      - flash_patch
+      - sysbuild
     extra_args: CONFIG_DISABLE_FLASH_PATCH=n
   flash_patch.flash_patch_on:
     sysbuild: true
-    platform_allow: nrf52840dk/nrf52840 nrf52833dk/nrf52833
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52833dk/nrf52833
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf52833dk/nrf52833
-    tags: flash_patch sysbuild
+    tags:
+      - flash_patch
+      - sysbuild

--- a/tests/drivers/fprotect/app/testcase.yaml
+++ b/tests/drivers/fprotect/app/testcase.yaml
@@ -1,11 +1,18 @@
 tests:
   lib.fprotect.sys_init_fprotect:
     sysbuild: true
-    platform_allow: nrf9160dk/nrf9160 nrf52840dk/nrf52840 nrf52dk/nrf52832
-      nrf5340dk/nrf5340/cpuapp
+    platform_allow:
+      - nrf9160dk/nrf9160
+      - nrf52840dk/nrf52840
+      - nrf52dk/nrf52832
+      - nrf5340dk/nrf5340/cpuapp
     integration_platforms:
       - nrf9160dk/nrf9160
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
-    tags: b0 fprotect sysbuild ci_tests_drivers_fprotect
+    tags:
+      - b0
+      - fprotect
+      - sysbuild
+      - ci_tests_drivers_fprotect

--- a/tests/drivers/fprotect/negative/testcase.yaml
+++ b/tests/drivers/fprotect/negative/testcase.yaml
@@ -1,11 +1,19 @@
 tests:
   drivers.fprotect.negative:
     sysbuild: true
-    platform_allow: nrf9160dk/nrf9160 nrf52dk/nrf52832
-      nrf5340dk/nrf5340/cpuapp nrf52840dk/nrf52840
+    platform_allow:
+      - nrf9160dk/nrf9160
+      - nrf52dk/nrf52832
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf52840dk/nrf52840
     integration_platforms:
       - nrf9160dk/nrf9160
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
       - nrf52840dk/nrf52840
-    tags: b0 fprotect ignore_faults sysbuild ci_tests_drivers_fprotect
+    tags:
+      - b0
+      - fprotect
+      - ignore_faults
+      - sysbuild
+      - ci_tests_drivers_fprotect

--- a/tests/drivers/fprotect/positive/testcase.yaml
+++ b/tests/drivers/fprotect/positive/testcase.yaml
@@ -1,11 +1,18 @@
 tests:
   drivers.fprotect.positive:
     sysbuild: true
-    platform_allow: nrf9160dk/nrf9160 nrf52840dk/nrf52840 nrf52dk/nrf52832
-      nrf5340dk/nrf5340/cpuapp
+    platform_allow:
+      - nrf9160dk/nrf9160
+      - nrf52840dk/nrf52840
+      - nrf52dk/nrf52832
+      - nrf5340dk/nrf5340/cpuapp
     integration_platforms:
       - nrf9160dk/nrf9160
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
-    tags: b0 fprotect sysbuild ci_tests_drivers_fprotect
+    tags:
+      - b0
+      - fprotect
+      - sysbuild
+      - ci_tests_drivers_fprotect

--- a/tests/drivers/fprotect/storage/testcase.yaml
+++ b/tests/drivers/fprotect/storage/testcase.yaml
@@ -3,4 +3,7 @@ tests:
     platform_allow: nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
-    tags: b0 fprotect ci_tests_drivers_fprotect
+    tags:
+      - b0
+      - fprotect
+      - ci_tests_drivers_fprotect

--- a/tests/drivers/lpuart/testcase.yaml
+++ b/tests/drivers/lpuart/testcase.yaml
@@ -1,6 +1,9 @@
 common:
-  tags: lpuart sysbuild ci_tests_drivers_lpuart
+  tags:
 
+    - lpuart
+    - sysbuild
+    - ci_tests_drivers_lpuart
 tests:
   lpuart.loopback_busy_sim:
     sysbuild: true
@@ -83,7 +86,9 @@ tests:
       fixture: gpio_loopback
   lpuart.two_chip_test:
     sysbuild: true
-    platform_allow: nrf9160dk/nrf9160 nrf9160dk/nrf52840
+    platform_allow:
+      - nrf9160dk/nrf9160
+      - nrf9160dk/nrf52840
     integration_platforms:
       - nrf9160dk/nrf9160
       - nrf9160dk/nrf52840
@@ -92,7 +97,9 @@ tests:
       - CONFIG_TEST_LPUART_TIMEOUT=10
   lpuart.two_chip_test_busy_sim:
     sysbuild: true
-    platform_allow: nrf9160dk/nrf9160 nrf9160dk/nrf52840
+    platform_allow:
+      - nrf9160dk/nrf9160
+      - nrf9160dk/nrf52840
     integration_platforms:
       - nrf9160dk/nrf9160
       - nrf9160dk/nrf52840
@@ -102,7 +109,9 @@ tests:
       - CONFIG_TEST_BUSY_SIM=y
   lpuart.two_chip_test_debug:
     sysbuild: true
-    platform_allow: nrf9160dk/nrf9160 nrf9160dk/nrf52840
+    platform_allow:
+      - nrf9160dk/nrf9160
+      - nrf9160dk/nrf52840
     integration_platforms:
       - nrf9160dk/nrf9160
       - nrf9160dk/nrf52840

--- a/tests/drivers/nrfx_integration_test/testcase.yaml
+++ b/tests/drivers/nrfx_integration_test/testcase.yaml
@@ -3,7 +3,11 @@ tests:
     sysbuild: true
     build_only: true
     filter: CONFIG_HAS_NRFX
-    tags: drivers ci_build sysbuild ci_tests_drivers_nrfx_integration_test
+    tags:
+      - drivers
+      - ci_build
+      - sysbuild
+      - ci_tests_drivers_nrfx_integration_test
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf9160dk/nrf9160
@@ -28,7 +32,11 @@ tests:
     sysbuild: true
     build_only: true
     filter: CONFIG_HAS_NRFX and CONFIG_BT_LL_SOFTDEVICE
-    tags: drivers ci_build sysbuild ci_tests_drivers_nrfx_integration_test
+    tags:
+      - drivers
+      - ci_build
+      - sysbuild
+      - ci_tests_drivers_nrfx_integration_test
     extra_configs:
       - CONFIG_NRFX_AND_BT_LL_SOFTDEVICE=y
     platform_allow:
@@ -41,7 +49,11 @@ tests:
     sysbuild: true
     build_only: true
     filter: CONFIG_HAS_NRFX and CONFIG_BT_LL_SW_SPLIT
-    tags: drivers ci_build sysbuild ci_tests_drivers_nrfx_integration_test
+    tags:
+      - drivers
+      - ci_build
+      - sysbuild
+      - ci_tests_drivers_nrfx_integration_test
     extra_configs:
       - CONFIG_NRFX_AND_BT_LL_SW_SPLIT=y
     extra_args: SNIPPET="bt-ll-sw-split"

--- a/tests/drivers/pwm/gpio_loopback/testcase.yaml
+++ b/tests/drivers/pwm/gpio_loopback/testcase.yaml
@@ -24,18 +24,16 @@ tests:
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
-      DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_0.overlay"
-      CONFIG_TEST_PWM_PERIOD_USEC=10000
-
+      - DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_0.overlay"
+      - CONFIG_TEST_PWM_PERIOD_USEC=10000
   drivers.pwm.gpio_loopback.fast_p7_1:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
-      DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_1.overlay"
-      CONFIG_TEST_PWM_PERIOD_USEC=10000
-
+      - DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_1.overlay"
+      - CONFIG_TEST_PWM_PERIOD_USEC=10000
   drivers.pwm.gpio_loopback.fast_p7_6:
     build_only: true
     platform_allow:
@@ -43,9 +41,8 @@ tests:
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
-      DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_6.overlay"
-      CONFIG_TEST_PWM_PERIOD_USEC=10000
-
+      - DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_6.overlay"
+      - CONFIG_TEST_PWM_PERIOD_USEC=10000
   drivers.pwm.gpio_loopback.fast_p7_7:
     build_only: true
     platform_allow:
@@ -53,5 +50,5 @@ tests:
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
-      DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_7.overlay"
-      CONFIG_TEST_PWM_PERIOD_USEC=10000
+      - DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_7.overlay"
+      - CONFIG_TEST_PWM_PERIOD_USEC=10000

--- a/tests/lib/at_cmd_custom/testcase.yaml
+++ b/tests/lib/at_cmd_custom/testcase.yaml
@@ -4,4 +4,7 @@ tests:
     platform_allow: nrf9160dk/nrf9160/ns
     integration_platforms:
       - nrf9160dk/nrf9160/ns
-    tags: at_cmd_custom sysbuild ci_tests_lib_at_cmd_custom
+    tags:
+      - at_cmd_custom
+      - sysbuild
+      - ci_tests_lib_at_cmd_custom

--- a/tests/lib/at_cmd_parser/at_cmd_parser/testcase.yaml
+++ b/tests/lib/at_cmd_parser/at_cmd_parser/testcase.yaml
@@ -1,8 +1,13 @@
 tests:
   at_cmd_parser.at_cmd_parser:
     sysbuild: true
-    platform_allow: qemu_cortex_m3 native_sim
+    platform_allow:
+      - qemu_cortex_m3
+      - native_sim
     integration_platforms:
       - qemu_cortex_m3
       - native_sim
-    tags: at_cmd_parser sysbuild ci_tests_lib_at_cmd_parser
+    tags:
+      - at_cmd_parser
+      - sysbuild
+      - ci_tests_lib_at_cmd_parser

--- a/tests/lib/at_cmd_parser/at_params/testcase.yaml
+++ b/tests/lib/at_cmd_parser/at_params/testcase.yaml
@@ -1,8 +1,13 @@
 tests:
   at_cmd_parser.at_params:
     sysbuild: true
-    platform_allow: qemu_cortex_m3 native_sim
+    platform_allow:
+      - qemu_cortex_m3
+      - native_sim
     integration_platforms:
       - qemu_cortex_m3
       - native_sim
-    tags: at_cmd_parser sysbuild ci_tests_lib_at_cmd_parser
+    tags:
+      - at_cmd_parser
+      - sysbuild
+      - ci_tests_lib_at_cmd_parser

--- a/tests/lib/at_cmd_parser/at_utils/testcase.yaml
+++ b/tests/lib/at_cmd_parser/at_utils/testcase.yaml
@@ -1,8 +1,13 @@
 tests:
   at_cmd_parser.at_utils:
     sysbuild: true
-    platform_allow: qemu_cortex_m3 native_sim
+    platform_allow:
+      - qemu_cortex_m3
+      - native_sim
     integration_platforms:
       - qemu_cortex_m3
       - native_sim
-    tags: at_cmd_parser sysbuild ci_tests_lib_at_cmd_parser
+    tags:
+      - at_cmd_parser
+      - sysbuild
+      - ci_tests_lib_at_cmd_parser

--- a/tests/lib/at_parser/testcase.yaml
+++ b/tests/lib/at_parser/testcase.yaml
@@ -4,4 +4,6 @@ tests:
     platform_allow: native_sim
     integration_platforms:
       - native_sim
-    tags: at_parser ci_tests_lib_at_parser
+    tags:
+      - at_parser
+      - ci_tests_lib_at_parser

--- a/tests/lib/contin_array/testcase.yaml
+++ b/tests/lib/contin_array/testcase.yaml
@@ -4,4 +4,8 @@ tests:
     platform_allow: qemu_cortex_m3
     integration_platforms:
       - qemu_cortex_m3
-    tags: contin_array nrf5340_audio_unit_tests sysbuild ci_tests_lib_contin_array
+    tags:
+      - contin_array
+      - nrf5340_audio_unit_tests
+      - sysbuild
+      - ci_tests_lib_contin_array

--- a/tests/lib/data_fifo/testcase.yaml
+++ b/tests/lib/data_fifo/testcase.yaml
@@ -4,4 +4,8 @@ tests:
     platform_allow: qemu_cortex_m3
     integration_platforms:
       - qemu_cortex_m3
-    tags: data_fifo nrf5340_audio_unit_tests sysbuild ci_tests_lib_data_fifo
+    tags:
+      - data_fifo
+      - nrf5340_audio_unit_tests
+      - sysbuild
+      - ci_tests_lib_data_fifo

--- a/tests/lib/date_time/testcase.yaml
+++ b/tests/lib/date_time/testcase.yaml
@@ -4,7 +4,10 @@ tests:
     platform_allow: native_sim
     integration_platforms:
       - native_sim
-    tags: date_time_unity sysbuild ci_tests_lib_date_time_unity
+    tags:
+      - date_time_unity
+      - sysbuild
+      - ci_tests_lib_date_time_unity
   date_time.unit_test.no_modem_time:
     sysbuild: true
     platform_allow: native_sim
@@ -12,7 +15,10 @@ tests:
       - native_sim
     extra_configs:
       - CONFIG_DATE_TIME_MODEM=n
-    tags: date_time_unity sysbuild ci_tests_lib_date_time_unity
+    tags:
+      - date_time_unity
+      - sysbuild
+      - ci_tests_lib_date_time_unity
   date_time.unit_test.no_ntp_time:
     sysbuild: true
     platform_allow: native_sim
@@ -20,7 +26,10 @@ tests:
       - native_sim
     extra_configs:
       - CONFIG_DATE_TIME_NTP=n
-    tags: date_time_unity sysbuild ci_tests_lib_date_time_unity
+    tags:
+      - date_time_unity
+      - sysbuild
+      - ci_tests_lib_date_time_unity
   date_time.unit_test.no_modem_or_ntp_time:
     sysbuild: true
     platform_allow: native_sim
@@ -29,4 +38,7 @@ tests:
     extra_configs:
       - CONFIG_DATE_TIME_MODEM=n
       - CONFIG_DATE_TIME_NTP=n
-    tags: date_time_unity sysbuild ci_tests_lib_date_time_unity
+    tags:
+      - date_time_unity
+      - sysbuild
+      - ci_tests_lib_date_time_unity

--- a/tests/lib/edge_impulse/testcase.yaml
+++ b/tests/lib/edge_impulse/testcase.yaml
@@ -1,7 +1,9 @@
 tests:
   edge_impulse.ei_wrapper:
     sysbuild: true
-    platform_exclude: native_sim qemu_x86
+    platform_exclude:
+      - native_sim
+      - qemu_x86
     platform_allow:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
@@ -12,5 +14,8 @@ tests:
       - nrf52840dk/nrf52840
       - nrf9160dk/nrf9160/ns
       - qemu_cortex_m3
-    tags: edge_impulse sysbuild ci_tests_lib_edge_impulse
+    tags:
+      - edge_impulse
+      - sysbuild
+      - ci_tests_lib_edge_impulse
     timeout: 420

--- a/tests/lib/gcf_sms/testcase.yaml
+++ b/tests/lib/gcf_sms/testcase.yaml
@@ -4,4 +4,7 @@ tests:
     platform_allow: nrf9160dk/nrf9160/ns
     integration_platforms:
       - nrf9160dk/nrf9160/ns
-    tags: gcf_sms sysbuild ci_tests_lib_gcf_sms
+    tags:
+      - gcf_sms
+      - sysbuild
+      - ci_tests_lib_gcf_sms

--- a/tests/lib/hw_id/testcase.yaml
+++ b/tests/lib/hw_id/testcase.yaml
@@ -4,7 +4,10 @@ tests:
     integration_platforms:
       - native_sim
     platform_allow: native_sim
-    tags: ci_build sysbuild ci_tests_lib_hw_id
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_tests_lib_hw_id
     extra_args:
       - CONFIG_HW_ID_OVERRIDE_FILE="kconfig_override_device_id.h"
   hw_id.uuid:
@@ -12,7 +15,10 @@ tests:
     integration_platforms:
       - native_sim
     platform_allow: native_sim
-    tags: ci_build sysbuild ci_tests_lib_hw_id
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_tests_lib_hw_id
     extra_args:
       - CONFIG_HW_ID_OVERRIDE_FILE="kconfig_override_uuid.h"
   hw_id.imei:
@@ -20,7 +26,10 @@ tests:
     integration_platforms:
       - native_sim
     platform_allow: native_sim
-    tags: ci_build sysbuild ci_tests_lib_hw_id
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_tests_lib_hw_id
     extra_args:
       - CONFIG_HW_ID_OVERRIDE_FILE="kconfig_override_imei.h"
   hw_id.ble:
@@ -28,7 +37,10 @@ tests:
     integration_platforms:
       - native_sim
     platform_allow: native_sim
-    tags: ci_build sysbuild ci_tests_lib_hw_id
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_tests_lib_hw_id
     extra_args:
       - CONFIG_HW_ID_OVERRIDE_FILE="kconfig_override_ble.h"
   hw_id.net:
@@ -36,6 +48,9 @@ tests:
     integration_platforms:
       - native_sim
     platform_allow: native_sim
-    tags: ci_build sysbuild ci_tests_lib_hw_id
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_tests_lib_hw_id
     extra_args:
       - CONFIG_HW_ID_OVERRIDE_FILE="kconfig_override_net.h"

--- a/tests/lib/hw_unique_key/testcase.yaml
+++ b/tests/lib/hw_unique_key/testcase.yaml
@@ -1,9 +1,15 @@
 tests:
   lib.hw_unique_key:
     sysbuild: true
-    platform_allow: nrf9160dk/nrf9160 nrf5340dk/nrf5340/cpuapp nrf52840dk/nrf52840
+    platform_allow:
+      - nrf9160dk/nrf9160
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf52840dk/nrf52840
     integration_platforms:
       - nrf9160dk/nrf9160
       - nrf5340dk/nrf5340/cpuapp
       - nrf52840dk/nrf52840
-    tags: huk sysbuild ci_tests_lib_hw_unique_key
+    tags:
+      - huk
+      - sysbuild
+      - ci_tests_lib_hw_unique_key

--- a/tests/lib/hw_unique_key_tfm/testcase.yaml
+++ b/tests/lib/hw_unique_key_tfm/testcase.yaml
@@ -11,5 +11,8 @@ tests:
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
       - nrf5340dk/nrf5340/cpuapp/ns
-    tags: huk sysbuild ci_tests_lib_hw_unique_key_tfm
+    tags:
+      - huk
+      - sysbuild
+      - ci_tests_lib_hw_unique_key_tfm
     build_only: true

--- a/tests/lib/location/testcase.yaml
+++ b/tests/lib/location/testcase.yaml
@@ -1,13 +1,19 @@
 tests:
   unity.location_test:
     sysbuild: true
-    tags: location sysbuild ci_tests_lib_location
+    tags:
+      - location
+      - sysbuild
+      - ci_tests_lib_location
     platform_allow: native_sim
     integration_platforms:
       - native_sim
   unity.location_test.no_agnss:
     sysbuild: true
-    tags: location_no_agnss sysbuild ci_tests_lib_location
+    tags:
+      - location_no_agnss
+      - sysbuild
+      - ci_tests_lib_location
     platform_allow: native_sim
     integration_platforms:
       - native_sim
@@ -15,7 +21,10 @@ tests:
       - CONFIG_LOCATION_TEST_AGNSS=n
   unity.location_test.no_wifi:
     sysbuild: true
-    tags: location_no_wifi sysbuild ci_tests_lib_location
+    tags:
+      - location_no_wifi
+      - sysbuild
+      - ci_tests_lib_location
     platform_allow: native_sim
     integration_platforms:
       - native_sim
@@ -23,7 +32,10 @@ tests:
       - CONFIG_LOCATION_METHOD_WIFI=n
   unity.location_test.service_external:
     sysbuild: true
-    tags: location_service_external sysbuild ci_tests_lib_location
+    tags:
+      - location_service_external
+      - sysbuild
+      - ci_tests_lib_location
     platform_allow: native_sim
     integration_platforms:
       - native_sim
@@ -33,7 +45,10 @@ tests:
       - CONFIG_LOCATION_SERVICE_HERE_API_KEY=""
   unity.location_test.data_details:
     sysbuild: true
-    tags: location_data_details sysbuild ci_tests_lib_location
+    tags:
+      - location_data_details
+      - sysbuild
+      - ci_tests_lib_location
     platform_allow: native_sim
     integration_platforms:
       - native_sim

--- a/tests/lib/lte_lc_api/testcase.yaml
+++ b/tests/lib/lte_lc_api/testcase.yaml
@@ -1,7 +1,10 @@
 tests:
   unity.lte_lc_api_test:
     sysbuild: true
-    tags: lte_lc_api sysbuild ci_tests_lib_lte_lc
+    tags:
+      - lte_lc_api
+      - sysbuild
+      - ci_tests_lib_lte_lc
     platform_allow: native_sim
     integration_platforms:
       - native_sim

--- a/tests/lib/modem_battery/testcase.yaml
+++ b/tests/lib/modem_battery/testcase.yaml
@@ -1,7 +1,10 @@
 tests:
   modem_battery.unit_test:
     sysbuild: true
-    tags: modem_battery sysbuild ci_tests_lib_modem_battery
+    tags:
+      - modem_battery
+      - sysbuild
+      - ci_tests_lib_modem_battery
     platform_allow: native_sim
     integration_platforms:
       - native_sim

--- a/tests/lib/modem_info/testcase.yaml
+++ b/tests/lib/modem_info/testcase.yaml
@@ -1,7 +1,10 @@
 tests:
   modem_info.unit_test:
     sysbuild: true
-    tags: modem_info sysbuild ci_tests_lib_modem_info
+    tags:
+      - modem_info
+      - sysbuild
+      - ci_tests_lib_modem_info
     platform_allow: native_sim
     integration_platforms:
       - native_sim

--- a/tests/lib/modem_jwt/testcase.yaml
+++ b/tests/lib/modem_jwt/testcase.yaml
@@ -1,8 +1,13 @@
 tests:
   unity.modem_jwt:
     sysbuild: true
-    platform_allow: qemu_cortex_m3 native_sim
+    platform_allow:
+      - qemu_cortex_m3
+      - native_sim
     integration_platforms:
       - qemu_cortex_m3
       - native_sim
-    tags: jwt sysbuild ci_tests_lib_modem_jwt
+    tags:
+      - jwt
+      - sysbuild
+      - ci_tests_lib_modem_jwt

--- a/tests/lib/nrf_fuel_gauge/testcase.yaml
+++ b/tests/lib/nrf_fuel_gauge/testcase.yaml
@@ -1,23 +1,36 @@
 tests:
   unity.nrf_fuel_gauge_no_fpu:
     sysbuild: true
-    platform_allow: nrf5340dk/nrf5340/cpuapp nrf52840dk/nrf52840 nrf52dk/nrf52832 nrf52dk/nrf52810
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf52840dk/nrf52840
+      - nrf52dk/nrf52832
+      - nrf52dk/nrf52810
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
       - nrf52dk/nrf52810
-    tags: nrf_fuel_gauge sysbuild ci_tests_lib_nrf_fuel_gauge
+    tags:
+      - nrf_fuel_gauge
+      - sysbuild
+      - ci_tests_lib_nrf_fuel_gauge
     build_only: true
     extra_args: CONFIG_FPU=n
   unity.nrf_fuel_gauge_fpu:
     sysbuild: true
-    platform_allow: nrf5340dk/nrf5340/cpuapp nrf52840dk/nrf52840 nrf52dk/nrf52832
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf52840dk/nrf52840
+      - nrf52dk/nrf52832
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
-    tags: nrf_fuel_gauge sysbuild ci_tests_lib_nrf_fuel_gauge
+    tags:
+      - nrf_fuel_gauge
+      - sysbuild
+      - ci_tests_lib_nrf_fuel_gauge
     build_only: true
     extra_args: CONFIG_FPU=y
   unity.nrf_fuel_gauge_qemu:
@@ -25,5 +38,8 @@ tests:
     platform_allow: qemu_cortex_m3
     integration_platforms:
       - qemu_cortex_m3
-    tags: nrf_fuel_gauge sysbuild ci_tests_lib_nrf_fuel_gauge
+    tags:
+      - nrf_fuel_gauge
+      - sysbuild
+      - ci_tests_lib_nrf_fuel_gauge
     build_only: false

--- a/tests/lib/nrf_modem_lib/lte_net_if/testcase.yaml
+++ b/tests/lib/nrf_modem_lib/lte_net_if/testcase.yaml
@@ -1,7 +1,10 @@
 tests:
   nrf_modem_lib.lte_net_if:
     sysbuild: true
-    tags: nrf_modem_lib sysbuild ci_tests_lib_nrf_modem_lib
+    tags:
+      - nrf_modem_lib
+      - sysbuild
+      - ci_tests_lib_nrf_modem_lib
     platform_allow:
       - native_sim
     integration_platforms:

--- a/tests/lib/nrf_modem_lib/nrf9x_sockets/testcase.yaml
+++ b/tests/lib/nrf_modem_lib/nrf9x_sockets/testcase.yaml
@@ -1,7 +1,10 @@
 tests:
   unity.nrf9x_sockets_test:
     sysbuild: true
-    tags: nrf_modem_lib sysbuild ci_tests_lib_nrf_modem_lib
+    tags:
+      - nrf_modem_lib
+      - sysbuild
+      - ci_tests_lib_nrf_modem_lib
     platform_allow:
       - native_sim
     integration_platforms:

--- a/tests/lib/nrf_modem_lib/nrf_modem_lib_trace/testcase.yaml
+++ b/tests/lib/nrf_modem_lib/nrf_modem_lib_trace/testcase.yaml
@@ -4,4 +4,8 @@ tests:
     platform_allow: qemu_cortex_m3
     integration_platforms:
       - qemu_cortex_m3
-    tags: nrf_modem_lib modem_trace sysbuild ci_tests_lib_nrf_modem_lib
+    tags:
+      - nrf_modem_lib
+      - modem_trace
+      - sysbuild
+      - ci_tests_lib_nrf_modem_lib

--- a/tests/lib/nrf_modem_lib/trace_backends/rtt/testcase.yaml
+++ b/tests/lib/nrf_modem_lib/trace_backends/rtt/testcase.yaml
@@ -4,4 +4,8 @@ tests:
     platform_allow: qemu_cortex_m3
     integration_platforms:
       - qemu_cortex_m3
-    tags: nrf_modem_lib modem_trace sysbuild ci_tests_lib_nrf_modem_lib
+    tags:
+      - nrf_modem_lib
+      - modem_trace
+      - sysbuild
+      - ci_tests_lib_nrf_modem_lib

--- a/tests/lib/pcm_mix/testcase.yaml
+++ b/tests/lib/pcm_mix/testcase.yaml
@@ -4,4 +4,8 @@ tests:
     platform_allow: qemu_cortex_m3
     integration_platforms:
       - qemu_cortex_m3
-    tags: pcm_mix nrf5340_audio_unit_tests sysbuild ci_tests_lib_pcm_mix
+    tags:
+      - pcm_mix
+      - nrf5340_audio_unit_tests
+      - sysbuild
+      - ci_tests_lib_pcm_mix

--- a/tests/lib/pdn/testcase.yaml
+++ b/tests/lib/pdn/testcase.yaml
@@ -1,7 +1,10 @@
 tests:
   pdn.unit_test:
     sysbuild: true
-    tags: modem_info sysbuild ci_tests_lib_pdn
+    tags:
+      - modem_info
+      - sysbuild
+      - ci_tests_lib_pdn
     platform_allow: native_sim
     integration_platforms:
       - native_sim

--- a/tests/lib/qos/testcase.yaml
+++ b/tests/lib/qos/testcase.yaml
@@ -1,8 +1,13 @@
 tests:
   unity.qos:
     sysbuild: true
-    platform_allow: qemu_cortex_m3 native_sim
+    platform_allow:
+      - qemu_cortex_m3
+      - native_sim
     integration_platforms:
       - qemu_cortex_m3
       - native_sim
-    tags: qos sysbuild ci_tests_lib_qos
+    tags:
+      - qos
+      - sysbuild
+      - ci_tests_lib_qos

--- a/tests/lib/ram_pwrdn/testcase.yaml
+++ b/tests/lib/ram_pwrdn/testcase.yaml
@@ -4,4 +4,7 @@ tests:
     platform_allow: nrf52840dk/nrf52840
     integration_platforms:
       - nrf52840dk/nrf52840
-    tags: ram_pwrdn sysbuild ci_tests_lib_ram_pwrdn
+    tags:
+      - ram_pwrdn
+      - sysbuild
+      - ci_tests_lib_ram_pwrdn

--- a/tests/lib/sample_rate_converter/testcase.yaml
+++ b/tests/lib/sample_rate_converter/testcase.yaml
@@ -4,4 +4,8 @@ tests:
     platform_allow: qemu_cortex_m3
     integration_platforms:
       - qemu_cortex_m3
-    tags: sample_rate_converter nrf5340_audio_unit_tests sysbuild ci_tests_lib_sample_rate_converter
+    tags:
+      - sample_rate_converter
+      - nrf5340_audio_unit_tests
+      - sysbuild
+      - ci_tests_lib_sample_rate_converter

--- a/tests/lib/sfloat/testcase.yaml
+++ b/tests/lib/sfloat/testcase.yaml
@@ -2,9 +2,14 @@ tests:
   lib.sfloat:
     sysbuild: true
     platform_allow:
-      nrf52dk/nrf52832 nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
-    tags: sfloat sysbuild ci_tests_lib_sfloat
+    tags:
+      - sfloat
+      - sysbuild
+      - ci_tests_lib_sfloat

--- a/tests/lib/sms/testcase.yaml
+++ b/tests/lib/sms/testcase.yaml
@@ -1,13 +1,19 @@
 tests:
   unity.sms_test:
     sysbuild: true
-    tags: sms sysbuild ci_tests_lib_sms
+    tags:
+      - sms
+      - sysbuild
+      - ci_tests_lib_sms
     platform_allow: native_sim
     integration_platforms:
       - native_sim
   unity.sms_test.no_status_report:
     sysbuild: true
-    tags: sms sysbuild ci_tests_lib_sms
+    tags:
+      - sms
+      - sysbuild
+      - ci_tests_lib_sms
     platform_allow: native_sim
     integration_platforms:
       - native_sim

--- a/tests/lib/tone/testcase.yaml
+++ b/tests/lib/tone/testcase.yaml
@@ -4,4 +4,8 @@ tests:
     platform_allow: qemu_cortex_m3
     integration_platforms:
       - qemu_cortex_m3
-    tags: tone nrf5340_audio_unit_tests sysbuild ci_tests_lib_tone
+    tags:
+      - tone
+      - nrf5340_audio_unit_tests
+      - sysbuild
+      - ci_tests_lib_tone

--- a/tests/lib/uicc_lwm2m/testcase.yaml
+++ b/tests/lib/uicc_lwm2m/testcase.yaml
@@ -1,7 +1,10 @@
 tests:
   uicc_lwm2m.unit_test:
     sysbuild: true
-    tags: uicc_lwm2m sysbuild ci_tests_lib_uicc_lwm2m
+    tags:
+      - uicc_lwm2m
+      - sysbuild
+      - ci_tests_lib_uicc_lwm2m
     platform_allow: native_sim
     integration_platforms:
       - native_sim

--- a/tests/modules/lib/zcbor/decode/testcase.yaml
+++ b/tests/modules/lib/zcbor/decode/testcase.yaml
@@ -1,7 +1,10 @@
 tests:
   modules.lib.zcbor.decode:
     sysbuild: true
-    tags: zcbor sysbuild ci_tests_modules_lib_zcbor
+    tags:
+      - zcbor
+      - sysbuild
+      - ci_tests_modules_lib_zcbor
     platform_allow: native_sim
     integration_platforms:
       - native_sim

--- a/tests/modules/lib/zcbor/encode/testcase.yaml
+++ b/tests/modules/lib/zcbor/encode/testcase.yaml
@@ -1,7 +1,10 @@
 tests:
   modules.lib.zcbor.encode:
     sysbuild: true
-    tags: zcbor sysbuild ci_tests_modules_lib_zcbor
+    tags:
+      - zcbor
+      - sysbuild
+      - ci_tests_modules_lib_zcbor
     platform_allow: native_sim
     integration_platforms:
       - native_sim

--- a/tests/modules/lib/zcbor/raw_encode/testcase.yaml
+++ b/tests/modules/lib/zcbor/raw_encode/testcase.yaml
@@ -1,7 +1,10 @@
 tests:
   modules.lib.zcbor.raw_encode:
     sysbuild: true
-    tags: zcbor sysbuild ci_tests_modules_lib_zcbor
+    tags:
+      - zcbor
+      - sysbuild
+      - ci_tests_modules_lib_zcbor
     platform_allow: native_sim
     integration_platforms:
       - native_sim

--- a/tests/modules/mcuboot/direct_xip/testcase.yaml
+++ b/tests/modules/mcuboot/direct_xip/testcase.yaml
@@ -1,9 +1,16 @@
 tests:
   mcuboot.direct_xip:
     sysbuild: true
-    tags: mcuboot direct_xip sysbuild ci_tests_modules_mcuboot
-    platform_allow: nrf9160dk/nrf9160 nrf52840dk/nrf52840 nrf52dk/nrf52832
-      nrf5340dk/nrf5340/cpuapp
+    tags:
+      - mcuboot
+      - direct_xip
+      - sysbuild
+      - ci_tests_modules_mcuboot
+    platform_allow:
+      - nrf9160dk/nrf9160
+      - nrf52840dk/nrf52840
+      - nrf52dk/nrf52832
+      - nrf5340dk/nrf5340/cpuapp
     integration_platforms:
       - nrf9160dk/nrf9160
       - nrf52840dk/nrf52840
@@ -12,9 +19,17 @@ tests:
   # Deprecated child and parent build to ensure feature does not break until it is removed
   mcuboot.direct_xip.child_parent:
     sysbuild: false
-    tags: mcuboot direct_xip child_parent deprecated ci_tests_modules_mcuboot
-    platform_allow: nrf9160dk/nrf9160 nrf52840dk/nrf52840 nrf52dk/nrf52832
-      nrf5340dk/nrf5340/cpuapp
+    tags:
+      - mcuboot
+      - direct_xip
+      - child_parent
+      - deprecated
+      - ci_tests_modules_mcuboot
+    platform_allow:
+      - nrf9160dk/nrf9160
+      - nrf52840dk/nrf52840
+      - nrf52dk/nrf52832
+      - nrf5340dk/nrf5340/cpuapp
     integration_platforms:
       - nrf9160dk/nrf9160
       - nrf52840dk/nrf52840

--- a/tests/modules/mcuboot/external_flash/testcase.yaml
+++ b/tests/modules/mcuboot/external_flash/testcase.yaml
@@ -1,8 +1,15 @@
 tests:
   mcuboot.external_flash:
     sysbuild: true
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp thingy53/nrf5340/cpuapp
-    tags: mcuboot external_flash sysbuild ci_tests_modules_mcuboot
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - thingy53/nrf5340/cpuapp
+    tags:
+      - mcuboot
+      - external_flash
+      - sysbuild
+      - ci_tests_modules_mcuboot
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
@@ -10,8 +17,16 @@ tests:
   # Deprecated child and parent build to ensure feature does not break until it is removed
   mcuboot.external_flash.child_parent:
     sysbuild: false
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp thingy53/nrf5340/cpuapp
-    tags: mcuboot external_flash child_parent deprecated ci_tests_modules_mcuboot
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - thingy53/nrf5340/cpuapp
+    tags:
+      - mcuboot
+      - external_flash
+      - child_parent
+      - deprecated
+      - ci_tests_modules_mcuboot
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp

--- a/tests/nrf5340_audio/lc3_file/testcase.yaml
+++ b/tests/nrf5340_audio/lc3_file/testcase.yaml
@@ -4,4 +4,8 @@ tests:
     platform_allow: qemu_cortex_m3
     integration_platforms:
       - qemu_cortex_m3
-    tags: lc3_file nrf5340_audio_unit_tests sysbuild ci_tests_nrf5340_audio
+    tags:
+      - lc3_file
+      - nrf5340_audio_unit_tests
+      - sysbuild
+      - ci_tests_nrf5340_audio

--- a/tests/nrf5340_audio/lc3_streamer/testcase.yaml
+++ b/tests/nrf5340_audio/lc3_streamer/testcase.yaml
@@ -4,4 +4,8 @@ tests:
     platform_allow: qemu_cortex_m3
     integration_platforms:
       - qemu_cortex_m3
-    tags: lc3_streamer nrf5340_audio_unit_tests sysbuild ci_tests_nrf5340_audio
+    tags:
+      - lc3_streamer
+      - nrf5340_audio_unit_tests
+      - sysbuild
+      - ci_tests_nrf5340_audio

--- a/tests/nrf5340_audio/macros/testcase.yaml
+++ b/tests/nrf5340_audio/macros/testcase.yaml
@@ -4,4 +4,9 @@ tests:
     platform_allow: qemu_cortex_m3
     integration_platforms:
       - qemu_cortex_m3
-    tags: macros ignore_faults nrf5340_audio_unit_tests sysbuild ci_tests_nrf5340_audio
+    tags:
+      - macros
+      - ignore_faults
+      - nrf5340_audio_unit_tests
+      - sysbuild
+      - ci_tests_nrf5340_audio

--- a/tests/nrf5340_audio/sd_card/testcase.yaml
+++ b/tests/nrf5340_audio/sd_card/testcase.yaml
@@ -4,6 +4,10 @@ tests:
     platform_allow: native_sim
     integration_platforms:
       - native_sim
-    tags: macros nrf5340_audio_unit_tests sysbuild ci_tests_nrf5340_audio
+    tags:
+      - macros
+      - nrf5340_audio_unit_tests
+      - sysbuild
+      - ci_tests_nrf5340_audio
     extra_args:
       - EXTRA_DTC_OVERLAY_FILE="ramdisk.overlay"

--- a/tests/nrf5340_audio/sw_codec_lc3/testcase.yaml
+++ b/tests/nrf5340_audio/sw_codec_lc3/testcase.yaml
@@ -1,9 +1,14 @@
 tests:
   nrf5340_audio.sw_codec_lc3_test:
     sysbuild: true
-    platform_allow: nrf5340dk/nrf5340/cpuapp nrf5340_audio_dk/nrf5340/cpuapp
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340_audio_dk/nrf5340/cpuapp
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340_audio_dk/nrf5340/cpuapp
-    tags: sw_codec_lc3 sysbuild ci_tests_nrf5340_audio
+    tags:
+      - sw_codec_lc3
+      - sysbuild
+      - ci_tests_nrf5340_audio
     timeout: 20

--- a/tests/psa_crypto/testcase.yaml
+++ b/tests/psa_crypto/testcase.yaml
@@ -5,7 +5,11 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
 
-    tags: tfm psa_crypto sysbuild ci_tests_tfm
+    tags:
+      - tfm
+      - psa_crypto
+      - sysbuild
+      - ci_tests_tfm
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns

--- a/tests/subsys/app_event_manager/testcase.yaml
+++ b/tests/subsys/app_event_manager/testcase.yaml
@@ -11,7 +11,10 @@ tests:
       - nrf52840dk/nrf52840
       - nrf9160dk/nrf9160/ns
       - qemu_cortex_m3
-    tags: app_event_manager sysbuild ci_tests_subsys_app_event_manager
+    tags:
+      - app_event_manager
+      - sysbuild
+      - ci_tests_subsys_app_event_manager
   app_event_manager.size_enabled:
     sysbuild: true
     extra_args: OVERLAY_CONFIG=overlay-event_size.conf
@@ -25,4 +28,7 @@ tests:
       - nrf52840dk/nrf52840
       - nrf9160dk/nrf9160/ns
       - qemu_cortex_m3
-    tags: app_event_manager sysbuild ci_tests_subsys_app_event_manager
+    tags:
+      - app_event_manager
+      - sysbuild
+      - ci_tests_subsys_app_event_manager

--- a/tests/subsys/audio_module/testcase.yaml
+++ b/tests/subsys/audio_module/testcase.yaml
@@ -4,4 +4,8 @@ tests:
     platform_allow: qemu_cortex_m3
     integration_platforms:
       - qemu_cortex_m3
-    tags: audio_module nrf5340_audio_unit_tests sysbuild ci_tests_subsys_audio_module
+    tags:
+      - audio_module
+      - nrf5340_audio_unit_tests
+      - sysbuild
+      - ci_tests_subsys_audio_module

--- a/tests/subsys/bluetooth/enocean/testcase.yaml
+++ b/tests/subsys/bluetooth/enocean/testcase.yaml
@@ -1,7 +1,11 @@
 tests:
   bluetooth.enocean:
-    platform_allow: native_sim qemu_cortex_m3
-    tags: bluetooth ci_build
+    platform_allow:
+      - native_sim
+      - qemu_cortex_m3
+    tags:
+      - bluetooth
+      - ci_build
     integration_platforms:
       - native_sim
       - qemu_cortex_m3

--- a/tests/subsys/bluetooth/fast_pair/crypto/testcase.yaml
+++ b/tests/subsys/bluetooth/fast_pair/crypto/testcase.yaml
@@ -15,7 +15,9 @@ tests:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    tags: sysbuild bluetooth
+    tags:
+      - sysbuild
+      - bluetooth
   fast_pair.crypto.psa:
     sysbuild: true
     platform_allow:
@@ -35,7 +37,9 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp/ns
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args: FILE_SUFFIX=psa
-    tags: sysbuild bluetooth
+    tags:
+      - sysbuild
+      - bluetooth
   fast_pair.crypto.tinycrypt:
     sysbuild: true
     platform_allow:
@@ -55,4 +59,6 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
       - qemu_cortex_m3
     extra_args: FILE_SUFFIX=tinycrypt
-    tags: sysbuild bluetooth
+    tags:
+      - sysbuild
+      - bluetooth

--- a/tests/subsys/bluetooth/fast_pair/storage/account_key_storage/testcase.yaml
+++ b/tests/subsys/bluetooth/fast_pair/storage/account_key_storage/testcase.yaml
@@ -17,7 +17,9 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
       - qemu_cortex_m3
-    tags: sysbuild bluetooth
+    tags:
+      - sysbuild
+      - bluetooth
   fast_pair.storage.account_key_storage.6keys:
     sysbuild: true
     platform_allow:
@@ -25,7 +27,9 @@ tests:
     integration_platforms:
       - qemu_cortex_m3
     extra_args: CONFIG_BT_FAST_PAIR_STORAGE_ACCOUNT_KEY_MAX=6
-    tags: sysbuild bluetooth
+    tags:
+      - sysbuild
+      - bluetooth
   fast_pair.storage.account_key_storage.7keys:
     sysbuild: true
     platform_allow:
@@ -33,7 +37,9 @@ tests:
     integration_platforms:
       - qemu_cortex_m3
     extra_args: CONFIG_BT_FAST_PAIR_STORAGE_ACCOUNT_KEY_MAX=7
-    tags: sysbuild bluetooth
+    tags:
+      - sysbuild
+      - bluetooth
   fast_pair.storage.account_key_storage.8keys:
     sysbuild: true
     platform_allow:
@@ -41,7 +47,9 @@ tests:
     integration_platforms:
       - qemu_cortex_m3
     extra_args: CONFIG_BT_FAST_PAIR_STORAGE_ACCOUNT_KEY_MAX=8
-    tags: sysbuild bluetooth
+    tags:
+      - sysbuild
+      - bluetooth
   fast_pair.storage.account_key_storage.9keys:
     sysbuild: true
     platform_allow:
@@ -49,7 +57,9 @@ tests:
     integration_platforms:
       - qemu_cortex_m3
     extra_args: CONFIG_BT_FAST_PAIR_STORAGE_ACCOUNT_KEY_MAX=9
-    tags: sysbuild bluetooth
+    tags:
+      - sysbuild
+      - bluetooth
   fast_pair.storage.account_key_storage.10keys:
     sysbuild: true
     platform_allow:
@@ -57,7 +67,9 @@ tests:
     integration_platforms:
       - qemu_cortex_m3
     extra_args: CONFIG_BT_FAST_PAIR_STORAGE_ACCOUNT_KEY_MAX=10
-    tags: sysbuild bluetooth
+    tags:
+      - sysbuild
+      - bluetooth
   fast_pair.storage.account_key_storage.minimal:
     sysbuild: true
     platform_allow:
@@ -77,4 +89,6 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
       - qemu_cortex_m3
     extra_args: CONFIG_TEST_BT_FAST_PAIR_STORAGE_OWNER_ACCOUNT_KEY=y
-    tags: sysbuild bluetooth
+    tags:
+      - sysbuild
+      - bluetooth

--- a/tests/subsys/bluetooth/fast_pair/storage/factory_reset/testcase.yaml
+++ b/tests/subsys/bluetooth/fast_pair/storage/factory_reset/testcase.yaml
@@ -16,7 +16,9 @@ tests:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
-    tags: sysbuild bluetooth
+    tags:
+      - sysbuild
+      - bluetooth
   fast_pair.storage.factory_reset.no_reboot:
     sysbuild: true
     platform_allow:
@@ -26,7 +28,9 @@ tests:
       - native_sim
       - nrf52840dk/nrf52840
     extra_args: CONFIG_REBOOT=n
-    tags: sysbuild bluetooth
+    tags:
+      - sysbuild
+      - bluetooth
   fast_pair.storage.factory_reset.6keys:
     sysbuild: true
     platform_exclude: native_sim
@@ -35,7 +39,9 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
     extra_args: CONFIG_BT_FAST_PAIR_STORAGE_ACCOUNT_KEY_MAX=6
-    tags: sysbuild bluetooth
+    tags:
+      - sysbuild
+      - bluetooth
   fast_pair.storage.factory_reset.7keys:
     sysbuild: true
     platform_exclude: native_sim
@@ -44,7 +50,9 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
     extra_args: CONFIG_BT_FAST_PAIR_STORAGE_ACCOUNT_KEY_MAX=7
-    tags: sysbuild bluetooth
+    tags:
+      - sysbuild
+      - bluetooth
   fast_pair.storage.factory_reset.8keys:
     sysbuild: true
     platform_exclude: native_sim
@@ -53,7 +61,9 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
     extra_args: CONFIG_BT_FAST_PAIR_STORAGE_ACCOUNT_KEY_MAX=8
-    tags: sysbuild bluetooth
+    tags:
+      - sysbuild
+      - bluetooth
   fast_pair.storage.factory_reset.9keys:
     sysbuild: true
     platform_exclude: native_sim
@@ -62,7 +72,9 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
     extra_args: CONFIG_BT_FAST_PAIR_STORAGE_ACCOUNT_KEY_MAX=9
-    tags: sysbuild bluetooth
+    tags:
+      - sysbuild
+      - bluetooth
   fast_pair.storage.factory_reset.10keys:
     sysbuild: true
     platform_exclude: native_sim
@@ -71,7 +83,9 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
     extra_args: CONFIG_BT_FAST_PAIR_STORAGE_ACCOUNT_KEY_MAX=10
-    tags: sysbuild bluetooth
+    tags:
+      - sysbuild
+      - bluetooth
   fast_pair.storage.factory_reset.ak_minimal_backend:
     sysbuild: true
     platform_exclude: native_sim
@@ -90,7 +104,9 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args: CONFIG_TEST_BT_FAST_PAIR_STORAGE_OWNER_ACCOUNT_KEY=y
-    tags: sysbuild bluetooth
+    tags:
+      - sysbuild
+      - bluetooth
   fast_pair.storage.factory_reset.ak_minimal_backend_no_reboot:
     sysbuild: true
     platform_allow:
@@ -99,5 +115,9 @@ tests:
     integration_platforms:
       - native_sim
       - nrf52840dk/nrf52840
-    extra_args: CONFIG_TEST_BT_FAST_PAIR_STORAGE_OWNER_ACCOUNT_KEY=y CONFIG_REBOOT=n
-    tags: sysbuild bluetooth
+    extra_args:
+      - CONFIG_TEST_BT_FAST_PAIR_STORAGE_OWNER_ACCOUNT_KEY=y
+      - CONFIG_REBOOT=n
+    tags:
+      - sysbuild
+      - bluetooth

--- a/tests/subsys/bluetooth/gatt_dm/testcase.yaml
+++ b/tests/subsys/bluetooth/gatt_dm/testcase.yaml
@@ -1,8 +1,13 @@
 tests:
   bluetooth.gatt_dm:
     sysbuild: true
-    platform_allow: native_sim nrf52840dk/nrf52840
+    platform_allow:
+      - native_sim
+      - nrf52840dk/nrf52840
     integration_platforms:
       - native_sim
       - nrf52840dk/nrf52840
-    tags: discovery_manager sysbuild bluetooth
+    tags:
+      - discovery_manager
+      - sysbuild
+      - bluetooth

--- a/tests/subsys/bluetooth/mesh/light_ctrl/testcase.yaml
+++ b/tests/subsys/bluetooth/mesh/light_ctrl/testcase.yaml
@@ -1,7 +1,12 @@
 tests:
   bluetooth.mesh.light_ctrl:
     sysbuild: true
-    platform_allow: native_sim qemu_cortex_m3
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - native_sim
+      - qemu_cortex_m3
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
     integration_platforms:
       - qemu_cortex_m3

--- a/tests/subsys/bluetooth/mesh/light_hue/testcase.yaml
+++ b/tests/subsys/bluetooth/mesh/light_hue/testcase.yaml
@@ -1,7 +1,12 @@
 tests:
   bluetooth.mesh.light_hue:
     sysbuild: true
-    platform_allow: native_sim qemu_cortex_m3
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - native_sim
+      - qemu_cortex_m3
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
     integration_platforms:
       - qemu_cortex_m3

--- a/tests/subsys/bluetooth/mesh/metadata_extraction/testcase.yaml
+++ b/tests/subsys/bluetooth/mesh/metadata_extraction/testcase.yaml
@@ -1,7 +1,9 @@
 common:
   build_only: true
   platform_allow: nrf52840dk/nrf52840
-  tags: bluetooth ci_build
+  tags:
+    - bluetooth
+    - ci_build
   integration_platforms:
     - nrf52840dk/nrf52840
 tests:

--- a/tests/subsys/bluetooth/mesh/models/testcase.yaml
+++ b/tests/subsys/bluetooth/mesh/models/testcase.yaml
@@ -1,7 +1,9 @@
 common:
   build_only: true
   platform_allow: nrf52840dk/nrf52840
-  tags: bluetooth ci_build
+  tags:
+    - bluetooth
+    - ci_build
   integration_platforms:
     - nrf52840dk/nrf52840
 tests:

--- a/tests/subsys/bluetooth/mesh/scheduler_model/action_planning/testcase.yaml
+++ b/tests/subsys/bluetooth/mesh/scheduler_model/action_planning/testcase.yaml
@@ -2,6 +2,9 @@ tests:
   bluetooth.mesh.scheduler_model.action_planning:
     sysbuild: true
     platform_allow: native_sim
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
     integration_platforms:
       - native_sim

--- a/tests/subsys/bluetooth/mesh/scheduler_model/message_validity/testcase.yaml
+++ b/tests/subsys/bluetooth/mesh/scheduler_model/message_validity/testcase.yaml
@@ -2,6 +2,9 @@ tests:
   bluetooth.mesh.scheduler_model.message_validity:
     sysbuild: true
     platform_allow: native_sim
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
     integration_platforms:
       - native_sim

--- a/tests/subsys/bluetooth/mesh/scheduler_model/timing/testcase.yaml
+++ b/tests/subsys/bluetooth/mesh/scheduler_model/timing/testcase.yaml
@@ -2,6 +2,9 @@ tests:
   bluetooth.mesh.scheduler_model:
     sysbuild: true
     platform_allow: native_sim
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
     integration_platforms:
       - native_sim

--- a/tests/subsys/bluetooth/mesh/sensor_subsys/testcase.yaml
+++ b/tests/subsys/bluetooth/mesh/sensor_subsys/testcase.yaml
@@ -1,8 +1,13 @@
 tests:
   bluetooth.mesh.sensor_subsys:
     sysbuild: true
-    platform_allow: native_sim qemu_cortex_m3
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - native_sim
+      - qemu_cortex_m3
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
     integration_platforms:
       - native_sim
       - qemu_cortex_m3

--- a/tests/subsys/bluetooth/mesh/silvair_enocean_model/testcase.yaml
+++ b/tests/subsys/bluetooth/mesh/silvair_enocean_model/testcase.yaml
@@ -1,8 +1,13 @@
 tests:
   bluetooth.mesh.silvair_enocean_model:
     sysbuild: true
-    platform_allow: native_sim qemu_cortex_m3
-    tags: bluetooth ci_build sysbuild
+    platform_allow:
+      - native_sim
+      - qemu_cortex_m3
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
     integration_platforms:
       - native_sim
       - qemu_cortex_m3

--- a/tests/subsys/bluetooth/mesh/time_model/testcase.yaml
+++ b/tests/subsys/bluetooth/mesh/time_model/testcase.yaml
@@ -2,6 +2,9 @@ tests:
   bluetooth.mesh.time_model:
     sysbuild: true
     platform_allow: native_sim
-    tags: bluetooth ci_build sysbuild
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
     integration_platforms:
       - native_sim

--- a/tests/subsys/bootloader/bl_crypto/testcase.yaml
+++ b/tests/subsys/bootloader/bl_crypto/testcase.yaml
@@ -17,7 +17,10 @@ tests:
       - nrf9151dk/nrf9151
       - nrf9160dk/nrf9160
       - nrf9161dk/nrf9161
-    tags: b0 sysbuild ci_tests_subsys_bootloader
+    tags:
+      - b0
+      - sysbuild
+      - ci_tests_subsys_bootloader
   # Deprecated child and parent build to ensure feature does not break until it is removed
   bootloader.bl_crypto.child_parent:
     sysbuild: false
@@ -37,4 +40,8 @@ tests:
       - nrf9151dk/nrf9151
       - nrf9160dk/nrf9160
       - nrf9161dk/nrf9161
-    tags: b0 child_parent deprecated ci_tests_subsys_bootloader
+    tags:
+      - b0
+      - child_parent
+      - deprecated
+      - ci_tests_subsys_bootloader

--- a/tests/subsys/bootloader/bl_storage/testcase.yaml
+++ b/tests/subsys/bootloader/bl_storage/testcase.yaml
@@ -13,7 +13,10 @@ tests:
       - nrf9151dk/nrf9151
       - nrf9160dk/nrf9160
       - nrf9161dk/nrf9161
-    tags: b0 sysbuild ci_tests_subsys_bootloader
+    tags:
+      - b0
+      - sysbuild
+      - ci_tests_subsys_bootloader
     harness: console
     harness_config:
       type: multi_line

--- a/tests/subsys/bootloader/bl_validation/testcase.yaml
+++ b/tests/subsys/bootloader/bl_validation/testcase.yaml
@@ -17,4 +17,8 @@ tests:
       - nrf9151dk/nrf9151
       - nrf9160dk/nrf9160
       - nrf9161dk/nrf9161
-    tags: b0 bl_validation sysbuild ci_tests_subsys_bootloader
+    tags:
+      - b0
+      - bl_validation
+      - sysbuild
+      - ci_tests_subsys_bootloader

--- a/tests/subsys/bootloader/bl_validation_ff_key/testcase.yaml
+++ b/tests/subsys/bootloader/bl_validation_ff_key/testcase.yaml
@@ -15,7 +15,12 @@ tests:
       - nrf9151dk/nrf9151
       - nrf9160dk/nrf9160
       - nrf9161dk/nrf9161
-    tags: b0 bl_validation ff_key sysbuild ci_tests_subsys_bootloader
+    tags:
+      - b0
+      - bl_validation
+      - ff_key
+      - sysbuild
+      - ci_tests_subsys_bootloader
     harness: console
     harness_config:
       type: multi_line

--- a/tests/subsys/bootloader/bl_validation_neg/testcase.yaml
+++ b/tests/subsys/bootloader/bl_validation_neg/testcase.yaml
@@ -11,7 +11,13 @@ tests:
       - nrf9151dk/nrf9151
       - nrf9160dk/nrf9160
       - nrf9161dk/nrf9161
-    tags: b0 bl_validation negative bl_validation_negative sysbuild ci_tests_subsys_bootloader
+    tags:
+      - b0
+      - bl_validation
+      - negative
+      - bl_validation_negative
+      - sysbuild
+      - ci_tests_subsys_bootloader
     harness: console
     harness_config:
       type: multi_line
@@ -40,7 +46,13 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
-    tags: b0 bl_validation negative bl_validation_negative sysbuild ci_tests_subsys_bootloader
+    tags:
+      - b0
+      - bl_validation
+      - negative
+      - bl_validation_negative
+      - sysbuild
+      - ci_tests_subsys_bootloader
     harness: console
     harness_config:
       type: multi_line

--- a/tests/subsys/bootloader/bl_validation_unittest/testcase.yaml
+++ b/tests/subsys/bootloader/bl_validation_unittest/testcase.yaml
@@ -5,4 +5,9 @@ tests:
       - native_sim
     integration_platforms:
       - native_sim
-    tags: b0 bl_validation unittest sysbuild ci_tests_subsys_bootloader
+    tags:
+      - b0
+      - bl_validation
+      - unittest
+      - sysbuild
+      - ci_tests_subsys_bootloader

--- a/tests/subsys/bootloader/boot_chains/testcase.yaml
+++ b/tests/subsys/bootloader/boot_chains/testcase.yaml
@@ -1,10 +1,10 @@
 common:
   platform_allow:
-    nrf52840dk/nrf52840
-    nrf5340dk/nrf5340/cpuapp
-    nrf54l15dk/nrf54l15/cpuapp
     # NB: It's not yet supported to boot TF-M from NSIB without
     # MCUBoot enabled as well
+    - nrf52840dk/nrf52840
+    - nrf5340dk/nrf5340/cpuapp
+    - nrf54l15dk/nrf54l15/cpuapp
   harness: console
   harness_config:
     type: one_line
@@ -14,33 +14,39 @@ common:
 tests:
   boot_chains.secure_boot:
     sysbuild: true
-    extra_args:
-      CONFIG_SECURE_BOOT=y
-    tags: sysbuild ci_tests_subsys_bootloader
+    extra_args: CONFIG_SECURE_BOOT=y
+    tags:
+      - sysbuild
+      - ci_tests_subsys_bootloader
   boot_chains.bootloader_mcuboot:
     sysbuild: true
-    extra_args:
-      SB_CONFIG_BOOTLOADER_MCUBOOT=y
+    extra_args: SB_CONFIG_BOOTLOADER_MCUBOOT=y
     platform_allow:
-      nrf5340dk/nrf5340/cpuapp/ns
-      nrf9151dk/nrf9151/ns
-      nrf9160dk/nrf9160/ns
-      nrf9161dk/nrf9161/ns
-    tags: sysbuild ci_tests_subsys_bootloader
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf9151dk/nrf9151/ns
+      - nrf9160dk/nrf9160/ns
+      - nrf9161dk/nrf9161/ns
+    tags:
+      - sysbuild
+      - ci_tests_subsys_bootloader
   boot_chains.secure_boot_and_bootloader_mcuboot:
     sysbuild: true
     extra_args:
-      SB_CONFIG_SECURE_BOOT_APPCORE=y
-      SB_CONFIG_BOOTLOADER_MCUBOOT=y
+      - SB_CONFIG_SECURE_BOOT_APPCORE=y
+      - SB_CONFIG_BOOTLOADER_MCUBOOT=y
     platform_allow:
-      nrf5340dk/nrf5340/cpuapp/ns
-      nrf9151dk/nrf9151/ns
-      nrf9160dk/nrf9160/ns
-      nrf9161dk/nrf9161/ns
-    tags: sysbuild ci_tests_subsys_bootloader
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf9151dk/nrf9151/ns
+      - nrf9160dk/nrf9160/ns
+      - nrf9161dk/nrf9161/ns
+    tags:
+      - sysbuild
+      - ci_tests_subsys_bootloader
   boot_chains.bootloader_mcuboot_and_nv_counters.sysbuild:
     sysbuild: true
     extra_args:
-      SB_CONFIG_BOOTLOADER_MCUBOOT=y
-      SB_CONFIG_MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION=y
-    tags: sysbuild ci_tests_subsys_bootloader
+      - SB_CONFIG_BOOTLOADER_MCUBOOT=y
+      - SB_CONFIG_MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION=y
+    tags:
+      - sysbuild
+      - ci_tests_subsys_bootloader

--- a/tests/subsys/caf/sensor_data_aggregator/testcase.yaml
+++ b/tests/subsys/caf/sensor_data_aggregator/testcase.yaml
@@ -13,4 +13,6 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf9160dk/nrf9160/ns
       - qemu_cortex_m3
-    tags: sysbuild ci_tests_subsys_caf
+    tags:
+      - sysbuild
+      - ci_tests_subsys_caf

--- a/tests/subsys/caf/sensor_manager/testcase.yaml
+++ b/tests/subsys/caf/sensor_manager/testcase.yaml
@@ -13,4 +13,6 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf9160dk/nrf9160/ns
       - qemu_cortex_m3
-    tags: sysbuild ci_tests_subsys_caf
+    tags:
+      - sysbuild
+      - ci_tests_subsys_caf

--- a/tests/subsys/debug/cpu_load/testcase.yaml
+++ b/tests/subsys/debug/cpu_load/testcase.yaml
@@ -1,18 +1,28 @@
 tests:
   debug.cpu_load:
     sysbuild: true
-    platform_allow: nrf52840dk/nrf52840 nrf9160dk/nrf9160
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf9160dk/nrf9160
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf9160dk/nrf9160
     build_only: true
-    tags: ci_build debug sysbuild ci_tests_subsys_debug
+    tags:
+      - ci_build
+      - debug
+      - sysbuild
+      - ci_tests_subsys_debug
   debug.cpu_load.shared_dppi:
     sysbuild: true
     platform_allow: nrf9160dk/nrf9160
     integration_platforms:
       - nrf9160dk/nrf9160
     build_only: true
-    tags: ci_build debug sysbuild ci_tests_subsys_debug
+    tags:
+      - ci_build
+      - debug
+      - sysbuild
+      - ci_tests_subsys_debug
     extra_configs:
       - CONFIG_CPU_LOAD_USE_SHARED_DPPI_CHANNELS=y

--- a/tests/subsys/dfu/dfu_multi_image/testcase.yaml
+++ b/tests/subsys/dfu/dfu_multi_image/testcase.yaml
@@ -4,4 +4,7 @@ tests:
     platform_allow: native_sim
     integration_platforms:
       - native_sim
-    tags: dfu sysbuild ci_tests_subsys_dfu
+    tags:
+      - dfu
+      - sysbuild
+      - ci_tests_subsys_dfu

--- a/tests/subsys/dfu/dfu_target/mcuboot_bootloader/testcase.yaml
+++ b/tests/subsys/dfu/dfu_target/mcuboot_bootloader/testcase.yaml
@@ -13,4 +13,8 @@ tests:
       - nrf9160dk/nrf9160
       - native_sim
       - qemu_cortex_m3
-    tags: dfu mcuboot sysbuild ci_tests_subsys_dfu
+    tags:
+      - dfu
+      - mcuboot
+      - sysbuild
+      - ci_tests_subsys_dfu

--- a/tests/subsys/dfu/dfu_target/smp/testcase.yaml
+++ b/tests/subsys/dfu/dfu_target/smp/testcase.yaml
@@ -4,4 +4,8 @@ tests:
     platform_allow: native_sim
     integration_platforms:
       - native_sim
-    tags: dfu smp sysbuild ci_tests_subsys_dfu
+    tags:
+      - dfu
+      - smp
+      - sysbuild
+      - ci_tests_subsys_dfu

--- a/tests/subsys/dfu/dfu_target/suit/testcase.yaml
+++ b/tests/subsys/dfu/dfu_target/suit/testcase.yaml
@@ -1,17 +1,27 @@
 tests:
   dfu.dfu_target.suit.single_partition:
     sysbuild: true
-    platform_allow: nrf54h20dk/nrf54h20/cpuapp native_sim
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+      - native_sim
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
       - native_sim
     extra_args: OVERLAY_CONFIG=single_partition.conf
-    tags: dfu sysbuild ci_tests_subsys_dfu
+    tags:
+      - dfu
+      - sysbuild
+      - ci_tests_subsys_dfu
   dfu.dfu_target.suit.cache_processing:
     sysbuild: true
-    platform_allow: nrf54h20dk/nrf54h20/cpuapp native_sim
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+      - native_sim
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
       - native_sim
     extra_args: OVERLAY_CONFIG=cache_processing.conf
-    tags: dfu sysbuild ci_tests_subsys_dfu
+    tags:
+      - dfu
+      - sysbuild
+      - ci_tests_subsys_dfu

--- a/tests/subsys/dfu/dfu_target_stream/testcase.yaml
+++ b/tests/subsys/dfu/dfu_target_stream/testcase.yaml
@@ -2,8 +2,15 @@
 tests:
   dfu.target_stream:
     sysbuild: true
-    tags: target_stream sysbuild ci_tests_subsys_dfu
-    platform_allow: nrf52840dk/nrf52840 nrf9160dk/nrf9160 nrf5340dk/nrf5340/cpuapp native_sim
+    tags:
+      - target_stream
+      - sysbuild
+      - ci_tests_subsys_dfu
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf9160dk/nrf9160
+      - nrf5340dk/nrf5340/cpuapp
+      - native_sim
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf9160dk/nrf9160
@@ -11,11 +18,18 @@ tests:
       - native_sim
   dfu.target_stream.store_progress:
     sysbuild: true
-    tags: target_stream sysbuild ci_tests_subsys_dfu
+    tags:
+      - target_stream
+      - sysbuild
+      - ci_tests_subsys_dfu
     extra_args: OVERLAY_CONFIG=overlay-store-progress.conf
     # Since we need the storage partition (and hence PM) allow some nRF devices
     # only.
-    platform_allow: nrf52840dk/nrf52840 nrf9160dk/nrf9160 nrf5340dk/nrf5340/cpuapp native_sim
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf9160dk/nrf9160
+      - nrf5340dk/nrf5340/cpuapp
+      - native_sim
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf9160dk/nrf9160

--- a/tests/subsys/emds/emds_api/testcase.yaml
+++ b/tests/subsys/emds/emds_api/testcase.yaml
@@ -1,8 +1,13 @@
 tests:
   emds.api:
     sysbuild: true
-    platform_allow: nrf52840dk/nrf52840 nrf54l15dk/nrf54l15/cpuapp
-    tags: emds sysbuild ci_tests_subsys_emds
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - emds
+      - sysbuild
+      - ci_tests_subsys_emds
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp

--- a/tests/subsys/emds/emds_flash/testcase.yaml
+++ b/tests/subsys/emds/emds_flash/testcase.yaml
@@ -1,8 +1,13 @@
 tests:
   emds.flash:
     sysbuild: true
-    platform_allow: nrf52840dk/nrf52840 nrf54l15dk/nrf54l15/cpuapp
-    tags: emds sysbuild ci_tests_subsys_emds
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - emds
+      - sysbuild
+      - ci_tests_subsys_emds
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp

--- a/tests/subsys/event_manager_proxy/testcase.yaml
+++ b/tests/subsys/event_manager_proxy/testcase.yaml
@@ -4,12 +4,17 @@ tests:
     platform_allow: nrf5340dk/nrf5340/cpuapp
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
-    tags: event_manager_proxy sysbuild ci_tests_subsys_event_manager_proxy
+    tags:
+      - event_manager_proxy
+      - sysbuild
+      - ci_tests_subsys_event_manager_proxy
   event_manager_proxy.icmsg:
     sysbuild: true
-    extra_args:
-      FILE_SUFFIX=icmsg
+    extra_args: FILE_SUFFIX=icmsg
     platform_allow: nrf5340dk/nrf5340/cpuapp
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
-    tags: event_manager_proxy sysbuild ci_tests_subsys_event_manager_proxy
+    tags:
+      - event_manager_proxy
+      - sysbuild
+      - ci_tests_subsys_event_manager_proxy

--- a/tests/subsys/fw_info/testcase.yaml
+++ b/tests/subsys/fw_info/testcase.yaml
@@ -1,11 +1,17 @@
 tests:
   fw_info.core:
     sysbuild: true
-    platform_allow: nrf9160dk/nrf9160 nrf52840dk/nrf52840 nrf52dk/nrf52832
-      nrf5340dk/nrf5340/cpuapp
+    platform_allow:
+      - nrf9160dk/nrf9160
+      - nrf52840dk/nrf52840
+      - nrf52dk/nrf52832
+      - nrf5340dk/nrf5340/cpuapp
     integration_platforms:
       - nrf9160dk/nrf9160
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
-    tags: b0 fw_info sysbuild
+    tags:
+      - b0
+      - fw_info
+      - sysbuild

--- a/tests/subsys/kmu/hello_for_kmu/testcase.yaml
+++ b/tests/subsys/kmu/hello_for_kmu/testcase.yaml
@@ -1,7 +1,10 @@
 common:
   sysbuild: true
   timeout: 180
-  tags: pytest mcuboot kmu
+  tags:
+    - pytest
+    - mcuboot
+    - kmu
   platform_allow:
     - nrf54l15dk/nrf54l15/cpuapp
   harness: pytest

--- a/tests/subsys/kmu/verify_west_ncs_provision/testcase.yaml
+++ b/tests/subsys/kmu/verify_west_ncs_provision/testcase.yaml
@@ -1,6 +1,8 @@
 common:
   timeout: 120
-  tags: pytest kmu
+  tags:
+    - pytest
+    - kmu
   platform_allow:
     - nrf54l15dk/nrf54l15/cpuapp
 tests:

--- a/tests/subsys/mpsl/pm/testcase.yaml
+++ b/tests/subsys/mpsl/pm/testcase.yaml
@@ -3,4 +3,6 @@ tests:
     platform_allow: native_sim
     integration_platforms:
       - native_sim
-    tags: pm ci_tests_subsys_mpsl
+    tags:
+      - pm
+      - ci_tests_subsys_mpsl

--- a/tests/subsys/net/lib/aws_fota/aws_fota_json/testcase.yaml
+++ b/tests/subsys/net/lib/aws_fota/aws_fota_json/testcase.yaml
@@ -1,10 +1,19 @@
 tests:
   net.lib.aws_fota.aws_fota_json:
     sysbuild: true
-    platform_allow: native_sim nrf52840dk/nrf52840 nrf9160dk/nrf9160 qemu_cortex_m3
+    platform_allow:
+      - native_sim
+      - nrf52840dk/nrf52840
+      - nrf9160dk/nrf9160
+      - qemu_cortex_m3
     integration_platforms:
       - native_sim
       - nrf52840dk/nrf52840
       - nrf9160dk/nrf9160
       - qemu_cortex_m3
-    tags: aws fota json sysbuild ci_tests_subsys_net
+    tags:
+      - aws
+      - fota
+      - json
+      - sysbuild
+      - ci_tests_subsys_net

--- a/tests/subsys/net/lib/aws_iot/testcase.yaml
+++ b/tests/subsys/net/lib/aws_iot/testcase.yaml
@@ -4,4 +4,7 @@ tests:
     platform_allow: native_sim
     integration_platforms:
       - native_sim
-    tags: aws_iot sysbuild ci_tests_subsys_net
+    tags:
+      - aws_iot
+      - sysbuild
+      - ci_tests_subsys_net

--- a/tests/subsys/net/lib/aws_jobs/testcase.yaml
+++ b/tests/subsys/net/lib/aws_jobs/testcase.yaml
@@ -1,8 +1,13 @@
 tests:
   net.lib.aws_jobs:
     sysbuild: true
-    platform_allow: native_sim qemu_cortex_m3
+    platform_allow:
+      - native_sim
+      - qemu_cortex_m3
     integration_platforms:
       - native_sim
       - qemu_cortex_m3
-    tags: aws sysbuild ci_tests_subsys_net
+    tags:
+      - aws
+      - sysbuild
+      - ci_tests_subsys_net

--- a/tests/subsys/net/lib/azure_iot_hub/dps/testcase.yaml
+++ b/tests/subsys/net/lib/azure_iot_hub/dps/testcase.yaml
@@ -4,4 +4,7 @@ tests:
     platform_allow: native_sim
     integration_platforms:
       - native_sim
-    tags: azure_iot_hub_dps sysbuild ci_tests_subsys_net
+    tags:
+      - azure_iot_hub_dps
+      - sysbuild
+      - ci_tests_subsys_net

--- a/tests/subsys/net/lib/azure_iot_hub/iot_hub/testcase.yaml
+++ b/tests/subsys/net/lib/azure_iot_hub/iot_hub/testcase.yaml
@@ -1,8 +1,13 @@
 tests:
   net.lib.azure_iot_hub.iot_hub:
     sysbuild: true
-    platform_allow: qemu_cortex_m3 native_sim
+    platform_allow:
+      - qemu_cortex_m3
+      - native_sim
     integration_platforms:
       - qemu_cortex_m3
       - native_sim
-    tags: azure_iot_hub sysbuild ci_tests_subsys_net
+    tags:
+      - azure_iot_hub
+      - sysbuild
+      - ci_tests_subsys_net

--- a/tests/subsys/net/lib/download_client/testcase.yaml
+++ b/tests/subsys/net/lib/download_client/testcase.yaml
@@ -1,7 +1,12 @@
 tests:
   net.lib.download_client:
     sysbuild: true
-    tags: fota sysbuild ci_tests_subsys_net
-    platform_allow: native_sim qemu_cortex_m3
+    tags:
+      - fota
+      - sysbuild
+      - ci_tests_subsys_net
+    platform_allow:
+      - native_sim
+      - qemu_cortex_m3
     integration_platforms:
       - native_sim

--- a/tests/subsys/net/lib/fota_download/testcase.yaml
+++ b/tests/subsys/net/lib/fota_download/testcase.yaml
@@ -1,8 +1,14 @@
 tests:
   net.lib.fota_download:
     sysbuild: true
-    tags: aws fota sysbuild ci_tests_subsys_net
-    platform_allow: nrf9160dk/nrf9160 nrf9160dk/nrf9160/ns
+    tags:
+      - aws
+      - fota
+      - sysbuild
+      - ci_tests_subsys_net
+    platform_allow:
+      - nrf9160dk/nrf9160
+      - nrf9160dk/nrf9160/ns
     integration_platforms:
       - nrf9160dk/nrf9160
       - nrf9160dk/nrf9160/ns

--- a/tests/subsys/net/lib/lwm2m_client_utils/testcase.yaml
+++ b/tests/subsys/net/lib/lwm2m_client_utils/testcase.yaml
@@ -1,7 +1,10 @@
 tests:
   subsys.net.lib.lwm2m_client_utils.unittest:
     sysbuild: true
-    tags: unittest sysbuild ci_tests_subsys_net
+    tags:
+      - unittest
+      - sysbuild
+      - ci_tests_subsys_net
     platform_allow: native_sim
     integration_platforms:
       - native_sim

--- a/tests/subsys/net/lib/lwm2m_fota_utils/testcase.yaml
+++ b/tests/subsys/net/lib/lwm2m_fota_utils/testcase.yaml
@@ -1,14 +1,20 @@
 tests:
   subsys.net.lib.lwm2m_fota_utils.unittest_adv:
     sysbuild: true
-    tags: unittest sysbuild ci_tests_subsys_net
+    tags:
+      - unittest
+      - sysbuild
+      - ci_tests_subsys_net
     platform_allow: native_sim
     integration_platforms:
       - native_sim
   subsys.net.lib.lwm2m_fota_utils.unittest_obj5:
     sysbuild: true
     extra_args: FILE_SUFFIX=obj5
-    tags: unittest sysbuild ci_tests_subsys_net
+    tags:
+      - unittest
+      - sysbuild
+      - ci_tests_subsys_net
     platform_allow: native_sim
     integration_platforms:
       - native_sim

--- a/tests/subsys/net/lib/mcumgr_smp_client/testcase.yaml
+++ b/tests/subsys/net/lib/mcumgr_smp_client/testcase.yaml
@@ -4,4 +4,7 @@ tests:
     platform_allow: native_sim
     integration_platforms:
       - native_sim
-    tags: unittest sysbuild ci_tests_subsys_net
+    tags:
+      - unittest
+      - sysbuild
+      - ci_tests_subsys_net

--- a/tests/subsys/net/lib/mqtt_helper/testcase.yaml
+++ b/tests/subsys/net/lib/mqtt_helper/testcase.yaml
@@ -1,8 +1,13 @@
 tests:
   net.lib.mqtt_helper:
     sysbuild: true
-    platform_allow: qemu_cortex_m3 native_sim
+    platform_allow:
+      - qemu_cortex_m3
+      - native_sim
     integration_platforms:
       - qemu_cortex_m3
       - native_sim
-    tags: mqtt_helper sysbuild ci_tests_subsys_net
+    tags:
+      - mqtt_helper
+      - sysbuild
+      - ci_tests_subsys_net

--- a/tests/subsys/net/lib/nrf_cloud/client_id/testcase.yaml
+++ b/tests/subsys/net/lib/nrf_cloud/client_id/testcase.yaml
@@ -2,21 +2,29 @@ common:
   platform_allow: nrf9160dk/nrf9160/ns
   integration_platforms:
     - nrf9160dk/nrf9160/ns
-  tags: ci_build nrf_cloud_test nrf_cloud_lib ci_tests_subsys_net
+  tags:
+    - ci_build
+    - nrf_cloud_test
+    - nrf_cloud_lib
+    - ci_tests_subsys_net
 tests:
   net.lib.nrf_cloud.client_id.imei:
     sysbuild: true
     timeout: 60
     extra_args:
       - CONFIG_NRF_CLOUD_CLIENT_ID_SRC_IMEI=y
-    tags: sysbuild ci_tests_subsys_net
+    tags:
+      - sysbuild
+      - ci_tests_subsys_net
   net.lib.nrf_cloud.client_id.runtime:
     sysbuild: true
     timeout: 60
     extra_args:
       - CONFIG_NRF_CLOUD_CLIENT_ID_SRC_IMEI=n
       - CONFIG_NRF_CLOUD_CLIENT_ID_SRC_RUNTIME=y
-    tags: sysbuild ci_tests_subsys_net
+    tags:
+      - sysbuild
+      - ci_tests_subsys_net
   net.lib.nrf_cloud.client_id.uuid:
     sysbuild: true
     timeout: 60
@@ -24,7 +32,9 @@ tests:
       - CONFIG_NRF_CLOUD_CLIENT_ID_SRC_IMEI=n
       - CONFIG_NRF_CLOUD_CLIENT_ID_SRC_INTERNAL_UUID=y
       - CONFIG_MODEM_JWT=y
-    tags: sysbuild ci_tests_subsys_net
+    tags:
+      - sysbuild
+      - ci_tests_subsys_net
   net.lib.nrf_cloud.client_id.hwid:
     sysbuild: true
     timeout: 60
@@ -32,11 +42,15 @@ tests:
       - CONFIG_NRF_CLOUD_CLIENT_ID_SRC_IMEI=n
       - CONFIG_NRF_CLOUD_CLIENT_ID_SRC_HW_ID=y
       - CONFIG_HW_ID_LIBRARY=y
-    tags: sysbuild ci_tests_subsys_net
+    tags:
+      - sysbuild
+      - ci_tests_subsys_net
   net.lib.nrf_cloud.client_id.comptime:
     sysbuild: true
     timeout: 60
     extra_args:
       - CONFIG_NRF_CLOUD_CLIENT_ID_SRC_IMEI=n
       - CONFIG_NRF_CLOUD_CLIENT_ID_SRC_COMPILE_TIME=y
-    tags: sysbuild ci_tests_subsys_net
+    tags:
+      - sysbuild
+      - ci_tests_subsys_net

--- a/tests/subsys/net/lib/nrf_cloud/cloud/testcase.yaml
+++ b/tests/subsys/net/lib/nrf_cloud/cloud/testcase.yaml
@@ -1,10 +1,17 @@
 tests:
   net.lib.nrf_cloud.cloud:
     sysbuild: true
-    platform_allow: nrf9160dk/nrf9160/ns native_sim qemu_cortex_m3
+    platform_allow:
+      - nrf9160dk/nrf9160/ns
+      - native_sim
+      - qemu_cortex_m3
     integration_platforms:
       - nrf9160dk/nrf9160/ns
       - native_sim
       - qemu_cortex_m3
-    tags: nrf_cloud_test nrf_cloud_lib sysbuild ci_tests_subsys_net
+    tags:
+      - nrf_cloud_test
+      - nrf_cloud_lib
+      - sysbuild
+      - ci_tests_subsys_net
     timeout: 90

--- a/tests/subsys/net/lib/nrf_cloud/fota_common/testcase.yaml
+++ b/tests/subsys/net/lib/nrf_cloud/fota_common/testcase.yaml
@@ -2,7 +2,11 @@ common:
   platform_allow: nrf9160dk/nrf9160/ns
   integration_platforms:
     - nrf9160dk/nrf9160/ns
-  tags: ci_build nrf_cloud_test nrf_cloud_lib ci_tests_subsys_net
+  tags:
+    - ci_build
+    - nrf_cloud_test
+    - nrf_cloud_lib
+    - ci_tests_subsys_net
 tests:
   net.lib.nrf_cloud.fota_common:
     sysbuild: true
@@ -16,7 +20,9 @@ tests:
       - CONFIG_STREAM_FLASH_ERASE=y
       - CONFIG_NRF_CLOUD_FOTA_FULL_MODEM_UPDATE=y
       - SB_CONFIG_BOOTLOADER_MCUBOOT=y
-    tags: sysbuild ci_tests_subsys_net
+    tags:
+      - sysbuild
+      - ci_tests_subsys_net
   net.lib.nrf_cloud.fota_common.no_img_mngr:
     sysbuild: true
     timeout: 60
@@ -27,4 +33,6 @@ tests:
       - CONFIG_MCUBOOT_IMG_MANAGER=n
       - CONFIG_IMG_MANAGER=n
       - CONFIG_STREAM_FLASH_ERASE=n
-    tags: sysbuild ci_tests_subsys_net
+    tags:
+      - sysbuild
+      - ci_tests_subsys_net

--- a/tests/subsys/net/lib/nrf_provisioning/testcase.yaml
+++ b/tests/subsys/net/lib/nrf_provisioning/testcase.yaml
@@ -5,17 +5,26 @@ tests:
     platform_allow: native_sim
     integration_platforms:
       - native_sim
-    tags: unittest sysbuild ci_tests_subsys_net
+    tags:
+      - unittest
+      - sysbuild
+      - ci_tests_subsys_net
   nrf_provisioning.unittest_http:
     sysbuild: true
     platform_allow: native_sim
     integration_platforms:
       - native_sim
-    tags: unittest sysbuild ci_tests_subsys_net
+    tags:
+      - unittest
+      - sysbuild
+      - ci_tests_subsys_net
   nrf_provisioning.unittest_coap:
     sysbuild: true
     extra_args: FILE_SUFFIX=coap
     platform_allow: native_sim
     integration_platforms:
       - native_sim
-    tags: unittest sysbuild ci_tests_subsys_net
+    tags:
+      - unittest
+      - sysbuild
+      - ci_tests_subsys_net

--- a/tests/subsys/net/lib/wifi_credentials/testcase.yaml
+++ b/tests/subsys/net/lib/wifi_credentials/testcase.yaml
@@ -4,4 +4,6 @@ tests:
     platform_allow: native_sim
     integration_platforms:
       - native_sim
-    tags: sysbuild ci_tests_subsys_net
+    tags:
+      - sysbuild
+      - ci_tests_subsys_net

--- a/tests/subsys/net/lib/wifi_credentials_backend_psa/testcase.yaml
+++ b/tests/subsys/net/lib/wifi_credentials_backend_psa/testcase.yaml
@@ -4,4 +4,6 @@ tests:
     platform_allow: native_sim
     integration_platforms:
       - native_sim
-    tags: sysbuild ci_tests_subsys_net
+    tags:
+      - sysbuild
+      - ci_tests_subsys_net

--- a/tests/subsys/net/lib/wifi_credentials_backend_settings/testcase.yaml
+++ b/tests/subsys/net/lib/wifi_credentials_backend_settings/testcase.yaml
@@ -4,4 +4,6 @@ tests:
     platform_allow: native_sim
     integration_platforms:
       - native_sim
-    tags: sysbuild ci_tests_subsys_net
+    tags:
+      - sysbuild
+      - ci_tests_subsys_net

--- a/tests/subsys/net/openthread/rpc/client/testcase.yaml
+++ b/tests/subsys/net/openthread/rpc/client/testcase.yaml
@@ -2,6 +2,10 @@ tests:
   net.openthread.rpc.client:
     sysbuild: true
     platform_allow: native_sim
-    tags: openthread ci_build sysbuild ci_tests_subsys_net_openthread
+    tags:
+      - openthread
+      - ci_build
+      - sysbuild
+      - ci_tests_subsys_net_openthread
     integration_platforms:
       - native_sim

--- a/tests/subsys/net/openthread/rpc/server/testcase.yaml
+++ b/tests/subsys/net/openthread/rpc/server/testcase.yaml
@@ -2,6 +2,10 @@ tests:
   net.openthread.rpc.server:
     sysbuild: true
     platform_allow: native_sim
-    tags: openthread ci_build sysbuild ci_tests_subsys_net_openthread
+    tags:
+      - openthread
+      - ci_build
+      - sysbuild
+      - ci_tests_subsys_net_openthread
     integration_platforms:
       - native_sim

--- a/tests/subsys/nfc/rpc/client/testcase.yaml
+++ b/tests/subsys/nfc/rpc/client/testcase.yaml
@@ -2,6 +2,10 @@ tests:
   nfc.rpc.client:
     sysbuild: true
     platform_allow: native_sim
-    tags: nfc ci_build sysbuild ci_tests_subsys_nfc
+    tags:
+      - nfc
+      - ci_build
+      - sysbuild
+      - ci_tests_subsys_nfc
     integration_platforms:
       - native_sim

--- a/tests/subsys/nfc/rpc/server/testcase.yaml
+++ b/tests/subsys/nfc/rpc/server/testcase.yaml
@@ -2,6 +2,10 @@ tests:
   nfc.rpc.server:
     sysbuild: true
     platform_allow: native_sim
-    tags: nfc ci_build sysbuild ci_tests_subsys_nfc
+    tags:
+      - nfc
+      - ci_build
+      - sysbuild
+      - ci_tests_subsys_nfc
     integration_platforms:
       - native_sim

--- a/tests/subsys/nrf_compress/decompression/arm_thumb/testcase.yaml
+++ b/tests/subsys/nrf_compress/decompression/arm_thumb/testcase.yaml
@@ -1,6 +1,11 @@
 common:
   sysbuild: true
-  tags: compress decompression arm_thumb sysbuild ci_tests_subsys_nrf_compress
+  tags:
+    - compress
+    - decompression
+    - arm_thumb
+    - sysbuild
+    - ci_tests_subsys_nrf_compress
   platform_allow:
     - native_sim
     - nrf52840dk/nrf52840

--- a/tests/subsys/nrf_compress/decompression/lzma/testcase.yaml
+++ b/tests/subsys/nrf_compress/decompression/lzma/testcase.yaml
@@ -1,6 +1,11 @@
 common:
   sysbuild: true
-  tags: compress decompression lzma sysbuild ci_tests_subsys_nrf_compress
+  tags:
+    - compress
+    - decompression
+    - lzma
+    - sysbuild
+    - ci_tests_subsys_nrf_compress
   platform_allow:
     - native_sim
     - nrf52840dk/nrf52840

--- a/tests/subsys/nrf_compress/decompression/mcuboot_update/testcase.yaml
+++ b/tests/subsys/nrf_compress/decompression/mcuboot_update/testcase.yaml
@@ -1,6 +1,8 @@
 common:
   sysbuild: true
-  tags: sysbuild ci_tests_subsys_nrf_compress
+  tags:
+    - sysbuild
+    - ci_tests_subsys_nrf_compress
 tests:
   nrf_compress.decompression.mcuboot_update:
     platform_allow:

--- a/tests/subsys/nrf_profiler/testcase.yaml
+++ b/tests/subsys/nrf_profiler/testcase.yaml
@@ -1,7 +1,10 @@
 tests:
   nrf_profiler.core:
     sysbuild: true
-    platform_exclude: native_sim qemu_x86 qemu_cortex_m3
+    platform_exclude:
+      - native_sim
+      - qemu_x86
+      - qemu_cortex_m3
     platform_allow:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
@@ -12,4 +15,7 @@ tests:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf9160dk/nrf9160/ns
-    tags: nrf_profiler sysbuild ci_tests_subsys_nrf_profiler
+    tags:
+      - nrf_profiler
+      - sysbuild
+      - ci_tests_subsys_nrf_profiler

--- a/tests/subsys/nrf_rpc/dev_info/client/testcase.yaml
+++ b/tests/subsys/nrf_rpc/dev_info/client/testcase.yaml
@@ -2,6 +2,9 @@ tests:
   nrf_rpc.dev_info.client:
     sysbuild: true
     platform_allow: native_sim
-    tags: ci_build sysbuild ci_tests_subsys_nrf_rpc
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_tests_subsys_nrf_rpc
     integration_platforms:
       - native_sim

--- a/tests/subsys/nrf_rpc/dev_info/server/testcase.yaml
+++ b/tests/subsys/nrf_rpc/dev_info/server/testcase.yaml
@@ -2,6 +2,9 @@ tests:
   nrf_rpc.dev_info.server:
     sysbuild: true
     platform_allow: native_sim
-    tags: ci_build sysbuild ci_tests_subsys_nrf_rpc
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_tests_subsys_nrf_rpc
     integration_platforms:
       - native_sim

--- a/tests/subsys/partition_manager/region/testcase.yaml
+++ b/tests/subsys/partition_manager/region/testcase.yaml
@@ -10,7 +10,9 @@ tests:
     extra_configs:
       - CONFIG_FILE_SYSTEM_LITTLEFS=y
       - CONFIG_PM_PARTITION_REGION_LITTLEFS_EXTERNAL=y
-    tags: sysbuild ci_tests_subsys_partition_manager
+    tags:
+      - sysbuild
+      - ci_tests_subsys_partition_manager
   regions.nvs_storage:
     sysbuild: true
     platform_allow: nrf5340dk/nrf5340/cpuapp
@@ -19,7 +21,9 @@ tests:
     extra_configs:
       - CONFIG_NVS=y
       - CONFIG_PM_PARTITION_REGION_NVS_STORAGE_EXTERNAL=y
-    tags: sysbuild ci_tests_subsys_partition_manager
+    tags:
+      - sysbuild
+      - ci_tests_subsys_partition_manager
   regions.settings_storage:
     sysbuild: true
     platform_allow: nrf5340dk/nrf5340/cpuapp
@@ -30,7 +34,9 @@ tests:
       - CONFIG_SETTINGS=y
       - CONFIG_SETTINGS_FCB=y
       - CONFIG_PM_PARTITION_REGION_SETTINGS_STORAGE_EXTERNAL=y
-    tags: sysbuild ci_tests_subsys_partition_manager
+    tags:
+      - sysbuild
+      - ci_tests_subsys_partition_manager
   regions.settings_storage_tfm:
     sysbuild: true
     platform_allow: nrf5340dk/nrf5340/cpuapp/ns
@@ -41,4 +47,6 @@ tests:
       - CONFIG_SETTINGS=y
       - CONFIG_SETTINGS_FCB=y
       - CONFIG_PM_PARTITION_REGION_SETTINGS_STORAGE_EXTERNAL=y
-    tags: sysbuild ci_tests_subsys_partition_manager
+    tags:
+      - sysbuild
+      - ci_tests_subsys_partition_manager

--- a/tests/subsys/partition_manager/static_pm_file/testcase.yaml
+++ b/tests/subsys/partition_manager/static_pm_file/testcase.yaml
@@ -1,5 +1,7 @@
 common:
-  tags: partition_manager ci_tests_subsys_partition_manager
+  tags:
+    - partition_manager
+    - ci_tests_subsys_partition_manager
 tests:
   static_pm_file.sysbuild:
     sysbuild: true

--- a/tests/subsys/pcd/testcase.yaml
+++ b/tests/subsys/pcd/testcase.yaml
@@ -4,11 +4,18 @@ tests:
     platform_allow: nrf5340dk/nrf5340/cpuapp
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
-    tags: pcd sysbuild ci_tests_subsys_pcd
+    tags:
+      - pcd
+      - sysbuild
+      - ci_tests_subsys_pcd
   # Deprecated child and parent build to ensure feature does not break until it is removed
   dfu.pcd.sysbuild.child_parent:
     sysbuild: false
     platform_allow: nrf5340dk/nrf5340/cpuapp
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
-    tags: pcd child_parent deprecated ci_tests_subsys_pcd
+    tags:
+      - pcd
+      - child_parent
+      - deprecated
+      - ci_tests_subsys_pcd

--- a/tests/subsys/sdfw_services/client/testcase.yaml
+++ b/tests/subsys/sdfw_services/client/testcase.yaml
@@ -4,4 +4,7 @@ tests:
     platform_allow: native_sim
     integration_platforms:
       - native_sim
-    tags: ssf sysbuild ci_tests_subsys_sdfw_services
+    tags:
+      - ssf
+      - sysbuild
+      - ci_tests_subsys_sdfw_services

--- a/tests/subsys/sdfw_services/client_notif/testcase.yaml
+++ b/tests/subsys/sdfw_services/client_notif/testcase.yaml
@@ -4,4 +4,7 @@ tests:
     platform_allow: native_sim
     integration_platforms:
       - native_sim
-    tags: ssf sysbuild ci_tests_subsys_sdfw_services
+    tags:
+      - ssf
+      - sysbuild
+      - ci_tests_subsys_sdfw_services

--- a/tests/subsys/suit/cache/testcase.yaml
+++ b/tests/subsys/suit/cache/testcase.yaml
@@ -1,7 +1,13 @@
 tests:
   suit-platform.integration.suit_cache:
-    platform_allow: nrf52840dk/nrf52840 native_sim native_sim/native/64
-    tags: suit suit_cache ci_tests_subsys_suit
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - native_sim
+      - native_sim/native/64
+    tags:
+      - suit
+      - suit_cache
+      - ci_tests_subsys_suit
     integration_platforms:
       - nrf52840dk/nrf52840
       - native_sim

--- a/tests/subsys/suit/cache_fetch/testcase.yaml
+++ b/tests/subsys/suit/cache_fetch/testcase.yaml
@@ -1,7 +1,15 @@
 tests:
   suit-platform.integration.cache_streamer:
-    platform_allow: nrf52840dk/nrf52840 native_sim native_sim/native/64
-    tags: suit-processor suit_cache suit_stream suit ci_tests_subsys_suit
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - native_sim
+      - native_sim/native/64
+    tags:
+      - suit-processor
+      - suit_cache
+      - suit_stream
+      - suit
+      - ci_tests_subsys_suit
     integration_platforms:
       - nrf52840dk/nrf52840
       - native_sim

--- a/tests/subsys/suit/cache_pool_digest/testcase.yaml
+++ b/tests/subsys/suit/cache_pool_digest/testcase.yaml
@@ -2,7 +2,14 @@ common:
   sysbuild: true
 tests:
   suit-platform.integration.cache_pool_digest:
-    platform_allow: nrf54h20dk/nrf54h20/cpuapp native_sim native_sim/native/64
-    tags: suit suit_cache digest ci_tests_subsys_suit
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+      - native_sim
+      - native_sim/native/64
+    tags:
+      - suit
+      - suit_cache
+      - digest
+      - ci_tests_subsys_suit
     integration_platforms:
       - native_sim

--- a/tests/subsys/suit/cache_sink/testcase.yaml
+++ b/tests/subsys/suit/cache_sink/testcase.yaml
@@ -2,7 +2,13 @@ common:
   sysbuild: true
 tests:
   suit-platform.integration.cache_sink:
-    platform_allow: nrf54h20dk/nrf54h20/cpuapp native_sim native_sim/native/64
-    tags: suit suit_cache ci_tests_subsys_suit
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+      - native_sim
+      - native_sim/native/64
+    tags:
+      - suit
+      - suit_cache
+      - ci_tests_subsys_suit
     integration_platforms:
       - native_sim

--- a/tests/subsys/suit/check_content/testcase.yaml
+++ b/tests/subsys/suit/check_content/testcase.yaml
@@ -1,7 +1,12 @@
 tests:
   suit.integration.check_content:
-    platform_allow: nrf52840dk/nrf52840 native_sim
-    tags: suit suit_plat_check_content ci_tests_subsys_suit
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - native_sim
+    tags:
+      - suit
+      - suit_plat_check_content
+      - ci_tests_subsys_suit
     timeout: 240
     integration_platforms:
       - nrf52840dk/nrf52840

--- a/tests/subsys/suit/check_image_match/testcase.yaml
+++ b/tests/subsys/suit/check_image_match/testcase.yaml
@@ -1,7 +1,12 @@
 tests:
   suit.integration.check_image_match:
-    platform_allow: nrf52840dk/nrf52840 native_sim
-    tags: suit suit_plat_check_image_match ci_tests_subsys_suit
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - native_sim
+    tags:
+      - suit
+      - suit_plat_check_image_match
+      - ci_tests_subsys_suit
     timeout: 240
     integration_platforms:
       - nrf52840dk/nrf52840

--- a/tests/subsys/suit/component_compatibility_check/testcase.yaml
+++ b/tests/subsys/suit/component_compatibility_check/testcase.yaml
@@ -1,6 +1,9 @@
 tests:
   suit-platform.integration.suit_component_compatibility_check:
     platform_allow: native_sim
-    tags: suit_storage suit ci_tests_subsys_suit
+    tags:
+      - suit_storage
+      - suit
+      - ci_tests_subsys_suit
     integration_platforms:
       - native_sim

--- a/tests/subsys/suit/copy/testcase.yaml
+++ b/tests/subsys/suit/copy/testcase.yaml
@@ -1,7 +1,14 @@
 tests:
   suit-platform.integration.copy:
-    platform_allow: nrf52840dk/nrf52840 native_sim native_sim/native/64
-    tags: suit-processor suit_platform suit ci_tests_subsys_suit
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - native_sim
+      - native_sim/native/64
+    tags:
+      - suit-processor
+      - suit_platform
+      - suit
+      - ci_tests_subsys_suit
     integration_platforms:
       - nrf52840dk/nrf52840
       - native_sim

--- a/tests/subsys/suit/decrypt_filter/testcase.yaml
+++ b/tests/subsys/suit/decrypt_filter/testcase.yaml
@@ -1,7 +1,13 @@
 tests:
   suit.integration.decrypt_filter:
-    platform_allow: nrf52840dk/nrf52840 native_sim native_sim/native/64
-    tags: suit suit_decrypt_filter ci_tests_subsys_suit
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - native_sim
+      - native_sim/native/64
+    tags:
+      - suit
+      - suit_decrypt_filter
+      - ci_tests_subsys_suit
     integration_platforms:
       - nrf52840dk/nrf52840
       - native_sim

--- a/tests/subsys/suit/digest/testcase.yaml
+++ b/tests/subsys/suit/digest/testcase.yaml
@@ -1,7 +1,13 @@
 tests:
   suit.integration.digest:
-    platform_allow: nrf52840dk/nrf52840 native_sim native_sim/native/64
-    tags: suit suit_digest ci_tests_subsys_suit
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - native_sim
+      - native_sim/native/64
+    tags:
+      - suit
+      - suit_digest
+      - ci_tests_subsys_suit
     timeout: 240
     integration_platforms:
       - nrf52840dk/nrf52840

--- a/tests/subsys/suit/digest_sink/testcase.yaml
+++ b/tests/subsys/suit/digest_sink/testcase.yaml
@@ -1,7 +1,13 @@
 tests:
   suit.integration.digest_sink:
-    platform_allow: nrf52840dk/nrf52840 native_sim native_sim/native/64
-    tags: suit suit_digest_sink ci_tests_subsys_suit
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - native_sim
+      - native_sim/native/64
+    tags:
+      - suit
+      - suit_digest_sink
+      - ci_tests_subsys_suit
     timeout: 240
     integration_platforms:
       - nrf52840dk/nrf52840

--- a/tests/subsys/suit/envelope_decoder/testcase.yaml
+++ b/tests/subsys/suit/envelope_decoder/testcase.yaml
@@ -1,5 +1,11 @@
 tests:
   suit-processor.integration.envelope_decoder:
-    platform_allow: native_sim native_sim/native/64
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
     build_only: true
-    tags: suit-processor envelope-decoder suit ci_tests_subsys_suit
+    tags:
+      - suit-processor
+      - envelope-decoder
+      - suit
+      - ci_tests_subsys_suit

--- a/tests/subsys/suit/execution_mode/testcase.yaml
+++ b/tests/subsys/suit/execution_mode/testcase.yaml
@@ -1,7 +1,15 @@
 tests:
   suit-platform.integration.common.execution_mode:
-    platform_allow: nrf52840dk/nrf52840 native_sim native_sim/native/64
-    tags: suit-processor suit_platform suit_execution_mode suit ci_tests_subsys_suit
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - native_sim
+      - native_sim/native/64
+    tags:
+      - suit-processor
+      - suit_platform
+      - suit_execution_mode
+      - suit
+      - ci_tests_subsys_suit
     integration_platforms:
       - nrf52840dk/nrf52840
       - native_sim

--- a/tests/subsys/suit/fetch/testcase.yaml
+++ b/tests/subsys/suit/fetch/testcase.yaml
@@ -1,7 +1,14 @@
 tests:
   suit-platform.integration.fetch:
-    platform_allow: nrf52840dk/nrf52840 native_sim native_sim/native/64
-    tags: suit-processor suit_platform suit ci_tests_subsys_suit
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - native_sim
+      - native_sim/native/64
+    tags:
+      - suit-processor
+      - suit_platform
+      - suit
+      - ci_tests_subsys_suit
     integration_platforms:
       - nrf52840dk/nrf52840
       - native_sim

--- a/tests/subsys/suit/fetch_integrated_payload_flash/testcase.yaml
+++ b/tests/subsys/suit/fetch_integrated_payload_flash/testcase.yaml
@@ -1,7 +1,16 @@
 tests:
   suit-processor.integration.fetch_integrated_payload_flash:
-    platform_allow: nrf52840dk/nrf52840 native_sim native_sim/native/64
-    tags: suit-processor integrated-payload fetch MRAM suit ci_tests_subsys_suit
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - native_sim
+      - native_sim/native/64
+    tags:
+      - suit-processor
+      - integrated-payload
+      - fetch
+      - MRAM
+      - suit
+      - ci_tests_subsys_suit
     integration_platforms:
       - nrf52840dk/nrf52840
       - native_sim

--- a/tests/subsys/suit/fetch_source_mgr/testcase.yaml
+++ b/tests/subsys/suit/fetch_source_mgr/testcase.yaml
@@ -1,6 +1,11 @@
 tests:
   suit-platform.integration.fetch_source_mgr:
-    platform_allow: native_sim native_sim/native/64
-    tags: suit_platform suit ci_tests_subsys_suit
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+    tags:
+      - suit_platform
+      - suit
+      - ci_tests_subsys_suit
     integration_platforms:
       - native_sim

--- a/tests/subsys/suit/flash_sink/testcase.yaml
+++ b/tests/subsys/suit/flash_sink/testcase.yaml
@@ -4,7 +4,11 @@ tests:
       - nrf52840dk/nrf52840
       - native_sim
       - native_sim/native/64
-    tags: suit-processor suit_platform suit ci_tests_subsys_suit
+    tags:
+      - suit-processor
+      - suit_platform
+      - suit
+      - ci_tests_subsys_suit
     integration_platforms:
       - nrf52840dk/nrf52840
       - native_sim
@@ -14,6 +18,10 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
       - native_sim
       - native_sim/native/64
-    tags: suit-processor suit_platform suit ci_tests_subsys_suit
+    tags:
+      - suit-processor
+      - suit_platform
+      - suit
+      - ci_tests_subsys_suit
     integration_platforms:
       - native_sim

--- a/tests/subsys/suit/integrated_fetch/testcase.yaml
+++ b/tests/subsys/suit/integrated_fetch/testcase.yaml
@@ -1,7 +1,14 @@
 tests:
   suit-platform.integration.memptr_streamer:
-    platform_allow: nrf52840dk/nrf52840 native_sim native_sim/native/64
-    tags: suit-processor suit_platform suit ci_tests_subsys_suit
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - native_sim
+      - native_sim/native/64
+    tags:
+      - suit-processor
+      - suit_platform
+      - suit
+      - ci_tests_subsys_suit
     integration_platforms:
       - nrf52840dk/nrf52840
       - native_sim

--- a/tests/subsys/suit/invoke/testcase.yaml
+++ b/tests/subsys/suit/invoke/testcase.yaml
@@ -1,7 +1,13 @@
 tests:
   suit-platform.integration.invoke:
-    platform_allow: native_sim native_sim/native/64
-    tags: suit-processor suit_platform suit ci_tests_subsys_suit
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+    tags:
+      - suit-processor
+      - suit_platform
+      - suit
+      - ci_tests_subsys_suit
     integration_platforms:
       - native_sim
       - native_sim/native/64

--- a/tests/subsys/suit/ipuc/testcase.yaml
+++ b/tests/subsys/suit/ipuc/testcase.yaml
@@ -1,6 +1,9 @@
 tests:
   suit-platform.integration.ipuc:
     platform_allow: native_sim
-    tags: suit_platform suit ci_tests_subsys_suit
+    tags:
+      - suit_platform
+      - suit
+      - ci_tests_subsys_suit
     integration_platforms:
       - native_sim

--- a/tests/subsys/suit/manifest_variables/testcase.yaml
+++ b/tests/subsys/suit/manifest_variables/testcase.yaml
@@ -1,6 +1,9 @@
 tests:
   suit-platform.integration.manifest_variables:
     platform_allow: native_sim
-    tags: suit_platform suit ci_tests_subsys_suit
+    tags:
+      - suit_platform
+      - suit
+      - ci_tests_subsys_suit
     integration_platforms:
       - native_sim

--- a/tests/subsys/suit/mci/testcase.yaml
+++ b/tests/subsys/suit/mci/testcase.yaml
@@ -1,6 +1,11 @@
 tests:
   suit-processor.integration.suit_mci:
-    platform_allow: native_sim native_sim/native/64
-    tags: suit-mci suit ci_tests_subsys_suit
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+    tags:
+      - suit-mci
+      - suit
+      - ci_tests_subsys_suit
     integration_platforms:
       - native_sim

--- a/tests/subsys/suit/memptr_sink/testcase.yaml
+++ b/tests/subsys/suit/memptr_sink/testcase.yaml
@@ -1,7 +1,14 @@
 tests:
   suit-platform.integration.memptr_sink:
-    platform_allow: nrf52840dk/nrf52840 native_sim native_sim/native/64
-    tags: suit-processor suit_platform suit ci_tests_subsys_suit
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - native_sim
+      - native_sim/native/64
+    tags:
+      - suit-processor
+      - suit_platform
+      - suit
+      - ci_tests_subsys_suit
     integration_platforms:
       - nrf52840dk/nrf52840
       - native_sim

--- a/tests/subsys/suit/orchestrator/orchestrator_app/testcase.yaml
+++ b/tests/subsys/suit/orchestrator/orchestrator_app/testcase.yaml
@@ -1,7 +1,11 @@
 tests:
   suit.integration.orchestrator_app.minimal:
     platform_allow: native_sim
-    tags: suit suit_orchestrator_app suit_orchestrator_app_minimal ci_tests_subsys_suit
+    tags:
+      - suit
+      - suit_orchestrator_app
+      - suit_orchestrator_app_minimal
+      - ci_tests_subsys_suit
     timeout: 240
     extra_args: OVERLAY_CONFIG=minimal_processing.conf
     integration_platforms:
@@ -9,7 +13,11 @@ tests:
 
   suit.integration.orchestrator_app.full:
     platform_allow: native_sim
-    tags: suit suit_orchestrator_app suit_orchestrator_app_full ci_tests_subsys_suit
+    tags:
+      - suit
+      - suit_orchestrator_app
+      - suit_orchestrator_app_full
+      - ci_tests_subsys_suit
     timeout: 240
     extra_args: OVERLAY_CONFIG=full_processing.conf
     integration_platforms:

--- a/tests/subsys/suit/orchestrator/orchestrator_sdfw/testcase.yaml
+++ b/tests/subsys/suit/orchestrator/orchestrator_sdfw/testcase.yaml
@@ -1,7 +1,13 @@
 tests:
   suit.integration.orchestrator:
-    platform_allow: nrf52840dk/nrf52840 native_sim native_sim/native/64
-    tags: suit suit_orchestrator ci_tests_subsys_suit
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - native_sim
+      - native_sim/native/64
+    tags:
+      - suit
+      - suit_orchestrator
+      - ci_tests_subsys_suit
     timeout: 240
     integration_platforms:
       - nrf52840dk/nrf52840

--- a/tests/subsys/suit/orchestrator/orchestrator_sdfw_nrf54h20/testcase.yaml
+++ b/tests/subsys/suit/orchestrator/orchestrator_sdfw_nrf54h20/testcase.yaml
@@ -1,6 +1,10 @@
 tests:
   suit.integration.orchestrator_nrf54h20:
     platform_allow: native_sim
-    tags: suit suit_orchestrator nrf54h20 ci_tests_subsys_suit
+    tags:
+      - suit
+      - suit_orchestrator
+      - nrf54h20
+      - ci_tests_subsys_suit
     integration_platforms:
       - native_sim

--- a/tests/subsys/suit/ram_sink/testcase.yaml
+++ b/tests/subsys/suit/ram_sink/testcase.yaml
@@ -1,7 +1,14 @@
 tests:
   suit-platform.integration.ram_sink:
-    platform_allow: nrf52840dk/nrf52840 native_sim native_sim/native/64
-    tags: suit-processor suit_platform suit ci_tests_subsys_suit
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - native_sim
+      - native_sim/native/64
+    tags:
+      - suit-processor
+      - suit_platform
+      - suit
+      - ci_tests_subsys_suit
     integration_platforms:
       - nrf52840dk/nrf52840
       - native_sim

--- a/tests/subsys/suit/sink_selector/testcase.yaml
+++ b/tests/subsys/suit/sink_selector/testcase.yaml
@@ -1,6 +1,12 @@
 tests:
   suit-platform.integration.sink_selector:
-    platform_allow: native_sim native_sim/native/64
-    tags: suit-processor suit_platform suit ci_tests_subsys_suit
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+    tags:
+      - suit-processor
+      - suit_platform
+      - suit
+      - ci_tests_subsys_suit
     integration_platforms:
       - native_sim

--- a/tests/subsys/suit/storage/testcase.yaml
+++ b/tests/subsys/suit/storage/testcase.yaml
@@ -1,7 +1,14 @@
 tests:
   suit-processor.integration.suit_storage:
-    platform_allow: nrf52840dk/nrf52840 native_sim native_sim/native/64
-    tags: suit-processor suit_storage suit ci_tests_subsys_suit
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - native_sim
+      - native_sim/native/64
+    tags:
+      - suit-processor
+      - suit_storage
+      - suit
+      - ci_tests_subsys_suit
     integration_platforms:
       - nrf52840dk/nrf52840
       - native_sim

--- a/tests/subsys/suit/storage_nrf54h20/testcase.yaml
+++ b/tests/subsys/suit/storage_nrf54h20/testcase.yaml
@@ -1,6 +1,10 @@
 tests:
   suit-processor.integration.suit_storage_nrf54h20:
     platform_allow: native_sim
-    tags: suit-processor suit_storage suit ci_tests_subsys_suit
+    tags:
+      - suit-processor
+      - suit_storage
+      - suit
+      - ci_tests_subsys_suit
     integration_platforms:
       - native_sim

--- a/tests/subsys/suit/suit_memptr_storage/testcase.yaml
+++ b/tests/subsys/suit/suit_memptr_storage/testcase.yaml
@@ -1,7 +1,15 @@
 tests:
   suit-platform.integration.common.memptr_storage:
-    platform_allow: nrf52840dk/nrf52840 native_sim native_sim/native/64
-    tags: suit-processor suit_platform suit_memptr_storage suit ci_tests_subsys_suit
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - native_sim
+      - native_sim/native/64
+    tags:
+      - suit-processor
+      - suit_platform
+      - suit_memptr_storage
+      - suit
+      - ci_tests_subsys_suit
     integration_platforms:
       - nrf52840dk/nrf52840
       - native_sim

--- a/tests/subsys/suit/unit/app_specific/suit_plat_fetch_app/testcase.yaml
+++ b/tests/subsys/suit/unit/app_specific/suit_plat_fetch_app/testcase.yaml
@@ -1,12 +1,12 @@
 tests:
   suit.unit.platform_app.fetch:
     type: unit
-    tags: >-
-      suit
-      suit_platform
-      suit_platform_app_specific
-      suit_plat_fetch_domain_specific_is_type_supported
-      suit_plat_fetch_integrated_domain_specific_is_type_supported
-      suit_plat_fetch_domain_specific
-      suit_plat_fetch_integrated_domain_specific
-      ci_tests_subsys_suit
+    tags:
+      - suit
+      - suit_platform
+      - suit_platform_app_specific
+      - suit_plat_fetch_domain_specific_is_type_supported
+      - suit_plat_fetch_integrated_domain_specific_is_type_supported
+      - suit_plat_fetch_domain_specific
+      - suit_plat_fetch_integrated_domain_specific
+      - ci_tests_subsys_suit

--- a/tests/subsys/suit/unit/app_specific/suit_plat_retrieve_manifest_app/testcase.yaml
+++ b/tests/subsys/suit/unit/app_specific/suit_plat_retrieve_manifest_app/testcase.yaml
@@ -1,9 +1,9 @@
 tests:
   suit.unit.platform_app.retreve_manifest:
     type: unit
-    tags: >-
-      suit
-      suit_platform
-      suit_plat_app
-      suit_plat_retrieve_manifest_domain_specific
-      ci_tests_subsys_suit
+    tags:
+      - suit
+      - suit_platform
+      - suit_plat_app
+      - suit_plat_retrieve_manifest_domain_specific
+      - ci_tests_subsys_suit

--- a/tests/subsys/suit/unit/plat_devconfig/testcase.yaml
+++ b/tests/subsys/suit/unit/plat_devconfig/testcase.yaml
@@ -1,9 +1,9 @@
 tests:
   suit.unit.platform.devconfig:
     type: unit
-    tags: >-
-      suit
-      suit_platform
-      suit_plat_sequence_completed
-      suit_plat_authorize_sequence_num
-      ci_tests_subsys_suit
+    tags:
+      - suit
+      - suit_platform
+      - suit_plat_sequence_completed
+      - suit_plat_authorize_sequence_num
+      - ci_tests_subsys_suit

--- a/tests/subsys/suit/unit/suit_metadata/testcase.yaml
+++ b/tests/subsys/suit/unit/suit_metadata/testcase.yaml
@@ -1,8 +1,8 @@
 tests:
   suit.unit.metadata:
     type: unit
-    tags: >-
-      suit
-      suit_metadata
-      suit_metadata_version_from_array
-      ci_tests_subsys_suit
+    tags:
+      - suit
+      - suit_metadata
+      - suit_metadata_version_from_array
+      - ci_tests_subsys_suit

--- a/tests/subsys/suit/unit/suit_plat_authorize_component_id/testcase.yaml
+++ b/tests/subsys/suit/unit/suit_plat_authorize_component_id/testcase.yaml
@@ -1,8 +1,8 @@
 tests:
   suit.unit.platform.suit_plat_authorize_component_id:
     type: unit
-    tags: >-
-      suit
-      suit_platform
-      suit_plat_authorize_component_id
-      ci_tests_subsys_suit
+    tags:
+      - suit
+      - suit_platform
+      - suit_plat_authorize_component_id
+      - ci_tests_subsys_suit

--- a/tests/subsys/suit/unit/suit_plat_authorize_process_dependency/testcase.yaml
+++ b/tests/subsys/suit/unit/suit_plat_authorize_process_dependency/testcase.yaml
@@ -1,8 +1,8 @@
 tests:
   suit.unit.platform.suit_plat_authorize_process_dependency:
     type: unit
-    tags: >-
-      suit
-      suit_platform
-      suit_plat_authorize_process_dependency
-      ci_tests_subsys_suit
+    tags:
+      - suit
+      - suit_platform
+      - suit_plat_authorize_process_dependency
+      - ci_tests_subsys_suit

--- a/tests/subsys/suit/unit/suit_plat_check_image_match/testcase.yaml
+++ b/tests/subsys/suit/unit/suit_plat_check_image_match/testcase.yaml
@@ -1,8 +1,8 @@
 tests:
   suit.unit.platform.suit_plat_check_image_match:
     type: unit
-    tags: >-
-      suit
-      suit_platform
-      suit_plat_check_image_match
-      ci_tests_subsys_suit
+    tags:
+      - suit
+      - suit_platform
+      - suit_plat_check_image_match
+      - ci_tests_subsys_suit

--- a/tests/subsys/suit/unit/suit_plat_class_check/testcase.yaml
+++ b/tests/subsys/suit/unit/suit_plat_class_check/testcase.yaml
@@ -1,8 +1,8 @@
 tests:
   suit.unit.platform.suit_plat_class_check:
     type: unit
-    tags: >-
-      suit
-      suit_platform
-      suit_plat_class_check
-      ci_tests_subsys_suit
+    tags:
+      - suit
+      - suit_platform
+      - suit_plat_class_check
+      - ci_tests_subsys_suit

--- a/tests/subsys/suit/unit/suit_plat_component_compatibility/testcase.yaml
+++ b/tests/subsys/suit/unit/suit_plat_component_compatibility/testcase.yaml
@@ -1,8 +1,8 @@
 tests:
   suit.unit.platform.suit_plat_component_compatibility:
     type: unit
-    tags: >-
-      suit
-      suit_platform
-      suit_plat_component_compatibility
-      ci_tests_subsys_suit
+    tags:
+      - suit
+      - suit_platform
+      - suit_plat_component_compatibility
+      - ci_tests_subsys_suit

--- a/tests/subsys/suit/unit/suit_plat_components/testcase.yaml
+++ b/tests/subsys/suit/unit/suit_plat_components/testcase.yaml
@@ -1,8 +1,8 @@
 tests:
   suit.unit.platform.suit_plat_components:
     type: unit
-    tags: >-
-      suit
-      suit_platform
-      suit_plat_components
-      ci_tests_subsys_suit
+    tags:
+      - suit
+      - suit_platform
+      - suit_plat_components
+      - ci_tests_subsys_suit

--- a/tests/subsys/suit/unit/suit_plat_digest_cache/testcase.yaml
+++ b/tests/subsys/suit/unit/suit_plat_digest_cache/testcase.yaml
@@ -1,8 +1,8 @@
 tests:
   suit.unit.platform.suit_plat_digest_cache:
     type: unit
-    tags: >-
-      suit
-      suit_platform
-      suit_plat_digest_cache
-      ci_tests_subsys_suit
+    tags:
+      - suit
+      - suit_platform
+      - suit_plat_digest_cache
+      - ci_tests_subsys_suit

--- a/tests/subsys/suit/unit/suit_plat_memptr_size_update/testcase.yaml
+++ b/tests/subsys/suit/unit/suit_plat_memptr_size_update/testcase.yaml
@@ -1,8 +1,8 @@
 tests:
   suit.unit.platform.suit_plat_memptr_size_update:
     type: unit
-    tags: >-
-      suit
-      suit_platform
-      suit_plat_memptr_size_update
-      ci_tests_subsys_suit
+    tags:
+      - suit
+      - suit_platform
+      - suit_plat_memptr_size_update
+      - ci_tests_subsys_suit

--- a/tests/subsys/suit/unit/suit_plat_override_image_size/testcase.yaml
+++ b/tests/subsys/suit/unit/suit_plat_override_image_size/testcase.yaml
@@ -1,9 +1,9 @@
 tests:
   suit.unit.platform.override_image_size:
     type: unit
-    tags: >-
-      suit
-      suit_platform
-      suit_plat_override_image_size
-      suit_plat_create_component_handle
-      ci_tests_subsys_suit
+    tags:
+      - suit
+      - suit_platform
+      - suit_plat_override_image_size
+      - suit_plat_create_component_handle
+      - ci_tests_subsys_suit

--- a/tests/subsys/suit/unit/suit_plat_retrieve_manifest/testcase.yaml
+++ b/tests/subsys/suit/unit/suit_plat_retrieve_manifest/testcase.yaml
@@ -1,8 +1,8 @@
 tests:
   suit.unit.platform.retrieve_manifest:
     type: unit
-    tags: >-
-      suit
-      suit_platform
-      suit_plat_retrieve_manifest
-      ci_tests_subsys_suit
+    tags:
+      - suit
+      - suit_platform
+      - suit_plat_retrieve_manifest
+      - ci_tests_subsys_suit

--- a/tests/subsys/suit/unit/suit_plat_version/testcase.yaml
+++ b/tests/subsys/suit/unit/suit_plat_version/testcase.yaml
@@ -1,8 +1,8 @@
 tests:
   suit.unit.platform.version:
     type: unit
-    tags: >-
-      suit
-      suit_platform
-      suit_plat_version
-      ci_tests_subsys_suit
+    tags:
+      - suit
+      - suit_platform
+      - suit_plat_version
+      - ci_tests_subsys_suit

--- a/tests/subsys/suit/unit/suit_plat_version_app_specific/testcase.yaml
+++ b/tests/subsys/suit/unit/suit_plat_version_app_specific/testcase.yaml
@@ -1,9 +1,9 @@
 tests:
   suit.unit.platform.version.app:
     type: unit
-    tags: >-
-      suit
-      suit_platform
-      suit_plat_version
-      suit_plat_version_domain_specific
-      ci_tests_subsys_suit
+    tags:
+      - suit
+      - suit_platform
+      - suit_plat_version
+      - suit_plat_version_domain_specific
+      - ci_tests_subsys_suit

--- a/tests/subsys/suit/unit/suit_run_nrf54h20/testcase.yaml
+++ b/tests/subsys/suit/unit/suit_run_nrf54h20/testcase.yaml
@@ -1,8 +1,8 @@
 tests:
   suit.unit.platform.run_nrf54h20:
     type: unit
-    tags: >-
-      suit
-      suit_platform
-      suit_run_nrf54h20
-      ci_tests_subsys_suit
+    tags:
+      - suit
+      - suit_platform
+      - suit_run_nrf54h20
+      - ci_tests_subsys_suit

--- a/tests/subsys/suit/write/testcase.yaml
+++ b/tests/subsys/suit/write/testcase.yaml
@@ -1,7 +1,14 @@
 tests:
   suit-platform.integration.write:
-    platform_allow: nrf52840dk/nrf52840 native_sim native_sim/native/64
-    tags: suit-processor suit_platform suit ci_tests_subsys_suit
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - native_sim
+      - native_sim/native/64
+    tags:
+      - suit-processor
+      - suit_platform
+      - suit
+      - ci_tests_subsys_suit
     integration_platforms:
       - nrf52840dk/nrf52840
       - native_sim

--- a/tests/subsys/zigbee/osif/crypto/testcase.yaml
+++ b/tests/subsys/zigbee/osif/crypto/testcase.yaml
@@ -1,8 +1,14 @@
 tests:
   zigbee.osif.crypto:
     sysbuild: true
-    platform_allow: nrf52840dk/nrf52840 nrf52833dk/nrf52833 nrf5340dk/nrf5340/cpuapp
-    tags: osif_crypto sysbuild ci_tests_subsys_zigbee
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52833dk/nrf52833
+      - nrf5340dk/nrf5340/cpuapp
+    tags:
+      - osif_crypto
+      - sysbuild
+      - ci_tests_subsys_zigbee
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf52833dk/nrf52833

--- a/tests/subsys/zigbee/osif/nvram/testcase.yaml
+++ b/tests/subsys/zigbee/osif/nvram/testcase.yaml
@@ -1,8 +1,14 @@
 tests:
   zigbee.osif.nvram:
     sysbuild: true
-    platform_allow: nrf52840dk/nrf52840 nrf52833dk/nrf52833 nrf5340dk/nrf5340/cpuapp
-    tags: zigbee_nvram sysbuild ci_tests_subsys_zigbee
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52833dk/nrf52833
+      - nrf5340dk/nrf5340/cpuapp
+    tags:
+      - zigbee_nvram
+      - sysbuild
+      - ci_tests_subsys_zigbee
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf52833dk/nrf52833

--- a/tests/subsys/zigbee/osif/serial/serial_async_api/testcase.yaml
+++ b/tests/subsys/zigbee/osif/serial/serial_async_api/testcase.yaml
@@ -2,8 +2,14 @@ tests:
   zigbee.osif.serial.async:
     sysbuild: true
     depends_on: gpio
-    platform_allow: nrf52840dk/nrf52840 nrf52833dk/nrf52833 nrf5340dk/nrf5340/cpuapp
-    tags: osif_serial sysbuild ci_tests_subsys_zigbee
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52833dk/nrf52833
+      - nrf5340dk/nrf5340/cpuapp
+    tags:
+      - osif_serial
+      - sysbuild
+      - ci_tests_subsys_zigbee
     harness: ztest
     harness_config:
       fixture: gpio_loopback

--- a/tests/subsys/zigbee/osif/serial/serial_basic_api/testcase.yaml
+++ b/tests/subsys/zigbee/osif/serial/serial_basic_api/testcase.yaml
@@ -2,8 +2,14 @@ tests:
   zigbee.osif.serial.basic:
     sysbuild: true
     depends_on: gpio
-    platform_allow: nrf52840dk/nrf52840 nrf52833dk/nrf52833 nrf5340dk/nrf5340/cpuapp
-    tags: osif_serial sysbuild ci_tests_subsys_zigbee
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52833dk/nrf52833
+      - nrf5340dk/nrf5340/cpuapp
+    tags:
+      - osif_serial
+      - sysbuild
+      - ci_tests_subsys_zigbee
     harness: ztest
     harness_config:
       fixture: gpio_loopback

--- a/tests/subsys/zigbee/osif/serial/serial_via_logger/testcase.yaml
+++ b/tests/subsys/zigbee/osif/serial/serial_via_logger/testcase.yaml
@@ -1,8 +1,14 @@
 tests:
   zigbee.osif.serial.logger:
     sysbuild: true
-    platform_allow: nrf52840dk/nrf52840 nrf52833dk/nrf52833 nrf5340dk/nrf5340/cpuapp
-    tags: osif_logger sysbuild ci_tests_subsys_zigbee
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52833dk/nrf52833
+      - nrf5340dk/nrf5340/cpuapp
+    tags:
+      - osif_logger
+      - sysbuild
+      - ci_tests_subsys_zigbee
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf52833dk/nrf52833

--- a/tests/subsys/zigbee/osif/timer_counter/testcase.yaml
+++ b/tests/subsys/zigbee/osif/timer_counter/testcase.yaml
@@ -1,8 +1,14 @@
 tests:
   zigbee.osif.timer.counter:
     sysbuild: true
-    platform_allow: nrf52840dk/nrf52840 nrf52833dk/nrf52833 nrf5340dk/nrf5340/cpuapp
-    tags: zigbee_osif sysbuild ci_tests_subsys_zigbee
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52833dk/nrf52833
+      - nrf5340dk/nrf5340/cpuapp
+    tags:
+      - zigbee_osif
+      - sysbuild
+      - ci_tests_subsys_zigbee
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf52833dk/nrf52833

--- a/tests/subsys/zigbee/osif/timer_ktimer/testcase.yaml
+++ b/tests/subsys/zigbee/osif/timer_ktimer/testcase.yaml
@@ -1,8 +1,14 @@
 tests:
   zigbee.osif.timer.ktimer:
     sysbuild: true
-    platform_allow: nrf52840dk/nrf52840 nrf52833dk/nrf52833 nrf5340dk/nrf5340/cpuapp
-    tags: zigbee_osif sysbuild ci_tests_subsys_zigbee
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52833dk/nrf52833
+      - nrf5340dk/nrf5340/cpuapp
+    tags:
+      - zigbee_osif
+      - sysbuild
+      - ci_tests_subsys_zigbee
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf52833dk/nrf52833

--- a/tests/subsys/zigbee/zboss_api/alarm_api/testcase.yaml
+++ b/tests/subsys/zigbee/zboss_api/alarm_api/testcase.yaml
@@ -1,8 +1,14 @@
 tests:
   zigbee.zboss_api.alarm_api:
     sysbuild: true
-    platform_allow: nrf52840dk/nrf52840 nrf52833dk/nrf52833 nrf5340dk/nrf5340/cpuapp
-    tags: zboss_api_alarm sysbuild ci_tests_subsys_zigbee
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52833dk/nrf52833
+      - nrf5340dk/nrf5340/cpuapp
+    tags:
+      - zboss_api_alarm
+      - sysbuild
+      - ci_tests_subsys_zigbee
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf52833dk/nrf52833

--- a/tests/subsys/zigbee/zboss_api/callback_api/testcase.yaml
+++ b/tests/subsys/zigbee/zboss_api/callback_api/testcase.yaml
@@ -1,8 +1,14 @@
 tests:
   zigbee.zboss_api.callback_api:
     sysbuild: true
-    platform_allow: nrf52840dk/nrf52840 nrf52833dk/nrf52833 nrf5340dk/nrf5340/cpuapp
-    tags: zboss_api_callback sysbuild ci_tests_subsys_zigbee
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52833dk/nrf52833
+      - nrf5340dk/nrf5340/cpuapp
+    tags:
+      - zboss_api_callback
+      - sysbuild
+      - ci_tests_subsys_zigbee
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf52833dk/nrf52833

--- a/tests/tfm/secure_services/testcase.yaml
+++ b/tests/tfm/secure_services/testcase.yaml
@@ -6,7 +6,11 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags: tfm secure_services sysbuild ci_tests_tfm
+    tags:
+      - tfm
+      - secure_services
+      - sysbuild
+      - ci_tests_tfm
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf9151dk/nrf9151/ns

--- a/tests/tfm/tfm_psa_test/testcase.yaml
+++ b/tests/tfm/tfm_psa_test/testcase.yaml
@@ -1,5 +1,8 @@
 common:
-  tags: sysbuild tfm ci_tests_tfm
+  tags:
+    - sysbuild
+    - tfm
+    - ci_tests_tfm
   build_only: true
   sysbuild: true
   platform_allow:

--- a/tests/tfm/tfm_regression_test/testcase.yaml
+++ b/tests/tfm/tfm_regression_test/testcase.yaml
@@ -1,5 +1,7 @@
 common:
-  tags: tfm ci_tests_tfm
+  tags:
+    - tfm
+    - ci_tests_tfm
   build_only: true
   harness: console
   harness_config:
@@ -12,8 +14,13 @@ common:
 tests:
   tfm.regression_ipc_lvl1:
     sysbuild: true
-    tags: tfm_lvl1 sysbuild ci_tests_tfm
-    extra_args: CONFIG_TFM_IPC=y CONFIG_TFM_ISOLATION_LEVEL=1
+    tags:
+      - tfm_lvl1
+      - sysbuild
+      - ci_tests_tfm
+    extra_args:
+      - CONFIG_TFM_IPC=y
+      - CONFIG_TFM_ISOLATION_LEVEL=1
     timeout: 200
     platform_allow:
       - nrf5340dk/nrf5340/cpuapp/ns
@@ -29,8 +36,13 @@ tests:
       - nrf9161dk/nrf9161/ns
   tfm.regression_ipc_lvl2.cc3xx:
     sysbuild: true
-    tags: tfm_lvl2 sysbuild ci_tests_tfm
-    extra_args: CONFIG_PSA_CRYPTO_DRIVER_CC3XX=y CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
+    tags:
+      - tfm_lvl2
+      - sysbuild
+      - ci_tests_tfm
+    extra_args:
+      - CONFIG_PSA_CRYPTO_DRIVER_CC3XX=y
+      - CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
     timeout: 200
     platform_allow:
       - nrf5340dk/nrf5340/cpuapp/ns
@@ -44,8 +56,13 @@ tests:
       - nrf9161dk/nrf9161/ns
   tfm.regression_ipc_lvl2.oberon:
     sysbuild: true
-    tags: tfm_lvl2 sysbuild ci_tests_tfm
-    extra_args: CONFIG_PSA_CRYPTO_DRIVER_CC3XX=n CONFIG_PSA_CRYPTO_DRIVER_OBERON=y
+    tags:
+      - tfm_lvl2
+      - sysbuild
+      - ci_tests_tfm
+    extra_args:
+      - CONFIG_PSA_CRYPTO_DRIVER_CC3XX=n
+      - CONFIG_PSA_CRYPTO_DRIVER_OBERON=y
     timeout: 200
     platform_allow:
       - nrf5340dk/nrf5340/cpuapp/ns
@@ -59,8 +76,13 @@ tests:
       - nrf9161dk/nrf9161/ns
   tfm.regression_ipc_lvl2.cc3xx_oberon:
     sysbuild: true
-    tags: tfm_lvl2 sysbuild ci_tests_tfm
-    extra_args: CONFIG_PSA_CRYPTO_DRIVER_CC3XX=y CONFIG_PSA_CRYPTO_DRIVER_OBERON=y
+    tags:
+      - tfm_lvl2
+      - sysbuild
+      - ci_tests_tfm
+    extra_args:
+      - CONFIG_PSA_CRYPTO_DRIVER_CC3XX=y
+      - CONFIG_PSA_CRYPTO_DRIVER_OBERON=y
     timeout: 200
     platform_allow:
       - nrf5340dk/nrf5340/cpuapp/ns
@@ -74,8 +96,13 @@ tests:
       - nrf9161dk/nrf9161/ns
   tfm.regression_ipc_lvl2.cracen:
     sysbuild: true
-    tags: tfm_lvl2 sysbuild ci_tests_tfm
-    extra_args: CONFIG_PSA_CRYPTO_DRIVER_CRACEN=y CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
+    tags:
+      - tfm_lvl2
+      - sysbuild
+      - ci_tests_tfm
+    extra_args:
+      - CONFIG_PSA_CRYPTO_DRIVER_CRACEN=y
+      - CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
     timeout: 200
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp/ns
@@ -83,8 +110,13 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp/ns
   tfm.regression_sfn_lvl1:
     sysbuild: true
-    tags: tfm_lvl1 sysbuild ci_tests_tfm
-    extra_args: CONFIG_TFM_SFN=y CONFIG_TFM_ISOLATION_LEVEL=1
+    tags:
+      - tfm_lvl1
+      - sysbuild
+      - ci_tests_tfm
+    extra_args:
+      - CONFIG_TFM_SFN=y
+      - CONFIG_TFM_ISOLATION_LEVEL=1
     timeout: 200
     platform_allow:
       - nrf5340dk/nrf5340/cpuapp/ns
@@ -100,8 +132,13 @@ tests:
       - nrf9161dk/nrf9161/ns
   tfm.regression_fp_hardabi:
     sysbuild: true
-    tags: tfm_fp sysbuild ci_tests_tfm
-    extra_args: CONFIG_FPU=y CONFIG_FP_HARDABI=y
+    tags:
+      - tfm_fp
+      - sysbuild
+      - ci_tests_tfm
+    extra_args:
+      - CONFIG_FPU=y
+      - CONFIG_FP_HARDABI=y
     platform_allow:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp/ns

--- a/tests/unity/example_test/testcase.yaml
+++ b/tests/unity/example_test/testcase.yaml
@@ -1,7 +1,10 @@
 tests:
   unity.example_test:
     sysbuild: true
-    tags: example sysbuild ci_tests_unity
+    tags:
+      - example
+      - sysbuild
+      - ci_tests_unity
     integration_platforms:
       - native_sim
     platform_allow:

--- a/tests/unity/wrap_test/testcase.yaml
+++ b/tests/unity/wrap_test/testcase.yaml
@@ -1,7 +1,10 @@
 tests:
   unity.wrap_test:
     sysbuild: true
-    tags: wrap_test sysbuild ci_tests_unity
+    tags:
+      - wrap_test
+      - sysbuild
+      - ci_tests_unity
     platform_allow:
       - native_sim
     integration_platforms:


### PR DESCRIPTION
Support for space-separated lists has been deprecated for a while and it will be soon removed.

Automated using $ZEPHYR/scripts/utils/twister_to_list.py.

test_crypto: PR-735