### PR TITLE
snippets: Fix nordic-bt-rpc memory remapping for BT RPC on nRF54H20.

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -114,6 +114,7 @@ Bluetooth® LE
 -------------
 
 * Fixed an issue where a flash operation executed on the system workqueue might result in ``-ETIMEDOUT``, if there is an active Bluetooth LE connection.
+* Fixed an issue where Bluetooth applications built with the ``nordic-bt-rpc`` snippet (in the :ref:`ble_rpc` configuration) did not work on the nRF54H20 devices due to incorrect memory mapping.
 
 Bluetooth Mesh
 --------------

--- a/snippets/nordic-bt-rpc/boards/nrf54h20dk_nrf54h20-mem-map-move.dtsi
+++ b/snippets/nordic-bt-rpc/boards/nrf54h20dk_nrf54h20-mem-map-move.dtsi
@@ -18,6 +18,7 @@
 &mram1x {
 	cpurad_rw_partitions: cpurad-rw-partitions {
 		compatible = "nordic,owned-partitions", "fixed-partitions";
+		status = "disabled";
 		nordic,access = <NRF_OWNER_ID_RADIOCORE NRF_PERM_RWS>;
 		#address-cells = <1>;
 		#size-cells = <1>;


### PR DESCRIPTION
The Bluetooth RPC configuration for BLE samples didn't work due to an issue in the dts file that modifies the MRAM sections mapping for this build type. Application core was given an additional storage section that was intended for Radio core.

Known Issues and Release notes will be updated through respective PRs.