### PR TITLE
samples: bluetooth: Enable ZMS for nRF54H20 platform

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -301,6 +301,21 @@ Bluetooth samples
       * :ref:`bluetooth_central_hids`
       * :ref:`peripheral_hids_keyboard`
       * :ref:`peripheral_hids_mouse`
+      * :ref:`central_and_peripheral_hrs`
+      * :ref:`central_bas`
+      * :ref:`central_nfc_pairing`
+      * :ref:`central_uart`
+      * :ref:`peripheral_bms`
+      * :ref:`peripheral_cgms`
+      * :ref:`peripheral_cts_client`
+      * :ref:`peripheral_lbs`
+      * :ref:`peripheral_mds`
+      * :ref:`peripheral_nfc_pairing`
+      * :ref:`power_profiling`
+      * :ref:`peripheral_rscs`
+      * :ref:`peripheral_status`
+      * :ref:`peripheral_uart`
+      * :ref:`ble_rpc_host`
 
     As a result, all :ref:`zephyr:nrf54h20dk_nrf54h20` configurations of the affected samples were migrated from the NVS settings backend to the ZMS settings backend.
   * Testing steps in the :ref:`peripheral_hids_mouse` to provide the build configuration that is compatible with the `Bluetooth Low Energy app`_ testing tool.

--- a/samples/bluetooth/central_and_peripheral_hr/Kconfig
+++ b/samples/bluetooth/central_and_peripheral_hr/Kconfig
@@ -7,7 +7,7 @@
 source "Kconfig.zephyr"
 
 config ZMS
