### PR TITLE
manifest: sdk-zephyr: [nrf fromtree] cmake: use the warnings_as_errors flag for cpp files

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -69,7 +69,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: a7fe5f7c4aab18312bd7f61afef55647e38f3db6
+      revision: pull/2350/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Next Zephyr upmerge will enable warnings-as-errors for C++.
This manifest update runs CI for a  cherry-picked Zephyr commit as to allow early fix of C++ warnings in NCS code base.


----------


Automatically created by action-manifest-pr GH action from PR: https://github.com/nrfconnect/sdk-zephyr/pull/2350