### PR TITLE
doc: nrf_security: Adding HKDF-extract and HKDF-Expand to supported

### DIFF
--- a/doc/nrf/libraries/security/nrf_security/doc/driver_config.rst
+++ b/doc/nrf/libraries/security/nrf_security/doc/driver_config.rst
@@ -240,9 +240,9 @@ The following table shows key derivation function (KDF) support for each driver:
 +==============================+==========================+============================+===========================+
 | HKDF                         | Not supported            | Supported                  | Supported                 |
 +------------------------------+--------------------------+----------------------------+---------------------------+
-| HKDF-Extract                 | Not supported            | Supported                  | Not Supported             |
+| HKDF-Extract                 | Not supported            | Supported                  | Supported                 |
 +------------------------------+--------------------------+----------------------------+---------------------------+
-| HKDF-Expand                  | Not supported            | Supported                  | Not Supported             |
+| HKDF-Expand                  | Not supported            | Supported                  | Supported                 |
 +------------------------------+--------------------------+----------------------------+---------------------------+
 | PBKDF2-HMAC                  | Not supported            | Supported                  | Supported                 |
 +------------------------------+--------------------------+----------------------------+---------------------------+

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -93,7 +93,7 @@ Developing with PMICs
 Security
 ========
 
-|no_changes_yet_note|
+  * Added support for HKDF-Expand and HKDF-Extract in CRACEN.
 
 Protocols
 =========


### PR DESCRIPTION
HKDF-Extract and HKDF-Expand support have been added to cracen. Updating docs to match.