### PR TITLE
samples: matter: disable mpsl before preforming factory reset

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -133,7 +133,7 @@ Gazell
 Matter
 ------
 
-|no_changes_yet_note|
+* Disabled the :ref:`mpsl` before performing factory reset to speed up the process.
 
 Matter fork
 +++++++++++

--- a/west.yml
+++ b/west.yml
@@ -159,7 +159,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: ad8ba68fd93b25f3fc0c0093bdaade96439b3987
+      revision: b237efcbd1e65dceab20e08d80721b1b4a71e6da
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
We can speed up flash operations while performing a factory reset by disabling mpsl before that.

Thanks to that flash operations do not wait for mpsl synchronization and all write operations take less time.