### PR TITLE
manifest: sdk-zephyr: Pull fix for App boot with Wi-Fi on nRF54H

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -69,7 +69,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: f5efb381b8af563600f327c2273b117d0ef7f785
+      revision: da1f133c5df6a507941690478b94f0b60bf42bdb
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Fixes issue with Application core not being booted by SDFW when Wi-Fi is enabled.