### PR TITLE
nrf_security: Reset the PRNG reseed counter in Cracen PSA

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/ctr_drbg.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/ctr_drbg.c
@@ -202,6 +202,8 @@ psa_status_t cracen_get_random(cracen_prng_context_t *context, uint8_t *output, 
 		}
 		safe_memset(entropy, sizeof(entropy), 0,
 			    CRACEN_PRNG_ENTROPY_SIZE + CRACEN_PRNG_NONCE_SIZE);
+
+		prng.reseed_counter = 0;
 	}
 
 	psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;


### PR DESCRIPTION
Reset the reseed counter when reseed is performed. Without this the cracen_get_random will perform reseeding for every call when reseed counter > reseed interval (Until reseed counter overflows which will have an undefined behavior).