### PR TITLE
[Backport v2.9-branch] lib: azure_iot_hub: Fix invalid message ID

### DIFF
--- a/subsys/net/lib/azure_iot_hub/src/azure_iot_hub.c
+++ b/subsys/net/lib/azure_iot_hub/src/azure_iot_hub.c
@@ -1098,6 +1098,7 @@ int azure_iot_hub_method_respond(struct azure_iot_hub_result *result)
 	}
 
 	struct mqtt_publish_param param = {
+		.message_id = mqtt_helper_msg_id_get(),
 		.message.payload.data = result->payload.ptr,
 		.message.payload.len = result->payload.size,
 		.message.topic.topic.utf8 = topic,

--- a/tests/subsys/net/lib/azure_iot_hub/iot_hub/src/azure_iot_hub_test.c
+++ b/tests/subsys/net/lib/azure_iot_hub/iot_hub/src/azure_iot_hub_test.c
@@ -600,6 +600,7 @@ void test_azure_iot_hub_method_respond(void)
 	iot_hub_state = STATE_CONNECTED;
 
 	__cmock_mqtt_helper_publish_Stub(mqtt_helper_publish_method_respond_stub);
+	__cmock_mqtt_helper_msg_id_get_ExpectAndReturn(1);
 
 	TEST_ASSERT_EQUAL(0, azure_iot_hub_method_respond(&result));
 }
@@ -607,6 +608,7 @@ void test_azure_iot_hub_method_respond(void)
 void test_azure_iot_hub_method_respond_not_connected(void)
 {
 	struct azure_iot_hub_result result_dummy;
+	__cmock_mqtt_helper_msg_id_get_ExpectAndReturn(1);
 
 	TEST_ASSERT_EQUAL(-ENOTCONN, azure_iot_hub_method_respond(&result_dummy));
 }
@@ -626,6 +628,7 @@ void test_azure_iot_hub_method_respond_too_long_request_id(void)
 	};
 
 	iot_hub_state = STATE_CONNECTED;
+	__cmock_mqtt_helper_msg_id_get_ExpectAndReturn(1);
 
 	TEST_ASSERT_EQUAL(-EFAULT, azure_iot_hub_method_respond(&result));
 }
@@ -652,6 +655,7 @@ void test_azure_iot_hub_method_respond_mqtt_fail(void)
 	iot_hub_state = STATE_CONNECTED;
 
 	__cmock_mqtt_helper_publish_Stub(mqtt_helper_publish_fail_stub);
+	__cmock_mqtt_helper_msg_id_get_ExpectAndReturn(1);
 
 	TEST_ASSERT_EQUAL(-ENXIO, azure_iot_hub_method_respond(&result));
 }


### PR DESCRIPTION
Backport ffa08e9d4e592eaf079eb6f9dccfe14ec9d50bf5 from #19389.