### PR TITLE
manifest: update sdk-zephyr to disable unused RAM on nRF54L05/L10

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -69,7 +69,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v3.7.99-ncs2-rc2
+      revision: 1f8f3dc291420c70cd39e77a5cdc954561d4a08f
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
nRF54L05 & nRF54L10 emulated on nRF54L15 need to have unused RAM disabled to avoid increased power consumption.