### PR TITLE
[Backport v2.9-branch] doc: Minor fixes to the 2.8 release notes

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-2.8.0.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-2.8.0.rst
@@ -92,7 +92,7 @@ Added the following features as experimental:
 * Bootloaders and DFU:
 
   * :ref:`mcuboot_image_compression` on nRF52840, nRF5340, and nRF54L15 targets.
-    This feature uses LZMA2 to compress the candidate image by ~30%, which gives more space for the application as it allows slot 1 (DFU slot) to be ~70% smaller than slot 0 (application slot).
+    This feature uses LZMA2 to compress the candidate image by ~30%, which gives more space for the application as it allows slot 1 (DFU slot) to be ~70% the size of slot 0 (application slot).
 
 Improved:
 


### PR DESCRIPTION
Backport 6dcaf8cf9cfc37959a1a1a5de2d98201c4e6b2e7 from #19296.