### PR TITLE
doc: fix to missing the for nRFVSC

### DIFF
--- a/doc/nrf/app_dev/config_and_build/kconfig/index.rst
+++ b/doc/nrf/app_dev/config_and_build/kconfig/index.rst
@@ -88,7 +88,7 @@ See :ref:`zephyr:setting_configuration_values` in the Zephyr documentation for i
 
    .. group-tab:: nRF Connect for VS Code
 
-      If you work with |nRFVSC|, you can use one of the following options:
+      If you work with the |nRFVSC|, you can use one of the following options:
 
       * Edit the :file:`prj.conf` directly in |VSC|.
       * Select an extra Kconfig fragment file when you `build an application <How to build an application_>`_.

--- a/doc/nrf/app_dev/device_guides/thingy91/thingy91_building_programming.rst
+++ b/doc/nrf/app_dev/device_guides/thingy91/thingy91_building_programming.rst
@@ -81,7 +81,7 @@ Complete the following steps to program firmware onto Thingy:91:
 
    .. group-tab:: nRF Connect for VS Code
 
-      5. In |nRFVSC|, click the :guilabel:`Flash` option in the **Actions View**.
+      5. In the |nRFVSC|, click the :guilabel:`Flash` option in the **Actions View**.
 
          If you have multiple boards connected, you are prompted to pick a device at the top of the screen.
 

--- a/doc/nrf/installation/recommended_versions.rst
+++ b/doc/nrf/installation/recommended_versions.rst
@@ -380,8 +380,8 @@ For more information on nrfjprog, see `Programming SoCs with nrfjprog`_.
 
 It is recommended to use the latest version of the package when you :ref:`installing_vsc`.
 
-|nRFVSC|
-========
+nRF Connect for Visual Studio Code
+==================================
 
 |vsc_extension_description|
 

--- a/doc/nrf/installation/updating.rst
+++ b/doc/nrf/installation/updating.rst
@@ -156,8 +156,8 @@ After you updated the |NCS| repositories to the new version and you need to migr
 
 .. _vsc_update:
 
-Updating |nRFVSC|
-*****************
+Updating the |nRFVSC|
+*********************
 
 |VSC| checks for extension updates and automatically installs them when they are available.
 After an extension is updated, |VSC| prompts you to reload the application.

--- a/samples/cellular/lwm2m_client/sample_description.rst
+++ b/samples/cellular/lwm2m_client/sample_description.rst
@@ -290,7 +290,7 @@ Avoiding re-writing credentials to modem
 Every time the sample starts, it provisions the keys to the modem and this is only needed once.
 To speed up the start up, you can prevent the provisioning by completing the following steps using |VSC|:
 
-1. In |nRFVSC|, `build the sample <How to build an application_>`_.
+1. In the |nRFVSC|, `build the sample <How to build an application_>`_.
 #. Under **Actions**, click :guilabel:`Kconfig`.
 #. Click :guilabel:`Application sample`.
 #. Under **LwM2M objects**, remove the key value next to :guilabel:`LwM2M pre-shared key for communication`.


### PR DESCRIPTION
Fixed the missing `the` before the |nRFVSC| shortcut. NCSDK-25286.