### PR TITLE
ci: Use CI_LIB and test-nrf from v2.9-branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library("CI_LIB") _
+@Library("CI_LIB@v2.9-branch") _
 
 def pipeline = new ncs.sdk_nrf.Main()
 


### PR DESCRIPTION
Use CI_LIB and test-nrf from v2.9-branch

Signed-off-by: Sebastian Wezel <sebastian.wezel@nordicsemi.no>
