### PR TITLE
doc: fixes to migration guide and user guide for nrf54h20

### DIFF
--- a/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_gs.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_gs.rst
@@ -157,7 +157,7 @@ Installing nRF Util and its commands
 Using the nRF54H20 DK with the |NCS| version |release| requires the following:
 
 * nRF Util version 7.13.0 or higher
-* nRF Util ``device`` version 2.7.8
+* nRF Util ``device`` version 2.7.10
 * nRF Util ``trace`` version 3.10.0
 * nRF Util ``suit`` version 0.9.0
 
@@ -181,9 +181,9 @@ Using the nRF54H20 DK with the |NCS| version |release| requires the following:
 
    For more information, consult the `nRF Util`_ documentation.
 
-#. Install the nRF Util ``device`` command version 2.7.8 as follows::
+#. Install the nRF Util ``device`` command version 2.7.10 as follows::
 
-      nrfutil install device=2.7.8 --force
+      nrfutil install device=2.7.10 --force
 
 #. Install the nRF Util ``trace`` command version 3.10.0 as follows::
 

--- a/doc/nrf/releases_and_maturity/migration/migration_guide_2.9.0-nrf54h20-rc1.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_guide_2.9.0-nrf54h20-rc1.rst
@@ -89,6 +89,11 @@ nRF54H20 SoC binaries
 
           nrfutil device x-suit-dfu --firmware nrf54h20_soc_binaries_v0.8.0.zip --serial-number <serial_number>
 
+    #. Purge the device again as follows::
+
+          nrfutil device recover --core Application --serial-number <serial_number>
+          nrfutil device recover --core Network --serial-number <serial_number>
+
     #. Erase the device again as follows::
 
           nrfutil device erase --all --core Network --serial-number <snr>
@@ -129,11 +134,11 @@ nrfutil device
 
 .. toggle::
 
-  * ``nrfutil device`` has been updated to version 2.7.8.
+  * ``nrfutil device`` has been updated to version 2.7.10.
 
-    Install the nRF Util ``device`` command version 2.7.8 as follows::
+    Install the nRF Util ``device`` command version 2.7.10 as follows::
 
-       nrfutil install device=2.7.8 --force
+       nrfutil install device=2.7.10 --force
 
     For more information, consult the `nRF Util`_ documentation.
 


### PR DESCRIPTION
Bump nrfutil device version to include bugfix for erase. Add purge command after installing new bundle.

Ref: NCSDK-NONE