### PR TITLE
applications: nrf_desktop: hwid fix c++ compatibility

### DIFF
--- a/applications/nrf_desktop/src/util/config_channel_transport.h
+++ b/applications/nrf_desktop/src/util/config_channel_transport.h
@@ -16,6 +16,10 @@
 
 #include "config_event.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief Parse the configuration channel report.
  *
@@ -129,6 +133,10 @@ bool config_channel_transport_rsp_receive(struct config_channel_transport *trans
  * @param transport Pointer to the configuration channel transport instance
  */
 void config_channel_transport_disconnect(struct config_channel_transport *transport);
+
+#ifdef __cplusplus
+}
+#endif
 
 /**
  * @}

--- a/applications/nrf_desktop/src/util/dfu_lock.h
+++ b/applications/nrf_desktop/src/util/dfu_lock.h
@@ -16,6 +16,10 @@
  * @{
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** @brief DFU lock owner descriptor. */
 struct dfu_lock_owner {
 	/** Owner name. */
@@ -68,6 +72,10 @@ int dfu_lock_claim(const struct dfu_lock_owner *new_owner);
  * @retval -EPERM if the DFU lock has not been claimed by the owner.
  */
 int dfu_lock_release(const struct dfu_lock_owner *owner);
+
+#ifdef __cplusplus
+}
+#endif
 
 /**
  * @}

--- a/applications/nrf_desktop/src/util/hwid.h
+++ b/applications/nrf_desktop/src/util/hwid.h
@@ -7,8 +7,16 @@
 #ifndef _HWID_H_
 #define _HWID_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define HWID_LEN 8
 
 void hwid_get(uint8_t *buf, size_t buf_size);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _HWID_H_ */


### PR DESCRIPTION
Make hwid header includable from a c++ code.