### PR TITLE
[Backport v2.9-nRF54H20-branch] manifest: mbedtls: Point to v3.6.2-ncs2

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -139,7 +139,7 @@ manifest:
     - name: mbedtls
       path: modules/crypto/mbedtls
       repo-path: sdk-mbedtls
-      revision: v3.6.2-ncs2-rc1
+      revision: v3.6.2-ncs2
     - name: oberon-psa-crypto
       path: modules/crypto/oberon-psa-crypto
       repo-path: sdk-oberon-psa-crypto


### PR DESCRIPTION
Backport 0a895ba42949d3ddc868898a1068b3fc2c12f575 from #19707.