### PR TITLE
doc: Fix wrong API links in some libraries

### DIFF
--- a/doc/nrf/libraries/others/contin_array.rst
+++ b/doc/nrf/libraries/others/contin_array.rst
@@ -11,7 +11,7 @@ The continuous array library introduces an array that you can loop over, for exa
 You can use it to test playback with applications that support audio development kits, for example the :ref:`nrf53_audio_app`.
 
 The library introduces the :c:func:`contin_array_create` function, which takes an array that the user wants to loop over.
-For more information, see `API documentation`_.
+For more information, see the following API documentation section.
 
 Configuration
 *************

--- a/doc/nrf/libraries/others/data_fifo.rst
+++ b/doc/nrf/libraries/others/data_fifo.rst
@@ -10,7 +10,7 @@ Data FIFO
 This library combines the Zephyr memory slab and message queue mechanisms.
 The purpose is to be able to allocate a memory slab, use it, and signal to a receiver when the write operation has completed.
 The reader can then read and free the memory slab when done.
-For more information, see `API documentation`_.
+For more information, see the following API documentation section.
 
 Configuration
 *************

--- a/doc/nrf/libraries/others/pcm_stream_channel_modifier.rst
+++ b/doc/nrf/libraries/others/pcm_stream_channel_modifier.rst
@@ -8,7 +8,7 @@ PCM Stream Channel Modifier
    :depth: 2
 
 PCM Stream Channel Modifier library enables users to split pulse-code modulation (PCM) streams from stereo to mono or combine mono streams to form a stereo stream.
-For more information, see `API documentation`_.
+For more information, see the following API documentation section.
 
 Configuration
 *************

--- a/doc/nrf/libraries/others/tone.rst
+++ b/doc/nrf/libraries/others/tone.rst
@@ -8,7 +8,7 @@ Tone generator
    :depth: 2
 
 The tone generator library creates an array of pulse-code modulation (PCM) data of a one-period sine tone, with a given tone frequency and sampling frequency.
-For more information, see `API documentation`_.
+For more information, see the following API documentation section.
 
 Configuration
 *************


### PR DESCRIPTION
Fix wrong API links in some libraries.
It wrongly points to the zboss API docs.