### PR TITLE
bluetooth: fast_pair: allow multiple instances of info callbacks

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -382,7 +382,9 @@ Binary libraries
 Bluetooth libraries and services
 --------------------------------
 
-|no_changes_yet_note|
+* :ref:`bt_fast_pair_readme` library:
+
+  * Updated the :c:func:`bt_fast_pair_info_cb_register` API to allow registration of multiple callbacks.
 
 Common Application Framework
 ----------------------------

--- a/include/bluetooth/services/fast_pair/fast_pair.h
+++ b/include/bluetooth/services/fast_pair/fast_pair.h
@@ -166,6 +166,9 @@ struct bt_fast_pair_info_cb {
 	 *  @param conn Connection object that wrote the Account Key.
 	 */
 	void (*account_key_written)(struct bt_conn *conn);
+
+	/** Internally used field for list handling. */
+	sys_snode_t node;
 };
 
 /** Enable Fast Pair.
@@ -294,7 +297,7 @@ int bt_fast_pair_battery_set(enum bt_fast_pair_battery_comp battery_comp,
  *
  *  This function registers an instance of information callbacks. The registered instance needs to
  *  persist in the memory after this function exits, as it is used directly without the copy
- *  operation. It is possible to register only one instance of callbacks with this API.
+ *  operation.
  *
  *  This function can only be called before enabling Fast Pair with the @ref bt_fast_pair_enable
  *  API.
@@ -305,7 +308,7 @@ int bt_fast_pair_battery_set(enum bt_fast_pair_battery_comp battery_comp,
  *
  *  @return Zero on success or negative error code otherwise
  */
-int bt_fast_pair_info_cb_register(const struct bt_fast_pair_info_cb *cb);
+int bt_fast_pair_info_cb_register(struct bt_fast_pair_info_cb *cb);
 
 /** Perform a reset to the default factory settings for Google Fast Pair Service.
  *

--- a/samples/bluetooth/fast_pair/input_device/src/main.c
+++ b/samples/bluetooth/fast_pair/input_device/src/main.c
@@ -419,7 +419,7 @@ static void init_work_handle(struct k_work *w)
 	static struct bt_conn_auth_info_cb auth_info_cb = {
 		.pairing_complete = pairing_complete
 	};
-	static const struct bt_fast_pair_info_cb fp_info_callbacks = {
+	static struct bt_fast_pair_info_cb fp_info_callbacks = {
 		.account_key_written = fp_account_key_written,
 	};
 

--- a/samples/bluetooth/fast_pair/locator_tag/src/main.c
+++ b/samples/bluetooth/fast_pair/locator_tag/src/main.c
@@ -217,7 +217,7 @@ static void fp_account_key_written(struct bt_conn *conn)
 	fp_account_key_present = bt_fast_pair_has_account_key();
 }
 
-static const struct bt_fast_pair_info_cb fp_info_callbacks = {
+static struct bt_fast_pair_info_cb fp_info_callbacks = {
 	.account_key_written = fp_account_key_written,
 };
 

--- a/subsys/bluetooth/services/fast_pair/fmdn/callbacks.c
+++ b/subsys/bluetooth/services/fast_pair/fmdn/callbacks.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
+#include <zephyr/sys/slist.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(fp_fmdn_callbacks, CONFIG_BT_FAST_PAIR_LOG_LEVEL);
@@ -56,19 +57,6 @@ void fp_fmdn_callbacks_provisioning_state_changed_notify(bool provisioned)
 	}
 }
 
-static bool node_uniqueness_validate(sys_slist_t *slist, sys_snode_t *new_node)
-{
-	sys_snode_t *current_node;
-
-	SYS_SLIST_FOR_EACH_NODE(slist, current_node) {
-		if (current_node == new_node) {
-			return false;
-		}
-	}
-
-	return true;
-}
-
 static int cb_register(sys_slist_t *slist, struct bt_fast_pair_fmdn_info_cb *cb)
 {
 	if (bt_fast_pair_is_ready()) {
@@ -83,7 +71,7 @@ static int cb_register(sys_slist_t *slist, struct bt_fast_pair_fmdn_info_cb *cb)
 		return -EINVAL;
 	}
 
-	if (!node_uniqueness_validate(slist, &cb->node)) {
+	if (sys_slist_find(slist, &cb->node, NULL)) {
 		return 0;
 	}
 


### PR DESCRIPTION
Updated the bt_fast_pair_info_cb_register API function in the Bluetooth Fast Pair library to allow registration of multiple callbacks.