### PR TITLE
samples: matter: Disabled RAM power down for nRF5340 DK

### DIFF
--- a/doc/nrf/releases_and_maturity/known_issues.rst
+++ b/doc/nrf/releases_and_maturity/known_issues.rst
@@ -491,6 +491,19 @@ Matter
 
 The issues in this section are related to the :ref:`ug_matter` protocol.
 
+.. rst-class:: v2-9-0
+
+KRKNWK-19826: The Device Firmware Upgrade (DFU) fails for nRF5340 DK with RAM power down enabled
+  The DFU fails for nRF5340 DK, if the application enables the :kconfig:option:`CONFIG_RAM_POWER_DOWN_LIBRARY` Kconfig option.
+  This option is enabled by default for the ``release`` configuration of the following samples:
+
+    * :ref:`matter_lock_sample`
+    * :ref:`matter_light_switch_sample`
+    * :ref:`matter_smoke_co_alarm_sample`
+    * :ref:`matter_window_covering_sample`
+
+  **Workaround:** Set the :kconfig:option:`CONFIG_RAM_POWER_DOWN_LIBRARY` Kconfig option to ``n`` in the :file:`prj_release.conf` file of the application.
+
 .. rst-class:: v2-9-0-nRF54H20-rc1 v2-9-0 v2-8-0
 
 KRKNWK-19388: The smart plug functionality of Matter Bridge application does not work with Apple Home application

--- a/samples/matter/light_switch/boards/nrf5340dk_nrf5340_cpuapp_release.conf
+++ b/samples/matter/light_switch/boards/nrf5340dk_nrf5340_cpuapp_release.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Do not enable RAM power-down library for nRF5340 DK due to DFU failures.
+CONFIG_RAM_POWER_DOWN_LIBRARY=n

--- a/samples/matter/lock/boards/nrf5340dk_nrf5340_cpuapp_release.conf
+++ b/samples/matter/lock/boards/nrf5340dk_nrf5340_cpuapp_release.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Do not enable RAM power-down library for nRF5340 DK due to DFU failures.
+CONFIG_RAM_POWER_DOWN_LIBRARY=n

--- a/samples/matter/smoke_co_alarm/boards/nrf5340dk_nrf5340_cpuapp_release.conf
+++ b/samples/matter/smoke_co_alarm/boards/nrf5340dk_nrf5340_cpuapp_release.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Do not enable RAM power-down library for nRF5340 DK due to DFU failures.
+CONFIG_RAM_POWER_DOWN_LIBRARY=n

--- a/samples/matter/window_covering/boards/nrf5340dk_nrf5340_cpuapp_release.conf
+++ b/samples/matter/window_covering/boards/nrf5340dk_nrf5340_cpuapp_release.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Do not enable RAM power-down library for nRF5340 DK due to DFU failures.
+CONFIG_RAM_POWER_DOWN_LIBRARY=n


### PR DESCRIPTION
Disabled RAM power down for nRF5340 DK release configuration due to DFU failures.