### PR TITLE
scripts: twister: alt: accel_polling remove logs for ppr configuration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -673,6 +673,9 @@
 /scripts/partition_manager/*.rst          @nrfconnect/ncs-aurora-doc
 /scripts/shell/ble_console/**/*.rst       @nrfconnect/ncs-doc-leads
 /scripts/west_commands/sbom/*.rst         @nrfconnect/ncs-si-muffin-doc
+/scripts/twister/alt/zephyr/samples/basic/ @nrfconnect/ncs-ll-ursus
+/scripts/twister/alt/zephyr/samples/sensor/ @nrfconnect/ncs-low-level-test
+/scripts/twister/alt/zephyr/tests/drivers/ @nrfconnect/ncs-low-level-test
 
 # Share
 /share/                                   @nrfconnect/ncs-co-build-system

--- a/scripts/twister/alt/zephyr/samples/sensor/accel_polling/sample.yaml
+++ b/scripts/twister/alt/zephyr/samples/sensor/accel_polling/sample.yaml
@@ -19,7 +19,6 @@ tests:
     extra_configs:
       - CONFIG_LOG=y
       - CONFIG_SENSOR_LOG_LEVEL_DBG=y
-      - CONFIG_SPI_LOG_LEVEL_DBG=y
     platform_allow: nrf54h20dk/nrf54h20/cpuapp
 
   sample.sensor.accel_polling.nrf54h_cpuppr:
@@ -49,7 +48,6 @@ tests:
     extra_configs:
       - CONFIG_LOG=y
       - CONFIG_SENSOR_LOG_LEVEL_DBG=y
-      - CONFIG_SPI_LOG_LEVEL_DBG=y
     platform_allow: nrf54h20dk/nrf54h20/cpuapp
 
   sample.sensor.accel_polling.nrf54l:
@@ -65,7 +63,6 @@ tests:
     extra_configs:
       - CONFIG_LOG=y
       - CONFIG_SENSOR_LOG_LEVEL_DBG=y
-      - CONFIG_SPI_LOG_LEVEL_DBG=y
     platform_allow: nrf54l15dk/nrf54l15/cpuapp
 
   sample.sensor.accel_polling.nrf54l_coverage:
@@ -81,7 +78,6 @@ tests:
     extra_configs:
       - CONFIG_LOG=y
       - CONFIG_SENSOR_LOG_LEVEL_DBG=y
-      - CONFIG_SPI_LOG_LEVEL_DBG=y
     platform_allow: nrf54l15dk/nrf54l15/cpuapp
 
   sample.sensor.accel_polling.nrf54l15_cpuflpr:
@@ -99,5 +95,4 @@ tests:
     extra_configs:
       - CONFIG_LOG=y
       - CONFIG_SENSOR_LOG_LEVEL_DBG=y
-      - CONFIG_SPI_LOG_LEVEL_DBG=y
     platform_allow: nrf54l15dk/nrf54l15/cpuflpr

--- a/scripts/twister/alt/zephyr/samples/sensor/accel_polling/sample.yaml
+++ b/scripts/twister/alt/zephyr/samples/sensor/accel_polling/sample.yaml
@@ -34,10 +34,6 @@ tests:
     extra_args:
       - accel_polling_SHIELD=pca63566
       - vpr_launcher_SHIELD=pca63566_fwd
-    extra_configs:
-      - CONFIG_LOG=y
-      - CONFIG_SENSOR_LOG_LEVEL_DBG=y
-      - CONFIG_SPI_LOG_LEVEL_DBG=y
     platform_allow: nrf54h20dk/nrf54h20/cpuppr
 
   sample.sensor.accel_polling.nrf54h_coverage:


### PR DESCRIPTION
With logs, sample does not fit memory.