### PR TITLE
samples: net: download: Fix compilation with secure socket disabled

### DIFF
--- a/samples/net/download/CMakeLists.txt
+++ b/samples/net/download/CMakeLists.txt
@@ -10,14 +10,16 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(download)
 
 # Generate hex file from pem file
-get_filename_component(FILE_NAME ${CONFIG_SAMPLE_CERT_FILE} NAME)
-set(OUTPUT_FILE "${CMAKE_CURRENT_BINARY_DIR}/certs/${FILE_NAME}.inc")
-add_definitions(-DSAMPLE_CERT_FILE_INC="${OUTPUT_FILE}")
-generate_inc_file_for_target(
+if(CONFIG_SAMPLE_SECURE_SOCKET)
+  get_filename_component(FILE_NAME ${CONFIG_SAMPLE_CERT_FILE} NAME)
+  set(OUTPUT_FILE "${CMAKE_CURRENT_BINARY_DIR}/certs/${FILE_NAME}.inc")
+  add_definitions(-DSAMPLE_CERT_FILE_INC="${OUTPUT_FILE}")
+  generate_inc_file_for_target(
     app
     ${CONFIG_SAMPLE_CERT_FILE}
     ${OUTPUT_FILE}
-)
+  )
+endif()
 
 # NORDIC SDK APP START
 target_sources(app PRIVATE src/main.c)


### PR DESCRIPTION
Fix compilation error when secure socket has been disabled in the sample.
Because of Kconfig dependency the sample cert file is not defined resulting in cmake error.