### PR TITLE
[Backport v2.9-nRF54H20-branch] doc: wifi: Fix shell sample

### DIFF
--- a/samples/wifi/shell/README.rst
+++ b/samples/wifi/shell/README.rst
@@ -78,6 +78,10 @@ The following is an example of the CLI command:
 
        west build -b nrf9160dk/nrf9160/ns -- -DEXTRA_CONF_FILE=overlay-scan-only.conf -DSHIELD=nrf7002ek
 
+.. note::
+   The nRF91 Series supports Wi-Fi through nR70 Series shields but is limited to scan-only operation to enhance location accuracy.
+   However, it does not support full Wi-Fi operations.
+
 To build for the Thingy:91 X using the nRF5340 as the host chip, use the ``thingy91x/nrf5340/cpuapp`` board target with the ``SB_CONFIG_THINGY91X_STATIC_PARTITIONS_NRF53_EXTERNAL_FLASH=y`` CMake option set.
 This requires an external debugger since the nRF9151 normally owns the buses.
 This special configuration is not compatible with nRF9151 firmware compiled for the default configuration.


### PR DESCRIPTION
Backport 0830afa2cbe9fd95afc1c35270d80efcb4411755 from #19778.