### PR TITLE
scripts: Replace ecdsa library with cryptography

### DIFF
--- a/scripts/bootloader/tests/conftest.py
+++ b/scripts/bootloader/tests/conftest.py
@@ -6,5 +6,14 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 # make all scripts importable in tests
 sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+@pytest.fixture(scope="session")
+def utils():
+    """Helper functions"""
+    import utils
+    return utils

--- a/scripts/bootloader/tests/keygen_test.py
+++ b/scripts/bootloader/tests/keygen_test.py
@@ -4,8 +4,10 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 
 import pytest
-from cryptography.hazmat.primitives.serialization import load_pem_private_key, load_pem_public_key
-
+from cryptography.hazmat.primitives.serialization import (
+    load_pem_private_key,
+    load_pem_public_key,
+)
 from keygen import Ed25519KeysGenerator, EllipticCurveKeysGenerator
 
 
@@ -36,7 +38,7 @@ def test_elliptic_curve_keys_generator(tmpdir):
     assert private_key_pem_1 == private_key_pem_2
 
 
-def test_signing_with_elliptic_curve_with_valid_keys(tmpdir):
+def test_signing_with_elliptic_curve_with_valid_keys(tmpdir, utils):
     private_key_file = tmpdir / 'private.pem'
     public_key_file = tmpdir / 'public.pem'
     generator = EllipticCurveKeysGenerator()
@@ -44,8 +46,8 @@ def test_signing_with_elliptic_curve_with_valid_keys(tmpdir):
     generator.write_public_key_pem(public_key_file)
 
     message = b'Test message for key verification'
-    private_key = load_pem_private_key(private_key_file.open('br').read(), password=None)
-    public_key = load_pem_public_key(public_key_file.open('br').read())
+    private_key = load_pem_private_key(utils.read_bytes(private_key_file), password=None)
+    public_key = load_pem_public_key(utils.read_bytes(public_key_file))
 
     signature = EllipticCurveKeysGenerator.sign_message(private_key, message)
     assert EllipticCurveKeysGenerator.verify_signature(public_key, message, signature)
@@ -81,7 +83,7 @@ def test_ed25519_keys_generator(tmpdir):
     assert private_key_pem_1 == private_key_pem_2
 
 
-def test_signing_with_ed25519_with_valid_keys(tmpdir):
+def test_signing_with_ed25519_with_valid_keys(tmpdir, utils):
     private_key_file = tmpdir / 'private.pem'
     public_key_file = tmpdir / 'public.pem'
     generator = Ed25519KeysGenerator()
@@ -89,13 +91,13 @@ def test_signing_with_ed25519_with_valid_keys(tmpdir):
     generator.write_public_key_pem(public_key_file.open('wb'))
 
     message = b'Test message for key verification'
-    private_key = load_pem_private_key(private_key_file.open('br').read(), password=None)
-    public_key = load_pem_public_key(public_key_file.open('br').read())
+    private_key = load_pem_private_key(utils.read_bytes(private_key_file), password=None)
+    public_key = load_pem_public_key(utils.read_bytes(public_key_file))
     signature = Ed25519KeysGenerator.sign_message(private_key, message)
     assert Ed25519KeysGenerator.verify_signature(public_key, message, signature)
 
 
-def test_signing_with_ed25519_with_valid_keys_and_private_key_from_public_pem_file(tmpdir):
+def test_signing_with_ed25519_with_valid_keys_and_private_key_from_public_pem_file(tmpdir, utils):
     private_key_file = tmpdir / 'private.pem'
     public_key_file = tmpdir / 'public.pem'
     private_generator = Ed25519KeysGenerator()
@@ -105,13 +107,13 @@ def test_signing_with_ed25519_with_valid_keys_and_private_key_from_public_pem_fi
     public_generator.write_public_key_pem(public_key_file.open('wb'))
 
     message = b'Test message for key verification'
-    private_key = load_pem_private_key(private_key_file.open('br').read(), password=None)
-    public_key = load_pem_public_key(public_key_file.open('br').read())
+    private_key = load_pem_private_key(utils.read_bytes(private_key_file), password=None)
+    public_key = load_pem_public_key(utils.read_bytes(public_key_file))
     signature = Ed25519KeysGenerator.sign_message(private_key, message)
     assert Ed25519KeysGenerator.verify_signature(public_key, message, signature)
 
 
