### PR TITLE
doc: Edits to the code owner file for the doc ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -89,7 +89,7 @@
 /doc/nrf/app_dev/device_guides/nrf91/     @nrfconnect/ncs-modem-doc
 /doc/nrf/app_dev/device_guides/nrf91/nrf91_snippet.rst @nrfconnect/ncs-cia-doc
 /doc/nrf/app_dev/device_guides/pmic/      @nrfconnect/ncs-pmic-doc
-/doc/nrf/app_dev/device_guides/nrf54h/ @FrancescoSer
+/doc/nrf/app_dev/device_guides/nrf54h/    @FrancescoSer
 /doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_suit_*.rst @nrfconnect/ncs-charon-doc
 /doc/nrf/app_dev/device_guides/wifi_coex.rst @nrfconnect/ncs-doc-leads
 /doc/nrf/dev_model_and_contributions/     @nrfconnect/ncs-doc-leads @nrfconnect/ncs-vestavind-doc
@@ -122,10 +122,10 @@
 /doc/nrf/installation/                    @nrfconnect/ncs-doc-leads @nrfconnect/ncs-vestavind-doc @nrfconnect/ncs-wayland-doc
 /doc/nrf/libraries/bin/                   @nrfconnect/ncs-doc-leads
 /doc/nrf/libraries/bin/lwm2m_carrier/     @nrfconnect/ncs-carrier-doc
-/doc/nrf/libraries/bluetooth/    @nrfconnect/ncs-si-muffin-doc @nrfconnect/ncs-dragoon-doc
-/doc/nrf/libraries/bluetooth/mesh/ @nrfconnect/ncs-paladin-doc
+/doc/nrf/libraries/bluetooth/             @nrfconnect/ncs-si-muffin-doc @nrfconnect/ncs-dragoon-doc
+/doc/nrf/libraries/bluetooth/mesh/        @nrfconnect/ncs-paladin-doc
 /doc/nrf/libraries/bluetooth/adv_prov.rst @nrfconnect/ncs-si-bluebagel-doc
-/doc/nrf/libraries/bluetooth/mesh.rst @nrfconnect/ncs-paladin-doc
+/doc/nrf/libraries/bluetooth/mesh.rst     @nrfconnect/ncs-paladin-doc
 /doc/nrf/libraries/bluetooth/services/fast_pair.rst @nrfconnect/ncs-si-bluebagel-doc
 /doc/nrf/libraries/bluetooth/services/wifi_prov.rst @nrfconnect/ncs-wifi-doc
 /doc/nrf/libraries/caf/                   @nrfconnect/ncs-si-muffin-doc @nrfconnect/ncs-si-bluebagel-doc
@@ -174,14 +174,18 @@
 /doc/nrf/libraries/networking/nrf_cloud.rst @nrfconnect/ncs-nrf-cloud-doc
 /doc/nrf/libraries/networking/nrf_cloud_*.rst @nrfconnect/ncs-nrf-cloud-doc
 /doc/nrf/libraries/networking/nrf_provisioning.rst @nrfconnect/ncs-iot-oulu-tampere-doc
-/doc/nrf/libraries/networking/ot_rpc.rst @nrfconnect/ncs-terahertz-doc @nrfconnect/ncs-protocols-serialization
+/doc/nrf/libraries/networking/ot_rpc.rst  @nrfconnect/ncs-terahertz-doc @nrfconnect/ncs-protocols-serialization
 /doc/nrf/libraries/networking/rest_client.rst @nrfconnect/ncs-iot-positioning-doc
 /doc/nrf/libraries/networking/softap_wifi_provision.rst @nrfconnect/ncs-cia-doc
 /doc/nrf/libraries/networking/wifi_credentials.rst @nrfconnect/ncs-cia-doc
 /doc/nrf/libraries/networking/wifi_mgmt_ext.rst @nrfconnect/ncs-cia-doc
 /doc/nrf/libraries/networking/wifi_ready.rst @nrfconnect/ncs-wifi-doc
 /doc/nrf/libraries/nfc/                   @nrfconnect/ncs-si-muffin-doc
