### PR TITLE
applications: nrf_desktop: Add pytest test for nRF54L15 DK

### DIFF
--- a/applications/nrf_desktop/pytest/test_mcuboot_kmu.py
+++ b/applications/nrf_desktop/pytest/test_mcuboot_kmu.py
@@ -1,0 +1,103 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+import os
+import logging
+import subprocess
+import re
+import shlex
+
+from twister_harness import DeviceAdapter
+from twister_harness.helpers.utils import find_in_config
+
+logger = logging.getLogger(__name__)
+
+def run_command(command: list[str], timeout: int = 30):
+    try:
+        ret: subprocess.CompletedProcess = subprocess.run(command,
+                                                          text=True,
+                                                          stdout=subprocess.PIPE,
+                                                          stderr=subprocess.STDOUT,
+                                                          timeout=timeout)
+    except subprocess.TimeoutExpired:
+        logger.error(f"Timeout expired for command: {shlex.join(command)}")
+        raise
+
+    if ret.returncode:
+        logger.error(f"Command failed: {shlex.join(command)}")
+        logger.error(ret.stdout)
+        raise subprocess.CalledProcessError(ret.returncode, command)
+
+
+def _mcuboot_key_path(dut: DeviceAdapter):
+    mcuboot_conf_path = os.path.join(str(dut.device_config.build_dir), "mcuboot", "zephyr",
+                                     ".config")
+    return find_in_config(mcuboot_conf_path, "CONFIG_BOOT_SIGNATURE_KEY_FILE")
+
+
+def mcuboot_provision(dut: DeviceAdapter):
+    soc = dut.device_config.platform.split("/")[1]
+    key_path = _mcuboot_key_path(dut)
+    command = ["west", "ncs-provision", "upload", "-s", soc, "-k", key_path]
+    if dut.device_config.id:
+        command.extend(["--dev-id", dut.device_config.id])
+
+    logger.info("KMU provisioning")
+    run_command(command)
+
+
+def board_reset(dut: DeviceAdapter):
+    command = ["nrfutil", "device", "reset"]
+    if dut.device_config.id:
+        command.extend(["--serial-number", dut.device_config.id])
+
+    logger.info("Resetting board")
+    run_command(command)
+
+
+def logs_verify(dut: DeviceAdapter):
+    # Expected logs are sourced from nRF Desktop `sample.yaml` file.
+    expected_logs = [
+      "app_event_manager: e:module_state_event module:main state:READY",
+      "ble_state: Bluetooth initialized",
+      "settings_loader: Settings loaded",
+      "ble_bond: Selected Bluetooth LE peers",
+      "(ble_adv: Advertising started)|(ble_scan: Scan started)",
+      "dfu: Secondary image slot is clean"
+    ]
+    error_log = "<err>"
+
+    expected_regexes = list(map(re.compile, expected_logs))
+
+    while True:
+        line = dut.readline(timeout=120)
+
+        if line is None:
+            break
+
+        assert error_log not in line
+
+        for r in expected_regexes:
+            if r.search(line):
+                expected_regexes.remove(r)
+
+        if len(expected_regexes) == 0:
+            break
+
+
+    # Expect to match all of the regexes
+    assert len(expected_regexes) == 0
+
+
+def test_boot(dut: DeviceAdapter):
+    # nRF Desktop and bootloader images are already programmed at this stage.
+    mcuboot_provision(dut)
+
+    # Clear buffer to ensure proper state and then reset the board to start test.
+    dut.clear_buffer()
+    board_reset(dut)
+
+    logs_verify(dut)

--- a/applications/nrf_desktop/sample.yaml
+++ b/applications/nrf_desktop/sample.yaml
@@ -6,7 +6,6 @@ sample:
 common:
   sysbuild: true
   tags: ci_build sysbuild ci_applications_nrf_desktop
-  harness: console
   harness_config:
     type: multi_line
     ordered: false
@@ -18,13 +17,19 @@ common:
       - "(ble_adv: Advertising started)|(ble_scan: Scan started)"
       - "dfu: Secondary image slot is clean"
 tests:
+  applications.nrf_desktop.zdebug.uart.kmu_provision:
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
+    timeout: 180
+    harness: pytest
   applications.nrf_desktop.zdebug.uart:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp
+    harness: console
   applications.nrf_desktop.zdebug:
     build_only: true
     platform_allow: >
@@ -49,7 +54,7 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
     extra_args: FILE_SUFFIX=wwcb
-  applications.nrf_desktop.zdebug_fast_pair.gmouse.uart:
+  applications.nrf_desktop.zdebug_fast_pair.gmouse.uart.kmu_provision:
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:
@@ -57,6 +62,8 @@ tests:
     extra_args: FILE_SUFFIX=fast_pair
                 FP_MODEL_ID=0x8E717D
                 FP_ANTI_SPOOFING_KEY=dZxFzP7X9CcfLPC0apyRkmgsh3n2EbWo9NFNXfVuxAM=
+    timeout: 180
+    harness: pytest
   applications.nrf_desktop.zdebug_fast_pair.gmouse:
     build_only: true
     platform_allow: nrf52840dk/nrf52840 nrf52840gmouse/nrf52840
@@ -111,12 +118,14 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
     extra_args: FILE_SUFFIX=dongle
-  applications.nrf_desktop.zdebug_keyboard.uart:
+  applications.nrf_desktop.zdebug_keyboard.uart.kmu_provision:
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
     extra_args: FILE_SUFFIX=keyboard
+    timeout: 180
+    harness: pytest
   applications.nrf_desktop.zdebug_keyboard:
     build_only: true
     platform_allow:


### PR DESCRIPTION
Change adds pytest test configuration for nRF54L15 DK. Using pytest is necessary to perform twister runtime tests of configurations that require MCUboot KMU keys provisioning.

Jira: NCSDK-30872