### PR TITLE
[Backport v2.9-branch] lib: modem_key_mgmt: Add CME error code 527 - Invalid content

### DIFF
--- a/lib/modem_key_mgmt/modem_key_mgmt.c
+++ b/lib/modem_key_mgmt/modem_key_mgmt.c
@@ -93,6 +93,9 @@ static int translate_error(int err)
 	case 519: /* already exists */
 		LOG_WRN("Key already exists");
 		return -EALREADY;
+	case 527: /* Invalid content */
+		LOG_WRN("Invalid content");
+		return -EINVAL;
 	case 528: /* not allowed in power off warning */
 		LOG_WRN("Not allowed when power off warning is active");
 		return -ECANCELED;


### PR DESCRIPTION
Backport c43a9ee4b4f20161b4d364c02e0540b04cd582d9 from #19392.