### PR TITLE
subsys: sdfw services: add device information service.

### DIFF
--- a/include/sdfw/sdfw_services/device_info_service.h
+++ b/include/sdfw/sdfw_services/device_info_service.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef DEVICE_INFO_SERVICE_H__
+#define DEVICE_INFO_SERVICE_H__
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <sdfw/sdfw_services/ssf_errno.h>
+
+#define UUID_BYTES_LENGTH 16UL
+
+/**
+ * @brief       Read UUID value.
+ *
+ * @note        UUID byte order is the same as read from the memory
+ *              and no endianness swapping is performed.
+ *
+ * @param[out]  uuid_buff Local buffer for copying the UUID into.
+ *              use defined UUID_BYTES_LENGTH to specify its size.
+ *
+ * @return      0 on success, otherwise a negative errno defined in ssf_errno.h.
+ *              -SSF_ENOBUFS if invalid buffer.
+ *              -SSF_EPROTO if server code resulted in an error.
+ *              -SSF_EBADMSG if client received a bad response.
+ */
+int ssf_device_info_get_uuid(uint8_t *uuid_buff);
+
+#endif /* DEVICE_INFO_SERVICE_H__ */

--- a/subsys/sdfw_services/services/CMakeLists.txt
+++ b/subsys/sdfw_services/services/CMakeLists.txt
@@ -5,6 +5,7 @@
 #
 
 # Services
+add_subdirectory_ifdef(CONFIG_SSF_DEVICE_INFO_SERVICE_ENABLED device_info)
 add_subdirectory_ifdef(CONFIG_SSF_ECHO_SERVICE_ENABLED echo)
 add_subdirectory_ifdef(CONFIG_SSF_ENC_FW_SERVICE_ENABLED enc_fw)
 add_subdirectory_ifdef(CONFIG_SSF_EXTMEM_SERVICE_ENABLED extmem)

--- a/subsys/sdfw_services/services/Kconfig
+++ b/subsys/sdfw_services/services/Kconfig
@@ -5,6 +5,7 @@
 #
 
 # Services
+rsource "device_info/Kconfig"
 rsource "echo/Kconfig"
 rsource "enc_fw/Kconfig"
 rsource "extmem/Kconfig"

--- a/subsys/sdfw_services/services/device_info/CMakeLists.txt
+++ b/subsys/sdfw_services/services/device_info/CMakeLists.txt
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+zephyr_sources(device_info_service.c)
+
+generate_and_add_cbor_files(device_info_service.cddl zcbor_generated
+  device_info_service_req
+  device_info_service_rsp
+)

--- a/subsys/sdfw_services/services/device_info/Kconfig
+++ b/subsys/sdfw_services/services/device_info/Kconfig
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+service_name = DEVICE_INFO
+service_default_enabled = y
+service_id = 0x78
+service_version = 1
+service_buffer_size = 128
+service_name_str = Device Info
+rsource "../Kconfig.template.service"

