### PR TITLE
sysbuild: mcuboot: Remove some compressed update restrictions

### DIFF
--- a/cmake/sysbuild/image_signing.cmake
+++ b/cmake/sysbuild/image_signing.cmake
@@ -233,10 +233,14 @@ function(zephyr_mcuboot_tasks)
     # add_custom_command() are run in order, so adding the 'west sign'
     # calls to the "extra_post_build_commands" property ensures they run
     # after the commands which generate the unsigned versions.
-    set_property(GLOBAL APPEND PROPERTY extra_post_build_commands COMMAND
-      ${imgtool_sign} ${imgtool_args} ${imgtool_directxip_hex_command} ${imgtool_hex_extra} ${unconfirmed_args})
+    if("${keyfile_enc}" STREQUAL "")
+      set_property(GLOBAL APPEND PROPERTY extra_post_build_commands COMMAND
+        ${imgtool_sign} ${imgtool_args} ${imgtool_directxip_hex_command} ${imgtool_hex_extra} ${unconfirmed_args})
+    else()
+      set_property(GLOBAL APPEND PROPERTY extra_post_build_commands COMMAND
+        ${imgtool_sign} ${imgtool_args} --encrypt "${keyfile_enc}" --clear
+        ${imgtool_directxip_hex_command} ${imgtool_hex_extra} ${unconfirmed_args})
 
-    if(NOT "${keyfile_enc}" STREQUAL "")
       set(unconfirmed_args ${input}.hex ${output}.encrypted.hex)
       list(APPEND byproducts ${output}.encrypted.hex)
       set(BYPRODUCT_KERNEL_SIGNED_ENCRYPTED_HEX_NAME "${output}.encrypted.hex"

--- a/sysbuild/Kconfig.mcuboot
+++ b/sysbuild/Kconfig.mcuboot
@@ -47,8 +47,6 @@ endif # MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION
 config MCUBOOT_COMPRESSED_IMAGE_SUPPORT
 	bool "Compressed image support"
 	depends on MCUBOOT_MODE_OVERWRITE_ONLY
-	depends on MCUBOOT_UPDATEABLE_IMAGES = "1"
-	depends on !BOOT_ENCRYPTION
 	help
 	  When enabled, supports loading compressed images using LZMA2 to the secondary slot which
 	  will then be decompressed and loaded to the primary slot.

--- a/west.yml
+++ b/west.yml
@@ -128,7 +128,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 47faf767ec38947bd317dee906d44bdaaeb59368
+      revision: 148712e7b4618aadbedd04e8d3ce5c3847d3be4f
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR


### PR DESCRIPTION
Removes restrictions requiring a single update image and without encryption support
