### PR TITLE
boards: thingy91x: add nrf5340 primary1 partition

### DIFF
--- a/boards/nordic/thingy91x/thingy91x_nrf5340_pm_static.yml
+++ b/boards/nordic/thingy91x/thingy91x_nrf5340_pm_static.yml
@@ -84,3 +84,7 @@ sram_retained_mem:
   region: sram_primary
   address: 0x2007FC00
   size: 0x400
+mcuboot_primary_1:
+  address: 0x0
+  region: ram_flash
+  size: 0x40000


### PR DESCRIPTION
This partition is usually autogenerated, but can end up missing. It should be statically defined in the board configuration. This patch has no effect on currently working builds.