-def test_signing_with_ed25519_signature_with_invalid_private_key(tmpdir):
+def test_signing_with_ed25519_signature_with_invalid_private_key(tmpdir, utils):
     private_key_file = tmpdir / 'private.pem'
     public_key_file = tmpdir / 'public.pem'
     private_generator = Ed25519KeysGenerator()
@@ -121,7 +123,7 @@ def test_signing_with_ed25519_signature_with_invalid_private_key(tmpdir):
     public_generator.write_public_key_pem(public_key_file.open('wb'))
 
     message = b'Test message for key verification'
-    private_key = load_pem_private_key(private_key_file.open('br').read(), password=None)
-    public_key = load_pem_public_key(public_key_file.open('br').read())
+    private_key = load_pem_private_key(utils.read_bytes(private_key_file), password=None)
+    public_key = load_pem_public_key(utils.read_bytes(public_key_file))
     signature = Ed25519KeysGenerator.sign_message(private_key, message)
     assert Ed25519KeysGenerator.verify_signature(public_key, message, signature) is False

--- a/scripts/bootloader/tests/utils.py
+++ b/scripts/bootloader/tests/utils.py
@@ -1,0 +1,60 @@
+import subprocess
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.utils import encode_dss_signature
+
+
+def write_bytes(filename: str, content: bytes) -> None:
+    with open(filename, 'wb') as f:
+        f.write(content)
+
+
+def read_bytes(filename: str) -> bytes:
+    with open(filename, 'rb') as f:
+        return f.read()
+
+
+def verify_ec_signature(
+    public_key: ec.EllipticCurvePublicKey, message: bytes, signature: bytes
+) -> bool:
+    assert len(signature) == 64
+    values = signature[:32], signature[32:]
+    key1, key2 = (int.from_bytes(v, byteorder='big') for v in values)
+    signature_encoded = encode_dss_signature(key1, key2)
+    try:
+        public_key.verify(signature_encoded, message, ec.ECDSA(hashes.SHA256()))
+        return True
+    except InvalidSignature:
+        return False
+
+
+def openssl_generate_public_key(private_key_file, public_key_file):
+    return subprocess.run(
+        [
+            'openssl', 'ec', '-in', str(private_key_file), '-pubout',
+            '-out', str(public_key_file)
+        ],
+        check=True,
+    )
+
+
+def openssl_generate_private_key(private_key_file):
+    return subprocess.run(
+        [
+            'openssl', 'ecparam', '-name', 'secp256r1', '-genkey',
+            '-noout', '-out', str(private_key_file)
+        ],
+        check=True
+    )
+
+
+def openssl_sign_message(public_key_file, input_file, output_file):
+    return subprocess.run(
+        [
+            'openssl', 'dgst', '-sha256', '-sign', str(public_key_file), str(input_file)
+        ],
+        check=True,
+        stdout=output_file.open('wb')
+    )

--- a/scripts/bootloader/tests/validation_data_test.py
+++ b/scripts/bootloader/tests/validation_data_test.py
@@ -6,39 +6,45 @@
 import hashlib
 import textwrap
 
-import ecdsa  # type: ignore[import-untyped]
-
 import do_sign
+from asn1parse import get_ecdsa_signature
+from cryptography.hazmat.primitives.serialization import load_pem_public_key
 from hash import generate_hash_digest
 from keygen import Ed25519KeysGenerator, EllipticCurveKeysGenerator
-from validation_data import (
-    Ed25519SignatureValidator,
-    EcdsaSignatureValidator,
-    main as validation_data_main
-)
+from validation_data import EcdsaSignatureValidator, Ed25519SignatureValidator
+from validation_data import main as validation_data_main
 
