### PR TITLE
lib: modem_key_mgmt: Add CME error code 527 - Invalid content

### DIFF
--- a/lib/modem_key_mgmt/modem_key_mgmt.c
+++ b/lib/modem_key_mgmt/modem_key_mgmt.c
@@ -93,6 +93,9 @@ static int translate_error(int err)
 	case 519: /* already exists */
 		LOG_WRN("Key already exists");
 		return -EALREADY;
+	case 527: /* Invalid content */
+		LOG_WRN("Invalid content");
+		return -EINVAL;
 	case 528: /* not allowed in power off warning */
 		LOG_WRN("Not allowed when power off warning is active");
 		return -ECANCELED;


### PR DESCRIPTION
Add CME error code 527 - Invalid content. This is returned with mfw >= 2.0.2 if the certificate written is not valid or too large.