### PR TITLE
sysbuild: Prevent some configuration options with single image mode

### DIFF
--- a/sysbuild/Kconfig.mcuboot
+++ b/sysbuild/Kconfig.mcuboot
@@ -55,6 +55,7 @@ config MCUBOOT_COMPRESSED_IMAGE_SUPPORT
 
 config MCUBOOT_MAX_UPDATEABLE_IMAGES
 	int
+	default 1 if MCUBOOT_MODE_SINGLE_APP
 	default 4
 
 config MCUBOOT_APPLICATION_IMAGE_NUMBER
@@ -63,7 +64,7 @@ config MCUBOOT_APPLICATION_IMAGE_NUMBER
 
 config MCUBOOT_NETWORK_CORE_IMAGE_NUMBER
 	int
-	default 1 if NETCORE_APP_UPDATE
+	default 1 if NETCORE_APP_UPDATE && !MCUBOOT_MODE_SINGLE_APP
 	default -1
 
 config MCUBOOT_WIFI_PATCHES_IMAGE_NUMBER
@@ -177,6 +178,7 @@ config MCUBOOT_USE_ALL_AVAILABLE_RAM
 config MCUBOOT_NRF53_MULTI_IMAGE_UPDATE
 	bool "Network core multi-image update (in single operation)"
 	depends on NETCORE_APP_UPDATE
+	depends on !MCUBOOT_MODE_SINGLE_APP
 	help
 	  If selected, network core image updates can be applied in a single operation. This is
 	  required if the secondary partition resides in off-chip memory.

--- a/west.yml
+++ b/west.yml
@@ -130,7 +130,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: v2.1.0-ncs3-rc1
+      revision: b82206c15fff357c151c24bf97c99c4348d14a46
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR


### PR DESCRIPTION
Prevents making some options configurable and sets correct limits when MCUboot is configured in single application mode

NCSDK-30866