### PR TITLE
Bluetooth: mesh: Fix scene recall for Light Ctrl server

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -421,7 +421,9 @@ Binary libraries
 Bluetooth libraries and services
 --------------------------------
 
-|no_changes_yet_note|
+* :ref:`bt_mesh` library:
+
+  * Fixed an issue in the :ref:`bt_mesh_light_ctrl_srv_readme` model to automatically resume the Lightness Controller after recalling a scene (``NCSDK-30033`` known issue).
 
 Common Application Framework
 ----------------------------

--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -1541,8 +1541,10 @@ static void scene_recall(const struct bt_mesh_model *model, const uint8_t data[]
 			.transition = transition,
 		};
 
+		bool restart = is_enabled(srv);
+
 		ctrl_disable(srv);
-		if (atomic_test_bit(&srv->flags, FLAG_RESUME_TIMER)) {
+		if (restart || atomic_test_bit(&srv->flags, FLAG_RESUME_TIMER)) {
 			schedule_resume_timer(srv);
 		}
 		lightness_srv_change_lvl(srv->lightness, NULL, &set, &status, true);


### PR DESCRIPTION
The Light Lightness Control Server was not correctly handling scene recalls. The Server now resumes the Lightness Controller automatically after a scene recall, fixing the known issue NCSDK-30033.