### PR TITLE
samples: matter: Enable Factory Data for nRF54H20 by default.

### DIFF
--- a/applications/matter_bridge/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/applications/matter_bridge/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -22,10 +22,8 @@ CONFIG_SETTINGS_ZMS_SECTOR_COUNT=8
 # It should be removed once the proper fix will be applied in Zephyr.
 CONFIG_NVS=n
 
-# TODO: Enable factory data once it is available
-CONFIG_CHIP_FACTORY_DATA=n
-
-# TODO: Workaround to be removed once Zephyr's CONFIG_FPROTECT is supported on nRF54H20.
+# TODO: Enable DAC key migration once it is supported.
+# Currently ITS does not work properly.
 CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT=n
 
 # Disable GPD

--- a/samples/matter/lock/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/samples/matter/lock/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -24,8 +24,8 @@ CONFIG_SETTINGS_ZMS_SECTOR_COUNT=8
 # It should be removed once the proper fix will be applied in Zephyr.
 CONFIG_NVS=n
 
-# TODO: Enable factory data once it is available
-CONFIG_CHIP_FACTORY_DATA=n
+# TODO: Enable DAC key migration once it is supported.
+# Currently ITS does not work properly.
 CONFIG_CHIP_CRYPTO_PSA_MIGRATE_DAC_PRIV_KEY=n
 
 # TODO: Workaround to be removed once Zephyr's CONFIG_FPROTECT is supported on nRF54H20.

--- a/samples/matter/template/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/samples/matter/template/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -24,8 +24,8 @@ CONFIG_NVS=n
 # It will add the application firmware to the cache partition.
 CONFIG_SUIT_DFU_CACHE_EXTRACT_IMAGE=y
 
-# TODO: Enable factory data and DAC key migration once it is available
-CONFIG_CHIP_FACTORY_DATA=n
+# TODO: Enable DAC key migration once it is supported.
+# Currently ITS does not work properly.
 CONFIG_CHIP_CRYPTO_PSA_MIGRATE_DAC_PRIV_KEY=n
 
 # TODO: Workaround to be removed once Zephyr's CONFIG_FPROTECT is supported on nRF54H20.

--- a/west.yml
+++ b/west.yml
@@ -159,7 +159,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 2340e0aad89bd415a3a1faa0af0da69169c8aa4a
+      revision: ad8ba68fd93b25f3fc0c0093bdaade96439b3987
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
Fixed DAC migration process for nRF54H20 and enabled Factory Data by default for that SoC.