### PR TITLE
nrf_security: cracen: Add HMAC SHA256 to KMU key types.

### DIFF
--- a/doc/nrf/app_dev/device_guides/nrf54l/cryptography.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54l/cryptography.rst
@@ -263,10 +263,18 @@ The following table lists all key types that can be stored in the KMU, indicatin
      - Yes
    * - ED25519 public key
      - | ``key_type``: ``PSA_KEY_TYPE_ECC_PUBLIC_KEY(PSA_ECC_FAMILY_TWISTED_EDWARDS)``
-       | ``key bits``: 255
+       | ``key_bits``: 255
      - 2
      - No
      - Yes
+     - Yes
+   * - HMAC SHA-256 128-bit keys
+     - | ``key_type``: ``PSA_KEY_TYPE_HMAC``
+       | ``key_bits``: 128
+       | ``key_algorithm``: ``PSA_ALG_HMAC(PSA_ALG_SHA_256)``
+     - 1
+     - No
+     - No
      - Yes
 .. [1] Keys with the Encrypted usage scheme (``CRACEN_KMU_KEY_USAGE_SCHEME_ENCRYPTED``) will require two additional KMU slots to store the nonce and the authentication tag.
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -68,7 +68,7 @@ Working with nRF54H Series
 Developing with nRF54L Series
 =============================
 
-|no_changes_yet_note|
+* Added HMAC SHA-256 with a 128-bit key type to KMU, as detailed in the :ref:`ug_nrf54l_crypto_kmu_supported_key_types` documentation section.
 
 Developing with nRF53 Series
 ============================

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/common.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/common.c
@@ -839,6 +839,8 @@ size_t cracen_get_opaque_size(const psa_key_attributes_t *attributes)
 					psa_get_key_type(attributes), psa_get_key_bits(attributes));
 			}
 			return PSA_BITS_TO_BYTES(psa_get_key_bits(attributes));
+		} else if (psa_get_key_type(attributes) == PSA_KEY_TYPE_HMAC) {
+			return PSA_BITS_TO_BYTES(psa_get_key_bits(attributes));
 		} else {
 			return sizeof(kmu_opaque_key_buffer);
 		}

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/key_management.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/key_management.c
@@ -1124,7 +1124,7 @@ psa_status_t generate_key_for_kmu(const psa_key_attributes_t *attributes, uint8_
 		if (status != PSA_SUCCESS) {
 			return status;
 		}
-	} else if (key_type == PSA_KEY_TYPE_AES) {
+	} else if (key_type == PSA_KEY_TYPE_AES || key_type == PSA_KEY_TYPE_HMAC) {
 		status = psa_generate_random(key, PSA_BITS_TO_BYTES(psa_get_key_bits(attributes)));
 		if (status != PSA_SUCCESS) {
 			return status;


### PR DESCRIPTION
Added HMAC SHA256 as a new KMU key type.