### PR TITLE
boards: thingy91x: fix swapped blue/green LEDs

### DIFF
--- a/boards/nordic/thingy91x/thingy91x_nrf9151_common.dts
+++ b/boards/nordic/thingy91x/thingy91x_nrf9151_common.dts
@@ -33,11 +33,11 @@
 			label = "RGB red channel";
 		};
 		green_led: led_2 {
-			gpios = <&gpio0 30 0>;
+			gpios = <&gpio0 31 0>;
 			label = "RGB green channel";
 		};
 		blue_led: led_3 {
-			gpios = <&gpio0 31 0>;
+			gpios = <&gpio0 30 0>;
 			label = "RGB blue channel";
 		};
 	};
@@ -48,10 +48,10 @@
 			pwms = <&pwm0 0 PWM_MSEC(8) PWM_POLARITY_NORMAL>;
 		};
 		pwm_led1: pwm_led_1 {
-			pwms = <&pwm0 1 PWM_MSEC(8) PWM_POLARITY_NORMAL>;
+			pwms = <&pwm0 2 PWM_MSEC(8) PWM_POLARITY_NORMAL>;
 		};
 		pwm_led2: pwm_led_2 {
-			pwms = <&pwm0 2 PWM_MSEC(8) PWM_POLARITY_NORMAL>;
+			pwms = <&pwm0 1 PWM_MSEC(8) PWM_POLARITY_NORMAL>;
 		};
 	};
 	zephyr,user {


### PR DESCRIPTION
The mapping for blue and green LEDs has been swapped for both `leds` and `pwmleds` nodes to correctly control the desired color.

## Issue

From the LED table on the [Thingy91x hardware documentation](https://docs.nordicsemi.com/bundle/ug_thingy91x/page/UG/thingy91x/hw_description/leds.html) we expect the following LED mappings:
![image](https://github.com/user-attachments/assets/37749aac-7716-4fbe-b9f6-d1cef24ada93)

However we can see from the current board mapping that blue and green are reversed.

https://github.com/nrfconnect/sdk-nrf/blob/84ec4da2bfb18ecc3a6adffb4ae67cb520634e04/boards/nordic/thingy91x/thingy91x_nrf9151_common.dts#L29-L43

## Reproducing the issue

```
➜ git rev-parse HEAD
84ec4da2bfb18ecc3a6adffb4ae67cb520634e04
```

Verify that the blue and green LEDs are reversed by running the zephyr/samples/basic/blinky application with the following patch:

```
diff --git a/samples/basic/blinky/src/main.c b/samples/basic/blinky/src/main.c
index 4cab4969d94..80f491f7161 100644
--- a/samples/basic/blinky/src/main.c
+++ b/samples/basic/blinky/src/main.c
@@ -12,7 +12,7 @@
 #define SLEEP_TIME_MS   1000

 /* The devicetree node identifier for the "led0" alias. */
-#define LED0_NODE DT_ALIAS(led0)
+#define LED0_NODE DT_NODELABEL(green_led)

 /*
  * A build error on this line means your board is unsupported.
```

## Correcting pwmleds

I could not find any documentation on the hardware page or in the available schematic for how the PWM channels should be mapped. However, when comparing the Thingy91 to the Thingy91x, pwmleds for green and blue are swapped in the same way described above. This PR also corrects this.