--- a/subsys/sdfw_services/services/device_info/device_info_service.c
+++ b/subsys/sdfw_services/services/device_info/device_info_service.c
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <sdfw/sdfw_services/device_info_service.h>
+
+#include "device_info_service_decode.h"
+#include "device_info_service_encode.h"
+#include "device_info_service_types.h"
+#include <sdfw/sdfw_services/ssf_client.h>
+#include <sdfw/sdfw_services/ssf_errno.h>
+#include "ssf_client_os.h"
+
+/* Not exposed in header because not used by interface */
+#define TESTIMPRINT_BYTES_LENGTH 32UL
+
+SSF_CLIENT_SERVICE_DEFINE(device_info_srvc, DEVICE_INFO, cbor_encode_device_info_req,
+			  cbor_decode_device_info_resp);
+
+static int get_device_info_data(struct device_info *device_info_data)
+{
+	int ret = -SSF_ENODATA;
+
+	if (device_info_data != NULL) {
+		const uint8_t *rsp_pkt;
+
+		int stat = stat_INTERNAL_ERROR_c;
+
+		struct device_info_req device_info_request = {
+			.device_info_req_msg.read_req_action.operation_choice =
+				operation_READ_DEVICE_INFO_c,
+		};
+
+		struct device_info_resp device_info_response;
+
+		ret = ssf_client_send_request(&device_info_srvc, &device_info_request,
+					      &device_info_response, &rsp_pkt);
+		if (ret == 0) {
+			if (device_info_response.device_info_resp_msg.read_resp_action
+				    .operation_choice == operation_READ_DEVICE_INFO_c) {
+				stat = device_info_response.device_info_resp_msg.read_resp_status
+					       .stat_choice;
+				if (stat == stat_SUCCESS_c) {
+
+					/* copy device info data to provided struction */
+					device_info_data->device_info_partno =
+						device_info_response.device_info_resp_msg
+							.read_resp_data.device_info_partno;
+
+					device_info_data->device_info_type =
+						device_info_response.device_info_resp_msg
+							.read_resp_data.device_info_type;
+
+					device_info_data->device_info_hwrevision =
+						device_info_response.device_info_resp_msg
+							.read_resp_data.device_info_hwrevision;
+
+					device_info_data->device_info_productionrevision =
+						device_info_response.device_info_resp_msg
+							.read_resp_data
+							.device_info_productionrevision;
+
+					memcpy((uint8_t *)(device_info_data->device_info_testimprint
+								   .value),
+					       (uint8_t *)(device_info_response.device_info_resp_msg
+								   .read_resp_data
+								   .device_info_testimprint.value),
+					       device_info_response.device_info_resp_msg
+						       .read_resp_data.device_info_testimprint.len);
+
+					device_info_data->device_info_testimprint.len =
+						device_info_response.device_info_resp_msg
+							.read_resp_data.device_info_testimprint.len;
+
+					memcpy((uint8_t *)(device_info_data->device_info_uuid
+								   .value),
+					       (uint8_t *)(device_info_response.device_info_resp_msg
+								   .read_resp_data.device_info_uuid
+								   .value),
+					       device_info_response.device_info_resp_msg
+						       .read_resp_data.device_info_uuid.len);
+
+					device_info_data->device_info_uuid.len =
+						device_info_response.device_info_resp_msg
+							.read_resp_data.device_info_uuid.len;
+
+					/* operation is successful */
+					ret = 0;
+				} else {
+					/* operation failed on server side */
+					ret = -SSF_EPROTO;
+				}
+			} else {
+				/* the received response message is not a read device info response
+				 */
+				ret = -SSF_EBADMSG;
+			}
+
+			/* at least a response message was received, free response packet buffer */
+			ssf_client_decode_done(rsp_pkt);
+		} else {
+			/* ssf error, no response received, no need to free response packet */
+			/* return value will be returned by ssf_client_send_request call */
+		}
+	}
+
+	return ret;
+}
+
+int ssf_device_info_get_uuid(uint8_t *uuid_buff)
+{
+	int err = -SSF_ENODATA;
+
+	if (NULL != uuid_buff) {
+
+		uint8_t testimprint_bytes[TESTIMPRINT_BYTES_LENGTH] = {0};
+
+		struct device_info device_info_data = {
+			.device_info_partno = 0,
+			.device_info_type = 0,
+			.device_info_hwrevision = 0,
+			.device_info_productionrevision = 0,
+			.device_info_testimprint.value = testimprint_bytes,
+			.device_info_testimprint.len = TESTIMPRINT_BYTES_LENGTH,
+			/* caller provided buffer for UUID value */
+			.device_info_uuid.value = uuid_buff,
+			.device_info_uuid.len = UUID_BYTES_LENGTH,
+		};
+
+		err = get_device_info_data(&device_info_data);
+	} else {
+		err = -SSF_ENOBUFS;
+	}
+
+	return err;
+}

--- a/subsys/sdfw_services/services/device_info/device_info_service.cddl
+++ b/subsys/sdfw_services/services/device_info/device_info_service.cddl
@@ -1,0 +1,52 @@
+;
+; Copyright (c) 2024 Nordic Semiconductor ASA
+;
+; SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+;
+
+; .. include_startingpoint_device_info_cddl_rst
+
+stat = (SUCCESS: 0) /
+	(INTERNAL_ERROR: 16781313) /
+	(UNPROGRAMMED: 16781314)
+
+operation = (READ_DEVICE_INFO: 0) /
+	(UNSUPPORTED: 1)
+
+device_info = [
+    uuid: bstr .size 16,
+    type: uint,
+    testimprint: bstr .size 32,
+    partno: uint,
+    hwrevision: uint,
+    productionrevision: uint,
+]
+
+read_req = (
+      1,
+      action: operation,
+)
+
+; Device Info service response to read data.
+read_resp = (
+      1,
+      action: operation,
+	status: stat,
+	data: device_info,
+)
+
+device_info_req = [
+      2,
+      msg: (
+            read_req
+      ),
+]
+
+device_info_resp = [
+      2,
+      msg: (
+            read_resp
+      ),
+]
+
+; .. include_endingpoint_device_info_cddl_rst