-/doc/nrf/libraries/nrf_rpc/               @nrfconnect/ncs-si-muffin-doc
+/doc/nrf/libraries/nrf_rpc/index.rst      @nrfconnect/ncs-si-muffin-doc
+/doc/nrf/libraries/nrf_rpc/nrf_rpc_ipc.rst @nrfconnect/ncs-si-muffin-doc
+/doc/nrf/libraries/nrf_rpc/nrf_rpc_uart.rst @nrfconnect/ncs-si-muffin-doc
+/doc/nrf/libraries/nrf_rpc/nrf_rpc_dev_info.rst @nrfconnect/ncs-terahertz-doc
+
 /doc/nrf/libraries/others/adp536x.rst     @nrfconnect/ncs-cia-doc
 /doc/nrf/libraries/others/app_event_manager.rst @nrfconnect/ncs-si-muffin-doc @nrfconnect/ncs-si-bluebagel-doc
 /doc/nrf/libraries/others/app_event_manager_profiler_tracer.rst @nrfconnect/ncs-si-bluebagel-doc
@@ -534,11 +538,57 @@
 /samples/app_event_manager/*.rst          @nrfconnect/ncs-si-muffin-doc @nrfconnect/ncs-si-bluebagel-doc
 /samples/app_event_manager_profiler_tracer/*.rst @nrfconnect/ncs-si-muffin-doc
 /samples/benchmarks/coremark/*.rst        @nrfconnect/ncs-si-bluebagel-doc
-/samples/bluetooth/**/*.rst               @nrfconnect/ncs-dragoon-doc @nrfconnect/ncs-si-muffin-doc
+/samples/bluetooth/**/*.rst                @nrfconnect/ncs-si-bluebagel-doc @nrfconnect/ncs-si-muffin-doc
+/samples/bluetooth/central_and_peripheral_hr/*.rst @nrfconnect/ncs-si-muffin-doc
+/samples/bluetooth/central_bas/*.rst      @nrfconnect/ncs-si-muffin-doc
 /samples/bluetooth/nrf_auraconfig/*.rst   @nrfconnect/ncs-audio-doc
 /samples/bluetooth/*_hids*/*.rst          @nrfconnect/ncs-si-bluebagel-doc
+/samples/bluetooth/central_hr_coded/*.rst @nrfconnect/ncs-si-muffin-doc
+/samples/bluetooth/central_nfc_pairing/*.rst @nrfconnect/ncs-si-muffin-doc
+/samples/bluetooth/central_smp_client/*.rst @nrfconnect/ncs-si-muffin-doc
+/samples/bluetooth/central_uart/*.rst     @nrfconnect/ncs-si-muffin-doc
+/samples/bluetooth/channel_sounding_ras_initiator/*.rst @nrfconnect/ncs-dragoon-doc
+/samples/bluetooth/channel_sounding_ras_reflector/*.rst @nrfconnect/ncs-dragoon-doc
+/samples/bluetooth/conn_time_sync/*.rst   @nrfconnect/ncs-dragoon-doc
+/samples/bluetooth/direction_finding_central/*.rst @nrfconnect/ncs-dragoon-doc
+/samples/bluetooth/direction_finding_connectionless_rx/*.rst @nrfconnect/ncs-dragoon-doc
+/samples/bluetooth/direction_finding_connectionless_tx/*.rst @nrfconnect/ncs-dragoon-doc
+/samples/bluetooth/direction_finding_peripheral/*.rst @nrfconnect/ncs-dragoon-doc
+/samples/bluetooth/direct_test_mode/*.rst @nrfconnect/ncs-si-muffin-doc
+/samples/bluetooth/enocean/*.rst          @nrfconnect/ncs-paladin-doc
+/samples/bluetooth/event_trigger/*.rst    @nrfconnect/ncs-dragoon-doc
 /samples/bluetooth/fast_pair/**/*.rst     @nrfconnect/ncs-si-bluebagel-doc
 /samples/bluetooth/mesh/**/*.rst          @nrfconnect/ncs-paladin-doc
