### PR TITLE
mcuboot: Add Kconfig to force in-tree version of imgtool

### DIFF
--- a/cmake/sysbuild/image_signing.cmake
+++ b/cmake/sysbuild/image_signing.cmake
@@ -57,9 +57,15 @@ function(zephyr_mcuboot_tasks)
   # back on mcuboot/scripts/imgtool.py. We exclude the system imgtool when
   # compressed image support is enabled due to needing a version of imgtool
   # that has features not in the most recent public release.
-  if(IMGTOOL AND
-     (NOT CONFIG_MCUBOOT_COMPRESSED_IMAGE_SUPPORT_ENABLED AND
-      NOT (CONFIG_SOC_SERIES_NRF54LX AND CONFIG_MCUBOOT_BOOTLOADER_SIGNATURE_TYPE_ED25519)))
+  if(CONFIG_MCUBOOT_FORCE_IN_TREE_IMGTOOL_USAGE)
+    if(NOT DEFINED ZEPHYR_MCUBOOT_MODULE_DIR)
+      message(FATAL_ERROR "MCUboot module cannot be found")
+    endif()
+    set(IMGTOOL_PY "${ZEPHYR_MCUBOOT_MODULE_DIR}/scripts/imgtool.py")
+    if(EXISTS "${IMGTOOL_PY}")
+      set(imgtool_path "${IMGTOOL_PY}")
+    endif()
+  elseif(IMGTOOL)
     set(imgtool_path "${IMGTOOL}")
   elseif(DEFINED ZEPHYR_MCUBOOT_MODULE_DIR)
     set(IMGTOOL_PY "${ZEPHYR_MCUBOOT_MODULE_DIR}/scripts/imgtool.py")

--- a/cmake/sysbuild/image_signing_firmware_loader.cmake
+++ b/cmake/sysbuild/image_signing_firmware_loader.cmake
@@ -53,7 +53,15 @@ function(zephyr_mcuboot_tasks)
   #
   # Therefore, go with an explicitly installed imgtool first, falling
   # back on mcuboot/scripts/imgtool.py.
-  if(IMGTOOL)
+  if(CONFIG_MCUBOOT_FORCE_IN_TREE_IMGTOOL_USAGE)
+    if(NOT DEFINED ZEPHYR_MCUBOOT_MODULE_DIR)
+      message(FATAL_ERROR "MCUboot module cannot be found")
+    endif()
+    set(IMGTOOL_PY "${ZEPHYR_MCUBOOT_MODULE_DIR}/scripts/imgtool.py")
+    if(EXISTS "${IMGTOOL_PY}")
+      set(imgtool_path "${IMGTOOL_PY}")
+    endif()
+  elseif(IMGTOOL)
     set(imgtool_path "${IMGTOOL}")
   elseif(DEFINED ZEPHYR_MCUBOOT_MODULE_DIR)
     set(IMGTOOL_PY "${ZEPHYR_MCUBOOT_MODULE_DIR}/scripts/imgtool.py")

--- a/cmake/sysbuild/image_signing_nrf700x.cmake
+++ b/cmake/sysbuild/image_signing_nrf700x.cmake
@@ -25,7 +25,16 @@ function(nrf7x_signing_tasks input output_hex output_bin dependencies)
   #
   # Therefore, go with an explicitly installed imgtool first, falling
   # back on mcuboot/scripts/imgtool.py.
-  if(IMGTOOL)
+  sysbuild_get(CONFIG_MCUBOOT_FORCE_IN_TREE_IMGTOOL_USAGE IMAGE ${DEFAULT_IMAGE} VAR CONFIG_MCUBOOT_FORCE_IN_TREE_IMGTOOL_USAGE KCONFIG)
+  if(CONFIG_MCUBOOT_FORCE_IN_TREE_IMGTOOL_USAGE)
+    if(NOT DEFINED ZEPHYR_MCUBOOT_MODULE_DIR)
+      message(FATAL_ERROR "MCUboot module cannot be found")
+    endif()
+    set(IMGTOOL_PY "${ZEPHYR_MCUBOOT_MODULE_DIR}/scripts/imgtool.py")
+    if(EXISTS "${IMGTOOL_PY}")
+      set(imgtool_path "${IMGTOOL_PY}")
+    endif()
+  elseif(IMGTOOL)
     set(imgtool_path "${IMGTOOL}")
   elseif(DEFINED ZEPHYR_MCUBOOT_MODULE_DIR)
     set(IMGTOOL_PY "${ZEPHYR_MCUBOOT_MODULE_DIR}/scripts/imgtool.py")

--- a/cmake/sysbuild/image_signing_split.cmake
+++ b/cmake/sysbuild/image_signing_split.cmake
@@ -80,7 +80,15 @@ function(zephyr_mcuboot_tasks)
   #
   # Therefore, go with an explicitly installed imgtool first, falling
   # back on mcuboot/scripts/imgtool.py.
-  if(IMGTOOL)
+  if(CONFIG_MCUBOOT_FORCE_IN_TREE_IMGTOOL_USAGE)
+    if(NOT DEFINED ZEPHYR_MCUBOOT_MODULE_DIR)
+      message(FATAL_ERROR "MCUboot module cannot be found")
+    endif()
+    set(IMGTOOL_PY "${ZEPHYR_MCUBOOT_MODULE_DIR}/scripts/imgtool.py")
+    if(EXISTS "${IMGTOOL_PY}")
+      set(imgtool_path "${IMGTOOL_PY}")
+    endif()
+  elseif(IMGTOOL)
     set(imgtool_path "${IMGTOOL}")
   elseif(DEFINED ZEPHYR_MCUBOOT_MODULE_DIR)
     set(IMGTOOL_PY "${ZEPHYR_MCUBOOT_MODULE_DIR}/scripts/imgtool.py")

--- a/subsys/bootloader/Kconfig
+++ b/subsys/bootloader/Kconfig
@@ -261,4 +261,12 @@ config MCUBOOT_BOOTLOADER_SIGNATURE_TYPE_PURE
 	help
 	  This is a Kconfig which is informative only, the value should not be changed.
 
+config MCUBOOT_FORCE_IN_TREE_IMGTOOL_USAGE
+	bool "Use in-tree NCS MCUboot imgtool"
+	default y
+	depends on BOOTLOADER_MCUBOOT
+	help
+	  Will force usage of the in-tree NCS MCUboot version of imgtool when signing images
+	  instead of the global system imgtool version.
+
 endmenu


### PR DESCRIPTION
Adds a new Kconfig which is selected by default, and will enforce that the in-tree version of imgtool is used instead of the system version