--- a/subsys/sdfw_services/services/device_info/zcbor_generated/CMakeLists.txt
+++ b/subsys/sdfw_services/services/device_info/zcbor_generated/CMakeLists.txt
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+#
+# Generated using cmake macro generate_and_add_cbor_files.
+#
+
+zephyr_sources(
+	device_info_service_decode.c
+	device_info_service_encode.c
+)
+
+zephyr_include_directories(.)

--- a/subsys/sdfw_services/services/device_info/zcbor_generated/device_info_service_decode.c
+++ b/subsys/sdfw_services/services/device_info/zcbor_generated/device_info_service_decode.c
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/*
+ * Generated using zcbor version 0.9.0
+ * https://github.com/NordicSemiconductor/zcbor
+ * Generated with a --default-max-qty of 3
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+#include "zcbor_decode.h"
+#include "device_info_service_decode.h"
+#include "zcbor_print.h"
+
+#if DEFAULT_MAX_QTY != 3
+#error "The type file was generated with a different default_max_qty than this file"
+#endif
+
+#define log_result(state, result, func) do { \
+	if (!result) { \
+		zcbor_trace_file(state); \
+		zcbor_log("%s error: %s\r\n", func, zcbor_error_str(zcbor_peek_error(state))); \
+	} else { \
+		zcbor_log("%s success\r\n", func); \
+	} \
+} while(0)
+
+static bool decode_operation(zcbor_state_t *state, struct operation_r *result);
+static bool decode_stat(zcbor_state_t *state, struct stat_r *result);
+static bool decode_device_info(zcbor_state_t *state, struct device_info *result);
+static bool decode_read_req(zcbor_state_t *state, struct read_req *result);
+static bool decode_read_resp(zcbor_state_t *state, struct read_resp *result);
+static bool decode_device_info_req(zcbor_state_t *state, struct device_info_req *result);
+static bool decode_device_info_resp(zcbor_state_t *state, struct device_info_resp *result);
+
+
+static bool decode_operation(
+		zcbor_state_t *state, struct operation_r *result)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool res = (((((zcbor_uint_decode(state, &(*result).operation_choice, sizeof((*result).operation_choice)))) && ((((((*result).operation_choice == operation_READ_DEVICE_INFO_c) && ((1)))
+	|| (((*result).operation_choice == operation_UNSUPPORTED_c) && ((1)))) || (zcbor_error(state, ZCBOR_ERR_WRONG_VALUE), false))))));
+
+	log_result(state, res, __func__);
+	return res;
+}
+
+static bool decode_stat(
+		zcbor_state_t *state, struct stat_r *result)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool res = (((((zcbor_uint_decode(state, &(*result).stat_choice, sizeof((*result).stat_choice)))) && ((((((*result).stat_choice == stat_SUCCESS_c) && ((1)))
+	|| (((*result).stat_choice == stat_INTERNAL_ERROR_c) && ((1)))
+	|| (((*result).stat_choice == stat_UNPROGRAMMED_c) && ((1)))) || (zcbor_error(state, ZCBOR_ERR_WRONG_VALUE), false))))));
+
+	log_result(state, res, __func__);
+	return res;
+}
+
+static bool decode_device_info(
+		zcbor_state_t *state, struct device_info *result)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool res = (((zcbor_list_start_decode(state) && ((((zcbor_bstr_decode(state, (&(*result).device_info_uuid)))
+	&& ((((*result).device_info_uuid.len == 16)) || (zcbor_error(state, ZCBOR_ERR_WRONG_RANGE), false)))
+	&& ((zcbor_uint32_decode(state, (&(*result).device_info_type))))
+	&& ((zcbor_bstr_decode(state, (&(*result).device_info_testimprint)))
+	&& ((((*result).device_info_testimprint.len == 32)) || (zcbor_error(state, ZCBOR_ERR_WRONG_RANGE), false)))
+	&& ((zcbor_uint32_decode(state, (&(*result).device_info_partno))))
+	&& ((zcbor_uint32_decode(state, (&(*result).device_info_hwrevision))))
+	&& ((zcbor_uint32_decode(state, (&(*result).device_info_productionrevision))))) || (zcbor_list_map_end_force_decode(state), false)) && zcbor_list_end_decode(state))));
+
+	log_result(state, res, __func__);
+	return res;
+}
+
+static bool decode_read_req(
+		zcbor_state_t *state, struct read_req *result)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool res = (((((zcbor_uint32_expect(state, (1))))
+	&& ((decode_operation(state, (&(*result).read_req_action)))))));
+
+	log_result(state, res, __func__);
+	return res;
+}
+
+static bool decode_read_resp(
+		zcbor_state_t *state, struct read_resp *result)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool res = (((((zcbor_uint32_expect(state, (1))))
+	&& ((decode_operation(state, (&(*result).read_resp_action))))
+	&& ((decode_stat(state, (&(*result).read_resp_status))))
+	&& ((decode_device_info(state, (&(*result).read_resp_data)))))));
+
+	log_result(state, res, __func__);
+	return res;
+}
+
+static bool decode_device_info_req(
+		zcbor_state_t *state, struct device_info_req *result)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool res = (((zcbor_list_start_decode(state) && ((((zcbor_uint32_expect(state, (2))))
+	&& ((decode_read_req(state, (&(*result).device_info_req_msg))))) || (zcbor_list_map_end_force_decode(state), false)) && zcbor_list_end_decode(state))));
+
+	log_result(state, res, __func__);
+	return res;
+}
+
+static bool decode_device_info_resp(
+		zcbor_state_t *state, struct device_info_resp *result)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool res = (((zcbor_list_start_decode(state) && ((((zcbor_uint32_expect(state, (2))))
+	&& ((decode_read_resp(state, (&(*result).device_info_resp_msg))))) || (zcbor_list_map_end_force_decode(state), false)) && zcbor_list_end_decode(state))));
+
+	log_result(state, res, __func__);
+	return res;
+}
+
+
+
+int cbor_decode_device_info_req(
+		const uint8_t *payload, size_t payload_len,
+		struct device_info_req *result,
+		size_t *payload_len_out)
+{
+	zcbor_state_t states[4];
+
+	return zcbor_entry_function(payload, payload_len, (void *)result, payload_len_out, states,
+		(zcbor_decoder_t *)decode_device_info_req, sizeof(states) / sizeof(zcbor_state_t), 1);
+}
+
+
+
+int cbor_decode_device_info_resp(
+		const uint8_t *payload, size_t payload_len,
+		struct device_info_resp *result,
+		size_t *payload_len_out)
+{
+	zcbor_state_t states[4];
+
+	return zcbor_entry_function(payload, payload_len, (void *)result, payload_len_out, states,
+		(zcbor_decoder_t *)decode_device_info_resp, sizeof(states) / sizeof(zcbor_state_t), 1);
+}

--- a/subsys/sdfw_services/services/device_info/zcbor_generated/device_info_service_decode.h
+++ b/subsys/sdfw_services/services/device_info/zcbor_generated/device_info_service_decode.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/*
+ * Generated using zcbor version 0.9.0
+ * https://github.com/NordicSemiconductor/zcbor
+ * Generated with a --default-max-qty of 3
+ */
+
+#ifndef DEVICE_INFO_SERVICE_DECODE_H__
+#define DEVICE_INFO_SERVICE_DECODE_H__
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+#include "device_info_service_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if DEFAULT_MAX_QTY != 3
+#error "The type file was generated with a different default_max_qty than this file"
+#endif
+
+
+int cbor_decode_device_info_req(
+		const uint8_t *payload, size_t payload_len,
+		struct device_info_req *result,
+		size_t *payload_len_out);
+
+
+int cbor_decode_device_info_resp(
+		const uint8_t *payload, size_t payload_len,
+		struct device_info_resp *result,
+		size_t *payload_len_out);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEVICE_INFO_SERVICE_DECODE_H__ */

