### PR TITLE
[Backport v2.9-branch] doc: Add instructions for how to install "nrfcredstore"

### DIFF
--- a/doc/nrf/libraries/networking/azure_iot_hub.rst
+++ b/doc/nrf/libraries/networking/azure_iot_hub.rst
@@ -52,6 +52,11 @@ To get started with testing the Azure IoT Hub, make sure that the following prer
 
 * Install the `Azure CLI`_.
 * To use the ``nrfcredstore`` tool, the dependencies in the :file:`nrf/scripts/requirements-extra.txt` file must be installed.
+  Enter the following command in a terminal window to install all the dependencies in the file:
+
+  .. code-block:: console
+
+     pip3 install -r nrf/scripts/requirements-extra.txt
 
 .. rst-class:: numbered-step
 


### PR DESCRIPTION
Backport 7ec7917a1b38a4ee005e5e1c40201f8f627106e9 from #19063.