### PR TITLE
bluetooth: controller: remove vs supported commands implementation

### DIFF
--- a/include/bluetooth/hci_vs_sdc.h
+++ b/include/bluetooth/hci_vs_sdc.h
@@ -114,17 +114,6 @@ int hci_vs_sdc_zephyr_read_tx_power(
 	const sdc_hci_cmd_vs_zephyr_read_tx_power_t *params,
 	sdc_hci_cmd_vs_zephyr_read_tx_power_return_t *return_params);
 
-/** @brief Read Supported Vendor Specific Commands.
- *
- * For the complete API description, see sdc_hci_cmd_vs_read_supported_vs_commands().
- *
- * @param[out] return_params Return parameters.
- *
- * @return 0 on success or negative error value on failure.
- */
-int hci_vs_sdc_read_supported_vs_commands(
-	sdc_hci_cmd_vs_read_supported_vs_commands_return_t *return_params);
-
 /** @brief Set Low Latency Packet Mode.
  *
  * For the complete API description, see sdc_hci_cmd_vs_llpm_mode_set().

--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -669,59 +669,6 @@ static void vs_zephyr_supported_commands(sdc_hci_vs_zephyr_supported_commands_t 
 	cmds->read_tx_power_level = 1;
 #endif /* CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL */
 }
-
-static void vs_supported_commands(sdc_hci_vs_supported_vs_commands_t *cmds)
-{
-	memset(cmds, 0, sizeof(*cmds));
-
-	cmds->read_supported_vs_commands = 1;
-#if defined(CONFIG_BT_CTLR_SDC_LLPM)
-	cmds->llpm_mode_set = 1;
-#endif
-	cmds->conn_update = 1;
-	cmds->conn_event_extend = 1;
-	cmds->qos_conn_event_report_enable = 1;
-	cmds->event_length_set = 1;
-#if defined(CONFIG_BT_CTLR_LE_POWER_CONTROL)
-	cmds->write_remote_tx_power = 1;
-	cmds->set_power_control_request_params = 1;
-	cmds->read_average_rssi = 1;
-#endif
-#if defined(CONFIG_BT_CENTRAL)
-	cmds->central_acl_event_spacing_set = 1;
-#endif
-
-#if defined(CONFIG_BT_CTLR_SDC_EVENT_TRIGGER)
-	cmds->set_event_start_task = 1;
-#endif
-
-#if defined(CONFIG_BT_CONN)
-	cmds->get_next_conn_event_counter = 1;
-#endif
-
-#if defined(CONFIG_BT_CTLR_SDC_PAWR_ADV)
-	cmds->allow_parallel_connection_establishments = 1;
-#endif
-
-#if defined(CONFIG_BT_CONN)
-	cmds->min_val_of_max_acl_tx_payload_set = 1;
-#endif
-#if defined(CONFIG_BT_CTLR_ISO_TX_BUFFERS)
-	cmds->iso_read_tx_timestamp = 1;
-#endif
-#if defined(CONFIG_BT_CTLR_ADV_ISO)
-	cmds->big_reserved_time_set = 1;
-#endif
-#if defined(CONFIG_BT_CTLR_CONN_ISO)
-	cmds->cig_reserved_time_set = 1;
-	cmds->cis_subevent_length_set = 1;
-#endif
-
-#if defined(CONFIG_BT_OBSERVER)
-	cmds->scan_channel_map_set = 1;
-	cmds->scan_accept_ext_adv_packets_set = 1;
-#endif
-}
 #endif	/* CONFIG_BT_HCI_VS */
 
 static void supported_features(sdc_hci_ip_lmp_features_t *features)
@@ -1689,10 +1636,6 @@ static uint8_t vs_cmd_put(uint8_t const *const cmd, uint8_t *const raw_event_out
 		return sdc_hci_cmd_vs_zephyr_read_tx_power((void *)cmd_params,
 							   (void *)event_out_params);
 #endif /* CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL */
-	case SDC_HCI_OPCODE_CMD_VS_READ_SUPPORTED_VS_COMMANDS:
-		*param_length_out += sizeof(sdc_hci_cmd_vs_read_supported_vs_commands_return_t);
-		vs_supported_commands((void *)event_out_params);
-		return 0;
 #if CONFIG_BT_CTLR_SDC_LLPM
 	case SDC_HCI_OPCODE_CMD_VS_LLPM_MODE_SET:
 		return sdc_hci_cmd_vs_llpm_mode_set((void *)cmd_params);

--- a/subsys/bluetooth/hci_vs_sdc.c
+++ b/subsys/bluetooth/hci_vs_sdc.c
@@ -128,14 +128,6 @@ int hci_vs_sdc_zephyr_read_tx_power(
 				   return_params, sizeof(*return_params));
 }
 
-int hci_vs_sdc_read_supported_vs_commands(
-	sdc_hci_cmd_vs_read_supported_vs_commands_return_t *return_params)
-{
-	return hci_vs_cmd_with_rsp_only(SDC_HCI_OPCODE_CMD_VS_READ_SUPPORTED_VS_COMMANDS,
-					return_params,
-					sizeof(*return_params));
-}
-
 int hci_vs_sdc_llpm_mode_set(const sdc_hci_cmd_vs_llpm_mode_set_t *params)
 {
 	return hci_vs_cmd_no_rsp(SDC_HCI_OPCODE_CMD_VS_LLPM_MODE_SET,


### PR DESCRIPTION
This command was deprecated a long time ago.