### PR TITLE
slm: fix IPv6 only case

### DIFF
--- a/applications/serial_lte_modem/src/slm_ppp.c
+++ b/applications/serial_lte_modem/src/slm_ppp.c
@@ -213,7 +213,11 @@ static int ppp_start_internal(void)
 	ret = pdn_dynamic_params_get(PDP_CID, &ctx->ipcp.my_options.dns1_address,
 				     &ctx->ipcp.my_options.dns2_address, &mtu);
 	if (ret) {
-		return ret;
+		/* If any error happened on pdn getting with IPv4, try to parse with IPv6 */
+		ret = pdn_dynamic_params_get_v6(PDP_CID, NULL, NULL, &mtu);
+		if (ret) {
+			return ret;
+		}
 	}
 
 	if (mtu) {

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -445,7 +445,9 @@ Security libraries
 Modem libraries
 ---------------
 
-|no_changes_yet_note|
+* :ref:`pdn_readme` library:
+
+  * Added the :c:func:`pdn_dynamic_params_get_v6` function to get PDN parameters for IPv6-only.
 
 Multiprotocol Service Layer libraries
 -------------------------------------

--- a/include/modem/pdn.h
+++ b/include/modem/pdn.h
@@ -194,6 +194,19 @@ int pdn_dynamic_params_get(uint8_t cid, struct in_addr *dns4_pri,
 			   struct in_addr *dns4_sec, unsigned int *ipv4_mtu);
 
 /**
+ * @brief Retrieve dynamic parameters of a given PDP context.
+ *
+ * @param cid The PDP context ID.
+ * @param[out] dns6_pri The address of the primary IPv6 DNS server. Optional, can be NULL.
+ * @param[out] dns6_sec The address of the secondary IPv6 DNS server. Optional, can be NULL.
+ * @param[out] ipv6_mtu The IPv6 MTU. Optional, can be NULL.
+ *
+ * @return Zero on success or an error code on failure.
+ */
+int pdn_dynamic_params_get_v6(uint8_t cid, struct in6_addr *dns6_pri,
+			   struct in6_addr *dns6_sec, unsigned int *ipv6_mtu);
+
+/**
  * @brief Retrieve the default Access Point Name (APN).
  *
  * The default APN is the APN of the default PDP context (zero).


### PR DESCRIPTION
When ISP sends only IPv6 DNS records, pdn_dynamic_params_get was failing. That's the why pdn_dynamic_params_get_v6 was implemented and used as a fallback on the SLM's ppp.

Real world example:
We were using Congstar sim card in Germany.
Here was the results if CGCONTRDP when we set CGDCONT like below:
| CGDCONT    | CGCONTRDP |
| -------- | ------- |
| +CGDCONT: 0,"IP","internet" | +CGCONTRDP: 0,,"internet","","","10.74.210.210","10.74.210.211",,,,,1500 |
| +CGDCONT: 0,"IPV4V6","internet.telekom" | +CGCONTRDP: 0,,"internet.telekom","","","10.74.210.210","10.74.210.211",,,,,1500 <br/> +CGCONTRDP: 0,,"internet.telekom","","","2A01:0598:07FF:0000:0010:0074:0210:0210","2A01:0598:07FF:0000:0010:0074:0210:0211",,,,,1500 |
| +CGDCONT: 0,"IPV6","ims" | +CGCONTRDP: 0,,"ims","","","10.74.210.210","10.74.210.211" <br/> +CGCONTRDP: 0,,"ims","","","2A01:0598:07FF:0000:0010:0074:0210:0210","2A01:0598:07FF:0000:0010:0074:0210:0211" |
| +CGDCONT: 0,"IPV6","internet.v6.telekom" | +CGCONTRDP: 0,,"internet.v6.telekom","","","2A01:0598:07FF:0000:0010:0074:0210:0221","2A01:0598:07FF:0000:0010:0074:0210:0222" |

As you can see only on PDP + APN = IPV6 + "internet.v6.telekom" case, it was returning IPv6-only DNS records. Other cases always sent IPv4 DNS records. Therefore SLM was failing for us to establish PPP connection only on that condition. Here is the ticket on Nordic Dev forum: https://devzone.nordicsemi.com/f/nordic-q-a/116425/serial-lte-modem-ipv6-problem-on-ppp-connection-establishment