### PR TITLE
scripts: west_commands: create_board: fix openocd for nrf52

### DIFF
--- a/scripts/west_commands/create_board/templates/nrf52/board.cmake.jinja2
+++ b/scripts/west_commands/create_board/templates/nrf52/board.cmake.jinja2
@@ -1,4 +1,6 @@
 board_runner_args(jlink "--device={{ soc | replace("nrf", "nRF") }}_xx{{ variant[2:] | upper }}" "--speed=4000")
+
+set(OPENOCD_NRF5_SUBFAMILY "nrf52")
 board_runner_args(pyocd "--target={{ soc }}" "--frequency=4000000")
 
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)


### PR DESCRIPTION
Since custom boards may not contain the soc name as part of the board name, automatic guess does not work.