### PR TITLE
samples: cellular: modem_shell: Add DTLS connection ID

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -291,6 +291,8 @@ Cellular samples
 
 * :ref:`modem_shell_application` sample:
 
+  * Added support for using DTLS connection ID.
+
   * Removed the ``CONFIG_MOSH_LINK`` Kconfig option.
     The link control functionality is now always enabled and cannot be disabled.
 

--- a/samples/cellular/modem_shell/src/sock/sock.h
+++ b/samples/cellular/modem_shell/src/sock/sock.h
@@ -26,7 +26,7 @@ int sock_open_and_connect(
 	int family, int type, char *address, int port,
 	int bind_port, int pdn_cid, bool secure, uint32_t sec_tag,
 	bool session_cache, bool keep_open, int peer_verify,
-	char *peer_hostname);
+	char *peer_hostname, int dtls_cid);
 
 int sock_send_data(
 	int socket_id, char *data, int data_length, int interval, bool packet_number_prefix,


### PR DESCRIPTION
Add support for using DTLS connection ID. Show DTLS handshake status and DTLS connection ID status after successful connect.