### PR TITLE
doc: applications: Update Machine Learning description of multi-image build

### DIFF
--- a/applications/machine_learning/app_desc.rst
+++ b/applications/machine_learning/app_desc.rst
@@ -379,15 +379,16 @@ For more information, see the :ref:`nrf_machine_learning_configuration` page.
 Multi-image builds
 ------------------
 
-The Thingy:53 and the nRF5340 DK use multi-image build with the following child images:
+The Thingy:53, and the nRF5340 and nRF54H20 DKs use :ref:`zephyr:sysbuild` to perform multi-image build with the following additional images:
 
 * MCUboot bootloader
-* Bluetooth HCI RPMsg
+* IPC Radio
 
-You can define the application-specific configuration for the mentioned child images in the board-specific directory in the :file:`applications/machine_learning/configuration/` directory.
-The Kconfig configuration file should be located in subdirectory :file:`child_image/<child_image_name>` and its name should match the application Kconfig file name, and it should contain the build type if necessary.
-For example, the :file:`applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/child_image/hci_ipc/prj.conf` file defines configuration of Bluetooth HCI RPMsg for the ``debug`` build type on ``thingy53_nrf5340_cpuapp`` board, while the :file:`applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/child_image/hci_ipc/prj_release.conf` file defines configuration of Bluetooth HCI RPMsg for the ``release`` build type.
-See :ref:`ug_multi_image` for detailed information about multi-image builds and child image configuration.
+You can define the application-specific configuration for the mentioned images in the board-specific directory in the :file:`applications/machine_learning/sysbuild/` directory.
+The Kconfig configuration file should be located in a subdirectory :file:`sysbuild/<image_name>/boards/<configuration_file>` and its name should match the application Kconfig file name, and it should contain the build type if necessary.
+For example, the :file:`applications/machine_learning/sysbuild/ipc_radio/boards/thingy53_nrf5340_cpunet.conf` file defines the configuration of IPC Radio for the ``debug`` build type for ``thingy53_nrf5340_cpunet`` board target, while the :file:`applications/machine_learning/sysbuild/ipc_radio/boards/thingy53_nrf5340_cpunet_release.conf` file defines the configuration of IPC Radio for the ``release`` build type.
+If you want to build the application for the nRF54H20 DK in the dual-core mode, the configuration files for the :term:`Peripheral Processor (PPR) <Peripheral Processor (PPR, pronounced “Pepper”)>` image are located in the :file:`applications/machine_learning/remote` folder.
+See :ref:`zephyr:sysbuild` for detailed information about using sysbuild for building multiple images with desired configurations.
 
 .. _nrf_machine_learning_app_requirements_build_types:
 .. _nrf_machine_learning_app_configuration_build_types:

--- a/applications/machine_learning/intenal_module.rst
+++ b/applications/machine_learning/intenal_module.rst
@@ -28,7 +28,7 @@ The nRF Machine Learning application also uses the following dedicated applicati
 
 ``ei_data_forwarder_bt_nus``
   The module forwards the sensor readouts over NUS to the connected Bluetooth Central.
-  The sensor data is forwarded only if the connection is secured and the connection interval is within the limit defined by the :kconfig:option:`CONFIG_BT_PERIPHERAL_PREF_MAX_INT` and :kconfig:option:`CONFIG_BT_PERIPHERAL_PREF_MAX_INT` Kconfig options.
+  The sensor data is forwarded only if the connection is secured and the connection interval is within the limit defined by the :kconfig:option:`CONFIG_BT_PERIPHERAL_PREF_MIN_INT` and :kconfig:option:`CONFIG_BT_PERIPHERAL_PREF_MAX_INT` Kconfig options.
 
 ``ei_data_forwarder_uart``
   The module forwards the sensor readouts over UART.


### PR DESCRIPTION
The description was outdated after introduction of sysbuild. Updating the text to reflect the current status of the build system.