### PR TITLE
suit: Workarounds for EXMIF

### DIFF
--- a/samples/suit/flash_companion/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/suit/flash_companion/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -25,6 +25,7 @@
 
 &mx25uw63 {
 	status = "okay";
+	/delete-property/ reset-gpios;
 };
 
 &uart136 {

--- a/samples/suit/flash_companion/prj.conf
+++ b/samples/suit/flash_companion/prj.conf
@@ -75,3 +75,4 @@ CONFIG_CLOCK_CONTROL=n
 # Set flash base address to zero to ensure that the executable
 # code is placed in CPUAPP RAM by the linker.
 CONFIG_FLASH_BASE_ADDRESS=0x0
+CONFIG_MSPI_XIP=n


### PR DESCRIPTION
Workarounds that make the external memory work again.

Ref: NCSDK-NONE