### PR TITLE
 [v2.8-branch] applications: nrf5340_audio: Fix audio sync timer off by one tick

### DIFF
--- a/applications/nrf5340_audio/unicast_server/main.c
+++ b/applications/nrf5340_audio/unicast_server/main.c
@@ -565,6 +565,43 @@ int main(void)
 
 	ret = bt_mgmt_adv_start(0, ext_adv_buf, ext_adv_buf_cnt, NULL, 0, true);
 	ERR_CHK(ret);
+	
+		// Test monotonicity
+	uint32_t timestamps_us[10];
+	int counter;
+	for (counter = 0; counter < 1000000; counter++){
+		// progress bar
+		if ((counter % 1000) == 0) {
+			LOG_ERR("%u", counter);
+		}
 
+		// get some timestamps
+		int i;
+		for (i=0;i<10;i++){
+			timestamps_us[i] = audio_sync_timer_capture();		
+		}
+
+		// check if there's a negative delta
+		int incorrect_entry = -1;
+		for (i=1;i<10;i++){
+			if (timestamps_us[i-1] > timestamps_us[i]){
+				incorrect_entry = i-1;
+			}
+		}
+
+		// report error
+		if (incorrect_entry >= 0){
+			LOG_ERR("\nIncorrect timestamp:");
+			for (i=0;i<10;i++){
+				if (incorrect_entry == i){
+					LOG_ERR("t[%u] = %u <<--", i, timestamps_us[i]);
+				} else {
+					LOG_ERR("t[%u] = %u", i, timestamps_us[i]);
+				}
+			}
+			break;
+		}
+	}
 	return 0;
 }
+


### PR DESCRIPTION
Fix audio sync timer off by one tick when TASKS_CAPTURE and
TASKS_CLEAR are in a race condition.

TASKS_CAPTURE is prioritized hence can have +30 us more when
RTC tick to trigger TASKS_CLEAR overlap with the capture of
the value.

The fix here initiates the RTC and TIMER sync only when a
capture is requested by the audio subsystem or the timestamp
request. This is in contrast to earlier implementation when
TIMER was sync on every RTC tick.

If a capture is requested in short duration of 30 us then
the race will still be present, but a subsequent fix for it
will be provided in a new commit.