### PR TITLE
doc: bluetooth: mesh update dfu sample README

### DIFF
--- a/samples/bluetooth/mesh/dfu/distributor/README.rst
+++ b/samples/bluetooth/mesh/dfu/distributor/README.rst
@@ -148,7 +148,7 @@ Follow the description in the :ref:`dfu_over_bt_mesh` guide on how to perform th
 
 The commands can be executed in two ways:
 
-* Through the shell management subsystem of MCU manager (for example, using the nRF Connect Device Manager mobile application or :ref:`Mcumgr command-line tool <dfu_tools_mcumgr_cli>`).
+* Through the shell management subsystem of MCU manager (for example, using the nRF Connect Device Manager mobile application on Android or :ref:`Mcumgr command-line tool <dfu_tools_mcumgr_cli>`).
 * By accessing the :ref:`zephyr:shell_api` module over RTT.
 
 .. _ble_mesh_dfu_distributor_fw_image_upload:


### PR DESCRIPTION
While the protocol documentation specifies that using the shell management subsystem of MCU manager via the nRF Connect Device Manager mobile application is only available for the Android app, this is missing from the sample documentation - which is added in this commit.