### PR TITLE
[Backport v2.9-nRF54H20] manifest: sdk-zephyr: Revert "[nrf noup] hostap: Avoid double-definition of base64 APIs"

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -69,7 +69,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: f5efb381b8af563600f327c2273b117d0ef7f785
+      revision: 7c3bd68895d63ae72906cfd2722a482209a12272
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Backport 4989dd10e20f684616dda81e4b9bb41bea81154c from #19544.