--- a/subsys/sdfw_services/services/device_info/zcbor_generated/device_info_service_encode.c
+++ b/subsys/sdfw_services/services/device_info/zcbor_generated/device_info_service_encode.c
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/*
+ * Generated using zcbor version 0.9.0
+ * https://github.com/NordicSemiconductor/zcbor
+ * Generated with a --default-max-qty of 3
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+#include "zcbor_encode.h"
+#include "device_info_service_encode.h"
+#include "zcbor_print.h"
+
+#if DEFAULT_MAX_QTY != 3
+#error "The type file was generated with a different default_max_qty than this file"
+#endif
+
+#define log_result(state, result, func) do { \
+	if (!result) { \
+		zcbor_trace_file(state); \
+		zcbor_log("%s error: %s\r\n", func, zcbor_error_str(zcbor_peek_error(state))); \
+	} else { \
+		zcbor_log("%s success\r\n", func); \
+	} \
+} while(0)
+
+static bool encode_operation(zcbor_state_t *state, const struct operation_r *input);
+static bool encode_stat(zcbor_state_t *state, const struct stat_r *input);
+static bool encode_device_info(zcbor_state_t *state, const struct device_info *input);
+static bool encode_read_req(zcbor_state_t *state, const struct read_req *input);
+static bool encode_read_resp(zcbor_state_t *state, const struct read_resp *input);
+static bool encode_device_info_req(zcbor_state_t *state, const struct device_info_req *input);
+static bool encode_device_info_resp(zcbor_state_t *state, const struct device_info_resp *input);
+
+static bool encode_operation(
+		zcbor_state_t *state, const struct operation_r *input)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool res = (((((*input).operation_choice == operation_READ_DEVICE_INFO_c) ? ((zcbor_uint32_put(state, (0))))
+	: (((*input).operation_choice == operation_UNSUPPORTED_c) ? ((zcbor_uint32_put(state, (1))))
+	: false))));
+
+	log_result(state, res, __func__);
+	return res;
+}
+
+static bool encode_stat(
+		zcbor_state_t *state, const struct stat_r *input)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool res = (((((*input).stat_choice == stat_SUCCESS_c) ? ((zcbor_uint32_put(state, (0))))
+	: (((*input).stat_choice == stat_INTERNAL_ERROR_c) ? ((zcbor_uint32_put(state, (16781313))))
+	: (((*input).stat_choice == stat_UNPROGRAMMED_c) ? ((zcbor_uint32_put(state, (16781314))))
+	: false)))));
+
+	log_result(state, res, __func__);
+	return res;
+}
+
+static bool encode_device_info(
+		zcbor_state_t *state, const struct device_info *input)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool res = (((zcbor_list_start_encode(state, 6) && (((((((*input).device_info_uuid.len == 16)) || (zcbor_error(state, ZCBOR_ERR_WRONG_RANGE), false))
+	&& (zcbor_bstr_encode(state, (&(*input).device_info_uuid))))
+	&& ((zcbor_uint32_encode(state, (&(*input).device_info_type))))
+	&& (((((*input).device_info_testimprint.len == 32)) || (zcbor_error(state, ZCBOR_ERR_WRONG_RANGE), false))
+	&& (zcbor_bstr_encode(state, (&(*input).device_info_testimprint))))
+	&& ((zcbor_uint32_encode(state, (&(*input).device_info_partno))))
+	&& ((zcbor_uint32_encode(state, (&(*input).device_info_hwrevision))))
+	&& ((zcbor_uint32_encode(state, (&(*input).device_info_productionrevision))))) || (zcbor_list_map_end_force_encode(state), false)) && zcbor_list_end_encode(state, 6))));
+
+	log_result(state, res, __func__);
+	return res;
+}
+
+static bool encode_read_req(
+		zcbor_state_t *state, const struct read_req *input)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool res = (((((zcbor_uint32_put(state, (1))))
+	&& ((encode_operation(state, (&(*input).read_req_action)))))));
+
+	log_result(state, res, __func__);
+	return res;
+}
+
+static bool encode_read_resp(
+		zcbor_state_t *state, const struct read_resp *input)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool res = (((((zcbor_uint32_put(state, (1))))
+	&& ((encode_operation(state, (&(*input).read_resp_action))))
+	&& ((encode_stat(state, (&(*input).read_resp_status))))
+	&& ((encode_device_info(state, (&(*input).read_resp_data)))))));
+
+	log_result(state, res, __func__);
+	return res;
+}
+
+static bool encode_device_info_req(
+		zcbor_state_t *state, const struct device_info_req *input)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool res = (((zcbor_list_start_encode(state, 3) && ((((zcbor_uint32_put(state, (2))))
+	&& ((encode_read_req(state, (&(*input).device_info_req_msg))))) || (zcbor_list_map_end_force_encode(state), false)) && zcbor_list_end_encode(state, 3))));
+
+	log_result(state, res, __func__);
+	return res;
+}
+
+static bool encode_device_info_resp(
+		zcbor_state_t *state, const struct device_info_resp *input)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool res = (((zcbor_list_start_encode(state, 5) && ((((zcbor_uint32_put(state, (2))))
+	&& ((encode_read_resp(state, (&(*input).device_info_resp_msg))))) || (zcbor_list_map_end_force_encode(state), false)) && zcbor_list_end_encode(state, 5))));
+
+	log_result(state, res, __func__);
+	return res;
+}
+
+
+
+int cbor_encode_device_info_req(
+		uint8_t *payload, size_t payload_len,
+		const struct device_info_req *input,
+		size_t *payload_len_out)
+{
+	zcbor_state_t states[4];
+
+	return zcbor_entry_function(payload, payload_len, (void *)input, payload_len_out, states,
+		(zcbor_decoder_t *)encode_device_info_req, sizeof(states) / sizeof(zcbor_state_t), 1);
+}
+
+
+
+int cbor_encode_device_info_resp(
+		uint8_t *payload, size_t payload_len,
+		const struct device_info_resp *input,
+		size_t *payload_len_out)
+{
+	zcbor_state_t states[4];
+
+	return zcbor_entry_function(payload, payload_len, (void *)input, payload_len_out, states,
+		(zcbor_decoder_t *)encode_device_info_resp, sizeof(states) / sizeof(zcbor_state_t), 1);
+}

--- a/subsys/sdfw_services/services/device_info/zcbor_generated/device_info_service_encode.h
+++ b/subsys/sdfw_services/services/device_info/zcbor_generated/device_info_service_encode.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/*
+ * Generated using zcbor version 0.9.0
+ * https://github.com/NordicSemiconductor/zcbor
+ * Generated with a --default-max-qty of 3
+ */
+
+#ifndef DEVICE_INFO_SERVICE_ENCODE_H__
+#define DEVICE_INFO_SERVICE_ENCODE_H__
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+#include "device_info_service_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if DEFAULT_MAX_QTY != 3
+#error "The type file was generated with a different default_max_qty than this file"
+#endif
+
+
+int cbor_encode_device_info_req(
+		uint8_t *payload, size_t payload_len,
+		const struct device_info_req *input,
+		size_t *payload_len_out);
+
+
+int cbor_encode_device_info_resp(
+		uint8_t *payload, size_t payload_len,
+		const struct device_info_resp *input,
+		size_t *payload_len_out);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEVICE_INFO_SERVICE_ENCODE_H__ */

