### PR TITLE
[Backport v2.8-branch] cmake: remove duplication of TOOLCHAIN_LD_FLAGS flags

### DIFF
--- a/subsys/nrf_security/cmake/extensions.cmake
+++ b/subsys/nrf_security/cmake/extensions.cmake
@@ -148,7 +148,6 @@ macro(nrf_security_add_zephyr_options lib_name)
 
     # Unsure if these are needed any more
     target_compile_options(${lib_name} PRIVATE ${TOOLCHAIN_C_FLAGS})
-    target_ld_options(${lib_name} PRIVATE ${TOOLCHAIN_LD_FLAGS})
   else()
     target_compile_options(${lib_name} PRIVATE "SHELL: -imacros ${ZEPHYR_AUTOCONF}")
     target_include_directories(${lib_name} PRIVATE
@@ -184,7 +183,6 @@ macro(nrf_security_add_zephyr_options_library lib_name)
 
     # Unsure if these are needed any more
     target_compile_options(${lib_name} PRIVATE ${TOOLCHAIN_C_FLAGS})
-    target_ld_options(${lib_name} PRIVATE ${TOOLCHAIN_LD_FLAGS})
   else()
     target_compile_options(${lib_name} PRIVATE "SHELL: -imacros ${ZEPHYR_AUTOCONF}")
     target_include_directories(${lib_name} PRIVATE


### PR DESCRIPTION
Backport 27f11591d852f79ff287c35de49574e07ce98555 from #19265.