### PR TITLE
doc: Fix nrfutil trace version for v2.9.0 nRF54H20 RC1

### DIFF
--- a/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_gs.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_gs.rst
@@ -158,7 +158,7 @@ Using the nRF54H20 DK with the |NCS| version |release| requires the following:
 
 * nRF Util version 7.13.0 or higher
 * nRF Util ``device`` version 2.7.10
-* nRF Util ``trace`` version 3.10.0
+* nRF Util ``trace`` version 3.1.0
 * nRF Util ``suit`` version 0.9.0
 
 1. Download the nrfutil executable file from the `nRF Util development tool`_ product page.
@@ -185,9 +185,9 @@ Using the nRF54H20 DK with the |NCS| version |release| requires the following:
 
       nrfutil install device=2.7.10 --force
 
-#. Install the nRF Util ``trace`` command version 3.10.0 as follows::
+#. Install the nRF Util ``trace`` command version 3.1.0 as follows::
 
-      nrfutil install trace=3.10.0 --force
+      nrfutil install trace=3.1.0 --force
 
 #. Install the nRF Util ``suit`` command version 0.9.0 as follows::
 

--- a/doc/nrf/releases_and_maturity/migration/migration_guide_2.9.0-nrf54h20-rc1.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_guide_2.9.0-nrf54h20-rc1.rst
@@ -145,11 +145,11 @@ nrfutil trace
 
 .. toggle::
 
-  * ``nrfutil trace`` has been updated to version 3.10.0.
+  * ``nrfutil trace`` has been updated to version 3.1.0.
 
-    Install the nRF Util ``trace`` command version 3.10.0 as follows::
+    Install the nRF Util ``trace`` command version 3.1.0 as follows::
 
-       nrfutil install trace=3.10.0 --force
+       nrfutil install trace=3.1.0 --force
 
     For more information, consult the `nRF Util`_ documentation.
 


### PR DESCRIPTION
The documentation tells to install nrfutil trace v3.10.0, but this version does not seem to exist :
```
:~/ncs$ nrfutil install trace=3.10.0 --force
nrfutil-trace already installed
Uninstalled nrfutil-trace
Error: Failed to install nrfutil-trace

Caused by:
    0: Package index file error
    1: Unable to find version '3.10.0' in the package index file
```

However, the latest version seems to be v3.1.0 :
```
:~/ncs$ nrfutil trace --version
nrfutil-trace 3.1.0 (2da0997 2024-12-11)
commit-hash: 2da0997efbe37ef990d0a0384eb49d13264bab45
commit-date: 2024-12-11
host: x86_64-unknown-linux-gnu
build-timestamp: 2024-12-12T08:08:37.332171808Z
classification: nrf-external
```