### PR TITLE
[Backport v2.9-branch] doc: fast_pair: Update software maturity tables for NCS 2.9.0

### DIFF
--- a/doc/nrf/releases_and_maturity/software_maturity.rst
+++ b/doc/nrf/releases_and_maturity/software_maturity.rst
@@ -1580,6 +1580,8 @@ The following table indicates the software maturity levels of the support for Go
         - nRF52840
         - nRF5340
         - nRF54H20
+        - nRF54L05
+        - nRF54L10
         - nRF54L15
         - nRF9131
         - nRF9151
@@ -1594,6 +1596,8 @@ The following table indicates the software maturity levels of the support for Go
         - Experimental
         - Experimental
         - Experimental
+        - Experimental
+        - --
         - --
         - Experimental
         - --
@@ -1609,6 +1613,8 @@ The following table indicates the software maturity levels of the support for Go
         - Supported
         - Supported
         - Experimental
+        - --
+        - --
         - --
         - Supported
         - --
@@ -1636,6 +1642,8 @@ The following table indicates the software maturity levels of the support for ea
         - nRF52840
         - nRF5340
         - nRF54H20
+        - nRF54L05
+        - nRF54L10
         - nRF54L15
         - nRF9131
         - nRF9151
@@ -1649,6 +1657,8 @@ The following table indicates the software maturity levels of the support for ea
         - Supported
         - Supported
         - Experimental
+        - Experimental
+        - --
         - --
         - Supported
         - --
@@ -1663,6 +1673,8 @@ The following table indicates the software maturity levels of the support for ea
         - Experimental
         - Experimental
         - Experimental
+        - Experimental
+        - --
         - --
         - Experimental
         - --
@@ -1677,6 +1689,8 @@ The following table indicates the software maturity levels of the support for ea
         - Experimental
         - Experimental
         - Experimental
+        - Experimental
+        - --
         - --
         - Experimental
         - --
@@ -1691,6 +1705,8 @@ The following table indicates the software maturity levels of the support for ea
         - Experimental
         - Experimental
         - Experimental
+        - Experimental
+        - --
         - --
         - Experimental
         - --
@@ -1705,6 +1721,8 @@ The following table indicates the software maturity levels of the support for ea
         - Supported
         - Supported
         - Experimental
+        - --
+        - --
         - --
         - Supported
         - --


### PR DESCRIPTION
Backport 3681d37ddabe1a468db71beeabb3dceb018afaee from #19385.