### PR TITLE
samples: cellular: nrf_cloud_multi_service: Fix at cmd handling

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -282,6 +282,10 @@ Cellular samples
   * Removed the ``CONFIG_MOSH_LINK`` Kconfig option.
     The link control functionality is now always enabled and cannot be disabled.
 
+* :ref:`nrf_cloud_multi_service` sample:
+
+  * Fixed an issue with an uninitialized variable in the :c:func:`handle_at_cmd_requests` function.
+
 Cryptography samples
 --------------------
 

--- a/samples/cellular/nrf_cloud_multi_service/src/application.c
+++ b/samples/cellular/nrf_cloud_multi_service/src/application.c
@@ -212,7 +212,7 @@ static void on_location_update(const struct location_event_data * const location
 static void handle_at_cmd_requests(const struct nrf_cloud_data *const dev_msg)
 {
 	char *cmd;
-	struct nrf_cloud_obj msg_obj;
+	NRF_CLOUD_OBJ_DEFINE(msg_obj, NRF_CLOUD_OBJ_TYPE__UNDEFINED);
 	int err = nrf_cloud_obj_input_decode(&msg_obj, dev_msg);
 
 	if (err) {


### PR DESCRIPTION
In handle_at_cmd_requests() we need to initialize msg_obj so that the parser used in nrf_cloud_obj_input_decode() operates correctly.

Jira: IRIS-9984