+/samples/bluetooth/hci_lpuart/*.rst       @nrfconnect/ncs-doc-leads
+/samples/bluetooth/iso_combined_bis_and_cis/*.rst @nrfconnect/ncs-dragoon-doc
+/samples/bluetooth/iso_time_sync/*.rst    @nrfconnect/ncs-dragoon-doc
+/samples/bluetooth/llpm/*.rst             @nrfconnect/ncs-dragoon-doc
+/samples/bluetooth/multiple_adv_sets/*.rst @nrfconnect/ncs-si-muffin-doc
+/samples/bluetooth/nrf_dm/*.rst           @nrfconnect/ncs-si-muffin-doc
+/samples/bluetooth/peripheral_ams_client/*.rst @nrfconnect/ncs-si-muffin-doc
+/samples/bluetooth/peripheral_ancs_client/*.rst @nrfconnect/ncs-si-muffin-doc
+/samples/bluetooth/peripheral_bms/*.rst   @nrfconnect/ncs-si-muffin-doc
+/samples/bluetooth/peripheral_cgms/*.rst  @nrfconnect/ncs-si-muffin-doc
+/samples/bluetooth/peripheral_cts_client/*.rst @nrfconnect/ncs-si-muffin-doc
+/samples/bluetooth/peripheral_gatt_dm/*.rst @nrfconnect/ncs-si-muffin-doc
+/samples/bluetooth/peripheral_hids_keyboard/*.rst @nrfconnect/ncs-si-bluebagel-doc
+/samples/bluetooth/peripheral_hids_mouse/*.rst @nrfconnect/ncs-si-bluebagel-doc
+/samples/bluetooth/peripheral_hr_coded/*.rst @nrfconnect/ncs-si-muffin-doc
+/samples/bluetooth/peripheral_lbs/*.rst   @nrfconnect/ncs-si-muffin-doc
+/samples/bluetooth/peripheral_mds/*.rst   @nrfconnect/ncs-si-muffin-doc
+/samples/bluetooth/peripheral_nfc_pairing/*.rst @nrfconnect/ncs-si-muffin-doc
+/samples/bluetooth/peripheral_power_profiling/*.rst @nrfconnect/ncs-si-muffin-doc
+/samples/bluetooth/peripheral_rscs/*.rst  @nrfconnect/ncs-si-muffin-doc
+/samples/bluetooth/peripheral_status/*.rst @nrfconnect/ncs-si-muffin-doc
+/samples/bluetooth/peripheral_uart/*.rst  @nrfconnect/ncs-si-muffin-doc
+/samples/bluetooth/peripheral_with_multiple_identities/*.rst @nrfconnect/ncs-dragoon-doc
+/samples/bluetooth/radio_coex_1wire/*.rst @nrfconnect/ncs-dragoon-doc
+/samples/bluetooth/radio_notification_cb/*.rst @nrfconnect/ncs-dragoon-doc
+/samples/bluetooth/rpc_host/*.rst         @nrfconnect/ncs-si-muffin-doc
+/samples/bluetooth/scanning_while_connecting/*.rst @nrfconnect/ncs-dragoon-doc
+/samples/bluetooth/shell_bt_nus/*.rst     @nrfconnect/ncs-si-muffin-doc
+/samples/bluetooth/subrating/*.rst        @nrfconnect/ncs-dragoon-doc
+/samples/bluetooth/throughput/*.rst       @nrfconnect/ncs-si-muffin-doc
 /samples/bootloader/*.rst                 @nrfconnect/ncs-pluto-doc
 /samples/caf/*.rst                        @nrfconnect/ncs-si-muffin-doc @nrfconnect/ncs-si-bluebagel-doc
 /samples/caf_sensor_manager/*.rst         @nrfconnect/ncs-si-muffin-doc @nrfconnect/ncs-si-bluebagel-doc
@@ -816,6 +866,7 @@
 /tests/benchmarks/multicore/idle/*.rst    @nrfconnect/ncs-si-bluebagel-doc
 /tests/benchmarks/multicore/idle_gpio/*.rst @nrfconnect/ncs-si-bluebagel-doc
 /tests/benchmarks/multicore/idle_pwm_led/*.rst @nrfconnect/ncs-si-bluebagel-doc
+/tests/bluetooth/bsim/nrf_auraconfig/*.rst @nrfconnect/ncs-audio-doc
 
 # CI specific west
 /test-manifests/99-default-test-nrf.yml   @nrfconnect/ncs-ci


### PR DESCRIPTION
NCSDK- 30694
Change the doc ownership to reflect the changes in this PR: https://github.com/nrfconnect/sdk-nrf/pull/18010
Also, added ownership for
/doc/nrf/libraries/nrf_rpc/nrf_rpc_dev_info.rst