### PR TITLE
doc: known issues: Fix an ESB 2.9.0 issue

### DIFF
--- a/doc/nrf/releases_and_maturity/known_issues.rst
+++ b/doc/nrf/releases_and_maturity/known_issues.rst
@@ -479,7 +479,7 @@ Enhanced ShockBurst (ESB)
 
 The issues in this section are related to the :ref:`ug_esb` protocol.
 
-.. rst-class:: v2.9
+.. rst-class:: v2-9-0
 
 NCSDK-30802: Packet retransmission is not working properly in the ESB for the nRF54 Series devices
   The device suddenly stops transmitting ESB packets.


### PR DESCRIPTION
The version tag didn't render properly as it had a wrong format.