### PR TITLE
applications: nrf5340_audio: Fix audio sync timer off by one tick

### DIFF
--- a/applications/nrf5340_audio/src/modules/audio_sync_timer.c
+++ b/applications/nrf5340_audio/src/modules/audio_sync_timer.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include "audio_sync_timer.h"
-
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
 #include <nrfx_dppi.h>
@@ -18,44 +16,47 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(audio_sync_timer, CONFIG_AUDIO_SYNC_TIMER_LOG_LEVEL);
 
-#define AUDIO_SYNC_TIMER_NET_APP_IPC_EVT_CHANNEL 4
-#define AUDIO_SYNC_TIMER_NET_APP_IPC_EVT	 NRF_IPC_EVENT_RECEIVE_4
+#include "audio_sync_timer.h"
+
+#define AUDIO_SYNC_TIMER_NET_APP_IPC_START_EVT_CHANNEL 4
+#define AUDIO_SYNC_TIMER_NET_APP_IPC_START_EVT         NRF_IPC_EVENT_RECEIVE_4
 
 #define AUDIO_SYNC_HF_TIMER_INSTANCE_NUMBER 1
 
 #define AUDIO_SYNC_HF_TIMER_I2S_FRAME_START_EVT_CAPTURE_CHANNEL 0
-#define AUDIO_SYNC_HF_TIMER_I2S_FRAME_START_EVT_CAPTURE		NRF_TIMER_TASK_CAPTURE0
-#define AUDIO_SYNC_HF_TIMER_CURR_TIME_CAPTURE_CHANNEL		1
-#define AUDIO_SYNC_HF_TIMER_CURR_TIME_CAPTURE			NRF_TIMER_TASK_CAPTURE1
-
-static const nrfx_timer_t audio_sync_hf_timer_instance =
-	NRFX_TIMER_INSTANCE(AUDIO_SYNC_HF_TIMER_INSTANCE_NUMBER);
-
-static uint8_t dppi_channel_i2s_frame_start;
+#define AUDIO_SYNC_HF_TIMER_I2S_FRAME_START_EVT_CAPTURE         NRF_TIMER_TASK_CAPTURE0
+#define AUDIO_SYNC_HF_TIMER_CURR_TIME_CAPTURE_CHANNEL           1
+#define AUDIO_SYNC_HF_TIMER_CURR_TIME_CAPTURE                   NRF_TIMER_TASK_CAPTURE1
 
 #define AUDIO_SYNC_LF_TIMER_INSTANCE_NUMBER 0
 
 #define AUDIO_SYNC_LF_TIMER_I2S_FRAME_START_EVT_CAPTURE_CHANNEL 0
-#define AUDIO_SYNC_LF_TIMER_I2S_FRAME_START_EVT_CAPTURE		NRF_RTC_TASK_CAPTURE_0
-#define AUDIO_SYNC_LF_TIMER_CURR_TIME_CAPTURE_CHANNEL		1
-#define AUDIO_SYNC_LF_TIMER_CURR_TIME_CAPTURE			NRF_RTC_TASK_CAPTURE_1
+#define AUDIO_SYNC_LF_TIMER_I2S_FRAME_START_EVT_CAPTURE         NRF_RTC_TASK_CAPTURE_0
+#define AUDIO_SYNC_LF_TIMER_CURR_TIME_CAPTURE_CHANNEL           1
+#define AUDIO_SYNC_LF_TIMER_CURR_TIME_CAPTURE                   NRF_RTC_TASK_CAPTURE_1
 
-static uint8_t dppi_channel_curr_time_capture;
-
-static const nrfx_rtc_config_t rtc_cfg = NRFX_RTC_DEFAULT_CONFIG;
+static const nrfx_timer_t audio_sync_hf_timer_instance =
+	NRFX_TIMER_INSTANCE(AUDIO_SYNC_HF_TIMER_INSTANCE_NUMBER);
 
 static const nrfx_rtc_t audio_sync_lf_timer_instance =
 	NRFX_RTC_INSTANCE(AUDIO_SYNC_LF_TIMER_INSTANCE_NUMBER);
 
