### PR TITLE
subsys: mpsl: Make the CONFIG_MPSL_HFCLK_LATENCY user configurable

### DIFF
--- a/subsys/mpsl/init/Kconfig
+++ b/subsys/mpsl/init/Kconfig
@@ -75,7 +75,7 @@ config MPSL_LOW_PRIO_IRQN
 	  Check the interrupt number in the MDK
 
 config MPSL_HFCLK_LATENCY
-	int
+	int "HFCLK ramp-up latency in microsecond, assumed by MPSL to wait for the clock availability"
 	default 854 if SOC_SERIES_NRF54LX
 	default 1400
 	help


### PR DESCRIPTION
The MPSL uses the CONFIG_MPSL_HFCLK_LATENCY Kconfig option to setup HFCLK latency. There is an mpsl_clock_hfclk_latency_set() API that a user can call to setup the HFCLK latency. It can also be done automatically on a user behalf while mpsl_init() is executed. That will be possible when CONFIG_MPSL_HFCLK_LATENCY is user configurable.