### PR TITLE
samples: benchmarks: coremark: Add nRF54L05 and nRF54L10 support

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -384,7 +384,9 @@ Wi-Fi samples
 Other samples
 -------------
 
-|no_changes_yet_note|
+* :ref:`coremark_sample` sample:
+
+  * Added support for the :ref:`nRF54L05 and nRF54L10 (emulated on nRF54L15 DK) <ug_nrf54l>` SoCs.
 
 Drivers
 =======

--- a/samples/benchmarks/coremark/README.rst
+++ b/samples/benchmarks/coremark/README.rst
@@ -48,6 +48,8 @@ The sample configuration sets up the following board targets for standard loggin
 * ``nrf52833dk/nrf52833``
 * ``nrf52dk/nrf52832``
 * ``nrf5340dk/nrf5340/cpuapp``
+* ``nrf54l15dk/nrf54l05/cpuapp``
+* ``nrf54l15dk/nrf54l10/cpuapp``
 * ``nrf54l15dk/nrf54l15/cpuapp``
 
 Multi-domain logging

--- a/samples/benchmarks/coremark/boards/nrf54l15dk_nrf54l05_cpuapp.conf
+++ b/samples/benchmarks/coremark/boards/nrf54l15dk_nrf54l05_cpuapp.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+CONFIG_COREMARK_ITERATIONS=4000
+
+CONFIG_LOG_MODE_IMMEDIATE=y

--- a/samples/benchmarks/coremark/boards/nrf54l15dk_nrf54l10_cpuapp.conf
+++ b/samples/benchmarks/coremark/boards/nrf54l15dk_nrf54l10_cpuapp.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+CONFIG_COREMARK_ITERATIONS=4000
+
+CONFIG_LOG_MODE_IMMEDIATE=y

--- a/samples/benchmarks/coremark/sample.yaml
+++ b/samples/benchmarks/coremark/sample.yaml
@@ -13,6 +13,8 @@ tests:
       - nrf52833dk/nrf52833
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
@@ -20,6 +22,8 @@ tests:
       - nrf52833dk/nrf52833
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     tags: ci_build sysbuild ci_samples_benchmarks
@@ -31,6 +35,8 @@ tests:
       - nrf52833dk/nrf52833
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
@@ -38,6 +44,8 @@ tests:
       - nrf52833dk/nrf52833
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     tags: ci_build sysbuild ci_samples_benchmarks
@@ -57,6 +65,8 @@ tests:
       - nrf52833dk/nrf52833
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
@@ -64,6 +74,8 @@ tests:
       - nrf52833dk/nrf52833
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     tags: ci_build sysbuild ci_samples_benchmarks
@@ -76,6 +88,8 @@ tests:
       - nrf52833dk/nrf52833
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
@@ -83,6 +97,8 @@ tests:
       - nrf52833dk/nrf52833
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     tags: ci_build sysbuild ci_samples_benchmarks
@@ -95,6 +111,8 @@ tests:
       - nrf52833dk/nrf52833
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
@@ -102,6 +120,8 @@ tests:
       - nrf52833dk/nrf52833
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     tags: ci_build sysbuild ci_samples_benchmarks

--- a/scripts/quarantine_integration.yaml
+++ b/scripts/quarantine_integration.yaml
@@ -544,6 +544,8 @@
   platforms:
     - nrf52dk/nrf52832
     - nrf52833dk/nrf52833
+    - nrf54l15dk/nrf54l05/cpuapp
+    - nrf54l15dk/nrf54l10/cpuapp
   comment: "Configurations excluded to limit resources usage in integration builds"
 
 - scenarios:
@@ -559,6 +561,8 @@
     - nrf52dk/nrf52832
     - nrf52833dk/nrf52833
     - nrf5340dk/nrf5340/cpuapp
+    - nrf54l15dk/nrf54l05/cpuapp
+    - nrf54l15dk/nrf54l10/cpuapp
     - nrf54l15dk/nrf54l15/cpuapp
     - nrf54h20dk/nrf54h20/cpuapp
   comment: "Configurations excluded to limit resources usage in integration builds"
@@ -569,6 +573,8 @@
     - nrf52dk/nrf52832
     - nrf52833dk/nrf52833
     - nrf5340dk/nrf5340/cpuapp
+    - nrf54l15dk/nrf54l05/cpuapp
+    - nrf54l15dk/nrf54l10/cpuapp
     - nrf54l15dk/nrf54l15/cpuapp
     - nrf54h20dk/nrf54h20/cpuapp
   comment: "Configurations excluded to limit resources usage in integration builds"
@@ -579,6 +585,8 @@
     - nrf52dk/nrf52832
     - nrf52833dk/nrf52833
     - nrf5340dk/nrf5340/cpuapp
+    - nrf54l15dk/nrf54l05/cpuapp
+    - nrf54l15dk/nrf54l10/cpuapp
     - nrf54l15dk/nrf54l15/cpuapp
     - nrf54h20dk/nrf54h20/cpuapp
   comment: "Configurations excluded to limit resources usage in integration builds"


### PR DESCRIPTION
Change adds support for nRF54L05 and nRF54L10 SoCs (emulated on nRF54L15 DK).

Jira: NCSDK-30313