### PR TITLE
debug: ppi_trace: use nrfx_gppi to support nRF54L series devices

### DIFF
--- a/include/debug/ppi_trace.h
+++ b/include/debug/ppi_trace.h
@@ -8,6 +8,11 @@
 #define __PPI_TRACE_H
 
 #include <stdint.h>
+#include <nrfx.h>
+
+#if defined(DPPI_PRESENT)
+#include <nrfx_dppi.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -48,6 +53,8 @@ void *ppi_trace_config(uint32_t pin, uint32_t evt);
  */
 void *ppi_trace_pair_config(uint32_t pin, uint32_t start_evt, uint32_t stop_evt);
 
+#if defined(DPPI_PRESENT)
+
 /** @brief Configure and enable a PPI trace pin for tracing a DPPI channel.
  *
  * This function allows to trace DPPI triggers without knowing any events being the source of the
@@ -60,12 +67,16 @@ void *ppi_trace_pair_config(uint32_t pin, uint32_t start_evt, uint32_t stop_evt)
  *
  * @param pin		Pin to use for tracing.
  * @param dppi_ch	DPPI channel number to be traced on the pin.
+ * @param dppic		Identifies the instance of DPPIC controller that the @c dppi_ch channel
+ *			belongs to.
  *
  * @retval 0		The configuration succeeded.
  * @retval -ENOMEM	The configuration failed, due to lack of necessary resources.
  * @retval -ENOTSUP	The function is not supported on current hardware platform.
  */
-int ppi_trace_dppi_ch_trace(uint32_t pin, uint32_t dppi_ch);
+int ppi_trace_dppi_ch_trace(uint32_t pin, uint32_t dppi_ch, const nrfx_dppi_t *dppic);
+
+#endif /* DPPI_PRESENT */
 
 /** @brief Enable PPI trace pin.
  *

--- a/subsys/debug/ppi_trace/Kconfig
+++ b/subsys/debug/ppi_trace/Kconfig
@@ -7,8 +7,13 @@
 config PPI_TRACE
 	bool "Enable PPI trace"
 	select NRFX_GPIOTE
+	select NRFX_GPPI
 	select NRFX_PPI if HAS_HW_NRF_PPI
-	select NRFX_DPPI if HAS_HW_NRF_DPPIC
+	select NRFX_DPPI0 if SOC_SERIES_NRF53X
+	select NRFX_DPPI00 if SOC_SERIES_NRF54LX
+	select NRFX_DPPI10 if SOC_SERIES_NRF54LX
+	select NRFX_DPPI20 if SOC_SERIES_NRF54LX
+	select NRFX_DPPI30 if SOC_SERIES_NRF54LX
 	help
 	  Enable PPI trace module which enables forwarding hardware events to
 	  GPIOs.


### PR DESCRIPTION
The ppi_trace module is rewritten and uses now nrfx_gppi API. This is to support nRF54L series devices which have multiple DPPI controllers and require passing DPPI signals through PPIB bridges. The complexity is enclosed by nrfx-provided nrfx_gppi API for most functions.

The function `ppi_trace_dppi_ch_trace` (necessary for testing behavior of RADIO peripheral with mpsl/sdc/802.15.4) requires special handling. The function is given additional parameter `dppic` to identify the DPPIC controller the `dppi_ch` belongs to. This function cannot be a simple wrapper for nrfx-provided function. It is also wrapped by DPPI_PRESENT macro.

Details in commit messages.