### PR TITLE
lib: lte_link_control: Skip parsing of unexpected %NCELLMEAS notif

### DIFF
--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -399,7 +399,7 @@ struct lte_lc_ncell {
 	uint32_t earfcn;
 
 	/**
-	 * Difference of current cell and neighbor cell measurement, in the range
+	 * Difference of current cell and neighbor cell measurement in milliseconds, in the range
 	 * -99999 ms < time_diff < 99999 ms. @ref LTE_LC_CELL_TIME_DIFF_INVALID if the value is not
 	 * valid.
 	 */
@@ -441,7 +441,9 @@ struct lte_lc_cell {
 	uint32_t earfcn;
 
 	/**
-	 * Timing advance decimal value.
+	 * Timing advance decimal value in basic time units (Ts).
+	 *
+	 * Ts = 1/(15000 x 2048) seconds (as specified in 3GPP TS 36.211).
 	 *
 	 * Range 0 - @ref LTE_LC_CELL_TIMING_ADVANCE_MAX. @ref LTE_LC_CELL_TIMING_ADVANCE_INVALID if
 	 * timing advance is not valid.
@@ -453,7 +455,7 @@ struct lte_lc_cell {
 	uint16_t timing_advance;
 
 	/**
-	 * Timing advance measurement time, calculated from modem boot time.
+	 * Timing advance measurement time in milliseconds, calculated from modem boot time.
 	 *
 	 * Range 0 - 18 446 744 073 709 551 614 ms.
 	 *
@@ -466,7 +468,7 @@ struct lte_lc_cell {
 	uint64_t timing_advance_meas_time;
 
 	/**
-	 * Measurement time.
+	 * Cell measurement time in milliseconds, calculated from modem boot time.
 	 *
 	 * Range 0 - 18 446 744 073 709 551 614 ms.
 	 */

--- a/tests/lib/location/src/location_test.c
+++ b/tests/lib/location/src/location_test.c
@@ -1017,7 +1017,9 @@ void test_location_cellular_cancel_during_ncellmeas(void)
 
 	err = location_request_cancel();
 	TEST_ASSERT_EQUAL(0, err);
-	k_sleep(K_MSEC(1));
+
+	/* Need to wait a bit because no %NCELLMEAS notification is sent after AT%NCELLMEASSTOP. */
+	k_sleep(K_MSEC(2100));
 }
 
 /* Test cellular timeout during the 1st NCELLMEAS. */


### PR DESCRIPTION
Added check to skip `%NCELLMEAS` notification parsing when neighbor cell measurement has not been requested by calling `lte_lc_neighbor_cell_measurement()`. If the neighbor cell measurement is triggered by sending the `AT%NCELLMEAS` AT command to the modem, LTE LC does not know how the received notification should be parsed, sometimes leading to a parsing error.

Added missing time units in structs `lte_lc_cell` and `lte_lc_ncell`.