### PR TITLE
[Backport v2.9-nRF54H20-branch] ci: fix docbuild for ubuntu 24.04

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -54,8 +54,7 @@ jobs:
       - name: Install Python dependencies
         working-directory: ncs
         run: |
-          sudo pip3 install -U setuptools wheel pip
-          pip3 install -r nrf/doc/requirements.txt
+          pip install -r nrf/doc/requirements.txt
 
       - name: West zephyr-export
         working-directory: ncs


### PR DESCRIPTION
Backport d9500b94b05c776294fda96ebb0baaedb553a47e from #19674.