### PR TITLE
actions: Use ubuntu-24.04 instead of ubuntu-latest

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -4,7 +4,7 @@ on: pull_request
 
 jobs:
   compliance_job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Run compliance checks on patch series (PR)
     steps:
     - name: Update PATH for west

--- a/.github/workflows/contribs.yml
+++ b/.github/workflows/contribs.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   contribs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Contribs
     steps:
       - name: Contribs

--- a/.github/workflows/create-upmerge-PRs.yml
+++ b/.github/workflows/create-upmerge-PRs.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   auto-upmerge-create-PRs:
     if: github.repository == 'nrfconnect/sdk-nrf'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
         uses: nrfconnect/action-checkout-west-update@main
@@ -88,7 +88,7 @@ jobs:
           gh pr create --base $PR_TARGET_BRANCH --title "manifest: Update revisions of upmerged projects (automatic upmerge)" --body "Automatic upmerge action" --label "CI-all-test" --label "auto-upmerge"
 
   failure-notifier:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: failure()
     needs: auto-upmerge-create-PRs
     env:

--- a/.github/workflows/dnm.yml
+++ b/.github/workflows/dnm.yml
@@ -8,7 +8,7 @@ jobs:
   do-not-merge:
     if: ${{ contains(github.event.*.labels.*.name, 'DNM') }}
     name: Prevent Merging
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Check for label
         run: |

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/docpublish.yml
+++ b/.github/workflows/docpublish.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Download artifacts

--- a/.github/workflows/docremove.yml
+++ b/.github/workflows/docremove.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   remove:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Try removal of PR-docs
         env:

--- a/.github/workflows/enforce-toolchain-synchronization.yml
+++ b/.github/workflows/enforce-toolchain-synchronization.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   check-prs:
     if: ${{ github.repository_owner == 'nrfconnect' && !github.event.created }}  # Skip for new branches or forks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Define list of files to check

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   triage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/labeler@v5.0.0
         with:

--- a/.github/workflows/license-reusable.yml
+++ b/.github/workflows/license-reusable.yml
@@ -33,7 +33,7 @@ on:
 
 jobs:
   license_job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Run license checks on patch series (PR)
     steps:
     - name: Checkout sources

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   manifest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Manifest
     steps:
       - name: Checkout the code

--- a/.github/workflows/oss-history.yml
+++ b/.github/workflows/oss-history.yml
@@ -3,7 +3,7 @@ on: pull_request
 
 jobs:
   contribs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Check OSS history
     steps:
       - name: Checkout sources

--- a/.github/workflows/reapply-ci-trusted-author.yml
+++ b/.github/workflows/reapply-ci-trusted-author.yml
@@ -10,7 +10,7 @@ jobs:
   reapply_label:
     name: Reapply label
     if: ${{ contains(github.event.*.labels.*.name, 'CI-trusted-author') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Remove CI-trusted-author label
         run: gh pr edit ${{ github.event.pull_request.number }} --remove-label "CI-trusted-author"

--- a/.github/workflows/remove-ci-requested.yml
+++ b/.github/workflows/remove-ci-requested.yml
@@ -8,7 +8,7 @@ jobs:
   remove_label:
     name: Remove label
     if: ${{ contains(github.event.*.labels.*.name, 'CI-Requested') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Remove label
         run: gh pr edit ${{ github.event.pull_request.number }} --remove-label "CI-Requested"

--- a/.github/workflows/scripts-test.yml
+++ b/.github/workflows/scripts-test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-24.04]
         python-version: ['3.10', '3.11', '3.12', '3.13']
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/src-mirror.yml
+++ b/.github/workflows/src-mirror.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   zip-and-upload:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
         uses: nrfconnect/action-checkout-west-update@main

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/stale@v9
       with:

--- a/.github/workflows/west-commands.yml
+++ b/.github/workflows/west-commands.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   west_commands_job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Run Python checks for west commands on patch series (PR)
     steps:
       - name: Checkout the code
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, windows-latest]
+        os: [ubuntu-24.04, macos-13, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources


### PR DESCRIPTION
Use fixed version of Ubuntu runner. It prevents unexpected failures when default Ubuntu runner is updated by GitHub.
It also limits number of changes which have to be backported to legacy branches.