### PR TITLE
manifest: pull in gdfs gdpwr hsfll driver

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -339,7 +339,7 @@ add_doxygen_docset(nrfxlib ${ZEPHYR_NRFXLIB_MODULE_DIR} ${NRF_VERSION})
 #-------------------------------------------------------------------------------
 # docset: wifi
 
-add_doxygen_docset(wifi ${ZEPHYR_HAL_NORDIC_MODULE_DIR} "" STANDALONE)
+add_doxygen_docset(wifi ${ZEPHYR_NRF_WIFI_MODULE_DIR} "" STANDALONE)
 
 #-------------------------------------------------------------------------------
 # docset: internal

--- a/doc/nrf/drivers/wifi/nrf70_native.rst
+++ b/doc/nrf/drivers/wifi/nrf70_native.rst
@@ -34,7 +34,7 @@ Design overview
 ***************
 
 The nRF Wi-Fi driver follows an OS-agnostic design, and the driver implementation is split into OS-agnostic and OS (Zephyr)-specific code.
-The OS-agnostic code is located in the :file:`${ZEPHYR_BASE}/../modules/hal/nordic/drivers/nrf_wifi/` folder, and the Zephyr OS port is located in the :file:`${ZEPHYR_BASE}/drivers/wifi/nrf_wifi/` folder.
+The OS-agnostic code is located in the :file:`${ZEPHYR_BASE}/../modules/nrf_wifi/` folder, and the Zephyr OS port is located in the :file:`${ZEPHYR_BASE}/drivers/wifi/nrf_wifi/` folder.
 
 The driver supports two modes of operation:
 

--- a/doc/wifi/wifi.doxyfile.in
+++ b/doc/wifi/wifi.doxyfile.in
@@ -190,7 +190,7 @@ FULL_PATH_NAMES        = YES
 # will be relative from the directory where Doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        = @DOCSET_SOURCE_BASE@/drivers/nrf_wifi
+STRIP_FROM_PATH        = @DOCSET_SOURCE_BASE@
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which
@@ -965,7 +965,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = @DOCSET_SOURCE_BASE@/drivers/nrf_wifi
+INPUT                  = @DOCSET_SOURCE_BASE@
 
 # This tag can be used to specify the character encoding of the source files
 # that Doxygen parses. Internally Doxygen uses the UTF-8 encoding. Doxygen uses

--- a/west.yml
+++ b/west.yml
@@ -69,7 +69,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 382877e15f13507f40c73b385446987fc7ace57e
+      revision: 0f2b574e26e65fcd5aaf0b0758595913c4514527
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull in GDFS and GDPWR NRFS services and HSFLL clock control driver along with adaptions required for GDPWR.

test_low_level: PR-1642
test_suit_dfu: pr-19324