### PR TITLE
doc: fix the ZBOSS Zigbee version number

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-2.9.0.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-2.9.0.rst
@@ -258,7 +258,7 @@ Zigbee
 
 * Updated:
 
-  * :ref:`nrfxlib:zboss` to v3.11.7.0 and platform v5.1.7 (``v3.11.6.0+5.1.7``).
+  * :ref:`nrfxlib:zboss` to v3.11.6.0 and platform v5.1.7 (``v3.11.6.0+5.1.7``).
     They contain several fixes related to malfunctioning in a heavy traffic environment and more.
     For details, see :ref:`zboss_changelog`.
   * The :ref:`ZBOSS Network Co-processor Host <ug_zigbee_tools_ncp_host>` package to the new version v2.2.5.


### PR DESCRIPTION
Fixing the version from 3.11.7.0 to 3.11.6.0