### PR TITLE
applications: nrf5340_audio: Channel not set for decoder/encoder

### DIFF
--- a/applications/nrf5340_audio/src/audio/audio_system.c
+++ b/applications/nrf5340_audio/src/audio/audio_system.c
@@ -68,6 +68,7 @@ static void audio_gateway_configure(void)
 	}
 
 #if (CONFIG_STREAM_BIDIRECTIONAL)
+	&sw_codec_cfg.decoder.audio_ch = AUDIO_CHANNEL_DEFAULT;
 	sw_codec_cfg.decoder.num_ch = 1;
 	sw_codec_cfg.decoder.channel_mode = SW_CODEC_MONO;
 #endif /* (CONFIG_STREAM_BIDIRECTIONAL) */
@@ -91,9 +92,12 @@ static void audio_headset_configure(void)
 	}
 
 #if (CONFIG_STREAM_BIDIRECTIONAL)
+	&sw_codec_cfg.decoder.audio_ch = AUDIO_CHANNEL_DEFAULT;
 	sw_codec_cfg.encoder.num_ch = 1;
 	sw_codec_cfg.encoder.channel_mode = SW_CODEC_MONO;
 #endif /* (CONFIG_STREAM_BIDIRECTIONAL) */
+
+	channel_assignment_get(&sw_codec_cfg.decoder.audio_ch);
 
 	sw_codec_cfg.decoder.num_ch = 1;
 	sw_codec_cfg.decoder.channel_mode = SW_CODEC_MONO;


### PR DESCRIPTION
OCT-2648

In the sw_config struct there is an enum in the decoder and encoder struct. These are not set during audio_headset_configure, thus defaulting to 0 being left. This should be done explicitly for both headsets.

This is a temporary fix as it will not cover all channel combinations.