+MAGIC_VALUE = '0x281ee6de,0x86518483,79362'
+OFFSET = 0
 DUMMY_ZEPHYR_HEX = textwrap.dedent("""\
-:1098000050110020EDA60000E5DE0000D9A6000002
-:10981000D9A60000D9A60000D9A60000D9A600004C
-:1098200000000000000000000000000099A80000F7
-:10983000D9A600000000000059A80000D9A6000029
-:1098400001AA000001AA000001AA000001AA00006C
-:1098500001AA000001AA000001AA000001AA00005C
-:1098600001AA000001AA000001AA000001AA00004C
-:1098700001AA000001AA000001AA000001AA00003C
-:1098800001AA000001AA000001AA000001AA00002C
-:1098900001AA000001AA000001AA000001AA00001C
-:08F5040050010020500100201D
-:0AF50C0000000000000000000000F5
-:04F5160015E015E007
-:040000030000A6ED66
-:00000001FF
+    :1098000050110020EDA60000E5DE0000D9A6000002
+    :10981000D9A60000D9A60000D9A60000D9A600004C
+    :1098200000000000000000000000000099A80000F7
+    :10983000D9A600000000000059A80000D9A6000029
+    :1098400001AA000001AA000001AA000001AA00006C
+    :1098500001AA000001AA000001AA000001AA00005C
+    :1098600001AA000001AA000001AA000001AA00004C
+    :1098700001AA000001AA000001AA000001AA00003C
+    :1098800001AA000001AA000001AA000001AA00002C
+    :1098900001AA000001AA000001AA000001AA00001C
+    :08F5040050010020500100201D
+    :0AF50C0000000000000000000000F5
+    :04F5160015E015E007
+    :040000030000A6ED66
+    :00000001FF
 """)
 
 
-def test_data_validation_for_ec(tmpdir):
-    magic_value = '0x281ee6de,0x86518483,79362'
-    offset = 0
+def load_ecdsa_public_key(public_key_file: str):
+    with open(public_key_file, 'rb') as f:
+        return load_pem_public_key(f.read())
+
+
+def load_ecdsa_public_key_from_string(public_key_string: bytes):
+    return load_pem_public_key(public_key_string)
+
+
+def test_data_validation_for_ec(tmpdir, utils):
     private_key_file = tmpdir / 'private.pem'
     public_key_file = tmpdir / 'public.pem'
     zephyr_hex_file = tmpdir / 'dummy_zephyr.hex'
@@ -52,21 +58,22 @@ def test_data_validation_for_ec(tmpdir):
     keys_generator.write_public_key_pem(public_key_file)
 
     zephyr_hex_file.write(DUMMY_ZEPHYR_HEX)
-    hash_file.open('wb').write(generate_hash_digest(str(zephyr_hex_file), 'sha256'))
+    hash_digest = generate_hash_digest(str(zephyr_hex_file), 'sha256')
+    utils.write_bytes(hash_file, hash_digest)
 
     do_sign.sign_with_ecdsa(private_key_file, hash_file, message_signature_file)
 
-    public_key = ecdsa.VerifyingKey.from_pem(public_key_file.read())
+    public_key = load_ecdsa_public_key(public_key_file)
     EcdsaSignatureValidator(hashfunc=hashlib.sha256).append_validation_data(
         signature_file=message_signature_file,
         input_file=zephyr_hex_file,
         public_key=public_key,
-        offset=offset,
+        offset=OFFSET,
         output_hex=output_hex_file.open('w'),
         output_bin=output_bin_file.open('wb'),
-        magic_value=magic_value
+        magic_value=MAGIC_VALUE
     )
-    assert message_signature_file.open('rb').read() in output_bin_file.open('rb').read()
+    assert utils.read_bytes(message_signature_file) in utils.read_bytes(output_bin_file)
     # check with CLI command too
     assert validation_data_main(
         [
@@ -74,18 +81,68 @@ def test_data_validation_for_ec(tmpdir):
             '--signature', str(message_signature_file),
             '--input', str(zephyr_hex_file),
             '--public-key', str(public_key_file),
-            '--offset', offset,
+            '--offset', OFFSET,
             '--output-hex', str(output_hex_file),
             '--output-bin', str(output_bin_file),
-            '--magic-value', magic_value
+            '--magic-value', MAGIC_VALUE
         ]
     ) == 0
