### PR TITLE
scripts: hid_configurator: Support pure ED25519 signature

### DIFF
--- a/scripts/hid_configurator/README.rst
+++ b/scripts/hid_configurator/README.rst
@@ -91,6 +91,18 @@ Complete the following steps:
       py -3 -m pip install -r requirements.txt
       py -3 -m pip install .
 
+.. note::
+   Currently, the ``imgtool`` from PyPI does not support pure ED25519 signature (used by nRF54L-based devices that enable MCUboot hardware cryptography).
+   This may result in rejecting proper DFU images (``DFU image is invalid``).
+   ``imgtool`` supporting pure ED25519 signature can be installed from the ``sdk-mcuboot`` repository (:file:`ncs/bootloader/mcuboot/scripts` directory of the |NCS|).
+   Run the following commands in the source directory to install ``imgtool`` and the required dependencies:
+
+   .. parsed-literal::
+      :class: highlight
+
+      py -3 -m pip install -r requirements.txt
+      py -3 -m pip install .
+
 Debian/Ubuntu/Linux Mint
 ========================
 
@@ -151,6 +163,17 @@ Complete the following steps:
       pip3 install --user -r requirements.txt
       pip3 install --user .
 
+.. note::
+   Currently, the ``imgtool`` from PyPI does not support pure ED25519 signature (used by nRF54L-based devices that enable MCUboot hardware cryptography).
+   This may result in rejecting proper DFU images (``DFU image is invalid``).
+   ``imgtool`` supporting pure ED25519 signature can be installed from the ``sdk-mcuboot`` repository (:file:`ncs/bootloader/mcuboot/scripts` directory of the |NCS|).
+   Run the following commands in the source directory to install ``imgtool`` and the required dependencies:
+
+   .. parsed-literal::
+      :class: highlight
+
+      pip3 install --user -r requirements.txt
+      pip3 install --user .
 
 Stopping fwupd daemon
 =====================

--- a/scripts/hid_configurator/modules/dfu.py
+++ b/scripts/hid_configurator/modules/dfu.py
@@ -209,7 +209,13 @@ def b0_get_dfu_image_bootloader_var():
 
 
 def mcuboot_common_is_dfu_file_correct(dfu_bin):
-    res, _, _ = imgtool.image.Image.verify(dfu_bin, None)
+    try:
+        res, _, _ = imgtool.image.Image.verify(dfu_bin, None)
+    except ValueError:
+        # `imgtool` from `sdk-mcuboot` repository is needed to support pure ED25519 signature.
+        # This `imgtool` package version modifies the `verify` function signature (the function
+        # returns one more value).
+        res, _, _, _ = imgtool.image.Image.verify(dfu_bin, None)
 
     if res != imgtool.image.VerifyResult.OK:
         print('DFU image is invalid')
@@ -219,7 +225,13 @@ def mcuboot_common_is_dfu_file_correct(dfu_bin):
 
 
 def mcuboot_common_get_dfu_image_version(dfu_bin):
-    res, ver, _ = imgtool.image.Image.verify(dfu_bin, None)
+    try:
+        res, ver, _ = imgtool.image.Image.verify(dfu_bin, None)
+    except ValueError:
+        # `imgtool` from `sdk-mcuboot` repository is needed to support pure ED25519 signature.
+        # This `imgtool` package version modifies the `verify` function signature (the function
+        # returns one more value).
+        res, ver, _, _ = imgtool.image.Image.verify(dfu_bin, None)
 
     if res != imgtool.image.VerifyResult.OK:
         print('Image in file is invalid')


### PR DESCRIPTION
Change adds support for pure ED25519 signature (used by nRF54L based devices that enable MCUboot hardware cryptography). imgtool from MCUboot upstream repository does not support this configuration, a dedicated imgtool version from sdk-mcuboot repository must be used.

Jira: NCSDK-30745