### PR TITLE
doc: requirements: specify min version for sphinx-notfound-page

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -18,11 +18,10 @@ sphinx~=7.4                     # |  X  |    X    |   X    |    X    |    X    |
 sphinx-autobuild                # |  X  |    X    |   X    |    X    |    X    |  X   |   X    |
 sphinx-copybutton               # |  X  |         |        |         |         |      |   X    |
 sphinx-ncs-theme<1.1            # |  X  |         |        |         |         |      |        |
-sphinx-notfound-page            # |  X  |         |        |         |         |      |   X    |
+sphinx-notfound-page>=1.0.0     # |  X  |         |        |         |         |      |   X    |
 sphinx-tabs>=3.4                # |  X  |         |        |         |         |      |   X    |
 sphinx-togglebutton             # |  X  |         |        |         |         |      |   X    |
 sphinx_markdown_tables          # |     |         |   X    |         |         |      |        |
 sphinxcontrib-mscgen            # |  X  |         |        |         |    X    |      |        |
 sphinxcontrib-plantuml>=0.27    # |     |         |        |         |         |  X   |        |
 west>=1.0.0                     # |     |         |        |         |         |      |   X    |
-anytree                         # |     |         |        |         |         |      |   X    |


### PR DESCRIPTION
sphinx > 7.2 removed the module  'setup_js_tag_helper' from 'sphinx.builders.html' requiring sphinx-notfound-page >= 1.0.0 to be used to remain compatible.

Remove duplicate anytree entry.