### PR TITLE
[Backport v2.9-branch] net: lib: mqtt_helper: Fix mqtt_helper_connect() documentation

### DIFF
--- a/include/net/mqtt_helper.h
+++ b/include/net/mqtt_helper.h
@@ -103,6 +103,8 @@ int mqtt_helper_init(struct mqtt_helper_cfg *cfg);
  *
  *  @retval 0 if successful.
  *  @retval -EOPNOTSUPP if operation is not supported in the current state.
+ *  @return A positive error code in case of DNS error, corresponding to ``getaddrinfo()`` return
+ *	    values.
  *  @return Otherwise a negative error code.
  */
 int mqtt_helper_connect(struct mqtt_helper_conn_params *conn_params);


### PR DESCRIPTION
Backport baaa9aaa55239a0b36ac27f2f3a6a11eb3692f8b from #19409.