### PR TITLE
applications: nrf_desktop: Support passthrough reports in hid state

### DIFF
--- a/applications/nrf_desktop/configuration/common/hid_report_desc.h
+++ b/applications/nrf_desktop/configuration/common/hid_report_desc.h
@@ -71,17 +71,32 @@ enum report_id {
 
 /** @brief Input reports map. */
 static const uint8_t input_reports[] = {
+#if CONFIG_DESKTOP_HID_REPORT_MOUSE_SUPPORT || CONFIG_DESKTOP_HID_BOOT_INTERFACE_MOUSE
 	REPORT_ID_MOUSE,
+#endif
+#if CONFIG_DESKTOP_HID_REPORT_KEYBOARD_SUPPORT || CONFIG_DESKTOP_HID_BOOT_INTERFACE_KEYBOARD
 	REPORT_ID_KEYBOARD_KEYS,
+#endif
+#if CONFIG_DESKTOP_HID_REPORT_SYSTEM_CTRL_SUPPORT
 	REPORT_ID_SYSTEM_CTRL,
+#endif
+#if CONFIG_DESKTOP_HID_REPORT_CONSUMER_CTRL_SUPPORT
 	REPORT_ID_CONSUMER_CTRL,
+#endif
+	/* Keep boot reports at the end as these don't have own data. */
+#if CONFIG_DESKTOP_HID_BOOT_INTERFACE_MOUSE
 	REPORT_ID_BOOT_MOUSE,
+#endif
+#if CONFIG_DESKTOP_HID_BOOT_INTERFACE_KEYBOARD
 	REPORT_ID_BOOT_KEYBOARD,
+#endif
 };
 
 /** @brief Output reports map. */
 static const uint8_t output_reports[] = {
+#if CONFIG_DESKTOP_HID_REPORT_KEYBOARD_SUPPORT
 	REPORT_ID_KEYBOARD_LEDS,
+#endif
 };
 
 /* Internal definitions used to calculate size of the biggest supported HID input report. */

--- a/applications/nrf_desktop/src/modules/Kconfig.hid_state
+++ b/applications/nrf_desktop/src/modules/Kconfig.hid_state
@@ -60,6 +60,16 @@ config DESKTOP_HID_EVENT_QUEUE_SIZE
 	help
 	  Size of the HID event queue.
 
+config DESKTOP_HID_STATE_RAW_REPORTS
+	bool
+	help
+	  This option should be selected if the application code issue reports
+	  prepared outside of the HID state module.
+	  The HID state module will work as proxy collecting and holding such
+	  reports.
+	  The HID state will not alter the data but will make sure the reports
+	  are sent to the transport in an organized manner.
+
 module = DESKTOP_HID_STATE
 module-str = HID state
 source "subsys/logging/Kconfig.template.log_config"

--- a/applications/nrf_desktop/src/modules/usb_state.c
+++ b/applications/nrf_desktop/src/modules/usb_state.c
@@ -539,85 +539,30 @@ static void broadcast_subscription_change(struct usb_hid_device *usb_hid)
 	bool new_rep_enabled = (usb_hid->enabled) && (usb_hid->hid_protocol == HID_PROTOCOL_REPORT);
 	bool new_boot_enabled = (usb_hid->enabled) && (usb_hid->hid_protocol == HID_PROTOCOL_BOOT);
 
-	if (IS_ENABLED(CONFIG_DESKTOP_HID_REPORT_MOUSE_SUPPORT) &&
-	    (new_rep_enabled != usb_hid->report_enabled[REPORT_ID_MOUSE]) &&
-	    (usb_hid->report_bm & BIT(REPORT_ID_MOUSE))) {
-		struct hid_report_subscription_event *event =
-			new_hid_report_subscription_event();
+	for (size_t i = 0; i < ARRAY_SIZE(input_reports); i++) {
+		uint8_t report_id = input_reports[i];
+		bool new_enabled;
 
-		event->report_id  = REPORT_ID_MOUSE;
-		event->enabled    = new_rep_enabled;
-		event->subscriber = usb_hid;
+		if ((report_id == REPORT_ID_BOOT_MOUSE) ||
+		    (report_id == REPORT_ID_BOOT_KEYBOARD)) {
+			new_enabled = new_boot_enabled;
+		} else {
+			new_enabled = new_rep_enabled;
+		}
 
-		APP_EVENT_SUBMIT(event);
+		if ((new_enabled != usb_hid->report_enabled[report_id]) &&
+		    (usb_hid->report_bm & BIT(report_id))) {
+			struct hid_report_subscription_event *event =
+				new_hid_report_subscription_event();
 
-		usb_hid->report_enabled[REPORT_ID_MOUSE] = new_rep_enabled;
-	}
-	if (IS_ENABLED(CONFIG_DESKTOP_HID_REPORT_KEYBOARD_SUPPORT) &&
-	    (new_rep_enabled != usb_hid->report_enabled[REPORT_ID_KEYBOARD_KEYS]) &&
-	    (usb_hid->report_bm & BIT(REPORT_ID_KEYBOARD_KEYS))) {
-		struct hid_report_subscription_event *event =
-			new_hid_report_subscription_event();
+			event->report_id  = report_id;
+			event->enabled    = new_enabled;
+			event->subscriber = usb_hid;
 
-		event->report_id  = REPORT_ID_KEYBOARD_KEYS;
-		event->enabled    = new_rep_enabled;
-		event->subscriber = usb_hid;
+			APP_EVENT_SUBMIT(event);
 
-		APP_EVENT_SUBMIT(event);
-
-		usb_hid->report_enabled[REPORT_ID_KEYBOARD_KEYS] = new_rep_enabled;
-	}
-	if (IS_ENABLED(CONFIG_DESKTOP_HID_REPORT_SYSTEM_CTRL_SUPPORT) &&
-	    (new_rep_enabled != usb_hid->report_enabled[REPORT_ID_SYSTEM_CTRL]) &&
-	    (usb_hid->report_bm & BIT(REPORT_ID_SYSTEM_CTRL))) {
-		struct hid_report_subscription_event *event =
-			new_hid_report_subscription_event();
-
-		event->report_id  = REPORT_ID_SYSTEM_CTRL;
-		event->enabled    = new_rep_enabled;
-		event->subscriber = usb_hid;
-
-		APP_EVENT_SUBMIT(event);
-		usb_hid->report_enabled[REPORT_ID_SYSTEM_CTRL] = new_rep_enabled;
-	}
-	if (IS_ENABLED(CONFIG_DESKTOP_HID_REPORT_CONSUMER_CTRL_SUPPORT) &&
-	    (new_rep_enabled != usb_hid->report_enabled[REPORT_ID_CONSUMER_CTRL]) &&
-	    (usb_hid->report_bm & BIT(REPORT_ID_CONSUMER_CTRL))) {
-		struct hid_report_subscription_event *event =
-			new_hid_report_subscription_event();
-
-		event->report_id  = REPORT_ID_CONSUMER_CTRL;
-		event->enabled    = new_rep_enabled;
-		event->subscriber = usb_hid;
-
-		APP_EVENT_SUBMIT(event);
-		usb_hid->report_enabled[REPORT_ID_CONSUMER_CTRL] = new_rep_enabled;
-	}
-	if (IS_ENABLED(CONFIG_DESKTOP_HID_BOOT_INTERFACE_MOUSE) &&
-	    (new_boot_enabled != usb_hid->report_enabled[REPORT_ID_BOOT_MOUSE]) &&
-	    (usb_hid->report_bm & BIT(REPORT_ID_BOOT_MOUSE))) {
-		struct hid_report_subscription_event *event =
-			new_hid_report_subscription_event();
-
-		event->report_id  = REPORT_ID_BOOT_MOUSE;
-		event->enabled    = new_boot_enabled;
-		event->subscriber = usb_hid;
-
-		APP_EVENT_SUBMIT(event);
-		usb_hid->report_enabled[REPORT_ID_BOOT_MOUSE] = new_boot_enabled;
-	}
-	if (IS_ENABLED(CONFIG_DESKTOP_HID_BOOT_INTERFACE_KEYBOARD) &&
-	    (new_boot_enabled != usb_hid->report_enabled[REPORT_ID_BOOT_KEYBOARD]) &&
-	    (usb_hid->report_bm & BIT(REPORT_ID_BOOT_KEYBOARD))) {
-		struct hid_report_subscription_event *event =
-			new_hid_report_subscription_event();
-
-		event->report_id  = REPORT_ID_BOOT_KEYBOARD;
-		event->enabled    = new_boot_enabled;
-		event->subscriber = usb_hid;
-
-		APP_EVENT_SUBMIT(event);
-		usb_hid->report_enabled[REPORT_ID_BOOT_KEYBOARD] = new_boot_enabled;
+			usb_hid->report_enabled[report_id] = new_enabled;
+		}
 	}
 
 	LOG_INF("USB HID %p %sabled", (void *)usb_hid, (usb_hid->enabled) ? ("en"):("dis"));


### PR DESCRIPTION
Allow the hid state module to handle reports created by external modules. These reports will still be sent according to the his state rules.