### PR TITLE
docs: nrf_security: drivers: Added ed25519ph to supported

### DIFF
--- a/doc/nrf/libraries/security/nrf_security/doc/driver_config.rst
+++ b/doc/nrf/libraries/security/nrf_security/doc/driver_config.rst
@@ -391,7 +391,7 @@ The following table shows asymmetric signature algorithm support for each driver
 +---------------------------------+---------------------------+----------------------------+---------------------------+
 | PureEdDSA                       | Supported                 | Supported                  | Supported                 |
 +---------------------------------+---------------------------+----------------------------+---------------------------+
-| HashEdDSA Edwards25519          | Not supported             | Not supported              | Not supported             |
+| HashEdDSA Edwards25519          | Not supported             | Not supported              | Supported                 |
 +---------------------------------+---------------------------+----------------------------+---------------------------+
 | HashEdDSA Edwards448            | Not supported             | Not supported              | Not supported             |
 +---------------------------------+---------------------------+----------------------------+---------------------------+

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -94,6 +94,7 @@ Security
 ========
 
   * Added support for HKDF-Expand and HKDF-Extract in CRACEN.
+  * Added support for Ed25519ph(HashEdDSA) to CRACEN
 
 Protocols
 =========


### PR DESCRIPTION
Added ed25519ph to the supported algorithms for cracen