### PR TITLE
actions: Do not trigger toolchain sync in forks

### DIFF
--- a/.github/workflows/enforce-toolchain-synchronization.yml
+++ b/.github/workflows/enforce-toolchain-synchronization.yml
@@ -19,7 +19,7 @@ on:
       - '**'  # Triggers on pushes to any branch
 jobs:
   check-prs:
-    if: ${{ !github.event.created }}  # Skip for new branches
+    if: ${{ github.repository_owner == 'nrfconnect' && !github.event.created }}  # Skip for new branches or forks
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
If actions are enabled in nrfconnect/sdk-nrf's fork, toolchain check should not be executed. It fails if developer force pushes a branch.