### PR TITLE
doc: fix path to DECT shell sample

### DIFF
--- a/samples/dect/dect_phy/dect_shell/README.rst
+++ b/samples/dect/dect_phy/dect_shell/README.rst
@@ -1047,7 +1047,7 @@ Example: starting of cluster beacon and sending RA data to it
 Building
 ********
 
-.. |sample path| replace:: :file:`samples/dect/dect_shell`
+.. |sample path| replace:: :file:`samples/dect/dect_phy/dect_shell`
 
 .. include:: /includes/build_and_run_ns.txt
 


### PR DESCRIPTION
The path to the sample was missing the dect_phy folder. Added now.