-static uint8_t dppi_channel_timer_sync_with_rtc;
-static uint8_t dppi_channel_rtc_start;
-static volatile uint32_t num_rtc_overflows;
+static const nrfx_timer_config_t cfg = {
+	.frequency = NRFX_MHZ_TO_HZ(1UL),
+	.mode = NRF_TIMER_MODE_TIMER,
+	.bit_width = NRF_TIMER_BIT_WIDTH_32,
+	.interrupt_priority = NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY,
+	.p_context = NULL
+};
 
-static nrfx_timer_config_t cfg = {.frequency = NRFX_MHZ_TO_HZ(1UL),
-				  .mode = NRF_TIMER_MODE_TIMER,
-				  .bit_width = NRF_TIMER_BIT_WIDTH_32,
-				  .interrupt_priority = NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY,
-				  .p_context = NULL};
+static const nrfx_rtc_config_t rtc_cfg = NRFX_RTC_DEFAULT_CONFIG;
+
+static uint8_t dppi_channel_i2s_frame_start;
+static uint8_t dppi_channel_curr_time_capture;
+static uint8_t dppi_channel_sync_start;
+static uint8_t dppi_channel_timer_sync_with_rtc;
+
+static volatile uint32_t num_rtc_overflows;
 
 static uint32_t timestamp_from_rtc_and_timer_get(uint32_t ticks, uint32_t remainder_us)
 {
@@ -143,8 +144,8 @@ static void rtc_isr_handler(nrfx_rtc_int_type_t int_type)
  */
 static int audio_sync_timer_init(void)
 {
-	nrfx_err_t ret;
 	nrfx_dppi_t dppi = NRFX_DPPI_INSTANCE(0);
+	nrfx_err_t ret;
 
 	ret = nrfx_timer_init(&audio_sync_hf_timer_instance, &cfg, unused_timer_isr_handler);
 	if (ret - NRFX_ERROR_BASE_NUM) {
@@ -178,6 +179,7 @@ static int audio_sync_timer_init(void)
 			      dppi_channel_i2s_frame_start);
 
 	nrf_i2s_publish_set(NRF_I2S0, NRF_I2S_EVENT_FRAMESTART, dppi_channel_i2s_frame_start);
+
 	ret = nrfx_dppi_channel_enable(&dppi, dppi_channel_i2s_frame_start);
 	if (ret - NRFX_ERROR_BASE_NUM) {
 		LOG_ERR("nrfx DPPI channel enable error (I2S frame start): %d", ret);
@@ -187,7 +189,7 @@ static int audio_sync_timer_init(void)
 	/* Initialize capturing of current timestamps */
 	ret = nrfx_dppi_channel_alloc(&dppi, &dppi_channel_curr_time_capture);
 	if (ret - NRFX_ERROR_BASE_NUM) {
-		LOG_ERR("nrfx DPPI channel alloc error (I2S frame start) - Return value: %d", ret);
+		LOG_ERR("nrfx DPPI channel alloc error (curr time capture): %d", ret);
 		return -ENOMEM;
 	}
 
@@ -203,36 +205,39 @@ static int audio_sync_timer_init(void)
 
 	ret = nrfx_dppi_channel_enable(&dppi, dppi_channel_curr_time_capture);
 	if (ret - NRFX_ERROR_BASE_NUM) {
-		LOG_ERR("nrfx DPPI channel enable error (I2S frame start) - Return value: %d", ret);
+		LOG_ERR("nrfx DPPI channel enable error (curr time capture): %d", ret);
 		return -EIO;
 	}
 
 	/* Initialize functionality for synchronization between APP and NET core */
-	ret = nrfx_dppi_channel_alloc(&dppi, &dppi_channel_rtc_start);
+	ret = nrfx_dppi_channel_alloc(&dppi, &dppi_channel_sync_start);
 	if (ret - NRFX_ERROR_BASE_NUM) {
-		LOG_ERR("nrfx DPPI channel alloc error (timer clear): %d", ret);
+		LOG_ERR("nrfx DPPI channel alloc error (sync start): %d", ret);
 		return -ENOMEM;
 	}
 
 	nrf_rtc_subscribe_set(audio_sync_lf_timer_instance.p_reg, NRF_RTC_TASK_CLEAR,
-			      dppi_channel_rtc_start);
+			      dppi_channel_sync_start);
+
 	nrf_timer_subscribe_set(audio_sync_hf_timer_instance.p_reg, NRF_TIMER_TASK_START,
-				dppi_channel_rtc_start);
+				dppi_channel_sync_start);
 
-	nrf_ipc_receive_config_set(NRF_IPC, AUDIO_SYNC_TIMER_NET_APP_IPC_EVT_CHANNEL,
+	nrf_ipc_receive_config_set(NRF_IPC, AUDIO_SYNC_TIMER_NET_APP_IPC_START_EVT_CHANNEL,
 				   NRF_IPC_CHANNEL_4);
-	nrf_ipc_publish_set(NRF_IPC, AUDIO_SYNC_TIMER_NET_APP_IPC_EVT, dppi_channel_rtc_start);
 
-	ret = nrfx_dppi_channel_enable(&dppi, dppi_channel_rtc_start);
+	nrf_ipc_publish_set(NRF_IPC, AUDIO_SYNC_TIMER_NET_APP_IPC_START_EVT,
+			    dppi_channel_sync_start);
+
+	ret = nrfx_dppi_channel_enable(&dppi, dppi_channel_sync_start);
 	if (ret - NRFX_ERROR_BASE_NUM) {
-		LOG_ERR("nrfx DPPI channel enable error (timer clear): %d", ret);
+		LOG_ERR("nrfx DPPI channel enable error (sync start): %d", ret);
 		return -EIO;
 	}
 
 	/* Initialize functionality for synchronization between RTC and TIMER */
 	ret = nrfx_dppi_channel_alloc(&dppi, &dppi_channel_timer_sync_with_rtc);
 	if (ret - NRFX_ERROR_BASE_NUM) {
-		LOG_ERR("nrfx DPPI channel alloc error (timer clear): %d", ret);
+		LOG_ERR("nrfx DPPI channel alloc error (timer sync): %d", ret);
 		return -ENOMEM;
 	}
 
@@ -241,13 +246,13 @@ static int audio_sync_timer_init(void)
 	nrf_timer_subscribe_set(audio_sync_hf_timer_instance.p_reg, NRF_TIMER_TASK_CLEAR,
 				dppi_channel_timer_sync_with_rtc);
 
-	nrfx_rtc_tick_enable(&audio_sync_lf_timer_instance, false);
-
 	ret = nrfx_dppi_channel_enable(&dppi, dppi_channel_timer_sync_with_rtc);
 	if (ret - NRFX_ERROR_BASE_NUM) {
-		LOG_ERR("nrfx DPPI channel enable error (timer clear): %d", ret);
+		LOG_ERR("nrfx DPPI channel enable error (timer sync): %d", ret);
 		return -EIO;
 	}
+
+	nrfx_rtc_tick_enable(&audio_sync_lf_timer_instance, false);
 
 	nrfx_rtc_enable(&audio_sync_lf_timer_instance);
 

--- a/applications/nrf5340_audio/src/modules/audio_sync_timer.c
+++ b/applications/nrf5340_audio/src/modules/audio_sync_timer.c
@@ -62,6 +62,24 @@ static uint32_t timestamp_from_rtc_and_timer_get(uint32_t ticks, uint32_t remain
 {
 	const uint64_t rtc_ticks_in_femto_units = 30517578125UL;
 	const uint32_t rtc_overflow_time_us = 512000000UL;
+	uint64_t remainder_fs;
+
+	remainder_fs = (uint64_t)remainder_us * 1000000000UL;
+
+	if (remainder_fs > rtc_ticks_in_femto_units) {
+		nrfx_dppi_t dppi = NRFX_DPPI_INSTANCE(0);
+		nrfx_err_t ret;
+
+		ret = nrfx_dppi_channel_enable(&dppi, dppi_channel_timer_sync_with_rtc);
+		if (ret - NRFX_ERROR_BASE_NUM) {
+			LOG_ERR("nrfx DPPI channel enable error (timer sync): %d", ret);
+		}
+
+		nrfx_rtc_tick_enable(&audio_sync_lf_timer_instance, true);
+	}
+
+	remainder_fs %= rtc_ticks_in_femto_units;
+	remainder_us = remainder_fs / 1000000000UL;
 
 	return ((ticks * rtc_ticks_in_femto_units) / 1000000000UL) +
 	       (num_rtc_overflows * rtc_overflow_time_us) + remainder_us;
@@ -128,6 +146,20 @@ static void unused_timer_isr_handler(nrf_timer_event_t event_type, void *ctx)
 
 static void rtc_isr_handler(nrfx_rtc_int_type_t int_type)
 {
+	if (int_type == NRFX_RTC_INT_TICK) {
+		nrfx_dppi_t dppi = NRFX_DPPI_INSTANCE(0);
+		nrfx_err_t ret;
+
+		nrfx_rtc_tick_enable(&audio_sync_lf_timer_instance, false);
+		nrfx_rtc_tick_disable(&audio_sync_lf_timer_instance);
+
+		ret = nrfx_dppi_channel_disable(&dppi, dppi_channel_timer_sync_with_rtc);
+		if (ret - NRFX_ERROR_BASE_NUM) {
+			LOG_ERR("nrfx DPPI channel disable error (timer sync): %d", ret);
+			return;
+		}
+	}
+
 	if (int_type == NRFX_RTC_INT_OVERFLOW) {
 		num_rtc_overflows++;
 	}
@@ -245,14 +277,6 @@ static int audio_sync_timer_init(void)
 			    dppi_channel_timer_sync_with_rtc);
 	nrf_timer_subscribe_set(audio_sync_hf_timer_instance.p_reg, NRF_TIMER_TASK_CLEAR,
 				dppi_channel_timer_sync_with_rtc);
-
-	ret = nrfx_dppi_channel_enable(&dppi, dppi_channel_timer_sync_with_rtc);
-	if (ret - NRFX_ERROR_BASE_NUM) {
-		LOG_ERR("nrfx DPPI channel enable error (timer sync): %d", ret);
-		return -EIO;
-	}
-
-	nrfx_rtc_tick_enable(&audio_sync_lf_timer_instance, false);
 
 	nrfx_rtc_enable(&audio_sync_lf_timer_instance);
 

--- a/applications/nrf5340_audio/unicast_server/main.c
+++ b/applications/nrf5340_audio/unicast_server/main.c
@@ -565,6 +565,43 @@ int main(void)
 
 	ret = bt_mgmt_adv_start(0, ext_adv_buf, ext_adv_buf_cnt, NULL, 0, true);
 	ERR_CHK(ret);
+	
+		// Test monotonicity
+	uint32_t timestamps_us[10];
+	int counter;
+	for (counter = 0; counter < 1000000; counter++){
+		// progress bar
+		if ((counter % 1000) == 0) {
+			LOG_ERR("%u", counter);
+		}
 
+		// get some timestamps
+		int i;
+		for (i=0;i<10;i++){
+			timestamps_us[i] = audio_sync_timer_capture();		
+		}
+
+		// check if there's a negative delta
+		int incorrect_entry = -1;
+		for (i=1;i<10;i++){
+			if (timestamps_us[i-1] > timestamps_us[i]){
+				incorrect_entry = i-1;
+			}
+		}
+
+		// report error
+		if (incorrect_entry >= 0){
+			LOG_ERR("\nIncorrect timestamp:");
+			for (i=0;i<10;i++){
+				if (incorrect_entry == i){
+					LOG_ERR("t[%u] = %u <<--", i, timestamps_us[i]);
+				} else {
+					LOG_ERR("t[%u] = %u", i, timestamps_us[i]);
+				}
+			}
+			break;
+		}
+	}
 	return 0;
 }
+


### PR DESCRIPTION
Fix audio sync timer off by one tick when TASKS_CAPTURE and
TASKS_CLEAR are in a race condition.

TASKS_CAPTURE is prioritized hence can have +30 us more when
RTC tick to trigger TASKS_CLEAR overlap with the capture of
the value.

The fix here initiates the RTC and TIMER sync only when a
capture is requested by the audio subsystem or the timestamp
request. This is in contrast to earlier implementation when
TIMER was sync on every RTC tick.

If a capture is requested in short duration of 30 us then
the race will still be present, but a subsequent fix for it
will be provided in a new commit.