### PR TITLE
actions: Skip toolchain check on branch creation

### DIFF
--- a/.github/workflows/enforce-toolchain-synchronization.yml
+++ b/.github/workflows/enforce-toolchain-synchronization.yml
@@ -17,9 +17,9 @@ on:
   push:
     branches:
       - '**'  # Triggers on pushes to any branch
-
 jobs:
   check-prs:
+    if: ${{ !github.event.created }}  # Skip for new branches
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Do not trigger enforce-toolchain-synchronization.yml when branch is created. 
Workflow fails on new branches due to lack of reference revision. 
It impacts all backport PRs