-    assert message_signature_file.open('rb').read() in output_bin_file.open('rb').read()
+    assert utils.read_bytes(message_signature_file) in utils.read_bytes(output_bin_file)
 
 
-def test_data_validation_for_ed25519(tmpdir):
-    magic_value = '0x281ee6de,0x86518483,79362'
-    offset = 0
+def test_data_validation_for_ec_with_openssl(tmpdir, utils):
+    private_key_file = tmpdir / 'private.pem'
+    public_key_file = tmpdir / 'public.pem'
+    zephyr_hex_file = tmpdir / 'dummy_zephyr.hex'
+    message_signature_file = tmpdir / 'zephyr.signature'
+    output_hex_file = tmpdir / 'output.hex'
+    output_bin_file = tmpdir / 'output.bin'
+    hash_file = tmpdir / 'hash.256'
+    asn1_signature_file = tmpdir / 'asn1.signature'
+
+    utils.openssl_generate_private_key(private_key_file)
+    utils.openssl_generate_public_key(private_key_file, public_key_file)
+
+    zephyr_hex_file.write(DUMMY_ZEPHYR_HEX)
+
+    # Generate sha256 hash
+    hash_digest = generate_hash_digest(str(zephyr_hex_file), 'sha256')
+    utils.write_bytes(hash_file, hash_digest)
+
+    # sign hex file
+    utils.openssl_sign_message(private_key_file, hash_file, message_signature_file)
+    asn1_signature = get_ecdsa_signature(utils.read_bytes(message_signature_file), 32)
+    utils.write_bytes(asn1_signature_file, asn1_signature)
+
+    # create validation data and verify signature
+    public_key = load_ecdsa_public_key(public_key_file)
+    EcdsaSignatureValidator(hashfunc=hashlib.sha256).append_validation_data(
+        signature_file=asn1_signature_file,
+        input_file=zephyr_hex_file,
+        public_key=public_key,
+        offset=OFFSET,
+        output_hex=output_hex_file.open('w'),
+        output_bin=output_bin_file.open('wb'),
+        magic_value=MAGIC_VALUE
+    )
+    assert utils.read_bytes(asn1_signature_file) in utils.read_bytes(output_bin_file)
+    # check with CLI command too
+    assert validation_data_main(
+        [
+            '--algorithm=ecdsa',
+            '--signature', str(asn1_signature_file),
+            '--input', str(zephyr_hex_file),
+            '--public-key', str(public_key_file),
+            '--offset', OFFSET,
+            '--output-hex', str(output_hex_file),
+            '--output-bin', str(output_bin_file),
+            '--magic-value', MAGIC_VALUE
+        ]
+    ) == 0
+    assert utils.read_bytes(asn1_signature_file) in utils.read_bytes(output_bin_file)
+
+
+def test_data_validation_for_ed25519_with_sha512(tmpdir, utils):
     private_key_file = tmpdir / 'private.pem'
     zephyr_hex_file = tmpdir / 'dummy_zephyr.hex'
     hash_file = tmpdir / 'hash.sha512'
@@ -97,7 +154,8 @@ def test_data_validation_for_ed25519(tmpdir):
     keys_generator.write_private_key_pem(private_key_file)
 
     zephyr_hex_file.write(DUMMY_ZEPHYR_HEX)
-    hash_file.open('wb').write(generate_hash_digest(str(zephyr_hex_file), 'sha512'))
+    hash_digits = generate_hash_digest(str(zephyr_hex_file), 'sha512')
+    utils.write_bytes(hash_file, hash_digits)
 
     do_sign.sign_with_ed25519(private_key_file, hash_file, message_signature_file)
 
@@ -105,17 +163,15 @@ def test_data_validation_for_ed25519(tmpdir):
         signature_file=message_signature_file,
         input_file=zephyr_hex_file,
         public_key=keys_generator.public_key,
-        offset=offset,
+        offset=OFFSET,
         output_hex=output_hex_file.open('w'),
         output_bin=output_bin_file.open('wb'),
-        magic_value=magic_value
+        magic_value=MAGIC_VALUE
     )
