### PR TITLE
sysbuild: Emit warning log when MCUboot uses KMU

### DIFF
--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -242,6 +242,14 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
 
       if(SB_CONFIG_MCUBOOT_SIGNATURE_USING_KMU)
         set_config_bool(mcuboot CONFIG_BOOT_SIGNATURE_USING_KMU y)
+        if(NOT SB_CONFIG_MCUBOOT_SIGNATURE_USING_KMU_SKIP_WARNING)
+          message(WARNING "
+          ------------------------------------------------------------------------------
+          --- WARNING: MCUboot uses KMU stored keys for signature verification. Make ---
+          --- sure to use `west ncs-provision` to manually provision the bootloader. ---
+          ------------------------------------------------------------------------------
+          ")
+        endif()
       else()
         set_config_bool(mcuboot CONFIG_BOOT_SIGNATURE_USING_KMU n)
       endif()

--- a/sysbuild/Kconfig.mcuboot
+++ b/sysbuild/Kconfig.mcuboot
@@ -164,6 +164,15 @@ config MCUBOOT_SIGNATURE_USING_KMU
 	help
 	  The device needs to be provisioned with proper set of keys.
 
+config MCUBOOT_SIGNATURE_USING_KMU_SKIP_WARNING
+	bool "Skip KMU provisioning CMake warning"
+	depends on MCUBOOT_SIGNATURE_USING_KMU
+	help
+	  When using KMU stored keys for MCUboot signature verification, build
+	  system emits a CMake warning to ensure that user is aware that manual
+	  provisioning of the KMU keys is necessary. Enable the option to skip
+	  the warning.
+
 endif
 
 config MCUBOOT_USE_ALL_AVAILABLE_RAM


### PR DESCRIPTION
Using KMU for MCUboot keys requires provisioning the device manually before running `west flash`. Emit a CMake warning to ensure that user is aware that an additional action is required.

Jira: NCSDK-30742