### PR TITLE
samples: cellular: nrf_cloud_multi_service: fix header defines for multi service sample

### DIFF
--- a/samples/cellular/nrf_cloud_multi_service/src/provisioning_support.h
+++ b/samples/cellular/nrf_cloud_multi_service/src/provisioning_support.h
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#ifndef _SAMPLE_REBOOT_H_
-#define _SAMPLE_REBOOT_H_
+#ifndef _PROVISIONING_SUPPORT_H_
+#define _PROVISIONING_SUPPORT_H_
 
 #include <zephyr/kernel.h>
 
@@ -28,4 +28,4 @@ static inline bool await_provisioning_idle(k_timeout_t timeout)
 
 #endif /*CONFIG_NRF_PROVISIONING*/
 
-#endif /* _SAMPLE_REBOOT_H_ */
+#endif /* _PROVISIONING_SUPPORT_H_ */


### PR DESCRIPTION
Fix header defines that causes build errors when sample_reboot.h is included in other source files.

