### PR TITLE
doc: Refer test commands section of BLE Core Spec in DTM sample

### DIFF
--- a/samples/bluetooth/direct_test_mode/README.rst
+++ b/samples/bluetooth/direct_test_mode/README.rst
@@ -8,6 +8,8 @@ Bluetooth: Direct Test Mode
    :depth: 2
 
 This sample enables the Direct Test Mode functions described in `Bluetooth® Core Specification <Bluetooth Core Specification_>`_ (Vol. 6, Part F).
+The actual encoding of the test commands and events are described in sections 3.3 and 3.4, respectively, of Vol. 6, Part F of this specification document.
+The `Vendor-specific packet payload`_ section describes some vendor-specific commands that comply with the core specification.
 
 Requirements
 ************


### PR DESCRIPTION
Refer actual encoding of the test commands and events section of BLE Core Spec in Direct test mode sample.

TECHDOC-3198