### PR TITLE
drivers: serial: lpuart: Fix in TX abort

### DIFF
--- a/drivers/serial/uart_nrf_sw_lpuart.c
+++ b/drivers/serial/uart_nrf_sw_lpuart.c
@@ -713,7 +713,10 @@ static int api_tx_abort(const struct device *dev)
 	irq_unlock(key);
 
 	err = uart_tx_abort(data->uart);
-	if (err != -EFAULT) {
+	if (err == -EFAULT) {
+		/* If abort is before TX is started just report ABORT from here. */
+		err = 0;
+	} else {
 		/* if successfully aborted or returned error different than
 		 * one indicating that there is no transfer, return error code.
 		 */


### PR DESCRIPTION
Fix TX abort to not return error when transfer is aborted in early phase (before actual transfer is started).
Tweak test to use higher than 1ms TX timeout as too short timeout may lead to abortion during transfer preparation.