### PR TITLE
lib: nrf_cloud: make COAP_DOWNLOADS experimental again

### DIFF
--- a/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_coap
+++ b/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_coap
@@ -66,9 +66,9 @@ config NRF_CLOUD_COAP_SEND_SSIDS
 endif # WIFI
 
 config NRF_CLOUD_COAP_DOWNLOADS
-	bool "Download files using CoAP instead of HTTP"
+	bool "Download files using CoAP instead of HTTP [EXPERIMENTAL]"
 	depends on NRF_CLOUD_COAP
-	default y if NRF_CLOUD_FOTA_POLL || NRF_CLOUD_PGPS
+	select EXPERIMENTAL
 	help
 	  Use nRF Cloud CoAP's proxy download resource to download files for FOTA and P-GPS.
 	  When enabled, the Kconfig option COAP_EXTENDED_OPTIONS_LEN_VALUE must be increased


### PR DESCRIPTION
This patch makes the NRF_CLOUD_COAP_DOWNLOADS option experimental again. Resumption is broken in the current version, so it is not ready for production use.