### PR TITLE
lib: location: Update documentation

### DIFF
--- a/doc/nrf/libraries/modem/location.rst
+++ b/doc/nrf/libraries/modem/location.rst
@@ -32,7 +32,7 @@ The supported location methods are as follows:
 
 * GNSS positioning
 
-  * Uses :ref:`gnss_interface` for getting the location.
+  * Uses :ref:`GNSS interface<gnss_interface>` for getting the location.
   * A-GNSS and P-GPS are managed with :ref:`lib_nrf_cloud_agnss` and :ref:`lib_nrf_cloud_pgps`.
   * The application may also use some other source for the data and use :c:func:`location_agnss_data_process` and :c:func:`location_pgps_data_process` to pass the data to the Location library.
   * The data format of A-GNSS or P-GPS must be as received from :ref:`lib_nrf_cloud_agnss`.
@@ -379,7 +379,10 @@ The following |NCS| applications and samples use this library:
 Limitations
 ***********
 
-* The Location library can only have one application registered at a time. If there is already an application handler registered, another initialization will override the existing handler.
+* The Location library can only have one application registered at a time.
+  If there is already an application handler registered, another initialization will override the existing handler.
+* The :ref:`GNSS interface<nrfxlib:gnss_interface>` should not be used directly by the application when using the Location library.
+  Using the GNSS interface from both the application and the Location library may lead to unexpected behavior.
 
 Dependencies
 ************
@@ -397,7 +400,7 @@ This library uses the following |NCS| libraries:
 
 It uses the following `sdk-nrfxlib`_ library:
 
-* :ref:`nrfxlib:gnss_interface`
+* :ref:`GNSS interface<nrfxlib:gnss_interface>`
 
 It uses the following Zephyr libraries:
 

--- a/doc/nrf/libraries/networking/nrf_cloud_agnss.rst
+++ b/doc/nrf/libraries/networking/nrf_cloud_agnss.rst
@@ -149,7 +149,7 @@ This library uses the following |NCS| libraries:
 
 It uses the following `sdk-nrfxlib`_ library:
 
-* :ref:`nrfxlib:gnss_interface`
+* :ref:`GNSS interface<nrfxlib:gnss_interface>`
 
 API documentation
 *****************

--- a/doc/nrf/libraries/networking/nrf_cloud_pgps.rst
+++ b/doc/nrf/libraries/networking/nrf_cloud_pgps.rst
@@ -298,7 +298,7 @@ This library uses the following |NCS| libraries:
 
 It uses the following `sdk-nrfxlib`_ library:
 
-* :ref:`nrfxlib:gnss_interface`
+* :ref:`GNSS interface<nrfxlib:gnss_interface>`
 
 It uses the following Zephyr subsystem:
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-1.6.0.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-1.6.0.rst
@@ -408,7 +408,7 @@ Modem library
 * Updated :ref:`nrf_modem` to version 1.2.1.
   See the :ref:`nrfxlib:nrf_modem_changelog` for detailed information.
 * Added a new function-based GNSS API with support for new GNSS features in modem firmware v1.3.0.
-  See :ref:`nrfxlib:gnss_interface` for more information.
+  See :ref:`GNSS interface<nrfxlib:gnss_interface>` for more information.
 
   * GNSS socket API is now deprecated.
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-1.7.0.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-1.7.0.rst
@@ -140,7 +140,7 @@ nRF9160
   * nRF9160: Asset Tracker has been deprecated in favor of :ref:`asset_tracker_v2`.
   * ``at_notif`` library has been deprecated in favor of the :ref:`at_monitor_readme` library.
   * ``at_cmd`` library has been deprecated in favor of Modem library's native AT interface.
-  * GPS driver has been deprecated in favor of the :ref:`nrfxlib:gnss_interface`.
+  * GPS driver has been deprecated in favor of the :ref:`GNSS interface<nrfxlib:gnss_interface>`.
 
 nRF5
 ====

--- a/samples/cellular/gnss/README.rst
+++ b/samples/cellular/gnss/README.rst
@@ -9,7 +9,7 @@ Cellular: GNSS
    :local:
    :depth: 2
 
-This sample demonstrates how to use the :ref:`nrfxlib:gnss_interface` to control the `GNSS`_ module.
+This sample demonstrates how to use the :ref:`GNSS interface<nrfxlib:gnss_interface>` to control the `GNSS`_ module.
 It also shows how to improve fix speed and accuracy with the :ref:`lib_nrf_cloud_agnss` library and how to use the :ref:`lib_nrf_cloud_pgps` library.
 Assistance data is downloaded from nRF Cloud using `nRF Cloud's REST-based device API <nRF Cloud REST API_>`_.
 


### PR DESCRIPTION
Added a limitation in the library documentation. GNSS API should not be used directly by the application when Location library is used. Doing so may lead to unexpected behavior, because GNSS may be in a different state than expected by the library.