### PR TITLE
[Backport v2.9-branch] ci: docpublish: fix monitor regex

### DIFF
--- a/.github/workflows/docpublish.yml
+++ b/.github/workflows/docpublish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Unzip html archive
         working-directory: docs
         run: |
-          OUTDIR=$(awk 'NR==1 { if ($3 ~ /^(latest|v([0-9a-z\.\-]+)|PR-[0-9]+)$/) print $3 }' monitor_*.txt)
+          OUTDIR=$(awk 'NR==1 { if ($3 ~ /^(latest|PR-[0-9]+|[0-9]+\.[0-9a-z\.\-]+)$/) print $3 }' monitor_*.txt)
           echo "OUTDIR=$OUTDIR" >> "$GITHUB_ENV"
           unzip legacy-ncs*.zip -d $OUTDIR
 


### PR DESCRIPTION
Backport b7a903a2018adc2299930514912354faeb3c17ad from #19629.