### PR TITLE
doc improvement: bme68x_iaq - Add file path to execute west config

### DIFF
--- a/doc/nrf/drivers/bme68x_iaq.rst
+++ b/doc/nrf/drivers/bme68x_iaq.rst
@@ -10,7 +10,7 @@ BME68X IAQ driver
 You can use the BME68X IAQ driver to run the Bosch Sensor Environmental Cluster (BSEC) library in order to get Indoor Air Quality (IAQ) readings.
 
 The BSEC library is distributed with a Bosch proprietary license (`BSEC license`_) that prevents it from being part of |NCS|.
-To start using it, you have to accept the license and enable the download with the following commands:
+To start using it, you have to accept the license and enable the download by running the following commands in the :file:`nrf` folder:
 
 .. code-block::
 


### PR DESCRIPTION
BME68X IAQ driver was missing path to where the west config command should be executed. Added the same.
TECHDOC-3224