### PR TITLE
net: openthread: Remove dependency on `CONFIG_POSIX_API`

### DIFF
--- a/samples/openthread/coap_client/prj.conf
+++ b/samples/openthread/coap_client/prj.conf
@@ -28,7 +28,6 @@ CONFIG_PM_PARTITION_SIZE_SETTINGS_STORAGE=0x8000
 
 # Network sockets
 CONFIG_NET_SOCKETS=y
-CONFIG_POSIX_API=y
 CONFIG_NET_SOCKETS_POLL_MAX=4
 
 # Same network Master Key for client and server

--- a/samples/openthread/coap_client/src/coap_client_utils.c
+++ b/samples/openthread/coap_client/src/coap_client_utils.c
@@ -125,7 +125,7 @@ static int on_provisioning_reply(const struct coap_packet *response,
 
 	memcpy(&unique_local_addr.sin6_addr, payload, payload_size);
 
-	if (!inet_ntop(AF_INET6, payload, unique_local_addr_str,
+	if (!zsock_inet_ntop(AF_INET6, payload, unique_local_addr_str,
 		       INET6_ADDRSTRLEN)) {
 		LOG_ERR("Received data is not IPv6 address: %d", errno);
 		ret = -errno;

--- a/samples/openthread/coap_server/prj.conf
+++ b/samples/openthread/coap_server/prj.conf
@@ -21,7 +21,6 @@ CONFIG_PM_PARTITION_SIZE_SETTINGS_STORAGE=0x8000
 
 # Network sockets
 CONFIG_NET_SOCKETS=y
-CONFIG_POSIX_API=y
 CONFIG_NET_SOCKETS_POLL_MAX=4
 
 # Same network Master Key for client and server


### PR DESCRIPTION
For CoAP utils, `CONFIG_POSIX_API` is required only for wrapping socket calls not to require `zsock` prefix. POSIX_API brings more features than needed, is still experimental in Zephyr and causes warnings on building.
This commit changes net socket calls to use `zsock_` prefix and disables `CONFIG_POSIX_API` for OpenThread.