### PR TITLE
[Backport v2.9-nRF54H20-branch] doc: Doc fixes for the FEM docs

### DIFF
--- a/doc/nrf/app_dev/device_guides/fem/fem_nrf21540_gpio.rst
+++ b/doc/nrf/app_dev/device_guides/fem/fem_nrf21540_gpio.rst
@@ -35,6 +35,15 @@ To use nRF21540 in GPIO mode, complete the following steps:
          };
       };
 
+   When you add the above node to the devicetree and build the application, FEM-related Kconfig options are automatically enabled and FEM support is enabled.
+   Additionally, you can consider setting the following Kconfig options:
+
+   * :kconfig:option:`CONFIG_MPSL_FEM_NRF21540_TX_GAIN_DB`
+   * :kconfig:option:`CONFIG_MPSL_FEM_NRF21540_TX_GAIN_DB_POUTA`
+   * :kconfig:option:`CONFIG_MPSL_FEM_NRF21540_TX_GAIN_DB_POUTB`
+   * :kconfig:option:`CONFIG_MPSL_FEM_NRF21540_RX_GAIN_DB`
+   * :kconfig:option:`CONFIG_MPSL_FEM_NRF21540_RUNTIME_PA_GAIN_CONTROL`
+
 #. Optionally replace the node name ``name_of_fem_node``.
 #. Replace the pin numbers provided for each of the required properties:
 

--- a/doc/nrf/app_dev/device_guides/fem/fem_nrf21540_gpio_spi.rst
+++ b/doc/nrf/app_dev/device_guides/fem/fem_nrf21540_gpio_spi.rst
@@ -27,7 +27,8 @@ To use nRF21540 in GPIO+SPI mode, complete the following steps:
                tx-en-gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
                rx-en-gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
                pdn-gpios   = <&gpio0 15 GPIO_ACTIVE_HIGH>;
-               spi-if = <&nrf_radio_fem_spi>
+               spi-if = <&nrf_radio_fem_spi>;
+               supply-voltage-mv = <3000>;
          };
       };
 #. Optionally replace the device name ``name_of_fem_node``.
@@ -52,17 +53,17 @@ To use nRF21540 in GPIO+SPI mode, complete the following steps:
       &pinctrl {
          spi3_default_alt: spi3_default_alt {
             group1 {
-               psels = <NRF_PSEL(SPI_SCK, 1, 15)>,
-                       <NRF_PSEL(SPI_MISO, 1, 14)>,
-                       <NRF_PSEL(SPI_MOSI, 1, 13)>;
+               psels = <NRF_PSEL(SPIM_SCK, 1, 15)>,
+                       <NRF_PSEL(SPIM_MISO, 1, 14)>,
+                       <NRF_PSEL(SPIM_MOSI, 1, 13)>;
             };
          };
 
          spi3_sleep_alt: spi3_sleep_alt {
             group1 {
-               psels = <NRF_PSEL(SPI_SCK, 1, 15)>,
-                       <NRF_PSEL(SPI_MISO, 1, 14)>,
-                       <NRF_PSEL(SPI_MOSI, 1, 13)>;
+               psels = <NRF_PSEL(SPIM_SCK, 1, 15)>,
+                       <NRF_PSEL(SPIM_MISO, 1, 14)>,
+                       <NRF_PSEL(SPIM_MOSI, 1, 13)>;
                low-power-enable;
             };
          };
@@ -85,7 +86,7 @@ To use nRF21540 in GPIO+SPI mode, complete the following steps:
 
    In this example, the nRF21540 is controlled by the ``spi3`` bus.
    Replace the SPI bus according to your hardware design, and create alternative entries for SPI3 with different ``pinctrl-N`` and ``pinctrl-names`` properties.
-#. On nRF53 devices, the devicetree nodes described above must be added to the network core.
+#. On nRF53 devices, the devicetree nodes described above must be added to the network core and ``spi0`` instance of the network core must be used.
    For the application core, you must also add a GPIO forwarder node to its devicetree file:
 
    .. code-block:: devicetree
@@ -121,3 +122,4 @@ To use nRF21540 in GPIO+SPI mode, complete the following steps:
 .. note::
    The nRF21540 GPIO-only mode of operation is selected by default in Kconfig when an nRF21540 node is provided in devicetree, as mentioned in the :ref:`ug_radio_fem_sw_support` section.
    To enable the GPIO+SPI mode of operation, you must explicitly set the :kconfig:option:`CONFIG_MPSL_FEM_NRF21540_GPIO_SPI` Kconfig option to ``y``.
+   On an nRF5340, the :kconfig:option:`CONFIG_MPSL_FEM_NRF21540_GPIO_SPI` Kconfig option must be set to ``y`` for the network core image.


### PR DESCRIPTION
Backport a8a573f6d797be22406f343d1b8bbd2799aa8bcc from #19729.