### PR TITLE
lib: location: Reduce LOCATION_WORKQUEUE_STACK_SIZE 4kB -> 3kB

### DIFF
--- a/lib/location/Kconfig
+++ b/lib/location/Kconfig
@@ -61,7 +61,7 @@ config LOCATION_DATA_DETAILS
 
 config LOCATION_WORKQUEUE_STACK_SIZE
 	int "Stack size for the library work queue"
-	default 4096
+	default 3072
 
 if LOCATION_METHOD_GNSS
 


### PR DESCRIPTION
We haven't seen values bigger than a bit over 2kB so reducing the size to 3kB.

Jira: NCSDK-30676