### PR TITLE
tests: drivers: audio: pdm_loopback: add support for nRF54l20

### DIFF
--- a/tests/drivers/audio/pdm_loopback/boards/nrf54l20pdk_nrf54l20_cpuapp.overlay
+++ b/tests/drivers/audio/pdm_loopback/boards/nrf54l20pdk_nrf54l20_cpuapp.overlay
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	gpio_test {
+		compatible = "gpio-leds";
+		pulse_counter: pulse_counter {
+			gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&pinctrl {
+	pdm20_default_alt: pdm20_default_alt {
+		group1 {
+			psels = <NRF_PSEL(PDM_CLK, 1, 10)>,
+				<NRF_PSEL(PDM_DIN, 1, 12)>;
+		};
+	};
+};
+
+pdm_dev: &pdm20 {
+	status = "okay";
+	pinctrl-0 = <&pdm20_default_alt>;
+	pinctrl-names = "default";
+	clock-source = "PCLK32M";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&timer00 {
+	status = "okay";
+};

--- a/tests/drivers/audio/pdm_loopback/testcase.yaml
+++ b/tests/drivers/audio/pdm_loopback/testcase.yaml
@@ -6,21 +6,24 @@ common:
     fixture: gpio_loopback
 
 tests:
-  drivers.audio.pdm_loopback.nrf54l15.1000khz:
+  drivers.audio.pdm_loopback.nrf54l.1000khz:
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l20pdk/nrf54l20/cpuapp
     extra_args:
       CONFIG_NRFX_TIMER00=y
-  drivers.audio.pdm_loopback.nrf54l15.1280khz:
+  drivers.audio.pdm_loopback.nrf54l.1280khz:
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l20pdk/nrf54l20/cpuapp
     extra_args:
       CONFIG_NRFX_TIMER00=y
       CONFIG_TEST_PDM_SAMPLING_RATE=16000
       CONFIG_TEST_PDM_EXPECTED_FREQUENCY=1280000
-  drivers.audio.pdm_loopback.nrf54l15.1600khz:
+  drivers.audio.pdm_loopback.nrf54l.1600khz:
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l20pdk/nrf54l20/cpuapp
     extra_args:
       CONFIG_NRFX_TIMER00=y
       CONFIG_TEST_PDM_SAMPLING_RATE=32000


### PR DESCRIPTION
Added support for testing on nRF54l20pdk.