### PR TITLE
[Backport v2.9-branch] Quarantine: Remove hostap tests

### DIFF
--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -10,13 +10,6 @@
   comment: "Flash overflow: https://nordicsemi.atlassian.net/browse/NCSDK-30731"
 
 - scenarios:
-    - sample.nrf7002.shell.psa
-    - sample.nrf7002.enterprise_mode
-  platforms:
-    - nrf7002dk/nrf5340/cpuapp
-  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-30762"
-
-- scenarios:
     - applications.matter_bridge.lto.br_ble.nrf54h20.wifi
     - applications.matter_bridge.release.br_ble.nrf54h20.wifi
     - sample.matter.template.nrf54h20.nrf7002eb


### PR DESCRIPTION
Backport fe34349d5cbbdd6e415cf72ac7eb72f3847a10a0 from #19235.