### PR TITLE
adapt to clock_control_get_rate() removed

### DIFF
--- a/tests/benchmarks/multicore/idle_clock_control/src/main.c
+++ b/tests/benchmarks/multicore/idle_clock_control/src/main.c
@@ -116,8 +116,10 @@ static void test_request_release_clock_spec(const struct device *clk_dev,
 	__ASSERT_NO_MSG(ret == 0);
 	__ASSERT_NO_MSG(res == 0);
 	ret = clock_control_get_rate(clk_dev, NULL, &rate);
-	__ASSERT_NO_MSG(ret == 0);
-	__ASSERT_NO_MSG(rate == clk_spec->frequency);
+	if (ret != -ENOSYS) {
+		__ASSERT_NO_MSG(ret == 0);
+		__ASSERT_NO_MSG(rate == clk_spec->frequency);
+	}
 	k_busy_wait(10000);
 	ret = nrf_clock_control_release(clk_dev, clk_spec);
 	__ASSERT_NO_MSG(ret == ONOFF_STATE_ON);

--- a/tests/benchmarks/peripheral_load/src/clock_thread.c
+++ b/tests/benchmarks/peripheral_load/src/clock_thread.c
@@ -127,7 +127,9 @@ static void test_request_release_clock_spec(const struct device *clk_dev,
 	}
 	ret = clock_control_get_rate(clk_dev, NULL, &rate);
 	LOG_INF("Clock control get rate response code: %d", ret);
-	if (ret != 0) {
+	if (ret == -ENOSYS) {
+		LOG_INF("Clock control get rate not supported");
+	} else if (ret != 0) {
 		LOG_ERR("Clock control get rate failed");
 		atomic_inc(&completed_threads);
 		return;


### PR DESCRIPTION
The clock_control_get_rate() API is not implemented for all clocks, so it must be conditionally checked. It is specifically not implemented for HSFLLs since they are dynamic, so nrf_desktop dvfs service has been updated to not rely on said API.

Ref: NRFX-6890