### PR TITLE
doc: edit nrfjprog/CLT deprecation note

### DIFF
--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -90,11 +90,11 @@
    You can continue to use it until the transition is complete in the |NCS| and the feature is removed in one of the upcoming |NCS| releases.
    For more information, see :ref:`zephyr:sysbuild`, :ref:`sysbuild_images`, :ref:`zephyr_samples_sysbuild`, and :ref:`sysbuild_forced_options`.
 
-.. |nrfjprog_deprecation_note| replace:: Starting with the |NCS| v2.8.0, nrfjprog is officially deprecated and will be removed in an upcoming release.
-   Transition to using `nRF Util (device command) <Device command overview_>`_ for all related tasks going forward.
+.. |nrfjprog_deprecation_note| replace:: Starting with the |NCS| v2.8.0, nrfjprog is in the process of being archived.
+   It will remain available for download, but `nRF Util (device command) <Device command overview_>`_ will gradually replace it.
 
-.. |nrf_CLT_deprecation_note| replace:: Starting with the |NCS| v2.8.0, the nRF Command Line Tools are officially deprecated and will be removed in an upcoming release.
-   Transition to using `nRF Util`_ for all related tasks going forward.
+.. |nrf_CLT_deprecation_note| replace:: Starting with the |NCS| v2.8.0, the nRF Command Line Tools are in the process of being archived.
+   They will remain available for download, but `nRF Util`_ will gradually replace them.
 
 .. ### Thread usage shortcuts
 


### PR DESCRIPTION
Updated wording from "deprecation" to the more correct "archiving". NCSDK-30819.