### PR TITLE
nrf_security: Add Cracen key derivation for SPAKE2P keys

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa.h
@@ -361,4 +361,8 @@ psa_status_t cracen_spake2p_get_shared_key(cracen_spake2p_operation_t *operation
 
 psa_status_t cracen_spake2p_abort(cracen_spake2p_operation_t *operation);
 
+psa_status_t cracen_derive_key(const psa_key_attributes_t *attributes, const uint8_t *input,
+			       size_t input_length, uint8_t *key, size_t key_size,
+			       size_t *key_length);
+
 #endif /* CRACEN_PSA_H */

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/common.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/common.h
@@ -288,3 +288,16 @@ int cracen_hash_input_with_context(struct sxhash *hashopctx, const uint8_t *inpu
  * @return sxsymcrypt status code.
  */
 int cracen_get_rnd_in_range(const uint8_t *n, size_t nsz, uint8_t *out);
+
+/**
+ * @brief Performs `input` modulo the order of the NIST p256 curve
+ *
+ * @param input Input for the modulo operation.
+ * @param input_size Input size in bytes.
+ * @param output Output of the modulo operation.
+ * @param output_size Output size in bytes.
+ *
+ * @return psa_status_t
+ */
+psa_status_t cracen_ecc_reduce_p256(const uint8_t *input, size_t input_size, uint8_t *output,
+				    size_t output_size);


### PR DESCRIPTION
Adds support for key derivation of SPAKE2P keys with Cracen. It currently supports only SECP256R1 keys.

Ref: NCSDK-30368