--- a/subsys/sdfw_services/services/device_info/zcbor_generated/device_info_service_types.h
+++ b/subsys/sdfw_services/services/device_info/zcbor_generated/device_info_service_types.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/*
+ * Generated using zcbor version 0.9.0
+ * https://github.com/NordicSemiconductor/zcbor
+ * Generated with a --default-max-qty of 3
+ */
+
+#ifndef DEVICE_INFO_SERVICE_TYPES_H__
+#define DEVICE_INFO_SERVICE_TYPES_H__
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <zcbor_common.h>
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Which value for --default-max-qty this file was created with.
+ *
+ *  The define is used in the other generated file to do a build-time
+ *  compatibility check.
+ *
+ *  See `zcbor --help` for more information about --default-max-qty
+ */
+#define DEFAULT_MAX_QTY 3
+
+struct operation_r {
+	enum {
+		operation_READ_DEVICE_INFO_c = 0,
+		operation_UNSUPPORTED_c = 1,
+	} operation_choice;
+};
+
+struct stat_r {
+	enum {
+		stat_SUCCESS_c = 0,
+		stat_INTERNAL_ERROR_c = 16781313,
+		stat_UNPROGRAMMED_c = 16781314,
+	} stat_choice;
+};
+
+struct device_info {
+	struct zcbor_string device_info_uuid;
+	uint32_t device_info_type;
+	struct zcbor_string device_info_testimprint;
+	uint32_t device_info_partno;
+	uint32_t device_info_hwrevision;
+	uint32_t device_info_productionrevision;
+};
+
+struct read_req {
+	struct operation_r read_req_action;
+};
+
+struct read_resp {
+	struct operation_r read_resp_action;
+	struct stat_r read_resp_status;
+	struct device_info read_resp_data;
+};
+
+struct device_info_req {
+	struct read_req device_info_req_msg;
+};
+
+struct device_info_resp {
+	struct read_resp device_info_resp_msg;
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEVICE_INFO_SERVICE_TYPES_H__ */


### PR DESCRIPTION
Enable reading device information (UUID for instance) as a service requested by a client and executed by the secure domain.