### PR TITLE
manifest: tf-m: Point to v2.1.1-ncs2

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -151,7 +151,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: v2.1.1-ncs2-rc1
+      revision: v2.1.1-ncs2
     - name: psa-arch-tests
       repo-path: sdk-psa-arch-tests
       path: modules/tee/tf-m/psa-arch-tests


### PR DESCRIPTION
The previous -rc1 was pointing to the same SHA, let's clean this up by pointing to the right semantic tag.