### PR TITLE
doc: pdn: lwm2m_carrier: Improve the PDN header file documentation

### DIFF
--- a/include/modem/pdn.h
+++ b/include/modem/pdn.h
@@ -262,7 +262,9 @@ int pdn_default_apn_get(char *buf, size_t len);
  *
  * @param cb The PDN event handler.
  *
- * @return int Zero on success or a negative errno otherwise.
+ * @retval 0       Callback registered successfully, or the callback is already registered.
+ * @retval -EFAULT The provided cb parameter was \c NULL.
+ * @retval -ENOMEM Insufficient heap to allocate the PDP context.
  */
 int pdn_default_ctx_cb_reg(pdn_event_handler_t cb);
 
@@ -271,7 +273,10 @@ int pdn_default_ctx_cb_reg(pdn_event_handler_t cb);
  *
  * @param cb The PDN event handler.
  *
- * @return int Zero on success or a negative errno otherwise.
+ * @retval 0       Callback deregistered successfully.
+ * @retval -EFAULT The provided cb parameter was \c NULL.
+ * @retval -EINVAL PDP context with the provided callback was not found. This can be returned if
+ *                 the callback was not registered upon calling this function.
  */
 int pdn_default_ctx_cb_dereg(pdn_event_handler_t cb);
 

--- a/lib/bin/lwm2m_carrier/include/lwm2m_os.h
+++ b/lib/bin/lwm2m_carrier/include/lwm2m_os.h
@@ -221,7 +221,8 @@ int lwm2m_os_pdn_ctx_destroy(uint8_t cid);
  *                    supported, or PDN_FAM_IPV6 if only IPv6 is supported. Otherwise, this value
  *                    will remain unchanged.
  *
- * @retval  0      If success.
+ * @retval 0 If the operation was successful.
+ *           Otherwise, a negative error code is returned.
  */
 int lwm2m_os_pdn_activate(uint8_t cid, int *esm, enum lwm2m_os_pdn_fam *family);
 
@@ -230,7 +231,8 @@ int lwm2m_os_pdn_activate(uint8_t cid, int *esm, enum lwm2m_os_pdn_fam *family);
  *
  * @param cid The PDP context ID.
  *
- * @retval  0      If success.
+ * @retval 0 If the operation was successful.
+ *           Otherwise, a negative error code is returned.
  */
 int lwm2m_os_pdn_deactivate(uint8_t cid);
 
@@ -241,7 +243,7 @@ int lwm2m_os_pdn_deactivate(uint8_t cid);
  *
  * @param cid The context ID of the PDN connection.
  *
- * @retval  0      If success.
+ * @return A non-negative PDN ID on success, or a negative errno otherwise.
  */
 int lwm2m_os_pdn_id_get(uint8_t cid);
 
@@ -249,6 +251,9 @@ int lwm2m_os_pdn_id_get(uint8_t cid);
  * @brief Set a callback for events pertaining to the default PDP context (zero).
  *
  * @param cb The PDN event handler.
+ *
+ * @retval 0 If the operation was successful.
+ *           Otherwise, a negative error code is returned.
  */
 int lwm2m_os_pdn_default_callback_set(lwm2m_os_pdn_event_handler_t cb);
 
@@ -333,8 +338,8 @@ uint32_t lwm2m_os_rand_get(void);
  *
  * @param[in] id of the entry to be deleted.
  *
- * @retval  0      If success
- * @retval  -ERRNO errno code if error.
+ * @retval 0 If the operation was successful.
+ *           Otherwise, a negative error code is returned.
  */
 int lwm2m_os_storage_delete(uint16_t id);
 


### PR DESCRIPTION
* in the PDN library the callback (de)register functions were missing retvals. These are useful to have for users such as the LwM2M carrier library.
* The LwM2M OS layer implies that ``lwm2m_os_pdn_id_get()`` returns 0 on success (which it _can_, yet it is a bit misleading).
* Added mention of -ERRNO for activate and deactivate functions.