### PR TITLE
nrf_security: Fix dependency for threading_alt.h

### DIFF
--- a/subsys/nrf_security/src/threading/threading.cmake
+++ b/subsys/nrf_security/src/threading/threading.cmake
@@ -7,7 +7,7 @@
 # This file includes threading support required by the PSA crypto core
 # Which was added in Mbed TLS 3.6.0.
 
-if(CONFIG_MBEDTLS_THREADING_C AND NOT (CONFIG_PSA_CRYPTO_DRIVER_CC3XX OR CONFIG_CC3XX_BACKEND))
+if(CONFIG_MBEDTLS_THREADING_C AND NOT CONFIG_NRF_CC3XX_PLATFORM)
 
   append_with_prefix(src_crypto_base ${CMAKE_CURRENT_LIST_DIR}
     threading_alt.c

--- a/west.yml
+++ b/west.yml
@@ -147,7 +147,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 3189339e38f52a92098945a3c7f070810a067390
+      revision: de671be0d84ffd92a7643b18a4dd64b735a4e028
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
    This fixes a dependency when including the threading_alt.h
    from nrf_security.
    
    The CC3XX platform library provides the implementation of the
    mbedtls_mutex functions and it expects the mbedTLS mutexes to be of
    type nrf_cc3xx_platform_mutex_t.
    The definitions of the mutexes included in the files
    nrf_cc3xx_platform_mutex_(zephyr/freertos).c
    
    The threading_alt.c in nrf_security defines the mbedTLS mutexes
    as Zephyr mutexes (k_mutex). This doesn't work when the CC3XX
    platform library is used, so here this dependency is added.
    
    Ref: NCSDK-31155