### PR TITLE
nrf_modem_lib: lte_net_if: query actual link MTU

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -492,6 +492,8 @@ Modem libraries
 
   * Fixed an issue with the :c:func:`modem_key_mgmt_clear` function where it returned ``-ENOENT`` when the credential was cleared.
 
+* Updated the :ref:`nrf_modem_lib_lte_net_if` to automatically set the actual link :term:`Maximum Transmission Unit (MTU)` on the network interface when PDN connectivity is gained.
+
 Multiprotocol Service Layer libraries
 -------------------------------------
 

--- a/lib/nrf_modem_lib/nrf9x_sockets.c
+++ b/lib/nrf_modem_lib/nrf9x_sockets.c
@@ -1168,7 +1168,7 @@ static struct offloaded_if_api nrf9x_iface_offload_api = {
 	.enable = nrf9x_iface_enable,
 };
 
-/* TODO Get the actual MTU for the nRF9x LTE link. */
+/* Actual MTU for the nRF9x LTE link is handled by `lte_net_if.c` */
 NET_DEVICE_OFFLOAD_INIT(nrf9x_socket, "nrf9x_socket",
 			nrf9x_socket_offload_init,
 			NULL,


### PR DESCRIPTION
Update the network interface MTU before raising the connectivity event, so that the MTU as queried by downstream users is correct, instead of an assumed value based on IPv6 required minimums.