### PR TITLE
tests: drivers: lpuart: allow testing on nRF54L05 and nRF54L10

### DIFF
--- a/samples/peripheral/lpuart/boards/nrf54l15dk_nrf54l05_cpuapp.conf
+++ b/samples/peripheral/lpuart/boards/nrf54l15dk_nrf54l05_cpuapp.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+CONFIG_UART_21_ASYNC=y
+CONFIG_UART_21_INTERRUPT_DRIVEN=n
+# Do not use interrupt driven API for console UART to not enable RX.
+CONFIG_UART_20_INTERRUPT_DRIVEN=n

--- a/samples/peripheral/lpuart/boards/nrf54l15dk_nrf54l05_cpuapp.overlay
+++ b/samples/peripheral/lpuart/boards/nrf54l15dk_nrf54l05_cpuapp.overlay
@@ -1,0 +1,1 @@
+#include "nrf54l15dk_nrf54l15_cpuapp.overlay"

--- a/samples/peripheral/lpuart/boards/nrf54l15dk_nrf54l10_cpuapp.conf
+++ b/samples/peripheral/lpuart/boards/nrf54l15dk_nrf54l10_cpuapp.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+CONFIG_UART_21_ASYNC=y
+CONFIG_UART_21_INTERRUPT_DRIVEN=n
+# Do not use interrupt driven API for console UART to not enable RX.
+CONFIG_UART_20_INTERRUPT_DRIVEN=n

--- a/samples/peripheral/lpuart/boards/nrf54l15dk_nrf54l10_cpuapp.overlay
+++ b/samples/peripheral/lpuart/boards/nrf54l15dk_nrf54l10_cpuapp.overlay
@@ -1,0 +1,1 @@
+#include "nrf54l15dk_nrf54l15_cpuapp.overlay"

--- a/samples/peripheral/lpuart/sample.yaml
+++ b/samples/peripheral/lpuart/sample.yaml
@@ -15,6 +15,8 @@ tests:
       - nrf9160dk/nrf9160/ns
       - nrf5340dk/nrf5340/cpuapp
       - nrf21540dk/nrf52840
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:
       - nrf52dk/nrf52832
@@ -23,6 +25,8 @@ tests:
       - nrf9160dk/nrf9160/ns
       - nrf5340dk/nrf5340/cpuapp
       - nrf21540dk/nrf52840
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
     platform_exclude: native_sim
     tags: ppk_power_measure
@@ -40,6 +44,8 @@ tests:
       - nrf9160dk/nrf9160/ns
       - nrf5340dk/nrf5340/cpuapp
       - nrf21540dk/nrf52840
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
@@ -74,9 +80,12 @@ tests:
       - nrf9160dk/nrf9160/ns
       - nrf5340dk/nrf5340/cpuapp
       - nrf21540dk/nrf52840
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
     platform_allow: nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840 nrf9160dk/nrf9160/ns
-      nrf5340dk/nrf5340/cpuapp nrf21540dk/nrf52840 nrf54l15dk/nrf54l15/cpuapp
+      nrf5340dk/nrf5340/cpuapp nrf21540dk/nrf52840 nrf54l15dk/nrf54l05/cpuapp
+      nrf54l15dk/nrf54l10/cpuapp nrf54l15dk/nrf54l15/cpuapp
     tags: ppk_power_measure
     harness: pytest
     harness_config:
@@ -100,9 +109,12 @@ tests:
       - nrf9160dk/nrf9160/ns
       - nrf5340dk/nrf5340/cpuapp
       - nrf21540dk/nrf52840
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
     platform_allow: nrf52dk/nrf52832 nrf52833dk/nrf52833 nrf52840dk/nrf52840 nrf9160dk/nrf9160/ns
-      nrf5340dk/nrf5340/cpuapp nrf21540dk/nrf52840 nrf54l15dk/nrf54l15/cpuapp
+      nrf5340dk/nrf5340/cpuapp nrf21540dk/nrf52840 nrf54l15dk/nrf54l05/cpuapp
+      nrf54l15dk/nrf54l10/cpuapp nrf54l15dk/nrf54l15/cpuapp
     harness: console
     harness_config:
       fixture: gpio_loopback

--- a/tests/drivers/lpuart/boards/nrf54l15dk_nrf54l05_cpuapp.conf
+++ b/tests/drivers/lpuart/boards/nrf54l15dk_nrf54l05_cpuapp.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+CONFIG_UART_21_ASYNC=y
+CONFIG_UART_21_INTERRUPT_DRIVEN=n
+# Do not use interrupt driven API for console UART to not enable RX.
+CONFIG_UART_20_INTERRUPT_DRIVEN=n

--- a/tests/drivers/lpuart/boards/nrf54l15dk_nrf54l05_cpuapp.overlay
+++ b/tests/drivers/lpuart/boards/nrf54l15dk_nrf54l05_cpuapp.overlay
@@ -1,0 +1,1 @@
+#include "nrf54l15dk_nrf54l15_cpuapp.overlay"

--- a/tests/drivers/lpuart/boards/nrf54l15dk_nrf54l10_cpuapp.conf
+++ b/tests/drivers/lpuart/boards/nrf54l15dk_nrf54l10_cpuapp.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+CONFIG_UART_21_ASYNC=y
+CONFIG_UART_21_INTERRUPT_DRIVEN=n
+# Do not use interrupt driven API for console UART to not enable RX.
+CONFIG_UART_20_INTERRUPT_DRIVEN=n

--- a/tests/drivers/lpuart/boards/nrf54l15dk_nrf54l10_cpuapp.overlay
+++ b/tests/drivers/lpuart/boards/nrf54l15dk_nrf54l10_cpuapp.overlay
@@ -1,0 +1,1 @@
+#include "nrf54l15dk_nrf54l15_cpuapp.overlay"

--- a/tests/drivers/lpuart/testcase.yaml
+++ b/tests/drivers/lpuart/testcase.yaml
@@ -16,8 +16,13 @@ tests:
       fixture: gpio_loopback
   lpuart.loopback.nrf54l:
     sysbuild: true
-    platform_allow: nrf54l15dk/nrf54l15/cpuapp
+    platform_allow:
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
     extra_configs:
       - CONFIG_TEST_LPUART_LOOPBACK=y
@@ -26,8 +31,13 @@ tests:
       fixture: gpio_loopback
   lpuart.loopback.nrf54l.busy_sim:
     sysbuild: true
-    platform_allow: nrf54l15dk/nrf54l15/cpuapp
+    platform_allow:
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
     extra_configs:
       - CONFIG_TEST_LPUART_LOOPBACK=y


### PR DESCRIPTION
Lpuart test and sample can now be run on nRF54L05 and nRF54l10 targets.