### PR TITLE
samples: bluetooth: fast_pair: Align Tx power for nRF54H20DK

### DIFF
--- a/samples/bluetooth/fast_pair/input_device/prj.conf
+++ b/samples/bluetooth/fast_pair/input_device/prj.conf
@@ -42,6 +42,7 @@ CONFIG_BT_ADV_PROV_GAP_APPEARANCE_SD=y
 #   * nrf52833dk/nrf52833
 #   * nrf52840dk/nrf52840
 #   * nrf5340dk/nrf5340/cpuapp(/ns)
+#   * nrf54h20dk/nrf54h20/cpuapp
 CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL=-15
 
 # Use a separate workqueue for connection TX notify processing. This is done to work


### PR DESCRIPTION
Just edits the comment as default configuration is already aligned with nRF54H20DK.

Jira: NCSDK-30345