### PR TITLE
ci: Use CI_IB and test-nrf from v2.9-nRF54H20

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library("CI_LIB") _
+@Library("CI_LIB@v2.9-nRF54H20") _
 
 def pipeline = new ncs.sdk_nrf.Main()
 

--- a/test-manifests/99-default-test-nrf.yml
+++ b/test-manifests/99-default-test-nrf.yml
@@ -11,7 +11,7 @@ manifest:
     - name: test_nrf
       remote: ncs-test
       repo-path: test-fw-nrfconnect-nrf
-      revision: master
+      revision: v2.9-nRF54H20
       import:
         name-blocklist: [sdk-nrf]
       userdata:


### PR DESCRIPTION
Switching to release branch v2.9-nRF54H20

Signed-off-by: Sebastian Wezel <sebastian.wezel@nordicsemi.no>
