### PR TITLE
lib: ram_pwrdwn: add support for nRF54L10 and nRF54L05

### DIFF
--- a/lib/ram_pwrdn/Kconfig
+++ b/lib/ram_pwrdn/Kconfig
@@ -6,7 +6,7 @@
 
 menuconfig RAM_POWER_DOWN_LIBRARY
 	bool "Enable API for turning off unused RAM segments"
-	depends on SOC_NRF52840 || SOC_NRF52833 || SOC_NRF5340_CPUAPP || SOC_NRF54L15_CPUAPP
+	depends on SOC_NRF52840 || SOC_NRF52833 || SOC_NRF5340_CPUAPP || SOC_SERIES_NRF54LX
 	# Powering down RAM blocks can only be done from the secure domain
 	# for security reasons. If necessary, this limitation could be
 	# addressed by a secure service in the future.

--- a/lib/ram_pwrdn/ram_pwrdn.c
+++ b/lib/ram_pwrdn/ram_pwrdn.c
@@ -13,7 +13,7 @@
 #include <hal/nrf_power.h>
 #elif defined(CONFIG_SOC_NRF5340_CPUAPP)
 #include <hal/nrf_vmc.h>
-#elif defined(CONFIG_SOC_NRF54L15_CPUAPP)
+#elif defined(CONFIG_SOC_SERIES_NRF54LX)
 #include <hal/nrf_memconf.h>
 #else
 #error "RAM power-down library is not supported on the current platform"
@@ -47,6 +47,13 @@ static const struct ram_bank banks[] = {
 	 * the same bank.
 	 */
 	{ .start = 0x20000000UL, .section_count = 8, .section_size = 0x8000 },
+#elif defined(CONFIG_SOC_NRF54L10_CPUAPP)
+	/* Section numbers for RAM00 are 0-3 and for RAM01 are 4-5 within
+	 * the same bank.
+	 */
+	{ .start = 0x20000000UL, .section_count = 6, .section_size = 0x8000 },
+#elif defined(CONFIG_SOC_NRF54L05_CPUAPP)
+	{ .start = 0x20000000UL, .section_count = 3, .section_size = 0x8000 },
 #elif defined(CONFIG_SOC_NRF52840) || defined(CONFIG_SOC_NRF52833)
 	{ .start = 0x20000000UL, .section_count = 2, .section_size = 0x1000 },
 	{ .start = 0x20002000UL, .section_count = 2, .section_size = 0x1000 },
@@ -86,7 +93,7 @@ static void ram_bank_power_down(uint8_t bank_id, uint8_t first_section_id, uint8
 	uint32_t mask = GENMASK(VMC_RAM_POWER_S0POWER_Pos + last_section_id,
 				VMC_RAM_POWER_S0POWER_Pos + first_section_id);
 	nrf_vmc_ram_block_power_clear(NRF_VMC, bank_id, mask);
-#elif defined(CONFIG_SOC_NRF54L15_CPUAPP)
+#elif defined(CONFIG_SOC_SERIES_NRF54LX)
 	uint32_t mask = GENMASK(MEMCONF_POWER_CONTROL_MEM0_Pos + last_section_id,
 				MEMCONF_POWER_CONTROL_MEM0_Pos + first_section_id);
 	nrf_memconf_ramblock_control_mask_enable_set(NRF_MEMCONF, bank_id, mask, false);
@@ -106,7 +113,7 @@ static void ram_bank_power_up(uint8_t bank_id, uint8_t first_section_id, uint8_t
 	uint32_t mask = GENMASK(VMC_RAM_POWER_S0POWER_Pos + last_section_id,
 				VMC_RAM_POWER_S0POWER_Pos + first_section_id);
 	nrf_vmc_ram_block_power_set(NRF_VMC, bank_id, mask);
-#elif defined(CONFIG_SOC_NRF54L15_CPUAPP)
+#elif defined(CONFIG_SOC_SERIES_NRF54LX)
 	uint32_t mask = GENMASK(MEMCONF_POWER_CONTROL_MEM0_Pos + last_section_id,
 				MEMCONF_POWER_CONTROL_MEM0_Pos + first_section_id);
 	nrf_memconf_ramblock_control_mask_enable_set(NRF_MEMCONF, bank_id, mask, true);

--- a/samples/matter/smoke_co_alarm/boards/nrf54l15dk_nrf54l10_cpuapp.conf
+++ b/samples/matter/smoke_co_alarm/boards/nrf54l15dk_nrf54l10_cpuapp.conf
@@ -19,6 +19,3 @@ CONFIG_NVS=n
 
 # Low Power mode
 CONFIG_POWEROFF=y
-
-# Disabling of unused RAM blocks to reduce power consumption is not yet available for nRF54L10 SoC
-CONFIG_RAM_POWER_DOWN_LIBRARY=n

--- a/samples/matter/template/boards/nrf54l15dk_nrf54l10_cpuapp.conf
+++ b/samples/matter/template/boards/nrf54l15dk_nrf54l10_cpuapp.conf
@@ -17,6 +17,3 @@ CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
 # Workaround required as Zephyr L2 implies usage of NVS backend for settings.
 # It should be removed once the proper fix will be applied in Zephyr.
 CONFIG_NVS=n
-
-# Disabling of unused RAM blocks to reduce power consumption is not yet available for nRF54L10 SoC
-CONFIG_RAM_POWER_DOWN_LIBRARY=n

--- a/samples/openthread/cli/README.rst
+++ b/samples/openthread/cli/README.rst
@@ -125,9 +125,6 @@ The following snippets are available:
 * ``tcp`` - Enables experimental TCP support in this sample.
 * ``low_power`` - Enables low power consumption mode in this sample.
 
-  .. note::
-     The ``low_power`` snippet does not support the ``nrf54l15dk/nrf54l10/cpuapp`` board target.
-
 FEM support
 ===========
 


### PR DESCRIPTION
Add support for nRF54L10 and nRF54L05 and enable ram power down for these SoCs in Matter and OpenThread.