### PR TITLE
[Backport v2.9-branch] doc improvement: bme68x_iaq - Add file path to execute west config

### DIFF
--- a/doc/nrf/drivers/bme68x_iaq.rst
+++ b/doc/nrf/drivers/bme68x_iaq.rst
@@ -10,7 +10,7 @@ BME68X IAQ driver
 You can use the BME68X IAQ driver to run the Bosch Sensor Environmental Cluster (BSEC) library in order to get Indoor Air Quality (IAQ) readings.
 
 The BSEC library is distributed with a Bosch proprietary license (`BSEC license`_) that prevents it from being part of |NCS|.
-To start using it, you have to accept the license and enable the download with the following commands:
+To start using it, you have to accept the license and enable the download by running the following commands in the :file:`nrf` folder:
 
 .. code-block::
 


### PR DESCRIPTION
Backport ea721da29d5309f8b6bc0630b3f1ae2efd0c6290 from #19465.