### PR TITLE
samples: hw_unique_key: Add nRF54L10 and nRF54L05

### DIFF
--- a/doc/nrf/releases_and_maturity/software_maturity.rst
+++ b/doc/nrf/releases_and_maturity/software_maturity.rst
@@ -2098,6 +2098,8 @@ Hardware Unique Key
         - nRF5340
         - nRF54H20
         - nRF54L15
+        - nRF54L10
+        - nRF54L05
         - nRF9131
         - nRF9151
         - nRF9160
@@ -2111,6 +2113,8 @@ Hardware Unique Key
         - Supported
         - Supported
         - --
+        - Experimental
+        - Experimental
         - Experimental
         - --
         - Supported

--- a/samples/keys/hw_unique_key/boards/nrf54l15dk_nrf54l05_cpuapp.conf
+++ b/samples/keys/hw_unique_key/boards/nrf54l15dk_nrf54l05_cpuapp.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_MBEDTLS_PSA_CRYPTO_C=y
+CONFIG_MAIN_STACK_SIZE=4096
+CONFIG_MBEDTLS_ENABLE_HEAP=y

--- a/samples/keys/hw_unique_key/boards/nrf54l15dk_nrf54l10_cpuapp.conf
+++ b/samples/keys/hw_unique_key/boards/nrf54l15dk_nrf54l10_cpuapp.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_MBEDTLS_PSA_CRYPTO_C=y
+CONFIG_MAIN_STACK_SIZE=4096
+CONFIG_MBEDTLS_ENABLE_HEAP=y

--- a/samples/keys/hw_unique_key/sample.yaml
+++ b/samples/keys/hw_unique_key/sample.yaml
@@ -15,6 +15,8 @@ common:
     - nrf52840dk/nrf52840
     - nrf21540dk/nrf52840
     - nrf54l15dk/nrf54l15/cpuapp
+    - nrf54l15dk/nrf54l10/cpuapp
+    - nrf54l15dk/nrf54l05/cpuapp
   integration_platforms:
     - nrf5340dk/nrf5340/cpuapp
     - nrf5340dk/nrf5340/cpuapp/ns
@@ -27,6 +29,8 @@ common:
     - nrf52840dk/nrf52840
     - nrf21540dk/nrf52840
     - nrf54l15dk/nrf54l15/cpuapp
+    - nrf54l15dk/nrf54l10/cpuapp
+    - nrf54l15dk/nrf54l05/cpuapp
   harness: console
   harness_config:
     type: multi_line


### PR DESCRIPTION
Hardware unique keys are supported on 54L10/L05