### PR TITLE
subsys: bluetooth: pass information on report id in callbacks

### DIFF
--- a/include/bluetooth/services/hids.h
+++ b/include/bluetooth/services/hids.h
@@ -170,6 +170,13 @@ struct bt_hids_rep {
  */
 typedef void (*bt_hids_notify_handler_t) (enum bt_hids_notify_evt evt);
 
+/** @brief HID notification event handler, with report identification.
+ *
+ * @param report_id Report ID defined in the HIDS Report Map.
+ * @param evt Notification event.
+ */
+typedef void (*bt_hids_notify_ext_handler_t) (uint8_t report_id, enum bt_hids_notify_evt evt);
+
 /** @brief HID Report event handler.
  *
  * @param rep	Pointer to the report descriptor.
@@ -228,8 +235,15 @@ struct bt_hids_inp_rep {
 	 */
 	const uint8_t *rep_mask;
 
-	/** Callback with the notification event. */
+	/** Callback with the notification event.
+	 * Used if set and extended callback is not set.
+	 */
 	bt_hids_notify_handler_t handler;
+
+	/** Extended callback with the notification event.
+	 * Has preference over the normal callback.
+	 */
+	bt_hids_notify_ext_handler_t handler_ext;
 };
 
 

--- a/include/bluetooth/services/hids.h
+++ b/include/bluetooth/services/hids.h
@@ -154,6 +154,9 @@ enum bt_hids_notify_evt {
 /** @brief Report data.
  */
 struct bt_hids_rep {
+	/** Report ID defined in the HIDS Report Map. Not valid for boot reports. */
+	uint8_t id;
+
 	/** Pointer to the report data. */
 	uint8_t *data;
 

--- a/subsys/bluetooth/services/hids.c
+++ b/subsys/bluetooth/services/hids.c
@@ -477,16 +477,21 @@ static void hids_input_report_ccc_changed(struct bt_gatt_attr const *attr,
 	    CONTAINER_OF((struct _bt_gatt_ccc *)attr->user_data,
 			 struct bt_hids_inp_rep, ccc);
 
+	uint8_t report_id = inp_rep->id;
+	enum bt_hids_notify_evt evt;
+
 	if (value == BT_GATT_CCC_NOTIFY) {
 		LOG_DBG("Notification has been turned on");
-		if (inp_rep->handler != NULL) {
-			inp_rep->handler(BT_HIDS_CCCD_EVT_NOTIFY_ENABLED);
-		}
+		evt = BT_HIDS_CCCD_EVT_NOTIFY_ENABLED;
 	} else {
 		LOG_DBG("Notification has been turned off");
-		if (inp_rep->handler != NULL) {
-			inp_rep->handler(BT_HIDS_CCCD_EVT_NOTIFY_DISABLED);
-		}
+		evt = BT_HIDS_CCCD_EVT_NOTIFY_DISABLED;
+	}
+
+	if (inp_rep->handler_ext != NULL) {
+		inp_rep->handler_ext(report_id, evt);
+	} else if (inp_rep->handler != NULL) {
+		inp_rep->handler(evt);
 	}
 }
 

--- a/subsys/bluetooth/services/hids.c
+++ b/subsys/bluetooth/services/hids.c
@@ -289,6 +289,7 @@ static ssize_t hids_outp_rep_read(struct bt_conn *conn,
 
 	if (rep->handler) {
 		struct bt_hids_rep report = {
+		    .id = rep->id,
 		    .data = buf,
 		    .size = rep->size,
 		};
@@ -333,6 +334,7 @@ static ssize_t hids_outp_rep_write(struct bt_conn *conn,
 
 	if (rep->handler) {
 		struct bt_hids_rep report = {
+		    .id = rep->id,
 		    .data = rep_data,
 		    .size = rep->size,
 		};
@@ -388,6 +390,7 @@ static ssize_t hids_feat_rep_read(struct bt_conn *conn,
 
 	if (rep->handler) {
 		struct bt_hids_rep report = {
+		    .id = rep->id,
 		    .data = buf,
 		    .size = rep->size,
 		};
@@ -438,6 +441,7 @@ static ssize_t hids_feat_rep_write(struct bt_conn *conn,
 
 	if (rep->handler) {
 		struct bt_hids_rep report = {
+		    .id = rep->id,
 		    .data = rep_data,
 		    .size = rep->size,
 		};
@@ -628,6 +632,7 @@ static ssize_t hids_boot_kb_outp_report_read(struct bt_conn *conn,
 
 	if (rep->handler) {
 		struct bt_hids_rep report = {
+		    .id = 0,
 		    .data = buf,
 		    .size = sizeof(conn_data->hids_boot_kb_outp_rep_ctx),
 		};
@@ -670,6 +675,7 @@ static ssize_t hids_boot_kb_outp_report_write(struct bt_conn *conn,
 
 	if (rep->handler) {
 		struct bt_hids_rep report = {
+		    .id = 0,
 		    .data = rep_data,
 		    .size = sizeof(conn_data->hids_boot_kb_outp_rep_ctx),
 		};


### PR DESCRIPTION
Add information about report id as argument to the callbacks. The old callback format is kept for backwards compatibility.