-	default y if SOC_FLASH_NRF_RRAM
+	default y if (SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
 
 config NVS
-	default y if !SOC_FLASH_NRF_RRAM
+	default y if !(SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)

--- a/samples/bluetooth/central_bas/Kconfig
+++ b/samples/bluetooth/central_bas/Kconfig
@@ -10,7 +10,7 @@ config SETTINGS
 	default y
 
 config ZMS
-	default y if SOC_FLASH_NRF_RRAM
+	default y if (SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
 
 config NVS
-	default y if !SOC_FLASH_NRF_RRAM
+	default y if !(SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)

--- a/samples/bluetooth/central_nfc_pairing/Kconfig
+++ b/samples/bluetooth/central_nfc_pairing/Kconfig
@@ -10,7 +10,7 @@ config SETTINGS
 	default y
 
 config ZMS
-	default y if SOC_FLASH_NRF_RRAM
+	default y if (SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
 
 config NVS
-	default y if !SOC_FLASH_NRF_RRAM
+	default y if !(SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)

--- a/samples/bluetooth/central_uart/Kconfig
+++ b/samples/bluetooth/central_uart/Kconfig
@@ -10,7 +10,7 @@ config SETTINGS
 	default y
 
 config ZMS
-	default y if SOC_FLASH_NRF_RRAM
+	default y if (SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
 
 config NVS
-	default y if !SOC_FLASH_NRF_RRAM
+	default y if !(SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)

--- a/samples/bluetooth/peripheral_bms/Kconfig
+++ b/samples/bluetooth/peripheral_bms/Kconfig
@@ -10,7 +10,7 @@ config SETTINGS
 	default y
 
 config ZMS
-	default y if SOC_FLASH_NRF_RRAM
+	default y if (SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
 
 config NVS
-	default y if !SOC_FLASH_NRF_RRAM
+	default y if !(SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)

--- a/samples/bluetooth/peripheral_cgms/Kconfig
+++ b/samples/bluetooth/peripheral_cgms/Kconfig
@@ -10,7 +10,7 @@ config SETTINGS
 	default y
 
 config ZMS
-	default y if SOC_FLASH_NRF_RRAM
+	default y if (SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
 
 config NVS
-	default y if !SOC_FLASH_NRF_RRAM
+	default y if !(SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)

--- a/samples/bluetooth/peripheral_cts_client/Kconfig
+++ b/samples/bluetooth/peripheral_cts_client/Kconfig
@@ -10,7 +10,7 @@ config SETTINGS
 	default y
 
 config ZMS
-	default y if SOC_FLASH_NRF_RRAM
+	default y if (SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
 
 config NVS
-	default y if !SOC_FLASH_NRF_RRAM
+	default y if !(SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)

--- a/samples/bluetooth/peripheral_lbs/Kconfig
+++ b/samples/bluetooth/peripheral_lbs/Kconfig
@@ -16,8 +16,8 @@ config BT_LBS_SECURITY_ENABLED
 	select FLASH
 	select FLASH_PAGE_LAYOUT
 	select FLASH_MAP
-	select ZMS if SOC_FLASH_NRF_RRAM
-	select NVS if !SOC_FLASH_NRF_RRAM
+	select ZMS if (SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
+	select NVS if !(SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
 	select SETTINGS
 	help
 	  "Enable BLE security for the LED-Button service"

--- a/samples/bluetooth/peripheral_mds/Kconfig
+++ b/samples/bluetooth/peripheral_mds/Kconfig
@@ -10,7 +10,6 @@ config SETTINGS
 	default y
 
 config ZMS
-	default y if SOC_FLASH_NRF_RRAM
-
+	default y if (SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
 config NVS
-	default y if !SOC_FLASH_NRF_RRAM
+	default y if !(SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)

--- a/samples/bluetooth/peripheral_nfc_pairing/Kconfig
+++ b/samples/bluetooth/peripheral_nfc_pairing/Kconfig
@@ -34,10 +34,10 @@ config SETTINGS
 	default y
 
 config ZMS
-	default y if SOC_FLASH_NRF_RRAM
+	default y if (SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
 
 config NVS
-	default y if !SOC_FLASH_NRF_RRAM
+	default y if !(SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
 
 endmenu
 

--- a/samples/bluetooth/peripheral_power_profiling/Kconfig
+++ b/samples/bluetooth/peripheral_power_profiling/Kconfig
@@ -80,9 +80,9 @@ config SETTINGS
 	default y
 
 config ZMS
-	default y if SOC_FLASH_NRF_RRAM
+	default y if (SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
 
 config NVS
-	default y if !SOC_FLASH_NRF_RRAM
+	default y if !(SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
 
 endmenu

--- a/samples/bluetooth/peripheral_rscs/Kconfig
+++ b/samples/bluetooth/peripheral_rscs/Kconfig
@@ -16,8 +16,8 @@ config BT_RSCS_SECURITY_ENABLED
 	select FLASH
 	select FLASH_PAGE_LAYOUT
 	select FLASH_MAP
-	select ZMS if SOC_FLASH_NRF_RRAM
-	select NVS if !SOC_FLASH_NRF_RRAM
+	select ZMS if (SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
+	select NVS if !(SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
 	select SETTINGS
 	help
 	  "Enable Bluetooth LE security for the Running Speed and Cadence Service"

--- a/samples/bluetooth/peripheral_status/Kconfig
+++ b/samples/bluetooth/peripheral_status/Kconfig
@@ -16,8 +16,8 @@ config BT_STATUS_SECURITY_ENABLED
 	select FLASH
 	select FLASH_PAGE_LAYOUT
 	select FLASH_MAP
-	select ZMS if SOC_FLASH_NRF_RRAM
-	select NVS if !SOC_FLASH_NRF_RRAM
+	select ZMS if (SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
+	select NVS if !(SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
 	select SETTINGS
 	help
 	  Enable BLE security implementation for Nordic Status Message instances.

--- a/samples/bluetooth/peripheral_uart/Kconfig
+++ b/samples/bluetooth/peripheral_uart/Kconfig
@@ -37,9 +37,9 @@ config SETTINGS
 	default y
 
 config ZMS
-	default y if SOC_FLASH_NRF_RRAM
+	default y if !(SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
 
 config NVS
-	default y if !SOC_FLASH_NRF_RRAM
+	default y if !(SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
 
 endmenu

--- a/samples/bluetooth/rpc_host/Kconfig
+++ b/samples/bluetooth/rpc_host/Kconfig
@@ -10,7 +10,7 @@ config SETTINGS
 	default y
 
 config ZMS
-	default y if SOC_FLASH_NRF_RRAM
+	default y if (SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
 
 config NVS
-	default y if !SOC_FLASH_NRF_RRAM
+	default y if !(SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)


### PR DESCRIPTION
Enabled the ZMS file system for the nRF54H20 DK in the Bluetooth samples.