### PR TITLE
cmake: Prevent regenerating dfu multi image on every build

### DIFF
--- a/cmake/dfu_multi_image.cmake
+++ b/cmake/dfu_multi_image.cmake
@@ -37,14 +37,18 @@ function(dfu_multi_image_package TARGET_NAME)
     string(REPLACE ";" "\n" SCRIPT_ARGS "${SCRIPT_ARGS}")
     file(GENERATE OUTPUT ${ARG_OUTPUT}.args CONTENT ${SCRIPT_ARGS})
 
-    add_custom_target(${TARGET_NAME} ALL
+    add_custom_command(
         COMMAND
         ${Python3_EXECUTABLE}
         ${ZEPHYR_NRF_MODULE_DIR}/scripts/bootloader/dfu_multi_image_tool.py
         @${ARG_OUTPUT}.args
-        BYPRODUCTS
+        OUTPUT
         ${ARG_OUTPUT}
         DEPENDS
         ${ARG_DEPENDS}
+    )
+    add_custom_target(${TARGET_NAME} ALL
+        DEPENDS
+        ${ARG_OUTPUT}
     )
 endfunction()

--- a/subsys/bootloader/cmake/packaging.cmake
+++ b/subsys/bootloader/cmake/packaging.cmake
@@ -18,7 +18,7 @@ if(SB_CONFIG_DFU_MULTI_IMAGE_PACKAGE_BUILD)
 
     list(APPEND dfu_multi_image_ids 0)
     list(APPEND dfu_multi_image_paths "${${DEFAULT_IMAGE}_image_dir}/zephyr/${${DEFAULT_IMAGE}_kernel_name}.signed.bin")
-    list(APPEND dfu_multi_image_targets ${DEFAULT_IMAGE}_extra_byproducts)
+    list(APPEND dfu_multi_image_targets ${DEFAULT_IMAGE}_extra_byproducts ${dfu_multi_image_paths})
   endif()
 
   if(SB_CONFIG_DFU_MULTI_IMAGE_PACKAGE_NET)


### PR DESCRIPTION
* Move running dfu_multi_image_tool.py out of custom target to stop regenerating the image on every build.
* Fix DEPENDS for dfu_multi_image_package.