### PR TITLE
scripts: memory-threshold: update ROM size for SDP GPIO

### DIFF
--- a/scripts/memory-threshold-list.yaml
+++ b/scripts/memory-threshold-list.yaml
@@ -119,7 +119,7 @@
     - applications.sdp.gpio.icbmsg
   platforms:
     - all
-  rom_size: 8400
+  rom_size: 8700
   ram_size: 12000
   codeowners:
     - nrfconnect/ncs-ll-ursus


### PR DESCRIPTION
Update ROM size for SDP GPIO application with ICBMSG backend after it was increased by https://github.com/nrfconnect/sdk-nrf/pull/18179