### PR TITLE
subsys: bluetooth: User data in HID service callback

### DIFF
--- a/include/bluetooth/services/hids.h
+++ b/include/bluetooth/services/hids.h
@@ -532,6 +532,26 @@ int bt_hids_connected(struct bt_hids *hids_obj, struct bt_conn *conn);
  */
 int bt_hids_disconnected(struct bt_hids *hids_obj, struct bt_conn *conn);
 
+/** @brief Send Input Report, operation complete callback has user data as argument.
+ *
+ *  @note The function is not thread safe.
+ *	     It cannot be called from multiple threads at the same time.
+ *
+ *  @param hids_obj Pointer to HIDS instance.
+ *  @param conn Pointer to Connection Object.
+ *  @param rep_index Index of report descriptor.
+ *  @param rep Pointer to the report data.
+ *  @param len Length of report data.
+ *  @param cb Notification complete callback (can be NULL).
+ *  @param userdata Argument passed to notificaion complete callback.
+ *
+ *  @return 0 If the operation was successful. Otherwise, a (negative) error
+ *	      code is returned.
+ */
+int bt_hids_inp_rep_send_userdata(struct bt_hids *hids_obj, struct bt_conn *conn,
+				  uint8_t rep_index, uint8_t const *rep, uint8_t len,
+				  bt_gatt_complete_func_t cb, void *userdata);
+
 /** @brief Send Input Report.
  *
  *  @note The function is not thread safe.
@@ -547,9 +567,12 @@ int bt_hids_disconnected(struct bt_hids *hids_obj, struct bt_conn *conn);
  *  @return 0 If the operation was successful. Otherwise, a (negative) error
  *	      code is returned.
  */
-int bt_hids_inp_rep_send(struct bt_hids *hids_obj, struct bt_conn *conn,
-			 uint8_t rep_index, uint8_t const *rep, uint8_t len,
-			 bt_gatt_complete_func_t cb);
+static inline int bt_hids_inp_rep_send(struct bt_hids *hids_obj, struct bt_conn *conn,
+				       uint8_t rep_index, uint8_t const *rep, uint8_t len,
+				       bt_gatt_complete_func_t cb)
+{
+	return bt_hids_inp_rep_send_userdata(hids_obj, conn, rep_index, rep, len, cb, NULL);
+}
 
 /** @brief Send Boot Mouse Input Report.
  *

--- a/subsys/bluetooth/services/hids.c
+++ b/subsys/bluetooth/services/hids.c
@@ -1106,10 +1106,10 @@ static int inp_rep_notify_all(struct bt_hids *hids_obj,
 	}
 }
 
-int bt_hids_inp_rep_send(struct bt_hids *hids_obj,
-			 struct bt_conn *conn, uint8_t rep_index,
-			 uint8_t const *rep, uint8_t len,
-			 bt_gatt_complete_func_t cb)
+int bt_hids_inp_rep_send_userdata(struct bt_hids *hids_obj,
+				  struct bt_conn *conn, uint8_t rep_index,
+				  uint8_t const *rep, uint8_t len,
+				  bt_gatt_complete_func_t cb, void *userdata)
 {
 	struct bt_hids_inp_rep *hids_inp_rep =
 	    &hids_obj->inp_rep_group.reports[rep_index];
@@ -1147,6 +1147,7 @@ int bt_hids_inp_rep_send(struct bt_hids *hids_obj,
 	params.data = rep;
 	params.len = hids_inp_rep->size;
 	params.func = cb;
+	params.user_data = userdata;
 
 	int err = bt_gatt_notify_cb(conn, &params);
 


### PR DESCRIPTION
Allow user to set argument with which notification completion callback is called.