### PR TITLE
Add ZMS as default storage subsystem for Soc family that has MRAM

### DIFF
--- a/samples/bluetooth/enocean/Kconfig
+++ b/samples/bluetooth/enocean/Kconfig
@@ -10,7 +10,7 @@ config SETTINGS
 	default y
 
 config ZMS
-	default y if SOC_FLASH_NRF_RRAM
+	default y if (SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
 
 config NVS
-	default y if !SOC_FLASH_NRF_RRAM
+	default y if !(SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)

--- a/samples/bluetooth/fast_pair/locator_tag/Kconfig
+++ b/samples/bluetooth/fast_pair/locator_tag/Kconfig
@@ -27,10 +27,10 @@ config SETTINGS
 	default y
 
 config ZMS
-	default y if SOC_FLASH_NRF_RRAM
+	default y if (SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
 
 config NVS
-	default y if !SOC_FLASH_NRF_RRAM
+	default y if !(SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
 
 endmenu
 

--- a/samples/bluetooth/peripheral_ams_client/Kconfig
+++ b/samples/bluetooth/peripheral_ams_client/Kconfig
@@ -10,7 +10,7 @@ config SETTINGS
 	default y
 
 config ZMS
-	default y if SOC_FLASH_NRF_RRAM
+	default y if (SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
 
 config NVS
-	default y if !SOC_FLASH_NRF_RRAM
+	default y if !(SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)

--- a/samples/bluetooth/peripheral_ancs_client/Kconfig
+++ b/samples/bluetooth/peripheral_ancs_client/Kconfig
@@ -10,7 +10,7 @@ config SETTINGS
 	default y
 
 config ZMS
-	default y if SOC_FLASH_NRF_RRAM
+	default y if (SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
 
 config NVS
-	default y if !SOC_FLASH_NRF_RRAM
+	default y if !(SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)

--- a/samples/bluetooth/peripheral_mds/Kconfig
+++ b/samples/bluetooth/peripheral_mds/Kconfig
@@ -11,5 +11,6 @@ config SETTINGS
 
 config ZMS
 	default y if (SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
+
 config NVS
 	default y if !(SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)

--- a/samples/bluetooth/peripheral_uart/Kconfig
+++ b/samples/bluetooth/peripheral_uart/Kconfig
@@ -37,7 +37,7 @@ config SETTINGS
 	default y
 
 config ZMS
-	default y if !(SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
+	default y if (SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
 
 config NVS
 	default y if !(SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)

--- a/subsys/net/openthread/settings_check/CMakeLists.txt
+++ b/subsys/net/openthread/settings_check/CMakeLists.txt
@@ -7,14 +7,14 @@
 # This script checks if NVS settings backend is used with nRF54L SoC target and prints
 # the warning that the recommended backend is ZMS due to the RRAM design.
 
-if (CONFIG_SOC_SERIES_NRF54LX AND CONFIG_SETTINGS_NVS)
+if((CONFIG_SOC_SERIES_NRF54LX OR CONFIG_SOC_SERIES_NRF54HX) AND CONFIG_SETTINGS_NVS)
     message(WARNING " ###################################################################################\n"
                     " #                                                                                 #\n"
                     " # Your application uses NVS backend for the settings storage that is not          #\n"
-                    " # optimal solution for the nRF54L SoC family and it may negatively impact         #\n"
-                    " # the non-volatile RRAM life-time.                                                #\n"
+                    " # optimal solution for the nRF54L or the nRF54H SoC family and it may negatively  #\n"
+                    " # impact the non-volatile RRAM or MRAM life-time.                                 #\n"
                     " #                                                                                 #\n"
-                    " # The recommended settings backend for nRF54L SoC family is ZMS.                  #\n"
+                    " # The recommended settings backend for nRF54L or nRF54H SoC family is ZMS.        #\n"
                     " # You can enable it by selecting CONFIG_SETTINGS_ZMS=y and CONFIG_ZMS=y.          #\n"
                     " # Please note that the other Kconfig options related to NVS like cache            #\n"
                     " # or block size will require alignment on the ZMS side as well.                   #\n"


### PR DESCRIPTION
For some samples ZMS is still not selected as the default storage subsystem when the SoC family has an MRAM flash