### PR TITLE
tests: benchmarks: multicore: idle_gpio: Add led

### DIFF
--- a/tests/benchmarks/multicore/idle_gpio/boards/nrf54h20dk_nrf54h20_cpuapp_s2ram.overlay
+++ b/tests/benchmarks/multicore/idle_gpio/boards/nrf54h20dk_nrf54h20_cpuapp_s2ram.overlay
@@ -7,10 +7,12 @@
 / {
 	aliases {
 		/delete-property/ sw1;
+		/delete-property/ led1;
 	};
 };
 
 /delete-node/ &button1;
+/delete-node/ &led1;
 
 &gpiote130 {
 	status = "okay";

--- a/tests/benchmarks/multicore/idle_gpio/remote/boards/nrf54h20dk_nrf54h20_cpurad_s2ram.overlay
+++ b/tests/benchmarks/multicore/idle_gpio/remote/boards/nrf54h20dk_nrf54h20_cpurad_s2ram.overlay
@@ -7,6 +7,7 @@
 / {
 	aliases {
 		sw1 = &button1;
+		led1 = &led1;
 	};
 	buttons {
 		compatible = "gpio-keys";
@@ -16,9 +17,20 @@
 			zephyr,code = <INPUT_KEY_1>;
 		};
 	};
+	leds {
+		compatible = "gpio-leds";
+		led1: led_1 {
+			gpios = <&gpio9 1 GPIO_ACTIVE_HIGH>;
+			label = "Green LED 1";
+		};
+	};
 };
 
 &gpio0 {
+	status = "okay";
+};
+
+&gpio9 {
 	status = "okay";
 };
 

--- a/tests/benchmarks/multicore/idle_gpio/src/main.c
+++ b/tests/benchmarks/multicore/idle_gpio/src/main.c
@@ -14,8 +14,10 @@ LOG_MODULE_REGISTER(idle_gpio);
 
 #if IS_ENABLED(CONFIG_SOC_NRF54H20_CPUAPP)
 static const struct gpio_dt_spec sw = GPIO_DT_SPEC_GET(DT_ALIAS(sw0), gpios);
+static const struct gpio_dt_spec led = GPIO_DT_SPEC_GET(DT_ALIAS(led0), gpios);
 #elif IS_ENABLED(CONFIG_SOC_NRF54H20_CPURAD)
 static const struct gpio_dt_spec sw = GPIO_DT_SPEC_GET(DT_ALIAS(sw1), gpios);
+static const struct gpio_dt_spec led = GPIO_DT_SPEC_GET(DT_ALIAS(led1), gpios);
 #else
 #error "Invalid core selected. "
 #endif
@@ -24,6 +26,7 @@ static K_SEM_DEFINE(my_gpio_sem, 0, 1);
 
 void my_gpio_callback(const struct device *dev, struct gpio_callback *cb, uint32_t pins)
 {
+	gpio_pin_set_dt(&led, 1);
 	LOG_INF("User callback for %s\n", CONFIG_BOARD_TARGET);
 	k_sem_give(&my_gpio_sem);
 }
@@ -34,6 +37,18 @@ int main(void)
 {
 	unsigned int cnt = 0;
 	int rc;
+
+	rc = gpio_is_ready_dt(&led);
+	if (rc < 0) {
+		LOG_ERR("GPIO Device not ready (%d)\n", rc);
+		return 0;
+	}
+
+	rc = gpio_pin_configure_dt(&led, GPIO_OUTPUT_ACTIVE);
+	if (rc < 0) {
+		LOG_ERR("Could not configure led GPIO (%d)\n", rc);
+		return 0;
+	}
 
 	rc = gpio_is_ready_dt(&sw);
 	if (rc < 0) {
@@ -57,6 +72,7 @@ int main(void)
 	LOG_INF("Multicore idle_gpio test on %s\n", CONFIG_BOARD_TARGET);
 	while (1) {
 		LOG_INF("Multicore idle_gpio test iteration %u\n", cnt++);
+		gpio_pin_set_dt(&led, 0);
 		if (k_sem_take(&my_gpio_sem, K_FOREVER) != 0) {
 			LOG_ERR("Failed to take a semaphore\n");
 			return 0;


### PR DESCRIPTION
Turn on the led when core becomes active.
This feature is needed for the new power
consumption measurement framework.