-    assert message_signature_file.open('rb').read() in output_bin_file.open('rb').read()
+    assert utils.read_bytes(message_signature_file) in utils.read_bytes(output_bin_file)
 
 
-def test_data_validation_for_signed_hex_file_with_ed25519(tmpdir):
-    magic_value = '0x281ee6de,0x86518483,79362'
-    offset = 0
+def test_data_validation_for_ed25519_no_hash(tmpdir, utils):
     private_key_file = tmpdir / 'private.pem'
     public_key_file = tmpdir / 'public.pem'
     zephyr_hex_file = tmpdir / 'dummy_zephyr.hex'
@@ -142,12 +198,12 @@ def test_data_validation_for_signed_hex_file_with_ed25519(tmpdir):
         signature_file=message_signature_file,
         input_file=zephyr_hex_file,
         public_key=keys_generator.public_key,
-        offset=offset,
+        offset=OFFSET,
         output_hex=output_hex_file.open('w'),
         output_bin=output_bin_file.open('wb'),
-        magic_value=magic_value
+        magic_value=MAGIC_VALUE
     )
-    assert message_signature_file.open('rb').read() in output_bin_file.open('rb').read()
+    assert utils.read_bytes(message_signature_file) in utils.read_bytes(output_bin_file)
 
     # check with CLI command too
     assert validation_data_main(
@@ -156,10 +212,39 @@ def test_data_validation_for_signed_hex_file_with_ed25519(tmpdir):
             '--signature', str(message_signature_file),
             '--input', str(zephyr_hex_file),
             '--public-key', str(public_key_file),
-            '--offset', offset,
+            '--offset', OFFSET,
             '--output-hex', str(output_hex_file),
             '--output-bin', str(output_bin_file),
-            '--magic-value', magic_value
+            '--magic-value', MAGIC_VALUE
         ]
     ) == 0
-    assert message_signature_file.open('rb').read() in output_bin_file.open('rb').read()
+    assert utils.read_bytes(message_signature_file) in utils.read_bytes(output_bin_file)
+
+
+def test_ecdsa_public_key_to_string(tmpdir):
+    public_key_data = textwrap.dedent("""\
+        -----BEGIN PUBLIC KEY-----
+        MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEihHfHl4KigTP4uFhlo1M1IkezteI
+        DLYmPEVtPrPYrQtqpctToFIG8uV3g6MAMhqPG/h69polPuvN3Lo56YnXhA==
+        -----END PUBLIC KEY-----
+    """)
+    public_key = load_ecdsa_public_key_from_string(public_key_data.encode())
+    validator = EcdsaSignatureValidator(hashfunc=hashlib.sha256)
+    expected_bytes = (b'\x8a\x11\xdf\x1e^\n\x8a\x04\xcf\xe2\xe1a\x96\x8dL\xd4\x89\x1e'
+                      b'\xce\xd7\x88\x0c\xb6&<Em>\xb3\xd8\xad\x0bj\xa5\xcbS\xa0R\x06'
+                      b'\xf2\xe5w\x83\xa3\x002\x1a\x8f\x1b\xf8z\xf6\x9a%>\xeb\xcd\xdc'
+                      b'\xba9\xe9\x89\xd7\x84')
+    assert validator.to_string(public_key) == expected_bytes
+
+
+def test_ed25519_public_key_to_string(tmpdir):
+    public_key_data = textwrap.dedent("""\
+        -----BEGIN PUBLIC KEY-----
+        MCowBQYDK2VwAyEAHq4VC8pj/yLm8a7IzOZfkjB4o6Vk6UvRGGKAgpl24q8=
+        -----END PUBLIC KEY-----
+    """)
+    public_key = load_pem_public_key(public_key_data.encode())
+    validator = Ed25519SignatureValidator()
+    expected_bytes = (b'\x1e\xae\x15\x0b\xcac\xff"\xe6\xf1\xae\xc8\xcc\xe6_\x920x'
+                      b'\xa3\xa5d\xe9K\xd1\x18b\x80\x82\x99v\xe2\xaf')
+    assert validator.to_string(public_key) == expected_bytes

--- a/scripts/requirements-test.txt
+++ b/scripts/requirements-test.txt
@@ -1,5 +1,4 @@
 # packages required to run tests for Python scripts
 cryptography
-ecdsa
 intelhex
 pytest


### PR DESCRIPTION
Simplify python scripts by removing ecdsa library and rewriting code with cryptography library,
which provides same functionality.