### PR TITLE
Update manifest to use a specific sdk-zephyr commit

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -69,7 +69,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 1e841e3e45ad9abf7174d6638e1771a9cc2dd126
+      revision: 2c7f6efa7220ef2fbdd70e8597aedf1a07e86067
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
this is needed to build secdom PR on CI, it will not be merged.