### PR TITLE
[Backport v2.9-branch] samples: matter: Fix WiFi release build by disabling RAM PWRDWN

### DIFF
--- a/samples/matter/light_switch/boards/nrf7002dk_nrf5340_cpuapp_release.conf
+++ b/samples/matter/light_switch/boards/nrf7002dk_nrf5340_cpuapp_release.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Do not enable RAM power-down library for nRF7002 DK due to incompatible WiFi configuration.
+CONFIG_RAM_POWER_DOWN_LIBRARY=n

--- a/samples/matter/lock/boards/nrf7002dk_nrf5340_cpuapp_release.conf
+++ b/samples/matter/lock/boards/nrf7002dk_nrf5340_cpuapp_release.conf
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Do not enable RAM power-down library for nRF7002 DK due to incompatible WiFi configuration.
+CONFIG_RAM_POWER_DOWN_LIBRARY=n
+
+# Enable LTO to decrease the flash usage.
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y

--- a/samples/matter/lock/prj_thread_wifi_switched.conf
+++ b/samples/matter/lock/prj_thread_wifi_switched.conf
@@ -56,3 +56,6 @@ CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
 # Enforce the use of mbedTLS crypto backend instead of PSA Crypto by
 # building OpenThread from sources. Wi-Fi stack does not support PSA Crypto yet.
 CONFIG_OPENTHREAD_SOURCES=y
+
+# Do not enable RAM power-down library for nRF7002 DK due to incompatible WiFi configuration.
+CONFIG_RAM_POWER_DOWN_LIBRARY=n


### PR DESCRIPTION
Backport 9397a22115ae70a6befc242320d5359941357e79 from #19423.