### PR TITLE
doc: extensions: page_filter: fix script import snippet

### DIFF
--- a/doc/_extensions/page_filter.py
+++ b/doc/_extensions/page_filter.py
@@ -197,10 +197,10 @@ def page_filter_install(
     if visitor.found_filter_dropdown:
         app.add_css_file("page_filter.css")
         app.add_js_file("page_filter.mjs", type="module")
-        filename = app.builder.script_files[-1]
+        script = app.builder.script_files[-1]
 
         page_depth = len(Path(pagename).parents) - 1
-        body = f"import setupFiltering from './{page_depth * '../'}{filename}'; "
+        body = f"import setupFiltering from './{page_depth * '../'}{script.filename}'; "
         for dropdown in visitor.found_filter_dropdown:
             body += f"setupFiltering('{dropdown.name}'"
             if dropdown.container_element and dropdown.filter_tags:


### PR DESCRIPTION
app.builder.script_files is now a list of `_JavaScript` objects. To access the actual file name, the `filename` property must be used. Stringification of the class contains other info like priority or type, making it unusable to obtain the path only.