### PR TITLE
Support for Model Publication in Light CTL Temperature Server

### DIFF
--- a/include/bluetooth/mesh/light_temp_srv.h
+++ b/include/bluetooth/mesh/light_temp_srv.h
@@ -150,6 +150,11 @@ struct bt_mesh_light_temp_srv {
 	const struct bt_mesh_light_ctl_srv *ctl;
 	/** Publish parameters. */
 	struct bt_mesh_model_pub pub;
+	/* Publication buffer */
+	struct net_buf_simple pub_buf;
+	/* Publication data */
+	uint8_t pub_data[BT_MESH_MODEL_BUF_LEN(
+		BT_MESH_LIGHT_CTL_STATUS, BT_MESH_LIGHT_CTL_MSG_MAXLEN_STATUS)];
 	/** Transaction ID tracker for the set messages. */
 	struct bt_mesh_tid_ctx prev_transaction;
 	/** Handler function structure. */


### PR DESCRIPTION
## Specification Requirements
| From the Mesh Model Specification v1.0.1, Section 6.4.4.1:

This model shall support model publication, as defined in Section 4.2.2 of the Mesh Profile specification.

The Mesh Profile Specification v1.0.1, Section 4.2.2 defines model publication as a composite state that controls message publishing parameters, including:

Publish Address
Publish Period
Retransmission Settings

# Implementation Approach
The implementation adds publication support following the same pattern established in the light_ctl_srv, ensuring consistency with existing model implementations while fulfilling the specification's requirements. This approach maintains architectural coherence within the Bluetooth mesh stack.