### PR TITLE
ci: docbuild/docpublish: allow uppercase in tags

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Check version
         run: |
-          VERSION_REGEX="^v([0-9a-z\.\-]+)$"
+          VERSION_REGEX="^v([0-9a-zA-Z\.\-]+)$"
           if [[ ${GITHUB_REF#refs/tags/} =~ $VERSION_REGEX ]]; then
             VERSION=${BASH_REMATCH[1]}
           elif [[ ${GITHUB_REF#refs/heads/} == "main" ]]; then

--- a/.github/workflows/docpublish.yml
+++ b/.github/workflows/docpublish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Unzip html archive
         working-directory: docs
         run: |
-          OUTDIR=$(awk 'NR==1 { if ($3 ~ /^(latest|PR-[0-9]+|[0-9]+\.[0-9a-z\.\-]+)$/) print $3 }' monitor_*.txt)
+          OUTDIR=$(awk 'NR==1 { if ($3 ~ /^(latest|PR-[0-9]+|[0-9]+\.[0-9a-zA-Z\.\-]+)$/) print $3 }' monitor_*.txt)
           echo "OUTDIR=$OUTDIR" >> "$GITHUB_ENV"
           unzip legacy-ncs*.zip -d $OUTDIR
 


### PR DESCRIPTION
Until now, we never allowed uppercase characters in tag. Allow them now.