### PR TITLE
Bluetooth: Sample: Make sample more stable on 54h

### DIFF
--- a/samples/bluetooth/iso_time_sync/src/main.c
+++ b/samples/bluetooth/iso_time_sync/src/main.c
@@ -171,17 +171,17 @@ int main(void)
 
 	printk("Bluetooth ISO Time Sync Demo\n");
 
-	err = timed_led_toggle_init();
-	if (err != 0) {
-		printk("Error failed to init LED device for toggling\n");
-		return err;
-	}
-
 	/* Initialize the Bluetooth Subsystem */
 	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 		return 0;
+	}
+
+	err = timed_led_toggle_init();
+	if (err != 0) {
+		printk("Error failed to init LED device for toggling\n");
+		return err;
 	}
 
 	role = role_select();


### PR DESCRIPTION
The sample sometimes failed to initialize bluetooth because of a EAGAIN error. Switching the order of initialization to initialize bluetooth before initializing the led toggling seems to resolve this.