### PR TITLE
lib: modem_key_mgmt: fix duplicate deletion of last cred type

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -459,6 +459,10 @@ Modem libraries
 
   * Fixed handling of ``%NCELLMEAS`` notification with status 2 (measurement interrupted) and no cells.
 
+* :ref:`modem_key_mgmt` library:
+
+  * Fixed an issue with the :c:func:`modem_key_mgmt_clear` function where it returned ``-ENOENT`` when the credential was cleared.
+
 Multiprotocol Service Layer libraries
 -------------------------------------
 

--- a/lib/modem_key_mgmt/modem_key_mgmt.c
+++ b/lib/modem_key_mgmt/modem_key_mgmt.c
@@ -306,7 +306,7 @@ int modem_key_mgmt_clear(nrf_sec_tag_t sec_tag)
 
 	while (token != NULL) {
 		err = sscanf(token, "%%CMNG: %u,%u,\"", &tag, &type);
-		if (tag == sec_tag) {
+		if (tag == sec_tag && err == 2) {
 			err = nrf_modem_at_printf("AT%%CMNG=3,%u,%u", sec_tag, type);
 		}
 		token = strtok(NULL, "\n");


### PR DESCRIPTION
Because of the ok\r\n in response from modem, the while loop iterates an extra round with scanf not matching any arguments. As the sectag matched the last credential is attempted deleted again and the function return an error. This commit fixes the issue by only deleting the credential in the modem if we match the sectag and credential type in scanf.