### PR TITLE
nrf_security: Refactor get_opaque_size function

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa.h
@@ -247,7 +247,7 @@ psa_status_t cracen_copy_key(psa_key_attributes_t *attributes, const uint8_t *so
 
 psa_status_t cracen_destroy_key(const psa_key_attributes_t *attributes);
 
-size_t cracen_get_opaque_size(const psa_key_attributes_t *attributes);
+psa_status_t cracen_get_opaque_size(const psa_key_attributes_t *attributes, size_t *key_size);
 
 psa_status_t cracen_jpake_setup(cracen_jpake_operation_t *operation,
 				const psa_key_attributes_t *attributes, const uint8_t *password,

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/kmu.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/kmu.c
@@ -901,6 +901,7 @@ psa_status_t cracen_kmu_get_builtin_key(psa_drv_slot_number_t slot_number,
 {
 	kmu_metadata metadata;
 	psa_status_t status = read_primary_slot_metadata(slot_number, &metadata);
+	size_t opaque_key_size;
 
 	if (status != PSA_SUCCESS) {
 		return status;
@@ -921,8 +922,14 @@ psa_status_t cracen_kmu_get_builtin_key(psa_drv_slot_number_t slot_number,
 		return status;
 	}
 
-	if (key_buffer_size >= cracen_get_opaque_size(attributes)) {
-		*key_buffer_length = cracen_get_opaque_size(attributes);
+
+	status = cracen_get_opaque_size(attributes, &opaque_key_size);
+	if (status != PSA_SUCCESS) {
+		return status;
+	}
+
+	if (key_buffer_size >= opaque_key_size) {
+		*key_buffer_length = opaque_key_size;
 		kmu_opaque_key_buffer *key = (kmu_opaque_key_buffer *)key_buffer;
 
 		key->key_usage_scheme = metadata.key_usage_scheme;

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/platform_keys/platform_keys.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/platform_keys/platform_keys.c
@@ -520,26 +520,24 @@ cleanup:
 	return PSA_ERROR_CORRUPTION_DETECTED;
 }
 
-size_t cracen_platform_keys_get_size(psa_key_attributes_t const *attributes)
+psa_status_t cracen_platform_keys_get_size(psa_key_attributes_t const *attributes, size_t *key_size)
 {
 	platform_key key;
 	key_type type = find_key(MBEDTLS_SVC_KEY_ID_GET_KEY_ID(psa_get_key_id(attributes)), &key);
 	psa_key_type_t key_type = psa_get_key_type(attributes);
 
-	if (type == INVALID) {
-		return 0;
-	}
-
 	if (type == IKG) {
-		return sizeof(ikg_opaque_key);
+		*key_size = sizeof(ikg_opaque_key);
+		return PSA_SUCCESS;
 	}
 
 	if (key_type == PSA_KEY_TYPE_ECC_PUBLIC_KEY(PSA_ECC_FAMILY_TWISTED_EDWARDS) ||
 	    key_type == PSA_KEY_TYPE_AES) {
-		return PSA_BITS_TO_BYTES(psa_get_key_bits(attributes));
+		*key_size = PSA_BITS_TO_BYTES(psa_get_key_bits(attributes));
+		return PSA_SUCCESS;
 	}
 
-	return 0;
+	return PSA_ERROR_INVALID_ARGUMENT;
 }
 
 psa_status_t cracen_platform_get_key_slot(mbedtls_svc_key_id_t key_id, psa_key_lifetime_t *lifetime,

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/platform_keys/platform_keys.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/platform_keys/platform_keys.h
@@ -13,7 +13,8 @@ psa_status_t cracen_platform_get_builtin_key(psa_drv_slot_number_t slot_number,
 					     psa_key_attributes_t *attributes, uint8_t *key_buffer,
 					     size_t key_buffer_size, size_t *key_buffer_length);
 
-size_t cracen_platform_keys_get_size(psa_key_attributes_t const *attributes);
+psa_status_t cracen_platform_keys_get_size(psa_key_attributes_t const *attributes,
+					   size_t *key_size);
 
 psa_status_t cracen_platform_get_key_slot(mbedtls_svc_key_id_t key_id, psa_key_lifetime_t *lifetime,
 					  psa_drv_slot_number_t *slot_number);

--- a/subsys/nrf_security/src/psa_crypto_driver_wrappers.c
+++ b/subsys/nrf_security/src/psa_crypto_driver_wrappers.c
@@ -463,8 +463,7 @@ psa_driver_wrapper_get_key_buffer_size_from_key_data(const psa_key_attributes_t 
 #if defined(PSA_NEED_CRACEN_KMU_DRIVER)
 	case PSA_KEY_LOCATION_CRACEN_KMU:
 #endif
-		*key_buffer_size = cracen_get_opaque_size(attributes);
-		return *key_buffer_size != 0 ? PSA_SUCCESS : PSA_ERROR_INVALID_ARGUMENT;
+		return cracen_get_opaque_size(attributes, key_buffer_size);
 #endif
 	default:
 		(void)key_type;
@@ -503,8 +502,7 @@ psa_status_t psa_driver_wrapper_get_key_buffer_size(const psa_key_attributes_t *
 #if defined(PSA_NEED_CRACEN_KMU_DRIVER)
 	case PSA_KEY_LOCATION_CRACEN_KMU:
 #endif
-		*key_buffer_size = cracen_get_opaque_size(attributes);
-		return *key_buffer_size != 0 ? PSA_SUCCESS : PSA_ERROR_NOT_SUPPORTED;
+		return cracen_get_opaque_size(attributes, key_buffer_size);
 #endif
 #if defined(PSA_CRYPTO_DRIVER_TFM_BUILTIN_KEY_LOADER)
 	case TFM_BUILTIN_KEY_LOADER_KEY_LOCATION:


### PR DESCRIPTION
This refactors the function cracen_get_opaque_size so that it returns psa_status_t and not a size_t value. With ths previous implementation it was not possible to distinguish between a key with invalid arguments or a key which is revoked. Revocation support will be added soon and this separation is needed.