### PR TITLE
SUIT FOTA updates section

### DIFF
--- a/applications/nrf_desktop/bootloader_dfu.rst
+++ b/applications/nrf_desktop/bootloader_dfu.rst
@@ -359,28 +359,7 @@ To perform DFU using the `nRF Connect Device Manager`_ mobile app, complete the 
 
    .. tab:: SUIT
 
-      1. Generate the SUIT envelope by building your application with the FOTA support over Bluetooth Low Energy.
-         You can find the generated :file:`root.suit` envelope in the :file:`<build_dir>/DFU` directory.
-         Alternatively, you can use the generated :file:`dfu_suit.zip` package in the :file:`<build_dir>/zephyr` directory.
-      #. Download the :file:`root.suit` envelope or the :file:`dfu_suit.zip` package to your device.
-
-         .. note::
-            `nRF Connect for Desktop`_ does not currently support the FOTA process.
-
-      #. Use the `nRF Connect Device Manager`_ mobile app to update your device with the new firmware.
-
-         a. Ensure that you can access the :file:`root.suit` envelope or the :file:`dfu_suit.zip` package from your phone or tablet.
-         #. In the mobile app, scan and select the device to update.
-         #. Switch to the :guilabel:`Image` tab.
-         #. In the **Firmware Upgrade** section, tap the :guilabel:`SELECT FILE` button and select the :file:`root.suit` envelope or the :file:`dfu_suit.zip` package.
-         #. Tap the :guilabel:`START` button.
-         #. Wait for the DFU to finish and then verify that the application works properly.
-
-      .. note::
-         Support for SUIT updates is available starting from the following versions of the `nRF Connect Device Manager`_ mobile app:
-
-         * Version ``2.0`` on Android.
-         * Version ``1.7`` on iOS.
+      .. include:: /includes/suit_fota_update_nrfcdm_test_steps.txt
 
 Update image verification and application image update
 ======================================================

--- a/doc/nrf/includes/suit_fota_update_nrfcdm_test_steps.txt
+++ b/doc/nrf/includes/suit_fota_update_nrfcdm_test_steps.txt
@@ -1,0 +1,22 @@
+1. Generate the SUIT envelope by building your application with the FOTA support over Bluetooth Low Energy.
+   You can find the generated :file:`root.suit` envelope in the :file:`<build_dir>/DFU` directory.
+   Alternatively, you can use the generated :file:`dfu_suit.zip` package in the :file:`<build_dir>/zephyr` directory.
+#. Download the :file:`root.suit` envelope or the :file:`dfu_suit.zip` package to your mobile device running the DFU mobile app.
+
+   .. note::
+      `nRF Connect for Desktop`_ does not currently support the FOTA process.
+
+#. Use the `nRF Connect Device Manager`_ mobile app to update your device with the new firmware.
+
+   a. Ensure that you can access the :file:`root.suit` envelope or the :file:`dfu_suit.zip` package from your phone or tablet.
+   #. In the mobile app, scan and select the device to update.
+   #. Switch to the :guilabel:`Image` tab.
+   #. In the **Firmware Upgrade** section, tap the :guilabel:`SELECT FILE` button and select the :file:`root.suit` envelope or the :file:`dfu_suit.zip` package.
+   #. Tap the :guilabel:`START` button.
+   #. Wait for the DFU to finish and then verify that the application works properly.
+
+.. note::
+   Support for SUIT updates is available starting from the following versions of the `nRF Connect Device Manager`_ mobile app:
+
+   * Version ``2.2.1`` on Android.
+   * Version ``1.8.0`` on iOS.

--- a/samples/bluetooth/fast_pair/locator_tag/README.rst
+++ b/samples/bluetooth/fast_pair/locator_tag/README.rst
@@ -956,28 +956,7 @@ To perform the DFU procedure, complete the following steps:
       #. Observe that **LED 2** is blinking, which indicates that the Fast Pair advertising is enabled.
       #. Perform DFU using the `nRF Connect Device Manager`_ mobile app:
 
-         1. Generate the SUIT envelope by building your application with the FOTA support over Bluetooth Low Energy.
-            You can find the generated :file:`root.suit` envelope in the :file:`<build_dir>/DFU` directory.
-            Alternatively, you can use the generated :file:`dfu_suit.zip` package in the :file:`<build_dir>/zephyr` directory.
-         #. Download the :file:`root.suit` envelope or the :file:`dfu_suit.zip` package to your device.
-
-            .. note::
-               `nRF Connect for Desktop`_ does not currently support the FOTA process.
-
-         #. Use the `nRF Connect Device Manager`_ mobile app to update your device with the new firmware.
-
-            a. Ensure that you can access the :file:`root.suit` envelope or the :file:`dfu_suit.zip` package from your phone or tablet.
-            #. In the mobile app, scan and select the device to update.
-            #. Switch to the :guilabel:`Image` tab.
-            #. In the **Firmware Upgrade** section, tap the :guilabel:`SELECT FILE` button and select the :file:`root.suit` envelope or the :file:`dfu_suit.zip` package.
-            #. Tap the :guilabel:`START` button.
-            #. Wait for the DFU to finish and verify that the application works properly.
-
-      .. note::
-         Support for SUIT updates is available starting from the following versions of the `nRF Connect Device Manager`_ mobile app:
-
-         * Version ``2.0`` on Android.
-         * Version ``1.7`` on iOS.
+         .. include:: /includes/suit_fota_update_nrfcdm_test_steps.txt
 
 Disabling the locator tag
 -------------------------


### PR DESCRIPTION
~Adding a page to have a similar look and feel to the MCUboot-based DFU documentation.~

~As requested by @tomchy, the new page is added as an orphan so that it can be properly integrated into the SUIT documentation set after its proper restructure.~

The rationale for adding another include file is to create linkable testing steps for FOTA over Bluetooth using MCUmgr and SMP that the applications with the SUIT support can use.