### PR TITLE
suit: Fix breaking build if APP_LOCAL_1_VERSION is undefined

### DIFF
--- a/config/suit/templates/nrf54h20/default/v1/root_with_binary_nordic_top.yaml.jinja2
+++ b/config/suit/templates/nrf54h20/default/v1/root_with_binary_nordic_top.yaml.jinja2
@@ -351,7 +351,7 @@ SUIT_Envelope_Tagged:
           - suit-send-record-failure
           - suit-send-sysinfo-success
           - suit-send-sysinfo-failure
-    {%- if radio is defined %}
+    {%- if radio is defined and APP_LOCAL_1_VERSION is defined %}
         # Ensure that the application manifest version matches exactly the installed radio manifest version.
         - suit-directive-set-component-index: {{ rad_component_index }}
         - suit-directive-override-parameters:


### PR DESCRIPTION
If APP_LOCAL_1_VERSION was undefined build failures occured due to suit-generator error.