### PR TITLE
[Backport v2.9-branch] manifest: sdk-zephyr: [nrf noup] drivers: flash: Allow reading secure…

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -69,7 +69,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: a97deec49ed5dfd09332eee0638b151cca5a8eac
+      revision: 3ba0b73aefd7e573871d75a0ddb3dc021f0f4cb8
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
… mem by nrf_rram.

Backport f951e1bc22e49d9ac28edd3fdcd2dbc630952fc1 from #19363