### PR TITLE
bluetooth: add Kconfig options to enable optional CS capabilities

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -579,11 +579,27 @@ config BT_CTLR_CHANNEL_SOUNDING
 	select EXPERIMENTAL
 
 config BT_CTLR_SDC_CS_COUNT
-	int "Number of concurrent connections supporting CS procedure"
+	int "Number of concurrent connections supporting CS procedure [EXPERIMENTAL]"
 	default 1
 	depends on BT_CTLR_CHANNEL_SOUNDING
 	help
 	  Set the number of concurrent connections that can support Channel Sounding procedure.
+
+config BT_CTLR_SDC_CS_MAX_ANTENNA_PATHS
+	int "Max number of Channel Sounding antenna paths supported by the controller [EXPERIMENTAL]"
+	default 1
+	range 1 4
+	depends on BT_CTLR_CHANNEL_SOUNDING
+
+config BT_CTLR_SDC_CS_NUM_ANTENNAS
+	int "Number of antennas used in Channel Sounding procedure supported by the controller [EXPERIMENTAL]"
+	default 1
+	range 1 BT_CTLR_SDC_CS_MAX_ANTENNA_PATHS
+	depends on BT_CTLR_CHANNEL_SOUNDING
+
+config BT_CTLR_SDC_CS_STEP_MODE3
+	bool "Enable optional step mode-3 capability [EXPERIMENTAL]"
+	depends on BT_CTLR_CHANNEL_SOUNDING
 
 config BT_CTLR_SDC_LE_POWER_CLASS_1
 	bool "Device supports transmitting at LE Power Class 1 level"

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -1225,6 +1225,19 @@ static int configure_memory_usage(void)
 	}
 #endif
 
+#if defined(CONFIG_BT_CTLR_SDC_CS_COUNT)
+	cfg.cs_cfg.max_antenna_paths_supported = CONFIG_BT_CTLR_SDC_CS_MAX_ANTENNA_PATHS;
+	cfg.cs_cfg.num_antennas_supported = CONFIG_BT_CTLR_SDC_CS_NUM_ANTENNAS;
+	cfg.cs_cfg.step_mode3_supported = IS_ENABLED(CONFIG_BT_CTLR_SDC_CS_STEP_MODE3);
+
+	required_memory = sdc_cfg_set(SDC_DEFAULT_RESOURCE_CFG_TAG,
+									SDC_CFG_TYPE_CS_CFG,
+									&cfg);
+	if (required_memory < 0) {
+		return required_memory;
+	}
+#endif
+
 	LOG_DBG("BT mempool size: %u, required: %u",
 	       sizeof(sdc_mempool), required_memory);
 


### PR DESCRIPTION
added 3 new options to allow developers to use step mode-3 and multiple antenna during CS procedure