### PR TITLE
samples: bluetooth: central_uart: fix error handling for bt_scan_stop()

### DIFF
--- a/samples/bluetooth/central_uart/src/main.c
+++ b/samples/bluetooth/central_uart/src/main.c
@@ -386,7 +386,7 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 	}
 
 	err = bt_scan_stop();
-	if ((!err) && (err != -EALREADY)) {
+	if (err) {
 		LOG_ERR("Stop LE scan failed (err %d)", err);
 	}
 }


### PR DESCRIPTION
Update the error handling logic for the bt_scan_stop() call in the connected callback to print an error message if the function returns an error.

This fixes the issue where the error message was incorrectly printed on success.